### PR TITLE
Own cargo on PATH and install Rust without modifying shell profiles

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -119,7 +119,10 @@ phoenix)
   ;;
 rust)
   echo -e "Installing Rust...\n"
-  bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs)" -- -y
+  # --no-modify-path: rustup's default .profile line sources ~/.cargo/env unguarded,
+  # which can abort UWSM session start if that file later goes missing. PATH for
+  # cargo is owned by default/bash/env-bootstrap instead.
+  bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs)" -- -y --no-modify-path
   ;;
 java)
   echo -e "Installing Java...\n"

--- a/default/bash/env-bootstrap
+++ b/default/bash/env-bootstrap
@@ -27,9 +27,9 @@ fi
 
 # User-level tool paths, appended so system binaries keep precedence. This is
 # what lets login shells (ssh, bash -lc) and the uwsm session find mise-managed
-# tools without an interactive rc. Keep these directories in sync with the PAM
-# PATH line from install/config/ssh-command-path.sh, which covers SSH commands
-# that run no shell setup at all.
+# tools and rustup/cargo without an interactive rc. Keep these directories in sync
+# with the PAM PATH line from install/config/ssh-command-path.sh, which covers
+# SSH commands that run no shell setup at all.
 case ":$PATH:" in
   *":$HOME/.local/share/mise/shims:"*) ;;
   *) PATH="${PATH:+$PATH:}$HOME/.local/share/mise/shims" ;;
@@ -37,5 +37,9 @@ esac
 case ":$PATH:" in
   *":$HOME/.local/bin:"*) ;;
   *) PATH="${PATH:+$PATH:}$HOME/.local/bin" ;;
+esac
+case ":$PATH:" in
+  *":$HOME/.cargo/bin:"*) ;;
+  *) PATH="${PATH:+$PATH:}$HOME/.cargo/bin" ;;
 esac
 export PATH

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -163,8 +163,8 @@ Single source of truth for `OMARCHY_PATH` and dev-link-aware `PATH`. It:
 - Prepends `$OMARCHY_PATH/bin` to `PATH` **only when** `OMARCHY_PATH` is
   not `/usr/share/omarchy`. On a production install the binaries are
   already on `PATH` as `/usr/bin/omarchy-*` via the `omarchy` package.
-- Appends `~/.local/share/mise/shims` and `~/.local/bin` so login shells and
-  the uwsm session find mise-managed tools — kept in sync with the PAM `PATH`
+- Appends `~/.local/share/mise/shims`, `~/.local/bin`, and `~/.cargo/bin` so login shells and
+  the uwsm session find mise-managed tools and rustup/cargo — kept in sync with the PAM `PATH`
   line written by `install/config/ssh-command-path.sh`, which covers SSH
   commands that run no shell setup at all.
 

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -163,10 +163,7 @@ Single source of truth for `OMARCHY_PATH` and dev-link-aware `PATH`. It:
 - Prepends `$OMARCHY_PATH/bin` to `PATH` **only when** `OMARCHY_PATH` is
   not `/usr/share/omarchy`. On a production install the binaries are
   already on `PATH` as `/usr/bin/omarchy-*` via the `omarchy` package.
-- Appends `~/.local/share/mise/shims`, `~/.local/bin`, and `~/.cargo/bin` so login shells and
-  the uwsm session find mise-managed tools and rustup/cargo — kept in sync with the PAM `PATH`
-  line written by `install/config/ssh-command-path.sh`, which covers SSH
-  commands that run no shell setup at all.
+- Appends `~/.local/share/mise/shims`, `~/.local/bin`, and `~/.cargo/bin` so login shells and the uwsm session find mise-managed tools and rustup/cargo — kept in sync with the PAM `PATH` line written by `install/config/ssh-command-path.sh`, which covers SSH commands that run no shell setup at all.
 
 Sourced by every entry point that needs the env set:
 

--- a/install/config/ssh-command-path.sh
+++ b/install/config/ssh-command-path.sh
@@ -1,12 +1,12 @@
 # SSH commands (ssh host cmd) run without a login or interactive shell, so on
 # Arch the PAM environment is the only place they can inherit PATH from. Add
 # the user-level tool paths there so remote tools (herdr, editors, agent CLIs)
