### PR TITLE
Find hidden desktop entries in one awk pass instead of per line in bash

### DIFF
--- a/shell/services/hidden-entries.sh
+++ b/shell/services/hidden-entries.sh
@@ -2,101 +2,100 @@
 
 desktop_names=${1:-}
 
-declare -A seen_ids
-
-desktop_matches() {
-  local list=$1
-  local desktop_name
-  local entry
-
-  IFS=":" read -ra desktop_parts <<< "$desktop_names"
-  IFS=";" read -ra entries <<< "$list"
-
-  for desktop_name in "${desktop_parts[@]}"; do
-    [[ -z $desktop_name ]] && continue
-
-    for entry in "${entries[@]}"; do
-      [[ -z $entry ]] && continue
-      [[ $entry == "$desktop_name" ]] && return 0
-    done
-  done
-
-  return 1
-}
-
-desktop_id_for_file() {
-  local dir=$1
-  local file=$2
-  local rel=${file#"$dir"/}
-
-  rel=${rel%.desktop}
-  printf '%s\n' "${rel//\//-}"
-}
-
-is_hidden_desktop_file() {
-  local file=$1
-  local in_desktop_entry=0
-  local hidden=false
-  local only_show_in=
-  local not_show_in=
-  local line key value
-
-  while IFS= read -r line || [[ -n $line ]]; do
-    line=${line%$'\r'}
-
-    if [[ $line =~ ^\[(.*)\]$ ]]; then
-      [[ ${BASH_REMATCH[1]} == "Desktop Entry" ]] && in_desktop_entry=1 || in_desktop_entry=0
-      continue
-    fi
-
-    (( in_desktop_entry )) || continue
-    [[ $line == *=* ]] || continue
-
-    key=${line%%=*}
-    value=${line#*=}
-
-    case $key in
-      Hidden|NoDisplay)
-        [[ $value == "true" ]] && hidden=true
-        ;;
-      OnlyShowIn)
-        only_show_in=$value
-        ;;
-      NotShowIn)
-        not_show_in=$value
-        ;;
-    esac
-  done < "$file"
-
-  [[ $hidden == "true" ]] && return 0
-  [[ -n $only_show_in ]] && ! desktop_matches "$only_show_in" && return 0
-  [[ -n $not_show_in ]] && desktop_matches "$not_show_in" && return 0
-
-  return 1
-}
-
-scan_dir() {
-  local dir=$1
-  local file id
-
-  [[ -d $dir ]] || return
-
-  while IFS= read -r -d '' file; do
-    id=$(desktop_id_for_file "$dir" "$file")
-    [[ -n ${seen_ids[$id]+set} ]] && continue
-    seen_ids[$id]=1
-
-    if is_hidden_desktop_file "$file"; then
-      printf '%s\n' "$id"
-    fi
-  done < <(find "$dir" -type f -name '*.desktop' -print0 2>/dev/null | sort -z)
-}
-
-scan_dir "$HOME/.local/share/applications"
+scan_dirs=("$HOME/.local/share/applications")
 
 IFS=":" read -ra data_dirs <<< "${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 for data_dir in "${data_dirs[@]}"; do
-  scan_dir "$data_dir/applications"
+  scan_dirs+=("$data_dir/applications")
 done
 
