### PR TITLE
Add Bluetooth keyboard support for encrypted disk unlock

### DIFF
--- a/bin/omarchy-setup-security-bluetooth-unlock
+++ b/bin/omarchy-setup-security-bluetooth-unlock
@@ -17,11 +17,13 @@ no_rebuild=false
 while (( $# )); do
   case "$1" in
     --device)
-      device=${2:-}
+      (( $# >= 2 )) || { echo "Missing address after --device." >&2; exit 1; }
+      device=$2
       shift 2
       ;;
     --controller)
-      controller=${2:-}
+      (( $# >= 2 )) || { echo "Missing address after --controller." >&2; exit 1; }
+      controller=$2
       shift 2
       ;;
     --yes)
@@ -60,6 +62,10 @@ valid_address() {
   [[ $1 =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]]
 }
 
+keyboard_info() {
+  [[ $1 == *"Icon: input-keyboard"* ]] || grep -qE '^[[:space:]]*Appearance: 0x0*3c1([[:space:]]|$)' <<<"$1"
+}
+
 normalize_address() {
   printf '%s\n' "${1^^}"
 }
@@ -70,10 +76,7 @@ configured() {
 
 rebuild() {
   $no_rebuild && return 0
-  if omarchy-cmd-missing limine-mkinitcpio; then
-    echo "Bluetooth disk unlock requires the Limine boot setup." >&2
-    exit 1
-  fi
+  rebuild_started=true
   echo "Regenerating the boot image..."
   sudo limine-mkinitcpio
 }
@@ -81,15 +84,73 @@ rebuild() {
 if [[ $action == "status" ]]; then
   if configured; then
     name=$(sudo sed -n 's/^NAME=//p' "$config_file" 2>/dev/null || true)
-    echo "Bluetooth disk unlock is enabled${name:+ for $name}."
+    echo "Bluetooth disk unlock is configured${name:+ for $name}."
+    echo "This checks configuration only; the boot image and keyboard connection are not verified."
     exit 0
   fi
   echo "Bluetooth disk unlock is disabled."
   exit 1
 fi
 
+# Check the rebuild tool before changing the installed configuration.
+if ! $no_rebuild && omarchy-cmd-missing limine-mkinitcpio; then
+  echo "Bluetooth disk unlock requires the Limine boot setup." >&2
+  exit 1
+fi
+
+managed_files=("$config_file" "$hook_dropin" "$install_hook" "$runtime_hook")
+stage=$(mktemp -d)
+transaction_started=false
+transaction_complete=false
+rebuild_started=false
+cleanup() {
+  local result=$? i rollback_failed=false
+  trap - EXIT
+  if $transaction_started && ! $transaction_complete; then
+    echo "Bluetooth unlock setup failed; restoring the previous configuration." >&2
+    for i in "${!managed_files[@]}"; do
+      if sudo test -e "$stage/backup/$i"; then
+        sudo cp -a --remove-destination -- "$stage/backup/$i" "${managed_files[i]}" || rollback_failed=true
+      else
+        sudo rm -f -- "${managed_files[i]}" || rollback_failed=true
+      fi
+    done
+    if $rollback_failed; then
+      echo "Configuration recovery failed. Backups are preserved in $stage/backup; restore them before rebuilding." >&2
+      exit 1
+    fi
+    if $rebuild_started; then
+      echo "The boot image may be incomplete. Fix the error and run sudo limine-mkinitcpio before rebooting." >&2
+    fi
+  fi
+  if [[ -d $stage/backup ]]; then
+    sudo rm -rf -- "$stage"
+  else
+    rm -rf -- "$stage"
+  fi
+  exit "$result"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+begin_transaction() {
+  local i
+  mkdir -m 700 "$stage/backup"
+  for i in "${!managed_files[@]}"; do
+    if sudo test -L "${managed_files[i]}" || sudo test -d "${managed_files[i]}"; then
+      echo "Refusing unsafe configuration path: ${managed_files[i]}" >&2
+      exit 1
+    fi
+    if sudo test -e "${managed_files[i]}"; then
+      sudo cp -a -- "${managed_files[i]}" "$stage/backup/$i"
+    fi
+  done
+  transaction_started=true
+}
+
 if [[ $action == "disable" ]]; then
-  if ! configured; then
+  if [[ ! -e $config_file && ! -e $hook_dropin && ! -e $install_hook && ! -e $runtime_hook ]]; then
     echo "Bluetooth disk unlock is already disabled."
     exit 0
   fi
@@ -98,9 +159,15 @@ if [[ $action == "disable" ]]; then
     exit 0
   fi
 
-  sudo rm -f -- "$config_file" "$hook_dropin" "$install_hook" "$runtime_hook"
+  begin_transaction
+  sudo rm -f -- "${managed_files[@]}"
   rebuild
-  echo "Bluetooth disk unlock is disabled. Keep a wired or 2.4 GHz keyboard available for the next boot."
+  transaction_complete=true
+  if $no_rebuild; then
+    echo "Bluetooth disk unlock configuration removed. Rebuild the boot image to remove its bond key."
+  else
+    echo "Bluetooth disk unlock is disabled. Keep a wired or 2.4 GHz keyboard available for the next boot."
+  fi
   exit 0
 fi
 
@@ -109,8 +176,41 @@ if [[ ! -e /sys/class/bluetooth && -z $controller ]]; then
   exit 1
 fi
 
-if ! grep -RqsE '^[[:space:]]*HOOKS=.*(^|[[:space:](])encrypt([[:space:])]|$)' "$mkinitcpio_dir"; then
-  echo "Bluetooth disk unlock currently requires Omarchy's encrypt initramfs hook." >&2
+# Resolve the actual configuration, including later overrides, in mkinitcpio's
+# version-sort order. A textual match can find encrypt in a superseded HOOKS.
+if ! (
+  set +u
+  HOOKS=()
+  base_config=${OMARCHY_BLUETOOTH_UNLOCK_MKINITCPIO_CONFIG:-/etc/mkinitcpio.conf}
+  if [[ -f $base_config ]]; then
+    source "$base_config" || exit 1
+  fi
+  while IFS= read -r -d '' dropin; do
+    if [[ $dropin == "$hook_dropin" ]]; then
+      source "$OMARCHY_PATH/default/initcpio/omarchy-bluetooth-unlock.conf" || exit 1
+    else
+      source "$dropin" || exit 1
+    fi
+  done < <({ find "$mkinitcpio_dir" -maxdepth 1 -xtype f -name '*.conf' -print0; printf '%s\0' "$hook_dropin"; } | LC_ALL=C.UTF-8 sort -zVu)
+  # mkinitcpio also accepts the legacy string form.
+  [[ ${HOOKS@a} == *a* ]] || read -ra HOOKS <<<"$HOOKS"
+  has_encrypt=false
+  has_udev=false
+  previous_hook=""
+  for hook in "${HOOKS[@]}"; do
+    case "$hook" in
+      systemd | sd-encrypt) exit 1 ;;
+      udev) has_udev=true ;;
+      encrypt)
+        $has_udev && [[ $previous_hook == "omarchy-bluetooth-unlock" ]] || exit 1
+        has_encrypt=true
+        ;;
+    esac
+    previous_hook=$hook
+  done
+  $has_encrypt
+); then
+  echo "Bluetooth disk unlock requires udev and its Bluetooth hook immediately before encrypt in the effective mkinitcpio HOOKS." >&2
   exit 1
 fi
 
@@ -120,7 +220,7 @@ if [[ -z $device ]]; then
     valid_address "$candidate" || continue
     info=$(timeout 3s bluetoothctl info "$candidate" 2>/dev/null || true)
     [[ $info == *"Paired: yes"* && $info == *"Trusted: yes"* ]] || continue
-    [[ $info == *"00001812-0000-1000-8000-00805f9b34fb"* || $info == *"00001124-0000-1000-8000-00805f9b34fb"* ]] || continue
+    keyboard_info "$info" || continue
     name=$(sed -n 's/^[[:space:]]*Name: //p' <<<"$info" | head -1 | tr '\t\r\n' '   ' | sed 's/[[:space:]]*$//')
     candidates+=("$candidate" "${name:-Bluetooth keyboard}")
   done < <(bluetoothctl devices Paired 2>/dev/null | awk '{print $2}')
@@ -145,13 +245,18 @@ if [[ -z $device ]]; then
   fi
 else
   valid_address "$device" || { echo "Invalid Bluetooth device address." >&2; exit 1; }
-  info=$(timeout 3s bluetoothctl info "$device" 2>/dev/null || true)
+  # bluetoothctl info addresses the default controller. With an explicit
+  # controller, validate its stored bond below instead (also works in chroot).
+  info=""
+  if [[ -z $controller ]]; then
+    info=$(timeout 3s bluetoothctl info "$device" 2>/dev/null || true)
+  fi
   if [[ -n $info ]]; then
     [[ $info == *"Paired: yes"* && $info == *"Trusted: yes"* ]] || {
       echo "The selected Bluetooth device is not paired and trusted." >&2
       exit 1
     }
-    [[ $info == *"00001812-0000-1000-8000-00805f9b34fb"* || $info == *"00001124-0000-1000-8000-00805f9b34fb"* ]] || {
+    keyboard_info "$info" || {
       echo "The selected Bluetooth device is not a keyboard." >&2
       exit 1
     }
@@ -177,6 +282,30 @@ if sudo test -L "$state_dir/$controller" || sudo test -L "$state_dir/$controller
   exit 1
 fi
 
+# Validate the selected controller's persisted bond even when the target has
+# no running D-Bus (the ISO finalization path). A generic HID UUID also matches
+# mice and gamepads, so require keyboard-specific appearance or class bits.
+if sudo test -L "$state_dir/$controller/$device/info"; then
+  echo "Refusing a symlinked Bluetooth bond." >&2
+  exit 1
+fi
+bond=$(sudo cat "$state_dir/$controller/$device/info")
+general=$(awk '/^\[General\]$/ { inside=1; next } /^\[/ { inside=0 } inside' <<<"$bond")
+bond_name=$(sed -n 's/^Name=//p' <<<"$general" | head -1 | tr '\t\r\n' '   ' | sed 's/[[:space:]]*$//')
+name=${bond_name:-$name}
+appearance=$(sed -n 's/^Appearance=//p' <<<"$general")
+class=$(sed -n 's/^Class=//p' <<<"$general")
+keyboard=false
+if [[ $appearance =~ ^0x0*3[cC]1$ ]]; then
+  keyboard=true
+elif [[ $class =~ ^0x[0-9A-Fa-f]{1,6}$ ]] && (( (class & 0x1f00) == 0x0500 && (class & 0x40) != 0 )); then
+  keyboard=true
+fi
+if ! $keyboard || ! grep -Fxq 'Trusted=true' <<<"$general" || ! grep -qE '^\[(LinkKey|LongTermKey)\]$' <<<"$bond"; then
+  echo "The selected controller has no trusted keyboard bond. Pair and trust the keyboard first." >&2
+  exit 1
+fi
+
 if ! $assume_yes; then
   echo
   echo "This adds $name to the boot image so it can connect before LUKS asks for your disk password."
@@ -187,13 +316,12 @@ if ! $assume_yes; then
   gum confirm "Enable Bluetooth keyboard disk unlock?" || exit 0
 fi
 
-stage=$(mktemp -d)
-trap 'rm -rf "$stage"' EXIT
 install -Dm755 "$OMARCHY_PATH/default/initcpio/install/omarchy-bluetooth-unlock" "$stage/install/omarchy-bluetooth-unlock"
 install -Dm755 "$OMARCHY_PATH/default/initcpio/hooks/omarchy-bluetooth-unlock" "$stage/hooks/omarchy-bluetooth-unlock"
 install -Dm644 "$OMARCHY_PATH/default/initcpio/omarchy-bluetooth-unlock.conf" "$stage/zz-omarchy-bluetooth-unlock.conf"
 printf 'CONTROLLER=%s\nDEVICE=%s\nNAME=%s\n' "$controller" "$device" "$name" >"$stage/bluetooth-unlock.conf"
 
+begin_transaction
 sudo install -d -m 0755 "$config_dir" "$mkinitcpio_dir" "$initcpio_dir/install" "$initcpio_dir/hooks"
 sudo install -m 0755 "$stage/install/omarchy-bluetooth-unlock" "$install_hook"
 sudo install -m 0755 "$stage/hooks/omarchy-bluetooth-unlock" "$runtime_hook"
@@ -201,5 +329,10 @@ sudo install -m 0644 "$stage/zz-omarchy-bluetooth-unlock.conf" "$hook_dropin"
 sudo install -m 0600 "$stage/bluetooth-unlock.conf" "$config_file"
 
 rebuild
-echo "Bluetooth disk unlock is enabled for $name."
-echo "Test it on the next reboot, with a wired or 2.4 GHz keyboard nearby for recovery."
+transaction_complete=true
+if $no_rebuild; then
+  echo "Bluetooth disk unlock is configured for $name. Rebuild the boot image to apply it."
+else
+  echo "Bluetooth disk unlock boot image rebuilt for $name."
+  echo "Test it on the next reboot, with a wired or 2.4 GHz keyboard nearby for recovery."
+fi

--- a/bin/omarchy-setup-security-bluetooth-unlock
+++ b/bin/omarchy-setup-security-bluetooth-unlock
@@ -1,0 +1,205 @@
+#!/bin/bash
+
+# omarchy:summary=Use a paired Bluetooth keyboard for encrypted disk unlock
+# omarchy:args=[enable|disable|status] [--device <address>] [--controller <address>] [--yes] [--no-rebuild]
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+action=${1:-enable}
+[[ $# -gt 0 ]] && shift
+
+device=""
+controller=""
+assume_yes=false
+no_rebuild=false
+
+while (( $# )); do
+  case "$1" in
+    --device)
+      device=${2:-}
+      shift 2
+      ;;
+    --controller)
+      controller=${2:-}
+      shift 2
+      ;;
+    --yes)
+      assume_yes=true
+      shift
+      ;;
+    --no-rebuild)
+      no_rebuild=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$action" in
+  enable | disable | status) ;;
+  *)
+    echo "Usage: omarchy setup security bluetooth-unlock [enable|disable|status] [--device <address>] [--controller <address>] [--yes] [--no-rebuild]" >&2
+    exit 1
+    ;;
+esac
+
+config_dir=${OMARCHY_BLUETOOTH_UNLOCK_CONFIG_DIR:-/etc/omarchy}
+config_file="$config_dir/bluetooth-unlock.conf"
+mkinitcpio_dir=${OMARCHY_BLUETOOTH_UNLOCK_MKINITCPIO_DIR:-/etc/mkinitcpio.conf.d}
+hook_dropin="$mkinitcpio_dir/zz-omarchy-bluetooth-unlock.conf"
+initcpio_dir=${OMARCHY_BLUETOOTH_UNLOCK_INITCPIO_DIR:-/usr/lib/initcpio}
+install_hook="$initcpio_dir/install/omarchy-bluetooth-unlock"
+runtime_hook="$initcpio_dir/hooks/omarchy-bluetooth-unlock"
+state_dir=${OMARCHY_BLUETOOTH_UNLOCK_STATE_DIR:-/var/lib/bluetooth}
+
+valid_address() {
+  [[ $1 =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]]
+}
+
+normalize_address() {
+  printf '%s\n' "${1^^}"
+}
+
+configured() {
+  [[ -f $config_file && -f $hook_dropin && -f $install_hook && -f $runtime_hook ]]
+}
+
+rebuild() {
+  $no_rebuild && return 0
+  if omarchy-cmd-missing limine-mkinitcpio; then
+    echo "Bluetooth disk unlock requires the Limine boot setup." >&2
+    exit 1
+  fi
+  echo "Regenerating the boot image..."
+  sudo limine-mkinitcpio
+}
+
+if [[ $action == "status" ]]; then
+  if configured; then
+    name=$(sudo sed -n 's/^NAME=//p' "$config_file" 2>/dev/null || true)
+    echo "Bluetooth disk unlock is enabled${name:+ for $name}."
+    exit 0
+  fi
+  echo "Bluetooth disk unlock is disabled."
+  exit 1
+fi
+
+if [[ $action == "disable" ]]; then
+  if ! configured; then
+    echo "Bluetooth disk unlock is already disabled."
+    exit 0
+  fi
+
+  if ! $assume_yes && ! gum confirm "Disable Bluetooth keyboard disk unlock?"; then
+    exit 0
+  fi
+
+  sudo rm -f -- "$config_file" "$hook_dropin" "$install_hook" "$runtime_hook"
+  rebuild
+  echo "Bluetooth disk unlock is disabled. Keep a wired or 2.4 GHz keyboard available for the next boot."
+  exit 0
+fi
+
+if [[ ! -e /sys/class/bluetooth && -z $controller ]]; then
+  echo "No Bluetooth adapter is available." >&2
+  exit 1
+fi
+
+if ! grep -RqsE '^[[:space:]]*HOOKS=.*(^|[[:space:](])encrypt([[:space:])]|$)' "$mkinitcpio_dir"; then
+  echo "Bluetooth disk unlock currently requires Omarchy's encrypt initramfs hook." >&2
+  exit 1
+fi
+
+declare -a candidates=()
+if [[ -z $device ]]; then
+  while read -r candidate; do
+    valid_address "$candidate" || continue
+    info=$(timeout 3s bluetoothctl info "$candidate" 2>/dev/null || true)
+    [[ $info == *"Paired: yes"* && $info == *"Trusted: yes"* ]] || continue
+    [[ $info == *"00001812-0000-1000-8000-00805f9b34fb"* || $info == *"00001124-0000-1000-8000-00805f9b34fb"* ]] || continue
+    name=$(sed -n 's/^[[:space:]]*Name: //p' <<<"$info" | head -1 | tr '\t\r\n' '   ' | sed 's/[[:space:]]*$//')
+    candidates+=("$candidate" "${name:-Bluetooth keyboard}")
+  done < <(bluetoothctl devices Paired 2>/dev/null | awk '{print $2}')
+
+  if (( ${#candidates[@]} == 0 )); then
+    echo "No paired and trusted Bluetooth keyboard was found." >&2
+    echo "Pair and trust the keyboard first, then run this setup again." >&2
+    exit 1
+  fi
+
+  if (( ${#candidates[@]} == 2 )); then
+    device=${candidates[0]}
+    name=${candidates[1]}
+  else
+    choices=()
+    for ((i = 0; i < ${#candidates[@]}; i += 2)); do
+      choices+=("${candidates[i + 1]}  ${candidates[i]}")
+    done
+    selection=$(printf '%s\n' "${choices[@]}" | gum choose --header "Select Bluetooth keyboard") || exit 0
+    device=${selection##*  }
+    name=${selection%  *}
+  fi
+else
+  valid_address "$device" || { echo "Invalid Bluetooth device address." >&2; exit 1; }
+  info=$(timeout 3s bluetoothctl info "$device" 2>/dev/null || true)
+  if [[ -n $info ]]; then
+    [[ $info == *"Paired: yes"* && $info == *"Trusted: yes"* ]] || {
+      echo "The selected Bluetooth device is not paired and trusted." >&2
+      exit 1
+    }
+    [[ $info == *"00001812-0000-1000-8000-00805f9b34fb"* || $info == *"00001124-0000-1000-8000-00805f9b34fb"* ]] || {
+      echo "The selected Bluetooth device is not a keyboard." >&2
+      exit 1
+    }
+    name=$(sed -n 's/^[[:space:]]*Name: //p' <<<"$info" | head -1 | tr '\t\r\n' '   ' | sed 's/[[:space:]]*$//')
+  else
+    name="Bluetooth keyboard"
+  fi
+fi
+
+device=$(normalize_address "$device")
+if [[ -z $controller ]]; then
+  controller=$(timeout 3s bluetoothctl show 2>/dev/null | awk '/^Controller / {print $2; exit}')
+fi
+valid_address "$controller" || { echo "Could not determine the Bluetooth controller address." >&2; exit 1; }
+controller=$(normalize_address "$controller")
+
+if ! sudo test -d "$state_dir/$controller/$device"; then
+  echo "The bond for $name is missing from BlueZ system storage." >&2
+  exit 1
+fi
+if sudo test -L "$state_dir/$controller" || sudo test -L "$state_dir/$controller/$device"; then
+  echo "Refusing unsafe symlinks in BlueZ system storage." >&2
+  exit 1
+fi
+
+if ! $assume_yes; then
+  echo
+  echo "This adds $name to the boot image so it can connect before LUKS asks for your disk password."
+  echo "Its Bluetooth bond key will be stored on the unencrypted EFI System Partition."
+  echo "Bluetooth can fail because of radio interference, firmware, batteries, or hardware changes."
+  echo "Keep a wired or 2.4 GHz keyboard available as a recovery method."
+  echo
+  gum confirm "Enable Bluetooth keyboard disk unlock?" || exit 0
+fi
+
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT
+install -Dm755 "$OMARCHY_PATH/default/initcpio/install/omarchy-bluetooth-unlock" "$stage/install/omarchy-bluetooth-unlock"
+install -Dm755 "$OMARCHY_PATH/default/initcpio/hooks/omarchy-bluetooth-unlock" "$stage/hooks/omarchy-bluetooth-unlock"
+install -Dm644 "$OMARCHY_PATH/default/initcpio/omarchy-bluetooth-unlock.conf" "$stage/zz-omarchy-bluetooth-unlock.conf"
+printf 'CONTROLLER=%s\nDEVICE=%s\nNAME=%s\n' "$controller" "$device" "$name" >"$stage/bluetooth-unlock.conf"
+
+sudo install -d -m 0755 "$config_dir" "$mkinitcpio_dir" "$initcpio_dir/install" "$initcpio_dir/hooks"
+sudo install -m 0755 "$stage/install/omarchy-bluetooth-unlock" "$install_hook"
+sudo install -m 0755 "$stage/hooks/omarchy-bluetooth-unlock" "$runtime_hook"
+sudo install -m 0644 "$stage/zz-omarchy-bluetooth-unlock.conf" "$hook_dropin"
+sudo install -m 0600 "$stage/bluetooth-unlock.conf" "$config_file"
+
+rebuild
+echo "Bluetooth disk unlock is enabled for $name."
+echo "Test it on the next reboot, with a wired or 2.4 GHz keyboard nearby for recovery."

--- a/default/initcpio/hooks/omarchy-bluetooth-unlock
+++ b/default/initcpio/hooks/omarchy-bluetooth-unlock
@@ -4,8 +4,12 @@ run_hook() {
   local waited=0
 
   mkdir -p /run/dbus /run/bluetooth
-  dbus-daemon --system
-/usr/lib/bluetooth/bluetoothd --nodetach >/dev/null 2>&1 &
+  if ! dbus-daemon --system --print-pid > /run/bluetooth/omarchy-dbus.pid; then
+    echo "Bluetooth disk unlock: D-Bus failed; use a wired or 2.4 GHz keyboard." >&2
+    rm -f /run/bluetooth/omarchy-dbus.pid
+    return 0
+  fi
+  /usr/lib/bluetooth/bluetoothd --nodetach >/dev/null 2>&1 &
   echo "$!" >/run/bluetooth/omarchy-bluetoothd.pid
 
   # Give udev and the adapter firmware a short head start. Do not block the
@@ -18,11 +22,32 @@ run_hook() {
   done
 }
 
-run_cleanuphook() {
-  if [ -s /run/bluetooth/omarchy-bluetoothd.pid ]; then
-    kill "$(cat /run/bluetooth/omarchy-bluetoothd.pid)" 2>/dev/null || true
+# /run survives switch_root. Stop our daemons before the real system starts
+# BlueZ and D-Bus, and remove the old bus socket and pid file.
+omarchy_bluetooth_stop() {
+  local pid waited=0
+  [ -s "$1" ] || return 0
+  read -r pid <"$1"
+  case "$pid" in
+    '' | *[!0-9]*) return 0 ;;
+  esac
+  [ "$pid" -gt 1 ] || return 0
+  kill "$pid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt 30 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null || true
   fi
-  if [ -s /run/dbus/pid ]; then
-    kill "$(cat /run/dbus/pid)" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  rm -f "$1"
+}
+
+run_cleanuphook() {
+  omarchy_bluetooth_stop /run/bluetooth/omarchy-bluetoothd.pid
+  if [ -s /run/bluetooth/omarchy-dbus.pid ]; then
+    omarchy_bluetooth_stop /run/bluetooth/omarchy-dbus.pid
+    rm -f /run/dbus/pid /run/dbus/system_bus_socket
   fi
 }

--- a/default/initcpio/hooks/omarchy-bluetooth-unlock
+++ b/default/initcpio/hooks/omarchy-bluetooth-unlock
@@ -5,7 +5,7 @@ run_hook() {
 
   mkdir -p /run/dbus /run/bluetooth
   dbus-daemon --system
-  /usr/lib/bluetooth/bluetoothd >/dev/null 2>&1 &
+/usr/lib/bluetooth/bluetoothd --nodetach >/dev/null 2>&1 &
   echo "$!" >/run/bluetooth/omarchy-bluetoothd.pid
 
   # Give udev and the adapter firmware a short head start. Do not block the

--- a/default/initcpio/hooks/omarchy-bluetooth-unlock
+++ b/default/initcpio/hooks/omarchy-bluetooth-unlock
@@ -1,0 +1,28 @@
+#!/usr/bin/ash
+
+run_hook() {
+  local waited=0
+
+  mkdir -p /run/dbus /run/bluetooth
+  dbus-daemon --system
+  /usr/lib/bluetooth/bluetoothd >/dev/null 2>&1 &
+  echo "$!" >/run/bluetooth/omarchy-bluetoothd.pid
+
+  # Give udev and the adapter firmware a short head start. Do not block the
+  # recovery path indefinitely: a wired keyboard must always reach cryptsetup.
+  set -- /sys/class/bluetooth/hci*
+  while [ ! -e "$1" ] && [ "$waited" -lt 30 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+    set -- /sys/class/bluetooth/hci*
+  done
+}
+
+run_cleanuphook() {
+  if [ -s /run/bluetooth/omarchy-bluetoothd.pid ]; then
+    kill "$(cat /run/bluetooth/omarchy-bluetoothd.pid)" 2>/dev/null || true
+  fi
+  if [ -s /run/dbus/pid ]; then
+    kill "$(cat /run/dbus/pid)" 2>/dev/null || true
+  fi
+}

--- a/default/initcpio/install/omarchy-bluetooth-unlock
+++ b/default/initcpio/install/omarchy-bluetooth-unlock
@@ -17,7 +17,8 @@ build() {
     error "Bluetooth unlock bond is missing or unsafe: %s" "$device_dir"
     return 1
   fi
-  if find "$device_dir" -type l -print -quit | grep -q .; then
+  if [[ -L $controller_dir/settings || -L $controller_dir/identity || -L $controller_dir/cache ]] ||
+    find "$device_dir" -type l -print -quit | grep -q .; then
     error "Bluetooth unlock bond contains an unsafe symlink: %s" "$device_dir"
     return 1
   fi
@@ -49,8 +50,10 @@ build() {
   add_file /usr/share/dbus-1/system.conf
   add_file /usr/share/dbus-1/system.d/bluetooth.conf
   add_file /etc/machine-id
-  add_file /etc/bluetooth/main.conf
-  add_file /etc/bluetooth/input.conf
+  # Boot needs only bonded input devices. Do not inherit host pairing or
+  # experimental settings, and power the controller without a desktop client.
+  printf '[General]\nAlwaysPairable=false\n[Policy]\nAutoEnable=true\n' | add_file - /etc/bluetooth/main.conf 0644
+  printf '[General]\nClassicBondedOnly=true\n' | add_file - /etc/bluetooth/input.conf 0644
 
   # dbus-daemon drops privileges by numeric uid/gid. Build a minimal account
   # database rather than copying the host's passwd, group, or shadow database
@@ -69,8 +72,8 @@ build() {
   # mkinitcpio otherwise creates copied directories as 0755.
   add_dir /var/lib/bluetooth 0700
   add_dir "$controller_dir" 0700
-  [[ -f $controller_dir/settings ]] && add_file "$controller_dir/settings"
-  [[ -f $controller_dir/identity ]] && add_file "$controller_dir/identity"
+  [[ -f $controller_dir/settings ]] && add_file "$controller_dir/settings" "$controller_dir/settings" 0600
+  [[ -f $controller_dir/identity ]] && add_file "$controller_dir/identity" "$controller_dir/identity" 0600
   add_full_dir "$device_dir"
   chmod 0700 "$BUILDROOT/var/lib/bluetooth" "$BUILDROOT$controller_dir" "$BUILDROOT$device_dir"
 

--- a/default/initcpio/install/omarchy-bluetooth-unlock
+++ b/default/initcpio/install/omarchy-bluetooth-unlock
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+build() {
+  local config=${OMARCHY_BLUETOOTH_UNLOCK_CONFIG:-/etc/omarchy/bluetooth-unlock.conf}
+  local controller device controller_dir device_dir firmware
+
+  controller=$(sed -n 's/^CONTROLLER=//p' "$config")
+  device=$(sed -n 's/^DEVICE=//p' "$config")
+  if [[ ! $controller =~ ^([0-9A-F]{2}:){5}[0-9A-F]{2}$ || ! $device =~ ^([0-9A-F]{2}:){5}[0-9A-F]{2}$ ]]; then
+    error "invalid Bluetooth unlock configuration: %s" "$config"
+    return 1
+  fi
+
+  controller_dir="/var/lib/bluetooth/$controller"
+  device_dir="$controller_dir/$device"
+  if [[ ! -d $device_dir || -L $controller_dir || -L $device_dir ]]; then
+    error "Bluetooth unlock bond is missing or unsafe: %s" "$device_dir"
+    return 1
+  fi
+  if find "$device_dir" -type l -print -quit | grep -q .; then
+    error "Bluetooth unlock bond contains an unsafe symlink: %s" "$device_dir"
+    return 1
+  fi
+
+  # Bluetooth HID can arrive over USB, UART, or platform-specific transports.
+  # autodetect, which runs before this hook in Omarchy's HOOKS, filters this to
+  # the adapter present on the machine. add_module also follows dependencies.
+  add_checked_modules '/drivers/bluetooth/'
+  add_module 'bluetooth'
+  add_module 'uhid'
+  add_module 'hidp?'
+
+  # Some Bluetooth drivers construct firmware names at runtime instead of
+  # exposing them through modinfo. The complete common Bluetooth firmware set
+  # is small enough to include and avoids a boot-only failure on Intel,
+  # Realtek, MediaTek, Qualcomm, and Broadcom adapters.
+  for firmware in \
+    /usr/lib/firmware/intel/ibt-* \
+    /usr/lib/firmware/rtl_bt/* \
+    /usr/lib/firmware/mediatek/*BT* \
+    /usr/lib/firmware/mediatek/*/*BT* \
+    /usr/lib/firmware/qca/* \
+    /usr/lib/firmware/brcm/BCM*.hcd*; do
+    [[ -f $firmware ]] && add_file "$firmware"
+  done
+
+  add_binary /usr/bin/dbus-daemon
+  add_binary /usr/lib/bluetooth/bluetoothd
+  add_file /usr/share/dbus-1/system.conf
+  add_file /usr/share/dbus-1/system.d/bluetooth.conf
+  add_file /etc/machine-id
+  add_file /etc/bluetooth/main.conf
+  add_file /etc/bluetooth/input.conf
+
+  # dbus-daemon drops privileges by numeric uid/gid. Build a minimal account
+  # database rather than copying the host's passwd, group, or shadow database
+  # into the unencrypted boot image.
+  {
+    getent passwd root
+    getent passwd dbus
+  } | add_file - /etc/passwd 0644
+  {
+    getent group root
+    getent group dbus
+  } | add_file - /etc/group 0644
+
+  # Copy only the selected keyboard's bond, not every paired phone, headset,
+  # or controller. Directory modes are tightened after add_full_dir because
+  # mkinitcpio otherwise creates copied directories as 0755.
+  add_dir /var/lib/bluetooth 0700
+  add_dir "$controller_dir" 0700
+  [[ -f $controller_dir/settings ]] && add_file "$controller_dir/settings"
+  [[ -f $controller_dir/identity ]] && add_file "$controller_dir/identity"
+  add_full_dir "$device_dir"
+  chmod 0700 "$BUILDROOT/var/lib/bluetooth" "$BUILDROOT$controller_dir" "$BUILDROOT$device_dir"
+
+  if [[ -f $controller_dir/cache/$device && ! -L $controller_dir/cache/$device ]]; then
+    add_dir "$controller_dir/cache" 0700
+    add_file "$controller_dir/cache/$device"
+  fi
+
+  add_runscript
+}
+
+help() {
+  cat <<'EOF'
+Starts a minimal D-Bus and BlueZ environment before the encrypted-root prompt,
+using one explicitly selected and already bonded Bluetooth keyboard.
+EOF
+}

--- a/default/initcpio/omarchy-bluetooth-unlock.conf
+++ b/default/initcpio/omarchy-bluetooth-unlock.conf
@@ -1,0 +1,13 @@
+# Insert the Bluetooth runtime immediately before the encrypted-root prompt.
+# This drop-in sorts after Omarchy's canonical HOOKS assignment and preserves
+# every unrelated hook another hardware or feature drop-in added.
+_omarchy_bluetooth_unlock_hooks=()
+for _omarchy_bluetooth_unlock_hook in "${HOOKS[@]}"; do
+  [[ $_omarchy_bluetooth_unlock_hook == "omarchy-bluetooth-unlock" ]] && continue
+  if [[ $_omarchy_bluetooth_unlock_hook == "encrypt" ]]; then
+    _omarchy_bluetooth_unlock_hooks+=(omarchy-bluetooth-unlock)
+  fi
+  _omarchy_bluetooth_unlock_hooks+=("$_omarchy_bluetooth_unlock_hook")
+done
+HOOKS=("${_omarchy_bluetooth_unlock_hooks[@]}")
+unset _omarchy_bluetooth_unlock_hooks _omarchy_bluetooth_unlock_hook

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -177,6 +177,7 @@
   "setup.config": {"icon":"","label":"Config"},
   "setup.security.fingerprint": {"icon":"󰈷","label":"Fingerprint","when":"omarchy-hw-fingerprint","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint"},
   "setup.security.fido2": {"icon":"","label":"Fido2","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fido2"},
+  "setup.security.bluetooth-unlock": {"icon":"󰂯","label":"Bluetooth Disk Unlock","when":"[[ -d /sys/class/bluetooth ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-bluetooth-unlock"},
   "setup.security.sshd": {"icon":"󰣀","label":"SSHD","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-sshd"},
   "setup.security.passwordless-sudo": {"icon":"󰟵","label":"Passwordless Sudo","action":"omarchy-launch-floating-terminal-with-presentation omarchy-sudo-passwordless"},
   "setup.security.sudoless-docker": {"icon":"󰡨","label":"Sudoless Docker","when":"omarchy-sudo-docker --configured","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-sudoless-docker"},

--- a/manual/02-getting-started.md
+++ b/manual/02-getting-started.md
@@ -22,6 +22,8 @@ The installer cannot use a Bluetooth keyboard until the live system has paired w
 
 After installation, a paired Bluetooth keyboard can be added to the encrypted-disk unlock environment with Setup > Security > Bluetooth Disk Unlock. This is opt-in: the keyboard's Bluetooth bond key is copied to the unencrypted boot image, and radio or battery trouble can still prevent it connecting. Keep a wired or 2.4ghz recovery keyboard available.
 
+Setup rebuilds the boot image before reporting success. If rebuilding fails, setup restores the previous configuration, but a partially written boot image may still need repair: fix the reported error and run `sudo limine-mkinitcpio` before rebooting. The `status` command checks configuration only. The installer's `--no-rebuild` option defers boot-image generation; it does not verify that the keyboard can unlock the disk. Test the next boot with your recovery keyboard available.
+
 ### Installing for another owner
 
 If you're setting up a machine for someone else — a family member, a new employee, a buyer — you shouldn't be answering the personal questions on their behalf. Hit `Ctrl + C` on the very first screen of the installer (the keyboard selection), and Omarchy will offer to prepare the machine for another owner instead. The system installs right away, but all the personal setup — keyboard layout, username, password — is deferred until the machine boots for the first time. The drive is still encrypted by default, and the password the new owner picks on that first boot becomes the encryption password too. (A machine you've already been using can be handed over without a reinstall too — see [resetting the computer](48-security.md).)

--- a/manual/02-getting-started.md
+++ b/manual/02-getting-started.md
@@ -16,9 +16,11 @@ Then select a drive for your installation, and sit back and watch the installati
 
 Now you're ready to Omarchy!
 
-### Use a wired or 2.4ghz keyboard!
+### Use a wired or 2.4ghz keyboard for installation
 
-The full-disk encryption won't allow you to enter the password from a Bluetooth keyboard at startup. Just like you can't use a Bluetooth keyboard to enter the BIOS on a PC. You'll need a keyboard that either uses a 2.4ghz dongle or a cable (which is much nicer for latency anyway!). I personally love the [Lofree Flow84](https://www.lofree.co/products/lofree-flow-the-smoothest-mechanical-keyboard)!
+The installer cannot use a Bluetooth keyboard until the live system has paired with it, and firmware menus cannot use it at all. Keep a cable or 2.4ghz receiver available while installing.
+
+After installation, a paired Bluetooth keyboard can be added to the encrypted-disk unlock environment with Setup > Security > Bluetooth Disk Unlock. This is opt-in: the keyboard's Bluetooth bond key is copied to the unencrypted boot image, and radio or battery trouble can still prevent it connecting. Keep a wired or 2.4ghz recovery keyboard available.
 
 ### Installing for another owner
 

--- a/test/shell.d/bluetooth-unlock-test.sh
+++ b/test/shell.d/bluetooth-unlock-test.sh
@@ -16,7 +16,7 @@ mkdir -p \
   "$test_dir/etc/mkinitcpio.conf.d" \
   "$test_dir/usr/lib/initcpio/install" \
   "$test_dir/usr/lib/initcpio/hooks"
-printf '[General]\nName=Test keyboard\n' >"$test_dir/state/$controller/$device/info"
+printf '[General]\nName=Test keyboard\nClass=0x002540\nTrusted=true\n[LinkKey]\nKey=00000000000000000000000000000000\n' >"$test_dir/state/$controller/$device/info"
 printf 'HOOKS=(base udev keyboard encrypt filesystems)\n' >"$test_dir/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
 
 cat >"$test_dir/bin/sudo" <<'EOF'
@@ -36,6 +36,11 @@ cat >"$test_dir/bin/omarchy-cmd-missing" <<'EOF'
 exit 1
 EOF
 
+cat >"$test_dir/bin/limine-mkinitcpio" <<'EOF'
+#!/bin/bash
+exit "${REBUILD_RESULT:-0}"
+EOF
+
 cat >"$test_dir/bin/gum" <<'EOF'
 #!/bin/bash
 exit 0
@@ -48,6 +53,7 @@ run_setup() {
     OMARCHY_PATH="$ROOT" \
     OMARCHY_BLUETOOTH_UNLOCK_CONFIG_DIR="$test_dir/etc/omarchy" \
     OMARCHY_BLUETOOTH_UNLOCK_MKINITCPIO_DIR="$test_dir/etc/mkinitcpio.conf.d" \
+    OMARCHY_BLUETOOTH_UNLOCK_MKINITCPIO_CONFIG="$test_dir/etc/mkinitcpio.conf" \
     OMARCHY_BLUETOOTH_UNLOCK_INITCPIO_DIR="$test_dir/usr/lib/initcpio" \
     OMARCHY_BLUETOOTH_UNLOCK_STATE_DIR="$test_dir/state" \
     "$ROOT/bin/omarchy-setup-security-bluetooth-unlock" "$@"
@@ -92,3 +98,103 @@ run_setup disable --yes --no-rebuild >/dev/null
 [[ ! -e $config && ! -e $dropin && ! -e $install_hook && ! -e $runtime_hook ]] ||
   fail "Bluetooth unlock disable removes every installed component"
 pass "Bluetooth unlock disable removes every installed component"
+
+# A failed build must not leave the next package update using broken settings.
+if REBUILD_RESULT=1 run_setup enable --device "$device" --controller "$controller" --yes >/dev/null 2>&1; then
+  fail "Bluetooth unlock propagates a failed image rebuild"
+fi
+[[ ! -e $config && ! -e $dropin && ! -e $install_hook && ! -e $runtime_hook ]] ||
+  fail "Failed first enable restores the disabled configuration"
+pass "Failed first enable restores the disabled configuration"
+
+run_setup enable --device "$device" --controller "$controller" --yes --no-rebuild >/dev/null
+printf '
+# Preserve existing configuration
+' >>"$config"
+cp "$config" "$test_dir/expected-config"
+if REBUILD_RESULT=1 run_setup disable --yes >/dev/null 2>&1; then
+  fail "Bluetooth unlock propagates a failed disable rebuild"
+fi
+cmp -s "$config" "$test_dir/expected-config" && [[ $(stat -c %a "$config") == "600" && -f $dropin && -x $install_hook && -x $runtime_hook ]] ||
+  fail "Failed disable restores the previous configuration and modes"
+pass "Failed disable restores the previous configuration and modes"
+
+if REBUILD_RESULT=1 run_setup enable --device "$device" --controller "$controller" --yes >/dev/null 2>&1; then
+  fail "Bluetooth unlock propagates a failed re-enable rebuild"
+fi
+cmp -s "$config" "$test_dir/expected-config" || fail "Failed re-enable restores the previous device selection"
+pass "Failed re-enable restores the previous device selection"
+
+rm "$runtime_hook"
+run_setup disable --yes --no-rebuild >/dev/null
+[[ ! -e $config && ! -e $dropin && ! -e $install_hook ]] || fail "Disable removes a partial installation"
+pass "Disable removes a partial installation"
+
+printf 'HOOKS=(base systemd keyboard sd-encrypt filesystems)\n' >"$test_dir/etc/mkinitcpio.conf.d/zz_override.conf"
+if run_setup enable --device "$device" --controller "$controller" --yes --no-rebuild >/dev/null 2>&1; then
+  fail "Setup rejects a later override that replaces encrypt"
+fi
+[[ ! -e $config ]] || fail "Unsupported hooks leave configuration unchanged"
+pass "Setup checks effective hooks rather than a superseded assignment"
+rm "$test_dir/etc/mkinitcpio.conf.d/zz_override.conf"
+
+if run_setup enable --device >/dev/null 2>&1; then
+  fail "Setup rejects a missing device argument"
+fi
+pass "Setup rejects a missing device argument"
+
+printf 'HOOKS=(base udev keyboard encrypt filesystems)\n' >"$test_dir/etc/mkinitcpio.conf.d/zz_override.conf"
+if run_setup enable --device "$device" --controller "$controller" --yes --no-rebuild >/dev/null 2>&1; then
+  fail "Setup rejects a later override that drops the Bluetooth hook"
+fi
+pass "Setup rejects a later override that drops the Bluetooth hook"
+rm "$test_dir/etc/mkinitcpio.conf.d/zz_override.conf"
+
+# Run the actual hook with filesystem paths redirected and process control
+# stubbed. No host bus, adapter, daemon, or PID is touched.
+sed -e "s|/run/|$test_dir/run/|g" \
+  -e "s|/sys/class/bluetooth|$test_dir/sys/class/bluetooth|g" \
+  -e "s|/usr/lib/bluetooth/bluetoothd|bluetoothd|g" \
+  "$ROOT/default/initcpio/hooks/omarchy-bluetooth-unlock" >"$test_dir/runtime-hook"
+cat >"$test_dir/bin/dbus-daemon" <<'EOF'
+#!/bin/bash
+[[ ${DBUS_FAIL:-0} == 0 ]] || exit 1
+touch "$TEST_DIR/run/dbus/pid" "$TEST_DIR/run/dbus/system_bus_socket"
+echo 424242
+EOF
+chmod +x "$test_dir/bin/dbus-daemon"
+cat >"$test_dir/runtime-test" <<'EOF'
+#!/bin/sh
+set -eu
+. "$TEST_DIR/runtime-hook"
+bluetoothd() { echo "$*" >"$TEST_DIR/bluetooth-args"; }
+kill() { echo "$*" >>"$TEST_DIR/kill-log"; return 1; }
+sleep() { echo "$*" >>"$TEST_DIR/sleep-log"; }
+run_hook
+# Wait for the harmless background stub to finish before inspecting its log.
+wait
+run_cleanuphook
+EOF
+if [[ -x /usr/lib/initcpio/busybox ]]; then
+  PATH="$test_dir/bin:$PATH" TEST_DIR="$test_dir" /usr/lib/initcpio/busybox ash "$test_dir/runtime-test"
+  grep -Fxq -- '--nodetach' "$test_dir/bluetooth-args" || fail "Runtime keeps bluetoothd in the foreground for PID tracking"
+  [[ $(wc -l <"$test_dir/sleep-log") == 30 ]] || fail "Runtime bounds adapter discovery to three seconds"
+  [[ ! -e $test_dir/run/dbus/pid && ! -e $test_dir/run/dbus/system_bus_socket && ! -e $test_dir/run/bluetooth/omarchy-bluetoothd.pid ]] ||
+    fail "Runtime removes its bus and daemon state before switch_root"
+  pass "Runtime bounds adapter discovery and cleans up its own bus before switch_root"
+  rm "$test_dir/bluetooth-args"
+  DBUS_FAIL=1 PATH="$test_dir/bin:$PATH" TEST_DIR="$test_dir" /usr/lib/initcpio/busybox ash "$test_dir/runtime-test" 2>/dev/null
+  [[ ! -e $test_dir/bluetooth-args ]] || fail "Runtime does not start BlueZ when D-Bus fails"
+  pass "Runtime preserves the recovery path when D-Bus fails"
+else
+  echo "# SKIP: mkinitcpio BusyBox is unavailable; runtime lifecycle is unverified"
+fi
+
+sed -i 's/Class=0x002540/Class=0x002580/' "$test_dir/state/$controller/$device/info"
+if run_setup enable --device "$device" --controller "$controller" --yes --no-rebuild >/dev/null 2>&1; then
+  fail "Setup rejects a trusted mouse bond"
+fi
+pass "Setup rejects a trusted mouse bond"
+sed -i 's/Class=0x002580/Appearance=0x03c1/' "$test_dir/state/$controller/$device/info"
+run_setup enable --device "$device" --controller "$controller" --yes --no-rebuild >/dev/null
+pass "Setup accepts a trusted BLE keyboard bond without a running target D-Bus"

--- a/test/shell.d/bluetooth-unlock-test.sh
+++ b/test/shell.d/bluetooth-unlock-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+controller="00:11:22:33:44:55"
+device="AA:BB:CC:DD:EE:FF"
+mkdir -p \
+  "$test_dir/bin" \
+  "$test_dir/state/$controller/$device" \
+  "$test_dir/etc/omarchy" \
+  "$test_dir/etc/mkinitcpio.conf.d" \
+  "$test_dir/usr/lib/initcpio/install" \
+  "$test_dir/usr/lib/initcpio/hooks"
+printf '[General]\nName=Test keyboard\n' >"$test_dir/state/$controller/$device/info"
+printf 'HOOKS=(base udev keyboard encrypt filesystems)\n' >"$test_dir/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
+
+cat >"$test_dir/bin/sudo" <<'EOF'
+#!/bin/bash
+exec "$@"
+EOF
+
+cat >"$test_dir/bin/bluetoothctl" <<'EOF'
+#!/bin/bash
+# An explicit controller/device pair lets the ISO configure the target after
+# copying its live BlueZ bond, before the target's D-Bus is running.
+exit 0
+EOF
+
+cat >"$test_dir/bin/omarchy-cmd-missing" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+
+cat >"$test_dir/bin/gum" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+chmod +x "$test_dir/bin/"*
+
+run_setup() {
+  PATH="$test_dir/bin:$PATH" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_BLUETOOTH_UNLOCK_CONFIG_DIR="$test_dir/etc/omarchy" \
+    OMARCHY_BLUETOOTH_UNLOCK_MKINITCPIO_DIR="$test_dir/etc/mkinitcpio.conf.d" \
+    OMARCHY_BLUETOOTH_UNLOCK_INITCPIO_DIR="$test_dir/usr/lib/initcpio" \
+    OMARCHY_BLUETOOTH_UNLOCK_STATE_DIR="$test_dir/state" \
+    "$ROOT/bin/omarchy-setup-security-bluetooth-unlock" "$@"
+}
+
+run_setup enable --device "$device" --controller "$controller" --yes --no-rebuild >/dev/null
+
+config="$test_dir/etc/omarchy/bluetooth-unlock.conf"
+dropin="$test_dir/etc/mkinitcpio.conf.d/zz-omarchy-bluetooth-unlock.conf"
+install_hook="$test_dir/usr/lib/initcpio/install/omarchy-bluetooth-unlock"
+runtime_hook="$test_dir/usr/lib/initcpio/hooks/omarchy-bluetooth-unlock"
+
+[[ -f $config && -f $dropin && -x $install_hook && -x $runtime_hook ]] ||
+  fail "Bluetooth unlock setup installs its complete boot configuration"
+pass "Bluetooth unlock setup installs its complete boot configuration"
+
+grep -Fxq "CONTROLLER=$controller" "$config" || fail "Bluetooth unlock records the selected controller"
+grep -Fxq "DEVICE=$device" "$config" || fail "Bluetooth unlock records the selected keyboard"
+[[ $(stat -c %a "$config") == "600" ]] || fail "Bluetooth unlock protects its device selection"
+pass "Bluetooth unlock records only the selected bond with protected configuration"
+
+resolved_hooks=$(bash -uc "HOOKS=(base udev keyboard resume encrypt filesystems); source '$dropin'; echo \"\${HOOKS[*]}\"")
+[[ $resolved_hooks == "base udev keyboard resume omarchy-bluetooth-unlock encrypt filesystems" ]] ||
+  fail "Bluetooth unlock is inserted immediately before encrypt" "$resolved_hooks"
+pass "Bluetooth unlock is inserted immediately before encrypt"
+
+resolved_hooks=$(bash -uc "HOOKS=(base udev keyboard omarchy-bluetooth-unlock block encrypt filesystems); source '$dropin'; echo \"\${HOOKS[*]}\"")
+[[ $resolved_hooks == "base udev keyboard block omarchy-bluetooth-unlock encrypt filesystems" ]] ||
+  fail "Bluetooth unlock is not duplicated on repeated setup" "$resolved_hooks"
+pass "Bluetooth unlock is not duplicated on repeated setup"
+
+! grep -Rq '/etc/shadow\|add_full_dir[[:space:]]\+/var/lib/bluetooth$' "$ROOT/default/initcpio" ||
+  fail "Bluetooth unlock does not copy password hashes or every Bluetooth bond"
+grep -Fq 'add_full_dir "$device_dir"' "$install_hook" ||
+  fail "Bluetooth unlock copies only the selected device directory"
+pass "Bluetooth unlock excludes password hashes and unrelated Bluetooth bonds"
+
+run_setup status >/dev/null || fail "Bluetooth unlock reports enabled status"
+pass "Bluetooth unlock reports enabled status"
+
+run_setup disable --yes --no-rebuild >/dev/null
+[[ ! -e $config && ! -e $dropin && ! -e $install_hook && ! -e $runtime_hook ]] ||
+  fail "Bluetooth unlock disable removes every installed component"
+pass "Bluetooth unlock disable removes every installed component"


### PR DESCRIPTION
## Why

Bluetooth normally becomes available only after the encrypted root filesystem
has been unlocked and the regular BlueZ service starts. A paired Bluetooth
keyboard therefore cannot enter the LUKS passphrase, forcing users to keep a
second keyboard, receiver, or data-capable cable available for every boot.

This is especially limiting for Bluetooth-only keyboards and machines without
a suitable free USB port. It is also distinct from the graphical login screen:
the missing capability is in the early boot environment, before the installed
system can start its normal services.

This explores the implementation requested in
[Discussion #6240](https://github.com/omacom/omarchy/discussions/6240).

## What changes

- Add `Setup > Security > Bluetooth Disk Unlock` as an explicit enable/disable
  control. The placement is practical rather than prescriptive; the primary
  change is the early-boot capability.
- Let the user select one already paired and trusted Bluetooth HID keyboard.
- Install a native mkinitcpio hook immediately before Omarchy's `encrypt` hook.
- Start a minimal D-Bus and BlueZ environment while LUKS is waiting.
- Include Bluetooth HID modules and common Intel, Realtek, MediaTek, Qualcomm,
  and Broadcom Bluetooth firmware.
- Copy only the selected keyboard bond and controller metadata into the boot
  image, rather than the complete BlueZ database.
- Provide `enable`, `disable`, and `status` operations and rebuild the Limine
  boot image when the state changes.

The current implementation deliberately targets Omarchy's classic `encrypt`
mkinitcpio flow and fails clearly for unsupported hook layouts.

## Security and recovery

Enabling this places the selected keyboard's Bluetooth bond material in the
boot image on the unencrypted EFI System Partition. The setup command explains
this before making changes and recommends keeping wired or 2.4 GHz input
available for recovery. Bluetooth can still fail because of batteries, radio
interference, firmware, or adapter changes.

The hook creates a minimal `passwd`/`group` database containing only root and
D-Bus. It never copies `/etc/shadow`, and it does not copy bonds belonging to
phones, headphones, or other input devices.

## Failure handling

Setup validates the effective mkinitcpio hook order before changing files. Failed setup or removal restores the previous configuration and permissions, including partially installed configurations. A failed boot-image rebuild can still leave an incomplete image; the command explicitly requires repairing and rebuilding it before rebooting. Configuration rollback does not restore boot-image contents.

`status` reports configuration state, not a verified image or keyboard connection. `--no-rebuild` stages configuration for the installer's final image build and reports that distinction.

## Validation

- Focused setup and runtime regression tests: `bash test/shell.d/bluetooth-unlock-test.sh`.
- CLI routing and metadata: `./test/cli`.
- Bash syntax, BusyBox ash runtime fixtures, and `git diff --check`.

Regression coverage includes failed enable/re-enable/disable rebuilds, partial installation removal, effective hook ordering, daemon cleanup, and D-Bus startup failure. Runtime fixtures isolate filesystem paths and mock process control; they do not exercise Bluetooth hardware.

## Remaining verification

This PR is open for review. Real encrypted-hardware boot/reconnection, adapter firmware coverage, recovery after a failed image build, and the running Setup > Security menu with and without an adapter remain unverified. Do not interpret the automated checks as hardware or UI acceptance.
