### PR TITLE
Link Omarchy agent skills into Hermes

### DIFF
--- a/bin/omarchy-provision-user
+++ b/bin/omarchy-provision-user
@@ -84,7 +84,7 @@ fi
 # Dev-aware skill symlinks. Cannot live in /etc/skel because OMARCHY_PATH may
 # point at a dev checkout (omarchy dev link) where the target differs.
 # Loops every skill directory, so shipping a new one needs no edit here.
-mkdir -p ~/.agents/skills ~/.claude/skills ~/.codex/skills ~/.pi/agent/skills ~/.gemini/config/skills
+mkdir -p ~/.agents/skills ~/.claude/skills ~/.codex/skills ~/.pi/agent/skills ~/.gemini/config/skills ~/.hermes/skills
 for skill in "$OMARCHY_PATH"/default/agents/skills/*/; do
   skill=${skill%/}
   name=${skill##*/}
@@ -93,6 +93,14 @@ for skill in "$OMARCHY_PATH"/default/agents/skills/*/; do
   ln -sfn "$skill" ~/.codex/skills/"$name"
   ln -sfn "$skill" ~/.pi/agent/skills/"$name"
   ln -sfn "$skill" ~/.gemini/config/skills/"$name"
+  ln -sfn "$skill" ~/.hermes/skills/"$name"
+  if [[ -d ~/.hermes/profiles ]]; then
+    for profile in ~/.hermes/profiles/*/; do
+      [[ -d $profile ]] || continue
+      mkdir -p "$profile/skills"
+      ln -sfn "$skill" "$profile/skills/$name"
+    done
+  fi
 done
 
 mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -198,12 +198,7 @@ Runs once per user. It does **not** copy `~/.config/**`, `~/.bashrc`,
 `flags.lua`, or the nautilus extensions — `/etc/skel` already seeded those.
 It only does the things `/etc/skel` can't:
 
-- Skill symlinks `~/.{agents,claude,codex,pi/agent,hermes}/skills/<name>` (and each `~/.hermes/profiles/*/skills/<name>`) →
-  `$OMARCHY_PATH/default/agents/skills/<name>`, looping over every skill
-  directory there (currently `omarchy` and `diagnose-crash`) so new skills
-  need no edit. Symlinks (not copies) so `omarchy dev link` against a dev
-  checkout repoints them correctly. Hermes profile dirs are only linked when
-  they already exist — provision does not create Hermes profiles.
+- Skill symlinks into `~/.agents/skills/<name>`, `~/.claude/skills/<name>`, `~/.codex/skills/<name>`, `~/.pi/agent/skills/<name>`, `~/.gemini/config/skills/<name>` (Antigravity), `~/.hermes/skills/<name>`, and each existing `~/.hermes/profiles/*/skills/<name>` → `$OMARCHY_PATH/default/agents/skills/<name>`, looping over every skill directory there (currently `omarchy` and `diagnose-crash`) so new skills need no edit. Symlinks (not copies) so `omarchy dev link` against a dev checkout repoints them correctly. Hermes profile dirs are only linked when they already exist — provision does not create Hermes profiles.
 - `xdg-user-dirs-update` (Templates/Public/Desktop folded back into `$HOME`)
   and `~/.config/gtk-3.0/bookmarks` (needs `$HOME` expansion).
 - Hyprland's package-owned default input reads `XKBLAYOUT` / `XKBVARIANT`

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -198,11 +198,12 @@ Runs once per user. It does **not** copy `~/.config/**`, `~/.bashrc`,
 `flags.lua`, or the nautilus extensions — `/etc/skel` already seeded those.
 It only does the things `/etc/skel` can't:
 
-- Skill symlinks `~/.{agents,claude,codex,pi/agent}/skills/<name>` →
+- Skill symlinks `~/.{agents,claude,codex,pi/agent,hermes}/skills/<name>` (and each `~/.hermes/profiles/*/skills/<name>`) →
   `$OMARCHY_PATH/default/agents/skills/<name>`, looping over every skill
   directory there (currently `omarchy` and `diagnose-crash`) so new skills
   need no edit. Symlinks (not copies) so `omarchy dev link` against a dev
