### PR TITLE
Detect Broadcom fingerprint readers by vendor ID

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -8,7 +8,9 @@
 # ship fingerprint readers; multi-purpose vendors (e.g. Elan/STMicro, which
 # also make USB touchscreens) are left out to avoid nagging laptops with no
 # reader — those still match on the product string below when present.
-fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e "
+# Broadcom (0a5c) readers report a bare model number as their product string
+# (e.g. "58200"), so they only match here, never on the product-name branch.
+fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e 0a5c "
 usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
 
 # libfprint drives every reader it supports from userspace over libusb, so a

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -74,6 +74,9 @@ assert_detects "a reader is detected by an existing product-name match"
 write_usb_devices '27c6:1234'
 assert_detects "a reader is detected by an existing vendor match"
 
+write_usb_devices '0a5c:5843:58200'
+assert_detects "a Broadcom reader is detected by vendor match despite a non-descriptive product string"
+
 bind_driver() {
   local dev="$1" driver="$2"
 


### PR DESCRIPTION
## Summary

- `omarchy-hw-fingerprint`'s vendor allowlist doesn't include Broadcom (`0a5c`), so Broadcom fingerprint readers are never detected — the wizard bails with "No fingerprint sensor detected" even though `fprintd`/`libfprint-tod` fully support the device once installed.
- Broadcom readers report a bare model number as their `product` string (e.g. `"58200"`), so they can't fall back to the product-name match either — they only match on vendor ID.
- Adds `0a5c` to `fingerprint_vendors` and a regression test mirroring the existing vendor-match coverage.

Fixes #8483

## Test plan

- [x] `./test/shell.d/hw-fingerprint-test.sh` — all cases pass, including the new Broadcom case
- [x] `./test/all` — same 5 pre-existing failures as on a clean `quattro` checkout (environment-dependent: missing `omarchy-pkgs` checkout, sandbox permission bits, `snapper`/pacman DB access), unrelated to this change
- [x] Verified on hardware: a Broadcom sensor (`idVendor=0a5c`, `idProduct=5843`) at `/sys/bus/usb/devices/3-8`, previously rejected by the detector, now passes; ran the full `omarchy setup security fingerprint` flow end to end (enroll, verify, PAM for sudo/polkit/lock screen) successfully with this fix applied.
