### PR TITLE
Keep wired Xbox controllers working with xpadneo

### DIFF
--- a/bin/omarchy-install-gaming-xbox-controllers
+++ b/bin/omarchy-install-gaming-xbox-controllers
@@ -12,8 +12,7 @@ echo "Installing Xbox controller Bluetooth support..."
 # Install xpadneo to ensure controllers work out of the box
 omarchy-pkg-add linux-headers xpadneo-dkms
 
-# Prevent xpad/xpadneo driver conflict
-echo blacklist xpad | sudo tee /etc/modprobe.d/blacklist-xpad.conf >/dev/null
+# Load xpadneo for Bluetooth controllers while keeping xpad available for USB controllers
 echo hid_xpadneo | sudo tee /etc/modules-load.d/xpadneo.conf >/dev/null
 
 # Ensure user is in the input group (controllers need it)
@@ -21,11 +20,6 @@ needs_reboot=false
 if ! id -nG "$USER" | grep -qw input; then
   sudo usermod -aG input "$USER"
   needs_reboot=true
-fi
-
-# Swap drivers in the running kernel so a reboot isn't needed otherwise
-if lsmod | grep -q '^xpad '; then
-  sudo modprobe -r xpad 2>/dev/null || needs_reboot=true
 fi
 
 if $needs_reboot; then

--- a/bin/omarchy-remove-gaming-xbox-controllers
+++ b/bin/omarchy-remove-gaming-xbox-controllers
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Remove the xpadneo Xbox controller driver and undo its module/blacklist config.
+# omarchy:summary=Remove the xpadneo Xbox controller driver and its module config.
 # omarchy:group=remove
 # omarchy:name=gaming xbox-controllers
 # omarchy:requires-sudo=true
@@ -9,7 +9,12 @@ set -e
 
 omarchy-pkg-drop xpadneo-dkms
 
-sudo rm -f /etc/modprobe.d/blacklist-xpad.conf /etc/modules-load.d/xpadneo.conf
+legacy_blacklist=/etc/modprobe.d/blacklist-xpad.conf
+if [[ -f $legacy_blacklist && $(<"$legacy_blacklist") == "blacklist xpad" ]]; then
+  sudo rm -f -- "$legacy_blacklist"
+fi
+
+sudo rm -f -- /etc/modules-load.d/xpadneo.conf
 
 echo ""
-echo "Xbox controller support removed. Reboot to fully unload xpadneo and restore xpad."
+echo "Xbox controller Bluetooth support removed. Reboot to fully unload xpadneo."

--- a/migrations/1787689809.sh
+++ b/migrations/1787689809.sh
@@ -1,0 +1,8 @@
+echo "Restore wired Xbox controller support alongside xpadneo"
+
+legacy_blacklist="${OMARCHY_XPAD_BLACKLIST:-/etc/modprobe.d/blacklist-xpad.conf}"
+
+if omarchy-pkg-present xpadneo-dkms && [[ -f $legacy_blacklist ]] && [[ $(<"$legacy_blacklist") == "blacklist xpad" ]]; then
+  sudo rm -f -- "$legacy_blacklist"
+  sudo modprobe xpad
+fi

