### PR TITLE
Look up image-selector thumbnail hashes in memory

### DIFF
--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -107,6 +107,18 @@ index_file="$cache_dir/index.tsv"
 rows=""
 mkdir -p "$cache_dir"
 
+# One pass over the index instead of an awk scan per image. Opening the
+# background picker with a large custom set used to re-read this file for
+# every row.
+declare -A thumbnail_index=()
+if [[ -f $index_file ]]; then
+  while IFS=$'\t' read -r index_path index_sig index_hash; do
+    [[ -n $index_hash ]] || continue
+    [[ -n ${thumbnail_index["$index_path"$'\t'"$index_sig"]+x} ]] && continue
+    thumbnail_index["$index_path"$'\t'"$index_sig"]=$index_hash
+  done < "$index_file"
+fi
+
 cache_key=$(printf '%s' "$image_dirs_env" | md5sum | cut -d ' ' -f 1)
 rows_cache_file="$cache_dir/$cache_key.rows"
 rows_signature_file="$cache_dir/$cache_key.signature"
@@ -176,10 +188,11 @@ thumbnail_for() {
   local signature hash thumbnail
 
   signature=$(stat -Lc '%s:%Y' "$image") || return
-  hash=$(awk -F '\t' -v path="$image" -v sig="$signature" '$1 == path && $2 == sig { print $3; exit }' "$index_file" 2>/dev/null)
+  hash=${thumbnail_index["$image"$'\t'"$signature"]-}
 
   if [[ -z $hash ]]; then
     hash=$(printf '%s\t%s' "$image" "$signature" | md5sum | cut -d ' ' -f 1)
+    thumbnail_index["$image"$'\t'"$signature"]=$hash
     printf '%s\t%s\t%s\n' "$image" "$signature" "$hash" >>"$index_file"
   fi
 

--- a/test/shell.d/menu-images-test.sh
+++ b/test/shell.d/menu-images-test.sh
@@ -139,3 +139,8 @@ PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" VIPSTHUMBNAIL_CALLS_FILE="$t
 
 (( $(wc -l <"$tmp/calls") == 6 )) || fail "image menu releases thumbnail locks after generation"
 pass "image menu owns locks for exactly one generator lifetime"
+
+# The per-image awk scan of index.tsv was the cost of a large wallpaper set.
+awk_hits=$(awk '/^thumbnail_for\(\)/,/^}/' "$ROOT/bin/omarchy-menu-images" | grep -c awk || true)
+(( awk_hits == 0 )) || fail "thumbnail_for looks up the index in memory, not via awk per image"
+pass "thumbnail_for does not scan index.tsv with awk per image"


### PR DESCRIPTION
Fixes #8503.

`thumbnail_for` scanned `index.tsv` with awk once per wallpaper. Opening the background picker on a large custom set re-read the whole file for every row.

This loads the index once into an associative array and answers lookups from memory. The tsv format is unchanged.

## Verification

`test/shell.d/menu-images-test.sh` (existing lock/lifetime cases, plus):

```
ok - thumbnail_for does not scan index.tsv with awk per image
```

That greps `thumbnail_for` and fails if an awk scan is still inside it. The rest of the file still covers lock ownership; this machine has no `flock`, so those existing cases were not re-run here.
