### PR TITLE
Set Tailscale operator for Taildrop

### DIFF
--- a/migrations/1787884977.sh
+++ b/migrations/1787884977.sh
@@ -1,15 +1,33 @@
 echo "Set Tailscale operator so Taildrop receive can read files"
 
 if omarchy-cmd-present tailscale; then
-  # The receiver runs as the user; without --operator it only loops
-  # "Access denied" every ten seconds. Match the installer.
-  if ! error=$(sudo tailscale set --operator="$USER" 2>&1); then
-    echo "Could not set Tailscale operator: $error"
+  # One machine-wide operator. Do not steal it from another user, and do not
+  # mark this complete if sudo is cancelled or tailscaled is down.
+  if ! prefs=$(sudo tailscale debug prefs 2>&1); then
+    echo "Could not read Tailscale preferences: $prefs"
+    echo "The Tailscale operator repair will be retried by omarchy-migrate."
+    exit 1
+  fi
+
+  operator=$(printf '%s\n' "$prefs" | awk -F'"' '/"OperatorUser"/ { print $4; exit }')
+
+  if [[ -n $operator && $operator != "$USER" ]]; then
+    echo "Tailscale operator is already $operator; leaving it unchanged."
   else
+    if [[ $operator != "$USER" ]]; then
+      if ! error=$(sudo tailscale set --operator="$USER" 2>&1); then
+        echo "Could not set Tailscale operator: $error"
+        echo "The Tailscale operator repair will be retried by omarchy-migrate."
+        exit 1
+      fi
+    fi
+
     systemctl --user daemon-reload >/dev/null 2>&1 || true
 
     if ! error=$(systemctl --user enable --now omarchy-tailscale-receive.service 2>&1); then
       echo "Could not enable omarchy-tailscale-receive.service: $error"
+      echo "The Tailscale operator repair will be retried by omarchy-migrate."
+      exit 1
     fi
   fi
 fi

--- a/migrations/1787884977.sh
+++ b/migrations/1787884977.sh
@@ -13,6 +13,9 @@ if omarchy-cmd-present tailscale; then
 
   if [[ -n $operator && $operator != "$USER" ]]; then
     echo "Tailscale operator is already $operator; leaving it unchanged."
+    # 1785101000 may already have started this user's receiver. It cannot
+    # receive files without being the operator, so stop the access-denied loop.
+    systemctl --user disable --now omarchy-tailscale-receive.service 2>/dev/null || true
   else
     if [[ $operator != "$USER" ]]; then
       if ! error=$(sudo tailscale set --operator="$USER" 2>&1); then

--- a/migrations/1787884977.sh
+++ b/migrations/1787884977.sh
@@ -1,0 +1,15 @@
+echo "Set Tailscale operator so Taildrop receive can read files"
+
+if omarchy-cmd-present tailscale; then
+  # The receiver runs as the user; without --operator it only loops
+  # "Access denied" every ten seconds. Match the installer.
+  if ! error=$(sudo tailscale set --operator="$USER" 2>&1); then
+    echo "Could not set Tailscale operator: $error"
+  else
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+    if ! error=$(systemctl --user enable --now omarchy-tailscale-receive.service 2>&1); then
+      echo "Could not enable omarchy-tailscale-receive.service: $error"
+    fi
+  fi
+fi

--- a/test/shell.d/tailscale-operator-migration-test.sh
+++ b/test/shell.d/tailscale-operator-migration-test.sh
@@ -12,18 +12,24 @@ tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 
 mkdir -p "$tmp_dir/bin"
-TAILSCALE_LOG="$tmp_dir/tailscale-log"
-SYSTEMCTL_LOG="$tmp_dir/systemctl-log"
+CALL_LOG="$tmp_dir/call-log"
 
 cat >"$tmp_dir/bin/systemctl" <<'SH'
 #!/bin/bash
-printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+printf 'systemctl %s\n' "$*" >>"$CALL_LOG"
 exit 0
 SH
 
 cat >"$tmp_dir/bin/tailscale" <<'SH'
 #!/bin/bash
