### PR TITLE
Let the weather panel switch forecast providers

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -55,6 +55,7 @@ The panels aren't read-outs. They're where you actually do the thing:
 - **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info.
 - **Display** carries a brightness slider, text size, monitor scaling presets, and — when you have more than one screen — per-monitor controls. See [monitors](33-monitors.md) for the deeper story.
 - **Clock** opens a month grid with ISO week numbers and month stepping.
+- **Weather** shows current conditions and the next few days. Open-Meteo is the default forecast. If those highs look hotter than Apple Weather or weather.gov, open the panel and switch **Forecast** to National Weather Service (US official) or NOAA National Blend. ECMWF and DWD ICON are independent global models; wttr.in is the original lookup service. The same setting is `omarchy bar set omarchy.weather provider nws`.
 
 Every panel takes the keyboard as well as the mouse: arrows move, Return activates, Tab steps to the neighbouring panel, and Escape closes.
 

--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -55,7 +55,7 @@ The panels aren't read-outs. They're where you actually do the thing:
 - **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info.
 - **Display** carries a brightness slider, text size, monitor scaling presets, and — when you have more than one screen — per-monitor controls. See [monitors](33-monitors.md) for the deeper story.
 - **Clock** opens a month grid with ISO week numbers and month stepping.
-- **Weather** shows current conditions and the next few days. Open-Meteo is the default forecast. If those highs look hotter than Apple Weather or weather.gov, open the panel and switch **Forecast** to National Weather Service (US official) or NOAA National Blend. ECMWF and DWD ICON are independent global models; wttr.in is the original lookup service. The same setting is `omarchy bar set omarchy.weather provider nws`.
+- **Weather** shows current conditions and the next few days. Open-Meteo is the default forecast. If those highs look hotter than Apple Weather or weather.gov, open the panel and switch **Forecast** to National Weather Service (US official) or NOAA National Blend — `f` opens that dropdown from the keyboard. ECMWF and DWD ICON are independent global models; wttr.in is the original lookup service. The same setting is `omarchy bar set omarchy.weather provider nws`.
 
 Every panel takes the keyboard as well as the mouse: arrows move, Return activates, Tab steps to the neighbouring panel, and Escape closes.
 

--- a/manual/10-notices.md
+++ b/manual/10-notices.md
@@ -16,6 +16,8 @@ You can quickly access the date and time, battery status, and current weather us
 
 The location is detected from your IP address, which is usually close enough, but not always. You can pin it down with `omarchy weather location --set Malibu`, or be exact about it by adding coordinates: `omarchy weather location --set Malibu 34.0259,-118.7798`. Run `omarchy weather location` on its own to see where it thinks you are, and `--clear` to go back to auto-detection.
 
+The forecast itself comes from Open-Meteo by default. Open the weather panel and use the **Forecast** dropdown to switch providers — National Weather Service if you want the US official forecast that Apple Weather tracks, NOAA National Blend for a calibrated US model, or ECMWF / DWD ICON for independent global models. From the terminal that's `omarchy bar set omarchy.weather provider nws`.
+
 ### Battery
 
 `Super + Ctrl + Alt + B`

--- a/manual/10-notices.md
+++ b/manual/10-notices.md
@@ -16,7 +16,7 @@ You can quickly access the date and time, battery status, and current weather us
 
 The location is detected from your IP address, which is usually close enough, but not always. You can pin it down with `omarchy weather location --set Malibu`, or be exact about it by adding coordinates: `omarchy weather location --set Malibu 34.0259,-118.7798`. Run `omarchy weather location` on its own to see where it thinks you are, and `--clear` to go back to auto-detection.
 
-The forecast itself comes from Open-Meteo by default. Open the weather panel and use the **Forecast** dropdown to switch providers — National Weather Service if you want the US official forecast that Apple Weather tracks, NOAA National Blend for a calibrated US model, or ECMWF / DWD ICON for independent global models. From the terminal that's `omarchy bar set omarchy.weather provider nws`.
+The forecast itself comes from Open-Meteo by default. Open the weather panel and use the **Forecast** dropdown to switch providers (`f` from the keyboard) — National Weather Service if you want the US official forecast that Apple Weather tracks, NOAA National Blend for a calibrated US model, or ECMWF / DWD ICON for independent global models. From the terminal that's `omarchy bar set omarchy.weather provider nws`.
 
 ### Battery
 

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -61,7 +61,7 @@ Example `shell.json` (bar subtree only shown):
 | `omarchy.indicators` | Manual state indicators | left = indicator action |
 | `omarchy.system-update` | Available update indicator | left = update |
 | `omarchy.tray` | System tray | hover = reveal drawer · right on chevron = manage |
-| `omarchy.weather` | Weather icon + popup with forecast | left = popup · right = full notification |
+| `omarchy.weather` | Weather icon + popup with forecast and provider picker | left = popup · right = full notification |
 | `omarchy.microphone` | Mic icon + scroll volume | left = mute toggle · middle = audio panel · scroll = source volume |
 
 | `omarchy.audio` | Volume icon + popup with master slider, output-device picker, per-app mixer | left = popup · right = mute · middle = popup · scroll = volume |

--- a/shell/plugins/panels/weather/Model.js
+++ b/shell/plugins/panels/weather/Model.js
@@ -86,6 +86,12 @@ function celsiusToFahrenheit(value) {
   return isNaN(n) ? "" : (n * 9 / 5) + 32
 }
 
