### PR TITLE
Add NetworkManager VPN access to the network panel

### DIFF
--- a/bin/omarchy-network-vpn
+++ b/bin/omarchy-network-vpn
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# omarchy:summary=Manage NetworkManager VPN connections
+# omarchy:group=network
+# omarchy:args=[list|active|up <connection>|down <connection>|editor]
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: omarchy-network-vpn [list|active|up <connection>|down <connection>|editor]
+
+Manage VPN profiles through NetworkManager. Any installed NetworkManager VPN
+plugin can be used, including OpenVPN and OpenConnect.
+EOF
+}
+
+case "${1:-list}" in
+  list)
+    nmcli -t --escape no -f UUID,TYPE,NAME connection show \
+      | awk -F: '$2 == "vpn" { print }'
+    ;;
+  active)
+    nmcli -t --escape no -f TYPE,NAME connection show --active \
+      | awk -F: '$1 == "vpn" { print $2 }'
+    ;;
+  up|down)
+    [[ $# -eq 2 ]] || { usage; exit 2; }
+    nmcli connection "$1" "$2"
+    ;;
+  editor)
+    if omarchy-cmd-present nm-connection-editor; then
+      exec nm-connection-editor
+    fi
+    echo "nm-connection-editor is not installed; use 'nmtui' instead." >&2
+    exit 1
+    ;;
+  -h|--help)
+    usage >&2
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/manual/35-networking.md
+++ b/manual/35-networking.md
@@ -16,6 +16,12 @@ Omarchy uses whatever DNS your network hands out over DHCP. You can override tha
 
 From the terminal, `omarchy dns` prints the current provider and `omarchy dns Cloudflare` sets one.
 
+## VPN connections
+
+VPN profiles managed by NetworkManager are available from the network panel's VPN button. The button opens NetworkManager's connection editor, where you can import an OpenVPN `.ovpn` profile or create an OpenConnect profile for a Cisco AnyConnect gateway. OpenConnect profiles that use browser-based SSO open the external authentication flow when you connect.
+
+From the terminal, `omarchy network vpn list` lists saved VPN profiles, `omarchy network vpn active` lists active tunnels, and `omarchy network vpn up <connection>` or `omarchy network vpn down <connection>` connects or disconnects one. The available VPN types depend on the NetworkManager plugins installed on the system.
+
 ## Pinning the Wi-Fi band
 
 If your router puts 2.4GHz, 5GHz, and 6GHz on the same network name, your laptop will sometimes cling to the slow one. `omarchy network band` shows which band you're on, and `omarchy network band 5` pins it. Use `auto` to let it choose again.

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -207,6 +207,10 @@ Panel {
     Qt.callLater(function() { root.refresh(true) })
   }
 
