### PR TITLE
Skip powerprofilesctl when daemon is down

### DIFF
--- a/bin/omarchy-powerprofiles-list
+++ b/bin/omarchy-powerprofiles-list
@@ -8,6 +8,11 @@ if [[ ${1:-} != "" && ${1:-} != "--active-state" ]]; then
   exit 1
 fi
 
+# TLP masks power-profiles-daemon; calling powerprofilesctl then SIGABRTs.
+if ! systemctl is-active --quiet power-profiles-daemon.service; then
+  exit 0
+fi
+
 powerprofilesctl list 2>/dev/null |
   awk -v with_state="${1:+1}" '/^\s*[* ]\s*[a-zA-Z0-9-]+:$/ {
     active = ($1 == "*") ? 1 : 0

--- a/bin/omarchy-powerprofiles-set
+++ b/bin/omarchy-powerprofiles-set
@@ -27,6 +27,11 @@ case "$action" in
   *) usage ;;
 esac
 
+# TLP masks power-profiles-daemon; calling powerprofilesctl then SIGABRTs.
+if ! systemctl is-active --quiet power-profiles-daemon.service; then
+  exit 0
+fi
+
 mapfile -t profiles < <(omarchy-powerprofiles-list)
 
 profile_available() {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -274,7 +274,7 @@ Item {
       actionFor: function(value) { return "omarchy-font-set " + Util.shellQuote(value) }
     },
     "power-profiles": {
-      script: "current=$(powerprofilesctl get 2>/dev/null); omarchy-powerprofiles-list 2>/dev/null | while read -r p; do [[ -z $p ]] && continue; printf '%s\\t%s\\t%s\\n' \"$p\" \"$p\" \"$current\"; done",
+      script: "current=$(omarchy-powerprofiles-list --active-state 2>/dev/null | awk '$2==1{print $1;exit}'); omarchy-powerprofiles-list 2>/dev/null | while read -r p; do [[ -z $p ]] && continue; printf '%s\\t%s\\t%s\\n' \"$p\" \"$p\" \"$current\"; done",
       icon: "\udb81\udc0b",
       actionFor: function(value) { return "omarchy-powerprofiles-set autodetect " + Util.shellQuote(value) }
     }

--- a/test/shell.d/powerprofiles-set-test.sh
+++ b/test/shell.d/powerprofiles-set-test.sh
@@ -32,6 +32,17 @@ fi
 EOF
 chmod +x "$tmp_dir/bin/busctl"
 
+cat >"$tmp_dir/bin/systemctl" <<'EOF'
+#!/bin/bash
+
+if [[ $1 == "is-active" ]]; then
+  [[ ${PPD_ACTIVE:-1} == "1" ]] || exit 1
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$tmp_dir/bin/systemctl"
+
 export PATH="$tmp_dir/bin:$ROOT/bin:$PATH"
 export POWERPROFILES_LOG="$tmp_dir/calls"
 export OMARCHY_POWERPROFILES_STATE_DIR="$tmp_dir/state"
@@ -80,3 +91,17 @@ pass "battery service applies profiles through Omarchy command"
 rg -F 'omarchy-powerprofiles-set autodetect' "$ROOT/shell/plugins/menu/Menu.qml" >/dev/null ||
   fail "power profile menu persists selections through Omarchy command"
 pass "power profile menu persists selections through Omarchy command"
+
+if rg -F 'powerprofilesctl' "$ROOT/shell/plugins/menu/Menu.qml" >/dev/null; then
+  fail "power profile menu still calls powerprofilesctl"
+fi
+pass "power profile menu lists profiles through Omarchy command"
+
+: >"$tmp_dir/calls"
+PPD_ACTIVE=0 "$ROOT/bin/omarchy-powerprofiles-set" ac performance
+[[ ! -s $tmp_dir/calls ]] || fail "power profile still calls powerprofilesctl when the daemon is inactive"
+[[ ! -f $tmp_dir/state/ac ]] || [[ $(<"$tmp_dir/state/ac") != "performance" ]] || fail "power profile persisted a selection while the daemon was inactive"
+pass "power profile skips set when the daemon is inactive"
+
+[[ -z $(PPD_ACTIVE=0 "$ROOT/bin/omarchy-powerprofiles-list") ]] || fail "power profile list is not empty when the daemon is inactive"
+pass "power profile list skips when the daemon is inactive"


### PR DESCRIPTION
**What**: Do not call `powerprofilesctl` when `power-profiles-daemon` is inactive.

**Why**: Fixes #8596. TLP masks the daemon; `powerprofilesctl` then SIGABRTs, which takes down the battery plugin and the power-profile menu. No EPP fallback in this PR.

**How**: `systemctl is-active --quiet power-profiles-daemon.service` in `omarchy-powerprofiles-list` and `omarchy-powerprofiles-set` (exit 0 if down). Menu current-profile read now uses `omarchy-powerprofiles-list --active-state` instead of `powerprofilesctl get`. Rejected guarding only QML: Panel/battery go through the wrappers.

**Verified**:
- `bash -n` on list, set, and the test
- stubbed skip: inactive set exits 0, writes no `powerprofilesctl set`, no state file; inactive list is empty; active set still applies
- Menu.qml no longer contains `powerprofilesctl`
- existing set/restore/init assertions in `powerprofiles-set-test.sh` passed
- issue comment: https://github.com/basecamp/omarchy/issues/8596#issuecomment-5447823228

**NOT verified**:
- live TLP / masked `power-profiles-daemon` (Windows; no systemd)
- menu rendering / `omarchy-restart-shell` (no Hyprland/Quickshell)
- full `powerprofiles-set-test.sh` `rg` of QML paths (Windows path mapping)
- `test/all`, pacman, omarchy-iso