### PR TITLE
Fuzzy-search the Wi-Fi list from the network panel

### DIFF
--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -287,6 +287,32 @@ function sortWifiRows(rows) {
   return nets
 }
 
+// Case-insensitive subsequence match: every query character appears in the
+// SSID in order, but not necessarily adjacent ("cfe" finds "Coffee-Guest").
+// An empty query matches everything, so the list is whole until typing starts.
+function fuzzyMatchSsid(ssid, query) {
+  var haystack = String(ssid || "").toLowerCase()
+  var needle = String(query || "").toLowerCase()
+  var pos = 0
+  for (var i = 0; i < needle.length; i++) {
+    pos = haystack.indexOf(needle[i], pos)
+    if (pos < 0) return false
+    pos++
+  }
+  return true
+}
+
+// Narrows sorted rows by fuzzy SSID match, preserving their order so the
+// connected/known/signal ranking still decides who is on top. Hidden-SSID
+// rows (ssid == "") have nothing to match against, so any query drops them.
+function filterWifiRows(rows, query) {
+  var nets = Array.isArray(rows) ? rows : []
+  if (!query) return nets
+  return nets.filter(function(row) {
+    return !!(row && row.ssid) && fuzzyMatchSsid(row.ssid, query)
+  })
+}
+
 function wifiSectionTitle(wifiNetworks, index) {
   var networks = Array.isArray(wifiNetworks) ? wifiNetworks : []
   if (index < 0 || index >= networks.length) return ""
@@ -370,6 +396,8 @@ if (typeof module !== "undefined") {
     formatPingLatency: formatPingLatency,
     wifiRow: wifiRow,
     sortWifiRows: sortWifiRows,
+    fuzzyMatchSsid: fuzzyMatchSsid,
+    filterWifiRows: filterWifiRows,
     wifiSectionTitle: wifiSectionTitle,
     requiresCredentials: requiresCredentials,
     canForgetNetwork: canForgetNetwork,

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -16,16 +16,37 @@ Panel {
   // permits — needed for the toggleNetwork method below.
   manageIpc: false
 
-  // Centralized close so callers can't forget to drop the passphrase prompt.
+  // Centralized close so callers can't forget to drop the passphrase prompt
+  // or a network filter left mid-search.
   function close() {
     root.controller.hide()
     cancelPasswordPrompt()
+    cancelFilter()
   }
 
   function cancelPasswordPrompt() {
     passwordSsid = ""
     passwordText = ""
     identityText = ""
+  }
+
+  function cancelFilter() {
+    filterOpen = false
+    filterText = ""
+  }
+
+  // Opening is separate from focusing: the field grabs focus when it first
+  // becomes visible, and the callLater covers re-entering "/" after focus
+  // wandered back to the list.
+  function openFilter() {
+    filterOpen = true
+    if (wifiNetworks.length > 0) {
+      focusSection = "wifi"
+      if (selectedIndex < 0) selectedIndex = 0
+      cursorActive = true
+      wifiActionFocused = false
+    }
+    Qt.callLater(function() { if (filterField.visible) filterField.forceActiveFocus() })
   }
 
   // Live connection details from `ip` / /sys / iw.
@@ -97,6 +118,12 @@ Panel {
   property string passwordSsid: ""
   property string passwordText: ""
   property string identityText: ""
+
+  // Fuzzy filter over the network list, opened with "/" (fzf-style). The
+  // query narrows `wifiNetworks` itself so selection clamping, section
+  // titles, and keyboard nav all see the same list the eye does.
+  property bool filterOpen: false
+  property string filterText: ""
 
   // ConnectionFailReason values as a plain object, so Model.js helpers stay
   // pure JS and Node-testable.
@@ -319,6 +346,9 @@ Panel {
   // what makes the SUPER+CTRL+W keybind land here with navigation ready.
   onOpenedChanged: {
     if (opened) {
+      // Outside-click closes skip close(), so a filter from the previous
+      // open could otherwise still be narrowing the list on reopen.
+      cancelFilter()
       refresh(true)
       selectedIndex = wifiNetworks.length > 0 ? 0 : -1
       wifiActionFocused = false
@@ -603,9 +633,21 @@ Panel {
       var row = Model.wifiRow(network)
       if (row) nets.push(row)
     }
-    wifiNetworks = Model.sortWifiRows(nets)
+    wifiNetworks = Model.filterWifiRows(Model.sortWifiRows(nets), filterText)
     wifiStationAvailable = !!wifiDevice
     scanning = false
+  }
+
+  // Every keystroke re-narrows the list and parks the cursor on the top
+  // match, so Enter connects to the best hit fzf-style without an extra j.
+  onFilterTextChanged: {
+    syncWifiNetworks()
+    if (wifiNetworks.length > 0) {
+      selectedIndex = 0
+      focusSection = "wifi"
+      cursorActive = true
+      wifiActionFocused = false
+    }
   }
 
   function wifiSectionTitle(index) {
@@ -991,9 +1033,10 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
-      // Freeze the cursor model while the inline password prompt is open;
-      // the TextField inside owns input until Esc/Enter/Cancel.
-      blocked: root.passwordSsid !== ""
+      // Freeze the cursor model while the inline password prompt or the
+      // network filter field owns input; keys reach them normally until
+      // Esc/Enter hands focus back.
+      blocked: root.passwordSsid !== "" || filterField.activeFocus
 
       onMoveRequested: function(dx, dy) {
         if (!root.cursorActive) {
@@ -1068,11 +1111,17 @@ Panel {
           else root.activateSelected()
         }
       }
-      onCloseRequested: root.close()
+      // Esc first backs out of an active filter (vim-style staged escape);
+      // only a second Esc, or Esc with no filter, closes the panel.
+      onCloseRequested: {
+        if (root.filterOpen || root.filterText !== "") root.cancelFilter()
+        else root.close()
+      }
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) {
         if (t === "r" || t === "R") root.refresh()
         else if (t === "w" || t === "W") root.toggleNetwork()
+        else if (t === "/" && root.wifiStationAvailable) root.openFilter()
       }
 
     Column {
@@ -1462,6 +1511,42 @@ Panel {
       PanelSectionHeader {
         visible: root.wifiStationAvailable && root.scanning
         text: "SCANNING WI-FI…"
+        foreground: root.bar.foreground
+        fontFamily: root.bar.fontFamily
+      }
+
+      // Fuzzy filter over the network list, summoned with "/". Same inline
+      // sizing as the passphrase prompt so it reads as part of the list.
+      TextField {
+        id: filterField
+        visible: root.filterOpen && root.wifiStationAvailable
+        width: parent.width
+        placeholderText: "Search networks"
+        font.family: Style.font.family
+        font.pixelSize: Style.font.body
+        foreground: root.bar.foreground
+        horizontalPadding: Style.spacing.controlGap
+        verticalPadding: Style.spacing.controlPaddingY
+
+        text: root.filterOpen ? root.filterText : ""
+        onTextChanged: if (root.filterOpen && text !== root.filterText) root.filterText = text
+
+        // Enter connects to the highlighted match; j/k stay literal while
+        // typing, so the arrows drive the selection from inside the field.
+        onAccepted: root.activateSelected()
+        Keys.onUpPressed: root.selectByDelta(-1)
+        Keys.onDownPressed: root.selectByDelta(1)
+        Keys.onEscapePressed: {
+          root.cancelFilter()
+          keyCatcher.forceActiveFocus()
+        }
+
+        onVisibleChanged: if (visible) Qt.callLater(forceActiveFocus)
+      }
+
+      PanelSectionHeader {
+        visible: root.wifiStationAvailable && root.filterText !== "" && root.wifiNetworks.length === 0
+        text: "NO MATCHING NETWORKS"
         foreground: root.bar.foreground
         fontFamily: root.bar.fontFamily
       }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -384,7 +384,13 @@ Panel {
   onPasswordSsidChanged: {
     if (passwordSsid === "" && opened) {
       passwordText = ""
-      Qt.callLater(function() { if (keyCatcher) keyCatcher.forceActiveFocus() })
+      // A prompt reached through the filter hands focus back to the still-
+      // visible search field, not the key catcher — otherwise typing would
+      // silently turn into j/k navigation under an open editor.
+      Qt.callLater(function() {
+        if (filterOpen && filterField.visible) filterField.forceActiveFocus()
+        else if (keyCatcher) keyCatcher.forceActiveFocus()
+      })
     }
   }
 

--- a/test/shell.d/network-filter-test.sh
+++ b/test/shell.d/network-filter-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const network = requireFromRoot('shell/plugins/panels/network/Model.js')
+const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
+
+// --- fuzzyMatchSsid ---
+
+assert(network.fuzzyMatchSsid('Coffee-Shop-Guest', 'cfe'), 'fuzzy match finds an in-order subsequence')
+assert(network.fuzzyMatchSsid('Coffee-Shop-Guest', 'COFFEE'), 'fuzzy match is case-insensitive')
+assert(!network.fuzzyMatchSsid('Coffee-Shop-Guest', 'efc'), 'fuzzy match requires the query characters in order')
+assert(network.fuzzyMatchSsid('Coffee-Shop-Guest', ''), 'an empty query matches every SSID')
+assert(!network.fuzzyMatchSsid('', 'x'), 'an empty SSID cannot satisfy a non-empty query')
+
+// --- filterWifiRows ---
+
+const rows = [
+  { connected: true, known: true, ssid: 'HomeBase', signal: 90 },
+  { connected: false, known: true, ssid: 'Hotspot-Office', signal: 70 },
+  { connected: false, known: false, ssid: '', signal: 60 },
+  { connected: false, known: false, ssid: 'Neighbor 5G', signal: 40 },
+]
+
+const all = network.filterWifiRows(rows, '')
+assertEqual(all.length, 4, 'an empty query keeps the whole list, hidden rows included')
+
+const narrowed = network.filterWifiRows(rows, 'ho')
+assertEqual(
+  narrowed.map(r => r.ssid).join(','),
+  'HomeBase,Hotspot-Office,Neighbor 5G',
+  'filtering preserves the incoming sort order of the matches'
+)
+
+assertEqual(
+  network.filterWifiRows(rows, 'off').map(r => r.ssid).join(','),
+  'Hotspot-Office',
+  'a tighter query narrows down to the single subsequence match'
+)
+
+assertEqual(network.filterWifiRows(rows, 'z').length, 0, 'a query with no matches empties the list')
+assert(
+  network.filterWifiRows(rows, 'e').every(r => r.ssid !== ''),
+  'hidden-SSID rows never match a non-empty query'
+)
+
+// --- Panel wiring ---
+
+// The query must narrow wifiNetworks itself: selection clamping, section
+// titles, and the ListView all read that one list, so filtering anywhere
+// else would let the cursor land on rows the eye cannot see.
+const syncFn = panelSource.match(/function syncWifiNetworks\(\) \{[\s\S]*?\n {2}\}/)
+assert(syncFn, 'network has a syncWifiNetworks function')
+assert(/Model\.filterWifiRows\(Model\.sortWifiRows\(nets\), filterText\)/.test(syncFn[0]),
+  'syncWifiNetworks applies the fuzzy filter after sorting')
+
+assert(/onFilterTextChanged:[\s\S]*?syncWifiNetworks\(\)/.test(panelSource),
+  'typing in the filter re-narrows the list immediately')
+
+// "/" opens the filter; the field then owns the keyboard the same way the
+// passphrase prompt does, or j/k would type into the query.
+assert(/t === "\/"[\s\S]*?root\.openFilter\(\)/.test(panelSource), 'the "/" key opens the network filter')
+assert(/blocked: root\.passwordSsid !== "" \|\| filterField\.activeFocus/.test(panelSource),
+  'the key catcher yields to the filter field while it has focus')
+
+// Esc is staged: first back out of the filter, only then close the panel.
+const closeReq = panelSource.match(/onCloseRequested: \{[\s\S]*?\n {6}\}/)
+assert(closeReq, 'network has a close-request handler')
+assert(/cancelFilter\(\)/.test(closeReq[0]) && /else root\.close\(\)/.test(closeReq[0]),
+  'Esc clears an active filter before it closes the panel')
+
+// Outside-click closes skip close(), so reopen must not inherit a stale query.
+const openedHandler = panelSource.match(/onOpenedChanged: \{[\s\S]*?refresh\(true\)/)
+assert(openedHandler && /cancelFilter\(\)/.test(openedHandler[0]),
+  'reopening the panel starts with the filter cleared')
+JS

--- a/test/shell.d/network-filter-test.sh
+++ b/test/shell.d/network-filter-test.sh
@@ -73,6 +73,14 @@ assert(closeReq, 'network has a close-request handler')
 assert(/cancelFilter\(\)/.test(closeReq[0]) && /else root\.close\(\)/.test(closeReq[0]),
   'Esc clears an active filter before it closes the panel')
 
+// A passphrase prompt reached through the filter must hand focus back to the
+// still-visible search field on close, or typing turns into j/k navigation
+// under an open editor.
+const passwordClose = panelSource.match(/onPasswordSsidChanged: \{[\s\S]*?\n {2}\}/)
+assert(passwordClose, 'network has a password-close focus handler')
+assert(/filterOpen && filterField\.visible[\s\S]*?filterField\.forceActiveFocus\(\)/.test(passwordClose[0]),
+  'closing the passphrase prompt restores focus to an open filter field')
+
 // Outside-click closes skip close(), so reopen must not inherit a stale query.
 const openedHandler = panelSource.match(/onOpenedChanged: \{[\s\S]*?refresh\(true\)/)
 assert(openedHandler && /cancelFilter\(\)/.test(openedHandler[0]),


### PR DESCRIPTION
## Why

In a dense neighbourhood the network panel's list runs to dozens of SSIDs, and reaching the one you want means scrolling or walking `j`/`k` through all of them. This came out of a real morning spent hunting one network in a huge scan list.

## What

Pressing `/` in the network panel opens an inline search field that narrows the list with case-insensitive fuzzy (subsequence) matching as you type, fzf-style:

- The cursor rides the top match, so **Enter** connects to it immediately (or opens its passphrase prompt).
- **Arrow keys** move the selection without leaving the field, so `j`/`k` stay literal while typing.
- **Esc is staged**: first press clears the filter, second closes the panel.
- Hidden-SSID rows have nothing to match against and drop out of any non-empty query.
- Reopening the panel always starts unfiltered (including after outside-click closes, which skip `close()`).

The matcher lives in `Model.js` as pure JS (`fuzzyMatchSsid` / `filterWifiRows`), and the query narrows `wifiNetworks` itself inside `syncWifiNetworks()`, so selection clamping, section titles, and the ListView all see the same list the eye does — no parallel filtered list to keep in sync.

`/` was chosen because it's the one obvious search idiom that doesn't collide with the panel's existing key map (`r` refresh, `w` radio toggle, `x` reserved by PanelKeyCatcher, `hjkl` navigation). The field reuses the shared `TextField` with the same inline sizing as the passphrase prompt, and takes the keyboard through the same `blocked` gate.

## Testing

- New `test/shell.d/network-filter-test.sh` covers the matcher semantics (subsequence order, case-insensitivity, hidden-SSID exclusion, order preservation) and the panel wiring (filter applied in sync, `/` binding, key-catcher gating, staged Esc, reopen reset). All pass, along with the existing `network-test.sh` and the rest of `./test/shell`.
- Visually verified in the running shell per `agents/skills/visual-verification.md`: drove the panel over IPC, typed via `wtype`, captured screenshots of each state and a screen recording of the full flow (open → `/` → progressive narrowing → staged Esc). Typing `gst` correctly narrowed a 10-network scan to `Gimmeitam_Guest_6GHz` alone via non-contiguous match; no clipping, overlap, or focus issues observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nT1dQ7YTpbqQRb3CWubFw