### PR TITLE
Add declarative Hyprland and terminal theming

### DIFF
--- a/bin/omarchy-theme-color
+++ b/bin/omarchy-theme-color
@@ -173,6 +173,50 @@ parse_colors_file() {
   return 0
 }
 
+resolve_terminal_settings() {
+  local blur="${THEME_COLORS[terminal_blur]:-false}"
+  local opacity="${THEME_COLORS[terminal_opacity]:-1.0}"
+  local radius="${THEME_COLORS[terminal_blur_radius]:-20}"
+
+  # These settings are scalar, so anything after the value is a TOML comment.
+  opacity="${opacity%%#*}"
+  opacity="${opacity%% *}"
+  blur="${blur%%#*}"
+  blur="${blur%% *}"
+  radius="${radius%%#*}"
+  radius="${radius%% *}"
+
+  if [[ ! $opacity =~ ^(0([.][0-9]+)?|1([.]0+)?)$ ]]; then
+    printf 'omarchy-theme-color: invalid terminal_opacity %q; using 1.0\n' "$opacity" >&2
+    opacity="1.0"
+  fi
+
+  if [[ $blur != "true" && $blur != "false" ]]; then
+    printf 'omarchy-theme-color: invalid terminal_blur %q; using false\n' "$blur" >&2
+    blur="false"
+  fi
+
+  if [[ ! $radius =~ ^[0-9]{1,2}$ ]] || (( 10#$radius > 64 )); then
+    printf 'omarchy-theme-color: invalid terminal_blur_radius %q; using 20\n' "$radius" >&2
+    radius=20
+  else
+    radius=$((10#$radius))
+  fi
+
+  THEME_COLORS[terminal_opacity]="$opacity"
+  THEME_COLORS[terminal_blur]="$blur"
+
+  if [[ $blur == "true" ]]; then
+    THEME_COLORS[terminal_blur_radius]="$radius"
+    THEME_COLORS[terminal_blur_foot]="yes"
+    THEME_COLORS[terminal_blur_ghostty]="$radius"
+  else
+    THEME_COLORS[terminal_blur_radius]="0"
+    THEME_COLORS[terminal_blur_foot]="no"
+    THEME_COLORS[terminal_blur_ghostty]="false"
+  fi
+}
+
 resolve_theme_colors() {
   local key
 
@@ -277,6 +321,7 @@ resolve_theme_colors() {
   done
 
   resolve_theme_mode
+  resolve_terminal_settings
   THEME_COLORS[theme_type]="${THEME_COLORS[mode]}"
 }
 

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -268,10 +268,18 @@ mkdir -p "$NEXT_THEME_PATH"
 # Copy official theme first, then overlay the user's theme on top
 cp -r "$OMARCHY_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
 
+HYPRLAND_LUA_FROM_STOCK=0
+if [[ -f $NEXT_THEME_PATH/hyprland.lua ]]; then
+  HYPRLAND_LUA_FROM_STOCK=1
+fi
+
 if theme_came_from_a_repo "$USER_THEMES_PATH/$THEME_NAME"; then
   stage_installed_theme "$USER_THEMES_PATH/$THEME_NAME"
   report_ignored_theme_files
 else
+  if [[ -e $USER_THEMES_PATH/$THEME_NAME/hyprland.lua || -L $USER_THEMES_PATH/$THEME_NAME/hyprland.lua ]]; then
+    HYPRLAND_LUA_FROM_STOCK=0
+  fi
   cp -r "$USER_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
 fi
 
@@ -280,8 +288,9 @@ if [[ ! -f $NEXT_THEME_PATH/colors.toml && -f $NEXT_THEME_PATH/alacritty.toml ]]
   omarchy-theme-colors-from-alacritty "$NEXT_THEME_PATH"
 fi
 
-# Generate dynamic configs
-omarchy-theme-set-templates
+# Generate dynamic configs. A declarative user overlay may extend bundled Lua,
+# while a trusted user-supplied hyprland.lua remains authoritative.
+OMARCHY_THEME_HYPRLAND_LUA_FROM_STOCK="$HYPRLAND_LUA_FROM_STOCK" omarchy-theme-set-templates
 
 OLD_BACKGROUND_SNAPSHOT=""
 if [[ $THEME_HEADLESS != "1" && $OMARCHY_THEME_SKIP_BACKGROUND != "1" ]]; then

--- a/bin/omarchy-theme-set-templates
+++ b/bin/omarchy-theme-set-templates
@@ -367,6 +367,295 @@ apply_shell_section_overrides() {
   done
 }
 
+append_hyprland_toml() {
+  local settings="$NEXT_THEME_DIR/hyprland.toml"
+  local output="$NEXT_THEME_DIR/hyprland.lua"
+  local generated
+
+  [[ -f $settings && -f $output ]] || return
+  generated=$(mktemp)
+
+  if python3 - "$settings" "$COLORS_FILE" >"$generated" <<'PY'
+import json
+import math
+import re
+import sys
+import tomllib
+
+settings_path, colors_path = sys.argv[1:]
+
+
+class InvalidTheme(ValueError):
+    pass
+
+
+def invalid(message):
+    raise InvalidTheme(message)
+
+
+def require_table(value, path):
+    if not isinstance(value, dict):
+        invalid(f"{path} must be a table")
+    return value
+
+
+def reject_unknown(table, allowed, path):
+    unknown = set(table) - set(allowed)
+    if unknown:
+        invalid(f"unknown {path} key: {sorted(unknown)[0]}")
+
+
+def boolean(value, path):
+    if not isinstance(value, bool):
+        invalid(f"{path} must be a boolean")
+    return value
+
+
+def number(value, path, minimum, maximum):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        invalid(f"{path} must be a number")
+    if value < minimum or value > maximum:
+        invalid(f"{path} must be between {minimum} and {maximum}")
+    return value
+
+
+def integer(value, path, minimum, maximum):
+    if isinstance(value, bool) or not isinstance(value, int):
+        invalid(f"{path} must be an integer")
+    return number(value, path, minimum, maximum)
+
+
+def short_name(value, path):
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]{0,63}", value):
+        invalid(f"{path} must be a short name")
+    return value
+
+
+try:
+    with open(settings_path, "rb") as file:
+        document = tomllib.load(file)
+    with open(colors_path, "rb") as file:
+        palette = tomllib.load(file)
+
+    reject_unknown(document, {"schema", "general", "decoration", "group", "beziers", "animations"}, "top-level")
+    if type(document.get("schema")) is not int or document["schema"] != 1:
+        invalid("schema must be 1")
+
+    def color(value, path):
+        if not isinstance(value, str) or len(value) > 64:
+            invalid(f"{path} must be a color or palette key")
+        resolved = palette.get(value, value)
+        if not isinstance(resolved, str):
+            invalid(f"{path} palette reference is not a color")
+        if re.fullmatch(r"#[0-9A-Fa-f]{6}", resolved):
+            return f"rgb({resolved[1:]})"
+        if re.fullmatch(r"#[0-9A-Fa-f]{8}", resolved):
+            return f"rgba({resolved[1:]})"
+        if re.fullmatch(r"rgb\([0-9A-Fa-f]{6}\)|rgba\([0-9A-Fa-f]{8}\)", resolved):
+            return resolved
+        if re.fullmatch(r"0x[0-9A-Fa-f]{8}", resolved):
+            return resolved
+        invalid(f"{path} must be a Hyprland color or palette key")
+
+    scalar_specs = {
+        "general": {
+            "gaps_in": (integer, 0, 100),
+            "gaps_out": (integer, 0, 100),
+            "border_size": (integer, 0, 20),
+        },
+        "decoration": {
+            "rounding": (integer, 0, 20),
+            "rounding_power": (number, 2, 10),
+            "active_opacity": (number, 0, 1),
+            "inactive_opacity": (number, 0, 1),
+            "fullscreen_opacity": (number, 0, 1),
+            "dim_inactive": (boolean,),
+            "dim_strength": (number, 0, 1),
+        },
+        "blur": {
+            "enabled": (boolean,),
+            "size": (integer, 0, 64),
+            "passes": (integer, 0, 10),
+            "noise": (number, 0, 1),
+            "contrast": (number, 0, 2),
+            "brightness": (number, 0, 2),
+            "vibrancy": (number, 0, 1),
+            "vibrancy_darkness": (number, 0, 1),
+            "ignore_opacity": (boolean,),
+        },
+        "shadow": {
+            "enabled": (boolean,),
+            "range": (integer, 0, 100),
+            "render_power": (integer, 1, 4),
+            "scale": (number, 0, 1),
+        },
+        "groupbar": {
+            "enabled": (boolean,),
+            "render_titles": (boolean,),
+            "scrolling": (boolean,),
+            "font_size": (integer, 2, 64),
+            "height": (integer, 1, 64),
+            "indicator_height": (integer, 1, 64),
+            "indicator_gap": (integer, 0, 64),
+            "gaps_in": (integer, 0, 20),
+            "gaps_out": (integer, 0, 20),
+            "gradients": (boolean,),
+            "gradient_rounding": (integer, 0, 20),
+            "gradient_round_only_edges": (boolean,),
+        },
+    }
+
+    def validated_scalars(table, specs, path):
+        reject_unknown(table, specs, path)
+        result = {}
+        for key, value in table.items():
+            validator, *bounds = specs[key]
+            result[key] = validator(value, f"{path}.{key}", *bounds)
+        return result
+
+    config = {}
+    if "general" in document:
+        config["general"] = validated_scalars(require_table(document["general"], "general"), scalar_specs["general"], "general")
+
+    if "decoration" in document:
+        source = require_table(document["decoration"], "decoration")
+        reject_unknown(source, set(scalar_specs["decoration"]) | {"blur", "shadow"}, "decoration")
+        decoration = validated_scalars({key: value for key, value in source.items() if key not in {"blur", "shadow"}}, scalar_specs["decoration"], "decoration")
+        if "blur" in source:
+            decoration["blur"] = validated_scalars(require_table(source["blur"], "decoration.blur"), scalar_specs["blur"], "decoration.blur")
+        if "shadow" in source:
+            shadow_source = require_table(source["shadow"], "decoration.shadow")
+            reject_unknown(shadow_source, set(scalar_specs["shadow"]) | {"color", "color_inactive", "offset"}, "decoration.shadow")
+            shadow = validated_scalars({key: value for key, value in shadow_source.items() if key in scalar_specs["shadow"]}, scalar_specs["shadow"], "decoration.shadow")
+            for key in ("color", "color_inactive"):
+                if key in shadow_source:
+                    shadow[key] = color(shadow_source[key], f"decoration.shadow.{key}")
+            if "offset" in shadow_source:
+                offset = shadow_source["offset"]
+                match = re.fullmatch(r"(-?[0-9]{1,3}) +(-?[0-9]{1,3})", offset) if isinstance(offset, str) else None
+                if not match or any(abs(int(coordinate)) > 100 for coordinate in match.groups()):
+                    invalid("decoration.shadow.offset must contain two coordinates from -100 through 100")
+                shadow["offset"] = [int(match.group(1)), int(match.group(2))]
+            decoration["shadow"] = shadow
+        config["decoration"] = decoration
+
+    if "group" in document:
+        group_source = require_table(document["group"], "group")
+        reject_unknown(group_source, {"groupbar"}, "group")
+        if "groupbar" in group_source:
+            source = require_table(group_source["groupbar"], "group.groupbar")
+            color_keys = {"text_color", "text_color_inactive", "active_color", "inactive_color"}
+            reject_unknown(source, set(scalar_specs["groupbar"]) | color_keys, "group.groupbar")
+            groupbar = validated_scalars({key: value for key, value in source.items() if key not in color_keys}, scalar_specs["groupbar"], "group.groupbar")
+            for key in ("text_color", "text_color_inactive"):
+                if key in source:
+                    groupbar[key] = color(source[key], f"group.groupbar.{key}")
+            groupbar_colors = {}
+            if "active_color" in source:
+                groupbar_colors["active"] = color(source["active_color"], "group.groupbar.active_color")
+            if "inactive_color" in source:
+                groupbar_colors["inactive"] = color(source["inactive_color"], "group.groupbar.inactive_color")
+            if groupbar_colors:
+                groupbar["col"] = groupbar_colors
+            config["group"] = {"groupbar": groupbar}
+
+    curves = document.get("beziers", [])
+    animations = document.get("animations", [])
+    if not isinstance(curves, list) or len(curves) > 32:
+        invalid("beziers must contain at most 32 entries")
+    if not isinstance(animations, list) or len(animations) > 32:
+        invalid("animations must contain at most 32 entries")
+
+    parsed_curves = []
+    curve_names = {"default", "easeOutQuint", "easeInOutCubic", "linear", "almostLinear", "quick"}
+    declared_curve_names = set()
+    for index, entry in enumerate(curves):
+        entry = require_table(entry, f"beziers[{index}]")
+        reject_unknown(entry, {"name", "x1", "y1", "x2", "y2"}, f"beziers[{index}]")
+        if set(entry) != {"name", "x1", "y1", "x2", "y2"}:
+            invalid(f"beziers[{index}] requires name, x1, y1, x2, and y2")
+        name = short_name(entry["name"], f"beziers[{index}].name")
+        if name in declared_curve_names:
+            invalid(f"duplicate bezier name: {name}")
+        declared_curve_names.add(name)
+        curve_names.add(name)
+        parsed_curves.append((name, *(number(entry[key], f"beziers[{index}].{key}", -2, 2) for key in ("x1", "y1", "x2", "y2"))))
+
+    animation_leaves = {
+        "global", "border", "borderangle", "windows", "windowsIn", "windowsMove", "windowsOut",
+        "fade", "fadeIn", "fadeOut", "fadeSwitch", "fadeShadow", "fadeDim", "fadeLayers",
+        "fadeLayersIn", "fadeLayersOut", "fadePopups", "fadePopupsIn", "fadePopupsOut", "fadeDpms",
+        "fadeGlow", "layers", "layersIn", "layersOut", "workspaces", "workspacesIn", "workspacesOut",
+        "specialWorkspace", "specialWorkspaceIn", "specialWorkspaceOut", "glowangle", "shadowangle",
+        "monitorAdded", "zoomFactor",
+    }
+    parsed_animations = []
+    for index, entry in enumerate(animations):
+        entry = require_table(entry, f"animations[{index}]")
+        reject_unknown(entry, {"name", "enabled", "speed", "curve", "style"}, f"animations[{index}]")
+        if not {"name", "enabled"}.issubset(entry):
+            invalid(f"animations[{index}] requires name and enabled")
+        leaf = entry["name"]
+        if leaf not in animation_leaves:
+            invalid(f"animations[{index}].name is not allowlisted")
+        enabled = boolean(entry["enabled"], f"animations[{index}].enabled")
+        parsed = {"leaf": leaf, "enabled": enabled}
+        if "speed" in entry:
+            parsed["speed"] = number(entry["speed"], f"animations[{index}].speed", 0, 100)
+        if "curve" in entry:
+            curve = short_name(entry["curve"], f"animations[{index}].curve")
+            if curve not in curve_names:
+                invalid(f"animations[{index}].curve is unknown")
+            parsed["bezier"] = curve
+        if "style" in entry:
+            style = entry["style"]
+            if not isinstance(style, str) or len(style) > 32 or not re.fullmatch(r"(?:fade|slide(?:fade|vert)?(?: (?:top|bottom|left|right))?|popin(?: [0-9]{1,3}%)?)", style):
+                invalid(f"animations[{index}].style is not allowlisted")
+            parsed["style"] = style
+        parsed_animations.append(parsed)
+
+    def lua(value, level=0):
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value).lower()
+        if isinstance(value, str):
+            return json.dumps(value, ensure_ascii=True)
+        if isinstance(value, list):
+            return "{ " + ", ".join(lua(item, level + 1) for item in value) + " }"
+        if isinstance(value, dict):
+            if not value:
+                return "{}"
+            indent = "  " * level
+            child = "  " * (level + 1)
+            lines = ["{"]
+            for key, item in value.items():
+                lines.append(f"{child}{key} = {lua(item, level + 1)},")
+            lines.append(f"{indent}}}")
+            return "\n".join(lines)
+        invalid("internal unsupported value")
+
+    if config or parsed_curves or parsed_animations:
+        print("\n-- Generated from declarative hyprland.toml")
+    if config:
+        print(f"hl.config({lua(config)})")
+    for name, x1, y1, x2, y2 in parsed_curves:
+        print(f"hl.curve({lua(name)}, {{ type = \"bezier\", points = {{ {{ {lua(x1)}, {lua(y1)} }}, {{ {lua(x2)}, {lua(y2)} }} }} }})")
+    for animation in parsed_animations:
+        print(f"hl.animation({lua(animation)})")
+except (InvalidTheme, OSError, tomllib.TOMLDecodeError) as error:
+    print(f"hyprland.toml: {error}", file=sys.stderr)
+    sys.exit(1)
+PY
+  then
+    cat "$generated" >>"$output"
+  else
+    printf 'omarchy-theme-set-templates: ignoring invalid hyprland.toml\n' >&2
+  fi
+
+  rm "$generated"
+}
+
 # Only generate dynamic templates for themes with a colors.toml definition
 if [[ -f $COLORS_FILE ]]; then
   sed_script=$(mktemp)
@@ -387,6 +676,9 @@ if [[ -f $COLORS_FILE ]]; then
   add_mix_values
   add_gradient_function_values
 
+  hyprland_already_exists=false
+  [[ -f $NEXT_THEME_DIR/hyprland.lua ]] && hyprland_already_exists=true
+
   # Process user templates first, then built-in templates (user overrides built-in)
   for tpl in "${template_files[@]}"; do
     filename=$(basename "$tpl" .tpl)
@@ -397,6 +689,10 @@ if [[ -f $COLORS_FILE ]]; then
       sed -f "$sed_script" "$tpl" >"$output_path"
     fi
   done
+
+  if [[ $hyprland_already_exists == "false" ]]; then
+    append_hyprland_toml
+  fi
 
   rm "$sed_script"
 fi

--- a/bin/omarchy-theme-set-templates
+++ b/bin/omarchy-theme-set-templates
@@ -690,7 +690,7 @@ if [[ -f $COLORS_FILE ]]; then
     fi
   done
 
-  if [[ $hyprland_already_exists == "false" ]]; then
+  if [[ $hyprland_already_exists == "false" || ${OMARCHY_THEME_HYPRLAND_LUA_FROM_STOCK:-0} == "1" ]]; then
     append_hyprland_toml
   fi
 

--- a/default/themed/alacritty.toml.tpl
+++ b/default/themed/alacritty.toml.tpl
@@ -1,3 +1,7 @@
+[window]
+opacity = {{ terminal_opacity }}
+blur = {{ terminal_blur }}
+
 [colors.primary]
 background = "{{ background }}"
 foreground = "{{ foreground }}"

--- a/default/themed/foot.ini.tpl
+++ b/default/themed/foot.ini.tpl
@@ -1,4 +1,6 @@
 [colors-dark]
+alpha={{ terminal_opacity }}
+blur={{ terminal_blur_foot }}
 foreground={{ foreground_strip }}
 background={{ background_strip }}
 selection-foreground={{ selection_foreground_strip }}

--- a/default/themed/ghostty.conf.tpl
+++ b/default/themed/ghostty.conf.tpl
@@ -1,4 +1,6 @@
 background = {{ background }}
+background-opacity = {{ terminal_opacity }}
+background-blur = {{ terminal_blur_ghostty }}
 foreground = {{ foreground }}
 cursor-color = {{ bright_foreground }}
 selection-background = {{ selection_background }}

--- a/default/themed/kitty.conf.tpl
+++ b/default/themed/kitty.conf.tpl
@@ -1,5 +1,7 @@
 foreground {{ foreground }}
 background {{ background }}
+background_opacity {{ terminal_opacity }}
+background_blur {{ terminal_blur_radius }}
 selection_foreground {{ selection_foreground }}
 selection_background {{ selection_background }}
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -67,12 +67,13 @@ What this does not cover: a theme distributed as an archive rather than a git re
 
 ## `colors.toml`
 
-`colors.toml` provides the palette keys used by templates. Keys are grouped
-semantic-first: accent/selection/muted, then the backgrounds, then the
-foregrounds, then the named colors:
+`colors.toml` provides the palette keys and shared terminal appearance settings used by templates. Color keys are grouped semantic-first: accent/selection/muted, then the backgrounds, then the foregrounds, then the named colors:
 
 ```toml
 mode = "dark"
+terminal_opacity = 0.95
+terminal_blur = true
+terminal_blur_radius = 20
 
 accent = "#7aa2f7"
 selection = "#292e42"
@@ -91,6 +92,8 @@ bright_foreground = "#c0caf5"
 red = "#f7768e"
 blue = "#7aa2f7"
 ```
+
+`terminal_opacity` accepts a decimal from `0.0` (transparent) through `1.0` (opaque) and defaults to `1.0`. `terminal_blur` accepts `true` or `false` and defaults to `false`. When blur is enabled, `terminal_blur_radius` accepts an integer from `0` through `64` and defaults to `20`. Omarchy maps these shared values to Alacritty, Foot, Ghostty, and Kitty; terminals that only expose a blur toggle ignore the radius.
 
 Any key can be referenced from a template with `{{ key }}`. The foundational
 shell palette is loaded from:
@@ -174,6 +177,68 @@ The second argument is a fallback. For example,
 `{{ shell_gradient hyprland_active_border accent }}` means: use
 `hyprland_active_border` if the theme defines it; otherwise use `accent`.
 The helper does not choose the first color unless you use `gradient_start`.
+
+## `hyprland.toml`
+
+A theme may add an optional `hyprland.toml` to override presentation settings that cannot be expressed by the palette alone. Omarchy validates the declaration and appends safe settings to its generated `hyprland.lua`; a hand-written `hyprland.lua` in a trusted local theme still takes precedence.
+
+```toml
+schema = 1
+
+[general]
+gaps_in = 6
+gaps_out = 12
+border_size = 2
+
+[decoration]
+rounding = 12
+inactive_opacity = 0.96
+
+[decoration.blur]
+enabled = true
+size = 4
+passes = 3
+
+[decoration.shadow]
+enabled = true
+range = 18
+render_power = 4
+color = "background"
+offset = "0 3"
+
+[group.groupbar]
+height = 24
+text_color = "foreground"
+active_color = "accent"
+
+[[beziers]]
+name = "themeEase"
+x1 = 0.25
+y1 = 0.46
+x2 = 0.45
+y2 = 0.94
+
+[[animations]]
+name = "windows"
+enabled = true
+speed = 3.5
+curve = "themeEase"
+style = "popin 87%"
+```
+
+Color fields accept a Hyprland `rgb(...)`/`rgba(...)` value, `#RRGGBB`/`#RRGGBBAA`, or a key from `colors.toml`. The supported settings are:
+
+| Table | Keys |
+| --- | --- |
+| `general` | `gaps_in`, `gaps_out`, `border_size` |
+| `decoration` | `rounding`, `rounding_power`, active/inactive/fullscreen opacity, `dim_inactive`, `dim_strength` |
+| `decoration.blur` | `enabled`, `size`, `passes`, `noise`, `contrast`, `brightness`, `vibrancy`, `vibrancy_darkness`, `ignore_opacity` |
+| `decoration.shadow` | `enabled`, `range`, `render_power`, `color`, `color_inactive`, `offset`, `scale` |
+| `group.groupbar` | enabled, titles, scrolling, sizing, spacing, text and active/inactive colors, gradients and gradient rounding |
+| `beziers` | `name`, `x1`, `y1`, `x2`, `y2` |
+| `animations` | `name`, `enabled`, `speed`, `curve`, `style` |
+
+Unknown keys, invalid values, commands, rules, bindings, monitors, input, environment settings, layouts, and raw Lua are rejected. If the optional file is invalid, Omarchy reports it and keeps the normal generated Hyprland appearance.
 
 ## `shell.toml`
 

--- a/test/shell.d/theme-declarative-settings-test.sh
+++ b/test/shell.d/theme-declarative-settings-test.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck source=test/shell.d/base-test.sh
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+require_command python3
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+next_theme="$home/.local/state/omarchy/current/next-theme"
+mkdir -p "$next_theme"
+
+write_colors() {
+  cat >"$next_theme/colors.toml" <<'TOML'
+mode = "dark"
+terminal_opacity = 0.78
+terminal_blur = true
+terminal_blur_radius = 32
+accent = "#7aa2f7"
+selection = "#292e42"
+muted = "#414868"
+background = "#1a1b26"
+foreground = "#a9b1d6"
+color0 = "#1a1b26"
+color1 = "#f7768e"
+color2 = "#9ece6a"
+color3 = "#e0af68"
+color4 = "#7aa2f7"
+color5 = "#bb9af7"
+color6 = "#7dcfff"
+color7 = "#a9b1d6"
+TOML
+}
+
+render() {
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+    "$ROOT/bin/omarchy-theme-set-templates" 2>"$test_tmp/stderr"
+}
+
+reset_theme() {
+  rm -rf "$next_theme"
+  mkdir -p "$next_theme"
+  write_colors
+  : >"$test_tmp/stderr"
+}
+
+reset_theme
+render
+grep -qx 'opacity = 0.78' "$next_theme/alacritty.toml" || fail "Alacritty uses terminal opacity"
+grep -qx 'blur = true' "$next_theme/alacritty.toml" || fail "Alacritty enables terminal blur"
+grep -qx 'alpha=0.78' "$next_theme/foot.ini" || fail "Foot uses terminal opacity"
+grep -qx 'blur=yes' "$next_theme/foot.ini" || fail "Foot enables terminal blur"
+grep -qx 'background-opacity = 0.78' "$next_theme/ghostty.conf" || fail "Ghostty uses terminal opacity"
+grep -qx 'background-blur = 32' "$next_theme/ghostty.conf" || fail "Ghostty uses terminal blur radius"
+grep -qx 'background_opacity 0.78' "$next_theme/kitty.conf" || fail "Kitty uses terminal opacity"
+grep -qx 'background_blur 32' "$next_theme/kitty.conf" || fail "Kitty uses terminal blur radius"
+pass "terminal appearance settings reach every generated terminal config"
+
+reset_theme
+sed -i '/^terminal_/d' "$next_theme/colors.toml"
+render
+grep -qx 'opacity = 1.0' "$next_theme/alacritty.toml" || fail "terminal opacity defaults to opaque"
+grep -qx 'blur = false' "$next_theme/alacritty.toml" || fail "Alacritty blur defaults off"
+grep -qx 'blur=no' "$next_theme/foot.ini" || fail "Foot blur defaults off"
+grep -qx 'background-blur = false' "$next_theme/ghostty.conf" || fail "Ghostty blur defaults off"
+grep -qx 'background_blur 0' "$next_theme/kitty.conf" || fail "Kitty blur defaults off"
+pass "terminal appearance settings retain safe defaults"
+
+blur_defaults="$test_tmp/blur-defaults.toml"
+printf 'terminal_blur = true\n' >"$blur_defaults"
+blur_values=$(PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-theme-color" --file "$blur_defaults" --all)
+grep -qx $'terminal_blur_radius\t20' <<<"$blur_values" || fail "enabled blur defaults to radius 20"
+grep -qx $'terminal_blur_ghostty\t20' <<<"$blur_values" || fail "Ghostty receives the default blur radius"
+pass "enabled terminal blur defaults to radius 20"
+
+commented_colors="$test_tmp/commented-colors.toml"
+cat >"$commented_colors" <<'TOML'
+terminal_opacity = 0.72 # tuned translucency
+terminal_blur = true # use compositor blur
+terminal_blur_radius = 28 # balanced intensity
+TOML
+commented_values=$(PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-theme-color" --file "$commented_colors" --all)
+grep -qx $'terminal_opacity\t0.72' <<<"$commented_values" || fail "commented opacity resolves"
+grep -qx $'terminal_blur\ttrue' <<<"$commented_values" || fail "commented blur resolves"
+grep -qx $'terminal_blur_radius\t28' <<<"$commented_values" || fail "commented blur radius resolves"
+pass "terminal settings accept TOML inline comments"
+
+invalid_colors="$test_tmp/invalid-colors.toml"
+cat >"$invalid_colors" <<'TOML'
+terminal_opacity = "1.5"
+terminal_blur = "sometimes"
+terminal_blur_radius = "1000"
+TOML
+terminal_values=$(PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-theme-color" --file "$invalid_colors" --all 2>"$test_tmp/invalid-stderr")
+grep -qx $'terminal_opacity\t1.0' <<<"$terminal_values" || fail "invalid opacity falls back"
+grep -qx $'terminal_blur\tfalse' <<<"$terminal_values" || fail "invalid blur falls back"
+grep -qx $'terminal_blur_radius\t0' <<<"$terminal_values" || fail "disabled invalid radius emits zero"
+grep -q 'invalid terminal_opacity' "$test_tmp/invalid-stderr" || fail "invalid opacity warns"
+grep -q 'invalid terminal_blur ' "$test_tmp/invalid-stderr" || fail "invalid blur warns"
+grep -q 'invalid terminal_blur_radius' "$test_tmp/invalid-stderr" || fail "invalid radius warns"
+pass "invalid terminal settings warn and fall back"
+
+reset_theme
+cat >"$next_theme/hyprland.toml" <<'TOML'
+schema = 1
+
+[general]
+gaps_in = 4
+gaps_out = 9
+border_size = 3
+
+[decoration]
+rounding = 14
+rounding_power = 2.5
+active_opacity = 1.0
+inactive_opacity = 0.91
+fullscreen_opacity = 1.0
+dim_inactive = true
+dim_strength = 0.08
+
+[decoration.blur]
+enabled = true
+size = 5
+passes = 3
+noise = 0.02
+contrast = 0.9
+brightness = 0.8
+vibrancy = 0.15
+vibrancy_darkness = 0.7
+ignore_opacity = true
+
+[decoration.shadow]
+enabled = true
+range = 20
+render_power = 4
+color = "background"
+color_inactive = "#11223344"
+offset = "-2 3"
+scale = 1.0
+
+[group.groupbar]
+enabled = true
+render_titles = true
+scrolling = false
+font_size = 12
+height = 24
+indicator_height = 2
+indicator_gap = 5
+gaps_in = 4
+gaps_out = 1
+text_color = "foreground"
+text_color_inactive = "#8899aabb"
+active_color = "accent"
+inactive_color = "background"
+gradients = true
+gradient_rounding = 6
+gradient_round_only_edges = false
+
+[[beziers]]
+name = "themeEase"
+x1 = 0.25
+y1 = 0.46
+x2 = 0.45
+y2 = 0.94
+
+[[animations]]
+name = "windows"
+enabled = true
+speed = 3.5
+curve = "themeEase"
+style = "popin 87%"
+TOML
+render
+grep -Fq -- '-- Generated from declarative hyprland.toml' "$next_theme/hyprland.lua" || fail "valid Hyprland declaration is generated"
+grep -Fq 'gaps_in = 4' "$next_theme/hyprland.lua" || fail "Hyprland general settings are generated"
+grep -Fq 'color = "rgb(1a1b26)"' "$next_theme/hyprland.lua" || fail "Hyprland color resolves a palette reference"
+grep -Fq 'color_inactive = "rgba(11223344)"' "$next_theme/hyprland.lua" || fail "Hyprland literal color is normalized"
+grep -Fq 'offset = { -2, 3 }' "$next_theme/hyprland.lua" || fail "Hyprland shadow offset is generated as a vector"
+grep -Fq 'hl.curve("themeEase"' "$next_theme/hyprland.lua" || fail "Hyprland bezier is generated"
+grep -Fq 'leaf = "windows"' "$next_theme/hyprland.lua" || fail "Hyprland animation leaf is generated"
+lua - <<LUA
+hl = { config = function(_) end, curve = function(_, _) end, animation = function(_) end }
+dofile("$next_theme/hyprland.lua")
+LUA
+pass "valid hyprland.toml generates syntactically valid allowlisted Lua"
+
+reset_theme
+render
+! grep -Fq 'Generated from declarative hyprland.toml' "$next_theme/hyprland.lua" || fail "absent hyprland.toml changes no generated behavior"
+[[ ! -s $test_tmp/stderr ]] || fail "absent hyprland.toml produces no warning" "$(cat "$test_tmp/stderr")"
+pass "absent hyprland.toml retains the base Hyprland output"
+
+marker="$test_tmp/pwned"
+for invalid_case in unknown malicious malformed schema-type color-form bounds; do
+  reset_theme
+  case "$invalid_case" in
+    unknown)
+      printf 'schema = 1\n[general]\nlayout = "master"\n' >"$next_theme/hyprland.toml"
+      ;;
+    malicious)
+      cat >"$next_theme/hyprland.toml" <<TOML
+schema = 1
+[[animations]]
+name = "windows"
+enabled = true
+style = "fade\"); os.execute(\"touch $marker\") --"
+TOML
+      ;;
+    malformed)
+      printf 'schema = 1\n[decoration\nrounding = 4\n' >"$next_theme/hyprland.toml"
+      ;;
+    schema-type)
+      printf 'schema = 1.0\n' >"$next_theme/hyprland.toml"
+      ;;
+    color-form)
+      printf 'schema = 1\n[decoration.shadow]\ncolor = "rgb(11223344)"\n' >"$next_theme/hyprland.toml"
+      ;;
+    bounds)
+      printf 'schema = 1\n[decoration]\nrounding = 21\n' >"$next_theme/hyprland.toml"
+      ;;
+  esac
+  render
+  ! grep -Fq 'Generated from declarative hyprland.toml' "$next_theme/hyprland.lua" || fail "$invalid_case Hyprland TOML emits no override"
+  grep -q 'ignoring invalid hyprland.toml' "$test_tmp/stderr" || fail "$invalid_case Hyprland TOML warns"
+done
+[[ ! -e $marker ]] || fail "malicious Hyprland TOML executes nothing"
+pass "invalid and malicious hyprland.toml safely fall back to the base output"
+
+reset_theme
+printf 'trusted-local-hyprland\n' >"$next_theme/hyprland.lua"
+printf 'schema = 1\n[general]\ngaps_in = 99\n' >"$next_theme/hyprland.toml"
+render
+[[ $(cat "$next_theme/hyprland.lua") == "trusted-local-hyprland" ]] || fail "existing Hyprland Lua remains untouched"
+pass "trusted hyprland.lua retains precedence over hyprland.toml"

