### PR TITLE
Prevent network address values from overlapping labels

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1251,12 +1251,16 @@ Panel {
 
           InfoLabel { text: "IP Address" }
           DetailValue {
+            Layout.columnSpan: 3
+            Layout.fillWidth: true
             text: root.info.ip || "--"
             copyable: !!root.info.ip
             tooltipText: "Copy IP"
           }
           InfoLabel { text: "Gateway" }
           DetailValue {
+            Layout.columnSpan: 3
+            Layout.fillWidth: true
             text: root.info.gateway || "--"
             copyable: !!root.info.gateway
             tooltipText: "Copy gateway"


### PR DESCRIPTION
## What

Give the IP address and gateway values the remaining three columns in the network details grid. Each value now uses its own row.

## Why

IPv4 addresses can exceed the width of one value cell and draw over the adjacent labels. This occurs in the stock panel at the default 12 px text size.

This uses the same full-width layout that #8683 applies to long IPv6 values, but fixes the existing IPv4 fields independently.

## Testing

- `bash test/shell.d/network-test.sh`
- Verified in the running Omarchy 4.0.1 shell at the default 12 px text size
- Confirmed that the IP address and gateway are fully visible with no overlap