-printf '%s\n' "$*" >>"$TAILSCALE_LOG"
+printf 'tailscale %s\n' "$*" >>"$CALL_LOG"
+if [[ $1 == "debug" && $2 == "prefs" ]]; then
+  printf '{"OperatorUser":"%s"}\n' "${STUB_OPERATOR:-}"
+  exit 0
+fi
+if [[ $1 == "set" ]]; then
+  exit "${STUB_SET_STATUS:-0}"
+fi
 exit 0
 SH
 
@@ -39,20 +45,23 @@ SH
 
 chmod +x "$tmp_dir/bin/systemctl" "$tmp_dir/bin/tailscale" "$tmp_dir/bin/sudo" "$tmp_dir/bin/omarchy-cmd-present"
 
+: >"$CALL_LOG"
+
 USER=omarchy-test \
 PATH="$tmp_dir/bin:$PATH" \
-TAILSCALE_LOG="$TAILSCALE_LOG" \
-SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+CALL_LOG="$CALL_LOG" \
   bash -euo pipefail "$migration" >/dev/null
 
-grep -Fqx -- "set --operator=omarchy-test" "$TAILSCALE_LOG" ||
-  fail "migration does not set the Tailscale operator"
-grep -Fqx -- "--user enable --now omarchy-tailscale-receive.service" "$SYSTEMCTL_LOG" ||
-  fail "migration does not enable the Taildrop receiver after setting the operator"
+printf '%s\n' \
+  "tailscale debug prefs" \
+  "tailscale set --operator=omarchy-test" \
+  "systemctl --user daemon-reload" \
+  "systemctl --user enable --now omarchy-tailscale-receive.service" >"$tmp_dir/expected"
+cmp -s "$CALL_LOG" "$tmp_dir/expected" ||
+  fail "migration does not set the operator before enabling the Taildrop receiver" "$(cat "$CALL_LOG")"
 pass "migration sets the operator before enabling the Taildrop receiver"
 
-: >"$TAILSCALE_LOG"
-: >"$SYSTEMCTL_LOG"
+: >"$CALL_LOG"
 
 cat >"$tmp_dir/bin/omarchy-cmd-present" <<'SH'
 #!/bin/bash
@@ -61,11 +70,46 @@ SH
 chmod +x "$tmp_dir/bin/omarchy-cmd-present"
 
 PATH="$tmp_dir/bin:$PATH" \
-TAILSCALE_LOG="$TAILSCALE_LOG" \
-SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+CALL_LOG="$CALL_LOG" \
   bash -euo pipefail "$migration" >/dev/null
 
-if [[ -s $TAILSCALE_LOG || -s $SYSTEMCTL_LOG ]]; then
+if [[ -s $CALL_LOG ]]; then
   fail "migration talks to Tailscale when it is not installed"
 fi
 pass "migration leaves Tailscale alone when it is not installed"
+
+cat >"$tmp_dir/bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ $1 == "tailscale" ]]
+SH
+chmod +x "$tmp_dir/bin/omarchy-cmd-present"
+
+: >"$CALL_LOG"
+
+if USER=omarchy-test \
+PATH="$tmp_dir/bin:$PATH" \
+CALL_LOG="$CALL_LOG" \
+STUB_SET_STATUS=1 \
+  bash -euo pipefail "$migration" >/dev/null 2>&1; then
+  fail "migration treats a failed operator set as success"
+fi
+if grep -q 'enable --now omarchy-tailscale-receive.service' "$CALL_LOG"; then
+  fail "migration enables the receiver after a failed operator set"
+fi
+pass "migration stays pending when setting the operator fails"
+
+: >"$CALL_LOG"
+
+USER=omarchy-test \
+PATH="$tmp_dir/bin:$PATH" \
+CALL_LOG="$CALL_LOG" \
+STUB_OPERATOR=other-user \
+  bash -euo pipefail "$migration" >/dev/null
+
+if grep -q 'tailscale set --operator=' "$CALL_LOG"; then
+  fail "migration replaces an existing Tailscale operator"
+fi
+if grep -q 'enable --now omarchy-tailscale-receive.service' "$CALL_LOG"; then
+  fail "migration enables a receiver for a user who is not the operator"
+fi
+pass "migration leaves an existing operator unchanged"

