### PR TITLE
Cycle backwards through every window with Alt + Shift + Tab

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -44,10 +44,12 @@ o.bind("SUPER + SHIFT + RIGHT", "Swap window to the right", hl.dsp.window.swap({
 o.bind("SUPER + SHIFT + UP", "Swap window up", hl.dsp.window.swap({ direction = "u" }))
 o.bind("SUPER + SHIFT + DOWN", "Swap window down", hl.dsp.window.swap({ direction = "d" }))
 
+-- Going backwards lowers the window it leaves instead of raising the one it lands on: bring_to_top
+-- moves the active window to the end of the same list cycle_next walks, so a raise here ping-pongs.
+o.bind("ALT + SHIFT + TAB", "Reveal active window on top", hl.dsp.window.alter_zorder({ mode = "bottom" }))
 o.bind("ALT + TAB", "Focus on next window", hl.dsp.window.cycle_next())
 o.bind("ALT + SHIFT + TAB", "Focus on previous window", hl.dsp.window.cycle_next({ next = false }))
 o.bind("ALT + TAB", "Reveal active window on top", hl.dsp.window.bring_to_top())
-o.bind("ALT + SHIFT + TAB", "Reveal active window on top", hl.dsp.window.bring_to_top())
 
 o.bind("CTRL + ALT + TAB", "Focus on next monitor", hl.dsp.focus({ monitor = "+1" }))
 o.bind("CTRL + ALT + SHIFT + TAB", "Focus on previous monitor", hl.dsp.focus({ monitor = "-1" }))


### PR DESCRIPTION
With three or more windows on a workspace, `Alt + Shift + Tab` alternated between two of them and never reached the rest, while `Alt + Tab` cycled through all of them.

Both chords stacked two dispatchers: cycle, then `bring_to_top`. Hyprland's `cyclenext` walks the compositor's z-order vector, and `bringactivetotop` rotates the active window to the back of that same vector — the raise mutates the very ordering the traversal reads. Going forwards that is harmless, because "next" from the back wraps to the front and lands on the window raised longest ago. Going backwards it is fatal: "previous" from the back is the second-from-back, which is exactly the window just left, so focus ping-pongs between two windows for as long as the chord is held.

Reverse now lowers the window it leaves rather than raising the one it lands on, with `alter_zorder({ mode = "bottom" })` running before the cycle. Sending the active window to the bottom makes its predecessor the new back of the vector, so "previous" wraps onto it: focus steps one window per press through the whole workspace, in the exact inverse of `Alt + Tab`, and the window landed on is still the one on top. Both chords keep their two stacked binds, which is what `test/shell.d/hyprland-binding-conflicts-test.sh` records as deliberate.

Verified on a disposable Omarchy worker running Hyprland 0.56.2, the version in the report: three tiled windows and three overlapping floating ones each cycle through all three in both directions, and the newly focused window is topmost after every reverse press. `alter_zorder` calls `simulateMouseMovement`, and Omarchy sets `follow_mouse = 1`, so lowering a window under the pointer could in principle hand focus to whatever it uncovers before the cycle runs; with the pointer parked over all three overlapping floating windows it did not, and `bring_to_top` on `Alt + Tab` has been going through that same code path all along.

Reviewed by Codex at xhigh reasoning, which traced the mechanism through Hyprland v0.56.2's own source and confirmed it, and established that the Lua `cycle_next` wrapper takes only `next`, `tiled` and `floating` — there is no argument that makes reverse cycling immune to the raise.

Fixes #7561