### PR TITLE
Show "Reboot to Windows" in the system menu

### DIFF
--- a/bin/omarchy-system-reboot-windows
+++ b/bin/omarchy-system-reboot-windows
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# omarchy:summary=Reboot straight into Windows without using the boot menu
+# omarchy:aliases=omarchy reboot-windows
+# omarchy:requires-sudo=true
+
+if [[ ! -d /sys/firmware/efi ]]; then
+  echo "Error: System is not booted in UEFI mode" >&2
+  exit 1
+fi
+
+if ! efibootmgr &>/dev/null; then
+  echo "Error: efibootmgr is not available or not functional" >&2
+  exit 1
+fi
+
+entry=$(efibootmgr | grep -m1 -E "^Boot[0-9A-Fa-f]+\*?[[:space:]]+Windows Boot Manager")
+
+if [[ -z $entry ]]; then
+  echo "Error: No 'Windows Boot Manager' EFI entry found" >&2
+  echo "Run 'limine-scan' to add other installs to the bootloader, then try again" >&2
+  exit 1
+fi
+
+boot_num=$(sed -n 's/^Boot\([0-9A-Fa-f]\+\).*/\1/p' <<<"$entry")
+
+if gum confirm "Reboot into Windows?"; then
+  # BootNext is a one-shot: the firmware consumes and clears it on the next
+  # boot, so this changes where you land exactly once and leaves BootOrder alone.
+  sudo efibootmgr --bootnext "$boot_num" >/dev/null || exit 1
+
+  # Schedule the reboot in the user manager so closing the terminal's systemd
+  # scope cannot terminate it before it runs.
+  systemd-run --user --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl reboot --no-wall || exit 1
+
+  omarchy-osd -i reboot -m "Rebooting to Windows" -d 5000
+
+  omarchy-state clear re*-required
+
+  # Now close all windows
+  omarchy-hyprland-window-close-all
+  sleep 1 # Allow apps like Chrome to shutdown correctly
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -39,7 +39,7 @@
   "system.hibernate": {"icon":"󰤁","label":"Hibernate","when":"omarchy-hibernation-available","action":"systemctl hibernate"},
   "system.logout": {"icon":"󰍃","label":"Logout","action":"omarchy-system-logout"},
   "system.reboot": {"icon":"󰜉","label":"Reboot","action":"omarchy-system-reboot"},
-  "system.reboot-windows": {"icon":"󰍲","label":"Reboot to Windows","when":"efibootmgr | grep -q 'Windows Boot Manager'","action":"omarchy-system-reboot-windows"},
+  "system.reboot-windows": {"icon":"󰍲","label":"Reboot to Windows","when":"efibootmgr | grep -q 'Windows Boot Manager'","action":"omarchy-launch-floating-terminal-with-presentation omarchy-system-reboot-windows"}
   "system.shutdown": {"icon":"󰐥","label":"Shutdown","action":"omarchy-system-shutdown"},
 
   // Learn

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -39,6 +39,7 @@
   "system.hibernate": {"icon":"󰤁","label":"Hibernate","when":"omarchy-hibernation-available","action":"systemctl hibernate"},
   "system.logout": {"icon":"󰍃","label":"Logout","action":"omarchy-system-logout"},
   "system.reboot": {"icon":"󰜉","label":"Reboot","action":"omarchy-system-reboot"},
+  "system.reboot-windows": {"icon":"󰍲","label":"Reboot to Windows","when":"efibootmgr | grep -q 'Windows Boot Manager'","action":"omarchy-system-reboot-windows"},
   "system.shutdown": {"icon":"󰐥","label":"Shutdown","action":"omarchy-system-shutdown"},
 
   // Learn

--- a/manual/50-dual-boot-install.md
+++ b/manual/50-dual-boot-install.md
@@ -37,6 +37,18 @@ When you finish your Omarchy install, you'll notice that the Limine bootloader i
 
 In order to do that, run `limine-scan` and follow the prompts to add whichever items you'd like to your limine config. Then when you boot, you'll see your normal options for Omarchy, as well as Windows Boot Manager or others.
 
+## Booting Into Windows
+
+Once Windows is in the bootloader, you can reach it from Omarchy without waiting for the menu:
+
+```bash
+omarchy reboot-windows
+```
+
+This sets the one-shot UEFI `BootNext` variable to the Windows Boot Manager entry and reboots, so the firmware goes straight there. `BootNext` is consumed and cleared by the firmware on that boot, so your normal boot order is untouched and the next restart lands back in Omarchy as usual.
+
+This is handy when the Limine menu is awkward to use on your hardware — on some machines the menu draws to a display that isn't lit yet during POST, which makes selecting an entry a guess.
+
 ## Bitlocker
 
 It's important to note that this install method is not compatible with Bitlocker as it encrypts the entire drive, not just the partition. If you encounter an error stating that Bitlocker is enabled, boot to Windows, go to **Settings -> Privacy & Security -> Device encryption** and toggle Bitlocker off. It may take some time to decrypt the drive.


### PR DESCRIPTION
Stacked on #8854, which adds the `omarchy-system-reboot-windows` command. This PR is the second commit — it puts that command on the power menu, beside Reboot and Shutdown, so switching to Windows doesn't require the terminal. Happy to fold it into #8854 instead if you'd rather review one thing.

```
"system.reboot": {"icon":"󰜉","label":"Reboot", ...},
"system.reboot-windows": {"icon":"󰍲","label":"Reboot to Windows", ...},
"system.shutdown": {"icon":"󰐥","label":"Shutdown", ...},
```

The row is guarded on a Windows Boot Manager EFI entry actually existing:

```
"when":"efibootmgr | grep -q 'Windows Boot Manager'"
```

so it stays hidden on single-boot machines rather than offering a reboot that would fail. This follows `system.hibernate`, which hides itself the same way when hibernation isn't set up.

On cost: guards are already batched into one bash process per menu load, and `MenuModel.js` wraps each expression in `if { … } >/dev/null 2>&1`, so the pipe is fine and stderr is already handled. It's one `efibootmgr` read of efivarfs, no `$(omarchy-…)` reader, so nothing needs adding to `GUARD_READERS`.

The icon `󰍲` is the one `install.windows` and `remove.windows` already use.

### Testing

`test/cli` passes, `test/shell`'s menu tests pass, and the menu JSON parses. The guard expression was checked directly on a dual-boot machine in the same form `MenuModel.js` runs it — true with a Windows Boot Manager entry present, false against a name that doesn't exist.

Being precise about what I have *not* done: I haven't opened the rendered menu and clicked the row. The command it calls is the one in #8854, which is exercised daily on this machine.
