### PR TITLE
Show inactive audio card outputs in picker

### DIFF
--- a/bin/omarchy-audio-output-profiles
+++ b/bin/omarchy-audio-output-profiles
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# omarchy:summary=List available audio output profiles for the shell
+# omarchy:hidden=true
+
+set -euo pipefail
+
+timeout 2 pactl -f json list cards 2>/dev/null | jq -c '
+  [ .[]
+    | . as $card
+    | (.ports // {} | to_entries[]) as $port
+    | select(($port.value.availability // "unknown") != "not available")
+    | [($port.value.profiles // [])[] as $profile_name
+        | ($card.profiles[$profile_name] // {}) as $profile
+        | select(($profile.sinks // 0) == 1)
+        | select(($profile.available // true) != false)
+        | select($profile_name | startswith("output:"))
+        | {
+            cardName: $card.name,
+            profileName: $profile_name,
+            label: ($port.value.properties["device.product.name"] // $port.value.description // $profile.description // $profile_name),
+            description: ($profile.description // $port.value.description // $profile_name),
+            priority: (($profile.priority // 0) + ($port.value.priority // 0))
+          }
+      ]
+    | select(length > 0)
+    | max_by(.priority)
+  ]
+  | unique_by(.cardName + "|" + .profileName)
+  | sort_by(-.priority)
+  | map(del(.priority))
+'

--- a/bin/omarchy-audio-output-set-profile
+++ b/bin/omarchy-audio-output-set-profile
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# omarchy:summary=Activate an audio card output profile and make its sink default
+# omarchy:args=<card-name> <profile-name>
+# omarchy:hidden=true
+
+set -euo pipefail
+
+card_name=${1:-}
+profile_name=${2:-}
+
+if [[ -z $card_name || -z $profile_name ]]; then
+  echo "Usage: omarchy-audio-output-set-profile <card-name> <profile-name>" >&2
+  exit 1
+fi
+
+cards=$(timeout 2 pactl -f json list cards 2>/dev/null)
+if ! jq -e --arg card "$card_name" --arg profile "$profile_name" '
+  any(.[];
+    .name == $card
+    and (.profiles[$profile].sinks // 0) > 0
+    and (.profiles[$profile].available // true) != false
+    and ($profile | startswith("output:")))
+' <<<"$cards" >/dev/null; then
+  echo "Audio output profile is unavailable: $card_name $profile_name" >&2
+  exit 1
+fi
+
+timeout 2 pactl set-card-profile "$card_name" "$profile_name"
+
+profile_device=${profile_name#output:}
+for _ in {1..20}; do
+  sink=$(timeout 2 pactl -f json list sinks 2>/dev/null | jq -c --arg card "$card_name" --arg profile "$profile_device" '
+    first(.[]
+      | select(.properties["device.name"] == $card)
+      | select(.properties["device.profile.name"] == $profile)) // empty
+  ')
+  if [[ -n $sink ]]; then
+    omarchy-audio-output-set-default "$(jq -r '.index' <<<"$sink")" "$(jq -r '.name' <<<"$sink")"
+    exit 0
+  fi
+  sleep 0.1
+done
+
+echo "Audio sink did not appear for profile: $card_name $profile_name" >&2
+exit 1

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -47,6 +47,96 @@ function parseSinkAvailability(raw) {
   return next
 }
 
+function parseOutputProfiles(raw) {
+  try {
+    var parsed = JSON.parse(String(raw || "[]"))
+    if (!Array.isArray(parsed)) return []
+
+    var profiles = []
+    for (var i = 0; i < parsed.length; i++) {
+      var profile = parsed[i] || {}
+      var cardName = String(profile.cardName || "")
+      var profileName = String(profile.profileName || "")
+      if (!cardName || !profileName) continue
+      profiles.push({
+        cardName: cardName,
+        profileName: profileName,
+        label: friendlyDeviceLabel(profile.label || profile.description || profileName),
+        description: friendlyDeviceLabel(profile.description || "")
+      })
+    }
+    return profiles
+  } catch (error) {
+    return []
+  }
+}
+
+function outputProfileKey(cardName, profileName) {
+  return String(cardName || "") + "|" + String(profileName || "")
+}
+
+function outputProfileSinkName(cardName, profileName) {
+  cardName = String(cardName || "")
+  profileName = String(profileName || "")
+  if (cardName.indexOf("alsa_card.") !== 0 || profileName.indexOf("output:") !== 0) return ""
+  return "alsa_output." + cardName.slice(10) + "." + profileName.slice(7)
+}
+
+function sinkProfileKey(node) {
+  var p = nodeProps(node)
+  var cardName = p["device.name"] || ""
+  var profileName = p["device.profile.name"] || ""
+  if (!cardName || !profileName) return ""
+  if (String(profileName).indexOf("output:") !== 0) profileName = "output:" + profileName
+  return outputProfileKey(cardName, profileName)
+}
+
+function outputRows(sinks, profiles) {
+  var rows = []
+  var activeProfiles = {}
+  var profilesByKey = {}
+  var profilesBySinkName = {}
+  var sinkValues = Array.isArray(sinks) ? sinks : []
+  var profileValues = Array.isArray(profiles) ? profiles : []
+
+  for (var i = 0; i < profileValues.length; i++) {
+    var availableProfile = profileValues[i]
+    var availableKey = outputProfileKey(availableProfile.cardName, availableProfile.profileName)
+    var sinkName = outputProfileSinkName(availableProfile.cardName, availableProfile.profileName)
+    profilesByKey[availableKey] = availableProfile
+    if (sinkName) profilesBySinkName[sinkName] = availableProfile
+  }
+
+  for (var j = 0; j < sinkValues.length; j++) {
+    var node = sinkValues[j]
+    var activeKey = sinkProfileKey(node)
+    var profile = profilesBySinkName[String(node && node.name || "")] || profilesByKey[activeKey]
+    if (profile) activeKey = outputProfileKey(profile.cardName, profile.profileName)
+    if (activeKey) activeProfiles[activeKey] = true
+    rows.push({
+      kind: "sink",
+      node: node,
+      label: profile ? profile.label : "",
+      description: profile ? profile.description : ""
+    })
+  }
+
+  for (var k = 0; k < profileValues.length; k++) {
+    var inactiveProfile = profileValues[k]
+    var key = outputProfileKey(inactiveProfile.cardName, inactiveProfile.profileName)
+    if (!key || activeProfiles[key]) continue
+    rows.push({
+      kind: "profile",
+      cardName: inactiveProfile.cardName,
+      profileName: inactiveProfile.profileName,
+      label: inactiveProfile.label,
+      description: inactiveProfile.description
+    })
+  }
+
+  return rows
+}
+
 function friendlyDeviceLabel(text) {
   var label = String(text || "").trim()
   label = label.replace(/^sof-soundwire\s+/i, "")
@@ -240,6 +330,11 @@ if (typeof module !== "undefined") {
     listSnapshot: listSnapshot,
     outputVolumeName: outputVolumeName,
     parseSinkAvailability: parseSinkAvailability,
+    parseOutputProfiles: parseOutputProfiles,
+    outputProfileKey: outputProfileKey,
+    outputProfileSinkName: outputProfileSinkName,
+    sinkProfileKey: sinkProfileKey,
+    outputRows: outputRows,
     friendlyDeviceLabel: friendlyDeviceLabel,
     nodeProps: nodeProps,
     nodeLabel: nodeLabel,

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -134,7 +134,11 @@ function outputRows(sinks, profiles) {
     })
   }
 
-  return rows
+  return rows.sort(function(a, b) {
+    var left = String(a && a.label || "")
+    var right = String(b && b.label || "")
+    return left < right ? -1 : left > right ? 1 : 0
+  })
 }
 
 function friendlyDeviceLabel(text) {

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -57,6 +57,7 @@ Panel {
 
   property var sinkAvailability: ({})
   property bool sinkAvailabilityLoaded: false
+  property var outputProfiles: []
 
   // Identify true playback streams without reading node.properties here:
   // PwNode.properties is invalid until the node is bound, and reading it while
@@ -73,7 +74,7 @@ Panel {
     return Model.isAudioSource(node)
   }
 
-  property var cachedAudioSinks: []
+  property var cachedAudioOutputs: []
   property var cachedAudioSources: []
 
   readonly property var rawAudioSinks: {
@@ -90,7 +91,8 @@ Panel {
     return list
   }
 
-  readonly property var audioSinks: rawAudioSinks.length > 0 ? rawAudioSinks : cachedAudioSinks
+  readonly property var rawAudioOutputs: Model.outputRows(rawAudioSinks, outputProfiles)
+  readonly property var audioOutputs: rawAudioOutputs.length > 0 ? rawAudioOutputs : cachedAudioOutputs
   readonly property var audioSources: rawAudioSources.length > 0 ? rawAudioSources : cachedAudioSources
 
   readonly property var audioStreams: {
@@ -148,7 +150,7 @@ Panel {
   readonly property real inputVolume: source && source.audio ? source.audio.volume : 0
   readonly property bool inputMuted: source && source.audio ? source.audio.muted : false
 
-  onRawAudioSinksChanged: if (rawAudioSinks.length > 0) cachedAudioSinks = rawAudioSinks
+  onRawAudioOutputsChanged: if (rawAudioOutputs.length > 0) cachedAudioOutputs = rawAudioOutputs
   onRawAudioSourcesChanged: if (rawAudioSources.length > 0) cachedAudioSources = rawAudioSources
 
   // Single cursor model shared by keyboard and mouse. Sections:
@@ -291,8 +293,8 @@ Panel {
     if (focusSection === "header") { toggleAllMuted(); return }
     if (focusSection === "output") {
       if (selectedIndex === -1) { toggleOutputMute(); return }
-      var sink = displayAudioSinks[selectedIndex]
-      if (sink) setDefaultSink(sink)
+      var output = displayAudioSinks[selectedIndex]
+      if (output) activateOutput(output)
       return
     }
     if (focusSection === "input") {
@@ -320,7 +322,7 @@ Panel {
   }
 
   // Clamp / repair the cursor whenever any list refreshes underneath us.
-  onAudioSinksChanged: scheduleDisplayAudioModelRefresh()
+  onAudioOutputsChanged: scheduleDisplayAudioModelRefresh()
   onAudioSourcesChanged: scheduleDisplayAudioModelRefresh()
   onAudioStreamsChanged: scheduleDisplayAudioModelRefresh()
 
@@ -330,7 +332,7 @@ Panel {
 
   function refreshDisplayAudioModels() {
     if (!opened) return
-    displayAudioSinks = listSnapshot(audioSinks)
+    displayAudioSinks = listSnapshot(audioOutputs)
     displayAudioSources = listSnapshot(audioSources)
     displayAudioStreams = listSnapshot(audioStreams)
     clampCursor()
@@ -472,6 +474,21 @@ Panel {
     }
   }
 
+  function activateOutput(output) {
+    if (!output) return
+    if (output.kind === "sink") {
+      setDefaultSink(output.node)
+      return
+    }
+    if (output.kind !== "profile" || outputProfileSetProc.running) return
+    outputProfileSetProc.command = [
+      "omarchy-audio-output-set-profile",
+      String(output.cardName),
+      String(output.profileName)
+    ]
+    outputProfileSetProc.running = true
+  }
+
   function setDefaultSource(node) {
     if (!node) return
     Pipewire.preferredDefaultAudioSource = node
@@ -493,6 +510,10 @@ Panel {
   function updateSinkAvailability(raw) {
     sinkAvailability = Model.parseSinkAvailability(raw)
     sinkAvailabilityLoaded = true
+  }
+
+  function updateOutputProfiles(raw) {
+    outputProfiles = Model.parseOutputProfiles(raw)
   }
 
   function friendlyDeviceLabel(text) {
@@ -593,6 +614,23 @@ Panel {
   }
 
   Process {
+    id: outputProfileProc
+    command: ["omarchy-audio-output-profiles"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateOutputProfiles(text)
+    }
+  }
+
+  Process {
+    id: outputProfileSetProc
+    onExited: function(exitCode) {
+      if (exitCode !== 0) console.warn("Could not switch audio output profile")
+      if (!outputProfileProc.running) outputProfileProc.running = true
+    }
+  }
+
+  Process {
     id: volumeSinkProc
     command: ["omarchy-audio-output-sink"]
     stdout: StdioCollector {
@@ -606,7 +644,10 @@ Panel {
     running: root.opened
     repeat: true
     triggeredOnStart: true
-    onTriggered: if (!sinkAvailabilityProc.running) sinkAvailabilityProc.running = true
+    onTriggered: {
+      if (!sinkAvailabilityProc.running) sinkAvailabilityProc.running = true
+      if (!outputProfileProc.running) outputProfileProc.running = true
+    }
   }
 
   // Runs whether or not the panel is open: the bar shows and scrolls the output
@@ -857,7 +898,7 @@ Panel {
                 required property var modelData
                 required property int index
                 width: panelColumn.width
-                node: modelData
+                output: modelData
                 rowIndex: index
               }
             }
@@ -1012,9 +1053,10 @@ Panel {
   // from hasCursor/current via CursorSurface, never from containsMouse.
   component SinkRow: CursorSurface {
     id: sinkRow
-    required property var node
+    required property var output
     required property int rowIndex
 
+    readonly property var node: output && output.kind === "sink" ? output.node : null
     readonly property bool isActive: root.sink && node && root.sink.id === node.id
     hasCursor: root.cursorActive && root.focusSection === "output" && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sinkRow)
@@ -1035,7 +1077,7 @@ Panel {
 
       Text {
         textFormat: Text.PlainText
-        text: root.sinkGlyph(sinkRow.node)
+        text: sinkRow.output && sinkRow.output.kind === "profile" ? "󰍹" : root.sinkGlyph(sinkRow.node)
         color: root.bar.foreground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.title
@@ -1046,7 +1088,9 @@ Panel {
 
       Text {
         textFormat: Text.PlainText
-        text: root.nodeLabel(sinkRow.node)
+        text: sinkRow.output && sinkRow.output.kind === "profile"
+          ? sinkRow.output.label
+          : (sinkRow.output.label || root.nodeLabel(sinkRow.node))
         color: root.bar.foreground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.body
@@ -1066,7 +1110,7 @@ Panel {
         root.focusSection = "output"
         root.selectedIndex = sinkRow.rowIndex
       }
-      onClicked: root.setDefaultSink(sinkRow.node)
+      onClicked: root.activateOutput(sinkRow.output)
     }
   }
 

--- a/test/shell.d/audio-output-profile-test.sh
+++ b/test/shell.d/audio-output-profile-test.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls"
+cards="$test_tmp/cards.json"
+sinks="$test_tmp/sinks.json"
+mkdir -p "$stub_bin"
+
+cat >"$cards" <<'JSON'
+[
+  {
+    "name": "alsa_card.gpu",
+    "active_profile": "output:hdmi-stereo",
+    "profiles": {
+      "output:hdmi-stereo": { "description": "Digital Stereo (HDMI) Output", "sinks": 1, "priority": 5900, "available": true },
+      "output:hdmi-stereo-extra1": { "description": "Digital Stereo (HDMI 2) Output", "sinks": 1, "priority": 5700, "available": true },
+      "output:hdmi-surround-extra1": { "description": "Digital Surround 5.1 (HDMI 2) Output", "sinks": 1, "priority": 600, "available": true },
+      "output:hdmi-stereo-extra2": { "description": "Digital Stereo (HDMI 3) Output", "sinks": 1, "priority": 5700, "available": false }
+    },
+    "ports": {
+      "hdmi-output-0": {
+        "description": "HDMI / DisplayPort",
+        "priority": 5900,
+        "availability": "available",
+        "properties": { "device.product.name": "Left Monitor" },
+        "profiles": ["output:hdmi-stereo"]
+      },
+      "hdmi-output-1": {
+        "description": "HDMI / DisplayPort 2",
+        "priority": 5800,
+        "availability": "available",
+        "properties": { "device.product.name": "Right Monitor" },
+        "profiles": ["output:hdmi-stereo-extra1", "output:hdmi-surround-extra1"]
+      },
+      "hdmi-output-2": {
+        "description": "HDMI / DisplayPort 3",
+        "priority": 5700,
+        "availability": "not available",
+        "properties": {},
+        "profiles": ["output:hdmi-stereo-extra2"]
+      }
+    }
+  }
+]
+JSON
+
+cat >"$sinks" <<'JSON'
+[
+  {
+    "index": 731,
+    "name": "alsa_output.gpu.hdmi-stereo-extra1",
+    "properties": {
+      "device.name": "alsa_card.gpu",
+      "device.profile.name": "hdmi-stereo-extra1"
+    }
+  }
+]
+JSON
+
+cat >"$stub_bin/pactl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "-f" && $2 == "json" && $3 == "list" && $4 == "cards" ]]; then
+  cat "$CARDS_FIXTURE"
+elif [[ $1 == "-f" && $2 == "json" && $3 == "list" && $4 == "sinks" ]]; then
+  cat "$SINKS_FIXTURE"
+elif [[ $1 == "set-card-profile" ]]; then
+  printf 'set-card-profile\t%s\t%s\n' "$2" "$3" >>"$CALL_LOG"
+else
+  exit 1
+fi
+SH
+
+cat >"$stub_bin/omarchy-audio-output-set-default" <<'SH'
+#!/bin/bash
+
+printf 'set-default\t%s\t%s\n' "$1" "$2" >>"$CALL_LOG"
+SH
+
+chmod +x "$stub_bin/pactl" "$stub_bin/omarchy-audio-output-set-default"
+
+profiles=$(CARDS_FIXTURE="$cards" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-audio-output-profiles")
+if jq -e '
+  length == 2
+  and any(.[]; .cardName == "alsa_card.gpu" and .profileName == "output:hdmi-stereo" and .label == "Left Monitor")
+  and any(.[]; .cardName == "alsa_card.gpu" and .profileName == "output:hdmi-stereo-extra1" and .label == "Right Monitor")
+' <<<"$profiles" >/dev/null; then
+  pass "audio output profiles list the best profile for each available port"
+else
+  fail "audio output profiles list the best profile for each available port" "$profiles"
+fi
+
+CARDS_FIXTURE="$cards" SINKS_FIXTURE="$sinks" CALL_LOG="$calls" PATH="$stub_bin:$PATH" \
+  "$ROOT/bin/omarchy-audio-output-set-profile" alsa_card.gpu output:hdmi-stereo-extra1
+
+if rg -F $'set-card-profile\talsa_card.gpu\toutput:hdmi-stereo-extra1' "$calls" >/dev/null; then
+  pass "audio output profile selection activates the requested card profile"
+else
+  fail "audio output profile selection activates the requested card profile"
+fi
+
+if rg -F $'set-default\t731\talsa_output.gpu.hdmi-stereo-extra1' "$calls" >/dev/null; then
+  pass "audio output profile selection promotes the recreated sink"
+else
+  fail "audio output profile selection promotes the recreated sink"
+fi
+
+if CARDS_FIXTURE="$cards" SINKS_FIXTURE="$sinks" CALL_LOG="$calls" PATH="$stub_bin:$PATH" \
+  "$ROOT/bin/omarchy-audio-output-set-profile" alsa_card.gpu output:missing 2>/dev/null; then
+  fail "audio output profile selection rejects unavailable profiles"
+else
+  pass "audio output profile selection rejects unavailable profiles"
+fi

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -18,6 +18,31 @@ assertEqual(audio.outputVolumeName(0.9, false), 'Party mode', 'audio labels loud
 assertEqual(audio.outputVolumeName(0.5, true), 'Muted', 'audio labels muted output')
 
 assertDeepEqual(audio.parseSinkAvailability('alsa_output\t1\nhdmi_output\t0\n'), { alsa_output: true, hdmi_output: false }, 'audio parses sink availability')
+const outputProfiles = audio.parseOutputProfiles(JSON.stringify([
+  { cardName: 'alsa_card.gpu', profileName: 'output:hdmi-stereo-extra1', label: 'Right Monitor', description: 'Digital Stereo (HDMI 2) Output' }
+]))
+assertEqual(outputProfiles[0].label, 'Right Monitor', 'audio parses inactive output profile labels')
+assertEqual(outputProfiles[0].description, 'Digital Stereo (HDMI 2)', 'audio cleans inactive output profile descriptions')
+assertDeepEqual(audio.parseOutputProfiles('{bad json'), [], 'audio rejects malformed output profile data')
+assertEqual(
+  audio.outputProfileSinkName('alsa_card.pci-0000_29_00.1', 'output:hdmi-stereo-extra1'),
+  'alsa_output.pci-0000_29_00.1.hdmi-stereo-extra1',
+  'audio derives the sink name created by an ALSA output profile'
+)
+
+const activeSink = {
+  name: 'alsa_output.gpu.hdmi-stereo',
+  ready: false
+}
+const outputRows = audio.outputRows([activeSink], [
+  { cardName: 'alsa_card.gpu', profileName: 'output:hdmi-stereo', label: 'Left Monitor', description: 'Digital Stereo' },
+  { cardName: 'alsa_card.gpu', profileName: 'output:hdmi-stereo-extra1', label: 'Right Monitor', description: 'Digital Stereo' }
+])
+assertEqual(outputRows.length, 2, 'audio combines active sinks with inactive card profiles')
+assertEqual(outputRows[0].kind, 'sink', 'audio keeps active sinks as selectable output rows')
+assertEqual(outputRows[0].label, 'Left Monitor', 'audio labels active sinks from their card ports')
+assertEqual(outputRows[1].kind, 'profile', 'audio exposes inactive profiles as selectable output rows')
+assertEqual(outputRows[1].label, 'Right Monitor', 'audio keeps monitor names on profile rows')
 assertEqual(audio.friendlyDeviceLabel('Built-in Audio Speakers Output'), 'Speakers', 'audio cleans device labels')
 assertEqual(
   audio.nodeLabel({ ready: true, properties: { 'node.nick': 'Built-in Audio Microphones Input' }, name: 'alsa_input' }),

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -43,6 +43,13 @@ assertEqual(outputRows[0].kind, 'sink', 'audio keeps active sinks as selectable 
 assertEqual(outputRows[0].label, 'Left Monitor', 'audio labels active sinks from their card ports')
 assertEqual(outputRows[1].kind, 'profile', 'audio exposes inactive profiles as selectable output rows')
 assertEqual(outputRows[1].label, 'Right Monitor', 'audio keeps monitor names on profile rows')
+
+const reorderedRows = audio.outputRows([{ ...activeSink, name: 'alsa_output.gpu.hdmi-stereo-extra1' }], [
+  { cardName: 'alsa_card.gpu', profileName: 'output:hdmi-stereo', label: 'Left Monitor', description: 'Digital Stereo' },
+  { cardName: 'alsa_card.gpu', profileName: 'output:hdmi-stereo-extra1', label: 'Right Monitor', description: 'Digital Stereo' }
+])
+assertEqual(reorderedRows[0].label, 'Left Monitor', 'audio keeps output rows sorted when the active profile changes')
+assertEqual(reorderedRows[1].label, 'Right Monitor', 'audio does not move the selected output to the front')
 assertEqual(audio.friendlyDeviceLabel('Built-in Audio Speakers Output'), 'Speakers', 'audio cleans device labels')
 assertEqual(
   audio.nodeLabel({ ready: true, properties: { 'node.nick': 'Built-in Audio Microphones Input' }, name: 'alsa_input' }),


### PR DESCRIPTION
## Problem

Quattro's audio panel only lists live PipeWire sink nodes. Some ALSA cards expose multiple mutually exclusive output profiles, so only the currently active HDMI/DisplayPort monitor has a sink. Other connected, available monitors are invisible in the picker even though `pactl list cards` reports their profiles as available.

Fixes #8789.

## Change

- Discover the best available one-sink output profile for every available ALSA card port.
- Merge inactive card profiles into the panel's normal output rows, using the monitor/product name supplied by the port.
- When an inactive row is selected, activate that profile, wait for its PipeWire sink to appear, then reuse the existing default-output helper to persist the selection and move playback streams.
- Keep active sinks on the existing Quickshell/PipeWire path.

PR #5317 addresses the related single-sink limitation in the old `dev` command switcher, but it hard-codes an analog/HDMI toggle and does not expose multiple HDMI ports in Quattro's panel. PRs #5830 and #8426 make missing HDMI hardware/profiles appear; this change handles profiles that already exist and are available but are mutually exclusive.

## Verification

- `bash test/shell.d/audio-test.sh`
- `bash test/shell.d/audio-output-profile-test.sh`
- `./test/cli`
- `./test/shell` (new audio tests pass; unrelated local failures require the separate `omarchy-pkgs` checkout, network access, or depend on the live multi-monitor shell environment)
- Live two-monitor test on an NVIDIA RTX 3080 Ti:
  - `M27T6` -> `output:hdmi-stereo`
  - `H27T7P-2` -> `output:hdmi-stereo-extra1`
  - selecting each panel row recreated the expected sink and made it the default

