### PR TITLE
Enable docker.service for Docker DBs

### DIFF
--- a/bin/omarchy-install-docker-dbs
+++ b/bin/omarchy-install-docker-dbs
@@ -12,6 +12,10 @@ else
 fi
 
 if [[ -n $choices ]]; then
+  # Socket activation does not start dockerd for published container ports, so
+  # --restart unless-stopped never fires after reboot unless docker.service is on.
+  sudo systemctl enable --now docker.service
+
   for db in $choices; do
     echo "Installing $db..."
     case $db in

--- a/migrations/1787864101.sh
+++ b/migrations/1787864101.sh
@@ -1,0 +1,22 @@
+echo "Enable docker.service so Install > Docker DB containers survive reboot"
+
+omarchy-cmd-present docker || exit 0
+
+if systemctl is-enabled docker.service >/dev/null 2>&1; then
+  exit 0
+fi
+
+# docker info talks to the socket, which is enough to start dockerd so inspect works.
+sudo docker info >/dev/null 2>&1 || exit 0
+
+found=0
+for name in mysql8 postgres18 mariadb11 redis mongodb mssql; do
+  if sudo docker inspect "$name" >/dev/null 2>&1; then
+    found=1
+    break
+  fi
+done
+
+(( found )) || exit 0
+
+sudo systemctl enable --now docker.service

--- a/migrations/1787864101.sh
+++ b/migrations/1787864101.sh
@@ -7,11 +7,13 @@ if systemctl is-enabled docker.service >/dev/null 2>&1; then
 fi
 
 # docker info talks to the socket, which is enough to start dockerd so inspect works.
-sudo docker info >/dev/null 2>&1 || exit 0
+# Let a cancelled sudo or a down dockerd fail the script so omarchy-migrate
+# leaves this pending instead of marking it complete.
+sudo docker info >/dev/null
 
 found=0
 for name in mysql8 postgres18 mariadb11 redis mongodb mssql; do
-  if sudo docker inspect "$name" >/dev/null 2>&1; then
+  if sudo docker inspect --type container "$name" >/dev/null 2>&1; then
     found=1
     break
   fi

--- a/test/shell.d/docker-dbs-service-test.sh
+++ b/test/shell.d/docker-dbs-service-test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+grep -F 'sudo systemctl enable --now docker.service' "$ROOT/bin/omarchy-install-docker-dbs" >/dev/null ||
+  fail "Docker DB installer does not enable docker.service"
+pass "Docker DB installer enables docker.service when a database is chosen"
+
+migration="$ROOT/migrations/1787864101.sh"
+[[ -f $migration ]] || fail "Docker DB docker.service migration is missing"
+pass "Docker DB docker.service migration exists"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+SYSTEMCTL_LOG="$tmp_dir/systemctl-log"
+DOCKER_LOG="$tmp_dir/docker-log"
+
+cat >"$tmp_dir/bin/systemctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+if [[ $1 == "is-enabled" ]]; then
+  exit 1
+fi
+exit 0
+SH
+
+cat >"$tmp_dir/bin/docker" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$DOCKER_LOG"
+if [[ $1 == "info" ]]; then
+  exit 0
+fi
+if [[ $1 == "inspect" && $2 == "postgres18" ]]; then
+  exit 0
+fi
+exit 1
+SH
+
+cat >"$tmp_dir/bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$tmp_dir/bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$tmp_dir/bin/systemctl" "$tmp_dir/bin/docker" "$tmp_dir/bin/sudo" "$tmp_dir/bin/omarchy-cmd-present"
+
+PATH="$tmp_dir/bin:$PATH" \
+SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+DOCKER_LOG="$DOCKER_LOG" \
+  bash -euo pipefail "$migration" >/dev/null
+
+grep -Fqx -- "enable --now docker.service" "$SYSTEMCTL_LOG" ||
+  fail "migration does not enable docker.service when a Docker DB container exists"
+pass "migration enables docker.service when a Docker DB container exists"
+
+: >"$SYSTEMCTL_LOG"
+: >"$DOCKER_LOG"
+
+cat >"$tmp_dir/bin/docker" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$DOCKER_LOG"
+if [[ $1 == "info" ]]; then
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$tmp_dir/bin/docker"
+
+PATH="$tmp_dir/bin:$PATH" \
+SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+DOCKER_LOG="$DOCKER_LOG" \
+  bash -euo pipefail "$migration" >/dev/null
+
+if grep -Fqx -- "enable --now docker.service" "$SYSTEMCTL_LOG"; then
+  fail "migration enables docker.service when no Docker DB container exists"
+fi
+pass "migration leaves docker.service alone when no Docker DB container exists"

