### PR TITLE
Report the machine's battery figures, not the first cell's

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -18,10 +18,21 @@ case "${1:-}" in
     ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
-[[ -z $battery ]] && exit 0
+# Charge, runtime and draw are properties of the machine, not of whichever cell
+# the kernel enumerated first. UPower's DisplayDevice is that aggregate: on a
+# single-battery machine it mirrors the one cell, and on a dual-battery ThinkPad
+# it is the difference between reporting 21% with 38m left and the 53% with
+# 2h 42m the laptop actually has.
+batteries=()
+while IFS= read -r device; do
+  batteries+=("$device")
+done < <(upower -e 2>/dev/null | grep BAT)
 
-battery_info=$(upower -i "$battery")
+(( ${#batteries[@]} )) || exit 0
+
+first_battery_info=$(upower -i "${batteries[0]}")
+battery_info=$(upower -i /org/freedesktop/UPower/devices/DisplayDevice 2>/dev/null)
+[[ -n $battery_info ]] || battery_info=$first_battery_info
 
 percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$battery_info")
 capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$battery_info")
@@ -42,19 +53,35 @@ time_remaining=$(awk '/time to (empty|full)/ {
   exit
 }' <<<"$battery_info")
 power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
-native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
-battery_path="$power_supply_path/$native_path"
 
 # UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
 # the instantaneous sysfs reading when available so the open panel stays live.
-if [[ -r $battery_path/power_now ]]; then
-  power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
-elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
-  power_rate_raw=$(awk \
-    -v microamps="$(<"$battery_path/current_now")" \
-    -v microvolts="$(<"$battery_path/voltage_now")" \
-    'BEGIN { print microamps * microvolts / 1000000000000 }')
-fi
+#
+# DisplayDevice has no native-path to read that from, and the draw has to cover
+# every pack anyway: a ThinkPad drains its external battery first, leaving the
+# internal one at current_now=0, so reading a single cell reports 0W while the
+# laptop is visibly discharging.
+sysfs_rate=""
+for device in "${batteries[@]}"; do
+  native_path=$(upower -i "$device" 2>/dev/null | awk '/native-path/ { print $2; exit }')
+  [[ -n $native_path ]] || continue
+  battery_path="$power_supply_path/$native_path"
+
+  if [[ -r $battery_path/power_now ]]; then
+    cell_rate=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
+  elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
+    cell_rate=$(awk \
+      -v microamps="$(<"$battery_path/current_now")" \
+      -v microvolts="$(<"$battery_path/voltage_now")" \
+      'BEGIN { print microamps * microvolts / 1000000000000 }')
+  else
+    continue
+  fi
+
+  sysfs_rate=$(awk -v total="${sysfs_rate:-0}" -v cell="$cell_rate" 'BEGIN { print total + cell }')
+done
+
+[[ -n $sysfs_rate ]] && power_rate_raw="$sysfs_rate"
 
 power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
   rounded = sprintf("%.1f", rate)
@@ -62,8 +89,13 @@ power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
   print rounded
 }')
 state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
-threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+# Charge thresholds are per-cell configuration rather than an aggregate, so they
+# come from a battery and not from DisplayDevice, which does not carry them.
+# Reading them from the aggregate would silently demote every machine to the
+# sysfs fallback below, and the two do not always agree: this ThinkPad reports
+# an 80% end threshold through UPower and 100% through sysfs.
+threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$first_battery_info")
+threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$first_battery_info")
 
 [[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
 [[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 tmp_dir=$(mktemp -d)
-trap 'rm -rf "$tmp_dir"' EXIT
+dual_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$dual_dir"' EXIT
 
 mkdir -p "$tmp_dir/bin"
 mkdir -p "$tmp_dir/power/BAT0"
@@ -43,6 +44,68 @@ grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "battery st
 grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status reports live sysfs power rate"
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
 grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
+
+# A machine with two batteries has to report its own charge, state and runtime,
+# not the first cell's. BAT0 is left at current_now=0 on purpose: a ThinkPad
+# drains the external pack first, so a draw read from one cell reports 0W while
+# the laptop is discharging. It is fully-charged for the same reason — the cell
+# the kernel enumerates first is the one still holding its charge, and reading
+# state from it reports a discharging laptop as holding.
+mkdir -p "$dual_dir/bin"
+mkdir -p "$dual_dir/power/BAT0" "$dual_dir/power/BAT1"
+printf '0\n' >"$dual_dir/power/BAT0/current_now"
+printf '12000000\n' >"$dual_dir/power/BAT0/voltage_now"
+printf '500000\n' >"$dual_dir/power/BAT1/current_now"
+printf '12000000\n' >"$dual_dir/power/BAT1/voltage_now"
+cat >"$dual_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  case "$2" in
+  */DisplayDevice)
+    cat <<'INFO'
+  state:                discharging
+  energy-full:          48.0 Wh
+  energy-rate:          6.0 W
+  time to empty:        3.0 hours
+  percentage:           53%
+INFO
+    ;;
+  */battery_BAT1)
+    cat <<'INFO'
+  native-path:          BAT1
+  state:                discharging
+  percentage:           95%
+INFO
+    ;;
+  *)
+    cat <<'INFO'
+  native-path:          BAT0
+  state:                fully-charged
+  percentage:           21%
+INFO
+    ;;
+  esac
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$dual_dir/bin/upower"
+
+dual_output=$(OMARCHY_POWER_SUPPLY_PATH="$dual_dir/power" PATH="$dual_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'percentage\t53%' <<<"$dual_output" >/dev/null || fail "battery status reports the machine percentage, not the first cell"
+grep -Fx $'state\tdischarging' <<<"$dual_output" >/dev/null || fail "battery status reports the machine state, not the first cell"
+grep -Fx $'time\t3h' <<<"$dual_output" >/dev/null || fail "battery status reports the machine remaining time"
+grep -Fx $'size\t48Wh' <<<"$dual_output" >/dev/null || fail "battery status reports the combined capacity"
+grep -Fx $'rate\t6W' <<<"$dual_output" >/dev/null || fail "battery status sums power draw across batteries"
 
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"


### PR DESCRIPTION
`omarchy-battery-status` reads a single device:

```bash
battery=$(upower -e | grep BAT | head -n 1)
```

Everything downstream of that line describes one cell while claiming to describe the laptop. On my T480 with the internal pack at 21% and the external at 95%, it reports **21% and 38m left** for a machine that actually holds **53% and 2h 42m**.

### This reaches the Quattro shell

`shell/plugins/panels/power/Panel.qml` renders the hero percentage from this script, while the progress bar *directly beneath it* and the bar widget itself both use `UPower.displayDevice`:

| line | value | source |
|---|---|---|
| `:281` | bar widget percentage | `Math.round(root.batteryFraction * 100)` → `displayDevice` |
| `:372` | panel hero percentage | `root.batteryInfo.percentage` → **this script** |
| `:403` | progress bar fill | `root.batteryFraction` → `displayDevice` |

So on a dual-battery machine the bar widget reads 53%, and the panel it opens reads 21% — printed directly above a bar drawn at half full.

That is the same inconsistency #5780 reported against Waybar ("inconsistent battery reading between what is shown in the waybar and the notification"), now inside the native shell.

### What changed

**Percentage, state, capacity and remaining time now come from `DisplayDevice`**, which is the aggregate and mirrors the single cell on a one-battery machine.

**The instantaneous sysfs rate is summed across packs.** `DisplayDevice` carries no `native-path` to read it from, and the reading has to cover every pack in any case: a ThinkPad drains its external battery first, leaving the internal one at `current_now=0`, so a rate read from one cell reports `0W` while the laptop is visibly discharging. That is the second symptom reported in #7214.

**Charge thresholds deliberately stay on a battery.** They are per-cell configuration, `DisplayDevice` does not carry them, and sourcing them from it would silently demote every machine to the `BAT*` sysfs fallback — which does not always agree. This ThinkPad reports an 80% end threshold through UPower and 100% through sysfs.

**Charge cycles are deliberately untouched.** They have no aggregate, so reporting them honestly needs somewhere per-battery to put them — a separate change, not this one.

### Testing

`test/shell.d/battery-status-test.sh` gains a dual-battery case: two stub packs with `BAT0` at `current_now=0`, asserting the aggregate percentage, combined capacity, aggregate runtime, and a summed non-zero draw. It fails against the current script with `not ok - battery status reports the machine percentage, not the first cell` and passes with this change. The existing single-battery assertions, including the `10.8W` sysfs rate, are unchanged and still pass.

Verified on a ThinkPad T480 with both packs installed and with only the internal pack:

```
$ bin/omarchy-battery-status --shell
percentage  47%          $ upower -i .../DisplayDevice
state       discharging    state:        discharging
rate        4.2W           energy-rate:  3.979 W
size        23Wh           time to empty: 2.8 hours
time        2h 36m         percentage:   47.615%
```

### Credits

Reported in #5780 by @Michael-Steshenko and again in #7214 by @syntaxboybe, with a second T480 confirmation from @raplo-z. #5958 by @stefanomainardi was an earlier fix for the pre-Quattro surfaces.

Closes #7214.
