### PR TITLE
Stop a font choice capturing every family named *mono*

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -46,22 +46,27 @@ fi
 
 # fontconfig is the canonical source of truth — the omarchy shell, Qt apps,
 # and anything resolving "monospace" all read from here. This file is loaded
-# after the package-owned default, and prepend_first puts the chosen family at
-# the head of the list so it wins over the family that default prefers.
+# after the package-owned default, and the alias inserts the chosen family
+# right where the generic sits, ahead of the family that default appends.
+#
+# An alias rather than a prepend_first edit: /etc/fonts/conf.d/48-guessfamily.conf
+# appends the generic "monospace" to every pattern whose family name merely
+# contains "mono", so a request for "Liberation Mono" arrives here carrying the
+# generic too. prepend_first would put the chosen family at the head of that
+# list, ahead of the family the application actually asked for, and every
+# installed font with "mono" in its name would resolve to this one.
 fontconfig_file="$HOME/.config/fontconfig/fonts.conf"
 mkdir -p "$(dirname "$fontconfig_file")"
 cat >"$fontconfig_file" <<XML
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
-  <match target="pattern">
-    <test name="family" qual="any">
-      <string>monospace</string>
-    </test>
-    <edit name="family" mode="prepend_first" binding="strong">
-      <string>$font_name</string>
-    </edit>
-  </match>
+  <alias binding="strong">
+    <family>monospace</family>
+    <prefer>
+      <family>$font_name</family>
+    </prefer>
+  </alias>
 </fontconfig>
 XML
 

--- a/default/fontconfig/conf.avail/50-omarchy.conf
+++ b/default/fontconfig/conf.avail/50-omarchy.conf
@@ -19,14 +19,17 @@
     </edit>
   </match>
 
-  <match target="pattern">
-    <test name="family" qual="any">
-      <string>monospace</string>
-    </test>
-    <edit name="family" mode="assign" binding="strong">
-      <string>JetBrainsMono Nerd Font</string>
-    </edit>
-  </match>
+  <!-- A default rather than an assignment, so it lands at the end of the
+       family list instead of consuming the generic. Assigning replaces the
+       monospace token itself, which leaves nothing for the user's own
+       fontconfig to match on, and `omarchy font set` silently stops working
+       once this file is loaded ahead of it. -->
+  <alias binding="strong">
+    <family>monospace</family>
+    <default>
+      <family>JetBrainsMono Nerd Font</family>
+    </default>
+  </alias>
 
   <!-- Arabic: prefer Naskh (standard Arabic) over Nastaliq (Urdu style) -->
   <match target="pattern">

--- a/migrations/1787771328.sh
+++ b/migrations/1787771328.sh
@@ -1,0 +1,53 @@
+echo "Rewrite the font override that captured every family named *mono*"
+
+# `omarchy font set` wrote the chosen family as a prepend_first edit on any
+# pattern carrying the monospace generic. /etc/fonts/conf.d/48-guessfamily.conf
+# appends that generic to every pattern whose family name merely contains
+# "mono", so the edit fired for a request naming Liberation Mono as readily as
+# for one naming monospace, and put the chosen family at the head of the list,
+# ahead of the family the application actually asked for. Every install that
+# picked a font since then carries that file, and rewriting it only happens on
+# the next pick. Restate it as the alias it should have been, which inserts the
+# family at the generic instead of at the head.
+
+fontconfig_file="$HOME/.config/fontconfig/fonts.conf"
+
+[[ -f $fontconfig_file ]] || exit 0
+
+font_name=$(sed -n '/mode="prepend_first"/{n;s#^ *<string>\(.*\)</string> *$#\1#p;}' "$fontconfig_file")
+
+[[ -n $font_name ]] || exit 0
+
+previous_override() {
+  cat <<XML
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend_first" binding="strong">
+      <string>$font_name</string>
+    </edit>
+  </match>
+</fontconfig>
+XML
+}
+
+# The whole file has to be what that version wrote, so an override someone has
+# edited by hand is left as it is rather than silently replaced.
+[[ $(<"$fontconfig_file") == "$(previous_override)" ]] || exit 0
+
+cat >"$fontconfig_file" <<XML
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <alias binding="strong">
+    <family>monospace</family>
+    <prefer>
+      <family>$font_name</family>
+    </prefer>
+  </alias>
+</fontconfig>
+XML

