### PR TITLE
Keep mailto parameters out of HEY's recipient

### DIFF
--- a/bin/omarchy-webapp-handler-hey
+++ b/bin/omarchy-webapp-handler-hey
@@ -8,8 +8,30 @@ web_url="https://app.hey.com"
 
 # Handle mailto: URLs
 if [[ $url =~ ^mailto: ]]; then
-  email=$(echo "$url" | sed 's/mailto://')
-  web_url="https://app.hey.com/messages/new?to=$email"
+  # A mailto: URL is "mailto:addresses?subject=…&body=…". The addresses run up
+  # to the first "?", and the parameters after it are already percent-encoded,
+  # so HEY can take them as they are. Folding the whole remainder into "to="
+  # leaves a second "?" inside the query, which HEY reads as part of the
+  # address: the compose window opens with no recipient and no subject.
+  rest="${url#mailto:}"
+  if [[ $rest == *\?* ]]; then
+    email="${rest%%\?*}"
+    params="${rest#*\?}"
+  else
+    email="$rest"
+    params=""
+  fi
+
+  web_url="https://app.hey.com/messages/new"
+  if [[ -n $email ]]; then
+    web_url="$web_url?to=$email"
+    if [[ -n $params ]]; then
+      web_url="$web_url&$params"
+    fi
+  elif [[ -n $params ]]; then
+    # "mailto:?to=someone@example.com" carries the address as a parameter.
+    web_url="$web_url?$params"
+  fi
 fi
 
 exec omarchy-launch-webapp "$web_url"

--- a/test/shell.d/webapp-handler-hey-test.sh
+++ b/test/shell.d/webapp-handler-hey-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+
+# The handler ends in an exec, so stand in for the launcher to see the URL it
+# would have opened.
+printf '#!/bin/bash\necho "$1"\n' >"$tmp_dir/bin/omarchy-launch-webapp"
+chmod +x "$tmp_dir/bin/omarchy-launch-webapp"
+
+open_url() {
+  PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-webapp-handler-hey" "$@"
+}
+
+# A mailto: link carrying a subject used to fold the whole query into "to=",
+# leaving a second "?" that HEY reads as part of the address. Assert on the
+# separator: the address alone lands in the right place either way, so only
+# the "&" shows the parameters survived as parameters.
+url=$(open_url "mailto:someone@example.com?subject=Hello")
+[[ $url == "https://app.hey.com/messages/new?to=someone@example.com&subject=Hello" ]] ||
+  fail "a mailto subject reaches HEY as its own parameter" "$url"
+pass "mailto with a subject keeps the address and subject apart"
+
+url=$(open_url "mailto:a@example.com?subject=Hi&body=Text")
+[[ $url == "https://app.hey.com/messages/new?to=a@example.com&subject=Hi&body=Text" ]] ||
+  fail "every mailto parameter is carried over" "$url"
+pass "mailto parameters past the first survive"
+
+url=$(open_url "mailto:someone@example.com")
+[[ $url == "https://app.hey.com/messages/new?to=someone@example.com" ]] ||
+  fail "a bare mailto address still opens addressed" "$url"
+pass "mailto without parameters is unchanged"
+
+# "mailto:?to=someone@example.com" carries the address as a parameter, which
+# must not become a second "to=".
+url=$(open_url "mailto:?to=someone@example.com&subject=Hello")
+[[ $url == "https://app.hey.com/messages/new?to=someone@example.com&subject=Hello" ]] ||
+  fail "the mailto parameter form addresses the message once" "$url"
+pass "mailto carrying the address as a parameter is not doubled"
+
+url=$(open_url "")
+[[ $url == "https://app.hey.com" ]] ||
+  fail "a call with no mailto URL opens HEY itself" "$url"
+pass "a non-mailto invocation opens HEY unchanged"


### PR DESCRIPTION
`omarchy-webapp-handler-hey` strips the `mailto:` scheme and assigns everything after it to HEY's `to=` parameter:

```bash
email=$(echo "$url" | sed 's/mailto://')
web_url="https://app.hey.com/messages/new?to=$email"
```

A mailto: URL carries its subject and body as query parameters after the address, so for `mailto:someone@example.com?subject=Hello` that builds:

```
https://app.hey.com/messages/new?to=someone@example.com?subject=Hello
                                                       ^ second "?"
```

The second `?` is inside the query, so `to` is the literal string `someone@example.com?subject=Hello` and `subject` never exists as a parameter. HEY opens a compose window with no recipient and no subject.

A bare `mailto:someone@example.com` works, which is why this has gone unnoticed since the handler landed — the break only shows up once a subject or body is involved, which is any prefilled mailto link on the system.

### Fix

Split the address at the first `?` and pass the remaining parameters through as parameters. They arrive already percent-encoded, so they need no further handling. The `mailto:?to=…` form is handled too; previously it produced `?to=?to=…`.

### Verification

`test/shell.d/webapp-handler-hey-test.sh` covers a subject, multiple parameters, a bare address, the `mailto:?to=` form, and a non-mailto invocation. It fails against the current handler on the first case and passes with the fix.

Also verified by hand on Omarchy 4.0.1: before, HEY opened blank; after, the recipient and subject are both filled in.

`./test/cli` passes.
