### PR TITLE
Add terminal opacity to generated themes

### DIFF
--- a/bin/omarchy-theme-color
+++ b/bin/omarchy-theme-color
@@ -173,6 +173,17 @@ parse_colors_file() {
   return 0
 }
 
+resolve_terminal_opacity() {
+  local opacity="${THEME_COLORS[terminal_opacity]:-}"
+
+  if [[ -z $opacity ]]; then
+    THEME_COLORS[terminal_opacity]="1.0"
+  elif [[ ! $opacity =~ ^(0([.][0-9]+)?|1([.]0+)?)$ ]]; then
+    printf 'omarchy-theme-color: invalid terminal_opacity %q; using 1.0\n' "$opacity" >&2
+    THEME_COLORS[terminal_opacity]="1.0"
+  fi
+}
+
 resolve_theme_colors() {
   local key
 
@@ -277,6 +288,7 @@ resolve_theme_colors() {
   done
 
   resolve_theme_mode
+  resolve_terminal_opacity
   THEME_COLORS[theme_type]="${THEME_COLORS[mode]}"
 }
 

--- a/default/themed/alacritty.toml.tpl
+++ b/default/themed/alacritty.toml.tpl
@@ -1,3 +1,6 @@
+[window]
+opacity = {{ terminal_opacity }}
+
 [colors.primary]
 background = "{{ background }}"
 foreground = "{{ foreground }}"

--- a/default/themed/foot.ini.tpl
+++ b/default/themed/foot.ini.tpl
@@ -1,4 +1,5 @@
 [colors-dark]
+alpha={{ terminal_opacity }}
 foreground={{ foreground_strip }}
 background={{ background_strip }}
 selection-foreground={{ selection_foreground_strip }}

--- a/default/themed/ghostty.conf.tpl
+++ b/default/themed/ghostty.conf.tpl
@@ -1,4 +1,5 @@
 background = {{ background }}
+background-opacity = {{ terminal_opacity }}
 foreground = {{ foreground }}
 cursor-color = {{ bright_foreground }}
 selection-background = {{ selection_background }}

--- a/default/themed/kitty.conf.tpl
+++ b/default/themed/kitty.conf.tpl
@@ -1,5 +1,6 @@
 foreground {{ foreground }}
 background {{ background }}
+background_opacity {{ terminal_opacity }}
 selection_foreground {{ selection_foreground }}
 selection_background {{ selection_background }}
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -67,9 +67,7 @@ What this does not cover: a theme distributed as an archive rather than a git re
 
 ## `colors.toml`
 
-`colors.toml` provides the palette and visual settings used by templates. Color
-keys are grouped semantic-first: accent/selection/muted, then the backgrounds,
-then the foregrounds, then the named colors:
+`colors.toml` provides the palette and visual settings used by templates. Color keys are grouped semantic-first: accent/selection/muted, then the backgrounds, then the foregrounds, then the named colors:
 
 ```toml
 mode = "dark"
@@ -93,13 +91,7 @@ red = "#f7768e"
 blue = "#7aa2f7"
 ```
 
-`terminal_opacity` controls the terminal emulator's default background
-translucency. It accepts a decimal from `0.0` (transparent) through `1.0`
-(opaque) and defaults to `1.0` when omitted or invalid. It is separate from
-Hyprland window opacity, which affects the whole window including its text.
-Running Foot windows keep the opacity they started with, so reopen Foot after a
-theme change to apply a new value. Existing windows in other terminals follow
-their emulator's normal configuration-reload behavior.
+`terminal_opacity` controls the terminal emulator's default background translucency. It accepts a decimal from `0.0` (transparent) through `1.0` (opaque) and defaults to `1.0` when omitted or invalid. It is separate from Hyprland window opacity, which affects the whole window including its text. Running Foot windows keep the opacity they started with, so reopen Foot after a theme change to apply a new value. Existing windows in other terminals follow their emulator's normal configuration-reload behavior.
 
 Any key can be referenced from a template with `{{ key }}`. The foundational
 shell palette is loaded from:

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -67,12 +67,13 @@ What this does not cover: a theme distributed as an archive rather than a git re
 
 ## `colors.toml`
 
-`colors.toml` provides the palette keys used by templates. Keys are grouped
-semantic-first: accent/selection/muted, then the backgrounds, then the
-foregrounds, then the named colors:
+`colors.toml` provides the palette and visual settings used by templates. Color
+keys are grouped semantic-first: accent/selection/muted, then the backgrounds,
+then the foregrounds, then the named colors:
 
 ```toml
 mode = "dark"
+terminal_opacity = "0.95"
 
 accent = "#7aa2f7"
 selection = "#292e42"
@@ -91,6 +92,14 @@ bright_foreground = "#c0caf5"
 red = "#f7768e"
 blue = "#7aa2f7"
 ```
+
+`terminal_opacity` controls the terminal emulator's default background
+translucency. It accepts a decimal from `0.0` (transparent) through `1.0`
+(opaque) and defaults to `1.0` when omitted or invalid. It is separate from
+Hyprland window opacity, which affects the whole window including its text.
+Running Foot windows keep the opacity they started with, so reopen Foot after a
+theme change to apply a new value. Existing windows in other terminals follow
+their emulator's normal configuration-reload behavior.
 
 Any key can be referenced from a template with `{{ key }}`. The foundational
 shell palette is loaded from:
@@ -374,7 +383,7 @@ local active_border_color = { colors = { "rgba(33ccffee)", "rgba(00ff99ee)" }, a
 ## Adding or overriding theme files
 
 - Add palette values to `themes/<name>/colors.toml`.
-- Hand-written overrides work everywhere except a `.lua`, a terminal config or a `vscode.json` in a theme cloned from a git repo; see [What an installed theme may not ship](#what-an-installed-theme-may-not-ship).
+- Hand-written overrides work everywhere except a `.lua`, a terminal config or a `vscode.json` in a theme cloned from a git repo; see [What an installed theme may not ship](#what-an-installed-theme-may-not-ship). A hand-written terminal config takes precedence over the generated `terminal_opacity` setting.
 - Prefer generated files when the theme can be expressed with templates.
 - Add a hand-written file in `themes/<name>/` only when that theme needs to
   override the generated output entirely.

--- a/test/cli
+++ b/test/cli
@@ -255,6 +255,7 @@ mkdir -p "$NEXT_THEME" "$CURRENT_THEME" "$USER_THEMED"
 
 cat >"$NEXT_THEME/colors.toml" <<'EOF'
 mode = "light"
+terminal_opacity = "0.78"
 accent = "#336699"
 hyprland_active_border = "rgba(010203ee) rgba(040506ee) 45deg"
 background = "#000000"
@@ -337,6 +338,12 @@ border = "#ffffff"
 EOF
 
 OMARCHY_PATH="$ROOT" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-templates"
+grep -qx 'opacity = 0.78' "$NEXT_THEME/alacritty.toml" || fail "Alacritty template uses terminal opacity"
+grep -qx 'alpha=0.78' "$NEXT_THEME/foot.ini" || fail "Foot template uses terminal opacity"
+grep -qx 'background-opacity = 0.78' "$NEXT_THEME/ghostty.conf" || fail "Ghostty template uses terminal opacity"
+grep -qx 'background_opacity 0.78' "$NEXT_THEME/kitty.conf" || fail "Kitty template uses terminal opacity"
+pass "terminal templates use the shared opacity token"
+
 grep -qx 'mix=#808080' "$NEXT_THEME/mix-test.txt" || fail "theme template mix helper works"
 grep -qx 'strip=808080' "$NEXT_THEME/mix-test.txt" || fail "theme template mix_strip helper works"
 grep -qx 'rgb=128,128,128' "$NEXT_THEME/mix-test.txt" || fail "theme template mix_rgb helper works"
@@ -364,6 +371,28 @@ grep -qx 'selection-background=#808080' "$NEXT_THEME/alias-test.txt" || fail "th
 grep -qx 'selection-foreground=#eeeeee' "$NEXT_THEME/alias-test.txt" || fail "theme template derives selection foreground from bright_foreground"
 grep -qx 'cursor-alias=#eeeeee' "$NEXT_THEME/alias-test.txt" || fail "theme template derives cursor alias from bright_foreground"
 pass "theme template semantic aliases expose legacy palette helpers"
+
+while read -r opacity expected; do
+  opacity_file="$PI_TMPDIR/opacity-$opacity.toml"
+  printf 'terminal_opacity = "%s"\n' "$opacity" >"$opacity_file"
+  actual=$("$ROOT/bin/omarchy-theme-color" --file "$opacity_file" terminal_opacity)
+  [[ $actual == "$expected" ]] || fail "terminal opacity resolves $opacity"
+done <<'EOF'
+0 0
+0.78 0.78
+1 1
+1.0 1.0
+EOF
+pass "terminal opacity accepts values from zero through one"
+
+for opacity in -0.1 1.1 transparent; do
+  opacity_file="$PI_TMPDIR/invalid-opacity-${opacity//[^a-zA-Z0-9]/-}.toml"
+  printf 'terminal_opacity = "%s"\n' "$opacity" >"$opacity_file"
+  actual=$("$ROOT/bin/omarchy-theme-color" --file "$opacity_file" terminal_opacity 2>"$PI_TMPDIR/opacity-stderr")
+  [[ $actual == "1.0" ]] || fail "invalid terminal opacity falls back to opaque"
+  grep -q 'invalid terminal_opacity' "$PI_TMPDIR/opacity-stderr" || fail "invalid terminal opacity reports its fallback"
+done
+pass "invalid terminal opacity warns and falls back to opaque"
 
 LEGACY_COLORS_FILE="$PI_TMPDIR/legacy-colors.toml"
 cat >"$LEGACY_COLORS_FILE" <<'EOF'
@@ -415,6 +444,10 @@ cp "$LEGACY_COLORS_FILE" "$LEGACY_NEXT_THEME/colors.toml"
 OMARCHY_PATH="$ROOT" HOME="$LEGACY_THEME_HOME" "$ROOT/bin/omarchy-theme-set-templates"
 grep -qx 'background = #101010' "$LEGACY_NEXT_THEME/ghostty.conf" || fail "legacy theme generates terminal background"
 grep -qx 'foreground = #f0f0f0' "$LEGACY_NEXT_THEME/ghostty.conf" || fail "legacy theme generates terminal foreground"
+grep -qx 'opacity = 1.0' "$LEGACY_NEXT_THEME/alacritty.toml" || fail "legacy Alacritty theme defaults to opaque"
+grep -qx 'alpha=1.0' "$LEGACY_NEXT_THEME/foot.ini" || fail "legacy Foot theme defaults to opaque"
+grep -qx 'background-opacity = 1.0' "$LEGACY_NEXT_THEME/ghostty.conf" || fail "legacy Ghostty theme defaults to opaque"
+grep -qx 'background_opacity 1.0' "$LEGACY_NEXT_THEME/kitty.conf" || fail "legacy Kitty theme defaults to opaque"
 grep -Fq 'dark_bg = "#111111"' "$LEGACY_NEXT_THEME/neovim.lua" || fail "legacy theme preserves dark_bg in generated editor theme"
 grep -Fq 'lighter_bg = "#131313"' "$LEGACY_NEXT_THEME/neovim.lua" || fail "legacy theme preserves lighter_bg in generated editor theme"
 grep -Fq 'dark_fg = "#d0d0d0"' "$LEGACY_NEXT_THEME/neovim.lua" || fail "legacy theme preserves dark_fg in generated editor theme"

--- a/test/shell.d/theme-staging-test.sh
+++ b/test/shell.d/theme-staging-test.sh
@@ -45,6 +45,7 @@ assert_no_marker() {
 write_colors() {
   cat >"$1" <<TOML
 mode = "light"
+terminal_opacity = "0.78"
 
 accent = "#7aa2f7"
 selection = "#292e42"
@@ -109,6 +110,10 @@ for generated in hyprland.lua neovim.lua gum_env.lua kitty.conf alacritty.toml f
   assert_staged "$generated" "$generated is generated from Omarchy's template"
   assert_no_marker "$generated" "an installed theme cannot supply $generated"
 done
+grep -qx 'opacity = 0.78' "$(staged alacritty.toml)" || fail "installed theme opacity reaches Alacritty's generated config"
+grep -qx 'alpha=0.78' "$(staged foot.ini)" || fail "installed theme opacity reaches Foot's generated config"
+grep -qx 'background-opacity = 0.78' "$(staged ghostty.conf)" || fail "installed theme opacity reaches Ghostty's generated config"
+grep -qx 'background_opacity 0.78' "$(staged kitty.conf)" || fail "installed theme opacity reaches Kitty's generated config"
 
 # Colour is kept, including a file Omarchy would otherwise have generated.
 assert_staged shell.toml "shell.toml is staged"
@@ -158,6 +163,7 @@ set_theme legacy || fail "omarchy-theme-set applies a theme that only ships alac
 assert_staged colors.toml "a legacy theme's palette is recovered from its alacritty.toml"
 grep -q '#102030' "$(staged colors.toml)" || fail "the recovered palette is the theme's"
 assert_no_marker alacritty.toml "a legacy theme's alacritty.toml is not staged"
+grep -qx 'opacity = 1.0' "$(staged alacritty.toml)" || fail "a legacy installed theme defaults to opaque"
 
 pass "a theme older than colors.toml keeps its palette and loses its terminal config"
 
@@ -179,10 +185,12 @@ mkdir -p "$mine"
 write_colors "$mine/colors.toml"
 printf 'os.execute("%s")\n' "$marker" >"$mine/hyprland.lua"
 printf '{"name":"Mine","extension":"pub.ext"}\n' >"$mine/vscode.json"
+printf '[colors-dark]\nalpha=0.42\n' >"$mine/foot.ini"
 
 set_theme mine || fail "omarchy-theme-set applies a theme the user wrote"
 grep -q "$marker" "$(staged hyprland.lua)" || fail "a theme the user wrote keeps its own hyprland.lua"
 assert_staged vscode.json "a theme the user wrote keeps every file it ships"
+grep -qx 'alpha=0.42' "$(staged foot.ini)" || fail "a theme the user wrote keeps its terminal config"
 [[ ! -s $test_tmp/stderr ]] || fail "a theme the user wrote reports nothing ignored" "$(cat "$test_tmp/stderr")"
 
 pass "a theme the user wrote is not held to the installed-theme list"


### PR DESCRIPTION
# Add terminal opacity to generated themes

Before Omarchy 4.0.1, themes could set terminal background transparency by shipping terminal config files. Omarchy 4.0.1 blocks those files in Git-installed themes because they can contain executable hooks, leaving installed themes without a safe way to set opacity. This PR adds a validated, data-only `terminal_opacity` value to `colors.toml` and uses it when generating terminal configs.

## What Is the Value of This?

Terminal background opacity lets wallpaper and blur show through without reducing the opacity of foreground text. Combined with Hyprland's blur settings, it gives theme authors finer control over the terminal's appearance, from a subtle haze to a more pronounced glass effect. That range helps themes develop a distinct visual character while keeping terminal text readable.

The Quickshell-based Omarchy Shell now offers detailed control over the transparency of its surfaces. Without a corresponding terminal setting, themes are limited to opaque terminal backgrounds or compositor opacity that fades the entire window. This token restores that missing layer of control and lets the terminal fit the rest of a theme more closely.

![Event Horizon terminal opacity comparison](https://raw.githubusercontent.com/OldJobobo/omarchy/pr-assets-8407/event-horizon-opacity-methods.png)

The Event Horizon comparison shows the practical difference:

- Left: terminal background alpha `0.45` with Hyprland window opacity `1.0`; foreground text remains opaque.
- Right: terminal background alpha `1.0` with Hyprland window opacity `0.45`; foreground text fades with the entire surface.
- Both captures use Foot 1.27.0 with the same text, palette, wallpaper, and window geometry.

<details>
<summary>Individual VM captures</summary>

### Opaque baseline

![Opaque Event Horizon terminal](https://raw.githubusercontent.com/OldJobobo/omarchy/pr-assets-8407/01-opaque-baseline.png)

### Terminal background opacity

![Event Horizon terminal with background opacity](https://raw.githubusercontent.com/OldJobobo/omarchy/pr-assets-8407/02-terminal-background-alpha.png)

### Hyprland whole-window opacity

![Event Horizon terminal with whole-window opacity](https://raw.githubusercontent.com/OldJobobo/omarchy/pr-assets-8407/03-hyprland-whole-window-alpha.png)

</details>

### Initial implementation evidence

An initial VM pass compared generated Foot configs using the compatibility default and the new token:

![Default opacity 1.0 compared with generated opacity 0.78](https://raw.githubusercontent.com/OldJobobo/omarchy/pr-assets-8407/terminal-opacity-pr-comparison.png)

The `0.78` capture was byte-identical before and after the existing color-only OSC sequence, confirming that this change leaves that path untouched.

## Summary

- add an optional `terminal_opacity` theme token with an opaque `1.0` default
- validate values from `0.0` through `1.0`, warning and falling back to `1.0` when invalid
- render the value into generated configs for Alacritty, Foot, Ghostty, and Kitty
- keep trusted hand-written terminal configs authoritative and continue filtering terminal configs from Git-installed themes
- document the difference from Hyprland whole-window opacity and Foot's existing-window limitation

## Behavior

Themes can now set:

```toml
terminal_opacity = "0.78"
```

Themes that omit the token remain opaque. This controls the terminal emulator's background rather than applying compositor opacity to text and the rest of the window.

Running Foot windows retain the opacity they started with and must be reopened after selecting a theme with a different value. The existing color-only OSC path is unchanged.

## Validation

Passed:

- `./test/cli`
- `bash test/shell.d/theme-staging-test.sh`
- `bash -n bin/omarchy-theme-color bin/omarchy-theme-set-templates`
- `foot --config=<generated-foot.ini> --check-config`
- `ghostty +validate-config --config-file=<generated-ghostty.conf>`
- `alacritty migrate --dry-run --silent --skip-imports --config-file <generated-alacritty.toml>`
- `git diff --check`
- VM visual comparison using Event Horizon installed through `omarchy theme install`
- Existing color-only OSC updates left terminal opacity unchanged

`./test/shell` ran all 206 shell test files. Five unrelated failures reproduce unchanged on a clean `origin/quattro` worktree at `0ae16948`:

- `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`: local `omarchy-pkgs` checkout unavailable
- `copy-url-shortcut-migration-test.sh`: existing mid-repair browser-start race assertion
- `runtime-smoke-test.sh`: existing duplicate IPC-handler count assertion

The VM comparison used Event Horizon installed from its Git repository through `omarchy theme install`. After adding `terminal_opacity = "0.45"` to the installed theme, Omarchy filtered its supplied terminal configs and regenerated Foot with the new value.
