### PR TITLE
Recover stale fprintd after suspend

### DIFF
--- a/bin/omarchy-remove-security-fingerprint
+++ b/bin/omarchy-remove-security-fingerprint
@@ -27,11 +27,19 @@ remove_lock_fingerprint_pam() {
   fi
 }
 
+remove_resume_recovery() {
+  if [[ -f /usr/lib/systemd/system-sleep/fprintd-resume-stop ]]; then
+    echo "Removing fingerprint recovery after resume..."
+    sudo rm -f /usr/lib/systemd/system-sleep/fprintd-resume-stop
+  fi
+}
+
 
 echo -e "\e[32mRemoving fingerprint scanner from authentication.\n\e[0m"
 
 remove_pam_config
 remove_lock_fingerprint_pam
+remove_resume_recovery
 
 echo "Removing fingerprint packages..."
 omarchy-pkg-drop fprintd libfprint libfprint-git

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -62,6 +62,13 @@ account    include                     system-local-login
 EOF
 }
 
+install_resume_recovery() {
+  echo "Installing fingerprint recovery after resume..."
+  sudo install -Dm755 \
+    "$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume-stop" \
+    /usr/lib/systemd/system-sleep/fprintd-resume-stop
+}
+
 
 echo -e "\e[32mSetting up fingerprint scanner for authentication.\n\e[0m"
 
@@ -100,6 +107,7 @@ if sudo fprintd-enroll "$USER"; then
     # pam_fprintd with nothing to match.
     setup_pam_config
     setup_lock_fingerprint_pam
+    install_resume_recovery
     echo -e "\e[32m\nPerfect! Fingerprint authentication is now configured.\e[0m"
     echo "You can use your fingerprint for sudo, polkit, and lock screen (Super + Ctrl + L)."
   else

--- a/default/systemd/system-sleep/fprintd-resume-stop
+++ b/default/systemd/system-sleep/fprintd-resume-stop
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# A fingerprint verification that races suspend can leave fprintd alive with a
+# stale device claim. The lock screen then receives PAM_AUTHINFO_UNAVAIL on
+# every retry after resume even though the reader itself is healthy.
+#
+# Record the daemon before sleep, then stop it after resume only if that exact
+# process survived. The PID check leaves a daemon newly started by some other
+# system component alone. The lock screen's next D-Bus request starts a fresh
+# fprintd against the fully resumed reader, so the hook does not wait for USB
+# probing while user.slice is frozen.
+
+state_file="${OMARCHY_FPRINTD_SLEEP_STATE:-/run/omarchy-fprintd-sleep.pid}"
+
+log_recovery() {
+  logger -t omarchy-fprintd-resume -- "$*" 2>/dev/null || true
+}
+
+case "$1" in
+  pre)
+    fprintd_pid=$(systemctl show --property MainPID --value fprintd.service 2>/dev/null || true)
+    if [[ $fprintd_pid =~ ^[1-9][0-9]*$ ]]; then
+      printf '%s\n' "$fprintd_pid" >"$state_file"
+    else
+      rm -f "$state_file"
+    fi
+    ;;
+  post)
+    [[ -r $state_file ]] || exit 0
+    read -r sleeping_pid <"$state_file"
+    rm -f "$state_file"
+
+    current_pid=$(systemctl show --property MainPID --value fprintd.service 2>/dev/null || true)
+    if [[ $current_pid == "$sleeping_pid" ]]; then
+      # Omarchy bounds service stops at five seconds. Keep a separate outer
+      # bound so an unexpected systemd delay cannot freeze the desktop forever.
+      if timeout 6s systemctl stop fprintd.service 2>/dev/null; then
+        log_recovery "Stopped fprintd PID $sleeping_pid after $2 resume"
+      else
+        log_recovery "Failed to stop fprintd PID $sleeping_pid after $2 resume"
+      fi
+    fi
+    ;;
+esac

--- a/migrations/1787689809.sh
+++ b/migrations/1787689809.sh
@@ -1,0 +1,12 @@
+echo "Install fingerprint recovery after resume"
+
+hook_src="${OMARCHY_FPRINTD_RESUME_SRC:-$OMARCHY_PATH/default/systemd/system-sleep/fprintd-resume-stop}"
+hook_dst="${OMARCHY_FPRINTD_RESUME_DST:-/usr/lib/systemd/system-sleep/fprintd-resume-stop}"
+lock_pam="${OMARCHY_LOCK_FINGERPRINT_PAM:-/etc/pam.d/omarchy-lock-fingerprint}"
+
+# Fingerprint setup is per-machine, while migration completion is per-user.
+# Install once on configured machines and let later users no-op.
+[[ -f $lock_pam && -f $hook_src && ! -e $hook_dst ]] || exit 0
+
+echo "Installing fingerprint resume recovery"
+sudo install -Dm755 "$hook_src" "$hook_dst"

