### PR TITLE
Keep fingerprint unlock working across suspend

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -110,7 +110,10 @@ Item {
   }
 
   function refreshFingerprintStatus() {
-    if (fingerprintSleepPaused) return
+    if (fingerprintSleepPaused) {
+      logEvent("fingerprint-check-skipped: sleep-paused")
+      return
+    }
     if (!fingerprintCheckProc.running) fingerprintCheckProc.running = true
   }
 
@@ -416,6 +419,7 @@ Item {
     repeat: false
     onTriggered: {
       if (root.fingerprintResumeAttempts > 0) root.fingerprintResumeAttempts -= 1
+      root.logEvent("fingerprint-resume-check attempts=" + root.fingerprintResumeAttempts)
       root.refreshFingerprintStatus()
     }
   }
@@ -474,9 +478,13 @@ Item {
       // question that no longer applies. Drop it and let the next probe decide.
       if (root.fingerprintCheckAborted) {
         root.fingerprintCheckAborted = false
+        root.logEvent("fingerprint-check-aborted")
         return
       }
-      if (root.fingerprintSleepPaused) return
+      if (root.fingerprintSleepPaused) {
+        root.logEvent("fingerprint-check-ignored: sleep-paused")
+        return
+      }
 
       var configured = String(fingerprintCheckStdout.text || "").trim() === "yes"
       if (configured) {
@@ -487,6 +495,7 @@ Item {
       } else if (SleepFingerprintModel.shouldRetryResumeProbe(root.fingerprintResumeAttempts, root.fingerprintResumeDeadlineAt, Date.now())) {
         // Fresh out of sleep, the reader may still be recovering. Keep
         // re-probing on the resume budget instead of taking "no" at face value.
+        root.logEvent("fingerprint-not-ready attempts=" + root.fingerprintResumeAttempts)
         fingerprintResumeTimer.restart()
       } else {
         root.fingerprintConfigured = false

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -4,6 +4,7 @@ import Quickshell.Io
 import Quickshell.Services.Pam
 import Quickshell.Wayland
 import qs.Commons
+import "SleepFingerprintModel.js" as SleepFingerprintModel
 
 Item {
   id: root
@@ -36,6 +37,7 @@ Item {
   property bool fingerprintSleepPaused: false
   property bool fingerprintCheckAborted: false
   property int fingerprintResumeAttempts: 0
+  property double fingerprintResumeDeadlineAt: 0
   property bool awaitingSleepSignalValue: false
 
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
@@ -216,12 +218,7 @@ Item {
     if (fingerprintPam.active || fingerprintAuthenticating) return
 
     fingerprintAuthenticating = true
-    if (!fingerprintPam.start()) {
-      fingerprintAuthenticating = false
-      fingerprintRetryTimer.restart()
-    } else {
-      fingerprintResumeAttempts = 0
-    }
+    if (!fingerprintPam.start()) fingerprintAuthenticating = false
   }
 
   function handleFingerprintFinished(result) {
@@ -257,33 +254,27 @@ Item {
     logEvent("fingerprint-paused-for-sleep")
   }
 
-  // The reader can take a few seconds to recover after resume, so re-probe
-  // for a while instead of accepting the first (possibly still-stale) answer.
+  // The reader can take a moment to recover after resume, so re-probe on a
+  // small budget instead of accepting the first (possibly still-stale)
+  // answer -- bounded by wall-clock time as well as attempt count, so a run
+  // of genuinely hung probes can't stretch this past its advertised budget.
   function resumeFingerprintAfterSleep() {
     if (!fingerprintSleepPaused) return
     fingerprintSleepPaused = false
     fingerprintAuthenticating = false
     fingerprintRetryTimer.stop()
-    fingerprintResumeAttempts = 20
+    fingerprintResumeAttempts = SleepFingerprintModel.RESUME_ATTEMPT_BUDGET
+    fingerprintResumeDeadlineAt = Date.now() + SleepFingerprintModel.RESUME_BUDGET_MS
     abortFingerprintCheck()
     logEvent("fingerprint-resume-pending")
     fingerprintResumeTimer.restart()
   }
 
   function handleSleepMonitorLine(data) {
-    var line = String(data || "")
-    if (line.indexOf("member=PrepareForSleep") !== -1) {
-      awaitingSleepSignalValue = true
-      return
-    }
-    if (!awaitingSleepSignalValue) return
-    if (line.indexOf("boolean true") !== -1) {
-      awaitingSleepSignalValue = false
-      pauseFingerprintForSleep()
-    } else if (line.indexOf("boolean false") !== -1) {
-      awaitingSleepSignalValue = false
-      resumeFingerprintAfterSleep()
-    }
+    var result = SleepFingerprintModel.parseSleepSignalLine(awaitingSleepSignalValue, data)
+    awaitingSleepSignalValue = result.awaitingValue
+    if (result.event === "pause") pauseFingerprintForSleep()
+    else if (result.event === "resume") resumeFingerprintAfterSleep()
   }
 
   WlSessionLock {
@@ -446,7 +437,16 @@ Item {
     id: fingerprintSleepMonitorRestart
     interval: 2000
     repeat: false
-    onTriggered: if (!fingerprintSleepMonitor.running) fingerprintSleepMonitor.running = true
+    onTriggered: {
+      if (!fingerprintSleepMonitor.running) fingerprintSleepMonitor.running = true
+      // The monitor exiting is itself abnormal -- it may have missed a
+      // PrepareForSleep(false) while it was down. Erring toward resuming is
+      // safe even if that guess is wrong: a probe that is genuinely too
+      // early just falls through to the resume re-probe budget, whereas
+      // staying paused on a bad guess disables fingerprint for the rest of
+      // the awake session.
+      if (root.fingerprintSleepPaused) root.resumeFingerprintAfterSleep()
+    }
   }
 
   Process {
@@ -484,8 +484,8 @@ Item {
         root.fingerprintResumeAttempts = 0
         root.logEvent("fingerprint-configured=true")
         if (root.lockRequested) root.startFingerprint()
-      } else if (root.fingerprintResumeAttempts > 0) {
-        // Fresh out of sleep, the reader is still probably recovering. Keep
+      } else if (SleepFingerprintModel.shouldRetryResumeProbe(root.fingerprintResumeAttempts, root.fingerprintResumeDeadlineAt, Date.now())) {
+        // Fresh out of sleep, the reader may still be recovering. Keep
         // re-probing on the resume budget instead of taking "no" at face value.
         fingerprintResumeTimer.restart()
       } else {

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -33,6 +33,10 @@ Item {
   property string lastEventAt: ""
   property bool strandedLock: false
   property bool strandedLockResolved: false
+  property bool fingerprintSleepPaused: false
+  property bool fingerprintCheckAborted: false
+  property int fingerprintResumeAttempts: 0
+  property bool awaitingSleepSignalValue: false
 
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
@@ -104,6 +108,7 @@ Item {
   }
 
   function refreshFingerprintStatus() {
+    if (fingerprintSleepPaused) return
     if (!fingerprintCheckProc.running) fingerprintCheckProc.running = true
   }
 
@@ -207,23 +212,77 @@ Item {
   }
 
   function startFingerprint() {
-    if (!lockRequested || !sessionLock.secure || !fingerprintConfigured) return
+    if (fingerprintSleepPaused || !lockRequested || !sessionLock.secure || !fingerprintConfigured) return
     if (fingerprintPam.active || fingerprintAuthenticating) return
 
     fingerprintAuthenticating = true
     if (!fingerprintPam.start()) {
       fingerprintAuthenticating = false
+      fingerprintRetryTimer.restart()
+    } else {
+      fingerprintResumeAttempts = 0
     }
   }
 
   function handleFingerprintFinished(result) {
     fingerprintAuthenticating = false
 
-    if (!lockRequested) return
+    if (fingerprintSleepPaused || !lockRequested) return
     if (result === PamResult.Success) {
       finishUnlock()
     } else if (fingerprintConfigured) {
       fingerprintRetryTimer.restart()
+    }
+  }
+
+  function abortFingerprintCheck() {
+    if (!fingerprintCheckProc.running) return
+    fingerprintCheckAborted = true
+    fingerprintCheckProc.running = false
+  }
+
+  // A sleep can catch fprintd mid-probe: it D-Bus-activates during suspend,
+  // sees the reader too early, and reports "unsupported firmware version"
+  // before it has actually come back. Pause checks across the sleep boundary
+  // and drop whatever result was already in flight, rather than trust a
+  // probe that straddled it.
+  function pauseFingerprintForSleep() {
+    fingerprintSleepPaused = true
+    fingerprintResumeAttempts = 0
+    fingerprintResumeTimer.stop()
+    fingerprintRetryTimer.stop()
+    fingerprintAuthenticating = false
+    if (fingerprintPam.active) fingerprintPam.abort()
+    abortFingerprintCheck()
+    logEvent("fingerprint-paused-for-sleep")
+  }
+
+  // The reader can take a few seconds to recover after resume, so re-probe
+  // for a while instead of accepting the first (possibly still-stale) answer.
+  function resumeFingerprintAfterSleep() {
+    if (!fingerprintSleepPaused) return
+    fingerprintSleepPaused = false
+    fingerprintAuthenticating = false
+    fingerprintRetryTimer.stop()
+    fingerprintResumeAttempts = 20
+    abortFingerprintCheck()
+    logEvent("fingerprint-resume-pending")
+    fingerprintResumeTimer.restart()
+  }
+
+  function handleSleepMonitorLine(data) {
+    var line = String(data || "")
+    if (line.indexOf("member=PrepareForSleep") !== -1) {
+      awaitingSleepSignalValue = true
+      return
+    }
+    if (!awaitingSleepSignalValue) return
+    if (line.indexOf("boolean true") !== -1) {
+      awaitingSleepSignalValue = false
+      pauseFingerprintForSleep()
+    } else if (line.indexOf("boolean false") !== -1) {
+      awaitingSleepSignalValue = false
+      resumeFingerprintAfterSleep()
     }
   }
 
@@ -349,7 +408,7 @@ Item {
 
     onError: function(error) {
       root.fingerprintAuthenticating = false
-      if (root.lockRequested && root.fingerprintConfigured) fingerprintRetryTimer.restart()
+      if (!root.fingerprintSleepPaused && root.lockRequested && root.fingerprintConfigured) fingerprintRetryTimer.restart()
     }
   }
 
@@ -358,6 +417,36 @@ Item {
     interval: 250
     repeat: false
     onTriggered: root.startFingerprint()
+  }
+
+  Timer {
+    id: fingerprintResumeTimer
+    interval: 1000
+    repeat: false
+    onTriggered: {
+      if (root.fingerprintResumeAttempts > 0) root.fingerprintResumeAttempts -= 1
+      root.refreshFingerprintStatus()
+    }
+  }
+
+  // login1 emits PrepareForSleep(true) just before suspend and (false) on
+  // resume. dbus-monitor is simpler than a proper signal-match subscription
+  // here, and this process is cheap to keep running for the plugin's lifetime.
+  Process {
+    id: fingerprintSleepMonitor
+    running: true
+    command: ["dbus-monitor", "--system", "type='signal',sender='org.freedesktop.login1',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'"]
+    stdout: SplitParser {
+      onRead: function(data) { root.handleSleepMonitorLine(data) }
+    }
+    onExited: fingerprintSleepMonitorRestart.restart()
+  }
+
+  Timer {
+    id: fingerprintSleepMonitorRestart
+    interval: 2000
+    repeat: false
+    onTriggered: if (!fingerprintSleepMonitor.running) fingerprintSleepMonitor.running = true
   }
 
   Process {
@@ -377,12 +466,33 @@ Item {
 
   Process {
     id: fingerprintCheckProc
-    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && command -v fprintd-list >/dev/null 2>&1 && fprintd-list \"$USER\" 2>/dev/null | grep -qi finger; then echo yes; else echo no; fi"]
+    // fprintd-list can hang instead of failing if the reader is wedged mid-resume.
+    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && command -v fprintd-list >/dev/null 2>&1 && timeout 8 fprintd-list \"$USER\" 2>/dev/null | grep -qi finger; then echo yes; else echo no; fi"]
     stdout: StdioCollector { id: fingerprintCheckStdout; waitForEnd: true }
     onExited: {
-      root.fingerprintConfigured = String(fingerprintCheckStdout.text || "").trim() === "yes"
-      if (root.lockRequested && root.fingerprintConfigured) root.startFingerprint()
-      else if (!root.fingerprintConfigured && fingerprintPam.active) fingerprintPam.abort()
+      // This result was in flight when sleep started or ended; it answers a
+      // question that no longer applies. Drop it and let the next probe decide.
+      if (root.fingerprintCheckAborted) {
+        root.fingerprintCheckAborted = false
+        return
+      }
+      if (root.fingerprintSleepPaused) return
+
+      var configured = String(fingerprintCheckStdout.text || "").trim() === "yes"
+      if (configured) {
+        root.fingerprintConfigured = true
+        root.fingerprintResumeAttempts = 0
+        root.logEvent("fingerprint-configured=true")
+        if (root.lockRequested) root.startFingerprint()
+      } else if (root.fingerprintResumeAttempts > 0) {
+        // Fresh out of sleep, the reader is still probably recovering. Keep
+        // re-probing on the resume budget instead of taking "no" at face value.
+        fingerprintResumeTimer.restart()
+      } else {
+        root.fingerprintConfigured = false
+        if (fingerprintPam.active) fingerprintPam.abort()
+        root.logEvent("fingerprint-configured=false")
+      }
     }
   }
 
@@ -530,6 +640,8 @@ Item {
         realScreens: root.realScreenCount(),
         passwordPam: root.passwordPamConfigured,
         fingerprint: root.fingerprintConfigured,
+        fingerprintSleepPaused: root.fingerprintSleepPaused,
+        fingerprintResumeAttempts: root.fingerprintResumeAttempts,
         authenticating: root.authenticating,
         lastEvent: root.lastEvent,
         lastEventAt: root.lastEventAt

--- a/shell/plugins/lock/SleepFingerprintModel.js
+++ b/shell/plugins/lock/SleepFingerprintModel.js
@@ -1,0 +1,51 @@
+// Parsing and pacing for pausing fingerprint checks across suspend. login1
+// emits PrepareForSleep as a multi-line dbus-monitor block: a header line
+// naming the member, then a separate body line carrying the boolean
+// argument. Track "we just saw the header" independently of the value line
+// itself, so a change of interface or path in the header can never be read
+// as a boolean that happens to appear nearby.
+
+function parseSleepSignalLine(awaitingValue, line) {
+  var text = String(line || "")
+
+  if (text.indexOf("member=PrepareForSleep") !== -1) {
+    return { awaitingValue: true, event: null }
+  }
+
+  if (!awaitingValue) return { awaitingValue: false, event: null }
+
+  if (text.indexOf("boolean true") !== -1) {
+    return { awaitingValue: false, event: "pause" }
+  }
+
+  if (text.indexOf("boolean false") !== -1) {
+    return { awaitingValue: false, event: "resume" }
+  }
+
+  return { awaitingValue: awaitingValue, event: null }
+}
+
+// A small margin, not the reader's full recovery envelope: every observed
+// resume on the reproducer hardware succeeded on the very first post-resume
+// check, so this is cheap insurance for hardware slower than that, not a
+// budget sized off a witnessed worst case.
+var RESUME_ATTEMPT_BUDGET = 3
+var RESUME_BUDGET_MS = 5000
+
+// The reader can take a moment to recover after resume, so re-probe instead
+// of trusting the first answer -- but bounded by wall-clock time as well as
+// attempt count. Each probe carries its own timeout, so a run of genuinely
+// hung probes must not be able to stretch this past the budget attempt
+// count alone would suggest.
+function shouldRetryResumeProbe(attemptsRemaining, deadlineAt, now) {
+  return attemptsRemaining > 0 && now < deadlineAt
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    RESUME_ATTEMPT_BUDGET: RESUME_ATTEMPT_BUDGET,
+    RESUME_BUDGET_MS: RESUME_BUDGET_MS,
+    parseSleepSignalLine: parseSleepSignalLine,
+    shouldRetryResumeProbe: shouldRetryResumeProbe
+  }
+}

--- a/test/shell.d/lock-sleep-fingerprint-model-test.sh
+++ b/test/shell.d/lock-sleep-fingerprint-model-test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const model = requireFromRoot('shell/plugins/lock/SleepFingerprintModel.js')
+
+// dbus-monitor emits PrepareForSleep as a header line, then a separate body
+// line with the boolean. Neither line alone is enough signal.
+function feed(lines) {
+  let awaiting = false
+  const events = []
+  for (const line of lines) {
+    const result = model.parseSleepSignalLine(awaiting, line)
+    awaiting = result.awaitingValue
+    if (result.event) events.push(result.event)
+  }
+  return { awaiting, events }
+}
+
+assertDeepEqual(
+  feed(["signal sender=:1.2 -> member=PrepareForSleep", "   boolean true"]).events,
+  ["pause"],
+  "a PrepareForSleep header followed by boolean true is a pause"
+)
+
+assertDeepEqual(
+  feed(["signal sender=:1.2 -> member=PrepareForSleep", "   boolean false"]).events,
+  ["resume"],
+  "a PrepareForSleep header followed by boolean false is a resume"
+)
+
+assertDeepEqual(
+  feed(["   boolean true"]).events,
+  [],
+  "a boolean line with no preceding header is not mistaken for a signal"
+)
+
+assertDeepEqual(
+  feed(["signal sender=:1.2 -> member=SomeOtherSignal", "   boolean true"]).events,
+  [],
+  "a boolean line after an unrelated member is ignored"
+)
+
+assertEqual(
+  feed(["signal sender=:1.2 -> member=PrepareForSleep", "   string \"unrelated\""]).awaiting,
+  true,
+  "a non-boolean body line leaves the header still pending"
+)
+
+assertDeepEqual(
+  feed([
+    "signal sender=:1.2 -> member=PrepareForSleep",
+    "   boolean true",
+    "signal sender=:1.2 -> member=PrepareForSleep",
+    "   boolean false"
+  ]).events,
+  ["pause", "resume"],
+  "consecutive sleep/wake signals are each parsed independently"
+)
+
+// Resume budget: bounded by wall-clock time as well as attempt count, so a
+// run of hung probes (each carrying its own timeout) cannot stretch the
+// recovery window past what the budget advertises.
+assert(
+  model.shouldRetryResumeProbe(1, Date.now() + 5000, Date.now()),
+  "retries while attempts remain and the deadline has not passed"
+)
+assert(
+  !model.shouldRetryResumeProbe(0, Date.now() + 5000, Date.now()),
+  "stops once attempts are exhausted even with time left on the clock"
+)
+assert(
+  !model.shouldRetryResumeProbe(10, Date.now() - 1, Date.now()),
+  "stops once the deadline has passed even with attempts left"
+)
+
+assert(model.RESUME_ATTEMPT_BUDGET > 0, "the attempt budget is a positive count")
+assert(model.RESUME_BUDGET_MS > 0, "the wall-clock budget is a positive duration")
+JS


### PR DESCRIPTION
## Problem

Stock lock can drop fingerprint PAM across suspend. The lock's "is
fingerprint configured" probe (`fprintd-list`, in `fingerprintCheckProc`)
starts in the same window the sleep inhibitor releases and real suspend
begins — it D-Bus-activates fprintd if it isn't already running. fprintd
is then refused its own sleep-delay inhibitor, because the sleep
operation it would be inhibiting is already in flight
(`org.freedesktop.login1.OperationInProgress`), and so never sees
`PrepareForSleep(false)`. On resume it answers before the reader has
actually recovered. On the reproducer hardware that's `unsupported
firmware version`; the probe reports "no" instead of hanging,
`fingerprintConfigured` gets stuck `false`, and the lock never offers
fingerprint for that unlock. Same shape as #7229.

**Nothing recovers from this on Arch.** The `fprintd` package ships one
unit, `fprintd.service`; `fprintd-resume.service` is a Debian/Ubuntu
addition. An earlier version of this description claimed the daemon is
restarted at resume and the device recovers "too late" — that was wrong,
and my own fault: the unit I was seeing is one I hand-wrote on this
machine a year ago and had forgotten, owned by no package and not
shipped by Omarchy. Thanks to @MaxMad75 for catching it. On a stock box
a poisoned instance is never cleaned up: they observed the same PID
still refusing every request three days after activation, 65 `already
claimed` refusals, never idle-exiting because each lock-screen retry
re-arms the idle timer. In the field the failure is not "one lost
unlock" — it persists until the user restarts fprintd by hand.

**Not specific to s2idle.** @MaxMad75 reproduced it with
`mem_sleep=deep`. The trigger is the logind inhibitor race inside the
sleep-delay window, which does not care which sleep mode follows.

## Fix

Watch login1's `PrepareForSleep` signal directly (a `dbus-monitor`
process) and pause fingerprint checks across the sleep boundary:

- Refuse to start a fresh probe once paused (`refreshFingerprintStatus`).
- Drop the result of a probe that was already running when the pause
  landed, rather than trust an answer that may straddle suspend
  (`abortFingerprintCheck`).
- On resume, re-probe on a 3-attempt / 5s wall-clock-bounded budget
  instead of trusting the first answer, since the reader can take a few
  seconds to recover.
- Add an 8s timeout to the `fprintd-list` probe itself — a wedged reader
  can hang rather than fail outright.
- If the sleep monitor exits having seen `PrepareForSleep(true)` but not
  `(false)`, reconcile the still-paused state to "resumed" when it
  restarts, instead of leaving fingerprint disabled for the rest of the
  session.

Signal parsing and the resume-budget arithmetic live in
`SleepFingerprintModel.js`, covered by
`test/shell.d/lock-sleep-fingerprint-model-test.sh`. Every state
transition logs a `fingerprint-*` journal marker (restored in the
latest commit after I over-trimmed them from the original push — the
testing evidence below is stated in terms of those markers, and they
need to exist for anyone else to check it).

## What this fix does not do

It stops the lock from being the thing that poisons fprintd inside the
sleep window. It does **not** make unlock succeed when the reader is
unavailable for any other reason, and the pre-existing failure path in
that case is bad: `onError` → 250ms `fingerprintRetryTimer` →
`startFingerprint()`, unbounded (#7176, #7172). @MaxMad75 hit exactly
that while testing this branch — see Testing — and I hit the same loop
via a polkit `ReleaseDevice` timeout with no suspend involved (94
failed PAM sessions, ~45 min degraded). A retry cap/backoff is
deliberately not in this PR: #7158's reachability-streak model is the
right shape for it, and widening this diff would collide with that
work. But it means this fix is necessary, not sufficient, on hardware
where the reader can stay claimed across resume.

## Scope and relation to existing sleep/suspend handling

Two things worth a maintainer's eyes on merge order:

**`omarchy-system-sleep-monitor` / `omarchy-system-sleep-lock` already
watch this signal.** That systemd service holds a
`systemd-inhibit --what=sleep --mode=delay` lock, runs its own
`dbus-monitor` on `PrepareForSleep`, and on `true` calls
`omarchy-shell lock lock` over IPC (what actually triggers
`beginLock()`), delaying real suspend until the session is secure. This
fix adds a second, independent `dbus-monitor` reacting to the same
signal rather than hooking into that pipeline. It's the simpler change,
and the bake evidence below shows it winning the race every time — but
it is a second consumer of a signal this codebase already has one
consumer for, and a maintainer may want it done through that pipeline
instead.

**Open PR #7158** fixes a related but distinct bug — a fingerprint
*verify* (not this PR's configuration check) caught mid-flight by
suspend — and edits the same functions this PR does:
`startFingerprint()`, `handleFingerprintFinished()`,
`fingerprintPam.onError`, `fingerprintRetryTimer`, via a
reachability-streak/backoff model. Two interactions: (a) this PR's
`pauseFingerprintForSleep()` calls `fingerprintPam.abort()` when a
verify is active at sleep time; if `PamContext.abort()` fires `onError`
the way a real failure does, every ordinary suspend could advance
#7158's unreached-attempt streak and eventually trip its "reader
unavailable" notice from routine sleep. I haven't verified whether
`abort()` fires `onError` in Quickshell's PAM context — flagged, not
confirmed. (b) The retry-storm evidence above is a point *in favor* of
#7158's backoff, not just a collision risk. The two PRs should be
reconciled by whoever merges second.

## Testing

52 sleep/resume cycles on a ThinkPad X1 Carbon Gen 9, Synaptics
Prometheus `06cb:00fc`, s2idle, 2026-08-22 → 2026-08-29, including six
overnight lid-close → morning-wake cycles:

- 51 logged resume probes, **every one** recovered
  `fingerprintConfigured=true` on its first attempt, ~1s after resume.
- Zero `unsupported firmware`, zero `fingerprint-configured=false`,
  zero fingerprint-related password fallback on any resume.
- The code changed once mid-bake, after review here: 41 of those
  resumes ran on the original 20-attempt/20s budget and 10 on the
  current 3-attempt/5s wall-clock-bounded one. Identical outcomes.

The "don't start a fresh probe while paused" guard
(`fingerprint-check-skipped: sleep-paused`) fired **42 times**, and in
every instance the journal shows the same sequence:
`PrepareForSleep(true)` → `lock-requested` (the screen lock that would
have started the probe) → the probe blocked. The signal-to-lock margin
is 85–208ms, median 112ms, across all 42 — structural rather than a
hairline race, consistent with this watcher reading the D-Bus signal
directly while the existing pipeline pays for a script spawn and an IPC
round trip first. That makes it a direct interception of the bug's
trigger, not a correlation.

Independently, @MaxMad75 ran this branch on a Synaptics `06cb:00bd`
under `mem_sleep=deep` (with their fprintd-resident workaround disabled
so it couldn't mask the race): two cycles, both with
`fingerprint-paused-for-sleep` → `fingerprint-resume-pending` →
`fingerprint-configured=true` firing correctly and on time. One
unlocked first-swipe ~2s after resume; the other still failed to
unlock because the reader stayed claimed after resume and the unbounded
retry loop described above took over (178 PAM sessions in 26s) — the
out-of-scope failure mode, with this PR's own state machine behaving
correctly through it.

What's **not** directly exercised: the in-flight-probe abort
(`fingerprint-check-aborted`: zero occurrences in the entire bake — the
guard above has always won the race first) and the resume re-probe
budget past its first attempt. Both are defensive for cases outside
what this machine's timing produces — slower D-Bus delivery, a reader
slower to recover, or hardware where the lock command wins the race
instead of the signal. Kept in rather than trimmed for that reason, and
noted here rather than presented as proven.

🤖 Prepared by Claude in Claude Code.
