### PR TITLE
Pop a window with one hyprctl batch instead of six round-trips

### DIFF
--- a/bin/omarchy-hyprland-window-pop
+++ b/bin/omarchy-hyprland-window-pop
@@ -13,28 +13,50 @@ pinned=$(echo "$active" | jq ".pinned")
 addr=$(echo "$active" | jq -r ".address")
 window="address:$addr"
 
-hypr_dispatch() {
-  local lua="$1"
-  shift
+lua_cmds=()
+classic_cmds=()
 
-  hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null
+hypr_queue() {
+  lua_cmds+=("$1")
+  classic_cmds+=("$2")
+}
+
+# One IPC round-trip for the whole pop/unpop. Each sequential dispatch is its
+# own hyprctl process and socket; popping a window used to pay that six times.
+hypr_flush() {
+  (( ${#lua_cmds[@]} > 0 )) || return 0
+
+  local batch="" lua i
+  for lua in "${lua_cmds[@]}"; do
+    batch+="dispatch ${lua}; "
+  done
+
+  if hyprctl --batch "$batch" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for i in "${!lua_cmds[@]}"; do
+    hyprctl dispatch "${lua_cmds[$i]}" >/dev/null 2>&1 || hyprctl dispatch ${classic_cmds[$i]} >/dev/null
+  done
 }
 
 if [[ $pinned == "true" ]]; then
-  hypr_dispatch "hl.dsp.window.pin({ window = \"$window\" })" pin "$window"
-  hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
-  hypr_dispatch "hl.dsp.window.tag({ window = \"$window\", tag = \"-pop\" })" tagwindow -pop "$window"
+  hypr_queue "hl.dsp.window.pin({ window = \"$window\" })" "pin $window"
+  hypr_queue "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" "togglefloating $window"
+  hypr_queue "hl.dsp.window.tag({ window = \"$window\", tag = \"-pop\" })" "tagwindow -pop $window"
 elif [[ -n $addr ]]; then
-  hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
-  hypr_dispatch "hl.dsp.window.resize({ window = \"$window\", x = $width, y = $height })" resizeactive exact "$width" "$height" "$window"
+  hypr_queue "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" "togglefloating $window"
+  hypr_queue "hl.dsp.window.resize({ window = \"$window\", x = $width, y = $height })" "resizeactive exact $width $height $window"
 
   if [[ -n $x && -n $y ]]; then
-    hypr_dispatch "hl.dsp.window.move({ window = \"$window\", x = $x, y = $y })" moveactive "$x" "$y" "$window"
+    hypr_queue "hl.dsp.window.move({ window = \"$window\", x = $x, y = $y })" "moveactive $x $y $window"
   else
-    hypr_dispatch "hl.dsp.window.center({ window = \"$window\" })" centerwindow "$window"
+    hypr_queue "hl.dsp.window.center({ window = \"$window\" })" "centerwindow $window"
   fi
 
-  hypr_dispatch "hl.dsp.window.pin({ window = \"$window\" })" pin "$window"
-  hypr_dispatch "hl.dsp.window.alter_zorder({ window = \"$window\", mode = \"top\" })" alterzorder top "$window"
-  hypr_dispatch "hl.dsp.window.tag({ window = \"$window\", tag = \"+pop\" })" tagwindow +pop "$window"
+  hypr_queue "hl.dsp.window.pin({ window = \"$window\" })" "pin $window"
+  hypr_queue "hl.dsp.window.alter_zorder({ window = \"$window\", mode = \"top\" })" "alterzorder top $window"
+  hypr_queue "hl.dsp.window.tag({ window = \"$window\", tag = \"+pop\" })" "tagwindow +pop $window"
 fi
+
+hypr_flush

--- a/test/shell.d/window-pop-batch-test.sh
+++ b/test/shell.d/window-pop-batch-test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+log="$tmpdir/hyprctl.log"
+cat >"$tmpdir/hyprctl" <<'BASH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+if [[ $1 == "activewindow" ]]; then
+  printf '{"pinned":%s,"address":"0x1"}\n' "${HYPR_PINNED:-false}"
+  exit 0
+fi
+if [[ $1 == "--batch" || $1 == "dispatch" ]]; then
+  exit 0
+fi
+exit 1
+BASH
+chmod +x "$tmpdir/hyprctl"
+
+PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_PINNED=false \
+  "$ROOT/bin/omarchy-hyprland-window-pop" >/dev/null
+
+grep -c '^--batch ' "$log" | grep -qx 1 ||
+  fail "popping a window sends one hyprctl --batch" "$(cat "$log")"
+! grep -q '^dispatch ' "$log" ||
+  fail "popping a window does not send per-action dispatch processes" "$(cat "$log")"
+grep -Fq 'hl.dsp.window.float' "$log" || fail "the batch still floats the window" "$(cat "$log")"
+grep -Fq 'hl.dsp.window.pin' "$log" || fail "the batch still pins the window" "$(cat "$log")"
+grep -Fq 'hl.dsp.window.tag({ window = "address:0x1", tag = "+pop" })' "$log" ||
+  fail "the batch still tags the popped window" "$(cat "$log")"
+pass "popping a window is one hyprctl batch"
+
+: >"$log"
+PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_PINNED=true \
+  "$ROOT/bin/omarchy-hyprland-window-pop" >/dev/null
+
+grep -c '^--batch ' "$log" | grep -qx 1 ||
+  fail "unpopping a window sends one hyprctl --batch" "$(cat "$log")"
+grep -Fq 'tag = "-pop"' "$log" || fail "the unpop batch removes the pop tag" "$(cat "$log")"
+pass "unpopping a window is one hyprctl batch"
+
+: >"$log"
+cat >"$tmpdir/hyprctl" <<'BASH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+if [[ $1 == "activewindow" ]]; then
+  printf '{"pinned":false,"address":"0x1"}\n'
+  exit 0
+fi
+if [[ $1 == "--batch" ]]; then
+  exit 1
+fi
+if [[ $1 == "dispatch" ]]; then
+  exit 0
+fi
+exit 1
+BASH
+chmod +x "$tmpdir/hyprctl"
+
+PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" \
+  "$ROOT/bin/omarchy-hyprland-window-pop" >/dev/null
+
+grep -q '^--batch ' "$log" || fail "a failed batch is still attempted" "$(cat "$log")"
+grep -q '^dispatch ' "$log" || fail "a failed batch falls back to sequential dispatch" "$(cat "$log")"
+pass "a compositor without --batch still pops via sequential dispatch"


### PR DESCRIPTION
Fixes #8502.

`omarchy-hyprland-window-pop` sent each action as its own `hyprctl dispatch` process. Popping a tiled window was six round-trips (float, resize, move/center, pin, z-order, tag).

This queues the lua commands and flushes them with one `hyprctl --batch`. If `--batch` fails, it falls back to the old sequential `dispatch` path.

#7910 is "don't tile an already-floating window" — different change, same script.

## Verification

`test/shell.d/window-pop-batch-test.sh`:

```
ok - popping a window is one hyprctl batch
ok - unpopping a window is one hyprctl batch
ok - a compositor without --batch still pops via sequential dispatch
```

A stub `hyprctl` records argv. Pop and unpop each send one `--batch` and no per-action `dispatch`. When `--batch` exits 1, the script retries with sequential `dispatch`.
