### PR TITLE
Let a cloned bar plugin load, and report plugin load failures

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -11,15 +11,22 @@ import "BarModel.js" as BarModel
 Item {
   id: root
 
-  // The omarchy-shell host injects omarchyPath from OMARCHY_PATH.
-  required property string omarchyPath
-  // Injected by the host shell so bar slots can resolve enabled widgets.
-  required property var barWidgetRegistry
-  // Injected by the host shell every time shell.json is reloaded. Holds the
-  // `bar:` subtree: position, centerAnchor, layout. The host owns file IO;
-  // the bar just renders whatever it's handed. The bar font follows the
-  // OS-level fontconfig monospace binding — it is not stored in shell.json.
-  required property var barConfig
+  // Injected by the host, never `required`: a plugin bar is loaded through
+  // pluginBarLoader's `source`, which cannot carry initial bindings, so
+  // configureBar() assigns these in onLoaded — after construction. A `required
+  // property` here aborts creation before that runs, which is why a clone of
+  // this file (`omarchy plugin clone omarchy.bar`) used to leave no bar at all.
+  // The built-in bar gets them as initial bindings from defaultBarComponent.
+  //
+  // omarchyPath comes from OMARCHY_PATH.
+  property string omarchyPath: ""
+  // Lets bar slots resolve enabled widgets.
+  property var barWidgetRegistry: null
+  // Re-assigned every time shell.json is reloaded. Holds the `bar:` subtree:
+  // position, centerAnchor, layout. The host owns file IO; the bar just renders
+  // whatever it's handed. The bar font follows the OS-level fontconfig monospace
+  // binding — it is not stored in shell.json.
+  property var barConfig: null
   // Injected by the host shell. Used for shell-wide actions such as opening
   // settings and persisting inline widget state.
   property var shell: null

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -253,8 +253,12 @@ ShellRoot {
     onActiveChanged: if (!active) shell.bar = null
     onStatusChanged: {
       if (status === Loader.Error) {
-        var detail = errorString && errorString() ? errorString() : ""
-        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId + ":", detail)
+        // Loader has no errorString(); referencing the bare identifier throws a
+        // ReferenceError that aborted this handler, so the fallback ran without
+        // ever telling the user why. The engine already logs the underlying QML
+        // errors, so point at those instead of inventing a detail string.
+        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to "
+          + shell.defaultBarId + " (source: " + shell.activeBarSourceUrl + "); see the QML errors above")
         shell.failedBarId = shell.activeBarId
       }
     }
