### PR TITLE
Use separate idle timeouts on AC and battery

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -2,7 +2,11 @@
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "ac": {
+      "screensaver": 300,
+      "lock": 1800
+    }
   },
   "bar": {
     "position": "top",

--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -289,6 +289,7 @@ This skill intentionally does not cover Omarchy source development. Do not use t
 - "Run a script every time I change themes" -> Install it with `omarchy hook install theme-set <script>`
 - "Change how workspace labels are rendered" -> Clone `omarchy.workspaces`, which switches the bar to `<username>.workspaces`, then edit the clone
 - "Lock after ten minutes" -> Set `idle.lock` to `600` in `~/.config/omarchy/shell.json`
+- "Longer idle timeouts when plugged in" -> Set `idle.ac.screensaver` and `idle.ac.lock` in `~/.config/omarchy/shell.json`; battery keeps `idle.screensaver` / `idle.lock`
 - "Reset shell/bar to defaults" -> `omarchy refresh shell`
 - "Record my screen" -> `omarchy screenrecord --fullscreen`, then `omarchy screenrecord --stop-recording` (see `capture.md`)
 - "Report this bug to Omarchy" -> Gather diagnostics and a capture of the problem, then file it (see `contributing.md`)

--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -14,6 +14,8 @@ $OMARCHY_PATH/config/omarchy/shell.json  # Canonical defaults
 
 The shell hot-reloads `shell.json` on save — no restart needed for layout
 changes. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+Optional `idle.ac` and `idle.battery` objects override those numbers while on
+AC or battery.
 
 **Commands:** `omarchy restart shell`, `omarchy refresh shell`
 
@@ -49,4 +51,5 @@ automatically. If a change somehow fails to apply, force a reload with
 
 Set `idle.screensaver` and `idle.lock` in `~/.config/omarchy/shell.json`,
 in seconds since user idle began. Example: "lock after ten minutes" means
-setting `idle.lock` to `600`.
+setting `idle.lock` to `600`. For a docked laptop, put the longer pair under
+`idle.ac` and leave the top-level values as the battery timings.

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -136,7 +136,11 @@ string on a miss.
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "ac": {
+      "screensaver": 300,
+      "lock": 1800
+    }
   },
   "bar": {
     "id": "omarchy.bar",
@@ -168,7 +172,7 @@ Rules:
 5. Third-party enabled ⇔ present; for full bar options that means `bar.id`.
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
-7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+7. `idle.screensaver` and `idle.lock` are seconds since user idle began. Optional `idle.ac` and `idle.battery` objects override those numbers while on AC or battery.
 8. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no

--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -131,4 +131,4 @@ Every widget is one entry in one of the three layout arrays, and its settings si
 
 One rule worth internalizing: **once you have your own `shell.json`, it's canonical**. Until you customize anything, the shell reads Omarchy's default file. The moment you drag a widget, run `omarchy bar`, or edit the file yourself, you own it — there's no deep merge, so new default widgets in future Omarchy releases won't appear on your bar automatically. `omarchy bar defaults` puts the shipped layout back whenever you want a clean slate.
 
-The same file also holds your idle timings at the top level, outside the `bar` key: `idle.screensaver` and `idle.lock`, both in seconds since you went idle. So the default screensaver kicks in at 150 seconds and the lock at 300.
+The same file also holds your idle timings at the top level, outside the `bar` key: `idle.screensaver` and `idle.lock`, both in seconds since you went idle. Optional `idle.ac` and `idle.battery` objects override those numbers by power source. On battery the default screensaver kicks in at 150 seconds and the lock at 300; on AC those stretch to 300 and 1800.

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -71,12 +71,16 @@ The Omarchy shell owns idle behavior, and the timings are a top-level `idle` blo
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "ac": {
+      "screensaver": 300,
+      "lock": 1800
+    }
   }
 }
 ```
 
-Both numbers are seconds counted from the moment you went idle — not from each other. So with the defaults, the screensaver comes up after two and a half minutes and the lock screen takes over at five minutes, whether or not the screensaver ran. Save the file and the shell picks up the new timings right away.
+Both numbers are seconds counted from the moment you went idle — not from each other. So with the defaults, on battery the screensaver comes up after two and a half minutes and the lock screen takes over at five minutes, whether or not the screensaver ran. Optional `ac` and `battery` objects override those numbers while you're plugged in or running on battery; omitted keys fall back to the top-level pair. The shipped config keeps 150/300 for battery and stretches AC to five minutes of screensaver and thirty minutes before lock — long enough for a docked laptop, short enough that an unplugged one still sleeps promptly. Save the file and the shell picks up the new timings right away.
 
 If you dismiss the screensaver before the lock deadline, that counts as activity and the pending lock is cancelled. You don't get locked out for glancing at your machine.
 

--- a/migrations/1787841800.sh
+++ b/migrations/1787841800.sh
@@ -1,0 +1,28 @@
+echo "Add longer idle timeouts for AC power"
+
+# Existing shell.json files are canonical and are not deep-merged with new
+# defaults. Users still on the stock 150/300 pair get the shipped AC profile
+# (5 min screensaver, 30 min lock). Anyone who already changed idle timings,
+# or already set idle.ac, is left alone.
+
+config_file="$HOME/.config/omarchy/shell.json"
+
+[[ -s $config_file ]] || exit 0
+omarchy-cmd-present jq || exit 0
+jq -e . "$config_file" >/dev/null 2>&1 || exit 0
+
+if ! jq -e '
+  (.idle | type == "object" or .idle == null) and
+  ((.idle // {}) | has("ac") | not) and
+  ((.idle.screensaver // 150) == 150) and
+  ((.idle.lock // 300) == 300)
+' "$config_file" >/dev/null; then
+  exit 0
+fi
+
+tmp=$(mktemp)
+jq '
+  .idle = ((.idle // { screensaver: 150, lock: 300 }) + {
+    ac: { screensaver: 300, lock: 1800 }
+  })
+' "$config_file" >"$tmp" && mv "$tmp" "$config_file" || rm -f "$tmp"

--- a/shell/README.md
+++ b/shell/README.md
@@ -232,7 +232,11 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "ac": {
+      "screensaver": 300,
+      "lock": 1800
+    }
   },
   "bar": {
     "id": "omarchy.bar",
@@ -276,7 +280,9 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    entries with their own values.
 7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
    are seconds since user idle began, so the default lock fires at 300s
-   even if the 150s screensaver starts first.
+   even if the 150s screensaver starts first. Optional `idle.ac` and
+   `idle.battery` objects override those numbers while on AC or battery;
+   omitted keys fall back to the top-level pair.
 8. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,7 +1,30 @@
 function secondsFromConfig(value, fallback) {
-  var n = Number(value)
+  var n
+  if (typeof value === "number") n = value
+  else if (typeof value === "string" && value.trim() !== "") n = Number(value)
+  else return fallback
   if (!isFinite(n) || n < 0) return fallback
   return Math.floor(n)
+}
+
+function profileBlock(idleConfig, name) {
+  var block = idleConfig && idleConfig[name]
+  if (!block || typeof block !== "object" || Array.isArray(block)) return null
+  return block
+}
+
+function effectiveTimeouts(idleConfig, onBattery, defaults) {
+  var config = idleConfig && typeof idleConfig === "object" ? idleConfig : {}
+  var fallbackScreensaver = secondsFromConfig(config.screensaver, defaults && defaults.screensaver)
+  var fallbackLock = secondsFromConfig(config.lock, defaults && defaults.lock)
+  var profile = profileBlock(config, onBattery ? "battery" : "ac")
+  if (!profile) {
+    return { screensaver: fallbackScreensaver, lock: fallbackLock }
+  }
+  return {
+    screensaver: secondsFromConfig(profile.screensaver, fallbackScreensaver),
+    lock: secondsFromConfig(profile.lock, fallbackLock)
+  }
 }
 
 function eventParts(event, count) {
@@ -46,6 +69,8 @@ function screensaverWindowsAfter(windows, address, visible) {
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
+    profileBlock: profileBlock,
+    effectiveTimeouts: effectiveTimeouts,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter
   }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Hyprland
 import Quickshell.Io
+import Quickshell.Services.UPower
 import Quickshell.Wayland
 import "IdleModel.js" as IdleModel
 
@@ -17,8 +18,12 @@ Item {
   readonly property int defaultScreensaverSeconds: 150
   readonly property int defaultLockSeconds: 300
   readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
-  readonly property int screensaverTimeoutSeconds: secondsFromConfig(idleConfig.screensaver, defaultScreensaverSeconds)
-  readonly property int lockTimeoutSeconds: secondsFromConfig(idleConfig.lock, defaultLockSeconds)
+  readonly property var resolvedTimeouts: IdleModel.effectiveTimeouts(idleConfig, UPower.onBattery, {
+    screensaver: defaultScreensaverSeconds,
+    lock: defaultLockSeconds
+  })
+  readonly property int screensaverTimeoutSeconds: resolvedTimeouts.screensaver
+  readonly property int lockTimeoutSeconds: resolvedTimeouts.lock
   readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
   readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
@@ -27,6 +32,8 @@ Item {
 
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
+  property bool monitorArmed: true
+  property bool timeoutsReady: false
   property bool hasPendingStayAwakePersist: false
   property bool pendingStayAwakePersist: false
   property bool idledThisCycle: false
@@ -39,6 +46,22 @@ Item {
   function secondsFromConfig(value, fallback) {
     return IdleModel.secondsFromConfig(value, fallback)
   }
+
+  function handleIdleTimeoutsChanged() {
+    if (!root.timeoutsReady) return
+
+    logEvent("idle-timeout-rearm", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds + " power=" + (UPower.onBattery ? "battery" : "ac"))
+    if (root.idledThisCycle) root.cancelIdleCycle("timeout-change")
+    if (!root.idleEnabled) return
+
+    // ext-idle-notify keeps the old timeout until the monitor is disabled and
+    // re-enabled. Plug/unplug and a shell.json edit both change the deadline.
+    root.monitorArmed = false
+    Qt.callLater(function() { root.monitorArmed = true })
+  }
+
+  onScreensaverTimeoutSecondsChanged: root.handleIdleTimeoutsChanged()
+  onLockTimeoutSecondsChanged: root.handleIdleTimeoutsChanged()
 
   function nowIso() {
     return new Date().toISOString()
@@ -185,6 +208,8 @@ Item {
       stayAwakeStatePath: root.stayAwakeStatePath,
       idle: idleMonitor.isIdle,
       inIdleCycle: root.idledThisCycle,
+      onBattery: UPower.onBattery,
+      powerSource: UPower.onBattery ? "battery" : "ac",
       screensaverStarted: root.screensaverStartedThisCycle,
       screensaver: root.screensaverTimeoutSeconds,
       lock: root.lockTimeoutSeconds,
@@ -249,7 +274,7 @@ Item {
 
   IdleMonitor {
     id: idleMonitor
-    enabled: root.idleEnabled
+    enabled: root.idleEnabled && root.monitorArmed
     timeout: root.firstIdleTimeoutSeconds
     respectInhibitors: true
     onIsIdleChanged: root.handleIdleChanged()
@@ -332,6 +357,7 @@ Item {
   Component.onCompleted: {
     logEvent("service-ready")
     refreshStayAwakeState()
+    root.timeoutsReady = true
   }
 
   IpcHandler {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -37,7 +37,11 @@ ShellRoot {
     version: 1,
     idle: {
       screensaver: 150,
-      lock: 300
+      lock: 300,
+      ac: {
+        screensaver: 300,
+        lock: 1800
+      }
     },
     bar: {
       position: "top",

--- a/test/shell.d/idle-ac-timeout-migration-test.sh
+++ b/test/shell.d/idle-ac-timeout-migration-test.sh
@@ -16,7 +16,7 @@ home="$test_dir/home"
 config="$home/.config/omarchy/shell.json"
 
 run_migration() {
-  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+  HOME="$home" PATH="$ROOT/bin:$PATH" bash -euo pipefail "$migration" >/dev/null
 }
 
 write_config() {

--- a/test/shell.d/idle-ac-timeout-migration-test.sh
+++ b/test/shell.d/idle-ac-timeout-migration-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+
+migration="$ROOT/migrations/1787841800.sh"
+[[ -f $migration ]] || fail "idle AC timeout migration exists"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+config="$home/.config/omarchy/shell.json"
+
+run_migration() {
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+write_config() {
+  rm -rf "$home"
+  mkdir -p "$home/.config/omarchy"
+  printf '%s\n' "$1" >"$config"
+}
+
+jq -e '.idle.ac.screensaver == 300 and .idle.ac.lock == 1800' "$ROOT/config/omarchy/shell.json" >/dev/null ||
+  fail "shipped config includes the AC idle profile"
+pass "shipped config includes the AC idle profile"
+
+write_config '{"version":1,"idle":{"screensaver":150,"lock":300},"plugins":[]}'
+run_migration
+jq -e '.idle.screensaver == 150 and .idle.lock == 300 and .idle.ac.screensaver == 300 and .idle.ac.lock == 1800' "$config" >/dev/null ||
+  fail "migration adds the AC profile to stock idle timings" "$(cat "$config")"
+pass "migration adds the AC profile to stock idle timings"
+
+before=$(sha256sum "$config")
+run_migration
+[[ $before == $(sha256sum "$config") ]] || fail "migration is idempotent" "$(cat "$config")"
+pass "migration is idempotent"
+
+write_config '{"version":1,"idle":{"screensaver":150,"lock":300,"ac":{"screensaver":600,"lock":900}}}'
+run_migration
+jq -e '.idle.ac.screensaver == 600 and .idle.ac.lock == 900' "$config" >/dev/null ||
+  fail "migration leaves an existing AC profile alone" "$(cat "$config")"
+pass "migration leaves an existing AC profile alone"
+
+write_config '{"version":1,"idle":{"screensaver":600,"lock":900}}'
+run_migration
+jq -e '.idle.screensaver == 600 and .idle.lock == 900 and (.idle.ac | not)' "$config" >/dev/null ||
+  fail "migration leaves customized idle timings alone" "$(cat "$config")"
+pass "migration leaves customized idle timings alone"
+
+write_config '{"version":1,"plugins":[]}'
+run_migration
+jq -e '.idle.ac.screensaver == 300 and .idle.ac.lock == 1800' "$config" >/dev/null ||
+  fail "migration adds AC timeouts when idle is omitted" "$(cat "$config")"
+pass "migration adds AC timeouts when idle is omitted"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -10,6 +10,42 @@ const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
+assertEqual(idle.secondsFromConfig(null, 10), 10, 'idle rejects null seconds')
+
+const defaults = { screensaver: 150, lock: 300 }
+const stock = { screensaver: 150, lock: 300, ac: { screensaver: 300, lock: 1800 } }
+
+assertDeepEqual(
+  idle.effectiveTimeouts(stock, false, defaults),
+  { screensaver: 300, lock: 1800 },
+  'idle uses the ac profile while plugged in'
+)
+assertDeepEqual(
+  idle.effectiveTimeouts(stock, true, defaults),
+  { screensaver: 150, lock: 300 },
+  'idle keeps the top-level pair on battery when no battery profile is set'
+)
+assertDeepEqual(
+  idle.effectiveTimeouts({ screensaver: 150, lock: 300, battery: { screensaver: 60, lock: 90 } }, true, defaults),
+  { screensaver: 60, lock: 90 },
+  'idle uses the battery profile while on battery'
+)
+assertDeepEqual(
+  idle.effectiveTimeouts({ screensaver: 150, lock: 300, ac: { lock: 1800 } }, false, defaults),
+  { screensaver: 150, lock: 1800 },
+  'idle falls back per-key when an ac override omits screensaver'
+)
+assertDeepEqual(
+  idle.effectiveTimeouts({ screensaver: 150, lock: 300, ac: { screensaver: 'nope', lock: -1 } }, false, defaults),
+  { screensaver: 150, lock: 300 },
+  'idle rejects invalid ac overrides'
+)
+assertDeepEqual(
+  idle.effectiveTimeouts(null, false, defaults),
+  { screensaver: 150, lock: 300 },
+  'idle uses builtin defaults without an idle config'
+)
+assertEqual(idle.profileBlock({ ac: [300] }, 'ac'), null, 'idle ignores a non-object power profile')
 
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(
@@ -52,3 +88,11 @@ if rg -q 'omarchy-shell' "$ROOT/bin/omarchy-toggle-idle"; then
 fi
 
 pass "Stay Awake toggle persists state without reentrant shell IPC"
+
+rg -q 'Quickshell.Services.UPower' "$ROOT/shell/plugins/services/idle/Service.qml" ||
+  fail "idle service reads the power source from UPower"
+rg -q 'IdleModel.effectiveTimeouts' "$ROOT/shell/plugins/services/idle/Service.qml" ||
+  fail "idle service resolves timeouts through IdleModel.effectiveTimeouts"
+rg -q 'monitorArmed' "$ROOT/shell/plugins/services/idle/Service.qml" ||
+  fail "idle service re-arms the idle monitor when timeouts change"
+pass "idle service selects timeouts by power source and re-arms on change"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -89,10 +89,29 @@ fi
 
 pass "Stay Awake toggle persists state without reentrant shell IPC"
 
-rg -q 'Quickshell.Services.UPower' "$ROOT/shell/plugins/services/idle/Service.qml" ||
-  fail "idle service reads the power source from UPower"
-rg -q 'IdleModel.effectiveTimeouts' "$ROOT/shell/plugins/services/idle/Service.qml" ||
-  fail "idle service resolves timeouts through IdleModel.effectiveTimeouts"
-rg -q 'monitorArmed' "$ROOT/shell/plugins/services/idle/Service.qml" ||
-  fail "idle service re-arms the idle monitor when timeouts change"
-pass "idle service selects timeouts by power source and re-arms on change"
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/services/idle/Service.qml'), 'utf8')
+
+assert(
+  /import Quickshell\.Services\.UPower/.test(serviceQml),
+  'idle service reads the power source from UPower'
+)
+assert(
+  /IdleModel\.effectiveTimeouts\(idleConfig, UPower\.onBattery/.test(serviceQml),
+  'idle service resolves timeouts through IdleModel.effectiveTimeouts'
+)
+assert(
+  /IdleMonitor \{[\s\S]*?enabled:\s*root\.idleEnabled && root\.monitorArmed/.test(serviceQml),
+  'IdleMonitor.enabled is gated on monitorArmed'
+)
+assert(
+  /onScreensaverTimeoutSecondsChanged:\s*root\.handleIdleTimeoutsChanged\(\)/.test(serviceQml) &&
+    /onLockTimeoutSecondsChanged:\s*root\.handleIdleTimeoutsChanged\(\)/.test(serviceQml),
+  'timeout changes invoke the idle-monitor re-arm'
+)
+assert(
+  /root\.monitorArmed = false[\s\S]*?Qt\.callLater\(function\(\) \{ root\.monitorArmed = true \}\)/.test(serviceQml),
+  're-arm disables the monitor and enables it again on the next tick'
+)
+JS


### PR DESCRIPTION
## Summary

Implements the Quickshell-era version of https://github.com/basecamp/omarchy/discussions/6239.

Idle currently has one screensaver/lock pair for every power source. That is the right default on battery and too aggressive on a docked laptop. This keeps the stock 150/300 pair as the battery (and fallback) timings, and lets `idle.ac` / `idle.battery` override them from the same UPower signal `omarchy.battery` already uses.

```json
"idle": {
  "screensaver": 150,
  "lock": 300,
  "ac": {
    "screensaver": 300,
    "lock": 1800
  }
}
```

The idle service reads the active pair in place. It does not rewrite `screensaver` / `lock` on plug/unplug.

This is different deadlines, not different actions. Skipping the screensaver on battery and only blanking (the original hypridle sketch in #6239) is still possible as a follow-up; this PR is the timeout split docked-laptop users actually need.

## Defaults

- Battery / no profile: screensaver 150, lock 300 (unchanged)
- AC: screensaver 300 (5 min), lock 1800 (30 min)
- Desktops have no battery, so they get the AC pair
- Anyone who already changed `idle.screensaver` / `idle.lock`, or already set `idle.ac`, is left alone
- A migration adds the AC profile only to configs still on the stock 150/300 pair

## Also

Changing the active timeouts re-arms `IdleMonitor`. ext-idle-notify keeps the old deadline until the monitor is disabled and enabled again, so without this a plug/unplug (or a `shell.json` edit) would leave idle detection dead. That is the same class of bug as #8038 / #8086.

## Test plan

- [x] `test/shell.d/idle-test.sh` — profile selection, invalid overrides, per-key fallback
- [x] `test/shell.d/idle-ac-timeout-migration-test.sh` — stock configs get AC defaults; customized configs do not
- [x] `./test/all` — CLI suite green; shell suite green except pre-existing env skips on this machine (`omarchy-pkgs` checkout, theme-install URL check, about-window animation)

Live check after merge: `omarchy-shell idle status` should report `powerSource` and the effective `screensaver` / `lock` for the current power source. Unplugging should switch the numbers and keep `idle-monitor: idle` lines coming in the journal.