### PR TITLE
Stop forcing Qt platform session-wide

### DIFF
--- a/bin/omarchy-launch-shell
+++ b/bin/omarchy-launch-shell
@@ -15,7 +15,7 @@
 # against a half-written tree, and that failed reload leaves a second engine
 # generation behind that turns the next restart's IPC kill into a crash.
 run_shell() {
-  QS_DISABLE_FILE_WATCHER=1 QS_NO_RELOAD_POPUP=1 \
+  QT_QPA_PLATFORM=wayland QS_DISABLE_FILE_WATCHER=1 QS_NO_RELOAD_POPUP=1 \
     systemd-cat -t omarchy-shell -- quickshell -n -p "$OMARCHY_PATH/shell" &
   shell_pid=$!
 

--- a/default/hypr/envs.lua
+++ b/default/hypr/envs.lua
@@ -8,9 +8,10 @@ require_optional.module("omarchy.current.theme.gum_env")
 hl.env("XCURSOR_SIZE", "24")
 hl.env("HYPRCURSOR_SIZE", "24")
 
--- Force all apps to use Wayland.
+-- Prefer Wayland where each toolkit owns a backward-compatible fallback.
 hl.env("GDK_BACKEND", "wayland,x11,*")
-hl.env("QT_QPA_PLATFORM", "wayland;xcb")
+-- Do not force QT_QPA_PLATFORM globally: older bundled Qt releases treat
+-- fallback lists as one plugin name and abort before they can use XWayland.
 hl.env("QT_QPA_PLATFORMTHEME", "gtk3")
 hl.env("MOZ_ENABLE_WAYLAND", "1")
 hl.env("ELECTRON_OZONE_PLATFORM_HINT", "wayland")

--- a/migrations/1787946762.sh
+++ b/migrations/1787946762.sh
@@ -1,0 +1,55 @@
+echo "Stop forcing the Qt platform in the current graphical session"
+
+user_manager_socket="${XDG_RUNTIME_DIR:-/run/user/$UID}/systemd/private"
+if ! manager_environment=$(systemctl --user show-environment 2>&1); then
+  if [[ -S $user_manager_socket ]]; then
+    echo "Could not reach the running user service manager: $manager_environment"
+    echo "The Qt platform environment cleanup will be retried by omarchy-migrate."
+    exit 1
+  fi
+
+  # A new user manager and D-Bus activation environment will start without the
+  # removed default at the next login.
+  exit 0
+fi
+
+if ! error=$(systemctl --user unset-environment QT_QPA_PLATFORM 2>&1); then
+  echo "Could not clear QT_QPA_PLATFORM from the user service manager: $error"
+  echo "The Qt platform environment cleanup will be retried by omarchy-migrate."
+  exit 1
+fi
+
+if ! graphical_state=$(systemctl --user show --property=ActiveState --value graphical-session.target 2>&1); then
+  echo "Could not inspect graphical-session.target: $graphical_state"
+  echo "The Qt platform environment cleanup will be retried by omarchy-migrate."
+  exit 1
+fi
+
+# D-Bus has no unset operation for activation variables. An empty value is
+# equivalent to no override for Qt and replaces the stale fallback list.
+if [[ -n ${DBUS_SESSION_BUS_ADDRESS:-} ]]; then
+  if ! error=$(dbus-update-activation-environment QT_QPA_PLATFORM= 2>&1); then
+    echo "Could not clear QT_QPA_PLATFORM from the D-Bus activation environment: $error"
+    echo "The Qt platform environment cleanup will be retried by omarchy-migrate."
+    exit 1
+  fi
+elif [[ $graphical_state == "active" ]]; then
+  echo "Could not reach the D-Bus activation environment in the graphical session."
+  echo "The Qt platform environment cleanup will be retried by omarchy-migrate."
+  exit 1
+fi
+
+# Removing hl.env() from the config does not mutate the already-running
+# compositor process. Empty the value there so future keybind launches do not
+# inherit the stale fallback list either.
+if [[ $graphical_state == "active" ]]; then
+  if ! error=$(hyprctl eval 'hl.env("QT_QPA_PLATFORM", "")' 2>&1); then
+    echo "Could not clear QT_QPA_PLATFORM from the running Hyprland session: $error"
+    echo "The Qt platform environment cleanup will be retried by omarchy-migrate."
+    exit 1
+  fi
+fi
+
+if pgrep -x steam >/dev/null 2>&1; then
+  echo "Steam is still running with the old Qt platform value. Fully exit and restart Steam before launching SteamVR."
+fi

--- a/test/shell.d/launch-shell-test.sh
+++ b/test/shell.d/launch-shell-test.sh
@@ -28,8 +28,8 @@ cat >"$fake_bin/quickshell" <<'SH'
 #!/bin/bash
 
 printf '%s\n' "$*" >>"$OMARCHY_TEST_QS_LOG"
-printf 'watcher=%s popup=%s\n' \
-  "${QS_DISABLE_FILE_WATCHER:-unset}" "${QS_NO_RELOAD_POPUP:-unset}" >>"$OMARCHY_TEST_QS_ENV_LOG"
+printf 'qpa=%s watcher=%s popup=%s\n' \
+  "${QT_QPA_PLATFORM:-unset}" "${QS_DISABLE_FILE_WATCHER:-unset}" "${QS_NO_RELOAD_POPUP:-unset}" >>"$OMARCHY_TEST_QS_ENV_LOG"
 
 launches=$(wc -l <"$OMARCHY_TEST_QS_LOG")
 status=$(awk -v n="$launches" 'NR == n { print; found = 1 } END { if (!found) print "0" }' <<<"$OMARCHY_TEST_QS_STATUSES")
@@ -113,9 +113,14 @@ pass "a shell that exits cleanly is left alone"
 
 # A misspelled variable would leave Quickshell hot-reloading the tree pacman
 # rewrites underneath it, which is what crashes the restart that follows.
-[[ $(<"$qs_env_log") == "watcher=1 popup=1" ]] ||
+[[ $(<"$qs_env_log") == "qpa=wayland watcher=1 popup=1" ]] ||
   fail "the shell launches with Quickshell's own reloading off" "$(<"$qs_env_log")"
 pass "the shell launches with Quickshell's config watcher and reload popup off"
+
+if grep -F 'hl.env("QT_QPA_PLATFORM"' "$ROOT/default/hypr/envs.lua" >/dev/null; then
+  fail "Qt platform selection is not forced on third-party applications"
+fi
+pass "Qt platform selection is scoped to Omarchy's shell"
 
 # Qt leaves through _exit(), so Quickshell's crash handler never relaunches it.
 launch_shell $'255\n0' || fail "a shell that died on a Wayland error is relaunched"

--- a/test/shell.d/qt-platform-env-migration-test.sh
+++ b/test/shell.d/qt-platform-env-migration-test.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/systemctl" <<'STUB'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$SYSTEMCTL_CALLS"
+
+case "$*" in
+  '--user show-environment')
+    if [[ ${MANAGER_AVAILABLE:-true} != "true" ]]; then
+      echo "manager unavailable" >&2
+      exit 1
+    fi
+    printf 'QT_QPA_PLATFORM=wayland;xcb\n'
+    ;;
+  '--user unset-environment QT_QPA_PLATFORM')
+    if [[ ${FAIL_ACTION:-} == "systemd" ]]; then
+      echo "unset failed" >&2
+      exit 1
+    fi
+    ;;
+  '--user show --property=ActiveState --value graphical-session.target')
+    if [[ ${FAIL_ACTION:-} == "session-state" ]]; then
+      echo "state lookup failed" >&2
+      exit 1
+    fi
+    printf '%s\n' "${GRAPHICAL_STATE:-active}"
+    ;;
+  *) exit 1 ;;
+esac
+STUB
+
+cat >"$stub_bin/dbus-update-activation-environment" <<'STUB'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$DBUS_CALLS"
+if [[ ${FAIL_ACTION:-} == "dbus" ]]; then
+  echo "D-Bus update failed" >&2
+  exit 1
+fi
+STUB
+
+cat >"$stub_bin/hyprctl" <<'STUB'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$HYPRCTL_CALLS"
+if [[ ${FAIL_ACTION:-} == "hyprland" ]]; then
+  echo "Hyprland update failed" >&2
+  exit 1
+fi
+STUB
+
+cat >"$stub_bin/pgrep" <<'STUB'
+#!/bin/bash
+
+[[ ${STEAM_RUNNING:-false} == "true" ]]
+STUB
+
+chmod +x "$stub_bin"/*
+
+migration="$ROOT/migrations/1787946762.sh"
+
+run_migration() {
+  local calls_dir="$1"
+  shift
+
+  mkdir -p "$calls_dir/run"
+  : >"$calls_dir/systemctl"
+  : >"$calls_dir/dbus"
+  : >"$calls_dir/hyprctl"
+
+  HOME="$calls_dir/home" XDG_RUNTIME_DIR="$calls_dir/run" \
+    DBUS_SESSION_BUS_ADDRESS="unix:path=$calls_dir/run/bus" \
+    SYSTEMCTL_CALLS="$calls_dir/systemctl" DBUS_CALLS="$calls_dir/dbus" HYPRCTL_CALLS="$calls_dir/hyprctl" \
+    PATH="$stub_bin:$PATH" "$@" bash -euo pipefail "$migration"
+}
+
+active_calls="$test_tmp/active"
+run_migration "$active_calls" env STEAM_RUNNING=true >"$test_tmp/active-output"
+
+grep -Fx -- '--user unset-environment QT_QPA_PLATFORM' "$active_calls/systemctl" >/dev/null ||
+  fail "Qt platform migration clears the user service manager environment"
+grep -Fx -- 'QT_QPA_PLATFORM=' "$active_calls/dbus" >/dev/null ||
+  fail "Qt platform migration neutralizes the D-Bus activation environment"
+grep -Fx -- 'eval hl.env("QT_QPA_PLATFORM", "")' "$active_calls/hyprctl" >/dev/null ||
+  fail "Qt platform migration clears the running compositor environment"
+pass "Qt platform migration clears every live launch environment"
+
+grep -F 'Fully exit and restart Steam before launching SteamVR' "$test_tmp/active-output" >/dev/null ||
+  fail "Qt platform migration tells users to restart an affected Steam process"
+pass "Qt platform migration communicates the required Steam restart"
+
+inactive_calls="$test_tmp/inactive"
+run_migration "$inactive_calls" env GRAPHICAL_STATE=inactive >/dev/null
+[[ ! -s $inactive_calls/hyprctl ]] ||
+  fail "Qt platform migration tries to mutate Hyprland outside a graphical session"
+pass "Qt platform migration skips Hyprland outside a graphical session"
+
+offline_calls="$test_tmp/offline"
+mkdir -p "$offline_calls"
+if HOME="$offline_calls/home" XDG_RUNTIME_DIR="$offline_calls/run" \
+  SYSTEMCTL_CALLS="$offline_calls/systemctl" PATH="$stub_bin:$PATH" MANAGER_AVAILABLE=false \
+  bash -euo pipefail "$migration" >"$test_tmp/offline-output" 2>&1; then
+  pass "Qt platform migration defers to a clean environment at the next login"
+else
+  fail "Qt platform migration fails without a running user manager" "$(<"$test_tmp/offline-output")"
+fi
+
+for action in systemd session-state dbus hyprland; do
+  failed_calls="$test_tmp/failed-$action"
+  if run_migration "$failed_calls" env FAIL_ACTION="$action" >"$test_tmp/failed-$action-output" 2>&1; then
+    fail "Qt platform migration ignores a failed $action cleanup"
+  fi
+  grep -F 'will be retried by omarchy-migrate' "$test_tmp/failed-$action-output" >/dev/null ||
+    fail "Qt platform migration does not keep a failed $action cleanup retryable"
+done
+pass "Qt platform migration keeps incomplete live cleanup retryable"
+
+rerun_calls="$test_tmp/rerun"
+run_migration "$rerun_calls" env STEAM_RUNNING=false >/dev/null
+run_migration "$rerun_calls" env STEAM_RUNNING=false >/dev/null
+pass "Qt platform migration is idempotent"


### PR DESCRIPTION
## Summary

- stop exporting `QT_QPA_PLATFORM=wayland;xcb` to every application in the Hyprland session
- keep Omarchy's Quickshell explicitly on its supported Wayland platform
- clean the stale value from systemd, D-Bus, and the running Hyprland process during upgrade
- tell users to fully restart Steam when it still holds the inherited value
- cover the steady-state and migration boundaries with regression tests

## Why

SteamVR bundles Qt 5.5 with only the XCB platform plugin. That Qt release treats the modern semicolon-separated fallback value as one literal plugin name, so `vrmonitor` aborts during `QGuiApplication` initialization instead of falling back to XWayland.

Scoping `QT_QPA_PLATFORM=wayland` to Quickshell preserves native Wayland for the Qt component Omarchy controls without imposing modern Qt fallback syntax on third-party bundled runtimes.

The migration also repairs existing graphical sessions. It unsets the systemd user-manager value, replaces the D-Bus activation value with an empty Qt override, and empties the running compositor's value so future keybind launches are clean. Partial cleanup failures keep the migration pending for retry.

Closes https://github.com/basecamp/omarchy/issues/8701

## Testing

- `bash test/shell.d/launch-shell-test.sh`
- `bash test/shell.d/qt-platform-env-migration-test.sh`
- `bash -n bin/omarchy-launch-shell migrations/1787946762.sh test/shell.d/launch-shell-test.sh test/shell.d/qt-platform-env-migration-test.sh`
- `git diff --check`
- `./test/all` (CLI suite passed; shell suite reached the new regression successfully, with seven unrelated environment-dependent failures from the missing `omarchy-pkgs` checkout, sandboxed home writes, and unavailable network/visual conditions)
