### PR TITLE
Skip the reboot prompt when the flag predates the current boot

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -25,7 +25,18 @@ done
 if [[ $kernel_updated == "true" ]]; then
   confirm_reboot "Linux kernel has been updated. Reboot?"
 elif [[ -f $HOME/.local/state/omarchy/reboot-required ]]; then
-  confirm_reboot "Updates require reboot. Ready?"
+  # Only omarchy-system-reboot clears this flag, so a reboot by any other route
+  # (systemctl reboot, the power button, a crash) leaves it behind to prompt
+  # after every later update. A flag written before the current boot has
+  # already been honored.
+  boot_time=$(awk '/^btime/ {print $2}' /proc/stat)
+  flag_time=$(stat -c %Y "$HOME/.local/state/omarchy/reboot-required")
+
+  if (( flag_time < boot_time )); then
+    omarchy-state clear reboot-required
+  else
+    confirm_reboot "Updates require reboot. Ready?"
+  fi
 fi
 
 running_hyprland=$(readlink /proc/$(pgrep -x Hyprland)/exe 2>/dev/null)

--- a/test/shell.d/update-restart-test.sh
+++ b/test/shell.d/update-restart-test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# The kernel check walks the real /usr/lib/modules; without an installed kernel
+# there the reboot-required branch is unreachable and there is nothing to test.
+installed_kernel=""
+for kernel in /usr/lib/modules/*/vmlinuz; do
+  [[ -f $kernel ]] || continue
+  installed_kernel=$(basename "$(dirname "$kernel")")
+  break
+done
+
+if [[ -z $installed_kernel ]]; then
+  pass "no kernel under /usr/lib/modules; skipping reboot-required checks"
+  exit 0
+fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+call_log="$test_tmp/calls.log"
+home="$test_tmp/home"
+state_dir="$home/.local/state/omarchy"
+flag="$state_dir/reboot-required"
+mkdir -p "$mock_bin" "$state_dir"
+
+cat >"$mock_bin/uname" <<SH
+#!/bin/bash
+
+echo "$installed_kernel"
+SH
+
+cat >"$mock_bin/pacman" <<'SH'
+#!/bin/bash
+
+exit 0
+SH
+
+cat >"$mock_bin/pgrep" <<'SH'
+#!/bin/bash
+
+exit 1
+SH
+
+# gum records the prompt and declines it, so the script continues past it.
+cat >"$mock_bin/gum" <<'SH'
+#!/bin/bash
+
+printf 'gum %s\n' "$*" >>"$CALL_LOG"
+exit 1
+SH
+
+for command in omarchy-system-reboot omarchy-restart-shell; do
+  cat >"$mock_bin/$command" <<'SH'
+#!/bin/bash
+
+printf '%s %s\n' "$(basename "$0")" "$*" >>"$CALL_LOG"
+SH
+done
+chmod +x "$mock_bin"/*
+
+run_update_restart() {
+  : >"$call_log"
+  HOME="$home" PATH="$mock_bin:$ROOT/bin:$PATH" CALL_LOG="$call_log" \
+    "$ROOT/bin/omarchy-update-restart" >/dev/null
+}
+
+prompted_for_reboot() {
+  grep -qF 'gum confirm Updates require reboot. Ready?' "$call_log"
+}
+
+boot_time=$(awk '/^btime/ {print $2}' /proc/stat)
+
+# A flag older than the current boot was already honored by a reboot that did
+# not go through omarchy-system-reboot.
+touch -d "@$((boot_time - 60))" "$flag"
+run_update_restart
+
+if prompted_for_reboot; then
+  fail "reboot-required flag written before the current boot does not prompt"
+fi
+pass "reboot-required flag written before the current boot does not prompt"
+
+if [[ -e $flag ]]; then
+  fail "reboot-required flag written before the current boot is cleared"
+fi
+pass "reboot-required flag written before the current boot is cleared"
+
+# A flag set since boot, e.g. by a migration in this very update, still prompts.
+touch "$flag"
+run_update_restart
+
+if ! prompted_for_reboot; then
+  fail "reboot-required flag written since boot prompts for a reboot" "$(cat "$call_log")"
+fi
+pass "reboot-required flag written since boot prompts for a reboot"
+
+if [[ ! -e $flag ]]; then
+  fail "declining the prompt keeps the reboot-required flag"
+fi
+pass "declining the prompt keeps the reboot-required flag"
+
+# No flag, no prompt.
+rm -f "$flag"
+run_update_restart
+
+if prompted_for_reboot; then
+  fail "no reboot-required flag means no prompt"
+fi
+pass "no reboot-required flag means no prompt"


### PR DESCRIPTION
## Problem

After `omarchy update`, `omarchy-update-restart` keeps asking "Updates require reboot. Ready?" on a machine that has already rebooted.

`~/.local/state/omarchy/reboot-required` is set by migrations and by the sudoless Docker commands (#8080), and the only thing that ever clears it is `omarchy-system-reboot`. Reboot any other way - `systemctl reboot`, the power button, a hard reset after a freeze - and the flag survives, so every following update prompts for a reboot that already happened. Saying No leaves it in place; the only way out is to accept the prompt once or delete the file by hand.

Seen here on 4.0.1: a migration set the flag on Aug 25, the machine was rebooted on Aug 27 outside the Omarchy path, and today's update (three userspace packages and an AUR rebuild, running kernel matching the installed one) still asked for a reboot.

## Fix

In the `reboot-required` branch, compare the flag's mtime with the kernel's boot time from `/proc/stat` (`btime`). A flag written before the current boot has already been honoured, so clear it and move on. A flag written since boot, for example by a migration in the same update run, still prompts as before. The kernel and Hyprland checks are untouched.

## Tests

New `test/shell.d/update-restart-test.sh` mocks `uname`, `pacman`, `pgrep`, `gum` and the reboot/restart commands, points `HOME` at a temp dir and covers three cases: a flag older than boot is cleared without a prompt, a flag newer than boot prompts and survives a declined prompt, and no flag means no prompt. It skips when there is no kernel under `/usr/lib/modules`, since the kernel check makes that branch unreachable there. `system-power-test.sh` and `update-sequence-test.sh` still pass.
