### PR TITLE
Show hotkey chips on menu rows a keybinding also reaches

### DIFF
--- a/bin/omarchy-menu-hotkeys
+++ b/bin/omarchy-menu-hotkeys
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# omarchy:summary=Report the hotkey chips the Omarchy menu shows on rows a keybinding also reaches
+# omarchy:hidden=true
+
+# One row per exec chord, tab-separated:
+#
+#   cmd\t<command>\t<chord>     what the chord runs, verbatim
+#   app\t<desktop id>\t<chord>  the app a launcher indirection resolves to today
+#
+# The menu matches `cmd` rows against JSONC actions, `omarchy-menu toggle`
+# routes, and desktop Exec lines, and `app` rows against app ids — so the
+# default terminal's chord lands on that terminal's row in Apps even though
+# the bind runs `omarchy-launch-terminal`, not the terminal itself.
+
+set -euo pipefail
+
+records=$(omarchy-menu-keybindings --records)
+
+# A record's display column is "CHORD [/ ALT-CHORD] → action" padded for the
+# keybindings menu; the chip keeps only the chord that leads the row.
+rows=$(awk -F'\t' '
+  NF >= 3 && $2 == "exec" && $3 != "" {
+    chord = $1
+    sub(/ *→.*$/, "", chord)
+    sub(/ *\/.*$/, "", chord)
+    gsub(/[[:space:]]+/, " ", chord)
+    sub(/^ /, "", chord)
+    sub(/ $/, "", chord)
+    if (chord == "") next
+
+    arg = $3
+    for (i = 4; i <= NF; i++) arg = arg "\t" $i
+    printf "cmd\t%s\t%s\n", arg, chord
+  }
+' <<<"$records")
+
+if [[ -n $rows ]]; then
+  printf '%s\n' "$rows"
+fi
+
+chord_for() {
+  awk -F'\t' -v cmd="$1" '$1 == "cmd" && ($2 == cmd || index($2, cmd " ") == 1) { print $3; exit }' <<<"$rows"
+}
+
+emit_app() {
+  local desktop_id="$1" chord="$2"
+
+  if [[ -n $desktop_id && -n $chord ]]; then
+    printf 'app\t%s\t%s\n' "${desktop_id%.desktop}" "$chord"
+  fi
+}
+
+terminal_chord=$(chord_for "omarchy-launch-terminal")
+if [[ -n $terminal_chord ]]; then
+  terminal_id=$(xdg-terminal-exec --print-id 2>/dev/null || true)
+  emit_app "${terminal_id%%:*}" "$terminal_chord"
+fi
+
+browser_chord=$(chord_for "omarchy-launch-browser")
+if [[ -n $browser_chord ]]; then
+  browser_id=$(env -u BROWSER xdg-settings get default-web-browser 2>/dev/null || true)
+  emit_app "$browser_id" "$browser_chord"
+fi

--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -654,6 +654,11 @@ dispatch_binding() {
 
 if [[ $1 == "--print" || $1 == "-p" ]]; then
   output_keybindings
+elif [[ $1 == "--records" ]]; then
+  # The raw records behind the menu: `<chords> → <action>\t<dispatcher>\t<arg>`
+  # per line. `omarchy-menu-hotkeys` reads these to chip menu rows with the
+  # chord that reaches them.
+  output_binding_records
 else
   records=$(output_binding_records)
   selection=$(cut -f1 <<<"$records" |

--- a/config/omarchy/extensions/omarchy-menu.jsonc
+++ b/config/omarchy/extensions/omarchy-menu.jsonc
@@ -15,6 +15,9 @@
   //   description Optional subtitle and extra search text.
   //   when        Shell condition; hide row when it fails.
   //   checked     Shell condition; append ✓ when it succeeds.
+  //   hotkey      Chord chip shown on the row's right edge. Derived from your
+  //               keybindings when a bind runs the row's action or opens its
+  //               route; set it only when the spellings differ.
   //
   // Examples:
   // "personal": {"icon":"","label":"Personal"},

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -19,6 +19,10 @@
   //                  goes dim, takes a ✓ and can no longer be selected. Install
   //                  rows use it so software already on the machine reads as
   //                  installed instead of vanishing from the list.
+  //   hotkey         chord chip shown on the row's right edge. Normally derived
+  //                  from the live keybindings (a bind running the row's action,
+  //                  or opening its route); set explicitly only when the
+  //                  spellings differ and the chip is still right.
 
   // Root Menu
   "apps": {"icon":"󰀻","label":"Apps","aliases":["app","applications"],"provider":"apps"},

--- a/default/themed/shell.toml.tpl
+++ b/default/themed/shell.toml.tpl
@@ -107,6 +107,7 @@ base-size = 12
 # Per-token overrides, in px. Uncomment any to pin a specific size without
 # affecting the rest of the scale. Useful for stylistic emphasis (a
 # minimalist theme that wants a bigger heading without scaling everything).
+# micro         = 9
 # caption       = 10
 # body-small    = 11
 # body          = 12

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -42,7 +42,7 @@ submenu. The fields:
 | `aliases` | Alternate `omarchy menu summon <name>` routes; also searchable |
 | `description` | Subtitle shown while searching, and extra search text matched by whole word |
 | `when` / `checked` / `disabled` | Shell conditions (see Guards) |
-| `hotkey` | Chord chip on the row's right edge; normally derived from the live keybindings (see Hotkey chips), declared only to override |
+| `hotkey` | Chord chip on the row's right edge, written as `SUPER + K` and shortened for display; normally derived from the live keybindings (see Hotkey chips), declared only to override |
 
 Do not add `aliases` to new entries. They are reserved for established
 alternate names users already type (`power-menu`, `settings`), kept for
@@ -100,7 +100,9 @@ to remove. `menu-test.sh` enforces the Install side of this convention.
 
 ## Hotkey chips
 
-A row a keybinding also reaches shows that chord as a small chip on its right edge — Learn > Keybindings carries `SUPER + K`, the System submenu carries `SUPER + ESCAPE`, and the default terminal's row in Apps carries `SUPER + RETURN`. The chips teach the faster path to what the user just navigated to.
+A row a keybinding also reaches shows that chord as a small chip on its right edge — Learn > Keybindings carries `SUP+K`, the System submenu carries `SUP+ESC`, and the default terminal's row in Apps carries `SUP+RET`. The chips teach the faster path to what the user just navigated to.
+
+A chip annotates a label, so it is spelled to stay out of its way: modifiers shorten to three letters, long X11 key names read as what the key does (`XF86MonBrightnessDown` becomes `BRIDN`), and the chip renders a step under caption, capped at a third of the row so a long chord elides before the title does. The keybindings menu keeps the spelled-out `SUPER + K` — it has the width for it.
 
 The chords are derived, not declared: `omarchy-menu-hotkeys` reads the same records as the keybindings menu (`omarchy-menu-keybindings --records`, cached in `~/.cache/omarchy`) and reports one `cmd`/`app` row per exec chord. The shell runs it like the guard batch — once per (re)load and per open, never blocking the open path — and `MenuModel.hotkeyIndex` matches the rows on:
 

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -42,6 +42,7 @@ submenu. The fields:
 | `aliases` | Alternate `omarchy menu summon <name>` routes; also searchable |
 | `description` | Subtitle shown while searching, and extra search text matched by whole word |
 | `when` / `checked` / `disabled` | Shell conditions (see Guards) |
+| `hotkey` | Chord chip on the row's right edge; normally derived from the live keybindings (see Hotkey chips), declared only to override |
 
 Do not add `aliases` to new entries. They are reserved for established
 alternate names users already type (`power-menu`, `settings`), kept for
@@ -96,6 +97,18 @@ The three guards differ in what failure means:
 Install rows should therefore carry `disabled:` with the presence check, not
 `when:`; Remove rows are the opposite, hiding via `when:` what is not there
 to remove. `menu-test.sh` enforces the Install side of this convention.
+
+## Hotkey chips
+
+A row a keybinding also reaches shows that chord as a small chip on its right edge — Learn > Keybindings carries `SUPER + K`, the System submenu carries `SUPER + ESCAPE`, and the default terminal's row in Apps carries `SUPER + RETURN`. The chips teach the faster path to what the user just navigated to.
+
+The chords are derived, not declared: `omarchy-menu-hotkeys` reads the same records as the keybindings menu (`omarchy-menu-keybindings --records`, cached in `~/.cache/omarchy`) and reports one `cmd`/`app` row per exec chord. The shell runs it like the guard batch — once per (re)load and per open, never blocking the open path — and `MenuModel.hotkeyIndex` matches the rows on:
+
+- the row's `action`, compared after collapsing quoting, desktop Exec field codes, and `uwsm-app -- `/`setsid ` prefixes, with webapp launches reduced to their URL so the focus variant still matches
+- binds that open the menu itself (`omarchy-menu toggle capture`), resolved through the same route/alias resolution as `omarchy menu summon`
+- app rows, by desktop id (`omarchy-menu-hotkeys` resolves the default terminal and browser indirections to today's app) or by the desktop entry's Exec matching what a chord runs — how each webapp row finds its chord
+
+Because the chords come from the live binds, a rebind in the hypr config moves the chip with it. An explicit `hotkey:` in JSONC wins over anything derived, for the rare row whose action spells the same launch differently; the first chord claiming a command wins when several run it, matching how the keybindings menu leads a merged row.
 
 ## Providers
 

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -322,6 +322,7 @@ bumping `base-size` rescales the whole shell proportionally:
 
 | Token                 | Multiplier | Default |
 |-----------------------|------------|---------|
+| `Style.font.micro`        | 0.75  | 9  |
 | `Style.font.caption`      | 0.833 | 10 |
 | `Style.font.bodySmall`    | 0.917 | 11 |
 | `Style.font.body`         | 1.0   | 12 |
@@ -351,7 +352,7 @@ heading       = 20
 display-large = 36
 ```
 
-Recognized override keys: `base-size`, `caption`, `body-small`,
+Recognized override keys: `base-size`, `micro`, `caption`, `body-small`,
 `body`, `subtitle`, `title`, `heading`, `display`, `display-large`,
 `icon-small`, `icon`, `icon-large`.
 

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -324,6 +324,7 @@ QtObject {
     readonly property string menuFamily: root.menuFontFamily
     readonly property int baseSize: root.fontBaseSize
 
+    readonly property int micro:        root.fontToken("micro",         root.fontPx(0.75))    // 9
     readonly property int caption:      root.fontToken("caption",       root.fontPx(0.833))   // 10
     readonly property int bodySmall:    root.fontToken("body-small",    root.fontPx(0.917))   // 11
     readonly property int body:         root.fontToken("body",          root.fontPx(1.0))     // 12

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -252,6 +252,8 @@ Item {
     root.itemOrder = mergedMenu.itemOrder
     root.rowsLoaded = true
     root.evaluateGuards()
+    root.rebuildHotkeyIndex()
+    root.refreshHotkeys()
     if (root.opened) {
       root.rebuildDisplay()
       if (!root.dmenuActive) {
@@ -318,6 +320,10 @@ Item {
         when: "",
         checked: "",
         disabled: "",
+        hotkey: "",
+        // What the entry launches, so a bind running the same command —
+        // a webapp chord and that webapp's row — meet in the hotkey index.
+        exec: String(entry.execString || ""),
         order: 0
       })
     }
@@ -325,6 +331,7 @@ Item {
     var merged = MenuModel.mergeAppRows(root.items, root.itemOrder, appRows)
     root.items = merged.items
     root.itemOrder = merged.itemOrder
+    root.rebuildHotkeyIndex()
     if (root.opened) root.rebuildDisplay()
   }
 
@@ -384,12 +391,14 @@ Item {
         when: "",
         checked: "",
         disabled: "",
+        hotkey: "",
         order: 0
       })
     }
     var merged = MenuModel.swapProviderRows(root.items, root.itemOrder, menuId, providerRows)
     root.items = merged.items
     root.itemOrder = merged.itemOrder
+    root.rebuildHotkeyIndex()
     if (root.opened) root.rebuildDisplay()
   }
 
@@ -516,7 +525,7 @@ Item {
   }
 
   function displayRow(entry, detail, score, section) {
-    return MenuModel.displayRow(root.items, root.itemOrder, root.checkedResults, root.disabledResults, entry, detail, score, section)
+    return MenuModel.displayRow(root.items, root.itemOrder, root.checkedResults, root.disabledResults, root.hotkeysById, entry, detail, score, section)
   }
 
   function rowSelectable(index) {
@@ -581,6 +590,7 @@ Item {
         appId: "",
         label: label,
         target: "",
+        hotkey: "",
         detail: detail,
         path: "",
         childCount: 0,
@@ -847,6 +857,7 @@ Item {
     cursorActive = true
     root.disarmPointer()
     root.evaluateGuards()
+    root.refreshHotkeys()
     opened = true
     rebuildDisplay()
     invalidateVolatileProvider(activeMenu)
@@ -1062,6 +1073,52 @@ Item {
       if (root.guardsPending) Qt.callLater(function() { root.evaluateGuards() })
     }
   }
+
+  // ----------------------------------------------------------- hotkey chips
+  //
+  // A row a keybinding also reaches shows that chord as a chip on its right
+  // edge. `omarchy-menu-hotkeys` derives the chords from the live binds, so a
+  // rebind moves the chip; matching onto rows is pure (MenuModel.hotkeyIndex)
+  // and re-runs whenever the items or the chords change. Like the guards, the
+  // batch never blocks the open path: the menu opens on the previous answers.
+
+  property var hotkeyRows: []
+  property var hotkeysById: ({})
+  property bool hotkeysPending: false
+
+  function rebuildHotkeyIndex() {
+    root.hotkeysById = MenuModel.hotkeyIndex(root.items, root.itemOrder, root.hotkeyRows)
+  }
+
+  function refreshHotkeys() {
+    // Same discipline as evaluateGuards: a run in flight keeps its output,
+    // and the refresh that arrived meanwhile goes once it lands.
+    if (hotkeysProc.running) {
+      root.hotkeysPending = true
+      return
+    }
+    root.hotkeysPending = false
+    hotkeysProc.collected = ""
+    hotkeysProc.running = true
+  }
+
+  Process {
+    id: hotkeysProc
+    command: ["bash", "-lc", "omarchy-menu-hotkeys"]
+    property string collected: ""
+    stdout: SplitParser {
+      onRead: function(data) { hotkeysProc.collected += data + "\n" }
+    }
+    onExited: function(exitCode, exitStatus) {
+      if (exitCode === 0 && exitStatus === 0) {
+        root.hotkeyRows = MenuModel.parseHotkeyLines(hotkeysProc.collected)
+        root.rebuildHotkeyIndex()
+        if (root.opened) root.rebuildDisplay()
+      }
+      if (root.hotkeysPending) Qt.callLater(function() { root.refreshHotkeys() })
+    }
+  }
+
   PanelWindow {
     id: panel
     visible: root.opened && root.rowsLoaded
@@ -1255,6 +1312,7 @@ Item {
               required property string appId
               required property string label
               required property string target
+              required property string hotkey
               required property string detail
               required property string path
               required property string action
@@ -1321,7 +1379,7 @@ Item {
                 id: contentColumn
                 anchors.left: row.hasIcon ? iconText.right : parent.left
                 anchors.leftMargin: row.hasIcon ? Style.space(6) : root.rowReservedBorderLeft + Style.space(18)
-                anchors.right: trail.left
+                anchors.right: hotkeyChip.left
                 anchors.rightMargin: Style.space(6)
                 anchors.verticalCenter: parent.verticalCenter
                 spacing: Style.space(3)
@@ -1347,6 +1405,19 @@ Item {
                   font.pixelSize: Style.font.bodySmall
                   elide: Text.ElideRight
                 }
+              }
+
+              // The chord that also reaches this row, kept on the label line —
+              // an empty chip is zero-width, so rows without one lose nothing.
+              Text {
+                id: hotkeyChip
+                text: row.hotkey
+                color: row.hasCursor ? root.selectedText : root.foreground
+                opacity: 0.4
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                anchors.right: trail.left
+                y: contentColumn.y + labelText.y + (labelText.height - height) / 2
               }
 
               Row {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1409,13 +1409,19 @@ Item {
 
               // The chord that also reaches this row, kept on the label line —
               // an empty chip is zero-width, so rows without one lose nothing.
+              // The chip annotates the label and must never crowd it out: a
+              // step under caption, and capped at a third of the row so a long
+              // chord elides before the title it belongs to does.
               Text {
                 id: hotkeyChip
                 text: row.hotkey
                 color: row.hasCursor ? root.selectedText : root.foreground
                 opacity: 0.4
                 font.family: root.fontFamily
-                font.pixelSize: Style.font.caption
+                font.pixelSize: Style.font.micro
+                width: Math.min(implicitWidth, row.width / 3)
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignRight
                 anchors.right: trail.left
                 y: contentColumn.y + labelText.y + (labelText.height - height) / 2
               }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -35,7 +35,8 @@ function normalizeItem(id, raw) {
     aliases: aliases,
     when: value.when || "",
     checked: value.checked || "",
-    disabled: value.disabled || ""
+    disabled: value.disabled || "",
+    hotkey: value.hotkey || ""
   }
 }
 
@@ -84,7 +85,7 @@ function mergeMenuSources(defaultItems, userItems) {
   }
 
   if (!nextItems.root) {
-    nextItems.root = { id: "root", parent: "", kind: "menu", icon: "", iconFont: "", label: "Go", title: "", target: "", description: "", aliases: [], when: "", checked: "", disabled: "", action: "", provider: "" }
+    nextItems.root = { id: "root", parent: "", kind: "menu", icon: "", iconFont: "", label: "Go", title: "", target: "", description: "", aliases: [], when: "", checked: "", disabled: "", hotkey: "", action: "", provider: "" }
     nextOrder.unshift("root")
   }
   for (var k3 = 0; k3 < nextOrder.length; k3++) nextItems[nextOrder[k3]].order = k3
@@ -287,6 +288,97 @@ function labelFor(entry, checkedResults, disabledResults) {
   return marked ? entry.label + " ✓" : entry.label
 }
 
+// ------------------------------------------------------------------ hotkeys
+//
+// A row a keybinding also reaches carries that chord as a chip, derived from
+// the live binds (via `omarchy-menu-hotkeys`) rather than declared twice — a
+// rebind in the hypr config moves the chip with it. An explicit `hotkey:` in
+// JSONC wins over anything derived, so an extension can label a row whose
+// action spells the same launch differently.
+
+// The same launch arrives in three spellings: the bind's command
+// (`omarchy-launch-webapp 'https://x.com/'`), a desktop entry's Exec
+// (`omarchy-launch-webapp https://x.com/ %U`), and a JSONC action. Collapse
+// quoting, Exec field codes, and launcher prefixes so equal launches compare
+// equal, and reduce webapp launches to their URL: the focus-variant bind
+// (`omarchy-launch-or-focus-webapp 'HEY' <url>`) opens the same page the
+// webapp's desktop entry does.
+function commandKey(value) {
+  var cmd = String(value || "")
+    .replace(/["']/g, "")
+    .replace(/\s+%[a-zA-Z]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^setsid /, "")
+    .replace(/^uwsm-app -- /, "")
+  var webapp = cmd.match(/^omarchy-launch(?:-or-focus)?-webapp\b.*?(https?:\/\/\S+)/)
+  if (webapp) return "webapp:" + webapp[1].replace(/\/+$/, "")
+  return cmd
+}
+
+// `omarchy-menu-hotkeys` reports one chord per line, tab-separated:
+// `cmd\t<command>\t<chord>` for what the chord runs verbatim, and
+// `app\t<desktop id>\t<chord>` where a launcher indirection resolves to an
+// installed app — the default terminal's SUPER + RETURN lands on that
+// terminal's row in Apps.
+function parseHotkeyLines(raw) {
+  var rows = []
+  var lines = String(raw || "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var parts = lines[i].split("\t")
+    if (parts.length < 3) continue
+    var kind = parts[0]
+    var match = parts[1]
+    var chord = parts[2].trim()
+    if ((kind !== "cmd" && kind !== "app") || !match || !chord) continue
+    rows.push({ kind: kind, match: match, chord: chord })
+  }
+  return rows
+}
+
+// id → chord for every row a chord reaches. The first chord claiming a
+// command wins, matching how the keybindings menu leads a merged row with
+// the chord declared first. A bind that opens the menu itself
+// (`omarchy-menu toggle capture`) lands on the submenu its route resolves
+// to, so section rows advertise their direct chord too.
+function hotkeyIndex(items, itemOrder, hotkeyRows) {
+  var byCommand = ({})
+  var byApp = ({})
+  var byRoute = ({})
+  var rows = Array.isArray(hotkeyRows) ? hotkeyRows : []
+
+  for (var i = 0; i < rows.length; i++) {
+    var row = rows[i]
+    if (row.kind === "app") {
+      if (!byApp[row.match]) byApp[row.match] = row.chord
+      continue
+    }
+    var key = commandKey(row.match)
+    if (key && !byCommand[key]) byCommand[key] = row.chord
+    var route = String(row.match).trim().match(/^omarchy-menu\s+(?:toggle|summon)\s+([A-Za-z0-9._-]+)$/)
+    if (route) {
+      var routeId = resolveRoute(items, itemOrder, route[1])
+      if (routeId !== "root" && item(items, routeId) && !byRoute[routeId]) byRoute[routeId] = row.chord
+    }
+  }
+
+  var byId = ({})
+  var order = Array.isArray(itemOrder) ? itemOrder : []
+  for (var j = 0; j < order.length; j++) {
+    var entry = item(items, order[j])
+    if (!entry || entry.id === "root") continue
+    var chord = ""
+    if (entry.hotkey) chord = entry.hotkey
+    else if (byRoute[entry.id]) chord = byRoute[entry.id]
+    else if (entry.kind === "app" && byApp[entry.appId]) chord = byApp[entry.appId]
+    else if (entry.kind === "app" && entry.exec) chord = byCommand[commandKey(entry.exec)] || ""
+    else if (entry.action) chord = byCommand[commandKey(entry.action)] || ""
+    if (chord) byId[entry.id] = chord
+  }
+
+  return byId
+}
+
 function searchableToken(value) {
   return String(value || "").replace(/[._-]+/g, " ")
 }
@@ -362,7 +454,7 @@ function searchScore(items, entry, query) {
   return score * 1000 + depthFor(items, entry.id) * 25 + entry.order
 }
 
-function displayRow(items, itemOrder, checkedResults, disabledResults, entry, detail, score, section) {
+function displayRow(items, itemOrder, checkedResults, disabledResults, hotkeys, entry, detail, score, section) {
   var target = entry.kind === "link" ? entry.target : entry.id
   return {
     itemId: entry.id,
@@ -374,6 +466,7 @@ function displayRow(items, itemOrder, checkedResults, disabledResults, entry, de
     appId: entry.appId || "",
     label: labelFor(entry, checkedResults, disabledResults),
     target: target,
+    hotkey: (hotkeys && hotkeys[entry.id]) || "",
     detail: detail || "",
     path: pathFor(items, entry.id),
     childCount: (entry.kind === "menu" || entry.kind === "link") ? childCount(items, itemOrder, target) : 0,
@@ -512,6 +605,9 @@ if (typeof module !== "undefined") {
     isVisible: isVisible,
     isDisabled: isDisabled,
     labelFor: labelFor,
+    commandKey: commandKey,
+    parseHotkeyLines: parseHotkeyLines,
+    hotkeyIndex: hotkeyIndex,
     searchableToken: searchableToken,
     leafIdFor: leafIdFor,
     nameSearchText: nameSearchText,

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -398,7 +398,7 @@ function hotkeyIndex(items, itemOrder, hotkeyRows) {
     }
     var key = commandKey(row.match)
     if (key && !byCommand[key]) byCommand[key] = row.chord
-    var route = String(row.match).trim().match(/^omarchy-menu\s+(?:toggle|summon)\s+([A-Za-z0-9._-]+)$/)
+    var route = key.match(/^omarchy-menu\s+(?:toggle|summon)\s+([A-Za-z0-9._-]+)$/)
     if (route) {
       var routeId = resolveRoute(items, itemOrder, route[1])
       if (routeId !== "root" && item(items, routeId) && !byRoute[routeId]) byRoute[routeId] = row.chord

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -316,6 +316,49 @@ function commandKey(value) {
   return cmd
 }
 
+// A chip annotates a label; it must not out-shout it. On a 300px card a
+// spelled-out "SUPER SHIFT CTRL + SPACE" is wider than the title it sits
+// beside, so the chip renders a compact spelling: modifiers to three letters,
+// the long X11 key names to what the key does, joined by a bare `+`. The
+// keybindings menu keeps the spelled-out form — it has the width for it.
+var CHORD_SHORT = {
+  SUPER: "SUP", META: "SUP", SHIFT: "SFT", CTRL: "CTL", ALT: "ALT",
+  RETURN: "RET", ESCAPE: "ESC", SPACE: "SPC", BACKSPACE: "BKSP",
+  DELETE: "DEL", INSERT: "INS", PRINT: "PRT", TAB: "TAB",
+  PAGEUP: "PGUP", PAGEDOWN: "PGDN",
+  BRACKETLEFT: "[", BRACKETRIGHT: "]", COMMA: ",", PERIOD: ".", SLASH: "/",
+  MINUS: "-", EQUAL: "=", SEMICOLON: ";", APOSTROPHE: "'", GRAVE: "`",
+  XF86AUDIORAISEVOLUME: "VOLUP", XF86AUDIOLOWERVOLUME: "VOLDN",
+  XF86AUDIOMUTE: "MUTE", XF86AUDIOMICMUTE: "MICMUTE",
+  XF86AUDIONEXT: "NEXT", XF86AUDIOPREV: "PREV",
+  XF86AUDIOPLAY: "PLAY", XF86AUDIOPAUSE: "PAUSE",
+  XF86MONBRIGHTNESSUP: "BRIUP", XF86MONBRIGHTNESSDOWN: "BRIDN",
+  XF86KBDBRIGHTNESSUP: "KBDUP", XF86KBDBRIGHTNESSDOWN: "KBDDN",
+  XF86KBDLIGHTONOFF: "KBDLT",
+  XF86TOUCHPADTOGGLE: "TPAD", XF86TOUCHPADON: "TPADON", XF86TOUCHPADOFF: "TPADOFF",
+  XF86POWEROFF: "PWR", XF86EJECT: "EJECT"
+}
+
+function compactChordToken(token) {
+  var upper = String(token || "").trim().toUpperCase()
+  if (!upper) return ""
+  if (CHORD_SHORT[upper]) return CHORD_SHORT[upper]
+  // A media key we have no short name for still drops the vendor prefix,
+  // so an unknown XF86 bind reads as the key rather than as the vendor.
+  if (upper.indexOf("XF86") === 0 && upper.length > 4) return upper.slice(4)
+  return upper
+}
+
+function compactChord(chord) {
+  var tokens = String(chord || "").replace(/\+/g, " ").split(/\s+/)
+  var out = []
+  for (var i = 0; i < tokens.length; i++) {
+    var token = compactChordToken(tokens[i])
+    if (token) out.push(token)
+  }
+  return out.join("+")
+}
+
 // `omarchy-menu-hotkeys` reports one chord per line, tab-separated:
 // `cmd\t<command>\t<chord>` for what the chord runs verbatim, and
 // `app\t<desktop id>\t<chord>` where a launcher indirection resolves to an
@@ -373,7 +416,7 @@ function hotkeyIndex(items, itemOrder, hotkeyRows) {
     else if (entry.kind === "app" && byApp[entry.appId]) chord = byApp[entry.appId]
     else if (entry.kind === "app" && entry.exec) chord = byCommand[commandKey(entry.exec)] || ""
     else if (entry.action) chord = byCommand[commandKey(entry.action)] || ""
-    if (chord) byId[entry.id] = chord
+    if (chord) byId[entry.id] = compactChord(chord)
   }
 
   return byId
@@ -606,6 +649,7 @@ if (typeof module !== "undefined") {
     isDisabled: isDisabled,
     labelFor: labelFor,
     commandKey: commandKey,
+    compactChord: compactChord,
     parseHotkeyLines: parseHotkeyLines,
     hotkeyIndex: hotkeyIndex,
     searchableToken: searchableToken,

--- a/test/shell.d/menu-hotkeys-test.sh
+++ b/test/shell.d/menu-hotkeys-test.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# ---------------------------------------------------------------------------
+# omarchy-menu-hotkeys turns the keybindings records into chip rows, with the
+# records and the default-app resolvers stubbed so the test owns both sides.
+
+stub_dir=$(mktemp -d)
+trap 'rm -rf "$stub_dir"' EXIT
+
+cat >"$stub_dir/omarchy-menu-keybindings" <<'STUB'
+#!/bin/bash
+if [[ $1 == "--records" ]]; then
+  printf 'SUPER + K                           → Keybindings\texec\tomarchy-menu-keybindings\n'
+  printf 'SUPER + RETURN                      → Terminal\texec\tomarchy-launch-terminal\n'
+  printf 'SUPER ALT + RETURN                  → Tmux\texec\tomarchy-launch-terminal-tmux\n'
+  printf 'SUPER + ESCAPE                      → System menu\texec\tomarchy-menu toggle system\n'
+  printf 'SUPER + W / SUPER + Q               → Close window\texec\tomarchy-close-window\n'
+  printf 'ALT + TAB                           → Reveal active window\tlua\thl.dsp.cyclenext()\n'
+  printf 'SHIFT ALT + L                       → Copy URL\tsendshortcut\tSHIFT ALT,L,\n'
+fi
+STUB
+
+cat >"$stub_dir/xdg-terminal-exec" <<'STUB'
+#!/bin/bash
+[[ ${1:-} == "--print-id" ]] && echo "Alacritty.desktop:/usr/share/xdg-terminals/Alacritty.desktop"
+STUB
+
+cat >"$stub_dir/xdg-settings" <<'STUB'
+#!/bin/bash
+echo "chromium.desktop"
+STUB
+
+chmod +x "$stub_dir/omarchy-menu-keybindings" "$stub_dir/xdg-terminal-exec" "$stub_dir/xdg-settings"
+
+output=$(PATH="$stub_dir:$PATH" "$ROOT/bin/omarchy-menu-hotkeys")
+
+assert_row() {
+  local row="$1" description="$2"
+
+  if grep -qxF "$row" <<<"$output"; then
+    pass "$description"
+  else
+    fail "$description" "$output"
+  fi
+}
+
+assert_row $'cmd\tomarchy-launch-terminal\tSUPER + RETURN' 'hotkeys report what each exec chord runs'
+assert_row $'cmd\tomarchy-menu toggle system\tSUPER + ESCAPE' 'hotkeys report chords that open menu routes'
+assert_row $'cmd\tomarchy-close-window\tSUPER + W' 'hotkeys keep only the chord that leads a merged row'
+assert_row $'app\tAlacritty\tSUPER + RETURN' 'hotkeys resolve the terminal indirection to the default terminal app'
+
+if grep -q $'^app\tchromium\t' <<<"$output"; then
+  fail 'hotkeys skip the browser app row when no bind runs omarchy-launch-browser' "$output"
+else
+  pass 'hotkeys skip the browser app row when no bind runs omarchy-launch-browser'
+fi
+
+if grep -qE 'cyclenext|Copy URL' <<<"$output"; then
+  fail 'hotkeys skip non-exec dispatchers' "$output"
+else
+  pass 'hotkeys skip non-exec dispatchers'
+fi
+
+if grep -qx $'app\tAlacritty\tSUPER ALT + RETURN' <<<"$output"; then
+  fail 'hotkeys do not let a longer launcher command claim the terminal chord' "$output"
+else
+  pass 'hotkeys do not let a longer launcher command claim the terminal chord'
+fi
+
+# ---------------------------------------------------------------------------
+# MenuModel matches the reported chords onto menu rows.
+
+run_node_test <<'JS'
+const fs = require('fs')
+const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+
+assertEqual(
+  menu.commandKey("  uwsm-app  --  obsidian %U "),
+  'obsidian',
+  'command keys shed launcher prefixes and Exec field codes'
+)
+assertEqual(
+  menu.commandKey("omarchy-launch-webapp 'https://youtube.com/'"),
+  menu.commandKey('omarchy-launch-webapp https://youtube.com'),
+  'command keys compare webapp launches by URL regardless of quoting and trailing slash'
+)
+assertEqual(
+  menu.commandKey("omarchy-launch-or-focus-webapp 'Google Messages' 'https://messages.google.com/web/conversations'"),
+  menu.commandKey('omarchy-launch-webapp https://messages.google.com/web/conversations'),
+  'command keys let the focus variant match the webapp desktop entry'
+)
+
+const rows = menu.parseHotkeyLines([
+  'cmd\tomarchy-menu-keybindings\tSUPER + K',
+  'cmd\tomarchy-menu toggle capture\tSUPER CTRL + C',
+  'cmd\tomarchy-menu toggle system\tSUPER + ESCAPE',
+  'cmd\tomarchy-menu toggle system\tXF86PowerOff',
+  "cmd\tomarchy-launch-webapp 'https://youtube.com/'\tSUPER SHIFT + Y",
+  'app\tAlacritty\tSUPER + RETURN',
+  'garbage line',
+  'cmd\tmissing-chord\t',
+].join('\n'))
+
+assertEqual(rows.length, 6, 'hotkey lines parse rows and drop malformed ones')
+
+const sources = menu.mergeMenuSources(menu.parseMenuJsonc(`
+{
+  "learn": {"label":"Learn"},
+  "learn.keybindings": {"label":"Keybindings","action":"omarchy-menu-keybindings"},
+  "system": {"label":"System"},
+  "system.lock": {"label":"Lock","action":"omarchy-system-lock","hotkey":"SUPER + L"},
+  "trigger": {"label":"Trigger"},
+  "trigger.capture": {"label":"Capture","aliases":["capture"]},
+  "trigger.capture.screenshot": {"label":"Screenshot","action":"omarchy-capture-screenshot"},
+}
+`), [])
+
+const withApps = menu.mergeAppRows(sources.items, sources.itemOrder, [
+  { id: 'apps.Alacritty', parent: 'apps', kind: 'app', appId: 'Alacritty', label: 'Alacritty', exec: 'alacritty', aliases: [] },
+  { id: 'apps.YouTube', parent: 'apps', kind: 'app', appId: 'YouTube', label: 'YouTube', exec: 'omarchy-launch-webapp https://youtube.com/', aliases: [] },
+])
+
+const hotkeys = menu.hotkeyIndex(withApps.items, withApps.itemOrder, rows)
+
+assertEqual(hotkeys['learn.keybindings'], 'SUPER + K', 'hotkey index matches a row by its action')
+assertEqual(hotkeys['trigger.capture'], 'SUPER CTRL + C', 'hotkey index resolves menu routes through aliases')
+assertEqual(hotkeys['system'], 'SUPER + ESCAPE', 'hotkey index keeps the first chord that claims a route')
+assertEqual(hotkeys['system.lock'], 'SUPER + L', 'an explicit hotkey wins over anything derived')
+assertEqual(hotkeys['apps.Alacritty'], 'SUPER + RETURN', 'hotkey index matches app rows by desktop id')
+assertEqual(hotkeys['apps.YouTube'], 'SUPER SHIFT + Y', 'hotkey index matches app rows by what their desktop entry runs')
+assertEqual(hotkeys['trigger.capture.screenshot'], undefined, 'rows no chord reaches carry no chip')
+
+assertEqual(
+  menu.displayRow(withApps.items, withApps.itemOrder, {}, {}, hotkeys, withApps.items['learn.keybindings'], '', 0).hotkey,
+  'SUPER + K',
+  'display rows carry their hotkey chip'
+)
+
+assert(
+  /omarchy-menu-hotkeys/.test(menuQml),
+  'menu shell derives hotkey chips from omarchy-menu-hotkeys'
+)
+assert(
+  /required property string hotkey/.test(menuQml),
+  'menu rows render their hotkey chip'
+)
+JS

--- a/test/shell.d/menu-hotkeys-test.sh
+++ b/test/shell.d/menu-hotkeys-test.sh
@@ -108,6 +108,23 @@ const rows = menu.parseHotkeyLines([
 
 assertEqual(rows.length, 6, 'hotkey lines parse rows and drop malformed ones')
 
+assertEqual(
+  menu.compactChord('SUPER SHIFT CTRL + SPACE'),
+  'SUP+SFT+CTL+SPC',
+  'chips spell modifiers short and join them without padding'
+)
+assertEqual(
+  menu.compactChord('SHIFT + XF86MonBrightnessDown'),
+  'SFT+BRIDN',
+  'chips name what a media key does rather than its X11 spelling'
+)
+assertEqual(
+  menu.compactChord('SUPER + XF86Sleep'),
+  'SUP+SLEEP',
+  'an unnamed media key still sheds the vendor prefix'
+)
+assertEqual(menu.compactChord(''), '', 'an absent chord stays absent')
+
 const sources = menu.mergeMenuSources(menu.parseMenuJsonc(`
 {
   "learn": {"label":"Learn"},
@@ -127,17 +144,17 @@ const withApps = menu.mergeAppRows(sources.items, sources.itemOrder, [
 
 const hotkeys = menu.hotkeyIndex(withApps.items, withApps.itemOrder, rows)
 
-assertEqual(hotkeys['learn.keybindings'], 'SUPER + K', 'hotkey index matches a row by its action')
-assertEqual(hotkeys['trigger.capture'], 'SUPER CTRL + C', 'hotkey index resolves menu routes through aliases')
-assertEqual(hotkeys['system'], 'SUPER + ESCAPE', 'hotkey index keeps the first chord that claims a route')
-assertEqual(hotkeys['system.lock'], 'SUPER + L', 'an explicit hotkey wins over anything derived')
-assertEqual(hotkeys['apps.Alacritty'], 'SUPER + RETURN', 'hotkey index matches app rows by desktop id')
-assertEqual(hotkeys['apps.YouTube'], 'SUPER SHIFT + Y', 'hotkey index matches app rows by what their desktop entry runs')
+assertEqual(hotkeys['learn.keybindings'], 'SUP+K', 'hotkey index matches a row by its action')
+assertEqual(hotkeys['trigger.capture'], 'SUP+CTL+C', 'hotkey index resolves menu routes through aliases')
+assertEqual(hotkeys['system'], 'SUP+ESC', 'hotkey index keeps the first chord that claims a route')
+assertEqual(hotkeys['system.lock'], 'SUP+L', 'an explicit hotkey wins over anything derived, in the chip spelling')
+assertEqual(hotkeys['apps.Alacritty'], 'SUP+RET', 'hotkey index matches app rows by desktop id')
+assertEqual(hotkeys['apps.YouTube'], 'SUP+SFT+Y', 'hotkey index matches app rows by what their desktop entry runs')
 assertEqual(hotkeys['trigger.capture.screenshot'], undefined, 'rows no chord reaches carry no chip')
 
 assertEqual(
   menu.displayRow(withApps.items, withApps.itemOrder, {}, {}, hotkeys, withApps.items['learn.keybindings'], '', 0).hotkey,
-  'SUPER + K',
+  'SUP+K',
   'display rows carry their hotkey chip'
 )
 

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -44,7 +44,8 @@ assertDeepEqual(
     aliases: ['theme'],
     when: '',
     checked: '',
-    disabled: ''
+    disabled: '',
+    hotkey: ''
   },
   'menu normalizes parsed items'
 )
@@ -89,7 +90,7 @@ assert(menu.isDisabled({ 'install.browser.zen': true }, installed), 'menu disabl
 assert(!menu.isDisabled({ 'install.browser.zen': false }, installed), 'menu leaves a row selectable when its disabled: failed')
 assert(!menu.isDisabled({ 'install.browser.zen': true }, visibilityItems.laptop), 'menu never disables a row that declares no disabled:')
 assert(
-  menu.displayRow({ 'install.browser.zen': installed }, ['install.browser.zen'], {}, { 'install.browser.zen': true }, installed, '', 0).disabled,
+  menu.displayRow({ 'install.browser.zen': installed }, ['install.browser.zen'], {}, { 'install.browser.zen': true }, {}, installed, '', 0).disabled,
   'menu display rows carry their disabled state'
 )
 assert(
@@ -105,7 +106,7 @@ assert(!menu.matchesQuery(entry, 'theme', false), 'menu hides invisible matches'
 assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'appearance'), 'menu scores name matches above description matches')
 
 assertDeepEqual(
-  menu.displayRow(merged.items, merged.itemOrder, {}, {}, entry, 'Style', 12, 'search'),
+  menu.displayRow(merged.items, merged.itemOrder, {}, {}, {}, entry, 'Style', 12, 'search'),
   {
     itemId: 'style.theme',
     disabled: false,
@@ -116,6 +117,7 @@ assertDeepEqual(
     appId: '',
     label: 'Theme picker',
     target: 'style.theme',
+    hotkey: '',
     detail: 'Style',
     path: 'Style › Theme picker',
     childCount: 0,


### PR DESCRIPTION
Rows in the menu that a keybinding also triggers now carry that chord as a small muted chip on their right edge — Learn > Keybindings reads `SUP+K`, the System submenu `SUP+ESC`, the default terminal's row in Apps `SUP+RET`. The chip teaches the faster path to whatever the user just navigated to by hand.


<img width="1284" height="1710" alt="image" src="https://github.com/user-attachments/assets/f176c754-d9d8-46cf-9032-efaa603623e1" />
<img width="1236" height="1617" alt="image" src="https://github.com/user-attachments/assets/d92cf47a-54fb-4974-92e8-9b185ed23981" />

