### PR TITLE
Migrate invitation hooks to notification argv

### DIFF
--- a/migrations/1787689809.sh
+++ b/migrations/1787689809.sh
@@ -1,0 +1,21 @@
+echo "Update first-run hooks to safe notification click arguments"
+
+hooks_dir="$HOME/.config/omarchy/hooks/post-update.d"
+
+agent_hook="$hooks_dir/setup-agent.hook"
+if [[ -f $agent_hook && ! -L $agent_hook ]] &&
+  grep -Fq -- '--exec "omarchy menu summon setup.default.agent"' "$agent_hook"; then
+  sed -i 's|--exec "omarchy menu summon setup\.default\.agent"|--exec omarchy menu summon setup.default.agent|' "$agent_hook"
+fi
+
+fingerprint_hook="$hooks_dir/setup-fingerprint.hook"
+if [[ -f $fingerprint_hook && ! -L $fingerprint_hook ]] &&
+  grep -Fq -- '--exec "omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint"' "$fingerprint_hook"; then
+  sed -i 's|--exec "omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint"|--exec omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint|' "$fingerprint_hook"
+fi
+
+voxtype_hook="$hooks_dir/install-voxtype.hook"
+if [[ -f $voxtype_hook && ! -L $voxtype_hook ]] &&
+  grep -Fq -- '--exec "omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install"' "$voxtype_hook"; then
+  sed -i 's|--exec "omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install"|--exec omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install|' "$voxtype_hook"
+fi

--- a/test/shell.d/invitation-hook-argv-migration-test.sh
+++ b/test/shell.d/invitation-hook-argv-migration-test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+test_home=$(mktemp -d)
+hooks_dir="$test_home/.config/omarchy/hooks/post-update.d"
+migration="$ROOT/migrations/1787689809.sh"
+
+cleanup() {
+  rm -rf "$test_home"
+}
+trap cleanup EXIT
+
+mkdir -p "$hooks_dir"
+
+cat >"$hooks_dir/setup-agent.hook" <<'EOF'
+#!/bin/bash
+# Keep this customization.
+omarchy-notification-send "Agent" --exec "omarchy menu summon setup.default.agent"
+EOF
+
+cat >"$hooks_dir/install-voxtype.hook" <<'EOF'
+#!/bin/bash
+omarchy-notification-send "Voxtype" \
+  --exec "omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install"
+EOF
+
+fingerprint_target="$test_home/custom-fingerprint-hook"
+cat >"$fingerprint_target" <<'EOF'
+#!/bin/bash
+omarchy-notification-send "Fingerprint" --exec "omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint"
+EOF
+ln -s "$fingerprint_target" "$hooks_dir/setup-fingerprint.hook"
+
+chmod 755 "$hooks_dir/setup-agent.hook" "$hooks_dir/install-voxtype.hook" "$fingerprint_target"
+
+HOME="$test_home" bash -euo pipefail "$migration" >/dev/null
+HOME="$test_home" bash -euo pipefail "$migration" >/dev/null
+
+grep -Fq -- '--exec omarchy menu summon setup.default.agent' "$hooks_dir/setup-agent.hook" ||
+  fail "migration updates the agent invitation click action"
+grep -Fq -- '--exec omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install' "$hooks_dir/install-voxtype.hook" ||
+  fail "migration updates the Voxtype invitation click action"
+grep -Fq -- '# Keep this customization.' "$hooks_dir/setup-agent.hook" ||
+  fail "migration preserves hook customizations"
+
+if grep -Fq -- '--exec "' "$hooks_dir/setup-agent.hook" "$hooks_dir/install-voxtype.hook"; then
+  fail "migration leaves a shipped command-string click action"
+fi
+
+grep -Fq -- '--exec "omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint"' "$fingerprint_target" ||
+  fail "migration leaves symlinked development hooks alone"
+
+[[ $(stat -c '%a' "$hooks_dir/setup-agent.hook") == "755" ]] ||
+  fail "migration preserves executable hook permissions"
+
+pass "invitation hook argv migration is targeted and idempotent"


### PR DESCRIPTION
## Summary

- migrate installed copies of the Agent, fingerprint, and Voxtype invitation hooks from a single command-string `--exec` argument to an argv-style click action
- only replace the exact legacy command strings shipped by Omarchy
- leave symlinked development hooks alone and preserve other user customizations and file modes
- cover targeting and idempotence with a migration regression test

## Why

The notification hardening in #7926 rejects a single quoted command string after `--exec`. The current hook templates already use separate arguments, but existing installations retain their copied hooks under `~/.config/omarchy/hooks/post-update.d`. Those legacy hooks now fail when they try to send their first-run invitation.

## Tests

- `./test/cli`
- invitation migration regression test
- existing Agent, fingerprint, and Voxtype invitation tests
- ShellCheck for the migration and regression test
- `./test/shell`: 201 of 207 test files pass; the six failures are unrelated existing environment/baseline checks: bar icon geometry, missing `omarchy-pkgs` checkout (three files), launch-about animation, and unreachable-theme guard behavior
