### PR TITLE
Add `omarchy reboot-windows` for dual-boot machines

### DIFF
--- a/bin/omarchy-system-reboot-windows
+++ b/bin/omarchy-system-reboot-windows
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# omarchy:summary=Reboot straight into Windows without using the boot menu
+# omarchy:aliases=omarchy reboot-windows
+# omarchy:requires-sudo=true
+
+if [[ ! -d /sys/firmware/efi ]]; then
+  echo "Error: System is not booted in UEFI mode" >&2
+  exit 1
+fi
+
+if ! efibootmgr &>/dev/null; then
+  echo "Error: efibootmgr is not available or not functional" >&2
+  exit 1
+fi
+
+entry=$(efibootmgr | grep -m1 -E "^Boot[0-9A-Fa-f]+\*?[[:space:]]+Windows Boot Manager")
+
+if [[ -z $entry ]]; then
+  echo "Error: No 'Windows Boot Manager' EFI entry found" >&2
+  echo "Run 'limine-scan' to add other installs to the bootloader, then try again" >&2
+  exit 1
+fi
+
+boot_num=$(sed -n 's/^Boot\([0-9A-Fa-f]\+\).*/\1/p' <<<"$entry")
+
+if gum confirm "Reboot into Windows?"; then
+  # BootNext is a one-shot: the firmware consumes and clears it on the next
+  # boot, so this changes where you land exactly once and leaves BootOrder alone.
+  sudo efibootmgr --bootnext "$boot_num" >/dev/null || exit 1
+
+  # Schedule the reboot in the user manager so closing the terminal's systemd
+  # scope cannot terminate it before it runs.
+  systemd-run --user --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl reboot --no-wall || exit 1
+
+  omarchy-osd -i reboot -m "Rebooting to Windows" -d 5000
+
+  omarchy-state clear re*-required
+
+  # Now close all windows
+  omarchy-hyprland-window-close-all
+  sleep 1 # Allow apps like Chrome to shutdown correctly
+fi

--- a/manual/50-dual-boot-install.md
+++ b/manual/50-dual-boot-install.md
@@ -37,6 +37,18 @@ When you finish your Omarchy install, you'll notice that the Limine bootloader i
 
 In order to do that, run `limine-scan` and follow the prompts to add whichever items you'd like to your limine config. Then when you boot, you'll see your normal options for Omarchy, as well as Windows Boot Manager or others.
 
+## Booting Into Windows
+
+Once Windows is in the bootloader, you can reach it from Omarchy without waiting for the menu:
+
+```bash
+omarchy reboot-windows
+```
+
+This sets the one-shot UEFI `BootNext` variable to the Windows Boot Manager entry and reboots, so the firmware goes straight there. `BootNext` is consumed and cleared by the firmware on that boot, so your normal boot order is untouched and the next restart lands back in Omarchy as usual.
+
+This is handy when the Limine menu is awkward to use on your hardware — on some machines the menu draws to a display that isn't lit yet during POST, which makes selecting an entry a guess.
+
 ## Bitlocker
 
 It's important to note that this install method is not compatible with Bitlocker as it encrypts the entire drive, not just the partition. If you encounter an error stating that Bitlocker is enabled, boot to Windows, go to **Settings -> Privacy & Security -> Device encryption** and toggle Bitlocker off. It may take some time to decrypt the drive.


### PR DESCRIPTION
The manual's [Dual Boot Install](manual/50-dual-boot-install.md) page already tells you to run `limine-scan` to add Windows to the bootloader. This adds the other half of that workflow: actually getting there.

`omarchy reboot-windows` sets the one-shot UEFI `BootNext` variable to the Windows Boot Manager entry and reboots, so the firmware goes straight to Windows. `BootNext` is consumed and cleared by the firmware on that boot, so `BootOrder` is never modified and the next restart lands back in Omarchy as usual.

### Why not just use the menu

Partly that it's a few seconds of attention on every switch. But on some hardware the menu isn't usable at all — the GPU's UEFI GOP may not have lit a display by the time Limine draws, so you're arrowing through a menu you can't see. On my machine an attached Apple Studio Display stalls the NVIDIA GOP's DisplayPort link training, and no head gets lit until the kernel takes over. `BootNext` needs no display at all.

### Details

- Named `omarchy-system-reboot-windows` so it lands in the existing `system` group beside `reboot`, `shutdown` and `logout`, with `omarchy reboot-windows` as an alias.
- Guards mirror `omarchy-setup-direct-boot`: UEFI mode, working `efibootmgr`. If there's no `Windows Boot Manager` entry it points at `limine-scan` rather than failing opaquely.
- The reboot path is lifted from `omarchy-system-reboot` — `systemd-run --user`, the OSD, `omarchy-state clear re*-required`, then closing windows. The state clear is deliberate, since the machine does genuinely reboot, but I'm happy to drop it if you'd rather that stay specific to rebooting back into Omarchy.

### Testing

Tested on an ASUS B650EM MAX GAMING WIFI (American Megatrends firmware, BIOS 3287) dual-booting Windows 11: `BootNext` is honored, the reboot lands in Windows, and restarting from Windows comes back to Omarchy. `test/cli` passes.

Worth flagging: `omarchy-setup-direct-boot` deliberately refuses AMI firmware, because *creating* custom EFI entries there is risky. `BootNext` is a different operation — it writes the number of an entry the firmware already created, and creates nothing — so that guard shouldn't apply here. This is AMI firmware and it works. I haven't tested other vendors.
