### PR TITLE
Add omarchy theme bg prev to cycle backgrounds backwards

### DIFF
--- a/bin/omarchy-theme-bg-prev
+++ b/bin/omarchy-theme-bg-prev
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# omarchy:summary=Cycle to the previous background for the current theme
+# omarchy:examples=omarchy theme bg prev
+
+THEME_NAME=$(cat "$HOME/.local/state/omarchy/current/theme.name" 2>/dev/null)
+THEME_BACKGROUNDS_PATH="$HOME/.local/state/omarchy/current/theme/backgrounds/"
+USER_BACKGROUNDS_PATH="$HOME/.config/omarchy/backgrounds/$THEME_NAME/"
+CURRENT_BACKGROUND_LINK="$HOME/.local/state/omarchy/current/background"
+
+mapfile -d '' -t BACKGROUNDS < <(
+  find -L "$USER_BACKGROUNDS_PATH" "$THEME_BACKGROUNDS_PATH" -maxdepth 1 -type f \
+    \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' -o -iname '*.bmp' -o -iname '*.webp' \) \
+    -print0 2>/dev/null | sort -z
+)
+TOTAL=${#BACKGROUNDS[@]}
+
+if (( TOTAL == 0 )); then
+  omarchy-notification-send "No background was found for theme" -t 2000
+else
+  if [[ -L $CURRENT_BACKGROUND_LINK ]]; then
+    CURRENT_BACKGROUND=$(readlink "$CURRENT_BACKGROUND_LINK")
+  else
+    CURRENT_BACKGROUND=""
+  fi
+
+  INDEX=-1
+  for i in "${!BACKGROUNDS[@]}"; do
+    if [[ ${BACKGROUNDS[$i]} == "$CURRENT_BACKGROUND" ]]; then
+      INDEX=$i
+      break
+    fi
+  done
+
+  if (( INDEX == -1 )); then
+    NEW_BACKGROUND="${BACKGROUNDS[TOTAL - 1]}"
+  else
+    PREV_INDEX=$(((INDEX - 1 + TOTAL) % TOTAL))
+    NEW_BACKGROUND="${BACKGROUNDS[$PREV_INDEX]}"
+  fi
+
+  omarchy-theme-bg-set "$NEW_BACKGROUND"
+fi

--- a/bin/omarchy-theme-bg-prev
+++ b/bin/omarchy-theme-bg-prev
@@ -18,15 +18,10 @@ TOTAL=${#BACKGROUNDS[@]}
 if (( TOTAL == 0 )); then
   omarchy-notification-send "No background was found for theme" -t 2000
 else
-  if [[ -L $CURRENT_BACKGROUND_LINK ]]; then
-    CURRENT_BACKGROUND=$(readlink "$CURRENT_BACKGROUND_LINK")
-  else
-    CURRENT_BACKGROUND=""
-  fi
-
   INDEX=-1
   for i in "${!BACKGROUNDS[@]}"; do
-    if [[ ${BACKGROUNDS[$i]} == "$CURRENT_BACKGROUND" ]]; then
+    # Compare the target files, including relative links and symlinked directories.
+    if [[ ${BACKGROUNDS[$i]} -ef $CURRENT_BACKGROUND_LINK ]]; then
       INDEX=$i
       break
     fi

--- a/default/agents/skills/omarchy/theming.md
+++ b/default/agents/skills/omarchy/theming.md
@@ -9,6 +9,7 @@ omarchy theme list              # Show available themes
 omarchy theme current           # Show current theme
 omarchy theme set <name>        # Apply theme ("Tokyo Night" and "tokyo-night" both work)
 omarchy theme bg next           # Cycle background
+omarchy theme bg prev           # Cycle background backwards
 omarchy theme install <url>     # Install from git repo
 ```
 

--- a/test/shell.d/theme-bg-prev-test.sh
+++ b/test/shell.d/theme-bg-prev-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+home="$tmpdir/home"
+stub="$tmpdir/bin"
+mkdir -p "$home/.local/state/omarchy/current/theme/backgrounds" "$stub"
+
+printf 'tokyo-night\n' >"$home/.local/state/omarchy/current/theme.name"
+for name in a-one.png b-two.png c-three.png; do
+  printf 'img-%s' "$name" >"$home/.local/state/omarchy/current/theme/backgrounds/$name"
+done
+
+ln -s "$home/.local/state/omarchy/current/theme/backgrounds/b-two.png" \
+  "$home/.local/state/omarchy/current/background"
+
+cat >"$stub/omarchy-theme-bg-set" <<'SH'
+#!/bin/bash
+printf '%s\n' "$1" >"$BG_SET_LOG"
+SH
+cat >"$stub/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$NOTIFY_LOG"
+SH
+chmod +x "$stub/omarchy-theme-bg-set" "$stub/omarchy-notification-send"
+
+HOME="$home" PATH="$stub:$PATH" BG_SET_LOG="$tmpdir/set" \
+  "$BASH" "$ROOT/bin/omarchy-theme-bg-prev"
+
+[[ $(<"$tmpdir/set") == "$home/.local/state/omarchy/current/theme/backgrounds/a-one.png" ]] ||
+  fail "theme-bg-prev selects the previous background in sort order" "$(cat "$tmpdir/set")"
+pass "theme-bg-prev selects the previous background"
+
+ln -sfn "$home/.local/state/omarchy/current/theme/backgrounds/a-one.png" \
+  "$home/.local/state/omarchy/current/background"
+
+HOME="$home" PATH="$stub:$PATH" BG_SET_LOG="$tmpdir/set" \
+  "$BASH" "$ROOT/bin/omarchy-theme-bg-prev"
+
+[[ $(<"$tmpdir/set") == "$home/.local/state/omarchy/current/theme/backgrounds/c-three.png" ]] ||
+  fail "theme-bg-prev wraps from the first background to the last" "$(cat "$tmpdir/set")"
+pass "theme-bg-prev wraps around to the last background"
+
+rm -f "$home/.local/state/omarchy/current/background"
+HOME="$home" PATH="$stub:$PATH" BG_SET_LOG="$tmpdir/set" \
+  "$BASH" "$ROOT/bin/omarchy-theme-bg-prev"
+
+[[ $(<"$tmpdir/set") == "$home/.local/state/omarchy/current/theme/backgrounds/c-three.png" ]] ||
+  fail "theme-bg-prev starts at the last background when none is current" "$(cat "$tmpdir/set")"
+pass "theme-bg-prev starts at the last background when none is set"
+
+rm -rf "$home/.local/state/omarchy/current/theme/backgrounds"
+mkdir -p "$home/.local/state/omarchy/current/theme/backgrounds"
+HOME="$home" PATH="$stub:$PATH" NOTIFY_LOG="$tmpdir/notify" \
+  "$BASH" "$ROOT/bin/omarchy-theme-bg-prev"
+
+grep -Fq 'No background was found for theme' "$tmpdir/notify" ||
+  fail "theme-bg-prev notifies when the theme has no backgrounds" "$(cat "$tmpdir/notify")"
+pass "theme-bg-prev notifies when there is nothing to cycle"

--- a/test/shell.d/theme-bg-prev-test.sh
+++ b/test/shell.d/theme-bg-prev-test.sh
@@ -62,3 +62,34 @@ HOME="$home" PATH="$stub:$PATH" NOTIFY_LOG="$tmpdir/notify" \
 grep -Fq 'No background was found for theme' "$tmpdir/notify" ||
   fail "theme-bg-prev notifies when the theme has no backgrounds" "$(cat "$tmpdir/notify")"
 pass "theme-bg-prev notifies when there is nothing to cycle"
+
+# The current background is stored by its resolved path, while candidates can
+# be reached through a symlinked user background directory.
+user_backgrounds="$home/.config/omarchy/backgrounds/tokyo-night"
+real_backgrounds="$tmpdir/backgrounds with spaces"
+mkdir -p "$(dirname "$user_backgrounds")" "$real_backgrounds"
+ln -s "$real_backgrounds" "$user_backgrounds"
+for name in a.png b.png c.png; do
+  printf 'image' >"$real_backgrounds/$name"
+done
+
+for current in c b a; do
+  case "$current" in
+    c) previous=b ;;
+    b) previous=a ;;
+    a) previous=c ;;
+  esac
+  ln -sfn "$real_backgrounds/$current.png" "$home/.local/state/omarchy/current/background"
+  HOME="$home" PATH="$stub:$PATH" BG_SET_LOG="$tmpdir/set" \
+    "$BASH" "$ROOT/bin/omarchy-theme-bg-prev"
+  [[ $(<"$tmpdir/set") == "$user_backgrounds/$previous.png" ]] ||
+    fail "theme-bg-prev cycles symlinked backgrounds from $current to $previous" "$(cat "$tmpdir/set")"
+done
+pass "theme-bg-prev cycles every background and wraps through a symlinked directory"
+
+ln -sfn "../../../../../backgrounds with spaces/b.png" "$home/.local/state/omarchy/current/background"
+HOME="$home" PATH="$stub:$PATH" BG_SET_LOG="$tmpdir/set" \
+  "$BASH" "$ROOT/bin/omarchy-theme-bg-prev"
+[[ $(<"$tmpdir/set") == "$user_backgrounds/a.png" ]] ||
+  fail "theme-bg-prev resolves a relative current background link" "$(cat "$tmpdir/set")"
+pass "theme-bg-prev resolves a relative current background link"


### PR DESCRIPTION
Fixes #8508.

`omarchy-theme-bg-next` walks the current theme's images forward. There is no matching previous, so going back one means cycling all the way around.

This adds `omarchy-theme-bg-prev` on the same image list, wrapping from the first image to the last. `omarchy theme next/prev` (#8155) is installed *themes*, not these background files.

## Verification

`test/shell.d/theme-bg-prev-test.sh`:

```
ok - theme-bg-prev selects the previous background
ok - theme-bg-prev wraps around to the last background
ok - theme-bg-prev starts at the last background when none is set
ok - theme-bg-prev notifies when there is nothing to cycle
```

Three stubbed backgrounds `a-one.png`, `b-two.png`, `c-three.png`. From `b` it sets `a`; from `a` it wraps to `c`; with no current link it starts at `c`; with an empty dir it notifies and does not call `omarchy-theme-bg-set`.


The background comparison follows file identity, so symlinked background directories and relative current-background links also cycle correctly. The six focused shell checks pass under Bash 5, including the original symlink failure. No compositor/UI run was performed on the macOS development host.
