### PR TITLE
Add fzf-style fuzzy fallback to menu and app search

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -48,6 +48,16 @@ alternate names users already type (`power-menu`, `settings`), kept for
 compatibility — see `AGENTS.md`. Search does not need them: labels, the last
 id segment, and descriptions are all searchable.
 
+A query that matches nowhere as a substring or whole word falls back to
+fuzzy (subsequence) matching against the label alone: typing `lean` finds
+`Learn` because `l-e-a-n` appears in order inside `L-e-a-r-n`, skipping the
+`r`. This fallback is scoped to the label only — never the description or
+aliases — because subsequence-matching a longer field turns almost any short
+query into a hit; it is also always the lowest-ranked tier, so a real
+substring or whole-word match wins whenever one exists. The same fallback,
+scoped to the app name, applies when browsing the Apps submenu directly
+(`AppSearch.js`).
+
 ## Load and merge
 
 `mergeMenuSources` overlays user entries on the defaults per key: reusing a

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -320,11 +320,44 @@ function descriptionTextMatches(query, text) {
   return true
 }
 
+// fzf-style subsequence match: every character of `term` must appear in
+// `text` in order, not necessarily adjacent. Returns -1 when `term` is not a
+// subsequence of `text`. Otherwise a quality score (higher is better): +3 for
+// a matched char at a word boundary, +2 for each char continuing an unbroken
+// run, minus how far into `text` the first match sits. Scoped to the short
+// label/name only wherever it's called — running it over a longer combined
+// field (description, keywords) turns most short queries into false hits.
+function fuzzySubsequenceScore(text, term) {
+  var hay = String(text || "")
+  var needle = String(term || "")
+  if (!needle || !hay) return -1
+
+  var hi = 0, ni = 0, firstIndex = -1, run = 0, bonus = 0
+  while (hi < hay.length && ni < needle.length) {
+    if (hay.charAt(hi) === needle.charAt(ni)) {
+      if (firstIndex < 0) firstIndex = hi
+      var prev = hi > 0 ? hay.charAt(hi - 1) : ""
+      var boundary = hi === 0 || /[^a-z0-9]/i.test(prev)
+      run += 1
+      bonus += (boundary ? 3 : 0) + (run > 1 ? 2 : 0)
+      ni += 1
+    } else {
+      run = 0
+    }
+    hi += 1
+  }
+  if (ni < needle.length) return -1
+  return bonus - firstIndex
+}
+
+var MIN_FUZZY_TERM_LENGTH = 3
+
 function matchesQuery(entry, query, visible) {
   if (!entry || entry.id === "root") return false
   if (!visible) return false
 
   var nameText = nameSearchText(entry)
+  var label = entry.label.toLowerCase()
   var descriptionText = String(entry.description || "").toLowerCase()
   var terms = String(query || "").toLowerCase().trim().split(/\s+/)
 
@@ -332,6 +365,7 @@ function matchesQuery(entry, query, visible) {
     if (!terms[i]) continue
     if (nameText.indexOf(terms[i]) >= 0) continue
     if (termInSearchWords(terms[i], descriptionText)) continue
+    if (terms[i].length >= MIN_FUZZY_TERM_LENGTH && fuzzySubsequenceScore(label, terms[i]) >= 0) continue
     return false
   }
 
@@ -353,6 +387,7 @@ function searchScore(items, entry, query) {
   else if (label.indexOf(needle) >= 0) score = 30
   else if (nameText.indexOf(needle) >= 0) score = 40
   else if (descriptionTextMatches(needle, descriptionText)) score = 60
+  else if (needle.length >= MIN_FUZZY_TERM_LENGTH && fuzzySubsequenceScore(label, needle) >= 0) score = 70
 
   if (entry.kind === "menu" || entry.kind === "link") score -= 2
   // App rows sort after all menu items, so they lose the tiebreak below to an
@@ -517,6 +552,7 @@ if (typeof module !== "undefined") {
     nameSearchText: nameSearchText,
     termInSearchWords: termInSearchWords,
     descriptionTextMatches: descriptionTextMatches,
+    fuzzySubsequenceScore: fuzzySubsequenceScore,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
     displayRow: displayRow

--- a/shell/services/AppSearch.js
+++ b/shell/services/AppSearch.js
@@ -46,6 +46,39 @@ function entryAcronym(entry) {
   return result
 }
 
+// fzf-style subsequence match: every character of `term` must appear in
+// `text` in order, not necessarily adjacent. Returns -1 when `term` is not a
+// subsequence of `text`. Otherwise a quality score (higher is better): +3 for
+// a matched char at a word boundary, +2 for each char continuing an unbroken
+// run, minus how far into `text` the first match sits. Scoped to the app
+// name only wherever it's called — running it over the full search haystack
+// (keywords/comment/id) turns most short queries into false hits, e.g.
+// "contact" is an in-order subsequence of Calculator's own keywords.
+function fuzzySubsequenceScore(text, term) {
+  var hay = String(text || "")
+  var needle = String(term || "")
+  if (!needle || !hay) return -1
+
+  var hi = 0, ni = 0, firstIndex = -1, run = 0, bonus = 0
+  while (hi < hay.length && ni < needle.length) {
+    if (hay.charAt(hi) === needle.charAt(ni)) {
+      if (firstIndex < 0) firstIndex = hi
+      var prev = hi > 0 ? hay.charAt(hi - 1) : ""
+      var boundary = hi === 0 || /[^a-z0-9]/i.test(prev)
+      run += 1
+      bonus += (boundary ? 3 : 0) + (run > 1 ? 2 : 0)
+      ni += 1
+    } else {
+      run = 0
+    }
+    hi += 1
+  }
+  if (ni < needle.length) return -1
+  return bonus - firstIndex
+}
+
+var MIN_FUZZY_TERM_LENGTH = 3
+
 function termMatches(entry, term) {
   if (!term) return true
 
@@ -56,8 +89,9 @@ function termMatches(entry, term) {
   if (name.indexOf(term) >= 0) return true
   if (id.indexOf(term) >= 0) return true
   if (haystack.indexOf(term) >= 0) return true
+  if (term.length <= 5 && entryAcronym(entry).indexOf(term) >= 0) return true
 
-  return term.length <= 5 && entryAcronym(entry).indexOf(term) >= 0
+  return term.length >= MIN_FUZZY_TERM_LENGTH && fuzzySubsequenceScore(name, term) >= 0
 }
 
 function allTermsMatch(entry, query) {
@@ -90,6 +124,11 @@ function fuzzyScore(entry, query) {
   var acronymIndex = acronym.indexOf(q)
   if (acronymIndex === 0) return 5000 - acronym.length
   if (acronymIndex > 0) return 4600 - acronymIndex * 10 - acronym.length
+
+  if (q.length >= MIN_FUZZY_TERM_LENGTH) {
+    var fuzzy = fuzzySubsequenceScore(name, q)
+    if (fuzzy >= 0) return 2000 + Math.max(0, Math.min(900, fuzzy))
+  }
 
   return 4000 - name.length
 }
@@ -128,6 +167,7 @@ if (typeof module !== "undefined") {
     entrySortKey: entrySortKey,
     entrySearchText: entrySearchText,
     entryAcronym: entryAcronym,
+    fuzzySubsequenceScore: fuzzySubsequenceScore,
     fuzzyScore: fuzzyScore,
     sortedEntries: sortedEntries
   }

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -69,6 +69,30 @@ assertEqual(acronymMatches[0], 'Google Contacts', 'short acronym matching still 
 const directMatches = search.sortedEntries(entries, 'obs').map(row => search.entryName(row.entry))
 assertEqual(directMatches[0], 'OBS Studio', 'direct app-name matching still works')
 
+// Fuzzy fallback: typo-tolerant subsequence matching against the app name,
+// only once substring/id/keyword/acronym matching has already failed.
+const rustdeskFuzzy = search.sortedEntries(entries, 'rustesk').map(row => search.entryName(row.entry))
+assertEqual(rustdeskFuzzy[0], 'RustDesk', 'fuzzy fallback finds RustDesk despite a dropped letter')
+
+const googleFuzzy = search.sortedEntries(entries, 'gogle').map(row => search.entryName(row.entry))
+assertEqual(googleFuzzy[0], 'Google Contacts', 'fuzzy fallback finds Google Contacts despite a dropped letter')
+
+// A real substring match still outranks a fuzzy one when both exist.
+assert(
+  search.fuzzyScore(entries[0], 'contact') > search.fuzzyScore(entries[0], 'cntct'),
+  'a real substring match outranks a fuzzy fallback match on the same entry'
+)
+
+// False-positive guard: "arsci" is a genuine subsequence of Calculator's own
+// keywords/comment ("arithmetic", "scientific") but not of its name
+// "Calculator" — fuzzy must not reach into keywords/comment/id, only the
+// name, or it reintroduces the same false-positive class "contact" would
+// otherwise trigger.
+assert(
+  search.fuzzyScore(entries[1], 'arsci') < 0,
+  'calculator does not fuzzy-match through its keywords/comment, only through its own name'
+)
+
 // The menu's Apps submenu is the launcher now: app rows launch and uninstall
 // through the shared app library instead of running commands themselves.
 const activateMatch = menuQml.match(/function activateIndex\(index, fromPointer\) \{([\s\S]*?)\n  \}/)

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -169,6 +169,26 @@ assertEqual(menu.resolveRoute(routed.items, routed.itemOrder, 'power_menu'), 'sy
 assertEqual(menu.resolveRoute(routed.items, routed.itemOrder, ''), 'root', 'menu routes empty input to root')
 assertEqual(menu.resolveRoute(routed.items, routed.itemOrder, 'no-such-route'), 'no-such-route', 'menu falls through to the literal input')
 assert(menu.matchesQuery(routed.items['apps.htop'], 'system', true), 'menu still finds an app by its keywords in search')
+
+// Fuzzy fallback: once substring and whole-word matching both fail for a
+// term, a subsequence match against the label still finds the row — "lean"
+// finds "Learn" because l-e-a-n is in order inside L-e-a-r-n, skipping the r.
+const learnEntry = rankBase.items['learn']
+assert(learnEntry && learnEntry.label === 'Learn', 'fixture: default menu ships a Learn entry')
+assert(menu.matchesQuery(learnEntry, 'lean', true), 'menu fuzzy-matches a skipped letter against the label ("lean" -> "Learn")')
+assert(
+  menu.searchScore(rankBase.items, learnEntry, 'learn') < menu.searchScore(rankBase.items, learnEntry, 'lean'),
+  'menu ranks an exact label match above its own fuzzy fallback match'
+)
+assert(menu.matchesQuery(learnEntry, 'lrn', true), 'menu fuzzy-matches multiple skipped letters')
+assert(!menu.matchesQuery(learnEntry, 'xqz', true), 'menu still rejects a query with no subsequence match')
+
+// Fuzzy is scoped to the label, not the description or aliases: "pearl" is a
+// genuine subsequence of "appearance colors" but must not match, or fuzzy
+// would turn near-arbitrary short queries into hits through the description
+// — the same failure mode "contact" would hit against Calculator's keywords.
+assert(!menu.matchesQuery(entry, 'pearl', true), 'menu fuzzy fallback does not reach into the description')
+
 assert(
   /function resolveRoute\(input\) \{\s*\n\s*return MenuModel\.resolveRoute\(root\.items, root\.itemOrder, input\)\s*\n\s*\}/.test(menuQml),
   'menu delegates route resolution to the shared model'


### PR DESCRIPTION
## Summary
- Substring/keyword matching already covers exact and whole-word queries, but a query like `lean` won't find `Learn` since it isn't a literal substring. Adds an fzf-style subsequence matcher as the lowest-priority fallback tier in both `MenuModel.js` (root menu) and `AppSearch.js` (Apps submenu).
- Fallback is scoped to the label/app name only (never description or keywords) so it can't reach into longer fields and produce false positives, and it's always ranked below any real substring/whole-word match.
- Documents the new fallback behavior in `docs/menu.md`.

## Test plan
- [x] `./test/shell` passes (`test/shell.d/app-search-test.sh`, `test/shell.d/menu-test.sh` cover the new fuzzy fallback specifically)
- [x] `./test/all` — only pre-existing, environment-specific failures unrelated to this change (missing sibling `omarchy-pkgs` checkout)