### PR TITLE
Add an opt-in showTemperature setting to the weather bar widget

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -125,7 +125,7 @@ All of it is stored in `~/.config/omarchy/shell.json`, under the `bar` key. Here
 }
 ```
 
-Every widget is one entry in one of the three layout arrays, and its settings sit inline on that entry — there's no separate settings file and no `config` sub-object. The clock's `format`, `formatAlt` (what right-click cycles to), and `verticalFormat` all live right there on `{ "id": "omarchy.clock" }`.
+Every widget is one entry in one of the three layout arrays, and its settings sit inline on that entry — there's no separate settings file and no `config` sub-object. The clock's `format`, `formatAlt` (what right-click cycles to), and `verticalFormat` all live right there on `{ "id": "omarchy.clock" }`. The weather widget takes `{ "id": "omarchy.weather", "showTemperature": true }` to put the current temperature next to its icon instead of showing the icon alone.
 
 `centerAnchor` names the one center widget that gets pinned to the exact center of the screen, with the others flanking it. That's how the clock stays dead center even as the weather and update badge come and go. Set it to an empty string and the center list is just centered as a group instead.
 

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -74,6 +74,8 @@ Example `shell.json` (bar subtree only shown):
 
 The `omarchy.indicators` widget loads individual bar indicators from `indicators/`. Omit `items` (or set it to an empty array) to show all indicators in the default order, or set `items` to a subset such as `["Dnd", "Reminder", "NightLight"]`. Set `alwaysShow` to `true` to keep inactive indicators visible instead of revealing them only on hover. Multiple `omarchy.indicators` instances are allowed, so different sections can show different subsets.
 
+The `omarchy.weather` widget shows just the condition icon by default. Set `showTemperature` to `true` on its entry (`omarchy bar set omarchy.weather showTemperature true --json`) to show the current temperature next to the icon.
+
 ## Orientation
 
 All widgets work in `top`, `bottom`, `left`, and `right` positions. Popups anchor on the side opposite the bar edge, sliding into the workspace. Vertical bars use 28px width; widgets that show text fall back to compact icon-only forms (e.g. `media` hides its scrolling label).

--- a/shell/plugins/panels/weather/BarWidget.qml
+++ b/shell/plugins/panels/weather/BarWidget.qml
@@ -6,6 +6,25 @@ BarWidget {
   id: root
   moduleName: "omarchy.weather"
 
+  // "showTemperature" on the bar entry turns the icon-only pill into a padded
+  // "<icon> <temp>°" label, laid out like the clock. Default is icon-only, so
+  // an existing bar is unchanged.
+  readonly property bool showTemperature: setting("showTemperature", false) === true
+
+  readonly property string barLabel: {
+    var p = panelLoader.item
+    if (!p) return ""
+    if (!root.showTemperature || !p.reportTempNum) return p.label
+    return p.label + " " + p.reportTempNum + p.tempUnit
+  }
+
+  function handlePress(b) {
+    if (!root.bar) return
+    if (b === Qt.RightButton) root.bar.run("omarchy-notification-send \"$(omarchy-weather-status)\"")
+    else if (b === Qt.MiddleButton) root.refresh()
+    else root.togglePanel()
+  }
+
   function injectPanel() {
     var target = panelLoader.item
     if (!target) return
@@ -64,20 +83,37 @@ BarWidget {
     }
   }
 
-  BarIconButton {
+  // Icon-only is a fixed square glyph slot (BarIconButton); the temperature
+  // variant needs a padded text label (WidgetButton), the same split the bar
+  // makes between icon widgets and text widgets like the clock.
+  Loader {
     id: button
     anchors.fill: parent
-    bar: root.bar
-    text: panelLoader.item ? panelLoader.item.label : ""
-    slotSize: Style.bar.statusSlot
-    // Tooltip suppressed because the panel is the detail view.
-    tooltipText: ""
+    sourceComponent: root.showTemperature ? temperatureLabel : iconOnly
+  }
 
-    onPressed: function(b) {
-      if (!root.bar) return
-      if (b === Qt.RightButton) root.bar.run("omarchy-notification-send \"$(omarchy-weather-status)\"")
-      else if (b === Qt.MiddleButton) root.refresh()
-      else root.togglePanel()
+  Component {
+    id: iconOnly
+    BarIconButton {
+      bar: root.bar
+      text: root.barLabel
+      slotSize: Style.bar.statusSlot
+      // Tooltip suppressed because the panel is the detail view.
+      tooltipText: ""
+      onPressed: function(b) { root.handlePress(b) }
+    }
+  }
+
+  Component {
+    id: temperatureLabel
+    WidgetButton {
+      bar: root.bar
+      text: root.barLabel
+      hasVisualContent: text !== ""
+      horizontalMargin: 8.75
+      verticalPadding: 8.75
+      tooltipText: ""
+      onPressed: function(b) { root.handlePress(b) }
     }
   }
 }

--- a/shell/plugins/panels/weather/BarWidget.qml
+++ b/shell/plugins/panels/weather/BarWidget.qml
@@ -20,6 +20,14 @@ BarWidget {
     return p.label + " " + p.reportTempNum + p.tempUnit
   }
 
+  // With the padded text label showing, the open-panel marker should span the
+  // painted "<icon> <temp>°" text rather than 55% of the whole padded slot
+  // (Bar.qml's fallback), the same hint the clock exposes. Icon-only keeps the
+  // fallback, unchanged from the stock widget.
+  readonly property real openPanelIndicatorWidth: root.showTemperature && button.item
+    ? (button.item.labelWidth || 0)
+    : 0
+
   function handlePress(b) {
     if (!root.bar) return
     if (b === Qt.RightButton) root.bar.run("omarchy-notification-send \"$(omarchy-weather-status)\"")

--- a/shell/plugins/panels/weather/BarWidget.qml
+++ b/shell/plugins/panels/weather/BarWidget.qml
@@ -8,8 +8,10 @@ BarWidget {
 
   // "showTemperature" on the bar entry turns the icon-only pill into a padded
   // "<icon> <temp>°" label, laid out like the clock. Default is icon-only, so
-  // an existing bar is unchanged.
-  readonly property bool showTemperature: setting("showTemperature", false) === true
+  // an existing bar is unchanged. Vertical bars keep the compact icon-only
+  // slot regardless (as the clock and media widgets do) -- a text label would
+  // paint past the narrow edge.
+  readonly property bool showTemperature: !vertical && setting("showTemperature", false) === true
 
   readonly property string barLabel: {
     var p = panelLoader.item

--- a/shell/plugins/panels/weather/manifest.json
+++ b/shell/plugins/panels/weather/manifest.json
@@ -16,6 +16,15 @@
     "description": "Weather pill with detail popup",
     "category": "Info",
     "allowMultiple": false,
-    "settingsForm": "weatherSettings"
+    "settingsForm": "weatherSettings",
+    "schema": [
+      {
+        "key": "showTemperature",
+        "type": "boolean",
+        "label": "Show temperature",
+        "description": "Show the current temperature next to the weather icon in the bar.",
+        "defaultValue": false
+      }
+    ]
   }
 }

--- a/test/shell.d/fixtures/bar-widget-contract/shell.qml
+++ b/test/shell.d/fixtures/bar-widget-contract/shell.qml
@@ -111,6 +111,27 @@ ShellRoot {
 
   Item { id: host }
 
+  // Second weather instance, opted into showTemperature, checked in both
+  // orientations alongside the generic contract loop below.
+  property var weatherTempWidget: null
+
+  function loadWeatherTempVariant(entries) {
+    for (var e = 0; e < entries.length; e++) {
+      if (entries[e].id !== "omarchy.weather") continue
+      var component = Qt.createComponent(entries[e].url, Component.PreferSynchronous)
+      if (component.status !== Component.Ready) {
+        fail("omarchy.weather showTemperature variant failed to load: " + component.errorString())
+        return
+      }
+      weatherTempWidget = component.createObject(host, {
+        moduleName: "omarchy.weather",
+        settings: { showTemperature: true }
+      })
+      if (weatherTempWidget) weatherTempWidget.bar = fakeBar
+      return
+    }
+  }
+
   QtObject {
     id: mockShell
     property var bar: fakeBar
@@ -151,6 +172,7 @@ ShellRoot {
       var entries = widgets()
       root.assertTrue(entries.length > 0, "bar widget list is not empty")
       for (var i = 0; i < entries.length; i++) root.loadWidget(entries[i])
+      root.loadWeatherTempVariant(entries)
 
       Qt.callLater(function() {
         for (var j = 0; j < root.createdObjects.length; j++) {
@@ -158,6 +180,13 @@ ShellRoot {
           var id = root.createdIds[j]
           root.assertTrue(root.finiteDimension(item.implicitWidth), id + " has a finite implicitWidth")
           root.assertTrue(root.finiteDimension(item.implicitHeight), id + " has a finite implicitHeight")
+        }
+
+        if (root.weatherTempWidget) {
+          root.assertTrue(root.weatherTempWidget.showTemperature === true,
+            "omarchy.weather composes the temperature label on a horizontal bar when showTemperature is set")
+          root.assertTrue(root.finiteDimension(root.weatherTempWidget.implicitWidth),
+            "omarchy.weather showTemperature variant has a finite implicitWidth")
         }
 
         fakeBar.vertical = true
@@ -173,6 +202,15 @@ ShellRoot {
               root.assertEqual(verticalItem.implicitHeight, Style.bar.statusSlot, verticalId + " uses one compact status slot")
             if (verticalItem && typeof verticalItem.destroy === "function") verticalItem.destroy()
           }
+
+          if (root.weatherTempWidget) {
+            root.assertTrue(root.weatherTempWidget.showTemperature === false,
+              "omarchy.weather forces icon-only on a vertical bar even with showTemperature set")
+            root.assertEqual(root.weatherTempWidget.implicitHeight, Style.bar.statusSlot,
+              "omarchy.weather keeps the compact status slot on a vertical bar with showTemperature set")
+            if (typeof root.weatherTempWidget.destroy === "function") root.weatherTempWidget.destroy()
+          }
+
           root.assertTrue(root.createdIds.length === entries.length, "all bar widgets instantiate")
           root.writeResult()
         })

--- a/test/shell.d/fixtures/bar-widget-contract/shell.qml
+++ b/test/shell.d/fixtures/bar-widget-contract/shell.qml
@@ -127,9 +127,17 @@ ShellRoot {
         moduleName: "omarchy.weather",
         settings: { showTemperature: true }
       })
-      if (weatherTempWidget) weatherTempWidget.bar = fakeBar
+      // createObject() can return null on an instantiation-time error even
+      // after Ready; record it rather than letting the guarded checks below
+      // skip and the file still pass.
+      if (!weatherTempWidget) {
+        fail("omarchy.weather showTemperature variant failed to instantiate: " + component.errorString())
+        return
+      }
+      weatherTempWidget.bar = fakeBar
       return
     }
+    fail("omarchy.weather is missing from the bar widget list")
   }
 
   QtObject {

--- a/test/shell.d/fixtures/bar-widget-contract/shell.qml
+++ b/test/shell.d/fixtures/bar-widget-contract/shell.qml
@@ -188,6 +188,8 @@ ShellRoot {
           var id = root.createdIds[j]
           root.assertTrue(root.finiteDimension(item.implicitWidth), id + " has a finite implicitWidth")
           root.assertTrue(root.finiteDimension(item.implicitHeight), id + " has a finite implicitHeight")
+          if (id === "omarchy.weather")
+            root.assertEqual(item.openPanelIndicatorWidth, 0, "omarchy.weather leaves the open-panel mark on the slot fallback when icon-only")
         }
 
         if (root.weatherTempWidget) {
@@ -195,6 +197,8 @@ ShellRoot {
             "omarchy.weather composes the temperature label on a horizontal bar when showTemperature is set")
           root.assertTrue(root.finiteDimension(root.weatherTempWidget.implicitWidth),
             "omarchy.weather showTemperature variant has a finite implicitWidth")
+          root.assertTrue(root.finiteDimension(root.weatherTempWidget.openPanelIndicatorWidth),
+            "omarchy.weather temperature variant exposes a finite open-panel indicator width tied to the label")
         }
 
         fakeBar.vertical = true

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -128,6 +128,24 @@ assert(
   widgetSource.includes('readonly property bool popoutSwitchClosing:') && widgetSource.includes('function closeForPopoutSwitch()'),
   'weather widget forwards the popout-switch handshake'
 )
+
+const weatherManifest = JSON.parse(fs.readFileSync(root + '/shell/plugins/panels/weather/manifest.json', 'utf8'))
+assert(
+  (weatherManifest.barWidget.schema || []).some(field => field.key === 'showTemperature' && field.type === 'boolean' && field.defaultValue === false),
+  'weather advertises an opt-in showTemperature boolean, defaulting off'
+)
+assert(
+  widgetSource.includes('setting("showTemperature", false)'),
+  'weather widget reads showTemperature from the bar entry'
+)
+assert(
+  /showTemperature[\s\S]*?p\.label \+ " " \+ p\.reportTempNum \+ p\.tempUnit/.test(widgetSource),
+  'weather widget appends the temperature to the icon only when showTemperature is set'
+)
+assert(
+  widgetSource.includes('sourceComponent: root.showTemperature ? temperatureLabel : iconOnly'),
+  'weather widget stays a plain BarIconButton until showTemperature turns it into a text label'
+)
 assert(
   /Qt\.callLater\(function\(\) \{\s*\n\s*if \(root\.opened\) setCenterHoverRevealSuppressed\(true\)/.test(panelSource),
   'weather claims the shared hover-reveal flag after the popout handoff, so the panel taking over wins'


### PR DESCRIPTION
The bar weather widget shows only the condition icon. Setting "showTemperature": true on its bar entry now puts the current temperature next to the icon; the default is icon-only, so an existing bar is unchanged.

Icon-only keeps the BarIconButton (a fixed square glyph slot). The temperature variant swaps to a padded WidgetButton -- the split the bar already makes between icon widgets and text widgets like the clock -- because a plain string in the icon slot overflows onto its neighbour. The panel already computes reportTempNum and tempUnit for its own hero row; the widget just reads them back.

manifest.json advertises the boolean in barWidget.schema, matching the shape omarchy.indicators uses for alwaysShow.