### PR TITLE
Install Apple Broadcom Wi-Fi firmware on every Mac brcmfmac drives, not just T2

### DIFF
--- a/install/hardware/apple/fix-brcmfmac-supplicant.sh
+++ b/install/hardware/apple/fix-brcmfmac-supplicant.sh
@@ -13,6 +13,10 @@
 # BCM43602 and 2015 firmware fails exactly this way, and connects once the
 # offload is disabled.
 #
+# apple-bcm-firmware installs here too, for the same population: without it
+# brcmfmac has no NVRAM/CLM/TxCap calibration data and the radio never comes
+# up at all, which T2 Macs already got from fix-t2.sh but no other Mac did.
+#
 # The IDs are brcmfmac's own, from brcm_hw_ids.h: BCM43602 and its single-band
 # variants in 2015-2017 Macs, BCM4350, BCM4355 and BCM4364 in the 2018-2019
 # machines including the T2-less iMac19,1 and iMac19,2, and BCM4377/4378/4387
@@ -23,7 +27,9 @@ sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
 if lspci -nn | grep "106b:180[12]" >/dev/null ||
   { [[ $sys_vendor == Apple* ]] &&
     lspci -nn | grep -E "14e4:(43ba|43bb|43bc|43a3|43dc|4464|4488|4425|4433)" >/dev/null; }; then
-  echo "Detected a Mac with Broadcom Wi-Fi; running the WPA handshake in software"
+  echo "Detected a Mac with Broadcom Wi-Fi; installing firmware and running the WPA handshake in software"
+
+  omarchy-pkg-add apple-bcm-firmware
 
   mkdir -p /etc/modprobe.d
   cat > /etc/modprobe.d/brcmfmac.conf <<'EOF'

--- a/install/hardware/pacman.sh
+++ b/install/hardware/pacman.sh
@@ -1,6 +1,10 @@
 # Hardware-specific pacman repository extensions that must survive the final
 # pacman.conf restore.
-if lspci -nn | grep "106b:180[12]" >/dev/null; then
+sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+
+if lspci -nn | grep "106b:180[12]" >/dev/null ||
+  { [[ $sys_vendor == Apple* ]] &&
+    lspci -nn | grep -E "14e4:(43ba|43bb|43bc|43a3|43dc|4464|4488|4425|4433)" >/dev/null; }; then
   if ! grep -q '^\[arch-mact2\]' /etc/pacman.conf; then
     cat >> /etc/pacman.conf <<'EOF'
 

--- a/migrations/1787847645.sh
+++ b/migrations/1787847645.sh
@@ -1,0 +1,27 @@
+echo "Install Apple Broadcom Wi-Fi firmware on Macs brcmfmac drives"
+
+dmi_vendor="${OMARCHY_BRCMFMAC_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+pacman_conf="${OMARCHY_BRCMFMAC_PACMAN_CONF:-/etc/pacman.conf}"
+
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+if ! lspci -nn | grep "106b:180[12]" >/dev/null &&
+  ! { [[ $sys_vendor == Apple* ]] &&
+    lspci -nn | grep -E "14e4:(43ba|43bb|43bc|43a3|43dc|4464|4488|4425|4433)" >/dev/null; }; then
+  exit 0
+fi
+
+if ! grep -q '^\[arch-mact2\]' "$pacman_conf"; then
+  sudo tee -a "$pacman_conf" >/dev/null <<'EOF'
+
+[arch-mact2]
+Server = https://github.com/NoaHimesaka1873/arch-mact2-mirror/releases/download/release
+SigLevel = Never
+EOF
+fi
+
+if omarchy-pkg-missing apple-bcm-firmware; then
+  sudo pacman -Sy
+  omarchy-pkg-add apple-bcm-firmware
+  omarchy-state set reboot-required
+fi

