### PR TITLE
Add opt-in toggle to scale X11 apps that ignore HiDPI hints

### DIFF
--- a/bin/omarchy-hyprland-xwayland-scaling-toggle
+++ b/bin/omarchy-hyprland-xwayland-scaling-toggle
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle compositor upscaling for X11 apps that ignore HiDPI scaling hints.
+
+# nf-md-monitor, escaped so this file reads without a Nerd Font.
+readonly MONITOR_GLYPH=$'\U000f0379'
+
+case $(omarchy-hyprland-toggle xwayland-scaling) in
+  on) omarchy-notification-send -g "$MONITOR_GLYPH" "X11 app scaling enabled" "Restart X11 apps to resize them" ;;
+  off) omarchy-notification-send -g "$MONITOR_GLYPH" "X11 app scaling disabled" "Restart X11 apps to resize them" ;;
+esac

--- a/default/hypr/toggles/xwayland-scaling.lua
+++ b/default/hypr/toggles/xwayland-scaling.lua
@@ -1,0 +1,16 @@
+-- Let Hyprland upscale X11 (XWayland) apps to match the monitor scale.
+--
+-- By default Omarchy sets xwayland:force_zero_scaling, which hands X11 clients
+-- an unscaled surface. Toolkit-aware apps (GTK/Qt/Electron) then scale
+-- themselves via GDK_SCALE/QT_* and stay crisp. Apps that ignore those hints
+-- render at 1x instead, so on a 2x monitor their text and controls come out
+-- half size (RealVNC Viewer, older Java/Motif/Tk apps, some installers).
+--
+-- Turning this flag on drops force_zero_scaling so the compositor upscales
+-- those windows to the monitor scale: correct apparent size, at the cost of
+-- slightly softer text on X11 apps that were already scaling themselves.
+hl.config({
+  xwayland = {
+    force_zero_scaling = false,
+  },
+})

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -97,6 +97,7 @@
   "trigger.toggle.workspace-layout": {"icon":"󱂬","label":"Workspace Layout","action":"omarchy-hyprland-workspace-layout-toggle"},
   "trigger.toggle.window-gaps": {"icon":"","label":"Window Gaps","action":"omarchy-hyprland-window-gaps-toggle"},
   "trigger.toggle.one-window-ratio": {"icon":"","label":"1-Window Ratio","action":"omarchy-hyprland-window-single-square-aspect-toggle"},
+  "trigger.toggle.xwayland-scaling": {"icon":"󰍹","label":"X11 App Scaling","checked":"omarchy-hyprland-toggle-enabled xwayland-scaling","action":"omarchy-hyprland-xwayland-scaling-toggle"},
   "trigger.tests.network-speedtest": {"icon":"󰓅","label":"Network Speed Test","action":"omarchy-shell shell summon omarchy.speedtest"},
   "trigger.tests.disk-speedtest": {"icon":"󰋊","label":"Disk Speed Test","action":"omarchy-shell shell summon omarchy.disk-speedtest"},
 

--- a/manual/33-monitors.md
+++ b/manual/33-monitors.md
@@ -30,6 +30,14 @@ omarchy display text size 14
 
 That takes a pixel size between 9 and 20, and moves the Omarchy shell, GTK applications, and your terminal together, so the whole desktop stays in proportion. Run it without an argument to see where you're at, and `omarchy display text size reset` to go back to the default. Foot is the one straggler: it has no way to reload its config, so running terminals keep their old size until you open a new one.
 
+### X11 apps that come out tiny on a scaled monitor
+
+On a scaled monitor, Omarchy hands X11 (XWayland) apps an unscaled surface, and the toolkit is expected to scale itself via `GDK_SCALE` and friends. GTK, Qt, and Electron apps do exactly that and stay perfectly crisp.
+
+Some X11 apps ignore those hints entirely and just render at 1x, so on a 2x monitor their text and buttons come out half size. RealVNC Viewer is the usual example, along with older Java/Motif/Tk apps and some installers.
+
+Toggle _Trigger > Toggle > X11 App Scaling_ in the Omarchy menu (or run `omarchy-hyprland-xwayland-scaling-toggle`) to have the compositor upscale those windows to the monitor scale instead. Each window is scaled by the scale of the monitor it's actually on, so a mixed 2x + 1x setup keeps both correct, and a window re-scales when you drag it across. The tradeoff is that X11 apps which were already scaling themselves properly will look slightly softer while this is on, so flip it back off if you don't need it. The menu row carries a ✓ while it's on, and toggling it notifies you to restart the affected app.
+
 ### Extending and mirroring laptop displays
 
 When you connect an external screen to your laptop, the display is automatically extended. But you can change that to mirroring instead using _Trigger > Hardware_ in the Omarchy menu or `Super + Ctrl + Alt + Delete`. This is especially helpful if that external screen is a projector, and you want to show something while working.


