### PR TITLE
[Security] Keep the menu password change on user and root together

### DIFF
--- a/bin/omarchy-user-password
+++ b/bin/omarchy-user-password
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Set a new password for the login user and for root
+# omarchy:requires-sudo=true
+# omarchy:examples=omarchy user password
+
+set -euo pipefail
+
+user="${USER:-$(id -un)}"
+
+new_password=$(gum input --password --header "New password (user and root)") || exit 1
+[[ -n $new_password ]] || { echo "Password cannot be empty."; exit 1; }
+
+confirmation=$(gum input --password --header "Confirm new password") || exit 1
+[[ $new_password == "$confirmation" ]] || { echo "Passwords do not match."; exit 1; }
+
+# Install sets user and root to the same password. The menu used to run
+# `passwd`, which only updates the login account and leaves the old root
+# password live for `su` and a TTY login.
+printf '%s:%s\n%s:%s\n' "$user" "$new_password" root "$new_password" | sudo chpasswd

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -364,5 +364,5 @@
   "update.hardware.bluetooth": {"icon":"󰂯","label":"Bluetooth","action":"omarchy-launch-floating-terminal-with-presentation omarchy-restart-bluetooth"},
   "update.hardware.trackpad": {"icon":"󰟸","label":"Trackpad","action":"omarchy-launch-floating-terminal-with-presentation omarchy-restart-trackpad"},
   "update.password.drive": {"icon":"","label":"Drive Encryption","action":"omarchy-launch-floating-terminal-with-presentation omarchy-drive-password"},
-  "update.password.user": {"icon":"","label":"User","action":"omarchy-launch-floating-terminal-with-presentation passwd"},
+  "update.password.user": {"icon":"","label":"User and root","action":"omarchy-launch-floating-terminal-with-presentation omarchy-user-password"},
 }

--- a/test/shell.d/user-password-test.sh
+++ b/test/shell.d/user-password-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -r "$tmp_dir"' EXIT
+
+cat >"$tmp_dir/gum" <<'EOF'
+#!/bin/bash
+IFS= read -r line <"$TEST_INPUTS"
+tail -n +2 "$TEST_INPUTS" >"$TEST_INPUTS.next"
+mv "$TEST_INPUTS.next" "$TEST_INPUTS"
+printf '%s\n' "$line"
+EOF
+
+cat >"$tmp_dir/sudo" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$@" >"$TEST_ARGS"
+cat >"$TEST_STDIN"
+EOF
+
+chmod +x "$tmp_dir/gum" "$tmp_dir/sudo"
+export PATH="$tmp_dir:$ROOT/bin:$PATH"
+export USER=tester
+export TEST_ARGS="$tmp_dir/args" TEST_INPUTS="$tmp_dir/inputs" TEST_STDIN="$tmp_dir/stdin"
+
+printf '\n' >"$TEST_INPUTS"
+if "$ROOT/bin/omarchy-user-password" >/dev/null; then
+  fail "user password rejects an empty passphrase"
+fi
+[[ ! -e $TEST_ARGS ]] || fail "user password does not run chpasswd for an empty passphrase"
+
+printf 'secret123\n*\n' >"$TEST_INPUTS"
+if "$ROOT/bin/omarchy-user-password" >/dev/null; then
+  fail "user password rejects a mismatched confirmation"
+fi
+[[ ! -e $TEST_ARGS ]] || fail "user password does not run chpasswd for a mismatched confirmation"
+
+printf 'new password\nnew password\n' >"$TEST_INPUTS"
+"$ROOT/bin/omarchy-user-password" >/dev/null
+
+[[ $(<"$TEST_ARGS") == "chpasswd" ]] || fail "user password runs chpasswd" "$(cat "$TEST_ARGS")"
+[[ $(<"$TEST_STDIN") == $'tester:new password\nroot:new password' ]] ||
+  fail "user password sets the same passphrase on the login user and on root" "$(cat "$TEST_STDIN")"
+pass "user password rejects empty and mismatched passphrases and updates user and root together"
+
+grep -Fq 'omarchy-user-password' "$ROOT/default/omarchy/omarchy-menu.jsonc" ||
+  fail "password menu updates user and root through omarchy-user-password"
+if grep -Fq 'omarchy-launch-floating-terminal-with-presentation passwd' "$ROOT/default/omarchy/omarchy-menu.jsonc"; then
+  fail "password menu no longer runs passwd alone"
+fi
+pass "password menu points at omarchy-user-password"


### PR DESCRIPTION
Fixes #7539.

Install sets the login user and root to the same password. Update → Password → User still runs `passwd`, which only changes the login account, so `su` and a root TTY keep the old one.

This replaces that menu action with `omarchy-user-password`, which prompts once and feeds both names to `chpasswd`.

## Verification

`test/shell.d/user-password-test.sh`:

```
ok - user password rejects empty and mismatched passphrases and updates user and root together
ok - password menu points at omarchy-user-password
```

The first case stubs `gum` and `sudo` and checks `chpasswd` stdin is `tester:new password` then `root:new password`. Empty and mismatched confirmations never invoke `chpasswd`. The second case asserts the menu no longer launches `passwd` alone.
