### PR TITLE
Make the screensaver engage properly when idle

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -49,7 +49,13 @@ wait_for_screensaver_window() {
   done
 }
 
-for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
+# Spawn on every monitor, saving the focused one for last: the last window to
+# map keeps focus, and omarchy-screensaver exits whenever it is not the active
+# window, so focus has to end on a screensaver terminal. Restoring focus to
+# the previously focused window instead kills the freshly launched screensaver
+# about a second after it opens, leaving a windowed flash instead of a
+# screensaver.
+for m in $(hyprctl monitors -j | jq -r --arg focused "$focused" 'sort_by(.name == $focused) | .[].name'); do
   hypr_focus_monitor "$m"
 
   case $terminal in
@@ -69,5 +75,3 @@ for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
 
   wait_for_screensaver_window
 done
-
-hypr_focus_monitor "$focused"

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -43,10 +43,19 @@ function screensaverWindowsAfter(windows, address, visible) {
   }
 }
 
+function openPanelIdsToClose(openPanelIds) {
+  var ids = []
+  for (var id in openPanelIds || {}) {
+    if (openPanelIds[id]) ids.push(id)
+  }
+  return ids
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
-    screensaverWindowsAfter: screensaverWindowsAfter
+    screensaverWindowsAfter: screensaverWindowsAfter,
+    openPanelIdsToClose: openPanelIdsToClose
   }
 }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -79,6 +79,28 @@ Item {
     runProcess(lockProcess, "lock", "omarchy-system-lock")
   }
 
+  // An open bar popout (battery, audio, network menu, ...) or summoned panel
+  // (menu, emojis, clipboard, ...) is a keyboard-focused overlay layer that
+  // keeps drawing on top of the fullscreen screensaver. Close them before the
+  // idle cycle takes over the screen.
+  function closeOpenPanels() {
+    if (!shell) return
+
+    if (shell.bar && shell.bar.activePopout) {
+      var popout = shell.bar.activePopout
+      if (typeof popout.close === "function") {
+        logEvent("close-open-panel", "bar popout")
+        popout.close()
+      }
+    }
+
+    var ids = IdleModel.openPanelIdsToClose(shell.openPanelIds)
+    for (var i = 0; i < ids.length; i++) {
+      logEvent("close-open-panel", ids[i])
+      shell.hide(ids[i])
+    }
+  }
+
   function startIdleCycle() {
     if (root.idledThisCycle) {
       logEvent("idle-cycle-already-running")
@@ -86,6 +108,7 @@ Item {
     }
 
     logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds)
+    closeOpenPanels()
     root.idledThisCycle = true
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -33,6 +33,14 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+
+assertDeepEqual(
+  idle.openPanelIdsToClose({ 'omarchy.emojis': true, 'omarchy.menu': false, 'pablo.custom': true }),
+  ['omarchy.emojis', 'pablo.custom'],
+  'idle lists only open panels to close'
+)
+assertDeepEqual(idle.openPanelIdsToClose(null), [], 'idle closes nothing without open panels')
+assertDeepEqual(idle.openPanelIdsToClose({}), [], 'idle closes nothing with no open panels')
 JS
 
 test_tmp=$(mktemp -d)


### PR DESCRIPTION
## What was broken

Two stacked bugs kept the screensaver from ever engaging:

1. **The screensaver always died ~1-3s after launch.** `omarchy-launch-screensaver` ends with `hypr_focus_monitor "$focused"`, restoring focus to the previously focused window. `omarchy-screensaver` exits whenever it is not the active window (`hyprctl activewindow` class check), so the launcher's own last line killed the screensaver it just launched — leaving a windowed flash instead of a screensaver, on every idle cycle. Because each death looked like a user dismissal, the idle service canceled the pending lock timer too, so the screen also never locked.
2. **Open bar panels kept drawing on top of the fullscreen screensaver.** A popout like the battery menu is a keyboard-focused overlay layer that renders above the screensaver window, so if one was open when idle fired, its card stayed floating over the screensaver.

## Fixes

**Commit 1 — keep focus on the screensaver after launching it:** iterate monitors with the focused one last and drop the final focus restore. The last spawned screensaver (on the user's own monitor) keeps focus, which preserves the intent of ending on the user's monitor — and since every screensaver terminal shares the `org.omarchy.screensaver` class, the active-window check passes for all of them.

**Commit 2 — close open panels before the screensaver takes over:** `startIdleCycle()` now closes the bar's active popout and any summoned panels (menu, emojis, clipboard, ...) before launching the screensaver, via the new `IdleModel.openPanelIdsToClose` helper. Each closure is logged as `close-open-panel` for diagnostics.

## Verification

On a single-monitor (eDP-1, foot) machine:

- Before commit 1, the screensaver window lost focus ~3s after launch and exited on every cycle; after it, it stayed active and on screen for the full 25s observation window until dismissed with a key.
- With the battery menu open and idle firing, the menu closes (`close-open-panel: bar popout` in the idle journal) and the screensaver engages fullscreen with nothing drawn on top.
- Idle-service journal on an affected machine (every cycle of the boot):

```
idle-cycle-start: screensaver=150 lock=300
process-start: screensaver ...
idle-cycle-cancel: screensaver-dismissed   # ~1-3s later, every time
```

- `test/shell.d/idle-test.sh` extended with coverage for `openPanelIdsToClose` and passing; `./test/cli` passes. Three shell-suite failures (`config-test`, `snapper-test`, `unowned-system-paths-test`) are pre-existing on this machine and unrelated to this change — e.g. "omarchy-pkgs checkout found for PKGBUILD coverage" fails for lack of a local checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)