### PR TITLE
Fix omarchy share clipboard sending an empty file for image clipboard content

### DIFF
--- a/bin/omarchy-menu-share
+++ b/bin/omarchy-menu-share
@@ -15,8 +15,32 @@ MODE="$1"
 shift
 
 if [[ $MODE == "clipboard" ]]; then
-  TEMP_FILE=$(mktemp --suffix=.txt)
-  wl-paste >"$TEMP_FILE"
+  types=$(wl-paste --list-types 2>/dev/null || true)
+
+  mime=""
+  for candidate in image/png image/jpeg image/webp image/gif image/bmp image/tiff; do
+    if grep -qx "$candidate" <<<"$types"; then
+      mime=$candidate
+      break
+    fi
+  done
+
+  if [[ -n $mime ]]; then
+    ext=${mime#image/}
+    [[ $ext == jpeg ]] && ext=jpg
+    TEMP_FILE=$(mktemp --suffix=".$ext")
+    wl-paste --type "$mime" >"$TEMP_FILE"
+  else
+    TEMP_FILE=$(mktemp --suffix=.txt)
+    wl-paste --type text --no-newline >"$TEMP_FILE"
+  fi
+
+  if [[ ! -s $TEMP_FILE ]]; then
+    rm -f "$TEMP_FILE"
+    omarchy-notification-send -g "" -u critical "Could not share" "Clipboard is empty"
+    exit 1
+  fi
+
   FILE_ARRAY=("$TEMP_FILE")
 elif (($# > 0)); then
   FILE_ARRAY=("$@")

--- a/test/shell.d/menu-share-test.sh
+++ b/test/shell.d/menu-share-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$mock_bin" "$test_home"
+
+cat >"$mock_bin/wl-paste" <<'SH'
+#!/bin/bash
+if [[ $1 == "--list-types" ]]; then
+  printf '%b' "${WL_PASTE_TYPES:-}"
+  exit 0
+fi
+
+if [[ $1 == "--type" && $2 == text ]]; then
+  [[ -n ${WL_PASTE_TEXT:-} ]] || exit 1
+  printf '%s' "$WL_PASTE_TEXT"
+  exit 0
+fi
+
+if [[ $1 == "--type" ]]; then
+  [[ -n ${WL_PASTE_IMAGE:-} ]] || exit 1
+  printf '%s' "$WL_PASTE_IMAGE"
+  exit 0
+fi
+
+exit 1
+SH
+
+cat >"$mock_bin/systemd-run" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_SYSTEMD_RUN_LOG"
+SH
+
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_NOTIFY_LOG"
+SH
+
+chmod +x "$mock_bin"/*
+
+run_share_clipboard() {
+  local systemd_run_log=$1 notify_log=$2
+  shift 2
+
+  status=0
+  HOME="$test_home" PATH="$mock_bin:$PATH" \
+    OMARCHY_TEST_SYSTEMD_RUN_LOG="$systemd_run_log" OMARCHY_TEST_NOTIFY_LOG="$notify_log" \
+    "$@" bash "$ROOT/bin/omarchy-menu-share" clipboard || status=$?
+}
+
+# An image on the clipboard (e.g. a screenshot copied via `wl-copy --type
+# image/png`) must reach LocalSend as the image, not as an empty text file.
+systemd_run_log="$test_tmp/systemd-run.image"
+notify_log="$test_tmp/notify.image"
+: >"$systemd_run_log"
+run_share_clipboard "$systemd_run_log" "$notify_log" \
+  env WL_PASTE_TYPES='image/png\n' WL_PASTE_IMAGE=$'\x89PNGfakebytes'
+
+((status == 0)) || fail "clipboard share exits 0 for an image clipboard"
+
+sent_path=$(grep -oE '/[^ ]+\.png' "$systemd_run_log") || fail "clipboard share sends a .png file for an image clipboard" "$(cat "$systemd_run_log")"
+[[ $(cat "$sent_path") == $'\x89PNGfakebytes' ]] || fail "clipboard share sends the actual image bytes, not an empty file"
+pass "clipboard share sends the image when the clipboard holds image/png"
+
+# Plain text clipboard content keeps working as a .txt file.
+systemd_run_log="$test_tmp/systemd-run.text"
+notify_log="$test_tmp/notify.text"
+: >"$systemd_run_log"
+run_share_clipboard "$systemd_run_log" "$notify_log" \
+  env WL_PASTE_TYPES='text/plain\n' WL_PASTE_TEXT="hello clipboard"
+
+((status == 0)) || fail "clipboard share exits 0 for a text clipboard"
+sent_path=$(grep -oE '/[^ ]+\.txt' "$systemd_run_log") || fail "clipboard share sends a .txt file for a text clipboard" "$(cat "$systemd_run_log")"
+[[ $(cat "$sent_path") == "hello clipboard" ]] || fail "clipboard share sends the actual text content"
+pass "clipboard share still sends text clipboard content as .txt"
+
+# An empty clipboard must not hand LocalSend a 0-byte file.
+systemd_run_log="$test_tmp/systemd-run.empty"
+notify_log="$test_tmp/notify.empty"
+: >"$systemd_run_log"
+: >"$notify_log"
+run_share_clipboard "$systemd_run_log" "$notify_log" env WL_PASTE_TYPES='' WL_PASTE_TEXT=''
+
+((status != 0)) || fail "clipboard share fails when the clipboard is empty"
+[[ ! -s $systemd_run_log ]] || fail "clipboard share does not invoke LocalSend for an empty clipboard"
+grep -qi "clipboard" "$notify_log" || fail "clipboard share notifies the user when the clipboard is empty" "$(cat "$notify_log")"
+pass "clipboard share refuses to send an empty file for an empty clipboard"


### PR DESCRIPTION
## Summary
- `omarchy share clipboard` (used by LocalSend's "clipboard" send option) read the clipboard with bare `wl-paste`, which infers `text/plain` when no `--type` is given. When the clipboard holds something else — an `image/png` screenshot, for example — that inference fails, `wl-paste` writes nothing, and the resulting 0-byte `.txt` file gets sent to LocalSend as-is.
- Now detects the clipboard's actual mime type via `wl-paste --list-types`, passes it explicitly to `wl-paste --type`, and gives the temp file a matching extension. Falls back to text as before when no image type is offered.
- Also refuses to hand LocalSend an empty file at all (notifies the user instead), covering a genuinely empty clipboard.

Fixes #8340

## Test plan
- [x] Added `test/shell.d/menu-share-test.sh` covering: image clipboard sent as the actual image bytes with a matching extension, plain text clipboard still sent as `.txt`, and an empty clipboard refused with a notification instead of an empty file.
- [x] `./test/shell` — all files pass except 4 pre-existing failures unrelated to this change (`config-test.sh`, `snapper-test.sh`, `theme-install-guards-test.sh`, `unowned-system-paths-test.sh`), confirmed to fail identically on unmodified `quattro` (missing `omarchy-pkgs` sibling checkout / no network in this sandbox).
- [x] `./test/cli` passes.
- [x] Manually verified against a real screenshot: clipboard held `image/png`, and the fixed logic wrote a full valid PNG instead of an empty file.