### PR TITLE
feat(bar): modular waybar style system with 4 built-in styles

### DIFF
--- a/bin/omarchy-bar-style-list
+++ b/bin/omarchy-bar-style-list
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# omarchy:summary=List available Waybar styles
+# omarchy:group=bar
+# omarchy:args=none
+# omarchy:examples=omarchy bar style list
+
+set -euo pipefail
+
+SYS_STYLES_DIR="$OMARCHY_PATH/default/waybar/styles"
+USER_STYLES_DIR="$HOME/.config/waybar/styles"
+CURRENT_STYLE_LINK="$HOME/.config/omarchy/current/waybar.style"
+
+CURRENT_STYLE=""
+if [[ -L $CURRENT_STYLE_LINK ]]; then
+  CURRENT_STYLE=$(basename "$(readlink -f "$CURRENT_STYLE_LINK")")
+fi
+
+echo "Available Waybar styles:"
+echo ""
+
+# System styles
+if [[ -d $SYS_STYLES_DIR ]]; then
+  for style in "$SYS_STYLES_DIR"/*/; do
+    [[ -d $style ]] || continue
+    name=$(basename "$style")
+    marker=""
+    [[ $name == "$CURRENT_STYLE" ]] && marker=" *"
+    echo "  $name (system)$marker"
+  done
+fi
+
+# User styles
+if [[ -d $USER_STYLES_DIR ]]; then
+  for style in "$USER_STYLES_DIR"/*/; do
+    [[ -d $style ]] || continue
+    name=$(basename "$style")
+    marker=""
+    [[ $name == "$CURRENT_STYLE" ]] && marker=" *"
+    echo "  $name (user)$marker"
+  done
+fi
+
+echo ""
+echo "* = currently active"

