### PR TITLE
Default OMARCHY_PATH in omarchy-update-available

### DIFF
--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -4,6 +4,13 @@
 
 set -euo pipefail
 
+# omarchy-update-status calls this from contexts that never sourced Omarchy's
+# shell environment -- a sudo'd update, a non-login SSH session -- where sudo's
+# env_reset has already dropped OMARCHY_PATH. Default it the way default/bash/rc
+# and omarchy-migrate do, so set -u does not turn a package-backed install into
+# a fatal unbound variable on the very check meant to recognize it.
+: "${OMARCHY_PATH:=/usr/share/omarchy}"
+
 updates=()
 
 if [[ $OMARCHY_PATH != "/usr/share/omarchy" ]]; then

--- a/test/shell.d/update-available-test.sh
+++ b/test/shell.d/update-available-test.sh
@@ -211,3 +211,25 @@ grep -Fx 'omarchy-dev-checkout 1 new commit on origin/quattro' "$stdout" >/dev/n
   fail "update checker reports cached dev commits after a fetch failure" "$(cat "$stdout")"
 [[ ! -s $stderr ]] || fail "update checker keeps dev fetch failures quiet" "$(cat "$stderr")"
 pass "update checker uses cached dev state when fetching is unavailable"
+
+# omarchy-update-status runs this at the end of every update, and sudo's
+# env_reset drops OMARCHY_PATH before it gets there. Unset must classify the
+# install as package-backed, not abort on set -u.
+: >"$git_log"
+set +e
+(
+  export TEST_CHECKUPDATES=none TEST_INSTALLED_PACKAGE=omarchy
+  unset OMARCHY_PATH
+  TEST_GIT_LOG="$git_log" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-available"
+) >"$stdout" 2>"$stderr"
+status=$?
+set -e
+[[ $status -eq 1 ]] || fail "update checker exits non-zero with OMARCHY_PATH unset" "$(cat "$stderr")"
+! grep -q 'unbound variable' "$stderr" ||
+  fail "update checker survives an unset OMARCHY_PATH" "$(cat "$stderr")"
+[[ ! -s $stderr ]] || fail "update checker is quiet with OMARCHY_PATH unset" "$(cat "$stderr")"
+grep -q '^Omarchy is up to date$' "$stdout" ||
+  fail "update checker reports up to date with OMARCHY_PATH unset" "$(cat "$stdout")"
+[[ ! -s $git_log ]] ||
+  fail "update checker treats an unset OMARCHY_PATH as package-backed" "$(cat "$git_log")"
+pass "update checker defaults OMARCHY_PATH when the environment does not carry it"


### PR DESCRIPTION
Fixes #8769.

## Problem

`omarchy-update-available` runs under `set -euo pipefail` and dereferences `$OMARCHY_PATH` bare on line 9, the check that decides whether the install is a dev checkout:

```bash
if [[ $OMARCHY_PATH != "/usr/share/omarchy" ]]; then
```

Any context that never sourced `default/bash/rc` reaches it unset — a `sudo`'d update under the default `env_reset`, a non-login SSH session:

```
$ env -u OMARCHY_PATH bin/omarchy-update-available
bin/omarchy-update-available: line 9: OMARCHY_PATH: unbound variable
```

This is the same defect #8369 reports in `omarchy-update-dev`, in the sibling script. #8590 fixes only `omarchy-update-dev`, so on the `sudo omarchy update` path it moves the crash rather than removing it: the update clears the dev-checkout step and then hits the identical error here.

`omarchy-update-status` calls this near the end of every update, and the failure is silent:

```bash
if omarchy-update-available >/dev/null; then
  omarchy-shell -q omarchy.system-update refresh
else
  omarchy-shell -q omarchy.system-update clear
fi
```

`omarchy-update-available` exits 1 both when Omarchy is up to date and when it crashes, and the `if` consumes that status. The crash therefore takes the `clear` branch: the bar's update indicator is cleared as though the system were current, and since only stdout is redirected the sole trace is a stray `unbound variable` line in the update output.

#7398 also touches this file, but rewrites the comparison as `${OMARCHY_PATH%/}` — still a bare dereference under `set -u` — so it does not cover this either. The two changes don't conflict; whichever lands second keeps the default.

## Fix

The established pattern, already used in `default/bash/rc`, `default/bash/env-bootstrap`, `bin/omarchy-migrate` and `bin/omarchy-version`:

```bash
: "${OMARCHY_PATH:=/usr/share/omarchy}"
```

An unset `OMARCHY_PATH` now classifies the install as package-backed and skips the dev-checkout branch, which is exactly what it means. Dev checkouts with the variable exported are unaffected, and the package/`checkupdates` half of the script never read it.

This matches the fallback #8590 adds to `omarchy-update-dev`; it is repeated locally here for the same reason given there — the command is reachable standalone from environments that never source Omarchy's shell bootstrap.

## Testing

Added a case to `test/shell.d/update-available-test.sh` that runs the real command with `OMARCHY_PATH` unset and asserts it exits 1 with the up-to-date message, stays quiet on stderr, and issues no `git` calls (proving it classified the install as package-backed rather than probing a checkout at `""`).

```
ok - update checker defaults OMARCHY_PATH when the environment does not carry it
```

Mutation-checked: reverting the one-line default fails the new case with the exact reported error, and no other case in the file notices.

Also passing: `bin-style-test`, `update-status-test`, `update-sequence-test`, `update-lock-test`, `./test/cli`, `bash -n` on both changed files, and `git diff --check`.
