### PR TITLE
Hide Ghostty scrollbar in screensaver

### DIFF
--- a/default/ghostty/screensaver
+++ b/default/ghostty/screensaver
@@ -1,3 +1,4 @@
 window-padding-x = 0
 window-padding-y = 0
 window-padding-color = "extend-always"
+scrollbar = never


### PR DESCRIPTION
## Problem

Ghostty 1.3 enables GTK overlay scrollbars by default. While ttfx is running, a gray scrollbar can intermittently appear at the right edge of each fullscreen screensaver window on multi-monitor setups.

## Fix

Disable the scrollbar in Omarchy's dedicated Ghostty screensaver profile. This does not change scrollbar behavior in ordinary Ghostty windows.

## Verification

- `ghostty +validate-config --config-file=default/ghostty/screensaver`
- Live two-monitor verification: scrollbar reproduced before the change and absent afterward
- `./test/all`: relevant idle and system-lock tests pass; the full run reports six unrelated host/checkout-dependent failures in `config-test`, `launch-about-test`, `network-qr-test`, `snapper-test`, `theme-install-guards-test`, and `unowned-system-paths-test`

### Before

<img width="5361" height="1200" alt="screenshot-2026-08-28_00-45-08" src="https://github.com/user-attachments/assets/f8f6437a-c66e-4e9c-809a-11e39f0867bd" />

### After

<img width="5360" height="1201" alt="screenshot-2026-08-28_00-47-11" src="https://github.com/user-attachments/assets/3b30ce71-35fb-45a9-a9ef-8f73b5b6c6bd" />