--- a/test/shell.d/tailscale-operator-migration-test.sh
+++ b/test/shell.d/tailscale-operator-migration-test.sh
@@ -106,10 +106,9 @@ CALL_LOG="$CALL_LOG" \
 STUB_OPERATOR=other-user \
   bash -euo pipefail "$migration" >/dev/null
 
-if grep -q 'tailscale set --operator=' "$CALL_LOG"; then
-  fail "migration replaces an existing Tailscale operator"
-fi
-if grep -q 'enable --now omarchy-tailscale-receive.service' "$CALL_LOG"; then
-  fail "migration enables a receiver for a user who is not the operator"
-fi
-pass "migration leaves an existing operator unchanged"
+printf '%s\n' \
+  "tailscale debug prefs" \
+  "systemctl --user disable --now omarchy-tailscale-receive.service" >"$tmp_dir/expected"
+cmp -s "$CALL_LOG" "$tmp_dir/expected" ||
+  fail "migration does not disable a leftover receiver when the operator belongs to someone else" "$(cat "$CALL_LOG")"
+pass "migration disables a leftover receiver when the operator belongs to someone else"

--- a/test/shell.d/tailscale-operator-migration-test.sh
+++ b/test/shell.d/tailscale-operator-migration-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787884977.sh"
+[[ -f $migration ]] || fail "Tailscale operator migration is missing"
+pass "Tailscale operator migration exists"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+TAILSCALE_LOG="$tmp_dir/tailscale-log"
+SYSTEMCTL_LOG="$tmp_dir/systemctl-log"
+
+cat >"$tmp_dir/bin/systemctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+exit 0
+SH
+
+cat >"$tmp_dir/bin/tailscale" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TAILSCALE_LOG"
+exit 0
+SH
+
+cat >"$tmp_dir/bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$tmp_dir/bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ $1 == "tailscale" ]]
+SH
+
+chmod +x "$tmp_dir/bin/systemctl" "$tmp_dir/bin/tailscale" "$tmp_dir/bin/sudo" "$tmp_dir/bin/omarchy-cmd-present"
+
+USER=omarchy-test \
+PATH="$tmp_dir/bin:$PATH" \
+TAILSCALE_LOG="$TAILSCALE_LOG" \
+SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+  bash -euo pipefail "$migration" >/dev/null
+
+grep -Fqx -- "set --operator=omarchy-test" "$TAILSCALE_LOG" ||
+  fail "migration does not set the Tailscale operator"
+grep -Fqx -- "--user enable --now omarchy-tailscale-receive.service" "$SYSTEMCTL_LOG" ||
+  fail "migration does not enable the Taildrop receiver after setting the operator"
+pass "migration sets the operator before enabling the Taildrop receiver"
+
+: >"$TAILSCALE_LOG"
+: >"$SYSTEMCTL_LOG"
+
+cat >"$tmp_dir/bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$tmp_dir/bin/omarchy-cmd-present"
+
+PATH="$tmp_dir/bin:$PATH" \
+TAILSCALE_LOG="$TAILSCALE_LOG" \
+SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+  bash -euo pipefail "$migration" >/dev/null
+
+if [[ -s $TAILSCALE_LOG || -s $SYSTEMCTL_LOG ]]; then
+  fail "migration talks to Tailscale when it is not installed"
+fi
+pass "migration leaves Tailscale alone when it is not installed"


### PR DESCRIPTION
**What**: Set the desktop user as the Tailscale operator before enabling the Taildrop receiver.

**Why**: Fixes #8484. Migration `1785101000.sh` enabled `omarchy-tailscale-receive.service` without `tailscale set --operator`, so the unit loops `Access denied: file access denied` every ten seconds. The current installer already sets `--operator=\"$USER\"` first.

**How**: New migration (the original already ran for existing installs). It matches the installer: set operator, then enable the receiver. If operator setup fails, it leaves the receiver alone and prints the error. No-ops when Tailscale is not installed.

**Verified**:
- `bash -n` on the migration and `test/shell.d/tailscale-operator-migration-test.sh`
- `bash test/shell.d/tailscale-operator-migration-test.sh` (pass)

**NOT verified**: live Tailscale/Taildrop on Linux; `shellcheck`/`shfmt` not installed.