### PR TITLE
Add Lenovo Yoga Slim 7x board support

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -45,6 +45,7 @@ run_logged "$OMARCHY_INSTALL/hardware/qualcomm/kernel-params.sh"
 run_logged "$OMARCHY_INSTALL/hardware/qualcomm/firmware.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
+run_logged "$OMARCHY_INSTALL/hardware/lenovo/yoga-slim7x.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/fix-bcm43xx.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-surface-keyboard.sh"

--- a/install/hardware/lenovo/start-yoga-slim7x-remoteprocs.sh
+++ b/install/hardware/lenovo/start-yoga-slim7x-remoteprocs.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+remoteproc_root=${OMARCHY_YOGA_REMOTEPROC_ROOT:-/sys/class/remoteproc}
+attempts=${OMARCHY_YOGA_REMOTEPROC_ATTEMPTS:-30}
+sleep_seconds=${OMARCHY_YOGA_REMOTEPROC_SLEEP:-1}
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  adsp_started=0
+  shopt -s nullglob
+
+  for state_file in "$remoteproc_root"/remoteproc*/state; do
+    remoteproc=${state_file%/state}
+    [[ -r $remoteproc/firmware && -r $state_file ]] || continue
+
+    firmware=$(tr -d '\0\n' <"$remoteproc/firmware")
+    case "$firmware" in
+      *qcadsp*) kind=ADSP ;;
+      *qccdsp*) kind=CDSP ;;
+      *) continue ;;
+    esac
+
+    if [[ $(<$state_file) == running ]]; then
+      echo "Yoga Slim 7x: $kind is already running"
+      [[ $kind == ADSP ]] && adsp_started=1
+    elif [[ -w $state_file ]] && printf 'start\n' >"$state_file"; then
+      echo "Yoga Slim 7x: started $kind"
+      [[ $kind == ADSP ]] && adsp_started=1
+    else
+      echo "Yoga Slim 7x: could not start $kind ($firmware)" >&2
+    fi
+  done
+
+  ((adsp_started)) && exit 0
+  sleep "$sleep_seconds"
+done
+
+echo "Yoga Slim 7x: audio DSP did not appear or could not be started" >&2
+exit 1

--- a/install/hardware/lenovo/yoga-slim7x.sh
+++ b/install/hardware/lenovo/yoga-slim7x.sh
@@ -4,6 +4,7 @@ yoga_slim7x_compatible=""
 compatible_path=${OMARCHY_YOGA_COMPATIBLE_PATH:-/sys/firmware/devicetree/base/compatible}
 modules_load_dir=${OMARCHY_YOGA_MODULES_LOAD_DIR:-/etc/modules-load.d}
 mkinitcpio_dir=${OMARCHY_YOGA_MKINITCPIO_DIR:-/etc/mkinitcpio.conf.d}
+limine_config_dir=${OMARCHY_YOGA_LIMINE_CONFIG_DIR:-/etc/limine-entry-tool.d}
 systemd_dir=${OMARCHY_YOGA_SYSTEMD_DIR:-/etc/systemd/system}
 
 if [[ -r $compatible_path ]]; then
@@ -19,20 +20,30 @@ if omarchy-hw-qualcomm-soc &&
   mkdir -p "$modules_load_dir"
   echo "scmi-cpufreq" >"$modules_load_dir/yoga-slim7x.conf"
 
-  # Its internal keyboard and touchpad are HID-over-I2C. Keep their OF
-  # transport in the initramfs so encrypted installs can accept a passphrase.
+  # Initialize the internal keyboard and display before disk unlock.
   mkdir -p "$mkinitcpio_dir"
   cat >"$mkinitcpio_dir/yoga-slim7x-initramfs.conf" <<'CONF'
-MODULES+=(i2c-hid-of)
+MODULES+=(i2c-hid-of qrtr ps883x pmic_glink_altmode)
+
+for firmware in \
+  /usr/lib/firmware/qcom/gen70500_sqe.fw \
+  /usr/lib/firmware/qcom/gen70500_gmu.bin \
+  /usr/lib/firmware/qcom/x1e80100/LENOVO/83ED/qcdxkmsuc8380.mbn; do
+  [[ -f $firmware ]] && FILES+=("$firmware")
+done
+unset firmware
 CONF
 
-  # Start the board's DSP remote processors after udev exposes them.
+  mkdir -p "$limine_config_dir"
+  cat >"$limine_config_dir/yoga-slim7x.conf" <<'CONF'
+KERNEL_CMDLINE[default]+=" initcall_blacklist=simpledrm_platform_driver_init"
+CONF
+
+  # Start the board's DSP remote processors.
   mkdir -p "$systemd_dir"
   cat >"$systemd_dir/yoga-slim7x-remoteprocs.service" <<'UNIT'
 [Unit]
 Description=Start the Lenovo Yoga Slim 7x DSPs
-Wants=systemd-udev-settle.service
-After=systemd-udev-settle.service
 ConditionPathExists=!/etc/modprobe.d/qualcomm-adsp-nofw.conf
 
 [Service]

--- a/install/hardware/lenovo/yoga-slim7x.sh
+++ b/install/hardware/lenovo/yoga-slim7x.sh
@@ -1,6 +1,4 @@
-# Lenovo Yoga Slim 7x (14Q8X9 / 83ED) details that are not common to every
-# Snapdragon laptop. Generic DTB, firmware, Vulkan and kernel-cmdline setup is
-# handled by install/hardware/qualcomm/.
+# Lenovo Yoga Slim 7x (14Q8X9 / 83ED) board-specific setup.
 
 yoga_slim7x_compatible=""
 if [[ -r /sys/firmware/devicetree/base/compatible ]]; then
