### PR TITLE
Tell contributors to check for duplicates and the right branch

### DIFF
--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -29,10 +29,11 @@ If a PR is already open, add to that discussion instead of filing again.
 
 ## Verify Against the Default Branch
 
-Check the bug against the branch development actually happens on, not against
-whatever `git clone` or a raw URL hands you. `master` is not it, and can be
-weeks behind a shipped release — so a bug "confirmed" there may already be
-fixed, or the code may not match what users are running:
+Check the bug against the branch development actually happens on. A fresh
+`git clone` lands there, but an older checkout or a raw URL pinned to
+`master` does not — `master` can be weeks behind a shipped release, so a bug
+"confirmed" there may already be fixed, or the code may not match what users
+are running:
 
 ```bash
 gh repo view basecamp/omarchy --json defaultBranchRef --jq .defaultBranchRef.name
@@ -95,5 +96,5 @@ For tests, `AGENTS.md` asks for the focused suite covering the area changed —
 too if you like, but treat unrelated failures as a signal about the machine
 rather than the change: parts of it depend on the local environment, such as
 attached-monitor counts or a sibling checkout, and can fail on a clean tree.
-Confirm by stashing the change and re-running, then say what you ran in the
-PR.
+Confirm by stashing the change (`git stash -u`, so new files go too) and
+re-running, then `git stash pop` and say what you ran in the PR.

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -14,6 +14,33 @@ right place:
   https://omarchy.org/discord. Start here when the problem isn't clearly a bug
   in Omarchy itself.
 
+## Check It Isn't Already Known
+
+Search issues **and** pull requests before writing anything up. An open PR
+often already fixes the bug, and it is easy to miss when only issues are
+searched:
+
+```bash
+gh search issues --repo basecamp/omarchy "<keywords>" --limit 10
+gh search prs --repo basecamp/omarchy "<keywords>" --limit 10
+```
+
+If a PR is already open, add to that discussion instead of filing again.
+
+## Verify Against the Default Branch
+
+Check the bug against the branch development actually happens on, not against
+whatever `git clone` or a raw URL hands you. `master` is not it, and can be
+weeks behind a shipped release — so a bug "confirmed" there may already be
+fixed, or the code may not match what users are running:
+
+```bash
+gh repo view basecamp/omarchy --json defaultBranchRef --jq .defaultBranchRef.name
+```
+
+Compare against the installed copy in `$OMARCHY_PATH` too; when they agree,
+the bug is current.
+
 ## Filing a Good Bug Report
 
 The bug template asks for system details (CPU, GPU, Omarchy version), a
@@ -59,7 +86,14 @@ cd omarchy
 ```
 
 Follow the repository's own `AGENTS.md` for style, testing, and commit
-conventions — it is the authority on contributions. Keep commits atomic, run
-`./test/all` before pushing, and open the PR with `gh pr create`. A PR that
-fixes a visual problem should include before/after captures (again, see
-[`capture.md`](capture.md)).
+conventions — it is the authority on contributions. Keep commits atomic and
+open the PR with `gh pr create`. A PR that fixes a visual problem should
+include before/after captures (again, see [`capture.md`](capture.md)).
+
+For tests, `AGENTS.md` asks for the focused suite covering the area changed —
+`./test/cli` or `./test/shell` — rather than `./test/all`. Run `./test/all`
+too if you like, but treat unrelated failures as a signal about the machine
+rather than the change: parts of it depend on the local environment, such as
+attached-monitor counts or a sibling checkout, and can fail on a clean tree.
+Confirm by stashing the change and re-running, then say what you ran in the
+PR.


### PR DESCRIPTION
`contributing.md` sends contributors straight from "found a bug" to filing. Two steps in between prevent wasted work on both sides, and I hit both writing #8597.

### Check for an existing report

Searching only issues misses open PRs. I found two bugs in `omarchy-font-set`; one was already #6957 with PR #6958 open and a better fix than I would have written. Searching issues alone would not have surfaced it.

### Verify against the default branch

`master` is not where development happens and can be weeks behind a shipped release:

```
default branch   2026-08-27   (current)
master           2026-08-14   (13 days stale, older than the installed 4.0.1)
```

I fetched `bin/omarchy-font-set` from `master` to check whether a bug still existed and got a version *older than my own installed copy* — missing the fontconfig rewrite that had already shipped. A bug "confirmed" that way may already be fixed, or simply not be the code users run.

The added section teaches the check (`gh repo view --json defaultBranchRef`) rather than naming today's branch, so it stays correct when the branch changes.

### Test guidance

`AGENTS.md` asks for "focused automated tests for the area you changed"; this file said to run `./test/all` before pushing, and calls `AGENTS.md` the authority. On my machine `./test/all` reports 6 failures on a clean tree — attached-monitor counts, a missing sibling checkout, a network-dependent check — none related to any change. Read as a gate, that blocks valid PRs. Aligned the wording with `AGENTS.md` and noted how to tell an environmental failure from a real one.

Docs only; no behaviour change.
