### PR TITLE
Fix AQ_DRM_DEVICES by-path login loop

### DIFF
--- a/config/uwsm/env-hyprland.d/99-omarchy-aq-drm
+++ b/config/uwsm/env-hyprland.d/99-omarchy-aq-drm
@@ -1,0 +1,3 @@
+# Rewrite PCI by-path AQ_DRM_DEVICES after user env-hyprland.
+# Aquamarine splits on ':' (hyprwm/aquamarine#167).
+[ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"

--- a/config/uwsm/env-hyprland.d/zz-omarchy-aq-drm
+++ b/config/uwsm/env-hyprland.d/zz-omarchy-aq-drm
@@ -1,4 +1,5 @@
 # Rewrite PCI by-path AQ_DRM_DEVICES after user env-hyprland and env-hyprland.d.
-# zz- sorts after numeric prefixes and letter-named files like my_vars under POSIX ls.
+# zz- sorts after numeric prefixes and letter-named files like my_vars under POSIX ls;
+# a later name such as zzz- still loads after this file.
 # Aquamarine splits on ':' (hyprwm/aquamarine#167).
 [ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"

--- a/config/uwsm/env-hyprland.d/zz-omarchy-aq-drm
+++ b/config/uwsm/env-hyprland.d/zz-omarchy-aq-drm
@@ -1,4 +1,4 @@
 # Rewrite PCI by-path AQ_DRM_DEVICES after user env-hyprland and env-hyprland.d.
-# zz- sorts after numeric and alphabetic names under POSIX ls (uwsm's loader).
+# zz- sorts after numeric prefixes and letter-named files like my_vars under POSIX ls.
 # Aquamarine splits on ':' (hyprwm/aquamarine#167).
 [ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"

--- a/config/uwsm/env-hyprland.d/zz-omarchy-aq-drm
+++ b/config/uwsm/env-hyprland.d/zz-omarchy-aq-drm
@@ -1,3 +1,4 @@
-# Rewrite PCI by-path AQ_DRM_DEVICES after user env-hyprland.
+# Rewrite PCI by-path AQ_DRM_DEVICES after user env-hyprland and env-hyprland.d.
+# zz- sorts after numeric and alphabetic names under POSIX ls (uwsm's loader).
 # Aquamarine splits on ':' (hyprwm/aquamarine#167).
 [ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"

--- a/default/uwsm/sanitize-aq-drm-devices
+++ b/default/uwsm/sanitize-aq-drm-devices
@@ -4,55 +4,90 @@
 # and SDDM autologin loops with no compositor error.
 #
 # Sourced from ~/.config/uwsm/env-hyprland.d after the wiki-documented
-# env-hyprland export. Colon-free pins (cardN, udev names) are left alone.
+# env-hyprland export. zz- sorts after numeric and alphabetic drop-ins under
+# POSIX ls (uwsm's loader). Colon-free pins (cardN, udev names) are left alone.
 # A set-but-empty value is unset: getenv non-null takes the explicit path,
 # and CVarList on "" yields no GPUs.
+#
+# Split on ':' like Aquamarine (removeEmpty), then reassemble PCI by-path
+# fragments (pci-DOMAIN:BUS:DEV.FUNC, two colons after pci-) so the pin
+# survives.
+
+omarchy_sanitize_aq_drm_emit() {
+  _omarchy_aq_path=$1
+  [[ -n $_omarchy_aq_path ]] || return 0
+
+  case "$_omarchy_aq_path" in
+    *:*)
+      _omarchy_aq_real=$(readlink -e "$_omarchy_aq_path" 2>/dev/null || true)
+      case "${_omarchy_aq_real:-}" in
+        ""|*:* ) return 0 ;;
+      esac
+      _omarchy_aq_path=$_omarchy_aq_real
+      ;;
+  esac
+
+  if [[ -n $_omarchy_aq_out ]]; then
+    _omarchy_aq_out=$_omarchy_aq_out:$_omarchy_aq_path
+  else
+    _omarchy_aq_out=$_omarchy_aq_path
+  fi
+}
 
 omarchy_sanitize_aq_drm_devices() {
-  if [ -z "${AQ_DRM_DEVICES:-}" ]; then
+  if [[ -z ${AQ_DRM_DEVICES:-} ]]; then
     unset AQ_DRM_DEVICES
     return 0
   fi
 
   _omarchy_aq_rest=$AQ_DRM_DEVICES
   _omarchy_aq_out=
+  _omarchy_aq_cur=
 
-  while [ -n "$_omarchy_aq_rest" ]; do
+  while :; do
     case "$_omarchy_aq_rest" in
-      *:/*)
-        _omarchy_aq_path=${_omarchy_aq_rest%%:/*}
-        _omarchy_aq_rest=/${_omarchy_aq_rest#*:/}
+      *:*)
+        _omarchy_aq_part=${_omarchy_aq_rest%%:*}
+        _omarchy_aq_rest=${_omarchy_aq_rest#*:}
         ;;
       *)
-        _omarchy_aq_path=$_omarchy_aq_rest
+        _omarchy_aq_part=$_omarchy_aq_rest
         _omarchy_aq_rest=
         ;;
     esac
 
-    # Aquamarine splits on ':' with removeEmpty=true. The :/ split leaves a
-    # trailing colon on the previous token (card1::/other → card1:), which
-    # would otherwise look like an unresolvable by-path and drop a working GPU.
-    _omarchy_aq_path=${_omarchy_aq_path%:}
-    [ -n "$_omarchy_aq_path" ] || continue
-
-    case "$_omarchy_aq_path" in
-      *:*)
-        _omarchy_aq_real=$(readlink -e "$_omarchy_aq_path" 2>/dev/null || true)
-        case "${_omarchy_aq_real:-}" in
-          ""|*:* ) continue ;;
+    if [[ -n $_omarchy_aq_part ]]; then
+      if [[ -z $_omarchy_aq_cur ]]; then
+        _omarchy_aq_cur=$_omarchy_aq_part
+      else
+        _omarchy_aq_glue=
+        case "$_omarchy_aq_cur" in
+          *pci-[0-9a-fA-F]*)
+            _omarchy_aq_pci=${_omarchy_aq_cur##*pci-}
+            _omarchy_aq_colons=${_omarchy_aq_pci//[^:]/}
+            if (( ${#_omarchy_aq_colons} < 2 )); then
+              case "$_omarchy_aq_part" in
+                [0-9a-fA-F]*) _omarchy_aq_glue=1 ;;
+              esac
+            fi
+            ;;
         esac
-        _omarchy_aq_path=$_omarchy_aq_real
-        ;;
-    esac
 
-    if [ -n "$_omarchy_aq_out" ]; then
-      _omarchy_aq_out=$_omarchy_aq_out:$_omarchy_aq_path
-    else
-      _omarchy_aq_out=$_omarchy_aq_path
+        if [[ -n $_omarchy_aq_glue ]]; then
+          _omarchy_aq_cur=$_omarchy_aq_cur:$_omarchy_aq_part
+        else
+          omarchy_sanitize_aq_drm_emit "$_omarchy_aq_cur"
+          _omarchy_aq_cur=$_omarchy_aq_part
+        fi
+      fi
     fi
+
+    [[ -n $_omarchy_aq_rest ]] || break
   done
 
-  if [ -n "$_omarchy_aq_out" ]; then
+  [[ -n $_omarchy_aq_cur ]] && omarchy_sanitize_aq_drm_emit "$_omarchy_aq_cur"
+
+  if [[ -n $_omarchy_aq_out ]]; then
     AQ_DRM_DEVICES=$_omarchy_aq_out
     export AQ_DRM_DEVICES
   else
@@ -60,7 +95,9 @@ omarchy_sanitize_aq_drm_devices() {
   fi
 
   unset _omarchy_aq_rest _omarchy_aq_out _omarchy_aq_path _omarchy_aq_real
+  unset _omarchy_aq_part _omarchy_aq_cur _omarchy_aq_glue
+  unset _omarchy_aq_pci _omarchy_aq_colons
 }
 
 omarchy_sanitize_aq_drm_devices
-unset -f omarchy_sanitize_aq_drm_devices
+unset -f omarchy_sanitize_aq_drm_devices omarchy_sanitize_aq_drm_emit

--- a/default/uwsm/sanitize-aq-drm-devices
+++ b/default/uwsm/sanitize-aq-drm-devices
@@ -4,14 +4,14 @@
 # and SDDM autologin loops with no compositor error.
 #
 # Sourced from ~/.config/uwsm/env-hyprland.d after the wiki-documented
-# env-hyprland export. zz- sorts after numeric and alphabetic drop-ins under
-# POSIX ls (uwsm's loader). Colon-free pins (cardN, udev names) are left alone.
-# A set-but-empty value is unset: getenv non-null takes the explicit path,
-# and CVarList on "" yields no GPUs.
+# env-hyprland export. zz- sorts after numeric prefixes and letter-named
+# files like my_vars under POSIX ls (uwsm's loader). Colon-free pins
+# (cardN, udev names) are left alone. A set-but-empty value is unset:
+# getenv non-null takes the explicit path, and CVarList on "" yields no GPUs.
 #
-# Split on ':' like Aquamarine (removeEmpty), then reassemble PCI by-path
-# fragments (pci-DOMAIN:BUS:DEV.FUNC, two colons after pci-) so the pin
-# survives.
+# Split on ':' like Aquamarine (removeEmpty). A by-path name runs to the
+# next '/', so keep absorbing colon fragments until the accumulated path
+# exists. Anything absolute starts a new entry.
 
 omarchy_sanitize_aq_drm_emit() {
   _omarchy_aq_path=$1
@@ -60,14 +60,16 @@ omarchy_sanitize_aq_drm_devices() {
       if [[ -z $_omarchy_aq_cur ]]; then
         _omarchy_aq_cur=$_omarchy_aq_part
       else
+        # A by-path name runs to the next '/', so keep absorbing colon
+        # fragments until the accumulated path exists. Anything absolute
+        # starts a new entry.
         _omarchy_aq_glue=
         case "$_omarchy_aq_cur" in
-          *pci-[0-9a-fA-F]*)
-            _omarchy_aq_pci=${_omarchy_aq_cur##*pci-}
-            _omarchy_aq_colons=${_omarchy_aq_pci//[^:]/}
-            if (( ${#_omarchy_aq_colons} < 2 )); then
+          */by-path/*)
+            if [[ ! -e $_omarchy_aq_cur ]]; then
               case "$_omarchy_aq_part" in
-                [0-9a-fA-F]*) _omarchy_aq_glue=1 ;;
+                /*) ;;
+                *) _omarchy_aq_glue=1 ;;
               esac
             fi
             ;;
@@ -96,7 +98,6 @@ omarchy_sanitize_aq_drm_devices() {
 
   unset _omarchy_aq_rest _omarchy_aq_out _omarchy_aq_path _omarchy_aq_real
   unset _omarchy_aq_part _omarchy_aq_cur _omarchy_aq_glue
-  unset _omarchy_aq_pci _omarchy_aq_colons
 }
 
 omarchy_sanitize_aq_drm_devices

--- a/default/uwsm/sanitize-aq-drm-devices
+++ b/default/uwsm/sanitize-aq-drm-devices
@@ -5,9 +5,14 @@
 #
 # Sourced from ~/.config/uwsm/env-hyprland.d after the wiki-documented
 # env-hyprland export. Colon-free pins (cardN, udev names) are left alone.
+# A set-but-empty value is unset: getenv non-null takes the explicit path,
+# and CVarList on "" yields no GPUs.
 
 omarchy_sanitize_aq_drm_devices() {
-  [ -n "${AQ_DRM_DEVICES:-}" ] || return 0
+  if [ -z "${AQ_DRM_DEVICES:-}" ]; then
+    unset AQ_DRM_DEVICES
+    return 0
+  fi
 
   _omarchy_aq_rest=$AQ_DRM_DEVICES
   _omarchy_aq_out=
@@ -24,14 +29,15 @@ omarchy_sanitize_aq_drm_devices() {
         ;;
     esac
 
+    # Aquamarine splits on ':' with removeEmpty=true. The :/ split leaves a
+    # trailing colon on the previous token (card1::/other → card1:), which
+    # would otherwise look like an unresolvable by-path and drop a working GPU.
+    _omarchy_aq_path=${_omarchy_aq_path%:}
     [ -n "$_omarchy_aq_path" ] || continue
 
     case "$_omarchy_aq_path" in
       *:*)
-        _omarchy_aq_real=
-        if [ -e "$_omarchy_aq_path" ] || [ -L "$_omarchy_aq_path" ]; then
-          _omarchy_aq_real=$(readlink -f "$_omarchy_aq_path" 2>/dev/null || true)
-        fi
+        _omarchy_aq_real=$(readlink -e "$_omarchy_aq_path" 2>/dev/null || true)
         case "${_omarchy_aq_real:-}" in
           ""|*:* ) continue ;;
         esac

--- a/default/uwsm/sanitize-aq-drm-devices
+++ b/default/uwsm/sanitize-aq-drm-devices
@@ -5,13 +5,14 @@
 #
 # Sourced from ~/.config/uwsm/env-hyprland.d after the wiki-documented
 # env-hyprland export. zz- sorts after numeric prefixes and letter-named
-# files like my_vars under POSIX ls (uwsm's loader). Colon-free pins
-# (cardN, udev names) are left alone. A set-but-empty value is unset:
-# getenv non-null takes the explicit path, and CVarList on "" yields no GPUs.
+# files like my_vars under POSIX ls (uwsm's loader); a later name such as
+# zzz- still loads after this file. Colon-free pins (cardN, udev names)
+# are left alone. A set-but-empty value is unset: getenv non-null takes
+# the explicit path, and CVarList on "" yields no GPUs.
 #
-# Split on ':' like Aquamarine (removeEmpty). A by-path name runs to the
-# next '/', so keep absorbing colon fragments until the accumulated path
-# exists. Anything absolute starts a new entry.
+# Split on ':' like Aquamarine (removeEmpty). A by-path name absorbs colon
+# fragments until it exists or ends in udev's -card/-control/-render suffix.
+# A continuation containing '/' starts a new entry.
 
 omarchy_sanitize_aq_drm_emit() {
   _omarchy_aq_path=$1
@@ -60,15 +61,16 @@ omarchy_sanitize_aq_drm_devices() {
       if [[ -z $_omarchy_aq_cur ]]; then
         _omarchy_aq_cur=$_omarchy_aq_part
       else
-        # A by-path name runs to the next '/', so keep absorbing colon
-        # fragments until the accumulated path exists. Anything absolute
-        # starts a new entry.
+        # Keep absorbing colon fragments until the by-path exists or hits
+        # udev's DRM suffix. A continuation containing '/' is a new entry.
         _omarchy_aq_glue=
         case "$_omarchy_aq_cur" in
+          */by-path/*-card|*/by-path/*-control|*/by-path/*-render)
+            ;;
           */by-path/*)
             if [[ ! -e $_omarchy_aq_cur ]]; then
               case "$_omarchy_aq_part" in
-                /*) ;;
+                */*) ;;
                 *) _omarchy_aq_glue=1 ;;
               esac
             fi

--- a/default/uwsm/sanitize-aq-drm-devices
+++ b/default/uwsm/sanitize-aq-drm-devices
@@ -1,0 +1,60 @@
+# Resolve PCI by-path entries in AQ_DRM_DEVICES to real DRM nodes.
+# Aquamarine splits this variable on ':' (hyprwm/aquamarine#167), so a path
+# like /dev/dri/by-path/pci-0000:13:00.0-card is truncated, Hyprland dies,
+# and SDDM autologin loops with no compositor error.
+#
+# Sourced from ~/.config/uwsm/env-hyprland.d after the wiki-documented
+# env-hyprland export. Colon-free pins (cardN, udev names) are left alone.
+
+omarchy_sanitize_aq_drm_devices() {
+  [ -n "${AQ_DRM_DEVICES:-}" ] || return 0
+
+  _omarchy_aq_rest=$AQ_DRM_DEVICES
+  _omarchy_aq_out=
+
+  while [ -n "$_omarchy_aq_rest" ]; do
+    case "$_omarchy_aq_rest" in
+      *:/*)
+        _omarchy_aq_path=${_omarchy_aq_rest%%:/*}
+        _omarchy_aq_rest=/${_omarchy_aq_rest#*:/}
+        ;;
+      *)
+        _omarchy_aq_path=$_omarchy_aq_rest
+        _omarchy_aq_rest=
+        ;;
+    esac
+
+    [ -n "$_omarchy_aq_path" ] || continue
+
+    case "$_omarchy_aq_path" in
+      *:*)
+        _omarchy_aq_real=
+        if [ -e "$_omarchy_aq_path" ] || [ -L "$_omarchy_aq_path" ]; then
+          _omarchy_aq_real=$(readlink -f "$_omarchy_aq_path" 2>/dev/null || true)
+        fi
+        case "${_omarchy_aq_real:-}" in
+          ""|*:* ) continue ;;
+        esac
+        _omarchy_aq_path=$_omarchy_aq_real
+        ;;
+    esac
+
+    if [ -n "$_omarchy_aq_out" ]; then
+      _omarchy_aq_out=$_omarchy_aq_out:$_omarchy_aq_path
+    else
+      _omarchy_aq_out=$_omarchy_aq_path
+    fi
+  done
+
+  if [ -n "$_omarchy_aq_out" ]; then
+    AQ_DRM_DEVICES=$_omarchy_aq_out
+    export AQ_DRM_DEVICES
+  else
+    unset AQ_DRM_DEVICES
+  fi
+
+  unset _omarchy_aq_rest _omarchy_aq_out _omarchy_aq_path _omarchy_aq_real
+}
+
+omarchy_sanitize_aq_drm_devices
+unset -f omarchy_sanitize_aq_drm_devices

--- a/default/uwsm/sanitize-aq-drm-devices
+++ b/default/uwsm/sanitize-aq-drm-devices
@@ -7,8 +7,9 @@
 # env-hyprland export. zz- sorts after numeric prefixes and letter-named
 # files like my_vars under POSIX ls (uwsm's loader); a later name such as
 # zzz- still loads after this file. Colon-free pins (cardN, udev names)
-# are left alone. A set-but-empty value is unset: getenv non-null takes
-# the explicit path, and CVarList on "" yields no GPUs.
+# are left alone, but every by-path entry is resolved so a stale one is
+# dropped. A set-but-empty value is unset: getenv non-null takes the
+# explicit path, and CVarList on "" yields no GPUs.
 #
 # Split on ':' like Aquamarine (removeEmpty). A by-path name absorbs colon
 # fragments until it exists or ends in udev's -card/-control/-render suffix.
@@ -18,8 +19,10 @@ omarchy_sanitize_aq_drm_emit() {
   _omarchy_aq_path=$1
   [[ -n $_omarchy_aq_path ]] || return 0
 
+  # Resolve every by-path entry, not just the colon-bearing ones: a colon-free
+  # name like platform-vkms-card is still unusable once the device is gone.
   case "$_omarchy_aq_path" in
-    *:*)
+    *:*|*/by-path/*)
       _omarchy_aq_real=$(readlink -e "$_omarchy_aq_path" 2>/dev/null || true)
       case "${_omarchy_aq_real:-}" in
         ""|*:* ) return 0 ;;

--- a/migrations/1787934927.sh
+++ b/migrations/1787934927.sh
@@ -3,7 +3,7 @@ echo "Install UWSM drop-in to resolve PCI by-path AQ_DRM_DEVICES"
 src="$OMARCHY_PATH/config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
 dst="$HOME/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
 
-if [[ -f $src ]] && ! [[ -e $dst ]]; then
+if [[ -f $src ]] && ! [[ -e $dst || -L $dst ]]; then
   mkdir -p "$(dirname "$dst")"
   cp "$src" "$dst"
 fi

--- a/migrations/1787934927.sh
+++ b/migrations/1787934927.sh
@@ -1,9 +1,15 @@
 echo "Install UWSM drop-in to resolve PCI by-path AQ_DRM_DEVICES"
 
-src="$OMARCHY_PATH/config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
-dst="$HOME/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+src="$OMARCHY_PATH/config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
+dst="$HOME/.config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
+old="$HOME/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
 
 if [[ -f $src ]] && ! [[ -e $dst || -L $dst ]]; then
   mkdir -p "$(dirname "$dst")"
   cp "$src" "$dst"
+fi
+
+# 99- sorts before letter-named user drop-ins under POSIX ls.
+if [[ -f $old ]] && ! [[ -L $old ]] && grep -q 'sanitize-aq-drm-devices' "$old"; then
+  rm -f "$old"
 fi

--- a/migrations/1787934927.sh
+++ b/migrations/1787934927.sh
@@ -10,6 +10,11 @@ if [[ -f $src ]] && ! [[ -e $dst || -L $dst ]]; then
 fi
 
 # 99- sorts before letter-named user drop-ins under POSIX ls.
-if [[ -f $old ]] && ! [[ -L $old ]] && grep -qxF '[ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"' "$old"; then
+# Remove only the exact previously shipped drop-in, not a user file that
+# happens to contain the helper source line.
+if [[ -f $old ]] && ! [[ -L $old ]] && cmp -s "$old" <(printf '%s\n' \
+  '# Rewrite PCI by-path AQ_DRM_DEVICES after user env-hyprland.' \
+  "# Aquamarine splits on ':' (hyprwm/aquamarine#167)." \
+  '[ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"'); then
   rm -f "$old"
 fi

--- a/migrations/1787934927.sh
+++ b/migrations/1787934927.sh
@@ -10,6 +10,6 @@ if [[ -f $src ]] && ! [[ -e $dst || -L $dst ]]; then
 fi
 
 # 99- sorts before letter-named user drop-ins under POSIX ls.
-if [[ -f $old ]] && ! [[ -L $old ]] && grep -q 'sanitize-aq-drm-devices' "$old"; then
+if [[ -f $old ]] && ! [[ -L $old ]] && grep -qxF '[ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"' "$old"; then
   rm -f "$old"
 fi

--- a/migrations/1787934927.sh
+++ b/migrations/1787934927.sh
@@ -1,0 +1,9 @@
+echo "Install UWSM drop-in to resolve PCI by-path AQ_DRM_DEVICES"
+
+src="$OMARCHY_PATH/config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+dst="$HOME/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+
+if [[ -f $src ]] && ! [[ -e $dst ]]; then
+  mkdir -p "$(dirname "$dst")"
+  cp "$src" "$dst"
+fi

--- a/test/shell.d/aq-drm-devices-test.sh
+++ b/test/shell.d/aq-drm-devices-test.sh
@@ -28,14 +28,20 @@ run_sanitize() {
   fi
 }
 
-[[ $(run_sanitize "") == "" ]] || fail "empty AQ_DRM_DEVICES is a no-op"
-pass "empty AQ_DRM_DEVICES is a no-op"
+[[ $(run_sanitize "") == "__UNSET__" ]] || fail "empty AQ_DRM_DEVICES is unset"
+pass "empty AQ_DRM_DEVICES is unset"
 
 [[ $(run_sanitize "/dev/dri/amd-igpu") == "/dev/dri/amd-igpu" ]] || fail "colon-free pin is left alone"
 pass "colon-free pin is left alone"
 
 [[ $(run_sanitize "/dev/dri/card0:/dev/dri/card1") == "/dev/dri/card0:/dev/dri/card1" ]] || fail "colon-free list is left alone"
 pass "colon-free list is left alone"
+
+[[ $(run_sanitize "/dev/dri/card1::/does-not-exist") == "/dev/dri/card1:/does-not-exist" ]] || fail "empty list component does not drop the previous GPU"
+pass "empty list component does not drop the previous GPU"
+
+[[ $(run_sanitize "/dev/dri/card1:") == "/dev/dri/card1" ]] || fail "trailing colon is stripped"
+pass "trailing colon is stripped"
 
 [[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0-card") == "__UNSET__" ]] || fail "missing by-path is dropped so Aquamarine cannot split it"
 pass "missing by-path is dropped so Aquamarine cannot split it"
@@ -52,6 +58,9 @@ mkdir -p "$dir/dri"
 [[ $(run_sanitize "$dir/dri/card0:$dir/dri/card1") == "$dir/dri/card0:$dir/dri/card1" ]] || fail "existing cardN list is left alone"
 pass "existing cardN list is left alone"
 
+[[ $(run_sanitize "$dir/dri/card0::$dir/dri/card1") == "$dir/dri/card0:$dir/dri/card1" ]] || fail "empty component between existing cards keeps both"
+pass "empty component between existing cards keeps both"
+
 mixed=$(run_sanitize "$dir/dri/card0:/dev/dri/by-path/pci-0000:13:00.0-card")
 [[ $mixed == "$dir/dri/card0" ]] || fail "usable card is kept when a by-path sibling is dropped" "$mixed"
 pass "usable card is kept when a by-path sibling is dropped"
@@ -59,18 +68,26 @@ pass "usable card is kept when a by-path sibling is dropped"
 by_dir="$dir/dri/by-path"
 by_path="$by_dir/pci-0000:13:00.0-card"
 if mkdir -p "$by_dir" && ln -s "$dir/dri/card0" "$by_path" 2>/dev/null; then
-  resolved=$(readlink -f "$by_path" 2>/dev/null || true)
+  resolved=$(readlink -e "$by_path" 2>/dev/null || true)
   if [[ -n $resolved && $resolved != *:* && $resolved == "$dir/dri/card0" ]]; then
     [[ $(run_sanitize "$by_path") == "$dir/dri/card0" ]] || fail "by-path symlink is resolved to the DRM node"
     pass "by-path symlink is resolved to the DRM node"
 
     [[ $(run_sanitize "$by_path:/dev/dri/by-path/pci-0000:03:00.0-card") == "$dir/dri/card0" ]] || fail "resolved by-path is kept when a missing sibling is dropped"
     pass "resolved by-path is kept when a missing sibling is dropped"
+
+    dangling="$by_dir/pci-0000:03:00.0-card"
+    if ln -s "$dir/dri/card99" "$dangling" 2>/dev/null; then
+      [[ $(run_sanitize "$dangling") == "__UNSET__" ]] || fail "dangling by-path is dropped"
+      pass "dangling by-path is dropped"
+    else
+      printf 'skip - cannot create a dangling by-path symlink here\n'
+    fi
   else
-    pass "by-path filenames are not usable here; skip symlink resolution"
+    printf 'skip - by-path filenames are not usable here; symlink resolution not exercised\n'
   fi
 else
-  pass "by-path filenames are not usable here; skip symlink resolution"
+  printf 'skip - by-path filenames are not usable here; symlink resolution not exercised\n'
 fi
 
 dropin_out=$(
@@ -88,6 +105,18 @@ dropin_out=$(
 )
 [[ $dropin_out == "__UNSET__" ]] || fail "sourcing the drop-in sanitizes AQ_DRM_DEVICES" "$dropin_out"
 pass "sourcing the drop-in sanitizes AQ_DRM_DEVICES"
+
+test_home=$(mktemp -d)
+dst="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+mkdir -p "$(dirname "$dst")"
+if ln -s "$test_home/missing-drop-in" "$dst" 2>/dev/null; then
+  HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null || fail "migration no-ops on a dangling drop-in symlink"
+  [[ -L $dst ]] || fail "migration leaves a dangling drop-in symlink in place"
+  pass "migration no-ops on a dangling drop-in symlink"
+else
+  printf 'skip - cannot create a dangling drop-in symlink here\n'
+fi
+rm -rf "$test_home"
 
 test_home=$(mktemp -d)
 dst="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"

--- a/test/shell.d/aq-drm-devices-test.sh
+++ b/test/shell.d/aq-drm-devices-test.sh
@@ -69,6 +69,15 @@ pass "missing by-path is dropped so Aquamarine cannot split it"
 [[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0-card:/dev/dri/by-path/pci-0000:03:00.0-card") == "__UNSET__" ]] || fail "missing by-path list is dropped"
 pass "missing by-path list is dropped"
 
+[[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0-card:rel/mygpu") == "rel/mygpu" ]] || fail "stale by-path does not swallow a following relative entry"
+pass "stale by-path does not swallow a following relative entry"
+
+[[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0-card:card1") == "card1" ]] || fail "stale by-path does not swallow a following cardN pin"
+pass "stale by-path does not swallow a following cardN pin"
+
+[[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0:rel/mygpu") == "rel/mygpu" ]] || fail "incomplete by-path does not absorb a slash-containing continuation"
+pass "incomplete by-path does not absorb a slash-containing continuation"
+
 usb_missing="/dev/dri/by-path/pci-0000:00:14.0-usb-0:8:1.0-card"
 [[ $(run_sanitize "$usb_missing") == "__UNSET__" ]] || fail "missing USB by-path is dropped instead of exporting debris"
 pass "missing USB by-path is dropped instead of exporting debris"
@@ -106,6 +115,9 @@ if mkdir -p "$by_dir" && ln -s "$dir/dri/card0" "$by_path" 2>/dev/null; then
 
     [[ $(run_sanitize "$by_path:$dir/dri/card1") == "$dir/dri/card0:$dir/dri/card1" ]] || fail "resolved by-path keeps a following colon-free pin"
     pass "resolved by-path keeps a following colon-free pin"
+
+    [[ $(run_sanitize "$by_path:rel/mygpu") == "$dir/dri/card0:rel/mygpu" ]] || fail "resolved by-path keeps a following relative entry"
+    pass "resolved by-path keeps a following relative entry"
 
     usb_path="$by_dir/pci-0000:00:14.0-usb-0:8:1.0-card"
     if ln -s "$dir/dri/card0" "$usb_path" 2>/dev/null; then
@@ -184,6 +196,20 @@ dst="$test_home/.config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
 old="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
 mkdir -p "$(dirname "$old")"
 printf '%s\n' '# leftover' '[ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"' >"$old"
+HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
+[[ -f $dst ]] || fail "migration installs the zz- drop-in beside an edited leftover 99-"
+[[ -f $old ]] || fail "migration leaves a 99- file that is not the exact shipped drop-in"
+pass "migration leaves a 99- file that is not the exact shipped drop-in"
+rm -rf "$test_home"
+
+test_home=$(mktemp -d)
+dst="$test_home/.config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
+old="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+mkdir -p "$(dirname "$old")"
+printf '%s\n' \
+  '# Rewrite PCI by-path AQ_DRM_DEVICES after user env-hyprland.' \
+  "# Aquamarine splits on ':' (hyprwm/aquamarine#167)." \
+  '[ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"' >"$old"
 HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
 [[ -f $dst ]] || fail "migration installs the zz- drop-in"
 [[ ! -e $old ]] || fail "migration removes the leftover sanitizer 99- drop-in"

--- a/test/shell.d/aq-drm-devices-test.sh
+++ b/test/shell.d/aq-drm-devices-test.sh
@@ -48,6 +48,9 @@ pass "udev-name list is left alone"
 [[ $(run_sanitize "/dev/dri/card0:card1") == "/dev/dri/card0:card1" ]] || fail "mixed colon-free list is left alone"
 pass "mixed colon-free list is left alone"
 
+[[ $(run_sanitize "amd-pci-dgpu:card1") == "amd-pci-dgpu:card1" ]] || fail "udev alias containing pci- is not glued to the next pin"
+pass "udev alias containing pci- is not glued to the next pin"
+
 [[ $(run_sanitize "/dev/dri/card1::/does-not-exist") == "/dev/dri/card1:/does-not-exist" ]] || fail "empty list component does not drop the previous GPU"
 pass "empty list component does not drop the previous GPU"
 
@@ -66,6 +69,10 @@ pass "missing by-path is dropped so Aquamarine cannot split it"
 [[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0-card:/dev/dri/by-path/pci-0000:03:00.0-card") == "__UNSET__" ]] || fail "missing by-path list is dropped"
 pass "missing by-path list is dropped"
 
+usb_missing="/dev/dri/by-path/pci-0000:00:14.0-usb-0:8:1.0-card"
+[[ $(run_sanitize "$usb_missing") == "__UNSET__" ]] || fail "missing USB by-path is dropped instead of exporting debris"
+pass "missing USB by-path is dropped instead of exporting debris"
+
 dir=$(mktemp -d)
 trap 'rm -rf "$dir"' EXIT
 mkdir -p "$dir/dri"
@@ -82,6 +89,10 @@ mixed=$(run_sanitize "$dir/dri/card0:/dev/dri/by-path/pci-0000:13:00.0-card")
 [[ $mixed == "$dir/dri/card0" ]] || fail "usable card is kept when a by-path sibling is dropped" "$mixed"
 pass "usable card is kept when a by-path sibling is dropped"
 
+usb_then_card=$(run_sanitize "$usb_missing:$dir/dri/card0")
+[[ $usb_then_card == "$dir/dri/card0" ]] || fail "usable card is kept when a missing USB by-path sibling is dropped" "$usb_then_card"
+pass "usable card is kept when a missing USB by-path sibling is dropped"
+
 by_dir="$dir/dri/by-path"
 by_path="$by_dir/pci-0000:13:00.0-card"
 if mkdir -p "$by_dir" && ln -s "$dir/dri/card0" "$by_path" 2>/dev/null; then
@@ -95,6 +106,14 @@ if mkdir -p "$by_dir" && ln -s "$dir/dri/card0" "$by_path" 2>/dev/null; then
 
     [[ $(run_sanitize "$by_path:$dir/dri/card1") == "$dir/dri/card0:$dir/dri/card1" ]] || fail "resolved by-path keeps a following colon-free pin"
     pass "resolved by-path keeps a following colon-free pin"
+
+    usb_path="$by_dir/pci-0000:00:14.0-usb-0:8:1.0-card"
+    if ln -s "$dir/dri/card0" "$usb_path" 2>/dev/null; then
+      [[ $(run_sanitize "$usb_path") == "$dir/dri/card0" ]] || fail "USB by-path with extra colons is resolved to the DRM node"
+      pass "USB by-path with extra colons is resolved to the DRM node"
+    else
+      printf 'skip - cannot create a USB by-path symlink here\n'
+    fi
 
     dangling="$by_dir/pci-0000:03:00.0-card"
     if ln -s "$dir/dri/card99" "$dangling" 2>/dev/null; then
@@ -153,7 +172,18 @@ test_home=$(mktemp -d)
 dst="$test_home/.config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
 old="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
 mkdir -p "$(dirname "$old")"
-printf '%s\n' '[ -r helper ] && . helper # sanitize-aq-drm-devices' >"$old"
+printf '%s\n' '# mention sanitize-aq-drm-devices in a comment' 'export FOO=1' >"$old"
+HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
+[[ -f $dst ]] || fail "migration installs the zz- drop-in beside a 99- comment mention"
+[[ -f $old ]] || fail "migration leaves a 99- file that only mentions the helper"
+pass "migration leaves a 99- file that only mentions the helper"
+rm -rf "$test_home"
+
+test_home=$(mktemp -d)
+dst="$test_home/.config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
+old="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+mkdir -p "$(dirname "$old")"
+printf '%s\n' '# leftover' '[ -r "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices" ] && . "${OMARCHY_PATH%/}/default/uwsm/sanitize-aq-drm-devices"' >"$old"
 HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
 [[ -f $dst ]] || fail "migration installs the zz- drop-in"
 [[ ! -e $old ]] || fail "migration removes the leftover sanitizer 99- drop-in"

--- a/test/shell.d/aq-drm-devices-test.sh
+++ b/test/shell.d/aq-drm-devices-test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+helper="$ROOT/default/uwsm/sanitize-aq-drm-devices"
+dropin="$ROOT/config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+migration="$ROOT/migrations/1787934927.sh"
+
+[[ -f $helper ]] || fail "sanitize helper is in the tree"
+[[ -f $dropin ]] || fail "uwsm env-hyprland.d drop-in is in the tree"
+[[ -f $migration ]] || fail "migration is in the tree"
+
+grep -q 'sanitize-aq-drm-devices' "$dropin" || fail "drop-in sources the sanitize helper"
+pass "drop-in sources the sanitize helper"
+
+run_sanitize() {
+  local value=$1
+  AQ_DRM_DEVICES=$value
+  export AQ_DRM_DEVICES
+  # shellcheck disable=SC1090
+  . "$helper"
+  if [[ -n ${AQ_DRM_DEVICES+x} ]]; then
+    printf '%s' "$AQ_DRM_DEVICES"
+  else
+    printf '%s' "__UNSET__"
+  fi
+}
+
+[[ $(run_sanitize "") == "" ]] || fail "empty AQ_DRM_DEVICES is a no-op"
+pass "empty AQ_DRM_DEVICES is a no-op"
+
+[[ $(run_sanitize "/dev/dri/amd-igpu") == "/dev/dri/amd-igpu" ]] || fail "colon-free pin is left alone"
+pass "colon-free pin is left alone"
+
+[[ $(run_sanitize "/dev/dri/card0:/dev/dri/card1") == "/dev/dri/card0:/dev/dri/card1" ]] || fail "colon-free list is left alone"
+pass "colon-free list is left alone"
+
+[[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0-card") == "__UNSET__" ]] || fail "missing by-path is dropped so Aquamarine cannot split it"
+pass "missing by-path is dropped so Aquamarine cannot split it"
+
+[[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0-card:/dev/dri/by-path/pci-0000:03:00.0-card") == "__UNSET__" ]] || fail "missing by-path list is dropped"
+pass "missing by-path list is dropped"
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+mkdir -p "$dir/dri"
+: >"$dir/dri/card0"
+: >"$dir/dri/card1"
+
+[[ $(run_sanitize "$dir/dri/card0:$dir/dri/card1") == "$dir/dri/card0:$dir/dri/card1" ]] || fail "existing cardN list is left alone"
+pass "existing cardN list is left alone"
+
+mixed=$(run_sanitize "$dir/dri/card0:/dev/dri/by-path/pci-0000:13:00.0-card")
+[[ $mixed == "$dir/dri/card0" ]] || fail "usable card is kept when a by-path sibling is dropped" "$mixed"
+pass "usable card is kept when a by-path sibling is dropped"
+
+by_dir="$dir/dri/by-path"
+by_path="$by_dir/pci-0000:13:00.0-card"
+if mkdir -p "$by_dir" && ln -s "$dir/dri/card0" "$by_path" 2>/dev/null; then
+  resolved=$(readlink -f "$by_path" 2>/dev/null || true)
+  if [[ -n $resolved && $resolved != *:* && $resolved == "$dir/dri/card0" ]]; then
+    [[ $(run_sanitize "$by_path") == "$dir/dri/card0" ]] || fail "by-path symlink is resolved to the DRM node"
+    pass "by-path symlink is resolved to the DRM node"
+
+    [[ $(run_sanitize "$by_path:/dev/dri/by-path/pci-0000:03:00.0-card") == "$dir/dri/card0" ]] || fail "resolved by-path is kept when a missing sibling is dropped"
+    pass "resolved by-path is kept when a missing sibling is dropped"
+  else
+    pass "by-path filenames are not usable here; skip symlink resolution"
+  fi
+else
+  pass "by-path filenames are not usable here; skip symlink resolution"
+fi
+
+dropin_out=$(
+  OMARCHY_PATH=$ROOT
+  export OMARCHY_PATH
+  AQ_DRM_DEVICES="/dev/dri/by-path/pci-0000:13:00.0-card"
+  export AQ_DRM_DEVICES
+  # shellcheck disable=SC1090
+  . "$dropin"
+  if [[ -n ${AQ_DRM_DEVICES+x} ]]; then
+    printf '%s' "$AQ_DRM_DEVICES"
+  else
+    printf '%s' "__UNSET__"
+  fi
+)
+[[ $dropin_out == "__UNSET__" ]] || fail "sourcing the drop-in sanitizes AQ_DRM_DEVICES" "$dropin_out"
+pass "sourcing the drop-in sanitizes AQ_DRM_DEVICES"
+
+test_home=$(mktemp -d)
+dst="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
+[[ -f $dst ]] || fail "migration installs the drop-in"
+cmp -s "$dst" "$dropin" || fail "migration copies the shipped drop-in"
+HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
+[[ -f $dst ]] || fail "migration is idempotent"
+echo changed >"$dst"
+HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
+[[ $(cat "$dst") == changed ]] || fail "migration does not overwrite an existing drop-in"
+pass "migration installs the drop-in without clobbering"
+rm -rf "$test_home"

--- a/test/shell.d/aq-drm-devices-test.sh
+++ b/test/shell.d/aq-drm-devices-test.sh
@@ -5,15 +5,20 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 helper="$ROOT/default/uwsm/sanitize-aq-drm-devices"
-dropin="$ROOT/config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+dropin="$ROOT/config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
 migration="$ROOT/migrations/1787934927.sh"
 
 [[ -f $helper ]] || fail "sanitize helper is in the tree"
 [[ -f $dropin ]] || fail "uwsm env-hyprland.d drop-in is in the tree"
+[[ ! -e $ROOT/config/uwsm/env-hyprland.d/99-omarchy-aq-drm ]] || fail "numeric 99- drop-in was renamed to zz-"
 [[ -f $migration ]] || fail "migration is in the tree"
 
 grep -q 'sanitize-aq-drm-devices' "$dropin" || fail "drop-in sources the sanitize helper"
 pass "drop-in sources the sanitize helper"
+
+sorted=$(printf '%s\n' '99-omarchy-aq-drm' 'my_vars' 'zz-omarchy-aq-drm' | LC_ALL=C sort | tail -n 1)
+[[ $sorted == "zz-omarchy-aq-drm" ]] || fail "zz- sorts after numeric and alphabetic drop-in names"
+pass "zz- sorts after numeric and alphabetic drop-in names"
 
 run_sanitize() {
   local value=$1
@@ -37,11 +42,23 @@ pass "colon-free pin is left alone"
 [[ $(run_sanitize "/dev/dri/card0:/dev/dri/card1") == "/dev/dri/card0:/dev/dri/card1" ]] || fail "colon-free list is left alone"
 pass "colon-free list is left alone"
 
+[[ $(run_sanitize "amd-igpu:nvidia-dgpu") == "amd-igpu:nvidia-dgpu" ]] || fail "udev-name list is left alone"
+pass "udev-name list is left alone"
+
+[[ $(run_sanitize "/dev/dri/card0:card1") == "/dev/dri/card0:card1" ]] || fail "mixed colon-free list is left alone"
+pass "mixed colon-free list is left alone"
+
 [[ $(run_sanitize "/dev/dri/card1::/does-not-exist") == "/dev/dri/card1:/does-not-exist" ]] || fail "empty list component does not drop the previous GPU"
 pass "empty list component does not drop the previous GPU"
 
 [[ $(run_sanitize "/dev/dri/card1:") == "/dev/dri/card1" ]] || fail "trailing colon is stripped"
 pass "trailing colon is stripped"
+
+[[ $(run_sanitize "/dev/dri/card1:::/dev/dri/card9999") == "/dev/dri/card1:/dev/dri/card9999" ]] || fail "two empty components do not drop the previous GPU"
+pass "two empty components do not drop the previous GPU"
+
+[[ $(run_sanitize "/dev/dri/card1::::/dev/dri/card9999") == "/dev/dri/card1:/dev/dri/card9999" ]] || fail "three empty components do not drop the previous GPU"
+pass "three empty components do not drop the previous GPU"
 
 [[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0-card") == "__UNSET__" ]] || fail "missing by-path is dropped so Aquamarine cannot split it"
 pass "missing by-path is dropped so Aquamarine cannot split it"
@@ -76,6 +93,9 @@ if mkdir -p "$by_dir" && ln -s "$dir/dri/card0" "$by_path" 2>/dev/null; then
     [[ $(run_sanitize "$by_path:/dev/dri/by-path/pci-0000:03:00.0-card") == "$dir/dri/card0" ]] || fail "resolved by-path is kept when a missing sibling is dropped"
     pass "resolved by-path is kept when a missing sibling is dropped"
 
+    [[ $(run_sanitize "$by_path:$dir/dri/card1") == "$dir/dri/card0:$dir/dri/card1" ]] || fail "resolved by-path keeps a following colon-free pin"
+    pass "resolved by-path keeps a following colon-free pin"
+
     dangling="$by_dir/pci-0000:03:00.0-card"
     if ln -s "$dir/dri/card99" "$dangling" 2>/dev/null; then
       [[ $(run_sanitize "$dangling") == "__UNSET__" ]] || fail "dangling by-path is dropped"
@@ -107,7 +127,7 @@ dropin_out=$(
 pass "sourcing the drop-in sanitizes AQ_DRM_DEVICES"
 
 test_home=$(mktemp -d)
-dst="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+dst="$test_home/.config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
 mkdir -p "$(dirname "$dst")"
 if ln -s "$test_home/missing-drop-in" "$dst" 2>/dev/null; then
   HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null || fail "migration no-ops on a dangling drop-in symlink"
@@ -119,7 +139,29 @@ fi
 rm -rf "$test_home"
 
 test_home=$(mktemp -d)
-dst="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+dst="$test_home/.config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
+old="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+mkdir -p "$(dirname "$old")"
+echo leftover >"$old"
+HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
+[[ -f $dst ]] || fail "migration installs the zz- drop-in beside an unrelated 99- file"
+[[ $(cat "$old") == leftover ]] || fail "migration leaves an unrelated 99- file in place"
+pass "migration leaves an unrelated 99- file in place"
+rm -rf "$test_home"
+
+test_home=$(mktemp -d)
+dst="$test_home/.config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
+old="$test_home/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+mkdir -p "$(dirname "$old")"
+printf '%s\n' '[ -r helper ] && . helper # sanitize-aq-drm-devices' >"$old"
+HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
+[[ -f $dst ]] || fail "migration installs the zz- drop-in"
+[[ ! -e $old ]] || fail "migration removes the leftover sanitizer 99- drop-in"
+pass "migration replaces a leftover sanitizer 99- drop-in with zz-"
+rm -rf "$test_home"
+
+test_home=$(mktemp -d)
+dst="$test_home/.config/uwsm/env-hyprland.d/zz-omarchy-aq-drm"
 HOME=$test_home OMARCHY_PATH=$ROOT bash -euo pipefail "$migration" >/dev/null
 [[ -f $dst ]] || fail "migration installs the drop-in"
 cmp -s "$dst" "$dropin" || fail "migration copies the shipped drop-in"

--- a/test/shell.d/aq-drm-devices-test.sh
+++ b/test/shell.d/aq-drm-devices-test.sh
@@ -78,6 +78,12 @@ pass "stale by-path does not swallow a following cardN pin"
 [[ $(run_sanitize "/dev/dri/by-path/pci-0000:13:00.0:rel/mygpu") == "rel/mygpu" ]] || fail "incomplete by-path does not absorb a slash-containing continuation"
 pass "incomplete by-path does not absorb a slash-containing continuation"
 
+[[ $(run_sanitize "/dev/dri/by-path/platform-omarchy-test-card") == "__UNSET__" ]] || fail "missing colon-free by-path is dropped instead of exported"
+pass "missing colon-free by-path is dropped instead of exported"
+
+[[ $(run_sanitize "/dev/dri/by-path/platform-omarchy-test-card:card1") == "card1" ]] || fail "missing colon-free by-path does not export an unusable list"
+pass "missing colon-free by-path does not export an unusable list"
+
 usb_missing="/dev/dri/by-path/pci-0000:00:14.0-usb-0:8:1.0-card"
 [[ $(run_sanitize "$usb_missing") == "__UNSET__" ]] || fail "missing USB by-path is dropped instead of exporting debris"
 pass "missing USB by-path is dropped instead of exporting debris"
@@ -118,6 +124,14 @@ if mkdir -p "$by_dir" && ln -s "$dir/dri/card0" "$by_path" 2>/dev/null; then
 
     [[ $(run_sanitize "$by_path:rel/mygpu") == "$dir/dri/card0:rel/mygpu" ]] || fail "resolved by-path keeps a following relative entry"
     pass "resolved by-path keeps a following relative entry"
+
+    plat_path="$by_dir/platform-omarchy-test-card"
+    if ln -s "$dir/dri/card0" "$plat_path" 2>/dev/null; then
+      [[ $(run_sanitize "$plat_path") == "$dir/dri/card0" ]] || fail "colon-free by-path is resolved to the DRM node"
+      pass "colon-free by-path is resolved to the DRM node"
+    else
+      printf 'skip - cannot create a colon-free by-path symlink here\n'
+    fi
 
     usb_path="$by_dir/pci-0000:00:14.0-usb-0:8:1.0-card"
     if ln -s "$dir/dri/card0" "$usb_path" 2>/dev/null; then


### PR DESCRIPTION
**What**: Resolve PCI by-path `AQ_DRM_DEVICES` entries so Hyprland can start on dual-GPU AMD.

**Why**: #8776 — Aquamarine splits `AQ_DRM_DEVICES` on `:` ([hyprwm/aquamarine#167](https://github.com/hyprwm/aquamarine/issues/167)). A wiki-style `/dev/dri/by-path/pci-0000:13:00.0-card` is truncated, the compositor dies, and SDDM autologin loops with no error. Setting the var in `hyprland.lua` is too late; this has to happen in session env.

**How**: UWSM drop-in `env-hyprland.d/zz-omarchy-aq-drm` runs after user `env-hyprland` and letter-named `env-hyprland.d` files (POSIX `ls` loads `99-` before `my_vars`; a later name such as `zzz-` still loads after `zz-`). It splits on `:` like Aquamarine (`removeEmpty`). A `*/by-path/*` name absorbs colon fragments until it exists or ends in udev's `-card`/`-control`/`-render` suffix; a continuation containing `/` starts a new entry. Every by-path entry is then `readlink -e`d, including colon-free names like `platform-vkms-card`. Colon-free pins that are not by-path (`cardN`, udev aliases) are left alone. Unusable by-path entries are dropped; if nothing remains the var is unset.

Rejected: wrapping `hyprland.desktop` (changes the compositor unit), putting this in `env.d` (runs before user `env-hyprland` and would be overwritten), rewriting `~/.config/uwsm/env-hyprland` (user-owned).

**Verified**:
- `bash -n` on helper, drop-in, migration, test
- `bash test/shell.d/aq-drm-devices-test.sh` (Git Bash): pass; by-path symlink case skipped (Windows cannot create `:` in filenames)
- Critic: passed

**NOT verified**:
- Dual-GPU AMD `/dev/dri/by-path/pci-0000:…-card` (this host has no passthrough; those nodes do not exist)
- USB by-path `pci-…-usb-0:8:1.0-card` resolution against a live node
- Sanitizer/drop-in inside a live uwsm session
- Planted colon `AQ_DRM_DEVICES` + SDDM autologin
- `omarchy-restart-shell` n/a (no QML)

Fixes #8776