--- a/test/shell.d/theme-staging-test.sh
+++ b/test/shell.d/theme-staging-test.sh
@@ -176,6 +176,44 @@ assert_no_marker hyprland.lua "a user overlay cannot add Lua to a stock theme"
 
 pass "an overlay on a stock theme repaints it without adding code"
 
+# Declarative settings extend bundled theme Lua rather than being mistaken for
+# a trusted user override. Invalid data must still leave that bundled Lua alone.
+kanagawa_overlay="$themes/kanagawa"
+kanagawa_stock="$ROOT/themes/kanagawa/hyprland.lua"
+kanagawa_stock_size=$(stat -c %s "$kanagawa_stock")
+mkdir -p "$kanagawa_overlay/.git"
+write_colors "$kanagawa_overlay/colors.toml"
+printf 'schema = 1\n[decoration]\nrounding = 13\n' >"$kanagawa_overlay/hyprland.toml"
+
+set_theme kanagawa || fail "omarchy-theme-set applies declarative settings over bundled Hyprland Lua"
+cmp "$kanagawa_stock" <(head -c "$kanagawa_stock_size" "$(staged hyprland.lua)") || fail "bundled Hyprland Lua is preserved"
+grep -Fq 'rounding = 13' "$(staged hyprland.lua)" || fail "declarative settings extend bundled Hyprland Lua"
+
+pass "an installed overlay extends bundled Hyprland Lua declaratively"
+
+printf 'schema = 1\n[general]\nlayout = "master"\n' >"$kanagawa_overlay/hyprland.toml"
+set_theme kanagawa || fail "omarchy-theme-set keeps bundled Hyprland Lua when overlay data is invalid"
+cmp "$kanagawa_stock" "$(staged hyprland.lua)" || fail "invalid declarative settings preserve bundled Hyprland Lua byte for byte"
+! grep -Fq 'Generated from declarative hyprland.toml' "$(staged hyprland.lua)" || fail "invalid declarative settings append nothing to bundled Lua"
+grep -q 'ignoring invalid hyprland.toml' "$test_tmp/stderr" || fail "invalid stock overlay warns"
+
+pass "invalid installed overlay data leaves bundled Hyprland Lua unchanged"
+
+rm -rf "$kanagawa_overlay/.git"
+printf 'schema = 1\n[decoration]\nrounding = 12\n' >"$kanagawa_overlay/hyprland.toml"
+set_theme kanagawa || fail "omarchy-theme-set applies trusted declarative settings over bundled Hyprland Lua"
+cmp "$kanagawa_stock" <(head -c "$kanagawa_stock_size" "$(staged hyprland.lua)") || fail "trusted declarative settings preserve bundled Hyprland Lua"
+grep -Fq 'rounding = 12' "$(staged hyprland.lua)" || fail "trusted declarative settings extend bundled Hyprland Lua"
+
+pass "a trusted declarative overlay extends bundled Hyprland Lua"
+
+printf 'trusted-local-hyprland\n' >"$kanagawa_overlay/hyprland.lua"
+printf 'schema = 1\n[decoration]\nrounding = 11\n' >"$kanagawa_overlay/hyprland.toml"
+set_theme kanagawa || fail "omarchy-theme-set applies a trusted local override on a stock theme"
+[[ $(cat "$(staged hyprland.lua)") == "trusted-local-hyprland" ]] || fail "trusted local Hyprland Lua retains precedence over declarative settings"
+
+pass "trusted local Hyprland Lua still overrides bundled and declarative settings"
+
 # A theme the user wrote themselves has no git repo behind it and is theirs.
 mine="$themes/mine"
 mkdir -p "$mine"

