### PR TITLE
Update installed themes in parallel

### DIFF
--- a/bin/omarchy-theme-update
+++ b/bin/omarchy-theme-update
@@ -4,7 +4,24 @@
 
 mapfile -t themes < <(omarchy-theme-extras)
 
+max_parallel=4
+active=0
+rc=0
+
 for theme in "${themes[@]}"; do
+  if (( active == max_parallel )); then
+    wait -n || rc=1
+    active=$((active - 1))
+  fi
+
   echo "Updating: $(basename "$theme")"
-  git -C "$theme" pull
+  git -C "$theme" pull &
+  active=$((active + 1))
 done
+
+while (( active > 0 )); do
+  wait -n || rc=1
+  active=$((active - 1))
+done
+
+exit "$rc"

--- a/test/shell.d/theme-update-test.sh
+++ b/test/shell.d/theme-update-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+themes="$test_tmp/themes"
+started="$test_tmp/started"
+mkdir -p "$mock_bin" "$started"
+for number in {1..5}; do
+  mkdir -p "$themes/theme-$number/.git"
+done
+
+cat >"$mock_bin/omarchy-theme-extras" <<'SH'
+#!/bin/bash
+printf '%s\n' "$OMARCHY_TEST_THEMES"/*
+SH
+
+cat >"$mock_bin/git" <<'SH'
+#!/bin/bash
+
+touch "$OMARCHY_TEST_STARTED/$(basename "$2")"
+while [[ ! -e $OMARCHY_TEST_RELEASE ]]; do
+  sleep 0.01
+done
+SH
+chmod +x "$mock_bin/omarchy-theme-extras" "$mock_bin/git"
+
+HOME="$test_tmp/home" PATH="$mock_bin:$PATH" OMARCHY_TEST_THEMES="$themes" \
+  OMARCHY_TEST_STARTED="$started" OMARCHY_TEST_RELEASE="$test_tmp/release" \
+  bash "$ROOT/bin/omarchy-theme-update" >/dev/null &
+updater=$!
+
+for _ in {1..100}; do
+  (( $(find "$started" -type f | wc -l) >= 4 )) && break
+  sleep 0.01
+done
+sleep 0.1
+
+(( $(find "$started" -type f | wc -l) == 4 )) || {
+  touch "$test_tmp/release"
+  wait "$updater" 2>/dev/null
+  fail "theme updater runs up to four pulls in parallel"
+}
+
+touch "$test_tmp/release"
+wait "$updater" || fail "theme updates finish successfully"
+(( $(find "$started" -type f | wc -l) == 5 )) || fail "theme updater waits for every pull"
+
+cat >"$mock_bin/git" <<'SH'
+#!/bin/bash
+[[ $(basename "$2") == "theme-1" ]]
+SH
+chmod +x "$mock_bin/git"
+
+if HOME="$test_tmp/home" PATH="$mock_bin:$PATH" OMARCHY_TEST_THEMES="$themes" \
+  bash "$ROOT/bin/omarchy-theme-update" >/dev/null; then
+  fail "theme updater reports a failed pull"
+fi
+
+pass "theme updater runs bounded parallel pulls and reports failures"


### PR DESCRIPTION
## What

Run up to four `git pull`s for user-installed themes concurrently, then wait for every pull before returning. The updater also exits non-zero if any theme fails to update.

This makes updates substantially faster for users with many installed themes without opening an unbounded number of simultaneous GitHub connections.

## Testing

- `bash test/shell.d/theme-update-test.sh` (verifies the four-pull limit, overlap, waiting, and failure status)
- `./test/cli`
- `bin/omarchy commands --check`
- syntax-checked every `bin/omarchy-*` command with its matching parser
- `./test/shell` (new test passes; 5 unrelated environment-dependent failures: `bar-icon-geometry`, `config`, `snapper`, `theme-install-guards`, and `unowned-system-paths`)
