### PR TITLE
Put the OLED Zephyrus G14 MUX back to hybrid on install

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -33,6 +33,7 @@ run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-display-backlight.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-display.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-z13-touchpad.sh"
+run_logged "$OMARCHY_INSTALL/hardware/asus/fix-rog-mux-brightness.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 

--- a/install/hardware/asus/fix-rog-mux-brightness.sh
+++ b/install/hardware/asus/fix-rog-mux-brightness.sh
@@ -1,0 +1,28 @@
+# Brightness fix for the OLED Zephyrus G14 (GA403), whose GPU MUX can route the
+# internal panel straight to the dGPU.
+#
+# Scoped to GA403 for now. Other MUX-capable ROG models need confirmation: this
+# only bites panels that take their brightness over DP AUX from the iGPU driver,
+# and a PWM-backlit ROG in the same position may well be fine.
+#
+# In the discrete position (gpu_mux_mode 0) the panel hangs off the NVIDIA GPU,
+# which reports "ACPI reported no NVIDIA native backlight available" and falls
+# back to an ACPI/EC interface this firmware only half-implements. A backlight
+# device still registers and still accepts writes, but the panel never responds,
+# so the machine is stuck at whatever brightness it booted at. Hybrid puts the
+# panel back on amdgpu, where amdgpu_bl* drives it over DP AUX.
+#
+# Firmware applies the attribute at the next POST and install is followed by a
+# reboot, so queue the change rather than trying to switch a live MUX.
+
+if omarchy-hw-match "GA403"; then
+  for mux_attr in /sys/class/firmware-attributes/asus-armoury/attributes/gpu_mux_mode/current_value \
+    /sys/devices/platform/asus-nb-wmi/gpu_mux_mode; do
+    if [[ -e $mux_attr ]]; then
+      if [[ $(cat "$mux_attr") == "0" ]]; then
+        echo 1 | sudo tee "$mux_attr" >/dev/null
+      fi
+      break
+    fi
+  done
+fi


### PR DESCRIPTION
## Problem

On the OLED Zephyrus G14 (GA403), a fresh Omarchy install comes up with **no working brightness control at all** if the GPU MUX is in the discrete position.

In that position the internal panel hangs off the NVIDIA GPU, which has no brightness path for it:

```
nvidia-modeset: ACPI reported no NVIDIA native backlight available; attempting to use ACPI backlight.
wmi_bus wmi_bus-PNP0C14:00: [Firmware Bug]: WQ00 data block query control method not found
```

A backlight device still registers and still accepts writes — the panel simply never responds, so the machine sits at whatever brightness it booted at. The brightness keys work, the OSD moves, nothing happens. Same failure shape already documented in `install/hardware/asus/fix-asus-ptl-display-backlight.sh`: *"sysfs writes succeed but produce no visible change."*

In hybrid the panel goes back to `amdgpu`, `amdgpu_bl*` registers and drives it over DP AUX, and brightness works with no further configuration — `omarchy-hw-display` already prefers `amdgpu_bl*`.

## Change

Queue the MUX back to hybrid at install time when the machine is a GA403 sitting in the discrete position. Idempotent: if it is already hybrid, nothing is written.

No live MUX switch is attempted. Firmware applies the attribute at the next POST, and install is followed by a reboot — the same reasoning `set-wireless-regdom.sh` already uses: *"Install is followed by reboot, so don't mutate live Wi-Fi state."*

## Scope

Scoped to GA403, following the precedent set by `fix-asus-ptl-display-backlight.sh` (*"Enabled only for ExpertBook B9406 and Zenbook UX5406AA for now. Other models need confirmation whether the issue exists there too."*).

This only bites panels that take brightness over DP AUX from the iGPU driver. A PWM-backlit ROG in the same MUX position may well be fine, so widening it needs someone with that hardware.

EDID-based OLED detection is not an option here: with the panel on the dGPU, `/sys/class/drm/card*-eDP-*/edid` reads back **empty**, so the approach `omarchy-hw-dell-xps-oled` uses would silently fail in exactly the state that needs detecting. DMI matching is what works.

## The judgement call for maintainers

Every other fix under `install/hardware/` changes OS-level state — a package, a kernel param, a modprobe config. **This one writes a firmware attribute**, and that deserves an explicit decision rather than slipping through on precedent.

The case for doing it automatically: in this MUX position the machine has no brightness control whatsoever, which is a broken laptop rather than a tuning preference. The change is reversible from BIOS, from Armoury Crate, and from Omarchy's own **Hybrid GPU** menu entry. And the tree already auto-applies opinionated per-machine choices — `install/user/hardware/dell/xps13-text-scaling.sh` sets a user's text size based on DMI match alone.

The case against: someone may have deliberately selected the discrete MUX for maximum GPU throughput, and this overrides that choice on install without asking. The counter is that they would be choosing a laptop with no brightness control, almost certainly without knowing.

Happy to rework this as a prompt or a first-run notification instead if that lands better.

## Testing

Both branches exercised with stubbed `sudo`/`cat`: a machine already in hybrid is a no-op, and a machine reading `0` queues exactly one write to the MUX attribute.

`test/shell` has 4 failures on my machine (`config`, `snapper`, `theme-install-guards`, `unowned-system-paths`) — identical on a clean checkout of `quattro`, so unrelated.

Single-machine report: one GA403UI, verified by switching it and rebooting. Brightness went from completely dead to `amdgpu_bl2` at 0–399000 granularity.
