### PR TITLE
Hide Obsidian's window buttons in the Omarchy theme

### DIFF
--- a/default/themed/obsidian.css.tpl
+++ b/default/themed/obsidian.css.tpl
@@ -97,3 +97,13 @@
 .search-result-file-title {
   color: var(--interactive-accent);
 }
+
+/* Window controls
+   Hyprland owns the window frame, so Obsidian's own minimize, maximize and
+   close buttons are dead controls next to the tab strip. */
+.titlebar-button-container.mod-right,
+.titlebar-button.mod-minimize,
+.titlebar-button.mod-maximize,
+.titlebar-button.mod-close {
+  display: none !important;
+}


### PR DESCRIPTION
Obsidian draws its own minimize, maximize and close buttons next to the tab strip (it runs with the hidden frame style, so it renders them itself rather than letting the compositor do it). Under Hyprland the compositor owns the window frame, so those three are dead controls, and no other app in Omarchy shows anything like them.

This adds a rule to `default/themed/obsidian.css.tpl` to hide them. The tab strip's own controls — the tab close button, new tab, tab list, sidebar toggle — are untouched.

Only affects users who have selected the Omarchy theme in Obsidian, as documented in `manual/06-themes.md` and `manual/22-guis.md`.

**Testing**

`./test/all` — 6 pre-existing failures on this machine (`config`, `manifest-entrypoints`, `runtime-smoke`, `snapper`, `theme-install-guards`, `unowned-system-paths`), all environmental: no sibling `omarchy-pkgs` checkout, no snapper/btrfs, network guard, live-system paths. Identical results with and without this commit on a stashed tree.

Verified in the running UI per `agents/skills/visual-verification.md`: regenerated the theme through `omarchy-theme-set-obsidian` from the modified template and confirmed in a live Obsidian window, with the local snippet removed so the rules could only arrive via the generated theme. Before/after screenshots in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
