### PR TITLE
Fix Latitude 7490 i915 hibernation resume

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -24,6 +24,7 @@ run_logged "$OMARCHY_INSTALL/hardware/intel/ipu7-camera.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fred.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fix-wifi7-eht.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/sof-firmware.sh"
+run_logged "$OMARCHY_INSTALL/hardware/intel/fix-dell-latitude-7490-hibernate.sh"
 
 # Rebuilds the boot image, so it has to follow the Panther Lake kernel swap
 # above rather than sit with the other Dell leaf at the top of this file.

--- a/install/hardware/intel/fix-dell-latitude-7490-hibernate.sh
+++ b/install/hardware/intel/fix-dell-latitude-7490-hibernate.sh
@@ -1,0 +1,23 @@
+# Dell Latitude 7490 systems with the Kaby Lake-R iGPU can hang while resuming
+# from hibernation in intel_power_domains_resume(). Disabling display C-states
+# avoids the broken DPLL/CDCLK restore path while leaving PSR and FBC enabled.
+
+dmi_vendor_file="${OMARCHY_LATITUDE_7490_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+dmi_product_file="${OMARCHY_LATITUDE_7490_DMI_PRODUCT:-/sys/class/dmi/id/product_name}"
+limine_conf="${OMARCHY_LATITUDE_7490_LIMINE_CONF:-/etc/limine-entry-tool.d/dell-latitude-7490-i915.conf}"
+OMARCHY_LATITUDE_7490_CHANGED=0
+
+dmi_vendor=""
+dmi_product=""
+[[ -r $dmi_vendor_file ]] && read -r dmi_vendor <"$dmi_vendor_file"
+[[ -r $dmi_product_file ]] && read -r dmi_product <"$dmi_product_file"
+
+if [[ $dmi_vendor == "Dell Inc." && $dmi_product == "Latitude 7490" ]]; then
+  expected='KERNEL_CMDLINE[default]+=" i915.enable_dc=0"'
+
+  if [[ ! -f $limine_conf ]] || [[ $(<"$limine_conf") != "$expected" ]]; then
+    printf '%s\n' "$expected" | sudo install -Dm644 /dev/stdin "$limine_conf"
+    sudo limine-mkinitcpio
+    OMARCHY_LATITUDE_7490_CHANGED=1
+  fi
+fi

--- a/install/hardware/intel/fix-dell-latitude-7490-hibernate.sh
+++ b/install/hardware/intel/fix-dell-latitude-7490-hibernate.sh
@@ -5,6 +5,7 @@
 dmi_vendor_file="${OMARCHY_LATITUDE_7490_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
 dmi_product_file="${OMARCHY_LATITUDE_7490_DMI_PRODUCT:-/sys/class/dmi/id/product_name}"
 limine_conf="${OMARCHY_LATITUDE_7490_LIMINE_CONF:-/etc/limine-entry-tool.d/dell-latitude-7490-i915.conf}"
+repair_marker="${OMARCHY_LATITUDE_7490_REPAIR_MARKER:-/var/lib/omarchy/migrations/1787689809}"
 OMARCHY_LATITUDE_7490_CHANGED=0
 
 dmi_vendor=""
@@ -16,8 +17,13 @@ if [[ $dmi_vendor == "Dell Inc." && $dmi_product == "Latitude 7490" ]]; then
   expected='KERNEL_CMDLINE[default]+=" i915.enable_dc=0"'
 
   if [[ ! -f $limine_conf ]] || [[ $(<"$limine_conf") != "$expected" ]]; then
+    sudo rm -f "$repair_marker"
     printf '%s\n' "$expected" | sudo install -Dm644 /dev/stdin "$limine_conf"
+  fi
+
+  if [[ ! -e $repair_marker ]]; then
     sudo limine-mkinitcpio
+    sudo install -Dm644 /dev/null "$repair_marker"
     OMARCHY_LATITUDE_7490_CHANGED=1
   fi
 fi

--- a/migrations/1787689809.sh
+++ b/migrations/1787689809.sh
@@ -1,0 +1,7 @@
+echo "Prevent Dell Latitude 7490 i915 hibernation resume hangs"
+
+source "$OMARCHY_PATH/install/hardware/intel/fix-dell-latitude-7490-hibernate.sh"
+
+if (( OMARCHY_LATITUDE_7490_CHANGED )); then
+  omarchy-state set reboot-required
+fi

--- a/test/shell.d/dell-latitude-7490-hibernate-test.sh
+++ b/test/shell.d/dell-latitude-7490-hibernate-test.sh
@@ -27,6 +27,7 @@ SH
 cat >"$test_tmp/bin/limine-mkinitcpio" <<'SH'
 #!/bin/bash
 echo limine-mkinitcpio >>"$TEST_LOG"
+exit "${TEST_LIMINE_STATUS:-0}"
 SH
 
 cat >"$test_tmp/bin/omarchy-state" <<'SH'