+function fahrenheitToCelsius(value) {
+  if (value === undefined || value === null || value === "") return ""
+  var n = parseFloat(String(value))
+  return isNaN(n) ? "" : (n - 32) * 5 / 9
+}
+
 function formatTemp(value, useImperial) {
   if (value === undefined || value === null || value === "") return ""
   return value + "°" + (useImperial ? "F" : "C")
@@ -120,6 +126,233 @@ function shouldUseImperial(unitOverride, localeName, countryName) {
   if (countryPreference !== null) return countryPreference
 
   return localeUsesImperial(localeName)
+}
+
+// Forecast sources the panel can switch between. Open-Meteo remains the
+// default: no API key, global coverage, one request for current + daily.
+// The other Open-Meteo entries pin a model. NWS is the US official forecast
+// (what Apple Weather tracks). wttr.in is the original lookup service.
+var WEATHER_PROVIDERS = [
+  { id: "open-meteo", label: "Open-Meteo", kind: "open-meteo", model: "" },
+  { id: "nws", label: "National Weather Service", kind: "nws", model: "" },
+  { id: "nbm", label: "NOAA National Blend", kind: "open-meteo", model: "ncep_nbm_conus" },
+  { id: "gfs", label: "NOAA GFS", kind: "open-meteo", model: "gfs_seamless" },
+  { id: "ecmwf", label: "ECMWF", kind: "open-meteo", model: "ecmwf_ifs025" },
+  { id: "icon", label: "DWD ICON", kind: "open-meteo", model: "icon_seamless" },
+  { id: "wttr", label: "wttr.in", kind: "wttr", model: "" }
+]
+
+function providerCatalog() {
+  return WEATHER_PROVIDERS
+}
+
+function providerOptions() {
+  var out = []
+  for (var i = 0; i < WEATHER_PROVIDERS.length; i++) {
+    out.push({ value: WEATHER_PROVIDERS[i].id, label: WEATHER_PROVIDERS[i].label })
+  }
+  return out
+}
+
+function normalizedProvider(value) {
+  var id = String(value || "").replace(/^\s+|\s+$/g, "").toLowerCase()
+  for (var i = 0; i < WEATHER_PROVIDERS.length; i++) {
+    if (WEATHER_PROVIDERS[i].id === id) return id
+  }
+  return "open-meteo"
+}
+
+function providerInfo(value) {
+  var id = normalizedProvider(value)
+  for (var i = 0; i < WEATHER_PROVIDERS.length; i++) {
+    if (WEATHER_PROVIDERS[i].id === id) return WEATHER_PROVIDERS[i]
+  }
+  return WEATHER_PROVIDERS[0]
+}
+
+function shellQuote(value) {
+  return "'" + String(value).replace(/'/g, "'\\''") + "'"
+}
+
+function openMeteoForecastUrl(lat, lon, model) {
+  var url = "https://api.open-meteo.com/v1/forecast"
+    + "?latitude=" + encodeURIComponent(String(lat))
+    + "&longitude=" + encodeURIComponent(String(lon))
+    + "&daily=weather_code,temperature_2m_max,temperature_2m_min"
+    + "&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,weather_code,is_day"
+    + "&forecast_days=4"
+    + "&timezone=auto"
+  var pinned = String(model || "")
+  if (pinned) url += "&models=" + encodeURIComponent(pinned)
+  return url
+}
+
+function nwsUserAgent() {
+  return "Omarchy weather (+https://github.com/basecamp/omarchy)"
+}
+
+function nwsPointsUrl(lat, lon) {
+  return "https://api.weather.gov/points/" + encodeURIComponent(String(lat)) + "," + encodeURIComponent(String(lon))
+}
+
+// One bash process: points -> forecast + latest observation. weather.gov
+// requires an identifying User-Agent; observation is best-effort so a
+// missing station still yields the daily forecast.
+function nwsFetchCommand(lat, lon) {
+  var ua = nwsUserAgent()
+  var script = "set -euo pipefail\n"
+    + "ua=" + shellQuote(ua) + "\n"
+    + "points=$(curl -fsS -A \"$ua\" --max-time 6 " + shellQuote(nwsPointsUrl(lat, lon)) + ")\n"
+    + "forecast_url=$(jq -er .properties.forecast <<<\"$points\")\n"
+    + "forecast=$(curl -fsS -A \"$ua\" --max-time 6 \"$forecast_url\")\n"
+    + "obs='{}'\n"
+    + "stations_url=$(jq -r '.properties.observationStations // empty' <<<\"$points\")\n"
+    + "if [[ -n $stations_url ]]; then\n"
+    + "  station=$(curl -fsS -A \"$ua\" --max-time 6 \"$stations_url\" | jq -r '.observationStations[0] // empty')\n"
+    + "  if [[ -n $station ]]; then\n"
+    + "    obs=$(curl -fsS -A \"$ua\" --max-time 6 \"$station/observations/latest\" || printf '%s' '{}')\n"
+    + "  fi\n"
+    + "fi\n"
+    + "jq -nc --argjson forecast \"$forecast\" --argjson observation \"$obs\" '{forecast:$forecast,observation:$observation}'\n"
+  return ["bash", "-c", script]
+}
+
+function nwsQuantity(value) {
+  if (value === undefined || value === null || value === "") return null
+  if (typeof value === "number") return value
+  if (typeof value === "object" && value.value !== undefined && value.value !== null && value.value !== "") {
+    var n = parseFloat(String(value.value))
+    return isNaN(n) ? null : n
+  }
+  var parsed = parseFloat(String(value))
+  return isNaN(parsed) ? null : parsed
+}
+
+function nwsTemps(value, unit) {
+  var n = parseFloat(String(value))
+  if (isNaN(n)) return { c: "", f: "" }
+  var isF = !unit || String(unit).toUpperCase() === "F"
+  if (isF) return { c: roundedTemp(fahrenheitToCelsius(n)), f: roundedTemp(n) }
+  return { c: roundedTemp(n), f: roundedTemp(celsiusToFahrenheit(n)) }
+}
+
+function nwsWindMph(text) {
+  var matches = String(text || "").match(/(\d+(?:\.\d+)?)/g)
+  if (!matches || !matches.length) return ""
+  return parseFloat(matches[matches.length - 1])
+}
+
+function iconCodeFromNwsText(text) {
+  var t = String(text || "").toLowerCase()
+  if (!t) return 3
+  if (t.indexOf("thunder") !== -1) return 95
+  if (t.indexOf("snow") !== -1 || t.indexOf("sleet") !== -1 || t.indexOf("blizzard") !== -1) return 71
+  if (t.indexOf("freezing") !== -1 || t.indexOf("ice") !== -1) return 71
+  if (t.indexOf("rain") !== -1 || t.indexOf("shower") !== -1 || t.indexOf("drizzle") !== -1) return 63
+  if (t.indexOf("fog") !== -1 || t.indexOf("mist") !== -1 || t.indexOf("haze") !== -1) return 45
+  if (t.indexOf("overcast") !== -1) return 3
+  if (t.indexOf("cloud") !== -1 && t.indexOf("partly") === -1 && t.indexOf("mostly sunny") === -1 && t.indexOf("mostly clear") === -1) return 3
+  if (t.indexOf("partly") !== -1 || t.indexOf("mostly sunny") !== -1 || t.indexOf("mostly clear") !== -1) return 2
+  if (t.indexOf("sunny") !== -1 || t.indexOf("clear") !== -1 || t.indexOf("fair") !== -1) return 0
+  return 3
+}
+
+function nwsObservationCondition(observation) {
+  var props = observation && observation.properties ? observation.properties : null
+  if (!props) return null
+  var tempC = nwsQuantity(props.temperature)
+  if (tempC === null) return null
+  var feelsC = nwsQuantity(props.heatIndex)
+  if (feelsC === null) feelsC = nwsQuantity(props.windChill)
+  if (feelsC === null) feelsC = tempC
+  var windKmh = nwsQuantity(props.windSpeed)
+  if (windKmh === null) windKmh = 0
+  var humidity = nwsQuantity(props.relativeHumidity)
+  return {
+    temp_C: roundedTemp(tempC),
+    temp_F: roundedTemp(celsiusToFahrenheit(tempC)),
+    FeelsLikeC: roundedTemp(feelsC),
+    FeelsLikeF: roundedTemp(celsiusToFahrenheit(feelsC)),
+    windspeedKmph: roundedTemp(windKmh),
+    windspeedMiles: roundedTemp(windKmh * 0.621371),
+    humidity: humidity === null ? "" : roundedTemp(humidity),
+    openMeteoWeatherCode: iconCodeFromNwsText(props.textDescription),
+    isDay: 1
+  }
+}
+
+function nwsPeriodCondition(period) {
+  if (!period || period.temperature === undefined || period.temperature === null) return null
+  var temps = nwsTemps(period.temperature, period.temperatureUnit)
+  var mph = nwsWindMph(period.windSpeed)
+  var kmh = mph === "" ? 0 : mph * 1.60934
+  return {
+    temp_C: temps.c,
+    temp_F: temps.f,
+    FeelsLikeC: temps.c,
+    FeelsLikeF: temps.f,
+    windspeedKmph: roundedTemp(kmh),
+    windspeedMiles: roundedTemp(mph === "" ? 0 : mph),
+    humidity: "",
+    openMeteoWeatherCode: iconCodeFromNwsText(period.shortForecast),
+    isDay: period.isDaytime ? 1 : 0
+  }
+}
+
+function nwsCurrentCondition(nwsReport) {
+  var fromObs = nwsObservationCondition(nwsReport && nwsReport.observation)
+  if (fromObs) return fromObs
+  var periods = nwsReport && nwsReport.forecast && nwsReport.forecast.properties
+    ? nwsReport.forecast.properties.periods : []
+  return nwsPeriodCondition(periods && periods[0] ? periods[0] : null)
+}
+
+function nwsForecastDays(nwsReport, todayString) {
+  var forecast = nwsReport && nwsReport.forecast ? nwsReport.forecast : nwsReport
+  var periods = forecast && forecast.properties && forecast.properties.periods ? forecast.properties.periods : []
+  if (!periods.length) return []
+
+  var byDate = {}
+  var order = []
+  for (var i = 0; i < periods.length; i++) {
+    var period = periods[i]
+    if (!period || !period.startTime) continue
+    var date = String(period.startTime).slice(0, 10)
+    if (!byDate[date]) {
+      byDate[date] = { date: date, day: null, night: null }
+      order.push(date)
+    }
+    if (period.isDaytime) byDate[date].day = period
+    else byDate[date].night = period
+  }
+
+  var result = []
+  for (var j = 0; j < order.length && result.length < 3; j++) {
+    var day = byDate[order[j]]
+    if (!isFutureForecastDate(day.date, todayString)) continue
+    var highPeriod = day.day || day.night
+    var lowPeriod = day.night || day.day
+    if (!highPeriod) continue
+    var high = nwsTemps(highPeriod.temperature, highPeriod.temperatureUnit)
+    var low = nwsTemps(lowPeriod.temperature, lowPeriod.temperatureUnit)
+    result.push({
+      date: day.date,
+      maxtempC: high.c,
+      mintempC: low.c,
+      maxtempF: high.f,
+      mintempF: low.f,
+      openMeteoWeatherCode: iconCodeFromNwsText(highPeriod.shortForecast)
+    })
+  }
+  return result
+}
+
+function currentCondition(hasConfiguredCoordinates, openMeteoCurrent, wttrCurrent, nwsCurrent, providerId) {
+  var kind = providerInfo(providerId).kind
+  if (kind === "nws") return nwsCurrent || null
+  if (kind === "wttr") return wttrCurrent || null
+  if (hasConfiguredCoordinates && openMeteoCurrent) return openMeteoCurrent
+  return wttrCurrent || openMeteoCurrent || null
 }
 
 function dayName(dateString, formatter) {
@@ -188,7 +421,10 @@ function provisionalCurrentIcon(current, resolvedIcon) {
   return resolvedIcon || currentIcon(current, "")
 }
 
-function weatherResponseCompletesSave(hasConfiguredCoordinates, source) {
+function weatherResponseCompletesSave(hasConfiguredCoordinates, source, providerId) {
+  var kind = providerInfo(providerId).kind
+  if (kind === "nws") return source === "nws"
+  if (kind === "wttr") return source === "wttr"
   return hasConfiguredCoordinates ? source === "open-meteo" : source === "wttr"
 }
 
@@ -201,7 +437,10 @@ function wttrNextForecastDays(report, todayString) {
   return result
 }
 
-function buildForecastDays(report, dailyForecastReport, todayString) {
+function buildForecastDays(report, dailyForecastReport, todayString, nwsReport, providerId) {
+  var kind = providerInfo(providerId).kind
+  if (kind === "nws") return nwsForecastDays(nwsReport, todayString)
+  if (kind === "wttr") return wttrNextForecastDays(report, todayString)
   var days = openMeteoForecastDays(dailyForecastReport, todayString)
   return days.length > 0 ? days : wttrNextForecastDays(report, todayString)
 }
@@ -274,11 +513,28 @@ if (typeof module !== "undefined") {
     isFutureForecastDate: isFutureForecastDate,
     roundedTemp: roundedTemp,
     celsiusToFahrenheit: celsiusToFahrenheit,
+    fahrenheitToCelsius: fahrenheitToCelsius,
     formatTemp: formatTemp,
     normalizedUnit: normalizedUnit,
     localeUsesImperial: localeUsesImperial,
     countryUsesImperial: countryUsesImperial,
     shouldUseImperial: shouldUseImperial,
+    providerCatalog: providerCatalog,
+    providerOptions: providerOptions,
+    normalizedProvider: normalizedProvider,
+    providerInfo: providerInfo,
+    openMeteoForecastUrl: openMeteoForecastUrl,
+    nwsUserAgent: nwsUserAgent,
+    nwsPointsUrl: nwsPointsUrl,
+    nwsFetchCommand: nwsFetchCommand,
+    nwsQuantity: nwsQuantity,
+    nwsTemps: nwsTemps,
+    nwsWindMph: nwsWindMph,
+    iconCodeFromNwsText: iconCodeFromNwsText,
+    nwsObservationCondition: nwsObservationCondition,
+    nwsCurrentCondition: nwsCurrentCondition,
+    nwsForecastDays: nwsForecastDays,
+    currentCondition: currentCondition,
     dayName: dayName,
     openMeteoForecastDays: openMeteoForecastDays,
     openMeteoCurrentCondition: openMeteoCurrentCondition,

--- a/shell/plugins/panels/weather/Model.js
+++ b/shell/plugins/panels/weather/Model.js
@@ -206,9 +206,9 @@ function nwsFetchCommand(lat, lon) {
     + "forecast_url=$(jq -er .properties.forecast <<<\"$points\")\n"
     + "forecast=$(curl -fsS -A \"$ua\" --max-time 6 \"$forecast_url\")\n"
     + "obs='{}'\n"
-    + "stations_url=$(jq -r '.properties.observationStations // empty' <<<\"$points\")\n"
+    + "stations_url=$(jq -r '.properties.observationStations // empty' <<<\"$points\" || true)\n"
     + "if [[ -n $stations_url ]]; then\n"
-    + "  station=$(curl -fsS -A \"$ua\" --max-time 6 \"$stations_url\" | jq -r '.observationStations[0] // empty')\n"
+    + "  station=$(curl -fsS -A \"$ua\" --max-time 6 \"$stations_url\" | jq -r '.observationStations[0] // empty' || true)\n"
     + "  if [[ -n $station ]]; then\n"
     + "    obs=$(curl -fsS -A \"$ua\" --max-time 6 \"$station/observations/latest\" || printf '%s' '{}')\n"
     + "  fi\n"
@@ -257,7 +257,12 @@ function iconCodeFromNwsText(text) {
   return 3
 }
 
-function nwsObservationCondition(observation) {
+function nwsPeriodIsDay(period) {
+  if (!period || period.isDaytime === undefined || period.isDaytime === null) return 1
+  return period.isDaytime ? 1 : 0
+}
+
+function nwsObservationCondition(observation, isDay) {
   var props = observation && observation.properties ? observation.properties : null
   if (!props) return null
   var tempC = nwsQuantity(props.temperature)
@@ -277,7 +282,7 @@ function nwsObservationCondition(observation) {
     windspeedMiles: roundedTemp(windKmh * 0.621371),
     humidity: humidity === null ? "" : roundedTemp(humidity),
     openMeteoWeatherCode: iconCodeFromNwsText(props.textDescription),
-    isDay: 1
+    isDay: Number(isDay) === 0 ? 0 : 1
   }
 }
 
@@ -300,11 +305,12 @@ function nwsPeriodCondition(period) {
 }
 
 function nwsCurrentCondition(nwsReport) {
-  var fromObs = nwsObservationCondition(nwsReport && nwsReport.observation)
-  if (fromObs) return fromObs
   var periods = nwsReport && nwsReport.forecast && nwsReport.forecast.properties
     ? nwsReport.forecast.properties.periods : []
-  return nwsPeriodCondition(periods && periods[0] ? periods[0] : null)
+  var period = periods && periods[0] ? periods[0] : null
+  var fromObs = nwsObservationCondition(nwsReport && nwsReport.observation, nwsPeriodIsDay(period))
+  if (fromObs) return fromObs
+  return nwsPeriodCondition(period)
 }
 
 function nwsForecastDays(nwsReport, todayString) {
@@ -531,6 +537,7 @@ if (typeof module !== "undefined") {
     nwsTemps: nwsTemps,
     nwsWindMph: nwsWindMph,
     iconCodeFromNwsText: iconCodeFromNwsText,
+    nwsPeriodIsDay: nwsPeriodIsDay,
     nwsObservationCondition: nwsObservationCondition,
     nwsCurrentCondition: nwsCurrentCondition,
     nwsForecastDays: nwsForecastDays,

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -70,7 +70,11 @@ Panel {
   // Parsed wttr.in j1 response. Kept on failure so stale data stays visible.
   property var report: null
   property var dailyForecastReport: null
+  property var nwsReport: null
   property string wttrLocation: ""
+
+  readonly property string weatherProvider: Model.normalizedProvider(setting("provider", "open-meteo"))
+  readonly property var weatherProviderInfo: Model.providerInfo(weatherProvider)
 
   // Configured location, read from the weather.json state file (owned by
   // omarchy-weather-location). The query is the wttr.in path segment
@@ -87,8 +91,10 @@ Panel {
     if (savingLocation) savingLocationQueryStarted = true
     forecastRetries = 0
     dailyForecastRetries = 0
+    nwsRetries = 0
     forecastProc.running = false
     dailyForecastProc.running = false
+    nwsProc.running = false
     Qt.callLater(refresh)
   }
 
@@ -113,6 +119,7 @@ Panel {
 
   property int forecastRetries: 0
   property int dailyForecastRetries: 0
+  property int nwsRetries: 0
 
   // Click-to-edit state for the location label.
   property bool editingLocation: false
@@ -128,9 +135,12 @@ Panel {
 
   // wttr's current conditions when available; open-meteo's (bundled with the
   // much faster daily forecast fetch) fill the hero while wttr is in flight.
+  // NWS uses its own observation (or the first forecast period if that misses).
   readonly property bool hasConfiguredCoordinates: !isNaN(parseFloat(String(configuredLocationState.latitude))) && !isNaN(parseFloat(String(configuredLocationState.longitude)))
   readonly property var openMeteoCurrent: Model.openMeteoCurrentCondition(dailyForecastReport)
-  readonly property var current: (hasConfiguredCoordinates && openMeteoCurrent) ? openMeteoCurrent : ((report && report.current_condition && report.current_condition[0]) ? report.current_condition[0] : openMeteoCurrent)
+  readonly property var wttrCurrent: (report && report.current_condition && report.current_condition[0]) ? report.current_condition[0] : null
+  readonly property var nwsCurrent: Model.nwsCurrentCondition(nwsReport)
+  readonly property var current: Model.currentCondition(hasConfiguredCoordinates, openMeteoCurrent, wttrCurrent, nwsCurrent, weatherProvider)
   readonly property var areaInfo: report && report.nearest_area && report.nearest_area[0] ? report.nearest_area[0] : null
   readonly property var forecastDays: buildForecastDays()
   readonly property string reportCountry: areaInfo && areaInfo.country && areaInfo.country[0] ? areaInfo.country[0].value : ""
@@ -145,7 +155,7 @@ Panel {
   readonly property string tempUnit:        "°" + (useImperial ? "F" : "C")
   readonly property string reportFeels:     current ? formatTemp(useImperial ? current.FeelsLikeF : current.FeelsLikeC) : ""
   readonly property string reportWind:      current ? (useImperial ? (current.windspeedMiles + " mph") : (current.windspeedKmph + " km/h")) : ""
-  readonly property string reportHumidity:  current ? (current.humidity + "%") : ""
+  readonly property string reportHumidity:  current && current.humidity !== undefined && current.humidity !== null && String(current.humidity) !== "" ? (current.humidity + "%") : (current ? "—" : "")
 
   function refresh() {
     // Each full refresh cycle gets a fresh retry budget, so an earlier
@@ -153,36 +163,81 @@ Panel {
     // starve retries for the rest of the session.
     forecastRetries = 0
     dailyForecastRetries = 0
-    if (!forecastProc.running) forecastProc.running = true
+    nwsRetries = 0
+    var kind = root.weatherProviderInfo.kind
+    if (kind !== "nws" || !root.hasConfiguredCoordinates) {
+      if (!forecastProc.running) forecastProc.running = true
+    }
     if (root.locationQuery === "" && !locationProc.running) locationProc.running = true
-    // With stored coordinates this fetches open-meteo right away — no need
-    // to wait for the slow wttr response. Without them it's a no-op until
-    // wttr reports the detected area.
-    refreshDailyForecast(null)
+    // With stored coordinates this fetches open-meteo / NWS right away — no
+    // need to wait for the slow wttr response. Without them it's a no-op
+    // until wttr reports the detected area.
+    if (kind === "open-meteo") refreshDailyForecast(null)
+    if (kind === "nws") refreshNwsForecast(null)
+  }
+
+  function resolvedCoordinates(sourceReport) {
+    var lat = parseFloat(String(root.configuredLocationState.latitude))
+    var lon = parseFloat(String(root.configuredLocationState.longitude))
+    if (!isNaN(lat) && !isNaN(lon)) return { latitude: lat, longitude: lon }
+
+    var area = sourceReport && sourceReport.nearest_area && sourceReport.nearest_area[0] ? sourceReport.nearest_area[0] : root.areaInfo
+    if (!area) return null
+    lat = parseFloat(String(area.latitude || ""))
+    lon = parseFloat(String(area.longitude || ""))
+    if (isNaN(lat) || isNaN(lon)) return null
+    return { latitude: lat, longitude: lon }
   }
 
   function refreshDailyForecast(sourceReport) {
     if (dailyForecastProc.running) return
+    if (root.weatherProviderInfo.kind !== "open-meteo") return
 
-    var lat = parseFloat(String(root.configuredLocationState.latitude))
-    var lon = parseFloat(String(root.configuredLocationState.longitude))
-    if (isNaN(lat) || isNaN(lon)) {
-      var area = sourceReport && sourceReport.nearest_area && sourceReport.nearest_area[0] ? sourceReport.nearest_area[0] : root.areaInfo
-      if (!area) return
-      lat = parseFloat(String(area.latitude || ""))
-      lon = parseFloat(String(area.longitude || ""))
-    }
-    if (isNaN(lat) || isNaN(lon)) return
+    var coords = root.resolvedCoordinates(sourceReport)
+    if (!coords) return
 
-    var url = "https://api.open-meteo.com/v1/forecast"
-      + "?latitude=" + encodeURIComponent(String(lat))
-      + "&longitude=" + encodeURIComponent(String(lon))
-      + "&daily=weather_code,temperature_2m_max,temperature_2m_min"
-      + "&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,weather_code,is_day"
-      + "&forecast_days=4"
-      + "&timezone=auto"
-    dailyForecastProc.command = ["curl", "-fsS", "--max-time", "5", url]
+    dailyForecastProc.command = ["curl", "-fsS", "--max-time", "5", Model.openMeteoForecastUrl(coords.latitude, coords.longitude, root.weatherProviderInfo.model)]
     dailyForecastProc.running = true
+  }
+
+  function refreshNwsForecast(sourceReport) {
+    if (nwsProc.running) return
+    if (root.weatherProviderInfo.kind !== "nws") return
+
+    var coords = root.resolvedCoordinates(sourceReport)
+    if (!coords) return
+
+    nwsProc.command = Model.nwsFetchCommand(coords.latitude, coords.longitude)
+    nwsProc.running = true
+  }
+
+  // Applied locally first so the dropdown redraws on the click itself; the
+  // shell.json write comes back through the bar as the same value.
+  function persistSettings(values) {
+    var entry = { id: root.moduleName }
+    for (var existing in root.settings) if (existing !== "id") entry[existing] = root.settings[existing]
+    for (var key in values) entry[key] = values[key]
+
+    root.settings = entry
+    if (root.hostWidget && "settings" in root.hostWidget) root.hostWidget.settings = entry
+    if (root.bar && root.bar.shell && typeof root.bar.shell.updateEntryInline === "function")
+      root.bar.shell.updateEntryInline(root.moduleName, entry)
+  }
+
+  function setProvider(id) {
+    var next = Model.normalizedProvider(id)
+    if (next === root.weatherProvider) return
+    persistSettings({ provider: next })
+  }
+
+  onWeatherProviderChanged: {
+    forecastRetries = 0
+    dailyForecastRetries = 0
+    nwsRetries = 0
+    forecastProc.running = false
+    dailyForecastProc.running = false
+    nwsProc.running = false
+    Qt.callLater(refresh)
   }
 
   // ---- Location editing. Clicking the location label swaps it for a search
@@ -278,7 +333,7 @@ Panel {
   }
 
   function buildForecastDays() {
-    return Model.buildForecastDays(report, dailyForecastReport, Qt.formatDate(new Date(), "yyyy-MM-dd"))
+    return Model.buildForecastDays(report, dailyForecastReport, Qt.formatDate(new Date(), "yyyy-MM-dd"), nwsReport, weatherProvider)
   }
 
   function openMeteoForecastDays() {
@@ -342,15 +397,19 @@ Panel {
         try {
           var parsed = JSON.parse(raw)
           root.report = parsed
-          if (!root.hasConfiguredCoordinates)
+          if (root.weatherProviderInfo.kind === "wttr")
+            root.label = Model.currentIcon(parsed.current_condition && parsed.current_condition[0], root.label)
+          else if (!root.hasConfiguredCoordinates)
             root.label = Model.provisionalCurrentIcon(parsed.current_condition && parsed.current_condition[0], root.label)
           root.forecastRetries = 0
-          if (Model.weatherResponseCompletesSave(root.hasConfiguredCoordinates, "wttr"))
+          if (Model.weatherResponseCompletesSave(root.hasConfiguredCoordinates, "wttr", root.weatherProvider))
             root.finishSavingLocation()
-          // Stored coordinates already drove the fast open-meteo fetch from
-          // refresh(); only auto-detect needs the area wttr reported.
-          if (isNaN(parseFloat(String(root.configuredLocationState.latitude))))
+          // Stored coordinates already drove the fast open-meteo / NWS fetch
+          // from refresh(); only auto-detect needs the area wttr reported.
+          if (isNaN(parseFloat(String(root.configuredLocationState.latitude)))) {
             root.refreshDailyForecast(parsed)
+            root.refreshNwsForecast(parsed)
+          }
         } catch (e) {
           // Keep last-good report visible, but try again shortly.
           root.scheduleForecastRetry()
@@ -377,15 +436,29 @@ Panel {
   // bar icon, so a dropped response (e.g. waking before the network is back)
   // must retry rather than wait out the refresh timer with a stale icon.
   function scheduleDailyForecastRetry() {
+    if (root.weatherProviderInfo.kind !== "open-meteo") return
     if (dailyForecastRetries >= 3) return
     dailyForecastRetries++
     dailyForecastRetryTimer.restart()
+  }
+
+  function scheduleNwsRetry() {
+    if (root.weatherProviderInfo.kind !== "nws") return
+    if (nwsRetries >= 3) return
+    nwsRetries++
+    nwsRetryTimer.restart()
   }
 
   Timer {
     id: dailyForecastRetryTimer
     interval: 2500
     onTriggered: root.refreshDailyForecast(null)
+  }
+
+  Timer {
+    id: nwsRetryTimer
+    interval: 2500
+    onTriggered: root.refreshNwsForecast(null)
   }
 
   Process {
@@ -402,13 +475,40 @@ Panel {
           var parsed = JSON.parse(raw)
           var parsedCurrent = Model.openMeteoCurrentCondition(parsed)
           root.dailyForecastReport = parsed
-          root.label = Model.currentIcon(parsedCurrent, root.label)
+          if (root.weatherProviderInfo.kind === "open-meteo")
+            root.label = Model.currentIcon(parsedCurrent, root.label)
           root.dailyForecastRetries = 0
-          if (Model.weatherResponseCompletesSave(root.hasConfiguredCoordinates, "open-meteo"))
+          if (Model.weatherResponseCompletesSave(root.hasConfiguredCoordinates, "open-meteo", root.weatherProvider))
             root.finishSavingLocation()
         } catch (e) {
           // Keep last-good daily forecast visible, but try again shortly.
           root.scheduleDailyForecastRetry()
+        }
+      }
+    }
+  }
+
+  Process {
+    id: nwsProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var raw = String(text || "").trim()
+        if (!raw) {
+          root.scheduleNwsRetry()
+          return
+        }
+        try {
+          var parsed = JSON.parse(raw)
+          var parsedCurrent = Model.nwsCurrentCondition(parsed)
+          root.nwsReport = parsed
+          if (root.weatherProviderInfo.kind === "nws")
+            root.label = Model.currentIcon(parsedCurrent, root.label)
+          root.nwsRetries = 0
+          if (Model.weatherResponseCompletesSave(root.hasConfiguredCoordinates, "nws", root.weatherProvider))
+            root.finishSavingLocation()
+        } catch (e) {
+          root.scheduleNwsRetry()
         }
       }
     }
@@ -444,8 +544,10 @@ Panel {
         root.savingLocationQueryStarted = true
         root.forecastRetries = 0
         root.dailyForecastRetries = 0
+        root.nwsRetries = 0
         forecastProc.running = false
         dailyForecastProc.running = false
+        nwsProc.running = false
         Qt.callLater(root.refresh)
       }
     }
@@ -498,7 +600,7 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
-      blocked: root.editingLocation
+      blocked: root.editingLocation || providerDropdown.popupOpen
       onReturnRequested: root.startEditingLocation()
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
@@ -855,6 +957,36 @@ Panel {
               }
             }
           }
+        }
+      }
+
+      PanelSeparator {
+        visible: !root.editingLocation
+        foreground: root.bar.foreground
+      }
+
+      Column {
+        visible: !root.editingLocation
+        width: parent.width
+        spacing: Style.space(8)
+
+        PanelSectionHeader {
+          text: "FORECAST"
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+          leftPadding: Style.space(16)
+        }
+
+        Dropdown {
+          id: providerDropdown
+          x: Style.space(16)
+          width: parent.width - Style.space(32)
+          showLabel: false
+          fontFamily: root.bar.fontFamily
+          foreground: root.bar.foreground
+          options: Model.providerOptions()
+          value: root.weatherProvider
+          onChanged: function(v) { root.setProvider(v) }
         }
       }
     }

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -604,6 +604,9 @@ Panel {
       onReturnRequested: root.startEditingLocation()
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
+      onTextKey: function(t) {
+        if (t === "f" || t === "F") providerDropdown.toggle()
+      }
 
       Flickable {
         id: weatherScroll

--- a/shell/plugins/panels/weather/manifest.json
+++ b/shell/plugins/panels/weather/manifest.json
@@ -16,6 +16,27 @@
     "description": "Weather pill with detail popup",
     "category": "Info",
     "allowMultiple": false,
-    "settingsForm": "weatherSettings"
+    "settingsForm": "weatherSettings",
+    "defaults": {
+      "provider": "open-meteo"
+    },
+    "schema": [
+      {
+        "key": "provider",
+        "type": "enum",
+        "label": "Forecast provider",
+        "description": "Open-Meteo is the default global forecast. National Weather Service matches US apps like Apple Weather. NOAA National Blend is a calibrated US model. ECMWF and DWD ICON are independent global models. wttr.in is the original lookup service.",
+        "options": [
+          { "value": "open-meteo", "label": "Open-Meteo" },
+          { "value": "nws", "label": "National Weather Service" },
+          { "value": "nbm", "label": "NOAA National Blend" },
+          { "value": "gfs", "label": "NOAA GFS" },
+          { "value": "ecmwf", "label": "ECMWF" },
+          { "value": "icon", "label": "DWD ICON" },
+          { "value": "wttr", "label": "wttr.in" }
+        ],
+        "defaultValue": "open-meteo"
+      }
+    ]
   }
 }

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -153,6 +153,91 @@ assertEqual(
   weather.iconForCode(389, false),
   'weather picks hourly forecast icon nearest noon'
 )
+
+assertEqual(weather.normalizedProvider(''), 'open-meteo', 'weather defaults an empty provider to Open-Meteo')
+assertEqual(weather.normalizedProvider('NWS'), 'nws', 'weather normalizes provider ids')
+assertEqual(weather.normalizedProvider('nope'), 'open-meteo', 'weather falls back from unknown providers')
+assertEqual(weather.providerInfo('nbm').model, 'ncep_nbm_conus', 'weather maps NOAA National Blend to the Open-Meteo NBM model')
+assertEqual(weather.providerInfo('gfs').kind, 'open-meteo', 'weather treats GFS as an Open-Meteo model pin')
+assertEqual(weather.providerInfo('nws').kind, 'nws', 'weather treats NWS as its own provider')
+assertEqual(weather.providerOptions().map(o => o.value).join(','), 'open-meteo,nws,nbm,gfs,ecmwf,icon,wttr', 'weather lists every forecast provider')
+
+assertEqual(
+  weather.openMeteoForecastUrl(36.023, -95.968, ''),
+  'https://api.open-meteo.com/v1/forecast?latitude=36.023&longitude=-95.968&daily=weather_code,temperature_2m_max,temperature_2m_min&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,weather_code,is_day&forecast_days=4&timezone=auto',
+  'weather Open-Meteo URL omits models for the default provider'
+)
+assert(
+  weather.openMeteoForecastUrl(36.023, -95.968, 'ncep_nbm_conus').endsWith('&models=ncep_nbm_conus'),
+  'weather Open-Meteo URL pins a selected model'
+)
+
+const nwsCommand = weather.nwsFetchCommand(36.023, -95.968)
+assertEqual(nwsCommand[0], 'bash', 'weather NWS fetch runs through bash')
+assert(nwsCommand[2].includes('api.weather.gov/points/36.023,-95.968'), 'weather NWS fetch starts at the points API')
+assert(nwsCommand[2].includes(weather.nwsUserAgent()), 'weather NWS fetch sends an identifying User-Agent')
+
+const nwsForecast = {
+  forecast: {
+    properties: {
+      periods: [
+        { name: 'Today', startTime: '2026-08-26T09:00:00-05:00', isDaytime: true, temperature: 95, temperatureUnit: 'F', shortForecast: 'Partly Sunny' },
+        { name: 'Tonight', startTime: '2026-08-26T18:00:00-05:00', isDaytime: false, temperature: 72, temperatureUnit: 'F', shortForecast: 'Mostly Clear' },
+        { name: 'Thursday', startTime: '2026-08-27T06:00:00-05:00', isDaytime: true, temperature: 94, temperatureUnit: 'F', shortForecast: 'Mostly Sunny' },
+        { name: 'Thursday Night', startTime: '2026-08-27T18:00:00-05:00', isDaytime: false, temperature: 68, temperatureUnit: 'F', shortForecast: 'Mostly Clear' },
+        { name: 'Friday', startTime: '2026-08-28T06:00:00-05:00', isDaytime: true, temperature: 94, temperatureUnit: 'F', shortForecast: 'Sunny' },
+        { name: 'Friday Night', startTime: '2026-08-28T18:00:00-05:00', isDaytime: false, temperature: 70, temperatureUnit: 'F', shortForecast: 'Mostly Clear' },
+        { name: 'Saturday', startTime: '2026-08-29T06:00:00-05:00', isDaytime: true, temperature: 97, temperatureUnit: 'F', shortForecast: 'Sunny' },
+        { name: 'Saturday Night', startTime: '2026-08-29T18:00:00-05:00', isDaytime: false, temperature: 73, temperatureUnit: 'F', shortForecast: 'Mostly Clear' }
+      ]
+    }
+  },
+  observation: {
+    properties: {
+      temperature: { value: 29 },
+      heatIndex: { value: 32.7 },
+      windSpeed: { value: 14.832 },
+      relativeHumidity: { value: 70.1 },
+      textDescription: 'Clear'
+    }
+  }
+}
+
+assertDeepEqual(
+  weather.nwsForecastDays(nwsForecast, '2026-08-26').map(day => ({ date: day.date, maxtempF: day.maxtempF, mintempF: day.mintempF })),
+  [
+    { date: '2026-08-27', maxtempF: '94', mintempF: '68' },
+    { date: '2026-08-28', maxtempF: '94', mintempF: '70' },
+    { date: '2026-08-29', maxtempF: '97', mintempF: '73' }
+  ],
+  'weather groups NWS day/night periods into future daily highs and lows'
+)
+assertDeepEqual(
+  weather.nwsCurrentCondition(nwsForecast),
+  { temp_C: '29', temp_F: '84', FeelsLikeC: '33', FeelsLikeF: '91', windspeedKmph: '15', windspeedMiles: '9', humidity: '70', openMeteoWeatherCode: 0, isDay: 1 },
+  'weather normalizes NWS observations to the shared current-condition shape'
+)
+assertEqual(weather.nwsCurrentCondition({ forecast: nwsForecast.forecast }).temp_F, '95', 'weather falls back to the first NWS period without an observation')
+assertEqual(weather.iconCodeFromNwsText('Mostly Sunny'), 2, 'weather maps NWS partly-sunny text to a partly-cloudy icon')
+assertEqual(weather.iconCodeFromNwsText('Thunderstorms'), 95, 'weather maps NWS thunder text to a storm icon')
+assertEqual(weather.nwsWindMph('5 to 10 mph'), 10, 'weather reads the upper NWS wind range')
+
+assertEqual(weather.buildForecastDays(wttr, {}, '2026-08-26', nwsForecast, 'nws')[0].maxtempF, '94', 'weather uses NWS days when that provider is selected')
+assertEqual(weather.buildForecastDays(wttr, openMeteo, '2026-05-25', nwsForecast, 'wttr')[0].date, '2026-05-26', 'weather uses wttr days when that provider is selected')
+assertEqual(weather.buildForecastDays(wttr, openMeteo, '2026-05-25', nwsForecast, 'open-meteo')[0].date, '2026-05-26', 'weather keeps Open-Meteo days for the default provider')
+assertEqual(weather.currentCondition(true, { temp_F: '99' }, { temp_F: '78' }, { temp_F: '84' }, 'nws').temp_F, '84', 'weather current conditions follow the selected provider')
+assertEqual(weather.currentCondition(true, { temp_F: '99' }, { temp_F: '78' }, { temp_F: '84' }, 'open-meteo').temp_F, '99', 'weather current conditions prefer Open-Meteo for a pinned location')
+
+assert(weather.weatherResponseCompletesSave(true, 'nws', 'nws'), 'weather completes a pinned NWS location save with NWS data')
+assert(!weather.weatherResponseCompletesSave(true, 'open-meteo', 'nws'), 'weather keeps the spinner through a non-NWS response when NWS is selected')
+assert(weather.weatherResponseCompletesSave(true, 'wttr', 'wttr'), 'weather completes a wttr provider save with wttr data')
+
+assert(panelSource.includes('text: "FORECAST"'), 'weather panel exposes a forecast provider dropdown')
+assert(panelSource.includes('root.setProvider(v)'), 'weather panel persists the selected forecast provider')
+assert(panelSource.includes('onWeatherProviderChanged:'), 'weather refetches when the provider setting changes')
+assert(panelSource.includes('Model.openMeteoForecastUrl'), 'weather panel builds Open-Meteo URLs from the selected model')
+assert(panelSource.includes('Model.nwsFetchCommand'), 'weather panel fetches NWS through the shared command builder')
+assert(panelSource.includes('blocked: root.editingLocation || providerDropdown.popupOpen'), 'weather blocks panel keys while the provider dropdown is open')
 JS
 
 test_tmp=$(mktemp -d)

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -176,6 +176,10 @@ const nwsCommand = weather.nwsFetchCommand(36.023, -95.968)
 assertEqual(nwsCommand[0], 'bash', 'weather NWS fetch runs through bash')
 assert(nwsCommand[2].includes('api.weather.gov/points/36.023,-95.968'), 'weather NWS fetch starts at the points API')
 assert(nwsCommand[2].includes(weather.nwsUserAgent()), 'weather NWS fetch sends an identifying User-Agent')
+assert(
+  nwsCommand[2].includes(".observationStations[0] // empty' || true"),
+  'weather NWS station lookup is best-effort so a failed observation still yields the forecast'
+)
 
 const nwsForecast = {
   forecast: {
@@ -218,6 +222,15 @@ assertDeepEqual(
   'weather normalizes NWS observations to the shared current-condition shape'
 )
 assertEqual(weather.nwsCurrentCondition({ forecast: nwsForecast.forecast }).temp_F, '95', 'weather falls back to the first NWS period without an observation')
+assertEqual(weather.nwsPeriodIsDay({ isDaytime: false }), 0, 'weather reads nighttime from an NWS period')
+assertEqual(
+  weather.nwsCurrentCondition({
+    forecast: { properties: { periods: [{ isDaytime: false, temperature: 72, temperatureUnit: 'F', shortForecast: 'Mostly Clear' }] } },
+    observation: nwsForecast.observation
+  }).isDay,
+  0,
+  'weather uses the current NWS period for observation day/night icons'
+)
 assertEqual(weather.iconCodeFromNwsText('Mostly Sunny'), 2, 'weather maps NWS partly-sunny text to a partly-cloudy icon')
 assertEqual(weather.iconCodeFromNwsText('Thunderstorms'), 95, 'weather maps NWS thunder text to a storm icon')
 assertEqual(weather.nwsWindMph('5 to 10 mph'), 10, 'weather reads the upper NWS wind range')
@@ -238,6 +251,8 @@ assert(panelSource.includes('onWeatherProviderChanged:'), 'weather refetches whe
 assert(panelSource.includes('Model.openMeteoForecastUrl'), 'weather panel builds Open-Meteo URLs from the selected model')
 assert(panelSource.includes('Model.nwsFetchCommand'), 'weather panel fetches NWS through the shared command builder')
 assert(panelSource.includes('blocked: root.editingLocation || providerDropdown.popupOpen'), 'weather blocks panel keys while the provider dropdown is open')
+assert(panelSource.includes('t === "f" || t === "F"'), 'weather opens the forecast dropdown from the f key')
+assert(panelSource.includes('providerDropdown.toggle()'), 'weather toggles the forecast dropdown from the keyboard')
 JS
 
 test_tmp=$(mktemp -d)


### PR DESCRIPTION
## What

The weather panel’s daily highs come from Open-Meteo’s default model (GFS in the US), which can run 8–12°F hotter than the NWS/Apple forecast. This adds a Forecast dropdown so you can pick the source.

Open-Meteo stays the default. National Weather Service is the US official forecast. NOAA National Blend, GFS, ECMWF, DWD ICON, and wttr.in are also available.

`omarchy bar set omarchy.weather provider nws`

## Test plan

- [x] `bash test/shell.d/weather-test.sh`
- [x] Open-Meteo still shows the old GFS highs
- [x] Switching to National Weather Service matches weather.gov