### PR TITLE
Fix slow battery app launches on Dell XPS 16

### DIFF
--- a/bin/omarchy-app-launch-responsive
+++ b/bin/omarchy-app-launch-responsive
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# omarchy:summary=Reduce slow app-launch latency in battery Balanced mode on supported hardware
+# omarchy:args=<status --json|set on|set off>
+# omarchy:group=power
+
+set -euo pipefail
+
+core="${OMARCHY_PATH:-/usr/share/omarchy}/bin/omarchy-app-launch-responsive-core"
+config="${OMARCHY_PATH:-/usr/share/omarchy}/default/app-launch-responsive/config.json"
+installed_config=/etc/omarchy-app-launch-responsive.json
+installed_unit=/etc/systemd/system/omarchy-app-launch-responsive.service
+installed_policy=/etc/polkit-1/actions/org.omarchy.app-launch-responsive.policy
+installed_state=/var/lib/omarchy-app-launch-responsive
+control=/usr/bin/omarchy-app-launch-responsive-control
+
+if [[ ! -x $core ]]; then
+  core=/usr/bin/omarchy-app-launch-responsive-core
+fi
+
+case "$#:${1:-}:${2:-}" in
+  2:status:--json)
+    if [[ -r $installed_config ]]; then
+      exec "$core" status --json
+    else
+      exec "$core" probe --json "$config"
+    fi
+    ;;
+  2:set:on | 2:set:off)
+    if [[ $2 == "off" && ! -e $installed_config && ! -L $installed_config &&
+      ! -e $installed_unit && ! -L $installed_unit &&
+      ! -e $installed_policy && ! -L $installed_policy &&
+      ! -e $installed_state && ! -L $installed_state ]]; then
+      exec "$core" probe --json "$config"
+    fi
+    exec pkexec "$control" "$1" "$2"
+    ;;
+  *)
+    printf '%s\n' \
+      'Usage: omarchy-app-launch-responsive status --json' \
+      '       omarchy-app-launch-responsive set on|off' >&2
+    exit 2
+    ;;
+esac