-# find mise-managed installs. @{HOME} expands per-user from passwd. Keep the
-# directories in sync with default/bash/env-bootstrap.
+# find mise-managed installs and rustup/cargo. @{HOME} expands per-user from
+# passwd. Keep the directories in sync with default/bash/env-bootstrap.
 if ! grep -qE '^PATH[[:space:]]' /etc/security/pam_env.conf; then
   cat >>/etc/security/pam_env.conf <<'EOF'
 
 # Omarchy: give SSH commands and other non-shell logins the user-level tool paths
-PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin
+PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin:@{HOME}/.cargo/bin
 EOF
 fi

--- a/migrations/1787864608.sh
+++ b/migrations/1787864608.sh
@@ -1,0 +1,21 @@
+echo "Add cargo bin to the Omarchy PAM PATH for SSH commands"
+
+# Fresh installs get the cargo-aware line from install/config/ssh-command-path.sh.
+# Existing installs still have the legacy line from migrations/1786181929.sh; the
+# install script skips any existing PATH, so upgrade those exact Omarchy-managed
+# lines here and leave custom PAM PATH configuration alone.
+pam="/etc/security/pam_env.conf"
+legacy="PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin"
+updated="PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin:@{HOME}/.cargo/bin"
+
+[[ -f $pam ]] || exit 0
+grep -qxF -- "$updated" "$pam" && exit 0
+grep -qxF -- "$legacy" "$pam" || exit 0
+
+tmp=$(mktemp)
+awk -v legacy="$legacy" -v updated="$updated" '
+  $0 == legacy { print updated; next }
+  { print }
+' "$pam" >"$tmp"
+sudo cp -- "$tmp" "$pam"
+rm -f "$tmp"

--- a/migrations/1787867690.sh
+++ b/migrations/1787867690.sh
@@ -1,0 +1,34 @@
+echo "Guard rustup cargo env lines so a missing ~/.cargo/env cannot login-loop UWSM"
+
+# rustup's default install appends an unguarded `. "$HOME/.cargo/env"` to shell
+# profiles. UWSM sources ~/.profile on graphical login; if that file is missing,
+# session start fails and SDDM loops. PATH for cargo is owned by env-bootstrap
+# after the companion change; keep a guarded source so leftover rustup env still
+# loads when present, and never aborts when absent.
+unguarded_dot='. "$HOME/.cargo/env"'
+unguarded_source='source "$HOME/.cargo/env"'
+guarded='[[ -r "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"'
+
+guard_cargo_env_line() {
+  local file="$1"
+  local tmp
+
+  [[ -f $file ]] || return 0
+  grep -qxF -- "$unguarded_dot" "$file" ||
+    grep -qxF -- "$unguarded_source" "$file" ||
+    return 0
+
+  tmp=$(mktemp)
+  awk -v guarded="$guarded" -v dot="$unguarded_dot" -v src="$unguarded_source" '
+    $0 == dot || $0 == src { print guarded; next }
+    { print }
+  ' "$file" >"$tmp"
+  cp -- "$tmp" "$file"
+  rm -f "$tmp"
+}
+
+guard_cargo_env_line "$HOME/.profile"
+guard_cargo_env_line "$HOME/.bash_profile"
+guard_cargo_env_line "$HOME/.bashrc"
+guard_cargo_env_line "$HOME/.zprofile"
+guard_cargo_env_line "$HOME/.zshrc"

--- a/test/shell.d/dev-env-path-test.sh
+++ b/test/shell.d/dev-env-path-test.sh
@@ -56,6 +56,7 @@ pass "env-bootstrap resolves default OMARCHY_PATH"
 assert_path_present "$default_path" "$tmpdir/unrelated/bin" "env-bootstrap preserves PATH entries in default mode"
 assert_path_present "$default_path" "$home/.local/share/mise/shims" "env-bootstrap appends mise shims"
 assert_path_present "$default_path" "$home/.local/bin" "env-bootstrap appends ~/.local/bin"
+assert_path_present "$default_path" "$home/.cargo/bin" "env-bootstrap appends ~/.cargo/bin"
 assert_path_first "$default_path" "$tmpdir/unrelated/bin" "env-bootstrap appends user-level paths after existing entries"
 
 printf 'export OMARCHY_PATH="%s"\n' "$tmpdir/active" >"$tmpdir/omarchy.conf"
