### PR TITLE
Use bypassPermissions for Claude agent

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -75,7 +75,7 @@ crush)
   fi
   ;;
 claude)
-  command=(claude --permission-mode auto)
+  command=(claude --permission-mode bypassPermissions)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;
 grok)

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -458,7 +458,7 @@ assert_launch pi pi "Review this project"
 assert_launch omp omp --auto-approve -- "Review this project"
 assert_launch opencode opencode --auto --prompt "Review this project"
 assert_launch ori ori code --interactive --prompt "Review this project"
-assert_launch claude claude --permission-mode auto -- "Review this project"
+assert_launch claude claude --permission-mode bypassPermissions -- "Review this project"
 assert_launch codex codex --approve-for-me -- "Review this project"
 assert_launch crush crush run "Review this project"
 assert_launch grok grok --permission-mode bypassPermissions -- "Review this project"
@@ -470,7 +470,7 @@ assert_bypass pi pi
 assert_bypass omp omp --auto-approve
 assert_bypass opencode opencode --auto
 assert_bypass ori ori code
-assert_bypass claude claude --permission-mode auto
+assert_bypass claude claude --permission-mode bypassPermissions
 assert_bypass codex codex --approve-for-me
 assert_bypass crush crush --yolo
 assert_bypass grok grok --permission-mode bypassPermissions


### PR DESCRIPTION
**What**: Launch Claude from `omarchy-agent` with `--permission-mode bypassPermissions`.

**Why**: Fixes #8607. `--permission-mode auto` is a real Claude Code mode but still prompts. Every other agent in the same table gets a genuine \"don't stop to ask\" flag; grok already uses `bypassPermissions`.

**How**: One flag change in `bin/omarchy-agent`, plus the matching `test/shell.d/default-agent-test.sh` expectations.

**Verified**:
- `bash -n bin/omarchy-agent`
- Stubbed `omarchy-agent` / `omarchy-agent-prompt` launch: argv is `claude --permission-mode bypassPermissions` (and `-- \"Review this project\"` for the prompt path)

**NOT verified**: full `test/shell.d/default-agent-test.sh` (fails earlier on this Windows host at `ln` into a directory); live Claude Code session.