### PR TITLE
Pin Cursor password store to gnome-libsecret so GitHub login can use the OS keyring

### DIFF
--- a/bin/omarchy-default-editor
+++ b/bin/omarchy-default-editor
@@ -42,7 +42,7 @@ if omarchy-cmd-missing "$editor"; then
   else
     case "$selection" in
     code) omarchy-install-editor-vscode ;;
-    cursor) omarchy-pkg-add cursor-bin ;;
+    cursor) omarchy-install-editor-cursor ;;
     zed) omarchy-install-editor-zed ;;
     sublime_text) omarchy-pkg-add sublime-text-4 ;;
     helix) omarchy-install-editor-helix ;;

--- a/bin/omarchy-install-editor-cursor
+++ b/bin/omarchy-install-editor-cursor
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# omarchy:summary=Install Cursor and configure Omarchy defaults for secrets and theme
+
+echo "Installing Cursor..."
+omarchy-pkg-add cursor-bin
+
+mkdir -p ~/.cursor ~/.config/Cursor/User
+
+# Electron cannot auto-detect GNOME Keyring when XDG_CURRENT_DESKTOP=Hyprland,
+# so GitHub login shows "An OS keyring couldn't be identified". Pin the same
+# gnome-libsecret backend VS Code already uses.
+cat > ~/.cursor/argv.json << 'EOF'
+// This configuration file allows you to pass permanent command line arguments to VS Code.
+// Only a subset of arguments is currently supported to reduce the likelihood of breaking
+// the installation.
+//
+// PLEASE DO NOT CHANGE WITHOUT UNDERSTANDING THE IMPACT
+//
+// NOTE: Changing this file requires a restart of VS Code.
+{
+  "password-store":"gnome-libsecret"
+}
+EOF
+
+omarchy-theme-set-vscode
+
+setsid uwsm-app -- gtk-launch cursor >/dev/null 2>&1 &

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -226,7 +226,7 @@
   "install.service.bitwarden": {"icon":"󰟵","label":"Bitwarden","disabled":"omarchy-pkg-present bitwarden","action":"omarchy-install-and-launch Bitwarden 'bitwarden bitwarden-cli' bitwarden"},
   "install.service.chromium-account": {"icon":"","label":"Chromium Account","when":"[[ -f ~/.config/chromium-flags.conf ]]","disabled":"grep -q oauth2-client-id ~/.config/chromium-flags.conf","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-chromium-google-account"},
   "install.editor.vscode": {"icon":"","label":"VSCode","disabled":"omarchy-pkg-present visual-studio-code-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-vscode"},
-  "install.editor.cursor": {"icon":"","label":"Cursor","disabled":"omarchy-pkg-present cursor-bin","action":"omarchy-install-and-launch Cursor cursor-bin cursor"},
+  "install.editor.cursor": {"icon":"","label":"Cursor","disabled":"omarchy-pkg-present cursor-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-cursor"},
   "install.editor.zed": {"icon":"","label":"Zed","disabled":"omarchy-pkg-present zed","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-zed"},
   "install.editor.sublime": {"icon":"","label":"Sublime Text","disabled":"omarchy-pkg-present sublime-text-4","action":"omarchy-install-and-launch 'Sublime Text' sublime-text-4 sublime_text"},
   "install.editor.helix": {"icon":"","label":"Helix","disabled":"omarchy-pkg-present helix","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-helix"},

--- a/migrations/1787689809.sh
+++ b/migrations/1787689809.sh
@@ -1,0 +1,38 @@
+echo "Pin Cursor password store to gnome-libsecret so GitHub login can use the OS keyring"
+
+# Cursor is a VS Code fork. On Hyprland, Electron cannot identify GNOME Keyring
+# from XDG_CURRENT_DESKTOP, so GitHub login offers "weaker encryption" instead.
+# Existing installs went through the generic package launcher and never got the
+# argv.json pin VS Code writes at install time. Leave an explicit password-store
+# alone so a user who chose "basic" is not silently moved.
+
+if [[ -d $HOME/.cursor ]] || omarchy-cmd-present cursor; then
+  argv="$HOME/.cursor/argv.json"
+  mkdir -p "$HOME/.cursor"
+
+  if [[ ! -f $argv ]]; then
+    cat > "$argv" << 'EOF'
+{
+  "password-store": "gnome-libsecret"
+}
+EOF
+  elif ! grep -q '"password-store"' "$argv"; then
+    python3 - "$argv" << 'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+idx = text.rfind("}")
+if idx < 0:
+    path.write_text(text.rstrip() + '\n{\n  "password-store": "gnome-libsecret"\n}\n')
+    raise SystemExit(0)
+head = text[:idx].rstrip()
+if head.endswith("{") or head.endswith(","):
+    insert = '\n  "password-store": "gnome-libsecret"\n'
+else:
+    insert = ',\n  "password-store": "gnome-libsecret"\n'
+path.write_text(head + insert + text[idx:])
+PY
+  fi
+fi

