### PR TITLE
Elide the not found menu title when it overflows

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1459,6 +1459,7 @@ Item {
               font.pixelSize: Style.font.title
               horizontalAlignment: Text.AlignHCenter
               width: Style.space(320)
+              elide: Text.ElideRight
             }
           }
         }


### PR DESCRIPTION
Adds Text.ElideRight to the not found menu title label so a long title truncates cleanly instead of spilling out of the dialog.