### PR TITLE
Add the 2020 Intel MacBook Air to the T2 device list

### DIFF
--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -65,6 +65,7 @@ The Apple T2 Security Chip was introduced in 2017. The T2 chip was discontinued 
 - MacBook Pro 13-inch (2019, two Thunderbolt 3 ports) – Model: A2159
 - MacBook Pro 13-inch (2019, four Thunderbolt 3 ports) – Model: A2178
 - MacBook Pro 15-inch (2019) – Model: A1990
+- MacBook Air (Retina, 13-inch, 2020) – Model: A2179
 - MacBook Pro 13-inch (2020, two Thunderbolt 3 ports) – Model: A2265
 - MacBook Pro 15-inch (2020) – Model: A1990
 


### PR DESCRIPTION
The T2 list in `manual/44-mac-support.md` skips the Intel MacBook Air (Retina, 13-inch, 2020) — `MacBookAir9,1`, model A2179. It goes from the 2018 Air straight to the 2020 MacBook Pros, even though Apple lists the 2020 Air among [Mac computers with the Apple T2 Security Chip](https://support.apple.com/en-us/103265).

I own one, and I installed Omarchy on it recently. The install went through without trouble and pretty much everything is working, so the machine belongs on that list.

That matches how the installer actually behaves: `install/hardware/apple/fix-t2.sh` detects a T2 by PCI ID (`106b:180[12]`) rather than by model, so my A2179 got `linux-t2`, `apple-t2-audio-config`, `apple-bcm-firmware`, and `t2fanrd` like every other machine already listed. Only the documentation left its owners guessing.

Added in date order, between the 2019 MacBook Pros and the 2020 ones.


<img width="671" height="900" alt="image" src="https://github.com/user-attachments/assets/c1829e1e-a5a1-43e8-8f11-dd9a47968b4e" />

Acceptance test was. done by my daughter, she was  playing SuperTux2 entire day on it 

<img width="458" height="592" alt="image" src="https://github.com/user-attachments/assets/37cec98d-3475-4057-9690-ed0115029bc9" />