--- a/test/shell.d/xbox-controller-driver-test.sh
+++ b/test/shell.d/xbox-controller-driver-test.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+installer="$ROOT/bin/omarchy-install-gaming-xbox-controllers"
+migration="$ROOT/migrations/1787689809.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+stub_bin="$test_dir/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/omarchy-pkg-add" <<'STUB'
+#!/bin/bash
+printf 'omarchy-pkg-add %s\n' "$*" >>"$CALLS"
+STUB
+
+cat >"$stub_bin/omarchy-pkg-present" <<'STUB'
+#!/bin/bash
+[[ $1 == "xpadneo-dkms" && ${XPADNEO_INSTALLED:-1} == 1 ]]
+STUB
+
+cat >"$stub_bin/id" <<'STUB'
+#!/bin/bash
+printf 'tester input\n'
+STUB
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$CALLS"
+
+case "$1" in
+  rm)
+    exec "$@"
+    ;;
+  tee)
+    cat >/dev/null
+    ;;
+esac
+STUB
+
+chmod +x "$stub_bin/"*
+export CALLS="$test_dir/calls"
+
+: >"$CALLS"
+USER=tester PATH="$stub_bin:$PATH" bash "$installer" >/dev/null
+
+grep -qx 'omarchy-pkg-add linux-headers xpadneo-dkms' "$CALLS" ||
+  fail "Xbox controller installer installs xpadneo" "$(cat "$CALLS")"
+grep -qx 'sudo tee /etc/modules-load.d/xpadneo.conf' "$CALLS" ||
+  fail "Xbox controller installer enables xpadneo at boot" "$(cat "$CALLS")"
+grep -qx 'sudo modprobe hid_xpadneo' "$CALLS" ||
+  fail "Xbox controller installer loads xpadneo now" "$(cat "$CALLS")"
+pass "Xbox controller installer configures Bluetooth support"
+
+if grep -Eq 'blacklist-xpad|modprobe -r xpad' "$CALLS"; then
+  fail "Xbox controller installer keeps the USB xpad driver available" "$(cat "$CALLS")"
+fi
+pass "Xbox controller installer keeps the USB xpad driver available"
+
+run_migration() {
+  local blacklist="$1"
+
+  : >"$CALLS"
+  OMARCHY_XPAD_BLACKLIST="$blacklist" PATH="$stub_bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+blacklist="$test_dir/blacklist-xpad.conf"
+printf 'blacklist xpad\n' >"$blacklist"
+run_migration "$blacklist"
+
+[[ ! -e $blacklist ]] || fail "migration removes Omarchy's legacy xpad blacklist"
+grep -qx "sudo modprobe xpad" "$CALLS" ||
+  fail "migration loads the restored USB driver" "$(cat "$CALLS")"
+pass "migration restores wired Xbox controller support"
+
+run_migration "$blacklist"
+[[ ! -s $CALLS ]] || fail "migration no-ops after the blacklist is gone" "$(cat "$CALLS")"
+pass "migration is idempotent"
+
+printf 'blacklist xpad\noptions xpad auto_poweroff=1\n' >"$blacklist"
+run_migration "$blacklist"
+
+[[ -f $blacklist ]] || fail "migration keeps a customized xpad configuration"
+[[ ! -s $CALLS ]] || fail "migration leaves customized xpad configuration untouched" "$(cat "$CALLS")"
+pass "migration keeps customized xpad configuration"
+
+printf 'blacklist xpad\n' >"$blacklist"
+: >"$CALLS"
+XPADNEO_INSTALLED=0 OMARCHY_XPAD_BLACKLIST="$blacklist" PATH="$stub_bin:$PATH" \
+  bash -euo pipefail "$migration" >/dev/null
+
+[[ -f $blacklist ]] || fail "migration keeps an unrelated xpad blacklist without xpadneo"
+[[ ! -s $CALLS ]] || fail "migration no-ops without xpadneo" "$(cat "$CALLS")"
+pass "migration only repairs xpadneo installations"


### PR DESCRIPTION
## Summary

- keep the stock `xpad` USB driver available when installing `xpadneo` Bluetooth support
- migrate existing installs by removing only the exact legacy blacklist Omarchy generated, then load `xpad`
- preserve customized and unrelated xpad blacklists and add regression coverage

Fixes #7073.

## Testing

- `bash test/shell.d/xbox-controller-driver-test.sh`
- `./test/cli`
- `./test/all` (the Xbox test passes; the aggregate remains red on five unrelated environment/existing failures: missing `omarchy-pkgs` coverage in three tests, `launch-about-test.sh`, and a live-session `runtime-smoke-test.sh` IPC count)