### PR TITLE
Say when an installed theme's files are refused

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -237,6 +237,13 @@ report_ignored_theme_files() {
 
   echo "Ignored in $USER_THEMES_PATH/$THEME_NAME: ${IGNORED_THEME_FILES[*]}" >&2
   echo "A theme installed from a git repo cannot supply Lua, a terminal config, or vscode.json." >&2
+
+  # Switching themes from the menu discards stderr, so a theme that lost its
+  # rounding, shadows or blur just looked broken with nothing said. Report the
+  # refusal where the switch was made.
+  omarchy-notification-send -t 10000 \
+    "Part of $THEME_NAME was not applied" \
+    "An installed theme cannot supply: ${IGNORED_THEME_FILES[*]}" || true
 }
 
 THEME_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')

--- a/test/shell.d/theme-staging-test.sh
+++ b/test/shell.d/theme-staging-test.sh
@@ -19,9 +19,22 @@ mkdir -p "$state" "$themes"
 
 marker="omarchy-theme-staging-marker"
 
+# A refusal is only useful if it reaches the person who switched the theme, so
+# record what would have been sent rather than trusting the stderr lines.
+notifications="$test_tmp/notifications"
+stub_bin="$test_tmp/stub-bin"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/omarchy-notification-send" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_NOTIFICATIONS"
+STUB
+chmod +x "$stub_bin/omarchy-notification-send"
+
 set_theme() {
-  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+  : >"$notifications"
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$ROOT/bin:$PATH" \
     OMARCHY_THEME_HEADLESS=1 OMARCHY_THEME_SKIP_BACKGROUND=1 \
+    OMARCHY_TEST_NOTIFICATIONS="$notifications" \
     XDG_RUNTIME_DIR="$test_tmp" \
     bash "$ROOT/bin/omarchy-theme-set" "$1" 2>"$test_tmp/stderr" || return $?
 }
@@ -96,6 +109,12 @@ assert_staged backgrounds/1-real.png "an image in backgrounds/ is staged"
 
 assert_not_staged unlock.png "a symlink is not followed out of the theme"
 assert_not_staged vscode.json "vscode.json names an extension to install and is not staged"
+
+grep -q 'hyprland.lua' "$notifications" ||
+  fail "the refusal is announced, not left on stderr" "$(cat "$notifications")"
+grep -q 'not applied' "$notifications" ||
+  fail "the announcement says something was not applied" "$(cat "$notifications")"
+pass "an installed theme's refused files are announced to the user"
 
 assert_staged icons.theme "the theme's icon set name is staged"
 grep -q 'Yaru-red' "$(staged icons.theme)" || fail "the staged icons.theme is the theme's"
@@ -186,6 +205,12 @@ assert_staged vscode.json "a theme the user wrote keeps every file it ships"
 [[ ! -s $test_tmp/stderr ]] || fail "a theme the user wrote reports nothing ignored" "$(cat "$test_tmp/stderr")"
 
 pass "a theme the user wrote is not held to the installed-theme list"
+
+# Nothing was refused, so nothing should be announced: the notification has to
+# report a real loss, not fire on every theme switch.
+[[ ! -s $notifications ]] ||
+  fail "a theme with nothing refused announces nothing" "$(cat "$notifications")"
+pass "a theme with nothing refused announces nothing"
 
 # A working copy symlinked into the themes folder is the user's own too.
 ln -s "$mine" "$themes/mine-link"


### PR DESCRIPTION
`omarchy-theme-set` drops the files that would let a cloned theme run code, and explains itself on stderr. Switching themes from the menu discards stderr, so the explanation never arrives.

What that looks like in practice: a theme whose `hyprland.lua` carried its `rounding`, `shadow` and `blur` comes up with none of them. The palette is applied, so the theme half-works — which reads as a broken theme rather than a deliberate refusal. Working out why means finding `is_denied_installed_file` in `omarchy-theme-set`; the only trace on the machine is a stderr line nobody saw.

This reports the refusal where the switch was made, naming the files. It fires only when something was actually refused, so it is not a notification on every theme change.

I hit this on three installed themes from one author, each of which put its decoration in `hyprland.lua`. None of them contained a single `os.execute`, `io.` or `require` — the refusal is correct policy and they are collateral, which is exactly why saying so matters.

Two tests in `test/shell.d/theme-staging-test.sh`, stubbing `omarchy-notification-send` to record what would be sent: the hostile theme's refusal is announced and names `hyprland.lua`, and a theme with nothing refused announces nothing. Verified by mutation — removing the call fails the first.

`./test/cli` passes and `omarchy commands --check` passes at 436 commands. `./test/shell` reports 5 of 206 files failing (`config`, `locale-env`, `snapper`, `theme-install-guards`, `unowned-system-paths`); all five fail identically on `quattro` without this branch on the same machine, so none are from this change.

Worth separating from this PR, but it is the reason I went looking: an installed theme currently has no declarative channel for visual identity at all. `hyprland.conf` is inert legacy, and the staged `hyprland.lua` is generated from Omarchy's template and carries border colours only. So rounding, shadows and blur are `.lua` or nothing, and `.lua` is refused. #8011, #8264 and #8266 all propose declarative theme data for other integrations; the same shape would fit here. Happy to open a separate issue if that is useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