@@ -23,9 +21,7 @@ if omarchy-hw-qualcomm-soc &&
 MODULES+=(i2c-hid-of)
 CONF
 
-  # On this board the ADSP remains offline after its firmware is installed.
-  # Starting it enables the speakers and microphone. The helper also starts
-  # the CDSP when present, but only the audio DSP is required for success.
+  # Start the board's DSP remote processors after udev exposes them.
   cat >/etc/systemd/system/yoga-slim7x-remoteprocs.service <<'UNIT'
 [Unit]
 Description=Start the Lenovo Yoga Slim 7x DSPs

--- a/install/hardware/lenovo/yoga-slim7x.sh
+++ b/install/hardware/lenovo/yoga-slim7x.sh
@@ -1,0 +1,44 @@
+# Lenovo Yoga Slim 7x (14Q8X9 / 83ED) details that are not common to every
+# Snapdragon laptop. Generic DTB, firmware, Vulkan and kernel-cmdline setup is
+# handled by install/hardware/qualcomm/.
+
+yoga_slim7x_compatible=""
+if [[ -r /sys/firmware/devicetree/base/compatible ]]; then
+  yoga_slim7x_compatible=$(tr '\0' '\n' </sys/firmware/devicetree/base/compatible)
+fi
+
+if omarchy-hw-qualcomm-soc &&
+  { grep -qi '^lenovo,yoga-slim7x$' <<<"$yoga_slim7x_compatible" ||
+    omarchy-hw-match 'Yoga Slim 7x' || omarchy-hw-match '83ED'; }; then
+  echo "Detected Lenovo Yoga Slim 7x, applying board-specific support..."
+
+  # The Yoga exposes its CPU performance domains through SCMI.
+  mkdir -p /etc/modules-load.d
+  echo "scmi-cpufreq" >/etc/modules-load.d/yoga-slim7x.conf
+
+  # Its internal keyboard and touchpad are HID-over-I2C. Keep their OF
+  # transport in the initramfs so encrypted installs can accept a passphrase.
+  mkdir -p /etc/mkinitcpio.conf.d
+  cat >/etc/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf <<'CONF'
+MODULES+=(i2c-hid-of)
+CONF
+
+  # On this board the ADSP remains offline after its firmware is installed.
+  # Starting it enables the speakers and microphone. The helper also starts
+  # the CDSP when present, but only the audio DSP is required for success.
+  cat >/etc/systemd/system/yoga-slim7x-remoteprocs.service <<'UNIT'
+[Unit]
+Description=Start the Lenovo Yoga Slim 7x DSPs
+Wants=systemd-udev-settle.service
+After=systemd-udev-settle.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /usr/share/omarchy/install/hardware/lenovo/start-yoga-slim7x-remoteprocs.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+  systemctl enable yoga-slim7x-remoteprocs.service
+fi

--- a/install/hardware/lenovo/yoga-slim7x.sh
+++ b/install/hardware/lenovo/yoga-slim7x.sh
@@ -1,8 +1,13 @@
 # Lenovo Yoga Slim 7x (14Q8X9 / 83ED) board-specific setup.
 
 yoga_slim7x_compatible=""
-if [[ -r /sys/firmware/devicetree/base/compatible ]]; then
-  yoga_slim7x_compatible=$(tr '\0' '\n' </sys/firmware/devicetree/base/compatible)
+compatible_path=${OMARCHY_YOGA_COMPATIBLE_PATH:-/sys/firmware/devicetree/base/compatible}
+modules_load_dir=${OMARCHY_YOGA_MODULES_LOAD_DIR:-/etc/modules-load.d}
+mkinitcpio_dir=${OMARCHY_YOGA_MKINITCPIO_DIR:-/etc/mkinitcpio.conf.d}
+systemd_dir=${OMARCHY_YOGA_SYSTEMD_DIR:-/etc/systemd/system}
+
+if [[ -r $compatible_path ]]; then
+  yoga_slim7x_compatible=$(tr '\0' '\n' <"$compatible_path")
 fi
 
 if omarchy-hw-qualcomm-soc &&
@@ -11,22 +16,24 @@ if omarchy-hw-qualcomm-soc &&
   echo "Detected Lenovo Yoga Slim 7x, applying board-specific support..."
 
   # The Yoga exposes its CPU performance domains through SCMI.
-  mkdir -p /etc/modules-load.d
-  echo "scmi-cpufreq" >/etc/modules-load.d/yoga-slim7x.conf
+  mkdir -p "$modules_load_dir"
+  echo "scmi-cpufreq" >"$modules_load_dir/yoga-slim7x.conf"
 
   # Its internal keyboard and touchpad are HID-over-I2C. Keep their OF
   # transport in the initramfs so encrypted installs can accept a passphrase.
-  mkdir -p /etc/mkinitcpio.conf.d
-  cat >/etc/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf <<'CONF'
+  mkdir -p "$mkinitcpio_dir"
+  cat >"$mkinitcpio_dir/yoga-slim7x-initramfs.conf" <<'CONF'
 MODULES+=(i2c-hid-of)
 CONF
 
   # Start the board's DSP remote processors after udev exposes them.
