### PR TITLE
Install both Intel VA-API drivers instead of guessing by GPU name

### DIFF
--- a/install/hardware/intel/video-acceleration.sh
+++ b/install/hardware/intel/video-acceleration.sh
@@ -1,11 +1,13 @@
-# This installs hardware video acceleration for Intel GPUs
-
-if INTEL_GPU=$(lspci | grep -iE 'vga|3d|display' | grep -i 'intel'); then
-  # HD Graphics / Iris / Xe / Arc / Non-Arc Panther Lake use intel-media-driver + VPL
-  if [[ ${INTEL_GPU,,} =~ (hd\ graphics|uhd\ graphics|xe|iris|arc|panther\ lake) ]]; then
-    omarchy-pkg-add intel-media-driver libvpl vpl-gpu-rt
-  elif [[ ${INTEL_GPU,,} =~ "gma" ]]; then
-    # Older generations from 2008 to ~2014-2017 use libva-intel-driver
-    omarchy-pkg-add libva-intel-driver
-  fi
+# This installs hardware video acceleration for Intel GPUs.
+#
+# GPU generation can't be reliably told apart from the lspci name alone: "HD
+# Graphics" is Intel's marketing name for both Gen7 (Ivy Bridge, needs the i965
+# driver) and Gen8+ (Broadwell and later, needs iHD), and some older
+# generations (Ironlake, Sandy Bridge, Haswell-ULT) don't say "HD Graphics" or
+# "gma" at all, so they matched neither branch here and got no driver.
+# Rather than chase the naming with a generation table, install both drivers;
+# libva probes them in order at runtime and uses whichever one initializes for
+# the GPU it finds, so this is correct on every generation without a table.
+if lspci | grep -iE 'vga|3d|display' | grep -qi 'intel'; then
+  omarchy-pkg-add intel-media-driver libva-intel-driver libvpl vpl-gpu-rt
 fi

--- a/install/hardware/intel/video-acceleration.sh
+++ b/install/hardware/intel/video-acceleration.sh
@@ -8,6 +8,6 @@
 # Rather than chase the naming with a generation table, install both drivers;
 # libva probes them in order at runtime and uses whichever one initializes for
 # the GPU it finds, so this is correct on every generation without a table.
-if lspci | grep -iE 'vga|3d|display' | grep -qi 'intel'; then
+if lspci | grep -iE 'VGA compatible controller|3D controller|Display controller' | grep -qi 'intel'; then
   omarchy-pkg-add intel-media-driver libva-intel-driver libvpl vpl-gpu-rt
 fi

--- a/migrations/1787689809.sh
+++ b/migrations/1787689809.sh
@@ -9,6 +9,6 @@ echo "Install libva-intel-driver alongside intel-media-driver for Intel GPU vide
 # that fails to initialize (or none), and this repair doesn't run itself, so
 # bring them in line with the new install-time behavior: install both
 # drivers and let libva pick the one that actually works for the GPU present.
-if lspci | grep -iE 'vga|3d|display' | grep -qi 'intel'; then
+if lspci | grep -iE 'VGA compatible controller|3D controller|Display controller' | grep -qi 'intel'; then
   omarchy-pkg-add intel-media-driver libva-intel-driver libvpl vpl-gpu-rt
 fi

--- a/migrations/1787689809.sh
+++ b/migrations/1787689809.sh
@@ -1,0 +1,14 @@
+echo "Install libva-intel-driver alongside intel-media-driver for Intel GPU video acceleration"
+
+# install/hardware/intel/video-acceleration.sh used to pick a single VA-API
+# driver by matching the GPU's marketing name from lspci. "HD Graphics" names
+# both Gen7 (Ivy Bridge, needs libva-intel-driver/i965) and Gen8+ (Broadwell+,
+# needs intel-media-driver/iHD) parts, and some older generations (Ironlake,
+# Sandy Bridge, Haswell-ULT) matched neither branch and got no driver at all.
+# Existing installs on the wrong side of that regex are left with a driver
+# that fails to initialize (or none), and this repair doesn't run itself, so
+# bring them in line with the new install-time behavior: install both
+# drivers and let libva pick the one that actually works for the GPU present.
+if lspci | grep -iE 'vga|3d|display' | grep -qi 'intel'; then
+  omarchy-pkg-add intel-media-driver libva-intel-driver libvpl vpl-gpu-rt
+fi

--- a/test/shell.d/intel-video-acceleration-test.sh
+++ b/test/shell.d/intel-video-acceleration-test.sh
@@ -58,6 +58,15 @@ run_leaf "00:02.0 VGA compatible controller: NVIDIA Corporation GA104M"
 [[ -s $call_log ]] && fail "the leaf no-ops on non-Intel GPUs"
 pass "the leaf no-ops on non-Intel GPUs"
 
