### PR TITLE
Save Apple GMUX backlight brightness across reboot

### DIFF
--- a/default/udev/gmux-backlight.rules
+++ b/default/udev/gmux-backlight.rules
@@ -1,0 +1,5 @@
+# Apple GMUX backlight is a PNP device. systemd's path_id builtin fails for it
+# ("No such file or directory"), so 99-systemd.rules never sets SYSTEMD_WANTS
+# and brightness is not saved or restored across reboot.
+SUBSYSTEM=="backlight", KERNEL=="gmux_backlight", \
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="systemd-backlight@backlight:gmux_backlight.service"

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -40,6 +40,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-gmux-backlight.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-gmux-backlight.sh
+++ b/install/hardware/apple/fix-gmux-backlight.sh
@@ -1,0 +1,32 @@
+# Apple dual-GPU Macs expose the panel backlight as gmux_backlight on the PNP
+# bus. systemd's path_id builtin fails for that device, so 99-systemd.rules
+# never sets SYSTEMD_WANTS and systemd-backlight never starts. After a reboot
+# the firmware default comes back (about 18% on these panels) instead of the
+# brightness the user last set.
+#
+# This rule starts systemd-backlight without needing ID_PATH. The service still
+# saves under /var/lib/systemd/backlight/backlight:gmux_backlight when path_id
+# cannot supply a name.
+udev_rules_dir="${OMARCHY_UDEV_RULES_DIR:-/etc/udev/rules.d}"
+backlight_path="${OMARCHY_BACKLIGHT_PATH:-/sys/class/backlight}"
+dmi_vendor="${OMARCHY_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+rule_src="$OMARCHY_PATH/default/udev/gmux-backlight.rules"
+rule_dest="$udev_rules_dir/99-omarchy-gmux-backlight.rules"
+
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+if [[ -e $backlight_path/gmux_backlight || $sys_vendor == Apple* ]]; then
+  echo "Detected Apple GMUX backlight; enabling systemd-backlight save/restore"
+
+  sudo mkdir -p "$udev_rules_dir"
+  if [[ ! -f $rule_dest ]]; then
+    sudo cp -f "$rule_src" "$rule_dest"
+  fi
+
+  # Best-effort on a live session so this shutdown already saves. The ISO chroot
+  # has no running udev/systemd for the target, and a missing binary must not
+  # abort hardware setup.
+  sudo udevadm control --reload-rules 2>/dev/null || true
+  sudo udevadm trigger --action=add --subsystem-match=backlight --sysname-match=gmux_backlight 2>/dev/null || true
+  sudo systemctl start systemd-backlight@backlight:gmux_backlight.service 2>/dev/null || true
+fi

--- a/migrations/1787689809.sh
+++ b/migrations/1787689809.sh
@@ -1,0 +1,7 @@
+echo "Save and restore Apple GMUX backlight brightness across reboot"
+
+# Dual-GPU Macs expose the panel as gmux_backlight on the PNP bus. systemd's
+# path_id builtin fails there, so 99-systemd.rules never starts
+# systemd-backlight and brightness resets to the firmware default after reboot.
+# See install/hardware/apple/fix-gmux-backlight.sh.
+source "$OMARCHY_PATH/install/hardware/apple/fix-gmux-backlight.sh"

