### PR TITLE
Fix migration 1787515927 failing on Bash 5.3

### DIFF
--- a/bin/omarchy-theme-set-browser-policy
+++ b/bin/omarchy-theme-set-browser-policy
@@ -76,8 +76,13 @@ require_root "$color"
 
 failed=0
 staged=""
+# Bash 5.3 makes the EXIT trap's last command decide the script's exit status,
+# so this handler must not end on a false test. Every successful run clears
+# staged, and a trailing `[[ -n $staged ]] && ...` would report that as failure.
 cleanup() {
-  [[ -n $staged ]] && rm -f "$staged"
+  if [[ -n $staged ]]; then
+    rm -f "$staged"
+  fi
 }
 trap cleanup EXIT
 

--- a/migrations/1787515927.sh
+++ b/migrations/1787515927.sh
@@ -9,8 +9,11 @@ for dir in "${BROWSER_POLICY_MANAGED_DIRS[@]}"; do
   repaired=1
 done
 
+# Repainting the policy color is cosmetic and the next theme change redoes it.
+# Under bash -euo pipefail a failure here would abort the migration before the
+# Firefox directories below are hardened, and the marker would never be written.
 if (( repaired )); then
-  omarchy-theme-set-browser
+  omarchy-theme-set-browser || true
 fi
 
 for dir in "${BROWSER_POLICY_FIREFOX_DIRS[@]}"; do

--- a/test/shell.d/browser-policy-dir-test.sh
+++ b/test/shell.d/browser-policy-dir-test.sh
@@ -294,6 +294,10 @@ cleanup || fail "omarchy-theme-set-browser-policy's EXIT trap succeeds with a st
 unset -f cleanup
 pass "omarchy-theme-set-browser-policy's EXIT trap never leaks a failure status"
 
+grep -F 'omarchy-theme-set-browser || true' "$ROOT/migrations/1787515927.sh" >/dev/null ||
+  fail "the policy-directory migration hardens Firefox even when the theme refresh fails"
+pass "the policy-directory migration does not abort on a failed theme refresh"
+
 policy_files=(
   "$ROOT/bin/omarchy-install-browser"
   "$ROOT/bin/omarchy-provision-owner"

--- a/test/shell.d/browser-policy-dir-test.sh
+++ b/test/shell.d/browser-policy-dir-test.sh
@@ -279,6 +279,21 @@ grep -F 'exit "$failed"' "$ROOT/bin/omarchy-theme-set-browser" >/dev/null ||
   fail "omarchy-theme-set-browser exits non-zero when a policy write fails"
 pass "omarchy-theme-set-browser exits non-zero when a policy write fails"
 
+# Bash 5.3 adopts the EXIT trap's last status as the script's exit status, so a
+# handler ending on a false test turns a clean run into a failure and aborts the
+# migration that calls this through omarchy-theme-set-browser.
+policy_cleanup=$(sed -n '/^cleanup() {/,/^}/p' "$ROOT/bin/omarchy-theme-set-browser-policy")
+[[ -n $policy_cleanup ]] || fail "omarchy-theme-set-browser-policy defines an EXIT cleanup handler"
+eval "$policy_cleanup"
+staged=""
+cleanup || fail "omarchy-theme-set-browser-policy's EXIT trap succeeds with nothing staged"
+staged=$test_tmp/staged-policy
+: >"$staged"
+cleanup || fail "omarchy-theme-set-browser-policy's EXIT trap succeeds with a staged file"
+[[ ! -e $staged ]] || fail "omarchy-theme-set-browser-policy's EXIT trap removes the staged file"
+unset -f cleanup
+pass "omarchy-theme-set-browser-policy's EXIT trap never leaks a failure status"
+
 policy_files=(
   "$ROOT/bin/omarchy-install-browser"
   "$ROOT/bin/omarchy-provision-owner"


### PR DESCRIPTION
Fixes #8832. Root cause diagnosed in #8833.

`omarchy update` aborts at migration `1787515927` ("Stop world-writable Chromium and Firefox policy directories") and fails identically on every retry, because `omarchy-migrate` only writes the completion marker after the migration script succeeds.

## Why it fails

`bin/omarchy-theme-set-browser-policy` installs an `EXIT` trap whose handler ends on a test:

```bash
staged=""
cleanup() {
  [[ -n $staged ]] && rm -f "$staged"
}
trap cleanup EXIT
```

Every successful run clears `staged` after writing each policy file, so at exit the test is false, the `&&` list short-circuits, and `cleanup` returns 1. Bash 5.3 adopts the `EXIT` trap's last status as the script's exit status, overriding `exit "$failed"`. Bash 5.2 did not.

```console
$ bash --version | head -1
GNU bash, version 5.3.15(1)-release (x86_64-pc-linux-gnu)
$ bash -c 'set -euo pipefail; staged=""; cleanup(){ [[ -n $staged ]] && rm -f "$staged"; }; trap cleanup EXIT; exit 0'; echo $?
1
```

`omarchy-theme-set-browser` propagates that as its own status, and the migration runs under `bash -euo pipefail`, so it aborts — after the Chromium half, before the Firefox half. Any machine that reaches the theme call never gets its `/usr/lib/firefox/distribution` or `/opt/zen-browser/distribution` hardened, which is what the migration exists to do.

It also means every theme change has been getting a spurious nonzero status from the browser step, since `omarchy-theme-set` calls `omarchy-theme-set-browser`.

## The fix

Two commits:

1. Rewrite `cleanup` as an `if` so the handler cannot end on a false test and leak a failure status.
2. Make the migration's theme repaint non-fatal. Repainting the policy color is cosmetic and the next theme change redoes it; it should never stand between the migration and the Firefox directories it still has to harden. This also covers the related hang reported in #8212 and #8158 to the extent that a failing (rather than hanging) browser refresh can no longer block the migration.

## Testing

Extends `test/shell.d/browser-policy-dir-test.sh`: it evaluates the real `cleanup` handler out of the script and asserts it returns 0 both with nothing staged and with a staged file present (also checking the file is removed). The assertion is bash-version independent — it pins the invariant rather than the 5.3 behavior.

Verified the new assertion fails against the unfixed scripts and passes with them, and that each commit passes `browser-policy-dir-test.sh` on its own.

`./test/cli` passes. `./test/shell` reports 6 of 211 files failing on my machine, all of which reproduce unchanged at the base commit (7d58bb9a) and none of which touch browser policy:

- `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh` — need an `omarchy-pkgs` checkout that is not present here
- `theme-install-guards-test.sh` — `omarchy-theme-install refuses a URL it cannot check`
- `runtime-smoke-test.sh` — `saw 3 [IPC handlers] for 2 screen(s)` against the live compositor
- `copy-url-shortcut-migration-test.sh` — hangs where `python3` is a version-manager shim: the test's stub `python3` calls `$REAL_PYTHON`, the shim re-resolves `python3` through `PATH`, finds the stub again, and recurses without bound. Unrelated to this PR; fixed separately in #8839 (issue #8742).

