### PR TITLE
Keep system binaries ahead of the mise shims in the uwsm session

### DIFF
--- a/default/uwsm/env.d/10-omarchy
+++ b/default/uwsm/env.d/10-omarchy
@@ -15,5 +15,12 @@ fi
 # Optional user overrides kept for compatibility with older installs.
 [ -f "$HOME/.config/uwsm/default" ] && . "$HOME/.config/uwsm/default"
 
-# Activate mise if present on the system
-omarchy-cmd-present mise && eval "$(mise activate bash --shims)"
+# Activate mise if present on the system.
+# env-bootstrap already appends the shims directory so system binaries keep
+# precedence, and `mise activate --shims` prepends unconditionally. Running it
+# on top of the bootstrap adds a second, winning copy ahead of /usr/bin, so only
+# fall back to it when the shims are not on PATH yet.
+case ":$PATH:" in
+  *":$HOME/.local/share/mise/shims:"*) ;;
+  *) omarchy-cmd-present mise && eval "$(mise activate bash --shims)" ;;
+esac

--- a/test/shell.d/uwsm-env-path-test.sh
+++ b/test/shell.d/uwsm-env-path-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+home="$tmpdir/home"
+stub_bin="$tmpdir/stub-bin"
+mkdir -p "$home" "$stub_bin"
+
+# `mise activate --shims` prepends the shims directory. Stub it so the test does
+# not depend on mise being installed, and so a fallback activation is visible in
+# the resulting PATH.
+cat >"$stub_bin/mise" <<'STUB'
+#!/bin/bash
+printf 'export PATH="$HOME/.local/share/mise/shims:$PATH"\n'
+STUB
+cat >"$stub_bin/omarchy-cmd-present" <<'STUB'
+#!/bin/bash
+command -v "$1" >/dev/null
+STUB
+chmod +x "$stub_bin/mise" "$stub_bin/omarchy-cmd-present"
+
+# Test against copies so the test controls the bootstrap it loads without
+# depending on an installed Omarchy.
+bootstrap="$tmpdir/env-bootstrap"
+sed "s#/etc/omarchy.conf#$tmpdir/omarchy.conf#g" "$ROOT/default/bash/env-bootstrap" >"$bootstrap"
+printf 'export OMARCHY_PATH="/usr/share/omarchy"\n' >"$tmpdir/omarchy.conf"
+
+env_d="$tmpdir/10-omarchy"
+sed "s#/usr/share/omarchy/default/bash/env-bootstrap#$bootstrap#g" "$ROOT/default/uwsm/env.d/10-omarchy" >"$env_d"
+
+# A variant whose bootstrap is missing, to exercise the fallback activation.
+env_d_no_bootstrap="$tmpdir/10-omarchy-no-bootstrap"
+sed "s#/usr/share/omarchy/default/bash/env-bootstrap#$tmpdir/absent-bootstrap#g" "$ROOT/default/uwsm/env.d/10-omarchy" >"$env_d_no_bootstrap"
+
+run_env_d() {
+  local script="$1"
+  local path_value="$2"
+
+  HOME="$home" PATH="$path_value" sh -c '. "$1"; printf "%s\n" "$PATH"' sh "$script"
+}
+
+count_path_entry() {
+  local path_value="$1"
+  local entry="$2"
+
+  printf '%s' "$path_value" | tr ':' '\n' | grep -cxF "$entry" || true
+}
+
+path_index() {
+  local path_value="$1"
+  local entry="$2"
+
+  printf '%s' "$path_value" | tr ':' '\n' | grep -nxF "$entry" | head -1 | cut -d: -f1
+}
+
+shims="$home/.local/share/mise/shims"
+
+result=$(run_env_d "$env_d" "$stub_bin:/usr/bin")
+
+count=$(count_path_entry "$result" "$shims")
+(( count == 1 )) || fail "uwsm env.d adds the mise shims exactly once" "expected 1 occurrence, found $count\nactual PATH: $result"
+pass "uwsm env.d adds the mise shims exactly once"
+
+shims_index=$(path_index "$result" "$shims")
+usr_bin_index=$(path_index "$result" "/usr/bin")
+[[ -n $shims_index && -n $usr_bin_index ]] || fail "uwsm env.d keeps /usr/bin and the shims on PATH" "actual PATH: $result"
+(( usr_bin_index < shims_index )) || fail "uwsm env.d keeps system binaries ahead of the mise shims" "/usr/bin at #$usr_bin_index, shims at #$shims_index\nactual PATH: $result"
+pass "uwsm env.d keeps system binaries ahead of the mise shims"
+
+# Without the bootstrap the shims are not on PATH yet, so mise still activates.
+fallback=$(run_env_d "$env_d_no_bootstrap" "$stub_bin:/usr/bin")
+fallback_count=$(count_path_entry "$fallback" "$shims")
+(( fallback_count == 1 )) || fail "uwsm env.d activates mise when the bootstrap did not run" "expected 1 occurrence, found $fallback_count\nactual PATH: $fallback"
+pass "uwsm env.d activates mise when the bootstrap did not run"


