### PR TITLE
Fix legacy Broadcom wl conflict on BCM4350 Macs upgrading to Quattro

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -718,7 +718,7 @@ remove_legacy_bcm4350_wl_driver() {
   log "Removing legacy Broadcom wl driver for Apple BCM4350"
   # BCM4350 uses the in-kernel brcmfmac driver. The legacy wl packages blacklist
   # it, so remove only those packages while ignoring pre-quattro dependency edges.
-  as_root pacman -Rdd --noconfirm "${legacy_wl_packages[@]}"
+  as_root pacman -Rdd --noconfirm "${legacy_wl_packages[@]}" || warn "Could not remove legacy Broadcom driver(s) ${legacy_wl_packages[*]}; continuing."
 }
 
 migrate_1password_beta_package() {

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -700,6 +700,27 @@ remove_conflicting_legacy_packages() {
   done
 }
 
+remove_legacy_bcm4350_wl_driver() {
+  local sys_vendor
+  sys_vendor=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)
+
+  [[ $sys_vendor == Apple* ]] || return 0
+  lspci -nn | grep -F '14e4:43a3' >/dev/null || return 0
+
+  local pkg
+  local legacy_wl_packages=()
+  for pkg in broadcom-wl broadcom-wl-dkms; do
+    package_installed_exact "$pkg" && legacy_wl_packages+=("$pkg")
+  done
+
+  ((${#legacy_wl_packages[@]})) || return 0
+
+  log "Removing legacy Broadcom wl driver for Apple BCM4350"
+  # BCM4350 uses the in-kernel brcmfmac driver. The legacy wl packages blacklist
+  # it, so remove only those packages while ignoring pre-quattro dependency edges.
+  as_root pacman -Rdd --noconfirm "${legacy_wl_packages[@]}"
+}
+
 migrate_1password_beta_package() {
   if ! package_installed_exact 1password-beta && ! package_installed_exact 1password-beta-bin; then
     return 0
@@ -2322,6 +2343,7 @@ install_keyrings
 remove_legacy_installer_package
 remove_legacy_limine_configs
 remove_conflicting_legacy_packages
+remove_legacy_bcm4350_wl_driver
 install_omarchy_quattro_packages
 install_hardware_transition_packages
 normalize_limine_config

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -143,6 +143,8 @@ for package in broadcom-wl broadcom-wl-dkms; do
   grep -F "$package" <<<"$bcm4350_body" >/dev/null ||
     fail "Omarchy 4 upgrade removes legacy package $package from Apple BCM4350 systems"
 done
+grep -F 'pacman -Rdd --noconfirm "${legacy_wl_packages[@]}" ||' <<<"$bcm4350_body" >/dev/null ||
+  fail "Omarchy 4 upgrade survives a failed legacy wl removal"
 ! function_body remove_retired_default_packages | grep -F 'broadcom-wl' >/dev/null ||
   fail "Omarchy 4 upgrade does not retire broadcom-wl globally"
 bcm4350_line=$(grep -n '^remove_legacy_bcm4350_wl_driver$' "$upgrade_to_quattro" | cut -d: -f1)

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -132,6 +132,26 @@ grep -F 'apply_user_hardware_transition' "$upgrade_to_quattro" >/dev/null
 grep -F 'DX13260' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade backfills hardware support from the legacy release"
 
+bcm4350_body=$(function_body remove_legacy_bcm4350_wl_driver)
+grep -F '[[ $sys_vendor == Apple* ]]' <<<"$bcm4350_body" >/dev/null ||
+  fail "Omarchy 4 upgrade limits BCM4350 wl cleanup to Apple hardware"
+grep -F "lspci -nn | grep -F '14e4:43a3'" <<<"$bcm4350_body" >/dev/null ||
+  fail "Omarchy 4 upgrade limits BCM4350 wl cleanup to PCI ID 14e4:43a3"
+for package in broadcom-wl broadcom-wl-dkms; do
+  grep -F "package_installed_exact \"\$pkg\"" <<<"$bcm4350_body" >/dev/null ||
+    fail "Omarchy 4 upgrade makes BCM4350 wl cleanup idempotent"
+  grep -F "$package" <<<"$bcm4350_body" >/dev/null ||
+    fail "Omarchy 4 upgrade removes legacy package $package from Apple BCM4350 systems"
+done
+! function_body remove_retired_default_packages | grep -F 'broadcom-wl' >/dev/null ||
+  fail "Omarchy 4 upgrade does not retire broadcom-wl globally"
+bcm4350_line=$(grep -n '^remove_legacy_bcm4350_wl_driver$' "$upgrade_to_quattro" | cut -d: -f1)
+packages_line=$(grep -n '^install_omarchy_quattro_packages$' "$upgrade_to_quattro" | cut -d: -f1)
+[[ -n $bcm4350_line && -n $packages_line ]] || fail "BCM4350 cleanup and package install calls exist"
+(( bcm4350_line < packages_line )) ||
+  fail "BCM4350 cleanup runs before the Quattro package transaction"
+pass "Omarchy 4 upgrade removes legacy wl packages only from Apple BCM4350 systems"
+
 grep -F 'omarchy-refresh-applications' "$upgrade_to_quattro" >/dev/null
 pass "Omarchy 4 upgrade refreshes application launchers"
 


### PR DESCRIPTION
Fixes #8810

Quattro already uses brcmfmac for Apple BCM4350 (14e4:43a3), but legacy Omarchy 3.x installs can retain broadcom-wl or broadcom-wl-dkms during upgrade.

Those legacy wl packages blacklist brcmfmac, which can leave the upgraded system without a Wi-Fi interface when wl fails to initialize.

This change removes legacy broadcom-wl/broadcom-wl-dkms only on Apple BCM4350 systems before the Quattro package transaction.

Other Broadcom devices that intentionally use wl are unchanged.

Validation:
- bash syntax checks pass
- full upgrade-to-quattro shell test passes
- regression test verifies cleanup is limited to Apple BCM4350 systems