### PR TITLE
Add keybindings to send a floating window to the back or front

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -49,6 +49,9 @@ o.bind("ALT + SHIFT + TAB", "Focus on previous window", hl.dsp.window.cycle_next
 o.bind("ALT + TAB", "Reveal active window on top", hl.dsp.window.bring_to_top())
 o.bind("ALT + SHIFT + TAB", "Reveal active window on top", hl.dsp.window.bring_to_top())
 
+o.bind("SUPER + SHIFT + code:34", "Send window to back", hl.dsp.window.alter_zorder({ mode = "bottom" }))
+o.bind("SUPER + SHIFT + code:35", "Bring window to front", hl.dsp.window.alter_zorder({ mode = "top" }))
+
 o.bind("CTRL + ALT + TAB", "Focus on next monitor", hl.dsp.focus({ monitor = "+1" }))
 o.bind("CTRL + ALT + SHIFT + TAB", "Focus on previous monitor", hl.dsp.focus({ monitor = "-1" }))
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/64ac3352-9742-4b57-9a4c-b685e40376ed



Hyprland has an `alter_zorder` dispatcher, but nothing in Omarchy binds it. `bring_to_top` only rides along on ALT+TAB to reveal the window you just cycled to, so there's no deliberate way to reorder overlapping floating windows.

This binds the pair to SUPER+SHIFT+[ and SUPER+SHIFT+], the keys Figma, Photoshop, and Illustrator all use for send-to-back and bring-to-front. They're spelled `code:34`/`code:35` to match how `utilities.lua` binds the webcam overlay to those same two physical keys. Unshifted SUPER+[ and SUPER+] are left free — in those apps they step one layer at a time, which Hyprland has no dispatcher for, so the slots stay open if it ever gains one.

One limit worth naming: Hyprland renders tiled, then floating, then pinned, and `alter_zorder` only reorders within a layer. A window popped out with SUPER+O (float & pin) won't drop behind an unpinned window, though pinned windows still reorder among themselves — press SUPER+O again to unpin first.
