### PR TITLE
Add Positron to the VS Code theme sync

### DIFF
--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -151,3 +151,4 @@ set_theme() {
 ! omarchy-toggle-enabled skip-vscode-insiders-theme-changes && set_theme "code-insiders" "$HOME/.config/Code - Insiders/User/settings.json" "$HOME/.vscode-insiders/extensions"
 ! omarchy-toggle-enabled skip-codium-theme-changes && set_theme "codium" "$HOME/.config/VSCodium/User/settings.json" "$HOME/.vscode-oss/extensions"
 ! omarchy-toggle-enabled skip-cursor-theme-changes && set_theme "/usr/bin/cursor" "$HOME/.config/Cursor/User/settings.json" "$HOME/.cursor/extensions"
+! omarchy-toggle-enabled skip-positron-theme-changes && set_theme "positron" "$HOME/.config/Positron/User/settings.json" "$HOME/.positron/extensions"

--- a/manual/18-development-tools.md
+++ b/manual/18-development-tools.md
@@ -4,7 +4,7 @@
 
 Omarchy ships with [Neovim](https://neovim.io/) by default, but if you'd like something a bit more mainstream and familiar, you can run the Omarchy Menu (`Super + Space`) and see the options under _Install > Editor_. We have VSCode, Cursor, Zed, Sublime Text, Helix, Vim, and Emacs listed there. If you don't find what you're looking for, checkout _Install > Package_, and see if it isn't in an Arch package (and if not, try _Install > AUR_ to check the AUR).
 
-Theme matching is offered for `VSCode`, `Cursor`, `VSCodium`, and `Helix`.
+Theme matching is offered for `VSCode`, `Cursor`, `VSCodium`, `Positron`, and `Helix`.
 
 You can set the system-wide default editor under `Setup > Defaults > Editor`.
 

--- a/test/shell.d/vscode-theme-test.sh
+++ b/test/shell.d/vscode-theme-test.sh
@@ -40,4 +40,33 @@ grep -Fxq 'positron' "$TEST_HOME/editor-probes.log" || fail "VS Code theme sync 
 [[ ! -e $TEST_HOME/cursor-shim-called ]] || fail "VS Code theme sync ignores a PATH-provided Cursor Agent shim"
 [[ ! -e $TEST_HOME/.config/Cursor/User/settings.json ]] || fail "VS Code theme sync skips Cursor when the packaged executable is unavailable"
 pass "VS Code theme sync selects the packaged Cursor executable"
-pass "VS Code theme sync covers Positron"
+pass "VS Code theme sync probes Positron"
+
+cat >"$FAKE_BIN/omarchy-cmd-present" <<'EOF'
+#!/bin/bash
+[[ $1 == "positron" ]]
+EOF
+rm -f "$CURRENT_THEME/vscode.json"
+printf '{"type":"light"}\n' >"$CURRENT_THEME/vscode-theme.json"
+
+PATH="$FAKE_BIN:$ROOT/bin:$PATH" \
+  HOME="$TEST_HOME" \
+  "$ROOT/bin/omarchy-theme-set-vscode"
+
+grep -Fq '"workbench.colorTheme": "Omarchy"' "$TEST_HOME/.config/Positron/User/settings.json" || fail "VS Code theme sync writes Positron settings"
+[[ -L $TEST_HOME/.positron/extensions/omarchy-theme/themes/omarchy-color-theme.json ]] || fail "VS Code theme sync installs the generated Positron extension"
+pass "VS Code theme sync uses Positron settings and extension paths"
+
+cat >"$FAKE_BIN/omarchy-toggle-enabled" <<'EOF'
+#!/bin/bash
+[[ $1 == "skip-positron-theme-changes" ]]
+EOF
+rm -rf "$TEST_HOME/.config/Positron" "$TEST_HOME/.positron"
+
+PATH="$FAKE_BIN:$ROOT/bin:$PATH" \
+  HOME="$TEST_HOME" \
+  "$ROOT/bin/omarchy-theme-set-vscode"
+
+[[ ! -e $TEST_HOME/.config/Positron/User/settings.json ]] || fail "VS Code theme sync honors the Positron skip toggle"
+[[ ! -e $TEST_HOME/.positron/extensions/omarchy-theme ]] || fail "VS Code theme sync honors the Positron skip toggle"
+pass "VS Code theme sync honors the Positron skip toggle"

--- a/test/shell.d/vscode-theme-test.sh
+++ b/test/shell.d/vscode-theme-test.sh
@@ -36,6 +36,8 @@ EDITOR_PROBE_LOG="$TEST_HOME/editor-probes.log" \
   "$ROOT/bin/omarchy-theme-set-vscode"
 
 grep -Fxq '/usr/bin/cursor' "$TEST_HOME/editor-probes.log" || fail "VS Code theme sync probes the packaged Cursor executable"
+grep -Fxq 'positron' "$TEST_HOME/editor-probes.log" || fail "VS Code theme sync probes Positron"
 [[ ! -e $TEST_HOME/cursor-shim-called ]] || fail "VS Code theme sync ignores a PATH-provided Cursor Agent shim"
 [[ ! -e $TEST_HOME/.config/Cursor/User/settings.json ]] || fail "VS Code theme sync skips Cursor when the packaged executable is unavailable"
 pass "VS Code theme sync selects the packaged Cursor executable"
+pass "VS Code theme sync covers Positron"


### PR DESCRIPTION
[Positron](https://positron.posit.co) is Posit's VS Code fork aimed at data science. It's packaged on the AUR as `positron-ide-bin`, but it doesn't follow the Omarchy theme, so it stays on its default light theme while everything else on the desktop retints.

Because it's a VS Code fork, `set_theme` already does everything needed: it edits `settings.json` in place as JSONC, installs the generated theme as a local extension, and clears the entry out of `.obsolete`. This just wires up Positron's paths and gives it a skip toggle like the other editors.

- settings: `~/.config/Positron/User/settings.json`
- extensions: `~/.positron/extensions`
- toggle: `skip-positron-theme-changes`

Positron's CLI supports `--list-extensions` and `--install-extension`, so a theme's `vscode.json` descriptor pointing at a third-party extension works too.

I used the bare `positron` command rather than an absolute path. The absolute `/usr/bin/cursor` alongside it exists to dodge the Cursor Agent PATH shim and has a regression test pinning it; Positron has no equivalent collision, so it follows the `code`/`codium` style and keeps non-packaged installs on `PATH` working.

## Verification

On Omarchy 4.x with `positron-ide-bin 2026.08.1.2-1` and the Lupine theme:

- Deleted `~/.positron/extensions/omarchy-theme/` and removed `local.omarchy-theme` from `extensions.json`, then ran the patched script. It rebuilt the extension, re-registered it, and set `workbench.colorTheme` to `Omarchy` from scratch.
- Confirmed in the running UI that Positron's editor, sidebar, and status bar all render Lupine's `#fafafa` with the `#3264eb` accent, matching the theme's `colors.toml`.
- `test/shell.d/vscode-theme-test.sh` passes, and fails with `not ok - VS Code theme sync probes Positron` when the `bin/` change is reverted.
- `./test/all` has 4 failures on my machine (`config-test`, `unowned-system-paths-test`, `theme-install-guards-test`, `snapper-test`), all of which fail identically on a clean checkout — two want a sibling `omarchy-pkgs` checkout, one needs network, one needs btrfs/snapper. None touch theming.

No screenshot attached: the visible result is Positron rendering the same palette as the rest of the desktop, and a capture would mostly be my own source files.