### PR TITLE
Add component wrapper in order to "preload" require properties

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -234,6 +234,18 @@ ShellRoot {
     }
   }
 
+  Component {
+    id: customBarComponent
+
+    Bar {
+      omarchyPath: shell.omarchyPath
+      barWidgetRegistry: shell.barWidgetRegistry
+      barConfig: shell.barConfig
+      shell: shell
+      manifest: shell.barManifestFor((shell.activeBarId) ? shell.activeBarId : shell.defaultBarId)
+    }
+  }
+
   Loader {
     id: defaultBarLoader
 
@@ -247,7 +259,7 @@ ShellRoot {
     id: pluginBarLoader
 
     active: !shell.pluginReloading && shell.activeBarId !== shell.defaultBarId && shell.activeBarSourceUrl !== ""
-    source: shell.activeBarId !== shell.defaultBarId ? shell.activeBarSourceUrl : ""
+    sourceComponent: customBarComponent 
     asynchronous: true
     onLoaded: shell.configureBar(item, shell.activeBarManifest)
     onActiveChanged: if (!active) shell.bar = null

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -153,6 +153,10 @@ ShellRoot {
     // case the user dir already existed at startup.
     pluginRegistry.rescan()
     shell._syncServices()
+    // The plugin bar loader below only reacts to property changes; run it
+    // once up front in case activeBarSourceUrl is already correct before
+    // anything else changes (e.g. a prior scan already populated the registry).
+    shell.loadPluginBar()
   }
 
   function mutateShellConfig(mutator) {
@@ -234,18 +238,6 @@ ShellRoot {
     }
   }
 
-  Component {
-    id: customBarComponent
-
-    Bar {
-      omarchyPath: shell.omarchyPath
-      barWidgetRegistry: shell.barWidgetRegistry
-      barConfig: shell.barConfig
-      shell: shell
-      manifest: shell.barManifestFor((shell.activeBarId) ? shell.activeBarId : shell.defaultBarId)
-    }
-  }
-
   Loader {
     id: defaultBarLoader
 
@@ -255,22 +247,121 @@ ShellRoot {
     onActiveChanged: if (!active && shell.activeBarId !== shell.defaultBarId) shell.bar = null
   }
 
-  Loader {
-    id: pluginBarLoader
+  // ------------------------------------------------------- plugin bar loader
+  //
+  // A third-party/cloned bar (kind "bar") is not a static import like the
+  // built-in one above, so it cannot be wrapped in an inline Component the
+  // same way — its QML lives at an arbitrary file URL discovered at runtime.
+  // A Loader's `source:` property was tried first, but it constructs the
+  // object immediately and only assigns properties afterwards in onLoaded,
+  // which fails Bar.qml's `required property` checks (omarchyPath,
+  // barWidgetRegistry, barConfig) before configureBar() ever gets to run.
+  //
+  // Qt.createComponent(url).createObject(parent, initialProperties) is the
+  // dynamic equivalent of the inline-Component binding defaultBarComponent
+  // uses: initialProperties are applied atomically as part of construction,
+  // so required properties are satisfied before the object finishes being
+  // created — same guarantee, still resolved from an arbitrary URL.
+  property var pluginBarComponent: null
+  property var pluginBarInstance: null
+  property string pluginBarComponentUrl: ""
 
-    active: !shell.pluginReloading && shell.activeBarId !== shell.defaultBarId && shell.activeBarSourceUrl !== ""
-    sourceComponent: customBarComponent 
-    asynchronous: true
-    onLoaded: shell.configureBar(item, shell.activeBarManifest)
-    onActiveChanged: if (!active) shell.bar = null
-    onStatusChanged: {
-      if (status === Loader.Error) {
-        var detail = errorString && errorString() ? errorString() : ""
-        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId + ":", detail)
-        shell.failedBarId = shell.activeBarId
+  // createObject only places the created object in the render scene when its
+  // parent argument is itself a QQuickItem (Loader gives this for free by
+  // being one itself). shell is a ShellRoot, not an Item, so parenting to it
+  // directly leaves the bar fully constructed but never inserted into the
+  // scene graph — it exists, but renders incorrectly until some unrelated
+  // event (e.g. a relayout) forces the compositor to notice it. This host
+  // gives the dynamically created bar a real place in the scene from the
+  // moment it is created.
+  Item {
+    id: pluginBarHost
+    visible: false
+  }
+
+  function destroyPluginBar() {
+    if (shell.bar && shell.bar === shell.pluginBarInstance) shell.bar = null
+    if (shell.pluginBarInstance) {
+      shell.pluginBarInstance.destroy()
+      shell.pluginBarInstance = null
+    }
+    shell.pluginBarComponent = null
+    shell.pluginBarComponentUrl = ""
+  }
+
+  function loadPluginBar() {
+    if (shell.pluginReloading || shell.activeBarId === shell.defaultBarId || shell.activeBarSourceUrl === "") {
+      shell.destroyPluginBar()
+      return
+    }
+
+    // Already built for this exact url and id — leave the live instance alone.
+    if (shell.pluginBarInstance && shell.pluginBarComponentUrl === shell.activeBarSourceUrl) return
+
+    var url = shell.activeBarSourceUrl
+    var barIdAtRequest = shell.activeBarId
+
+    shell.destroyPluginBar()
+    shell.pluginBarComponentUrl = url
+
+    var comp = Qt.createComponent(url, Component.Asynchronous)
+    shell.pluginBarComponent = comp
+
+    function finalize() {
+      // Superseded by a later call (config changed again while this was
+      // loading, or the bar was disabled) — drop this attempt entirely.
+      if (shell.pluginBarComponentUrl !== url || shell.pluginBarComponent !== comp) return
+
+      if (comp.status === Component.Error) {
+        console.warn("bar option " + barIdAtRequest + " failed to load, falling back to " + shell.defaultBarId + ":", comp.errorString())
+        shell.pluginBarComponent = null
+        shell.pluginBarComponentUrl = ""
+        shell.failedBarId = barIdAtRequest
+        return
       }
+
+      if (comp.status !== Component.Ready) return
+
+      // Component.createObject's initial-properties object assigns plain
+      // values, not bindings — unlike defaultBarComponent's inline
+      // `barConfig: shell.barConfig`, which stays live for the object's whole
+      // lifetime. A plain value here can also be stale: loading is
+      // asynchronous, so shell.activeBarManifest may have moved on by the
+      // time this callback runs. Qt.binding() re-establishes a genuine live
+      // binding for each property, matching what the static Bar {} component
+      // gets for free, and re-reading shell.activeBarManifest fresh (rather
+      // than a value captured back when loadPluginBar() was first called)
+      // keeps the very first frame in sync with whatever is current now.
+      var inst = comp.createObject(pluginBarHost, {
+        omarchyPath: Qt.binding(function() { return shell.omarchyPath }),
+        barWidgetRegistry: Qt.binding(function() { return shell.barWidgetRegistry }),
+        barConfig: Qt.binding(function() { return shell.barConfig }),
+        shell: shell,
+        manifest: Qt.binding(function() { return shell.activeBarManifest })
+      })
+
+      if (!inst) {
+        console.warn("bar option " + barIdAtRequest + " failed to construct, falling back to " + shell.defaultBarId)
+        shell.pluginBarComponent = null
+        shell.pluginBarComponentUrl = ""
+        shell.failedBarId = barIdAtRequest
+        return
+      }
+
+      shell.pluginBarInstance = inst
+      shell.bar = inst
+    }
+
+    if (comp.status === Component.Loading) {
+      comp.statusChanged.connect(finalize)
+    } else {
+      finalize()
     }
   }
+
+  onActiveBarSourceUrlChanged: shell.loadPluginBar()
+  onActiveBarIdChanged: shell.loadPluginBar()
+  onPluginReloadingChanged: shell.loadPluginBar()
 
   // ------------------------------------------------------------- services
   //

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -361,7 +361,10 @@ ShellRoot {
 
   onActiveBarSourceUrlChanged: shell.loadPluginBar()
   onActiveBarIdChanged: shell.loadPluginBar()
-  onPluginReloadingChanged: shell.loadPluginBar()
+onPluginReloadingChanged: {
+    if (!shell.pluginReloading && shell.failedBarId !== "") shell.failedBarId = ""
+    shell.loadPluginBar()
+  }
 
   // ------------------------------------------------------------- services
   //

--- a/test/shell.d/plugin-bar-loader-test.sh
+++ b/test/shell.d/plugin-bar-loader-test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const shellSource = fs.readFileSync(root + '/shell/shell.qml', 'utf8')
+const barSource = fs.readFileSync(root + '/shell/plugins/bar/Bar.qml', 'utf8')
+
+const loader = shellSource.slice(
+  shellSource.indexOf('function loadPluginBar()'),
+  shellSource.indexOf('onActiveBarSourceUrlChanged:')
+)
+const finalize = loader.slice(loader.indexOf('function finalize()'))
+const createObjectCall = finalize.slice(
+  finalize.indexOf('comp.createObject('),
+  finalize.indexOf('\n      })') + '\n      })'.length
+)
+
+// #8007: a cloned/third-party bar loaded through Qt.createComponent().createObject()
+// must receive every one of Bar.qml's required properties in the initial-properties
+// object passed to createObject, not assigned afterwards — QML enforces required
+// properties at construction, so anything injected post-construction (the way the old
+// Loader.source-based pluginBarLoader worked) throws before the bar ever renders.
+//
+// Only the root Item's own required properties matter here — Bar.qml also declares
+// `required property` inside nested delegates (Instantiator/Repeater models), which
+// are satisfied by their own model data, not by createObject's initial properties.
+const barRoot = barSource.slice(0, barSource.indexOf('required property var modelData'))
+for (const requiredProp of Array.from(barRoot.matchAll(/required property (?:string|var) (\w+)/g)).map(m => m[1])) {
+  assert(
+    new RegExp(`\\b${requiredProp}\\s*:`).test(createObjectCall),
+    `loadPluginBar's createObject call initializes Bar.qml's required property "${requiredProp}"`
+  )
+}
+
+// Every property handed to createObject must be a live Qt.binding, not a one-time
+// value snapshot — a plain value would desync from shell state the instant something
+// changes after construction (the "must double-click to render" regression), whereas
+// defaultBarComponent's inline `barConfig: shell.barConfig` binding stays live for the
+// object's whole lifetime for free.
+for (const boundProp of ['omarchyPath', 'barWidgetRegistry', 'barConfig', 'manifest']) {
+  assert(
+    new RegExp(`${boundProp}\\s*:\\s*Qt\\.binding\\(function\\(\\)`).test(createObjectCall),
+    `loadPluginBar binds "${boundProp}" live via Qt.binding instead of a one-time value`
+  )
+}
+
+// createObject's parent argument must be a real Item (pluginBarHost), not shell
+// itself (a ShellRoot). Only a QQuickItem parent gives the created object a
+// parentItem, which is what actually places it in the render scene graph — passing
+// shell would leave the bar fully constructed but invisible until an unrelated
+// relayout forced the compositor to notice it.
+assert(
+  /comp\.createObject\(pluginBarHost,/.test(finalize),
+  'the plugin bar is parented to a real Item (pluginBarHost) so it lands in the scene graph'
+)
+assert(
+  /id:\s*pluginBarHost/.test(shellSource) && /Item\s*\{\s*\n\s*id:\s*pluginBarHost/.test(shellSource),
+  'pluginBarHost is a QQuickItem, not the ShellRoot itself'
+)
+
+// --- fallback behavior --------------------------------------------------
+//
+// A load failure (bad QML) and a construction failure (createObject returns
+// null) must both record failedBarId so activeBarId's `selectedBarId !==
+// failedBarId` check falls back to the default bar — losing either path
+// silently recreates the blank-bar failure from #8007.
+assert(
+  /comp\.status === Component\.Error\)[\s\S]*?shell\.failedBarId = barIdAtRequest/.test(finalize),
+  'a Component.Error status records failedBarId so the shell falls back to the default bar'
+)
+assert(
+  /if \(!inst\)[\s\S]*?shell\.failedBarId = barIdAtRequest/.test(finalize),
+  'a null createObject result records failedBarId so the shell falls back to the default bar'
+)
+assert(
+  /activeBarId: selectedBarId !== failedBarId && selectedBarAvailable \? selectedBarId : defaultBarId/.test(shellSource),
+  'activeBarId actually falls back to defaultBarId once failedBarId is recorded'
+)
+
+// A stale async load (superseded by a newer config change while Qt.createComponent
+// was still resolving) must be dropped rather than mistakenly finalized — closure-
+// captured `url`/`comp` staleness was the root cause of the double-click-to-render bug.
+assert(
+  /if \(shell\.pluginBarComponentUrl !== url \|\| shell\.pluginBarComponent !== comp\) return/.test(finalize),
+  'a superseded plugin bar load is dropped instead of finalized against stale state'
+)
+
+// --- reload behavior ------------------------------------------------------
+//
+// The loader only reacts to property changes, so every input that can make a
+// different bar become active must re-invoke loadPluginBar(): the selected bar id
+// changing, its resolved source url changing (e.g. after a plugin rescan), and a
+// plugin reload starting or finishing.
+for (const trigger of ['onActiveBarSourceUrlChanged', 'onActiveBarIdChanged', 'onPluginReloadingChanged']) {
+  assert(
+    new RegExp(`${trigger}:\\s*shell\\.loadPluginBar\\(\\)`).test(shellSource),
+    `${trigger} re-invokes loadPluginBar so a bar change is picked up`
+  )
+}
+
+// A plugin reload in progress, selecting the default bar, or having no resolvable
+// source url must tear down any live plugin bar instance rather than leave a stale
+// one mounted.
+assert(
+  /if \(shell\.pluginReloading \|\| shell\.activeBarId === shell\.defaultBarId \|\| shell\.activeBarSourceUrl === ""\) \{\s*\n\s*shell\.destroyPluginBar\(\)/.test(loader),
+  'loadPluginBar tears down the plugin bar when reloading, defaulted, or sourceless'
+)
+
+// destroyPluginBar must fully release the instance: clear shell.bar if it was the
+// active bar, destroy the QML object, and reset the component bookkeeping so a
+// later loadPluginBar() does not mistake stale state for an up-to-date build.
+const destroy = shellSource.slice(
+  shellSource.indexOf('function destroyPluginBar()'),
+  shellSource.indexOf('function loadPluginBar()')
+)
+assert(/shell\.bar = null/.test(destroy), 'destroyPluginBar clears shell.bar when it held the plugin instance')
+assert(/shell\.pluginBarInstance\.destroy\(\)/.test(destroy), 'destroyPluginBar destroys the QML instance')
+assert(/shell\.pluginBarComponent = null/.test(destroy), 'destroyPluginBar clears the tracked component')
+assert(/shell\.pluginBarComponentUrl = ""/.test(destroy), 'destroyPluginBar clears the tracked component url')
+
+// An already-built bar for the exact same url must be left alone rather than
+// rebuilt on every reactive trigger (e.g. an unrelated shell.json field changing).
+assert(
+  /if \(shell\.pluginBarInstance && shell\.pluginBarComponentUrl === shell\.activeBarSourceUrl\) return/.test(loader),
+  'loadPluginBar reuses an already-built instance instead of rebuilding on every trigger'
+)
+JS


### PR DESCRIPTION
Adding a component "Bar" wrapper to make sure required properties are load before the component is spawned. 
It's the same mecanism as for the omarchy default bar but was missing for customs bars.

Relates to #8007 