### PR TITLE
Let a workspace carry a name in the bar

### DIFF
--- a/bin/omarchy-hyprland-workspace-name
+++ b/bin/omarchy-hyprland-workspace-name
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# omarchy:summary=Name a workspace in the bar, or take the name away again
+# omarchy:args=<id> [name] | --prompt <id> | --clear <id> | --list [--widget <widget-id>]
+# omarchy:examples=omarchy hyprland workspace name 2 web | omarchy hyprland workspace name --prompt 2 | omarchy hyprland workspace name --clear 2 | omarchy hyprland workspace name --list
+
+# Names live on the workspaces widget's entry in shell.json, so they travel
+# with the rest of the bar configuration and reach the running bar through
+# the same settings patch as any other widget setting:
+#
+#   { "id": "omarchy.workspaces", "names": { "1": "term", "2": "web" } }
+#
+# The bar passes its own widget id in --widget, so a cloned widget names its
+# own entry. Without it the built-in id is used, falling back to whichever
+# clone has taken its place.
+
+set -euo pipefail
+
+MAX_NAME_LENGTH=16
+DEFAULT_WIDGET="omarchy.workspaces"
+
+fail() {
+  echo "omarchy-hyprland-workspace-name: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<USAGE
+Usage:
+  omarchy-hyprland-workspace-name <id> <name>     Name a workspace
+  omarchy-hyprland-workspace-name <id> ""         Clear its name
+  omarchy-hyprland-workspace-name --prompt <id>   Ask for the name in a menu
+  omarchy-hyprland-workspace-name --clear <id>    Clear its name
+  omarchy-hyprland-workspace-name --list          Print every name as JSON
+
+Options:
+  --widget <widget-id>   The bar widget holding the names (default: $DEFAULT_WIDGET)
+
+Names are at most $MAX_NAME_LENGTH characters. A workspace without a name shows its number.
+USAGE
+}
+
+valid_id() {
+  [[ $1 =~ ^[0-9]+$ ]] && (( $1 > 0 )) || fail "workspace id must be a positive number, got: $1"
+}
+
+shell_config() {
+  omarchy-shell shell listShellConfig 2>/dev/null || fail "the Omarchy shell is not running"
+}
+
+config_has_widget() {
+  jq -e --arg id "$1" '
+    (.bar.layout // {}) | [.left, .center, .right] | flatten | map(select(. != null))
+    | any((if type == "object" then .id else . end) == $id)
+  ' <<<"$2" >/dev/null
+}
+
+# The built-in id names the widget the user sees, which after a clone is the
+# clone. Resolve it the way the shell routes calls to a cloned plugin.
+resolve_widget() {
+  local id="$1" config="$2" clone
+  if config_has_widget "$id" "$config"; then
+    echo "$id"
+    return
+  fi
+  clone=$(omarchy-plugin-list --json 2>/dev/null | jq -r --arg id "$id" '
+    map(select(.clonedFrom == $id and .enabled)) | .[0].id // empty
+  ')
+  echo "${clone:-$id}"
+}
+
+current_names() {
+  jq -c --arg id "$1" '
+    (.bar.layout // {}) | [.left, .center, .right] | flatten | map(select(. != null))
+    | map(select(type == "object" and .id == $id)) | .[0].names // {}
+    | with_entries(select(.value | type == "string"))
+  ' <<<"$2"
+}
+
+write_names() {
+  omarchy-bar set "$1" names "$2" --json >/dev/null
+}
+
+normalize_name() {
+  local name
+  name=$(printf '%s' "$1" | tr -d '\n\r' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  (( ${#name} <= MAX_NAME_LENGTH )) || return 1
+  printf '%s' "$name"
+}
+
+set_name() {
+  local id="$1" name="$2" widget config names
+  config=$(shell_config)
+  widget=$(resolve_widget "$WIDGET" "$config")
+  names=$(current_names "$widget" "$config")
+  if [[ -z $name ]]; then
+    names=$(jq -c --arg id "$id" 'del(.[$id])' <<<"$names")
+  else
+    names=$(jq -c --arg id "$id" --arg name "$name" '.[$id] = $name' <<<"$names")
+  fi
+  write_names "$widget" "$names"
+}
+
+prompt_name() {
+  local id="$1" config widget current prompt answer name
+  config=$(shell_config)
+  widget=$(resolve_widget "$WIDGET" "$config")
+  current=$(current_names "$widget" "$config" | jq -r --arg id "$id" '.[$id] // ""')
+  if [[ -n $current ]]; then
+    prompt="Rename workspace $id (now: $current)"
+  else
+    prompt="Name workspace $id"
+  fi
+  # A dismissed menu exits non-zero: the name stays as it was.
+  answer=$(omarchy-menu-input "$prompt" --width 420) || return 0
+  if ! name=$(normalize_name "$answer"); then
+    omarchy-notification-send "Workspace name not saved" "Names are at most $MAX_NAME_LENGTH characters."
+    return 1
+  fi
+  set_name "$id" "$name"
+}
+
+WIDGET="$DEFAULT_WIDGET"
+mode="set"
+positional=()
+while (( $# > 0 )); do
+  case "$1" in
+  --widget)
+    shift
+    (( $# > 0 )) || fail "--widget requires a widget id"
+    WIDGET="$1"
+    ;;
+  --prompt | --clear | --list)
+    mode="${1#--}"
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --*)
+    fail "unknown option: $1"
+    ;;
+  *)
+    positional+=("$1")
+    ;;
+  esac
+  shift
+done
+
+case "$mode" in
+list)
+  config=$(shell_config)
+  current_names "$(resolve_widget "$WIDGET" "$config")" "$config"
+  ;;
+prompt | clear)
+  (( ${#positional[@]} == 1 )) || fail "--$mode takes exactly one workspace id"
+  valid_id "${positional[0]}"
+  if [[ $mode == "prompt" ]]; then
+    prompt_name "${positional[0]}"
+  else
+    set_name "${positional[0]}" ""
+  fi
+  ;;
+set)
+  (( ${#positional[@]} >= 1 )) || { usage >&2; exit 1; }
+  valid_id "${positional[0]}"
+  raw="${positional[*]:1}"
+  name=$(normalize_name "$raw") || fail "workspace names are at most $MAX_NAME_LENGTH characters"
+  set_name "${positional[0]}" "$name"
+  ;;
+esac

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -48,6 +48,10 @@ hl.config({
 })
 ```
 
+### Naming workspaces
+
+A workspace can wear a name instead of its number in the bar. Right-click its tile, type the name, and it's there — `code`, `web`, whatever tells you what lives on it. Leave the prompt empty to go back to the number, or middle-click the tile. The keys don't change: hovering a named tile shows the number it stands for, and `Super + 2` still takes you to the second one whatever it's called. (`omarchy hyprland workspace name 2 web` does the same from a terminal.)
+
 ### Grouping windows
 
 Windows can be grouped using `Super + G`. Once you're in a group, every window you start while that's active will belong to the group. You can move between these grouped windows using `Super + Ctrl + Arrow Left/Right` or `Super + Alt + 1/2/3/4` to go directly to grouped window in order.

--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -17,7 +17,7 @@ Nearly every widget does something on left, right, and middle click, and several
 | Widget | Left | Right | Middle / scroll |
 | --- | --- | --- | --- |
 | Menu | Omarchy menu | New terminal | — |
-| Workspaces | Focus that workspace | — | — |
+| Workspaces | Focus that workspace | Name it | Middle: clear the name |
 | Clock | Calendar popup | Cycle the label format | Middle: timezone picker |
 | Weather | Forecast popup | Full weather as a notification | Middle: refresh |
 | Audio | Audio panel | Mute | Middle: panel · scroll: volume |

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -48,6 +48,24 @@ Example `shell.json` (bar subtree only shown):
 
 `centerAnchor` pins one center module to the exact horizontal/vertical center and flanks others around it. Set to an empty string to disable anchoring (the center list is centered as a group).
 
+### Naming workspaces
+
+A workspace can carry a name in place of its number. Right-click its tile in the bar and type one (leave it empty to go back to the number), or use the command:
+
+```bash
+omarchy hyprland workspace name 2 web
+omarchy hyprland workspace name --clear 2
+omarchy hyprland workspace name --list
+```
+
+Names are stored on the widget's own entry in `shell.json`, so they travel with the rest of the bar:
+
+```json
+{ "id": "omarchy.workspaces", "names": { "1": "term", "2": "web" } }
+```
+
+A name is at most 16 characters. Hovering a named tile shows its workspace number; existing workspace shortcuts remain unchanged. A vertical bar is too narrow for words and keeps the numbers.
+
 ## Module catalogue
 
 ### First-party interactive widgets
@@ -55,7 +73,7 @@ Example `shell.json` (bar subtree only shown):
 | Name | What it does | Interactions |
 |---|---|---|
 | `omarchy.menu` | Omarchy menu launcher | left = menu · right = terminal |
-| `omarchy.workspaces` | Hyprland workspace switcher | left = focus workspace |
+| `omarchy.workspaces` | Hyprland workspace switcher, with optional names | left = focus workspace · right = name it · middle = clear the name |
 | `omarchy.clock` | Date/time label + popup with a month grid, ISO week numbers, and month stepping | left = popup · right = cycle label format · middle = timezone selector |
 | `omarchy.media` | MPRIS now-playing — scrolling track + artist, cover-art popup | left = play/pause · middle = next · scroll = prev/next · right = popup |
 | `omarchy.indicators` | Manual state indicators | left = indicator action |

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -17,17 +17,25 @@ BarWidget {
     return null
   }
 
+  // 1-5 are always offered; any other workspace appears once Hyprland has
+  // created it, however high its id. Special workspaces carry negative ids
+  // and stay out.
   function workspaceIds() {
     var ids = [1, 2, 3, 4, 5]
     var values = Hyprland.workspaces.values
 
     for (var i = 0; i < values.length; i++) {
       var id = values[i].id
-      if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
+      if (id > 0 && ids.indexOf(id) === -1) ids.push(id)
     }
 
     ids.sort(function(left, right) { return left - right })
     return ids
+  }
+
+  readonly property int highestWorkspaceId: {
+    var ids = root.workspaceIds()
+    return ids[ids.length - 1]
   }
 
   function focusWorkspace(id) {
@@ -58,8 +66,17 @@ BarWidget {
         readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
         readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
 
+        // 10 is written as "0" after its SUPER+0 key, but only while it ends
+        // the row: between 9 and 11 a literal "10" reads as the number it is.
+        readonly property string numeral: (modelData === 10 && root.highestWorkspaceId <= 10) ? "0" : String(modelData)
+        // The focus dot stands in for a numeral the keyboard already knows;
+        // past 10 there is no key, so the number is the only identification.
+        readonly property bool keyed: modelData <= 10
+
         bar: root.bar
-        text: focused ? "\uDB85\uDCFB" : (modelData === 10 ? "0" : String(modelData))
+        text: focused && keyed ? "\uDB85\uDCFB" : numeral
+        // A tile that keeps its number under focus marks the focus by colour.
+        active: focused && !keyed
         opacity: occupied || focused ? 1 : 0.5
         horizontalMargin: 6
         verticalPadding: 6

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -80,8 +80,13 @@ BarWidget {
         opacity: occupied || focused ? 1 : 0.5
         horizontalMargin: 6
         verticalPadding: 6
-        fixedWidth: root.vertical ? root.barSize : Style.space(20)
+        // Horizontal tiles grow when a workspace id needs more room. A
+        // vertical bar stays one bar wide and clips unusually long ids; the
+        // tooltip still exposes the complete number.
+        fixedWidth: root.vertical ? root.barSize : Math.max(Style.space(20), labelWidth + scaledHorizontalMargin * 2)
         fixedHeight: root.barSize
+        clip: root.vertical
+        tooltipText: root.vertical && numeral.length > 2 ? numeral : ""
         onPressed: function() { root.focusWorkspace(modelData) }
       }
     }

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -43,6 +43,28 @@ BarWidget {
     root.bar.run("hyprctl dispatch " + Util.shellQuote("hl.dsp.focus({ workspace = \"" + id + "\" })"))
   }
 
+  // Names come from this widget's shell.json entry, keyed by workspace id:
+  //   { "id": "omarchy.workspaces", "names": { "1": "term", "2": "web" } }
+  // omarchy-hyprland-workspace-name writes them; the bar patches settings in
+  // place, so a rename lands without a restart. A hand-edited name longer
+  // than the command allows is cut rather than left to widen the bar.
+  readonly property int maxNameLength: 16
+  readonly property var names: root.setting("names", {})
+
+  function nameFor(id) {
+    var value = names && typeof names === "object" ? names[String(id)] : undefined
+    if (typeof value !== "string") return ""
+    var characters = Array.from(value)
+    return characters.length > maxNameLength ? characters.slice(0, maxNameLength - 1).join("") + "\u2026" : value
+  }
+
+  // The widget id is the layout entry the names sit on, so a cloned widget
+  // edits its own entry rather than the built-in one.
+  function runNameCommand(args) {
+    if (!root.bar) return
+    root.bar.run("omarchy-hyprland-workspace-name " + args + " --widget " + Util.shellQuote(root.moduleName))
+  }
+
   readonly property real trailingGap: root.vertical ? 0 : Style.spaceReal(1.5)
 
   implicitWidth: grid.implicitWidth + trailingGap
@@ -72,11 +94,14 @@ BarWidget {
         // The focus dot stands in for a numeral the keyboard already knows;
         // past 10 there is no key, so the number is the only identification.
         readonly property bool keyed: modelData <= 10
+        // A vertical bar is too narrow for words, so it keeps the numbers.
+        readonly property string wsName: root.vertical ? "" : root.nameFor(modelData)
 
         bar: root.bar
-        text: focused && keyed ? "\uDB85\uDCFB" : numeral
-        // A tile that keeps its number under focus marks the focus by colour.
-        active: focused && !keyed
+        // A name is never hidden behind the focus dot.
+        text: wsName !== "" ? wsName : (focused && keyed ? "\uDB85\uDCFB" : numeral)
+        // A tile that keeps its text under focus marks the focus by colour.
+        active: focused && (wsName !== "" || !keyed)
         opacity: occupied || focused ? 1 : 0.5
         horizontalMargin: 6
         verticalPadding: 6
@@ -86,8 +111,14 @@ BarWidget {
         fixedWidth: root.vertical ? root.barSize : Math.max(Style.space(20), labelWidth + scaledHorizontalMargin * 2)
         fixedHeight: root.barSize
         clip: root.vertical
-        tooltipText: root.vertical && numeral.length > 2 ? numeral : ""
-        onPressed: function() { root.focusWorkspace(modelData) }
+        // A name's tooltip identifies its workspace. In a vertical bar the
+        // tooltip also preserves a long number that cannot fit the slot.
+        tooltipText: wsName !== "" ? numeral : (root.vertical && numeral.length > 2 ? numeral : "")
+        onPressed: function(button) {
+          if (button === Qt.RightButton) root.runNameCommand("--prompt " + modelData)
+          else if (button === Qt.MiddleButton) root.runNameCommand("--clear " + modelData)
+          else root.focusWorkspace(modelData)
+        }
       }
     }
   }

--- a/test/shell.d/hyprland-workspace-name-test.sh
+++ b/test/shell.d/hyprland-workspace-name-test.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command jq
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_dir="$tmpdir/bin"
+config_file="$tmpdir/shell.json"
+bar_log="$tmpdir/bar.log"
+notify_log="$tmpdir/notify.log"
+mkdir -p "$stub_dir"
+
+# The shell answers listShellConfig with whatever the test put in shell.json.
+cat >"$stub_dir/omarchy-shell" <<'STUB'
+#!/bin/bash
+[[ $1 == "shell" && $2 == "listShellConfig" ]] || exit 1
+[[ -n $SHELL_DOWN ]] && exit 1
+cat "$SHELL_CONFIG"
+STUB
+
+cat >"$stub_dir/omarchy-bar" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$BAR_LOG"
+STUB
+
+cat >"$stub_dir/omarchy-plugin-list" <<'STUB'
+#!/bin/bash
+printf '%s\n' "${PLUGIN_LIST:-[]}"
+STUB
+
+cat >"$stub_dir/omarchy-menu-input" <<'STUB'
+#!/bin/bash
+[[ -n $MENU_CANCELLED ]] && exit 1
+printf '%s\n' "$MENU_ANSWER"
+STUB
+
+cat >"$stub_dir/omarchy-notification-send" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+STUB
+
+chmod +x "$stub_dir"/*
+
+run() {
+  SHELL_CONFIG="$config_file" BAR_LOG="$bar_log" NOTIFY_LOG="$notify_log" PATH="$stub_dir:$PATH" \
+    "$ROOT/bin/omarchy-hyprland-workspace-name" "$@"
+}
+
+reset_logs() {
+  : >"$bar_log"
+  : >"$notify_log"
+}
+
+write_config() {
+  printf '%s\n' "$1" >"$config_file"
+}
+
+last_bar_call() {
+  tail -n 1 "$bar_log"
+}
+
+write_config '{"bar":{"layout":{"left":[{"id":"omarchy.menu"},{"id":"omarchy.workspaces","names":{"1":"term"}}],"center":[],"right":[]}}}'
+
+reset_logs
+run 2 web
+[[ $(last_bar_call) == 'set omarchy.workspaces names {"1":"term","2":"web"} --json' ]] ||
+  fail "naming a workspace merges into the existing names" "$(cat "$bar_log")"
+pass "naming a workspace merges into the existing names"
+
+reset_logs
+run 1 "  two words  "
+[[ $(last_bar_call) == 'set omarchy.workspaces names {"1":"two words"} --json' ]] ||
+  fail "a name is trimmed and may hold a space" "$(cat "$bar_log")"
+pass "a name is trimmed and may hold a space"
+
+reset_logs
+run --clear 1
+[[ $(last_bar_call) == 'set omarchy.workspaces names {} --json' ]] ||
+  fail "clearing removes the name" "$(cat "$bar_log")"
+pass "clearing removes the name"
+
+reset_logs
+run 1 ""
+[[ $(last_bar_call) == 'set omarchy.workspaces names {} --json' ]] ||
+  fail "an empty name clears like --clear" "$(cat "$bar_log")"
+pass "an empty name clears like --clear"
+
+reset_logs
+if run 3 "seventeen chars!!" 2>/dev/null; then
+  fail "a name over the limit is refused"
+fi
+[[ ! -s $bar_log ]] || fail "a refused name writes nothing" "$(cat "$bar_log")"
+pass "a name over the limit is refused without writing"
+
+reset_logs
+run 3 "sixteen chars ok"
+[[ $(last_bar_call) == 'set omarchy.workspaces names {"1":"term","3":"sixteen chars ok"} --json' ]] ||
+  fail "a name at the limit is accepted" "$(cat "$bar_log")"
+pass "a name at the limit is accepted"
+
+reset_logs
+for bad in 0 -1 x 1.5 ""; do
+  if run "$bad" web 2>/dev/null; then
+    fail "workspace id '$bad' is rejected"
+  fi
+done
+[[ ! -s $bar_log ]] || fail "a rejected id writes nothing" "$(cat "$bar_log")"
+pass "only positive whole numbers are workspace ids"
+
+reset_logs
+MENU_ANSWER="  mail " run --prompt 4
+[[ $(last_bar_call) == 'set omarchy.workspaces names {"1":"term","4":"mail"} --json' ]] ||
+  fail "the prompt answer is saved trimmed" "$(cat "$bar_log")"
+pass "the prompt answer is saved trimmed"
+
+reset_logs
+MENU_CANCELLED=1 run --prompt 4
+[[ ! -s $bar_log ]] || fail "a dismissed prompt changes nothing" "$(cat "$bar_log")"
+pass "a dismissed prompt changes nothing"
+
+reset_logs
+MENU_ANSWER="" run --prompt 1
+[[ $(last_bar_call) == 'set omarchy.workspaces names {} --json' ]] ||
+  fail "an empty prompt answer clears the name" "$(cat "$bar_log")"
+pass "an empty prompt answer clears the name"
+
+reset_logs
+if MENU_ANSWER="far too long a workspace name" run --prompt 1 2>/dev/null; then
+  fail "an over-long prompt answer fails"
+fi
+[[ ! -s $bar_log ]] || fail "an over-long prompt answer writes nothing" "$(cat "$bar_log")"
+grep -q "at most 16" "$notify_log" || fail "an over-long prompt answer is explained in a notification" "$(cat "$notify_log")"
+pass "an over-long prompt answer is refused with a notification"
+
+reset_logs
+run --widget local.workspaces 2 web
+[[ $(last_bar_call) == 'set local.workspaces names {"2":"web"} --json' ]] ||
+  fail "--widget names the entry the bar asked for" "$(cat "$bar_log")"
+pass "--widget names the entry the bar asked for"
+
+# A user who cloned the widget has the clone in the bar under its own id. The
+# built-in id still reaches it, the way the shell routes calls to clones.
+write_config '{"bar":{"layout":{"left":[{"id":"me.workspaces","names":{"5":"chat"}}],"center":[],"right":[]}}}'
+reset_logs
+PLUGIN_LIST='[{"id":"me.workspaces","enabled":true,"clonedFrom":"omarchy.workspaces"},{"id":"omarchy.workspaces","enabled":false,"clonedFrom":""}]' \
+  run 2 web
+[[ $(last_bar_call) == 'set me.workspaces names {"5":"chat","2":"web"} --json' ]] ||
+  fail "the built-in id resolves to the clone that replaced it" "$(cat "$bar_log")"
+pass "the built-in id resolves to the clone that replaced it"
+
+output=$(PLUGIN_LIST='[{"id":"me.workspaces","enabled":true,"clonedFrom":"omarchy.workspaces"}]' run --list)
+[[ $output == '{"5":"chat"}' ]] || fail "--list prints the names as JSON" "$output"
+pass "--list prints the names as JSON"
+
+write_config '{"bar":{"layout":{"left":[{"id":"omarchy.workspaces","names":{"1":"term","2":7}}],"center":[],"right":[]}}}'
+output=$(run --list)
+[[ $output == '{"1":"term"}' ]] || fail "--list drops names that are not strings" "$output"
+pass "--list drops names that are not strings"
+
+write_config '{}'
+reset_logs
+run 2 web
+[[ $(last_bar_call) == 'set omarchy.workspaces names {"2":"web"} --json' ]] ||
+  fail "a user without shell.json still gets the built-in widget named" "$(cat "$bar_log")"
+pass "a user without shell.json still gets the built-in widget named"
+
+reset_logs
+if SHELL_DOWN=1 run 2 web 2>/dev/null; then
+  fail "a stopped shell is an error"
+fi
+[[ ! -s $bar_log ]] || fail "a stopped shell writes nothing" "$(cat "$bar_log")"
+pass "a stopped shell is reported, not written around"

--- a/test/shell.d/workspaces-widget-test.sh
+++ b/test/shell.d/workspaces-widget-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const source = fs.readFileSync(root + '/shell/plugins/bar/widgets/Workspaces.qml', 'utf8')
+
+// The bar used to stop at 10 because SUPER+1..0 stops there. Hyprland does
+// not, so a workspace reached by other means must still get a tile.
+assert(
+  /if \(id > 0 && ids\.indexOf\(id\) === -1\) ids\.push\(id\)/.test(source),
+  'workspaces widget lists every positive workspace id, with no upper bound'
+)
+assert(!/id <= 10/.test(source), 'workspaces widget no longer caps ids at 10')
+
+// "0" for 10 mirrors its key. It only reads that way while nothing follows.
+assert(
+  /modelData === 10 && root\.highestWorkspaceId <= 10\) \? "0" : String\(modelData\)/.test(source),
+  'workspace 10 is written as "0" only while it ends the row'
+)
+
+// The focus dot replaces a numeral the keyboard already knows. Above 10 there
+// is no key, so the number must stay visible on the focused tile.
+assert(/readonly property bool keyed: modelData <= 10/.test(source), 'workspaces above 10 count as unkeyed')
+assert(
+  /text: focused && keyed \? "\\uDB85\\uDCFB" : numeral/.test(source),
+  'only a keyed workspace swaps its numeral for the focus dot'
+)
+assert(/active: focused && !keyed/.test(source), 'an unkeyed focused workspace marks its focus by colour instead')
+JS

--- a/test/shell.d/workspaces-widget-test.sh
+++ b/test/shell.d/workspaces-widget-test.sh
@@ -25,11 +25,6 @@ assert(
 // The focus dot replaces a numeral the keyboard already knows. Above 10 there
 // is no key, so the number must stay visible on the focused tile.
 assert(/readonly property bool keyed: modelData <= 10/.test(source), 'workspaces above 10 count as unkeyed')
-assert(
-  /text: focused && keyed \? "\\uDB85\\uDCFB" : numeral/.test(source),
-  'only a keyed workspace swaps its numeral for the focus dot'
-)
-assert(/active: focused && !keyed/.test(source), 'an unkeyed focused workspace marks its focus by colour instead')
 
 // Arbitrarily high workspace ids must not paint over the next tile. The
 // horizontal bar can grow with the rendered numeral; a vertical bar cannot,
@@ -40,7 +35,39 @@ assert(
 )
 assert(/clip: root\.vertical/.test(source), 'vertical workspace tiles clip labels to the bar width')
 assert(
-  /tooltipText: root\.vertical && numeral\.length > 2 \? numeral : ""/.test(source),
+  /tooltipText: wsName !== "" \? numeral : \(root\.vertical && numeral\.length > 2 \? numeral : ""\)/.test(source),
   'vertical workspace tiles expose long ids in a tooltip'
 )
+JS
+
+run_node_test <<'JS'
+const fs = require('fs')
+const source = fs.readFileSync(root + '/shell/plugins/bar/widgets/Workspaces.qml', 'utf8')
+
+// Names ride on the widget's shell.json entry like any other widget setting,
+// so the bar's in-place settings patch delivers a rename without a restart.
+assert(/readonly property var names: root\.setting\("names", \{\}\)/.test(source), 'workspace names are read from the widget settings')
+
+// The command enforces the length; the widget still cuts a hand-edited name
+// so shell.json cannot widen the bar. Array.from counts Unicode code points,
+// matching Bash's locale-aware limit without splitting surrogate pairs.
+assert(/var characters = Array\.from\(value\)/.test(source), 'workspace names are measured as Unicode code points')
+assert(
+  /characters\.length > maxNameLength \? characters\.slice\(0, maxNameLength - 1\)\.join\(""\) \+ "\\u2026" : value/.test(source),
+  'an over-long Unicode name is cut with an ellipsis between code points'
+)
+
+// A name must never disappear behind the focus dot, and a named tile marks
+// its focus by colour instead.
+assert(/text: wsName !== "" \? wsName : \(focused && keyed \? "\\uDB85\\uDCFB" : numeral\)/.test(source), 'a name is shown in place of the numeral and the focus dot')
+assert(/active: focused && \(wsName !== "" \|\| !keyed\)/.test(source), 'a named focused tile marks its focus by colour')
+
+// A vertical bar has no room for words.
+assert(/readonly property string wsName: root\.vertical \? "" : root\.nameFor\(modelData\)/.test(source), 'a vertical bar keeps the numbers')
+
+// The bar hands the command its own widget id, so a cloned widget names the
+// entry it is actually configured on.
+assert(/"omarchy-hyprland-workspace-name " \+ args \+ " --widget " \+ Util\.shellQuote\(root\.moduleName\)/.test(source), 'the name command targets this widget\'s own entry')
+assert(/if \(button === Qt\.RightButton\) root\.runNameCommand\("--prompt " \+ modelData\)/.test(source), 'right-click prompts for a name')
+assert(/else if \(button === Qt\.MiddleButton\) root\.runNameCommand\("--clear " \+ modelData\)/.test(source), 'middle-click clears the name')
 JS

--- a/test/shell.d/workspaces-widget-test.sh
+++ b/test/shell.d/workspaces-widget-test.sh
@@ -30,4 +30,17 @@ assert(
   'only a keyed workspace swaps its numeral for the focus dot'
 )
 assert(/active: focused && !keyed/.test(source), 'an unkeyed focused workspace marks its focus by colour instead')
+
+// Arbitrarily high workspace ids must not paint over the next tile. The
+// horizontal bar can grow with the rendered numeral; a vertical bar cannot,
+// so it clips to its slot and exposes the complete number in a tooltip.
+assert(
+  /fixedWidth: root\.vertical \? root\.barSize : Math\.max\(Style\.space\(20\), labelWidth \+ scaledHorizontalMargin \* 2\)/.test(source),
+  'horizontal workspace tiles grow to fit long ids'
+)
+assert(/clip: root\.vertical/.test(source), 'vertical workspace tiles clip labels to the bar width')
+assert(
+  /tooltipText: root\.vertical && numeral\.length > 2 \? numeral : ""/.test(source),
+  'vertical workspace tiles expose long ids in a tooltip'
+)
 JS


### PR DESCRIPTION
Stacked on #8802 — the first commit here is that PR's; the diff slims down once it merges.

**Files:** `bin/omarchy-hyprland-workspace-name`, `shell/plugins/bar/widgets/Workspaces.qml`, `shell/plugins/bar/README.md`, `manual/04-navigation.md`, `manual/05-the-top-bar.md`, tests

## What's wrong

A tile only ever shows its number, so a bar full of numbers says nothing about what lives where. Waybar users had labels through `format-icons` and asked for them back in the Quattro bar — see discussion #8764, which is still unanswered.

## What changes

A workspace can carry a name in place of its number.

- **Right-click a tile** to type a name (leave it empty to go back to the number). **Middle-click** clears it.
- `omarchy hyprland workspace name 2 web`, `--clear 2`, `--prompt 2`, `--list` do the same from the command line.

<!-- screenshot: 02-names.png (named tiles) — drag the file here -->
<img width="560" height="28" alt="02-names" src="https://github.com/user-attachments/assets/a2b98f2d-df4e-4d4a-a0b5-e861b30413d2" />

A named tile marks focus by colour, since the focus dot would hide the name:

<!-- screenshot: 02-names-focused.png (named tile focused) — drag the file here -->
<img width="560" height="28" alt="02-names-focused" src="https://github.com/user-attachments/assets/f99138db-80ac-478d-a1ae-93932ce91cfb" />

The prompt is the ordinary Omarchy menu input:

<!-- screenshot: 02-names-prompt.png (prompt) — drag the file here -->
<img width="640" height="150" alt="02-names-prompt" src="https://github.com/user-attachments/assets/fad98678-8ddf-4a15-abe5-e62cc56a5e13" />

### Where the names live

On the widget's own entry in `shell.json`, like any other widget setting, so they travel with the rest of the bar and reach the running widget through the existing settings patch (`omarchy-shell shell setBarWidget`) — no restart, no new file, no new watcher:

```json
{ "id": "omarchy.workspaces", "names": { "1": "term", "2": "web" } }
```

The command writes through `omarchy bar set <widget> names <json> --json`. The bar hands the command its own widget id (`--widget`), so a cloned widget names the entry it is actually configured on; without it the built-in id resolves to whichever clone has taken its place, the way the shell routes calls to clones.

### Limits and edges

- Names are at most 16 Unicode code points. The command refuses longer ones; the widget still cuts a hand-edited longer name with an ellipsis rather than let `shell.json` widen the bar.
- Hovering a named tile shows its workspace number; existing workspace shortcuts remain unchanged.
- A vertical bar keeps the numbers; there is no room for words.
- Unicode is fine (`żółć ok` renders as typed).

The manual gets a *Naming workspaces* section in `04-navigation.md` and the new right/middle actions in the bar table of `05-the-top-bar.md`.

## Tests

- `test/shell.d/hyprland-workspace-name-test.sh` (17 assertions): merge with existing names, trim, clear, empty-means-clear, the 16-character limit both ways, id validation, prompt answer / dismissed prompt / empty answer / over-long answer with a notification, `--widget`, clone resolution through `omarchy-plugin-list`, `--list`, non-string entries dropped, a user without `shell.json`, and a stopped shell reported rather than written around. All stubs, no shell needed.
- `workspaces-widget-test.sh` gains assertions for the settings read, the ellipsis cut, name-over-dot, colour focus, the vertical fallback, and the right/middle bindings.
- `bin-style-test.sh`, `test/cli` (command metadata) and `bar-widget-contract-test.sh` pass.

Tested live on Omarchy 4.0.1 / Hyprland 0.56.2: CLI and right-click prompt both land in the bar without a restart; the clone case was exercised with an actual `omarchy plugin clone omarchy.workspaces`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPJPbKJnjGPiY7ovUHaHH8

