### PR TITLE
fix(clipboard): render clipboard text and search filter as plain text

### DIFF
--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -597,6 +597,7 @@ Item {
 
             Text {
               text: root.history.length === 0 ? "Clipboard is empty" : "No matches for “" + root.filterText + "”"
+              textFormat: Text.PlainText
               color: root.foreground
               opacity: 0.7
               font.family: root.fontFamily

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -436,6 +436,7 @@ Item {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             text: root.filterText || "Search clipboard…"
+            textFormat: Text.PlainText
             color: root.foreground
             opacity: root.filterText ? 1 : 0.58
             font.family: root.fontFamily
@@ -503,6 +504,7 @@ Item {
                       width: parent.width - (parent.parent.previewImage.length > 0 ? parent.height + parent.spacing : 0)
                       height: parent.height
                       text: parent.parent.previewText
+                      textFormat: Text.PlainText
                       color: parent.parent.hasCursor ? root.selectedText : root.foreground
                       font.family: root.fontFamily
                       font.pixelSize: Style.font.title
@@ -553,6 +555,7 @@ Item {
                 anchors.topMargin: 0
                 anchors.bottomMargin: 0
                 text: parent.activeRow ? parent.activeRow.fullText : ""
+                textFormat: Text.PlainText
                 color: root.foreground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.title

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -39,6 +39,26 @@ assertDeepEqual(
 
 assertDeepEqual(clipboard.parseHistory(JSON.stringify([' ', '\n', { type: 'text', text: '\t' }])), [], 'clipboard history parser drops whitespace-only text')
 
+assert(
+  /text:\s*root\.filterText \|\| "Search clipboard…"\s*\n\s*textFormat:\s*Text\.PlainText/.test(clipboardQml),
+  'clipboard search header renders filter text as plain text'
+)
+
+assert(
+  /text:\s*parent\.parent\.previewText\s*\n\s*textFormat:\s*Text\.PlainText/.test(clipboardQml),
+  'clipboard list item renders preview text as plain text'
+)
+
+assert(
+  /text:\s*parent\.activeRow \? parent\.activeRow\.fullText : ""\s*\n\s*textFormat:\s*Text\.PlainText/.test(clipboardQml),
+  'clipboard detail pane renders full text as plain text'
+)
+
+assert(
+  /text:\s*root\.history\.length === 0 \? "Clipboard is empty" : "No matches for “" \+ root\.filterText \+ "”"\s*\n\s*textFormat:\s*Text\.PlainText/.test(clipboardQml),     
+  'clipboard empty/no-matches view renders filter text as plain text'
+)
+
 const history = [
   { type: 'text', text: 'old' },
   { type: 'text', text: 'new' },


### PR DESCRIPTION
### Problem
When copying code or text containing HTML/JSX `<img>` tags (e.g. `<img src={imageUrl} ... />`), Quickshell crashes with `SIGSEGV` in `QQuickTextPrivate::updateLayout()`.
  
Because `Text.textFormat` defaults to `Text.AutoText`, Qt Quick attempts to parse arbitrary clipboard strings as `StyledText`. When it encounters `<img>` tags with non-URL expressions, it fails to resolve the image and segfaults during layout calculation, causing a crash loop upon shell restart as history is reloaded.
  
### Solution
Explicitly set `textFormat: Text.PlainText` on all `Text` components rendering clipboard contents and filter text in `Clipboard.qml`.
