### PR TITLE
Make SUPER+J split toggle work on scrolling layouts

### DIFF
--- a/bin/omarchy-hyprland-window-split-toggle
+++ b/bin/omarchy-hyprland-window-split-toggle
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle the window split in the active workspace layout, using a layout-aware action
+
+CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+
+if [[ $CURRENT_LAYOUT == "scrolling" ]]; then
+  hyprctl dispatch 'hl.dsp.layout("promote")' >/dev/null 2>&1 || hyprctl dispatch layoutmsg promote >/dev/null
+else
+  hyprctl dispatch 'hl.dsp.layout("togglesplit")' >/dev/null 2>&1 || hyprctl dispatch layoutmsg togglesplit >/dev/null
+fi

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -2,7 +2,7 @@ o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+o.bind("SUPER + J", "Toggle window split", "omarchy-hyprland-window-split-toggle")
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))

--- a/test/shell.d/hyprland-window-split-test.sh
+++ b/test/shell.d/hyprland-window-split-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 tmpdir=$(mktemp -d)

--- a/test/shell.d/hyprland-window-split-test.sh
+++ b/test/shell.d/hyprland-window-split-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_dir="$tmpdir/bin"
+log_file="$tmpdir/hyprctl.log"
+mkdir -p "$stub_dir"
+
+cat >"$stub_dir/hyprctl" <<'EOF'
+#!/bin/bash
+
+if [[ $1 == "activeworkspace" ]]; then
+  printf '{"id":1,"tiledLayout":"%s"}\n' "$HYPRCTL_LAYOUT"
+else
+  printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+fi
+EOF
+chmod +x "$stub_dir/hyprctl"
+
+HYPRCTL_LAYOUT=dwindle HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" \
+  "$ROOT/bin/omarchy-hyprland-window-split-toggle"
+
+grep -F 'dispatch hl.dsp.layout("togglesplit")' "$log_file" >/dev/null ||
+  fail "split toggle uses togglesplit on dwindle layout"
+pass "split toggle uses togglesplit on dwindle layout"
+
+: >"$log_file"
+HYPRCTL_LAYOUT=scrolling HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" \
+  "$ROOT/bin/omarchy-hyprland-window-split-toggle"
+
+grep -F 'dispatch hl.dsp.layout("promote")' "$log_file" >/dev/null ||
+  fail "split toggle uses promote on scrolling layout"
+! grep -F 'togglesplit' "$log_file" >/dev/null ||
+  fail "split toggle does not dispatch togglesplit on scrolling layout"
+pass "split toggle uses promote on scrolling layout"


### PR DESCRIPTION
## Problem

Pressing SUPER+J ("Toggle window split") on a workspace in the **scrolling layout** raises:

```
runtime error in lua: ?:?: no such layoutmsg for scrolling
```

SUPER+J dispatches `layoutmsg togglesplit`, which only exists in the dwindle layout. Since Omarchy's SUPER+L toggle can put workspaces into the scrolling layout, users hit this error whenever they press SUPER+J there.

## Fix

Route SUPER+J through a new `omarchy-hyprland-window-split-toggle` command that checks the active workspace's layout:

- **dwindle** → `layoutmsg togglesplit` (unchanged behavior)
- **scrolling** → `layoutmsg promote` (move window to its own column, a meaningful scrolling-layout action)

## Tests

Added `test/shell.d/hyprland-window-split-test.sh` covering both layout branches. `./test/shell` and `./test/cli` pass (the 4 unrelated failures in `./test/shell` are pre-existing and also fail on the base commit).