### PR TITLE
Restore lock screen password focus lost on suspend

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -160,6 +160,15 @@ Item {
           visible: passwordInput.cursorVisible
         }
 
+        // Suspending drops keyboard focus from this field while the lock is
+        // still up, and nothing puts it back: focus is only taken in
+        // Component.onCompleted and when inputEnabled changes, and inputEnabled
+        // is already true by then. Take it back so the machine wakes ready to
+        // type instead of needing a click first.
+        onActiveFocusChanged: {
+          if (!activeFocus && root.inputEnabled) Qt.callLater(root.forcePasswordFocus)
+        }
+
         onTextChanged: {
           if (!root.syncingPasswordText) root.passwordTextEdited(text)
           if (text.length > 0) {

--- a/test/shell.d/lock-focus-recovery-test.sh
+++ b/test/shell.d/lock-focus-recovery-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const lockView = fs.readFileSync(path.join(root, 'shell/plugins/lock/LockView.qml'), 'utf8')
+
+// Suspending drops focus from the field while the lock is still up. Focus is
+// otherwise only taken in Component.onCompleted and when inputEnabled changes,
+// and inputEnabled follows lockRequested, which is already true by then, so
+// without this handler the machine wakes to a lock screen that ignores the
+// keyboard until it is clicked.
+assert(
+  /onActiveFocusChanged: \{\s*if \(!activeFocus && root\.inputEnabled\) Qt\.callLater\(root\.forcePasswordFocus\)/.test(lockView),
+  'the password field reclaims focus when it loses it while the lock is up'
+)
+
+// Gating on inputEnabled keeps the unlocked preview surface, which builds the
+// same view with inputEnabled false, from fighting the compositor for focus.
+assert(
+  !/onActiveFocusChanged: \{\s*if \(!activeFocus\) /.test(lockView),
+  'focus recovery only runs while the lock is accepting input'
+)
+JS


### PR DESCRIPTION
Suspending drops keyboard focus from the lock screen password field, and nothing puts it back. Focus is only taken in `Component.onCompleted` and when `inputEnabled` changes, and `inputEnabled` is bound to `lockRequested`, which is already true by the time the machine suspends and stays true across resume. The only remaining path was the background `MouseArea`'s `onClicked` handler, so the machine woke to a lock screen that ignored the keyboard until it was clicked.

Reclaim focus when the field loses it while the lock is up.

Traced on a 4.0 desktop, timestamps from journalctl:

```
11:09:39.982  activeFocus=true       field focused at lock
11:09:39.992  secure=true
11:09:40.086  kernel: PM: suspend entry (deep)
11:09:40.099  activeFocus=false      focus dropped
11:09:40.099  activeFocus=true       reclaimed by this change
11:10:07.577  kernel: PM: suspend exit
```

A plain lock without a suspend does not drop focus, so reproducing this needs an actual suspend rather than just locking the session. Verified on hardware: with the change, the machine wakes with the field focused and accepts typing without a click.