### PR TITLE
Fix clock widget to respect system locale for date formatting

### DIFF
--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -57,7 +57,7 @@ BarWidget {
   }
 
   function formatted(date) {
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
+    return Qt.locale().toString(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
   }
 
   // ---- Calendar popup. Shape contract for shell.summon/hide/toggle

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -312,7 +312,7 @@ Panel {
               Text {
                 id: heroDate
                 anchors.verticalCenter: parent.verticalCenter
-                text: Qt.formatDate(root.today, "MMMM d")
+                text: Qt.locale().toString(root.today, "MMMM d")
                 color: heroMouse.containsMouse
                   ? Style.hoverStateColor(root.contentForeground, Color.accent)
                   : root.contentForeground
@@ -713,7 +713,7 @@ Panel {
                 // "MAY 2026" and a "SEPTEMBER 2026".
                 width: Style.space(130)
                 horizontalAlignment: Text.AlignHCenter
-                text: Qt.formatDate(root.viewDate, "MMMM yyyy").toUpperCase()
+                text: Qt.locale().toString(root.viewDate, "MMMM yyyy").toUpperCase()
                 color: Qt.darker(root.contentForeground, 1.4)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -713,7 +713,7 @@ Panel {
                 // "MAY 2026" and a "SEPTEMBER 2026".
                 width: Style.space(130)
                 horizontalAlignment: Text.AlignHCenter
-                text: Qt.locale().toString(root.viewDate, "MMMM yyyy").toUpperCase()
+                text: Qt.locale().toString(root.viewDate, "MMMM yyyy").toLocaleUpperCase(Qt.locale())
                 color: Qt.darker(root.contentForeground, 1.4)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -212,7 +212,8 @@ assert(/function close\(\) \{\s*\n\s*setCenterHoverRevealSuppressed\(false\)/.te
 assert(/width: Math\.max\(calendarScroll\.width, gridColumn\.width\)/.test(panelSource), 'calendar scrolls rather than clipping the grid on a narrow popup')
 assert(/enabled: !root\.viewingCurrentMonth/.test(panelSource) && /onClicked: root\.goToToday\(\)/.test(panelSource), 'calendar hero returns to today once the view has stepped away')
 assert(!/clampMonth/.test(panelSource), 'calendar steps freely into future months')
-assert(/Qt\.formatDate\(root\.today, "MMMM d"\)/.test(panelSource), 'calendar hero spells out today')
+assert(/Qt\.locale\(\)\.toString\(root\.today, "MMMM d"\)/.test(panelSource), 'calendar hero spells out today')
+assert(/Qt\.locale\(\)\.toString\(root\.viewDate, "MMMM yyyy"\)\.toLocaleUpperCase\(Qt\.locale\(\)\)/.test(panelSource), 'calendar month header uses locale-aware uppercasing')
 assert(/id: yearLabel/.test(panelSource) && /root\.yearDone/.test(panelSource), 'calendar panel shows the year progress bar')
 
 // The memento mori bar is opt-in: double-tapping the year bar asks for an age,


### PR DESCRIPTION
## Summary

Replace  /  with  in the clock widget so that day names, month names, and AM/PM markers respect the user's system locale.

## Problem

 and  in QML internally call , which **always uses the C locale (English)** for format specifiers like `dddd` (weekday), `MMMM` (month), and `AP` (AM/PM). It completely ignores `LANG`, `LC_TIME`, and `QLocale::system()`.

This means **all non-English users** see the clock in English regardless of their system locale.

## Example

With `LANG=es_ES.UTF-8`:
- **Before:** `Thursday, 27 August 9:51 A. M.`
- **After:** `jueves, 27 agosto 9:51 AM`

## Changes

Three call sites modified:

| File | Line | Before | After |
|------|------|--------|-------|
| `shell/plugins/panels/clock/BarWidget.qml` | 60 | `Qt.formatDateTime(date, format)` | `Qt.locale().toString(date, format)` |
| `shell/plugins/panels/clock/Panel.qml` | 315 | `Qt.formatDate(date, "MMMM d")` | `Qt.locale().toString(date, "MMMM d")` |
| `shell/plugins/panels/clock/Panel.qml` | 716 | `Qt.formatDate(date, "MMMM yyyy")` | `Qt.locale().toString(date, "MMMM yyyy")` |

## Compatibility

The codebase already uses `Qt.locale()` elsewhere (e.g., `Panel.qml` line 66 for `firstDayOfWeek`, `SpeedTestOverlay.qml` for number formatting), so this fix is consistent with existing patterns. `Model.js` is explicitly locale-free and is not affected.

Fixes #8600