### PR TITLE
Cycle backgrounds through a symlinked backgrounds directory

### DIFF
--- a/bin/omarchy-theme-bg-next
+++ b/bin/omarchy-theme-bg-next
@@ -8,10 +8,11 @@ THEME_BACKGROUNDS_PATH="$HOME/.local/state/omarchy/current/theme/backgrounds/"
 USER_BACKGROUNDS_PATH="$HOME/.config/omarchy/backgrounds/$THEME_NAME/"
 CURRENT_BACKGROUND_LINK="$HOME/.local/state/omarchy/current/background"
 
+# Resolve candidates, since the current background symlink stores a real path
 mapfile -d '' -t BACKGROUNDS < <(
   find -L "$USER_BACKGROUNDS_PATH" "$THEME_BACKGROUNDS_PATH" -maxdepth 1 -type f \
     \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' -o -iname '*.bmp' -o -iname '*.webp' \) \
-    -print0 2>/dev/null | sort -z
+    -print0 2>/dev/null | sort -z | xargs -0 -r realpath -z --
 )
 TOTAL=${#BACKGROUNDS[@]}
 
@@ -20,7 +21,7 @@ if (( TOTAL == 0 )); then
 else
   # Get current background from symlink
   if [[ -L $CURRENT_BACKGROUND_LINK ]]; then
-    CURRENT_BACKGROUND=$(readlink "$CURRENT_BACKGROUND_LINK")
+    CURRENT_BACKGROUND=$(readlink -f "$CURRENT_BACKGROUND_LINK")
   else
     # Default to first background if no symlink exists
     CURRENT_BACKGROUND=""

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -74,18 +74,19 @@ choose_theme_background() {
   local current_background index next_index i
 
   CHOSEN_THEME_BACKGROUND=""
+  # Resolve candidates, since the current background symlink stores a real path
   mapfile -d '' -t backgrounds < <(
     find -L "$HOME/.config/omarchy/backgrounds/$THEME_NAME/" "$CURRENT_THEME_PATH/backgrounds/" -maxdepth 1 -type f \
       \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' -o -iname '*.bmp' -o -iname '*.webp' \) \
-      -print0 2>/dev/null | sort -z
+      -print0 2>/dev/null | sort -z | xargs -0 -r realpath -z --
   )
 
   (( ${#backgrounds[@]} > 0 )) || return 1
 
-  current_background=$(readlink "$CURRENT_BACKGROUND_LINK" 2>/dev/null || true)
+  current_background=$(readlink -f "$CURRENT_BACKGROUND_LINK" 2>/dev/null || true)
   index=-1
   for i in "${!backgrounds[@]}"; do
-    if [[ ${backgrounds[$i]} == $current_background ]]; then
+    if [[ ${backgrounds[$i]} == "$current_background" ]]; then
       index=$i
       break
     fi

--- a/test/cli
+++ b/test/cli
@@ -519,6 +519,53 @@ expected_background="$THEME_TMPDIR/.local/state/omarchy/current/theme/background
 [[ ! -e $THEME_TMPDIR/.config/omarchy/current ]] || fail "headless theme set avoids config current state"
 pass "headless theme set creates current background symlink"
 
+make_tmpdir BG_TMPDIR
+BG_HOME="$BG_TMPDIR/home"
+BG_STUBS="$BG_TMPDIR/stubs"
+mkdir -p "$BG_HOME/.local/state/omarchy/current/theme/backgrounds" "$BG_HOME/.config/omarchy/backgrounds" "$BG_TMPDIR/walls" "$BG_STUBS"
+printf 'bg-cycle-test\n' >"$BG_HOME/.local/state/omarchy/current/theme.name"
+for background_name in a b c; do
+  printf 'x' >"$BG_TMPDIR/walls/$background_name.jpg"
+done
+printf '#!/bin/bash\nexit 0\n' >"$BG_STUBS/omarchy-shell"
+cp "$BG_STUBS/omarchy-shell" "$BG_STUBS/omarchy-notification-send"
+chmod +x "$BG_STUBS/omarchy-shell" "$BG_STUBS/omarchy-notification-send"
+
+cycle_backgrounds() {
+  local names=()
+  local i
+
+  for (( i = 0; i < 4; i++ )); do
+    PATH="$BG_STUBS:$ROOT/bin:$PATH" HOME="$BG_HOME" "$ROOT/bin/omarchy-theme-bg-next"
+    names+=("$(basename -- "$(readlink -f "$BG_HOME/.local/state/omarchy/current/background")")")
+  done
+
+  printf '%s' "${names[*]}"
+}
+
+ln -s "$BG_TMPDIR/walls" "$BG_HOME/.config/omarchy/backgrounds/bg-cycle-test"
+[[ $(cycle_backgrounds) == "a.jpg b.jpg c.jpg a.jpg" ]] || fail "background cycling advances through a symlinked backgrounds directory"
+pass "background cycling advances through a symlinked backgrounds directory"
+
+rm "$BG_HOME/.config/omarchy/backgrounds/bg-cycle-test" "$BG_HOME/.local/state/omarchy/current/background"
+cp -r "$BG_TMPDIR/walls" "$BG_HOME/.config/omarchy/backgrounds/bg-cycle-test"
+[[ $(cycle_backgrounds) == "a.jpg b.jpg c.jpg a.jpg" ]] || fail "background cycling advances through a real backgrounds directory"
+pass "background cycling advances through a real backgrounds directory"
+
+make_tmpdir BG_THEME_TMPDIR
+mkdir -p "$BG_THEME_TMPDIR/.config/omarchy/backgrounds" "$BG_THEME_TMPDIR/walls"
+for background_name in 1-one 2-two; do
+  printf 'x' >"$BG_THEME_TMPDIR/walls/$background_name.jpg"
+done
+ln -s "$BG_THEME_TMPDIR/walls" "$BG_THEME_TMPDIR/.config/omarchy/backgrounds/tokyo-night"
+OMARCHY_PATH="$ROOT" HOME="$BG_THEME_TMPDIR" OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" "Tokyo Night"
+[[ $(readlink -f "$BG_THEME_TMPDIR/.local/state/omarchy/current/background") == "$BG_THEME_TMPDIR/walls/1-one.jpg" ]] || fail "headless theme set picks a symlinked user background"
+
+PATH="$BG_STUBS:$ROOT/bin:$PATH" HOME="$BG_THEME_TMPDIR" "$ROOT/bin/omarchy-theme-bg-set" "$BG_THEME_TMPDIR/.config/omarchy/backgrounds/tokyo-night/1-one.jpg"
+OMARCHY_PATH="$ROOT" HOME="$BG_THEME_TMPDIR" OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" "Tokyo Night"
+[[ $(readlink -f "$BG_THEME_TMPDIR/.local/state/omarchy/current/background") == "$BG_THEME_TMPDIR/walls/2-two.jpg" ]] || fail "headless theme set advances past a symlinked user background"
+pass "headless theme set advances through symlinked user backgrounds"
+
 make_tmpdir MIGRATION_TMPDIR
 mkdir -p \
   "$MIGRATION_TMPDIR/.config/omarchy/current/theme" \


### PR DESCRIPTION
Fixes #8594.

`omarchy theme bg next` never advances when `~/.config/omarchy/backgrounds/<theme>` is a symlink — the kind a dotfiles manager leaves behind. Every invocation re-selects the alphabetically first image.

Two scripts spell the same path differently:

- `omarchy-theme-bg-set` links the background's **resolved** path (`realpath`), so `current/background` points at `/home/u/dotfiles/.../foo.jpg`.
- `omarchy-theme-bg-next` and `choose_theme_background` in `omarchy-theme-set` list candidates as `find -L` reaches them, i.e. **unresolved** (`/home/u/.config/omarchy/backgrounds/<theme>/foo.jpg`), then string-compare against `readlink` of that link.

The two never match, so the index lookup returns -1 and both commands fall through to `backgrounds[0]`. Stock theme backgrounds are unaffected, because `current/theme/backgrounds/` is a real copied directory.

This resolves both sides before comparing: the candidate list goes through `realpath`, and the link is read with `readlink -f`. Sorting still happens on the paths as found, so ordering by filename is unchanged. `omarchy-menu-images` already did the equivalent via `find -samefile`, so the background switcher needed no change.

Also quotes the comparison's right-hand side in `choose_theme_background`, which was an unquoted variable in `[[ ]]` and so a glob match rather than a string compare.

## Verification

Live, on a machine where `~/.config/omarchy/backgrounds` is a symlink into a dotfiles repo — stock, then patched:

```
--- stock ---            --- patched ---
  -> 3d-model.jpg          -> asian-village.png
  -> 3d-model.jpg          -> beach.jpg
  -> 3d-model.jpg          -> black-hole.png
```

Three tests added to `test/cli`: cycling through a symlinked backgrounds directory, through a real one (regression guard), and `omarchy-theme-set` resuming the cycle from a link that `omarchy-theme-bg-set` wrote. Each fails against the unpatched scripts and passes with them.

Also checked by hand: an empty backgrounds directory still sends the "No background was found for theme" notification, stow-style per-file symlinks cycle, and filenames containing spaces cycle.

`./test/cli` passes. `./test/shell` has 3 failures on this branch (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`) that also fail on a clean `quattro` checkout, so they are unrelated.