### PR TITLE
Resolve mise wrapper binaries before execution

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -53,7 +53,8 @@ cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
 mise use -g --quiet $package_arg || exit 1
-exec mise x $package_arg -- $bin_arg "\$@"
+bin_path=\$(mise which $bin_arg --tool=$package_arg) || exit 1
+exec mise x $package_arg -- "\$bin_path" "\$@"
 EOF
 
 chmod +x "$HOME/.local/bin/$command"

--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -25,6 +25,11 @@ case "$command" in
     ;;
 esac
 
+if [[ $bin == */* || $bin == "." || $bin == ".." ]]; then
+  echo "omarchy-mise-install: bin-name must be a basename" >&2
+  exit 1
+fi
+
 mkdir -p "$HOME/.local/bin"
 
 # The heredoc below is unquoted, so whatever these hold is written into the
@@ -53,7 +58,20 @@ cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
 mise use -g --quiet $package_arg || exit 1
-bin_path=\$(mise which $bin_arg --tool=$package_arg) || exit 1
+bin_path=
+bin_paths=\$(mise bin-paths $package_arg) || exit 1
+while IFS= read -r bin_dir; do
+  [[ -n \$bin_dir ]] || continue
+  candidate="\$bin_dir"/$bin_arg
+  if [[ -f \$candidate && -x \$candidate ]]; then
+    bin_path=\$candidate
+    break
+  fi
+done <<<"\$bin_paths"
+if [[ -z \$bin_path ]]; then
+  printf "%s: mise package '%s' provides no executable '%s'\n" "\${0##*/}" $package_arg $bin_arg >&2
+  exit 1
+fi
 exec mise x $package_arg -- "\$bin_path" "\$@"
 EOF
 

--- a/migrations/1787809285.sh
+++ b/migrations/1787809285.sh
@@ -1,0 +1,30 @@
+echo "Regenerate mise wrappers to resolve their binaries before execution"
+
+# `mise x "$package" -- "$bin"` still resolves the bare bin through PATH.
+# When ~/.local/bin is ahead of mise's shims, that lookup finds the generated
+# wrapper itself and execs it forever. Regenerate wrappers on the current
+# template so they pass mise x the package-scoped absolute path instead.
+
+current_template() {
+  local package=$1 bin=$2
+
+  printf '#!/bin/bash\nexport MISE_MINIMUM_RELEASE_AGE=0\nmise use -g --quiet "%s" || exit 1\nexec mise x "%s" -- "%s" "$@"' "$package" "$package" "$bin"
+}
+
+bin_dir="$HOME/.local/bin"
+
+[[ -d $bin_dir ]] || exit 0
+
+for wrapper in "$bin_dir"/*; do
+  [[ -f $wrapper && ! -L $wrapper && -r $wrapper ]] || continue
+  (($(stat -c%s "$wrapper") <= 1024)) || continue
+
+  contents=$(<"$wrapper")
+  package=$(sed -n 's/^mise use -g --quiet "\(.*\)" || exit 1$/\1/p' <<<"$contents")
+  bin=$(sed -n 's/^exec mise x ".*" -- "\(.*\)" "\$@"$/\1/p' <<<"$contents")
+
+  [[ -n $package && -n $bin ]] || continue
+  [[ $contents == "$(current_template "$package" "$bin")" ]] || continue
+
+  omarchy-mise-install "$package" "${wrapper##*/}" "$bin"
+done

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -20,7 +20,8 @@ stub_log="$test_tmp/stubs"
 terminal_log="$test_tmp/terminal"
 menu_log="$test_tmp/menu"
 muse_login_log="$test_tmp/muse-login"
-mkdir -p "$mock_bin" "$test_home"
+resolved_dir="$test_tmp/resolved"
+mkdir -p "$mock_bin" "$test_home" "$resolved_dir"
 
 cat >"$mock_bin/omarchy-notification-send" <<'SH'
 #!/bin/bash
@@ -62,8 +63,8 @@ if [[ $1 == "where" ]]; then
   exit
 fi
 
-if [[ $1 == "which" ]]; then
-  printf '/resolved/%s\n' "$2"
+if [[ $1 == "bin-paths" ]]; then
+  printf '%s\n' "$OMARCHY_TEST_RESOLVED_DIR"
   exit
 fi
 
