### PR TITLE
feat(bar): per-region adaptive text and icon contrast on transparent bar

### DIFF
--- a/bin/omarchy-bar-text-color
+++ b/bin/omarchy-bar-text-color
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Choose a legible transparent bar text color
+# omarchy:summary=Choose legible transparent bar text colors across regions
 # omarchy:hidden=true
 
 set -e
@@ -11,6 +11,7 @@ text_color=${3:-}
 background_color=${4:-}
 background_path=""
 screen_size=""
+mode="regions"
 
 shift 4 2>/dev/null || true
 while (($# > 0)); do
@@ -23,6 +24,10 @@ while (($# > 0)); do
     screen_size=${2:-}
     shift 2
     ;;
+  --single)
+    mode="single"
+    shift
+    ;;
   *)
     shift
     ;;
@@ -34,7 +39,11 @@ valid_hex() {
 }
 
 fallback() {
-  printf '%s\n' "$text_color"
+  if [[ $mode == "single" ]]; then
+    printf '%s\n' "$text_color"
+  else
+    printf '%s %s %s\n' "$text_color" "$text_color" "$text_color"
+  fi
   exit 0
 }
 
@@ -68,6 +77,18 @@ contrast() {
   '
 }
 
+pick_best_color() {
+  local sample="$1"
+  local text_contrast
+  local background_contrast
+  text_contrast=$(contrast "$text_color" "$sample")
+  background_contrast=$(contrast "$background_color" "$sample")
+
+  awk -v text="$text_contrast" -v background="$background_contrast" 'BEGIN { exit !(background > text) }' \
+    && printf '%s' "$background_color" \
+    || printf '%s' "$text_color"
+}
+
 valid_hex "$text_color" || fallback
 valid_hex "$background_color" || fallback
 [[ $position =~ ^(top|bottom|left|right)$ ]] || fallback
@@ -93,33 +114,69 @@ screen_height=${BASH_REMATCH[2]}
 case "$position" in
 top)
   crop="${screen_width}x${bar_size}+0+0"
+  sample_geom="3x1!"
+  sample_fmt='%[fx:int(255*p{0,0}.r)],%[fx:int(255*p{0,0}.g)],%[fx:int(255*p{0,0}.b)]\n%[fx:int(255*p{1,0}.r)],%[fx:int(255*p{1,0}.g)],%[fx:int(255*p{1,0}.b)]\n%[fx:int(255*p{2,0}.r)],%[fx:int(255*p{2,0}.g)],%[fx:int(255*p{2,0}.b)]\n'
   ;;
 bottom)
   crop_y=$((screen_height - bar_size))
   ((crop_y >= 0)) || fallback
   crop="${screen_width}x${bar_size}+0+${crop_y}"
+  sample_geom="3x1!"
+  sample_fmt='%[fx:int(255*p{0,0}.r)],%[fx:int(255*p{0,0}.g)],%[fx:int(255*p{0,0}.b)]\n%[fx:int(255*p{1,0}.r)],%[fx:int(255*p{1,0}.g)],%[fx:int(255*p{1,0}.b)]\n%[fx:int(255*p{2,0}.r)],%[fx:int(255*p{2,0}.g)],%[fx:int(255*p{2,0}.b)]\n'
   ;;
 left)
   crop="${bar_size}x${screen_height}+0+0"
+  sample_geom="1x3!"
+  sample_fmt='%[fx:int(255*p{0,0}.r)],%[fx:int(255*p{0,0}.g)],%[fx:int(255*p{0,0}.b)]\n%[fx:int(255*p{0,1}.r)],%[fx:int(255*p{0,1}.g)],%[fx:int(255*p{0,1}.b)]\n%[fx:int(255*p{0,2}.r)],%[fx:int(255*p{0,2}.g)],%[fx:int(255*p{0,2}.b)]\n'
   ;;
 right)
   crop_x=$((screen_width - bar_size))
   ((crop_x >= 0)) || fallback
   crop="${bar_size}x${screen_height}+${crop_x}+0"
