### PR TITLE
Answer arithmetic and unit conversions in the menu search

### DIFF
--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -2,6 +2,8 @@
 
 Everything in Omarchy happens via the keyboard — _EVERYTHING!_ When the system first starts, you literally can't do a thing with the mouse alone. But you can hit `Super + Space` to reveal the Omarchy Menu and from here you to do just about everything.
 
+The menu search doubles as a calculator. Type an expression and the answer is the first row: `1024/16`, `(12+8)*3`, `sqrt(2)`, `1e6/4`. Percentages read the way a till does — `178000*20%` and `20% of 178000` both take the share, while `178000+20%` adds it on. Type a quantity and it converts: `20 km to mi`, `100 f to c`, `1 gb to mib`. A quantity on its own answers with the units its readers usually want, so `5km` offers both miles and metres. Enter copies the result. A single-letter unit needs a space to be read as one (`20 c`, not `20c`), so searches like `4k` and `3d` stay searches.
+
 But the Omarchy menu is not even intended to be the main way to operate the system most of the time. We can get faster than that! All the most important applications are bound directly to individual hotkeys. You start the terminal with `Super + Return` and a browser with `Super + Shift + Return`. Try doing one after the other, and you'll see the magic of Hyprland's tiling in action:
 
  ![navigation-browser-terminal](images/navigation-browser-terminal.webp)