-  checkout repoints them correctly.
+  checkout repoints them correctly. Hermes profile dirs are only linked when
+  they already exist — provision does not create Hermes profiles.
 - `xdg-user-dirs-update` (Templates/Public/Desktop folded back into `$HOME`)
   and `~/.config/gtk-3.0/bookmarks` (needs `$HOME` expansion).
 - Hyprland's package-owned default input reads `XKBLAYOUT` / `XKBVARIANT`

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -51,6 +51,6 @@ Omarchy recommends two ways of running local LLM models: LM Studio and Ollama. L
 
 ### The Omarchy Skill
 
-Agent skills help AI use specific tools in a specific way, and Omarchy ships with a default skill for tailoring the system. Like tweaking your Hyprland config, adjusting the bar, or even creating a new theme from scratch. It's symlinked into the skill directories for Claude Code (`~/.claude/skills`), Codex (`~/.codex/skills`), Pi (`~/.pi/agent/skills`), Antigravity (`~/.gemini/config/skills`), and the generic `~/.agents/skills` location, so most harnesses pick it up automatically.
+Agent skills help AI use specific tools in a specific way, and Omarchy ships with a default skill for tailoring the system. Like tweaking your Hyprland config, adjusting the bar, or even creating a new theme from scratch. It's symlinked into the skill directories for Claude Code (`~/.claude/skills`), Codex (`~/.codex/skills`), Pi (`~/.pi/agent/skills`), Antigravity (`~/.gemini/config/skills`), Hermes (`~/.hermes/skills` and each `~/.hermes/profiles/*/skills`), and the generic `~/.agents/skills` location, so most harnesses pick it up automatically.
 
 But you should treat this skill as experimental. Different models will use it to different effect. It's best to run in plan mode first, so you have an idea of what the agent would like to change. And then be ready to rollback changes or even invoking `omarchy reinstall configs`, if the agent makes a mess of everything.

