### PR TITLE
Fix out-of-range group window shortcuts

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -91,7 +91,17 @@ o.bind("SUPER + ALT + mouse_down", "Next window in group", hl.dsp.group.next())
 o.bind("SUPER + ALT + mouse_up", "Previous window in group", hl.dsp.group.prev())
 
 for index = 1, 5 do
-  o.bind("SUPER + ALT + code:" .. tostring(index + 9), "Switch to group window " .. index, hl.dsp.group.active({ index = index }))
+  local group_index = index
+  local dispatcher = hl.dsp.group.active({ index = group_index })
+
+  o.bind("SUPER + ALT + code:" .. tostring(group_index + 9), "Switch to group window " .. group_index, function()
+    local window = hl.get_active_window()
+    local group = window and window.group
+
+    if group and group_index <= group.size then
+      hl.dispatch(dispatcher)
+    end
+  end)
 end
 
 o.bind("SUPER + SLASH", "Monitor scaling up", "omarchy-hyprland-monitor-scaling up")

--- a/test/shell.d/hyprland-group-bindings-test.sh
+++ b/test/shell.d/hyprland-group-bindings-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command lua
+
+OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local function proxy()
+  return setmetatable({}, {
+    __index = function(self, key)
+      local value = proxy()
+      rawset(self, key, value)
+      return value
+    end,
+    __call = function()
+      return {}
+    end,
+  })
+end
+
+local bindings = {}
+local active_window
+local dispatched_index
+
+hl = {
+  dsp = proxy(),
+  bind = function(keys, dispatcher)
+    bindings[keys] = dispatcher
+  end,
+  dispatch = function(dispatcher)
+    dispatched_index = dispatcher.index
+  end,
+  get_active_window = function()
+    return active_window
+  end,
+}
+
+hl.dsp.group.active = function(options)
+  return { index = options.index }
+end
+
+require("default.hypr.helpers")
+require("default.hypr.bindings.tiling")
+
+active_window = { group = { size = 2 } }
+bindings["SUPER + ALT + code:11"]()
+assert(dispatched_index == 2, "an available group window is selected")
+
+dispatched_index = nil
+bindings["SUPER + ALT + code:12"]()
+assert(dispatched_index == nil, "an out-of-range group window is ignored")
+
+active_window = nil
+bindings["SUPER + ALT + code:10"]()
+assert(dispatched_index == nil, "a group window shortcut outside a group is ignored")
+LUA
+
+pass "group number bindings dispatch only available group windows"

--- a/test/shell.d/hyprland-group-bindings-test.sh
+++ b/test/shell.d/hyprland-group-bindings-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 require_command lua


### PR DESCRIPTION
## Problem

Omarchy binds `Super + Alt + 1` through `Super + Alt + 5` directly to `hl.dsp.group.active`.

When the active group contains fewer windows than the selected index, Hyprland returns an `Index out of range` Lua runtime error. For example, with two windows in a group, `Super + Alt + 1` and `Super + Alt + 2` work, but pressing `Super + Alt + 3` produces an error notification. Repeated key presses can fill the screen with these notifications.
<img width="2875" height="1802" alt="screenshot-2026-08-26_22-39-18" src="https://github.com/user-attachments/assets/7ef800b1-59d8-409e-ade7-f93baec46e68" />
## Solution

Resolve the active window and its group when the shortcut is pressed, then dispatch the group switch only when the requested index is within `group.size`.

Valid group window shortcuts retain their existing behavior. Shortcuts targeting unavailable group positions, or used outside a window group, now safely do nothing.

This uses Hyprland's Lua window and group APIs directly instead of catching or matching runtime error messages.

## Testing

- Added a regression test covering valid, out-of-range, and ungrouped window shortcuts.
- Ran `bash test/shell.d/hyprland-group-bindings-test.sh`.
- Ran `bash test/shell.d/hyprland-binding-conflicts-test.sh`.
