### PR TITLE
Give the lock screen longer before it blanks the display

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -413,7 +413,10 @@ Item {
 
   Timer {
     id: idleBlankTimer
-    interval: 5000
+    // Long enough to wake the machine, read the field and type a password
+    // without the panel going dark mid-entry. Any activity re-arms it, so an
+    // untouched lock screen still blanks one interval after the last input.
+    interval: 30000
     repeat: false
     property double armedAt: 0
     onTriggered: {

--- a/test/shell.d/lock-blank-fingerprint-test.sh
+++ b/test/shell.d/lock-blank-fingerprint-test.sh
@@ -30,4 +30,11 @@ assert(
   !/onAuthenticatingChanged:/.test(serviceQml),
   'the combined authenticating state no longer drives the blank timer'
 )
+
+// Five seconds is shorter than it takes to wake the machine and type a
+// password, so the panel used to go dark mid-entry. Pin the interval.
+assert(
+  /id: idleBlankTimer[\s\S]*?interval: 30000/.test(serviceQml),
+  'the blank timer waits thirty seconds before turning the display off'
+)
 JS


### PR DESCRIPTION
idleBlankTimer turns the display off five seconds after the last input on the lock screen. That is shorter than it takes to wake the machine, focus the password field and start typing, so the panel goes dark mid-entry and has to be nudged awake again, often more than once per unlock.

Raise the interval to thirty seconds. Activity still re-arms the timer, so an untouched lock screen blanks one interval after the last input.


Claude-Session: https://claude.ai/code/session_01WDCXKUYgyKMb1ACcoBAbro