### PR TITLE
Add FAM as an externally packaged coding agent

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -46,8 +46,10 @@ if [[ -z $agent ]]; then
   exit 1
 fi
 
-if omarchy-cmd-missing "$agent"; then
-  echo "$agent is not installed. Choose an installed agent with: omarchy default agent <name>" >&2
+agent_command=$agent
+[[ $agent == "fam" ]] && agent_command=omarchy-fam
+if omarchy-cmd-missing "$agent_command"; then
+  echo "$agent_command is not installed. Choose an installed agent with: omarchy default agent <name>" >&2
   exit 1
 fi
 
@@ -85,6 +87,10 @@ grok)
 codex)
   command=(codex --approve-for-me)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
+  ;;
+fam)
+  command=(omarchy-fam)
+  [[ -n ${prompt:-} ]] && command+=("$prompt")
   ;;
 omp)
   command=(omp --auto-approve)

--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -89,8 +89,11 @@ codex)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;
 fam)
-  command=(omarchy-fam)
-  [[ -n ${prompt:-} ]] && command+=("$prompt")
+  if [[ -n ${prompt:-} ]]; then
+    command=(omarchy-fam --prompt "$prompt")
+  else
+    command=(omarchy-fam --interactive)
+  fi
   ;;
 omp)
   command=(omp --auto-approve)

--- a/bin/omarchy-agent-crash
+++ b/bin/omarchy-agent-crash
@@ -49,4 +49,4 @@ mechanism, read the skill files directly and follow them instead:
 PROMPT
 )
 
-exec omarchy-agent --prompt "$prompt"
+FAM_OMARCHY_SOURCE=omarchy-crash-diagnosis exec omarchy-agent --prompt "$prompt"

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set and launch the default coding agent
-# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|agy|copilot|crush]
+# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|agy|copilot|fam|crush]
 # omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent claude
 
 installing=false
@@ -34,13 +34,24 @@ crush) agent="crush"; name="Crush" ;;
 grok) agent="grok"; name="Grok"; agent_package="npm:@xai-official/grok" ;;
 agy | antigravity | antigravity-cli | gemini | gemini-cli) agent="agy"; name="Antigravity"; agent_package="antigravity-cli" ;;
 copilot | github-copilot) agent="copilot"; name="GitHub Copilot" ;;
+fam | fam-os) agent="fam"; name="FAM_OS" ;;
 *)
-  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|agy|copilot|crush>"
+  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|agy|copilot|fam|crush>"
   exit 1
   ;;
 esac
 
 agent_package=${agent_package:-$agent}
+
+if [[ $agent == "fam" ]]; then
+  if ! command -v omarchy-fam >/dev/null; then
+    echo "FAM_OS is not installed. Install the fam-os package first." >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "$agent_file")"
+  printf '%s\n' "$agent" >"$agent_file"
+  exec omarchy-agent
+fi
 
 if [[ $installing == "false" ]] && ! mise where "$agent_package" &>/dev/null; then
   exec omarchy-launch-floating-terminal-with-presentation omarchy-default-agent --install "$agent"

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -140,6 +140,7 @@
   "setup.default.agent.codex": {"icon":"","iconFont":"omarchy","label":"Codex","checked":"[[ \"$(omarchy-default-agent)\" == \"codex\" ]]","action":"omarchy-default-agent codex"},
   "setup.default.agent.copilot": {"icon":"","label":"Copilot","checked":"[[ \"$(omarchy-default-agent)\" == \"copilot\" ]]","action":"omarchy-default-agent copilot"},
   "setup.default.agent.crush": {"icon":"󰋑","label":"Crush","checked":"[[ \"$(omarchy-default-agent)\" == \"crush\" ]]","action":"omarchy-default-agent crush"},
+  "setup.default.agent.fam": {"icon":"󰚩","label":"FAM","checked":"[[ \"$(omarchy-default-agent)\" == \"fam\" ]]","action":"omarchy-default-agent fam"},
   "setup.default.agent.grok": {"icon":"","iconFont":"omarchy","label":"Grok","checked":"[[ \"$(omarchy-default-agent)\" == \"grok\" ]]","action":"omarchy-default-agent grok"},
   "setup.default.agent.omp": {"icon":"","iconFont":"omarchy","label":"omp","checked":"[[ \"$(omarchy-default-agent)\" == \"omp\" ]]","action":"omarchy-default-agent omp"},
   "setup.default.agent.opencode": {"icon":"","iconFont":"omarchy","label":"OpenCode","checked":"[[ \"$(omarchy-default-agent)\" == \"opencode\" ]]","action":"omarchy-default-agent opencode"},

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -1,19 +1,20 @@
 # AI
 
-Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a favorite for you. Instead, every major coding-agent CLI comes pre-wired as a lazy-loaded launcher. The launchers are tiny [mise](https://mise.jdx.dev/)-managed stubs in `~/.local/bin/`, so nothing is downloaded until the first time you actually run one. Invoke any of these and authenticate when prompted:
+Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a favorite for you. Most major coding-agent CLIs come pre-wired as lazy-loaded launchers. These launchers are tiny [mise](https://mise.jdx.dev/)-managed stubs in `~/.local/bin/`, so nothing is downloaded until the first time you actually run one. FAM is the exception: its `omarchy-fam` launcher is supplied by the separately installed `fam-os` package. Invoke any installed agent and authenticate when prompted:
 
-| Command    | Agent                                                            |
-|------------|------------------------------------------------------------------|
-| `claude`   | [Claude Code](https://code.claude.com/docs/en/overview)          |
-| `codex`    | [OpenAI Codex](https://github.com/openai/codex)                  |
-| `opencode` | [OpenCode](https://opencode.ai/)                                 |
-| `agy`      | [Google Antigravity CLI](https://github.com/google-antigravity/antigravity-cli) |
-| `copilot`  | [GitHub Copilot CLI](https://github.com/github/copilot-cli)      |
-| `crush`    | [Crush](https://github.com/charmbracelet/crush)                  |
-| `grok`     | Grok CLI from xAI                                                |
-| `pi`       | [Mario Zechner's Pi](https://github.com/badlogic/pi-mono)        |
-| `omp`      | [Oh My Pi](https://github.com/can1357/oh-my-pi)                  |
-| `ori`      | [Ori](https://openrouter.ai/docs/guides/ori/harness), OpenRouter's harness |
+| Command       | Agent                                                            |
+|---------------|------------------------------------------------------------------|
+| `claude`      | [Claude Code](https://code.claude.com/docs/en/overview)          |
+| `codex`       | [OpenAI Codex](https://github.com/openai/codex)                  |
+| `opencode`    | [OpenCode](https://opencode.ai/)                                 |
+| `agy`         | [Google Antigravity CLI](https://github.com/google-antigravity/antigravity-cli) |
+| `copilot`     | [GitHub Copilot CLI](https://github.com/github/copilot-cli)      |
+| `crush`       | [Crush](https://github.com/charmbracelet/crush)                  |
+| `omarchy-fam` | [FAM_OS](https://github.com/demimagic-ML/FAM-os) (external `fam-os` package) |
+| `grok`        | Grok CLI from xAI                                                |
+| `pi`          | [Mario Zechner's Pi](https://github.com/badlogic/pi-mono)        |
+| `omp`         | [Oh My Pi](https://github.com/can1357/oh-my-pi)                  |
+| `ori`         | [Ori](https://openrouter.ai/docs/guides/ori/harness), OpenRouter's harness |
 
 `ori` is the odd one out: it runs the other harnesses against OpenRouter's whole model catalog, so `ori claude`, `ori codex`, or `ori opencode` start those agents on whichever model you point them at, and `ori code` is Ori's own agent.
 
@@ -21,7 +22,7 @@ To wrap an additional CLI the same way, run `omarchy-mise-install <package> [com
 
 ### The default agent
 
-Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If the agent isn't installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification.
+Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If a mise-managed agent isn't installed yet, picking it installs it first. FAM must be installed separately through the `fam-os` package before it can be selected; Omarchy reports that requirement instead of attempting a mise installation. A fresh Omarchy will invite you to make this choice with a one-time notification.
 
 Once you've chosen, `Super + Shift + Ctrl + A` launches the default agent in a dedicated terminal window (or brings up the picker if you haven't chosen yet). You can also launch it straight into a task with `omarchy agent prompt "Review this project"`. Agents launched this way run unattended in their respective don't-stop-to-ask modes, so be ready for them to actually do things! And since agents refuse to remember trust for your home directory, launches from `$HOME` start in `~/Work` instead.
 

--- a/test/shell.d/crash-capture-test.sh
+++ b/test/shell.d/crash-capture-test.sh
@@ -378,6 +378,27 @@ grep -Fq 'omarchy-crash-mute' "$skill" ||
   fail "the diagnosis no longer names the command that mutes, so the offer it makes cannot be carried out"
 pass "the diagnosis names the command that mutes"
 
+CRASH_AGENT_LOG="$TMPDIR/crash-agent-log"
+cat >"$watch_bin/coredumpctl" <<'SH'
+#!/bin/bash
+echo 'Wed 2026-08-28 12:34:56 UTC 4242 1000 1000 SIGSEGV present app'
+SH
+cat >"$watch_bin/omarchy-agent" <<'SH'
+#!/bin/bash
+printf '%s\0' "${FAM_OMARCHY_SOURCE-}" "$@" >"$CRASH_AGENT_LOG"
+SH
+chmod +x "$watch_bin/coredumpctl" "$watch_bin/omarchy-agent"
+
+PATH="$watch_bin:$ROOT/bin:$PATH" \
+  OMARCHY_PATH="$ROOT" CRASH_AGENT_LOG="$CRASH_AGENT_LOG" \
+  "$ROOT/bin/omarchy-agent-crash" 4242 app /usr/bin/app SIGSEGV
+mapfile -d '' -t crash_agent_args <"$CRASH_AGENT_LOG"
+[[ ${crash_agent_args[0]} == "omarchy-crash-diagnosis" ]] ||
+  fail "crash diagnosis does not identify its invocation source to FAM"
+[[ ${crash_agent_args[1]} == "--prompt" && ${crash_agent_args[2]} == *"A process crashed"* ]] ||
+  fail "crash diagnosis no longer forwards the diagnostic prompt"
+pass "crash diagnosis preserves source context for FAM without changing other agents"
+
 grep -Fq 'GROUP_DESCRIPTIONS[crash]' "$ROOT/bin/omarchy" ||
   fail "the crash group has no description, so the router lists a group it cannot describe"
 pass "the crash group is described in the router"

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -46,6 +46,11 @@ cat >"$mock_bin/opencode" <<'SH'
 printf '%s\0' opencode "$@" >"$OMARCHY_TEST_AGENT_INLINE_LOG"
 SH
 
+cat >"$mock_bin/omarchy-fam" <<'SH'
+#!/bin/bash
+printf '%s\0' omarchy-fam "$@" >"$OMARCHY_TEST_AGENT_INLINE_LOG"
+SH
+
 cat >"$mock_bin/omarchy-mise-install" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >>"$OMARCHY_TEST_STUB_LOG"
@@ -337,6 +342,18 @@ for selection in "${!expected_agents[@]}"; do
     fail "default agent opens $selection after selecting it"
 done
 pass "default agent selects and opens every supported provider and alias"
+
+for selection in fam fam-os; do
+  : >"$agent_open_log"
+  : >"$mise_log"
+  omarchy-default-agent "$selection"
+  [[ $(omarchy-default-agent) == "fam" ]] || fail "default agent canonicalizes $selection"
+  [[ ! -s $mise_log ]] || fail "default agent keeps FAM outside the mise lifecycle"
+  mapfile -d '' -t agent_open_args <"$agent_open_log"
+  [[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
+    fail "default agent opens $selection after selecting it"
+done
+pass "default agent selects the externally packaged FAM launcher and alias"
 [[ -f $agent_file && ! -e $test_home/.local/state/omarchy/defaults/agent ]] ||
   fail "default agent stores its selection in Omarchy user config"
 pass "default agent stores its selection in Omarchy user config"
@@ -464,6 +481,7 @@ assert_launch crush crush run "Review this project"
 assert_launch grok grok --permission-mode bypassPermissions -- "Review this project"
 assert_launch agy agy --dangerously-skip-permissions --prompt-interactive "Review this project"
 assert_launch copilot copilot --allow-all --interactive "Review this project"
+assert_launch fam omarchy-fam "Review this project"
 pass "agent launcher adapts initial prompts for every supported agent"
 
 assert_bypass pi pi
@@ -476,6 +494,7 @@ assert_bypass crush crush --yolo
 assert_bypass grok grok --permission-mode bypassPermissions
 assert_bypass agy agy --dangerously-skip-permissions
 assert_bypass copilot copilot --allow-all
+assert_bypass fam omarchy-fam
 pass "agent launcher skips permission prompts for every supported agent"
 
 printf '%s\n' "opencode" >"$agent_file"
@@ -531,3 +550,11 @@ fi
 grep -F "missing is not installed" "$test_tmp/missing-output" >/dev/null ||
   fail "agent launcher explains when the default command is missing"
 pass "agent launcher reports a missing default command"
+
+printf '%s\n' "fam" >"$agent_file"
+if OMARCHY_TEST_MISSING_COMMAND=omarchy-fam omarchy-agent >"$test_tmp/missing-fam-output" 2>&1; then
+  fail "agent launcher rejects a missing FAM launcher"
+fi
+grep -F "omarchy-fam is not installed" "$test_tmp/missing-fam-output" >/dev/null ||
+  fail "agent launcher checks FAM's packaged launcher name"
+pass "agent launcher maps the FAM provider to its packaged command"

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -481,7 +481,7 @@ assert_launch crush crush run "Review this project"
 assert_launch grok grok --permission-mode bypassPermissions -- "Review this project"
 assert_launch agy agy --dangerously-skip-permissions --prompt-interactive "Review this project"
 assert_launch copilot copilot --allow-all --interactive "Review this project"
-assert_launch fam omarchy-fam "Review this project"
+assert_launch fam omarchy-fam --prompt "Review this project"
 pass "agent launcher adapts initial prompts for every supported agent"
 
 assert_bypass pi pi
@@ -494,7 +494,7 @@ assert_bypass crush crush --yolo
 assert_bypass grok grok --permission-mode bypassPermissions
 assert_bypass agy agy --dangerously-skip-permissions
 assert_bypass copilot copilot --allow-all
-assert_bypass fam omarchy-fam
+assert_bypass fam omarchy-fam --interactive
 pass "agent launcher skips permission prompts for every supported agent"
 
 printf '%s\n' "opencode" >"$agent_file"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -226,6 +226,7 @@ const expectedAgents = {
   grok: { icon: '\ue904', iconFont: 'omarchy', label: 'Grok' },
   copilot: { icon: '', label: 'Copilot' },
   crush: { icon: '󰋑', label: 'Crush' },
+  fam: { icon: '󰚩', label: 'FAM' },
 }
 assert(
   Object.entries(expectedAgents).every(([agent, expected]) => {
@@ -238,13 +239,13 @@ assert(
       && !entry.when
       && entry.checked.includes(`== \"${agent}\"`)
   }),
-  'menu exposes every mise-installable coding agent with its own glyph under Defaults > Agent'
+  'menu exposes every supported coding agent with its own glyph under Defaults > Agent'
 )
 assertDeepEqual(
   defaultItems
     .filter(item => item.parent === 'setup.default.agent')
     .map(item => item.label),
-  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Grok', 'omp', 'OpenCode', 'Ori', 'Pi'],
+  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'FAM', 'Grok', 'omp', 'OpenCode', 'Ori', 'Pi'],
   'menu sorts coding agents alphabetically'
 )
 const expectedDefaults = {


### PR DESCRIPTION
## Summary

- expose FAM in Defaults > Agent with the existing agent providers
- recognize `fam` and `fam-os` in `omarchy default agent`
- launch the externally packaged `omarchy-fam` command without routing it through mise
- use `omarchy-fam --interactive` for scratchpad/default-agent launches and `omarchy-fam --prompt` for one-shot prompts
- mark Omarchy crash-diagnosis prompts so FAM can retain their source context
- report a clear error when FAM is not installed

Project site: [fam-os.demimagic.chatgpt.site](https://fam-os.demimagic.chatgpt.site)

## Why FAM

FAM_OS is a Linux-native engineering supervisor for durable, resumable work: it can select a local model or Codex, execute in an isolated candidate workspace, retain goal and recovery state, and apply changes only after file, command, browser, or application verification. Omarchy recognition gives that supervisor the same default-agent, scratchpad, prompt, and crash-diagnosis entry points as direct coding agents, while installation, authority, provider selection, execution, and state remain owned by the separately packaged FAM service.

FAM remains separately packaged; this contribution does not install software or claim an in-tree runtime. The supported Omarchy integration, launcher, widget, and package source live in [FAM_OS](https://github.com/demimagic-ML/FAM-os).

## Verification

- `bash test/shell.d/default-agent-test.sh`
- `bash test/shell.d/crash-capture-test.sh`
- `bash test/shell.d/menu-test.sh`

All focused suites pass, covering aliases, missing-command handling, interactive and prompt routing, crash-source propagation, and the complete Defaults > Agent menu contract.