+  function openVpnEditor() {
+    if (root.bar) root.bar.run("omarchy-network-vpn editor")
+  }
+
   IpcHandler {
     target: "omarchy.network"
 
@@ -1137,6 +1141,20 @@ Panel {
             Layout.alignment: Qt.AlignVCenter
             onHovered: function(on) { if (on) root.setHeaderCursor(root.speedHeaderIndex) }
             onClicked: root.summonSpeedTest()
+          }
+
+          Button {
+            id: vpnAction
+            visible: root.networkManagerAvailable
+            iconText: "󰌆"
+            tooltipText: "Manage VPN connections"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            iconSize: Style.font.subtitle * 1.5
+            horizontalPadding: Style.space(5)
+            verticalPadding: Style.space(2)
+            Layout.alignment: Qt.AlignVCenter
+            onClicked: root.openVpnEditor()
           }
 
           ToggleSwitch {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -208,7 +208,7 @@ Panel {
   }
 
   function openVpnEditor() {
-    if (root.bar) root.bar.run("omarchy-network-vpn editor")
+    if (root.bar) root.bar.run("nm-connection-editor")
   }
 
   IpcHandler {

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -941,7 +941,7 @@ Panel {
 
   Process {
     id: vpnProc
-    command: ["bash", "-c", "active=$(nmcli -t --escape no -f UUID,TYPE connection show --active 2>/dev/null | awk -F: '$2 == \\\"vpn\\\" { print $1 }'); nmcli -t --escape no -f UUID,TYPE,NAME connection show 2>/dev/null | awk -F: -v active=\"$active\" '$2 == \\\"vpn\\\" { uuid=$1; name=$0; sub(/^[^:]*:[^:]*:/, \\\"\\\", name); state=index(\\\"\\n\\\" active \\\"\\n\\\", \\\"\\n\\\" uuid \\\"\\n\\\") ? 1 : 0; print uuid \\\"\\t\\\" state \\\"\\t\\\" name }'"]
+    command: ["bash", "-c", "active=$(nmcli -t --escape no -f UUID,TYPE connection show --active 2>/dev/null | awk -F: '$2 == \"vpn\" { print $1 }'); nmcli -t --escape no -f UUID,TYPE,NAME connection show 2>/dev/null | awk -F: -v active=\"$active\" '$2 == \"vpn\" { uuid=$1; name=$0; sub(/^[^:]*:[^:]*:/, \"\", name); state=index(\"\\n\" active \"\\n\", \"\\n\" uuid \"\\n\") ? 1 : 0; print uuid \"\\t\" state \"\\t\" name }'"]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.updateVpn(text)

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -82,6 +82,8 @@ Panel {
   property string bandSelected: "auto"
   property var bandAvailable: []
   property string pendingBand: ""
+  property var vpnConnections: []
+  property string vpnActionUuid: ""
 
   // Per-row in-flight state. `actionSsid` flips on for the row whose action
   // is currently running so it can render "Connecting…" / "Disconnecting…" /
@@ -211,6 +213,29 @@ Panel {
     if (root.bar) root.bar.run("nm-connection-editor")
   }
 
+  function refreshVpn() {
+    if (!vpnProc.running) vpnProc.running = true
+  }
+
+  function updateVpn(raw) {
+    var rows = []
+    var lines = String(raw || "").trim().split("\n")
+    for (var i = 0; i < lines.length; i++) {
+      if (!lines[i]) continue
+      var fields = lines[i].split("\t")
+      if (fields.length < 3) continue
+      rows.push({ uuid: fields[0], active: fields[1] === "1", name: fields.slice(2).join("\t") })
+    }
+    vpnConnections = rows
+  }
+
+  function toggleVpn(connection) {
+    if (!connection || vpnActionUuid !== "") return
+    vpnActionUuid = connection.uuid
+    vpnActionProc.command = ["nmcli", "connection", connection.active ? "down" : "up", "uuid", connection.uuid]
+    vpnActionProc.running = true
+  }
+
   IpcHandler {
     target: "omarchy.network"
 
@@ -324,6 +349,7 @@ Panel {
   onOpenedChanged: {
     if (opened) {
       refresh(true)
+      refreshVpn()
       selectedIndex = wifiNetworks.length > 0 ? 0 : -1
       wifiActionFocused = false
       focusSection = wifiNetworks.length > 0 ? "wifi" : "dns"
@@ -808,7 +834,10 @@ Panel {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
-  Component.onCompleted: refresh()
+  Component.onCompleted: {
+    refresh()
+    refreshVpn()
+  }
 
   // Pulls everything we want about the active route's interface in one shot.
   Process {
@@ -900,6 +929,31 @@ Panel {
     repeat: true
     running: root.opened
     onTriggered: if (!detailsProc.running) detailsProc.running = true
+  }
+
+  Timer {
+    id: vpnPoll
+    interval: 2000
+    repeat: true
+    running: root.opened
+    onTriggered: root.refreshVpn()
+  }
+
+  Process {
+    id: vpnProc
+    command: ["bash", "-c", "active=$(nmcli -t --escape no -f UUID,TYPE connection show --active 2>/dev/null | awk -F: '$2 == \\\"vpn\\\" { print $1 }'); nmcli -t --escape no -f UUID,TYPE,NAME connection show 2>/dev/null | awk -F: -v active=\"$active\" '$2 == \\\"vpn\\\" { uuid=$1; name=$0; sub(/^[^:]*:[^:]*:/, \\\"\\\", name); state=index(\\\"\\n\\\" active \\\"\\n\\\", \\\"\\n\\\" uuid \\\"\\n\\\") ? 1 : 0; print uuid \\\"\\t\\\" state \\\"\\t\\\" name }'"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateVpn(text)
+    }
+  }
+
+  Process {
+    id: vpnActionProc
+    onExited: {
+      root.vpnActionUuid = ""
+      root.refreshVpn()
+    }
   }
 
   Timer {
@@ -1228,6 +1282,68 @@ Panel {
           }
         }
 
+      }
+
+      // Connection details: transfer metrics first, then IP/Gateway.
+      PanelSeparator {
+        visible: root.vpnConnections.length > 0
+        foreground: root.bar.foreground
+      }
+
+      Column {
+        visible: root.vpnConnections.length > 0
+        width: parent.width
+        spacing: Style.space(8)
+
+        PanelSectionHeader {
+          text: "VPN CONNECTIONS"
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+        }
+
+        Repeater {
+          model: root.vpnConnections
+
+          delegate: Item {
+            required property var modelData
+            width: parent.width
+            implicitHeight: vpnRow.implicitHeight
+
+            RowLayout {
+              id: vpnRow
+              width: parent.width
+              spacing: Style.space(8)
+
+              Text {
+                text: modelData.active ? "󰌆" : "󰦜"
+                color: modelData.active ? Color.accent : root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.body
+              }
+
+              Text {
+                text: modelData.name
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.body
+                elide: Text.ElideRight
+                Layout.fillWidth: true
+              }
+
+              Button {
+                text: modelData.active ? "Disconnect" : "Connect"
+                enabled: root.vpnActionUuid === "" || root.vpnActionUuid === modelData.uuid
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                fontSize: Style.font.bodySmall
+                horizontalPadding: Style.spacing.controlPaddingX
+                verticalPadding: Style.spacing.controlPaddingY
+                bordered: true
+                onClicked: root.toggleVpn(modelData)
+              }
+            }
+          }
+        }
       }
 
       // Connection details: transfer metrics first, then IP/Gateway.

--- a/test/shell.d/network-vpn-test.sh
+++ b/test/shell.d/network-vpn-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+cat >"$tmp/bin/nmcli" <<'EOF'
+#!/bin/bash
+case "$*" in
+  *"connection show --active"*)
+    printf 'vpn:Work VPN\nwifi:Home\n'
+    ;;
+  *"connection show"*)
+    printf 'uuid-work:vpn:Work VPN\nuuid-home:802-11-wireless:Home\n'
+    ;;
+  *)
+    printf '%s\n' "$*" >"${NMCLI_CALLS:?}"
+    ;;
+esac
+EOF
+chmod +x "$tmp/bin/nmcli"
+export PATH="$tmp/bin:$PATH"
+export NMCLI_CALLS="$tmp/calls"
+export PATH="$ROOT/bin:$PATH"
+
+assert_output() {
+  local expected=$1
+  shift
+  local actual
+  actual=$("$@")
+  [[ "$actual" == "$expected" ]] || {
+    echo "expected: $expected" >&2
+    echo "actual:   $actual" >&2
+    exit 1
+  }
+}
+
+assert_output 'uuid-work:vpn:Work VPN' omarchy-network-vpn list
+assert_output 'Work VPN' omarchy-network-vpn active
+omarchy-network-vpn up 'Work VPN'
+grep -Fx 'connection up Work VPN' "$NMCLI_CALLS" >/dev/null
+
+pass "NetworkManager VPN helper lists, reports, and changes VPN connections"


### PR DESCRIPTION
Closes #8528

## What this changes

- Adds `omarchy network vpn` for listing saved VPN profiles, listing active VPNs, and bringing profiles up or down through NetworkManager.
- Adds a VPN action to the existing NetworkManager network panel that opens the connection editor.
- Documents OpenVPN `.ovpn` imports and OpenConnect profiles, including external-browser SSO flows.
- Adds shell coverage for the NetworkManager VPN helper.

The implementation is intentionally backend-neutral: the available VPN types come from the NetworkManager plugins installed by the user or distribution. It does not store or handle VPN credentials itself.

## Validation

- `test/shell.d/network-vpn-test.sh`
- `test/shell.d/network-test.sh`
- `test/shell.d/bin-style-test.sh`
- `git diff --check`

The full shell suite was also run; unrelated baseline failures require the separate `omarchy-pkgs` checkout or desktop-specific runtime state.
