### PR TITLE
Report Omarchy dev-link session state accurately

### DIFF
--- a/bin/omarchy-dev-status
+++ b/bin/omarchy-dev-status
@@ -44,11 +44,20 @@ sudo_bin_dir() {
   dirname "$resolved"
 }
 
+session_matches=0
+if [[ ${OMARCHY_PATH:-$default_target} == "$configured" ]]; then
+  session_matches=1
+fi
+
 if (( linked )); then
   echo "dev-link: configured"
   echo "  /etc/omarchy.conf -> OMARCHY_PATH=$configured"
   echo "  sudo resolves omarchy-* from: $(sudo_bin_dir)"
-  echo "  status: reboot required before all session layers use this checkout"
+  if (( session_matches )); then
+    echo "  status: active in this session"
+  else
+    echo "  status: reboot required before all session layers use this checkout"
+  fi
 else
   echo "dev-link: inactive"
   if (( conf_present )); then
@@ -58,7 +67,11 @@ fi
 
 echo "  current shell:       OMARCHY_PATH=${OMARCHY_PATH:-<unset>}"
 
-if [[ ${OMARCHY_PATH:-$default_target} != "$configured" ]]; then
+if (( ! session_matches )); then
   echo
-  echo "Note: the running session does not match /etc/omarchy.conf. Reboot to settle it."
+  if [[ -z ${OMARCHY_PATH:-} ]]; then
+    echo "Note: this shell has no session OMARCHY_PATH. That is normal under sudo or outside the desktop session; check from a session terminal."
+  else
+    echo "Note: the running session does not match /etc/omarchy.conf. Reboot to settle it."
+  fi
 fi

--- a/bin/omarchy-dev-status
+++ b/bin/omarchy-dev-status
@@ -44,20 +44,29 @@ sudo_bin_dir() {
   dirname "$resolved"
 }
 
-session_matches=0
-if [[ ${OMARCHY_PATH:-$default_target} == "$configured" ]]; then
-  session_matches=1
+session_environment=$(systemctl --user show-environment 2>/dev/null || true)
+session_omarchy_path=$(sed -n 's/^OMARCHY_PATH=//p' <<<"$session_environment" | tail -n 1)
+
+session_state="unknown"
+if [[ -n $session_omarchy_path ]]; then
+  if [[ $session_omarchy_path == "$configured" ]]; then
+    session_state="matching"
+  else
+    session_state="mismatched"
+  fi
+elif (( ! linked )); then
+  session_state="matching"
 fi
 
 if (( linked )); then
   echo "dev-link: configured"
   echo "  /etc/omarchy.conf -> OMARCHY_PATH=$configured"
   echo "  sudo resolves omarchy-* from: $(sudo_bin_dir)"
-  if (( session_matches )); then
-    echo "  status: active in this session"
-  else
-    echo "  status: reboot required before all session layers use this checkout"
-  fi
+  case "$session_state" in
+    matching) echo "  status: active in this session" ;;
+    mismatched) echo "  status: reboot required before all session layers use this checkout" ;;
+    unknown) echo "  status: unknown from this shell" ;;
+  esac
 else
   echo "dev-link: inactive"
   if (( conf_present )); then
@@ -67,11 +76,13 @@ fi
 
 echo "  current shell:       OMARCHY_PATH=${OMARCHY_PATH:-<unset>}"
 
-if (( ! session_matches )); then
-  echo
-  if [[ -z ${OMARCHY_PATH:-} ]]; then
-    echo "Note: this shell has no session OMARCHY_PATH. That is normal under sudo or outside the desktop session; check from a session terminal."
-  else
+case "$session_state" in
+  unknown)
+    echo
+    echo "Note: the desktop session OMARCHY_PATH is unavailable. That is normal under sudo or outside the desktop session; check from a session terminal."
+    ;;
+  mismatched)
+    echo
     echo "Note: the running session does not match /etc/omarchy.conf. Reboot to settle it."
-  fi
-fi
+    ;;
+esac

