### PR TITLE
fix: use --disable-gpu in Obsidian user-flags.conf

### DIFF
--- a/config/obsidian/user-flags.conf
+++ b/config/obsidian/user-flags.conf
@@ -1,3 +1,3 @@
 # Obsidian reads this file through the Arch package wrapper.
--disable-gpu
+--disable-gpu
 --enable-wayland-ime


### PR DESCRIPTION
Fixes #8538

Obsidian's CLI dispatcher treats any non-`--` token as a command name, so the shipped `-disable-gpu` in `config/obsidian/user-flags.conf` breaks `obsidian --version` when CLI is enabled. Chromium itself accepts both `-` and `--`; this does not change GPU behaviour.

Based on `quattro` (4.x). Replaces #8563 which was accidentally opened from master.