### PR TITLE
Add `omarchy:examples` metadata to brightness keyboard commands

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -2,6 +2,7 @@
 
 # omarchy:summary=Adjust keyboard backlight brightness using available steps.
 # omarchy:args=<up|down|cycle|off|restore>
+# omarchy:examples=omarchy brightness keyboard up | omarchy brightness keyboard down | omarchy brightness keyboard off | omarchy brightness keyboard restore
 
 direction="${1:-up}"
 

--- a/bin/omarchy-brightness-keyboard-mute
+++ b/bin/omarchy-brightness-keyboard-mute
@@ -2,6 +2,7 @@
 
 # omarchy:summary=Set the mic-mute indicator LED on laptops that expose a platform::micmute LED node.
 # omarchy:args=<on|off>
+# omarchy:examples=omarchy brightness keyboard mute on | omarchy brightness keyboard mute off
 
 if [[ -e /sys/class/leds/platform::micmute/brightness ]]; then
   case "$1" in


### PR DESCRIPTION
## Summary
Two user-facing `brightness` commands were missing usage examples in their CLI metadata:

- `bin/omarchy-brightness-keyboard` (`omarchy brightness keyboard`)
- `bin/omarchy-brightness-keyboard-mute` (`omarchy brightness keyboard mute`)

This adds `# omarchy:examples=` lines so `omarchy brightness keyboard --help` and `omarchy brightness keyboard mute --help` show copy-pasteable invocations, matching the rest of the `brightness-*` group.

## Test plan
- `bash -n bin/omarchy-brightness-keyboard bin/omarchy-brightness-keyboard-mute`
- `./bin/omarchy commands --check` passes (284 commands)
- `bash test/omarchy-cli-test.sh` passes

Co-Authored-By: opencode <noreply@opencode.ai>