### PR TITLE
Add agent diagnostics, MCP inspection, and safe launch mode

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -7,6 +7,7 @@
 inline=false
 pick=false
 approval=auto
+approval_explicit=false
 
 # Flags only. A bare prompt would shadow the subcommands under this group, so
 # prompts go through omarchy-agent-prompt, which passes one here as --prompt.
@@ -21,11 +22,21 @@ while (($#)); do
       shift
       ;;
     --safe)
+      if [[ $approval_explicit == "true" && $approval != "safe" ]]; then
+        echo "Cannot combine --safe and --auto" >&2
+        exit 1
+      fi
       approval=safe
+      approval_explicit=true
       shift
       ;;
     --auto)
+      if [[ $approval_explicit == "true" && $approval != "auto" ]]; then
+        echo "Cannot combine --safe and --auto" >&2
+        exit 1
+      fi
       approval=auto
+      approval_explicit=true
       shift
       ;;
     --prompt)
@@ -94,7 +105,7 @@ claude)
   ;;
 grok)
   command=(grok)
-  [[ $approval == "auto" ]] && command+=(--permission-mode bypassPermissions)
+  [[ $approval == "auto" ]] && command+=(--always-approve)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;
 codex)

--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 # omarchy:summary=Launch the default coding agent in a terminal
-# omarchy:args=[--inline] [--pick]
-# omarchy:examples=omarchy agent | omarchy agent --inline
+# omarchy:args=[--inline] [--pick] [--safe|--auto]
+# omarchy:examples=omarchy agent | omarchy agent --safe | omarchy agent --inline
 
 inline=false
 pick=false
+approval=auto
 
 # Flags only. A bare prompt would shadow the subcommands under this group, so
 # prompts go through omarchy-agent-prompt, which passes one here as --prompt.
@@ -17,6 +18,14 @@ while (($#)); do
       ;;
     --pick)
       pick=true
+      shift
+      ;;
+    --safe)
+      approval=safe
+      shift
+      ;;
+    --auto)
+      approval=auto
       shift
       ;;
     --prompt)
@@ -55,15 +64,18 @@ fi
 # with its own spelling of "don't stop to ask". Pi and Ori have none to skip.
 case "$agent" in
 opencode)
-  command=(opencode --auto)
+  command=(opencode)
+  [[ $approval == "auto" ]] && command+=(--auto)
   [[ -n ${prompt:-} ]] && command+=(--prompt "$prompt")
   ;;
 agy)
-  command=(agy --dangerously-skip-permissions)
+  command=(agy)
+  [[ $approval == "auto" ]] && command+=(--dangerously-skip-permissions)
   [[ -n ${prompt:-} ]] && command+=(--prompt-interactive "$prompt")
   ;;
 copilot)
-  command=(copilot --allow-all)
+  command=(copilot)
+  [[ $approval == "auto" ]] && command+=(--allow-all)
   [[ -n ${prompt:-} ]] && command+=(--interactive "$prompt")
   ;;
 crush)
@@ -71,23 +83,28 @@ crush)
   if [[ -n ${prompt:-} ]]; then
     command=(crush run "$prompt")
   else
-    command=(crush --yolo)
+    command=(crush)
+    [[ $approval == "auto" ]] && command+=(--yolo)
   fi
   ;;
 claude)
-  command=(claude --permission-mode auto)
+  command=(claude)
+  [[ $approval == "auto" ]] && command+=(--permission-mode auto)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;
 grok)
-  command=(grok --permission-mode bypassPermissions)
+  command=(grok)
+  [[ $approval == "auto" ]] && command+=(--permission-mode bypassPermissions)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;
 codex)
-  command=(codex --approve-for-me)
+  command=(codex)
+  [[ $approval == "auto" ]] && command+=(--approve-for-me)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;
 omp)
-  command=(omp --auto-approve)
+  command=(omp)
+  [[ $approval == "auto" ]] && command+=(--auto-approve)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;
 ori)