@@ -114,6 +115,7 @@ export OMARCHY_TEST_STUB_LOG="$stub_log"
 export OMARCHY_TEST_AGENT_TERMINAL_LOG="$terminal_log"
 export OMARCHY_TEST_AGENT_MENU_LOG="$menu_log"
 export OMARCHY_TEST_MUSE_LOGIN_LOG="$muse_login_log"
+export OMARCHY_TEST_RESOLVED_DIR="$resolved_dir"
 export OMARCHY_PATH="$ROOT"
 
 grok_package="npm:@xai-official/grok"
@@ -128,14 +130,16 @@ assert_lazy_stub() {
   local package=$1
   local command=$2
 
+  printf '#!/bin/bash\nexit 0\n' >"$resolved_dir/$command"
+  chmod +x "$resolved_dir/$command"
   : >"$mise_history"
   "$ROOT/bin/omarchy-mise-install" "$package" "$command"
   "$test_home/.local/bin/$command" --version
   mapfile -t mise_calls <"$mise_history"
 
   [[ ${mise_calls[0]} == "use -g --quiet $package" &&
-    ${mise_calls[1]} == "which $command --tool=$package" &&
-    ${mise_calls[2]} == "x $package -- /resolved/$command --version" ]] ||
+    ${mise_calls[1]} == "bin-paths $package" &&
+    ${mise_calls[2]} == "x $package -- $resolved_dir/$command --version" ]] ||
     fail "$command lazy stub preserves its mise package"
 }
 

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -62,6 +62,11 @@ if [[ $1 == "where" ]]; then
   exit
 fi
 
+if [[ $1 == "which" ]]; then
+  printf '/resolved/%s\n' "$2"
+  exit
+fi
+
 [[ ${OMARCHY_TEST_MISE_FAIL:-false} != "true" ]]
 SH
 
