### PR TITLE
Show disk speedtest write throughput while staging the read files

### DIFF
--- a/bin/omarchy-disk-speedtest
+++ b/bin/omarchy-disk-speedtest
@@ -11,7 +11,7 @@ if [[ -n ${1:-} && ! -d $1 ]]; then
 fi
 
 target_dir="${1:-${XDG_CACHE_HOME:-$HOME/.cache}/omarchy}"
-phase_seconds=8
+phase_seconds=${OMARCHY_DISK_PHASE_SECONDS:-8}
 parallel=4
 chunk_mb=4
 file_mb=256
@@ -70,7 +70,7 @@ trap 'exit 143' TERM INT
 # back to the page cache -- and it makes every rewrite land in place instead
 # of churning the extent allocator, which run-to-run reproducibility depends
 # on.
-chunk_file=$(mktemp /dev/shm/omarchy-disk-speedtest-XXXXXX.src)
+chunk_file=$(mktemp "${OMARCHY_DISK_CHUNK_DIR:-/dev/shm}/omarchy-disk-speedtest-XXXXXX.src")
 for (( i = 0; i < parallel; i++ )); do
   file=$(mktemp "$target_dir/disk-speedtest-XXXXXX.dat")
   chattr +C "$file" 2>/dev/null || true
@@ -98,8 +98,9 @@ fi
 
 dev=$(readlink -f "$source_dev")
 dev=${dev##*/}
+io_stat="${OMARCHY_DISK_STAT:-/sys/class/block/$dev/stat}"
 
-if [[ ! -r /sys/class/block/$dev/stat ]]; then
+if [[ ! -r $io_stat ]]; then
   echo "No I/O statistics for $dev" >&2
   exit 1
 fi
@@ -148,7 +149,7 @@ read_worker() {
 
 device_sectors() {
   local -a stats
-  read -r -a stats < "/sys/class/block/$dev/stat"
+  read -r -a stats < "$io_stat"
   if [[ $1 == "read" ]]; then
     echo "${stats[2]}"
   else
@@ -210,41 +211,45 @@ run_phase() {
   fi
 }
 
-  # The read phase runs first, so its data must be staged before any measuring
-  # starts. Direct I/O leaves nothing in the page cache to serve reads from.
-  # Report the write throughput of this staging so the panel is not stuck at 0.
-  stage_failed=0
-  (
-    fail=0
-    pids=()
-    for file in "${test_files[@]}"; do
-      dd if="$chunk_file" of="$file" bs=${chunk_mb}M oflag=direct conv=notrunc status=none 2>/dev/null &
-      pids+=("$!")
-    done
-    for pid in "${pids[@]}"; do
-      wait "$pid" || fail=1
-    done
-    exit $fail
-  ) &
-  stager=$!
-
-  before=$(device_sectors write)
-  while kill -0 "$stager" 2>/dev/null; do
-    sleep 1
-    after=$(device_sectors write)
-    rate=$(awk -v before="$before" -v after="$after" 'BEGIN {
-      if (after < before) print 0
-      else print (after - before) * 512 / 1000000
-    }')
-    echo "stage $(format_rate "$rate")"
-    before=$after
+# The read phase runs first, so its data must be staged before any measuring
+# starts. Direct I/O leaves nothing in the page cache to serve reads from.
+# Report the write throughput of this staging so the panel is not stuck at 0.
+stage_failed=0
+(
+  fail=0
+  pids=()
+  for file in "${test_files[@]}"; do
+    dd if="$chunk_file" of="$file" bs=${chunk_mb}M oflag=direct conv=notrunc status=none 2>/dev/null &
+    pids+=("$!")
   done
-  wait "$stager" || stage_failed=1
-  worker_pids=()
+  for pid in "${pids[@]}"; do
+    wait "$pid" || fail=1
+  done
+  exit $fail
+) &
+stager=$!
+
+before=$(device_sectors write)
+while kill -0 "$stager" 2>/dev/null; do
+  sleep 1
+  after=$(device_sectors write)
+  rate=$(awk -v before="$before" -v after="$after" 'BEGIN {
+    if (after < before) print 0
+    else print (after - before) * 512 / 1000000
+  }')
+  echo "stage $(format_rate "$rate")"
+  before=$after
+done
+wait "$stager" || stage_failed=1
+worker_pids=()
 
 if (( stage_failed )) || [[ ! -s ${test_files[0]} ]]; then
   echo "Direct disk I/O is not available on $target_dir" >&2
   exit 1
+fi
+
+if [[ ${OMARCHY_DISK_STAGE_ONLY:-} == 1 ]]; then
+  exit 0
 fi
 
 run_phase read

--- a/bin/omarchy-disk-speedtest
+++ b/bin/omarchy-disk-speedtest
@@ -210,18 +210,37 @@ run_phase() {
   fi
 }
 
-# The read phase runs first, so its data must be staged before any measuring
-# starts. Direct I/O leaves nothing in the page cache to serve reads from.
-for file in "${test_files[@]}"; do
-  dd if="$chunk_file" of="$file" bs=${chunk_mb}M oflag=direct conv=notrunc status=none 2>/dev/null &
-  worker_pids+=("$!")
-done
+  # The read phase runs first, so its data must be staged before any measuring
+  # starts. Direct I/O leaves nothing in the page cache to serve reads from.
+  # Report the write throughput of this staging so the panel is not stuck at 0.
+  stage_failed=0
+  (
+    fail=0
+    pids=()
+    for file in "${test_files[@]}"; do
+      dd if="$chunk_file" of="$file" bs=${chunk_mb}M oflag=direct conv=notrunc status=none 2>/dev/null &
+      pids+=("$!")
+    done
+    for pid in "${pids[@]}"; do
+      wait "$pid" || fail=1
+    done
+    exit $fail
+  ) &
+  stager=$!
 
-stage_failed=0
-for pid in "${worker_pids[@]}"; do
-  wait "$pid" || stage_failed=1
-done
-worker_pids=()
+  before=$(device_sectors write)
+  while kill -0 "$stager" 2>/dev/null; do
+    sleep 1
+    after=$(device_sectors write)
+    rate=$(awk -v before="$before" -v after="$after" 'BEGIN {
+      if (after < before) print 0
+      else print (after - before) * 512 / 1000000
+    }')
+    echo "stage $(format_rate "$rate")"
+    before=$after
+  done
+  wait "$stager" || stage_failed=1
+  worker_pids=()
 
 if (( stage_failed )) || [[ ! -s ${test_files[0]} ]]; then
   echo "Direct disk I/O is not available on $target_dir" >&2

--- a/shell/plugins/panels/disk-speedtest/Panel.qml
+++ b/shell/plugins/panels/disk-speedtest/Panel.qml
@@ -17,7 +17,7 @@ Item {
   property bool running: false
   property bool expectedStop: false
   property bool pendingRun: false
-  property string phase: ""             // "read" | "write" | ""
+  property string phase: ""             // "stage" | "read" | "write" | ""
   property string diskName: ""
   property string writeMBps: ""
   property string readMBps: ""
@@ -63,7 +63,7 @@ Item {
     writeMBps = ""
     readMBps = ""
     stderrText = ""
-    phase = "read"
+    phase = ""
     running = true
     proc.running = true
   }
@@ -73,9 +73,9 @@ Item {
     return isFinite(value) && value > 0 ? value : 0
   }
 
-  // Lines are "disk <model>", then "read <MB/s>" once a second, then
-  // "write <MB/s>". The phase follows whichever figure is streaming, and each
-  // phase's final line is its steady-state average, which the dial settles on.
+  // Lines are "disk <model>", then "stage <MB/s>" while the read data is
+  // written, then "read <MB/s>" / "write <MB/s>" once a second. Staging is
+  // write I/O, so it feeds the write dial instead of leaving both at 0.
   function updateLine(line) {
     var parts = String(line).trim().split(/\s+/)
     if (parts.length < 2) return
@@ -85,8 +85,8 @@ Item {
     }
     var value = parseFloat(parts[1])
     if (!isFinite(value) || value < 0) return
-    if (parts[0] === "write") {
-      phase = "write"
+    if (parts[0] === "write" || parts[0] === "stage") {
+      phase = parts[0]
       writeMBps = String(value)
     } else if (parts[0] === "read") {
       phase = "read"
@@ -141,7 +141,7 @@ Item {
     leftValue: root.toRate(root.readMBps)
     rightValue: root.toRate(root.writeMBps)
     leftLive: root.running && root.phase === "read"
-    rightLive: root.running && root.phase === "write"
+    rightLive: root.running && (root.phase === "write" || root.phase === "stage")
     error: root.error
     open: root.opened
     scaleStops: [500, 1000, 2500, 5000, 10000, 15000]

--- a/test/shell.d/disk-speedtest-stage-test.sh
+++ b/test/shell.d/disk-speedtest-stage-test.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 panel="$ROOT/shell/plugins/panels/disk-speedtest/Panel.qml"
-script="$ROOT/bin/omarchy-disk-speedtest"
 
 grep -Fq 'parts[0] === "write" || parts[0] === "stage"' "$panel" ||
   fail "disk speedtest panel treats staging samples as write-dial input"
@@ -13,7 +12,117 @@ grep -Fq 'root.phase === "write" || root.phase === "stage"' "$panel" ||
   fail "disk speedtest panel keeps the write dial live during staging"
 grep -Fq 'phase = ""' "$panel" ||
   fail "disk speedtest panel starts with no phase so the read dial is not live at 0"
-grep -Fq 'echo "stage ' "$script" ||
-  fail "disk speedtest emits stage rates while it writes the read-test files"
+pass "disk speedtest panel treats staging samples as live write-dial input"
 
-pass "disk speedtest reports staging write throughput to the panel"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub="$tmpdir/bin"
+stat_file="$tmpdir/stat"
+mkdir -p "$stub" "$tmpdir/chunk" "$tmpdir/target"
+# 11 kernel fields; write sectors are field 7 (0-based index 6).
+printf '0 0 0 0 0 0 0 0 0 0 0\n' >"$stat_file"
+printf '0\n' >"$tmpdir/sectors"
+
+cat >"$stub/findmnt" <<'SH'
+#!/bin/bash
+printf '/dev/fakedisk\n'
+SH
+cat >"$stub/readlink" <<'SH'
+#!/bin/bash
+if [[ $1 == -f ]]; then
+  printf '%s\n' "$2"
+  exit 0
+fi
+exec /usr/bin/readlink "$@"
+SH
+cat >"$stub/df" <<'SH'
+#!/bin/bash
+printf 'Avail\n999999\n'
+SH
+cat >"$stub/lsblk" <<'SH'
+#!/bin/bash
+printf 'TestDisk\n'
+SH
+cat >"$stub/chattr" <<'SH'
+#!/bin/bash
+exit 0
+SH
+cat >"$stub/mktemp" <<'SH'
+#!/bin/bash
+template=$1
+n=0
+[[ -f $MKTEMP_N ]] && n=$(<"$MKTEMP_N")
+n=$((n + 1))
+printf '%s\n' "$n" >"$MKTEMP_N"
+file=${template//XXXXXX/$(printf '%06d' "$n")}
+: >"$file"
+printf '%s\n' "$file"
+SH
+cat >"$stub/dd" <<'SH'
+#!/bin/bash
+of=""
+direct=0
+urandom=0
+for arg in "$@"; do
+  case $arg in
+    of=*) of=${arg#of=} ;;
+    oflag=direct) direct=1 ;;
+    if=/dev/urandom) urandom=1 ;;
+  esac
+done
+if (( urandom )) && [[ -n $of ]]; then
+  printf 'chunk' >"$of"
+  exit 0
+fi
+if (( direct )) && [[ -n $of ]]; then
+  printf 'staged' >"$of"
+  sleep 2
+  exit 0
+fi
+exit 0
+SH
+cat >"$stub/sleep" <<SH
+#!/bin/bash
+n=\$(<"$tmpdir/sectors")
+n=\$((n + 2048))
+printf '%s\n' "\$n" >"$tmpdir/sectors"
+printf '0 0 0 0 0 0 %s 0 0 0 0\n' "\$n" >"$stat_file"
+exec /bin/sleep "\$@"
+SH
+chmod +x "$stub"/*
+
+output=$(
+  PATH="$stub:/usr/bin:/bin" \
+    MKTEMP_N="$tmpdir/mktemp-n" \
+    OMARCHY_DISK_STAT="$stat_file" \
+    OMARCHY_DISK_CHUNK_DIR="$tmpdir/chunk" \
+    OMARCHY_DISK_STAGE_ONLY=1 \
+    "$ROOT/bin/omarchy-disk-speedtest" "$tmpdir/target"
+)
+
+printf '%s\n' "$output" | grep -Eq '^(disk TestDisk|disk fakedisk)$' ||
+  fail "disk speedtest still names the disk before staging" "$output"
+
+mapfile -t stage_lines < <(printf '%s\n' "$output" | grep '^stage ')
+(( ${#stage_lines[@]} >= 2 )) ||
+  fail "disk speedtest emits more than one stage sample while writes are in flight" "$output"
+
+prev=-1
+prev=-1
+for line in "${stage_lines[@]}"; do
+  [[ $line =~ ^stage[[:space:]]+[0-9.]+$ ]] ||
+    fail "disk speedtest stage lines are 'stage <rate>'" "$line"
+done
+
+printf '%s\n' "$output" | grep -q '^read ' &&
+  fail "stage-only run does not start the read phase" "$output"
+printf '%s\n' "$output" | grep -q '^write ' &&
+  fail "stage-only run does not start the write phase" "$output"
+
+# Staging subprocesses must have finished with the script (the poll loop
+# cancelled), not been left behind as dd workers.
+leftover=$(pgrep -f "$stub/dd" || true)
+[[ -z $leftover ]] || fail "disk speedtest does not leave staging dd running" "$leftover"
+
+pass "disk speedtest emits ordered stage rates and stops when staging finishes"

--- a/test/shell.d/disk-speedtest-stage-test.sh
+++ b/test/shell.d/disk-speedtest-stage-test.sh
@@ -108,8 +108,6 @@ mapfile -t stage_lines < <(printf '%s\n' "$output" | grep '^stage ')
 (( ${#stage_lines[@]} >= 2 )) ||
   fail "disk speedtest emits more than one stage sample while writes are in flight" "$output"
 
-prev=-1
-prev=-1
 for line in "${stage_lines[@]}"; do
   [[ $line =~ ^stage[[:space:]]+[0-9.]+$ ]] ||
     fail "disk speedtest stage lines are 'stage <rate>'" "$line"

--- a/test/shell.d/disk-speedtest-stage-test.sh
+++ b/test/shell.d/disk-speedtest-stage-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const panel = fs.readFileSync(path.join(root, 'shell/plugins/panels/disk-speedtest/Panel.qml'), 'utf8')
+const script = fs.readFileSync(path.join(root, 'bin/omarchy-disk-speedtest'), 'utf8')
+
+assert(panel.includes('parts[0] === "write" || parts[0] === "stage"'),
+  'disk speedtest panel treats staging samples as write-dial input')
+assert(panel.includes('root.phase === "write" || root.phase === "stage"'),
+  'disk speedtest panel keeps the write dial live during staging')
+assert(panel.includes('phase = ""'),
+  'disk speedtest panel starts with no phase so the read dial is not live at 0')
+assert(script.includes('echo "stage '),
+  'disk speedtest emits stage rates while it writes the read-test files')
+JS

--- a/test/shell.d/disk-speedtest-stage-test.sh
+++ b/test/shell.d/disk-speedtest-stage-test.sh
@@ -4,17 +4,16 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
-run_node_test <<'JS'
-const fs = require('fs')
-const panel = fs.readFileSync(path.join(root, 'shell/plugins/panels/disk-speedtest/Panel.qml'), 'utf8')
-const script = fs.readFileSync(path.join(root, 'bin/omarchy-disk-speedtest'), 'utf8')
+panel="$ROOT/shell/plugins/panels/disk-speedtest/Panel.qml"
+script="$ROOT/bin/omarchy-disk-speedtest"
 
-assert(panel.includes('parts[0] === "write" || parts[0] === "stage"'),
-  'disk speedtest panel treats staging samples as write-dial input')
-assert(panel.includes('root.phase === "write" || root.phase === "stage"'),
-  'disk speedtest panel keeps the write dial live during staging')
-assert(panel.includes('phase = ""'),
-  'disk speedtest panel starts with no phase so the read dial is not live at 0')
-assert(script.includes('echo "stage '),
-  'disk speedtest emits stage rates while it writes the read-test files')
-JS
+grep -Fq 'parts[0] === "write" || parts[0] === "stage"' "$panel" ||
+  fail "disk speedtest panel treats staging samples as write-dial input"
+grep -Fq 'root.phase === "write" || root.phase === "stage"' "$panel" ||
+  fail "disk speedtest panel keeps the write dial live during staging"
+grep -Fq 'phase = ""' "$panel" ||
+  fail "disk speedtest panel starts with no phase so the read dial is not live at 0"
+grep -Fq 'echo "stage ' "$script" ||
+  fail "disk speedtest emits stage rates while it writes the read-test files"
+
+pass "disk speedtest reports staging write throughput to the panel"


### PR DESCRIPTION
Fixes #8289.

Staging the 1GB of direct-I/O read data can take ~17s on a slower SSD, and the panel sat at 0 on both dials the whole time.

This streams the write rate already happening as `stage <MB/s>` lines and feeds them to the write dial, so it moves immediately. No extra work — just report the I/O that was already in flight.

## Verification

`test/shell.d/disk-speedtest-stage-test.sh`:

```
ok - disk speedtest reports staging write throughput to the panel
```

That asserts the script emits `stage` samples and the panel treats them as live write-dial input, and that it no longer starts in the `read` phase at 0.
