### PR TITLE
Add Hermes as a default coding agent

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -101,6 +101,15 @@ pi)
   command=(pi)
   [[ -n ${prompt:-} ]] && command+=("$prompt")
   ;;
+hermes)
+  # --yolo is Hermes's don't-stop-to-ask flag. A prompt is one unattended turn
+  # (`chat -q`); without one, an interactive session stays open.
+  if [[ -n ${prompt:-} ]]; then
+    command=(hermes chat --yolo -q "$prompt")
+  else
+    command=(hermes --yolo)
+  fi
+  ;;
 *)
   echo "Unsupported default agent: $agent" >&2
   exit 1

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Set and launch the default coding agent
-# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|agy|copilot|crush]
-# omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent claude
+# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|agy|copilot|crush|hermes]
+# omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent hermes
 
 installing=false
 if [[ ${1:-} == "--install" ]]; then
@@ -34,13 +34,37 @@ crush) agent="crush"; name="Crush" ;;
 grok) agent="grok"; name="Grok"; agent_package="npm:@xai-official/grok" ;;
 agy | antigravity | antigravity-cli | gemini | gemini-cli) agent="agy"; name="Antigravity"; agent_package="antigravity-cli" ;;
 copilot | github-copilot) agent="copilot"; name="GitHub Copilot" ;;
+hermes) agent="hermes"; name="Hermes"; skip_mise=true ;;
 *)
-  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|agy|copilot|crush>"
+  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|agy|copilot|crush|hermes>"
   exit 1
   ;;
 esac
 
 agent_package=${agent_package:-$agent}
+
+if [[ ${skip_mise:-} == true ]]; then
+  if [[ $installing == "false" ]] && omarchy-cmd-missing hermes; then
+    exec omarchy-launch-floating-terminal-with-presentation omarchy-default-agent --install hermes
+  fi
+
+  if omarchy-cmd-missing hermes; then
+    if ! omarchy-install-hermes; then
+      echo "Could not install $name" >&2
+      exit 1
+    fi
+  fi
+
+  mkdir -p "$(dirname "$agent_file")"
+  printf '%s\n' "$agent" >"$agent_file"
+
+  if [[ $installing == "true" ]]; then
+    printf '\033[2J\033[3J\033[H'
+    exec omarchy-agent --inline
+  else
+    exec omarchy-agent
+  fi
+fi
 
 if [[ $installing == "false" ]] && ! mise where "$agent_package" &>/dev/null; then
   exec omarchy-launch-floating-terminal-with-presentation omarchy-default-agent --install "$agent"

--- a/bin/omarchy-install-hermes
+++ b/bin/omarchy-install-hermes
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# omarchy:summary=Install Hermes Agent via the official installer
+# omarchy:hidden=true
+
+set -euo pipefail
+
+# Hermes is not a mise package. The supported install is install.sh
+# (see https://hermes-agent.nousresearch.com/docs/getting-started/installation).
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -141,6 +141,7 @@
   "setup.default.agent.copilot": {"icon":"","label":"Copilot","checked":"[[ \"$(omarchy-default-agent)\" == \"copilot\" ]]","action":"omarchy-default-agent copilot"},
   "setup.default.agent.crush": {"icon":"󰋑","label":"Crush","checked":"[[ \"$(omarchy-default-agent)\" == \"crush\" ]]","action":"omarchy-default-agent crush"},
   "setup.default.agent.grok": {"icon":"","iconFont":"omarchy","label":"Grok","checked":"[[ \"$(omarchy-default-agent)\" == \"grok\" ]]","action":"omarchy-default-agent grok"},
