### PR TITLE
Re-arm lock blank timer with backoff on screen changes

### DIFF
--- a/manual/45-troubleshooting.md
+++ b/manual/45-troubleshooting.md
@@ -47,3 +47,10 @@ In order for the rich approval prompt to appear, Settings > Advanced > Use Hardw
  ![troubleshooting-1password](images/troubleshooting-1password.webp)
 
 Or if you haven't launched 1Password since booting up, the prompt will not appear.
+
+### Why does my monitor turn off and on (flash) continuously while locked?
+
+Some monitors (especially HDMI panels with Input Auto-Scan or Auto Source enabled) shut down their signal receiver when DPMS turns the display off, causing the system to detect a Hot Plug Detect (HPD) drop. When the monitor re-scans inputs, Hyprland re-detects the output and powers it back on.
+
+To eliminate this loop, open your monitor's built-in OSD menu and set **Auto Source** or **Input Auto-Scan** to **Off** (pinning the input source directly to HDMI or DisplayPort).
+

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -33,6 +33,7 @@ Item {
   property string lastEventAt: ""
   property bool strandedLock: false
   property bool strandedLockResolved: false
+  property int screenChangeBlankCount: 0
 
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
@@ -133,6 +134,7 @@ Item {
 
     resetAuthenticationState()
     lockRequested = true
+    screenChangeBlankCount = 0
     armBlankTimer()
     logEvent("lock-requested")
     queueSessionLock()
@@ -159,17 +161,21 @@ Item {
     runWake()
   }
 
-  function armBlankTimer() {
+  function armBlankTimer(customInterval) {
+    var ms = (typeof customInterval === "number" && customInterval > 0) ? customInterval : 5000
+    idleBlankTimer.interval = ms
     idleBlankTimer.armedAt = Date.now()
     idleBlankTimer.restart()
   }
 
   function runWake() {
+    screenChangeBlankCount = 0
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
   }
 
   function runBlank() {
+    logEvent("blanking-display")
     if (!blankProcess.running) blankProcess.running = true
   }
 
@@ -472,6 +478,14 @@ Item {
       // A monitor still coming up has no workspace, so cannot answer yet.
       strandedLockRetryTimer.rearm()
       root.checkStrandedLock()
+
+      if ((root.locked || root.lockRequested) && !root.authenticatingPassword) {
+        root.screenChangeBlankCount += 1
+        var delay = 5000
+        if (root.screenChangeBlankCount === 2) delay = 15000
+        else if (root.screenChangeBlankCount >= 3) delay = 30000
+        root.armBlankTimer(delay)
+      }
     }
   }
 

--- a/test/shell.d/lock-blank-fingerprint-test.sh
+++ b/test/shell.d/lock-blank-fingerprint-test.sh
@@ -37,13 +37,8 @@ assert(
 )
 
 assert(
-  /onScreensChanged\(\) \{[\s\S]*root\.screenChangeBlankCount \+= 1/.test(serviceQml),
-  'screen changes while locked increment the screen change count'
-)
-
-assert(
-  /onScreensChanged\(\) \{[\s\S]*root\.armBlankTimer\(delay\)/.test(serviceQml),
-  'screen changes while locked re-arm the blank timer with backoff'
+  /onScreensChanged\(\) \{[\s\S]*if \(\(root\.locked \|\| root\.lockRequested\) && !root\.authenticatingPassword\) \{[\s\S]*root\.screenChangeBlankCount \+= 1\s*var delay = 5000\s*if \(root\.screenChangeBlankCount === 2\) delay = 15000\s*else if \(root\.screenChangeBlankCount >= 3\) delay = 30000\s*root\.armBlankTimer\(delay\)/.test(serviceQml),
+  'screen changes re-arm blanking at 5s, 15s, then cap at 30s only while locked and not authenticating'
 )
 
 assert(

--- a/test/shell.d/lock-blank-fingerprint-test.sh
+++ b/test/shell.d/lock-blank-fingerprint-test.sh
@@ -30,4 +30,24 @@ assert(
   !/onAuthenticatingChanged:/.test(serviceQml),
   'the combined authenticating state no longer drives the blank timer'
 )
+
+assert(
+  /function runBlank\(\) \{\s*logEvent\("blanking-display"\)/.test(serviceQml),
+  'runBlank logs display blanking event'
+)
+
+assert(
+  /onScreensChanged\(\) \{[\s\S]*root\.screenChangeBlankCount \+= 1/.test(serviceQml),
+  'screen changes while locked increment the screen change count'
+)
+
+assert(
+  /onScreensChanged\(\) \{[\s\S]*root\.armBlankTimer\(delay\)/.test(serviceQml),
+  'screen changes while locked re-arm the blank timer with backoff'
+)
+
+assert(
+  /function runWake\(\) \{\s*screenChangeBlankCount = 0/.test(serviceQml),
+  'waking resets the screen change blank count'
+)
 JS


### PR DESCRIPTION
When a panel deep-sleeps after DPMS-off and drops HPD (such as input-scanning HDMI displays), Hyprland removes and re-adds the monitor powered on. Because the lock blank timer was a one-shot fired at lock+5s, returning monitors remained lit showing the lock screen indefinitely.

Re-arm idleBlankTimer with exponential/capped backoff (5s -> 15s -> 30s) on screen changes while locked, allowing Hyprland time to finish configuring newly re-added outputs without high-frequency flashing. Reset backoff count on user wake or password input, and log blanking-display in runBlank for journal visibility.

Fixes #8580
