### PR TITLE
Resolve through EasyEffects to its configured output device

### DIFF
--- a/bin/omarchy-audio-output-sink
+++ b/bin/omarchy-audio-output-sink
@@ -50,6 +50,19 @@ if [[ -n $downstream ]]; then
   fi
 fi
 
+# EasyEffects can forward to its output device through direct PipeWire node
+# links, which never appear as PulseAudio sink-inputs at all -- and those links
+# only exist while audio flows. Its configured output device is persisted in
+# easyeffectsrc, so read the physical sink from there.
+if [[ $sink == easyeffects_sink ]]; then
+  ee_rc="${XDG_CONFIG_HOME:-$HOME/.config}/easyeffects/db/easyeffectsrc"
+  ee_device="$(awk -F= '/^outputDevice=/ {print $2; exit}' "$ee_rc" 2>/dev/null)"
+  if [[ -n $ee_device ]] && pactl list sinks short 2>/dev/null | awk '{print $2}' | grep -qxF "$ee_device"; then
+    printf '%s\n' "$ee_device"
+    exit 0
+  fi
+fi
+
 # Nothing resolvable downstream -- the DSP sink may simply be idle and unlinked.
 # Fall back to the sink itself so callers still have something to act on.
 printf '%s\n' "$sink"


### PR DESCRIPTION
## Problem

With Easy Effects as the default output ("Process all outputs"), the volume keys, the OSD, and the audio panel slider adjust the **virtual** `easyeffects_sink` instead of the physical sink:

- **Loudness doesn't change.** With a dynamics plugin in the chain (e.g. `autogain`), the input-level change is normalized away -- the OSD moves while the speakers stay exactly as loud.

## Root cause

`omarchy-audio-output-sink` resolves a DSP sink's physical output by scanning `pactl list sink-inputs` for the forwarding stream (matching the sink name, or `application.name = "EasyEffects"`). Current EasyEffects forwards through **direct PipeWire node links** (`ee_soe_output_level:output_* -> alsa_output...:playback_*`), which never appear as PulseAudio sink-inputs at all. The scan finds nothing, so the script falls back to returning `easyeffects_sink` itself -- exactly the case the header comment warns about: *"the display moves while the speakers do not"*.

Verified live: during active playback through Easy Effects, `pactl list sink-inputs` shows only the apps playing **into** `easyeffects_sink`; no EasyEffects stream toward the physical sink exists.

## Fix

EasyEffects persists its configured output device in `~/.config/easyeffects/db/easyeffectsrc` (`[StreamOutputs] outputDevice=`). When the stream scan finds nothing and the selected sink is `easyeffects_sink`, read the physical sink from there:

- validated against the live sink list (`pactl list sinks short`), so a stale/unplugged device falls through to the existing fallback unchanged
- complements the existing EasyEffects stream matcher -- setups where the forwarding stream *does* appear keep working exactly as before
- works whether or not audio is currently flowing (the node links only exist during playback; the config is always there)

## Reproduction

```bash
# Easy Effects running, Process-all-outputs on, default output = Easy Effects Sink,
# EE output device = speakers, autogain (or any dynamics) in the chain
omarchy-audio-output-sink
# before: easyeffects_sink          <- virtual sink, wrong target for volume
# after:  alsa_output...Speaker__sink  <- physical sink

omarchy-audio-output-volume +5
# before: OSD moves, loudness unchanged (autogain normalizes it)
# after:  loudness actually changes, easyeffects_sink untouched
```

## Verification

| Case | Result |
|---|---|
| Default = Easy Effects Sink, playing | resolves to physical speaker, keys change real loudness |
| Default = Easy Effects Sink, idle (no links) | same, via persisted config |
| Default = physical sink (EE off) | unchanged (early return) |
| Missing/stale easyeffectsrc | falls back to previous behavior |
| omarchy speaker-tuning filter chain | unchanged (stream scan runs first) |

Tested on Omarchy 4.0.1 with Easy Effects 7.x, PipeWire/WirePlumber.