### PR TITLE
Fix workspace indicator lag under rapid Super+number switching

### DIFF
--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -17,19 +17,6 @@ BarWidget {
     return null
   }
 
-  function workspaceIds() {
-    var ids = [1, 2, 3, 4, 5]
-    var values = Hyprland.workspaces.values
-
-    for (var i = 0; i < values.length; i++) {
-      var id = values[i].id
-      if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
-    }
-
-    ids.sort(function(left, right) { return left - right })
-    return ids
-  }
-
   function focusWorkspace(id) {
     if (!root.bar) return
     root.bar.run("hyprctl dispatch " + Util.shellQuote("hl.dsp.focus({ workspace = \"" + id + "\" })"))
@@ -44,19 +31,28 @@ BarWidget {
     id: grid
     anchors.fill: parent
     anchors.rightMargin: root.trailingGap
-    columns: root.vertical ? 1 : root.workspaceIds().length
+    columns: root.vertical ? 1 : 10
     columnSpacing: root.vertical ? 0 : Style.space(1)
     rowSpacing: root.vertical ? Style.space(2) : 0
 
     Repeater {
-      model: root.workspaceIds()
+      // Static model: delegates are created once and only toggle visibility/state
+      // afterwards. Rebuilding the model on every workspace create/destroy forces
+      // Quickshell to recreate WidgetButton objects on the main thread, which
+      // saturates the Hyprland event loop under rapid switching and makes the
+      // focus indicator lag (the "stuck workspace" backlog from #8788).
+      model: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
       WidgetButton {
         required property int modelData
 
         readonly property var workspace: root.workspaceById(modelData)
         readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
-        readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
+        readonly property bool focused: Hyprland.focusedMonitor !== null && Hyprland.focusedMonitor.activeWorkspace !== null && Hyprland.focusedMonitor.activeWorkspace.id === modelData
+
+        // Base workspaces 1-5 are always shown; extras 6-10 only when they carry
+        // state, so empty non-persistent workspaces never linger in the bar (#8788).
+        visible: modelData <= 5 || occupied || focused
 
         bar: root.bar
         text: focused ? "\uDB85\uDCFB" : (modelData === 10 ? "0" : String(modelData))


### PR DESCRIPTION
## Summary
The workspace indicator in the Omarchy bar lags / looks "stuck" during rapid `Super+<number>` switching (e.g. mashing `12344567890`), and empty non-persistent workspaces (6–10) linger in the bar after they're left.

## Root cause
`Workspaces.qml` built the `Repeater` model from `Hyprland.workspaces.values` via `workspaceIds()`. Every workspace create/destroy event (very frequent while mashing) rebuilt that model, forcing Quickshell to destroy and re-create `WidgetButton` QML objects on the main thread. That work saturates the Hyprland event loop, so `Hyprland.focusedWorkspace` updates queue up and the indicator trails reality — appearing stuck — then catches up once input stops. (`omarchy restart shell` rebuilds Quickshell and clears it, matching the reported workaround.)

## Fix
- Use a **static** `Repeater` model `[1..10]`. Delegates are created once; a workspace switch only toggles `visible` / `opacity` / `focused` booleans — no object churn, near-zero per-event cost, so the shell keeps up.
- `visible: modelData <= 5 || occupied || focused` — base workspaces 1–5 stay always visible; extras 6–10 only appear when they carry state, so empty non-persistent workspaces no longer linger.
- `focused` derived from `Hyprland.focusedMonitor.activeWorkspace` (equivalent to `Hyprland.focusedWorkspace`, kept for robustness).

No regression in normal use: bar width is unchanged when only 1–5 are used (hidden items are excluded from layout) and still expands when 6–10 are active. The only added cost is 5 hidden delegates allocated once at startup.

## Verification
Reproduced the freeze with a live Quickshell probe watching `Hyprland.focusedWorkspace` vs `hyprctl` truth while flooding `hl.dsp.focus` dispatches; confirmed the static-model version keeps the indicator in sync even under sustained mashing.

Fixes #8788