### PR TITLE
fix: arm signature verification for the T2 repo and close the quattro override window

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -455,6 +455,25 @@ install_keyrings() {
   }
 }
 
+# install_keyrings can only run while the [omarchy] stanza accepts unsigned
+# packages: the keyring package that provides trust arrives through the very
+# repository it is meant to authenticate. Once it is installed the override
+# has served its purpose, so drop it before anything else is fetched -- every
+# later transaction in this upgrade then verifies signatures like a normal
+# post-#8072 machine instead of trusting the wire.
+require_signed_omarchy_repo() {
+  if ! as_root pacman -Q omarchy-keyring >/dev/null 2>&1; then
+    warn "omarchy-keyring did not install; leaving the unsigned-package override in place."
+    return
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  sed '/^\[omarchy\]/,/^\[/{/^SigLevel = Optional TrustAll$/d}' /etc/pacman.conf >"$tmp"
+  as_root install -m 0644 "$tmp" /etc/pacman.conf
+  rm -f "$tmp"
+}
+
 remove_legacy_installer_package() {
   if pacman -Q omarchy-installer >/dev/null 2>&1; then
     log "Removing legacy omarchy-installer package"
@@ -2319,6 +2338,7 @@ suppress_hyprland_config_reload
 create_pre_upgrade_snapshot
 configure_pacman_channel
 install_keyrings
+require_signed_omarchy_repo
 remove_legacy_installer_package
 remove_legacy_limine_configs
 remove_conflicting_legacy_packages

--- a/install/hardware/pacman.sh
+++ b/install/hardware/pacman.sh
@@ -9,9 +9,12 @@
 #
 # - PackageOptional verifies any package that carries a signature the moment
 #   upstream starts signing, while still accepting the unsigned packages
-#   shipped today. A present-but-invalid signature is rejected, so a later
-#   compromise cannot rely on swapping signatures past an already-imported
-#   key.
+#   shipped today. A signature that is present but invalid is rejected, so an
+#   already-imported key cannot be walked past with a bad signature. It does
+#   NOT prevent signature stripping: an attacker who controls the repository
+#   can simply stop publishing signatures and pacman accepts the unsigned
+#   result. Stripping is only excluded once upstream signs consistently and
+#   this policy tightens to PackageRequired.
 # - DatabaseNever skips the stale database signature, which a plain Optional
 #   would find and reject.
 #
@@ -26,7 +29,17 @@ t2_pacman_conf=${OMARCHY_T2_PACMAN_CONF:-/etc/pacman.conf}
 t2_signing_key=8BE1FEE14302371DEF6F910A0E5877AC225D1980
 
 if lspci -nn | grep "106b:180[12]" >/dev/null; then
-  if ! grep -q '^\[arch-mact2\]' "$t2_pacman_conf"; then
+  # Fresh installs append the armed stanza; installs that predate this change
+  # already carry [arch-mact2] with SigLevel = Never and are reconciled in
+  # place instead of skipped.
+  if grep -q '^SigLevel = Never$' "$t2_pacman_conf"; then
+    if pacman-key --recv-keys "$t2_signing_key" --keyserver keyserver.ubuntu.com &&
+       pacman-key --lsign-key "$t2_signing_key"; then
+      sed -i 's/^SigLevel = Never$/SigLevel = PackageOptional DatabaseNever/' "$t2_pacman_conf"
+    else
+      echo "Could not import the pinned t2linux signing key ($t2_signing_key); the arch-mact2 repository stays unverified." >&2
+    fi
+  elif ! grep -q '^\[arch-mact2\]' "$t2_pacman_conf"; then
     if ! pacman-key --recv-keys "$t2_signing_key" --keyserver keyserver.ubuntu.com; then
       echo "Could not import the pinned t2linux signing key ($t2_signing_key); refusing to enable the arch-mact2 repository unverified." >&2
       exit 1

--- a/install/hardware/pacman.sh
+++ b/install/hardware/pacman.sh
@@ -1,12 +1,43 @@
 # Hardware-specific pacman repository extensions that must survive the final
 # pacman.conf restore.
+#
+# The t2linux repository publishes no package signatures today, and the
+# database signature it does publish is stale (it verifies as BAD against the
+# current database), so full enforcement would refuse every T2 package and
+# break the install. The stanza below arms verification as far as the current
+# upstream state allows instead of leaving it off outright:
+#
+# - PackageOptional verifies any package that carries a signature the moment
+#   upstream starts signing, while still accepting the unsigned packages
+#   shipped today. A present-but-invalid signature is rejected, so a later
+#   compromise cannot rely on swapping signatures past an already-imported
+#   key.
+# - DatabaseNever skips the stale database signature, which a plain Optional
+#   would find and reject.
+#
+# The pinned t2linux signing key (upstream: Noa Himesaka
+# <himesaka@noa.codes>) is imported and locally signed so those future
+# signatures verify. Residual risk until upstream signs its packages: a
+# compromise of the arch-mact2 repository or its delivery path is root code
+# execution on T2 machines. That exposure is disclosed to the Omarchy
+# security contact and needs an upstream fix (signing the repository); this
+# stanza is the strongest stance the current upstream state permits.
+t2_pacman_conf=${OMARCHY_T2_PACMAN_CONF:-/etc/pacman.conf}
+t2_signing_key=8BE1FEE14302371DEF6F910A0E5877AC225D1980
+
 if lspci -nn | grep "106b:180[12]" >/dev/null; then
-  if ! grep -q '^\[arch-mact2\]' /etc/pacman.conf; then
-    cat >> /etc/pacman.conf <<'EOF'
+  if ! grep -q '^\[arch-mact2\]' "$t2_pacman_conf"; then
+    if ! pacman-key --recv-keys "$t2_signing_key" --keyserver keyserver.ubuntu.com; then
+      echo "Could not import the pinned t2linux signing key ($t2_signing_key); refusing to enable the arch-mact2 repository unverified." >&2
+      exit 1
+    fi
+    pacman-key --lsign-key "$t2_signing_key"
+
+    cat >> "$t2_pacman_conf" <<'EOF'
 
 [arch-mact2]
 Server = https://github.com/NoaHimesaka1873/arch-mact2-mirror/releases/download/release
-SigLevel = Never
+SigLevel = PackageOptional DatabaseNever
 EOF
   fi
 fi

--- a/migrations/1787720000.sh
+++ b/migrations/1787720000.sh
@@ -1,0 +1,21 @@
+# Reconcile existing T2 installs whose arch-mact2 stanza predates signature
+# arming. Fresh installs get the armed stanza from install/hardware/pacman.sh;
+# this covers machines that already carry SigLevel = Never and whose normal
+# update path runs migrations rather than the hardware installer.
+
+arch_mact2_never='SigLevel = Never'
+t2_signing_key=8BE1FEE14302371DEF6F910A0E5877AC225D1980
+
+if grep -q '^\[arch-mact2\]' /etc/pacman.conf 2>/dev/null &&
+   grep -q "^${arch_mact2_never}$" /etc/pacman.conf; then
+  # A failed key import leaves the machine exactly as it was: the stanza keeps
+  # working as it always has, and a later migration retry can import the key.
+  # Refusing to transact would break a working T2 machine for no immediate
+  # gain, because packages are unsigned either way.
+  if sudo pacman-key --recv-keys "$t2_signing_key" --keyserver keyserver.ubuntu.com &&
+     sudo pacman-key --lsign-key "$t2_signing_key"; then
+    sudo sed -i "s/^${arch_mact2_never}$/SigLevel = PackageOptional DatabaseNever/" /etc/pacman.conf
+  else
+    echo "Could not import the pinned t2linux signing key; the arch-mact2 repository stays unverified." >&2
+  fi
+fi

--- a/test/shell.d/t2-repo-signature-test.sh
+++ b/test/shell.d/t2-repo-signature-test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Guards around package-repository signature policy:
+#
+# 1. install/hardware/pacman.sh must never re-add a repository that disables
+#    signature verification outright, and must arm verification for the
+#    t2linux repository with the pinned upstream signing key.
+# 2. bin/omarchy-upgrade-to-quattro may write the unsigned-package override
+#    only to bootstrap the keyring, and must drop it before any further
+#    transaction in the upgrade.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=shell.d/base-test.sh
+source "$ROOT/test/shell.d/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+# ---------------------------------------------------------------- T2 stanza
+
+fail_guard() {
+  fail "$1" "${2-}"
+}
+
+# No repository anywhere in the tree may switch verification off outright.
+if grep -rn 'SigLevel = Never' "$ROOT/install" "$ROOT/default" "$ROOT/bin" 2>/dev/null; then
+  fail_guard "no repository stanza disables signature verification outright"
+fi
+pass "no repository stanza disables signature verification outright"
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+# A T2 machine reports the Apple T2 PCI vendor:device ids.
+cat >"$mock_bin/lspci" <<'SH'
+#!/bin/bash
+printf '00:1f.0 Communication controller [106b:1801]\n'
+SH
+
+# Record pacman-key usage; validate every key argument against the pinned
+# fingerprint so a drift or typo cannot silently re-point trust.
+cat >"$mock_bin/pacman-key" <<SH
+#!/bin/bash
+printf '%s\n' "\$*" >>"$test_tmp/pacman-key-calls"
+for arg in "\$@"; do
+  case "\$arg" in
+    [0-9A-F]*) [[ \$arg == 8BE1FEE14302371DEF6F910A0E5877AC225D1980 ]] ||
+      { echo "unexpected key: \$arg" >&2; exit 1; } ;;
+  esac
+done
+exit 0
+SH
+
+chmod +x "$mock_bin/"*
+
+conf="$test_tmp/pacman.conf"
+printf '[options]\nHoldPkg = pacman glibc\n' >"$conf"
+
+run_t2_repo_setup() {
+  PATH="$mock_bin:$PATH" OMARCHY_T2_PACMAN_CONF="$conf" \
+    bash "$ROOT/install/hardware/pacman.sh"
+}
+
+run_t2_repo_setup
+
+grep -q '^\[arch-mact2\]' "$conf" ||
+  fail_guard "the T2 repository stanza is written for T2 hardware" "$(cat "$conf")"
+grep -q '^SigLevel = PackageOptional DatabaseNever$' "$conf" ||
+  fail_guard "the T2 stanza arms verification instead of disabling it" "$(cat "$conf")"
+grep -q 'SigLevel = Never' "$conf" &&
+  fail_guard "the T2 stanza never carries the old disable-verification line"
+grep -q 'keyserver.ubuntu.com' "$test_tmp/pacman-key-calls" ||
+  fail_guard "the pinned t2linux key is imported from a keyserver" "$(cat "$test_tmp/pacman-key-calls")"
+grep -q -- '--lsign-key' "$test_tmp/pacman-key-calls" ||
+  fail_guard "the imported t2linux key is locally signed" "$(cat "$test_tmp/pacman-key-calls")"
+pass "the T2 stanza arms verification and pins the upstream signing key"
+
+# A second run must not append a duplicate stanza.
+run_t2_repo_setup
+[[ $(grep -c '^\[arch-mact2\]' "$conf") == 1 ]] ||
+  fail_guard "the T2 stanza is idempotent" "$(cat "$conf")"
+pass "the T2 stanza is idempotent"
+
+# An unusable keyserver must refuse to enable the repository rather than fall
+# back to an unsigned stanza: failing the install is safer than silently
+# running an unauthenticated repository as root.
+cat >"$mock_bin/pacman-key" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$mock_bin/pacman-key"
+
+conf2="$test_tmp/pacman-fail.conf"
+printf '[options]\n' >"$conf2"
+if PATH="$mock_bin:$PATH" OMARCHY_T2_PACMAN_CONF="$conf2" \
+    bash "$ROOT/install/hardware/pacman.sh" 2>/dev/null; then
+  fail_guard "a failed key import refuses to enable the arch-mact2 repository"
+fi
+grep -q '^\[arch-mact2\]' "$conf2" &&
+  fail_guard "a failed key import leaves no repository stanza behind"
+pass "a failed key import refuses to enable the arch-mact2 repository"
+
+# ------------------------------------------------------------ quattro override
+
+quattro="$ROOT/bin/omarchy-upgrade-to-quattro"
+
+# The override exists only as a keyring bootstrap: it may be written, but the
+# script must drop it again before any further transaction.
+grep -q 'SigLevel = Optional TrustAll' "$quattro" ||
+  fail_guard "the quattro bootstrap override is still written for the keyring install"
+grep -q 'require_signed_omarchy_repo()' "$quattro" ||
+  fail_guard "quattro defines the override removal step"
+grep -q 'SigLevel = Optional TrustAll' "$quattro" &&
+  ! sed -n '/^require_signed_omarchy_repo()/,/^}/p' "$quattro" |
+      grep -q '/\^SigLevel = Optional TrustAll\$/d' &&
+  fail_guard "the removal step deletes the bootstrap override line"
+
+# The removal must run immediately after the keyring install, before any
+# package-bearing step.
+keyring_line=$(grep -n '^install_keyrings$' "$quattro" | cut -d: -f1)
+removal_line=$(grep -n '^require_signed_omarchy_repo$' "$quattro" | cut -d: -f1)
+next_line=$((keyring_line + 1))
+[[ $removal_line == "$next_line" ]] ||
+  fail_guard "the override removal runs immediately after install_keyrings" \
+    "install_keyrings at $keyring_line, removal at $removal_line"
+pass "quattro drops the bootstrap override right after the keyring install"

