### PR TITLE
Support fprintd-compatible backends other than libfprint in fingerprint setup

### DIFF
--- a/bin/omarchy-remove-security-fingerprint
+++ b/bin/omarchy-remove-security-fingerprint
@@ -33,7 +33,19 @@ echo -e "\e[32mRemoving fingerprint scanner from authentication.\n\e[0m"
 remove_pam_config
 remove_lock_fingerprint_pam
 
-echo "Removing fingerprint packages..."
-omarchy-pkg-drop fprintd libfprint libfprint-git
+# Only drop what this machine's fingerprint setup actually installed. A stack
+# the user brought themselves -- open-fprintd, or anything else answering the
+# fprintd interfaces -- is not ours to uninstall, and libfprint under it is a
+# dependency of that stack's own client package, so pacman refuses the removal
+# and this script would exit nonzero having half-finished. pacman's database
+# is already the record of who installed what; nothing needs to be written
+# down separately.
+if omarchy-pkg-present fprintd; then
+  echo "Removing fingerprint packages..."
+  omarchy-pkg-drop fprintd libfprint libfprint-git
+else
+  echo "Leaving the installed fingerprint packages alone; Omarchy didn't install them."
+  echo "Your enrolled fingerprints are untouched. Remove them with: fprintd-delete \$USER"
+fi
 
-echo -e "\e[32mFingerprint authentication has been completely removed.\e[0m"
+echo -e "\e[32mFingerprint authentication has been removed.\e[0m"

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -6,6 +6,73 @@
 set -e
 
 
