### PR TITLE
Constrain the asdcontrol sudoers rule to hiddev detect/get/set

### DIFF
--- a/etc/pacman.d/hooks/omarchy-asdcontrol-sudoers.hook
+++ b/etc/pacman.d/hooks/omarchy-asdcontrol-sudoers.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = asdcontrol
+
+[Action]
+Description = Removing asdcontrol's unconstrained sudoers (Omarchy ships a scoped rule)
+When = PostTransaction
+Exec = /usr/bin/rm -f /etc/sudoers.d/asdcontrol

--- a/etc/sudoers.d/omarchy-asdcontrol
+++ b/etc/sudoers.d/omarchy-asdcontrol
@@ -1,1 +1,4 @@
-%wheel ALL=(ALL) NOPASSWD: /usr/bin/asdcontrol
+# Brightness keys need passwordless asdcontrol. Only hiddev detect/get/set.
+%wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^--detect( /dev/(usb/)?hiddev[0-9]+)+$
+%wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^/dev/(usb/)?hiddev[0-9]+$
+%wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^/dev/(usb/)?hiddev[0-9]+ -- [+-]?[0-9]+%$

--- a/migrations/1787807253.sh
+++ b/migrations/1787807253.sh
@@ -1,0 +1,4 @@
+echo "Remove the unconstrained asdcontrol sudoers file"
+
+[[ -e /etc/sudoers.d/asdcontrol || -L /etc/sudoers.d/asdcontrol ]] || exit 0
+sudo rm -f /etc/sudoers.d/asdcontrol

--- a/test/shell.d/asdcontrol-sudoers-test.sh
+++ b/test/shell.d/asdcontrol-sudoers-test.sh
@@ -8,18 +8,64 @@ sudoers_file="$ROOT/etc/sudoers.d/omarchy-asdcontrol"
 wrapper="$ROOT/bin/omarchy-brightness-display-apple"
 hook="$ROOT/etc/pacman.d/hooks/omarchy-asdcontrol-sudoers.hook"
 
+expected='%wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^--detect( /dev/(usb/)?hiddev[0-9]+)+$
+%wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^/dev/(usb/)?hiddev[0-9]+$
+%wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^/dev/(usb/)?hiddev[0-9]+ -- [+-]?[0-9]+%$'
+
 rules=$(grep -vE '^[[:space:]]*(#|$)' "$sudoers_file")
-[[ $rules == *'(root) NOPASSWD:'* ]] ||
-  fail "asdcontrol sudoers runs as root, not ALL" "got: $rules"
+[[ $rules == "$expected" ]] ||
+  fail "asdcontrol sudoers is the three hiddev detect/get/set rules" "got: $rules"
 
-! grep -Eq 'NOPASSWD:[[:space:]]*/usr/bin/asdcontrol[[:space:]]*$' "$sudoers_file" ||
-  fail "asdcontrol sudoers does not grant any arguments"
+eres=()
+while IFS= read -r line; do
+  [[ $line =~ /usr/bin/asdcontrol[[:space:]]+(.*)$ ]] ||
+    fail "asdcontrol sudoers rule is a command ERE" "got: $line"
+  eres+=("${BASH_REMATCH[1]}")
+done <<<"$rules"
 
