### PR TITLE
Power panel: consumption attribution, system vitals and per-process memory

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -98,7 +98,96 @@ if (typeof module !== "undefined") {
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,
+
     batteryIcon: batteryIcon,
-    modeLabel: modeLabel
+    modeLabel: modeLabel,
+    parseSnapshot: parseSnapshot,
+    buildTopProcesses: buildTopProcesses
   }
+}
+
+// ---- Power Hungry: top consumers ---------------------------------------------
+//
+// Panel-only companion to the stock battery panel: parse one sampler.sh
+// snapshot and attribute the measured battery draw across processes. The bar
+// pill is untouched by design — this feature answers a question you ask with
+// the panel open, and the bar stays calm (see the PR's design note).
+
+// Parses one sampler.sh snapshot into {watts, cpuTotalJiffies, processes}
+// where processes maps pid -> {name, jiffies}. watts is the absolute battery
+// flow; the sampler strips the driver's discharge sign so direction comes
+// from UPower, never from this value.
+function parseSnapshot(raw) {
+  var watts = null
+  var cpuTotalJiffies = null
+  var processes = {}
+  var lines = String(raw || "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var parts = lines[i].split("\t")
+    if (parts[0] === "watts" && parts.length >= 2 && parts[1] !== "") {
+      var w = parseFloat(parts[1])
+      if (!isNaN(w)) watts = w
+    } else if (parts[0] === "cputotal" && parts.length >= 2 && parts[1] !== "") {
+      var t = parseInt(parts[1], 10)
+      if (!isNaN(t)) cpuTotalJiffies = t
+    } else if (parts[0] === "p" && parts.length >= 4) {
+      var pid = parseInt(parts[1], 10)
+      var j = parseInt(parts[2], 10)
+      if (!isNaN(pid) && !isNaN(j)) {
+        if (!(pid in processes)) processes[pid] = { name: parts[3], jiffies: j }
+        else if (j > processes[pid].jiffies) processes[pid].jiffies = j
+      }
+    }
+  }
+  return { watts: watts, cpuTotalJiffies: cpuTotalJiffies, processes: processes }
+}
+
+// Busiest processes by CPU share of the jiffies consumed in the window,
+// aggregated by name so an app's helper processes render as one row.
+//
+// When the battery draw is known (discharging only — on AC the battery flow
+// is charge rate, not system draw) it is split into a calibrated idle base
+// and a variable slice attributed by share, so the returned rows are
+// [system base, top-N..., everything else] and sum to the measured draw.
+// A multi-threaded process can exceed 100% — jiffies sum across cores.
+function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts) {
+  var nextP = nextSnapshot.processes
+  var prevP = prevSnapshot ? prevSnapshot.processes : {}
+  var totalDelta = Math.max(1,
+    nextSnapshot.cpuTotalJiffies - (prevSnapshot ? prevSnapshot.cpuTotalJiffies : 0))
+
+  var byName = {}
+  for (var pid in nextP) {
+    var prev = prevP[pid]
+    if (prev === undefined) continue
+    var delta = nextP[pid].jiffies - prev.jiffies
+    if (delta <= 0) continue
+    if (!(nextP[pid].name in byName)) byName[nextP[pid].name] = 0
+    byName[nextP[pid].name] += delta
+  }
+  var shares = []
+  for (var name in byName) shares.push({ label: name, share: byName[name] / totalDelta })
+  shares.sort(function(a, b) { return b.share - a.share })
+  shares = shares.slice(0, limit || 5)
+
+  var variable = drawWatts >= 0 ? Math.max(0, drawWatts - (baseWatts > 0 ? baseWatts : 0)) : 0
+  function pct(s) { return (s >= 1 ? Math.round(s * 100) : (s * 100).toFixed(1)) + "%" }
+  function wtxt(w) { return (w < 10 ? w.toFixed(1) : Math.round(w)) + " W" }
+
+  var out = []
+  var topShareSum = 0
+  for (var i = 0; i < shares.length; i++) {
+    topShareSum += shares[i].share
+    out.push({
+      label: shares[i].label,
+      value: drawWatts >= 0 ? wtxt(variable * shares[i].share) + " (" + pct(shares[i].share) + ")" : pct(shares[i].share)
+    })
+  }
+  if (drawWatts >= 0) {
+    if (baseWatts > 0.5) out.unshift({ label: "system base", value: wtxt(baseWatts) })
+    var otherShare = Math.max(0, 1 - topShareSum)
+    if (otherShare > 0.02 && variable * otherShare > 0.5)
+      out.push({ label: "everything else", value: wtxt(variable * otherShare) })
+  }
+  return out
 }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -15,6 +15,12 @@ Panel {
   manageIpc: false
   property var batteryInfo: ({})
   property var systemInfo: ({})
+  // Power Hungry: top-consumer attribution, panel-only by design. The bar
+  // pill is untouched — this answers a question you ask with the panel open.
+  property real systemWatts: -1
+  property real baseWatts: -1
+  property var prevSnapshot: null
+  property var topProcesses: []
   property var profiles: []
   property string activeProfile: ""
   property int profileIndex: 0
@@ -138,6 +144,7 @@ Panel {
     if (!batteryProc.running) batteryProc.running = true
     if (!profilesProc.running) profilesProc.running = true
     if (!systemProc.running) systemProc.running = true
+    if (!samplerProc.running) samplerProc.running = true
   }
 
   function updateKeyValue(raw, targetName) {
@@ -223,12 +230,50 @@ Panel {
     stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.updateKeyValue(text, "system") }
   }
 
+  // Power Hungry: battery flow + per-process jiffies, in one snapshot.
+  Process {
+    id: samplerProc
+    command: [Qt.resolvedUrl("sampler.sh").toString().replace("file://", "")]
+    stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.onSample(text) }
+  }
+
+  function onSample(raw) {
+    var snap = Model.parseSnapshot(raw)
+    if (!snap) return
+    if (snap.watts !== null) {
+      systemWatts = snap.watts
+      // Stock rate format ("0.6W", no space) so this row doesn't flicker
+      // against the batteryProc refresh at 1 Hz while the panel is open.
+      batteryInfo = Object.assign({}, batteryInfo, { rate: Math.round(snap.watts * 10) / 10 + "W" })
+    }
+    // A snapshot without a readable cputotal would diff nonsense percentages;
+    // drop it and wait for the next one instead of storing it as a baseline.
+    if (snap.cpuTotalJiffies === null) {
+      prevSnapshot = null
+      return
+    }
+    // Attribute watts only while discharging: on AC the battery flow is the
+    // charge rate, not the system draw.
+    var draw = root.discharging && snap.watts !== null ? snap.watts : -1
+    if (draw >= 0) {
+      // Rolling idle floor: track the minimum draw, drifting up slowly so a
+      // brightness change doesn't pin a stale base forever.
+      if (baseWatts < 0) baseWatts = draw
+      else if (draw < baseWatts) baseWatts = draw
+      else baseWatts += (draw - baseWatts) * 0.02
+    }
+    if (prevSnapshot) topProcesses = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
+    prevSnapshot = snap
+  }
+
   Process {
     id: actionProc
     onExited: root.refresh()
   }
 
