### PR TITLE
Fix SPICE clipboard sharing in Wayland guests

### DIFF
--- a/bin/omarchy-provision-first-run
+++ b/bin/omarchy-provision-first-run
@@ -77,6 +77,8 @@ run_first_run_step "install agent setup post-update hook" \
 
 run_first_run_step "enable user systemd units" \
   bash "$OMARCHY_PATH/install/user/first-run/enable-user-units.sh"
+run_first_run_step "enable SPICE Wayland clipboard" \
+  bash "$OMARCHY_PATH/install/user/first-run/spice-vdagent.sh"
 run_first_run_step "set GNOME theme" \
   bash "$OMARCHY_PATH/install/user/first-run/gnome-theme.sh"
 run_first_run_step "set GTK primary paste" \

--- a/bin/omarchy-vdagent
+++ b/bin/omarchy-vdagent
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# omarchy:summary=Bridge the SPICE guest clipboard to Wayland
+# omarchy:hidden=true
+# Copyright (c) 2026 Gabriel
+# SPDX-License-Identifier: MIT
+# Adapted from https://github.com/ggalancs/omarchy-arm-utm
+"""Bridge the SPICE guest clipboard to a native Wayland clipboard.
+
+The host SPICE client talks to the system spice-vdagentd daemon over the
+com.redhat.spice.0 virtio port. The daemon then multiplexes messages to the
+active graphical session over /run/spice-vdagentd/spice-vdagent-sock.
+
+The stock session agent only exposes an X11 clipboard. This replacement speaks
+the same udscs protocol to spice-vdagentd and uses wl-copy/wl-paste on the
+session side, so text can move in both directions under Hyprland.
+
+Keep spice-vdagentd's normal logind session integration enabled. Running the
+daemon with -X is unnecessary on current Omarchy sessions and can break its
+uinput tablet, making the guest cursor disappear.
+
+Only UTF-8 text is supported; images and files are intentionally ignored.
+"""
+
+import os
+import signal
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import threading
+import time
+
+VDAGENTD_SOCKET = os.environ.get(
+    "VDAGENTD_SOCK", "/run/spice-vdagentd/spice-vdagent-sock"
+)
+
+# vdagentd-proto.h
+GUEST_XORG_RESOLUTION = 0
+MONITORS_CONFIG = 1
+CLIPBOARD_GRAB = 2
+CLIPBOARD_REQUEST = 3
+CLIPBOARD_DATA = 4
+CLIPBOARD_RELEASE = 5
+VERSION = 6
+CLIENT_DISCONNECTED = 12
+
+CLIPBOARD_SELECTION = 0  # VD_AGENT_CLIPBOARD_SELECTION_CLIPBOARD
+UTF8_TEXT = 1  # VD_AGENT_CLIPBOARD_UTF8_TEXT
+
+DEBUG = bool(os.environ.get("VDAGENT_DEBUG"))
+
+
+def debug(*args):
+    if DEBUG:
+        print("[vdagent]", *args, file=sys.stderr, flush=True)
+
+
+class Agent:
+    def __init__(self, connection):
+        self.connection = connection
+        self.lock = threading.Lock()
+        self.last_local = None
+        self.waiting = threading.Event()
+        self.received = None
+
+    def send(self, message_type, arg1=0, arg2=0, data=b""):
+        header = struct.pack("<IIII", message_type, arg1, arg2, len(data))
+        with self.lock:
+            self.connection.sendall(header + data)
+        debug("→", message_type, arg1, arg2, len(data))
+
+    def _read(self, size):
+        data = b""
+        while len(data) < size:
+            chunk = self.connection.recv(size - len(data))
+            if not chunk:
+                raise EOFError
+            data += chunk
+        return data
+
+    def run(self):
+        while True:
+            try:
+                message_type, arg1, arg2, size = struct.unpack(
+                    "<IIII", self._read(16)
+                )
+                data = self._read(size) if size else b""
+            except (EOFError, OSError) as error:
+                debug("socket closed:", error)
+                return
+            debug("←", message_type, arg1, arg2, size)
+
+            if message_type == CLIPBOARD_GRAB:
+                # The host offers clipboard content, so request it.
+                self.send(CLIPBOARD_REQUEST, CLIPBOARD_SELECTION, UTF8_TEXT)
+
+            elif message_type == CLIPBOARD_REQUEST:
+                text = read_clipboard() or ""
+                self.send(
+                    CLIPBOARD_DATA,
+                    CLIPBOARD_SELECTION,
+                    UTF8_TEXT,
+                    text.encode("utf-8"),
+                )
+
+            elif message_type == CLIPBOARD_DATA:
+                if arg2 == UTF8_TEXT:
+                    text = data.decode("utf-8", "replace")
+                    write_clipboard(text)
+                    self.last_local = text
+                    debug("  received from host:", len(text), "bytes")
+
+            elif message_type == VERSION:
+                debug("  vdagentd version:", data.decode("utf-8", "replace").strip())
+
+
+def read_clipboard():
+    try:
+        result = subprocess.run(
+            ["wl-paste", "--no-newline", "--type", "text/plain"],
+            capture_output=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.decode("utf-8", "replace")
+    except Exception:
+        pass
+    return None
+
+
+def write_clipboard(text):
+    try:
+        subprocess.run(
+            ["wl-copy", "--type", "text/plain;charset=utf-8"],
+            input=text.encode("utf-8"),
+            timeout=5,
+        )
+    except Exception as error:
+        debug("wl-copy failed:", error)
+
+
+def resolution():
+    """Return the current Hyprland resolution, or a conservative fallback."""
+    try:
+        result = subprocess.run(
+            ["hyprctl", "monitors", "-j"], capture_output=True, timeout=4
+        )
+        if result.returncode == 0:
+            import json
+
+            monitor = json.loads(result.stdout)[0]
+            return int(monitor["width"]), int(monitor["height"])
+    except Exception:
+        pass
+    return 1920, 1200
+
+
+def watch_clipboard(agent):
+    """Offer clipboard changes made inside the guest to the host."""
+    while True:
+        text = read_clipboard()
+        if text is not None and text != agent.last_local:
+            agent.last_local = text
+            if text:
+                agent.send(
+                    CLIPBOARD_GRAB,
+                    CLIPBOARD_SELECTION,
+                    0,
+                    struct.pack("<I", UTF8_TEXT),
+                )
+        time.sleep(1)
+
+
+def main():
+    for command in ("wl-paste", "wl-copy"):
+        if shutil.which(command) is None:
+            print(f"missing {command} (install wl-clipboard)", file=sys.stderr)
+            return 1
+
+    if not os.path.exists(VDAGENTD_SOCKET):
+        print(f"missing {VDAGENTD_SOCKET}", file=sys.stderr)
+        print(
+            "start the daemon with: sudo systemctl start spice-vdagentd.socket",
+            file=sys.stderr,
+        )
+        return 1
+
+    connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    connection.connect(VDAGENTD_SOCKET)
+    agent = Agent(connection)
+
+    # The stock agent announces its resolution immediately. vdagentd uses this
+    # to identify a live graphical session. The payload is five ints: width,
+    # height, x, y, display_id (vdagentd-proto.h).
+    width, height = resolution()
+    agent.send(
+        GUEST_XORG_RESOLUTION,
+        width,
+        height,
+        struct.pack("<iiiii", width, height, 0, 0, 0),
+    )
+
+    agent.last_local = read_clipboard()
+    threading.Thread(target=watch_clipboard, args=(agent,), daemon=True).start()
+    try:
+        agent.run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        connection.close()
+    return 0
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+    sys.exit(main())

--- a/default/systemd/user/omarchy-vdagent.service
+++ b/default/systemd/user/omarchy-vdagent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Bridge the SPICE guest clipboard to Wayland
-Documentation=https://github.com/basecamp/omarchy/blob/master/manual/49-omarchy-on.md
+Documentation=https://github.com/basecamp/omarchy/blob/quattro/manual/49-omarchy-on.md
 After=graphical-session.target
 PartOf=graphical-session.target
 ConditionEnvironment=WAYLAND_DISPLAY

--- a/default/systemd/user/omarchy-vdagent.service
+++ b/default/systemd/user/omarchy-vdagent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Bridge the SPICE guest clipboard to Wayland
+Documentation=https://github.com/basecamp/omarchy/blob/master/manual/49-omarchy-on.md
+After=graphical-session.target
+PartOf=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+ConditionPathExists=/dev/virtio-ports/com.redhat.spice.0
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-vdagent
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=graphical-session.target

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -4,6 +4,7 @@ run_logged "$OMARCHY_INSTALL/hardware/dell-xps-touchpad-haptics.sh"
 run_logged "$OMARCHY_INSTALL/hardware/surface.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/network.sh"
+run_logged "$OMARCHY_INSTALL/hardware/spice-vdagent.sh"
 run_logged "$OMARCHY_INSTALL/hardware/set-wireless-regdom.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-fkeys.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-synaptic-touchpad.sh"

--- a/install/hardware/spice-vdagent.sh
+++ b/install/hardware/spice-vdagent.sh
@@ -1,0 +1,9 @@
+# The stock SPICE session agent only exposes an X11 clipboard. Install the
+# daemon package when the guest has a SPICE virtio channel, but mask only its
+# per-session X11 agent; omarchy-vdagent replaces that half under Wayland.
+spice_port="${OMARCHY_SPICE_PORT:-/dev/virtio-ports/com.redhat.spice.0}"
+
+if [[ -e $spice_port ]]; then
+  omarchy-pkg-add spice-vdagent
+  systemctl --global mask spice-vdagent.service
+fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -40,6 +40,7 @@ pipewire-pulse
 qt6-wayland
 snapper
 sof-firmware
+spice-vdagent
 thermald
 webp-pixbuf-loader
 yay-debug

--- a/install/user/first-run/spice-vdagent.sh
+++ b/install/user/first-run/spice-vdagent.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# The system half is prepared by install/hardware/spice-vdagent.sh. By first
+# run, UWSM has imported WAYLAND_DISPLAY into the user manager and the SPICE
+# virtio channel has activated spice-vdagentd.socket.
+
+set -euo pipefail
+
+spice_port="${OMARCHY_SPICE_PORT:-/dev/virtio-ports/com.redhat.spice.0}"
+[[ -e $spice_port ]] || exit 0
+
+stock_state="$(systemctl --user is-enabled spice-vdagent.service 2>/dev/null || true)"
+if [[ $stock_state != "masked" ]]; then
+  echo "The stock SPICE X11 session agent is not masked; refusing to run two agents." >&2
+  exit 1
+fi
+
+unit_name=omarchy-vdagent.service
+unit_source="$OMARCHY_PATH/default/systemd/user/$unit_name"
+unit="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/$unit_name"
+
+install -Dm644 "$unit_source" "$unit"
+systemctl --user daemon-reload
+systemctl --user enable --now "$unit_name"

--- a/manual/49-omarchy-on.md
+++ b/manual/49-omarchy-on.md
@@ -8,6 +8,32 @@
 
 You can also install Omarchy inside a Parallels VM. Quite the cumbersome process, but there's [a user-driven guide](https://github.com/basecamp/omarchy/discussions/452) for that too.
 
+### QEMU/KVM with SPICE
+
+Omarchy automatically enables two-way text clipboard sharing when it is
+installed in a QEMU/KVM guest with a SPICE virtio channel. In virt-manager,
+use a SPICE display, add a SPICE agent channel named
+`com.redhat.spice.0`, and leave clipboard sharing enabled. The first graphical
+login installs `omarchy-vdagent`, which connects the SPICE daemon directly to
+Hyprland's Wayland clipboard through `wl-copy` and `wl-paste`.
+
+The stock `spice-vdagent` session process is X11-only, so Omarchy masks that
+session process inside matching guests while leaving the system
+`spice-vdagentd` daemon unchanged. Do not add the daemon's `-X` flag: current
+Omarchy sessions pass the normal logind active-session check, and `-X` can
+break the guest's uinput tablet and make its cursor disappear.
+
+Clipboard transfer is text-only. Check the guest side with:
+
+```bash
+systemctl --user status omarchy-vdagent
+journalctl --user -u omarchy-vdagent
+```
+
+The Wayland agent is adapted from
+[`omarchy-arm-vdagent`](https://github.com/ggalancs/omarchy-arm-utm) and the
+investigation shared in [discussion #7956](https://github.com/basecamp/omarchy/discussions/7956).
+
 ### VirtualBox
 
 VirtualBox is a popular VM runner. [You can run Omarchy inside that too](https://github.com/basecamp/omarchy/discussions/176). But performance probably won't be great.

--- a/manual/49-omarchy-on.md
+++ b/manual/49-omarchy-on.md
@@ -10,18 +10,9 @@ You can also install Omarchy inside a Parallels VM. Quite the cumbersome process
 
 ### QEMU/KVM with SPICE
 
-Omarchy automatically enables two-way text clipboard sharing when it is
-installed in a QEMU/KVM guest with a SPICE virtio channel. In virt-manager,
-use a SPICE display, add a SPICE agent channel named
-`com.redhat.spice.0`, and leave clipboard sharing enabled. The first graphical
-login installs `omarchy-vdagent`, which connects the SPICE daemon directly to
-Hyprland's Wayland clipboard through `wl-copy` and `wl-paste`.
+Omarchy automatically enables two-way text clipboard sharing when it is installed in a QEMU/KVM guest with a SPICE virtio channel. In virt-manager, use a SPICE display, add a SPICE agent channel named `com.redhat.spice.0`, and leave clipboard sharing enabled. The first graphical login installs `omarchy-vdagent`, which connects the SPICE daemon directly to Hyprland's Wayland clipboard through `wl-copy` and `wl-paste`.
 
-The stock `spice-vdagent` session process is X11-only, so Omarchy masks that
-session process inside matching guests while leaving the system
-`spice-vdagentd` daemon unchanged. Do not add the daemon's `-X` flag: current
-Omarchy sessions pass the normal logind active-session check, and `-X` can
-break the guest's uinput tablet and make its cursor disappear.
+The stock `spice-vdagent` session process is X11-only, so Omarchy masks that session process inside matching guests while leaving the system `spice-vdagentd` daemon unchanged. Do not add the daemon's `-X` flag: current Omarchy sessions pass the normal logind active-session check, and `-X` can break the guest's uinput tablet and make its cursor disappear.
 
 Clipboard transfer is text-only. Check the guest side with:
 
@@ -30,9 +21,7 @@ systemctl --user status omarchy-vdagent
 journalctl --user -u omarchy-vdagent
 ```
 
-The Wayland agent is adapted from
-[`omarchy-arm-vdagent`](https://github.com/ggalancs/omarchy-arm-utm) and the
-investigation shared in [discussion #7956](https://github.com/basecamp/omarchy/discussions/7956).
+The Wayland agent is adapted from [`omarchy-arm-vdagent`](https://github.com/ggalancs/omarchy-arm-utm) and the investigation shared in [discussion #7956](https://github.com/basecamp/omarchy/discussions/7956).
 
 ### VirtualBox
 

--- a/migrations/1787768303.sh
+++ b/migrations/1787768303.sh
@@ -1,0 +1,41 @@
+echo "Enable native Wayland clipboard sharing in SPICE guests"
+
+spice_port="${OMARCHY_SPICE_PORT:-/dev/virtio-ports/com.redhat.spice.0}"
+[[ -e $spice_port ]] || exit 0
+
+omarchy-pkg-add spice-vdagent
+
+# Never leave the stock X11 agent connected beside the Wayland replacement.
+# vdagentd accepts one session agent and disconnects both when they compete.
+systemctl --user stop spice-vdagent.service >/dev/null 2>&1 || true
+pkill -x spice-vdagent >/dev/null 2>&1 || true
+global_state="$(systemctl --global is-enabled spice-vdagent.service 2>/dev/null || true)"
+if [[ $global_state != "masked" ]]; then
+  sudo systemctl --global mask spice-vdagent.service
+fi
+
+# Installing the package after the virtio device appeared cannot replay its
+# udev add event, so activate the static socket explicitly for existing VMs.
+if ! systemctl is-active --quiet spice-vdagentd.socket; then
+  sudo systemctl start spice-vdagentd.socket
+fi
+
+unit_name=omarchy-vdagent.service
+unit_source="$OMARCHY_PATH/default/systemd/user/$unit_name"
+unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+unit="$unit_dir/$unit_name"
+
+install -Dm644 "$unit_source" "$unit"
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# A TTY update may not have a live user manager. In that case, write the same
+# wants link systemctl would create and let the next graphical login start it.
+if ! systemctl --user enable "$unit_name" >/dev/null 2>&1; then
+  wants_dir="$unit_dir/graphical-session.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn "../$unit_name" "$wants_dir/$unit_name"
+fi
+
+if systemctl --user is-active --quiet graphical-session.target; then
+  systemctl --user restart "$unit_name"
+fi

--- a/test/shell.d/spice-vdagent-test.sh
+++ b/test/shell.d/spice-vdagent-test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command python3
+
+agent="$ROOT/bin/omarchy-vdagent"
+service="$ROOT/default/systemd/user/omarchy-vdagent.service"
+hardware="$ROOT/install/hardware/spice-vdagent.sh"
+first_run="$ROOT/install/user/first-run/spice-vdagent.sh"
+migration="$ROOT/migrations/1787768303.sh"
+
+AGENT="$agent" python3 <<'PY'
+import os
+import runpy
+import struct
+
+module = runpy.run_path(os.environ["AGENT"])
+Agent = module["Agent"]
+
+
+class MemoryConnection:
+    def __init__(self, incoming=b""):
+        self.incoming = bytearray(incoming)
+        self.sent = bytearray()
+
+    def recv(self, size):
+        data = self.incoming[:size]
+        del self.incoming[:size]
+        return bytes(data)
+
+    def sendall(self, data):
+        self.sent.extend(data)
+
+
+connection = MemoryConnection()
+agent = Agent(connection)
+payload = struct.pack("<iiiii", 1920, 1200, 0, 0, 0)
+agent.send(module["GUEST_XORG_RESOLUTION"], 1920, 1200, payload)
+header = struct.unpack("<IIII", connection.sent[:16])
+assert header == (module["GUEST_XORG_RESOLUTION"], 1920, 1200, len(payload))
+assert connection.sent[16:] == payload
+
+incoming = struct.pack("<IIII", module["CLIPBOARD_GRAB"], 0, 0, 0)
+connection = MemoryConnection(incoming)
+agent = Agent(connection)
+agent.run()
+reply = struct.unpack("<IIII", connection.sent)
+assert reply == (
+    module["CLIPBOARD_REQUEST"],
+    module["CLIPBOARD_SELECTION"],
+    module["UTF8_TEXT"],
+    0,
+)
+PY
+pass "SPICE agent preserves udscs framing and host clipboard requests"
+
+grep -qx '# omarchy:hidden=true' "$agent" || fail "SPICE agent stays out of user-facing CLI listings"
+grep -qx 'ConditionEnvironment=WAYLAND_DISPLAY' "$service" || fail "SPICE agent starts only in a Wayland session"
+grep -qx 'ConditionPathExists=/dev/virtio-ports/com.redhat.spice.0' "$service" || fail "SPICE agent starts only in matching guests"
+grep -qx 'ExecStart=/usr/bin/omarchy-vdagent' "$service" || fail "SPICE unit runs the package-owned agent"
+grep -qx 'Restart=always' "$service" || fail "SPICE agent reconnects after daemon socket closure"
+pass "SPICE user unit is scoped to matching Wayland guests"
+
+grep -qx 'spice-vdagent' "$ROOT/install/omarchy-other.packages" || fail "SPICE package is available in the offline ISO pool"
+if grep -qx 'spice-vdagent' "$ROOT/install/omarchy-base.packages"; then
+  fail "SPICE package is not installed on bare-metal systems"
+fi
+grep -Fq 'hardware/spice-vdagent.sh' "$ROOT/install/hardware/all.sh" || fail "SPICE hardware setup runs during installation"
+grep -Fq 'first-run/spice-vdagent.sh' "$ROOT/bin/omarchy-provision-first-run" || fail "SPICE user agent is installed on first login"
+pass "SPICE support is available offline but installed only for matching guests"
+
+if [[ -e $ROOT/etc/systemd/system/spice-vdagentd.service.d/override.conf ]]; then
+  fail "SPICE support does not ship a spice-vdagentd override"
+fi
+if grep -R -E 'ExecStart=.*spice-vdagentd.*(^|[[:space:]])-X([[:space:]]|$)' \
+  "$ROOT/bin" "$ROOT/default" "$ROOT/install" "$ROOT/migrations" >/dev/null; then
+  fail "SPICE support never disables daemon session integration with -X"
+fi
+pass "SPICE daemon remains unchanged and keeps cursor-safe session integration"
+
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+stub_bin="$test_root/bin"
+log="$test_root/commands.log"
+spice_port="$test_root/com.redhat.spice.0"
+mkdir -p "$stub_bin" "$test_root/home"
+touch "$spice_port" "$log"
+
+cat >"$stub_bin/omarchy-pkg-add" <<'STUB'
+#!/bin/bash
+printf 'pkg\t%s\n' "$*" >>"$SPICE_TEST_LOG"
+STUB
+cat >"$stub_bin/systemctl" <<'STUB'
+#!/bin/bash
+printf 'systemctl\t%s\n' "$*" >>"$SPICE_TEST_LOG"
+if [[ $* == "--user is-enabled spice-vdagent.service" ]]; then
+  echo masked
+  exit 1
+fi
+if [[ $* == "--user is-active --quiet graphical-session.target" ]]; then
+  exit 1
+fi
+if [[ $* == "--global is-enabled spice-vdagent.service" ]]; then
+  if [[ ${SPICE_TEST_SETTLED:-0} == "1" ]]; then
+    echo masked
+  fi
+  exit 1
+fi
+if [[ $* == "is-active --quiet spice-vdagentd.socket" ]]; then
+  [[ ${SPICE_TEST_SETTLED:-0} == "1" ]]
+  exit
+fi
+STUB
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo\t%s\n' "$*" >>"$SPICE_TEST_LOG"
+"$@"
+STUB
+cat >"$stub_bin/pkill" <<'STUB'
+#!/bin/bash
+printf 'pkill\t%s\n' "$*" >>"$SPICE_TEST_LOG"
+STUB
+chmod +x "$stub_bin/omarchy-pkg-add" "$stub_bin/systemctl" "$stub_bin/sudo" "$stub_bin/pkill"
+
+SPICE_TEST_LOG="$log" OMARCHY_SPICE_PORT="$spice_port" \
+  PATH="$stub_bin:$PATH" bash -eE -c 'source "$1"' bash "$hardware"
+grep -Fq $'pkg\tspice-vdagent' "$log" || fail "matching VM installs spice-vdagent"
+grep -Fq $'systemctl\t--global mask spice-vdagent.service' "$log" || fail "matching VM masks only the stock session agent"
+pass "hardware setup replaces the stock SPICE session agent"
+
+SPICE_TEST_LOG="$log" OMARCHY_SPICE_PORT="$spice_port" OMARCHY_PATH="$ROOT" \
+  HOME="$test_root/home" XDG_CONFIG_HOME="$test_root/config" \
+  PATH="$stub_bin:$PATH" bash "$first_run"
+cmp -s "$service" "$test_root/config/systemd/user/omarchy-vdagent.service" || fail "first run installs the shipped SPICE unit"
+grep -Fq $'systemctl\t--user enable --now omarchy-vdagent.service' "$log" || fail "first run enables and starts the SPICE agent"
+pass "first login installs the package-owned SPICE unit template"
+
+: >"$log"
+SPICE_TEST_LOG="$log" OMARCHY_SPICE_PORT="$spice_port" OMARCHY_PATH="$ROOT" \
+  HOME="$test_root/home" XDG_CONFIG_HOME="$test_root/migration-config" \
+  PATH="$stub_bin:$PATH" bash -euo pipefail "$migration"
+grep -Fq $'pkg\tspice-vdagent' "$log" || fail "migration installs spice-vdagent"
+grep -Fq $'sudo\tsystemctl --global mask spice-vdagent.service' "$log" || fail "migration masks the stock session agent"
+grep -Fq $'sudo\tsystemctl start spice-vdagentd.socket' "$log" || fail "migration activates the daemon socket"
+cmp -s "$service" "$test_root/migration-config/systemd/user/omarchy-vdagent.service" || fail "migration installs the shipped SPICE unit"
+pass "existing SPICE guests migrate to the Wayland clipboard agent"
+
+: >"$log"
+SPICE_TEST_SETTLED=1 SPICE_TEST_LOG="$log" OMARCHY_SPICE_PORT="$spice_port" \
+  OMARCHY_PATH="$ROOT" HOME="$test_root/home" \
+  XDG_CONFIG_HOME="$test_root/migration-config" PATH="$stub_bin:$PATH" \
+  bash -euo pipefail "$migration"
+if grep -q $'^sudo\t' "$log"; then
+  fail "settled machine-wide SPICE state does not prompt every user for sudo"
+fi
+pass "SPICE migration is machine-idempotent for additional users"
+
+: >"$log"
+SPICE_TEST_LOG="$log" OMARCHY_SPICE_PORT="$test_root/missing-port" \
+  PATH="$stub_bin:$PATH" bash -eE -c 'source "$1"' bash "$hardware"
+[[ ! -s $log ]] || fail "non-SPICE machines skip VM clipboard setup"
+pass "non-SPICE machines remain untouched"


### PR DESCRIPTION
## Summary

- add a Wayland-native SPICE session agent that speaks the existing `udscs`
  protocol to `spice-vdagentd` and bridges UTF-8 text through
  `wl-copy`/`wl-paste`
- install `spice-vdagent` only when the guest exposes
  `/dev/virtio-ports/com.redhat.spice.0`, while keeping it available in the
  ISO's offline package pool
- mask only the stock X11 session agent, leaving the socket-activated system
  daemon unchanged
- enable the replacement on first login and migrate existing SPICE guests
- document virt-manager/QEMU setup and the text-only limitation

## Why

The packaged `spice-vdagent` session process connects the guest clipboard to
X11. A pure Hyprland session has no automatic X11-to-Wayland clipboard bridge,
so host-to-guest and guest-to-host clipboard transfers do not reach native
Wayland applications.

The replacement keeps the proven SPICE daemon/protocol half and swaps only the
session clipboard backend. It is guarded by both `WAYLAND_DISPLAY` and the
SPICE virtio port, so non-SPICE and non-Wayland systems remain untouched.

## Safety and lifecycle

- no `spice-vdagentd` override is shipped
- the daemon is **not** started with `-X`; that flag can break its uinput tablet
  and make the guest cursor disappear
- UWSM supplies the session environment; no display name, UID, or runtime path
  is hard-coded
- `Restart=always` reconnects the session agent after daemon/socket restarts
- the migration is machine-idempotent, so additional users do not repeat
  already-settled privileged operations

## Verification

- tested both clipboard directions in an Omarchy QEMU/KVM guest opened through
  virt-manager/SPICE; the legacy X11/Wayland clipboard bridge was disabled
  before the final verification
- protocol handlers and constants compared against the deployed working agent
  from commit `a11d9c1`
- `bash test/shell.d/spice-vdagent-test.sh`
- `./test/cli`
- `bash test/shell.d/bin-style-test.sh`
- Python compile check, Bash syntax checks, ShellCheck, and `git diff --check`
- the new test passes inside `./test/all`; remaining local full-suite failures
  reproduce on unmodified `origin/quattro` in this sandbox (notably the absent
  private `omarchy-pkgs` checkout and restricted system paths)

## Credits

The protocol bridge is adapted under MIT from
[`omarchy-arm-vdagent`](https://github.com/ggalancs/omarchy-arm-utm). The prior
investigation is documented in
[discussion #7956](https://github.com/basecamp/omarchy/discussions/7956).