-  cat >/etc/systemd/system/yoga-slim7x-remoteprocs.service <<'UNIT'
+  mkdir -p "$systemd_dir"
+  cat >"$systemd_dir/yoga-slim7x-remoteprocs.service" <<'UNIT'
 [Unit]
 Description=Start the Lenovo Yoga Slim 7x DSPs
 Wants=systemd-udev-settle.service
 After=systemd-udev-settle.service
+ConditionPathExists=!/etc/modprobe.d/qualcomm-adsp-nofw.conf
 
 [Service]
 Type=oneshot

--- a/install/hardware/lenovo/yoga-slim7x.sh
+++ b/install/hardware/lenovo/yoga-slim7x.sh
@@ -25,13 +25,13 @@ if omarchy-hw-qualcomm-soc &&
   cat >"$mkinitcpio_dir/yoga-slim7x-initramfs.conf" <<'CONF'
 MODULES+=(i2c-hid-of qrtr ps883x pmic_glink_altmode)
 
+# The board-signed zap shader is included by qcom-firmware-extract.
 for firmware in \
   qcom/gen70500_sqe.fw \
-  qcom/gen70500_gmu.bin \
-  qcom/x1e80100/LENOVO/83ED/qcdxkmsuc8380.mbn; do
-  for directory in "${OMARCHY_YOGA_FIRMWARE_ROOT:-/usr/lib/firmware}/updates" \
-    "${OMARCHY_YOGA_FIRMWARE_ROOT:-/usr/lib/firmware}"; do
-    for suffix in '' .zst .xz; do
+  qcom/gen70500_gmu.bin; do
+  for suffix in '' .zst .xz; do
+    for directory in "${OMARCHY_YOGA_FIRMWARE_ROOT:-/usr/lib/firmware}/updates" \
+      "${OMARCHY_YOGA_FIRMWARE_ROOT:-/usr/lib/firmware}"; do
       if [[ -f $directory/$firmware$suffix ]]; then
         FILES+=("$directory/$firmware$suffix")
         break 2

--- a/install/hardware/lenovo/yoga-slim7x.sh
+++ b/install/hardware/lenovo/yoga-slim7x.sh
@@ -26,12 +26,20 @@ if omarchy-hw-qualcomm-soc &&
 MODULES+=(i2c-hid-of qrtr ps883x pmic_glink_altmode)
 
 for firmware in \
-  /usr/lib/firmware/qcom/gen70500_sqe.fw \
-  /usr/lib/firmware/qcom/gen70500_gmu.bin \
-  /usr/lib/firmware/qcom/x1e80100/LENOVO/83ED/qcdxkmsuc8380.mbn; do
-  [[ -f $firmware ]] && FILES+=("$firmware")
+  qcom/gen70500_sqe.fw \
+  qcom/gen70500_gmu.bin \
+  qcom/x1e80100/LENOVO/83ED/qcdxkmsuc8380.mbn; do
+  for directory in "${OMARCHY_YOGA_FIRMWARE_ROOT:-/usr/lib/firmware}/updates" \
+    "${OMARCHY_YOGA_FIRMWARE_ROOT:-/usr/lib/firmware}"; do
+    for suffix in '' .zst .xz; do
+      if [[ -f $directory/$firmware$suffix ]]; then
+        FILES+=("$directory/$firmware$suffix")
+        break 2
+      fi
+    done
+  done
 done
-unset firmware
+unset firmware directory suffix
 CONF
 
   mkdir -p "$limine_config_dir"

--- a/install/hardware/lenovo/yoga-slim7x.sh
+++ b/install/hardware/lenovo/yoga-slim7x.sh
@@ -45,6 +45,8 @@ CONF
   mkdir -p "$limine_config_dir"
   cat >"$limine_config_dir/yoga-slim7x.conf" <<'CONF'
 KERNEL_CMDLINE[default]+=" initcall_blacklist=simpledrm_platform_driver_init"
+# Keep Plymouth and the keyboard hooks on the laptop console, not the serial port.
+KERNEL_CMDLINE[default]+=" console=tty0"
 CONF
 
   # Start the board's DSP remote processors.

--- a/test/shell.d/yoga-slim7x-hardware-test.sh
+++ b/test/shell.d/yoga-slim7x-hardware-test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+setup="$ROOT/install/hardware/lenovo/yoga-slim7x.sh"
+starter="$ROOT/install/hardware/lenovo/start-yoga-slim7x-remoteprocs.sh"
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+
+bash -n "$setup" "$starter" || fail "Yoga Slim 7x hardware scripts have valid syntax"
+grep -Fq 'MODULES+=(i2c-hid-of)' "$setup" ||
+  fail "Yoga Slim 7x setup keeps the internal keyboard in the initramfs"
+grep -Fq 'scmi-cpufreq' "$setup" ||
+  fail "Yoga Slim 7x setup loads its SCMI CPU-frequency driver"
+
+remoteprocs="$scratch/remoteproc"
+mkdir -p "$remoteprocs/remoteproc0" "$remoteprocs/remoteproc1" "$remoteprocs/remoteproc2"
+printf 'qcom/x1e80100/LENOVO/83ED/qcadsp8380.mbn\n' >"$remoteprocs/remoteproc0/firmware"
+printf 'offline\n' >"$remoteprocs/remoteproc0/state"
+printf 'qcom/x1e80100/LENOVO/83ED/qccdsp8380.mbn\n' >"$remoteprocs/remoteproc1/firmware"
+printf 'offline\n' >"$remoteprocs/remoteproc1/state"
+printf 'unrelated.mbn\n' >"$remoteprocs/remoteproc2/firmware"
+printf 'offline\n' >"$remoteprocs/remoteproc2/state"
+
+OMARCHY_YOGA_REMOTEPROC_ROOT="$remoteprocs" \
+  OMARCHY_YOGA_REMOTEPROC_ATTEMPTS=1 \
+  OMARCHY_YOGA_REMOTEPROC_SLEEP=0 \
+  bash "$starter"
+
+[[ $(<"$remoteprocs/remoteproc0/state") == start ]] ||
+  fail "Yoga Slim 7x helper starts the audio DSP by firmware identity"
+[[ $(<"$remoteprocs/remoteproc1/state") == start ]] ||
+  fail "Yoga Slim 7x helper starts the compute DSP by firmware identity"
+[[ $(<"$remoteprocs/remoteproc2/state") == offline ]] ||
+  fail "Yoga Slim 7x helper leaves unrelated remote processors alone"
+
+pass "Yoga Slim 7x adds only its board-specific keyboard, CPU and DSP setup"

