### PR TITLE
Add a Wi-Fi adapter selector to the network panel

### DIFF
--- a/bin/omarchy-network-band
+++ b/bin/omarchy-network-band
@@ -80,7 +80,12 @@ selected_band() {
 # the rest of its line, so an SSID containing ':' needs no special handling.
 read_link() {
   local link
-  link=$(iw dev "$1" link 2>/dev/null)
+  # iw can print a perfectly good link report and still exit non-zero: on a
+  # secondary adapter it fails the signal-strength ioctl with "Operation not
+  # permitted" after emitting SSID and freq. Under `set -e` that would abort
+  # the script even though the fields we want are present, so the exit status
+  # is deliberately ignored and the parsed values are what get validated.
+  link=$(iw dev "$1" link 2>/dev/null || true)
   ssid=$(awk '/SSID:/ { sub(/.*SSID: /, ""); print; exit }' <<<"$link")
   freq=$(awk '/freq:/ { print $2; exit }' <<<"$link")
 }

--- a/bin/omarchy-network-band
+++ b/bin/omarchy-network-band
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Show or pin the Wi-Fi band for the active connection
 # omarchy:group=network
-# omarchy:args=[auto|2.4|5|6]
+# omarchy:args=[--iface <name>] [auto|2.4|5|6]
 # omarchy:examples=omarchy network band | omarchy network band 5 | omarchy network band auto
 
 set -euo pipefail
@@ -54,7 +54,16 @@ nm_get() {
   LC_ALL=C nmcli -e no -g "$@" 2>/dev/null
 }
 
+# A machine can have several Wi-Fi NICs, and the panel's adapter selector lets
+# the user act on one that is not the first connected device. An explicit
+# --iface pins the target; without it, keep the historical behaviour of taking
+# the first connected Wi-Fi device.
 wifi_device() {
+  if [[ -n ${want_iface:-} ]]; then
+    printf '%s\n' "$want_iface"
+    return
+  fi
+
   nm_get DEVICE,TYPE,STATE device status |
     awk -F: '$2 == "wifi" && $3 == "connected" { print $1; exit }'
 }
@@ -168,8 +177,26 @@ set_band() {
 }
 
 usage() {
-  echo "Usage: omarchy-network-band [auto|2.4|5|6]" >&2
+  echo "Usage: omarchy-network-band [--iface <name>] [auto|2.4|5|6]" >&2
 }
+
+want_iface=""
+
+while (($#)); do
+  case "$1" in
+    --iface)
+      if [[ -z ${2:-} ]]; then
+        usage
+        exit 1
+      fi
+      want_iface=$2
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if (($# == 0)); then
   print_status

--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -2,27 +2,56 @@
 
 # omarchy:summary=Print active network status for the shell
 # omarchy:group=network
-# omarchy:args=[--verbose]
+# omarchy:args=[--verbose] [--iface <name>]
 
 verbose=false
 internet_probe=1.1.1.1
+want_iface=""
 
-case "${1:-}" in
-  "")
-    ;;
-  --verbose)
-    verbose=true
-    ;;
-  *)
-    echo "Usage: omarchy-network-status [--verbose]" >&2
-    exit 2
-    ;;
-esac
+while (($#)); do
+  case "$1" in
+    --verbose)
+      verbose=true
+      shift
+      ;;
+    --iface)
+      if [[ -z ${2:-} ]]; then
+        echo "Usage: omarchy-network-status [--verbose] [--iface <name>]" >&2
+        exit 2
+      fi
+      want_iface=$2
+      shift 2
+      ;;
+    *)
+      echo "Usage: omarchy-network-status [--verbose] [--iface <name>]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# The panel can pin a specific interface so a multi-NIC machine reports the
+# adapter the user is looking at rather than whichever one owns the default
+# route. Unpinned callers keep the route-derived behaviour exactly as before.
+route_device() {
+  ip route get "$internet_probe" 2>/dev/null |
+    awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }'
+}
+
+selected_device() {
+  if [[ -n $want_iface ]]; then
+    # A pinned interface that has gone away is reported as disconnected rather
+    # than silently falling back to a different adapter.
+    [[ -d /sys/class/net/$want_iface ]] && printf '%s\n' "$want_iface"
+    return
+  fi
+
+  route_device
+}
 
 print_status() {
   local device nm state ssid signal freq
 
-  device=$(ip route get "$internet_probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
+  device=$(selected_device)
 
   if [[ -z $device ]]; then
     printf 'disconnected\t\t\t\n'
@@ -85,14 +114,25 @@ print_ping_samples() {
 print_verbose() {
   local route_json iface gw src prefix link
 
-  route_json=$(ip -j route get "$internet_probe" 2>/dev/null)
-  [[ -z $route_json ]] && return
-
-  iface=$(jq -r '.[0].dev // ""' <<<"$route_json" 2>/dev/null)
-  gw=$(jq -r '.[0].gateway // ""' <<<"$route_json" 2>/dev/null)
-  src=$(jq -r '.[0].prefsrc // ""' <<<"$route_json" 2>/dev/null)
-
+  iface=$(selected_device)
   [[ -z $iface ]] && return
+
+  # For the routed interface, `ip route get` is the cheapest source of both the
+  # gateway and the preferred source address. A pinned interface that is not
+  # the default route needs its own lookup instead, since the route to the
+  # probe address says nothing about it.
+  if [[ -n $want_iface && $want_iface != "$(route_device)" ]]; then
+    src=$(ip -j addr show "$iface" 2>/dev/null |
+      jq -r '.[0].addr_info[]? | select(.family == "inet") | .local // ""' 2>/dev/null | head -n 1)
+    gw=$(ip -j route show default dev "$iface" 2>/dev/null |
+      jq -r '.[0].gateway // ""' 2>/dev/null)
+  else
+    route_json=$(ip -j route get "$internet_probe" 2>/dev/null)
+    [[ -z $route_json ]] && return
+
+    gw=$(jq -r '.[0].gateway // ""' <<<"$route_json" 2>/dev/null)
+    src=$(jq -r '.[0].prefsrc // ""' <<<"$route_json" 2>/dev/null)
+  fi
 
   prefix=$(ip -j addr show "$iface" 2>/dev/null | jq -r '.[0].addr_info[]? | select(.family == "inet") | .prefixlen // ""' 2>/dev/null | head -n 1)
 

--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -79,12 +79,20 @@ print_status() {
 
 ping_latency_ms() {
   local host=$1
+  local iface=${2:-}
+  local args=(-n -c 1 -W 1)
 
-  LC_ALL=C ping -n -c 1 -W 1 "$host" 2>/dev/null | awk -F'time[=<]' '/time[=<]/ { split($2, parts, " "); print parts[1]; exit }'
+  # A selected adapter may not own the default route. Bind the probe to that
+  # interface so the panel's latency/loss values describe the adapter it is
+  # showing rather than whichever connection wins route selection.
+  [[ -n $iface ]] && args+=( -I "$iface" )
+  LC_ALL=C ping "${args[@]}" "$host" 2>/dev/null |
+    awk -F'time[=<]' '/time[=<]/ { split($2, parts, " "); print parts[1]; exit }'
 }
 
 print_ping_samples() {
   local gateway=$1
+  local iface=$2
   local tmpdir router_file internet_file
   local router_pid="" internet_pid=""
 
@@ -94,11 +102,11 @@ print_ping_samples() {
   internet_file="$tmpdir/internet"
 
   if [[ -n $gateway ]]; then
-    ping_latency_ms "$gateway" >"$router_file" &
+    ping_latency_ms "$gateway" "$iface" >"$router_file" &
     router_pid=$!
   fi
 
-  ping_latency_ms "$internet_probe" >"$internet_file" &
+  ping_latency_ms "$internet_probe" "$iface" >"$internet_file" &
   internet_pid=$!
 
   if [[ -n $router_pid ]]; then
@@ -167,7 +175,7 @@ print_verbose() {
     [[ -r /sys/class/net/$iface/duplex ]] && printf 'duplex\t%s\n' "$(cat /sys/class/net/$iface/duplex)"
   fi
 
-  print_ping_samples "$gw"
+  print_ping_samples "$gw" "$iface"
 }
 
 if [[ $verbose == "true" ]]; then

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -95,7 +95,6 @@ Panel {
   property string selectedWifiIface: ""
   property var disabledAdapters: []
   property string pendingAdapterIface: ""
-  property bool pendingAdapterEnable: false
   property int adapterIndex: 0
   property var wifiNetworks: []
   property bool scanning: false
@@ -118,7 +117,7 @@ Panel {
   // comparisons on the matching `*Kind`/`*Reason` being non-empty so a
   // hidden-SSID row (ssid == "") doesn't collide with the "" defaults.
   property string actionSsid: ""
-  property string actionKind: ""  // "connect" | "disconnect" | "forget"
+  property string actionKind: ""  // "connect" | "disconnect" | "forget" | "adapter"
   property string failureSsid: ""
   property string failureReason: ""
   property string passwordSsid: ""
@@ -213,7 +212,14 @@ Panel {
   }
 
   onAllWifiDevicesChanged: {
-    // When the set of devices changes (hot-plug, etc.), re-sync.
+    // Hot-plug or removal: the selector can shrink or disappear entirely, so
+    // an index left pointing past the end would highlight nothing and make
+    // Enter a no-op. Clamp it, and evacuate focus when the section is gone.
+    var count = allWifiDevices.length
+    if (adapterIndex > count - 1) adapterIndex = Math.max(0, count - 1)
+    if (!showAdapterSelector && focusSection === "adapter") {
+      focusSection = wifiNetworks.length > 0 ? "wifi" : "dns"
+    }
     root.refresh()
   }
 
@@ -567,16 +573,38 @@ Panel {
     bar.shell.summon("omarchy.wifiqr", JSON.stringify(payload))
   }
 
+  // The interface the panel is currently acting on. Helper scripts default to
+  // the routed / first-connected device, which is the wrong adapter whenever
+  // the user has selected another one, so every invocation pins it explicitly.
+  readonly property string selectedIface: selectedWifiDevice ? (selectedWifiDevice.name || "") : ""
+
+  function statusCommand(verbose) {
+    var command = ["omarchy-network-status"]
+    if (verbose) command.push("--verbose")
+    if (selectedIface !== "") command = command.concat(["--iface", selectedIface])
+    return command
+  }
+
+  function bandCommand(band) {
+    var command = ["omarchy-network-band"]
+    if (selectedIface !== "") command = command.concat(["--iface", selectedIface])
+    if (band) command.push(band)
+    return command
+  }
+
   function refresh(scanWifi) {
     checkConnectivity()
     if (scanWifi === undefined) scanWifi = false
-    if (!detailsProc.running) detailsProc.running = true
+    if (!detailsProc.running) {
+      detailsProc.command = root.statusCommand(true)
+      detailsProc.running = true
+    }
     if (!dnsProc.running) {
       dnsProc.command = ["bash", "-c", root.dnsCommand("")]
       dnsProc.running = true
     }
     if (!bandProc.running) {
-      bandProc.command = ["omarchy-network-band"]
+      bandProc.command = root.bandCommand("")
       bandProc.running = true
     }
     // A closed panel has no nearby-network list to fill, and bare refresh()
@@ -797,21 +825,28 @@ Panel {
     if (!band || actionProc.running) return
 
     root.pendingBand = band
-    actionProc.command = ["omarchy-network-band", band]
+    actionProc.command = root.bandCommand(band)
     actionProc.running = true
   }
 
   // Toggle a single Wi-Fi adapter on/off. The device stays managed by
   // NetworkManager so it remains in the device model and the selector keeps
-  // its pill; only the connection is brought up or down. `disabledAdapters`
-  // tracks the user's intent, and an adapter absent from it is enabled.
+  // its pill; only the connection is brought up or down.
+  //
+  // This claims the panel's shared `actionKind` rather than only checking
+  // actionProc: native WifiNetwork.connect()/disconnect() calls do not go
+  // through actionProc at all, so a private guard would let a network row
+  // action and an adapter toggle race and leave the result timing-dependent.
   //
   // No shell: the interface name reaches nmcli as its own argv entry, so a
   // device name carrying shell metacharacters cannot be executed.
   function toggleAdapter(iface, enable) {
-    if (!iface || actionProc.running) return
+    if (!iface || actionKind !== "" || actionProc.running) return
+
+    actionKind = "adapter"
+    actionSsid = ""
     root.pendingAdapterIface = iface
-    root.pendingAdapterEnable = enable
+
     var disabled = root.disabledAdapters.slice()
     if (enable) {
       var idx = disabled.indexOf(iface)
@@ -823,8 +858,12 @@ Panel {
       disabled.push(iface)
       root.disabledAdapters = disabled
     }
+
     actionProc.command = ["nmcli", "device", enable ? "connect" : "disconnect", iface]
     actionProc.running = true
+    // Same safety net runNetworkAction uses: if the process never reports,
+    // don't leave the whole panel wedged behind the shared guard.
+    actionTimeout.restart()
   }
 
   // The speed test is its own panel plugin (omarchy.speedtest) so a
@@ -988,10 +1027,11 @@ Panel {
 
   Component.onCompleted: refresh()
 
-  // Pulls everything we want about the active route's interface in one shot.
+  // Pulls everything we want about the selected adapter in one shot. The
+  // command is rebuilt at each launch so it follows the adapter selection.
   Process {
     id: detailsProc
-    command: ["omarchy-network-status", "--verbose"]
+    command: root.statusCommand(true)
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.updateDetails(text)
@@ -1042,7 +1082,7 @@ Panel {
     running: root.opened
     onTriggered: {
       if (bandProc.running) return
-      bandProc.command = ["omarchy-network-band"]
+      bandProc.command = root.bandCommand("")
       bandProc.running = true
     }
   }
@@ -1069,16 +1109,15 @@ Panel {
       }
       if (root.pendingAdapterIface !== "") {
         var iface = root.pendingAdapterIface
-        var wanted = root.pendingAdapterEnable
         root.pendingAdapterIface = ""
-        // The pill flipped optimistically when the toggle was clicked. nmcli
-        // refusing the change leaves the adapter as it was, so put the pill
-        // back rather than showing a state that never took effect.
-        if (exitCode !== 0) {
-          var disabled = root.disabledAdapters.slice()
-          var idx = disabled.indexOf(iface)
-          if (wanted && idx === -1) disabled.push(iface)
-          else if (!wanted && idx >= 0) disabled.splice(idx, 1)
+        if (root.actionKind === "adapter") root.actionKind = ""
+        // The pill's state comes from NetworkManager once nothing is in flight,
+        // so the optimistic entry is dropped either way and a refused command
+        // simply leaves the switch showing the device's real state.
+        var disabled = root.disabledAdapters.slice()
+        var idx = disabled.indexOf(iface)
+        if (idx >= 0) {
+          disabled.splice(idx, 1)
           root.disabledAdapters = disabled
         }
         root.refresh()
@@ -1093,7 +1132,10 @@ Panel {
     interval: 1500
     repeat: true
     running: root.opened
-    onTriggered: if (!detailsProc.running) detailsProc.running = true
+    onTriggered: if (!detailsProc.running) {
+      detailsProc.command = root.statusCommand(true)
+      detailsProc.running = true
+    }
   }
 
   Timer {
@@ -1139,6 +1181,15 @@ Panel {
     repeat: false
     onTriggered: {
       if (!root.actionKind) return
+      // An adapter toggle is not tied to an SSID, so it reports through the
+      // pill rather than a network row's failure line. Release the shared
+      // guard and let the next refresh show whatever actually happened.
+      if (root.actionKind === "adapter") {
+        root.actionKind = ""
+        root.pendingAdapterIface = ""
+        root.refresh()
+        return
+      }
       var reason
       if (root.actionKind === "connect") reason = "Timed out connecting"
       else if (root.actionKind === "disconnect") reason = "Timed out disconnecting"
@@ -1757,29 +1808,27 @@ Panel {
           fontFamily: root.bar.fontFamily
         }
 
-        Row {
+        // One pill per adapter. A plain Row dividing the panel width by the
+        // device count makes each cell arbitrarily narrow, and with three or
+        // more adapters the interface name collides with the right-anchored
+        // switch (Button centres its label and reserves nothing for child
+        // controls). Flow wraps to a second line instead, and each pill asks
+        // for its natural width -- label plus reserved switch space -- with a
+        // floor so a long name truncates rather than crushing the control.
+        Flow {
           id: adapterRow
           width: parent.width
           spacing: Style.space(6)
 
-          readonly property int count: Math.max(1, root.allWifiDevices.length)
-          readonly property real cellWidth: (width - spacing * (count - 1)) / count
-
           Repeater {
             model: root.allWifiDevices
 
-            delegate: Item {
+            delegate: AdapterPill {
               required property var modelData
               required property int index
-              width: adapterRow.cellWidth
-              height: adapterPill.implicitHeight
 
-              AdapterPill {
-                id: adapterPill
-                device: modelData
-                slot: index
-                width: parent.width
-              }
+              device: modelData
+              slot: index
             }
           }
         }
@@ -1932,22 +1981,41 @@ Panel {
     // panel falls back to prefer-connected, and the pill showing that
     // adapter is the one that should read as selected.
     readonly property bool isSelected: root.selectedWifiDevice === device
-    readonly property bool isEnabled: iface !== "" && !root.disabledAdapters.includes(iface)
+    // Derived from NetworkManager, not from a local wish-list. A shell reload
+    // or an external `nmcli device disconnect` must not leave the switch
+    // showing "on" for a device that is actually down -- the first click would
+    // then issue a second disconnect instead of reconnecting it.
+    // `disabledAdapters` only holds the in-flight optimistic state, so the knob
+    // still moves the instant it is clicked.
+    readonly property bool isEnabled: {
+      if (iface === "") return false
+      if (root.pendingAdapterIface === iface) return !root.disabledAdapters.includes(iface)
+      return isConnected
+    }
 
     text: iface
     fontSize: Style.font.bodySmall
     foreground: root.bar.foreground
     fontFamily: root.bar.fontFamily
+    // Button centres its label and reserves no room for child items, so the
+    // trailing padding has to cover the switch explicitly or a longer
+    // interface name runs straight under it.
     horizontalPadding: Style.spacing.controlPaddingX
+    rightPadding: Style.spacing.controlPaddingX + adapterToggle.implicitWidth + Style.spacing.controlGap
     verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
     bordered: true
+
+    // Natural width, floored so a long name elides instead of squeezing the
+    // switch, and capped so one adapter cannot span the whole panel.
+    readonly property real minPillWidth: Style.space(120)
+    width: Math.max(minPillWidth, Math.min(implicitWidth, adapterRow.width))
 
     active: isSelected
     selected: isSelected
     hasCursor: root.cursorActive && root.focusSection === "adapter" && root.adapterIndex === slot
-    tooltipText: isEnabled
-      ? (isConnected ? "Showing " + iface + " (connected)" : "Showing " + iface + " (not connected)")
-      : iface + " is off"
+    tooltipText: isConnected
+      ? "Showing " + iface + " (connected)"
+      : (isEnabled ? "Showing " + iface + " (connecting)" : "Showing " + iface + " (off)")
 
     onClicked: {
       root.selectedWifiIface = iface

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -67,9 +67,36 @@ Panel {
   readonly property string connectionPhrase: connectionPhrases[connectionPhraseIndex % connectionPhrases.length]
   readonly property bool networkManagerAvailable: Networking.backend === NetworkBackendType.NetworkManager
   readonly property var networkDevices: Networking.devices ? Networking.devices.values : []
-  readonly property var wifiDevice: findDevice(DeviceType.Wifi)
+  readonly property var allWifiDevices: findAllWifiDevices()
+  readonly property var wifiDevice: selectedWifiDevice
+  // Selection is tracked by interface name, not index: the device list can
+  // reorder or change length as adapters come and go, and an index would
+  // silently point at a different NIC when it did.
+  readonly property var selectedWifiDevice: {
+    var devices = allWifiDevices || []
+    if (devices.length === 0) return null
+    for (var i = 0; i < devices.length; i++) {
+      if (devices[i] && devices[i].name === selectedWifiIface) return devices[i]
+    }
+    // No pin, or the pinned adapter is gone: fall back to the same
+    // prefer-connected rule the panel used before the selector existed.
+    for (var j = 0; j < devices.length; j++) {
+      if (devices[j] && devices[j].connected) return devices[j]
+    }
+    return devices[0]
+  }
   readonly property var wifiNetworkObjects: wifiDevice && wifiDevice.networks ? wifiDevice.networks.values : []
   readonly property var connectedWifiNetwork: findConnectedWifiNetwork()
+  // The bar pill reports the machine's actual Wi-Fi connectivity, which is not
+  // the same question as "what is the panel listing". Viewing an idle adapter
+  // must not make a connected one look disconnected in the bar.
+  readonly property int activeWifiStrength: findActiveWifiStrength()
+  readonly property bool showAdapterSelector: allWifiDevices.length > 1
+  property string selectedWifiIface: ""
+  property var disabledAdapters: []
+  property string pendingAdapterIface: ""
+  property bool pendingAdapterEnable: false
+  property int adapterIndex: 0
   property var wifiNetworks: []
   property bool scanning: false
   property bool wifiStationAvailable: false
@@ -183,6 +210,20 @@ Panel {
       focusSection = "dns"
       bandAutoFocused = true
     }
+  }
+
+  onAllWifiDevicesChanged: {
+    // When the set of devices changes (hot-plug, etc.), re-sync.
+    root.refresh()
+  }
+
+  onSelectedWifiDeviceChanged: {
+    // When the selected adapter changes, reset per-device state and refresh.
+    selectedIndex = -1
+    passwordSsid = ""
+    passwordText = ""
+    identityText = ""
+    root.refresh(true)
   }
 
   // Collapsing the pills out from under the cursor would leave it pointing at
@@ -436,16 +477,20 @@ Panel {
 
   // Bar pill state, derived from the native NetworkManager service so the
   // icon reflects connection changes without polling. Wired is preferred
-  // when both are up, matching the default-route device.
+  // when both are up, matching the default-route device. Wi-Fi presence comes
+  // from `anyWifiConnected` rather than the selected adapter: the bar answers
+  // "am I online", which does not change because the panel is showing a
+  // different NIC's network list.
   readonly property var wiredDevice: findDevice(DeviceType.Wired)
   readonly property string kind: {
     if (wiredDevice && wiredDevice.connected) return "ethernet"
-    if (connectedWifiNetwork) return "wifi"
+    if (anyWifiConnected) return "wifi"
     return "disconnected"
   }
-  readonly property int signalStrength: connectedWifiNetwork
-    ? Math.round((connectedWifiNetwork.signalStrength || 0) * 100)
-    : -1
+  // Strength is -1 only when nothing published one; connectionIcon then draws
+  // the weakest bars, which still reads as "connected" rather than the
+  // crossed-out glyph.
+  readonly property int signalStrength: anyWifiConnected ? activeWifiStrength : -1
 
   function copyToClipboard(value) {
     if (!value || !root.bar) return
@@ -639,12 +684,68 @@ Panel {
     return fallback
   }
 
+  // Every Wi-Fi device, in NetworkManager's own enumeration order. The order
+  // is deliberately not connected-first: these back a selector whose pills
+  // must not reshuffle under the user's cursor when an adapter connects or
+  // drops. `selectedWifiDevice` handles prefer-connected instead.
+  function findAllWifiDevices() {
+    var devices = networkDevices || []
+    var wifi = []
+    for (var i = 0; i < devices.length; i++) {
+      var device = devices[i]
+      if (!device || device.type !== DeviceType.Wifi) continue
+      wifi.push(device)
+    }
+    return wifi
+  }
+
   function findConnectedWifiNetwork() {
     var networks = wifiNetworkObjects || []
     for (var i = 0; i < networks.length; i++) {
       if (networks[i] && networks[i].connected) return networks[i]
     }
     return null
+  }
+
+  // Signal strength for the bar pill, as a percentage, or -1 when unknown.
+  //
+  // A WifiNetwork only reports connected == true on a device whose scanner the
+  // panel has enabled, and the panel only scans the selected device. So when
+  // the panel is showing an idle adapter, the genuinely connected one publishes
+  // its networks with the flag unset -- but they still carry a live
+  // signalStrength. Prefer the flagged network when there is one; otherwise
+  // fall back to the strongest network the connected device publishes, which is
+  // the access point it is associated with.
+  function findActiveWifiStrength() {
+    var devices = allWifiDevices || []
+    var best = -1
+
+    for (var i = 0; i < devices.length; i++) {
+      var device = devices[i]
+      if (!device || !device.connected || !device.networks) continue
+      var networks = device.networks.values || []
+
+      for (var j = 0; j < networks.length; j++) {
+        var network = networks[j]
+        if (!network) continue
+        var pct = Math.round((network.signalStrength || 0) * 100)
+        if (network.connected) return pct
+        if (pct > best) best = pct
+      }
+    }
+
+    return best
+  }
+
+  // True when any Wi-Fi adapter is connected, regardless of which adapter the
+  // panel happens to be showing. NetworkDevice.connected is published for every
+  // device, scanned or not, so this is the honest answer to "am I online".
+  readonly property bool anyWifiConnected: {
+    var devices = allWifiDevices || []
+    for (var i = 0; i < devices.length; i++) {
+      if (devices[i] && devices[i].connected) return true
+    }
+    return false
   }
 
   function syncWifiNetworks() {
@@ -697,6 +798,32 @@ Panel {
 
     root.pendingBand = band
     actionProc.command = ["omarchy-network-band", band]
+    actionProc.running = true
+  }
+
+  // Toggle a single Wi-Fi adapter on/off. The device stays managed by
+  // NetworkManager so it remains in the device model and the selector keeps
+  // its pill; only the connection is brought up or down. `disabledAdapters`
+  // tracks the user's intent, and an adapter absent from it is enabled.
+  //
+  // No shell: the interface name reaches nmcli as its own argv entry, so a
+  // device name carrying shell metacharacters cannot be executed.
+  function toggleAdapter(iface, enable) {
+    if (!iface || actionProc.running) return
+    root.pendingAdapterIface = iface
+    root.pendingAdapterEnable = enable
+    var disabled = root.disabledAdapters.slice()
+    if (enable) {
+      var idx = disabled.indexOf(iface)
+      if (idx >= 0) {
+        disabled.splice(idx, 1)
+        root.disabledAdapters = disabled
+      }
+    } else if (!disabled.includes(iface)) {
+      disabled.push(iface)
+      root.disabledAdapters = disabled
+    }
+    actionProc.command = ["nmcli", "device", enable ? "connect" : "disconnect", iface]
     actionProc.running = true
   }
 
@@ -940,6 +1067,22 @@ Panel {
         // instead of leaving stale readings until the next poll tick.
         root.refresh()
       }
+      if (root.pendingAdapterIface !== "") {
+        var iface = root.pendingAdapterIface
+        var wanted = root.pendingAdapterEnable
+        root.pendingAdapterIface = ""
+        // The pill flipped optimistically when the toggle was clicked. nmcli
+        // refusing the change leaves the adapter as it was, so put the pill
+        // back rather than showing a state that never took effect.
+        if (exitCode !== 0) {
+          var disabled = root.disabledAdapters.slice()
+          var idx = disabled.indexOf(iface)
+          if (wanted && idx === -1) disabled.push(iface)
+          else if (!wanted && idx >= 0) disabled.splice(idx, 1)
+          root.disabledAdapters = disabled
+        }
+        root.refresh()
+      }
     }
   }
 
@@ -1059,7 +1202,8 @@ Panel {
           if (dy >= 0) return
         }
         if (dy !== 0) {
-          // Hidden sections drop out of the keyboard chain entirely.
+          // Hidden sections drop out of the keyboard chain entirely; the
+          // adapter selector is inserted between DNS and the Wi-Fi list.
           if (root.focusSection === "header") {
             if (dy > 0) {
               if (root.hasCaptivePortal) {
@@ -1110,6 +1254,17 @@ Panel {
                 root.focusSection = "header"
                 root.headerIndex = 0
               }
+            } else if (root.showAdapterSelector) {
+              root.focusSection = "adapter"
+              if (root.adapterIndex < 0) root.adapterIndex = 0
+            } else if (root.wifiNetworks.length > 0) {
+              root.focusSection = "wifi"
+              if (root.selectedIndex < 0) root.selectedIndex = 0
+            }
+          } else if (root.focusSection === "adapter") {
+            // k from adapter moves up to DNS; j drops into the wifi list.
+            if (dy < 0) {
+              root.focusSection = "dns"
             } else if (root.wifiNetworks.length > 0) {
               root.focusSection = "wifi"
               if (root.selectedIndex < 0) root.selectedIndex = 0
@@ -1118,7 +1273,7 @@ Panel {
             // k from the top row escapes back up to the DNS row rather than
             // wrapping around to the bottom of the list.
             if (dy < 0 && root.selectedIndex <= 0) {
-              root.focusSection = "dns"
+              root.focusSection = root.showAdapterSelector ? "adapter" : "dns"
               root.wifiActionFocused = false
             }
             else root.selectByDelta(dy)
@@ -1128,6 +1283,11 @@ Panel {
           if (root.focusSection === "header") root.selectHeaderByDelta(dx)
           else if (root.focusSection === "band") { if (!root.bandAutoFocused) root.selectBandByDelta(dx) }
           else if (root.focusSection === "dns") root.selectDnsByDelta(dx)
+          else if (root.focusSection === "adapter") {
+            if (root.allWifiDevices.length > 1) {
+              root.adapterIndex = Math.max(0, Math.min(root.allWifiDevices.length - 1, root.adapterIndex + dx))
+            }
+          }
           else if (root.focusSection === "wifi") root.selectWifiActionByDelta(dx)
         }
       }
@@ -1137,6 +1297,14 @@ Panel {
           else if (root.focusSection === "portal") root.openCaptivePortal()
           else if (root.focusSection === "band") root.activateBand()
           else if (root.focusSection === "dns") root.activateDns()
+          else if (root.focusSection === "adapter") {
+            // Enter on an adapter pill selects it
+            var devices = root.allWifiDevices || []
+            if (root.adapterIndex >= 0 && root.adapterIndex < devices.length) {
+              var device = devices[root.adapterIndex]
+              if (device) root.selectedWifiIface = device.name || ""
+            }
+          }
           else root.activateSelected()
         }
       }
@@ -1570,6 +1738,53 @@ Panel {
       }
 
 
+      // Wi-Fi adapter selection. Only shown when there are multiple Wi-Fi
+      // adapters (e.g. onboard + USB dongle). Each pill shows the interface
+      // name and connection state, with an on/off toggle.
+      PanelSeparator {
+        visible: root.showAdapterSelector
+        foreground: root.bar.foreground
+      }
+
+      Column {
+        visible: root.showAdapterSelector
+        width: parent.width
+        spacing: Style.space(10)
+
+        PanelSectionHeader {
+          text: "WI-FI ADAPTER"
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+        }
+
+        Row {
+          id: adapterRow
+          width: parent.width
+          spacing: Style.space(6)
+
+          readonly property int count: Math.max(1, root.allWifiDevices.length)
+          readonly property real cellWidth: (width - spacing * (count - 1)) / count
+
+          Repeater {
+            model: root.allWifiDevices
+
+            delegate: Item {
+              required property var modelData
+              required property int index
+              width: adapterRow.cellWidth
+              height: adapterPill.implicitHeight
+
+              AdapterPill {
+                id: adapterPill
+                device: modelData
+                slot: index
+                width: parent.width
+              }
+            }
+          }
+        }
+      }
+
       // Wi-Fi networks (only if a Wi-Fi station is available).
       PanelSeparator {
         visible: root.wifiStationAvailable
@@ -1700,6 +1915,65 @@ Panel {
       root.cursorActive = true
       root.focusSection = "dns"
       root.dnsIndex = pill.index
+    }
+  }
+
+  // A single Wi-Fi adapter pill. Shows the interface name, connection state,
+  // and an on/off toggle. Clicking selects the adapter; the toggle enables
+  // or disables it.
+  component AdapterPill: Button {
+    id: pill
+    required property var device
+    required property int slot
+
+    readonly property string iface: device ? (device.name || "") : ""
+    readonly property bool isConnected: device ? !!device.connected : false
+    // Compare against the resolved device, not the pin: with no pin set the
+    // panel falls back to prefer-connected, and the pill showing that
+    // adapter is the one that should read as selected.
+    readonly property bool isSelected: root.selectedWifiDevice === device
+    readonly property bool isEnabled: iface !== "" && !root.disabledAdapters.includes(iface)
+
+    text: iface
+    fontSize: Style.font.bodySmall
+    foreground: root.bar.foreground
+    fontFamily: root.bar.fontFamily
+    horizontalPadding: Style.spacing.controlPaddingX
+    verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
+    bordered: true
+
+    active: isSelected
+    selected: isSelected
+    hasCursor: root.cursorActive && root.focusSection === "adapter" && root.adapterIndex === slot
+    tooltipText: isEnabled
+      ? (isConnected ? "Showing " + iface + " (connected)" : "Showing " + iface + " (not connected)")
+      : iface + " is off"
+
+    onClicked: {
+      root.selectedWifiIface = iface
+    }
+
+    onHovered: function(isHovered) {
+      if (!isHovered) return
+      root.cursorActive = true
+      root.focusSection = "adapter"
+      root.adapterIndex = pill.slot
+    }
+
+    // On/off toggle switch on the right side of the pill
+    ToggleSwitch {
+      id: adapterToggle
+      trackHeight: Math.round(pill.fontSize * 1.2)
+      cursorPad: Style.space(3)
+      anchors.right: parent.right
+      anchors.rightMargin: Style.spacing.controlGap
+      anchors.verticalCenter: parent.verticalCenter
+      checked: isEnabled
+      busy: root.pendingAdapterIface === iface
+      foreground: root.bar.foreground
+      onToggled: {
+        if (iface !== "") root.toggleAdapter(iface, !isEnabled)
+      }
     }
   }
 

--- a/test/shell.d/network-adapters-test.sh
+++ b/test/shell.d/network-adapters-test.sh
@@ -1,0 +1,386 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
+
+// ---------------------------------------------------------------------------
+// Multi-adapter selection. A machine can expose several Wi-Fi NICs (an onboard
+// radio alongside a USB dongle), and the panel lets the user pick which one it
+// acts on. These are the state-heavy paths that manual two-adapter poking does
+// not protect from regressions.
+// ---------------------------------------------------------------------------
+
+function extract(pattern, label) {
+  const match = panelSource.match(pattern)
+  assert(match, label)
+  return match[0]
+}
+
+function mkDevice(name, connected, networks) {
+  return {
+    name: name,
+    type: 'wifi',
+    connected: connected,
+    networks: { values: networks || [] }
+  }
+}
+
+function mkNetwork(connected, strength) {
+  return { connected: connected, signalStrength: strength }
+}
+
+// --- device enumeration ----------------------------------------------------
+
+// Pills must not reshuffle under the cursor when an adapter connects or drops,
+// so the selector keeps NetworkManager's own order rather than sorting the
+// connected device to the front.
+const findAllSource = extract(
+  /function findAllWifiDevices\(\) \{[\s\S]*?\n {2}\}/,
+  'network has a findAllWifiDevices() helper'
+)
+
+var DeviceType = { Wifi: 'wifi', Wired: 'wired' }
+var networkDevices = []
+eval(findAllSource)
+
+const onboard = mkDevice('wlp3s0', false)
+const dongle = mkDevice('wlp0s20u1', true, [mkNetwork(true, 0.9)])
+const wired = { name: 'enp0s1', type: 'wired', connected: true }
+
+networkDevices = [onboard, dongle, wired]
+var enumerated = findAllWifiDevices()
+assert(
+  enumerated.length === 2 && enumerated[0] === onboard && enumerated[1] === dongle,
+  'network enumerates every Wi-Fi device in backend order and skips other device types'
+)
+
+networkDevices = [dongle, onboard]
+enumerated = findAllWifiDevices()
+assert(
+  enumerated[0] === dongle && enumerated[1] === onboard,
+  'network does not reorder the adapter list when the connected device is not first'
+)
+
+// --- selection resolution --------------------------------------------------
+
+// Selection is pinned by interface name: the device list can change length as
+// adapters come and go, and an index would silently name a different NIC.
+const selectedSource = extract(
+  /readonly property var selectedWifiDevice: \{[\s\S]*?\n {2}\}/,
+  'network resolves a selected Wi-Fi device'
+)
+const selectedBody = selectedSource.replace(
+  /^\s*readonly property var selectedWifiDevice: \{/,
+  ''
+).replace(/\n {2}\}$/, '')
+
+function resolveSelected(devices, pinned) {
+  var allWifiDevices = devices
+  var selectedWifiIface = pinned
+  return new Function('allWifiDevices', 'selectedWifiIface', selectedBody)(
+    allWifiDevices, selectedWifiIface
+  )
+}
+
+const pair = [onboard, dongle]
+
+// With nothing pinned the panel must behave exactly as it did before the
+// selector existed: prefer whichever adapter is actually connected.
+assert(
+  resolveSelected(pair, '') === dongle,
+  'network falls back to the connected adapter when no interface is pinned'
+)
+assert(
+  resolveSelected(pair, 'wlp3s0') === onboard,
+  'network honours a pinned interface even when it is not the connected one'
+)
+
+// Hot-unplugging the pinned adapter must not leave the panel pointing at a
+// device that no longer exists.
+assert(
+  resolveSelected(pair, 'wlp-removed') === dongle,
+  'network falls back to the connected adapter when the pinned interface is gone'
+)
+assert(
+  resolveSelected([onboard], 'wlp-removed') === onboard,
+  'network falls back to the first adapter when nothing is connected'
+)
+assert(
+  resolveSelected([], 'wlp3s0') === null,
+  'network resolves no device when there are no Wi-Fi adapters'
+)
+
+// --- cross-device connectivity --------------------------------------------
+
+// The bar answers "am I online", which does not change because the panel is
+// listing a different NIC. Deriving it from the selected device made the bar
+// show the crossed-out glyph whenever an idle adapter was on screen.
+const anyConnectedSource = extract(
+  /readonly property bool anyWifiConnected: \{[\s\S]*?\n {2}\}/,
+  'network tracks whether any Wi-Fi adapter is connected'
+)
+const anyConnectedBody = anyConnectedSource.replace(
+  /^\s*readonly property bool anyWifiConnected: \{/,
+  ''
+).replace(/\n {2}\}$/, '')
+
+function anyConnected(devices) {
+  return new Function('allWifiDevices', anyConnectedBody)(devices)
+}
+
+assert(
+  anyConnected([onboard, dongle]) === true,
+  'network reports Wi-Fi connectivity from a non-selected adapter'
+)
+assert(
+  anyConnected([onboard, mkDevice('wlp1s0', false)]) === false,
+  'network reports no Wi-Fi connectivity when every adapter is down'
+)
+
+// --- cross-device signal strength ----------------------------------------
+
+// A WifiNetwork only reports connected == true on a device whose scanner the
+// panel enabled, and the panel only scans the selected device. A connected
+// adapter the user is not looking at therefore publishes its networks with the
+// flag unset -- but they still carry a live signalStrength.
+const strengthSource = extract(
+  /function findActiveWifiStrength\(\) \{[\s\S]*?\n {2}\}/,
+  'network has a cross-device signal strength helper'
+)
+
+function activeStrength(devices) {
+  var allWifiDevices = devices
+  eval(strengthSource)
+  return findActiveWifiStrength()
+}
+
+assert(
+  activeStrength([onboard, dongle]) === 90,
+  'network reads signal strength from the flagged network of a connected adapter'
+)
+
+const unscanned = mkDevice('wlp0s20u1', true, [
+  mkNetwork(false, 0.4),
+  mkNetwork(false, 0.85)
+])
+assert(
+  activeStrength([onboard, unscanned]) === 85,
+  'network falls back to the strongest published network when no flag is set'
+)
+assert(
+  activeStrength([onboard]) === -1,
+  'network reports unknown strength when no adapter is connected'
+)
+assert(
+  activeStrength([mkDevice('wlp0s20u1', true, [])]) === -1,
+  'network reports unknown strength when a connected adapter publishes no networks'
+)
+
+// --- helper command targeting --------------------------------------------
+
+// omarchy-network-status derives its interface from the default route and
+// omarchy-network-band takes the first connected Wi-Fi device, so both have to
+// be told which adapter the panel is acting on or they silently report and
+// modify a different one.
+const statusCommandSource = extract(
+  /function statusCommand\(verbose\) \{[\s\S]*?\n {2}\}/,
+  'network builds its status command'
+)
+const bandCommandSource = extract(
+  /function bandCommand\(band\) \{[\s\S]*?\n {2}\}/,
+  'network builds its band command'
+)
+
+function buildCommands(iface) {
+  var selectedIface = iface
+  eval(statusCommandSource)
+  eval(bandCommandSource)
+  return {
+    status: statusCommand(true).join(' '),
+    bandStatus: bandCommand('').join(' '),
+    bandSet: bandCommand('5').join(' ')
+  }
+}
+
+var pinned = buildCommands('wlp3s0')
+assert(
+  pinned.status === 'omarchy-network-status --verbose --iface wlp3s0',
+  'network pins the selected interface when reading connection details'
+)
+assert(
+  pinned.bandStatus === 'omarchy-network-band --iface wlp3s0',
+  'network pins the selected interface when reading the Wi-Fi band'
+)
+assert(
+  pinned.bandSet === 'omarchy-network-band --iface wlp3s0 5',
+  'network pins the selected interface when changing the Wi-Fi band'
+)
+
+var unpinned = buildCommands('')
+assert(
+  unpinned.status === 'omarchy-network-status --verbose',
+  'network omits --iface entirely when it has no adapter to pin'
+)
+assert(
+  unpinned.bandSet === 'omarchy-network-band 5',
+  'network omits --iface from a band change when it has no adapter to pin'
+)
+
+// --- adapter toggle ------------------------------------------------------
+
+// The toggle has to claim the panel's shared action guard: native
+// WifiNetwork.connect() calls never touch actionProc, so a private guard would
+// let a row action and an adapter toggle race.
+const toggleSource = extract(
+  /function toggleAdapter\(iface, enable\) \{[\s\S]*?\n {2}\}/,
+  'network has an adapter toggle helper'
+)
+
+function runToggle(state, iface, enable) {
+  var root = state
+  var actionKind = state.actionKind
+  var actionSsid = state.actionSsid
+  var actionProc = state.actionProc
+  var actionTimeout = { restart: function() { state.timeoutArmed = true } }
+
+  eval(toggleSource)
+  toggleAdapter(iface, enable)
+
+  // The helper assigns the bare names for the shared guard.
+  state.actionKind = actionKind
+  state.actionSsid = actionSsid
+  return state
+}
+
+function freshState() {
+  return {
+    actionKind: '',
+    actionSsid: 'something',
+    disabledAdapters: [],
+    pendingAdapterIface: '',
+    timeoutArmed: false,
+    actionProc: { running: false, command: null }
+  }
+}
+
+var state = runToggle(freshState(), 'wlp3s0', false)
+assert(
+  state.actionKind === 'adapter',
+  'network claims the shared action guard while an adapter command is in flight'
+)
+assert(
+  state.timeoutArmed === true,
+  'network arms the action timeout so a stalled adapter command cannot wedge the panel'
+)
+assert(
+  state.pendingAdapterIface === 'wlp3s0',
+  'network records which adapter is being toggled'
+)
+assert(
+  state.disabledAdapters.indexOf('wlp3s0') !== -1,
+  'network marks the adapter off optimistically so the switch moves on click'
+)
+assert(
+  Array.isArray(state.actionProc.command) &&
+    state.actionProc.command.join(' ') === 'nmcli device disconnect wlp3s0',
+  'network disconnects an adapter without routing the interface name through a shell'
+)
+
+state = runToggle(freshState(), 'wlp3s0', true)
+assert(
+  state.actionProc.command.join(' ') === 'nmcli device connect wlp3s0',
+  'network reconnects an adapter through nmcli argv'
+)
+assert(
+  state.disabledAdapters.indexOf('wlp3s0') === -1,
+  'network clears the optimistic off state when reconnecting an adapter'
+)
+
+// A network row action already holds the guard: the toggle must not start.
+var busy = freshState()
+busy.actionKind = 'connect'
+busy = runToggle(busy, 'wlp3s0', false)
+assert(
+  busy.actionProc.command === null && busy.pendingAdapterIface === '',
+  'network refuses an adapter toggle while another action holds the shared guard'
+)
+
+// A device name is never interpolated into a shell string.
+assert(
+  !/bash", "-c", "nmcli/.test(panelSource) && !/nmcli device (connect|disconnect) " \+/.test(panelSource),
+  'network never builds an nmcli adapter command by string concatenation'
+)
+
+// --- switch state reconciliation ----------------------------------------
+
+// The switch must reflect NetworkManager, not a local wish-list: after a shell
+// reload or an external `nmcli device disconnect`, showing "on" for a device
+// that is actually down makes the first click issue a second disconnect.
+const isEnabledSource = extract(
+  /readonly property bool isEnabled: \{[\s\S]*?\n {4}\}/,
+  'network derives the adapter switch state'
+)
+const isEnabledBody = isEnabledSource.replace(
+  /^\s*readonly property bool isEnabled: \{/,
+  ''
+).replace(/\n {4}\}$/, '')
+
+function switchOn(iface, isConnected, pendingIface, disabled) {
+  return new Function(
+    'iface', 'isConnected', 'root',
+    isEnabledBody
+  )(iface, isConnected, { pendingAdapterIface: pendingIface, disabledAdapters: disabled })
+}
+
+assert(
+  switchOn('wlp3s0', false, '', []) === false,
+  'network shows an adapter switch off when NetworkManager has the device disconnected'
+)
+assert(
+  switchOn('wlp0s20u1', true, '', []) === true,
+  'network shows an adapter switch on when the device is connected'
+)
+assert(
+  switchOn('wlp3s0', false, 'wlp3s0', []) === true,
+  'network shows the optimistic on state while a connect is in flight'
+)
+assert(
+  switchOn('wlp0s20u1', true, 'wlp0s20u1', ['wlp0s20u1']) === false,
+  'network shows the optimistic off state while a disconnect is in flight'
+)
+assert(
+  switchOn('', false, '', []) === false,
+  'network shows an adapter switch off when it has no interface name'
+)
+
+// --- keyboard focus safety ----------------------------------------------
+
+// Hot-unplugging the adapter under the cursor can leave focusSection on a
+// section that no longer renders, with an index past the end of the list.
+const devicesChanged = extract(
+  /onAllWifiDevicesChanged: \{[\s\S]*?\n {2}\}/,
+  'network reacts to the adapter list changing'
+)
+assert(
+  /adapterIndex/.test(devicesChanged),
+  'network clamps the adapter cursor when the device list changes'
+)
+assert(
+  /showAdapterSelector/.test(devicesChanged) && /focusSection/.test(devicesChanged),
+  'network moves keyboard focus out of the adapter section when it disappears'
+)
+
+const timeoutHandler = extract(
+  /id: actionTimeout[\s\S]*?onTriggered: \{[\s\S]*?\n {4}\}/,
+  'network has an action timeout handler'
+)
+assert(
+  /adapter/.test(timeoutHandler),
+  'network releases the shared guard when an adapter command times out'
+)
+JS

--- a/test/shell.d/network-band-test.sh
+++ b/test/shell.d/network-band-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# omarchy-network-band reads the link with `iw dev <iface> link`. On a secondary
+# Wi-Fi adapter iw prints a complete link report -- SSID and freq included --
+# and then still exits non-zero, failing the signal-strength ioctl with
+# "Operation not permitted". The script runs under `set -euo pipefail`, so
+# taking that exit status at face value aborted before printing anything, and
+# the panel's band section silently vanished for any adapter that was not the
+# one holding the default route.
+
+band_script="$ROOT/bin/omarchy-network-band"
+
+stub_dir=$(mktemp -d)
+trap 'rm -rf "$stub_dir"' EXIT
+
+# An `iw` that behaves like the real one on a secondary adapter: correct output
+# on stdout, a diagnostic on stderr, and a non-zero exit.
+cat >"$stub_dir/iw" <<'STUB'
+#!/bin/bash
+echo "command failed: Operation not permitted (-1)" >&2
+cat <<'OUT'
+Connected to b8:fb:b3:ea:61:70 (on wlp3s0)
+	SSID: TestNet
+	freq: 5180.0
+OUT
+exit 255
+STUB
+chmod +x "$stub_dir/iw"
+
+# nmcli stub: the device has an active profile, no band pinned, and the SSID is
+# visible on both bands so `available` carries more than one entry.
+#
+# Field order matters: available_bands() asks for FREQ,SSID (frequency first,
+# SSID last so an SSID containing ':' can be reassembled), so the stub must
+# emit "<freq>:<ssid>" and not the reverse.
+cat >"$stub_dir/nmcli" <<'STUB'
+#!/bin/bash
+args="$*"
+case "$args" in
+  *GENERAL.CONNECTION*) echo "TestProfile" ;;
+  *802-11-wireless.band*) echo "" ;;
+  *FREQ,SSID*)
+    printf '2457 MHz:TestNet\n'
+    printf '5180 MHz:TestNet\n'
+    ;;
+  *DEVICE,TYPE,STATE*) printf 'wlp3s0:wifi:connected\n' ;;
+  *) : ;;
+esac
+exit 0
+STUB
+chmod +x "$stub_dir/nmcli"
+
+status=0
+output=$(PATH="$stub_dir:$PATH" bash "$band_script" --iface wlp3s0 2>/dev/null) || status=$?
+
+if (( status == 0 )); then
+  pass "omarchy-network-band survives iw exiting non-zero on a secondary adapter"
+else
+  fail "omarchy-network-band survives iw exiting non-zero on a secondary adapter" \
+    "exited with status $status"
+fi
+
+# An empty report is indistinguishable from "no band control" in the panel,
+# which is exactly how the bug presented.
+if [[ -n $output ]]; then
+  pass "omarchy-network-band prints a report rather than aborting under set -e"
+else
+  fail "omarchy-network-band prints a report rather than aborting under set -e" \
+    "no output produced"
+fi
+
+if [[ $output == *"band	5"* ]]; then
+  pass "omarchy-network-band reports the band parsed from a non-zero iw run"
+else
+  fail "omarchy-network-band reports the band parsed from a non-zero iw run" \
+    "output was: $output"
+fi
+
+# The panel only renders its band section when more than one band is available.
+if [[ $output == *"available	2.4 5"* ]]; then
+  pass "omarchy-network-band still enumerates available bands after a non-zero iw run"
+else
+  fail "omarchy-network-band still enumerates available bands after a non-zero iw run" \
+    "output was: $output"
+fi

--- a/test/shell.d/network-status-test.sh
+++ b/test/shell.d/network-status-test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+status_script="$ROOT/bin/omarchy-network-status"
+stub_dir=$(mktemp -d)
+trap 'rm -rf "$stub_dir"' EXIT
+
+# Make the selected interface look like a real connected secondary adapter.
+cat >"$stub_dir/ip" <<'STUB'
+#!/bin/bash
+case "$*" in
+  "route get 1.1.1.1")
+    printf '1.1.1.1 via 192.168.68.1 dev wlp0s20u1 src 192.168.68.51\n'
+    ;;
+  "-j addr show wlp3s0")
+    printf '[{"addr_info":[{"family":"inet","local":"10.0.0.2","prefixlen":24}]}]\n'
+    ;;
+  "-j route show default dev wlp3s0")
+    printf '[{"gateway":"10.0.0.1"}]\n'
+    ;;
+  *)
+    :
+    ;;
+esac
+STUB
+
+cat >"$stub_dir/nmcli" <<'STUB'
+#!/bin/bash
+case "$*" in
+  *'GENERAL.STATE,GENERAL.CONNECTION dev show wlp3s0'*)
+    printf '100:TestNet\n'
+    ;;
+  *'IN-USE,SIGNAL dev wifi list ifname wlp3s0'*)
+    printf '*:90\n'
+    ;;
+  *)
+    :
+    ;;
+esac
+STUB
+
+cat >"$stub_dir/iw" <<'STUB'
+#!/bin/bash
+cat <<'OUT'
+Connected to 00:11:22:33:44:55 (on wlp3s0)
+	SSID: TestNet
+	freq: 5180.0
+	signal: -50 dBm
+	tx bitrate: 433.3 MBit/s
+OUT
+STUB
+
+cat >"$stub_dir/omarchy-cmd-present" <<'STUB'
+#!/bin/bash
+command -v "$1" >/dev/null
+STUB
+
+cat >"$stub_dir/ping" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "${PING_LOG:?}"
+printf '64 bytes from test: time=12.34 ms\n'
+STUB
+
+chmod +x "$stub_dir"/*
+PING_LOG="$stub_dir/ping.log" \
+  PATH="$stub_dir:$PATH" \
+  bash "$status_script" --verbose --iface wlp3s0 >"$stub_dir/output"
+
+output=$(<"$stub_dir/output")
+pings=$(<"$stub_dir/ping.log")
+
+if [[ $output == *$'iface\twlp3s0'* ]]; then
+  pass "status reports the selected interface"
+else
+  fail "status reports the selected interface" "output was: $output"
+fi
+
+if [[ $output == *$'ip\t10.0.0.2'* && $output == *$'gateway\t10.0.0.1'* ]]; then
+  pass "status reports the selected interface's address and gateway"
+else
+  fail "status reports the selected interface's address and gateway" "output was: $output"
+fi
+
+if [[ $(grep -c -- '-I wlp3s0' "$stub_dir/ping.log") == 2 ]]; then
+  pass "status binds both gateway and internet probes to the selected interface"
+else
+  fail "status binds both gateway and internet probes to the selected interface" \
+    "ping invocations were: $pings"
+fi
+
+if grep -q -- '-I wlp3s0 10.0.0.1' "$stub_dir/ping.log"; then
+  pass "status binds the gateway probe to the selected interface"
+else
+  fail "status binds the gateway probe to the selected interface" \
+    "ping invocations were: $pings"
+fi
+
+if grep -q -- '-I wlp3s0 1.1.1.1' "$stub_dir/ping.log"; then
+  pass "status binds the internet probe to the selected interface"
+else
+  fail "status binds the internet probe to the selected interface" \
+    "ping invocations were: $pings"
+fi


### PR DESCRIPTION
## What

Adds a **Wi-Fi adapter selector** to the network panel, so a machine with more than one Wi-Fi NIC can choose which adapter the panel talks to, and turn each one on or off.

The section only renders when a second Wi-Fi device is present, so single-adapter machines are visually unchanged.

## Why

`Panel.qml` resolved one device via `findDevice(DeviceType.Wifi)` and listed only that adapter's networks. There was no concept of a second radio.

My onboard Wi-Fi drops connections, so I run a USB dongle alongside it. Both show up in `nmcli`, but the panel silently picks one and gives you no way to see or reach the other — switching adapters meant leaving the GUI for `nmcli` entirely.

## How it works

Each adapter gets a pill with its interface name and a `ToggleSwitch`. Clicking a pill points the network list, band controls and details rows at that adapter; the switch connects/disconnects that device.

```
WI-FI ADAPTER
[ wlp3s0      (o ) ]  [ wlp0s20u1   ( o) ]
```

A few decisions worth flagging for review:

- **Selection is pinned by interface name, not list index.** Devices come and go; an index would quietly start naming a different NIC when the list changed length.

- **`findAllWifiDevices()` keeps NetworkManager's enumeration order** rather than sorting connected-first, so pills don't reshuffle under the cursor when an adapter connects or drops. The old prefer-connected behaviour lives on in `selectedWifiDevice`, which is also the no-pin fallback — so with no selection the panel opens on the same adapter it picked before this change.

- **The bar pill no longer derives from the selected adapter.** This was a real bug I hit while testing: a `WifiNetwork` only reports `connected == true` on a device whose scanner the panel has enabled, and the panel only scans the *selected* device. So viewing an idle adapter while another carried traffic showed the crossed-out "disconnected" glyph. `kind` now reads `anyWifiConnected` (`NetworkDevice.connected` across all devices), and `findActiveWifiStrength()` prefers the flagged network but falls back to the strongest network the connected device publishes — those objects still carry a live `signalStrength` even when the flag is unset.

- **Adapters stay managed by NetworkManager**; only the connection goes up/down. Marking a device unmanaged would drop it from `Networking.devices` and take its own pill off screen with it.

- **`toggleAdapter()` passes the interface to nmcli as its own argv entry** rather than interpolating into `bash -c`, keeping device names out of a shell.

Keyboard nav gains the section in the existing chain (header → band → DNS → adapter → wifi), with `h`/`l` walking the pills and Enter selecting.

## Review follow-up (a6214af)

Copilot's review found six real issues; all are fixed in the second commit. Two were genuine bugs rather than polish:

- **The selector didn't actually retarget details or band.** `omarchy-network-status` derives its interface from `ip route get` and took no interface argument; `omarchy-network-band`'s `wifi_device()` takes the *first connected* device. With two active NICs the panel displayed and modified a different adapter than the selected pill. Both now accept `--iface`, and the panel pins the selection on every call. Unpinned callers behave exactly as before.
- **The selected adapter's latency probes still used the default route.** The first fix retargeted the displayed IP/gateway but left `ping` unbound, so ping and packet-loss statistics could describe another NIC. `ping_latency_ms` now receives the selected interface and both gateway/internet probes use `ping -I <iface>`.
- **The switch asserted state it hadn't checked.** `disabledAdapters` started empty, so after a reload or external `nmcli device disconnect` the knob showed "on" for a down device and the first click issued a *second* disconnect. It now derives from `NetworkDevice.connected`, with the local list reduced to in-flight optimistic state.

Also: adapter operations now claim the shared `actionKind` guard (and arm the same timeout) so they can't race native `WifiNetwork` actions; hot-unplug clamps the keyboard cursor and evacuates focus; and the pill row is a wrapping `Flow` with a minimum width and padding that explicitly reserves the switch.

## Follow-up: band section on a secondary adapter (45242ae)

Running this on a laptop with **three** Wi-Fi adapters, two connected at once, surfaced a real bug in `omarchy-network-band` that the selector makes reachable.

`iw dev <iface> link` prints a complete link report and *still exits 255* on an adapter that isn't holding the default route — it emits SSID and freq, then fails the signal-strength ioctl with "Operation not permitted". `read_link` took that status at face value under `set -euo pipefail`, so the script aborted before printing anything. Since the panel only renders the band section when more than one band is available, an empty report is indistinguishable from "no band control" — so selecting the non-routed pill silently dropped the whole section.

Fixed by ignoring the exit status and validating the parsed fields instead, which is what the callers already do (`print_status` returns early on an empty ssid; `set_band` refuses a band absent from `available_bands`).

This is pre-existing rather than introduced here — it just needed two connected NICs and the wrong enumeration order to hit before the selector existed.

`test/shell.d/network-band-test.sh` covers it with an `iw` stub that reproduces the real behaviour (correct stdout, diagnostic on stderr, exit 255). Verified the test fails against the previous code and passes with the fix.

## Testing

Verified on a two-adapter laptop — idle onboard `wlp3s0` plus connected USB `wlp0s20u1`:

- Selector switches the listed networks between adapters
- Toggles connect and disconnect each device independently
- Bar reports the connected dongle's live 90% signal while the panel shows the idle onboard NIC (previously: crossed-out icon)
- Details and band now follow the selected pill; each pin reports its own interface, unpinned still reports the routed one
- Single-adapter path unchanged — section hidden, panel picks the connected device as before

Additionally verified with **three adapters** (`wlp0s20u1` + `wlp3s0` connected simultaneously, `wlp0s20u2` idle), which is the case the `Flow` layout was added for:

- Pills wrap to two rows rather than shrinking; measured from the screenshot, each pill is 118px wide with its switch clear of the label (no truncation at 9-character interface names)
- With two NICs connected at once, each pill reports its **own** adapter's state — `wlp0s20u1` → 192.168.68.51 / Damon_MLO / 5GHz, `wlp3s0` → 192.168.68.60 / Damon — matching what the kernel reports for each interface. Before the `--iface` plumbing both pills showed the default route's values.

And with all **three connected simultaneously across two different networks**, including a separate subnet:

```
wlp0s20u1  192.168.68.51  Damon_MLO      gw 192.168.68.1   5GHz
wlp3s0     192.168.68.60  Damon          gw 192.168.68.1   5GHz
wlp0s20u2  172.20.10.2    iPhone 17 Pro  gw 172.20.10.1    2.4GHz
```

Selecting the third pill retargets the whole panel to it — header SSID, IP, gateway and band all follow the selection while the other two stay connected on the other subnet.

Automated:

- **New `test/shell.d/network-adapters-test.sh`, 45 assertions** — enumeration order, interface pinning and pinned-device removal, connected-device fallback, cross-device connectivity and strength (including the unflagged-network path), helper command targeting, toggle argv and guard behaviour, switch reconciliation, focus clamping
- **New `test/shell.d/network-band-test.sh`, 4 assertions** — the non-zero-`iw` regression above, driven by a stub; confirmed to fail without the fix
- **New `test/shell.d/network-status-test.sh`, 5 assertions** — both latency probes carry `-I <selected-interface>`, preventing statistics from silently using the default route
- `./test/shell` — 3068 assertions pass; all network suites, including the new status-probe test, are green
- `./test/cli` — passes, including the `bin/` metadata lint on both modified scripts
- `qmllint` — 0 errors against the rebased tree

Six suites fail in this environment (agent-usage scanners, config, screenshot sanity, snapper, and unowned-system-paths); each fails identically on a pristine `quattro` checkout and is unrelated to this PR — they require an `omarchy-pkgs` checkout, real agent usage data, screenshot access, or other environment-specific facilities.

## Known limitation

The switch is built on `nmcli device connect/disconnect`, which only activates an *existing* profile. An adapter that has never joined a network has no profile bound to its interface, so turning it on fails with `A 'wireless' setting is required if no AP path was given` and the pill stays off.

Hit this with a freshly plugged third dongle: it scanned fine and `rfkill` was clear, but every saved profile was pinned to another interface. Joining a network once from the panel's list creates the interface-bound profile, and the switch works for that adapter from then on.

That seems like the right split to me — the switch enables and disables a *configured* adapter, and first-time setup goes through the network list, which is where credentials belong.

Happy to adjust that, along with the naming, the section placement, or the toggle semantics (currently connect/disconnect rather than rfkill), if you'd prefer a different approach.

## Attribution

To be upfront about who did what here: **[@drbree82](https://github.com/drbree82) is the human on this PR, and the code was written by [Hermes Agent](https://github.com/NousResearch/hermes-agent)** (LongCat 2.0) running on his machine.

The split was roughly:

- **Human** — hit the underlying problem (flaky onboard radio + USB dongle), specified the feature, ran the shell with the patch applied, and caught the crossed-out-icon regression that the agent's own unit-level test had missed
- **Agent** — read the existing panel, wrote the implementation, root-caused the icon bug against the live NetworkManager model via Quickshell's `Networking` service, worked through the review feedback, and wrote this description

Flagging it plainly since the diff is ~280 lines of QML in a file none of us wrote by hand. Review it as agent-generated code — I've tried to keep the reasoning in comments where a decision isn't obvious, but please push back on anything that reads as over-engineered.



