### PR TITLE
Cap screensaver frame rate at the panel refresh rate

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -33,11 +33,37 @@ wait_for_terminal_resize() {
   done
 }
 
+# ttfx paints as fast as it is asked to, and the screensaver runs precisely when
+# the machine is idle and most likely on battery. Frames beyond what the panel
+# can show are drawn and then discarded -- on a 60 Hz laptop that is half of a
+# 120 fps animation, spent keeping the CPU and GPU awake for nothing. Follow the
+# refresh rate, and never ask for more than the fixed rate this replaces.
+screensaver_frame_rate() {
+  local refresh
+
+  refresh=$(hyprctl monitors -j 2>/dev/null | jq -r '[.[] | select(.focused)][0].refreshRate // empty' 2>/dev/null)
+  [[ $refresh =~ ^[0-9]+(\.[0-9]+)?$ ]] || refresh=""
+
+  if [[ -n $refresh ]]; then
+    refresh=$(printf '%.0f' "$refresh")
+  else
+    refresh=60
+  fi
+
+  if (( refresh < 120 )); then
+    echo "$refresh"
+  else
+    echo 120
+  fi
+}
+
 wait_for_terminal_resize
+
+frame_rate=$(screensaver_frame_rate)
 
 while true; do
   ttfx -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
+    --frame-rate "$frame_rate" --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
     --random-effect --no-eol --no-restore-cursor &
 
   while pgrep -t "${tty#/dev/}" -x ttfx >/dev/null; do


### PR DESCRIPTION
## Problem

`omarchy-screensaver` renders at a fixed `--frame-rate 120`. On a 60 Hz laptop panel that draws every second frame only to discard it — and it does so precisely when the machine is idle and unattended, which on a laptop usually means on battery.

By default the screensaver starts 150s after idle (`config/omarchy/shell.json` → `idle.screensaver`), so this is the steady state of an idle machine, not a rare path.

## Measurements

`ttfx` alone, fixed `matrix` effect, 200x50 pty, output discarded (Dell Latitude 7420, i7-1185G7):

| frame-rate | CPU |
| --- | --- |
| 120 | 14% of a core |
| 60 | 5% |
| 30 | 1% |

That is only the animation process. In the real screensaver its output also drives a fullscreen terminal render and compositing, both additive and not captured above.

## Change

Follow the focused monitor's refresh rate instead of a fixed 120, clamped to 120 so no high-refresh setup asks for more than it does today, and falling back to 60 when the rate cannot be read.

The repo already uses `--frame-rate 60` in `bin/omarchy-provision-owner`, so this also lines the two up.

## Testing

`./test/cli` passes. The rate helper was checked against `60.00200`, `59.951`, `144.0`, `165`, `119.998`, `120.0`, empty, `null`, and non-numeric input; it yields 60 on this 60 Hz panel and never exceeds 120.

Not verified in the running UI — happy to do that, or to swap the monitor probe for a plain `60` if you'd rather not spend a `hyprctl` call at screensaver start.
