### PR TITLE
Fix local plugin reloads

### DIFF
--- a/shell/scripts/watch-local-plugins
+++ b/shell/scripts/watch-local-plugins
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-plugins_dir=$(realpath -e -- "$1")
+plugins_dir=$1
+canonical_plugins_dir=$(realpath -e -- "$plugins_dir")
 watch_paths=("$plugins_dir")
 
 # inotifywait does not traverse a symlink it finds below a recursive watch.
@@ -11,7 +12,7 @@ watch_paths=("$plugins_dir")
 for plugin_dir in "$plugins_dir"/*; do
   [[ -L $plugin_dir && -d $plugin_dir ]] || continue
   target=$(realpath -e -- "$plugin_dir") || continue
-  [[ $target == "$plugins_dir" || $target == "$plugins_dir"/* ]] && continue
+  [[ $target == "$canonical_plugins_dir" || $target == "$canonical_plugins_dir"/* ]] && continue
   watch_paths+=("$plugin_dir")
 done
 

--- a/shell/scripts/watch-local-plugins
+++ b/shell/scripts/watch-local-plugins
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+plugins_dir=$(realpath -e -- "$1")
+watch_paths=("$plugins_dir")
+
+# inotifywait does not traverse a symlink it finds below a recursive watch.
+# Passing a direct plugin symlink explicitly makes it report changes through
+# the logical plugin path, which the registry already knows how to route.
+for plugin_dir in "$plugins_dir"/*; do
+  [[ -L $plugin_dir && -d $plugin_dir ]] || continue
+  target=$(realpath -e -- "$plugin_dir") || continue
+  [[ $target == "$plugins_dir" || $target == "$plugins_dir"/* ]] && continue
+  watch_paths+=("$plugin_dir")
+done
+
+exec inotifywait -m -r -q \
+  -e close_write,create,delete,move \
+  --format '%w%f' \
+  "${watch_paths[@]}"

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -25,6 +25,7 @@ QtObject {
   property int registryRevision: 0
   property bool scanning: false
   property string lastEnableError: ""
+  readonly property string localPluginWatcherPath: Quickshell.env("OMARCHY_PATH") + "/shell/scripts/watch-local-plugins"
 
   signal pluginsChanged()
   signal scanFinished()
@@ -634,21 +635,12 @@ QtObject {
   }
 
   property Process localPluginWatcher: Process {
-    command: [
-      "inotifywait",
-      "-m",
-      "-r",
-      "-q",
-      "-e",
-      "close_write,create,delete,move",
-      "--format",
-      "%w%f",
-      registry.pluginsDir
-    ]
+    command: [registry.localPluginWatcherPath, registry.pluginsDir]
     stdout: SplitParser {
       onRead: function(path) {
         var pluginId = registry.localPluginIdForPath(path)
         if (pluginId) registry.localPluginChanged(pluginId)
+        if (registry.localPluginRootChanged(path)) registry.restartLocalPluginWatcher()
       }
     }
     onExited: localPluginWatcherRestart.restart()
@@ -657,6 +649,11 @@ QtObject {
   property Timer localPluginWatcherRestart: Timer {
     interval: 1000
     onTriggered: localPluginWatcher.running = true
+  }
+
+  function restartLocalPluginWatcher() {
+    if (localPluginWatcher.running) localPluginWatcher.running = false
+    localPluginWatcherRestart.restart()
   }
 
   function rescan() {
@@ -710,6 +707,15 @@ QtObject {
 
     var slash = relative.indexOf("/")
     return slash === -1 ? relative : relative.slice(0, slash)
+  }
+
+  function localPluginRootChanged(filePath) {
+    var base = pluginsDir.replace(/\/$/, "") + "/"
+    var path = String(filePath || "").trim()
+    if (path.indexOf(base) !== 0) return false
+
+    var relative = path.slice(base.length)
+    return relative.length > 0 && relative.charAt(0) !== "." && relative.indexOf("/") === -1
   }
 
   Component.onCompleted: ensureUserDir()

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -54,9 +54,7 @@ ShellRoot {
 
   property var defaultsConfig: builtinShellConfig
   property var shellConfig: builtinShellConfig
-  property bool pluginReloading: false
-  property bool pluginReloadPending: false
-
+  property var hyprlandPluginState: ({ enabled: [] })
   Timer {
     id: localPluginReloadTimer
     interval: 150
@@ -246,7 +244,7 @@ ShellRoot {
   Loader {
     id: pluginBarLoader
 
-    active: !shell.pluginReloading && shell.activeBarId !== shell.defaultBarId && shell.activeBarSourceUrl !== ""
+    active: shell.activeBarId !== shell.defaultBarId && shell.activeBarSourceUrl !== ""
     source: shell.activeBarId !== shell.defaultBarId ? shell.activeBarSourceUrl : ""
     asynchronous: true
     onLoaded: shell.configureBar(item, shell.activeBarManifest)
@@ -345,17 +343,9 @@ ShellRoot {
     }
   }
 
-  function unloadPluginServices() {
-    for (var existingId in _services) {
-      var inst = _services[existingId]
-      if (inst && typeof inst.destroy === "function") inst.destroy()
-    }
-    _services = ({})
-  }
-
   Connections {
     target: shell.pluginRegistry
-    function onPluginsChanged() { if (!shell.pluginReloading) shell._syncServices() }
+    function onPluginsChanged() { shell._syncServices() }
   }
 
   // Writes inline settings to a bar layout entry or top-level plugin entry in
@@ -530,14 +520,6 @@ ShellRoot {
     panelLoaders = next
   }
 
-  function unloadPanels() {
-    for (var id in panelLoaders) hide(id)
-    panelEntries = []
-    panelLoaders = ({})
-    pendingPayloads = ({})
-    openPanelIds = ({})
-  }
-
   function deliverIfLoaded(pluginId) {
     var loader = panelLoaders[pluginId]
     if (!loader || !loader.item) return
@@ -604,7 +586,7 @@ ShellRoot {
 
   Connections {
     target: shell.pluginRegistry
-    function onPluginsChanged() { if (!shell.pluginReloading) shell.panelEntries = shell.computePanelEntries() }
+    function onPluginsChanged() { shell.panelEntries = shell.computePanelEntries() }
   }
 
   Instantiator {
@@ -661,7 +643,7 @@ ShellRoot {
   // widgets use the same first-party manifest contract as third-party widgets.
   Connections {
     target: shell.pluginRegistry
-    function onPluginsChanged() { if (!shell.pluginReloading) shell.syncPluginWidgets() }
+    function onPluginsChanged() { shell.syncPluginWidgets() }
   }
 
   property var pluginWidgetComponents: ({})
@@ -731,31 +713,8 @@ ShellRoot {
     }
   }
 
-  function unloadPluginWidgets() {
-    for (var id in pluginWidgetComponents) shell.barWidgetRegistry.unregister(id)
-    pluginWidgetComponents = ({})
-  }
-
   function reloadPlugins() {
-    if (shell.pluginReloading || shell.pluginRegistry.scanning) {
-      shell.pluginReloadPending = true
-      return
-    }
-    shell.pluginReloading = true
-    shell.unloadPanels()
-    shell.unloadPluginServices()
-    shell.unloadPluginWidgets()
-    Qt.callLater(shell.finishPluginReload)
-  }
-
-  function finishPluginReload() {
-    if (!shell.pluginReloading) return
-    if (shell.pluginRegistry.scanning) {
-      shell.pluginReloadPending = true
-      return
-    }
-    if (typeof Qt.clearComponentCache === "function") Qt.clearComponentCache()
-    shell.pluginRegistry.rescan()
+    Quickshell.reload(false)
   }
 
   Connections {
@@ -765,13 +724,6 @@ ShellRoot {
       localPluginReloadTimer.restart()
     }
     function onScanFinished() {
-      if (shell.pluginReloadPending) {
-        shell.pluginReloadPending = false
-        shell.pluginReloading = false
-        Qt.callLater(shell.reloadPlugins)
-        return
-      }
-      shell.pluginReloading = false
       shell._syncServices()
       shell.panelEntries = shell.computePanelEntries()
       shell.syncPluginWidgets()

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -54,7 +54,6 @@ ShellRoot {
 
   property var defaultsConfig: builtinShellConfig
   property var shellConfig: builtinShellConfig
-  property var hyprlandPluginState: ({ enabled: [] })
   Timer {
     id: localPluginReloadTimer
     interval: 150

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -441,6 +441,9 @@ ShellRoot {
     root.assertEqual(registry.localPluginIdForPath(registry.pluginsDir + "/acme.clock/BarWidget.qml"), "acme.clock", "installed plugin changes are watched")
     root.assertEqual(registry.localPluginIdForPath(cloneBase + "/.git/index"), "", "plugin git metadata is ignored")
     root.assertEqual(registry.localPluginIdForPath(registry.pluginsDir + "/.clone.abc123/manifest.json"), "", "hidden staging and backup dirs are ignored")
+    root.assertTrue(registry.localPluginRootChanged(registry.pluginsDir + "/acme.clock"), "plugin root changes rebuild the watcher")
+    root.assertTrue(!registry.localPluginRootChanged(registry.pluginsDir + "/acme.clock/BarWidget.qml"), "plugin file changes keep the watcher running")
+    root.assertTrue(!registry.localPluginRootChanged(registry.pluginsDir + "/.clone.abc123"), "hidden staging changes keep the watcher running")
 
     root.assertTrue(changeCount > 0, "registry emits change notifications")
     writeResult()

--- a/test/shell.d/local-plugin-watcher-test.sh
+++ b/test/shell.d/local-plugin-watcher-test.sh
@@ -29,15 +29,12 @@ ln -s "$linked_source" "$plugins_dir/acme.linked"
 
 "$ROOT/shell/scripts/watch-local-plugins" "$plugins_dir" >"$events" 2>&1 &
 WATCHER_PID=$!
-sleep 0.1
-
-printf 'updated\n' >"$linked_source/Overlay.qml"
-
 for _ in {1..30}; do
-  grep -F "$plugins_dir/acme.linked/Overlay.qml" "$events" >/dev/null 2>&1 && break
+  printf 'updated %s\n' "$_" >"$linked_source/Overlay.qml"
   sleep 0.1
+  grep -Fx -- "$plugins_dir/acme.linked/Overlay.qml" "$events" >/dev/null 2>&1 && break
 done
-grep -F "$plugins_dir/acme.linked/Overlay.qml" "$events" >/dev/null ||
+grep -Fx -- "$plugins_dir/acme.linked/Overlay.qml" "$events" >/dev/null ||
   fail "linked plugin target writes reach the local plugin watcher"
 pass "linked plugin target writes reach the local plugin watcher"
 
@@ -46,9 +43,9 @@ ln -s "$TMPDIR/replacement-source" "$plugins_dir/.acme.linked-replacement"
 mv -T "$plugins_dir/.acme.linked-replacement" "$plugins_dir/acme.linked"
 
 for _ in {1..30}; do
-  grep -F "$plugins_dir/acme.linked" "$events" >/dev/null 2>&1 && break
+  grep -Fx -- "$plugins_dir/acme.linked" "$events" >/dev/null 2>&1 && break
   sleep 0.1
 done
-grep -F "$plugins_dir/acme.linked" "$events" >/dev/null ||
+grep -Fx -- "$plugins_dir/acme.linked" "$events" >/dev/null ||
   fail "linked plugin replacement reaches the local plugin watcher"
 pass "linked plugin replacement reaches the local plugin watcher"

--- a/test/shell.d/local-plugin-watcher-test.sh
+++ b/test/shell.d/local-plugin-watcher-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+WATCHER_PID=""
+
+cleanup() {
+  if [[ -n $WATCHER_PID ]] && kill -0 "$WATCHER_PID" 2>/dev/null; then
+    kill "$WATCHER_PID" 2>/dev/null || true
+    wait "$WATCHER_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_command inotifywait
+
+TMPDIR=$(mktemp -d)
+plugins_dir="$TMPDIR/plugins"
+linked_source="$TMPDIR/linked-source"
+events="$TMPDIR/events"
+mkdir -p "$plugins_dir" "$linked_source"
+ln -s "$linked_source" "$plugins_dir/acme.linked"
+
+"$ROOT/shell/scripts/watch-local-plugins" "$plugins_dir" >"$events" 2>&1 &
+WATCHER_PID=$!
+sleep 0.1
+
+printf 'updated\n' >"$linked_source/Overlay.qml"
+
+for _ in {1..30}; do
+  grep -F "$plugins_dir/acme.linked/Overlay.qml" "$events" >/dev/null 2>&1 && break
+  sleep 0.1
+done
+grep -F "$plugins_dir/acme.linked/Overlay.qml" "$events" >/dev/null ||
+  fail "linked plugin target writes reach the local plugin watcher"
+pass "linked plugin target writes reach the local plugin watcher"
+
+mkdir -p "$TMPDIR/replacement-source"
+ln -s "$TMPDIR/replacement-source" "$plugins_dir/.acme.linked-replacement"
+mv -T "$plugins_dir/.acme.linked-replacement" "$plugins_dir/acme.linked"
+
+for _ in {1..30}; do
+  grep -F "$plugins_dir/acme.linked" "$events" >/dev/null 2>&1 && break
+  sleep 0.1
+done
+grep -F "$plugins_dir/acme.linked" "$events" >/dev/null ||
+  fail "linked plugin replacement reaches the local plugin watcher"
+pass "linked plugin replacement reaches the local plugin watcher"

--- a/test/shell.d/local-plugin-watcher-test.sh
+++ b/test/shell.d/local-plugin-watcher-test.sh
@@ -21,10 +21,12 @@ trap cleanup EXIT
 require_command inotifywait
 
 TMPDIR=$(mktemp -d)
+plugins_root="$TMPDIR/plugins-root"
 plugins_dir="$TMPDIR/plugins"
 linked_source="$TMPDIR/linked-source"
 events="$TMPDIR/events"
-mkdir -p "$plugins_dir" "$linked_source"
+mkdir -p "$plugins_root" "$linked_source"
+ln -s "$plugins_root" "$plugins_dir"
 ln -s "$linked_source" "$plugins_dir/acme.linked"
 
 "$ROOT/shell/scripts/watch-local-plugins" "$plugins_dir" >"$events" 2>&1 &

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -421,21 +421,24 @@ pass "direct panel IPC opens and closes default panels"
 
 # Each widget registers its IPC handler once per bar, and the bar is
 # instantiated once per screen, so Quickshell reports one collision per screen
-# past the first. Anything beyond that is two instances on the same screen —
-# the shape duplicate component loads produced, where a sync pass that ran
-# while a widget's asynchronous load was still in flight started a second one.
-# Checked before the reload below, which rebuilds widgets by design.
+# past the first for each loaded engine generation. Anything beyond that is two
+# instances on the same screen — the shape duplicate component loads produced,
+# where a sync pass that ran while a widget's asynchronous load was still in
+# flight started a second one.
 screens=$(hyprctl -j monitors 2>/dev/null | jq 'length' 2>/dev/null || true)
 [[ $screens =~ ^[0-9]+$ ]] && (( screens > 0 )) || screens=1
+generations=$(grep -c "Configuration Loaded" "$log" || true)
+(( generations > 0 )) || generations=1
+allowed_collisions=$((generations * (screens - 1)))
 # No matches is the good case, and pipefail would otherwise abort the run.
 worst=$(grep -oE "another handler is registered for target [a-z.-]+" "$log" |
   sort | uniq -c | sort -rn | head -1 | awk '{print $1}' || true)
 worst=${worst:-0}
-if (( worst > screens - 1 )); then
+if (( worst > allowed_collisions )); then
   grep "another handler is registered for target" "$log" | sed 's/^/  /' | head -20 >&2
-  fail_with_log "each widget registers its IPC handler once per screen (saw $worst for $screens screen(s))"
+  fail_with_log "each widget registers its IPC handler once per screen and generation (saw $worst; allowed $allowed_collisions for $screens screen(s) across $generations generation(s))"
 fi
-pass "each widget registers its IPC handler once per screen"
+pass "each widget registers its IPC handler once per screen and generation"
 
 HOME="$test_home" OMARCHY_PATH="$test_root" PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-plugin-disable" omarchy.audio
 

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -236,6 +236,22 @@ done
 [[ $marker == "after" ]] || fail_with_log "plugin rescan reloads imported JavaScript"
 pass "plugin rescan reloads imported JavaScript"
 
+# The rescan above writes through an open descriptor, avoiding its close_write
+# event. A normal edit must instead trigger the local plugin watcher itself.
+printf 'var marker = "watcher"\n' >"$hot_reload_dir/Simulation.js"
+
+marker=""
+for _ in {1..80}; do
+  marker=$(shell_ipc hot-reload marker 2>/dev/null || true)
+  [[ $marker == "watcher" ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while watcher-reloading imported JavaScript"
+  fi
+  sleep 0.1
+done
+[[ $marker == "watcher" ]] || fail_with_log "editing imported JavaScript reloads through the local plugin watcher"
+pass "editing imported JavaScript reloads through the local plugin watcher"
+
 [[ $(shell_ipc shell summon omarchy.emojis "{}") == "ok" ]] ||
   fail_with_log "calls to a cloned source id do not reach its enabled clone"
 shell_ipc_quiet shell hide omarchy.emojis >/dev/null

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -220,7 +220,8 @@ for _ in {1..80}; do
 done
 [[ $marker == "before" ]] || fail_with_log "installed plugin loads imported JavaScript"
 
-printf 'var marker = "after"\n' >"$hot_reload_dir/Simulation.js"
+exec 3>"$hot_reload_dir/Simulation.js"
+printf 'var marker = "after"\n' >&3
 shell_ipc_quiet shell rescanPlugins >/dev/null
 
 marker=""

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -209,6 +209,52 @@ done
   fail_with_log "linked plugin changes reload without an explicit rescan"
 pass "linked plugin changes reload without an explicit rescan"
 
+replacement_linked_plugin_source="$TMPDIR/replacement-linked-plugin"
+mkdir -p "$replacement_linked_plugin_source"
+cat >"$replacement_linked_plugin_source/manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "id": "$linked_plugin_id",
+  "name": "After Linked Replacement",
+  "version": "1.0.0",
+  "kinds": ["overlay"],
+  "entryPoints": {"overlay": "Overlay.qml"}
+}
+JSON
+cp "$linked_plugin_source/Overlay.qml" "$replacement_linked_plugin_source/Overlay.qml"
+ln -s "$replacement_linked_plugin_source" "$test_home/.config/omarchy/plugins/.replacement-linked-plugin"
+mv -T "$test_home/.config/omarchy/plugins/.replacement-linked-plugin" "$linked_plugin_dir"
+
+linked_reload_name=""
+for _ in {1..80}; do
+  linked_reload_name=$(shell_ipc shell listPlugins 2>/dev/null |
+    jq -r --arg id "$linked_plugin_id" '.[] | select(.id == $id) | .name' 2>/dev/null || true)
+  [[ $linked_reload_name == "After Linked Replacement" ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while reloading a replaced linked plugin"
+  fi
+  sleep 0.1
+done
+[[ $linked_reload_name == "After Linked Replacement" ]] ||
+  fail_with_log "replacing a linked plugin reloads its replacement"
+
+jq '.name = "After Replacement Target Write"' "$replacement_linked_plugin_source/manifest.json" >"$replacement_linked_plugin_source/manifest.json.tmp"
+mv "$replacement_linked_plugin_source/manifest.json.tmp" "$replacement_linked_plugin_source/manifest.json"
+
+linked_reload_name=""
+for _ in {1..80}; do
+  linked_reload_name=$(shell_ipc shell listPlugins 2>/dev/null |
+    jq -r --arg id "$linked_plugin_id" '.[] | select(.id == $id) | .name' 2>/dev/null || true)
+  [[ $linked_reload_name == "After Replacement Target Write" ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while reloading a replacement linked plugin"
+  fi
+  sleep 0.1
+done
+[[ $linked_reload_name == "After Replacement Target Write" ]] ||
+  fail_with_log "replacement linked plugin changes reload without an explicit rescan"
+pass "replacing a linked plugin rebuilds its watcher"
+
 [[ $(shell_ipc shell setPluginEnabled "$hot_reload_id" true) == "ok" ]] ||
   fail_with_log "installed plugin could not be enabled"
 

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -61,11 +61,46 @@ cat >"$hot_reload_dir/manifest.json" <<JSON
   "name": "Before Hot Reload",
   "version": "1.0.0",
   "kinds": ["overlay"],
+  "keepLoaded": true,
   "entryPoints": {"overlay": "Overlay.qml"},
   "omarchy": {"clonedFrom": "omarchy.emojis"}
 }
 JSON
 cat >"$hot_reload_dir/Overlay.qml" <<'QML'
+import QtQuick
+import Quickshell.Io
+import "Simulation.js" as Simulation
+
+Item {
+  function open(payloadJson) {}
+  function close() {}
+
+  IpcHandler {
+    target: "hot-reload"
+    function marker(): string { return Simulation.marker }
+  }
+}
+QML
+cat >"$hot_reload_dir/Simulation.js" <<'JS'
+var marker = "before"
+JS
+
+linked_plugin_id="acme.linked-reload"
+linked_plugin_source="$TMPDIR/linked-plugin"
+linked_plugin_dir="$test_home/.config/omarchy/plugins/$linked_plugin_id"
+mkdir -p "$linked_plugin_source"
+ln -s "$linked_plugin_source" "$linked_plugin_dir"
+cat >"$linked_plugin_source/manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "id": "$linked_plugin_id",
+  "name": "Before Linked Reload",
+  "version": "1.0.0",
+  "kinds": ["overlay"],
+  "entryPoints": {"overlay": "Overlay.qml"}
+}
+JSON
+cat >"$linked_plugin_source/Overlay.qml" <<'QML'
 import QtQuick
 
 Item {
@@ -157,8 +192,49 @@ done
   fail_with_log "installed plugin changes reload without an explicit rescan"
 pass "installed plugin changes reload without an explicit rescan"
 
+jq '.name = "After Linked Reload"' "$linked_plugin_source/manifest.json" >"$linked_plugin_source/manifest.json.tmp"
+mv "$linked_plugin_source/manifest.json.tmp" "$linked_plugin_source/manifest.json"
+
+linked_reload_name=""
+for _ in {1..80}; do
+  linked_reload_name=$(shell_ipc shell listPlugins 2>/dev/null |
+    jq -r --arg id "$linked_plugin_id" '.[] | select(.id == $id) | .name' 2>/dev/null || true)
+  [[ $linked_reload_name == "After Linked Reload" ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while reloading a changed linked plugin"
+  fi
+  sleep 0.1
+done
+[[ $linked_reload_name == "After Linked Reload" ]] ||
+  fail_with_log "linked plugin changes reload without an explicit rescan"
+pass "linked plugin changes reload without an explicit rescan"
+
 [[ $(shell_ipc shell setPluginEnabled "$hot_reload_id" true) == "ok" ]] ||
   fail_with_log "installed plugin could not be enabled"
+
+marker=""
+for _ in {1..80}; do
+  marker=$(shell_ipc hot-reload marker 2>/dev/null || true)
+  [[ $marker == "before" ]] && break
+  sleep 0.1
+done
+[[ $marker == "before" ]] || fail_with_log "installed plugin loads imported JavaScript"
+
+printf 'var marker = "after"\n' >"$hot_reload_dir/Simulation.js"
+shell_ipc_quiet shell rescanPlugins >/dev/null
+
+marker=""
+for _ in {1..80}; do
+  marker=$(shell_ipc hot-reload marker 2>/dev/null || true)
+  [[ $marker == "after" ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited while reloading imported JavaScript"
+  fi
+  sleep 0.1
+done
+[[ $marker == "after" ]] || fail_with_log "plugin rescan reloads imported JavaScript"
+pass "plugin rescan reloads imported JavaScript"
+
 [[ $(shell_ipc shell summon omarchy.emojis "{}") == "ok" ]] ||
   fail_with_log "calls to a cloned source id do not reach its enabled clone"
 shell_ipc_quiet shell hide omarchy.emojis >/dev/null


### PR DESCRIPTION
## What changed

- Watch direct symlinked plugin directories as well as the normal plugin tree.
- Rebuild that watcher when a top-level plugin entry changes.
- Use a soft Quickshell reload for plugin rescans, so QML and imported JavaScript load from disk again.

## Why

I am working on a local plugin installed through a symlink under `~/.config/omarchy/plugins`. Editing the checkout behind that link did not trigger a reload. A manual rescan found manifest changes, but could still run an old imported JavaScript module.

The watcher now includes direct external symlink targets. Rescanning creates a fresh QML engine without unnecessarily recreating windows.

## Testing

- `bash test/shell.d/local-plugin-watcher-test.sh`
- `bash test/shell.d/plugin-registry-contract-test.sh`
- `bash test/shell.d/runtime-smoke-test.sh`
- `qmllint shell/shell.qml shell/services/PluginRegistry.qml`
- `bash test/shell` reaches an unrelated package-checkout failure because `OMARCHY_PKGS_PATH` is not configured in this worktree.