--- a/test/shell.d/t2-repo-signature-test.sh
+++ b/test/shell.d/t2-repo-signature-test.sh
@@ -24,9 +24,24 @@ fail_guard() {
 }
 
 # No repository anywhere in the tree may switch verification off outright.
-if grep -rn 'SigLevel = Never' "$ROOT/install" "$ROOT/default" "$ROOT/bin" 2>/dev/null; then
+# install/hardware/pacman.sh is exempt from the text scan because it must
+# mention SigLevel = Never to reconcile pre-arming installs (comments, the
+# detection gate, and the sed that replaces the line); its appended stanza is
+# asserted separately below.
+if grep -rn 'SigLevel = Never' \
+     --exclude=pacman.sh "$ROOT/install" "$ROOT/default" "$ROOT/bin" 2>/dev/null; then
   fail_guard "no repository stanza disables signature verification outright"
 fi
+
+# The stanza pacman.sh appends must itself be the armed policy: check the
+# heredoc body rather than the whole file.
+if sed -n '/cat >> "\$t2_pacman_conf"/,/^EOF$/p' "$ROOT/install/hardware/pacman.sh" |
+     grep -q 'SigLevel = Never'; then
+  fail_guard "the appended T2 stanza never disables signature verification"
+fi
+sed -n '/cat >> "\$t2_pacman_conf"/,/^EOF$/p' "$ROOT/install/hardware/pacman.sh" |
+  grep -q 'SigLevel = PackageOptional DatabaseNever' ||
+  fail_guard "the appended T2 stanza arms verification"
 pass "no repository stanza disables signature verification outright"
 
 mock_bin="$test_tmp/bin"
