### PR TITLE
Harden Hermes wrapper ownership

### DIFF
--- a/bin/omarchy-install-hermes-cli
+++ b/bin/omarchy-install-hermes-cli
@@ -73,11 +73,14 @@ foreign_hermes() {
   [[ -e $HOME/.local/bin/hermes || -L $HOME/.local/bin/hermes ]] && ! ours
 }
 
-# A foreign path is usable when it is a command: a regular file that runs.
-# A directory passes -x on search permission alone, and is no more a command
-# than a dangling link is.
+# A foreign path is usable when it is a command that runs: a regular executable
+# whose --version answers. The executable bit alone proves little -- a directory
+# passes -x on search permission, and a wrapper whose interpreter or target is
+# gone passes it too. The desktop app applies the same probe with the same 15
+# second budget, so what passes here is what it will use.
 foreign_hermes_runs() {
-  [[ -f $HOME/.local/bin/hermes && -x $HOME/.local/bin/hermes ]]
+  [[ -f $HOME/.local/bin/hermes && -x $HOME/.local/bin/hermes ]] &&
+    timeout 15 "$HOME/.local/bin/hermes" --version >/dev/null 2>&1
 }
 
 # --check lets callers tell a cold stub from a working one before they commit

--- a/bin/omarchy-install-hermes-cli
+++ b/bin/omarchy-install-hermes-cli
@@ -30,6 +30,10 @@ mode=${1:-}
 tool='pipx:hermes-agent[extras=all]'
 python='3.13'
 
