### PR TITLE
agents: support spend limits for Claude Enterprise

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -760,9 +760,33 @@ def probe_limits(access_token: str) -> dict[str, Any]:
       limits.append({"label": "Weekly (7-day)", "percent": percent, "resetsAt": normalize_reset_at(weekly.get("resets_at"))})
   limits.extend(scoped_limits(payload, percent_scale))
 
-  if not limits:
+
+  balance = None
+  spend = payload.get("spend")
+  if isinstance(spend, dict) and isinstance(spend.get("limit"), dict) and isinstance(spend.get("used"), dict):
+    limit_minor = number(spend["limit"].get("amount_minor"))
+    limit_exp = number(spend["limit"].get("exponent", 2))
+    used_minor = number(spend["used"].get("amount_minor"))
+    used_exp = number(spend["used"].get("exponent", 2))
+    funded = limit_minor / (10 ** limit_exp)
+    spent = used_minor / (10 ** used_exp)
+    if funded > 0:
+      balance = {
+        "remaining": max(0, funded - spent),
+        "funded": funded,
+        "spent": spent,
+        "currency": str(spend["limit"].get("currency", "USD")),
+        "estimated": False,
+        "type": "spend_limit"
+      }
+
+  if not limits and not balance:
     return {"ok": False, "helpText": "Anthropic's usage endpoint returned no limits. Local Claude Code stats are still shown."}
-  return {"ok": True, "limits": limits}
+  
+  ans = {"ok": True, "limits": limits}
+  if balance:
+    ans["balance"] = balance
+  return ans
 
 
 # A cached percentage outlives the probe that measured it, but only until its
@@ -791,6 +815,7 @@ def usable_cached_limits(cached: dict[str, Any]) -> list[dict[str, Any]]:
   return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
 
 
+
 def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[str, Any]:
   result = {"limits": [], "usageStatusText": "", "authHelpText": AUTH_HELP}
 
@@ -800,22 +825,20 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
   probe_cache = cache_root() / "claude-limits.json"
   cached = read_fresh_json(probe_cache, float("inf")) or {}
   fallback = usable_cached_limits(cached)
+  fallback_balance = cached.get("balance")
 
-  # Probing needs a live token and only the Claude Code CLI can mint one: it
-  # refreshes the credential file when it runs, so a machine left alone long
-  # enough finds the saved token lapsed. Say so — an empty limits list with
-  # nothing else set hides the whole section and explains nothing — and keep
-  # showing the last numbers whose window has not since reset.
   if access_token == "":
     result["limits"] = fallback
+    if fallback_balance: result["balance"] = fallback_balance
     result["usageStatusText"] = "Waiting for auth"
     return result
   if expires_at_ms > 0 and expires_at_ms <= time.time() * 1000:
     result["limits"] = fallback
+    if fallback_balance: result["balance"] = fallback_balance
     result["usageStatusText"] = "Sign-in expired"
     result["authHelpText"] = (
       "Claude Code's saved sign-in expired"
-      + (" — showing the last known limits." if fallback else ".")
+      + (" — showing the last known limits." if fallback or fallback_balance else ".")
       + " Start Claude Code, or run `claude auth login`, to refresh it."
     )
     return result
@@ -824,27 +847,30 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
   # entirely; the interval is there to absorb repeated panel opens, not to
   # overrule someone who pressed refresh.
   fetched_at = number(cached.get("fetchedAtMs")) / 1000
-  if fallback and not force and time.time() - fetched_at < PROBE_MIN_INTERVAL_SECONDS:
+  if (fallback or fallback_balance) and not force and time.time() - fetched_at < PROBE_MIN_INTERVAL_SECONDS:
     result["limits"] = fallback
+    if fallback_balance: result["balance"] = fallback_balance
     return result
 
   probe = probe_limits(access_token)
   if probe["ok"]:
     result["limits"] = probe["limits"]
-    write_json(probe_cache, {"fetchedAtMs": round(time.time() * 1000), "limits": probe["limits"]})
+    if "balance" in probe:
+      result["balance"] = probe["balance"]
+    write_json(probe_cache, {"fetchedAtMs": round(time.time() * 1000), "limits": probe["limits"], "balance": probe.get("balance")})
     return result
 
   # The first probe after login often fires before DHCP has handed out a
   # route. Ask the shell to try again sooner than its regular interval.
   if probe.get("transport"):
     result["retryAdvised"] = True
-  if fallback:
+  if fallback or fallback_balance:
     result["limits"] = fallback
+    if fallback_balance: result["balance"] = fallback_balance
   else:
     result["usageStatusText"] = "Claude limits unavailable"
     result["authHelpText"] = probe["helpText"]
   return result