--- a/bin/omarchy-agent-doctor
+++ b/bin/omarchy-agent-doctor
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+# omarchy:summary=Diagnose coding agent and skill setup
+# omarchy:args=[--json]
+
+set -uo pipefail
+
+json=false
+case ${1:-} in
+"") ;;
+--json) json=true ;;
+*)
+  echo "Usage: omarchy-agent-doctor [--json]" >&2
+  exit 1
+  ;;
+esac
+
+if (($# > 1)); then
+  echo "Usage: omarchy-agent-doctor [--json]" >&2
+  exit 1
+fi
+
+default_agent=""
+agent_binary=""
+agent_version=""
+binary_available=false
+declare -a instructions=()
+declare -a installed_skills=()
+declare -a broken_skills=()
+declare -a warnings=()
+
+agent_file="$HOME/.config/omarchy/defaults/agent"
+if [[ -f $agent_file ]]; then
+  read -r default_agent <"$agent_file" || true
+fi
+
+if [[ -n $default_agent ]]; then
+  if omarchy-cmd-present "$default_agent"; then
+    agent_binary=$(type -P -- "$default_agent" 2>/dev/null || true)
+    binary_available=true
+
+    # Mise lazy stubs can install software when invoked. Presence is useful on
+    # its own, but probing those wrappers would turn this diagnostic into a
+    # mutating command.
+    if ! grep -Eq '^[[:space:]]*mise (use|x) ' "$agent_binary" 2>/dev/null; then
+      agent_version=$(timeout 2 "$default_agent" --version 2>&1 | head -n 1 || true)
+      agent_version=${agent_version//$'\r'/}
+    fi
+  else
+    warnings+=("Default agent '$default_agent' is not available on PATH")
+  fi
+else
+  warnings+=("No default coding agent is configured")
+fi
+
+for instruction in AGENTS.md CLAUDE.md GEMINI.md; do
+  [[ -f $PWD/$instruction ]] && instructions+=("$instruction")
+done
+
+skill_source="$OMARCHY_PATH/default/agents/skills"
+skill_roots=(
+  "$HOME/.agents/skills"
+  "$HOME/.claude/skills"
+  "$HOME/.codex/skills"
+  "$HOME/.pi/agent/skills"
+  "$HOME/.gemini/config/skills"
+)
+
+for skill_root in "${skill_roots[@]}"; do
+  [[ -d $skill_root ]] || continue
+
+  while IFS= read -r -d '' skill; do
+    name=${skill##*/}
+    target=""
+    package_owned=false
+    broken=false
+
+    if [[ -L $skill ]]; then
+      # -m resolves relative targets lexically even when the destination is
+      # missing, so a broken packaged link can still be identified as owned.
+      target=$(readlink -m -- "$skill" 2>/dev/null || true)
+      if [[ ! -e $skill ]]; then
+        broken=true
+      fi
+      if [[ $target == "$skill_source"/* ]]; then
+        package_owned=true
+      fi
+    elif [[ -d $skill ]]; then
+      target=$(readlink -f -- "$skill" 2>/dev/null || true)
+    else
+      continue
+    fi
+
+    record="$skill_root"$'\t'"$name"$'\t'"$skill"$'\t'"$target"$'\t'"$package_owned"$'\t'"$broken"
+    installed_skills+=("$record")
+    if [[ $broken == "true" ]]; then
+      broken_skills+=("$record")
+      warnings+=("Broken skill link: $skill")
+    fi
+  done < <(find "$skill_root" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -print0 2>/dev/null | sort -z)
+done
+
+if [[ ! -d $skill_source ]]; then
+  warnings+=("Packaged Omarchy skills are unavailable at $skill_source")
+fi
+
+json_string() {
+  local value=$1
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\t'/\\t}
+  printf '"%s"' "$value"
+}
+
+json_string_array() {
+  local -n values=$1
+  local separator=""
+  local value
+  printf '['
+  for value in "${values[@]}"; do
+    printf '%s' "$separator"
+    json_string "$value"
+    separator=','
+  done
+  printf ']'
+}
+
+json_skill_array() {
+  local -n values=$1
+  local separator=""
+  local record root name path target package_owned broken
+  printf '['
+  for record in "${values[@]}"; do
+    IFS=$'\t' read -r root name path target package_owned broken <<<"$record"
+    printf '%s{' "$separator"
+    printf '"root":'; json_string "$root"
+    printf ',"name":'; json_string "$name"
+    printf ',"path":'; json_string "$path"
+    printf ',"target":'; json_string "$target"
+    printf ',"package_owned":%s,"broken":%s}' "$package_owned" "$broken"
+    separator=','
+  done
+  printf ']'
+}
+
+if [[ $json == "true" ]]; then
+  printf '{"default_agent":'; json_string "$default_agent"
+  printf ',"binary_available":%s,"binary_path":' "$binary_available"; json_string "$agent_binary"
+  printf ',"version":'; json_string "$agent_version"
+  printf ',"instruction_files":'; json_string_array instructions
+  printf ',"skills":{"installed":'; json_skill_array installed_skills
+  printf ',"broken":'; json_skill_array broken_skills
+  printf '},"warnings":'; json_string_array warnings
+  printf '}\n'
+else
+  printf 'Default agent: %s\n' "${default_agent:-not configured}"
+  printf 'Binary: %s\n' "${agent_binary:-not available}"
+  [[ -n $agent_version ]] && printf 'Version: %s\n' "$agent_version"
+  printf 'Instruction files: %s\n' "${instructions[*]:-none}"
+  printf 'Installed skill links: %d\n' "${#installed_skills[@]}"
+  printf 'Broken skill links: %d\n' "${#broken_skills[@]}"
+  for warning in "${warnings[@]}"; do
+    printf 'Warning: %s\n' "$warning"
+  done
+fi

--- a/bin/omarchy-agent-mcp
+++ b/bin/omarchy-agent-mcp
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+# omarchy:summary=Inspect coding-agent MCP configurations without exposing secrets
+# omarchy:args=<list|doctor> [--json]
+# omarchy:examples=omarchy agent mcp list --json | omarchy agent mcp doctor
+
+set -euo pipefail
+
+action=${1:-}
+[[ -n $action ]] && shift
+
+json=false
+while (($#)); do
+  case "$1" in
+  --json)
+    json=true
+    ;;
+  *)
+    echo "Unexpected argument: $1" >&2
+    exit 2
+    ;;
+  esac
+  shift
+done
+
+case "$action" in
+list | doctor) ;;
+*)
+  echo "Usage: omarchy agent mcp <list|doctor> [--json]" >&2
+  exit 2
+  ;;
+esac
+
+export OMARCHY_AGENT_MCP_ACTION="$action"
+export OMARCHY_AGENT_MCP_JSON="$json"
+
+python3 <<'PY'
+import json
+import os
+import pathlib
+import shutil
+import sys
+
+try:
+  import tomllib
+except ImportError:
+  tomllib = None
+
+home = pathlib.Path.home()
+cwd = pathlib.Path.cwd()
+
+# Omarchy can launch more agents than appear here. An omitted adapter is
+# reported honestly below instead of guessing at a vendor's private format.
+adapters = {
+  "agy": [(home / ".gemini/settings.json", "json", "mcpServers")],
+  "claude": [
+    (home / ".claude.json", "json", "mcpServers"),
+    (cwd / ".mcp.json", "json", "mcpServers"),
+  ],
+  "codex": [(home / ".codex/config.toml", "toml", "mcp_servers")],
+  "copilot": [(home / ".copilot/mcp-config.json", "json", "mcpServers")],
+  "crush": [(home / ".config/crush/crush.json", "json", "mcp")],
+  "opencode": [
+    (home / ".config/opencode/opencode.json", "json", "mcp"),
+    (home / ".config/opencode/opencode.jsonc", "jsonc", "mcp"),
+  ],
+}
+launchable = ("opencode", "agy", "copilot", "crush", "claude", "grok", "codex", "omp", "ori", "pi")
+
+def clean_jsonc(source):
+  output = []
+  index = 0
+  in_string = False
+  escaped = False
+  while index < len(source):
+    char = source[index]
+    following = source[index + 1] if index + 1 < len(source) else ""
+    if in_string:
+      output.append(char)
+      if escaped:
+        escaped = False
+      elif char == "\\":
+        escaped = True
+      elif char == '"':
+        in_string = False
+      index += 1
+      continue
+    if char == '"':
+      in_string = True
+      output.append(char)
+      index += 1
+    elif char == "/" and following == "/":
+      index += 2
+      while index < len(source) and source[index] not in "\r\n":
+        index += 1
+    elif char == "/" and following == "*":
+      index += 2
+      while index + 1 < len(source) and source[index:index + 2] != "*/":
+        index += 1
+      if index + 1 >= len(source):
+        raise ValueError("unterminated JSONC block comment")
+      index += 2
+    else:
+      output.append(char)
+      index += 1
+
+  # JSONC permits a comma before a closing object or array. At this point all
+  # comments are gone, so remove only commas whose next non-space byte closes.
+  cleaned = "".join(output)
+  output = []
+  in_string = False
+  escaped = False
+  for index, char in enumerate(cleaned):
+    if in_string:
+      output.append(char)
+      if escaped:
+        escaped = False
+      elif char == "\\":
+        escaped = True
+      elif char == '"':
+        in_string = False
+      continue
+    if char == '"':
+      in_string = True
+    if char == "," and cleaned[index + 1:].lstrip().startswith(("}", "]")):
+      continue
+    output.append(char)
+  return "".join(output)
+
+def read_config(path, kind):
+  with path.open("rb") as stream:
+    if kind == "toml":
+      if tomllib is None:
+        raise RuntimeError("Python TOML support is unavailable")
+      return tomllib.load(stream)
+    source = stream.read().decode("utf-8")
+    return json.loads(clean_jsonc(source) if kind == "jsonc" else source)
+
+agents = []
+servers = []
+issues = []
+for agent in launchable:
+  if shutil.which(agent) is None:
+    continue
+
+  specs = adapters.get(agent)
+  agent_result = {
+    "name": agent,
+    "adapter": "supported" if specs else "unsupported",
+    "configs": [],
+  }
+  agents.append(agent_result)
+  if specs is None:
+    continue
+
+  for path, kind, key in specs:
+    if not path.is_file():
+      continue
+    display_path = str(path)
+    agent_result["configs"].append(display_path)
+    try:
+      document = read_config(path, kind)
+      configured = document.get(key, {}) if isinstance(document, dict) else {}
+      if configured is None:
+        configured = {}
+      if not isinstance(configured, dict):
+        raise ValueError(f"{key} must be an object or table")
+      for name in sorted(configured):
+        servers.append({"agent": agent, "name": str(name), "config": display_path})
+    except (OSError, ValueError, RuntimeError) as error:
+      issues.append({"agent": agent, "config": display_path, "error": str(error)})
+
+result = {
+  "ok": not issues,
+  "agents": agents,
+  "servers": servers,
+  "issues": issues,
+}
+
+if os.environ["OMARCHY_AGENT_MCP_JSON"] == "true":
+  print(json.dumps(result, separators=(",", ":")))
+elif os.environ["OMARCHY_AGENT_MCP_ACTION"] == "list":
+  if servers:
+    for server in servers:
+      print(f'{server["agent"]}\t{server["name"]}\t{server["config"]}')
+  else:
+    print("No configured MCP servers found.")
+else:
+  supported = sum(agent["adapter"] == "supported" for agent in agents)
+  unsupported = [agent["name"] for agent in agents if agent["adapter"] == "unsupported"]
+  print(f"Installed agents: {len(agents)}")
+  print(f"Supported adapters: {supported}")
+  print(f"Configured MCP servers: {len(servers)}")
+  if unsupported:
+    print(f'Unsupported adapters: {", ".join(unsupported)}')
+  for issue in issues:
+    print(f'ERROR {issue["agent"]}: cannot inspect {issue["config"]}: {issue["error"]}')
+
+if os.environ["OMARCHY_AGENT_MCP_ACTION"] == "doctor" and issues:
+  sys.exit(1)
+PY

--- a/bin/omarchy-agent-prompt
+++ b/bin/omarchy-agent-prompt
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Launch the default coding agent with a prompt
-# omarchy:args=[--inline] <prompt...>
+# omarchy:args=[--inline] [--safe|--auto] <prompt...>
 # omarchy:examples=omarchy agent prompt "Review this project"
 
 # Prompts live here rather than on `omarchy agent`, where a bare prompt would
@@ -9,15 +9,15 @@
 
 set -euo pipefail
 
-inline=()
-if [[ ${1:-} == "--inline" ]]; then
-  inline=(--inline)
+launcher_args=()
+while [[ ${1:-} == "--inline" || ${1:-} == "--safe" || ${1:-} == "--auto" ]]; do
+  launcher_args+=("$1")
   shift
-fi
+done
 
 if (($# == 0)); then
-  echo "Usage: omarchy agent prompt [--inline] <prompt...>" >&2
+  echo "Usage: omarchy agent prompt [--inline] [--safe|--auto] <prompt...>" >&2
   exit 1
 fi
 
-exec omarchy-agent "${inline[@]}" --prompt "$*"
+exec omarchy-agent "${launcher_args[@]}" --prompt "$*"

--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -46,6 +46,7 @@ matching guide before starting:
 - [`theming.md`](theming.md) - themes, backgrounds, and fonts
 - [`hooks.md`](hooks.md) - automation hooks that run on system events
 - [`capture.md`](capture.md) - screenshots, screen recordings, OCR text capture, and file sharing
+- [`agents.md`](agents.md) - coding-agent instructions, launch safety, skills, and MCP diagnostics
 - [`contributing.md`](contributing.md) - reporting Omarchy bugs and submitting fixes upstream
 
 ## Critical Safety Rules
@@ -129,26 +130,7 @@ omarchy commands --json
 cat $(which omarchy-theme-set)
 ```
 
-### Command Groups
-
-Run `omarchy --help` for the full list. The most common groups:
-
-| Group | Purpose | Example |
-|-------|---------|---------|
-| `omarchy refresh` | Reset config to defaults (backs up first) | `omarchy refresh shell` |
-| `omarchy restart` | Restart a service/app | `omarchy restart shell` |
-| `omarchy toggle` | Toggle feature on/off | `omarchy toggle nightlight` |
-| `omarchy theme` | Theme management | `omarchy theme set <name>` |
-| `omarchy bar` | Bar layout and widgets | `omarchy bar move omarchy.clock --section right` |
-| `omarchy plugin` | Manage/clone shell plugins | `omarchy plugin clone omarchy.clock` |
-| `omarchy hook` | Install automation hooks | `omarchy hook install theme-set <script>` |
-| `omarchy install` | Install optional software / packages | `omarchy install docker dbs` |
-| `omarchy launch` | Launch apps | `omarchy launch browser` |
-| `omarchy capture` | Screenshots and recordings | `omarchy capture screenshot` |
-| `omarchy reminder` | Desktop notification reminders | `omarchy reminder 15 "Pickup Jack"` |
-| `omarchy pkg` | Package management | `omarchy pkg add <pkg>` |
-| `omarchy setup` | Interactive setup wizards | `omarchy setup security fingerprint` |
-| `omarchy update` | System updates | `omarchy update` |
+Do not copy the command catalog into instructions. Query `omarchy commands --json` when exact routes, arguments, aliases, or privilege requirements matter; it is the canonical machine-readable source and changes with the installed version.
 
 ## Configuration Locations
 
@@ -179,25 +161,30 @@ The Omarchy shell (bar, notifications, plugins, idle) is configured in
 
 ## Safe Customization Patterns
 
-### Edit User Config Directly
+### Edit User Config Transactionally
 
-For simple changes, edit files in `~/.config/`:
+Treat a config change as a small transaction, especially for Hyprland, terminal, shell JSON, and hooks:
 
 ```bash
 # 1. Read current config
 cat ~/.config/hypr/bindings.lua
 
-# 2. Backup before changes
+# 2. Record the resolved path and permissions; reject an unexpected symlink
+# 3. Backup before changes
 cp ~/.config/hypr/bindings.lua ~/.config/hypr/bindings.lua.bak.$(date +%s)
 
-# 3. Make changes with Edit tool
+# 4. Make the smallest user-owned change
 
-# 4. Apply changes
+# 5. Validate, apply/reload, and inspect runtime errors
 # - Hyprland: auto-reloads on save, but MUST validate with `hyprctl reload` and `hyprctl configerrors`
 # - Omarchy shell: shell.json and user plugin code under ~/.config/omarchy/plugins/ hot-reload on save
 # - Menus/launcher: ~/.config/omarchy/extensions/omarchy-menu.jsonc hot-reloads on save
 # - Terminals: apply with `omarchy restart terminal` (reloads running terminals; foot picks changes up in new windows)
+
+# 6. If validation fails, restore the backup, reload again, and report both the failure and backup path
 ```
+
+Preserve ownership and mode, prefer an atomic replacement over a partially written file, and never report success until the component-specific validation passes. Do not follow a symlink from a user config path into `/usr/share/omarchy/` or another package-owned location.
 
 ### Reset to Defaults -- ALWAYS SEEK USER CONFIRMATION BEFORE RUNNING
 
@@ -256,6 +243,7 @@ When user requests system changes:
 5. **Is it a package install?** Use `omarchy pkg add <pkgs...>` (or `omarchy pkg aur add <pkgs...>` for AUR-only packages)
 6. **Is it built-in shell/plugin code?** Follow [`plugins.md`](plugins.md); clone it with `omarchy plugin clone`, never edit the packaged copy
 7. **Unsure if command exists?** Run `omarchy commands` (or `omarchy <group> --help` for one group)
+8. **Is it agent, skill, or MCP setup?** Follow [`agents.md`](agents.md); distinguish packaged defaults from user-owned configuration and disclose the launch approval policy
 
 ### Reminder Requests
 

--- a/default/agents/skills/omarchy/agents.md
+++ b/default/agents/skills/omarchy/agents.md
@@ -1,0 +1,46 @@
+# Coding Agents
+
+Use this guide for the installed system's coding-agent launcher, repository instruction files, skills, and MCP setup. Query `omarchy commands --json` for the current CLI surface rather than copying its command catalog here.
+
+## Repository Instructions
+
+Before working in a repository, walk from the repository root toward the working directory and read the instruction files supported by the selected agent. Common entry points include `AGENTS.md` and `CLAUDE.md`; treat the repository's own file as authoritative about precedence. A small `AGENTS.md` may point to a canonical `CLAUDE.md` or another shared contract. Follow that pointer instead of restating its contents, because duplicated rules drift.
+
+Chat history is not durable shared state. Put facts that every future agent needs in a committed instruction or documentation file, and put task evidence in the repository's documented handoff location. Never put secrets, transient status, or machine-specific credentials in shared instructions.
+
+If two applicable instruction files conflict and neither declares precedence, stop and report the conflict. Do not guess which agent-specific file wins.
+
+## Launch Policy
+
+`omarchy agent` and `omarchy agent prompt` launch the configured default agent using Omarchy's autonomous approval profile. This is suitable only when the user has authorized autonomous changes within the current working directory and understands that the agent may act without pausing for each tool call.
+
+For an approval-first session, use `omarchy agent --safe` or `omarchy agent prompt --safe <prompt>`. Use `--auto` only when autonomous operation is explicitly appropriate. Query the current route metadata and help because supported flags may change with the installed version. If launching the selected agent's native CLI instead, omit auto-approval, bypass-permissions, and yolo flags and check that CLI's current help. State which policy is active before beginning consequential work.
+
+Keep authorization scope separate from persistence: autonomous mode does not authorize unrelated repositories, package-owned files, credential changes, deletion, publishing, or external messages.
+
+## Skills
+
+The Omarchy skill installed under `/usr/share/omarchy/default/agents/skills/` is package-owned. User-facing tasks may read it, but must not edit it; an update will overwrite local changes. Its links in agent-specific skill directories may be symlinks to that packaged copy, so resolve a path before editing.
+
+Develop a personal or experimental skill in a user-owned skill directory. Contribute improvements to the Omarchy source repository when they belong in the packaged skill. Avoid copying the packaged skill merely to patch it: two skills with the same purpose or name can confuse discovery and silently drift.
+
+## MCP Diagnostics
+
+Use the read-only `omarchy agent doctor`, `omarchy agent mcp list`, and `omarchy agent mcp doctor` diagnostics. Add `--json` when another tool will consume the result. Query their current help and JSON output rather than encoding their fields in this guide. They consolidate discovery but do not replace each agent's native configuration format:
+
+1. Identify the selected agent and confirm its binary and version.
+2. Run Omarchy's MCP list/doctor route, then use that agent's help when native detail is needed.
+3. Inspect configured server names, transports, executable paths or URLs, and required environment-variable names. Redact values.
+4. Check whether local executables exist, remote endpoints are reachable, and authentication is present without printing tokens.
+5. Separate “configured” from “reachable” and “authenticated” in the report.
+6. Make changes only in the selected agent's user-owned config, then rerun its diagnostics.
+
+Keep secrets in the agent's supported credential store or environment references, not literal values in repository instructions or portable MCP templates. When several agents need the same server, document the intended server and variable names once, but generate or maintain each agent's native configuration explicitly; do not assume their schemas or permission models are interchangeable.
+
+## Handoff Checklist
+
+- Name the selected agent, version, and active approval policy.
+- List the instruction files actually read and any declared precedence.
+- Report skills as packaged, user-owned, or broken links.
+- Report MCP servers separately as configured, reachable, and authenticated.
+- Record durable non-secret conclusions in the repository's canonical documentation.

--- a/default/agents/skills/omarchy/scripts/validate.py
+++ b/default/agents/skills/omarchy/scripts/validate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python3
+
+"""Validate the Omarchy end-user skill against its links and CLI metadata."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from urllib.parse import unquote
+
+
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+COMMAND_RE = re.compile(r"(?<![-\w/])omarchy(?:\s+(?:--?[A-Za-z0-9_.:/<>-]+|[A-Za-z0-9_.:/<>-]+))+")
+INLINE_CODE_RE = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
+
+
+def heading_anchor(value: str) -> str:
+    value = re.sub(r"[`*_~]", "", value.strip().lower())
+    value = re.sub(r"[^\w\- ]", "", value)
+    return re.sub(r"[\s-]+", "-", value).strip("-")
+
+
+def anchors(path: Path) -> set[str]:
+    return {
+        heading_anchor(match.group(1))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if (match := re.match(r"^#{1,6}\s+(.+?)\s*$", line))
+    }
+
+
+def load_metadata(root: Path, metadata_path: Path | None) -> dict:
+    if metadata_path:
+        return json.loads(metadata_path.read_text(encoding="utf-8"))
+    environment = os.environ.copy()
+    environment["OMARCHY_PATH"] = str(root)
+    result = subprocess.run(
+        ["bash", str(root / "bin/omarchy"), "commands", "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    return json.loads(result.stdout)
+
+
+def validate_links(markdown: Path, skill_dir: Path) -> list[str]:
+    errors = []
+    for raw in LINK_RE.findall(markdown.read_text(encoding="utf-8")):
+        destination = raw.split(maxsplit=1)[0].strip("<>")
+        if re.match(r"^[a-z][a-z0-9+.-]*:", destination) or destination.startswith("#"):
+            continue
+        path_text, _, fragment = destination.partition("#")
+        target = (markdown.parent / unquote(path_text)).resolve()
+        try:
+            target.relative_to(skill_dir.resolve())
+        except ValueError:
+            errors.append(f"{markdown}: link escapes skill directory: {destination}")
+            continue
+        if not target.is_file():
+            errors.append(f"{markdown}: missing link target: {destination}")
+        elif fragment and unquote(fragment) not in anchors(target):
+            errors.append(f"{markdown}: missing anchor: {destination}")
+    return errors
+
+
+def validate_commands(markdown: Path, routes: set[str]) -> list[str]:
+    errors = []
+    in_fence = False
+    for line_number, line in enumerate(markdown.read_text(encoding="utf-8").splitlines(), 1):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        fragments = [line] if in_fence else INLINE_CODE_RE.findall(line)
+        for fragment in fragments:
+            if fragment.lstrip().startswith("#"):
+                continue
+            for match in COMMAND_RE.finditer(fragment):
+                invocation = match.group(0).rstrip(".,:;)")
+                words = invocation.split()
+                if any("<" in word or ">" in word for word in words):
+                    continue
+                if not any(invocation == route or invocation.startswith(route + " ") for route in routes):
+                    errors.append(f"{markdown}:{line_number}: unknown command route: {invocation}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    script = Path(__file__).resolve()
+    parser.add_argument("--root", type=Path, default=script.parents[5])
+    parser.add_argument("--skill-dir", type=Path, default=script.parent.parent)
+    parser.add_argument("--commands-json", type=Path)
+    args = parser.parse_args()
+
+    metadata = load_metadata(args.root.resolve(), args.commands_json)
+    if not metadata.get("ok"):
+        print("CLI metadata reports errors", file=sys.stderr)
+        return 1
+    routes = {
+        route
+        for command in metadata.get("commands", [])
+        for route in command.get("routes", [command.get("route")])
+        if route
+    }
+    routes.update({"omarchy --help", "omarchy commands"})
+    routes.update(
+        f"omarchy {command['group']}"
+        for command in metadata.get("commands", [])
+        if command.get("group")
+    )
+
+    markdown_files = sorted(args.skill_dir.glob("*.md"))
+    errors = []
+    for markdown in markdown_files:
+        errors.extend(validate_links(markdown, args.skill_dir))
+        errors.extend(validate_commands(markdown, routes))
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print(f"ok - validated {len(markdown_files)} skill documents against {len(routes)} CLI routes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/shell.d/agent-doctor-test.sh
+++ b/test/shell.d/agent-doctor-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+test_repo="$test_tmp/repo"
+test_omarchy="$test_tmp/omarchy"
+test_bin="$test_tmp/bin"
+mkdir -p "$test_home/.config/omarchy/defaults" "$test_home/.codex/skills" \
+  "$test_home/.claude/skills" "$test_repo" "$test_omarchy/default/agents/skills/omarchy" "$test_bin"
+
+printf 'codex\n' >"$test_home/.config/omarchy/defaults/agent"
+touch "$test_repo/AGENTS.md" "$test_repo/CLAUDE.md"
+ln -s "$test_omarchy/default/agents/skills/omarchy" "$test_home/.codex/skills/omarchy"
+ln -s "$test_omarchy/default/agents/skills/missing" "$test_home/.claude/skills/missing"
+
+cat >"$test_bin/codex" <<'SH'
+#!/bin/bash
+printf 'codex-cli 1.2.3\n'
+SH
+chmod +x "$test_bin/codex"
+
+output=$(cd "$test_repo" && HOME="$test_home" OMARCHY_PATH="$test_omarchy" PATH="$test_bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-doctor" --json)
+
+jq -e '.default_agent == "codex" and .binary_available == true and .version == "codex-cli 1.2.3"' \
+  <<<"$output" >/dev/null || fail "agent doctor reports the selected agent and version"
+pass "agent doctor reports the selected agent and version"
+
+jq -e '.instruction_files == ["AGENTS.md", "CLAUDE.md"]' <<<"$output" >/dev/null ||
+  fail "agent doctor reports repository instruction files"
+pass "agent doctor reports repository instruction files"
+
+jq -e '.skills.installed | any(.name == "omarchy" and .package_owned == true and .broken == false)' \
+  <<<"$output" >/dev/null || fail "agent doctor identifies packaged Omarchy skill links"
+pass "agent doctor identifies packaged Omarchy skill links"
+
+jq -e '.skills.broken | any(.name == "missing" and .broken == true and .package_owned == true)' <<<"$output" >/dev/null ||
+  fail "agent doctor identifies broken skill links"
+jq -e '.warnings | any(contains("Broken skill link:"))' <<<"$output" >/dev/null ||
+  fail "agent doctor warns about broken skill links"
+pass "agent doctor reports broken skill links without following them"
+
+rm -f "$test_home/.config/omarchy/defaults/agent"
+output=$(cd "$test_repo" && HOME="$test_home" OMARCHY_PATH="$test_omarchy" PATH="$test_bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-doctor" --json)
+jq -e '.default_agent == "" and .binary_available == false and (.warnings | any(contains("No default")))' \
+  <<<"$output" >/dev/null || fail "agent doctor handles an unconfigured default"
+pass "agent doctor handles an unconfigured default"
+
+if "$ROOT/bin/omarchy-agent-doctor" --bogus >/dev/null 2>&1; then
+  fail "agent doctor rejects unsupported arguments"
+fi
+pass "agent doctor rejects unsupported arguments"

--- a/test/shell.d/agent-mcp-test.sh
+++ b/test/shell.d/agent-mcp-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+mock_bin="$test_tmp/bin"
+mkdir -p "$test_home/.codex" "$test_home/.claude" "$test_home/.config/opencode" "$mock_bin" "$test_tmp/work"
+
+for agent in codex claude opencode pi; do
+  printf '#!/bin/bash\nexit 0\n' >"$mock_bin/$agent"
+  chmod +x "$mock_bin/$agent"
+done
+
+cat >"$test_home/.codex/config.toml" <<'EOF'
+[mcp_servers.railway]
+command = "secret-command"
+args = ["--token", "super-secret-token"]
+EOF
+
+cat >"$test_home/.claude.json" <<'EOF'
+{"mcpServers":{"sentry":{"url":"https://secret.example/token"}}}
+EOF
+
+cat >"$test_home/.config/opencode/opencode.jsonc" <<'EOF'
+{
+  // OpenCode accepts JSONC comments and trailing commas.
+  "mcp": {"docs": {"headers": {"Authorization": "Bearer hidden"}},},
+}
+EOF
+
+output=$(cd "$test_tmp/work" && HOME="$test_home" PATH="$mock_bin:/usr/bin" "$ROOT/bin/omarchy-agent-mcp" list --json)
+python3 - "$output" <<'PY'
+import json
+import sys
+
+result = json.loads(sys.argv[1])
+assert result["ok"] is True
+assert {(row["agent"], row["name"]) for row in result["servers"]} == {
+  ("claude", "sentry"),
+  ("codex", "railway"),
+  ("opencode", "docs"),
+}
+assert next(row for row in result["agents"] if row["name"] == "pi")["adapter"] == "unsupported"
+PY
+[[ $output != *"super-secret-token"* && $output != *"secret.example"* && $output != *"Bearer hidden"* ]] ||
+  fail "agent MCP JSON does not expose configuration secrets"
+pass "agent MCP list discovers server names without exposing secrets"
+
+doctor_output=$(cd "$test_tmp/work" && HOME="$test_home" PATH="$mock_bin:/usr/bin" "$ROOT/bin/omarchy-agent-mcp" doctor)
+[[ $doctor_output == *"Configured MCP servers: 3"* && $doctor_output == *"Unsupported adapters: pi"* ]] ||
+  fail "agent MCP doctor summarizes supported and unsupported adapters"
+pass "agent MCP doctor reports an honest adapter summary"
+
+printf '{broken' >"$test_home/.claude.json"
+if cd "$test_tmp/work" && HOME="$test_home" PATH="$mock_bin:/usr/bin" "$ROOT/bin/omarchy-agent-mcp" doctor --json >"$test_tmp/doctor.json"; then
+  fail "agent MCP doctor fails on an unreadable configuration"
+fi
+jq -e '.ok == false and (.issues | length == 1) and .issues[0].agent == "claude"' "$test_tmp/doctor.json" >/dev/null ||
+  fail "agent MCP doctor returns structured parse failures"
+if grep -q 'super-secret-token\|secret.example\|Bearer hidden' "$test_tmp/doctor.json"; then
+  fail "agent MCP doctor failure output does not expose configuration secrets"
+fi
+pass "agent MCP doctor diagnoses malformed configuration safely"
+
+if "$ROOT/bin/omarchy-agent-mcp" add example >/dev/null 2>&1; then
+  fail "agent MCP command rejects mutating operations"
+fi
+pass "agent MCP command is read-only"

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -478,6 +478,34 @@ assert_bypass agy agy --dangerously-skip-permissions
 assert_bypass copilot copilot --allow-all
 pass "agent launcher skips permission prompts for every supported agent"
 
+assert_safe() {
+  local agent=$1
+  shift
+
+  printf '%s\n' "$agent" >"$agent_file"
+  omarchy-agent --safe
+  assert_launched "$agent" "keeps permission prompts enabled in safe mode" "$@"
+}
+
+assert_safe pi pi
+assert_safe omp omp
+assert_safe opencode opencode
+assert_safe ori ori code
+assert_safe claude claude
+assert_safe codex codex
+assert_safe crush crush
+assert_safe grok grok
+assert_safe agy agy
+assert_safe copilot copilot
+pass "agent launcher offers a safe permission profile for every supported agent"
+
+printf '%s\n' "codex" >"$agent_file"
+omarchy-agent-prompt --safe "Review this project"
+mapfile -d '' -t safe_prompt_args <"$launch_log"
+[[ ${safe_prompt_args[*]} == "--app-id=org.omarchy.agent codex -- Review this project" ]] ||
+  fail "safe prompt route preserves approval-first mode"
+pass "safe prompt route preserves approval-first mode"
+
 printf '%s\n' "opencode" >"$agent_file"
 omarchy-agent
 mapfile -d '' -t launch_args <"$launch_log"

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -461,7 +461,7 @@ assert_launch ori ori code --interactive --prompt "Review this project"
 assert_launch claude claude --permission-mode auto -- "Review this project"
 assert_launch codex codex --approve-for-me -- "Review this project"
 assert_launch crush crush run "Review this project"
-assert_launch grok grok --permission-mode bypassPermissions -- "Review this project"
+assert_launch grok grok --always-approve -- "Review this project"
 assert_launch agy agy --dangerously-skip-permissions --prompt-interactive "Review this project"
 assert_launch copilot copilot --allow-all --interactive "Review this project"
 pass "agent launcher adapts initial prompts for every supported agent"
@@ -473,7 +473,7 @@ assert_bypass ori ori code
 assert_bypass claude claude --permission-mode auto
 assert_bypass codex codex --approve-for-me
 assert_bypass crush crush --yolo
-assert_bypass grok grok --permission-mode bypassPermissions
+assert_bypass grok grok --always-approve
 assert_bypass agy agy --dangerously-skip-permissions
 assert_bypass copilot copilot --allow-all
 pass "agent launcher skips permission prompts for every supported agent"
@@ -505,6 +505,13 @@ mapfile -d '' -t safe_prompt_args <"$launch_log"
 [[ ${safe_prompt_args[*]} == "--app-id=org.omarchy.agent codex -- Review this project" ]] ||
   fail "safe prompt route preserves approval-first mode"
 pass "safe prompt route preserves approval-first mode"
+
+for conflicting_flags in "--safe --auto" "--auto --safe"; do
+  if omarchy-agent $conflicting_flags >/dev/null 2>&1; then
+    fail "agent launcher rejects conflicting approval modes"
+  fi
+done
+pass "agent launcher rejects conflicting approval modes"
 
 printf '%s\n' "opencode" >"$agent_file"
 omarchy-agent

--- a/test/shell.d/omarchy-skill-test.sh
+++ b/test/shell.d/omarchy-skill-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+validator="$ROOT/default/agents/skills/omarchy/scripts/validate.py"
+
+[[ -x $validator ]] || fail "Omarchy skill validator is executable"
+
+output=$("$validator" --root "$ROOT") || fail "Omarchy skill documentation passes drift validation" "$output"
+[[ $output == ok\ -* ]] || fail "Omarchy skill validator reports success" "$output"
+pass "Omarchy skill links and command routes match CLI metadata"
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/skill"
+printf '# Broken\n\nSee [missing](missing.md).\n\n`omarchy imaginary route`\n' >"$scratch/skill/SKILL.md"
+printf '{"ok":true,"commands":[]}' >"$scratch/commands.json"
+
+if "$validator" --root "$ROOT" --skill-dir "$scratch/skill" --commands-json "$scratch/commands.json" >"$scratch/out" 2>"$scratch/error"; then
+  fail "Omarchy skill validator rejects drift"
+fi
+grep -q 'missing link target' "$scratch/error" || fail "Omarchy skill validator diagnoses missing links"
+grep -q 'unknown command route' "$scratch/error" || fail "Omarchy skill validator diagnoses unknown commands"
+pass "Omarchy skill validator diagnoses documentation drift"


### PR DESCRIPTION
Adds read-only coding-agent diagnostics, secret-safe MCP configuration inspection, explicit safe and auto launcher profiles, and an agent-focused Omarchy skill guide with CLI-driven drift validation.

Highlights:
- omarchy agent doctor with structured JSON output
- omarchy agent mcp list and doctor without emitting config values
- safe and auto approval profiles for agent and prompt launches
- package-owned skill, shared-instruction, MCP, and transactional-edit guidance
- focused shell tests and skill route/link validation

Validation:
- focused agent doctor, MCP, launcher, skill, metadata, and bin-style tests pass
- command metadata check passes for 439 commands
- full non-graphical suite ran 210 shell test files; remaining failures require missing omarchy-pkgs fixtures or host capabilities such as writable runtime directories and network access