### PR TITLE
Add face authentication (howdy) to the lock screen

### DIFF
--- a/bin/omarchy-remove-security-face
+++ b/bin/omarchy-remove-security-face
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# omarchy:summary=Remove face authentication from sudo and lock screen
+# omarchy:requires-sudo=true
+
+set -e
+
+
+remove_pam_config() {
+  if grep -q 'pam_howdy\.so' /etc/pam.d/sudo; then
+    echo "Removing face authentication from sudo..."
+    sudo sed -i '/pam_howdy\.so/d' /etc/pam.d/sudo
+  fi
+}
+
+remove_lock_face_pam() {
+  if [[ -f /etc/pam.d/omarchy-lock-face ]]; then
+    echo "Removing lock screen face authentication..."
+    sudo rm -f /etc/pam.d/omarchy-lock-face
+  fi
+}
+
+
+echo -e "\e[32mRemoving face authentication.\n\e[0m"
+
+remove_pam_config
+remove_lock_face_pam
+
+echo "Removing howdy..."
+omarchy-pkg-drop howdy-git
+
+echo -e "\e[32mFace authentication has been completely removed.\e[0m"

--- a/bin/omarchy-setup-security-face
+++ b/bin/omarchy-setup-security-face
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# omarchy:summary=Set up face authentication (howdy) for sudo and lock screen
+# omarchy:requires-sudo=true
+
+set -e
+
+
+find_ir_camera() {
+  # IR cameras used for face auth expose a greyscale (GREY) stream. Prefer one
+  # of those; plain RGB webcams work with howdy too, but are easy to fool with
+  # a photo, so they are only offered as an explicit fallback.
+  local dev
+  for dev in /dev/v4l/by-id/*; do
+    [[ -e $dev ]] || continue
+    if v4l2-ctl -d "$dev" --list-formats 2>/dev/null | grep -q "'GREY'"; then
+      echo "$dev"
+      return 0
+    fi
+  done
+  return 1
+}
+
+verify_face() {
+  # compare.py is the exact matcher PAM runs; exit 0 means the camera saw and
+  # matched the enrolled face. Skip the check if the packaging moved it.
+  local compare=/usr/lib/howdy/compare.py
+  [[ -f $compare ]] || return 0
+  sudo python "$compare" "$USER"
+}
+
+setup_pam_config() {
+  # howdy aborts on its own when the lid is closed (abort_if_lid_closed) or in
+  # SSH sessions (abort_if_ssh), so no extra PAM gate is needed here.
+  if ! grep -q pam_howdy.so /etc/pam.d/sudo; then
+    echo "Configuring sudo for face authentication..."
+    sudo sed -i '1i auth      sufficient pam_howdy.so' /etc/pam.d/sudo
+  fi
+}
+
+setup_lock_face_pam() {
+  echo "Configuring lock screen for face authentication..."
+  sudo tee /etc/pam.d/omarchy-lock-face >/dev/null <<'EOF'
+#%PAM-1.0
+auth       required                    pam_howdy.so
+account    include                     system-local-login
+EOF
+}
+
+
+echo -e "\e[32mSetting up face authentication.\n\e[0m"
+
+# Bail before installing anything if there's no camera to talk to.
+if ! compgen -G "/dev/video*" >/dev/null; then
+  echo -e "\e[31mNo camera detected.\e[0m"
+  exit 1
+fi
+
+# Install required packages
+echo "Installing required packages..."
+omarchy-pkg-add v4l-utils
+omarchy-pkg-aur-add howdy-git
+
+# Point howdy at the IR camera; every reboot can renumber the bare
+# /dev/videoN nodes, so use the stable by-id path.
+if camera=$(find_ir_camera); then
+  echo "Using IR camera: $camera"
+else
+  echo -e "\e[33mNo IR (greyscale) camera found.\e[0m"
+  echo "A regular webcam can be used, but it is much easier to fool than an IR camera."
+  read -rp "Continue with the default camera? [y/N] " reply
+  [[ ${reply,,} == y* ]] || exit 1
+  camera=$(compgen -G "/dev/v4l/by-id/*" | head -1 || true)
+  [[ -n $camera ]] || camera=$(compgen -G "/dev/video*" | head -1)
+  echo "Using camera: $camera"
+fi
+
+sudo sed -i "s|^device_path = .*|device_path = $camera|" /etc/howdy/config.ini
+
+# Enroll a face model
+echo -e "\e[32m\nLet's capture your face model. Look straight at the camera.\e[0m\n"
+
+if sudo howdy add; then
+  echo -e "\e[32m\nFace model added successfully!\e[0m"
+
+  # Verify
+  echo -e "\nNow let's verify that it's working correctly. Look at the camera again.\n"
+  if verify_face; then
+    # PAM comes last, once a model is enrolled and verified, so a machine
+    # where the camera can't actually match anything never ends up with
+    # pam_howdy wired into its auth stacks.
+    setup_pam_config
+    setup_lock_face_pam
+    echo -e "\e[32m\nPerfect! Face authentication is now configured.\e[0m"
+    echo "You can use your face for sudo and the lock screen (Super + Ctrl + L)."
+  else
+    echo -e "\e[31m\nVerification failed. You may want to try enrolling again.\e[0m"
+  fi
+else
+  echo -e "\e[31m\nEnrollment failed. Please try again.\e[0m"
+  exit 1
+fi

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -9,6 +9,7 @@ Item {
   property string backgroundPath: ""
   property int backgroundVersion: 0
   property bool fingerprintConfigured: false
+  property bool faceConfigured: false
   property bool authenticatingPassword: false
   property string failureMessage: ""
   property int failedAttempts: 0
@@ -24,9 +25,11 @@ Item {
   readonly property int fieldFontSize: Math.round(Style.font.heading * 1.125)
   readonly property int passwordDotFontSize: Math.round(Style.font.heading * 1.33)
   readonly property int passwordDotLetterSpacing: Math.round(Style.font.heading * 0.19)
-  // Space to keep clear on each side of the field for the fingerprint icon
-  // (icon width plus a gap) so the centered dots never run under it.
-  readonly property real fingerprintReserve: fingerprintConfigured ? Math.round(fingerprintIcon.implicitWidth + 12) : 0
+  // Space to keep clear on each side of the field for the biometric icons
+  // (icon width plus a gap) so the centered dots never run under them.
+  readonly property real iconReserve: (fingerprintConfigured || faceConfigured)
+    ? Math.round(Math.max(fingerprintIcon.implicitWidth, faceIcon.implicitWidth) + 12)
+    : 0
   // Shrink the dots to fit once the password outgrows the field, so every
   // keystroke stays visible — otherwise long passwords clip with no feedback.
   readonly property real passwordDotScale: dotMetrics.advanceWidth > 0
@@ -133,11 +136,11 @@ Item {
         id: passwordInput
         anchors.fill: parent
         anchors.topMargin: inputField.borderTop
-        // Reserve the fingerprint icon's width on both sides so the centered
-        // dots stay symmetric and never slide under the icon as they grow.
-        anchors.rightMargin: inputField.borderRight + 18 + root.fingerprintReserve
+        // Reserve the icon width on both sides so the centered dots stay
+        // symmetric and never slide under an icon as they grow.
+        anchors.rightMargin: inputField.borderRight + 18 + root.iconReserve
         anchors.bottomMargin: inputField.borderBottom
-        anchors.leftMargin: inputField.borderLeft + 18 + root.fingerprintReserve
+        anchors.leftMargin: inputField.borderLeft + 18 + root.iconReserve
         verticalAlignment: TextInput.AlignVCenter
         horizontalAlignment: TextInput.AlignHCenter
         activeFocusOnPress: true
@@ -207,6 +210,24 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         visible: root.fingerprintConfigured
         text: "󰈷"
+        color: Color.lock.placeholder
+        font.family: Style.font.family
+        font.pixelSize: Math.round(root.fieldFontSize * 1.1)
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+      }
+
+      // Face hint pinned inside the field's left edge when face auth is set
+      // up, so the user knows a look at the camera can unlock instead of
+      // typing.
+      Text {
+        id: faceIcon
+        objectName: "faceIndicator"
+        anchors.left: parent.left
+        anchors.leftMargin: inputField.borderLeft + 18
+        anchors.verticalCenter: parent.verticalCenter
+        visible: root.faceConfigured
+        text: "󰱻"
         color: Color.lock.placeholder
         font.family: Style.font.family
         font.pixelSize: Math.round(root.fieldFontSize * 1.1)

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -20,8 +20,15 @@ Item {
   property bool pendingSessionLock: false
   property bool authenticatingPassword: false
   property bool fingerprintAuthenticating: false
+  property bool faceAuthenticating: false
   property bool passwordPamConfigured: false
   property bool fingerprintConfigured: false
+  property bool faceConfigured: false
+  // Unlike fprintd, a face scan drives the camera and IR emitters, so it
+  // cannot stay armed for the whole lock. Scan a few times after locking or
+  // waking, then go quiet until the user stirs again.
+  property int faceAttempts: 0
+  readonly property int maxFaceAttempts: 3
   property bool previewVisible: false
   property string enteredPassword: ""
   property string pendingPassword: ""
@@ -35,7 +42,7 @@ Item {
   property bool strandedLockResolved: false
 
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
-  readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
+  readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating || faceAuthenticating
 
   function realScreenCount() {
     var screens = Quickshell.screens || []
@@ -107,6 +114,10 @@ Item {
     if (!fingerprintCheckProc.running) fingerprintCheckProc.running = true
   }
 
+  function refreshFaceStatus() {
+    if (!faceCheckProc.running) faceCheckProc.running = true
+  }
+
   function logEvent(event) {
     lastEvent = event
     lastEventAt = new Date().toISOString()
@@ -120,9 +131,13 @@ Item {
     failedAttempts = 0
     authenticatingPassword = false
     fingerprintAuthenticating = false
+    faceAuthenticating = false
+    faceAttempts = 0
     fingerprintRetryTimer.stop()
+    faceRetryTimer.stop()
     if (passwordPam.active) passwordPam.abort()
     if (fingerprintPam.active) fingerprintPam.abort()
+    if (facePam.active) facePam.abort()
   }
 
   function beginLock() {
@@ -140,6 +155,7 @@ Item {
     Qt.callLater(function() {
       root.refreshBackground()
       root.refreshFingerprintStatus()
+      root.refreshFaceStatus()
     })
 
     return true
@@ -166,7 +182,12 @@ Item {
 
   function runWake() {
     if (!wakeProcess.running) wakeProcess.running = true
-    if (lockRequested) armBlankTimer()
+    if (lockRequested) {
+      armBlankTimer()
+      // The user is back at the machine: give the face another scan window.
+      faceAttempts = 0
+      startFace()
+    }
   }
 
   function runBlank() {
@@ -227,6 +248,29 @@ Item {
     }
   }
 
+  function startFace() {
+    if (!lockRequested || !sessionLock.secure || !faceConfigured) return
+    if (facePam.active || faceAuthenticating) return
+    if (faceAttempts >= maxFaceAttempts) return
+
+    faceAuthenticating = true
+    if (!facePam.start()) {
+      faceAuthenticating = false
+    }
+  }
+
+  function handleFaceFinished(result) {
+    faceAuthenticating = false
+
+    if (!lockRequested) return
+    if (result === PamResult.Success) {
+      finishUnlock()
+    } else if (faceConfigured) {
+      faceAttempts += 1
+      if (faceAttempts < maxFaceAttempts) faceRetryTimer.restart()
+    }
+  }
+
   WlSessionLock {
     id: sessionLock
 
@@ -239,6 +283,7 @@ Item {
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
         root.startFingerprint()
+        root.startFace()
       }
     }
 
@@ -271,6 +316,7 @@ Item {
         backgroundPath: root.backgroundPath
         backgroundVersion: root.backgroundVersion
         fingerprintConfigured: root.fingerprintConfigured
+        faceConfigured: root.faceConfigured
         authenticatingPassword: root.authenticatingPassword
         failureMessage: root.failureMessage
         failedAttempts: root.failedAttempts
@@ -301,6 +347,7 @@ Item {
       backgroundPath: root.backgroundPath
       backgroundVersion: root.backgroundVersion
       fingerprintConfigured: root.fingerprintConfigured
+      faceConfigured: root.faceConfigured
       authenticatingPassword: false
       failureMessage: ""
       failedAttempts: 0
@@ -353,11 +400,38 @@ Item {
     }
   }
 
+  PamContext {
+    id: facePam
+    config: "omarchy-lock-face"
+    user: root.userName
+
+    onCompleted: function(result) {
+      root.handleFaceFinished(result)
+    }
+
+    onError: function(error) {
+      root.faceAuthenticating = false
+      if (root.lockRequested && root.faceConfigured) {
+        root.faceAttempts += 1
+        if (root.faceAttempts < root.maxFaceAttempts) faceRetryTimer.restart()
+      }
+    }
+  }
+
   Timer {
     id: fingerprintRetryTimer
     interval: 250
     repeat: false
     onTriggered: root.startFingerprint()
+  }
+
+  Timer {
+    id: faceRetryTimer
+    // A scan already takes the recognizer's own timeout; a longer gap keeps
+    // the IR emitters from strobing back to back.
+    interval: 1000
+    repeat: false
+    onTriggered: root.startFace()
   }
 
   Process {
@@ -383,6 +457,19 @@ Item {
       root.fingerprintConfigured = String(fingerprintCheckStdout.text || "").trim() === "yes"
       if (root.lockRequested && root.fingerprintConfigured) root.startFingerprint()
       else if (!root.fingerprintConfigured && fingerprintPam.active) fingerprintPam.abort()
+    }
+  }
+
+  Process {
+    id: faceCheckProc
+    // Face auth is wired up when the admin has created the PAM service and the
+    // recognizer (howdy) holds a model for this user.
+    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-face ]] && { [[ -f \"/etc/howdy/models/$USER.dat\" ]] || [[ -f \"/var/lib/howdy/models/$USER.dat\" ]]; }; then echo yes; else echo no; fi"]
+    stdout: StdioCollector { id: faceCheckStdout; waitForEnd: true }
+    onExited: {
+      root.faceConfigured = String(faceCheckStdout.text || "").trim() === "yes"
+      if (root.lockRequested && root.faceConfigured) root.startFace()
+      else if (!root.faceConfigured && facePam.active) facePam.abort()
     }
   }
 
@@ -504,6 +591,7 @@ Item {
   Component.onCompleted: {
     refreshBackground()
     refreshFingerprintStatus()
+    refreshFaceStatus()
     checkStrandedLock()
   }
 
@@ -530,6 +618,7 @@ Item {
         realScreens: root.realScreenCount(),
         passwordPam: root.passwordPamConfigured,
         fingerprint: root.fingerprintConfigured,
+        face: root.faceConfigured,
         authenticating: root.authenticating,
         lastEvent: root.lastEvent,
         lastEventAt: root.lastEventAt
@@ -539,6 +628,7 @@ Item {
     function preview(): string {
       root.refreshBackground()
       root.refreshFingerprintStatus()
+      root.refreshFaceStatus()
       root.previewVisible = true
       return "ok"
     }

--- a/shell/plugins/lock/manifest.json
+++ b/shell/plugins/lock/manifest.json
@@ -4,7 +4,7 @@
   "name": "Lock Screen",
   "version": "1.0.0",
   "author": "Omarchy",
-  "description": "Quickshell session lock with separate password and fingerprint PAM flows.",
+  "description": "Quickshell session lock with separate password, fingerprint, and face PAM flows.",
   "kinds": [
     "service"
   ],

--- a/test/shell.d/fixtures/lock-face-indicator/shell.qml
+++ b/test/shell.d/fixtures/lock-face-indicator/shell.qml
@@ -57,20 +57,18 @@ ShellRoot {
           return
         }
 
-        var indicator = view.children ? findByObjectName(view, "fingerprintIndicator") : null
-        root.assertTrue(indicator !== null, "fingerprint indicator exists in the lock view")
+        var indicator = view.children ? findByObjectName(view, "faceIndicator") : null
+        root.assertTrue(indicator !== null, "face indicator exists in the lock view")
 
         if (indicator) {
-          view.fingerprintConfigured = false
-          root.assertTrue(!indicator.visible, "fingerprint indicator is hidden when no sensor is configured")
+          view.faceConfigured = false
+          root.assertTrue(!indicator.visible, "face indicator is hidden when face auth is not configured")
 
-          view.fingerprintConfigured = true
-          root.assertTrue(indicator.visible, "fingerprint indicator is shown when a sensor is configured")
+          view.faceConfigured = true
+          root.assertTrue(indicator.visible, "face indicator is shown when face auth is configured")
 
           // The field reserves space for the icon so a long password can never
-          // slide underneath it. The reserve must exceed the icon's own width
-          // (leaving a gap), and the shrunk dots must fit the reserved-clear
-          // area even at extreme lengths.
+          // slide underneath it, whichever biometric icons are shown.
           root.assertTrue(view.iconReserve > indicator.width,
             "reserved space exceeds the icon width, got reserve " + view.iconReserve + " vs icon " + indicator.width)
 
@@ -80,15 +78,20 @@ ShellRoot {
           probe.font.letterSpacing = view.passwordDotLetterSpacing * view.passwordDotScale
           probe.text = "●".repeat(80)
           root.assertTrue(probe.advanceWidth <= clearWidth,
-            "80 dots stay clear of the fingerprint icon, need " + probe.advanceWidth + "px of " + clearWidth)
+            "80 dots stay clear of the face icon, need " + probe.advanceWidth + "px of " + clearWidth)
 
+          // Both biometric icons shown together share one symmetric reserve.
+          view.fingerprintConfigured = true
+          root.assertTrue(view.iconReserve > 0, "space stays reserved with both icons shown")
           view.fingerprintConfigured = false
-          root.assertTrue(view.iconReserve === 0, "no space is reserved when no sensor is configured")
+
+          view.faceConfigured = false
+          root.assertTrue(view.iconReserve === 0, "no space is reserved when nothing is configured")
         }
 
         view.destroy()
       } catch (error) {
-        root.fail("lock fingerprint indicator fixture threw: " + error)
+        root.fail("lock face indicator fixture threw: " + error)
       } finally {
         root.writeResult()
       }

--- a/test/shell.d/lock-face-indicator-test.sh
+++ b/test/shell.d/lock-face-indicator-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "lock face indicator test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping lock face indicator test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+config_dir="$TMPDIR/lock-face-indicator"
+mkdir -p "$config_dir" "$TMPDIR/home"
+cp "$SHELL_TEST_DIR/fixtures/lock-face-indicator/shell.qml" "$config_dir/shell.qml"
+ln -s "$ROOT/shell/Ui" "$config_dir/Ui"
+ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "lock face indicator quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "lock face indicator test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Lock face indicator result:\n' >&2
+  jq . "$result" >&2
+  printf 'Lock face indicator log:\n' >&2
+  sed -n '1,220p' "$log" >&2
+  fail "face indicator tracks the configured face auth"
+fi
+
+pass "face indicator tracks the configured face auth"


### PR DESCRIPTION
## What

The lock screen supports fingerprint unlock but not face unlock. This adds a face flow that mirrors the fingerprint one, plus setup and removal wizards:

- `Service.qml` gains a third PAM context, `omarchy-lock-face`, next to the password and fingerprint ones. It arms when `/etc/pam.d/omarchy-lock-face` exists and howdy holds a model for the user.
- Unlike fprintd, a face scan drives the camera and IR emitters, so the PAM context cannot stay armed for the whole lock. The plugin scans up to three times after locking, then goes quiet; any wake (mouse, key) grants a fresh set of scans.
- `LockView.qml` shows a face icon on the left edge of the password field when face auth is set up, matching the fingerprint icon on the right. The dot-reserve logic now covers both icons (`fingerprintReserve` became `iconReserve`).
- `omarchy setup security face` installs howdy, points it at an IR (greyscale) camera by its stable `/dev/v4l/by-id` path, enrolls a model, verifies it with the same matcher PAM runs, and only then writes the PAM files — the same order the fingerprint wizard uses. Plain webcams need explicit confirmation, since a photo can fool them. `omarchy remove security face` undoes all of it.

## Why the stable camera path matters

Howdy configs that point at a bare `/dev/videoN` break silently when a reboot renumbers the nodes — that failure is what led me here. The wizard writes the `by-id` symlink so the config survives renumbering.

## Testing

- New `test/shell.d/lock-face-indicator-test.sh` with fixture, mirroring the fingerprint indicator test; both pass locally.
- `./test/cli` passes.
- Verified live on a BRIO IR camera: lock screen scans on lock and on wake, unlocks on face, falls back to password, and the icon renders in preview and on the real lock surface.