### PR TITLE
Reduce battery app-launch latency on Dell XPS 16

### DIFF
--- a/manual/36-system-sleep.md
+++ b/manual/36-system-sleep.md
@@ -8,6 +8,8 @@ On a laptop, Omarchy remembers your power profile separately for plugged in and 
 
 You can see what your machine offers with `omarchy powerprofiles list`, and set the one you want for the state you're currently in with `omarchy powerprofiles set autodetect power-saver`. To set the other state without unplugging anything, name it directly: `omarchy powerprofiles set battery power-saver`. Whatever you pick is what you'll get back the next time you're in that state.
 
+Power-profile names are policy labels; the actual CPU, firmware, fan, and responsiveness changes depend on the machine. If every app is slow to show its first window only while on battery, fully quit one app and compare its launch in Balanced and Performance. If the delay follows the profile, save the profile you prefer for battery use or install a hardware-specific provider or plugin. Never copy low-level sysfs values from another model.
+
 ### Toggle suspend
 
 You toggle suspend by running `omarchy toggle suspend` from the terminal. That just reveals/hides the option under _System_ (or `Super + Esc`), and then you can see if it works consistently on your system. If not, you can hide it again with the same command.


### PR DESCRIPTION
## Summary

- Explain that power-profile labels map to machine-specific firmware and driver behavior.
- Document a safe Balanced-versus-Performance check when every app is slow to show its first window only on battery.
- Point users to the remembered battery profile or a hardware-specific provider/plugin, and warn against copying low-level sysfs values across models.

## Why

Reports in #1684 mix launcher latency with a system-wide delay before unrelated apps become visible. On a tested Dell XPS 16 DA16260, literal 120 fps process-cold first-visible medians improved from 845 to 429 ms for Chrome, 389 to 206 ms for Ghostty, 702 to 367 ms for Nautilus, and 539 to 313 ms for Pulse when the battery Balanced policy was refined: 42–49% faster per app.

A separate six-block idle-power comparison estimated +0.167 W with a 95% interval of -0.009 to +0.342 W. That established neither a penalty nor a saving and is not a battery-runtime claim.

The measured low-level values are deliberately not included here: they are specific to the exact model and provider stack, and prior broad Intel integration in #5327 exposed regression risk. This change gives users the supported diagnosis and immediate workaround without changing defaults for unrelated hardware.

## Validation

- 108/108 accepted launch-screening trials across the full policy grid
- 32/32 accepted literal first-pixel A/B trials
- `git diff --check`
- `./test/all`: CLI passed; 202/207 shell test files passed. The five failures are local-environment checks unrelated to this docs-only change: missing `omarchy-pkgs` checkout (three), installed-command PATH isolation (one), and installed fastfetch config drift (one).

## Investigation credit

Investigation and validation were supported by OpenAI Codex (Sol model, Ultra reasoning effort) over roughly eight hours, including launch, 120 fps first-pixel, power, transition, and rollback testing.