@@ -39,6 +40,7 @@ chmod +x "$test_tmp/bin"/*
 vendor_file="$test_tmp/sys_vendor"
 product_file="$test_tmp/product_name"
 limine_conf="$test_tmp/dell-latitude-7490-i915.conf"
+repair_marker="$test_tmp/latitude-7490-repair-complete"
 call_log="$test_tmp/calls.log"
 
 run_leaf() {
@@ -51,6 +53,8 @@ run_leaf() {
     OMARCHY_LATITUDE_7490_DMI_VENDOR="$vendor_file" \
     OMARCHY_LATITUDE_7490_DMI_PRODUCT="$product_file" \
     OMARCHY_LATITUDE_7490_LIMINE_CONF="$limine_conf" \
+    OMARCHY_LATITUDE_7490_REPAIR_MARKER="$repair_marker" \
+    TEST_LIMINE_STATUS="${3:-0}" \
     bash -euo pipefail -c 'source "$1"' bash "$leaf"
 }
 
@@ -59,13 +63,31 @@ grep -Fxq 'KERNEL_CMDLINE[default]+=" i915.enable_dc=0"' "$limine_conf" ||
   fail "the target Latitude gets the i915 display C-state parameter"
 grep -Fxq 'limine-mkinitcpio' "$call_log" ||
   fail "adding the quirk rebuilds the boot image"
+[[ -f $repair_marker ]] || fail "a successful rebuild records completion"
 pass "the target Latitude gets the i915 display C-state quirk"
 
 run_leaf || fail "the Latitude quirk is idempotent"
 [[ ! -s $call_log ]] || fail "an already configured Latitude is left unchanged"
 pass "the Latitude quirk is idempotent"
 
+rm -f "$repair_marker"
+run_leaf "Dell Inc." "Latitude 7490" 1 &&
+  fail "a failed rebuild fails the hardware setup"
+[[ ! -e $repair_marker ]] || fail "a failed rebuild does not record completion"
+pass "a failed rebuild remains pending"
+
+run_leaf || fail "a pending rebuild is retried"
+grep -Fxq 'limine-mkinitcpio' "$call_log" ||
+  fail "a pending rebuild runs limine-mkinitcpio again"
+[[ -f $repair_marker ]] || fail "a successful retry records completion"
+pass "a failed rebuild is retried successfully"
+
+run_leaf || fail "a completed rebuild remains idempotent"
+[[ ! -s $call_log ]] || fail "a completed rebuild is not repeated"
+pass "a completed rebuild remains idempotent"
+
 rm -f "$limine_conf"
+rm -f "$repair_marker"
 run_leaf "Dell Inc." "Latitude 7480" || fail "another Dell model is handled safely"
 [[ ! -e $limine_conf ]] || fail "another Dell model does not get the quirk"
 [[ ! -s $call_log ]] || fail "another Dell model does not rebuild the boot image"
@@ -86,6 +108,7 @@ PATH="$test_tmp/bin:$PATH" \
   OMARCHY_LATITUDE_7490_DMI_VENDOR="$vendor_file" \
   OMARCHY_LATITUDE_7490_DMI_PRODUCT="$product_file" \
   OMARCHY_LATITUDE_7490_LIMINE_CONF="$limine_conf" \
+  OMARCHY_LATITUDE_7490_REPAIR_MARKER="$repair_marker" \
   bash -euo pipefail "$migration" >/dev/null
 
 grep -Fxq 'omarchy-state set reboot-required' "$call_log" ||

--- a/test/shell.d/dell-latitude-7490-hibernate-test.sh
+++ b/test/shell.d/dell-latitude-7490-hibernate-test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/intel/fix-dell-latitude-7490-hibernate.sh"
+all="$ROOT/install/hardware/all.sh"
+migration=$(grep -l "fix-dell-latitude-7490-hibernate" "$ROOT"/migrations/*.sh | head -1)
+
+grep -q 'run_logged .*hardware/intel/fix-dell-latitude-7490-hibernate.sh' "$all" ||
+  fail "the Latitude 7490 hibernation quirk runs during hardware setup"
+pass "the Latitude 7490 hibernation quirk runs during hardware setup"
+
+[[ -n $migration ]] || fail "a migration enables the quirk on existing installs"
+pass "a migration enables the quirk on existing installs"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+
+cat >"$test_tmp/bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$test_tmp/bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+echo limine-mkinitcpio >>"$TEST_LOG"
+SH
+
+cat >"$test_tmp/bin/omarchy-state" <<'SH'
+#!/bin/bash
+printf 'omarchy-state %s\n' "$*" >>"$TEST_LOG"
+SH
+
+chmod +x "$test_tmp/bin"/*
+
+vendor_file="$test_tmp/sys_vendor"
+product_file="$test_tmp/product_name"
+limine_conf="$test_tmp/dell-latitude-7490-i915.conf"
+call_log="$test_tmp/calls.log"
+
+run_leaf() {
+  : >"$call_log"
+  printf '%s\n' "${1-Dell Inc.}" >"$vendor_file"
+  printf '%s\n' "${2-Latitude 7490}" >"$product_file"
+
+  PATH="$test_tmp/bin:$PATH" \
+    TEST_LOG="$call_log" \
+    OMARCHY_LATITUDE_7490_DMI_VENDOR="$vendor_file" \
+    OMARCHY_LATITUDE_7490_DMI_PRODUCT="$product_file" \
+    OMARCHY_LATITUDE_7490_LIMINE_CONF="$limine_conf" \
+    bash -euo pipefail -c 'source "$1"' bash "$leaf"
+}
+
+run_leaf || fail "the target Latitude gets the i915 display C-state quirk"
+grep -Fxq 'KERNEL_CMDLINE[default]+=" i915.enable_dc=0"' "$limine_conf" ||
+  fail "the target Latitude gets the i915 display C-state parameter"
+grep -Fxq 'limine-mkinitcpio' "$call_log" ||
+  fail "adding the quirk rebuilds the boot image"
+pass "the target Latitude gets the i915 display C-state quirk"
+
+run_leaf || fail "the Latitude quirk is idempotent"
+[[ ! -s $call_log ]] || fail "an already configured Latitude is left unchanged"
+pass "the Latitude quirk is idempotent"
+
+rm -f "$limine_conf"
+run_leaf "Dell Inc." "Latitude 7480" || fail "another Dell model is handled safely"
+[[ ! -e $limine_conf ]] || fail "another Dell model does not get the quirk"
+[[ ! -s $call_log ]] || fail "another Dell model does not rebuild the boot image"
+pass "another Dell model does not get the quirk"
+
+run_leaf "LENOVO" "Latitude 7490" || fail "another vendor is handled safely"
+[[ ! -e $limine_conf ]] || fail "another vendor does not get the quirk"
+[[ ! -s $call_log ]] || fail "another vendor does not rebuild the boot image"
+pass "another vendor does not get the quirk"
+
+: >"$call_log"
+printf '%s\n' 'Dell Inc.' >"$vendor_file"
+printf '%s\n' 'Latitude 7490' >"$product_file"
+
+PATH="$test_tmp/bin:$PATH" \
+  TEST_LOG="$call_log" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_LATITUDE_7490_DMI_VENDOR="$vendor_file" \
+  OMARCHY_LATITUDE_7490_DMI_PRODUCT="$product_file" \
+  OMARCHY_LATITUDE_7490_LIMINE_CONF="$limine_conf" \
+  bash -euo pipefail "$migration" >/dev/null
+
+grep -Fxq 'omarchy-state set reboot-required' "$call_log" ||
+  fail "the migration requests a reboot after enabling the quirk"
+pass "the migration enables the quirk and requests a reboot"


### PR DESCRIPTION
## Summary

- add a narrowly scoped Dell Latitude 7490 hardware quirk that appends `i915.enable_dc=0` to the Limine kernel command line
- rebuild the UKI only when the dedicated drop-in changes
- migrate existing installations and request a reboot
- cover exact DMI matching, idempotency, unrelated hardware, rebuild, and migration behavior

## Why

On a Dell Latitude 7490 with Intel UHD Graphics 620, hibernation consistently hung and required a hard reset. The resume path reported:

```text
i915 0000:00:02.0: [drm] *ERROR* DPLL0 not locked
WARNING: drivers/gpu/drm/i915/display/intel_cdclk.c:977 at skl_get_cdclk()
intel_power_domains_resume()
i915_drm_resume_early()
```

The machine was tested with a valid Btrfs swapfile resume configuration and a current Limine UKI. Disabling Bluetooth and the fingerprint reader did not change the failure.

Disabling all three commonly implicated i915 power features (`enable_psr`, `enable_dc`, and `enable_fbc`) restored hibernation. A follow-up isolation test with only `i915.enable_dc=0` also hibernated and restored the running session successfully, while PSR and FBC remained at their driver defaults.

Tested on:

- Dell Latitude 7490
- Intel Kaby Lake-R GT2 / UHD Graphics 620 (`8086:5917`)
- BIOS 1.41.0
- Linux `7.1.9-arch1-2`
- Omarchy `4.0.1-1`

The workaround is intentionally limited to an exact `Dell Inc.` / `Latitude 7490` DMI match because disabling display C-states can increase power use.

## Tests

- `bash test/shell.d/dell-latitude-7490-hibernate-test.sh` — passes
- live hibernate/resume with only `i915.enable_dc=0` — passes
- `git diff --check` — passes
- `./test/all` — the new test passes; the suite reports six unrelated environment/baseline failures in `config-test.sh`, `launch-about-test.sh`, `network-qr-test.sh`, `snapper-test.sh`, `theme-install-guards-test.sh`, and `unowned-system-paths-test.sh`

`shellcheck` was not available on the test machine.
