### PR TITLE
Take privileged usernames from id -un, not USER

### DIFF
--- a/bin/omarchy-dev-install-ydoo
+++ b/bin/omarchy-dev-install-ydoo
@@ -12,9 +12,10 @@ if ! getent group input >/dev/null; then
   exit 1
 fi
 
-if ! id -nG "$USER" | tr ' ' '\n' | grep -x input >/dev/null; then
-  echo "Adding $USER to the input group. You may need to log out and back in before this applies."
-  pkexec usermod -aG input "$USER"
+user=$(id -un)
+if ! id -nG | tr ' ' '\n' | grep -x input >/dev/null; then
+  echo "Adding $user to the input group. You may need to log out and back in before this applies."
+  pkexec usermod -aG input "$user"
 fi
 
 if omarchy-cmd-missing ydotool || omarchy-pkg-missing ydotool; then

--- a/bin/omarchy-install-gaming-xbox-controllers
+++ b/bin/omarchy-install-gaming-xbox-controllers
@@ -17,9 +17,10 @@ echo blacklist xpad | sudo tee /etc/modprobe.d/blacklist-xpad.conf >/dev/null
 echo hid_xpadneo | sudo tee /etc/modules-load.d/xpadneo.conf >/dev/null
 
 # Ensure user is in the input group (controllers need it)
+user=$(id -un)
 needs_reboot=false
-if ! id -nG "$USER" | grep -qw input; then
-  sudo usermod -aG input "$USER"
+if ! id -nG "$user" | grep -qw input; then
+  sudo usermod -aG input "$user"
   needs_reboot=true
 fi
 

--- a/bin/omarchy-install-service-nordvpn
+++ b/bin/omarchy-install-service-nordvpn
@@ -9,8 +9,9 @@ omarchy-pkg-add nordvpn-bin
 echo "Enabling NordVPN daemon..."
 sudo systemctl enable --now nordvpnd
 
+user=$(id -un)
 echo "Adding user to nordvpn group..."
-sudo usermod -aG nordvpn "$USER"
+sudo usermod -aG nordvpn "$user"
 
 echo -e "\nNordVPN installed! After reboot, run 'nordvpn login' to authenticate."
 

--- a/bin/omarchy-install-service-tailscale
+++ b/bin/omarchy-install-service-tailscale
@@ -10,8 +10,9 @@ echo -e "\nStarting Tailscale..."
 sudo systemctl enable --now tailscaled.service
 sudo tailscale up --accept-routes
 
-echo -e "\nAllowing $USER to manage Tailscale..."
-sudo tailscale set --operator="$USER"
+user=$(id -un)
+echo -e "\nAllowing $user to manage Tailscale..."
+sudo tailscale set --operator="$user"
 
 echo -e "\nReceiving Taildrop files in $HOME/Downloads..."
 systemctl --user enable --now omarchy-tailscale-receive.service

--- a/bin/omarchy-remove-security-sudoless-docker
+++ b/bin/omarchy-remove-security-sudoless-docker
@@ -5,16 +5,18 @@
 
 set -e
 
+user=$(id -un)
+
 # Ask about the configured groups, not this session's: right after enabling,
 # sudoless Docker is on for the account even though the running session still
 # needs a prompt, and this command is what turns it back off.
 if omarchy-sudo-docker --configured; then
-  echo "Sudoless Docker is not enabled: $USER is not in the docker group."
+  echo "Sudoless Docker is not enabled: $user is not in the docker group."
   exit 0
 fi
 
-echo "Removing $USER from the docker group..."
-sudo gpasswd -d "$USER" docker >/dev/null
+echo "Removing $user from the docker group..."
+sudo gpasswd -d "$user" docker >/dev/null
 
 # Group membership is only re-read by a fresh session, and in practice logging
 # out or newgrp isn't enough — only a reboot reliably applies it. Record it so a

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -87,7 +87,7 @@ omarchy-pkg-add libfprint fprintd usbutils
 echo -e "\e[32m\nLet's setup your right index finger as the first fingerprint.\e[0m"
 echo -e "Keep moving the finger around on sensor until the process completes.\n"
 