@@ -128,7 +133,9 @@ assert_lazy_stub() {
   "$test_home/.local/bin/$command" --version
   mapfile -t mise_calls <"$mise_history"
 
-  [[ ${mise_calls[0]} == "use -g --quiet $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
+  [[ ${mise_calls[0]} == "use -g --quiet $package" &&
+    ${mise_calls[1]} == "which $command --tool=$package" &&
+    ${mise_calls[2]} == "x $package -- /resolved/$command --version" ]] ||
     fail "$command lazy stub preserves its mise package"
 }
 

--- a/test/shell.d/mise-install-test.sh
+++ b/test/shell.d/mise-install-test.sh
@@ -9,7 +9,8 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 home="$tmpdir/home"
 stub_bin="$tmpdir/bin"
-mkdir -p "$home" "$stub_bin"
+resolved_bin="$tmpdir/resolved"
+mkdir -p "$home" "$stub_bin" "$resolved_bin"
 
 # Stands in for the real mise so a generated wrapper can be run and asked what
 # arguments it passed on.
@@ -21,8 +22,15 @@ for arg in "$@"; do
   printf '\t%s' "$arg" >>"$OMARCHY_MISE_TEST_LOG"
 done
 printf '\n' >>"$OMARCHY_MISE_TEST_LOG"
+
+if [[ $1 == "bin-paths" ]]; then
+  printf '%s\n' "$OMARCHY_MISE_TEST_BIN_DIR"
+fi
 SH
-chmod +x "$stub_bin/mise"
+printf '#!/bin/bash\nexit 0\n' >"$resolved_bin/playwright"
+printf '#!/bin/bash\nexit 0\n' >"$resolved_bin/hostile"
+chmod +x "$stub_bin/mise" "$resolved_bin/playwright" "$resolved_bin/hostile"
+export OMARCHY_MISE_TEST_BIN_DIR="$resolved_bin"
 
 install_wrapper() {
   HOME="$home" "$ROOT/bin/omarchy-mise-install" "$@"

--- a/test/shell.d/mise-wrapper-quiet-migration-test.sh
+++ b/test/shell.d/mise-wrapper-quiet-migration-test.sh
@@ -71,11 +71,11 @@ pass "migration adds --quiet to a stale wrapper"
 
 grep -qF 'mise use -g --quiet "github:can1357/oh-my-pi" || exit 1' "$bin_dir/omp" ||
   fail "migration keeps a wrapper's package when the command name differs"
-grep -qF 'exec mise x "github:can1357/oh-my-pi" -- "omp" "$@"' "$bin_dir/omp" ||
+grep -qF 'bin_path=$(mise which "omp" --tool="github:can1357/oh-my-pi") || exit 1' "$bin_dir/omp" ||
   fail "migration keeps a wrapper's bin name when the command name differs"
 pass "migration preserves package and bin names"
 
-grep -qF 'exec mise x "npm:@kitlangton/ghui" -- "ghui" "$@"' "$bin_dir/ghui" ||
+grep -qF 'bin_path=$(mise which "ghui" --tool="npm:@kitlangton/ghui") || exit 1' "$bin_dir/ghui" ||
   fail "migration preserves a scoped npm package name"
 pass "migration preserves a scoped npm package name"
 
@@ -87,18 +87,18 @@ pass "migration rewrites wrappers on the pre-export template"
 
 grep -qF 'mise use -g --quiet "npm:some/tool" || exit 1' "$bin_dir/mise-exec-era" ||
   fail "migration rewrites a wrapper on the mise-exec template"
-grep -qF 'exec mise x "npm:some/tool" -- "tool-bin" "$@"' "$bin_dir/mise-exec-era" ||
+grep -qF 'bin_path=$(mise which "tool-bin" --tool="npm:some/tool") || exit 1' "$bin_dir/mise-exec-era" ||
   fail "migration keeps the bin name from a mise-exec wrapper"
 grep -qF 'mise use -g --quiet "aqua:some/other" || exit 1' "$bin_dir/bare-exec-era" ||
   fail "migration rewrites a wrapper on the bare-exec template"
-grep -qF 'exec mise x "aqua:some/other" -- "other-bin" "$@"' "$bin_dir/bare-exec-era" ||
+grep -qF 'bin_path=$(mise which "other-bin" --tool="aqua:some/other") || exit 1' "$bin_dir/bare-exec-era" ||
   fail "migration keeps the bin name from a bare-exec wrapper"
 pass "migration rewrites every generated form that predates --quiet"
 
 [[ -x $bin_dir/claude ]] || fail "migration leaves the rewritten wrapper executable"
 pass "migration leaves the rewritten wrapper executable"
 
-# Running twice must not touch an already-quiet wrapper.
+# Running twice must not touch a wrapper already on the current template.
 before=$(cat "$bin_dir/claude")
 run_migration
 [[ $(cat "$bin_dir/claude") == "$before" ]] || fail "migration is idempotent"

--- a/test/shell.d/mise-wrapper-quiet-migration-test.sh
+++ b/test/shell.d/mise-wrapper-quiet-migration-test.sh
@@ -71,11 +71,11 @@ pass "migration adds --quiet to a stale wrapper"
 
 grep -qF 'mise use -g --quiet "github:can1357/oh-my-pi" || exit 1' "$bin_dir/omp" ||
   fail "migration keeps a wrapper's package when the command name differs"
-grep -qF 'bin_path=$(mise which "omp" --tool="github:can1357/oh-my-pi") || exit 1' "$bin_dir/omp" ||
+grep -qF 'candidate="$bin_dir"/"omp"' "$bin_dir/omp" ||
   fail "migration keeps a wrapper's bin name when the command name differs"
 pass "migration preserves package and bin names"
 
-grep -qF 'bin_path=$(mise which "ghui" --tool="npm:@kitlangton/ghui") || exit 1' "$bin_dir/ghui" ||
+grep -qF 'bin_paths=$(mise bin-paths "npm:@kitlangton/ghui")' "$bin_dir/ghui" ||
   fail "migration preserves a scoped npm package name"
 pass "migration preserves a scoped npm package name"
 
@@ -87,11 +87,11 @@ pass "migration rewrites wrappers on the pre-export template"
 
 grep -qF 'mise use -g --quiet "npm:some/tool" || exit 1' "$bin_dir/mise-exec-era" ||
   fail "migration rewrites a wrapper on the mise-exec template"
-grep -qF 'bin_path=$(mise which "tool-bin" --tool="npm:some/tool") || exit 1' "$bin_dir/mise-exec-era" ||
+grep -qF 'candidate="$bin_dir"/"tool-bin"' "$bin_dir/mise-exec-era" ||
   fail "migration keeps the bin name from a mise-exec wrapper"
 grep -qF 'mise use -g --quiet "aqua:some/other" || exit 1' "$bin_dir/bare-exec-era" ||
   fail "migration rewrites a wrapper on the bare-exec template"
-grep -qF 'bin_path=$(mise which "other-bin" --tool="aqua:some/other") || exit 1' "$bin_dir/bare-exec-era" ||
+grep -qF 'candidate="$bin_dir"/"other-bin"' "$bin_dir/bare-exec-era" ||
   fail "migration keeps the bin name from a bare-exec wrapper"
 pass "migration rewrites every generated form that predates --quiet"
 

--- a/test/shell.d/mise-wrapper-resolution-test.sh
+++ b/test/shell.d/mise-wrapper-resolution-test.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787809285.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+bin_dir="$home/.local/bin"
+stub_bin="$test_dir/bin"
+resolved_bin="$test_dir/resolved"
+mise_log="$test_dir/mise.log"
+tool_log="$test_dir/tool.log"
+mkdir -p "$bin_dir" "$stub_bin" "$resolved_bin"
+
+cat >"$stub_bin/mise" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$MISE_TEST_LOG"
+
+case "$1" in
+  use)
+    exit 0
+    ;;
+  which)
+    if (( ${MISE_TEST_WHICH_FAIL:-0} )); then
+      exit 1
+    fi
+    printf '%s\n' "$MISE_TEST_RESOLVED_BIN"
+    ;;
+  x)
+    shift 2
+    [[ $1 == "--" ]] || exit 2
+    shift
+    [[ $1 == "$MISE_TEST_RESOLVED_BIN" ]] || exit 3
+    export MISE_TEST_RUNTIME=present
+    exec "$@"
+    ;;
+  *)
+    exit 4
+    ;;
+esac
+SH
+
+cat >"$resolved_bin/ghui" <<'SH'
+#!/bin/bash
+printf '%s\0' "$MISE_TEST_RUNTIME" "$@" >"$MISE_TEST_TOOL_LOG"
+SH
+chmod +x "$stub_bin/mise" "$resolved_bin/ghui"
+
+export MISE_TEST_LOG="$mise_log"
+export MISE_TEST_RESOLVED_BIN="$resolved_bin/ghui"
+export MISE_TEST_TOOL_LOG="$tool_log"
+
+HOME="$home" "$ROOT/bin/omarchy-mise-install" npm:@kitlangton/ghui ghui
+PATH="$bin_dir:$stub_bin:/usr/bin" "$bin_dir/ghui" first "two words"
+
+grep -qx 'use -g --quiet npm:@kitlangton/ghui' "$mise_log" ||
+  fail "wrapper activates its mise package quietly"
+grep -qx 'which ghui --tool=npm:@kitlangton/ghui' "$mise_log" ||
+  fail "wrapper resolves the bin from its package"
+grep -qx "x npm:@kitlangton/ghui -- $resolved_bin/ghui first two words" "$mise_log" ||
+  fail "wrapper gives mise x the resolved path"
+mapfile -d '' -t tool_args <"$tool_log"
+[[ ${tool_args[0]} == "present" && ${tool_args[1]} == "first" && ${tool_args[2]} == "two words" ]] ||
+  fail "wrapper retains mise's runtime environment and argument boundaries"
+pass "wrapper executes a package-scoped absolute path through mise"
+
+: >"$mise_log"
+if MISE_TEST_WHICH_FAIL=1 PATH="$bin_dir:$stub_bin:/usr/bin" "$bin_dir/ghui" >/dev/null 2>&1; then
+  fail "wrapper exits when mise cannot resolve the requested bin"
+fi
+if grep -q '^x ' "$mise_log"; then
+  fail "wrapper does not invoke mise x after resolution fails"
+fi
+pass "wrapper stops when its bin cannot be resolved"
+
+cat >"$bin_dir/codex" <<'SH'
+#!/bin/bash
+export MISE_MINIMUM_RELEASE_AGE=0
+mise use -g --quiet "codex" || exit 1
+exec mise x "codex" -- "codex" "$@"
+SH
+chmod +x "$bin_dir/codex"
+
+cat >"$bin_dir/customized" <<'SH'
+#!/bin/bash
+export MISE_MINIMUM_RELEASE_AGE=0
+export CUSTOMIZED=1
+mise use -g --quiet "customized" || exit 1
+exec mise x "customized" -- "customized" "$@"
+SH
+chmod +x "$bin_dir/customized"
+customized_before=$(<"$bin_dir/customized")
+
+run_migration() {
+  HOME="$home" PATH="$ROOT/bin:$stub_bin:/usr/bin" bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration
+
+grep -qF 'bin_path=$(mise which "codex" --tool="codex") || exit 1' "$bin_dir/codex" ||
+  fail "migration regenerates a current mise wrapper with resolved execution"
+grep -qF 'exec mise x "codex" -- "$bin_path" "$@"' "$bin_dir/codex" ||
+  fail "migrated wrapper passes the resolved path to mise x"
+[[ $(<"$bin_dir/customized") == "$customized_before" ]] ||
+  fail "migration leaves a customized wrapper alone"
+pass "migration only regenerates the exact current wrapper template"
+
+before=$(<"$bin_dir/codex")
+run_migration
+[[ $(<"$bin_dir/codex") == "$before" ]] || fail "migration is idempotent"
+pass "migration is idempotent"
+
+empty_home="$test_dir/empty-home"
+mkdir -p "$empty_home"
+HOME="$empty_home" PATH="$ROOT/bin:$stub_bin:/usr/bin" bash -euo pipefail "$migration" >/dev/null ||
+  fail "migration succeeds when ~/.local/bin is missing"
+pass "migration succeeds when ~/.local/bin is missing"

--- a/test/shell.d/mise-wrapper-resolution-test.sh
+++ b/test/shell.d/mise-wrapper-resolution-test.sh
@@ -71,17 +71,6 @@ export MISE_TEST_DIRECTORY_BIN="$directory_bin"
 export MISE_TEST_WRONG_BIN="$wrong_bin/pi"
 export MISE_TEST_TOOL_LOG="$tool_log"
 
-mkdir -p "$home/.local"
-printf 'keep\n' >"$home/.local/sentinel"
-for bad_command in ../sentinel . ..; do
-  if HOME="$home" "$ROOT/bin/omarchy-mise-install" pi "$bad_command" pi >/dev/null 2>&1; then
-    fail "wrapper generator rejects unsafe command name $bad_command"
-  fi
-done
-[[ $(<"$home/.local/sentinel") == keep ]] ||
-  fail "wrapper generator does not overwrite a path escaped through command-name"
-pass "wrapper generator rejects unsafe command names"
-
 for bad_bin in ../wrong-bin/pi /tmp/pi . ..; do
   if HOME="$home" "$ROOT/bin/omarchy-mise-install" pi escaped "$bad_bin" >/dev/null 2>&1; then
     fail "wrapper generator rejects unsafe bin name $bad_bin"

--- a/test/shell.d/mise-wrapper-resolution-test.sh
+++ b/test/shell.d/mise-wrapper-resolution-test.sh
@@ -11,10 +11,12 @@ trap 'rm -rf "$test_dir"' EXIT
 home="$test_dir/home"
 bin_dir="$home/.local/bin"
 stub_bin="$test_dir/bin"
-resolved_bin="$test_dir/resolved"
+package_bin="$test_dir/package-bin"
+directory_bin="$test_dir/directory-bin"
+wrong_bin="$test_dir/wrong-bin"
 mise_log="$test_dir/mise.log"
 tool_log="$test_dir/tool.log"
-mkdir -p "$bin_dir" "$stub_bin" "$resolved_bin"
+mkdir -p "$bin_dir" "$stub_bin" "$package_bin" "$directory_bin/pi" "$wrong_bin"
 
 cat >"$stub_bin/mise" <<'SH'
 #!/bin/bash
@@ -26,16 +28,22 @@ case "$1" in
     exit 0
     ;;
   which)
