### PR TITLE
Stop the agents status card rendering as an empty box

### DIFF
--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -509,7 +509,11 @@ Panel {
               anchors.verticalCenter: parent.verticalCenter
               anchors.leftMargin: Style.space(12)
               anchors.rightMargin: Style.space(12)
-              text: root.provider ? String(root.provider.authHelpText || "") : ""
+              // The card is gated on usageStatusText, but the remedy in
+              // authHelpText is the better message when a collector offers
+              // one. A record can carry a status with no auth advice to give,
+              // so fall back to the status rather than render an empty box.
+              text: root.provider ? String(root.provider.authHelpText || root.provider.usageStatusText || "") : ""
               color: root.dim
               font.family: root.fontFamily
               font.pixelSize: Style.font.caption

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -14,4 +14,5 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+assert(/text: root\.provider \? String\(root\.provider\.authHelpText \|\| root\.provider\.usageStatusText \|\| ""\) : ""/.test(panelSource), 'status card falls back to the usage status when a record has no auth help')
 JS


### PR DESCRIPTION
The status card in the agents panel gates its visibility on `usageStatusText` but draws `authHelpText` (Panel.qml lines 498 and 512 before this change). A record that carries a status with no auth help renders the card as an empty urgent-tinted box.

The combination is reachable through the documented collector contract. The plugin README says adding an agent never touches the plugin: ship a collector and the panel gains a tab. An agent whose provider publishes no quota endpoint has a real status to report but no sign-in advice to go with it. The in-tree collectors happen to set both fields together or neither, which is why the empty box never shows up in stock.

Moving the gate to `authHelpText` instead would be wrong: the Claude collector's healthy path returns an empty status while `authHelpText` still holds the default sign-in hint, so gating on the help text would put an urgent card on every healthy Claude tab. Instead the drawn text now falls back to the status, so the card always has words in it and every current in-tree record renders exactly as it did before.

Before and after, with a record that has `usageStatusText` set and `authHelpText` empty:

![before](https://raw.githubusercontent.com/tsouth89/omarchy/pr-assets/agents-status-card/agents-card-before.png)
![after](https://raw.githubusercontent.com/tsouth89/omarchy/pr-assets/agents-status-card/agents-card-after.png)

Fixes #8445

## Tests

- `bash test/shell.d/agents-panel-test.sh` covers the fallback with a new assertion
- `./test/shell` passes apart from 6 files that fail identically on a clean quattro checkout in my environment
- verified in the running shell, screenshots above
