### PR TITLE
Use the real game title for RetroArch launchers installed from arcade ROMs

### DIFF
--- a/bin/omarchy-games-retro-install
+++ b/bin/omarchy-games-retro-install
@@ -46,7 +46,39 @@ if [[ ! -f $core_path ]]; then
   exit 1
 fi
 
-game_name=$(printf '%s' "${game_path##*/}" | sed 's/\.[^.]*$//; s/[[:space:]]*([^)]*)//g; s/[[:space:]]\+/ /g; s/^ //; s/ $//' | perl -Mopen=locale -pe 's/(^|[[:space:]])([^[:space:]])/$1\U$2/g')
+rom_filename="${game_path##*/}"
+
+# Arcade ROM filenames are short codes (e.g. ffight.zip) rather than game
+# titles. Look up the canonical title in RetroArch's own arcade databases,
+# preferring FBNeo's (the most complete, actively maintained arcade set)
+# over the MAME variants.
+db_name=""
+arcade_rdbs=(
+  "FBNeo - Arcade Games"
+  "MAME"
+  "MAME 2003-Plus"
+  "MAME 2003"
+  "MAME 2010"
+  "MAME 2015"
+  "MAME 2016"
+  "MAME 2000"
+  "HBMAME"
+)
+for collection in "${arcade_rdbs[@]}"; do
+  rdb="/usr/share/libretro/database/rdb/$collection.rdb"
+  [[ -f $rdb ]] || continue
+  match=$(omarchy-games-retro-rdb-name "$rdb" "$rom_filename" 2>/dev/null) || continue
+  [[ -n $match ]] || continue
+  db_name="$match"
+  break
+done
+
+if [[ -n $db_name ]]; then
+  game_name=$(printf '%s' "$db_name" | sed 's/[[:space:]]*([^)]*)//g; s/[[:space:]]\+/ /g; s/^ //; s/ $//')
+else
+  game_name=$(printf '%s' "$rom_filename" | sed 's/\.[^.]*$//; s/[[:space:]]*([^)]*)//g; s/[[:space:]]\+/ /g; s/^ //; s/ $//' | perl -Mopen=locale -pe 's/(^|[[:space:]])([^[:space:]])/$1\U$2/g')
+fi
+
 desktop_name="$game_name"
 desktop_id=$(printf '%s' "$desktop_name" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-' | sed 's/^-//; s/-$//')
 desktop_dir="$HOME/.local/share/applications"

--- a/bin/omarchy-games-retro-rdb-name
+++ b/bin/omarchy-games-retro-rdb-name
@@ -1,0 +1,143 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Look up a ROM's canonical name in a libretro RDB database
+# omarchy:args=[rdb-path rom-filename]
+# omarchy:examples=omarchy-games-retro-rdb-name "/usr/share/libretro/database/rdb/FBNeo - Arcade Games.rdb" ffight.zip
+# omarchy:hidden=true
+
+# RetroArch's RDB files are a thin custom format (an 8-byte "RARCHDB\0"
+# magic, an 8-byte big-endian offset to a trailing index, then records
+# packed back-to-back) around plain msgpack maps. python-msgpack isn't part
+# of the default install, so this decodes just enough of the msgpack subset
+# RDB actually uses rather than adding a dependency for one lookup.
+
+import sys
+
+
+def read_obj(buf, pos):
+    b = buf[pos]
+    if b <= 0x7F:
+        return b, pos + 1
+    if b >= 0xE0:
+        return b - 256, pos + 1
+    if 0x80 <= b <= 0x8F:
+        return read_map(buf, pos + 1, b & 0x0F)
+    if 0x90 <= b <= 0x9F:
+        return read_array(buf, pos + 1, b & 0x0F)
+    if 0xA0 <= b <= 0xBF:
+        n = b & 0x1F
+        return buf[pos + 1 : pos + 1 + n].decode("utf-8", "replace"), pos + 1 + n
+    if b == 0xC0:
+        return None, pos + 1
+    if b == 0xC2:
+        return False, pos + 1
+    if b == 0xC3:
+        return True, pos + 1
+    if b == 0xC4:
+        n = buf[pos + 1]
+        return buf[pos + 2 : pos + 2 + n], pos + 2 + n
+    if b == 0xC5:
+        n = int.from_bytes(buf[pos + 1 : pos + 3], "big")
+        return buf[pos + 3 : pos + 3 + n], pos + 3 + n
+    if b == 0xC6:
+        n = int.from_bytes(buf[pos + 1 : pos + 5], "big")
+        return buf[pos + 5 : pos + 5 + n], pos + 5 + n
+    if b == 0xCA:
+        import struct
+
+        return struct.unpack(">f", buf[pos + 1 : pos + 5])[0], pos + 5
+    if b == 0xCB:
+        import struct
+
+        return struct.unpack(">d", buf[pos + 1 : pos + 9])[0], pos + 9
+    if b == 0xCC:
+        return buf[pos + 1], pos + 2
+    if b == 0xCD:
+        return int.from_bytes(buf[pos + 1 : pos + 3], "big"), pos + 3
+    if b == 0xCE:
+        return int.from_bytes(buf[pos + 1 : pos + 5], "big"), pos + 5
+    if b == 0xCF:
+        return int.from_bytes(buf[pos + 1 : pos + 9], "big"), pos + 9
+    if b == 0xD0:
+        return int.from_bytes(buf[pos + 1 : pos + 2], "big", signed=True), pos + 2
+    if b == 0xD1:
+        return int.from_bytes(buf[pos + 1 : pos + 3], "big", signed=True), pos + 3
+    if b == 0xD2:
+        return int.from_bytes(buf[pos + 1 : pos + 5], "big", signed=True), pos + 5
+    if b == 0xD3:
+        return int.from_bytes(buf[pos + 1 : pos + 9], "big", signed=True), pos + 9
+    if b == 0xD9:
+        n = buf[pos + 1]
+        return buf[pos + 2 : pos + 2 + n].decode("utf-8", "replace"), pos + 2 + n
+    if b == 0xDA:
+        n = int.from_bytes(buf[pos + 1 : pos + 3], "big")
+        return buf[pos + 3 : pos + 3 + n].decode("utf-8", "replace"), pos + 3 + n
+    if b == 0xDB:
+        n = int.from_bytes(buf[pos + 1 : pos + 5], "big")
+        return buf[pos + 5 : pos + 5 + n].decode("utf-8", "replace"), pos + 5 + n
+    if b == 0xDC:
+        n = int.from_bytes(buf[pos + 1 : pos + 3], "big")
+        return read_array(buf, pos + 3, n)
+    if b == 0xDD:
+        n = int.from_bytes(buf[pos + 1 : pos + 5], "big")
+        return read_array(buf, pos + 5, n)
+    if b == 0xDE:
+        n = int.from_bytes(buf[pos + 1 : pos + 3], "big")
+        return read_map(buf, pos + 3, n)
+    if b == 0xDF:
+        n = int.from_bytes(buf[pos + 1 : pos + 5], "big")
+        return read_map(buf, pos + 5, n)
+    raise ValueError(f"unknown msgpack type byte {b:#x} at offset {pos}")
+
+
+def read_map(buf, pos, n):
+    d = {}
+    for _ in range(n):
+        k, pos = read_obj(buf, pos)
+        v, pos = read_obj(buf, pos)
+        d[k] = v
+    return d, pos
+
+
+def read_array(buf, pos, n):
+    arr = []
+    for _ in range(n):
+        v, pos = read_obj(buf, pos)
+        arr.append(v)
+    return arr, pos
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: omarchy-games-retro-rdb-name <rdb-file> <rom-filename>", file=sys.stderr)
+        return 2
+
+    rdb_path, target = sys.argv[1], sys.argv[2]
+
+    try:
+        with open(rdb_path, "rb") as f:
+            buf = f.read()
+    except OSError:
+        return 1
+
+    if buf[:7] != b"RARCHDB":
+        return 1
+
+    meta_offset = int.from_bytes(buf[8:16], "big")
+    pos = 16
+    while pos < meta_offset:
+        try:
+            rec, pos = read_obj(buf, pos)
+        except Exception:
+            return 1
+        if isinstance(rec, dict) and rec.get("rom_name") == target:
+            name = rec.get("name")
+            if name:
+                print(name)
+                return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Arcade ROM filenames are short internal codes (`ffight.zip`, `mslug.zip`) rather than game titles, so `omarchy-games-retro-install` produced launchers named "Ffight" instead of "Final Fight".
- `omarchy-games-retro-install` now looks the ROM up in RetroArch's own arcade databases (FBNeo first, then the MAME variants) and uses the matched title when found, falling back to the existing filename-derived title otherwise.
- Adds `omarchy-games-retro-rdb-name` (hidden helper), a small pure-Python reader for the subset of RetroArch's RARCHDB/msgpack format needed to look up a ROM's `name` by `rom_name`. No new dependency: `python-msgpack` isn't part of the default install.

## Test plan
- [x] `./test/cli` passes
- [x] `./test/shell` — same 5 pre-existing failures as a clean `quattro` checkout (`config-test.sh`, `manifest-entrypoints-test.sh`, `snapper-test.sh`, `theme-install-guards-test.sh`, `unowned-system-paths-test.sh`), confirmed unrelated to this change
- [x] Manually verified end to end on a live Omarchy install: `omarchy games retro install mame ~/Games/roms/ffight.zip` now creates a launcher named "Final Fight" (was "Ffight"); non-arcade content (e.g. SNES) is unaffected and still uses the filename-derived title

🤖 Generated with [Claude Code](https://claude.com/claude-code)