-    if (( ${MISE_TEST_WHICH_FAIL:-0} )); then
-      exit 1
+    printf '%s\n' "$MISE_TEST_WRONG_BIN"
+    ;;
+  bin-paths)
+    if (( ${MISE_TEST_BIN_PATHS_FAIL_AFTER_OUTPUT:-0} )); then
+      printf '%s\n' "$MISE_TEST_PACKAGE_BIN"
+      exit 42
     fi
-    printf '%s\n' "$MISE_TEST_RESOLVED_BIN"
+    if (( ${MISE_TEST_BIN_PATHS_EMPTY:-0} )); then
+      exit 0
+    fi
+    printf '%s\n' "$MISE_TEST_DIRECTORY_BIN" "$MISE_TEST_PACKAGE_BIN"
     ;;
   x)
     shift 2
     [[ $1 == "--" ]] || exit 2
     shift
-    [[ $1 == "$MISE_TEST_RESOLVED_BIN" ]] || exit 3
     export MISE_TEST_RUNTIME=present
     exec "$@"
     ;;
@@ -45,34 +53,84 @@ case "$1" in
 esac
 SH
 
-cat >"$resolved_bin/ghui" <<'SH'
+cat >"$package_bin/pi" <<'SH'
 #!/bin/bash
 printf '%s\0' "$MISE_TEST_RUNTIME" "$@" >"$MISE_TEST_TOOL_LOG"
 SH
