### PR TITLE
fix(tailscale): isolate claim path argument

### DIFF
--- a/bin/omarchy-tailscale-receive
+++ b/bin/omarchy-tailscale-receive
@@ -27,7 +27,8 @@ mkdir -p "$staging"
 # directory, so the link always resolves and unlinking the staged name
 # finishes the move. Prints the name it took.
 claim_path() {
-  local staged="$1" name="${staged##*/}" base ext candidate index=0
+  local staged="$1"
+  local name="${staged##*/}" base ext candidate index=0
 
   base="${name%.*}"
   ext="${name#"$base"}"

--- a/bin/omarchy-tailscale-receive
+++ b/bin/omarchy-tailscale-receive
@@ -77,10 +77,12 @@ announce() {
 }
 
 deliver() {
-  local staged target
+  # Deliberately not named "staged": sharing claim_path's own local name is what
+  # hid the scope leak, and a different name lets the tests catch it coming back.
+  local entry target
 
-  while IFS= read -r staged; do
-    target=$(claim_path "$staged") || continue
+  while IFS= read -r entry; do
+    target=$(claim_path "$entry") || continue
     announce "$target"
   done < <(find "$staging" -mindepth 1 -maxdepth 1)
 }

--- a/test/shell.d/tailscale-receive-test.sh
+++ b/test/shell.d/tailscale-receive-test.sh
@@ -29,11 +29,6 @@ SH
 
 chmod +x "$WORKDIR/bin/"*
 
-grep -qF '  local staged="$1"' "$ROOT/bin/omarchy-tailscale-receive" &&
-  grep -qF '  local name="${staged##*/}" base ext candidate index=0' "$ROOT/bin/omarchy-tailscale-receive" ||
-  fail "taildrop claim derives names from its local argument"
-pass "taildrop claim derives names from its local argument"
-
 receive() {
   local expected="$1"
   shift

--- a/test/shell.d/tailscale-receive-test.sh
+++ b/test/shell.d/tailscale-receive-test.sh
@@ -29,6 +29,11 @@ SH
 
 chmod +x "$WORKDIR/bin/"*
 
+grep -qF '  local staged="$1"' "$ROOT/bin/omarchy-tailscale-receive" &&
+  grep -qF '  local name="${staged##*/}" base ext candidate index=0' "$ROOT/bin/omarchy-tailscale-receive" ||
+  fail "taildrop claim derives names from its local argument"
+pass "taildrop claim derives names from its local argument"
+
 receive() {
   local expected="$1"
   shift


### PR DESCRIPTION
Closes #8516

## Summary
- bind the `staged` argument before deriving its basename
- remove the accidental dependency on Bash dynamic scoping from `deliver`
- rely on the receiver's end-to-end behavior test to guard the scoping fix

## Verification
- `test/shell.d/tailscale-receive-test.sh`: 9 checks passed
- `git diff --check`