### PR TITLE
Match Apple Touch (MTP) trackpads in omarchy-hw-touchpad

### DIFF
--- a/bin/omarchy-hw-touchpad
+++ b/bin/omarchy-hw-touchpad
@@ -2,5 +2,5 @@
 
 # omarchy:summary=Print the detected Hyprland touchpad or trackpad device name
 
-device=$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad"; "i"))] | first // empty')
+device=$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad|multi-touch"; "i"))] | first // empty')
 [[ -n $device ]] && echo "$device"


### PR DESCRIPTION
Fixes #8376.

`bin/omarchy-hw-touchpad` matches the device by name, and Apple trackpads on the
Apple Touch (MTP) protocol are exposed by Hyprland as **`apple-mtp-multi-touch`** —
neither `touchpad` nor `trackpad`. Detection returns empty,
`omarchy-toggle-input-device` takes its "No touchpad device found" branch, and
because `default/hypr/bindings/media.lua` runs the command without a terminal
that error goes nowhere. `XF86TouchpadToggle` just appears dead.

It is model-dependent rather than vendor-dependent, which is what makes it easy
to miss — two MacBook Airs of the same family disagree:

| host | Hyprland device name | before | after |
|---|---|---|---|
| MacBook Air M1 (2020) | `apple-spi-trackpad` | matched | matched |
| MacBook Air M2 (2022) | `apple-mtp-multi-touch` | **empty** | matched |

## Verification

Both real device names, plus devices that must *not* match:

```
apple-spi-trackpad         -> apple-spi-trackpad
apple-mtp-multi-touch      -> apple-mtp-multi-touch
synaptics-touchpad         -> synaptics-touchpad
logitech-mx-master         -> (no match)
tpps/2-elan-trackpoint     -> (no match)
```

`multi-touch` is specific enough not to catch anything else in `.mice[]`, and
`bin/omarchy-hw-touchscreen` is unaffected — it reads `.touch[]` / `.tablets[]`
rather than matching by name.

`./test/cli` passes. `./test/shell` is 202/206 — the same four files fail identically on
unpatched `quattro` on this machine and are environmental, not related to this change:
`config-test`, `snapper-test` and `unowned-system-paths-test` each want an `omarchy-pkgs`
checkout, and `locale-env-test` wants a UTF-8 locale in the bash env.
