### PR TITLE
Distinguish plugged in but not charging in the bar battery icon

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -69,10 +69,11 @@ function batteryIcon(device, onBattery, states) {
 
   var chargingIcons = ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"]
   var defaultIcons = ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
+  var plugIcon = "󰚥"
   var index = Math.max(0, Math.min(9, Math.floor(d.percentage * 10)))
   var threshold = chargeThresholdActive(d, onBattery, states)
 
-  if (threshold) return defaultIcons[index]
+  if (threshold) return defaultIcons[index] + plugIcon
   if (d.state === states.FullyCharged) return "󰂅"
   if (!onBattery) return chargingIcons[index]
   return defaultIcons[index]

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -42,6 +42,15 @@ assertEqual(
   'power shows battery icon when unplugged before battery state refreshes'
 )
 
+const idleOnAc = { isPresent: true, percentage: 0.4, state: states.PendingCharge }
+const dischargingIcon = power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Discharging }, true, states)
+const chargingIcon = power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states)
+
+assert(power.batteryIcon(idleOnAc, false, states) !== dischargingIcon, 'power distinguishes plugged in but idle from running on battery')
+assert(power.batteryIcon(idleOnAc, false, states) !== chargingIcon, 'power distinguishes plugged in but idle from active charging')
+assert(power.batteryIcon(idleOnAc, false, states).startsWith(dischargingIcon), 'power keeps the charge level readable while plugged in but idle')
+assertEqual(Array.from(power.batteryIcon(idleOnAc, false, states)).length, 2, 'power pairs the level glyph with a plug while plugged in but idle')
+
 assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')
 assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon')


### PR DESCRIPTION
## The problem

`batteryIcon` returns the same glyph for "running on battery" and "plugged in but not charging":

```js
if (threshold) return defaultIcons[index]
```

`chargeThresholdActive` is true whenever the machine is on AC with no meaningful current flowing — a charge-control threshold holding the battery at its limit, `PendingCharge`, or the EC stalling right after plug-in. In all of those the bar renders a byte-identical icon to discharging, so there is no way to tell from the bar whether the laptop is plugged in.

On a laptop with charge thresholds configured (ThinkPad, Framework, several Dell models) that is not a transient — it is the steady state for as long as the battery sits above the start threshold. The panel already distinguishes it ("Threshold" / "Holding" / "Charge limit"); only the bar icon does not.

## The change

Pair the level glyph with a plug (`nf-md-power_plug`) for that state:

| state | before | after |
| --- | --- | --- |
| on battery | `󰁿` | `󰁿` |
| plugged in, not charging | `󰁿` | `󰁿󰚥` |
| charging | `󰂉` | `󰂉` |
| fully charged | `󰂅` | `󰂅` |

The charge level still reads, and the state is now distinct from both discharging and the battery-plus-bolt charging icons. The plug shows while the EC stalls right after plug-in and gives way to the lightning icons once current actually flows.

There is no battery-with-plug glyph in the Nerd Font Material Design set, so the pair is two glyphs. It fits the existing slot: at stock tokens (`iconSlot: 27`, `iconFont: 13`) a single icon inks ~11px and the pair ~14px. `Panel.qml` and `slotSize` are therefore untouched, which is what keeps the neighbouring widgets from shifting on plug/unplug -- verified by measuring icon ink positions, which are pixel-identical between the charging and holding states.

A vertical bar is fine too: `WidgetButton.implicitWidth` resolves to `barSize` (28) rather than to content width when `fixedWidth` is -1, so the pair has room there as well.

## Behavior change worth flagging

This also affects machines **without** charge thresholds. For the first second or so after plugging in, `changeRate` reads ~0 and UPower often still reports `pending-charge`, so those users will briefly see the plug before the bolt. That is arguably more accurate than showing an on-battery icon while plugged in, but it is a visible change for everyone, not only threshold users.

## Testing

`test/shell.d/power-test.sh` extended with four assertions covering the new state: that it differs from both discharging and charging, that the charge level still reads, and that it is a two-glyph pair. Purely additive -- no existing assertion changed.

`./test/shell` passes for this file. Four unrelated files fail identically with and without this change on a clean `quattro` checkout (`config`, `snapper`, `theme-install-guards`, `unowned-system-paths`) — they appear to need real system state.

Verified in the running UI per `agents/skills/visual-verification.md`, on a Dell with `charge_control_end_threshold=90`: captured the bar across discharging, holding, and charging, and measured icon ink positions to confirm nothing shifts. Neighbouring widget positions are pixel-identical between charging and holding.
