### PR TITLE
Throw windows across monitors with Super+Shift+arrows

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -39,10 +39,104 @@ o.bind("SUPER + SHIFT + ALT + RIGHT", "Move workspace to right monitor", hl.dsp.
 o.bind("SUPER + SHIFT + ALT + UP", "Move workspace to up monitor", hl.dsp.workspace.move({ monitor = "u" }))
 o.bind("SUPER + SHIFT + ALT + DOWN", "Move workspace to down monitor", hl.dsp.workspace.move({ monitor = "d" }))
 
-o.bind("SUPER + SHIFT + LEFT", "Swap window to the left", hl.dsp.window.swap({ direction = "l" }))
-o.bind("SUPER + SHIFT + RIGHT", "Swap window to the right", hl.dsp.window.swap({ direction = "r" }))
-o.bind("SUPER + SHIFT + UP", "Swap window up", hl.dsp.window.swap({ direction = "u" }))
-o.bind("SUPER + SHIFT + DOWN", "Swap window down", hl.dsp.window.swap({ direction = "d" }))
+-- Super+Shift+arrows swap with a neighbor on this workspace. Hyprland's
+-- directional swap also targets the next monitor, which exchanges the two
+-- workspaces' windows; if nothing is in that direction here, throw the window
+-- onto the adjacent monitor instead. After a throw, walk it to the incoming
+-- edge so dwindle force_split=2 does not land a rightward throw on the far side.
+local opposite_direction = { l = "r", r = "l", u = "d", d = "u" }
+
+local function ranges_overlap(a, alen, b, blen)
+  return a < b + blen and b < a + alen
+end
+
+local function same_workspace_neighbor(win, direction)
+  local ws = win.workspace
+  local at, size = win.at, win.size
+  if not ws or not at or not size then
+    return nil
+  end
+
+  local ax, ay, aw, ah = at.x, at.y, size.x, size.y
+  local acx, acy = ax + aw / 2, ay + ah / 2
+  local best, best_dist = nil, nil
+
+  for _, other in ipairs(hl.get_windows({ workspace = ws, mapped = true })) do
+    if other ~= win and not other.hidden and other.floating == win.floating then
+      local oat, osize = other.at, other.size
+      if oat and osize then
+        local bx, by, bw, bh = oat.x, oat.y, osize.x, osize.y
+        local bcx, bcy = bx + bw / 2, by + bh / 2
+        local dx, dy = bcx - acx, bcy - acy
+        local in_direction = false
+        if direction == "l" then
+          in_direction = dx < 0 and ranges_overlap(ay, ah, by, bh)
+        elseif direction == "r" then
+          in_direction = dx > 0 and ranges_overlap(ay, ah, by, bh)
+        elseif direction == "u" then
+          in_direction = dy < 0 and ranges_overlap(ax, aw, bx, bw)
+        elseif direction == "d" then
+          in_direction = dy > 0 and ranges_overlap(ax, aw, bx, bw)
+        end
+        if in_direction then
+          local dist = dx * dx + dy * dy
+          if not best_dist or dist < best_dist then
+            best, best_dist = other, dist
+          end
+        end
+      end
+    end
+  end
+
+  return best
+end
+
+local function settle_on_incoming_edge(win, throw_direction)
+  local settle_dir = opposite_direction[throw_direction]
+  if not win or win.floating or not settle_dir then
+    return
+  end
+
+  for _ = 1, 16 do
+    local neighbor = same_workspace_neighbor(win, settle_dir)
+    if not neighbor then
+      return
+    end
+    local result = hl.dispatch(hl.dsp.window.swap({ window = win, target = neighbor }))
+    if not result or not result.ok then
+      return
+    end
+  end
+end
+
+local function swap_or_move_to_monitor(direction)
+  return function()
+    local win = hl.get_active_window()
+    if not win then
+      return
+    end
+
+    local neighbor = same_workspace_neighbor(win, direction)
+    if neighbor then
+      hl.dispatch(hl.dsp.window.swap({ target = neighbor }))
+      return
+    end
+
+    local target = hl.get_monitor(direction)
+    local current = win.monitor or hl.get_active_monitor()
+    if not target or (current and target.id == current.id) then
+      return
+    end
+
+    hl.dispatch(hl.dsp.window.move({ monitor = target, window = win }))
+    settle_on_incoming_edge(win, direction)
+  end
+end
+
+o.bind("SUPER + SHIFT + LEFT", "Swap or move window left", swap_or_move_to_monitor("l"))
+o.bind("SUPER + SHIFT + RIGHT", "Swap or move window right", swap_or_move_to_monitor("r"))
+o.bind("SUPER + SHIFT + UP", "Swap or move window up", swap_or_move_to_monitor("u"))
+o.bind("SUPER + SHIFT + DOWN", "Swap or move window down", swap_or_move_to_monitor("d"))
 
 o.bind("ALT + TAB", "Focus on next window", hl.dsp.window.cycle_next())
 o.bind("ALT + SHIFT + TAB", "Focus on previous window", hl.dsp.window.cycle_next({ next = false }))

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -10,7 +10,7 @@ You can then hit `Super + J` to stack them on top of each other instead of side 
 
  ![navigation-stacked](images/navigation-stacked.webp)
 
-Hit `Super + J` again to return them to their side-by-side positions. Then try `Super + Shift + Arrow Right` while on the browser to swap the windows.
+Hit `Super + J` again to return them to their side-by-side positions. Then try `Super + Shift + Arrow Right` while on the browser to swap the windows. On a multi-monitor setup, the same chord throws the window onto the next monitor when there's nothing to swap with in that direction.
 
 Now try `Super + Ctrl + T` to start the Activity monitor. That'll appears as a floating window. You can tile it using `Super + T` (and hit that again to make it floating again). Now press `Super + Shift + F` to open the files manager. You'll have a neat four-way setup:
 


### PR DESCRIPTION
## What

`Super+Shift+arrows` still swaps with a neighbor on the current workspace. When there isn't one in that direction, it now moves the window onto the adjacent monitor instead of swapping with a window there (or doing nothing if that workspace is empty).

A throw also lands on the incoming edge of the destination. Dwindle's `force_split = 2` would otherwise insert a rightward throw on the far side.

![Monitors as boxes, windows as boxes inside them. Three before/after cases: empty destination, occupied destination, and landing side.](https://raw.githubusercontent.com/anagrius/omarchy/pr-8722-assets/super-shift-arrows-monitors.png)

## Why

Hyprland's directional swap looks across monitors. With one window per screen that exchanges them. With an empty target, nothing happens. Same-workspace swap is unchanged, which is what the manual demonstrates on a single display.

## Test plan

- Two tiled windows on one workspace: Super+Shift+Left/Right still swaps them
- One window on the right monitor, empty left monitor: Super+Shift+Left moves it over
- One window on each monitor: Super+Shift+Left from the right monitor joins the left workspace; the left window stays
- Throw from left to right: incoming window is on the left of the right monitor