### PR TITLE
Clean up stale SDDM pacsave and legacy hyprland.conf

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1370,6 +1370,7 @@ EOF
   log "Normalizing SDDM login configuration"
   # The omarchy package already installed 10-theme.conf and 10-wayland.conf.
   as_root install -d -m 0755 /etc/sddm.conf.d
+  as_root rm -f /etc/sddm.conf.d/10-wayland.conf.pacsave /usr/share/sddm/hyprland.conf
   cat <<'EOF' | as_root tee /etc/sddm.conf.d/99-omarchy-login.conf >/dev/null
 [Users]
 RememberLastUser=true

--- a/migrations/1787902586.sh
+++ b/migrations/1787902586.sh
@@ -1,0 +1,9 @@
+echo "Remove legacy SDDM Hyprland config and stale pacsave files"
+
+# SDDM loads all files in /etc/sddm.conf.d/ in alphabetical order. If a stale
+# 10-wayland.conf.pacsave exists from a pacman upgrade, it sorts after
+# 10-wayland.conf, overriding the Lua configuration and forcing the old
+# hyprland.conf format which triggers Hyprland's deprecation banner.
+if [[ -f /etc/sddm.conf.d/10-wayland.conf.pacsave || -f /usr/share/sddm/hyprland.conf ]]; then
+  sudo rm -f /etc/sddm.conf.d/10-wayland.conf.pacsave /usr/share/sddm/hyprland.conf 2>/dev/null || true
+fi


### PR DESCRIPTION
### Summary
SDDM loads configuration files in `/etc/sddm.conf.d/` in alphabetical order. When previous package upgrades left behind a `10-wayland.conf.pacsave` referencing `/usr/share/sddm/hyprland.conf`, it sorts alphabetically after `10-wayland.conf`, overriding `CompositorCommand` back to the legacy `.conf` file.

This causes Hyprland to launch the greeter using the old `.conf` format, displaying the deprecation warning banner (`"You are using the .conf config format, support for which will be removed in Hyprland 0.57"`) across the top of the SDDM login screen.

### Changes
1. Added a migration in `migrations/1787902586.sh` to remove `/etc/sddm.conf.d/10-wayland.conf.pacsave` and legacy `/usr/share/sddm/hyprland.conf`.
2. Updated `bin/omarchy-upgrade-to-quattro` to clean them up during Quattro normalization.

### Captures
Screenshots demonstrating before and after:
- **Before:** Deprecation banner rendered on SDDM greeter
- **After:** Clean greeter running via `hyprland.lua`