### PR TITLE
Allow overriding terminal screensaver frame rate

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -2,6 +2,12 @@
 
 # omarchy:summary=Run the Omarchy screensaver using random effects from TTE.
 
+frame_rate=${OMARCHY_SCREENSAVER_FRAME_RATE:-120}
+if [[ ! $frame_rate =~ ^[1-9][0-9]{0,2}$ ]] || ((10#$frame_rate > 240)); then
+  echo "OMARCHY_SCREENSAVER_FRAME_RATE must be an integer between 1 and 240" >&2
+  exit 1
+fi
+
 screensaver_in_focus() {
   hyprctl activewindow -j | jq -e '.class == "org.omarchy.screensaver"' >/dev/null 2>&1
 }
@@ -37,7 +43,7 @@ wait_for_terminal_resize
 
 while true; do
   ttfx -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
+    --frame-rate "$frame_rate" --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
     --random-effect --no-eol --no-restore-cursor &
 
   while pgrep -t "${tty#/dev/}" -x ttfx >/dev/null; do

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -92,6 +92,8 @@ You can start it on demand from _System > Screensaver_ (`Super + Esc`), which fo
 
 `omarchy toggle screensaver` is what turns the idle one off, if you'd rather go straight from working to locked. It needs a terminal it knows how to configure — Alacritty, Foot, Ghostty, or Kitty — and will tell you so if your default terminal is something else.
 
+The animation normally runs at 120 frames per second. On a constrained virtual or software-rendered display, set `OMARCHY_SCREENSAVER_FRAME_RATE` to a lower value such as `20` in a file under `~/.config/uwsm/env.d/`, then restart Omarchy. Values from 1 through 240 are accepted.
+
 The logo it draws is yours to change, under _Style > Screensaver_. Upload a png or svg and Omarchy converts it to ASCII. See [branding](41-branding.md).
 
 ### The lock screen

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -92,7 +92,13 @@ You can start it on demand from _System > Screensaver_ (`Super + Esc`), which fo
 
 `omarchy toggle screensaver` is what turns the idle one off, if you'd rather go straight from working to locked. It needs a terminal it knows how to configure — Alacritty, Foot, Ghostty, or Kitty — and will tell you so if your default terminal is something else.
 
-The animation normally runs at 120 frames per second. On a constrained virtual or software-rendered display, set `OMARCHY_SCREENSAVER_FRAME_RATE` to a lower value such as `20` in a file under `~/.config/uwsm/env.d/`, then restart Omarchy. Values from 1 through 240 are accepted.
+The animation normally runs at 120 frames per second. On a constrained virtual or software-rendered display, create a file such as `~/.config/uwsm/env.d/screensaver` containing:
+
+```bash
+export OMARCHY_SCREENSAVER_FRAME_RATE=20
+```
+
+Then restart Omarchy. Values from 1 through 240 are accepted.
 
 The logo it draws is yours to change, under _Style > Screensaver_. Upload a png or svg and Omarchy converts it to ASCII. See [branding](41-branding.md).
 

--- a/test/shell.d/screensaver-test.sh
+++ b/test/shell.d/screensaver-test.sh
@@ -68,9 +68,13 @@ HOME="$test_tmp/home" \
 grep -q -- '--frame-rate 120' "$call_log" || fail "screensaver keeps the 120 FPS default"
 
 for invalid in 0 241 twenty; do
-  if OMARCHY_SCREENSAVER_FRAME_RATE="$invalid" "$ROOT/bin/omarchy-screensaver" >/dev/null 2>&1; then
-    fail "screensaver rejects invalid frame rate" "accepted: $invalid"
-  fi
+  set +e
+  OMARCHY_SCREENSAVER_FRAME_RATE="$invalid" timeout 2s "$ROOT/bin/omarchy-screensaver" >/dev/null 2>&1
+  status=$?
+  set -e
+
+  (( status != 124 )) || fail "screensaver rejects invalid frame rate without hanging" "timed out: $invalid"
+  (( status == 1 )) || fail "screensaver rejects invalid frame rate" "value: $invalid, exit status: $status"
 done
 
 pass "screensaver validates and forwards its frame rate"

--- a/test/shell.d/screensaver-test.sh
+++ b/test/shell.d/screensaver-test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command script
+require_command timeout
+
+test_tmp=$(mktemp -d)
+mock_bin="$test_tmp/bin"
+call_log="$test_tmp/ttfx-calls"
+pid_file="$test_tmp/ttfx-pid"
+mkdir -p "$mock_bin" "$test_tmp/home/.config/omarchy/branding"
+printf 'Omarchy\n' >"$test_tmp/home/.config/omarchy/branding/screensaver.txt"
+
+cleanup() {
+  if [[ -s $pid_file ]]; then
+    kill "$(<"$pid_file")" 2>/dev/null || true
+  fi
+  rm -rf "$test_tmp"
+}
+trap cleanup EXIT
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ $* == "activewindow -j" ]]; then
+  printf '{"class":"org.omarchy.screensaver"}\n'
+fi
+SH
+
+cat >"$mock_bin/ttfx" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$CALL_LOG"
+printf '%s\n' "$$" >"$TTFX_PID_FILE"
+kill -HUP "$PPID"
+rm -f "$TTFX_PID_FILE"
+SH
+
+cat >"$mock_bin/pkill" <<'SH'
+#!/bin/bash
+if [[ $* == *"ttfx"* && -s $TTFX_PID_FILE ]]; then
+  kill "$(<"$TTFX_PID_FILE")" 2>/dev/null || true
+fi
+SH
+
+chmod +x "$mock_bin/hyprctl" "$mock_bin/ttfx" "$mock_bin/pkill"
+
+run_screensaver() {
+  local frame_rate=$1
+  HOME="$test_tmp/home" \
+    PATH="$mock_bin:$PATH" \
+    CALL_LOG="$call_log" \
+    TTFX_PID_FILE="$pid_file" \
+    OMARCHY_SCREENSAVER_FRAME_RATE="$frame_rate" \
+    timeout 2s script -qefc "$ROOT/bin/omarchy-screensaver" /dev/null >/dev/null 2>&1 || true
+}
+
+run_screensaver 20
+grep -q -- '--frame-rate 20' "$call_log" || fail "screensaver forwards configured frame rate"
+
+: >"$call_log"
+HOME="$test_tmp/home" \
+  PATH="$mock_bin:$PATH" \
+  CALL_LOG="$call_log" \
+  TTFX_PID_FILE="$pid_file" \
+  timeout 2s script -qefc "$ROOT/bin/omarchy-screensaver" /dev/null >/dev/null 2>&1 || true
+grep -q -- '--frame-rate 120' "$call_log" || fail "screensaver keeps the 120 FPS default"
+
+for invalid in 0 241 twenty; do
+  if OMARCHY_SCREENSAVER_FRAME_RATE="$invalid" "$ROOT/bin/omarchy-screensaver" >/dev/null 2>&1; then
+    fail "screensaver rejects invalid frame rate" "accepted: $invalid"
+  fi
+done
+
+pass "screensaver validates and forwards its frame rate"


