### PR TITLE
Report input devices holding a button down in omarchy-debug

### DIFF
--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -26,6 +26,84 @@ while (( $# > 0 )); do
   esac
 done
 
+# A button held down forever by faulty hardware is close to invisible. Wayland
+# merges every pointer into one seat, so a dongle that reports BTN_RIGHT stuck
+# means the seat's right button is *already* pressed and no later click produces
+# a press edge -- right-click silently stops working in every application, while
+# the kernel, libinput and the compositor all keep behaving correctly. Nothing in
+# a normal log shows it, because nothing is going wrong.
+#
+# EVIOCGKEY returns the current pressed-state bitmap for a device, so one ioctl
+# per device catches it. Devices we cannot read are skipped rather than reported
+# as clean, so an unreadable device is never mistaken for a healthy one.
+report_stuck_inputs() {
+  python3 - <<'PY' 2>/dev/null || echo "(python3 unavailable - skipped)"
+import fcntl, glob, os
+
+KEY_MAX = 0x2ff
+NBYTES = (KEY_MAX // 8) + 1
+EVIOCGKEY = (2 << 30) | (NBYTES << 16) | (0x45 << 8) | 0x18
+
+NAMES = {
+    0x110: "BTN_LEFT", 0x111: "BTN_RIGHT", 0x112: "BTN_MIDDLE",
+    0x113: "BTN_SIDE", 0x114: "BTN_EXTRA",
+    29: "LEFTCTRL", 97: "RIGHTCTRL", 42: "LEFTSHIFT", 54: "RIGHTSHIFT",
+    56: "LEFTALT", 100: "RIGHTALT", 125: "LEFTMETA", 126: "RIGHTMETA",
+}
+
+
+def device_name(path):
+    node = os.path.basename(path)
+    try:
+        with open("/sys/class/input/%s/device/name" % node) as fh:
+            return fh.read().strip()
+    except OSError:
+        return "unknown"
+
+
+stuck, unreadable = [], []
+for path in sorted(glob.glob("/dev/input/event*")):
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+    except OSError:
+        unreadable.append(path)
+        continue
+    try:
+        buf = bytearray(NBYTES)
+        fcntl.ioctl(fd, EVIOCGKEY, buf)
+    except OSError:
+        unreadable.append(path)
+        continue
+    finally:
+        os.close(fd)
+
+    held = [
+        NAMES.get(byte * 8 + bit, "code_%d" % (byte * 8 + bit))
+        for byte in range(NBYTES)
+        for bit in range(8)
+        if buf[byte] >> bit & 1
+    ]
+    if held:
+        stuck.append((path, device_name(path), held))
+
+for path, name, held in stuck:
+    print("%s (%s) reports HELD: %s" % (path, name, ", ".join(held)))
+
+if not stuck:
+    print("No stuck buttons or keys detected.")
+else:
+    print("")
+    print("A button listed above is being reported as held down right now.")
+    print("If nothing is physically pressing it, that device is faulty and will")
+    print("suppress that button across the whole session. Unplug it to confirm.")
+
+if unreadable:
+    print("")
+    print("Not checked (permission denied): %s" % ", ".join(unreadable))
+    print("Add your user to the 'input' group for a complete report.")
+PY
+}
+
 LOG_FILE="/tmp/omarchy-debug.log"
 
 if [[ $NO_SUDO = "true" ]]; then
@@ -43,6 +121,11 @@ Omarchy Package: $(pacman -Q omarchy-dev 2>/dev/null || pacman -Q omarchy 2>/dev
 SYSTEM INFORMATION
 =========================================
 $(inxi -Farz)
+
+=========================================
+STUCK INPUT BUTTONS
+=========================================
+$(report_stuck_inputs)
 
 =========================================
 DMESG


### PR DESCRIPTION
## What this does

Adds a section to `omarchy-debug` that reports any input device currently holding a button or key down.

## Why this is hard to diagnose without it

Wayland merges every pointer into one seat. If a device reports `BTN_RIGHT` stuck — a failing mouse, a dodgy dongle, a tablet that never sent the release — the seat's right button is *already* pressed, so no later click produces a press edge. Right-click silently stops working in every application at once.

What makes it nasty is that nothing is failing. The kernel is fine, libinput is fine, the compositor is fine, and every log is clean, because from their point of view nothing has gone wrong: a button is down, and it stays down. The user experiences "right-click stopped working" with nothing anywhere to point at, and the usual next steps — restart the compositor, reinstall drivers, reset the config — all fail to fix something that was never software.

Unplugging the culprit fixes it instantly, but only once you know a culprit exists.

## How it detects it

`EVIOCGKEY` returns the current pressed-state bitmap for an evdev device, so one ioctl per device is enough. No polling, no event capture, no waiting to catch it happening — it reports the state as it stands right now.

Two deliberate choices:

- **A device that cannot be read is reported as skipped, never as clean.** Mistaking an unreadable device for a healthy one would send someone looking in the wrong place, which is exactly the failure this is meant to end.
- **Buttons are named** (`BTN_RIGHT`, not `0x111`), so the output says which button on which device without the reader needing a lookup table.

Falls back gracefully with a note if `python3` is unavailable, rather than failing the whole debug report.

