### PR TITLE
Open the apps menu on a right click on the bare desktop

### DIFF
--- a/manual/03-coming-from-mac-or-windows.md
+++ b/manual/03-coming-from-mac-or-windows.md
@@ -10,7 +10,7 @@ Your Spotlight or Raycast or Start-menu reflex becomes `Super + Space`. That ope
 
 ### There's no dock and no desktop icons
 
-Nothing to click to launch things, no icons to arrange on the desktop. Apps start from a hotkey (`Super + Return` for the terminal, `Super + Shift + Return` for the browser, and `Super + K` for a list of everything that's mapped) or from the menu. The one persistent piece of UI is [the top bar](05-the-top-bar.md), which covers what the menu bar, system tray, and Notification Center did for you before — and nearly every widget on it does something on left, right, and middle click.
+Nothing to click to launch things, no icons to arrange on the desktop. Apps start from a hotkey (`Super + Return` for the terminal, `Super + Shift + Return` for the browser, and `Super + K` for a list of everything that's mapped) or from the menu. The one persistent piece of UI is [the top bar](05-the-top-bar.md), which covers what the menu bar, system tray, and Notification Center did for you before — and nearly every widget on it does something on left, right, and middle click. The desktop is not inert either: right-clicking the bare desktop opens the apps menu, the same one `Super + Alt + Space` reaches.
 
 ### Windows place themselves
 

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -108,6 +108,10 @@ Item {
     if (!themeSwitchProc.running) themeSwitchProc.running = true
   }
 
+  function openAppsMenu() {
+    if (!appsMenuProc.running) appsMenuProc.running = true
+  }
+
   Process {
     id: bgSwitchProc
     command: ["bash", "-c", "background=$(omarchy-theme-bg-switcher); [[ -n $background ]] && omarchy-theme-bg-set \"$background\""]
@@ -118,6 +122,11 @@ Item {
     id: themeSwitchProc
     command: ["bash", "-c", "theme=$(omarchy-theme-switcher); [[ -n $theme ]] && omarchy-theme-set \"$theme\" >/dev/null 2>&1 &"]
     onExited: root.refreshBackground()
+  }
+
+  Process {
+    id: appsMenuProc
+    command: ["omarchy-menu", "toggle", "apps"]
   }
 
   Process {
@@ -309,10 +318,26 @@ Item {
         }
       }
 
+      // A right click on the bare desktop opens the apps menu, the same one
+      // SUPER + ALT + SPACE reaches. It waits out the double-click interval
+      // first because the second click of a right double-click still belongs
+      // to the theme switcher, and a menu opened on the first of the two would
+      // swallow it.
+      Timer {
+        id: appsMenuTimer
+        interval: Qt.styleHints.mouseDoubleClickInterval
+        onTriggered: root.openAppsMenu()
+      }
+
       MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onClicked: function(mouse) {
+          if (mouse.button === Qt.RightButton) appsMenuTimer.restart()
+          mouse.accepted = true
+        }
         onDoubleClicked: function(mouse) {
+          appsMenuTimer.stop()
           if (mouse.button === Qt.RightButton) root.openThemeSwitcher()
           else root.openSelector()
           mouse.accepted = true

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -12,6 +12,14 @@ assert(
 )
 
 assert(
+  backgroundQml.includes('command: ["omarchy-menu", "toggle", "apps"]') &&
+    /id: appsMenuTimer\s+interval: Qt\.styleHints\.mouseDoubleClickInterval\s+onTriggered: root\.openAppsMenu\(\)/.test(backgroundQml) &&
+    /onClicked: function\(mouse\) \{\s+if \(mouse\.button === Qt\.RightButton\) appsMenuTimer\.restart\(\)/.test(backgroundQml) &&
+    /onDoubleClicked: function\(mouse\) \{\s+appsMenuTimer\.stop\(\)/.test(backgroundQml),
+  'right click on the desktop opens the apps menu once the double-click interval has passed'
+)
+
+assert(
   backgroundQml.includes('pendingThemeFallbackTimer.restart()') &&
     backgroundQml.includes('pendingThemeFallbackTimer.stop()') &&
     backgroundQml.includes('id: pendingThemeFallbackTimer') &&


### PR DESCRIPTION
Right-clicking bare desktop opens the apps menu — the same one `Super + Alt + Space` reaches. A right click there does nothing today until it becomes a double click, and an empty desktop is exactly where the reflex to reach for a launcher lands.

Nothing that worked before changes. The second click of a right double-click still belongs to the theme switcher, so the single click waits out `Qt.styleHints.mouseDoubleClickInterval` before opening — a menu opened on the first of the two would have swallowed the second. Left double-click still opens the background switcher.

Verified on a running session, and covered in `test/shell.d/background-test.sh`.
