### PR TITLE
Document USB autosuspend and how to exempt a device

### DIFF
--- a/manual/36-system-sleep.md
+++ b/manual/36-system-sleep.md
@@ -8,6 +8,38 @@ On a laptop, Omarchy remembers your power profile separately for plugged in and 
 
 You can see what your machine offers with `omarchy powerprofiles list`, and set the one you want for the state you're currently in with `omarchy powerprofiles set autodetect power-saver`. To set the other state without unplugging anything, name it directly: `omarchy powerprofiles set battery power-saver`. Whatever you pick is what you'll get back the next time you're in that state.
 
+### USB power saving
+
+Linux lets idle USB devices power down after a couple of seconds, and Omarchy leaves that alone. It's a real saving on battery — a port held awake keeps its controller awake with it — and for most peripherals you'll never notice it happen.
+
+Occasionally you will. A dock, a webcam, a DAC, or a wireless dongle that handles the wake badly turns up as input that lags for a beat when you come back to the machine, audio that clips the front of a sound, or a device that drops off the bus and takes its time coming back.
+
+Fix it for the one device rather than all of them. `inxi -Jxxx` lists what's on the bus:
+
+```
+USB:
+  Device-1: 3-6:2 info: Integrated_Webcam_FHD type: video driver: uvcvideo
+    interfaces: 4 rev: 2.0 speed: 480 Mb/s lanes: 1 power: 500mA chip-ID: 1bcf:2ba9 class-ID: 0e02
+```
+
+The `chip-ID` is the vendor and product ID pair. Take the one belonging to the device that's misbehaving, and keep it powered with a udev rule in `/etc/udev/rules.d/99-usb-no-autosuspend.rules`:
+
+```
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="1bcf", ATTR{idProduct}=="2ba9", ATTR{power/control}="on"
+```
+
+The `99` matters. systemd ships `60-autosuspend.rules`, which sets `power/control` back to `auto` for every device its hardware database marks as safe to suspend. A rule numbered below that gets quietly undone for exactly the devices you'd want to exempt.
+
+Then reload the rules and replug the device, or reboot:
+
+```bash
+sudo udevadm control --reload
+```
+
+To confirm it took, `grep . /sys/bus/usb/devices/*/power/control` prints each device's path beside its setting, and the one you named reads `on`.
+
+There is a global version of this, `usbcore.autosuspend=-1` on the kernel command line, which stops every USB device from powering down. It's the blunt instrument: it spends battery on your whole USB tree to settle one peripheral, so try the rule above first.
+
 ### Toggle suspend
 
 You toggle suspend by running `omarchy toggle suspend` from the terminal. That just reveals/hides the option under _System_ (or `Super + Esc`), and then you can see if it works consistently on your system. If not, you can hide it again with the same command.


### PR DESCRIPTION
Follows up #8097 and #6671, which both report that `etc/modprobe.d/omarchy-usb-autosuspend.conf` never applies — `usbcore` is built into the Arch kernel, so `modprobe.d` options for it are ignored and the effective `autosuspend` stays at the kernel default of 2.

#6671 was closed with the call that turning autosuspend off by default isn't wanted, since it would raise power consumption on laptops, and that this is "something to document instead". This is that documentation. It deliberately does not touch the drop-in file or the default behaviour — where that file lands is #8097's business, not this PR's.

## Change

One section in `manual/36-system-sleep.md`, after Power profiles: what USB autosuspend does, why it's left on, the symptoms when a peripheral handles the wake badly, and the per-device udev rule to exempt just that device. The global `usbcore.autosuspend=-1` kernel command line switch is mentioned last and framed as the blunt option, so a reader reaches for the narrow fix first.

Devices are listed with `inxi -Jxxx`, whose `chip-ID` field is the `idVendor:idProduct` pair the rule matches on. `lsusb` would be the obvious choice, but `usbutils` isn't in `install/omarchy-base.packages` and isn't pulled in transitively, so it's absent on a stock install — whereas `inxi` is already a default. Worth noting `pciutils` is a hard dependency of `base`, which is why the many `lspci` calls across `bin/` and `install/hardware/` are safe without being listed; `usbutils` has no such guarantee.

## Checked

On a stock Omarchy 4.0.1 install: `inxi -Jxxx` prints the `chip-ID` shown in the example, and that pair belongs to the device named beside it, so the two blocks in the section line up rather than being invented. `udevadm` resolves these devices with `SUBSYSTEM=usb` and `DEVTYPE=usb_device`, and the `power/control`, `idVendor` and `idProduct` attributes the rule matches on are all present. `./test/cli` passes.

I have not rebooted into the rule to watch it apply — the attribute paths and matching are verified, the round trip isn't.
