### PR TITLE
Allow forgetting the connected Wi-Fi network

### DIFF
--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -308,8 +308,11 @@ function requiresCredentials(security, openSecurity, oweSecurity) {
   return security !== openSecurity && security !== oweSecurity
 }
 
+// Connected networks stay forgettable: deleting the active profile makes
+// NetworkManager drop the connection itself, so no separate disconnect step
+// is needed (mirrors the Bluetooth panel, which forgets connected devices).
 function canForgetNetwork(network) {
-  return !!(network && network.known && !network.connected)
+  return !!(network && network.known)
 }
 
 // The password arrives on stdin and reaches nmcli through the scriptable

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -260,7 +260,8 @@ assertEqual(network.networkFailureReason(99, true, reasons), 'Failed to connect'
 assertEqual(network.canForgetNetwork({ known: true, connected: false, security: security.Owe }), true, 'network can forget known disconnected OWE networks')
 assertEqual(network.canForgetNetwork({ known: true, connected: false, security: security.Open }), true, 'network can forget known disconnected open networks')
 assertEqual(network.canForgetNetwork({ known: false, connected: false, security: security.Owe }), false, 'network cannot forget unknown networks')
-assertEqual(network.canForgetNetwork({ known: true, connected: true, security: security.Owe }), false, 'network cannot forget the connected network')
+assertEqual(network.canForgetNetwork({ known: true, connected: true, security: security.Owe }), true, 'network can forget the connected network')
+assertEqual(network.canForgetNetwork({ known: true, connected: true, security: security.Sae }), true, 'network can forget the connected credentialed network')
 
 assertEqual(network.shouldRepromptPassphrase(reasons.NoSecrets, true, reasons), true, 'network reprompts when required credentials are missing')
 assertEqual(network.shouldRepromptPassphrase(reasons.NoSecrets, false, reasons), false, 'network does not ask a passwordless network for missing secrets')


### PR DESCRIPTION
Fixes #8624

## Problem

The network panel hides the forget action for the currently connected Wi-Fi network, because `canForgetNetwork()` in `shell/plugins/panels/network/Model.js` required `!network.connected`. This means you cannot remove a saved network you are connected to — e.g. to re-enter a changed password — without first connecting to a different network or disconnecting.

The Bluetooth panel already allows forgetting a connected device, so this brings the network panel in line with that behavior.

## Fix

Relax `canForgetNetwork()` to only require that the network is known. No changes to Panel.qml are needed: the forget action already routes eligibility through `Model.canForgetNetwork`, and `checkActionCompletion` already tracks forget completion via `!network.known`.

Forgetting a connected network is safe: Quickshell's `Network::forget()` deletes the connection profile via the NetworkManager D-Bus `Settings.Connection.Delete()` call, and NetworkManager deactivates the active connection itself when its profile is removed.

## Testing

- Updated `test/shell.d/network-test.sh` assertions for connected known networks; all 105 assertions pass.
- Verified live via `omarchy dev link`: opened the network panel, focused the forget action on the connected network with keyboard navigation, triggered it, and confirmed the network disconnected and its profile was removed from NetworkManager.

Screenshots to follow in a comment.