--- a/test/shell.d/dev-status-test.sh
+++ b/test/shell.d/dev-status-test.sh
@@ -25,39 +25,79 @@ exit 1
 SH
 chmod +x "$stub_bin/sudo"
 
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+
+[[ $1 == "--user" && $2 == "show-environment" ]] || exit 2
+
+case "$DEV_STATUS_MANAGER_PATH" in
+  '<missing>') printf 'DISPLAY=:0\n' ;;
+  '<unavailable>') exit 1 ;;
+  *) printf 'OMARCHY_PATH=%s\n' "$DEV_STATUS_MANAGER_PATH" ;;
+esac
+SH
+chmod +x "$stub_bin/systemctl"
+
 printf 'export OMARCHY_PATH="%s"\n' "$configured" >"$conf_file"
 
 run_status() {
-  local shell_path="$1"
+  local manager_path="$1" shell_path="$2"
 
   if [[ $shell_path == "<unset>" ]]; then
-    env -u OMARCHY_PATH PATH="$stub_bin:$PATH" "$status_script"
+    DEV_STATUS_MANAGER_PATH="$manager_path" env -u OMARCHY_PATH \
+      PATH="$stub_bin:$PATH" "$status_script"
   else
-    OMARCHY_PATH="$shell_path" PATH="$stub_bin:$PATH" "$status_script"
+    DEV_STATUS_MANAGER_PATH="$manager_path" OMARCHY_PATH="$shell_path" \
+      PATH="$stub_bin:$PATH" "$status_script"
   fi
 }
 
-matching_output=$(run_status "$configured")
+matching_output=$(run_status "$configured" "$configured")
 grep -F 'status: active in this session' <<<"$matching_output" >/dev/null ||
-  fail "dev status reports a configured checkout active in the session" "$matching_output"
+  fail "dev status trusts a matching user-manager session" "$matching_output"
 ! grep -F 'reboot required' <<<"$matching_output" >/dev/null ||
-  fail "dev status does not request a reboot when the session matches" "$matching_output"
+  fail "dev status does not request a reboot when the user manager matches" "$matching_output"
 pass "dev status reports a matching session as active"
 
-mismatch_output=$(run_status "$mismatched")
+mismatch_output=$(run_status "$mismatched" "$configured")
 grep -F 'status: reboot required before all session layers use this checkout' <<<"$mismatch_output" >/dev/null ||
-  fail "dev status requests a reboot for a real session mismatch" "$mismatch_output"
+  fail "dev status trusts a mismatched user-manager session" "$mismatch_output"
 grep -F 'the running session does not match' <<<"$mismatch_output" >/dev/null ||
   fail "dev status explains a real session mismatch" "$mismatch_output"
 ! grep -F 'status: active in this session' <<<"$mismatch_output" >/dev/null ||
   fail "dev status does not call a mismatched session active" "$mismatch_output"
 pass "dev status reports a real session mismatch"
 
-unset_output=$(run_status '<unset>')
+unset_output=$(run_status '<missing>' '<unset>')
 grep -F 'current shell:       OMARCHY_PATH=<unset>' <<<"$unset_output" >/dev/null ||
   fail "dev status shows an unset shell path" "$unset_output"
+! grep -F 'reboot required' <<<"$unset_output" >/dev/null ||
+  fail "dev status does not request a reboot from an outside-session shell" "$unset_output"
+! grep -F 'status: active in this session' <<<"$unset_output" >/dev/null ||
+  fail "dev status does not call an outside-session shell active" "$unset_output"
+grep -F 'status: unknown from this shell' <<<"$unset_output" >/dev/null ||
+  fail "dev status marks the session state unknown outside the session" "$unset_output"
 grep -F 'normal under sudo or outside the desktop session' <<<"$unset_output" >/dev/null ||
   fail "dev status identifies a sudo or outside-session shell" "$unset_output"
 ! grep -F 'the running session does not match' <<<"$unset_output" >/dev/null ||
   fail "dev status does not mistake an outside shell for the desktop session" "$unset_output"
 pass "dev status identifies an outside-session shell"
+
+unavailable_output=$(run_status '<unavailable>' "$configured")
+grep -F 'status: unknown from this shell' <<<"$unavailable_output" >/dev/null ||
+  fail "dev status keeps an unavailable user-manager environment unknown" "$unavailable_output"
+! grep -F 'reboot required' <<<"$unavailable_output" >/dev/null ||
+  fail "dev status does not infer a reboot from the current shell" "$unavailable_output"
+! grep -F 'status: active in this session' <<<"$unavailable_output" >/dev/null ||
+  fail "dev status does not infer an active session from the current shell" "$unavailable_output"
+pass "dev status keeps an unavailable user-manager environment unknown"
+
+printf 'export OMARCHY_PATH="/usr/share/omarchy"\n' >"$conf_file"
+inactive_output=$(run_status '<missing>' '<unset>')
+grep -F 'dev-link: inactive' <<<"$inactive_output" >/dev/null ||
+  fail "dev status preserves inactive default mode" "$inactive_output"
+! grep -F 'status:' <<<"$inactive_output" >/dev/null ||
+  fail "dev status does not invent a session state in inactive mode" "$inactive_output"
+! grep -F 'Note:' <<<"$inactive_output" >/dev/null ||
+  fail "dev status keeps inactive default mode quiet" "$inactive_output"
+pass "dev status preserves inactive default mode"

