### PR TITLE
Show a QR code for the clipboard from Trigger > Share

### DIFF
--- a/bin/omarchy-share-qr
+++ b/bin/omarchy-share-qr
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# omarchy:summary=Show a QR code for the clipboard or given text
+# omarchy:group=share
+# omarchy:args=[text]
+# omarchy:examples=omarchy share qr | omarchy share qr 'https://omarchy.org'
+
+set -euo pipefail
+
+display=0
+if [[ ${1:-} == "--display" ]]; then
+  display=1
+  shift
+fi
+
+text=${1:-${OMARCHY_SHARE_QR_TEXT:-}}
+if [[ -z $text ]]; then
+  text=$(wl-paste --no-newline 2>/dev/null || true)
+fi
+
+if [[ -z $text ]]; then
+  omarchy-notification-send -g 󰐲 -u critical "Nothing to share" "Copy some text first, or pass it as an argument"
+  exit 1
+fi
+
+if (( ${#text} > 2000 )); then
+  omarchy-notification-send -g 󰐲 -u critical "Too much to encode" "QR codes top out around 2 KB of text"
+  exit 1
+fi
+
+# Menu actions and other non-tty callers get a floating terminal. Clipboard
+# content is read again inside it; an explicit argument is handed over in the
+# environment so it does not have to stay on the terminal argv.
+if (( ! display )) && [[ ! -t 1 ]]; then
+  if [[ -n ${1:-} ]]; then
+    exec env OMARCHY_SHARE_QR_TEXT="$1" omarchy-launch-floating-terminal-with-presentation "omarchy-share-qr --display"
+  else
+    exec omarchy-launch-floating-terminal-with-presentation "omarchy-share-qr --display"
+  fi
+fi
+
+if ! printf '%s' "$text" | qrencode --type ANSIUTF8 --output -; then
+  omarchy-notification-send -g 󰐲 -u critical "Could not encode QR" "Try a shorter string"
+  exit 1
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -84,6 +84,7 @@
   "trigger.reminder.show": {"icon":"󰢌","label":"Show all","action":"omarchy-reminder show"},
   "trigger.reminder.clear": {"icon":"󰢌","label":"Clear all","action":"omarchy-reminder clear"},
   "trigger.share.clipboard": {"icon":"","label":"Clipboard","action":"omarchy-menu-share clipboard"},
+  "trigger.share.qr": {"icon":"󰐲","label":"QR Code","action":"omarchy-share-qr"},
   "trigger.share.file": {"icon":"","label":"File","action":"omarchy-menu-share file"},
   "trigger.share.folder": {"icon":"","label":"Folder","action":"omarchy-menu-share folder"},
   "trigger.share.receive": {"icon":"󰥦","label":"Receive","action":"uwsm-app -- localsend"},

--- a/test/shell.d/share-qr-test.sh
+++ b/test/shell.d/share-qr-test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub="$tmpdir/bin"
+mkdir -p "$stub"
+
+cat >"$stub/qrencode" <<'SH'
+#!/bin/bash
+cat >"$QRENCODE_IN"
+printf 'QR:%s\n' "$(<"$QRENCODE_IN")"
+SH
+cat >"$stub/wl-paste" <<'SH'
+#!/bin/bash
+printf '%s' "${PASTE:-}"
+SH
+cat >"$stub/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$NOTIFY_LOG"
+SH
+cat >"$stub/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$LAUNCH_LOG"
+SH
+chmod +x "$stub"/*
+
+run_qr() {
+  PATH="$stub:$PATH" QRENCODE_IN="$tmpdir/qr-in" NOTIFY_LOG="$tmpdir/notify" LAUNCH_LOG="$tmpdir/launch" \
+    "$ROOT/bin/omarchy-share-qr" "$@"
+}
+
+: >"$tmpdir/notify"
+if PATH="$stub:$PATH" PASTE="" NOTIFY_LOG="$tmpdir/notify" "$ROOT/bin/omarchy-share-qr" --display; then
+  fail "share-qr refuses an empty clipboard"
+fi
+grep -Fq 'Nothing to share' "$tmpdir/notify" ||
+  fail "share-qr names an empty clipboard" "$(cat "$tmpdir/notify")"
+pass "share-qr refuses an empty clipboard"
+
+output=$(PATH="$stub:$PATH" QRENCODE_IN="$tmpdir/qr-in" "$ROOT/bin/omarchy-share-qr" --display "https://omarchy.org")
+[[ $output == "QR:https://omarchy.org" ]] ||
+  fail "share-qr encodes an explicit argument" "$output"
+[[ $(<"$tmpdir/qr-in") == "https://omarchy.org" ]] ||
+  fail "share-qr hands the argument to qrencode" "$(cat "$tmpdir/qr-in")"
+pass "share-qr encodes an explicit argument"
+
+output=$(PATH="$stub:$PATH" PASTE="hello from clip" QRENCODE_IN="$tmpdir/qr-in" "$ROOT/bin/omarchy-share-qr" --display)
+[[ $output == "QR:hello from clip" ]] ||
+  fail "share-qr encodes the clipboard" "$output"
+pass "share-qr encodes the clipboard"
+
+PATH="$stub:$PATH" PASTE="x" LAUNCH_LOG="$tmpdir/launch" \
+  "$ROOT/bin/omarchy-share-qr" </dev/null >/dev/null || true
+[[ $(<"$tmpdir/launch") == "omarchy-share-qr --display" ]] ||
+  fail "share-qr opens a floating terminal when stdout is not a tty" "$(cat "$tmpdir/launch")"
+pass "share-qr opens a floating terminal when stdout is not a tty"
+
+long=$(python3 -c 'print("a"*2001)')
+: >"$tmpdir/notify"
+if PATH="$stub:$PATH" NOTIFY_LOG="$tmpdir/notify" "$ROOT/bin/omarchy-share-qr" --display "$long"; then
+  fail "share-qr refuses a payload that cannot fit in a QR"
+fi
+grep -Fq 'Too much to encode' "$tmpdir/notify" ||
+  fail "share-qr names an oversized payload" "$(cat "$tmpdir/notify")"
+pass "share-qr refuses a payload that cannot fit in a QR"
+
+grep -Fq '"trigger.share.qr"' "$ROOT/default/omarchy/omarchy-menu.jsonc" ||
+  fail "share-qr is on the Share menu"
+pass "share-qr is on the Share menu"


### PR DESCRIPTION
Fixes #8509.

Trigger > Share can send the clipboard with LocalSend. There is no scan-with-phone path for a URL or snippet already copied.

This adds `omarchy-share-qr` on that menu. It encodes the clipboard (or an argument) with the same `qrencode --type ANSIUTF8` the Wi-Fi share card uses, opens a floating terminal when stdout is not a tty, and refuses empty or oversized payloads.

## Verification

`test/shell.d/share-qr-test.sh`:

```
ok - share-qr refuses an empty clipboard
ok - share-qr encodes an explicit argument
ok - share-qr encodes the clipboard
ok - share-qr opens a floating terminal when stdout is not a tty
ok - share-qr refuses a payload that cannot fit in a QR
ok - share-qr is on the Share menu
```

A stub `qrencode` records stdin. `--display` is the in-terminal path the floating helper re-invokes.
