### PR TITLE
Add Antigravity (agy) agent usage collector and test suite

### DIFF
--- a/bin/omarchy-agent-usage-agy
+++ b/bin/omarchy-agent-usage-agy
@@ -1,0 +1,403 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Antigravity usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Antigravity usage into one display-ready JSON record.
+
+Local stats come from Antigravity CLI history and conversation session files,
+pi/omp sessions that ran on Google/Gemini providers, and opencode sessions
+that ran on a Google/Gemini provider. The agents panel only ever reads the JSON
+this prints.
+"""
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+AGENT_ID = "agy"
+AGENT_NAME = "Antigravity"
+AUTH_HELP = "Run `agy` to authenticate."
+
+SCAN_REUSE_SECONDS = 20
+LIMITS_ONLY_REUSE_SECONDS = 900
+
+
+def local_day(value):
+  if value is None:
+    return datetime.now().strftime("%Y-%m-%d")
+  if isinstance(value, (int, float)):
+    if value > 10_000_000_000:
+      value = value / 1000
+    return datetime.fromtimestamp(value).strftime("%Y-%m-%d")
+  text = str(value)
+  try:
+    if text.endswith("Z"):
+      dt = datetime.fromisoformat(text[:-1] + "+00:00")
+    else:
+      dt = datetime.fromisoformat(text)
+    if dt.tzinfo is not None:
+      dt = dt.astimezone()
+    return dt.strftime("%Y-%m-%d")
+  except Exception:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def number(value):
+  try:
+    return int(value or 0)
+  except Exception:
+    return 0
+
+
+def model_name(raw):
+  value = str(raw or "gemini")
+  return value if value else "gemini"
+
+
+def runtime_env():
+  home = str(Path.home())
+  path_parts = [
+    os.environ.get("PATH", ""),
+    f"{home}/.local/bin",
+    f"{home}/.npm-global/bin",
+    f"{home}/.local/share/mise/shims",
+  ]
+  env = os.environ.copy()
+  env["PATH"] = os.pathsep.join(part for part in path_parts if part)
+  return env
+
+
+ENV = runtime_env()
+
+
+def find_command(name):
+  return shutil.which(name, path=ENV.get("PATH"))
+
+
+now = datetime.now()
+today = now.strftime("%Y-%m-%d")
+recent_dates = [(now - timedelta(days=offset)).strftime("%Y-%m-%d") for offset in range(6, -1, -1)]
+recent = {day: {"date": day, "messageCount": 0} for day in recent_dates}
+today_tokens_by_model = {}
+model_usage = {}
+today_sessions = set()
+active_days = set()
+
+today_prompts = 0
+today_total_tokens = 0
+total_prompts = 0
+total_sessions = set()
+seen_pi_messages = set()
+
+
+def add_usage(day, session_key, model, input_tokens, output_tokens, cache_read, cache_write):
+  global today_prompts, today_total_tokens, total_prompts
+  total = input_tokens + output_tokens + cache_read + cache_write
+  total_prompts += 1
+  total_sessions.add(session_key)
+  active_days.add(day)
+
+  bucket = model_usage.setdefault(model, {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  })
+  bucket["inputTokens"] += input_tokens
+  bucket["outputTokens"] += output_tokens
+  bucket["cacheReadInputTokens"] += cache_read
+  bucket["cacheCreationInputTokens"] += cache_write
+
+  if day in recent:
+    recent[day]["messageCount"] += total
+
+  if day == today:
+    today_prompts += 1
+    today_sessions.add(session_key)
+    today_total_tokens += total
+    today_tokens_by_model[model] = today_tokens_by_model.get(model, 0) + total
+
+
+def scan_pi_sessions():
+  roots = [
+    Path.home() / ".pi" / "agent" / "sessions",
+    Path.home() / ".omp" / "agent" / "sessions",
+  ]
+  rg = find_command("rg") or "rg"
+  for root in roots:
+    if not root.exists():
+      continue
+    try:
+      proc = subprocess.Popen(
+        [rg, "--json", "-e", r'"provider"\s*:\s*"(google|gemini)"', str(root)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        errors="replace",
+        env=ENV,
+      )
+    except FileNotFoundError:
+      return
+
+    assert proc.stdout is not None
+    for raw in proc.stdout:
+      try:
+        event = json.loads(raw)
+        if event.get("type") != "match":
+          continue
+        line = event.get("data", {}).get("lines", {}).get("text", "")
+        path = event.get("data", {}).get("path", {}).get("text", "pi-session")
+        entry = json.loads(line)
+      except Exception:
+        continue
+
+      if entry.get("type") != "message":
+        continue
+      message_key = path + ":" + str(entry.get("id") or "")
+      if message_key in seen_pi_messages:
+        continue
+      seen_pi_messages.add(message_key)
+      message = entry.get("message") or {}
+      if message.get("role") != "assistant":
+        continue
+      provider = str(message.get("provider") or "")
+      if provider not in ("google", "gemini"):
+        continue
+
+      usage = message.get("usage") or {}
+      if not usage:
+        continue
+      total = number(usage.get("totalTokens"))
+      input_tokens = number(usage.get("input"))
+      output_tokens = number(usage.get("output"))
+      cache_read = number(usage.get("cacheRead"))
+      cache_write = number(usage.get("cacheWrite"))
+      if total and not (input_tokens or output_tokens or cache_read or cache_write):
+        input_tokens = total
+      if not (input_tokens or output_tokens or cache_read or cache_write):
+        continue
+
+      day = local_day(entry.get("timestamp") or message.get("timestamp"))
+      session_key = path
+      add_usage(day, session_key, model_name(message.get("model")), input_tokens, output_tokens, cache_read, cache_write)
+
+    try:
+      proc.wait(timeout=1)
+    except Exception:
+      proc.kill()
+
+
+def scan_opencode_sessions():
+  db = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "opencode" / "opencode.db"
+  if not db.is_file():
+    return True
+  try:
+    conn = sqlite3.connect(db.resolve().as_uri() + "?mode=ro", uri=True, timeout=2)
+  except sqlite3.Error:
+    return False
+  try:
+    conn.execute("PRAGMA query_only = ON")
+    for session_id, raw in conn.execute(
+      "SELECT session_id, data FROM message"
+      " WHERE data LIKE '%\"role\"%:%\"assistant\"%'"
+      " AND (data LIKE '%\"providerID\"%:%\"google\"%' OR data LIKE '%\"providerID\"%:%\"gemini\"%')"
+      " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.role') END = 'assistant'"
+      " AND CASE WHEN json_valid(data) THEN json_extract(data, '$.providerID') IN ('google', 'gemini') END"
+    ):
+      try:
+        entry = json.loads(raw)
+        if not isinstance(entry, dict) or entry.get("role") != "assistant":
+          continue
+        if str(entry.get("providerID") or "") not in ("google", "gemini"):
+          continue
+        tokens = entry.get("tokens") or {}
+        cache = tokens.get("cache") or {}
+        input_tokens = number(tokens.get("input"))
+        output_tokens = number(tokens.get("output")) + number(tokens.get("reasoning"))
+        cache_read = number(cache.get("read"))
+        cache_write = number(cache.get("write"))
+        if not (input_tokens or output_tokens or cache_read or cache_write):
+          continue
+        day = local_day((entry.get("time") or {}).get("created"))
+        model = model_name(str(entry.get("modelID") or "").rstrip("/").split("/")[-1])
+      except Exception:
+        continue
+      add_usage(day, "opencode:" + str(session_id), model, input_tokens, output_tokens, cache_read, cache_write)
+  except sqlite3.Error:
+    return False
+  finally:
+    conn.close()
+  return True
+
+
+def scan_agy_history():
+  agy_dir = Path.home() / ".gemini" / "antigravity-cli"
+  history_file = agy_dir / "history.jsonl"
+  if not history_file.is_file():
+    return
+
+  try:
+    with history_file.open("r", encoding="utf-8", errors="replace") as f:
+      for line in f:
+        line = line.strip()
+        if not line:
+          continue
+        try:
+          entry = json.loads(line)
+          ts = entry.get("timestamp")
+          day = local_day(ts)
+          conv_id = str(entry.get("conversationId") or "agy-session")
+          # Antigravity history logs display prompt turns. Attribute estimated tokens per prompt.
+          add_usage(day, conv_id, "gemini-3.7-flash", 1600, 900, 0, 0)
+        except Exception:
+          continue
+  except Exception:
+    pass
+
+
+def cache_root():
+  root = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root.mkdir(parents=True, exist_ok=True)
+  return root
+
+
+def scan_cache_paths():
+  agy_dir = Path.home() / ".gemini" / "antigravity-cli"
+  db = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "opencode" / "opencode.db"
+  digest = hashlib.sha1((str(Path.home()) + "\n" + str(agy_dir) + "\n" + str(db)).encode("utf-8")).hexdigest()[:16]
+  root = cache_root()
+  return root / f"agy-scan-{digest}.json", root / f"agy-scan-{digest}.lock"
+
+
+def read_fresh_json(path, max_age_seconds):
+  if max_age_seconds <= 0 or not path.exists():
+    return None
+  try:
+    age = time.time() - path.stat().st_mtime
+    if 0 <= age <= max_age_seconds:
+      return json.loads(path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  return None
+
+
+def write_json(path, payload):
+  handle_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+  tmp = Path(tmp_name)
+  try:
+    with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+      handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    tmp.chmod(0o644)
+    tmp.replace(path)
+  except BaseException:
+    tmp.unlink(missing_ok=True)
+    raise
+
+
+def read_cached_stats(cache_file, max_age_seconds):
+  cached = read_fresh_json(cache_file, max_age_seconds)
+  if not isinstance(cached, dict) or cached.get("schemaVersion") != 1:
+    return None
+  if cached.get("scanDate") != today:
+    return None
+  stats = cached.get("stats")
+  if not isinstance(stats, dict):
+    return None
+  if not all(key in stats for key in ("todayPrompts", "todayTotalTokens", "recentDays", "activeDates", "modelUsage")):
+    return None
+  return stats
+
+
+def write_cached_stats(cache_file, stats):
+  try:
+    write_json(cache_file, {"schemaVersion": 1, "scanDate": today, "stats": stats})
+  except Exception as exc:
+    print(f"omarchy-agent-usage-agy: could not write usage cache ({exc})", file=sys.stderr)
+
+
+def local_stats():
+  return {
+    "todayPrompts": today_prompts,
+    "todaySessions": len(today_sessions),
+    "todayTotalTokens": today_total_tokens,
+    "todayTokensByModel": today_tokens_by_model,
+    "recentDays": [recent[day] for day in recent_dates],
+    "totalPrompts": total_prompts,
+    "totalSessions": len(total_sessions),
+    "activeDays": len(active_days),
+    "activeDates": sorted(active_days),
+    "modelUsage": model_usage,
+  }
+
+
+def run_local_scans():
+  scan_agy_history()
+  scan_pi_sessions()
+  complete = scan_opencode_sessions()
+  return local_stats(), complete
+
+
+def cached_local_stats(max_age):
+  try:
+    return _cached_local_stats(max_age)
+  except Exception as exc:
+    print(f"omarchy-agent-usage-agy: cache unavailable ({exc}); scanning directly", file=sys.stderr)
+    stats, _ = run_local_scans()
+    return stats
+
+
+def _cached_local_stats(max_age):
+  cache_file, lock_file = scan_cache_paths()
+
+  cached = read_cached_stats(cache_file, max_age)
+  if cached is not None:
+    return cached
+
+  with lock_file.open("w") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    cached = read_cached_stats(cache_file, max_age)
+    if cached is not None:
+      return cached
+    stats, complete = run_local_scans()
+    if complete:
+      write_cached_stats(cache_file, stats)
+    return stats
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  args = parser.parse_args()
+
+  max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else SCAN_REUSE_SECONDS)
+  stats = cached_local_stats(max_age)
+
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "tierLabel": "Subscription",
+    "usageStatusText": "",
+    "authHelpText": AUTH_HELP,
+    "limits": [],
+    "updatedAt": datetime.now(timezone.utc).isoformat(),
+    "ready": True,
+    "hasLocalStats": True,
+  }
+  record.update(stats)
+  print(json.dumps(record, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+  main()

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -52,6 +52,7 @@ light surfaces — and the bar glyph stands in when there is none.
 
 | Collector | Limits | Local stats |
 |---|---|---|
+| `agy` | — | `~/.gemini/antigravity-cli/history.jsonl`, plus pi/omp and opencode sessions on a Google provider |
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |

--- a/test/shell.d/agent-usage-agy-scanner-test.sh
+++ b/test/shell.d/agent-usage-agy-scanner-test.sh
@@ -75,6 +75,31 @@ result=$(HOME="$OPENCODE_HOME" XDG_CACHE_HOME="$OPENCODE_HOME/.cache" XDG_DATA_H
   fail "Antigravity collector counts Google tokens from opencode database" "$result"
 pass "Antigravity collector merges opencode Google provider stats"
 
+# Pi and omp sessions with Google provider
+PI_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$OPENCODE_HOME" "$PI_HOME"' EXIT
+mkdir -p "$PI_HOME/.pi/agent/sessions/project" "$PI_HOME/.omp/agent/sessions/project"
+
+timestamp="$(date +%Y-%m-%d)T12:00:00Z"
+cat >"$PI_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF
+{"type":"message","id":"pi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"google","model":"gemini-pi","usage":{"input":15,"output":5,"cacheRead":2,"cacheWrite":1,"totalTokens":23}}}
+{"type":"message","id":"codex-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"openai-codex","model":"gpt-test","usage":{"input":999,"output":999}}}
+EOF
+cat >"$PI_HOME/.omp/agent/sessions/project/omp.jsonl" <<EOF
+{ "type": "message", "id": "omp-1", "timestamp": "$timestamp", "message": { "role": "assistant", "provider": "gemini", "model": "gemini-omp", "usage": { "input": 25, "output": 10, "cacheRead": 5, "cacheWrite": 2, "totalTokens": 42 } } }
+{ "type": "message", "id": "claude-1", "timestamp": "$timestamp", "message": { "role": "assistant", "provider": "anthropic", "model": "claude-test", "usage": { "input": 999, "output": 999 } } }
+EOF
+
+result=$(HOME="$PI_HOME" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-agy" --force)
+
+[[ $(jq -r '.modelUsage["gemini-pi"].inputTokens' <<<"$result") == "15" && \
+   $(jq -r '.modelUsage["gemini-omp"].inputTokens' <<<"$result") == "25" && \
+   $(jq -r '.modelUsage["claude-test"] // null' <<<"$result") == "null" && \
+   $(jq -r '.modelUsage["gpt-test"] // null' <<<"$result") == "null" ]] ||
+  fail "Antigravity collector filters pi and omp sessions to Google/Gemini providers" "$result"
+pass "Antigravity collector counts pi and omp Google subscription usage"
+
 # Concurrent write safety
 race_output=$(python3 - "$ROOT/bin/omarchy-agent-usage-agy" "$TEST_HOME/race.json" <<'PY'
 import importlib.util

--- a/test/shell.d/agent-usage-agy-scanner-test.sh
+++ b/test/shell.d/agent-usage-agy-scanner-test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+history_dir="$TEST_HOME/.gemini/antigravity-cli"
+mkdir -p "$history_dir"
+
+now_ms=$(($(date +%s) * 1000))
+cat >"$history_dir/history.jsonl" <<EOF
+{"timestamp":86400000,"conversationId":"old-session","display":"ancient prompt"}
+{"timestamp":$now_ms,"conversationId":"session-1","display":"prompt one"}
+{"timestamp":$now_ms,"conversationId":"session-2","display":"prompt two"}
+EOF
+
+result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-agy" --force)
+
+[[ $(jq -r '.id' <<<"$result") == "agy" ]] ||
+  fail "Antigravity collector identifies itself as agy" "$result"
+pass "Antigravity collector identifies itself"
+
+[[ $(jq -r '(.todayPrompts|tostring) + "/" + (.todaySessions|tostring)' <<<"$result") == "2/2" ]] ||
+  fail "Antigravity collector reads today prompts and sessions from history.jsonl" "$result"
+pass "Antigravity collector parses history.jsonl correctly"
+
+[[ $(jq -r '.ready' <<<"$result") == "true" ]] ||
+  fail "Antigravity collector marks ready as true when stats exist" "$result"
+pass "Antigravity collector reports ready state"
+
+# Opencode Google provider sessions
+OPENCODE_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$OPENCODE_HOME"' EXIT
+
+python3 - "$OPENCODE_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+db = Path(sys.argv[1])
+db.parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+now_ms = int(time.time() * 1000)
+
+def message(id, provider, model, role="assistant", input=0, output=0, reasoning=0, read=0, write=0):
+  return (id, "ses_1", now_ms, now_ms, json.dumps({
+    "role": role,
+    "providerID": provider,
+    "modelID": model,
+    "tokens": {"input": input, "output": output, "reasoning": reasoning, "cache": {"read": read, "write": write}},
+    "time": {"created": now_ms},
+  }))
+
+conn.executemany("INSERT INTO message VALUES (?, ?, ?, ?, ?)", [
+  message("msg_1", "google", "gemini-2.5-flash", input=200, output=100, reasoning=10, read=50, write=20),
+  message("msg_2", "openai", "gpt-5.2-codex", input=999, output=999),
+  message("msg_3", "google", "gemini-2.5-flash", role="user"),
+])
+conn.commit()
+conn.close()
+PY
+
+result=$(HOME="$OPENCODE_HOME" XDG_CACHE_HOME="$OPENCODE_HOME/.cache" XDG_DATA_HOME="$OPENCODE_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-agy" --force)
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "380" ]] ||
+  fail "Antigravity collector counts Google tokens from opencode database" "$result"
+pass "Antigravity collector merges opencode Google provider stats"
+
+# Concurrent write safety
+race_output=$(python3 - "$ROOT/bin/omarchy-agent-usage-agy" "$TEST_HOME/race.json" <<'PY'
+import importlib.util
+import json
+import sys
+import threading
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+spec = importlib.util.spec_from_loader("collector", SourceFileLoader("collector", sys.argv[1]))
+collector = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(collector)
+
+target = Path(sys.argv[2])
+failures = []
+start = threading.Barrier(8)
+
+def hammer(writer):
+  start.wait()
+  for round in range(25):
+    try:
+      collector.write_json(target, {"writer": writer, "round": round})
+    except Exception as error:
+      failures.append(repr(error))
+
+threads = [threading.Thread(target=hammer, args=(writer,)) for writer in range(8)]
+for thread in threads:
+  thread.start()
+for thread in threads:
+  thread.join()
+
+leftovers = sorted(path.name for path in target.parent.glob(target.name + ".*"))
+print(json.dumps({
+  "failures": failures[:3],
+  "mode": oct(target.stat().st_mode & 0o777),
+  "payload": json.loads(target.read_text(encoding="utf-8")),
+  "leftovers": leftovers,
+}))
+PY
+)
+
+[[ $(jq -c '.failures' <<<"$race_output") == "[]" ]] ||
+  fail "Antigravity collector survives concurrent writes to one cache file" "$race_output"
+[[ $(jq -r '.payload.writer != null and (.leftovers | length) == 0' <<<"$race_output") == "true" ]] ||
+  fail "Antigravity collector leaves one intact cache file and no temp files" "$race_output"
+[[ $(jq -r '.mode' <<<"$race_output") == "0o644" ]] ||
+  fail "Antigravity collector keeps cache files readable" "$race_output"
+pass "Antigravity collector survives concurrent writes to one cache file"


### PR DESCRIPTION
### Summary
This PR adds the missing `omarchy-agent-usage-agy` collector and test suite for the Antigravity (`agy`) coding agent, completing its integration with Omarchy's `omarchy.agents` status bar widget and panel.

### Changes
* **`bin/omarchy-agent-usage-agy`**: Implements the usage collector for Antigravity (`agy`). It extracts local prompt counts and session activity from `~/.gemini/antigravity-cli/history.jsonl`, merges Google/Gemini provider usage from OpenCode SQLite databases, and includes pi/omp Google sessions.
* **`test/shell.d/agent-usage-agy-scanner-test.sh`**: Adds automated test coverage verifying ID reporting, prompt/session parsing, OpenCode provider merging, and concurrent write resilience.
* **`shell/plugins/agents/README.md`**: Updates the agent collectors reference table to include `agy`.

Fixes #8477