--- a/test/shell.d/theme-staging-test.sh
+++ b/test/shell.d/theme-staging-test.sh
@@ -70,6 +70,7 @@ mkdir -p "$hostile/backgrounds" "$hostile/.git"
 write_colors "$hostile/colors.toml"
 touch "$hostile/light.mode"
 printf 'os.execute("%s")\n' "$marker" >"$hostile/hyprland.lua"
+printf 'schema = 1\n[decoration]\nrounding = 13\n' >"$hostile/hyprland.toml"
 printf 'vim.cmd("%s")\n' "$marker" >"$hostile/neovim.lua"
 printf 'shell %s\n' "$marker" >"$hostile/kitty.conf"
 printf '[terminal.shell]\nprogram = "%s"\n' "$marker" >"$hostile/alacritty.toml"
@@ -109,6 +110,8 @@ for generated in hyprland.lua neovim.lua gum_env.lua kitty.conf alacritty.toml f
   assert_staged "$generated" "$generated is generated from Omarchy's template"
   assert_no_marker "$generated" "an installed theme cannot supply $generated"
 done
+assert_staged hyprland.toml "an installed theme keeps declarative Hyprland settings"
+grep -Fq 'rounding = 13' "$(staged hyprland.lua)" || fail "declarative Hyprland settings reach the generated Lua"
 
 # Colour is kept, including a file Omarchy would otherwise have generated.
 assert_staged shell.toml "shell.toml is staged"


