### PR TITLE
Seed polkit fingerprint config from vendor default, route fallback through system-auth

### DIFF
--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -30,6 +30,16 @@ setup_pam_config() {
   fi
 
   # Configure polkit
+  if [[ ! -f /etc/pam.d/polkit-1 && -f /usr/lib/pam.d/polkit-1 ]]; then
+    # polkit ships its stack under /usr/lib, and any file in /etc shadows it
+    # whole -- there's no way to prepend to the vendor copy in place. Start
+    # from an exact copy so the machine keeps faillock, the keyring, and
+    # everything else system-auth pulls in; building a stack from pam_unix by
+    # hand instead (the fallback below) loses all of it.
+    echo "Seeding polkit configuration from the vendor default..."
+    sudo cp /usr/lib/pam.d/polkit-1 /etc/pam.d/polkit-1
+  fi
+
   if [[ -f /etc/pam.d/polkit-1 ]]; then
     if ! grep -q 'pam_fprintd.so' /etc/pam.d/polkit-1; then
       echo "Configuring polkit for fingerprint authentication..."
@@ -40,15 +50,18 @@ setup_pam_config() {
       sudo sed -i "/pam_fprintd\.so/i $fprintd_gate" /etc/pam.d/polkit-1
     fi
   else
+    # No vendor file to seed from -- fall back to a minimal stack that still
+    # routes through system-auth rather than pam_unix directly, so faillock
+    # and the rest of the system's auth policy still apply.
     echo "Creating polkit configuration with fingerprint authentication..."
     sudo tee /etc/pam.d/polkit-1 >/dev/null <<EOF
 $fprintd_gate
 auth      sufficient pam_fprintd.so
-auth      required pam_unix.so
+auth      include    system-auth
 
-account   required pam_unix.so
-password  required pam_unix.so
-session   required pam_unix.so
+account   include    system-auth
+password  include    system-auth
+session   include    system-auth
 EOF
   fi
 }


### PR DESCRIPTION
## Problem

`omarchy-setup-security-fingerprint` builds a from-scratch PAM stack on bare
`pam_unix.so` when `/etc/pam.d/polkit-1` doesn't already exist, bypassing
`system-auth` entirely -- losing faillock and anything else the system's own
auth policy pulls in through `system-auth`.

## Fix

- Seed `/etc/pam.d/polkit-1` from the vendor default at
  `/usr/lib/pam.d/polkit-1` when it's available, so the fingerprint gate gets
  added to the same stack the rest of the system already uses.
- When there's no vendor file to seed from, route the fallback stack through
  `system-auth` includes instead of `pam_unix.so` directly.

This is independent of what fingerprint backend is installed -- it benefits
stock `libfprint`/`fprintd` installs the same as any other.

## Testing

Ran the existing `test/shell.d/polkit-test.sh` suite; unaffected (it tests
fingerprint-prompt/PAM-config detection logic, not this script). No new
automated coverage needed for a change this size.