-if sudo fprintd-enroll "$USER"; then
+if sudo fprintd-enroll "$(id -un)"; then
   echo -e "\e[32m\nFingerprint enrolled successfully!\e[0m"
 
   # Verify

--- a/bin/omarchy-setup-security-sudoless-docker
+++ b/bin/omarchy-setup-security-sudoless-docker
@@ -5,10 +5,12 @@
 
 set -e
 
+user=$(id -un)
+
 # Ask about the configured groups, not this session's: once enabled it stays
 # enabled for the account even before the reboot that lets this session use it.
 if ! omarchy-sudo-docker --configured; then
-  echo "Sudoless Docker is already enabled: $USER is in the docker group."
+  echo "Sudoless Docker is already enabled: $user is in the docker group."
   echo "To disable it again, run: omarchy-remove-security-sudoless-docker"
   exit 0
 fi
@@ -29,7 +31,7 @@ echo "Docker access goes through a polkit/sudo prompt."
 echo ""
 
 if gum confirm "Enable sudoless Docker? This gives anything running as you passwordless root."; then
-  sudo usermod -aG docker "$USER"
+  sudo usermod -aG docker "$user"
   # A new docker group membership is only picked up by a fresh session, and in
   # practice logging out or newgrp isn't enough — only a reboot reliably applies
   # it. Record it so a later `omarchy update` still prompts

--- a/bin/omarchy-sudo-docker
+++ b/bin/omarchy-sudo-docker
@@ -28,7 +28,7 @@ DOCKER_SOCKET="${OMARCHY_DOCKER_SOCKET:-/var/run/docker.sock}"
 case "${1:-}" in
 --configured)
   # An account in the docker group will not need sudo after the next login.
-  id -nG "$USER" 2>/dev/null | grep -qw docker && exit 1
+  id -nG 2>/dev/null | grep -qw docker && exit 1
   exit 0
   ;;
 "")

--- a/bin/omarchy-sudo-passwordless
+++ b/bin/omarchy-sudo-passwordless
@@ -4,8 +4,17 @@
 # omarchy:args=[MINUTES]
 # omarchy:requires-sudo=true
 
-NOPASSWD_FILE="/etc/sudoers.d/99-omarchy-nopasswd-${USER}"
-TIMER_NAME="omarchy-nopasswd-expire-${USER}"
+# $USER is the environment, not the uid. A session that exported USER=ALL would
+# write `ALL ALL=(ALL) NOPASSWD: ALL`. id -un is the euid; the pattern is the
+# same one first-boot setup accepts, plus ALL which is a sudoers alias.
+user=$(id -un)
+if [[ ! $user =~ ^[a-z_][a-z0-9_-]*$ || $user == "ALL" ]]; then
+  echo "omarchy-sudo-passwordless: refusing to write a sudoers grant for '$user'" >&2
+  exit 1
+fi
+
+NOPASSWD_FILE="/etc/sudoers.d/99-omarchy-nopasswd-${user}"
+TIMER_NAME="omarchy-nopasswd-expire-${user}"
 
 MINUTES=${1:-15}
 if [[ $1 && ! $1 =~ ^[0-9]+$ ]]; then
@@ -46,7 +55,7 @@ else
   echo ""
 
   if gum confirm "Enable passwordless sudo for ${MINUTES} minutes? This is a significant security risk!"; then
-    echo "${USER} ALL=(ALL) NOPASSWD: ALL" | sudo tee "$NOPASSWD_FILE" > /dev/null
+    echo "${user} ALL=(ALL) NOPASSWD: ALL" | sudo tee "$NOPASSWD_FILE" > /dev/null
     sudo chmod 440 "$NOPASSWD_FILE"
     sudo systemd-run --on-active=${MINUTES}m --timer-property=AccuracySec=1s --unit="$TIMER_NAME" \
       rm "$NOPASSWD_FILE"

