### PR TITLE
Paste clipboard history with Ctrl+V outside terminals

### DIFF
--- a/bin/omarchy-clipboard-paste-file
+++ b/bin/omarchy-clipboard-paste-file
@@ -8,6 +8,16 @@
 
 copy_only=false
 
+# Terminals take Shift+Insert, everything else Ctrl+V — same split as universal
+# paste in default/hypr/bindings/clipboard.lua.
+paste_into_focused_window() {
+  if hyprctl -j activewindow 2>/dev/null | jq -e '[.tags[]? | sub("\\*$"; "")] | index("terminal")' >/dev/null; then
+    wtype -M shift -k Insert -m shift 2>/dev/null || true
+  else
+    wtype -M ctrl v -m ctrl 2>/dev/null || true
+  fi
+}
+
 if [[ ${1:-} == "--copy-only" ]]; then
   copy_only=true
   shift
@@ -30,4 +40,4 @@ if [[ $copy_only == "true" ]]; then
 fi
 
 sleep 0.15
-wtype -M shift -k Insert -m shift 2>/dev/null || true
+paste_into_focused_window

--- a/bin/omarchy-clipboard-paste-text
+++ b/bin/omarchy-clipboard-paste-text
@@ -6,7 +6,7 @@
 # omarchy:examples=omarchy clipboard paste text "hello" | omarchy clipboard paste text --shift-insert "hello"
 # omarchy:hidden=true
 
-use_shift_insert=false
+use_paste_shortcut=false
 copy_only=false
 history_index=""
 text=""
@@ -14,7 +14,7 @@ text=""
 while (( $# > 0 )); do
   case "$1" in
     --shift-insert)
-      use_shift_insert=true
+      use_paste_shortcut=true
       shift
       ;;
     --copy-only)
