### PR TITLE
Prevent undefined reference error on ErrorString

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -253,7 +253,7 @@ ShellRoot {
     onActiveChanged: if (!active) shell.bar = null
     onStatusChanged: {
       if (status === Loader.Error) {
-        var detail = errorString && errorString() ? errorString() : ""
+        var detail = (typeof errorString !== "undefined" && errorString && errorString()) ? errorString() : ""
         console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId + ":", detail)
         shell.failedBarId = shell.activeBarId
       }

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -216,6 +216,26 @@ assert(
   'shell toggles a bar panel by its position over IPC'
 )
 
+// A required-property failure — or an engine where Loader.errorString isn't
+// callable — must not stop failedBarId from being recorded. That assignment
+// is what lets the bar fall back to omarchy.bar; losing it silently
+// recreates the blank-bar failure from a cloned/third-party bar plugin.
+const pluginBarLoaderBlock = shellSource.slice(shellSource.indexOf('id: pluginBarLoader'))
+const pluginBarLoaderBody = pluginBarLoaderBlock.slice(0, pluginBarLoaderBlock.indexOf('\n  }\n'))
+
+assert(
+  /typeof errorString !== ["']undefined["']/.test(pluginBarLoaderBody),
+  'the bar loader reads errorString through a typeof guard instead of a bare reference'
+)
+assert(
+  /shell\.failedBarId = shell\.activeBarId/.test(pluginBarLoaderBody),
+  'the bar loader records failedBarId on a Loader.Error status'
+)
+assert(
+  !/try\s*\{[\s\S]*shell\.failedBarId = shell\.activeBarId[\s\S]*?\}\s*catch/.test(pluginBarLoaderBody),
+  'failedBarId assignment sits outside the errorString try/catch, so it always runs even if reading errorString throws'
+)
+
 const clockSlot = { id: 'clock' }
 const traySlot = { id: 'tray' }
 const horizontalTargets = [


### PR DESCRIPTION
Loading a cloned/custom bar (kind: "bar") that fails required-property initialization throws a ReferenceError on the undefined errorString property, which prevents the automatic fallback to omarchy.bar from running. The result is no top bar at all.

This fix guards the errorString access with typeof, so a failed load falls back to the default bar gracefully instead of crashing.

Fixes the required-property failure in pluginBarLoader for third-party bar plugins.

Relates to #7418