### PR TITLE
Use German console keymap with umlauts

### DIFF
--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -47,7 +47,7 @@ French|fr
 French (Canada)|cf
 French (Switzerland)|fr_CH
 Georgian|ge
-German|de
+German|de-latin1
 German (Switzerland)|de_CH-latin1
 Greek|gr
 Hebrew|il

--- a/test/shell.d/setup-form-test.sh
+++ b/test/shell.d/setup-form-test.sh
@@ -127,7 +127,7 @@ pass "the form publishes the 0/1/130 status contract and leads with English (US)
 
 run_prompt omarchy_prompt_keyboard "0:German"
 assert_status 0 "keyboard prompt succeeds"
-[[ $(field keyboard) == "de" ]] || fail "keyboard prompt resolves the label to a keymap"
+[[ $(field keyboard) == "de-latin1" ]] || fail "keyboard prompt resolves the label to a keymap"
 [[ $(field keyboard_label) == "German" ]] || fail "keyboard prompt keeps the label for the summary"
 [[ $(head -n 1 "$tmp_dir/stdin.1") == "English (US)" ]] || fail "keyboard prompt offers English (US) first"
 grep -qF -- '--selected English (US)' "$GUM_ARGS" || fail "keyboard prompt preselects English (US)"


### PR DESCRIPTION
## Summary

- map the German installer option to the standard `de-latin1` console keymap
- update the setup-form regression test to protect the corrected mapping

The previous `de` console keymap does not provide the standard German umlaut keys in the live installer. `de-latin1` provides `ä`, `ö`, `ü`, and `AltGr+Q` for `@`, while `systemd-firstboot` still derives the installed `XKBLAYOUT=de`.

Fixes #8680

## Tests

- `bash test/shell.d/setup-form-test.sh`
- `git diff --check`
- `./test/all` — relevant tests pass; five unrelated environment-dependent test files fail locally because `omarchy-pkgs` is absent, `NO_COLOR=1` is inherited, and the installed URL checker prevents an absence test
