### PR TITLE
Derive the Hyprland keyboard layout from the console keymap

### DIFF
--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -21,6 +21,49 @@ local function read_vconsole()
   return values
 end
 
+-- systemd translates console keymaps through this table when it can. Some
+-- keymaps offered by Omarchy have no entry there, so keep their XKB spelling
+-- here for the same fallback path.
+local keymap_xkb_fallbacks = {
+  -- The installer labels this console keymap as Azerbaijani. The console
+  -- keymap itself is historically French AZERTY; keep installer intent here.
+  azerty = { "az", "" },
+  ["bg-cp1251"] = { "bg", "" },
+  colemak = { "us", "colemak" },
+  cz = { "cz", "" },
+  ["de_CH-latin1"] = { "ch", "" },
+  kyrgyz = { "kg", "" },
+  ["no-latin1"] = { "no", "" },
+  pl = { "pl", "" },
+  ua = { "ua", "" },
+}
+
+local function resolve_keymap(keymap)
+  if not keymap or keymap == "" then
+    return nil, nil
+  end
+
+  local file = io.open("/usr/share/systemd/kbd-model-map", "r")
+  if file then
+    for line in file:lines() do
+      local console_layout, xkb_layout, xkb_variant =
+        line:match("^%s*([^#%s]+)%s+(%S+)%s+%S+%s+(%S+)")
+      if console_layout == keymap then
+        file:close()
+        return xkb_layout, xkb_variant == "-" and "" or xkb_variant
+      end
+    end
+    file:close()
+  end
+
+  local fallback = keymap_xkb_fallbacks[keymap]
+  if fallback then
+    return fallback[1], fallback[2]
+  end
+
+  return nil, nil
+end
+
 -- Layouts that can't type Latin letters. Keep in sync with the list in
 -- etc/mkinitcpio.conf.d/omarchy_hooks.conf.
 local non_latin_layouts =
@@ -28,8 +71,15 @@ local non_latin_layouts =
 
 local vconsole = read_vconsole()
 
