### PR TITLE
Size popped-out windows for the active monitor

### DIFF
--- a/bin/omarchy-hyprland-window-pop
+++ b/bin/omarchy-hyprland-window-pop
@@ -3,14 +3,15 @@
 # omarchy:summary=Toggle to pop-out a tile to stay fixed on a display basis.
 # omarchy:args=[width height x y]
 
-width=${1:-1300}
-height=${2:-900}
+width=${1:-}
+height=${2:-}
 x=${3:-}
 y=${4:-}
 
 active=$(hyprctl activewindow -j)
 pinned=$(echo "$active" | jq ".pinned")
 addr=$(echo "$active" | jq -r ".address")
+monitor=$(echo "$active" | jq ".monitor")
 window="address:$addr"
 
 hypr_dispatch() {
@@ -25,6 +26,20 @@ if [[ $pinned == "true" ]]; then
   hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
   hypr_dispatch "hl.dsp.window.tag({ window = \"$window\", tag = \"-pop\" })" tagwindow -pop "$window"
 elif [[ -n $addr ]]; then
+  if [[ -z $width && -z $height ]]; then
+    # Size an unqualified pop-out to 80% of the monitor's usable logical area.
+    read -r width height < <(
+      hyprctl monitors -j | jq -r --argjson id "$monitor" '
+        first(.[] | select(.id == $id)) |
+        ((if (.transform // 0) % 2 == 1 then .height else .width end) / .scale - .reserved[0] - .reserved[2]) as $width |
+        ((if (.transform // 0) % 2 == 1 then .width else .height end) / .scale - .reserved[1] - .reserved[3]) as $height |
+        [($width * 0.8 | floor), ($height * 0.8 | floor)] | @tsv
+      '
+    )
+  fi
+  width=${width:-1300}
+  height=${height:-900}
+
   hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
   hypr_dispatch "hl.dsp.window.resize({ window = \"$window\", x = $width, y = $height })" resizeactive exact "$width" "$height" "$window"
 

--- a/test/shell.d/hyprland-window-pop-test.sh
+++ b/test/shell.d/hyprland-window-pop-test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "activewindow" && $2 == "-j" ]]; then
+  printf '%s\n' "$HYPR_ACTIVE_WINDOW"
+elif [[ $1 == "monitors" && $2 == "-j" ]]; then
+  printf '%s\n' "$*" >>"$HYPRCTL_MONITORS_LOG"
+  printf '%s\n' "$HYPR_MONITORS"
+elif [[ $1 == "dispatch" ]]; then
+  printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+else
+  exit 1
+fi
+SH
+chmod +x "$mock_bin/hyprctl"
+
+run_pop() {
+  local active_window="$1"
+  local monitors="$2"
+  shift 2
+
+  PATH="$mock_bin:$PATH" \
+    HYPR_ACTIVE_WINDOW="$active_window" \
+    HYPR_MONITORS="$monitors" \
+    HYPRCTL_LOG="$hyprctl_log" \
+    HYPRCTL_MONITORS_LOG="$hyprctl_monitors_log" \
+    "$ROOT/bin/omarchy-hyprland-window-pop" "$@"
+}
+
+assert_resize() {
+  local expected="$1"
+
+  grep -Fq "$expected" "$hyprctl_log" || fail "pop-out resizes to $expected" "$(<"$hyprctl_log")"
+  pass "pop-out resizes to $expected"
+}
+
+hyprctl_log="$test_tmp/hyprctl.log"
+hyprctl_monitors_log="$test_tmp/hyprctl-monitors.log"
+
+run_pop \
+  '{"address":"0xabc","pinned":false,"monitor":2}' \
+  '[{"id":1,"width":1920,"height":1080,"scale":1,"transform":0,"reserved":[0,0,0,0]},{"id":2,"width":3840,"height":2160,"scale":2,"transform":0,"reserved":[0,30,0,40]}]'
+assert_resize 'hl.dsp.window.resize({ window = "address:0xabc", x = 1536, y = 808 })'
+
+>"$hyprctl_log"
+>"$hyprctl_monitors_log"
+run_pop \
+  '{"address":"0xdef","pinned":false,"monitor":3}' \
+  '[{"id":3,"width":2160,"height":3840,"scale":2,"transform":1,"reserved":[40,10,20,30]}]'
+assert_resize 'hl.dsp.window.resize({ window = "address:0xdef", x = 1488, y = 832 })'
+
+>"$hyprctl_log"
+>"$hyprctl_monitors_log"
+run_pop \
+  '{"address":"0x123","pinned":false,"monitor":4}' \
+  '[]' \
+  1300 900 123 456
+assert_resize 'hl.dsp.window.resize({ window = "address:0x123", x = 1300, y = 900 })'
+grep -Fq 'dispatch hl.dsp.window.move({ window = "address:0x123", x = 123, y = 456 })' "$hyprctl_log" || fail "explicit position is preserved" "$(<"$hyprctl_log")"
+pass "explicit position is preserved"
+[[ ! -s $hyprctl_monitors_log ]] || fail "explicit dimensions do not query monitor geometry" "$(<"$hyprctl_monitors_log")"
+pass "explicit dimensions do not query monitor geometry"


### PR DESCRIPTION
SUPER+O currently always resizes a popped-out window to 1300x900. On a scaled laptop display with 900 logical pixels of height, that cannot fit once the bar and other reserved edges are subtracted.

This sizes the no-argument pop-out to 80% of the active monitor usable logical area. It accounts for display scaling, rotation, and reserved edges. Explicit dimensions and partial arguments keep the existing 1300x900 fallbacks.

Tests:
- bash test/shell.d/hyprland-window-pop-test.sh
- bash test/shell.d/bin-style-test.sh
- ./test/cli