### PR TITLE
Handle unset OMARCHY_PATH in update-dev

### DIFF
--- a/bin/omarchy-update-dev
+++ b/bin/omarchy-update-dev
@@ -3,6 +3,7 @@
 # omarchy:summary=Update the active Omarchy dev checkout
 
 set -euo pipefail
+: "${OMARCHY_PATH:=/usr/share/omarchy}"
 
 [[ $OMARCHY_PATH != "/usr/share/omarchy" ]] || exit 0
 

--- a/test/shell.d/update-dev-test.sh
+++ b/test/shell.d/update-dev-test.sh
@@ -53,10 +53,26 @@ run_dev_update() {
     "$ROOT/bin/omarchy-update-dev"
 }
 
+run_dev_update_without_path() {
+  env -u OMARCHY_PATH \
+    TEST_GIT_LOG="$git_log" \
+    PATH="$stub_bin:$PATH" \
+    "$ROOT/bin/omarchy-update-dev"
+}
+
 : >"$git_log"
 run_dev_update /usr/share/omarchy
 [[ ! -s $git_log ]] || fail "package-backed updates do not invoke git" "$(cat "$git_log")"
 pass "package-backed updates skip the dev checkout step"
+
+: >"$git_log"
+if run_dev_update_without_path; then
+  :
+else
+  fail "package-backed updates default when OMARCHY_PATH is unset"
+fi
+[[ ! -s $git_log ]] || fail "unset path updates do not invoke git" "$(cat "$git_log")"
+pass "package-backed updates default when OMARCHY_PATH is unset"
 
 : >"$git_log"
 run_dev_update "$checkout"


### PR DESCRIPTION
Fixes #8369
Fixes #8239

## Summary

- Default `OMARCHY_PATH` to `/usr/share/omarchy` in `omarchy-update-dev`.
- Add regression coverage for running the helper with `OMARCHY_PATH` unset.

## Problem

`omarchy update` can invoke `omarchy-update-dev` from an environment where `OMARCHY_PATH` is not exported, including privileged or non-login SSH contexts.

The helper runs with `set -euo pipefail` and directly evaluates `$OMARCHY_PATH` before deciding whether the installation is package-backed:

```bash
[[ $OMARCHY_PATH != "/usr/share/omarchy" ]] || exit 0
```

When `OMARCHY_PATH` is unset, Bash exits with:

```text
omarchy-update-dev: line 7: OMARCHY_PATH: unbound variable
```

This aborts an otherwise valid package-backed update before the system package transaction runs.

## Fix

Initialize the default package-backed path immediately after enabling strict shell options:

```bash
: "${OMARCHY_PATH:=/usr/share/omarchy}"
```

This is an established Omarchy environment pattern already used in:

- `default/bash/rc`
- `default/bash/env-bootstrap`
- `bin/omarchy-migrate`
- `bin/omarchy-version`

The fallback preserves the existing behavior:

- Package-backed installations default to `/usr/share/omarchy` and skip the dev-checkout update.
- Dev-linked installations continue using their configured checkout path.
- Existing invalid-checkout and no-upstream handling is unchanged.

The fallback is local to `omarchy-update-dev` because the command can be executed standalone from contexts that do not source Omarchy's shell environment bootstrap, or where `sudo` has filtered the variable.

## Testing

Passed:

- `bash test/shell.d/update-dev-test.sh`
- `./test/cli`
- `bash -n bin/omarchy-update-dev test/shell.d/update-dev-test.sh`
- `git diff --check`
- `env -u OMARCHY_PATH ./bin/omarchy-update-dev`

The regression test fails with the reported unbound-variable error before the fix and passes after the fallback is added.