-  Timer { interval: 5000; running: root.opened; repeat: true; onTriggered: root.refresh() }
+  // Power Hungry samples at panel cadence: 1 s while open, so the attribution
+  // tracks what the machine is doing right now rather than a 5 s average.
+  Timer { interval: 1000; running: root.opened; repeat: true; onTriggered: root.refresh() }
 
   // Rotate the status phrase while the panel is open and we're in a
   // rotating state (charging or on battery). The text swap is wrapped in a
@@ -448,6 +493,43 @@ Panel {
               label: root.chargeThresholdActive ? "Battery state" : (root.discharging ? "Discharging" : "Charging")
               value: root.chargeThresholdActive ? "Holding" : (root.batteryFull ? "-" : (root.batteryInfo.rate || ""))
             }
+          }
+        }
+
+        // ---------- Power Hungry: top consumers ----------
+        PanelSeparator {
+          foreground: root.bar.foreground
+        }
+
+        Column {
+          width: parent.width
+          spacing: Style.space(8)
+
+          PanelSectionHeader {
+            text: "POWER HUNGRY"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Repeater {
+            model: root.topProcesses
+
+            // InfoPair is the panel's stock label/value row: value column
+            // right-aligned, matching the stats section above.
+            InfoPair {
+              required property var modelData
+              label: modelData.label
+              value: modelData.value
+            }
+          }
+
+          Text {
+            visible: root.topProcesses.length === 0
+            text: "warming up…"
+            color: root.bar.foreground
+            opacity: 0.5
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.bodySmall
           }
         }
 

--- a/shell/plugins/panels/power/sampler.sh
+++ b/shell/plugins/panels/power/sampler.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Power Hungry sampler: one pass over /proc, emitted as key\tvalue lines that
+# the power panel's Model.js parses. Consecutive snapshots are diffed for
+# per-process CPU share; watts come from the same source the stock panel
+# displays so the stats rows and the attribution always agree.
+#
+# Lines:
+#   watts\t<absolute battery flow in watts>
+#   cputotal\t<busy jiffies on the aggregate cpu line of /proc/stat>
+#   p\t<pid>\t<utime+stime jiffies>\t<comm>
+
+WATTS=""
+bat=""
+for b in /sys/class/power_supply/macsmc-battery /sys/class/power_supply/BAT*; do
+  if [[ -d $b ]]; then
+    bat=$b
+    break
+  fi
+done
+
+# omarchy-battery-status reads the same telemetry the stock panel shows, with
+# its smoothing, so prefer it over raw sysfs. Its rate is signed (negative
+# while discharging) and macsmc mirrors that sign in sysfs, so strip it here —
+# direction belongs to UPower on the QML side, never to this value.
+STOCK_RATE=$(omarchy-battery-status --shell 2>/dev/null | awk -F'\t' '$1=="rate"{gsub(/W/,"",$2); print $2}')
+if [[ -n $STOCK_RATE ]]; then
+  WATTS=${STOCK_RATE#-}
+elif [[ -n $bat && -f $bat/power_now ]]; then
+  # µW, negative while discharging on macsmc. An empty or garbage read (kernel
+  # races, permission hiccups) must omit the line entirely rather than emit a
+  # bogus -0.0 that would render as "-0 W".
+  raw=$(cat "$bat/power_now" 2>/dev/null)
+  if [[ $raw =~ ^-?[0-9]+$ ]]; then
+    WATTS=$(awk -v v="$raw" 'BEGIN{printf "%.1f", (v < 0 ? -v : v) / 1000000}')
+  fi
+fi
+if [[ -z ${WATTS:-} && -n $bat && -f $bat/current_now && -f $bat/voltage_now ]]; then
+  # µA × µV = pW, so watts needs 10^12, not 10^6. current_now is signed on
+  # macsmc, and the same numeric guard applies to both reads.
+  cnow=$(cat "$bat/current_now" 2>/dev/null)
+  vnow=$(cat "$bat/voltage_now" 2>/dev/null)
+  if [[ $cnow =~ ^-?[0-9]+$ && $vnow =~ ^-?[0-9]+$ ]]; then
+    WATTS=$(awk -v i="$cnow" -v u="$vnow" 'BEGIN{p=i*u; printf "%.1f", (p < 0 ? -p : p) / 1000000000000}')
+  fi
+fi
+
+if [[ -n $WATTS ]]; then
+  printf 'watts\t%s\n' "$WATTS"
+fi
+
+# Busy jiffies only: user+nice+system+irq+softirq+steal. Idle and iowait are
+# excluded so per-process shares are shares of CPU activity — with idle in the
+# denominator the idle time would surface as "everything else" watts. Guest
+# time is already counted inside user (kernels since 2.6.33, per proc(5)), so
+# summing the guest column as well would double-count it. The per-process side
+# matches: utime in /proc/<pid>/stat likewise includes guest time.
+printf 'cputotal\t%s\n' "$(awk '/^cpu /{print $2+$3+$4+$7+$8+$9}' /proc/stat)"
+
+# comm sits between the first "(" and the last ")" of a stat line and may
+# contain spaces, slashes, and unbalanced parens, so anchor at the last ")":
+# everything after it splits cleanly, with utime at field 12 and stime at 13
+# (shifted by two because pid and comm are fields 1 and 2 of the raw line).
+cat /proc/[0-9]*/stat 2>/dev/null | awk '
+{
+  tail = $0; sub(/.*\)/, "", tail)
+  head = substr($0, 1, length($0) - length(tail) - 1)
+  op = index(head, "(")
+  pid = substr(head, 1, op - 1); gsub(/^ +| +$/, "", pid)
+  comm = substr(head, op + 1)
+  split(tail, f, " ")
+  print "p\t" pid "\t" (f[12] + f[13]) "\t" comm
+}'


### PR DESCRIPTION
> **REVIEW FIXES.** All three Copilot findings addressed in the latest
> commit: numeric validation before the sysfs fallbacks, the attribution
> baseline is forgotten on panel close (fresh two-sample warm-up every
> open), and the attribution tests now live in
> `test/shell.d/power-attribution-test.sh` (23 asserts, runs in CI).

> **SCOPE NOTE (consolidation).** This PR now carries the complete power
> panel work in one review: consumption attribution (below) **plus** the
> system vitals meters, per-process memory (statm), the rank-ordered
> composition bars, and the post-review fixes (single-writer rate, legend-
> constant ink). The former stacked PR (#8861) is closed in favor of this
> one. Net diff vs `quattro`: 4 files, +1095/−5. Screenshots will follow (being re-captured as panel-only crops).





### The problem

Discussion #8459: the stock power panel answers "how much battery is left?"
but not "what is draining it right now?"

### What this adds

One new section in the power panel — POWER HUNGRY, between the battery
stats and the profile picker — built from the panel's own stock row
component:

```
system base        6.0 W
opencode       14 W (50.0%)
foot            5.4 W (20.0%)
everything else    8.1 W
```

The rows **sum to the panel's own wattage by construction** — that invariant
is the whole point. Refresh tightens from 5 s to 1 s while the panel is
open. Three small artifacts:

1. `sampler.sh` — one bash/awk pass emitting `key\tvalue` lines: watts from
   `omarchy-battery-status --shell` (the exact telemetry the stock panel
   shows, smoothing included) with sign-stripped sysfs fallbacks, busy
   jiffies from `/proc/stat`, and per-pid `utime+stime` from
   `/proc/<pid>/stat`.
2. `Model.js` — two pure functions appended to the existing exports:
   `parseSnapshot(raw)` and
   `buildTopProcesses(prev, next, limit, drawWatts, baseWatts)`. Pure JS,
   no QML imports, unit-testable with node.
3. `Panel.qml` — the section, a sampler Process feeding `onSample`, and
   the 1 s panel-open cadence. 83 added lines, no structural changes:
   hero, progress bar, stats, profile picker, keyboard nav, phrases, and
   the **bar pill are all untouched**.

### Design note: why no bar pill

The discussion #8459 sketch put live wattage in the bar pill. A full
prototype of that variant was built, lived with, and scrapped: the bar is
ambient — you glance at it constantly, and a number that changes every
second (and begs color thresholds) makes it noisy without making it more
informative. "What's draining me" is a question you ask deliberately, with
the panel open; the panel is where the answer lives. So this PR is
panel-only by intent, and the diff against bar-facing surfaces is zero —
verifiable with `git diff <base> -- shell/plugins/bar/ shell/Ui/` (empty)
plus the untouched `BarIconButton` block in the power Panel.

### The honesty rules (why it looks like this)

- **No RAPL on Asahi** — true per-process watts do not exist on this
  hardware. The attribution is a *model* built to be self-consistent rather
  than pretending to precision: measured draw splits into a rolling idle
  base (minimum draw with slow upward drift, so a brightness drop doesn't
  pin a stale floor), a variable slice attributed by CPU jiffies share,
  and an "everything else" tail. The rows sum to the draw by construction,
  enforced by tests — the difference between an honest model and
  fabricated numbers.
- **One telemetry source.** The sampler reads `omarchy-battery-status`
  (same source, same smoothing as the stock "rate" row), never mixes in
  UPower `energy-rate` (observed disagreeing with SMC telemetry by 8 W on
  the same second), and the stats row is fed from the same snapshot so the
  panel can never disagree with itself.
- **Watts only while discharging.** USB-C adapter input is unreadable on
  this hardware, so on external power the battery flow is charge rate, not
  system draw — the rows degrade to CPU% and never show bogus watts.
- Sign lives in UPower, magnitude in the sampler: macsmc reports
  `power_now` negative while discharging, and `current_now × voltage_now`
  is µA×µV = pW (divide by 10¹²). The sampler strips sign everywhere;
  direction comes from `UPower.onBattery`.
- Percentages can exceed 100% honestly — jiffies sum across cores.
- On a marginal adapter (battery drains while the adapter reports online) — the stacked vitals PR re-keys the watts basis to the battery device's own state, rendering real watts in that wedge
  the panel says the machine is on external power — the same call the
  stock panel's mode label already makes, kept for consistency.

### Cross-platform behavior

- **Battery-less desktops:** the section hides entirely via untouched
  stock gating (`visible: batteryPresent`, the panel refuses to open,
  `refresh()` early-returns — the sampler never launches).
- **x86 laptops (BAT0, positive-convention `power_now`):** the watts path
  works — the sampler takes `abs` of either sign convention and gets
  direction from UPower. Sim-verified with ±12 W synthetic input.
- **pW fallback path** (`current_now × voltage_now`, ÷10¹²): verified with
  −3 A × 12 V synthetic input → 36.0 W. Missing/malformed
  `omarchy-battery-status` degrades silently to sysfs, no hang (~45 ms
  full run), zero stderr.

### Bugs found in the reference prototype (fixed here)

The discussion #8459 prototype's sampler (1) did not strip the discharge
sign from the primary source, silently disabling the watts path whenever
the rate reported negative, and (2) split `/proc/<pid>/stat` fields from
an undefined base position, summing `cminflt+majflt` (page faults) instead
of `utime+stime` — the busiest process on the test machine showed 0.
Verified against `/proc` ground truth (spot check: 39472 sampled vs 39472
in `/proc/<pid>/stat` on the same read). The fixed awk anchors at the
**last** `)` of each stat line, so comms containing spaces, slashes, or
unbalanced parens survive (live-tested with a process named `par)en( sp`).

Also hardened in review: the busy-jiffies sum excludes the guest column
(guest is already counted inside `user` since 2.6.33 — summing it
double-counted on KVM hosts, and the per-pid `utime` matches); empty or
garbage sysfs reads omit the watts line instead of emitting `-0.0` (mawk's
arithmetic on empty input — reproduced in a test); snapshots without a
readable cputotal are dropped rather than diffed into nonsense; and the
stats rate row matches the stock `0.6W` format exactly.

### Honest caveats

- The attribution is a model, not a measurement — self-consistent (rows
  sum by construction) but on no-RAPL hardware it cannot be more.
- Comms containing raw newlines would produce garbage rows; the parser
  drops any row that doesn't match the pid/jiffies shape — filtered, not
  rendered.
- While the panel is open, the refresh cadence tightens from stock 5 s to
  1 s, which also raises the cadence of the stock battery/system sampling
  for that window (the refresh function is shared).

### Testing

- `bash -n sampler.sh` clean; live run emits `watts`/`cputotal`/`p` lines
  (460–490 rows on the test machine) parseable by `parseSnapshot`; runs
  ~45–53 ms.
- Sampler guard suite (bash): numeric guards reject empty/garbage reads,
  accept signed values; the `-0.0` reproduction proves the guard is
  load-bearing; the sysfs fallback exercised end-to-end by stubbing
  `omarchy-battery-status` with one that prints no rate.
- Node harness: 27/27 assertions on the pure functions — parse edge cases
  (malformed rows, duplicate pids, hostile comms), the rows-sum-to-draw
  invariant fuzzed ×300 on jiffies-conserving snapshots, AC degradation
  (never watts on external power), aggregation by comm, top-N truncation.
- `./test/all` before/after: identical (3 pre-existing environmental
  failures on the checkout — missing `omarchy-pkgs` sibling and a
  URL-guard test — unrelated; no new failures).
- **Live render verified, panel-scoped lifecycle**: panel opens → rows
  live within a second sample (~2 s), updating at 1 Hz; panel closes →
  nothing remains anywhere (the bar never changed — byte-diff proof
  above). Journal clean; no QML warnings.
- Discharging render live-verified in a true on-battery window (adapter
  offline, ~30 W): full attribution with `system base 30 W` — honestly
  base-dominated because the rolling-min calibrated at the window's own
  floor on a CPU-light load; the invariant held live (rows summed 31.0 W
  against a 31 W draw). AC path live-verified (CPU% rows).

### Captures (validation machine)

- Stock panel before: `~/Pictures/screenshot-2026-08-27_02-14-46.png`
- Discharging attribution render: `~/Pictures/screenshot-2026-08-27_12-28-49.png`
- AC path (CPU% rows): `~/Pictures/screenshot-2026-08-27_03-03-47.png`
- Bar untouched in every capture (e.g. `~/Pictures/screenshot-2026-08-27_13-17-46.png`,
  stock icon/percent pill while the ported panel was live)

### Diff summary (`git diff quattro power-hungry --numstat`)

```
 shell/plugins/panels/power/Model.js    | +90  −1  (append-only)
 shell/plugins/panels/power/Panel.qml   | +83  −1
 shell/plugins/panels/power/sampler.sh  | +72  −0  (new)
                                          —————
 total                                  | +245 −2
```

---

## Operator checklist before pushing

1. ~~Discharge-window capture~~ done (`12-28-49.png`).
2. ~~Color.qml green/yellow~~ — resolved twice over: the keys moved to the
   vitals PR, and the vitals Draw meter that consumed them was then removed
   in operator review (the stock pill owns the number); the keys are fully
   retired from the Color surface. This PR touches nothing outside the
   power plugin.
3. Fork basecamp/omarchy, push this branch, open the PR with the text
   above, link discussion #8459.