--- a/test/shell.d/docker-dbs-service-test.sh
+++ b/test/shell.d/docker-dbs-service-test.sh
@@ -34,7 +34,7 @@ printf '%s\n' "$*" >>"$DOCKER_LOG"
 if [[ $1 == "info" ]]; then
   exit 0
 fi
-if [[ $1 == "inspect" && $2 == "postgres18" ]]; then
+if [[ $1 == "inspect" && $2 == "--type" && $3 == "container" && $4 == "postgres18" ]]; then
   exit 0
 fi
 exit 1
@@ -59,6 +59,8 @@ DOCKER_LOG="$DOCKER_LOG" \
 
 grep -Fqx -- "enable --now docker.service" "$SYSTEMCTL_LOG" ||
   fail "migration does not enable docker.service when a Docker DB container exists"
+grep -Fqx -- "inspect --type container postgres18" "$DOCKER_LOG" ||
+  fail "migration does not inspect containers by type"
 pass "migration enables docker.service when a Docker DB container exists"
 
 : >"$SYSTEMCTL_LOG"
@@ -83,3 +85,27 @@ if grep -Fqx -- "enable --now docker.service" "$SYSTEMCTL_LOG"; then
   fail "migration enables docker.service when no Docker DB container exists"
 fi
 pass "migration leaves docker.service alone when no Docker DB container exists"
+
+: >"$SYSTEMCTL_LOG"
+: >"$DOCKER_LOG"
+
+cat >"$tmp_dir/bin/docker" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$DOCKER_LOG"
+if [[ $1 == "info" ]]; then
+  exit 1
+fi
+exit 0
+SH
+chmod +x "$tmp_dir/bin/docker"
+
+if PATH="$tmp_dir/bin:$PATH" \
+SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+DOCKER_LOG="$DOCKER_LOG" \
+  bash -euo pipefail "$migration" >/dev/null 2>&1; then
+  fail "migration treats docker info failure as success"
+fi
+if grep -Fqx -- "enable --now docker.service" "$SYSTEMCTL_LOG"; then
+  fail "migration enables docker.service after docker info failure"
+fi
+pass "migration stays pending when docker info fails"


### PR DESCRIPTION
**What**: Enable `docker.service` when a Docker DB is installed, so containers with `--restart unless-stopped` come back after reboot.

**Why**: Fixes #8541. Quattro enables `docker.socket` and disables `docker.service`. Socket activation only starts dockerd when something talks to `/run/docker.sock`. A TCP connect to a published port (e.g. `127.0.0.1:5432`) never hits that socket, so `docker-proxy` is not listening and `--restart unless-stopped` never fires.

**How**: Keep socket activation as the default. Enable and start `docker.service` only when Install > Docker DB actually creates a container. A migration does the same for existing mysql8/postgres18/mariadb11/redis/mongodb/mssql containers, and no-ops if those names are absent.

Rejected: turning `docker.service` on for every install — machines that never used Docker DB should stay on socket activation.

**Verified**:
- `bash -n` on `bin/omarchy-install-docker-dbs`, `migrations/1787864101.sh`, `test/shell.d/docker-dbs-service-test.sh`
- `bash test/shell.d/docker-dbs-service-test.sh` (pass)

**NOT verified**: live reboot with Hyprland/Docker (this machine is Windows); `shellcheck`/`shfmt` not installed; `./test/all` and `omarchy-iso` not run.