### PR TITLE
Add `omarchy setup dual-boot` to add other OSes to the boot menu

### DIFF
--- a/bin/omarchy-setup-dual-boot
+++ b/bin/omarchy-setup-dual-boot
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Add other installed operating systems to the boot menu
+# omarchy:requires-sudo=true
+
+if [[ ! -d /sys/firmware/efi ]]; then
+  echo "Error: System is not booted in UEFI mode" >&2
+  exit 1
+fi
+
+if omarchy-cmd-missing limine-scan; then
+  echo "Error: limine-scan is not available; this system does not boot with Limine" >&2
+  exit 1
+fi
+
+echo "Scanning for other installed operating systems."
+echo "Anything you add appears in the boot menu alongside Omarchy."
+echo
+
+sudo limine-scan

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -184,6 +184,7 @@
   "setup.config.hyprsunset": {"icon":"","label":"Hyprsunset","action":"omarchy-launch-config-editor ~/.config/hypr/hyprsunset.conf && omarchy-restart-hyprsunset"},
   "setup.config.xcompose": {"icon":"󰞅","label":"XCompose","action":"omarchy-launch-config-editor ~/.XCompose && omarchy-restart-xcompose"},
   "setup.direct-boot": {"icon":"","label":"Direct Boot","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-direct-boot"},
+  "setup.dual-boot": {"icon":"󰋊","label":"Dual Boot","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-dual-boot"},
   "setup.reset": {"icon":"󰑓","label":"Reset Computer","when":"[[ $(findmnt -no FSTYPE /) == btrfs ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-system-factory-reset"},
 
   // Install

--- a/manual/50-dual-boot-install.md
+++ b/manual/50-dual-boot-install.md
@@ -35,7 +35,7 @@ Confirm that everything looks good and wait for the install to finish like norma
 
 When you finish your Omarchy install, you'll notice that the Limine bootloader is the default now. With this, you can also add options to Limine for your other installs such as Windows.
 
-In order to do that, run `limine-scan` and follow the prompts to add whichever items you'd like to your limine config. Then when you boot, you'll see your normal options for Omarchy, as well as Windows Boot Manager or others.
+In order to do that, run `omarchy setup dual boot` (or **Setup > Dual Boot** in the menu) and follow the prompts to add whichever items you'd like to your limine config. Then when you boot, you'll see your normal options for Omarchy, as well as Windows Boot Manager or others.
 
 ## Bitlocker
 


### PR DESCRIPTION
The [Dual Boot Install](manual/50-dual-boot-install.md) page walks through making space, installing, and Bitlocker — and then for the bootloader step it says to run `limine-scan` by hand. That's the one step on the page with no Omarchy command behind it and nothing in the menu pointing at it, so adding Windows to the boot menu is only findable if you already know the Arch tool's name.

This wraps it as `omarchy setup dual boot`, sitting next to Direct Boot in Setup:

```
"setup.direct-boot": {"icon":"","label":"Direct Boot", ...},
"setup.dual-boot":   {"icon":"󰋊","label":"Dual Boot",   ...},
```

Both launch through `omarchy-launch-floating-terminal-with-presentation`, since `limine-scan` is interactive.

### On the guard

`limine-scan` comes from `limine-mkinitcpio-hook`, which is in `install/omarchy-other.packages` rather than the base set, so it isn't a runtime invariant — Omarchy installed over an existing Arch system may be booting something else. The command checks with `omarchy-cmd-missing` and says plainly that the system doesn't boot with Limine, instead of failing with `command not found`. Per AGENTS.md I've kept that to the genuinely-optional dependency and haven't wrapped anything from the default package set.

### Related

Independent of #8854 and #8857 (reboot into Windows) but the same corner of the manual; I checked, and it merges cleanly with them in either order.

### Testing

`test/cli` passes and both routes resolve (`omarchy setup dual boot` and the hyphenated form).

To be clear about scope: `limine-scan` itself is the existing Arch tool and was used to set up dual-boot on this machine, but I have not re-run it *through this wrapper* — it rewrites the bootloader config, so I didn't want to exercise it a second time just for a test. The wrapper's own logic is the UEFI check, the `limine-scan` presence check, and `sudo limine-scan`.