--- a/bin/omarchy-app-launch-responsive-control
+++ b/bin/omarchy-app-launch-responsive-control
@@ -1,0 +1,284 @@
+#!/bin/bash
+
+# omarchy:summary=Privileged setup and preference helper for responsive app launches
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+set -Eeuo pipefail
+
+source_dir=/usr/share/omarchy/default/app-launch-responsive
+core=/usr/bin/omarchy-app-launch-responsive-core
+config=/etc/omarchy-app-launch-responsive.json
+unit=/etc/systemd/system/omarchy-app-launch-responsive.service
+policy=/etc/polkit-1/actions/org.omarchy.app-launch-responsive.policy
+wants=/etc/systemd/system/multi-user.target.wants/omarchy-app-launch-responsive.service
+state_dir=/var/lib/omarchy-app-launch-responsive
+state_file="$state_dir/state.json"
+runtime_dir=/run/omarchy-app-launch-responsive
+service=omarchy-app-launch-responsive.service
+
+owned_files=("$config" "$unit" "$policy")
+owned_paths=("${owned_files[@]}" "$wants" "$state_dir" "$runtime_dir")
+
+service_active() {
+  systemctl is-active --quiet "$service"
+}
+
+service_enabled() {
+  systemctl is-enabled --quiet "$service"
+}
+
+any_artifact_exists() {
+  local path
+  for path in "${owned_paths[@]}"; do
+    [[ -e $path || -L $path ]] && return 0
+  done
+  return 1
+}
+
+assert_root_file() {
+  local path=$1 attributes
+  [[ -f $path && ! -L $path ]] || {
+    echo "Refusing unsafe artifact type: $path" >&2
+    return 1
+  }
+  attributes=$(stat -c '%u:%g:%a' "$path")
+  [[ $attributes == "0:0:644" ]] || {
+    echo "Refusing artifact with unexpected owner/mode: $path ($attributes)" >&2
+    return 1
+  }
+}
+
+assert_root_directory() {
+  local path=$1 attributes
+  [[ -d $path && ! -L $path ]] || {
+    echo "Refusing unsafe artifact type: $path" >&2
+    return 1
+  }
+  attributes=$(stat -c '%u:%g:%a' "$path")
+  [[ $attributes == "0:0:755" ]] || {
+    echo "Refusing artifact with unexpected owner/mode: $path ($attributes)" >&2
+    return 1
+  }
+}
+
+assert_wants_if_present() {
+  local ownership
+  [[ -e $wants || -L $wants ]] || return 0
+  [[ -L $wants && $(readlink -f "$wants") == "$unit" ]] || {
+    echo "Refusing unexpected service enablement link: $wants" >&2
+    return 1
+  }
+  ownership=$(stat -c '%u:%g' "$wants")
+  [[ $ownership == "0:0" ]] || {
+    echo "Refusing enablement link with unexpected ownership: $wants ($ownership)" >&2
+    return 1
+  }
+}
+
+assert_installed_shape() {
+  local path
+  for path in "${owned_files[@]}"; do assert_root_file "$path"; done
+  assert_root_directory "$state_dir"
+  assert_root_file "$state_file"
+  if [[ -e $runtime_dir || -L $runtime_dir ]]; then
+    assert_root_directory "$runtime_dir"
+  fi
+  assert_wants_if_present
+  "$core" status --json >/dev/null
+}
+
+assert_templates_current() {
+  cmp -s "$source_dir/config.json" "$config" || {
+    echo "Installed app-launch policy differs from this Omarchy version; leave it off until an updated migration is available." >&2
+    return 1
+  }
+  cmp -s "$source_dir/omarchy-app-launch-responsive.service" "$unit" || {
+    echo "Installed app-launch service differs from this Omarchy version; leave it off until an updated migration is available." >&2
+    return 1
+  }
+  cmp -s "$source_dir/org.omarchy.app-launch-responsive.policy" "$policy" || {
+    echo "Installed app-launch authorization differs from this Omarchy version; leave it off until an updated migration is available." >&2
+    return 1
+  }
+}
+
+status_field() {
+  local field=$1 document value
+  document=$("$core" status --json)
+  value=$(jq -r --arg field "$field" '
+    .[$field] | if type == "boolean" then tostring else error("not boolean") end
+  ' <<<"$document")
+  [[ $value == "true" || $value == "false" ]] || return 1
+  printf '%s\n' "$value"
+}
+
+install_templates() {
+  install -D -o root -g root -m 0644 "$source_dir/config.json" "$config"
+  install -D -o root -g root -m 0644 \
+    "$source_dir/omarchy-app-launch-responsive.service" "$unit"
+  install -D -o root -g root -m 0644 \
+    "$source_dir/org.omarchy.app-launch-responsive.policy" "$policy"
+}
+
+reload_managers() {
+  systemctl daemon-reload
+  systemctl reload polkit.service
+}
+
+rollback_incomplete_setup() {
+  local recovery_failed=false pending=false
+
+  if [[ -r $config && -e $state_file ]]; then
+    # A journal may describe live sysfs ownership. Ask the core to restore it
+    # before inspecting the resulting ownership bit; never infer that pending
+    # ownership is a reason to skip restoration.
+    "$core" set off >/dev/null 2>&1 || recovery_failed=true
+    pending=$(status_field ownership_pending 2>/dev/null) || pending=true
+  fi
+  if [[ $pending == true || $recovery_failed == true ]]; then
+    echo "CRITICAL: setup failed with unresolved rollback ownership; existing recovery files were retained" >&2
+    return 1
+  fi
+
+  systemctl disable --now "$service" >/dev/null 2>&1 || true
+  if service_active; then
+    echo "CRITICAL: setup rollback could not stop the service; no files were removed" >&2
+    return 1
+  fi
+  if [[ -r $config && -e $state_file ]]; then
+    "$core" verify-removable --json >/dev/null 2>&1 || recovery_failed=true
+  fi
+  if [[ $recovery_failed == true ]]; then
+    echo "CRITICAL: setup rollback could not prove clean ownership; no files were removed" >&2
+    return 1
+  fi
+
+  # systemctl disable owns removal of the wants link. Check it rather than
+  # deleting an unexpected symlink after the unit has stopped.
+  [[ ! -e $wants && ! -L $wants ]] || {
+    echo "CRITICAL: setup rollback left an unexpected enablement link; no files were removed" >&2
+    return 1
+  }
+  rm -f -- "$policy" "$unit" "$config"
+  rm -rf -- "$state_dir" "$runtime_dir"
+  reload_managers >/dev/null 2>&1 || {
+    echo "CRITICAL: setup files were removed but manager reload failed" >&2
+    return 1
+  }
+}
+
+fresh_enable() {
+  local setup_complete=false transaction_active=true
+
+  any_artifact_exists && {
+    echo "Refusing fresh setup because app-launch policy artifacts already exist" >&2
+    return 1
+  }
+  service_active && {
+    echo "Refusing fresh setup because the service is already active" >&2
+    return 1
+  }
+  service_enabled && {
+    echo "Refusing fresh setup because the service is already enabled" >&2
+    return 1
+  }
+
+  # This exact live-stock preflight is the final read-only operation before the
+  # first mutation. Setup is intentionally available only on battery Balanced.
+  "$core" audit-config --json "$source_dir/config.json" --require-stock
+
+  rollback_setup() {
+    local original_rc=$? pending=false
+    trap - ERR EXIT
+    [[ $transaction_active == true ]] || exit "$original_rc"
+
+    if [[ $setup_complete == true ]]; then
+      # A failed first apply is allowed to leave the fully installed backend
+      # OFF. The core transaction already attempted exact stock restoration.
+      # Retry OFF even when the first status reports pending ownership; a
+      # transient apply/rollback failure may already have cleared.
+      "$core" set off >/dev/null 2>&1 || true
+      pending=$(status_field ownership_pending 2>/dev/null) || pending=true
+      if [[ $pending == true ]]; then
+        echo "CRITICAL: first apply failed with rollback ownership pending; the complete enabled recovery backend was retained" >&2
+        exit 125
+      fi
+      echo "First apply failed; the complete backend was retained OFF at verified stock values" >&2
+      exit "$original_rc"
+    fi
+
+    if ! rollback_incomplete_setup; then
+      exit 125
+    fi
+    exit "$original_rc"
+  }
+  trap rollback_setup ERR EXIT
+
+  install_templates
+  reload_managers
+  systemctl enable --now "$service"
+  "$core" activate >/dev/null
+  assert_installed_shape
+  assert_templates_current
+  setup_complete=true
+
+  "$core" set on
+  transaction_active=false
+  trap - ERR EXIT
+}
+
+enable_existing() {
+  assert_installed_shape
+  assert_templates_current
+  systemctl enable --now "$service"
+  "$core" activate >/dev/null
+  "$core" set on
+}
+
+disable_existing() {
+  # OFF is the recovery path. Do not gate it on unit, policy, mode, service, or
+  # packaged-template drift: the root core can restore its journal directly.
+  [[ -r $config ]] || {
+    echo "Cannot restore app-launch policy because its root config is missing" >&2
+    return 1
+  }
+  "$core" set off
+}
+
+main() {
+  [[ $EUID == 0 ]] || {
+    echo "omarchy-app-launch-responsive-control must run as root" >&2
+    exit 77
+  }
+
+  # The core serializes individual reconciliations. This separate root-owned
+  # lock serializes the larger setup/start/set transaction across callers.
+  exec 9>/run/lock/omarchy-app-launch-responsive.lock
+  flock -x 9
+
+  case "$#:${1:-}:${2:-}" in
+    2:set:on)
+      if any_artifact_exists; then
+        enable_existing
+      else
+        fresh_enable
+      fi
+      ;;
+    2:set:off)
+      if any_artifact_exists; then
+        disable_existing
+      else
+        "$core" probe --json "$source_dir/config.json"
+      fi
+      ;;
+    *)
+      echo "Usage: omarchy-app-launch-responsive-control set on|off" >&2
+      exit 2
+      ;;
+  esac
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/bin/omarchy-app-launch-responsive-core
+++ b/bin/omarchy-app-launch-responsive-core
@@ -1,0 +1,1261 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Internal reconciler for responsive battery app launches
+# omarchy:hidden=true
+
+"""Safely own the supported battery-Balanced app-launch latency override."""
+
+from __future__ import annotations
+
+import fcntl
+import glob
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Mapping
+
+
+CONFIG_DEFAULT = Path("/etc/omarchy-app-launch-responsive.json")
+STATE_DEFAULT = Path("/var/lib/omarchy-app-launch-responsive/state.json")
+LOCK_DEFAULT = Path("/run/omarchy-app-launch-responsive/control.lock")
+SERVICE_UNIT = "omarchy-app-launch-responsive.service"
+
+SLIDER_BALANCE = Path(
+    "/sys/module/processor_thermal_soc_slider/parameters/slider_balance"
+)
+SLIDER_OFFSET = Path(
+    "/sys/module/processor_thermal_soc_slider/parameters/slider_offset"
+)
+PRESERVE_PATHS = {
+    "hwp_dynamic_boost": Path(
+        "/sys/devices/system/cpu/intel_pstate/hwp_dynamic_boost"
+    ),
+    "no_turbo": Path("/sys/devices/system/cpu/intel_pstate/no_turbo"),
+    "min_perf_pct": Path("/sys/devices/system/cpu/intel_pstate/min_perf_pct"),
+    "max_perf_pct": Path("/sys/devices/system/cpu/intel_pstate/max_perf_pct"),
+}
+POWER_SUPPLY_ROOT = Path("/sys/class/power_supply")
+
+UP_NAME = "org.freedesktop.UPower"
+UP_PATH = "/org/freedesktop/UPower"
+UP_IFACE = "org.freedesktop.UPower"
+PPD_NAME = "org.freedesktop.UPower.PowerProfiles"
+PPD_PATH = "/org/freedesktop/UPower/PowerProfiles"
+PPD_IFACE = "org.freedesktop.UPower.PowerProfiles"
+
+LOG = logging.getLogger("omarchy-app-launch-responsive")
+
+
+class StateFileError(RuntimeError):
+    """The persistent ownership journal cannot safely be trusted."""
+
+
+def runtime_path(default: Path, environment_name: str) -> Path:
+    # Root operations always use fixed paths. Overrides exist only for tests
+    # and unprivileged read-only probes.
+    if os.geteuid() == 0:
+        return default
+    return Path(os.environ.get(environment_name, str(default)))
+
+
+def config_path() -> Path:
+    return runtime_path(
+        CONFIG_DEFAULT, "OMARCHY_APP_LAUNCH_RESPONSIVE_CONFIG"
+    )
+
+
+def state_path() -> Path:
+    return runtime_path(STATE_DEFAULT, "OMARCHY_APP_LAUNCH_RESPONSIVE_STATE")
+
+
+def lock_path() -> Path:
+    return runtime_path(LOCK_DEFAULT, "OMARCHY_APP_LAUNCH_RESPONSIVE_LOCK")
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def read_optional(path: Path) -> str | None:
+    try:
+        return read(path)
+    except OSError:
+        return None
+
+
+def write(path: Path, value: str) -> None:
+    path.write_text(f"{value}\n", encoding="utf-8")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    if value.get("schema") != 1:
+        raise ValueError(f"unsupported config schema {value.get('schema')!r}")
+    return value
+
+
+def default_state() -> dict[str, Any]:
+    return {
+        "schema": 1,
+        "initialized": False,
+        "requested": False,
+        "applied": False,
+        "needs_restore": False,
+        "failure_latched": False,
+        "quiesced": False,
+        "baseline": None,
+        "blocked_reason": None,
+        "last_error": None,
+        "last_reconcile_unix": None,
+    }
+
+
+def validate_state(value: Mapping[str, Any]) -> None:
+    if value.get("schema") != 1:
+        raise StateFileError(f"unsupported state schema {value.get('schema')!r}")
+    for key in (
+        "initialized",
+        "requested",
+        "applied",
+        "needs_restore",
+        "failure_latched",
+        "quiesced",
+    ):
+        if type(value.get(key)) is not bool:
+            raise StateFileError(f"state field {key!r} must be boolean")
+    baseline = value.get("baseline")
+    if baseline is not None:
+        if not isinstance(baseline, Mapping):
+            raise StateFileError("state baseline must be an object or null")
+        required = {"slider_balance", "slider_offset", "epp", "platform"}
+        if not required.issubset(baseline):
+            raise StateFileError("state baseline is incomplete")
+        if not isinstance(baseline.get("epp"), Mapping):
+            raise StateFileError("state baseline EPP must be a path/value object")
+        if not isinstance(baseline.get("platform"), Mapping):
+            raise StateFileError("state baseline platform must be an object")
+    if value.get("applied") and not value.get("needs_restore"):
+        raise StateFileError("applied state must retain a rollback obligation")
+    if value.get("needs_restore") and baseline is None:
+        raise StateFileError("rollback obligation requires a baseline")
+    for key in ("blocked_reason", "last_error"):
+        if value.get(key) is not None and not isinstance(value.get(key), str):
+            raise StateFileError(f"state field {key!r} must be a string or null")
+    stamp = value.get("last_reconcile_unix")
+    if stamp is not None and type(stamp) is not int:
+        raise StateFileError("last_reconcile_unix must be an integer or null")
+
+
+def load_state(*, strict: bool = False) -> dict[str, Any]:
+    result = default_state()
+    try:
+        value = json.loads(state_path().read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise StateFileError("state must contain a JSON object")
+        validate_state(value)
+    except FileNotFoundError:
+        result["_valid"] = True
+        result["_present"] = False
+        return result
+    except (OSError, ValueError, json.JSONDecodeError, StateFileError) as exc:
+        if strict:
+            raise StateFileError(f"state unreadable: {exc}") from exc
+        result["_valid"] = False
+        result["_present"] = True
+        result["blocked_reason"] = "state_corrupt"
+        result["last_error"] = str(exc)
+        return result
+    result.update(value)
+    result["_valid"] = True
+    result["_present"] = True
+    return result
+
+
+def save_state(state: Mapping[str, Any]) -> None:
+    if os.geteuid() != 0:
+        raise PermissionError("state mutation requires root")
+    path = state_path()
+    path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+    descriptor, temp_name = tempfile.mkstemp(prefix=".state.", dir=path.parent)
+    temp = Path(temp_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            persisted = {
+                key: value for key, value in state.items() if not key.startswith("_")
+            }
+            validate_state(persisted)
+            json.dump(persisted, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp, 0o644)
+        os.replace(temp, path)
+        directory_descriptor = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    finally:
+        try:
+            temp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+class Locked:
+    def __enter__(self) -> "Locked":
+        if os.geteuid() != 0:
+            raise PermissionError("reconciliation requires root")
+        path = lock_path()
+        path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+        self.handle = path.open("a+", encoding="utf-8")
+        os.chmod(path, 0o644)
+        fcntl.flock(self.handle.fileno(), fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        fcntl.flock(self.handle.fileno(), fcntl.LOCK_UN)
+        self.handle.close()
+
+
+def command_output(argv: list[str]) -> str:
+    result = subprocess.run(
+        argv,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=5,
+    )
+    return result.stdout.strip()
+
+
+def bus_property(name: str, path: str, interface: str, prop: str) -> Any:
+    output = command_output(
+        [
+            "/usr/bin/busctl",
+            "--json=short",
+            "get-property",
+            name,
+            path,
+            interface,
+            prop,
+        ]
+    )
+    return json.loads(output)["data"]
+
+
+def service_active(unit: str = SERVICE_UNIT) -> bool:
+    try:
+        result = subprocess.run(
+            ["/usr/bin/systemctl", "is-active", "--quiet", unit],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def cpu_identity() -> tuple[int, int]:
+    family: int | None = None
+    model: int | None = None
+    for line in Path("/proc/cpuinfo").read_text(encoding="utf-8").splitlines():
+        if ":" not in line:
+            continue
+        key, value = (part.strip() for part in line.split(":", 1))
+        if key == "cpu family":
+            family = int(value)
+        elif key == "model":
+            model = int(value)
+        if family is not None and model is not None:
+            return family, model
+    raise RuntimeError("could not determine CPU family/model")
+
+
+def platform_snapshot() -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for raw in sorted(glob.glob("/sys/class/platform-profile/platform-profile-*")):
+        directory = Path(raw)
+        name = read(directory / "name")
+        if name in result:
+            raise RuntimeError(f"duplicate platform profile name: {name}")
+        result[name] = {
+            "realpath": str((directory / "profile").resolve(strict=True)),
+            "profile": read(directory / "profile"),
+            "choices": (read_optional(directory / "choices") or "").split(),
+        }
+    return result
+
+
+def epp_snapshot() -> tuple[dict[str, str], dict[str, list[str]], dict[str, str]]:
+    values: dict[str, str] = {}
+    choices: dict[str, list[str]] = {}
+    drivers: dict[str, str] = {}
+    pattern = "/sys/devices/system/cpu/cpufreq/policy*/energy_performance_preference"
+    for raw in sorted(glob.glob(pattern)):
+        path = Path(raw)
+        values[raw] = read(path)
+        choices[raw] = (
+            read_optional(path.parent / "energy_performance_available_preferences") or ""
+        ).split()
+        drivers[raw] = read_optional(path.parent / "scaling_driver") or ""
+    return values, choices, drivers
+
+
+def power_supply_snapshot() -> tuple[dict[str, Any], dict[str, Any]]:
+    external: dict[str, Any] = {}
+    batteries: dict[str, Any] = {}
+    for directory in sorted(POWER_SUPPLY_ROOT.glob("*")):
+        scope = read_optional(directory / "scope")
+        # Bluetooth peripherals and other device-scoped supplies are not part
+        # of the laptop's physical power source. System-scoped and legacy
+        # supplies without a scope remain in the conservative source audit.
+        if scope == "Device":
+            continue
+        if scope not in {None, "System"}:
+            raise RuntimeError(
+                f"power supply {directory.name!r} has unknown scope {scope!r}"
+            )
+        supply_type = read_optional(directory / "type")
+        if supply_type is None:
+            raise RuntimeError(f"power supply {directory.name!r} has no readable type")
+        if supply_type == "Battery":
+            batteries[directory.name] = {
+                "present": read_optional(directory / "present"),
+                "status": read_optional(directory / "status"),
+            }
+        else:
+            # Treat every non-battery supply conservatively as a possible input.
+            # An unknown device without an online signal makes DC ineligible.
+            external[directory.name] = {
+                "type": supply_type,
+                "online": read_optional(directory / "online"),
+            }
+    return external, batteries
+
+
+def ppd_profiles() -> list[dict[str, str]]:
+    raw_profiles = bus_property(PPD_NAME, PPD_PATH, PPD_IFACE, "Profiles")
+    result: list[dict[str, str]] = []
+    for raw in raw_profiles:
+        result.append(
+            {
+                key: str(value.get("data"))
+                for key, value in raw.items()
+                if isinstance(value, Mapping)
+            }
+        )
+    return result
+
+
+def observe() -> dict[str, Any]:
+    family, model = cpu_identity()
+    external, batteries = power_supply_snapshot()
+    epp, epp_choices, epp_drivers = epp_snapshot()
+    return {
+        "sys_vendor": read(Path("/sys/class/dmi/id/sys_vendor")),
+        "product_name": read(Path("/sys/class/dmi/id/product_name")),
+        "product_sku": read(Path("/sys/class/dmi/id/product_sku")),
+        "cpu_family": family,
+        "cpu_model": model,
+        "on_battery": bool(bus_property(UP_NAME, UP_PATH, UP_IFACE, "OnBattery")),
+        "active_profile": str(
+            bus_property(PPD_NAME, PPD_PATH, PPD_IFACE, "ActiveProfile")
+        ),
+        "battery_aware": bool(
+            bus_property(PPD_NAME, PPD_PATH, PPD_IFACE, "BatteryAware")
+        ),
+        "ppd_profiles": ppd_profiles(),
+        "lpmd_active": service_active("intel_lpmd.service"),
+        "platform": platform_snapshot(),
+        "epp": epp,
+        "epp_choices": epp_choices,
+        "epp_drivers": epp_drivers,
+        "slider_balance": read(SLIDER_BALANCE),
+        "slider_offset": read(SLIDER_OFFSET),
+        "preserve": {name: read(path) for name, path in PRESERVE_PATHS.items()},
+        "external_power": external,
+        "batteries": batteries,
+    }
+
+
+def lpmd_semantic_errors(config: Mapping[str, Any]) -> list[str]:
+    providers = config["providers"]
+    path = Path(providers["intel_lpmd_config"])
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as exc:
+        return [f"cannot parse Intel LPMD config {path}: {exc}"]
+
+    def text(tag: str) -> str | None:
+        element = root.find(tag)
+        return element.text.strip() if element is not None and element.text else None
+
+    errors: list[str] = []
+    expected = {
+        "BalancedSliderDC": str(providers["balanced_slider_dc"]),
+        "SliderOffsetDC": str(providers["slider_offset_dc"]),
+    }
+    for tag, wanted in expected.items():
+        actual = text(tag)
+        if actual != wanted:
+            errors.append(f"Intel LPMD {tag}: expected {wanted!r}, got {actual!r}")
+
+    hardware = config["hardware"]
+    matching_state = False
+    for states in root.findall("States"):
+        family = states.findtext("CPUFamily", default="").strip()
+        model = states.findtext("CPUModel", default="").strip()
+        if family == str(hardware["cpu_family"]) and model == str(
+            hardware["cpu_model"]
+        ):
+            matching_state = True
+            break
+    if not matching_state:
+        errors.append("Intel LPMD config has no matching CPU state")
+    return errors
+
+
+def static_audit(config: Mapping[str, Any], observed: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    hardware = config["hardware"]
+    for key in ("sys_vendor", "product_name", "product_sku", "cpu_family", "cpu_model"):
+        if observed.get(key) != hardware[key]:
+            errors.append(
+                f"{key}: expected {hardware[key]!r}, got {observed.get(key)!r}"
+            )
+
+    if observed.get("preserve") != hardware["preserve"]:
+        errors.append("non-target Intel P-state baseline changed")
+
+    expected_epp = set(hardware["epp_paths"])
+    actual_epp = set(observed.get("epp", {}))
+    if actual_epp != expected_epp:
+        errors.append("EPP policy path inventory changed")
+    required_epp = {
+        config["stock_battery_balanced"]["epp"],
+        config["responsive_battery_balanced"]["epp"],
+    }
+    for path in sorted(expected_epp & actual_epp):
+        available = set(observed.get("epp_choices", {}).get(path, []))
+        if not required_epp.issubset(available):
+            errors.append(f"EPP capabilities changed at {path}")
+        if observed.get("epp_drivers", {}).get(path) != "intel_pstate":
+            errors.append(f"EPP driver is not intel_pstate at {path}")
+
+    expected_platform = hardware["platform_profile_realpaths"]
+    actual_platform = observed.get("platform", {})
+    if set(actual_platform) != set(expected_platform):
+        errors.append("platform profile provider inventory changed")
+    else:
+        realpaths = {name: item.get("realpath") for name, item in actual_platform.items()}
+        if realpaths != expected_platform:
+            errors.append("platform profile realpaths changed")
+        for name, item in actual_platform.items():
+            if "balanced" not in item.get("choices", []):
+                errors.append(f"platform profile {name!r} no longer offers balanced")
+
+    providers = config["providers"]
+    if providers.get("require_battery_aware") and not observed.get("battery_aware"):
+        errors.append("power-profiles-daemon BatteryAware is false")
+    balanced_profiles = [
+        item
+        for item in observed.get("ppd_profiles", [])
+        if item.get("Profile") == "balanced"
+    ]
+    if len(balanced_profiles) != 1:
+        errors.append("power-profiles-daemon balanced profile is missing or ambiguous")
+    elif (
+        balanced_profiles[0].get("CpuDriver") != "intel_pstate"
+        or balanced_profiles[0].get("PlatformDriver") != "platform_profile"
+    ):
+        errors.append("power-profiles-daemon balanced providers changed")
+    if not observed.get("lpmd_active"):
+        errors.append("intel_lpmd.service is inactive")
+    errors.extend(lpmd_semantic_errors(config))
+    return errors
+
+
+def externally_powered(observed: Mapping[str, Any]) -> bool:
+    return any(
+        item.get("online") == "1"
+        for item in observed.get("external_power", {}).values()
+    )
+
+
+def is_eligible(observed: Mapping[str, Any]) -> tuple[bool, str]:
+    external = observed.get("external_power", {})
+    batteries = observed.get("batteries", {})
+    if not external or not batteries:
+        return False, "physical_source_unknown"
+    online_values = [item.get("online") for item in external.values()]
+    if any(value not in {"0", "1"} for value in online_values):
+        return False, "physical_source_unknown"
+    if any(value == "1" for value in online_values):
+        return False, "ac_power"
+    if observed.get("on_battery") is not True:
+        return False, "source_disagreement"
+    if any(item.get("present") != "1" for item in batteries.values()):
+        return False, "battery_not_present"
+    if any(item.get("status") != "Discharging" for item in batteries.values()):
+        return False, "battery_not_discharging"
+    if observed.get("active_profile") != "balanced":
+        return False, f"profile_{observed.get('active_profile')}"
+    if any(
+        item.get("profile") != "balanced"
+        for item in observed.get("platform", {}).values()
+    ):
+        return False, "platform_profile_not_balanced"
+    return True, "eligible"
+
+
+def tuning_matches(observed: Mapping[str, Any], target: Mapping[str, Any]) -> bool:
+    if observed.get("slider_balance") != target["slider_balance"]:
+        return False
+    if observed.get("slider_offset") != target["slider_offset"]:
+        return False
+    wanted_epp = target["epp"]
+    if isinstance(wanted_epp, Mapping):
+        return observed.get("epp") == wanted_epp
+    values = list(observed.get("epp", {}).values())
+    return bool(values) and all(value == wanted_epp for value in values)
+
+
+def capture_baseline(observed: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "slider_balance": observed["slider_balance"],
+        "slider_offset": observed["slider_offset"],
+        "epp": observed["epp"],
+        "platform": {
+            name: item["profile"] for name, item in observed["platform"].items()
+        },
+    }
+
+
+def validate_write_scope(
+    config: Mapping[str, Any],
+    target: Mapping[str, Any],
+    observed: Mapping[str, Any],
+) -> None:
+    expected_platform = config["hardware"]["platform_profile_realpaths"]
+    actual_platform = {
+        name: item.get("realpath")
+        for name, item in observed.get("platform", {}).items()
+    }
+    if actual_platform != expected_platform:
+        raise RuntimeError("refusing write: platform provider realpaths changed")
+    expected_epp = set(config["hardware"]["epp_paths"])
+    if set(observed.get("epp", {})) != expected_epp:
+        raise RuntimeError("refusing write: EPP path inventory changed")
+    wanted_epp = target["epp"]
+    if isinstance(wanted_epp, Mapping) and set(wanted_epp) != expected_epp:
+        raise RuntimeError("refusing write: target EPP inventory is not pinned")
+    platform_target = target.get("platform")
+    if platform_target is not None and (
+        not isinstance(platform_target, Mapping)
+        or set(platform_target) != set(expected_platform)
+        or any(value != "balanced" for value in platform_target.values())
+    ):
+        raise RuntimeError("refusing write: target platform inventory is not pinned")
+
+
+def write_tuning(
+    config: Mapping[str, Any],
+    target: Mapping[str, Any],
+    observed: Mapping[str, Any],
+) -> dict[str, Any]:
+    audit_errors = static_audit(config, observed)
+    if audit_errors:
+        raise RuntimeError(f"refusing write after provider drift: {'; '.join(audit_errors)}")
+    if not is_eligible(observed)[0]:
+        raise RuntimeError("refusing write outside verified battery Balanced mode")
+    validate_write_scope(config, target, observed)
+    preserve_before = dict(observed["preserve"])
+
+    write(SLIDER_BALANCE, str(target["slider_balance"]))
+    write(SLIDER_OFFSET, str(target["slider_offset"]))
+
+    # Rewriting the already-balanced provider profiles commits the two module
+    # parameters on this hardware. Only configured canonical realpaths are used.
+    realpaths = config["hardware"]["platform_profile_realpaths"]
+    for name in sorted(realpaths):
+        if observed["platform"][name]["profile"] != "balanced":
+            raise RuntimeError(f"refusing write while {name!r} is not balanced")
+        write(Path(realpaths[name]), "balanced")
+
+    wanted_epp = target["epp"]
+    for raw in sorted(config["hardware"]["epp_paths"]):
+        value = wanted_epp[raw] if isinstance(wanted_epp, Mapping) else wanted_epp
+        write(Path(raw), str(value))
+
+    verify_ms = int(config["timing"]["post_write_verify_ms"])
+    time.sleep(verify_ms / 1000)
+    after = observe()
+    if not is_eligible(after)[0]:
+        raise RuntimeError("power source or profile changed during write")
+    if not tuning_matches(after, target):
+        raise RuntimeError("post-write tuning verification failed")
+    if after["preserve"] != preserve_before:
+        raise RuntimeError("an unrelated Intel P-state value changed")
+    return after
+
+
+def mark_state(
+    state: dict[str, Any], *, blocked: str | None = None, error: str | None = None
+) -> None:
+    state["blocked_reason"] = blocked
+    state["last_error"] = error
+    state["last_reconcile_unix"] = int(time.time())
+
+
+def clear_ownership(state: dict[str, Any]) -> None:
+    state["applied"] = False
+    state["needs_restore"] = False
+    state["baseline"] = None
+
+
+def restore_owned(
+    config: Mapping[str, Any], state: dict[str, Any], observed: Mapping[str, Any]
+) -> None:
+    baseline = state.get("baseline")
+    if not isinstance(baseline, Mapping):
+        raise RuntimeError("rollback obligation exists without a valid baseline")
+    if set(baseline.get("epp", {})) != set(observed.get("epp", {})):
+        raise RuntimeError("EPP path inventory changed since baseline capture")
+    if set(baseline.get("platform", {})) != set(observed.get("platform", {})):
+        raise RuntimeError("platform provider inventory changed since baseline capture")
+    write_tuning(config, baseline, observed)
+    clear_ownership(state)
+
+
+def state_is_fresh(config: Mapping[str, Any], state: Mapping[str, Any]) -> bool:
+    stamp = state.get("last_reconcile_unix")
+    if type(stamp) is not int:
+        return False
+    maximum_age = max(
+        5,
+        2 * int(config["timing"]["periodic_reconcile_seconds"])
+        + int(config["timing"]["event_debounce_ms"]) // 1000
+        + 5,
+    )
+    return 0 <= int(time.time()) - stamp <= maximum_age
+
+
+def reconcile_locked(reason: str) -> tuple[bool, str]:
+    config = load_json(config_path())
+    state = load_state(strict=True)
+    try:
+        observed = observe()
+    except Exception as exc:
+        mark_state(state, blocked="observation_failed", error=str(exc))
+        save_state(state)
+        return False, str(exc)
+
+    errors = static_audit(config, observed)
+    eligible, eligibility_reason = is_eligible(observed)
+    stock = config["stock_battery_balanced"]
+    responsive = config["responsive_battery_balanced"]
+
+    if errors:
+        # A provider audit failure can mean that the machine identity, driver,
+        # capabilities, or policy semantics changed. Never write through that
+        # uncertainty, including for rollback: preserve the ownership journal
+        # so a later reconcile can restore only after every gate passes again.
+        message = "; ".join(errors)
+        state["failure_latched"] = True
+        mark_state(state, blocked="provider_drift", error=message)
+        save_state(state)
+        LOG.error("reconcile %s blocked: %s", reason, message)
+        if not state["requested"] and not state["needs_restore"]:
+            return True, f"disabled with clean ownership despite drift: {message}"
+        return False, message
+
+    if not state["initialized"]:
+        if not eligible:
+            message = "stock battery-Balanced baseline has not been observed"
+            mark_state(state, blocked="baseline_unverified", error=message)
+            save_state(state)
+            return False, message
+        if not tuning_matches(observed, stock):
+            message = "initialization requires exact stock battery-Balanced values"
+            mark_state(state, blocked="unexpected_unowned_policy", error=message)
+            save_state(state)
+            return False, message
+        state["initialized"] = True
+        mark_state(state)
+        save_state(state)
+
+    if not eligible:
+        if state["needs_restore"] and (
+            not state["requested"] or state["failure_latched"] or state["quiesced"]
+        ):
+            message = f"restore deferred while {eligibility_reason}"
+            mark_state(state, blocked="restore_deferred", error=message)
+            save_state(state)
+            return False, message
+        if state["failure_latched"] and state["requested"]:
+            mark_state(
+                state,
+                blocked=state.get("blocked_reason"),
+                error=state.get("last_error"),
+            )
+            save_state(state)
+            return False, state.get("last_error") or "apply failure is latched"
+        mark_state(state)
+        save_state(state)
+        return True, eligibility_reason
+
+    if state["quiesced"]:
+        if state["needs_restore"]:
+            try:
+                restore_owned(config, state, observed)
+            except Exception as exc:
+                mark_state(state, blocked="restore_failed", error=str(exc))
+                save_state(state)
+                return False, str(exc)
+        mark_state(state)
+        save_state(state)
+        return True, "quiesced"
+
+    if state["failure_latched"] and state["requested"]:
+        if state["needs_restore"]:
+            try:
+                restore_owned(config, state, observed)
+                state["requested"] = False
+            except Exception as exc:
+                message = f"latched apply failure; restoration failed: {exc}"
+                mark_state(state, blocked="apply_failed", error=message)
+                save_state(state)
+                return False, message
+        mark_state(
+            state,
+            blocked=state.get("blocked_reason"),
+            error=state.get("last_error"),
+        )
+        save_state(state)
+        return False, state.get("last_error") or "apply failure is latched"
+
+    if state["requested"]:
+        if not service_active():
+            message = "refusing enable while the watcher service is inactive"
+            mark_state(state, blocked="service_inactive", error=message)
+            save_state(state)
+            return False, message
+        if state.get("baseline") is None:
+            if not tuning_matches(observed, stock):
+                message = "cannot capture baseline because current values are not stock"
+                mark_state(state, blocked="unexpected_baseline", error=message)
+                save_state(state)
+                return False, message
+            state["baseline"] = capture_baseline(observed)
+            save_state(state)
+
+        if not tuning_matches(observed, responsive):
+            state["needs_restore"] = True
+            save_state(state)
+            try:
+                write_tuning(config, responsive, observed)
+            except Exception as exc:
+                rollback_ok = False
+                try:
+                    current = observe()
+                    if (
+                        not static_audit(config, current)
+                        and is_eligible(current)[0]
+                        and isinstance(state.get("baseline"), Mapping)
+                    ):
+                        write_tuning(config, state["baseline"], current)
+                        rollback_ok = True
+                except Exception as rollback_exc:
+                    exc = RuntimeError(f"{exc}; rollback also failed: {rollback_exc}")
+                state["applied"] = False
+                state["needs_restore"] = not rollback_ok
+                state["failure_latched"] = True
+                if rollback_ok:
+                    state["requested"] = False
+                    state["baseline"] = None
+                mark_state(state, blocked="apply_failed", error=str(exc))
+                save_state(state)
+                return False, str(exc)
+        state["applied"] = True
+        state["needs_restore"] = True
+        mark_state(state)
+        save_state(state)
+        return True, "responsive_app_launches"
+
+    if state["applied"] or state["needs_restore"]:
+        try:
+            restore_owned(config, state, observed)
+        except Exception as exc:
+            mark_state(state, blocked="restore_failed", error=str(exc))
+            save_state(state)
+            return False, str(exc)
+        observed = observe()
+    clear_ownership(state)
+    if not tuning_matches(observed, stock):
+        message = "disabled backend requires exact stock battery-Balanced values"
+        mark_state(state, blocked="unexpected_unowned_policy", error=message)
+        save_state(state)
+        return False, message
+    if not state["failure_latched"]:
+        mark_state(state)
+    else:
+        state["last_reconcile_unix"] = int(time.time())
+    save_state(state)
+    return True, "stock"
+
+
+def reconcile(reason: str) -> tuple[bool, str]:
+    with Locked():
+        return reconcile_locked(reason)
+
+
+def set_requested(enabled: bool) -> tuple[bool, str]:
+    with Locked():
+        state = load_state(strict=True)
+        if enabled:
+            if not service_active():
+                return False, "watcher service is inactive"
+            if not state["initialized"]:
+                return False, "stock baseline has not been initialized"
+            if state["quiesced"]:
+                return False, "watcher service is quiescing"
+            state["failure_latched"] = False
+        state["requested"] = enabled
+        state["blocked_reason"] = None
+        state["last_error"] = None
+        if (
+            not enabled
+            and not state["applied"]
+            and not state["needs_restore"]
+        ):
+            # A baseline without applied/needs_restore is the intentional
+            # pre-write crash boundary. No sysfs ownership was established.
+            state["baseline"] = None
+            state["failure_latched"] = False
+            mark_state(state)
+            save_state(state)
+            return True, "disabled with clean ownership"
+        save_state(state)
+        ok, detail = reconcile_locked("set_on" if enabled else "set_off")
+        if not enabled and ok:
+            state = load_state(strict=True)
+            if not state["needs_restore"]:
+                state["failure_latched"] = False
+                if state["blocked_reason"] not in {"provider_drift"}:
+                    state["blocked_reason"] = None
+                    state["last_error"] = None
+                save_state(state)
+        return ok, detail
+
+
+def activate_service() -> tuple[bool, str]:
+    with Locked():
+        state = load_state(strict=True)
+        state["quiesced"] = False
+        save_state(state)
+        return reconcile_locked("startup")
+
+
+def quiesce_service() -> tuple[bool, str]:
+    with Locked():
+        state = load_state(strict=True)
+        state["quiesced"] = True
+        save_state(state)
+        if (
+            not state["applied"]
+            and not state["needs_restore"]
+        ):
+            state["baseline"] = None
+            save_state(state)
+            return True, "quiesced with clean ownership"
+        ok, detail = reconcile_locked("quiesce")
+        after = load_state(strict=True)
+        if after["needs_restore"]:
+            return False, f"quiesce left a rollback obligation: {detail}"
+        return True, "quiesced" if ok else f"quiesced after: {detail}"
+
+
+def verify_removable() -> tuple[bool, str]:
+    try:
+        state = load_state(strict=True)
+    except Exception as exc:
+        return False, str(exc)
+    if service_active():
+        return False, "service is still active"
+    if state["requested"]:
+        return False, "preference is still enabled"
+    if state["applied"] or state["needs_restore"] or state.get("baseline") is not None:
+        return False, "rollback ownership has not been cleared"
+    return True, "safe: service inactive and rollback ownership is clean"
+
+
+def source_name(observed: Mapping[str, Any]) -> str:
+    if externally_powered(observed):
+        return "ac"
+    if observed.get("on_battery") is True:
+        return "battery"
+    return "unknown"
+
+
+def actual_document(observed: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "slider_balance": observed["slider_balance"],
+        "slider_offset": observed["slider_offset"],
+        "epp_values": sorted(set(observed["epp"].values())),
+        "platform_profiles": {
+            name: item["profile"] for name, item in observed["platform"].items()
+        },
+    }
+
+
+def probe_document(config_override: Path) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "schema": 1,
+        "installed": False,
+        "supported": False,
+        "available": False,
+        "enabled": False,
+        "requested": False,
+        "effective": False,
+        "can_enable_now": False,
+        "health": "blocked",
+        "reason": "observation_failed",
+        "detail": None,
+        "source": "unknown",
+        "profile": None,
+        "actual": None,
+    }
+    try:
+        config = load_json(config_override)
+        observed = observe()
+        errors = static_audit(config, observed)
+    except Exception as exc:
+        result["detail"] = str(exc)
+        return result
+    eligible, eligibility_reason = is_eligible(observed)
+    stock = tuning_matches(observed, config["stock_battery_balanced"])
+    supported = not errors
+    can_enable = bool(supported and eligible and stock)
+    result.update(
+        {
+            "supported": supported,
+            "available": can_enable,
+            "can_enable_now": can_enable,
+            "source": source_name(observed),
+            "profile": observed["active_profile"],
+            "actual": actual_document(observed),
+        }
+    )
+    if errors:
+        result["reason"] = "unsupported"
+        result["detail"] = "; ".join(errors)
+    elif not eligible:
+        result["health"] = "ok"
+        result["reason"] = eligibility_reason
+    elif not stock:
+        result["reason"] = "unexpected_unowned_policy"
+        result["detail"] = "first enable requires exact stock values"
+    else:
+        result["health"] = "ok"
+        result["reason"] = "ready"
+    return result
+
+
+def status_document() -> dict[str, Any]:
+    state = load_state()
+    active = service_active()
+    valid = state.get("_valid") is True
+    result: dict[str, Any] = {
+        "schema": 1,
+        "installed": True,
+        "supported": False,
+        "available": False,
+        # A pending rollback stays user-visible/actionable even after an OFF
+        # request. `requested` separately reports the user's preference.
+        "enabled": bool(state["requested"] or state["needs_restore"]),
+        "requested": bool(state["requested"]),
+        "effective": False,
+        "can_enable_now": False,
+        "health": "blocked",
+        "reason": "observation_failed",
+        "detail": None,
+        "source": "unknown",
+        "profile": None,
+        "actual": None,
+        "service_active": active,
+        "state_valid": valid,
+        "initialized": bool(state["initialized"]),
+        "ownership_pending": bool(state["needs_restore"]),
+        "last_reconcile_unix": state.get("last_reconcile_unix"),
+    }
+    try:
+        config = load_json(config_path())
+        observed = observe()
+        errors = static_audit(config, observed)
+    except Exception as exc:
+        result["detail"] = str(exc)
+        return result
+    eligible, eligibility_reason = is_eligible(observed)
+    responsive = config["responsive_battery_balanced"]
+    stock = config["stock_battery_balanced"]
+    supported = not errors
+    effective = bool(
+        state["requested"] and eligible and tuning_matches(observed, responsive)
+    )
+    can_enable = bool(
+        supported
+        and active
+        and valid
+        and state["initialized"]
+        and not state["quiesced"]
+        and eligible
+        and (
+            (state["requested"] and tuning_matches(observed, responsive))
+            or (not state["requested"] and tuning_matches(observed, stock))
+        )
+    )
+    result.update(
+        {
+            "supported": supported,
+            "available": can_enable,
+            "effective": effective,
+            "can_enable_now": can_enable,
+            "source": source_name(observed),
+            "profile": observed["active_profile"],
+            "actual": actual_document(observed),
+        }
+    )
+    if not valid:
+        result["reason"] = "state_corrupt"
+        result["detail"] = state.get("last_error")
+    elif errors:
+        result["reason"] = "provider_drift"
+        result["detail"] = "; ".join(errors)
+    elif not active:
+        result["reason"] = "service_inactive"
+    elif not state["initialized"]:
+        result["reason"] = "baseline_unverified"
+    elif state["requested"] and not state_is_fresh(config, state):
+        result["reason"] = "state_stale"
+    elif state.get("blocked_reason"):
+        result["reason"] = state["blocked_reason"]
+        result["detail"] = state.get("last_error")
+    elif (
+        eligible
+        and not state["requested"]
+        and not state["needs_restore"]
+        and state.get("baseline") is None
+        and not tuning_matches(observed, stock)
+    ):
+        result["reason"] = "unexpected_unowned_policy"
+        result["detail"] = "disabled backend requires exact stock values"
+    elif not state["requested"]:
+        result["health"] = "ok"
+        result["reason"] = "disabled"
+    elif effective:
+        result["health"] = "ok"
+        result["reason"] = "responsive_app_launches"
+    elif not eligible:
+        result["health"] = "ok"
+        result["reason"] = eligibility_reason
+    else:
+        result["health"] = "pending"
+        result["reason"] = "awaiting_reconcile"
+    return result
+
+
+def audit_document(config_override: Path, require_stock: bool) -> dict[str, Any]:
+    try:
+        config = load_json(config_override)
+        observed = observe()
+        errors = static_audit(config, observed)
+        eligible, eligibility_reason = is_eligible(observed)
+        if require_stock:
+            if not eligible:
+                errors.append(
+                    f"first setup requires stock battery Balanced: {eligibility_reason}"
+                )
+            elif not tuning_matches(observed, config["stock_battery_balanced"]):
+                errors.append("live values are not the exact stock baseline")
+        return {
+            "schema": 1,
+            "ok": not errors,
+            "errors": errors,
+            "eligible_now": eligible,
+            "eligibility_reason": eligibility_reason,
+            "source": source_name(observed),
+            "profile": observed["active_profile"],
+            "actual": actual_document(observed),
+        }
+    except Exception as exc:
+        return {"schema": 1, "ok": False, "errors": [str(exc)]}
+
+
+def run_daemon() -> None:
+    if os.geteuid() != 0:
+        raise PermissionError("daemon must run as root")
+    from gi.repository import Gio, GLib
+
+    config = load_json(config_path())
+    debounce_ms = int(config["timing"]["event_debounce_ms"])
+    periodic_seconds = int(config["timing"]["periodic_reconcile_seconds"])
+    loop = GLib.MainLoop()
+    bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+    pending: int | None = None
+
+    def do_reconcile(reason: str) -> bool:
+        nonlocal pending
+        pending = None
+        try:
+            ok, detail = reconcile(reason)
+            if not ok:
+                LOG.error("%s", detail)
+        except Exception:
+            LOG.exception("reconciliation failed")
+        return GLib.SOURCE_REMOVE
+
+    def schedule(reason: str = "dbus_event") -> None:
+        nonlocal pending
+        if pending is not None:
+            GLib.source_remove(pending)
+        pending = GLib.timeout_add(debounce_ms, do_reconcile, reason)
+
+    def changed(*_: object) -> None:
+        schedule("dbus_event")
+
+    for sender, path, changed_interface in (
+        (UP_NAME, UP_PATH, UP_IFACE),
+        (PPD_NAME, PPD_PATH, PPD_IFACE),
+    ):
+        bus.signal_subscribe(
+            sender,
+            "org.freedesktop.DBus.Properties",
+            "PropertiesChanged",
+            path,
+            changed_interface,
+            Gio.DBusSignalFlags.NONE,
+            changed,
+        )
+    bus.signal_subscribe(
+        "org.freedesktop.login1",
+        "org.freedesktop.login1.Manager",
+        "PrepareForSleep",
+        "/org/freedesktop/login1",
+        None,
+        Gio.DBusSignalFlags.NONE,
+        changed,
+    )
+
+    def periodic() -> bool:
+        try:
+            state = load_state()
+            if (
+                not state.get("_valid")
+                or not state["initialized"]
+                or state["requested"]
+                or state["needs_restore"]
+            ):
+                schedule("periodic")
+        except Exception:
+            schedule("periodic")
+        return GLib.SOURCE_CONTINUE
+
+    def startup() -> bool:
+        nonlocal pending
+        pending = None
+        try:
+            ok, detail = activate_service()
+            if not ok:
+                LOG.error("%s", detail)
+        except Exception:
+            LOG.exception("startup reconciliation failed")
+        return GLib.SOURCE_REMOVE
+
+    GLib.timeout_add_seconds(periodic_seconds, periodic)
+    GLib.idle_add(startup)
+    signal.signal(signal.SIGHUP, lambda *_: GLib.idle_add(schedule, "sighup"))
+    signal.signal(signal.SIGTERM, lambda *_: GLib.idle_add(loop.quit))
+    signal.signal(signal.SIGINT, lambda *_: GLib.idle_add(loop.quit))
+    loop.run()
+
+
+def emit(value: Mapping[str, Any]) -> None:
+    json.dump(dict(value), sys.stdout, separators=(",", ":"), sort_keys=True)
+    sys.stdout.write("\n")
+
+
+def usage() -> None:
+    print(
+        "internal usage: core status --json | probe --json CONFIG | "
+        "audit-config --json CONFIG --require-stock | set on|off | "
+        "reconcile | activate | quiesce | verify-removable --json | daemon",
+        file=sys.stderr,
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = sys.argv[1:]
+    if args == ["status", "--json"]:
+        emit(status_document())
+        return
+    if len(args) == 3 and args[:2] == ["probe", "--json"]:
+        emit(probe_document(Path(args[2])))
+        return
+    if len(args) == 4 and args[:2] == ["audit-config", "--json"]:
+        if args[3] != "--require-stock":
+            usage()
+            raise SystemExit(2)
+        document = audit_document(Path(args[2]), True)
+        emit(document)
+        raise SystemExit(0 if document.get("ok") else 1)
+    if len(args) == 2 and args[0] == "set" and args[1] in {"on", "off"}:
+        if os.geteuid() != 0:
+            raise PermissionError("set requires root")
+        ok, detail = set_requested(args[1] == "on")
+        document = status_document()
+        document["operation"] = {"ok": ok, "detail": detail}
+        emit(document)
+        raise SystemExit(0 if ok else 1)
+    if args == ["reconcile"]:
+        ok, detail = reconcile("manual")
+        emit({"ok": ok, "detail": detail})
+        raise SystemExit(0 if ok else 1)
+    if args == ["activate"]:
+        ok, detail = activate_service()
+        emit({"ok": ok, "detail": detail})
+        raise SystemExit(0 if ok else 1)
+    if args == ["quiesce"]:
+        ok, detail = quiesce_service()
+        emit({"ok": ok, "detail": detail})
+        raise SystemExit(0 if ok else 1)
+    if args == ["verify-removable", "--json"]:
+        ok, detail = verify_removable()
+        emit({"ok": ok, "detail": detail})
+        raise SystemExit(0 if ok else 1)
+    if args == ["daemon"]:
+        run_daemon()
+        return
+    usage()
+    raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        LOG.error("%s", exc)
+        raise SystemExit(1)

--- a/default/app-launch-responsive/config.json
+++ b/default/app-launch-responsive/config.json
@@ -1,0 +1,59 @@
+{
+  "schema": 1,
+  "hardware": {
+    "sys_vendor": "Dell Inc.",
+    "product_name": "XPS 16 DA16260",
+    "product_sku": "0DBA",
+    "cpu_family": 6,
+    "cpu_model": 204,
+    "preserve": {
+      "hwp_dynamic_boost": "0",
+      "no_turbo": "0",
+      "min_perf_pct": "9",
+      "max_perf_pct": "100"
+    },
+    "epp_paths": [
+      "/sys/devices/system/cpu/cpufreq/policy0/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy1/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy2/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy3/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy4/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy5/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy6/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy7/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy8/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy9/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy10/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy11/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy12/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy13/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy14/energy_performance_preference",
+      "/sys/devices/system/cpu/cpufreq/policy15/energy_performance_preference"
+    ],
+    "platform_profile_realpaths": {
+      "SoC Power Slider": "/sys/devices/pci0000:00/0000:00:04.0/platform-profile/platform-profile-0/profile",
+      "dell-pc": "/sys/devices/faux/dell-pc/platform-profile/platform-profile-1/profile"
+    }
+  },
+  "providers": {
+    "intel_lpmd_config": "/etc/intel_lpmd/intel_lpmd_config_F6_M204.xml",
+    "balanced_slider_dc": "3",
+    "slider_offset_dc": "3",
+    "require_battery_aware": true
+  },
+  "stock_battery_balanced": {
+    "slider_balance": "03",
+    "slider_offset": "03",
+    "epp": "balance_power"
+  },
+  "responsive_battery_balanced": {
+    "slider_balance": "01",
+    "slider_offset": "00",
+    "epp": "balance_performance"
+  },
+  "timing": {
+    "event_debounce_ms": 1000,
+    "post_write_verify_ms": 500,
+    "periodic_reconcile_seconds": 60
+  }
+}

--- a/default/app-launch-responsive/omarchy-app-launch-responsive.service
+++ b/default/app-launch-responsive/omarchy-app-launch-responsive.service
@@ -1,0 +1,58 @@
+[Unit]
+Description=Reduce battery app-launch latency on supported Dell XPS hardware
+Wants=upower.service power-profiles-daemon.service intel_lpmd.service
+After=upower.service power-profiles-daemon.service intel_lpmd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-app-launch-responsive-core daemon
+ExecStop=/usr/bin/omarchy-app-launch-responsive-core quiesce
+ExecStopPost=/usr/bin/omarchy-app-launch-responsive-core quiesce
+Restart=on-failure
+RestartSec=2s
+TimeoutStopSec=20s
+StateDirectory=omarchy-app-launch-responsive
+StateDirectoryMode=0755
+RuntimeDirectory=omarchy-app-launch-responsive
+RuntimeDirectoryMode=0755
+UMask=0022
+User=root
+Group=root
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectSystem=strict
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectClock=yes
+RestrictAddressFamilies=AF_UNIX
+LockPersonality=yes
+SystemCallArchitectures=native
+ProtectKernelTunables=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
+ReadWritePaths=/var/lib/omarchy-app-launch-responsive
+ReadWritePaths=/run/omarchy-app-launch-responsive
+ReadWritePaths=/sys/module/processor_thermal_soc_slider/parameters/slider_balance
+ReadWritePaths=/sys/module/processor_thermal_soc_slider/parameters/slider_offset
+ReadWritePaths=/sys/devices/pci0000:00/0000:00:04.0/platform-profile/platform-profile-0/profile
+ReadWritePaths=/sys/devices/faux/dell-pc/platform-profile/platform-profile-1/profile
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy0/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy1/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy2/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy3/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy4/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy5/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy6/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy7/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy8/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy9/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy10/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy11/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy12/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy13/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy14/energy_performance_preference
+ReadWritePaths=/sys/devices/system/cpu/cpufreq/policy15/energy_performance_preference
+
+[Install]
+WantedBy=multi-user.target

--- a/default/app-launch-responsive/org.omarchy.app-launch-responsive.policy
+++ b/default/app-launch-responsive/org.omarchy.app-launch-responsive.policy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <vendor>Omarchy</vendor>
+  <vendor_url>https://omarchy.org/</vendor_url>
+  <action id="org.omarchy.app-launch-responsive.set">
+    <description>Change the responsive app-launch preference</description>
+    <message>Authentication is required to change the responsive app-launch preference</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/omarchy-app-launch-responsive-control</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">set</annotate>
+  </action>
+</policyconfig>

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -38,6 +38,43 @@ function parseProfiles(raw, previousIndex) {
   }
 }
 
+function parseResponsiveStatus(raw) {
+  var invalid = {
+    valid: false,
+    supported: false,
+    installed: false,
+    available: false,
+    enabled: false,
+    health: "blocked",
+    reason: "status_invalid"
+  }
+
+  try {
+    var value = JSON.parse(String(raw || ""))
+    if (!value || typeof value !== "object"
+        || typeof value.available !== "boolean"
+        || typeof value.enabled !== "boolean"
+        || (value.supported !== undefined && typeof value.supported !== "boolean")
+        || (value.installed !== undefined && typeof value.installed !== "boolean")) {
+      return invalid
+    }
+
+    return {
+      valid: true,
+      supported: value.supported === undefined
+        ? value.available || value.enabled
+        : value.supported,
+      installed: value.installed === undefined ? value.enabled : value.installed,
+      available: value.available,
+      enabled: value.enabled,
+      health: typeof value.health === "string" ? value.health : "blocked",
+      reason: typeof value.reason === "string" ? value.reason : "status_incomplete"
+    }
+  } catch (error) {
+    return invalid
+  }
+}
+
 function profileIcon(name) {
   if (name === "power-saver") return "󰌪"
   if (name === "balanced") return "󰊚"
@@ -95,6 +132,7 @@ if (typeof module !== "undefined") {
     selectProfileIndex: selectProfileIndex,
     parseKeyValue: parseKeyValue,
     parseProfiles: parseProfiles,
+    parseResponsiveStatus: parseResponsiveStatus,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -19,6 +19,25 @@ Panel {
   property string activeProfile: ""
   property int profileIndex: 0
   property bool cursorActive: false
+  property string cursorSection: "profiles"
+  property bool responsiveSupported: false
+  property bool responsiveInstalled: false
+  property bool responsiveAvailable: false
+  property bool responsiveEnabled: false
+  property bool responsiveBusy: false
+  property string responsiveHealth: "blocked"
+  property string responsiveReason: "unavailable"
+  property string _responsiveStatusOutput: ""
+  readonly property bool responsiveVisible: responsiveSupported || responsiveEnabled
+  readonly property bool responsiveCanToggle: responsiveAvailable || responsiveEnabled
+  readonly property bool responsiveNeedsReview: (
+    responsiveInstalled && responsiveHealth === "blocked"
+  ) || (
+    responsiveEnabled && (
+      responsiveReason === "provider_drift"
+        || responsiveReason === "state_stale"
+    )
+  )
   readonly property bool showPercentage: setting("showPercentage", false) === true
   // With the percentage shown the button paints a text block wider than an
   // icon, so the open-panel mark takes the painted width instead of the
@@ -45,6 +64,11 @@ Panel {
   function activateSelectedProfile() {
     if (profileIndex < 0 || profileIndex >= profiles.length) return
     setProfile(profiles[profileIndex])
+  }
+
+  function activateCurrentControl() {
+    if (cursorSection === "responsive" && responsiveVisible) toggleResponsive()
+    else if (cursorSection === "profiles") activateSelectedProfile()
   }
 
   function batteryIcon() {
@@ -138,6 +162,61 @@ Panel {
     if (!batteryProc.running) batteryProc.running = true
     if (!profilesProc.running) profilesProc.running = true
     if (!systemProc.running) systemProc.running = true
+    refreshResponsive()
+  }
+
+  function refreshResponsive() {
+    if (responsiveStatusProc.running || responsiveActionProc.running) return
+    _responsiveStatusOutput = ""
+    responsiveStatusProc.running = true
+  }
+
+  function normalizeResponsiveCursor() {
+    if (!responsiveVisible && cursorSection === "responsive") {
+      cursorSection = "profiles"
+    }
+  }
+
+  function applyResponsiveStatus(raw, exitCode) {
+    if (exitCode !== 0) {
+      responsiveSupported = false
+      responsiveAvailable = false
+      responsiveHealth = "blocked"
+      responsiveReason = "status_error"
+      normalizeResponsiveCursor()
+      return
+    }
+
+    var status = Model.parseResponsiveStatus(raw)
+    if (!status.valid) {
+      responsiveSupported = false
+      responsiveAvailable = false
+      responsiveHealth = "blocked"
+      responsiveReason = "status_invalid"
+      normalizeResponsiveCursor()
+      return
+    }
+
+    responsiveSupported = status.supported
+    responsiveInstalled = status.installed
+    responsiveAvailable = status.available
+    responsiveEnabled = status.enabled
+    responsiveHealth = status.health
+    responsiveReason = status.reason
+    normalizeResponsiveCursor()
+  }
+
+  function toggleResponsive() {
+    if (!responsiveCanToggle || responsiveBusy
+        || responsiveStatusProc.running || responsiveActionProc.running) return
+
+    responsiveBusy = true
+    responsiveActionProc.command = [
+      "omarchy-app-launch-responsive",
+      "set",
+      responsiveEnabled ? "off" : "on"
+    ]
+    responsiveActionProc.running = true
   }
 
   function updateKeyValue(raw, targetName) {
@@ -196,6 +275,7 @@ Panel {
       var idx = profiles.indexOf(activeProfile)
       profileIndex = idx >= 0 ? idx : 0
       cursorActive = false
+      cursorSection = "profiles"
     }
   }
 
@@ -226,6 +306,28 @@ Panel {
   Process {
     id: actionProc
     onExited: root.refresh()
+  }
+
+  Process {
+    id: responsiveStatusProc
+    command: ["omarchy-app-launch-responsive", "status", "--json"]
+    stdout: StdioCollector {
+      id: responsiveStatusStdout
+      waitForEnd: true
+      onStreamFinished: root._responsiveStatusOutput = text
+    }
+    onExited: function(exitCode) {
+      var output = String(responsiveStatusStdout.text || root._responsiveStatusOutput || "")
+      root.applyResponsiveStatus(output, exitCode)
+    }
+  }
+
+  Process {
+    id: responsiveActionProc
+    onExited: function() {
+      root.responsiveBusy = false
+      root.refreshResponsive()
+    }
   }
 
   Timer { interval: 5000; running: root.opened; repeat: true; onTriggered: root.refresh() }
@@ -303,11 +405,23 @@ Panel {
       id: keyCatcher
       anchors.fill: parent
       onMoveRequested: function(dx, dy) {
-        if (!root.cursorActive) { root.cursorActive = true; return }
-        if (dx !== 0) root.selectProfileByDelta(dx)
-        else if (dy !== 0) root.selectProfileByDelta(dy)
+        if (!root.cursorActive) {
+          root.cursorActive = true
+          root.cursorSection = root.responsiveVisible && dy < 0 ? "responsive" : "profiles"
+          return
+        }
+        if (!root.responsiveVisible) {
+          if (dx !== 0) root.selectProfileByDelta(dx)
+          else if (dy !== 0) root.selectProfileByDelta(dy)
+        } else if (dy < 0) {
+          root.cursorSection = "responsive"
+        } else if (dy > 0) {
+          root.cursorSection = "profiles"
+        } else if (dx !== 0 && root.cursorSection === "profiles") {
+          root.selectProfileByDelta(dx)
+        }
       }
-      onActivateRequested: if (root.cursorActive) root.activateSelectedProfile()
+      onActivateRequested: if (root.cursorActive) root.activateCurrentControl()
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
 
@@ -448,6 +562,44 @@ Panel {
           }
         }
 
+        // ---------- Faster app launches ----------
+        Column {
+          visible: root.responsiveVisible
+          width: parent.width
+          spacing: Style.space(14)
+
+          PanelSeparator {
+            width: parent.width
+            foreground: root.bar.foreground
+          }
+
+          Toggle {
+            id: responsiveToggle
+            width: parent.width
+            label: "Faster app launches"
+            description: root.responsiveNeedsReview
+              ? "Needs review"
+              : (root.responsiveAvailable || root.responsiveEnabled
+                ? "On battery in Balanced mode"
+                : (root.responsiveInstalled
+                  ? "Unplug and select Balanced to enable"
+                  : "Unplug and select Balanced to set up"))
+            checked: root.responsiveEnabled
+            enabled: root.responsiveCanToggle && !root.responsiveBusy
+            opacity: responsiveToggle.enabled ? 1.0 : 0.45
+            hasCursor: root.cursorActive && root.cursorSection === "responsive"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            onHovered: function(h) {
+              if (h) {
+                root.cursorActive = true
+                root.cursorSection = "responsive"
+              }
+            }
+            onClicked: root.toggleResponsive()
+          }
+        }
+
         // ---------- Power profile picker ----------
         PanelSeparator {
           foreground: root.bar.foreground
@@ -488,11 +640,12 @@ Panel {
                 verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
                 bordered: true
                 active: root.activeProfile === modelData
-                hasCursor: root.cursorActive && root.profileIndex === index
+                hasCursor: root.cursorActive && root.cursorSection === "profiles" && root.profileIndex === index
                 onClicked: root.setProfile(modelData)
                 onHovered: function(h) {
                   if (h) {
                     root.cursorActive = true
+                    root.cursorSection = "profiles"
                     root.profileIndex = index
                   }
                 }

--- a/test/shell.d/app-launch-responsive-control-test.sh
+++ b/test/shell.d/app-launch-responsive-control-test.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+control="$ROOT/bin/omarchy-app-launch-responsive-control"
+test_tmp=$(mktemp -d)
+trap 'rm -rf -- "$test_tmp"' EXIT
+
+mock_core="$test_tmp/mock-core"
+cat >"$mock_core" <<'SH'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$CONTROL_TEST_LOG"
+
+case "${1:-}:${2:-}" in
+  status:--json)
+    pending=$(<"$CONTROL_TEST_PENDING")
+    printf '{"ownership_pending":%s,"requested":false}\n' "$pending"
+    ;;
+  set:off)
+    if [[ ${CONTROL_TEST_OFF_FAIL:-false} == true ]]; then
+      exit 1
+    fi
+    printf '%s\n' false >"$CONTROL_TEST_PENDING"
+    printf '%s\n' '{"operation":{"ok":true}}'
+    ;;
+  set:on)
+    if [[ ${CONTROL_TEST_ON_FAIL:-false} == true ]]; then
+      exit 1
+    fi
+    printf '%s\n' '{"operation":{"ok":true}}'
+    ;;
+  audit-config:--json | activate: | reconcile: | verify-removable:--json)
+    printf '%s\n' '{"ok":true}'
+    ;;
+  probe:--json)
+    printf '%s\n' '{"supported":true,"available":true}'
+    ;;
+  *)
+    echo "unexpected mock core invocation: $*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$mock_core"
+
+export CONTROL_TEST_LOG="$test_tmp/core.log"
+export CONTROL_TEST_PENDING="$test_tmp/pending"
+: >"$CONTROL_TEST_LOG"
+printf '%s\n' false >"$CONTROL_TEST_PENDING"
+
+(
+  # Sourcing exposes the actual helper functions without running privileged main.
+  source "$control"
+  core="$mock_core"
+  [[ $(status_field ownership_pending) == false ]] ||
+    fail "status_field treats a valid false boolean as a command failure"
+)
+pass "control reads false JSON ownership booleans without jq -e ambiguity"
+
+rollback_root="$test_tmp/rollback"
+mkdir -p "$rollback_root/state" "$rollback_root/runtime"
+touch "$rollback_root/config" "$rollback_root/unit" "$rollback_root/policy" \
+  "$rollback_root/state/state.json"
+printf '%s\n' true >"$CONTROL_TEST_PENDING"
+: >"$CONTROL_TEST_LOG"
+(
+  source "$control"
+  core="$mock_core"
+  config="$rollback_root/config"
+  unit="$rollback_root/unit"
+  policy="$rollback_root/policy"
+  wants="$rollback_root/wants"
+  state_dir="$rollback_root/state"
+  state_file="$state_dir/state.json"
+  runtime_dir="$rollback_root/runtime"
+  service_active() { return 1; }
+  systemctl() { return 0; }
+  reload_managers() { return 0; }
+  rollback_incomplete_setup
+)
+grep -Fxq 'set off' "$CONTROL_TEST_LOG" ||
+  fail "rollback skipped core restoration while ownership was pending"
+grep -Fxq 'verify-removable --json' "$CONTROL_TEST_LOG" ||
+  fail "rollback did not verify clean ownership after restoration"
+[[ ! -e $rollback_root/config && ! -e $rollback_root/state ]] ||
+  fail "verified incomplete setup artifacts were not removed"
+pass "incomplete setup executes restore before verified cleanup"
+
+stop_root="$test_tmp/stop-failure"
+mkdir -p "$stop_root/state" "$stop_root/runtime"
+touch "$stop_root/config" "$stop_root/unit" "$stop_root/policy" \
+  "$stop_root/state/state.json"
+printf '%s\n' true >"$CONTROL_TEST_PENDING"
+if (
+  source "$control"
+  core="$mock_core"
+  config="$stop_root/config"
+  unit="$stop_root/unit"
+  policy="$stop_root/policy"
+  wants="$stop_root/wants"
+  state_dir="$stop_root/state"
+  state_file="$state_dir/state.json"
+  runtime_dir="$stop_root/runtime"
+  service_active() { return 0; }
+  systemctl() { return 1; }
+  reload_managers() { return 0; }
+  rollback_incomplete_setup
+); then
+  fail "setup rollback succeeded despite a service that would not stop"
+fi
+[[ -e $stop_root/config && -e $stop_root/state/state.json ]] ||
+  fail "setup rollback deleted recovery files while the service remained active"
+pass "setup rollback retains every recovery artifact when stop fails"
+
+drift_root="$test_tmp/drift-off"
+mkdir -p "$drift_root"
+touch "$drift_root/config"
+: >"$CONTROL_TEST_LOG"
+printf '%s\n' true >"$CONTROL_TEST_PENDING"
+(
+  source "$control"
+  core="$mock_core"
+  config="$drift_root/config"
+  unit="$drift_root/missing-unit"
+  policy="$drift_root/missing-policy"
+  state_dir="$drift_root/missing-state"
+  disable_existing
+)
+grep -Fxq 'set off' "$CONTROL_TEST_LOG" ||
+  fail "OFF recovery was blocked by missing or drifted non-core artifacts"
+pass "OFF remains directly actionable despite service/policy/template drift"
+
+first_root="$test_tmp/first-apply"
+mkdir -p "$first_root/source"
+touch "$first_root/source/config.json" \
+  "$first_root/source/omarchy-app-launch-responsive.service" \
+  "$first_root/source/org.omarchy.app-launch-responsive.policy"
+: >"$CONTROL_TEST_LOG"
+# Simulate a failed first apply that initially reports rollback ownership. The
+# setup transaction must retry OFF before deciding to retain recovery state.
+printf '%s\n' true >"$CONTROL_TEST_PENDING"
+export CONTROL_TEST_ON_FAIL=true
+set +e
+(
+  source "$control"
+  core="$mock_core"
+  source_dir="$first_root/source"
+  config="$first_root/config"
+  unit="$first_root/unit"
+  policy="$first_root/policy"
+  wants="$first_root/wants"
+  state_dir="$first_root/state"
+  state_file="$state_dir/state.json"
+  runtime_dir="$first_root/runtime"
+  owned_files=("$config" "$unit" "$policy")
+  owned_paths=("${owned_files[@]}" "$wants" "$state_dir" "$runtime_dir")
+  active=false
+  enabled=false
+  service_active() { [[ $active == true ]]; }
+  service_enabled() { [[ $enabled == true ]]; }
+  install_templates() {
+    touch "$config" "$unit" "$policy"
+  }
+  reload_managers() { return 0; }
+  assert_installed_shape() { return 0; }
+  assert_templates_current() { return 0; }
+  systemctl() {
+    if [[ $1 == "enable" ]]; then
+      enabled=true
+      active=true
+      mkdir -p "$state_dir" "$runtime_dir"
+      touch "$state_file"
+      ln -s "$unit" "$wants"
+    fi
+    return 0
+  }
+  fresh_enable
+)
+first_rc=$?
+set -e
+unset CONTROL_TEST_ON_FAIL
+((first_rc != 0 && first_rc != 125)) ||
+  fail "clean first-apply failure did not preserve its original failure status"
+[[ -e $first_root/config && -e $first_root/unit && -e $first_root/state/state.json ]] ||
+  fail "clean first-apply failure left a partial persistent installation"
+grep -Fxq 'set off' "$CONTROL_TEST_LOG" ||
+  fail "clean first-apply failure was not finalized OFF"
+pass "failed first apply retains a complete, clean, OFF backend"

--- a/test/shell.d/app-launch-responsive-core-test.py
+++ b/test/shell.d/app-launch-responsive-core-test.py
@@ -1,0 +1,615 @@
+#!/usr/bin/python3
+
+from __future__ import annotations
+
+import copy
+import importlib.machinery
+import json
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from typing import Mapping
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CORE_PATH = ROOT / "bin/omarchy-app-launch-responsive-core"
+CONFIG_PATH = ROOT / "default/app-launch-responsive/config.json"
+
+loader = importlib.machinery.SourceFileLoader("app_launch_responsive_core", str(CORE_PATH))
+core = types.ModuleType(loader.name)
+loader.exec_module(core)
+
+
+def config() -> dict:
+    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def observed(value: dict | None = None) -> dict:
+    cfg = config()
+    epp_paths = cfg["hardware"]["epp_paths"]
+    platform_paths = cfg["hardware"]["platform_profile_realpaths"]
+    result = {
+        "sys_vendor": "Dell Inc.",
+        "product_name": "XPS 16 DA16260",
+        "product_sku": "0DBA",
+        "cpu_family": 6,
+        "cpu_model": 204,
+        "on_battery": True,
+        "active_profile": "balanced",
+        "battery_aware": True,
+        "ppd_profiles": [
+            {
+                "Profile": "balanced",
+                "CpuDriver": "intel_pstate",
+                "PlatformDriver": "platform_profile",
+            }
+        ],
+        "lpmd_active": True,
+        "platform": {
+            name: {
+                "realpath": path,
+                "profile": "balanced",
+                "choices": ["low-power", "balanced", "performance"],
+            }
+            for name, path in platform_paths.items()
+        },
+        "epp": {path: "balance_power" for path in epp_paths},
+        "epp_choices": {
+            path: ["performance", "balance_performance", "balance_power", "power"]
+            for path in epp_paths
+        },
+        "epp_drivers": {path: "intel_pstate" for path in epp_paths},
+        "slider_balance": "03",
+        "slider_offset": "03",
+        "preserve": {
+            "hwp_dynamic_boost": "0",
+            "no_turbo": "0",
+            "min_perf_pct": "9",
+            "max_perf_pct": "100",
+        },
+        "external_power": {"AC": {"type": "Mains", "online": "0"}},
+        "batteries": {"BAT0": {"present": "1", "status": "Discharging"}},
+    }
+    if value:
+        result.update(value)
+    return result
+
+
+class StaticAuditTest(unittest.TestCase):
+    def test_exact_supported_capabilities_pass(self) -> None:
+        with patch.object(core, "lpmd_semantic_errors", return_value=[]):
+            self.assertEqual(core.static_audit(config(), observed()), [])
+
+    def test_vendor_product_sku_and_cpu_are_all_exact(self) -> None:
+        keys = ("sys_vendor", "product_name", "product_sku", "cpu_family", "cpu_model")
+        with patch.object(core, "lpmd_semantic_errors", return_value=[]):
+            for key in keys:
+                sample = observed({key: "wrong"})
+                self.assertTrue(
+                    any(error.startswith(f"{key}:") for error in core.static_audit(config(), sample)),
+                    key,
+                )
+
+    def test_epp_inventory_capability_and_driver_are_gated(self) -> None:
+        cfg = config()
+        path = cfg["hardware"]["epp_paths"][0]
+        with patch.object(core, "lpmd_semantic_errors", return_value=[]):
+            sample = observed()
+            sample["epp"].pop(path)
+            self.assertIn("EPP policy path inventory changed", core.static_audit(cfg, sample))
+
+            sample = observed()
+            sample["epp_choices"][path].remove("balance_performance")
+            self.assertTrue(any("EPP capabilities changed" in error for error in core.static_audit(cfg, sample)))
+
+            sample = observed()
+            sample["epp_drivers"][path] = "acpi-cpufreq"
+            self.assertTrue(any("not intel_pstate" in error for error in core.static_audit(cfg, sample)))
+
+    def test_platform_provider_and_ppd_semantics_are_gated(self) -> None:
+        cfg = config()
+        with patch.object(core, "lpmd_semantic_errors", return_value=[]):
+            sample = observed()
+            sample["platform"]["dell-pc"]["realpath"] = "/wrong"
+            self.assertIn("platform profile realpaths changed", core.static_audit(cfg, sample))
+
+            sample = observed({"battery_aware": False})
+            self.assertIn("power-profiles-daemon BatteryAware is false", core.static_audit(cfg, sample))
+
+            sample = observed()
+            sample["ppd_profiles"][0]["CpuDriver"] = "other"
+            self.assertIn("power-profiles-daemon balanced providers changed", core.static_audit(cfg, sample))
+
+    def test_non_target_pstate_baseline_is_exactly_gated(self) -> None:
+        cfg = config()
+        sample = observed()
+        sample["preserve"]["min_perf_pct"] = "8"
+        with patch.object(core, "lpmd_semantic_errors", return_value=[]):
+            self.assertIn(
+                "non-target Intel P-state baseline changed",
+                core.static_audit(cfg, sample),
+            )
+
+    def test_lpmd_gate_checks_only_relevant_semantics(self) -> None:
+        cfg = config()
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "lpmd.xml"
+            cfg["providers"]["intel_lpmd_config"] = str(path)
+            path.write_text(
+                """<Configuration>
+                <BalancedSliderDC>3</BalancedSliderDC>
+                <SliderOffsetDC>3</SliderOffsetDC>
+                <States><CPUFamily>6</CPUFamily><CPUModel>204</CPUModel></States>
+                </Configuration>""",
+                encoding="utf-8",
+            )
+            self.assertEqual(core.lpmd_semantic_errors(cfg), [])
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "<BalancedSliderDC>3", "<BalancedSliderDC>2"
+                ),
+                encoding="utf-8",
+            )
+            self.assertTrue(any("BalancedSliderDC" in error for error in core.lpmd_semantic_errors(cfg)))
+
+    def test_no_volatile_version_or_supply_inventory_pins(self) -> None:
+        raw = CONFIG_PATH.read_text(encoding="utf-8")
+        for forbidden in (
+            "bios_version",
+            "kernel_release",
+            "microcode",
+            "package_version",
+            "srcversion",
+            "vermagic",
+            "sha256",
+            "power_supply_inventory",
+        ):
+            self.assertNotIn(forbidden, raw)
+
+
+class PowerSupplySnapshotTest(unittest.TestCase):
+    def write_supply(self, root: Path, name: str, values: Mapping[str, str]) -> None:
+        directory = root / name
+        directory.mkdir()
+        for key, value in values.items():
+            (directory / key).write_text(f"{value}\n", encoding="utf-8")
+
+    def test_device_scoped_peripherals_are_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.write_supply(
+                root,
+                "BAT0",
+                {
+                    "scope": "System",
+                    "type": "Battery",
+                    "present": "1",
+                    "status": "Discharging",
+                },
+            )
+            self.write_supply(root, "AC", {"type": "Mains", "online": "0"})
+            self.write_supply(root, "mouse", {"scope": "Device"})
+            with patch.object(core, "POWER_SUPPLY_ROOT", root):
+                external, batteries = core.power_supply_snapshot()
+            self.assertEqual(set(external), {"AC"})
+            self.assertEqual(set(batteries), {"BAT0"})
+
+    def test_unknown_supply_scope_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.write_supply(
+                root,
+                "mystery",
+                {"scope": "SomethingNew", "type": "Mains", "online": "0"},
+            )
+            with patch.object(core, "POWER_SUPPLY_ROOT", root):
+                with self.assertRaisesRegex(RuntimeError, "unknown scope"):
+                    core.power_supply_snapshot()
+
+
+class StateValidationTest(unittest.TestCase):
+    def test_ownership_invariants_fail_closed(self) -> None:
+        applied_without_restore = core.default_state()
+        applied_without_restore["applied"] = True
+        with self.assertRaisesRegex(core.StateFileError, "rollback obligation"):
+            core.validate_state(applied_without_restore)
+
+        restore_without_baseline = core.default_state()
+        restore_without_baseline["needs_restore"] = True
+        with self.assertRaisesRegex(core.StateFileError, "requires a baseline"):
+            core.validate_state(restore_without_baseline)
+
+
+class EligibilityTest(unittest.TestCase):
+    def test_only_discharging_battery_balanced_is_eligible(self) -> None:
+        self.assertEqual(core.is_eligible(observed()), (True, "eligible"))
+        cases = (
+            ({"external_power": {"AC": {"online": "1"}}}, "ac_power"),
+            ({"external_power": {"AC": {"online": None}}}, "physical_source_unknown"),
+            ({"on_battery": False}, "source_disagreement"),
+            ({"batteries": {"BAT0": {"present": "1", "status": "Charging"}}}, "battery_not_discharging"),
+            ({"active_profile": "performance"}, "profile_performance"),
+        )
+        for update, reason in cases:
+            self.assertEqual(core.is_eligible(observed(update)), (False, reason))
+
+        sample = observed()
+        sample["platform"]["dell-pc"]["profile"] = "performance"
+        self.assertEqual(core.is_eligible(sample), (False, "platform_profile_not_balanced"))
+
+
+class WriteTuningGateTest(unittest.TestCase):
+    def test_static_audit_failure_prevents_every_write(self) -> None:
+        writes: list[tuple[Path, str]] = []
+        with (
+            patch.object(core, "static_audit", return_value=["identity drift"]),
+            patch.object(core, "write", side_effect=lambda path, value: writes.append((path, value))),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "provider drift"):
+                core.write_tuning(
+                    config(), config()["responsive_battery_balanced"], observed()
+                )
+        self.assertEqual(writes, [])
+
+
+class ReconcileHarness(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        root = Path(self.temp.name)
+        self.state_path = root / "state.json"
+        self.lock_path = root / "control.lock"
+        self.config = config()
+        self.current = observed()
+        self.writes: list[dict] = []
+        self.fail_writes = 0
+        self.drift_after_failed_write = None
+        self.real_static_audit = core.static_audit
+
+        self.patches = (
+            patch.object(core.os, "geteuid", return_value=0),
+            patch.object(core, "config_path", return_value=root / "config.json"),
+            patch.object(core, "state_path", return_value=self.state_path),
+            patch.object(core, "lock_path", return_value=self.lock_path),
+            patch.object(core, "load_json", return_value=self.config),
+            patch.object(core, "observe", side_effect=self.observe),
+            patch.object(core, "static_audit", return_value=[]),
+            patch.object(core, "service_active", return_value=True),
+            patch.object(core, "write_tuning", side_effect=self.write_tuning),
+        )
+        for item in self.patches:
+            item.start()
+            self.addCleanup(item.stop)
+
+    def observe(self) -> dict:
+        return copy.deepcopy(self.current)
+
+    def write_tuning(self, _config: dict, target: Mapping, _observed: Mapping) -> dict:
+        self.writes.append(copy.deepcopy(dict(target)))
+        if self.fail_writes:
+            self.fail_writes -= 1
+            if self.drift_after_failed_write is not None:
+                self.drift_after_failed_write(self.current)
+            raise RuntimeError("simulated write failure")
+        self.current["slider_balance"] = target["slider_balance"]
+        self.current["slider_offset"] = target["slider_offset"]
+        wanted_epp = target["epp"]
+        if isinstance(wanted_epp, Mapping):
+            self.current["epp"] = dict(wanted_epp)
+        else:
+            self.current["epp"] = {
+                path: wanted_epp for path in self.config["hardware"]["epp_paths"]
+            }
+        if isinstance(target.get("platform"), Mapping):
+            for name, value in target["platform"].items():
+                self.current["platform"][name]["profile"] = value
+        return self.observe()
+
+    def state(self) -> dict:
+        return json.loads(self.state_path.read_text(encoding="utf-8"))
+
+    def initialize(self) -> None:
+        ok, detail = core.reconcile("test_initialize")
+        self.assertTrue(ok, detail)
+        self.assertTrue(self.state()["initialized"])
+
+    def enable(self) -> None:
+        self.initialize()
+        ok, detail = core.set_requested(True)
+        self.assertTrue(ok, detail)
+
+    def test_enable_captures_stock_then_applies_exact_target(self) -> None:
+        self.enable()
+        state = self.state()
+        self.assertTrue(state["requested"])
+        self.assertTrue(state["applied"])
+        self.assertTrue(state["needs_restore"])
+        self.assertEqual(state["baseline"]["slider_balance"], "03")
+        self.assertEqual(self.current["slider_balance"], "01")
+        self.assertEqual(self.current["slider_offset"], "00")
+        self.assertEqual(set(self.current["epp"].values()), {"balance_performance"})
+
+    def test_disable_restores_captured_stock_and_clears_ownership(self) -> None:
+        self.enable()
+        ok, detail = core.set_requested(False)
+        self.assertTrue(ok, detail)
+        state = self.state()
+        self.assertFalse(state["requested"])
+        self.assertFalse(state["applied"])
+        self.assertFalse(state["needs_restore"])
+        self.assertIsNone(state["baseline"])
+        self.assertEqual(self.current["slider_balance"], "03")
+        self.assertEqual(self.current["slider_offset"], "03")
+        self.assertEqual(set(self.current["epp"].values()), {"balance_power"})
+
+    def test_ac_never_writes_and_defers_owned_restore(self) -> None:
+        self.enable()
+        writes_before = len(self.writes)
+        self.current["external_power"]["AC"]["online"] = "1"
+        self.current["on_battery"] = False
+        ok, detail = core.set_requested(False)
+        self.assertFalse(ok)
+        self.assertIn("restore deferred", detail)
+        self.assertEqual(len(self.writes), writes_before)
+        self.assertTrue(self.state()["needs_restore"])
+        self.current["external_power"]["AC"]["online"] = "0"
+        self.current["on_battery"] = True
+        ok, detail = core.reconcile("back_on_dc")
+        self.assertTrue(ok, detail)
+        self.assertFalse(self.state()["needs_restore"])
+        self.assertEqual(self.current["slider_balance"], "03")
+
+    def test_non_balanced_profile_never_writes(self) -> None:
+        self.enable()
+        writes_before = len(self.writes)
+        self.current["active_profile"] = "performance"
+        for item in self.current["platform"].values():
+            item["profile"] = "performance"
+        ok, detail = core.set_requested(False)
+        self.assertFalse(ok)
+        self.assertIn("restore deferred", detail)
+        self.assertEqual(len(self.writes), writes_before)
+
+    def test_failed_apply_rolls_back_and_latches(self) -> None:
+        self.initialize()
+        self.fail_writes = 1
+        ok, detail = core.set_requested(True)
+        self.assertFalse(ok)
+        self.assertIn("simulated write failure", detail)
+        state = self.state()
+        self.assertFalse(state["requested"])
+        self.assertFalse(state["needs_restore"])
+        self.assertTrue(state["failure_latched"])
+        self.assertEqual(len(self.writes), 2)
+
+    def test_failed_apply_and_rollback_preserve_ownership_obligation(self) -> None:
+        self.initialize()
+        self.fail_writes = 2
+        ok, detail = core.set_requested(True)
+        self.assertFalse(ok)
+        self.assertIn("rollback also failed", detail)
+        state = self.state()
+        self.assertTrue(state["needs_restore"])
+        self.assertIsNotNone(state["baseline"])
+        self.assertTrue(state["failure_latched"])
+
+    def test_apply_failure_race_drift_blocks_rollback_write(self) -> None:
+        self.initialize()
+        self.fail_writes = 1
+        self.drift_after_failed_write = lambda sample: sample.__setitem__(
+            "product_sku", "wrong"
+        )
+        core.static_audit.side_effect = self.real_static_audit
+        with patch.object(core, "lpmd_semantic_errors", return_value=[]):
+            ok, detail = core.set_requested(True)
+        self.assertFalse(ok)
+        self.assertIn("simulated write failure", detail)
+        self.assertEqual(len(self.writes), 1)
+        state = self.state()
+        self.assertTrue(state["needs_restore"])
+        self.assertIsNotNone(state["baseline"])
+        self.assertTrue(state["failure_latched"])
+
+    def test_off_discards_prewrite_crash_baseline_even_under_drift(self) -> None:
+        self.initialize()
+        state = self.state()
+        state.update(
+            {
+                "requested": True,
+                "applied": False,
+                "needs_restore": False,
+                "baseline": core.capture_baseline(self.current),
+            }
+        )
+        core.save_state(state)
+        core.static_audit.return_value = ["simulated provider drift"]
+        ok, detail = core.set_requested(False)
+        self.assertTrue(ok, detail)
+        self.assertEqual(self.writes, [])
+        state = self.state()
+        self.assertFalse(state["requested"])
+        self.assertFalse(state["needs_restore"])
+        self.assertIsNone(state["baseline"])
+
+    def test_quiesce_discards_prewrite_crash_baseline(self) -> None:
+        self.initialize()
+        state = self.state()
+        state.update(
+            {
+                "requested": True,
+                "applied": False,
+                "needs_restore": False,
+                "baseline": core.capture_baseline(self.current),
+            }
+        )
+        core.save_state(state)
+        ok, detail = core.quiesce_service()
+        self.assertTrue(ok, detail)
+        self.assertEqual(self.writes, [])
+        state = self.state()
+        self.assertTrue(state["quiesced"])
+        self.assertIsNone(state["baseline"])
+
+    def test_drift_never_writes_and_retains_owned_baseline(self) -> None:
+        self.enable()
+        writes_before = len(self.writes)
+        core.static_audit.return_value = ["simulated provider drift"]
+        ok, detail = core.reconcile("drift")
+        self.assertFalse(ok)
+        self.assertIn("simulated provider drift", detail)
+        state = self.state()
+        self.assertTrue(state["needs_restore"])
+        self.assertIsNotNone(state["baseline"])
+        self.assertTrue(state["failure_latched"])
+        self.assertEqual(len(self.writes), writes_before)
+        self.assertEqual(self.current["slider_balance"], "01")
+
+    def assert_owned_drift_never_writes(self, mutate) -> None:
+        self.enable()
+        writes_before = len(self.writes)
+        mutate(self.current)
+        core.static_audit.side_effect = self.real_static_audit
+        with patch.object(core, "lpmd_semantic_errors", return_value=[]):
+            ok, _detail = core.reconcile("audited_drift")
+        self.assertFalse(ok)
+        self.assertEqual(len(self.writes), writes_before)
+        self.assertTrue(self.state()["needs_restore"])
+        self.assertIsNotNone(self.state()["baseline"])
+
+    def test_identity_drift_never_writes(self) -> None:
+        self.assert_owned_drift_never_writes(
+            lambda sample: sample.__setitem__("product_sku", "wrong")
+        )
+
+    def test_epp_driver_drift_never_writes(self) -> None:
+        path = self.config["hardware"]["epp_paths"][0]
+        self.assert_owned_drift_never_writes(
+            lambda sample: sample["epp_drivers"].__setitem__(path, "acpi-cpufreq")
+        )
+
+    def test_epp_capability_drift_never_writes(self) -> None:
+        path = self.config["hardware"]["epp_paths"][0]
+        self.assert_owned_drift_never_writes(
+            lambda sample: sample["epp_choices"][path].remove("balance_performance")
+        )
+
+    def test_non_target_pstate_drift_never_writes(self) -> None:
+        self.assert_owned_drift_never_writes(
+            lambda sample: sample["preserve"].__setitem__("min_perf_pct", "8")
+        )
+
+    def test_matching_target_without_ownership_is_not_claimed_or_restored(self) -> None:
+        self.initialize()
+        self.current["slider_balance"] = "01"
+        self.current["slider_offset"] = "00"
+        self.current["epp"] = {
+            path: "balance_performance" for path in self.config["hardware"]["epp_paths"]
+        }
+        ok, detail = core.reconcile("unowned_target")
+        self.assertFalse(ok)
+        self.assertIn("exact stock", detail)
+        self.assertEqual(self.writes, [])
+        self.assertFalse(self.state()["needs_restore"])
+
+    def test_quiesce_restores_before_service_stop(self) -> None:
+        self.enable()
+        ok, detail = core.quiesce_service()
+        self.assertTrue(ok, detail)
+        state = self.state()
+        self.assertTrue(state["quiesced"])
+        self.assertFalse(state["needs_restore"])
+        self.assertTrue(state["requested"])
+        self.assertEqual(self.current["slider_balance"], "03")
+
+    def test_installed_availability_requires_eligible_policy(self) -> None:
+        self.initialize()
+        status = core.status_document()
+        self.assertTrue(status["supported"])
+        self.assertTrue(status["available"])
+        self.assertFalse(status["enabled"])
+
+        self.current["external_power"]["AC"]["online"] = "1"
+        self.current["on_battery"] = False
+        status = core.status_document()
+        self.assertTrue(status["supported"])
+        self.assertFalse(status["available"])
+        self.assertFalse(status["enabled"])
+
+    def test_enabled_remains_off_actionable_under_provider_drift(self) -> None:
+        self.enable()
+        core.static_audit.return_value = ["simulated drift"]
+        ok, _detail = core.set_requested(False)
+        self.assertFalse(ok)
+        status = core.status_document()
+        self.assertTrue(status["enabled"])
+        self.assertFalse(status["requested"])
+        self.assertTrue(status["ownership_pending"])
+        self.assertFalse(status["available"])
+        self.assertFalse(status["supported"])
+        self.assertEqual(status["reason"], "provider_drift")
+
+    def test_unowned_non_stock_policy_is_blocked_not_disabled(self) -> None:
+        self.initialize()
+        self.current["slider_balance"] = "02"
+        status = core.status_document()
+        self.assertTrue(status["supported"])
+        self.assertFalse(status["available"])
+        self.assertFalse(status["enabled"])
+        self.assertEqual(status["health"], "blocked")
+        self.assertEqual(status["reason"], "unexpected_unowned_policy")
+
+
+class ProbeTest(unittest.TestCase):
+    def test_preinstall_status_is_available_only_on_supported_hardware(self) -> None:
+        cfg = config()
+        with (
+            patch.object(core, "load_json", return_value=cfg),
+            patch.object(core, "observe", return_value=observed()),
+            patch.object(core, "static_audit", return_value=[]),
+        ):
+            status = core.probe_document(CONFIG_PATH)
+            self.assertFalse(status["installed"])
+            self.assertTrue(status["supported"])
+            self.assertTrue(status["available"])
+            self.assertTrue(status["can_enable_now"])
+            self.assertFalse(status["enabled"])
+
+        ac = observed()
+        ac["external_power"]["AC"]["online"] = "1"
+        ac["on_battery"] = False
+        with (
+            patch.object(core, "load_json", return_value=cfg),
+            patch.object(core, "observe", return_value=ac),
+            patch.object(core, "static_audit", return_value=[]),
+        ):
+            status = core.probe_document(CONFIG_PATH)
+            self.assertTrue(status["supported"])
+            self.assertFalse(status["available"])
+            self.assertFalse(status["can_enable_now"])
+            self.assertEqual(status["reason"], "ac_power")
+
+        performance = observed({"active_profile": "performance"})
+        with (
+            patch.object(core, "load_json", return_value=cfg),
+            patch.object(core, "observe", return_value=performance),
+            patch.object(core, "static_audit", return_value=[]),
+        ):
+            status = core.probe_document(CONFIG_PATH)
+            self.assertTrue(status["supported"])
+            self.assertFalse(status["available"])
+            self.assertEqual(status["reason"], "profile_performance")
+
+        with (
+            patch.object(core, "load_json", return_value=cfg),
+            patch.object(core, "observe", return_value=observed()),
+            patch.object(core, "static_audit", return_value=["wrong SKU"]),
+        ):
+            status = core.probe_document(CONFIG_PATH)
+            self.assertFalse(status["supported"])
+            self.assertFalse(status["available"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/shell.d/app-launch-responsive-test.sh
+++ b/test/shell.d/app-launch-responsive-test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+facade="$ROOT/bin/omarchy-app-launch-responsive"
+control="$ROOT/bin/omarchy-app-launch-responsive-control"
+core="$ROOT/bin/omarchy-app-launch-responsive-core"
+assets="$ROOT/default/app-launch-responsive"
+config="$assets/config.json"
+unit="$assets/omarchy-app-launch-responsive.service"
+policy="$assets/org.omarchy.app-launch-responsive.policy"
+
+python3 -m py_compile "$core" "$ROOT/test/shell.d/app-launch-responsive-core-test.py"
+python3 -m json.tool "$config" >/dev/null
+python3 "$ROOT/test/shell.d/app-launch-responsive-core-test.py"
+pass "responsive app-launch core gates, transitions, ownership, and rollback"
+
+grep -Fq 'Reduce slow app-launch latency' "$facade" ||
+  fail "facade is framed around slow app-launch latency"
+grep -Fq 'probe --json' "$facade" ||
+  fail "facade cannot report exact hardware support before setup"
+grep -Fq 'audit-config --json "$source_dir/config.json" --require-stock' "$control" ||
+  fail "first enable lacks an exact live-stock preflight"
+
+audit_line=$(grep -nF 'audit-config --json "$source_dir/config.json" --require-stock' "$control" | cut -d: -f1)
+first_install_line=$(grep -nF '  install_templates' "$control" | tail -1 | cut -d: -f1)
+((audit_line < first_install_line)) ||
+  fail "first setup mutates the system before its stock preflight"
+pass "first toggle probes support and stock before setup mutations"
+
+grep -Fq 'exec 9>/run/lock/omarchy-app-launch-responsive.lock' "$control" ||
+  fail "privileged setup and preference changes have no fixed serialization lock"
+grep -Fq 'flock -x 9' "$control" || fail "privileged control lock is not exclusive"
+pass "privileged control operations are serialized"
+
+stop_line=$(grep -nF 'systemctl disable --now "$service"' "$control" | head -1 | cut -d: -f1)
+inactive_line=$(grep -nF 'if service_active' "$control" | head -1 | cut -d: -f1)
+verify_line=$(grep -nF '"$core" verify-removable --json' "$control" | head -1 | cut -d: -f1)
+delete_line=$(grep -nF 'rm -f -- "$policy" "$unit" "$config"' "$control" | cut -d: -f1)
+((stop_line < inactive_line && inactive_line < verify_line && verify_line < delete_line)) ||
+  fail "setup rollback deletes files before stop and clean-ownership verification"
+grep -Fq '[[ ! -e $wants && ! -L $wants ]]' "$control" ||
+  fail "setup rollback ignores the systemd wants symlink"
+pass "incomplete setup rollback proves stop, ownership, and wants cleanup before deletion"
+
+grep -Fq 'setup_complete=true' "$control" || fail "first apply is outside the setup transaction"
+grep -Fq 'complete backend was retained OFF' "$control" ||
+  fail "clean first-apply failure does not retain a complete OFF backend"
+pass "failed first apply retains either a complete OFF backend or its recovery watcher"
+
+mapfile -t writable < <(sed -n 's/^ReadWritePaths=//p' "$unit" | sort)
+mapfile -t expected < <(
+  {
+    printf '%s\n' \
+      /run/omarchy-app-launch-responsive \
+      /var/lib/omarchy-app-launch-responsive \
+      /sys/module/processor_thermal_soc_slider/parameters/slider_balance \
+      /sys/module/processor_thermal_soc_slider/parameters/slider_offset
+    jq -r '.hardware.epp_paths[], .hardware.platform_profile_realpaths[]' "$config"
+  } | sort
+)
+[[ ${writable[*]} == "${expected[*]}" ]] ||
+  fail "systemd write allowlist differs from the exact configured paths"
+grep -Fxq 'ProtectSystem=strict' "$unit" || fail "service lacks ProtectSystem=strict"
+grep -Fxq 'ProtectKernelTunables=yes' "$unit" || fail "service lacks ProtectKernelTunables=yes"
+grep -Fxq 'CapabilityBoundingSet=' "$unit" || fail "service retains Linux capabilities"
+pass "root service can write only its exact state and tuned sysfs paths"
+
+grep -Fq '<allow_active>yes</allow_active>' "$policy" ||
+  fail "installed set toggle is not available to the active local user"
+grep -Fq '<allow_inactive>no</allow_inactive>' "$policy" ||
+  fail "inactive sessions can invoke the privileged control helper"
+grep -Fq '/usr/bin/omarchy-app-launch-responsive-control' "$policy" ||
+  fail "Polkit policy is not pinned to the fixed control helper"
+pass "Polkit grants only the fixed active-session helper actions"
+
+for forbidden in bios_version kernel_release microcode package_version srcversion vermagic sha256 power_supply_inventory; do
+  ! grep -Fq "$forbidden" "$config" || fail "config pins volatile field: $forbidden"
+done
+pass "config has no volatile software-version or power-supply inventory pins"

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -19,6 +19,21 @@ assertDeepEqual(
   { profiles: ['power-saver', 'balanced', 'performance'], activeProfile: 'balanced', profileIndex: 2 },
   'power parses profile output and clamps selection'
 )
+assertDeepEqual(
+  power.parseResponsiveStatus('{"available":true,"enabled":true,"health":"ok","reason":"responsive"}'),
+  { valid: true, supported: true, installed: true, available: true, enabled: true, health: 'ok', reason: 'responsive' },
+  'power parses app launch responsiveness status'
+)
+assertDeepEqual(
+  power.parseResponsiveStatus('{"supported":true,"installed":false,"available":false,"enabled":false,"health":"ok","reason":"ineligible"}'),
+  { valid: true, supported: true, installed: false, available: false, enabled: false, health: 'ok', reason: 'ineligible' },
+  'power parses supported app launch setup status'
+)
+assertDeepEqual(
+  power.parseResponsiveStatus('not json'),
+  { valid: false, supported: false, installed: false, available: false, enabled: false, health: 'blocked', reason: 'status_invalid' },
+  'power rejects invalid app launch responsiveness status'
+)
 
 assert(power.profileIcon('performance').length > 0, 'power maps profile icons')
 assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'power clamps battery fraction')
@@ -48,4 +63,12 @@ assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
+assert(/command: \["omarchy-app-launch-responsive", "status", "--json"\]/.test(panelSource), 'power discovers app launch responsiveness support')
+assert(/"omarchy-app-launch-responsive",[\s\S]*?"set",[\s\S]*?responsiveEnabled \? "off" : "on"/.test(panelSource), 'power toggles app launch responsiveness')
+assert(/visible: root\.responsiveVisible[\s\S]*?label: "Faster app launches"/.test(panelSource), 'power only shows the faster app launches toggle when supported')
+assert(/enabled: root\.responsiveCanToggle && !root\.responsiveBusy/.test(panelSource), 'power only enables app launch setup in an eligible state')
+assert(/"Unplug and select Balanced to set up"/.test(panelSource), 'power explains how to make app launch setup available')
+assert(/responsiveInstalled && responsiveHealth === "blocked"/.test(panelSource), 'power flags an installed blocked backend for review')
+assert(/!root\.responsiveVisible[\s\S]*?selectProfileByDelta\(dy\)/.test(panelSource), 'power keeps vertical profile navigation when the hardware toggle is hidden')
+assert(/function normalizeResponsiveCursor\(\)[\s\S]*?!responsiveVisible && cursorSection === "responsive"[\s\S]*?cursorSection = "profiles"/.test(panelSource), 'power clears a hidden app launch cursor')
 JS


### PR DESCRIPTION
## Summary

- Add an opt-in **Faster app launches** switch to the power panel for the exact Dell XPS 16 DA16260 (SKU 0DBA) configuration that was measured.
- In battery Balanced mode only, apply the measured `03/03 + balance_power` to `01/00 + balance_performance` policy change; AC power and other profiles are never modified.
- On first use, authenticate once, verify the exact live stock state, install a constrained root watcher, and journal ownership before any sysfs write.
- Restore the captured stock policy when switched off. Unsupported machines never show the switch.

## Why

On the tested machine, battery Balanced imposed a large delay before unrelated applications showed their first pixel. Literal 120 fps process-cold medians improved as follows:

| App | Stock Balanced | Faster launches | Improvement |
| --- | ---: | ---: | ---: |
| Chrome | 845 ms | 429 ms | 49% |
| Ghostty | 389 ms | 206 ms | 47% |
| Nautilus | 702 ms | 367 ms | 48% |
| Pulse | 539 ms | 313 ms | 42% |

This fixes the machine-wide launch latency rather than changing individual launchers or applications.

## Safety

- Gate every write on exact vendor, model, SKU, CPU, sysfs paths, EPP capabilities/driver, PPD providers, Intel LPMD semantics, and the measured non-target P-state values.
- Require physical battery discharge plus Balanced at both the PPD and platform-provider layers.
- Persist the rollback baseline and ownership obligation before writing; verify the result after writing.
- Treat identity, provider, capability, source, profile, or state drift as zero-write. Keep the rollback journal until all gates are safe again.
- Ignore device-scoped peripheral batteries, serialize privileged operations, and constrain the watcher with a fixed systemd write allowlist and Polkit action.
- Pin no BIOS, kernel, microcode, package version, file hash, or power-supply inventory.

The six-block idle-power comparison estimated +0.167 W with a 95% interval of -0.009 to +0.342 W. It established neither a penalty nor a saving, so this PR makes no battery-runtime claim and leaves the feature off by default.

## Validation

- 32 mocked core tests covering exact gates, transitions, failure races, ownership, crash boundaries, and rollback
- Executable privileged-control failure-injection tests
- Power-panel model, command, visibility, keyboard, and recovery-state tests
- Live panel preview on the target machine
- 32/32 accepted literal first-pixel A/B trials
- 108/108 accepted full policy-grid launch trials
- `omarchy commands --check`: 440 commands
- `./test/all`: CLI passed; 206/209 shell test files passed. The three unchanged local-environment failures require an Omarchy ISO checkout or conflict with installed-system test fixtures: `launch-about`, `snapper`, and `theme-install-guards`.

## Investigation credit

The underlying investigation and validation were carried out with OpenAI Codex using the **Sol** model at **Ultra** reasoning effort over approximately eight hours, including launch-screening, 120 fps first-pixel, power, transition, rollback, and failure-injection testing.