@@ -101,6 +116,70 @@ grep -q '^\[arch-mact2\]' "$conf2" &&
   fail_guard "a failed key import leaves no repository stanza behind"
 pass "a failed key import refuses to enable the arch-mact2 repository"
 
+# Installs that predate signature arming already carry the stanza with
+# SigLevel = Never. The script must reconcile those in place -- import the
+# key and upgrade the policy -- rather than skipping them because the stanza
+# exists.
+cat >"$mock_bin/pacman-key" <<SH
+#!/bin/bash
+printf '%s\n' "\$*" >>"$test_tmp/pacman-key-calls"
+for arg in "\$@"; do
+  case "\$arg" in
+    [0-9A-F]*) [[ \$arg == 8BE1FEE14302371DEF6F910A0E5877AC225D1980 ]] ||
+      { echo "unexpected key: \$arg" >&2; exit 1; } ;;
+  esac
+done
+exit 0
+SH
+chmod +x "$mock_bin/pacman-key"
+
+conf3="$test_tmp/pacman-legacy.conf"
+cat >"$conf3" <<'EOF'
+[options]
+HoldPkg = pacman glibc
+
+[arch-mact2]
+Server = https://github.com/NoaHimesaka1873/arch-mact2-mirror/releases/download/release
+SigLevel = Never
+EOF
+: >"$test_tmp/pacman-key-calls"
+
+run_t2_repo_setup_with() { # $1 = conf path
+  PATH="$mock_bin:$PATH" OMARCHY_T2_PACMAN_CONF="$1" \
+    bash "$ROOT/install/hardware/pacman.sh"
+}
+
+run_t2_repo_setup_with "$conf3"
+
+grep -q '^SigLevel = PackageOptional DatabaseNever$' "$conf3" ||
+  fail_guard "a legacy Never stanza is upgraded in place" "$(cat "$conf3")"
+grep -q 'SigLevel = Never' "$conf3" &&
+  fail_guard "the legacy Never line is gone after reconciliation"
+[[ $(grep -c '^\[arch-mact2\]' "$conf3") == 1 ]] ||
+  fail_guard "reconciliation does not duplicate the stanza"
+grep -q -- '--lsign-key' "$test_tmp/pacman-key-calls" ||
+  fail_guard "reconciliation imports and signs the pinned key" "$(cat "$test_tmp/pacman-key-calls")"
+pass "a legacy Never stanza is reconciled in place"
+
+# A failed key import during reconciliation cannot fix the machine, but it
+# must also not break it: the stanza keeps working exactly as before and the
+# script exits zero so the hardware stage continues.
+cat >"$mock_bin/pacman-key" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$mock_bin/pacman-key"
+cp "$conf3" "$test_tmp/pacman-legacy-fail.conf"
+sed -i 's/^SigLevel = PackageOptional DatabaseNever$/SigLevel = Never/' "$test_tmp/pacman-legacy-fail.conf"
+
+if ! PATH="$mock_bin:$PATH" OMARCHY_T2_PACMAN_CONF="$test_tmp/pacman-legacy-fail.conf" \
+    bash "$ROOT/install/hardware/pacman.sh" 2>/dev/null; then
+  fail_guard "a failed reconciliation import does not fail the hardware stage"
+fi
+grep -q '^SigLevel = Never$' "$test_tmp/pacman-legacy-fail.conf" ||
+  fail_guard "a failed reconciliation leaves the working stanza untouched"
+pass "a failed reconciliation import leaves the machine working as it was"
+
 # ------------------------------------------------------------ quattro override
 
 quattro="$ROOT/bin/omarchy-upgrade-to-quattro"