+# The line that identifies the stub as this installer's; matched whole, so a
+# wrapper that merely mentions the command is not mistaken for ours.
+marker='# Written by omarchy-install-hermes-cli.'
+
 # The package, not the runtime directory: it is installed before the app has
 # ever run, and that is exactly when we must not start building a second copy.
 desktop_owns_hermes() {
@@ -55,11 +59,37 @@ installed() {
   [[ -d "$(mise where "$tool" 2>/dev/null)/hermes-agent/lib/python$python" ]]
 }
 
+# The stub is the only thing this installer owns. Anything else at that path
+# -- Hermes' official installer, a hand-rolled wrapper, even a dangling link
+# -- was put there by the user and is never deleted or overwritten here.
+# Symlinks count as foreign even when they resolve to a marked file: the stub
+# is written as a regular file, so a link is someone else's arrangement.
+ours() {
+  [[ -f $HOME/.local/bin/hermes && ! -L $HOME/.local/bin/hermes ]] &&
+    grep -qxF "$marker" "$HOME/.local/bin/hermes"
+}
+
+foreign_hermes() {
+  [[ -e $HOME/.local/bin/hermes || -L $HOME/.local/bin/hermes ]] && ! ours
+}
+
+# A foreign path is usable when it is a command: a regular file that runs.
+# A directory passes -x on search permission alone, and is no more a command
+# than a dangling link is.
+foreign_hermes_runs() {
+  [[ -f $HOME/.local/bin/hermes && -x $HOME/.local/bin/hermes ]]
+}
+
 # --check lets callers tell a cold stub from a working one before they commit
 # to a path that assumes Hermes is ready.
 if [[ $mode == "--check" ]]; then
   if desktop_owns_hermes; then
     if desktop_hermes_ready; then exit 0; else exit 1; fi
+  fi
+  # A foreign command is ready when it runs; a broken one is not, and since it
+  # is not ours to replace, nothing this installer does will make it ready.
+  if foreign_hermes; then
+    if foreign_hermes_runs; then exit 0; else exit 1; fi
   fi
   if installed; then exit 0; else exit 1; fi
 fi
@@ -79,7 +109,7 @@ if desktop_owns_hermes; then
   # Our own stub has to go with it. Left in place it still answers `hermes`
   # until the app's bootstrap overwrites it, and answering means building the
   # second Hermes this whole arrangement exists to avoid.
-  if [[ -f $HOME/.local/bin/hermes ]] && grep -q omarchy-install-hermes-cli "$HOME/.local/bin/hermes"; then
+  if ours; then
     rm -f "$HOME/.local/bin/hermes"
   fi
 
@@ -92,13 +122,25 @@ if desktop_owns_hermes; then
   exit 1
 fi
 
+# The user already has a hermes of their own. Leave it be: a working one is
+# what the default agent will run, and a broken one is theirs to fix.
+if foreign_hermes; then
+  if foreign_hermes_runs; then
+    exit 0
+  fi
+
+  echo "~/.local/bin/hermes exists but is not runnable, and it was not installed by Omarchy." >&2
+  echo "Fix or remove it, then run omarchy-install-hermes-cli again." >&2
+  exit 1
+fi
+
 mkdir -p "$HOME/.local/bin"
 rm -f "$HOME/.local/bin/hermes"
 
 cat >"$HOME/.local/bin/hermes" <<EOF
 #!/bin/bash
 
-# Written by omarchy-install-hermes-cli.
+$marker
 
 export UV_PYTHON="$python"
 

--- a/bin/omarchy-remove-preinstalls
+++ b/bin/omarchy-remove-preinstalls
@@ -17,9 +17,12 @@ if gum confirm "Are you sure you want to remove all preinstalled web apps, TUI w
        ~/.local/bin/gh ~/.local/bin/opencode ~/.local/bin/playwright ~/.local/bin/playwright-cli ~/.local/bin/pi \
        ~/.local/bin/omp ~/.local/bin/ori ~/.local/bin/grok ~/.local/bin/crush ~/.local/bin/ghui ~/.local/bin/hunk
 
-  # Hermes Desktop owns this path once installed, and its own CLI is not a
-  # preinstall to sweep away.
-  omarchy-pkg-present hermes-desktop || rm -f ~/.local/bin/hermes
+  # Only the wrapper omarchy-install-hermes-cli wrote is a preinstall. Hermes
+  # Desktop's command, an official install, or anything else at that path is
+  # the user's, so it is the marker that decides, not which packages are around.
+  if [[ -f ~/.local/bin/hermes && ! -L ~/.local/bin/hermes ]] && grep -qxF '# Written by omarchy-install-hermes-cli.' ~/.local/bin/hermes; then
+    rm -f ~/.local/bin/hermes
+  fi
 
   omarchy-pkg-drop \
     aether \

--- a/migrations/1787760281.sh
+++ b/migrations/1787760281.sh
@@ -4,8 +4,14 @@ echo "Install the Hermes CLI wrapper for existing installs"
 # is one of them.
 [[ -f $HOME/.local/state/omarchy/preinstalls-removed ]] && exit 0
 
-# Hermes Desktop provides its own Hermes; the installer would only stand aside.
-omarchy-pkg-present hermes-desktop && exit 0
+# Hermes Desktop provides its own Hermes. The installer stands aside for it,
+# removing the mise copy and the Omarchy wrapper an earlier install may have
+# left beside the app. It also reports when the app has not finished setting
+# Hermes up, which is the app's to finish, not this migration's to fail on.
+if omarchy-pkg-present hermes-desktop; then
+  omarchy-install-hermes-cli || true
+  exit 0
+fi
 
 # Anything already answering to hermes that this installer did not write --
 # an official install, a hand-rolled wrapper, even a dangling link -- belongs to

--- a/migrations/1787760281.sh
+++ b/migrations/1787760281.sh
@@ -1,0 +1,20 @@
+echo "Install the Hermes CLI wrapper for existing installs"
+
+# Users who removed the preinstalls opted out of the mise wrappers, and Hermes
+# is one of them.
+[[ -f $HOME/.local/state/omarchy/preinstalls-removed ]] && exit 0
+
+# Hermes Desktop provides its own Hermes; the installer would only stand aside.
+omarchy-pkg-present hermes-desktop && exit 0
+
+# Anything already answering to hermes that this installer did not write --
+# an official install, a hand-rolled wrapper, even a dangling link -- belongs to
+# the user and stays exactly as it is.
+wrapper="$HOME/.local/bin/hermes"
+if [[ -e $wrapper || -L $wrapper ]]; then
+  if [[ -L $wrapper || ! -f $wrapper ]] || ! grep -qxF '# Written by omarchy-install-hermes-cli.' "$wrapper"; then
+    exit 0
+  fi
+fi
+
+omarchy-install-hermes-cli

--- a/test/shell.d/hermes-cli-migration-test.sh
+++ b/test/shell.d/hermes-cli-migration-test.sh
@@ -24,8 +24,10 @@ cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
 ! command -v "$1" >/dev/null 2>&1
 SH
 
+mise_log="$test_tmp/mise-log"
 cat >"$mock_bin/mise" <<'SH'
 #!/bin/bash
+printf '%s\0' "$@" >>"$OMARCHY_TEST_MISE_LOG"
 [[ $1 != "where" ]]
 SH
 
@@ -35,6 +37,7 @@ chmod +x "$mock_bin"/*
 # copy of it.
 run_migration() {
   OMARCHY_TEST_DESKTOP_INSTALLED="${1:-0}" \
+    OMARCHY_TEST_MISE_LOG="$mise_log" \
     HOME="$test_home" \
     PATH="$mock_bin:$ROOT/bin:$PATH" \
     bash -euo pipefail "$migration" >/dev/null 2>&1
@@ -65,6 +68,33 @@ rm -f "$test_home/.local/state/omarchy/preinstalls-removed"
 run_migration 1 || fail "the migration succeeds when Hermes Desktop owns Hermes"
 [[ ! -e $hermes ]] || fail "the migration writes nothing when Hermes Desktop owns Hermes"
 pass "the migration stands aside for Hermes Desktop"
+
+# Standing aside is not the same as leaving a second Hermes behind: the wrapper
+# an earlier install wrote and the mise copy it points at both go when the
+# desktop app owns Hermes, even though the app has not finished setting up.
+printf '%s\n' "#!/bin/bash" "$marker" >"$hermes"
+chmod +x "$hermes"
+: >"$mise_log"
+run_migration 1 || fail "the migration succeeds when Hermes Desktop owns Hermes and the old wrapper is present"
+[[ ! -e $hermes ]] || fail "the migration removes the Omarchy wrapper when Hermes Desktop owns Hermes"
+mise_calls=$(tr '\0' ' ' <"$mise_log")
+[[ $mise_calls == *"rm -g "* ]] || fail "the migration removes the global mise Hermes for Hermes Desktop"
+[[ $mise_calls == *"uninstall --all "* ]] || fail "the migration uninstalls the mise Hermes for Hermes Desktop"
+pass "the migration clears the old Omarchy Hermes for Hermes Desktop"
+
+# ...while anyone else's hermes stays exactly where it is, and is not run.
+foreign_ran="$test_tmp/foreign-ran"
+foreign_body="#!/bin/bash
+touch $foreign_ran
+exec $test_home/.hermes/hermes-agent/venv/bin/hermes \"\$@\""
+printf '%s\n' "$foreign_body" >"$hermes"
+chmod +x "$hermes"
+run_migration 1 || fail "the migration succeeds over a foreign hermes when Hermes Desktop owns Hermes"
+[[ -x $hermes && $(cat "$hermes") == "$foreign_body" ]] ||
+  fail "the migration leaves a foreign hermes alone when Hermes Desktop owns Hermes"
+[[ ! -e $foreign_ran ]] || fail "the migration does not run a foreign hermes"
+pass "the migration preserves a foreign hermes for Hermes Desktop"
+rm -f "$hermes"
 
 official_body="#!/bin/bash
 unset PYTHONPATH

--- a/test/shell.d/hermes-cli-migration-test.sh
+++ b/test/shell.d/hermes-cli-migration-test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787760281.sh"
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+hermes="$test_home/.local/bin/hermes"
+marker="# Written by omarchy-install-hermes-cli."
+mkdir -p "$mock_bin" "$test_home/.local/bin" "$test_home/.local/state/omarchy"
+
+cat >"$mock_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+[[ ${OMARCHY_TEST_DESKTOP_INSTALLED:-0} == 1 ]]
+SH
+
+cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+! command -v "$1" >/dev/null 2>&1
+SH
+
+cat >"$mock_bin/mise" <<'SH'
+#!/bin/bash
+[[ $1 != "where" ]]
+SH
+
+chmod +x "$mock_bin"/*
+
+# The real installer is on PATH so the migration writes today's stub, not a
+# copy of it.
+run_migration() {
+  OMARCHY_TEST_DESKTOP_INSTALLED="${1:-0}" \
+    HOME="$test_home" \
+    PATH="$mock_bin:$ROOT/bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null 2>&1
+}
+
+run_migration || fail "the migration installs the wrapper on a plain install"
+[[ -x $hermes ]] && grep -qxF "$marker" "$hermes" || fail "the migration writes the Omarchy wrapper"
+pass "the migration installs the Hermes wrapper"
+
+before=$(cat "$hermes")
+run_migration || fail "rerunning the migration succeeds"
+[[ $(cat "$hermes") == "$before" ]] || fail "rerunning the migration leaves the same wrapper"
+pass "the migration is idempotent"
+
+chmod -x "$hermes"
+run_migration || fail "the migration repairs a non-executable Omarchy wrapper"
+[[ -x $hermes ]] && grep -qxF "$marker" "$hermes" ||
+  fail "the migration restores a non-executable Omarchy wrapper"
+pass "the migration repairs a non-executable Omarchy wrapper"
+
+rm -f "$hermes"
+touch "$test_home/.local/state/omarchy/preinstalls-removed"
+run_migration || fail "the migration succeeds for users who removed the preinstalls"
+[[ ! -e $hermes ]] || fail "the migration respects the preinstalls opt-out"
+pass "the migration skips users who removed the preinstalls"
+rm -f "$test_home/.local/state/omarchy/preinstalls-removed"
+
+run_migration 1 || fail "the migration succeeds when Hermes Desktop owns Hermes"
+[[ ! -e $hermes ]] || fail "the migration writes nothing when Hermes Desktop owns Hermes"
+pass "the migration stands aside for Hermes Desktop"
+
+official_body="#!/bin/bash
+unset PYTHONPATH
+unset PYTHONHOME
+exec $test_home/.hermes/hermes-agent/venv/bin/hermes \"\$@\""
+printf '%s\n' "$official_body" >"$hermes"
+chmod +x "$hermes"
+run_migration || fail "the migration succeeds over a foreign hermes command"
+[[ $(cat "$hermes") == "$official_body" ]] || fail "the migration leaves a foreign hermes command alone"
+pass "the migration preserves a foreign hermes command"
+
+chmod -x "$hermes"
+run_migration || fail "the migration succeeds over a non-executable foreign hermes"
+[[ -f $hermes && ! -x $hermes && $(cat "$hermes") == "$official_body" ]] ||
+  fail "the migration leaves a non-executable foreign hermes alone"
+pass "the migration preserves a non-executable foreign hermes"
+
+rm -f "$hermes"
+ln -s "$test_home/nowhere/hermes" "$hermes"
+run_migration || fail "the migration succeeds over a dangling hermes link"
+[[ -L $hermes && $(readlink "$hermes") == "$test_home/nowhere/hermes" ]] ||
+  fail "the migration leaves a dangling hermes link alone"
+pass "the migration preserves a dangling hermes link"
+
+rm -f "$hermes"
+mkdir "$hermes"
+run_migration || fail "the migration succeeds over a directory at the hermes path"
+[[ -d $hermes ]] || fail "the migration leaves a directory at the hermes path alone"
+pass "the migration preserves a directory at the hermes path"
+
+rmdir "$hermes"
+printf '%s\n' "#!/bin/bash" "# Replaces the stub omarchy-install-hermes-cli used to write." >"$hermes"
+chmod +x "$hermes"
+run_migration || fail "the migration succeeds over a wrapper that mentions the installer"
+grep -qxF "$marker" "$hermes" && fail "the migration does not rewrite a wrapper that merely mentions the installer"
+pass "the migration preserves a wrapper that merely mentions the installer"

--- a/test/shell.d/hermes-cli-test.sh
+++ b/test/shell.d/hermes-cli-test.sh
@@ -87,8 +87,10 @@ pass "takeover removes an unhealthy mise copy"
 rm -rf "$test_home/.hermes"
 rm -f "$test_home/.local/bin/hermes"
 run_installer 1 --check && fail "--check reports Hermes missing before the app installs it"
+# The venv command answers --version, as the real one does: foreign wrappers
+# below exec it, and the installer probes them by running exactly that.
 mkdir -p "$test_home/.hermes/hermes-agent/venv/bin"
-printf '%s\n' "#!/bin/bash" >"$test_home/.hermes/hermes-agent/venv/bin/hermes"
+printf '%s\n' "#!/bin/bash" 'echo "hermes-agent 0.0.0-test"' >"$test_home/.hermes/hermes-agent/venv/bin/hermes"
 chmod +x "$test_home/.hermes/hermes-agent/venv/bin/hermes"
 run_installer 1 --check && fail "--check waits for the install to finish, not just the venv"
 touch "$test_home/.hermes/hermes-agent/.hermes-bootstrap-complete"
@@ -130,6 +132,32 @@ run_installer 0 && fail "the installer does not succeed over a non-executable fo
   fail "a non-executable foreign hermes is left untouched"
 pass "a non-executable foreign hermes is preserved"
 
+# The executable bit is not enough: a wrapper whose interpreter is gone passes
+# -x and still cannot run. The probe has to run it to find out, and finding
+# out never touches the file.
+broken_interp_body="#!$test_home/nowhere/python3
+print('hermes')"
+printf '%s\n' "$broken_interp_body" >"$test_home/.local/bin/hermes"
+chmod +x "$test_home/.local/bin/hermes"
+run_installer 0 --check && fail "--check rejects a foreign hermes whose interpreter is missing"
+run_installer 0 && fail "the installer does not succeed over a foreign hermes whose interpreter is missing"
+run_installer 0 --now && fail "--now does not succeed over a foreign hermes whose interpreter is missing"
+[[ -x $test_home/.local/bin/hermes && $(cat "$test_home/.local/bin/hermes") == "$broken_interp_body" ]] ||
+  fail "a foreign hermes whose interpreter is missing is left untouched"
+pass "a foreign hermes with a missing interpreter is preserved and rejected"
+
+# Likewise a wrapper that execs a target that is no longer there.
+broken_target_body="#!/bin/bash
+exec $test_home/nowhere/hermes \"\$@\""
+printf '%s\n' "$broken_target_body" >"$test_home/.local/bin/hermes"
+chmod +x "$test_home/.local/bin/hermes"
+run_installer 0 --check && fail "--check rejects a foreign hermes whose target is missing"
+run_installer 0 && fail "the installer does not succeed over a foreign hermes whose target is missing"
+run_installer 0 --now && fail "--now does not succeed over a foreign hermes whose target is missing"
+[[ -x $test_home/.local/bin/hermes && $(cat "$test_home/.local/bin/hermes") == "$broken_target_body" ]] ||
+  fail "a foreign hermes whose target is missing is left untouched"
+pass "a foreign hermes with a missing target is preserved and rejected"
+
 foreign_target="$test_home/foreign/hermes"
 mkdir -p "$(dirname "$foreign_target")"
 printf '%s\n' "$official_body" >"$foreign_target"
@@ -161,9 +189,9 @@ pass "a directory at the hermes path is preserved and rejected"
 
 # Mentioning the installer is not the same as being written by it.
 rmdir "$test_home/.local/bin/hermes"
-mentions_body='#!/bin/bash
+mentions_body="#!/bin/bash
 # Replaces the stub omarchy-install-hermes-cli used to write.
-exec /usr/local/bin/hermes "$@"'
+exec $test_home/.hermes/hermes-agent/venv/bin/hermes \"\$@\""
 printf '%s\n' "$mentions_body" >"$test_home/.local/bin/hermes"
 chmod +x "$test_home/.local/bin/hermes"
 run_installer 0 || fail "installing over a wrapper that mentions the installer returns success"

--- a/test/shell.d/hermes-cli-test.sh
+++ b/test/shell.d/hermes-cli-test.sh
@@ -41,7 +41,7 @@ run_installer() {
     bash "$ROOT/bin/omarchy-install-hermes-cli" ${2:+"$2"} >/dev/null 2>&1
 }
 
-stub_marker="omarchy-install-hermes-cli"
+stub_marker="# Written by omarchy-install-hermes-cli."
 app_stub_body='#!/bin/bash
 exec /home/x/.hermes/hermes-agent/venv/bin/hermes "$@"'
 
@@ -51,14 +51,14 @@ exec /home/x/.hermes/hermes-agent/venv/bin/hermes "$@"'
 rm -f "$test_home/.local/bin/hermes"
 run_installer 0 || fail "installer failed with no desktop installed"
 [[ -x $test_home/.local/bin/hermes ]] || fail "installer writes a hermes stub when the desktop is absent"
-grep -q "$stub_marker" "$test_home/.local/bin/hermes" || fail "the stub records which command wrote it"
+grep -qxF "$stub_marker" "$test_home/.local/bin/hermes" || fail "the stub records which command wrote it"
 tr '\0' ' ' <"$mise_log" | grep -q "use -g --quiet uv" &&
   fail "writing the stub does not install uv"
 pass "writing the Hermes stub provisions nothing"
 
 # The desktop app owns Hermes, so our own stub must go rather than sit there
 # answering `hermes` until the app's bootstrap replaces it.
-printf '%s\n' "#!/bin/bash" "# $stub_marker" >"$test_home/.local/bin/hermes"
+printf '%s\n' "#!/bin/bash" "$stub_marker" >"$test_home/.local/bin/hermes"
 chmod +x "$test_home/.local/bin/hermes"
 run_installer 1 || true
 [[ ! -e $test_home/.local/bin/hermes ]] ||
@@ -74,7 +74,7 @@ run_installer 1 || true
 pass "the app's own hermes command is left alone"
 
 # A copy mise cannot vouch for is still a second Hermes.
-printf '%s\n' "#!/bin/bash" "# $stub_marker" >"$test_home/.local/bin/hermes"
+printf '%s\n' "#!/bin/bash" "$stub_marker" >"$test_home/.local/bin/hermes"
 chmod +x "$test_home/.local/bin/hermes"
 : >"$mise_log"
 OMARCHY_TEST_MISE_WHERE_OK=1 run_installer 1 || true
@@ -103,3 +103,81 @@ printf '%s\n' "#!/bin/bash" "exec /usr/local/bin/somebody-elses-hermes \"\$@\"" 
 chmod +x "$test_home/.local/bin/hermes"
 run_installer 1 --check && fail "--check rejects a hermes command belonging to something else"
 pass "--check rejects a foreign hermes command"
+
+# A hermes the user installed themselves -- the official installer, a wrapper of
+# their own -- is not ours to replace. --check follows whether it runs, and
+# installing steps aside so the default agent uses it.
+official_body="#!/bin/bash
+unset PYTHONPATH
+unset PYTHONHOME
+exec $test_home/.hermes/hermes-agent/venv/bin/hermes \"\$@\""
+printf '%s\n' "$official_body" >"$test_home/.local/bin/hermes"
+chmod +x "$test_home/.local/bin/hermes"
+run_installer 0 --check || fail "--check accepts a working foreign hermes command"
+run_installer 0 || fail "installing over a foreign hermes command returns success"
+run_installer 0 --now || fail "--now over a foreign hermes command returns success"
+[[ $(cat "$test_home/.local/bin/hermes") == "$official_body" ]] ||
+  fail "a foreign hermes command is left untouched"
+pass "a foreign hermes command is preserved and satisfies --check"
+
+# Broken foreign paths are still foreign. They cannot be used, so --check says
+# so and the installer refuses rather than replacing them.
+printf '%s\n' "$official_body" >"$test_home/.local/bin/hermes"
+chmod -x "$test_home/.local/bin/hermes"
+run_installer 0 --check && fail "--check rejects a non-executable foreign hermes"
+run_installer 0 && fail "the installer does not succeed over a non-executable foreign hermes"
+[[ -f $test_home/.local/bin/hermes && ! -x $test_home/.local/bin/hermes ]] ||
+  fail "a non-executable foreign hermes is left untouched"
+pass "a non-executable foreign hermes is preserved"
+
+foreign_target="$test_home/foreign/hermes"
+mkdir -p "$(dirname "$foreign_target")"
+printf '%s\n' "$official_body" >"$foreign_target"
+chmod +x "$foreign_target"
+rm -f "$test_home/.local/bin/hermes"
+ln -s "$foreign_target" "$test_home/.local/bin/hermes"
+run_installer 0 --check || fail "--check accepts a foreign link to a working hermes command"
+run_installer 0 || fail "the installer succeeds over a foreign link to a working hermes command"
+run_installer 0 --now || fail "--now succeeds over a foreign link to a working hermes command"
+[[ -L $test_home/.local/bin/hermes && $(readlink "$test_home/.local/bin/hermes") == "$foreign_target" ]] ||
+  fail "a foreign link to a working hermes command is left untouched"
+pass "a foreign link to a working hermes command is preserved"
+
+rm -f "$test_home/.local/bin/hermes"
+ln -s "$test_home/nowhere/hermes" "$test_home/.local/bin/hermes"
+run_installer 0 --check && fail "--check rejects a dangling hermes link"
+run_installer 0 && fail "the installer does not succeed over a dangling hermes link"
+[[ -L $test_home/.local/bin/hermes && $(readlink "$test_home/.local/bin/hermes") == "$test_home/nowhere/hermes" ]] ||
+  fail "a dangling hermes link is left untouched"
+pass "a dangling hermes link is preserved"
+
+# A directory passes -x on search permission alone. It is still not a command.
+rm -f "$test_home/.local/bin/hermes"
+mkdir "$test_home/.local/bin/hermes"
+run_installer 0 --check && fail "--check rejects a directory at the hermes path"
+run_installer 0 && fail "the installer does not succeed over a directory at the hermes path"
+[[ -d $test_home/.local/bin/hermes ]] || fail "a directory at the hermes path is left untouched"
+pass "a directory at the hermes path is preserved and rejected"
+
+# Mentioning the installer is not the same as being written by it.
+rmdir "$test_home/.local/bin/hermes"
+mentions_body='#!/bin/bash
+# Replaces the stub omarchy-install-hermes-cli used to write.
+exec /usr/local/bin/hermes "$@"'
+printf '%s\n' "$mentions_body" >"$test_home/.local/bin/hermes"
+chmod +x "$test_home/.local/bin/hermes"
+run_installer 0 || fail "installing over a wrapper that mentions the installer returns success"
+[[ $(cat "$test_home/.local/bin/hermes") == "$mentions_body" ]] ||
+  fail "a wrapper that merely mentions the installer is left untouched"
+pass "ownership needs the exact marker line, not a mention"
+
+# Our own stub is ours to rewrite, so reinstalling refreshes it to the current
+# template.
+rm -f "$test_home/.local/bin/hermes"
+printf '%s\n' "#!/bin/bash" "$stub_marker" "# stale template" >"$test_home/.local/bin/hermes"
+chmod +x "$test_home/.local/bin/hermes"
+run_installer 0 || fail "reinstalling over our own stub succeeds"
+grep -qxF "$stub_marker" "$test_home/.local/bin/hermes" || fail "the refreshed stub still carries the marker"
+grep -q "stale template" "$test_home/.local/bin/hermes" && fail "reinstalling rewrites our own stub"
+grep -q "exec mise x" "$test_home/.local/bin/hermes" || fail "the refreshed stub is the current template"
+pass "reinstalling refreshes the Omarchy stub"

--- a/test/shell.d/preinstalls-test.sh
+++ b/test/shell.d/preinstalls-test.sh
@@ -89,3 +89,43 @@ pass "declining Remove Preinstalls changes nothing"
 "$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
 [[ -f $marker ]] || fail "Remove Preinstalls records the opt-out"
 pass "Remove Preinstalls records the opt-out"
+
+# Hermes' wrapper is only a preinstall when omarchy-install-hermes-cli wrote it.
+# The desktop app's command and an official install live at the same path and
+# are the user's, whether or not any package says so.
+hermes="$test_home/.local/bin/hermes"
+mkdir -p "$(dirname "$hermes")"
+
+printf '%s\n' "#!/bin/bash" "# Written by omarchy-install-hermes-cli." >"$hermes"
+chmod +x "$hermes"
+"$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
+[[ ! -e $hermes ]] || fail "Remove Preinstalls deletes the Omarchy Hermes wrapper"
+pass "Remove Preinstalls deletes the Omarchy Hermes wrapper"
+
+printf '%s\n' "#!/bin/bash" "exec $test_home/.hermes/hermes-agent/venv/bin/hermes \"\$@\"" >"$hermes"
+chmod +x "$hermes"
+"$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
+[[ -x $hermes ]] || fail "Remove Preinstalls keeps the desktop app's Hermes command"
+pass "Remove Preinstalls keeps the desktop app's Hermes command"
+
+official_body="#!/bin/bash
+unset PYTHONPATH
+unset PYTHONHOME
+exec $test_home/.hermes/hermes-agent/venv/bin/hermes \"\$@\""
+printf '%s\n' "$official_body" >"$hermes"
+chmod +x "$hermes"
+"$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
+[[ -x $hermes && $(cat "$hermes") == "$official_body" ]] || fail "Remove Preinstalls keeps an official Hermes install"
+pass "Remove Preinstalls keeps an official Hermes install"
+
+printf '%s\n' "#!/bin/bash" "# Replaces the stub omarchy-install-hermes-cli used to write." >"$hermes"
+chmod +x "$hermes"
+"$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
+[[ -x $hermes ]] || fail "Remove Preinstalls keeps a wrapper that merely mentions the installer"
+pass "Remove Preinstalls keeps a wrapper that merely mentions the installer"
+
+rm -f "$hermes"
+ln -s "$test_home/nowhere/hermes" "$hermes"
+"$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
+[[ -L $hermes ]] || fail "Remove Preinstalls keeps a foreign hermes link"
+pass "Remove Preinstalls keeps a foreign hermes link"


### PR DESCRIPTION
This contributes the installation hardening identified during review directly into the head branch of #7469. It is intended to be absorbed by #7469, not to compete with it against `quattro`.

## Summary

- Preserve official, hand-written, symlinked, dangling, directory, and otherwise externally owned `~/.local/bin/hermes` paths.
- Recognize Omarchy ownership only through the exact generated marker line.
- Remove only Omarchy-created Hermes wrappers during Remove Preinstalls.
- Add an existing-user migration that respects `preinstalls-removed`, Hermes Desktop ownership, foreign paths, and idempotence.
- Add focused regression coverage for the full ownership matrix.

The Hermes packaging, Python pin, readiness probe, desktop handoff, and upstream installation strategy are unchanged.

## Verification

- Omabot disposable worker: 188 targeted assertions passed, including 116 CLI assertions.
- Real cold migration and `--now` installation: Hermes Agent 0.19.0 on Python 3.13.15, completed in 13 seconds.
- Exact Nous-style wrapper remained byte-for-byte unchanged through `--check`, normal install, `--now`, and the migration.
- Preinstall opt-out prevented wrapper creation.
- Independent Claude Fable review: GO, no substantive findings.
- `git diff --check`: clean.