--- a/test/shell.d/dev-status-test.sh
+++ b/test/shell.d/dev-status-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+conf_file="$test_tmp/omarchy.conf"
+status_script="$test_tmp/omarchy-dev-status"
+configured="$test_tmp/checkout"
+mismatched="$test_tmp/other-checkout"
+mkdir -p "$stub_bin" "$configured" "$mismatched"
+
+# Test a copy so the fixture controls /etc/omarchy.conf without changing the
+# public command or touching the host.
+sed "s#/etc/omarchy.conf#$conf_file#g" "$ROOT/bin/omarchy-dev-status" >"$status_script"
+chmod +x "$status_script"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$stub_bin/sudo"
+
+printf 'export OMARCHY_PATH="%s"\n' "$configured" >"$conf_file"
+
+run_status() {
+  local shell_path="$1"
+
+  if [[ $shell_path == "<unset>" ]]; then
+    env -u OMARCHY_PATH PATH="$stub_bin:$PATH" "$status_script"
+  else
+    OMARCHY_PATH="$shell_path" PATH="$stub_bin:$PATH" "$status_script"
+  fi
+}
+
+matching_output=$(run_status "$configured")
+grep -F 'status: active in this session' <<<"$matching_output" >/dev/null ||
+  fail "dev status reports a configured checkout active in the session" "$matching_output"
+! grep -F 'reboot required' <<<"$matching_output" >/dev/null ||
+  fail "dev status does not request a reboot when the session matches" "$matching_output"
+pass "dev status reports a matching session as active"
+
+mismatch_output=$(run_status "$mismatched")
+grep -F 'status: reboot required before all session layers use this checkout' <<<"$mismatch_output" >/dev/null ||
+  fail "dev status requests a reboot for a real session mismatch" "$mismatch_output"
+grep -F 'the running session does not match' <<<"$mismatch_output" >/dev/null ||
+  fail "dev status explains a real session mismatch" "$mismatch_output"
+! grep -F 'status: active in this session' <<<"$mismatch_output" >/dev/null ||
+  fail "dev status does not call a mismatched session active" "$mismatch_output"
+pass "dev status reports a real session mismatch"
+
+unset_output=$(run_status '<unset>')
+grep -F 'current shell:       OMARCHY_PATH=<unset>' <<<"$unset_output" >/dev/null ||
+  fail "dev status shows an unset shell path" "$unset_output"
+grep -F 'normal under sudo or outside the desktop session' <<<"$unset_output" >/dev/null ||
+  fail "dev status identifies a sudo or outside-session shell" "$unset_output"
+! grep -F 'the running session does not match' <<<"$unset_output" >/dev/null ||
+  fail "dev status does not mistake an outside shell for the desktop session" "$unset_output"
+pass "dev status identifies an outside-session shell"


### PR DESCRIPTION
## Summary

- derive dev-link activation from the user-manager environment instead of the
  current shell
- report configured links as active, mismatched, or unknown
- add focused coverage for each state without introducing a production test hook

`omarchy dev status` currently prints "reboot required" whenever a dev link is
configured, even after the desktop session is using that checkout.

The current shell alone cannot fix that: a terminal opened after
`omarchy dev link --no-reboot` sources `/etc/omarchy.conf` immediately, while
the user manager, compositor, and shell can still retain the previous path.
This change reads `OMARCHY_PATH` from `systemctl --user show-environment`, which
is the session state the command is trying to report.

If the user-manager value cannot be read, the command reports the state as
unknown. It does not guess that the session is active or that a reboot is
required. The current shell path remains visible as diagnostic information.

## TDD evidence

The new test first reproduced both incorrect results:

- a fully matching session still reported reboot required
- a newly opened shell matching the configured checkout falsely reported the
  session active while the user manager still held the old path

The final test covers:

- matching user-manager path → active
- explicit manager mismatch, even with a matching shell → reboot required
- missing or inaccessible manager state → unknown
- unset shell state
- inactive/default configuration

## Verification

- focused dev-status and related dev-link tests
- `./test/cli`
- command metadata for 436 commands
- parser-aware syntax for 438 command files
- changed-file `bash -n`
- `git diff --check`

`./test/all` completed and the candidate dev-status test passed in the aggregate
run. The overall runner also reported six base-identical exceptions unrelated
to this two-file diff: three require the absent `omarchy-pkgs` checkout, and
three are unchanged timing/network-sensitive tests.
