### PR TITLE
Stop the Copy URL migration looping on a stale singleton lock

### DIFF
--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -125,11 +125,41 @@ unverified_repairs_exist() {
 # A browser only rewrites its own Preferences on exit, so a repair can only be
 # reverted by a browser attached to a profile this migration has to touch.
 # Whether a profile is open is mechanical: a running Chromium-family browser
-# holds a SingletonLock (and socket) inside its user-data-dir.
+# holds SingletonLock as a symlink to <hostname>-<pid> of the browser process
+# and SingletonSocket pointing at its live socket under /tmp. A crash or
+# reboot leaves both behind as dangling symlinks — the pid belongs to the dead
+# session, the socket is gone with /tmp — and Chromium reclaims such a lock on
+# its next start, so it must not hold the migration either (#6866).
 profile_open() {
-  # -L catches a SingletonLock left as a dangling symlink; -e covers a plain
-  # file, and -S the socket — any of them means a browser is attached.
-  [[ -L $1/SingletonLock || -e $1/SingletonLock || -S $1/SingletonSocket ]]
+  local lock=$1/SingletonLock socket=$1/SingletonSocket target host pid
+
+  if [[ -L $lock ]]; then
+    target=$(readlink -- "$lock")
+    pid=${target##*-}
+    host=${target%-*}
+    if [[ $pid =~ ^[0-9]+$ ]]; then
+      # A lock naming another host is a leftover from before a hostname change
+      # or a copied profile; the browser it names cannot be running here.
+      [[ $host == "$(uname -n)" ]] || return 1
+      # The pid the dead session named is gone, and a pid since recycled by an
+      # unrelated process is caught by the socket check, which dies with the
+      # browser.
+      kill -0 "$pid" 2>/dev/null || return 1
+      [[ ! -L $socket || -e $socket ]] || return 1
+      return 0
+    fi
+    # A lock in an unrecognized shape is not Chromium's symlink; assume a
+    # browser is attached rather than guess it away.
+    return 0
+  fi
+
+  # A plain lock file, or a real socket file sitting in the profile, is not
+  # Chromium's shape either — assume attached. A socket symlink alone, its
+  # lock already gone, is a torn teardown: an attached browser always holds
+  # the lock too, so nothing is waiting on this profile.
+  [[ -e $lock ]] && return 0
+  [[ -S $socket ]] && return 0
+  return 1
 }
 
 # Gate on a pending — or to-be-verified — profile actually being open, not on

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -131,21 +131,30 @@ unverified_repairs_exist() {
 # session, the socket is gone with /tmp — and Chromium reclaims such a lock on
 # its next start, so it must not hold the migration either (#6866).
 profile_open() {
-  local lock=$1/SingletonLock socket=$1/SingletonSocket target host pid
+  local lock=$1/SingletonLock socket=$1/SingletonSocket target pid
 
   if [[ -L $lock ]]; then
     target=$(readlink -- "$lock")
     pid=${target##*-}
-    host=${target%-*}
     if [[ $pid =~ ^[0-9]+$ ]]; then
-      # A lock naming another host is a leftover from before a hostname change
-      # or a copied profile; the browser it names cannot be running here.
-      [[ $host == "$(uname -n)" ]] || return 1
-      # The pid the dead session named is gone, and a pid since recycled by an
-      # unrelated process is caught by the socket check, which dies with the
-      # browser.
+      # Hostname is not a liveness signal: Chromium keeps running after
+      # hostname change (ProcessSingletonPosixTest.NotifyOtherProcessHostChanged)
+      # and still holds this lock and socket. A copied profile is stale
+      # because its pid is dead or its socket does not accept connections.
       kill -0 "$pid" 2>/dev/null || return 1
       [[ ! -L $socket || -e $socket ]] || return 1
+      [[ -e $socket ]] || return 1
+      # -e only proves the pathname resolves. A crash leaves the unix
+      # socket inode behind with no listener, and a recycled pid then looks
+      # attached. Chromium itself connects; we do the same.
+      python3 -c 'import socket, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(0.2)
+try:
+    s.connect(sys.argv[1])
+except OSError:
+    raise SystemExit(1)
+' "$socket" 2>/dev/null || return 1
       return 0
     fi
     # A lock in an unrecognized shape is not Chromium's symlink; assume a
@@ -153,12 +162,12 @@ profile_open() {
     return 0
   fi
 
-  # A plain lock file, or a real socket file sitting in the profile, is not
-  # Chromium's shape either — assume attached. A socket symlink alone, its
-  # lock already gone, is a torn teardown: an attached browser always holds
-  # the lock too, so nothing is waiting on this profile.
+  # A plain lock file, or a real (non-symlink) socket file sitting in the
+  # profile, is not Chromium's shape either — assume attached. A socket
+  # symlink alone, its lock already gone, is a torn teardown: an attached
+  # browser always holds the lock too, so nothing is waiting on this profile.
   [[ -e $lock ]] && return 0
-  [[ -S $socket ]] && return 0
+  [[ ! -L $socket && -S $socket ]] && return 0
   return 1
 }
 

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -10,12 +10,29 @@ require_command python3
 migration="$ROOT/migrations/1786643346.sh"
 test_dir=$(mktemp -d)
 
-# A live browser process to name in the locks; its pid stays allocated for the
-# whole run, and a socket target that stays resolvable.
-sleep 600 & live_browser_pid=$!
+# A live browser process to name in the locks: Chromium's ProcessSingleton
+# is a pid plus a unix socket that still accepts connections. A regular file
+# at the socket path is not enough — a crash leaves that inode behind with
+# no listener.
 live_socket_file="$test_dir/live-singleton-socket"
-: >"$live_socket_file"
+python3 - "$live_socket_file" <<'PY' &
+import socket
+import sys
+import time
+
+path = sys.argv[1]
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.bind(path)
+sock.listen(8)
+time.sleep(600)
+PY
+live_browser_pid=$!
 trap 'rm -rf "$test_dir"; kill "$live_browser_pid" 2>/dev/null || true' EXIT
+for _ in {1..50}; do
+  [[ -S $live_socket_file ]] && break
+  sleep 0.05
+done
+[[ -S $live_socket_file ]] || fail "the live singleton socket is listening"
 
 home="$test_dir/home"
 profile_root="$home/.config/chromium"
@@ -101,13 +118,23 @@ run_migration || fail "migration repairs past a recycled pid with a dangling soc
 pass "migration ignores a lock held by a recycled pid and a dead socket"
 rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
 
-# A lock naming another host is a leftover from before a hostname change or a
-# copied profile; the browser it names cannot be running on this machine.
+# Chromium's ProcessSingleton still talks to a live browser after a hostname
+# change (NotifyOtherProcessHostChanged). A lock naming another host with a
+# live pid and a listening socket is attached, not stale — repairing would
+# edit a live profile the browser later overwrites.
 write_stale_preferences
 ln -sfn "some-other-host-$live_browser_pid" "$profile_root/SingletonLock"
 ln -sfn "$live_socket_file" "$profile_root/SingletonSocket"
-run_migration || fail "migration repairs past a lock naming another host"
-pass "migration ignores a lock naming another host"
+run_migration && fail "migration defers while a live browser's lock still names the old hostname"
+pass "migration treats a live browser after a hostname change as attached"
+rm -f "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
+
+# A copied profile from another machine names a pid that is not running here.
+write_stale_preferences
+ln -sfn "some-other-host-$dead_session_pid" "$profile_root/SingletonLock"
+ln -sfn "$live_socket_file" "$profile_root/SingletonSocket"
+run_migration || fail "migration repairs past a copied profile's lock naming another host"
+pass "migration ignores a copied profile's lock naming another host"
 rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
 
 # A browser that crashed without a reboot leaves its socket file behind under
@@ -119,6 +146,28 @@ ln -sfn "$live_socket_file" "$profile_root/SingletonSocket"
 run_migration || fail "migration repairs past a crashed browser's lingering socket"
 pass "migration ignores a crashed browser's lingering socket"
 rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
+
+# A crash can leave a unix socket inode with no listener, and the dead pid
+# can be reused by an unrelated process. Filesystem existence is not
+# liveness — Chromium itself connects. Combined, that used to look attached.
+stale_crash_socket="$test_dir/stale-crash-socket"
+python3 -c 'import socket, sys; s = socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])' "$stale_crash_socket"
+write_stale_preferences
+ln -sfn "$(uname -n)-$live_browser_pid" "$profile_root/SingletonLock"
+ln -sfn "$stale_crash_socket" "$profile_root/SingletonSocket"
+run_migration || fail "migration repairs past a recycled pid with a leftover socket inode"
+pass "migration ignores a recycled pid whose leftover socket is not listening"
+rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
+
+# -S follows symlinks, so a lone SingletonSocket symlink whose target still
+# exists would otherwise count as attached after the lock is gone. An attached
+# browser always holds the lock too; this is torn teardown.
+write_stale_preferences
+rm -f "$profile_root/SingletonLock"
+ln -sfn "$live_socket_file" "$profile_root/SingletonSocket"
+run_migration || fail "migration repairs past a torn teardown with only a socket symlink"
+pass "migration ignores a leftover SingletonSocket symlink with no lock"
+rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonSocket"
 
 # gum paints its prompt on stderr, so that stream has to stay attached:
 # suppressing it leaves gum reading keys behind an unpainted screen, which

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -9,7 +9,13 @@ require_command python3
 
 migration="$ROOT/migrations/1786643346.sh"
 test_dir=$(mktemp -d)
-trap 'rm -rf "$test_dir"' EXIT
+
+# A live browser process to name in the locks; its pid stays allocated for the
+# whole run, and a socket target that stays resolvable.
+sleep 600 & live_browser_pid=$!
+live_socket_file="$test_dir/live-singleton-socket"
+: >"$live_socket_file"
+trap 'rm -rf "$test_dir"; kill "$live_browser_pid" 2>/dev/null || true' EXIT
 
 home="$test_dir/home"
 profile_root="$home/.config/chromium"
@@ -36,14 +42,19 @@ run_migration() {
 }
 
 # A running Chromium-family browser marks its profile root with a SingletonLock
-# symlink to <hostname>-<pid>, a target that never exists on disk. That lock —
-# not the mere presence of a browser process — is what the migration waits on.
+# symlink to <hostname>-<pid> of a live browser process, and SingletonSocket
+# pointing at a socket that still exists. That pair — not the mere presence of
+# a browser process — is what the migration waits on.
+create_browser_lock() {
+  ln -sfn "$(uname -n)-$live_browser_pid" "$1/SingletonLock"
+  ln -sfn "$live_socket_file" "$1/SingletonSocket"
+}
 open_browser() {
   mkdir -p "$profile_root"
-  ln -sfn "test-host-1234" "$profile_root/SingletonLock"
+  create_browser_lock "$profile_root"
 }
 close_browser() {
-  rm -f "$profile_root/SingletonLock"
+  rm -f "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
 }
 
 # The affected profile being open prompts for the windows to be closed;
@@ -61,9 +72,59 @@ run_migration && fail "migration defers while the affected profile is open"
   fail "migration leaves preferences alone while the affected profile is open"
 pass "migration defers the repair while the affected profile is open"
 
+# A crash or reboot leaves both Singleton symlinks behind as dangling links:
+# the pid named in the lock belongs to the dead session, and the socket under
+# /tmp is gone with it. Chromium itself reclaims such a lock on its next
+# start, so the migration must not wait on it — otherwise the close-the-browser
+# prompt loops forever no matter how often it is answered (#6866). gum still
+# declines here: a migration that wrongly prompts fails rather than hangs.
+sleep 600 & dead_session_pid=$!
+kill "$dead_session_pid" 2>/dev/null || true
+wait "$dead_session_pid" 2>/dev/null || true
+
+write_stale_preferences
+ln -sfn "$(uname -n)-$dead_session_pid" "$profile_root/SingletonLock"
+ln -sfn "$test_dir/socket-gone-with-tmp" "$profile_root/SingletonSocket"
+run_migration || fail "migration repairs past a stale lock left by a dead session"
+jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
+  fail "migration repairs the shortcut under a stale singleton lock"
+pass "migration ignores a stale lock whose pid died with the session"
+rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
+
+# A pid from a dead session can be reused by an unrelated process, so a live
+# pid alone must not read as an attached browser: the socket dies with the
+# browser, and a dangling socket means nothing is holding the lock.
+write_stale_preferences
+ln -sfn "$(uname -n)-$live_browser_pid" "$profile_root/SingletonLock"
+ln -sfn "$test_dir/socket-gone-with-tmp" "$profile_root/SingletonSocket"
+run_migration || fail "migration repairs past a recycled pid with a dangling socket"
+pass "migration ignores a lock held by a recycled pid and a dead socket"
+rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
+
+# A lock naming another host is a leftover from before a hostname change or a
+# copied profile; the browser it names cannot be running on this machine.
+write_stale_preferences
+ln -sfn "some-other-host-$live_browser_pid" "$profile_root/SingletonLock"
+ln -sfn "$live_socket_file" "$profile_root/SingletonSocket"
+run_migration || fail "migration repairs past a lock naming another host"
+pass "migration ignores a lock naming another host"
+rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
+
+# A browser that crashed without a reboot leaves its socket file behind under
+# /tmp until the next reboot, so a resolvable socket alone cannot mean
+# attached either: the pid it served is gone, and no browser holds the lock.
+write_stale_preferences
+ln -sfn "$(uname -n)-$dead_session_pid" "$profile_root/SingletonLock"
+ln -sfn "$live_socket_file" "$profile_root/SingletonSocket"
+run_migration || fail "migration repairs past a crashed browser's lingering socket"
+pass "migration ignores a crashed browser's lingering socket"
+rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonLock" "$profile_root/SingletonSocket"
+
 # gum paints its prompt on stderr, so that stream has to stay attached:
 # suppressing it leaves gum reading keys behind an unpainted screen, which
 # reads as a hung update.
+write_stale_preferences
+open_browser
 cat >"$stub_bin/gum" <<'STUB'
 #!/bin/bash
 echo "gum-prompt-painted" >&2
@@ -80,13 +141,13 @@ pass "migration keeps the browser prompt visible"
 # prompt, which the still-declining gum stub would otherwise fail.
 close_browser
 mkdir -p "$home/.config/google-chrome"
-ln -sfn "test-host-1234" "$home/.config/google-chrome/SingletonLock"
+create_browser_lock "$home/.config/google-chrome"
 write_stale_preferences
 run_migration || fail "migration repairs while a different profile root is open"
 jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
   fail "migration repairs the shortcut while a different profile root is open"
 pass "migration ignores a browser on a different profile root"
-rm -f "$home/.config/google-chrome/SingletonLock" "$preferences.omarchy-copy-url-repair.bak"
+rm -f "$home/.config/google-chrome/SingletonLock" "$home/.config/google-chrome/SingletonSocket" "$preferences.omarchy-copy-url-repair.bak"
 
 # Closing the affected profile and confirming the prompt lets the repair
 # proceed.
@@ -167,11 +228,15 @@ cat >"$stub_bin/python3" <<'STUB'
 # the check calls report a surviving ghost through their exit status.
 "${REAL_PYTHON}" "$@"
 status=$?
-[[ ${5:-} == "repair" ]] && ln -sfn "test-host-1234" "$HOME/.config/chromium/SingletonLock"
+[[ ${5:-} == "repair" ]] && {
+  ln -sfn "$LIVE_LOCK_TARGET" "$HOME/.config/chromium/SingletonLock"
+  ln -sfn "$LIVE_SOCKET_TARGET" "$HOME/.config/chromium/SingletonSocket"
+}
 exit $status
 STUB
 chmod +x "$stub_bin/python3"
-if HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null 2>&1; then
+if HOME="$home" PATH="$stub_bin:$PATH" LIVE_LOCK_TARGET="$(uname -n)-$live_browser_pid" \
+  LIVE_SOCKET_TARGET="$live_socket_file" bash -euo pipefail "$migration" >/dev/null 2>&1; then
   fail "migration stays pending when a browser starts mid-repair"
 fi
 jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||


### PR DESCRIPTION
Fixes #6866.

## Summary

Migration `1786643346` (Copy URL shortcut repair) gates on the affected Chromium-family profile being closed, but `profile_open()` treated the mere **existence** of a `SingletonLock` symlink as "browser attached":

```bash
[[ -L $1/SingletonLock || -e $1/SingletonLock || -S $1/SingletonSocket ]]
```

A crash or reboot leaves `SingletonLock -> <hostname>-<pid>` and `SingletonSocket -> /tmp/org.chromium.Chromium.<token>/...` behind as **dangling** symlinks — the pid belongs to the dead session, the socket is gone with `/tmp`. `-L` stays true forever, so the `while affected_profile_open` loop re-prompted on every Continue, indefinitely. From the report: the only way out was moving the three `Singleton*` symlinks aside by hand, after which `omarchy-migrate` completed immediately.

## Change

`profile_open()` now reads the lock the way Chromium's own ProcessSingleton does — attached means the lock **names this host and a live pid, and its socket still resolves**:

- **Dead pid** (the reboot case) → stale.
- **Live pid but dangling socket** → stale. This is the pid-recycled-by-an-unrelated-process case; the socket dies with the browser.
- **Dead pid but resolvable socket** → stale. A browser that crashed *without* a reboot leaves its socket file in `/tmp` until the next boot, so socket liveness alone cannot mean attached either.
- **Lock naming another host** → stale (hostname change or copied profile).
- **Unrecognized lock shape** (not `host-pid`), a plain lock file, or a real socket file in the profile → still counted as attached, rather than guessed away.

## Test

`copy-url-shortcut-migration-test.sh`:

- `open_browser`/`close_browser` and the other lock-creating sites now hold a lock that is *actually* live — `$(uname -n)-<live pid>` plus a resolvable socket — instead of `test-host-1234`, so the pre-existing deferral scenarios keep testing what their names claim under the stricter check. The prompt-visibility scenario now sets up its own state instead of inheriting the first scenario's browser.
- Four new scenarios: stale lock from a dead session (the report's case), recycled pid with a dangling socket, another host's lock, and a crashed browser's lingering socket. Each repairs without prompting; gum still declines, so a migration that wrongly prompts fails rather than hangs.

Mutation-checked, each mutation failing the suite at its own scenario: reverting `profile_open` wholesale, dropping the socket check, dropping the hostname check, and dropping the pid-alive check. All 13 pre-existing assertions still pass, and `migrate-wrapper-test`, `migrate-scope-test`, and `migrate-notify-test` are green.

One deliberate non-goal: this does not delete stale symlinks (Chromium reclaims the lock itself on next start, and touching another program's profile state from a migration buys little for the risk).
