### PR TITLE
Add a presentation mode that stays awake, silences notifications, and hides the bar

### DIFF
--- a/bin/omarchy-toggle-presentation
+++ b/bin/omarchy-toggle-presentation
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle presentation mode (stay awake, silence notifications, hide the bar)
+# omarchy:group=toggle
+# omarchy:args=[toggle|on|off|status]
+# omarchy:examples=omarchy toggle presentation | omarchy toggle presentation on | omarchy toggle presentation status
+
+set -euo pipefail
+
+STATE_DIR="$HOME/.local/state/omarchy/toggles"
+STATE_FILE="$STATE_DIR/presentation"
+RESTORE_FILE="$HOME/.local/state/omarchy/presentation-restore"
+STAY_AWAKE_FILE="$HOME/.local/state/omarchy/indicators/stay-awake"
+
+enabled() {
+  [[ -f $STATE_FILE ]]
+}
+
+dnd_state() {
+  local state
+  state=$(omarchy-shell notifications dndState 2>/dev/null || true)
+  if [[ $state == "on" ]]; then
+    printf 'on\n'
+  else
+    printf 'off\n'
+  fi
+}
+
+write_restore() {
+  local bar_off=0 stay=0 dnd
+  mkdir -p "$(dirname "$RESTORE_FILE")"
+  omarchy-toggle-enabled bar-off && bar_off=1 || true
+  [[ -f $STAY_AWAKE_FILE ]] && stay=1 || true
+  dnd=$(dnd_state)
+  printf 'bar_off=%s\ndnd=%s\nstay_awake=%s\n' "$bar_off" "$dnd" "$stay" >"$RESTORE_FILE"
+}
+
+enable_presentation() {
+  mkdir -p "$STATE_DIR"
+  if enabled; then
+    return 0
+  fi
+  write_restore
+  omarchy-toggle-bar on
+  omarchy-shell -q notifications setDnd on
+  omarchy-toggle-idle stay-awake >/dev/null
+  touch "$STATE_FILE"
+  omarchy-shell -q omarchy.indicators refresh
+  omarchy-notification-send -g 󰐼 "Presentation mode on" "Stay awake, notifications silenced, bar hidden"
+}
+
+disable_presentation() {
+  local bar_off=0 stay=0 dnd=off
+  if [[ -f $RESTORE_FILE ]]; then
+    bar_off=$(awk -F= '$1 == "bar_off" { print $2 }' "$RESTORE_FILE")
+    dnd=$(awk -F= '$1 == "dnd" { print $2 }' "$RESTORE_FILE")
+    stay=$(awk -F= '$1 == "stay_awake" { print $2 }' "$RESTORE_FILE")
+  fi
+  rm -f "$STATE_FILE" "$RESTORE_FILE"
+
+  if [[ $bar_off != "1" ]]; then
+    omarchy-toggle-bar off
+  fi
+  if [[ $dnd != "on" ]]; then
+    omarchy-shell -q notifications setDnd off
+  fi
+  if [[ $stay != "1" ]]; then
+    omarchy-toggle-idle allow-idle >/dev/null
+  fi
+  omarchy-shell -q omarchy.indicators refresh
+  omarchy-notification-send -g 󰐼 "Presentation mode off"
+}
+
+print_status() {
+  if enabled; then
+    printf 'on\n'
+  else
+    printf 'off\n'
+  fi
+}
+
+case "${1:-toggle}" in
+  toggle)
+    if enabled; then
+      disable_presentation
+    else
+      enable_presentation
+    fi
+    print_status
+    ;;
+  on)
+    enable_presentation
+    print_status
+    ;;
+  off)
+    disable_presentation
+    print_status
+    ;;
+  status|--status)
+    print_status
+    ;;
+  *)
+    echo "Usage: omarchy-toggle-presentation [toggle|on|off|status]" >&2
+    exit 1
+    ;;
+esac

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -88,6 +88,7 @@
   "trigger.share.folder": {"icon":"","label":"Folder","action":"omarchy-menu-share folder"},
   "trigger.share.receive": {"icon":"󰥦","label":"Receive","action":"uwsm-app -- localsend"},
   "trigger.toggle.idle-lock": {"icon":"󰅶","label":"Stay Awake","action":"omarchy-toggle-idle"},
