### PR TITLE
Wait on the menu done file instead of polling for it

### DIFF
--- a/bin/omarchy-menu-await-done
+++ b/bin/omarchy-menu-await-done
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# omarchy:summary=Block until the shell signals a menu request is complete
+# omarchy:group=menu
+# omarchy:hidden=true
+# omarchy:args=<done-file>
+
+set -euo pipefail
+
+done_file="${1:-}"
+
+if [[ -z $done_file ]]; then
+  echo "Usage: omarchy-menu-await-done <done-file>" >&2
+  exit 1
+fi
+
+# A menu stays open for as long as the reader takes to choose, so this wait has
+# no bound: a menu opened and left alone waits all day. Polling spends that
+# whole time waking the CPU several times a second out of its idle states, for
+# an answer that arrives exactly once. Block on the event instead.
+#
+# The watch is on the directory rather than the file because inotify cannot
+# watch a file that does not exist yet, and it starts before the first existence
+# test so a file created in the window between the two is caught by the watch
+# rather than missed by both.
+watch_dir=${done_file%/*}
+[[ $watch_dir == "$done_file" ]] && watch_dir="."
+done_name=${done_file##*/}
+
+exec {watch_fd}< <(inotifywait -q -m -e create,moved_to --format "%f" "$watch_dir")
+watch_pid=$!
+trap 'kill "$watch_pid" 2>/dev/null || true' EXIT
+
+# A watch that ends before the file appears leaves nothing else to wait for, so
+# give up rather than block forever. Return success either way: every caller
+# already reads an absent or empty selection as the cancellation it is, and
+# they run under `set -e`, where a failure here would exit before they could.
+while [[ ! -e $done_file ]]; do
+  if read -r -u "$watch_fd" created; then
+    [[ $created == "$done_name" ]] || continue
+  else
+    break
+  fi
+done
+
+exit 0

--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -298,9 +298,7 @@ if [[ $open_result != "ok" ]]; then
   exit 1
 fi
 
-while [[ ! -e $done_file ]]; do
-  sleep 0.01
-done
+omarchy-menu-await-done "$done_file"
 
 if [[ -s $selection_file ]]; then
   if [[ $print_name == true ]]; then

--- a/bin/omarchy-menu-input
+++ b/bin/omarchy-menu-input
@@ -47,9 +47,7 @@ payload=$(perl -MEncode=decode -MJSON::PP=encode_json -e '
 
 omarchy-shell shell summon omarchy.menu "$payload" >/dev/null
 
-while [[ ! -e $done_file ]]; do
-  sleep 0.05
-done
+omarchy-menu-await-done "$done_file"
 
 if [[ -s $selection_file ]]; then
   cat "$selection_file"

--- a/bin/omarchy-menu-select
+++ b/bin/omarchy-menu-select
@@ -88,9 +88,7 @@ payload=$(perl -MEncode=decode -MJSON::PP=encode_json,decode_json -e '
 
 omarchy-shell shell summon omarchy.menu "$payload" >/dev/null
 
-while [[ ! -e $done_file ]]; do
-  sleep 0.05
-done
+omarchy-menu-await-done "$done_file"
 
 if [[ -s $selection_file ]]; then
   cat "$selection_file"


### PR DESCRIPTION
## Problem

`omarchy-menu-select`, `omarchy-menu-input` and `omarchy-menu-images` each spin on the shell's done file:

```bash
while [[ ! -e $done_file ]]; do
  sleep 0.05   # 0.01 in omarchy-menu-images
done
```

The wait is unbounded — it lasts as long as the reader takes to choose. A menu opened and left alone polls for as long as it stays open; I found one on my machine still going after 45 minutes.

## Measurements

Over a 20s wait:

| | context switches/sec | CPU |
| --- | --- | --- |
| `sleep 0.05` (select, input) | 19 | 7 jiffies / 20s |
| `sleep 0.01` (images) | 92 | 35 jiffies / 20s |
| inotify wait | **0** | **0** |

Each polled iteration also forks a `sleep`, so this additionally removes roughly 20–100 process spawns per second while a menu is open. The CPU time is small; the wakeups are the point, since they keep the package out of its deeper idle states for the whole time a menu sits open.

The helper and its `inotifywait` child both measure 0 CPU jiffies and 0 voluntary context switches over a 15s wait.

## Change

Adds `bin/omarchy-menu-await-done`, which blocks on an inotify watch, and points the three callers at it.

Two details worth flagging in review:

- The watch is on the **directory**, because inotify cannot watch a file that does not exist yet, and it starts **before** the first existence test — otherwise a file created between the two would be missed by both. Verified with 8 consecutive runs where the file is created 5ms after launch.
- The helper returns success even when its watch ends early. The callers run under `set -e` and already read an absent or empty selection as cancellation, so a non-zero exit here would take them out before their own handling ran.

`inotify-tools` is already in `install/omarchy-base.packages`, so this adds no dependency.

## Testing

`./test/cli` passes. Helper checked for: file appearing after a delay (returns within ~3ms of the write), file already present (returns immediately), the 5ms creation race, unrelated churn in the same directory not returning early, no leaked `inotifywait`, and exit status across normal, already-present, watch-died, and missing-argument paths.

Not exercised against a real summoned menu in a running session — worth a sanity check before merge.

## Note

I also looked at the other sub-second `sleep`s in `bin/`. The ones in `omarchy-plugin-add`, `omarchy-plugin-clone`, `omarchy-launch-about`, `omarchy-update-stay-awake` and `omarchy-screensaver` are all bounded retry loops that settle in a second or two, so they are left alone. These three were the only unbounded ones.
