### PR TITLE
Show every Hyprland workspace in the bar, not only 1-10

### DIFF
--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -17,17 +17,25 @@ BarWidget {
     return null
   }
 
+  // 1-5 are always offered; any other workspace appears once Hyprland has
+  // created it, however high its id. Special workspaces carry negative ids
+  // and stay out.
   function workspaceIds() {
     var ids = [1, 2, 3, 4, 5]
     var values = Hyprland.workspaces.values
 
     for (var i = 0; i < values.length; i++) {
       var id = values[i].id
-      if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
+      if (id > 0 && ids.indexOf(id) === -1) ids.push(id)
     }
 
     ids.sort(function(left, right) { return left - right })
     return ids
+  }
+
+  readonly property int highestWorkspaceId: {
+    var ids = root.workspaceIds()
+    return ids[ids.length - 1]
   }
 
   function focusWorkspace(id) {
@@ -58,8 +66,17 @@ BarWidget {
         readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
         readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
 
+        // 10 is written as "0" after its SUPER+0 key, but only while it ends
+        // the row: between 9 and 11 a literal "10" reads as the number it is.
+        readonly property string numeral: (modelData === 10 && root.highestWorkspaceId <= 10) ? "0" : String(modelData)
+        // The focus dot stands in for a numeral the keyboard already knows;
+        // past 10 there is no key, so the number is the only identification.
+        readonly property bool keyed: modelData <= 10
+
         bar: root.bar
-        text: focused ? "\uDB85\uDCFB" : (modelData === 10 ? "0" : String(modelData))
+        text: focused && keyed ? "\uDB85\uDCFB" : numeral
+        // A tile that keeps its number under focus marks the focus by colour.
+        active: focused && !keyed
         opacity: occupied || focused ? 1 : 0.5
         horizontalMargin: 6
         verticalPadding: 6

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -80,8 +80,13 @@ BarWidget {
         opacity: occupied || focused ? 1 : 0.5
         horizontalMargin: 6
         verticalPadding: 6
-        fixedWidth: root.vertical ? root.barSize : Style.space(20)
+        // Horizontal tiles grow when a workspace id needs more room. A
+        // vertical bar stays one bar wide and clips unusually long ids; the
+        // tooltip still exposes the complete number.
+        fixedWidth: root.vertical ? root.barSize : Math.max(Style.space(20), labelWidth + scaledHorizontalMargin * 2)
         fixedHeight: root.barSize
+        clip: root.vertical
+        tooltipText: root.vertical && numeral.length > 2 ? numeral : ""
         onPressed: function() { root.focusWorkspace(modelData) }
       }
     }

--- a/test/shell.d/workspaces-widget-test.sh
+++ b/test/shell.d/workspaces-widget-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const source = fs.readFileSync(root + '/shell/plugins/bar/widgets/Workspaces.qml', 'utf8')
+
+// The bar used to stop at 10 because SUPER+1..0 stops there. Hyprland does
+// not, so a workspace reached by other means must still get a tile.
+assert(
+  /if \(id > 0 && ids\.indexOf\(id\) === -1\) ids\.push\(id\)/.test(source),
+  'workspaces widget lists every positive workspace id, with no upper bound'
+)
+assert(!/id <= 10/.test(source), 'workspaces widget no longer caps ids at 10')
+
+// "0" for 10 mirrors its key. It only reads that way while nothing follows.
+assert(
+  /modelData === 10 && root\.highestWorkspaceId <= 10\) \? "0" : String\(modelData\)/.test(source),
+  'workspace 10 is written as "0" only while it ends the row'
+)
+
+// The focus dot replaces a numeral the keyboard already knows. Above 10 there
+// is no key, so the number must stay visible on the focused tile.
+assert(/readonly property bool keyed: modelData <= 10/.test(source), 'workspaces above 10 count as unkeyed')
+assert(
+  /text: focused && keyed \? "\\uDB85\\uDCFB" : numeral/.test(source),
+  'only a keyed workspace swaps its numeral for the focus dot'
+)
+assert(/active: focused && !keyed/.test(source), 'an unkeyed focused workspace marks its focus by colour instead')
+JS

--- a/test/shell.d/workspaces-widget-test.sh
+++ b/test/shell.d/workspaces-widget-test.sh
@@ -30,4 +30,17 @@ assert(
   'only a keyed workspace swaps its numeral for the focus dot'
 )
 assert(/active: focused && !keyed/.test(source), 'an unkeyed focused workspace marks its focus by colour instead')
+
+// Arbitrarily high workspace ids must not paint over the next tile. The
+// horizontal bar can grow with the rendered numeral; a vertical bar cannot,
+// so it clips to its slot and exposes the complete number in a tooltip.
+assert(
+  /fixedWidth: root\.vertical \? root\.barSize : Math\.max\(Style\.space\(20\), labelWidth \+ scaledHorizontalMargin \* 2\)/.test(source),
+  'horizontal workspace tiles grow to fit long ids'
+)
+assert(/clip: root\.vertical/.test(source), 'vertical workspace tiles clip labels to the bar width')
+assert(
+  /tooltipText: root\.vertical && numeral\.length > 2 \? numeral : ""/.test(source),
+  'vertical workspace tiles expose long ids in a tooltip'
+)
 JS


### PR DESCRIPTION
**Files:** `shell/plugins/bar/widgets/Workspaces.qml`, `test/shell.d/workspaces-widget-test.sh`

## What's wrong

The workspaces widget drops any workspace above 10. A workspace reached through `SUPER+TAB`, a window rule, `hyprctl dispatch`, or a plugin has no tile and no way back from the bar. The cap mirrors the `SUPER+1..0` keys, which Hyprland itself does not share: it happily creates workspace 12, and the bar just does not say so.

Before, focused on workspace 12 — nothing in the bar shows it:

<!-- screenshot: 01-beyond-ten-before.png (before) — drag the file here -->
<img width="560" height="28" alt="01-beyond-ten-before" src="https://github.com/user-attachments/assets/31c39c49-90bb-4bbd-8ee3-2e5c6bdeb9b0" />

## What changes

Every positive workspace id gets a tile. Special workspaces (negative ids) stay out as before, and 1-5 are still always offered.

Two details follow from the keys:

- **10 keeps its `0` spelling only while it ends the row.** Between 9 and 11 a literal `10` reads as the number it is.
- **Above 10 the focused tile keeps its number.** The focus dot stands in for a numeral the keyboard already knows; past 10 there is no key, so the number is the only identification. Focus is marked by colour instead.

After, focused on workspace 12:

<!-- screenshot: 01-beyond-ten-after.png (after) — drag the file here -->
<img width="560" height="28" alt="01-beyond-ten-after" src="https://github.com/user-attachments/assets/9fbf6454-b3cc-458d-aedc-3360d2dffe94" />

Below 10 nothing changes: the dot, the `0`, the spacing are as they were.

## Tests

`test/shell.d/workspaces-widget-test.sh` pins the three decisions above the way `bar-test.sh` pins the bar's — by reading the widget source — so removing any one of them fails the test. `bar-widget-contract-test.sh` still passes.

`./test/shell` on this rebased branch: the same six files fail as on unmodified `quattro` in this environment (three need an `omarchy-pkgs` checkout; the others depend on desktop or network state); nothing new. The focused workspace and bar contract tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPJPbKJnjGPiY7ovUHaHH8

