### PR TITLE
Show IPv6 address and gateway in the network panel

### DIFF
--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -6,6 +6,7 @@
 
 verbose=false
 internet_probe=1.1.1.1
+internet_probe6=2606:4700:4700::1111
 
 case "${1:-}" in
   "")
@@ -84,6 +85,7 @@ print_ping_samples() {
 
 print_verbose() {
   local route_json iface gw src prefix link
+  local route6_json iface6 gw6 ip6
 
   route_json=$(ip -j route get "$internet_probe" 2>/dev/null)
   [[ -z $route_json ]] && return
@@ -100,6 +102,22 @@ print_verbose() {
   printf 'ip\t%s\n' "$src"
   printf 'prefix\t%s\n' "$prefix"
   printf 'gateway\t%s\n' "$gw"
+
+  # A dual-stack link routes its IPv6 traffic over the same physical
+  # interface, but not necessarily with a route in the main table -- look it
+  # up independently instead of assuming it matches $iface.
+  route6_json=$(ip -j -6 route get "$internet_probe6" 2>/dev/null)
+  if [[ -n $route6_json ]]; then
+    iface6=$(jq -r '.[0].dev // ""' <<<"$route6_json" 2>/dev/null)
+    gw6=$(jq -r '.[0].gateway // ""' <<<"$route6_json" 2>/dev/null)
+
+    if [[ -n $iface6 ]]; then
+      ip6=$(ip -j addr show "$iface6" 2>/dev/null | jq -r '.[0].addr_info[]? | select(.family == "inet6" and .scope == "global") | .local' 2>/dev/null | head -n 1)
+
+      [[ -n $ip6 ]] && printf 'ip6\t%s\n' "$ip6"
+      [[ -n $gw6 ]] && printf 'gateway6\t%s\n' "$gw6"
+    fi
+  fi
 
   if [[ -r /sys/class/net/$iface/statistics/rx_bytes ]]; then
     printf 'rx_bytes\t%s\n' "$(cat /sys/class/net/$iface/statistics/rx_bytes)"

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1249,17 +1249,36 @@ Panel {
           InfoLabel { text: "Uploaded" }
           DetailValue { text: root.hasTransferStats ? root.formatBytes(parseFloat(root.info.tx_bytes || "0")) : "--" }
 
-          InfoLabel { text: "IP Address" }
+          InfoLabel { text: "IPv4 Address" }
           DetailValue {
             text: root.info.ip || "--"
             copyable: !!root.info.ip
-            tooltipText: "Copy IP"
+            tooltipText: "Copy IPv4"
           }
-          InfoLabel { text: "Gateway" }
+          InfoLabel { text: "IPv4 Gateway" }
           DetailValue {
             text: root.info.gateway || "--"
             copyable: !!root.info.gateway
-            tooltipText: "Copy gateway"
+            tooltipText: "Copy IPv4 gateway"
+          }
+
+          InfoLabel { text: "IPv6 Address" }
+          DetailValue {
+            Layout.columnSpan: 3
+            Layout.fillWidth: true
+            elide: Text.ElideMiddle
+            text: root.info.ip6 || "--"
+            copyable: !!root.info.ip6
+            tooltipText: "Copy IPv6"
+          }
+          InfoLabel { text: "IPv6 Gateway" }
+          DetailValue {
+            Layout.columnSpan: 3
+            Layout.fillWidth: true
+            elide: Text.ElideMiddle
+            text: root.info.gateway6 || "--"
+            copyable: !!root.info.gateway6
+            tooltipText: "Copy IPv6 gateway"
           }
         }
       }


### PR DESCRIPTION
## What

Adds an **IPv6 Address** / **IPv6 Gateway** row to the network panel's connection-details grid, and relabels the existing rows **IPv4 Address** / **IPv4 Gateway** for clarity now that both stacks show up side by side.

## Why

`omarchy-network-status` only ever resolved IPv4: it routes to `1.1.1.1` and filters `ip addr show` to `family == "inet"`. On a dual-stack link, the box can be fully reachable over IPv6 and the panel would still never show it — there was simply no code path that looked.

## How

- `bin/omarchy-network-status`: added an independent `ip -6 route get` lookup against Cloudflare's IPv6 address (`2606:4700:4700::1111`, the v6 counterpart of the existing v4 probe), and print `ip6`/`gateway6` when a global (non link-local) IPv6 route exists. Silently no-ops on a v4-only link, matching how the existing v4 path already no-ops when disconnected.
- `shell/plugins/panels/network/Panel.qml`: added the two new rows. Each value spans the full row (`Layout.columnSpan: 3`) rather than sharing a quarter-width slot like the shorter IPv4 fields, with `elide: Text.ElideMiddle` as a safety net — IPv6 addresses are long enough that the original 4-up grid cell truncated/overlapped illegibly.

No `Model.js` changes needed — `info` is parsed generically from the script's tab-separated output, so the new fields flow through automatically.

## Testing

- `./test/all` — same 4 pre-existing failures with and without this change (missing sibling `omarchy-pkgs` checkout for PKGBUILD coverage, and a permission bit on `snapper-test.sh`); nothing newly broken.
- Verified live in the running shell on a dual-stack Wi-Fi network: the panel cleanly shows both an IPv4 Address/Gateway pair and an IPv6 Address/Gateway pair, full width, no clipping or overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)