### PR TITLE
Measure every rotated transform as rotated in the capture picker

### DIFF
--- a/bin/omarchy-capture-region
+++ b/bin/omarchy-capture-region
@@ -23,14 +23,18 @@
 FULLSCREEN_MARKER="${XDG_RUNTIME_DIR:-/tmp}/omarchy-capture-region-fullscreen"
 WINDOW_MARKER="${XDG_RUNTIME_DIR:-/tmp}/omarchy-capture-region-window"
 
-# accounting for portrait/transformed displays
+# accounting for portrait/transformed displays. Hyprland reports the mode, so a
+# rotated output has its logical width and height the other way round. Every
+# odd transform is a quarter turn -- 5 and 7 are 90 and 270 with a flip, and
+# listing only 1 and 3 left those two measured as landscape. Test the parity,
+# the way omarchy-capture-webcam-resize already does.
 JQ_MONITOR_GEO='
   def format_geo:
     .x as $x | .y as $y |
     (.width / .scale | floor) as $w |
     (.height / .scale | floor) as $h |
-    .transform as $t |
-    if $t == 1 or $t == 3 then
+    (((.transform // 0) % 2) == 1) as $rotated |
+    if $rotated then
       "\($x),\($y) \($h)x\($w)"
     else
       "\($x),\($y) \($w)x\($h)"

--- a/test/shell.d/capture-region-geometry-test.sh
+++ b/test/shell.d/capture-region-geometry-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Stand in for the compositor. Only "monitors -j" is asked for on the fullscreen
+# path, so a fixed payload is the whole dependency: no slurp, no hyprpicker, no
+# Wayland. $OMARCHY_TEST_MONITORS carries the monitor list under test.
+printf '%s\n' \
+  '#!/bin/bash' \
+  'printf "%s\n" "$OMARCHY_TEST_MONITORS"' \
+  >"$tmpdir/hyprctl"
+chmod +x "$tmpdir/hyprctl"
+
+# One 1920x1080 output at scale 1, so a rotated result is exactly the mode the
+# other way round and the assertion cannot be satisfied by rounding.
+monitors_with_transform() {
+  printf '[{"name":"DP-1","focused":true,"x":0,"y":0,"width":1920,"height":1080,"scale":1,"transform":%s,"activeWorkspace":{"id":1}}]' "$1"
+}
+
+geo_for_transform() {
+  OMARCHY_TEST_MONITORS="$(monitors_with_transform "$1")" \
+    PATH="$tmpdir:$ROOT/bin:$PATH" omarchy-capture-region fullscreen
+}
+
+# Hyprland reports the mode, not the logical size, so every quarter-turn
+# transform has to come back measured the other way round. 1 and 3 are the
+# plain rotations; 5 and 7 are the same two turns with a flip, and those are
+# the ones a "$t == 1 or $t == 3" test used to miss.
+for transform in 1 3 5 7; do
+  geo=$(geo_for_transform "$transform")
+  [[ $geo == "0,0 1080x1920" ]] ||
+    fail "transform $transform is measured as rotated" "expected: 0,0 1080x1920
+actual:   $geo"
+done
+
+pass "every quarter-turn transform is measured as rotated"
+
+# The even transforms are upright (0 and 4 unflipped/flipped, 2 and 6 half a
+# turn), so the mode passes through unswapped.
+for transform in 0 2 4 6; do
+  geo=$(geo_for_transform "$transform")
+  [[ $geo == "0,0 1920x1080" ]] ||
+    fail "transform $transform is measured as upright" "expected: 0,0 1920x1080
+actual:   $geo"
+done
+
+pass "upright transforms keep the mode as reported"
+
+# A monitor list without the key at all must not read as rotated.
+geo=$(OMARCHY_TEST_MONITORS='[{"name":"DP-1","focused":true,"x":0,"y":0,"width":1920,"height":1080,"scale":1,"activeWorkspace":{"id":1}}]' \
+  PATH="$tmpdir:$ROOT/bin:$PATH" omarchy-capture-region fullscreen)
+[[ $geo == "0,0 1920x1080" ]] ||
+  fail "a monitor with no transform key is measured as upright" "$geo"
+
+pass "a missing transform key is treated as upright"
+
+# --match-monitor matches the picked geometry back to a monitor by name. It
+# compares against the same format_geo, so a rotated output whose geometry was
+# measured the wrong way round could never match itself.
+name=$(OMARCHY_TEST_MONITORS="$(monitors_with_transform 5)" \
+  PATH="$tmpdir:$ROOT/bin:$PATH" omarchy-capture-region fullscreen --match-monitor)
+[[ $name == "monitor:DP-1" ]] ||
+  fail "a flipped-and-rotated monitor matches itself by name" "expected: monitor:DP-1
+actual:   $name"
+
+pass "--match-monitor recognizes a flipped-and-rotated output"


### PR DESCRIPTION
## Symptom

On a display rotated with `transform = 5` or `transform = 7`, the capture picker measures the output as landscape when it is portrait. `omarchy capture region fullscreen` grabs a 1920x1080 rectangle from a screen that is 1080x1920, the whole-monitor candidate offered in `smart` and `windows` mode is the wrong shape, a bare click resolves against that wrong rectangle, and `--match-monitor` never recognizes the output at all — its geometry cannot equal the geometry the same function just computed for it.

## Root cause

`JQ_MONITOR_GEO` in `bin/omarchy-capture-region` swaps width and height for a rotated output, but decides "rotated" by listing two of the four rotated transforms:

```jq
.transform as $t |
if $t == 1 or $t == 3 then
```

Hyprland has eight transforms. The odd ones are the quarter turns: 1 and 3 are 90 and 270, and 5 and 7 are those same two turns with a flip. Testing `$t == 1 or $t == 3` therefore catches half of them and measures 5 and 7 as landscape.

`hyprctl monitors -j` reports the *mode*, not the logical size, so this is the only thing standing between a rotated output and a wrong rectangle:

```
transform : capture-region | correct
    1     : 1080x1920      | 1080x1920
    3     : 1080x1920      | 1080x1920
    5     : 1920x1080      | 1080x1920   <-- wrong
    7     : 1920x1080      | 1080x1920   <-- wrong
```

The sibling helper in the same directory already gets this right. `bin/omarchy-capture-webcam-resize:49` tests the parity instead:

```jq
(($monitor.transform // 0) % 2 == 1) as $rotated |
```

These are the only two places in the repository that compute logical monitor extents, and they disagree.

## Fix

Adopt the parity test in `capture-region`, so all four quarter turns swap and the even transforms (0 and 4 upright, 2 and 6 half a turn) pass through unswapped. The `// 0` default also matches the sibling, so a monitor object without the key reads as upright rather than as null.

## Verification

`test/shell.d/capture-region-geometry-test.sh` is new. It stubs `hyprctl` and drives the `fullscreen` path, which needs no compositor, slurp or hyprpicker, and asserts all eight transforms plus a monitor object with no `transform` key, plus `--match-monitor` recognizing a `transform = 5` output by name.

On the current code it fails with:

```
expected: 0,0 1080x1920
actual:   0,0 1920x1080
not ok - transform 5 is measured as rotated
```

and passes with this change.

`./test/cli` passes. `./test/shell` is unchanged against a clean checkout apart from the new file; the same handful of pre-existing failures (three wanting an `omarchy-pkgs` checkout, one a compositor, one network) fail identically before and after.

Reported against Omarchy 4.0.1. I run a rotated secondary output (`transform = 3`) beside a fractionally scaled ultrawide, which is what led me here; 5 and 7 are the same code path with a flip.

## Note on overlap

#8238 also touches `bin/omarchy-capture-region`, at the click-snap block near the bottom, and adds `test/shell.d/capture-region-test.sh`. No overlap with this change, which is confined to the `JQ_MONITOR_GEO` definition at the top; the new test here is deliberately named `capture-region-geometry-test.sh` so both files can land.