### PR TITLE
Fix Emoji Picker for all apps with both keyboard and mouse

### DIFF
--- a/bin/omarchy-menu-emoji-insert
+++ b/bin/omarchy-menu-emoji-insert
@@ -2,19 +2,65 @@
 
 # omarchy:summary=Insert an emoji into the focused application
 # omarchy:group=menu
-# omarchy:args=<emoji>
+# omarchy:args=<emoji> [window-address]
 # omarchy:hidden=true
 
 emoji="${1:-}"
-copy_pid=""
+target="${2:-}"
 
-[[ -n $emoji ]] || exit
+[[ -n $emoji ]] || exit 0
 
-printf '%s' "$emoji" | wl-copy --type text/plain --sensitive --foreground &
-copy_pid=$!
+focus_window() {
+  hyprctl dispatch "hl.dsp.focus({ window = \"address:$1\" })" >/dev/null 2>&1 ||
+    hyprctl dispatch focuswindow "address:$1" >/dev/null 2>&1
+}
 
-sleep 0.15
-wtype -M shift -k Insert -m shift 2>/dev/null || true
-sleep 0.2
+active_address() {
+  hyprctl activewindow -j 2>/dev/null | jq -r '.address // ""'
+}
 
-kill "$copy_pid" 2>/dev/null || true
+if [[ -n $target ]]; then
+  [[ $target == 0x* ]] || target="0x$target"
+
+  # The picker is a fullscreen layer holding exclusive keyboard focus, so a
+  # focus request while it is still up does nothing. Once it closes,
+  # follow_mouse hands focus to whichever window sits under the (centred)
+  # cursor - so a mouse-picked emoji lands in the wrong window. Wait for the
+  # picker to go, then re-focus its origin window and confirm it stuck before
+  # typing.
+  sleep 0.15
+  for _ in {1..15}; do
+    [[ $(active_address) == "$target" ]] && break
+    focus_window "$target"
+    sleep 0.04
+  done
+else
+  # No origin window recorded: just let focus settle.
+  sleep 0.15
+fi
+
+# Terminals accept injected Unicode directly, and typing it leaves the
+# clipboard and primary selection untouched. Chromium- and Electron-based apps
+# (Chrome, VS Code, Slack, ...) ignore the transient keymap wtype uses to type
+# Unicode, so the character never arrives - they need a real clipboard paste,
+# which also works fine in Firefox, GTK and Qt. Terminal vs. not is decided
+# with the same "terminal" window tag omarchy's universal paste keybind uses
+# (default/hypr/bindings/clipboard.lua).
+is_terminal() {
+  hyprctl activewindow -j 2>/dev/null |
+    jq -e '[(.tags // [])[] | rtrimstr("*")] | index("terminal") != null' >/dev/null 2>&1
+}
+
+if is_terminal; then
+  wtype "$emoji"
+else
+  # Offer the emoji on the clipboard just long enough to paste it, marked
+  # --sensitive so clipboard managers don't archive it, then withdraw the
+  # offer. Ctrl+V is the paste shortcut everywhere outside a terminal.
+  printf '%s' "$emoji" | wl-copy --type text/plain --sensitive --foreground &
+  copy_pid=$!
+  sleep 0.15
+  wtype -M ctrl -P v -p v -m ctrl 2>/dev/null || true
+  sleep 0.2
+  kill "$copy_pid" 2>/dev/null || true
+fi

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -1,6 +1,7 @@
 import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
+import Quickshell.Hyprland
 import QtQuick
 import qs.Commons
 import qs.Ui
