### PR TITLE
Keep the Bluetooth pairing agent from skipping late USB adapters

### DIFF
--- a/bin/omarchy-bluetooth-agent-start
+++ b/bin/omarchy-bluetooth-agent-start
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# omarchy:summary=Start the BlueZ pairing agent once the adapter exists
+# omarchy:group=bluetooth
+# omarchy:hidden=true
+
+# bt-agent must be the session's default pairing agent or bluetoothctl pair
+# (used by the Omarchy Bluetooth panel) fails with "No agent available".
+# The user unit used to skip forever when /sys/class/bluetooth was missing at
+# graphical-session start. USB adapters (Broadcom on Intel MacBooks, dongles)
+# often appear a few seconds later, so wait for them, then exec bt-agent.
+# If nothing shows up, exit 0 so systemd does not restart-loop on machines
+# without Bluetooth.
+
+set -euo pipefail
+
+wait_seconds=${OMARCHY_BT_AGENT_WAIT_SECONDS:-60}
+sysfs=${OMARCHY_BT_SYSFS:-/sys/class/bluetooth}
+agent=${OMARCHY_BT_AGENT:-/usr/bin/bt-agent}
+
+deadline=$((SECONDS + wait_seconds))
+while (( SECONDS <= deadline )); do
+  if [[ -d $sysfs ]] && systemctl is-active --quiet bluetooth.service; then
+    exec "$agent" -c NoInputNoOutput
+  fi
+  if (( wait_seconds == 0 )); then
+    break
+  fi
+  sleep 1
+done
+
+echo "No Bluetooth adapter after ${wait_seconds}s; pairing agent not started" >&2
+exit 0

--- a/default/systemd/user/bt-agent.service
+++ b/default/systemd/user/bt-agent.service
@@ -1,21 +1,21 @@
 [Unit]
 Description=Bluetooth pairing agent (auto-accept)
 Documentation=man:bt-agent(1)
-ConditionPathIsDirectory=/sys/class/bluetooth
-# bluez must be reachable on the system bus before we can register.
+# Do not ConditionPathIsDirectory=/sys/class/bluetooth. That directory is
+# missing at graphical-session start on USB adapters (Broadcom on Intel
+# MacBooks, dongles). A failed Condition skips the unit forever; Restart=
+# does not apply. The ExecStart wrapper waits, then gives up with exit 0
+# on machines that never grow an adapter.
 After=dbus.socket
 Requires=dbus.socket
 
 [Service]
 Type=simple
-# If bluetoothd is unavailable (for example in VMs or machines without a
-# usable adapter), skip cleanly instead of entering a restart loop.
-ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service
 # NoInputNoOutput auto-accepts pair requests. Safe because the adapter
 # is only `pairable: true` when the user explicitly opens the omarchy
 # bluetoothPanel and starts scanning; outside that window bluez refuses
 # inbound pair attempts at a lower layer.
-ExecStart=/usr/bin/bt-agent -c NoInputNoOutput
+ExecStart=/usr/bin/omarchy-bluetooth-agent-start
 Restart=on-failure
 RestartSec=2
 

--- a/migrations/1787815267.sh
+++ b/migrations/1787815267.sh
@@ -1,0 +1,12 @@
+echo "Restart the Bluetooth pairing agent so it waits for late USB adapters"
+
+# The packaged unit used to skip forever when /sys/class/bluetooth was missing
+# at graphical-session start (Broadcom on Intel MacBooks, USB dongles). Reload
+# so the user manager picks up the wait-then-exec wrapper, then bounce a live
+# or skipped agent. Login starts it for everyone else.
+systemctl --user daemon-reload
+
+if systemctl --user is-enabled --quiet bt-agent.service 2>/dev/null; then
+  systemctl --user reset-failed bt-agent.service 2>/dev/null || true
+  systemctl --user restart bt-agent.service || true
+fi

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -4,9 +4,13 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
-grep -q '^ConditionPathIsDirectory=/sys/class/bluetooth$' "$ROOT/default/systemd/user/bt-agent.service" || \
-  fail "bt-agent is skipped on machines without Bluetooth hardware"
-pass "bt-agent is skipped on machines without Bluetooth hardware"
+# USB/Broadcom adapters often appear after graphical-session starts. A
+# ConditionPathIsDirectory skip is permanent (Restart= does not apply).
+grep -q '^ConditionPathIsDirectory=/sys/class/bluetooth$' "$ROOT/default/systemd/user/bt-agent.service" && \
+  fail "bt-agent must not skip forever when /sys/class/bluetooth is missing at login"
+grep -Fx 'ExecStart=/usr/bin/omarchy-bluetooth-agent-start' "$ROOT/default/systemd/user/bt-agent.service" >/dev/null || \
+  fail "bt-agent waits for a late adapter instead of starting bt-agent immediately"
+pass "bt-agent waits for a late adapter instead of skipping at login"
 
 run_node_test <<'JS'
 const fs = require('fs')
@@ -280,3 +284,43 @@ pass "bluetooth counts a secondary controller as on"
 grep -q 'AutoEnable=false' "$ROOT/install/hardware/bluetooth.sh" &&
   fail "bluetooth install leaves AutoEnable at its default"
 pass "bluetooth install leaves AutoEnable at its default"