--- a/test/shell.d/brcmfmac-firmware-migration-test.sh
+++ b/test/shell.d/brcmfmac-firmware-migration-test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+pacman_leaf="$ROOT/install/hardware/pacman.sh"
+migration="$ROOT/migrations/1787847645.sh"
+
+# arch-mact2 has to reach every Mac apple-bcm-firmware is installed on, not
+# just T2 ones, or omarchy-pkg-add apple-bcm-firmware has no repo to pull from.
+grep -Eq '14e4:\(43ba\|43bb\|43bc\|43a3\|43dc\|4464\|4488\|4425\|4433\)' "$pacman_leaf" ||
+  fail "arch-mact2 is added for every Mac brcmfmac drives, not just T2 ones"
+pass "arch-mact2 is added for every Mac brcmfmac drives, not just T2 ones"
+
+# This leaf runs after every package-installing leaf in hardware/all.sh, so no
+# install in the current run ever depends on its repo being synced yet -- and
+# a failed sync here would abort an otherwise offline-capable install for no
+# benefit. The refresh belongs only in the migration, which repairs an
+# already-installed, networked system.
+! grep -q 'pacman -Sy' "$pacman_leaf" ||
+  fail "install-time repository persistence does not force a network sync"
+pass "install-time repository persistence does not force a network sync"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+pacman_conf="$test_tmp/pacman.conf"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no such hardware" (#6608).
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+if [[ -n ${WIFI_ID:-} ]]; then
+  echo "03:00.0 Network controller [0280]: Broadcom Inc. Wireless [14e4:$WIFI_ID]"
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+# Stubbed rather than run: the real one would hit pacman. Controlled by
+# APPLE_BCM_FIRMWARE_INSTALLED so the same stub covers the fresh-install and
+# already-repaired cases.
+cat >"$stub_bin/omarchy-pkg-missing" <<'SH'
+#!/bin/bash
+
+(( ${APPLE_BCM_FIRMWARE_INSTALLED:-0} == 0 ))
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+# Stubbed rather than run: a real `pacman -Sy` would hit the network and
+# mutate this machine's package databases. The sudo stub forwards through to
+# this rather than the real binary, since stub_bin leads PATH.
+cat >"$stub_bin/pacman" <<'SH'
+#!/bin/bash
+
+printf 'pacman' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_migration() {
+  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}" installed="${4:-0}"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" APPLE_BCM_FIRMWARE_INSTALLED="$installed" \
+    PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_BRCMFMAC_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    OMARCHY_BRCMFMAC_PACMAN_CONF="$pacman_conf" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+# A T2 install from before apple-bcm-firmware moved to fix-brcmfmac-supplicant.sh
+# already has the repo (fix-t2.sh's own pacman.sh call added it), so this proves
+# the migration's own repo/package logic still fires on top of that.
+printf '[options]\n' >"$pacman_conf"
+run_migration "Apple Inc." 4488 1 0
+grep -q '^\[arch-mact2\]$' "$pacman_conf" ||
+  fail "the migration ensures arch-mact2 exists for a T2 Mac" "$(cat "$pacman_conf")"
+grep -Fq $'sudo\tpacman\t-Sy' "$calls" ||
+  fail "the migration syncs the freshly added repo before installing from it" "$(cat "$calls")"
+grep -Fq $'omarchy-pkg-add\tapple-bcm-firmware' "$calls" ||
+  fail "the migration installs the firmware package on a T2 Mac" "$(cat "$calls")"
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the migration asks for the reboot that applies the firmware" "$(cat "$calls")"
+pass "the migration repairs a T2 install"
+
+# The machine this was written for: no T2, so the repo was never added and the
+# package was never installed by anything.
+printf '[options]\n' >"$pacman_conf"
+run_migration "Apple Inc." 43ba 0 0
+grep -q '^\[arch-mact2\]$' "$pacman_conf" ||
+  fail "the migration adds arch-mact2 on a Mac without a T2" "$(cat "$pacman_conf")"
+grep -Fq $'sudo\tpacman\t-Sy' "$calls" ||
+  fail "the migration syncs the freshly added repo on a Mac without a T2" "$(cat "$calls")"
+grep -Fq $'omarchy-pkg-add\tapple-bcm-firmware' "$calls" ||
+  fail "the migration installs the firmware package on a Mac without a T2" "$(cat "$calls")"
+pass "the migration repairs an install on a Mac without a T2"
+
+# Repeat runs, and other users on an already-repaired machine, must not
+# re-append the repo block, resync it, or ask for another reboot.
+run_migration "Apple Inc." 43ba 0 1
+(( $(grep -c '^\[arch-mact2\]$' "$pacman_conf") == 1 )) ||
+  fail "the migration does not duplicate the repo block" "$(cat "$pacman_conf")"
+[[ ! -s $calls ]] || fail "an already repaired install is left untouched" "$(cat "$calls")"
+pass "the migration is idempotent"
+
+# Plenty of non-Apple hardware uses brcmfmac and does not share this bug.
+printf '[options]\n' >"$pacman_conf"
+run_migration "LENOVO" 43ba 0 0
+[[ ! -s $calls ]] || fail "the migration escalates nothing on unaffected Macs" "$(cat "$calls")"
+grep -q '^\[arch-mact2\]$' "$pacman_conf" && fail "the migration leaves non-Apple hardware alone" "$(cat "$pacman_conf")"
+pass "the migration skips hardware brcmfmac does not drive"
+
+# A prior run could have appended the repo block and then failed the sync (a
+# transient network outage), leaving the block in place with no marker
+# written. That must not make the sync look already done: the package is
+# still missing, so a retry has to sync again before it can install.
+printf '%s\n' '[options]' '' '[arch-mact2]' \
+  'Server = https://github.com/NoaHimesaka1873/arch-mact2-mirror/releases/download/release' \
+  'SigLevel = Never' >"$pacman_conf"
+run_migration "Apple Inc." 43ba 0 0
+grep -Fq $'sudo\tpacman\t-Sy' "$calls" ||
+  fail "a retry resyncs an already-appended repo when the package is still missing" "$(cat "$calls")"
+grep -Fq $'omarchy-pkg-add\tapple-bcm-firmware' "$calls" ||
+  fail "a retry still installs the firmware package" "$(cat "$calls")"
+(( $(grep -c '^\[arch-mact2\]$' "$pacman_conf") == 1 )) ||
+  fail "a retry does not duplicate the repo block" "$(cat "$pacman_conf")"
+pass "an interrupted migration recovers on retry"