-local kb_layout = vconsole.XKBLAYOUT or "us"
-local kb_variant = vconsole.XKBVARIANT or ""
+local kb_layout, kb_variant
+if vconsole.XKBLAYOUT and vconsole.XKBLAYOUT ~= "" then
+  kb_layout = vconsole.XKBLAYOUT
+  kb_variant = vconsole.XKBVARIANT or ""
+else
+  kb_layout, kb_variant = resolve_keymap(vconsole.KEYMAP)
+  kb_layout = kb_layout or "us"
+  kb_variant = kb_variant or ""
+end
 -- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
 -- Both Shifts together is the usual home for it, but it's easy to hit by
 -- accident while typing. The _cancel variant sets Caps Lock the same way and

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -5,23 +5,32 @@ source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 require_command lua
 
 resolved_input() {
-  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua <<'LUA'
+  OMARCHY_PATH="$ROOT" \
+    OMARCHY_VCONSOLE="${1-}" \
+    OMARCHY_KBD_MODEL_MAP="${2-}" \
+    lua <<'LUA'
 package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
 
 local vconsole = os.getenv("OMARCHY_VCONSOLE")
+local kbd_model_map = os.getenv("OMARCHY_KBD_MODEL_MAP")
 local real_open = io.open
 
 io.open = function(path, mode)
-  if path ~= "/etc/vconsole.conf" then
+  local contents
+  if path == "/etc/vconsole.conf" then
+    contents = vconsole
+  elseif path == "/usr/share/systemd/kbd-model-map" then
+    contents = kbd_model_map
+  else
     return real_open(path, mode)
   end
 
-  if not vconsole then
+  if not contents or contents == "" then
     return nil
   end
 
   local file = io.tmpfile()
-  file:write(vconsole)
+  file:write(contents)
   file:seek("set")
   return file
 end
@@ -44,7 +53,9 @@ assert_input() {
   local expected="$2"
   local actual
 
-  if (( $# > 2 )); then
+  if (( $# > 3 )); then
+    actual=$(resolved_input "$3" "$4")
+  elif (( $# > 2 )); then
     actual=$(resolved_input "$3")
   else
     actual=$(resolved_input)
@@ -73,8 +84,59 @@ XKBVARIANT=phonetic
 assert_input "non-latin layout in front gains us even when us trails" "[us,il,us] [,] [$toggle_options]" 'XKBLAYOUT=il,us
 '
 
+assert_input "console keymap resolves through systemd's XKB map" "[fr] [] [$base_options]" 'KEYMAP=fr
+' 'fr fr pc105 - terminate:ctrl_alt_bksp
+'
+assert_input "console keymap keeps the variant from systemd's XKB map" "[us] [dvorak] [$base_options]" 'KEYMAP=dvorak
+' 'dvorak us pc105 dvorak terminate:ctrl_alt_bksp
+'
+assert_input "non-latin console keymap resolved through systemd gains us in front" "[us,ru] [,] [$toggle_options]" 'KEYMAP=ru
+' 'ru ru pc105 - terminate:ctrl_alt_bksp
+'
+assert_input "console keymap missing from systemd's map uses Omarchy's fallback" "[us] [colemak] [$base_options]" 'KEYMAP=colemak
+' 'us us pc105 - terminate:ctrl_alt_bksp
+'
+assert_input "explicit XKB settings take precedence over the console keymap" "[de] [nodeadkeys] [$base_options]" 'KEYMAP=colemak
+XKBLAYOUT=de
+XKBVARIANT=nodeadkeys
+'
+assert_input "an unknown console keymap still falls back to us" "[us] [] [$base_options]" 'KEYMAP=definitely-not-a-keymap
+'
+
+while IFS='|' read -r keymap expected; do
+  assert_input "installer keymap $keymap has an XKB fallback" "$expected" "KEYMAP=$keymap"$'\n'
+done <<EOF
+colemak|[us] [colemak] [$base_options]
+azerty|[az] [] [$base_options]
+bg-cp1251|[us,bg] [,] [$toggle_options]
+cz|[cz] [] [$base_options]
+de_CH-latin1|[ch] [] [$base_options]
+kyrgyz|[us,kg] [,] [$toggle_options]
+no-latin1|[no] [] [$base_options]
+pl|[pl] [] [$base_options]
+ua|[us,ua] [,] [$toggle_options]
+EOF
+
 hooks_conf="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
 input_lua="$ROOT/default/hypr/input.lua"
+setup_form="$ROOT/install/provisioning/setup-form.sh"
+
+if [[ -r /usr/share/systemd/kbd-model-map ]]; then
+  source "$setup_form"
+
+  installer_keymaps=$(printf '%s\n' "$OMARCHY_KEYBOARD_LAYOUTS" | cut -d'|' -f2 | sort -u)
+  model_map_keymaps=$(awk '!/^[[:space:]]*#/ && NF { print $1 }' /usr/share/systemd/kbd-model-map | sort -u)
+  fallback_keymaps=$(sed -n '/^local keymap_xkb_fallbacks = {/,/^}/p' "$input_lua" |
+    sed -E -n 's/^[[:space:]]*([[:alnum:]_-]+)[[:space:]]*=.*/\1/p; s/^[[:space:]]*\["([^"]+)"\][[:space:]]*=.*/\1/p' |
+    sort -u)
+  unresolved_keymaps=$(comm -23 <(printf '%s\n' "$installer_keymaps") <(printf '%s\n%s\n' "$model_map_keymaps" "$fallback_keymaps" | sort -u))
+
+  [[ -z $unresolved_keymaps ]] ||
+    fail "installer keymaps resolve through systemd or Omarchy's fallback table" "unresolved keymaps:"$'\n'"$unresolved_keymaps"
+  pass "installer keymaps resolve through systemd or Omarchy's fallback table"
+else
+  pass "systemd keyboard map unavailable; skipping installer keymap sync check"
+fi
 
 hooks_layouts=$(awk -F')' '/\) ;;$/ { gsub(/[[:space:]|]+/, "\n", $1); print $1 }' "$hooks_conf" | grep '^[a-z]\+$' | sort)
 lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$input_lua" | grep -o '"[^"]*"' | tr -d '"' | tr ' ' '\n' | grep '^[a-z]\+$' | sort)


### PR DESCRIPTION
Fresh Quattro installs persist the selected keyboard with systemd-firstboot --keymap, which writes KEYMAP to /etc/vconsole.conf. The Hyprland input defaults only read XKBLAYOUT, so selections such as Colemak silently fell back to the US layout in the session.

When XKBLAYOUT is absent or empty, derive the XKB layout and variant from KEYMAP through /usr/share/systemd/kbd-model-map. Explicit XKB settings still take precedence, and resolved non-Latin layouts continue through the existing US-prefix handling.

Nine keymaps offered by the installer have no entry in the systemd map, so a small fallback table covers those choices. The test suite also keeps the installer list synchronized with either the systemd map or that table.

One existing mismatch is made explicit in the code: the installer labels the azerty console keymap as Azerbaijani, while that console keymap is historically French AZERTY. The fallback preserves the installer intent by resolving it to the az XKB layout; the installer label/keymap pairing can be corrected separately.

Addresses #7049 and #6878 without closing them: this fixes the Hyprland session layout, while the fcitx5 and installer-persistence aspects remain outside this change.

Tested:
- bash test/shell.d/hyprland-keyboard-layout-test.sh (23 checks pass)
- ./test/cli (passes)
- Patched module against this affected host with KEYMAP=colemak resolves layout=us and variant=colemak
- ./test/shell: the keyboard test passes; five unrelated files also fail on a clean upstream checkout because local package fixtures or external access are unavailable. A transient screenshot sanity failure passed on immediate rerun.