### PR TITLE
Ask before normalizing screen recording audio that's unusually quiet or loud

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -270,8 +270,6 @@ measure_loudness() {
 prompt_normalize_audio() {
   local input_i=$1
   local prompt keep normalize selection
-  # glyph<TAB>label<TAB>subtext — a leading tab is an empty glyph; without it
-  # the label is drawn as a huge icon and overlaps the measured LUFS.
   keep=$'\tKeep original levels\tas recorded'
   if awk -v i="$input_i" -v target="$LOUDNORM_I" 'BEGIN { exit (i < target) ? 0 : 1 }'; then
     prompt="Audio may be unintentionally quiet"

--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -352,6 +352,17 @@ start_screenrecording() {
   fi
 }
 
+# Drop the sidecar only if it still names this recording. A stop that sits in
+# finalize (measure + prompt) can outlive a new start writing a different path.
+release_recording_file() {
+  local filename=$1
+  local current
+  current=$(cat "$RECORDING_FILE" 2>/dev/null) || true
+  if [[ $current == "$filename" ]]; then
+    rm -f "$RECORDING_FILE"
+  fi
+}
+
 stop_screenrecording() {
   pkill -SIGINT -f "^gpu-screen-recorder" # SIGINT required to save video properly
 
@@ -365,12 +376,13 @@ stop_screenrecording() {
   toggle_screenrecording_indicator
   cleanup_webcam
 
+  local filename
+  filename=$(cat "$RECORDING_FILE" 2>/dev/null)
+
   if pgrep -f "^gpu-screen-recorder" >/dev/null; then
     pkill -9 -f "^gpu-screen-recorder"
     omarchy-notification-send -u critical -t 5000 "Screen recording error" "Recording process had to be force-killed. Video may be corrupted."
   else
-    local filename
-    filename=$(cat "$RECORDING_FILE" 2>/dev/null)
     finalize_recording "$filename"
     echo "$filename"
     local preview="${filename%.mp4}-preview.png"
@@ -391,7 +403,7 @@ stop_screenrecording() {
     ) &
   fi
 
-  rm -f "$RECORDING_FILE"
+  release_recording_file "$filename"
 }
 
 toggle_screenrecording_indicator() {

--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -323,11 +323,6 @@ start_screenrecording() {
   local capture_args=()
   local target
 
-  if [[ ! -d $OUTPUT_DIR ]]; then
-    omarchy-notification-send -u critical -t 3000 "Screen recording directory does not exist: $OUTPUT_DIR"
-    return 1
-  fi
-
   # Opt-in path for HDR, external-GPU monitors, and window capture (all things
   # the portal backend supports and the kms backend doesn't). Default flow uses
   # slurp + the kms backend, which avoids the EGL DMA-BUF modifier import
@@ -467,7 +462,12 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
     stop_screenrecording
   elif [[ $STOP_RECORDING == "true" ]]; then
     exit 1
-  else
+  elif [[ -d $OUTPUT_DIR ]]; then
     start_screenrecording || cleanup_webcam
+  else
+    # Only starting needs the directory; stopping still has to finalize a
+    # recording whose directory went away mid-capture.
+    omarchy-notification-send -u critical -t 3000 "Screen recording directory does not exist: $OUTPUT_DIR"
+    exit 1
   fi
 fi

--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Start or stop screen recording
 # omarchy:group=capture
-# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--normalize-audio] [--no-normalize-audio] [--stop-recording]
+# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording]
 # omarchy:examples=omarchy screenrecord | omarchy capture screenrecording --with-desktop-audio
 # omarchy:aliases=omarchy screenrecord
 #
@@ -21,7 +21,6 @@
 # Env: OMARCHY_SCREENRECORD_NORMALIZE=true always applies loudnorm after stop;
 # false never does. Unset asks when integrated loudness is quieter than -18 LUFS
 # or louder than -11 LUFS.
-# --normalize-audio / --no-normalize-audio on start are remembered until stop.
 
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR:-$HOME/Videos}}"
@@ -34,11 +33,13 @@ WEBCAM_SIZE="medium"
 RESOLUTION=""
 FULLSCREEN="false"
 STOP_RECORDING="false"
-NORMALIZE_AUDIO=""
 RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
 REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
-NORMALIZE_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-normalize"
 LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "/tmp/omarchy-screenrecord.log" || echo "/dev/null")
+# Seconds to wait on the post-stop normalize prompt before keeping original
+# levels and dismissing the leftover dialog. Super+Space unstrands immediately
+# via the menu; this is for an unanswered prompt (walk-away or shell death).
+NORMALIZE_PROMPT_TIMEOUT=120
 
 # -14 LUFS is the typical target for YouTube, Spotify, and Amazon Music
 # -16 LUBS Apple Music
@@ -60,8 +61,6 @@ for arg in "$@"; do
   --webcam-size=*) WEBCAM_SIZE="${arg#*=}" ;;
   --resolution=*) RESOLUTION="${arg#*=}" ;;
   --fullscreen) FULLSCREEN="true" ;;
-  --normalize-audio) NORMALIZE_AUDIO="true" ;;
-  --no-normalize-audio) NORMALIZE_AUDIO="false" ;;
   --stop-recording) STOP_RECORDING="true" ;;
   esac
 done
@@ -158,49 +157,19 @@ select_capture_target() {
   echo "region:${BASH_REMATCH[3]}x${BASH_REMATCH[4]}+${BASH_REMATCH[1]}+${BASH_REMATCH[2]}"
 }
 
-persist_normalize_preference() {
-  local value=ask
-  if [[ $NORMALIZE_AUDIO == "true" ]]; then
-    value=yes
-  elif [[ $NORMALIZE_AUDIO == "false" ]]; then
-    value=no
-  fi
-  echo "$value" >"$NORMALIZE_FILE"
-}
-
-# Echoes yes, no, or ask. Start and stop are separate processes, so start-time
-# flags live in NORMALIZE_FILE until stop reads them.
+# Echoes yes, no, or ask from OMARCHY_SCREENRECORD_NORMALIZE.
 normalize_preference() {
-  if [[ $NORMALIZE_AUDIO == "true" ]]; then
-    echo yes
-    return
-  fi
-  if [[ $NORMALIZE_AUDIO == "false" ]]; then
-    echo no
-    return
-  fi
-
   case ${OMARCHY_SCREENRECORD_NORMALIZE:-} in
   true)
     echo yes
-    return
     ;;
   false)
     echo no
-    return
+    ;;
+  *)
+    echo ask
     ;;
   esac
