### PR TITLE
Restore pacman config after failed refresh

### DIFF
--- a/bin/omarchy-refresh-pacman
+++ b/bin/omarchy-refresh-pacman
@@ -13,14 +13,51 @@ if [[ $channel != "stable" && $channel != "rc" && $channel != "edge" ]]; then
   exit 1
 fi
 
+if rollback_dir=$(sudo mktemp -d); then
+  trap 'sudo rm -rf "$rollback_dir"' EXIT
+else
+  echo "Unable to create a secure pacman rollback directory. Aborting refresh." >&2
+  exit 1
+fi
+
+if sudo cp -f /etc/pacman.conf "$rollback_dir/pacman.conf" &&
+  sudo cp -f /etc/pacman.d/mirrorlist "$rollback_dir/mirrorlist"; then
+  :
+else
+  echo "Unable to preserve the current pacman configuration. Aborting refresh." >&2
+  exit 1
+fi
+
 echo "Setting channel to $channel"
 echo
 
-sudo cp -f "$OMARCHY_PATH/default/pacman/pacman-$channel.conf" /etc/pacman.conf
-sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$channel" /etc/pacman.d/mirrorlist
+apply_pacman_channel() {
+  sudo cp -f "$OMARCHY_PATH/default/pacman/pacman-$channel.conf" /etc/pacman.conf &&
+    sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$channel" /etc/pacman.d/mirrorlist &&
+    omarchy-hook pre-refresh-pacman &&
+    sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syyuu --noconfirm
+}
 
-# Allow user customization of /etc/pacman.conf before the upgrade runs
-omarchy-hook pre-refresh-pacman
+restore_pacman_config() {
+  local restore_status=0
 
-# Reset all package DBs and then update
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syyuu --noconfirm
+  sudo cp -f "$rollback_dir/pacman.conf" /etc/pacman.conf || restore_status=$?
+  sudo cp -f "$rollback_dir/mirrorlist" /etc/pacman.d/mirrorlist || restore_status=$?
+
+  return "$restore_status"
+}
+
+if apply_pacman_channel; then
+  exit 0
+else
+  refresh_status=$?
+  echo "Package refresh failed. Restoring the previous pacman configuration." >&2
+
+  if restore_pacman_config; then
+    echo "Previous pacman configuration restored." >&2
+  else
+    echo "Failed to restore the previous pacman configuration." >&2
+  fi
+
+  exit "$refresh_status"
+fi

