### PR TITLE
[Security] Give the Battle.net installer log an unpredictable private path

### DIFF
--- a/bin/omarchy-install-gaming-battlenet
+++ b/bin/omarchy-install-gaming-battlenet
@@ -57,7 +57,12 @@ app launcher.
 
 EOF
 
-  log="/tmp/omarchy-battlenet-installer.log"
+  # The wizard writes its whole transcript here while it runs. A fixed name in
+  # world-writable /tmp lets any other local account pre-plant a symlink at it
+  # and have the wizard's output written through to a file of their choosing,
+  # or read the log from outside. mktemp's file is unpredictable and 0600,
+  # which is the boundary.
+  log=$(mktemp "${TMPDIR:-/tmp}/omarchy-battlenet-installer.XXXXXXXX")
   setsid -f sh -c "umu-run '$installer' >'$log' 2>&1" </dev/null >/dev/null 2>&1
   echo "Installer log: $log"
   launched_installer=1

--- a/test/shell.d/battlenet-installer-log-test.sh
+++ b/test/shell.d/battlenet-installer-log-test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin" "$tmp_dir/home" "$tmp_dir/tmpdir"
+
+for stub in omarchy-pkg-add omarchy-install-gaming-gpu-lib32 update-desktop-database; do
+  printf '#!/bin/bash\nexit 0\n' >"$stub_bin/$stub"
+done
+
+# The real download is a Windows installer fetched over the network; hand curl
+# a stub that just creates the file it was told to write.
+cat >"$stub_bin/curl" <<'SH'
+#!/bin/bash
+out=""
+grab=0
+for arg in "$@"; do
+  if ((grab)); then out="$arg"; grab=0; fi
+  [[ $arg == "--output" ]] && grab=1
+done
+[[ -n $out ]] && : >"$out"
+SH
+
+# setsid -f detaches the wizard; run it in the foreground instead so the
+# transcript is complete before the assertions look at it.
+cat >"$stub_bin/setsid" <<'SH'
+#!/bin/bash
+[[ ${1:-} == "-f" ]] && shift
+exec "$@"
+SH
+
+cat >"$stub_bin/umu-run" <<'SH'
+#!/bin/bash
+printf 'stub installer output\n'
+SH
+
+chmod +x "$stub_bin"/*
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+export HOME="$tmp_dir/home"
+export OMARCHY_PATH="$ROOT"
+export TMPDIR="$tmp_dir/tmpdir"
+
+output=$("$ROOT/bin/omarchy-install-gaming-battlenet" 2>&1)
+
+log=$(grep '^Installer log: ' <<<"$output" | head -n1 | sed 's/^Installer log: //')
+[[ -n $log ]] ||
+  fail "the installer still reports where its log went" "$output"
+pass "the installer still reports where its log went"
+
+[[ $log != "/tmp/omarchy-battlenet-installer.log" ]] ||
+  fail "the installer log is not a fixed world-writable name" "$log"
+pass "the installer log is not a fixed world-writable name"
+
+[[ $log == "$TMPDIR"/omarchy-battlenet-installer.* ]] ||
+  fail "the installer log is an unpredictable name under TMPDIR" "$log"
+pass "the installer log is an unpredictable name under TMPDIR"
+
+[[ -f $log && $(<"$log") == *"stub installer output"* ]] ||
+  fail "the wizard's output still lands in the log" "${log:+$(<"$log")}"
+pass "the wizard's output still lands in the log"
+
+mode=$(stat -c '%a' "$log" 2>/dev/null || stat -f '%Lp' "$log")
+[[ $mode == "600" ]] ||
+  fail "the installer log is readable only by its owner" "mode: $mode"
+pass "the installer log is readable only by its owner"
+
+if grep -q '/tmp/omarchy-battlenet-installer.log' "$ROOT/bin/omarchy-install-gaming-battlenet"; then
+  fail "the installer script no longer names a world-writable log path"
+fi
+pass "the installer script no longer names a world-writable log path"


### PR DESCRIPTION
## Summary

The Battle.net wizard's transcript went to the fixed name `/tmp/omarchy-battlenet-installer.log`. Any other local account can pre-plant a symlink at that path and have the wizard's output written through to a file of their choosing (as the user running the installer), or simply read the log from outside while the install runs.

Same class as #8367 and #8372 (predictable `/tmp` staging), in a file neither of those fixes covers.

## Change

`mktemp "${TMPDIR:-/tmp}/omarchy-battlenet-installer.XXXXXXXX"` — an unpredictable file created `0600`; the `>` redirect inside the wizard's shell truncates it without changing its mode. The "Installer log:" line still prints, so the reported path keeps working.

## Scope

Local multi-user attack surface (symlink clobber as the installing user). Single-user machines are unaffected.

## Test

`test/shell.d/battlenet-installer-log-test.sh` — runs the installer with stubbed `curl`/`umu-run`/`setsid` and covers: the log path is still reported, is not the fixed `/tmp` name, is an unpredictable name under `TMPDIR`, still receives the wizard's output, is `0600`, and that the script no longer names the world-writable path.

Mutation-checked: restoring the fixed name fails the suite. The pre-existing `battlenet-test` and `bin-style-test` still pass.
