### PR TITLE
Keep kitty font zoom when switching themes

### DIFF
--- a/bin/omarchy-restart-terminal
+++ b/bin/omarchy-restart-terminal
@@ -7,7 +7,25 @@ if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
 fi
 
 if pgrep -x kitty >/dev/null; then
-  killall -SIGUSR1 kitty >/dev/null
+  theme_conf=~/.local/state/omarchy/current/theme/kitty.conf
+  declare -A recolored
+
+  # Repaint colors over kitty's remote-control sockets where possible: unlike a
+  # SIGUSR1 full-config reload, set-colors leaves runtime state such as the
+  # interactive font-size zoom intact.
+  if [[ -f $theme_conf ]]; then
+    for sock in "$XDG_RUNTIME_DIR"/omarchy-kitty-*; do
+      if [[ -S $sock ]] && kitten @ --to "unix:$sock" set-colors --all --configured "$theme_conf" 2>/dev/null; then
+        recolored[${sock##*-}]=1
+      fi
+    done
+  fi
+
+  for pid in $(pgrep -x kitty); do
+    if [[ -z ${recolored[$pid]} ]]; then
+      kill -SIGUSR1 "$pid" 2>/dev/null
+    fi
+  done
 fi
 
 if pgrep -x ghostty >/dev/null; then


### PR DESCRIPTION
Changing themes currently resets kitty’s font size back to `font_size` in the config, so any live zoom is lost.

Repro:
1. Zoom in with `ctrl+shift+plus`
2. Run `omarchy-theme-set <any theme>`
3. Font size snaps back

That’s because `omarchy-theme-set` calls `omarchy-restart-terminal`, which sends SIGUSR1. Kitty then reloads the whole config, including `font_size`. We only needed new colors.

Omarchy’s default kitty.conf already opens a remote-control socket per instance, so this change uses that: apply colors with `kitten @ set-colors --all --configured`, and fall back to SIGUSR1 for any instance that didn’t get recolored (no socket, unresponsive, or no theme conf).

One behavior change worth calling out: `set-colors` ignores non-color options. A custom theme `kitty.conf` that also sets non-color keys will no longer apply those on theme change. Stock themes are generated from a colors-only template, so they’re unaffected. Happy to add a guard that takes the SIGUSR1 path when the theme conf has non-color keys, if you’d rather keep the old behavior for those.

Tested live: zoom survives theme changes, colors apply to all windows including scrollback, and the SIGUSR1 fallback still runs for instances without a socket. `./test/cli` passes.