@@ -31,6 +31,16 @@ while (( $# > 0 )); do
   esac
 done
 
+# Terminals take Shift+Insert, everything else Ctrl+V — same split as universal
+# paste in default/hypr/bindings/clipboard.lua.
+paste_into_focused_window() {
+  if hyprctl -j activewindow 2>/dev/null | jq -e '[.tags[]? | sub("\\*$"; "")] | index("terminal")' >/dev/null; then
+    wtype -M shift -k Insert -m shift 2>/dev/null || true
+  else
+    wtype -M ctrl v -m ctrl 2>/dev/null || true
+  fi
+}
+
 copy_history_entry() {
   local history_path="$HOME/.local/state/omarchy/clipboard-history.json"
 
@@ -42,7 +52,7 @@ copy_history_entry() {
 if [[ -n $history_index ]]; then
   copy_history_entry
   if [[ $copy_only != "true" ]]; then
-    use_shift_insert=true
+    use_paste_shortcut=true
   fi
 else
   text=${1:-}
@@ -56,8 +66,8 @@ fi
 
 sleep 0.15
 
-if [[ $use_shift_insert == "true" ]]; then
-  wtype -M shift -k Insert -m shift 2>/dev/null || true
+if [[ $use_paste_shortcut == "true" ]]; then
+  paste_into_focused_window
 else
   wtype "$text" 2>/dev/null || true
 fi

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -266,6 +266,15 @@ cat >"$TMPDIR/bin/wtype" <<'SH'
 printf '%s\n' "$*" >"$WTYPE_OUT"
 SH
 
+cat >"$TMPDIR/bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ ${FOCUSED_IS_TERMINAL:-} == "1" ]]; then
+  printf '{"tags":["terminal"]}'
+else
+  printf '{"tags":["floating-window"]}'
+fi
+SH
+
 cat >"$TMPDIR/bin/omarchy-launch-browser" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >"$BROWSER_OUT"
@@ -282,7 +291,7 @@ cat >"$TMPDIR/bin/tensaku-edit" <<'SH'
 printf '%s\n' "$*" >"$TENSAKU_OUT"
 SH
 
-chmod +x "$TMPDIR/bin/wl-copy" "$TMPDIR/bin/wl-paste" "$TMPDIR/bin/wtype" "$TMPDIR/bin/omarchy-launch-browser" "$TMPDIR/bin/omarchy-launch-editor" "$TMPDIR/bin/tensaku-edit"
+chmod +x "$TMPDIR/bin/wl-copy" "$TMPDIR/bin/wl-paste" "$TMPDIR/bin/wtype" "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/omarchy-launch-browser" "$TMPDIR/bin/omarchy-launch-editor" "$TMPDIR/bin/tensaku-edit"
 
 capture_output=$(XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" "$ROOT/shell/plugins/clipboard/capture.sh")
 [[ $capture_output == '{"type":"text","text":"terminal copy"}' ]] || fail "clipboard capture records normal text events"
@@ -465,14 +474,21 @@ pass "clipboard watcher dies with its owner via pdeathsig"
 
 jq -n --arg text "$(printf 'large block line 1\nlarge block line 2\n')" '[{type:"text", text:"ignored"}, {type:"text", text:$text}]' >"$TMPDIR/home/.local/state/omarchy/clipboard-history.json"
 
-WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$PATH" \
+FOCUSED_IS_TERMINAL=1 WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$PATH" \
   "$ROOT/bin/omarchy-clipboard-paste-text" --shift-insert --history-index 1
 
 [[ $(<"$TMPDIR/copied") == "$(printf 'large block line 1\nlarge block line 2')" ]] || fail "clipboard paste helper copies history entry text"
 pass "clipboard paste helper copies history entry text"
 
-[[ $(<"$TMPDIR/wtype") == "-M shift -k Insert -m shift" ]] || fail "clipboard paste helper pastes history entries with shift insert"
-pass "clipboard paste helper pastes history entries with shift insert"
+[[ $(<"$TMPDIR/wtype") == "-M shift -k Insert -m shift" ]] || fail "clipboard paste helper pastes into terminals with shift insert"
+pass "clipboard paste helper pastes into terminals with shift insert"
+
+rm -f "$TMPDIR/wtype"
+WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$PATH" \
+  "$ROOT/bin/omarchy-clipboard-paste-text" --shift-insert --history-index 1
+
+[[ $(<"$TMPDIR/wtype") == "-M ctrl v -m ctrl" ]] || fail "clipboard paste helper pastes into non-terminals with ctrl v"
+pass "clipboard paste helper pastes into non-terminals with ctrl v"
 
 rm -f "$TMPDIR/wtype"
 WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$PATH" \


### PR DESCRIPTION
Selecting an entry from clipboard history always sends `Shift+Insert`. That keystroke is handled by each client application rather than by the compositor, so it is inconsistent across GUI apps — in a browser window nothing pastes at all. The entry lands on the clipboard but never reaches the window, so you have to press Ctrl+V yourself. In a terminal it works, which is why it looks intermittent rather than broken.

Omarchy already solves this for universal paste in `default/hypr/bindings/clipboard.lua`:

```lua
o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "V", "SHIFT", "Insert"))
```

Ctrl+V for normal windows, Shift+Insert for terminals, off the `terminal` tag from `default/hypr/apps/terminals.lua`. The clipboard paste helpers just don't follow that rule. This makes them follow it — terminals keep Shift+Insert, everything else gets Ctrl+V.

Same fix in `omarchy-clipboard-paste-text` and `omarchy-clipboard-paste-file`. The inline-text path still types instead of pasting, unchanged.

Checked on 4.0.1 with different text in the clipboard and in the primary selection: `wtype -M shift -k Insert -m shift` pastes nothing into a browser window. I've been running the Ctrl+V half locally since 4.0 and it pastes correctly there and in Electron apps.

`test/shell.d/clipboard-test.sh` now stubs `hyprctl` and covers both branches. `./test/shell` and `./test/cli` pass.