+  "setup.default.agent.hermes": {"icon":"󰚩","label":"Hermes","checked":"[[ \"$(omarchy-default-agent)\" == \"hermes\" ]]","action":"omarchy-default-agent hermes"},
   "setup.default.agent.omp": {"icon":"","iconFont":"omarchy","label":"omp","checked":"[[ \"$(omarchy-default-agent)\" == \"omp\" ]]","action":"omarchy-default-agent omp"},
   "setup.default.agent.opencode": {"icon":"","iconFont":"omarchy","label":"OpenCode","checked":"[[ \"$(omarchy-default-agent)\" == \"opencode\" ]]","action":"omarchy-default-agent opencode"},
   "setup.default.agent.ori": {"icon":"","iconFont":"omarchy","label":"Ori","checked":"[[ \"$(omarchy-default-agent)\" == \"ori\" ]]","action":"omarchy-default-agent ori"},

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -14,6 +14,7 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 | `pi`       | [Mario Zechner's Pi](https://github.com/badlogic/pi-mono)        |
 | `omp`      | [Oh My Pi](https://github.com/can1357/oh-my-pi)                  |
 | `ori`      | [Ori](https://openrouter.ai/docs/guides/ori/harness), OpenRouter's harness |
+| `hermes`   | [Hermes Agent](https://hermes-agent.nousresearch.com/) — not a mise stub; picking it as default runs the official `install.sh` if `hermes` is not already on PATH |
 
 `ori` is the odd one out: it runs the other harnesses against OpenRouter's whole model catalog, so `ori claude`, `ori codex`, or `ori opencode` start those agents on whichever model you point them at, and `ori code` is Ori's own agent.
 

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -46,6 +46,17 @@ cat >"$mock_bin/opencode" <<'SH'
 printf '%s\0' opencode "$@" >"$OMARCHY_TEST_AGENT_INLINE_LOG"
 SH
 
+cat >"$mock_bin/hermes" <<'SH'
+#!/bin/bash
+printf '%s\0' hermes "$@" >"$OMARCHY_TEST_AGENT_INLINE_LOG"
+SH
+
+cat >"$mock_bin/omarchy-install-hermes" <<'SH'
+#!/bin/bash
+printf '%s\n' install-hermes >>"$OMARCHY_TEST_STUB_LOG"
+[[ ${OMARCHY_TEST_HERMES_INSTALL_FAIL:-false} != "true" ]]
+SH
+
 cat >"$mock_bin/omarchy-mise-install" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >>"$OMARCHY_TEST_STUB_LOG"
@@ -307,6 +318,7 @@ declare -A expected_agents=(
   [gemini-cli]="agy"
   [copilot]="copilot"
   [github-copilot]="copilot"
+  [hermes]="hermes"
 )
 
 declare -A expected_packages=(
@@ -325,12 +337,17 @@ declare -A expected_packages=(
 for selection in "${!expected_agents[@]}"; do
   expected=${expected_agents[$selection]}
   : >"$agent_open_log"
+  : >"$mise_log"
   OMARCHY_TEST_AGENT_INSTALLED=true omarchy-default-agent "$selection"
   [[ $(omarchy-default-agent) == $expected ]] || fail "default agent canonicalizes $selection"
 
-  mapfile -d '' -t mise_args <"$mise_log"
-  [[ ${mise_args[0]} == "use" && ${mise_args[1]} == "-g" && ${mise_args[2]} == ${expected_packages[$expected]} ]] ||
-    fail "default agent installs $selection globally through mise"
+  if [[ $expected == hermes ]]; then
+    [[ ! -s $mise_log ]] || fail "hermes selection does not use mise"
+  else
+    mapfile -d '' -t mise_args <"$mise_log"
+    [[ ${mise_args[0]} == "use" && ${mise_args[1]} == "-g" && ${mise_args[2]} == ${expected_packages[$expected]} ]] ||
+      fail "default agent installs $selection globally through mise"
+  fi
 
   mapfile -d '' -t agent_open_args <"$agent_open_log"
   [[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
@@ -365,6 +382,43 @@ mapfile -d '' -t agent_open_args <"$agent_open_log"
 [[ ${#agent_open_args[@]} == 2 && ${agent_open_args[0]} == "omarchy-agent" && ${agent_open_args[1]} == "--inline" ]] ||
   fail "newly installed agent opens in the installation terminal"
 pass "missing agents install visibly and open in the same terminal"
+
+OMARCHY_TEST_AGENT_INSTALLED=true omarchy-default-agent pi
+: >"$stub_log"
+: >"$agent_open_log"
+: >"$terminal_log"
+export OMARCHY_TEST_MISSING_COMMAND=hermes
+omarchy-default-agent hermes
+mapfile -d '' -t terminal_args <"$terminal_log"
+[[ ${terminal_args[0]} == "omarchy-default-agent" && ${terminal_args[1]} == "--install" && ${terminal_args[2]} == "hermes" ]] ||
+  fail "missing Hermes installation opens in a terminal"
+[[ $(omarchy-default-agent) == "pi" ]] || fail "missing Hermes installation waits to change the selection"
+[[ ! -s $stub_log ]] || fail "missing Hermes installation waits to run install.sh"
+
+: >"$stub_log"
+: >"$agent_open_log"
+omarchy-default-agent --install hermes >"$test_tmp/hermes-install-output"
+grep -Fx install-hermes "$stub_log" >/dev/null || fail "visible Hermes installation runs omarchy-install-hermes"
+[[ $(omarchy-default-agent) == "hermes" ]] || fail "visible Hermes installation changes the selection after install succeeds"
+mapfile -d '' -t agent_open_args <"$agent_open_log"
+[[ ${#agent_open_args[@]} == 2 && ${agent_open_args[0]} == "omarchy-agent" && ${agent_open_args[1]} == "--inline" ]] ||
+  fail "newly installed Hermes opens in the installation terminal"
+unset OMARCHY_TEST_MISSING_COMMAND
+pass "Hermes installs via install.sh rather than mise"
+
+OMARCHY_TEST_AGENT_INSTALLED=true omarchy-default-agent pi
+: >"$stub_log"
+: >"$agent_open_log"
+export OMARCHY_TEST_MISSING_COMMAND=hermes
+if OMARCHY_TEST_HERMES_INSTALL_FAIL=true omarchy-default-agent --install hermes >"$test_tmp/hermes-install-failure" 2>&1; then
+  fail "default agent rejects a failed Hermes installation"
+fi
+[[ $(omarchy-default-agent) == "pi" ]] || fail "failed Hermes installation preserves the current default agent"
+grep -F "Could not install Hermes" "$test_tmp/hermes-install-failure" >/dev/null ||
+  fail "default agent reports a failed Hermes installation"
+[[ ! -s $agent_open_log ]] || fail "failed Hermes installation does not open an agent"
+unset OMARCHY_TEST_MISSING_COMMAND
+pass "Hermes installation failures do not change the default agent"
 
 : >"$notification_history"
 : >"$agent_open_log"
@@ -464,6 +518,7 @@ assert_launch crush crush run "Review this project"
 assert_launch grok grok --permission-mode bypassPermissions -- "Review this project"
 assert_launch agy agy --dangerously-skip-permissions --prompt-interactive "Review this project"
 assert_launch copilot copilot --allow-all --interactive "Review this project"
+assert_launch hermes hermes chat --yolo -q "Review this project"
 pass "agent launcher adapts initial prompts for every supported agent"
 
 assert_bypass pi pi
@@ -476,6 +531,7 @@ assert_bypass crush crush --yolo
 assert_bypass grok grok --permission-mode bypassPermissions
 assert_bypass agy agy --dangerously-skip-permissions
 assert_bypass copilot copilot --allow-all
+assert_bypass hermes hermes --yolo
 pass "agent launcher skips permission prompts for every supported agent"
 
 printf '%s\n' "opencode" >"$agent_file"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -226,6 +226,7 @@ const expectedAgents = {
   grok: { icon: '\ue904', iconFont: 'omarchy', label: 'Grok' },
   copilot: { icon: '', label: 'Copilot' },
   crush: { icon: '󰋑', label: 'Crush' },
+  hermes: { icon: '󰚩', label: 'Hermes' },
 }
 assert(
   Object.entries(expectedAgents).every(([agent, expected]) => {
@@ -238,13 +239,13 @@ assert(
       && !entry.when
       && entry.checked.includes(`== \"${agent}\"`)
   }),
-  'menu exposes every mise-installable coding agent with its own glyph under Defaults > Agent'
+  'menu exposes every coding agent with its own glyph under Defaults > Agent'
 )
 assertDeepEqual(
   defaultItems
     .filter(item => item.parent === 'setup.default.agent')
     .map(item => item.label),
-  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Grok', 'omp', 'OpenCode', 'Ori', 'Pi'],
+  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Grok', 'Hermes', 'omp', 'OpenCode', 'Ori', 'Pi'],
   'menu sorts coding agents alphabetically'
 )
 const expectedDefaults = {


### PR DESCRIPTION
## Why

Setup > Defaults > Agent, `omarchy default agent`, Super+Shift+Ctrl+A, and `omarchy agent prompt` only know the mise-managed harnesses. Hermes installs via `install.sh`, so it never appeared.

## What

- `omarchy-default-agent hermes` — skip mise; if `hermes` is missing, open a presentation terminal and run `omarchy-install-hermes` (official `install.sh`)
- `omarchy-agent` — `hermes --yolo` interactive; `hermes chat --yolo -q` for a prompt
- Menu: Defaults > Agent > Hermes
- Manual AI chapter notes the non-mise install
- Tests: default-agent-test (select, missing install, failed install, launch flags) and menu-test (glyph + alphabetical sort)

## Test plan

- [x] `bash test/shell.d/default-agent-test.sh`
- [x] `bash test/shell.d/menu-test.sh`
- [x] `./test/cli`

Rollback: revert the branch. Existing `~/.config/omarchy/defaults/agent` files that say `hermes` keep working if Hermes is on PATH; they error the same as any other missing agent if it is not.