### PR TITLE
Monitor scaling: honour desc: and multi-line hl.monitor rules for the internal panel

### DIFF
--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -71,11 +71,78 @@ lua_scalar() {
 monitor_rules() {
   [[ -f $MONITOR_LUA ]] || return 0
 
-  sed -E -e 's/--\[\[[^]]*\]\]//g' -e 's/--.*$//' "$MONITOR_LUA"
+  # Comments cut away first, then every hl.monitor({ ... }) call folded onto one
+  # line. A rule split across lines -- what nwg-displays writes, and how anyone
+  # formatting by hand tends to write a long rule -- otherwise matches nothing
+  # here, and the panel silently falls back to the catch-all.
+  sed -E -e 's/--\[\[[^]]*\]\]//g' -e 's/--.*$//' "$MONITOR_LUA" |
+    awk '
+      {
+        counted = $0
+        opened = gsub(/\{/, "{", counted)
+        closed = gsub(/\}/, "}", counted)
+
+        if (depth == 0) {
+          buffer = $0
+        } else {
+          trimmed = $0
+          sub(/^[[:space:]]+/, "", trimmed)
+          buffer = buffer " " trimmed
+        }
+
+        depth += opened - closed
+        if (depth <= 0) {
+          print buffer
+          buffer = ""
+          depth = 0
+        }
+      }
+    '
+}
+
+# A monitor description is free text from the EDID and routinely carries regex
+# metacharacters, so it cannot go into a pattern unquoted.
+regex_escape() {
+  printf '%s' "$1" | sed -E 's/[][(){}.*+?^$|\\/]/\\&/g'
 }
 
 monitor_rule_regex() {
-  printf '^[[:space:]]*hl\\.monitor\\(\\{.*output[[:space:]]*=[[:space:]]*"%s"' "$1"
+  printf '^[[:space:]]*hl\\.monitor\\(\\{.*output[[:space:]]*=[[:space:]]*"%s"' "$(regex_escape "$1")"
+}
+
+# Every rule's output= value, in file order.
+monitor_rule_outputs() {
+  monitor_rules |
+    sed -nE 's/^[[:space:]]*hl\.monitor\(\{.*[{,;[:space:]]output[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p'
+}
+
+internal_monitor_description() {
+  [[ -n $INTERNAL ]] || return 0
+
+  hyprctl monitors all -j | jq -r --arg internal "$INTERNAL" \
+    '.[] | select(.name == $internal) | .description' | head -1
+}
+
+# The rule Hyprland itself would apply to the internal panel: one naming the
+# connector if there is one, otherwise the first desc: rule whose text prefixes
+# the panel's description, which is how Hyprland matches desc:. Empty when no
+# rule names the panel at all, leaving the caller on the catch-all as before.
+internal_rule_key() {
+  local description key
+
+  [[ -n $INTERNAL ]] || return 0
+  if monitor_rule_outputs | grep -qxF "$INTERNAL"; then
+    printf '%s\n' "$INTERNAL"
+    return
+  fi
+
+  description=$(internal_monitor_description)
+  [[ -n $description ]] || return 0
+
+  while IFS= read -r key; do
+    [[ $key == desc:* ]] || continue
+    [[ $description == "${key#desc:}"* ]] && { printf '%s\n' "$key"; return; }
+  done < <(monitor_rule_outputs)
 }
 
 # A key is preceded by a table separator, so a longer key cannot stand in for it,
@@ -89,9 +156,14 @@ configured_monitor_value() {
 }
 
 configured_internal_monitor_value() {
+  local key
+
   [[ -n $INTERNAL ]] || return 0
 
-  configured_monitor_value "$INTERNAL" "$1"
+  key=$(internal_rule_key)
+  [[ -n $key ]] || return 0
+
+  configured_monitor_value "$key" "$1"
 }
 
 configured_monitor_scale() {


### PR DESCRIPTION
### What's wrong?

`omarchy-hyprland-monitor-clamshell` reads the internal panel's intended scale and position out of `monitors.lua`, but `monitor_rule_regex` only matches a rule that is **written on one line** and **keyed by connector name**. Two shapes that Hyprland itself honours match nothing:

- a rule keyed by `desc:` — standard Hyprland syntax, and the usual way to survive connectors renumbering across hotplug (#7084)
- a rule written across several lines — what `nwg-displays` writes, and how a long rule tends to get hand-formatted (#8123, #8335)

The panel then falls through to the catch-all. Because the watcher re-applies the internal output every ~2s while docked, the user's arranged `position` is replaced with `auto` (#7326), and on clamshell exit `enable_internal_output` re-enables the panel at the remembered-or-default scale instead of the configured one.

### Reproduction

Parser output for the same panel, `eDP-2`, description `EDO EF10QBC64.C`, against `main` (06e32d2):

| `monitors.lua` form | `configured_monitor_scale` | `read_monitor_position` |
|---|---|---|
| single line, connector name | `1.6` | `0x0` |
| `desc:` keyed | **`auto`** | **`auto`** |
| multi-line table | **`auto`** | **`auto`** |

On real hardware with a `desc:`-keyed multi-line rule, `configured_monitor_scale` returns empty and the panel is driven from the fallback instead of the config.

### What this changes

1. `monitor_rules` folds each `hl.monitor({ ... })` call onto a single line before matching, so a multi-line rule parses identically to the single-line form. Comment stripping still happens first, so a commented-out rule still cannot pose as a real one.
2. `internal_rule_key` looks the panel up by connector name first, then by any `desc:` rule whose text is a **prefix** of the panel's description — which is how Hyprland matches `desc:` itself.
3. `regex_escape` guards the description before it goes into a pattern. Descriptions are EDID free text and routinely contain `.`, `(`, `+`.

A panel that no rule names still falls through to the catch-all exactly as before, so the shipped default config behaves identically.

### Tests

Six cases against the patched parser, including two negative controls:

| case | before | after |
|---|---|---|
| single line, connector name | `1.6` / `0x0` | `1.6` / `0x0` |
| `desc:` keyed | `auto` / `auto` | `1.6` / `0x0` |
| multi-line table | `auto` / `auto` | `1.6` / `0x0` |
| `desc:` prefix + multi-line | `auto` / `auto` | `1.6` / `0x0` |
| no rule names the panel | `1.25` (catch-all) | `1.25` unchanged |
| rule commented out | `1.25` | `1.25` unchanged |

Verified on Omarchy 4.0.0-1 / Hyprland 0.56.2, Lenovo Legion 5 15IRX10, internal `eDP-2` 2560x1600 (203 PPI) + external `HDMI-A-1` 1920x1080 (102 PPI).

Fixes #7084