+  sample_geom="1x3!"
+  sample_fmt='%[fx:int(255*p{0,0}.r)],%[fx:int(255*p{0,0}.g)],%[fx:int(255*p{0,0}.b)]\n%[fx:int(255*p{0,1}.r)],%[fx:int(255*p{0,1}.g)],%[fx:int(255*p{0,1}.b)]\n%[fx:int(255*p{0,2}.r)],%[fx:int(255*p{0,2}.g)],%[fx:int(255*p{0,2}.b)]\n'
   ;;
 esac
 
-pixel=$(magick "$background_path" -auto-orient \
+if [[ $mode == "single" ]]; then
+  pixel=$(magick "$background_path" -auto-orient \
+    -resize "${screen_width}x${screen_height}^" \
+    -gravity center -extent "${screen_width}x${screen_height}" \
+    -gravity NorthWest -crop "$crop" +repage \
+    -scale '1x1!' -format '%[fx:int(255*r)],%[fx:int(255*g)],%[fx:int(255*b)]' info:- 2>/dev/null || true)
+  [[ $pixel =~ ^([0-9]+),([0-9]+),([0-9]+)$ ]] || fallback
+
+  sample=$(printf '#%02x%02x%02x' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}")
+  printf '%s\n' "$(pick_best_color "$sample")"
+  exit 0
+fi
+
+pixels=$(magick "$background_path" -auto-orient \
   -resize "${screen_width}x${screen_height}^" \
   -gravity center -extent "${screen_width}x${screen_height}" \
   -gravity NorthWest -crop "$crop" +repage \
-  -resize '1x1!' -format '%[fx:int(255*r)],%[fx:int(255*g)],%[fx:int(255*b)]' info:- 2>/dev/null || true)
-[[ $pixel =~ ^([0-9]+),([0-9]+),([0-9]+)$ ]] || fallback
+  -scale "$sample_geom" -format "$sample_fmt" info:- 2>/dev/null || true)
 
