### PR TITLE
Show a QR code for the clipboard from Trigger > Share

### DIFF
--- a/bin/omarchy-share-qr
+++ b/bin/omarchy-share-qr
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# omarchy:summary=Show a QR code for the clipboard or given text
+# omarchy:group=share
+# omarchy:args=[text...]
+# omarchy:examples=omarchy share qr | omarchy share qr 'https://omarchy.org'
+
+set -euo pipefail
+
+display=0
+if [[ ${1:-} == "--display" ]]; then
+  display=1
+  shift
+fi
+
+if (($# > 0)); then
+  text="$*"
+elif [[ -n ${OMARCHY_SHARE_QR_TEXT:-} ]]; then
+  text=$OMARCHY_SHARE_QR_TEXT
+else
+  # Images and other non-text types are not QR payloads; ignore them.
+  text=$(wl-paste --type text/plain --no-newline 2>/dev/null || true)
+fi
+
+if [[ -z $text ]]; then
+  omarchy-notification-send -g 󰐲 -u critical "Nothing to share" "Copy some text first, or pass it as an argument"
+  exit 1
+fi
+
+# QR capacity is in bytes. Version-40 binary tops out near 2.9 KB; stay under
+# 2 KB so scanners and phone cameras keep a comfortable margin.
+bytes=$(printf '%s' "$text" | wc -c)
+if ((bytes > 2000)); then
+  omarchy-notification-send -g 󰐲 -u critical "Too much to encode" "QR codes top out around 2 KB of text"
+  exit 1
+fi
+
+# Menu actions and other non-tty callers get a floating terminal. Clipboard
+# content is read again inside it; an explicit argument is handed over in the
+# environment so it does not have to stay on the terminal argv.
+if (( ! display )) && [[ ! -t 1 ]]; then
+  if (($# > 0)); then
+    exec env OMARCHY_SHARE_QR_TEXT="$text" omarchy-launch-floating-terminal-with-presentation "omarchy-share-qr --display"
+  else
+    exec omarchy-launch-floating-terminal-with-presentation "omarchy-share-qr --display"
+  fi
+fi
+
+if ! printf '%s' "$text" | qrencode --type ANSIUTF8 --output -; then
+  omarchy-notification-send -g 󰐲 -u critical "Could not encode QR" "Try a shorter string"
+  exit 1
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -84,6 +84,7 @@
   "trigger.reminder.show": {"icon":"󰢌","label":"Show all","action":"omarchy-reminder show"},
   "trigger.reminder.clear": {"icon":"󰢌","label":"Clear all","action":"omarchy-reminder clear"},
   "trigger.share.clipboard": {"icon":"","label":"Clipboard","action":"omarchy-menu-share clipboard"},
+  "trigger.share.qr": {"icon":"󰐲","label":"QR Code","action":"omarchy-share-qr"},
   "trigger.share.file": {"icon":"","label":"File","action":"omarchy-menu-share file"},
   "trigger.share.folder": {"icon":"","label":"Folder","action":"omarchy-menu-share folder"},
   "trigger.share.receive": {"icon":"󰥦","label":"Receive","action":"uwsm-app -- localsend"},

--- a/manual/22-guis.md
+++ b/manual/22-guis.md
@@ -40,14 +40,15 @@ You start Aether via the application launcher (`Super + Space`).
 
 [LocalSend](https://localsend.org/) lets you send files to other devices on the same network running the app, like Apple's AirDrop. It's cross-platform, though, so you can send files to and from Windows, macOS, Android, iOS, and of course Linux.
 
-You can open the Share menu on `Super + Ctrl + S` or under _Trigger > Share_ in the Omarchy menu. It gives you four options:
+You can open the Share menu on `Super + Ctrl + S` or under _Trigger > Share_ in the Omarchy menu. It gives you five options:
 
 - **Clipboard** sends whatever you've copied as a text file. Great for getting a link or a snippet onto your phone without emailing yourself.
+- **QR Code** shows a scannable QR for the text on your clipboard (or for text you pass on the command line). Handy when the other device isn't on LocalSend.
 - **File** opens a file picker where you can select several at once.
 - **Folder** sends an entire directory.
 - **Receive** opens LocalSend proper so another device can send something to you.
 
-The same thing works from the terminal with `omarchy share clipboard`, `omarchy share file [path]`, and `omarchy share folder [path]`. Leave the path off and you get the picker.
+The same thing works from the terminal with `omarchy share clipboard`, `omarchy share qr`, `omarchy share file [path]`, and `omarchy share folder [path]`. Leave the path off and you get the picker.
 
 You can also send straight from the file manager: right-click any selection in Nautilus and pick _Send via LocalSend_.
 

--- a/test/shell.d/share-qr-test.sh
+++ b/test/shell.d/share-qr-test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub="$tmpdir/bin"
+mkdir -p "$stub"
+
+cat >"$stub/qrencode" <<'SH'
+#!/bin/bash
+cat >"$QRENCODE_IN"
+printf 'QR:%s\n' "$(<"$QRENCODE_IN")"
+SH
+cat >"$stub/wl-paste" <<'SH'
+#!/bin/bash
+# Only text/plain is a shareable clipboard payload for QR.
+for arg in "$@"; do
+  [[ $arg == text/plain ]] && printf '%s' "${PASTE:-}" && exit 0
+done
+exit 1
+SH
+cat >"$stub/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$NOTIFY_LOG"
+SH
+cat >"$stub/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$LAUNCH_LOG"
+env | grep -E '^OMARCHY_SHARE_QR_TEXT=' >"$LAUNCH_ENV" || true
+SH
+chmod +x "$stub"/*
+
+run_qr() {
+  PATH="$stub:$PATH" QRENCODE_IN="$tmpdir/qr-in" NOTIFY_LOG="$tmpdir/notify" LAUNCH_LOG="$tmpdir/launch" \
+    LAUNCH_ENV="$tmpdir/launch-env" "$ROOT/bin/omarchy-share-qr" "$@"
+}
+
+: >"$tmpdir/notify"
+if PATH="$stub:$PATH" PASTE="" NOTIFY_LOG="$tmpdir/notify" "$ROOT/bin/omarchy-share-qr" --display; then
+  fail "share-qr refuses an empty clipboard"
+fi
+grep -Fq 'Nothing to share' "$tmpdir/notify" ||
+  fail "share-qr names an empty clipboard" "$(cat "$tmpdir/notify")"
+pass "share-qr refuses an empty clipboard"
+
+output=$(PATH="$stub:$PATH" QRENCODE_IN="$tmpdir/qr-in" "$ROOT/bin/omarchy-share-qr" --display "https://omarchy.org")
+[[ $output == "QR:https://omarchy.org" ]] ||
+  fail "share-qr encodes an explicit argument" "$output"
+[[ $(<"$tmpdir/qr-in") == "https://omarchy.org" ]] ||
+  fail "share-qr hands the argument to qrencode" "$(cat "$tmpdir/qr-in")"
+pass "share-qr encodes an explicit argument"
+
+output=$(PATH="$stub:$PATH" QRENCODE_IN="$tmpdir/qr-in" "$ROOT/bin/omarchy-share-qr" --display hello world)
+[[ $output == "QR:hello world" ]] ||
+  fail "share-qr joins multi-word arguments" "$output"
+pass "share-qr joins multi-word arguments"
+
+output=$(PATH="$stub:$PATH" PASTE="hello from clip" QRENCODE_IN="$tmpdir/qr-in" "$ROOT/bin/omarchy-share-qr" --display)
+[[ $output == "QR:hello from clip" ]] ||
+  fail "share-qr encodes the clipboard" "$output"
+pass "share-qr encodes the clipboard"
+
+: >"$tmpdir/launch"
+: >"$tmpdir/launch-env"
+PATH="$stub:$PATH" PASTE="x" LAUNCH_LOG="$tmpdir/launch" LAUNCH_ENV="$tmpdir/launch-env" \
+  "$ROOT/bin/omarchy-share-qr" </dev/null >/dev/null || true
+[[ $(<"$tmpdir/launch") == "omarchy-share-qr --display" ]] ||
+  fail "share-qr opens a floating terminal when stdout is not a tty" "$(cat "$tmpdir/launch")"
+pass "share-qr opens a floating terminal when stdout is not a tty"
+
+: >"$tmpdir/launch"
+: >"$tmpdir/launch-env"
+PATH="$stub:$PATH" LAUNCH_LOG="$tmpdir/launch" LAUNCH_ENV="$tmpdir/launch-env" \
+  "$ROOT/bin/omarchy-share-qr" "https://omarchy.org/share" </dev/null >/dev/null || true
+[[ $(<"$tmpdir/launch") == "omarchy-share-qr --display" ]] ||
+  fail "share-qr reopens with --display for an explicit argument" "$(cat "$tmpdir/launch")"
+grep -Fq 'OMARCHY_SHARE_QR_TEXT=https://omarchy.org/share' "$tmpdir/launch-env" ||
+  fail "share-qr hands explicit text through the environment" "$(cat "$tmpdir/launch-env")"
+pass "share-qr hands explicit text through the environment"
+
+long=$(awk 'BEGIN { while (n++ < 2001) printf "a" }')
+: >"$tmpdir/notify"
+if PATH="$stub:$PATH" NOTIFY_LOG="$tmpdir/notify" "$ROOT/bin/omarchy-share-qr" --display "$long"; then
+  fail "share-qr refuses a payload that cannot fit in a QR"
+fi
+grep -Fq 'Too much to encode' "$tmpdir/notify" ||
+  fail "share-qr names an oversized payload" "$(cat "$tmpdir/notify")"
+pass "share-qr refuses a payload that cannot fit in a QR"
+
+grep -Fq '"trigger.share.qr"' "$ROOT/default/omarchy/omarchy-menu.jsonc" ||
+  fail "share-qr is on the Share menu"
+pass "share-qr is on the Share menu"


### PR DESCRIPTION
Fixes #8509.

Trigger > Share can send the clipboard with LocalSend. There is no scan-with-phone path for a URL or snippet already copied.

This adds `omarchy-share-qr` on that menu. It encodes the clipboard (or an argument) with `qrencode --type ANSIUTF8`, opens a floating terminal when stdout is not a tty, and refuses empty or oversized payloads. Clipboard reads are limited to `text/plain` so an image on the pasteboard does not become a broken encode.

## Verification

`test/shell.d/share-qr-test.sh`:

```
ok - share-qr refuses an empty clipboard
ok - share-qr encodes an explicit argument
ok - share-qr joins multi-word arguments
ok - share-qr encodes the clipboard
ok - share-qr opens a floating terminal when stdout is not a tty
ok - share-qr hands explicit text through the environment
ok - share-qr refuses a payload that cannot fit in a QR
ok - share-qr is on the Share menu
```

A stub `qrencode` records stdin. `--display` is the in-terminal path the floating helper re-invokes.