-
-  local sidecar
-  sidecar=$(cat "$NORMALIZE_FILE" 2>/dev/null || true)
-  case $sidecar in
-  yes | no)
-    echo "$sidecar"
-    return
-    ;;
-  esac
-
-  echo ask
 }
 
 screenrecord_pop_filter() {
@@ -269,7 +238,7 @@ measure_loudness() {
 
 prompt_normalize_audio() {
   local input_i=$1
-  local prompt keep normalize selection
+  local prompt keep normalize selection status
   keep=$'\tKeep original levels\tas recorded'
   if awk -v i="$input_i" -v target="$LOUDNORM_I" 'BEGIN { exit (i < target) ? 0 : 1 }'; then
     prompt="Audio may be unintentionally quiet"
@@ -278,7 +247,13 @@ prompt_normalize_audio() {
     prompt="Audio may be unintentionally loud"
     normalize=$'\tNormalize\tlower to typical YouTube and Spotify volume'
   fi
-  selection=$(omarchy-menu-select "$prompt" "$keep" "$normalize" -- --width 560) || return 1
+  status=0
+  selection=$(timeout "$NORMALIZE_PROMPT_TIMEOUT" omarchy-menu-select "$prompt" "$keep" "$normalize" -- --width 560) || status=$?
+  if (( status == 124 )); then
+    omarchy-menu close >/dev/null 2>&1 || true
+    return 1
+  fi
+  (( status == 0 )) || return 1
   [[ $selection == Normalize* ]]
 }
 
@@ -373,7 +348,6 @@ start_screenrecording() {
 
   if kill -0 $pid 2>/dev/null; then
     echo "$filename" >"$RECORDING_FILE"
-    persist_normalize_preference
     toggle_screenrecording_indicator
   fi
 }
@@ -395,8 +369,9 @@ stop_screenrecording() {
     pkill -9 -f "^gpu-screen-recorder"
     omarchy-notification-send -u critical -t 5000 "Screen recording error" "Recording process had to be force-killed. Video may be corrupted."
   else
-    finalize_recording
-    local filename=$(cat "$RECORDING_FILE" 2>/dev/null)
+    local filename
+    filename=$(cat "$RECORDING_FILE" 2>/dev/null)
+    finalize_recording "$filename"
     echo "$filename"
     local preview="${filename%.mp4}-preview.png"
 
@@ -416,7 +391,7 @@ stop_screenrecording() {
     ) &
   fi
 
-  rm -f "$RECORDING_FILE" "$NORMALIZE_FILE"
+  rm -f "$RECORDING_FILE"
 }
 
 toggle_screenrecording_indicator() {
@@ -428,8 +403,7 @@ screenrecording_active() {
 }
 
 finalize_recording() {
-  local latest
-  latest=$(cat "$RECORDING_FILE" 2>/dev/null)
+  local latest=$1
   [[ -f $latest ]] || return
 
   # Re-encode only when the first GOP contains discardable warmup packets — stream copy can't

--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -19,8 +19,9 @@
 # users can attach a log when reporting capture failures.
 #
 # Env: OMARCHY_SCREENRECORD_NORMALIZE=true always applies loudnorm after stop;
-# false never does. Unset asks when integrated loudness is quieter than -18 LUFS
-# or louder than -11 LUFS.
+# false never does. Unset asks immediately when the recording is longer than 10
+# minutes, or when a shorter recording's integrated loudness is quieter than
+# -18 LUFS or louder than -11 LUFS.
 
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR:-$HOME/Videos}}"
@@ -49,6 +50,8 @@ LOUDNORM_TP=-1.5
 LOUDNORM_LRA=11
 LOUDNORM_I_QUIET_TOLERANCE=4
 LOUDNORM_I_LOUD_TOLERANCE=3
+# First-pass loudnorm decodes the whole soundtrack; skip it past this length.
+LOUDNORM_ANALYZE_MAX_SECONDS=600
 SCREENRECORD_LOUDNESS_STATS=""
 SCREENRECORD_NORMALIZE=no
 
@@ -236,25 +239,45 @@ measure_loudness() {
   printf '%s\n' "$stats"
 }
 
-prompt_normalize_audio() {
-  local input_i=$1
-  local prompt keep normalize selection status
-  keep=$'\tKeep original levels\tas recorded'
-  if awk -v i="$input_i" -v target="$LOUDNORM_I" 'BEGIN { exit (i < target) ? 0 : 1 }'; then
-    prompt="Audio may be unintentionally quiet"
-    normalize=$'\tNormalize\traise to typical YouTube and Spotify volume'
-  else
-    prompt="Audio may be unintentionally loud"
-    normalize=$'\tNormalize\tlower to typical YouTube and Spotify volume'
-  fi
-  status=0
-  selection=$(timeout "$NORMALIZE_PROMPT_TIMEOUT" omarchy-menu-select "$prompt" "$keep" "$normalize" -- --width 560) || status=$?
+# Remaining args are options in display order. Returns 0 when the user picks Normalize.
+run_normalize_prompt() {
+  local prompt=$1
+  shift
+  local selection status=0
+  selection=$(timeout "$NORMALIZE_PROMPT_TIMEOUT" omarchy-menu-select "$prompt" "$@" -- --width 560) || status=$?
   if (( status == 124 )); then
     omarchy-menu close >/dev/null 2>&1 || true
     return 1
   fi
   (( status == 0 )) || return 1
   [[ $selection == Normalize* ]]
+}
+
+prompt_normalize_audio() {
+  local input_i=$1
+  local keep normalize
+  keep=$'\tKeep original levels\tas recorded'
+  if awk -v i="$input_i" -v target="$LOUDNORM_I" 'BEGIN { exit (i < target) ? 0 : 1 }'; then
+    normalize=$'\tNormalize\traise to typical broadcast levels'
+    run_normalize_prompt "Audio may be unintentionally quiet" "$keep" "$normalize"
+  else
+    normalize=$'\tNormalize\tlower to typical broadcast levels'
+    run_normalize_prompt "Audio may be unintentionally loud" "$keep" "$normalize"
+  fi
+}
+
+prompt_normalize_long_recording() {
+  local keep=$'\tKeep original levels\tas recorded'
+  local normalize=$'\tNormalize\tRecommended'
+  run_normalize_prompt "Normalize audio to typical broadcast levels?" "$normalize" "$keep"
+}
+
+# Returns 0 when duration is strictly greater than LOUDNORM_ANALYZE_MAX_SECONDS.
+recording_too_long_to_analyze() {
+  local duration
+  duration=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$1" 2>/dev/null) || return 1
+  [[ $duration =~ ^[0-9]+(\.[0-9]+)?$ ]] || return 1
+  awk -v d="$duration" -v max="$LOUDNORM_ANALYZE_MAX_SECONDS" 'BEGIN { exit (d > max) ? 0 : 1 }'
 }
 
 # Sets SCREENRECORD_NORMALIZE to yes or no. SCREENRECORD_LOUDNESS_STATS holds
@@ -276,6 +299,13 @@ decide_normalize() {
     return
     ;;
   esac
+
+  if recording_too_long_to_analyze "$file"; then
+    if prompt_normalize_long_recording; then
+      SCREENRECORD_NORMALIZE=yes
+    fi
+    return
+  fi
 
   if SCREENRECORD_LOUDNESS_STATS=$(measure_loudness "$file"); then
     input_i=$(jq -r '.input_i' <<<"$SCREENRECORD_LOUDNESS_STATS")

--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Start or stop screen recording
 # omarchy:group=capture
-# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording]
+# omarchy:args=[--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--normalize-audio] [--no-normalize-audio] [--stop-recording]
 # omarchy:examples=omarchy screenrecord | omarchy capture screenrecording --with-desktop-audio
 # omarchy:aliases=omarchy screenrecord
 #
@@ -17,14 +17,14 @@
 # Env: OMARCHY_SCREENRECORD_DEBUG=true appends gpu-screen-recorder's stderr (and
 # the picker target it was launched with) to /tmp/omarchy-screenrecord.log so
 # users can attach a log when reporting capture failures.
+#
+# Env: OMARCHY_SCREENRECORD_NORMALIZE=true always applies loudnorm after stop;
+# false never does. Unset asks when integrated loudness is quieter than -18 LUFS
+# or louder than -11 LUFS.
+# --normalize-audio / --no-normalize-audio on start are remembered until stop.
 
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR:-$HOME/Videos}}"
-
-if [[ ! -d $OUTPUT_DIR ]]; then
-  omarchy-notification-send -u critical -t 3000 "Screen recording directory does not exist: $OUTPUT_DIR"
-  exit 1
-fi
 
 DESKTOP_AUDIO="false"
 MICROPHONE_AUDIO="false"
@@ -34,9 +34,22 @@ WEBCAM_SIZE="medium"
 RESOLUTION=""
 FULLSCREEN="false"
 STOP_RECORDING="false"
+NORMALIZE_AUDIO=""
 RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
 REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
+NORMALIZE_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-normalize"
 LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "/tmp/omarchy-screenrecord.log" || echo "/dev/null")
+
+# -14 LUFS is the typical target for YouTube, Spotify, and Amazon Music
+# -16 LUBS Apple Music
+# -27 to -24 Netflix, ATSC A/85 (US TV), EBU R128 (Europe TV)
+LOUDNORM_I=-14
+LOUDNORM_TP=-1.5
+LOUDNORM_LRA=11
+LOUDNORM_I_QUIET_TOLERANCE=4
+LOUDNORM_I_LOUD_TOLERANCE=3
+SCREENRECORD_LOUDNESS_STATS=""
+SCREENRECORD_NORMALIZE=no
 
 for arg in "$@"; do
   case "$arg" in
@@ -47,6 +60,8 @@ for arg in "$@"; do
   --webcam-size=*) WEBCAM_SIZE="${arg#*=}" ;;
   --resolution=*) RESOLUTION="${arg#*=}" ;;
   --fullscreen) FULLSCREEN="true" ;;
+  --normalize-audio) NORMALIZE_AUDIO="true" ;;
+  --no-normalize-audio) NORMALIZE_AUDIO="false" ;;
   --stop-recording) STOP_RECORDING="true" ;;
   esac
 done
@@ -143,9 +158,177 @@ select_capture_target() {
   echo "region:${BASH_REMATCH[3]}x${BASH_REMATCH[4]}+${BASH_REMATCH[1]}+${BASH_REMATCH[2]}"
 }
 