@@ -67,15 +68,15 @@ pass "env-bootstrap resolves linked OMARCHY_PATH"
 assert_path_first "$linked_path" "$tmpdir/active/bin" "env-bootstrap prepends active checkout bin in linked mode"
 assert_path_present "$linked_path" "$tmpdir/unrelated/bin" "env-bootstrap preserves unrelated PATH entries in linked mode"
 
-mapfile -t linked_duplicate_result < <(run_bootstrap bash "$bootstrap" "$home" "$tmpdir/active/bin:/usr/bin:$home/.local/share/mise/shims:$home/.local/bin")
+mapfile -t linked_duplicate_result < <(run_bootstrap bash "$bootstrap" "$home" "$tmpdir/active/bin:/usr/bin:$home/.local/share/mise/shims:$home/.local/bin:$home/.cargo/bin")
 linked_duplicate_path=${linked_duplicate_result[1]}
-[[ $linked_duplicate_path == "$tmpdir/active/bin:/usr/bin:$home/.local/share/mise/shims:$home/.local/bin" ]] || fail "env-bootstrap does not duplicate PATH entries" "actual PATH: $linked_duplicate_path"
+[[ $linked_duplicate_path == "$tmpdir/active/bin:/usr/bin:$home/.local/share/mise/shims:$home/.local/bin:$home/.cargo/bin" ]] || fail "env-bootstrap does not duplicate PATH entries" "actual PATH: $linked_duplicate_path"
 pass "env-bootstrap does not duplicate PATH entries"
 
 # An empty PATH must not produce empty entries (a bare ":" means the cwd)
 mapfile -t empty_path_result < <(run_bootstrap bash "$bootstrap" "$home" "")
 empty_path=${empty_path_result[1]}
-[[ $empty_path == "$tmpdir/active/bin:$home/.local/share/mise/shims:$home/.local/bin" ]] || fail "env-bootstrap builds a clean PATH from an empty one" "actual PATH: $empty_path"
+[[ $empty_path == "$tmpdir/active/bin:$home/.local/share/mise/shims:$home/.local/bin:$home/.cargo/bin" ]] || fail "env-bootstrap builds a clean PATH from an empty one" "actual PATH: $empty_path"
 pass "env-bootstrap builds a clean PATH from an empty one"
 
 if command -v zsh >/dev/null 2>&1; then

