### PR TITLE
Keep hyprsunset running after a restart

### DIFF
--- a/bin/omarchy-restart-hyprsunset
+++ b/bin/omarchy-restart-hyprsunset
@@ -2,4 +2,5 @@
 
 # omarchy:summary=Restart the hyprsunset service (used for blue light filtering/night light).
 
-omarchy-restart-app hyprsunset
+pkill -x hyprsunset 2>/dev/null || true
+setsid hyprsunset >/dev/null 2>&1 &

--- a/test/shell.d/restart-hyprsunset-test.sh
+++ b/test/shell.d/restart-hyprsunset-test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+test_bin="$test_tmp/bin"
+call_log="$test_tmp/calls.log"
+mkdir -p "$test_bin"
+trap 'rm -rf "$test_tmp"' EXIT
+
+cat >"$test_bin/pkill" <<'SH'
+#!/bin/bash
+printf 'pkill:%s\n' "$*" >>"$OMARCHY_TEST_CALL_LOG"
+exit "${OMARCHY_TEST_PKILL_STATUS:-0}"
+SH
+
+cat >"$test_bin/setsid" <<'SH'
+#!/bin/bash
+printf 'setsid:%s\n' "$*" >>"$OMARCHY_TEST_CALL_LOG"
+SH
+
+cat >"$test_bin/omarchy-restart-app" <<'SH'
+#!/bin/bash
+printf 'restart-app:%s\n' "$*" >>"$OMARCHY_TEST_CALL_LOG"
+SH
+
+chmod +x "$test_bin"/*
+
+run_restart() {
+  : >"$call_log"
+  PATH="$test_bin:$PATH" \
+  OMARCHY_TEST_CALL_LOG="$call_log" \
+  OMARCHY_TEST_PKILL_STATUS="$1" \
+    "$ROOT/bin/omarchy-restart-hyprsunset"
+
+  for _ in {1..50}; do
+    grep -q '^setsid:' "$call_log" && return
+    sleep 0.01
+  done
+}
+
+run_restart 0
+grep -Fx 'pkill:-x hyprsunset' "$call_log" >/dev/null ||
+  fail "hyprsunset restart stops the existing process" "$(cat "$call_log")"
+grep -Fx 'setsid:hyprsunset' "$call_log" >/dev/null ||
+  fail "hyprsunset restart launches the daemon directly" "$(cat "$call_log")"
+if grep -q '^restart-app:' "$call_log"; then
+  fail "hyprsunset restart does not use the short-lived uwsm app launcher" "$(cat "$call_log")"
+fi
+pass "hyprsunset restarts directly outside the short-lived uwsm app scope"
+
+run_restart 1
+grep -Fx 'setsid:hyprsunset' "$call_log" >/dev/null ||
+  fail "hyprsunset starts when no previous process exists" "$(cat "$call_log")"
+pass "hyprsunset starts even when no previous process exists"


### PR DESCRIPTION
## Why

`omarchy restart hyprsunset` relaunches the daemon through `uwsm-app`. That client creates a scope tied to its short-lived launching context, so the replacement process disappears shortly after the restart command exits and night-light configuration changes never take effect.

## What

- stop the existing hyprsunset process directly
- relaunch hyprsunset in its own session without the short-lived `uwsm-app` scope
- tolerate restart requests when hyprsunset is not already running
- add regression coverage for both running and absent-process cases

## Testing

- `bash test/shell.d/restart-hyprsunset-test.sh`
- `bash test/shell.d/nightlight-test.sh`
- `bash -n bin/omarchy-restart-hyprsunset test/shell.d/restart-hyprsunset-test.sh`
- `git diff --check`

Fixes #8646