### PR TITLE
Give btop a float big enough for its 80x24 minimum

### DIFF
--- a/default/hypr/apps/system.lua
+++ b/default/hypr/apps/system.lua
@@ -4,7 +4,7 @@ o.window({ tag = "floating-window" }, { center = true })
 o.window({ tag = "floating-window" }, { size = { 875, 600 } })
 
 o.window(
-  "(org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.codeberg.dnkl.foot|org.gnome.NautilusPreviewer|org.gnome.Evince|Omarchy|About|TUI.float|imv|mpv)",
+  "(org.omarchy.terminal|org.omarchy.bash|org.codeberg.dnkl.foot|org.gnome.NautilusPreviewer|org.gnome.Evince|Omarchy|About|TUI.float|imv|mpv)",
   {
     tag = "+floating-window",
   }
@@ -26,6 +26,18 @@ o.window({
 o.window("org.omarchy.about", { float = true })
 o.window("org.omarchy.about", { center = true })
 o.window("org.omarchy.about", { size = { 920, 480 } })
+
+-- btop refuses to draw at all below 80x24 characters. The standard float clears
+-- that easily at the stock terminal font -- roughly 117x33 at foot's shipped 9pt
+-- -- but the margin is spent as soon as the font is raised: 13pt on a 1.25-scaled
+-- 1080p panel lands on exactly 80x24, and ghostty at 11pt on a 1.5-scaled one
+-- comes up a column short at 79x24. Height is the constrained axis -- a 1280x720
+-- logical screen has ~690 usable once the bar takes its cut -- while width has
+-- room to spare, so this is sized to clear 80x24 with margin on both and still
+-- fit the smallest screen.
+o.window("org.omarchy.btop", { float = true })
+o.window("org.omarchy.btop", { center = true })
+o.window("org.omarchy.btop", { size = { 1040, 672 } })
 
 o.window("dev.tensaku.Tensaku", { float = true })
 o.window("dev.tensaku.Tensaku", { center = true })


### PR DESCRIPTION
Fixes #8702.

## Problem

`Super + Ctrl + T` (Activity) opens btop, which refuses to render below **80x24 characters** with the shipped `shown_boxes = "cpu mem net proc"` — I probed the boundary in a detached pty, 80x23 fails and 80x24 passes.

`org.omarchy.btop` is swept into the shared floating-window rule, a fixed `{ 875, 600 }` in pixels. How many *cells* that buys depends on the terminal font, so the margin evaporates as soon as anyone raises it. Measured by launching a real window under the rule and reading the pty after the resize settled:

| | cells at 875x600 | |
| --- | --- | --- |
| foot 9pt (stock), 1920x1080 @1.25 | ~117x33 | fine |
| foot 13pt, 1920x1080 @1.25 | 80x24 | passes by exactly one row |
| foot 14pt, 1920x1080 @1.25 | ~74x22 | fails |
| ghostty 11pt, 1920x1080 @1.5 | 79x24 | fails by one column |

The last row is from @zoranbolic in #8702 — a different terminal, a different scale, and a different binding axis, which is what established this isn't foot-specific.

The failure is opaque: the hotkey opens a window reading only "Terminal size too small", with nothing connecting it to the terminal font or a window rule.

## Change

Drop `org.omarchy.btop` from the shared class list and give it its own float, following the `org.omarchy.about` precedent immediately above — that one already exists because "the About fastfetch layout needs more columns than the standard float provides". btop has the same problem and a harder failure mode: fastfetch wraps badly, btop draws nothing.

## Why 1040x672

The two axes are not equally constrained, which is the useful thing the second report surfaced:

- **Height is tight.** A 1280x720 logical screen (1080p at scale 1.5) has ~690 usable once the bar takes its 30px. This is what rules out a size generous enough for large fonts.
- **Width has slack.** 875 against 1280 logical, and the ghostty failure was a *column* short.

`1040x672` clears 80x24 with margin on both reported machines and still fits 1280x720:

| | today | with this change |
| --- | --- | --- |
| ghostty 11pt, 1280x720 logical | 79x24 — fails | 94x27 |
| foot 13pt, 1536x864 logical | 80x24 — one row spare | 97x26 |

Both measured, not calculated. It is strictly larger than the current value on both axes and still fits the smallest screen between the two reports, so it cannot regress anyone.

**It raises the threshold, it does not remove it.** A large enough font still loses. That is unavoidable while the rule is expressed in pixels and btop's requirement is in cells, and Hyprland window rules take pixels. Worth noting an oversized rule is not a safe escape hatch either — I checked, and Hyprland does not clamp to the monitor: requesting 3000x2000 on a 1536x864 screen really does produce a 3000x2000 window.

If you'd rather btop simply tiled — correct at every font size, no magic number — that's a one-line change instead and I'm happy to send it. I went with the smaller, precedented change since tiling alters what Activity feels like.

## Checked

`luac -p` on the changed file, `./test/cli` passes, and the resulting cell counts measured on a live window at both sizes. Confirmed the `floating-window` tag carries only float/center/size, so nothing else is lost by dropping btop from it; it keeps its `terminal` and `default-opacity` tags.
