### PR TITLE
Browse and install any mise tool from the menu

### DIFF
--- a/bin/omarchy-mise-browse
+++ b/bin/omarchy-mise-browse
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# omarchy:summary=Show a fuzzy-finder TUI for picking new mise tools to install.
+
+fzf_args=(
+  --multi
+  --preview 'mise ls-remote {1} 2>/dev/null | tail -n 15'
+  --preview-label='alt-p: toggle available versions, alt-j/k: scroll, tab: multi-select'
+  --preview-label-pos='bottom'
+  --preview-window 'down:65%:wrap'
+  --bind 'alt-p:toggle-preview'
+  --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
+  --bind 'alt-k:preview-up,alt-j:preview-down'
+  --color 'pointer:green,marker:green'
+)
+
+tool_names=$(mise registry | awk '{print $1}' | fzf "${fzf_args[@]}")
+
+if [[ -n $tool_names ]]; then
+  # Install eagerly with visible progress, then layer the standard lazy wrapper
+  # from omarchy-mise-install on top so future runs keep self-upgrading.
+  export MISE_MINIMUM_RELEASE_AGE=0
+  failed=()
+  while IFS= read -r tool; do
+    [[ -n $tool ]] || continue
+    echo "==> Installing mise tool: $tool"
+    if mise use -g "$tool" && omarchy-mise-install "$tool"; then
+      echo "==> Installed $tool ✓"
+    else
+      echo "==> Failed to install $tool ✗" >&2
+      failed+=("$tool")
+    fi
+  done <<<"$tool_names"
+
+  if ((${#failed[@]} > 0)); then
+    echo
+    echo "These tools failed to install: ${failed[*]}" >&2
+    exit 1
+  fi
+
+  omarchy-show-done
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -192,6 +192,7 @@
   "install.ai": {"icon":"󱚤","label":"AI"},
   "install.service": {"icon":"","label":"Service"},
   "install.development": {"icon":"󰵮","label":"Development"},
+  "install.development.mise": {"icon":"󰒔","label":"All Tools","description":"Search and install any tool from the mise registry","action":"xdg-terminal-exec --app-id=org.omarchy.terminal omarchy-mise-browse"},
   "install.editor": {"icon":"","label":"Editor"},
   "install.style": {"icon":"","label":"Style"},
   "install.style.theme": {"icon":"󰸌","label":"Theme","action":"omarchy-launch-floating-terminal-with-presentation omarchy-theme-install"},


### PR DESCRIPTION
The menu can browse and install pacman and AUR packages, but mise — which backs every development environment here — only offered the fixed set of dev envs. There was no way to discover what else it carries.

This adds Install > Development > All Tools: an fzf picker over the full mise registry, shaped after Install > AUR. The preview shows the versions mise can install for the highlighted tool. Selecting one installs it right away with mise's own progress visible, then layers the standard omarchy-mise-install wrapper on top so the tool keeps self-upgrading on later runs like every other mise-managed command.

## Verification

- `bash test/shell.d/menu-test.sh`, `bash test/shell.d/bin-style-test.sh`, `./test/cli`
- Installed jq, bun, and others end-to-end on a live system through the new menu row, including the wrapper's first-run upgrade path