### PR TITLE
Keep the battery icon charging while UPower measures a fresh plug-in

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -60,7 +60,15 @@ function chargeThresholdActive(device, onBattery, states) {
   if (d.state === s.FullyCharged && fraction < 0.99) return true
   if (d.state !== s.Charging || fraction >= 0.99) return false
 
-  return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
+  // A freshly plugged-in battery reports changeRate 0 and timeToFull 0 until
+  // UPower measures the charge, which can take a minute. That is "not known
+  // yet", not "stalled at a charge limit" -- while the state still says
+  // Charging, trust it rather than flagging a threshold from empty readings.
+  var rate = Number(d.changeRate || 0)
+  var timeToFull = Number(d.timeToFull || 0)
+  if (rate <= 0 && timeToFull <= 0) return false
+
+  return rate <= 0.2 || timeToFull >= 8 * 60 * 60
 }
 
 function batteryIcon(device, onBattery, states) {

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -26,6 +26,7 @@ assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'pow
 assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power detects threshold by pending charge state')
 assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states), 'power detects threshold by stalled charging')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states), 'power does not flag active charging as threshold')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0, timeToFull: 0 }, false, states), 'power does not flag a freshly plugged-in battery as threshold before UPower measures the rate')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
@@ -35,6 +36,11 @@ assertEqual(
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Discharging }, false, states),
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states),
   'power shows charging icon when external power is present before battery state refreshes'
+)
+assertEqual(
+  power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging, changeRate: 0, timeToFull: 0 }, false, states),
+  power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states),
+  'power shows the charging icon right after plug-in, before UPower reports a rate'
 )
 assertEqual(
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging }, true, states),


### PR DESCRIPTION
chargeThresholdActive() reads a stalled charge as changeRate at or below 0.2 W, or a time-to-full over eight hours. A battery that was just plugged in reports changeRate 0 and timeToFull 0 until UPower measures the charge, which can take up to a minute, and 0 clears both of those bars. So for that first minute the bar showed the static (non-charging) icon and the panel read "Charge limit", on a machine with no charge limit set, every time the charger went in.

Empty readings are "not known yet", not "stalled": while the state still says Charging, treat changeRate 0 with timeToFull 0 as active charging and let UPower's next update decide. A real charge limit still reports either a PendingCharge/FullyCharged state or a measured low rate, all of which are unchanged.