### PR TITLE
Allow IGMP so multicast group queries stop flooding the firewall log

### DIFF
--- a/install/config/firewall.sh
+++ b/install/config/firewall.sh
@@ -6,6 +6,11 @@ ufw default allow outgoing
 ufw allow 53317/udp
 ufw allow 53317/tcp
 
+# Allow IGMP so the kernel can answer multicast group queries. Routers query
+# every 125 seconds by default, and without this the deny-incoming policy drops
+# and logs each one, burying every other kernel message in the ring buffer.
+ufw allow in proto igmp to 224.0.0.0/4 comment 'allow-igmp-multicast'
+
 # Allow Docker containers to use DNS on host.
 ufw allow in proto udp from 172.16.0.0/12 to 172.17.0.1 port 53 comment 'allow-docker-dns'
 ufw allow in proto udp from 192.168.0.0/16 to 172.17.0.1 port 53 comment 'allow-docker-dns'

--- a/migrations/1787954561.sh
+++ b/migrations/1787954561.sh
@@ -1,0 +1,15 @@
+echo "Allow IGMP so multicast group queries stop flooding the firewall log"
+
+# Omarchy's deny-incoming policy has no exception for IGMP, so ufw drops and
+# logs every multicast group query the router sends. The default query interval
+# is 125 seconds, which is thousands of log entries a day on an ordinary LAN.
+# They evict everything else from the kernel ring buffer and leave dmesg useless
+# for diagnosing real problems. A host that never answers those queries can also
+# be pruned from multicast by a switch doing IGMP snooping, which breaks mDNS and
+# LocalSend discovery.
+#
+# Machine-wide, but self-detecting: a second user's rerun finds the rule already
+# added and no-ops, so no marker file is needed.
+if ! sudo ufw show added | grep -q "allow-igmp-multicast"; then
+  sudo ufw allow in proto igmp to 224.0.0.0/4 comment 'allow-igmp-multicast'
+fi


### PR DESCRIPTION
## The problem

`install/config/firewall.sh` sets `ufw default deny incoming` with no exception for IGMP. Routers act as the network's IGMP querier and send group membership queries every 125 seconds (the RFC default query interval), so ufw drops and logs every one.

On my machine that is **9,168 blocked packets in a single boot, 9,138 of them IGMP — 99.7%**. Only 30 blocks were actual TCP/UDP traffic:

```
5132  DST=224.0.0.1     (all-hosts general queries)
4006  DST=224.0.0.251   (mDNS group-specific queries)
  30  real TCP/UDP
```

The practical effect is that the kernel ring buffer is entirely evicted within hours, so `dmesg` is useless for diagnosing anything else. I hit this while trying to read i915 errors on a dock wake hang and found six days of uptime had left nothing but UFW lines.

## Second-order effect

A host that never answers membership queries can be pruned from multicast by a switch doing IGMP snooping. That breaks the mDNS discovery LocalSend depends on — even though `firewall.sh` already opens its port explicitly. ufw's `before.rules` permits mDNS *data* (`udp/5353 -> 224.0.0.251`) but nothing permits the group-management layer that keeps it flowing.

## The change

```
ufw allow in proto igmp to 224.0.0.0/4 comment 'allow-igmp-multicast'
```

Scoped to the multicast destination range rather than allowing IGMP from anywhere. IGMP carries no payload reachable from off-link — these packets are TTL 1 — so this does not widen the attack surface.

Two parts, because `install/` only runs on fresh installs:

- `install/config/firewall.sh` — new installs
- `migrations/1787954561.sh` — existing installs

The migration is machine-wide but self-detecting via `ufw show added`, so a second user's run no-ops and no marker file is needed (same pattern as `1787589206.sh`). No `omarchy-cmd-missing ufw` guard, since `ufw` is in `omarchy-base.packages` and AGENTS.md treats default-set commands as runtime invariants.

## Testing

- `./test/all` — 3 of 211 files failed, all pre-existing and unrelated (verified identical with the change stashed; they need a sibling `omarchy-pkgs` checkout)
- Migration run against a live system with the rule already present: correctly no-ops
- Rule applied on ThinkPad L13 Gen 2, Omarchy 4.0.0, ufw 0.36.2 — accept counter increments, and UFW blocks dropped from ~2.5/min to **zero**

🤖 Generated with [Claude Code](https://claude.com/claude-code)