### PR TITLE
Open Kitty links with Super-click

### DIFF
--- a/bin/omarchy-terminal-open-link
+++ b/bin/omarchy-terminal-open-link
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# omarchy:summary=Open the link under the mouse in the active Kitty window
+# omarchy:hidden=true
+
+# Fail closed: only the active default-class Kitty process receives the click,
+# and only through its own remote-control socket. Never surfaces errors.
+
+active=$(hyprctl activewindow -j 2>/dev/null) || exit 0
+terminal_pid=$(jq -r 'select(.class == "kitty") | .pid // empty' <<<"$active" 2>/dev/null)
+
+[[ $terminal_pid =~ ^[0-9]+$ ]] || exit 0
+
+socket="${XDG_RUNTIME_DIR:-/run/user/$UID}/omarchy-kitty-$terminal_pid"
+[[ -S $socket ]] || exit 0
+
+kitten @ --to "unix:$socket" action --no-response --match state:focused mouse_handle_click link >/dev/null 2>&1
+
+exit 0

--- a/config/kitty/open-actions.conf
+++ b/config/kitty/open-actions.conf
@@ -1,0 +1,9 @@
+# Open local file links with their default handler. Web and remote URLs match
+# nothing and keep kitty's default behavior.
+#
+# ${FILE_PATH} is the percent-decoded path without query or fragment, passed
+# as one argument so paths with spaces stay intact. xdg-open does not accept a
+# -- separator.
+protocol file
+url (?i:^file://(?:localhost)?/)
+action launch --type=background xdg-open ${FILE_PATH}

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -70,7 +70,8 @@ o.bind("SUPER + CTRL + SHIFT + code:21", "Expand window down a lot", hl.dsp.wind
 o.bind("SUPER + mouse_down", "Scroll active workspace forward", hl.dsp.focus({ workspace = "e+1" }))
 o.bind("SUPER + mouse_up", "Scroll active workspace backward", hl.dsp.focus({ workspace = "e-1" }))
 
-o.bind("SUPER + mouse:272", "Move window", hl.dsp.window.drag(), { mouse = true })
+o.bind("SUPER + mouse:272", "Move window", hl.dsp.window.drag(), { mouse = true, drag = true })
+o.bind("SUPER + mouse:272", "Open link in terminal", "omarchy-terminal-open-link", { mouse = true, click = true })
 o.bind("SUPER + mouse:273", "Resize window", hl.dsp.window.resize(), { mouse = true })
 
 o.bind("SUPER + G", "Toggle window grouping", hl.dsp.group.toggle())

--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -72,6 +72,12 @@ hl.config({
     key_press_enables_dpms = true,
     mouse_move_enables_dpms = true,
   },
+
+  -- A Super+left press that moves less than this counts as a click rather
+  -- than a drag, so links in the terminal stay clickable.
+  binds = {
+    drag_threshold = 8,
+  },
 })
 
 -- Scroll nicely in the terminal.

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -20,7 +20,9 @@ You navigate between the window you want to be active with `Super + Arrow`. This
 
 If you hit `Super + Shift + 2`, you'll move the current focused application onto the second workspace. `Super + Shift + 1` moves it back. (And `Super + Shift + Alt + 2` will move the current focused application onto the second workspace without switching to it).
 
-If you hold down `Super` and use the mouse to click on a window, you'll be able to rearrange where it sits. If you hold `Super` and use the right button on the mouse, you can freely resize the window.
+If you hold down `Super` and drag with the left mouse button, you can move a window around to rearrange where it sits. If you hold `Super` and use the right mouse button, you can freely resize the window.
+
+A stationary `Super + Left` click — pressing without dragging — opens a hyperlink under the pointer, but only in Kitty. If the pointer isn't on a link, or the window isn't Kitty, nothing happens.
 
 You close a window on `Super + W` or `Super + Q` (and close all windows on `Ctrl + Alt + Delete`).
 

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -39,7 +39,8 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Ctrl + Minus/Equal` | Same resizing in bigger steps |
 | `Super + Alt + Home` | Save window width |
 | `Super + Home` | Restore saved window width |
-| `Super + Left Mouse` | Drag window around |
+| `Super + Left Mouse` (click) | Open hyperlink under pointer (Kitty only) |
+| `Super + Left Mouse` (drag) | Drag window around |
 | `Super + Right Mouse` | Resize window |
 | `Super + Scroll Wheel` | Scroll through workspaces |
 | `Super + G`               | Toggle window grouping      |

--- a/migrations/1787852446.sh
+++ b/migrations/1787852446.sh
@@ -1,0 +1,10 @@
+echo "Add Kitty open-actions rules for clicking local file links"
+
+# Fresh installs get open-actions.conf from the packaged config directory, so
+# only bring existing Kitty installs up to date, and only when they don't
+# already have the file — a customized one is never overwritten.
+kitty_config="$HOME/.config/kitty/kitty.conf"
+open_actions="$HOME/.config/kitty/open-actions.conf"
+if [[ -f $kitty_config && ! -e $open_actions && ! -L $open_actions ]]; then
+  cp "$OMARCHY_PATH/config/kitty/open-actions.conf" "$open_actions"
+fi

--- a/test/shell.d/hyprland-binding-conflicts-test.sh
+++ b/test/shell.d/hyprland-binding-conflicts-test.sh
@@ -29,18 +29,30 @@ local function proxy()
 end
 
 local bindings = {}
+local drag_threshold
+local dsp = proxy()
+dsp.exec_cmd = function(command)
+  return { command = command }
+end
 
 hl = setmetatable({
-  dsp = proxy(),
+  dsp = dsp,
   bind = function(keys, dispatcher, opts)
     opts = opts or {}
     table.insert(bindings, {
       keys = keys,
       description = opts.description or "(no description)",
       release = opts.release == true,
+      click = opts.click == true,
+      drag = opts.drag == true,
+      command = type(dispatcher) == "table" and dispatcher.command or nil,
     })
   end,
-  config = function() end,
+  config = function(options)
+    if options.binds and options.binds.drag_threshold then
+      drag_threshold = options.binds.drag_threshold
+    end
+  end,
   env = function() end,
   monitor = function() end,
   window_rule = function() end,
@@ -102,12 +114,20 @@ local function signature(binding)
   table.sort(parts)
   table.insert(parts, key:upper())
 
-  return table.concat(parts, "+") .. (binding.release and " (release)" or "")
+  -- Release, click, and drag binds can share a chord with their complements,
+  -- so each flavor keeps its own signature the way release always has.
+  local flavor = (binding.release and " (release)")
+    or (binding.click and " (click)")
+    or (binding.drag and " (drag)")
+    or ""
+
+  return table.concat(parts, "+") .. flavor
 end
 
 for _, binding in ipairs(bindings) do
-  print(signature(binding) .. "\t" .. binding.keys .. "\t" .. binding.description)
+  print(signature(binding) .. "\t" .. binding.keys .. "\t" .. binding.description .. "\t" .. (binding.command or ""))
 end
+print("CONFIG\tbinds.drag_threshold\t" .. tostring(drag_threshold))
 LUA
 }
 
@@ -174,6 +194,24 @@ pass "allowed duplicate chords are still stacked on purpose"
 (( $(grep -c $'^F9 (release)\t' <<<"$bindings") == 1 )) ||
   fail "release bindings keep their own signature"
 pass "press and release bindings on one key do not read as a conflict"
+grep -Fqx $'CONFIG\tbinds.drag_threshold\t8' <<<"$bindings" ||
+  fail "Super+left uses the expected click-versus-drag threshold"
+pass "Super+left uses an eight-pixel drag threshold"
+
+# Super+left carries two complementary binds on one chord: dragging moves the
+# window, a plain click opens the link under the cursor. Exactly one of each
+# flavor, or the gesture stops being a gesture.
+(( $(grep -c $'^SUPER+MOUSE:272 (click)\t' <<<"$bindings") == 1 )) ||
+  fail "Super+left has exactly one click binding"
+(( $(grep -c $'^SUPER+MOUSE:272 (drag)\t' <<<"$bindings") == 1 )) ||
+  fail "Super+left has exactly one drag binding"
+(( $(grep -c $'^SUPER+MOUSE:272\t' <<<"$bindings") == 0 )) ||
+  fail "Super+left carries no unflavored mouse binding"
+grep -Fq $'SUPER+MOUSE:272 (drag)\tSUPER + mouse:272\tMove window' <<<"$bindings" ||
+  fail "the Super+left drag moves the window"
+grep -Fq $'SUPER+MOUSE:272 (click)\tSUPER + mouse:272\tOpen link in terminal\tomarchy-terminal-open-link' <<<"$bindings" ||
+  fail "the Super+left click runs the terminal link helper"
+pass "Super+left is one drag and one click binding"
 
 # Guard the guard: a keysym that lands on an already bound keycode has to be
 # caught, or the check above passes by simply not looking.
@@ -188,3 +226,11 @@ probe=$(PATH="$stub_bin:$PATH" list_bindings "$home" \
 grep -Fqx "ALT+SHIFT+SUPER+RIGHT" <<<"$probe" ||
   fail "the conflict check ignores modifier order"
 pass "the conflict check catches collisions across keycodes and modifier order"
+
+# The flavor suffixes must narrow the check, not blunt it: two binds of the
+# same flavor on one chord are still a collision.
+probe=$(PATH="$stub_bin:$PATH" list_bindings "$home" \
+  'o.bind("SUPER + mouse:272", "Conflict probe", "true", { mouse = true, click = true })' | duplicate_signatures)
+grep -Fqx "SUPER+MOUSE:272 (click)" <<<"$probe" ||
+  fail "the conflict check catches two same-flavor mouse bindings on one chord"
+pass "the conflict check catches two same-flavor mouse bindings on one chord"

--- a/test/shell.d/terminal-super-click-test.sh
+++ b/test/shell.d/terminal-super-click-test.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+helper="$ROOT/bin/omarchy-terminal-open-link"
+open_actions="$ROOT/config/kitty/open-actions.conf"
+migration="$ROOT/migrations/1787852446.sh"
+
+[[ -f $helper ]] || fail "Super+left ships the terminal link helper"
+[[ -f $open_actions ]] || fail "Super+left ships the Kitty open-actions source"
+[[ -f $migration ]] || fail "Super+left ships the open-actions migration"
+pass "Super+left ships its helper, open-actions source, and migration"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# One case-insensitive rule claims exactly the local file URLs --
+# file:///path and file://localhost/path -- anchored so file:/ with one slash
+# or a host other than localhost matches nothing. Everything else keeps
+# kitty's default behavior, including web and remote URLs.
+(( $(grep -cxF 'url (?i:^file://(?:localhost)?/)' "$open_actions") == 1 )) ||
+  fail "open-actions claims exactly one anchored local file URL rule"
+[[ -z $(grep '^protocol ' "$open_actions" | grep -vxF 'protocol file') ]] ||
+  fail "open-actions leaves web and remote URLs to kitty"
+
+local_url_pattern=$(sed -n 's/^url //p' "$open_actions")
+for url in file:///tmp/a file://localhost/tmp/a FILE:///tmp/a file://LOCALHOST/tmp/a; do
+  grep -Pq "$local_url_pattern" <<<"$url" ||
+    fail "open-actions matches local file URLs case-insensitively" "$url"
+done
+for url in file:/tmp/a file://remote/tmp/a file://localhost.example/tmp/a https://example.com/file:///tmp/a; do
+  ! grep -Pq "$local_url_pattern" <<<"$url" ||
+    fail "open-actions rejects non-local URL forms" "$url"
+done
+pass "open-actions claims only local file URLs"
+
+# ${FILE_PATH} arrives percent-decoded, without query or fragment, as one
+# argument. xdg-open does not accept a -- separator, so there is none.
+(( $(grep -cxF 'action launch --type=background xdg-open ${FILE_PATH}' "$open_actions") == 1 )) ||
+  fail "open-actions opens local files with xdg-open in the background and a single path argument"
+grep -q -- 'xdg-open --' "$open_actions" &&
+  fail "open-actions never passes -- to xdg-open"
+pass "open-actions opens local files with xdg-open and a single path argument"
+
+# The migration brings existing installs along: copy the shipped rules next to
+# kitty.conf, and only when Kitty is configured and nothing custom would be
+# clobbered.
+migration_home="$TMPDIR/migration-home"
+mkdir -p "$migration_home/.config/kitty"
+cp "$ROOT/config/kitty/kitty.conf" "$migration_home/.config/kitty/kitty.conf"
+HOME="$migration_home" OMARCHY_PATH="$ROOT" bash "$migration" >/dev/null ||
+  fail "open-actions migration runs on an existing Kitty install"
+
+cmp -s "$open_actions" "$migration_home/.config/kitty/open-actions.conf" ||
+  fail "migration copies the shipped open-actions file verbatim"
+pass "migration copies the shipped open-actions file verbatim"
+
+before=$(find "$migration_home/.config" -type f -print0 | sort -z | xargs -0 sha256sum)
+HOME="$migration_home" OMARCHY_PATH="$ROOT" bash "$migration" >/dev/null ||
+  fail "open-actions migration runs a second time"
+after=$(find "$migration_home/.config" -type f -print0 | sort -z | xargs -0 sha256sum)
+
+[[ $before == "$after" ]] || fail "open-actions migration is idempotent"
+pass "open-actions migration is idempotent"
+
+custom_home="$TMPDIR/custom-home"
+mkdir -p "$custom_home/.config/kitty"
+cp "$ROOT/config/kitty/kitty.conf" "$custom_home/.config/kitty/kitty.conf"
+cat >"$custom_home/.config/kitty/open-actions.conf" <<'EOF'
+# Hand-written rules this user wants to keep
+protocol file
+url ^file://(localhost)?/
+action launch --type=background my-open ${FILE_PATH}
+EOF
+custom_rules="$TMPDIR/custom-rules"
+cp "$custom_home/.config/kitty/open-actions.conf" "$custom_rules"
+
+HOME="$custom_home" OMARCHY_PATH="$ROOT" bash "$migration" >/dev/null ||
+  fail "open-actions migration runs alongside a custom open-actions file"
+
+cmp -s "$custom_rules" "$custom_home/.config/kitty/open-actions.conf" ||
+  fail "migration leaves a custom open-actions file untouched"
+pass "migration leaves a custom open-actions file untouched"
+symlink_home="$TMPDIR/symlink-home"
+mkdir -p "$symlink_home/.config/kitty"
+cp "$ROOT/config/kitty/kitty.conf" "$symlink_home/.config/kitty/kitty.conf"
+dangling_target="$TMPDIR/missing-open-actions"
+ln -s "$dangling_target" "$symlink_home/.config/kitty/open-actions.conf"
+
+HOME="$symlink_home" OMARCHY_PATH="$ROOT" bash "$migration" >/dev/null ||
+  fail "open-actions migration runs alongside a dangling custom symlink"
+[[ -L $symlink_home/.config/kitty/open-actions.conf ]] ||
+  fail "migration preserves a dangling custom open-actions symlink"
+[[ $(readlink "$symlink_home/.config/kitty/open-actions.conf") == "$dangling_target" ]] ||
+  fail "migration leaves a dangling custom open-actions symlink unchanged"
+[[ ! -e $dangling_target ]] ||
+  fail "migration does not create the missing target of a custom symlink"
+pass "migration preserves dangling custom open-actions symlinks"
+
+bare_home="$TMPDIR/bare-home"
+mkdir -p "$bare_home/.config/kitty"
+HOME="$bare_home" OMARCHY_PATH="$ROOT" bash "$migration" >/dev/null ||
+  fail "open-actions migration runs without a kitty.conf"
+[[ ! -e $bare_home/.config/kitty/open-actions.conf ]] ||
+  fail "migration installs nothing without kitty.conf"
+pass "migration installs nothing without kitty.conf"
+
+empty_home="$TMPDIR/empty-home"
+mkdir -p "$empty_home"
+HOME="$empty_home" OMARCHY_PATH="$ROOT" bash "$migration" >/dev/null ||
+  fail "open-actions migration runs on a home without a config dir"
+[[ -z $(find "$empty_home" -type f) ]] ||
+  fail "migration leaves no files behind on a home without a config dir"
+pass "migration leaves no files behind on a home without a config dir"
+
+# The helper is what Super+left runs on a plain click. It must find the focused
+# Kitty window itself, so everything it asks is stubbed and logged: hyprctl
+# answers with a canned window, and kitten records its exact argv.
+runtime_dir="$TMPDIR/runtime"
+stub_bin="$TMPDIR/bin"
+mkdir -p "$runtime_dir" "$stub_bin"
+
+kitten_log="$TMPDIR/kitten-argv"
+hyprctl_log="$TMPDIR/hyprctl-argv"
+
+cat >"$stub_bin/kitten" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$@" >>"$KITTEN_ARGV_LOG"
+STUB
+chmod +x "$stub_bin/kitten"
+
+stub_activewindow() {
+  cat >"$stub_bin/hyprctl" <<STUB
+#!/bin/bash
+printf '%s\n' "\$@" >>"\$HYPRCTL_ARGV_LOG"
+printf '%s\n' '$1'
+exit ${2:-0}
+STUB
+  chmod +x "$stub_bin/hyprctl"
+}
+
+run_helper() {
+  KITTEN_ARGV_LOG="$kitten_log" HYPRCTL_ARGV_LOG="$hyprctl_log" \
+    XDG_RUNTIME_DIR="$runtime_dir" PATH="$stub_bin:$PATH" \
+    bash "$helper" 2>&1
+}
+
+# Every way the helper must refuse to click: no dispatch, no output, and still
+# a zero exit -- a failed click must never surface as an error.
+assert_never_dispatches() {
+  local description="$1" output
+
+  : >"$kitten_log"
+  output=$(run_helper) || fail "$description"
+  [[ -z $output ]] || fail "$description" "$output"
+  [[ ! -s $kitten_log ]] || fail "$description" "$(paste -sd' ' "$kitten_log")"
+  pass "$description"
+}
+
+stub_activewindow '{"class":"foot","pid":2718}'
+assert_never_dispatches "helper ignores an active window that is not Kitty"
+
+stub_activewindow '{"class":"kitty","pid":"not-a-number"}'
+assert_never_dispatches "helper rejects a pid that is not numeric"
+
+stub_activewindow '{"class":"kitty","title":"no pid field"}'
+assert_never_dispatches "helper rejects a window without a pid"
+
+stub_activewindow 'not json at all'
+assert_never_dispatches "helper fails closed on malformed activewindow output"
+
+# hyprctl prints "Invalid" and exits 1 when there is no active window.
+stub_activewindow 'Invalid' 1
+assert_never_dispatches "helper fails closed when no window is active"
+
+# A plain file squatting on the socket's name is not a socket.
+stub_activewindow '{"class":"kitty","pid":4711}'
+touch "$runtime_dir/omarchy-kitty-4711"
+assert_never_dispatches "helper requires a Unix socket, not just any file at the socket path"
+rm "$runtime_dir/omarchy-kitty-4711"
+
+# Everything below clicks through a real bound socket, and binding one is the
+# only thing a sandbox may deny; treat the fixture as optional rather than fail
+# there.
+socket_bound=1
+if command -v python3 >/dev/null; then
+  python3 -c 'import socket, sys; socket.socket(socket.AF_UNIX).bind(sys.argv[1])' \
+    "$runtime_dir/omarchy-kitty-31415" 2>/dev/null || socket_bound=0
+else
+  socket_bound=0
+fi
+
+if (( ! socket_bound )); then
+  pass "cannot bind a Unix socket here; skipping the cases that need one"
+  exit 0
+fi
+
+stub_activewindow '{"class":"kitty","pid":31415}'
+: >"$kitten_log"
+: >"$hyprctl_log"
+output=$(run_helper) || fail "helper succeeds on an active Kitty window with a live socket"
+[[ -z $output ]] || fail "helper is silent when it dispatches the click" "$output"
+
+[[ $(cat "$hyprctl_log") == $'activewindow\n-j' ]] ||
+  fail "helper asks hyprctl for the active window as JSON" "$(cat "$hyprctl_log")"
+
+expected_argv="$TMPDIR/expected-kitten-argv"
+printf '%s\n' @ --to "unix:$runtime_dir/omarchy-kitty-31415" \
+  action --no-response --match state:focused mouse_handle_click link >"$expected_argv"
+cmp -s "$expected_argv" "$kitten_log" ||
+  fail "helper clicks the focused window's link over its own socket" "$(paste -sd' ' "$kitten_log")"
+pass "helper clicks the link through the window's kitten socket"
+
+# The socket alone is not permission: with a live socket in place the class
+# still has to match exactly, or any window could click through a stray socket.
+stub_activewindow '{"class":"Kitty","pid":31415}'
+assert_never_dispatches "helper matches the Kitty class exactly even with a live socket"


### PR DESCRIPTION
## Summary

- split `Super + left mouse` into native click and drag gestures with an 8px threshold, preserving window movement
- ask the active Kitty instance to open the hyperlink beneath the pointer; non-Kitty and no-link clicks remain silent no-ops
- open local `file://` links through their query/fragment-free path, migrate existing Kitty installs without overwriting custom rules, and document the gesture

## Testing

- `test/shell.d/terminal-super-click-test.sh`
- `test/shell.d/hyprland-binding-conflicts-test.sh`
- `bash test/shell.d/hyprland-default-config-test.sh`
- Lua and shell syntax checks for changed executable/config files
- live Hyprland reload: both Super+left bindings active with `binds:drag_threshold = 8`
- isolated Kitty smoke test: web hyperlink dispatch preserved the URL; a `file:///...?...#...` hyperlink opened only the local path

`test/all` also ran. `test/cli` passed; `test/shell` reported six unrelated baseline/environment failures. Five reproduced on `origin/quattro`; the sixth baseline test hung after printing all of its assertions as passing.