-scan_dir "$HOME/.nix-profile/share/applications"
+scan_dirs+=("$HOME/.nix-profile/share/applications")
+
+# One awk pass over every entry, rather than a bash read loop per line. A
+# desktop file is mostly localization -- on a stock install 19,507 of 24,064
+# lines are Name[xx]/Comment[xx] -- and bash reads each of those one line at a
+# time only to discard it, which cost ~800ms and pinned a core every time the
+# desktop-entry watcher fired.
+#
+# Directories are streamed as D: records ahead of their F: entries so a single
+# awk keeps the first-hit-wins dedup across all of them, and both stay NUL
+# separated to survive whitespace in paths.
+{
+  for dir in "${scan_dirs[@]}"; do
+    [[ -d $dir ]] || continue
+    printf 'D:%s\0' "$dir"
+    find "$dir" -type f -name '*.desktop' -printf 'F:%p\0' 2>/dev/null | sort -z
+  done
+} | awk -v RS='\0' -v names="$desktop_names" '
+function desktop_matches(list,   i, j, name_count, entry_count, parts, entries) {
+  name_count = split(names, parts, ":")
+  entry_count = split(list, entries, ";")
+
+  for (i = 1; i <= name_count; i++) {
+    if (parts[i] == "") continue
+
+    for (j = 1; j <= entry_count; j++) {
+      if (entries[j] == "") continue
+      if (entries[j] == parts[i]) return 1
+    }
+  }
+
+  return 0
+}
+
+/^D:/ { dir = substr($0, 3); next }
+
+{
+  file = substr($0, 3)
+
+  id = substr(file, length(dir) + 2)
+  sub(/\.desktop$/, "", id)
+  gsub("/", "-", id)
+
+  if (id in seen) next
+  seen[id] = 1
+
+  # RS is NUL for the file list, and getline honours it here too, so a desktop
+  # file arrives as a single record. Split it rather than fighting RS: one read
+  # per file beats one per line either way.
+  contents = ""
+  while ((getline chunk < file) > 0) contents = contents chunk
+  close(file)
+
+  in_desktop_entry = 0
+  hidden = 0
+  only_show_in = ""
+  not_show_in = ""
+
+  line_count = split(contents, lines, "\n")
+  for (i = 1; i <= line_count; i++) {
+    line = lines[i]
+    sub(/\r$/, "", line)
+
+    if (line ~ /^\[.*\]$/) {
+      in_desktop_entry = (line == "[Desktop Entry]")
+      continue
+    }
+
+    if (!in_desktop_entry) continue
+
+    separator = index(line, "=")
+    if (separator == 0) continue
+
+    key = substr(line, 1, separator - 1)
+    value = substr(line, separator + 1)
+
+    if (key == "Hidden" || key == "NoDisplay") {
+      if (value == "true") hidden = 1
+    } else if (key == "OnlyShowIn") {
+      only_show_in = value
+    } else if (key == "NotShowIn") {
+      not_show_in = value
+    }
+  }
+
+  if (hidden) { print id; next }
+  if (only_show_in != "" && !desktop_matches(only_show_in)) { print id; next }
+  if (not_show_in != "" && desktop_matches(not_show_in)) { print id; next }
+}
+'

--- a/shell/services/hidden-entries.sh
+++ b/shell/services/hidden-entries.sh
@@ -26,9 +26,12 @@ scan_dirs+=("$HOME/.nix-profile/share/applications")
     printf 'D:%s\0' "$dir"
     find "$dir" -type f -name '*.desktop' -printf 'F:%p\0' 2>/dev/null | sort -z
   done
