### PR TITLE
Fix Obsidian window not focusing due to app id mismatch

### DIFF
--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -15,7 +15,7 @@ if o.preinstalled_bindings_enabled() then
   o.bind("SUPER + SHIFT + ALT + M", "Music TUI", { tui = "cliamp", focus = true })
   o.bind("SUPER + SHIFT + D", "Docker", { tui = "omarchy-launch-docker-tui" })
   o.bind("SUPER + SHIFT + G", "Signal", { omarchy = "signal" })
-  o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "^obsidian$" })
+  o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "^md.obsidian.Obsidian$" })
   o.bind("SUPER + SHIFT + W", "Omawrite", { launch = "omawrite" })
   o.bind("SUPER + SHIFT + SLASH", "Passwords", { omarchy = "1password" })
 
@@ -23,10 +23,18 @@ if o.preinstalled_bindings_enabled() then
   o.bind("SUPER + SHIFT + ALT + A", "Grok", { webapp = "https://grok.com" })
   o.bind("SUPER + SHIFT + C", "Calendar", { webapp = "https://app.hey.com/calendar/weeks/" })
   o.bind("SUPER + SHIFT + E", "Email", { webapp = "https://app.hey.com" })
-  o.bind("SUPER + SHIFT + ALT + E", "New email", { webapp = "https://app.hey.com/messages/new?display=standalone&new_window=true" })
+  o.bind(
+    "SUPER + SHIFT + ALT + E",
+    "New email",
+    { webapp = "https://app.hey.com/messages/new?display=standalone&new_window=true" }
+  )
   o.bind("SUPER + SHIFT + Y", "YouTube", { webapp = "https://youtube.com/" })
   o.bind("SUPER + SHIFT + ALT + G", "WhatsApp", { webapp = "https://web.whatsapp.com/", focus = true })
-  o.bind( "SUPER + SHIFT + CTRL + G", "Google Messages", { webapp = "https://messages.google.com/web/conversations", focus = true })
+  o.bind(
+    "SUPER + SHIFT + CTRL + G",
+    "Google Messages",
+    { webapp = "https://messages.google.com/web/conversations", focus = true }
+  )
   o.bind("SUPER + SHIFT + P", "Google Photos", { webapp = "https://photos.google.com/", focus = true })
   o.bind("SUPER + SHIFT + S", "Google Maps", { webapp = "https://maps.google.com/", focus = true })
   o.bind("SUPER + SHIFT + X", "X", { webapp = "https://x.com/" })


### PR DESCRIPTION
Fixed `SUPER + SHIFT + O` not focusing an already-open Obsidian window.

The bind matched `focus = "^obsidian$"`, but Obsidian's window class/appid
isn't a fixed string — it varies per vault, so it almost never matches.
`initialclass` stays `md.obsidian.Obsidian` regardless of which vault is
open, so this switches the match to that instead.