### PR DESCRIPTION
Fixes #8554

## Summary

- let the terminal screensaver read `OMARCHY_SCREENSAVER_FRAME_RATE`
- keep the existing 120 FPS behavior when the variable is unset
- reject values outside the supported 1–240 range before launching ttfx
- document the UWSM environment override and cover custom/default/invalid values with a headless shell test

## Context

The QXL guest documented in #8554 freezes its Wayland session after the stock 120 FPS Foot/ttfx screensaver starts. The kernel recorded 117 TTM eviction failures, a QXL VRAM allocation failure, and repeated `qxl_fence_wait` stalls. Disabling the screensaver prevents the failure, but currently there is no supported middle ground between editing the package-owned script and disabling the feature entirely.

This intentionally does not auto-detect QXL or change the default for everyone. It provides a small, reversible mitigation and a controlled way to test a conservative rate such as 20 on constrained displays.

PR #7193 would make the terminal implementation a fallback behind a native Wayland client. That client should preserve the same override if it becomes the default; this draft is limited to the implementation currently shipped by `quattro`.

## Testing

- `test/shell.d/screensaver-test.sh`
- `bash -n bin/omarchy-screensaver test/shell.d/screensaver-test.sh`
- `git diff --check`
- `./test/all`: `test/cli` passed and the new screensaver test passed. The shell suite reported seven unrelated environment/fixture failures that also reproduce at the untouched base commit: missing `omarchy-pkgs` checkout coverage, two existing command-path/animation tests, a QR fixture mismatch, and restricted writes under the host `$HOME`.

I did not deliberately run the live 120 FPS failure again: recovering this guest requires stopping the graphical session, and #8554 already contains the complete user-journal and kernel timeline. The override path itself is exercised through a pseudo-terminal with stubbed `ttfx`, `hyprctl`, and process cleanup.