+  "trigger.toggle.presentation": {"icon":"󰐼","label":"Presentation","checked":"omarchy-toggle-enabled presentation","action":"omarchy-toggle-presentation"},
   "trigger.toggle.notifications": {"icon":"󰂛","label":"Notifications","action":"omarchy-toggle-notification-silencing"},
   "trigger.toggle.crash-capture": {"icon":"󱚡","label":"Crash Capture","action":"omarchy-toggle-crash-capture"},
   "trigger.toggle.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-toggle-screensaver"},

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -13,6 +13,7 @@ From the terminal, the same switches are `omarchy toggle <thing>`. Run `omarchy 
 | Night light | `Super + Ctrl + N` | `omarchy toggle nightlight` |
 | Silence notifications | `Super + Ctrl + ,` | `omarchy toggle notification silencing` |
 | Stay awake (no idle lock) | `Super + Ctrl + I` | `omarchy toggle idle` |
+| Presentation | — | `omarchy toggle presentation` |
 | Crash capture | — | `omarchy toggle crash-capture` |
 | Screensaver | — | `omarchy toggle screensaver` |
 | Menu bar | `Super + Shift + Space` | `omarchy toggle bar` |

--- a/test/shell.d/presentation-mode-test.sh
+++ b/test/shell.d/presentation-mode-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+home="$tmpdir/home"
+stub="$tmpdir/bin"
+mkdir -p "$home" "$stub"
+
+cat >"$stub/omarchy-shell" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SHELL_LOG"
+if [[ $1 == "-q" ]]; then
+  shift
+fi
+if [[ $1 == "notifications" && $2 == "dndState" ]]; then
+  printf '%s\n' "${DND_STATE:-off}"
+  exit 0
+fi
+if [[ $1 == "notifications" && $2 == "setDnd" ]]; then
+  printf '%s\n' "$3" >"$DND_SET_LOG"
+  exit 0
+fi
+exit 0
+SH
+cat >"$stub/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+SH
+chmod +x "$stub/omarchy-shell" "$stub/omarchy-notification-send"
+
+run() {
+  HOME="$home" PATH="$stub:$ROOT/bin:$PATH" \
+    SHELL_LOG="$tmpdir/shell.log" DND_SET_LOG="$tmpdir/dnd" NOTIFY_LOG="$tmpdir/notify" \
+    DND_STATE="${DND_STATE:-off}" \
+    "$ROOT/bin/omarchy-toggle-presentation" "$@"
+}
+
+status=$(run on)
+[[ $status == "on" ]] || fail "presentation on prints on" "$status"
+[[ -f $home/.local/state/omarchy/toggles/presentation ]] ||
+  fail "presentation on sets the presentation flag"
+[[ -f $home/.local/state/omarchy/toggles/bar-off ]] ||
+  fail "presentation on hides the bar"
+[[ -f $home/.local/state/omarchy/indicators/stay-awake ]] ||
+  fail "presentation on stays awake"
+[[ $(<"$tmpdir/dnd") == "on" ]] ||
+  fail "presentation on silences notifications" "$(cat "$tmpdir/dnd")"
+grep -Fq 'Presentation mode on' "$tmpdir/notify" ||
+  fail "presentation on notifies" "$(cat "$tmpdir/notify")"
+pass "presentation on hides the bar, silences notifications, and stays awake"
+
+: >"$tmpdir/dnd"
+: >"$tmpdir/notify"
+status=$(run off)
+[[ $status == "off" ]] || fail "presentation off prints off" "$status"
+[[ ! -f $home/.local/state/omarchy/toggles/presentation ]] ||
+  fail "presentation off clears the presentation flag"
+[[ ! -f $home/.local/state/omarchy/toggles/bar-off ]] ||
+  fail "presentation off shows the bar again when it was visible"
+[[ ! -f $home/.local/state/omarchy/indicators/stay-awake ]] ||
+  fail "presentation off allows idle when stay-awake was off"
+[[ $(<"$tmpdir/dnd") == "off" ]] ||
+  fail "presentation off restores notifications" "$(cat "$tmpdir/dnd")"
+pass "presentation off restores the previous bar, dnd, and idle state"
+
+# Already presenting: bar hidden, dnd on, stay-awake on — turning presentation
+# off must leave those alone.
+mkdir -p "$home/.local/state/omarchy/toggles" "$home/.local/state/omarchy/indicators"
+touch "$home/.local/state/omarchy/toggles/bar-off"
+touch "$home/.local/state/omarchy/indicators/stay-awake"
+DND_STATE=on
+: >"$tmpdir/dnd"
+run on >/dev/null
+: >"$tmpdir/dnd"
+run off >/dev/null
+[[ -f $home/.local/state/omarchy/toggles/bar-off ]] ||
+  fail "presentation off leaves a bar that was already hidden"
+[[ -f $home/.local/state/omarchy/indicators/stay-awake ]] ||
+  fail "presentation off leaves stay-awake that was already on"
+[[ ! -s $tmpdir/dnd ]] ||
+  fail "presentation off does not clear dnd that was already on" "$(cat "$tmpdir/dnd")"
+pass "presentation off does not undo state it did not change"
+
+grep -Fq '"trigger.toggle.presentation"' "$ROOT/default/omarchy/omarchy-menu.jsonc" ||
+  fail "presentation mode is on the Toggle menu"
+pass "presentation mode is on the Toggle menu"


### PR DESCRIPTION
Fixes #8510.

Stay Awake, notification silencing, and hiding the bar are separate toggles. For a talk you want all three at once, then the previous combination restored.

This adds `omarchy-toggle-presentation` on Trigger > Toggle. It records whether the bar was already hidden, DND already on, and stay-awake already set, then restores only what it changed. #8154 is the presentation *logo* color, not this toggle.

## Verification

`test/shell.d/presentation-mode-test.sh`:

```
ok - presentation on hides the bar, silences notifications, and stays awake
ok - presentation off restores the previous bar, dnd, and idle state
ok - presentation off does not undo state it did not change
ok - presentation mode is on the Toggle menu
```

On/off from a clean home hides the bar, sets DND, and stay-awake, then puts them back. A second case starts with those already on and checks `off` leaves them alone.