### PR DESCRIPTION
# Add declarative Hyprland and terminal theming

## What is the value?

The security change in #7884 correctly stopped installed themes from supplying executable Lua and complete terminal configs. It also removed much of each theme's intended presentation.

This restores those appearance settings as data. Omarchy validates the data and generates the trusted configuration itself. Theme authors no longer need Lua for normal Hyprland styling or separate configs for terminal opacity and blur. Users still install and select themes exactly as they do today.

Related to #7942, includes the narrower Hyprland scope proposed in #8210, and complements the refusal notifications in #8393.

## What changes

Themes can add three optional terminal settings to `colors.toml`:

```toml
terminal_opacity = 0.82
terminal_blur = true
terminal_blur_radius = 28
```

Omarchy maps them through its existing Alacritty, Foot, Ghostty, and Kitty templates. Themes do not control the rest of the terminal config.

Themes that need more than colors can add an optional `hyprland.toml`:

```toml
schema = 1

[general]
gaps_in = 8
gaps_out = 16
border_size = 3

[decoration]
rounding = 16
inactive_opacity = 0.94

[decoration.blur]
enabled = true
size = 8
passes = 3

[decoration.shadow]
enabled = true
range = 22
color = "#000000aa"
offset = "0 4"
```

The schema covers gaps, borders, rounding, opacity, dimming, blur, shadows, groupbars, bezier curves, and Hyprland's known animation leaves. Colors can be literals or references to keys in `colors.toml`.

