### PR TITLE
[Security] Stage diagnostics where only their owner can read them

### DIFF
--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -37,8 +37,10 @@ LOG_FILE="$log_dir/omarchy-debug.log"
 
 # Nothing here runs under `set -e`, so an unusable log_dir -- a stale
 # XDG_RUNTIME_DIR, a full tmpfs, a read-only home -- would leave `--print`
-# exiting 0 having printed nothing at all.
-if ! mkdir -p "$log_dir" || ! install -m 600 /dev/null "$LOG_FILE"; then
+# exiting 0 having printed nothing at all. -T is what makes a directory at
+# LOG_FILE an error; without it `install` treats one as a destination
+# directory, writes $LOG_FILE/null, and reports success.
+if ! mkdir -p "$log_dir" || ! install -T -m 600 /dev/null "$LOG_FILE"; then
   echo "Error: Failed to create $LOG_FILE" >&2
   exit 1
 fi

--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -26,7 +26,16 @@ while (( $# > 0 )); do
   esac
 done
 
-LOG_FILE="/tmp/omarchy-debug.log"
+# /tmp is world-writable, so a fixed name there is a file any other local
+# account can create first and then read -- and this one holds `sudo dmesg`,
+# the journal, and a full hardware inventory. It is also what a symlink planted
+# at the same path would redirect the write into. Keep it under the per-user
+# runtime directory (0700) instead, and fall back to the state directory where
+# Omarchy keeps everything else of its own when there is no session runtime dir.
+log_dir="${XDG_RUNTIME_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/omarchy}"
+mkdir -p "$log_dir"
+LOG_FILE="$log_dir/omarchy-debug.log"
+install -m 600 /dev/null "$LOG_FILE"
 
 if [[ $NO_SUDO = "true" ]]; then
   DMESG_OUTPUT="(skipped - --no-sudo flag used)"

--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -26,11 +26,11 @@ while (( $# > 0 )); do
   esac
 done
 
-# /tmp is world-writable, so a fixed name there is a file any other local
-# account can create first and then read -- and this one holds `sudo dmesg`,
-# the journal, and a full hardware inventory. It is also what a symlink planted
-# at the same path would redirect the write into. Keep it under the per-user
-# runtime directory (0700) instead, and fall back to the state directory where
+# /tmp is world-writable, so a fixed name there is created world-readable by
+# the default umask and left behind until reboot -- and this one holds
+# `sudo dmesg`, the journal, and a full hardware inventory that the invoking
+# user's own uid otherwise cannot read. Keep it under the per-user runtime
+# directory (0700) instead, and fall back to the state directory where
 # Omarchy keeps everything else of its own when there is no session runtime dir.
 log_dir="${XDG_RUNTIME_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/omarchy}"
 LOG_FILE="$log_dir/omarchy-debug.log"

--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -33,9 +33,15 @@ done
 # runtime directory (0700) instead, and fall back to the state directory where
 # Omarchy keeps everything else of its own when there is no session runtime dir.
 log_dir="${XDG_RUNTIME_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/omarchy}"
-mkdir -p "$log_dir"
 LOG_FILE="$log_dir/omarchy-debug.log"
-install -m 600 /dev/null "$LOG_FILE"
+
+# Nothing here runs under `set -e`, so an unusable log_dir -- a stale
+# XDG_RUNTIME_DIR, a full tmpfs, a read-only home -- would leave `--print`
+# exiting 0 having printed nothing at all.
+if ! mkdir -p "$log_dir" || ! install -m 600 /dev/null "$LOG_FILE"; then
+  echo "Error: Failed to create $LOG_FILE" >&2
+  exit 1
+fi
 
 if [[ $NO_SUDO = "true" ]]; then
   DMESG_OUTPUT="(skipped - --no-sudo flag used)"

--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -51,7 +51,7 @@ else
   DMESG_OUTPUT="$(sudo dmesg)"
 fi
 
-cat > "$LOG_FILE" <<EOF
+if ! cat > "$LOG_FILE" <<EOF
 Date: $(date)
 Hostname: $(hostname)
 Omarchy Package: $(pacman -Q omarchy-dev 2>/dev/null || pacman -Q omarchy 2>/dev/null || echo "unknown")
@@ -76,6 +76,10 @@ INSTALLED PACKAGES
 =========================================
 $({ expac -S '%n %v (%r)' $(pacman -Qqe) 2>/dev/null; comm -13 <(pacman -Sql | sort) <(pacman -Qqe | sort) | xargs -r expac -Q '%n %v (AUR)'; } | sort)
 EOF
+then
+  echo "Error: Failed to write $LOG_FILE" >&2
+  exit 1
+fi
 
 if [[ $PRINT_ONLY = "true" ]]; then
   cat "$LOG_FILE"

--- a/bin/omarchy-upload-log
+++ b/bin/omarchy-upload-log
@@ -5,8 +5,17 @@
 # omarchy:hidden=true
 
 LOG_TYPE="${1:-install}"
-TEMP_LOG="/tmp/upload-log.txt"
-SYSTEM_INFO="/tmp/system-info.txt"
+
+# What lands in these two files is the whole journal, the package list and a
+# hardware inventory, and the first of them is then published to a paste. A
+# fixed name in world-writable /tmp lets any other local account create the
+# file first and read what the upload gathered, redirect the write through a
+# symlink, or swap the contents between the last append and the upload. mktemp
+# picks an unpredictable name and creates it 0600.
+staging_dir=$(mktemp -d) || exit 1
+trap 'rm -rf "$staging_dir"' EXIT
+TEMP_LOG="$staging_dir/upload-log.txt"
+SYSTEM_INFO="$staging_dir/system-info.txt"
 
 # Get system information if fastfetch is available
 if omarchy-cmd-present fastfetch; then

--- a/bin/omarchy-upload-log
+++ b/bin/omarchy-upload-log
@@ -9,9 +9,11 @@ LOG_TYPE="${1:-install}"
 # What lands in these two files is the whole journal, the package list and a
 # hardware inventory, and the first of them is then published to a paste. A
 # fixed name in world-writable /tmp lets any other local account create the
-# file first and read what the upload gathered, redirect the write through a
-# symlink, or swap the contents between the last append and the upload. mktemp
-# picks an unpredictable name and creates it 0600.
+# file first and read what the upload gathered before it is even sent, or
+# replace it after the fact and change what gets published under this upload.
+# mktemp gives this run a directory only its owner can enter (0700), which is
+# the actual boundary -- the files created inside it still land at the
+# default umask.
 staging_dir=$(mktemp -d) || exit 1
 trap 'rm -rf "$staging_dir"' EXIT
 TEMP_LOG="$staging_dir/upload-log.txt"

--- a/bin/omarchy-upload-log
+++ b/bin/omarchy-upload-log
@@ -8,12 +8,12 @@ LOG_TYPE="${1:-install}"
 
 # What lands in these two files is the whole journal, the package list and a
 # hardware inventory, and the first of them is then published to a paste. A
-# fixed name in world-writable /tmp lets any other local account create the
-# file first and read what the upload gathered before it is even sent, or
-# replace it after the fact and change what gets published under this upload.
-# mktemp gives this run a directory only its owner can enter (0700), which is
-# the actual boundary -- the files created inside it still land at the
-# default umask.
+# fixed name in /tmp is created world-readable by the default umask, so any
+# other local account can read the payload before it is sent -- and one that
+# creates the name first makes every write here fail closed while `curl` still
+# uploads their file and prints the URL as this user's log. mktemp gives this
+# run a directory only its owner can enter (0700), which is the actual
+# boundary -- the files created inside it still land at the default umask.
 staging_dir=$(mktemp -d) || exit 1
 trap 'rm -rf "$staging_dir"' EXIT
 TEMP_LOG="$staging_dir/upload-log.txt"

--- a/default/agents/skills/diagnose-crash/reporting.md
+++ b/default/agents/skills/diagnose-crash/reporting.md
@@ -87,8 +87,10 @@ gh issue create --repo basecamp/omarchy --title "..." --body "..."
 
 Include what happened, what was expected, steps to reproduce, system details from
 `omarchy version`, and diagnostics from `omarchy debug --no-sudo --print` (which
-also writes `$XDG_RUNTIME_DIR/omarchy-debug.log`; the interactive `omarchy debug`
-can upload it and print a shareable URL worth including).
+also writes `$XDG_RUNTIME_DIR/omarchy-debug.log`, or
+`${XDG_STATE_HOME:-~/.local/state}/omarchy/omarchy-debug.log` when there is no
+session runtime directory; the interactive `omarchy debug` can upload it and
+print a shareable URL worth including).
 
 `gh` cannot attach media. If a screenshot would help, save one and give the user
 the path to drag into the web form.

--- a/default/agents/skills/diagnose-crash/reporting.md
+++ b/default/agents/skills/diagnose-crash/reporting.md
@@ -87,8 +87,8 @@ gh issue create --repo basecamp/omarchy --title "..." --body "..."
 
 Include what happened, what was expected, steps to reproduce, system details from
 `omarchy version`, and diagnostics from `omarchy debug --no-sudo --print` (which
-also writes `/tmp/omarchy-debug.log`; the interactive `omarchy debug` can upload
-it and print a shareable URL worth including).
+also writes `$XDG_RUNTIME_DIR/omarchy-debug.log`; the interactive `omarchy debug`
+can upload it and print a shareable URL worth including).
 
 `gh` cannot attach media. If a screenshot would help, save one and give the user
 the path to drag into the web form.

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -22,7 +22,7 @@ description with steps to reproduce, and diagnostics. Gather them:
 ```bash
 omarchy version
 
-# Generate the diagnostic log (also written to /tmp/omarchy-debug.log)
+# Generate the diagnostic log (also written to $XDG_RUNTIME_DIR/omarchy-debug.log)
 omarchy debug --no-sudo --print
 
 # Interactive variant: `omarchy debug` offers to upload the log to

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -22,7 +22,8 @@ description with steps to reproduce, and diagnostics. Gather them:
 ```bash
 omarchy version
 
-# Generate the diagnostic log (also written to $XDG_RUNTIME_DIR/omarchy-debug.log)
+# Generate the diagnostic log (also written to $XDG_RUNTIME_DIR/omarchy-debug.log,
+# or ${XDG_STATE_HOME:-~/.local/state}/omarchy/omarchy-debug.log without a session)
 omarchy debug --no-sudo --print
 
 # Interactive variant: `omarchy debug` offers to upload the log to

--- a/migrations/1788398495.sh
+++ b/migrations/1788398495.sh
@@ -1,13 +1,13 @@
 echo "Remove leftover world-readable diagnostics files from /tmp"
 
-# omarchy-debug and omarchy-upload-log used to write these under /tmp at the
-# default umask (0644). The sticky bit does not stop another local account from
-# reading them for as long as they remain. The scripts now stage under
-# $XDG_RUNTIME_DIR / mktemp -d; drop any leftovers this user still owns.
+# omarchy-debug and omarchy-upload-log used to write these under /tmp, where the
+# default umask leaves them mode 0644. The sticky bit does not stop another local
+# account from reading them for as long as they remain. The scripts now stage
+# under $XDG_RUNTIME_DIR / mktemp -d; drop any leftovers this user still owns.
 #
-# Only regular files owned by the current uid, and never through a symlink:
-# /tmp is shared, so a redirected name must not make us unlink someone else's
-# target. Overridable for tests.
+# Only regular files owned by the current uid, and never through a symlink: -f
+# and -O both follow one, so a link this user left at the name would otherwise be
+# unlinked in place of a leftover. Overridable for tests.
 
 tmp_root=${OMARCHY_LEGACY_DIAGNOSTICS_TMP:-/tmp}
 

--- a/migrations/1788398495.sh
+++ b/migrations/1788398495.sh
@@ -1,0 +1,26 @@
+echo "Remove leftover world-readable diagnostics files from /tmp"
+
+# omarchy-debug and omarchy-upload-log used to write these under /tmp at the
+# default umask (0644). The sticky bit does not stop another local account from
+# reading them for as long as they remain. The scripts now stage under
+# $XDG_RUNTIME_DIR / mktemp -d; drop any leftovers this user still owns.
+#
+# Only regular files owned by the current uid, and never through a symlink:
+# /tmp is shared, so a redirected name must not make us unlink someone else's
+# target. Overridable for tests.
+
+tmp_root=${OMARCHY_LEGACY_DIAGNOSTICS_TMP:-/tmp}
+
+remove_owned_legacy() {
+  local path=$1
+
+  # -e follows symlinks; -L catches a dangling or live symlink at the name.
+  [[ -L $path ]] && return 0
+  [[ -f $path ]] || return 0
+  [[ -O $path ]] || return 0
+  rm -f -- "$path"
+}
+
+remove_owned_legacy "$tmp_root/omarchy-debug.log"
+remove_owned_legacy "$tmp_root/upload-log.txt"
+remove_owned_legacy "$tmp_root/system-info.txt"

--- a/test/shell.d/diagnostics-staging-test.sh
+++ b/test/shell.d/diagnostics-staging-test.sh
@@ -94,3 +94,16 @@ if [[ -d $staging_dir ]]; then
   fail "the staging directory is cleaned up after the upload" "left behind: $staging_dir"
 fi
 pass "the staging directory is cleaned up after the upload"
+
+# A directory at the log path is the one shape `install` accepts without
+# producing the file, so the guard has to be the thing that catches it --
+# otherwise `--print` exits 0 having printed nothing, which is what a caller
+# reads as a successful empty diagnostic.
+blocked_runtime="$tmp_dir/blocked"
+mkdir -p "$blocked_runtime/omarchy-debug.log"
+blocked_out=$(XDG_RUNTIME_DIR="$blocked_runtime" "$ROOT/bin/omarchy-debug" --no-sudo --print 2>/dev/null) && blocked_status=0 || blocked_status=$?
+
+if (( blocked_status == 0 )) || [[ -n $blocked_out ]]; then
+  fail "omarchy-debug fails loudly when the log file cannot be created" "status: $blocked_status, bytes: ${#blocked_out}"
+fi
+pass "omarchy-debug fails loudly when the log file cannot be created"

--- a/test/shell.d/diagnostics-staging-test.sh
+++ b/test/shell.d/diagnostics-staging-test.sh
@@ -26,10 +26,17 @@ SH
 
 # The upload is the point of the staging file, so capture what curl was handed
 # rather than sending anything.
+# The staging directory is removed when the upload exits, so the mode has to be
+# read here, while the payload still exists.
 cat >"$stub_bin/curl" <<'SH'
 #!/bin/bash
 for arg in "$@"; do
-  [[ $arg == file=@* ]] && printf '%s\n' "${arg#file=@}" >"$OMARCHY_TEST_UPLOAD_PATH"
+  if [[ $arg == file=@* ]]; then
+    payload="${arg#file=@}"
+    printf '%s\n' "$payload" >"$OMARCHY_TEST_UPLOAD_PATH"
+    stat -c '%a' "${payload%/*}" >"$OMARCHY_TEST_UPLOAD_MODE" 2>/dev/null ||
+      stat -f '%Lp' "${payload%/*}" >"$OMARCHY_TEST_UPLOAD_MODE" 2>/dev/null || true
+  fi
 done
 printf 'https://logs.omarchy.org/test\n'
 SH
@@ -39,6 +46,7 @@ export PATH="$stub_bin:$ROOT/bin:$PATH"
 export HOME="$tmp_dir/home"
 export XDG_RUNTIME_DIR="$tmp_dir/run"
 export OMARCHY_TEST_UPLOAD_PATH="$tmp_dir/upload-path"
+export OMARCHY_TEST_UPLOAD_MODE="$tmp_dir/upload-mode"
 
 # omarchy-debug: the log holds sudo dmesg and the journal, so it must not be
 # staged under a name every account on the machine can predict and read.
@@ -68,11 +76,20 @@ pass "omarchy-debug no longer names a world-writable path"
 "$ROOT/bin/omarchy-upload-log" system-info >/dev/null
 
 uploaded=$(<"$OMARCHY_TEST_UPLOAD_PATH")
-[[ $uploaded != /tmp/* ]] ||
-  fail "the uploaded payload is staged outside /tmp" "uploaded: $uploaded"
-pass "the uploaded payload is staged outside /tmp"
-
 staging_dir=${uploaded%/*}
+
+# mktemp still puts its directory under /tmp; the boundary is that the
+# directory is unpredictable and only its owner can enter it, not that the
+# path leaves /tmp behind.
+[[ $uploaded != "/tmp/upload-log.txt" && $staging_dir != "/tmp" ]] ||
+  fail "the uploaded payload is not staged at a shared, predictable name" "uploaded: $uploaded"
+pass "the uploaded payload is not staged at a shared, predictable name"
+
+staging_mode=$(<"$OMARCHY_TEST_UPLOAD_MODE")
+[[ $staging_mode == "700" ]] ||
+  fail "the staging directory is reachable only by its owner" "mode: ${staging_mode:-unreadable}"
+pass "the staging directory is reachable only by its owner"
+
 if [[ -d $staging_dir ]]; then
   fail "the staging directory is cleaned up after the upload" "left behind: $staging_dir"
 fi

--- a/test/shell.d/diagnostics-staging-test.sh
+++ b/test/shell.d/diagnostics-staging-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin" "$tmp_dir/run" "$tmp_dir/home"
+
+for stub in inxi journalctl expac pacman comm sort ping fastfetch uname; do
+  printf '#!/bin/bash\nexit 0\n' >"$stub_bin/$stub"
+done
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$stub_bin/dmesg" <<'SH'
+#!/bin/bash
+printf '%s\n' "secret kernel ring buffer"
+SH
+
+# The upload is the point of the staging file, so capture what curl was handed
+# rather than sending anything.
+cat >"$stub_bin/curl" <<'SH'
+#!/bin/bash
+for arg in "$@"; do
+  [[ $arg == file=@* ]] && printf '%s\n' "${arg#file=@}" >"$OMARCHY_TEST_UPLOAD_PATH"
+done
+printf 'https://logs.omarchy.org/test\n'
+SH
+
+chmod +x "$stub_bin"/*
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+export HOME="$tmp_dir/home"
+export XDG_RUNTIME_DIR="$tmp_dir/run"
+export OMARCHY_TEST_UPLOAD_PATH="$tmp_dir/upload-path"
+
+# omarchy-debug: the log holds sudo dmesg and the journal, so it must not be
+# staged under a name every account on the machine can predict and read.
+"$ROOT/bin/omarchy-debug" --print >/dev/null
+
+[[ -f $XDG_RUNTIME_DIR/omarchy-debug.log ]] ||
+  fail "omarchy-debug writes its log under the per-user runtime directory" "$(ls -a "$XDG_RUNTIME_DIR")"
+pass "omarchy-debug writes its log under the per-user runtime directory"
+
+mode=$(stat -c '%a' "$XDG_RUNTIME_DIR/omarchy-debug.log" 2>/dev/null || stat -f '%Lp' "$XDG_RUNTIME_DIR/omarchy-debug.log")
+[[ $mode == "600" ]] ||
+  fail "the debug log is readable only by its owner" "mode: $mode"
+pass "the debug log is readable only by its owner"
+
+grep -Fq 'secret kernel ring buffer' "$XDG_RUNTIME_DIR/omarchy-debug.log" ||
+  fail "the debug log still collects what it collected before"
+pass "the debug log still collects what it collected before"
+
+if grep -q '/tmp/omarchy-debug.log' "$ROOT/bin/omarchy-debug"; then
+  fail "omarchy-debug no longer names a world-writable path"
+fi
+pass "omarchy-debug no longer names a world-writable path"
+
+# omarchy-upload-log stages the payload it publishes; the same reasoning
+# applies, and there the file is also swappable between the last write and the
+# upload.
+"$ROOT/bin/omarchy-upload-log" system-info >/dev/null
+
+uploaded=$(<"$OMARCHY_TEST_UPLOAD_PATH")
+[[ $uploaded != /tmp/* ]] ||
+  fail "the uploaded payload is staged outside /tmp" "uploaded: $uploaded"
+pass "the uploaded payload is staged outside /tmp"
+
+staging_dir=${uploaded%/*}
+if [[ -d $staging_dir ]]; then
+  fail "the staging directory is cleaned up after the upload" "left behind: $staging_dir"
+fi
+pass "the staging directory is cleaned up after the upload"

--- a/test/shell.d/diagnostics-staging-test.sh
+++ b/test/shell.d/diagnostics-staging-test.sh
@@ -107,3 +107,16 @@ if (( blocked_status == 0 )) || [[ -n $blocked_out ]]; then
   fail "omarchy-debug fails loudly when the log file cannot be created" "status: $blocked_status, bytes: ${#blocked_out}"
 fi
 pass "omarchy-debug fails loudly when the log file cannot be created"
+
+# Simulate ENOSPC after creation: install succeeds, but the body writer fails.
+cat >"$stub_bin/cat" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$stub_bin/cat"
+write_out=$("$ROOT/bin/omarchy-debug" --no-sudo --print 2>"$tmp_dir/write-error") && write_status=0 || write_status=$?
+if (( write_status == 0 )) || [[ -n $write_out ]]; then
+  fail "omarchy-debug rejects a failed diagnostic body write"
+fi
+grep -Fq 'Failed to write' "$tmp_dir/write-error" || fail "body write failure reports an error"
+pass "omarchy-debug rejects a failed diagnostic body write"

--- a/test/shell.d/legacy-diagnostics-tmp-migration-test.sh
+++ b/test/shell.d/legacy-diagnostics-tmp-migration-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration=$(grep -rl 'Remove leftover world-readable diagnostics files from /tmp' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "legacy diagnostics /tmp migration exists"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+run_migration() {
+  OMARCHY_LEGACY_DIAGNOSTICS_TMP="$tmp" bash -euo pipefail "$migration" >/dev/null
+}
+
+# Own leftovers are removed.
+: >"$tmp/omarchy-debug.log"
+: >"$tmp/upload-log.txt"
+: >"$tmp/system-info.txt"
+chmod 644 "$tmp/omarchy-debug.log" "$tmp/upload-log.txt" "$tmp/system-info.txt"
+run_migration
+[[ ! -e $tmp/omarchy-debug.log ]] || fail "removes omarchy-debug.log"
+[[ ! -e $tmp/upload-log.txt ]] || fail "removes upload-log.txt"
+[[ ! -e $tmp/system-info.txt ]] || fail "removes system-info.txt"
+pass "removes owned legacy diagnostics files from the staging dir"
+
+# Idempotent when nothing is left.
+run_migration
+pass "no-ops when the legacy files are already gone"
+
+# Unrelated files in the same directory stay put.
+: >"$tmp/omarchy-debug.log"
+: >"$tmp/keep-me.txt"
+run_migration
+[[ ! -e $tmp/omarchy-debug.log ]] || fail "still removes the legacy name"
+[[ -f $tmp/keep-me.txt ]] || fail "leaves unrelated files alone"
+pass "leaves unrelated files in the same directory alone"
+
+# Symlinks at the legacy names are left alone (do not follow / unlink the target).
+: >"$tmp/real-target.txt"
+ln -s "$tmp/real-target.txt" "$tmp/omarchy-debug.log"
+run_migration
+[[ -L $tmp/omarchy-debug.log ]] || fail "leaves a symlink at the legacy name"
+[[ -f $tmp/real-target.txt ]] || fail "does not unlink a symlink target"
+pass "refuses to remove a symlink at a legacy name"
+
+# A non-owned regular file is left alone when we can create one (skip if not root
+# and the filesystem forbids alien ownership — the common case is a no-op create).
+other="$tmp/upload-log.txt"
+: >"$other"
+if chown nobody "$other" 2>/dev/null; then
+  run_migration
+  [[ -f $other ]] || fail "leaves a file owned by another user"
+  pass "leaves a legacy file owned by another user"
+else
+  rm -f "$other"
+  pass "skips other-owner check when chown is unavailable"
+fi


### PR DESCRIPTION
Fixes #8367.

`omarchy-debug` wrote `sudo dmesg`, the journal and a full hardware inventory to `/tmp/omarchy-debug.log`, and `omarchy-upload-log` assembled what it publishes at `/tmp/upload-log.txt` / `/tmp/system-info.txt`. Under the default umask those land mode 0644 in a world-writable directory, so any other local account can read them for as long as they remain. Separately, if another account creates the upload name first, every redirect in `omarchy-upload-log` fails closed (no `set -e`) while `curl` still uploads *their* file and prints the URL as this user's log.

(`fs.protected_regular=1` / `fs.protected_symlinks=1` and the sticky bit already stop the planted-0666, symlink-redirect, and mid-flight swap variants that an earlier draft of this body claimed.)

- `omarchy-debug` now writes under `$XDG_RUNTIME_DIR` (0700, per-user), falling back to `$XDG_STATE_HOME/omarchy` where there is no session runtime dir, and pre-creates the file at mode 600 (`install -T`) so the fallback is not exposed by a traversable home either.
- `omarchy-upload-log` stages in a `mktemp -d` directory and removes it on exit. Nothing about what gets uploaded changes.
- Migration `1788398495.sh` removes leftover `/tmp/omarchy-debug.log`, `/tmp/upload-log.txt`, and `/tmp/system-info.txt` when they are regular files owned by the current user (symlinks and other-owned files are left alone).

The two agent-skill docs that named `/tmp/omarchy-debug.log` are updated to match.

## Verification

`test/shell.d/diagnostics-staging-test.sh` stubs the collectors and `curl`, then runs both real commands:

```
ok - omarchy-debug writes its log under the per-user runtime directory
ok - the debug log is readable only by its owner
ok - the debug log still collects what it collected before
ok - omarchy-debug no longer names a world-writable path
ok - the uploaded payload is not staged at a shared, predictable name
ok - the staging directory is reachable only by its owner
ok - the staging directory is cleaned up after the upload
ok - omarchy-debug fails loudly when the log file cannot be created
```

`test/shell.d/legacy-diagnostics-tmp-migration-test.sh` covers the migration (owned leftovers removed, idempotent, unrelated files kept, symlinks refused, other-owned skipped).

It asserts on the path `curl` was actually handed, not just on the source, and it fails on the unfixed scripts at the first assertion.

Two related paths I did **not** touch here, to keep this to one change — say the word and I will follow up: `omarchy-update` logs the whole update through `script` to `/tmp/omarchy-update.log`, and `omarchy-install-gaming-battlenet` writes `/tmp/omarchy-battlenet-installer.log`.

### September 12 review follow-up
The diagnostic heredoc write is now checked separately from empty-file creation. A failure to write the body exits nonzero with an error, preventing successful empty/partial `--print` output after an exhausted filesystem. The existing legacy-file migration was verified again.

Current focused checks: 9 diagnostics assertions pass; migration checks pass (other-owner case skipped because chown is unavailable). These ran on macOS with stubbed collectors/upload and a local install compatibility wrapper for GNU `-T`; native Arch validation remains outstanding. Bash syntax and diff checks pass.
