### PR TITLE
Add a Hermes collector for the agents usage panel

### DIFF
--- a/bin/omarchy-agent-usage-hermes
+++ b/bin/omarchy-agent-usage-hermes
@@ -1,0 +1,351 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Hermes Agent usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Hermes Agent usage into one display-ready JSON record.
+
+Token and session stats come from local state.db files (default ~/.hermes
+and each ~/.hermes/profiles/*/state.db). There is no Hermes-wide 5-hour or
+weekly quota — mixed providers — so this record carries local stats and an
+empty limits list. The agents panel only ever reads the JSON this prints.
+
+state.db is internal and versioned; queries probe sqlite_master / PRAGMA
+table_info and skip missing columns rather than assuming a schema version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+AGENT_ID = "hermes"
+AGENT_NAME = "Hermes Agent"
+
+
+def number(value: Any) -> int:
+  try:
+    n = float(value or 0)
+    return round(n) if n == n else 0
+  except (TypeError, ValueError):
+    return 0
+
+
+def empty_bucket() -> dict[str, int]:
+  return {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  }
+
+
+def empty_stats() -> dict[str, Any]:
+  return {
+    "todayPrompts": 0,
+    "todaySessions": 0,
+    "todayTotalTokens": 0,
+    "todayTokensByModel": {},
+    "recentDays": [],
+    "totalPrompts": 0,
+    "totalSessions": 0,
+    "activeDays": 0,
+    "activeDates": [],
+    "modelUsage": {},
+  }
+
+
+def base_record(**overrides: Any) -> dict[str, Any]:
+  record: dict[str, Any] = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "ready": False,
+    "hasLocalStats": True,
+    "hasPromptStats": True,
+    "tierLabel": "Hermes",
+    "usageStatusText": "",
+    "authHelpText": "",
+    "limits": [],
+  }
+  record.update(empty_stats())
+  record.update(overrides)
+  return record
+
+
+def date_string(value: dt.date) -> str:
+  return value.strftime("%Y-%m-%d")
+
+
+def recent_date_strings() -> list[str]:
+  today = dt.datetime.now().date()
+  return [date_string(today - dt.timedelta(days=offset)) for offset in range(6, -1, -1)]
+
+
+def local_date_from_unix(value: Any) -> str | None:
+  if value is None or value == "":
+    return None
+  try:
+    seconds = float(value)
+  except (TypeError, ValueError):
+    return None
+  if seconds > 10_000_000_000:
+    seconds /= 1000.0
+  try:
+    return date_string(dt.datetime.fromtimestamp(seconds).date())
+  except (OverflowError, OSError, ValueError):
+    return None
+
+
+def hermes_homes(root: Path) -> list[Path]:
+  homes: list[Path] = []
+  default = root / ".hermes"
+  if default.is_dir():
+    homes.append(default)
+  profiles = default / "profiles"
+  if profiles.is_dir():
+    for profile in sorted(profiles.iterdir()):
+      if profile.is_dir():
+        homes.append(profile)
+  return homes
+
+
+def table_names(conn: sqlite3.Connection) -> set[str]:
+  return {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+
+
+def table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+  return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def open_db(path: Path) -> sqlite3.Connection | None:
+  if not path.is_file():
+    return None
+  try:
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+  except sqlite3.Error:
+    return None
+
+
+def token_total(bucket: dict[str, int]) -> int:
+  return (
+    bucket["inputTokens"]
+    + bucket["outputTokens"]
+    + bucket["cacheReadInputTokens"]
+    + bucket["cacheCreationInputTokens"]
+  )
+
+
+def add_bucket(dest: dict[str, int], src: dict[str, int]) -> None:
+  for key in dest:
+    dest[key] += src[key]
+
+
+def scan_db(path: Path) -> dict[str, Any] | None:
+  conn = open_db(path)
+  if conn is None:
+    return None
+
+  try:
+    tables = table_names(conn)
+    if "session_model_usage" not in tables and "sessions" not in tables:
+      return None
+
+    today = date_string(dt.datetime.now().date())
+    recent_dates = recent_date_strings()
+    recent = {day: 0 for day in recent_dates}
+    today_by_model: dict[str, int] = {}
+    model_usage: dict[str, dict[str, int]] = {}
+    active_dates: set[str] = set()
+    session_days: dict[str, set[str]] = {}
+    providers: dict[str, int] = {}
+
+    if "session_model_usage" in tables:
+      usage_cols = table_columns(conn, "session_model_usage")
+      session_cols = table_columns(conn, "sessions") if "sessions" in tables else set()
+      select = ["u.session_id", "u.model"]
+      for col in (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "reasoning_tokens",
+        "billing_provider",
+        "last_seen",
+        "first_seen",
+      ):
+        if col in usage_cols:
+          select.append(f"u.{col}")
+      join = ""
+      if "sessions" in tables:
+        join = " LEFT JOIN sessions s ON s.id = u.session_id"
+        if "last_activity_at" in session_cols:
+          select.append("s.last_activity_at")
+        if "started_at" in session_cols:
+          select.append("s.started_at")
+      rows = conn.execute(f"SELECT {', '.join(select)} FROM session_model_usage u{join}")
+      for row in rows:
+        mapping = dict(row)
+        bucket = empty_bucket()
+        bucket["inputTokens"] = number(mapping.get("input_tokens"))
+        bucket["outputTokens"] = number(mapping.get("output_tokens")) + number(mapping.get("reasoning_tokens"))
+        bucket["cacheReadInputTokens"] = number(mapping.get("cache_read_tokens"))
+        bucket["cacheCreationInputTokens"] = number(mapping.get("cache_write_tokens"))
+        total = token_total(bucket)
+        if total <= 0:
+          continue
+        model = str(mapping.get("model") or "unknown").strip() or "unknown"
+        add_bucket(model_usage.setdefault(model, empty_bucket()), bucket)
+        provider = str(mapping.get("billing_provider") or "").strip()
+        if provider:
+          providers[provider] = providers.get(provider, 0) + total
+        day = (
+          local_date_from_unix(mapping.get("last_seen"))
+          or local_date_from_unix(mapping.get("last_activity_at"))
+          or local_date_from_unix(mapping.get("first_seen"))
+          or local_date_from_unix(mapping.get("started_at"))
+        )
+        session_id = str(mapping.get("session_id") or "")
+        if day:
+          active_dates.add(day)
+          if day in recent:
+            recent[day] += total
+          if session_id:
+            session_days.setdefault(session_id, set()).add(day)
+          if day == today:
+            today_by_model[model] = today_by_model.get(model, 0) + total
+
+    today_sessions = {sid for sid, days in session_days.items() if today in days}
+    total_sessions = set(session_days)
+
+    today_prompts = 0
+    total_prompts = 0
+    if "messages" in tables:
+      msg_cols = table_columns(conn, "messages")
+      if {"role", "timestamp"}.issubset(msg_cols):
+        active_filter = " AND COALESCE(active, 1) = 1" if "active" in msg_cols else ""
+        for role, timestamp in conn.execute(
+          f"SELECT role, timestamp FROM messages WHERE role = 'user'{active_filter}"
+        ):
+          total_prompts += 1
+          day = local_date_from_unix(timestamp)
+          if day == today:
+            today_prompts += 1
+
+    return {
+      "todayPrompts": today_prompts,
+      "todaySessions": len(today_sessions),
+      "todayTotalTokens": sum(today_by_model.values()),
+      "todayTokensByModel": today_by_model,
+      "recentDays": [{"date": day, "messageCount": recent[day]} for day in recent_dates],
+      "totalPrompts": total_prompts,
+      "totalSessions": len(total_sessions),
+      "activeDays": len(active_dates),
+      "activeDates": sorted(active_dates),
+      "modelUsage": model_usage,
+      "providers": providers,
+    }
+  except sqlite3.Error:
+    return None
+  finally:
+    conn.close()
+
+
+def merge_stats(parts: list[dict[str, Any]]) -> dict[str, Any]:
+  if not parts:
+    return empty_stats()
+
+  recent_dates = recent_date_strings()
+  recent = {day: 0 for day in recent_dates}
+  today_by_model: dict[str, int] = {}
+  model_usage: dict[str, dict[str, int]] = {}
+  active_dates: set[str] = set()
+  providers: dict[str, int] = {}
+  today_prompts = 0
+  today_sessions = 0
+  total_prompts = 0
+  total_sessions = 0
+
+  for part in parts:
+    today_prompts += number(part.get("todayPrompts"))
+    today_sessions += number(part.get("todaySessions"))
+    total_prompts += number(part.get("totalPrompts"))
+    total_sessions += number(part.get("totalSessions"))
+    for model, bucket in (part.get("modelUsage") or {}).items():
+      add_bucket(model_usage.setdefault(model, empty_bucket()), dict(empty_bucket(), **{
+        key: number(bucket.get(key)) for key in empty_bucket()
+      }))
+    for model, total in (part.get("todayTokensByModel") or {}).items():
+      today_by_model[model] = today_by_model.get(model, 0) + number(total)
+    for day in part.get("activeDates") or []:
+      active_dates.add(str(day))
+    for row in part.get("recentDays") or []:
+      day = str(row.get("date") or "")
+      if day in recent:
+        recent[day] += number(row.get("messageCount"))
+    for provider, total in (part.get("providers") or {}).items():
+      providers[provider] = providers.get(provider, 0) + number(total)
+
+  return {
+    "todayPrompts": today_prompts,
+    "todaySessions": today_sessions,
+    "todayTotalTokens": sum(today_by_model.values()),
+    "todayTokensByModel": today_by_model,
+    "recentDays": [{"date": day, "messageCount": recent[day]} for day in recent_dates],
+    "totalPrompts": total_prompts,
+    "totalSessions": total_sessions,
+    "activeDays": len(active_dates),
+    "activeDates": sorted(active_dates),
+    "modelUsage": model_usage,
+    "providers": providers,
+  }
+
+
+def tier_label(providers: dict[str, int]) -> str:
+  if not providers:
+    return "Hermes"
+  return max(providers.items(), key=lambda item: item[1])[0]
+
+
+def collect(home: Path) -> dict[str, Any]:
+  parts = []
+  for hermes_home in hermes_homes(home):
+    scanned = scan_db(hermes_home / "state.db")
+    if scanned is not None:
+      parts.append(scanned)
+
+  if not parts:
+    return base_record(ready=False, hasLocalStats=False)
+
+  stats = merge_stats(parts)
+  providers = stats.pop("providers", {})
+  ready = number(stats.get("todayTotalTokens")) > 0 or number(stats.get("totalSessions")) > 0
+  return base_record(ready=ready, tierLabel=tier_label(providers), **stats)
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Print the Hermes Agent usage record as JSON")
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  args = parser.parse_args()
+  _ = args  # same flags as every collector; no remote probe to skip
+
+  try:
+    record = collect(Path.home())
+  except Exception as error:
+    record = base_record(ready=False, hasLocalStats=False, usageStatusText="Hermes usage scan failed")
+    print(f"omarchy-agent-usage-hermes: {type(error).__name__}", file=sys.stderr)
+
+  print(json.dumps(record, separators=(",", ":"), sort_keys=True))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -29,7 +29,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 ### The agents panel
 
-The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
+The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, Fireworks, and Hermes Agent are covered out of the box.
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -55,6 +55,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `hermes` | none (mixed providers, no shared quota) | `~/.hermes/state.db` and each `~/.hermes/profiles/*/state.db` (`session_model_usage` + user messages) |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via

--- a/shell/plugins/agents/assets/hermes.svg
+++ b/shell/plugins/agents/assets/hermes.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g fill="none" stroke="#c9a227" stroke-linecap="round" stroke-width="5">
+    <path d="M32 6v52"/>
+    <path d="M32 16c-12 8-12 16 0 24 12 8 12 16 0 24"/>
+    <path d="M32 16c12 8 12 16 0 24-12 8-12 16 0 24"/>
+  </g>
+</svg>

--- a/test/shell.d/agent-usage-hermes-scanner-test.sh
+++ b/test/shell.d/agent-usage-hermes-scanner-test.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+# No Hermes install: still print a full, hidden-by-default record so the
+# updater can write valid JSON without failing the other collectors.
+empty=$(HOME="$TEST_HOME" "$ROOT/bin/omarchy-agent-usage-hermes")
+[[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.hasLocalStats | tostring)' <<<"$empty") == "hermes:false:false" ]] ||
+  fail "Hermes collector prints a valid record without a state.db" "$empty"
+pass "Hermes collector prints a valid record without a state.db"
+
+[[ $(jq -r '.name' <<<"$empty") == "Hermes Agent" ]] ||
+  fail "Hermes collector identifies itself" "$empty"
+pass "Hermes collector identifies itself"
+
+python3 - "$TEST_HOME" <<'PY'
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+home = Path(sys.argv[1])
+now = time.time()
+today = now
+week_ago = now - 7 * 24 * 3600
+
+def write_db(path, rows, users):
+  path.parent.mkdir(parents=True, exist_ok=True)
+  conn = sqlite3.connect(path)
+  conn.executescript("""
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      source TEXT NOT NULL,
+      started_at REAL NOT NULL,
+      last_activity_at REAL,
+      message_count INTEGER DEFAULT 0,
+      input_tokens INTEGER DEFAULT 0,
+      output_tokens INTEGER DEFAULT 0
+    );
+    CREATE TABLE session_model_usage (
+      session_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      billing_provider TEXT NOT NULL DEFAULT '',
+      billing_base_url TEXT NOT NULL DEFAULT '',
+      billing_mode TEXT NOT NULL DEFAULT '',
+      task TEXT NOT NULL DEFAULT '',
+      api_call_count INTEGER NOT NULL DEFAULT 0,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+      reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+      estimated_cost_usd REAL NOT NULL DEFAULT 0,
+      actual_cost_usd REAL NOT NULL DEFAULT 0,
+      first_seen REAL,
+      last_seen REAL,
+      PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
+    );
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT,
+      timestamp REAL NOT NULL,
+      active INTEGER NOT NULL DEFAULT 1
+    );
+  """)
+  for session_id, started in {row[0]: row[5] for row in rows}.items():
+    conn.execute(
+      "INSERT OR IGNORE INTO sessions(id, source, started_at, last_activity_at) VALUES (?, 'cli', ?, ?)",
+      (session_id, started, started),
+    )
+  conn.executemany(
+    """INSERT INTO session_model_usage(
+         session_id, model, billing_provider, input_tokens, output_tokens,
+         cache_read_tokens, cache_write_tokens, reasoning_tokens, last_seen, first_seen
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+    rows,
+  )
+  conn.executemany(
+    "INSERT INTO messages(session_id, role, content, timestamp, active) VALUES (?, 'user', 'hi', ?, 1)",
+    users,
+  )
+  conn.commit()
+  conn.close()
+
+write_db(
+  home / ".hermes" / "state.db",
+  [
+    ("ses-default", "grok-4.6", "xai-oauth", 100, 40, 10, 5, 2, today, today),
+    ("ses-old", "glm-5.3-flash:cloud", "custom", 50, 10, 0, 0, 0, week_ago, week_ago),
+  ],
+  [("ses-default", today), ("ses-old", week_ago)],
+)
+write_db(
+  home / ".hermes" / "profiles" / "james" / "state.db",
+  [
+    ("ses-james", "grok-4.6", "xai-oauth", 20, 8, 0, 0, 0, today, today),
+  ],
+  [("ses-james", today)],
+)
+PY
+
+result=$(HOME="$TEST_HOME" "$ROOT/bin/omarchy-agent-usage-hermes" --force --limits-only)
+
+[[ $(jq -r '.ready | tostring' <<<"$result") == "true" ]] ||
+  fail "Hermes collector is ready when state.db has usage" "$result"
+pass "Hermes collector is ready when state.db has usage"
+
+# today: default 100+40+10+5+2=157 plus profile 20+8=28 → 185
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "185" ]] ||
+  fail "Hermes collector sums tokens from default home and profiles" "$result"
+pass "Hermes collector sums tokens from default home and profiles"
+
+[[ $(jq -r '.todayPrompts' <<<"$result") == "2" ]] ||
+  fail "Hermes collector counts today's user messages" "$result"
+[[ $(jq -r '.todaySessions' <<<"$result") == "2" ]] ||
+  fail "Hermes collector counts today's sessions" "$result"
+pass "Hermes collector counts today's prompts and sessions"
+
+[[ $(jq -c '.modelUsage["grok-4.6"]' <<<"$result") == '{"cacheCreationInputTokens":5,"cacheReadInputTokens":10,"inputTokens":120,"outputTokens":50}' ]] ||
+  fail "Hermes collector merges per-model buckets and folds reasoning into output" "$result"
+pass "Hermes collector merges per-model buckets and folds reasoning into output"
+
+[[ $(jq -r '.tierLabel' <<<"$result") == "xai-oauth" ]] ||
+  fail "Hermes collector labels the dominant billing provider" "$result"
+pass "Hermes collector labels the dominant billing provider"
+
+[[ $(jq -r '.limits | length' <<<"$result") == "0" ]] ||
+  fail "Hermes collector does not invent rate limits" "$result"
+pass "Hermes collector does not invent rate limits"
+
+# A truncated db (no usage table) must not crash the updater.
+BROKEN_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$BROKEN_HOME"' EXIT
+mkdir -p "$BROKEN_HOME/.hermes"
+python3 - "$BROKEN_HOME/.hermes/state.db" <<'PY'
+import sqlite3, sys
+conn = sqlite3.connect(sys.argv[1])
+conn.execute("CREATE TABLE unrelated (id INTEGER)")
+conn.commit()
+conn.close()
+PY
+broken=$(HOME="$BROKEN_HOME" "$ROOT/bin/omarchy-agent-usage-hermes")
+[[ $(jq -r '.id + ":" + (.ready | tostring)' <<<"$broken") == "hermes:false" ]] ||
+  fail "Hermes collector survives a state.db without usage tables" "$broken"
+pass "Hermes collector survives a state.db without usage tables"


### PR DESCRIPTION
## Why

The agents bar panel is display-only. It picks up any `omarchy-agent-usage-<agent>` collector. Claude, Codex, and Fireworks ship; Hermes does not.

## What

- `omarchy-agent-usage-hermes` prints the panel record from local `state.db` (`~/.hermes` + existing `~/.hermes/profiles/*`)
- Queries `session_model_usage` and user `messages`; probes `sqlite_master` / `PRAGMA table_info` so a schema bump does not crash the updater
- No 5-hour/weekly limits — Hermes is multi-provider. `tierLabel` is the dominant billing provider
- Missing Hermes or a truncated db still prints valid JSON (`ready: false`) so sibling collectors are not failed
- Optional `assets/hermes.svg` mark
- Zero QML changes

## Test plan

- [x] `bash test/shell.d/agent-usage-hermes-scanner-test.sh`
- [x] `./test/cli` (metadata)
- [x] Live scan of this machine's James profile `state.db` (ready, grok-4.6 + glm models, empty limits)

Rollback: revert the branch. Existing `~/.local/state/omarchy/agents/usage/hermes.json` can be deleted; the panel hides agents with no record.