--- a/bin/omarchy-bar-style-next
+++ b/bin/omarchy-bar-style-next
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# omarchy:summary=Cycle to the next Waybar style
+# omarchy:group=bar
+# omarchy:args=none
+# omarchy:examples=omarchy bar style next
+
+set -euo pipefail
+
+SYS_STYLES_DIR="$OMARCHY_PATH/default/waybar/styles"
+USER_STYLES_DIR="$HOME/.config/waybar/styles"
+CURRENT_STYLE_LINK="$HOME/.config/omarchy/current/waybar.style"
+
+# Build array of available styles
+styles=()
+
+if [[ -d $SYS_STYLES_DIR ]]; then
+  for style in "$SYS_STYLES_DIR"/*/; do
+    [[ -d $style ]] || continue
+    styles+=("$(basename "$style")")
+  done
+fi
+
+if [[ -d $USER_STYLES_DIR ]]; then
+  for style in "$USER_STYLES_DIR"/*/; do
+    [[ -d $style ]] || continue
+    name=$(basename "$style")
+    # Avoid duplicates if user has same name
+    [[ " ${styles[*]} " =~  $name ]] || styles+=("$name")
+  done
+fi
+
+(( ${#styles[@]} > 0 )) || {
+  echo "No styles available"
+  exit 1
+}
+
+# Get current style
+current=""
+if [[ -L $CURRENT_STYLE_LINK ]]; then
+  current=$(basename "$(readlink -f "$CURRENT_STYLE_LINK")")
+fi
+
+# Find next
+next_index=0
+for i in "${!styles[@]}"; do
+  if [[ ${styles[$i]} == "$current" ]]; then
+    next_index=$(( (i + 1) % ${#styles[@]} ))
+    break
+  fi
+done
+
+next_style="${styles[$next_index]}"
+omarchy-bar-style-set "$next_style"

--- a/bin/omarchy-bar-style-set
+++ b/bin/omarchy-bar-style-set
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# omarchy:summary=Set the active Waybar style
+# omarchy:group=bar
+# omarchy:args=<style-name>
+# omarchy:examples=omarchy bar style set pills | omarchy bar style set classic
+
+set -euo pipefail
+
+if [[ -z ${1:-} ]]; then
+  echo "Usage: omarchy-waybar-style-set <style-name>"
+  echo "Run 'omarchy bar style list' to see available styles"
+  exit 1
+fi
+
+STYLE_NAME="$1"
+STYLE_DIR="$OMARCHY_PATH/default/waybar/styles/$STYLE_NAME"
+USER_STYLE_DIR="$HOME/.config/waybar/styles/$STYLE_NAME"
+CURRENT_STYLE_LINK="$HOME/.config/omarchy/current/waybar.style"
+
+# Check if style exists (system or user)
+if [[ ! -d $STYLE_DIR && ! -d $USER_STYLE_DIR ]]; then
+  echo "Style '$STYLE_NAME' not found"
+  echo "Run 'omarchy bar style list' to see available styles"
+  exit 1
+fi
+
+# Determine source directory
+SOURCE_DIR="$STYLE_DIR"
+[[ -d $USER_STYLE_DIR ]] && SOURCE_DIR="$USER_STYLE_DIR"
+
+# Create parent directory
+mkdir -p "$(dirname "$CURRENT_STYLE_LINK")"
+
+# Atomic symlink swap
+ln -nsf "$SOURCE_DIR" "$CURRENT_STYLE_LINK"
+
+# Restart Waybar to pick up new style
+omarchy-restart-waybar
+
+echo "Waybar style set to: $STYLE_NAME"

--- a/bin/omarchy-bar-style-switcher
+++ b/bin/omarchy-bar-style-switcher
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# omarchy:summary=Interactive Waybar style switcher
+# omarchy:group=bar
+# omarchy:args=none
+# omarchy:examples=omarchy bar style switcher
+
+set -euo pipefail
+
+SYS_STYLES_DIR="$OMARCHY_PATH/default/waybar/styles"
+USER_STYLES_DIR="$HOME/.config/waybar/styles"
+CURRENT_STYLE_LINK="$HOME/.config/omarchy/current/waybar.style"
+
+# Build list of styles
+styles=()
+style_sources=()
+
+if [[ -d $SYS_STYLES_DIR ]]; then
+  for style in "$SYS_STYLES_DIR"/*/; do
+    [[ -d $style ]] || continue
+    name=$(basename "$style")
+    styles+=("$name")
+    style_sources+=("system")
+  done
+fi
+
+if [[ -d $USER_STYLES_DIR ]]; then
+  for style in "$USER_STYLES_DIR"/*/; do
+    [[ -d $style ]] || continue
+    name=$(basename "$style")
+    [[ " ${styles[*]} " =~  $name ]] || {
+      styles+=("$name")
+      style_sources+=("user")
+    }
+  done
+fi
+
+(( ${#styles[@]} > 0 )) || {
+  echo "No styles available"
+  exit 1
+}
+
+# Get current style
+current=""
+if [[ -L $CURRENT_STYLE_LINK ]]; then
+  current=$(basename "$(readlink -f "$CURRENT_STYLE_LINK")")
+fi
+
+# Build walker/gum input
+input=""
+for i in "${!styles[@]}"; do
+  name="${styles[$i]}"
+  source="${style_sources[$i]}"
+  marker=""
+  [[ $name == "$current" ]] && marker=" ●"
+  input+="$name ($source)$marker"$'\n'
+done
+
+# Try walker first, fallback to gum, then select
+selected=""
+if command -v walker &>/dev/null; then
+  selected=$(printf "%s" "$input" | walker --dmenu -p "Waybar Style" 2>/dev/null || true)
+elif command -v gum &>/dev/null; then
+  selected=$(printf "%s" "$input" | gum choose --header "Select Waybar style" 2>/dev/null || true)
+else
+  echo "Select a Waybar style:"
+  PS3="Choice: "
+  select opt in "${styles[@]}"; do
+    [[ -n $opt ]] && selected="$opt (${style_sources[$REPLY-1]})" && break
+  done
+fi
+
+# Extract style name (remove source marker)
+selected_style="${selected%% (*}"
+
+if [[ -n $selected_style ]]; then
+  omarchy-bar-style-set "$selected_style"
+else
+  echo "No style selected"
+  exit 1
+fi

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -147,6 +147,20 @@ mkdir -p "$NEXT_THEME_PATH"
 cp -r "$OMARCHY_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
 cp -r "$USER_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
 
+# Handle waybar style if specified by theme
+if [[ -f $NEXT_THEME_PATH/waybar.style ]]; then
+  THEME_WAYBAR_STYLE=$(cat "$NEXT_THEME_PATH/waybar.style" | tr -d '[:space:]')
+  STYLE_DIR="$OMARCHY_PATH/default/waybar/styles/$THEME_WAYBAR_STYLE"
+  USER_STYLE_DIR="$HOME/.config/waybar/styles/$THEME_WAYBAR_STYLE"
+  CURRENT_STYLE_LINK="$HOME/.config/omarchy/current/waybar.style"
+  SOURCE_DIR="$STYLE_DIR"
+  [[ -d $USER_STYLE_DIR ]] && SOURCE_DIR="$USER_STYLE_DIR"
+  if [[ -d $SOURCE_DIR ]]; then
+    mkdir -p "$(dirname "$CURRENT_STYLE_LINK")"
+    ln -nsf "$SOURCE_DIR" "$CURRENT_STYLE_LINK"
+  fi
+fi
+
 # Generate colors.toml from alacritty.toml if theme is missing colors.toml
 if [[ ! -f $NEXT_THEME_PATH/colors.toml && -f $NEXT_THEME_PATH/alacritty.toml ]]; then
   omarchy-theme-colors-from-alacritty "$NEXT_THEME_PATH"

--- a/default/waybar/styles/classic/style.css
+++ b/default/waybar/styles/classic/style.css
@@ -1,0 +1,132 @@
+@import "../omarchy/current/theme/waybar.css";
+
+/* ==================== CLASSIC OMARCHY BAR ==================== */
+/* Flat, continuous bar - the original Omarchy default */
+
+* {
+  color: @foreground;
+  border: none;
+  border-radius: 0;
+  min-height: 0;
+  font-family: 'JetBrainsMono Nerd Font', 'Fira Sans';
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* BAR BACKGROUND - flat, no margin, no radius */
+window#waybar {
+  background: @background;
+  border: none;
+  box-shadow: none;
+}
+
+window#waybar > box {
+  background: @background;
+  margin: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+/* OMARCHY START BUTTON */
+#custom-omarchy {
+  padding: 0 16px;
+  font-size: 16px;
+  background: transparent;
+}
+
+/* WORKSPACES */
+#workspaces {
+  padding: 0 8px;
+  background: transparent;
+}
+
+#workspaces button {
+  all: initial;
+  padding: 0 10px;
+  margin: 0 2px;
+  min-width: 10px;
+  color: @foreground;
+  font-size: 12px;
+  opacity: 0.6;
+}
+
+#workspaces button.active {
+  opacity: 1;
+  font-weight: 700;
+}
+
+#workspaces button:hover {
+  opacity: 0.9;
+}
+
+/* CLOCK */
+#custom-clock {
+  padding: 0 16px;
+  background: transparent;
+  font-weight: 600;
+}
+
+/* MODULES - flat, no pills */
+#mpris,
+#idle_inhibitor,
+#custom-uptime,
+#custom-power-profile,
+#custom-weather,
+#custom-update,
+#cpu,
+#battery,
+#pulseaudio,
+#network,
+#custom-network-speed,
+#bluetooth,
+#tray {
+  padding: 0 12px;
+  background: transparent;
+}
+
+/* STATES */
+#idle_inhibitor.activated {
+  color: #4EC85A;
+}
+
+#custom-power-profile.performance { color: #4EC85A; }
+#custom-power-profile.power-saver { color: #35BCDE; }
+
+#custom-network-speed.disconnected { color: #C85A50; }
+
+#custom-update.has-update {
+  color: #4EC85A;
+}
+
+#battery.warning { color: #C8A830; }
+#battery.critical { color: #C85A50; }
+
+/* TOOLTIP */
+tooltip {
+  background: rgba(0, 0, 0, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+
+tooltip label { color: #D0ECE8; }
+
+/* INDICATORS */
+#custom-screenrecording-indicator,
+#custom-notification-silencing-indicator,
+#custom-voxtype,
+#custom-expand-icon {
+  padding: 0 10px;
+  background: transparent;
+}
+
+#custom-screenrecording-indicator.active,
+#custom-notification-silencing-indicator.active,
+#custom-voxtype.recording {
+  color: #C85A50;
+}
+
+/* VERTICAL MODE */
+.left .modules-left, .right .modules-left { margin: 8px 0 0 0; }
+.left .modules-right, .right .modules-right { margin: 0 0 8px 0; }

--- a/default/waybar/styles/compact/style.css
+++ b/default/waybar/styles/compact/style.css
@@ -1,0 +1,154 @@
+@import "../omarchy/current/theme/waybar.css";
+
+/* ==================== COMPACT STYLE ==================== */
+/* Ultra-thin bar for small screens / vertical layouts - 24px height */
+
+* {
+  color: @foreground;
+  border: none;
+  border-radius: 0;
+  min-height: 0;
+  font-family: 'JetBrainsMono Nerd Font', 'Fira Sans';
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+/* BAR BACKGROUND - minimal height */
+window#waybar {
+  background: @background;
+  border: none;
+  box-shadow: none;
+}
+
+window#waybar > box {
+  background: @background;
+  margin: 0;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0 4px;
+}
+
+/* Reduce bar height globally */
+window#waybar,
+window#waybar > box {
+  min-height: 24px;
+}
+
+/* OMARCHY START BUTTON */
+#custom-omarchy {
+  padding: 0 10px;
+  margin: 2px;
+  border-radius: 4px;
+  font-size: 14px;
+  background: transparent;
+}
+
+/* WORKSPACES - minimal */
+#workspaces {
+  margin: 2px;
+  padding: 0 4px;
+  border-radius: 4px;
+  background: transparent;
+}
+
+#workspaces button {
+  all: initial;
+  padding: 0 6px;
+  margin: 0 1px;
+  min-width: 8px;
+  min-height: 18px;
+  border-radius: 3px;
+  color: @foreground;
+  font-size: 10px;
+  opacity: 0.5;
+}
+
+#workspaces button.active {
+  background: rgba(18, 153, 202, 0.3);
+  color: #35BCDE;
+  opacity: 1;
+}
+
+#workspaces button.empty { opacity: 0.2; }
+#workspaces button:hover { background: rgba(18, 153, 202, 0.1); }
+
+/* CLOCK */
+#custom-clock {
+  margin: 2px 6px;
+  padding: 0 10px;
+  border-radius: 4px;
+  background: transparent;
+  font-weight: 600;
+}
+
+/* MODULES - tiny pills */
+#mpris,
+#idle_inhibitor,
+#custom-uptime,
+#custom-power-profile,
+#custom-weather,
+#custom-update,
+#cpu,
+#battery,
+#pulseaudio,
+#network,
+#custom-network-speed,
+#bluetooth,
+#tray {
+  margin: 2px 2px;
+  padding: 0 8px;
+  border-radius: 4px;
+  background: rgba(18, 153, 202, 0.08);
+}
+
+/* STATES */
+#idle_inhibitor.activated { color: #4EC85A; background: rgba(78, 200, 90, 0.15); }
+#custom-power-profile.performance { color: #4EC85A; }
+#custom-power-profile.power-saver { color: #35BCDE; }
+#custom-network-speed.disconnected { color: #C85A50; }
+#custom-update.has-update { color: #4EC85A; background: rgba(78, 200, 90, 0.15); }
+#battery.warning { color: #C8A830; }
+#battery.critical { color: #C85A50; }
+
+/* MPRIS */
+#mpris { min-width: 60px; font-size: 10px; }
+#mpris.playing { background: rgba(18, 153, 202, 0.15); }
+#mpris.paused { opacity: 0.6; }
+#mpris.stopped { opacity: 0; min-width: 0; padding: 0; }
+
+/* TOOLTIP */
+tooltip {
+  background: rgba(10, 10, 15, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 10px;
+}
+tooltip label { color: #D0D0D0; }
+
+/* INDICATORS */
+#custom-screenrecording-indicator,
+#custom-notification-silencing-indicator,
+#custom-voxtype,
+#custom-expand-icon {
+  margin: 2px;
+  padding: 0 6px;
+  border-radius: 4px;
+  font-size: 9px;
+  background: rgba(18, 153, 202, 0.08);
+}
+
+#custom-screenrecording-indicator.active,
+#custom-notification-silencing-indicator.active,
+#custom-voxtype.recording { color: #C85A50; }
+
+/* VERTICAL MODE */
+.left .modules-left, .right .modules-left { margin: 4px 0 0 0; }
+.left .modules-right, .right .modules-right { margin: 0 0 4px 0; }
+
+.left #workspaces button, .right #workspaces button {
+  padding: 5px 0;
+  margin: 1px 0;
+  min-width: 18px;
+}

