### PR TITLE
Stop the copy-url migration test from fork-bombing the session under a python3 shim

### DIFF
--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -28,7 +28,13 @@ write_stale_preferences() {
 stub_bin="$test_dir/bin"
 mkdir -p "$stub_bin"
 
-REAL_PYTHON=$(command -v python3)
+# The stubs below shadow python3 on PATH and delegate to this interpreter, so
+# it has to be the interpreter itself rather than whatever `command -v` finds.
+# Where python3 is a version-manager shim (mise, asdf, pyenv), the shim resolves
+# python3 through PATH again, lands back on the stub, and recurses without
+# bound. sys.executable is always the real binary.
+REAL_PYTHON=$(python3 -c 'import sys; print(sys.executable)')
+[[ -x $REAL_PYTHON ]] || fail "python3 reports the interpreter behind any shim"
 export REAL_PYTHON
 
 run_migration() {


### PR DESCRIPTION
Fixes #8742.

`test/shell.d/copy-url-shortcut-migration-test.sh` hangs and spawns an unbounded process chain on any machine where `python3` resolves to a version-manager shim. I hit this running the suite on an unrelated change: it took ~11 minutes to notice, and the chain was hundreds of processes deep across two runs before I killed it. #8742 documents the full blast radius — the session's `TasksMax` is exhausted, unrelated processes are denied forks, and `mise` aborts with a core dump.

## Mechanism

Line 31 captured the interpreter as `REAL_PYTHON=$(command -v python3)`. Where python is installed under a version manager but not active in the current directory, that is the **shim**, not an interpreter. The test then writes its own `python3` stub into `$stub_bin`, puts that directory first on `PATH`, and has the stub delegate with `"${REAL_PYTHON}" "$@"`. The shim resolves `python3` through `PATH` again, finds the stub, and the loop closes:

> stub → shim → `PATH` lookup → stub → shim → …

The stub uses no `exec`, so every level forks and waits.

Reproduced here in isolation, with a depth counter standing in for the unbounded chain:

```console
$ command -v python3
/home/ryan/.local/share/mise/shims/python3
$ # stub on PATH delegating to $REAL_PYTHON=the shim:
stub depth 0
stub depth 1
stub depth 2
stub depth 3
stub depth 4
RECURSION CONFIRMED
```

## The fix

Ask the interpreter where it lives instead of asking `PATH` what `python3` means:

```bash
REAL_PYTHON=$(python3 -c 'import sys; print(sys.executable)')   # /usr/bin/python3
```

`sys.executable` is the real binary, so the delegated call never re-enters a `PATH` lookup and cannot land back on the stub. On a machine with no shim this resolves to the same interpreter `command -v` would have found, so behavior is unchanged there.

This is the same fix proposed in #8742; I reached it independently before finding the issue, which I take as a good sign it is the right one. As that issue notes, it is the only occurrence of the pattern in `test/shell.d` — `command -v` is unsafe for any name a version manager shims (mise, asdf, pyenv, rbenv) when paired with a same-named stub earlier on `PATH`.

I did not implement the issue's optional suggestion of running `test/shell` under a `TasksMax` cap. It is a change to the runner for everyone and depends on `systemd-run` being present, so it seemed like a maintainer call rather than something to fold into this fix.

## Testing

The test previously hung at `migration stays pending when a browser starts mid-repair` and never reached the four assertions after it. With this change all 13 assertions pass and no stray processes are left behind:

```console
$ bash test/shell.d/copy-url-shortcut-migration-test.sh
...
ok - migration stays pending when a browser starts mid-repair
ok - migration stays pending when a briefly-lived browser undoes the repair
ok - migration keeps an unverified repair pending while a browser runs
ok - migration verifies an attempted repair on a browser-free rerun
ok - migration leaves installed third-party extensions alone
$ echo $?
0
```

The two assertions that exercise the stubs both pass, so the stubs are still reached and doing their job — they were simply never able to return before.