### PR TITLE
Restart crash-watch after updates

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -49,3 +49,8 @@ done
 echo -e "\e[32m\nRestarting shell\e[0m"
 echo "All plugins have been reloaded"
 omarchy-restart-shell || true
+
+# bash holds a running crash-watch on the unlinked inode after pacman
+# replaces the script, so the next toast calls the new notification
+# helper with the old argv. try-restart is a no-op if it isn't running.
+systemctl --user try-restart omarchy-crash-watch.service >/dev/null 2>&1 || true

--- a/test/shell.d/crash-capture-test.sh
+++ b/test/shell.d/crash-capture-test.sh
@@ -54,6 +54,10 @@ grep -F 'omarchy-crash-watch.service' "$ROOT/install/user/first-run/enable-user-
   fail "crash capture is no longer on by default for new installs"
 pass "crash capture is on by default"
 
+grep -F 'try-restart omarchy-crash-watch.service' "$ROOT/bin/omarchy-update-restart" >/dev/null ||
+  fail "updates leave the running watcher on the unlinked inode after pacman replaces it"
+pass "updates restart the crash watcher"
+
 require_command jq
 
 # The per-program mute, driven through the real watcher with a stubbed journal:


### PR DESCRIPTION
**What**: Restart `omarchy-crash-watch` from `omarchy-update-restart` after an update.

**Why**: Fixes #8613. `pacman` replaces `bin/omarchy-crash-watch` while the running process still holds the unlinked inode (fd 255). The next journal toast then execs the new `omarchy-notification-send` with the old argv, so notifications fail.

**How**: `systemctl --user try-restart omarchy-crash-watch.service` after the existing shell restart. try-restart is a no-op if the watcher is stopped, so crash-capture-off stays off. Rejected a one-shot migration: it would not cover the next script change. Restarts belong here, not in a migration (same rule as the shell).

**Verified**:
- `bash -n bin/omarchy-update-restart`
- grep assertion that `omarchy-update-restart` contains `try-restart omarchy-crash-watch.service`
- issue comment: https://github.com/basecamp/omarchy/issues/8613#issuecomment-5447795057

**NOT verified**:
- live `systemctl --user try-restart` (Windows; no user systemd / Hyprland)
- full `test/shell.d/crash-capture-test.sh` (needs `jq` + journal stubs beyond the new grep)
- `test/all`, pacman, omarchy-iso