### PR TITLE
Stop network speed tests when their launcher dies

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -10,6 +10,7 @@ direction="${1:-}"
 probe=1.1.1.1
 parallel=8
 url_count=3
+network_devices_path="${OMARCHY_NETWORK_DEVICES_PATH:-/sys/class/net}"
 
 case "$direction" in
   down | up)
@@ -30,7 +31,10 @@ format_mbps() {
 
 iface=$(ip route get "$probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
 
-if [[ -z $iface || ! -r /sys/class/net/$iface/statistics/rx_bytes || ! -r /sys/class/net/$iface/statistics/tx_bytes ]]; then
+rx_path="$network_devices_path/$iface/statistics/rx_bytes"
+tx_path="$network_devices_path/$iface/statistics/tx_bytes"
+
+if [[ -z $iface || ! -r $rx_path || ! -r $tx_path ]]; then
   echo "No active network interface" >&2
   exit 1
 fi
@@ -51,9 +55,14 @@ if [[ -z $fast_urls ]]; then
 fi
 
 traffic_pids=()
+parent_watch_pid=""
 
 cleanup() {
   local pid
+  if [[ -n $parent_watch_pid ]]; then
+    kill "$parent_watch_pid" 2>/dev/null || true
+    wait "$parent_watch_pid" 2>/dev/null || true
+  fi
   for pid in "${traffic_pids[@]}"; do
     [[ -n $pid ]] || continue
     pkill -TERM -P "$pid" 2>/dev/null || true
@@ -65,6 +74,18 @@ cleanup() {
   done
 }
 trap cleanup EXIT
+
+# Quickshell cannot signal this process when it crashes or is killed, so stop
+# the test ourselves when the parent that launched it disappears.
+parent_pid=$PPID
+watch_parent() {
+  while kill -0 "$parent_pid" 2>/dev/null; do
+    sleep 0.5
+  done
+  kill -TERM "$$" 2>/dev/null || true
+}
+watch_parent &
+parent_watch_pid=$!
 
 # Round-robin across the returned URLs so we spread load across Netflix OCA nodes.
 traffic_worker() {
@@ -91,8 +112,8 @@ for (( i = 0; i < parallel; i++ )); do
   traffic_pids+=("$!")
 done
 
-rx_before=$(cat "/sys/class/net/$iface/statistics/rx_bytes")
-tx_before=$(cat "/sys/class/net/$iface/statistics/tx_bytes")
+rx_before=$(<"$rx_path")
+tx_before=$(<"$tx_path")
 
 any_alive() {
   local pid
@@ -107,8 +128,8 @@ any_alive() {
 
 while any_alive; do
   sleep 1
-  rx_after=$(cat "/sys/class/net/$iface/statistics/rx_bytes")
-  tx_after=$(cat "/sys/class/net/$iface/statistics/tx_bytes")
+  rx_after=$(<"$rx_path")
+  tx_after=$(<"$tx_path")
 
   if [[ $direction == "down" ]]; then
     rate=$(awk -v before="$rx_before" -v after="$rx_after" 'BEGIN {

--- a/test/shell.d/network-speedtest-parent-test.sh
+++ b/test/shell.d/network-speedtest-parent-test.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+require_command pkill
+require_command python3
+
+test_tmp=$(mktemp -d)
+test_bin="$test_tmp/bin"
+child_file="$test_tmp/speedtest.pid"
+curl_pids="$test_tmp/curl-pids"
+parent_pid=""
+speedtest_pid=""
+mkdir -p "$test_bin"
+mkdir -p "$test_tmp/net/lo/statistics"
+: >"$curl_pids"
+printf '0\n' >"$test_tmp/net/lo/statistics/rx_bytes"
+printf '0\n' >"$test_tmp/net/lo/statistics/tx_bytes"
+
+cleanup_test() {
+  local pid
+  [[ -n $parent_pid ]] && kill "$parent_pid" 2>/dev/null || true
+  [[ -n $speedtest_pid ]] && kill "$speedtest_pid" 2>/dev/null || true
+  while IFS= read -r pid; do
+    [[ -n $pid ]] && kill "$pid" 2>/dev/null || true
+  done <"$curl_pids"
+  rm -rf "$test_tmp"
+}
+trap cleanup_test EXIT
+
+cat >"$test_bin/ip" <<'SH'
+#!/bin/bash
+printf '1.1.1.1 via 127.0.0.1 dev lo\n'
+SH
+
+cat >"$test_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ ${1:-} == "curl" ]]
+SH
+
+cat >"$test_bin/curl" <<'SH'
+#!/usr/bin/env python3
+import os
+import signal
+import sys
+
+if any(arg.startswith("https://api.fast.com/") for arg in sys.argv[1:]):
+  print('{"targets":[{"url":"https://speedtest.invalid/payload"}]}')
+  raise SystemExit(0)
+
+with open(os.environ["OMARCHY_TEST_CURL_PIDS"], "a") as log:
+  print(os.getpid(), file=log, flush=True)
+signal.pause()
+SH
+
+cat >"$test_bin/speedtest-parent" <<'SH'
+#!/bin/bash
+
+"$OMARCHY_TEST_SPEEDTEST" down >"$OMARCHY_TEST_OUTPUT" 2>"$OMARCHY_TEST_ERROR" &
+child=$!
+printf '%s\n' "$child" >"$OMARCHY_TEST_CHILD_FILE"
+wait "$child"
+SH
+
+chmod +x "$test_bin"/*
+
+PATH="$test_bin:$PATH" \
+OMARCHY_TEST_SPEEDTEST="$ROOT/bin/omarchy-network-speedtest" \
+OMARCHY_TEST_CHILD_FILE="$child_file" \
+OMARCHY_TEST_CURL_PIDS="$curl_pids" \
+OMARCHY_TEST_OUTPUT="$test_tmp/output" \
+OMARCHY_TEST_ERROR="$test_tmp/error" \
+OMARCHY_NETWORK_DEVICES_PATH="$test_tmp/net" \
+  "$test_bin/speedtest-parent" &
+parent_pid=$!
+
+for _ in {1..100}; do
+  [[ -s $child_file ]] && (( $(wc -l <"$curl_pids") >= 8 )) && break
+  sleep 0.05
+done
+
+[[ -s $child_file ]] || fail "speed test starts under its launcher" "$(cat "$test_tmp/error" 2>/dev/null || true)"
+(( $(wc -l <"$curl_pids") >= 8 )) || fail "speed test starts traffic workers" "$(cat "$test_tmp/error" 2>/dev/null || true)"
+speedtest_pid=$(<"$child_file")
+actual_parent=$(ps -o ppid= -p "$speedtest_pid" | awk '{print $1}')
+[[ $actual_parent == "$parent_pid" ]] ||
+  fail "speed test is a child of the simulated launcher" "expected $parent_pid, got $actual_parent"
+
+# Model Quickshell crashing without giving its Process children a signal.
+kill -KILL "$parent_pid"
+wait "$parent_pid" 2>/dev/null || true
+parent_pid=""
+
+for _ in {1..100}; do
+  if ! kill -0 "$speedtest_pid" 2>/dev/null; then
+    all_curls_stopped=1
+    while IFS= read -r pid; do
+      if [[ -n $pid ]] && kill -0 "$pid" 2>/dev/null; then
+        all_curls_stopped=0
+        break
+      fi
+    done <"$curl_pids"
+    (( all_curls_stopped )) && break
+  fi
+  sleep 0.05
+done
+
+if kill -0 "$speedtest_pid" 2>/dev/null; then
+  fail "speed test exits when its launcher dies" "curl pids: $(tr '\n' ' ' <"$curl_pids")
+$(ps -axo pid,ppid,stat,command | grep -E "(^ *PID|$speedtest_pid|omarchy-network-speedtest)" | grep -v grep)"
+fi
+while IFS= read -r pid; do
+  if [[ -n $pid ]] && kill -0 "$pid" 2>/dev/null; then
+    fail "speed test stops traffic processes when its launcher dies" "$(ps -o pid,ppid,stat,command -p "$pid")"
+  fi
+done <"$curl_pids"
+pass "speed test stops itself and its traffic processes when its launcher dies"


### PR DESCRIPTION
## Why

When Quickshell crashes or is killed, it cannot signal the `omarchy-network-speedtest` processes it launched. Their traffic loops then keep running indefinitely, and each shell restart can leave another eight download or upload streams behind.

## What

- watch the launcher PID while a speed test is active
- terminate the speed-test supervisor when that launcher disappears, allowing the existing `EXIT` cleanup to stop every traffic worker
- add a hermetic regression test that kills a simulated Quickshell parent with `SIGKILL` and verifies the supervisor and all eight traffic processes exit
- make the network statistics root overridable so the process-level test does not depend on the host interface layout

## Testing

- `bash test/shell.d/network-speedtest-parent-test.sh` (three consecutive runs)
- `bash test/shell.d/network-test.sh`
- `bash -n bin/omarchy-network-speedtest test/shell.d/network-speedtest-parent-test.sh`
- `git diff --check`

Fixes #8515