### PR TITLE
Add PTL kernel in installation script for all Intel Panther Lake systems

### DIFF
--- a/install/hardware/intel/ptl-kernel.sh
+++ b/install/hardware/intel/ptl-kernel.sh
@@ -1,8 +1,8 @@
-# Install Panther Lake kernel for Dell XPS Panther Lake systems
+# Install Panther Lake kernel for all Intel Panther Lake systems
 # The linux-ptl kernel includes audio driver patches not yet in mainline.
 
-if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
-  echo "Detected Dell XPS Panther Lake, installing PTL kernel..."
+if omarchy-hw-intel-ptl; then
+  echo "Detected Intel Panther Lake, installing PTL kernel..."
 
   omarchy-pkg-add linux-ptl linux-ptl-headers
   pacman -Rdd --noconfirm linux linux-headers || true
@@ -14,12 +14,15 @@ if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
     pacman -Qi linux | grep -i "required by"
   fi
 
-  mkdir -p /etc/limine-entry-tool.d
-  # Named to sort after omarchy-defaults.conf: drop-ins are read in order and
-  # the last BOOT_ORDER wins, so an earlier-sorting name is a silent no-op.
-  rm -f /etc/limine-entry-tool.d/dell-xps-panther-lake.conf
-  cat > /etc/limine-entry-tool.d/zz-dell-xps-panther-lake.conf <<'EOF'
+  # For Dell XPS, also set boot order to only show PTL kernel
+  if omarchy-hw-match "XPS"; then
+    mkdir -p /etc/limine-entry-tool.d
+    # Named to sort after omarchy-defaults.conf: drop-ins are read in order and
+    # the last BOOT_ORDER wins, so an earlier-sorting name is a silent no-op.
+    rm -f /etc/limine-entry-tool.d/dell-xps-panther-lake.conf
+    cat > /etc/limine-entry-tool.d/zz-dell-xps-panther-lake.conf <<'EOF'
 # Only show Panther Lake kernel in boot menu on Dell XPS Panther Lake
 BOOT_ORDER="linux-ptl*, *fallback, Snapshots"
 EOF
+  fi
 fi


### PR DESCRIPTION
Updated the script to install the Panther Lake kernel for all Intel Panther Lake systems instead of just Dell XPS systems.