--- a/migrations/1787843905.sh
+++ b/migrations/1787843905.sh
@@ -1,0 +1,22 @@
+echo "Link Omarchy agent skills into Hermes skill directories"
+
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+skills_source="$OMARCHY_PATH/default/agents/skills"
+
+[[ -d $skills_source ]] || exit 0
+
+mkdir -p "$HOME/.hermes/skills"
+
+for skill in "$skills_source"/*/; do
+  [[ -d $skill ]] || continue
+  name=${skill%/}
+  name=${name##*/}
+  ln -sfn "$skills_source/$name" "$HOME/.hermes/skills/$name"
+  if [[ -d $HOME/.hermes/profiles ]]; then
+    for profile in "$HOME"/.hermes/profiles/*/; do
+      [[ -d $profile ]] || continue
+      mkdir -p "$profile/skills"
+      ln -sfn "$skills_source/$name" "$profile/skills/$name"
+    done
+  fi
+done

--- a/test/shell.d/hermes-skills-migration-test.sh
+++ b/test/shell.d/hermes-skills-migration-test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1787843905.sh"
+[[ -f $migration ]] || fail "Hermes skills migration exists"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+home="$test_dir/home"
+
+run_migration() {
+  HOME="$home" OMARCHY_PATH="$ROOT" bash -euo pipefail "$migration" >/dev/null ||
+    fail "migration exits clean"
+}
+
+assert_link() {
+  local link="$1"
+  local skill="$2"
+  local description="$3"
+
+  [[ -L $link && $(readlink "$link") == "$ROOT/default/agents/skills/$skill" ]] ||
+    fail "$description" "$link -> $(readlink "$link" 2>/dev/null || echo missing)"
+}
+
+# ------------------------------------------------------------------ default home, no profiles
+
+rm -rf "$home"
+mkdir -p "$home"
+run_migration
+
+for skill in omarchy diagnose-crash; do
+  assert_link "$home/.hermes/skills/$skill" "$skill" "migration links $skill into the default Hermes home"
+done
+[[ -e $home/.hermes/profiles ]] && fail "migration does not create Hermes profiles"
+pass "migration links the default Hermes home and does not create profiles"
+
+run_migration
+for skill in omarchy diagnose-crash; do
+  assert_link "$home/.hermes/skills/$skill" "$skill" "migration is idempotent on the default home for $skill"
+done
+pass "migration is idempotent on the default home"
+
+# ------------------------------------------------------------------ pre-existing profile
+
+rm -rf "$home"
+mkdir -p "$home/.hermes/profiles/james"
+run_migration
+
+for skill in omarchy diagnose-crash; do
+  assert_link "$home/.hermes/skills/$skill" "$skill" "migration links $skill into the default Hermes home when a profile exists"
+  assert_link "$home/.hermes/profiles/james/skills/$skill" "$skill" "migration links $skill into a pre-existing Hermes profile"
+done
+[[ -d $home/.hermes/profiles/james ]] || fail "migration leaves the pre-existing profile in place"
+profile_count=$(find "$home/.hermes/profiles" -mindepth 1 -maxdepth 1 -type d | wc -l)
+(( profile_count == 1 )) || fail "migration does not create extra profiles" "count=$profile_count"
+pass "migration links a pre-existing Hermes profile and does not create extras"
+
+run_migration
+for skill in omarchy diagnose-crash; do
+  assert_link "$home/.hermes/skills/$skill" "$skill" "migration is idempotent on the default home when a profile exists for $skill"
+  assert_link "$home/.hermes/profiles/james/skills/$skill" "$skill" "migration is idempotent on a pre-existing profile for $skill"
+done
+pass "migration is idempotent on a pre-existing profile"
+
+# ------------------------------------------------------------------ missing skill source
+
+rm -rf "$home"
+mkdir -p "$home" "$test_dir/empty-omarchy"
+HOME="$home" OMARCHY_PATH="$test_dir/empty-omarchy" bash -euo pipefail "$migration" >/dev/null ||
+  fail "migration exits clean when the skill source is missing"
+[[ -e $home/.hermes ]] && fail "migration no-ops when the skill source is missing"
+pass "migration no-ops when the skill source is missing"

--- a/test/shell.d/provision-user-test.sh
+++ b/test/shell.d/provision-user-test.sh
@@ -8,7 +8,7 @@ test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
 mock_bin="$test_tmp/bin"
-mkdir -p "$mock_bin" "$test_tmp/home"
+mkdir -p "$mock_bin" "$test_tmp/home" "$test_tmp/home/.hermes/profiles/james"
 
 for command in xdg-user-dirs-update xdg-settings xdg-mime; do
   printf '#!/bin/bash\nexit 0\n' >"$mock_bin/$command"
@@ -30,6 +30,14 @@ for skill in omarchy diagnose-crash; do
   link="$test_tmp/home/.gemini/config/skills/$skill"
   [[ -L $link && $(readlink "$link") == "$ROOT/default/agents/skills/$skill" ]] ||
     fail "omarchy-provision-user provisions the $skill skill for Antigravity"
+
+  link="$test_tmp/home/.hermes/skills/$skill"
+  [[ -L $link && $(readlink "$link") == "$ROOT/default/agents/skills/$skill" ]] ||
+    fail "omarchy-provision-user provisions the $skill skill for Hermes"
+
+  link="$test_tmp/home/.hermes/profiles/james/skills/$skill"
+  [[ -L $link && $(readlink "$link") == "$ROOT/default/agents/skills/$skill" ]] ||
+    fail "omarchy-provision-user provisions the $skill skill for a Hermes profile"
 done
 
-pass "omarchy-provision-user provisions Antigravity skills"
+pass "omarchy-provision-user provisions Antigravity and Hermes skills"


### PR DESCRIPTION
## Why

Omarchy already symlinks `omarchy` and `diagnose-crash` into Claude, Codex, Pi, Antigravity, and `~/.agents/skills`. Hermes was missing, so Hermes agents on Omarchy never picked up the shipped skill for editing `~/.config/hypr`, `shell.json`, or themes.

## What

- `omarchy-provision-user` also links into `~/.hermes/skills` and every existing `~/.hermes/profiles/*/skills` (does not create Hermes profiles)
- Migration `1787843905.sh` for current installs
- `test/shell.d/provision-user-test.sh` covers default Hermes home plus a pre-existing profile
- Manual AI chapter and `docs/file-layout.md` updated

## Test plan

- [x] `bash test/shell.d/provision-user-test.sh`
- [x] `HOME=$(mktemp -d) bash -euo pipefail migrations/1787843905.sh` creates the default-home links

Rollback: remove the migration marker is not needed for a revert; reverting the provision-user loop restores previous harness list. Existing Hermes symlinks are harmless if left in place.