### PR TITLE
Preserve alacritty font styles when changing font family

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -27,7 +27,7 @@ if ! fc-list | grep -Fqi -- "$font_name"; then
 fi
 
 if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
-  sed -i "s/family = \".*\"/family = \"$font_name\"/g" ~/.config/alacritty/alacritty.toml
+  sed -i "s/family = \"[^\"]*\"/family = \"$font_name\"/g" ~/.config/alacritty/alacritty.toml
 fi
 
 if [[ -f ~/.config/kitty/kitty.conf ]]; then

--- a/test/cli
+++ b/test/cli
@@ -253,11 +253,13 @@ pass "safe dispatch works for font current"
 # the closing quote to the end of the line, deleting all three.
 make_tmpdir FONT_STYLE_TMPDIR
 mkdir -p "$FONT_STYLE_TMPDIR/.config/alacritty"
+# The starting family is a sentinel no fontconfig can resolve, so the family
+# assertion below can only pass if the file was actually rewritten.
 cat >"$FONT_STYLE_TMPDIR/.config/alacritty/alacritty.toml" <<'EOF'
 [font]
-normal = { family = "JetBrainsMono Nerd Font", style = "Regular" }
-bold = { family = "JetBrainsMono Nerd Font", style = "Bold" }
-italic = { family = "JetBrainsMono Nerd Font", style = "Italic" }
+normal = { family = "Sentinel Mono Unset", style = "Regular" }
+bold = { family = "Sentinel Mono Unset", style = "Bold" }
+italic = { family = "Sentinel Mono Unset", style = "Italic" }
 size = 9
 EOF
 
@@ -268,7 +270,20 @@ if [[ -z $FONT_STYLE_FAMILY ]]; then
   fail "fontconfig has no resolvable monospace family for the alacritty style test"
 fi
 
-HOME="$FONT_STYLE_TMPDIR" "$ROOT/bin/omarchy-font-set" "$FONT_STYLE_FAMILY" >/dev/null 2>&1 || true
+# omarchy-font-set ends by restarting the shell, notifying, and firing the
+# font-set hook. Stub those so the test never touches the live desktop, and so
+# the command's own exit status can be checked.
+FONT_STYLE_BIN="$FONT_STYLE_TMPDIR/fake-bin"
+mkdir -p "$FONT_STYLE_BIN"
+for cmd in omarchy-restart-shell omarchy-notification-send omarchy-hook; do
+  printf '#!/bin/bash\nexit 0\n' >"$FONT_STYLE_BIN/$cmd"
+  chmod +x "$FONT_STYLE_BIN/$cmd"
+done
+printf '#!/bin/bash\nexit 1\n' >"$FONT_STYLE_BIN/pgrep"
+chmod +x "$FONT_STYLE_BIN/pgrep"
+
+PATH="$FONT_STYLE_BIN:$ROOT/bin:$PATH" HOME="$FONT_STYLE_TMPDIR" "$ROOT/bin/omarchy-font-set" "$FONT_STYLE_FAMILY" >/dev/null
+pass "font set exits cleanly with stubbed downstream commands"
 
 for style in Regular Bold Italic; do
   if ! grep -q "style = \"$style\"" "$FONT_STYLE_TMPDIR/.config/alacritty/alacritty.toml"; then
@@ -278,10 +293,14 @@ for style in Regular Bold Italic; do
 done
 pass "font set preserves alacritty font styles"
 
-if ! grep -q "family = \"$FONT_STYLE_FAMILY\"" "$FONT_STYLE_TMPDIR/.config/alacritty/alacritty.toml"; then
-  fail "font set still replaces the alacritty family"
+# All three entries (normal, bold, italic) must carry the new family; a
+# regression that rewrote only the first line would otherwise pass.
+FONT_STYLE_COUNT=$(grep -cF "family = \"$FONT_STYLE_FAMILY\"" "$FONT_STYLE_TMPDIR/.config/alacritty/alacritty.toml")
+if (( FONT_STYLE_COUNT != 3 )); then
+  printf 'Actual alacritty.toml:\n%s\n' "$(cat "$FONT_STYLE_TMPDIR/.config/alacritty/alacritty.toml")" >&2
+  fail "font set replaces all three alacritty family entries (found $FONT_STYLE_COUNT)"
 fi
-pass "font set still replaces the alacritty family"
+pass "font set replaces all three alacritty family entries"
 
 make_tmpdir PI_TMPDIR
 NEXT_THEME="$PI_TMPDIR/.local/state/omarchy/current/next-theme"

