### PR TITLE
Fix premature lock reblank on slow displays

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -33,6 +33,11 @@ Item {
   property string lastEventAt: ""
   property bool strandedLock: false
   property bool strandedLockResolved: false
+  property bool displayBlanked: false
+  property double wakeGraceUntil: 0
+
+  readonly property int blankDelayMilliseconds: 5000
+  readonly property int wakeBlankDelayMilliseconds: 30000
 
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
@@ -154,22 +159,49 @@ Item {
     pendingSessionLockTimer.stop()
     resetAuthenticationState()
     idleBlankTimer.stop()
+    displayBlanked = false
+    wakeGraceUntil = 0
     sessionLock.locked = false
     logEvent("unlocked")
     runWake()
   }
 
-  function armBlankTimer() {
+  function armBlankTimer(delayMilliseconds) {
+    var delay = Number(delayMilliseconds)
+    if (!isFinite(delay) || delay <= 0) delay = root.blankDelayMilliseconds
+    idleBlankTimer.interval = Math.round(delay)
     idleBlankTimer.armedAt = Date.now()
     idleBlankTimer.restart()
   }
 
   function runWake() {
+    // DPMS reports an output enabled before a slow DisplayPort panel has
+    // finished link training and become visible. Keep the first wake from
+    // re-blanking underneath that hardware startup; later activity preserves
+    // the remainder of the same grace window instead of shortening it.
+    if (displayBlanked) wakeGraceUntil = Date.now() + wakeBlankDelayMilliseconds
+    displayBlanked = false
+
     if (!wakeProcess.running) wakeProcess.running = true
-    if (lockRequested) armBlankTimer()
+    if (lockRequested) armBlankTimer(Math.max(blankDelayMilliseconds, wakeGraceUntil - Date.now()))
+  }
+
+  function handleSystemResume(suspendedMilliseconds) {
+    if (!root.lockRequested) return
+
+    // Timers resume before a slow physical display has finished link training.
+    // Start a complete wake grace instead of letting a frozen countdown blank
+    // the prompt as the panel becomes visible.
+    wakeGraceUntil = Date.now() + wakeBlankDelayMilliseconds
+    displayBlanked = false
+    logEvent("system-resume: suspended=" + Math.round(suspendedMilliseconds) + "ms")
+    if (!wakeProcess.running) wakeProcess.running = true
+    armBlankTimer(wakeBlankDelayMilliseconds)
   }
 
   function runBlank() {
+    displayBlanked = true
+    wakeGraceUntil = 0
     if (!blankProcess.running) blankProcess.running = true
   }
 
@@ -413,21 +445,36 @@ Item {
 
   Timer {
     id: idleBlankTimer
-    interval: 5000
+    interval: root.blankDelayMilliseconds
     repeat: false
     property double armedAt: 0
     onTriggered: {
       // A countdown frozen by suspend fires right after resume, which would
       // blank the freshly woken unlock screen under the user. Wall-clock time
-      // exposes the gap: take a fresh run-up instead of blanking.
+      // exposes the gap: take a full slow-display wake grace instead of
+      // blanking as the panel finishes link training.
       if (Date.now() - armedAt > interval + 2000) {
-        root.armBlankTimer()
+        root.handleSystemResume(Date.now() - armedAt)
         return
       }
       // Only a password check in flight should hold the display up. The
       // fingerprint PAM stays armed for the whole lock, so gating on
       // `authenticating` here would keep the panel lit until unlock.
       if (root.lockRequested && !root.authenticatingPassword) root.runBlank()
+    }
+  }
+
+  Timer {
+    id: systemResumeGapTimer
+    interval: 1000
+    repeat: true
+    running: true
+    property double lastTickAt: Date.now()
+    onTriggered: {
+      var now = Date.now()
+      var elapsed = now - lastTickAt
+      lastTickAt = now
+      if (elapsed > interval + 2000) root.handleSystemResume(elapsed)
     }
   }
 

--- a/test/shell.d/lock-wake-grace-test.sh
+++ b/test/shell.d/lock-wake-grace-test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(`${root}/shell/plugins/lock/Service.qml`, 'utf8')
+
+assert(
+  /readonly property int blankDelayMilliseconds: 5000/.test(serviceQml),
+  'an untouched lock still blanks after five seconds'
+)
+
+assert(
+  /readonly property int wakeBlankDelayMilliseconds: 30000/.test(serviceQml),
+  'a DPMS wake gets enough time for slow displays to finish link training'
+)
+
+assert(
+  /function runBlank\(\) \{\s*displayBlanked = true\s*wakeGraceUntil = 0/.test(serviceQml),
+  'blanking records that the next activity is a hardware wake'
+)
+
+assert(
+  /if \(displayBlanked\) wakeGraceUntil = Date\.now\(\) \+ wakeBlankDelayMilliseconds\s*displayBlanked = false/.test(serviceQml),
+  'the first activity after blanking starts one wake grace window'
+)
+
+assert(
+  /armBlankTimer\(Math\.max\(blankDelayMilliseconds, wakeGraceUntil - Date\.now\(\)\)\)/.test(serviceQml),
+  'later wake activity cannot shorten the active grace window'
+)
+
+assert(
+  /function handleSystemResume\(suspendedMilliseconds\)[\s\S]*wakeGraceUntil = Date\.now\(\) \+ wakeBlankDelayMilliseconds[\s\S]*armBlankTimer\(wakeBlankDelayMilliseconds\)/.test(serviceQml),
+  'system resume starts the full slow-display wake grace'
+)
+
+assert(
+  /id: systemResumeGapTimer[\s\S]*if \(elapsed > interval \+ 2000\) root\.handleSystemResume\(elapsed\)/.test(serviceQml),
+  'a wall-clock gap detects resume even after the ordinary blank timer stopped'
+)
+
+assert(
+  /if \(Date\.now\(\) - armedAt > interval \+ 2000\) \{\s*root\.handleSystemResume\(Date\.now\(\) - armedAt\)/.test(serviceQml),
+  'a frozen active blank timer also enters the resume grace path'
+)
+JS


### PR DESCRIPTION
## Summary

- keep the existing 5-second blank delay for a newly locked session
- after waking an actually blanked display, preserve a 30-second grace window for slow DisplayPort panels to finish link training
- keep later input from shortening that grace window
- detect a system-resume wall-clock gap even when the ordinary blank timer had already fired, then apply the same complete wake grace

This addresses the wake-then-immediate-black symptom reported in #7399 without making every initial lock wait 30 seconds. Hyprland can report DPMS enabled before the physical panel is visibly ready, and QML timers resume before a slow panel finishes training, so either path can otherwise blank the output underneath monitor startup.

This is separate from #7806: that PR concerns wake-key leakage and keyboard auto-repeat into the password field.

## Testing

- `test/shell.d/lock-wake-grace-test.sh`
- `test/shell.d/lock-blank-fingerprint-test.sh`
- `test/shell.d/lock-stranded-recovery-test.sh`
- `test/shell.d/lock-password-overflow-test.sh`
- `git diff --check`

The complete test suite was also run for the original change. The focused wake-grace test was rerun after adding system-resume coverage; all eight assertions pass.

Addresses #7399.