--- a/test/shell.d/yoga-slim7x-hardware-test.sh
+++ b/test/shell.d/yoga-slim7x-hardware-test.sh
@@ -10,10 +10,53 @@ scratch=$(mktemp -d)
 trap 'rm -rf "$scratch"' EXIT
 
 bash -n "$setup" "$starter" || fail "Yoga Slim 7x hardware scripts have valid syntax"
-grep -Fq 'MODULES+=(i2c-hid-of)' "$setup" ||
-  fail "Yoga Slim 7x setup keeps the internal keyboard in the initramfs"
-grep -Fq 'scmi-cpufreq' "$setup" ||
+
+matching="$scratch/matching"
+mkdir -p "$matching"
+printf 'qcom,x1e80100\0lenovo,yoga-slim7x\0' >"$matching/compatible"
+(
+  omarchy-hw-qualcomm-soc() { return 0; }
+  omarchy-hw-match() { return 1; }
+  systemctl() { printf '%s\n' "$*" >>"$matching/systemctl.log"; }
+
+  OMARCHY_YOGA_COMPATIBLE_PATH="$matching/compatible" \
+    OMARCHY_YOGA_MODULES_LOAD_DIR="$matching/modules-load.d" \
+    OMARCHY_YOGA_MKINITCPIO_DIR="$matching/mkinitcpio.conf.d" \
+    OMARCHY_YOGA_SYSTEMD_DIR="$matching/systemd" \
+    source "$setup"
+)
+
+grep -Fxq 'scmi-cpufreq' "$matching/modules-load.d/yoga-slim7x.conf" ||
   fail "Yoga Slim 7x setup loads its SCMI CPU-frequency driver"
+grep -Fxq 'MODULES+=(i2c-hid-of)' "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf" ||
+  fail "Yoga Slim 7x setup keeps the internal keyboard in the initramfs"
+grep -Fq 'ConditionPathExists=!/etc/modprobe.d/qualcomm-adsp-nofw.conf' \
+  "$matching/systemd/yoga-slim7x-remoteprocs.service" ||
+  fail "Yoga Slim 7x skips DSP startup when the generic firmware leaf blacklists it"
+grep -Fxq 'enable yoga-slim7x-remoteprocs.service' "$matching/systemctl.log" ||
+  fail "Yoga Slim 7x enables its remote processor service"
+
+nonmatching="$scratch/nonmatching"
+mkdir -p "$nonmatching"
+printf 'qcom,x1e80100\0hp,elitebook-ultra-g1q\0' >"$nonmatching/compatible"
+(
+  omarchy-hw-qualcomm-soc() { return 0; }
+  omarchy-hw-match() { return 1; }
+  systemctl() { fail "nonmatching Qualcomm hardware does not enable Yoga services"; }
+
+  OMARCHY_YOGA_COMPATIBLE_PATH="$nonmatching/compatible" \
+    OMARCHY_YOGA_MODULES_LOAD_DIR="$nonmatching/modules-load.d" \
+    OMARCHY_YOGA_MKINITCPIO_DIR="$nonmatching/mkinitcpio.conf.d" \
+    OMARCHY_YOGA_SYSTEMD_DIR="$nonmatching/systemd" \
+    source "$setup"
+)
+
+[[ ! -e $nonmatching/modules-load.d/yoga-slim7x.conf ]] ||
+  fail "nonmatching Qualcomm hardware does not get Yoga CPU setup"
+[[ ! -e $nonmatching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf ]] ||
+  fail "nonmatching Qualcomm hardware does not get Yoga initramfs setup"
+[[ ! -e $nonmatching/systemd/yoga-slim7x-remoteprocs.service ]] ||
+  fail "nonmatching Qualcomm hardware does not get Yoga services"
 
 remoteprocs="$scratch/remoteproc"
 mkdir -p "$remoteprocs/remoteproc0" "$remoteprocs/remoteproc1" "$remoteprocs/remoteproc2"

--- a/test/shell.d/yoga-slim7x-hardware-test.sh
+++ b/test/shell.d/yoga-slim7x-hardware-test.sh
@@ -22,17 +22,28 @@ printf 'qcom,x1e80100\0lenovo,yoga-slim7x\0' >"$matching/compatible"
   OMARCHY_YOGA_COMPATIBLE_PATH="$matching/compatible" \
     OMARCHY_YOGA_MODULES_LOAD_DIR="$matching/modules-load.d" \
     OMARCHY_YOGA_MKINITCPIO_DIR="$matching/mkinitcpio.conf.d" \
