### PR TITLE
Fix Dropbox panel pause/resume snapping back to the wrong state

### DIFF
--- a/shell/plugins/panels/dropbox/Panel.qml
+++ b/shell/plugins/panels/dropbox/Panel.qml
@@ -147,6 +147,7 @@ Panel {
     id: dropbox
     settings: root.settings
     omarchyPath: root.omarchyPath
+    detailsWanted: root.opened
   }
 
   Connections {

--- a/shell/plugins/panels/dropbox/Service.qml
+++ b/shell/plugins/panels/dropbox/Service.qml
@@ -18,8 +18,16 @@ Item {
   // waiting for dropboxd to actually settle. _desired is -1 while we just
   // follow the real state, or 0/1 while a pause/resume is still catching up.
   property int _desired: -1
+  // Bumped on every pause/resume. A status result whose process started
+  // before the bump captured pre-control daemon state, so it is thrown away
+  // rather than allowed to overwrite `running` after the switch flipped.
+  property int _generation: 0
   readonly property bool active: _desired === -1 ? running : (_desired === 1)
   property bool refreshing: false
+  // Set by the panel while it is open. Only then does the periodic tick run
+  // the full scan (usage + recent files); a closed panel needs daemon state
+  // for the bar icon and nothing else.
+  property bool detailsWanted: false
   property string statusText: "Checking…"
   property string accountPath: ""
   property string plan: ""
@@ -32,7 +40,9 @@ Item {
   property string lastError: ""
 
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 60, 10, 3600)
-  readonly property bool busy: statusProcess.running || loginProcess.running || controlProcess.running
+  // Background status polls are not "busy": they must not swallow clicks on
+  // the pause/resume switch (a full poll walks the whole Dropbox folder).
+  readonly property bool busy: loginProcess.running || controlProcess.running
   readonly property string helperPath: (omarchyPath || "") + "/shell/plugins/panels/dropbox/status.py"
 
   property string _statusOutput: ""
@@ -61,8 +71,18 @@ Item {
     _statusOutput = ""
     _statusError = ""
     refreshing = true
+    statusProcess.generation = _generation
     statusProcess.command = ["python3", helperPath, "25"]
     statusProcess.running = true
+  }
+
+  // Daemon state only, no folder walk: ~100ms instead of seconds, and it runs
+  // on its own process so it never queues behind a full refresh.
+  function quickRefresh() {
+    if (quickStatusProcess.running || helperPath === "/shell/plugins/panels/dropbox/status.py") return
+    quickStatusProcess.generation = _generation
+    quickStatusProcess.command = ["python3", helperPath, "--quick"]
+    quickStatusProcess.running = true
   }
 
   function applyStatus(raw) {
@@ -72,18 +92,31 @@ Item {
       return
     }
     installed = parsed.installed === true
-    running = parsed.running === true
     authenticated = parsed.authenticated === true
-    // Reality caught up to the pending pause/resume — stop overriding.
-    if (_desired !== -1 && running === (_desired === 1)) _desired = -1
+    var observed = parsed.running === true
+    if (_desired === -1) {
+      running = observed
+    } else if (observed === (_desired === 1)) {
+      // Reality caught up to the pending pause/resume — stop overriding, and
+      // load the real file list/usage now that the daemon has settled.
+      running = observed
+      _desired = -1
+      settleTimer.running = false
+      if (parsed.quick === true) delayedRefresh.restart()
+    }
+    // Otherwise the poll predates the stop/start landing (dropboxd takes ~5s
+    // to exit after `dropbox-cli stop`, and `status` reports "Up to date"
+    // until then), so keep the optimistic state and wait for the next poll.
     statusText = String(parsed.statusText || (installed ? "Stopped" : "Not installed"))
     accountPath = String(parsed.accountPath || "")
     plan = String(parsed.plan || "")
-    usedBytes = Number(parsed.usedBytes || 0)
-    quotaBytes = Number(parsed.quotaBytes || 0)
-    usagePercent = Number(parsed.usagePercent || 0)
-    quotaKnown = parsed.quotaKnown === true
-    files = parsed.files || []
+    if (parsed.quick !== true) {
+      usedBytes = Number(parsed.usedBytes || 0)
+      quotaBytes = Number(parsed.quotaBytes || 0)
+      usagePercent = Number(parsed.usagePercent || 0)
+      quotaKnown = parsed.quotaKnown === true
+      files = parsed.files || []
+    }
     lastError = ""
   }
 
@@ -120,6 +153,7 @@ Item {
     // the pause/resume; only surface a message if the command fails.
     if (!installed || controlProcess.running) return
     _desired = desired
+    _generation += 1
     _controlOutput = ""
     _controlError = ""
     controlProcess.command = command
@@ -158,12 +192,23 @@ Item {
   }
 
   Timer {
+    // One full scan at startup so the panel has data the first time it opens,
+    // then the cheap daemon poll unless the panel is open and looking at the
+    // file list. Opening the panel and pressing R run the full scan directly.
     id: refreshTimer
+    property bool primed: false
     interval: root.refreshIntervalSec * 1000
     repeat: true
     running: true
     triggeredOnStart: true
-    onTriggered: root.refresh()
+    onTriggered: {
+      if (root.detailsWanted || !primed) {
+        primed = true
+        root.refresh()
+      } else {
+        root.quickRefresh()
+      }
+    }
   }
 
   Timer {
@@ -179,7 +224,7 @@ Item {
     onTriggered: {
       ticks += 1
       if (root.running || ticks >= 15) startupRamp.running = false
-      else root.refresh()
+      else root.quickRefresh()
     }
   }
 
@@ -198,33 +243,50 @@ Item {
   }
 
   Timer {
-    // dropboxd takes a few (variable) seconds to settle after stop/start, so
-    // re-poll a handful of times to reflect the new state without waiting for
-    // the next periodic refresh.
+    // dropboxd takes a few (variable) seconds to settle after stop/start
+    // (~5s to exit, up to ~15s to come back up), so quick-poll until the
+    // daemon state matches what was asked for. applyStatus stops this timer
+    // when it does; give up and fall back to reality after ~20s.
     id: settleTimer
     property int ticks: 0
-    interval: 1500
+    interval: 1000
     repeat: true
     running: false
     onTriggered: {
       settleTimer.ticks += 1
-      root.refresh()
-      if (settleTimer.ticks >= 4) {
+      if (settleTimer.ticks >= 20) {
         settleTimer.ticks = 0
         settleTimer.running = false
         root._desired = -1
+        root.refresh()
+        return
       }
+      root.quickRefresh()
+    }
+  }
+
+  Process {
+    id: quickStatusProcess
+    property int generation: 0
+    running: false
+    command: []
+    stdout: StdioCollector { id: quickStdout; waitForEnd: true }
+    onExited: function(exitCode) {
+      if (generation !== root._generation) return
+      if (exitCode === 0) root.applyStatus(String(quickStdout.text || ""))
     }
   }
 
   Process {
     id: statusProcess
+    property int generation: 0
     running: false
     command: []
     stdout: StdioCollector { id: statusStdout; waitForEnd: true; onStreamFinished: root._statusOutput = text }
     stderr: StdioCollector { id: statusStderr; waitForEnd: true; onStreamFinished: root._statusError = text }
     onExited: function(exitCode) {
       root.refreshing = false
+      if (generation !== root._generation) return
       var stdout = String(statusStdout.text || root._statusOutput || "")
       var stderr = String(statusStderr.text || root._statusError || "")
       if (exitCode === 0) root.applyStatus(stdout)
@@ -262,16 +324,20 @@ Item {
       var stdout = String(controlStdout.text || root._controlOutput || "")
       var stderr = String(controlStderr.text || root._controlError || "")
       if (exitCode !== 0) {
+        // Nothing to settle: the daemon state did not change. A plain delayed
+        // refresh re-syncs with reality without a 20s quick-poll loop, and
+        // without an immediate poll wiping the error before anyone reads it.
         root._desired = -1
         root.lastError = root.elideStatus(stderr || stdout || "Dropbox command failed")
         root.actionStatus = root.lastError
-      } else {
-        root.lastError = ""
-        root.actionStatus = ""
+        delayedRefresh.restart()
+        return
       }
+      root.lastError = ""
+      root.actionStatus = ""
       settleTimer.ticks = 0
       settleTimer.restart()
-      delayedRefresh.restart()
+      root.quickRefresh()
     }
   }
 }

--- a/shell/plugins/panels/dropbox/status.py
+++ b/shell/plugins/panels/dropbox/status.py
@@ -44,47 +44,61 @@ def command_output(command):
 
 
 def scan_dropbox(path, limit):
+  # One scandir per directory and one lstat per file. The type checks come
+  # from the directory entry itself, so a large folder costs a fraction of
+  # what os.walk plus per-file islink/stat/relpath did (~1s vs ~5s for
+  # 470k files).
+  root = str(path).rstrip("/") or "/"
+  prefix_len = len(root) + 1
   total = 0
   counter = 0
   recent = []
-  try:
-    for root, dirs, files in os.walk(path):
-      dirs[:] = [name for name in dirs if not os.path.islink(os.path.join(root, name))]
-      for name in files:
-        file_path = os.path.join(root, name)
-        if os.path.islink(file_path):
-          continue
+  stack = [root]
+  while stack:
+    folder_path = stack.pop()
+    try:
+      entries = os.scandir(folder_path)
+    except OSError:
+      continue
+    folder = folder_path[prefix_len:] or "/"
+    with entries:
+      for entry in entries:
         try:
-          stat = os.stat(file_path)
+          if entry.is_symlink():
+            continue
+          if entry.is_dir(follow_symlinks=False):
+            stack.append(entry.path)
+            continue
+          stat = entry.stat(follow_symlinks=False)
         except OSError:
           continue
         total += stat.st_size
-        rel = os.path.relpath(file_path, path)
-        folder = os.path.dirname(rel)
         row = {
-          "name": name,
-          "path": file_path,
-          "folder": "/" if folder in ("", ".") else folder,
+          "name": entry.name,
+          "path": entry.path,
+          "folder": folder,
           "modifiedTs": int(stat.st_mtime),
           "sizeBytes": stat.st_size,
         }
         counter += 1
-        entry = (row["modifiedTs"], counter, row)
+        entry_key = (row["modifiedTs"], counter, row)
         if len(recent) < limit:
-          heapq.heappush(recent, entry)
+          heapq.heappush(recent, entry_key)
         else:
-          heapq.heappushpop(recent, entry)
-  except OSError:
-    return 0, []
-  rows = [entry[2] for entry in sorted(recent, reverse=True)]
+          heapq.heappushpop(recent, entry_key)
+  rows = [entry_key[2] for entry_key in sorted(recent, reverse=True)]
   return total, rows
 
 
 def main():
   limit = 25
-  if len(sys.argv) > 1:
+  # "quick" skips the Dropbox folder walk (seconds on large folders) and only
+  # reports daemon state, for the fast re-polls after a pause/resume.
+  quick = "--quick" in sys.argv[1:]
+  args = [a for a in sys.argv[1:] if a != "--quick"]
+  if args:
     try:
-      limit = max(1, min(100, int(sys.argv[1])))
+      limit = max(1, min(100, int(args[0])))
     except ValueError:
       limit = 25
 
@@ -105,11 +119,12 @@ def main():
     stopped = "not running" in lowered or "isn't running" in lowered or lowered == "stopped"
     running = status_exit == 0 and status_output != "" and not stopped
 
-  used, files = scan_dropbox(account_path, limit) if authenticated else (0, [])
+  used, files = scan_dropbox(account_path, limit) if authenticated and not quick else (0, [])
   usage_percent = (used / quota * 100) if quota > 0 else 0
 
   print(json.dumps({
     "ok": True,
+    "quick": quick,
     "installed": dropbox_cli is not None,
     "running": running,
     "authenticated": authenticated,


### PR DESCRIPTION
## Problem

The pause/resume switch in the Dropbox panel could not reliably pause or resume syncing. Clicking pause flipped the switch off, then ~7s later it snapped back on even though dropboxd was dead. The next click then sent `stop` again instead of `start`.

Two measured timing facts cause it:

1. `dropbox-cli stop` returns in ~50ms but dropboxd takes ~5s to exit, and `dropbox-cli status` reports "Up to date" until it does.
2. `status.py` walks the whole Dropbox folder on every poll (~5.3s for a 468k-file folder), including the fast settle re-polls after a click.

So the first settle poll read the stale pre-stop state, the other settle ticks were skipped because that poll was still running, tick 4 cleared the optimistic override, and the stale result landed and flipped the switch back. The switch also swallowed clicks while a 5s poll counted as `busy`.

## Fix

- `status.py --quick`: daemon state only, no folder walk (5.3s -> 0.09s here).
- Settle polls use `--quick` on their own `Process` every second until the daemon state matches the request (up to 20s), then fall back to a full refresh.
- A poll that disagrees with a pending pause/resume no longer overrides the optimistic state.
- Each pause/resume bumps a request generation; any status result whose process started before it is discarded, so a slow full refresh already in flight cannot overwrite the new state when it finally lands.
- A failed `dropbox-cli` command no longer enters the settle loop; it schedules the normal delayed refresh so the error stays visible instead of being wiped by an immediate quick poll.
- Background polls no longer count as `busy`.
- Startup ramp and post-control refreshes use the quick poll as well.

## Idle cost of the full scan

The full walk was also the bar's largest idle cost: every bar instance (one per monitor) re-walked the folder every refresh interval, panel open or not.

- The walk now does one `scandir` per directory and one `lstat` per file instead of `os.walk` plus per-file `islink` + `stat` + `relpath`. Output is byte-identical (same usage total, same 25 recent files); 5.4s -> 1.4s on the 468k-file folder.
- The periodic tick only runs the full scan while the panel is open (`Panel.qml` already refreshes on open). A closed panel polls daemon state with `--quick`, which is all the bar icon needs. One full scan still runs at startup so the panel has data on first open.

Per bar instance at the default 60s interval that is roughly 5.4s CPU/min while idle before, ~0.1s/min now.

## Testing

Drove the real `Service.qml` in a scratch Quickshell config on a 468k-file Dropbox folder, logging state every 500ms:

- pause: `active` goes false immediately and stays false; status reads "Dropbox isn't running!" once the daemon exits.
- resume: `active` goes true immediately; daemon goes Connecting -> Starting -> Up to date and the file list reloads after settling.
- A full (slow) refresh started just before the pause no longer flips the switch back.
- With a 10s interval and the panel closed: one startup full scan, then quick polls only; flipping `detailsWanted` on resumes full scans every tick.
- Old and new `status.py 25` output diffed identical.