-chmod +x "$stub_bin/mise" "$resolved_bin/ghui"
+# A Node runtime may also provide `pi`; `mise which pi --tool=pi` can select it.
+# The wrapper must stay inside the dedicated Pi package's bin paths instead.
+cat >"$wrong_bin/pi" <<'SH'
+#!/bin/bash
+printf 'wrong-package\0' >"$MISE_TEST_TOOL_LOG"
+SH
+chmod +x "$stub_bin/mise" "$package_bin/pi" "$wrong_bin/pi"
 
 export MISE_TEST_LOG="$mise_log"
-export MISE_TEST_RESOLVED_BIN="$resolved_bin/ghui"
+export MISE_TEST_PACKAGE_BIN="$package_bin"
+export MISE_TEST_DIRECTORY_BIN="$directory_bin"
+export MISE_TEST_WRONG_BIN="$wrong_bin/pi"
 export MISE_TEST_TOOL_LOG="$tool_log"
 
-HOME="$home" "$ROOT/bin/omarchy-mise-install" npm:@kitlangton/ghui ghui
-PATH="$bin_dir:$stub_bin:/usr/bin" "$bin_dir/ghui" first "two words"
+mkdir -p "$home/.local"
+printf 'keep\n' >"$home/.local/sentinel"
+for bad_command in ../sentinel . ..; do
+  if HOME="$home" "$ROOT/bin/omarchy-mise-install" pi "$bad_command" pi >/dev/null 2>&1; then
+    fail "wrapper generator rejects unsafe command name $bad_command"
+  fi
+done
+[[ $(<"$home/.local/sentinel") == keep ]] ||
+  fail "wrapper generator does not overwrite a path escaped through command-name"
+pass "wrapper generator rejects unsafe command names"
 