-! grep -F '*' "$sudoers_file" >/dev/null ||
-  fail "asdcontrol sudoers does not use a wildcard that admits extra arguments"
+(( ${#eres[@]} == 3 )) ||
+  fail "asdcontrol sudoers has three command EREs" "got ${#eres[@]}"
 
-! grep -vE '^[[:space:]]*(#|$)' "$sudoers_file" | grep -F -- '--force' >/dev/null ||
-  fail "asdcontrol sudoers does not admit --force"
+granted() {
+  local args=$1
+  local ere
+  for ere in "${eres[@]}"; do
+    grep -Eq -- "$ere" <<<"$args" && return 0
+  done
+  return 1
+}
+
+must_grant() {
+  if ! granted "$1"; then
+    fail "sudoers ERE grants '$1'"
+  fi
+}
+
+must_deny() {
+  if granted "$1"; then
+    fail "sudoers ERE rejects '$1'"
+  fi
+}
+
+must_grant "--detect /dev/usb/hiddev0"
+must_grant "--detect /dev/hiddev0"
+must_grant "--detect /dev/usb/hiddev0 /dev/hiddev1"
+must_grant "/dev/usb/hiddev0"
+must_grant "/dev/hiddev0"
+must_grant "/dev/usb/hiddev0 -- +5%"
+must_grant "/dev/hiddev0 -- -10%"
+must_grant "/dev/usb/hiddev0 -- 50%"
+
+must_deny "--force /dev/usb/hiddev0"
+must_deny "--detect /dev/sda"
+must_deny "--detect /tmp/hiddev0"
+must_deny "--detect"
+must_deny "/dev/sda"
+must_deny "/dev/usb/hiddev0 extra"
+must_deny "/dev/usb/hiddev0 -- +5% extra"
+must_deny "/dev/usb/hiddev0 -- 50"
+must_deny "--detect /dev/usb/hiddev0 --force"
+must_deny "/dev/usb/hiddev0 -- --force"
 
 if command -v visudo >/dev/null; then
   visudo -cf "$sudoers_file" >/dev/null || fail "asdcontrol sudoers rule parses"

--- a/test/shell.d/asdcontrol-sudoers-test.sh
+++ b/test/shell.d/asdcontrol-sudoers-test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+sudoers_file="$ROOT/etc/sudoers.d/omarchy-asdcontrol"
+wrapper="$ROOT/bin/omarchy-brightness-display-apple"
+hook="$ROOT/etc/pacman.d/hooks/omarchy-asdcontrol-sudoers.hook"
+
+rules=$(grep -vE '^[[:space:]]*(#|$)' "$sudoers_file")
+[[ $rules == *'(root) NOPASSWD:'* ]] ||
+  fail "asdcontrol sudoers runs as root, not ALL" "got: $rules"
+
+! grep -Eq 'NOPASSWD:[[:space:]]*/usr/bin/asdcontrol[[:space:]]*$' "$sudoers_file" ||
+  fail "asdcontrol sudoers does not grant any arguments"
+
+! grep -F '*' "$sudoers_file" >/dev/null ||
+  fail "asdcontrol sudoers does not use a wildcard that admits extra arguments"
+
+! grep -vE '^[[:space:]]*(#|$)' "$sudoers_file" | grep -F -- '--force' >/dev/null ||
+  fail "asdcontrol sudoers does not admit --force"
+
+if command -v visudo >/dev/null; then
+  visudo -cf "$sudoers_file" >/dev/null || fail "asdcontrol sudoers rule parses"
+fi
+
+grep -F 'sudo asdcontrol --detect "${devices[@]}"' "$wrapper" >/dev/null ||
+  fail "brightness wrapper detects with passwordless --detect"
+
+grep -F 'sudo asdcontrol "$device"' "$wrapper" >/dev/null ||
+  fail "brightness wrapper reads brightness with a hiddev path"
+
+grep -F 'sudo asdcontrol "$device" -- "$step"' "$wrapper" >/dev/null ||
+  fail "brightness wrapper sets brightness as hiddev -- step"
+
+grep -F 'Exec = /usr/bin/rm -f /etc/sudoers.d/asdcontrol' "$hook" >/dev/null ||
+  fail "pacman hook removes the unconstrained asdcontrol sudoers file"
+
+pass "asdcontrol sudoers is scoped to hiddev detect/get/set"


### PR DESCRIPTION
## What was wrong

`etc/sudoers.d/omarchy-asdcontrol` granted `%wheel` passwordless asdcontrol with no argument restriction, as any user:

```
%wheel ALL=(ALL) NOPASSWD: /usr/bin/asdcontrol
```

Its only caller, `bin/omarchy-brightness-display-apple`, runs three shapes:

```
sudo asdcontrol --detect "${devices[@]}"
sudo asdcontrol "$device"
sudo asdcontrol "$device" -- "$step"
```

where `devices`/`device` come from `/dev/usb/hiddev*` and `/dev/hiddev*`, and `step` is a percent brightness. Everything else the unrestricted rule admits is unintended authority.

asdcontrol also has `--force`, which skips the Apple vendor/product allowlist and still writes brightness ioctls on any USB-monitor HID. Combined with NOPASSWD-any-args, any wheel user can `sudo asdcontrol --force <path>` with no password. The binary opens that path as root.

A second file makes the same grant and survives a change to only `omarchy-asdcontrol`: the `asdcontrol` package ships `/etc/sudoers.d/asdcontrol` (`<install-user> ALL=(ALL) NOPASSWD: /usr/bin/asdcontrol`). sudo ORs matching rules, so tightening Omarchy's drop-in does nothing while that file remains. A package upgrade restores it.

## The change

Constrain the Omarchy rule with sudo's POSIX ERE command-argument matching (same form as `omarchy-tzupdate` / #8194), as root, to the three invocations the wrapper actually makes:

```
%wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^--detect( /dev/(usb/)?hiddev[0-9]+)+$
%wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^/dev/(usb/)?hiddev[0-9]+$
%wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^/dev/(usb/)?hiddev[0-9]+ -- [+-]?[0-9]+%$
```

`--force`, a non-hiddev path, and extra arguments now require a password. `visudo` parses the file.

A PostTransaction hook on the `asdcontrol` package removes `/etc/sudoers.d/asdcontrol` after install/upgrade so the unconstrained grant cannot come back. A migration deletes it on existing machines.

`test/shell.d/asdcontrol-sudoers-test.sh` asserts the rule is not any-args, is `(root)`, has no `*`, does not mention `--force`, still matches the wrapper's three sudo lines, and that the hook removes the package file.

## Not changed

The brightness wrapper is untouched. #8198 covers validating the cached hiddev path; this change is the sudoers boundary even if that cache is wrong.