+    OMARCHY_YOGA_LIMINE_CONFIG_DIR="$matching/limine-entry-tool.d" \
     OMARCHY_YOGA_SYSTEMD_DIR="$matching/systemd" \
     source "$setup"
 )
 
 grep -Fxq 'scmi-cpufreq' "$matching/modules-load.d/yoga-slim7x.conf" ||
   fail "Yoga Slim 7x setup loads its SCMI CPU-frequency driver"
-grep -Fxq 'MODULES+=(i2c-hid-of)' "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf" ||
-  fail "Yoga Slim 7x setup keeps the internal keyboard in the initramfs"
+grep -Fxq 'MODULES+=(i2c-hid-of qrtr ps883x pmic_glink_altmode)' \
+  "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf" ||
+  fail "Yoga Slim 7x setup initializes the keyboard and display in the initramfs"
+grep -Fq '/usr/lib/firmware/qcom/gen70500_sqe.fw' \
+  "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf" ||
+  fail "Yoga Slim 7x setup includes its display firmware in the initramfs"
+grep -Fxq 'KERNEL_CMDLINE[default]+=" initcall_blacklist=simpledrm_platform_driver_init"' \
+  "$matching/limine-entry-tool.d/yoga-slim7x.conf" ||
+  fail "Yoga Slim 7x setup defers display ownership to the native driver"
 grep -Fq 'ConditionPathExists=!/etc/modprobe.d/qualcomm-adsp-nofw.conf' \
   "$matching/systemd/yoga-slim7x-remoteprocs.service" ||
   fail "Yoga Slim 7x skips DSP startup when the generic firmware leaf blacklists it"
+if grep -Fq 'systemd-udev-settle.service' "$matching/systemd/yoga-slim7x-remoteprocs.service"; then
+  fail "Yoga Slim 7x DSP startup does not wait for all udev devices"
+fi
 grep -Fxq 'enable yoga-slim7x-remoteprocs.service' "$matching/systemctl.log" ||
   fail "Yoga Slim 7x enables its remote processor service"
 
@@ -47,6 +58,7 @@ printf 'qcom,x1e80100\0hp,elitebook-ultra-g1q\0' >"$nonmatching/compatible"
   OMARCHY_YOGA_COMPATIBLE_PATH="$nonmatching/compatible" \
     OMARCHY_YOGA_MODULES_LOAD_DIR="$nonmatching/modules-load.d" \
     OMARCHY_YOGA_MKINITCPIO_DIR="$nonmatching/mkinitcpio.conf.d" \
+    OMARCHY_YOGA_LIMINE_CONFIG_DIR="$nonmatching/limine-entry-tool.d" \
     OMARCHY_YOGA_SYSTEMD_DIR="$nonmatching/systemd" \
     source "$setup"
 )
@@ -55,6 +67,8 @@ printf 'qcom,x1e80100\0hp,elitebook-ultra-g1q\0' >"$nonmatching/compatible"
   fail "nonmatching Qualcomm hardware does not get Yoga CPU setup"
 [[ ! -e $nonmatching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf ]] ||
   fail "nonmatching Qualcomm hardware does not get Yoga initramfs setup"
+[[ ! -e $nonmatching/limine-entry-tool.d/yoga-slim7x.conf ]] ||
+  fail "nonmatching Qualcomm hardware does not get Yoga boot parameters"
 [[ ! -e $nonmatching/systemd/yoga-slim7x-remoteprocs.service ]] ||
   fail "nonmatching Qualcomm hardware does not get Yoga services"
 
@@ -79,4 +93,4 @@ OMARCHY_YOGA_REMOTEPROC_ROOT="$remoteprocs" \
 [[ $(<"$remoteprocs/remoteproc2/state") == offline ]] ||
   fail "Yoga Slim 7x helper leaves unrelated remote processors alone"
 
-pass "Yoga Slim 7x adds only its board-specific keyboard, CPU and DSP setup"
+pass "Yoga Slim 7x adds only its board-specific keyboard, display, CPU and DSP setup"

--- a/test/shell.d/yoga-slim7x-hardware-test.sh
+++ b/test/shell.d/yoga-slim7x-hardware-test.sh
@@ -53,6 +53,14 @@ grep -Fxq 'MODULES+=(i2c-hid-of qrtr ps883x pmic_glink_altmode)' \
 grep -Fxq 'KERNEL_CMDLINE[default]+=" initcall_blacklist=simpledrm_platform_driver_init"' \
   "$matching/limine-entry-tool.d/yoga-slim7x.conf" ||
   fail "Yoga Slim 7x setup defers display ownership to the native driver"
+(
+  declare -A KERNEL_CMDLINE=([default]="root=/dev/mapper/root quiet splash")
+  source "$matching/limine-entry-tool.d/yoga-slim7x.conf"
+  [[ " ${KERNEL_CMDLINE[default]} " == *" console=tty0 "* ]] ||
+    fail "Yoga Slim 7x uses the laptop console for graphical disk unlock"
+  [[ ${KERNEL_CMDLINE[default]} == "root=/dev/mapper/root quiet splash "* ]] ||
+    fail "Yoga Slim 7x preserves the existing boot parameters"
+)
 grep -Fq 'ConditionPathExists=!/etc/modprobe.d/qualcomm-adsp-nofw.conf' \
   "$matching/systemd/yoga-slim7x-remoteprocs.service" ||
   fail "Yoga Slim 7x skips DSP startup when the generic firmware leaf blacklists it"