--- a/test/shell.d/privileged-user-identity-test.sh
+++ b/test/shell.d/privileged-user-identity-test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+passwordless="$ROOT/bin/omarchy-sudo-passwordless"
+
+grep -Fq 'user=$(id -un)' "$passwordless" ||
+  fail "passwordless sudo takes the username from id -un"
+
+grep -Fq 'echo "${user} ALL=(ALL) NOPASSWD: ALL"' "$passwordless" ||
+  fail "passwordless sudo writes the id -un subject into sudoers"
+
+grep -Fq 'NOPASSWD_FILE="/etc/sudoers.d/99-omarchy-nopasswd-${user}"' "$passwordless" ||
+  fail "passwordless sudo names the drop-in from id -un"
+
+! grep -Fq '${USER}' "$passwordless" ||
+  fail "passwordless sudo does not interpolate USER into sudoers"
+
+grep -Fq 'id -nG 2>/dev/null' "$ROOT/bin/omarchy-sudo-docker" ||
+  fail "sudoless Docker --configured reads groups of the current euid"
+
+for cmd in \
+  "$ROOT/bin/omarchy-setup-security-sudoless-docker" \
+  "$ROOT/bin/omarchy-remove-security-sudoless-docker" \
+  "$ROOT/bin/omarchy-dev-install-ydoo" \
+  "$ROOT/bin/omarchy-install-service-tailscale"
+do
+  grep -Fq 'user=$(id -un)' "$cmd" ||
+    fail "$(basename "$cmd") takes the username from id -un"
+  ! grep -Fq '"$USER"' "$cmd" ||
+    fail "$(basename "$cmd") does not pass USER to a privileged command"
+done
+
+grep -Fq 'fprintd-enroll "$(id -un)"' "$ROOT/bin/omarchy-setup-security-fingerprint" ||
+  fail "fingerprint enroll uses id -un"
+
+pass "privileged commands take the username from the euid, not USER"

--- a/test/shell.d/privileged-user-identity-test.sh
+++ b/test/shell.d/privileged-user-identity-test.sh
@@ -25,7 +25,9 @@ for cmd in \
   "$ROOT/bin/omarchy-setup-security-sudoless-docker" \
   "$ROOT/bin/omarchy-remove-security-sudoless-docker" \
   "$ROOT/bin/omarchy-dev-install-ydoo" \
-  "$ROOT/bin/omarchy-install-service-tailscale"
+  "$ROOT/bin/omarchy-install-service-tailscale" \
+  "$ROOT/bin/omarchy-install-gaming-xbox-controllers" \
+  "$ROOT/bin/omarchy-install-service-nordvpn"
 do
   grep -Fq 'user=$(id -un)' "$cmd" ||
     fail "$(basename "$cmd") takes the username from id -un"


### PR DESCRIPTION
## What was wrong

Several privileged commands interpolate `$USER` into sudoers, `usermod`, `gpasswd`, `fprintd-enroll`, and `tailscale set --operator`. `$USER` is the environment, not the euid. Anything in the session can export it.

The one that writes policy is `omarchy-sudo-passwordless`:

```
NOPASSWD_FILE="/etc/sudoers.d/99-omarchy-nopasswd-${USER}"
echo "${USER} ALL=(ALL) NOPASSWD: ALL" | sudo tee "$NOPASSWD_FILE"
```

`USER=ALL` produces a valid drop-in named `99-omarchy-nopasswd-ALL` whose body is `ALL ALL=(ALL) NOPASSWD: ALL`. After the gum confirm and one sudo prompt (or a cached timestamp), every local account is passwordless root for the grant window.

The same environment is inherited by _Setup > Security > Passwordless Sudo_ from the session. A plugin, hook, or `export` in `~/.bashrc` is enough; the user sees the usual warning and thinks they are granting only themselves.

Sibling commands have a smaller version of the same bug: `usermod -aG docker "$USER"` with `USER=nobody` adds `nobody` to the docker group (root-equivalent) instead of the person who typed the password.

Does not overlap #7990, which clears the grant at boot. This change is who the grant names.

## The change

- `omarchy-sudo-passwordless` takes `id -un`, refuses anything outside first-boot's username pattern and the sudoers alias `ALL`, then writes that subject.
- `omarchy-sudo-docker --configured` uses `id -nG` with no name, so it answers about this euid.
- sudoless Docker setup/remove, ydotool `usermod`, fingerprint enroll, and Tailscale `--operator` take `id -un`.

`test/shell.d/privileged-user-identity-test.sh` greps those call sites. `test/shell.d/sudo-docker-test.sh` still passes (its `id` stub ignores arguments).