### PR TITLE
Add Flatpak install dirs to session XDG_DATA_DIRS so launcher finds Flatpak apps

### DIFF
--- a/default/uwsm/env.d/10-omarchy
+++ b/default/uwsm/env.d/10-omarchy
@@ -3,6 +3,15 @@
 # UWSM doesn't source /etc/profile.d, so pull the env bootstrap in directly.
 [ -r /usr/share/omarchy/default/bash/env-bootstrap ] && . /usr/share/omarchy/default/bash/env-bootstrap
 
+# UWSM likewise misses the profile.d/Flatpak hook: it is what prepends the
+# Flatpak export dirs to XDG_DATA_DIRS in login shells, and without them the
+# launcher (which scans XDG_DATA_DIRS for desktop entries) silently omits
+# Flatpak apps. Source the same script when Flatpak is installed; it skips
+# itself when it is not. OMARCHY_FLATPAK_PROFILE is a test seam.
+if [ -r "${OMARCHY_FLATPAK_PROFILE:-/etc/profile.d/flatpak.sh}" ]; then
+  . "${OMARCHY_FLATPAK_PROFILE:-/etc/profile.d/flatpak.sh}"
+fi
+
 # Omarchy session defaults. Users can override these in ~/.config/uwsm/default
 # or, preferably, ~/.config/uwsm/env.d/*.
 if [ -f "${OMARCHY_PATH%/}/default/uwsm/default" ]; then

--- a/test/shell.d/flatpak-env-test.sh
+++ b/test/shell.d/flatpak-env-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+uwsm_env="$ROOT/default/uwsm/env.d/10-omarchy"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+# A stub in the shape of /etc/profile.d/flatpak.sh: prepend Flatpak's export
+# dirs to XDG_DATA_DIRS, but only when flatpak is on PATH.
+stub="$test_tmp/flatpak.sh"
+cat > "$stub" <<'EOF'
+if command -v flatpak > /dev/null; then
+  export XDG_DATA_DIRS="/home/test/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:$XDG_DATA_DIRS"
+fi
+EOF
+mkdir -p "$test_tmp/bin"
+printf '#!/bin/sh\nexit 0\n' > "$test_tmp/bin/flatpak"
+chmod +x "$test_tmp/bin/flatpak"
+
+run_uwsm_env() {
+  local flatpak_profile="$1"
+  local bin_dir="$2"
+
+  HOME=/home/test OMARCHY_PATH="$ROOT" XDG_DATA_HOME=/home/test/.local/share \
+    XDG_DATA_DIRS="/some/base" OMARCHY_FLATPAK_PROFILE="$flatpak_profile" \
+    bash -c 'PATH="$2:$ROOT/bin"; source "$1"; printf "%s" "$XDG_DATA_DIRS"' bash \
+    "$uwsm_env" "$bin_dir"
+}
+
+# With Flatpak installed, the session env picks up its export dirs ahead of the
+# inherited XDG_DATA_DIRS.
+xdg=$(run_uwsm_env "$stub" "$test_tmp/bin")
+[[ $xdg == "/home/test/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/some/base" ]] ||
+  fail "session env adds Flatpak export dirs when Flatpak is installed" "actual: $xdg"
+pass "session env adds Flatpak export dirs when Flatpak is installed"
+
+# The Flatpak script is only sourced when present.
+xdg=$(run_uwsm_env "$test_tmp/missing.sh" "$test_tmp/bin")
+[[ $xdg == "/some/base" ]] ||
+  fail "session env leaves XDG_DATA_DIRS alone without the Flatpak script" "actual: $xdg"
+pass "session env leaves XDG_DATA_DIRS alone without the Flatpak script"
+
+# flatpak.sh skips itself (and the env is unchanged) when Flatpak is absent.
+xdg=$(run_uwsm_env "$stub" "$test_tmp/empty")
+[[ $xdg == "/some/base" ]] ||
+  fail "session env leaves XDG_DATA_DIRS alone when Flatpak is not installed" "actual: $xdg"
+pass "session env leaves XDG_DATA_DIRS alone when Flatpak is not installed"


### PR DESCRIPTION
## What this fixes

Flatpak-installed applications never appear in the Omarchy launcher (`Apps menu` / `omarchy-menu toggle apps`), and new installs are not picked up. Closes #8650.

The launcher's app list (Quickshell `DesktopEntries` via `shell/services/AppLibrary.qml`) scans `XDG_DATA_DIRS` for `applications/*.desktop`. uwsm composes the Hyprland session environment **without sourcing `/etc/profile.d`**, so the `profile.d/flatpak.sh` hook that prepends Flatpak's export dirs to `XDG_DATA_DIRS` only ever ran in login shells. The running shell process therefore saw:

```
$ tr '\0' '\n' </proc/$(pgrep -o quickshell)/environ | grep XDG_DATA_DIRS
XDG_DATA_DIRS=/usr/local/share:/usr/share
```

while a login shell sees the Flatpak export dirs — so `/var/lib/flatpak/exports/share/applications` (and the per-user equivalent) was never scanned.

## The fix

Source `profile.d/flatpak.sh` from `default/uwsm/env.d/10-omarchy` when Flatpak is installed — the same pattern that file already uses to pull the omarchy env bootstrap into the session. The script self-skips when `flatpak` is absent, mirrors the exact dirs upstream computes (user + system + extra installations), and is idempotent against an already-set `XDG_DATA_DIRS`.

Takes effect on the next login. After that the launcher (which watches the scanned `applications` dirs) picks up new Flatpak installs live, no restart required per install.

## Why not `environment.d` / the `60-flatpak` user-environment-generator

Both apply to systemd *user services*. The shell is spawned by Hyprland from the uwsm-composed session env, so neither reaches the launcher — `XDG_DATA_DIRS` must be in the session env itself, which is exactly what this changes.

## Tests

- New `test/shell.d/flatpak-env-test.sh`: session env prepends Flatpak export dirs when installed, leaves `XDG_DATA_DIRS` alone when the script is absent, and leaves it alone when Flatpak isn't on PATH. ✓
- `./test/all` — only pre-existing, machine-local failures remain (missing dev-only `omarchy-pkgs` sibling checkout config-test/snapper/unowned-system-paths, live-session runtime-smoke, offline theme-install-guards); all 5 reproduce identically without this change.