### PR TITLE
Detect Microarray MAFP fingerprint reader

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -9,14 +9,17 @@
 # also make USB touchscreens) are left out to avoid nagging laptops with no
 # reader — those still match on the product string below when present.
 fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e "
+# The Microarray MAFP reader exposes only a generic product descriptor, so
+# match its libfprint-supported USB ID explicitly.
+fingerprint_devices=" 3274:8012 "
 usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
 
 # libfprint drives every reader it supports from userspace over libusb, so a
 # real reader sits there with no kernel driver bound to any of its interfaces.
 # The other things these vendors build — Synaptics webcam bridges (usbio-bridge
 # on the Dell XPS 14), touchpads and touchscreens (usbhid), cameras (uvcvideo)
-# — all bind one. Only the vendor-ID guess needs this; a device that names
-# itself a fingerprint reader is trusted outright.
+# — all bind one. ID-based matches need this check; a device that names itself
+# a fingerprint reader is trusted outright.
 has_kernel_driver() {
   local intf driver
   for intf in "$1"/*:*; do
@@ -46,8 +49,11 @@ for dev in "$usb_devices_path"/*; do
     [[ $product == *fingerprint* || $product == *biometric* || $product == *elan:arm-m4* || $product == "fpc "* ]] && exit 0
   fi
 
-  if [[ -r $dev/idVendor ]]; then
+  if [[ -r $dev/idVendor && -r $dev/idProduct ]]; then
     vendor=$(<"$dev/idVendor")
+    product_id=$(<"$dev/idProduct")
+    [[ $fingerprint_devices == *" $vendor:$product_id "* ]] &&
+      ! has_kernel_driver "$dev" && exit 0
     [[ $fingerprint_vendors == *" $vendor "* ]] &&
       ! has_kernel_driver "$dev" && exit 0
   fi

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -71,6 +71,12 @@ assert_rejects "an FPC token mid-string is not detected"
 write_usb_devices '1234:5678:Goodix Fingerprint USB Device'
 assert_detects "a reader is detected by an existing product-name match"
 
+write_usb_devices '3274:8012:MAFP General Device'
+assert_detects "a Microarray MAFP reader is detected by its exact USB ID"
+
+write_usb_devices '3274:1234:Generic USB Device'
+assert_rejects "an unknown Microarray USB device is not detected"
+
 write_usb_devices '27c6:1234'
 assert_detects "a reader is detected by an existing vendor match"
 
@@ -90,6 +96,14 @@ assert_rejects "a vendor guess bound to a kernel driver is rejected"
 write_usb_devices '27c6:1234'
 bind_driver '1-0/1-0:1.0' usbfs
 assert_detects "a vendor guess claimed through usbfs is still detected"
+
+write_usb_devices '3274:8012:MAFP General Device'
+bind_driver '1-0/1-0:1.0' usbfs
+assert_detects "an exact reader match claimed through usbfs is still detected"
+
+write_usb_devices '3274:8012:MAFP General Device'
+bind_driver '1-0/1-0:1.0' usbhid
+assert_rejects "an exact reader match bound to a kernel driver is rejected"
 
 write_usb_devices '27c6:1234'
 bind_driver '1-0/1-0:1.0' usbfs


### PR DESCRIPTION
Add fingerprint-reader detection for the Microarray MAFP match-on-chip sensor with USB ID `3274:8012`.

Support for this device was added to libfprint in version `1.94.100`. The device identifies itself as `MAFP General Device`, so Omarchy's product-name heuristics do not recognize it.

The detector now matches its exact USB ID while retaining the existing kernel-driver guard.

## Testing

Tested manually on physical `3274:8012` hardware with libfprint `1.94.100`:

- Patched `omarchy-hw-fingerprint` detects the reader
- `fprintd` identifies it as `MAFP MOC Fingerprint Sensor`
- Fingerprint enrollment completes successfully
- Fingerprint verification matches successfully
- Fingerprint authentication works with `sudo`

Added automated coverage for:

- Detecting `3274:8012` by its exact USB ID
- Rejecting an unknown device from vendor `3274`
- Accepting a reader claimed through `usbfs`
- Rejecting the device when bound to a real kernel driver
  
## There are more

There are more fingerprints readers in this library that may work but I have only this one to test, so I added only this one for now. It is builtin fingerprint reader from AOOSTAR MACO AMD R7 H255 MINI PC.