--- a/test/shell.d/brcmfmac-supplicant-test.sh
+++ b/test/shell.d/brcmfmac-supplicant-test.sh
@@ -61,6 +61,15 @@ printf '\t%s' "$@" >>"$TEST_LOG"
 printf '\n' >>"$TEST_LOG"
 SH
 
+# Stubbed rather than run: the real one would hit pacman.
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
 chmod +x "$stub_bin"/*
 
 # The leaf reads the vendor from an absolute path, so point it at a fixture by
@@ -71,6 +80,7 @@ run_leaf() {
   rm -rf "$test_tmp/etc"
   mkdir -p "$test_tmp/etc"
   printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
 
   # Redirect both absolute paths the leaf touches into the sandbox.
   local script="$test_tmp/leaf.sh"
@@ -78,7 +88,7 @@ run_leaf() {
       -e "s|/etc/modprobe.d|$test_tmp/etc/modprobe.d|g" \
       "$leaf" >"$script"
 
-  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" PATH="$stub_bin:$PATH" \
+  WIFI_ID="$wifi_id" T2_HARDWARE="$t2" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
     bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
 }
 
@@ -87,15 +97,19 @@ run_leaf() {
 run_leaf "Apple Inc." 4488 1 >/dev/null
 grep -q 'feature_disable=0x82000' "$conf" 2>/dev/null ||
   fail "a T2 Mac still gets the quirk" "$(ls -R "$test_tmp/etc" 2>&1)"
-pass "a T2 Mac still gets the quirk"
+grep -Fq $'omarchy-pkg-add\tapple-bcm-firmware' "$calls" ||
+  fail "a T2 Mac still gets the firmware package" "$(cat "$calls")"
+pass "a T2 Mac still gets the quirk and the firmware package"
 
 # Every Broadcom part brcmfmac drives, on a Mac with no T2 to detect: BCM43602
 # and its single-band variants, BCM4350, BCM4355, BCM4364, BCM4378, BCM4387.
 for wifi_id in 43ba 43bb 43bc 43a3 43dc 4464 4425 4433; do
   run_leaf "Apple Inc." "$wifi_id" 0 >/dev/null
   [[ -f $conf ]] || fail "a Mac without a T2 gets the quirk" "14e4:$wifi_id"
+  grep -Fq $'omarchy-pkg-add\tapple-bcm-firmware' "$calls" ||
+    fail "a Mac without a T2 gets the firmware package" "14e4:$wifi_id"
 done
-pass "every brcmfmac part on a Mac without a T2 gets the quirk"
+pass "every brcmfmac part on a Mac without a T2 gets the quirk and the firmware package"
 
 # Older Macs report the vendor differently.
 run_leaf "Apple Computer, Inc." 43ba 0 >/dev/null
@@ -103,18 +117,22 @@ run_leaf "Apple Computer, Inc." 43ba 0 >/dev/null
 pass "the older Apple vendor string is recognized"
 
 # BCM4360 Macs run the out-of-tree wl driver, which never reads this option, so
-# writing it would only look like the machine had been dealt with.
+# writing it would only look like the machine had been dealt with -- and it
+# never shipped Apple NVRAM through this package either.
 run_leaf "Apple Inc." 43a0 0 >/dev/null
 [[ ! -f $conf ]] || fail "a Mac whose Wi-Fi brcmfmac does not drive is left alone"
+[[ ! -s $calls ]] || fail "a Mac whose Wi-Fi brcmfmac does not drive gets no firmware package" "$(cat "$calls")"
 pass "a Mac whose Wi-Fi brcmfmac does not drive is left alone"
 
 # Plenty of non-Apple hardware uses brcmfmac and does not share this bug.
 run_leaf "LENOVO" 43ba 0 >/dev/null
 [[ ! -f $conf ]] || fail "non-Apple hardware is left alone"
+[[ ! -s $calls ]] || fail "non-Apple hardware gets no firmware package" "$(cat "$calls")"
 pass "non-Apple hardware is left alone"
 
 run_leaf "Apple Inc." "" 0 >/dev/null
 [[ ! -f $conf ]] || fail "a Mac with no wireless device is left alone"
+[[ ! -s $calls ]] || fail "a Mac with no wireless device gets no firmware package" "$(cat "$calls")"
 pass "a Mac with no wireless device is left alone"
 
 # Installs that predate the quirk never ran the leaf, so the migration has to


### PR DESCRIPTION
## Summary

`apple-bcm-firmware` currently only gets installed on T2 Macs, via `fix-t2.sh`. Every other Mac whose Wi-Fi `brcmfmac` drives — including the T2-less iMac19,1 and iMac19,2 that `install/hardware/apple/fix-brcmfmac-supplicant.sh` already calls out by name in its own comments — gets no NVRAM/CLM/TxCap calibration data at all. Without it the radio never comes up: `dmesg` shows `brcmf_pcie_download_fw_nvram: FW failed to initialize` and `Firmware has halted or crashed`, and no `wlan`/`wlp*` interface ever appears.

I hit this on a real 2019 27" iMac (iMac19,1, BCM4364, board-id `Mac-AA95B1DDAB278B95`) running Omarchy: Wi-Fi was completely dead out of the box. Root-caused it down to the missing firmware package, confirmed the fix manually (installed `apple-bcm-firmware`'s files under the plain `brcmfmac4364b2-pcie.*` names this kernel's driver actually requests, reloaded `brcmfmac`, and the card came up and connected), then generalized it into this patch so it's not a manual fix every T2-less Mac owner has to rediscover.

- `install/hardware/pacman.sh` now adds the `arch-mact2` repo (which carries `apple-bcm-firmware`) for any Mac with brcmfmac-driven Broadcom Wi-Fi, not only T2 PCI IDs — reusing the exact detection condition already in `fix-brcmfmac-supplicant.sh`.
- `install/hardware/apple/fix-brcmfmac-supplicant.sh` now also installs `apple-bcm-firmware` for every Mac it detects, alongside the existing WPA handshake quirk it already applies to the same population.
- `migrations/1787847645.sh` repairs existing installs the same way, idempotently, following the existing migration conventions (per-user completion tracking, `omarchy-state set reboot-required` since brcmfmac only reads firmware at module load).
- Extended `test/shell.d/brcmfmac-supplicant-test.sh` and added `test/shell.d/brcmfmac-firmware-migration-test.sh`.

## Test plan

- [x] `bash test/shell.d/brcmfmac-supplicant-test.sh` passes
- [x] `bash test/shell.d/brcmfmac-firmware-migration-test.sh` passes
- [x] Full `bash test/shell` suite passes (no regressions)
- [x] Verified manually on the affected hardware (iMac19,1, BCM4364) that installing `apple-bcm-firmware` and reloading `brcmfmac` brings the Wi-Fi interface up