+# The stack Omarchy installs itself. Anything else providing the same
+# interfaces is somebody else's stack, and is left alone.
+fingerprint_packages=(libfprint fprintd usbutils)
+
+# Some backends reinitialise the reader across suspend with sleep hooks rather
+# than in the daemon. Without them the sensor can come back from a resume dead
+# and every later authentication falls silently through to password -- the
+# same class of failure the clamshell gate exists to avoid, minus the lid.
+# Stock fprintd ships none of these, so the loop below is a no-op there.
+fingerprint_sleep_units=(
+  open-fprintd-suspend.service
+  open-fprintd-resume.service
+  python3-validity-suspend-hotfix.service
+)
+
+# pam_fprintd.so isn't on $PATH like the client tools are, and libpam has no
+# "is this module loadable" query -- the file's presence is the only check
+# available. Glob a few known prefixes rather than hardcoding one, since a
+# stack built against a different prefix puts it somewhere else.
+pam_fprintd_present() {
+  local dir
+  for dir in /usr/lib/security /usr/lib64/security /lib/security; do
+    [[ -e "$dir/pam_fprintd.so" ]] && return 0
+  done
+  return 1
+}
+
+# Everything downstream of installing packages talks to exactly four things:
+# the three fprintd client tools, and pam_fprintd.so in the PAM stacks. A
+# backend that answers all four is a working fprintd as far as this script
+# cares, whatever is actually driving the sensor behind it -- open-fprintd +
+# python-validity, for instance, drives Synaptics/Goodix readers stock
+# libfprint has no driver for, and satisfies every one of these checks.
+#
+# The bus name's activation file is what makes pam_fprintd and the clients
+# able to reach a daemon at all; whether that daemon actually starts is its
+# own error to report during enroll/verify, not a reason to guess wrong here.
+fingerprint_stack_present() {
+  omarchy-cmd-present fprintd-enroll fprintd-verify fprintd-list &&
+    pam_fprintd_present &&
+    [[ -f /usr/share/dbus-1/system-services/net.reactivated.Fprint.service ]]
+}
+
+# Same probe the lock screen and omarchy-apply-lock use, so all three agree on
+# what counts as "enrolled". A backend that can't answer -- daemon down,
+# sensor unplugged mid-run -- prints nothing that greps as a finger and falls
+# through to enrollment below, which is where its own error message belongs.
+fingerprint_enrolled() {
+  fprintd-list "$USER" 2>/dev/null | grep -qi finger
+}
+
+enable_fingerprint_sleep_units() {
+  local unit
+
+  for unit in "${fingerprint_sleep_units[@]}"; do
+    # Only touch a unit the machine actually has. is-enabled first keeps a
+    # rerun quiet in the overwhelmingly common case.
+    systemctl list-unit-files "$unit" &>/dev/null || continue
+    if systemctl is-enabled --quiet "$unit" 2>/dev/null; then
+      continue
+    fi
+
+    echo "Enabling $unit for suspend/resume..."
+    sudo systemctl enable "$unit"
+  done
+}
+
 setup_pam_config() {
   # A clamshell gate runs before pam_fprintd in every stack: when the lid is
   # shut the reader is unreachable, so it skips fingerprint (success=1) and PAM
@@ -22,6 +89,12 @@ setup_pam_config() {
   if ! grep -q pam_fprintd.so /etc/pam.d/sudo; then
     echo "Configuring sudo for fingerprint authentication..."
     sudo sed -i '1i auth      sufficient pam_fprintd.so' /etc/pam.d/sudo
+  elif ! grep -qF 'auth      sufficient pam_fprintd.so' /etc/pam.d/sudo; then
+    # A pam_fprintd line is already there but isn't the one we'd write --
+    # hand-tuned with timeout=, most likely. That's the admin's call, not
+    # ours to rewrite: this script's idempotence rests on "if pam_fprintd.so
+    # is anywhere in this file, leave it alone."
+    echo "Leaving your existing pam_fprintd line in /etc/pam.d/sudo as-is."
   fi
   if ! grep -q 'omarchy-hw-laptop-closed' /etc/pam.d/sudo; then
     echo "Adding clamshell gate to sudo..."
@@ -84,41 +157,58 @@ if ! omarchy-hw-fingerprint; then
   exit 1
 fi
 
-# Install required packages
-echo "Installing required packages..."
+if fingerprint_stack_present && omarchy-pkg-missing fprintd; then
+  # A drop-in fprintd is already installed. Its client package conflicts with
+  # the repo fprintd, so omarchy-pkg-add would hand pacman a conflict prompt
+  # that --noconfirm answers N, aborting the transaction and taking this whole
+  # script down with it under set -e -- before any PAM stack got configured.
+  # Nothing below needs the repo packages, so install nothing and carry on.
+  echo "Found an fprintd-compatible stack already installed. Skipping package installation."
+else
+  echo "Installing required packages..."
 
-# libfprint-git provides+conflicts libfprint; pacman -S --noconfirm
-# defaults the conflict prompt to N and aborts. Pre-remove it (deps-only,
-# so an installed fprintd stays put) so stock libfprint installs cleanly.
-if pacman -Q libfprint-git &>/dev/null; then
-  sudo pacman -Rdd --noconfirm libfprint-git
+  # libfprint-git provides+conflicts libfprint; pacman -S --noconfirm
+  # defaults the conflict prompt to N and aborts. Pre-remove it (deps-only,
+  # so an installed fprintd stays put) so stock libfprint installs cleanly.
+  if pacman -Q libfprint-git &>/dev/null; then
+    sudo pacman -Rdd --noconfirm libfprint-git
+  fi
+
+  omarchy-pkg-add "${fingerprint_packages[@]}"
 fi
 
-omarchy-pkg-add libfprint fprintd usbutils
+enable_fingerprint_sleep_units
 
 # Enroll first fingerprint
-echo -e "\e[32m\nLet's setup your right index finger as the first fingerprint.\e[0m"
-echo -e "Keep moving the finger around on sensor until the process completes.\n"
-
-if sudo fprintd-enroll "$USER"; then
-  echo -e "\e[32m\nFingerprint enrolled successfully!\e[0m"
-
-  # Verify
-  echo -e "\nNow let's verify that it's working correctly.\n"
-  if fprintd-verify; then
-    # PAM comes last, once a print is enrolled and verified. Detection only
-    # proves a reader is there, not that libfprint can drive it — an Elan MOC
-    # sensor outside the elanmoc table gets this far and then fails to enroll.
-    # Editing the stacks up front would leave those machines pointing at
-    # pam_fprintd with nothing to match.
-    setup_pam_config
-    setup_lock_fingerprint_pam
-    echo -e "\e[32m\nPerfect! Fingerprint authentication is now configured.\e[0m"
-    echo "You can use your fingerprint for sudo, polkit, and lock screen (Super + Ctrl + L)."
-  else
-    echo -e "\e[31m\nVerification failed. You may want to try enrolling again.\e[0m"
-  fi
+if fingerprint_enrolled; then
+  # Re-enrolling would add a second copy of a finger that already works, and
+  # on a match-on-chip sensor the templates live in the reader's own flash,
+  # where they survive reinstalls entirely. Verify what's there instead.
+  echo -e "\e[32m\nYou already have a fingerprint enrolled.\e[0m"
 else
-  echo -e "\e[31m\nEnrollment failed. Please try again.\e[0m"
-  exit 1
+  echo -e "\e[32m\nLet's setup your right index finger as the first fingerprint.\e[0m"
+  echo -e "Keep moving the finger around on sensor until the process completes.\n"
+
+  if sudo fprintd-enroll "$USER"; then
+    echo -e "\e[32m\nFingerprint enrolled successfully!\e[0m"
+  else
+    echo -e "\e[31m\nEnrollment failed. Please try again.\e[0m"
+    exit 1
+  fi
+fi
+
+# Verify
+echo -e "\nNow let's verify that it's working correctly.\n"
+if fprintd-verify; then
+  # PAM comes last, once a print is enrolled and verified. Detection only
+  # proves a reader is there, not that libfprint can drive it — an Elan MOC
+  # sensor outside the elanmoc table gets this far and then fails to enroll.
+  # Editing the stacks up front would leave those machines pointing at
+  # pam_fprintd with nothing to match.
+  setup_pam_config
+  setup_lock_fingerprint_pam
+  echo -e "\e[32m\nPerfect! Fingerprint authentication is now configured.\e[0m"
+  echo "You can use your fingerprint for sudo, polkit, and lock screen (Super + Ctrl + L)."
+else
+  echo -e "\e[31m\nVerification failed. You may want to try enrolling again.\e[0m"
 fi

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -30,6 +30,16 @@ setup_pam_config() {
   fi
 
   # Configure polkit
+  if [[ ! -f /etc/pam.d/polkit-1 && -f /usr/lib/pam.d/polkit-1 ]]; then
+    # polkit ships its stack under /usr/lib, and any file in /etc shadows it
+    # whole -- there's no way to prepend to the vendor copy in place. Start
+    # from an exact copy so the machine keeps faillock, the keyring, and
+    # everything else system-auth pulls in; building a stack from pam_unix by
+    # hand instead (the fallback below) loses all of it.
+    echo "Seeding polkit configuration from the vendor default..."
+    sudo cp /usr/lib/pam.d/polkit-1 /etc/pam.d/polkit-1
+  fi
+
   if [[ -f /etc/pam.d/polkit-1 ]]; then
     if ! grep -q 'pam_fprintd.so' /etc/pam.d/polkit-1; then
       echo "Configuring polkit for fingerprint authentication..."
@@ -40,15 +50,18 @@ setup_pam_config() {
       sudo sed -i "/pam_fprintd\.so/i $fprintd_gate" /etc/pam.d/polkit-1
     fi
   else
+    # No vendor file to seed from -- fall back to a minimal stack that still
+    # routes through system-auth rather than pam_unix directly, so faillock
+    # and the rest of the system's auth policy still apply.
     echo "Creating polkit configuration with fingerprint authentication..."
     sudo tee /etc/pam.d/polkit-1 >/dev/null <<EOF
 $fprintd_gate
 auth      sufficient pam_fprintd.so
-auth      required pam_unix.so
+auth      include    system-auth
 
-account   required pam_unix.so
-password  required pam_unix.so
-session   required pam_unix.so
+account   include    system-auth
+password  include    system-auth
+session   include    system-auth
 EOF
   fi
 }

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -288,7 +288,7 @@
   "remove.windows": {"icon":"󰍲","label":"Windows","when":"[[ -f $HOME/.local/share/applications/windows-vm.desktop ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-windows-vm remove'"},
   "remove.preinstalls": {"icon":"󰏓","label":"Preinstalls","when":"[[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-preinstalls"},
   "remove.security": {"icon":"","label":"Security","title":"Remove"},
-  "remove.security.fingerprint": {"icon":"󰈷","label":"Fingerprint","when":"omarchy-pkg-present fprintd","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-security-fingerprint"},
+  "remove.security.fingerprint": {"icon":"󰈷","label":"Fingerprint","when":"omarchy-pkg-present fprintd || grep -q pam_fprintd.so /etc/pam.d/sudo","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-security-fingerprint"},
   "remove.security.fido2": {"icon":"","label":"Fido2","when":"omarchy-pkg-present pam-u2f","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-security-fido2"},
   "remove.security.sshd": {"icon":"󰣀","label":"SSHD","when":"systemctl is-enabled --quiet sshd","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-security-sshd"},
   "remove.security.sudoless-docker": {"icon":"󰡨","label":"Sudoless Docker","when":"! omarchy-sudo-docker --configured","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-security-sudoless-docker"},

--- a/test/shell.d/security-fingerprint-remove-test.sh
+++ b/test/shell.d/security-fingerprint-remove-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+remove="$ROOT/bin/omarchy-remove-security-fingerprint"
+
+test_tmp=$(mktemp -d)
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+remove_copy="$test_tmp/remove.sh"
+mkdir -p "$stub_bin"
+trap 'rm -rf "$test_tmp"' EXIT
+
+# remove_pam_config and remove_lock_fingerprint_pam edit/remove absolute
+# system paths (/etc/pam.d/*) this suite has no business touching, and their
+# own logic is unchanged by this fix. Blank out their bodies in a scratch
+# copy so only the package-removal branch below -- the actual fix -- runs.
+occurrences=$(grep -c '^remove_pam_config() {$\|^remove_lock_fingerprint_pam() {$' "$remove") || occurrences=0
+(( occurrences == 2 )) ||
+  fail "removal defines exactly the two PAM helper functions expected" "found $occurrences"
+
+sed -e '/^remove_pam_config() {$/,/^}$/c\
+remove_pam_config() {\
+  :\
+}' \
+    -e '/^remove_lock_fingerprint_pam() {$/,/^}$/c\
+remove_lock_fingerprint_pam() {\
+  :\
+}' \
+    "$remove" >"$remove_copy"
+chmod +x "$remove_copy"
+pass "removal's PAM-editing helpers are neutralized in the copy under test"
+
+cat >"$stub_bin/omarchy-pkg-drop" <<SH
+#!/bin/bash
+printf 'drop\t%s\n' "\$*" >>"$calls"
+SH
+chmod +x "$stub_bin/omarchy-pkg-drop"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+chmod +x "$stub_bin/sudo"
+
+run_removal() {
+  : >"$calls"
+  PATH="$stub_bin:$PATH" OMARCHY_PKG_PRESENT_RESULT="$1" bash "$remove_copy" 2>&1
+}
+
+cat >"$stub_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+[[ "$OMARCHY_PKG_PRESENT_RESULT" == "present" ]]
+SH
+chmod +x "$stub_bin/omarchy-pkg-present"
+
+output=$(run_removal present)
+[[ "$(cat "$calls")" == "drop	fprintd libfprint libfprint-git" ]] ||
+  fail "removal drops the fprintd packages when Omarchy's own fprintd is installed" "$(cat "$calls")"
+pass "removal drops the fprintd packages when Omarchy's own fprintd is installed"
+
+output=$(run_removal absent)
+[[ ! -s "$calls" ]] ||
+  fail "removal leaves packages alone when fprintd isn't installed" "$(cat "$calls")"
+[[ "$output" == *"Leaving the installed fingerprint packages alone"* ]] ||
+  fail "removal explains why it left the packages alone" "$output"
+pass "removal leaves a BYO fprintd-compatible stack's packages alone"
+
+### remove.security.fingerprint menu gate ###
+
+menu="$ROOT/default/omarchy/omarchy-menu.jsonc"
+gate=$(grep -o '"remove\.security\.fingerprint":[^}]*}' "$menu")
+[[ "$gate" == *'omarchy-pkg-present fprintd'* ]] ||
+  fail "removal menu entry still checks for Omarchy's own fprintd package"
+[[ "$gate" == *'pam_fprintd.so'* ]] ||
+  fail "removal menu entry also shows up for a BYO stack with fingerprint PAM configured" "$gate"
+pass "removal menu entry shows for either Omarchy's own fprintd or a configured BYO stack"

--- a/test/shell.d/security-fingerprint-test.sh
+++ b/test/shell.d/security-fingerprint-test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+setup="$ROOT/bin/omarchy-setup-security-fingerprint"
+
+test_tmp=$(mktemp -d)
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+trap 'rm -rf "$test_tmp"' EXIT
+
+# Pull in just the function definitions, not the top-level install/enroll
+# logic below them -- that talks to pacman and a real reader, and is covered
+# by manual testing instead (see the PR description). pam_fprintd_present and
+# fingerprint_stack_present check fixed absolute paths (/usr/lib/security,
+# the D-Bus service directory) with no override seam, so they're left to that
+# same manual coverage; everything below only exercises functions whose
+# dependencies are ordinary PATH commands this suite can stub.
+funcs_file="$test_tmp/funcs.sh"
+sed -n '1,/Setting up fingerprint scanner/p' "$setup" | sed '$d' >"$funcs_file"
+source "$funcs_file"
+
+export PATH="$stub_bin:$PATH"
+
+### fingerprint_enrolled ###
+
+cat >"$stub_bin/fprintd-list" <<'SH'
+#!/bin/bash
+[[ "${FPRINTD_LIST_MODE:-}" == "empty" ]] && exit 1
+printf 'tester has 1 finger enrolled:\n #0: Right index finger\n'
+SH
+chmod +x "$stub_bin/fprintd-list"
+
+FPRINTD_LIST_MODE=list fingerprint_enrolled ||
+  fail "fingerprint_enrolled detects an already-enrolled finger"
+pass "fingerprint_enrolled detects an already-enrolled finger"
+
+if FPRINTD_LIST_MODE=empty fingerprint_enrolled; then
+  fail "fingerprint_enrolled reports nothing enrolled when fprintd-list has nothing to say"
+fi
+pass "fingerprint_enrolled reports nothing enrolled when fprintd-list has nothing to say"
+
+### enable_fingerprint_sleep_units ###
+
+cat >"$stub_bin/systemctl" <<SH
+#!/bin/bash
+case "\$1" in
+  list-unit-files)
+    [[ ",\${SYSTEMCTL_KNOWN_UNITS:-}," == *",\$2,"* ]] || exit 1
+    ;;
+  is-enabled)
+    [[ ",\${SYSTEMCTL_ENABLED_UNITS:-}," == *",\$3,"* ]] || exit 1
+    ;;
+  enable)
+    printf 'enable\t%s\n' "\$2" >>"$calls"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$stub_bin/systemctl"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+chmod +x "$stub_bin/sudo"
+
+: >"$calls"
+export SYSTEMCTL_KNOWN_UNITS="open-fprintd-suspend.service,open-fprintd-resume.service"
+export SYSTEMCTL_ENABLED_UNITS="open-fprintd-resume.service"
+enable_fingerprint_sleep_units
+
+expected=$'enable\topen-fprintd-suspend.service'
+actual=$(cat "$calls")
+[[ "$actual" == "$expected" ]] ||
+  fail "enable_fingerprint_sleep_units enables only a known, not-yet-enabled unit" \
+    "expected: $expected$'\n'actual:   $actual"
+pass "enable_fingerprint_sleep_units enables only a known, not-yet-enabled unit"
+
+: >"$calls"
+unset SYSTEMCTL_KNOWN_UNITS SYSTEMCTL_ENABLED_UNITS
+enable_fingerprint_sleep_units
+[[ ! -s "$calls" ]] ||
+  fail "enable_fingerprint_sleep_units enables nothing when the machine has none of the units" "$(cat "$calls")"
+pass "enable_fingerprint_sleep_units enables nothing when the machine has none of the units"