--- a/shell/plugins/menu/Calculator.js
+++ b/shell/plugins/menu/Calculator.js
@@ -1,0 +1,619 @@
+// Arithmetic and unit conversion for the menu's search box.
+//
+// Every other row in the menu is looked up; this is the one that has to be
+// computed from what was typed. It parses rather than evaluates: the search box
+// sees whatever the user is halfway through typing, and `eval` would hand that
+// the entire QML scope.
+
+var CONSTANTS = {
+  pi: Math.PI,
+  e: Math.E
+}
+
+// `arity` and `maxArity` are both ends of the accepted range. A call outside it
+// is not an expression -- an argument a function would ignore is a typo, and
+// answering it anyway would present sqrt(4, 9) as a valid 2.
+var FUNCTIONS = {
+  sqrt: { arity: 1, maxArity: 1, apply: function(args) { return Math.sqrt(args[0]) } },
+  abs: { arity: 1, maxArity: 1, apply: function(args) { return Math.abs(args[0]) } },
+  round: {
+    arity: 1,
+    maxArity: 2,
+    apply: function(args) {
+      var factor = Math.pow(10, args.length > 1 ? Math.round(args[1]) : 0)
+      return Math.round(args[0] * factor) / factor
+    }
+  },
+  floor: { arity: 1, maxArity: 1, apply: function(args) { return Math.floor(args[0]) } },
+  ceil: { arity: 1, maxArity: 1, apply: function(args) { return Math.ceil(args[0]) } },
+  log: { arity: 1, maxArity: 1, apply: function(args) { return Math.log(args[0]) / Math.LN10 } },
+  ln: { arity: 1, maxArity: 1, apply: function(args) { return Math.log(args[0]) } },
+  min: { arity: 2, maxArity: Infinity, apply: function(args) { return Math.min.apply(null, args) } },
+  max: { arity: 2, maxArity: Infinity, apply: function(args) { return Math.max.apply(null, args) } }
+}
+
+// `factor` is how much of the dimension's base unit one of this unit is worth,
+// so converting is value * from.factor / to.factor. The bases are metre, gram,
+// second, byte and litre. Temperature has no common zero and is converted on
+// its own, below.
+//
+// Imperial volumes are US customary: a US pint is 473 ml, an imperial one 568.
+var UNITS = {
+  mm: { dimension: "length", factor: 0.001 },
+  cm: { dimension: "length", factor: 0.01 },
+  dm: { dimension: "length", factor: 0.1 },
+  m: { dimension: "length", factor: 1 },
+  km: { dimension: "length", factor: 1000 },
+  in: { dimension: "length", factor: 0.0254 },
+  ft: { dimension: "length", factor: 0.3048 },
+  yd: { dimension: "length", factor: 0.9144 },
+  mi: { dimension: "length", factor: 1609.344 },
+  nmi: { dimension: "length", factor: 1852 },
+
+  mg: { dimension: "mass", factor: 0.001 },
+  g: { dimension: "mass", factor: 1 },
+  kg: { dimension: "mass", factor: 1000 },
+  t: { dimension: "mass", factor: 1000000 },
+  oz: { dimension: "mass", factor: 28.349523125 },
+  lb: { dimension: "mass", factor: 453.59237 },
+  st: { dimension: "mass", factor: 6350.29318 },
+
+  ms: { dimension: "time", factor: 0.001 },
+  s: { dimension: "time", factor: 1 },
+  min: { dimension: "time", factor: 60 },
+  h: { dimension: "time", factor: 3600 },
+  d: { dimension: "time", factor: 86400 },
+  wk: { dimension: "time", factor: 604800 },
+
+  b: { dimension: "data", factor: 1 },
+  kb: { dimension: "data", factor: 1e3 },
+  mb: { dimension: "data", factor: 1e6 },
+  gb: { dimension: "data", factor: 1e9 },
+  tb: { dimension: "data", factor: 1e12 },
+  pb: { dimension: "data", factor: 1e15 },
+  kib: { dimension: "data", factor: 1024 },
+  mib: { dimension: "data", factor: 1048576 },
+  gib: { dimension: "data", factor: 1073741824 },
+  tib: { dimension: "data", factor: 1099511627776 },
+
+  ml: { dimension: "volume", factor: 0.001 },
+  cl: { dimension: "volume", factor: 0.01 },
+  l: { dimension: "volume", factor: 1 },
+  tsp: { dimension: "volume", factor: 0.00492892159375 },
+  tbsp: { dimension: "volume", factor: 0.01478676478125 },
+  floz: { dimension: "volume", factor: 0.0295735295625 },
+  cup: { dimension: "volume", factor: 0.2365882365 },
+  pt: { dimension: "volume", factor: 0.473176473 },
+  qt: { dimension: "volume", factor: 0.946352946 },
+  gal: { dimension: "volume", factor: 3.785411784 },
+
+  c: { dimension: "temperature" },
+  f: { dimension: "temperature" },
+  k: { dimension: "temperature" }
+}
+
+// Only the spellings that are not the canonical symbol. Plurals are handled by
+// dropping a trailing "s" at lookup time rather than listed twice here.
+var ALIASES = {
+  millimeter: "mm", millimetre: "mm",
+  centimeter: "cm", centimetre: "cm",
+  decimeter: "dm", decimetre: "dm",
+  meter: "m", metre: "m",
+  kilometer: "km", kilometre: "km",
+  inch: "in", inches: "in",
+  foot: "ft", feet: "ft",
+  yard: "yd",
+  mile: "mi",
+  nauticalmile: "nmi",
+
+  milligram: "mg",
+  gram: "g",
+  kilogram: "kg", kilo: "kg",
+  tonne: "t",
+  ounce: "oz",
+  pound: "lb",
+  stone: "st",
+
+  millisecond: "ms", msec: "ms",
+  second: "s", sec: "s",
+  minute: "min",
+  hour: "h", hr: "h",
+  day: "d",
+  week: "wk",
+
+  byte: "b",
+  kilobyte: "kb", megabyte: "mb", gigabyte: "gb", terabyte: "tb", petabyte: "pb",
+  kibibyte: "kib", mebibyte: "mib", gibibyte: "gib", tebibyte: "tib",
+
+  milliliter: "ml", millilitre: "ml",
+  centiliter: "cl", centilitre: "cl",
+  liter: "l", litre: "l",
+  teaspoon: "tsp", tablespoon: "tbsp",
+  fluidounce: "floz",
+  pint: "pt", quart: "qt", gallon: "gal",
+
+  celsius: "c", centigrade: "c",
+  fahrenheit: "f",
+  kelvin: "k"
+}
+
+// What a bare quantity converts into. "5km" asks a question without naming an
+// answer, so each unit names the units its own readers actually want: metric
+// asks for its imperial counterpart and vice versa, and the neighbouring scale
+// covers the rest. Explicit lists rather than a ranking rule, because a ranking
+// that picks "500000 cm" for 5 km is worse than no answer at all.
+var PEERS = {
+  mm: ["cm", "in"],
+  cm: ["in", "mm"],
+  dm: ["cm", "in"],
+  m: ["ft", "cm"],
+  km: ["mi", "m"],
+  in: ["cm", "mm"],
+  ft: ["m", "cm"],
+  yd: ["m"],
+  mi: ["km", "m"],
+  nmi: ["km", "mi"],
+
+  mg: ["g"],
+  g: ["oz", "kg"],
+  kg: ["lb", "g"],
+  t: ["kg", "lb"],
+  oz: ["g", "lb"],
+  lb: ["kg", "g"],
+  st: ["kg", "lb"],
+
+  ms: ["s"],
+  s: ["ms", "min"],
+  min: ["s", "h"],
+  h: ["min", "d"],
+  d: ["h", "wk"],
+  wk: ["d", "h"],
+
+  b: ["kb"],
+  kb: ["kib", "mb"],
+  mb: ["mib", "gb"],
+  gb: ["gib", "mb"],
+  tb: ["tib", "gb"],
+  pb: ["tb"],
+  kib: ["kb", "mib"],
+  mib: ["mb", "gib"],
+  gib: ["gb", "mib"],
+  tib: ["tb", "gib"],
+
+  ml: ["floz", "l"],
+  cl: ["ml", "floz"],
+  l: ["gal", "ml"],
+  tsp: ["ml"],
+  tbsp: ["ml"],
+  floz: ["ml", "l"],
+  cup: ["ml", "l"],
+  pt: ["ml", "l"],
+  qt: ["l", "ml"],
+  gal: ["l", "ml"],
+
+  c: ["f", "k"],
+  f: ["c", "k"],
+  k: ["c", "f"]
+}
+
+// Display spellings for the units whose canonical key is not how they are
+// written. Everything else prints as its key.
+var SYMBOLS = {
+  b: "B", kb: "kB", mb: "MB", gb: "GB", tb: "TB", pb: "PB",
+  kib: "KiB", mib: "MiB", gib: "GiB", tib: "TiB",
+  ml: "mL", cl: "cL", l: "L",
+  c: "°C", f: "°F", k: "K"
+}
+
+function isDigit(character) {
+  return character >= "0" && character <= "9"
+}
+
+function isLetter(character) {
+  return (character >= "a" && character <= "z") || (character >= "A" && character <= "Z")
+}
+
+// Returns null on anything it cannot read, which is most of what a search box
+// contains: the caller treats that as "this query is not a calculation".
+function tokenize(text) {
+  var tokens = []
+  var index = 0
+
+  while (index < text.length) {
+    var character = text.charAt(index)
+
+    if (character === " " || character === "\t") {
+      index++
+      continue
+    }
+
+    if (isDigit(character) || (character === "." && isDigit(text.charAt(index + 1)))) {
+      var numberStart = index
+      while (index < text.length && isDigit(text.charAt(index))) index++
+      if (text.charAt(index) === ".") {
+        index++
+        while (index < text.length && isDigit(text.charAt(index))) index++
+      }
+      // An exponent only counts when it is complete. Half of one is the
+      // constant e standing next to a number, which is not an expression, and
+      // consuming it here would swallow the evidence.
+      var exponent = index
+      if (text.charAt(exponent) === "e" || text.charAt(exponent) === "E") {
+        exponent++
+        if (text.charAt(exponent) === "+" || text.charAt(exponent) === "-") exponent++
+        if (isDigit(text.charAt(exponent))) {
+          while (exponent < text.length && isDigit(text.charAt(exponent))) exponent++
+          index = exponent
+        }
+      }
+      tokens.push({ type: "number", value: Number(text.slice(numberStart, index)) })
+      continue
+    }
+
+    if (isLetter(character)) {
+      var nameStart = index
+      while (index < text.length && isLetter(text.charAt(index))) index++
+      tokens.push({ type: "name", value: text.slice(nameStart, index).toLowerCase() })
+      continue
+    }
+
+    // The typographic operators are what a phone keyboard and a pasted formula
+    // produce, and they mean exactly what their ASCII twins do.
+    if (character === "×") { tokens.push({ type: "*" }); index++; continue }
+    if (character === "÷") { tokens.push({ type: "/" }); index++; continue }
+    if (character === "−") { tokens.push({ type: "-" }); index++; continue }
+
+    if ("+-*/%^(),".indexOf(character) >= 0) {
+      tokens.push({ type: character })
+      index++
+      continue
+    }
+
+    return null
+  }
+
+  return tokens
+}
+
+function peek(state) {
+  return state.index < state.tokens.length ? state.tokens[state.index] : null
+}
+
+function take(state) {
+  return state.index < state.tokens.length ? state.tokens[state.index++] : null
+}
+
+// Values carry whether they were written as a percentage, because that decides
+// what the operator above them means: 20% of a product is a fifth of it, but
+// 20% added to a sum is a fifth of what it is being added to. Only the operator
+// directly above a percentage sees the flag -- parentheses close over it, so
+// (20%) is plainly 0.2.
+function plain(value) {
+  return { value: value, percent: false }
+}
+
+// A percentage read as the number it stands for: 20% is 0.2. Everything except
+// the till-style + and - below wants this rather than the raw 20, so every
+// operator, function argument, group and final result goes through it.
+function fraction(operand) {
+  return operand.percent ? operand.value / 100 : operand.value
+}
+
+function shareOf(total, percentage) {
+  return total * percentage / 100
+}
+
+// Recursive descent, one function per precedence level. Every one of them
+// returns null to mean "not a valid expression from here", which is why the
+// callers compare against null rather than testing truthiness: 0 is a perfectly
+// good answer.
+function parseSum(state) {
+  var left = parseProduct(state)
+  if (left === null) return null
+
+  for (;;) {
+    var token = peek(state)
+    if (!token || (token.type !== "+" && token.type !== "-")) return left
+    take(state)
+    state.operators++
+
+    var right = parseProduct(state)
+    if (right === null) return null
+
+    // "178000 - 20%" takes a fifth off 178000; it does not subtract 0.2. The
+    // left side is a plain value by then -- a percentage on the left is the
+    // fraction it names, so "20% + 100" is 100.2 and not 120.
+    var total = fraction(left)
+    var addend = right.percent ? shareOf(total, right.value) : right.value
+    left = plain(token.type === "+" ? total + addend : total - addend)
+  }
+}
+
+function parseProduct(state) {
+  var left = parsePower(state)
+  if (left === null) return null
+
+  for (;;) {
+    var token = peek(state)
+    // "of" multiplies, which is all "20% of 80" is asking for.
+    var isOf = token !== null && token.type === "name" && token.value === "of"
+    if (!token || (token.type !== "*" && token.type !== "/" && !isOf)) return left
+    take(state)
+    state.operators++
+
+    var right = parsePower(state)
+    if (right === null) return null
+
+    // Multiplied or divided, a percentage is simply its fraction: the operand
+    // it meets is the whole that it is a part of.
+    var leftValue = fraction(left)
+    var rightValue = fraction(right)
+    left = plain(token.type === "/" ? leftValue / rightValue : leftValue * rightValue)
+  }
+}
+
+// Right associative, so 2^3^2 is 2^9 rather than 64.
+function parsePower(state) {
+  var base = parseUnary(state)
+  if (base === null) return null
+
+  var token = peek(state)
+  if (!token || token.type !== "^") return base
+  take(state)
+  state.operators++
+
+  var exponent = parsePower(state)
+  if (exponent === null) return null
+  return plain(Math.pow(fraction(base), fraction(exponent)))
+}
+
+function parseUnary(state) {
+  var token = peek(state)
+  if (token && (token.type === "-" || token.type === "+")) {
+    take(state)
+    var operand = parseUnary(state)
+    if (operand === null) return null
+    if (token.type !== "-") return operand
+    return { value: -operand.value, percent: operand.percent }
+  }
+
+  var value = parsePrimary(state)
+  if (value === null) return null
+
+  // Postfix, so "%" is a percentage and not a remainder. A search box is asked
+  // for "20% off" far more often than for a modulo, and the two cannot share
+  // the sign: one wants an operand on its right and the other refuses one.
+  var next = peek(state)
+  if (next && next.type === "%") {
+    take(state)
+    state.operators++
+    return { value: value.value, percent: true }
+  }
+
+  return value
+}
+
+function parsePrimary(state) {
+  var token = take(state)
+  if (!token) return null
+
+  if (token.type === "number") return plain(token.value)
+
+  if (token.type === "(") {
+    // Deliberately not counted as an operation: grouping computes nothing on
+    // its own, and counting it would answer "(5)" with 5. Whatever is inside
+    // raises the count itself if it is worth answering.
+    var grouped = parseSum(state)
+    if (grouped === null) return null
+    var close = take(state)
+    if (!close || close.type !== ")") return null
+    return plain(fraction(grouped))
+  }
+
+  if (token.type === "name") {
+    if (CONSTANTS.hasOwnProperty(token.value)) return plain(CONSTANTS[token.value])
+    if (!FUNCTIONS.hasOwnProperty(token.value)) return null
+    return parseCall(state, FUNCTIONS[token.value])
+  }
+
+  return null
+}
+
+function parseCall(state, callee) {
+  var open = take(state)
+  if (!open || open.type !== "(") return null
+  state.operators++
+
+  var args = []
+  var next = peek(state)
+  if (next && next.type === ")") {
+    take(state)
+  } else {
+    for (;;) {
+      var argument = parseSum(state)
+      if (argument === null) return null
+      args.push(fraction(argument))
+
+      var separator = take(state)
+      if (!separator) return null
+      if (separator.type === ")") break
+      if (separator.type !== ",") return null
+    }
+  }
+
+  // Both ends of the range, so a fixed-arity function does not quietly drop
+  // what it was handed: sqrt(4, 9) is malformed, not 2.
+  if (args.length < callee.arity || args.length > callee.maxArity) return null
+  return plain(callee.apply(args))
+}
+
+function evaluateExpression(text) {
+  var tokens = tokenize(text)
+  if (!tokens || tokens.length === 0) return null
+
+  var state = { tokens: tokens, index: 0, operators: 0 }
+  var parsed = parseSum(state)
+  if (parsed === null) return null
+  // Anything left over means the query only started out looking like a sum.
+  if (state.index !== tokens.length) return null
+
+  // A percentage standing on its own is the fraction it names: "20%" is 0.2.
+  var value = fraction(parsed)
+  if (typeof value !== "number" || !isFinite(value)) return null
+
+  return { value: value, operators: state.operators }
+}
+
+function lookupUnit(name) {
+  var key = String(name || "").toLowerCase().replace(/[°\s]/g, "")
+  if (!key) return ""
+  if (UNITS.hasOwnProperty(key)) return key
+  if (ALIASES.hasOwnProperty(key)) return ALIASES[key]
+
+  // Plurals, without a second row per unit in the tables. The length guard
+  // keeps "s" itself -- seconds -- from being read as a plural of nothing.
+  if (key.length > 2 && key.charAt(key.length - 1) === "s") return lookupUnit(key.slice(0, -1))
+  return ""
+}
+
+function symbolFor(unit) {
+  return SYMBOLS.hasOwnProperty(unit) ? SYMBOLS[unit] : unit
+}
+
+// Temperature scales share no zero, so they convert through kelvin instead of
+// through a factor.
+function toKelvin(value, unit) {
+  if (unit === "c") return value + 273.15
+  if (unit === "f") return (value - 32) * 5 / 9 + 273.15
+  return value
+}
+
+function fromKelvin(kelvin, unit) {
+  if (unit === "c") return kelvin - 273.15
+  if (unit === "f") return (kelvin - 273.15) * 9 / 5 + 32
+  return kelvin
+}
+
+function convert(value, from, to) {
+  var source = UNITS[from]
+  var target = UNITS[to]
+  if (!source || !target || source.dimension !== target.dimension) return null
+  if (source.dimension === "temperature") return fromKelvin(toKelvin(value, from), to)
+  return value * source.factor / target.factor
+}
+
+// The amount is a whole expression with the unit stuck on the end, so
+// "2 * 3 kg" and "20km" both split cleanly. `spaced` reports whether the unit
+// stood on its own, which is what tells a quantity from a search term.
+function splitAmount(text) {
+  var match = String(text).match(/^(.*?)(\s*)([a-zA-Z°]+)$/)
+  if (!match || !match[1].trim()) return null
+
+  var unit = lookupUnit(match[3])
+  if (!unit) return null
+
+  var amount = evaluateExpression(match[1])
+  if (!amount) return null
+
+  return { value: amount.value, unit: unit, spaced: match[2].length > 0, written: match[3] }
+}
+
+// Splits on the connector words, last one first. Order matters for "10 in to
+// cm": read from the left, "in" looks like the connector and leaves "to cm" as
+// the target unit; read from the right, "to" splits it the way it was meant.
+function conversionSplits(text) {
+  var words = text.split(/\s+/)
+  var splits = []
+
+  for (var i = words.length - 2; i > 0; i--) {
+    if (words[i].toLowerCase() !== "to" && words[i].toLowerCase() !== "in") continue
+    splits.push({
+      amount: words.slice(0, i).join(" "),
+      target: words.slice(i + 1).join(" ")
+    })
+  }
+
+  return splits
+}
+
+function evaluateConversion(text) {
+  var splits = conversionSplits(text)
+
+  for (var i = 0; i < splits.length; i++) {
+    var target = lookupUnit(splits[i].target)
+    if (!target) continue
+
+    var amount = splitAmount(splits[i].amount)
+    if (!amount) continue
+
+    var converted = convert(amount.value, amount.unit, target)
+    if (converted === null || !isFinite(converted)) continue
+
+    return [formatNumber(converted) + " " + symbolFor(target)]
+  }
+
+  return null
+}
+
+// A quantity with no target named: answer with the units its own readers want.
+//
+// A unit written against its number has to be at least two letters. Every
+// single-letter unit is also the tail of something people search for -- 4k, 3d,
+// 5g, 7z -- and answering those with a temperature or a duration is worse than
+// not answering. Written with a space, "20 c" is unambiguous and allowed.
+function evaluateQuantity(text) {
+  var amount = splitAmount(text)
+  if (!amount) return null
+  if (!amount.spaced && amount.written.length < 2) return null
+
+  var peers = PEERS[amount.unit]
+  if (!peers) return null
+
+  var results = []
+  for (var i = 0; i < peers.length; i++) {
+    var converted = convert(amount.value, amount.unit, peers[i])
+    if (converted === null || !isFinite(converted)) continue
+    results.push(formatNumber(converted) + " " + symbolFor(peers[i]))
+  }
+
+  return results.length > 0 ? results : null
+}
+
+// Twelve significant digits: enough that a conversion keeps its precision, few
+// enough that 0.1 + 0.2 comes back as 0.3 rather than as the float that
+// actually holds. Number() drops the trailing zeros toPrecision leaves behind.
+function formatNumber(value) {
+  if (value === 0) return "0"
+  return String(Number(value.toPrecision(12)))
+}
+
+// The results as they should be shown, most useful first, or null when the
+// query is not a calculation -- which is nearly every query, so this stays
+// cheap to ask. A list because a bare quantity has more than one right answer.
+function evaluate(query) {
+  var text = String(query || "").trim()
+  if (!text) return null
+
+  var converted = evaluateConversion(text)
+  if (converted !== null) return converted
+
+  var quantity = evaluateQuantity(text)
+  if (quantity !== null) return quantity
+
+  var math = evaluateExpression(text)
+  if (!math) return null
+  // A bare number or constant is not a calculation. "5" typed into a search box
+  // is someone looking for 5, and answering it with "5" is noise.
+  if (math.operators === 0) return null
+
+  return [formatNumber(math.value)]
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    evaluate: evaluate,
+    formatNumber: formatNumber,
+    lookupUnit: lookupUnit,
+    convert: convert
+  }
+}

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -4,6 +4,7 @@ import Quickshell.Wayland
 import QtQuick
 import qs.Commons
 import qs.Ui
