### PR TITLE
Fix: Use relative positioning (auto-right) in multi-monitor defaults to prevent scaling cursor traps

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -86,7 +86,7 @@ set_scale() {
   local new_gdk_scale="$(awk -v scale="$new_scale" 'BEGIN { printf "%d", int(scale + 0.5) }')"
   local monitor_lua="$HOME/.config/hypr/monitors.lua"
 
-  hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
+  hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
 
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all

--- a/config/hypr/monitors.lua
+++ b/config/hypr/monitors.lua
@@ -8,7 +8,7 @@ local omarchy_monitor_scale = "auto"
 hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
 
 -- Configure a specific monitor.
--- hl.monitor({ output = "DP-2", mode = "2560x1440@144", position = "0x0", scale = 1 })
+-- hl.monitor({ output = "DP-2", mode = "2560x1440@144", position = "auto-right", scale = 1 })
 
 -- Portrait/rotated secondary monitor (transform: 1 = 90°, 3 = 270°).
 -- hl.monitor({ output = "DP-2", mode = "preferred", position = "auto", scale = 1, transform = 1 })

--- a/default/agents/skills/omarchy/hyprland.md
+++ b/default/agents/skills/omarchy/hyprland.md
@@ -61,7 +61,7 @@ Always tell the user: "Note: SUPER+F was previously bound to fullscreen. I've ad
 Edit `~/.config/hypr/monitors.lua`. Format:
 ```lua
 hl.monitor({ output = "eDP-1", mode = "1920x1080@60", position = "0x0", scale = 1 })
-hl.monitor({ output = "HDMI-A-1", mode = "2560x1440@144", position = "1920x0", scale = 1 })
+hl.monitor({ output = "HDMI-A-1", mode = "2560x1440@144", position = "auto-right", scale = 1 })
 ```
 
 List monitors and supported modes: `hyprctl monitors all`


### PR DESCRIPTION
Updates monitor examples to use scale-safe relative positioning, preventing cursor dead zones in multi-monitor layouts.

### Changes:
- **Documentation**: Uses `auto-right` in the default monitor example and agent guidance to prevent users from hardcoding absolute pixel offsets (which breaks under fractional scaling).
- **Runtime Fix**: Strips `position = "auto"` from the `hyprctl eval` runtime injection in `bin/omarchy-hyprland-monitor-scaling`. This ensures that triggering a scale change preserves the user's active layout instead of collapsing it.

*(Note: The persistence parser commit was reverted as parsing Lua with regex is too brittle for edge cases. Leaving the persistence fix to PR #8300 / #7495).*