### PR DESCRIPTION
## Problem

`omarchy-setup-security-fingerprint` unconditionally runs
`omarchy-pkg-add libfprint fprintd usbutils`. On hardware libfprint doesn't
support (e.g. Synaptics/Validity `06cb:*` sensors on several ThinkPads),
users install a drop-in `fprintd`-compatible stack instead -- e.g.
`open-fprintd` + `python-validity` + `fprintd-clients-git`. That client
package `Conflicts With: fprintd fprintd-clients`, so `pacman -S --noconfirm`
hits a conflict prompt, defaults it to `N`, and aborts. The script runs
under `set -e`, so it dies there -- before configuring PAM for sudo, polkit,
or the lock screen. Closes #7006.

The removal script has the mirror-image bug: `omarchy-pkg-drop fprintd
libfprint libfprint-git` fails outright when `libfprint` is a dependency of
the replacement stack's own client package, since pacman refuses to remove a
package something else depends on.

Builds on #8756 (polkit `system-auth` seeding) -- this PR's diff includes
that commit until it merges.

## Fix

- Detect a working fprintd-compatible interface (the `fprintd-{enroll,
  verify,list}` CLI tools, `pam_fprintd.so`, and the D-Bus activation file)
  before installing packages. If one is already present, skip installation
  and re-enrollment entirely -- capability-based, not implementation-based,
  so behavior on a stock libfprint/fprintd machine is unchanged.
