### PR TITLE
Restart the media marquee when the track or clip width changes

### DIFF
--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -112,7 +112,11 @@ BarWidget {
         loops: Animation.Infinite
         from: 0
         to: -scrollClip.cycle
-        duration: Math.max(3000, scrollClip.cycle * 25)
+        // Hold the previous scroll rate. The old animation covered
+        // scrollClip.width + implicitWidth in max(6000, implicitWidth * 25) ms,
+        // so scale that pace to the cycle this one travels instead.
+        duration: scrollClip.cycle * Math.max(6000, labelText.implicitWidth * 25)
+          / Math.max(1, scrollClip.width + labelText.implicitWidth)
         easing.type: Easing.Linear
       }
     }

--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -52,26 +52,68 @@ BarWidget {
       anchors.verticalCenter: parent.verticalCenter
       visible: !root.bar.vertical && root.title !== ""
 
-      Text {
-        id: labelText
-        textFormat: Text.PlainText
-        text: root.title + (root.artist ? "  ·  " + root.artist : "")
-        color: root.bar.barForeground
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.body
+      // Gap between the two copies of the label, so the loop reads as a
+      // continuous ribbon instead of a hard cut back to the start.
+      readonly property real gap: Style.space(28)
+      readonly property real cycle: labelText.implicitWidth + gap
+      readonly property bool needsScroll: labelText.implicitWidth > width + 0.5
+      readonly property bool scrolling: needsScroll && !root.popupOpen && !root.bar.vertical && visible
+
+      // from/to/duration are only sampled when an animation starts, so a new
+      // track has to stop, rewind and start it again. Without this the marquee
+      // keeps replaying the geometry of whatever track was playing when it
+      // first started and looks frozen.
+      function resyncScroll() {
+        scrollAnim.stop()
+        scrollRow.x = 0
+        if (scrolling && cycle > 0) scrollAnim.start()
+      }
+
+      onScrollingChanged: resyncScroll()
+      onCycleChanged: resyncTimer.restart()
+      onWidthChanged: resyncTimer.restart()
+      Component.onCompleted: resyncScroll()
+
+      Timer {
+        id: resyncTimer
+        interval: 60
+        onTriggered: scrollClip.resyncScroll()
+      }
+
+      Row {
+        id: scrollRow
         anchors.verticalCenter: parent.verticalCenter
+        spacing: scrollClip.gap
 
-        property bool needsScroll: implicitWidth > scrollClip.width
-
-        NumberAnimation on x {
-          id: scrollAnim
-          running: labelText.needsScroll && !root.popupOpen && !root.bar.vertical
-          loops: Animation.Infinite
-          duration: Math.max(6000, labelText.implicitWidth * 25)
-          from: scrollClip.width
-          to: -labelText.implicitWidth
-          easing.type: Easing.Linear
+        Text {
+          id: labelText
+          textFormat: Text.PlainText
+          text: root.title + (root.artist ? "  ·  " + root.artist : "")
+          color: root.bar.barForeground
+          font.family: root.bar.fontFamily
+          font.pixelSize: Style.font.body
+          onTextChanged: resyncTimer.restart()
         }
+
+        Text {
+          textFormat: Text.PlainText
+          text: labelText.text
+          color: labelText.color
+          font.family: labelText.font.family
+          font.pixelSize: labelText.font.pixelSize
+          visible: scrollClip.scrolling
+        }
+      }
+
+      NumberAnimation {
+        id: scrollAnim
+        target: scrollRow
+        property: "x"
+        loops: Animation.Infinite
+        from: 0
+        to: -scrollClip.cycle
+        duration: Math.max(3000, scrollClip.cycle * 25)
+        easing.type: Easing.Linear
       }
     }
   }


### PR DESCRIPTION
The now-playing marquee in the media bar widget stops scrolling after the first track and stays stuck until the shell restarts.

### Cause

`NumberAnimation` samples `from`, `to` and `duration` once, when it starts. In `shell/plugins/services/media/BarWidget.qml` they are bound to values that change with every track:

```qml
NumberAnimation on x {
  running: labelText.needsScroll && !root.popupOpen && !root.bar.vertical
  loops: Animation.Infinite
  duration: Math.max(6000, labelText.implicitWidth * 25)
  from: scrollClip.width
  to: -labelText.implicitWidth
}
```

`running` stays `true` for as long as a scrollable title is playing, so the animation is never restarted and never re-reads those bindings. Every subsequent track replays the geometry of whichever track was playing when it first started:

- a longer title scrolls through only a fraction of its width and reads as frozen;
- when a short title flips `needsScroll` off, `x` is left wherever it stopped, which strands the label outside the clip and blanks the widget.

### Fix

Drive `x` from an explicit animation that is stopped, rewound to `0` and started again whenever the label text or the available width changes, and render a second copy of the label after the first so the infinite loop reads as a continuous ribbon rather than a hard cut back to the start.

The scroll rate is preserved. It is worth noting it was never the 25 ms/px the coefficient suggests: `from` started at `scrollClip.width`, so the label travelled `scrollClip.width + implicitWidth` while `duration` was derived from `implicitWidth` alone, which works out to 47-70 px/s across the usable range of title widths rather than a flat 40. The second commit scales that distance/duration ratio onto the cycle this animation travels, so the pace matches the old one at every title width.

### Before / after

`BEFORE` is today's code, `AFTER` is this patch, both fed the same title and switched to a new track every 5s. The before row goes blank or pins the title against the right edge; the after row keeps scrolling across every change.

![marquee before and after](https://raw.githubusercontent.com/vinispg/omarchy/media-marquee-assets/marquee-before-after.gif)

### Reproducing

1. Put `omarchy.media` in the bar and play something whose `title · artist` is wider than the 180px label.
2. Let it scroll, then skip to a track with a noticeably longer or shorter title.
3. The marquee no longer covers the new title.

### Verification

- Verified in the running shell on Omarchy 4.0.1 (Hyprland, dual monitor) with Spotify, across several track changes; the marquee restarts cleanly on every one and the loop seam is not visible.
- `./test/all` shows no new failures. `test/shell.d/{config,runtime-smoke,snapper,theme-install-guards,unowned-system-paths}-test.sh` already fail on a pristine checkout of `quattro` in this environment (`runtime-smoke` collides with the session's own running shell over the polkit agent and the portal registration), and this patch does not change that set.
