### PR TITLE
fix: prevent Chromium notifications from persisting indefinitely

### DIFF
--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -5,8 +5,8 @@ function isChromiumDerived(app, appIcon) {
          source.indexOf("opera") >= 0
 }
 
-function shouldPersistPopup(app, appIcon, urgency, criticalUrgency) {
-  return urgency === criticalUrgency && !isChromiumDerived(app, appIcon)
+function shouldPersistPopup(chromiumDerived, urgency, criticalUrgency) {
+  return urgency === criticalUrgency && !chromiumDerived
 }
 
 function sanitizeBody(body, app, appIcon) {
@@ -110,6 +110,7 @@ function snapshotOf(notification, timestamp) {
     originalId: id,
     app: n.appName || "",
     appIcon: n.appIcon || "",
+    chromiumDerived: isChromiumDerived(n.appName, n.appIcon),
     summary: String(n.summary || ""),
     body: n.body || "",
     image: n.image || "",
@@ -121,9 +122,9 @@ function snapshotOf(notification, timestamp) {
   }
 }
 
-// Everything the popup card draws, and therefore everything an in-place
-// update has to write through to the row and its file.
-var POPUP_ROLES = ["app", "appIcon", "summary", "body", "image", "glyph", "execArgv", "urgency", "expireTimeout"]
+// Everything the popup card or its lifetime policy depends on, and therefore
+// everything an in-place update has to write through to the row and its file.
+var POPUP_ROLES = ["app", "appIcon", "chromiumDerived", "summary", "body", "image", "glyph", "execArgv", "urgency", "expireTimeout"]
 
 function popupRoles() {
   return POPUP_ROLES
@@ -161,6 +162,9 @@ function historyEntry(value, normalUrgency) {
     originalId: e.originalId || e.id || 0,
     app: e.app || "",
     appIcon: e.appIcon || "",
+    chromiumDerived: typeof e.chromiumDerived === "boolean"
+      ? e.chromiumDerived
+      : isChromiumDerived(e.app, e.appIcon),
     summary: e.summary || "",
     body: e.body || "",
     image: e.image || "",

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -5,6 +5,10 @@ function isChromiumDerived(app, appIcon) {
          source.indexOf("opera") >= 0
 }
 
+function shouldPersistPopup(app, appIcon, urgency, criticalUrgency) {
+  return urgency === criticalUrgency && !isChromiumDerived(app, appIcon)
+}
+
 function sanitizeBody(body, app, appIcon) {
   var text = String(body || "").replace(/<img[^>]*>/gi, "")
   if (!isChromiumDerived(app, appIcon)) return text
@@ -365,6 +369,7 @@ function historyRows(raw, liveRows, normalUrgency, limit) {
 if (typeof module !== "undefined") {
   module.exports = {
     isChromiumDerived: isChromiumDerived,
+    shouldPersistPopup: shouldPersistPopup,
     sanitizeBody: sanitizeBody,
     summaryStartsWithGlyph: summaryStartsWithGlyph,
     shouldBypassDnd: shouldBypassDnd,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -99,8 +99,8 @@ Item {
   readonly property int normalPopupDuration: 8000
   readonly property int maxPopupDuration: 30000
 
-  function durationFor(app, appIcon, urgency, expireTimeout) {
-    if (NotificationLogic.shouldPersistPopup(app, appIcon, urgency, NotificationUrgency.Critical))
+  function durationFor(chromiumDerived, urgency, expireTimeout) {
+    if (NotificationLogic.shouldPersistPopup(chromiumDerived, urgency, NotificationUrgency.Critical))
       return 0
 
     switch (urgency) {
@@ -725,7 +725,7 @@ Item {
     var live = []
     for (var i = 0; i < entries.length; i++) {
       var entry = entries[i]
-      var duration = durationFor(entry.app, entry.appIcon, entry.urgency, entry.expireTimeout)
+      var duration = durationFor(entry.chromiumDerived, entry.urgency, entry.expireTimeout)
       if (NotificationLogic.popupExpired(entry, duration, now)) {
         // It would have expired on screen had the shell kept running, so it
         // gets archived exactly like an expiry that happened while it did.
@@ -1011,7 +1011,7 @@ Item {
             Layout.alignment: Qt.AlignRight
             implicitHeight: card.implicitHeight
 
-            readonly property real lifetime: service.durationFor(cardSlot.app, cardSlot.appIcon, cardSlot.urgency, cardSlot.expireTimeout)
+            readonly property real lifetime: service.durationFor(cardSlot.chromiumDerived, cardSlot.urgency, cardSlot.expireTimeout)
             property real remainingLifetime: 1.0
             readonly property bool ticking: cardSlot.lifetime > 0 && !card.hovered
 

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -99,10 +99,11 @@ Item {
   readonly property int normalPopupDuration: 8000
   readonly property int maxPopupDuration: 30000
 
-  function durationFor(urgency, expireTimeout) {
-    switch (urgency) {
-    case NotificationUrgency.Critical:
+  function durationFor(app, appIcon, urgency, expireTimeout) {
+    if (NotificationLogic.shouldPersistPopup(app, appIcon, urgency, NotificationUrgency.Critical))
       return 0
+
+    switch (urgency) {
     case NotificationUrgency.Low:
       return Math.min(maxPopupDuration, Math.max(lowPopupDuration, requestedDuration(expireTimeout)))
     default:
@@ -724,7 +725,7 @@ Item {
     var live = []
     for (var i = 0; i < entries.length; i++) {
       var entry = entries[i]
-      var duration = durationFor(entry.urgency, entry.expireTimeout)
+      var duration = durationFor(entry.app, entry.appIcon, entry.urgency, entry.expireTimeout)
       if (NotificationLogic.popupExpired(entry, duration, now)) {
         // It would have expired on screen had the shell kept running, so it
         // gets archived exactly like an expiry that happened while it did.
@@ -1010,7 +1011,7 @@ Item {
             Layout.alignment: Qt.AlignRight
             implicitHeight: card.implicitHeight
 
-            readonly property real lifetime: service.durationFor(cardSlot.urgency, cardSlot.expireTimeout)
+            readonly property real lifetime: service.durationFor(cardSlot.app, cardSlot.appIcon, cardSlot.urgency, cardSlot.expireTimeout)
             property real remainingLifetime: 1.0
             readonly property bool ticking: cardSlot.lifetime > 0 && !card.hovered
 

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -13,19 +13,15 @@ assert(notifications.isChromiumDerived('', 'microsoft-edge'), 'notifications det
 assert(!notifications.isChromiumDerived('Slack', ''), 'notifications do not treat unrelated apps as chromium-derived')
 
 assert(
-  !notifications.shouldPersistPopup('Brave Browser', '', 2, 2),
+  !notifications.shouldPersistPopup(true, 2, 2),
   'critical chromium-derived notifications use a finite popup lifetime'
 )
 assert(
-  !notifications.shouldPersistPopup('', 'microsoft-edge', 2, 2),
-  'critical chromium-derived notifications are detected by icon'
-)
-assert(
-  notifications.shouldPersistPopup('Slack', '', 2, 2),
+  notifications.shouldPersistPopup(false, 2, 2),
   'critical non-browser notifications remain persistent'
 )
 assert(
-  !notifications.shouldPersistPopup('Slack', '', 1, 2),
+  !notifications.shouldPersistPopup(false, 1, 2),
   'normal notifications are never treated as persistent'
 )
 
@@ -218,6 +214,52 @@ assertEqual(
   notifications.popupFileName(replacement),
   '12345-12.json',
   'notifications keep the persisted file name across an in-place update'
+)
+
+
+// Browser classification is captured while the live sender identity is still
+// available. Persisting a file-backed icon rewrites its path, so restoration
+// must use the stored classification rather than trying to detect the browser
+// again from the rewritten icon.
+const iconOnlyChromium = notifications.snapshotOf({
+  id: 21,
+  appName: 'Web App',
+  appIcon: '/tmp/microsoft-edge-icon.png',
+  summary: 'Browser notification',
+  urgency: 2,
+  expireTimeout: 0
+}, 20000)
+
+assertEqual(
+  iconOnlyChromium.chromiumDerived,
+  true,
+  'notifications classify chromium-derived popups before persistence rewrites their icon'
+)
+
+const persistedChromium = notifications.persistablePopup(
+  iconOnlyChromium,
+  '/tmp/omarchy-notification-images/'
+)
+
+assert(
+  persistedChromium.entry.appIcon.indexOf('microsoft-edge') < 0,
+  'notifications persistence may replace the browser-identifying app icon'
+)
+
+const restoredChromium = notifications.parsePopupFiles(
+  notifications.serializePopup(persistedChromium.entry, 1),
+  1
+)[0]
+
+assertEqual(
+  restoredChromium.chromiumDerived,
+  true,
+  'notifications preserve chromium classification across popup serialization'
+)
+
+assert(
+  !notifications.shouldPersistPopup(restoredChromium.chromiumDerived, restoredChromium.urgency, 2),
+  'restored critical chromium-derived notifications keep a finite lifetime'
 )
 assert(
   !notifications.popupRowChanged(replacement, replacement),

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -12,6 +12,23 @@ assert(notifications.isChromiumDerived('Brave Browser', ''), 'notifications dete
 assert(notifications.isChromiumDerived('', 'microsoft-edge'), 'notifications detect chromium-derived apps by icon')
 assert(!notifications.isChromiumDerived('Slack', ''), 'notifications do not treat unrelated apps as chromium-derived')
 
+assert(
+  !notifications.shouldPersistPopup('Brave Browser', '', 2, 2),
+  'critical chromium-derived notifications use a finite popup lifetime'
+)
+assert(
+  !notifications.shouldPersistPopup('', 'microsoft-edge', 2, 2),
+  'critical chromium-derived notifications are detected by icon'
+)
+assert(
+  notifications.shouldPersistPopup('Slack', '', 2, 2),
+  'critical non-browser notifications remain persistent'
+)
+assert(
+  !notifications.shouldPersistPopup('Slack', '', 1, 2),
+  'normal notifications are never treated as persistent'
+)
+
 assertEqual(
   notifications.sanitizeBody('<img src="x">Hello', 'Slack', ''),
   'Hello',


### PR DESCRIPTION
## Summary

Prevents critical notifications from Chromium-derived browsers from remaining on screen indefinitely.

Chromium-based browsers can send web notifications with `urgency=2` (critical) and `expireTimeout=0`. The Omarchy notification service currently treats every critical notification as persistent, resulting in browser notifications that never expire.

This change keeps persistent behavior for critical non-browser notifications while giving Chromium-derived notifications the standard finite popup lifetime.

## Root cause

The notification service currently maps every `NotificationUrgency.Critical` notification to a lifetime of `0`, which means the popup timer never runs.

A Chromium web notification can arrive as:

```text
urgency=2
expireTimeout=0
```

This causes it to be treated as permanently persistent even though it is a regular web notification.

## Changes

- Add `shouldPersistPopup()` to centralize the persistence decision.
- Reuse the existing `isChromiumDerived()` detection instead of introducing a separate browser list.
- Keep critical non-browser notifications persistent.
- Give critical Chromium-derived notifications a finite popup lifetime.
- Apply the same policy when restoring persisted popups.
- Add tests covering Chromium-derived and non-browser critical notifications.

## Validation

### Automated tests

```bash
bash test/shell.d/notifications-test.sh
bash test/shell.d/notification-send-test.sh
```

Both pass.

### Manual verification

Manually verified on Omarchy with Brave:

- normal notification expires normally
- critical non-browser notification remains persistent
- critical Brave web notification now expires normally

`git diff --check` also passes.