### PR TITLE
Focus existing windows after no-op app launches

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -26,6 +26,7 @@ Item {
   property int launchSerial: 0
   property int launchToplevelCount: 0
   property var launchActiveToplevel: null
+  property var launchExistingToplevel: null
   // True while the launch OSD is on screen. It outlives the launch that opened
   // it: the OSD shows with duration 0, so only closeLaunchFeedback() takes it
   // down.
@@ -77,7 +78,7 @@ Item {
   function launch(desktopId, name) {
     var id = String(desktopId || "")
     if (!id) return
-    root.beginLaunchFeedback(name)
+    root.beginLaunchFeedback(id, name)
     // Start gtk-launch inside a scope under app-graphical.slice so apps do not
     // inherit wayland-wm@.service. Keeping gtk-launch as the desktop-entry
     // resolver supports IDs with spaces and entries that UWSM rejects.
@@ -157,10 +158,23 @@ Item {
     try { return ToplevelManager.toplevels.values.length } catch (e) { return 0 }
   }
 
-  function beginLaunchFeedback(name) {
+  function existingToplevelFor(desktopId) {
+    var entry = DesktopEntries.byId(desktopId)
+    var startupClass = String((entry && entry.startupClass) || "")
+    var toplevels = ToplevelManager.toplevels.values || []
+
+    for (var i = 0; i < toplevels.length; i++) {
+      if (AppSearch.appIdsMatch(desktopId, startupClass, toplevels[i] && toplevels[i].appId)) return toplevels[i]
+    }
+
+    return null
+  }
+
+  function beginLaunchFeedback(desktopId, name) {
     root.launchSerial++
     root.launchToplevelCount = root.toplevelCount()
     root.launchActiveToplevel = ToplevelManager.activeToplevel
+    root.launchExistingToplevel = root.existingToplevelFor(desktopId)
     root.launchOsdMessage = "Launching " + String(name || "application") + "…"
     launchDelay.restart()
     launchTimeout.restart()
@@ -241,6 +255,14 @@ Item {
     interval: 2000
     onTriggered: {
       if (root.toplevelCount() > root.launchToplevelCount || ToplevelManager.activeToplevel !== root.launchActiveToplevel) return
+      // A single-instance app may accept the second launch without mapping or
+      // activating a window. Focus the window that existed before the launch
+      // instead of showing launch feedback until the timeout.
+      if (root.launchExistingToplevel) {
+        root.launchExistingToplevel.activate()
+        root.closeLaunchFeedback(root.launchSerial)
+        return
+      }
       root.launchOsdOpen = true
       Quickshell.execDetached(["omarchy-shell", "osd", "show", JSON.stringify({ icon: "󱓞", message: root.launchOsdMessage, duration: 0 })])
     }

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -162,6 +162,9 @@ Item {
     var entry = DesktopEntries.byId(desktopId)
     var startupClass = String((entry && entry.startupClass) || "")
     var toplevels = ToplevelManager.toplevels.values || []
+    var active = ToplevelManager.activeToplevel
+
+    if (active && AppSearch.appIdsMatch(desktopId, startupClass, active.appId)) return active
 
     for (var i = 0; i < toplevels.length; i++) {
       if (AppSearch.appIdsMatch(desktopId, startupClass, toplevels[i] && toplevels[i].appId)) return toplevels[i]
@@ -176,12 +179,15 @@ Item {
     root.launchActiveToplevel = ToplevelManager.activeToplevel
     root.launchExistingToplevel = root.existingToplevelFor(desktopId)
     root.launchOsdMessage = "Launching " + String(name || "application") + "…"
+    if (root.launchExistingToplevel) existingFocusDelay.restart()
+    else existingFocusDelay.stop()
     launchDelay.restart()
     launchTimeout.restart()
   }
 
   function closeLaunchFeedback(serial) {
     if (serial !== root.launchSerial) return
+    existingFocusDelay.stop()
     launchDelay.stop()
     launchTimeout.stop()
     if (root.launchOsdOpen) {
@@ -191,7 +197,7 @@ Item {
   }
 
   function maybeFinishLaunchFeedback() {
-    if (!launchDelay.running && !launchTimeout.running && !root.launchOsdOpen) return
+    if (!existingFocusDelay.running && !launchDelay.running && !launchTimeout.running && !root.launchOsdOpen) return
     if (root.toplevelCount() <= root.launchToplevelCount && ToplevelManager.activeToplevel === root.launchActiveToplevel) return
     root.closeLaunchFeedback(root.launchSerial)
   }
@@ -251,18 +257,22 @@ Item {
   }
 
   Timer {
+    id: existingFocusDelay
+    interval: 150
+    onTriggered: {
+      if (root.toplevelCount() > root.launchToplevelCount || ToplevelManager.activeToplevel !== root.launchActiveToplevel) return
+      // Give the app a brief chance to activate itself or map a new window.
+      // If its relaunch is a no-op, focus the window that was already open.
+      root.launchExistingToplevel.activate()
+      root.closeLaunchFeedback(root.launchSerial)
+    }
+  }
+
+  Timer {
     id: launchDelay
     interval: 2000
     onTriggered: {
       if (root.toplevelCount() > root.launchToplevelCount || ToplevelManager.activeToplevel !== root.launchActiveToplevel) return
-      // A single-instance app may accept the second launch without mapping or
-      // activating a window. Focus the window that existed before the launch
-      // instead of showing launch feedback until the timeout.
-      if (root.launchExistingToplevel) {
-        root.launchExistingToplevel.activate()
-        root.closeLaunchFeedback(root.launchSerial)
-        return
-      }
       root.launchOsdOpen = true
       Quickshell.execDetached(["omarchy-shell", "osd", "show", JSON.stringify({ icon: "󱓞", message: root.launchOsdMessage, duration: 0 })])
     }

--- a/shell/services/AppSearch.js
+++ b/shell/services/AppSearch.js
@@ -7,7 +7,7 @@ function entrySubtext(entry) {
 }
 
 function normalizedAppId(id) {
-  return String(id || "").toLowerCase().replace(/\.desktop$/, "")
+  return String(id || "").toLowerCase()
 }
 
 function appIdsMatch(desktopId, startupClass, appId) {

--- a/shell/services/AppSearch.js
+++ b/shell/services/AppSearch.js
@@ -6,6 +6,17 @@ function entrySubtext(entry) {
   return String((entry && entry.genericName) || "")
 }
 
+function normalizedAppId(id) {
+  return String(id || "").toLowerCase().replace(/\.desktop$/, "")
+}
+
+function appIdsMatch(desktopId, startupClass, appId) {
+  var id = normalizedAppId(desktopId)
+  var startup = normalizedAppId(startupClass)
+  var candidate = normalizedAppId(appId)
+  return candidate === id || (startup.length > 0 && candidate === startup)
+}
+
 function entrySortKey(entry) {
   return entryName(entry).toLowerCase()
 }
@@ -125,6 +136,8 @@ if (typeof module !== "undefined") {
   module.exports = {
     entryName: entryName,
     entrySubtext: entrySubtext,
+    normalizedAppId: normalizedAppId,
+    appIdsMatch: appIdsMatch,
     entrySortKey: entrySortKey,
     entrySearchText: entrySearchText,
     entryAcronym: entryAcronym,

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -74,6 +74,7 @@ assert(search.appIdsMatch('org.telegram.desktop', 'TelegramDesktop', 'org.telegr
 assert(search.appIdsMatch('signal', 'Signal', 'signal'), 'launcher matches window app ids case-insensitively')
 assert(search.appIdsMatch('example', 'ExampleWindow', 'ExampleWindow'), 'launcher falls back to StartupWMClass')
 assert(!search.appIdsMatch('foot', '', 'footclient'), 'launcher does not use partial app-id matches')
+assert(!search.appIdsMatch('foo', '', 'foo.desktop'), 'launcher keeps distinct desktop ids distinct')
 
 // The menu's Apps submenu is the launcher now: app rows launch and uninstall
 // through the shared app library instead of running commands themselves.
@@ -152,8 +153,13 @@ assert(
 )
 
 assert(
-  /if \(root\.launchExistingToplevel\) \{[\s\S]*?root\.launchExistingToplevel\.activate\(\)[\s\S]*?root\.closeLaunchFeedback/.test(appLibraryQml),
-  'launch feedback focuses an existing app window when a second launch has no visible effect'
+  /var active = ToplevelManager\.activeToplevel[\s\S]*?if \(active && AppSearch\.appIdsMatch\([\s\S]*?return active/.test(appLibraryQml),
+  'app library prefers an active matching window when an app has several windows'
+)
+
+assert(
+  /id: existingFocusDelay[\s\S]*?interval: 150[\s\S]*?root\.launchExistingToplevel\.activate\(\)[\s\S]*?root\.closeLaunchFeedback/.test(appLibraryQml),
+  'launch feedback quickly focuses an existing app window when a second launch has no visible effect'
 )
 
 const openMatch = menuQml.match(/function openExistingMenu\(initialMenu\) \{([\s\S]*?)\n  \}/)

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -69,6 +69,12 @@ assertEqual(acronymMatches[0], 'Google Contacts', 'short acronym matching still 
 const directMatches = search.sortedEntries(entries, 'obs').map(row => search.entryName(row.entry))
 assertEqual(directMatches[0], 'OBS Studio', 'direct app-name matching still works')
 
+assert(search.appIdsMatch('aether', '', 'aether'), 'launcher matches Aether by desktop id')
+assert(search.appIdsMatch('org.telegram.desktop', 'TelegramDesktop', 'org.telegram.desktop'), 'launcher preserves a meaningful desktop suffix when matching Telegram')
+assert(search.appIdsMatch('signal', 'Signal', 'signal'), 'launcher matches window app ids case-insensitively')
+assert(search.appIdsMatch('example', 'ExampleWindow', 'ExampleWindow'), 'launcher falls back to StartupWMClass')
+assert(!search.appIdsMatch('foot', '', 'footclient'), 'launcher does not use partial app-id matches')
+
 // The menu's Apps submenu is the launcher now: app rows launch and uninstall
 // through the shared app library instead of running commands themselves.
 const activateMatch = menuQml.match(/function activateIndex\(index, fromPointer\) \{([\s\S]*?)\n  \}/)
@@ -133,11 +139,21 @@ assert(
   'app library prefers indexed app icons over ambiguous themed icons'
 )
 
-const beginLaunchMatch = appLibraryQml.match(/function beginLaunchFeedback\(name\) \{([\s\S]*?)\n  \}/)
+const beginLaunchMatch = appLibraryQml.match(/function beginLaunchFeedback\(desktopId, name\) \{([\s\S]*?)\n  \}/)
 assert(beginLaunchMatch, 'app library beginLaunchFeedback function exists')
 assert(
   !beginLaunchMatch[1].includes('root.launchOsdOpen = false'),
   'app library keeps owning an OSD a previous launch left on screen'
+)
+
+assert(
+  appLibraryQml.includes('root.launchExistingToplevel = root.existingToplevelFor(desktopId)'),
+  'app library remembers an existing window before launching an app'
+)
+
+assert(
+  /if \(root\.launchExistingToplevel\) \{[\s\S]*?root\.launchExistingToplevel\.activate\(\)[\s\S]*?root\.closeLaunchFeedback/.test(appLibraryQml),
+  'launch feedback focuses an existing app window when a second launch has no visible effect'
 )
 
 const openMatch = menuQml.match(/function openExistingMenu\(initialMenu\) \{([\s\S]*?)\n  \}/)


### PR DESCRIPTION
## Why

Relaunching an already-running single-instance app such as Telegram or Aether can succeed without creating a new window or activating the existing one. Omarchy currently interprets the lack of window activity as an app still starting, so it displays a misleading `Launching…` OSD until the timeout.

### Before 
https://github.com/user-attachments/assets/f254bd67-baa4-474b-802f-c7c1af556948

### After 
https://github.com/user-attachments/assets/b689776f-677c-455f-809e-b6fa94beabfb

## Summary

- remember a matching top-level window before launching a desktop entry
- if the launch produces no new window or activation within the existing two-second feedback delay, activate that window instead of showing a misleading `Launching…` OSD
- match exact desktop IDs case-insensitively, with `StartupWMClass` as a fallback

This preserves normal multi-window behavior because Omarchy still launches the desktop entry first. The focus fallback only runs when that launch has no visible effect, as happens when relaunching single-instance apps such as Telegram and Aether.

## Testing

- `bash test/shell.d/app-search-test.sh`
- `qmllint -I shell shell/services/AppLibrary.qml`
- `git diff --check`
- `./test/all` (unrelated environment failures: three packaging-coverage tests require an `omarchy-pkgs` checkout; `launch-about-test.sh` reports its existing `a roomy window animates` failure on this machine)