### PR TITLE
Fix lopsided cursor highlight on network panel header actions

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -1107,32 +1107,28 @@ Panel {
           anchors.right: parent.right
           anchors.verticalCenter: parent.verticalCenter
 
-          Button {
+          PanelActionButton {
             id: qrAction
             visible: root.canShareWifi
             iconText: "󰐲"
             tooltipText: "Show QR code"
             foreground: root.bar.foreground
             fontFamily: root.bar.fontFamily
-            iconSize: Style.font.subtitle * 1.5
-            horizontalPadding: Style.space(5)
-            verticalPadding: Style.space(2)
+            fontSize: Style.font.subtitle * 1.5
             hasCursor: root.qrHeaderHasCursor
             Layout.alignment: Qt.AlignVCenter
             onHovered: function(on) { if (on) root.setHeaderCursor(root.qrHeaderIndex) }
             onClicked: root.summonWifiQr()
           }
 
-          Button {
+          PanelActionButton {
             id: speedAction
             visible: root.canRunSpeedTest
             iconText: "󰓅"
             tooltipText: "Run a speed test"
             foreground: root.bar.foreground
             fontFamily: root.bar.fontFamily
-            iconSize: Style.font.subtitle * 1.5
-            horizontalPadding: Style.space(5)
-            verticalPadding: Style.space(2)
+            fontSize: Style.font.subtitle * 1.5
             hasCursor: root.speedHeaderHasCursor
             Layout.alignment: Qt.AlignVCenter
             onHovered: function(on) { if (on) root.setHeaderCursor(root.speedHeaderIndex) }


### PR DESCRIPTION
## Summary

- The QR and speed-test header buttons in the network panel (`shell/plugins/panels/network/Panel.qml`) used raw `Button` components with asymmetric padding (`horizontalPadding: Style.space(5)`, `verticalPadding: Style.space(2)`), which produced a hover/keyboard-cursor highlight ~30×24px — wider than tall — around their near-square icons.
- Swapped both to `PanelActionButton`, the kit's canonical square inline-action component (already used elsewhere in this same file, e.g. `connectPwBtn`), which sizes itself symmetrically around the icon (`size: Math.max(Style.space(22), fontSize + Style.spacing.sm * 2)`).
- No other wiring changes needed — `PanelActionButton` already supports `hasCursor`, `onHovered(bool)`, `onClicked()`, and `tooltipText`, matching what the two buttons already used.

Fixes #8782

## Before / after

Measured the rendered highlight box directly from screenshots (pixel bounding box of the hover fill color):

- Before: ~30×24px (per the issue report)
- After: speed-test button 28×28px, QR button 27×28px — both square, centered on the icon

## Test plan

- [x] `./test/shell` passes (4 pre-existing failures unrelated to this file — `config-test.sh`, `snapper-test.sh`, `theme-install-guards-test.sh`, `unowned-system-paths-test.sh` — confirmed failing identically on a clean checkout before this change)
- [x] Verified visually in the running shell via `omarchy dev link` + reboot: opened the network panel, hovered both buttons, confirmed the highlight box is now a centered square on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)