### PR TITLE
Sanitize legacy Windows VM usernames

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -340,7 +340,7 @@ migrate_legacy_compose() {
   [[ -f $LEGACY_COMPOSE_FILE ]] || return 1
 
   echo "Migrating Windows VM configuration to $COMPOSE_FILE ..."
-  local ram cores disk username password tz storage shared
+  local ram cores disk username password tz storage shared rdp_username
   ram=$(read_compose_value RAM_SIZE "$LEGACY_COMPOSE_FILE")
   cores=$(read_compose_value CPU_CORES "$LEGACY_COMPOSE_FILE")
   disk=$(read_compose_value DISK_SIZE "$LEGACY_COMPOSE_FILE")
@@ -355,12 +355,24 @@ migrate_legacy_compose() {
   shared="$HOME/Windows"
 
   [[ -z $tz ]] && tz="UTC"
+
+  # Pre-4.0.1 installers accepted any username (including emails). The elevated
+  # writer now rejects those. USERNAME is only used during first-run unattend,
+  # so fall back to docker like install does; keep the original for RDP so the
+  # existing Windows account still logs in.
+  rdp_username=$username
+  if ! valid_username "$username"; then
+    echo "Legacy username is not valid for the compose writer; using docker. The Windows account itself is unchanged."
+    username="docker"
+    [[ -n $rdp_username ]] || rdp_username="docker"
+  fi
+
   if ! write_compose "$ram" "$cores" "$disk" "$username" "$password" "$tz" "$storage" "$shared"; then
     echo "Could not migrate the existing configuration automatically." >&2
     echo "Re-run: omarchy-windows-vm install" >&2
     return 1
   fi
-  write_credentials "$username" "$password"
+  write_credentials "$rdp_username" "$password"
   rm -f "$LEGACY_COMPOSE_FILE"
 }
 

--- a/test/shell.d/windows-vm-compose-test.sh
+++ b/test/shell.d/windows-vm-compose-test.sh
@@ -94,6 +94,38 @@ grep -q -- '- /etc:/shared' "$COMPOSE_FILE" && fail "migration must not carry a 
 [[ ! -f $LEGACY_COMPOSE_FILE ]] || fail "migration removes the legacy compose"
 pass "migration reconstructs data paths from \$HOME and ignores tampered legacy volumes"
 
+# --- pre-4.0.1 usernames the writer now rejects still migrate ---
+# Install used to accept emails and other strings that fail valid_username.
+# USERNAME is inert after Windows setup; RDP uses the credentials file.
+rm -rf "$OMARCHY_WINDOWS_DIR"
+export HOME="$TMPDIR/home-email"
+mkdir -p "$HOME/.config/windows"
+LEGACY_COMPOSE_FILE="$HOME/.config/windows/docker-compose.yml"
+CREDENTIALS_FILE="$HOME/.config/windows/credentials"
+COMPOSE_FILE="$COMPOSE"
+cat >"$LEGACY_COMPOSE_FILE" <<'LEG'
+services:
+  windows:
+    environment:
+      RAM_SIZE: "8G"
+      CPU_CORES: "4"
+      DISK_SIZE: "64G"
+      USERNAME: "user@example.com"
+      PASSWORD: "legacypass"
+      TZ: "UTC"
+    volumes:
+      - /home/old/.windows:/storage
+      - /home/old/Windows:/shared
+LEG
+migrate_legacy_compose
+[[ -f $COMPOSE_FILE ]] || fail "migration wrote the root-owned compose for an email username"
+grep -q 'USERNAME: "docker"' "$COMPOSE_FILE" || fail "migration sanitizes an invalid legacy username to docker"
+grep -q 'USERNAME: "user@example.com"' "$COMPOSE_FILE" && fail "migration must not write an invalid username into the compose"
+[[ $(read_credential USERNAME) == "user@example.com" ]] || fail "RDP credentials keep the original Windows username"
+[[ $(read_credential PASSWORD) == "legacypass" ]] || fail "RDP credentials keep the original password"
+[[ ! -f $LEGACY_COMPOSE_FILE ]] || fail "migration removes the legacy compose after sanitizing username"
+pass "migration sanitizes invalid legacy usernames and keeps RDP credentials"
+
 # --- bring-up refuses a symlinked mount source (a symlink redirects the
 #     privileged bind mount the same way traversal would; the string check on
 #     the stored path cannot see it) ---


### PR DESCRIPTION
**What**: Sanitize invalid legacy Windows VM usernames during compose migration so existing VMs stay reachable.

**Why**: Fixes #8619. 4.0.1's elevated compose writer rejects usernames the pre-4.0.1 installer allowed (email-style Microsoft accounts, etc.). `migrate_legacy_compose` then failed, and `launch`/`status` reported "not configured" while the VM disk was intact.

**How**: In `migrate_legacy_compose`, fall back to `docker` when the legacy `USERNAME` fails `valid_username` — the same substitution `install` already makes. The elevated writer stays strict. RDP credentials keep the original username so the already-provisioned Windows account still logs in. `USERNAME` is only consumed by dockurr/windows during first-run unattend.

Rejected: relaxing `valid_username` in `__priv_write_compose` (that check is the security boundary).

**Verified**:
- `bash -n bin/omarchy-windows-vm` (exit 0)
- `bash -n test/shell.d/windows-vm-compose-test.sh` (exit 0)
- `bash test/shell.d/windows-vm-compose-test.sh` through the new assertion: `ok - migration sanitizes invalid legacy usernames and keeps RDP credentials`

**NOT verified**:
- independent /review
- shellcheck / shfmt (not installed on this machine)
- full `test/shell` / `test/cli` / `test/all` (Windows host; the later symlink-to-`/` assertion in the same compose test hung)
- live Omarchy Windows VM migration
- Hyprland / pacman / Quickshell