### PR TITLE
Fix the Dropbox login button never opening the account link

### DIFF
--- a/shell/plugins/panels/dropbox/Service.qml
+++ b/shell/plugins/panels/dropbox/Service.qml
@@ -85,6 +85,9 @@ Item {
     quotaKnown = parsed.quotaKnown === true
     files = parsed.files || []
     lastError = ""
+    // While a login attempt is pending, the poll doubles as the URL source:
+    // dropbox-cli status prints the same account-link URL start should have.
+    if (loginRetry.running) openAuthUrlFrom(statusText)
   }
 
   function elideStatus(text) {
@@ -93,11 +96,18 @@ Item {
   }
 
   function login() {
-    if (!installed || loginProcess.running) return
+    // Middle-click reaches here even on a linked account; there is no link
+    // URL to wait for then, so don't start a retry that can only end in a
+    // spurious error.
+    if (!installed || authenticated || loginProcess.running) return
     _loginOutput = ""
     _loginError = ""
     _loginUrlOpened = false
     actionStatus = "Starting Dropbox login…"
+    // A single start invocation often misses the link URL (see loginRetry),
+    // so the status poll keeps looking for it after the process exits.
+    loginRetry.ticks = 0
+    loginRetry.restart()
     loginProcess.command = ["dropbox-cli", "start"]
     loginProcess.running = true
   }
@@ -142,6 +152,7 @@ Item {
     var match = String(text || "").match(/https?:\/\/\S+/)
     if (match && match[0]) {
       _loginUrlOpened = true
+      loginRetry.stop()
       Qt.openUrlExternally(match[0])
       actionStatus = "Opened Dropbox login"
       actionStatusTimer.restart()
@@ -217,6 +228,30 @@ Item {
     }
   }
 
+  Timer {
+    // dropbox-cli start waits on the daemon's pidfile, not its command
+    // socket, so on a cold start it asks for the account-link URL before the
+    // daemon can answer and prints Done! without it. The same URL comes back
+    // from dropbox-cli status once the socket is up, so keep polling for a
+    // while instead of trusting the one-shot output — and if it never shows,
+    // say so instead of leaving "Starting Dropbox login…" up forever.
+    id: loginRetry
+    property int ticks: 0
+    interval: 2000
+    repeat: true
+    running: false
+    onTriggered: {
+      ticks += 1
+      if (ticks >= 15) {
+        loginRetry.stop()
+        root.actionStatus = ""
+        root.lastError = "Dropbox offered no login link. Pause and resume Dropbox, then try again."
+        return
+      }
+      root.refresh()
+    }
+  }
+
   Process {
     id: statusProcess
     running: false
@@ -242,11 +277,9 @@ Item {
       var combined = String(root._loginOutput || "") + "\n" + String(root._loginError || "")
       var opened = root.openAuthUrlFrom(combined)
       if (exitCode !== 0 && !opened) {
+        loginRetry.stop()
         root.lastError = root.elideStatus(combined || "Dropbox login failed")
         root.actionStatus = root.lastError
-      } else if (!opened) {
-        root.actionStatus = ""
-        root.lastError = ""
       }
       delayedRefresh.restart()
     }

--- a/shell/plugins/panels/dropbox/Service.qml
+++ b/shell/plugins/panels/dropbox/Service.qml
@@ -244,8 +244,11 @@ Item {
       ticks += 1
       if (ticks >= 15) {
         loginRetry.stop()
-        root.actionStatus = ""
+        // Set actionStatus too, the way controlProcess reports failures: a
+        // poll can still be in flight when this fires, and applyStatus
+        // clears lastError, which would wipe the advice within seconds.
         root.lastError = "Dropbox offered no login link. Pause and resume Dropbox, then try again."
+        root.actionStatus = root.lastError
         return
       }
       root.refresh()

--- a/shell/plugins/panels/dropbox/status.py
+++ b/shell/plugins/panels/dropbox/status.py
@@ -94,7 +94,10 @@ def main():
   account_path = account.get("path") if isinstance(account.get("path"), str) else ""
   plan = account.get("subscription_type") if isinstance(account.get("subscription_type"), str) else ""
   quota = PLAN_QUOTAS.get(plan.lower(), 0)
-  authenticated = account_path != "" and Path(account_path).exists()
+  # The account block in info.json appears the moment linking completes; the
+  # sync folder only appears once the first sync starts. Gating on the folder
+  # kept a freshly linked account on the login screen.
+  authenticated = bool(account)
 
   running = False
   status_text = "Not installed"

--- a/test/shell.d/dropbox-test.sh
+++ b/test/shell.d/dropbox-test.sh
@@ -32,3 +32,50 @@ assertEqual(
   'dropbox file metadata includes relative time and folder'
 )
 JS
+
+run_node_test "dropbox login retry wiring" <<'JS'
+const fs = require('fs')
+const service = fs.readFileSync(root + '/shell/plugins/panels/dropbox/Service.qml', 'utf8')
+
+assert(/function login\(\)[^}]*loginRetry\.restart\(\)/s.test(service), 'login starts the status-poll retry for the link URL')
+assert(/if \(loginRetry\.running\) openAuthUrlFrom\(statusText\)/.test(service), 'status poll feeds the pending login the link URL')
+assert(/Dropbox offered no login link/.test(service), 'an exhausted login retry surfaces an error instead of hanging')
+JS
+
+# The account block in info.json marks a linked account; the sync folder only
+# appears once the first sync starts. A freshly linked account must not read as
+# unauthenticated in that window.
+require_command python3
+require_command jq
+
+DROPBOX_HOME=$(mktemp -d)
+trap 'rm -rf "$DROPBOX_HOME"' EXIT
+
+STUB_BIN="$DROPBOX_HOME/bin"
+mkdir -p "$STUB_BIN" "$DROPBOX_HOME/.dropbox"
+cat >"$STUB_BIN/dropbox-cli" <<'EOF'
+#!/bin/bash
+echo "Starting..."
+EOF
+chmod +x "$STUB_BIN/dropbox-cli"
+
+cat >"$DROPBOX_HOME/.dropbox/info.json" <<EOF
+{"personal": {"path": "$DROPBOX_HOME/Dropbox", "subscription_type": "basic"}}
+EOF
+
+result=$(HOME="$DROPBOX_HOME" PATH="$STUB_BIN:$PATH" python3 "$ROOT/shell/plugins/panels/dropbox/status.py" 5)
+
+[[ $(jq -r '.authenticated' <<<"$result") == "true" ]] ||
+  fail "dropbox status reports a linked account before its folder exists" "$result"
+pass "dropbox status reports a linked account before its folder exists"
+
+[[ $(jq -r '.usedBytes' <<<"$result") == "0" ]] ||
+  fail "dropbox status survives scanning a folder that is not there yet" "$result"
+pass "dropbox status survives scanning a folder that is not there yet"
+
+rm "$DROPBOX_HOME/.dropbox/info.json"
+result=$(HOME="$DROPBOX_HOME" PATH="$STUB_BIN:$PATH" python3 "$ROOT/shell/plugins/panels/dropbox/status.py" 5)
+
+[[ $(jq -r '.authenticated' <<<"$result") == "false" ]] ||
+  fail "dropbox status keeps an unlinked install on the login screen" "$result"
+pass "dropbox status keeps an unlinked install on the login screen"

--- a/test/shell.d/dropbox-test.sh
+++ b/test/shell.d/dropbox-test.sh
@@ -39,7 +39,7 @@ const service = fs.readFileSync(root + '/shell/plugins/panels/dropbox/Service.qm
 
 assert(/function login\(\)[^}]*loginRetry\.restart\(\)/s.test(service), 'login starts the status-poll retry for the link URL')
 assert(/if \(loginRetry\.running\) openAuthUrlFrom\(statusText\)/.test(service), 'status poll feeds the pending login the link URL')
-assert(/Dropbox offered no login link/.test(service), 'an exhausted login retry surfaces an error instead of hanging')
+assert(/Dropbox offered no login link[\s\S]{0,200}root\.actionStatus = root\.lastError/.test(service), 'an exhausted login retry surfaces an error that survives the next status poll')
 JS
 
 # The account block in info.json marks a linked account; the sync folder only


### PR DESCRIPTION
On a fresh Dropbox install, the widget's login button does nothing: no browser, no error, and `actionStatus` sits on "Starting Dropbox login…" forever. This is the login half of #7423 (defects 2 and 3), with the root cause the thread there worked out.

`Service.qml` runs `dropbox-cli start` once and scrapes its output for the account-link URL. `start` does print that URL on a healthy daemon, but it waits on the daemon's pidfile rather than its command socket, and the pidfile lands seconds before the socket accepts. On a cold start the URL request inside `start` fails, the command prints `Done!` with no URL, and the one-shot scrape comes up empty. There is a second way in: a daemon whose socket has wedged makes `start` short-circuit entirely, and the button can never recover.

The status poll already runs `dropbox-cli status` on a timer, and that command returns the same link URL once the socket is up. So the fix feeds the pending login from the poll instead of trusting the single invocation: `login()` arms a bounded retry (2s interval, 30s total, matching `startupRamp`) that keeps refreshing until the URL shows up in the status output, and `applyStatus` hands the status text to the existing `openAuthUrlFrom`. If the URL never arrives, the retry expires into a visible error whose advice (pause and resume Dropbox) is exactly the recovery a commenter confirmed clears the wedged-socket state. The silent-hang path is gone either way.

Two guards keep this from regressing anything that works today. The URL scrape only runs off the poll while a login attempt is pending, so an unlinked machine at boot does not open a browser from `startupRamp`'s polls. And `login()` now declines on an already linked account, because middle-click on the bar icon reaches it unconditionally and a linked account has no link URL to wait for.

Also from the thread: `status.py` derived `authenticated` from the sync folder existing, but the folder only appears once the first sync starts, while the account block in `info.json` appears the moment linking completes. A freshly linked account therefore fell back to the same broken login screen. It now reads `authenticated` from the account block.

Part of #7423. The tray menu, walk cost, and pin defects there are separate and not touched here.

## Tests

- `bash test/shell.d/dropbox-test.sh` gains coverage for the retry wiring, and runs `status.py` against a fake `$HOME` in both the linked-before-first-sync and unlinked states
- `./test/shell` passes apart from 6 files that fail identically on a clean quattro checkout in my environment
- `qmllint` clean on `Service.qml` apart from the expected unresolved `qs.Commons` import
- I do not have a Dropbox account to run the full link flow end to end; the `dropbox-cli` behavior this builds on is the literal output two reporters captured in the issue, and the retry, guard, and error paths are covered by the tests above
