### PR TITLE
Keep Ori interactive when launched with a prompt

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -92,8 +92,10 @@ omp)
   ;;
 ori)
   # Ori is a harness launcher, and `ori code` is the agent it runs itself.
+  # A prompt alone means one headless turn there, printed after the turn ends,
+  # so --interactive is what seeds the session with it and keeps the window.
   command=(ori code)
-  [[ -n ${prompt:-} ]] && command+=(--prompt "$prompt")
+  [[ -n ${prompt:-} ]] && command+=(--interactive --prompt "$prompt")
   ;;
 pi)
   command=(pi)

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -457,7 +457,7 @@ assert_bypass() {
 assert_launch pi pi "Review this project"
 assert_launch omp omp --auto-approve -- "Review this project"
 assert_launch opencode opencode --auto --prompt "Review this project"
-assert_launch ori ori code --prompt "Review this project"
+assert_launch ori ori code --interactive --prompt "Review this project"
 assert_launch claude claude --permission-mode auto -- "Review this project"
 assert_launch codex codex --approve-for-me -- "Review this project"
 assert_launch crush crush run "Review this project"


### PR DESCRIPTION
`omarchy-agent` launched Ori with `ori code --prompt "$prompt"`, but for Ori a prompt alone means one headless turn whose output is printed only after the turn ends — the window then sits idle instead of dropping into a session.

Passing `--interactive` alongside `--prompt` seeds the session with the prompt and keeps the window interactive, matching how every other supported agent behaves when handed an initial prompt.

- `bin/omarchy-agent`: add `--interactive` to the Ori prompt path (bare `ori code` launch unchanged)
- `test/shell.d/default-agent-test.sh`: update the `assert_launch ori` expectation

Verified with `bash test/shell.d/default-agent-test.sh` — all passing, including "agent launcher adapts initial prompts for every supported agent".