--- a/test/shell.d/fprintd-resume-stop-migration-test.sh
+++ b/test/shell.d/fprintd-resume-stop-migration-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787689809.sh"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mock_bin="$tmp_dir/bin"
+mkdir -p "$mock_bin"
+cat >"$mock_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+chmod +x "$mock_bin/sudo"
+
+src="$tmp_dir/fprintd-resume-stop"
+dst="$tmp_dir/system-sleep/fprintd-resume-stop"
+lock_pam="$tmp_dir/omarchy-lock-fingerprint"
+printf '#!/bin/bash\n' >"$src"
+chmod +x "$src"
+
+run_migration() {
+  PATH="$mock_bin:$PATH" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_FPRINTD_RESUME_SRC="$src" \
+    OMARCHY_FPRINTD_RESUME_DST="$dst" \
+    OMARCHY_LOCK_FINGERPRINT_PAM="$lock_pam" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+: >"$lock_pam"
+run_migration
+[[ -x $dst ]] || fail "migration installs executable fingerprint recovery"
+pass "migration installs executable fingerprint recovery"
+
+printf 'locally changed\n' >>"$dst"
+run_migration
+grep -q 'locally changed' "$dst" || fail "migration preserves an existing hook"
+pass "migration preserves an existing hook"
+
+rm -f "$lock_pam" "$dst"
+run_migration
+[[ ! -e $dst ]] || fail "migration skips machines without fingerprint authentication"
+pass "migration skips machines without fingerprint authentication"

--- a/test/shell.d/fprintd-resume-stop-test.sh
+++ b/test/shell.d/fprintd-resume-stop-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hook="$ROOT/default/systemd/system-sleep/fprintd-resume-stop"
+[[ -x $hook ]] || fail "fingerprint resume hook is executable" "mode: $(stat -c '%A' "$hook")"
+pass "fingerprint resume hook is executable"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mock_bin="$tmp_dir/bin"
+timeout_log="$tmp_dir/timeout.log"
+systemctl_log="$tmp_dir/systemctl.log"
+logger_log="$tmp_dir/logger.log"
+state_file="$tmp_dir/fprintd-sleep.pid"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/timeout" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TIMEOUT_LOG"
+if [[ ${TIMEOUT_FAIL:-0} == 1 ]]; then
+  exit 124
+fi
+shift
+exec "$@"
+STUB
+
+cat >"$mock_bin/systemctl" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+if [[ $1 == "show" ]]; then
+  printf '%s\n' "${MOCK_FPRINTD_PID:-0}"
+fi
+STUB
+
+cat >"$mock_bin/logger" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$LOGGER_LOG"
+STUB
+
+chmod +x "$mock_bin/timeout" "$mock_bin/systemctl" "$mock_bin/logger"
+
+run_hook() {
+  : >"$timeout_log"
+  : >"$systemctl_log"
+  : >"$logger_log"
+  PATH="$mock_bin:$PATH" \
+    TIMEOUT_LOG="$timeout_log" \
+    SYSTEMCTL_LOG="$systemctl_log" \
+    LOGGER_LOG="$logger_log" \
+    OMARCHY_FPRINTD_SLEEP_STATE="$state_file" \
+    "$hook" "$@"
+}
+
+MOCK_FPRINTD_PID=101 run_hook pre suspend
+[[ $(<"$state_file") == 101 ]] ||
+  fail "pre-suspend records the active fprintd process" "state: $(<"$state_file")"
+pass "pre-suspend records the active fprintd process"
+
+MOCK_FPRINTD_PID=101 run_hook post suspend
+[[ $(<"$timeout_log") == "6s systemctl stop fprintd.service" ]] ||
+  fail "resume bounds the stale daemon stop" "timeout: $(<"$timeout_log")"
+grep -qx 'stop fprintd.service' "$systemctl_log" ||
+  fail "resume stops fprintd without restarting it in the hook" "systemctl: $(<"$systemctl_log")"
+grep -q 'Stopped fprintd PID 101 after suspend resume' "$logger_log" ||
+  fail "resume logs successful recovery" "log: $(<"$logger_log")"
+pass "resume stops the stale daemon within a bound"
+
+MOCK_FPRINTD_PID=102 run_hook pre hibernate
+MOCK_FPRINTD_PID=102 run_hook post hibernate
+grep -qx 'stop fprintd.service' "$systemctl_log" ||
+  fail "hibernate resume clears the stale daemon" "systemctl: $(<"$systemctl_log")"
+pass "hibernate resume clears the stale daemon"
+
+MOCK_FPRINTD_PID=201 run_hook pre suspend
+MOCK_FPRINTD_PID=202 run_hook post suspend
+[[ ! -s $timeout_log ]] ||
+  fail "resume leaves a replacement daemon alone" "timeout: $(<"$timeout_log")"
+! grep -q '^stop ' "$systemctl_log" ||
+  fail "resume leaves a replacement daemon alone" "systemctl: $(<"$systemctl_log")"
+[[ ! -s $logger_log ]] ||
+  fail "resume stays quiet when preserving a replacement daemon" "log: $(<"$logger_log")"
+pass "resume leaves a replacement daemon alone"
+
+MOCK_FPRINTD_PID=0 run_hook pre suspend
+[[ ! -e $state_file ]] || fail "pre-suspend records no inactive daemon"
+[[ ! -s $logger_log ]] ||
+  fail "pre-suspend stays quiet without an active daemon" "log: $(<"$logger_log")"
+pass "pre-suspend records no inactive daemon"
+
+MOCK_FPRINTD_PID=301 run_hook pre suspend
+MOCK_FPRINTD_PID=301 TIMEOUT_FAIL=1 run_hook post suspend ||
+  fail "a timed-out daemon stop does not block resume"
+grep -q 'Failed to stop fprintd PID 301 after suspend resume' "$logger_log" ||
+  fail "a timed-out daemon stop is visible in the journal" "log: $(<"$logger_log")"
+pass "a timed-out daemon stop does not block resume"


### PR DESCRIPTION
## What this changes

- Record `fprintd.service`'s PID immediately before suspend or hibernate.
- After resume, stop the daemon only when that exact PID survived the sleep transition.
- Let the next fingerprint request start a clean daemon through normal D-Bus activation, after `user.slice` has thawed.
- Install the hook for new fingerprint setups, migrate existing setups once, and remove it when fingerprint authentication is removed.
- Log only an actual recovery or a bounded stop failure; ordinary sleep cycles remain silent.

## Why

The lock screen can begin a fingerprint PAM conversation just as a lid close enters suspend. On the affected machine, `fprintd` reported `Cannot run while suspended`, but the daemon survived with its device claim stuck. After resume, the lock screen retried every 250 ms and received `PAM_AUTHINFO_UNAVAIL` (code 9) until password unlock or the daemon's idle exit.

The reader itself remained healthy: stopping the surviving daemon and allowing D-Bus to start a fresh one restored fingerprint verification immediately.

The PID comparison makes the recovery selective. If `fprintd` exited during sleep and another system component started a replacement, this hook leaves that new process alone.

## Why stop instead of restart inside the hook?

System-sleep hooks run while `user.slice` is frozen. Stopping the stale daemon there establishes the ordering we need, but starting `fprintd` there would also make wake wait for USB probing and the D-Bus service start. Leaving startup to the next PAM request moves that work after thaw, when the reader has fully resumed.

The service stop is bounded at six seconds, one second beyond Omarchy's five-second systemd service-stop timeout. A failure is logged and wake continues.

## Hardware validation

Tested on Omarchy 4.0.0-1 with:

- Goodix MOC fingerprint reader `27c6:634c`
- `fprintd` 1.94.5-2
- `libfprint` 1.94.100-1
- Linux 7.1.8-arch1-3, s2idle

Historical journal data contained three `Cannot run while suspended` events across twelve lid cycles, followed by a large code-9 retry storm.

With this hook installed, the race was reproduced and recovered in three consecutive test cycles:

1. 18-second sleep on battery
2. 17-minute sleep on battery
3. 10-minute sleep beginning on AC power and resuming on battery

In every cycle:

- the pre-suspend PID survived;
- PAM emitted code 9 before the post-resume hook ran;
- the hook stopped that exact PID successfully;
- the next PAM attempt reached the reader within one to two seconds; and
- fingerprint authentication succeeded with no subsequent code-9 storm.

The power-state instrumentation used during validation is not included in this patch.

## Scope and relationship to other work

This fixes the stale-daemon suspend race reported in #7229 and related evidence in #7172. It deliberately does not change the lock screen's retry policy, unavailable UI, thermal-error handling, or mid-verification driver-error behavior.

#7158 addresses the same stale-daemon diagnosis as part of a broader fingerprint recovery and retry design. This PR offers a narrower alternative: a PID-selective stop, lazy D-Bus activation after thaw, and no QML or retry-policy changes. The approaches could also be combined if maintainers prefer its broader backoff behavior.

One intentional tradeoff is that a fingerprint conversation left open across suspend, such as `sudo` waiting in another terminal, is ended and falls back to password. That is the same class of conversation that can otherwise retain the stale claim.

## Tests

- `test/shell.d/fprintd-resume-stop-test.sh`
- `test/shell.d/fprintd-resume-stop-migration-test.sh`
- `./test/cli`
- `./test/shell`: all relevant tests pass; the sole persistent failure is `launch-about-test.sh`, reproduced unchanged on a detached `origin/quattro` worktree. The initially transient screenshot test passed on rerun, and the Snapper coverage passed once its documented sibling `omarchy-pkgs` and `omarchy-iso` checkouts were present.

@spencerbull, I would value your review of the suspend/service-lifecycle tradeoff here, particularly the selective stop and deferred D-Bus startup versus restarting the service inside the post-resume hook.
