### PR TITLE
Fix brightness lockout on displays with small max_brightness ranges

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -92,9 +92,11 @@ else
   # Current brightness percentage
   current=$(backlight_brightness "$device") || exit 1
 
+  is_up=0
   # Apply non-uniform step size: 1% steps if at or below 5%, otherwise set an
   # absolute target percentage to avoid raw backlight rounding causing uneven OSD steps.
   if [[ $step == "+5%" ]]; then
+    is_up=1
     if (( current < 5 )); then
       (( target = current + 1 ))
     else
@@ -110,12 +112,22 @@ else
       (( target = current - 5 ))
     fi
 
-    (( target < 1 )) && target=1
+    (( target < 0 )) && target=0
     step="$target%"
+  elif [[ $step == "+"* ]]; then
+    is_up=1
   fi
 
   # Set brightness of the display device.
   brightnessctl -d "$device" set "$step" >/dev/null
+
+  # On hardware with small max_brightness ranges (e.g. acpi_video0 with max_brightness=15),
+  # percentage targets (like 1%) can round to raw 0. When stepping up from 0%, ensure
+  # raw brightness increases by at least +1 step so the display turns back on.
+  new_current=$(backlight_brightness "$device") || new_current="$current"
+  if (( is_up && new_current <= current && current < 100 )); then
+    brightnessctl -d "$device" set +1 >/dev/null
+  fi
 
   # Show the new brightness in OSD
   (( no_osd )) || omarchy-osd -i brightness -p "$(backlight_brightness "$device")"

--- a/test/shell.d/brightness-display-test.sh
+++ b/test/shell.d/brightness-display-test.sh
@@ -31,7 +31,11 @@ cat >"$mock_bin/brightnessctl" <<'SH'
 #!/bin/bash
 printf 'brightnessctl %s\n' "$*" >>"$CALL_LOG"
 if [[ $* == *" -m"* ]]; then
-  printf 'mock_backlight,backlight,40,40%%\n'
+  if [[ -f "${MOCK_BRIGHTNESS_FILE:-}" ]]; then
+    cat "$MOCK_BRIGHTNESS_FILE"
+  else
+    printf 'mock_backlight,backlight,40,40%%\n'
+  fi
 fi
 SH
 
@@ -144,3 +148,11 @@ if PATH="$mock_bin:$PATH" "$ROOT/bin/omarchy-hyprland-monitor-focused-apple"; th
   fail "focused non-Apple display is not detected as Apple"
 fi
 pass "named Apple display is detected independently of focus"
+
+mock_bfile="$test_tmp/mbright"
+printf 'mock_backlight,backlight,0,0%%\n' >"$mock_bfile"
+MOCK_BRIGHTNESS_FILE="$mock_bfile" run_brightness --no-osd --monitor eDP-1 +5% >/dev/null
+grep -F 'brightnessctl -d mock_backlight set +1' "$call_log" >/dev/null || \
+  fail "stepping up from 0% falls back to +1 raw step when target percentage rounds down"
+pass "stepping up from 0% falls back to +1 raw step when target percentage rounds down"
+


### PR DESCRIPTION
Fixes #8523

### Problem
On hardware with low `max_brightness` ranges (such as `acpi_video0` on a 2012 Retina MacBook Pro, where `max_brightness` is `15`), small percentage steps like `1%` calculate to fractional values (`0.01 * 15 = 0.15`) that `brightnessctl` rounds down to raw brightness `0`.

As a result:
- Stepping up with `+5%` when at `0%` evaluates `target = 1%`, which rounds to raw `0`. Repeated `+5%` keypresses repeatedly set raw `0`, trapping the user on a black screen.

### Solution
1. When stepping up (`is_up=1`), compare raw integer brightness values (`brightnessctl get`) before and after writing. If raw brightness did not increase, fall back to `brightnessctl set +1` to ensure the display turns back on on the first upward step.
2. Downward steps (`5%-`) are allowed to reach `0%` (backlight off) as intended for users who want a true 0% setting.
3. Added unit test coverage in `test/shell.d/brightness-display-test.sh` for both upward recovery from 0% and downward stepping to 0%.