### PR DESCRIPTION
## What happens

On a graphical session with mise installed, the shims directory ends up on `PATH` twice, and the copy that wins sits ahead of `/usr/bin`:

```console
$ systemctl --user show-environment | grep ^PATH= | tr ':' '\n' | grep -n -E 'mise/shims|/usr/bin$'
 3  /home/<user>/.local/share/mise/shims   # wins
10  /usr/bin
11  /home/<user>/.local/share/mise/shims   # where env-bootstrap put it
```

`default/uwsm/env.d/10-omarchy` sources `env-bootstrap` at the top, which appends the shims so system binaries keep precedence, and then runs `mise activate bash --shims` at the bottom, which is just:

```console
$ mise activate bash --shims
export PATH="$HOME/.local/share/mise/shims:$PATH"
```

So the same file appends the directory and then prepends it again. Every session started through uwsm inherits the result.

## Why this looks like a missed migration rather than a deliberate override

The prepend is older than the bootstrap, and was correct when it was written:

- `babfafa5` (2026-05-27) added the `--shims` line, back when it was the only thing putting the shims on `PATH`.
- #6632 (2026-08-08) introduced the appending bootstrap, with the comment *"appended so system binaries keep precedence"*, and extended `dev-env-path-test.sh` to pin the behaviour down — the shims go after existing entries, and no `PATH` entry is ever duplicated.

#6632 migrated `default/bashrc`, `install/config/ssh-command-path.sh`, a migration, and the shell tests, but not `default/uwsm/env.d/10-omarchy`. The older prepend stayed behind and now overrides the ordering that change established, which is why the session `PATH` violates an invariant the test suite already asserts for the bootstrap itself.

## Impact

Because the shims win, a tool mise does **not** manage still resolves through a shim. On a machine where mise has no `php` (`~/.config/mise/config.toml` lists only `gh`, `codex`, `claude`, `go`), running `php` starts mise first, which stats its entire install tree — every unrelated tool it manages — before `exec`ing `/usr/bin/php`:

```console
$ grep -n execve hello.php.log
1:    execve("/home/<user>/.local/share/mise/shims/php", ["php", "hello.php"], ...) = 0
1498: execve("/usr/bin/php", ["/usr/bin/php", "hello.php"], ...) = 0

$ sed -n '1,1497p' hello.php.log | grep -oP 'statx\(.*?"\K[^"]+' | sed 's|/[^/]*$||' | sort | uniq -c | sort -rn | head -4
     74 /home/<user>/.local/share/mise/installs/gh
     74 /home/<user>/.local/share/mise/installs/codex
     74 /home/<user>/.local/share/mise/installs/claude
     30 /home/<user>/.local/share/mise/installs/go
```

For a one-line `hello.php`, that is 2335 strace lines instead of 848, and roughly 28ms instead of 15ms per invocation — 64% of the trace is the shim resolving a lookup whose answer is fixed. It is small per call but pure overhead, it applies to every non-mise tool in the session, and nothing about it is visible without tracing.

Users who let mise manage everything never notice, since going through the shim is the correct behaviour for them. It only surfaces when a system package and mise coexist.

## The change

Guard the activation with the same `PATH` check `env-bootstrap` already uses, so the session falls back to `mise activate --shims` only when the bootstrap did not run:

```sh
case ":$PATH:" in
  *":$HOME/.local/share/mise/shims:"*) ;;
  *) omarchy-cmd-present mise && eval "$(mise activate bash --shims)" ;;
esac
```

I kept the existing `[ ]`/`case` style of the file rather than the `[[ ]]` in AGENTS.md, since this one is read as a uwsm env fragment — happy to switch it if you'd prefer.

`bin/omarchy-upgrade-to-quattro` matches the old line as a string, but that awk block strips known Omarchy lines out of a user's *legacy* `~/.config/uwsm/env`, so it is unrelated to this default and is left untouched.

## Testing

`test/shell.d/uwsm-env-path-test.sh` (new) covers both paths: the shims appear exactly once, `/usr/bin` stays ahead of them, and mise still activates when the bootstrap did not run. It fails on the current default:

```
expected 1 occurrence, found 2
actual PATH: .../shims:.../stub-bin:/usr/bin:.../shims:.../.local/bin
```

`./test/all` on this branch: **2680 ok, 5 not ok**.

Three failures are the missing `omarchy-pkgs` checkout (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`); I confirmed they fail identically on `quattro` without this change. The other two are `copy-url-shortcut-migration-test.sh` ("migration stays pending when a browser starts mid-repair") and `runtime-smoke-test.sh` ("each widget registers its IPC handler once per screen (saw 6 for 3 screen(s))"), which exercise a browser launch and Quickshell IPC across this machine's three monitors — neither area is touched here, but I could not complete a clean-tree baseline run of those two before opening this, so I'm flagging them rather than claiming they're unrelated.

Verified on Omarchy 4.0.0-1 with mise 2026.8.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
