### PR TITLE
Focus Activity within the current workspace

### DIFF
--- a/bin/omarchy-launch-or-focus
+++ b/bin/omarchy-launch-or-focus
@@ -1,16 +1,29 @@
 #!/bin/bash
 
 # omarchy:summary=Launch an app or focus an existing window matching a pattern
-# omarchy:args=<window-pattern> <launch-command>
+# omarchy:args=[--current-workspace] <window-pattern> [launch-command]
+
+CURRENT_WORKSPACE_ONLY=0
+if [[ ${1:-} == "--current-workspace" ]]; then
+  CURRENT_WORKSPACE_ONLY=1
+  shift
+fi
 
 if (($# == 0)); then
-  echo "Usage: omarchy-launch-or-focus [window-pattern] [launch-command]"
+  echo "Usage: omarchy-launch-or-focus [--current-workspace] <window-pattern> [launch-command]"
   exit 1
 fi
 
 WINDOW_PATTERN="$1"
 LAUNCH_COMMAND="${2:-"uwsm-app -- $WINDOW_PATTERN"}"
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
+if (( CURRENT_WORKSPACE_ONLY )); then
+  CURRENT_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
+  WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" --argjson workspace "$CURRENT_WORKSPACE" \
+    '.[]|select(.workspace.id == $workspace)|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
+else
+  WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" \
+    '.[]|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
+fi
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"

--- a/bin/omarchy-launch-or-focus-tui
+++ b/bin/omarchy-launch-or-focus-tui
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 # omarchy:summary=Launch a TUI or focus an existing terminal window for it
-# omarchy:args=[--app-id=<app-id>] <command> [args...]
+# omarchy:args=[--current-workspace] [--app-id=<app-id>] <command> [args...]
+
+FOCUS_SCOPE=()
+if [[ ${1:-} == "--current-workspace" ]]; then
+  FOCUS_SCOPE=(--current-workspace)
+  shift
+fi
 
 if [[ ${1:-} == --app-id=* ]]; then
   APP_ID="${1#--app-id=}"
@@ -11,4 +17,4 @@ fi
 
 LAUNCH_COMMAND="omarchy-launch-tui $@"
 
-exec omarchy-launch-or-focus "$APP_ID" "$LAUNCH_COMMAND"
+exec omarchy-launch-or-focus "${FOCUS_SCOPE[@]}" "$APP_ID" "$LAUNCH_COMMAND"

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -100,7 +100,7 @@ o.bind("SUPER + CTRL + D", "Display", "omarchy-shell shell toggle omarchy.monito
 o.bind("SUPER + CTRL + ALT + D", "Calendar", "omarchy-shell shell toggle omarchy.clock")
 o.bind("SUPER + CTRL + W", "Network", "omarchy-shell shell toggle omarchy.network")
 o.bind("SUPER + CTRL + P", "Power", "omarchy-shell shell toggle omarchy.power")
-o.bind("SUPER + CTRL + T", "Activity", { tui = "btop" })
+o.bind("SUPER + CTRL + T", "Activity", { tui = "btop", focus = "current-workspace" })
 
 -- The letters above name a panel; the numbers count them. 1 is the leftmost
 -- panel in the bar's right section, and a widget with no panel of its own (the

--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -71,7 +71,9 @@ local function command_from(value, description)
       return o.launch_webapp(value.webapp)
     end
   elseif value.tui then
-    if value.focus then
+    if value.focus == "current-workspace" then
+      return "omarchy-launch-or-focus-tui --current-workspace " .. shell_quote(value.tui)
+    elseif value.focus then
       return "omarchy-launch-or-focus-tui " .. shell_quote(value.tui)
     else
       return "omarchy-launch-tui " .. shell_quote(value.tui)

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -61,11 +61,18 @@ if prelude ~= "" then
 end
 
 hl = setmetatable({
-  dsp = proxy(),
+  dsp = setmetatable({
+    exec_cmd = function(command)
+      return { command = command }
+    end,
+  }, { __index = proxy() }),
   bind = function(keys, dispatcher, opts)
     opts = opts or {}
     if opts.description then
       print(keys .. "\t" .. opts.description)
+    end
+    if type(dispatcher) == "table" and dispatcher.command then
+      print("command\t" .. keys .. "\t" .. dispatcher.command)
     end
   end,
   config = function() end,
@@ -104,6 +111,11 @@ fresh_output=$(run_application_bindings "$fresh_home")
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$fresh_output" || fail "default application bindings include essentials"
 grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
 pass "default application bindings load from package defaults"
+
+omarchy_output=$(run_omarchy_bindings "$fresh_home")
+grep -Fq $'command\tSUPER + CTRL + T\tomarchy-launch-or-focus-tui --current-workspace '\''btop'\''' <<<"$omarchy_output" ||
+  fail "activity binding focuses an existing btop window on the current workspace"
+pass "activity binding focuses an existing btop window on the current workspace"
 
 grep -F 'hl.dsp.send_key_state({ mods = mods, key = key, state = "down" })' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null ||
   fail "universal clipboard shortcuts send explicit mods to the focused surface"

--- a/test/shell.d/launch-or-focus-test.sh
+++ b/test/shell.d/launch-or-focus-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+case $1 in
+  activeworkspace) printf '{"id":%s}\n' "$OMARCHY_TEST_WORKSPACE" ;;
+  clients) printf '%s\n' "$OMARCHY_TEST_CLIENTS" ;;
+  dispatch) printf '%s\n' "$2" >"$OMARCHY_TEST_DISPATCH_LOG" ;;
+esac
+SH
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_LAUNCH_LOG"
+SH
+chmod +x "$mock_bin"/*
+
+dispatch_log="$test_tmp/dispatch"
+launch_log="$test_tmp/launch"
+clients='[
+  {"address":"0xone","class":"org.omarchy.btop","title":"foot","workspace":{"id":1}},
+  {"address":"0xtwo","class":"org.omarchy.btop","title":"foot","workspace":{"id":2}}
+]'
+
+PATH="$mock_bin:$PATH" OMARCHY_TEST_WORKSPACE=2 OMARCHY_TEST_CLIENTS="$clients" \
+  OMARCHY_TEST_DISPATCH_LOG="$dispatch_log" OMARCHY_TEST_LAUNCH_LOG="$launch_log" \
+  bash "$ROOT/bin/omarchy-launch-or-focus" --current-workspace org.omarchy.btop 'example --flag'
+
+grep -Fq 'address:0xtwo' "$dispatch_log" ||
+  fail "workspace-scoped launch focuses the matching window on the current workspace"
+[[ ! -e $launch_log ]] || fail "workspace-scoped launch does not open a duplicate on the current workspace"
+pass "workspace-scoped launch focuses the matching window on the current workspace"
+
+rm -f "$dispatch_log"
+clients='[
+  {"address":"0xone","class":"org.omarchy.btop","title":"foot","workspace":{"id":1}}
+]'
+
+PATH="$mock_bin:$PATH" OMARCHY_TEST_WORKSPACE=2 OMARCHY_TEST_CLIENTS="$clients" \
+  OMARCHY_TEST_DISPATCH_LOG="$dispatch_log" OMARCHY_TEST_LAUNCH_LOG="$launch_log" \
+  bash "$ROOT/bin/omarchy-launch-or-focus" --current-workspace org.omarchy.btop 'example --flag'
+
+grep -Fxq 'example --flag' "$launch_log" ||
+  fail "workspace-scoped launch opens a window when the match is on another workspace"
+[[ ! -e $dispatch_log ]] || fail "workspace-scoped launch ignores matches on another workspace"
+pass "workspace-scoped launch opens a window when the match is on another workspace"
+
+rm -f "$launch_log"
+PATH="$mock_bin:$PATH" OMARCHY_TEST_WORKSPACE=2 OMARCHY_TEST_CLIENTS="$clients" \
+  OMARCHY_TEST_DISPATCH_LOG="$dispatch_log" OMARCHY_TEST_LAUNCH_LOG="$launch_log" \
+  bash "$ROOT/bin/omarchy-launch-or-focus" org.omarchy.btop 'example --flag'
+
+grep -Fq 'address:0xone' "$dispatch_log" || fail "unscoped launch still focuses a match on another workspace"
+[[ ! -e $launch_log ]] || fail "unscoped launch keeps its global singleton behavior"
+pass "unscoped launch keeps its global singleton behavior"
+
+cat >"$mock_bin/omarchy-launch-or-focus" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >"$OMARCHY_TEST_FORWARD_LOG"
+SH
+chmod +x "$mock_bin/omarchy-launch-or-focus"
+
+forward_log="$test_tmp/forward"
+PATH="$mock_bin:$PATH" OMARCHY_TEST_FORWARD_LOG="$forward_log" \
+  bash "$ROOT/bin/omarchy-launch-or-focus-tui" --current-workspace btop
+
+mapfile -t forwarded <"$forward_log"
+[[ ${forwarded[0]} == "--current-workspace" ]] || fail "TUI launcher forwards the workspace scope"
+[[ ${forwarded[1]} == "org.omarchy.btop" ]] || fail "TUI launcher derives the btop app id"
+[[ ${forwarded[2]} == "omarchy-launch-tui btop" ]] || fail "TUI launcher preserves its launch command"
+pass "TUI launcher forwards the workspace scope"


### PR DESCRIPTION
## Summary

- Add an opt-in current-workspace scope to the existing launch-or-focus helpers while preserving their global default behavior.
- Make `Super + Ctrl + T` reuse the Activity window on the current workspace, but allow a separate Activity window on every other workspace.
- Add regression coverage for workspace selection, cross-workspace independence, the unchanged global mode, TUI flag forwarding, and the generated Activity binding.

## Verification

- `env -u NO_COLOR ./test/all` — all 208 test files passed
- Focused launcher, binding, and CLI tests passed
- Live desktop sweep across workspaces 1–10: each workspace stayed at exactly one Activity client after a repeated launch
- Revisited workspaces 10–1: each focused its recorded Activity address while the total stayed at ten
- Visually inspected the active workspace and confirmed no stacked Activity window

Fixes #8660