--- a/test/shell.d/yoga-slim7x-hardware-test.sh
+++ b/test/shell.d/yoga-slim7x-hardware-test.sh
@@ -9,7 +9,9 @@ starter="$ROOT/install/hardware/lenovo/start-yoga-slim7x-remoteprocs.sh"
 scratch=$(mktemp -d)
 trap 'rm -rf "$scratch"' EXIT
 
-bash -n "$setup" "$starter" || fail "Yoga Slim 7x hardware scripts have valid syntax"
+for script in "$setup" "$starter"; do
+  bash -n "$script" || fail "Yoga Slim 7x hardware scripts have valid syntax"
+done
 
 matching="$scratch/matching"
 mkdir -p "$matching"
@@ -29,35 +31,35 @@ printf 'qcom,x1e80100\0lenovo,yoga-slim7x\0' >"$matching/compatible"
 
 grep -Fxq 'scmi-cpufreq' "$matching/modules-load.d/yoga-slim7x.conf" ||
   fail "Yoga Slim 7x setup loads its SCMI CPU-frequency driver"
-grep -Fxq 'MODULES+=(i2c-hid-of qrtr ps883x pmic_glink_altmode)' \
-  "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf" ||
-  fail "Yoga Slim 7x setup initializes the keyboard and display in the initramfs"
 (
   firmware_root="$scratch/firmware"
-  mkdir -p "$firmware_root/qcom" "$firmware_root/updates/qcom/x1e80100/LENOVO/83ED"
+  mkdir -p "$firmware_root/qcom" "$firmware_root/updates/qcom"
   touch "$firmware_root/qcom/gen70500_sqe.fw.zst" \
-    "$firmware_root/qcom/gen70500_gmu.bin.xz" \
-    "$firmware_root/updates/qcom/gen70500_sqe.fw" \
-    "$firmware_root/updates/qcom/x1e80100/LENOVO/83ED/qcdxkmsuc8380.mbn"
+    "$firmware_root/qcom/gen70500_gmu.bin.xz"
   MODULES=() FILES=()
   OMARCHY_YOGA_FIRMWARE_ROOT="$firmware_root" \
     source "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf"
   [[ ${MODULES[*]} == "i2c-hid-of qrtr ps883x pmic_glink_altmode" ]] ||
     fail "the generated config loads the keyboard and display modules"
-  [[ ${#FILES[@]} == 3 ]] || fail "all available display firmware is included"
-  [[ ${FILES[0]} == "$firmware_root/updates/qcom/gen70500_sqe.fw" ]] ||
-    fail "extracted firmware takes precedence over packaged firmware"
+  (( ${#FILES[@]} == 2 )) || fail "GPU microcode is included without duplicating the board zap shader"
+  [[ ${FILES[0]} == "$firmware_root/qcom/gen70500_sqe.fw.zst" ]] ||
+    fail "zstd display firmware is included"
   [[ ${FILES[1]} == "$firmware_root/qcom/gen70500_gmu.bin.xz" ]] ||
-    fail "compressed display firmware is included"
+    fail "xz display firmware is included"
+  touch "$firmware_root/updates/qcom/gen70500_sqe.fw"
+  FILES=()
+  OMARCHY_YOGA_FIRMWARE_ROOT="$firmware_root" \
+    source "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf"
+  [[ ${FILES[0]} == "$firmware_root/updates/qcom/gen70500_sqe.fw" ]] ||
+    fail "plain extracted firmware takes precedence over compressed packaged firmware"
 )
-grep -Fxq 'KERNEL_CMDLINE[default]+=" initcall_blacklist=simpledrm_platform_driver_init"' \
-  "$matching/limine-entry-tool.d/yoga-slim7x.conf" ||
-  fail "Yoga Slim 7x setup defers display ownership to the native driver"
 (
   declare -A KERNEL_CMDLINE=([default]="root=/dev/mapper/root quiet splash")
   source "$matching/limine-entry-tool.d/yoga-slim7x.conf"
   [[ " ${KERNEL_CMDLINE[default]} " == *" console=tty0 "* ]] ||
     fail "Yoga Slim 7x uses the laptop console for graphical disk unlock"
+  [[ " ${KERNEL_CMDLINE[default]} " == *" initcall_blacklist=simpledrm_platform_driver_init "* ]] ||
+    fail "Yoga Slim 7x defers display ownership to the native driver"
   [[ ${KERNEL_CMDLINE[default]} == "root=/dev/mapper/root quiet splash "* ]] ||
     fail "Yoga Slim 7x preserves the existing boot parameters"
 )
@@ -95,6 +97,20 @@ printf 'qcom,x1e80100\0hp,elitebook-ultra-g1q\0' >"$nonmatching/compatible"
 [[ ! -e $nonmatching/systemd/yoga-slim7x-remoteprocs.service ]] ||
   fail "nonmatching Qualcomm hardware does not get Yoga services"
 
+(
+  omarchy-hw-qualcomm-soc() { return 0; }
+  omarchy-hw-match() { [[ $1 == "83ED" ]]; }
+  systemctl() { :; }
+  OMARCHY_YOGA_COMPATIBLE_PATH="$scratch/no-compatible" \
+    OMARCHY_YOGA_MODULES_LOAD_DIR="$nonmatching/modules-load.d" \
+    OMARCHY_YOGA_MKINITCPIO_DIR="$nonmatching/mkinitcpio.conf.d" \
+    OMARCHY_YOGA_LIMINE_CONFIG_DIR="$nonmatching/limine-entry-tool.d" \
+    OMARCHY_YOGA_SYSTEMD_DIR="$nonmatching/systemd" \
+    source "$setup"
+)
+[[ -f $nonmatching/modules-load.d/yoga-slim7x.conf ]] ||
+  fail "Lenovo DMI matching works without a device-tree compatible property"
+
 remoteprocs="$scratch/remoteproc"
 mkdir -p "$remoteprocs/remoteproc0" "$remoteprocs/remoteproc1" "$remoteprocs/remoteproc2"
 printf 'qcom/x1e80100/LENOVO/83ED/qcadsp8380.mbn\n' >"$remoteprocs/remoteproc0/firmware"
@@ -115,5 +131,31 @@ OMARCHY_YOGA_REMOTEPROC_ROOT="$remoteprocs" \
   fail "Yoga Slim 7x helper starts the compute DSP by firmware identity"
 [[ $(<"$remoteprocs/remoteproc2/state") == offline ]] ||
   fail "Yoga Slim 7x helper leaves unrelated remote processors alone"
+
+run_starter() {
+  OMARCHY_YOGA_REMOTEPROC_ROOT="$remoteprocs" \
+    OMARCHY_YOGA_REMOTEPROC_ATTEMPTS=1 \
+    OMARCHY_YOGA_REMOTEPROC_SLEEP=0 \
+    bash "$starter"
+}
+printf 'running\n' >"$remoteprocs/remoteproc0/state"
+printf 'running\n' >"$remoteprocs/remoteproc1/state"
+run_starter
+[[ $(<"$remoteprocs/remoteproc0/state") == running ]] || fail "running ADSP is not restarted"
+[[ $(<"$remoteprocs/remoteproc1/state") == running ]] || fail "running CDSP is not restarted"
+
+printf 'unrelated.mbn\n' >"$remoteprocs/remoteproc0/firmware"
+if run_starter; then fail "missing ADSP must time out, even when CDSP is running"; fi
+printf 'qcadsp8380.mbn\n' >"$remoteprocs/remoteproc0/firmware"
+printf 'offline\n' >"$remoteprocs/remoteproc0/state"
+(
+  printf() {
+    [[ $1 != "start\n" ]] || return 1
+    # shellcheck disable=SC2059 # Forward the caller's format unchanged.
+    builtin printf "$@"
+  }
+  export -f printf
+  if run_starter; then fail "a failed ADSP start must be reported"; fi
+)
 
 pass "Yoga Slim 7x adds only its board-specific keyboard, display, CPU and DSP setup"

--- a/test/shell.d/yoga-slim7x-hardware-test.sh
+++ b/test/shell.d/yoga-slim7x-hardware-test.sh
@@ -32,9 +32,24 @@ grep -Fxq 'scmi-cpufreq' "$matching/modules-load.d/yoga-slim7x.conf" ||
 grep -Fxq 'MODULES+=(i2c-hid-of qrtr ps883x pmic_glink_altmode)' \
   "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf" ||
   fail "Yoga Slim 7x setup initializes the keyboard and display in the initramfs"
-grep -Fq '/usr/lib/firmware/qcom/gen70500_sqe.fw' \
-  "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf" ||
-  fail "Yoga Slim 7x setup includes its display firmware in the initramfs"
+(
+  firmware_root="$scratch/firmware"
+  mkdir -p "$firmware_root/qcom" "$firmware_root/updates/qcom/x1e80100/LENOVO/83ED"
+  touch "$firmware_root/qcom/gen70500_sqe.fw.zst" \
+    "$firmware_root/qcom/gen70500_gmu.bin.xz" \
+    "$firmware_root/updates/qcom/gen70500_sqe.fw" \
+    "$firmware_root/updates/qcom/x1e80100/LENOVO/83ED/qcdxkmsuc8380.mbn"
+  MODULES=() FILES=()
+  OMARCHY_YOGA_FIRMWARE_ROOT="$firmware_root" \
+    source "$matching/mkinitcpio.conf.d/yoga-slim7x-initramfs.conf"
+  [[ ${MODULES[*]} == "i2c-hid-of qrtr ps883x pmic_glink_altmode" ]] ||
+    fail "the generated config loads the keyboard and display modules"
+  [[ ${#FILES[@]} == 3 ]] || fail "all available display firmware is included"
+  [[ ${FILES[0]} == "$firmware_root/updates/qcom/gen70500_sqe.fw" ]] ||
+    fail "extracted firmware takes precedence over packaged firmware"
+  [[ ${FILES[1]} == "$firmware_root/qcom/gen70500_gmu.bin.xz" ]] ||
+    fail "compressed display firmware is included"
+)
 grep -Fxq 'KERNEL_CMDLINE[default]+=" initcall_blacklist=simpledrm_platform_driver_init"' \
   "$matching/limine-entry-tool.d/yoga-slim7x.conf" ||
   fail "Yoga Slim 7x setup defers display ownership to the native driver"


### PR DESCRIPTION
## Summary

- Detects the Yoga Slim 7x by Qualcomm device-tree compatible or Lenovo DMI identifiers.
- Loads the keyboard and native display dependencies early enough for the encrypted-root password prompt.
- Selects the laptop console (`console=tty0`) for graphical Plymouth disk unlock and working keymap/consolefont hooks.
- Includes plain, zstd or xz GPU microcode using the kernel's search order. The shared extractor supplies the board-matched zap shader, without a second hardcoded Lenovo entry.
- Loads `scmi-cpufreq` and starts ADSP/CDSP by firmware identity, respecting the generic DSP-disable guard.

## Dependencies

- **Prerequisite:** the generic Snapdragon runtime in #8672. This branch now contains its full current head [`6daf6db`](https://github.com/omacom/omarchy/commit/6daf6dbb9da181d1b6d29424774b36a22c8dffc6), including Jim Martin's repository-preservation fix, merged in [`4279ca2`](https://github.com/omacom/omarchy/pull/8673/commits/4279ca250e542da20ecd0bfb5bd8080d07ff06d6) on September 11. The generic runtime should land first; relative to #8672, this branch contains only the four Yoga-specific setup/test files. Recheck that relationship if the prerequisite changes before merging.
- **Required by this installation path:** omacom/omarchy-pkgs#221 handles firmware inspection and includes the board-selected GPU zap firmware in the initramfs, including when it is already installed. This package dependency does not mean Windows extraction is always needed.
- **Enables:** Yoga setup in omacom/omarchy-iso#129. The ISO is a downstream consumer, not a prerequisite for merging this PR.

The systemd shutdown fix and camera stack described below are separate follow-ups, not merge prerequisites.

## Validation

[Physical Yoga Slim 7x 14Q8X9 (83ED) validation](https://github.com/omacom/omarchy/discussions/10426) confirms Limine boot without the UKI hash warning, graphical Omarchy disk-encryption unlock with the built-in keyboard, polished shutdown/reboot without terminal messages, the graphical desktop, native display, GPU acceleration, Wi-Fi, Bluetooth mouse, internal speakers and microphone. The shutdown/reboot result also used a separate systemd v261.2 backport of the change proposed in [systemd/systemd#43671](https://github.com/systemd/systemd/pull/43671). That fix remains under review and is not included in this PR. The speaker-reset kernel fix, archlinuxarm/PKGBUILDs#2217, has merged.

The OV02C10 camera also has a visually confirmed fast, upright preview with natural-looking colors and strong noise reduction on the separate experimental kernel `7.2.0-1.1-aarch64-ARCH-camera1`. Camera enablement is a follow-up, not part of this PR; the hardware report covers the subsequent Chromium live-video test and remaining integration work. The separate [libcamera cleanup-hang fix](https://patchwork.libcamera.org/patch/28196/) prevents a hang after capture-start failure and carries Kieran Bingham's `Reviewed-by`. It remains unmerged and does not fix the underlying sensor timeout or image quality.

Barnabás Pőcze's [PipeWire libcamera compatibility fixes (!2981)](https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2981) are merged and backported to the 1.6 branch. As checked on September 11, 1.6.9 is not tagged. A release and Arch Linux ARM packaging containing the fixes are still needed for normal distribution; the source merge alone does not provide stock camera support.

The later [September 7 isolated Chromium tests](https://gitlab.freedesktop.org/pipewire/pipewire/-/work_items/5459#note_3650166) passed 11 complete 12-second 720p captures at 29.8-30.0 fps across initial starts, page refresh, browser/services restart and one whole-machine suspend/wake. They used source-built libcamera and the unmodified PipeWire 1.6 branch on the existing experimental camera kernel, without the GStreamer diagnostic patch. The owner reported upright, responsive video with acceptable but slightly pale colors. These results establish that isolated browser path, not measured end-to-end latency or a normally packaged replacement. Candidate startup timing, calibration, the shared 1080p CMA allocation problem and the separate GStreamer timestamp issue remain open; normal package/update/reboot integration and the newer kernel still need validation.

The updated Bash 5 tests pass for matching/nonmatching boards, DMI-only detection, already-running DSPs, missing ADSP, failed starts, independent zstd/xz selection, firmware precedence and console selection without replacing existing boot parameters. A cross-repository fixture verifies that shared extraction and Yoga setup include each GPU firmware file once.

The September 11 synchronization passed five focused Bash 5 suites in an isolated ARM64 Linux container for install repositories, repository refresh, the pacman upgrade guard, generic Snapdragon setup and Yoga setup. The full CLI suite, Bash syntax checks, whitespace checks and ShellCheck 0.11.0 for the four incoming repository-refresh files also passed. The Yoga-specific code was unchanged. The merged branch combined cleanly with `quattro` at `5b91db5`. No installed-system package upgrade or Yoga reboot was performed for this synchronization.

The console change was boot-tested on the Yoga with kernel `7.2.0-1.1-aarch64-ARCH`, changing only the command line of the working boot image. Active consoles changed from `tty0 ttyMSM0` to `tty0`. The owner confirmed graphical Omarchy disk unlock and successful desktop startup, without `kbd_mode: KDSKBMODE: Inappropriate ioctl for device`, `Couldn't open /dev/console`, or scrolling service status.

The current firmware-consolidation and failure-path changes were tested in an ARM64 container; they have not been deployed to the Yoga for another boot test. HP/ASUS validation of the console and early-display changes is still pending.
