### PR TITLE
Add an optional screensaver to the lock screen

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -169,6 +169,10 @@ Rules:
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+   `idle.lockScreensaver` draws the branding animation on the lock surface
+   itself; `idle.lockScreensaverDelay` is seconds after locking before it
+   appears, and `idle.lockScreensaverDuration` is how long it runs before the
+   display blanks, where `0` means it never blanks.
 8. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -80,6 +80,29 @@ Both numbers are seconds counted from the moment you went idle — not from each
 
 If you dismiss the screensaver before the lock deadline, that counts as activity and the pending lock is cancelled. You don't get locked out for glancing at your machine.
 
+### Keeping the screensaver on the lock screen
+
+The screensaver you see before the lock is a terminal window, and the lock screen draws over every window on the machine — so by default locking ends the animation and blanks the display. If you want something moving on screen while the machine is still locked, turn on the lock screensaver:
+
+```json
+{
+  "version": 1,
+  "idle": {
+    "screensaver": 150,
+    "lock": 300,
+    "lockScreensaver": true,
+    "lockScreensaverDelay": 20,
+    "lockScreensaverDuration": 0
+  }
+}
+```
+
+`lockScreensaverDelay` is how many seconds the ordinary lock screen stays up before the animation fades in, and `lockScreensaverDuration` is how long the animation runs before the display blanks — `0` means it never does, so it keeps going for as long as the machine stays locked. It draws the same branding art as the regular screensaver, so _Style > Screensaver_ changes both.
+
+The machine stays locked the whole time. Any key or a real mouse movement brings the password box straight back, and the keystroke you typed goes into it, so you can start typing your password without waiting for the animation to clear. `omarchy toggle screensaver` turns this off along with the regular one.
+
+Leaving it at `0` means the display never sleeps while locked, which is the point — but it is your monitor staying lit, not a screen blanking after a few seconds as it normally would.
+
 To stop locking on idle entirely, `Super + Ctrl + I` — or `omarchy toggle idle` — flips stay awake on, and the coffee cup indicator appears in the bar. That's the one to hit before a long presentation or a build you want to watch. Hit it again to go back to normal. `omarchy toggle idle status` prints the current state as JSON if you need it from a script.
 
 This is about locking and the screensaver, not power. Suspend and hibernation have their own setup in [system sleep](36-system-sleep.md).

--- a/shell/README.md
+++ b/shell/README.md
@@ -276,7 +276,11 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    entries with their own values.
 7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
    are seconds since user idle began, so the default lock fires at 300s