@@ -125,3 +204,32 @@ next_line=$((keyring_line + 1))
   fail_guard "the override removal runs immediately after install_keyrings" \
     "install_keyrings at $keyring_line, removal at $removal_line"
 pass "quattro drops the bootstrap override right after the keyring install"
+
+# ---------------------------------------------------------------- migration
+
+# Normal updates run migrations, not the hardware installer, so existing T2
+# machines are reconciled by a migration with the same fingerprint and the
+# same replacement line as the installer.
+migration="$ROOT/migrations/1787720000.sh"
+
+grep -q '8BE1FEE14302371DEF6F910A0E5877AC225D1980' "$migration" ||
+  fail_guard "the migration pins the same t2linux signing key"
+grep -q 'keyserver.ubuntu.com' "$migration" ||
+  fail_guard "the migration imports the key from the keyserver"
+grep -q -- '--lsign-key' "$migration" ||
+  fail_guard "the migration locally signs the imported key"
+grep -q 'SigLevel = PackageOptional DatabaseNever' "$migration" ||
+  fail_guard "the migration upgrades the stanza to the armed policy"
+grep -q "arch_mact2_never='SigLevel = Never'" "$migration" &&
+  grep -q '\${arch_mact2_never}' "$migration" &&
+  grep -q 'if .*pacman-key' "$migration" ||
+  fail_guard "the migration is gated on a legacy Never stanza and a successful import"
+
+# Self-detecting and idempotent by construction: the Never check gates the
+# sed, so a rerun after a successful upgrade (or on a machine without the
+# stanza) never touches pacman.conf again.
+never_line=$(grep -n 'arch_mact2_never}' "$migration" | cut -d: -f1 | head -1)
+sed_line=$(grep -n 'sed -i' "$migration" | cut -d: -f1 | head -1)
+[[ -n $never_line && -n $sed_line && $sed_line -gt $never_line ]] ||
+  fail_guard "the migration only mutates pacman.conf under the Never gate"
+pass "the migration reconciles legacy T2 installs with the same pinning"


### PR DESCRIPTION
Follow-up to #8072 (Require signed packages from the Omarchy repository). Two repositories in the tree still accept unauthenticated packages as root; this closes what can be closed Omarchy-side and arms the rest.

## 1. `install/hardware/pacman.sh` — the T2 stanza disables verification outright

```
[arch-mact2]
Server = https://github.com/NoaHimesaka1873/arch-mact2-mirror/releases/download/release
SigLevel = Never
```

`SigLevel = Never` means pacman performs no package authentication at all for the life of the install: any compromise of the arch-mact2 repository, the `NoaHimesaka1873` account, or GitHub's release delivery path is root code execution on every T2 machine, through routine unattended `pacman -Syu` transactions. The repo ships the T2 kernel (`linux-t2`), firmware, and fan daemon, all executed or loaded at boot.

This differs from the #8072 finding in one important way: **upstream cannot enforce signatures today.** Verified against the live repository:

- none of the ~40 packages in `arch-mact2.db` carries a `%PGPSIG%` entry except `apple-bcm-wifi-firmware`;
- standalone `.sig` sidecars 404 for every package checked;
- `arch-mact2.db.sig` exists but is stale — it verifies as **BAD** (signed 2022-02-26, key `8BE1FEE1 4302 371D EF6F 910A 0E58 77AC 225D 1980`, "Noa Himesaka <himesaka@noa.codes>") against the current database.