@@ -19,6 +20,20 @@ Item {
   property bool cursorActive: false
   property var emojis: []
   property var filteredEmojis: []
+
+  // Address of the window that was focused when the picker opened, so the
+  // emoji is typed back into it rather than whatever follow_mouse focuses
+  // once the picker closes.
+  property string targetWindow: ""
+  property string lastToplevelAddress: ""
+
+  Connections {
+    target: Hyprland
+    function onActiveToplevelChanged() {
+      var t = Hyprland.activeToplevel
+      if (t && t.address) root.lastToplevelAddress = t.address
+    }
+  }
 
   // Shares the [menu] surface tokens — themes that style the menu also
   // style emojis. Selected-cell colors composed in the
@@ -43,6 +58,8 @@ Item {
   property int columns: Math.floor((cardWidth - contentMargin * 2) / cellWidth)
 
   function open(payloadJson) {
+    var active = Hyprland.activeToplevel
+    root.targetWindow = (active && active.address) ? active.address : root.lastToplevelAddress
     root.opened = true
     root.filterText = ""
     root.selectedIndex = 0
@@ -148,7 +165,9 @@ Item {
   function applySelected(emoji) {
     if (!emoji) return
     root.dismiss()
-    Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-menu-emoji-insert", emoji])
+    var args = [root.omarchyPath + "/bin/omarchy-menu-emoji-insert", emoji]
+    if (root.targetWindow) args.push(root.targetWindow)
+    Quickshell.execDetached(args)
   }
 
   ListModel { id: displayModel }

--- a/test/shell.d/emojis-test.sh
+++ b/test/shell.d/emojis-test.sh
@@ -51,38 +51,113 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 mkdir -p "$TMPDIR/bin"
 
-cat >"$TMPDIR/bin/wl-copy" <<'SH'
-#!/bin/bash
-args="$*"
-target="$WL_COPY_OUT"
-if [[ $args == "--type text/plain --sensitive --foreground" ]]; then
-  target="$WL_COPY_EMOJI_OUT"
-fi
-
-printf '%s\n' "$args" >"$target.args"
-cat >"$target"
-SH
-
 cat >"$TMPDIR/bin/wtype" <<'SH'
 #!/bin/bash
-printf '%s\n' "$*" >"$WTYPE_OUT"
+printf '%s' "$*" >"$WTYPE_OUT"
 SH
 
 cat >"$TMPDIR/bin/sleep" <<'SH'
 #!/bin/bash
-exit 0
+printf '%s\n' "$*" >>"$SLEEP_OUT"
 SH
 
-chmod +x "$TMPDIR/bin/wl-copy" "$TMPDIR/bin/wtype" "$TMPDIR/bin/sleep"
+cat >"$TMPDIR/bin/wl-copy" <<'SH'
+#!/bin/bash
+cat >"$WLCOPY_OUT"
+SH
 
-WL_COPY_OUT="$TMPDIR/copy" WL_COPY_EMOJI_OUT="$TMPDIR/emoji" WTYPE_OUT="$TMPDIR/wtype" PATH="$TMPDIR/bin:$PATH" \
+cat >"$TMPDIR/bin/hyprctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HYPRCTL_OUT"
+case "$*" in
+  *activewindow*)
+    if [[ -n $HYPRCTL_ACTIVE ]]; then
+      printf '%s\n' "$HYPRCTL_ACTIVE"
+    else
+      printf '{"address": "%s", "tags": [%s]}\n' "${HYPRCTL_ADDRESS:-0x0}" "${HYPRCTL_TAGS:-}"
+    fi
+    ;;
+esac
+SH
+
+chmod +x "$TMPDIR/bin/wtype" "$TMPDIR/bin/sleep" "$TMPDIR/bin/wl-copy" "$TMPDIR/bin/hyprctl"
+
+term_env=(WTYPE_OUT="$TMPDIR/wtype" SLEEP_OUT="$TMPDIR/sleep" HYPRCTL_OUT="$TMPDIR/hyprctl" WLCOPY_OUT="$TMPDIR/wlcopy" PATH="$TMPDIR/bin:$PATH")
+
+# A terminal is tagged "terminal" (dynamic tags carry a trailing "*").
+env "${term_env[@]}" HYPRCTL_TAGS='"default-opacity*", "terminal*"' \
+  "$ROOT/bin/omarchy-menu-emoji-insert" "😀" "0xdeadbeef"
+
+[[ $(<"$TMPDIR/wtype") == "😀" ]] || fail "emoji insert helper types the emoji into a focused terminal"
+pass "emoji insert helper types the emoji into a focused terminal"
+
+[[ -s "$TMPDIR/sleep" ]] || fail "emoji insert helper waits for focus to settle before inserting"
+pass "emoji insert helper waits for focus to settle before inserting"
+
+[[ ! -e "$TMPDIR/wlcopy" ]] || fail "emoji insert helper leaves the clipboard alone for a terminal"
+pass "emoji insert helper leaves the clipboard alone for a terminal"
+
+grep -qF 'hl.dsp.focus({ window = "address:0xdeadbeef" })' "$TMPDIR/hyprctl" || fail "emoji insert helper refocuses the picker's origin window by address"
+pass "emoji insert helper refocuses the picker's origin window by address"
+
+# A bare (0x-less) address is normalised before dispatch.
+: >"$TMPDIR/hyprctl"
+env "${term_env[@]}" WTYPE_OUT="$TMPDIR/wtype2" SLEEP_OUT="$TMPDIR/sleep2" HYPRCTL_TAGS='"terminal*"' \
+  "$ROOT/bin/omarchy-menu-emoji-insert" "😀" "deadbeef"
+grep -qF 'address:0xdeadbeef' "$TMPDIR/hyprctl" || fail "emoji insert helper normalises a bare window address"
+pass "emoji insert helper normalises a bare window address"
+
+# Refocus loop stops once the origin window is active again.
+: >"$TMPDIR/hyprctl"
+env "${term_env[@]}" WTYPE_OUT="$TMPDIR/wtype3" SLEEP_OUT="$TMPDIR/sleep3" \
+  HYPRCTL_ACTIVE='{"address": "0xdeadbeef", "tags": ["terminal*"]}' \
+  "$ROOT/bin/omarchy-menu-emoji-insert" "😀" "0xdeadbeef"
+! grep -q "address:" "$TMPDIR/hyprctl" || fail "emoji insert helper stops refocusing once the origin window is active"
+pass "emoji insert helper stops refocusing once the origin window is active"
+
+# A non-terminal window (here a browser) gets a clipboard paste, not injected
+# Unicode - Chromium and Electron apps drop wtype's transient keymap.
+: >"$TMPDIR/hyprctl"
+env "${term_env[@]}" WTYPE_OUT="$TMPDIR/wtype-gui" WLCOPY_OUT="$TMPDIR/wlcopy-gui" \
+  HYPRCTL_TAGS='"default-opacity*", "firefox-based-browser*"' \
+  "$ROOT/bin/omarchy-menu-emoji-insert" "😀" "0xdeadbeef"
+
+[[ $(<"$TMPDIR/wlcopy-gui") == "😀" ]] || fail "emoji insert helper puts the emoji on the clipboard for a GUI app"
+pass "emoji insert helper puts the emoji on the clipboard for a GUI app"
+
+grep -q "ctrl" "$TMPDIR/wtype-gui" || fail "emoji insert helper sends Ctrl+V to paste into a GUI app"
+pass "emoji insert helper sends Ctrl+V to paste into a GUI app"
+
+[[ $(<"$TMPDIR/wtype-gui") != "😀" ]] || fail "emoji insert helper does not inject raw Unicode into a GUI app"
+pass "emoji insert helper does not inject raw Unicode into a GUI app"
+
+# An untagged window falls back to the paste path.
+: >"$TMPDIR/hyprctl"
+env "${term_env[@]}" WTYPE_OUT="$TMPDIR/wtype-untagged" WLCOPY_OUT="$TMPDIR/wlcopy-untagged" \
+  "$ROOT/bin/omarchy-menu-emoji-insert" "😀" "0xdeadbeef"
+[[ $(<"$TMPDIR/wlcopy-untagged") == "😀" ]] || fail "emoji insert helper defaults to paste for an untagged window"
+pass "emoji insert helper defaults to paste for an untagged window"
+
+# No origin window recorded: still inserts, but dispatches no focus change.
+env "${term_env[@]}" WTYPE_OUT="$TMPDIR/wtype-notarget" HYPRCTL_OUT="$TMPDIR/hyprctl-notarget" \
+  HYPRCTL_TAGS='"terminal*"' \
   "$ROOT/bin/omarchy-menu-emoji-insert" "😀"
 
-[[ $(<"$TMPDIR/emoji") == "😀" ]] || fail "emoji insert helper copies emoji transiently"
-pass "emoji insert helper copies emoji transiently"
+[[ $(<"$TMPDIR/wtype-notarget") == "😀" ]] || fail "emoji insert helper still inserts without a window address"
+pass "emoji insert helper still inserts without a window address"
 
-[[ $(<"$TMPDIR/emoji.args") == "--type text/plain --sensitive --foreground" ]] || fail "emoji insert helper serves sensitive transient clipboard in foreground"
-pass "emoji insert helper serves transient clipboard in foreground"
+! grep -qE 'dsp\.focus|dispatch focuswindow' "$TMPDIR/hyprctl-notarget" || fail "emoji insert helper skips refocus without a window address"
+pass "emoji insert helper skips refocus without a window address"
 
-[[ $(<"$TMPDIR/wtype") == "-M shift -k Insert -m shift" ]] || fail "emoji insert helper pastes with shift insert"
-pass "emoji insert helper pastes with shift insert"
+env "${term_env[@]}" WTYPE_OUT="$TMPDIR/wtype-noarg" SLEEP_OUT="$TMPDIR/sleep-noarg" \
+  HYPRCTL_OUT="$TMPDIR/hyprctl-noarg" WLCOPY_OUT="$TMPDIR/wlcopy-noarg" \
+  "$ROOT/bin/omarchy-menu-emoji-insert" ""
+
+[[ ! -e "$TMPDIR/wtype-noarg" ]] || fail "emoji insert helper does nothing without an emoji argument"
+pass "emoji insert helper does nothing without an emoji argument"
+
+[[ ! -e "$TMPDIR/sleep-noarg" ]] || fail "emoji insert helper exits before sleeping without an emoji argument"
+pass "emoji insert helper exits before sleeping without an emoji argument"
+
+[[ ! -e "$TMPDIR/hyprctl-noarg" ]] || fail "emoji insert helper exits before querying hyprctl without an emoji argument"
+pass "emoji insert helper exits before querying hyprctl without an emoji argument"


### PR DESCRIPTION
Now works reliably on
- GTK
- Qt6
- Terminals
- Chromium
- **Firefox** (previously broken)
- VS Code
- IntelliJ

With
- keyboard
- **mouse** (previously broken)

Fixes
- #7350
- #7379
- #8206 

Supersedes
- #6892
- #7351
- #7449

## What changed

`omarchy-menu-emoji-insert` used to copy the emoji to a transient clipboard and simulate `Shift+Insert` for every app. It now **types** the emoji with `wtype` in terminals and **pastes** it (transient `--sensitive` clipboard + synthetic `Ctrl+V`) everywhere else. The picker also records which window was focused when it opened and re-focuses it before inserting.

## Why — insertion method

The old copy-and-paste approach relied on the focused app treating `Shift+Insert` as "paste clipboard". That breaks:

- **Firefox silently ignores a *synthetic* `Shift+Insert`.** A manual one pastes fine, and a synthetic `Ctrl+V` / `Ctrl+Shift+V` both work — but the `wtype`-generated `Shift+Insert` does nothing, so the emoji never lands.
- **No single paste shortcut covers everything.** `Ctrl+Shift+V` (cf. #6892) fixes Firefox and terminals but is unbound in Qt text widgets, so it misses omawrite and other Qt apps. `Ctrl+V` misses terminals. Sending two shortcuts double-pastes in apps that accept both.
- **Typing the emoji doesn't work in Chromium / Electron apps** (Chrome, VS Code, Slack, Discord…). They ignore the transient keymap `wtype` uses for Unicode, so a typed emoji never arrives — those need a real clipboard paste.

So no single method works everywhere. The helper splits on the same `terminal` window tag omarchy's universal-paste keybind already uses (`default/hypr/bindings/clipboard.lua`): terminals get the emoji **typed** (clipboard and primary selection stay untouched); everything else gets a transient `--sensitive` clipboard offer + synthetic `Ctrl+V`, withdrawn straight after.

## Why — origin window

The picker is a fullscreen layer holding exclusive keyboard focus. When it closes, `follow_mouse` hands focus to whichever window is under the (centred) cursor — so an emoji chosen by **mouse click** was inserted into the wrong window (with the picker straddling two windows, left-side emoji → left window, right-side → right window). `Emojis.qml` now captures `Hyprland.activeToplevel.address` in `open()` and passes it to the helper, which re-focuses that window with `hl.dsp.focus({ window = "address:…" })` (the classic `dispatch focuswindow` form is routed through the Lua dispatcher and errors on current Hyprland) and polls `activewindow` until it sticks before inserting. No address (keyboard-only, nothing focused) → unchanged behaviour.

## Testing

- `bash test/shell.d/emojis-test.sh` — covers the terminal/GUI split, clipboard handling, address normalisation, the refocus loop, and the no-argument path.
- Manually verified an emoji, a ZWJ sequence (👨‍👩‍👧) and a flag (🇺🇸) insert correctly — via **both keyboard and mouse selection**, including the picker straddling two windows — in foot, Firefox, Chromium, omawrite (Qt6), Nautilus (GTK) and IntelliJ.