-} | awk -v RS='\0' -v names="$desktop_names" '
+} | desktop_names="$desktop_names" awk -v RS='\0' '
+# Read the names from the environment rather than -v: gawk runs escape processing
+# over a -v assignment, so a name containing a backslash would arrive mangled and
+# silently stop matching.
 function desktop_matches(list,   i, j, name_count, entry_count, parts, entries) {
-  name_count = split(names, parts, ":")
+  name_count = split(ENVIRON["desktop_names"], parts, ":")
   entry_count = split(list, entries, ";")
 
   for (i = 1; i <= name_count; i++) {
@@ -59,8 +62,15 @@ function desktop_matches(list,   i, j, name_count, entry_count, parts, entries) 
   # file arrives as a single record. Split it rather than fighting RS: one read
   # per file beats one per line either way.
   contents = ""
-  while ((getline chunk < file) > 0) contents = contents chunk
+  while ((status = (getline chunk < file)) > 0) contents = contents chunk
+  # Read ERRNO before close(), which overwrites it when the file never opened.
+  if (status < 0) reason = ERRNO
   close(file)
+
+  if (status < 0) {
+    print file ": " reason > "/dev/stderr"
+    next
+  }
 
   in_desktop_entry = 0
   hidden = 0

--- a/test/shell.d/hidden-entries-test.sh
+++ b/test/shell.d/hidden-entries-test.sh
@@ -27,7 +27,14 @@ hidden_entries() {
 }
 
 lists_entry() {
-  hidden_entries "${2:-}" | grep -qx "$1"
+  local output
+  # Capture first: piping straight into grep would discard the script's exit
+  # status, so a crash would read the same as an entry that is simply absent.
+  if ! output=$(hidden_entries "${2:-}"); then
+    fail "hidden-entries.sh exited non-zero"
+  fi
+
+  grep -Fqx -- "$1" <<<"$output"
 }
 
 write_entry "$user_apps/plain.desktop" <<'EOF'
@@ -147,3 +154,14 @@ EOF
 
 lists_entry "with space-spaced" || fail "a path containing a space is scanned"
 pass "hidden-entries scans paths containing spaces"
+
+# Desktop names reach awk through the environment, so a backslash has to arrive
+# intact. Passing them via -v would let gawk eat the escape and hide the entry.
+write_entry "$system_dir/applications/backslash.desktop" <<'ENTRY'
+[Desktop Entry]
+Name=Backslash
+OnlyShowIn=Foo\Bar;
+ENTRY
+
+lists_entry "backslash" 'Foo\Bar' && fail "a backslash in a desktop name survives transport"
+pass "hidden-entries passes desktop names to awk without escape processing"

--- a/test/shell.d/hidden-entries-test.sh
+++ b/test/shell.d/hidden-entries-test.sh
@@ -163,5 +163,5 @@ Name=Backslash
 OnlyShowIn=Foo\Bar;
 ENTRY
 
-lists_entry "backslash" 'Foo\Bar' && fail "a backslash in a desktop name survives transport"
+lists_entry backslash 'Foo\Bar' && fail "a backslash in a desktop name survives transport"
 pass "hidden-entries passes desktop names to awk without escape processing"

--- a/test/shell.d/hidden-entries-test.sh
+++ b/test/shell.d/hidden-entries-test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+script="$ROOT/shell/services/hidden-entries.sh"
+
+test_home=$(mktemp -d)
+system_dir=$(mktemp -d)
+local_dir=$(mktemp -d)
+
+cleanup() {
+  rm -rf "$test_home" "$system_dir" "$local_dir"
+}
+trap cleanup EXIT
+
+user_apps="$test_home/.local/share/applications"
+mkdir -p "$user_apps" "$system_dir/applications" "$local_dir/applications"
+
+write_entry() {
+  local path="$1"
+  mkdir -p "$(dirname "$path")"
+  cat >"$path"
+}
+
+hidden_entries() {
+  HOME="$test_home" XDG_DATA_DIRS="$local_dir:$system_dir" bash "$script" "${1:-}"
+}
+
+lists_entry() {
+  hidden_entries "${2:-}" | grep -qx "$1"
+}
+
+write_entry "$user_apps/plain.desktop" <<'EOF'
+[Desktop Entry]
+Name=Plain
+Exec=plain
+EOF
+
+write_entry "$user_apps/hidden.desktop" <<'EOF'
+[Desktop Entry]
+Name=Hidden
+Hidden=true
+EOF
+
+write_entry "$user_apps/nodisplay.desktop" <<'EOF'
+[Desktop Entry]
+Name=NoDisplay
+NoDisplay=true
+EOF
+
+lists_entry hidden || fail "Hidden=true is hidden"
+lists_entry nodisplay || fail "NoDisplay=true is hidden"
+lists_entry plain && fail "an entry with neither key stays visible"
+pass "hidden-entries reports Hidden and NoDisplay entries"
+
+# The value is compared literally: only "true" hides an entry, so "True" and
+# "1" leave it visible rather than silently disappearing from the launcher.
+write_entry "$user_apps/capitalized.desktop" <<'EOF'
+[Desktop Entry]
+Name=Capitalized
+Hidden=True
+EOF
+
+lists_entry capitalized && fail "Hidden=True (capitalized) does not hide"
+pass "hidden-entries only treats a literal true as hidden"
+
+write_entry "$user_apps/only-hyprland.desktop" <<'EOF'
+[Desktop Entry]
+Name=Only Hyprland
+OnlyShowIn=Hyprland;
+EOF
+
+write_entry "$user_apps/not-hyprland.desktop" <<'EOF'
+[Desktop Entry]
+Name=Not Hyprland
+NotShowIn=Hyprland;
+EOF
+
+lists_entry only-hyprland Hyprland && fail "OnlyShowIn match stays visible"
+lists_entry only-hyprland GNOME || fail "OnlyShowIn mismatch is hidden"
+lists_entry not-hyprland Hyprland || fail "NotShowIn match is hidden"
+lists_entry not-hyprland GNOME && fail "NotShowIn mismatch stays visible"
+pass "hidden-entries honours OnlyShowIn and NotShowIn"
+
+# Quickshell passes XDG_CURRENT_DESKTOP, XDG_SESSION_DESKTOP and
+# DESKTOP_SESSION joined by ":", so any one of them matching is a match.
+lists_entry only-hyprland "GNOME:Hyprland" && fail "a later desktop name still matches OnlyShowIn"
+lists_entry not-hyprland "GNOME:Hyprland" || fail "a later desktop name still matches NotShowIn"
+pass "hidden-entries matches any of the colon-separated desktop names"
+
+# Keys belong to [Desktop Entry]. An action group carrying Hidden=true must not
+# hide the application the actions belong to.
+write_entry "$user_apps/action-group.desktop" <<'EOF'
+[Desktop Entry]
+Name=Action Group
+Actions=extra;
+
+[Desktop Action extra]
+Name=Extra
+Hidden=true
+EOF
+
+lists_entry action-group && fail "Hidden in a non-Desktop Entry group is ignored"
+pass "hidden-entries only reads the Desktop Entry group"
+
+# Desktop files written on Windows keep their CRLF endings; the trailing \r must
+# not turn "true" into something that no longer compares equal.
+printf '[Desktop Entry]\r\nName=Crlf\r\nHidden=true\r\n' >"$user_apps/crlf.desktop"
+
+lists_entry crlf || fail "CRLF line endings are handled"
+pass "hidden-entries handles CRLF desktop files"
+
+# A user entry shadows a system entry of the same id, so the user's visible copy
+# must win over a system copy marked hidden.
+write_entry "$user_apps/shadowed.desktop" <<'EOF'
+[Desktop Entry]
+Name=Shadowed
+EOF
+
+write_entry "$system_dir/applications/shadowed.desktop" <<'EOF'
+[Desktop Entry]
+Name=Shadowed
+Hidden=true
+EOF
+
+lists_entry shadowed && fail "the first directory scanned wins"
+pass "hidden-entries keeps the first entry found for an id"
+
+# Nested entries get their separators folded into the id, matching the desktop
+# id Quickshell reports for them.
+write_entry "$system_dir/applications/nested/deep.desktop" <<'EOF'
+[Desktop Entry]
+Name=Deep
+Hidden=true
+EOF
+
+lists_entry nested-deep || fail "a nested entry uses a dashed id"
+pass "hidden-entries derives dashed ids for nested entries"
+
+# Paths are streamed NUL separated, so a directory with a space must survive.
+spaced_dir="$system_dir/applications/with space"
+write_entry "$spaced_dir/spaced.desktop" <<'EOF'
+[Desktop Entry]
+Name=Spaced
+Hidden=true
+EOF
+
+lists_entry "with space-spaced" || fail "a path containing a space is scanned"
+pass "hidden-entries scans paths containing spaces"


### PR DESCRIPTION
I noticed this chasing why my laptop felt sluggish after a forced power-off. Most of it was just a cold page cache, but profiling turned up `hidden-entries.sh` took like ~800ms of CPU per run. It runs every time the desktop-entry watcher fires.

## What changed

Parse every desktop file in a single awk pass instead of a bash read loop per line.

Two more things turned up while reviewing this. Desktop names now reach awk through the environment instead of `-v`, because gawk runs escape processing over a `-v` assignment and a name containing a backslash stopped matching. A failed `getline` is now reported instead of being read as EOF.

## Why

A desktop app file contains a lot of localization. On a default installations it's about 19k files. Bash reads each one of those just to discard most of them.

Same machine, same entries:

| | |
|---|---|
| before | 770–1334 ms |
| after | 55–62 ms |

The output is unchanges. Same ids, same order. Both implementations have been diffed against the real entry set for 13 desktop name inputs. Empty, single, colon-joined, non-matching, "::", leading and trailing ":" and they agree byte to byte. 

Directories are streamed as `D:` records ahead of their `F:` entries so one awk still keeps the first-hit-wins dedup across all of them, and both stay NUL separated so paths with whitespace survive.

## Tests

`test/shell.d/hidden-entries-test.sh` is new. The script had no coverage until now I think. It pins the behaviour I was preserving `Hidden`/`NoDisplay`, literal `true` only, `OnlyShowIn`/`NotShowIn`, colon-joined desktop names, keys outside `[Desktop Entry]`, CRLF, first-hit-wins shadowing, dashed nested ids, and paths containing spaces.

The test script works against the old implementation as well, with one exception. The old script exits 1 on any machine without `~/.nix-profile`, because the last directory check fails and its status becomes the exit code. The rewrite exits 0. Nothing reads the exit code today, `AppLibrary.qml` only looks at stdout.

## Note

This does not touch `AppLibrary.qml`, so it should not collide with #6505 beyond the one `XDG_DATA_DIRS` fallback line that PR also edits.