-grep -qx 'use -g --quiet npm:@kitlangton/ghui' "$mise_log" ||
+for bad_bin in ../wrong-bin/pi /tmp/pi . ..; do
+  if HOME="$home" "$ROOT/bin/omarchy-mise-install" pi escaped "$bad_bin" >/dev/null 2>&1; then
+    fail "wrapper generator rejects unsafe bin name $bad_bin"
+  fi
+done
+[[ ! -e $bin_dir/escaped ]] ||
+  fail "wrapper generator does not write a wrapper for an escaping bin name"
+pass "wrapper generator rejects escaping bin names"
+
+hostile_bin='pi$(touch${IFS}BIN_PWNED)'
+HOME="$home" "$ROOT/bin/omarchy-mise-install" pi hostile "$hostile_bin"
+(cd "$test_dir" && MISE_TEST_BIN_PATHS_EMPTY=1 PATH="$bin_dir:$stub_bin:/usr/bin" "$bin_dir/hostile" >/dev/null 2>&1) || true
+[[ ! -e $test_dir/BIN_PWNED ]] ||
+  fail "wrapper treats shell characters in a bin name as code"
+pass "wrapper treats shell characters in a bin name as data"
+
+HOME="$home" "$ROOT/bin/omarchy-mise-install" pi
+grep -qF '[[ -n $bin_dir ]] || continue' "$bin_dir/pi" ||
+  fail "wrapper skips empty package bin-directory entries"
+PATH="$bin_dir:$stub_bin:/usr/bin" "$bin_dir/pi" first "two words"
+
+grep -qx 'use -g --quiet pi' "$mise_log" ||
   fail "wrapper activates its mise package quietly"
