### PR TITLE
Route the Voxtype model picker to the install flow when voxtype is missing

### DIFF
--- a/bin/omarchy-voxtype-model
+++ b/bin/omarchy-voxtype-model
@@ -4,5 +4,12 @@
 
 set -e
 
-omarchy-launch-floating-terminal-with-presentation "voxtype setup model"
-omarchy-restart-shell
+# Voxtype is optional, so the model picker can be reached before it is
+# installed. Route to the install flow rather than opening a terminal that
+# dies with "voxtype: command not found".
+if omarchy-cmd-missing voxtype; then
+  omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install
+else
+  omarchy-launch-floating-terminal-with-presentation "voxtype setup model"
+  omarchy-restart-shell
+fi

--- a/test/shell.d/voxtype-model-test.sh
+++ b/test/shell.d/voxtype-model-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+test_bin=$(mktemp -d)
+log_file=$(mktemp)
+
+cleanup() {
+  rm -rf "$test_bin"
+  rm -f "$log_file"
+}
+trap cleanup EXIT
+
+# Presence is stubbed rather than probed so the branch under test is decided by
+# the test and not by whether the developer's own machine has Voxtype installed.
+cat >"$test_bin/omarchy-cmd-missing" <<'STUB'
+#!/bin/bash
+[[ -n $TEST_VOXTYPE_PRESENT ]] && exit 1
+exit 0
+STUB
+
+cat >"$test_bin/omarchy-launch-floating-terminal-with-presentation" <<'STUB'
+#!/bin/bash
+echo "present:$*" >>"$TEST_LOG"
+STUB
+
+cat >"$test_bin/omarchy-restart-shell" <<'STUB'
+#!/bin/bash
+echo "restart-shell" >>"$TEST_LOG"
+STUB
+
+chmod +x "$test_bin"/*
+
+run_model() {
+  : >"$log_file"
+  TEST_VOXTYPE_PRESENT="$1" TEST_LOG="$log_file" PATH="$test_bin:$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-voxtype-model"
+}
+
+run_model ""
+
+grep -qx 'present:omarchy-voxtype-install' "$log_file" ||
+  fail "missing Voxtype routes the model picker to the installer" "$(cat "$log_file")"
+grep -q 'voxtype setup model' "$log_file" &&
+  fail "missing Voxtype does not run the model picker"
+grep -qx 'restart-shell' "$log_file" &&
+  fail "missing Voxtype does not restart the shell"
+
+run_model 1
+
+grep -qx 'present:voxtype setup model' "$log_file" ||
+  fail "installed Voxtype opens the model picker" "$(cat "$log_file")"
+grep -qx 'restart-shell' "$log_file" ||
+  fail "installed Voxtype restarts the shell to pick up the new model"
+grep -q 'omarchy-voxtype-install' "$log_file" &&
+  fail "installed Voxtype does not re-run the installer"
+
+pass "Voxtype model picker guards against a missing Voxtype"


### PR DESCRIPTION
Follow-up to #6832, which guards `omarchy-voxtype-config` but leaves the sibling command unguarded.

`omarchy-voxtype-model` opens the model picker unconditionally:

```bash
omarchy-launch-floating-terminal-with-presentation "voxtype setup model"
```

Voxtype is optional, so this is reachable before it is installed — `omarchy voxtype model` then pops a floating terminal containing nothing but the failure:

```text
bash: line 1: voxtype: command not found

● Done! Press any key to close...
```

This is the same shape as #6823, and the same remedy: when voxtype is missing, route to the install flow instead, so the command that was meant to configure dictation offers to install it.

That path is easy to reach right now on any non-x86_64 machine, where `voxtype-bin` cannot install at all (#8530, and the source-build fallback in #8316). I hit it on aarch64 — the manual points users at `voxtype setup model` for changing models, so a user following the manual on a machine where the installer silently failed lands here.

### Notes

- Uses a full `if`/`else` rather than #6832's `exec`, per `AGENTS.md`: *"Prefer a full `if`/`else` conditional for simple two-path control flow; don't rely on `exec` or `exit` in one branch to make following statements unreachable."* Happy to match #6832's shape instead if consistency between the two commands is preferred.
- `omarchy-restart-shell` stays on the installed path only; the installer already reloads Hyprland and restarts the shell itself.
- The two PRs touch different files and won't conflict.

### Tests

Adds `test/shell.d/voxtype-model-test.sh`, covering both branches. Presence is stubbed rather than probed so the branch under test doesn't depend on whether the developer's own machine has Voxtype installed. Verified it fails against the unpatched script.

`./test/all`: `test/cli` passes; `test/shell` passes 202/207. The 5 failures (`bar-icon-geometry`, `config`, `snapper`, `theme-install-guards`, `unowned-system-paths`) reproduce identically on a clean checkout of `quattro` on this machine and are unrelated to this change.