+persist_normalize_preference() {
+  local value=ask
+  if [[ $NORMALIZE_AUDIO == "true" ]]; then
+    value=yes
+  elif [[ $NORMALIZE_AUDIO == "false" ]]; then
+    value=no
+  fi
+  echo "$value" >"$NORMALIZE_FILE"
+}
+
+# Echoes yes, no, or ask. Start and stop are separate processes, so start-time
+# flags live in NORMALIZE_FILE until stop reads them.
+normalize_preference() {
+  if [[ $NORMALIZE_AUDIO == "true" ]]; then
+    echo yes
+    return
+  fi
+  if [[ $NORMALIZE_AUDIO == "false" ]]; then
+    echo no
+    return
+  fi
+
+  case ${OMARCHY_SCREENRECORD_NORMALIZE:-} in
+  true)
+    echo yes
+    return
+    ;;
+  false)
+    echo no
+    return
+    ;;
+  esac
+
+  local sidecar
+  sidecar=$(cat "$NORMALIZE_FILE" 2>/dev/null || true)
+  case $sidecar in
+  yes | no)
+    echo "$sidecar"
+    return
+    ;;
+  esac
+
+  echo ask
+}
+
+screenrecord_pop_filter() {
+  echo "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05"
+}
+
+loudnorm_filter() {
+  local stats=${1:-}
+  local filter="loudnorm=I=${LOUDNORM_I}:TP=${LOUDNORM_TP}:LRA=${LOUDNORM_LRA}"
+  local measured_i measured_lra measured_tp measured_thresh offset
+
+  if [[ -n $stats ]]; then
+    measured_i=$(jq -r '.input_i // empty' <<<"$stats" 2>/dev/null || true)
+    measured_lra=$(jq -r '.input_lra // empty' <<<"$stats" 2>/dev/null || true)
+    measured_tp=$(jq -r '.input_tp // empty' <<<"$stats" 2>/dev/null || true)
+    measured_thresh=$(jq -r '.input_thresh // empty' <<<"$stats" 2>/dev/null || true)
+    offset=$(jq -r '.target_offset // empty' <<<"$stats" 2>/dev/null || true)
+    if [[ $measured_i =~ ^-?[0-9]+(\.[0-9]+)?$ && $measured_lra =~ ^-?[0-9]+(\.[0-9]+)?$ &&
+      $measured_tp =~ ^-?[0-9]+(\.[0-9]+)?$ && $measured_thresh =~ ^-?[0-9]+(\.[0-9]+)?$ &&
+      $offset =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+      filter+=":measured_I=${measured_i}:measured_LRA=${measured_lra}:measured_TP=${measured_tp}:measured_thresh=${measured_thresh}:offset=${offset}"
+    fi
+  fi
+
+  echo "$filter"
+}
+
+# $1 is yes or no. Optional $2 is first-pass loudnorm JSON for two-pass.
+screenrecord_audio_filter() {
+  local normalize=$1
+  local stats=${2:-}
+  local filter
+  filter=$(screenrecord_pop_filter)
+  if [[ $normalize == yes ]]; then
+    filter+=",$(loudnorm_filter "$stats")"
+  fi
+  echo "$filter"
+}
+
+# Returns 0 when integrated loudness is outside the skip window: more than
+# LOUDNORM_I_QUIET_TOLERANCE LU below -14, or more than LOUDNORM_I_LOUD_TOLERANCE
+# LU above it.
+loudness_might_need_normalization() {
+  local input_i=$1
+
+  [[ $input_i =~ ^-?[0-9]+(\.[0-9]+)?$ ]] || return 1
+
+  awk -v i="$input_i" -v target="$LOUDNORM_I" -v quiet="$LOUDNORM_I_QUIET_TOLERANCE" -v loud="$LOUDNORM_I_LOUD_TOLERANCE" '
+    BEGIN { exit (i < target - quiet || i > target + loud) ? 0 : 1 }
+  '
+}
+
+extract_loudnorm_json() {
+  awk '/^{/,/^}/'
+}
+
+measure_loudness() {
+  local file=$1
+  local filter output stats
+  filter="$(screenrecord_pop_filter),$(loudnorm_filter):print_format=json"
+  output=$(ffmpeg -hide_banner -nostats -ss 0.1 -i "$file" -vn -af "$filter" -f null - 2>&1) || true
+  stats=$(extract_loudnorm_json <<<"$output")
+  jq -e '.input_i' <<<"$stats" >/dev/null 2>&1 || return 1
+  printf '%s\n' "$stats"
+}
+
+prompt_normalize_audio() {
+  local input_i=$1
+  local prompt keep normalize selection
+  # glyph<TAB>label<TAB>subtext — a leading tab is an empty glyph; without it
+  # the label is drawn as a huge icon and overlaps the measured LUFS.
+  keep=$'\tKeep original levels\tas recorded'
+  if awk -v i="$input_i" -v target="$LOUDNORM_I" 'BEGIN { exit (i < target) ? 0 : 1 }'; then
+    prompt="Audio may be unintentionally quiet"
+    normalize=$'\tNormalize\traise to typical YouTube and Spotify volume'
+  else
+    prompt="Audio may be unintentionally loud"
+    normalize=$'\tNormalize\tlower to typical YouTube and Spotify volume'
+  fi
+  selection=$(omarchy-menu-select "$prompt" "$keep" "$normalize" -- --width 560) || return 1
+  [[ $selection == Normalize* ]]
+}
+
+# Sets SCREENRECORD_NORMALIZE to yes or no. SCREENRECORD_LOUDNESS_STATS holds
+# first-pass JSON when a measurement ran — callers must invoke this directly,
+# not via $(...), or the stats never leave the subshell.
+decide_normalize() {
+  local file=$1
+  local choice input_i
+  SCREENRECORD_NORMALIZE=no
+  SCREENRECORD_LOUDNESS_STATS=""
+  choice=$(normalize_preference)
+
+  case $choice in
+  yes)
+    SCREENRECORD_NORMALIZE=yes
+    return
+    ;;
+  no)
+    return
+    ;;
+  esac
+
+  if SCREENRECORD_LOUDNESS_STATS=$(measure_loudness "$file"); then
+    input_i=$(jq -r '.input_i' <<<"$SCREENRECORD_LOUDNESS_STATS")
+    if loudness_might_need_normalization "$input_i"; then
+      if prompt_normalize_audio "$input_i"; then
+        SCREENRECORD_NORMALIZE=yes
+        return
+      fi
+    fi
+  fi
+
+  SCREENRECORD_LOUDNESS_STATS=""
+}
+
+recording_has_audio() {
+  ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$1" 2>/dev/null | grep -q audio
+}
+
 start_screenrecording() {
   local capture_args=()
   local target
+
+  if [[ ! -d $OUTPUT_DIR ]]; then
+    omarchy-notification-send -u critical -t 3000 "Screen recording directory does not exist: $OUTPUT_DIR"
+    return 1
+  fi
 
   # Opt-in path for HDR, external-GPU monitors, and window capture (all things
   # the portal backend supports and the kms backend doesn't). Default flow uses
@@ -197,6 +380,7 @@ start_screenrecording() {
 
   if kill -0 $pid 2>/dev/null; then
     echo "$filename" >"$RECORDING_FILE"
+    persist_normalize_preference
     toggle_screenrecording_indicator
   fi
 }
@@ -239,7 +423,7 @@ stop_screenrecording() {
     ) &
   fi
 
-  rm -f "$RECORDING_FILE"
+  rm -f "$RECORDING_FILE" "$NORMALIZE_FILE"
 }
 
 toggle_screenrecording_indicator() {
@@ -262,13 +446,13 @@ finalize_recording() {
     video_codec=(-c:v libx264 -preset veryfast -crf 20)
   fi
 
-  # Trim the first frame, and normalize audio to -14 LUFS if present, in a single pass
   local args=(-y -ss 0.1 -i "$latest" "${video_codec[@]}")
-  if ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$latest" 2>/dev/null | grep -q audio; then
+  if recording_has_audio "$latest"; then
     # Hard-mute the first 400ms to drop the PipeWire capture-open pop (a near-clipping
     # transient around 130-200ms that a gentle fade-in can't attenuate enough), then a
-    # 50ms fade avoids a click at the boundary before loudnorm normalizes the rest.
-    args+=(-af "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05,loudnorm=I=-14:TP=-1.5:LRA=11")
+    # 50ms fade avoids a click at the boundary. loudnorm is optional; see decide_normalize.
+    decide_normalize "$latest"
+    args+=(-af "$(screenrecord_audio_filter "$SCREENRECORD_NORMALIZE" "$SCREENRECORD_LOUDNESS_STATS")")
   fi
 
   local processed="${latest%.mp4}-processed.mp4"
@@ -279,10 +463,13 @@ finalize_recording() {
   fi
 }
 
-if screenrecording_active; then
-  stop_screenrecording
-elif [[ $STOP_RECORDING == "true" ]]; then
-  exit 1
-else
-  start_screenrecording || cleanup_webcam
+# Keep start/stop from running when the file is sourced.
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  if screenrecording_active; then
+    stop_screenrecording
+  elif [[ $STOP_RECORDING == "true" ]]; then
+    exit 1
+  else
+    start_screenrecording || cleanup_webcam
+  fi
 fi

--- a/default/agents/skills/omarchy/capture.md
+++ b/default/agents/skills/omarchy/capture.md
@@ -27,17 +27,15 @@ omarchy screenrecord --stop-recording         # Stop; prints the saved path
 
 Optional flags: `--with-desktop-audio`, `--with-microphone-audio`,
 `--with-webcam` (plus `--webcam-device=` and `--webcam-size=`),
-`--resolution=<size>`, `--normalize-audio`, and `--no-normalize-audio`.
+`--resolution=<size>`.
 Without `--fullscreen` a region picker opens first.
 Recordings land in the configured Videos directory (override with
 `OMARCHY_SCREENRECORD_DIR`). Resize a live webcam overlay with
 `omarchy capture webcam resize <smaller|larger|reset|small|medium|large>`.
 
 After stop, audio between about -18 and -11 LUFS is left as-is. Quieter or
-louder recordings are asked whether to normalize. `--normalize-audio` /
-`--no-normalize-audio` skip the prompt; flags passed at start are remembered until
-you stop. `OMARCHY_SCREENRECORD_NORMALIZE=true|false` does the same for the whole
-session.
+louder recordings are asked whether to normalize. `OMARCHY_SCREENRECORD_NORMALIZE=true|false`
+skips the prompt for the whole session.
 
 If recording fails to start, rerun with `OMARCHY_SCREENRECORD_DEBUG=true` to
 collect a log at `/tmp/omarchy-screenrecord.log` worth attaching to a bug

--- a/default/agents/skills/omarchy/capture.md
+++ b/default/agents/skills/omarchy/capture.md
@@ -34,7 +34,8 @@ Recordings land in the configured Videos directory (override with
 `omarchy capture webcam resize <smaller|larger|reset|small|medium|large>`.
 
 After stop, audio between about -18 and -11 LUFS is left as-is. Quieter or
-louder recordings are asked whether to normalize. `OMARCHY_SCREENRECORD_NORMALIZE=true|false`
+louder recordings are asked whether to normalize. Recordings longer than 10
+minutes skip the loudness check and ask immediately. `OMARCHY_SCREENRECORD_NORMALIZE=true|false`
 skips the prompt for the whole session.
 
 If recording fails to start, rerun with `OMARCHY_SCREENRECORD_DEBUG=true` to

--- a/default/agents/skills/omarchy/capture.md
+++ b/default/agents/skills/omarchy/capture.md
@@ -26,11 +26,18 @@ omarchy screenrecord --stop-recording         # Stop; prints the saved path
 ```
 
 Optional flags: `--with-desktop-audio`, `--with-microphone-audio`,
-`--with-webcam` (plus `--webcam-device=` and `--webcam-size=`), and
-`--resolution=<size>`. Without `--fullscreen` a region picker opens first.
+`--with-webcam` (plus `--webcam-device=` and `--webcam-size=`),
+`--resolution=<size>`, `--normalize-audio`, and `--no-normalize-audio`.
+Without `--fullscreen` a region picker opens first.
 Recordings land in the configured Videos directory (override with
 `OMARCHY_SCREENRECORD_DIR`). Resize a live webcam overlay with
 `omarchy capture webcam resize <smaller|larger|reset|small|medium|large>`.
+
+After stop, audio between about -18 and -11 LUFS is left as-is. Quieter or
+louder recordings are asked whether to normalize. `--normalize-audio` /
+`--no-normalize-audio` skip the prompt; flags passed at start are remembered until
+you stop. `OMARCHY_SCREENRECORD_NORMALIZE=true|false` does the same for the whole
+session.
 
 If recording fails to start, rerun with `OMARCHY_SCREENRECORD_DEBUG=true` to
 collect a log at `/tmp/omarchy-screenrecord.log` worth attaching to a bug

--- a/manual/12-screenshots-recording.md
+++ b/manual/12-screenshots-recording.md
@@ -42,7 +42,7 @@ Recording runs on gpu-screen-recorder, which encodes on the GPU at 60fps and fal
 
 While you're recording, a little indicator shows up in the bar. Click it to stop. You can also stop with `Alt + Print Screen` again, or with the _Stop Screenrecording_ entry under _Trigger > Capture > Screenrecord_, which only appears while something is actually recording.
 
-Stopping does a bit of tidying before it hands you the file: the first frame gets trimmed, and if there's audio it's normalized to -14 LUFS with the PipeWire capture pop at the very start muted out. Then a notification appears with a thumbnail from the recording. Click it to play the file in mpv.
+Stopping does a bit of tidying before it hands you the file: the first frame gets trimmed, and the PipeWire capture pop at the very start of the soundtrack is muted out. If the recording's audio is much quieter or louder than usual, you'll be asked whether to normalize it to typical streaming volume (YouTube, Spotify, and similar) — that helps spoken voice, but it raises quiet sounds and turns hot levels down, so you can keep the original levels instead. Set `OMARCHY_SCREENRECORD_NORMALIZE=true` to always normalize, or `false` to never be asked. Then a notification appears with a thumbnail from the recording. Click it to play the file in mpv.
 
 ### The webcam overlay
 

--- a/manual/12-screenshots-recording.md
+++ b/manual/12-screenshots-recording.md
@@ -42,7 +42,7 @@ Recording runs on gpu-screen-recorder, which encodes on the GPU at 60fps and fal
 
 While you're recording, a little indicator shows up in the bar. Click it to stop. You can also stop with `Alt + Print Screen` again, or with the _Stop Screenrecording_ entry under _Trigger > Capture > Screenrecord_, which only appears while something is actually recording.
 
-Stopping does a bit of tidying before it hands you the file: the first frame gets trimmed, and the PipeWire capture pop at the very start of the soundtrack is muted out. If the recording's audio is much quieter or louder than usual, you'll be asked whether to normalize it to typical streaming volume (YouTube, Spotify, and similar) — that helps spoken voice, but it raises quiet sounds and turns hot levels down, so you can keep the original levels instead. Set `OMARCHY_SCREENRECORD_NORMALIZE=true` to always normalize, or `false` to never be asked. Then a notification appears with a thumbnail from the recording. Click it to play the file in mpv.
+Stopping does a bit of tidying before it hands you the file: the first frame gets trimmed, and the PipeWire capture pop at the very start of the soundtrack is muted out. If the recording's audio is much quieter or louder than usual, you'll be asked whether to normalize it to typical streaming volume (YouTube, Spotify, and similar) — that helps spoken voice, but it raises quiet sounds and turns hot levels down, so you can keep the original levels instead. Recordings longer than 10 minutes skip that loudness check and ask immediately. Set `OMARCHY_SCREENRECORD_NORMALIZE=true` to always normalize, or `false` to never be asked. Then a notification appears with a thumbnail from the recording. Click it to play the file in mpv.
 
 ### The webcam overlay
 

--- a/manual/14-omarchy-cli.md
+++ b/manual/14-omarchy-cli.md
@@ -48,7 +48,7 @@ And you can dive deeper on every group:
 ~ ❯ omarchy capture
 Capture commands — Screenshots and screen recording:
   omarchy capture qr                                                                                                                                                                                                       Decode a QR code from a screenshot region
-  omarchy capture screenrecording [--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--normalize-audio] [--no-normalize-audio] [--stop-recording]  Start or stop screen recording
+  omarchy capture screenrecording [--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording]  Start or stop screen recording
   omarchy capture screenrecording with webcam                                                                                                                                                                              Pick a webcam and start a screen recording with it
   omarchy capture screenshot [smart|region|windows|fullscreen] [slurp|copy|save] [--editor=<name>]                                                                                                                         Take a screenshot
   omarchy capture text                                                                                                                                                                                                     Extract text from a screenshot region with OCR

--- a/manual/14-omarchy-cli.md
+++ b/manual/14-omarchy-cli.md
@@ -48,7 +48,7 @@ And you can dive deeper on every group:
 ~ ❯ omarchy capture
 Capture commands — Screenshots and screen recording:
   omarchy capture qr                                                                                                                                                                                                       Decode a QR code from a screenshot region
-  omarchy capture screenrecording [--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--stop-recording]  Start or stop screen recording
+  omarchy capture screenrecording [--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=<device>] [--webcam-size=<small|medium|large>] [--resolution=<size>] [--normalize-audio] [--no-normalize-audio] [--stop-recording]  Start or stop screen recording
   omarchy capture screenrecording with webcam                                                                                                                                                                              Pick a webcam and start a screen recording with it
   omarchy capture screenshot [smart|region|windows|fullscreen] [slurp|copy|save] [--editor=<name>]                                                                                                                         Take a screenshot
   omarchy capture text                                                                                                                                                                                                     Extract text from a screenshot region with OCR

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -835,6 +835,9 @@ Item {
   }
 
   function openExistingMenu(initialMenu) {
+    // finishRequest before replacing doneFile, or omarchy-menu-select waits forever.
+    if (root.requestActive) root.finishRequest(null)
+
     requestSerial += 1
     mode = "menu"
     requestActive = false
@@ -859,6 +862,8 @@ Item {
   }
 
   function openDmenu(payload) {
+    if (root.requestActive) root.finishRequest(null)
+
     requestSerial += 1
     mode = payload.mode === "input" ? "input" : "select"
     dmenuPrompt = String(payload.prompt || (mode === "input" ? "Input" : "Select"))

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -615,6 +615,12 @@ for (const functionName of ['openExistingMenu', 'openDmenu']) {
       && !openMatch[1].includes('pointerGate.allowInitialSample()'),
     `menu ${functionName} ignores a stale hidden-pointer position when becoming visible`
   )
+  const finish = openMatch[1].indexOf('if (root.requestActive) root.finishRequest(null)')
+  const doneFile = openMatch[1].search(/doneFile = /)
+  assert(
+    finish >= 0 && doneFile >= 0 && finish < doneFile,
+    `menu ${functionName} releases an in-flight select before replacing doneFile`
+  )
 }
 assert(
   /function selectFromPointer\(index, item, mouse\)[\s\S]*pointerGate\.moved\(item, mouse\)[\s\S]*root\.selectedIndex = index/.test(menuQml),

--- a/test/shell.d/screenrecording-test.sh
+++ b/test/shell.d/screenrecording-test.sh
@@ -345,7 +345,28 @@ declare -f stop_screenrecording | awk '
   /finalize_recording/ { fin=NR }
   END { exit (rec && fin && rec < fin) ? 0 : 1 }
 ' || fail "stop pins the recording path before finalize"
+declare -f stop_screenrecording | grep -q 'release_recording_file "$filename"' ||
+  fail "stop drops the sidecar through release_recording_file"
 pass "stop pins the recording path before finalize"
+
+sidecar="$tmp_dir/recording-file"
+saved_recording_file=$RECORDING_FILE
+RECORDING_FILE=$sidecar
+
+echo "$tmp_dir/old.mp4" >"$sidecar"
+release_recording_file "$tmp_dir/old.mp4"
+if [[ -e $sidecar ]]; then
+  fail "release_recording_file drops the sidecar when it still names this recording"
+fi
+pass "release_recording_file drops the sidecar when it still names this recording"
+
+echo "$tmp_dir/new.mp4" >"$sidecar"
+release_recording_file "$tmp_dir/old.mp4"
+if [[ $(cat "$sidecar") != "$tmp_dir/new.mp4" ]]; then
+  fail "release_recording_file leaves the sidecar when a newer recording owns it"
+fi
+RECORDING_FILE=$saved_recording_file
+pass "release_recording_file leaves the sidecar when a newer recording owns it"
 
 cat >"$stub_bin/ffmpeg" <<'SH'
 #!/bin/bash

--- a/test/shell.d/screenrecording-test.sh
+++ b/test/shell.d/screenrecording-test.sh
@@ -304,117 +304,44 @@ pass "webcam size rules place the initial window in its final corner"
 
 source "$ROOT/bin/omarchy-capture-screenrecording"
 
-quiet_loudnorm_json='{
-	"input_i" : "-28.00",
-	"input_tp" : "-8.00",
-	"input_lra" : "8.00",
-	"input_thresh" : "-38.00",
-	"output_i" : "-14.00",
-	"output_tp" : "-1.50",
-	"output_lra" : "8.00",
-	"output_thresh" : "-24.00",
-	"normalization_type" : "dynamic",
-	"target_offset" : "0.00"
-}'
-near_target_loudnorm_json='{
-	"input_i" : "-14.20",
-	"input_tp" : "-2.00",
-	"input_lra" : "8.00",
-	"input_thresh" : "-24.00",
-	"output_i" : "-14.00",
-	"output_tp" : "-1.50",
-	"output_lra" : "8.00",
-	"output_thresh" : "-24.00",
-	"normalization_type" : "dynamic",
-	"target_offset" : "0.20"
-}'
-wide_lra_loudnorm_json='{
-	"input_i" : "-14.00",
-	"input_tp" : "-1.80",
-	"input_lra" : "18.00",
-	"input_thresh" : "-32.00",
-	"output_i" : "-14.00",
-	"output_tp" : "-1.50",
-	"output_lra" : "11.00",
-	"output_thresh" : "-24.00",
-	"normalization_type" : "dynamic",
-	"target_offset" : "0.00"
-}'
-hot_loudnorm_json='{
-	"input_i" : "-8.00",
-	"input_tp" : "-1.20",
-	"input_lra" : "8.00",
-	"input_thresh" : "-18.00",
-	"output_i" : "-14.00",
-	"output_tp" : "-1.50",
-	"output_lra" : "8.00",
-	"output_thresh" : "-24.00",
-	"normalization_type" : "dynamic",
-	"target_offset" : "6.00"
-}'
-inf_loudnorm_json='{
-	"input_i" : "-inf",
-	"input_tp" : "-inf",
-	"input_lra" : "0.00",
-	"input_thresh" : "-70.00",
-	"output_i" : "-14.00",
-	"output_tp" : "-1.50",
-	"output_lra" : "0.00",
-	"output_thresh" : "-24.00",
-	"normalization_type" : "dynamic",
-	"target_offset" : "0.00"
-}'
+# Fields two-pass loudnorm reads. `}` is on its own line so extract_loudnorm_json's
+# awk range matches; extra ffmpeg keys are unused.
+loudnorm_json() {
+  printf '%s\n' '{' \
+    "	\"input_i\" : \"$1\"," \
+    "	\"input_tp\" : \"${2:--2.00}\"," \
+    "	\"input_lra\" : \"${3:-8.00}\"," \
+    "	\"input_thresh\" : \"${4:--24.00}\"," \
+    "	\"target_offset\" : \"${5:-0.00}\"" \
+    '}'
+}
 
-loudness_might_need_normalization -14.0 8.0 && fail "loudness already at -14 LUFS does not need normalization"
-loudness_might_need_normalization -18.0 8.0 && fail "loudness at the -18 LUFS quiet threshold does not need normalization"
-loudness_might_need_normalization -18.1 8.0 || fail "loudness quieter than -18 LUFS needs normalization"
-loudness_might_need_normalization -11.0 8.0 && fail "loudness at the -11 LUFS loud threshold does not need normalization"
-loudness_might_need_normalization -10.9 8.0 || fail "loudness louder than -11 LUFS needs normalization"
-loudness_might_need_normalization -8.0 8.0 || fail "loudness at -8 LUFS needs normalization"
-loudness_might_need_normalization -14.0 18.0 && fail "wide LRA inside the LUFS window does not need normalization"
-loudness_might_need_normalization -inf 8.0 && fail "non-numeric loudness does not need normalization"
-loudness_might_need_normalization "" 8.0 && fail "empty loudness does not need normalization"
+loudness_might_need_normalization -14.0 && fail "loudness already at -14 LUFS does not need normalization"
+loudness_might_need_normalization -18.0 && fail "loudness at the -18 LUFS quiet threshold does not need normalization"
+loudness_might_need_normalization -18.1 || fail "loudness quieter than -18 LUFS needs normalization"
+loudness_might_need_normalization -11.0 && fail "loudness at the -11 LUFS loud threshold does not need normalization"
+loudness_might_need_normalization -10.9 || fail "loudness louder than -11 LUFS needs normalization"
+loudness_might_need_normalization -inf && fail "non-numeric loudness does not need normalization"
 pass "loudness_might_need_normalization asks outside -18 to -11 LUFS"
 
-pop_only=$(screenrecord_audio_filter no)
-[[ $pop_only == *loudnorm* ]] && fail "skipping loudnorm still mutes the PipeWire pop" "$pop_only"
-[[ $pop_only == "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05" ]] || \
-  fail "skipping loudnorm still mutes the PipeWire pop" "$pop_only"
+pop=$(screenrecord_pop_filter)
+[[ $(screenrecord_audio_filter no) == "$pop" ]] || fail "skipping loudnorm still mutes the PipeWire pop"
 with_loudnorm=$(screenrecord_audio_filter yes)
-[[ $with_loudnorm == *loudnorm=I=-14:TP=-1.5:LRA=11 ]] || fail "yes applies single-pass loudnorm" "$with_loudnorm"
-[[ $with_loudnorm == volume=enable* ]] || fail "yes still mutes the PipeWire pop" "$with_loudnorm"
-two_pass=$(screenrecord_audio_filter yes "$quiet_loudnorm_json")
+[[ $with_loudnorm == "$pop,loudnorm=I=-14:TP=-1.5:LRA=11" ]] || fail "yes appends single-pass loudnorm" "$with_loudnorm"
+two_pass=$(screenrecord_audio_filter yes "$(loudnorm_json -28.00)")
 [[ $two_pass == *measured_I=-28.00* ]] || fail "measured stats feed two-pass loudnorm" "$two_pass"
-[[ $two_pass == *measured_LRA=8.00* ]] || fail "measured LRA feeds two-pass loudnorm" "$two_pass"
 pass "screenrecord_audio_filter always mutes the pop and only adds loudnorm when asked"
 
-NORMALIZE_AUDIO=true
-[[ $(normalize_preference) == yes ]] || fail "invocation --normalize-audio prefers yes"
-NORMALIZE_AUDIO=false
-[[ $(normalize_preference) == no ]] || fail "invocation --no-normalize-audio prefers no"
-NORMALIZE_AUDIO=""
-OMARCHY_SCREENRECORD_NORMALIZE=true
-[[ $(normalize_preference) == yes ]] || fail "OMARCHY_SCREENRECORD_NORMALIZE=true prefers yes"
-OMARCHY_SCREENRECORD_NORMALIZE=false
-[[ $(normalize_preference) == no ]] || fail "OMARCHY_SCREENRECORD_NORMALIZE=false prefers no"
 NORMALIZE_AUDIO=true
 OMARCHY_SCREENRECORD_NORMALIZE=false
 [[ $(normalize_preference) == yes ]] || fail "invocation flags beat the env var"
 NORMALIZE_AUDIO=""
-unset OMARCHY_SCREENRECORD_NORMALIZE
-echo yes >"$NORMALIZE_FILE"
-[[ $(normalize_preference) == yes ]] || fail "start-time sidecar yes is honored at stop"
-echo no >"$NORMALIZE_FILE"
-[[ $(normalize_preference) == no ]] || fail "start-time sidecar no is honored at stop"
 OMARCHY_SCREENRECORD_NORMALIZE=false
 echo yes >"$NORMALIZE_FILE"
 [[ $(normalize_preference) == no ]] || fail "env var beats the start-time sidecar"
 unset OMARCHY_SCREENRECORD_NORMALIZE
 rm -f "$NORMALIZE_FILE"
 [[ $(normalize_preference) == ask ]] || fail "missing sidecar asks"
-NORMALIZE_AUDIO=""
-persist_normalize_preference
-[[ $(cat "$NORMALIZE_FILE") == ask ]] || fail "start without flags persists ask"
 NORMALIZE_AUDIO=true
 persist_normalize_preference
 [[ $(cat "$NORMALIZE_FILE") == yes ]] || fail "start --normalize-audio persists yes"
@@ -422,6 +349,8 @@ NORMALIZE_AUDIO=false
 persist_normalize_preference
 [[ $(cat "$NORMALIZE_FILE") == no ]] || fail "start --no-normalize-audio persists no"
 NORMALIZE_AUDIO=""
+persist_normalize_preference
+[[ $(cat "$NORMALIZE_FILE") == ask ]] || fail "start without flags persists ask"
 rm -f "$NORMALIZE_FILE"
 pass "normalize_preference prefers flags, then env, then the start sidecar"
 
@@ -452,11 +381,12 @@ export OMARCHY_TEST_FFMPEG_ARGS="$tmp_dir/ffmpeg-args"
 dummy_recording="$tmp_dir/dummy.mp4"
 touch "$dummy_recording"
 
-extracted=$(extract_loudnorm_json <<<"noise"$'\n'"$quiet_loudnorm_json"$'\n'"more")
-[[ $extracted == "$quiet_loudnorm_json" ]] || fail "extract_loudnorm_json keeps the loudnorm object" "$extracted"
-pass "extract_loudnorm_json keeps the loudnorm JSON object"
+quiet_json=$(loudnorm_json -28.00)
+extracted=$(extract_loudnorm_json <<<"noise"$'\n'"$quiet_json"$'\n'"more")
+[[ $extracted == *'"input_i" : "-28.00"'* && $extracted != *more* ]] || \
+  fail "extract_loudnorm_json keeps the loudnorm object" "$extracted"
 
-export OMARCHY_TEST_LOUDNORM_JSON="$quiet_loudnorm_json"
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_json"
 : >"$OMARCHY_TEST_FFMPEG_ARGS"
 measured=$(measure_loudness "$dummy_recording")
 [[ $measured == *'"input_i" : "-28.00"'* ]] || fail "measure_loudness reads first-pass JSON" "$measured"
@@ -468,24 +398,22 @@ pass "measure_loudness runs an audio-only first pass with the pop mute"
 unset OMARCHY_SCREENRECORD_NORMALIZE
 NORMALIZE_AUDIO=""
 rm -f "$NORMALIZE_FILE"
+
 : >"$OMARCHY_TEST_MENU_ARGS"
-: >"$OMARCHY_TEST_FFMPEG_ARGS"
-export OMARCHY_TEST_LOUDNORM_JSON="$near_target_loudnorm_json"
+export OMARCHY_TEST_LOUDNORM_JSON="$(loudnorm_json -14.20)"
 decide_normalize "$dummy_recording"
 [[ $SCREENRECORD_NORMALIZE == no ]] || fail "near-target audio skips loudnorm"
 [[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "near-target audio does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
-pass "decide_normalize skips the prompt when I and LRA already match"
+pass "decide_normalize skips the prompt when loudness is already in the window"
 
 : >"$OMARCHY_TEST_MENU_ARGS"
 : >"$OMARCHY_TEST_FFMPEG_ARGS"
-export OMARCHY_TEST_LOUDNORM_JSON="$quiet_loudnorm_json"
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_json"
 export OMARCHY_TEST_MENU_REPLY=$'Normalize\traise to typical YouTube and Spotify volume'
 decide_normalize "$dummy_recording"
 [[ $SCREENRECORD_NORMALIZE == yes ]] || fail "quiet audio normalizes when the user accepts"
-[[ $SCREENRECORD_LOUDNESS_STATS == *'"input_i" : "-28.00"'* ]] || \
-  fail "accepting the prompt keeps first-pass stats for two-pass loudnorm" "$SCREENRECORD_LOUDNESS_STATS"
 wired=$(screenrecord_audio_filter "$SCREENRECORD_NORMALIZE" "$SCREENRECORD_LOUDNESS_STATS")
-[[ $wired == *measured_I=-28.00* ]] || fail "finalize wiring applies two-pass loudnorm" "$wired"
+[[ $wired == *measured_I=-28.00* ]] || fail "accepting the prompt keeps first-pass stats for two-pass loudnorm" "$wired"
 grep -q "Audio may be unintentionally quiet" "$OMARCHY_TEST_MENU_ARGS" || fail "quiet audio prompt explains the recording is quiet"
 grep -q $'\tKeep original levels\tas recorded' "$OMARCHY_TEST_MENU_ARGS" || \
   fail "keep option uses empty glyph so the label is not drawn as an icon" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
@@ -494,25 +422,17 @@ grep -q $'\tNormalize\traise to typical YouTube and Spotify volume' "$OMARCHY_TE
 pass "decide_normalize prompts when audio is quiet"
 
 : >"$OMARCHY_TEST_MENU_ARGS"
-: >"$OMARCHY_TEST_FFMPEG_ARGS"
-export OMARCHY_TEST_LOUDNORM_JSON="$hot_loudnorm_json"
+export OMARCHY_TEST_LOUDNORM_JSON="$(loudnorm_json -8.00)"
 export OMARCHY_TEST_MENU_REPLY=$'Keep original levels\tas recorded'
 decide_normalize "$dummy_recording"
-[[ $SCREENRECORD_NORMALIZE == no ]] || fail "hot -8 LUFS keeps original levels when the user declines"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "hot audio keeps original levels when the user declines"
 grep -q "Audio may be unintentionally loud" "$OMARCHY_TEST_MENU_ARGS" || fail "hot audio prompt explains the recording is loud"
 grep -q $'\tNormalize\tlower to typical YouTube and Spotify volume' "$OMARCHY_TEST_MENU_ARGS" || \
   fail "loud normalize option says it will lower to typical streaming volume" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
 pass "decide_normalize prompts when audio is louder than -11 LUFS"
 
 : >"$OMARCHY_TEST_MENU_ARGS"
-export OMARCHY_TEST_LOUDNORM_JSON="$wide_lra_loudnorm_json"
-decide_normalize "$dummy_recording"
-[[ $SCREENRECORD_NORMALIZE == no ]] || fail "wide LRA on already-loud audio skips loudnorm"
-[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "wide LRA on already-loud audio does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
-pass "decide_normalize skips the prompt when LRA is wide but loudness is inside the window"
-
-: >"$OMARCHY_TEST_MENU_ARGS"
-export OMARCHY_TEST_LOUDNORM_JSON="$quiet_loudnorm_json"
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_json"
 export OMARCHY_TEST_MENU_EXIT=1
 unset OMARCHY_TEST_MENU_REPLY
 decide_normalize "$dummy_recording"
@@ -520,14 +440,6 @@ decide_normalize "$dummy_recording"
 pass "decide_normalize treats a cancelled prompt as keep original"
 
 unset OMARCHY_TEST_MENU_EXIT
-: >"$OMARCHY_TEST_MENU_ARGS"
-: >"$OMARCHY_TEST_FFMPEG_ARGS"
-export OMARCHY_TEST_LOUDNORM_JSON="$inf_loudnorm_json"
-decide_normalize "$dummy_recording"
-[[ $SCREENRECORD_NORMALIZE == no ]] || fail "silent/-inf audio skips loudnorm"
-[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "-inf audio does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
-pass "decide_normalize skips the prompt for unusable loudness"
-
 : >"$OMARCHY_TEST_MENU_ARGS"
 : >"$OMARCHY_TEST_FFMPEG_ARGS"
 export OMARCHY_TEST_LOUDNORM_JSON="not json"
@@ -539,7 +451,7 @@ pass "decide_normalize skips the prompt when measurement fails"
 : >"$OMARCHY_TEST_MENU_ARGS"
 : >"$OMARCHY_TEST_FFMPEG_ARGS"
 OMARCHY_SCREENRECORD_NORMALIZE=false
-export OMARCHY_TEST_LOUDNORM_JSON="$quiet_loudnorm_json"
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_json"
 decide_normalize "$dummy_recording"
 [[ $SCREENRECORD_NORMALIZE == no ]] || fail "env false skips loudnorm"
 [[ -s $OMARCHY_TEST_FFMPEG_ARGS ]] && fail "env false does not measure" "$(cat "$OMARCHY_TEST_FFMPEG_ARGS")"
@@ -556,12 +468,3 @@ decide_normalize "$dummy_recording"
 [[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "flag true does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
 NORMALIZE_AUDIO=""
 pass "invocation flags override the prompt"
-
-echo yes >"$NORMALIZE_FILE"
-: >"$OMARCHY_TEST_MENU_ARGS"
-: >"$OMARCHY_TEST_FFMPEG_ARGS"
-decide_normalize "$dummy_recording"
-[[ $SCREENRECORD_NORMALIZE == yes ]] || fail "sidecar yes applies loudnorm without prompting"
-[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "sidecar yes does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
-rm -f "$NORMALIZE_FILE"
-pass "start-time sidecar overrides the prompt"

--- a/test/shell.d/screenrecording-test.sh
+++ b/test/shell.d/screenrecording-test.sh
@@ -332,27 +332,20 @@ two_pass=$(screenrecord_audio_filter yes "$(loudnorm_json -28.00)")
 [[ $two_pass == *measured_I=-28.00* ]] || fail "measured stats feed two-pass loudnorm" "$two_pass"
 pass "screenrecord_audio_filter always mutes the pop and only adds loudnorm when asked"
 
-NORMALIZE_AUDIO=true
 OMARCHY_SCREENRECORD_NORMALIZE=false
-[[ $(normalize_preference) == yes ]] || fail "invocation flags beat the env var"
-NORMALIZE_AUDIO=""
-OMARCHY_SCREENRECORD_NORMALIZE=false
-echo yes >"$NORMALIZE_FILE"
-[[ $(normalize_preference) == no ]] || fail "env var beats the start-time sidecar"
+[[ $(normalize_preference) == no ]] || fail "env false"
+OMARCHY_SCREENRECORD_NORMALIZE=true
+[[ $(normalize_preference) == yes ]] || fail "env true"
 unset OMARCHY_SCREENRECORD_NORMALIZE
-rm -f "$NORMALIZE_FILE"
-[[ $(normalize_preference) == ask ]] || fail "missing sidecar asks"
-NORMALIZE_AUDIO=true
-persist_normalize_preference
-[[ $(cat "$NORMALIZE_FILE") == yes ]] || fail "start --normalize-audio persists yes"
-NORMALIZE_AUDIO=false
-persist_normalize_preference
-[[ $(cat "$NORMALIZE_FILE") == no ]] || fail "start --no-normalize-audio persists no"
-NORMALIZE_AUDIO=""
-persist_normalize_preference
-[[ $(cat "$NORMALIZE_FILE") == ask ]] || fail "start without flags persists ask"
-rm -f "$NORMALIZE_FILE"
-pass "normalize_preference prefers flags, then env, then the start sidecar"
+[[ $(normalize_preference) == ask ]] || fail "unset env asks"
+pass "normalize_preference follows OMARCHY_SCREENRECORD_NORMALIZE"
+
+declare -f stop_screenrecording | awk '
+  /RECORDING_FILE/ && !seen { rec=NR; seen=1 }
+  /finalize_recording/ { fin=NR }
+  END { exit (rec && fin && rec < fin) ? 0 : 1 }
+' || fail "stop pins the recording path before finalize"
+pass "stop pins the recording path before finalize"
 
 cat >"$stub_bin/ffmpeg" <<'SH'
 #!/bin/bash
@@ -396,8 +389,6 @@ grep -q "volume=enable='lt(t,0.4)':volume=0" "$OMARCHY_TEST_FFMPEG_ARGS" || \
 pass "measure_loudness runs an audio-only first pass with the pop mute"
 
 unset OMARCHY_SCREENRECORD_NORMALIZE
-NORMALIZE_AUDIO=""
-rm -f "$NORMALIZE_FILE"
 
 : >"$OMARCHY_TEST_MENU_ARGS"
 export OMARCHY_TEST_LOUDNORM_JSON="$(loudnorm_json -14.20)"
@@ -461,13 +452,50 @@ pass "env false overrides the prompt"
 
 : >"$OMARCHY_TEST_MENU_ARGS"
 : >"$OMARCHY_TEST_FFMPEG_ARGS"
-NORMALIZE_AUDIO=true
+OMARCHY_SCREENRECORD_NORMALIZE=true
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_json"
 decide_normalize "$dummy_recording"
-[[ $SCREENRECORD_NORMALIZE == yes ]] || fail "flag true applies loudnorm"
-[[ -s $OMARCHY_TEST_FFMPEG_ARGS ]] && fail "flag true does not need a first pass" "$(cat "$OMARCHY_TEST_FFMPEG_ARGS")"
-[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "flag true does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
-NORMALIZE_AUDIO=""
-pass "invocation flags override the prompt"
+[[ $SCREENRECORD_NORMALIZE == yes ]] || fail "env true applies loudnorm"
+[[ -s $OMARCHY_TEST_FFMPEG_ARGS ]] && fail "env true does not measure" "$(cat "$OMARCHY_TEST_FFMPEG_ARGS")"
+[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "env true does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+unset OMARCHY_SCREENRECORD_NORMALIZE
+pass "env true overrides the prompt"
+
+cat >"$stub_bin/omarchy-menu-select" <<'SH'
+#!/bin/bash
+
+sleep infinity
+SH
+chmod +x "$stub_bin/omarchy-menu-select"
+cat >"$stub_bin/omarchy-menu" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$@" >"$OMARCHY_TEST_MENU_CLOSE_ARGS"
+SH
+chmod +x "$stub_bin/omarchy-menu"
+export OMARCHY_TEST_MENU_CLOSE_ARGS="$tmp_dir/menu-close-args"
+: >"$OMARCHY_TEST_MENU_CLOSE_ARGS"
+NORMALIZE_PROMPT_TIMEOUT=1
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_json"
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "a timed-out prompt keeps original levels"
+[[ $(cat "$OMARCHY_TEST_MENU_CLOSE_ARGS") == close ]] ||
+  fail "a timed-out prompt dismisses the leftover menu" "$(cat "$OMARCHY_TEST_MENU_CLOSE_ARGS")"
+NORMALIZE_PROMPT_TIMEOUT=120
+rm -f "$stub_bin/omarchy-menu"
+cat >"$stub_bin/omarchy-menu-select" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$@" >"$OMARCHY_TEST_MENU_ARGS"
+if [[ ${OMARCHY_TEST_MENU_EXIT:-0} != 0 ]]; then
+  exit "$OMARCHY_TEST_MENU_EXIT"
+fi
+printf '%s\n' "${OMARCHY_TEST_MENU_REPLY-}"
+SH
+chmod +x "$stub_bin/omarchy-menu-select"
+pass "a hung normalize prompt times out instead of stranding stop"
 
 # --- the recording directory only gates starting ---
 

--- a/test/shell.d/screenrecording-test.sh
+++ b/test/shell.d/screenrecording-test.sh
@@ -380,6 +380,17 @@ exit 0
 SH
 chmod +x "$stub_bin/ffmpeg"
 
+cat >"$stub_bin/ffprobe" <<'SH'
+#!/bin/bash
+
+if printf '%s\n' "$@" | grep -q format=duration; then
+  printf '%s\n' "${OMARCHY_TEST_DURATION:-30}"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$stub_bin/ffprobe"
+
 cat >"$stub_bin/omarchy-menu-select" <<'SH'
 #!/bin/bash
 
@@ -421,7 +432,7 @@ pass "decide_normalize skips the prompt when loudness is already in the window"
 : >"$OMARCHY_TEST_MENU_ARGS"
 : >"$OMARCHY_TEST_FFMPEG_ARGS"
 export OMARCHY_TEST_LOUDNORM_JSON="$quiet_json"
-export OMARCHY_TEST_MENU_REPLY=$'Normalize\traise to typical YouTube and Spotify volume'
+export OMARCHY_TEST_MENU_REPLY=$'Normalize\traise to typical broadcast levels'
 decide_normalize "$dummy_recording"
 [[ $SCREENRECORD_NORMALIZE == yes ]] || fail "quiet audio normalizes when the user accepts"
 wired=$(screenrecord_audio_filter "$SCREENRECORD_NORMALIZE" "$SCREENRECORD_LOUDNESS_STATS")
@@ -429,8 +440,8 @@ wired=$(screenrecord_audio_filter "$SCREENRECORD_NORMALIZE" "$SCREENRECORD_LOUDN
 grep -q "Audio may be unintentionally quiet" "$OMARCHY_TEST_MENU_ARGS" || fail "quiet audio prompt explains the recording is quiet"
 grep -q $'\tKeep original levels\tas recorded' "$OMARCHY_TEST_MENU_ARGS" || \
   fail "keep option uses empty glyph so the label is not drawn as an icon" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
-grep -q $'\tNormalize\traise to typical YouTube and Spotify volume' "$OMARCHY_TEST_MENU_ARGS" || \
-  fail "quiet normalize option says it will raise to typical streaming volume" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+grep -q $'\tNormalize\traise to typical broadcast levels' "$OMARCHY_TEST_MENU_ARGS" || \
+  fail "quiet normalize option says it will raise to typical broadcast levels" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
 pass "decide_normalize prompts when audio is quiet"
 
 : >"$OMARCHY_TEST_MENU_ARGS"
@@ -439,8 +450,8 @@ export OMARCHY_TEST_MENU_REPLY=$'Keep original levels\tas recorded'
 decide_normalize "$dummy_recording"
 [[ $SCREENRECORD_NORMALIZE == no ]] || fail "hot audio keeps original levels when the user declines"
 grep -q "Audio may be unintentionally loud" "$OMARCHY_TEST_MENU_ARGS" || fail "hot audio prompt explains the recording is loud"
-grep -q $'\tNormalize\tlower to typical YouTube and Spotify volume' "$OMARCHY_TEST_MENU_ARGS" || \
-  fail "loud normalize option says it will lower to typical streaming volume" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+grep -q $'\tNormalize\tlower to typical broadcast levels' "$OMARCHY_TEST_MENU_ARGS" || \
+  fail "loud normalize option says it will lower to typical broadcast levels" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
 pass "decide_normalize prompts when audio is louder than -11 LUFS"
 
 : >"$OMARCHY_TEST_MENU_ARGS"
@@ -481,6 +492,46 @@ decide_normalize "$dummy_recording"
 [[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "env true does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
 unset OMARCHY_SCREENRECORD_NORMALIZE
 pass "env true overrides the prompt"
+
+export OMARCHY_TEST_DURATION=601
+recording_too_long_to_analyze "$dummy_recording" || fail "601s is too long to analyze"
+export OMARCHY_TEST_DURATION=600
+recording_too_long_to_analyze "$dummy_recording" && fail "600s still analyzes"
+export OMARCHY_TEST_DURATION=N/A
+recording_too_long_to_analyze "$dummy_recording" && fail "unreadable duration still analyzes"
+unset OMARCHY_TEST_DURATION
+pass "recording_too_long_to_analyze is strictly greater than 10 minutes"
+
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+export OMARCHY_TEST_DURATION=601
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_json"
+export OMARCHY_TEST_MENU_REPLY=$'Normalize\tRecommended'
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == yes ]] || fail "a long recording normalizes when the user accepts"
+[[ -z $SCREENRECORD_LOUDNESS_STATS ]] || fail "a long recording does not keep first-pass stats" "$SCREENRECORD_LOUDNESS_STATS"
+wired=$(screenrecord_audio_filter "$SCREENRECORD_NORMALIZE" "$SCREENRECORD_LOUDNESS_STATS")
+[[ $wired == *loudnorm=I=-14:TP=-1.5:LRA=11* ]] || fail "accepting a long recording uses single-pass loudnorm" "$wired"
+[[ $wired == *measured_I* ]] && fail "accepting a long recording must not use two-pass loudnorm" "$wired"
+grep -q "print_format=json" "$OMARCHY_TEST_FFMPEG_ARGS" && \
+  fail "a long recording does not measure loudness" "$(cat "$OMARCHY_TEST_FFMPEG_ARGS")"
+grep -q "Normalize audio to typical broadcast levels?" "$OMARCHY_TEST_MENU_ARGS" || \
+  fail "a long recording asks about typical broadcast levels" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+grep -q $'\tNormalize\tRecommended' "$OMARCHY_TEST_MENU_ARGS" || \
+  fail "a long recording marks normalize as recommended" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+awk '
+  $0 == "\tNormalize\tRecommended" { n=NR }
+  $0 == "\tKeep original levels\tas recorded" { k=NR }
+  END { exit (n && k && n < k) ? 0 : 1 }
+' "$OMARCHY_TEST_MENU_ARGS" || fail "a long recording lists Normalize before Keep" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+pass "decide_normalize skips analysis on recordings longer than 10 minutes"
+
+: >"$OMARCHY_TEST_MENU_ARGS"
+export OMARCHY_TEST_MENU_REPLY=$'Keep original levels\tas recorded'
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "a long recording keeps original levels when the user declines"
+unset OMARCHY_TEST_DURATION
+pass "decide_normalize keeps original levels when a long recording declines"
 
 cat >"$stub_bin/omarchy-menu-select" <<'SH'
 #!/bin/bash

--- a/test/shell.d/screenrecording-test.sh
+++ b/test/shell.d/screenrecording-test.sh
@@ -299,3 +299,269 @@ grep -F 'move = { "(monitor_w-monitor_h*2/9-40)", "(monitor_h-monitor_h/4-40)" }
 grep -F 'move = { "(monitor_w-monitor_h*3/10-40)", "(monitor_h-monitor_h*27/80-40)" }' "$webcam_rules" >/dev/null || \
   fail "large webcam starts at its final corner position"
 pass "webcam size rules place the initial window in its final corner"
+
+# --- loudnorm helpers (source the recorder without starting a capture) ---
+
+source "$ROOT/bin/omarchy-capture-screenrecording"
+
+quiet_loudnorm_json='{
+	"input_i" : "-28.00",
+	"input_tp" : "-8.00",
+	"input_lra" : "8.00",
+	"input_thresh" : "-38.00",
+	"output_i" : "-14.00",
+	"output_tp" : "-1.50",
+	"output_lra" : "8.00",
+	"output_thresh" : "-24.00",
+	"normalization_type" : "dynamic",
+	"target_offset" : "0.00"
+}'
+near_target_loudnorm_json='{
+	"input_i" : "-14.20",
+	"input_tp" : "-2.00",
+	"input_lra" : "8.00",
+	"input_thresh" : "-24.00",
+	"output_i" : "-14.00",
+	"output_tp" : "-1.50",
+	"output_lra" : "8.00",
+	"output_thresh" : "-24.00",
+	"normalization_type" : "dynamic",
+	"target_offset" : "0.20"
+}'
+wide_lra_loudnorm_json='{
+	"input_i" : "-14.00",
+	"input_tp" : "-1.80",
+	"input_lra" : "18.00",
+	"input_thresh" : "-32.00",
+	"output_i" : "-14.00",
+	"output_tp" : "-1.50",
+	"output_lra" : "11.00",
+	"output_thresh" : "-24.00",
+	"normalization_type" : "dynamic",
+	"target_offset" : "0.00"
+}'
+hot_loudnorm_json='{
+	"input_i" : "-8.00",
+	"input_tp" : "-1.20",
+	"input_lra" : "8.00",
+	"input_thresh" : "-18.00",
+	"output_i" : "-14.00",
+	"output_tp" : "-1.50",
+	"output_lra" : "8.00",
+	"output_thresh" : "-24.00",
+	"normalization_type" : "dynamic",
+	"target_offset" : "6.00"
+}'
+inf_loudnorm_json='{
+	"input_i" : "-inf",
+	"input_tp" : "-inf",
+	"input_lra" : "0.00",
+	"input_thresh" : "-70.00",
+	"output_i" : "-14.00",
+	"output_tp" : "-1.50",
+	"output_lra" : "0.00",
+	"output_thresh" : "-24.00",
+	"normalization_type" : "dynamic",
+	"target_offset" : "0.00"
+}'
+
+loudness_might_need_normalization -14.0 8.0 && fail "loudness already at -14 LUFS does not need normalization"
+loudness_might_need_normalization -18.0 8.0 && fail "loudness at the -18 LUFS quiet threshold does not need normalization"
+loudness_might_need_normalization -18.1 8.0 || fail "loudness quieter than -18 LUFS needs normalization"
+loudness_might_need_normalization -11.0 8.0 && fail "loudness at the -11 LUFS loud threshold does not need normalization"
+loudness_might_need_normalization -10.9 8.0 || fail "loudness louder than -11 LUFS needs normalization"
+loudness_might_need_normalization -8.0 8.0 || fail "loudness at -8 LUFS needs normalization"
+loudness_might_need_normalization -14.0 18.0 && fail "wide LRA inside the LUFS window does not need normalization"
+loudness_might_need_normalization -inf 8.0 && fail "non-numeric loudness does not need normalization"
+loudness_might_need_normalization "" 8.0 && fail "empty loudness does not need normalization"
+pass "loudness_might_need_normalization asks outside -18 to -11 LUFS"
+
+pop_only=$(screenrecord_audio_filter no)
+[[ $pop_only == *loudnorm* ]] && fail "skipping loudnorm still mutes the PipeWire pop" "$pop_only"
+[[ $pop_only == "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05" ]] || \
+  fail "skipping loudnorm still mutes the PipeWire pop" "$pop_only"
+with_loudnorm=$(screenrecord_audio_filter yes)
+[[ $with_loudnorm == *loudnorm=I=-14:TP=-1.5:LRA=11 ]] || fail "yes applies single-pass loudnorm" "$with_loudnorm"
+[[ $with_loudnorm == volume=enable* ]] || fail "yes still mutes the PipeWire pop" "$with_loudnorm"
+two_pass=$(screenrecord_audio_filter yes "$quiet_loudnorm_json")
+[[ $two_pass == *measured_I=-28.00* ]] || fail "measured stats feed two-pass loudnorm" "$two_pass"
+[[ $two_pass == *measured_LRA=8.00* ]] || fail "measured LRA feeds two-pass loudnorm" "$two_pass"
+pass "screenrecord_audio_filter always mutes the pop and only adds loudnorm when asked"
+
+NORMALIZE_AUDIO=true
+[[ $(normalize_preference) == yes ]] || fail "invocation --normalize-audio prefers yes"
+NORMALIZE_AUDIO=false
+[[ $(normalize_preference) == no ]] || fail "invocation --no-normalize-audio prefers no"
+NORMALIZE_AUDIO=""
+OMARCHY_SCREENRECORD_NORMALIZE=true
+[[ $(normalize_preference) == yes ]] || fail "OMARCHY_SCREENRECORD_NORMALIZE=true prefers yes"
+OMARCHY_SCREENRECORD_NORMALIZE=false
+[[ $(normalize_preference) == no ]] || fail "OMARCHY_SCREENRECORD_NORMALIZE=false prefers no"
+NORMALIZE_AUDIO=true
+OMARCHY_SCREENRECORD_NORMALIZE=false
+[[ $(normalize_preference) == yes ]] || fail "invocation flags beat the env var"
+NORMALIZE_AUDIO=""
+unset OMARCHY_SCREENRECORD_NORMALIZE
+echo yes >"$NORMALIZE_FILE"
+[[ $(normalize_preference) == yes ]] || fail "start-time sidecar yes is honored at stop"
+echo no >"$NORMALIZE_FILE"
+[[ $(normalize_preference) == no ]] || fail "start-time sidecar no is honored at stop"
+OMARCHY_SCREENRECORD_NORMALIZE=false
+echo yes >"$NORMALIZE_FILE"
+[[ $(normalize_preference) == no ]] || fail "env var beats the start-time sidecar"
+unset OMARCHY_SCREENRECORD_NORMALIZE
+rm -f "$NORMALIZE_FILE"
+[[ $(normalize_preference) == ask ]] || fail "missing sidecar asks"
+NORMALIZE_AUDIO=""
+persist_normalize_preference
+[[ $(cat "$NORMALIZE_FILE") == ask ]] || fail "start without flags persists ask"
+NORMALIZE_AUDIO=true
+persist_normalize_preference
+[[ $(cat "$NORMALIZE_FILE") == yes ]] || fail "start --normalize-audio persists yes"
+NORMALIZE_AUDIO=false
+persist_normalize_preference
+[[ $(cat "$NORMALIZE_FILE") == no ]] || fail "start --no-normalize-audio persists no"
+NORMALIZE_AUDIO=""
+rm -f "$NORMALIZE_FILE"
+pass "normalize_preference prefers flags, then env, then the start sidecar"
+
+cat >"$stub_bin/ffmpeg" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$@" >>"$OMARCHY_TEST_FFMPEG_ARGS"
+if printf '%s\n' "$@" | grep -q 'print_format=json'; then
+  printf '%s\n' "${OMARCHY_TEST_LOUDNORM_JSON-}" >&2
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$stub_bin/ffmpeg"
+
+cat >"$stub_bin/omarchy-menu-select" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$@" >"$OMARCHY_TEST_MENU_ARGS"
+if [[ ${OMARCHY_TEST_MENU_EXIT:-0} != 0 ]]; then
+  exit "$OMARCHY_TEST_MENU_EXIT"
+fi
+printf '%s\n' "${OMARCHY_TEST_MENU_REPLY-}"
+SH
+chmod +x "$stub_bin/omarchy-menu-select"
+
+export OMARCHY_TEST_FFMPEG_ARGS="$tmp_dir/ffmpeg-args"
+dummy_recording="$tmp_dir/dummy.mp4"
+touch "$dummy_recording"
+
+extracted=$(extract_loudnorm_json <<<"noise"$'\n'"$quiet_loudnorm_json"$'\n'"more")
+[[ $extracted == "$quiet_loudnorm_json" ]] || fail "extract_loudnorm_json keeps the loudnorm object" "$extracted"
+pass "extract_loudnorm_json keeps the loudnorm JSON object"
+
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_loudnorm_json"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+measured=$(measure_loudness "$dummy_recording")
+[[ $measured == *'"input_i" : "-28.00"'* ]] || fail "measure_loudness reads first-pass JSON" "$measured"
+grep -q "print_format=json" "$OMARCHY_TEST_FFMPEG_ARGS" || fail "measure_loudness requests print_format=json"
+grep -q "volume=enable='lt(t,0.4)':volume=0" "$OMARCHY_TEST_FFMPEG_ARGS" || \
+  fail "measure_loudness applies the pop mute so the transient does not skew LUFS"
+pass "measure_loudness runs an audio-only first pass with the pop mute"
+
+unset OMARCHY_SCREENRECORD_NORMALIZE
+NORMALIZE_AUDIO=""
+rm -f "$NORMALIZE_FILE"
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+export OMARCHY_TEST_LOUDNORM_JSON="$near_target_loudnorm_json"
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "near-target audio skips loudnorm"
+[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "near-target audio does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+pass "decide_normalize skips the prompt when I and LRA already match"
+
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_loudnorm_json"
+export OMARCHY_TEST_MENU_REPLY=$'Normalize\traise to typical YouTube and Spotify volume'
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == yes ]] || fail "quiet audio normalizes when the user accepts"
+[[ $SCREENRECORD_LOUDNESS_STATS == *'"input_i" : "-28.00"'* ]] || \
+  fail "accepting the prompt keeps first-pass stats for two-pass loudnorm" "$SCREENRECORD_LOUDNESS_STATS"
+wired=$(screenrecord_audio_filter "$SCREENRECORD_NORMALIZE" "$SCREENRECORD_LOUDNESS_STATS")
+[[ $wired == *measured_I=-28.00* ]] || fail "finalize wiring applies two-pass loudnorm" "$wired"
+grep -q "Audio may be unintentionally quiet" "$OMARCHY_TEST_MENU_ARGS" || fail "quiet audio prompt explains the recording is quiet"
+grep -q $'\tKeep original levels\tas recorded' "$OMARCHY_TEST_MENU_ARGS" || \
+  fail "keep option uses empty glyph so the label is not drawn as an icon" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+grep -q $'\tNormalize\traise to typical YouTube and Spotify volume' "$OMARCHY_TEST_MENU_ARGS" || \
+  fail "quiet normalize option says it will raise to typical streaming volume" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+pass "decide_normalize prompts when audio is quiet"
+
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+export OMARCHY_TEST_LOUDNORM_JSON="$hot_loudnorm_json"
+export OMARCHY_TEST_MENU_REPLY=$'Keep original levels\tas recorded'
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "hot -8 LUFS keeps original levels when the user declines"
+grep -q "Audio may be unintentionally loud" "$OMARCHY_TEST_MENU_ARGS" || fail "hot audio prompt explains the recording is loud"
+grep -q $'\tNormalize\tlower to typical YouTube and Spotify volume' "$OMARCHY_TEST_MENU_ARGS" || \
+  fail "loud normalize option says it will lower to typical streaming volume" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+pass "decide_normalize prompts when audio is louder than -11 LUFS"
+
+: >"$OMARCHY_TEST_MENU_ARGS"
+export OMARCHY_TEST_LOUDNORM_JSON="$wide_lra_loudnorm_json"
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "wide LRA on already-loud audio skips loudnorm"
+[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "wide LRA on already-loud audio does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+pass "decide_normalize skips the prompt when LRA is wide but loudness is inside the window"
+
+: >"$OMARCHY_TEST_MENU_ARGS"
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_loudnorm_json"
+export OMARCHY_TEST_MENU_EXIT=1
+unset OMARCHY_TEST_MENU_REPLY
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "Esc keeps original levels"
+pass "decide_normalize treats a cancelled prompt as keep original"
+
+unset OMARCHY_TEST_MENU_EXIT
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+export OMARCHY_TEST_LOUDNORM_JSON="$inf_loudnorm_json"
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "silent/-inf audio skips loudnorm"
+[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "-inf audio does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+pass "decide_normalize skips the prompt for unusable loudness"
+
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+export OMARCHY_TEST_LOUDNORM_JSON="not json"
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "unreadable loudnorm JSON skips loudnorm"
+[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "unreadable JSON does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+pass "decide_normalize skips the prompt when measurement fails"
+
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+OMARCHY_SCREENRECORD_NORMALIZE=false
+export OMARCHY_TEST_LOUDNORM_JSON="$quiet_loudnorm_json"
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == no ]] || fail "env false skips loudnorm"
+[[ -s $OMARCHY_TEST_FFMPEG_ARGS ]] && fail "env false does not measure" "$(cat "$OMARCHY_TEST_FFMPEG_ARGS")"
+[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "env false does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+unset OMARCHY_SCREENRECORD_NORMALIZE
+pass "env false overrides the prompt"
+
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+NORMALIZE_AUDIO=true
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == yes ]] || fail "flag true applies loudnorm"
+[[ -s $OMARCHY_TEST_FFMPEG_ARGS ]] && fail "flag true does not need a first pass" "$(cat "$OMARCHY_TEST_FFMPEG_ARGS")"
+[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "flag true does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+NORMALIZE_AUDIO=""
+pass "invocation flags override the prompt"
+
+echo yes >"$NORMALIZE_FILE"
+: >"$OMARCHY_TEST_MENU_ARGS"
+: >"$OMARCHY_TEST_FFMPEG_ARGS"
+decide_normalize "$dummy_recording"
+[[ $SCREENRECORD_NORMALIZE == yes ]] || fail "sidecar yes applies loudnorm without prompting"
+[[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "sidecar yes does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
+rm -f "$NORMALIZE_FILE"
+pass "start-time sidecar overrides the prompt"

--- a/test/shell.d/screenrecording-test.sh
+++ b/test/shell.d/screenrecording-test.sh
@@ -468,3 +468,30 @@ decide_normalize "$dummy_recording"
 [[ -s $OMARCHY_TEST_MENU_ARGS ]] && fail "flag true does not prompt" "$(cat "$OMARCHY_TEST_MENU_ARGS")"
 NORMALIZE_AUDIO=""
 pass "invocation flags override the prompt"
+
+# --- the recording directory only gates starting ---
+
+cat >"$stub_bin/pgrep" <<'SH'
+#!/bin/bash
+
+exit 1
+SH
+chmod +x "$stub_bin/pgrep"
+
+missing_dir="$tmp_dir/gone"
+
+: >"$OMARCHY_TEST_NOTIFICATION_ARGS"
+if OMARCHY_SCREENRECORD_DIR="$missing_dir" "$ROOT/bin/omarchy-capture-screenrecording"; then
+  fail "starting into a missing recording directory reports failure"
+fi
+grep -Fq "Screen recording directory does not exist: $missing_dir" "$OMARCHY_TEST_NOTIFICATION_ARGS" ||
+  fail "starting into a missing recording directory names the directory" "$(cat "$OMARCHY_TEST_NOTIFICATION_ARGS")"
+pass "starting into a missing recording directory fails instead of reporting success"
+
+: >"$OMARCHY_TEST_NOTIFICATION_ARGS"
+OMARCHY_SCREENRECORD_DIR="$missing_dir" "$ROOT/bin/omarchy-capture-screenrecording" --stop-recording || true
+[[ -s $OMARCHY_TEST_NOTIFICATION_ARGS ]] &&
+  fail "stopping does not complain about the recording directory" "$(cat "$OMARCHY_TEST_NOTIFICATION_ARGS")"
+pass "a missing recording directory does not block stopping"
+
+rm -f "$stub_bin/pgrep"


### PR DESCRIPTION
## Summary

Discussion: https://github.com/basecamp/omarchy/discussions/9020

Screen recordings no longer always run `loudnorm` on stop. That was crushing quiet sounds and dynamic range.

After stop, short recordings are measured. If the audio is unusually quiet (more than 4 LU below -14 LUFS) or unusually loud (more than 3 LU above), a menu asks whether to normalize to typical broadcast levels or keep the recording as-is. Esc keeps the original. Audio already in that window is left alone.

Recordings longer than 10 minutes skip that analysis and ask immediately — measuring a long soundtrack left a dead screen after the bar indicator was already gone. The prompt is “Normalize audio to typical broadcast levels?” with Normalize (Recommended) first. Saying yes does a single `loudnorm` pass in the remux, same as `OMARCHY_SCREENRECORD_NORMALIZE=true`. Short clips that accept still get the two-pass path with the first-pass stats.

The PipeWire capture-pop mute still always runs. `OMARCHY_SCREENRECORD_NORMALIZE=true` always normalizes; `false` never asks.

<img width="696" height="260" alt="screenshot-2026-08-31_02-29-04" src="https://github.com/user-attachments/assets/c72e5c11-ac0b-48a5-bf93-53beaef36cb0" />


## Test plan
- [x] Record with desktop audio that is clearly quiet; stopping should ask “Audio may be unintentionally quiet” with Keep original / Normalize
- [x] Record with hot audio (well above broadcast level); stopping should ask “Audio may be unintentionally loud”
- [x] Esc or Keep original leaves levels alone; Normalize raises or lowers toward typical broadcast levels
- [x] A recording already near normal speech volume should not prompt
- [x] A recording longer than 10 minutes asks immediately (no analysis wait), with Normalize recommended; yes is a single loudnorm pass
- [x] `OMARCHY_SCREENRECORD_NORMALIZE=false` never asks
- [x] `bash test/shell.d/screenrecording-test.sh`