### PR TITLE
Keep Funnel ingress relays out of the Tailscale machine list

### DIFF
--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -41,6 +41,11 @@ function isMullvadHost(name) {
   return value.length > suffix.length && value.indexOf(suffix) === value.length - suffix.length
 }
 
+function isIngressRelay(peer) {
+  var tags = (peer && peer.Tags) || []
+  return tags.indexOf("tag:ingress") !== -1
+}
+
 function isMullvadPeer(peer) {
   var hostName = String((peer && peer.HostName) || "")
   var dnsName = cleanDnsName((peer && peer.DNSName) || "")
@@ -231,12 +236,21 @@ function parseStatus(raw) {
     var selfIps = filterIPv4(self.TailscaleIPs || data.TailscaleIPs || [])
     var peers = []
     var exitNodes = []
+    var serviceNodes = []
     var rawPeers = data.Peer || {}
 
     for (var id in rawPeers) {
       var peer = rawPeers[id] || {}
       var normalized = peerFromStatus(id, peer)
       if (normalized.Mullvad) continue
+      // Funnel adds an ingress relay per region to the netmap, each named
+      // funnel-ingress-node with no DNS name and no OS. They carry ShareeNode,
+      // the flag `tailscale status` uses to leave them out, and so do nodes
+      // owned by a shared-to user — neither belongs among real machines.
+      if (peer.ShareeNode === true) {
+        if (normalized.Online && isIngressRelay(peer)) serviceNodes.push(normalized)
+        continue
+      }
       if (normalized.Online) {
         peers.push(normalized)
         if (normalized.ExitNodeOption) exitNodes.push(normalized)
@@ -263,7 +277,8 @@ function parseStatus(raw) {
       selfUserId: String(self.UserID || ""),
       fileSharing: hasFileSharing(self),
       peers: peers,
-      exitNodes: exitNodes
+      exitNodes: exitNodes,
+      serviceNodes: serviceNodes
     }
   } catch (e) {
     return { ok: false, unavailable: true, message: "Status error", error: "Failed to parse tailscale status" }
@@ -314,6 +329,7 @@ if (typeof module !== "undefined") {
     loginPlan: loginPlan,
     hasFileSharing: hasFileSharing,
     isTaildropTarget: isTaildropTarget,
+    isIngressRelay: isIngressRelay,
     isMullvadPeer: isMullvadPeer,
     peerFromStatus: peerFromStatus,
     parseExitNodeList: parseExitNodeList,

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -43,6 +43,7 @@ Panel {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property bool showConnections: tailscale.accounts.length > 1 || tailscale.accountsAccessDenied
   readonly property bool showPeers: tailscale.active && tailscale.peers.length > 0
+  readonly property bool showServiceNodes: tailscale.active && tailscale.serviceNodes.length > 0
   readonly property var recentMullvadRegions: settings.recentMullvadRegions instanceof Array ? settings.recentMullvadRegions : (settings.recentMullvadCountries instanceof Array ? settings.recentMullvadCountries : [])
   readonly property var recentMullvadExitNodes: recentMullvadNodes()
   readonly property var exitNodes: displayExitNodes()
@@ -706,6 +707,35 @@ Panel {
                   rowIndex: index
                 }
               }
+            }
+          }
+
+          PanelSeparator {
+            visible: root.showServiceNodes
+            foreground: root.foreground
+          }
+
+          Column {
+            visible: root.showServiceNodes
+            width: parent.width
+            spacing: Style.space(10)
+
+            PanelSectionHeader {
+              text: "FUNNEL INGRESS"
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+            }
+
+            // A count, not a row each: ingress relays carry no hostname, no OS
+            // and no address worth copying, so listing them individually only
+            // moves the clutter into its own section.
+            Text {
+              width: parent.width
+              text: tailscale.serviceNodes.length + (tailscale.serviceNodes.length === 1 ? " ingress relay" : " ingress relays")
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.body
+              horizontalAlignment: Text.AlignHCenter
             }
           }
         }

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -28,6 +28,7 @@ Item {
   property bool fileSharing: false
   property string authUrl: ""
   property var peers: []
+  property var serviceNodes: []
   property var exitNodes: []
   property var tailnetExitNodes: []
   property var mullvadExitNodes: []
@@ -210,6 +211,7 @@ Item {
     fileSharing = false
     authUrl = ""
     peers = []
+    serviceNodes = []
     exitNodes = []
     tailnetExitNodes = []
     mullvadExitNodes = []
@@ -248,6 +250,7 @@ Item {
     selfUserId = parsed.selfUserId
     fileSharing = parsed.fileSharing
     peers = parsed.running ? parsed.peers : []
+    serviceNodes = parsed.running ? (parsed.serviceNodes || []) : []
     tailnetExitNodes = parsed.running ? parsed.exitNodes : []
     exitNodes = parsed.running ? tailnetExitNodes.concat(mullvadRegions) : []
 

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -73,6 +73,23 @@ const status = tailscale.parseStatus(JSON.stringify({
       UserID: 1001,
       TaildropTarget: 1
     },
+    funnelIngress: {
+      HostName: 'funnel-ingress-node',
+      DNSName: '',
+      TailscaleIPs: ['fd7a:115c:a1e0::a801:26ab'],
+      Tags: ['tag:ingress'],
+      ShareeNode: true,
+      Online: true,
+      OS: ''
+    },
+    sharee: {
+      HostName: 'sharee-laptop',
+      DNSName: 'sharee-laptop.tail32f559.ts.net.',
+      TailscaleIPs: ['100.1.1.9'],
+      ShareeNode: true,
+      Online: true,
+      OS: 'macos'
+    },
     mullvadExit: {
       HostName: 'al-tia-wg-003',
       DNSName: 'al-tia-wg-003.mullvad.ts.net.',
@@ -91,6 +108,9 @@ assertDeepEqual(status.peers.map(peer => peer.HostName), ['alpha', 'zed'], 'tail
 assertDeepEqual(status.peers[0].TailscaleIPv6, ['fd7a:115c:a1e0::1901:334b'], 'tailscale preserves peer IPv6 addresses for copy menu')
 assert(status.peers[1].ExitNodeOption && status.peers[1].ExitNode, 'tailscale preserves exit node flags')
 assertDeepEqual(status.exitNodes.map(peer => peer.HostName), ['zed'], 'tailscale lists only online tailnet exit nodes')
+assertDeepEqual(status.serviceNodes.map(peer => peer.HostName), ['funnel-ingress-node'], 'tailscale keeps Funnel ingress relays out of the machine list')
+assert(tailscale.isIngressRelay({ Tags: ['tag:ingress'] }), 'tailscale detects Funnel ingress relays by tag')
+assert(!tailscale.isIngressRelay({ Tags: ['tag:server'] }), 'tailscale leaves other tagged nodes alone')
 assert(tailscale.isMullvadPeer({ HostName: 'al-tia-wg-003', DNSName: 'al-tia-wg-003.mullvad.ts.net.' }), 'tailscale detects Mullvad status peers')
 
 assert(status.fileSharing, 'tailscale reads Taildrop capability from the status capability map')


### PR DESCRIPTION
### What happens now

With Funnel enabled, MACHINES fills up with identical blank rows:

```
MACHINES
  funnel-ingress-node
  funnel-ingress-node
  ... (24 of them on my tailnet)
  a-real-machine
```

Turning on Funnel puts one ingress relay per region into the netmap. They arrive as peers named `funnel-ingress-node`, with no DNS name, no OS, and only an IPv6 address:

```json
{
  "HostName": "funnel-ingress-node",
  "DNSName": "",
  "Tags": ["tag:ingress"],
  "ShareeNode": true,
  "Online": true
}
```

`tailscale status` never shows them — it skips peers with `ShareeNode` set. The panel had no such filter, so every relay counted as a machine.

### The change

`parseStatus` now keeps `ShareeNode` peers out of `peers`, matching the CLI. That flag also covers nodes owned by a shared-to user, which are equally not machines on this tailnet.

The `tag:ingress` ones land in a new `serviceNodes` list, and the panel gives them their own section under MACHINES:

```
MACHINES
  a-real-machine

FUNNEL INGRESS
  24 ingress relays
```

A count rather than a row each: these peers have no hostname, no OS and no address worth copying, so listing them individually would only move the clutter into its own section. The section hides itself when Funnel is off.

### Testing

`test/shell.d/tailscale-test.sh` gains a Funnel relay and a sharee peer in the `parseStatus` fixture, asserting both stay out of the machine list and that only the relay reaches `serviceNodes`. Suite passes.

Verified on a live tailnet with Funnel on: 24 relays collapsed into one line, real machines unaffected.