### PR TITLE
Fix Bitwarden extension popout rendering

### DIFF
--- a/default/hypr/apps/bitwarden.lua
+++ b/default/hypr/apps/bitwarden.lua
@@ -1,6 +1,10 @@
 o.window("^(Bitwarden)$", { no_screen_share = true, tag = "+floating-window" })
 
-o.window("chrome-nngceckbapebfimnlniiiahkandclblb-Default", {
+-- Chromium prefixes extension popout classes with the browser name and can
+-- append the popup path. Match Bitwarden's stable extension ID instead.
+o.window(".*nngceckbapebfimnlniiiahkandclblb.*", {
+  float = true,
+  max_size = { 480, 650 },
+  no_blur = true,
   no_screen_share = true,
-  tag = "+floating-window",
 })

--- a/test/shell.d/hyprland-bitwarden-test.sh
+++ b/test/shell.d/hyprland-bitwarden-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command lua
+
+OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local rules = {}
+hl = {
+  window_rule = function(rule)
+    table.insert(rules, rule)
+  end,
+}
+
+require("default.hypr.helpers")
+require("default.hypr.apps.bitwarden")
+
+assert(#rules == 2, "Bitwarden defines desktop and browser-extension rules")
+
+local desktop = rules[1]
+assert(desktop.match.class == "^(Bitwarden)$", "desktop rule keeps its exact class match")
+assert(desktop.no_screen_share == true, "desktop rule blocks screen sharing")
+
+local extension = rules[2]
+assert(extension.match.class == ".*nngceckbapebfimnlniiiahkandclblb.*", "extension rule matches every Chromium browser prefix and popup suffix")
+assert(extension.float == true, "extension popouts float directly")
+assert(extension.no_blur == true, "extension popouts disable blur")
+assert(extension.no_screen_share == true, "extension popouts block screen sharing")
+assert(type(extension.max_size) == "table", "extension maximum size uses a vec2")
+assert(extension.max_size[1] == 480 and extension.max_size[2] == 650, "extension popouts stay within Bitwarden's supported size")
+assert(extension.tag == nil, "extension popouts bypass the generic floating-window size")
+LUA
+
+pass "Bitwarden popouts match all Chromium browsers at their supported size"

--- a/test/shell.d/hyprland-bitwarden-test.sh
+++ b/test/shell.d/hyprland-bitwarden-test.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 require_command lua
 
-OMARCHY_PATH="$ROOT" lua <<'LUA'
+# "lua -" rather than "lua": reading the chunk off bare stdin, Lua 5.5 reports the
+# error and still exits 0, so every assertion below would be dead.
+OMARCHY_PATH="$ROOT" lua - <<'LUA'
 package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local rules = {}


### PR DESCRIPTION
## Summary

- match Bitwarden extension popouts by their stable extension ID, regardless of Chromium browser prefix or popup-path suffix
- float the popout directly instead of applying the generic `floating-window` tag
- cap it at Bitwarden's supported `480x650` size and disable blur/screen sharing
- add a regression test for the desktop and extension rules

## Why

Brave currently exposes the Bitwarden popup as:

```
brave-nngceckbapebfimnlniiiahkandclblb__popup_index.html-Default
```

The existing `chrome-nngceckbapebfimnlniiiahkandclblb-Default` rule does not match that class, so Hyprland tiles the narrow popup surface into a wide window. This produces the apparent half-rendered/transparent popup.

Applying Omarchy's generic `floating-window` tag is not sufficient here: its `875x600` size is also incompatible with Bitwarden's current popup layout. This rule therefore floats Bitwarden directly and uses a maximum size of `480x650`.

This combines the browser-class coverage from #8236 with the Bitwarden-specific sizing approach from #6449.

Fixes #6075.

## Verification

Live tested with Hyprland 0.56.2, Brave, and Bitwarden extension 2026.7.0:

- before: the class above opened tiled at `1386x858`
- after: the same class opened floating at `480x650`, with screen-share protection applied

Tests:

```bash
./test/shell.d/hyprland-bitwarden-test.sh
bash test/shell.d/hyprland-default-config-test.sh
git diff --check
```

The full `./test/all` suite was also run. Its five failures were reproduced unchanged on a detached, unmodified `upstream/quattro` checkout (one local bar-geometry check, three checks requiring an `omarchy-pkgs` checkout, and one network-dependent theme URL check).
