### PR TITLE
Recognize Brave Origin window class for chromium-based browser rules

### DIFF
--- a/default/hypr/apps/browser.lua
+++ b/default/hypr/apps/browser.lua
@@ -1,5 +1,8 @@
 -- Browser tags and styling.
-o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
+-- Chromium-family browsers (Chrome, Chromium, Brave, Brave Origin, Edge, Vivaldi, Helium).
+-- Brave uses a tighter match so both the regular browser and the standalone Origin
+-- build are tagged; the anchors + (?i) make the match exact and case-insensitive.
+o.window("((google-)?[cC]hrom(e|ium)|^(?i)brave-(browser|origin)$|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
 o.window("([fF]irefox|zen|librewolf)", { tag = "+firefox-based-browser" })
 o.window({ tag = "chromium-based-browser" }, { tag = "-default-opacity", tile = true, opacity = "1.0 0.985" })
 o.window({ tag = "firefox-based-browser" }, { tag = "-default-opacity", opacity = "1.0 0.985" })

--- a/default/hypr/apps/browser.lua
+++ b/default/hypr/apps/browser.lua
@@ -2,7 +2,7 @@
 -- Chromium-family browsers (Chrome, Chromium, Brave, Brave Origin, Edge, Vivaldi, Helium).
 -- Brave uses a tighter match so both the regular browser and the standalone Origin
 -- build are tagged; the anchors + (?i) make the match exact and case-insensitive.
-o.window("((google-)?[cC]hrom(e|ium)|^(?i)brave-(browser|origin)$|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
+o.window("((google-)?[cC]hrom(e|ium)|^(?i:brave-(browser|origin))$|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
 o.window("([fF]irefox|zen|librewolf)", { tag = "+firefox-based-browser" })
 o.window({ tag = "chromium-based-browser" }, { tag = "-default-opacity", tile = true, opacity = "1.0 0.985" })
 o.window({ tag = "firefox-based-browser" }, { tag = "-default-opacity", opacity = "1.0 0.985" })


### PR DESCRIPTION
## Summary
Omarchy’s browser installer supports both Brave and Brave Origin. The
window-class matcher in `default/hypr/apps/browser.lua` only covered the
regular Brave Browser class, so Origin windows did not receive the
`+chromium-based-browser` tag (and therefore missed the tile + opacity
rules that other Chromium-family browsers get).

## Change
Updated the Brave portion of the regex from `[bB]rave-browser` to an
exact, case-insensitive match for either `brave-browser` or
`brave-origin`.

```diff
- o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
+ o.window("((google-)?[cC]hrom(e|ium)|^(?i)brave-(browser|origin)$|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })