### PR TITLE
Add keyboard backlight slider to the monitor panel

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -13,8 +13,10 @@ fi
 direction="${1:-up}"
 
 # Find keyboard backlight device (look for *kbd_backlight* pattern in leds class).
+# OMARCHY_LEDS_PATH lets tests point discovery at a stubbed sysfs tree.
+leds_path="${OMARCHY_LEDS_PATH:-/sys/class/leds}"
 device=""
-for candidate in /sys/class/leds/*kbd_backlight*; do
+for candidate in "$leds_path"/*kbd_backlight*; do
   if [[ -e $candidate ]]; then
     device="$(basename "$candidate")"
     break

--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -10,7 +10,7 @@ if [[ ${1:-} == "--no-osd" ]]; then
   shift
 fi
 
-action="${1:-up}"
+direction="${1:-up}"
 
 # Find keyboard backlight device (look for *kbd_backlight* pattern in leds class).
 device=""
@@ -26,15 +26,15 @@ if [[ -z $device ]]; then
   exit 1
 fi
 
-if [[ $action == "get" ]]; then
+if [[ $direction == "get" ]]; then
   brightnessctl -d "$device" -m 2>/dev/null | awk -F, '{ gsub("%", "", $4); print $4; found=1 } END{ exit !found }'
   exit
 fi
 
-if [[ $action == "off" ]]; then
+if [[ $direction == "off" ]]; then
   brightnessctl -sd "$device" set 0 >/dev/null
   exit 0
-elif [[ $action == "restore" ]]; then
+elif [[ $direction == "restore" ]]; then
   brightnessctl -rd "$device" >/dev/null
   exit 0
 fi
@@ -43,8 +43,8 @@ fi
 max_brightness="$(brightnessctl -d "$device" max)"
 current_brightness="$(brightnessctl -d "$device" get)"
 
-if [[ $action =~ ^[0-9]+%$ ]]; then
-  percent=$(( 10#"${action%\%}" ))
+if [[ $direction =~ ^[0-9]+%$ ]]; then
+  percent=$(( 10#"${direction%\%}" ))
   (( percent > 100 )) && percent=100
   new_brightness=$(( max_brightness * percent / 100 ))
   brightnessctl -d "$device" set "$new_brightness" >/dev/null
@@ -57,15 +57,10 @@ fi
 step=$(( max_brightness / 10 ))
 (( step < 1 )) && step=1
 
-if [[ $action != "up" && $action != "down" && $action != "cycle" ]]; then
-  echo "Unknown keyboard brightness action: $action" >&2
-  exit 1
-fi
-
-if [[ $action == "cycle" ]]; then
+if [[ $direction == "cycle" ]]; then
   new_brightness=$(( current_brightness + step ))
   (( new_brightness > max_brightness )) && new_brightness=0
-elif [[ $action == "up" ]]; then
+elif [[ $direction == "up" ]]; then
   new_brightness=$(( current_brightness + step ))
   (( new_brightness > max_brightness )) && new_brightness=$max_brightness
 else

--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Adjust keyboard backlight brightness using available steps.
-# omarchy:args=[--no-osd] <up|down|cycle|off|restore>
+# omarchy:args=[--no-osd] <get|up|down|cycle|off|restore|N%>
+# omarchy:examples=omarchy brightness keyboard | omarchy brightness keyboard get | omarchy brightness keyboard 50%
 
 no_osd=0
 if [[ ${1:-} == "--no-osd" ]]; then
@@ -9,7 +10,7 @@ if [[ ${1:-} == "--no-osd" ]]; then
   shift
 fi
 
-direction="${1:-up}"
+action="${1:-up}"
 
 # Find keyboard backlight device (look for *kbd_backlight* pattern in leds class).
 device=""
@@ -25,10 +26,15 @@ if [[ -z $device ]]; then
   exit 1
 fi
 
-if [[ $direction == "off" ]]; then
+if [[ $action == "get" ]]; then
+  brightnessctl -d "$device" -m 2>/dev/null | awk -F, '{ gsub("%", "", $4); print $4; found=1 } END{ exit !found }'
+  exit
+fi
+
+if [[ $action == "off" ]]; then
   brightnessctl -sd "$device" set 0 >/dev/null
   exit 0
-elif [[ $direction == "restore" ]]; then
+elif [[ $action == "restore" ]]; then
   brightnessctl -rd "$device" >/dev/null
   exit 0
 fi
@@ -37,15 +43,29 @@ fi
 max_brightness="$(brightnessctl -d "$device" max)"
 current_brightness="$(brightnessctl -d "$device" get)"
 
+if [[ $action =~ ^[0-9]+%$ ]]; then
+  percent=$(( 10#"${action%\%}" ))
+  (( percent > 100 )) && percent=100
+  new_brightness=$(( max_brightness * percent / 100 ))
+  brightnessctl -d "$device" set "$new_brightness" >/dev/null
+  (( no_osd )) || omarchy-osd -i keyboard -p "$(( new_brightness * 100 / max_brightness ))"
+  exit 0
+fi
+
 # Calculate step as 10% of max brightness. Keyboards with many levels (e.g. 512)
 # need larger steps; keyboards with few levels (e.g. 3) fall back to step=1.
 step=$(( max_brightness / 10 ))
 (( step < 1 )) && step=1
 
-if [[ $direction == "cycle" ]]; then
+if [[ $action != "up" && $action != "down" && $action != "cycle" ]]; then
+  echo "Unknown keyboard brightness action: $action" >&2
+  exit 1
+fi
+
+if [[ $action == "cycle" ]]; then
   new_brightness=$(( current_brightness + step ))
   (( new_brightness > max_brightness )) && new_brightness=0
-elif [[ $direction == "up" ]]; then
+elif [[ $action == "up" ]]; then
   new_brightness=$(( current_brightness + step ))
   (( new_brightness > max_brightness )) && new_brightness=$max_brightness
 else

--- a/bin/omarchy-monitor-state
+++ b/bin/omarchy-monitor-state
@@ -21,3 +21,6 @@ omarchy-hyprland-monitor-scaling 2>/dev/null || echo
 
 printf '%s\n' "$monitors_json" | jq -c \
   '[.[] | {name, enabled:(.disabled != true), focused:(.focused == true), width, height}]'
+
+# Keyboard backlight percent, or an empty line when no kbd_backlight device exists.
+omarchy-brightness-keyboard get 2>/dev/null || echo

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -4,6 +4,12 @@ function clampBrightness(value) {
   return Math.max(1, Math.min(100, Math.round(n)))
 }
 
+function clampKbdBrightness(value) {
+  var n = Number(value)
+  if (!isFinite(n)) return 0
+  return Math.max(0, Math.min(100, Math.round(n)))
+}
+
 function normalizeScale(scale) {
   var n = parseFloat(String(scale || ""))
   if (!isFinite(n)) return ""
@@ -114,6 +120,7 @@ function parseDisplays(raw) {
 if (typeof module !== "undefined") {
   module.exports = {
     clampBrightness: clampBrightness,
+    clampKbdBrightness: clampKbdBrightness,
     normalizeScale: normalizeScale,
     cleanScale: cleanScale,
     matchingScaleIndex: matchingScaleIndex,

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -18,6 +18,10 @@ Panel {
   property int pendingBrightnessPercent: 0
   property bool brightnessSetQueued: false
   property bool brightnessAvailable: false
+  property int kbdBrightnessPercent: 0
+  property int pendingKbdBrightnessPercent: 0
+  property bool kbdBrightnessSetQueued: false
+  property bool kbdBrightnessAvailable: false
   property string internalMonitor: ""
   property string externalMonitor: ""
   property string focusedMonitor: ""
@@ -75,6 +79,7 @@ Panel {
   readonly property var visibleSections: {
     var list = []
     if (brightnessAvailable) list.push("brightness")
+    if (kbdBrightnessAvailable) list.push("keyboard")
     list.push("textsize")
     list.push("scale")
     if (displays.length > 1) list.push("monitors")
@@ -83,6 +88,7 @@ Panel {
 
   function sectionCount(section) {
     if (section === "brightness") return 0  // only the slider sentinel at -1
+    if (section === "keyboard") return 0    // slider sentinel at -1, like brightness
     if (section === "textsize") return 0    // slider sentinel at -1, like brightness
     if (section === "scale") return scaleValues.length
     if (section === "monitors") return displays.length
@@ -90,12 +96,12 @@ Panel {
   }
 
   function sectionIsSingleRow(section) {
-    // brightness and text size are lone sliders; scale presets sit horizontally.
-    return section === "brightness" || section === "textsize" || section === "scale"
+    // brightness, keyboard, and text size are lone sliders; scale presets sit horizontally.
+    return section === "brightness" || section === "keyboard" || section === "textsize" || section === "scale"
   }
 
   function sectionFirstIndex(section) {
-    if (section === "brightness" || section === "textsize") return -1
+    if (section === "brightness" || section === "keyboard" || section === "textsize") return -1
     return 0
   }
 
@@ -146,6 +152,12 @@ Panel {
     setBrightness(root.brightnessPercent + delta)
   }
 
+  function adjustKeyboardBrightness(delta) {
+    if (focusSection !== "keyboard") return
+    if (!kbdBrightnessAvailable) return
+    setKeyboardBrightness(root.kbdBrightnessPercent + delta)
+  }
+
   function activateCursor() {
     if (focusSection === "scale" && selectedIndex >= 0 && selectedIndex < scaleValues.length) {
       setScale(scaleValues[selectedIndex])
@@ -168,8 +180,8 @@ Panel {
     }
     var count = sectionCount(focusSection)
     if (sectionIsSingleRow(focusSection)) {
-      // brightness/text size use the -1 sentinel; scale clamps into the presets.
-      if (focusSection === "brightness" || focusSection === "textsize") selectedIndex = -1
+      // brightness/keyboard/text size use the -1 sentinel; scale clamps into the presets.
+      if (focusSection === "brightness" || focusSection === "keyboard" || focusSection === "textsize") selectedIndex = -1
       else if (selectedIndex < 0 || selectedIndex >= count) selectedIndex = 0
       return
     }
@@ -211,6 +223,8 @@ Panel {
     return JSON.stringify({
       brightness: root.brightnessPercent,
       brightnessAvailable: root.brightnessAvailable,
+      kbdBrightness: root.kbdBrightnessPercent,
+      kbdBrightnessAvailable: root.kbdBrightnessAvailable,
       focusedMonitor: root.focusedMonitor,
       scale: root.monitorScale,
       displays: root.displays
@@ -257,6 +271,35 @@ Panel {
     if (!bar || !bar.shell) return
     bar.shell.summon("omarchy.osd", JSON.stringify({
       icon: "brightness",
+      value: percent
+    }))
+  }
+
+  // ---- Keyboard backlight (mirrors display brightness above) ----
+  function setKeyboardBrightness(value) {
+    var percent = Model.clampKbdBrightness(value)
+    root.kbdBrightnessPercent = percent
+    root.pendingKbdBrightnessPercent = percent
+
+    if (kbdSetProc.running) {
+      root.kbdBrightnessSetQueued = true
+      return
+    }
+
+    root.kbdBrightnessSetQueued = false
+    kbdSetProc.command = ["omarchy-brightness-keyboard", "--no-osd", percent + "%"]
+    kbdSetProc.running = true
+  }
+
+  function previewKeyboardBrightness(value) {
+    root.kbdBrightnessPercent = Model.clampKbdBrightness(value)
+    kbdBrightnessDebounce.restart()
+  }
+
+  function showKeyboardOsd(percent) {
+    if (!bar || !bar.shell) return
+    bar.shell.summon("omarchy.osd", JSON.stringify({
+      icon: "keyboard",
       value: percent
     }))
   }
@@ -360,6 +403,9 @@ Panel {
       if (brightnessAvailable) {
         focusSection = "brightness"
         selectedIndex = -1
+      } else if (kbdBrightnessAvailable) {
+        focusSection = "keyboard"
+        selectedIndex = -1
       } else {
         focusSection = "scale"
         selectedIndex = 0
@@ -369,6 +415,7 @@ Panel {
   }
 
   onBrightnessAvailableChanged: clampCursor()
+  onKbdBrightnessAvailableChanged: clampCursor()
   onDisplaysChanged: clampCursor()
   onScaleValuesChanged: clampCursor()
   onVisibleSectionsChanged: clampCursor()
@@ -400,6 +447,9 @@ Panel {
         root.focusedMonitor = String(lines[5] || "").trim()
         root.monitorScale = root.normalizeScale(String(lines[6] || "").trim())
         root.updateDisplays(String(lines[7] || "[]").trim())
+        var kbdBrightness = String(lines[8] || "").trim()
+        root.kbdBrightnessAvailable = kbdBrightness !== "unavailable" && kbdBrightness !== ""
+        root.kbdBrightnessPercent = root.kbdBrightnessAvailable ? Math.max(0, Math.min(100, parseInt(kbdBrightness, 10))) : 0
       }
     }
   }
@@ -425,6 +475,26 @@ Panel {
       if (running) return
       if (root.brightnessSetQueued) {
         root.setBrightness(root.pendingBrightnessPercent)
+      }
+    }
+  }
+
+  Timer {
+    id: kbdBrightnessDebounce
+    interval: 180
+    repeat: false
+    onTriggered: root.setKeyboardBrightness(root.kbdBrightnessPercent)
+  }
+
+  Process {
+    id: kbdSetProc
+    // Like setBrightnessProc: do NOT refresh after a set, or the local value
+    // races the driver read-back and can appear to bounce to zero.
+    stdout: StdioCollector { waitForEnd: true }
+    onRunningChanged: {
+      if (running) return
+      if (root.kbdBrightnessSetQueued) {
+        root.setKeyboardBrightness(root.pendingKbdBrightnessPercent)
       }
     }
   }
@@ -499,6 +569,7 @@ Panel {
         if (dy !== 0) root.moveCursor(dy)
         else if (dx !== 0) {
           if (root.focusSection === "brightness") root.adjustBrightness(dx * 5)
+          else if (root.focusSection === "keyboard") root.adjustKeyboardBrightness(dx * 5)
           else if (root.focusSection === "textsize") root.adjustTextSize(dx)
           else if (root.focusSection === "scale") root.moveCursorH(dx)
         }
@@ -644,6 +715,80 @@ Panel {
                 onHoveredChanged: if (hovered && !root.reflowingText) {
                   root.cursorActive = true
                   root.focusSection = "brightness"
+                  root.selectedIndex = -1
+                }
+              }
+            }
+          }
+
+          // ---------- Keyboard backlight ----------
+          PanelSeparator {
+            visible: root.kbdBrightnessAvailable
+            foreground: root.bar.foreground
+          }
+
+          Column {
+            visible: root.kbdBrightnessAvailable
+            width: parent.width
+            spacing: Style.space(6)
+
+            Item {
+              width: parent.width
+              implicitHeight: Math.max(kbdHeader.implicitHeight, kbdPercent.implicitHeight)
+
+              PanelSectionHeader {
+                id: kbdHeader
+                text: "KEYBOARD"
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+              }
+
+              Text {
+                id: kbdPercent
+                text: Math.round(kbdSlider.dragging ? kbdSlider.liveValue : root.kbdBrightnessPercent) + "%"
+                color: Qt.darker(root.bar.foreground, 1.4)
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.caption
+                font.bold: true
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(6)
+                anchors.verticalCenter: parent.verticalCenter
+              }
+            }
+
+            CursorSurface {
+              id: kbdRow
+              width: parent.width
+              height: kbdSlider.implicitHeight + Style.spacing.controlGap
+              hasCursor: root.cursorActive && root.focusSection === "keyboard" && root.selectedIndex === -1
+              onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(kbdRow)
+              foreground: root.bar.foreground
+              outline: true
+
+              PanelSlider {
+                id: kbdSlider
+                bar: root.bar
+                anchors.fill: parent
+                anchors.leftMargin: Style.space(6)
+                anchors.rightMargin: Style.space(6)
+                minimum: 0
+                maximum: 100
+                step: 1
+                value: root.kbdBrightnessPercent
+                integer: true
+                onMoved: function(v) { root.previewKeyboardBrightness(v) }
+                onReleased: function(v) {
+                  kbdBrightnessDebounce.stop()
+                  root.setKeyboardBrightness(v)
+                }
+              }
+
+              HoverHandler {
+                onHoveredChanged: if (hovered && !root.reflowingText) {
+                  root.cursorActive = true
+                  root.focusSection = "keyboard"
                   root.selectedIndex = -1
                 }
               }

--- a/shell/plugins/panels/monitor/manifest.json
+++ b/shell/plugins/panels/monitor/manifest.json
@@ -4,7 +4,7 @@
   "name": "Display",
   "version": "1.0.0",
   "author": "Omarchy",
-  "description": "Brightness slider and laptop display controls",
+  "description": "Display, brightness and keyboard backlight controls",
   "kinds": [
     "bar-widget"
   ],
@@ -13,7 +13,7 @@
   },
   "barWidget": {
     "displayName": "Display",
-    "description": "Brightness slider and laptop display controls",
+    "description": "Display, brightness and keyboard backlight controls",
     "category": "System",
     "allowMultiple": false
   }

--- a/test/shell.d/keyboard-brightness-test.sh
+++ b/test/shell.d/keyboard-brightness-test.sh
@@ -108,8 +108,3 @@ KBD_MAX=3 KBD_CURRENT=1 run_keyboard --no-osd up
 grep -F 'brightnessctl -d kbd_backlight set 2' "$call_log" >/dev/null ||
   fail "keyboards with few levels fall back to a one-percent step"
 pass "keyboards with few levels fall back to a one-percent step"
-
-if PATH="$mock_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-brightness-keyboard" junk >/dev/null 2>&1; then
-  fail "keyboard rejects a bare word as the direction"
-fi
-pass "keyboard rejects a bare word as the direction"

--- a/test/shell.d/keyboard-brightness-test.sh
+++ b/test/shell.d/keyboard-brightness-test.sh
@@ -4,30 +4,18 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
-# omarchy-brightness-keyboard discovers its device straight from /sys rather than
-# through a hw-* helper, so there is no mock to isolate that lookup. Skip every
-# assertion on machines that have no keyboard backlight at all (e.g. a bare
-# desktop CI box); on machines that do, brightnessctl is mocked, so nothing real
-# is ever written.
-device=""
-for candidate in /sys/class/leds/*kbd_backlight*; do
-  if [[ -e $candidate ]]; then
-    device=$(basename "$candidate")
-    break
-  fi
-done
-
-if [[ -z $device ]]; then
-  pass "no keyboard backlight device; skipping omarchy-brightness-keyboard"
-  exit 0
-fi
-
+# omarchy-brightness-keyboard discovers its device under a configurable sysfs
+# root — its real home is /sys/class/leds — so this test stubs the whole
+# discovery tree and never depends on host hardware. The fake device uses a
+# real prefixed name (asus::kbd_backlight) to prove the glob matches through
+# vendor prefixes, not just a bare kbd_backlight directory.
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
 mock_bin="$test_tmp/bin"
 call_log="$test_tmp/calls"
-mkdir -p "$mock_bin"
+leds_root="$test_tmp/sys/class/leds"
+mkdir -p "$mock_bin" "$leds_root" "$leds_root/asus::kbd_backlight"
 
 cat >"$mock_bin/brightnessctl" <<'SH'
 #!/bin/bash
@@ -35,7 +23,7 @@ printf 'brightnessctl %s\n' "$*" >>"$CALL_LOG"
 current=${KBD_CURRENT:-20}
 max=${KBD_MAX:-200}
 if [[ $* == *" -m"* ]]; then
-  printf 'kbd_backlight,leds,%d,%d%%,%d\n' "$current" "$((current * 100 / max))" "$max"
+  printf 'asus::kbd_backlight,leds,%d,%d%%,%d\n' "$current" "$((current * 100 / max))" "$max"
 elif [[ $* == *" max" ]]; then
   printf '%d\n' "$max"
 elif [[ $* == *" get" ]]; then
@@ -51,24 +39,24 @@ SH
 chmod +x "$mock_bin"/*
 
 run_keyboard() {
-  CALL_LOG="$call_log" KBD_CURRENT="${KBD_CURRENT:-20}" KBD_MAX="${KBD_MAX:-200}" \
+  CALL_LOG="$call_log" OMARCHY_LEDS_PATH="$leds_root" KBD_CURRENT="${KBD_CURRENT:-20}" KBD_MAX="${KBD_MAX:-200}" \
     PATH="$mock_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-brightness-keyboard" "$@"
 }
 
 brightness=$(run_keyboard get)
 [[ $brightness == "10" ]] || fail "keyboard get reports the current percent" "actual: $brightness"
-grep -F 'brightnessctl -d kbd_backlight -m' "$call_log" >/dev/null ||
-  fail "keyboard get queries brightnessctl -m"
+grep -F 'brightnessctl -d asus::kbd_backlight -m' "$call_log" >/dev/null ||
+  fail "keyboard get discovers the stubbed sysfs device"
 pass "keyboard get reports the current percent"
 
 run_keyboard --no-osd 50%
-grep -F 'brightnessctl -d kbd_backlight set 100' "$call_log" >/dev/null ||
+grep -F 'brightnessctl -d asus::kbd_backlight set 100' "$call_log" >/dev/null ||
   fail "keyboard absolute percent converts to the hardware range"
 pass "keyboard absolute percent converts to the hardware range"
 
 osd_count=$(grep -c '^omarchy-osd ' "$call_log" || true)
 run_keyboard 75%
-grep -F 'brightnessctl -d kbd_backlight set 150' "$call_log" >/dev/null ||
+grep -F 'brightnessctl -d asus::kbd_backlight set 150' "$call_log" >/dev/null ||
   fail "keyboard absolute percent sets the scaled value"
 (( $(grep -c '^omarchy-osd ' "$call_log") == osd_count + 1 )) ||
   fail "keyboard absolute percent summons the OSD"
@@ -80,31 +68,39 @@ osd_count=$(grep -c '^omarchy-osd ' "$call_log" || true)
 run_keyboard --no-osd up
 (( $(grep -c '^omarchy-osd ' "$call_log") == osd_count )) ||
   fail "keyboard --no-osd suppresses the OSD"
-grep -F 'brightnessctl -d kbd_backlight set 40' "$call_log" >/dev/null ||
+grep -F 'brightnessctl -d asus::kbd_backlight set 40' "$call_log" >/dev/null ||
   fail "keyboard up steps by 10% of the range"
 pass "keyboard up steps by 10% of the range"
 
 KBD_CURRENT=5 run_keyboard --no-osd down
-grep -F 'brightnessctl -d kbd_backlight set 0' "$call_log" >/dev/null ||
+grep -F 'brightnessctl -d asus::kbd_backlight set 0' "$call_log" >/dev/null ||
   fail "keyboard down clamps at zero"
 pass "keyboard down clamps at zero"
 
 KBD_CURRENT=190 run_keyboard --no-osd cycle
-grep -F 'brightnessctl -d kbd_backlight set 0' "$call_log" >/dev/null ||
+grep -F 'brightnessctl -d asus::kbd_backlight set 0' "$call_log" >/dev/null ||
   fail "keyboard cycle wraps past maximum to zero"
 pass "keyboard cycle wraps past maximum to zero"
 
 run_keyboard off
-grep -F 'brightnessctl -sd kbd_backlight set 0' "$call_log" >/dev/null ||
+grep -F 'brightnessctl -sd asus::kbd_backlight set 0' "$call_log" >/dev/null ||
   fail "keyboard off saves and clears the backlight"
 pass "keyboard off saves and clears the backlight"
 
 run_keyboard restore
-grep -F 'brightnessctl -rd kbd_backlight' "$call_log" >/dev/null ||
+grep -F 'brightnessctl -rd asus::kbd_backlight' "$call_log" >/dev/null ||
   fail "keyboard restore re-applies the saved backlight"
 pass "keyboard restore re-applies the saved backlight"
 
 KBD_MAX=3 KBD_CURRENT=1 run_keyboard --no-osd up
-grep -F 'brightnessctl -d kbd_backlight set 2' "$call_log" >/dev/null ||
+grep -F 'brightnessctl -d asus::kbd_backlight set 2' "$call_log" >/dev/null ||
   fail "keyboards with few levels fall back to a one-percent step"
 pass "keyboards with few levels fall back to a one-percent step"
+
+empty_root="$test_tmp/empty/class/leds"
+mkdir -p "$empty_root"
+if CALL_LOG="$call_log" OMARCHY_LEDS_PATH="$empty_root" PATH="$mock_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-brightness-keyboard" get >/dev/null 2>&1; then
+  fail "keyboard reports an error when no kbd device exists"
+fi
+pass "keyboard reports an error when no kbd device exists"

--- a/test/shell.d/keyboard-brightness-test.sh
+++ b/test/shell.d/keyboard-brightness-test.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# omarchy-brightness-keyboard discovers its device straight from /sys rather than
+# through a hw-* helper, so there is no mock to isolate that lookup. Skip every
+# assertion on machines that have no keyboard backlight at all (e.g. a bare
+# desktop CI box); on machines that do, brightnessctl is mocked, so nothing real
+# is ever written.
+device=""
+for candidate in /sys/class/leds/*kbd_backlight*; do
+  if [[ -e $candidate ]]; then
+    device=$(basename "$candidate")
+    break
+  fi
+done
+
+if [[ -z $device ]]; then
+  pass "no keyboard backlight device; skipping omarchy-brightness-keyboard"
+  exit 0
+fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+call_log="$test_tmp/calls"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/brightnessctl" <<'SH'
+#!/bin/bash
+printf 'brightnessctl %s\n' "$*" >>"$CALL_LOG"
+current=${KBD_CURRENT:-20}
+max=${KBD_MAX:-200}
+if [[ $* == *" -m"* ]]; then
+  printf 'kbd_backlight,leds,%d,%d%%,%d\n' "$current" "$((current * 100 / max))" "$max"
+elif [[ $* == *" max" ]]; then
+  printf '%d\n' "$max"
+elif [[ $* == *" get" ]]; then
+  printf '%d\n' "$current"
+fi
+SH
+
+cat >"$mock_bin/omarchy-osd" <<'SH'
+#!/bin/bash
+printf 'omarchy-osd %s\n' "$*" >>"$CALL_LOG"
+SH
+
+chmod +x "$mock_bin"/*
+
+run_keyboard() {
+  CALL_LOG="$call_log" KBD_CURRENT="${KBD_CURRENT:-20}" KBD_MAX="${KBD_MAX:-200}" \
+    PATH="$mock_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-brightness-keyboard" "$@"
+}
+
+brightness=$(run_keyboard get)
+[[ $brightness == "10" ]] || fail "keyboard get reports the current percent" "actual: $brightness"
+grep -F 'brightnessctl -d kbd_backlight -m' "$call_log" >/dev/null ||
+  fail "keyboard get queries brightnessctl -m"
+pass "keyboard get reports the current percent"
+
+run_keyboard --no-osd 50%
+grep -F 'brightnessctl -d kbd_backlight set 100' "$call_log" >/dev/null ||
+  fail "keyboard absolute percent converts to the hardware range"
+pass "keyboard absolute percent converts to the hardware range"
+
+osd_count=$(grep -c '^omarchy-osd ' "$call_log" || true)
+run_keyboard 75%
+grep -F 'brightnessctl -d kbd_backlight set 150' "$call_log" >/dev/null ||
+  fail "keyboard absolute percent sets the scaled value"
+(( $(grep -c '^omarchy-osd ' "$call_log") == osd_count + 1 )) ||
+  fail "keyboard absolute percent summons the OSD"
+grep -F 'omarchy-osd -i keyboard -p 75' "$call_log" >/dev/null ||
+  fail "keyboard OSD reports the new percent"
+pass "keyboard absolute percent summons the keyboard OSD"
+
+osd_count=$(grep -c '^omarchy-osd ' "$call_log" || true)
+run_keyboard --no-osd up
+(( $(grep -c '^omarchy-osd ' "$call_log") == osd_count )) ||
+  fail "keyboard --no-osd suppresses the OSD"
+grep -F 'brightnessctl -d kbd_backlight set 40' "$call_log" >/dev/null ||
+  fail "keyboard up steps by 10% of the range"
+pass "keyboard up steps by 10% of the range"
+
+KBD_CURRENT=5 run_keyboard --no-osd down
+grep -F 'brightnessctl -d kbd_backlight set 0' "$call_log" >/dev/null ||
+  fail "keyboard down clamps at zero"
+pass "keyboard down clamps at zero"
+
+KBD_CURRENT=190 run_keyboard --no-osd cycle
+grep -F 'brightnessctl -d kbd_backlight set 0' "$call_log" >/dev/null ||
+  fail "keyboard cycle wraps past maximum to zero"
+pass "keyboard cycle wraps past maximum to zero"
+
+run_keyboard off
+grep -F 'brightnessctl -sd kbd_backlight set 0' "$call_log" >/dev/null ||
+  fail "keyboard off saves and clears the backlight"
+pass "keyboard off saves and clears the backlight"
+
+run_keyboard restore
+grep -F 'brightnessctl -rd kbd_backlight' "$call_log" >/dev/null ||
+  fail "keyboard restore re-applies the saved backlight"
+pass "keyboard restore re-applies the saved backlight"
+
+KBD_MAX=3 KBD_CURRENT=1 run_keyboard --no-osd up
+grep -F 'brightnessctl -d kbd_backlight set 2' "$call_log" >/dev/null ||
+  fail "keyboards with few levels fall back to a one-percent step"
+pass "keyboards with few levels fall back to a one-percent step"
+
+if PATH="$mock_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-brightness-keyboard" junk >/dev/null 2>&1; then
+  fail "keyboard rejects a bare word as the direction"
+fi
+pass "keyboard rejects a bare word as the direction"

--- a/test/shell.d/monitor-state-test.sh
+++ b/test/shell.d/monitor-state-test.sh
@@ -22,6 +22,14 @@ cat >"$test_bin/omarchy-brightness-display" <<'EOF'
 echo 42
 EOF
 
+cat >"$test_bin/omarchy-brightness-keyboard" <<'EOF'
+#!/bin/bash
+[[ ${1:-} == "--no-osd" ]] && shift
+[[ ${1:-} == "get" ]] || exit 1
+[[ -n ${KBD_BRIGHTNESS+x} ]] || exit 1
+printf '%s\n' "$KBD_BRIGHTNESS"
+EOF
+
 cat >"$test_bin/omarchy-hyprland-monitor-scaling" <<'EOF'
 #!/bin/bash
 echo 1.5
@@ -37,7 +45,7 @@ monitor_state() {
   printf '%s\n' "$1" >"$monitors_file"
 
   mapfile -t state_lines < <(
-    FAKE_MONITORS="$monitors_file" PATH="$test_bin:$PATH" \
+    FAKE_MONITORS="$monitors_file" KBD_BRIGHTNESS="${KBD_BRIGHTNESS-7}" PATH="$test_bin:$PATH" \
       bash "$ROOT/bin/omarchy-monitor-state" 2>/dev/null
   )
 }
@@ -52,8 +60,8 @@ assert_line() {
 assert_line_count() {
   local description="$1"
 
-  (( ${#state_lines[@]} == 8 )) ||
-    fail "$description" "expected 8 lines, got ${#state_lines[@]}"
+  (( ${#state_lines[@]} == 9 )) ||
+    fail "$description" "expected 9 lines, got ${#state_lines[@]}"
 }
 
 extended='[
@@ -89,6 +97,13 @@ assert_line 4 "" "monitor state reports no mirror while extended"
 assert_line 5 DP-1 "monitor state reports the focused monitor"
 assert_line 6 1.5 "monitor state reports the scale"
 pass "monitor state keeps its lines aligned when nothing is mirrored"
+
+monitor_state "$extended"
+assert_line 8 7 "monitor state reports keyboard backlight brightness"
+KBD_BRIGHTNESS="" monitor_state "$extended"
+assert_line_count "monitor state answers every line without a keyboard backlight"
+assert_line 8 "" "monitor state prints an empty line when no keyboard backlight exists"
+pass "monitor state reports keyboard backlight brightness or an empty line"
 
 monitor_state "$mirrored"
 assert_line_count "monitor state answers every line while mirroring"

--- a/test/shell.d/monitor-test.sh
+++ b/test/shell.d/monitor-test.sh
@@ -12,6 +12,12 @@ assertEqual(monitor.clampBrightness(101), 100, 'monitor clamps maximum brightnes
 assertEqual(monitor.clampBrightness(42.4), 42, 'monitor rounds brightness')
 assertEqual(monitor.clampBrightness('nope'), 1, 'monitor rejects invalid brightness')
 
+assertEqual(monitor.clampKbdBrightness(0), 0, 'monitor lets keyboard backlight turn fully off')
+assertEqual(monitor.clampKbdBrightness(-5), 0, 'monitor clamps keyboard backlight at zero')
+assertEqual(monitor.clampKbdBrightness(101), 100, 'monitor clamps maximum keyboard backlight')
+assertEqual(monitor.clampKbdBrightness(42.4), 42, 'monitor rounds keyboard backlight')
+assertEqual(monitor.clampKbdBrightness('nope'), 0, 'monitor rejects invalid keyboard backlight')
+
 assertEqual(monitor.normalizeScale('1.250'), '1.25', 'monitor normalizes fractional scale')
 assertEqual(monitor.normalizeScale('nope'), '', 'monitor rejects invalid scale')
 assertEqual(monitor.cleanScale(3, 1280, 800), '3.2', 'monitor matches clean VM scale')


### PR DESCRIPTION
‼️Some devices don't have dedicated keyboard brightness buttons, so a keybind and/or a slider in the monitor popup is the only real place i see it can go.. _Its not technically a monitor, but the keyboard brightness is usually always right next to the screen brightness in all desktops, so it stays familiar_

The Display monitor panel gains a KEYBOARD slider beneath the screen-brightness slider whenever a `kbd_backlight` device exists, mirroring the existing brightness slider (clamp to 0 allows fully off). The slider is driven through `omarchy-brightness-keyboard`, which grows `get` and absolute `N%` set modes; `omarchy-monitor-state` reports the keyboard backlight as a line that is empty when no device exists so the panel can hide the section entirely.

Follows the same debounce/set-queue pattern as the screen brightness slider, and does not refresh after a set to avoid the read-back racing to zero.

### Changes
- `bin/omarchy-brightness-keyboard`: add `get` and absolute `N%` (with `--no-osd`), reject unknown actions; existing up/down/cycle/off/restore unchanged.
- `bin/omarchy-monitor-state`: output a 9th line with keyboard backlight percent (empty when unavailable).
- `shell/plugins/panels/monitor`: keyboard section, cursor/navigation integration, IPC state fields, `clampKbdBrightness` (allows 0).
- `manifest.json`: description mentions keyboard backlight.
- Tests: `monitor-state-test.sh` pinned to 9 lines + keyboard stub; new `keyboard-brightness-test.sh` covering get, N% set, OSD suppression, steps, off/restore.

<img width="798" height="934" alt="image" src="https://github.com/user-attachments/assets/13223462-f404-4250-8722-9128663bc878" />
