### PR TITLE
Fix pixelated motion rendering on Dell Inspiron 16 Plus (disable i915 PSR)

### DIFF
--- a/bin/omarchy-hw-dell-inspiron16-plus
+++ b/bin/omarchy-hw-dell-inspiron16-plus
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# omarchy:summary=Match Dell Inspiron 16 Plus laptops (Alder Lake Iris Xe + NVIDIA hybrid, eDP panel).
+
+# The Inspiron 16 Plus family (7620 and siblings) pairs Alder Lake Intel Iris Xe
+# with a discrete NVIDIA GPU and drives the internal panel from the Intel i915
+# GPU. On these panels i915 PSR2 selective-fetch fails (kernel log: "Selective
+# fetch area calculation failed in pipe A"), which shows up as pixelation of
+# moving content while static content stays crisp. Matches the whole family.
+omarchy-hw-match "Inspiron 16 Plus"

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -29,6 +29,8 @@ run_logged "$OMARCHY_INSTALL/hardware/intel/sof-firmware.sh"
 # above rather than sit with the other Dell leaf at the top of this file.
 run_logged "$OMARCHY_INSTALL/hardware/dell-xps13-sidecar-amps.sh"
 
+run_logged "$OMARCHY_INSTALL/hardware/dell/fix-inspiron16-plus-psr.sh"
+
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-display-backlight.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-display.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-touchpad.sh"

--- a/install/hardware/dell/fix-inspiron16-plus-psr.sh
+++ b/install/hardware/dell/fix-inspiron16-plus-psr.sh
@@ -1,0 +1,20 @@
+# Fix for pixelated / broken rendering of moving content on Dell Inspiron 16 Plus
+# laptops (7620 family) with an Alder Lake Intel Iris Xe iGPU driving the internal
+# eDP panel in a hybrid Intel + NVIDIA setup.
+#
+# The panel's i915 Panel Self-Refresh (PSR2) selective-fetch path fails on these
+# panels: the kernel logs "Selective fetch area calculation failed in pipe A" and
+# "Port E/TC#2: timeout waiting for PHY ready", and the compositor shows crisp
+# static content but pixelated artifacts whenever anything moves. Disabling PSR
+# (i915.enable_psr=0) makes the panel refresh cleanly on motion.
+#
+# gated to the Inspiron 16 Plus family; other models need confirmation the issue
+# exists there too before broadening.
+
+if omarchy-hw-dell-inspiron16-plus; then
+  sudo mkdir -p /etc/limine-entry-tool.d
+  sudo tee /etc/limine-entry-tool.d/dell-inspiron16-plus-psr.conf >/dev/null <<'EOF'
+# Dell Inspiron 16 Plus (7620 family) eDP PSR selective-fetch failure workaround
+KERNEL_CMDLINE[default]+=" i915.enable_psr=0"
+EOF
+fi


### PR DESCRIPTION
## What

Fix pixelated / broken rendering of moving content on **Dell Inspiron 16 Plus** laptops (7620 family) by disabling Intel i915 Panel Self-Refresh (PSR) on these panels.

## Symptom

On a hybrid Intel + NVIDIA Inspiron 16 Plus (Alder Lake Iris Xe driving the internal eDP panel), the compositor renders crisp static content but **pixelated artifacts whenever anything moves**. `grim` screen capture also hangs. No software-rendering fallback is involved — Hyprland runs hardware-accelerated on the Iris Xe (Mesa, OpenGL ES 3.2, ~1% CPU).

## Root cause

The kernel logs on the affected panel:

```
i915 0000:00:02.0: [drm] *ERROR* Port E/TC#2: timeout waiting for PHY ready
i915 0000:00:02.0: [drm] Selective fetch area calculation failed in pipe A
```

This is the **i915 PSR2 selective-fetch path failing** on the internal eDP panel. When selective fetch breaks, the panel cannot correctly refresh just the moving regions of the frame, so motion renders as pixelated/torn artifacts while static content stays clean.

## Fix

Disable Panel Self-Refresh with the `i915.enable_psr=0` kernel parameter, applied as a Limine drop-in following the same pattern as the existing ASUS Panther Lake display fixes (`install/hardware/asus/fix-asus-ptl-display-backlight.sh`, `fix-asus-ptl-b9406-display.sh`).

## Verification

- Confirmed working on a Dell Inspiron 16 Plus 7620: after adding `i915.enable_psr=0`, the pixelation-on-motion is gone.
- Detector verified against the device's DMI (`product_name: Inspiron 16 Plus 7620`, `product_family: Inspiron`).
- Mirrors existing Omarchy conventions: hardware detector in `bin/`, gated fix script writing a `KERNEL_CMDLINE[default]+=` drop-in to `/etc/limine-entry-tool.d/`, registered in `install/hardware/all.sh`.
- `bin-style-test.sh` passes.

## Scope note

Gated to the **Inspiron 16 Plus** family only, since `i915.enable_psr=0` disables a power-saving feature. Following the ASUS precedent ("Other models need confirmation whether the issue exists there too"), this should not be broadened to all Intel eDP laptops until the PSR failure is confirmed on more hardware.