--- a/test/shell.d/refresh-pacman-rollback-test.sh
+++ b/test/shell.d/refresh-pacman-rollback-test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+root_fs="$test_tmp/fs"
+log_file="$test_tmp/refresh.log"
+mkdir -p "$stub_bin" "$root_fs/etc/pacman.d"
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+
+printf 'sudo' >>"$OMARCHY_REFRESH_TEST_LOG"
+for arg in "$@"; do
+  printf '\t%s' "$arg" >>"$OMARCHY_REFRESH_TEST_LOG"
+done
+printf '\n' >>"$OMARCHY_REFRESH_TEST_LOG"
+
+action=$1
+shift
+
+case "$action" in
+  cp)
+    if [[ ${OMARCHY_REFRESH_TEST_CHANNEL_COPY_FAIL:-0} == "1" && $2 == "$OMARCHY_PATH/default/pacman/mirrorlist-stable" ]]; then
+      exit 1
+    fi
+
+    rerooted=()
+    for arg in "$@"; do
+      case "$arg" in
+        /etc/*) rerooted+=("$OMARCHY_REFRESH_TEST_ROOT$arg") ;;
+        *) rerooted+=("$arg") ;;
+      esac
+    done
+    command cp "${rerooted[@]}"
+    ;;
+  env)
+    [[ ${OMARCHY_REFRESH_TEST_PACMAN_FAIL:-0} == "0" ]]
+    ;;
+  mktemp | rm)
+    command "$action" "$@"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$stub_bin/sudo"
+
+cat >"$stub_bin/omarchy-hook" <<'STUB'
+#!/bin/bash
+
+printf 'hook\t%s\n' "$*" >>"$OMARCHY_REFRESH_TEST_LOG"
+[[ ${OMARCHY_REFRESH_TEST_HOOK_FAIL:-0} == "0" ]]
+STUB
+chmod +x "$stub_bin/omarchy-hook"
+
+reset_config() {
+  printf 'original pacman config\n' >"$root_fs/etc/pacman.conf"
+  printf 'original mirrorlist\n' >"$root_fs/etc/pacman.d/mirrorlist"
+  : >"$log_file"
+}
+
+run_refresh() {
+  OMARCHY_PATH="$ROOT" \
+    OMARCHY_REFRESH_TEST_LOG="$log_file" \
+    OMARCHY_REFRESH_TEST_ROOT="$root_fs" \
+    PATH="$stub_bin:$PATH" \
+    "$ROOT/bin/omarchy-refresh-pacman" stable
+}
+
+assert_original_config() {
+  grep -qx 'original pacman config' "$root_fs/etc/pacman.conf" ||
+    fail "$1" "pacman.conf: $(cat "$root_fs/etc/pacman.conf")"
+  grep -qx 'original mirrorlist' "$root_fs/etc/pacman.d/mirrorlist" ||
+    fail "$1" "mirrorlist: $(cat "$root_fs/etc/pacman.d/mirrorlist")"
+  pass "$1"
+}
+
+reset_config
+if OMARCHY_REFRESH_TEST_PACMAN_FAIL=1 run_refresh >"$test_tmp/pacman.out" 2>"$test_tmp/pacman.err"; then
+  fail "a failed package refresh returns non-zero"
+fi
+
+assert_original_config "a failed package refresh restores both pacman configuration files"
+grep -q 'Previous pacman configuration restored.' "$test_tmp/pacman.err" ||
+  fail "a failed package refresh reports the rollback" "$(cat "$test_tmp/pacman.err")"
+pass "a failed package refresh reports the rollback"
+
+reset_config
+if OMARCHY_REFRESH_TEST_CHANNEL_COPY_FAIL=1 run_refresh >"$test_tmp/channel-copy.out" 2>"$test_tmp/channel-copy.err"; then
+  fail "a failed channel copy returns non-zero"
+fi
+
+assert_original_config "a partial channel copy restores both pacman configuration files"
+if grep -q $'^hook\t' "$log_file" || grep -q $'^sudo\tenv\t' "$log_file"; then
+  fail "the hook and pacman do not run after a failed channel copy" "$(cat "$log_file")"
+fi
+pass "the hook and pacman do not run after a failed channel copy"
+
+reset_config
+if OMARCHY_REFRESH_TEST_HOOK_FAIL=1 run_refresh >"$test_tmp/hook.out" 2>"$test_tmp/hook.err"; then
+  fail "a failed pre-refresh hook returns non-zero"
+fi
+
+assert_original_config "a failed pre-refresh hook restores both pacman configuration files"
+if grep -q $'^sudo\tenv\t' "$log_file"; then
+  fail "pacman does not run after a failed pre-refresh hook" "$(cat "$log_file")"
+fi
+pass "pacman does not run after a failed pre-refresh hook"
+
+reset_config
+run_refresh >"$test_tmp/success.out" 2>"$test_tmp/success.err"
+
+cmp -s "$ROOT/default/pacman/pacman-stable.conf" "$root_fs/etc/pacman.conf" ||
+  fail "a successful refresh keeps the selected pacman config"
+cmp -s "$ROOT/default/pacman/mirrorlist-stable" "$root_fs/etc/pacman.d/mirrorlist" ||
+  fail "a successful refresh keeps the selected mirrorlist"
+pass "a successful refresh keeps the selected pacman configuration"


### PR DESCRIPTION
# Restore pacman config after failed refresh

## What changed

- Preserve root-owned, private copies of `/etc/pacman.conf` and `/etc/pacman.d/mirrorlist` before changing channels.
- Restore both files when channel configuration, the `pre-refresh-pacman` hook, or the package refresh fails.
- Keep the selected channel configuration after a successful refresh.
- Add shell regression coverage for partial channel-copy failure, hook failure, package-refresh failure, and success paths.

## Why

`omarchy-refresh-pacman` replaces both pacman configuration files before running the pre-refresh hook and `pacman -Syyuu`. If either step fails, the machine is left pointing at a channel that was never refreshed successfully.

This was reproduced by switching an ARM64 Omarchy development VM to the dev channel. The edge repositories returned 404 responses for aarch64, and the existing command left pacman pointing at those unusable repositories. With this change, the command reports the refresh failure, restores both previous configuration files, and returns the original failure status.

## Related work

I searched the issue and pull-request tracker before preparing this change and did not find an existing report or fix for rollback after a failed refresh.

#7998 timestamps the persistent user backup files and validates the channel before creating them. This change is separate and compatible: it uses private, root-owned transaction copies to restore the exact pre-refresh state when a later step fails.

## Tests

- `bash -n bin/omarchy-refresh-pacman test/shell.d/refresh-pacman-rollback-test.sh`
- `bash test/shell.d/refresh-pacman-rollback-test.sh`
- `bash test/shell.d/channel-test.sh`
- `./test/all` in the Omarchy ARM64 VM: the new test and 204 of 208 shell test files pass. The same four failures reproduce on the unmodified base commit: three require a separate `omarchy-pkgs` checkout, and `theme-install-guards-test.sh` also fails unchanged in this VM.
- VM acceptance: reproduced the aarch64 edge-repository 404, observed both pacman files being restored, completed the ARM fallback/update, rebooted, passed the dev-channel audit, and passed the full appliance verifier.