-
 
 # -------------------------------------------------------------------- record
 
@@ -882,19 +908,23 @@ def main() -> int:
   access_token, expires_at_ms, plan = oauth_login(claude_dir)
   limits = collect_limits(access_token, expires_at_ms, args.force)
 
+
   record = {
     "schemaVersion": 1,
     "id": AGENT_ID,
     "name": AGENT_NAME,
     "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
-    "ready": number(stats.get("totalPrompts")) > 0 or len(limits["limits"]) > 0,
+    "ready": number(stats.get("totalPrompts")) > 0 or len(limits.get("limits", [])) > 0 or "balance" in limits,
     "hasLocalStats": True,
     "tierLabel": plan,
     "usageStatusText": limits["usageStatusText"],
     "authHelpText": limits["authHelpText"],
     "limits": limits["limits"],
   }
+  if "balance" in limits:
+    record["balance"] = limits["balance"]
   if limits.get("retryAdvised"):
+
     record["retryAdvised"] = True
   record.update(stats)
   print(json.dumps(record, separators=(",", ":"), sort_keys=True))

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -235,7 +235,8 @@ Item {
       funded: isFinite(funded) && funded > 0 ? funded : 0,
       spent: Math.max(0, Number(raw.spent) || 0),
       currency: String(raw.currency || "USD"),
-      estimated: raw.estimated === true
+      estimated: raw.estimated === true,
+      type: raw.type ? String(raw.type) : "prepaid"
     }
   }
 

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -169,7 +169,8 @@ Panel {
 
   function balanceDetailText(b) {
     if (!b || !(b.funded > 0)) return ""
-    var text = formatMoney(b.spent, b.currency) + " spent of " + formatMoney(b.funded, b.currency) + " funded"
+    var denominator = b.type === "spend_limit" ? " limit" : " funded"
+    var text = formatMoney(b.spent, b.currency) + " spent of " + formatMoney(b.funded, b.currency) + denominator
     if (b.estimated) text += " · estimated"
     return text
   }

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -529,15 +529,16 @@ Panel {
             width: parent.width
             spacing: Style.space(10)
 
-            // The meter shows what is left, not what is used: a prepaid
-            // account drains toward empty rather than filling toward a cap.
+            readonly property bool isSpendLimit: root.balance && root.balance.type === "spend_limit"
+
+            // Prepaid accounts drain toward empty. Spend limits fill toward a cap.
             readonly property real ratio: root.balance && root.balance.funded > 0
-              ? root.clamp(root.balance.remaining / root.balance.funded, 0, 1)
+              ? root.clamp(balanceSection.isSpendLimit ? (root.balance.spent / root.balance.funded) : (root.balance.remaining / root.balance.funded), 0, 1)
               : -1
 
             PanelSectionHeader {
               width: parent.width
-              text: "BALANCE"
+              text: balanceSection.isSpendLimit ? "SPEND LIMIT" : "BALANCE"
               foreground: root.foreground
               fontFamily: root.fontFamily
             }
@@ -548,7 +549,7 @@ Panel {
 
               Text {
                 id: balanceLabel
-                text: "Prepaid credits"
+                text: balanceSection.isSpendLimit ? "Used" : "Prepaid credits"
                 color: root.foreground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.body
@@ -558,7 +559,7 @@ Panel {
 
               Text {
                 id: balanceValue
-                text: root.balance ? root.formatMoney(root.balance.remaining, root.balance.currency) : ""
+                text: root.balance ? root.formatMoney(balanceSection.isSpendLimit ? root.balance.spent : root.balance.remaining, root.balance.currency) : ""
                 color: root.balanceAlarming ? root.urgent : root.foreground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.caption

--- a/test/shell.d/agents-main-test.sh
+++ b/test/shell.d/agents-main-test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const mainSource = fs.readFileSync(root + '/shell/plugins/agents/Main.qml', 'utf8')
+
+assert(/type:\s*raw\.type\s*\?/.test(mainSource), 'agents main normalizes balance type')
+JS


### PR DESCRIPTION
Enterprise accounts on the Claude API do not return the standard token allowances, but instead expose a `spend` block with a financial limit.

This patch extracts that spend limit and tags it as a `spend_limit` balance type. The agents widget panel is updated to render `spend_limit` balances as a filling progress bar labeled "SPEND LIMIT" (unlike prepaid balances, which drain toward empty).

Fixes issue where Enterprise users get a "Claude limit unavailable - Anthropic's usage endpoint returned no limits..." message in the Omarchy agent widget.

<img width="498" height="646" alt="image" src="https://github.com/user-attachments/assets/c0b3e99d-aede-4364-9f93-4126701ce515" />
