### PR TITLE
Document the community Local AI plugin

### DIFF
--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -49,6 +49,15 @@ The _Install > AI_ menu also carries a couple of graphical AI apps: the ChatGPT 
 
 Omarchy recommends two ways of running local LLM models: LM Studio and Ollama. LM Studio provides a GUI interface for finding open-weight models, installing them, and running them. It's a great way to get going easily. Ollama offers a CLI for doing so similarly. But if you're new to local models, I'd start with LM Studio. You can install either under _Install > AI_ in the Omarchy Menu.
 
+For a native bar panel that connects local models directly to Pi or OMP, install the community [Local AI plugin](https://github.com/0xSero/local-ai-mono). It detects local GPUs and reads validated launch recipes from the linked [Local AI registry](https://github.com/0xSero/local-ai-registry), rather than carrying a second model catalog:
+
+```bash
+omarchy plugin add https://github.com/0xSero/local-ai-mono.git
+omarchy plugin enable sero.local-ai
+```
+
+The plugin adds no Omarchy packages or background daemon. Its repository includes a [screenshot](https://github.com/0xSero/local-ai-mono/blob/main/media/dashboard.png) and [verified lifecycle demo](https://github.com/0xSero/local-ai-mono/blob/main/media/demo.mp4). Read its README and the diff shown by `omarchy plugin add` before enabling it; third-party plugins run as unsandboxed user code inside the Omarchy shell.
+
 ### The Omarchy Skill
 
 Agent skills help AI use specific tools in a specific way, and Omarchy ships with a default skill for tailoring the system. Like tweaking your Hyprland config, adjusting the bar, or even creating a new theme from scratch. It's symlinked into the skill directories for Claude Code (`~/.claude/skills`), Codex (`~/.codex/skills`), Pi (`~/.pi/agent/skills`), Antigravity (`~/.gemini/config/skills`), and the generic `~/.agents/skills` location, so most harnesses pick it up automatically.


### PR DESCRIPTION
## Summary

- document the community Local AI bar plugin under Local LLMs
- link its registry-driven implementation, screenshot, and verified lifecycle video
- keep Omarchy core unchanged beyond nine documentation lines

## Decisions

The plugin stays in its own repository so Omarchy does not vendor a second model catalog or add packages, services, runtimes, or a build step. The UI reads the linked registry, detects hardware locally, and uses Omarchy’s existing plugin lifecycle. The documentation also preserves the existing unsandboxed-plugin review warning.

## Verification

- plugin controller, manifest, QML, and tests: exactly 1,000 physical lines
- deterministic suite: 22/22 passing
- live host: 4 GPUs and 1,043 registry recipes detected
- live Qwen3.6 model: API identity, chat completion, shell tool call, Pi integration, and unload verified
- final live state: idle with zero plugin-owned containers