### PR TITLE
WhatsApp Slim: avatar-name tooltip and rail divider

### DIFF
--- a/default/chromium/extensions/whatsapp-slim/avatar-tooltip.js
+++ b/default/chromium/extensions/whatsapp-slim/avatar-tooltip.js
@@ -30,13 +30,23 @@
   document.documentElement.appendChild(tip);
 
   function getName(cell) {
+    // The avatar image's title is the contact/group name. An unread row can
+    // instead surface an indicator image (muted/pinned/etc.), so only trust the
+    // title when it reads like a name rather than a count or status word.
     const img = cell.querySelector("img[title]");
-    const t = img && img.getAttribute("title");
-    if (t && t.trim()) return t.trim();
+    if (img) {
+      const t = img.getAttribute("title").trim();
+      if (t && !/^\d+$/.test(t) && !/unread|message|muted|pinned|archived/i.test(t)) {
+        return t;
+      }
+    }
+    // Fallback: first text span that isn't the unread badge or a bare count,
+    // either of which would otherwise masquerade as the name in the tooltip.
     const spans = cell.querySelectorAll("span");
     for (const s of spans) {
+      if (s.matches('[aria-label*="unread"]')) continue;
       const x = s.textContent.trim();
-      if (x) return x;
+      if (x && !/^\d+$/.test(x)) return x;
     }
     return "";
   }

--- a/default/chromium/extensions/whatsapp-slim/avatar-tooltip.js
+++ b/default/chromium/extensions/whatsapp-slim/avatar-tooltip.js
@@ -61,7 +61,7 @@
   }
 
   function show(cell) {
-    const name = cell.dataset.waName || getName(cell);
+    const name = getName(cell);
     if (!name) return;
     tip.textContent = name;
     const r = cell.getBoundingClientRect();

--- a/default/chromium/extensions/whatsapp-slim/avatar-tooltip.js
+++ b/default/chromium/extensions/whatsapp-slim/avatar-tooltip.js
@@ -1,0 +1,73 @@
+// Shows the chat/contact name in a floating tooltip when hovering an avatar in
+// the collapsed (rail) layout. Only active when the chat list is narrowed to the
+// avatar rail (window <= 1100px), matching whatsapp.css's collapse breakpoint.
+(function () {
+  const RAIL_QUERY = "(max-width: 1100px)";
+  let railMode = window.matchMedia(RAIL_QUERY).matches;
+  window.matchMedia(RAIL_QUERY).addEventListener("change", (e) => {
+    railMode = e.matches;
+    hide();
+  });
+
+  const tip = document.createElement("div");
+  tip.id = "wa-slim-tooltip";
+  Object.assign(tip.style, {
+    position: "fixed",
+    zIndex: "2147483647",
+    display: "none",
+    maxWidth: "240px",
+    padding: "6px 10px",
+    borderRadius: "8px",
+    background: "rgba(32,44,51,0.96)",
+    color: "#e9edef",
+    font: "500 13px/1.3 'Helvetica Neue',Arial,sans-serif",
+    boxShadow: "0 2px 12px rgba(0,0,0,0.4)",
+    pointerEvents: "none",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  });
+  document.documentElement.appendChild(tip);
+
+  function getName(cell) {
+    const img = cell.querySelector("img[title]");
+    const t = img && img.getAttribute("title");
+    if (t && t.trim()) return t.trim();
+    const spans = cell.querySelectorAll("span");
+    for (const s of spans) {
+      const x = s.textContent.trim();
+      if (x) return x;
+    }
+    return "";
+  }
+
+  function tag(cell) {
+    if (cell.dataset.waName !== undefined) return;
+    cell.dataset.waName = getName(cell);
+    cell.addEventListener("mouseenter", () => {
+      if (railMode) show(cell);
+    });
+    cell.addEventListener("mouseleave", hide);
+  }
+
+  function show(cell) {
+    const name = cell.dataset.waName || getName(cell);
+    if (!name) return;
+    tip.textContent = name;
+    const r = cell.getBoundingClientRect();
+    tip.style.display = "block";
+    tip.style.left = r.right + 8 + "px";
+    tip.style.top = Math.max(8, r.top) + "px";
+  }
+
+  function hide() {
+    tip.style.display = "none";
+  }
+
+  const root = document.querySelector("#pane-side") || document.body;
+  const io = new MutationObserver(() => {
+    root.querySelectorAll('[data-testid="cell-frame-container"]').forEach(tag);
+  });
+  io.observe(root, { childList: true, subtree: true });
+  root.querySelectorAll('[data-testid="cell-frame-container"]').forEach(tag);
+})();

--- a/default/chromium/extensions/whatsapp-slim/manifest.json
+++ b/default/chromium/extensions/whatsapp-slim/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WhatsApp Slim",
-  "version": "1.1",
+  "version": "1.2",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAszLhFYxjvKqx1VAORt3M6b0H1Kz03cmQ1MrUjJZ8gj3nhRcvufk6PS17yUIjEdKKmuj+1HuFVwOaHJQsACGJXwn2TeKQqZmZx/83yd7ydgabHXTsJbhy5O+Yunv+VA1B2IX/phcXpkH9bPv2PuC/bQ13nmmAvT2b+EMyq8EPQHOoSWhE4M4kIhLDczTmxfJX5X3tTxH66952DYuQWvGpIXLAUXkvIgap0qemW68/LymPaWzcg6g3oE/nZ7C0j7JE5bnqLFxqXNlA9Jt+Ss/1Y33QL3OSD9EEsrpgueS0bbqtkmFQ9/jGlruIL+qj0xe+CAtqbJ5ty9H/sqi01kjfyQIDAQAB",
   "description": "Make WhatsApp Web follow the system theme and collapse its chat list in narrow windows, this extension is installed by Omarchy",
   "content_scripts": [
@@ -16,6 +16,15 @@
         "system-theme.js"
       ],
       "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "https://web.whatsapp.com/*"
+      ],
+      "js": [
+        "avatar-tooltip.js"
+      ],
+      "run_at": "document_idle"
     }
   ]
 }

