### PR TITLE
Show notification dismiss button without hover

### DIFF
--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -154,7 +154,7 @@ BorderSurface {
       ColumnLayout {
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignVCenter
-        // Keep the first line clear of the hover-revealed close button.
+        // Keep the first line clear of the close button.
         Layout.rightMargin: Style.space(10)
         spacing: Style.space(2)
 
@@ -188,7 +188,7 @@ BorderSurface {
     }
   }
 
-  // Hover-revealed close. Stacked after mainColumn so its MouseArea sits
+  // Always-visible close. Stacked after mainColumn so its MouseArea sits
   // above the full-card one and the click never reaches cardClicked.
   Item {
     anchors.top: parent.top
@@ -197,11 +197,6 @@ BorderSurface {
     anchors.rightMargin: root.borderRight + Style.space(3)
     width: Style.space(18)
     height: Style.space(18)
-    visible: opacity > 0
-    opacity: root.hovered ? 1 : 0
-
-    Behavior on opacity { NumberAnimation { duration: 100 } }
-
     Text {
       anchors.centerIn: parent
       text: "✕"

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -426,6 +426,15 @@ assert(!('exec' in legacyRestored), 'a restored legacy popup drops the old exec 
 assertEqual(notifications.parseExecArgv(legacyRestored.execArgv || ''), null, 'a restored legacy popup has no runnable click action')
 
 const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/Service.qml'), 'utf8')
+const notificationCardQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/components/NotificationCard.qml'), 'utf8')
+assert(
+  /Always-visible close[\s\S]{0,700}?text: "✕"[\s\S]{0,300}?onClicked: root\.closeRequested\(\)/.test(notificationCardQml),
+  'notifications show a close button that dismisses the popup'
+)
+assert(
+  !/opacity: root\.hovered/.test(notificationCardQml),
+  'notifications do not hide the close button until hover'
+)
 assert(
   /readonly property int historyLimit: 10/.test(serviceQml),
   'notifications service keeps the last ten notifications in history'


### PR DESCRIPTION
## Summary

- keep the notification close control visible without requiring hover
- preserve the existing automatic notification timeouts and click behavior
- cover the always-visible close control with the notification shell test

Fixes #7711.

## Testing

- `bash test/shell.d/notifications-test.sh`
