### PR TITLE
Calendar: move the year figure with the clock, not the date

### DIFF
--- a/shell/plugins/panels/clock/Model.js
+++ b/shell/plugins/panels/clock/Model.js
@@ -159,16 +159,28 @@ function daysInYear(year) {
   return dayOfYear(year, 11, 31)
 }
 
-// Share of the year already behind you: whole days completed over days in
-// the year, so January 1 reads 0% and December 31 reads 100%.
-function yearProgress(year, month, day) {
-  var total = daysInYear(year)
-  if (total <= 0) return 0
-  return Math.max(0, Math.min(1, (dayOfYear(year, month, day) - 1) / total))
+// Share of the year already behind you, measured to the moment rather than to
+// the day: January 1 at midnight reads 0% and the last second of December
+// reads 100%. Counted in milliseconds between the two January firsts in local
+// time, so a year carrying a daylight-saving shift — 8759 or 8761 hours
+// rather than 8760 — still ends on exactly full.
+function yearProgressAt(date) {
+  var at = (date instanceof Date && isFinite(date.getTime())) ? date : new Date()
+  var start = new Date(at.getFullYear(), 0, 1).getTime()
+  var end = new Date(at.getFullYear() + 1, 0, 1).getTime()
+  if (!(end > start)) return 0
+  return Math.max(0, Math.min(1, (at.getTime() - start) / (end - start)))
 }
 
-function yearProgressPercent(year, month, day) {
-  return Math.round(yearProgress(year, month, day) * 100)
+// Two decimals, because that is the coarsest reading that still moves. One
+// hundredth of a percent of a year is about 53 minutes, so the figure differs
+// between any two visits to the panel while never ticking over under the eye;
+// a single decimal is 8 hours 46 minutes, the same number at breakfast as at
+// dinner, which is the one thing a progress read-out must not be. It is also
+// why the share above is taken to the moment: whole days move 0.27% in one
+// midnight step and would leave both decimals frozen in between.
+function yearProgressPercentText(date) {
+  return (yearProgressAt(date) * 100).toFixed(2)
 }
 
 // Memento mori. The default span is a round number rather than anything from
@@ -289,8 +301,8 @@ if (typeof module !== "undefined") {
     isoWeek: isoWeek,
     dayOfYear: dayOfYear,
     daysInYear: daysInYear,
-    yearProgress: yearProgress,
-    yearProgressPercent: yearProgressPercent,
+    yearProgressAt: yearProgressAt,
+    yearProgressPercentText: yearProgressPercentText,
     parseAge: parseAge,
     parseBirthYear: parseBirthYear,
     ageFromBirthYear: ageFromBirthYear,

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -43,10 +43,12 @@ Panel {
   readonly property date viewDate: new Date(viewYear, viewMonth, 1)
   readonly property bool viewingCurrentMonth: viewYear === today.getFullYear() && viewMonth === today.getMonth()
 
-  // Pinned to today, not to the month being browsed — stepping through the
-  // calendar does not change how much of the year is gone.
-  readonly property real yearDone: Model.yearProgress(today.getFullYear(), today.getMonth(), today.getDate())
-  readonly property int yearDonePercent: Model.yearProgressPercent(today.getFullYear(), today.getMonth(), today.getDate())
+  // Pinned to now, not to the month being browsed — stepping through the
+  // calendar does not change how much of the year is gone. Read off the clock
+  // rather than `today`, which only moves at midnight: the figure resolves to
+  // roughly the hour, so a date-only source would hold it still all day.
+  readonly property real yearDone: Model.yearProgressAt(clock.date)
+  readonly property string yearDoneText: Model.yearProgressPercentText(clock.date)
 
   // Memento mori, for anyone who goes looking: double-tapping the year bar
   // asks for a birth year and a life expectancy, and a second bar tracks one
@@ -428,7 +430,7 @@ Panel {
                 visible: !root.editingLife
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
-                text: root.yearDonePercent + "%"
+                text: root.yearDoneText + "%"
                 color: root.contentForeground
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.bodySmall

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -39,10 +39,25 @@ assertEqual(calendar.isoWeek(2026, 6, 26), 30, 'calendar numbers a midsummer Sun
 
 // ---- day-of-year arithmetic behind the hero stats
 assertEqual(calendar.dayOfYear(2026, 6, 26), 207, 'calendar counts the day of the year')
-assertEqual(calendar.yearProgressPercent(2026, 0, 1), 0, 'calendar starts the year at zero percent done')
-assertEqual(calendar.yearProgressPercent(2026, 6, 26), 56, 'calendar reports the share of the year behind you')
-assertEqual(calendar.yearProgressPercent(2026, 11, 31), 100, 'calendar finishes the year at a hundred percent')
-assertEqual(calendar.yearProgressPercent(2024, 11, 31), 100, 'calendar finishes a leap year too')
+assertEqual(calendar.yearProgressPercentText(new Date(2026, 0, 1)), '0.00', 'calendar starts the year at zero percent done')
+assertEqual(calendar.yearProgressPercentText(new Date(2026, 6, 26)), '56.43', 'calendar reports the share of the year behind you')
+assertEqual(calendar.yearProgressPercentText(new Date(2026, 11, 31, 23, 59, 59)), '100.00', 'calendar finishes the year at a hundred percent')
+assertEqual(calendar.yearProgressPercentText(new Date(2024, 11, 31, 23, 59, 59)), '100.00', 'calendar finishes a leap year too')
+
+// The share is taken to the moment, not to the day: at two decimals one
+// hundredth of a percent is about 53 minutes, so a date-only source would hold
+// both decimals still from midnight to midnight.
+assert(calendar.yearProgressPercentText(new Date(2026, 6, 26, 0, 0, 0)) !== calendar.yearProgressPercentText(new Date(2026, 6, 26, 12, 0, 0)), 'calendar moves the year figure within a single day')
+assert(calendar.yearProgressAt(new Date(2026, 6, 26, 12)) > calendar.yearProgressAt(new Date(2026, 6, 26, 0)), 'calendar year progress rises with the clock')
+
+// February 29 falls before July, so by midsummer a leap year is fractionally
+// further along than a common one (182/366 against 181/365) despite being the
+// longer year.
+assert(calendar.yearProgressAt(new Date(2028, 6, 1)) > calendar.yearProgressAt(new Date(2026, 6, 1)), 'calendar counts the leap day into the share behind you')
+
+// Clamped at both ends, and never NaN when handed something that is not a date.
+assertEqual(calendar.yearProgressAt(new Date(2026, 0, 1)), 0, 'calendar year progress opens at zero')
+assert(calendar.yearProgressAt(new Date('nonsense')) >= 0, 'calendar year progress falls back to now on an unusable date')
 
 // ---- memento mori
 // A birth year rather than an age, so the bar keeps counting on its own.
@@ -206,7 +221,7 @@ assert(/function moveMonth\(delta\)/.test(panelSource), 'calendar panel steps be
 assert(!/property bool onToday/.test(panelSource) && !/root\.onToday/.test(panelSource), 'calendar panel avoids the on-prefixed property name QML reads as a signal handler')
 assert(/readonly property bool viewingCurrentMonth:/.test(panelSource), 'calendar panel tracks whether the current month is on screen')
 assert(!/MouseArea/.test(panelSource.slice(panelSource.indexOf('model: modelData.days'), panelSource.indexOf('// Hairline'))), 'calendar day cells are not selectable')
-assert(/yearDone: Model\.yearProgress\(today\./.test(panelSource), 'calendar year bar stays pinned to today while months are stepped')
+assert(/yearDone: Model\.yearProgressAt\(clock\.date\)/.test(panelSource) && !/yearDone:.*view(Year|Month|Date)/.test(panelSource), 'calendar year bar tracks the clock, not the month being browsed')
 assert(/Qt\.callLater\(function\(\) \{\s*\n\s*if \(root\.opened\) setCenterHoverRevealSuppressed\(true\)/.test(panelSource), 'calendar claims the shared hover-reveal flag after the popout handoff, so the panel taking over wins')
 assert(/function close\(\) \{\s*\n\s*setCenterHoverRevealSuppressed\(false\)/.test(panelSource), 'calendar always releases the shared hover-reveal flag on close')
 assert(/width: Math\.max\(calendarScroll\.width, gridColumn\.width\)/.test(panelSource), 'calendar scrolls rather than clipping the grid on a narrow popup')
@@ -214,6 +229,7 @@ assert(/enabled: !root\.viewingCurrentMonth/.test(panelSource) && /onClicked: ro
 assert(!/clampMonth/.test(panelSource), 'calendar steps freely into future months')
 assert(/Qt\.formatDate\(root\.today, "MMMM d"\)/.test(panelSource), 'calendar hero spells out today')
 assert(/id: yearLabel/.test(panelSource) && /root\.yearDone/.test(panelSource), 'calendar panel shows the year progress bar')
+assert(/root\.yearDoneText \+ "%"/.test(panelSource), 'calendar panel prints the year figure to two decimals')
 
 // The memento mori bar is opt-in: double-tapping the year bar asks for an age,
 // and nothing shows until one has been given.


### PR DESCRIPTION
The calendar popup's year rail computes progress from whole days — `(dayOfYear - 1) / daysInYear` — and prints it rounded to a whole percent. Two consequences:

- **The number never moves while you are awake.** It changes once, at midnight.
- **Rounding hides how coarse it is.** A day is 0.27% of a year, so the rail advances in visible steps.

This takes the share to the moment instead (milliseconds between the two January firsts) and prints two decimals.

### Why two decimals

A year is 31,536,000 seconds, so the last digit steps every `31.536e6 / 10^(d+2)` seconds:

| decimals | last digit moves every |
|---|---|
| `.0` | 8h 46m |
| `.00` | **52.6 min** |
| `.000` | 5.3 min |

Two is the coarsest reading that still moves: the figure differs between any two visits to the panel, and never ticks over while one is open. One decimal is 8¾ hours — the same number at breakfast as at dinner, which is the one thing a progress read-out must not be.

Decimals also have to be *earned*: on day-quantized data both would sit frozen midnight to midnight and then jump 0.27 in a single step. That is why the underlying share moves to the moment rather than just gaining a `toFixed`.

### Daylight saving

Measuring in milliseconds between the two January firsts in local time makes the existing comment's promise literally true. A year carrying a DST shift is 8759 or 8761 hours rather than 8760; it still ends on exactly full, and a date sits where the wall clock actually puts it.

### Panel wake-ups

The panel reads the figure off its existing `SystemClock` rather than `today`, which only moves at midnight and would have held both decimals still all day. **`precision` stays `Minutes`** — nothing here moves faster than 53 minutes, so the panel wakes no more often than before.

### Tests

`test/shell.d/clock-test.sh` updated and extended: the source-shape assertion now pins the rail to the clock rather than to a browsed month, plus new coverage for movement within a single day, monotonicity, the leap day landing on the correct side (182/366 > 181/365 — February 29 falls before July), and a non-date input not producing `NaN`.

Full `test/shell.d` suite passes (202/202 excluding five that fail identically on a clean `quattro` here for environment reasons — no `omarchy-pkgs` checkout, no network).