### PR TITLE
Add ntfsprogs to base packages

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -89,6 +89,7 @@ noto-fonts
 noto-fonts-cjk
 noto-fonts-emoji
 nss-mdns
+ntfsprogs
 nvim
 obs-studio
 obsidian

--- a/manual/45-troubleshooting.md
+++ b/manual/45-troubleshooting.md
@@ -26,6 +26,10 @@ hl.config({
 
 Before you reboot, try restarting the offending subsystem on its own. _Update > Hardware_ in the Omarchy menu has Wi-Fi, Bluetooth, Audio, and Trackpad, and reloading one of those clears up the majority of "it worked five minutes ago" situations — a Bluetooth headset that won't reconnect, a trackpad that went dead after a suspend, sound that vanished when you unplugged a monitor.
 
+### My external NTFS drive won't mount
+
+Files says "wrong fs type, bad option, bad superblock" for a drive that works fine on Windows. Run `sudo dmesg | tail` right after the failed mount. If a line ends in `volume is dirty and "force" flag is not set!`, Windows didn't detach the drive cleanly (Fast Startup, hibernation, or pulling the cable without Safely Remove), and the kernel's ntfs3 driver refuses to write to it. Clear the flag with `sudo ntfsfix --clear-dirty /dev/sdX1` and mount again, or plug it into Windows once and eject it properly. To read the files without changing anything, `udisksctl mount -b /dev/sdX1 -o ro` mounts it read-only.
+
 ### Why are my external speakers not playing?
 
 Probably because they're not set as the primary output. Click on the speaker icon on the right side of the bar, and it'll open the volume popup where you can pick the output device (and mix per-app volumes too).

--- a/migrations/1787936858.sh
+++ b/migrations/1787936858.sh
@@ -1,0 +1,3 @@
+echo "Install ntfsprogs to check and format NTFS drives"
+
+omarchy-pkg-add ntfsprogs


### PR DESCRIPTION
NTFS drives that Windows left flagged dirty fail to mount from Files with the generic "wrong fs type, bad option, bad superblock" error (#8725, #3549, and a steady stream of the same report on Discord). The kernel `ntfs3` driver refuses a read/write mount until the flag is cleared, and the tool that clears it, `ntfsfix --clear-dirty`, is not on a fresh Omarchy. On current Arch it lives in `ntfsprogs`, not in `ntfs-3g`.

This ships `ntfsprogs` in the base packages the same way #3448 added `exfatprogs`, with a migration for existing installs. It also gives Disks and the shell the tools to format, label and resize NTFS.

The second commit adds a troubleshooting entry to the manual with the `dmesg` check and the fixes.

Considered and dropped: `ntfs-3g`. udisks tries `ntfs3` first and only falls back to the next driver when no driver exists at all, so the FUSE driver never sees a dirty volume. A `mount_options.conf` with `force` would mount dirty volumes read/write and is not something to ship.

Tests: `./test/all` fails the same five files on untouched `quattro` (they need an `omarchy-pkgs` or `omarchy-iso` checkout, a live Quickshell, or network). With `OMARCHY_PKGS_PATH` set, `config-test` (PKGBUILD coverage) and `unowned-system-paths-test` pass on this branch.

<details>
<summary>Reproduction on a loop image (kernel 7.1.9, udisks2 2.11.2)</summary>

Set `VOLUME_IS_DIRTY` in `$Volume` of a fresh `mkntfs` image, then:

```
$ udisksctl mount -b /dev/loop0
Error mounting /dev/loop0 at /run/media/ms/DIRTYTEST: wrong fs type, bad option, bad superblock on /dev/loop0, missing codepage or helper program, or other error
$ journalctl -k | grep ntfs3
ntfs3(loop0): volume is dirty and "force" flag is not set!
$ udisksctl mount -b /dev/loop0 -o ro
Mounted /dev/loop0 at /run/media/ms/DIRTYTEST
$ ntfsfix --clear-dirty dirty.img
NTFS partition dirty.img was processed successfully.
$ findmnt -no FSTYPE,OPTIONS /dev/loop0
ntfs3 rw,nosuid,nodev,relatime,uid=1000,gid=1000,acl,iocharset=utf8,prealloc
```
</details>
