### PR TITLE
Install system-sleep hooks executable

### DIFF
--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -89,7 +89,7 @@ echo "Adding resume hook to $MKINITCPIO_CONF"
 echo "HOOKS+=(resume)" | sudo tee "$MKINITCPIO_CONF" >/dev/null
 
 # Ensure keyboard backlight doesn't prevent sleep
-sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
+sudo install -m755 "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
 
 # Add resume= kernel parameters so the initramfs resume hook knows where to find the
 # hibernation image. Without these, resume happens late (after GPU drivers load) and fails.

--- a/bin/omarchy-toggle-hybrid-gpu
+++ b/bin/omarchy-toggle-hybrid-gpu
@@ -60,7 +60,7 @@ case "$gpu_mode" in
 
     # Force igpu mode after system sleep (or dgpu could get activated)
     sudo mkdir -p /usr/lib/systemd/system-sleep
-    sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/force-igpu" /usr/lib/systemd/system-sleep/
+    sudo install -m755 "$OMARCHY_PATH/default/systemd/system-sleep/force-igpu" /usr/lib/systemd/system-sleep/
 
     # Delay supergfxd startup to avoid race condition with display manager
     # that can cause system freeze when booting in Integrated mode


### PR DESCRIPTION
`systemd-sleep` runs only **executables** in `/usr/lib/systemd/system-sleep/`:

> Immediately before entering system suspend and/or hibernation ... will run all
> executables in /usr/lib/systemd/system-sleep/

Both hooks that Omarchy copies there use `cp -p`, and their sources are tracked at
mode `100644`. They arrive non-executable, so they never run.

## Reproduce

On any install that has run `omarchy-hibernation-setup`:

```console
$ stat -c %A /usr/lib/systemd/system-sleep/keyboard-backlight
-rw-r--r--
$ stat -c %A /usr/lib/systemd/system-sleep/unmount-fuse
-rwxr-xr-x
```

`unmount-fuse` is executable only because it ships via the package
(`omarchy-upgrade-to-quattro --overwrite`) instead of a script copy.

## Affected hooks

- `bin/omarchy-hibernation-setup:92` -> `keyboard-backlight`
  ("Turn off keyboard backlight before hibernate to prevent hang on power-off")
- `bin/omarchy-toggle-hybrid-gpu:63` -> `force-igpu`
  ("Without this, hibernate resume fails because the nvidia driver can't freeze a
  powered-off dGPU (returns -EIO), which aborts the entire resume")

The `delay-start.conf` copy alongside `force-igpu` is a systemd drop-in, not an
executable, so it is left unchanged.

## Fix

Use `install -m755` instead of `cp -p`, setting the mode at the destination
regardless of how the source is tracked. Marking the files in
`default/systemd/system-sleep/` executable in git would also work; I chose
`install` so the scripts don't depend on the tracked mode.

## Verified

```
source         -rw-r--r--
cp -p          -rw-r--r--
install -m755  -rwxr-xr-x
```

Both scripts pass `bash -n`.

Found while debugging an unrelated hibernation failure on a GA403UV; I have not
tested the `force-igpu` path, as this machine has no dGPU. The mode problem is
identical at both call sites.