+# A PCI bus address like "3d:00.0" contains "3d" as plain text, and an
+# unrelated Intel device sitting at that address (not a GPU) also contains
+# "Intel" in its description. Detection has to key off the actual PCI class
+# name, not a bare substring, or a device like this triggers installing the
+# video-acceleration stack for no GPU at all.
+run_leaf "3d:00.0 Non-Volatile memory controller: Intel Corporation NVMe SSD Controller"
+[[ -s $call_log ]] && fail "the leaf no-ops on a non-GPU Intel device at a bus address containing 3d"
+pass "the leaf no-ops on a non-GPU Intel device at a bus address containing 3d"
+
 run_migration() {
   : >"$call_log"
   PATH="$test_tmp/bin:$PATH" \
@@ -74,3 +83,7 @@ pass "the migration brings existing Intel installs onto both VA-API drivers"
 run_migration "00:02.0 VGA compatible controller: NVIDIA Corporation GA104M"
 [[ -s $call_log ]] && fail "the migration no-ops on non-Intel GPUs"
 pass "the migration no-ops on non-Intel GPUs"
+
+run_migration "3d:00.0 Non-Volatile memory controller: Intel Corporation NVMe SSD Controller"
+[[ -s $call_log ]] && fail "the migration no-ops on a non-GPU Intel device at a bus address containing 3d"
+pass "the migration no-ops on a non-GPU Intel device at a bus address containing 3d"

--- a/test/shell.d/intel-video-acceleration-test.sh
+++ b/test/shell.d/intel-video-acceleration-test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/intel/video-acceleration.sh"
+migration=$(grep -l 'intel-media-driver libva-intel-driver' "$ROOT"/migrations/*.sh | head -1)
+
+[[ -n $migration ]] || fail "a migration brings existing installs onto both VA-API drivers"
+pass "a migration brings existing installs onto both VA-API drivers"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+
+cat >"$test_tmp/bin/lspci" <<'SH'
+#!/bin/bash
+printf '%s\n' "${TEST_LSPCI_LINE:-00:02.0 VGA compatible controller: Intel Corporation Ivy Bridge mobile GT2 [HD Graphics 4000] (rev 09)}"
+SH
+
+cat >"$test_tmp/bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg-add %s\n' "$*" >>"$CALL_LOG"
+SH
+
+chmod +x "$test_tmp/bin"/*
+
+call_log="$test_tmp/calls.log"
+
+run_leaf() {
+  : >"$call_log"
+  PATH="$test_tmp/bin:$PATH" \
+    CALL_LOG="$call_log" \
+    TEST_LSPCI_LINE="${1-}" \
+    bash -c 'source "$1"' bash "$leaf"
+}
+
+# Ivy Bridge "HD Graphics 4000" used to match the same name-based branch as
+# Broadwell+ and get only intel-media-driver, which can't decode on Gen7 and
+# leaves vaInitialize failing outright (confirmed on real Ivy Bridge hardware
+# in basecamp/omarchy#7866). Installing both drivers means libva's own
+# fallback probing picks the one that actually initializes, regardless of
+# generation.
+run_leaf
+grep -q 'pkg-add intel-media-driver libva-intel-driver libvpl vpl-gpu-rt' "$call_log" ||
+  fail "the leaf installs both VA-API drivers on Ivy Bridge HD Graphics 4000"
+pass "the leaf installs both VA-API drivers on Ivy Bridge HD Graphics 4000"
+
+# Haswell-ULT and other older parts that don't say "HD Graphics" or "gma" at
+# all used to match neither branch and got no driver installed.
+run_leaf "00:02.0 VGA compatible controller: Intel Corporation Haswell-ULT Integrated Graphics Controller (rev 0b)"
+grep -q 'pkg-add intel-media-driver libva-intel-driver libvpl vpl-gpu-rt' "$call_log" ||
+  fail "the leaf installs both VA-API drivers on hardware with no name match"
+pass "the leaf installs both VA-API drivers on hardware with no name match"
+
+run_leaf "00:02.0 VGA compatible controller: NVIDIA Corporation GA104M"
+[[ -s $call_log ]] && fail "the leaf no-ops on non-Intel GPUs"
+pass "the leaf no-ops on non-Intel GPUs"
+
+run_migration() {
+  : >"$call_log"
+  PATH="$test_tmp/bin:$PATH" \
+    CALL_LOG="$call_log" \
+    TEST_LSPCI_LINE="${1-}" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration
+grep -q 'pkg-add intel-media-driver libva-intel-driver libvpl vpl-gpu-rt' "$call_log" ||
+  fail "the migration brings existing Intel installs onto both VA-API drivers"
+pass "the migration brings existing Intel installs onto both VA-API drivers"
+
+run_migration "00:02.0 VGA compatible controller: NVIDIA Corporation GA104M"
+[[ -s $call_log ]] && fail "the migration no-ops on non-Intel GPUs"
+pass "the migration no-ops on non-Intel GPUs"


### PR DESCRIPTION
## Problem

`install/hardware/intel/video-acceleration.sh` picks a single VA-API driver by pattern-matching the GPU's marketing name from `lspci`:

```bash
if [[ ${INTEL_GPU,,} =~ (hd\ graphics|uhd\ graphics|xe|iris|arc|panther\ lake) ]]; then
  omarchy-pkg-add intel-media-driver libvpl vpl-gpu-rt   # intended for Broadwell+ (Gen8+)
elif [[ ${INTEL_GPU,,} =~ "gma" ]]; then
  omarchy-pkg-add libva-intel-driver                      # intended for Sandy/Ivy Bridge
fi
```

This misclassifies real hardware:

- **Wrong driver, not just suboptimal.** Intel reused "HD Graphics" as the marketing name for both Gen7 (Ivy Bridge, needs `libva-intel-driver`/i965) and Gen8+ (Broadwell+, needs `intel-media-driver`/iHD). Ivy Bridge's lspci string (`Ivy Bridge mobile GT2 [HD Graphics 4000]`) matches the first branch and installs a driver that can't decode on Gen7 hardware at all.
- **No driver at all for some generations.** Ironlake, Sandy Bridge HD 2000/3000, and Haswell-ULT lspci strings don't contain "HD Graphics" or "gma", so they match neither branch and get nothing installed.
- **The `xe` pattern also matches "Xeon"**, which is presumably unintended and happens to route some Xeon-graphics strings into the Broadwell+ branch too.

Fixes #7866. #8388 independently identified the same misclassification on Haswell/Iris 5100 (its "Secondary: driver selection on Haswell" section) — this PR fixes that part too. #8388's primary problem, offline installs getting no VA-API driver at all because the packages aren't in the ISO's offline mirror and the script has no `set -e` to surface the failure, is a separate issue and is not addressed here.

## Fix

Install both `intel-media-driver` and `libva-intel-driver` (with `libvpl`/`vpl-gpu-rt`) whenever any Intel GPU is present, instead of picking one by name:

```bash
if lspci | grep -iE 'vga|3d|display' | grep -qi 'intel'; then
  omarchy-pkg-add intel-media-driver libva-intel-driver libvpl vpl-gpu-rt
fi
```

### Why install both instead of fixing the classification

The obvious "proper" fix looks like replacing the name regex with a GPU-generation table. I didn't do that, on purpose:

- **libva already does exactly this job at runtime.** It tries drivers in order and falls through to the first one that initializes for the hardware present. A generation table would just be reimplementing that logic at install time, worse — since it can go stale.
- **A generation table has its own edge cases that undercut the "fix it properly" case.** Cherryview/Braswell is Gen8 but isn't supported by iHD, so a clean "Gen8+ → iHD" rule is already wrong without a carve-out. Getting this fully right would mean auditing and maintaining the full Intel iGPU generation list, including future SKUs, indefinitely.
- **The cost of installing both is one small extra package** (`libva-intel-driver` is ~2.4MB) versus a correctness-critical script staying in a state where it's plausible to get subtly wrong again for the next naming surprise.

In short: matching on marketing names to *predict* which driver will work is inherently fragile, when we can just *ask* — install candidates and let libva's own probing decide. This trades a small amount of disk for driver selection that's correct on every past and future Intel generation without needing to track Intel's naming history.

## Verification

Reproduced and fixed on real hardware — a Dell Latitude E6430s (Intel Core i7-3520M, Ivy Bridge, HD Graphics 4000):

**Before** (only `intel-media-driver` installed, matching current `main` behavior):
```
$ vainfo
libva error: /usr/lib/dri/iHD_drv_video.so init failed
vaInitialize failed with error code -1 (unknown libva error), exit
```

**After** (`libva-intel-driver` installed alongside it):
```
$ vainfo
libva error: /usr/lib/dri/iHD_drv_video.so init failed
vainfo: VA-API version: 1.24 (libva 2.24.0)
vainfo: Driver version: Intel i965 driver for Intel(R) Ivybridge Mobile - 2.4.5
vainfo: Supported profile and entrypoints
      VAProfileMPEG2Simple            :    VAEntrypointVLD
      ...
      VAProfileH264High               :    VAEntrypointVLD
      ...
```

libva logs the iHD init failure (harmless) and falls through to i965, which initializes correctly with the full expected profile list.

## Existing installs

Added `migrations/1787689809.sh` so machines that already ran the old install-time logic pick up `libva-intel-driver` too, since this repair doesn't apply itself.

## Testing

Added `test/shell.d/intel-video-acceleration-test.sh` covering: both drivers installed on an Ivy Bridge HD Graphics 4000 string, both drivers installed on a Haswell-ULT string that previously matched neither branch, no-op on non-Intel GPUs, and the same coverage for the migration. Ran the full `./test/all` suite; 5 pre-existing failures remain (all due to a missing local `omarchy-pkgs` checkout in this sandbox) and reproduce identically on a clean checkout of `quattro` with no changes applied — none touch this code path.

---

This PR was prepared with AI assistance (Claude Code), including reproducing the bug on real Ivy Bridge hardware before and after the fix, per this project's documented AI-assisted contribution workflow.
