### PR TITLE
Share Voxtype status across bar surfaces

### DIFF
--- a/bin/omarchy-voxtype-status
+++ b/bin/omarchy-voxtype-status
@@ -7,7 +7,7 @@ if omarchy-cmd-missing voxtype; then
   exit 0
 fi
 
-# Keep the status follower as the direct child of the bar. Quickshell
-# clean up their direct child when they restart; a shell pipeline/coproc would
-# leave `voxtype status --follow` orphaned under the user systemd instance.
+# Keep the status follower as a direct child of Quickshell. The parent-death
+# signal stops it with the shell; a pipeline or coprocess in between could leave
+# `voxtype status --follow` orphaned under the user systemd instance.
 exec setpriv --pdeathsig TERM voxtype status --follow --extended --format json

--- a/shell/plugins/bar/indicators/Dictation.qml
+++ b/shell/plugins/bar/indicators/Dictation.qml
@@ -1,35 +1,18 @@
 import QtQuick
-import Quickshell.Io
 import qs.Ui
 
 BarIndicator {
   id: root
 
-  property string state: "idle"
-  property string icon: ""
+  readonly property var dictationService: bar?.shell?.firstPartyServiceFor("omarchy.dictation")
+  property string state: dictationService ? dictationService.dictationState : "idle"
+  readonly property string icon: state === "recording" ? "󰍬" : state === "transcribing" ? "󰔟" : ""
 
   active: state === "recording"
   activeText: icon
   inactiveText: "󰍬"
   activeTooltipText: state
   inactiveTooltipText: "Dictate"
-
-  function update(raw) {
-    var data = extractData(raw)
-
-    state = String(data.alt || data.class || "idle")
-    if (state === "recording") icon = "󰍬"
-    else if (state === "transcribing") icon = "󰔟"
-    else icon = ""
-  }
-
-  Process {
-    command: ["bash", "-c", "omarchy-voxtype-status"]
-    running: true
-    stdout: SplitParser {
-      onRead: function(data) { root.update(data) }
-    }
-  }
 
   onPressed: function() {
     if (!root.bar) return

--- a/shell/plugins/services/dictation/Service.qml
+++ b/shell/plugins/services/dictation/Service.qml
@@ -1,0 +1,23 @@
+import QtQuick
+import Quickshell.Io
+import qs.Commons
+
+Item {
+  id: root
+
+  property var shell: null
+  property string dictationState: "idle"
+
+  function update(raw) {
+    var data = Util.parseModuleJson(raw)
+    dictationState = String(data.alt || data.class || "idle")
+  }
+
+  Process {
+    command: ["omarchy-voxtype-status"]
+    running: true
+    stdout: SplitParser {
+      onRead: function(data) { root.update(data) }
+    }
+  }
+}

--- a/shell/plugins/services/dictation/manifest.json
+++ b/shell/plugins/services/dictation/manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.dictation",
+  "name": "Dictation",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Shares Voxtype dictation status with every bar surface.",
+  "kinds": [
+    "service"
+  ],
+  "entryPoints": {
+    "service": "Service.qml"
+  }
+}

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -42,11 +42,17 @@ ShellRoot {
   }
 
   QtObject {
+    id: dictationService
+    property string dictationState: "idle"
+  }
+
+  QtObject {
     id: mockShell
     function firstPartyServiceFor(id) {
       if (id === "omarchy.notifications") return notificationService
       if (id === "omarchy.idle") return idleService
       if (id === "omarchy.nightlight") return nightlightService
+      if (id === "omarchy.dictation") return dictationService
       return null
     }
   }
@@ -202,6 +208,13 @@ ShellRoot {
       if (dictation) {
         dictation.moduleName = "Dictation"
         root.injectBar(dictation)
+        root.assertTrue(dictation.state === "idle" && !dictation.active, "Dictation reads idle state from the shared service")
+        dictationService.dictationState = "recording"
+        root.assertTrue(dictation.state === "recording" && dictation.active, "Dictation reads recording state from the shared service")
+        root.assertTrue(dictation.activeText === "󰍬", "Dictation shows the recording icon")
+        dictationService.dictationState = "transcribing"
+        root.assertTrue(dictation.state === "transcribing" && !dictation.active, "Dictation reads transcribing state from the shared service")
+        root.assertTrue(dictation.icon === "󰔟", "Dictation tracks the transcribing icon")
         dictation.triggerPress(Qt.LeftButton)
         dictation.triggerPress(Qt.RightButton)
         root.assertTrue(root.commandCount("omarchy-voxtype-config") === 2, "Dictation clicks run config command")

--- a/test/shell.d/indicator-contract-test.sh
+++ b/test/shell.d/indicator-contract-test.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+status_owner=$(rg -l 'omarchy-voxtype-status' "$ROOT/shell" --glob '*.qml')
+[[ $status_owner == "$ROOT/shell/plugins/services/dictation/Service.qml" ]] ||
+  fail "Voxtype status has exactly one owner in the shared dictation service"
+pass "Voxtype status has exactly one owner in the shared dictation service"
+
 TMPDIR=""
 QS_PID=""
 


### PR DESCRIPTION
Fixes #8674

## Summary

- add a first-party `omarchy.dictation` service that owns the single long-running `omarchy-voxtype-status` process
- bind every Dictation indicator instance to that shared service instead of starting one follower per monitor
- keep the existing recording/transcribing state and click behavior intact
- add regression coverage for single process ownership and shared-state propagation

## Why

`Dictation.qml` is instantiated once per bar surface. Owning the follower there starts one `voxtype status --follow` process per monitor and can accumulate more as surfaces are rebuilt. The shell already has a service loader specifically for state shared across UI instances, so the follower now lives there once per shell session.

## Tests

- `bash test/shell.d/plugins-test.sh`
- `bash test/shell.d/indicator-contract-test.sh` (single-owner assertion passes; live QML portion skipped because this host has no Wayland compositor)
- `bash test/shell.d/manifest-entrypoints-test.sh` (skipped because this host has no Wayland compositor)
- `bash -n bin/omarchy-voxtype-status test/shell.d/indicator-contract-test.sh`
- `jq empty shell/plugins/services/dictation/manifest.json`
- `git diff --check`

The broader config test was not runnable on this macOS host because `lua` is unavailable.