### PR TITLE
Wait longer for a restarted shell to become ready

### DIFF
--- a/bin/omarchy-restart-shell
+++ b/bin/omarchy-restart-shell
@@ -69,7 +69,9 @@ while timeout 5 quickshell kill -p "$CONFIG_DIR" --any-display >/dev/null 2>&1; 
 # not transient variables from a terminal, SSH connection, or development tool.
 hyprctl dispatch 'hl.dsp.exec_cmd("omarchy-launch-shell")' >/dev/null
 
-for (( attempt = 0; attempt < 20; attempt++ )); do
+# Plugin discovery and first-load QML compilation can take several seconds.
+ready_deadline=$((SECONDS + 30))
+while (( SECONDS < ready_deadline )); do
   if OMARCHY_PATH="$session_omarchy_path" OMARCHY_SHELL_IPC_TIMEOUT=0.5s omarchy-shell shell ping >/dev/null 2>&1; then
     # The session stays compositor-locked after the old lock client died, so
     # re-acquire the lock and let the user authenticate out of it.

--- a/test/shell.d/restart-shell-test.sh
+++ b/test/shell.d/restart-shell-test.sh
@@ -89,9 +89,19 @@ printf '%s\n' "$*" >>"$OMARCHY_TEST_IPC_LOG"
 
 case "$*" in
   *'shell ping')
-    [[ $* == *"-p $OMARCHY_TEST_SESSION_PATH/shell"* ]] &&
+    if [[ -n ${OMARCHY_TEST_QS_READY_AFTER:-} ]]; then
+      attempts=$(<"$OMARCHY_TEST_QS_READY_COUNT")
+      attempts=$((attempts + 1))
+      printf '%s\n' "$attempts" >"$OMARCHY_TEST_QS_READY_COUNT"
+    fi
+
+    if [[ $* == *"-p $OMARCHY_TEST_SESSION_PATH/shell"* ]] &&
       grep -Fx '303' "$OMARCHY_TEST_QS_STATE" >/dev/null &&
+      (( ${attempts:-1} >= ${OMARCHY_TEST_QS_READY_AFTER:-1} )); then
       printf 'ok\n'
+    else
+      exit 1
+    fi
     ;;
   *'lock lock')
     touch "$OMARCHY_TEST_QS_STATE.locked"
@@ -213,6 +223,29 @@ grep -F "kill -p $restart_root/shell --any-display" "$restart_log" >/dev/null ||
 grep -F 'hl.dsp.exec_cmd("omarchy-launch-shell")' "$dispatch_log" >/dev/null || fail "restart launches the fresh shell through Hyprland"
 grep -F "ipc -n -p $restart_root/shell call -- shell ping" "$ipc_log" >/dev/null || fail "restart checks readiness in the session checkout"
 pass "restart replaces duplicate shell instances from the session checkout"
+
+# Plugin discovery and first-load QML compilation can take longer than the old
+# 20-attempt readiness budget. Keep polling long enough for a slow shell that
+# eventually becomes IPC-responsive.
+ready_count="$test_tmp/ready-count"
+printf '0\n' >"$ready_count"
+printf '303\n' >"$restart_state"
+
+PATH="$restart_bin:$PATH" \
+OMARCHY_PATH="$restart_root" \
+XDG_RUNTIME_DIR="$runtime_dir" \
+OMARCHY_TEST_QS_STATE="$restart_state" \
+OMARCHY_TEST_QS_LOG="$restart_log" \
+OMARCHY_TEST_QS_ENV_LOG="$restart_env_log" \
+OMARCHY_TEST_DISPATCH_LOG="$dispatch_log" \
+OMARCHY_TEST_IPC_LOG="$ipc_log" \
+OMARCHY_TEST_SESSION_PATH="$restart_root" \
+OMARCHY_TEST_QS_READY_AFTER=25 \
+OMARCHY_TEST_QS_READY_COUNT="$ready_count" \
+  timeout 8 "$ROOT/bin/omarchy-restart-shell" || fail "restart waits for a slow shell to become ready"
+
+(( $(<"$ready_count") >= 25 )) || fail "restart keeps polling beyond the old readiness budget"
+pass "restart waits for a slow shell to become ready"
 
 : >"$restart_log"
 printf '303\n' >"$restart_state"


### PR DESCRIPTION
## Why

`omarchy restart shell` gives up after 20 readiness probes. Plugin discovery and first-load QML compilation can take longer, so the command can report failure even though the new shell becomes responsive shortly afterward.

## What

- replace the fixed 20-probe loop with a 30-second wall-clock deadline
- add regression coverage for a shell that becomes responsive after 25 probes

## Testing

- `bash test/shell.d/restart-shell-test.sh`
- `bash -n bin/omarchy-restart-shell test/shell.d/restart-shell-test.sh`
- `git diff --check`

Fixes #8568