So `SigLevel = Required` would refuse every T2 package and break the install. The stanza instead **arms** verification as far as upstream permits:

- The pinned upstream signing key is imported and locally signed (`pacman-key --recv-keys … --keyserver keyserver.ubuntu.com`, then `--lsign-key`). A failed import **refuses to enable the repository** rather than silently continuing unverified — a T2 install without its kernel cannot succeed anyway, and an explicit error beats an unauthenticated stanza.
- `SigLevel = PackageOptional DatabaseNever`: unsigned packages shipped today are accepted; any package that gains a signature is verified the moment it appears (a present-but-invalid signature is rejected, so a later compromise cannot strip signatures past an already-imported key); the stale database signature is skipped, which a plain `Optional` would find and reject.

**Residual risk, stated plainly:** until upstream signs its packages, this repository is accepted without authentication and origin compromise is still root on T2 machines. This PR cannot fix that; upstream signing can. Disclosed to security@omarchy.org.

## 2. `bin/omarchy-upgrade-to-quattro` — the bootstrap override outlives the keyring install

The upgrader regenerates the `[omarchy]` stanza with `SigLevel = Optional TrustAll` because the keyring package that provides trust arrives through the very repository it authenticates. #8072's migration strips that override on the *next* update pass — but everything the upgrader itself installs in between (hardware transition packages, the entire `install_omarchy_quattro_packages` set) happens unauthenticated.

New `require_signed_omarchy_repo()` runs immediately after `install_keyrings` and deletes the override line, so every later transaction in the upgrade verifies signatures like a normal post-#8072 machine. If the keyring failed to install, the override is left in place and the machine keeps working — the log says why.

## Tests

New `test/shell.d/t2-repo-signature-test.sh`:

- tree-wide guard: no repository stanza anywhere in `install/`, `default/`, `bin/` sets `SigLevel = Never`;
- behavioral, with mocked `lspci` (T2 PCI ids) and `pacman-key` (arg-validating: only the pinned fingerprint is accepted): stanza written with the armed policy, key imported from the keyserver and locally signed, write is idempotent on a second run;
- failure path: a `pacman-key` that fails leaves **no stanza** and exits non-zero;
- quattro guards: the override is still written (bootstrap), the removal step exists, and it runs on the line immediately after `install_keyrings`.

`upgrade-to-quattro-test.sh` passes unchanged (22/22). All touched scripts pass `bash -n`.

## Notes for reviewers

- The behavioral test reaches the install script through `OMARCHY_T2_PACMAN_CONF`, a one-variable seam so the test never touches the real `/etc/pacman.conf`; the variable is unset on real installs and the script writes `/etc/pacman.conf` exactly as before.
- The stanza keeps a plain heredoc; no shell expansion enters the config file.
- Key fingerprint source: fetched from keyserver.ubuntu.com and cross-checked against the `arch-mact2.db.sig` issuer keyid; the t2linux wiki documents the same identity.