### PR TITLE
Give each battery its own section in the power panel

### DIFF
--- a/bin/omarchy-battery-details
+++ b/bin/omarchy-battery-details
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# omarchy:summary=Returns per-battery cycles, capacity, health and charge thresholds
+
+# omarchy-battery-status describes the machine. This describes each cell.
+#
+# Charge cycles, design capacity and health belong to a physical battery and
+# have no aggregate — a machine with a 965-cycle pack and a 156-cycle pack has
+# no meaningful cycle count of its own. So this emits one record per battery
+# and lets the panel render each on its own.
+#
+# UPower drives the live values in the panel; this covers the fields
+# Quickshell's UPower QML API does not expose (charge cycles, thresholds) plus
+# a human name for the cell.
+#
+# Output: <native-path>\t<key>\t<value>, one field per line.
+
+power_supply_path="${OMARCHY_POWER_SUPPLY_PATH:-/sys/class/power_supply}"
+dmi_path="${OMARCHY_DMI_PATH:-/sys/class/dmi/id}"
+
+emit() { printf '%s\t%s\t%s\n' "$1" "$2" "$3"; }
+
+# Peripherals — Bluetooth mice, keyboards, headsets — enumerate under the same
+# battery_ prefix as the machine's own cells, so the prefix alone is not a
+# filter. Only a power supply is a battery of this machine. The panel applies
+# the same test through UPower's powerSupply property, so the two agree on what
+# counts: the numbering below matches the cards that actually get rendered, and
+# a paired mouse cannot turn "Battery" into "Battery 1".
+names=()
+infos=()
+while IFS= read -r device; do
+  info=$(upower -i "$device" 2>/dev/null) || continue
+  grep -q '^[[:space:]]*power supply:[[:space:]]*yes' <<<"$info" || continue
+
+  name=$(awk '/native-path:/ { print $2; exit }' <<<"$info")
+  [[ -n $name ]] || continue
+
+  names+=("$name")
+  infos+=("$info")
+done < <(upower -e 2>/dev/null | grep '/battery_' | sort)
+
+count=${#names[@]}
+(( count )) || exit 0
+
+# Lenovo's Power Bridge pairs a built-in cell with a hot-swappable one, always
+# enumerated BAT0 then BAT1. That is the only two-battery layout we can name
+# with confidence, so every other machine falls back to ordinals.
+power_bridge=false
+if (( count == 2 )); then
+  product="$(cat "$dmi_path/product_version" "$dmi_path/product_name" 2>/dev/null)"
+  [[ $product == *ThinkPad* ]] && power_bridge=true
+fi
+
+for (( i = 0; i < count; i++ )); do
+  name=${names[i]}
+  info=${infos[i]}
+
+  if [[ $power_bridge == "true" ]]; then
+    if (( i == 0 )); then label="Internal"; else label="External"; fi
+  elif (( count > 1 )); then
+    label="Battery $((i + 1))"
+  else
+    label="Battery"
+  fi
+
+  model=$(awk '/^ *model:/ { $1 = ""; sub(/^ +/, ""); print; exit }' <<<"$info")
+  vendor=$(awk '/^ *vendor:/ { $1 = ""; sub(/^ +/, ""); print; exit }' <<<"$info")
+  cycles=$(awk '/charge-cycles:/ { print $2; exit }' <<<"$info")
+  full=$(awk '/energy-full:/ { print $2; exit }' <<<"$info")
+  design=$(awk '/energy-full-design:/ { print $2; exit }' <<<"$info")
+  health=$(awk '/^ *capacity:/ { gsub(/%/, "", $2); print $2; exit }' <<<"$info")
+  start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$info")
+  end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$info")
+
+  # UPower's charge-cycles is absent on some firmware; sysfs usually still has it.
+  [[ -z $cycles || $cycles == "N/A" ]] && cycles=$(cat "$power_supply_path/$name/cycle_count" 2>/dev/null)
+  [[ -z $start ]] && start=$(cat "$power_supply_path/$name/charge_control_start_threshold" 2>/dev/null)
+  [[ -z $end ]] && end=$(cat "$power_supply_path/$name/charge_control_end_threshold" 2>/dev/null)
+
+  emit "$name" label "$label"
+  [[ -n $model ]] && emit "$name" model "$model"
+  [[ -n $vendor ]] && emit "$name" vendor "$vendor"
+  [[ -n $cycles && $cycles != "N/A" ]] && emit "$name" cycles "$cycles"
+  [[ -n $full ]] && emit "$name" size "$(awk -v v="$full" 'BEGIN { printf "%.1fWh", v }')"
+  [[ -n $design ]] && emit "$name" design "$(awk -v v="$design" 'BEGIN { printf "%.1fWh", v }')"
+  [[ -n $health ]] && emit "$name" health "$(awk -v v="$health" 'BEGIN { printf "%d%%", v + 0.5 }')"
+
+  if [[ -n $end ]]; then
+    if [[ -n $start && $start != "$end" ]]; then
+      emit "$name" threshold "${start}-${end}%"
+    else
+      emit "$name" threshold "${end}%"
+    fi
+  fi
+done

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -89,6 +89,72 @@ function modeLabel(device, onBattery, states) {
   return "Charging"
 }
 
+// A device is a physical battery when UPower types it as one, it is a power
+// supply (rules out battery-powered peripherals — mice, headsets, controllers)
+// and it carries a native path. The display pseudo-device also types itself as
+// a battery, so it is excluded by identity and by its empty native path.
+function isPhysicalBattery(device, displayDevice, types) {
+  var d = device || {}
+  var t = types || {}
+  if (!d || d === displayDevice) return false
+  if (d.type !== t.Battery) return false
+  if (d.powerSupply === false) return false
+  return String(d.nativePath || "") !== ""
+}
+
+function physicalBatteries(devices, displayDevice, types) {
+  var list = []
+  var values = devices || []
+  for (var i = 0; i < values.length; i++) {
+    if (isPhysicalBattery(values[i], displayDevice, types))
+      list.push(values[i])
+  }
+  list.sort(function(a, b) {
+    return String(a.nativePath).localeCompare(String(b.nativePath))
+  })
+  return list
+}
+
+// Parses the plugin's bin/battery-details output: <native-path>\t<key>\t<value>
+// per line, into { BAT0: { cycles: "964", ... }, BAT1: {...} }.
+function parseBatteryDetails(raw) {
+  var out = {}
+  var lines = String(raw || "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var parts = lines[i].split("\t")
+    if (parts.length < 3) continue
+    var name = parts[0].trim()
+    var key = parts[1].trim()
+    if (!name || !key) continue
+    if (!out[name]) out[name] = {}
+    out[name][key] = parts.slice(2).join("\t").trim()
+  }
+  return out
+}
+
+function deviceStateLabel(device, states) {
+  var d = device || {}
+  var s = states || {}
+  if (!d.isPresent) return "Absent"
+  if (d.state === s.Charging) return "Charging"
+  if (d.state === s.Discharging) return "Discharging"
+  if (d.state === s.Empty) return "Empty"
+  if (d.state === s.FullyCharged) return "Full"
+  if (d.state === s.PendingCharge) return "Holding"
+  if (d.state === s.PendingDischarge) return "Pending"
+  return "Idle"
+}
+
+// Watts flowing through one cell. UPower reports changeRate unsigned, so the
+// sign has to come from the state.
+function deviceRateLabel(device, states) {
+  var d = device || {}
+  var rate = Math.abs(Number(d.changeRate || 0))
+  if (!d.isPresent || rate < 0.05) return "—"
+  var sign = d.state === (states || {}).Discharging ? "-" : "+"
+  return sign + (rate < 10 ? rate.toFixed(1) : Math.round(rate)) + "W"
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampIndex: clampIndex,
@@ -99,6 +165,11 @@ if (typeof module !== "undefined") {
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,
-    modeLabel: modeLabel
+    modeLabel: modeLabel,
+    isPhysicalBattery: isPhysicalBattery,
+    physicalBatteries: physicalBatteries,
+    parseBatteryDetails: parseBatteryDetails,
+    deviceStateLabel: deviceStateLabel,
+    deviceRateLabel: deviceRateLabel
   }
 }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -29,13 +29,34 @@ Panel {
     return !!(device && device.isPresent)
   }
 
+  // Every physical battery UPower knows about, in native-path order. The hero
+  // above stays on displayDevice — the machine-wide view — while these get a
+  // section each, because cycles and capacity are per-cell facts that cannot
+  // be aggregated.
+  readonly property var batteryDevices: Model.physicalBatteries(
+    UPower.devices ? UPower.devices.values : [], UPower.displayDevice, upowerTypes())
+  readonly property bool multiBattery: batteryDevices.length > 1
+  // { BAT0: { cycles, size, health, ... }, ... } from omarchy-battery-details.
+  property var batteryDetails: ({})
+
+  function detailsFor(device) {
+    var key = device ? String(device.nativePath || "") : ""
+    return (key && batteryDetails[key]) ? batteryDetails[key] : ({})
+  }
+
   function upowerStates() {
     return {
       Charging: UPowerDeviceState.Charging,
       Discharging: UPowerDeviceState.Discharging,
+      Empty: UPowerDeviceState.Empty,
       FullyCharged: UPowerDeviceState.FullyCharged,
-      PendingCharge: UPowerDeviceState.PendingCharge
+      PendingCharge: UPowerDeviceState.PendingCharge,
+      PendingDischarge: UPowerDeviceState.PendingDischarge
     }
+  }
+
+  function upowerTypes() {
+    return { Battery: UPowerDeviceType.Battery }
   }
 
   function selectProfileByDelta(delta) {
@@ -81,6 +102,7 @@ Panel {
     var d = UPower.displayDevice
     return Model.batteryFraction(d)
   }
+
 
   readonly property bool charging: {
     var d = UPower.displayDevice
@@ -138,6 +160,15 @@ Panel {
     if (!batteryProc.running) batteryProc.running = true
     if (!profilesProc.running) profilesProc.running = true
     if (!systemProc.running) systemProc.running = true
+    if (!detailsProc.running) detailsProc.running = true
+  }
+
+  function updateBatteryDetails(raw) {
+    var next = Model.parseBatteryDetails(raw)
+    // Same guard as the other readers: keep the last good payload rather than
+    // blanking every card if a refresh lands mid AC transition.
+    if (Object.keys(next).length === 0) return
+    batteryDetails = next
   }
 
   function updateKeyValue(raw, targetName) {
@@ -221,6 +252,12 @@ Panel {
     id: systemProc
     command: ["omarchy-system-stats"]
     stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.updateKeyValue(text, "system") }
+  }
+
+  Process {
+    id: detailsProc
+    command: ["omarchy-battery-details"]
+    stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.updateBatteryDetails(text) }
   }
 
   Process {
@@ -345,7 +382,7 @@ Panel {
             spacing: Style.space(2)
 
             Text {
-              text: "Battery"
+              text: root.multiBattery ? "All batteries" : "Battery"
               color: root.bar.foreground
               font.family: root.bar.fontFamily
               font.pixelSize: Style.font.title
@@ -428,6 +465,10 @@ Panel {
           spacing: Style.space(20)
 
           Column {
+            // Hidden on multi-battery machines. Charge cycles are a fact about
+            // a physical cell with no aggregate to report, and capacity is more
+            // useful per cell than summed. The cards below carry both.
+            visible: !root.multiBattery
             width: (parent.width - parent.spacing) / 2
             spacing: Style.spacing.labelGap
             InfoPair { label: "Battery size"; value: root.batteryInfo.size || "" }
@@ -435,7 +476,7 @@ Panel {
           }
 
           Column {
-            width: (parent.width - parent.spacing) / 2
+            width: root.multiBattery ? parent.width : (parent.width - parent.spacing) / 2
             spacing: Style.spacing.labelGap
             InfoPair {
               label: root.chargeThresholdActive ? "Charge limit" : (root.discharging ? "Time left" : "Time to full")
@@ -444,6 +485,36 @@ Panel {
             InfoPair {
               label: root.chargeThresholdActive ? "Battery state" : (root.discharging ? "Discharging" : "Charging")
               value: root.chargeThresholdActive ? "Holding" : (root.batteryFull ? "-" : (root.batteryInfo.rate || ""))
+            }
+          }
+        }
+
+        // ---------- Per-battery breakdown ----------
+        // One section per physical cell. Only shown when there is more than
+        // one — a single-battery machine already has all of this in the hero
+        // and the stats row above.
+        Column {
+          id: batteryList
+          visible: root.multiBattery
+          width: parent.width
+          spacing: Style.space(12)
+
+          PanelSeparator {
+            foreground: root.bar.foreground
+          }
+
+          PanelSectionHeader {
+            text: "BATTERIES"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Repeater {
+            model: root.batteryDevices
+            BatteryCard {
+              required property var modelData
+              width: batteryList.width
+              device: modelData
             }
           }
         }
@@ -499,6 +570,114 @@ Panel {
               }
             }
           }
+        }
+      }
+    }
+  }
+
+  // One physical battery: name, model, its own charge level, and the stats
+  // that belong to a cell rather than to the machine.
+  component BatteryCard: Column {
+    property var device: null
+
+    readonly property var details: root.detailsFor(device)
+    readonly property real fraction: Model.batteryFraction(device)
+
+    spacing: Style.space(8)
+
+    Item {
+      width: parent.width
+      implicitHeight: Math.max(cellName.implicitHeight, cellPercent.implicitHeight)
+
+      // Named by omarchy-battery-details: the T480 is a Power Bridge machine, so
+      // BAT0/BAT1 are the internal and hot-swappable cells rather than two
+      // interchangeable slots. Falls back to the kernel name off that hardware.
+      Text {
+        id: cellName
+        text: String(details.label || (device ? device.nativePath : "")).toUpperCase()
+        color: root.bar.foreground
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.body
+        font.bold: true
+        font.letterSpacing: 0.8
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+      }
+
+      // The kernel name stays visible but demoted — it is what upower, sysfs
+      // and any bug report will call this cell.
+      Text {
+        id: cellModel
+        text: [String(device ? device.nativePath : ""), details.vendor || "", details.model || ""]
+          .filter(function(part) { return part !== "" }).join(" · ")
+        color: root.bar.foreground
+        opacity: 0.55
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.caption
+        elide: Text.ElideRight
+        anchors.left: cellName.right
+        anchors.leftMargin: Style.space(8)
+        anchors.right: cellPercent.left
+        anchors.rightMargin: Style.space(8)
+        anchors.baseline: cellName.baseline
+      }
+
+      Text {
+        id: cellPercent
+        text: device && device.isPresent ? Math.round(fraction * 100) + "%" : "—"
+        color: root.bar.foreground
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.title
+        font.bold: true
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+      }
+    }
+
+    Item {
+      width: parent.width
+      implicitHeight: Style.space(5)
+
+      Rectangle {
+        id: cellTrack
+        anchors.fill: parent
+        radius: height / 2
+        color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
+      }
+
+      Rectangle {
+        anchors.left: cellTrack.left
+        anchors.verticalCenter: cellTrack.verticalCenter
+        height: cellTrack.height
+        radius: cellTrack.radius
+        color: root.batteryFillColor
+        width: Math.max(cellTrack.height, cellTrack.width * fraction)
+
+        Behavior on width { NumberAnimation { duration: 320; easing.type: Easing.OutCubic } }
+      }
+    }
+
+    Row {
+      width: parent.width
+      spacing: Style.space(20)
+
+      Column {
+        width: (parent.width - parent.spacing) / 2
+        spacing: Style.spacing.labelGap
+        InfoPair { label: "Charge cycles"; value: details.cycles || "—" }
+        InfoPair { label: "Capacity"; value: details.size || "—" }
+      }
+
+      Column {
+        width: (parent.width - parent.spacing) / 2
+        spacing: Style.spacing.labelGap
+        // Health is energy-full against energy-full-design: how much of the
+        // cell's original capacity survives. Worth showing per battery, since
+        // two cells of different ages wear at different rates.
+        InfoPair { label: "Health"; value: details.health || "—" }
+        InfoPair {
+          label: Model.deviceStateLabel(device, root.upowerStates())
+          value: Model.deviceRateLabel(device, root.upowerStates())
         }
       }
     }

--- a/test/shell.d/battery-details-test.sh
+++ b/test/shell.d/battery-details-test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Each scenario is a directory holding a device list, one canned `upower -i`
+# dump per device, and the DMI product string the machine would report.
+new_machine() {
+  local name="$1"
+  local product="${2:-}"
+
+  scenario="$tmp_dir/$name"
+  mkdir -p "$scenario/bin" "$scenario/dmi" "$scenario/power"
+  : >"$scenario/devices"
+  [[ -n $product ]] && printf '%s\n' "$product" >"$scenario/dmi/product_version"
+
+  cat >"$scenario/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  cat "$STUB_DIR/devices"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  cat "$STUB_DIR/${2##*/}" 2>/dev/null
+  exit 0
+fi
+
+exit 1
+STUB
+  chmod +x "$scenario/bin/upower"
+}
+
+add_device() {
+  local device="$1"
+
+  printf '/org/freedesktop/UPower/devices/%s\n' "$device" >>"$scenario/devices"
+  cat >"$scenario/$device"
+}
+
+run_details() {
+  STUB_DIR="$scenario" \
+    OMARCHY_DMI_PATH="$scenario/dmi" \
+    OMARCHY_POWER_SUPPLY_PATH="$scenario/power" \
+    PATH="$scenario/bin:$PATH" \
+    "$ROOT/bin/omarchy-battery-details"
+}
+
+# A Power Bridge ThinkPad names its cells, and a paired mouse is not one of
+# them: UPower enumerates peripherals under the same battery_ prefix, so the
+# prefix alone is not a filter.
+new_machine power_bridge "ThinkPad T480 W0A"
+add_device battery_BAT0 <<'INFO'
+  native-path:          BAT0
+  vendor:               SMP
+  model:                01AV421
+  power supply:         yes
+  charge-cycles:        965
+  energy-full:          13.6 Wh
+  energy-full-design:   24.0 Wh
+  capacity:             57%
+INFO
+add_device battery_BAT1 <<'INFO'
+  native-path:          BAT1
+  vendor:               LGC
+  model:                01AV490
+  power supply:         yes
+  charge-cycles:        156
+  energy-full:          10.1 Wh
+  energy-full-design:   23.9 Wh
+  capacity:             42%
+INFO
+add_device battery_hid_mouse <<'INFO'
+  native-path:          /sys/devices/virtual/misc/uhid/0005:046D:B01D.0003
+  model:                MX Master 3
+  power supply:         no
+  percentage:           70%
+INFO
+
+output=$(run_details)
+
+grep -Fx $'BAT0\tlabel\tInternal' <<<"$output" >/dev/null || fail "power bridge names the built-in cell"
+grep -Fx $'BAT1\tlabel\tExternal' <<<"$output" >/dev/null || fail "power bridge names the hot-swappable cell"
+grep -Fx $'BAT0\tcycles\t965' <<<"$output" >/dev/null || fail "each cell keeps its own charge cycles"
+grep -Fx $'BAT1\tcycles\t156' <<<"$output" >/dev/null || fail "each cell keeps its own charge cycles"
+grep -Fx $'BAT0\thealth\t57%' <<<"$output" >/dev/null || fail "each cell keeps its own health"
+grep -Fx $'BAT1\tsize\t10.1Wh' <<<"$output" >/dev/null || fail "each cell keeps its own capacity"
+grep -q 'MX Master' <<<"$output" && fail "a peripheral is not a battery of this machine"
+pass "power bridge cells are named and peripherals are left out"
+
+# Anything that is not a two-cell ThinkPad gets ordinals rather than a guess,
+# and the peripheral must not consume one of them.
+new_machine ordinals "Precision 7550"
+add_device battery_BAT0 <<'INFO'
+  native-path:          BAT0
+  power supply:         yes
+  capacity:             90%
+INFO
+add_device battery_BAT1 <<'INFO'
+  native-path:          BAT1
+  power supply:         yes
+  capacity:             88%
+INFO
+add_device battery_BAT2 <<'INFO'
+  native-path:          BAT2
+  power supply:         yes
+  capacity:             81%
+INFO
+
+output=$(run_details)
+
+grep -Fx $'BAT0\tlabel\tBattery 1' <<<"$output" >/dev/null || fail "unknown layouts fall back to ordinals"
+grep -Fx $'BAT2\tlabel\tBattery 3' <<<"$output" >/dev/null || fail "ordinals cover any battery count"
+pass "unknown layouts fall back to ordinals"
+
+# One battery is just "Battery" — a paired mouse must not make it "Battery 1".
+new_machine single "XPS 13"
+add_device battery_BAT0 <<'INFO'
+  native-path:          BAT0
+  power supply:         yes
+  capacity:             94%
+INFO
+add_device battery_hid_keyboard <<'INFO'
+  native-path:          /sys/devices/virtual/misc/uhid/0005:05AC:0267.0004
+  power supply:         no
+  percentage:           55%
+INFO
+
+output=$(run_details)
+
+grep -Fx $'BAT0\tlabel\tBattery' <<<"$output" >/dev/null || fail "a lone battery is not numbered"
+pass "a lone battery is not numbered"
+
+# A desktop with a wireless mouse has no battery to report.
+new_machine desktop "OptiPlex 7090"
+add_device battery_hid_mouse <<'INFO'
+  native-path:          /sys/devices/virtual/misc/uhid/0005:046D:B01D.0003
+  power supply:         no
+  percentage:           70%
+INFO
+
+output=$(run_details)
+
+[[ -z $output ]] || fail "a machine with no battery reports nothing"
+pass "a machine with no battery reports nothing"

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -42,6 +42,39 @@ assertEqual(
   'power shows battery icon when unplugged before battery state refreshes'
 )
 
+// Per-battery cards. The fixture above renumbers the enum, so these use UPower's
+// real ordering: Empty sits at 3, where that fixture has FullyCharged.
+const deviceStates = { Unknown: 0, Charging: 1, Discharging: 2, Empty: 3, FullyCharged: 4, PendingCharge: 5, PendingDischarge: 6 }
+const types = { Battery: 2 }
+const displayDevice = { type: types.Battery, powerSupply: true, nativePath: '' }
+const bat0 = { type: types.Battery, powerSupply: true, nativePath: 'BAT0' }
+const bat1 = { type: types.Battery, powerSupply: true, nativePath: 'BAT1' }
+const mouse = { type: types.Battery, powerSupply: false, nativePath: 'hid-dc:2c:26:1b:14:9f-battery' }
+const headset = { type: 8, powerSupply: false, nativePath: 'hid-headset' }
+
+assert(power.isPhysicalBattery(bat0, displayDevice, types), 'power counts a power supply battery as the machine\'s own')
+assert(!power.isPhysicalBattery(mouse, displayDevice, types), 'power excludes a peripheral battery')
+assert(!power.isPhysicalBattery(headset, displayDevice, types), 'power excludes a device that is not a battery')
+assert(!power.isPhysicalBattery(displayDevice, displayDevice, types), 'power excludes the aggregate display device')
+assert(!power.isPhysicalBattery(bat0, bat0, types), 'power excludes whichever device UPower hands back as the aggregate')
+assertDeepEqual(
+  power.physicalBatteries([bat1, mouse, displayDevice, bat0], displayDevice, types).map(function(d) { return d.nativePath }),
+  ['BAT0', 'BAT1'],
+  'power orders batteries by native path and drops everything else'
+)
+
+assertEqual(power.deviceStateLabel({ isPresent: true, state: deviceStates.Empty }, deviceStates), 'Empty', 'power labels a drained pack as empty')
+assertEqual(power.deviceStateLabel({ isPresent: true, state: deviceStates.Unknown }, deviceStates), 'Idle', 'power labels an unreported state as idle')
+assertEqual(power.deviceStateLabel({ isPresent: false }, deviceStates), 'Absent', 'power labels a missing pack as absent')
+
+// The states object lives in Panel.qml, so a member missing there reads as Idle
+// no matter what Model.js maps. That is how Empty was lost.
+for (const member of ['Charging', 'Discharging', 'Empty', 'FullyCharged', 'PendingCharge', 'PendingDischarge'])
+  assert(
+    new RegExp(member + ': UPowerDeviceState\\.' + member).test(panelSource),
+    `power hands UPower's ${member} state to the per-battery labels`
+  )
+
 assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')
 assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon')


### PR DESCRIPTION
Charge cycles, design capacity and health are facts about a physical cell. They have no aggregate — a machine with a 965-cycle pack and a 156-cycle pack has no cycle count of its own.

The panel reports the first cell's numbers under a machine-wide label. On my T480 it shows **965 cycles and 57% health** for a laptop whose other pack is at **156 and 42%**. Swap which pack the kernel enumerates first and the same machine reports the other set. Neither is wrong about a battery; both are wrong about the laptop.

### What this does

Renders one section per battery below the machine-wide summary, each with its own charge level, cycles, capacity, health and flow. The hero and the stats row keep describing the machine; the sections describe the cells.

**On a single-battery machine nothing changes.** The sections only appear when there is more than one cell to tell apart, and `omarchy-battery-details` exits 0 with no output when there is nothing to say.

### `bin/omarchy-battery-details`

UPower's QML API exposes neither charge cycles nor charge thresholds, so the panel cannot reach them through `UPowerDevice`. This supplies those, plus a vendor and model so a cell is identifiable, and falls back to `/sys/class/power_supply` where the firmware reports nothing to UPower — common on older machines. Live values still come from UPower; this only covers the gaps.

Cells are selected on UPower's **power-supply flag** rather than the `battery_` D-Bus prefix. Peripherals enumerate under that same prefix, so the prefix alone is not a filter — without this, a paired Bluetooth mouse takes an ordinal and turns "Battery" into "Battery 1". `Model.isPhysicalBattery` applies the same test on the QML side, so the two agree on what counts.

Two-battery ThinkPads are named **Internal** and **External** from DMI, since Power Bridge always enumerates the built-in cell first. That is the only layout nameable with confidence; every other machine gets ordinals.

### Testing

`test/shell.d/battery-details-test.sh` is new and covers four machines with a stubbed `upower`: a Power Bridge ThinkPad with a Bluetooth mouse attached, a three-battery non-ThinkPad, a single-battery laptop with a paired keyboard, and a desktop with only a mouse. Removing the power-supply filter fails it with `not ok - power bridge names the built-in cell`, because the mouse inflates the count to three and the naming no longer applies.

Verified on a ThinkPad T480 running the exact files in this PR — script resolved through `PATH`, no QML errors in the journal:

<img width="560" alt="Panel showing INTERNAL and EXTERNAL sections with separate cycles, capacity and health" src="https://raw.githubusercontent.com/alhasapi/omarchy-power-multibattery/main/docs/screenshot.png">

<sub>Same sections, captured from this code running as a local plugin so the machine-wide figures above them are already correct; in this PR alone the hero still comes from <code>omarchy-battery-status</code> until #8770 lands.</sub>

### Relationship to #8770

Independent — no overlapping files — but they are two halves of the same problem, and this one reads better on top of #8770. That PR fixes the machine-wide figures (the hero percentage and runtime, which today come from the first cell too); this one gives the per-cell facts somewhere honest to live. #8770 deliberately left `cycles` alone because there was nowhere to put it; this is that somewhere.