+
+agent_mock="$device_tmp/agent"
+mkdir -p "$agent_mock/sys" "$agent_mock/bin"
+cat >"$agent_mock/bin/systemctl" <<'SH'
+#!/bin/bash
+[[ $1 == is-active && $3 == bluetooth.service ]] && exit 0
+exit 1
+SH
+cat >"$agent_mock/bin/bt-agent" <<'SH'
+#!/bin/bash
+printf 'bt-agent %s\n' "$*" >"$AGENT_RAN"
+exit 0
+SH
+chmod +x "$agent_mock/bin/systemctl" "$agent_mock/bin/bt-agent"
+
+# No adapter: give up with success so systemd does not restart-loop.
+: >"$device_tmp/agent-ran"
+if ! PATH="$agent_mock/bin:$PATH" \
+  OMARCHY_BT_AGENT_WAIT_SECONDS=0 \
+  OMARCHY_BT_SYSFS="$agent_mock/missing" \
+  OMARCHY_BT_AGENT="$agent_mock/bin/bt-agent" \
+  AGENT_RAN="$device_tmp/agent-ran" \
+  "$ROOT/bin/omarchy-bluetooth-agent-start"; then
+  fail "pairing agent start exits 0 when no adapter appears"
+fi
+[[ ! -s $device_tmp/agent-ran ]] || fail "pairing agent is not started without an adapter"
+pass "pairing agent start exits 0 when no adapter appears"
+
+# Adapter already present: exec bt-agent immediately.
+: >"$device_tmp/agent-ran"
+PATH="$agent_mock/bin:$PATH" \
+  OMARCHY_BT_AGENT_WAIT_SECONDS=0 \
+  OMARCHY_BT_SYSFS="$agent_mock/sys" \
+  OMARCHY_BT_AGENT="$agent_mock/bin/bt-agent" \
+  AGENT_RAN="$device_tmp/agent-ran" \
+  "$ROOT/bin/omarchy-bluetooth-agent-start" ||
+  fail "pairing agent start runs bt-agent when the adapter is already up"
+grep -qx "bt-agent -c NoInputNoOutput" "$device_tmp/agent-ran" ||
+  fail "pairing agent start execs NoInputNoOutput bt-agent" "$(cat "$device_tmp/agent-ran")"
+pass "pairing agent start execs bt-agent once the adapter exists"

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -6,8 +6,13 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 service="$ROOT/default/systemd/user/bt-agent.service"
 
-grep -Fx 'ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service' "$service" >/dev/null
-pass "bt-agent skips when bluetooth.service is inactive"
+grep -Fx 'ExecStart=/usr/bin/omarchy-bluetooth-agent-start' "$service" >/dev/null ||
+  fail "bt-agent still launches bt-agent immediately, which races USB adapters"
+pass "bt-agent waits for bluetoothd and sysfs before registering"
+
+grep -q '^ExecCondition=' "$service" &&
+  fail "ExecCondition skips the unit with no Restart= when bluetoothd is not up yet"
+pass "bt-agent does not skip permanently when bluetoothd is still starting"
 
 grep -Fx 'Restart=on-failure' "$service" >/dev/null
 pass "bt-agent still restarts after runtime failures"


### PR DESCRIPTION
## What

The session `bt-agent` no longer skips forever when `/sys/class/bluetooth` is missing at login. It waits for bluetoothd and the adapter sysfs node, then registers as the default pairing agent. If nothing appears, it exits 0 so machines without Bluetooth do not restart-loop.

## Why

Omarchy's Bluetooth panel pairs with `bluetoothctl pair`. That needs a registered BlueZ agent. The user unit used `ConditionPathIsDirectory=/sys/class/bluetooth` plus `ExecCondition=` on `bluetooth.service`. A failed Condition/ExecCondition **skips** the unit; `Restart=` does not apply.

On a MacBookPro12,1 (Broadcom USB adapter) that looks like:

```
bt-agent.service: skipped, unmet condition check ConditionPathIsDirectory=/sys/class/bluetooth
```

Then pairing from Super+Ctrl+B logs:

```
src/device.c:new_auth() No agent available for request type 2
device_confirm_passkey: Operation not permitted
```

Reproduced pairing Logitech MX Anywhere 3S and Pebble Keys 2 K380s. They advertised fine; the GUI could not confirm the passkey because no agent was running. `bluetoothctl --agent NoInputNoOutput pair …` succeeded immediately.

## Related

This is separate from the trusted-but-unpaired state machine (#7879 / #7880) and from showing keyboard passkeys (#8485 / #6877). Those still matter. Even with them, this skip leaves the panel with no agent on late USB adapters.

#6877 keeps `ConditionPathIsDirectory=/sys/class/bluetooth`, so it would still skip on this hardware.

## Test

- `bash test/shell.d/bluetooth-test.sh`
- `bash test/shell.d/systemd-test.sh`
- `./test/cli`

`./test/all`: bluetooth/systemd tests pass. Remaining failures (`config`, `launch-about`, `snapper`, `unowned-system-paths`, plus flaky `theme-install-guards` / `runtime-smoke`) also fail on `quattro` here without this change (missing `omarchy-pkgs` checkout / compositor).