### PR TITLE
Stop Neovim from previewing completions inline without an AI source

### DIFF
--- a/migrations/1787927123.sh
+++ b/migrations/1787927123.sh
@@ -1,0 +1,15 @@
+echo "Stop Neovim from previewing completions inline without an AI source"
+
+nvim_options="$HOME/.config/nvim/lua/config/options.lua"
+
+if [[ -f $nvim_options ]] && ! grep -qF 'ai_cmp' "$nvim_options"; then
+  cat >>"$nvim_options" <<'LUA'
+
+-- Only preview completions inline when an AI source is actually installed.
+-- LazyVim's ai_cmp routes AI suggestions through the completion menu and turns
+-- on blink's ghost text to preview them; with no AI extra enabled that ghost
+-- text just echoes buffer words back at you while you type. Off, the AI extras
+-- use their own native inline suggestions instead, still accepted with <Tab>.
+vim.g.ai_cmp = false
+LUA
+fi

--- a/test/shell.d/nvim-ai-cmp-migration-test.sh
+++ b/test/shell.d/nvim-ai-cmp-migration-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration=$(grep -rl 'Stop Neovim from previewing completions inline' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "Neovim ai_cmp migration exists"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# omarchy-migrate runs each migration with `bash -euo pipefail` and stops the
+# whole chain on a non-zero exit, so match that invocation exactly.
+run_migration() {
+  HOME="$1" bash -euo pipefail "$migration" >/dev/null ||
+    fail "migration exits clean for $(basename "$1")"
+}
+
+# The two lines omarchy-nvim ships in options.lua, minus the ones that would
+# drag the remote clipboard provider into the test.
+seed_options() {
+  local home="$TMPDIR/$1"
+
+  mkdir -p "$home/.config/nvim/lua/config"
+  printf '%s\n' 'vim.opt.relativenumber = false' 'vim.g.autoformat = false' \
+    >"$home/.config/nvim/lua/config/options.lua"
+  printf '%s' "$home"
+}
+
+setting_count() {
+  grep -c '^vim\.g\.ai_cmp = false$' "$1/.config/nvim/lua/config/options.lua"
+}
+
+# A stock options.lua gets the setting appended.
+home=$(seed_options stock)
+run_migration "$home"
+(( $(setting_count "$home") == 1 )) || fail "migration turns ai_cmp off in a stock options.lua"
+pass "migration turns ai_cmp off in a stock options.lua"
+
+# Migrations can be rerun by hand, and every user on the machine runs this one.
+run_migration "$home"
+(( $(setting_count "$home") == 1 )) || fail "migration appends the setting only once"
+pass "migration appends the setting only once"
+
+# Someone who wants the inline preview keeps it: any mention of the flag is a
+# deliberate answer, and the migration does not argue with it.
+home=$(seed_options explicit)
+printf 'vim.g.ai_cmp = true\n' >>"$home/.config/nvim/lua/config/options.lua"
+run_migration "$home"
+(( $(setting_count "$home") == 0 )) || fail "migration leaves a deliberate ai_cmp setting alone"
+pass "migration leaves a deliberate ai_cmp setting alone"
+
+# Neovim's config is user-owned and may not exist at all; the migration has
+# nothing to repair and must not create one.
+home="$TMPDIR/no-nvim"
+mkdir -p "$home"
+run_migration "$home"
+[[ -e "$home/.config/nvim" ]] && fail "migration no-ops without a Neovim config"
+pass "migration no-ops without a Neovim config"


### PR DESCRIPTION
Companion to omacom/omarchy-pkgs#234, which turns off Neovim's inline completion preview in the seeded config. That one only reaches newly created users — `~/.config/nvim` is user-owned and `/etc/skel` seeds it once — so this migration carries the same line to everyone already running Omarchy.

### The problem

LazyVim defaults `vim.g.ai_cmp = true`, which routes AI completions through the completion menu and switches on blink.cmp's ghost text so the selected item previews inline. `omarchy-nvim` enables no AI extra — its `lazyvim.json` lists only `editor.neo-tree` — so the sources are `lsp`, `path`, `snippets`, `buffer`, and the inline preview spends its time writing words already on screen back into the line you are typing.

Typing `Notes on cons` on line 3, stock `omarchy-nvim` 2026.8.13:

```
  1   The constitutional convention met in Philadelphia.
  2
  3   Notes on constitutional      <- only "cons" was typed
            constitutional
            convention
          󱄽  caution~
```

After:

```
  1   The constitutional convention met in Philadelphia.
  2
  3   Notes on cons
            constitutional
            convention
          󱄽  caution~
```

The menu is untouched. Only the text that wrote itself ahead of the cursor is gone. It is worst in prose — a commit message, a note, a markdown draft — where the guess comes from nothing but the words already in the file.

`ai_cmp` is LazyVim's own switch for this: its AI extras read the same flag (copilot, supermaven and codeium all set `suggestion.enabled = not vim.g.ai_cmp`), so a user who enables one gets that provider's native inline suggestions, still accepted with `<Tab>` through `LazyVim.cmp.actions.ai_accept`. Inline suggestions when something can genuinely predict the next words; none when nothing can.

### The migration

Appends the setting to `~/.config/nvim/lua/config/options.lua`, in the shape of `1781587663.sh`. It skips any `options.lua` that already mentions `ai_cmp`, so someone who set the flag deliberately — either way — keeps their answer, and rerunning is a no-op. A home with no Neovim config is left alone; nothing is created.

### Tests

`test/shell.d/nvim-ai-cmp-migration-test.sh` covers the stock file, a rerun, a deliberate `vim.g.ai_cmp = true`, and a home without a Neovim config.

```
ok - migration turns ai_cmp off in a stock options.lua
ok - migration appends the setting only once
ok - migration leaves a deliberate ai_cmp setting alone
ok - migration no-ops without a Neovim config
```

`./test/all` is otherwise unchanged: `snapper-test.sh` and `theme-install-guards-test.sh` fail on `quattro` in my environment too, before this branch — one wants a sibling `omarchy-iso` checkout, the other reaches the network.

Behaviour was verified in a real editor, not only in the migration: the captures above are `tmux capture-pane` of stock `/etc/skel/.config/nvim` and a patched copy running side by side against the shipped plugin cache, and `require("blink.cmp.config").completion.ghost_text.enabled()` returns `true` before and `false` after.