-sample=$(printf '#%02x%02x%02x' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}")
-text_contrast=$(contrast "$text_color" "$sample")
-background_contrast=$(contrast "$background_color" "$sample")
+readarray -t pixel_array <<< "$pixels"
+if ((${#pixel_array[@]} < 3)); then
+  fallback
+fi
 
-awk -v text="$text_contrast" -v background="$background_contrast" 'BEGIN { exit !(background > text) }' \
-  && printf '%s\n' "$background_color" \
-  || printf '%s\n' "$text_color"
+to_hex() {
+  local p="$1"
+  if [[ $p =~ ^([0-9]+),([0-9]+),([0-9]+)$ ]]; then
+    printf '#%02x%02x%02x' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+  else
+    echo "$text_color"
+  fi
+}
+
+sample_left=$(to_hex "${pixel_array[0]}")
+sample_center=$(to_hex "${pixel_array[1]}")
+sample_right=$(to_hex "${pixel_array[2]}")
+
+color_left=$(pick_best_color "$sample_left")
+color_center=$(pick_best_color "$sample_center")
+color_right=$(pick_best_color "$sample_right")
+
+printf '%s %s %s\n' "$color_left" "$color_center" "$color_right"

--- a/shell/Ui/BarWidget.qml
+++ b/shell/Ui/BarWidget.qml
@@ -15,6 +15,11 @@ Item {
   property QtObject bar: null
   property string moduleName: ""
   property var settings: ({})
+  property string region: ""
+
+  readonly property color effectiveForeground: (bar && typeof bar.regionForeground === "function" && region !== "")
+    ? bar.regionForeground(region)
+    : (bar ? bar.barForeground : Color.foreground)
 
   // Bar geometry, lifted off the host. Widgets read these constantly to pick
   // between horizontal/vertical layouts; defining them on the base keeps the

--- a/shell/Ui/BarWidget.qml
+++ b/shell/Ui/BarWidget.qml
@@ -17,9 +17,15 @@ Item {
   property var settings: ({})
   property string region: ""
 
-  readonly property color effectiveForeground: (bar && typeof bar.regionForeground === "function" && region !== "")
-    ? bar.regionForeground(region)
-    : (bar ? bar.barForeground : Color.foreground)
+  readonly property color effectiveForeground: {
+    if (bar && typeof bar.regionForeground === "function" && region !== "") {
+      var rf = bar.regionForeground(region)
+      if (rf !== undefined) return rf
+    }
+    if (bar && bar.barForeground !== undefined) return bar.barForeground
+    if (bar && bar.foreground !== undefined) return bar.foreground
+    return Color.foreground
+  }
 
   // Bar geometry, lifted off the host. Widgets read these constantly to pick
   // between horizontal/vertical layouts; defining them on the base keeps the

--- a/shell/Ui/WidgetButton.qml
+++ b/shell/Ui/WidgetButton.qml
@@ -8,7 +8,19 @@ Item {
   property string text: ""
   property string fontFamily: bar ? bar.fontFamily : Style.font.family
   property real fontSize: Style.font.body
-  property color foreground: bar ? bar.barForeground : Color.foreground
+  property string region: ""
+  readonly property string effectiveRegion: {
+    if (region !== "") return region
+    var p = root.parent
+    while (p) {
+      if (p.region !== undefined && p.region !== "") return p.region
+      p = p.parent
+    }
+    return ""
+  }
+  property color foreground: (bar && typeof bar.regionForeground === "function" && effectiveRegion !== "")
+    ? bar.regionForeground(effectiveRegion)
+    : (bar ? bar.barForeground : Color.foreground)
   property color activeColor: bar ? bar.urgent : Color.urgent
   property bool active: false
   property real horizontalMargin: 8.5

--- a/shell/Ui/WidgetButton.qml
+++ b/shell/Ui/WidgetButton.qml
@@ -18,9 +18,15 @@ Item {
     }
     return ""
   }
-  property color foreground: (bar && typeof bar.regionForeground === "function" && effectiveRegion !== "")
-    ? bar.regionForeground(effectiveRegion)
-    : (bar ? bar.barForeground : Color.foreground)
+  property color foreground: {
+    if (bar && typeof bar.regionForeground === "function" && effectiveRegion !== "") {
+      var rf = bar.regionForeground(effectiveRegion)
+      if (rf !== undefined) return rf
+    }
+    if (bar && bar.barForeground !== undefined) return bar.barForeground
+    if (bar && bar.foreground !== undefined) return bar.foreground
+    return Color.foreground
+  }
   property color activeColor: bar ? bar.urgent : Color.urgent
   property bool active: false
   property real horizontalMargin: 8.5

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -65,15 +65,31 @@ Item {
   property color themeForeground: Color.bar.text
   property color themeContrastForeground: Color.background
   property color transparentForeground: Color.bar.text
+  property color transparentForegroundLeft: Color.bar.text
+  property color transparentForegroundCenter: Color.bar.text
+  property color transparentForegroundRight: Color.bar.text
   property color foreground: themeForeground
   property color barForeground: useTransparentForeground ? transparentForeground : themeForeground
+  property color barForegroundLeft: useTransparentForeground ? transparentForegroundLeft : themeForeground
+  property color barForegroundCenter: useTransparentForeground ? transparentForegroundCenter : themeForeground
+  property color barForegroundRight: useTransparentForeground ? transparentForegroundRight : themeForeground
   property bool foregroundAnimationEnabled: true
   property color background: Color.bar.background
   property color urgent: Color.bar.active
 
   Behavior on barForeground { enabled: root.foregroundAnimationEnabled; ColorAnimation { duration: 420; easing.type: Easing.InOutCubic } }
+  Behavior on barForegroundLeft { enabled: root.foregroundAnimationEnabled; ColorAnimation { duration: 420; easing.type: Easing.InOutCubic } }
+  Behavior on barForegroundCenter { enabled: root.foregroundAnimationEnabled; ColorAnimation { duration: 420; easing.type: Easing.InOutCubic } }
+  Behavior on barForegroundRight { enabled: root.foregroundAnimationEnabled; ColorAnimation { duration: 420; easing.type: Easing.InOutCubic } }
   Behavior on background { ColorAnimation { duration: 420; easing.type: Easing.InOutCubic } }
   Behavior on urgent { ColorAnimation { duration: 420; easing.type: Easing.InOutCubic } }
+
+  function regionForeground(region) {
+    if (region === "left") return barForegroundLeft
+    if (region === "center") return barForegroundCenter
+    if (region === "right") return barForegroundRight
+    return barForeground
+  }
   property var tooltipTarget: null
   property var pendingTooltipTarget: null
   property string tooltipText: ""
@@ -822,6 +838,9 @@ Item {
   function scheduleTransparentForegroundRefresh() {
     if (!requestedTransparent) {
       transparentForeground = themeForeground
+      transparentForegroundLeft = themeForeground
+      transparentForegroundCenter = themeForeground
+      transparentForegroundRight = themeForeground
       return
     }
     transparentForegroundTimer.restart()
@@ -856,16 +875,33 @@ Item {
     id: transparentForegroundProc
     stdout: SplitParser {
       onRead: function(line) {
-        var value = String(line || "").trim()
-        if (!/^#[0-9A-Fa-f]{6}$/.test(value)) return
-
-        root.foregroundAnimationEnabled = false
-        root.transparentForeground = value
-        if (root.requestedTransparent) {
-          root.useTransparentForeground = true
-          root.transparent = true
+        var parts = String(line || "").trim().split(/\s+/)
+        if (parts.length >= 3 &&
+            /^#[0-9A-Fa-f]{6}$/.test(parts[0]) &&
+            /^#[0-9A-Fa-f]{6}$/.test(parts[1]) &&
+            /^#[0-9A-Fa-f]{6}$/.test(parts[2])) {
+          root.foregroundAnimationEnabled = false
+          root.transparentForegroundLeft = parts[0]
+          root.transparentForegroundCenter = parts[1]
+          root.transparentForegroundRight = parts[2]
+          root.transparentForeground = parts[1]
+          if (root.requestedTransparent) {
+            root.useTransparentForeground = true
+            root.transparent = true
+          }
+          root.restoreForegroundAnimation()
+        } else if (parts.length >= 1 && /^#[0-9A-Fa-f]{6}$/.test(parts[0])) {
+          root.foregroundAnimationEnabled = false
+          root.transparentForegroundLeft = parts[0]
+          root.transparentForegroundCenter = parts[0]
+          root.transparentForegroundRight = parts[0]
+          root.transparentForeground = parts[0]
+          if (root.requestedTransparent) {
+            root.useTransparentForeground = true
+            root.transparent = true
+          }
+          root.restoreForegroundAnimation()
         }
-        root.restoreForegroundAnimation()
       }
     }
   }
@@ -1753,6 +1789,7 @@ Item {
       if ("bar" in target) target.bar = root
       if ("moduleName" in target) target.moduleName = moduleName
       if ("settings" in target) target.settings = moduleSettings
+      if ("region" in target) target.region = region
     }
 
     Component {

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -876,11 +876,12 @@ Item {
     stdout: SplitParser {
       onRead: function(line) {
         var parts = String(line || "").trim().split(/\s+/)
+        var wasTransparent = root.useTransparentForeground
         if (parts.length >= 3 &&
             /^#[0-9A-Fa-f]{6}$/.test(parts[0]) &&
             /^#[0-9A-Fa-f]{6}$/.test(parts[1]) &&
             /^#[0-9A-Fa-f]{6}$/.test(parts[2])) {
-          root.foregroundAnimationEnabled = false
+          if (!wasTransparent) root.foregroundAnimationEnabled = false
           root.transparentForegroundLeft = parts[0]
           root.transparentForegroundCenter = parts[1]
           root.transparentForegroundRight = parts[2]
@@ -889,9 +890,9 @@ Item {
             root.useTransparentForeground = true
             root.transparent = true
           }
-          root.restoreForegroundAnimation()
+          if (!wasTransparent) root.restoreForegroundAnimation()
         } else if (parts.length >= 1 && /^#[0-9A-Fa-f]{6}$/.test(parts[0])) {
-          root.foregroundAnimationEnabled = false
+          if (!wasTransparent) root.foregroundAnimationEnabled = false
           root.transparentForegroundLeft = parts[0]
           root.transparentForegroundCenter = parts[0]
           root.transparentForegroundRight = parts[0]
@@ -900,7 +901,7 @@ Item {
             root.useTransparentForeground = true
             root.transparent = true
           }
-          root.restoreForegroundAnimation()
+          if (!wasTransparent) root.restoreForegroundAnimation()
         }
       }
     }

--- a/shell/plugins/bar/widgets/ActiveWindow.qml
+++ b/shell/plugins/bar/widgets/ActiveWindow.qml
@@ -33,7 +33,7 @@ BarWidget {
       anchors.left: parent.left
       width: parent.width
       text: root.title
-      color: root.bar ? root.bar.barForeground : Color.foreground
+      color: root.effectiveForeground
       font.family: root.bar ? root.bar.fontFamily : Style.font.family
       font.pixelSize: Style.font.body
       elide: Text.ElideRight

--- a/shell/plugins/panels/dropbox/Panel.qml
+++ b/shell/plugins/panels/dropbox/Panel.qml
@@ -38,7 +38,7 @@ Panel {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property color iconColor: dropbox.authenticated && dropbox.active ? foreground : dim
   readonly property string toggleHint: dropbox.active ? "Pause syncing" : "Resume syncing"
-  readonly property color barIconColor: dropbox.authenticated && dropbox.active ? barForeground : Qt.darker(barForeground, 1.55)
+  readonly property color barIconColor: dropbox.authenticated && dropbox.active ? button.foreground : Qt.darker(button.foreground, 1.55)
   // Only claim the header cursor when the switch is actually on screen —
   // "header" stays navigable, but an absent CLI leaves nothing to highlight.
   readonly property bool headerHasCursor: cursorActive && focusSection === "header" && dropbox.installed

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -53,7 +53,7 @@ Panel {
   readonly property bool headerHasCursor: cursorActive && focusSection === "header" && tailscale.installed
   readonly property color iconColor: tailscale.active ? foreground : dim
   readonly property string toggleHint: tailscale.active ? "Turn Tailscale off" : (tailscale.needsLogin ? "Authorize this device" : "Turn Tailscale on")
-  readonly property color barIconColor: tailscale.active ? barForeground : Qt.darker(barForeground, 1.55)
+  readonly property color barIconColor: tailscale.active ? button.foreground : Qt.darker(button.foreground, 1.55)
   readonly property color hoverFill: bar ? Style.hoverFillFor(bar.foreground, Color.accent) : "transparent"
   readonly property color selectedFill: bar ? Style.selectedFillFor(bar.foreground, Color.accent) : "transparent"
 

--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -34,7 +34,7 @@ BarWidget {
       id: glyph
       anchors.verticalCenter: parent.verticalCenter
       text: root.playIcon
-      color: activePlayer && activePlayer.isPlaying ? root.bar.barForeground : Qt.darker(root.bar.barForeground, 1.5)
+      color: activePlayer && activePlayer.isPlaying ? root.effectiveForeground : Qt.darker(root.effectiveForeground, 1.5)
       font.family: root.bar.fontFamily
       font.pixelSize: Style.font.body
       Behavior on color {
@@ -54,7 +54,7 @@ BarWidget {
       Text {
         id: labelText
         text: root.title + (root.artist ? "  ·  " + root.artist : "")
-        color: root.bar.barForeground
+        color: root.effectiveForeground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.body
         anchors.verticalCenter: parent.verticalCenter

--- a/test/shell.d/bar-text-color-test.sh
+++ b/test/shell.d/bar-text-color-test.sh
@@ -13,18 +13,37 @@ export PATH="$ROOT/bin:$PATH"
 
 light_top="$TMPDIR/light-top.png"
 dark_top="$TMPDIR/dark-top.png"
+split_top="$TMPDIR/split-top.png"
 
 magick -size 100x100 xc:'#202020' -fill '#f5f5f5' -draw 'rectangle 0,0 99,19' "$light_top"
 magick -size 100x100 xc:'#f5f5f5' -fill '#202020' -draw 'rectangle 0,0 99,19' "$dark_top"
 
+# Split wallpaper: Left 1/3 light (#f5f5f5), center/right dark (#202020)
+magick -size 300x100 xc:'#202020' -fill '#f5f5f5' -draw 'rectangle 0,0 99,19' "$split_top"
+
+# Multi-region default outputs 3 space-separated colors
 result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$light_top" --screen 100x100)
-[[ $result == "#101010" ]] || fail "transparent bar text switches to background color on light wallpaper" "expected #101010, got $result"
-pass "transparent bar text switches to background color on light wallpaper"
+[[ $result == "#101010 #101010 #101010" ]] || fail "transparent bar text switches to background color across regions on light wallpaper" "expected '#101010 #101010 #101010', got '$result'"
+pass "transparent bar text switches to background color across regions on light wallpaper"
 
 result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$dark_top" --screen 100x100)
-[[ $result == "#ffffff" ]] || fail "transparent bar text keeps text color on dark wallpaper" "expected #ffffff, got $result"
-pass "transparent bar text keeps text color on dark wallpaper"
+[[ $result == "#ffffff #ffffff #ffffff" ]] || fail "transparent bar text keeps text color across regions on dark wallpaper" "expected '#ffffff #ffffff #ffffff', got '$result'"
+pass "transparent bar text keeps text color across regions on dark wallpaper"
 
+# Split wallpaper test
+result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$split_top" --screen 300x100)
+read -r left_col center_col right_col <<< "$result"
+[[ $left_col == "#101010" ]] || fail "split wallpaper left region contrast" "expected #101010, got $left_col"
+[[ $center_col == "#ffffff" ]] || fail "split wallpaper center region contrast" "expected #ffffff, got $center_col"
+[[ $right_col == "#ffffff" ]] || fail "split wallpaper right region contrast" "expected #ffffff, got $right_col"
+pass "transparent bar text calculates independent contrast colors per region on split wallpaper"
+
+# Single compatibility mode
+result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$light_top" --screen 100x100 --single)
+[[ $result == "#101010" ]] || fail "transparent bar text supports --single flag" "expected #101010, got $result"
+pass "transparent bar text supports --single flag"
+
+# Fallback on missing file
 result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$TMPDIR/missing.png" --screen 100x100)
-[[ $result == "#ffffff" ]] || fail "transparent bar text falls back to text color when sampling fails" "expected #ffffff, got $result"
+[[ $result == "#ffffff #ffffff #ffffff" ]] || fail "transparent bar text falls back to text color when sampling fails" "expected '#ffffff #ffffff #ffffff', got '$result'"
 pass "transparent bar text falls back to text color when sampling fails"

--- a/test/shell.d/fixtures/bar-widget-contract/shell.qml
+++ b/test/shell.d/fixtures/bar-widget-contract/shell.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import Quickshell
 import qs.Commons
+import qs.Ui
 
 ShellRoot {
   id: root
@@ -131,9 +132,19 @@ ShellRoot {
     property string omarchyPath: root.rootPath
     property string fontFamily: "monospace"
     property color foreground: "white"
+    property color barForeground: "white"
+    property color barForegroundLeft: "#112233"
+    property color barForegroundCenter: "#445566"
+    property color barForegroundRight: "#778899"
     property color background: "black"
     property color urgent: "red"
     property var shell: mockShell
+    function regionForeground(region) {
+      if (region === "left") return barForegroundLeft
+      if (region === "center") return barForegroundCenter
+      if (region === "right") return barForegroundRight
+      return barForeground
+    }
     function run(command) {}
     function showTooltip(target, text) {}
     function hideTooltip(target) {}
@@ -143,11 +154,48 @@ ShellRoot {
     function unregisterClickTarget(target) {}
   }
 
+  function testRegionalResolution() {
+    var directBtn = widgetButtonComponent.createObject(host, { bar: fakeBar, region: "left" })
+    root.assertTrue(directBtn !== null, "direct WidgetButton instantiated")
+    root.assertEqual(directBtn.foreground, fakeBar.regionForeground("left"), "direct WidgetButton resolves explicit region foreground")
+    directBtn.region = "right"
+    root.assertEqual(directBtn.foreground, fakeBar.regionForeground("right"), "direct WidgetButton updates on region change")
+    directBtn.destroy()
+
+    var barWidget = barWidgetComponent.createObject(host, { bar: fakeBar, region: "center" })
+    root.assertTrue(barWidget !== null, "BarWidget container instantiated")
+    root.assertEqual(barWidget.effectiveForeground, fakeBar.regionForeground("center"), "BarWidget resolves effectiveForeground")
+
+    var nestedBtn = widgetButtonComponent.createObject(barWidget, { bar: fakeBar })
+    root.assertTrue(nestedBtn !== null, "nested WidgetButton instantiated")
+    root.assertEqual(nestedBtn.effectiveRegion, "center", "nested WidgetButton resolves ancestor region from BarWidget")
+    root.assertEqual(nestedBtn.foreground, fakeBar.regionForeground("center"), "nested WidgetButton inherits ancestor region foreground")
+
+    barWidget.region = "left"
+    root.assertEqual(nestedBtn.effectiveRegion, "left", "nested WidgetButton dynamically follows ancestor region changes")
+    root.assertEqual(nestedBtn.foreground, fakeBar.regionForeground("left"), "nested WidgetButton dynamically follows ancestor region foreground changes")
+
+    nestedBtn.destroy()
+    barWidget.destroy()
+  }
+
+  Component {
+    id: widgetButtonComponent
+    WidgetButton {}
+  }
+
+  Component {
+    id: barWidgetComponent
+    BarWidget {}
+  }
+
   Timer {
     interval: 1
     running: true
     repeat: false
     onTriggered: {
+      root.testRegionalResolution()
+
       var entries = widgets()
       root.assertTrue(entries.length > 0, "bar widget list is not empty")
       for (var i = 0; i < entries.length; i++) root.loadWidget(entries[i])


### PR DESCRIPTION
### Summary
When the top bar is set to transparent (`"transparent": true` in `shell.json`), widgets currently determine text/icon foreground color from a single global luminance sample squashed across the entire width of the display.

On wallpapers with mixed luminance (for example: light pastel on the left, but dark navy/black in the center and right), a single global foreground color creates severe legibility failures:
- If a dark foreground color is picked based on the left section, widgets over dark sections (like the center clock, weather, or system tray) become nearly invisible.
- If a light foreground color is picked, widgets over bright sections wash out.

### Key Changes
1. **Multi-Region Sampling (`bin/omarchy-bar-text-color`)**:
   - Updates `omarchy-bar-text-color` to use ImageMagick `-scale 3x1!` (or `1x3!` for vertical bars) to compute exact box luminance averages across **Left**, **Center**, and **Right** bar sections in a single fast invocation.
   - Returns 3 space-separated contrast colors (`color_left color_center color_right`).
   - Supports `--single` flag for backward-compatible global luminance sampling.
2. **Bar Host (`shell/plugins/bar/Bar.qml`)**:
   - Introduces `transparentForegroundLeft`, `transparentForegroundCenter`, and `transparentForegroundRight` with smooth transition animations.
   - Adds `regionForeground(region)` lookup helper and forwards region context to module slots.
3. **Widget Inheritance (`shell/Ui/BarWidget.qml`, `shell/Ui/WidgetButton.qml`)**:
   - `BarWidget` exposes `effectiveForeground`.
   - `WidgetButton` resolves its parent region dynamically and applies the section's optimal contrast color.
   - Updated `ActiveWindow` and media `BarWidget` to bind to `effectiveForeground`.
4. **Automated Unit Tests (`test/shell.d/bar-text-color-test.sh`)**:
   - Added test cases verifying split-wallpaper contrast calculation, multi-region output, single fallback mode, and missing image handling.