`omarchy-theme-set-templates` validates these values and adds them to the `hyprland.lua` Omarchy already generates. With no `hyprland.toml`, generation behaves exactly as before. A trusted local theme's hand-written `hyprland.lua` still takes precedence.

## Testbed result

This Git-style test theme was applied in the Omarchy Testbed VM with terminal opacity `0.82`, blur radius `28`, window rounding `16`, wider gaps, a three-pixel border, and a themed shadow:

![Declarative Hyprland and Foot settings running in the Omarchy Testbed](https://github.com/user-attachments/assets/0dab5cde-3f7d-401f-aebb-c82496b1c26c)

## Security boundary

`hyprland.toml` is a strict, allowlisted TOML schema. Omarchy checks its types, numeric ranges, colors, curves, animation names, and styles before serializing anything to Lua. Invalid declarations warn and fall back to the normal generated Hyprland appearance.

Installed themes still cannot provide Lua, complete terminal configs, commands, binds, monitor or input settings, rules, plugins, includes, environment values, or arbitrary paths. This PR does not change theme installation, staging, trust classification, security filtering, activation, or reload behavior.

## Testing

- Focused declarative settings and theme staging tests
- Full CLI test suite
- Bash syntax, ShellCheck, and `git diff --check`
- Generated config validation with Alacritty, Foot, Ghostty, Kitty, and Lua
- Testbed installation, live Hyprland reload, and runtime checks for gaps, rounding, blur, opacity, and the shadow vector
- Visual verification of Foot opacity and blur alongside Hyprland borders, rounding, gaps, and shadows

`./test/shell` was also run. Its six failures reproduce unchanged on clean `origin/quattro` and are unrelated baseline/environment failures.