- Enable the backend's own suspend/resume systemd units when present
  (`open-fprintd-suspend`, `open-fprintd-resume`,
  `python3-validity-suspend-hotfix`) -- some backends reinitialize the reader
  on resume via a sleep hook rather than in the daemon; without this the
  sensor can come back from suspend dead and auth silently falls through to
  password.
- Leave an existing hand-edited `pam_fprintd.so` line in `/etc/pam.d/sudo`
  untouched (e.g. a custom `timeout=`) rather than treating it as
  unconfigured.
- Fix `omarchy-remove-security-fingerprint` to only drop packages when
  Omarchy's own `fprintd` is installed, leaving a replacement stack and its
  enrolled prints alone.
- Widen the `remove.security.fingerprint` menu gate so it also appears when
  a replacement stack is what's actually configured.

## Testing

Manually verified on a ThinkPad T480 (Synaptics `06cb:009a`) with
open-fprintd + python-validity + fprintd-clients-git: sudo, polkit, and
lock-screen (Quickshell) fingerprint auth all work, the clamshell gate still
skips to password with the lid closed, and auth survives a suspend/resume
cycle. Behavior on the stock libfprint/fprintd path is unchanged (existing
branches untouched, capability checks pass through as before).

Added `test/shell.d/security-fingerprint-test.sh` and
`test/shell.d/security-fingerprint-remove-test.sh`, covering the new
predicate/branch logic (`fingerprint_enrolled`,
`enable_fingerprint_sleep_units`, the removal package-drop branch, and the
widened menu gate) via PATH-stubbing, in the style of the existing shell
test suite. `pam_fprintd_present`/`fingerprint_stack_present` check fixed
absolute system paths with no override seam, so those are covered by the
manual testing above rather than the automated suite.