--- a/test/cli
+++ b/test/cli
@@ -247,6 +247,42 @@ pass "safe dispatch works for font list"
 "$CLI" font current >/dev/null
 pass "safe dispatch works for font current"
 
+# omarchy-font-set must swap only the family and leave the rest of alacritty's
+# font table alone. The shipped config/alacritty/alacritty.toml carries
+# style = "Regular"/"Bold"/"Italic", and a greedy `family = ".*"` match ran past
+# the closing quote to the end of the line, deleting all three.
+make_tmpdir FONT_STYLE_TMPDIR
+mkdir -p "$FONT_STYLE_TMPDIR/.config/alacritty"
+cat >"$FONT_STYLE_TMPDIR/.config/alacritty/alacritty.toml" <<'EOF'
+[font]
+normal = { family = "JetBrainsMono Nerd Font", style = "Regular" }
+bold = { family = "JetBrainsMono Nerd Font", style = "Bold" }
+italic = { family = "JetBrainsMono Nerd Font", style = "Italic" }
+size = 9
+EOF
+
+# The family must be one fontconfig actually knows; omarchy-font-set rejects
+# anything else before it edits a single file.
+FONT_STYLE_FAMILY=$(fc-match -f '%{family[0]}\n' monospace | head -1)
+if [[ -z $FONT_STYLE_FAMILY ]]; then
+  fail "fontconfig has no resolvable monospace family for the alacritty style test"
+fi
+
+HOME="$FONT_STYLE_TMPDIR" "$ROOT/bin/omarchy-font-set" "$FONT_STYLE_FAMILY" >/dev/null 2>&1 || true
+
+for style in Regular Bold Italic; do
+  if ! grep -q "style = \"$style\"" "$FONT_STYLE_TMPDIR/.config/alacritty/alacritty.toml"; then
+    printf 'Actual alacritty.toml:\n%s\n' "$(cat "$FONT_STYLE_TMPDIR/.config/alacritty/alacritty.toml")" >&2
+    fail "font set preserves alacritty style = \"$style\""
+  fi
+done
+pass "font set preserves alacritty font styles"
+
+if ! grep -q "family = \"$FONT_STYLE_FAMILY\"" "$FONT_STYLE_TMPDIR/.config/alacritty/alacritty.toml"; then
+  fail "font set still replaces the alacritty family"
+fi
+pass "font set still replaces the alacritty family"
+
 make_tmpdir PI_TMPDIR
 NEXT_THEME="$PI_TMPDIR/.local/state/omarchy/current/next-theme"
 CURRENT_THEME="$PI_TMPDIR/.local/state/omarchy/current/theme"


### PR DESCRIPTION
`omarchy font set` deletes the `style` fields from `~/.config/alacritty/alacritty.toml`.

The family substitution matches greedily:

```bash
sed -i "s/family = \".*\"/family = \"$font_name\"/g" ~/.config/alacritty/alacritty.toml
```

`.*` runs past the closing quote to the last `"` on the line, so it consumes `", style = "Regular` along with the family. Omarchy's own `config/alacritty/alacritty.toml` sets those styles, so a stock install loses all three on the first font change and alacritty stops explicitly selecting the bold and italic faces.

### Reproduce

Against the shipped template:

```
BEFORE (config/alacritty/alacritty.toml)
  normal = { family = "JetBrainsMono Nerd Font", style = "Regular" }
  bold   = { family = "JetBrainsMono Nerd Font", style = "Bold" }
  italic = { family = "JetBrainsMono Nerd Font", style = "Italic" }

AFTER `omarchy font set "Liberation Mono"`
  normal = { family = "Liberation Mono" }
  bold   = { family = "Liberation Mono" }
  italic = { family = "Liberation Mono" }
```

### Fix

Match the quoted family with a negated character class so the substitution stops at the closing quote.

### Tests

Added a regression test to `test/cli` that writes the shipped font table into a temporary `HOME`, runs `omarchy-font-set`, and asserts all three styles survive while the family is still replaced. Verified it fails without the one-line fix and passes with it.

`./test/cli` passes (118 ok). `./test/all` shows 6 failures on my machine that are unrelated and present without this change too — they are environmental (multi-monitor widget counts, a missing `omarchy-pkgs` checkout, a network-dependent theme-install check).

### Related

#6957 / #6958 cover the foot font-size reset in this same script. Different line, no overlap with this change.
