### PR TITLE
Honor never-expire notification timeouts

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -14,11 +14,7 @@ The end-user view (hotkey notices for time, battery, weather) is in
 
 ## Toast lifecycle
 
-A toast lives on screen for at least 5s (low), 8s (normal), or forever
-(critical), stretched up to 30s if the sender asked for a longer
-`expire_timeout`. Hovering pauses the countdown, and a content update restarts
-it — new text deserves a full look. Left-click invokes the default action,
-right-click or the hover-revealed close button dismisses.
+A toast lives on screen for at least 5s (low), 8s (normal), or forever (critical), stretched up to 30s if the sender asked for a longer `expire_timeout`. An explicit timeout of `0` also keeps a low or normal toast on screen until it is answered, independently of urgency. Hovering pauses the countdown, and a content update restarts it — new text deserves a full look. Left-click invokes the default action, right-click or the hover-revealed close button dismisses.
 
 Every on-screen popup is mirrored to its own file under
 `~/.local/state/omarchy/notifications/` (one JSON line per file, named
@@ -77,7 +73,7 @@ flags map onto that call:
 | `-i` / `--icon` | `app_icon` | themed icon name for the toast |
 | `--app-name` | `app_name` | defaults to `omarchy-action` |
 | `-u` / `--urgency` | hint `urgency` (byte) | `low`/`normal`/`critical`; defaults to `low` |
-| `-t` / `--expire-time` | `expire_timeout` | milliseconds on screen; server default otherwise |
+| `-t` / `--expire-time` | `expire_timeout` | milliseconds on screen; `0` means until dismissed; server default otherwise |
 
 Unknown flags are a hard error, not a silent pass-through: `--exec` is the only
 door to a click command, and there is no generic option pass-through to smuggle

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -96,11 +96,28 @@ function shouldRenderCompactGlyph(glyph, iconSource, singleLineToast) {
   return String(glyph || "").length > 0 && String(iconSource || "").length === 0 && !!singleLineToast
 }
 
+function normalizeExpireTimeout(value) {
+  if (value === undefined || value === null || value === "") return -1
+  var timeout = Number(value)
+  if (!isFinite(timeout) || timeout < 0) return -1
+  return timeout
+}
+
+function popupDuration(expireTimeout, defaultDuration, maxDuration) {
+  var timeout = normalizeExpireTimeout(expireTimeout)
+  if (timeout === 0) return 0
+
+  var fallback = Math.max(0, Number(defaultDuration) || 0)
+  if (timeout < 0) return fallback
+
+  var maximum = Math.max(fallback, Number(maxDuration) || 0)
+  return Math.min(maximum, Math.max(fallback, Math.max(1, Math.round(timeout))))
+}
+
 function snapshotOf(notification, timestamp) {
   var n = notification || {}
   var id = n.id || 0
-  var expireTimeout = Number(n.expireTimeout || 0)
-  if (!isFinite(expireTimeout) || expireTimeout < 0) expireTimeout = 0
+  var expireTimeout = normalizeExpireTimeout(n.expireTimeout)
   return {
     id: id,
     originalId: id,
@@ -163,7 +180,9 @@ function historyEntry(value, normalUrgency) {
     glyph: e.glyph || "",
     execArgv: e.execArgv || "",
     urgency: typeof e.urgency === "number" ? e.urgency : normalUrgency,
-    expireTimeout: 0,
+    // History replays use the server default rather than inheriting the
+    // original toast's requested lifetime.
+    expireTimeout: -1,
     timestamp: e.timestamp || 0
   }
 }
@@ -197,10 +216,15 @@ function parseSettings(raw) {
 // moved into the history/ subdirectory when the toast expires, is dismissed,
 // or its action is invoked. History is those moved files, newest last-10.
 
-function popupEntry(value, normalUrgency) {
-  var entry = historyEntry(value, normalUrgency)
-  var expire = Number((value || {}).expireTimeout || 0)
-  if (!isFinite(expire) || expire < 0) expire = 0
+function popupEntry(value, normalUrgency, fromDisk) {
+  var source = value || {}
+  var entry = historyEntry(source, normalUrgency)
+  var expire = normalizeExpireTimeout(source.expireTimeout)
+  // Popup files written before timeoutPolicyVersion existed normalized the
+  // server default (-1) to 0. Preserve their old timed behavior on upgrade;
+  // newly written files mark 0 as an explicit never-expire request.
+  var timeoutPolicyVersion = Number(source.timeoutPolicyVersion || 0)
+  if (fromDisk && expire === 0 && (!isFinite(timeoutPolicyVersion) || timeoutPolicyVersion < 1)) expire = -1
   entry.expireTimeout = expire
   // Absolute expiry deadline, set only when a restore resets a surviving
   // popup's display lifetime. Kept out of the entry entirely when unset so
@@ -269,7 +293,9 @@ function persistablePopup(entry, imagesDir) {
 function serializePopup(entry, normalUrgency) {
   // Compact (single-line) on purpose: restore cats every file together and
   // parses line by line, which only works when each file is one line.
-  return JSON.stringify(popupEntry(entry, normalUrgency))
+  var persisted = popupEntry(entry, normalUrgency)
+  persisted.timeoutPolicyVersion = 1
+  return JSON.stringify(persisted)
 }
 
 // Parse the concatenation of every persisted popup file into entries,
@@ -288,7 +314,7 @@ function parsePopupFiles(raw, normalUrgency) {
     if (!line) continue
     try {
       var value = JSON.parse(line)
-      if (value && typeof value === "object") entries.push(popupEntry(value, normalUrgency))
+      if (value && typeof value === "object") entries.push(popupEntry(value, normalUrgency, true))
     } catch (e) {
       // A torn write from a crash mid-save — skip the line, keep the rest.
     }
@@ -299,7 +325,8 @@ function parsePopupFiles(raw, normalUrgency) {
 
 // A persisted popup whose lifetime already ran out would have expired on
 // screen had the shell kept running, so it is not restored. duration 0 means
-// the popup never expires (critical urgency) and always survives restarts.
+// the popup never expires (critical urgency or an explicit timeout of 0) and
+// always survives restarts.
 // A restore-reset deadline outranks the original timestamp: without it, a
 // second restart would judge a re-shown toast by a clock that no longer
 // governs its display and drop it while it is still on screen.
@@ -374,6 +401,8 @@ if (typeof module !== "undefined") {
     execArgvFromHints: execArgvFromHints,
     parseExecArgv: parseExecArgv,
     shouldRenderCompactGlyph: shouldRenderCompactGlyph,
+    normalizeExpireTimeout: normalizeExpireTimeout,
+    popupDuration: popupDuration,
     snapshotOf: snapshotOf,
     popupRoles: popupRoles,
     popupRowChanged: popupRowChanged,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -100,22 +100,12 @@ Item {
   readonly property int maxPopupDuration: 30000
 
   function durationFor(urgency, expireTimeout) {
-    switch (urgency) {
-    case NotificationUrgency.Critical:
-      return 0
-    case NotificationUrgency.Low:
-      return Math.min(maxPopupDuration, Math.max(lowPopupDuration, requestedDuration(expireTimeout)))
-    default:
-      return Math.min(maxPopupDuration, Math.max(normalPopupDuration, requestedDuration(expireTimeout)))
-    }
-  }
+    if (urgency === NotificationUrgency.Critical) return 0
 
-  function requestedDuration(expireTimeout) {
-    // FreeDesktop notification spec (and Quickshell) report expireTimeout in
-    // milliseconds, so pass it through directly.
-    var ms = Number(expireTimeout || 0)
-    if (!isFinite(ms) || ms <= 0) return 0
-    return Math.round(ms)
+    var defaultDuration = urgency === NotificationUrgency.Low
+      ? lowPopupDuration
+      : normalPopupDuration
+    return NotificationLogic.popupDuration(expireTimeout, defaultDuration, maxPopupDuration)
   }
 
   // DND bypass: only let through notifications we trust to be intentional
@@ -692,7 +682,7 @@ Item {
         glyph: "󰂚",
         execArgv: "",
         urgency: NotificationUrgency.Low,
-        expireTimeout: 0,
+        expireTimeout: -1,
         timestamp: Date.now()
       })
       return

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -155,6 +155,20 @@ assertDeepEqual(
   },
   'notifications create stable snapshots'
 )
+assertEqual(
+  notifications.snapshotOf({ id: 1, urgency: 1 }, 1).expireTimeout,
+  -1,
+  'notifications preserve the server-default timeout separately from never-expire'
+)
+assertEqual(
+  notifications.snapshotOf({ id: 1, urgency: 1, expireTimeout: 0 }, 1).expireTimeout,
+  0,
+  'notifications preserve an explicit never-expire timeout'
+)
+assertEqual(notifications.popupDuration(-1, 8000, 30000), 8000, 'notifications use the default lifetime when requested')
+assertEqual(notifications.popupDuration(0, 8000, 30000), 0, 'notifications honor a never-expire timeout')
+assertEqual(notifications.popupDuration(12000, 8000, 30000), 12000, 'notifications honor a longer requested lifetime')
+assertEqual(notifications.popupDuration(60000, 8000, 30000), 30000, 'notifications cap finite requested lifetimes')
 
 // An in-place update keeps the popup's identity — the file name it was
 // persisted under — and takes everything the card draws from the new content.
@@ -240,7 +254,7 @@ assertDeepEqual(
   ['newest', 'middle'],
   'notifications replay the newest history rows up to the limit'
 )
-assertEqual(historyReplay[0].expireTimeout, 0, 'notifications replay history rows with the standard toast lifetime')
+assertEqual(historyReplay[0].expireTimeout, -1, 'notifications replay history rows with the standard toast lifetime')
 assertEqual('deadline' in historyReplay[0], false, 'notifications drop the restore deadline from replayed history rows')
 assertDeepEqual(notifications.historyRows('', [], 1, 10), [], 'notifications replay nothing from an empty history dir')
 
@@ -293,6 +307,16 @@ assertEqual(
   notifications.popupEntry({ id: 1, timestamp: 5, expireTimeout: 4000 }, 1).expireTimeout,
   4000,
   'notifications preserve popup expire timeouts unlike history rows'
+)
+assertEqual(
+  notifications.popupEntry({ id: 1, timestamp: 5 }, 1).expireTimeout,
+  -1,
+  'notifications keep an omitted popup timeout as the server default'
+)
+assertEqual(
+  notifications.popupEntry({ id: 1, timestamp: 5, expireTimeout: 0 }, 1).expireTimeout,
+  0,
+  'notifications keep an explicit zero popup timeout as never-expire'
 )
 
 // Persisted entries must not reference images another process owns: Chromium
@@ -361,6 +385,22 @@ assertDeepEqual(
   notifications.parsePopupFiles('', 1),
   [],
   'notifications restore nothing from an empty popup dir'
+)
+assertEqual(
+  notifications.parsePopupFiles(
+    notifications.serializePopup({ id: 3, originalId: 3, urgency: 1, expireTimeout: 0, timestamp: 400 }, 1),
+    1
+  )[0].expireTimeout,
+  0,
+  'notifications restore a newly persisted never-expire timeout'
+)
+assertEqual(
+  notifications.parsePopupFiles(
+    JSON.stringify({ id: 3, originalId: 3, urgency: 1, expireTimeout: 0, timestamp: 400 }),
+    1
+  )[0].expireTimeout,
+  -1,
+  'notifications keep legacy default-timeout popup files timed after upgrade'
 )
 
 assert(!notifications.popupExpired({ timestamp: 0 }, 0, 999999), 'critical popups never expire on restore')


### PR DESCRIPTION
Honor `expire_timeout=0` as never-expire for low- and normal-urgency notifications instead of treating it like the server default.

The notification service currently collapses -1 (server default) and 0 (never expire) into the same timed path. Preserve that distinction through snapshotting and persistence so callers can request a persistent notification without inflating its urgency.

Legacy persisted popups retain their previous timed behavior. Critical notifications and history replay behavior remain unchanged.

This provides the dedicated “wants an answer” mechanism discussed in #7953. Related earlier discussion: #5059