### PR TITLE
Keep the keyboard backlight level when off runs twice

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -26,7 +26,12 @@ if [[ -z $device ]]; then
 fi
 
 if [[ $direction == "off" ]]; then
-  brightnessctl -sd "$device" set 0 >/dev/null
+  # -s saves the current level into a single slot before zeroing it. Blanking
+  # again while already dark would save 0 over the level restore needs, and the
+  # lock screen can blank more than once per lock.
+  if (( $(brightnessctl -d "$device" get) > 0 )); then
+    brightnessctl -sd "$device" set 0 >/dev/null
+  fi
   exit 0
 elif [[ $direction == "restore" ]]; then
   brightnessctl -rd "$device" >/dev/null


### PR DESCRIPTION
Fixes #7650.

`brightnessctl -s` saves the current level into a **single slot**
(`$XDG_RUNTIME_DIR/brightnessctl/leds/<device>`) before zeroing it. Calling
`off` a second time while the backlight is already dark saves `0` over the real
level, and the `restore` that `omarchy-system-wake` runs on unlock then
faithfully restores darkness.

A second `off` is routine rather than exotic: `runBlank()` in
`shell/plugins/lock/Service.qml` is reached at lock time and from
`idleBlankTimer`, and `runWake()` re-arms that timer on every wake while still
locked — so any wake-then-idle cycle on the lock screen produces one.

This guards the save. An already-dark backlight has nothing worth saving, so it
is left alone; `restore` and every other verb are untouched.

## Verification

On a MacBook Air (M1, 2020) with `kbd_backlight`, level 75, running the script
from this branch:

```
off      -> level=0   saved=75
off x2   -> level=0   saved=75
off x3   -> level=0   saved=75
restore  -> level=75
```

Same sequence on `quattro` without the patch, for contrast:

```
off, off, restore -> level=0
```

`./test/cli` passes. `./test/shell` is 202/206 — the same four files fail identically on
unpatched `quattro` on this machine and are environmental, not related to this change:
`config-test`, `snapper-test` and `unowned-system-paths-test` each want an `omarchy-pkgs`
checkout, and `locale-env-test` wants a UTF-8 locale in the bash env.