--- a/test/shell.d/font-set-test.sh
+++ b/test/shell.d/font-set-test.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command python3
+
+migration="$ROOT/migrations/1787771328.sh"
+default_fontconfig="$ROOT/default/fontconfig/conf.avail/50-omarchy.conf"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin"
+
+cat >"$test_dir/bin/fc-list" <<'STUB'
+#!/bin/bash
+
+echo "${FONT_SET_TEST_FAMILY:-Test Mono S}"
+STUB
+
+for stub in omarchy-restart-shell omarchy-notification-send omarchy-hook; do
+  printf '#!/bin/bash\n\nexit 0\n' >"$test_dir/bin/$stub"
+done
+
+# No terminal is running under a fake home, so the restart toasts stay quiet.
+printf '#!/bin/bash\n\nexit 1\n' >"$test_dir/bin/pgrep"
+
+chmod +x "$test_dir/bin/"*
+
+home="$test_dir/home"
+fontconfig_file="$home/.config/fontconfig/fonts.conf"
+
+# The override "omarchy font set" wrote before the alias: it fires on any
+# pattern carrying the monospace generic, and 48-guessfamily.conf appends that
+# generic to every family whose name merely contains "mono".
+legacy_override() {
+  cat <<XML
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend_first" binding="strong">
+      <string>$1</string>
+    </edit>
+  </match>
+</fontconfig>
+XML
+}
+
+expected_override() {
+  cat <<XML
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <alias binding="strong">
+    <family>monospace</family>
+    <prefer>
+      <family>$1</family>
+    </prefer>
+  </alias>
+</fontconfig>
+XML
+}
+
+run_migration() {
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+set_font() {
+  rm -rf "$home"
+  mkdir -p "$home"
+  HOME="$home" FONT_SET_TEST_FAMILY="$1" PATH="$test_dir/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-font-set" "$1" >/dev/null
+}
+
+# --- The generic keeps its place in the family list ---------------------------
+
+# Read as XML rather than as text. Both properties hold or not regardless of how
+# a rule is spelled, where matching the spelling would accept a rule that
+# consumes the generic without `qual="any"` and reject an append that behaves
+# exactly like the one shipped.
+packaged=$(python3 - "$default_fontconfig" <<'PYTHON'
+import sys, xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+
+# Anything that replaces the element it matched, or jumps the head of the list,
+# takes the generic away from the user file fontconfig loads next.
+CONSUMING = {"assign", "assign_replace", "prepend_first"}
+
+def matches_generic(match):
+  if match.get("target") not in (None, "pattern"):
+    return False
+  return any((string.text or "").strip() == "monospace"
+             for test in match.findall("test") if test.get("name") == "family"
+             for string in test.findall("string"))
+
+consumed = [edit.get("mode", "assign")
+            for match in root.findall("match") if matches_generic(match)
+            for edit in match.findall("edit")
+            if edit.get("name") == "family" and edit.get("mode", "assign") in CONSUMING]
+
+# The packaged family may arrive as an alias default or as an appending edit;
+# either one leaves the generic in place for the user override to match on.
+fallbacks = ["%s %s" % ((family.text or "").strip(), alias.get("binding") or "weak")
+             for alias in root.findall("alias")
+             if alias.find("family") is not None
+             and (alias.find("family").text or "").strip() == "monospace"
+             for default in alias.findall("default")
+             for family in default.findall("family")]
+
+fallbacks += ["%s %s" % ((string.text or "").strip(), edit.get("binding") or "weak")
+              for match in root.findall("match") if matches_generic(match)
+              for edit in match.findall("edit")
+              if edit.get("name") == "family" and edit.get("mode") in ("append", "append_last")
+              for string in edit.findall("string")]
+
+print("consumed:", ", ".join(consumed) if consumed else "nothing")
+print("fallback:", "; ".join(fallbacks) if fallbacks else "none")
+PYTHON
+)
+
+[[ $packaged == *"consumed: nothing"* ]] ||
+  fail "the packaged default leaves the monospace generic in the pattern" "$packaged"
+pass "the packaged default leaves the monospace generic in the pattern"
+
+# The strong binding is load-bearing: weak, and 60-latin.conf's own monospace
+# list outranks it on a machine that has chosen no font.
+[[ $packaged == *"fallback: JetBrainsMono Nerd Font strong"* ]] ||
+  fail "the packaged default names its own family after the generic, strongly bound" "$packaged"
+pass "the packaged default names its own family after the generic, strongly bound"
+
+# --- omarchy-font-set writes the alias ---------------------------------------
+
+set_font "Test Mono S"
+
+[[ $(<"$fontconfig_file") == "$(expected_override "Test Mono S")" ]] ||
+  fail "omarchy-font-set writes the chosen family as an alias" "$(cat "$fontconfig_file")"
+pass "omarchy-font-set writes the chosen family as an alias"
+
+# --- The migration repairs an override the old command left behind ------------
+
+rm -rf "$home"
+mkdir -p "$(dirname "$fontconfig_file")"
+legacy_override "Test Mono S" >"$fontconfig_file"
+run_migration
+
+[[ $(<"$fontconfig_file") == "$(expected_override "Test Mono S")" ]] ||
+  fail "migration rewrites the legacy override and keeps the chosen family" "$(cat "$fontconfig_file")"
+pass "migration rewrites the legacy override and keeps the chosen family"
+
+before=$(<"$fontconfig_file")
+run_migration
+
+[[ $(<"$fontconfig_file") == "$before" ]] ||
+  fail "migration is idempotent" "$(cat "$fontconfig_file")"
+pass "migration is idempotent"
+
+# --- Anything else stays as the user left it ----------------------------------
+
+rm -rf "$home"
+mkdir -p "$(dirname "$fontconfig_file")"
+cat >"$fontconfig_file" <<'XML'
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend_first" binding="strong">
+      <string>Test Mono S</string>
+    </edit>
+  </match>
+  <match target="pattern">
+    <edit name="rgba" mode="assign">
+      <const>none</const>
+    </edit>
+  </match>
+</fontconfig>
+XML
+customized=$(<"$fontconfig_file")
+run_migration
+
+[[ $(<"$fontconfig_file") == "$customized" ]] ||
+  fail "migration leaves a hand-edited override alone" "$(cat "$fontconfig_file")"
+pass "migration leaves a hand-edited override alone"
+
+rm -rf "$home"
+mkdir -p "$home"
+run_migration
+
+[[ ! -e $fontconfig_file ]] ||
+  fail "migration writes nothing when no override exists" "$(cat "$fontconfig_file")"
+pass "migration writes nothing when no override exists"
+
+# --- What fontconfig resolves with those files --------------------------------
+
+# The assertions above pin what the two files say; this one pins what fontconfig
+# does with them, which is the only part a user ever sees. It needs the system
+# fontconfig directory and enough monospace families installed to tell a capture
+# apart from a correct match, so it skips where a machine cannot answer.
+
+packaged_family="JetBrainsMono Nerd Font"
+fixture="$test_dir/fontconfig"
+
+installed_mono_families() {
+  fc-list :spacing=100 family | tr ',' '\n' | sed 's/^ *//; s/ *$//' | sort -u
+}
+
+build_fixture() {
+  rm -rf "$fixture"
+  mkdir -p "$fixture/conf.d" "$fixture/cache"
+
+  local file
+  for file in /etc/fonts/conf.d/*.conf; do
+    ln -s "$file" "$fixture/conf.d/${file##*/}"
+  done
+
+  # Only the packaged file is swapped for the one under test; the rest of the
+  # system directory loads exactly as it would on the machine.
+  rm -f "$fixture/conf.d/50-omarchy.conf"
+  cp "$default_fontconfig" "$fixture/conf.d/50-omarchy.conf"
+
+  sed "s#<include ignore_missing=\"yes\">conf.d</include>#<include ignore_missing=\"yes\">$fixture/conf.d</include>#" \
+    /etc/fonts/fonts.conf >"$fixture/fonts.conf"
+}
+
+resolve() {
+  FONTCONFIG_FILE="$fixture/fonts.conf" XDG_CONFIG_HOME="$home/.config" XDG_CACHE_HOME="$fixture/cache" \
+    fc-match "$1" family | cut -d, -f1
+}
+
+resolvable=1
+command -v fc-match >/dev/null && command -v fc-list >/dev/null || resolvable=0
+# Without the guessfamily rules the capture cannot happen in the first place,
+# and without the packaged family there is no default left to compare against.
+[[ -r /etc/fonts/fonts.conf && -r /etc/fonts/conf.d/48-guessfamily.conf ]] || resolvable=0
+
+chosen=""
+named=""
+if ((resolvable)); then
+  installed_mono_families | grep -Fxq "$packaged_family" || resolvable=0
+fi
+if ((resolvable)); then
+  mapfile -t candidates < <(installed_mono_families | grep -i mono | grep -Fxv "$packaged_family")
+  chosen=${candidates[0]:-}
+  named=${candidates[1]:-}
+  [[ -n $chosen && -n $named ]] || resolvable=0
+fi
+
+if ((resolvable)); then
+  build_fixture
+
+  rm -rf "$home"
+  mkdir -p "$home/.config"
+
+  [[ $(resolve monospace) == "$packaged_family" ]] ||
+    fail "with no font chosen, monospace resolves to the packaged family" "$(resolve monospace)"
+  pass "with no font chosen, monospace resolves to the packaged family"
+
+  set_font "$chosen"
+
+  [[ $(resolve monospace) == "$chosen" ]] ||
+    fail "the chosen family follows the monospace generic" "monospace -> $(resolve monospace), wanted $chosen"
+  pass "the chosen family follows the monospace generic"
+
+  [[ $(resolve "$named") == "$named" ]] ||
+    fail "a named mono family still resolves to itself" "$named -> $(resolve "$named"), chosen was $chosen"
+  pass "a named mono family still resolves to itself"
+else
+  pass "no fontconfig fixture on this machine; skipping resolution checks"
+fi

