### PR TITLE
windows-vm: negotiate RDP with /sec:tls by default

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -684,8 +684,13 @@ To stop: omarchy-windows-vm stop"
   fi
   # If scale is less than 130%, don't set any scale (use default 100)
 
+  # Default to TLS so the connection negotiates cleanly against Entra ID-
+  # joined Windows VMs. Override with OMARCHY_RDP_SEC (e.g. "nla", "rdp").
+  # See https://github.com/basecamp/omarchy/discussions/3106
+  RDP_SEC="${OMARCHY_RDP_SEC:-tls}"
+
   # Connect with RDP in fullscreen (auto-detects resolution)
-  xfreerdp3 /u:"$WIN_USER" /p:"$WIN_PASS" /v:127.0.0.1:3389 -grab-keyboard /sound /microphone /clipboard /cert:ignore /title:"Windows VM - Omarchy" /dynamic-resolution /gfx:AVC444 /floatbar:sticky:off,default:visible,show:fullscreen $RDP_SCALE
+  xfreerdp3 /u:"$WIN_USER" /p:"$WIN_PASS" /v:127.0.0.1:3389 -grab-keyboard /sound /microphone /clipboard /cert:ignore /sec:"${RDP_SEC}" /title:"Windows VM - Omarchy" /dynamic-resolution /gfx:AVC444 /floatbar:sticky:off,default:visible,show:fullscreen $RDP_SCALE
 
   # After RDP closes, stop the container unless --keep-alive was specified
   if [[ $KEEP_ALIVE = "false" ]]; then


### PR DESCRIPTION
## Summary

The xfreerdp3 invocation in `bin/omarchy-windows-vm` previously omitted a `/sec:` flag. Connections to Entra ID-joined (Azure AD) Windows VMs routinely failed with `ERRCONNECT_SECURITY_NEGO_CONNECT_FAILED` or hung at the login screen until the OMarchy launcher tore the container down.

This defaults the RDP security protocol to `tls` and exposes `OMARCHY_RDP_SEC` as an override.

## Why /sec:tls

- `tls` negotiates cleanly against Windows Server and Entra ID-joined hosts.
- `rdp`/`nla` remains available through `OMARCHY_RDP_SEC` for environments that need a different protocol (e.g., classic RDP-only servers).

## Why an env var instead of a docker-compose switch

Anything passed through the docker `environment:` block stays inside the container; it never reaches the omarchy-windows-vm launcher that runs the xfreerdp3 client. A shell env var is the right boundary for this concern, mirrors how `--keep-alive` already gates per-call behavior, and survives `omarchy update` because the launcher is rewritten in place.

## Testing

- `./test/cli` passes locally with the change applied.
- `bash -n bin/omarchy-windows-vm` clean.
- Manual reproduction (Entra ID-joined VM, fresh install, default launcher invocation): connect succeeds without further flags.

Refs discussion #3106.