### PR TITLE
Fix SDDM greeter never auto-selecting the Omarchy session

### DIFF
--- a/default/sddm/omarchy/Main.qml
+++ b/default/sddm/omarchy/Main.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import SddmComponents 2.0
+import "resolve-session-index.js" as SessionIndex
 
 Rectangle {
   id: root
@@ -9,14 +10,7 @@ Rectangle {
 
   property string currentUser: userModel.lastUser
   property bool loginFailed: false
-  property int sessionIndex: {
-    for (var i = 0; i < sessionModel.rowCount(); i++) {
-      var name = (sessionModel.data(sessionModel.index(i, 0), Qt.DisplayRole) || "").toString()
-      if (name.indexOf("uwsm") !== -1)
-        return i
-    }
-    return sessionModel.lastIndex
-  }
+  property int sessionIndex: SessionIndex.resolveSessionIndex(sessionModel, Qt.UserRole + 2)
 
   Connections {
     target: sddm

--- a/default/sddm/omarchy/resolve-session-index.js
+++ b/default/sddm/omarchy/resolve-session-index.js
@@ -1,0 +1,15 @@
+.pragma library
+
+// SDDM's SessionModel.data() only handles its own SessionRoles enum (FileRole =
+// Qt.UserRole + 2); it has no Qt.DisplayRole case and returns an invalid
+// QVariant for it, so DisplayRole must not be used here. Match on the .desktop
+// path rather than the display name: "uwsm" also appears in the name of
+// hyprland-uwsm.desktop, which sorts ahead of omarchy.desktop.
+function resolveSessionIndex(sessionModel, fileRole) {
+  for (var i = 0; i < sessionModel.rowCount(); i++) {
+    var file = (sessionModel.data(sessionModel.index(i, 0), fileRole) || "").toString()
+    if (file.indexOf("/omarchy.desktop") !== -1)
+      return i
+  }
+  return sessionModel.lastIndex
+}

--- a/test/shell.d/sddm-greeter-session-test.sh
+++ b/test/shell.d/sddm-greeter-session-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Regression coverage for the greeter's session auto-selection
+
+source "$(dirname "$0")/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+
+const source = fs
+  .readFileSync(path.join(root, 'default/sddm/omarchy/resolve-session-index.js'), 'utf8')
+  .replace(/^\.pragma library\n/, '')
+const sandbox = {}
+vm.createContext(sandbox)
+vm.runInContext(source, sandbox)
+
+const FILE_ROLE = 258
+const DISPLAY_ROLE = 0
+
+function mockSessionModel(lastIndex, files) {
+  return {
+    lastIndex,
+    rowCount: () => files.length,
+    index: (row, _column) => row,
+    data: (idx, role) => (role === FILE_ROLE ? files[idx] : undefined),
+  }
+}
+
+const sessions = [
+  '/usr/share/wayland-sessions/gnome.desktop',
+  '/usr/share/wayland-sessions/hyprland-uwsm.desktop',
+  '/usr/share/wayland-sessions/hyprland.desktop',
+  '/usr/share/wayland-sessions/omarchy.desktop',
+  '/usr/share/wayland-sessions/plasma.desktop',
+]
+
+assertEqual(
+  sandbox.resolveSessionIndex(mockSessionModel(0, sessions), FILE_ROLE),
+  3,
+  'selects omarchy.desktop over the hyprland-uwsm.desktop that sorts ahead of it'
+)
+
+assertEqual(
+  sandbox.resolveSessionIndex(mockSessionModel(0, sessions), DISPLAY_ROLE),
+  0,
+  'querying Qt.DisplayRole instead of FileRole matches nothing, as it does on real SDDM'
+)
+
+assertEqual(
+  sandbox.resolveSessionIndex(mockSessionModel(1, sessions.filter((s) => !s.endsWith('omarchy.desktop'))), FILE_ROLE),
+  1,
+  'keeps the recorded last session when no Omarchy session is installed'
+)
+
+assertEqual(
+  sandbox.resolveSessionIndex(mockSessionModel(0, []), FILE_ROLE),
+  0,
+  'stays on the recorded index rather than crashing when the model is empty'
+)
+JS


### PR DESCRIPTION
`Main.qml` picked the session by scanning `sessionModel` for a display name containing `uwsm`. `SessionModel.data()` only handles its own `SessionRoles` enum and has no `Qt.DisplayRole` case, so it returns an invalid QVariant — the comparison can never be true, and `sessionIndex` always falls through to `sessionModel.lastIndex`. Same root cause @ErikMelton documented for `UserModel` in #8069.

Model dump from a probe theme on SDDM 0.21.0 (roles are `Qt.UserRole + n`):

```
row 0 | display=[undefined] | 258=[…/gnome.desktop]         | 260=[GNOME]
row 1 | display=[undefined] | 258=[…/hyprland-uwsm.desktop] | 260=[Hyprland (uwsm-managed)]
row 2 | display=[undefined] | 258=[…/hyprland.desktop]      | 260=[Hyprland]
row 3 | display=[undefined] | 258=[…/omarchy.desktop]       | 260=[Omarchy (Hyprland uwsm)]
row 4 | display=[undefined] | 258=[…/plasma.desktop]        | 260=[Plasma (Wayland)]
```

It is invisible whenever `lastIndex` already points at the Omarchy session. It bites when `state.conf` records nothing — the same missing-`state.conf` condition behind #7949 — and the greeter then starts whatever sorts first (`gnome.desktop` above).

Switching to `NameRole` alone would not be enough: `hyprland-uwsm.desktop` also contains "uwsm" and sorts ahead of `omarchy.desktop`, so a name match picks the wrong session. Matching the `.desktop` path is unambiguous.

The resolution moves into `resolve-session-index.js` following the structure of #8069, so it can be tested directly.

## Testing

`test/shell.d/sddm-greeter-session-test.sh` runs the real `resolve-session-index.js` source against four cases: the session list above, a `Qt.DisplayRole` query (which resolves nothing, as it does on real SDDM), no Omarchy session installed, and an empty model. Verified the test fails against the old behaviour (`expected: 3, actual: 0`).

Also verified in a live `sddm-greeter-qt6 --test-mode` greeter: `sessionIndex` resolves to 3 (`omarchy.desktop`) where `lastIndex` is 0.

`./test/all` shows the same pre-existing failures before and after this change (`config`, `runtime-smoke`, `snapper`, `theme-install-guards`, `unowned-system-paths`) — my machine is not a stock Omarchy install.
