### PR TITLE
Proposal for a localization framework: Add the I18n translation primitive

### DIFF
--- a/default/bash/i18n
+++ b/default/bash/i18n
@@ -1,0 +1,130 @@
+# Translation lookup for interactive omarchy-* scripts.
+#
+#   source "$OMARCHY_PATH/default/bash/i18n"
+#   omarchy_t "Update now?"
+#   omarchy_t "Removing %1" "$pkg"
+#   omarchy_tn "$n" "%1 package" "%1 packages" "$n"
+#
+# Reads the cache the shell's I18n singleton maintains at
+# $XDG_CACHE_HOME/omarchy/i18n/<language>.json — one file, no plugin
+# enumeration, no knowledge of which language packs exist. Scripts run on a
+# tty, over ssh, or under sudo, where there is no shell process to ask.
+#
+# Every function falls back to its English source, so a script behaves
+# identically when the cache is absent, unreadable, or lacks a key. Safe under
+# `set -u` and `set -e`. Domain is omarchy.cli.
+
+OMARCHY_I18N_DOMAIN="omarchy.cli"
+
+# Primary language from the gettext variables, or empty for English / C.
+omarchy_i18n_language() {
+  local raw="${LANGUAGE:-${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}}"
+  raw="${raw%%:*}"      # LANGUAGE is a colon list; the first entry wins
+  raw="${raw%%.*}"      # ca_ES.UTF-8
+  raw="${raw%%@*}"      # es_ES@euro
+  raw="${raw%%_*}"      # ca_ES -> ca
+  raw="${raw%%-*}"      # ca-ES -> ca
+  raw="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$raw" in
+    "" | c | posix | en) return 0 ;;
+  esac
+  printf '%s' "$raw"
+}
+
+omarchy_i18n_cache_path() {
+  local lang
+  lang="$(omarchy_i18n_language)"
+  [[ -n $lang ]] || return 0
+  printf '%s/omarchy/i18n/%s.json' "${XDG_CACHE_HOME:-$HOME/.cache}" "$lang"
+}
+
+# Usable at all? Cheap check so the English path never spawns jq.
+omarchy_i18n_available() {
+  local path
+  path="$(omarchy_i18n_cache_path)"
+  [[ -n $path && -r $path ]] && command -v jq >/dev/null 2>&1
+}
+
+# %1, %2 ... from the highest index down, so %10 is not %1 followed by 0 and
+# an argument containing "%2" is never re-expanded once inserted. The
+# replacement is quoted so `&` stays literal under patsub_replacement.
+omarchy_i18n_interpolate() {
+  local text="$1"
+  shift
+  local i
+  for (( i = $#; i >= 1; i-- )); do
+    text="${text//"%$i"/"${!i}"}"
+  done
+  printf '%s' "$text"
+}
+
+# Raw catalog value for a key: a string, a JSON array (plural), or nothing.
+omarchy_i18n_raw() {
+  local key="$1" path
+  path="$(omarchy_i18n_cache_path)"
+  jq -r --arg d "$OMARCHY_I18N_DOMAIN" --arg k "$key" \
+    '.catalogs[$d][$k] // empty | if type == "array" then tojson else . end' \
+    "$path" 2>/dev/null
+}
+
+# The catalog's plural rule as a bash arithmetic expression, validated to a
+# strict whitelist first: bash arithmetic on untrusted text is an injection
+# vector (`a[$(cmd)]`), so only n, digits, spaces and C operators pass.
+omarchy_i18n_plural_index() {
+  local n="$1" path header rule
+  [[ $n =~ ^[0-9]+$ ]] || n=0
+  path="$(omarchy_i18n_cache_path)"
+  header="$(jq -r --arg d "$OMARCHY_I18N_DOMAIN" \
+    '.catalogs[$d][""]["plural-forms"] // empty' "$path" 2>/dev/null)"
+  rule="${header#*plural=}"
+  rule="${rule%%;*}"
+  # Fail closed: evaluate only when the whole rule matches the whitelist.
+  local allowed='^[n0-9 ?:()<>=!&|%+*/-]+$'
+  local index
+  if [[ -n $rule && $rule =~ $allowed ]]; then
+    index=$(( rule )) 2>/dev/null || index=0
+  else
+    (( n == 1 )) && index=0 || index=1
+  fi
+  printf '%s' "$index"
+}
+
+# omarchy_t <source> [args...]
+omarchy_t() {
+  local source="$1"
+  shift
+  local text="$source"
+  if omarchy_i18n_available; then
+    local raw
+    raw="$(omarchy_i18n_raw "$source")"
+    if [[ -n $raw ]]; then
+      if [[ $raw == \[* ]]; then
+        text="$(printf '%s' "$raw" | jq -r '.[0]')"
+      else
+        text="$raw"
+      fi
+    fi
+  fi
+  omarchy_i18n_interpolate "$text" "$@"
+}
+
+# omarchy_tn <count> <singular> <plural> [args...]
+omarchy_tn() {
+  local count="$1" singular="$2" plural="$3"
+  shift 3
+  local text
+  if (( count == 1 )); then text="$singular"; else text="$plural"; fi
+  if omarchy_i18n_available; then
+    local raw
+    raw="$(omarchy_i18n_raw "$singular")"
+    if [[ $raw == \[* ]]; then
+      local index picked
+      index="$(omarchy_i18n_plural_index "$count")"
+      picked="$(printf '%s' "$raw" | jq -r --argjson i "$index" '.[$i] // .[-1]')"
+      [[ -n $picked ]] && text="$picked"
+    elif [[ -n $raw ]]; then
+      text="$raw"
+    fi
+  fi
+  omarchy_i18n_interpolate "$text" "$@"
+}

--- a/default/bash/i18n
+++ b/default/bash/i18n
@@ -70,12 +70,14 @@ omarchy_i18n_interpolate() {
 }
 
 # Raw catalog value for a key: a string, a JSON array (plural), or nothing.
+# A readable cache can still be malformed; jq's failure is turned into empty
+# output here so a `set -e` caller gets the English fallback, not an exit.
 omarchy_i18n_raw() {
   local key="$1" path
   path="$(omarchy_i18n_cache_path)"
   jq -r --arg d "$OMARCHY_I18N_DOMAIN" --arg k "$key" \
     '.catalogs[$d][$k] // empty | if type == "array" then tojson else . end' \
-    "$path" 2>/dev/null
+    "$path" 2>/dev/null || true
 }
 
 # The catalog's plural rule as a bash arithmetic expression, validated to a
@@ -86,7 +88,7 @@ omarchy_i18n_plural_index() {
   [[ $n =~ ^[0-9]+$ ]] || n=0
   path="$(omarchy_i18n_cache_path)"
   header="$(jq -r --arg d "$OMARCHY_I18N_DOMAIN" \
-    '.catalogs[$d][""]["plural-forms"] // empty' "$path" 2>/dev/null)"
+    '.catalogs[$d][""]["plural-forms"] // empty' "$path" 2>/dev/null || true)"
   rule="${header#*plural=}"
   rule="${rule%%;*}"
   # Fail closed: evaluate only when the whole rule matches the whitelist,

--- a/default/bash/i18n
+++ b/default/bash/i18n
@@ -45,17 +45,28 @@ omarchy_i18n_available() {
   [[ -n $path && -r $path ]] && command -v jq >/dev/null 2>&1
 }
 
-# %1, %2 ... from the highest index down, so %10 is not %1 followed by 0 and
-# an argument containing "%2" is never re-expanded once inserted. The
-# replacement is quoted so `&` stays literal under patsub_replacement.
+# %1, %2 ... Scans the template once and appends each piece to a separate
+# buffer, so an inserted argument is never re-scanned: "%2 %1" with $2 being
+# "say %1" yields "say %1 a". An index with no argument stays as written.
 omarchy_i18n_interpolate() {
   local text="$1"
   shift
-  local i
-  for (( i = $#; i >= 1; i-- )); do
-    text="${text//"%$i"/"${!i}"}"
+  local out="" prefix rest index
+  while :; do
+    prefix="${text%%%[1-9]*}"
+    [[ $prefix != "$text" ]] || break
+    out+="$prefix"
+    rest="${text:${#prefix}}"
+    [[ $rest =~ ^%([1-9][0-9]*) ]]
+    index="${BASH_REMATCH[1]}"
+    if (( index <= $# )); then
+      out+="${!index}"
+    else
+      out+="${BASH_REMATCH[0]}"
+    fi
+    text="${rest:${#BASH_REMATCH[0]}}"
   done
-  printf '%s' "$text"
+  printf '%s' "$out$text"
 }
 
 # Raw catalog value for a key: a string, a JSON array (plural), or nothing.
@@ -78,12 +89,17 @@ omarchy_i18n_plural_index() {
     '.catalogs[$d][""]["plural-forms"] // empty' "$path" 2>/dev/null)"
   rule="${header#*plural=}"
   rule="${rule%%;*}"
-  # Fail closed: evaluate only when the whole rule matches the whitelist.
+  # Fail closed: evaluate only when the whole rule matches the whitelist,
+  # and only in a subshell — the whitelist admits malformed expressions such
+  # as "(n ? )", and an arithmetic syntax error in the caller's shell exits
+  # a `set -e` script before any `||` can catch it. Anything but a number
+  # coming back means English behaviour.
   local allowed='^[n0-9 ?:()<>=!&|%+*/-]+$'
-  local index
+  local index=""
   if [[ -n $rule && $rule =~ $allowed ]]; then
-    index=$(( rule )) 2>/dev/null || index=0
-  else
+    index="$( ( n="$n"; printf '%s' "$(( rule ))" ) 2>/dev/null )" || index=""
+  fi
+  if [[ ! $index =~ ^[0-9]+$ ]]; then
     (( n == 1 )) && index=0 || index=1
   fi
   printf '%s' "$index"
@@ -112,6 +128,9 @@ omarchy_t() {
 omarchy_tn() {
   local count="$1" singular="$2" plural="$3"
   shift 3
+  # Arithmetic on an unvalidated value is the same injection vector as the
+  # plural rule; the count is normalized before the first (( )).
+  [[ $count =~ ^[0-9]+$ ]] || count=0
   local text
   if (( count == 1 )); then text="$singular"; else text="$plural"; fi
   if omarchy_i18n_available; then

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -110,6 +110,8 @@ default/snapper/root           ──►  omarchy-settings    /etc/snapper/confi
 default/**                     ──►  omarchy-settings    /usr/share/omarchy/default/
   ├─ bash/env-bootstrap                                 /usr/share/omarchy/default/bash/env-bootstrap
   │                                                       (sourced by every shell/session entry point; see "Env bootstrap")
+  ├─ bash/i18n                                          /usr/share/omarchy/default/bash/i18n
+  │                                                       (omarchy_t / omarchy_tn for interactive scripts; see docs/i18n.md)
   ├─ bashrc                                             /usr/share/omarchy/etc-overrides/dot.bashrc
   │                                                       → /etc/skel/.bashrc (post_install cp -f)
   ├─ hypr/toggles/*.lua (flags,

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -66,7 +66,7 @@ I18n.setCatalogs("lang.ca", { "omarchy.menu": {...}, "omarchy.shell": {...} }, {
 I18n.clearCatalogs("lang.ca")
 ```
 
-`links` are the clone relationships the owner knows about. `precedence` is the owner's position in the user's language preference (`I18n.precedenceFor(locale)`): with `LANGUAGE=ca:es`, the Catalan pack registers at 0 and the Spanish one at 1, and a key missing from Catalan falls through to Spanish before English.
+`links` are the clone relationships the owner knows about. `precedence` is the owner's position in the user's language preference (`I18n.precedenceFor(locale)`): with `LANGUAGE=ca:es`, the Catalan pack registers at 0 and the Spanish one at 1, and a key missing from Catalan falls through to Spanish before English. A domain's plural rule is the preferred owner's; a fallback owner whose rule differs lends its singular entries but not its plural ones, since forms written for one rule are meaningless under another.
 
 ## Startup cache
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,89 @@
+# Translation
+
+How the shell and the `omarchy-*` scripts look strings up in another language. This describes the mechanism only; as of this document nothing in the tree calls it and no catalogs ship, so a stock install renders exactly as before.
+
+Quickshell builds a bare `QQmlEngine` with no `QTranslator`, so Qt's own `qsTr`/`.qm` pipeline has no runtime to attach to here. The primitive is a QML singleton over a plain-JS model instead.
+
+## Pieces
+
+- `shell/Commons/I18n.qml` — the `qs.Commons.I18n` singleton. Owns everything that touches Qt: the locale from the environment, the startup cache file, and reactivity.
+- `shell/Commons/I18nModel.js` — the Qt-free core: locale rules, `%1` interpolation, plural rules, and the catalog registry. Loaded by the singleton and by `test/shell.d/i18n-test.sh` under node.
+- `default/bash/i18n` — `omarchy_t` and `omarchy_tn` for the interactive `bin/` scripts, which run on a tty, over ssh, or under `sudo` where there is no shell process to ask.
+
+## Call sites
+
+```qml
+import qs.Commons
+
+Item {
+  // One line per file that wants its own domain; see "Domains".
+  readonly property var _: I18n.domain(root.manifest && root.manifest.id ? root.manifest.id : "omarchy.example")
+
+  Text { text: _.tr("Connect") }
+  Text { text: _.trc("verb", "Open") }                  // msgctxt, for one English word with two meanings
+  Text { text: _.ntr(n, "%1 city", "%1 cities", [n]) }  // plural
+}
+```
+
+- `tr(source, args)`, `trc(context, source, args)`, `ntr(count, singular, plural, args)` — the English string is the key; `%1`, `%2` … are filled from `args` in a single pass, so an argument containing `%2` is never re-expanded.
+- `noop(source)` returns its argument. Use it where a string is defined away from where it is shown (a JS model returning a status that a view translates later) so extraction still sees it.
+- Unbound calls — `I18n.tr("Cancel")` — resolve through the global merge of every registered catalog. Core files under `shell/Ui` and `shell/services` have no plugin id and use this form.
+
+Every lookup reads `I18n.revision`, so a QML binding that calls `tr()` re-evaluates when a catalog registers. Text assembled imperatively (a list built in a function) has to be rebuilt by hand; connect to `revisionChanged`.
+
+## Domains
+
+A domain is a namespace for keys, normally a plugin id. Two reserved domains cover code with no plugin id: `omarchy.shell` for `shell/Ui` and `shell/services`, and `omarchy.cli` for `bin/`.
+
+A bound lookup walks: the caller's domain → the domain it was cloned from (`omarchy.clonedFrom` in the manifest) → the global merge → the English source. First hit wins, per key. So a plugin copied with `omarchy plugin clone` resolves its own catalog first and falls through to the original's for everything it did not change, and its catalog only needs to hold the differences.
+
+Two plugins may translate the same English word differently as long as both are bound. An unbound caller gets whichever registered last — the same collision `msgctxt` exists for.
+
+## Catalogs
+
+One JSON object per domain, in the shape `po2json`/Jed produce from gettext PO files:
+
+```json
+{
+  "": { "language": "ca", "plural-forms": "nplurals=2; plural=(n != 1);", "source": "quattro@06e32d2" },
+  "Connect": "Connecta",
+  "verb\u0004Open": "Obre",
+  "%1 city": ["%1 ciutat", "%1 ciutats"]
+}
+```
+
+- The `""` header carries the locale, the gettext plural rule, and the upstream commit the catalog was extracted from.
+- `msgctxt` is encoded as `context` + U+0004 + `msgid`, the gettext convention.
+- Plural entries are arrays indexed by the plural rule's result. The rule is a C expression over `n`; it is evaluated by a small parser, not `eval`, so a hostile catalog cannot run code and a malformed rule is rejected whole.
+- Entries with the wrong shape are dropped one by one; a bad line does not lose the file.
+
+## Registration
+
+Catalogs are contributed by owners — a language pack plugin is one — and replaced atomically:
+
+```qml
+I18n.setCatalogs("lang.ca", { "omarchy.menu": {...}, "omarchy.shell": {...} }, { links: { "my.menu": "omarchy.menu" }, precedence: 0 })
+I18n.clearCatalogs("lang.ca")
+```
+
+`links` are the clone relationships the owner knows about. `precedence` is the owner's position in the user's language preference (`I18n.precedenceFor(locale)`): with `LANGUAGE=ca:es`, the Catalan pack registers at 0 and the Spanish one at 1, and a key missing from Catalan falls through to Spanish before English.
+
+## Startup cache
+
+Language packs are plugins and load after the registry scan, which is after the bar's first frame. To avoid a flash of English on every login, the singleton persists the merged catalogs to `$XDG_CACHE_HOME/omarchy/i18n/<language>.json` (a quarter-second after the last registration) and reads that file synchronously at the next start.
+
+The cache is a stand-in, not a second copy: it registers as an ordinary owner at the lowest precedence and is dropped as soon as a live owner registers. Otherwise disabling a pack would leave the cache still holding an identical copy of the strings it just removed. For the same reason the snapshot written to disk never includes the cache owner, and it will not reload over live data. The Bash helper reads the same file, which is how `bin/` scripts find translations without enumerating plugins.
+
+## Bash
+
+```bash
+source "$OMARCHY_PATH/default/bash/i18n"
+gum confirm "$(omarchy_t "Continue with update?")"
+echo "$(omarchy_tn "$n" "%1 package" "%1 packages" "$n")"
+```
+
+Domain `omarchy.cli`. Safe under `set -u` and `set -e`; every function falls back to its English source when the cache is absent, unreadable, or lacks the key. A catalog's plural rule is evaluated with bash arithmetic only after matching a strict whitelist — bash arithmetic on untrusted text is an injection vector — and the check fails closed.
+
+## Tests
+
+`test/shell.d/i18n-test.sh` covers the model under node and asserts that no shell code calls the primitive yet. `test/shell.d/i18n-bash-test.sh` covers the helper against fixture caches, including a catalog whose plural rule tries to run a command.

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -9,6 +9,9 @@ IPC is the canonical way for CLIs to talk to a running shell —
 (`-q` makes it quiet best-effort; `OMARCHY_SHELL_IPC_TIMEOUT` bounds the
 wait).
 
+Strings the shell renders can be looked up in another language through
+`qs.Commons.I18n`; see [`docs/i18n.md`](i18n.md). Nothing calls it yet.
+
 ## Plugin manifest
 
 ```json

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -9,8 +9,7 @@ IPC is the canonical way for CLIs to talk to a running shell —
 (`-q` makes it quiet best-effort; `OMARCHY_SHELL_IPC_TIMEOUT` bounds the
 wait).
 
-Strings the shell renders can be looked up in another language through
-`qs.Commons.I18n`; see [`docs/i18n.md`](i18n.md). Nothing calls it yet.
+Strings the shell renders can be looked up in another language through `qs.Commons.I18n`; see [`docs/i18n.md`](i18n.md). Nothing calls it yet.
 
 ## Plugin manifest
 

--- a/shell/Commons/I18n.qml
+++ b/shell/Commons/I18n.qml
@@ -1,0 +1,182 @@
+pragma Singleton
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "I18nModel.js" as Model
+
+// qs.Commons.I18n — the shell's translation primitive.
+//
+// This file owns everything that touches Qt: the environment, the cache file,
+// and reactivity. All lookup logic lives in I18nModel.js so it can be tested
+// under node.
+//
+// Call sites
+//   I18n.tr("Connect")                          unbound: global merge
+//   readonly property var _: I18n.domain("dev.foo.weather")
+//   _.tr("Connect")  _.trc("verb", "Open")  _.ntr(n, "%1 city", "%1 cities", [n])
+//
+// Registration (language packs)
+//   I18n.setCatalogs("lang.ca", { "omarchy.menu": {...}, ... }, { links, precedence })
+//   I18n.clearCatalogs("lang.ca")
+//
+// With nothing registered every call returns its source string, so a stock
+// install is unaffected. Catalogs arrive late — language packs are plugins
+// and load after the registry scan — so lookups read `revision` and any
+// binding that called tr() re-evaluates when a catalog registers. To avoid
+// a flash of English on every login, the merged catalogs are persisted to
+// $XDG_CACHE_HOME/omarchy/i18n/<language>.json and loaded synchronously here,
+// before the first frame. The Bash helper in default/bash/i18n reads the
+// same file.
+
+QtObject {
+  id: root
+
+  // ---------------------------------------------------------------------
+  // Locale
+
+  readonly property var candidates: Model.localeCandidates({
+    LANGUAGE: Quickshell.env("LANGUAGE"),
+    LC_ALL: Quickshell.env("LC_ALL"),
+    LC_MESSAGES: Quickshell.env("LC_MESSAGES"),
+    LANG: Quickshell.env("LANG")
+  })
+
+  // Primary language code ("ca" for ca_ES, or the first LANGUAGE entry).
+  // Empty means English / C: nothing to translate and no cache to keep.
+  readonly property string language: candidates.length > 0 ? candidates[0].split("_")[0] : ""
+
+  // Where a pack's locale sits in the user's preference order, for use as
+  // its registration precedence. -1 means the pack does not apply.
+  function precedenceFor(locale) {
+    var normalized = Model.normalizeLocale(locale)
+    if (!normalized) return -1
+    var index = candidates.indexOf(normalized)
+    if (index === -1) index = candidates.indexOf(normalized.split("_")[0])
+    return index
+  }
+
+  // ---------------------------------------------------------------------
+  // Lookup
+
+  // Bumped on every registry change. Read inside every lookup so QML
+  // bindings that call tr() depend on it and repaint when catalogs change.
+  property int revision: 0
+  property var _registry: Model.createRegistry()
+
+  function _lookup(source, options) {
+    void root.revision
+    return root._registry.translate(source, options)
+  }
+
+  function _lookupPlural(count, singular, plural, options) {
+    void root.revision
+    return root._registry.translatePlural(count, singular, plural, options)
+  }
+
+  function tr(source, args) {
+    return _lookup(source, { args: args })
+  }
+
+  function trc(context, source, args) {
+    return _lookup(source, { context: context, args: args })
+  }
+
+  function ntr(count, singular, plural, args) {
+    return _lookupPlural(count, singular, plural, { args: args })
+  }
+
+  // Marks a string for extraction without translating it, for strings
+  // defined away from where they are shown (a model returning a status).
+  function noop(source) {
+    return source
+  }
+
+  // A translator bound to one domain: lookups walk the domain, its
+  // clonedFrom parents, then the global merge.
+  function domain(id) {
+    var d = String(id === undefined || id === null ? "" : id)
+    return {
+      id: d,
+      tr: function(source, args) {
+        return root._lookup(source, { domain: d, args: args })
+      },
+      trc: function(context, source, args) {
+        return root._lookup(source, { domain: d, context: context, args: args })
+      },
+      ntr: function(count, singular, plural, args) {
+        return root._lookupPlural(count, singular, plural, { domain: d, args: args })
+      },
+      noop: function(source) { return source }
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Registration
+
+  // Replace an owner's whole contribution atomically.
+  //   catalogs  { domain: catalog }   one po2json-shaped object per domain
+  //   options   { links: { childDomain: parentDomain }, precedence: int }
+  function setCatalogs(ownerId, catalogs, options) {
+    var result = root._registry.setCatalogs(String(ownerId), catalogs, options)
+    root._changed()
+    return result
+  }
+
+  function clearCatalogs(ownerId) {
+    var removed = root._registry.clearOwner(String(ownerId))
+    if (removed) root._changed()
+    return removed
+  }
+
+  function _changed() {
+    root.revision = root._registry.revision()
+    root.cacheWriteTimer.restart()
+  }
+
+  // ---------------------------------------------------------------------
+  // Startup cache
+
+  readonly property string cacheDir: {
+    var xdg = Quickshell.env("XDG_CACHE_HOME")
+    var base = xdg ? String(xdg) : String(Quickshell.env("HOME")) + "/.cache"
+    return base.replace(/\/$/, "") + "/omarchy/i18n"
+  }
+  readonly property string cachePath: language ? cacheDir + "/" + language + ".json" : ""
+
+  property FileView cacheFile: FileView {
+    path: root.cachePath
+    // Synchronous on purpose: the whole point is having catalogs before the
+    // bar's first frame. The file is small and local.
+    blockLoading: true
+    atomicWrites: true
+    printErrors: false
+    onLoaded: root._loadCache(text())
+    // No cache yet, or unreadable: English until a pack registers.
+    onLoadFailed: function(error) { }
+  }
+
+  function _loadCache(raw) {
+    var text = String(raw || "").trim()
+    if (!text) return
+    try {
+      var parsed = JSON.parse(text)
+      if (root._registry.loadSnapshot(parsed)) root.revision = root._registry.revision()
+    } catch (error) {
+      console.warn("I18n: ignoring unreadable cache at " + root.cachePath + ": " + error)
+    }
+  }
+
+  // Registrations arrive in bursts (one pack per locale, a rescan); coalesce
+  // them into one write.
+  property Timer cacheWriteTimer: Timer {
+    interval: 250
+    repeat: false
+    onTriggered: root._writeCache()
+  }
+
+  function _writeCache() {
+    if (!root.cachePath) return
+    var snapshot = root._registry.snapshot()
+    root.cacheFile.setText(JSON.stringify(snapshot) + "\n")
+  }
+}

--- a/shell/Commons/I18nModel.js
+++ b/shell/Commons/I18nModel.js
@@ -196,9 +196,15 @@ function parsePluralForms(header) {
 // object; every other value is a string or an array of strings. Anything else
 // is dropped entry-by-entry so one bad line does not lose the whole file.
 
+// Dictionaries keyed by untrusted names — domains are plugin ids, keys are
+// source strings — must not inherit from Object.prototype: a plugin id of
+// "constructor" would otherwise resolve to an inherited function and skip
+// initialization, and a "__proto__" key would rewrite the map's prototype.
+function dict() { return Object.create(null) }
+
 function sanitizeCatalog(raw) {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
-  var out = {}
+  var out = dict()
   for (var key in raw) {
     if (!Object.prototype.hasOwnProperty.call(raw, key)) continue
     var value = raw[key]
@@ -240,9 +246,9 @@ function headerPluralForms(catalog) {
 // are rare (login, plugin toggles), so simplicity wins over incrementality.
 
 function createRegistry() {
-  var owners = {}          // ownerId -> { catalogs, links, precedence, order }
+  var owners = dict()      // ownerId -> { catalogs, links, precedence, order }
   var nextOrder = 0
-  var state = { revision: 0, merged: {}, global: {}, parents: {}, plurals: {} }
+  var state = { revision: 0, merged: dict(), global: dict(), parents: dict(), plurals: dict() }
 
   // The startup cache is registered as an ordinary owner at the lowest
   // precedence so it can answer lookups for the frames before the real packs
@@ -261,19 +267,19 @@ function createRegistry() {
       return a.precedence !== b.precedence ? b.precedence - a.precedence : a.order - b.order
     })
 
-    var merged = {}
-    var parents = {}
+    var merged = dict()
+    var parents = dict()
     var domainOrder = []
     // A domain's plural rule is the winning owner's header. Owners fold in
     // ascending order of preference, so the last header written wins.
-    var rules = {}
+    var rules = dict()
     for (var h = 0; h < list.length; h++) {
       for (var hd in list[h].catalogs) rules[hd] = pluralRuleText(list[h].catalogs[hd])
     }
     for (var i = 0; i < list.length; i++) {
       var owner = list[i]
       for (var domain in owner.catalogs) {
-        if (!merged[domain]) { merged[domain] = {}; domainOrder.push(domain) }
+        if (!merged[domain]) { merged[domain] = dict(); domainOrder.push(domain) }
         var cat = owner.catalogs[domain]
         // A lower-preference owner may supply keys the winner lacks, but a
         // plural entry is only meaningful under the rule its forms were
@@ -290,15 +296,15 @@ function createRegistry() {
       for (var child in owner.links) parents[child] = owner.links[child]
     }
 
-    var plurals = {}
+    var plurals = dict()
     for (var d = 0; d < domainOrder.length; d++) {
       plurals[domainOrder[d]] = headerPluralForms(merged[domainOrder[d]])
     }
 
     // Global merge: a domain's ancestors are folded before it, so a clone's
     // translation shadows the original's for unbound callers.
-    var global = {}
-    var folded = {}
+    var global = dict()
+    var folded = dict()
     function fold(domain, depth) {
       if (folded[domain] || depth > 16) return
       folded[domain] = true
@@ -329,7 +335,7 @@ function createRegistry() {
   // Domain chain for a bound caller: the domain, then its parents.
   function chain(domain) {
     var out = []
-    var seen = {}
+    var seen = dict()
     var current = domain ? String(domain) : ""
     while (current && !seen[current] && out.length < 16) {
       seen[current] = true
@@ -384,15 +390,17 @@ function createRegistry() {
   //   options    { links: { child: parent }, precedence: number }
   function setCatalogs(ownerId, catalogs, options) {
     var opts = options || {}
-    var clean = {}
+    var clean = dict()
     var raw = catalogs && typeof catalogs === "object" ? catalogs : {}
     for (var domain in raw) {
+      if (!Object.prototype.hasOwnProperty.call(raw, domain)) continue
       var cat = sanitizeCatalog(raw[domain])
       if (cat) clean[String(domain)] = cat
     }
-    var links = {}
+    var links = dict()
     var rawLinks = opts.links && typeof opts.links === "object" ? opts.links : {}
     for (var child in rawLinks) {
+      if (!Object.prototype.hasOwnProperty.call(rawLinks, child)) continue
       if (typeof rawLinks[child] === "string" && rawLinks[child] && rawLinks[child] !== child) {
         links[String(child)] = rawLinks[child]
       }
@@ -426,9 +434,9 @@ function createRegistry() {
   function snapshot(options) {
     var exclude = options && options.exclude !== undefined ? options.exclude : CACHE_OWNER
     var view = computeState(ownerList(exclude))
-    var catalogs = {}
+    var catalogs = dict()
     for (var domain in view.merged) catalogs[domain] = view.merged[domain]
-    var links = {}
+    var links = dict()
     for (var child in view.parents) links[child] = view.parents[child]
     return { version: 1, catalogs: catalogs, links: links }
   }

--- a/shell/Commons/I18nModel.js
+++ b/shell/Commons/I18nModel.js
@@ -216,6 +216,15 @@ function sanitizeCatalog(raw) {
   return out
 }
 
+// The plural rule a catalog declares, normalized for comparison. A catalog
+// without a header is taken to use the English rule.
+var ENGLISH_PLURAL_TEXT = "nplurals=2; plural=(n != 1);"
+function pluralRuleText(catalog) {
+  var header = catalog && catalog[""]
+  var text = header && (header["plural-forms"] || header["Plural-Forms"])
+  return String(text || ENGLISH_PLURAL_TEXT).replace(/\s+/g, "")
+}
+
 function headerPluralForms(catalog) {
   var header = catalog && catalog[""]
   if (!header) return null
@@ -255,12 +264,28 @@ function createRegistry() {
     var merged = {}
     var parents = {}
     var domainOrder = []
+    // A domain's plural rule is the winning owner's header. Owners fold in
+    // ascending order of preference, so the last header written wins.
+    var rules = {}
+    for (var h = 0; h < list.length; h++) {
+      for (var hd in list[h].catalogs) rules[hd] = pluralRuleText(list[h].catalogs[hd])
+    }
     for (var i = 0; i < list.length; i++) {
       var owner = list[i]
       for (var domain in owner.catalogs) {
         if (!merged[domain]) { merged[domain] = {}; domainOrder.push(domain) }
         var cat = owner.catalogs[domain]
-        for (var key in cat) merged[domain][key] = cat[key]
+        // A lower-preference owner may supply keys the winner lacks, but a
+        // plural entry is only meaningful under the rule its forms were
+        // written for. With LANGUAGE=ca:pl a Polish three-form entry indexed
+        // by the Catalan rule would show the wrong form, so such entries are
+        // left out and fall back to English instead. The snapshot Bash reads
+        // stays consistent with its one header per domain for the same reason.
+        var compatible = pluralRuleText(cat) === rules[domain]
+        for (var key in cat) {
+          if (Array.isArray(cat[key]) && !compatible) continue
+          merged[domain][key] = cat[key]
+        }
       }
       for (var child in owner.links) parents[child] = owner.links[child]
     }

--- a/shell/Commons/I18nModel.js
+++ b/shell/Commons/I18nModel.js
@@ -1,0 +1,445 @@
+// I18nModel.js — the pure-JS core of qs.Commons.I18n.
+//
+// No Qt or QML dependencies, so it runs under node for tests and QML loads it
+// with `import "I18nModel.js" as Model`. Keep it that way: everything that
+// touches FileView, Quickshell.env, or the plugin registry lives in I18n.qml.
+//
+// Vocabulary
+//   domain    a namespace for keys, normally a plugin id ("omarchy.menu");
+//             "omarchy.shell" and "omarchy.cli" are reserved for code with no id
+//   owner     whoever registered a set of catalogs, normally a language pack;
+//             owners are replaced atomically and can be cleared
+//   catalog   one JSON object per domain, po2json/Jed shape: a "" header entry
+//             plus msgid -> msgstr, or msgid -> [forms] for plurals
+//   link      child domain -> parent domain, from a clone's omarchy.clonedFrom
+
+var CONTEXT_SEPARATOR = "\u0004"
+
+// ---------------------------------------------------------------------------
+// Locale selection
+
+function normalizeLocale(value) {
+  var locale = String(value || "").trim()
+  if (!locale) return ""
+  locale = locale.split(".")[0].split("@")[0].replace(/-/g, "_")
+  if (locale === "C" || locale === "POSIX") return ""
+  var parts = locale.split("_")
+  var language = parts[0].toLowerCase()
+  if (!language) return ""
+  return parts.length > 1 && parts[1] ? language + "_" + parts[1].toUpperCase() : language
+}
+
+// Ordered preference list from the gettext environment variables. LANGUAGE is
+// a colon-separated list and wins outright; the others are single values.
+// Each entry expands to [regional, language] so "ca_ES" also tries "ca".
+// "en" is the source language: nothing after it can apply, so the list stops.
+function localeCandidates(environment) {
+  var env = environment || {}
+  var raw = env.LANGUAGE || env.LC_ALL || env.LC_MESSAGES || env.LANG || ""
+  var requested = env.LANGUAGE ? String(raw).split(":") : [raw]
+  var candidates = []
+  for (var i = 0; i < requested.length; i++) {
+    var normalized = normalizeLocale(requested[i])
+    if (!normalized) continue
+    var language = normalized.split("_")[0]
+    if (candidates.indexOf(normalized) === -1) candidates.push(normalized)
+    if (candidates.indexOf(language) === -1) candidates.push(language)
+    if (language === "en") break
+  }
+  return candidates
+}
+
+// ---------------------------------------------------------------------------
+// Interpolation: %1, %2 ... Single pass, so an argument that itself contains
+// "%2" is inserted verbatim and never re-expanded. Unknown indices stay as-is.
+
+function interpolate(value, args) {
+  var output = String(value === undefined || value === null ? "" : value)
+  var values = Array.isArray(args) ? args : []
+  return output.replace(/%([1-9][0-9]*)/g, function(match, rawIndex) {
+    var index = Number(rawIndex) - 1
+    return index < values.length ? String(values[index]) : match
+  })
+}
+
+function contextKey(context, source) {
+  var ctx = String(context === undefined || context === null ? "" : context)
+  var key = String(source === undefined || source === null ? "" : source)
+  return ctx ? ctx + CONTEXT_SEPARATOR + key : key
+}
+
+// ---------------------------------------------------------------------------
+// Plural rules. The catalog header carries a gettext Plural-Forms line:
+//   "nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);"
+// The expression is a C integer expression over n. It is evaluated by a small
+// recursive-descent parser rather than eval/Function, so a hostile catalog
+// cannot run code and a malformed one is rejected rather than half-applied.
+
+var ENGLISH_PLURAL = { nplurals: 2, plural: function(n) { return n !== 1 ? 1 : 0 } }
+
+function tokenizePlural(text) {
+  var tokens = []
+  var i = 0
+  while (i < text.length) {
+    var c = text.charAt(i)
+    if (c === " " || c === "\t" || c === "\n") { i++; continue }
+    if (c >= "0" && c <= "9") {
+      var j = i
+      while (j < text.length && text.charAt(j) >= "0" && text.charAt(j) <= "9") j++
+      tokens.push({ type: "num", value: Number(text.slice(i, j)) })
+      i = j
+      continue
+    }
+    if (c === "n") { tokens.push({ type: "n" }); i++; continue }
+    var two = text.substr(i, 2)
+    if (["||", "&&", "==", "!=", "<=", ">="].indexOf(two) !== -1) {
+      tokens.push({ type: "op", value: two }); i += 2; continue
+    }
+    if ("?:()<>+-*/%!".indexOf(c) !== -1) { tokens.push({ type: "op", value: c }); i++; continue }
+    throw new Error("unexpected character in plural expression: " + c)
+  }
+  return tokens
+}
+
+function parsePluralExpression(text) {
+  var tokens = tokenizePlural(text)
+  var pos = 0
+
+  function peek() { return tokens[pos] }
+  function take(value) {
+    var t = tokens[pos]
+    if (!t || (value !== undefined && (t.type !== "op" || t.value !== value))) {
+      throw new Error("plural expression: expected " + (value || "token") + " at " + pos)
+    }
+    pos++
+    return t
+  }
+  function isOp(value) { var t = peek(); return t && t.type === "op" && t.value === value }
+
+  function primary() {
+    var t = peek()
+    if (!t) throw new Error("plural expression: unexpected end")
+    if (t.type === "num") { pos++; var v = t.value; return function() { return v } }
+    if (t.type === "n") { pos++; return function(n) { return n } }
+    if (isOp("(")) { take("("); var e = ternary(); take(")"); return e }
+    throw new Error("plural expression: unexpected " + t.value)
+  }
+  function unary() {
+    if (isOp("!")) { take("!"); var e = unary(); return function(n) { return e(n) ? 0 : 1 } }
+    return primary()
+  }
+  function binary(next, ops, apply) {
+    return function parse() {
+      var left = next()
+      while (peek() && peek().type === "op" && ops.indexOf(peek().value) !== -1) {
+        var op = take().value
+        var right = next()
+        left = (function(l, r, o) { return function(n) { return apply(o, l(n), r(n)) } })(left, right, op)
+      }
+      return left
+    }
+  }
+  var mul = binary(unary, ["*", "/", "%"], function(o, a, b) {
+    if (o === "*") return a * b
+    if (b === 0) return 0
+    return o === "/" ? Math.floor(a / b) : a % b
+  })
+  var add = binary(mul, ["+", "-"], function(o, a, b) { return o === "+" ? a + b : a - b })
+  var rel = binary(add, ["<", ">", "<=", ">="], function(o, a, b) {
+    if (o === "<") return a < b ? 1 : 0
+    if (o === ">") return a > b ? 1 : 0
+    if (o === "<=") return a <= b ? 1 : 0
+    return a >= b ? 1 : 0
+  })
+  var eq = binary(rel, ["==", "!="], function(o, a, b) { return (o === "==" ? a === b : a !== b) ? 1 : 0 })
+  var and = binary(eq, ["&&"], function(o, a, b) { return a && b ? 1 : 0 })
+  var or = binary(and, ["||"], function(o, a, b) { return a || b ? 1 : 0 })
+  function ternary() {
+    var cond = or()
+    if (!isOp("?")) return cond
+    take("?")
+    var yes = ternary()
+    take(":")
+    var no = ternary()
+    return function(n) { return cond(n) ? yes(n) : no(n) }
+  }
+
+  var fn = ternary()
+  if (pos !== tokens.length) throw new Error("plural expression: trailing tokens")
+  return fn
+}
+
+// Returns { nplurals, plural(n) } or null when the header is absent/invalid.
+function parsePluralForms(header) {
+  var text = String(header || "")
+  var countMatch = text.match(/nplurals\s*=\s*(\d+)/)
+  var exprMatch = text.match(/plural\s*=\s*([^;]+)/)
+  if (!countMatch || !exprMatch) return null
+  var nplurals = Number(countMatch[1])
+  if (!(nplurals >= 1)) return null
+  var expr
+  try { expr = parsePluralExpression(exprMatch[1]) } catch (e) { return null }
+  return {
+    nplurals: nplurals,
+    plural: function(n) {
+      var count = Math.abs(Math.floor(Number(n) || 0))
+      var index = Number(expr(count))
+      if (!(index >= 0)) index = 0
+      if (index >= nplurals) index = nplurals - 1
+      return index
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Catalog validation. A catalog is a plain object; the "" entry is a header
+// object; every other value is a string or an array of strings. Anything else
+// is dropped entry-by-entry so one bad line does not lose the whole file.
+
+function sanitizeCatalog(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
+  var out = {}
+  for (var key in raw) {
+    if (!Object.prototype.hasOwnProperty.call(raw, key)) continue
+    var value = raw[key]
+    if (key === "") {
+      if (value && typeof value === "object" && !Array.isArray(value)) out[""] = value
+      continue
+    }
+    if (typeof value === "string") { out[key] = value; continue }
+    if (Array.isArray(value) && value.length > 0) {
+      var ok = true
+      for (var i = 0; i < value.length; i++) if (typeof value[i] !== "string") { ok = false; break }
+      if (ok) out[key] = value.slice()
+    }
+  }
+  return out
+}
+
+function headerPluralForms(catalog) {
+  var header = catalog && catalog[""]
+  if (!header) return null
+  return parsePluralForms(header["plural-forms"] || header["Plural-Forms"])
+}
+
+// ---------------------------------------------------------------------------
+// Registry. Holds every owner's catalogs and links, and derives:
+//   merged[domain]  one catalog per domain, owners folded by precedence
+//   global          every domain folded into one map, parents before children
+//   parents         child domain -> parent domain
+// Derived state is rebuilt on every change; catalogs are small and changes
+// are rare (login, plugin toggles), so simplicity wins over incrementality.
+
+function createRegistry() {
+  var owners = {}          // ownerId -> { catalogs, links, precedence, order }
+  var nextOrder = 0
+  var state = { revision: 0, merged: {}, global: {}, parents: {}, plurals: {} }
+
+  // The startup cache is registered as an ordinary owner at the lowest
+  // precedence so it can answer lookups for the frames before the real packs
+  // register. It is only ever a stand-in: once a live pack has registered,
+  // the cache copy is dropped and no longer reloadable, so disabling that
+  // pack actually reverts the interface instead of falling back to a stale
+  // duplicate of the strings it just removed.
+  var CACHE_OWNER = "cache"
+  var liveOwnerSeen = false
+
+  // Fold a list of owners into { merged, parents, plurals, global }.
+  function computeState(list) {
+    // Lower precedence number wins. Among equals, the later registration
+    // wins, which is what lets a pack refresh itself by re-registering.
+    list = list.slice().sort(function(a, b) {
+      return a.precedence !== b.precedence ? b.precedence - a.precedence : a.order - b.order
+    })
+
+    var merged = {}
+    var parents = {}
+    var domainOrder = []
+    for (var i = 0; i < list.length; i++) {
+      var owner = list[i]
+      for (var domain in owner.catalogs) {
+        if (!merged[domain]) { merged[domain] = {}; domainOrder.push(domain) }
+        var cat = owner.catalogs[domain]
+        for (var key in cat) merged[domain][key] = cat[key]
+      }
+      for (var child in owner.links) parents[child] = owner.links[child]
+    }
+
+    var plurals = {}
+    for (var d = 0; d < domainOrder.length; d++) {
+      plurals[domainOrder[d]] = headerPluralForms(merged[domainOrder[d]])
+    }
+
+    // Global merge: a domain's ancestors are folded before it, so a clone's
+    // translation shadows the original's for unbound callers.
+    var global = {}
+    var folded = {}
+    function fold(domain, depth) {
+      if (folded[domain] || depth > 16) return
+      folded[domain] = true
+      if (parents[domain] && merged[parents[domain]]) fold(parents[domain], depth + 1)
+      var cat = merged[domain]
+      for (var key in cat) if (key !== "") global[key] = { value: cat[key], domain: domain }
+    }
+    for (var o = 0; o < domainOrder.length; o++) fold(domainOrder[o], 0)
+
+    return { merged: merged, global: global, parents: parents, plurals: plurals }
+  }
+
+  function ownerList(excludeId) {
+    var list = []
+    for (var id in owners) if (id !== excludeId) list.push(owners[id])
+    return list
+  }
+
+  function rebuild() {
+    var next = computeState(ownerList())
+    state.merged = next.merged
+    state.global = next.global
+    state.parents = next.parents
+    state.plurals = next.plurals
+    state.revision++
+  }
+
+  // Domain chain for a bound caller: the domain, then its parents.
+  function chain(domain) {
+    var out = []
+    var seen = {}
+    var current = domain ? String(domain) : ""
+    while (current && !seen[current] && out.length < 16) {
+      seen[current] = true
+      out.push(current)
+      current = state.parents[current]
+    }
+    return out
+  }
+
+  // Per-key lookup. Returns { value, domain } or null.
+  function lookup(key, domain) {
+    var domains = chain(domain)
+    for (var i = 0; i < domains.length; i++) {
+      var cat = state.merged[domains[i]]
+      if (cat && Object.prototype.hasOwnProperty.call(cat, key) && key !== "") {
+        return { value: cat[key], domain: domains[i] }
+      }
+    }
+    return Object.prototype.hasOwnProperty.call(state.global, key) ? state.global[key] : null
+  }
+
+  function translate(source, options) {
+    var opts = options || {}
+    var fallback = String(source === undefined || source === null ? "" : source)
+    var key = contextKey(opts.context, fallback)
+    var hit = lookup(key, opts.domain)
+    var value = hit ? hit.value : fallback
+    if (Array.isArray(value)) value = value[0]
+    return interpolate(value, opts.args)
+  }
+
+  function translatePlural(count, singular, plural, options) {
+    var opts = options || {}
+    var n = Number(count) || 0
+    var key = contextKey(opts.context, String(singular === undefined || singular === null ? "" : singular))
+    var hit = lookup(key, opts.domain)
+    var text
+    if (hit && Array.isArray(hit.value)) {
+      var rule = state.plurals[hit.domain] || ENGLISH_PLURAL
+      var index = rule.plural(n)
+      text = hit.value[index] !== undefined ? hit.value[index] : hit.value[hit.value.length - 1]
+    } else if (hit && typeof hit.value === "string") {
+      text = hit.value
+    } else {
+      text = ENGLISH_PLURAL.plural(n) === 0 ? singular : plural
+    }
+    return interpolate(text, opts.args)
+  }
+
+  // Replace an owner's whole contribution atomically.
+  //   catalogs   { domain: catalog }
+  //   options    { links: { child: parent }, precedence: number }
+  function setCatalogs(ownerId, catalogs, options) {
+    var opts = options || {}
+    var clean = {}
+    var raw = catalogs && typeof catalogs === "object" ? catalogs : {}
+    for (var domain in raw) {
+      var cat = sanitizeCatalog(raw[domain])
+      if (cat) clean[String(domain)] = cat
+    }
+    var links = {}
+    var rawLinks = opts.links && typeof opts.links === "object" ? opts.links : {}
+    for (var child in rawLinks) {
+      if (typeof rawLinks[child] === "string" && rawLinks[child] && rawLinks[child] !== child) {
+        links[String(child)] = rawLinks[child]
+      }
+    }
+    var existing = owners[ownerId]
+    owners[ownerId] = {
+      catalogs: clean,
+      links: links,
+      precedence: typeof opts.precedence === "number" ? opts.precedence : 0,
+      order: nextOrder++
+    }
+    if (ownerId !== CACHE_OWNER) {
+      liveOwnerSeen = true
+      delete owners[CACHE_OWNER]
+    }
+    rebuild()
+    return existing ? "replaced" : "added"
+  }
+
+  function clearOwner(ownerId) {
+    if (!owners[ownerId]) return false
+    delete owners[ownerId]
+    rebuild()
+    return true
+  }
+
+  // Serializable view of the merged state, for the startup cache. The
+  // snapshot excludes the cache owner: otherwise disabling every pack would
+  // write the old cache back out and the translations would return at the
+  // next login.
+  function snapshot(options) {
+    var exclude = options && options.exclude !== undefined ? options.exclude : CACHE_OWNER
+    var view = computeState(ownerList(exclude))
+    var catalogs = {}
+    for (var domain in view.merged) catalogs[domain] = view.merged[domain]
+    var links = {}
+    for (var child in view.parents) links[child] = view.parents[child]
+    return { version: 1, catalogs: catalogs, links: links }
+  }
+
+  function loadSnapshot(snap, ownerId) {
+    if (!snap || typeof snap !== "object" || snap.version !== 1) return false
+    // Writing the cache re-triggers the FileView that loads it. Without this
+    // a pack's own registration would come straight back in as a cache owner
+    // that outlives it.
+    if (liveOwnerSeen && (ownerId || CACHE_OWNER) === CACHE_OWNER) return false
+    setCatalogs(ownerId || CACHE_OWNER, snap.catalogs, { links: snap.links, precedence: 1000 })
+    return true
+  }
+
+  return {
+    setCatalogs: setCatalogs,
+    clearOwner: clearOwner,
+    lookup: lookup,
+    chain: chain,
+    translate: translate,
+    translatePlural: translatePlural,
+    snapshot: snapshot,
+    loadSnapshot: loadSnapshot,
+    domains: function() { var out = []; for (var d in state.merged) out.push(d); return out },
+    owners: function() { var out = []; for (var o in owners) out.push(o); return out },
+    revision: function() { return state.revision }
+  }
+}
+
+if (typeof module !== "undefined") module.exports = {
+  CONTEXT_SEPARATOR: CONTEXT_SEPARATOR,
+  normalizeLocale: normalizeLocale,
+  localeCandidates: localeCandidates,
+  interpolate: interpolate,
+  contextKey: contextKey,
+  parsePluralForms: parsePluralForms,
+  sanitizeCatalog: sanitizeCatalog,
+  createRegistry: createRegistry
+}

--- a/shell/Commons/qmldir
+++ b/shell/Commons/qmldir
@@ -1,5 +1,6 @@
 module qs.Commons
 singleton Border 1.0 Border.qml
 singleton Color 1.0 Color.qml
+singleton I18n 1.0 I18n.qml
 singleton Style 1.0 Style.qml
 singleton Util 1.0 Util.qml

--- a/test/shell.d/i18n-bash-test.sh
+++ b/test/shell.d/i18n-bash-test.sh
@@ -42,6 +42,21 @@ cat >"$tmp/omarchy/i18n/pl.json" <<'JSON'
 }
 JSON
 
+# A rule the whitelist admits but bash cannot parse. Evaluated in the
+# caller's shell it would exit a set -e script before || could catch it.
+cat >"$tmp/omarchy/i18n/yy.json" <<'JSON'
+{
+  "version": 1,
+  "catalogs": {
+    "omarchy.cli": {
+      "": { "plural-forms": "nplurals=2; plural=(n ? );" },
+      "%1 item": ["one", "many"]
+    }
+  },
+  "links": {}
+}
+JSON
+
 # A plural rule is evaluated with bash arithmetic, which will run a command
 # substitution hidden in an array subscript. The helper must refuse it.
 cat >"$tmp/omarchy/i18n/xx.json" <<JSON
@@ -84,6 +99,11 @@ check "plural form other" "5 paquets" "$(omarchy_tn 5 "%1 package" "%1 packages"
 check "an ampersand in a translation is literal" "A & B" "$(omarchy_t "Ampersand")"
 check "%10 is not %1 followed by 0" "j a" "$(omarchy_i18n_interpolate "%10 %1" a b c d e f g h i j)"
 check "an argument containing a placeholder is not re-expanded" "say %2 in 5 min" "$(omarchy_i18n_interpolate "%1 in %2 min" "say %2" 5)"
+check "an inserted argument is never re-scanned, whatever the order" "say %1 a" "$(omarchy_i18n_interpolate "%2 %1" a "say %1")"
+check "a bare percent and %0 are literal" "100% %0 a" "$(omarchy_i18n_interpolate "100% %0 %1" a)"
+check "a non-numeric count is treated as zero" "many" "$(omarchy_tn "a[\$(touch $tmp/pwned2)]" "one" "many")"
+[[ -e $tmp/pwned2 ]] && fail "a hostile count must not run commands"
+pass "a hostile count does not run commands"
 
 LANG=pl_PL.UTF-8
 check "a three-form plural rule is evaluated" "5 plików" "$(omarchy_tn 5 "%1 file" "%1 files" 5)"
@@ -93,6 +113,10 @@ LANG=xx_XX.UTF-8
 check "a hostile plural rule falls back to English behaviour" "many" "$(omarchy_tn 3 "%1 item" "%1 items")"
 [[ -e $tmp/pwned ]] && fail "a hostile plural rule must not run commands"
 pass "a hostile plural rule does not run commands"
+
+LANG=yy_YY.UTF-8
+out=$(set -e; source "$helper"; omarchy_tn 3 "%1 item" "%1 items"; echo "|ok")
+check "a malformed plural rule does not exit a set -e caller" "many|ok" "$out"
 
 LANG=de_DE.UTF-8
 check "a locale with no cache returns the source" "Update now?" "$(omarchy_t "Update now?")"

--- a/test/shell.d/i18n-bash-test.sh
+++ b/test/shell.d/i18n-bash-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+helper="$ROOT/default/bash/i18n"
+bash -n "$helper" || fail "default/bash/i18n parses"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/omarchy/i18n"
+
+cat >"$tmp/omarchy/i18n/ca.json" <<'JSON'
+{
+  "version": 1,
+  "catalogs": {
+    "omarchy.cli": {
+      "": { "plural-forms": "nplurals=2; plural=(n != 1);" },
+      "Update now?": "Actualitzar ara?",
+      "Removing %1": "Suprimint %1",
+      "%1 package": ["%1 paquet", "%1 paquets"],
+      "Ampersand": "A & B"
+    }
+  },
+  "links": {}
+}
+JSON
+
+cat >"$tmp/omarchy/i18n/pl.json" <<'JSON'
+{
+  "version": 1,
+  "catalogs": {
+    "omarchy.cli": {
+      "": { "plural-forms": "nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);" },
+      "%1 file": ["%1 plik", "%1 pliki", "%1 plików"]
+    }
+  },
+  "links": {}
+}
+JSON
+
+# A plural rule is evaluated with bash arithmetic, which will run a command
+# substitution hidden in an array subscript. The helper must refuse it.
+cat >"$tmp/omarchy/i18n/xx.json" <<JSON
+{
+  "version": 1,
+  "catalogs": {
+    "omarchy.cli": {
+      "": { "plural-forms": "nplurals=2; plural=(a[\$(touch $tmp/pwned)]);" },
+      "%1 item": ["one", "many"]
+    }
+  },
+  "links": {}
+}
+JSON
+
+export XDG_CACHE_HOME="$tmp"
+unset LANGUAGE LC_ALL LC_MESSAGES
+
+check() {
+  local description="$1" expected="$2" actual="$3"
+  if [[ $expected == "$actual" ]]; then
+    pass "$description"
+  else
+    fail "$description" "expected: $expected"$'\n'"actual:   $actual"
+  fi
+}
+
+LANG=en_US.UTF-8
+source "$helper"
+check "English needs no cache and returns the source" "Update now?" "$(omarchy_t "Update now?")"
+check "English interpolates arguments" "Removing vim" "$(omarchy_t "Removing %1" vim)"
+check "English plural follows n != 1" "3 packages" "$(omarchy_tn 3 "%1 package" "%1 packages" 3)"
+
+LANG=ca_ES.UTF-8
+check "a translated string is returned" "Actualitzar ara?" "$(omarchy_t "Update now?")"
+check "arguments are interpolated into the translation" "Suprimint vim" "$(omarchy_t "Removing %1" vim)"
+check "a missing key falls back to the source" "Not in catalog" "$(omarchy_t "Not in catalog")"
+check "plural form one" "1 paquet" "$(omarchy_tn 1 "%1 package" "%1 packages" 1)"
+check "plural form other" "5 paquets" "$(omarchy_tn 5 "%1 package" "%1 packages" 5)"
+check "an ampersand in a translation is literal" "A & B" "$(omarchy_t "Ampersand")"
+check "%10 is not %1 followed by 0" "j a" "$(omarchy_i18n_interpolate "%10 %1" a b c d e f g h i j)"
+check "an argument containing a placeholder is not re-expanded" "say %2 in 5 min" "$(omarchy_i18n_interpolate "%1 in %2 min" "say %2" 5)"
+
+LANG=pl_PL.UTF-8
+check "a three-form plural rule is evaluated" "5 plików" "$(omarchy_tn 5 "%1 file" "%1 files" 5)"
+check "a three-form plural rule picks the middle form" "22 pliki" "$(omarchy_tn 22 "%1 file" "%1 files" 22)"
+
+LANG=xx_XX.UTF-8
+check "a hostile plural rule falls back to English behaviour" "many" "$(omarchy_tn 3 "%1 item" "%1 items")"
+[[ -e $tmp/pwned ]] && fail "a hostile plural rule must not run commands"
+pass "a hostile plural rule does not run commands"
+
+LANG=de_DE.UTF-8
+check "a locale with no cache returns the source" "Update now?" "$(omarchy_t "Update now?")"
+
+out=$(set -eu; source "$helper"; LANG=ca_ES.UTF-8 omarchy_t "Update now?"; echo "|ok")
+check "the helper survives set -eu" "Actualitzar ara?|ok" "$out"

--- a/test/shell.d/i18n-bash-test.sh
+++ b/test/shell.d/i18n-bash-test.sh
@@ -118,6 +118,11 @@ LANG=yy_YY.UTF-8
 out=$(set -e; source "$helper"; omarchy_tn 3 "%1 item" "%1 items"; echo "|ok")
 check "a malformed plural rule does not exit a set -e caller" "many|ok" "$out"
 
+printf 'not json' >"$tmp/omarchy/i18n/zz.json"
+LANG=zz_ZZ.UTF-8
+out=$(set -e; source "$helper"; omarchy_t "Update now?"; omarchy_tn 3 "%1 item" "%1 items" 3; echo "|ok")
+check "a malformed cache gives English and does not exit a set -e caller" "Update now?3 items|ok" "$out"
+
 LANG=de_DE.UTF-8
 check "a locale with no cache returns the source" "Update now?" "$(omarchy_t "Update now?")"
 

--- a/test/shell.d/i18n-test.sh
+++ b/test/shell.d/i18n-test.sh
@@ -66,6 +66,20 @@ assertEqual(mixed.translate('Save', { domain: 'd' }), 'Zapisz', 'a fallback loca
 assertEqual(mixed.translatePlural(5, '%1 file', '%1 files', { domain: 'd', args: [5] }), '5 files', 'a fallback locale with another plural rule does not lend plural entries')
 assertEqual(mixed.snapshot().catalogs.d['%1 file'], undefined, 'the snapshot Bash reads stays consistent with its one header per domain')
 
+// Names that collide with Object.prototype: PluginRegistry accepts them as ids
+// (built with JSON.parse, as a real catalog is: in an object literal
+// `__proto__:` would set the prototype instead of creating a key)
+const proto = I18n.createRegistry()
+proto.setCatalogs('constructor',
+  JSON.parse('{"constructor": {"toString": "cadena", "__proto__": "proto", "Open": "Obre"}}'),
+  { links: JSON.parse('{"__proto__": "constructor"}') })
+assertEqual(proto.translate('Open', { domain: 'constructor' }), 'Obre', 'a plugin id of "constructor" gets a real catalog')
+assertEqual(proto.translate('toString', { domain: 'constructor' }), 'cadena', 'a source string of "toString" is an ordinary key')
+assertEqual(proto.translate('__proto__', { domain: 'constructor' }), 'proto', 'a source string of "__proto__" is an ordinary key')
+assertEqual(Object.prototype.toString.call({}), '[object Object]', 'Object.prototype is untouched')
+assertEqual(typeof ({}).constructor, 'function', 'Object.prototype.constructor is untouched')
+assertDeepEqual(proto.domains(), ['constructor'], 'the domain list is exactly what was registered')
+
 // Clone chain: own domain, then clonedFrom, then global
 const clone = I18n.createRegistry()
 clone.setCatalogs('lang.ca', {

--- a/test/shell.d/i18n-test.sh
+++ b/test/shell.d/i18n-test.sh
@@ -57,6 +57,15 @@ assertEqual(reg.translate('Play', { domain: 'omarchy.menu', context: 'verb' }), 
 assertEqual(reg.translate('Play', { domain: 'omarchy.menu' }), 'Play', 'a context-free lookup does not see the contextual entry')
 assertEqual(reg.translatePlural(4, '%1 city', '%1 cities', { domain: 'omarchy.menu', args: [4] }), '4 ciutats', 'plurals use the rule from the catalog the key was found in')
 
+// A fallback locale with a different plural rule cannot lend plural entries
+const mixed = I18n.createRegistry()
+mixed.setCatalogs('lang.pl', { d: { '': { 'plural-forms': 'nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);' },
+  '%1 file': ['%1 plik', '%1 pliki', '%1 plików'], Save: 'Zapisz' } }, { precedence: 1 })
+mixed.setCatalogs('lang.ca', { d: Object.assign({}, en, { Open: 'Obre' }) }, { precedence: 0 })
+assertEqual(mixed.translate('Save', { domain: 'd' }), 'Zapisz', 'a fallback locale lends singular entries the preferred one lacks')
+assertEqual(mixed.translatePlural(5, '%1 file', '%1 files', { domain: 'd', args: [5] }), '5 files', 'a fallback locale with another plural rule does not lend plural entries')
+assertEqual(mixed.snapshot().catalogs.d['%1 file'], undefined, 'the snapshot Bash reads stays consistent with its one header per domain')
+
 // Clone chain: own domain, then clonedFrom, then global
 const clone = I18n.createRegistry()
 clone.setCatalogs('lang.ca', {

--- a/test/shell.d/i18n-test.sh
+++ b/test/shell.d/i18n-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# The primitive must be a no-op on a stock tree: nothing calls it yet.
+if matches=$(rg -n 'I18n\.(tr|trc|ntr|domain|noop)\(|\b_\.(tr|trc|ntr)\(' "$ROOT/shell" -g '*.qml' -g '*.js' -g '!I18n.qml' -g '!I18nModel.js'); then
+  fail "no shell code calls I18n yet (this change is mechanism only)" "$matches"
+fi
+pass "no shell code calls I18n yet"
+
+run_node_test <<'JS'
+const I18n = requireFromRoot('shell/Commons/I18nModel.js')
+
+// Locale selection
+assertEqual(I18n.normalizeLocale('ca_ES.UTF-8'), 'ca_ES', 'locale normalization strips the encoding')
+assertEqual(I18n.normalizeLocale('es-ar@latin'), 'es_AR', 'locale normalization canonicalizes separators')
+assertEqual(I18n.normalizeLocale('C'), '', 'C locale means no translation')
+assertDeepEqual(I18n.localeCandidates({ LANG: 'ca_ES.UTF-8' }), ['ca_ES', 'ca'], 'regional locale falls back to its language')
+assertDeepEqual(I18n.localeCandidates({ LANG: 'de_DE', LC_MESSAGES: 'fr_FR' }), ['fr_FR', 'fr'], 'LC_MESSAGES beats LANG')
+assertDeepEqual(I18n.localeCandidates({ LANGUAGE: 'ca:es', LANG: 'de_DE' }), ['ca', 'es'], 'LANGUAGE is an ordered preference list')
+assertDeepEqual(I18n.localeCandidates({ LANGUAGE: 'fr:en:es' }), ['fr', 'en'], 'nothing after English can apply')
+
+// Interpolation
+assertEqual(I18n.interpolate('%1 of %2', ['3', 7]), '3 of 7', 'placeholders are filled by position')
+assertEqual(I18n.interpolate('%10 %1', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']), 'j a', '%10 is not %1 followed by 0')
+assertEqual(I18n.interpolate('%1 in %2 min', ['say %2', 5]), 'say %2 in 5 min', 'an argument containing a placeholder is inserted verbatim')
+assertEqual(I18n.interpolate('%1 and %3', ['a']), 'a and %3', 'unmatched placeholders are preserved')
+
+// Plural rules come from the catalog header and are evaluated by a parser, never eval
+const pl = I18n.parsePluralForms('nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);')
+assertDeepEqual([1, 2, 5, 22, 102].map(pl.plural), [0, 1, 2, 1, 1], 'Polish plural rule selects all three forms')
+const ar = I18n.parsePluralForms('nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);')
+assertDeepEqual([0, 1, 2, 3, 11, 100].map(ar.plural), [0, 1, 2, 3, 4, 5], 'Arabic plural rule selects all six forms')
+assertEqual(I18n.parsePluralForms('nplurals=2; plural=(process.exit(1));'), null, 'a plural rule that is not a C expression is rejected, not evaluated')
+assertEqual(I18n.parsePluralForms('nplurals=2; plural=(n ? );'), null, 'a malformed plural rule is rejected whole')
+
+// Resolution: nothing registered, bound, unbound, context
+const empty = I18n.createRegistry()
+assertEqual(empty.translate('Connect'), 'Connect', 'with nothing registered a lookup returns its source')
+assertEqual(empty.translatePlural(3, '%1 city', '%1 cities', { args: [3] }), '3 cities', 'with nothing registered plurals follow English')
+
+const en = { '': { 'plural-forms': 'nplurals=2; plural=(n != 1);' } }
+const reg = I18n.createRegistry()
+reg.setCatalogs('lang.ca', {
+  'omarchy.shell': Object.assign({}, en, { Cancel: 'Cancel·la', Open: 'Obre' }),
+  'omarchy.menu': Object.assign({}, en, { Connect: 'Connecta', Open: 'Obre', '%1 city': ['%1 ciutat', '%1 ciutats'], 'verb\u0004Play': 'Reprodueix' }),
+  'dev.foo.weather': Object.assign({}, en, { Open: 'Obert' }),
+})
+assertEqual(reg.translate('Connect', { domain: 'omarchy.menu' }), 'Connecta', 'a bound caller resolves in its own domain')
+assertEqual(reg.translate('Open', { domain: 'omarchy.menu' }), 'Obre', 'two bound plugins can translate one word differently (menu)')
+assertEqual(reg.translate('Open', { domain: 'dev.foo.weather' }), 'Obert', 'two bound plugins can translate one word differently (weather)')
+assertEqual(reg.translate('Cancel', { domain: 'dev.foo.weather' }), 'Cancel·la', 'a bound caller falls through to the global merge')
+assertEqual(reg.translate('Connect'), 'Connecta', 'an unbound caller resolves through the global merge')
+assertEqual(reg.translate('Play', { domain: 'omarchy.menu', context: 'verb' }), 'Reprodueix', 'msgctxt separates entries')
+assertEqual(reg.translate('Play', { domain: 'omarchy.menu' }), 'Play', 'a context-free lookup does not see the contextual entry')
+assertEqual(reg.translatePlural(4, '%1 city', '%1 cities', { domain: 'omarchy.menu', args: [4] }), '4 ciutats', 'plurals use the rule from the catalog the key was found in')
+
+// Clone chain: own domain, then clonedFrom, then global
+const clone = I18n.createRegistry()
+clone.setCatalogs('lang.ca', {
+  'omarchy.menu': { Connect: 'Connecta', Open: 'Obre', Refresh: 'Actualitza' },
+  'my.menu': { Open: 'Obre-ho', Frobnicate: 'Frobnica' },
+}, { links: { 'my.menu': 'omarchy.menu' } })
+assertEqual(clone.translate('Frobnicate', { domain: 'my.menu' }), 'Frobnica', 'a clone translates strings it added')
+assertEqual(clone.translate('Refresh', { domain: 'my.menu' }), 'Actualitza', 'a clone inherits what it did not change')
+assertEqual(clone.translate('Open', { domain: 'my.menu' }), 'Obre-ho', 'a clone overrides one upstream translation')
+assertEqual(clone.translate('Open', { domain: 'omarchy.menu' }), 'Obre', 'the original is unaffected by the clone')
+
+// Owners are replaced atomically and removed cleanly
+const owners = I18n.createRegistry()
+owners.setCatalogs('p', { d: { a: '1', b: '2' } })
+owners.setCatalogs('p', { d: { a: '9' } })
+assertEqual(owners.translate('b', { domain: 'd' }), 'b', 're-registering an owner replaces its whole set')
+assertEqual(owners.clearOwner('p'), true, 'an owner can be cleared')
+assertEqual(owners.translate('a', { domain: 'd' }), 'a', 'clearing an owner removes its catalogs')
+
+// Startup cache: a stand-in that never outlives a live pack
+const first = I18n.createRegistry()
+first.setCatalogs('lang.ca', { 'omarchy.menu': { Refresh: 'Actualitza' } })
+const login2 = I18n.createRegistry()
+assertEqual(login2.loadSnapshot(first.snapshot()), true, 'the cache loads at the next start')
+assertEqual(login2.translate('Refresh', { domain: 'omarchy.menu' }), 'Actualitza', 'the cache answers before packs register')
+login2.setCatalogs('lang.ca', { 'omarchy.menu': { Refresh: 'Refresca' } })
+assertEqual(login2.translate('Refresh', { domain: 'omarchy.menu' }), 'Refresca', 'a live pack overrides the cache')
+login2.clearOwner('lang.ca')
+assertEqual(login2.translate('Refresh', { domain: 'omarchy.menu' }), 'Refresh', 'disabling the pack reverts to English, the cache does not linger')
+assertDeepEqual(login2.snapshot().catalogs, {}, 'the written cache never contains the cache itself')
+assertEqual(login2.loadSnapshot(first.snapshot()), false, 'the cache does not reload over live data')
+JS


### PR DESCRIPTION
## Summary

The mechanism for translating the shell, and nothing else: a `qs.Commons.I18n` singleton, its Qt-free model, and a Bash counterpart for the interactive `bin/` scripts. No call sites change and no catalogs ship. With nothing registered every lookup returns its source string, and `test/shell.d/i18n-test.sh` asserts that nothing in `shell/` calls it — so a stock install renders exactly as before.

This is the first step of the design at https://github.com/xavivars/omal10n-poc, written in answer to #6360 ("need a comprehensive solution to full OS translation"). It builds on #7434 — same `I18n` singleton and `%1` interpolation — split so the primitive can land alone and the call-site conversions follow plugin by plugin, each small and revertible. Related: #7284.

## Why a custom primitive

Quickshell builds a bare `QQmlEngine` with no `QTranslator`, so Qt's `qsTr`/`.qm` pipeline has no runtime to attach to. `qsTr()` compiles here and silently returns the source string forever.

## What the design settles

- **Catalogs are keyed by domain** — a plugin id, or `omarchy.shell` / `omarchy.cli` for code without one. A bound lookup walks the caller's domain → the domain it was cloned from → the global merge → English, per key. A plugin copied with `omarchy plugin clone` resolves its own catalog first and inherits the rest.
- **Language packs are plugins**, registering catalogs as owners. That reuses install, update, enable/disable, and the plugins UI. Translations would live in a separate community repo as gettext PO; core never reviews a translation.
- **Plural rules come from the catalog header** and are evaluated by a small parser, never `eval`, so a catalog cannot run code. The Bash side whitelists the rule before arithmetic evaluation for the same reason.
- **A startup cache** of the merged catalogs is read synchronously so the first frame is already translated. It is a stand-in that is dropped the moment a live pack registers; disabling a pack reverts the interface immediately and stays reverted after a restart.

`docs/i18n.md` has the full contract.

## What it looks like once call sites exist

Not in this PR. The prototype repo carries the `omarchy.menu` and clock conversions, a Catalan pack, and the extraction/build tooling, all run on a real session — screenshots there: the menu, the confirm dialog, `omarchy-update-confirm` and the clock in Catalan, with a cold boot showing no flash of English.

## Testing

- `bash test/shell.d/i18n-test.sh` — 39 assertions: the no-op guard, locale rules, interpolation, plural rules including a hostile one, bound/unbound/context resolution, the clone chain, owner replacement, and the cache stand-in rule.
- `bash test/shell.d/i18n-bash-test.sh` — 17 assertions against fixture caches, including a catalog whose plural rule tries to run a command.
- `git diff --stat`: 1,044 insertions, 0 deletions.

## Two questions

1. Is "primitive in core, language packs as plugins" the right split in principle?
2. If so, is one PR per plugin the right shape for the call-site conversions?

I'm happy to own the community side — the translation repo, its tooling, and eventually a Weblate.
