### PR TITLE
Keep GNOME text scaling from clipping 1Password's fixed-size dialogs

### DIFF
--- a/bin/omarchy-install-service-1password
+++ b/bin/omarchy-install-service-1password
@@ -27,8 +27,16 @@ omarchy-pkg-add 1password 1password-cli
 echo "Installing 1Password extension for Chromium..."
 install_chromium_extension
 
+# Launch with default gsettings so GNOME's text-scaling-factor doesn't clip
+# 1Password's fixed-size dialogs; the desktop override keeps app-launcher
+# starts consistent with omarchy-launch-1password and the autostart drop-in.
+mkdir -p "$HOME/.local/share/applications"
+install -m 644 "$OMARCHY_PATH/default/applications/1password.desktop" \
+  "$HOME/.local/share/applications/1password.desktop"
+update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+
 echo "Opening 1Password..."
-uwsm-app -- 1password >/dev/null 2>&1 &
+uwsm-app -- env GSETTINGS_BACKEND=memory 1password >/dev/null 2>&1 &
 
 echo ""
 echo "1Password has been installed. Restart Chromium to load the browser extension."

--- a/bin/omarchy-launch-1password
+++ b/bin/omarchy-launch-1password
@@ -5,7 +5,11 @@
 set -e
 
 if omarchy-cmd-present 1password; then
-  exec setsid uwsm-app -- 1password
+  # GSETTINGS_BACKEND=memory: don't let GNOME's text-scaling-factor inflate
+  # 1Password's Electron device scale — it clips the app's fixed-size dialogs
+  # (SSH authorization prompt). Same env as its autostart drop-in under
+  # etc/systemd/user/app-1password@autostart.service.d/.
+  exec setsid uwsm-app -- env GSETTINGS_BACKEND=memory 1password
 else
   exec omarchy-launch-floating-terminal-with-presentation omarchy-install-service-1password
 fi

--- a/default/applications/1password.desktop
+++ b/default/applications/1password.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=1Password
+# GSETTINGS_BACKEND=memory keeps GNOME's text-scaling-factor away from
+# 1Password's Electron runtime, which otherwise scales content beyond its
+# fixed-size dialogs (SSH authorization prompt) and clips them. See the
+# matching drop-in at etc/systemd/user/app-1password@autostart.service.d/.
+Exec=env GSETTINGS_BACKEND=memory /opt/1Password/1password %U
+Terminal=false
+Type=Application
+Icon=1password
+StartupWMClass=1Password
+Comment=Password manager and secure wallet
+MimeType=x-scheme-handler/onepassword;
+Categories=Office;

--- a/etc/systemd/user/app-1password@autostart.service.d/text-scaling.conf
+++ b/etc/systemd/user/app-1password@autostart.service.d/text-scaling.conf
@@ -1,0 +1,14 @@
+# 1Password sizes its dialogs in fixed logical pixels, but its Electron
+# runtime multiplies GNOME's text-scaling-factor (set by `omarchy display
+# text size`) into the device scale. Any factor above 1.0 shrinks the usable
+# layout of fixed-size windows, clipping the SSH authorization prompt's
+# buttons off-screen (it refuses resizes: min size = max size).
+#
+# Serving 1Password default gsettings keeps it at the plain monitor scale so
+# its dialogs lay out at their designed size. Dark/light detection is portal
+# based and unaffected.
+#
+# This unit is generated from ~/.config/autostart/1password.desktop, which
+# 1Password rewrites on startup — hence the env lives here, not there.
+[Service]
+Environment=GSETTINGS_BACKEND=memory

--- a/migrations/1787832813.sh
+++ b/migrations/1787832813.sh
@@ -1,0 +1,12 @@
+echo "Keep GNOME text scaling from clipping 1Password's fixed-size dialogs"
+
+if omarchy-cmd-present 1password; then
+  mkdir -p "$HOME/.local/share/applications"
+  install -m 644 "$OMARCHY_PATH/default/applications/1password.desktop" \
+    "$HOME/.local/share/applications/1password.desktop"
+  update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+
+  # Pick up the packaged autostart drop-in without waiting for a relogin.
+  # The running 1Password keeps its old environment until it is restarted.
+  systemctl --user daemon-reload
+fi