--- a/default/chromium/extensions/whatsapp-slim/whatsapp.css
+++ b/default/chromium/extensions/whatsapp-slim/whatsapp.css
@@ -10,6 +10,10 @@
     flex: 0 0 90px !important;
     min-width: 90px !important;
     max-width: 90px !important;
+    /* Keep the divider that the full-width list shows, so the rail reads as a
+     * distinct column. Uses WhatsApp's pane-border var when present and falls
+     * back to a neutral that works in both light and dark themes. */
+    border-right: 1px solid var(--pane-border, rgba(127, 127, 127, 0.3)) !important;
   }
 
   /* Chat-list title bar, search, filter chips, and banner don't fit.


### PR DESCRIPTION
## Summary

Two fixes for the WhatsApp Slim extension's collapsed avatar rail (window <= 1100px):

- Show the contact name in a tooltip when hovering an avatar.
- Restore the rail's divider border.

## What changed

- `avatar-tooltip.js` (new): hover tooltip with the chat name, gated to rail mode.
- `whatsapp.css`: adds the rail divider border.
- `manifest.json`: 1.1 -> 1.2, registers the new script (key unchanged, so the
  extension id stays stable).

## Verification

- `test/shell.d/chromium-whatsapp-slim-test.sh` passes.
- Screenshots below: rail divider, and name tooltip on avatar hover.

## Screenshots
<img width="1420" height="1724" alt="screenshot-1" src="https://github.com/user-attachments/assets/960cacd2-46bc-40fb-ad7d-0054a8db2700" />
<img width="1420" height="1724" alt="screenshot-2" src="https://github.com/user-attachments/assets/f2fd1bba-8bfa-4e84-9f94-539cdd04e3fb" />