--- a/test/shell.d/guard-cargo-env-profile-migration-test.sh
+++ b/test/shell.d/guard-cargo-env-profile-migration-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1787867690.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+mkdir -p "$home"
+
+unguarded_dot='. "$HOME/.cargo/env"'
+unguarded_source='source "$HOME/.cargo/env"'
+guarded='[[ -r "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"'
+custom='export EDITOR=nvim'
+
+run_migration() {
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+# ~/.profile with rustup's unguarded line: rewritten.
+printf '%s\n' "$unguarded_dot" >"$home/.profile"
+run_migration || fail "migration runs against an unguarded .profile"
+grep -qxF -- "$guarded" "$home/.profile" || fail "migration guards the rustup .profile line" "actual: $(cat "$home/.profile")"
+grep -qxF -- "$unguarded_dot" "$home/.profile" && fail "migration must remove the unguarded .profile line"
+pass "migration guards an unguarded .profile cargo env line"
+
+# Idempotent when already guarded.
+before=$(cat "$home/.profile")
+run_migration || fail "migration is idempotent on a guarded .profile"
+[[ $(cat "$home/.profile") == "$before" ]] || fail "migration must not rewrite an already-guarded .profile"
+pass "migration is a no-op when .profile is already guarded"
+
+# source form in .bashrc, leave unrelated lines alone.
+printf '%s\n' "$custom" "$unguarded_source" >"$home/.bashrc"
+run_migration || fail "migration runs against .bashrc"
+grep -qxF -- "$custom" "$home/.bashrc" || fail "migration preserves unrelated .bashrc lines"
+grep -qxF -- "$guarded" "$home/.bashrc" || fail "migration guards the source form in .bashrc"
+grep -qxF -- "$unguarded_source" "$home/.bashrc" && fail "migration must remove the unguarded source line"
+pass "migration guards source \"\$HOME/.cargo/env\" in .bashrc and keeps other lines"
+
+# Custom profile with no rustup line: untouched.
+printf '%s\n' "$custom" >"$home/.zprofile"
+run_migration || fail "migration runs when no cargo env line is present"
+grep -qxF -- "$custom" "$home/.zprofile" || fail "migration must leave unrelated profiles alone"
+grep -q 'cargo/env' "$home/.zprofile" && fail "migration must not invent a cargo env line"
+pass "migration leaves profiles without a rustup cargo env line alone"
+
+# Missing files: no-op.
+rm -f "$home/.bash_profile" "$home/.zshrc"
+run_migration || fail "migration tolerates missing profile files"
+[[ ! -e $home/.bash_profile ]] || fail "migration must not create missing profile files"
+pass "migration no-ops for missing profile files"

--- a/test/shell.d/pam-cargo-path-migration-test.sh
+++ b/test/shell.d/pam-cargo-path-migration-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1787864608.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+stub_bin="$test_dir/bin"
+pam="$test_dir/pam_env.conf"
+migration_copy="$test_dir/migration.sh"
+mkdir -p "$stub_bin"
+
+legacy="PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin"
+updated="PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin:@{HOME}/.cargo/bin"
+custom="PATH DEFAULT=/usr/bin:@{HOME}/custom/bin"
+
+occurrences=$(grep -Fo '/etc/security/pam_env.conf' "$migration" | wc -l) || occurrences=0
+(( occurrences == 1 )) ||
+  fail "the migration names pam_env.conf exactly once, so the test can retarget a copy" \
+    "found $occurrences occurrences"
+grep -Fxq 'pam="/etc/security/pam_env.conf"' "$migration" ||
+  fail "the production pam path is a fixed literal, not caller-controlled"
+pass "migration names pam_env.conf once, and the test drives a retargeted copy"
+
+sed "s#/etc/security/pam_env.conf#$pam#g" "$migration" >"$migration_copy"
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+chmod +x "$stub_bin/sudo"
+
+run_migration() {
+  PATH="$stub_bin:$PATH" bash -euo pipefail "$migration_copy" >/dev/null
+}
+
+# Legacy Omarchy line: rewritten to include cargo.
+printf '%s\n' "# Omarchy: give SSH commands and other non-shell logins the user-level tool paths" "$legacy" >"$pam"
+run_migration || fail "migration runs against the legacy Omarchy PAM PATH"
+grep -qxF -- "$updated" "$pam" || fail "migration rewrites the legacy line to include cargo" "actual: $(cat "$pam")"
+grep -qxF -- "$legacy" "$pam" && fail "migration must remove the legacy line"
+pass "migration upgrades the exact Omarchy-managed legacy PATH line"
+
+# Already current: no-op and still succeeds.
+before=$(cat "$pam")
+run_migration || fail "migration is idempotent when cargo is already present"
+[[ $(cat "$pam") == "$before" ]] || fail "migration must not rewrite an already-current PAM PATH"
+pass "migration is a no-op when the PAM PATH already includes cargo"
+
+# Custom PATH: leave alone.
+printf '%s\n' "$custom" >"$pam"
+run_migration || fail "migration runs when PATH is custom"
+grep -qxF -- "$custom" "$pam" || fail "migration must preserve a custom PAM PATH"
+grep -q 'cargo/bin' "$pam" && fail "migration must not append cargo onto a custom PAM PATH"
+pass "migration leaves custom PAM PATH configuration alone"
+
+# Missing file: no-op.
+rm -f "$pam"
+run_migration || fail "migration tolerates a missing pam_env.conf"
+[[ ! -e $pam ]] || fail "migration must not create pam_env.conf when it was missing"
+pass "migration no-ops when pam_env.conf is missing"


### PR DESCRIPTION
## Summary
- Install Rust with rustup `--no-modify-path` so it no longer writes an unguarded `. "$HOME/.cargo/env"` into `~/.profile` (that line can abort UWSM session start and loop SDDM when the file is missing).
- Append `$HOME/.cargo/bin` in `default/bash/env-bootstrap` (and keep PAM `ssh-command-path` in sync), same pattern as mise / `~/.local/bin`.

Fixes #8669

## Test plan
- [x] `./test/shell.d/dev-env-path-test.sh` passes (including new `~/.cargo/bin` coverage)
- [ ] Fresh `omarchy-install-dev-env rust` does not add a cargo/env line to `~/.profile`
- [ ] After install, `cargo` / `rustc` resolve via PATH from a new login/UWSM session
- [ ] With `~/.cargo/env` absent and no unguarded `.profile` source, SDDM login succeeds