--- a/default/waybar/styles/island/style.css
+++ b/default/waybar/styles/island/style.css
@@ -1,0 +1,184 @@
+@import "../omarchy/current/theme/waybar.css";
+
+/* ==================== ISLAND STYLE ==================== */
+/* Centered floating dock with rounded ends - macOS/Plasma style */
+
+* {
+  color: @foreground;
+  border: none;
+  border-radius: 0;
+  min-height: 0;
+  font-family: 'JetBrainsMono Nerd Font', 'Fira Sans';
+  font-size: 13px;
+  font-weight: 500;
+}
+
+@keyframes island-glow {
+  0%, 100% { box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3), 0 0 0 rgba(18, 153, 202, 0); }
+  50% { box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3), 0 0 32px rgba(18, 153, 202, 0.15); }
+}
+
+/* BAR BACKGROUND - centered island */
+window#waybar {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+window#waybar > box {
+  background: @background;
+  margin: 8px 120px;
+  border-radius: 24px;
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+  animation: island-glow 4s ease-in-out infinite;
+}
+
+/* OMARCHY START BUTTON - pill within island */
+#custom-omarchy {
+  padding: 0 18px;
+  margin: 6px 8px 6px 12px;
+  border-radius: 16px;
+  font-size: 18px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15);
+}
+
+#custom-omarchy:hover {
+  background: rgba(18, 153, 202, 0.2);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.25),
+    0 0 20px rgba(18, 153, 202, 0.3);
+}
+
+/* WORKSPACES - seamless pill */
+#workspaces {
+  margin: 6px 4px;
+  padding: 0 12px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+#workspaces button {
+  all: initial;
+  padding: 0 14px;
+  margin: 0 2px;
+  min-width: 12px;
+  min-height: 28px;
+  border-radius: 14px;
+  color: @foreground;
+  font-size: 13px;
+  font-weight: 600;
+  opacity: 0.5;
+  transition: all 0.2s ease;
+}
+
+#workspaces button.active {
+  background: linear-gradient(135deg, rgba(18, 153, 202, 0.4), rgba(53, 188, 222, 0.2));
+  color: #35BCDE;
+  opacity: 1;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    0 0 16px rgba(18, 153, 202, 0.3);
+}
+
+#workspaces button.empty { opacity: 0.2; }
+#workspaces button:hover { background: rgba(18, 153, 202, 0.15); opacity: 0.8; }
+
+/* CLOCK */
+#custom-clock {
+  margin: 6px 12px;
+  padding: 0 20px;
+  border-radius: 16px;
+  background: rgba(18, 153, 202, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+/* MODULES - unified pill groups */
+.module-group {
+  margin: 6px 4px;
+  padding: 0 16px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+#mpris,
+#idle_inhibitor,
+#custom-uptime,
+#custom-power-profile,
+#custom-weather,
+#custom-update,
+#cpu,
+#battery,
+#pulseaudio,
+#network,
+#custom-network-speed,
+#bluetooth,
+#tray {
+  margin: 0;
+  padding: 0 12px;
+  background: transparent;
+  border-radius: 0;
+}
+
+/* Space between modules in same group */
+#mpris + #idle_inhibitor,
+#idle_inhibitor + #custom-uptime,
+#custom-uptime + #custom-power-profile,
+#custom-power-profile + #custom-weather,
+#custom-weather + #custom-update,
+#custom-update + #cpu,
+#cpu + #battery,
+#battery + #pulseaudio,
+#pulseaudio + #network,
+#network + #custom-network-speed,
+#custom-network-speed + #bluetooth,
+#bluetooth + #tray {
+  margin-left: 8px;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  padding-left: 20px;
+}
+
+/* STATES */
+#idle_inhibitor.activated { color: #4EC85A; }
+#custom-power-profile.performance { color: #4EC85A; }
+#custom-power-profile.power-saver { color: #35BCDE; }
+#custom-network-speed.disconnected { color: #C85A50; }
+#custom-update.has-update { color: #4EC85A; }
+#battery.warning { color: #C8A830; }
+#battery.critical { color: #C85A50; }
+
+/* MPRIS */
+#mpris { min-width: 100px; }
+#mpris.playing { color: #35BCDE; }
+#mpris.paused { opacity: 0.6; }
+#mpris.stopped { opacity: 0; min-width: 0; padding: 0; }
+
+/* TOOLTIP */
+tooltip {
+  background: rgba(20, 20, 30, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-size: 12px;
+}
+tooltip label { color: #E0E0E0; }
+
+/* INDICATORS */
+#custom-screenrecording-indicator,
+#custom-notification-silencing-indicator,
+#custom-voxtype,
+#custom-expand-icon {
+  padding: 0 12px;
+  background: transparent;
+}
+#custom-screenrecording-indicator.active,
+#custom-notification-silencing-indicator.active,
+#custom-voxtype.recording { color: #C85A50; }
+
+/* VERTICAL - not applicable for island */

--- a/default/waybar/styles/pills/style.css
+++ b/default/waybar/styles/pills/style.css
@@ -1,0 +1,518 @@
+@import "../omarchy/current/theme/waybar.css";
+
+/* ==================== PILLS STYLE ==================== */
+/* Floating modular pills with glassmorphism - Frutiger Aero signature */
+
+* {
+  color: @foreground;
+  border: none;
+  border-radius: 0;
+  min-height: 0;
+  font-family: 'JetBrainsMono Nerd Font', 'Fira Sans';
+  font-size: 13px;
+  font-weight: 600;
+  text-shadow: 0 1px 4px rgba(255, 255, 255, 0.15);
+  letter-spacing: 0.3px;
+}
+
+/* ==================== ANIMATIONS ==================== */
+
+@keyframes orb-pulse {
+  0% {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.18),
+      0 0 8px rgba(18, 153, 202, 0.12);
+  }
+  50% {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.18),
+      0 0 22px rgba(18, 153, 202, 0.28),
+      0 0 44px rgba(18, 153, 202, 0.08);
+  }
+  100% {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.18),
+      0 0 8px rgba(18, 153, 202, 0.12);
+  }
+}
+
+/* ==================== BAR BACKGROUND ==================== */
+
+window#waybar {
+  background: @background;
+  border: none;
+  box-shadow: none;
+}
+
+window#waybar > box {
+  background: linear-gradient(
+                90deg,
+                rgba(138, 43, 226, 0.28) 0%,
+                rgba(53, 188, 222, 0.22) 25%,
+                rgba(78, 200, 90, 0.16) 50%,
+                rgba(100, 120, 220, 0.22) 75%,
+                rgba(138, 43, 226, 0.28) 100%
+              ),
+              @background;
+  margin: 4px 6px 0;
+  border-radius: 16px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -1px 0 rgba(18, 153, 202, 0.06),
+    0 3px 16px rgba(18, 153, 202, 0.08),
+    0 1px 4px rgba(0, 0, 0, 0.03);
+}
+
+/* Shared glass shine */
+@define-color pill-shine rgba(255, 255, 255, 0.18);
+
+/* ==================== OMARCHY START BUTTON ==================== */
+
+#custom-omarchy {
+  padding: 0 16px 0 18px;
+  margin: 4px 2px;
+  border-radius: 14px;
+  font-size: 17px;
+  background:
+    radial-gradient(
+      ellipse at 30% 20%,
+      rgba(255, 255, 255, 0.18) 0%,
+      rgba(18, 153, 202, 0.14) 40%,
+      rgba(18, 153, 202, 0.06) 100%
+    );
+  box-shadow:
+    inset 0 1px 0 @pill-shine,
+    inset 0 -1px 0 rgba(18, 153, 202, 0.10),
+    0 0 8px rgba(18, 153, 202, 0.05);
+}
+
+#custom-omarchy:hover {
+  background:
+    radial-gradient(
+      ellipse at 30% 20%,
+      rgba(255, 255, 255, 0.25) 0%,
+      rgba(18, 153, 202, 0.22) 40%,
+      rgba(18, 153, 202, 0.10) 100%
+    );
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.30),
+    0 0 20px rgba(18, 153, 202, 0.20),
+    0 0 40px rgba(18, 153, 202, 0.08);
+}
+
+/* ==================== WORKSPACES ==================== */
+
+#workspaces {
+  margin: 4px 2px;
+  padding: 0 8px;
+  border-radius: 14px;
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.06) 0%,
+    rgba(90, 172, 160, 0.04) 100%
+  );
+  box-shadow: inset 0 1px 0 @pill-shine;
+}
+
+#workspaces button {
+  all: initial;
+  padding: 0 12px;
+  margin: 2px 3px;
+  min-width: 10px;
+  min-height: 22px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  color: @foreground;
+  font-size: 13px;
+}
+
+#workspaces button.active {
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.30) 0%,
+    rgba(53, 188, 222, 0.12) 100%
+  );
+  color: #35BCDE;
+  animation: orb-pulse 3s ease-in-out infinite;
+}
+
+#workspaces button.empty {
+  opacity: 0.25;
+}
+
+#workspaces button:hover {
+  background: rgba(18, 153, 202, 0.10);
+}
+
+/* ==================== CLOCK ==================== */
+
+#custom-clock {
+  margin: 4px 6px;
+  padding: 0 18px;
+  border-radius: 14px;
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.08) 0%,
+    rgba(90, 172, 160, 0.04) 100%
+  );
+  box-shadow: inset 0 1px 0 @pill-shine;
+  font-weight: 700;
+  font-size: 13.5px;
+  letter-spacing: 0.5px;
+}
+
+/* ==================== PILL MODULES ==================== */
+
+#mpris,
+#idle_inhibitor,
+#custom-uptime,
+#custom-power-profile,
+#custom-weather,
+#custom-update,
+#cpu,
+#battery,
+#pulseaudio,
+#network,
+#custom-network-speed,
+#bluetooth,
+#tray {
+  margin: 4px 3px;
+  padding: 0 14px;
+  border-radius: 14px;
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.06) 0%,
+    rgba(90, 172, 160, 0.04) 100%
+  );
+  box-shadow: inset 0 1px 0 @pill-shine;
+}
+
+/* MPRIS now-playing states */
+#mpris.playing {
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.14) 0%,
+    rgba(53, 188, 222, 0.08) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 @pill-shine,
+    0 0 12px rgba(18, 153, 202, 0.08);
+}
+
+#mpris.paused {
+  opacity: 0.7;
+}
+
+/* Idle-inhibitor states */
+#idle_inhibitor.activated {
+  background: linear-gradient(
+    135deg,
+    rgba(78, 200, 90, 0.18) 0%,
+    rgba(78, 200, 90, 0.06) 100%
+  );
+  color: #4EC85A;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.20),
+    0 0 12px rgba(78, 200, 90, 0.25),
+    0 0 24px rgba(78, 200, 90, 0.08);
+}
+
+/* Hover effects */
+#custom-uptime:hover,
+#custom-power-profile:hover,
+#custom-weather:hover,
+#custom-update:hover,
+#cpu:hover,
+#battery:hover,
+#pulseaudio:hover,
+#network:hover,
+#custom-network-speed:hover,
+#bluetooth:hover,
+#tray:hover,
+#custom-clock:hover,
+#custom-omarchy:hover,
+#mpris:hover,
+#idle_inhibitor:hover {
+  transition: all 0.15s ease;
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.14) 0%,
+    rgba(90, 172, 160, 0.08) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 @pill-shine,
+    0 0 14px rgba(18, 153, 202, 0.10);
+}
+
+#idle_inhibitor.activated:hover {
+  background: linear-gradient(
+    135deg,
+    rgba(78, 200, 90, 0.24) 0%,
+    rgba(78, 200, 90, 0.10) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.25),
+    0 0 18px rgba(78, 200, 90, 0.30);
+}
+
+/* Power profile states */
+#custom-power-profile.performance {
+  color: #4EC85A;
+}
+
+#custom-power-profile.power-saver {
+  color: #35BCDE;
+}
+
+/* Network speed */
+#custom-network-speed {
+  font-size: 11.5px;
+  letter-spacing: -0.3px;
+}
+
+#custom-network-speed.disconnected {
+  color: #C85A50;
+}
+
+/* Uptime */
+#custom-uptime {
+  font-size: 11px;
+  color: @foreground;
+}
+
+#custom-weather.unavailable {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+}
+
+#custom-update {
+  font-size: 12px;
+}
+
+#custom-update.has-update {
+  background: linear-gradient(
+    135deg,
+    rgba(78, 200, 90, 0.14) 0%,
+    rgba(78, 200, 90, 0.06) 100%
+  );
+  color: #4EC85A;
+}
+
+#cpu,
+#battery,
+#pulseaudio {
+  font-size: 13px;
+}
+
+#battery.warning {
+  background: linear-gradient(
+    135deg,
+    rgba(200, 168, 48, 0.14) 0%,
+    rgba(200, 168, 48, 0.06) 100%
+  );
+  color: #C8A830;
+}
+
+#battery.critical {
+  background: linear-gradient(
+    135deg,
+    rgba(200, 90, 80, 0.14) 0%,
+    rgba(200, 90, 80, 0.06) 100%
+  );
+  color: #C85A50;
+}
+
+/* ==================== MPRIS ==================== */
+
+#mpris {
+  font-size: 13px;
+  min-width: 80px;
+}
+
+#mpris.playing {
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.14) 0%,
+    rgba(90, 172, 160, 0.08) 100%
+  );
+  animation: orb-pulse 4s ease-in-out infinite;
+}
+
+#mpris.paused {
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.04) 0%,
+    rgba(90, 172, 160, 0.02) 100%
+  );
+  opacity: 0.7;
+}
+
+#mpris.stopped {
+  min-width: 0;
+  margin: 4px 0;
+  padding: 0;
+  opacity: 0;
+}
+
+/* TOOLTIP */
+tooltip {
+  background: rgba(10, 26, 46, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 8px 14px;
+  font-size: 12px;
+}
+
+tooltip label {
+  color: #D0ECE8;
+}
+
+/* INDICATORS */
+#custom-screenrecording-indicator,
+#custom-notification-silencing-indicator {
+  margin: 4px 2px;
+  padding: 0 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.06) 0%,
+    rgba(90, 172, 160, 0.04) 100%
+  );
+  box-shadow: inset 0 1px 0 @pill-shine;
+}
+
+#custom-screenrecording-indicator.active {
+  background: linear-gradient(
+    135deg,
+    rgba(200, 90, 80, 0.18) 0%,
+    rgba(200, 90, 80, 0.06) 100%
+  );
+  color: #C85A50;
+}
+
+#custom-notification-silencing-indicator.active {
+  background: linear-gradient(
+    135deg,
+    rgba(200, 90, 80, 0.18) 0%,
+    rgba(200, 90, 80, 0.06) 100%
+  );
+  color: #C85A50;
+}
+
+#custom-voxtype {
+  margin: 4px 2px;
+  padding: 0 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.06) 0%,
+    rgba(90, 172, 160, 0.04) 100%
+  );
+  box-shadow: inset 0 1px 0 @pill-shine;
+}
+
+#custom-voxtype.recording {
+  background: linear-gradient(
+    135deg,
+    rgba(200, 90, 80, 0.18) 0%,
+    rgba(200, 90, 80, 0.06) 100%
+  );
+  color: #C85A50;
+}
+
+#custom-expand-icon {
+  margin: 4px 2px;
+  padding: 0 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  background: linear-gradient(
+    135deg,
+    rgba(18, 153, 202, 0.06) 0%,
+    rgba(90, 172, 160, 0.04) 100%
+  );
+  box-shadow: inset 0 1px 0 @pill-shine;
+}
+
+#custom-weather.unavailable {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+}
+
+/* VERTICAL MODE OVERRIDES */
+.left .modules-left, .right .modules-left { margin: 8px 0 0 0; }
+.left .modules-right, .right .modules-right { margin: 0 0 8px 0; }
+
+.left #workspaces button, .right #workspaces button {
+  padding: 8px 0;
+  margin: 1.5px 0;
+}
+
+.left #cpu, .right #cpu,
+.left #battery, .right #battery,
+.left #pulseaudio, .right #pulseaudio,
+.left #custom-omarchy, .right #custom-omarchy,
+.left #custom-update, .right #custom-update,
+.left #custom-uptime, .right #custom-uptime,
+.left #custom-power-profile, .right #custom-power-profile,
+.left #custom-network-speed, .right #custom-network-speed,
+.left #tray, .right #tray { margin: 0 0 16px 0; }
+.left #bluetooth, .right #bluetooth { margin: 1.5px 0; padding: 8px 0; min-height: 14px; }
+.left #network, .right #network { margin: 1.5px 0; padding: 8px 0; min-height: 14px; }
+.left #custom-expand-icon, .right #custom-expand-icon { margin: 1.5px 0; padding: 8px 0; min-height: 14px; }
+.left #mpris, .right #mpris { margin: 1.5px 0; padding: 8px 0; min-height: 14px; min-width: 80px; }
+.left #custom-clock, .right #custom-clock { margin: 8.75px 0 0 0; }
+.left #custom-weather, .right #custom-weather { margin: 1.5px 0; padding: 8px 0; min-height: 14px; min-width: 14px; margin-right: 4px; }
+
+.left #custom-screenrecording-indicator, .right #custom-screenrecording-indicator,
+.left #custom-notification-silencing-indicator, .right #custom-notification-silencing-indicator {
+  margin: 5px 0 0 0;
+  min-width: 0;
+  min-height: 14px;
+}
+
+.left #custom-voxtype, .right #custom-voxtype { margin: 7.5px 0 0 0; min-width: 0; min-height: 14px; }
+
+#custom-expand-icon.vertical,
+.left #custom-expand-icon.horizontal,
+.right #custom-expand-icon.horizontal {
+  opacity: 0;
+  font-size: 0;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.left #custom-expand-icon.vertical,
+.right #custom-expand-icon.vertical {
+  opacity: 1;
+  font-size: inherit;
+  min-width: 0;
+  min-height: 14px;
+  margin: 1.5px 0;
+  padding: 8px 0;
+}
+
+#custom-clock.vertical,
+.left #custom-clock.horizontal,
+.right #custom-clock.horizontal {
+  opacity: 0;
+  font-size: 0;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.left #custom-clock.vertical,
+.right #custom-clock.vertical {
+  opacity: 1;
+  font-size: inherit;
+  min-width: 0;
+  min-height: 14px;
+  margin: 8.75px 0 0 0;
+}