### PR DESCRIPTION
## Problem

On a scaled monitor, X11 apps that ignore HiDPI hints render at half size.

Omarchy sets `xwayland:force_zero_scaling`, which hands X11 clients an unscaled
surface and expects the toolkit to scale itself via `GDK_SCALE`/`QT_*`. GTK, Qt and
Electron apps do exactly that and stay perfectly crisp — that's why this default is
the right one.

But apps that ignore those hints just render at 1x. On a 2x monitor their text and
controls come out half size. RealVNC Viewer is the common case (reported on a
3456x2234 MacBook display at scale 2), along with older Java/Motif/Tk apps and some
installers.

Measured on eDP-1 @ 2x with Hyprland 0.56.1: RealVNC Viewer reports 852x530 with the
current default, versus 1714x1071 once the compositor scales it.

## Fix

Add an `xwayland-scaling` toggle that drops `force_zero_scaling`, so the compositor
upscales those windows to the monitor scale instead.

- `default/hypr/toggles/xwayland-scaling.lua` — the flag
- `bin/omarchy-hyprland-xwayland-scaling-toggle` — wrapper, matching
  `omarchy-hyprland-window-gaps-toggle`
- menu entry under _Trigger > Toggle_ as "X11 App Scaling"
- manual section in `manual/33-monitors.md`

It reuses the existing `omarchy-hyprland-toggle` flag mechanism, so it's opt-in,
reversible, and applies live via `hyprctl reload` — no relogin needed.

The toggle notifies on both transitions (matching
`omarchy-hyprland-window-single-square-aspect-toggle`), because X11 clients only pick
up the new scale when restarted — without a hint that's easy to read as "the toggle did
nothing". The menu row also carries the usual `✓` while it's on, driven by the existing
`omarchy-hyprland-toggle-enabled` predicate through the standard `checked:` field.

## Why off by default

`force_zero_scaling` is a global option — Hyprland has no per-window rule for it. X11
apps that already scale themselves correctly look slightly softer when it's off, so
enabling this for everyone would trade crispness across the whole desktop to fix a
handful of apps. Opt-in keeps the good default and gives affected users a switch.

## Mixed-scale monitors

Scaling is resolved per monitor, not globally, so a 2x + 1x setup stays correct.
`CWindow::realToReportSize` / `xwaylandSizeToReal` use `PMONITOR->m_scale` — the scale
of the monitor each window is currently on — and windows re-scale when moved between
monitors.

Verified with a headless 1x output alongside a 2x eDP-1: two RealVNC windows under the
same toggle reported 1714x1071 on the 2x monitor and 948x1040 on the 1x monitor, and a
window re-scaled when dispatched across.

## Relationship to #7021

#7021 is the opposite failure mode on the same option: apps that *do* honor `GDK_SCALE`
get oversized when the auto monitor scale and `GDK_SCALE` disagree. This PR does not
attempt to fix that, and does not change any default — it only adds an opt-in escape
hatch for clients that ignore the hints entirely. The two are complementary.

## Verification

- Toggle on → `xwayland:force_zero_scaling = false`; off → `true`; flag file created
  and removed correctly.
- Notifications confirmed on both transitions in the running UI, glyph rendering
  correctly.
- `checked:` verified through `MenuModel.labelFor`, which yields "X11 App Scaling ✓"
  when enabled and the bare label when not; `omarchy-hyprland-toggle-enabled
  xwayland-scaling` returns the matching exit status in both states.
- RealVNC Viewer confirmed correct size in the running UI, and the menu toggle applied
  instantly (slightly softer text, as expected).
- Menu entry parses with the repo's own `MenuModel.js parseMenuJsonc`, producing the
  same shape as its siblings.
- `./test/cli` passes with 0 failures.
- `./test/shell` shows 4 failures, all reproduced identically on a clean unmodified
  clone — pre-existing and unrelated (missing `omarchy-pkgs` checkout x3, plus a
  network-dependent `omarchy-theme-install` check).

Tested on Hyprland 0.56.1, aarch64 (Asahi), scale 2 display.