--- a/test/shell.d/launch-1password-test.sh
+++ b/test/shell.d/launch-1password-test.sh
@@ -31,8 +31,9 @@ chmod +x "$mock_bin"/*
 launch_log="$test_tmp/launch-log"
 PATH="$mock_bin:$PATH" OMARCHY_TEST_INSTALLED=true OMARCHY_TEST_LOG="$launch_log" \
   bash "$ROOT/bin/omarchy-launch-1password"
-grep -Fxq 'launch:-- 1password' "$launch_log" || fail "1Password launcher starts the installed app"
-pass "1Password launcher starts the installed app"
+grep -Fxq 'launch:-- env GSETTINGS_BACKEND=memory 1password' "$launch_log" ||
+  fail "1Password launcher starts the installed app with default gsettings"
+pass "1Password launcher starts the installed app with default gsettings"
 
 PATH="$mock_bin:$PATH" OMARCHY_TEST_INSTALLED=false OMARCHY_TEST_LOG="$launch_log" \
   bash "$ROOT/bin/omarchy-launch-1password"
@@ -43,3 +44,12 @@ pass "1Password launcher starts the installer when missing"
 grep -Fq '{ omarchy = "1password" }' "$ROOT/default/hypr/bindings/applications.lua" ||
   fail "1Password keybinding uses the conditional launcher"
 pass "1Password keybinding uses the conditional launcher"
+
+grep -Fq 'Environment=GSETTINGS_BACKEND=memory' \
+  "$ROOT/etc/systemd/user/app-1password@autostart.service.d/text-scaling.conf" ||
+  fail "1Password autostart drop-in serves default gsettings"
+pass "1Password autostart drop-in serves default gsettings"
+
+grep -Eq '^Exec=env GSETTINGS_BACKEND=memory ' "$ROOT/default/applications/1password.desktop" ||
+  fail "1Password desktop override serves default gsettings"
+pass "1Password desktop override serves default gsettings"


### PR DESCRIPTION
Fixes #8574 (root cause of #2016).

## Problem

`omarchy display text size` sets GNOME's `text-scaling-factor`, and 1Password's Electron runtime multiplies that factor into its device scale. Its fixed-size windows then lose that factor of layout space: at text size 16 (factor 1.36) the SSH authorization prompt — fixed at ~402x371 logical px, min size = max size, so window rules and resize dispatchers are ignored — clips ~26% of its content, including the authorize button. Full analysis and DPR measurements in #8574.

## Fix

Serve 1Password default gsettings (`GSETTINGS_BACKEND=memory`) so it renders at the plain monitor scale, on every launch path:

- **`bin/omarchy-launch-1password`** — the keybinding/menu launcher passes the env.
- **`etc/systemd/user/app-1password@autostart.service.d/text-scaling.conf`** — packaged drop-in for the autostart unit. The env can't live in the autostart desktop file because 1Password rewrites `~/.config/autostart/1password.desktop` on startup; the generated `app-1password@autostart.service` picks the drop-in up instead.
- **`default/applications/1password.desktop`** — local desktop override (battlenet pattern) so app-library launches match; installed by `omarchy-install-service-1password` and by the migration for existing installs with 1Password present.
- **Migration** — installs the desktop override and `systemctl --user daemon-reload`s so the packaged drop-in applies without a relogin. The running 1Password keeps its old environment until restarted (deliberately not restarted mid-update: that would lock the vault under the user).

Trade-off: 1Password renders at standard size instead of following the text scale (in-app Ctrl+= zoom compensates for the main window and doesn't affect the dialogs). Dark/light detection is portal-based and unaffected.

## Verification

On a live Omarchy install (3840x2160 @ scale 2, `text-scaling-factor` 1.3636, 1Password 8.12.32):

- Before: SSH authorization prompt fixed at 402x371 with buttons clipped; `devicePixelRatio` 2.72.
- After relaunching with the env: DPR 2.0, the prompt sizes itself to fit its content (402x426), everything visible, agent signs fine.
- Env candidates were measured with a scratch Chromium + CDP before settling on `GSETTINGS_BACKEND=memory` (`GDK_DPI_SCALE` is a no-op for Chromium; `--force-device-scale-factor` multiplies and makes it worse) — table in #8574.
- `test/shell.d/launch-1password-test.sh` extended to cover the env on the launcher, the drop-in, and the desktop override; passes. The rest of `./test/all` matches master (5 pre-existing environment-dependent failures, unrelated).

(No before/after captures possible: 1Password windows are `no_screen_share`-tagged, screenshots come out black.)