--- a/themes/catppuccin/waybar.style
+++ b/themes/catppuccin/waybar.style
@@ -1,0 +1,1 @@
+classic


### PR DESCRIPTION
## Summary
Adds a modular Waybar style system that lets users change the bar layout as easily as changing the wallpaper (`omarchy bar style next` / `omarchy bar style set <name>`).

## Architecture

### Two-Layer Separation (adev modularity)
- **Layer 1 - Colors** (managed by themes): `~/.config/omarchy/current/theme/waybar.css` → only `@foreground` / `@background`
- **Layer 2 - Styles** (managed by new system): `~/.config/omarchy/current/waybar.style` (symlink) → geometry, padding, borders, layout

Themes remain unchanged — they only supply colors. Styles control visual structure.

### Built-in Styles (in `default/waybar/styles/`)
| Style | Description |
|-------|-------------|
| `classic` | Flat continuous bar — original Omarchy default |
| `pills` | Floating glassmorphism pills — Frutiger Aero signature |
| `island` | Centered dock with rounded ends — macOS/Plasma style |
| `compact` | Ultra-thin 24px — small screens / vertical layouts |

### CLI Commands
| Command | Description |
|---------|-------------|
| `omarchy bar style set <name>` | Atomic symlink swap + `omarchy-restart-waybar` |
| `omarchy bar style next` | Cycle styles (like `omarchy theme bg next`) |
| `omarchy bar style list` | List system + user styles with active marker |
| `omarchy bar style switcher` | Interactive picker (walker / gum / select) |

### User Styles
Custom styles at `~/.config/waybar/styles/<name>/style.css` — detected and listed automatically.

### Theme Integration
- `omarchy-theme-set` reads `waybar.style` from theme directory and applies it
- Example: `catppuccin/waybar.style = classic`, `frutiger-aero/waybar.style = pills`
- Zero regressions: existing themes without `waybar.style` keep current behavior

## Testing
- `./bin/omarchy commands --check` — 432 commands pass
- `shellcheck bin/omarchy-bar-style-*` — passes
- `luac -p config/hypr/*.lua` — passes
- Manual test loop: 10/10 tests pass (list, set, cycle, wrap, theme-integration, CLI, metadata, shellcheck)

## Migration Path for Frutiger Aero Theme
Theme just adds `waybar.style = pills` file — automatically gets pill layout when applied.

## Screenshots
(Will add after visual verification)