--- a/test/shell.d/cursor-password-store-migration-test.sh
+++ b/test/shell.d/cursor-password-store-migration-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command python3
+
+migration="$ROOT/migrations/1787689809.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+stub_bin="$test_dir/bin"
+mkdir -p "$home" "$stub_bin"
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ ${OMARCHY_TEST_CURSOR_PRESENT:-0} == 1 ]]
+SH
+chmod +x "$stub_bin/omarchy-cmd-present"
+
+run_migration() {
+  HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration
+[[ ! -e $home/.cursor ]] || fail "migration ignores machines without Cursor"
+pass "migration ignores machines without Cursor"
+
+OMARCHY_TEST_CURSOR_PRESENT=1 run_migration
+grep -Fq '"password-store": "gnome-libsecret"' "$home/.cursor/argv.json" ||
+  fail "migration writes argv.json when Cursor is installed but has never launched"
+pass "migration writes argv.json when Cursor is installed but has never launched"
+
+rm -rf "$home/.cursor"
+mkdir -p "$home/.cursor"
+cat >"$home/.cursor/argv.json" <<'EOF'
+// NOTE: Changing this file requires a restart of VS Code.
+{
+	"enable-crash-reporter": true,
+	"crash-reporter-id": "keep-me"
+}
+EOF
+
+run_migration
+grep -Fq '"crash-reporter-id": "keep-me"' "$home/.cursor/argv.json" ||
+  fail "migration preserves existing argv.json keys"
+grep -Fq '"password-store": "gnome-libsecret"' "$home/.cursor/argv.json" ||
+  fail "migration inserts gnome-libsecret into an existing argv.json"
+python3 -c 'import json,pathlib,re,sys
+text=pathlib.Path(sys.argv[1]).read_text()
+text=re.sub(r"//.*?$", "", text, flags=re.M)
+json.loads(text)
+' "$home/.cursor/argv.json" || fail "migrated argv.json stays parseable"
+pass "migration inserts gnome-libsecret into an existing argv.json"
+
+cat >"$home/.cursor/argv.json" <<'EOF'
+{
+  "password-store": "basic",
+  "crash-reporter-id": "keep-me"
+}
+EOF
+
+run_migration
+grep -Fq '"password-store": "basic"' "$home/.cursor/argv.json" ||
+  fail "migration leaves an explicit password-store alone"
+if grep -Fq 'gnome-libsecret' "$home/.cursor/argv.json"; then
+  fail "migration leaves an explicit password-store alone"
+fi
+pass "migration leaves an explicit password-store alone"

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -94,6 +94,7 @@ omarchy-install-editor-*)
   printf 'editor:%s\n' "$editor" >>"$OMARCHY_TEST_INSTALL_LOG"
   case $editor in
   vscode) command=code ;;
+  cursor) command=cursor ;;
   zed) command=zeditor ;;
   helix) command=helix ;;
   emacs) command=emacs ;;
@@ -110,6 +111,7 @@ for installer in \
   omarchy-install-browser \
   omarchy-install-terminal \
   omarchy-install-editor-vscode \
+  omarchy-install-editor-cursor \
   omarchy-install-editor-zed \
   omarchy-install-editor-helix \
   omarchy-install-editor-emacs; do
@@ -164,7 +166,7 @@ terminal_cases=(
 
 editor_cases=(
   'code code editor:vscode'
-  'cursor cursor pkg:cursor-bin'
+  'cursor cursor editor:cursor'
   'zed zeditor editor:zed'
   'sublime_text sublime_text pkg:sublime-text-4'
   'helix helix editor:helix'

--- a/test/shell.d/desktop-entry-launch-test.sh
+++ b/test/shell.d/desktop-entry-launch-test.sh
@@ -68,6 +68,10 @@ assert_detached_installer_launch() {
 
 assert_detached_installer_launch omarchy-install-editor-emacs emacsclient
 assert_detached_installer_launch omarchy-install-editor-vscode code
+assert_detached_installer_launch omarchy-install-editor-cursor cursor
+grep -Fq '"password-store":"gnome-libsecret"' "$test_home/.cursor/argv.json" ||
+  fail "Cursor installer pins gnome-libsecret in argv.json"
+pass "Cursor installer pins gnome-libsecret in argv.json"
 assert_detached_installer_launch omarchy-install-editor-zed dev.zed.Zed
 assert_detached_installer_launch omarchy-install-gaming-heroic heroic
 assert_detached_installer_launch omarchy-install-gaming-steam steam


### PR DESCRIPTION
## Problem

Signing into GitHub from Cursor on Omarchy shows:

> An OS keyring couldn't be identified for storing the encryption related data in your current desktop environment.

Omarchy already runs GNOME Keyring (`org.freedesktop.secrets`). The failure is on the Cursor side: it is an Electron/VS Code fork, and Chromium os_crypt cannot auto-detect GNOME Keyring when `XDG_CURRENT_DESKTOP=Hyprland`.

VS Code already avoids this by writing `"password-store": "gnome-libsecret"` to `~/.vscode/argv.json` in `omarchy-install-editor-vscode`. Cursor was installed through the generic `omarchy-install-and-launch` path and never got that pin.

Related: #1015 (VS Code), and the Chromium `--password-store=gnome-libsecret` pin in `config/chromium-flags.conf`.

## Change

- Add `omarchy-install-editor-cursor`, matching the VS Code installer: package, pin `~/.cursor/argv.json`, apply the Omarchy theme, launch.
- Route Install → Editor → Cursor and `omarchy default editor cursor` through that installer.
- Migrate existing Cursor installs: write or insert `gnome-libsecret` when `password-store` is missing, leave an explicit value (including `basic`) alone.

New installs pick this up from the installer. Existing installs pick it up on the next `omarchy update`. Cursor still has to be restarted once after the pin.

## Test plan

- `bash test/shell.d/cursor-password-store-migration-test.sh`
- `bash test/shell.d/desktop-entry-launch-test.sh`
- `bash test/shell.d/default-apps-test.sh`
- `./test/all` — remaining failures are pre-existing on `quattro` in this environment (missing `omarchy-pkgs` checkout, About animation, theme-install URL check)