### PR TITLE
Let an explicit name mean the launcher it has always meant

### DIFF
--- a/bin/omarchy-webapp-present
+++ b/bin/omarchy-webapp-present
@@ -9,7 +9,7 @@ DESKTOP_DIR="$HOME/.local/share/applications"
 # removed: find descends into the directories an older omarchy-webapp-install
 # made out of a slash in the name, and reads a launcher that is a symlink.
 while IFS= read -r -d '' file; do
-  if grep -q '^Exec=.*\(omarchy-launch-webapp\|omarchy-webapp-handler\).*' "$file"; then
+  if grep -q '^Exec=.*\(omarchy-launch-webapp\|omarchy-webapp-handler\).*' "$file" 2>/dev/null; then
     exit 0
   fi
 done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0 2>/dev/null)

--- a/bin/omarchy-webapp-present
+++ b/bin/omarchy-webapp-present
@@ -4,9 +4,14 @@
 
 DESKTOP_DIR="$HOME/.local/share/applications"
 
-# An older omarchy-webapp-install turned a slash in the name into a directory
-# level, and omarchy-webapp-remove can still reach what that left behind, so
-# look for launchers the way it does rather than only at the top level.
-grep -rqE --include='*.desktop' \
-  '^Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler)' \
-  "$DESKTOP_DIR" 2>/dev/null
+# Look for launchers exactly the way omarchy-webapp-remove does, so the menu
+# cannot offer a row the remover finds nothing for, or hide one it could have
+# removed: find descends into the directories an older omarchy-webapp-install
+# made out of a slash in the name, and reads a launcher that is a symlink.
+while IFS= read -r -d '' file; do
+  if grep -q '^Exec=.*\(omarchy-launch-webapp\|omarchy-webapp-handler\).*' "$file"; then
+    exit 0
+  fi
+done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0 2>/dev/null)
+
+exit 1

--- a/bin/omarchy-webapp-present
+++ b/bin/omarchy-webapp-present
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# omarchy:summary=Returns true if any web app launcher is installed.
+
+DESKTOP_DIR="$HOME/.local/share/applications"
+
+# An older omarchy-webapp-install turned a slash in the name into a directory
+# level, and omarchy-webapp-remove can still reach what that left behind, so
+# look for launchers the way it does rather than only at the top level.
+grep -rqE --include='*.desktop' \
+  '^Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler)' \
+  "$DESKTOP_DIR" 2>/dev/null

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -51,7 +51,14 @@ if [[ -z $APP_NAME ]]; then
 fi
 
 icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