+import "Calculator.js" as Calculator
 import "MenuModel.js" as MenuModel
 
 Item {
@@ -519,6 +520,30 @@ Item {
     return MenuModel.displayRow(root.items, root.itemOrder, root.checkedResults, root.disabledResults, entry, detail, score, section)
   }
 
+  // The calculated answer, in the row shape every other row uses: displayModel
+  // is a ListModel and takes its roles from the first row appended to it, so a
+  // row that skipped a key would drop that key for every row behind it.
+  function calculatorRow(result) {
+    return {
+      itemId: "calculator",
+      disabled: false,
+      kind: "action",
+      icon: "󰃬",
+      iconFont: "",
+      appIcon: "",
+      appId: "",
+      label: result,
+      target: "",
+      detail: "Copy to clipboard",
+      path: "",
+      childCount: 0,
+      action: "printf '%s' " + Util.shellQuote(result) + " | wl-copy",
+      provider: "",
+      score: 0,
+      section: ""
+    }
+  }
+
   function rowSelectable(index) {
     if (index < 0 || index >= displayModel.count) return false
     return !displayModel.get(index).disabled
@@ -646,6 +671,15 @@ Item {
         for (var d = 0; d < drilldownRows.length; d++) drilldownRows[d].section = "drilldown"
       }
       rows = currentRows.concat(drilldownRows)
+
+      // Ahead of the matches rather than scored among them. The answer to
+      // "1024 mb to gb" is the whole reason that query was typed, and it should
+      // not have to outrank an app whose name happens to contain "gb".
+      // Unshifted back to front so the list keeps the order it was answered in.
+      var calculation = Calculator.evaluate(query)
+      if (calculation) {
+        for (var c = calculation.length - 1; c >= 0; c--) rows.unshift(root.calculatorRow(calculation[c]))
+      }
     } else {
       for (var j = 0; j < root.itemOrder.length; j++) {
         var child = root.item(root.itemOrder[j])

--- a/test/shell.d/menu-calculator-test.sh
+++ b/test/shell.d/menu-calculator-test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+source "$(dirname "$0")/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const calculator = requireFromRoot('shell/plugins/menu/Calculator.js')
+
+assertDeepEqual(calculator.evaluate('2+2'), ['4'], 'adds')
+assertDeepEqual(calculator.evaluate('10 / 4'), ['2.5'], 'divides into a fraction')
+assertDeepEqual(calculator.evaluate('(1+2)*3'), ['9'], 'respects parentheses')
+assertDeepEqual(calculator.evaluate('2^3^2'), ['512'], 'exponentiation is right associative')
+assertDeepEqual(calculator.evaluate('-5 + 3'), ['-2'], 'reads a leading minus as a sign')
+assertDeepEqual(calculator.evaluate('2 × 3'), ['6'], 'accepts the typographic multiplication sign')
+assertDeepEqual(calculator.evaluate('sqrt(16)'), ['4'], 'calls a function')
+assertDeepEqual(calculator.evaluate('max(3, 9, 2)'), ['9'], 'passes every argument to a variadic function')
+assertDeepEqual(calculator.evaluate('0.1 + 0.2'), ['0.3'], 'rounds float noise away')
+assertDeepEqual(calculator.evaluate('1e6 / 4'), ['250000'], 'reads scientific notation')
+assertDeepEqual(calculator.evaluate('round(3.14159, 2)'), ['3.14'], 'rounds to a given number of places')
+
+// "%" is a percentage, not a remainder: the two cannot share the sign, since
+// one wants an operand on its right and the other refuses one.
+assertDeepEqual(calculator.evaluate('178000*20%'), ['35600'], 'multiplies by a percentage')
+assertDeepEqual(calculator.evaluate('20% of 178000'), ['35600'], 'reads "of" as taking a share')
+assertDeepEqual(calculator.evaluate('178000+20%'), ['213600'], 'adds a percentage of what it is added to')
+assertDeepEqual(calculator.evaluate('178000-20%'), ['142400'], 'subtracts a percentage of what it is taken from')
+assertDeepEqual(calculator.evaluate('20%'), ['0.2'], 'a percentage on its own is its fraction')
+assertDeepEqual(calculator.evaluate('178000 * 20% + 500'), ['36100'], 'keeps precedence around a percentage')
+assertDeepEqual(calculator.evaluate('(20%) * 50'), ['10'], 'parentheses close over the percentage')
+assertDeepEqual(calculator.evaluate('20% + 100'), ['100.2'], 'a percentage on the left is its own fraction, not a share of what follows')
+assertDeepEqual(calculator.evaluate('20% + 20%'), ['0.24'], 'two percentages keep both readings')
+assertDeepEqual(calculator.evaluate('2^50%'), ['1.41421356237'], 'an exponent written as a percentage is its fraction')
+assertDeepEqual(calculator.evaluate('20%^2'), ['0.04'], 'a base written as a percentage is its fraction')
+
+// Grouping computes nothing on its own, so it cannot be what makes a query an
+// expression -- otherwise "(5)" would answer 5.
+assertEqual(calculator.evaluate('(5)'), null, 'parentheses alone are not a calculation')
+assertEqual(calculator.evaluate('(pi)'), null, 'a grouped constant is not a calculation')
+
+// An argument a function would ignore is a typo, not an expression.
+assertEqual(calculator.evaluate('sqrt(4, 9)'), null, 'refuses an extra argument instead of dropping it')
+assertEqual(calculator.evaluate('round(1.234, 2, 3)'), null, 'refuses a third argument to round')
+assertEqual(calculator.evaluate('min(5)'), null, 'refuses a missing argument')
+assertDeepEqual(calculator.evaluate('50% of 80 kg'), ['88.184904874 lb', '40000 g'], 'expands a quantity computed from a share')
+
+assertDeepEqual(calculator.evaluate('20 km to mi'), ['12.4274238447 mi'], 'converts length')
+assertDeepEqual(calculator.evaluate('2 lb to kg'), ['0.90718474 kg'], 'converts mass')
+assertDeepEqual(calculator.evaluate('90 min to h'), ['1.5 h'], 'converts time')
+assertDeepEqual(calculator.evaluate('1 gb to mb'), ['1000 MB'], 'converts decimal data units')
+assertDeepEqual(calculator.evaluate('1 gib to mib'), ['1024 MiB'], 'converts binary data units')
+assertDeepEqual(calculator.evaluate('1 gal to l'), ['3.785411784 L'], 'converts volume')
+assertDeepEqual(calculator.evaluate('100 f to c'), ['37.7777777778 °C'], 'converts temperature across offsets')
+assertDeepEqual(calculator.evaluate('0 c to f'), ['32 °F'], 'converts freezing point')
+assertDeepEqual(calculator.evaluate('72f to c'), ['22.2222222222 °C'], 'reads a unit stuck to its number')
+assertDeepEqual(calculator.evaluate('2 * 3 kg to lb'), ['13.2277357311 lb'], 'converts a computed amount')
+assertDeepEqual(calculator.evaluate('5 kilometers to miles'), ['3.10685596119 mi'], 'reads plural long unit names')
+assertDeepEqual(calculator.evaluate('2 lbs to kg'), ['0.90718474 kg'], 'reads a plural symbol without a table entry for it')
+
+// "ton" is 1000 kg in most of the world and 907 kg in the US. An alias that is
+// silently wrong by a tenth is worse than an alias that is missing.
+assertEqual(calculator.evaluate('1 ton to kg'), null, 'refuses the ambiguous ton')
+assertDeepEqual(calculator.evaluate('1 tonne to kg'), ['1000 kg'], 'accepts the unambiguous tonne')
+
+// "in" is both a connector and a unit, so the split has to be read from the
+// right: from the left this is 10 converted into a unit called "to cm".
+assertDeepEqual(calculator.evaluate('10 in to cm'), ['25.4 cm'], 'prefers the rightmost connector')
+
+// A quantity with no target named answers with the units its readers want.
+assertDeepEqual(calculator.evaluate('5km'), ['3.10685596119 mi', '5000 m'], 'expands a bare length')
+assertDeepEqual(calculator.evaluate('20kg'), ['44.092452437 lb', '20000 g'], 'expands a bare mass')
+assertDeepEqual(calculator.evaluate('1gb'), ['0.931322574615 GiB', '1000 MB'], 'expands a bare data size across both bases')
+assertDeepEqual(calculator.evaluate('20 c'), ['68 °F', '293.15 K'], 'expands a bare temperature')
+assertDeepEqual(calculator.evaluate('2*3 kg'), ['13.2277357311 lb', '6000 g'], 'expands a computed bare quantity')
+
+// Every single-letter unit is also the tail of something people search for, so
+// against a number it needs the space that makes it a quantity.
+assertEqual(calculator.evaluate('4k'), null, 'does not read 4k as kelvin')
+assertEqual(calculator.evaluate('3d'), null, 'does not read 3d as days')
+assertEqual(calculator.evaluate('5m'), null, 'does not read an attached single-letter unit')
+assertDeepEqual(calculator.evaluate('5 m'), ['16.4041994751 ft', '500 cm'], 'reads the same unit once it is spaced')
+
+assertEqual(calculator.evaluate(''), null, 'ignores an empty query')
+assertEqual(calculator.evaluate('5'), null, 'a bare number is not a calculation')
+assertEqual(calculator.evaluate('pi'), null, 'a bare constant is not a calculation')
+assertEqual(calculator.evaluate('app'), null, 'ignores an ordinary search')
+assertEqual(calculator.evaluate('zen browser'), null, 'ignores a two-word search')
+assertEqual(calculator.evaluate('2 factorio'), null, 'ignores a search that starts with a number')
+assertEqual(calculator.evaluate('1password'), null, 'ignores a search that starts with a number and ends in letters')
+assertEqual(calculator.evaluate('20 km to kg'), null, 'refuses to convert across dimensions')
+assertEqual(calculator.evaluate('1/0'), null, 'refuses a result that is not finite')
+
+const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+
+assert(
+  menuQml.includes('Calculator.evaluate(query)') && menuQml.includes('rows.unshift(root.calculatorRow(calculation[c]))'),
+  'menu search puts every calculated answer ahead of the matches'
+)
+
+assert(
+  /action: "printf '%s' " \+ Util\.shellQuote\(result\) \+ " \| wl-copy"/.test(menuQml),
+  'calculator row copies its result through a quoted argument'
+)
+JS


### PR DESCRIPTION
The menu search answers arithmetic and unit conversions, so `Super + Space` covers the "quick sum" and "how many miles is that" reflexes without leaving the launcher.

- Arithmetic: `1024/16`, `(12+8)*3`, `2^10`, `sqrt(2)`, `max(3, 9, 2)`, `1e6/4`, `round(3.14159, 2)`
- Percentages: `178000*20%` and `20% of 178000` take the share, while `178000+20%` adds it to what it is added to, the way a till does
- Conversions: `20 km to mi`, `100 f to c`, `1 gb to mib`, `2 lbs to kg` — length, mass, time, data, volume and temperature
- A quantity on its own answers with the units its readers usually want, so `5km` offers both miles and metres

Enter copies the result.

`%` is a percentage rather than a remainder. The two cannot share the sign — one wants an operand on its right and the other refuses one — and a search box is asked for "20% off" far more often than for a modulo.

The evaluation is a tokenizer and a recursive-descent parser in `shell/plugins/menu/Calculator.js`, not `eval`: the search box sees whatever is halfway typed, and `eval` would hand that the whole QML scope. The module is pure JS with no QML types, so `test/shell.d/menu-calculator-test.sh` exercises it directly under Node.

Search stays search. A row appears only when something was actually computed, so a bare number or a bare constant produces nothing, and a single-letter unit written against its number is not read as a unit: `4k`, `3d`, `5m` and `1080p` stay queries, while `20 c` with its space is a temperature. `ton` is deliberately missing — 1000 kg in most of the world and 907 kg in the US, and an alias silently wrong by a tenth is worse than one that is absent.
