### PR TITLE
Fix font restart notifications

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -68,11 +68,11 @@ XML
 omarchy-restart-shell
 
 if pgrep -x ghostty; then
-  omarchy-notification-send -g  "You must restart Ghostty to see font change"
+  omarchy-notification-send "You must restart Ghostty to see font change"
 fi
 
 if pgrep -x foot; then
-  omarchy-notification-send -g  "You must restart Foot to see font change"
+  omarchy-notification-send "You must restart Foot to see font change"
 fi
 
 omarchy-hook font-set "$font_name"


### PR DESCRIPTION
Fixes the Ghostty and Foot restart notifications in omarchy-font-set. The stray -g flag consumed the notification headline as its missing glyph value, causing the notification command to fail. 