--- a/test/shell.d/font-set-test.sh
+++ b/test/shell.d/font-set-test.sh
@@ -233,7 +233,16 @@ build_fixture() {
 
 resolve() {
   FONTCONFIG_FILE="$fixture/fonts.conf" XDG_CONFIG_HOME="$home/.config" XDG_CACHE_HOME="$fixture/cache" \
-    fc-match "$1" family | cut -d, -f1
+    fc-match "$1" family
+}
+
+# fc-match answers with every name the matched font carries, and a family can be
+# a font's alternate name: "JetBrainsMono NF" answers "JetBrainsMono Nerd
+# Font,JetBrainsMono NF". Reading only the head calls that a capture.
+resolved_to() {
+  local answer=$1 family=$2
+
+  [[ ,$answer, == *",$family,"* ]]
 }
 
 resolvable=1
@@ -260,18 +269,21 @@ if ((resolvable)); then
   rm -rf "$home"
   mkdir -p "$home/.config"
 
-  [[ $(resolve monospace) == "$packaged_family" ]] ||
-    fail "with no font chosen, monospace resolves to the packaged family" "$(resolve monospace)"
+  answer=$(resolve monospace)
+  resolved_to "$answer" "$packaged_family" ||
+    fail "with no font chosen, monospace resolves to the packaged family" "monospace -> $answer"
   pass "with no font chosen, monospace resolves to the packaged family"
 
   set_font "$chosen"
 
-  [[ $(resolve monospace) == "$chosen" ]] ||
-    fail "the chosen family follows the monospace generic" "monospace -> $(resolve monospace), wanted $chosen"
+  answer=$(resolve monospace)
+  resolved_to "$answer" "$chosen" ||
+    fail "the chosen family follows the monospace generic" "monospace -> $answer, wanted $chosen"
   pass "the chosen family follows the monospace generic"
 
-  [[ $(resolve "$named") == "$named" ]] ||
-    fail "a named mono family still resolves to itself" "$named -> $(resolve "$named"), chosen was $chosen"
+  answer=$(resolve "$named")
+  resolved_to "$answer" "$named" ||
+    fail "a named mono family still resolves to itself" "$named -> $answer, chosen was $chosen"
   pass "a named mono family still resolves to itself"
 else
   pass "no fontconfig fixture on this machine; skipping resolution checks"


### PR DESCRIPTION
Fixes #8404.

## Problem

`omarchy font set` wrote the chosen family as a `prepend_first` edit on any pattern carrying the `monospace` generic:

```xml
<match target="pattern">
  <test name="family" qual="any"><string>monospace</string></test>
  <edit name="family" mode="prepend_first" binding="strong"><string>$font_name</string></edit>
</match>
```

`/etc/fonts/conf.d/48-guessfamily.conf` loads earlier and appends that generic to every pattern whose family name merely *contains* `mono`, so a request naming `Liberation Mono` arrives here as `[Liberation Mono, monospace]` and matches. `prepend_first` then inserts at the head of the whole list, ahead of the family the application actually asked for.

The result: every installed font with `mono` in its name resolves to the chosen one, and launching a terminal with an explicit font override renders in the wrong font with no error. Monaspace is the single family that escapes — its name does not contain `mono`, so `48-guessfamily.conf` never appends the generic to it, which is what makes the bug invisible if that is what you test with.

## Fix

An `alias`/`prefer` inserts the family at the generic it matched rather than at the head of the list, so a pattern naming a family keeps that family in front.

That only works while the generic is still in the pattern, and `50-omarchy.conf` assigned over it — `assign` replaces the `monospace` token itself, leaving the user's own file nothing to match on. That is what `prepend_first` was reaching around in the first place (#1bc98a7d, "Make the font choice actually stick"). So the packaged default becomes an alias too, as a `default` rather than a `prefer`: it lands at the end of the family list, where the user's `prefer` still outranks it and an install with no font chosen resolves `monospace` exactly as before.

## Verification

Measured with fontconfig in a sandbox (`FONTCONFIG_FILE` + `XDG_CONFIG_HOME`) that mirrors the real load order, running `/etc/fonts/conf.d` unchanged with only `50-omarchy.conf` and the user override swapped. Chosen font: `iA Writer Mono S`.

| `fc-match` | before | after |
| --- | --- | --- |
| `monospace` | iA Writer Mono S | iA Writer Mono S |
| `Liberation Mono` | **iA Writer Mono S** | Liberation Mono |
| `Adwaita Mono` | **iA Writer Mono S** | Adwaita Mono |
| `JetBrainsMono Nerd Font` | **iA Writer Mono S** | JetBrainsMono Nerd Font |
| `Nimbus Mono PS` | **iA Writer Mono S** | Nimbus Mono PS |

With no font chosen, every probe answers identically before and after, including the fallbacks the file exists to keep working: `monospace` → JetBrainsMono Nerd Font, `sans-serif` → Liberation Sans, `serif` → Liberation Serif, `monospace:charset=1f600` → Noto Color Emoji, `monospace:charset=e0b0` → JetBrainsMono Nerd Font.

## Migration

Anyone who has picked a font since #1bc98a7d is carrying the broken override, and it is only rewritten on the next pick. The migration restates a file still holding exactly what that version wrote, keeping the chosen family, and leaves a hand-edited one alone.

Installs that predate that commit hold a full copy of `50-omarchy.conf` instead, in whatever shape the default had at the time. Those are left untouched — too many shapes to match safely — and are repaired by picking a font once.

## Tests

`test/shell.d/font-set-test.sh`: the packaged default keeps the generic in the pattern, `omarchy-font-set` writes the alias, and the migration rewrites the legacy override, is idempotent, leaves a customized file alone, and writes nothing when no override exists.

`./test/all` passes apart from four files that also fail on `quattro` unmodified here: `config-test.sh`, `snapper-test.sh` and `unowned-system-paths-test.sh` want an `omarchy-pkgs` checkout, and `copy-url-shortcut-migration-test.sh` fails against this machine's running profile.
