### PR TITLE
Show power profiles on battery-less machines

### DIFF
--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -19,11 +19,14 @@ Panel {
   property string activeProfile: ""
   property int profileIndex: 0
   property bool cursorActive: false
+  readonly property var idleService: bar?.shell?.firstPartyServiceFor("omarchy.idle")
+  readonly property bool screensaverActive: idleService ? idleService.screensaverWindowCount > 0 : false
   readonly property bool showPercentage: setting("showPercentage", false) === true
+  readonly property bool percentageVisible: batteryPresent && showPercentage && !button.vertical
   // With the percentage shown the button paints a text block wider than an
   // icon, so the open-panel mark takes the painted width instead of the
   // icon-sized fraction of the slot the fallback assumes.
-  readonly property real openPanelIndicatorWidth: showPercentage && !button.vertical ? button.glyphPaintedWidth : 0
+  readonly property real openPanelIndicatorWidth: percentageVisible ? button.glyphPaintedWidth : 0
   readonly property bool batteryPresent: {
     var device = UPower.displayDevice
     return !!(device && device.isPresent)
@@ -50,6 +53,10 @@ Panel {
   function batteryIcon() {
     var device = UPower.displayDevice
     return Model.batteryIcon(device, root.discharging, upowerStates())
+  }
+
+  function barIcon() {
+    return batteryPresent ? batteryIcon() : ""
   }
 
   function modeLabel() {
@@ -133,11 +140,14 @@ Panel {
   }
 
   function refresh() {
-    if (!batteryPresent) return
-
-    if (!batteryProc.running) batteryProc.running = true
+    if (batteryPresent && !batteryProc.running) batteryProc.running = true
     if (!profilesProc.running) profilesProc.running = true
-    if (!systemProc.running) systemProc.running = true
+    if (batteryPresent && !systemProc.running) systemProc.running = true
+  }
+
+  function open() {
+    if (screensaverActive) return
+    controller.show()
   }
 
   function updateKeyValue(raw, targetName) {
@@ -187,11 +197,6 @@ Panel {
 
   onOpenedChanged: {
     if (opened) {
-      if (!batteryPresent) {
-        close()
-        return
-      }
-
       refresh()
       var idx = profiles.indexOf(activeProfile)
       profileIndex = idx >= 0 ? idx : 0
@@ -199,11 +204,11 @@ Panel {
     }
   }
 
-  onBatteryPresentChanged: if (!batteryPresent) close()
+  onBatteryPresentChanged: if (opened) refresh()
+  onScreensaverActiveChanged: if (screensaverActive && opened) close()
 
-  visible: batteryPresent
-  implicitWidth: batteryPresent ? button.implicitWidth : 0
-  implicitHeight: batteryPresent ? button.implicitHeight : 0
+  implicitWidth: button.implicitWidth
+  implicitHeight: button.implicitHeight
 
   Process {
     id: batteryProc
@@ -277,14 +282,15 @@ Panel {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.showPercentage && !vertical
-      ? Math.round(root.batteryFraction * 100) + "% " + root.batteryIcon()
-      : root.batteryIcon()
-    slotSize: Style.bar.iconSlot * (root.showPercentage && !vertical ? 2 : 1)
+    text: root.percentageVisible
+      ? Math.round(root.batteryFraction * 100) + "% " + root.barIcon()
+      : root.barIcon()
+    slotSize: Style.bar.iconSlot * (root.percentageVisible ? 2 : 1)
     tooltipText: ""
     onPressed: function(b) {
-      if (!root.batteryPresent) return
-      if (b === Qt.RightButton) root.togglePercentage()
+      if (b === Qt.RightButton) {
+        if (root.batteryPresent) root.togglePercentage()
+      }
       else root.toggle()
     }
   }
@@ -294,7 +300,7 @@ Panel {
     anchorItem: button
     owner: root
     bar: root.bar
-    open: root.opened && root.batteryPresent
+    open: root.opened
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(380))
     contentHeight: panel.fittedContentHeight(column.implicitHeight)
@@ -320,6 +326,7 @@ Panel {
 
         // ---------- Hero: battery icon · title/status · percentage ----------
         Item {
+          visible: root.batteryPresent
           width: parent.width
           implicitHeight: Math.max(heroIcon.implicitHeight, heroLabels.implicitHeight, heroPercent.implicitHeight)
 
@@ -386,6 +393,7 @@ Panel {
 
         // ---------- Battery progress bar ----------
         Item {
+          visible: root.batteryPresent
           width: parent.width
           implicitHeight: Style.space(8)
 
@@ -426,7 +434,7 @@ Panel {
         // the battery sits above the charge-control start threshold, and we
         // refuse to flicker the whole panel for that ~1s window.
         Row {
-          visible: root.batteryInfo.percentage !== undefined
+          visible: root.batteryPresent && root.batteryInfo.percentage !== undefined
           width: parent.width
           spacing: Style.space(20)
 
@@ -453,6 +461,7 @@ Panel {
 
         // ---------- Power profile picker ----------
         PanelSeparator {
+          visible: root.batteryPresent
           foreground: root.bar.foreground
         }
 
@@ -461,7 +470,7 @@ Panel {
           spacing: Style.space(10)
 
           PanelSectionHeader {
-            text: "POWER PROFILE"
+            text: "AVAILABLE POWER PROFILES"
             foreground: root.bar.foreground
             fontFamily: root.bar.fontFamily
           }

--- a/test/acceptance.d/panels-test.sh
+++ b/test/acceptance.d/panels-test.sh
@@ -23,6 +23,7 @@ hide_panels() {
 
 restore_weather() {
   hide_panels
+  close_windows 'org\.omarchy\.screensaver'
 
   if ((weather_existed)); then
     mkdir -p "$(dirname "$WEATHER_FILE")"
@@ -46,6 +47,60 @@ open_and_capture_panel() {
 
   omarchy-shell shell hide "$plugin" >/dev/null
   wait_until "$name panel closes" 15 layer_absent "omarchy-keyboard-panel"
+}
+
+screen_contains_upscaled() {
+  local text="$1"
+  local work snapshot status=1
+
+  work=$(mktemp -d)
+  snapshot="$work/screen.png"
+
+  if timeout 10 grim "$snapshot" 2>/dev/null &&
+    magick "$snapshot" -crop 2x2@ +repage -resize 400% -colorspace Gray -auto-level "$work/tile-%d.png" 2>/dev/null; then
+    if for tile in "$work"/tile-*.png; do
+      tesseract "$tile" stdout --psm 11 2>/dev/null
+    done | grep -Fi -- "$text" >/dev/null; then
+      status=0
+    fi
+  fi
+
+  rm -rf "$work"
+  return "$status"
+}
+
+open_and_capture_power_panel() {
+  omarchy-shell shell summon omarchy.power >/dev/null
+  wait_until "power panel opens" 15 layer_present "omarchy-keyboard-panel"
+  wait_until "available power profiles are visible" 15 screen_contains_upscaled "AVAILABLE POWER PROFILES"
+
+  if upower -e | grep '/battery_' >/dev/null; then
+    wait_until "power battery details are visible" 15 screen_contains_upscaled "Battery"
+  else
+    if screen_contains_upscaled "Battery"; then
+      fail "power panel hides battery details without battery hardware"
+    fi
+    pass "power panel hides battery details without battery hardware"
+  fi
+
+  sleep 1
+  screenshot "success-panel-power"
+  omarchy-shell shell hide omarchy.power >/dev/null
+  wait_until "power panel closes" 15 layer_absent "omarchy-keyboard-panel"
+}
+
+verify_power_hidden_over_screensaver() {
+  omarchy-launch-screensaver force
+  wait_until "screensaver opens for power suppression" 15 window_present 'org\.omarchy\.screensaver'
+
+  omarchy-shell shell summon omarchy.power >/dev/null
+  sleep 1
+  layer_absent "omarchy-keyboard-panel" || fail "power panel stays hidden over the screensaver"
+  pass "power panel stays hidden over the screensaver"
+  screenshot "success-panel-power-screensaver-hidden"
+
+  close_windows 'org\.omarchy\.screensaver'
+  wait_until "screensaver closes after power suppression" 15 window_absent 'org\.omarchy\.screensaver'
 }
 
 # Give weather deterministic coordinates so this test exercises the real
@@ -73,18 +128,20 @@ while IFS='|' read -r name plugin; do
   fi
 done <<<"$panels"
 
-# The power widget intentionally disappears on desktops and VMs without a
-# battery. Exercise it on laptops, and verify that hardware-less sessions take
-# the supported no-panel path instead of treating that as a shell failure.
-if upower -e | grep '/battery_' >/dev/null; then
-  if ! (trap - EXIT; open_and_capture_panel "power" "omarchy.power"); then
-    status=1
-    hide_panels
-    wait_until "power failed panel is dismissed" 15 layer_absent "omarchy-keyboard-panel"
-  fi
-else
-  pass "power panel is hidden without battery hardware"
-  screenshot "success-panel-power-unavailable"
+# The profile picker is useful on every machine. Battery-less systems render
+# the supported profiles without the battery-specific hero and statistics.
+if ! (trap - EXIT; open_and_capture_power_panel); then
+  status=1
+  hide_panels
+  wait_until "power failed panel is dismissed" 15 layer_absent "omarchy-keyboard-panel"
+fi
+
+if ! (trap - EXIT; verify_power_hidden_over_screensaver); then
+  status=1
+  hide_panels
+  close_windows 'org\.omarchy\.screensaver'
+  wait_until "power suppression failure is dismissed" 15 layer_absent "omarchy-keyboard-panel"
+  wait_until "screensaver suppression failure is dismissed" 15 window_absent 'org\.omarchy\.screensaver'
 fi
 
 # The common panel keyboard contract uses Tab to move to the next bar panel.

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -19,6 +19,11 @@ assertDeepEqual(
   { profiles: ['power-saver', 'balanced', 'performance'], activeProfile: 'balanced', profileIndex: 2 },
   'power parses profile output and clamps selection'
 )
+assertDeepEqual(
+  power.parseProfiles('power-saver\t0\nbalanced\t1\n', 0),
+  { profiles: ['power-saver', 'balanced'], activeProfile: 'balanced', profileIndex: 0 },
+  'power accepts fallback platforms without a performance profile'
+)
 
 assert(power.profileIcon('performance').length > 0, 'power maps profile icons')
 assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'power clamps battery fraction')
@@ -42,10 +47,21 @@ assertEqual(
   'power shows battery icon when unplugged before battery state refreshes'
 )
 
-assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
+assert(/if \(root\.batteryPresent\) root\.togglePercentage\(\)/.test(panelSource), 'power limits the percentage toggle to battery hardware')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')
-assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon')
-assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
+assert(/percentageVisible: batteryPresent && showPercentage && !button\.vertical/.test(panelSource), 'power suppresses percentage text without battery hardware')
+assert(/return batteryPresent \? batteryIcon\(\) : ""/.test(panelSource), 'power uses an AC plug icon without battery hardware')
+assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.barIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon')
+assert(/openPanelIndicatorWidth: percentageVisible \? button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
+assert(/open: root\.opened\n/.test(panelSource), 'power panel opens without requiring battery hardware')
+assert(!/if \(!batteryPresent\) \{\s*close\(\)/.test(panelSource), 'power does not self-close without battery hardware')
+assert(/idleService: bar\?\.shell\?\.firstPartyServiceFor\("omarchy\.idle"\)/.test(panelSource), 'power reads the shared screensaver state')
+assert(/function open\(\) \{\s*if \(screensaverActive\) return\s*controller\.show\(\)\s*\}/.test(panelSource), 'power refuses to open over the screensaver')
+assert(/onScreensaverActiveChanged: if \(screensaverActive && opened\) close\(\)/.test(panelSource), 'power closes if the screensaver starts while it is open')
+assert(/if \(batteryPresent && !systemProc\.running\) systemProc\.running = true/.test(panelSource), 'power keeps unused system-stat polling off battery-less hardware')
+assert(/visible: root\.batteryPresent[\s\S]*text: "Battery"/.test(panelSource), 'power keeps the battery hero hardware-scoped')
+assert(/PanelSeparator \{\s*visible: root\.batteryPresent/.test(panelSource), 'power hides the battery separator without battery hardware')
+assert(/text: "AVAILABLE POWER PROFILES"/.test(panelSource), 'power presents daemon-advertised profiles as the complete available set')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
 JS

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -227,7 +227,8 @@ visible_default_ids='[
   "omarchy.system-update",
   "omarchy.network",
   "omarchy.audio",
-  "omarchy.monitor"
+  "omarchy.monitor",
+  "omarchy.power"
 ]'
 
 geometry=""
@@ -279,6 +280,11 @@ for panel_id in omarchy.audio omarchy.bluetooth omarchy.monitor omarchy.network 
   shell_ipc "$panel_id" close >/dev/null || fail_with_log "direct panel IPC closes $panel_id"
 done
 pass "direct panel IPC opens and closes default panels"
+
+if grep -F 'Binding loop detected for property "opened"' "$log" >/dev/null; then
+  fail_with_log "default panels open without an opened binding loop"
+fi
+pass "default panels open without an opened binding loop"
 
 # Each widget registers its IPC handler once per bar, and the bar is
 # instantiated once per screen, so Quickshell reports one collision per screen


### PR DESCRIPTION
## Summary

- Restore the Power bar widget and panel on machines without batteries, using the historical AC plug glyph.
- Keep profile handling capability-driven through `power-profiles-daemon`; the panel renders only the profiles the daemon advertises and labels them as **AVAILABLE POWER PROFILES**.
- Keep battery percentage, hero, progress, statistics, and separator scoped to systems with battery hardware.
- Prevent the Power panel from opening over the screensaver, and close it if the screensaver starts while the panel is open.
- Preserve existing AC/battery profile preferences and IPC/keybinding routes.

## Testing

- `bash test/shell.d/power-test.sh`
- `bash -n test/shell.d/power-test.sh test/shell.d/runtime-smoke-test.sh test/acceptance.d/panels-test.sh`
- ARM UTM VM without a battery:
  - confirmed the plug icon and compact panel
  - opened from the icon and `SUPER+CTRL+P`
  - confirmed only daemon-advertised `power-saver` and `balanced` profiles
  - changed profiles, verified the active state, and restored `balanced`
  - verified the panel stays hidden over the screensaver
  - confirmed no Power-panel `opened` binding-loop warning in the user journal
- `./test/shell`: 204/208; the four failures reproduce on the untouched base (`config-test`, `snapper-test`, `theme-install-guards`, and `unowned-system-paths`)
- `./test/all`: same four baseline failures; a transient blank-frame `screenshot-sanity-test` failure passed when rerun independently

Fixes #8536