--- a/test/shell.d/gmux-backlight-test.sh
+++ b/test/shell.d/gmux-backlight-test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-gmux-backlight.sh"
+rule="$ROOT/default/udev/gmux-backlight.rules"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1787689809.sh"
+
+grep -q 'apple/fix-gmux-backlight.sh' "$all" ||
+  fail "the gmux backlight quirk runs during hardware setup"
+pass "the gmux backlight quirk runs during hardware setup"
+
+grep -Fq 'ENV{SYSTEMD_WANTS}+="systemd-backlight@backlight:gmux_backlight.service"' "$rule" ||
+  fail "the udev rule starts systemd-backlight for gmux_backlight"
+! grep -Fq 'IMPORT{builtin}="path_id"' "$rule" ||
+  fail "the udev rule must not depend on path_id"
+pass "the udev rule starts systemd-backlight without path_id"
+
+grep -q 'fix-gmux-backlight.sh' "$migration" ||
+  fail "the migration applies the gmux backlight quirk" "$migration"
+pass "the migration applies the gmux backlight quirk"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+rules_dir="$test_tmp/etc/udev/rules.d"
+dest="$rules_dir/99-omarchy-gmux-backlight.rules"
+mkdir -p "$stub_bin" "$test_tmp/dmi" "$test_tmp/backlight"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/udevadm" <<'SH'
+#!/bin/bash
+
+printf 'udevadm' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local vendor="$1" gmux="${2:-0}" keep="${3:-0}"
+  if (( keep == 0 )); then
+    rm -rf "$test_tmp/etc" "$test_tmp/backlight"
+    mkdir -p "$test_tmp/etc" "$test_tmp/backlight"
+  fi
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  if (( gmux == 1 )); then
+    mkdir -p "$test_tmp/backlight/gmux_backlight"
+  fi
+  : >"$calls"
+
+  OMARCHY_PATH="$ROOT" \
+    OMARCHY_UDEV_RULES_DIR="$rules_dir" \
+    OMARCHY_BACKLIGHT_PATH="$test_tmp/backlight" \
+    OMARCHY_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$leaf" </dev/null
+}
+
+run_leaf "Apple Inc." 1 >/dev/null
+[[ -f $dest ]] || fail "a Mac with gmux gets the udev rule" "$(ls -R "$test_tmp/etc" 2>&1)"
+diff -q "$rule" "$dest" >/dev/null ||
+  fail "the installed udev rule matches the packaged source"
+grep -Fq $'udevadm\tcontrol\t--reload-rules' "$calls" ||
+  fail "a live session reloads udev" "$(cat "$calls")"
+grep -Fq $'systemctl\tstart\tsystemd-backlight@backlight:gmux_backlight.service' "$calls" ||
+  fail "a live session starts systemd-backlight" "$(cat "$calls")"
+pass "a Mac with gmux gets the udev rule"
+
+# ISO-time apple_gmux may not have registered yet; still drop the rule so first
+# boot can start systemd-backlight when the device appears.
+run_leaf "Apple Inc." 0 >/dev/null
+[[ -f $dest ]] || fail "an Apple machine without gmux sysfs still gets the rule"
+pass "an Apple machine without gmux sysfs still gets the rule"
+
+run_leaf "Apple Computer, Inc." 0 >/dev/null
+[[ -f $dest ]] || fail "the older Apple vendor string is recognized"
+pass "the older Apple vendor string is recognized"
+
+run_leaf "LENOVO" 0 >/dev/null
+[[ ! -f $dest ]] || fail "non-Apple hardware without gmux is left alone"
+[[ ! -s $calls ]] || fail "non-Apple hardware escalates nothing" "$(cat "$calls")"
+pass "non-Apple hardware without gmux is left alone"
+
+run_leaf "LENOVO" 1 >/dev/null
+[[ -f $dest ]] || fail "a gmux device on unexpected vendor still gets the rule"
+pass "a gmux device on unexpected vendor still gets the rule"
+
+run_leaf "Apple Inc." 1 >/dev/null
+printf 'keep me\n' >"$dest"
+run_leaf "Apple Inc." 1 1 >/dev/null
+[[ $(<"$dest") == "keep me" ]] || fail "an existing udev rule is not overwritten"
+grep -Fq $'systemctl\tstart\tsystemd-backlight@backlight:gmux_backlight.service' "$calls" ||
+  fail "a second run still starts systemd-backlight" "$(cat "$calls")"
+pass "an existing udev rule is left in place"
+
+run_migration() {
+  local vendor="$1" gmux="${2:-0}"
+  rm -rf "$test_tmp/etc" "$test_tmp/backlight"
+  mkdir -p "$test_tmp/etc" "$test_tmp/backlight"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  if (( gmux == 1 )); then
+    mkdir -p "$test_tmp/backlight/gmux_backlight"
+  fi
+  : >"$calls"
+
+  OMARCHY_PATH="$ROOT" \
+    OMARCHY_UDEV_RULES_DIR="$rules_dir" \
+    OMARCHY_BACKLIGHT_PATH="$test_tmp/backlight" \
+    OMARCHY_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration "Apple Inc." 1
+[[ -f $dest ]] || fail "the migration installs the udev rule on a Mac with gmux"
+pass "the migration installs the udev rule on a Mac with gmux"
+
+run_migration "LENOVO" 0
+[[ ! -f $dest ]] || fail "the migration skips non-Apple hardware without gmux"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on unaffected hardware" "$(cat "$calls")"
+pass "the migration skips hardware without gmux"


### PR DESCRIPTION
## Summary

Dual-GPU Macs expose the panel backlight as `gmux_backlight` on the PNP bus (`/devices/pnp0/00:00/backlight/gmux_backlight`). systemd's `path_id` builtin fails for that device (`No such file or directory`), so the stock `99-systemd.rules` line never sets `SYSTEMD_WANTS` and `systemd-backlight@backlight:gmux_backlight.service` never starts.

After a reboot the firmware default comes back instead of the brightness the user last set. On a MacBookPro11,3 that default is 184/1023 (**18%**). Keyboard backlight *is* restored, because that LED has a working `ID_PATH`.

This ships a udev rule that tags `gmux_backlight` with `systemd` and `SYSTEMD_WANTS` without requiring `path_id`. `systemd-backlight` still saves under `/var/lib/systemd/backlight/backlight:gmux_backlight` when `ID_PATH` is missing.

## Changes

- `default/udev/gmux-backlight.rules` — the rule (next to the Framework 16 QMK rule)
- `install/hardware/apple/fix-gmux-backlight.sh` — copies it to `/etc/udev/rules.d/` on Apple machines (or any machine that already has `gmux_backlight`), reloads udev, and starts the unit so the *current* session will save on shutdown
- Wired into `install/hardware/all.sh`
- `migrations/1787689809.sh` — same leaf for existing installs
- `test/shell.d/gmux-backlight-test.sh`

## Tested

- MacBookPro11,3, Omarchy 4.0.1, `gmux_backlight` 1023 max
- Before: `udevadm info` showed `TAGS=:seat:` only; `systemd-backlight@backlight:gmux_backlight.service` inactive; no save file under `/var/lib/systemd/backlight/`
- After installing the equivalent rule locally: `SYSTEMD_WANTS` is set, the unit is active, shutdown will save
- `bash test/shell.d/gmux-backlight-test.sh` passes

## Notes

The rule is a no-op on machines without `KERNEL=="gmux_backlight"`. It is still dropped on any `Apple*` DMI vendor so ISO finalization does not depend on `apple_gmux` already having registered the sysfs node.

Related but distinct: #8205 reads `actual_brightness` for gmux OSD steps. This PR is about save/restore across reboot.
