### PR TITLE
Skip orphan prompt during unattended updates

### DIFF
--- a/bin/omarchy-update-orphan-pkgs
+++ b/bin/omarchy-update-orphan-pkgs
@@ -12,7 +12,7 @@ echo -e "\e[32m\nOrphan system packages\e[0m"
 printf '  %s\n' "${orphans[@]}"
 echo
 
-if [[ ! -t 0 || ! -t 1 ]]; then
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == 1 || ! -t 0 || ! -t 1 ]]; then
   echo "${#orphans[@]} orphaned package(s) found. Re-run omarchy-update-orphan-pkgs in a terminal to review/remove them."
   echo
   exit 0

--- a/test/shell.d/update-orphan-test.sh
+++ b/test/shell.d/update-orphan-test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source "$(dirname "$0")/base-test.sh"
 
+require_command script
+
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
@@ -26,6 +28,11 @@ run_orphan_checker() {
   HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-orphan-pkgs"
 }
 
+run_unattended_orphan_checker_on_terminal() {
+  HOME="$test_home" PATH="$stub_bin:$PATH" OMARCHY_UPDATE_UNATTENDED=1 \
+    script -qec "bash '$ROOT/bin/omarchy-update-orphan-pkgs'" "$test_tmp/unattended.out" >/dev/null 2>&1
+}
+
 write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then printf "old-lib\nunused-tool\n"; exit 0; fi; exit 1'
 write_stub sudo 'echo "sudo should not be called" >&2; exit 99'
 write_stub gum 'echo "gum should not be called" >&2; exit 99'
@@ -34,6 +41,14 @@ run_orphan_checker >"$test_tmp/noninteractive.out" 2>"$test_tmp/noninteractive.e
 grep -q '^  old-lib$' "$test_tmp/noninteractive.out" || fail "orphan checker lists orphan packages"
 grep -q 'Re-run omarchy-update-orphan-pkgs in a terminal' "$test_tmp/noninteractive.out" || fail "orphan checker does not remove packages non-interactively"
 pass "orphan checker only reports orphans non-interactively"
+
+run_unattended_orphan_checker_on_terminal || fail "unattended orphan checker fails on a terminal"
+grep -q 'Re-run omarchy-update-orphan-pkgs in a terminal' "$test_tmp/unattended.out" ||
+  fail "unattended orphan checker prompts inside the update pseudo-terminal"
+if grep -q 'should not be called' "$test_tmp/unattended.out"; then
+  fail "unattended orphan checker calls an interactive or privileged command"
+fi
+pass "unattended orphan checker only reports orphans on a terminal"
 
 write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then exit 0; fi; exit 1'
 run_orphan_checker >"$test_tmp/none.out" 2>"$test_tmp/none.err"


### PR DESCRIPTION
## Summary

- Treat `OMARCHY_UPDATE_UNATTENDED=1` like a non-interactive session when reviewing orphaned packages.
- Report the discovered orphans without invoking `gum` or `sudo`.
- Exercise the real helper under the same `script(1)` pseudo-terminal used by `omarchy update`, with package and privileged commands stubbed.

Fixes #8780.

## Reproduction evidence

The current `quattro` implementation reproduced the hang path on three consecutive isolated runs. A temporary `PATH` supplied a fake orphan and replaced `gum` with a blocking stub while `sudo` failed closed. The captured calls were:

```text
pacman -Qtdq
gum unattended=1 args=confirm --default=false Remove 1 orphaned package(s)?
```

The outer timeout had to terminate the pseudo-terminal session. `sudo` was never called. Running the same helper without `script(1)` called only `pacman`, printed the report-only message, and exited normally. No real package, configuration, or network operation was performed.

## Testing

Tests were run in a headless Bubblewrap sandbox with a read-only host filesystem and checkout, private `/home`, `/tmp`, `/run`, and `/var/tmp`, cleared environment, no display or DBus sockets, and unshared network/process namespaces.

- `bash test/shell.d/update-orphan-test.sh` passes.
- `./test/all`: CLI passes; the changed orphan suite passes; 204 of 209 shell test files pass.
- The five unrelated shell failures are environment/prerequisite failures: three require an adjacent `omarchy-pkgs` checkout, `network-qr-test.sh` expects a usable network route, and `theme-install-guards-test.sh` sees the system-installed URL checker.
- `git diff --check` passes.

## Scope

This keeps the change focused on the orphan-package prompt reported by the issue. The similar conditional reboot prompt noted in #8780 is unchanged and can be handled separately once its unattended behavior is agreed.