-grep -qx 'which ghui --tool=npm:@kitlangton/ghui' "$mise_log" ||
-  fail "wrapper resolves the bin from its package"
-grep -qx "x npm:@kitlangton/ghui -- $resolved_bin/ghui first two words" "$mise_log" ||
-  fail "wrapper gives mise x the resolved path"
+grep -qx 'bin-paths pi' "$mise_log" ||
+  fail "wrapper asks mise for the requested package's bin directories"
+grep -qx "x pi -- $package_bin/pi first two words" "$mise_log" ||
+  fail "wrapper gives mise x the package-scoped absolute path"
 mapfile -d '' -t tool_args <"$tool_log"
 [[ ${tool_args[0]} == "present" && ${tool_args[1]} == "first" && ${tool_args[2]} == "two words" ]] ||
-  fail "wrapper retains mise's runtime environment and argument boundaries"
-pass "wrapper executes a package-scoped absolute path through mise"
+  fail "wrapper executes the requested package's bin with its runtime environment and argument boundaries"
+pass "wrapper ignores a same-named executable from another package"
 
 : >"$mise_log"
-if MISE_TEST_WHICH_FAIL=1 PATH="$bin_dir:$stub_bin:/usr/bin" "$bin_dir/ghui" >/dev/null 2>&1; then
+if MISE_TEST_BIN_PATHS_FAIL_AFTER_OUTPUT=1 PATH="$bin_dir:$stub_bin:/usr/bin" "$bin_dir/pi" >/dev/null 2>&1; then
+  fail "wrapper exits when mise bin-paths fails after writing output"
+fi
+if grep -q '^x ' "$mise_log"; then
+  fail "wrapper does not invoke mise x after bin-paths fails"
+fi
+pass "wrapper stops when mise bin-paths fails after writing output"
+
+: >"$mise_log"
+error_log="$test_dir/error"
+if MISE_TEST_BIN_PATHS_EMPTY=1 PATH="$bin_dir:$stub_bin:/usr/bin" "$bin_dir/pi" >/dev/null 2>"$error_log"; then
   fail "wrapper exits when mise cannot resolve the requested bin"
 fi
+grep -qx "pi: mise package 'pi' provides no executable 'pi'" "$error_log" ||
+  fail "wrapper explains when its bin cannot be resolved"
+pass "wrapper explains when its bin cannot be resolved"
 if grep -q '^x ' "$mise_log"; then
   fail "wrapper does not invoke mise x after resolution fails"
 fi
@@ -102,7 +160,7 @@ run_migration() {
 
 run_migration
 
-grep -qF 'bin_path=$(mise which "codex" --tool="codex") || exit 1' "$bin_dir/codex" ||
+grep -qF 'bin_paths=$(mise bin-paths "codex")' "$bin_dir/codex" ||
   fail "migration regenerates a current mise wrapper with resolved execution"
 grep -qF 'exec mise x "codex" -- "$bin_path" "$@"' "$bin_dir/codex" ||
   fail "migrated wrapper passes the resolved path to mise x"


### PR DESCRIPTION
Fixes #7360.
Fixes #7234.

## Problem

When `~/.local/bin` comes before mise's binaries in `PATH`, a generated wrapper can execute itself through `mise x` and hang forever.

## Fix

The wrapper first activates the requested package:

```bash
mise use -g --quiet "$package" || exit 1
```

A straightforward way to resolve the command would be:

```bash
bin_path=$(mise which "$bin" --tool="$package") || exit 1
```

Here, `--tool="$package"` tells mise which tool/version to use while resolving `"$bin"`. It does not guarantee that the returned executable comes from that package's own install directory. Another active package can provide the same executable name.

The wrapper therefore asks for the requested package's runtime directories and searches them directly:

```bash
bin_paths=$(mise bin-paths "$package") || exit 1
```

It passes the first matching absolute path to `mise x` and reports an error when no match exists. Keeping `mise x` supplies the Node environment that npm-backed tools need.

Migration `1787809285.sh` regenerates wrappers matching the vulnerable template. It preserves custom wrappers and symlinks and leaves repaired wrappers alone.

## Testing

All tests in `./test/all` pass: CLI and all 237 shell test files.

The new regression coverage verifies that:

- `mise bin-paths "$package"` stays within the requested package;
- a same-named executable from another package is rejected;
- package runtime variables and argument boundaries survive `mise x`;
- shell metacharacters in bin names remain literal, and bin names containing paths are rejected;
- missing or failing `bin-paths` stops before execution;
- migration remains safe and idempotent.


Written with Codex and reviewed by a human.



