### PR TITLE
Honor D-Bus idle inhibits again: screensaver no longer fires over video playback

### DIFF
--- a/bin/omarchy-idle-inhibit-daemon
+++ b/bin/omarchy-idle-inhibit-daemon
@@ -29,6 +29,7 @@
 
 import json
 import os
+import signal
 import sys
 import warnings
 from datetime import datetime, timezone
@@ -61,16 +62,25 @@ STATE_FILE = os.path.join(STATE_DIR, "state")
 class InhibitState:
     """Pure bookkeeping: cookie table plus the state derived from it."""
 
+    MAX_HOLDERS = 256
+    MAX_TEXT = 4096
+
     def __init__(self):
         self.cookies = {}
         self.next_cookie = 1
 
     def add(self, app, reason, owner):
+        if len(self.cookies) >= self.MAX_HOLDERS:
+            # A pathological client must not grow the state without bound.
+            raise GLib.Error(
+                Gio.DBusError.LIMITS_EXCEEDED,
+                message="too many outstanding inhibits",
+            )
         cookie = self.next_cookie
-        self.next_cookie += 1
+        self.next_cookie = (self.next_cookie + 1) & 0xFFFFFFFF or 1
         self.cookies[cookie] = {
-            "app": str(app),
-            "reason": str(reason),
+            "app": str(app)[: self.MAX_TEXT],
+            "reason": str(reason)[: self.MAX_TEXT],
             "owner": str(owner),
             "cookie": cookie,
             "since": datetime.now(timezone.utc).isoformat(),
@@ -98,6 +108,12 @@ class InhibitState:
     def snapshot(self):
         holders = self.holders()
         return {
+            # The serving daemon signs the state with its pid, so a consumer
+            # can tell a file served by a live daemon from one an earlier
+            # instance left behind when it died mid-inhibit: the file's
+            # holder list may claim an inhibit nobody holds anymore, and no
+            # bystander process can clean that up for us.
+            "pid": os.getpid(),
             "inhibited": bool(holders),
             "count": len(holders),
             "holders": holders,
@@ -134,21 +150,32 @@ class Daemon:
         Both the file and the signals describe the same transition, and the
         file landing first means a caller holding a returned cookie never
         reads a state that lacks its own inhibit.
+
+        A publish failure — full tmpfs, hostile directory mode — must not hang
+        the D-Bus caller waiting on a reply that never comes: it is logged and
+        answered normally. The state file going stale is survivable by
+        contract (the consumer parses absence and garbage as no-inhibit); an
+        unanswered method call is not.
         """
-        self.publish()
+        try:
+            self.publish()
+        except OSError as error:
+            print(f"omarchy-idle-inhibit: cannot write {STATE_FILE} ({error})", file=sys.stderr)
         inhibited = self.state.inhibited()
         if inhibited != self.published_inhibited:
             self.published_inhibited = inhibited
             active = GLib.Variant("(b)", (inhibited,))
-            for path in SS_PATHS:
-                self.connection.emit_signal(None, path, SS_IFACE, "ActiveChanged", active)
             self.connection.emit_signal(None, PM_PATH, PM_IFACE, "HasInhibitChanged", active)
 
     # -- method handlers -----------------------------------------------------
 
     def handle_ss_inhibit(self, connection, sender, path, iface, method, params, invocation):
         app, reason = params.unpack()
-        cookie = self.state.add(app, reason, sender)
+        try:
+            cookie = self.state.add(app, reason, sender)
+        except GLib.Error as error:
+            invocation.return_dbus_error("org.freedesktop.DBus.Error.LimitsExceeded", error.message)
+            return
         self.after_change()
         invocation.return_value(GLib.Variant("(u)", (cookie,)))
 
@@ -160,12 +187,13 @@ class Daemon:
         self.after_change()
         invocation.return_value(None)
 
-    def handle_ss_get_active(self, connection, sender, path, iface, method, params, invocation):
-        invocation.return_value(GLib.Variant("(b)", (self.state.inhibited(),)))
-
     def handle_pm_inhibit(self, connection, sender, path, iface, method, params, invocation):
         app, reason = params.unpack()
-        cookie = self.state.add(app, reason, sender)
+        try:
+            cookie = self.state.add(app, reason, sender)
+        except GLib.Error as error:
+            invocation.return_dbus_error("org.freedesktop.DBus.Error.LimitsExceeded", error.message)
+            return
         self.after_change()
         invocation.return_value(GLib.Variant("(u)", (cookie,)))
 
@@ -205,12 +233,6 @@ class Daemon:
                 <method name="UnInhibit">
                   <arg name="cookie" type="u" direction="in"/>
                 </method>
-                <method name="GetActive">
-                  <arg name="active" type="b" direction="out"/>
-                </method>
-                <signal name="ActiveChanged">
-                  <arg name="new_state" type="b"/>
-                </signal>
               </interface>
             </node>
             """
@@ -241,7 +263,6 @@ class Daemon:
         ss_handlers = {
             "Inhibit": self.handle_ss_inhibit,
             "UnInhibit": self.handle_ss_uninhibit,
-            "GetActive": self.handle_ss_get_active,
         }
         pm_handlers = {
             "Inhibit": self.handle_pm_inhibit,
@@ -284,8 +305,16 @@ class Daemon:
 
         def on_lost(connection, name):
             # Somebody else owns it (or took it from us): that service is the
-            # session's screensaver-inhibit answer. Leave quietly rather than
-            # flap a failed unit or fight over the name.
+            # session's screensaver-inhibit answer. Stand down quietly rather
+            # than fight over the name or flap a failed unit.
+            #
+            # Deliberately no state-file surgery here: a daemon that never
+            # owned anything cannot tell whether the file on disk belongs to a
+            # dead predecessor (stale) or to a live sibling mid-transition,
+            # and unlinking by guesswork once clobbered exactly that sibling.
+            # Liveness instead rides in the file itself — every snapshot
+            # carries the serving pid, and consumers read a dead-pid state as
+            # released — so no coordination or cleanup pass is needed.
             print(f"omarchy-idle-inhibit: {name} is owned elsewhere, standing down", file=sys.stderr)
             GLib.idle_add(lambda: (loop.quit(), False)[1])
 
@@ -297,6 +326,18 @@ class Daemon:
             on_lost,
         )
 
+    def stop_serving(self):
+        """One last write when ending orderly: an inhibit claimed by a client
+        of ours does not survive us losing the bus names, so the file must not
+        go on claiming one either. Writing the empty snapshot rather than
+        deleting keeps the consumer's contract total: the file always parses."""
+        if not self.owned_names:
+            return
+        try:
+            self.publish()
+        except OSError as error:
+            print(f"omarchy-idle-inhibit: final publish failed ({error})", file=sys.stderr)
+
 
 def main():
     if not os.environ.get("XDG_RUNTIME_DIR"):
@@ -307,7 +348,11 @@ def main():
         print("omarchy-idle-inhibit: XDG_RUNTIME_DIR is not set; no session to serve", file=sys.stderr)
         return 1
 
+    global loop
+    loop = GLib.MainLoop()
+
     state = InhibitState()
+    daemon = None
     try:
         connection = Gio.bus_get_sync(Gio.BusType.SESSION, None)
     except GLib.Error as error:
@@ -319,12 +364,21 @@ def main():
     daemon.own_name(SS_NAME)
     daemon.own_name(PM_NAME)
 
-    global loop
-    loop = GLib.MainLoop()
+    # An orderly exit (systemd stop, session end) leaves the file honest: the
+    # last thing it claims is nothing inhibited, rather than whatever clients
+    # held when the stop arrived.
+    def on_term(signum, frame):
+        daemon.stop_serving()
+        GLib.idle_add(lambda: (loop.quit(), False)[1])
+
+    signal.signal(signal.SIGTERM, on_term)
+    signal.signal(signal.SIGINT, on_term)
+
     try:
         loop.run()
     except KeyboardInterrupt:
         pass
+    daemon.stop_serving()
     return 0
 
 

--- a/bin/omarchy-idle-inhibit-daemon
+++ b/bin/omarchy-idle-inhibit-daemon
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+
+# omarchy:summary=Own the freedesktop screensaver inhibit names and publish their state for the idle service
+# omarchy:hidden=true
+
+# Quattro's idle logic lives in the Quickshell idle service, whose
+# IdleMonitor honors only the Wayland idle-inhibit protocol. Applications that
+# request their inhibit over D-Bus — every browser playing a video, VLC —
+# address org.freedesktop.ScreenSaver and org.freedesktop.PowerManagement,
+# and nothing owned those names since hypridle was replaced, so the requests
+# were dropped and the screensaver fired over playing videos.
+#
+# This daemon owns both names for the session and answers the interfaces the
+# clients actually call (verified against Chromium, Firefox, and VLC source;
+# see plans/idle-inhibit.md), reaping inhibits whose client left the bus, and
+# publishes the state as JSON so the idle service can hold its idle cycles:
+#
+#   {"inhibited": false, "count": 0, "holders": []}
+#
+# The file is written with write-temp-then-rename so a reader never sees a
+# torn write, is published BEFORE each method reply (a caller that has its
+# cookie can already read its own inhibit), and starts at "nothing inhibited"
+# so consumers never have to guess the initial state. A stale file after a
+# daemon crash must be read as no-inhibit, never as a permanent inhibit —
+# the idle service's parser is the tolerant side of that contract.
+#
+# If the names cannot be owned — a machine running its own screensaver daemon
+# — exit 0 without fighting: the other service is doing this job.
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+import gi
+
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib  # noqa: E402
+
+SS_NAME = "org.freedesktop.ScreenSaver"
+SS_IFACE = "org.freedesktop.ScreenSaver"
+SS_PATHS = ["/org/freedesktop/ScreenSaver", "/ScreenSaver"]  # Chromium / VLC+Firefox
+
+PM_NAME = "org.freedesktop.PowerManagement"
+PM_IFACE = "org.freedesktop.PowerManagement.Inhibit"
+PM_PATH = "/org/freedesktop/PowerManagement/Inhibit"
+
+STATE_DIR = os.path.join(
+    os.environ.get("XDG_RUNTIME_DIR", os.path.expanduser("~/.runtime")), "omarchy", "idle-inhibit"
+)
+STATE_FILE = os.path.join(STATE_DIR, "state")
+
+
+class InhibitState:
+    """Pure bookkeeping: cookie table plus the state derived from it."""
+
+    def __init__(self):
+        self.cookies = {}
+        self.next_cookie = 1
+
+    def add(self, app, reason, owner):
+        cookie = self.next_cookie
+        self.next_cookie += 1
+        self.cookies[cookie] = {
+            "app": str(app),
+            "reason": str(reason),
+            "owner": str(owner),
+            "cookie": cookie,
+            "since": datetime.now(timezone.utc).isoformat(),
+        }
+        return cookie
+
+    def remove(self, cookie):
+        return self.cookies.pop(int(cookie), None)
+
+    def drop_owner(self, owner):
+        gone = [c for c, h in self.cookies.items() if h["owner"] == owner]
+        for c in gone:
+            del self.cookies[c]
+        return gone
+
+    def holders(self):
+        return [self.cookies[c] for c in sorted(self.cookies)]
+
+    def count(self):
+        return len(self.cookies)
+
+    def inhibited(self):
+        return bool(self.cookies)
+
+    def snapshot(self):
+        holders = self.holders()
+        return {
+            "inhibited": bool(holders),
+            "count": len(holders),
+            "holders": holders,
+        }
+
+
+class Daemon:
+    def __init__(self, state, connection):
+        self.state = state
+        self.connection = connection
+        self.registration_ids = []
+        self.signal_match = None
+        self.owned_names = 0
+        self.published_inhibited = None
+
+    # -- state publication --------------------------------------------------
+
+    def publish(self):
+        os.makedirs(STATE_DIR, mode=0o700, exist_ok=True)
+        tmp = STATE_FILE + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as handle:
+            json.dump(self.state.snapshot(), handle, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, STATE_FILE)
+
+    def after_change(self):
+        """Publish the file, then signal the transition, before the reply.
+
+        Both the file and the signals describe the same transition, and the
+        file landing first means a caller holding a returned cookie never
+        reads a state that lacks its own inhibit.
+        """
+        self.publish()
+        inhibited = self.state.inhibited()
+        if inhibited != self.published_inhibited:
+            self.published_inhibited = inhibited
+            active = GLib.Variant("(b)", (inhibited,))
+            for path in SS_PATHS:
+                self.connection.emit_signal(None, path, SS_IFACE, "ActiveChanged", active)
+            self.connection.emit_signal(None, PM_PATH, PM_IFACE, "HasInhibitChanged", active)
+
+    # -- method handlers -----------------------------------------------------
+
+    def handle_ss_inhibit(self, connection, sender, path, iface, method, params, invocation):
+        app, reason = params.unpack()
+        cookie = self.state.add(app, reason, sender)
+        self.after_change()
+        invocation.return_value(GLib.Variant("(u)", (cookie,)))
+
+    def handle_ss_uninhibit(self, connection, sender, path, iface, method, params, invocation):
+        (cookie,) = params.unpack()
+        # An unknown cookie is not an error: a restarted client replaying a
+        # stale cookie must not wedge the session (hypridle precedent).
+        self.state.remove(cookie)
+        self.after_change()
+        invocation.return_value(None)
+
+    def handle_ss_get_active(self, connection, sender, path, iface, method, params, invocation):
+        invocation.return_value(GLib.Variant("(b)", (self.state.inhibited(),)))
+
+    def handle_pm_inhibit(self, connection, sender, path, iface, method, params, invocation):
+        app, reason = params.unpack()
+        cookie = self.state.add(app, reason, sender)
+        self.after_change()
+        invocation.return_value(GLib.Variant("(u)", (cookie,)))
+
+    def handle_pm_uninhibit(self, connection, sender, path, iface, method, params, invocation):
+        (cookie,) = params.unpack()
+        self.state.remove(cookie)
+        self.after_change()
+        invocation.return_value(None)
+
+    def handle_pm_has_inhibit(self, connection, sender, path, iface, method, params, invocation):
+        invocation.return_value(GLib.Variant("(b)", (self.state.inhibited(),)))
+
+    # -- client lifetime -----------------------------------------------------
+
+    def handle_name_owner_changed(self, connection, sender, path, iface, signal, params):
+        name, old_owner, new_owner = params.unpack()
+        if old_owner and not new_owner:
+            # The client's connection is gone — crashed or exited without
+            # uninhibiting. The spec ends the inhibition with the
+            # disconnection; leaving it held would pin the session awake
+            # forever.
+            if self.state.drop_owner(old_owner):
+                self.after_change()
+
+    # -- startup -------------------------------------------------------------
+
+    def export_objects(self):
+        node_ss = Gio.DBusNodeInfo.new_for_xml(
+            """
+            <node>
+              <interface name="org.freedesktop.ScreenSaver">
+                <method name="Inhibit">
+                  <arg name="application_name" type="s" direction="in"/>
+                  <arg name="reason_for_inhibit" type="s" direction="in"/>
+                  <arg name="cookie" type="u" direction="out"/>
+                </method>
+                <method name="UnInhibit">
+                  <arg name="cookie" type="u" direction="in"/>
+                </method>
+                <method name="GetActive">
+                  <arg name="active" type="b" direction="out"/>
+                </method>
+                <signal name="ActiveChanged">
+                  <arg name="new_state" type="b"/>
+                </signal>
+              </interface>
+            </node>
+            """
+        )
+        node_pm = Gio.DBusNodeInfo.new_for_xml(
+            """
+            <node>
+              <interface name="org.freedesktop.PowerManagement.Inhibit">
+                <method name="Inhibit">
+                  <arg name="application" type="s" direction="in"/>
+                  <arg name="reason" type="s" direction="in"/>
+                  <arg name="cookie" type="u" direction="out"/>
+                </method>
+                <method name="UnInhibit">
+                  <arg name="cookie" type="u" direction="in"/>
+                </method>
+                <method name="HasInhibit">
+                  <arg name="has_inhibit" type="b" direction="out"/>
+                </method>
+                <signal name="HasInhibitChanged">
+                  <arg name="has_inhibit" type="b"/>
+                </signal>
+              </interface>
+            </node>
+            """
+        )
+
+        ss_handlers = {
+            "Inhibit": self.handle_ss_inhibit,
+            "UnInhibit": self.handle_ss_uninhibit,
+            "GetActive": self.handle_ss_get_active,
+        }
+        pm_handlers = {
+            "Inhibit": self.handle_pm_inhibit,
+            "UnInhibit": self.handle_pm_uninhibit,
+            "HasInhibit": self.handle_pm_has_inhibit,
+        }
+
+        def make_dispatcher(handlers):
+            def dispatch(connection, sender, path, iface, method, params, invocation):
+                handlers[method](connection, sender, path, iface, method, params, invocation)
+
+            return dispatch
+
+        for path in SS_PATHS:
+            self.registration_ids.append(
+                self.connection.register_object(
+                    path, node_ss.interfaces[0], make_dispatcher(ss_handlers)
+                )
+            )
+        self.registration_ids.append(
+            self.connection.register_object(
+                PM_PATH, node_pm.interfaces[0], make_dispatcher(pm_handlers)
+            )
+        )
+
+        self.signal_match = self.connection.signal_subscribe(
+            "org.freedesktop.DBus",
+            "org.freedesktop.DBus",
+            "NameOwnerChanged",
+            None,
+            None,
+            Gio.DBusSignalFlags.NONE,
+            self.handle_name_owner_changed,
+        )
+
+    def own_name(self, name):
+        def on_acquired(connection, name):
+            self.owned_names += 1
+            self.publish()
+
+        def on_lost(connection, name):
+            # Somebody else owns it (or took it from us): that service is the
+            # session's screensaver-inhibit answer. Leave quietly rather than
+            # flap a failed unit or fight over the name.
+            print(f"omarchy-idle-inhibit: {name} is owned elsewhere, standing down", file=sys.stderr)
+            GLib.idle_add(lambda: (loop.quit(), False)[1])
+
+        Gio.bus_own_name_on_connection(
+            self.connection,
+            name,
+            Gio.BusNameOwnerFlags.NONE,
+            on_acquired,
+            on_lost,
+        )
+
+
+def main():
+    state = InhibitState()
+    try:
+        connection = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+    except GLib.Error as error:
+        print(f"omarchy-idle-inhibit: no session bus ({error.message})", file=sys.stderr)
+        return 1
+
+    daemon = Daemon(state, connection)
+    daemon.export_objects()
+    daemon.own_name(SS_NAME)
+    daemon.own_name(PM_NAME)
+
+    global loop
+    loop = GLib.MainLoop()
+    try:
+        loop.run()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/omarchy-idle-inhibit-daemon
+++ b/bin/omarchy-idle-inhibit-daemon
@@ -45,6 +45,9 @@ warnings.filterwarnings("ignore", message=".*register_object is deprecated.*")
 gi.require_version("Gio", "2.0")
 from gi.repository import Gio, GLib  # noqa: E402
 
+gi.require_version("GLibUnix", "2.0")
+from gi.repository import GLibUnix  # noqa: E402
+
 SS_NAME = "org.freedesktop.ScreenSaver"
 SS_IFACE = "org.freedesktop.ScreenSaver"
 SS_PATHS = ["/org/freedesktop/ScreenSaver", "/ScreenSaver"]  # Chromium / VLC+Firefox
@@ -329,12 +332,30 @@ class Daemon:
     def stop_serving(self):
         """One last write when ending orderly: an inhibit claimed by a client
         of ours does not survive us losing the bus names, so the file must not
-        go on claiming one either. Writing the empty snapshot rather than
-        deleting keeps the consumer's contract total: the file always parses."""
+        go on claiming one either. That is why this writes a forced-empty
+        snapshot instead of republishing the live table — the holder client is
+        usually still connected while we are being stopped, so the honest
+        final claim is nothing."""
         if not self.owned_names:
             return
         try:
-            self.publish()
+            os.makedirs(STATE_DIR, mode=0o700, exist_ok=True)
+            tmp = STATE_FILE + ".tmp"
+            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "pid": os.getpid(),
+                        "inhibited": False,
+                        "count": 0,
+                        "holders": [],
+                    },
+                    handle,
+                    separators=(",", ":"),
+                )
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, STATE_FILE)
         except OSError as error:
             print(f"omarchy-idle-inhibit: final publish failed ({error})", file=sys.stderr)
 
@@ -366,13 +387,20 @@ def main():
 
     # An orderly exit (systemd stop, session end) leaves the file honest: the
     # last thing it claims is nothing inhibited, rather than whatever clients
-    # held when the stop arrived.
-    def on_term(signum, frame):
+    # held when the stop arrived. Registered through GLibUnix, not Python's
+    # signal module: a Python handler never runs while the C mainloop sits
+    # inside loop.run(), so the process would die by default disposition and
+    # skip the final publish entirely. (GLib.unix_signal_add's shim looks
+    # registered but is equally dead here — verified.)
+    def on_term():
         daemon.stop_serving()
         GLib.idle_add(lambda: (loop.quit(), False)[1])
+        return GLib.SOURCE_REMOVE
+        GLib.idle_add(lambda: (loop.quit(), False)[1])
+        return GLib.SOURCE_REMOVE
 
-    signal.signal(signal.SIGTERM, on_term)
-    signal.signal(signal.SIGINT, on_term)
+    GLibUnix.signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, on_term)
+    GLibUnix.signal_add(GLib.PRIORITY_DEFAULT, signal.SIGINT, on_term)
 
     try:
         loop.run()

--- a/bin/omarchy-idle-inhibit-daemon
+++ b/bin/omarchy-idle-inhibit-daemon
@@ -30,9 +30,16 @@
 import json
 import os
 import sys
+import warnings
 from datetime import datetime, timezone
 
 import gi
+
+# The dispatch-table register_object is the maintained way to serve methods
+# from PyGObject; the deprecation it emits is for the closure-based variant's
+# benefit and fires on every start, so it is quieted rather than printed to
+# the journal forever.
+warnings.filterwarnings("ignore", message=".*register_object is deprecated.*")
 
 gi.require_version("Gio", "2.0")
 from gi.repository import Gio, GLib  # noqa: E402
@@ -46,7 +53,7 @@ PM_IFACE = "org.freedesktop.PowerManagement.Inhibit"
 PM_PATH = "/org/freedesktop/PowerManagement/Inhibit"
 
 STATE_DIR = os.path.join(
-    os.environ.get("XDG_RUNTIME_DIR", os.path.expanduser("~/.runtime")), "omarchy", "idle-inhibit"
+    os.environ.get("XDG_RUNTIME_DIR", ""), "omarchy", "idle-inhibit"
 )
 STATE_FILE = os.path.join(STATE_DIR, "state")
 
@@ -111,11 +118,14 @@ class Daemon:
     def publish(self):
         os.makedirs(STATE_DIR, mode=0o700, exist_ok=True)
         tmp = STATE_FILE + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as handle:
+        # Create-and-write in one step at 0600: a plain open() honors the umask
+        # first, leaving a window where holder names are world-readable under
+        # a permissive umask.
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
             json.dump(self.state.snapshot(), handle, separators=(",", ":"))
             handle.flush()
             os.fsync(handle.fileno())
-        os.chmod(tmp, 0o600)
         os.replace(tmp, STATE_FILE)
 
     def after_change(self):
@@ -289,6 +299,14 @@ class Daemon:
 
 
 def main():
+    if not os.environ.get("XDG_RUNTIME_DIR"):
+        # The state dir belongs to the session runtime, which a systemd user
+        # service always has. Writing it anywhere else (a home dir, /tmp)
+        # would leak holder names and recreate exactly the predictable-path
+        # problems the diagnostics fixes removed.
+        print("omarchy-idle-inhibit: XDG_RUNTIME_DIR is not set; no session to serve", file=sys.stderr)
+        return 1
+
     state = InhibitState()
     try:
         connection = Gio.bus_get_sync(Gio.BusType.SESSION, None)

--- a/bin/omarchy-idle-inhibit-probe
+++ b/bin/omarchy-idle-inhibit-probe
@@ -4,16 +4,17 @@
 # omarchy:hidden=true
 
 # Prints omarchy-idle-inhibit-daemon's state file (normalized to exactly one
-# line) when that state can be trusted, and nothing when it cannot:
+# line) when that state can be trusted, and one empty line when it cannot:
 #
 # - no state file            -> one empty line  (nothing inhibited)
 # - unparseable/torn file    -> one empty line  (garbage never pins idle off)
 # - served by a live daemon  -> the JSON line
-# - serving pid is gone      -> NOTHING         (a crashed daemon's last write
+# - serving pid is gone      -> one empty line  (a crashed daemon's last write
 #                                               must not claim inhibits
-#                                               forever; "not inhibited" is
-#                                               printed implicitly by the
-#                                       caller tolerating silence)
+#                                               forever; SplitParser only
+#                                               fires onRead for bytes, so
+#                                               silence would pin the last
+#                                               applied inhibit)
 #
 # The liveness half is what makes daemon death self-healing: the pid is part
 # of every snapshot the daemon writes, so a SIGKILL mid-inhibit — where no
@@ -34,6 +35,7 @@ pid=$(jq -er '.pid // empty' "$state_file" 2>/dev/null) || {
 }
 
 if [[ ! $pid =~ ^[0-9]+$ ]] || ! kill -0 "$pid" 2>/dev/null; then
+  printf '\n'
   exit 0
 fi
 

--- a/bin/omarchy-idle-inhibit-probe
+++ b/bin/omarchy-idle-inhibit-probe
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# omarchy:summary=Emit the idle inhibit daemon's state as one line, only while its daemon is alive
+# omarchy:hidden=true
+
+# Prints omarchy-idle-inhibit-daemon's state file (normalized to exactly one
+# line) when that state can be trusted, and nothing when it cannot:
+#
+# - no state file            -> one empty line  (nothing inhibited)
+# - unparseable/torn file    -> one empty line  (garbage never pins idle off)
+# - served by a live daemon  -> the JSON line
+# - serving pid is gone      -> NOTHING         (a crashed daemon's last write
+#                                               must not claim inhibits
+#                                               forever; "not inhibited" is
+#                                               printed implicitly by the
+#                                       caller tolerating silence)
+#
+# The liveness half is what makes daemon death self-healing: the pid is part
+# of every snapshot the daemon writes, so a SIGKILL mid-inhibit — where no
+# orderly final publish is possible — still reads as released.
+
+set -euo pipefail
+
+state_file="${1:-}"
+
+[[ -n $state_file && -r $state_file ]] || {
+  printf '\n'
+  exit 0
+}
+
+pid=$(jq -er '.pid // empty' "$state_file" 2>/dev/null) || {
+  printf '\n'
+  exit 0
+}
+
+if [[ ! $pid =~ ^[0-9]+$ ]] || ! kill -0 "$pid" 2>/dev/null; then
+  exit 0
+fi
+
+printf '%s\n' "$(cat "$state_file")"

--- a/default/systemd/user/omarchy-idle-inhibit.service
+++ b/default/systemd/user/omarchy-idle-inhibit.service
@@ -9,7 +9,9 @@ PartOf=graphical-session.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/omarchy-idle-inhibit-daemon
-Restart=always
+# on-failure, not always: standing down when the names are owned elsewhere is
+# a clean exit 0, and restarting into the same loss would respawn forever.
+Restart=on-failure
 RestartSec=5
 
 [Install]

--- a/default/systemd/user/omarchy-idle-inhibit.service
+++ b/default/systemd/user/omarchy-idle-inhibit.service
@@ -1,9 +1,13 @@
 [Unit]
 Description=Own the freedesktop screensaver inhibit names for the session
-# Browsers and players request idle inhibition over D-Bus
-# (org.freedesktop.ScreenSaver); the daemon must own the names before any of
-# them probe, which means starting with the graphical session, not on demand.
-After=graphical-session.target
+# Browsers and players probe NameHasOwner before Inhibit, which never
+# auto-starts. After=graphical-session.target would start us only once the
+# target is already reached — autostarted browsers would win that race.
+# Keep the target's default ordering (WantedBy= pulls this in before the
+# target is reached) and wait only on the session bus, matching
+# omarchy-sleep-lock.service.
+After=dbus.socket
+Requires=dbus.socket
 PartOf=graphical-session.target
 
 [Service]

--- a/default/systemd/user/omarchy-idle-inhibit.service
+++ b/default/systemd/user/omarchy-idle-inhibit.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Own the freedesktop screensaver inhibit names for the session
+# Browsers and players request idle inhibition over D-Bus
+# (org.freedesktop.ScreenSaver); the daemon must own the names before any of
+# them probe, which means starting with the graphical session, not on demand.
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-idle-inhibit-daemon
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -18,4 +18,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  omarchy-idle-inhibit.service

--- a/migrations/1787769449.sh
+++ b/migrations/1787769449.sh
@@ -1,0 +1,22 @@
+echo "Enable the D-Bus idle inhibit daemon so browser video playback stops triggering the screensaver"
+
+# Quattro's idle service honors only the Wayland idle-inhibit protocol, and
+# nothing has owned org.freedesktop.ScreenSaver since hypridle was replaced —
+# so an inhibit requested over D-Bus (every browser playing video, VLC) was
+# dropped and the screensaver fired over the playing video. The new
+# omarchy-idle-inhibit-daemon owns those names and publishes its state for the
+# idle service to hold its cycles.
+
+# Enable without --now: this usually runs inside `omarchy update`, where
+# starting the daemon is harmless but pointless half a second before the
+# session restarts. `systemctl enable` needs a live user manager, which
+# `omarchy update` over SSH does not have, so fall back to writing precisely
+# the symlink it would have written rather than silently doing nothing.
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+if ! systemctl --user enable omarchy-idle-inhibit.service >/dev/null 2>&1; then
+  wants_dir="$HOME/.config/systemd/user/graphical-session.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn /usr/lib/systemd/user/omarchy-idle-inhibit.service \
+    "$wants_dir/omarchy-idle-inhibit.service"
+fi

--- a/plans/idle-inhibit.md
+++ b/plans/idle-inhibit.md
@@ -77,14 +77,17 @@ A session-bus responder owned by a systemd user unit
 (`omarchy-idle-inhibit.service`, `WantedBy=graphical-session.target`, the
 crash-watch/migrate-notify pattern) so it is running before any browser probes:
 
-- Owns **`org.freedesktop.ScreenSaver`**, exporting `Inhibit(ss) → u`,
-  `UnInhibit(u)`, and the KDE-compat extras `GetActive() → b` +
-  `ActiveChanged(b)` signal, on **both** `/org/freedesktop/ScreenSaver` and
-  `/ScreenSaver`.
+- Owns **`org.freedesktop.ScreenSaver`**, exporting `Inhibit(ss) → u` and
+  `UnInhibit(u)` on **both** `/org/freedesktop/ScreenSaver` and `/ScreenSaver`.
+  The KDE-legacy `GetActive`/`ActiveChanged` extras are deliberately *not*
+  offered: they mean "the screensaver is showing", which this daemon cannot
+  honestly report — emitting them for inhibit-held state would be exactly
+  inverted.
 - Owns **`org.freedesktop.PowerManagement`**, exporting `Inhibit(ss) → u`,
   `UnInhibit(u)`, `HasInhibit() → b` + `HasInhibitChanged(b)` at
   `/org/freedesktop/PowerManagement/Inhibit` (what Chromium's second inhibit
-  and Firefox's third backend expect).
+  and Firefox's third backend expect; Clight-class clients listen to the
+  signal).
 - Cookies are a global counter; each cookie records the caller's unique bus
   name. `UnInhibit` with an unknown cookie returns normally (hypridle
   precedent; a restarted browser replaying a stale cookie must not wedge).
@@ -92,17 +95,29 @@ crash-watch/migrate-notify pattern) so it is running before any browser probes:
   run code; matching hypridle).
 - Watches `NameOwnerChanged`; when a cookie's owner disappears the cookie is
   reaped — a crashed browser cannot leave the session inhibited forever.
+- Application/reason strings are truncated and outstanding inhibits capped;
+  over the cap a caller gets `LimitsExceeded` rather than unbounded state.
 - If either well-known name cannot be acquired (another screensaver service is
   present), logs and exits 0: never fight over the name, never show a failed
-  unit for a machine that has its own screensaver daemon.
+  unit for a machine that has its own screensaver daemon. The unit uses
+  `Restart=on-failure` so that clean stand-down does not respawn forever.
 - Publishes the inhibit state as JSON to
   `$XDG_RUNTIME_DIR/omarchy/idle-inhibit/state` — written with
-  write-temp-then-rename so readers never see a torn file, mode 0600, on
-  **every** state change including the initial "nothing inhibited" snapshot:
+  write-temp-then-rename at 0600, on **every** state change including the
+  initial "nothing inhibited" snapshot:
 
   ```json
-  {"inhibited": false, "count": 0, "holders": []}
+  {"pid": 12345, "inhibited": false, "count": 0, "holders": []}
   ```
+
+  The **pid** is the liveness contract: consumers read a snapshot whose pid is
+  no longer running as released, which is what makes daemon death — SIGKILL
+  mid-inhibit included — self-healing without any cross-process cleanup. An
+  orderly exit additionally republishes an empty snapshot.
+- An `omarchy-idle-inhibit-probe` helper consumes the file for the shell: it
+  prints the JSON as exactly one line when the serving pid is alive, one empty
+  line for absence/garbage, and nothing for a dead pid. Silence means "not
+  inhibited", so every failure mode lands on the safe side.
 
   `holders` entries carry `{app, reason, owner, cookie, since}` — enough for
   `omarchy debug` to say *who* is keeping the screen awake, which no
@@ -126,10 +141,13 @@ atomic renames surface as change events):
 - `IdleMonitor.enabled` gains `&& !externalInhibit`: while any D-Bus inhibit is
   held, no idle cycle can start — the same gate `stay-awake` already uses, one
   row over.
+- The shell reads the file only through the probe script: every failure mode —
+  daemon down, file torn, garbage, stale pid — lands on "not inhibited", the
+  one direction that can never wedge idle behavior.
 - An inhibit arriving mid-cycle cancels it (consistent with toggling Stay
-  Awake, which also cancels: starting a video should clear a screensaver that
-  is already up, and Omarchy's screensaver is intrusive enough that leaving it
-  over a playing video is the worse failure).
+  Awake, which also cancels): a browser that started playing video owns the
+  screen, screensaver included. A lock that already fired is left alone —
+  inhibits never dismiss a lock.
 - The watcher is best-effort: missing runtime dir, unreadable file, or a
   daemon that is not running all degrade to "no external inhibits" and the
   idle timers behave exactly as they do today.

--- a/plans/idle-inhibit.md
+++ b/plans/idle-inhibit.md
@@ -1,0 +1,200 @@
+# Plan: Idle inhibit — honor D-Bus screensaver inhibits again
+
+Revision 1.
+
+## Problem
+
+Quattro replaced `hypridle` with the Quickshell idle service. hypridle registered
+`org.freedesktop.ScreenSaver` on the session bus; the Quickshell service does
+not, and `IdleMonitor { respectInhibitors: true }` honors only the Wayland
+`zwp_idle_inhibit_manager_v1` protocol. An application that requests its inhibit
+over D-Bus therefore has it dropped on the floor:
+
+- Firefox and Zen play a video → nothing owns `org.freedesktop.ScreenSaver` →
+  the screensaver launches over the playing video, then the session locks
+  (#6475, #7220, #7199 — 42 👍 across the three).
+- Chromium-family browsers take *two* inhibits for video (ScreenSaver +
+  `org.freedesktop.PowerManagement.Inhibit`) and lose both.
+- VLC inhibits through `org.freedesktop.ScreenSaver` at the legacy `/ScreenSaver`
+  object path and loses it.
+
+The applications are behaving correctly; nobody is listening. Every
+desktop environment owns these names; Omarchy 3 did too, through hypridle.
+
+## What the browsers actually do (verified from source, not assumed)
+
+The client side dictates several constraints that rule designs out:
+
+- **Chromium** (`power_save_blocker_linux.cc`) probes with
+  `org.freedesktop.DBus.NameHasOwner` before calling `Inhibit`.
+  `NameHasOwner` does **not** trigger D-Bus activation. If the name is
+  unowned, Chromium logs "we just ignore them" and never inhibits — no retry,
+  no fallback. VLC behaves the same (it only calls backends whose name has an
+  owner).
+- **Firefox** (`WakeLockListener.cpp`) rotates backends — portal →
+  `org.freedesktop.ScreenSaver` at `/ScreenSaver` →
+  `org.freedesktop.PowerManagement.Inhibit` → `org.gnome.SessionManager` —
+  retrying once per state transition when a backend errors.
+- **Object paths split by client**: VLC and Firefox use the legacy `/ScreenSaver`
+  path (KDE ≤ 4.11 compatibility, codified in the spec's design notes);
+  Chromium uses `/org/freedesktop/ScreenSaver`. A responder must export the
+  interface on **both**.
+- **Lifetime**: the spec says inhibition ends on `UnInhibit` *or when the
+  application disconnects from the bus*. A browser crash must not leave the
+  session permanently uninhibited; hypridle reaps by watching
+  `NameOwnerChanged` with an empty new owner, and this design does the same.
+
+## Rejected approaches
+
+- **D-Bus service activation** (`~/.local/share/dbus-1/services` `.service`
+  file, daemon spawned on first `Inhibit`): dead on arrival given the
+  `NameHasOwner` probing above — Chromium and VLC would never trigger it, and
+  they are the majority of the reports. Activation also restarts from zero
+  state (inhibits silently forgotten) whenever the daemon exits.
+- **Bridging D-Bus inhibits to a Wayland inhibitor held by a helper**
+  (`zwp_idle_inhibit_manager_v1` in a bridge process): the protocol binds an
+  inhibitor to a surface, and sway explicitly ignores inhibitors whose surface
+  is not visible — a bare never-mapped surface from a headless bridge does not
+  count. Layer-shell trickery to keep an invisible-but-"visible" surface is
+  fragile, compositor-specific, and untestable without a session. The ext-idle
+  notify v2 `get_input_idle_notification` clients ignore inhibitors anyway.
+- **Running hypridle alongside the Quickshell idle service**: two idle daemons
+  racing to run screensaver/lock actions; hypridle holds its inhibit state
+  internally where the Quickshell service cannot see it.
+- **Teaching Quickshell to serve D-Bus**: Quickshell 0.3.1 has no D-Bus service
+  registration API (client-side calls only; serving `org.freedesktop.ScreenSaver`
+  is an open upstream discussion). Waiting on upstream leaves the bug open.
+- **`systemd-inhibit` / logind**: logind's `idle` inhibitor is not consulted by
+  the Quickshell `IdleMonitor`, and browsers do not use it for display idle.
+
+## Chosen design: a small always-on responder that owns the names and publishes state; the idle service gates on it
+
+Two components, one contract.
+
+### 1. `omarchy-idle-inhibit-daemon` (python3 + PyGObject, already a base dependency)
+
+A session-bus responder owned by a systemd user unit
+(`omarchy-idle-inhibit.service`, `WantedBy=graphical-session.target`, the
+crash-watch/migrate-notify pattern) so it is running before any browser probes:
+
+- Owns **`org.freedesktop.ScreenSaver`**, exporting `Inhibit(ss) → u`,
+  `UnInhibit(u)`, and the KDE-compat extras `GetActive() → b` +
+  `ActiveChanged(b)` signal, on **both** `/org/freedesktop/ScreenSaver` and
+  `/ScreenSaver`.
+- Owns **`org.freedesktop.PowerManagement`**, exporting `Inhibit(ss) → u`,
+  `UnInhibit(u)`, `HasInhibit() → b` + `HasInhibitChanged(b)` at
+  `/org/freedesktop/PowerManagement/Inhibit` (what Chromium's second inhibit
+  and Firefox's third backend expect).
+- Cookies are a global counter; each cookie records the caller's unique bus
+  name. `UnInhibit` with an unknown cookie returns normally (hypridle
+  precedent; a restarted browser replaying a stale cookie must not wedge).
+  `UnInhibit` does not verify the sender (any same-uid process can already
+  run code; matching hypridle).
+- Watches `NameOwnerChanged`; when a cookie's owner disappears the cookie is
+  reaped — a crashed browser cannot leave the session inhibited forever.
+- If either well-known name cannot be acquired (another screensaver service is
+  present), logs and exits 0: never fight over the name, never show a failed
+  unit for a machine that has its own screensaver daemon.
+- Publishes the inhibit state as JSON to
+  `$XDG_RUNTIME_DIR/omarchy/idle-inhibit/state` — written with
+  write-temp-then-rename so readers never see a torn file, mode 0600, on
+  **every** state change including the initial "nothing inhibited" snapshot:
+
+  ```json
+  {"inhibited": false, "count": 0, "holders": []}
+  ```
+
+  `holders` entries carry `{app, reason, owner, cookie, since}` — enough for
+  `omarchy debug` to say *who* is keeping the screen awake, which no
+  `org.freedesktop.ScreenSaver` implementation exposes (the spec has no query
+  method; that gap is a standing complaint).
+
+The daemon never touches Wayland, never draws anything, and needs no
+privileges. All decision logic lives in small pure functions so the test suite
+can drive the real daemon over a real session bus.
+
+### 2. The idle service consumes the state file
+
+`shell/plugins/services/idle/Service.qml` gains the state-file watch it already
+has a pattern for (the stay-awake indicator watcher watches a directory so
+atomic renames surface as change events):
+
+- A `FileView` on the `omarchy/idle-inhibit` directory; each change re-reads
+  `state` through `IdleModel.externalInhibitFromState(raw)`, a tolerant parser
+  (garbage or absence reads as "not inhibited" — a daemon crash must never
+  wedge the idle timers *on*).
+- `IdleMonitor.enabled` gains `&& !externalInhibit`: while any D-Bus inhibit is
+  held, no idle cycle can start — the same gate `stay-awake` already uses, one
+  row over.
+- An inhibit arriving mid-cycle cancels it (consistent with toggling Stay
+  Awake, which also cancels: starting a video should clear a screensaver that
+  is already up, and Omarchy's screensaver is intrusive enough that leaving it
+  over a playing video is the worse failure).
+- The watcher is best-effort: missing runtime dir, unreadable file, or a
+  daemon that is not running all degrade to "no external inhibits" and the
+  idle timers behave exactly as they do today.
+- `omarchy-shell idle status` reports the external inhibit state, and
+  `omarchy-debug-idle` prints it, so a stuck inhibit is diagnosable.
+
+### Scope and non-goals
+
+- `xdg-desktop-portal` Inhibit (`org.freedesktop.impl.portal.Inhibit`) is not
+  implemented here: flatpaked browsers go through the portal, whose Hyprland
+  backend does not implement it either — that belongs to
+  xdg-desktop-portal-hyprland, not to a session responder. The plan notes it
+  so the gap is documented rather than rediscovered.
+- `org.gnome.SessionManager` is not implemented: Firefox only reaches it after
+  both freedesktop names fail, so owning the two standard names covers it.
+- Power actions (suspend/hibernate inhibits via logind) are out of scope;
+  Omarchy does not auto-suspend on idle.
+
+## Edge cases the design must answer
+
+- **Daemon starts after an inhibit was attempted**: the browser's probe failed
+  once; Firefox rotates back on its next state change, Chromium on its next
+  video. The unit starts with the graphical session, before browsers, so this
+  is a reboot-ordering curiosity rather than a support case.
+- **Daemon crashes**: the bus name drops; the state file goes stale. The
+  service's tolerant parser does not treat a stale file as a held inhibit, and
+  `Restart=always` brings the name back. Chromium/VLC re-probe per video.
+- **Two users / two sessions**: bus names are per-session; the runtime dir is
+  per-session. Nothing is shared.
+- **`checkupdates`-style long holds** (a download manager inhibiting for an
+  hour): that is the API working as designed; the status command exists so the
+  user can see why.
+- **Cookie exhaustion**: uint32 counter starting at 1; wraparound at 4 billion
+  inhibits is not a support case.
+
+## Wiring
+
+- `default/systemd/user/omarchy-idle-inhibit.service` — house pattern
+  (`After=graphical-session.target`, `WantedBy=graphical-session.target`,
+  `Restart=always`, `ExecStart=/usr/bin/omarchy-idle-inhibit-daemon`; the
+  PKGBUILD install line lives in omarchy-pkgs and is called out in the PR).
+- New installs: added to `install/user/first-run/enable-user-units.sh`.
+- Existing installs: a migration enables the unit, with the
+  no-live-user-manager fallback (symlink into
+  `graphical-session.target.wants`) used by the migrate-notify migration.
+- No new package dependencies: `python-gobject` is already in
+  `install/omarchy-base.packages`.
+
+## Test plan
+
+All red-green, run against the real components:
+
+- **Daemon, over a real bus** (`dbus-run-session` + `busctl`): inhibit returns
+  a cookie and flips the state file; both object paths answer; a second sender
+  stacks; `UnInhibit` drops one; unknown cookie tolerated; a sender that exits
+  without uninhibiting is reaped via `NameOwnerChanged`; the name-loss case
+  exits 0; `HasInhibit`/`GetActive` agree with the state file; the state file
+  is 0600 and always complete JSON under an inhibit/uninhibit storm; the
+  initial "nothing inhibited" snapshot exists without any caller.
+- **Model, in node** (`idle-test.sh`): the tolerant parser — valid state, torn
+  file, garbage, missing — and the gating arithmetic.
+- **Wiring, house style**: the unit file's `ExecStart`, the service's
+  `FileView` and the `IdleMonitor.enabled` gate, checked the way
+  `powerprofiles-set-test.sh` checks `Service.qml` bindings.
+- **Migration**: idempotent rerun, respects `OMARCHY_PATH`, enables the unit
+  with and without a live user manager.
+- **Mutation checks**: every behavior above is proven by reverting the code
+  that implements it and watching its test fail.

--- a/plans/idle-inhibit.md
+++ b/plans/idle-inhibit.md
@@ -1,71 +1,33 @@
 # Plan: Idle inhibit — honor D-Bus screensaver inhibits again
 
-Revision 1.
+Revision 2. Rev 1 had After=graphical-session.target (too late for NameHasOwner probes), Restart=always in the wiring summary (would flap a clean stand-down), a hard-wrapped body, and a test-plan claim that GetActive is exported.
 
 ## Problem
 
-Quattro replaced `hypridle` with the Quickshell idle service. hypridle registered
-`org.freedesktop.ScreenSaver` on the session bus; the Quickshell service does
-not, and `IdleMonitor { respectInhibitors: true }` honors only the Wayland
-`zwp_idle_inhibit_manager_v1` protocol. An application that requests its inhibit
-over D-Bus therefore has it dropped on the floor:
+Quattro replaced `hypridle` with the Quickshell idle service. hypridle registered `org.freedesktop.ScreenSaver` on the session bus; the Quickshell service does not, and `IdleMonitor { respectInhibitors: true }` honors only the Wayland `zwp_idle_inhibit_manager_v1` protocol. An application that requests its inhibit over D-Bus therefore has it dropped on the floor:
 
-- Firefox and Zen play a video → nothing owns `org.freedesktop.ScreenSaver` →
-  the screensaver launches over the playing video, then the session locks
-  (#6475, #7220, #7199 — 42 👍 across the three).
-- Chromium-family browsers take *two* inhibits for video (ScreenSaver +
-  `org.freedesktop.PowerManagement.Inhibit`) and lose both.
-- VLC inhibits through `org.freedesktop.ScreenSaver` at the legacy `/ScreenSaver`
-  object path and loses it.
+- Firefox and Zen play a video → nothing owns `org.freedesktop.ScreenSaver` → the screensaver launches over the playing video, then the session locks (#6475, #7220, #7199 — 42 👍 across the three).
+- Chromium-family browsers take *two* inhibits for video (ScreenSaver + `org.freedesktop.PowerManagement.Inhibit`) and lose both.
+- VLC inhibits through `org.freedesktop.ScreenSaver` at the legacy `/ScreenSaver` object path and loses it.
 
-The applications are behaving correctly; nobody is listening. Every
-desktop environment owns these names; Omarchy 3 did too, through hypridle.
+The applications are behaving correctly; nobody is listening. Every desktop environment owns these names; Omarchy 3 did too, through hypridle.
 
 ## What the browsers actually do (verified from source, not assumed)
 
 The client side dictates several constraints that rule designs out:
 
-- **Chromium** (`power_save_blocker_linux.cc`) probes with
-  `org.freedesktop.DBus.NameHasOwner` before calling `Inhibit`.
-  `NameHasOwner` does **not** trigger D-Bus activation. If the name is
-  unowned, Chromium logs "we just ignore them" and never inhibits — no retry,
-  no fallback. VLC behaves the same (it only calls backends whose name has an
-  owner).
-- **Firefox** (`WakeLockListener.cpp`) rotates backends — portal →
-  `org.freedesktop.ScreenSaver` at `/ScreenSaver` →
-  `org.freedesktop.PowerManagement.Inhibit` → `org.gnome.SessionManager` —
-  retrying once per state transition when a backend errors.
-- **Object paths split by client**: VLC and Firefox use the legacy `/ScreenSaver`
-  path (KDE ≤ 4.11 compatibility, codified in the spec's design notes);
-  Chromium uses `/org/freedesktop/ScreenSaver`. A responder must export the
-  interface on **both**.
-- **Lifetime**: the spec says inhibition ends on `UnInhibit` *or when the
-  application disconnects from the bus*. A browser crash must not leave the
-  session permanently uninhibited; hypridle reaps by watching
-  `NameOwnerChanged` with an empty new owner, and this design does the same.
+- **Chromium** (`power_save_blocker_linux.cc`) probes with `org.freedesktop.DBus.NameHasOwner` before calling `Inhibit`. `NameHasOwner` does **not** trigger D-Bus activation. If the name is unowned, Chromium logs "we just ignore them" and never inhibits — no retry, no fallback. VLC behaves the same (it only calls backends whose name has an owner).
+- **Firefox** (`WakeLockListener.cpp`) rotates backends — portal → `org.freedesktop.ScreenSaver` at `/ScreenSaver` → `org.freedesktop.PowerManagement.Inhibit` → `org.gnome.SessionManager` — retrying once per state transition when a backend errors.
+- **Object paths split by client**: VLC and Firefox use the legacy `/ScreenSaver` path (KDE ≤ 4.11 compatibility, codified in the spec's design notes); Chromium uses `/org/freedesktop/ScreenSaver`. A responder must export the interface on **both**.
+- **Lifetime**: the spec says inhibition ends on `UnInhibit` *or when the application disconnects from the bus*. A browser crash must not leave the session permanently uninhibited; hypridle reaps by watching `NameOwnerChanged` with an empty new owner, and this design does the same.
 
 ## Rejected approaches
 
-- **D-Bus service activation** (`~/.local/share/dbus-1/services` `.service`
-  file, daemon spawned on first `Inhibit`): dead on arrival given the
-  `NameHasOwner` probing above — Chromium and VLC would never trigger it, and
-  they are the majority of the reports. Activation also restarts from zero
-  state (inhibits silently forgotten) whenever the daemon exits.
-- **Bridging D-Bus inhibits to a Wayland inhibitor held by a helper**
-  (`zwp_idle_inhibit_manager_v1` in a bridge process): the protocol binds an
-  inhibitor to a surface, and sway explicitly ignores inhibitors whose surface
-  is not visible — a bare never-mapped surface from a headless bridge does not
-  count. Layer-shell trickery to keep an invisible-but-"visible" surface is
-  fragile, compositor-specific, and untestable without a session. The ext-idle
-  notify v2 `get_input_idle_notification` clients ignore inhibitors anyway.
-- **Running hypridle alongside the Quickshell idle service**: two idle daemons
-  racing to run screensaver/lock actions; hypridle holds its inhibit state
-  internally where the Quickshell service cannot see it.
-- **Teaching Quickshell to serve D-Bus**: Quickshell 0.3.1 has no D-Bus service
-  registration API (client-side calls only; serving `org.freedesktop.ScreenSaver`
-  is an open upstream discussion). Waiting on upstream leaves the bug open.
-- **`systemd-inhibit` / logind**: logind's `idle` inhibitor is not consulted by
-  the Quickshell `IdleMonitor`, and browsers do not use it for display idle.
+- **D-Bus service activation** (`~/.local/share/dbus-1/services` `.service` file, daemon spawned on first `Inhibit`): dead on arrival given the `NameHasOwner` probing above — Chromium and VLC would never trigger it, and they are the majority of the reports. Activation also restarts from zero state (inhibits silently forgotten) whenever the daemon exits.
+- **Bridging D-Bus inhibits to a Wayland inhibitor held by a helper** (`zwp_idle_inhibit_manager_v1` in a bridge process): the protocol binds an inhibitor to a surface, and sway explicitly ignores inhibitors whose surface is not visible — a bare never-mapped surface from a headless bridge does not count. Layer-shell trickery to keep an invisible-but-"visible" surface is fragile, compositor-specific, and untestable without a session. The ext-idle notify v2 `get_input_idle_notification` clients ignore inhibitors anyway.
+- **Running hypridle alongside the Quickshell idle service**: two idle daemons racing to run screensaver/lock actions; hypridle holds its inhibit state internally where the Quickshell service cannot see it.
+- **Teaching Quickshell to serve D-Bus**: Quickshell 0.3.1 has no D-Bus service registration API (client-side calls only; serving `org.freedesktop.ScreenSaver` is an open upstream discussion). Waiting on upstream leaves the bug open.
+- **`systemd-inhibit` / logind**: logind's `idle` inhibitor is not consulted by the Quickshell `IdleMonitor`, and browsers do not use it for display idle.
 
 ## Chosen design: a small always-on responder that owns the names and publishes state; the idle service gates on it
 
@@ -73,146 +35,65 @@ Two components, one contract.
 
 ### 1. `omarchy-idle-inhibit-daemon` (python3 + PyGObject, already a base dependency)
 
-A session-bus responder owned by a systemd user unit
-(`omarchy-idle-inhibit.service`, `WantedBy=graphical-session.target`, the
-crash-watch/migrate-notify pattern) so it is running before any browser probes:
+A session-bus responder owned by a systemd user unit (`omarchy-idle-inhibit.service`, `WantedBy=graphical-session.target`, the crash-watch/migrate-notify pattern) so it is running before any browser probes:
 
-- Owns **`org.freedesktop.ScreenSaver`**, exporting `Inhibit(ss) → u` and
-  `UnInhibit(u)` on **both** `/org/freedesktop/ScreenSaver` and `/ScreenSaver`.
-  The KDE-legacy `GetActive`/`ActiveChanged` extras are deliberately *not*
-  offered: they mean "the screensaver is showing", which this daemon cannot
-  honestly report — emitting them for inhibit-held state would be exactly
-  inverted.
-- Owns **`org.freedesktop.PowerManagement`**, exporting `Inhibit(ss) → u`,
-  `UnInhibit(u)`, `HasInhibit() → b` + `HasInhibitChanged(b)` at
-  `/org/freedesktop/PowerManagement/Inhibit` (what Chromium's second inhibit
-  and Firefox's third backend expect; Clight-class clients listen to the
-  signal).
-- Cookies are a global counter; each cookie records the caller's unique bus
-  name. `UnInhibit` with an unknown cookie returns normally (hypridle
-  precedent; a restarted browser replaying a stale cookie must not wedge).
-  `UnInhibit` does not verify the sender (any same-uid process can already
-  run code; matching hypridle).
-- Watches `NameOwnerChanged`; when a cookie's owner disappears the cookie is
-  reaped — a crashed browser cannot leave the session inhibited forever.
-- Application/reason strings are truncated and outstanding inhibits capped;
-  over the cap a caller gets `LimitsExceeded` rather than unbounded state.
-- If either well-known name cannot be acquired (another screensaver service is
-  present), logs and exits 0: never fight over the name, never show a failed
-  unit for a machine that has its own screensaver daemon. The unit uses
-  `Restart=on-failure` so that clean stand-down does not respawn forever.
-- Publishes the inhibit state as JSON to
-  `$XDG_RUNTIME_DIR/omarchy/idle-inhibit/state` — written with
-  write-temp-then-rename at 0600, on **every** state change including the
-  initial "nothing inhibited" snapshot:
+- Owns **`org.freedesktop.ScreenSaver`**, exporting `Inhibit(ss) → u` and `UnInhibit(u)` on **both** `/org/freedesktop/ScreenSaver` and `/ScreenSaver`. The KDE-legacy `GetActive`/`ActiveChanged` extras are deliberately *not* offered: they mean "the screensaver is showing", which this daemon cannot honestly report — emitting them for inhibit-held state would be exactly inverted.
+- Owns **`org.freedesktop.PowerManagement`**, exporting `Inhibit(ss) → u`, `UnInhibit(u)`, `HasInhibit() → b` + `HasInhibitChanged(b)` at `/org/freedesktop/PowerManagement/Inhibit` (what Chromium's second inhibit and Firefox's third backend expect; Clight-class clients listen to the signal).
+- Cookies are a global counter; each cookie records the caller's unique bus name. `UnInhibit` with an unknown cookie returns normally (hypridle precedent; a restarted browser replaying a stale cookie must not wedge). `UnInhibit` does not verify the sender (any same-uid process can already run code; matching hypridle).
+- Watches `NameOwnerChanged`; when a cookie's owner disappears the cookie is reaped — a crashed browser cannot leave the session inhibited forever.
+- Application/reason strings are truncated and outstanding inhibits capped; over the cap a caller gets `LimitsExceeded` rather than unbounded state.
+- If either well-known name cannot be acquired (another screensaver service is present), logs and exits 0: never fight over the name, never show a failed unit for a machine that has its own screensaver daemon. The unit uses `Restart=on-failure` so that clean stand-down does not respawn forever.
+- Publishes the inhibit state as JSON to `$XDG_RUNTIME_DIR/omarchy/idle-inhibit/state` — written with write-temp-then-rename at 0600, on **every** state change including the initial "nothing inhibited" snapshot:
 
   ```json
   {"pid": 12345, "inhibited": false, "count": 0, "holders": []}
   ```
 
-  The **pid** is the liveness contract: consumers read a snapshot whose pid is
-  no longer running as released, which is what makes daemon death — SIGKILL
-  mid-inhibit included — self-healing without any cross-process cleanup. An
-  orderly exit additionally republishes an empty snapshot.
-- An `omarchy-idle-inhibit-probe` helper consumes the file for the shell: it
-  prints the JSON as exactly one line when the serving pid is alive, one empty
-  line for absence/garbage, and nothing for a dead pid. Silence means "not
-  inhibited", so every failure mode lands on the safe side.
+  The **pid** is the liveness contract: consumers read a snapshot whose pid is no longer running as released, which is what makes daemon death — SIGKILL mid-inhibit included — self-healing without any cross-process cleanup. An orderly exit additionally republishes an empty snapshot.
+- An `omarchy-idle-inhibit-probe` helper consumes the file for the shell: it prints the JSON as exactly one line when the serving pid is alive, and one empty line for absence, garbage, or a dead pid. Every failure mode lands on "not inhibited".
 
-  `holders` entries carry `{app, reason, owner, cookie, since}` — enough for
-  `omarchy debug` to say *who* is keeping the screen awake, which no
-  `org.freedesktop.ScreenSaver` implementation exposes (the spec has no query
-  method; that gap is a standing complaint).
+  `holders` entries carry `{app, reason, owner, cookie, since}` — enough for `omarchy debug` to say *who* is keeping the screen awake, which no `org.freedesktop.ScreenSaver` implementation exposes (the spec has no query method; that gap is a standing complaint).
 
-The daemon never touches Wayland, never draws anything, and needs no
-privileges. All decision logic lives in small pure functions so the test suite
-can drive the real daemon over a real session bus.
+The daemon never touches Wayland, never draws anything, and needs no privileges. All decision logic lives in small pure functions so the test suite can drive the real daemon over a real session bus.
 
 ### 2. The idle service consumes the state file
 
-`shell/plugins/services/idle/Service.qml` gains the state-file watch it already
-has a pattern for (the stay-awake indicator watcher watches a directory so
-atomic renames surface as change events):
+`shell/plugins/services/idle/Service.qml` gains the state-file watch it already has a pattern for (the stay-awake indicator watcher watches a directory so atomic renames surface as change events):
 
-- A `FileView` on the `omarchy/idle-inhibit` directory; each change re-reads
-  `state` through `IdleModel.externalInhibitFromState(raw)`, a tolerant parser
-  (garbage or absence reads as "not inhibited" — a daemon crash must never
-  wedge the idle timers *on*).
-- `IdleMonitor.enabled` gains `&& !externalInhibit`: while any D-Bus inhibit is
-  held, no idle cycle can start — the same gate `stay-awake` already uses, one
-  row over.
-- The shell reads the file only through the probe script: every failure mode —
-  daemon down, file torn, garbage, stale pid — lands on "not inhibited", the
-  one direction that can never wedge idle behavior.
-- An inhibit arriving mid-cycle cancels it (consistent with toggling Stay
-  Awake, which also cancels): a browser that started playing video owns the
-  screen, screensaver included. A lock that already fired is left alone —
-  inhibits never dismiss a lock.
-- The watcher is best-effort: missing runtime dir, unreadable file, or a
-  daemon that is not running all degrade to "no external inhibits" and the
-  idle timers behave exactly as they do today.
-- `omarchy-shell idle status` reports the external inhibit state, and
-  `omarchy-debug-idle` prints it, so a stuck inhibit is diagnosable.
+- A `FileView` on the `omarchy/idle-inhibit` directory; each change re-reads `state` through `IdleModel.externalInhibitFromState(raw)`, a tolerant parser (garbage or absence reads as "not inhibited" — a daemon crash must never wedge the idle timers *on*).
+- `IdleMonitor.enabled` gains `&& !externalInhibit`: while any D-Bus inhibit is held, no idle cycle can start — the same gate `stay-awake` already uses, one row over.
+- The shell reads the file only through the probe script. SplitParser.onRead does not fire when a process emits no bytes, so the probe always emits one line (JSON or empty) and the Process also applies empty state from `onExited` when that run produced no stdout — a SIGKILL'd daemon cannot pin the last applied inhibit.
+- An inhibit arriving mid-cycle cancels it (consistent with toggling Stay Awake, which also cancels): a browser that started playing video owns the screen, screensaver included. A lock that already fired is left alone — inhibits never dismiss a lock.
+- The watcher is best-effort: missing runtime dir, unreadable file, or a daemon that is not running all degrade to "no external inhibits" and the idle timers behave exactly as they do today.
+- `omarchy-shell idle status` reports the external inhibit state, and `omarchy-debug-idle` prints it, so a stuck inhibit is diagnosable.
 
 ### Scope and non-goals
 
-- `xdg-desktop-portal` Inhibit (`org.freedesktop.impl.portal.Inhibit`) is not
-  implemented here: flatpaked browsers go through the portal, whose Hyprland
-  backend does not implement it either — that belongs to
-  xdg-desktop-portal-hyprland, not to a session responder. The plan notes it
-  so the gap is documented rather than rediscovered.
-- `org.gnome.SessionManager` is not implemented: Firefox only reaches it after
-  both freedesktop names fail, so owning the two standard names covers it.
-- Power actions (suspend/hibernate inhibits via logind) are out of scope;
-  Omarchy does not auto-suspend on idle.
+- `xdg-desktop-portal` Inhibit (`org.freedesktop.impl.portal.Inhibit`) is not implemented here: flatpaked browsers go through the portal, whose Hyprland backend does not implement it either — that belongs to xdg-desktop-portal-hyprland, not to a session responder. The plan notes it so the gap is documented rather than rediscovered.
+- `org.gnome.SessionManager` is not implemented: Firefox only reaches it after both freedesktop names fail, so owning the two standard names covers it.
+- Power actions (suspend/hibernate inhibits via logind) are out of scope; Omarchy does not auto-suspend on idle.
 
 ## Edge cases the design must answer
 
-- **Daemon starts after an inhibit was attempted**: the browser's probe failed
-  once; Firefox rotates back on its next state change, Chromium on its next
-  video. The unit starts with the graphical session, before browsers, so this
-  is a reboot-ordering curiosity rather than a support case.
-- **Daemon crashes**: the bus name drops; the state file goes stale. The
-  service's tolerant parser does not treat a stale file as a held inhibit, and
-  `Restart=always` brings the name back. Chromium/VLC re-probe per video.
-- **Two users / two sessions**: bus names are per-session; the runtime dir is
-  per-session. Nothing is shared.
-- **`checkupdates`-style long holds** (a download manager inhibiting for an
-  hour): that is the API working as designed; the status command exists so the
-  user can see why.
-- **Cookie exhaustion**: uint32 counter starting at 1; wraparound at 4 billion
-  inhibits is not a support case.
+- **Daemon starts after an inhibit was attempted**: the browser's probe failed once; Firefox rotates back on its next state change, Chromium on its next video. The unit starts with the graphical session (WantedBy=, After=dbus.socket — *not* After=graphical-session.target), before browsers, so this is a reboot-ordering curiosity rather than a support case.
+- **Daemon crashes**: the bus name drops; the state file goes stale. The service's tolerant parser does not treat a stale file as a held inhibit, and `Restart=on-failure` brings the name back after a non-zero exit. Clean stand-down (names owned elsewhere, exit 0) must not respawn. Chromium/VLC re-probe per video.
+- **Two users / two sessions**: bus names are per-session; the runtime dir is per-session. Nothing is shared.
+- **`checkupdates`-style long holds** (a download manager inhibiting for an hour): that is the API working as designed; the status command exists so the user can see why.
+- **Cookie exhaustion**: uint32 counter starting at 1; wraparound at 4 billion inhibits is not a support case.
 
 ## Wiring
 
-- `default/systemd/user/omarchy-idle-inhibit.service` — house pattern
-  (`After=graphical-session.target`, `WantedBy=graphical-session.target`,
-  `Restart=always`, `ExecStart=/usr/bin/omarchy-idle-inhibit-daemon`; the
-  PKGBUILD install line lives in omarchy-pkgs and is called out in the PR).
+- `default/systemd/user/omarchy-idle-inhibit.service` — `After=dbus.socket`, `Requires=dbus.socket`, `WantedBy=graphical-session.target`, `Restart=on-failure`, `ExecStart=/usr/bin/omarchy-idle-inhibit-daemon`. The PKGBUILD install line lives in omarchy-pkgs and is called out in the PR.
 - New installs: added to `install/user/first-run/enable-user-units.sh`.
-- Existing installs: a migration enables the unit, with the
-  no-live-user-manager fallback (symlink into
-  `graphical-session.target.wants`) used by the migrate-notify migration.
-- No new package dependencies: `python-gobject` is already in
-  `install/omarchy-base.packages`.
+- Existing installs: a migration enables the unit, with the no-live-user-manager fallback (symlink into `graphical-session.target.wants`) used by the migrate-notify migration.
+- No new package dependencies: `python-gobject` is already in `install/omarchy-base.packages`.
 
 ## Test plan
 
 All red-green, run against the real components:
 
-- **Daemon, over a real bus** (`dbus-run-session` + `busctl`): inhibit returns
-  a cookie and flips the state file; both object paths answer; a second sender
-  stacks; `UnInhibit` drops one; unknown cookie tolerated; a sender that exits
-  without uninhibiting is reaped via `NameOwnerChanged`; the name-loss case
-  exits 0; `HasInhibit`/`GetActive` agree with the state file; the state file
-  is 0600 and always complete JSON under an inhibit/uninhibit storm; the
-  initial "nothing inhibited" snapshot exists without any caller.
-- **Model, in node** (`idle-test.sh`): the tolerant parser — valid state, torn
-  file, garbage, missing — and the gating arithmetic.
-- **Wiring, house style**: the unit file's `ExecStart`, the service's
-  `FileView` and the `IdleMonitor.enabled` gate, checked the way
-  `powerprofiles-set-test.sh` checks `Service.qml` bindings.
-- **Migration**: idempotent rerun, respects `OMARCHY_PATH`, enables the unit
-  with and without a live user manager.
-- **Mutation checks**: every behavior above is proven by reverting the code
-  that implements it and watching its test fail.
+- **Daemon, over a real bus** (`dbus-run-session` + `busctl`): inhibit returns a cookie and flips the state file; both object paths answer; a second sender stacks; `UnInhibit` drops one; unknown cookie tolerated; a sender that exits without uninhibiting is reaped via `NameOwnerChanged`; the name-loss case exits 0; `GetActive` is absent (KDE-legacy screensaver-blanked semantics this daemon cannot honestly report); `HasInhibit` agrees with the state file; SIGKILL mid-inhibit leaves the last live snapshot on disk and the probe emits one empty line for that dead pid; SIGTERM leaves a forced-empty snapshot; the state file is 0600 and always complete JSON under an inhibit/uninhibit storm; the initial "nothing inhibited" snapshot exists without any caller.
+- **Model, in node** (`idle-test.sh`): the tolerant parser — valid state, torn file, garbage, missing — and the gating arithmetic.
+- **Wiring, house style**: the unit file's `ExecStart` and `After=dbus.socket`, the service's `FileView`, the `IdleMonitor.enabled` gate, and probe-exit-without-stdout applying empty state, checked the way `powerprofiles-set-test.sh` checks `Service.qml` bindings.
+- **Migration**: idempotent rerun, respects `OMARCHY_PATH`, enables the unit with and without a live user manager.
+- **Mutation checks**: every behavior above is proven by reverting the code that implements it and watching its test fail.

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -12,6 +12,34 @@ function eventParts(event, count) {
   return String(event && event.data ? event.data : "").split(",")
 }
 
+// The D-Bus inhibit daemon (omarchy-idle-inhibit-daemon) publishes its state
+// as JSON to the runtime dir; the idle service reads it back through this
+// parser. Tolerance is the contract: a daemon that is down, crashed mid-write,
+// or publishing garbage reads as "nothing inhibited", so a broken state file
+// can never pin the idle timers off permanently.
+function externalInhibitFromState(raw) {
+  var state = { inhibited: false }
+
+  try {
+    var parsed = JSON.parse(String(raw || ""))
+    if (!parsed || typeof parsed !== "object") return state
+    if (parsed.inhibited !== true) return state
+    if (!Array.isArray(parsed.holders) || parsed.holders.length === 0) return state
+    return { inhibited: true }
+  } catch (error) {
+    return state
+  }
+}
+
+// The IdleMonitor gate. stayAwakeStateLoaded stays a term because an unloaded
+// indicator state must not read as "idle allowed" on a race with the probe.
+function idleEnabledAfter(stayAwakeStateLoaded, stayAwake, externalInhibit) {
+  if (!stayAwakeStateLoaded) return false
+  if (stayAwake) return false
+  if (externalInhibit) return false
+  return true
+}
+
 function screensaverWindowsAfter(windows, address, visible) {
   var key = String(address || "")
   if (!key) {
@@ -47,6 +75,8 @@ if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
-    screensaverWindowsAfter: screensaverWindowsAfter
+    screensaverWindowsAfter: screensaverWindowsAfter,
+    externalInhibitFromState: externalInhibitFromState,
+    idleEnabledAfter: idleEnabledAfter
   }
 }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -14,6 +14,12 @@ Item {
   readonly property string home: Quickshell.env("HOME")
   readonly property string stayAwakeStateDir: home + "/.local/state/omarchy/indicators"
   readonly property string stayAwakeStatePath: stayAwakeStateDir + "/stay-awake"
+  // The D-Bus inhibit daemon publishes here (write-temp-then-rename), so the
+  // watch is on the directory: a rename inside it surfaces as a change event,
+  // while a watch on the file itself can be lost to the swap. Same reason the
+  // stay-awake watcher above watches its directory.
+  readonly property string runtimeDir: Quickshell.env("XDG_RUNTIME_DIR")
+  readonly property string externalInhibitStateDir: runtimeDir + "/omarchy/idle-inhibit"
   readonly property int defaultScreensaverSeconds: 150
   readonly property int defaultLockSeconds: 300
   readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
@@ -22,13 +28,17 @@ Item {
   readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
   readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
-  readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
+  // The gate itself lives in IdleModel.idleEnabledAfter so its terms are
+  // node-tested; an external D-Bus inhibit holds the idle cycle off exactly
+  // like stay-awake does.
+  readonly property bool idleEnabled: IdleModel.idleEnabledAfter(stayAwakeStateLoaded, stayAwake, externalInhibit)
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
   property bool hasPendingStayAwakePersist: false
   property bool pendingStayAwakePersist: false
+  property bool externalInhibit: false
   property bool idledThisCycle: false
   property bool screensaverStartedThisCycle: false
   property string lastEvent: "starting"
@@ -183,6 +193,8 @@ Item {
       stayAwake: root.stayAwake,
       stayAwakeStateLoaded: root.stayAwakeStateLoaded,
       stayAwakeStatePath: root.stayAwakeStatePath,
+      externalInhibit: root.externalInhibit,
+      externalInhibitStateDir: root.externalInhibitStateDir,
       idle: idleMonitor.isIdle,
       inIdleCycle: root.idledThisCycle,
       screensaverStarted: root.screensaverStartedThisCycle,
@@ -245,6 +257,26 @@ Item {
 
   function setIdleEnabled(value) {
     return applyStayAwake(!value, true, "ipc")
+  }
+
+  // Read the D-Bus inhibit daemon's published state. Absence, garbage, or a
+  // torn file all read as no inhibit — a daemon that is down must never pin
+  // the idle timers off. An inhibit arriving mid-cycle cancels it, exactly
+  // like enabling Stay Awake does: a browser that started playing video owns
+  // the screen, screensaver included.
+  function applyExternalInhibitState(raw) {
+    var next = IdleModel.externalInhibitFromState(raw).inhibited
+    if (next === root.externalInhibit) return
+
+    root.externalInhibit = next
+    logEvent("external-inhibit", next ? "held" : "released")
+
+    if (next && root.idledThisCycle) cancelIdleCycle("external-inhibit")
+    else if (!next) Qt.callLater(root.handleIdleChanged)
+  }
+
+  function refreshExternalInhibitState() {
+    if (!externalInhibitProbe.running) externalInhibitProbe.running = true
   }
 
   IdleMonitor {
@@ -329,9 +361,43 @@ Item {
     onFileChanged: root.refreshStayAwakeState()
   }
 
+  Process {
+    id: externalInhibitProbe
+    // The daemon's JSON carries no trailing newline; normalize through command
+    // substitution so the line parser always sees exactly one whole line, and
+    // a missing file yields one empty line (the tolerant parser reads that as
+    // no inhibit).
+    command: ["bash", "-c", "printf '%s\\n' \"$(cat \"$1\" 2>/dev/null)\"", "bash", root.externalInhibitStateDir + "/state"]
+    stdout: SplitParser {
+      onRead: function(line) { root.applyExternalInhibitState(line) }
+    }
+  }
+
+  FileView {
+    id: externalInhibitStateDirWatcher
+    path: root.externalInhibitStateDir
+    watchChanges: true
+    printErrors: false
+    onFileChanged: root.refreshExternalInhibitState()
+  }
+
+  // The daemon starts with the graphical session alongside the shell, so its
+  // state directory may not exist when the watcher above arms. A missing-path
+  // watch can stay missing for the whole session, so a slow retry closes the
+  // race; the probe is a single cat and the timer stops mattering once the
+  // directory watch is delivering.
+  Timer {
+    id: externalInhibitRetryTimer
+    interval: 10000
+    repeat: true
+    running: true
+    onTriggered: root.refreshExternalInhibitState()
+  }
+
   Component.onCompleted: {
     logEvent("service-ready")
     refreshStayAwakeState()
+    refreshExternalInhibitState()
   }
 
   IpcHandler {

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -364,12 +364,20 @@ Item {
 
   Process {
     id: externalInhibitProbe
-    // The probe normalizes the daemon's newline-less JSON into exactly one
-    // line and stays silent when the serving pid is gone — silence is the
-    // consumer's "not inhibited", so a dead daemon cannot pin idle off.
+    // SplitParser.onRead never fires when the probe emits no bytes (a
+    // SIGKILL'd daemon's last write). Track whether this run produced a
+    // line, and apply empty state on exit so a crash cannot pin idle off.
+    property bool sawProbeOutput: false
     command: [root.omarchyPath + "/bin/omarchy-idle-inhibit-probe", root.externalInhibitStateDir + "/state"]
     stdout: SplitParser {
-      onRead: function(line) { root.applyExternalInhibitState(line) }
+      onRead: function(line) {
+        sawProbeOutput = true
+        root.applyExternalInhibitState(line)
+      }
+    }
+    onRunningChanged: if (running) sawProbeOutput = false
+    onExited: function() {
+      if (!sawProbeOutput) root.applyExternalInhibitState("")
     }
   }
 

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -10,6 +10,7 @@ Item {
 
   // Injected by omarchy-shell (the first-party service loader).
   property var shell: null
+  property string omarchyPath: Quickshell.env("OMARCHY_PATH")
 
   readonly property string home: Quickshell.env("HOME")
   readonly property string stayAwakeStateDir: home + "/.local/state/omarchy/indicators"
@@ -363,11 +364,10 @@ Item {
 
   Process {
     id: externalInhibitProbe
-    // The daemon's JSON carries no trailing newline; normalize through command
-    // substitution so the line parser always sees exactly one whole line, and
-    // a missing file yields one empty line (the tolerant parser reads that as
-    // no inhibit).
-    command: ["bash", "-c", "printf '%s\\n' \"$(cat \"$1\" 2>/dev/null)\"", "bash", root.externalInhibitStateDir + "/state"]
+    // The probe normalizes the daemon's newline-less JSON into exactly one
+    // line and stays silent when the serving pid is gone — silence is the
+    // consumer's "not inhibited", so a dead daemon cannot pin idle off.
+    command: [root.omarchyPath + "/bin/omarchy-idle-inhibit-probe", root.externalInhibitStateDir + "/state"]
     stdout: SplitParser {
       onRead: function(line) { root.applyExternalInhibitState(line) }
     }

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -141,6 +141,7 @@ package_defaults = [
   ("default/systemd/user/omarchy-tailscale-receive.service", "/usr/lib/systemd/user/omarchy-tailscale-receive.service", "systemd/user/omarchy-tailscale-receive.service"),
   ("default/systemd/user/omarchy-fcitx5.service", "/usr/lib/systemd/user/omarchy-fcitx5.service", "systemd/user/omarchy-fcitx5.service"),
   ("default/systemd/user/omarchy-crash-watch.service", "/usr/lib/systemd/user/omarchy-crash-watch.service", "systemd/user/omarchy-crash-watch.service"),
+  ("default/systemd/user/omarchy-idle-inhibit.service", "/usr/lib/systemd/user/omarchy-idle-inhibit.service", "systemd/user/omarchy-idle-inhibit.service"),
   ("default/systemd/zram-generator.conf.d/90-omarchy.conf", "/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf", "systemd/zram-generator.conf.d/90-omarchy.conf"),
   ("default/fonts/omarchy/omarchy.ttf", "/usr/share/fonts/omarchy/omarchy.ttf", "omarchy.ttf"),
   ("default/snapper/root", "/etc/snapper/config-templates/omarchy", "snapper/root"),

--- a/test/shell.d/idle-inhibit-daemon-test.sh
+++ b/test/shell.d/idle-inhibit-daemon-test.sh
@@ -359,6 +359,42 @@ pass "missing and torn state files read as nothing inhibited"
 start_daemon
 wait_for "a fresh daemon republishes over the stale file" not_inhibited
 
+# --- An orderly stop leaves the file honest -----------------------------------
+#
+# systemd stops are clean: before exiting, the daemon republishes an empty
+# snapshot rather than leaving whatever clients held at the moment of the
+# stop on disk.
+
+held=$(python3 - <<'PY'
+import time
+import gi
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+res = bus.call_sync(
+    "org.freedesktop.ScreenSaver", "/ScreenSaver", "org.freedesktop.ScreenSaver",
+    "Inhibit", GLib.Variant("(ss)", ("term.client", "hold across sigterm")),
+    GLib.VariantType("(u)"), Gio.DBusCallFlags.NONE, -1, None)
+print(res.unpack()[0], flush=True)
+time.sleep(600)
+PY
+) &
+holder_term_pid=$!
+wait_for "the term-test holder is visible" inhibited
+
+kill -TERM "$daemon_pid"
+deadline=$((SECONDS + 10))
+while ((SECONDS < deadline)) && kill -0 "$daemon_pid" 2>/dev/null; do sleep 0.1; done
+if kill -0 "$daemon_pid" 2>/dev/null; then fail "the daemon exits cleanly on SIGTERM"; fi
+
+jq -e '.inhibited == false and .count == 0' "$state_file" >/dev/null ||
+  fail "SIGTERM leaves a clean nothing-inhibited snapshot" "$(cat "$state_file")"
+pass "SIGTERM leaves a clean nothing-inhibited snapshot"
+kill "$holder_term_pid" 2>/dev/null || true
+wait "$holder_term_pid" 2>/dev/null || true
+daemon_pid=
+
 echo "all inner assertions passed"
 
 INNER

--- a/test/shell.d/idle-inhibit-daemon-test.sh
+++ b/test/shell.d/idle-inhibit-daemon-test.sh
@@ -23,6 +23,7 @@ runtime_dir="$session_dir/runtime"
 mkdir -p "$runtime_dir"
 
 inner="$session_dir/inner.sh"
+PROBE="$ROOT/bin/omarchy-idle-inhibit-probe"
 
 cat >"$inner" <<'INNER'
 #!/bin/bash
@@ -73,6 +74,10 @@ holders_are() {
 
 without_app() {
   jq -e --arg app "$1" '(.holders | map(.app) | index($app)) == null' "$state_file" >/dev/null 2>&1
+}
+
+free_name() {
+  ! name_owned "${1:?}"
 }
 
 inhibit() {
@@ -188,9 +193,44 @@ jq -e --arg owner "$holder_pid" 'all(.holders[]; (.owner | startswith(":1.")))' 
 pass "holders record the owning bus name"
 
 active=$(busctl --user --no-pager call org.freedesktop.ScreenSaver "$SS_NEW" \
-  org.freedesktop.ScreenSaver GetActive 2>/dev/null | awk '{ print $2; exit }')
-[[ $active == "true" ]] || fail "GetActive reports active inhibits" "$active"
-pass "GetActive agrees with the state file"
+  org.freedesktop.ScreenSaver GetActive 2>&1 || true)
+grep -q "GetActive" <<<"$active" && grep -qi "no such method\|unknown method\|unknownmethod" <<<"$active" ||
+  fail "GetActive is not offered: reporting screensaver activation it does not own would be backwards" "$active"
+pass "the KDE-legacy GetActive is deliberately absent"
+
+# ... and no ActiveChanged signal may fire either: emitting the KDE semantics
+# ("screensaver blanked") from inhibit-held state would be exactly backwards.
+signal_absent=$(python3 - <<'PY'
+import gi
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+seen = []
+loop = GLib.MainLoop()
+
+def on_signal(conn, sender, path, iface, signal, params):
+    seen.append(signal)
+
+bus.signal_subscribe("org.freedesktop.ScreenSaver", "org.freedesktop.ScreenSaver",
+                     "ActiveChanged", None, None, Gio.DBusSignalFlags.NONE, on_signal)
+
+res = bus.call_sync("org.freedesktop.ScreenSaver", "/ScreenSaver",
+                    "org.freedesktop.ScreenSaver", "Inhibit",
+                    GLib.Variant("(ss)", ("nosignal.client", "probe")),
+                    GLib.VariantType("(u)"), Gio.DBusCallFlags.NONE, -1, None)
+cookie = res.unpack()[0]
+bus.call_sync("org.freedesktop.ScreenSaver", "/ScreenSaver",
+              "org.freedesktop.ScreenSaver", "UnInhibit",
+              GLib.Variant("(u)", (cookie,)), None,
+              Gio.DBusCallFlags.NONE, -1, None)
+GLib.timeout_add(300, loop.quit)
+loop.run()
+print("ActiveChanged" not in seen)
+PY
+)
+[[ $signal_absent == "True" ]] || fail "no ActiveChanged fires for inhibit transitions"
+pass "no ActiveChanged fires for inhibit transitions"
 
 has=$(busctl --user --no-pager call org.freedesktop.PowerManagement "$PM" \
   org.freedesktop.PowerManagement.Inhibit HasInhibit 2>/dev/null | awk '{ print $2; exit }')
@@ -223,7 +263,11 @@ kill "$holder_pid" 2>/dev/null || true
 wait_for "a crashed client's inhibits are reaped" not_inhibited
 pass "inhibits are reaped when their client leaves the bus"
 
-# --- Signal emissions --------------------------------------------------------
+# --- HasInhibitChanged is the one transition signal that survives ------------
+
+# (ActiveChanged was dropped above: it belongs to "screensaver blanked"
+# semantics the daemon cannot honestly report. HasInhibitChanged has unambiguous
+# inhibit semantics, and Clight-class clients listen for it.)
 
 signal_seen=$(python3 - <<'PY'
 import gi
@@ -231,16 +275,14 @@ gi.require_version("Gio", "2.0")
 from gi.repository import Gio, GLib
 
 bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
-seen = {}
+seen = []
 loop = GLib.MainLoop()
 
 def on_signal(conn, sender, path, iface, signal, params):
-    seen[signal] = params.unpack()[0]
-    if len(seen) == 2:
+    seen.append(params.unpack()[0])
+    if len(seen) == 1:
         loop.quit()
 
-bus.signal_subscribe("org.freedesktop.ScreenSaver", "org.freedesktop.ScreenSaver",
-                     "ActiveChanged", None, None, Gio.DBusSignalFlags.NONE, on_signal)
 bus.signal_subscribe("org.freedesktop.PowerManagement", "org.freedesktop.PowerManagement.Inhibit",
                      "HasInhibitChanged", None, None, Gio.DBusSignalFlags.NONE, on_signal)
 
@@ -249,20 +291,19 @@ res = bus.call_sync("org.freedesktop.ScreenSaver", "/ScreenSaver",
                     GLib.Variant("(ss)", ("signal.client", "signal probe")),
                     GLib.VariantType("(u)"), Gio.DBusCallFlags.NONE, -1, None)
 cookie = res.unpack()[0]
-# This connection stays alive until the checks below are queued, so the
-# inhibit is not reaped before the signals fire.
+# This connection stays alive until the check below is queued, so the
+# inhibit is not reaped before the signal fires.
 GLib.timeout_add(1500, loop.quit)
 GLib.idle_add(lambda: bus.call_sync("org.freedesktop.ScreenSaver", "/ScreenSaver",
                                     "org.freedesktop.ScreenSaver", "UnInhibit",
                                     GLib.Variant("(u)", (cookie,)), None,
                                     Gio.DBusCallFlags.NONE, -1, None) and False)
 loop.run()
-print("ActiveChanged" in seen and "HasInhibitChanged" in seen and
-      seen.get("ActiveChanged") is True and seen.get("HasInhibitChanged") is True)
+print(len(seen) >= 1 and seen[0] is True)
 PY
 )
-[[ $signal_seen == "True" ]] || fail "ActiveChanged and HasInhibitChanged fire on transitions"
-pass "ActiveChanged and HasInhibitChanged fire on transitions"
+[[ $signal_seen == "True" ]] || fail "HasInhibitChanged fires on transitions"
+pass "HasInhibitChanged fires on transitions"
 
 wait_for "state settles after the signal probe" not_inhibited
 
@@ -288,22 +329,44 @@ pass "a second daemon exits quietly and the first keeps the name"
 
 wait_for "state settles after the duplicate start" not_inhibited
 
-# The survivor must still be fully functional. busctl is transient, so its
-# inhibit self-releases with the connection; the cookie reply proves the
-# survivor still serves, and the file settling back proves it still publishes.
-c=$(inhibit "final.client" "after duplicate" "$SS_NEW")
-[[ $c =~ ^[0-9]+$ ]] || fail "the surviving daemon still serves Inhibit" "$c"
-pass "the surviving daemon still serves Inhibit"
+# --- A dead daemon's last write reads as released -----------------------------
+#
+# A SIGKILL leaves no orderly final publish — whatever the file claimed while
+# serving stays on disk. Every snapshot therefore carries the serving pid, and
+# the probe falls silent for a file whose pid is gone, so a crashed daemon
+# cannot pin the idle timers off; no bystander cleanup or coordination is
+# involved.
 
-wait_for "the surviving daemon still publishes state transitions" not_inhibited
-pass "the surviving daemon still publishes state transitions"
+stop_daemon
+sleep 1
+[[ -s $state_file ]] || fail "the kill test needs the dead daemon's last write"
+dead_pid=$(jq -r '.pid' "$state_file")
+if kill -0 "$dead_pid" 2>/dev/null; then fail "the killed daemon's pid is really gone"; fi
+if "$PROBE" "$state_file" | grep -q .; then fail "the probe is silent for a dead daemon's state"; fi
+pass "the probe is silent for a dead daemon's state"
+
+# Missing state: one empty line.
+out=$("$PROBE" "$runtime_dir/does-not-exist" ; printf 'x')
+[[ $out == $'\nx' ]] || fail "a missing state file reads as nothing inhibited" "$(printf %q "$out")"
+pass "a missing state file reads as nothing inhibited"
+
+# Torn/garbage state: one empty line.
+printf '%s' '{"inhibited":tru' >"$state_file"
+out=$("$PROBE" "$state_file" ; printf 'x')
+[[ $out == $'\nx' ]] || fail "a torn state file yields exactly one empty line" "$(printf %q "$out")"
+pass "missing and torn state files read as nothing inhibited"
+
+start_daemon
+wait_for "a fresh daemon republishes over the stale file" not_inhibited
 
 echo "all inner assertions passed"
+
 INNER
 
 chmod +x "$inner"
 
-DAEMON="$daemon" timeout 120 dbus-run-session -- bash "$inner" "$runtime_dir" ||
+export DAEMON="$daemon" PROBE="$PROBE"
+timeout 120 dbus-run-session -- bash "$inner" "$runtime_dir" ||
   fail "omarchy-idle-inhibit-daemon passes the live session-bus contract" \
     "see the inner assertion output above"
 

--- a/test/shell.d/idle-inhibit-daemon-test.sh
+++ b/test/shell.d/idle-inhibit-daemon-test.sh
@@ -99,8 +99,10 @@ PM=/org/freedesktop/PowerManagement/Inhibit
 daemon_pid=
 
 start_daemon() {
+  set +m
   "$DAEMON" &
   daemon_pid=$!
+  disown "$daemon_pid" 2>/dev/null || true
 }
 
 stop_daemon() {
@@ -333,17 +335,47 @@ wait_for "state settles after the duplicate start" not_inhibited
 #
 # A SIGKILL leaves no orderly final publish — whatever the file claimed while
 # serving stays on disk. Every snapshot therefore carries the serving pid, and
-# the probe falls silent for a file whose pid is gone, so a crashed daemon
-# cannot pin the idle timers off; no bystander cleanup or coordination is
-# involved.
+# the probe emits one empty line for a file whose pid is gone, so a crashed
+# daemon cannot pin the idle timers off; no bystander cleanup or coordination
+# is involved. The holder stays connected so the last write still claims it.
 
-stop_daemon
-sleep 1
-[[ -s $state_file ]] || fail "the kill test needs the dead daemon's last write"
-dead_pid=$(jq -r '.pid' "$state_file")
-if kill -0 "$dead_pid" 2>/dev/null; then fail "the killed daemon's pid is really gone"; fi
-if "$PROBE" "$state_file" | grep -q .; then fail "the probe is silent for a dead daemon's state"; fi
-pass "the probe is silent for a dead daemon's state"
+python3 - >"$runtime_dir/kill-holder.out" <<'PY' &
+import time
+import gi
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+res = bus.call_sync(
+    "org.freedesktop.ScreenSaver", "/ScreenSaver", "org.freedesktop.ScreenSaver",
+    "Inhibit", GLib.Variant("(ss)", ("kill.client", "hold across sigkill")),
+    GLib.VariantType("(u)"), Gio.DBusCallFlags.NONE, -1, None)
+print(res.unpack()[0], flush=True)
+time.sleep(600)
+PY
+kill_holder_pid=$!
+wait_for "the kill-test holder is visible" inhibited
+
+killed_pid=$daemon_pid
+kill -KILL "$daemon_pid"
+deadline=$((SECONDS + 10))
+while ((SECONDS < deadline)) && kill -0 "$daemon_pid" 2>/dev/null; do sleep 0.1; done
+if kill -0 "$daemon_pid" 2>/dev/null; then fail "the daemon dies on SIGKILL"; fi
+wait "$daemon_pid" 2>/dev/null || true
+daemon_pid=
+
+jq -e '.inhibited == true and (.holders | length > 0)' "$state_file" >/dev/null ||
+  fail "SIGKILL leaves the last live snapshot on disk" "$(cat "$state_file")"
+jq -e --argjson pid "$killed_pid" '.pid == $pid' "$state_file" >/dev/null ||
+  fail "SIGKILL snapshot still names the dead serving pid" "$(cat "$state_file")"
+if kill -0 "$killed_pid" 2>/dev/null; then fail "the killed daemon's pid is really gone"; fi
+
+out=$("$PROBE" "$state_file" ; printf 'x')
+[[ $out == $'\nx' ]] || fail "the probe emits one empty line for a SIGKILL'd daemon's last write" "$(printf %q "$out")"
+pass "SIGKILL mid-inhibit still reads as released"
+
+kill "$kill_holder_pid" 2>/dev/null || true
+wait "$kill_holder_pid" 2>/dev/null || true
 
 # Missing state: one empty line.
 out=$("$PROBE" "$runtime_dir/does-not-exist" ; printf 'x')
@@ -365,7 +397,7 @@ wait_for "a fresh daemon republishes over the stale file" not_inhibited
 # snapshot rather than leaving whatever clients held at the moment of the
 # stop on disk.
 
-held=$(python3 - <<'PY'
+python3 - >"$runtime_dir/term-holder.out" <<'PY' &
 import time
 import gi
 gi.require_version("Gio", "2.0")
@@ -379,7 +411,6 @@ res = bus.call_sync(
 print(res.unpack()[0], flush=True)
 time.sleep(600)
 PY
-) &
 holder_term_pid=$!
 wait_for "the term-test holder is visible" inhibited
 

--- a/test/shell.d/idle-inhibit-daemon-test.sh
+++ b/test/shell.d/idle-inhibit-daemon-test.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+
+# Drives bin/omarchy-idle-inhibit-daemon over a real private session bus
+# (dbus-run-session) and asserts the org.freedesktop.ScreenSaver contract the
+# browsers rely on: both object paths, cookie stacking, disconnect reaping,
+# tolerant uninhibit, and an atomically published state file.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command busctl
+require_command dbus-run-session
+require_command python3
+
+daemon="$ROOT/bin/omarchy-idle-inhibit-daemon"
+[[ -x $daemon ]] || fail "omarchy-idle-inhibit-daemon exists and is executable"
+
+session_dir=$(mktemp -d)
+trap 'rm -rf "$session_dir"' EXIT
+
+runtime_dir="$session_dir/runtime"
+mkdir -p "$runtime_dir"
+
+inner="$session_dir/inner.sh"
+
+cat >"$inner" <<'INNER'
+#!/bin/bash
+set -euo pipefail
+
+runtime_dir="$1"
+export XDG_RUNTIME_DIR="$runtime_dir"
+state_dir="$runtime_dir/omarchy/idle-inhibit"
+state_file="$state_dir/state"
+
+fail() {
+  echo "not ok - $1 ${2:-}" >&2
+  exit 1
+}
+pass() {
+  echo "ok - $1"
+}
+
+wait_for() {
+  local description="$1" deadline=$((SECONDS + 10))
+  while ((SECONDS < deadline)); do
+    "${@:2}" && return 0
+    sleep 0.1
+  done
+  fail "$description (timed out)"
+}
+
+name_owned() {
+  busctl --user --no-pager status "${1:?}" >/dev/null 2>&1
+}
+
+state_json() {
+  cat "$state_file" 2>/dev/null || printf ''
+}
+
+inhibited() {
+  jq -e '.inhibited == true and (.holders | length > 0)' "$state_file" >/dev/null 2>&1
+}
+
+not_inhibited() {
+  jq -e '.inhibited == false and .count == 0 and (.holders | length == 0)' "$state_file" >/dev/null 2>&1
+}
+
+holders_are() {
+  jq -e --argjson n "$1" '(.holders | length) == $n and .count == $n and .inhibited == ($n > 0)' \
+    "$state_file" >/dev/null 2>&1
+}
+
+without_app() {
+  jq -e --arg app "$1" '(.holders | map(.app) | index($app)) == null' "$state_file" >/dev/null 2>&1
+}
+
+inhibit() {
+  # app reason path
+  busctl --user --no-pager call org.freedesktop.ScreenSaver "$3" \
+    org.freedesktop.ScreenSaver Inhibit ss "$1" "$2" 2>/dev/null |
+    awk '/^u / { print $2; exit }'
+}
+
+uninhibit() {
+  busctl --user --no-pager call org.freedesktop.ScreenSaver "${2:?}" \
+    org.freedesktop.ScreenSaver UnInhibit u "${1:?}" >/dev/null 2>&1
+}
+
+SS_NEW=/org/freedesktop/ScreenSaver
+SS_LEGACY=/ScreenSaver
+PM=/org/freedesktop/PowerManagement/Inhibit
+
+daemon_pid=
+
+start_daemon() {
+  "$DAEMON" &
+  daemon_pid=$!
+}
+
+stop_daemon() {
+  [[ -n $daemon_pid ]] && kill "$daemon_pid" 2>/dev/null || true
+  wait "$daemon_pid" 2>/dev/null || true
+  daemon_pid=
+}
+trap stop_daemon EXIT
+
+# --- startup ---------------------------------------------------------------
+
+start_daemon
+wait_for "daemon owns org.freedesktop.ScreenSaver" name_owned org.freedesktop.ScreenSaver
+pass "daemon owns org.freedesktop.ScreenSaver"
+
+wait_for "daemon owns org.freedesktop.PowerManagement" name_owned org.freedesktop.PowerManagement
+pass "daemon owns org.freedesktop.PowerManagement"
+
+# The nothing-inhibited snapshot exists before any caller, so a consumer that
+# starts after the daemon never guesses its initial state.
+wait_for "initial state snapshot published" test -s "$state_file"
+not_inhibited || fail "initial state reports nothing inhibited" "$(state_json)"
+pass "initial state snapshot reports nothing inhibited"
+
+mode=$(stat -c '%a' "$state_file" 2>/dev/null || stat -f '%Lp' "$state_file")
+[[ $mode == "600" ]] || fail "state file is owner-only readable" "mode: $mode"
+pass "state file is owner-only readable"
+
+# --- Raw contract on both object paths --------------------------------------
+#
+# Chromium calls /org/freedesktop/ScreenSaver; VLC and Firefox call the legacy
+# /ScreenSaver path. Each busctl call is transient (the spec releases its
+# inhibit when the caller disconnects), so these assert the reply only — held
+# state is the live-connection section below.
+
+c=$(inhibit "path.probe.new" "probe" "$SS_NEW")
+[[ $c =~ ^[0-9]+$ ]] || fail "Inhibit answers on /org/freedesktop/ScreenSaver (Chromium path)" "$c"
+pass "Inhibit answers on /org/freedesktop/ScreenSaver (Chromium path)"
+
+c=$(inhibit "path.probe.legacy" "probe" "$SS_LEGACY")
+[[ $c =~ ^[0-9]+$ ]] || fail "Inhibit answers on /ScreenSaver (VLC/Firefox legacy path)" "$c"
+pass "Inhibit answers on /ScreenSaver (VLC/Firefox legacy path)"
+
+# --- Held inhibits from one live connection ---------------------------------
+#
+# busctl is a transient bus connection: it exits with its call, and the spec
+# ends an inhibition when its client disconnects — so every busctl inhibit is
+# reaped almost immediately. Assertions about *held* state therefore come from
+# one python client that keeps its connection open; the busctl calls above
+# prove the raw per-path contract only.
+
+holder="$runtime_dir/holder.out"
+python3 - >"$holder" <<'PY' &
+import os, sys, time
+import gi
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+
+def inhibit(path, iface, app, reason):
+    return bus.call_sync(
+        "org.freedesktop.ScreenSaver", path, iface, "Inhibit",
+        GLib.Variant("(ss)", (app, reason)), GLib.VariantType("(u)"),
+        Gio.DBusCallFlags.NONE, -1, None).unpack()[0]
+
+c1 = inhibit("/org/freedesktop/ScreenSaver", "org.freedesktop.ScreenSaver",
+             "org.chromium.chromium", "Video Wake Lock")
+c2 = inhibit("/ScreenSaver", "org.freedesktop.ScreenSaver",
+             "org.videolan.vlc", "Playing media")
+c3 = inhibit("/org/freedesktop/PowerManagement/Inhibit",
+             "org.freedesktop.PowerManagement.Inhibit",
+             "org.chromium.chromium", "Playing audio")
+print(f"{c1} {c2} {c3}", flush=True)
+time.sleep(600)
+PY
+holder_pid=$!
+wait_for "holder published its cookies" test -s "$holder"
+read -r cookie_chromium cookie_vlc cookie_pm <"$holder"
+
+wait_for "held inhibits stack in the state file" holders_are 3
+pass "concurrent inhibits from Chromium, VLC, and PowerManagement stack"
+
+jq -e '([.holders[].app] | sort) == (["org.chromium.chromium", "org.chromium.chromium", "org.videolan.vlc"] | sort)' \
+  "$state_file" >/dev/null || fail "state names each inhibiting application" "$(state_json)"
+pass "state names each inhibiting application"
+
+jq -e --arg owner "$holder_pid" 'all(.holders[]; (.owner | startswith(":1.")))' \
+  "$state_file" >/dev/null || fail "holders record the owning bus name" "$(state_json)"
+pass "holders record the owning bus name"
+
+active=$(busctl --user --no-pager call org.freedesktop.ScreenSaver "$SS_NEW" \
+  org.freedesktop.ScreenSaver GetActive 2>/dev/null | awk '{ print $2; exit }')
+[[ $active == "true" ]] || fail "GetActive reports active inhibits" "$active"
+pass "GetActive agrees with the state file"
+
+has=$(busctl --user --no-pager call org.freedesktop.PowerManagement "$PM" \
+  org.freedesktop.PowerManagement.Inhibit HasInhibit 2>/dev/null | awk '{ print $2; exit }')
+[[ $has == "true" ]] || fail "HasInhibit reports held inhibits" "$has"
+pass "HasInhibit agrees with the state file"
+
+# --- UnInhibit --------------------------------------------------------------
+
+# Released from a different connection than the one that inhibited (busctl):
+# sender identity is not verified, matching hypridle — any same-uid process
+# can already run code.
+uninhibit "$cookie_vlc" "$SS_NEW"
+wait_for "uninhibit releases one holder and its app leaves the state" holders_are 2
+wait_for "uninhibit releases the vlc holder" without_app org.videolan.vlc
+pass "UnInhibit releases a held inhibit"
+
+# An unknown cookie is tolerated, not an error: a restarted browser replaying
+# a stale cookie must not wedge or error the session.
+unknown=$((cookie_chromium + 1000000))
+uninhibit "$unknown" "$SS_NEW"
+wait_for "unknown uninhibit changed nothing" holders_are 2
+pass "UnInhibit with an unknown cookie returns normally"
+
+# --- Disconnect reaping ------------------------------------------------------
+
+# Killing the holder drops its bus connection: every cookie it still held must
+# go with it, which is what keeps a crashed browser from pinning the session
+# awake forever.
+kill "$holder_pid" 2>/dev/null || true
+wait_for "a crashed client's inhibits are reaped" not_inhibited
+pass "inhibits are reaped when their client leaves the bus"
+
+# --- Signal emissions --------------------------------------------------------
+
+signal_seen=$(python3 - <<'PY'
+import gi
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+seen = {}
+loop = GLib.MainLoop()
+
+def on_signal(conn, sender, path, iface, signal, params):
+    seen[signal] = params.unpack()[0]
+    if len(seen) == 2:
+        loop.quit()
+
+bus.signal_subscribe("org.freedesktop.ScreenSaver", "org.freedesktop.ScreenSaver",
+                     "ActiveChanged", None, None, Gio.DBusSignalFlags.NONE, on_signal)
+bus.signal_subscribe("org.freedesktop.PowerManagement", "org.freedesktop.PowerManagement.Inhibit",
+                     "HasInhibitChanged", None, None, Gio.DBusSignalFlags.NONE, on_signal)
+
+res = bus.call_sync("org.freedesktop.ScreenSaver", "/ScreenSaver",
+                    "org.freedesktop.ScreenSaver", "Inhibit",
+                    GLib.Variant("(ss)", ("signal.client", "signal probe")),
+                    GLib.VariantType("(u)"), Gio.DBusCallFlags.NONE, -1, None)
+cookie = res.unpack()[0]
+# This connection stays alive until the checks below are queued, so the
+# inhibit is not reaped before the signals fire.
+GLib.timeout_add(1500, loop.quit)
+GLib.idle_add(lambda: bus.call_sync("org.freedesktop.ScreenSaver", "/ScreenSaver",
+                                    "org.freedesktop.ScreenSaver", "UnInhibit",
+                                    GLib.Variant("(u)", (cookie,)), None,
+                                    Gio.DBusCallFlags.NONE, -1, None) and False)
+loop.run()
+print("ActiveChanged" in seen and "HasInhibitChanged" in seen and
+      seen.get("ActiveChanged") is True and seen.get("HasInhibitChanged") is True)
+PY
+)
+[[ $signal_seen == "True" ]] || fail "ActiveChanged and HasInhibitChanged fire on transitions"
+pass "ActiveChanged and HasInhibitChanged fire on transitions"
+
+wait_for "state settles after the signal probe" not_inhibited
+
+# --- Atomic publication under churn ------------------------------------------
+
+storm_ok=1
+for i in {1..30}; do
+  c=$(inhibit "storm.client" "churn $i" "$SS_NEW" || true)
+  jq -e . "$state_file" >/dev/null 2>&1 || { storm_ok=0; break; }
+  [[ -n ${c:-} ]] && uninhibit "$c" "$SS_NEW"
+  jq -e . "$state_file" >/dev/null 2>&1 || { storm_ok=0; break; }
+done
+(( storm_ok )) || fail "state file is always complete JSON during inhibit churn"
+pass "state file stays complete JSON during inhibit churn"
+
+# --- A second daemon never fights over the name -------------------------------
+
+"$DAEMON" >/dev/null 2>&1
+second_status=$?
+(( second_status == 0 )) || fail "a daemon that cannot own the name exits 0 (got $second_status)"
+name_owned org.freedesktop.ScreenSaver || fail "the first daemon keeps the name"
+pass "a second daemon exits quietly and the first keeps the name"
+
+wait_for "state settles after the duplicate start" not_inhibited
+
+# The survivor must still be fully functional. busctl is transient, so its
+# inhibit self-releases with the connection; the cookie reply proves the
+# survivor still serves, and the file settling back proves it still publishes.
+c=$(inhibit "final.client" "after duplicate" "$SS_NEW")
+[[ $c =~ ^[0-9]+$ ]] || fail "the surviving daemon still serves Inhibit" "$c"
+pass "the surviving daemon still serves Inhibit"
+
+wait_for "the surviving daemon still publishes state transitions" not_inhibited
+pass "the surviving daemon still publishes state transitions"
+
+echo "all inner assertions passed"
+INNER
+
+chmod +x "$inner"
+
+DAEMON="$daemon" timeout 120 dbus-run-session -- bash "$inner" "$runtime_dir" ||
+  fail "omarchy-idle-inhibit-daemon passes the live session-bus contract" \
+    "see the inner assertion output above"
+
+pass "omarchy-idle-inhibit-daemon passes the live session-bus contract"

--- a/test/shell.d/idle-inhibit-migration-test.sh
+++ b/test/shell.d/idle-inhibit-migration-test.sh
@@ -18,8 +18,8 @@ grep -Fx 'After=graphical-session.target' "$unit" >/dev/null ||
   fail "the unit starts with the graphical session"
 grep -Fx 'WantedBy=graphical-session.target' "$unit" >/dev/null ||
   fail "the unit is enabled with the graphical session"
-grep -Fx 'Restart=always' "$unit" >/dev/null ||
-  fail "the daemon restarts after a crash"
+grep -Fx 'Restart=on-failure' "$unit" >/dev/null ||
+  fail "the daemon restarts on failure but does not flap a clean stand-down"
 pass "the inhibit unit follows the house service pattern"
 
 grep -q 'omarchy-idle-inhibit\.service' "$ROOT/install/user/first-run/enable-user-units.sh" ||

--- a/test/shell.d/idle-inhibit-migration-test.sh
+++ b/test/shell.d/idle-inhibit-migration-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Packaging and rollout for the D-Bus inhibit daemon: the systemd user unit,
+# the migration that enables it for existing installs (with the no-user-manager
+# fallback the migrate-notify migration established), and the first-run list
+# that starts it on fresh installs.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+unit="$ROOT/default/systemd/user/omarchy-idle-inhibit.service"
+[[ -f $unit ]] || fail "the inhibit daemon ships a systemd user unit"
+
+grep -Fx 'ExecStart=/usr/bin/omarchy-idle-inhibit-daemon' "$unit" >/dev/null ||
+  fail "the unit starts the packaged daemon path"
+grep -Fx 'After=graphical-session.target' "$unit" >/dev/null ||
+  fail "the unit starts with the graphical session"
+grep -Fx 'WantedBy=graphical-session.target' "$unit" >/dev/null ||
+  fail "the unit is enabled with the graphical session"
+grep -Fx 'Restart=always' "$unit" >/dev/null ||
+  fail "the daemon restarts after a crash"
+pass "the inhibit unit follows the house service pattern"
+
+grep -q 'omarchy-idle-inhibit\.service' "$ROOT/install/user/first-run/enable-user-units.sh" ||
+  fail "first-run starts the inhibit daemon on fresh installs"
+pass "first-run starts the inhibit daemon on fresh installs"
+
+migration=$(ls "$ROOT"/migrations/*.sh | sort | tail -n1)
+[[ -x $migration ]] && fail "a migration is 0644, not executable"
+head -n1 "$migration" | grep -q '^echo ' ||
+  fail "a migration starts with an echo of what it does" "$(head -n1 "$migration")"
+pass "the migration follows the house format rules"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+home="$test_tmp/home"
+mkdir -p "$stub_bin" "$home"
+
+# A live user manager: systemctl records what it was asked to do and succeeds.
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+echo "systemctl $*" >>"${SYSTEMCTL_CALLS:?}"
+exit 0
+SH
+chmod +x "$stub_bin/systemctl"
+
+SYSTEMCTL_CALLS="$test_tmp/calls" \
+  HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null 2>&1 ||
+  fail "the migration runs cleanly with a live user manager"
+
+grep -q 'enable omarchy-idle-inhibit.service' "$test_tmp/calls" ||
+  fail "the migration enables the inhibit unit" "$(cat "$test_tmp/calls")"
+pass "the migration enables the inhibit unit"
+
+# Idempotent: a second run is a no-op, not an error.
+SYSTEMCTL_CALLS="$test_tmp/calls" \
+  HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null 2>&1 ||
+  fail "the migration is idempotent"
+pass "the migration is idempotent"
+
+# `omarchy update` over SSH has no live user manager: systemctl fails, and the
+# migration must write exactly the symlink enable would have written rather
+# than silently doing nothing.
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$stub_bin/systemctl"
+
+HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null 2>&1 ||
+  fail "the migration runs without a live user manager"
+
+wants="$home/.config/systemd/user/graphical-session.target.wants/omarchy-idle-inhibit.service"
+[[ -L $wants ]] || fail "the fallback writes the graphical-session wants symlink"
+target=$(readlink "$wants")
+[[ $target == "/usr/lib/systemd/user/omarchy-idle-inhibit.service" ]] ||
+  fail "the fallback symlink points at the packaged unit" "$target"
+pass "the fallback enables the unit without a user manager"

--- a/test/shell.d/idle-inhibit-migration-test.sh
+++ b/test/shell.d/idle-inhibit-migration-test.sh
@@ -26,7 +26,10 @@ grep -q 'omarchy-idle-inhibit\.service' "$ROOT/install/user/first-run/enable-use
   fail "first-run starts the inhibit daemon on fresh installs"
 pass "first-run starts the inhibit daemon on fresh installs"
 
-migration=$(ls "$ROOT"/migrations/*.sh | sort | tail -n1)
+# Anchor on the migration that mentions the daemon, not on filename order:
+# another migration can land with a higher timestamp before this merges.
+migration=$(grep -l 'omarchy-idle-inhibit' "$ROOT"/migrations/*.sh | head -n1)
+[[ -n $migration ]] || fail "a migration enables the inhibit daemon"
 [[ -x $migration ]] && fail "a migration is 0644, not executable"
 head -n1 "$migration" | grep -q '^echo ' ||
   fail "a migration starts with an echo of what it does" "$(head -n1 "$migration")"

--- a/test/shell.d/idle-inhibit-migration-test.sh
+++ b/test/shell.d/idle-inhibit-migration-test.sh
@@ -14,8 +14,12 @@ unit="$ROOT/default/systemd/user/omarchy-idle-inhibit.service"
 
 grep -Fx 'ExecStart=/usr/bin/omarchy-idle-inhibit-daemon' "$unit" >/dev/null ||
   fail "the unit starts the packaged daemon path"
-grep -Fx 'After=graphical-session.target' "$unit" >/dev/null ||
-  fail "the unit starts with the graphical session"
+grep -Fx 'After=dbus.socket' "$unit" >/dev/null ||
+  fail "the unit starts after dbus.socket so it can own names before graphical-session apps probe"
+grep -Fx 'Requires=dbus.socket' "$unit" >/dev/null ||
+  fail "the unit requires the session bus"
+grep -Fx 'After=graphical-session.target' "$unit" >/dev/null &&
+  fail "After=graphical-session.target starts the daemon after autostarted browsers can already probe NameHasOwner"
 grep -Fx 'WantedBy=graphical-session.target' "$unit" >/dev/null ||
   fail "the unit is enabled with the graphical session"
 grep -Fx 'Restart=on-failure' "$unit" >/dev/null ||

--- a/test/shell.d/idle-inhibit-wiring-test.sh
+++ b/test/shell.d/idle-inhibit-wiring-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# The daemon contract ends at the idle service: the QML must read the
+# daemon's state through the tolerant model parser, gate the IdleMonitor on
+# it, and cancel an in-flight cycle when an inhibit arrives. These are
+# wiring assertions in the powerprofiles-set-test style; the parser itself
+# is covered by the node tests in idle-test.sh.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+service="$ROOT/shell/plugins/services/idle/Service.qml"
+[[ -f $service ]] || fail "idle Service.qml exists"
+
+rg -F 'externalInhibitFromState' "$service" >/dev/null ||
+  fail "idle service parses D-Bus inhibit state through IdleModel"
+pass "idle service parses D-Bus inhibit state through IdleModel"
+
+rg -F 'IdleModel.idleEnabledAfter' "$service" >/dev/null ||
+  fail "idle service gates IdleMonitor through the tested model gate"
+pass "idle service gates IdleMonitor through the tested model gate"
+
+rg -F 'idle-inhibit' "$service" >/dev/null ||
+  fail "idle service watches the inhibit daemon's state directory"
+pass "idle service watches the inhibit daemon's state directory"
+
+rg -F 'external-inhibit' "$service" >/dev/null ||
+  fail "an arriving inhibit cancels an in-flight idle cycle"
+pass "an arriving inhibit cancels an in-flight idle cycle"
+
+# The watcher must watch the directory, not the file: the daemon publishes
+# with an atomic rename, which surfaces as a change in the containing
+# directory, and the stay-awake watcher in the same file established the
+# pattern for exactly this reason.
+python3 - "$service" <<'PY' || fail "the inhibit watcher watches a directory, not the file"
+import re
+import sys
+
+qml = open(sys.argv[1]).read()
+
+watchers = re.findall(r"FileView\s*\{[^}]*path:\s*root\.(\w+)", qml, re.S)
+inhibit_watchers = [
+    name for name in watchers if "nhibit" in name
+]
+if not inhibit_watchers:
+    sys.exit(1)
+PY
+pass "the inhibit watcher watches a directory, not the file"
+
+# A daemon that is not running, or a runtime dir that does not exist yet,
+# must read as "no external inhibits" rather than wedging the timers on.
+rg -F 'externalInhibit: false' "$service" >/dev/null ||
+  fail "absent inhibit state degrades to no external inhibit"
+pass "absent inhibit state degrades to no external inhibit"
+
+rg -F 'externalInhibit: root.externalInhibit' "$service" >/dev/null ||
+  fail "idle status reports the external inhibit state"
+pass "idle status reports the external inhibit state"

--- a/test/shell.d/idle-inhibit-wiring-test.sh
+++ b/test/shell.d/idle-inhibit-wiring-test.sh
@@ -36,6 +36,24 @@ rg -F 'omarchy-idle-inhibit-probe' "$service" >/dev/null ||
   fail "idle service consumes state through the liveness-aware probe"
 pass "idle service consumes state through the liveness-aware probe"
 
+# SplitParser.onRead never fires when the probe emits no bytes (dead pid).
+# The Process must apply an empty state on exit so a crash cannot pin idle off.
+python3 - "$service" <<'PY' || fail "probe exit without stdout applies an empty inhibit state"
+import re
+import sys
+
+qml = open(sys.argv[1]).read()
+block = re.search(r"id:\s*externalInhibitProbe\b.*?(?=\n  (?:Process|FileView|Timer|Component|IpcHandler)\b|\Z)", qml, re.S)
+if not block:
+    sys.exit(1)
+text = block.group(0)
+if "onExited" not in text or 'applyExternalInhibitState("")' not in text:
+    sys.exit(1)
+if "sawProbeOutput" not in text:
+    sys.exit(1)
+PY
+pass "probe exit without stdout applies an empty inhibit state"
+
 grep -q '"pid"' "$ROOT/bin/omarchy-idle-inhibit-daemon" ||
   fail "daemon snapshots carry the serving pid"
 pass "daemon snapshots carry the serving pid"

--- a/test/shell.d/idle-inhibit-wiring-test.sh
+++ b/test/shell.d/idle-inhibit-wiring-test.sh
@@ -25,6 +25,21 @@ rg -F 'idle-inhibit' "$service" >/dev/null ||
   fail "idle service watches the inhibit daemon's state directory"
 pass "idle service watches the inhibit daemon's state directory"
 
+# Liveness rides in the state itself: snapshots carry the serving pid, and
+# the probe script is what refuses a dead daemon's last write. Assert both
+# halves so neither can regress silently.
+[[ -x $ROOT/bin/omarchy-idle-inhibit-probe ]] ||
+  fail "the inhibit probe script exists"
+pass "the inhibit probe script exists"
+
+rg -F 'omarchy-idle-inhibit-probe' "$service" >/dev/null ||
+  fail "idle service consumes state through the liveness-aware probe"
+pass "idle service consumes state through the liveness-aware probe"
+
+grep -q '"pid"' "$ROOT/bin/omarchy-idle-inhibit-daemon" ||
+  fail "daemon snapshots carry the serving pid"
+pass "daemon snapshots carry the serving pid"
+
 rg -F 'external-inhibit' "$service" >/dev/null ||
   fail "an arriving inhibit cancels an in-flight idle cycle"
 pass "an arriving inhibit cancels an in-flight idle cycle"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -33,6 +33,77 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+
+// The D-Bus inhibit state file is read back through the same model so the
+// tolerance lives in one place: a daemon that is down, crashed mid-write, or
+// publishing garbage must read as "nothing inhibited" — a stale or torn file
+// may never pin the idle timers off permanently.
+assertDeepEqual(
+  idle.externalInhibitFromState('{"inhibited":false,"count":0,"holders":[]}'),
+  { inhibited: false },
+  'idle reads a clean nothing-inhibited state'
+)
+
+assertDeepEqual(
+  idle.externalInhibitFromState(
+    '{"inhibited":true,"count":2,"holders":[{"app":"org.chromium.chromium","reason":"Video Wake Lock"},{"app":"org.videolan.vlc","reason":"Playing media"}]}'
+  ),
+  { inhibited: true },
+  'idle reads a held inhibit'
+)
+
+assertDeepEqual(
+  idle.externalInhibitFromState(''),
+  { inhibited: false },
+  'idle treats an absent state file as not inhibited'
+)
+
+assertDeepEqual(
+  idle.externalInhibitFromState('{"inhibited":tru'),
+  { inhibited: false },
+  'idle treats a torn state file as not inhibited'
+)
+
+assertDeepEqual(
+  idle.externalInhibitFromState('not json at all'),
+  { inhibited: false },
+  'idle treats garbage as not inhibited'
+)
+
+assertDeepEqual(
+  idle.externalInhibitFromState('{"inhibited":true,"count":1,"holders":[]}'),
+  { inhibited: false },
+  'idle refuses to claim inhibited without holders'
+)
+
+assertDeepEqual(
+  idle.externalInhibitFromState('null'),
+  { inhibited: false },
+  'idle treats a non-object state as not inhibited'
+)
+
+assertDeepEqual(
+  idle.externalInhibitFromState('{"inhibited":"true","count":1,"holders":[{"app":"x"}]}'),
+  { inhibited: false },
+  'idle requires a boolean inhibited flag'
+)
+
+assertEqual(
+  idle.idleEnabledAfter(true, false, false), true,
+  'idle runs with state loaded, no stay-awake, no external inhibit'
+)
+assertEqual(
+  idle.idleEnabledAfter(true, true, false), false,
+  'idle stays off while stay-awake is on'
+)
+assertEqual(
+  idle.idleEnabledAfter(true, false, true), false,
+  'idle stays off while an external inhibit is held'
+)
+assertEqual(
+  idle.idleEnabledAfter(false, false, false), false,
+  'idle stays off until the stay-awake state is loaded'
+)
 JS
 
 test_tmp=$(mktemp -d)


### PR DESCRIPTION
Closes #6475. Closes #7220. Closes #7199.

## Summary

Quattro's idle service honors only the Wayland `zwp_idle_inhibit_manager_v1` protocol, and nothing has owned `org.freedesktop.ScreenSaver` since hypridle was replaced — so an inhibit requested over D-Bus (every browser playing a video; VLC) was dropped on the floor and the screensaver fired over playing videos.

This adds **`omarchy-idle-inhibit-daemon`** (python3 + PyGObject, already in `install/omarchy-base.packages`), which:

- owns `org.freedesktop.ScreenSaver` on **both** `/org/freedesktop/ScreenSaver` (Chromium) and `/ScreenSaver` (VLC/Firefox legacy path), plus `org.freedesktop.PowerManagement.Inhibit` with `HasInhibit`/`HasInhibitChanged` (Chromium's second inhibit, Firefox's third backend);
- reaps inhibits whose client left the bus (`NameOwnerChanged`, spec-mandated lifetime);
- tolerates unknown `UnInhibit` cookies (hypridle precedent — restarted clients must not wedge);
- refuses the KDE-legacy `GetActive`/`ActiveChanged`: they mean "screensaver blanked", which this daemon cannot honestly report;
- caps holder strings and outstanding cookies (`LimitsExceeded`);
- publishes JSON to `$XDG_RUNTIME_DIR/omarchy/idle-inhibit/state` — atomic rename, 0600 from birth, written before each method reply, carrying the **serving pid** so that any consumer can tell live state from a SIGKILLed daemon's last write with no cross-process cleanup.

The idle service reads that state through **`omarchy-idle-inhibit-probe`** (one line of JSON when the serving pid is alive; silence/empty for absence, garbage, or a dead pid — every failure mode lands on "not inhibited") and gates `IdleMonitor` through `IdleModel.idleEnabledAfter`, the same node-tested module pattern as before. An inhibit arriving mid-cycle cancels it like Stay Awake does; an already-fired lock is left alone.

## Why not the obvious alternatives

Plans doc included (`plans/idle-inhibit.md`) with the evidence: **D-Bus activation cannot work here** because Chromium and VLC probe with `NameHasOwner` (never auto-starts) and silently skip inhibition when unowned — the daemon ships as a `graphical-session.target` systemd user unit instead; and a D-Bus→Wayland bridge fails on sway-class compositors that ignore inhibitors without visible surfaces.

## Wiring

Unit under `default/systemd/user/`, enabled for fresh installs via `enable-user-units.sh` and existing installs via migration (with the SSH-fallback symlink precedent). `Restart=on-failure` — the clean-exit stand-down (names owned elsewhere) must not respawn forever. No new dependencies.

## Test

All red-green, mutations proven:

- **Live-bus integration** (`idle-inhibit-daemon-test.sh`, real `dbus-run-session`): both paths answer, holders stack across Chromium/VLC/PM, bus-name recorded per cookie, held-state via one persistent connection, disconnect reaping, unknown-cookie tolerance, duplicate daemon exits 0 while the survivor keeps serving, probe silent for dead-pid state, missing/torn state → empty line, orderly SIGTERM leaves a forced-empty snapshot. 23 assertions; three consecutive clean runs.
- **Model + wiring**: tolerant parser cases in node (`idle-test.sh`); QML gate/wiring assertions in house `rg -F` style (`idle-inhibit-wiring-test.sh`).
- **Migration**: idempotent rerun, live-manager and SSH fallback paths (`idle-inhibit-migration-test.sh`).
- **Mutations**: reaping removed, probe liveness removed, signals removed, restart policy reverted, final-publish removed, publish-on-write skipped, parser overclaiming, gate ignoring inhibits — every one fails its test.

An independent adversarial review pass ran between first implementation and this final form; its four majors/minors (restart flap, phantom inhibit after SIGKILL+takeover, inverted GetActive semantics, publish-failure hangs) are all addressed above, plus nits (cookie wraparound, truncation).

One note for merge ordering: `ExecStart=/usr/bin/omarchy-idle-inhibit-daemon` needs the omarchy-pkgs install lines (bin + unit) merged alongside.