-   even if the 150s screensaver starts first.
+   even if the 150s screensaver starts first. `idle.lockScreensaver`
+   (default off) keeps a branding animation running on the lock surface,
+   with `idle.lockScreensaverDelay` seconds of lock screen before it starts
+   and `idle.lockScreensaverDuration` seconds before the display blanks —
+   `0`, the default, never blanks.
 8. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -17,6 +17,20 @@ Item {
   property string passwordText: ""
   property bool syncingPasswordText: false
 
+  // Lock-surface screensaver. `screensaverShowing` only changes what is
+  // painted: the password field stays enabled and focused underneath, so the
+  // first keystroke both dismisses the animation and starts the password.
+  property bool screensaverEnabled: false
+  property int screensaverDelaySec: 20
+  property string screensaverBrandingPath: ""
+  property bool screensaverPaused: false
+  property bool screensaverActive: false
+  readonly property bool screensaverShowing: screensaverEnabled && screensaverActive && !screensaverPaused
+  // Pointer jitter must not read as presence, or the animation never starts.
+  readonly property real pointerSlop: 40
+  property real lastPointerX: -1
+  property real lastPointerY: -1
+
   readonly property string placeholderText: "Enter Password"
   readonly property int fieldWidth: 381
   readonly property int fieldHeight: 67
@@ -60,6 +74,32 @@ Item {
     passwordTextEdited("")
   }
 
+  function noteActivity() {
+    if (root.screensaverActive) {
+      root.screensaverActive = false
+      // Re-baseline the pointer so the next move is measured from here.
+      root.lastPointerX = -1
+      root.lastPointerY = -1
+    }
+    if (root.screensaverEnabled) screensaverIdleTimer.restart()
+  }
+
+  function notePointer(x, y) {
+    if (root.lastPointerX < 0) {
+      root.lastPointerX = x
+      root.lastPointerY = y
+      return
+    }
+
+    var dx = x - root.lastPointerX
+    var dy = y - root.lastPointerY
+    if (Math.sqrt(dx * dx + dy * dy) < root.pointerSlop) return
+
+    root.lastPointerX = x
+    root.lastPointerY = y
+    root.noteActivity()
+  }
+
   function syncPasswordText() {
     if (passwordInput.text === passwordText) return
     syncingPasswordText = true
@@ -78,6 +118,14 @@ Item {
 
   // Measures the masked password at full size; passwordDotScale compares this
   // against the field width to decide how far the dots must shrink to fit.
+  Timer {
+    id: screensaverIdleTimer
+    interval: Math.max(1, root.screensaverDelaySec) * 1000
+    repeat: false
+    running: root.screensaverEnabled && !root.screensaverActive
+    onTriggered: if (root.screensaverEnabled) root.screensaverActive = true
+  }
+
   TextMetrics {
     id: dotMetrics
     font.family: Style.font.family
@@ -94,6 +142,7 @@ Item {
       id: wallpaper
       anchors.fill: parent
       source: root.loadBackground ? root.fileUrl(root.backgroundPath) : ""
+      visible: !root.screensaverShowing
       fillMode: Image.PreserveAspectCrop
       asynchronous: true
       cache: false
@@ -105,18 +154,30 @@ Item {
       anchors.fill: wallpaper
       source: wallpaper
       autoPaddingEnabled: false
-      blurEnabled: root.loadBackground && wallpaper.status === Image.Ready
+      visible: !root.screensaverShowing
+      blurEnabled: root.loadBackground && wallpaper.status === Image.Ready && !root.screensaverShowing
       blur: 1.0
       blurMax: 128
       blurMultiplier: 1.25
       contrast: -0.08
     }
 
+    Screensaver {
+      anchors.fill: parent
+      brandingPath: root.screensaverBrandingPath
+      opacity: root.screensaverShowing ? 1 : 0
+      visible: opacity > 0.01
+      Behavior on opacity { NumberAnimation { duration: 800; easing.type: Easing.InOutQuad } }
+    }
+
     MouseArea {
       anchors.fill: parent
       hoverEnabled: true
-      onClicked: { root.wakeRequested(); root.forcePasswordFocus() }
-      onPositionChanged: root.wakeRequested()
+      onClicked: { root.wakeRequested(); root.noteActivity(); root.forcePasswordFocus() }
+      onPositionChanged: function(mouse) {
+        root.wakeRequested()
+        root.notePointer(mouse.x, mouse.y)
+      }
     }
 
     BorderSurface {
@@ -128,6 +189,10 @@ Item {
       borderSpec: root.inputBorderSpec
       radius: Style.cornerRadius
       clip: true
+      // Faded, never hidden: an invisible TextInput cannot hold focus, and
+      // losing focus here would swallow the first keystroke of the password.
+      opacity: root.screensaverShowing ? 0 : 1
+      Behavior on opacity { NumberAnimation { duration: 500; easing.type: Easing.InOutQuad } }
 
       TextInput {
         id: passwordInput
@@ -176,6 +241,7 @@ Item {
 
         Keys.onPressed: function(event) {
           root.wakeRequested()
+          root.noteActivity()
           if (event.key === Qt.Key_Escape || (event.modifiers & Qt.ControlModifier && event.key === Qt.Key_U)) {
             root.passwordTextEdited("")
             event.accepted = true

--- a/shell/plugins/lock/Screensaver.qml
+++ b/shell/plugins/lock/Screensaver.qml
@@ -1,0 +1,165 @@
+import QtQuick
+import Quickshell.Io
+import qs.Commons
+
+// Animated branding drawn on the lock surface itself. The session lock renders
+// above every window, so the windowed screensaver can never show through it --
+// anything visible while locked has to be painted here.
+//
+// Deliberately input-transparent: it declares no MouseArea and takes no focus,
+// so the password field behind it keeps receiving every keystroke.
+Item {
+  id: root
+
+  property string brandingPath: ""
+
+  // Drives one cycle: 0 hidden, 1 fully drawn.
+  property real phase: 0
+  property int effect: 0
+  property color inkColor: Color.foreground
+  property string displayText: ""
+  // Position is stored as a 0..1 fraction of the free space rather than in
+  // pixels, so it is resolved against the block's current size. Pixels picked
+  // before the text had measured itself put the logo partly off-screen.
+  property real posFx: 0.5
+  property real posFy: 0.5
+
+  readonly property string logoText: {
+    var raw = brandingFile.loaded ? String(brandingFile.text() || "") : ""
+    // A trailing newline adds a blank row and skews the vertical centring.
+    return raw.replace(/\s+$/, "") || "omarchy"
+  }
+  readonly property var logoLines: logoText.split("\n")
+  readonly property int logoRows: Math.max(1, logoLines.length)
+  readonly property int logoCols: {
+    var widest = 0
+    for (var i = 0; i < logoLines.length; i++) widest = Math.max(widest, logoLines[i].length)
+    return Math.max(1, widest)
+  }
+
+  // Advance width per pixel of font size, measured rather than assumed.
+  readonly property real glyphRatio: glyphMetrics.advanceWidth > 0 ? glyphMetrics.advanceWidth / 100 : 0.6
+  // Constrained on both axes so tall art on a short screen still fits.
+  readonly property int glyphSize: {
+    var byWidth = (width * 0.5) / logoCols / Math.max(0.1, glyphRatio)
+    var byHeight = (height * 0.5) / logoRows
+    return Math.max(6, Math.floor(Math.min(byWidth, byHeight)))
+  }
+
+  readonly property real marginX: Math.max(40, width * 0.06)
+  readonly property real marginY: Math.max(40, height * 0.08)
+  readonly property var palette: [Color.foreground, Color.accent, Color.lock.borderActive, Color.muted]
+
+  function pickCycle() {
+    effect = Math.floor(Math.random() * 3)
+    inkColor = palette[Math.floor(Math.random() * palette.length)]
+    posFx = Math.random()
+    posFy = Math.random()
+    displayText = logoText
+  }
+
+  // Randomised glyphs settling into the real art, left to right.
+  function scrambled(source, progress) {
+    var pool = "▀▄█▌▐░▒▓/\\|_-=+*#"
+    var cut = Math.floor(source.length * progress)
+    var out = ""
+
+    for (var i = 0; i < source.length; i++) {
+      var c = source.charAt(i)
+      if (c === "\n" || c === " " || i < cut) out += c
+      else out += pool.charAt(Math.floor(Math.random() * pool.length))
+    }
+
+    return out
+  }
+
+  Component.onCompleted: pickCycle()
+
+  FileView {
+    id: brandingFile
+    path: root.brandingPath
+    watchChanges: true
+    printErrors: false
+  }
+
+  TextMetrics {
+    id: glyphMetrics
+    font.family: "monospace"
+    font.pixelSize: 100
+    text: "M"
+  }
+
+  Rectangle {
+    anchors.fill: parent
+    color: Color.background
+  }
+
+  Item {
+    id: block
+    width: logo.implicitWidth
+    height: logo.implicitHeight
+
+    // Slow wander on top of the per-cycle jump, so a held frame is never
+    // perfectly static on the panel.
+    property real driftX: 0
+    property real driftY: 0
+
+    // No Behavior on these: the block only moves while phase is 0, which is
+    // while it is invisible, so there is nothing to glide.
+    x: root.marginX + root.posFx * Math.max(0, root.width - width - root.marginX * 2) + driftX
+    y: root.marginY + root.posFy * Math.max(0, root.height - height - root.marginY * 2) + driftY
+
+    opacity: root.effect === 1 ? 1 : root.phase
+    scale: root.effect === 0 ? 0.94 + 0.06 * root.phase : 1
+
+    Text {
+      id: logo
+      // A single Text keeps the block art aligned; the effects act on the
+      // string or on the whole block, never on per-character items.
+      text: {
+        if (root.effect === 1) return root.logoText.substring(0, Math.ceil(root.logoText.length * root.phase))
+        if (root.effect === 2) return root.displayText
+        return root.logoText
+      }
+      font.family: "monospace"
+      font.pixelSize: root.glyphSize
+      color: root.inkColor
+      textFormat: Text.PlainText
+      lineHeight: 1.0
+      lineHeightMode: Text.ProportionalHeight
+      renderType: Text.NativeRendering
+    }
+  }
+
+  SequentialAnimation {
+    running: root.visible
+    loops: Animation.Infinite
+
+    ScriptAction { script: root.pickCycle() }
+    NumberAnimation { target: root; property: "phase"; from: 0; to: 1; duration: 2600; easing.type: Easing.OutCubic }
+    PauseAnimation { duration: 9000 }
+    NumberAnimation { target: root; property: "phase"; from: 1; to: 0; duration: 1100; easing.type: Easing.InCubic }
+    PauseAnimation { duration: 500 }
+  }
+
+  SequentialAnimation {
+    running: root.visible
+    loops: Animation.Infinite
+    ParallelAnimation {
+      NumberAnimation { target: block; property: "driftX"; to: 18; duration: 7000; easing.type: Easing.InOutSine }
+      NumberAnimation { target: block; property: "driftY"; to: -12; duration: 9000; easing.type: Easing.InOutSine }
+    }
+    ParallelAnimation {
+      NumberAnimation { target: block; property: "driftX"; to: -18; duration: 8000; easing.type: Easing.InOutSine }
+      NumberAnimation { target: block; property: "driftY"; to: 12; duration: 6000; easing.type: Easing.InOutSine }
+    }
+  }
+
+  Timer {
+    // Only ticks while a scramble is resolving.
+    running: root.visible && root.effect === 2 && root.phase < 1
+    interval: 55
+    repeat: true
+    onTriggered: root.displayText = root.scrambled(root.logoText, root.phase)
+  }
+}

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -11,6 +11,28 @@ Item {
   property var shell: null
   property string omarchyPath: ""
 
+  // Lock-surface screensaver settings, alongside the other idle timings in
+  // ~/.config/omarchy/shell.json under `idle`.
+  readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
+  // `omarchy toggle screensaver` opts out of the screensaver everywhere, so it
+  // opts out of this one too.
+  readonly property bool lockScreensaverEnabled: idleConfig.lockScreensaver === true && !screensaverToggledOff
+  readonly property int lockScreensaverDelaySec: {
+    var n = Number(idleConfig.lockScreensaverDelay)
+    return (!isFinite(n) || n < 1) ? 20 : Math.floor(n)
+  }
+  // How long the screensaver runs before the display is blanked. 0, the
+  // default, means it never blanks: it animates for as long as the session
+  // stays locked.
+  readonly property int lockScreensaverDurationSec: {
+    var n = Number(idleConfig.lockScreensaverDuration)
+    return (!isFinite(n) || n < 0) ? 0 : Math.floor(n)
+  }
+  readonly property bool lockScreensaverForever: lockScreensaverEnabled && lockScreensaverDurationSec === 0
+  readonly property string lockBrandingPath: home + "/.config/omarchy/branding/screensaver.txt"
+  property bool screensaverToggledOff: false
+  property bool displayBlanked: false
+
   readonly property string home: Quickshell.env("HOME")
   readonly property string stateHome: home + "/.local/state"
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
@@ -160,16 +182,24 @@ Item {
   }
 
   function armBlankTimer() {
+    // "Runs forever" means there is no blank deadline at all.
+    if (root.lockScreensaverForever) {
+      idleBlankTimer.stop()
+      return
+    }
+
     idleBlankTimer.armedAt = Date.now()
     idleBlankTimer.restart()
   }
 
   function runWake() {
+    root.displayBlanked = false
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
   }
 
   function runBlank() {
+    root.displayBlanked = true
     if (!blankProcess.running) blankProcess.running = true
   }
 
@@ -277,6 +307,10 @@ Item {
         inputEnabled: root.lockRequested
         loadBackground: root.locked
         passwordText: root.enteredPassword
+        screensaverEnabled: root.lockScreensaverEnabled
+        screensaverDelaySec: root.lockScreensaverDelaySec
+        screensaverBrandingPath: root.lockBrandingPath
+        screensaverPaused: root.displayBlanked
         onPasswordTextEdited: function(password) { root.enteredPassword = password }
         onSubmitPassword: function(password) { root.submitPassword(password) }
         onClearFailureRequested: root.failureMessage = ""
@@ -307,6 +341,9 @@ Item {
       inputEnabled: false
       loadBackground: root.previewVisible
       passwordText: ""
+      screensaverEnabled: root.lockScreensaverEnabled
+      screensaverDelaySec: root.lockScreensaverDelaySec
+      screensaverBrandingPath: root.lockBrandingPath
     }
 
     MouseArea {
@@ -413,7 +450,11 @@ Item {
 
   Timer {
     id: idleBlankTimer
-    interval: 5000
+    // The deadline is measured from the lock, so it has to cover the delay
+    // before the screensaver appears as well as its own run time.
+    interval: root.lockScreensaverEnabled
+      ? Math.max(1000, (root.lockScreensaverDelaySec + root.lockScreensaverDurationSec) * 1000)
+      : 5000
     repeat: false
     property double armedAt: 0
     onTriggered: {
@@ -479,6 +520,25 @@ Item {
     if (!lockRequested) return
     if (authenticatingPassword) idleBlankTimer.stop()
     else armBlankTimer()
+  }
+
+  FileView {
+    id: screensaverToggleFile
+    path: root.home + "/.local/state/omarchy/toggles/screensaver-off"
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.screensaverToggledOff = true
+    onLoadFailed: root.screensaverToggledOff = false
+    onFileChanged: reload()
+  }
+
+  FileView {
+    // The flag is created and deleted rather than edited, and a watcher on a
+    // missing file never fires on creation, so watch the directory too.
+    path: root.home + "/.local/state/omarchy/toggles"
+    watchChanges: true
+    printErrors: false
+    onFileChanged: screensaverToggleFile.reload()
   }
 
   FileView {


### PR DESCRIPTION
## The problem

There is currently no way to have anything on screen while the machine is locked. If you like the screensaver and want to leave it running, your only option is to not lock — which is exactly the wrong trade to make.

Three things enforce that today, and they are all deliberate:

- `bin/omarchy-system-lock` kills the screensaver on the way in — `pkill -x ttfx`, under the comment *"Avoid running screensaver when locked"*.
- Even if it survived, it could not be seen. The screensaver is a terminal window, and the session lock is an `ext-session-lock` surface (`WlSessionLock` in `shell/plugins/lock/Service.qml`) that renders above every window by design. The same applies to a `wlr-layer-shell` client, so #7193 does not change this.
- `launchScreensaver()` in the idle service short-circuits on `omarchy-shell lock isLocked`, so a cycle that starts while locked is skipped.

The consequence is that `idle.lock` is the only dial available, and turning it up far enough to keep the animation going means the machine effectively stops locking. On a desktop that gets left overnight, that is a real exposure — which is what prompted this.

## The approach

Rather than trying to keep a window alive over the lock, draw the animation **on the lock surface itself**, behind the password field. The session stays locked the entire time; nothing is layered over the lock and no window survives it.

`shell/plugins/lock/Screensaver.qml` is a new, input-transparent component: no `MouseArea`, no focus, so every keystroke still reaches the password field behind it. It renders the same `~/.config/omarchy/branding/screensaver.txt` art the windowed screensaver uses, so _Style > Screensaver_ continues to drive both. Each cycle picks one of three effects (fade-and-scale, typewriter reveal, scramble-resolve), a new colour from the theme palette, and a new screen position, so it is not a static logo burned into one spot.

## Configuration

New keys in the existing `idle` block of `shell.json`, all off by default:

```json
"idle": {
  "screensaver": 150,
  "lock": 300,
  "lockScreensaver": true,
  "lockScreensaverDelay": 20,
  "lockScreensaverDuration": 0
}
```

- `lockScreensaver` — off unless set to `true`. Absent keys mean stock behaviour, so `config/omarchy/shell.json` is untouched.
- `lockScreensaverDelay` — seconds of ordinary lock screen before the animation fades in.
- `lockScreensaverDuration` — seconds the animation runs before the display blanks. `0`, the default, never blanks: it runs for as long as the session stays locked.

`omarchy toggle screensaver` gates this too — someone who turned the screensaver off does not get one on their lock screen.

## Notes on the implementation

- The password field is **faded, not hidden**. An invisible `TextInput` cannot hold focus, and losing focus would swallow the first keystroke of the password. It sits at `opacity: 0` and stays enabled.
- Pointer motion only counts as presence past a 40px threshold. The lock view's existing `onPositionChanged` fires on any movement, and jitter from an optical mouse would otherwise stop the animation ever starting.
- The wallpaper `Image` and its blur `MultiEffect` are switched off while the animation is up. With `lockScreensaverDuration: 0` the display never blanks, so leaving a full-screen 128px blur compositing indefinitely would be a pointless load.
- `idleBlankTimer`'s interval now covers the delay plus the duration, since its deadline is measured from the lock rather than from when the animation starts.

## Verification

Verified in the running UI:

- The animation renders on the lock surface, repositions and recolours per cycle, and stays fully within the screen bounds across cycles.
- **The keystroke path**, which is the assertion the whole design rests on: with the animation showing and the field at `opacity: 0`, three simulated keystrokes (`wtype`) dismissed the animation and all three landed in the password field. Nothing was swallowed.
- The wallpaper and blur are correctly suppressed while animating and restored on dismissal.
- `./test/all` — 5 pre-existing failures on my machine (`bar-icon-geometry`, `config`, `snapper`, `theme-install-guards`, `unowned-system-paths`), identical with and without this change on a stashed tree. No regressions introduced.

Not verified, stated plainly:

- `lockScreensaverDuration > 0` — the blank path. The blank timer is only armed by a real lock, so it cannot be exercised through the lock preview.
- Developed and verified as an inlined variant inside `LockView.qml` in a user plugin directory, because sibling QML types do not resolve there. Submitted in the conventional shape as a sibling `Screensaver.qml`, matching how `Service.qml` already resolves `LockView`.

Happy to move this to a suggestions discussion instead if that is the preferred route for a feature of this size.
