### PR TITLE
Mock omarchy-osd in the system power test

### DIFF
--- a/test/shell.d/system-power-test.sh
+++ b/test/shell.d/system-power-test.sh
@@ -17,7 +17,10 @@ printf 'systemd-run %s\n' "$*" >>"$CALL_LOG"
 exit 0
 SH
 
-for command in omarchy-state omarchy-hyprland-window-close-all sleep; do
+# omarchy-osd belongs in this list: without it the test calls the real one and
+# paints "Rebooting", then "Shutting down", across the screen of whoever is
+# running the suite.
+for command in omarchy-osd omarchy-state omarchy-hyprland-window-close-all sleep; do
   cat >"$mock_bin/$command" <<'SH'
 #!/bin/bash
 
@@ -36,10 +39,12 @@ run_power_command() {
 assert_power_calls() {
   local action="$1"
   local systemctl_action="$2"
+  local osd_message="$3"
   local expected_log="$test_tmp/$action-expected.log"
 
   cat >"$expected_log" <<EOF
 systemd-run --user --collect --quiet --on-active=2s --timer-property=AccuracySec=100ms systemctl $systemctl_action --no-wall
+omarchy-osd -i $action -m $osd_message -d 5000
 omarchy-state clear re*-required
 omarchy-hyprland-window-close-all 
 sleep 1
@@ -50,10 +55,10 @@ EOF
 }
 
 run_power_command reboot
-assert_power_calls reboot reboot
+assert_power_calls reboot reboot "Rebooting"
 
 run_power_command shutdown
-assert_power_calls shutdown poweroff
+assert_power_calls shutdown poweroff "Shutting down"
 
 for action in reboot shutdown; do
   : >"$call_log"


### PR DESCRIPTION
The test runs the real `bin/omarchy-system-reboot` and `bin/omarchy-system-shutdown`, mocking the commands they call so nothing actually happens. `omarchy-osd` was left out of that list:

```bash
for command in omarchy-state omarchy-hyprland-window-close-all sleep; do
```

but `bin/omarchy-system-shutdown:11` calls it:

```bash
omarchy-osd -i shutdown -m "Shutting down" -d 5000
```

So running the suite paints **"Rebooting"** and then **"Shutting down"** across the screen of whoever is running it, five seconds each. I hit this on my own machine and went looking for a scheduled poweroff before I found the test.

Nothing is actually at risk — `systemd-run` is mocked, so no poweroff is ever scheduled, and `omarchy-hyprland-window-close-all` is mocked too. But a test that tells you your machine is shutting down is its own kind of failure.

This mocks it like the rest, and asserts the call while here: the icon and message the OSD is asked for are part of what these commands do, and nothing covered them before.

All four assertions pass, and the suite no longer touches the screen.