-desktop_file=$(path_for_web_app "$APP_NAME")
+# An explicit name has always addressed the launcher of that name in the
+# applications directory, and omarchy-remove-launcher-entry hands one straight
+# back from the file it just found. Reach into the index only when no such file
+# exists -- the one case where a nested launcher can be named at all.
+desktop_file="$DESKTOP_DIR/$APP_NAME.desktop"
+if [[ ! -f $desktop_file ]]; then
+  desktop_file=$(path_for_web_app "$APP_NAME")
+fi
 rm -f "${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}"
 rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
 

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -37,12 +37,21 @@ if (( $# == 0 )); then
   if ((${#WEB_APPS[@]})); then
     mapfile -t SORTED_WEB_APPS < <(printf '%s\n' "${WEB_APPS[@]}" | sort)
     APP_NAME=$(omarchy-menu-select "Select web app to remove" "${SORTED_WEB_APPS[@]}" -- --width 520 --maxheight 520)
+    # The picker offers names the scan produced, so the file a name came from is
+    # the file to delete. Rebuilding a path out of the name cannot reach a
+    # launcher an older install nested inside directories.
+    DESKTOP_FILE=$(path_for_web_app "$APP_NAME")
   else
     echo "No web apps to remove."
     exit 1
   fi
 else
   APP_NAME="$*"
+  # A name from a caller has always meant the launcher of that name in the
+  # applications directory, and omarchy-remove-service-tailscale and its
+  # siblings pass fixed ones. Resolving those through the scan lets a nested
+  # launcher that merely shares a basename answer to them.
+  DESKTOP_FILE="$DESKTOP_DIR/$APP_NAME.desktop"
 fi
 
 if [[ -z $APP_NAME ]]; then
@@ -51,15 +60,7 @@ if [[ -z $APP_NAME ]]; then
 fi
 
 icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
-# An explicit name has always addressed the launcher of that name in the
-# applications directory, and omarchy-remove-launcher-entry hands one straight
-# back from the file it just found. Reach into the index only when no such file
-# exists -- the one case where a nested launcher can be named at all.
-desktop_file="$DESKTOP_DIR/$APP_NAME.desktop"
-if [[ ! -f $desktop_file ]]; then
-  desktop_file=$(path_for_web_app "$APP_NAME")
-fi
-rm -f "${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}"
+rm -f "${DESKTOP_FILE:-$DESKTOP_DIR/$APP_NAME.desktop}"
 rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
 
 if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -21,8 +21,9 @@ while IFS= read -r -d '' file; do
   fi
 done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0 2>/dev/null)
 
-# The launcher matching a chosen name, or empty when nothing was indexed under
-# it (an app removed between the scan and the pick, say).
+# The launcher matching a chosen name, or empty when the name does not match
+# anything the scan indexed -- which the picker can return, because it parses a
+# tab in an option as its own separator and hands back only what follows.
 path_for_web_app() {
   local wanted="$1" i
   for i in "${!WEB_APPS[@]}"; do
@@ -60,7 +61,14 @@ if [[ -z $APP_NAME ]]; then
 fi
 
 icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
-rm -f "${DESKTOP_FILE:-$DESKTOP_DIR/$APP_NAME.desktop}"
+# A name the index cannot place is not an invitation to guess: reconstructing a
+# top-level path from it deletes whatever happens to sit there.
+if [[ -z $DESKTOP_FILE ]]; then
+  echo "No web app launcher found for: $APP_NAME"
+  exit 1
+fi
+
+rm -f "$DESKTOP_FILE"
 rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
 
 if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -283,7 +283,7 @@
   "remove.theme": {"icon":"󰸌","label":"Theme","action":"omarchy-theme-remove"},
   "remove.gaming": {"icon":"","label":"Gaming","title":"Remove"},
   "remove.browser": {"icon":"","label":"Browser","title":"Remove"},
-  "remove.webapp": {"icon":"","label":"Web App","when":"grep -qE '^Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler)' $HOME/.local/share/applications/*.desktop","action":"omarchy-webapp-remove"},
+  "remove.webapp": {"icon":"","label":"Web App","when":"grep -rqE --include='*.desktop' '^Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler)' $HOME/.local/share/applications 2>/dev/null","action":"omarchy-webapp-remove"},
   "remove.tui": {"icon":"","label":"TUI","when":"grep -qE '^Exec=.*(\\$TERMINAL|xdg-terminal-exec).*-e' $HOME/.local/share/applications/*.desktop","action":"omarchy-tui-remove"},
   "remove.windows": {"icon":"󰍲","label":"Windows","when":"[[ -f $HOME/.local/share/applications/windows-vm.desktop ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-windows-vm remove'"},
   "remove.preinstalls": {"icon":"󰏓","label":"Preinstalls","when":"[[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-preinstalls"},

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -283,7 +283,7 @@
   "remove.theme": {"icon":"󰸌","label":"Theme","action":"omarchy-theme-remove"},
   "remove.gaming": {"icon":"","label":"Gaming","title":"Remove"},
   "remove.browser": {"icon":"","label":"Browser","title":"Remove"},
-  "remove.webapp": {"icon":"","label":"Web App","when":"grep -rqE --include='*.desktop' '^Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler)' $HOME/.local/share/applications 2>/dev/null","action":"omarchy-webapp-remove"},
+  "remove.webapp": {"icon":"","label":"Web App","when":"omarchy-webapp-present","action":"omarchy-webapp-remove"},
   "remove.tui": {"icon":"","label":"TUI","when":"grep -qE '^Exec=.*(\\$TERMINAL|xdg-terminal-exec).*-e' $HOME/.local/share/applications/*.desktop","action":"omarchy-tui-remove"},
   "remove.windows": {"icon":"󰍲","label":"Windows","when":"[[ -f $HOME/.local/share/applications/windows-vm.desktop ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-windows-vm remove'"},
   "remove.preinstalls": {"icon":"󰏓","label":"Preinstalls","when":"[[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-preinstalls"},

--- a/test/shell.d/webapp-name-test.sh
+++ b/test/shell.d/webapp-name-test.sh
@@ -124,3 +124,19 @@ noise=$(HOME="$tmp_dir/empty" PATH="$tmp_dir/bin:$PATH" OMARCHY_REMOVE_NOTIFY=fa
 [[ -n $noise ]] &&
   fail "webapp remove stays quiet with no applications directory" "$noise"
 pass "webapp remove stays quiet when there is no applications directory"
+
+# omarchy-remove-launcher-entry hands back the basename of a top-level launcher
+# it just found, so an explicit name has to keep meaning that file. The
+# top-level entry here is deliberately not a web app: that keeps it out of the
+# index, so the outcome does not depend on the order find walked the directory.
+rm -rf "$apps_dir"
+mkdir -p "$apps_dir/legacy"
+printf '[Desktop Entry]\nExec=foot\n' >"$apps_dir/Tailscale.desktop"
+cat >"$apps_dir/legacy/Tailscale.desktop" <<'DESKTOP'
+[Desktop Entry]
+Exec=omarchy-launch-webapp https://unrelated.example
+DESKTOP
+run_remove "Tailscale" >/dev/null
+[[ -f "$apps_dir/legacy/Tailscale.desktop" ]] ||
+  fail "webapp remove leaves a nested launcher alone when it was given a top-level name"
+pass "webapp remove addresses the top-level launcher an explicit name asks for"

--- a/test/shell.d/webapp-name-test.sh
+++ b/test/shell.d/webapp-name-test.sh
@@ -23,6 +23,17 @@ run_remove() {
     "$ROOT/bin/omarchy-webapp-remove" "$@"
 }
 
+# The picker and a caller hand the remover the same kind of string and mean
+# different things by it, so the no-argument path has to be driven as itself
+# rather than imitated with an argument. The stub returns whatever was picked.
+printf '#!/bin/bash\nprintf "%%s\\n" "$PICK"\n' >"$tmp_dir/bin/omarchy-menu-select"
+chmod +x "$tmp_dir/bin/omarchy-menu-select"
+
+run_pick() {
+  HOME="$tmp_dir/home" PATH="$tmp_dir/bin:$PATH" OMARCHY_REMOVE_NOTIFY=false PICK="$1" \
+    "$ROOT/bin/omarchy-webapp-remove"
+}
+
 apps_dir="$tmp_dir/home/.local/share/applications"
 icons_dir="$tmp_dir/home/.local/share/icons/hicolor/256x256/apps"
 
@@ -112,7 +123,7 @@ DESKTOP
 
 # This is the name the picker shows for that file: the script strips .desktop
 # from the path and then takes the basename, which lands on the directory.
-run_remove "127.0.0.1:4000" >/dev/null
+run_pick "127.0.0.1:4000" >/dev/null
 [[ -f "$apps_dir/http:/127.0.0.1:4000/.desktop" ]] &&
   fail "webapp remove deletes a launcher left nested by an older install"
 pass "webapp remove reaches a nested legacy launcher"
@@ -139,4 +150,24 @@ DESKTOP
 run_remove "Tailscale" >/dev/null
 [[ -f "$apps_dir/legacy/Tailscale.desktop" ]] ||
   fail "webapp remove leaves a nested launcher alone when it was given a top-level name"
+[[ -f "$apps_dir/Tailscale.desktop" ]] &&
+  fail "webapp remove deletes the top-level launcher an explicit name asks for"
 pass "webapp remove addresses the top-level launcher an explicit name asks for"
+
+# The same two files, reached the other way. The picker only ever offered the
+# nested web app -- the top-level entry is not one and was never in the list --
+# so picking that name has to delete what was shown rather than what shares its
+# name in the applications directory.
+rm -rf "$apps_dir"
+mkdir -p "$apps_dir/legacy"
+printf '[Desktop Entry]\nExec=foot\n' >"$apps_dir/Tailscale.desktop"
+cat >"$apps_dir/legacy/Tailscale.desktop" <<'DESKTOP'
+[Desktop Entry]
+Exec=omarchy-launch-webapp https://unrelated.example
+DESKTOP
+run_pick "Tailscale" >/dev/null
+[[ -f "$apps_dir/legacy/Tailscale.desktop" ]] &&
+  fail "webapp remove deletes the launcher the picker offered"
+[[ -f "$apps_dir/Tailscale.desktop" ]] ||
+  fail "webapp remove leaves alone a launcher the picker never offered"
+pass "webapp remove deletes the file behind the name the picker showed"

--- a/test/shell.d/webapp-name-test.sh
+++ b/test/shell.d/webapp-name-test.sh
@@ -215,3 +215,17 @@ printf '[Desktop Entry]\nExec=foot\n' >"$apps_dir/foot.desktop"
 HOME="$tmp_dir/home" PATH="$ROOT/bin:$PATH" bash -c "$webapp_menu_guard" &&
   fail "the Remove menu hides Web App when no launcher is a web app"
 pass "the Remove menu hides Web App when there is none"
+
+# A launcher can be a symlink, and the remover's own scan reads one, so the menu
+# has to see it too -- a guard that misses it hides a row for something that is
+# sitting there removable.
+rm -rf "$apps_dir" "$tmp_dir/elsewhere"
+mkdir -p "$apps_dir" "$tmp_dir/elsewhere"
+cat >"$tmp_dir/elsewhere/Linked.desktop" <<'DESKTOP'
+[Desktop Entry]
+Exec=omarchy-launch-webapp https://linked.example
+DESKTOP
+ln -s "$tmp_dir/elsewhere/Linked.desktop" "$apps_dir/Linked.desktop"
+HOME="$tmp_dir/home" PATH="$ROOT/bin:$PATH" bash -c "$webapp_menu_guard" ||
+  fail "the Remove menu sees a launcher that is a symlink"
+pass "the Remove menu sees a symlinked launcher"

--- a/test/shell.d/webapp-name-test.sh
+++ b/test/shell.d/webapp-name-test.sh
@@ -203,7 +203,7 @@ cat >"$apps_dir/http:/127.0.0.1:4000/.desktop" <<'DESKTOP'
 [Desktop Entry]
 Exec=omarchy-launch-webapp https://127.0.0.1:4000
 DESKTOP
-HOME="$tmp_dir/home" bash -c "$webapp_menu_guard" ||
+HOME="$tmp_dir/home" PATH="$ROOT/bin:$PATH" bash -c "$webapp_menu_guard" ||
   fail "the Remove menu offers Web App when the only launcher is a nested one"
 pass "the Remove menu reaches a launcher an older install nested"
 
@@ -212,6 +212,6 @@ pass "the Remove menu reaches a launcher an older install nested"
 rm -rf "$apps_dir"
 mkdir -p "$apps_dir"
 printf '[Desktop Entry]\nExec=foot\n' >"$apps_dir/foot.desktop"
-HOME="$tmp_dir/home" bash -c "$webapp_menu_guard" &&
+HOME="$tmp_dir/home" PATH="$ROOT/bin:$PATH" bash -c "$webapp_menu_guard" &&
   fail "the Remove menu hides Web App when no launcher is a web app"
 pass "the Remove menu hides Web App when there is none"

--- a/test/shell.d/webapp-name-test.sh
+++ b/test/shell.d/webapp-name-test.sh
@@ -229,3 +229,16 @@ ln -s "$tmp_dir/elsewhere/Linked.desktop" "$apps_dir/Linked.desktop"
 HOME="$tmp_dir/home" PATH="$ROOT/bin:$PATH" bash -c "$webapp_menu_guard" ||
   fail "the Remove menu sees a launcher that is a symlink"
 pass "the Remove menu sees a symlinked launcher"
+
+# A predicate answers with its exit status, so a launcher it cannot read is not
+# something to say anything about: omarchy-webapp-present is run directly as
+# `omarchy webapp present`, where find's silence would not cover grep's.
+rm -rf "$apps_dir"
+mkdir -p "$apps_dir"
+printf '[Desktop Entry]\nExec=foot\n' >"$apps_dir/unreadable.desktop"
+chmod 000 "$apps_dir/unreadable.desktop"
+guard_noise=$(HOME="$tmp_dir/home" "$ROOT/bin/omarchy-webapp-present" 2>&1 >/dev/null || true)
+chmod 644 "$apps_dir/unreadable.desktop"
+[[ -n $guard_noise ]] &&
+  fail "omarchy-webapp-present stays quiet about a launcher it cannot read" "$guard_noise"
+pass "omarchy-webapp-present stays quiet about a launcher it cannot read"

--- a/test/shell.d/webapp-name-test.sh
+++ b/test/shell.d/webapp-name-test.sh
@@ -171,3 +171,47 @@ run_pick "Tailscale" >/dev/null
 [[ -f "$apps_dir/Tailscale.desktop" ]] ||
   fail "webapp remove leaves alone a launcher the picker never offered"
 pass "webapp remove deletes the file behind the name the picker showed"
+
+# The picker parses a tab in an option as its own separator, so a name it hands
+# back is not guaranteed to be one the scan indexed. Rebuilding a top-level path
+# from a name that cannot be placed deletes whatever happens to sit there.
+rm -rf "$apps_dir"
+mkdir -p "$apps_dir/legacy"
+printf '[Desktop Entry]\nExec=foot\n' >"$apps_dir/Victim.desktop"
+cat >"$apps_dir/legacy/Real.desktop" <<'DESKTOP'
+[Desktop Entry]
+Exec=omarchy-launch-webapp https://real.example
+DESKTOP
+run_pick "Victim" >/dev/null 2>&1 &&
+  fail "webapp remove refuses a picked name the scan never indexed"
+[[ -f "$apps_dir/Victim.desktop" ]] ||
+  fail "webapp remove deletes nothing when it cannot place the picked name"
+pass "webapp remove refuses a picked name the scan never indexed"
+
+# Reaching the picker at all is the menu's decision, and a launcher an older
+# install nested is exactly the one a non-recursive glob cannot see. Take the
+# guard from the menu definition rather than restating it, so the two cannot
+# drift apart.
+webapp_menu_guard=$(grep -o '"remove\.webapp":.*' "$ROOT/default/omarchy/omarchy-menu.jsonc" |
+  sed 's/.*"when":"//; s/","action".*//')
+[[ -n $webapp_menu_guard ]] ||
+  fail "the menu definition still has a when guard on Remove > Web App"
+
+rm -rf "$apps_dir"
+mkdir -p "$apps_dir/http:/127.0.0.1:4000"
+cat >"$apps_dir/http:/127.0.0.1:4000/.desktop" <<'DESKTOP'
+[Desktop Entry]
+Exec=omarchy-launch-webapp https://127.0.0.1:4000
+DESKTOP
+HOME="$tmp_dir/home" bash -c "$webapp_menu_guard" ||
+  fail "the Remove menu offers Web App when the only launcher is a nested one"
+pass "the Remove menu reaches a launcher an older install nested"
+
+# And still hides the row when there is nothing to remove, so the guard has not
+# simply been widened into always-true.
+rm -rf "$apps_dir"
+mkdir -p "$apps_dir"
+printf '[Desktop Entry]\nExec=foot\n' >"$apps_dir/foot.desktop"
+HOME="$tmp_dir/home" bash -c "$webapp_menu_guard" &&
+  fail "the Remove menu hides Web App when no launcher is a web app"
+pass "the Remove menu hides Web App when there is none"


### PR DESCRIPTION
#7984 taught `omarchy-webapp-remove` to delete the file its scan found rather than a path rebuilt from the displayed name, which is what lets removal reach a launcher an older install nested inside directories. It applied that to every name, and the two kinds of name mean different things.

A name from the picker is a label the scan produced, and only the scan can turn it back into a file. A name from a caller is the launcher of that name in the applications directory: `omarchy-remove-launcher-entry` hands back the basename of a top-level file it just found, and `omarchy-remove-service-tailscale` and its siblings pass fixed strings. Resolving those through the index answers them with whichever match the recursive walk reached first, so with only `applications/legacy/Tailscale.desktop` present, `omarchy-webapp-remove Tailscale` deleted it — where before #7984 that call touched nothing.

So each branch resolves its own path and neither consults the other's. That narrows what #7984 added: an explicit name no longer reaches a nested launcher. The picker still does, which is the route #7914 was reported through, and the only route where such a name exists to be typed at all.

The picker's fallback went too. `omarchy-menu-select` treats a tab in an option as its own separator and returns only what follows, so a name coming back from it is not guaranteed to be one the scan indexed — and rebuilding a top-level path from a name that cannot be placed deletes whatever happens to sit there. An unplaceable name is now an error.

Which left the menu. Remove → Web App was guarded by a grep spelled out in `omarchy-menu.jsonc`, globbing `applications/*.desktop`, so for a user whose only web app is the nested one it matched nothing and hid the row: the recovery existed and could not be reached from the UI. That guard is now `omarchy-webapp-present`, a command like the `omarchy-pkg-present` and `omarchy-hw-*` checks the rest of that file uses, and it scans with the same `find` the remover does. Sharing the scan is the point — two expressions meant to agree had already drifted once, over launchers that are symlinks, which `find` reads and a recursive `grep` skips.

The tests drive the picker through a stub rather than imitating it with an argument, since the argument path is the one whose meaning differs, and they take the menu guard out of the menu definition and run it, so the helper and the entry that calls it cannot drift apart unnoticed.