@@ -639,12 +643,13 @@ ShellRoot {
         }
         onStatusChanged: {
           if (status === Loader.Error) {
-            // Loader.errorString() reflects the source-load failure even when
-            // sourceComponent is null. Surface both so the user sees something
-            // actionable instead of a panel that silently refuses to open.
-            var detail = errorString && errorString() ? errorString() : ""
-            if (!detail && sourceComponent) detail = sourceComponent.errorString()
-            console.warn("panel plugin " + panelEntry.pluginId + " failed to load:", detail)
+            // Loader exposes no errorString(); the bare identifier threw a
+            // ReferenceError and this handler never reached shell.hide(). Only
+            // sourceComponent can carry a detail, and it is null for a source-load
+            // failure — so name the source and defer to the engine's own errors.
+            var detail = sourceComponent ? sourceComponent.errorString() : ""
+            console.warn("panel plugin " + panelEntry.pluginId + " failed to load (source: "
+              + panelEntry.sourceUrl + "):", detail || "see the QML errors above")
             shell.hide(panelEntry.pluginId)
           }
         }

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -254,8 +254,8 @@ ShellRoot {
     onStatusChanged: {
       if (status === Loader.Error) {
         // Loader has no errorString(); referencing the bare identifier throws a
-        // ReferenceError that aborted this handler, so the fallback ran without
-        // ever telling the user why. The engine already logs the underlying QML
+        // ReferenceError that aborted this handler before either diagnostics or
+        // the fallback could run. The engine already logs the underlying QML
         // errors, so point at those instead of inventing a detail string.
         console.warn("bar option " + shell.activeBarId + " failed to load, falling back to "
           + shell.defaultBarId + " (source: " + shell.activeBarSourceUrl + "); see the QML errors above")

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -485,3 +485,22 @@ put_output=$(PATH="$put_tmp/bin:$ROOT/bin:$PATH" \
   fail "put places a widget through a ready shell" "$put_output"
 [[ $put_output == "omarchy.keyboard-layout is on the bar" ]] || fail "put reports the placed widget" "$put_output"
 pass "put places a widget through a ready shell"
+
+# A plugin bar is loaded through pluginBarLoader's `source`, which carries no
+# initial bindings, so the host assigns these in onLoaded — after construction.
+# Marking any of them `required` aborts creation first, which left a cloned bar
+# rendering nothing at all on every monitor.
+for injected in omarchyPath barWidgetRegistry barConfig; do
+  if rg -q "required property [A-Za-z<>]+ $injected\b" "$ROOT/shell/plugins/bar/Bar.qml"; then
+    fail "host-injected bar property $injected must not be required"
+  fi
+done
+pass "host-injected bar properties are assignable after construction"
+
+# Loader has no errorString(): the bare identifier raises a ReferenceError that
+# aborts the very handler meant to report the failure, so a plugin that fails to
+# load did so silently. Only a QQmlComponent can be asked for a detail string.
+if perl -0ne 's{//[^\n]*}{}g; exit(/(?<![.\w])errorString\s*\(/ ? 0 : 1)' "$ROOT/shell/shell.qml"; then
+  fail "plugin load failures must not call an unqualified errorString()"
+fi
+pass "plugin load failures report through a qualified errorString()"


### PR DESCRIPTION
## Problem

`shell/plugins/bar/Bar.qml` declares `omarchyPath`, `barWidgetRegistry` and
`barConfig` as `required property`. But `pluginBarLoader` loads a plugin bar
through `source` (`shell/shell.qml:250`), which carries no initial bindings —
`configureBar()` assigns those values in `onLoaded`, after construction. QML
aborts creation first, so `omarchy plugin clone omarchy.bar` produces a bar that
never renders on any monitor, even when the clone is byte-identical.

The built-in bar is unaffected: `defaultBarComponent` supplies the same three
values as initial bindings inside the `Component`.

The failure is silent, which is why this has been reported so many times. Both
`Loader.onStatusChanged` handlers guard on a bare `errorString` identifier:

```qml
var detail = errorString && errorString() ? errorString() : ""
```

`Loader` has no `errorString()`, and referencing an undeclared identifier throws
a `ReferenceError` — so the handler meant to report the failure aborts on its
own first line. The bar falls back with no message, and at `shell.qml:645` a
failing panel plugin never reaches `shell.hide()`.

## Fix

- Drop `required` from the three host-injected properties, with a comment saying
  why they cannot be required, so it does not come back. This matches the
  documented contract in `agents/skills/shell-dev.md` ("accept the
  shell-injected properties"), and keeps working for third-party bars that
  declare any subset of them.
- Both handlers: only a `QQmlComponent` can be asked for a detail string, and it
  is `null` for a source-load failure — so name the source and defer to the QML
  errors the engine already logs.

I kept the fix to `required` rather than switching `pluginBarLoader` to
`setSource(url, props)`. `setSource` would preserve `required`, but it warns
"does not have a property" for any third-party bar that declares a subset of the
injected properties, and the host cannot know that subset before construction.

## Verification

- `test/shell.d/bar-test.sh` gains two invariants: no host-injected bar property
  is `required`, and `shell.qml` calls no unqualified `errorString()`. Both were
  confirmed to fail when the respective fix is reverted.
- Full `test/shell`: 202/206 files pass. The 4 failures (`config-test.sh`,
  `snapper-test.sh`, `theme-install-guards-test.sh`,
  `unowned-system-paths-test.sh`) fail identically on a clean `quattro` checkout
  on this machine, so they are environment-dependent and unrelated.
- The `required` half has been running on my own machine for weeks: my cloned
  bar only works because I had made exactly this change locally.

## Related issues

Closes #6915.

Same bug, also open: #7253, #7418, #8007, #8189, #8202, #8334.
