### PR TITLE
Add window-relayout command to recover stuck web app layouts

### DIFF
--- a/bin/omarchy-hyprland-window-relayout
+++ b/bin/omarchy-hyprland-window-relayout
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# omarchy:summary=Nudge the focused window 1px and back to force a stuck web app or Electron window to recompute its layout
+
+set -euo pipefail
+
+# Chromium/Electron windows (including browser --app web apps) intermittently
+# fail to re-run their responsive layout after a Hyprland resize such as a
+# tiling split or fullscreen toggle, especially on HiDPI (scale 2) outputs. The
+# page keeps the wider desktop layout painted at the new narrow width, so the
+# content overflows (e.g. x.com shows the full labelled sidebar over the
+# timeline). This is an upstream Chromium/Electron-on-Wayland bug, not something
+# Hyprland or the compositor can fix from the outside.
+#
+# Resizing the window by a single pixel and back delivers a fresh configure that
+# the client processes as a real resize, so the web app recomputes its layout.
+# The net size change is zero. This works on any output regardless of scale.
+
+resize() {
+  hyprctl dispatch "hl.dsp.window.resize({ x = $1, y = 0, relative = true })" >/dev/null 2>&1 ||
+    hyprctl dispatch "resizeactive $1 0" >/dev/null
+}
+
+resize 1
+sleep 0.06
+resize -1

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -19,7 +19,7 @@ o.bind("SUPER + SHIFT + CTRL + SPACE", "Theme menu", "omarchy-menu toggle theme"
 o.bind("SUPER + BACKSPACE", "Toggle window transparency", "omarchy-hyprland-window-transparency-toggle")
 o.bind("SUPER + SHIFT + BACKSPACE", "Toggle window gaps", "omarchy-hyprland-window-gaps-toggle")
 o.bind("SUPER + CTRL + BACKSPACE", "Toggle single-window square aspect", "omarchy-hyprland-window-single-square-aspect-toggle")
-o.bind("SUPER + SHIFT + R", "Fix stuck window layout", "omarchy-hyprland-window-relayout")
+o.bind("SUPER + ALT + BACKSPACE", "Fix stuck window layout", "omarchy-hyprland-window-relayout")
 
 -- xkbcommon names the comma keysym "comma"; the upper-case "COMMA" does not match.
 o.bind("SUPER + comma", "Dismiss last notification", "omarchy-shell notifications dismissOne")

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -19,6 +19,7 @@ o.bind("SUPER + SHIFT + CTRL + SPACE", "Theme menu", "omarchy-menu toggle theme"
 o.bind("SUPER + BACKSPACE", "Toggle window transparency", "omarchy-hyprland-window-transparency-toggle")
 o.bind("SUPER + SHIFT + BACKSPACE", "Toggle window gaps", "omarchy-hyprland-window-gaps-toggle")
 o.bind("SUPER + CTRL + BACKSPACE", "Toggle single-window square aspect", "omarchy-hyprland-window-single-square-aspect-toggle")
+o.bind("SUPER + SHIFT + R", "Fix stuck window layout", "omarchy-hyprland-window-relayout")
 
 -- xkbcommon names the comma keysym "comma"; the upper-case "COMMA" does not match.
 o.bind("SUPER + comma", "Dismiss last notification", "omarchy-shell notifications dismissOne")


### PR DESCRIPTION
## Problem

Chromium/Electron windows — browser `--app` web apps in particular — sometimes keep their old, wider responsive layout after a Hyprland resize such as a tiling split or a fullscreen toggle. The page stays in its desktop layout at the new narrow width, so content overflows the window. A common example is the x.com web app: after splitting it, the full labelled sidebar stays rendered on top of the timeline instead of collapsing to the icon rail.

This is an upstream Chromium/Electron-on-Wayland bug (missing relayout on some `xdg_toplevel.configure` sequences), most visible on HiDPI (`scale 2`) outputs. It cannot be fixed from the compositor side, and browser startup flags don't help because web apps hand off to an already-running browser process.

BEFORE:
<img width="1474" height="1872" alt="image" src="https://github.com/user-attachments/assets/fe792af2-6ecf-4a7e-a0c8-5810048ce1e4" />

AFTER:

<img width="1474" height="1872" alt="image" src="https://github.com/user-attachments/assets/61c7ccbe-8c63-43de-ab2d-dab4e0766e1c" />

## Fix

Add `omarchy-hyprland-window-relayout`, which nudges the focused window 1px and back. That delivers a fresh configure the client processes as a real resize, so the web app recomputes its layout. The net size change is zero and it works on any output regardless of scale.

Bound to **SUPER + SHIFT + R** ("Fix stuck window layout"). A keybind (rather than a plain command) is required because the fix targets the *focused* window — running it from a terminal would relayout the terminal.

## Testing

- `./test/cli` and the `bin-style` shell test pass.
- Reproduced the stuck layout with the x.com web app (make it full-width so the sidebar expands, then re-split it narrow) and confirmed the command recovers it. Before/after attached.
