### PR TITLE
Power panel: system vitals meters and per-process memory

### DIFF
--- a/shell/Commons/Color.qml
+++ b/shell/Commons/Color.qml
@@ -21,6 +21,10 @@ QtObject {
   property color accent: "#cacccc"
   property color urgent: "#a55555"
   property color muted: "#707880"
+  // Status pair graded against urgent for positive/intermediate feedback;
+  // themes override via the same colorN key mapping in loadColors.
+  property color green: "#8fae8f"
+  property color yellow: "#b3a26b"
 
   // Flat dictionary of "section.key" -> raw string from shell.toml.
   // Reassigning this whole property is what makes surface bindings below
@@ -157,6 +161,8 @@ QtObject {
       else if (match[1] === "color7") color7Value = match[2]
       else if (match[1] === "color8") color8Value = match[2]
       else if (match[1] === "red" || match[1] === "color1") urgent = match[2]
+      else if (match[1] === "green" || match[1] === "color2") green = match[2]
+      else if (match[1] === "yellow" || match[1] === "color3") yellow = match[2]
     }
     if (!loadedBackground && color0Value.length > 0) background = color0Value
     if (!loadedForeground && color7Value.length > 0) foreground = color7Value

--- a/shell/Commons/Color.qml
+++ b/shell/Commons/Color.qml
@@ -21,12 +21,10 @@ QtObject {
   property color accent: "#cacccc"
   property color urgent: "#a55555"
   property color muted: "#707880"
-  // Status pair graded against urgent for positive/intermediate feedback;
-  // plus the distinguishable non-threshold hues used to key chart segments
-  // (red/yellow/green stay reserved for threshold grading). Themes override
+  // The distinguishable non-threshold hues used to key chart segments and
+  // metric columns (red stays reserved for threshold grading as urgent;
+  // green/yellow remain unexposed — no current consumer). Themes override
   // via the same colorN key mapping in loadColors.
-  property color green: "#8fae8f"
-  property color yellow: "#b3a26b"
   property color blue: "#6f8fae"
   property color cyan: "#7faeae"
   property color magenta: "#a68fae"
@@ -166,8 +164,6 @@ QtObject {
       else if (match[1] === "color7") color7Value = match[2]
       else if (match[1] === "color8") color8Value = match[2]
       else if (match[1] === "red" || match[1] === "color1") urgent = match[2]
-      else if (match[1] === "green" || match[1] === "color2") green = match[2]
-      else if (match[1] === "yellow" || match[1] === "color3") yellow = match[2]
       else if (match[1] === "blue" || match[1] === "color4") blue = match[2]
       else if (match[1] === "magenta" || match[1] === "color5") magenta = match[2]
       else if (match[1] === "cyan" || match[1] === "color6") cyan = match[2]

--- a/shell/Commons/Color.qml
+++ b/shell/Commons/Color.qml
@@ -22,9 +22,14 @@ QtObject {
   property color urgent: "#a55555"
   property color muted: "#707880"
   // Status pair graded against urgent for positive/intermediate feedback;
-  // themes override via the same colorN key mapping in loadColors.
+  // plus the distinguishable non-threshold hues used to key chart segments
+  // (red/yellow/green stay reserved for threshold grading). Themes override
+  // via the same colorN key mapping in loadColors.
   property color green: "#8fae8f"
   property color yellow: "#b3a26b"
+  property color blue: "#6f8fae"
+  property color cyan: "#7faeae"
+  property color magenta: "#a68fae"
 
   // Flat dictionary of "section.key" -> raw string from shell.toml.
   // Reassigning this whole property is what makes surface bindings below
@@ -163,6 +168,9 @@ QtObject {
       else if (match[1] === "red" || match[1] === "color1") urgent = match[2]
       else if (match[1] === "green" || match[1] === "color2") green = match[2]
       else if (match[1] === "yellow" || match[1] === "color3") yellow = match[2]
+      else if (match[1] === "blue" || match[1] === "color4") blue = match[2]
+      else if (match[1] === "magenta" || match[1] === "color5") magenta = match[2]
+      else if (match[1] === "cyan" || match[1] === "color6") cyan = match[2]
     }
     if (!loadedBackground && color0Value.length > 0) background = color0Value
     if (!loadedForeground && color7Value.length > 0) foreground = color7Value

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -98,7 +98,96 @@ if (typeof module !== "undefined") {
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,
+
     batteryIcon: batteryIcon,
-    modeLabel: modeLabel
+    modeLabel: modeLabel,
+    parseSnapshot: parseSnapshot,
+    buildTopProcesses: buildTopProcesses
   }
+}
+
+// ---- Power Hungry: top consumers ---------------------------------------------
+//
+// Panel-only companion to the stock battery panel: parse one sampler.sh
+// snapshot and attribute the measured battery draw across processes. The bar
+// pill is untouched by design — this feature answers a question you ask with
+// the panel open, and the bar stays calm (see the PR's design note).
+
+// Parses one sampler.sh snapshot into {watts, cpuTotalJiffies, processes}
+// where processes maps pid -> {name, jiffies}. watts is the absolute battery
+// flow; the sampler strips the driver's discharge sign so direction comes
+// from UPower, never from this value.
+function parseSnapshot(raw) {
+  var watts = null
+  var cpuTotalJiffies = null
+  var processes = {}
+  var lines = String(raw || "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var parts = lines[i].split("\t")
+    if (parts[0] === "watts" && parts.length >= 2 && parts[1] !== "") {
+      var w = parseFloat(parts[1])
+      if (!isNaN(w)) watts = w
+    } else if (parts[0] === "cputotal" && parts.length >= 2 && parts[1] !== "") {
+      var t = parseInt(parts[1], 10)
+      if (!isNaN(t)) cpuTotalJiffies = t
+    } else if (parts[0] === "p" && parts.length >= 4) {
+      var pid = parseInt(parts[1], 10)
+      var j = parseInt(parts[2], 10)
+      if (!isNaN(pid) && !isNaN(j)) {
+        if (!(pid in processes)) processes[pid] = { name: parts[3], jiffies: j }
+        else if (j > processes[pid].jiffies) processes[pid].jiffies = j
+      }
+    }
+  }
+  return { watts: watts, cpuTotalJiffies: cpuTotalJiffies, processes: processes }
+}
+
+// Busiest processes by CPU share of the jiffies consumed in the window,
+// aggregated by name so an app's helper processes render as one row.
+//
+// When the battery draw is known (discharging only — on AC the battery flow
+// is charge rate, not system draw) it is split into a calibrated idle base
+// and a variable slice attributed by share, so the returned rows are
+// [system base, top-N..., everything else] and sum to the measured draw.
+// A multi-threaded process can exceed 100% — jiffies sum across cores.
+function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts) {
+  var nextP = nextSnapshot.processes
+  var prevP = prevSnapshot ? prevSnapshot.processes : {}
+  var totalDelta = Math.max(1,
+    nextSnapshot.cpuTotalJiffies - (prevSnapshot ? prevSnapshot.cpuTotalJiffies : 0))
+
+  var byName = {}
+  for (var pid in nextP) {
+    var prev = prevP[pid]
+    if (prev === undefined) continue
+    var delta = nextP[pid].jiffies - prev.jiffies
+    if (delta <= 0) continue
+    if (!(nextP[pid].name in byName)) byName[nextP[pid].name] = 0
+    byName[nextP[pid].name] += delta
+  }
+  var shares = []
+  for (var name in byName) shares.push({ label: name, share: byName[name] / totalDelta })
+  shares.sort(function(a, b) { return b.share - a.share })
+  shares = shares.slice(0, limit || 5)
+
+  var variable = drawWatts >= 0 ? Math.max(0, drawWatts - (baseWatts > 0 ? baseWatts : 0)) : 0
+  function pct(s) { return (s >= 1 ? Math.round(s * 100) : (s * 100).toFixed(1)) + "%" }
+  function wtxt(w) { return (w < 10 ? w.toFixed(1) : Math.round(w)) + " W" }
+
+  var out = []
+  var topShareSum = 0
+  for (var i = 0; i < shares.length; i++) {
+    topShareSum += shares[i].share
+    out.push({
+      label: shares[i].label,
+      value: drawWatts >= 0 ? wtxt(variable * shares[i].share) + " (" + pct(shares[i].share) + ")" : pct(shares[i].share)
+    })
+  }
+  if (drawWatts >= 0) {
+    if (baseWatts > 0.5) out.unshift({ label: "system base", value: wtxt(baseWatts) })
+    var otherShare = Math.max(0, 1 - topShareSum)
+    if (otherShare > 0.02 && variable * otherShare > 0.5)
+      out.push({ label: "everything else", value: wtxt(variable * otherShare) })
+  }
+  return out
 }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -102,6 +102,13 @@ function wattsBasis(deviceState, dischargingState, watts) {
 // Kernel comm fields cap at 15 characters (TASK_COMM_LEN), so the panel's
 // comm column can be sized once for the realistic worst case and never per
 // sample.
+// The shade lattice: three fixed opacity steps over each identity hue,
+// multiplying the SAME theme color — nine distinguishable identity slots
+// from three collision-free keys, zero new RGB, the 22-theme guarantee
+// intact. Steps chosen against the panel's 0.12-alpha track: the lowest
+// shade stays clearly above the track at panel scale (verified live).
+var SHADES = [0.5, 0.75, 1.0]
+
 var COMM_MAX_CHARS = 15
 
 // Gap budget basis for the composition bars: the most segments any bar can
@@ -134,6 +141,10 @@ if (typeof module !== "undefined") {
     aggregateCommShares: aggregateCommShares,
     assignColorKeys: assignColorKeys,
     stableColorKey: stableColorKey,
+    stableColorHash: stableColorHash,
+    SHADES: SHADES,
+    slotPreferences: slotPreferences,
+    resolveColorSlots: resolveColorSlots,
     SPLIT_MAX_SEGMENTS: SPLIT_MAX_SEGMENTS,
     collisionOrdinals: collisionOrdinals
   }
@@ -485,21 +496,31 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
   // panel's palette rationale). Passed in so callers own it; defaulted so
   // the pure builder is self-contained.
   palette = palette || ["blue", "cyan", "magenta"]
-  // Composition bars keep PER-COMM segments (the round-8 merge chunked the
-  // geometry away), laid out in CANONICAL hue order: every blue-hue comm
-  // first, then cyan, then magenta — rank order only WITHIN a hue — then
-  // rest, then idle/available. Rank shuffles can reorder members inside
-  // their hue block and shares may breathe, but hue blocks never relocate:
-  // horizontal calm. Callers draw constant separators between segments and
-  // scale fills against a fixed gap budget (SPLIT_MAX_SEGMENTS) so the
-  // bar's geometry is comparable across refreshes and across resources.
-  function canonicalCommSegments(fracList) {
-    var out = []
-    for (var p = 0; p < palette.length; p++)
-      for (var i = 0; i < fracList.length; i++)
-        if (stableColorKey(fracList[i].key, palette.length) === p)
-          out.push({ key: fracList[i].key, share: fracList[i].share, kind: "comm" })
-    return out
+  // The shade lattice assignment, resolved ONCE over the visible set (the
+  // table's rank order, extended with any RSS-only comms) and shared by the
+  // table accents and every bar — one function, one visible set, so
+  // cross-surface consistency stays structural. Bars lay comm segments out
+  // in LATTICE order: hue-major, shade-minor — fully rank-independent now
+  // that slots are unique below exhaustion, so segment order changes only
+  // with membership. Callers draw constant separators and scale fills
+  // against the fixed gap budget (SPLIT_MAX_SEGMENTS).
+  var lattice = null
+  function slotOf(comm) {
+    if (lattice === null) lattice = resolveColorSlots(result.order, palette, SHADES)
+    return lattice.assignment[comm] !== undefined
+      ? lattice.assignment[comm]
+      : { hue: palette[stableColorKey(comm, palette.length)], hueIdx: stableColorKey(comm, palette.length), shadeIdx: 2, shade: 1 }
+  }
+  function latticeCommSegments(fracList) {
+    var withSlots = []
+    for (var i = 0; i < fracList.length; i++)
+      withSlots.push({ key: fracList[i].key, share: fracList[i].share, kind: "comm", slot: slotOf(fracList[i].key) })
+    withSlots.sort(function(a, b) {
+      if (a.slot.hueIdx !== b.slot.hueIdx) return a.slot.hueIdx - b.slot.hueIdx
+      if (a.slot.shadeIdx !== b.slot.shadeIdx) return a.slot.shadeIdx - b.slot.shadeIdx
+      return a.key < b.key ? -1 : 1
+    })
+    return withSlots
   }
   var n = limit || 5
   var result = { order: [], cpu: null, ram: null, watts: null, gpu: null }
@@ -525,7 +546,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
         var frac = agg.shares[i].share * busyDelta / totalDelta
         if (frac > 0) { commFracs.push({ key: agg.shares[i].label, share: frac }); used += frac }
       }
-      var segs = canonicalCommSegments(commFracs)
+      var segs = latticeCommSegments(commFracs)
       // thresholds would drop sub-pixel segments and break the exact sum;
       // a 0.4% segment renders sub-pixel, which is invisibility enough
       var rest = Math.max(0, busyDelta / totalDelta - used)
@@ -561,7 +582,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
       if (rf > 0) { ramFracs.push({ key: ramList[j].label, share: rf }); rused += rf }
       if (result.order.indexOf(ramList[j].label) === -1) result.order.push(ramList[j].label)
     }
-    var rsegs = canonicalCommSegments(ramFracs)
+    var rsegs = latticeCommSegments(ramFracs)
     var rrest = Math.max(0, usedFrac - rused)
     rsegs.push({ key: "rest", label: "rest", share: rrest, kind: "rest" })
     rsegs.push({ key: "avail", label: "available", share: Math.max(0, 1 - usedFrac), kind: "avail" })
@@ -586,7 +607,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
       var wf = variable * agg.shares[k].share / drawWatts
       if (wf > 0) { wFracs.push({ key: agg.shares[k].label, share: wf }); wused += wf }
     }
-    wsegs = wsegs.concat(canonicalCommSegments(wFracs))
+    wsegs = wsegs.concat(latticeCommSegments(wFracs))
     var welse = Math.max(0, 1 - wused)
     wsegs.push({ key: "else", label: "everything else", share: welse, kind: "else" })
     result.watts = wsegs
@@ -602,6 +623,8 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
     result.intensity.gpu = 0.45 + 0.55 * g
   }
 
+  if (lattice === null) lattice = resolveColorSlots(result.order, palette, SHADES)
+  result.lattice = lattice
   return result
 }
 
@@ -611,14 +634,80 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
 // hue everywhere and forever: table label accents, composition-bar groups,
 // any surface. The multiply stays under 2^53 and the >>>0 fold makes the
 // uint32 overflow explicit, so every QML JS engine agrees bit-for-bit.
-function stableColorKey(comm, paletteSize) {
+function stableColorHash(comm) {
   var h = 2166136261
   var s = String(comm)
   for (var i = 0; i < s.length; i++) {
     h ^= s.charCodeAt(i)
     h = (h * 16777619) >>> 0
   }
-  return h % (paletteSize || 3)
+  return h >>> 0
+}
+
+function stableColorKey(comm, paletteSize) {
+  return stableColorHash(comm) % (paletteSize || 3)
+}
+
+// Full 9-slot preference ordering, derived deterministically from ONE hash:
+// hue = h % 3 (low bits), shade = floor(h / 3) % 3 (the next bits —
+// decorrelated from the hue bits, tested). The preferred slot comes first;
+// then the SAME hue's other shades (cyclically from the preferred shade —
+// hue identity survives displacement, only the shade yields); then the
+// other hues in cyclic order from the preferred hue, each with shades
+// cyclically from the preferred shade. Same comm, same list, forever.
+function slotPreferences(comm, palette, shades) {
+  palette = palette || ["blue", "cyan", "magenta"]
+  shades = shades || SHADES
+  var h = stableColorHash(comm)
+  var hue = h % palette.length
+  var shade = Math.floor(h / palette.length) % shades.length
+  var prefs = [{ hue: hue, shade: shade }]
+  for (var s = 1; s < shades.length; s++) prefs.push({ hue: hue, shade: (shade + s) % shades.length })
+  for (var hu = 1; hu < palette.length; hu++) {
+    for (var s2 = 0; s2 < shades.length; s2++)
+      prefs.push({ hue: (hue + hu) % palette.length, shade: (shade + s2) % shades.length })
+  }
+  return prefs
+}
+
+// Claim resolution over the visible set: a pure function of the rank-ordered
+// comm list — same list, same assignment, always. Claims are processed in
+// claim-strength order (rank first, name lexicographic as the tiebreak), and
+// each comm takes the first slot on its preference list not already taken.
+// Greedy-by-strength IS the displacement fixed point in a single pass — a
+// stronger claim never moves after taking a slot, so cascades cannot arise
+// and termination is structural (one pass, at most nine slots). A comm with
+// no free slot on any of its nine preferences is UNASSIGNED — the table
+// falls back to the round-9 ordinal badge for exactly those.
+// Stability contract: an uncontested comm keeps its hash slot forever;
+// a contested comm's displacement is deterministic (top ranks most stable,
+// shade yields before hue).
+function resolveColorSlots(comms, palette, shades) {
+  palette = palette || ["blue", "cyan", "magenta"]
+  shades = shades || SHADES
+  var ranked = comms.slice().sort(function(a, b) {
+    var ia = comms.indexOf(a), ib = comms.indexOf(b)
+    if (ia !== ib) return ia - ib
+    return a < b ? -1 : (a > b ? 1 : 0)
+  })
+  var taken = {}
+  var assignment = {}
+  var unassigned = []
+  for (var i = 0; i < ranked.length; i++) {
+    var prefs = slotPreferences(ranked[i], palette, shades)
+    var placed = false
+    for (var p = 0; p < prefs.length; p++) {
+      var key = prefs[p].hue + "-" + prefs[p].shade
+      if (!taken[key]) {
+        taken[key] = ranked[i]
+        assignment[ranked[i]] = { hue: palette[prefs[p].hue], hueIdx: prefs[p].hue, shadeIdx: prefs[p].shade, shade: shades[prefs[p].shade] }
+        placed = true
+        break
+      }
+    }
+    if (!placed) unassigned.push(ranked[i])
+  }
+  return { assignment: assignment, unassigned: unassigned }
 }
 
 // comm → palette-entry map, hash-derived (the old order-based assignment is

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -134,19 +134,16 @@ if (typeof module !== "undefined") {
     buildTopProcesses: buildTopProcesses,
     buildSystemRows: buildSystemRows,
     buildSystemAnchorRow: buildSystemAnchorRow,
-    buildRowImpact: buildRowImpact,
     wattsBasis: wattsBasis,
     COMM_MAX_CHARS: COMM_MAX_CHARS,
     buildResourceSplits: buildResourceSplits,
     aggregateCommShares: aggregateCommShares,
-    assignColorKeys: assignColorKeys,
     stableColorKey: stableColorKey,
     stableColorHash: stableColorHash,
     SHADES: SHADES,
     slotPreferences: slotPreferences,
     resolveColorSlots: resolveColorSlots,
-    SPLIT_MAX_SEGMENTS: SPLIT_MAX_SEGMENTS,
-    collisionOrdinals: collisionOrdinals
+    SPLIT_MAX_SEGMENTS: SPLIT_MAX_SEGMENTS
   }
 }
 
@@ -277,10 +274,8 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
   // limitation of per-process memory accounting; the row is a size hint, not
   // an addition that should sum to RAM used.
   var ramByName = {}
-  var anyRam = false
   for (var rpid in nextP) {
     var r = nextP[rpid].rssKb || 0
-    if (r > 0) anyRam = true
     var rname = nextP[rpid].name
     if (!(rname in ramByName)) ramByName[rname] = 0
     ramByName[rname] += r
@@ -290,10 +285,7 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
   var topShareSum = 0
   for (var i = 0; i < shares.length; i++) {
     topShareSum += shares[i].share
-    var cols = [pct(shares[i].share)]
-    if (anyRam && ramByName[shares[i].label] > 0) cols.push(ramTxt(ramByName[shares[i].label]))
-    if (drawWatts >= 0) cols.unshift(wtxt(variable * shares[i].share))
-    out.push({ label: shares[i].label, value: cols.join(" · ") })
+    out.push({ label: shares[i].label })
   }
   var otherShare = drawWatts >= 0 ? Math.max(0, 1 - topShareSum) : 0
   // One graphic line per process: each row carries metric cells (CPU, RAM,
@@ -457,30 +449,7 @@ function buildSystemRows(prevSnapshot, nextSnapshot, drawWatts) {
   return rows
 }
 
-// ---- Power Hungry: impact meters and resource splits -------------------------
-
-// Per-row impact fractions for the POWER HUNGRY rows. Process rows use the
-// share that ranks them — CPU share on external power, and while discharging
-// the attributed watts hold the same proportion (W_i = variable × share_i by
-// construction), so one fraction stays consistent with both the pct and the
-// watt number the row displays. The base and tail rows meter their slice of
-// the whole measured draw instead, matching the watts split bar. All values
-// clamp to 0..1; -1 means "no meter" (row absent).
-function buildRowImpact(topShares, drawWatts, baseWatts, variableWatts, elseShare) {
-  function clamp01(v) { return Math.max(0, Math.min(1, v)) }
-  var top = []
-  var intensity = []
-  var topShare = topShares.length > 0 ? topShares[0].share : 0
-  for (var i = 0; i < topShares.length; i++) {
-    top.push(clamp01(topShares[i].share))
-    // intensity ramp: the top row at full opacity, tail rows fading toward a
-    // 0.35 floor — share-normalized so the ramp reads the same at any load
-    intensity.push(topShare > 0 ? 0.35 + 0.65 * clamp01(topShares[i].share / topShare) : 0.35)
-  }
-  var base = drawWatts > 0 && baseWatts > 0.5 ? clamp01(baseWatts / drawWatts) : -1
-  var elseMeter = drawWatts > 0 && variableWatts >= 0 ? clamp01(variableWatts * elseShare / drawWatts) : -1
-  return { top: top, intensity: intensity, base: base, elseMeter: elseMeter, baseIntensity: 1, elseIntensity: 0.8 }
-}
+// ---- Power Hungry: resource splits --------------------------------------------
 
 // Segment lists for the split bars, one per resource. Every list sums to 1.0
 // on physical data (fuzz-tested); the one honest exception is RAM when
@@ -709,28 +678,4 @@ function resolveColorSlots(comms, palette, shades) {
     if (!placed) unassigned.push(ranked[i])
   }
   return { assignment: assignment, unassigned: unassigned }
-}
-
-// comm → palette-entry map, hash-derived (the old order-based assignment is
-// retired: rank shuffles used to swap colors, which taught nothing). Same
-// signature as before, so call sites are unchanged.
-function assignColorKeys(comms, palette) {
-  var map = {}
-  for (var i = 0; i < comms.length; i++) map[comms[i]] = palette[stableColorKey(comms[i], palette.length)]
-  return map
-}
-
-// Ordinal badges for simultaneous same-hue rows: within the visible set,
-// the first member of a hue stays clean and later members get 2, 3, ... by
-// rank order. The hue is identity; the badge only breaks simultaneous ties,
-// so a lone member of a hue never carries a badge.
-function collisionOrdinals(comms, palette) {
-  var seen = {}
-  var out = {}
-  for (var i = 0; i < comms.length; i++) {
-    var k = stableColorKey(comms[i], palette.length)
-    seen[k] = (seen[k] || 0) + 1
-    out[comms[i]] = seen[k] > 1 ? seen[k] : 0
-  }
-  return out
 }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -102,13 +102,10 @@ function wattsBasis(deviceState, dischargingState, watts) {
 // Kernel comm fields cap at 15 characters (TASK_COMM_LEN), so the panel's
 // comm column can be sized once for the realistic worst case and never per
 // sample.
-// Identity colors are name→hue only: stableColorKey hashes the comm into
-// the three collision-free theme hues, the SAME key on every surface — the
-// table row's mark, every composition bar's segment — so a process is one
-// color wherever it appears (the operator review's single-color-authority
-// rule: the table). Two comms may share a hue (three hues, five rows); the
-// row label and the bar's segment gaps keep them distinct, and the hue
-// never depends on which other comms are visible.
+// Identity is POSITIONAL, not chromatic (grayscale-by-load, operator
+// decision 2026-08-29): the system block leads in white, process blocks
+// follow biggest-to-lightest, and ink brightness carries magnitude. The
+// hash below remains exported for potential non-color reuse.
 var COMM_MAX_CHARS = 15
 
 // Gap budget basis for the composition bars: the most segments any bar can
@@ -420,29 +417,22 @@ function buildSystemRows(prevSnapshot, nextSnapshot) {
 // bar's non-GPU remainder), "idle" / "avail" (unused capacity — rendered as
 // the unfilled track). The same comm carries the same key in every list so
 // one color map serves all bars.
-function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts, palette) {
-  // The identity palette: the three collision-free theme hues (see the
-  // panel's palette rationale). Passed in so callers own it; defaulted so
-  // the pure builder is self-contained.
-  palette = palette || ["blue", "cyan", "magenta"]
-  // Segment colors are the TABLE's colors — the operator review made the
-  // table the single color authority: every comm segment (and the table
-  // row's mark beside it) carries its name-hashed palette hue at full
-  // strength, the same key everywhere, no per-bar shading. Bars are
-  // self-sorted visualizations (round 12, superseding round 11's
-  // bar-follows-table order by the operator's final choice): a SYSTEM
-  // block leads — the table's system row made spatial, in foreground —
-  // then process blocks size-descending by the bar's own metric, then the
-  // idle/available frame. The TABLE keeps the single shared rank; per-bar
+function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts) {
+  // Segment ink is the PANEL's concern (foreground at load-scaled opacity);
+  // this builder owns membership and order: a SYSTEM block leads — the
+  // table's system row made spatial — then process blocks size-descending
+  // by the bar's own metric, then the idle/available frame.
+  // Ink follows load (operator decision 2026-08-29): segments carry no
+  // color — the panel paints every comm in foreground at a load-scaled
+  // opacity. Bars are self-sorted visualizations: a SYSTEM block leads —
+  // the table's system row made spatial, in full ink — then process
+  // blocks size-descending by the bar's own metric, then the idle/
+  // available frame. The TABLE keeps the single shared rank; per-bar
   // order may differ from it and between bars by design.
-  function slotOf(comm) {
-    var idx = stableColorKey(comm, palette.length)
-    return { hue: palette[idx], hueIdx: idx }
-  }
   function rankCommSegments(fracList) {
     var out = []
     for (var i = 0; i < fracList.length; i++)
-      out.push({ key: fracList[i].key, share: fracList[i].share, kind: "comm", slot: slotOf(fracList[i].key) })
+      out.push({ key: fracList[i].key, share: fracList[i].share, kind: "comm" })
     return out
   }
   var n = limit || 5

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -102,10 +102,13 @@ function wattsBasis(deviceState, dischargingState, watts) {
 // Kernel comm fields cap at 15 characters (TASK_COMM_LEN), so the panel's
 // comm column can be sized once for the realistic worst case and never per
 // sample.
-// Identity is POSITIONAL, not chromatic (grayscale-by-load, operator
-// decision 2026-08-29): the system block leads in white, process blocks
-// follow biggest-to-lightest, and ink brightness carries magnitude. The
-// hash below remains exported for potential non-color reuse.
+// Identity colors are name→hue only: stableColorKey hashes the comm into
+// the three collision-free theme hues, the SAME key on every surface — the
+// table row's mark, every composition bar's segment — so a process is one
+// color wherever it appears (the operator review's single-color-authority
+// rule: the table). Two comms may share a hue (three hues, five rows); the
+// row label and the bar's segment gaps keep them distinct, and the hue
+// never depends on which other comms are visible.
 var COMM_MAX_CHARS = 15
 
 // Gap budget basis for the composition bars: the most segments any bar can
@@ -417,22 +420,29 @@ function buildSystemRows(prevSnapshot, nextSnapshot) {
 // bar's non-GPU remainder), "idle" / "avail" (unused capacity — rendered as
 // the unfilled track). The same comm carries the same key in every list so
 // one color map serves all bars.
-function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts) {
-  // Segment ink is the PANEL's concern (foreground at load-scaled opacity);
-  // this builder owns membership and order: a SYSTEM block leads — the
-  // table's system row made spatial — then process blocks size-descending
-  // by the bar's own metric, then the idle/available frame.
-  // Ink follows load (operator decision 2026-08-29): segments carry no
-  // color — the panel paints every comm in foreground at a load-scaled
-  // opacity. Bars are self-sorted visualizations: a SYSTEM block leads —
-  // the table's system row made spatial, in full ink — then process
-  // blocks size-descending by the bar's own metric, then the idle/
-  // available frame. The TABLE keeps the single shared rank; per-bar
+function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts, palette) {
+  // The identity palette: the three collision-free theme hues (see the
+  // panel's palette rationale). Passed in so callers own it; defaulted so
+  // the pure builder is self-contained.
+  palette = palette || ["blue", "cyan", "magenta"]
+  // Segment colors are the TABLE's colors — the operator review made the
+  // table the single color authority: every comm segment (and the table
+  // row's mark beside it) carries its name-hashed palette hue at full
+  // strength, the same key everywhere, no per-bar shading. Bars are
+  // self-sorted visualizations (round 12, superseding round 11's
+  // bar-follows-table order by the operator's final choice): a SYSTEM
+  // block leads — the table's system row made spatial, in foreground —
+  // then process blocks size-descending by the bar's own metric, then the
+  // idle/available frame. The TABLE keeps the single shared rank; per-bar
   // order may differ from it and between bars by design.
+  function slotOf(comm) {
+    var idx = stableColorKey(comm, palette.length)
+    return { hue: palette[idx], hueIdx: idx }
+  }
   function rankCommSegments(fracList) {
     var out = []
     for (var i = 0; i < fracList.length; i++)
-      out.push({ key: fracList[i].key, share: fracList[i].share, kind: "comm" })
+      out.push({ key: fracList[i].key, share: fracList[i].share, kind: "comm", slot: slotOf(fracList[i].key) })
     return out
   }
   var n = limit || 5

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -498,17 +498,16 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
   palette = palette || ["blue", "cyan", "magenta"]
   // The shade lattice assignment, resolved ONCE over the visible set — the
   // TABLE's rank order (CPU busy-share) and nothing else — and shared by the
-  // table accents and every bar: one function, one visible set. Bars lay
-  // their process segments out IN THAT SAME TABLE RANK ORDER, left-to-right
-  // as the table reads top-to-bottom (the operator's correspondence
-  // decision): a rank swap moves exactly the swapped segments — discrete,
-  // meaningful motion, identity preserved by the stable lattice colors.
-  // Round 9's canonical hue-major order is superseded: it existed because
-  // round-8's rank-coupled GROUP order relocated whole hue blocks; with
-  // per-comm lattice-colored segments that disease no longer exists. The
-  // RAM bar previously ranked its own top-N by RSS — that divergence dies
-  // here: it shows the table's comms with their RSS widths, the rest
-  // segment absorbing any used memory the table set doesn't cover.
+  // table accents and every bar: one function, one visible set. Bars are
+  // self-sorted visualizations (round 12, superseding round 11's
+  // bar-follows-table order by the operator's final choice): a SYSTEM
+  // block leads — the table's system-anchor concept made spatial, in
+  // foreground — then process blocks size-descending by the bar's own
+  // metric, then the idle/available frame. The TABLE keeps the single
+  // shared rank; per-bar order may differ from it and between bars by
+  // design. (Round 11's correspondence superseded round 9's canonical
+  // order; the lattice colors, gaps, budget, snap fills, and no-text
+  // rules carry through all three eras untouched.)
   var lattice = null
   function slotOf(comm) {
     if (lattice === null) lattice = resolveColorSlots(result.order, palette, SHADES)
@@ -546,12 +545,10 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
         var frac = agg.shares[i].share * busyDelta / totalDelta
         if (frac > 0) { commFracs.push({ key: agg.shares[i].label, share: frac }); used += frac }
       }
-      var segs = rankCommSegments(commFracs)
-      // thresholds would drop sub-pixel segments and break the exact sum;
-      // a 0.4% segment renders sub-pixel, which is invisibility enough
-      var rest = Math.max(0, busyDelta / totalDelta - used)
-      segs.push({ key: "rest", label: "rest", share: rest, kind: "rest" })
-      var idle = Math.max(0, 1 - used - Math.max(0, rest))
+      // SYSTEM block first: unattributed busy, the anchor made spatial
+      var segs = [{ key: "system", label: "system", share: Math.max(0, busyDelta / totalDelta - used), kind: "system" }]
+      segs = segs.concat(rankCommSegments(commFracs))
+      var idle = Math.max(0, 1 - used - Math.max(0, busyDelta / totalDelta - used))
       segs.push({ key: "idle", label: "idle", share: idle, kind: "idle" })
       result.cpu = segs
       result.intensity.cpu = 0.45 + 0.55 * Math.min(1, Math.max(0, busyDelta / totalDelta))
@@ -584,9 +581,11 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
         }
       }
     }
-    var rsegs = rankCommSegments(ramFracs)
-    var rrest = Math.max(0, usedFrac - rused)
-    rsegs.push({ key: "rest", label: "rest", share: rrest, kind: "rest" })
+    // per-bar size-descending: the RAM bar sorts by RSS even though the
+    // table ranks by CPU — bars are self-sorted visualizations
+    ramFracs.sort(function(a, b) { return b.share - a.share })
+    var rsegs = [{ key: "system", label: "system", share: Math.max(0, usedFrac - rused), kind: "system" }]
+    rsegs = rsegs.concat(rankCommSegments(ramFracs))
     rsegs.push({ key: "avail", label: "available", share: Math.max(0, 1 - usedFrac), kind: "avail" })
     result.ram = rsegs
     result.intensity.ram = 0.45 + 0.55 * usedFrac

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -89,6 +89,16 @@ function modeLabel(device, onBattery, states) {
   return "Charging"
 }
 
+// The watts basis: the battery device's OWN state, not the plug's claim.
+// Attribution is valid whenever the battery is the power source — its
+// discharge rate then IS system draw — including the marginal-adapter
+// wedge where the adapter stays latched online (UPower.onBattery false)
+// while the battery drains. Charging/full/pending return -1: adapter input
+// is unreadable, so per-process watts are physically unattributable there.
+function wattsBasis(deviceState, dischargingState, watts) {
+  return deviceState === dischargingState && watts !== null && watts >= 0 ? watts : -1
+}
+
 // Kernel comm fields cap at 15 characters (TASK_COMM_LEN), so the panel's
 // comm column can be sized once for the realistic worst case and never per
 // sample.
@@ -110,6 +120,7 @@ if (typeof module !== "undefined") {
     buildTopProcesses: buildTopProcesses,
     buildSystemRows: buildSystemRows,
     buildRowImpact: buildRowImpact,
+    wattsBasis: wattsBasis,
     COMM_MAX_CHARS: COMM_MAX_CHARS,
     buildResourceSplits: buildResourceSplits,
     aggregateCommShares: aggregateCommShares,

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -227,7 +227,7 @@ function parseSnapshot(raw) {
 // When the battery draw is known (discharging only — on AC the battery flow
 // is charge rate, not system draw) it is split into a calibrated idle base
 // and a variable slice attributed by share, so the returned rows are
-// [system base, top-N..., everything else] and sum to the measured draw.
+// [base load, top-N..., everything else] and sum to the measured draw.
 // A multi-threaded process can exceed 100% — jiffies sum across cores.
 // Jiffies attributed per comm over the window, share of busy activity —
 // shared by the top-process rows and the resource splits so both views are

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -102,20 +102,20 @@ function wattsBasis(deviceState, dischargingState, watts) {
 // Kernel comm fields cap at 15 characters (TASK_COMM_LEN), so the panel's
 // comm column can be sized once for the realistic worst case and never per
 // sample.
-// The shade lattice: three fixed opacity steps over each identity hue,
-// multiplying the SAME theme color — nine distinguishable identity slots
-// from three collision-free keys, zero new RGB, the 22-theme guarantee
-// intact. Steps chosen against the panel's 0.12-alpha track: the lowest
-// shade stays clearly above the track at panel scale (verified live).
-var SHADES = [0.5, 0.75, 1.0]
-
+// Identity colors are name→hue only: stableColorKey hashes the comm into
+// the three collision-free theme hues, the SAME key on every surface — the
+// table row's mark, every composition bar's segment — so a process is one
+// color wherever it appears (the operator review's single-color-authority
+// rule: the table). Two comms may share a hue (three hues, five rows); the
+// row label and the bar's segment gaps keep them distinct, and the hue
+// never depends on which other comms are visible.
 var COMM_MAX_CHARS = 15
 
 // Gap budget basis for the composition bars: the most segments any bar can
-// show (top-N processes + rest + idle/available; the watts bar's base +
-// top-N + else fits the same count). Callers reserve this many constant
-// separators' worth of width so fills scale identically no matter how many
-// segments are visible.
+// show (top-N processes + the idle/available frame; the watts bar's system
+// block + top-N fits under the same count). Callers reserve this many
+// constant separators' worth of width so fills scale identically no matter
+// how many segments are visible.
 var SPLIT_MAX_SEGMENTS = 7
 
 if (typeof module !== "undefined") {
@@ -133,16 +133,12 @@ if (typeof module !== "undefined") {
     parseSnapshot: parseSnapshot,
     buildTopProcesses: buildTopProcesses,
     buildSystemRows: buildSystemRows,
-    buildSystemAnchorRow: buildSystemAnchorRow,
     wattsBasis: wattsBasis,
     COMM_MAX_CHARS: COMM_MAX_CHARS,
     buildResourceSplits: buildResourceSplits,
     aggregateCommShares: aggregateCommShares,
     stableColorKey: stableColorKey,
     stableColorHash: stableColorHash,
-    SHADES: SHADES,
-    slotPreferences: slotPreferences,
-    resolveColorSlots: resolveColorSlots,
     SPLIT_MAX_SEGMENTS: SPLIT_MAX_SEGMENTS
   }
 }
@@ -227,11 +223,10 @@ function parseSnapshot(raw) {
 // When the battery draw is known (discharging only — on AC the battery flow
 // is charge rate, not system draw) it is split into a calibrated idle base
 // and a variable slice attributed by share, so the returned rows are
-// [base load, top-N..., everything else] and sum to the measured draw.
-// A multi-threaded process can exceed 100% — jiffies sum across cores.
-// Jiffies attributed per comm over the window, share of busy activity —
-// shared by the top-process rows and the resource splits so both views are
-// computed from the same numbers and can never disagree.
+// [system, top-N...] and sum to the measured draw. Jiffies attributed per
+// comm over the window, share of busy activity — shared by the top-process
+// rows and the resource splits so both views are computed from the same
+// numbers and can never disagree.
 function aggregateCommShares(prevSnapshot, nextSnapshot, limit) {
   var nextP = nextSnapshot.processes
   var prevP = prevSnapshot ? prevSnapshot.processes : {}
@@ -317,13 +312,10 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
   var totalAllDelta = prevSnapshot && nextSnapshot.cpuTotal !== null && prevSnapshot.cpuTotal !== null
     ? Math.max(0, nextSnapshot.cpuTotal - prevSnapshot.cpuTotal) : 0
   var busyFrac = totalAllDelta > 0 ? agg.totalDelta / totalAllDelta : 0
-  // the W column's ramp normalizes against its largest cell, whichever row
-  // owns it (usually the top process, sometimes the base floor)
+  // the W column's ramp normalizes against the top process's cell; the
+  // system row below anchors at full intensity and does not contend
   var topW = 0
-  if (drawWatts >= 0) {
-    if (baseWatts > 0.5) topW = Math.max(topW, baseWatts / drawWatts)
-    if (shares.length > 0) topW = Math.max(topW, variable * topShare / drawWatts)
-  }
+  if (drawWatts >= 0 && shares.length > 0) topW = variable * topShare / drawWatts
 
   var procIdx = 0
   var cpuUsedByRows = 0
@@ -342,78 +334,49 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
     procIdx++
   }
 
-  // The everything-else row is a whole-machine remainder row: the CPU left
-  // over after the listed processes (closing the sum to global CPU%), the
-  // used RAM beyond the listed processes' RSS (clamped at zero — shared
-  // pages double-counted per process can push it negative, the standing
-  // disclosure), and the watts tail. It exists when ANY metric has a
-  // meaningful remainder — its old existence gate was watts-only, which
-  // starved the CPU/RAM closure whenever the watts tail was display noise.
+  // The system row: everything not attributed to a listed process — one row,
+  // first in the table (the operator review folded the old "base load" and
+  // "everything else" rows into it; a separate floor row read as a mystery
+  // second "system"). Its cells are the remainders on the same grid and
+  // scale as the processes: the CPU left over after the listed processes
+  // (closing the sum to global CPU%), the used RAM beyond the listed
+  // processes' RSS (clamped at zero — shared pages double-counted per
+  // process can push it negative, the standing disclosure), and the watts
+  // the model does not attribute (the calibrated idle floor PLUS the
+  // variable tail). System + top processes = the whole on every metric,
+  // exactly — that sum is the one-reality invariant. Cells anchor at full
+  // intensity; the panel renders the row in theme foreground so it reads as
+  // the neutral machine against metric-colored processes.
   var usedFracAll = memTotal !== null && nextSnapshot.memAvailKb !== null
     ? Math.max(0, Math.min(1, 1 - nextSnapshot.memAvailKb / memTotal)) : 0
-  var elseCpuRem = totalAllDelta > 0 ? Math.max(0, busyFrac - cpuUsedByRows) : 0
-  var elseRamRem = memTotal !== null ? Math.max(0, usedFracAll - ramUsedByRows) : 0
-  var wTail = drawWatts >= 0 ? variable * otherShare / drawWatts : 0
-  if (elseCpuRem > 0.005 || elseRamRem > 0.005 || (drawWatts >= 0 && otherShare > 0.02 && variable * otherShare > 0.5)) {
-    var eCells = []
-    if (totalAllDelta > 0) eCells.push(cellAtIntensity("CPU", pct(elseCpuRem), elseCpuRem, 0.8))
-    if (memTotal !== null) eCells.push(cellAtIntensity("RAM", ramTxt(Math.round(elseRamRem * memTotal)), elseRamRem, 0.8))
-    if (drawWatts >= 0) eCells.push(cellAtIntensity("W", wtxt(variable * otherShare), wTail, 0.8))
-    out.push({ label: "everything else", value: drawWatts >= 0 ? wtxt(variable * otherShare) : "", key: "else", cells: eCells })
-  }
-
-  if (drawWatts >= 0 && baseWatts > 0.5) {
-    out.unshift({ label: "base load", value: wtxt(baseWatts), key: "base",
-      cells: [cell("W", wtxt(baseWatts), baseWatts / drawWatts, topW)] })
-  }
-  return out
-}
-
-// The anchor row: the machine itself, rendered first in the process table
-// with global values on the same grid and scale — CPU global%, RAM used%,
-// and total draw while the watts basis is active (its W cell fills the whole
-// column because the draw IS the whole the rows below decompose). The panel
-// renders it in theme foreground (never literal white) so it reads as the
-// neutral machine against metric-colored processes.
-function buildSystemAnchorRow(prevSnapshot, nextSnapshot, drawWatts) {
-  var cells = []
-  if (prevSnapshot && nextSnapshot.cpuTotal !== null && prevSnapshot.cpuTotal !== null
-    && nextSnapshot.cpuBusy !== null && prevSnapshot.cpuBusy !== null) {
-    var totalDelta = nextSnapshot.cpuTotal - prevSnapshot.cpuTotal
-    if (totalDelta > 0) {
-      var g = Math.min(1, Math.max(0, (nextSnapshot.cpuBusy - prevSnapshot.cpuBusy) / totalDelta))
-      cells.push({ metric: "CPU", value: Math.round(g * 100) + "%", normalized: g, intensity: 1 })
-    }
-  }
-  if (nextSnapshot.memTotalKb !== null && nextSnapshot.memAvailKb !== null && nextSnapshot.memTotalKb > 0) {
-    var used = Math.max(0, Math.min(1, 1 - nextSnapshot.memAvailKb / nextSnapshot.memTotalKb))
-    cells.push({ metric: "RAM", value: Math.round(used * 100) + "%", normalized: used, intensity: 1 })
-  }
+  var sysCpuRem = totalAllDelta > 0 ? Math.max(0, busyFrac - cpuUsedByRows) : 0
+  var sysRamRem = memTotal !== null ? Math.max(0, usedFracAll - ramUsedByRows) : 0
+  var sysCells = []
+  if (totalAllDelta > 0) sysCells.push(cellAtIntensity("CPU", pct(sysCpuRem), sysCpuRem, 1))
+  if (memTotal !== null) sysCells.push(cellAtIntensity("RAM", ramTxt(Math.round(sysRamRem * memTotal)), sysRamRem, 1))
   if (drawWatts >= 0) {
-    cells.push({ metric: "W", value: (drawWatts < 10 ? drawWatts.toFixed(1) : Math.round(drawWatts)) + " W", normalized: 1, intensity: 1 })
+    var sysW = (baseWatts > 0 ? baseWatts : 0) + variable * otherShare
+    sysCells.push(cellAtIntensity("W", wtxt(sysW), sysW / drawWatts, 1))
   }
-  if (cells.length === 0) return null
-  return { label: "system", key: "system", value: "", cells: cells }
+  if (sysCells.length > 0) out.unshift({ label: "system", key: "system", cells: sysCells })
+  return out
 }
 
 // ---- Power Hungry: system vitals rows ----------------------------------------
 
-// One row per vital as {label, value, meter}, in fixed order: CPU, RAM, GPU,
-// Draw. meter is 0..1 for the panel's progress-bar idiom, or -1 when the row
+// One row per vital as {label, value, meter}, in fixed order: CPU, RAM, GPU.
+// meter is 0..1 for the panel's progress-bar idiom, or -1 when the row
 // has no meter to draw (a dash, or a value that is not a fraction). CPU%
 // needs two snapshots (busy-delta over all-ticks-delta, idle included);
 // before a second snapshot exists it shows the stock "—" placeholder rather
 // than a number, matching how the stats section renders unknowns. RAM% comes
 // from MemAvailable/MemTotal. GPU% appears only when the sampler found a
 // user-readable utilization source — absence is the honest state on GPUs that
-// expose none (e.g. Asahi), so no row is invented. Draw appears only while
-// discharging with known watts, mirroring the attribution's watts rule: on
-// AC the battery flow is charge rate, not system draw, and the row is omitted
-// entirely instead of showing a bogus number. Draw's meter is draw/40 capped
-// at 1 so the panel's green (<20 W) / yellow (<40 W) / red (beyond)
-// thresholds land at 0.5 and 1.0 of the bar.
-function buildSystemRows(prevSnapshot, nextSnapshot, drawWatts) {
-  function wtxt(w) { return (w < 10 ? w.toFixed(1) : Math.round(w)) + " W" }
+// expose none (e.g. Asahi), so no row is invented. There is deliberately no
+// Draw row: total system draw is the stock pill's own number and the stats
+// section's rate row (same sampler telemetry), and the attribution below
+// decomposes it — a third copy was duplication, removed in operator review.
+function buildSystemRows(prevSnapshot, nextSnapshot) {
   var rows = []
 
   var cpuText = "—"
@@ -442,10 +405,6 @@ function buildSystemRows(prevSnapshot, nextSnapshot, drawWatts) {
     rows.push({ label: "GPU", value: gpu + "%", meter: gpu / 100 })
   }
 
-  if (drawWatts >= 0) {
-    rows.push({ label: "Draw", value: wtxt(drawWatts), meter: Math.min(1, drawWatts / 40) })
-  }
-
   return rows
 }
 
@@ -456,33 +415,29 @@ function buildSystemRows(prevSnapshot, nextSnapshot, drawWatts) {
 // per-process RSS sums exceed system used (shared pages counted per process)
 // — there the rest segment clamps to 0 and the list sums above 1, which is
 // the documented double-count disclosure rather than a hidden rescale.
-// Segment kinds: "comm" (top processes), "rest" (other busy / other used),
-// "idle" / "avail" (unused capacity — rendered as the unfilled track),
-// "base" and "else" (the attribution model's floor and tail). The same comm
-// carries the same key in every list so one color map serves all bars.
+// Segment kinds: "comm" (top processes), "system" (everything unattributed
+// — leads every bar, mirroring the table's system row), "rest" (the GPU
+// bar's non-GPU remainder), "idle" / "avail" (unused capacity — rendered as
+// the unfilled track). The same comm carries the same key in every list so
+// one color map serves all bars.
 function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts, palette) {
   // The identity palette: the three collision-free theme hues (see the
   // panel's palette rationale). Passed in so callers own it; defaulted so
   // the pure builder is self-contained.
   palette = palette || ["blue", "cyan", "magenta"]
-  // The shade lattice assignment, resolved ONCE over the visible set — the
-  // TABLE's rank order (CPU busy-share) and nothing else — and shared by the
-  // table accents and every bar: one function, one visible set. Bars are
+  // Segment colors are the TABLE's colors — the operator review made the
+  // table the single color authority: every comm segment (and the table
+  // row's mark beside it) carries its name-hashed palette hue at full
+  // strength, the same key everywhere, no per-bar shading. Bars are
   // self-sorted visualizations (round 12, superseding round 11's
   // bar-follows-table order by the operator's final choice): a SYSTEM
-  // block leads — the table's system-anchor concept made spatial, in
-  // foreground — then process blocks size-descending by the bar's own
-  // metric, then the idle/available frame. The TABLE keeps the single
-  // shared rank; per-bar order may differ from it and between bars by
-  // design. (Round 11's correspondence superseded round 9's canonical
-  // order; the lattice colors, gaps, budget, snap fills, and no-text
-  // rules carry through all three eras untouched.)
-  var lattice = null
+  // block leads — the table's system row made spatial, in foreground —
+  // then process blocks size-descending by the bar's own metric, then the
+  // idle/available frame. The TABLE keeps the single shared rank; per-bar
+  // order may differ from it and between bars by design.
   function slotOf(comm) {
-    if (lattice === null) lattice = resolveColorSlots(result.order, palette, SHADES)
-    return lattice.assignment[comm] !== undefined
-      ? lattice.assignment[comm]
-      : { hue: palette[stableColorKey(comm, palette.length)], hueIdx: stableColorKey(comm, palette.length), shadeIdx: 2, shade: 1 }
+    var idx = stableColorKey(comm, palette.length)
+    return { hue: palette[idx], hueIdx: idx }
   }
   function rankCommSegments(fracList) {
     var out = []
@@ -496,8 +451,8 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
   var agg = prevSnapshot ? aggregateCommShares(prevSnapshot, nextSnapshot, n) : null
   if (agg) result.order = agg.shares.map(function(s) { return s.label })
   // intensity-as-criticality: utilization ramps each system bar's opacity
-  // from 0.45 at idle toward 1.0 at full; the watts bar is categorical
-  // (green/yellow/red) and stays at full intensity.
+  // from 0.45 at idle toward 1.0 at full; the watts bar has no utilization
+  // ramp (draw is not a fraction of a capacity) and stays at full intensity.
   result.intensity = { cpu: 0.45, ram: 0.45, watts: 1, gpu: 0.45 }
 
   // CPU: shares of ALL ticks this window (busy + idle) so the segments,
@@ -536,8 +491,9 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
       if (!(p.name in ramAll)) ramAll[p.name] = 0
       ramAll[p.name] += p.rssKb
     }
-    // table-order RAM segments: the table's comms, in the table's rank,
-    // widths = each comm's RSS share of MemTotal
+    // the table's comms with their RSS widths, self-sorted size-descending
+    // (the RAM bar sorts by RSS even though the table ranks by CPU — bars
+    // are self-sorted visualizations)
     var ramFracs = []
     var rused = 0
     if (agg) {
@@ -550,8 +506,6 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
         }
       }
     }
-    // per-bar size-descending: the RAM bar sorts by RSS even though the
-    // table ranks by CPU — bars are self-sorted visualizations
     ramFracs.sort(function(a, b) { return b.share - a.share })
     var rsegs = [{ key: "system", label: "system", share: Math.max(0, usedFrac - rused), kind: "system" }]
     rsegs = rsegs.concat(rankCommSegments(ramFracs))
@@ -560,26 +514,21 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
     result.intensity.ram = 0.45 + 0.55 * usedFrac
   }
 
-  // Watts: the attribution model as a bar — base floor, top processes, tail.
+  // Watts: the attribution model as a bar — the system block (everything
+  // unattributed: the calibrated idle floor plus the variable tail) first,
+  // then the top processes in their table colors, biggest to lightest.
   // Present only while discharging; on AC the battery flow is charge rate,
   // not system draw, and the bar is omitted rather than faked.
   if (drawWatts >= 0 && agg) {
     var variable = Math.max(0, drawWatts - (baseWatts > 0 ? baseWatts : 0))
-    var wsegs = []
     var wused = 0
-    if (baseWatts > 0.5) {
-      var bf = Math.min(1, baseWatts / drawWatts)
-      wsegs.push({ key: "base", label: "base load", share: bf, kind: "base" })
-      wused += bf
-    }
     var wFracs = []
     for (var k = 0; k < agg.shares.length; k++) {
       var wf = variable * agg.shares[k].share / drawWatts
       if (wf > 0) { wFracs.push({ key: agg.shares[k].label, share: wf }); wused += wf }
     }
+    var wsegs = [{ key: "system", label: "system", share: Math.max(0, 1 - wused), kind: "system" }]
     wsegs = wsegs.concat(rankCommSegments(wFracs))
-    var welse = Math.max(0, 1 - wused)
-    wsegs.push({ key: "else", label: "everything else", share: welse, kind: "else" })
     result.watts = wsegs
   }
 
@@ -593,17 +542,19 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
     result.intensity.gpu = 0.45 + 0.55 * g
   }
 
-  if (lattice === null) lattice = resolveColorSlots(result.order, palette, SHADES)
-  result.lattice = lattice
   return result
 }
 
 // Stable identity colors: FNV-1a over the comm name, reduced into the
 // palette. Deterministic across calls, sessions, and machines — no
 // randomness, no seed state, no order dependence — so a process keeps its
-// hue everywhere and forever: table label accents, composition-bar groups,
-// any surface. The multiply stays under 2^53 and the >>>0 fold makes the
-// uint32 overflow explicit, so every QML JS engine agrees bit-for-bit.
+// hue everywhere and forever: the table row's mark, composition-bar
+// segments, any surface. (Hues can collide — three palette keys, five rows —
+// and that is accepted by the operator-review color rule: the table is the
+// single color authority, identity is name→hue, and a displaced hue would
+// break the table↔bar correspondence the lattice was retired for.) The
+// multiply stays under 2^53 and the >>>0 fold makes the uint32 overflow
+// explicit, so every QML JS engine agrees bit-for-bit.
 function stableColorHash(comm) {
   var h = 2166136261
   var s = String(comm)
@@ -616,66 +567,4 @@ function stableColorHash(comm) {
 
 function stableColorKey(comm, paletteSize) {
   return stableColorHash(comm) % (paletteSize || 3)
-}
-
-// Full 9-slot preference ordering, derived deterministically from ONE hash:
-// hue = h % 3 (low bits), shade = floor(h / 3) % 3 (the next bits —
-// decorrelated from the hue bits, tested). The preferred slot comes first;
-// then the SAME hue's other shades (cyclically from the preferred shade —
-// hue identity survives displacement, only the shade yields); then the
-// other hues in cyclic order from the preferred hue, each with shades
-// cyclically from the preferred shade. Same comm, same list, forever.
-function slotPreferences(comm, palette, shades) {
-  palette = palette || ["blue", "cyan", "magenta"]
-  shades = shades || SHADES
-  var h = stableColorHash(comm)
-  var hue = h % palette.length
-  var shade = Math.floor(h / palette.length) % shades.length
-  var prefs = [{ hue: hue, shade: shade }]
-  for (var s = 1; s < shades.length; s++) prefs.push({ hue: hue, shade: (shade + s) % shades.length })
-  for (var hu = 1; hu < palette.length; hu++) {
-    for (var s2 = 0; s2 < shades.length; s2++)
-      prefs.push({ hue: (hue + hu) % palette.length, shade: (shade + s2) % shades.length })
-  }
-  return prefs
-}
-
-// Claim resolution over the visible set: a pure function of the rank-ordered
-// comm list — same list, same assignment, always. Claims are processed in
-// claim-strength order (rank first, name lexicographic as the tiebreak), and
-// each comm takes the first slot on its preference list not already taken.
-// Greedy-by-strength IS the displacement fixed point in a single pass — a
-// stronger claim never moves after taking a slot, so cascades cannot arise
-// and termination is structural (one pass, at most nine slots). A comm with
-// no free slot on any of its nine preferences is UNASSIGNED — the table
-// falls back to the round-9 ordinal badge for exactly those.
-// Stability contract: an uncontested comm keeps its hash slot forever;
-// a contested comm's displacement is deterministic (top ranks most stable,
-// shade yields before hue).
-function resolveColorSlots(comms, palette, shades) {
-  palette = palette || ["blue", "cyan", "magenta"]
-  shades = shades || SHADES
-  var ranked = comms.slice().sort(function(a, b) {
-    var ia = comms.indexOf(a), ib = comms.indexOf(b)
-    if (ia !== ib) return ia - ib
-    return a < b ? -1 : (a > b ? 1 : 0)
-  })
-  var taken = {}
-  var assignment = {}
-  var unassigned = []
-  for (var i = 0; i < ranked.length; i++) {
-    var prefs = slotPreferences(ranked[i], palette, shades)
-    var placed = false
-    for (var p = 0; p < prefs.length; p++) {
-      var key = prefs[p].hue + "-" + prefs[p].shade
-      if (!taken[key]) {
-        taken[key] = ranked[i]
-        assignment[ranked[i]] = { hue: palette[prefs[p].hue], hueIdx: prefs[p].hue, shadeIdx: prefs[p].shade, shade: shades[prefs[p].shade] }
-        placed = true
-        break
-      }
-    }
-    if (!placed) unassigned.push(ranked[i])
-  }
-  return { assignment: assignment, unassigned: unassigned }
 }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -103,7 +103,11 @@ if (typeof module !== "undefined") {
     modeLabel: modeLabel,
     parseSnapshot: parseSnapshot,
     buildTopProcesses: buildTopProcesses,
-    buildSystemRows: buildSystemRows
+    buildSystemRows: buildSystemRows,
+    buildRowImpact: buildRowImpact,
+    buildResourceSplits: buildResourceSplits,
+    aggregateCommShares: aggregateCommShares,
+    assignColorKeys: assignColorKeys
   }
 }
 
@@ -188,7 +192,10 @@ function parseSnapshot(raw) {
 // and a variable slice attributed by share, so the returned rows are
 // [system base, top-N..., everything else] and sum to the measured draw.
 // A multi-threaded process can exceed 100% — jiffies sum across cores.
-function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts) {
+// Jiffies attributed per comm over the window, share of busy activity —
+// shared by the top-process rows and the resource splits so both views are
+// computed from the same numbers and can never disagree.
+function aggregateCommShares(prevSnapshot, nextSnapshot, limit) {
   var nextP = nextSnapshot.processes
   var prevP = prevSnapshot ? prevSnapshot.processes : {}
   var totalDelta = Math.max(1,
@@ -206,7 +213,13 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
   var shares = []
   for (var name in byName) shares.push({ label: name, share: byName[name] / totalDelta })
   shares.sort(function(a, b) { return b.share - a.share })
-  shares = shares.slice(0, limit || 5)
+  return { shares: shares.slice(0, limit || 5), all: shares, totalDelta: totalDelta }
+}
+
+function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts) {
+  var nextP = nextSnapshot.processes
+  var agg = aggregateCommShares(prevSnapshot, nextSnapshot, limit)
+  var shares = agg.shares
 
   var variable = drawWatts >= 0 ? Math.max(0, drawWatts - (baseWatts > 0 ? baseWatts : 0)) : 0
   function pct(s) { return (s >= 1 ? Math.round(s * 100) : (s * 100).toFixed(1)) + "%" }
@@ -242,11 +255,22 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
     if (drawWatts >= 0) cols.unshift(wtxt(variable * shares[i].share))
     out.push({ label: shares[i].label, value: cols.join(" · ") })
   }
+  var otherShare = drawWatts >= 0 ? Math.max(0, 1 - topShareSum) : 0
   if (drawWatts >= 0) {
-    if (baseWatts > 0.5) out.unshift({ label: "system base", value: wtxt(baseWatts) })
-    var otherShare = Math.max(0, 1 - topShareSum)
+    if (baseWatts > 0.5) out.unshift({ label: "system base", value: wtxt(baseWatts), key: "base" })
     if (otherShare > 0.02 && variable * otherShare > 0.5)
-      out.push({ label: "everything else", value: wtxt(variable * otherShare) })
+      out.push({ label: "everything else", value: wtxt(variable * otherShare), key: "else" })
+  }
+  // per-row impact meters, aligned to the rows above (process rows only; the
+  // base/else meters ride on their own rows below)
+  var impact = buildRowImpact(shares, drawWatts, baseWatts, variable, otherShare)
+  var procIdx = 0
+  for (var r = 0; r < out.length; r++) {
+    if (out[r].key === "base") { out[r].meter = impact.base; continue }
+    if (out[r].key === "else") { out[r].meter = impact.elseMeter; continue }
+    out[r].meter = impact.top[procIdx]
+    out[r].key = out[r].label
+    procIdx++
   }
   return out
 }
@@ -302,4 +326,135 @@ function buildSystemRows(prevSnapshot, nextSnapshot, drawWatts) {
   }
 
   return rows
+}
+
+// ---- Power Hungry: impact meters and resource splits -------------------------
+
+// Per-row impact fractions for the POWER HUNGRY rows. Process rows use the
+// share that ranks them — CPU share on external power, and while discharging
+// the attributed watts hold the same proportion (W_i = variable × share_i by
+// construction), so one fraction stays consistent with both the pct and the
+// watt number the row displays. The base and tail rows meter their slice of
+// the whole measured draw instead, matching the watts split bar. All values
+// clamp to 0..1; -1 means "no meter" (row absent).
+function buildRowImpact(topShares, drawWatts, baseWatts, variableWatts, elseShare) {
+  function clamp01(v) { return Math.max(0, Math.min(1, v)) }
+  var top = []
+  for (var i = 0; i < topShares.length; i++) top.push(clamp01(topShares[i].share))
+  var base = drawWatts > 0 && baseWatts > 0.5 ? clamp01(baseWatts / drawWatts) : -1
+  var elseMeter = drawWatts > 0 && variableWatts >= 0 ? clamp01(variableWatts * elseShare / drawWatts) : -1
+  return { top: top, base: base, elseMeter: elseMeter }
+}
+
+// Segment lists for the split bars, one per resource. Every list sums to 1.0
+// on physical data (fuzz-tested); the one honest exception is RAM when
+// per-process RSS sums exceed system used (shared pages counted per process)
+// — there the rest segment clamps to 0 and the list sums above 1, which is
+// the documented double-count disclosure rather than a hidden rescale.
+// Segment kinds: "comm" (top processes), "rest" (other busy / other used),
+// "idle" / "avail" (unused capacity — rendered as the unfilled track),
+// "base" and "else" (the attribution model's floor and tail). The same comm
+// carries the same key in every list so one color map serves all bars.
+function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts) {
+  var n = limit || 5
+  var result = { order: [], cpu: null, ram: null, watts: null, gpu: null }
+
+  var agg = prevSnapshot ? aggregateCommShares(prevSnapshot, nextSnapshot, n) : null
+  if (agg) result.order = agg.shares.map(function(s) { return s.label })
+
+  // CPU: shares of ALL ticks this window (busy + idle) so the segments,
+  // including idle, sum to exactly 1.
+  if (agg && prevSnapshot && nextSnapshot.cpuBusy !== null && nextSnapshot.cpuTotal !== null
+    && prevSnapshot.cpuBusy !== null && prevSnapshot.cpuTotal !== null) {
+    var totalDelta = nextSnapshot.cpuTotal - prevSnapshot.cpuTotal
+    var busyDelta = nextSnapshot.cpuBusy - prevSnapshot.cpuBusy
+    if (totalDelta > 0) {
+      var segs = []
+      var used = 0
+      for (var i = 0; i < agg.shares.length; i++) {
+        // share_i is of busy activity; rescale to all ticks
+        var frac = agg.shares[i].share * busyDelta / totalDelta
+        if (frac > 0) { segs.push({ key: agg.shares[i].label, label: agg.shares[i].label, share: frac, kind: "comm" }); used += frac }
+      }
+      // thresholds would drop sub-pixel segments and break the exact sum;
+      // a 0.4% segment renders sub-pixel, which is invisibility enough
+      var rest = Math.max(0, busyDelta / totalDelta - used)
+      segs.push({ key: "rest", label: "rest", share: rest, kind: "rest" })
+      var idle = Math.max(0, 1 - used - Math.max(0, rest))
+      segs.push({ key: "idle", label: "idle", share: idle, kind: "idle" })
+      result.cpu = segs
+    }
+  }
+
+  // RAM: shares of MemTotal. RSS double-counting makes the sum exceed 1 only
+  // when shared pages outweigh the slack; see the doc note above.
+  if (nextSnapshot.memTotalKb !== null && nextSnapshot.memAvailKb !== null && nextSnapshot.memTotalKb > 0) {
+    var totalKb = nextSnapshot.memTotalKb
+    var usedFrac = Math.max(0, Math.min(1, 1 - nextSnapshot.memAvailKb / totalKb))
+    var ramAll = []
+    var seen = {}
+    for (var pid in nextSnapshot.processes) {
+      var p = nextSnapshot.processes[pid]
+      if (!p.rssKb) continue
+      if (!(p.name in seen)) { seen[p.name] = 0; }
+      seen[p.name] += p.rssKb
+    }
+    var ramList = []
+    for (var nm in seen) ramList.push({ label: nm, kb: seen[nm] })
+    ramList.sort(function(a, b) { return b.kb - a.kb })
+    ramList = ramList.slice(0, n)
+    var rsegs = []
+    var rused = 0
+    for (var j = 0; j < ramList.length; j++) {
+      var rf = ramList[j].kb / totalKb
+      if (rf > 0) { rsegs.push({ key: ramList[j].label, label: ramList[j].label, share: rf, kind: "comm" }); rused += rf }
+      if (result.order.indexOf(ramList[j].label) === -1) result.order.push(ramList[j].label)
+    }
+    var rrest = Math.max(0, usedFrac - rused)
+    rsegs.push({ key: "rest", label: "rest", share: rrest, kind: "rest" })
+    rsegs.push({ key: "avail", label: "available", share: Math.max(0, 1 - usedFrac), kind: "avail" })
+    result.ram = rsegs
+  }
+
+  // Watts: the attribution model as a bar — base floor, top processes, tail.
+  // Present only while discharging; on AC the battery flow is charge rate,
+  // not system draw, and the bar is omitted rather than faked.
+  if (drawWatts >= 0 && agg) {
+    var variable = Math.max(0, drawWatts - (baseWatts > 0 ? baseWatts : 0))
+    var wsegs = []
+    var wused = 0
+    if (baseWatts > 0.5) {
+      var bf = Math.min(1, baseWatts / drawWatts)
+      wsegs.push({ key: "base", label: "system base", share: bf, kind: "base" })
+      wused += bf
+    }
+    for (var k = 0; k < agg.shares.length; k++) {
+      var wf = variable * agg.shares[k].share / drawWatts
+      if (wf > 0) { wsegs.push({ key: agg.shares[k].label, label: agg.shares[k].label, share: wf, kind: "comm" }); wused += wf }
+    }
+    var welse = Math.max(0, 1 - wused)
+    wsegs.push({ key: "else", label: "everything else", share: welse, kind: "else" })
+    result.watts = wsegs
+  }
+
+  // GPU: a one-value split; absent sources stay null (absence by design).
+  if (nextSnapshot.gpuPct !== null) {
+    var g = Math.min(100, Math.max(0, nextSnapshot.gpuPct)) / 100
+    result.gpu = [
+      { key: "gpu", label: "GPU", share: g, kind: "comm" },
+      { key: "gpu-rest", label: "rest", share: 1 - g, kind: "rest" }
+    ]
+  }
+
+  return result
+}
+
+// Deterministic comm → palette-slot map so a comm keeps one color across the
+// CPU, RAM, and watts bars and its row meter. Palette cycles past its length;
+// beyond the palette the collision is accepted (row order disambiguates) and
+// documented — themes carry only so many distinguishable hues.
+function assignColorKeys(order, palette) {
+  var map = {}
+  for (var i = 0; i < order.length; i++) map[order[i]] = palette[i % palette.length]
+  return map
 }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -261,14 +261,26 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
     if (otherShare > 0.02 && variable * otherShare > 0.5)
       out.push({ label: "everything else", value: wtxt(variable * otherShare), key: "else" })
   }
-  // per-row impact meters, aligned to the rows above (process rows only; the
-  // base/else meters ride on their own rows below)
+  // per-row impact, aligned to the rows above: fill fraction (meter), the
+  // intensity ramp, the raw share, and the RSS fraction for the sub-bar
   var impact = buildRowImpact(shares, drawWatts, baseWatts, variable, otherShare)
   var procIdx = 0
   for (var r = 0; r < out.length; r++) {
-    if (out[r].key === "base") { out[r].meter = impact.base; continue }
-    if (out[r].key === "else") { out[r].meter = impact.elseMeter; continue }
+    if (out[r].key === "base") {
+      out[r].meter = impact.base
+      out[r].intensity = impact.baseIntensity
+      continue
+    }
+    if (out[r].key === "else") {
+      out[r].meter = impact.elseMeter
+      out[r].intensity = impact.elseIntensity
+      continue
+    }
     out[r].meter = impact.top[procIdx]
+    out[r].intensity = impact.intensity[procIdx]
+    out[r].share = shares[procIdx].share
+    out[r].ramShare = ramByName[shares[procIdx].label] !== undefined && nextSnapshot.memTotalKb
+      ? Math.min(1, ramByName[shares[procIdx].label] / nextSnapshot.memTotalKb) : 0
     out[r].key = out[r].label
     procIdx++
   }
@@ -340,10 +352,17 @@ function buildSystemRows(prevSnapshot, nextSnapshot, drawWatts) {
 function buildRowImpact(topShares, drawWatts, baseWatts, variableWatts, elseShare) {
   function clamp01(v) { return Math.max(0, Math.min(1, v)) }
   var top = []
-  for (var i = 0; i < topShares.length; i++) top.push(clamp01(topShares[i].share))
+  var intensity = []
+  var topShare = topShares.length > 0 ? topShares[0].share : 0
+  for (var i = 0; i < topShares.length; i++) {
+    top.push(clamp01(topShares[i].share))
+    // intensity ramp: the top row at full opacity, tail rows fading toward a
+    // 0.35 floor — share-normalized so the ramp reads the same at any load
+    intensity.push(topShare > 0 ? 0.35 + 0.65 * clamp01(topShares[i].share / topShare) : 0.35)
+  }
   var base = drawWatts > 0 && baseWatts > 0.5 ? clamp01(baseWatts / drawWatts) : -1
   var elseMeter = drawWatts > 0 && variableWatts >= 0 ? clamp01(variableWatts * elseShare / drawWatts) : -1
-  return { top: top, base: base, elseMeter: elseMeter }
+  return { top: top, intensity: intensity, base: base, elseMeter: elseMeter, baseIntensity: 1, elseIntensity: 0.8 }
 }
 
 // Segment lists for the split bars, one per resource. Every list sums to 1.0
@@ -361,6 +380,10 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
 
   var agg = prevSnapshot ? aggregateCommShares(prevSnapshot, nextSnapshot, n) : null
   if (agg) result.order = agg.shares.map(function(s) { return s.label })
+  // intensity-as-criticality: utilization ramps each system bar's opacity
+  // from 0.45 at idle toward 1.0 at full; the watts bar is categorical
+  // (green/yellow/red) and stays at full intensity.
+  result.intensity = { cpu: 0.45, ram: 0.45, watts: 1, gpu: 0.45 }
 
   // CPU: shares of ALL ticks this window (busy + idle) so the segments,
   // including idle, sum to exactly 1.
@@ -383,6 +406,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
       var idle = Math.max(0, 1 - used - Math.max(0, rest))
       segs.push({ key: "idle", label: "idle", share: idle, kind: "idle" })
       result.cpu = segs
+      result.intensity.cpu = 0.45 + 0.55 * Math.min(1, Math.max(0, busyDelta / totalDelta))
     }
   }
 
@@ -414,6 +438,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
     rsegs.push({ key: "rest", label: "rest", share: rrest, kind: "rest" })
     rsegs.push({ key: "avail", label: "available", share: Math.max(0, 1 - usedFrac), kind: "avail" })
     result.ram = rsegs
+    result.intensity.ram = 0.45 + 0.55 * usedFrac
   }
 
   // Watts: the attribution model as a bar — base floor, top processes, tail.
@@ -444,6 +469,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
       { key: "gpu", label: "GPU", share: g, kind: "comm" },
       { key: "gpu-rest", label: "rest", share: 1 - g, kind: "rest" }
     ]
+    result.intensity.gpu = 0.45 + 0.55 * g
   }
 
   return result

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -102,7 +102,8 @@ if (typeof module !== "undefined") {
     batteryIcon: batteryIcon,
     modeLabel: modeLabel,
     parseSnapshot: parseSnapshot,
-    buildTopProcesses: buildTopProcesses
+    buildTopProcesses: buildTopProcesses,
+    buildSystemRows: buildSystemRows
   }
 }
 
@@ -113,13 +114,21 @@ if (typeof module !== "undefined") {
 // pill is untouched by design — this feature answers a question you ask with
 // the panel open, and the bar stays calm (see the PR's design note).
 
-// Parses one sampler.sh snapshot into {watts, cpuTotalJiffies, processes}
-// where processes maps pid -> {name, jiffies}. watts is the absolute battery
-// flow; the sampler strips the driver's discharge sign so direction comes
-// from UPower, never from this value.
+// Parses one sampler.sh snapshot into {watts, cpuTotalJiffies, cpuBusy,
+// cpuTotal, memTotalKb, memAvailKb, gpuPct, processes} where processes maps
+// pid -> {name, jiffies, rssKb}. watts is the absolute battery flow; the
+// sampler strips the driver's discharge sign so direction comes from UPower,
+// never from this value. cpuTotalJiffies is busy jiffies (the attribution
+// key); cpuBusy mirrors it and cpuTotal adds idle+iowait for the system CPU%.
+// mem*/gpuPct/rssKb are null/0 when their source was absent or unreadable.
 function parseSnapshot(raw) {
   var watts = null
   var cpuTotalJiffies = null
+  var cpuBusy = null
+  var cpuTotal = null
+  var memTotalKb = null
+  var memAvailKb = null
+  var gpuPct = null
   var processes = {}
   var lines = String(raw || "").split("\n")
   for (var i = 0; i < lines.length; i++) {
@@ -130,16 +139,45 @@ function parseSnapshot(raw) {
     } else if (parts[0] === "cputotal" && parts.length >= 2 && parts[1] !== "") {
       var t = parseInt(parts[1], 10)
       if (!isNaN(t)) cpuTotalJiffies = t
+    } else if (parts[0] === "cpu_busy" && parts.length >= 2 && parts[1] !== "") {
+      var b = parseInt(parts[1], 10)
+      if (!isNaN(b)) cpuBusy = b
+    } else if (parts[0] === "cpu_total" && parts.length >= 2 && parts[1] !== "") {
+      var a = parseInt(parts[1], 10)
+      if (!isNaN(a)) cpuTotal = a
+    } else if (parts[0] === "mem_total_kb" && parts.length >= 2 && parts[1] !== "") {
+      var mt = parseInt(parts[1], 10)
+      if (!isNaN(mt)) memTotalKb = mt
+    } else if (parts[0] === "mem_avail_kb" && parts.length >= 2 && parts[1] !== "") {
+      var ma = parseInt(parts[1], 10)
+      if (!isNaN(ma)) memAvailKb = ma
+    } else if (parts[0] === "gpu_pct" && parts.length >= 2 && parts[1] !== "") {
+      var gp = parseInt(parts[1], 10)
+      if (!isNaN(gp)) gpuPct = gp
     } else if (parts[0] === "p" && parts.length >= 4) {
       var pid = parseInt(parts[1], 10)
       var j = parseInt(parts[2], 10)
       if (!isNaN(pid) && !isNaN(j)) {
-        if (!(pid in processes)) processes[pid] = { name: parts[3], jiffies: j }
-        else if (j > processes[pid].jiffies) processes[pid].jiffies = j
+        var rss = parts.length >= 5 ? parseInt(parts[4], 10) : 0
+        if (isNaN(rss)) rss = 0
+        if (!(pid in processes)) processes[pid] = { name: parts[3], jiffies: j, rssKb: rss }
+        else {
+          if (j > processes[pid].jiffies) processes[pid].jiffies = j
+          if (rss > processes[pid].rssKb) processes[pid].rssKb = rss
+        }
       }
     }
   }
-  return { watts: watts, cpuTotalJiffies: cpuTotalJiffies, processes: processes }
+  return {
+    watts: watts,
+    cpuTotalJiffies: cpuTotalJiffies,
+    cpuBusy: cpuBusy,
+    cpuTotal: cpuTotal,
+    memTotalKb: memTotalKb,
+    memAvailKb: memAvailKb,
+    gpuPct: gpuPct,
+    processes: processes
+  }
 }
 
 // Busiest processes by CPU share of the jiffies consumed in the window,
@@ -173,15 +211,36 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
   var variable = drawWatts >= 0 ? Math.max(0, drawWatts - (baseWatts > 0 ? baseWatts : 0)) : 0
   function pct(s) { return (s >= 1 ? Math.round(s * 100) : (s * 100).toFixed(1)) + "%" }
   function wtxt(w) { return (w < 10 ? w.toFixed(1) : Math.round(w)) + " W" }
+  function ramTxt(kb) {
+    var mib = kb / 1024
+    if (mib >= 1024) return (mib / 1024).toFixed(1) + " GiB"
+    if (mib >= 1) return Math.floor(mib) + " MiB"
+    return kb + " KiB"
+  }
+
+  // Current resident memory aggregated by comm — a level, not a delta, so it
+  // comes from the next snapshot. RSS sums double-count pages shared between
+  // processes (helpers of one app share libc etc.), which is the honest known
+  // limitation of per-process memory accounting; the row is a size hint, not
+  // an addition that should sum to RAM used.
+  var ramByName = {}
+  var anyRam = false
+  for (var rpid in nextP) {
+    var r = nextP[rpid].rssKb || 0
+    if (r > 0) anyRam = true
+    var rname = nextP[rpid].name
+    if (!(rname in ramByName)) ramByName[rname] = 0
+    ramByName[rname] += r
+  }
 
   var out = []
   var topShareSum = 0
   for (var i = 0; i < shares.length; i++) {
     topShareSum += shares[i].share
-    out.push({
-      label: shares[i].label,
-      value: drawWatts >= 0 ? wtxt(variable * shares[i].share) + " (" + pct(shares[i].share) + ")" : pct(shares[i].share)
-    })
+    var cols = [pct(shares[i].share)]
+    if (anyRam && ramByName[shares[i].label] > 0) cols.push(ramTxt(ramByName[shares[i].label]))
+    if (drawWatts >= 0) cols.unshift(wtxt(variable * shares[i].share))
+    out.push({ label: shares[i].label, value: cols.join(" · ") })
   }
   if (drawWatts >= 0) {
     if (baseWatts > 0.5) out.unshift({ label: "system base", value: wtxt(baseWatts) })
@@ -190,4 +249,57 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
       out.push({ label: "everything else", value: wtxt(variable * otherShare) })
   }
   return out
+}
+
+// ---- Power Hungry: system vitals rows ----------------------------------------
+
+// One row per vital as {label, value, meter}, in fixed order: CPU, RAM, GPU,
+// Draw. meter is 0..1 for the panel's progress-bar idiom, or -1 when the row
+// has no meter to draw (a dash, or a value that is not a fraction). CPU%
+// needs two snapshots (busy-delta over all-ticks-delta, idle included);
+// before a second snapshot exists it shows the stock "—" placeholder rather
+// than a number, matching how the stats section renders unknowns. RAM% comes
+// from MemAvailable/MemTotal. GPU% appears only when the sampler found a
+// user-readable utilization source — absence is the honest state on GPUs that
+// expose none (e.g. Asahi), so no row is invented. Draw appears only while
+// discharging with known watts, mirroring the attribution's watts rule: on
+// AC the battery flow is charge rate, not system draw, and the row is omitted
+// entirely instead of showing a bogus number. Draw's meter is draw/40 capped
+// at 1 so the panel's green (<20 W) / yellow (<40 W) / red (beyond)
+// thresholds land at 0.5 and 1.0 of the bar.
+function buildSystemRows(prevSnapshot, nextSnapshot, drawWatts) {
+  function wtxt(w) { return (w < 10 ? w.toFixed(1) : Math.round(w)) + " W" }
+  var rows = []
+
+  var cpuText = "—"
+  var cpuMeter = -1
+  if (prevSnapshot && nextSnapshot.cpuBusy !== null && nextSnapshot.cpuTotal !== null
+    && prevSnapshot.cpuBusy !== null && prevSnapshot.cpuTotal !== null) {
+    var totalDelta = nextSnapshot.cpuTotal - prevSnapshot.cpuTotal
+    if (totalDelta > 0) {
+      var busyDelta = Math.max(0, nextSnapshot.cpuBusy - prevSnapshot.cpuBusy)
+      cpuMeter = Math.min(1, busyDelta / totalDelta)
+      cpuText = Math.round(cpuMeter * 100) + "%"
+    }
+  }
+  rows.push({ label: "CPU", value: cpuText, meter: cpuMeter })
+
+  if (nextSnapshot.memTotalKb !== null && nextSnapshot.memAvailKb !== null
+    && nextSnapshot.memTotalKb > 0) {
+    // avail can exceed total only through a torn read; clamp so the row never
+    // shows a negative or >100 percent.
+    var used = Math.max(0, Math.min(1, 1 - nextSnapshot.memAvailKb / nextSnapshot.memTotalKb))
+    rows.push({ label: "RAM", value: Math.round(used * 100) + "%", meter: used })
+  }
+
+  if (nextSnapshot.gpuPct !== null) {
+    var gpu = Math.min(100, Math.max(0, nextSnapshot.gpuPct))
+    rows.push({ label: "GPU", value: gpu + "%", meter: gpu / 100 })
+  }
+
+  if (drawWatts >= 0) {
+    rows.push({ label: "Draw", value: wtxt(drawWatts), meter: Math.min(1, drawWatts / 40) })
+  }
+
+  return rows
 }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -104,6 +104,13 @@ function wattsBasis(deviceState, dischargingState, watts) {
 // sample.
 var COMM_MAX_CHARS = 15
 
+// Gap budget basis for the composition bars: the most segments any bar can
+// show (top-N processes + rest + idle/available; the watts bar's base +
+// top-N + else fits the same count). Callers reserve this many constant
+// separators' worth of width so fills scale identically no matter how many
+// segments are visible.
+var SPLIT_MAX_SEGMENTS = 7
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampIndex: clampIndex,
@@ -127,6 +134,7 @@ if (typeof module !== "undefined") {
     aggregateCommShares: aggregateCommShares,
     assignColorKeys: assignColorKeys,
     stableColorKey: stableColorKey,
+    SPLIT_MAX_SEGMENTS: SPLIT_MAX_SEGMENTS,
     collisionOrdinals: collisionOrdinals
   }
 }
@@ -477,19 +485,20 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
   // panel's palette rationale). Passed in so callers own it; defaulted so
   // the pure builder is self-contained.
   palette = palette || ["blue", "cyan", "magenta"]
-  // Composition bars group same-hue comms into one segment per hue: the bar
-  // honestly shows what color can distinguish, and the table below names
-  // members. Group share = sum of members; group order = first appearance
-  // by rank; rest/idle/avail/base/else segments are untouched.
-  function groupByHue(fracList) {
-    var sums = {}, orderKeys = []
-    for (var i = 0; i < fracList.length; i++) {
-      var entry = palette[stableColorKey(fracList[i].key, palette.length)]
-      if (!(entry in sums)) { sums[entry] = 0; orderKeys.push(entry) }
-      sums[entry] += fracList[i].share
-    }
+  // Composition bars keep PER-COMM segments (the round-8 merge chunked the
+  // geometry away), laid out in CANONICAL hue order: every blue-hue comm
+  // first, then cyan, then magenta — rank order only WITHIN a hue — then
+  // rest, then idle/available. Rank shuffles can reorder members inside
+  // their hue block and shares may breathe, but hue blocks never relocate:
+  // horizontal calm. Callers draw constant separators between segments and
+  // scale fills against a fixed gap budget (SPLIT_MAX_SEGMENTS) so the
+  // bar's geometry is comparable across refreshes and across resources.
+  function canonicalCommSegments(fracList) {
     var out = []
-    for (var g = 0; g < orderKeys.length; g++) out.push({ key: orderKeys[g], share: sums[orderKeys[g]], kind: "group" })
+    for (var p = 0; p < palette.length; p++)
+      for (var i = 0; i < fracList.length; i++)
+        if (stableColorKey(fracList[i].key, palette.length) === p)
+          out.push({ key: fracList[i].key, share: fracList[i].share, kind: "comm" })
     return out
   }
   var n = limit || 5
@@ -516,7 +525,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
         var frac = agg.shares[i].share * busyDelta / totalDelta
         if (frac > 0) { commFracs.push({ key: agg.shares[i].label, share: frac }); used += frac }
       }
-      var segs = groupByHue(commFracs)
+      var segs = canonicalCommSegments(commFracs)
       // thresholds would drop sub-pixel segments and break the exact sum;
       // a 0.4% segment renders sub-pixel, which is invisibility enough
       var rest = Math.max(0, busyDelta / totalDelta - used)
@@ -552,7 +561,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
       if (rf > 0) { ramFracs.push({ key: ramList[j].label, share: rf }); rused += rf }
       if (result.order.indexOf(ramList[j].label) === -1) result.order.push(ramList[j].label)
     }
-    var rsegs = groupByHue(ramFracs)
+    var rsegs = canonicalCommSegments(ramFracs)
     var rrest = Math.max(0, usedFrac - rused)
     rsegs.push({ key: "rest", label: "rest", share: rrest, kind: "rest" })
     rsegs.push({ key: "avail", label: "available", share: Math.max(0, 1 - usedFrac), kind: "avail" })
@@ -577,7 +586,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
       var wf = variable * agg.shares[k].share / drawWatts
       if (wf > 0) { wFracs.push({ key: agg.shares[k].label, share: wf }); wused += wf }
     }
-    wsegs = wsegs.concat(groupByHue(wFracs))
+    wsegs = wsegs.concat(canonicalCommSegments(wFracs))
     var welse = Math.max(0, 1 - wused)
     wsegs.push({ key: "else", label: "everything else", share: welse, kind: "else" })
     result.watts = wsegs

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -125,7 +125,9 @@ if (typeof module !== "undefined") {
     COMM_MAX_CHARS: COMM_MAX_CHARS,
     buildResourceSplits: buildResourceSplits,
     aggregateCommShares: aggregateCommShares,
-    assignColorKeys: assignColorKeys
+    assignColorKeys: assignColorKeys,
+    stableColorKey: stableColorKey,
+    collisionOrdinals: collisionOrdinals
   }
 }
 
@@ -470,7 +472,26 @@ function buildRowImpact(topShares, drawWatts, baseWatts, variableWatts, elseShar
 // "idle" / "avail" (unused capacity — rendered as the unfilled track),
 // "base" and "else" (the attribution model's floor and tail). The same comm
 // carries the same key in every list so one color map serves all bars.
-function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts) {
+function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseWatts, palette) {
+  // The identity palette: the three collision-free theme hues (see the
+  // panel's palette rationale). Passed in so callers own it; defaulted so
+  // the pure builder is self-contained.
+  palette = palette || ["blue", "cyan", "magenta"]
+  // Composition bars group same-hue comms into one segment per hue: the bar
+  // honestly shows what color can distinguish, and the table below names
+  // members. Group share = sum of members; group order = first appearance
+  // by rank; rest/idle/avail/base/else segments are untouched.
+  function groupByHue(fracList) {
+    var sums = {}, orderKeys = []
+    for (var i = 0; i < fracList.length; i++) {
+      var entry = palette[stableColorKey(fracList[i].key, palette.length)]
+      if (!(entry in sums)) { sums[entry] = 0; orderKeys.push(entry) }
+      sums[entry] += fracList[i].share
+    }
+    var out = []
+    for (var g = 0; g < orderKeys.length; g++) out.push({ key: orderKeys[g], share: sums[orderKeys[g]], kind: "group" })
+    return out
+  }
   var n = limit || 5
   var result = { order: [], cpu: null, ram: null, watts: null, gpu: null }
 
@@ -488,13 +509,14 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
     var totalDelta = nextSnapshot.cpuTotal - prevSnapshot.cpuTotal
     var busyDelta = nextSnapshot.cpuBusy - prevSnapshot.cpuBusy
     if (totalDelta > 0) {
-      var segs = []
+      var commFracs = []
       var used = 0
       for (var i = 0; i < agg.shares.length; i++) {
         // share_i is of busy activity; rescale to all ticks
         var frac = agg.shares[i].share * busyDelta / totalDelta
-        if (frac > 0) { segs.push({ key: agg.shares[i].label, label: agg.shares[i].label, share: frac, kind: "comm" }); used += frac }
+        if (frac > 0) { commFracs.push({ key: agg.shares[i].label, share: frac }); used += frac }
       }
+      var segs = groupByHue(commFracs)
       // thresholds would drop sub-pixel segments and break the exact sum;
       // a 0.4% segment renders sub-pixel, which is invisibility enough
       var rest = Math.max(0, busyDelta / totalDelta - used)
@@ -523,13 +545,14 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
     for (var nm in seen) ramList.push({ label: nm, kb: seen[nm] })
     ramList.sort(function(a, b) { return b.kb - a.kb })
     ramList = ramList.slice(0, n)
-    var rsegs = []
+    var ramFracs = []
     var rused = 0
     for (var j = 0; j < ramList.length; j++) {
       var rf = ramList[j].kb / totalKb
-      if (rf > 0) { rsegs.push({ key: ramList[j].label, label: ramList[j].label, share: rf, kind: "comm" }); rused += rf }
+      if (rf > 0) { ramFracs.push({ key: ramList[j].label, share: rf }); rused += rf }
       if (result.order.indexOf(ramList[j].label) === -1) result.order.push(ramList[j].label)
     }
+    var rsegs = groupByHue(ramFracs)
     var rrest = Math.max(0, usedFrac - rused)
     rsegs.push({ key: "rest", label: "rest", share: rrest, kind: "rest" })
     rsegs.push({ key: "avail", label: "available", share: Math.max(0, 1 - usedFrac), kind: "avail" })
@@ -546,13 +569,15 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
     var wused = 0
     if (baseWatts > 0.5) {
       var bf = Math.min(1, baseWatts / drawWatts)
-      wsegs.push({ key: "base", label: "system base", share: bf, kind: "base" })
+      wsegs.push({ key: "base", label: "base load", share: bf, kind: "base" })
       wused += bf
     }
+    var wFracs = []
     for (var k = 0; k < agg.shares.length; k++) {
       var wf = variable * agg.shares[k].share / drawWatts
-      if (wf > 0) { wsegs.push({ key: agg.shares[k].label, label: agg.shares[k].label, share: wf, kind: "comm" }); wused += wf }
+      if (wf > 0) { wFracs.push({ key: agg.shares[k].label, share: wf }); wused += wf }
     }
+    wsegs = wsegs.concat(groupByHue(wFracs))
     var welse = Math.max(0, 1 - wused)
     wsegs.push({ key: "else", label: "everything else", share: welse, kind: "else" })
     result.watts = wsegs
@@ -571,12 +596,42 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
   return result
 }
 
-// Deterministic comm → palette-slot map so a comm keeps one color across the
-// CPU, RAM, and watts bars and its row meter. Palette cycles past its length;
-// beyond the palette the collision is accepted (row order disambiguates) and
-// documented — themes carry only so many distinguishable hues.
-function assignColorKeys(order, palette) {
+// Stable identity colors: FNV-1a over the comm name, reduced into the
+// palette. Deterministic across calls, sessions, and machines — no
+// randomness, no seed state, no order dependence — so a process keeps its
+// hue everywhere and forever: table label accents, composition-bar groups,
+// any surface. The multiply stays under 2^53 and the >>>0 fold makes the
+// uint32 overflow explicit, so every QML JS engine agrees bit-for-bit.
+function stableColorKey(comm, paletteSize) {
+  var h = 2166136261
+  var s = String(comm)
+  for (var i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = (h * 16777619) >>> 0
+  }
+  return h % (paletteSize || 3)
+}
+
+// comm → palette-entry map, hash-derived (the old order-based assignment is
+// retired: rank shuffles used to swap colors, which taught nothing). Same
+// signature as before, so call sites are unchanged.
+function assignColorKeys(comms, palette) {
   var map = {}
-  for (var i = 0; i < order.length; i++) map[order[i]] = palette[i % palette.length]
+  for (var i = 0; i < comms.length; i++) map[comms[i]] = palette[stableColorKey(comms[i], palette.length)]
   return map
+}
+
+// Ordinal badges for simultaneous same-hue rows: within the visible set,
+// the first member of a hue stays clean and later members get 2, 3, ... by
+// rank order. The hue is identity; the badge only breaks simultaneous ties,
+// so a lone member of a hue never carries a badge.
+function collisionOrdinals(comms, palette) {
+  var seen = {}
+  var out = {}
+  for (var i = 0; i < comms.length; i++) {
+    var k = stableColorKey(comms[i], palette.length)
+    seen[k] = (seen[k] || 0) + 1
+    out[comms[i]] = seen[k] > 1 ? seen[k] : 0
+  }
+  return out
 }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -89,6 +89,11 @@ function modeLabel(device, onBattery, states) {
   return "Charging"
 }
 
+// Kernel comm fields cap at 15 characters (TASK_COMM_LEN), so the panel's
+// comm column can be sized once for the realistic worst case and never per
+// sample.
+var COMM_MAX_CHARS = 15
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampIndex: clampIndex,
@@ -105,6 +110,7 @@ if (typeof module !== "undefined") {
     buildTopProcesses: buildTopProcesses,
     buildSystemRows: buildSystemRows,
     buildRowImpact: buildRowImpact,
+    COMM_MAX_CHARS: COMM_MAX_CHARS,
     buildResourceSplits: buildResourceSplits,
     aggregateCommShares: aggregateCommShares,
     assignColorKeys: assignColorKeys
@@ -112,6 +118,7 @@ if (typeof module !== "undefined") {
 }
 
 // ---- Power Hungry: top consumers ---------------------------------------------
+
 //
 // Panel-only companion to the stock battery panel: parse one sampler.sh
 // snapshot and attribute the measured battery draw across processes. The bar

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -261,26 +261,52 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
     if (otherShare > 0.02 && variable * otherShare > 0.5)
       out.push({ label: "everything else", value: wtxt(variable * otherShare), key: "else" })
   }
-  // per-row impact, aligned to the rows above: fill fraction (meter), the
-  // intensity ramp, the raw share, and the RSS fraction for the sub-bar
-  var impact = buildRowImpact(shares, drawWatts, baseWatts, variable, otherShare)
+  // One graphic line per process: each row carries metric cells (CPU, RAM,
+  // W discharging only) rendered as mini-meters in fixed columns. Cells are
+  // built here so QML only draws them. Normalization, per metric: CPU cell =
+  // the process's CPU share clamped to the cell width (shares can exceed 1
+  // across cores — the clamp is display-only, the number tells the truth);
+  // RAM cell = comm RSS / MemTotal; W cell = attributed watts / measured
+  // draw. Each cell's intensity ramps with its own magnitude, normalized to
+  // its metric's top row (0.35 floor, 1.0 at the column's max) so the
+  // strongest signal in every column reads at full strength.
+  function ramp(value, top) { return top > 0 ? 0.35 + 0.65 * Math.max(0, Math.min(1, value / top)) : 0.35 }
+  function cell(metric, display, normalized, top) {
+    return { metric: metric, value: display, normalized: Math.max(0, Math.min(1, normalized)), intensity: ramp(normalized, top) }
+  }
+
+  var topShare = shares.length > 0 ? shares[0].share : 0
+  var topRamKb = 0
+  for (var rk in ramByName) if (ramByName[rk] > topRamKb) topRamKb = ramByName[rk]
+  var memTotal = nextSnapshot.memTotalKb
+  // the W column's ramp normalizes against its largest cell, whichever row
+  // owns it (usually the top process, sometimes the base floor)
+  var topW = 0
+  if (drawWatts >= 0) {
+    if (baseWatts > 0.5) topW = Math.max(topW, baseWatts / drawWatts)
+    if (shares.length > 0) topW = Math.max(topW, variable * topShare / drawWatts)
+  }
+
   var procIdx = 0
   for (var r = 0; r < out.length; r++) {
     if (out[r].key === "base") {
-      out[r].meter = impact.base
-      out[r].intensity = impact.baseIntensity
+      out[r].cells = drawWatts >= 0
+        ? [cell("W", wtxt(baseWatts), baseWatts / drawWatts, topW)]
+        : []
       continue
     }
     if (out[r].key === "else") {
-      out[r].meter = impact.elseMeter
-      out[r].intensity = impact.elseIntensity
+      out[r].cells = drawWatts >= 0
+        ? [cell("W", wtxt(variable * otherShare), variable * otherShare / drawWatts, topW)]
+        : []
       continue
     }
-    out[r].meter = impact.top[procIdx]
-    out[r].intensity = impact.intensity[procIdx]
-    out[r].share = shares[procIdx].share
-    out[r].ramShare = ramByName[shares[procIdx].label] !== undefined && nextSnapshot.memTotalKb
-      ? Math.min(1, ramByName[shares[procIdx].label] / nextSnapshot.memTotalKb) : 0
+    var share = shares[procIdx].share
+    var ramKb = ramByName[shares[procIdx].label] !== undefined ? ramByName[shares[procIdx].label] : 0
+    var cells = [cell("CPU", pct(share), share, topShare)]
+    if (memTotal !== null && ramKb > 0) cells.push(cell("RAM", ramTxt(ramKb), ramKb / memTotal, topRamKb / memTotal))
+    if (drawWatts >= 0) cells.push(cell("W", wtxt(variable * share), variable * share / drawWatts, topW))
+    out[r].cells = cells
     out[r].key = out[r].label
     procIdx++
   }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -496,14 +496,19 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
   // panel's palette rationale). Passed in so callers own it; defaulted so
   // the pure builder is self-contained.
   palette = palette || ["blue", "cyan", "magenta"]
-  // The shade lattice assignment, resolved ONCE over the visible set (the
-  // table's rank order, extended with any RSS-only comms) and shared by the
-  // table accents and every bar — one function, one visible set, so
-  // cross-surface consistency stays structural. Bars lay comm segments out
-  // in LATTICE order: hue-major, shade-minor — fully rank-independent now
-  // that slots are unique below exhaustion, so segment order changes only
-  // with membership. Callers draw constant separators and scale fills
-  // against the fixed gap budget (SPLIT_MAX_SEGMENTS).
+  // The shade lattice assignment, resolved ONCE over the visible set — the
+  // TABLE's rank order (CPU busy-share) and nothing else — and shared by the
+  // table accents and every bar: one function, one visible set. Bars lay
+  // their process segments out IN THAT SAME TABLE RANK ORDER, left-to-right
+  // as the table reads top-to-bottom (the operator's correspondence
+  // decision): a rank swap moves exactly the swapped segments — discrete,
+  // meaningful motion, identity preserved by the stable lattice colors.
+  // Round 9's canonical hue-major order is superseded: it existed because
+  // round-8's rank-coupled GROUP order relocated whole hue blocks; with
+  // per-comm lattice-colored segments that disease no longer exists. The
+  // RAM bar previously ranked its own top-N by RSS — that divergence dies
+  // here: it shows the table's comms with their RSS widths, the rest
+  // segment absorbing any used memory the table set doesn't cover.
   var lattice = null
   function slotOf(comm) {
     if (lattice === null) lattice = resolveColorSlots(result.order, palette, SHADES)
@@ -511,16 +516,11 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
       ? lattice.assignment[comm]
       : { hue: palette[stableColorKey(comm, palette.length)], hueIdx: stableColorKey(comm, palette.length), shadeIdx: 2, shade: 1 }
   }
-  function latticeCommSegments(fracList) {
-    var withSlots = []
+  function rankCommSegments(fracList) {
+    var out = []
     for (var i = 0; i < fracList.length; i++)
-      withSlots.push({ key: fracList[i].key, share: fracList[i].share, kind: "comm", slot: slotOf(fracList[i].key) })
-    withSlots.sort(function(a, b) {
-      if (a.slot.hueIdx !== b.slot.hueIdx) return a.slot.hueIdx - b.slot.hueIdx
-      if (a.slot.shadeIdx !== b.slot.shadeIdx) return a.slot.shadeIdx - b.slot.shadeIdx
-      return a.key < b.key ? -1 : 1
-    })
-    return withSlots
+      out.push({ key: fracList[i].key, share: fracList[i].share, kind: "comm", slot: slotOf(fracList[i].key) })
+    return out
   }
   var n = limit || 5
   var result = { order: [], cpu: null, ram: null, watts: null, gpu: null }
@@ -546,7 +546,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
         var frac = agg.shares[i].share * busyDelta / totalDelta
         if (frac > 0) { commFracs.push({ key: agg.shares[i].label, share: frac }); used += frac }
       }
-      var segs = latticeCommSegments(commFracs)
+      var segs = rankCommSegments(commFracs)
       // thresholds would drop sub-pixel segments and break the exact sum;
       // a 0.4% segment renders sub-pixel, which is invisibility enough
       var rest = Math.max(0, busyDelta / totalDelta - used)
@@ -563,26 +563,28 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
   if (nextSnapshot.memTotalKb !== null && nextSnapshot.memAvailKb !== null && nextSnapshot.memTotalKb > 0) {
     var totalKb = nextSnapshot.memTotalKb
     var usedFrac = Math.max(0, Math.min(1, 1 - nextSnapshot.memAvailKb / totalKb))
-    var ramAll = []
-    var seen = {}
+    var ramAll = {}
     for (var pid in nextSnapshot.processes) {
       var p = nextSnapshot.processes[pid]
       if (!p.rssKb) continue
-      if (!(p.name in seen)) { seen[p.name] = 0; }
-      seen[p.name] += p.rssKb
+      if (!(p.name in ramAll)) ramAll[p.name] = 0
+      ramAll[p.name] += p.rssKb
     }
-    var ramList = []
-    for (var nm in seen) ramList.push({ label: nm, kb: seen[nm] })
-    ramList.sort(function(a, b) { return b.kb - a.kb })
-    ramList = ramList.slice(0, n)
+    // table-order RAM segments: the table's comms, in the table's rank,
+    // widths = each comm's RSS share of MemTotal
     var ramFracs = []
     var rused = 0
-    for (var j = 0; j < ramList.length; j++) {
-      var rf = ramList[j].kb / totalKb
-      if (rf > 0) { ramFracs.push({ key: ramList[j].label, share: rf }); rused += rf }
-      if (result.order.indexOf(ramList[j].label) === -1) result.order.push(ramList[j].label)
+    if (agg) {
+      for (var j = 0; j < agg.shares.length; j++) {
+        var nm2 = agg.shares[j].label
+        if (ramAll[nm2] !== undefined && ramAll[nm2] > 0) {
+          var rf = ramAll[nm2] / totalKb
+          ramFracs.push({ key: nm2, share: rf })
+          rused += rf
+        }
+      }
     }
-    var rsegs = latticeCommSegments(ramFracs)
+    var rsegs = rankCommSegments(ramFracs)
     var rrest = Math.max(0, usedFrac - rused)
     rsegs.push({ key: "rest", label: "rest", share: rrest, kind: "rest" })
     rsegs.push({ key: "avail", label: "available", share: Math.max(0, 1 - usedFrac), kind: "avail" })
@@ -607,7 +609,7 @@ function buildResourceSplits(prevSnapshot, nextSnapshot, limit, drawWatts, baseW
       var wf = variable * agg.shares[k].share / drawWatts
       if (wf > 0) { wFracs.push({ key: agg.shares[k].label, share: wf }); wused += wf }
     }
-    wsegs = wsegs.concat(latticeCommSegments(wFracs))
+    wsegs = wsegs.concat(rankCommSegments(wFracs))
     var welse = Math.max(0, 1 - wused)
     wsegs.push({ key: "else", label: "everything else", share: welse, kind: "else" })
     result.watts = wsegs

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -119,6 +119,7 @@ if (typeof module !== "undefined") {
     parseSnapshot: parseSnapshot,
     buildTopProcesses: buildTopProcesses,
     buildSystemRows: buildSystemRows,
+    buildSystemAnchorRow: buildSystemAnchorRow,
     buildRowImpact: buildRowImpact,
     wattsBasis: wattsBasis,
     COMM_MAX_CHARS: COMM_MAX_CHARS,
@@ -274,29 +275,35 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
     out.push({ label: shares[i].label, value: cols.join(" · ") })
   }
   var otherShare = drawWatts >= 0 ? Math.max(0, 1 - topShareSum) : 0
-  if (drawWatts >= 0) {
-    if (baseWatts > 0.5) out.unshift({ label: "system base", value: wtxt(baseWatts), key: "base" })
-    if (otherShare > 0.02 && variable * otherShare > 0.5)
-      out.push({ label: "everything else", value: wtxt(variable * otherShare), key: "else" })
-  }
   // One graphic line per process: each row carries metric cells (CPU, RAM,
   // W discharging only) rendered as mini-meters in fixed columns. Cells are
-  // built here so QML only draws them. Normalization, per metric: CPU cell =
-  // the process's CPU share clamped to the cell width (shares can exceed 1
-  // across cores — the clamp is display-only, the number tells the truth);
-  // RAM cell = comm RSS / MemTotal; W cell = attributed watts / measured
-  // draw. Each cell's intensity ramps with its own magnitude, normalized to
-  // its metric's top row (0.35 floor, 1.0 at the column's max) so the
-  // strongest signal in every column reads at full strength.
+  // built here so QML only draws them. Normalization, per metric — ONE CPU
+  // denominator everywhere: a process's CPU cell is its jiffies over ALL
+  // ticks including idle (machine capacity), the same denominator as the
+  // global CPU bar and the CPU composition bar, so process cells plus the
+  // everything-else row sum to the global CPU% by construction. Rows still
+  // rank by share of busy activity, which is the identical ordering — a
+  // snapshot's busy fraction is a common factor — merely re-scaled for
+  // display. RAM cell = comm RSS / MemTotal. W cell = attributed watts over
+  // measured draw. Each cell's intensity ramps with its own magnitude,
+  // normalized to its metric's top row (0.35 floor, 1.0 at the column max).
   function ramp(value, top) { return top > 0 ? 0.35 + 0.65 * Math.max(0, Math.min(1, value / top)) : 0.35 }
+  function cellAtIntensity(metric, display, normalized, intensity) {
+    return { metric: metric, value: display, normalized: Math.max(0, Math.min(1, normalized)), intensity: intensity }
+  }
   function cell(metric, display, normalized, top) {
-    return { metric: metric, value: display, normalized: Math.max(0, Math.min(1, normalized)), intensity: ramp(normalized, top) }
+    return cellAtIntensity(metric, display, normalized, ramp(normalized, top))
   }
 
   var topShare = shares.length > 0 ? shares[0].share : 0
   var topRamKb = 0
   for (var rk in ramByName) if (ramByName[rk] > topRamKb) topRamKb = ramByName[rk]
   var memTotal = nextSnapshot.memTotalKb
+  // busy/total fraction = the global CPU%: the scale that converts
+  // share-of-work into share-of-capacity
+  var totalAllDelta = prevSnapshot && nextSnapshot.cpuTotal !== null && prevSnapshot.cpuTotal !== null
+    ? Math.max(0, nextSnapshot.cpuTotal - prevSnapshot.cpuTotal) : 0
+  var busyFrac = totalAllDelta > 0 ? agg.totalDelta / totalAllDelta : 0
   // the W column's ramp normalizes against its largest cell, whichever row
   // owns it (usually the top process, sometimes the base floor)
   var topW = 0
@@ -306,29 +313,74 @@ function buildTopProcesses(prevSnapshot, nextSnapshot, limit, drawWatts, baseWat
   }
 
   var procIdx = 0
+  var cpuUsedByRows = 0
+  var ramUsedByRows = 0
   for (var r = 0; r < out.length; r++) {
-    if (out[r].key === "base") {
-      out[r].cells = drawWatts >= 0
-        ? [cell("W", wtxt(baseWatts), baseWatts / drawWatts, topW)]
-        : []
-      continue
-    }
-    if (out[r].key === "else") {
-      out[r].cells = drawWatts >= 0
-        ? [cell("W", wtxt(variable * otherShare), variable * otherShare / drawWatts, topW)]
-        : []
-      continue
-    }
     var share = shares[procIdx].share
+    var cpuFrac = Math.min(1, share * busyFrac)
     var ramKb = ramByName[shares[procIdx].label] !== undefined ? ramByName[shares[procIdx].label] : 0
-    var cells = [cell("CPU", pct(share), share, topShare)]
+    cpuUsedByRows += cpuFrac
+    ramUsedByRows += memTotal !== null ? ramKb / memTotal : 0
+    var cells = [cell("CPU", pct(cpuFrac), cpuFrac, Math.min(1, topShare * busyFrac))]
     if (memTotal !== null && ramKb > 0) cells.push(cell("RAM", ramTxt(ramKb), ramKb / memTotal, topRamKb / memTotal))
     if (drawWatts >= 0) cells.push(cell("W", wtxt(variable * share), variable * share / drawWatts, topW))
     out[r].cells = cells
     out[r].key = out[r].label
     procIdx++
   }
+
+  // The everything-else row is a whole-machine remainder row: the CPU left
+  // over after the listed processes (closing the sum to global CPU%), the
+  // used RAM beyond the listed processes' RSS (clamped at zero — shared
+  // pages double-counted per process can push it negative, the standing
+  // disclosure), and the watts tail. It exists when ANY metric has a
+  // meaningful remainder — its old existence gate was watts-only, which
+  // starved the CPU/RAM closure whenever the watts tail was display noise.
+  var usedFracAll = memTotal !== null && nextSnapshot.memAvailKb !== null
+    ? Math.max(0, Math.min(1, 1 - nextSnapshot.memAvailKb / memTotal)) : 0
+  var elseCpuRem = totalAllDelta > 0 ? Math.max(0, busyFrac - cpuUsedByRows) : 0
+  var elseRamRem = memTotal !== null ? Math.max(0, usedFracAll - ramUsedByRows) : 0
+  var wTail = drawWatts >= 0 ? variable * otherShare / drawWatts : 0
+  if (elseCpuRem > 0.005 || elseRamRem > 0.005 || (drawWatts >= 0 && otherShare > 0.02 && variable * otherShare > 0.5)) {
+    var eCells = []
+    if (totalAllDelta > 0) eCells.push(cellAtIntensity("CPU", pct(elseCpuRem), elseCpuRem, 0.8))
+    if (memTotal !== null) eCells.push(cellAtIntensity("RAM", ramTxt(Math.round(elseRamRem * memTotal)), elseRamRem, 0.8))
+    if (drawWatts >= 0) eCells.push(cellAtIntensity("W", wtxt(variable * otherShare), wTail, 0.8))
+    out.push({ label: "everything else", value: drawWatts >= 0 ? wtxt(variable * otherShare) : "", key: "else", cells: eCells })
+  }
+
+  if (drawWatts >= 0 && baseWatts > 0.5) {
+    out.unshift({ label: "base load", value: wtxt(baseWatts), key: "base",
+      cells: [cell("W", wtxt(baseWatts), baseWatts / drawWatts, topW)] })
+  }
   return out
+}
+
+// The anchor row: the machine itself, rendered first in the process table
+// with global values on the same grid and scale — CPU global%, RAM used%,
+// and total draw while the watts basis is active (its W cell fills the whole
+// column because the draw IS the whole the rows below decompose). The panel
+// renders it in theme foreground (never literal white) so it reads as the
+// neutral machine against metric-colored processes.
+function buildSystemAnchorRow(prevSnapshot, nextSnapshot, drawWatts) {
+  var cells = []
+  if (prevSnapshot && nextSnapshot.cpuTotal !== null && prevSnapshot.cpuTotal !== null
+    && nextSnapshot.cpuBusy !== null && prevSnapshot.cpuBusy !== null) {
+    var totalDelta = nextSnapshot.cpuTotal - prevSnapshot.cpuTotal
+    if (totalDelta > 0) {
+      var g = Math.min(1, Math.max(0, (nextSnapshot.cpuBusy - prevSnapshot.cpuBusy) / totalDelta))
+      cells.push({ metric: "CPU", value: Math.round(g * 100) + "%", normalized: g, intensity: 1 })
+    }
+  }
+  if (nextSnapshot.memTotalKb !== null && nextSnapshot.memAvailKb !== null && nextSnapshot.memTotalKb > 0) {
+    var used = Math.max(0, Math.min(1, 1 - nextSnapshot.memAvailKb / nextSnapshot.memTotalKb))
+    cells.push({ metric: "RAM", value: Math.round(used * 100) + "%", normalized: used, intensity: 1 })
+  }
+  if (drawWatts >= 0) {
+    cells.push({ metric: "W", value: (drawWatts < 10 ? drawWatts.toFixed(1) : Math.round(drawWatts)) + " W", normalized: 1, intensity: 1 })
+  }
+  if (cells.length === 0) return null
+  return { label: "system", key: "system", value: "", cells: cells }
 }
 
 // ---- Power Hungry: system vitals rows ----------------------------------------

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -15,6 +15,12 @@ Panel {
   manageIpc: false
   property var batteryInfo: ({})
   property var systemInfo: ({})
+  // Power Hungry: top-consumer attribution, panel-only by design. The bar
+  // pill is untouched — this answers a question you ask with the panel open.
+  property real systemWatts: -1
+  property real baseWatts: -1
+  property var prevSnapshot: null
+  property var topProcesses: []
   property var profiles: []
   property string activeProfile: ""
   property int profileIndex: 0
@@ -138,6 +144,7 @@ Panel {
     if (!batteryProc.running) batteryProc.running = true
     if (!profilesProc.running) profilesProc.running = true
     if (!systemProc.running) systemProc.running = true
+    if (!samplerProc.running) samplerProc.running = true
   }
 
   function updateKeyValue(raw, targetName) {
@@ -223,12 +230,50 @@ Panel {
     stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.updateKeyValue(text, "system") }
   }
 
+  // Power Hungry: battery flow + per-process jiffies, in one snapshot.
+  Process {
+    id: samplerProc
+    command: [Qt.resolvedUrl("sampler.sh").toString().replace("file://", "")]
+    stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.onSample(text) }
+  }
+
+  function onSample(raw) {
+    var snap = Model.parseSnapshot(raw)
+    if (!snap) return
+    if (snap.watts !== null) {
+      systemWatts = snap.watts
+      // Stock rate format ("0.6W", no space) so this row doesn't flicker
+      // against the batteryProc refresh at 1 Hz while the panel is open.
+      batteryInfo = Object.assign({}, batteryInfo, { rate: Math.round(snap.watts * 10) / 10 + "W" })
+    }
+    // A snapshot without a readable cputotal would diff nonsense percentages;
+    // drop it and wait for the next one instead of storing it as a baseline.
+    if (snap.cpuTotalJiffies === null) {
+      prevSnapshot = null
+      return
+    }
+    // Attribute watts only while discharging: on AC the battery flow is the
+    // charge rate, not the system draw.
+    var draw = root.discharging && snap.watts !== null ? snap.watts : -1
+    if (draw >= 0) {
+      // Rolling idle floor: track the minimum draw, drifting up slowly so a
+      // brightness change doesn't pin a stale base forever.
+      if (baseWatts < 0) baseWatts = draw
+      else if (draw < baseWatts) baseWatts = draw
+      else baseWatts += (draw - baseWatts) * 0.02
+    }
+    if (prevSnapshot) topProcesses = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
+    prevSnapshot = snap
+  }
+
   Process {
     id: actionProc
     onExited: root.refresh()
   }
 
-  Timer { interval: 5000; running: root.opened; repeat: true; onTriggered: root.refresh() }
+  // Power Hungry samples at panel cadence: 1 s while open, so the attribution
+  // tracks what the machine is doing right now rather than a 5 s average.
+  Timer { interval: 1000; running: root.opened; repeat: true; onTriggered: root.refresh() }
 
   // Rotate the status phrase while the panel is open and we're in a
   // rotating state (charging or on battery). The text swap is wrapped in a
@@ -448,6 +493,43 @@ Panel {
               label: root.chargeThresholdActive ? "Battery state" : (root.discharging ? "Discharging" : "Charging")
               value: root.chargeThresholdActive ? "Holding" : (root.batteryFull ? "-" : (root.batteryInfo.rate || ""))
             }
+          }
+        }
+
+        // ---------- Power Hungry: top consumers ----------
+        PanelSeparator {
+          foreground: root.bar.foreground
+        }
+
+        Column {
+          width: parent.width
+          spacing: Style.space(8)
+
+          PanelSectionHeader {
+            text: "POWER HUNGRY"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Repeater {
+            model: root.topProcesses
+
+            // InfoPair is the panel's stock label/value row: value column
+            // right-aligned, matching the stats section above.
+            InfoPair {
+              required property var modelData
+              label: modelData.label
+              value: modelData.value
+            }
+          }
+
+          Text {
+            visible: root.topProcesses.length === 0
+            text: "warming up…"
+            color: root.bar.foreground
+            opacity: 0.5
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.bodySmall
           }
         }
 

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -29,6 +29,11 @@ Panel {
   // The identity palette — three collision-free theme hues; see the
   // rationale at the colorMap assignment below.
   readonly property var paletteKeys: ["blue", "cyan", "magenta"]
+  // Composition-bar gap geometry: a constant separator width and a constant
+  // budget for the maximum segment count, so fills scale identically across
+  // refreshes and resources regardless of how many segments are visible.
+  readonly property real splitGap: Style.space(2)
+  readonly property real splitGapBudget: Model.SPLIT_MAX_SEGMENTS * root.splitGap
   property var profiles: []
   property string activeProfile: ""
   property int profileIndex: 0
@@ -660,13 +665,14 @@ Panel {
             Row {
               id: wattsSegmentRow
               anchors.fill: parent
+              spacing: root.splitGap
 
               Repeater {
                 model: root.resourceSplits !== null && root.resourceSplits.watts !== null ? root.resourceSplits.watts : []
 
                 Rectangle {
                   required property var modelData
-                  width: modelData.share * wattsSegmentRow.width
+                  width: modelData.share * Math.max(0, wattsSegmentRow.width - root.splitGapBudget)
                   height: parent.height
                   color: root.segmentColor(modelData)
                 }
@@ -871,22 +877,29 @@ Panel {
       color: metricRow.commColor
     }
 
-    Text {
-      id: rowBadge
-      visible: metricRow.badge >= 2
-      text: metricRow.badge >= 2 ? String(metricRow.badge) : ""
+    // Fixed badge micro-slot: reserved whether or not a badge shows, so a
+    // collision appearing or clearing mid-refresh cannot shift the line.
+    Item {
+      id: badgeSlot
       x: commMark.width + Style.space(2)
-      anchors.verticalCenter: parent.verticalCenter
-      color: metricRow.commColor
-      opacity: 0.9
-      font.family: root.bar.fontFamily
-      font.pixelSize: Style.font.caption
+      width: Style.space(7)
+      height: parent.height
+
+      Text {
+        visible: parent.parent.badge >= 2
+        text: parent.parent.badge >= 2 ? String(parent.parent.badge) : ""
+        anchors.centerIn: parent
+        color: parent.parent.commColor
+        opacity: 0.9
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.caption
+      }
     }
 
     Text {
       id: rowLabel
       text: metricRow.label
-      x: commMark.width + Style.space(5) + (metricRow.badge >= 2 ? rowBadge.implicitWidth + Style.space(2) : 0)
+      x: badgeSlot.x + badgeSlot.width + Style.space(2)
       width: commMetrics.advanceWidth
       anchors.verticalCenter: parent.verticalCenter
       color: root.bar ? root.bar.foreground : Color.foreground
@@ -1014,6 +1027,7 @@ Panel {
         width: splitTrack.width - x - splitValue.width - Style.space(10)
         height: parent.height - Style.space(4)
         y: Style.space(2)
+        spacing: root.splitGap
         opacity: splitBar.barIntensity
 
         Repeater {
@@ -1028,7 +1042,7 @@ Panel {
 
           Rectangle {
             required property var modelData
-            width: modelData.share * splitSegments.width
+            width: modelData.share * Math.max(0, splitSegments.width - root.splitGapBudget)
             height: splitSegments.height
             color: root.segmentColor(modelData)
 

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -294,9 +294,15 @@ Panel {
       prevSnapshot = null
       return
     }
-    // Attribute watts only while discharging: on AC the battery flow is the
-    // charge rate, not the system draw.
-    var draw = root.discharging && snap.watts !== null ? snap.watts : -1
+    // Attribute watts whenever the BATTERY DEVICE is discharging — its own
+    // claim, not the plug's (UPower.onBattery). In the marginal-adapter
+    // wedge (adapter latched online, delivering nothing) the battery is the
+    // power source, its sampled rate is real system draw, and attribution
+    // is valid; while charging/full/pending the adapter input is unreadable
+    // and per-process watts stay hidden. The basis lives in Model.wattsBasis
+    // so the rule is one pure, tested function.
+    var device = UPower.displayDevice
+    var draw = Model.wattsBasis(device ? device.state : -1, UPowerDeviceState.Discharging, snap.watts)
     if (draw >= 0) {
       // Rolling idle floor: track the minimum draw, drifting up slowly so a
       // brightness change doesn't pin a stale base forever.

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -517,7 +517,7 @@ Panel {
             id: barTrack
             anchors.fill: parent
             radius: height / 2
-            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
+            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.08)
           }
 
           Rectangle {
@@ -640,7 +640,7 @@ Panel {
             height: Style.space(6)
             radius: height / 2
             clip: true
-            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
+            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.08)
 
             Row {
               id: wattsSegmentRow

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -22,6 +22,7 @@ Panel {
   property var topProcesses: []
   property var systemRows: []
   property var resourceSplits: null
+  property var heat: ({})
   property var processColumns: []
   // Composition-bar gap geometry: a constant separator width and a constant
   // budget for the maximum segment count, so fills scale identically across
@@ -145,16 +146,16 @@ Panel {
     return modeLabel()
   }
 
-  // Ink, not hue: every surface speaks foreground-at-load. The system
-  // block/row is WHITE (the machine itself); a process's ink dims with its
-  // load — opacity 0.35..1.0 mapped from its share of the bar's busiest
-  // process. Identity is carried by ORDER (biggest to lightest, mirroring
-  // the table) and by label; brightness carries magnitude. This matches
-  // the shell's native monochrome language (operator decision, 2026-08-29).
+  // Ink, not hue: one heat per process — foreground at 0.35..1.0 mapped
+  // from its CPU share against the busiest process, and that value follows
+  // the process everywhere (row mark, every bar segment). The system
+  // block/row is WHITE (the machine itself); ink fades monotonically down
+  // the table's rank. Identity is positional and by label; brightness is
+  // the process's heat (operator decisions, 2026-08-29).
   function segmentInk(seg) {
     if (seg.kind === "system") return 1
     if (seg.ink !== undefined) return seg.ink
-    return 1
+    return 0.35
   }
 
   function segmentColor(seg) {
@@ -313,22 +314,31 @@ Panel {
     }
     processColumns = cols
     resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
-    // Ink follows load (operator decision, 2026-08-29): every comm segment
-    // carries its own opacity — 0.35..1.0 mapped from its share of that
-    // bar's busiest process. System leads at full ink (white: the machine
-    // itself); brightness IS magnitude, order IS identity. The muted frame
-    // (rest) stays muted. Computed here, once per refresh, so delegates
-    // bind a plain number.
+    // ONE HEAT PER PROCESS (operator decision, 2026-08-29): a process's ink
+    // is a single value — its share of the busiest process's CPU load,
+    // 0.35..1.0 — and that value follows it EVERYWHERE: the table row's
+    // mark, its segment in every composition bar. Like a heatmap of
+    // processes: the system leads in white (the machine itself), the top
+    // process glows brightest, and ink fades monotonically down the table's
+    // rank. Segment SIZE still encodes each bar's own metric share; INK
+    // encodes who the process is and how hot it runs. One writer: computed
+    // here, once per refresh, onto plain numbers.
+    var heatMap = {}
+    var maxHeat = 0
+    var cpuBar = resourceSplits.cpu
+    for (var hi = 0; hi < cpuBar.length; hi++)
+      if (cpuBar[hi].kind === "comm" && cpuBar[hi].share > maxHeat) maxHeat = cpuBar[hi].share
+    for (var hj = 0; hj < cpuBar.length; hj++)
+      if (cpuBar[hj].kind === "comm")
+        heatMap[cpuBar[hj].key] = 0.35 + 0.65 * (maxHeat > 0 ? cpuBar[hj].share / maxHeat : 0)
     var allBars = [resourceSplits.cpu, resourceSplits.ram, resourceSplits.watts, resourceSplits.gpu]
     for (var bi = 0; bi < allBars.length; bi++) {
       var bar = allBars[bi]
       if (!bar) continue
-      var maxComm = 0
-      for (var si2 = 0; si2 < bar.length; si2++)
-        if (bar[si2].kind === "comm" && bar[si2].share > maxComm) maxComm = bar[si2].share
       for (var si3 = 0; si3 < bar.length; si3++)
-        if (bar[si3].kind === "comm") bar[si3].ink = 0.35 + 0.65 * (maxComm > 0 ? bar[si3].share / maxComm : 0)
+        if (bar[si3].kind === "comm") bar[si3].ink = heatMap[bar[si3].key] !== undefined ? heatMap[bar[si3].key] : 0.35
     }
+    heat = heatMap
     // Vitals rows are rebuilt complete with their segments attached: a
     // property added to a plain JS object after the fact carries no change
     // signal, so a delegate that bound before the attach would stay null.
@@ -715,11 +725,11 @@ Panel {
               columns: root.processColumns
               anchor: modelData.key === "system"
               commColor: root.bar ? root.bar.foreground : Color.foreground
-              // The mark rides the same load ladder as its bar segment:
-              // the row's CPU-cell intensity IS share/busiest-share, so
-              // mark, cells, and bar all dim together.
-              commInk: modelData.key === "system" || modelData.cells === undefined
-                || modelData.cells.length === 0 ? 1 : modelData.cells[0].intensity
+              // The mark IS the process's heat — the same one-writer value
+              // its bar segments use (root.heat), so mark and bars can
+              // never disagree about a process.
+              commInk: modelData.key === "system" ? 1
+                : (root.heat[modelData.key] !== undefined ? root.heat[modelData.key] : 0.35)
             }
           }
 

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -22,7 +22,9 @@ Panel {
   property var topProcesses: []
   property var systemRows: []
   property var resourceSplits: null
-  property var heat: ({})
+  // The legend ink: ONE constant for every process surface — the same
+  // value the table mark and every bar block render at, never modulated.
+  readonly property real processInk: 0.85
   property var processColumns: []
   // Composition-bar gap geometry: a constant separator width and a constant
   // budget for the maximum segment count, so fills scale identically across
@@ -146,16 +148,15 @@ Panel {
     return modeLabel()
   }
 
-  // Ink, not hue: RANK-NORMALIZED heat — foreground at even steps from
-  // 1.0 (rank 1) down to 0.35 (last rank), and that value follows the
-  // process everywhere (row mark, every bar segment). The system block/row
-  // is WHITE (the machine itself). Magnitude lives in segment SIZE and the
-  // numeric cells; ink's only job is ORDER. Identity is positional and by
-  // label (operator decisions, 2026-08-29).
+  // Ink is the LEGEND: one constant ink for every process surface — the
+  // table mark and its bar blocks are the exact same color, always, with
+  // no modulation by resource usage. The system block/row is WHITE (the
+  // machine itself). Magnitude lives in segment SIZE and the numeric
+  // cells; identity lives in order and label (operator decision,
+  // 2026-08-29).
   function segmentInk(seg) {
     if (seg.kind === "system") return 1
-    if (seg.ink !== undefined) return seg.ink
-    return 0.35
+    return root.processInk
   }
 
   function segmentColor(seg) {
@@ -315,39 +316,11 @@ Panel {
     processColumns = cols
     resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
     // ONE HEAT PER PROCESS (operator decision, 2026-08-29): a process's ink
-    // is a single value — its share of the busiest process's CPU load,
-    // 0.35..1.0 — and that value follows it EVERYWHERE: the table row's
-    // mark, its segment in every composition bar. Like a heatmap of
-    // processes: the system leads in white (the machine itself), the top
-    // process glows brightest, and ink fades monotonically down the table's
-    // rank. Segment SIZE still encodes each bar's own metric share; INK
-    // encodes who the process is and how hot it runs. One writer: computed
-    // here, once per refresh, onto plain numbers.
-    // RANK-NORMALIZED (operator decision, 2026-08-29): ink steps EVENLY by
-    // rank — rank 1 is white, the last rank sits at the 0.35 floor — not by
-    // share ratio. How much hotter one process runs than another is already
-    // encoded by segment SIZE; ink's only job is order.
-    var heatMap = {}
-    var cpuBar = resourceSplits.cpu
-    // The cpu split is NULL until two samples exist (and stays null on AC
-    // restarts) — a null bar means "no heat yet", not an error.
-    if (cpuBar !== null && cpuBar !== undefined) {
-      var comms = []
-      for (var hi = 0; hi < cpuBar.length; hi++)
-        if (cpuBar[hi].kind === "comm") comms.push(cpuBar[hi])
-      for (var hj = 0; hj < comms.length; hj++) {
-        var step = comms.length > 1 ? 0.65 / (comms.length - 1) : 0
-        heatMap[comms[hj].key] = 1 - hj * step
-      }
-    }
-    var allBars = [resourceSplits.cpu, resourceSplits.ram, resourceSplits.watts, resourceSplits.gpu]
-    for (var bi = 0; bi < allBars.length; bi++) {
-      var bar = allBars[bi]
-      if (!bar) continue
-      for (var si3 = 0; si3 < bar.length; si3++)
-        if (bar[si3].kind === "comm") bar[si3].ink = heatMap[bar[si3].key] !== undefined ? heatMap[bar[si3].key] : 0.35
-    }
-    heat = heatMap
+    // LEGEND-CONSTANT ink (operator decision, 2026-08-29): the table mark
+    // and every bar segment for a process wear the SAME constant ink — no
+    // heat modulation by resource usage. What a process consumes is already
+    // encoded by segment SIZE and the numeric cells; order is shared by
+    // table and bars alike. The legend never changes under the reader.
     // Vitals rows are rebuilt complete with their segments attached: a
     // property added to a plain JS object after the fact carries no change
     // signal, so a delegate that bound before the attach would stay null.
@@ -734,11 +707,9 @@ Panel {
               columns: root.processColumns
               anchor: modelData.key === "system"
               commColor: root.bar ? root.bar.foreground : Color.foreground
-              // The mark IS the process's heat — the same one-writer value
-              // its bar segments use (root.heat), so mark and bars can
-              // never disagree about a process.
-              commInk: modelData.key === "system" ? 1
-                : (root.heat[modelData.key] !== undefined ? root.heat[modelData.key] : 0.35)
+              // The mark is the legend swatch: the exact ink its bar
+              // blocks render at, constant, never modulated.
+              commInk: modelData.key === "system" ? 1 : root.processInk
             }
           }
 

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -290,10 +290,14 @@ Panel {
     }
     if (prevSnapshot) topProcesses = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
     resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
-    // Palette keys map to Color singleton properties; the four non-threshold
-    // hues every theme defines. Same comm = same key = same color in the CPU,
-    // RAM, and watts bars and its row meter.
-    colorMap = Model.assignColorKeys(resourceSplits.order, ["blue", "cyan", "magenta", "accent"])
+    // Palette keys map to Color singleton properties: the three
+    // non-threshold hues that are universal AND mutually distinct across the
+    // themes (reviewer finding: accent hex-collides with blue or magenta on
+    // 21/22 themes; bright_* variants equal their base hue on roughly half,
+    // so no six-key collision-free set exists — retro-82 collapses hues by
+    // design and remains the one residual collision). Same comm = same key =
+    // same color in the CPU, RAM, and watts bars and its row meter.
+    colorMap = Model.assignColorKeys(resourceSplits.order, ["blue", "cyan", "magenta"])
     // Vitals rows are rebuilt complete with their segments attached: a
     // property added to a plain JS object after the fact carries no change
     // signal, so a delegate that bound before the attach would stay null.

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -328,6 +328,7 @@ Panel {
     // share ratio. How much hotter one process runs than another is already
     // encoded by segment SIZE; ink's only job is order.
     var heatMap = {}
+    var rankMap = {}
     var cpuBar = resourceSplits.cpu
     // The cpu split is NULL until two samples exist (and stays null on AC
     // restarts) — a null bar means "no heat yet", not an error.
@@ -338,6 +339,7 @@ Panel {
       for (var hj = 0; hj < comms.length; hj++) {
         var step = comms.length > 1 ? 0.65 / (comms.length - 1) : 0
         heatMap[comms[hj].key] = 1 - hj * step
+        rankMap[comms[hj].key] = hj + 1
       }
     }
     var allBars = [resourceSplits.cpu, resourceSplits.ram, resourceSplits.watts, resourceSplits.gpu]
@@ -345,7 +347,10 @@ Panel {
       var bar = allBars[bi]
       if (!bar) continue
       for (var si3 = 0; si3 < bar.length; si3++)
-        if (bar[si3].kind === "comm") bar[si3].ink = heatMap[bar[si3].key] !== undefined ? heatMap[bar[si3].key] : 0.35
+        if (bar[si3].kind === "comm") {
+          bar[si3].ink = heatMap[bar[si3].key] !== undefined ? heatMap[bar[si3].key] : 0.35
+          bar[si3].rank = rankMap[bar[si3].key] !== undefined ? rankMap[bar[si3].key] : 0
+        }
     }
     heat = heatMap
     // Vitals rows are rebuilt complete with their segments attached: a
@@ -1023,11 +1028,24 @@ Panel {
           }
 
           Rectangle {
+            id: splitSeg
             required property var modelData
             width: modelData.share * Math.max(0, splitSegments.width - root.splitGapBudget)
             height: splitSegments.height
             color: root.segmentColor(modelData)
             opacity: root.segmentInk(modelData)
+
+            // Rank numeral, rendered only where the segment is wide enough
+            // to hold it without crowding — the table is the legend, and
+            // this is its index echoed at the point of use.
+            Text {
+              visible: splitSeg.width >= Style.space(7) && modelData.rank !== undefined && modelData.rank > 0
+              text: modelData.rank !== undefined ? String(modelData.rank) : ""
+              anchors.centerIn: parent
+              color: root.bar ? root.bar.background : Color.background
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.caption
+            }
           }
         }
       }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -22,6 +22,8 @@ Panel {
   property var prevSnapshot: null
   property var topProcesses: []
   property var systemRows: []
+  property var resourceSplits: null
+  property var colorMap: ({})
   property var profiles: []
   property string activeProfile: ""
   property int profileIndex: 0
@@ -137,6 +139,20 @@ Panel {
     if (fullyCharged) return "Fully charged"
     if (rotatingPhrases) return activePhrases[phraseIndex % activePhrases.length]
     return modeLabel()
+  }
+
+  // Segment/row colors, one resolver for every surface: comms take their
+  // assigned palette hue, the attribution floor takes accent, tails take
+  // muted, unknown keys fall back to the bar foreground.
+  function segmentColor(seg) {
+    if (seg.kind === "base") return Color.accent
+    if (seg.kind === "rest" || seg.kind === "else") return Color.muted
+    var k = seg.kind === "comm" ? colorMap[seg.key] : ""
+    if (k === "blue") return Color.blue
+    if (k === "cyan") return Color.cyan
+    if (k === "magenta") return Color.magenta
+    if (k === "accent") return Color.accent
+    return root.bar ? root.bar.foreground : Color.foreground
   }
 
   function refresh() {
@@ -264,7 +280,23 @@ Panel {
       else baseWatts += (draw - baseWatts) * 0.02
     }
     if (prevSnapshot) topProcesses = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
-    systemRows = Model.buildSystemRows(prevSnapshot, snap, draw)
+    resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
+    // Palette keys map to Color singleton properties; the four non-threshold
+    // hues every theme defines. Same comm = same key = same color in the CPU,
+    // RAM, and watts bars and its row meter.
+    colorMap = Model.assignColorKeys(resourceSplits.order, ["blue", "cyan", "magenta", "accent"])
+    // Vitals rows are rebuilt complete with their segments attached: a
+    // property added to a plain JS object after the fact carries no change
+    // signal, so a delegate that bound before the attach would stay null.
+    var rows = Model.buildSystemRows(prevSnapshot, snap, draw)
+    for (var si = 0; si < rows.length; si++) {
+      var segsFor = null
+      if (rows[si].label === "CPU") segsFor = resourceSplits.cpu
+      else if (rows[si].label === "RAM") segsFor = resourceSplits.ram
+      else if (rows[si].label === "GPU") segsFor = resourceSplits.gpu
+      rows[si] = { label: rows[si].label, value: rows[si].value, meter: rows[si].meter, segments: segsFor }
+    }
+    systemRows = rows
     prevSnapshot = snap
   }
 
@@ -530,6 +562,7 @@ Panel {
               label: modelData.label
               value: modelData.value
               meter: modelData.meter
+              segments: modelData.segments !== undefined ? modelData.segments : null
               fillColor: modelData.label === "Draw"
                 ? (modelData.meter < 0.5 ? Color.green : modelData.meter < 1 ? Color.yellow : Color.urgent)
                 : (root.bar ? root.bar.foreground : Color.foreground)
@@ -552,15 +585,49 @@ Panel {
             fontFamily: root.bar.fontFamily
           }
 
+          // The attribution model as one bar: system base (accent), the top
+          // processes in their assigned comm colors, and the tail (muted).
+          // Discharging only — on AC the battery flow is charge rate, not
+          // system draw, so there is no honest bar to draw.
+          Rectangle {
+            visible: root.resourceSplits !== null && root.resourceSplits.watts !== null
+            width: column.width
+            height: Style.space(6)
+            radius: height / 2
+            clip: true
+            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
+
+            Row {
+              id: wattsSegmentRow
+              anchors.fill: parent
+
+              Repeater {
+                model: root.resourceSplits !== null && root.resourceSplits.watts !== null ? root.resourceSplits.watts : []
+
+                Rectangle {
+                  required property var modelData
+                  width: modelData.share * wattsSegmentRow.width
+                  height: parent.height
+                  color: root.segmentColor(modelData)
+                }
+              }
+            }
+          }
+
           Repeater {
             model: root.topProcesses
 
-            // InfoPair is the panel's stock label/value row: value column
-            // right-aligned, matching the stats section above.
-            InfoPair {
+            // Same row shape as SYSTEM, with the row's impact meter in its
+            // comm color (attribution floor accent, tail muted) — the row is
+            // its own legend entry for the split bars above.
+            VitalRow {
               required property var modelData
               label: modelData.label
               value: modelData.value
+              meter: modelData.meter !== undefined ? modelData.meter : -1
+              fillColor: modelData.key === "base" || modelData.key === "else"
+                ? root.segmentColor({ kind: modelData.key, key: modelData.key })
+                : root.segmentColor({ kind: "comm", key: modelData.key })
             }
           }
 
@@ -664,6 +731,7 @@ Panel {
     property string label: ""
     property string value: ""
     property real meter: -1
+    property var segments: null
     property color fillColor: root.bar ? root.bar.foreground : Color.foreground
 
     width: column.width
@@ -685,7 +753,7 @@ Panel {
 
     Rectangle {
       id: meterTrack
-      visible: meter >= 0
+      visible: segments !== null || meter >= 0
       anchors.left: rowLabel.right
       anchors.leftMargin: Style.space(8)
       anchors.right: rowValue.left
@@ -693,9 +761,11 @@ Panel {
       anchors.verticalCenter: parent.verticalCenter
       height: Style.space(4)
       radius: height / 2
+      clip: true
       color: Qt.rgba(fillColor.r, fillColor.g, fillColor.b, 0.12)
 
       Rectangle {
+        visible: segments === null && meter >= 0
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
         height: parent.height
@@ -705,6 +775,30 @@ Panel {
 
         Behavior on width { NumberAnimation { duration: 260; easing.type: Easing.OutCubic } }
         Behavior on color { ColorAnimation { duration: 220 } }
+      }
+
+      Row {
+        id: segmentRow
+        visible: segments !== null
+        anchors.fill: meterTrack
+
+        Repeater {
+          model: {
+            var segs = segments
+            if (!segs) return []
+            var drawn = []
+            for (var i = 0; i < segs.length; i++)
+              if (segs[i].kind !== "idle" && segs[i].kind !== "avail") drawn.push(segs[i])
+            return drawn
+          }
+
+          Rectangle {
+            required property var modelData
+            width: modelData.share * segmentRow.width
+            height: meterTrack.height
+            color: root.segmentColor(modelData)
+          }
+        }
       }
     }
   }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -141,6 +141,15 @@ Panel {
     return modeLabel()
   }
 
+  // Legible text on an arbitrary theme fill: pick whichever of the theme's
+  // own foreground/background contrasts more with the fill's luminance —
+  // no hardcoded RGB, adapts to light and dark themes alike.
+  function textOn(c) {
+    function lum(x) { return 0.299 * x.r + 0.587 * x.g + 0.114 * x.b }
+    var lc = lum(c), lf = lum(Color.foreground), lb = lum(Color.background)
+    return Math.abs(lc - lf) >= Math.abs(lc - lb) ? Color.foreground : Color.background
+  }
+
   // Segment/row colors, one resolver for every surface: comms take their
   // assigned palette hue, the attribution floor takes accent, tails take
   // muted, unknown keys fall back to the bar foreground.
@@ -291,10 +300,12 @@ Panel {
     var rows = Model.buildSystemRows(prevSnapshot, snap, draw)
     for (var si = 0; si < rows.length; si++) {
       var segsFor = null
-      if (rows[si].label === "CPU") segsFor = resourceSplits.cpu
-      else if (rows[si].label === "RAM") segsFor = resourceSplits.ram
-      else if (rows[si].label === "GPU") segsFor = resourceSplits.gpu
-      rows[si] = { label: rows[si].label, value: rows[si].value, meter: rows[si].meter, segments: segsFor }
+      var intensityFor = 0.45
+      if (rows[si].label === "CPU") { segsFor = resourceSplits.cpu; intensityFor = resourceSplits.intensity.cpu }
+      else if (rows[si].label === "RAM") { segsFor = resourceSplits.ram; intensityFor = resourceSplits.intensity.ram }
+      else if (rows[si].label === "GPU") { segsFor = resourceSplits.gpu; intensityFor = resourceSplits.intensity.gpu }
+      else if (rows[si].label === "Draw") intensityFor = 1
+      rows[si] = { label: rows[si].label, value: rows[si].value, meter: rows[si].meter, segments: segsFor, barIntensity: intensityFor }
     }
     systemRows = rows
     prevSnapshot = snap
@@ -557,12 +568,13 @@ Panel {
           Repeater {
             model: root.systemRows
 
-            VitalRow {
+            SplitBar {
               required property var modelData
               label: modelData.label
               value: modelData.value
-              meter: modelData.meter
               segments: modelData.segments !== undefined ? modelData.segments : null
+              meter: modelData.meter
+              barIntensity: modelData.barIntensity !== undefined ? modelData.barIntensity : 0.45
               fillColor: modelData.label === "Draw"
                 ? (modelData.meter < 0.5 ? Color.green : modelData.meter < 1 ? Color.yellow : Color.urgent)
                 : (root.bar ? root.bar.foreground : Color.foreground)
@@ -617,14 +629,16 @@ Panel {
           Repeater {
             model: root.topProcesses
 
-            // Same row shape as SYSTEM, with the row's impact meter in its
-            // comm color (attribution floor accent, tail muted) — the row is
-            // its own legend entry for the split bars above.
-            VitalRow {
+            // The bar IS the row: comm-colored fill sized by impact, ramped
+            // by intensity, value text at the fill's end, and a thin RSS
+            // sub-bar beneath in the same comm color.
+            BarRow {
               required property var modelData
               label: modelData.label
               value: modelData.value
-              meter: modelData.meter !== undefined ? modelData.meter : -1
+              share: modelData.meter !== undefined ? modelData.meter : 0
+              intensity: modelData.intensity !== undefined ? modelData.intensity : 1
+              ramShare: modelData.ramShare !== undefined ? modelData.ramShare : 0
               fillColor: modelData.key === "base" || modelData.key === "else"
                 ? root.segmentColor({ kind: modelData.key, key: modelData.key })
                 : root.segmentColor({ kind: "comm", key: modelData.key })
@@ -724,67 +738,139 @@ Panel {
     font.pixelSize: Style.font.bodySmall
   }
 
-  // A vitals row: stock InfoLabel left, stock InfoValue right, and between
-  // them the battery progress bar's track-and-fill idiom scaled down to a
-  // slim meter. meter < 0 hides the bar (dash rows, unknowns).
-  component VitalRow: Item {
+  // A POWER HUNGRY row where the bar IS the row: a rounded track spans the
+  // width, the comm label sits in the left gutter, the comm-colored fill
+  // grows from the gutter sized by the row's impact and faded by its
+  // intensity ramp, the value text anchors just past the fill's end (always
+  // on the unfilled track, where the panel's own text color is legible in
+  // every theme), and a thin RSS sub-bar runs beneath in the same color.
+  component BarRow: Item {
+    id: barRow
+    property string label: ""
+    property string value: ""
+    property real share: 0
+    property real intensity: 1
+    property real ramShare: 0
+    property color fillColor: root.bar ? root.bar.foreground : Color.foreground
+
+    width: column.width
+    implicitHeight: Style.space(16) + (ramShare > 0 ? Style.space(5) : 0)
+
+    Rectangle {
+      id: barTrack
+      width: parent.width
+      height: Style.space(16)
+      radius: height / 3
+      clip: true
+      color: Qt.rgba(barRow.fillColor.r, barRow.fillColor.g, barRow.fillColor.b, 0.08)
+
+      Text {
+        id: barLabel
+        text: barRow.label
+        x: Style.space(6)
+        anchors.verticalCenter: parent.verticalCenter
+        color: root.bar ? root.bar.foreground : Color.foreground
+        opacity: 0.65
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      Rectangle {
+        id: barFill
+        x: barLabel.implicitWidth + Style.space(12)
+        width: Math.max(0, Math.min(share, 1) * (barTrack.width - x - valueText.width - Style.space(8)))
+        y: Style.space(2)
+        height: parent.height - Style.space(4)
+        radius: height / 3
+        color: barRow.fillColor
+        opacity: intensity
+      }
+
+      Text {
+        id: valueText
+        text: barRow.value
+        anchors.left: barFill.right
+        anchors.leftMargin: Style.space(6)
+        anchors.verticalCenter: parent.verticalCenter
+        color: root.bar ? root.bar.foreground : Color.foreground
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+    }
+
+    Rectangle {
+      id: ramBar
+      visible: ramShare > 0
+      x: barLabel.implicitWidth + Style.space(12)
+      width: Math.min(ramShare, 1) * (parent.width - x - Style.space(8))
+      y: barTrack.height + Style.space(1)
+      height: Style.space(3)
+      radius: height / 2
+      color: barRow.fillColor
+      opacity: 0.7
+    }
+  }
+
+  // A SYSTEM bar: one rounded track per resource with the label in the left
+  // gutter and the value at the right edge. With segments the fill is the
+  // composition (comm colors, idle/available left as track), ramped by the
+  // resource's utilization; without segments it is a single intensity-graded
+  // fill (the categorical Draw row colors itself). Wide segments carry their
+  // comm's name in whichever theme color contrasts with the fill.
+  component SplitBar: Item {
+    id: splitBar
     property string label: ""
     property string value: ""
     property real meter: -1
+    property real barIntensity: 0.45
     property var segments: null
     property color fillColor: root.bar ? root.bar.foreground : Color.foreground
 
     width: column.width
-    implicitHeight: Math.max(rowLabel.implicitHeight, Style.space(6))
-
-    InfoLabel {
-      id: rowLabel
-      text: parent.label
-      anchors.left: parent.left
-      anchors.verticalCenter: parent.verticalCenter
-    }
-
-    InfoValue {
-      id: rowValue
-      text: parent.value
-      anchors.right: parent.right
-      anchors.verticalCenter: parent.verticalCenter
-    }
+    implicitHeight: Style.space(16)
 
     Rectangle {
-      id: meterTrack
-      visible: segments !== null || meter >= 0
-      anchors.left: rowLabel.right
-      anchors.leftMargin: Style.space(8)
-      anchors.right: rowValue.left
-      anchors.rightMargin: Style.space(8)
-      anchors.verticalCenter: parent.verticalCenter
-      height: Style.space(4)
-      radius: height / 2
+      id: splitTrack
+      width: parent.width
+      height: Style.space(16)
+      radius: height / 3
       clip: true
-      color: Qt.rgba(fillColor.r, fillColor.g, fillColor.b, 0.12)
+      color: Qt.rgba(splitBar.fillColor.r, splitBar.fillColor.g, splitBar.fillColor.b, 0.08)
+
+      Text {
+        id: splitLabel
+        text: splitBar.label
+        x: Style.space(6)
+        anchors.verticalCenter: parent.verticalCenter
+        color: root.bar ? root.bar.foreground : Color.foreground
+        opacity: 0.65
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
 
       Rectangle {
-        visible: segments === null && meter >= 0
-        anchors.left: parent.left
-        anchors.verticalCenter: parent.verticalCenter
-        height: parent.height
-        radius: parent.radius
-        width: Math.max(0, Math.min(1, meter)) * parent.width
-        color: fillColor
-
-        Behavior on width { NumberAnimation { duration: 260; easing.type: Easing.OutCubic } }
-        Behavior on color { ColorAnimation { duration: 220 } }
+        visible: splitBar.segments === null && splitBar.meter >= 0
+        x: splitLabel.implicitWidth + Style.space(12)
+        width: Math.max(0, Math.min(1, splitBar.meter)) * (splitTrack.width - x - splitValue.width - Style.space(10))
+        y: Style.space(2)
+        height: parent.height - Style.space(4)
+        radius: height / 3
+        color: splitBar.fillColor
+        opacity: splitBar.barIntensity
       }
 
       Row {
-        id: segmentRow
-        visible: segments !== null
-        anchors.fill: meterTrack
+        id: splitSegments
+        visible: splitBar.segments !== null
+        x: splitLabel.implicitWidth + Style.space(12)
+        width: splitTrack.width - x - splitValue.width - Style.space(10)
+        height: parent.height - Style.space(4)
+        y: Style.space(2)
+        opacity: splitBar.barIntensity
 
         Repeater {
           model: {
-            var segs = segments
+            var segs = splitBar.segments
             if (!segs) return []
             var drawn = []
             for (var i = 0; i < segs.length; i++)
@@ -794,11 +880,32 @@ Panel {
 
           Rectangle {
             required property var modelData
-            width: modelData.share * segmentRow.width
-            height: meterTrack.height
+            width: modelData.share * splitSegments.width
+            height: splitSegments.height
             color: root.segmentColor(modelData)
+
+            Text {
+              visible: parent.width > Style.space(56)
+              text: parent.modelData.label
+              x: Style.space(5)
+              anchors.verticalCenter: parent.verticalCenter
+              color: root.textOn(parent.color)
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.bodySmall
+            }
           }
         }
+      }
+
+      Text {
+        id: splitValue
+        text: splitBar.value
+        anchors.right: parent.right
+        anchors.rightMargin: Style.space(6)
+        anchors.verticalCenter: parent.verticalCenter
+        color: root.bar ? root.bar.foreground : Color.foreground
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.bodySmall
       }
     }
   }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -181,7 +181,8 @@ Panel {
   function segmentColor(seg) {
     if (seg.kind === "base") return Color.accent
     if (seg.kind === "rest" || seg.kind === "else") return Color.muted
-    var k = seg.kind === "group" ? seg.key : (seg.kind === "comm" ? colorMap[seg.key] : "")
+    var k = seg.kind === "comm" && seg.slot !== undefined ? seg.slot.hue
+      : (seg.kind === "comm" && colorMap[seg.key] !== undefined ? colorMap[seg.key].hue : "")
     if (k === "blue") return Color.blue
     if (k === "cyan") return Color.cyan
     if (k === "magenta") return Color.magenta
@@ -343,10 +344,15 @@ Panel {
     // collision-free set exists — retro-82's residual defect is its own
     // blue == magenta, a theme-level reduction). Same comm = same key =
     // same color in the CPU, RAM, and watts bars and its row meter.
-    colorMap = Model.assignColorKeys(resourceSplits.order, root.paletteKeys)
-    // Ordinal badges for simultaneous same-hue rows: the hue is identity,
-    // the badge only breaks ties among what is visible right now.
-    rowOrdinals = Model.collisionOrdinals(resourceSplits.order, root.paletteKeys)
+    // The shade-lattice assignment (one function, one visible set): accents,
+    // cell fills, and every bar segment read from it. Badges are the
+    // exhaustion path only — a comm with no free slot among nine — which
+    // the table's top-N practically never reaches.
+    var lattice = resourceSplits.lattice
+    colorMap = lattice.assignment
+    rowOrdinals = {}
+    for (var ui = 0; ui < lattice.unassigned.length; ui++)
+      rowOrdinals[lattice.unassigned[ui]] = ui + 2
     // Vitals rows are rebuilt complete with their segments attached: a
     // property added to a plain JS object after the fact carries no change
     // signal, so a delegate that bound before the attach would stay null.
@@ -675,6 +681,7 @@ Panel {
                   width: modelData.share * Math.max(0, wattsSegmentRow.width - root.splitGapBudget)
                   height: parent.height
                   color: root.segmentColor(modelData)
+                  opacity: modelData.slot !== undefined ? modelData.slot.shade : 1
                 }
               }
             }
@@ -734,11 +741,15 @@ Panel {
               columns: root.processColumns
               anchor: modelData.key === "system"
               badge: root.rowOrdinals[modelData.key] !== undefined ? root.rowOrdinals[modelData.key] : 0
+              shade: root.colorMap[modelData.key] !== undefined && root.colorMap[modelData.key].shade !== undefined
+                ? root.colorMap[modelData.key].shade : 1
               commColor: modelData.key === "system"
                 ? (root.bar ? root.bar.foreground : Color.foreground)
                 : (modelData.key === "base" || modelData.key === "else"
                   ? root.segmentColor({ kind: modelData.key, key: modelData.key })
-                  : root.segmentColor({ kind: "comm", key: modelData.key }))
+                  : (root.colorMap[modelData.key] !== undefined
+                    ? Color[root.colorMap[modelData.key].hue]
+                    : root.segmentColor({ kind: "comm", key: modelData.key })))
             }
           }
 
@@ -855,6 +866,7 @@ Panel {
     property var columns: []
     property bool anchor: false
     property int badge: 0
+    property real shade: 1
     property color commColor: root.bar ? root.bar.foreground : Color.foreground
 
     width: column.width
@@ -875,6 +887,7 @@ Panel {
       x: 0
       anchors.verticalCenter: parent.verticalCenter
       color: metricRow.commColor
+      opacity: metricRow.shade
     }
 
     // Fixed badge micro-slot: reserved whether or not a badge shows, so a
@@ -964,7 +977,7 @@ Panel {
               color: metricRow.anchor
                 ? (root.bar ? root.bar.foreground : Color.foreground)
                 : root.metricColor(cellSlot.modelData)
-              opacity: cellSlot.cellData !== null ? cellSlot.cellData.intensity : 0
+              opacity: cellSlot.cellData !== null ? cellSlot.cellData.intensity * metricRow.shade : 0
             }
           }
         }
@@ -1045,6 +1058,7 @@ Panel {
             width: modelData.share * Math.max(0, splitSegments.width - root.splitGapBudget)
             height: splitSegments.height
             color: root.segmentColor(modelData)
+            opacity: modelData.slot !== undefined ? modelData.slot.shade : 1
 
           }
         }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -292,10 +292,11 @@ Panel {
     resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
     // Palette keys map to Color singleton properties: the three
     // non-threshold hues that are universal AND mutually distinct across the
-    // themes (reviewer finding: accent hex-collides with blue or magenta on
-    // 21/22 themes; bright_* variants equal their base hue on roughly half,
-    // so no six-key collision-free set exists — retro-82 collapses hues by
-    // design and remains the one residual collision). Same comm = same key =
+    // themes (reviewer finding, hex re-derived: accent equals blue on 17
+    // themes and magenta on lumon only, so it cannot serve as a fourth hue;
+    // bright_* variants equal their base hue on roughly half, so no six-key
+    // collision-free set exists — retro-82's residual defect is its own
+    // blue == magenta, a theme-level reduction). Same comm = same key =
     // same color in the CPU, RAM, and watts bars and its row meter.
     colorMap = Model.assignColorKeys(resourceSplits.order, ["blue", "cyan", "magenta"])
     // Vitals rows are rebuilt complete with their segments attached: a

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -326,11 +326,15 @@ Panel {
     var heatMap = {}
     var maxHeat = 0
     var cpuBar = resourceSplits.cpu
-    for (var hi = 0; hi < cpuBar.length; hi++)
-      if (cpuBar[hi].kind === "comm" && cpuBar[hi].share > maxHeat) maxHeat = cpuBar[hi].share
-    for (var hj = 0; hj < cpuBar.length; hj++)
-      if (cpuBar[hj].kind === "comm")
-        heatMap[cpuBar[hj].key] = 0.35 + 0.65 * (maxHeat > 0 ? cpuBar[hj].share / maxHeat : 0)
+    // The cpu split is NULL until two samples exist (and stays null on AC
+    // restarts) — a null bar means "no heat yet", not an error.
+    if (cpuBar !== null && cpuBar !== undefined) {
+      for (var hi = 0; hi < cpuBar.length; hi++)
+        if (cpuBar[hi].kind === "comm" && cpuBar[hi].share > maxHeat) maxHeat = cpuBar[hi].share
+      for (var hj = 0; hj < cpuBar.length; hj++)
+        if (cpuBar[hj].kind === "comm")
+          heatMap[cpuBar[hj].key] = 0.35 + 0.65 * (maxHeat > 0 ? cpuBar[hj].share / maxHeat : 0)
+    }
     var allBars = [resourceSplits.cpu, resourceSplits.ram, resourceSplits.watts, resourceSplits.gpu]
     for (var bi = 0; bi < allBars.length; bi++) {
       var bar = allBars[bi]

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -22,11 +22,8 @@ Panel {
   property var topProcesses: []
   property var systemRows: []
   property var resourceSplits: null
-  property var colorMap: ({})
+  property var heat: ({})
   property var processColumns: []
-  // The identity palette — three collision-free theme hues; see the
-  // rationale at the colorMap assignment below.
-  readonly property var paletteKeys: ["blue", "cyan", "magenta"]
   // Composition-bar gap geometry: a constant separator width and a constant
   // budget for the maximum segment count, so fills scale identically across
   // refreshes and resources regardless of how many segments are visible.
@@ -149,36 +146,20 @@ Panel {
     return modeLabel()
   }
 
-  // Metric-type colors for the per-process cells: the three collision-free
-  // hues, one per metric (CPU blue, RAM cyan, W magenta), so a column reads
-  // as one metric at a glance. W stays magenta rather than categorical
-  // green/yellow/red: per-process watts carry no honest absolute thresholds
-  // (the old system-level Draw meter that used them was removed in operator
-  // review — the stock pill already shows total draw). GPU is reserved
-  // to accent for the future fdinfo cell (never emitted on this hardware;
-  // accent may sit near blue on some themes — a documented follow-up
-  // question for whoever adds GPU cells).
-  function metricColor(metric) {
-    if (metric === "CPU") return Color.blue
-    if (metric === "RAM") return Color.cyan
-    if (metric === "W") return Color.magenta
-    return Color.accent
+  // Ink, not hue: RANK-NORMALIZED heat — foreground at even steps from
+  // 1.0 (rank 1) down to 0.35 (last rank), and that value follows the
+  // process everywhere (row mark, every bar segment). The system block/row
+  // is WHITE (the machine itself). Magnitude lives in segment SIZE and the
+  // numeric cells; ink's only job is ORDER. Identity is positional and by
+  // label (operator decisions, 2026-08-29).
+  function segmentInk(seg) {
+    if (seg.kind === "system") return 1
+    if (seg.ink !== undefined) return seg.ink
+    return 0.35
   }
 
-  // Segment/row colors, one resolver for every surface: comms take their
-  // name-hashed palette hue — the table row's mark is the single color
-  // authority, and bars render the same hue at the same full strength —
-  // the system block takes foreground (the neutral machine), the GPU bar's
-  // rest takes muted, unknown keys fall back to the bar foreground.
   function segmentColor(seg) {
     if (seg.kind === "rest") return Color.muted
-    if (seg.kind === "system") return root.bar ? root.bar.foreground : Color.foreground
-    var k = seg.kind === "comm" && seg.slot !== undefined ? seg.slot.hue
-      : (seg.kind === "comm" && colorMap[seg.key] !== undefined ? colorMap[seg.key] : "")
-    if (k === "blue") return Color.blue
-    if (k === "cyan") return Color.cyan
-    if (k === "magenta") return Color.magenta
-    if (k === "accent") return Color.accent
     return root.bar ? root.bar.foreground : Color.foreground
   }
 
@@ -289,11 +270,11 @@ Panel {
   function onSample(raw) {
     var snap = Model.parseSnapshot(raw)
     if (!snap) return
-    // The sampler's watts feed the ATTRIBUTION — the displayed rate comes
-    // only from batteryProc (the stock smoothed source), written in exactly
-    // one place. A second writer here (tried in v1) made the row flip sign
-    // and value at 1 Hz: two reads of the same telemetry with different
-    // conventions. Never two writers on one field.
+    // NOTE: the sampler's watts feed the ATTRIBUTION here — the displayed
+    // rate comes only from batteryProc (the stock smoothed source), written
+    // in exactly one place. A second writer here (tried in v1) made the row
+    // flip sign and value at 1 Hz — two reads of the same telemetry with
+    // different conventions. Never two writers on one field.
     // A snapshot without a readable cputotal would diff nonsense percentages;
     // drop it and wait for the next one instead of storing it as a baseline.
     if (snap.cpuTotalJiffies === null) {
@@ -332,25 +313,41 @@ Panel {
       }
     }
     processColumns = cols
-    resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts, root.paletteKeys)
-    // Palette keys map to Color singleton properties: the three
-    // non-threshold hues that are universal AND mutually distinct across the
-    // themes (reviewer finding, hex re-derived: accent equals blue on 17
-    // themes and magenta on lumon only, so it cannot serve as a fourth hue;
-    // bright_* variants equal their base hue on roughly half, so no six-key
-    // collision-free set exists — retro-82's residual defect is its own
-    // blue == magenta, a theme-level reduction). Identity is name→hue and
-    // nothing else: same comm = same key = same color on its table row's
-    // mark and in every bar segment, at full strength, per the operator
-    // review's table-is-the-color-authority rule. Hue collisions between
-    // comms are accepted (three hues, five rows) — labels disambiguate the
-    // table, gaps disambiguate the bars.
-    var cmap = {}
-    for (var ci2 = 0; ci2 < resourceSplits.order.length; ci2++) {
-      var comm = resourceSplits.order[ci2]
-      cmap[comm] = root.paletteKeys[Model.stableColorKey(comm, root.paletteKeys.length)]
+    resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
+    // ONE HEAT PER PROCESS (operator decision, 2026-08-29): a process's ink
+    // is a single value — its share of the busiest process's CPU load,
+    // 0.35..1.0 — and that value follows it EVERYWHERE: the table row's
+    // mark, its segment in every composition bar. Like a heatmap of
+    // processes: the system leads in white (the machine itself), the top
+    // process glows brightest, and ink fades monotonically down the table's
+    // rank. Segment SIZE still encodes each bar's own metric share; INK
+    // encodes who the process is and how hot it runs. One writer: computed
+    // here, once per refresh, onto plain numbers.
+    // RANK-NORMALIZED (operator decision, 2026-08-29): ink steps EVENLY by
+    // rank — rank 1 is white, the last rank sits at the 0.35 floor — not by
+    // share ratio. How much hotter one process runs than another is already
+    // encoded by segment SIZE; ink's only job is order.
+    var heatMap = {}
+    var cpuBar = resourceSplits.cpu
+    // The cpu split is NULL until two samples exist (and stays null on AC
+    // restarts) — a null bar means "no heat yet", not an error.
+    if (cpuBar !== null && cpuBar !== undefined) {
+      var comms = []
+      for (var hi = 0; hi < cpuBar.length; hi++)
+        if (cpuBar[hi].kind === "comm") comms.push(cpuBar[hi])
+      for (var hj = 0; hj < comms.length; hj++) {
+        var step = comms.length > 1 ? 0.65 / (comms.length - 1) : 0
+        heatMap[comms[hj].key] = 1 - hj * step
+      }
     }
-    colorMap = cmap
+    var allBars = [resourceSplits.cpu, resourceSplits.ram, resourceSplits.watts, resourceSplits.gpu]
+    for (var bi = 0; bi < allBars.length; bi++) {
+      var bar = allBars[bi]
+      if (!bar) continue
+      for (var si3 = 0; si3 < bar.length; si3++)
+        if (bar[si3].kind === "comm") bar[si3].ink = heatMap[bar[si3].key] !== undefined ? heatMap[bar[si3].key] : 0.35
+    }
+    heat = heatMap
     // Vitals rows are rebuilt complete with their segments attached: a
     // property added to a plain JS object after the fact carries no change
     // signal, so a delegate that bound before the attach would stay null.
@@ -539,7 +536,7 @@ Panel {
             id: barTrack
             anchors.fill: parent
             radius: height / 2
-            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
+            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.08)
           }
 
           Rectangle {
@@ -662,7 +659,7 @@ Panel {
             height: Style.space(6)
             radius: height / 2
             clip: true
-            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
+            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.08)
 
             Row {
               id: wattsSegmentRow
@@ -677,6 +674,7 @@ Panel {
                   width: modelData.share * Math.max(0, wattsSegmentRow.width - root.splitGapBudget)
                   height: parent.height
                   color: root.segmentColor(modelData)
+                  opacity: root.segmentInk(modelData)
                 }
               }
             }
@@ -716,7 +714,7 @@ Panel {
                   text: parent.modelData
                   anchors.right: parent.right
                   anchors.rightMargin: Style.space(4)
-                  color: root.metricColor(parent.modelData)
+                  color: root.bar ? root.bar.foreground : Color.foreground
                   opacity: 0.8
                   font.family: root.bar.fontFamily
                   font.pixelSize: Style.font.caption
@@ -735,11 +733,12 @@ Panel {
               cells: modelData.cells !== undefined ? modelData.cells : []
               columns: root.processColumns
               anchor: modelData.key === "system"
-              commColor: modelData.key === "system"
-                ? (root.bar ? root.bar.foreground : Color.foreground)
-                : (root.colorMap[modelData.key] !== undefined
-                  ? Color[root.colorMap[modelData.key]]
-                  : root.segmentColor({ kind: "comm", key: modelData.key }))
+              commColor: root.bar ? root.bar.foreground : Color.foreground
+              // The mark IS the process's heat — the same one-writer value
+              // its bar segments use (root.heat), so mark and bars can
+              // never disagree about a process.
+              commInk: modelData.key === "system" ? 1
+                : (root.heat[modelData.key] !== undefined ? root.heat[modelData.key] : 0.35)
             }
           }
 
@@ -838,8 +837,9 @@ Panel {
 
   // One graphic line per process on a FIXED grid, recalculated only on
   // basis change (column set) or panel width — never per sample. Comm
-  // column: the identity mark in its own slot (the row's color — the single
-  // color authority the bars mirror) plus a left-aligned label elided at
+  // column: the identity mark in its own slot — foreground ink, since
+  // identity is carried by the label and by row order (system leads;
+  // processes descend by load) — plus a left-aligned label elided at
   // the kernel's 15-char comm cap (Model.COMM_MAX_CHARS, sized once via
   // TextMetrics). Metric cells: the remaining track split equally across
   // the section's column set, so every row lands in the same pixel columns
@@ -856,6 +856,7 @@ Panel {
     property var columns: []
     property bool anchor: false
     property color commColor: root.bar ? root.bar.foreground : Color.foreground
+    property real commInk: 1
 
     width: column.width
     implicitHeight: Style.space(16)
@@ -875,6 +876,7 @@ Panel {
       x: 0
       anchors.verticalCenter: parent.verticalCenter
       color: metricRow.commColor
+      opacity: metricRow.commInk
     }
 
     Text {
@@ -944,9 +946,7 @@ Panel {
                 : 0
               height: parent.height - Style.space(4)
               radius: height / 3
-              color: metricRow.anchor
-                ? (root.bar ? root.bar.foreground : Color.foreground)
-                : root.metricColor(cellSlot.modelData)
+              color: root.bar ? root.bar.foreground : Color.foreground
               opacity: cellSlot.cellData !== null ? cellSlot.cellData.intensity : 0
             }
           }
@@ -1027,6 +1027,7 @@ Panel {
             width: modelData.share * Math.max(0, splitSegments.width - root.splitGapBudget)
             height: splitSegments.height
             color: root.segmentColor(modelData)
+            opacity: root.segmentInk(modelData)
           }
         }
       }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -21,6 +21,7 @@ Panel {
   property real baseWatts: -1
   property var prevSnapshot: null
   property var topProcesses: []
+  property var systemRows: []
   property var profiles: []
   property string activeProfile: ""
   property int profileIndex: 0
@@ -263,6 +264,7 @@ Panel {
       else baseWatts += (draw - baseWatts) * 0.02
     }
     if (prevSnapshot) topProcesses = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
+    systemRows = Model.buildSystemRows(prevSnapshot, snap, draw)
     prevSnapshot = snap
   }
 
@@ -496,6 +498,45 @@ Panel {
           }
         }
 
+        // ---------- System vitals ----------
+        // General system state, kin to the battery stats above; the
+        // attribution section below answers "who is eating it". Rows come
+        // from the same sampler snapshots as everything else, so vitals and
+        // attribution can never disagree, and the Draw row appears only
+        // while discharging (on AC the battery flow is charge rate, not
+        // system draw). Meters reuse the battery bar's own idiom — a
+        // rounded track at foreground alpha with a foreground fill — no new
+        // widget. The Draw meter grades green under 20 W, yellow under 40,
+        // red beyond, at 50%/100% of the bar.
+        PanelSeparator {
+          foreground: root.bar.foreground
+        }
+
+        Column {
+          width: parent.width
+          spacing: Style.space(8)
+
+          PanelSectionHeader {
+            text: "SYSTEM"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Repeater {
+            model: root.systemRows
+
+            VitalRow {
+              required property var modelData
+              label: modelData.label
+              value: modelData.value
+              meter: modelData.meter
+              fillColor: modelData.label === "Draw"
+                ? (modelData.meter < 0.5 ? Color.green : modelData.meter < 1 ? Color.yellow : Color.urgent)
+                : (root.bar ? root.bar.foreground : Color.foreground)
+            }
+          }
+        }
+
         // ---------- Power Hungry: top consumers ----------
         PanelSeparator {
           foreground: root.bar.foreground
@@ -614,5 +655,57 @@ Panel {
     color: root.bar.foreground
     font.family: root.bar.fontFamily
     font.pixelSize: Style.font.bodySmall
+  }
+
+  // A vitals row: stock InfoLabel left, stock InfoValue right, and between
+  // them the battery progress bar's track-and-fill idiom scaled down to a
+  // slim meter. meter < 0 hides the bar (dash rows, unknowns).
+  component VitalRow: Item {
+    property string label: ""
+    property string value: ""
+    property real meter: -1
+    property color fillColor: root.bar ? root.bar.foreground : Color.foreground
+
+    width: column.width
+    implicitHeight: Math.max(rowLabel.implicitHeight, Style.space(6))
+
+    InfoLabel {
+      id: rowLabel
+      text: parent.label
+      anchors.left: parent.left
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    InfoValue {
+      id: rowValue
+      text: parent.value
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Rectangle {
+      id: meterTrack
+      visible: meter >= 0
+      anchors.left: rowLabel.right
+      anchors.leftMargin: Style.space(8)
+      anchors.right: rowValue.left
+      anchors.rightMargin: Style.space(8)
+      anchors.verticalCenter: parent.verticalCenter
+      height: Style.space(4)
+      radius: height / 2
+      color: Qt.rgba(fillColor.r, fillColor.g, fillColor.b, 0.12)
+
+      Rectangle {
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        height: parent.height
+        radius: parent.radius
+        width: Math.max(0, Math.min(1, meter)) * parent.width
+        color: fillColor
+
+        Behavior on width { NumberAnimation { duration: 260; easing.type: Easing.OutCubic } }
+        Behavior on color { ColorAnimation { duration: 220 } }
+      }
+    }
   }
 }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -981,7 +981,10 @@ Panel {
         height: parent.height - Style.space(4)
         y: Style.space(2)
         spacing: root.splitGap
-        opacity: splitBar.barIntensity
+        // NO container opacity here: the legacy barIntensity multiplied
+        // every segment by the resource's TOTAL utilization, so the same
+        // process rendered a different gray in the CPU, RAM and watts
+        // bars. The legend ink is constant; size carries the magnitude.
 
         Repeater {
           model: {

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -648,7 +648,7 @@ Panel {
             fontFamily: root.bar.fontFamily
           }
 
-          // The attribution model as one bar: system base (accent), the top
+          // The attribution model as one bar: base load (accent), the top
           // processes in their assigned comm colors, and the tail (muted).
           // Discharging only — on AC the battery flow is charge rate, not
           // system draw, so there is no honest bar to draw.
@@ -981,8 +981,7 @@ Panel {
   // gutter and the value at the right edge. With segments the fill is the
   // composition (comm colors, idle/available left as track), ramped by the
   // resource's utilization; without segments it is a single intensity-graded
-  // fill (the categorical Draw row colors itself). Wide segments carry their
-  // comm's name in whichever theme color contrasts with the fill.
+  // fill (the categorical Draw row colors itself).
   component SplitBar: Item {
     id: splitBar
     property string label: ""

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -660,22 +660,37 @@ Panel {
           // Column headers, learned once: CPU / RAM / W (discharging only).
           // The column set is derived in onSample from the rows' own cells,
           // so the header can never drift from what renders beneath it.
+          // Header on the same fixed grid as the rows: each label right-aligned
+          // inside its column slot, matching where the values render below.
           Row {
             id: processHeader
             visible: root.processColumns.length > 0
             width: column.width
+
+            TextMetrics {
+              id: headerCommMetrics
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.caption
+              text: "WWWWWWWWWWWWWWW"
+            }
+
+            Item {
+              width: headerCommMetrics.advanceWidth + Style.space(16)
+              height: Style.space(12)
+            }
 
             Repeater {
               model: root.processColumns
 
               Item {
                 required property var modelData
-                width: processHeader.width / root.processColumns.length
+                width: (processHeader.width - headerCommMetrics.advanceWidth - Style.space(16)) / Math.max(1, root.processColumns.length)
                 height: Style.space(12)
 
                 Text {
                   text: parent.modelData
-                  x: Style.space(6)
+                  anchors.right: parent.right
+                  anchors.rightMargin: Style.space(4)
                   color: root.metricColor(parent.modelData)
                   opacity: 0.8
                   font.family: root.bar.fontFamily
@@ -693,6 +708,7 @@ Panel {
               required property var modelData
               label: modelData.label
               cells: modelData.cells !== undefined ? modelData.cells : []
+              columns: root.processColumns
               commColor: modelData.key === "base" || modelData.key === "else"
                 ? root.segmentColor({ kind: modelData.key, key: modelData.key })
                 : root.segmentColor({ kind: "comm", key: modelData.key })
@@ -792,22 +808,35 @@ Panel {
     font.pixelSize: Style.font.bodySmall
   }
 
-  // One graphic line per process: the comm label (with a small comm-colored
-  // accent mark preserving some identity cross-referencing to the SYSTEM
-  // composition bars) sits in the left gutter, and ONE track carries the
-  // metric cells — CPU, RAM, W (discharging only) — each a mini-meter in
-  // its own fixed column: metric-type color, fill normalized per metric,
-  // intensity ramped by the cell's magnitude within its column, value text
-  // at the fill's end on the unfilled track (the established legibility
-  // rule). The old two-line row (impact fill + RAM sub-bar) is gone.
+  // One graphic line per process on a FIXED grid, recalculated only on
+  // basis change (column set) or panel width — never per sample. Comm
+  // column: the accent mark in its own slot plus a left-aligned label
+  // elided at the kernel's 15-char comm cap (Model.COMM_MAX_CHARS, sized
+  // once via TextMetrics). Metric cells: the remaining track split equally
+  // across the section's column set, so every row — including the base and
+  // tail rows' single W cell — lands in the same pixel columns as the
+  // header. Value text is right-aligned INSIDE its fixed cell: the same
+  // pixel column every refresh regardless of fill length, and fills are
+  // capped short of the text so type never sits on a fill. No width
+  // Behaviors anywhere — fills step at the 1 Hz cadence, geometry never
+  // moves. Fixed decimals (pct one place, watts one place, RAM auto-unit
+  // in the slot) keep digit-count changes absorbed by the right alignment.
   component MetricRow: Item {
     id: metricRow
     property string label: ""
     property var cells: []
+    property var columns: []
     property color commColor: root.bar ? root.bar.foreground : Color.foreground
 
     width: column.width
     implicitHeight: Style.space(16)
+
+    TextMetrics {
+      id: commMetrics
+      font.family: root.bar.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      text: "WWWWWWWWWWWWWWW"
+    }
 
     Rectangle {
       id: commMark
@@ -823,18 +852,18 @@ Panel {
       id: rowLabel
       text: metricRow.label
       x: commMark.width + Style.space(5)
+      width: commMetrics.advanceWidth
       anchors.verticalCenter: parent.verticalCenter
       color: root.bar ? root.bar.foreground : Color.foreground
       opacity: 0.75
       font.family: root.bar.fontFamily
       font.pixelSize: Style.font.bodySmall
       elide: Text.ElideRight
-      width: Math.min(implicitWidth + Style.space(6), parent.width * 0.32)
     }
 
     Rectangle {
       id: cellTrack
-      x: rowLabel.x + rowLabel.width + Style.space(6)
+      x: rowLabel.x + rowLabel.width + Style.space(8)
       width: parent.width - x
       height: parent.height
       radius: height / 3
@@ -843,37 +872,49 @@ Panel {
                      (root.bar ? root.bar.foreground : Color.foreground).b, 0.08)
 
       Row {
-        id: cellRow
+        id: cellGrid
         anchors.fill: parent
 
         Repeater {
-          model: metricRow.cells
+          model: metricRow.columns
 
           Item {
+            id: cellSlot
             required property var modelData
-            width: cellRow.width / Math.max(1, metricRow.cells.length)
-            height: cellRow.height
+            width: metricRow.columns.length > 0 ? cellGrid.width / metricRow.columns.length : cellGrid.width
+            height: cellGrid.height
 
-            Rectangle {
-              id: cellFill
-              x: Style.space(2)
-              y: Style.space(2)
-              width: Math.max(0, Math.min(1, parent.modelData.normalized)) * (parent.width - Style.space(4))
-              height: parent.height - Style.space(4)
-              radius: height / 3
-              color: root.metricColor(parent.modelData.metric)
-              opacity: parent.modelData.intensity
+            // the cell for this column, when the row carries one
+            readonly property var cellData: {
+              for (var i = 0; i < metricRow.cells.length; i++)
+                if (metricRow.cells[i].metric === cellSlot.modelData) return metricRow.cells[i]
+              return null
             }
 
             Text {
-              text: parent.modelData.value
-              anchors.left: parent.left
-              anchors.leftMargin: cellFill.width + Style.space(6)
+              id: cellValue
+              visible: cellSlot.cellData !== null
+              text: cellSlot.cellData !== null ? cellSlot.cellData.value : ""
+              anchors.right: parent.right
+              anchors.rightMargin: Style.space(4)
               anchors.verticalCenter: parent.verticalCenter
               color: root.bar ? root.bar.foreground : Color.foreground
               opacity: 0.75
               font.family: root.bar.fontFamily
               font.pixelSize: Style.font.bodySmall
+            }
+
+            Rectangle {
+              visible: cellSlot.cellData !== null
+              x: Style.space(2)
+              y: Style.space(2)
+              width: cellSlot.cellData !== null
+                ? Math.max(0, Math.min(1, cellSlot.cellData.normalized)) * Math.max(0, parent.width - cellValue.implicitWidth - Style.space(10))
+                : 0
+              height: parent.height - Style.space(4)
+              radius: height / 3
+              color: root.metricColor(cellSlot.modelData)
+              opacity: cellSlot.cellData !== null ? cellSlot.cellData.intensity : 0
             }
           }
         }
@@ -954,15 +995,6 @@ Panel {
             height: splitSegments.height
             color: root.segmentColor(modelData)
 
-            Text {
-              visible: parent.width > Style.space(56)
-              text: parent.modelData.label
-              x: Style.space(5)
-              anchors.verticalCenter: parent.verticalCenter
-              color: root.textOn(parent.color)
-              font.family: root.bar.fontFamily
-              font.pixelSize: Style.font.bodySmall
-            }
           }
         }
       }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -166,15 +166,6 @@ Panel {
     return Color.accent
   }
 
-  // Legible text on an arbitrary theme fill: pick whichever of the theme's
-  // own foreground/background contrasts more with the fill's luminance —
-  // no hardcoded RGB, adapts to light and dark themes alike.
-  function textOn(c) {
-    function lum(x) { return 0.299 * x.r + 0.587 * x.g + 0.114 * x.b }
-    var lc = lum(c), lf = lum(Color.foreground), lb = lum(Color.background)
-    return Math.abs(lc - lf) >= Math.abs(lc - lb) ? Color.foreground : Color.background
-  }
-
   // Segment/row colors, one resolver for every surface: comms take their
   // assigned palette hue, the attribution floor takes accent, tails take
   // muted, unknown keys fall back to the bar foreground.

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -310,7 +310,11 @@ Panel {
       else if (draw < baseWatts) baseWatts = draw
       else baseWatts += (draw - baseWatts) * 0.02
     }
-    if (prevSnapshot) topProcesses = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
+    if (prevSnapshot) {
+      var procRows = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
+      var anchorRow = Model.buildSystemAnchorRow(prevSnapshot, snap, draw)
+      topProcesses = anchorRow !== null ? [anchorRow].concat(procRows) : procRows
+    }
     // column set = the first row's cell metrics, in the builder's fixed
     // order (CPU, RAM, W discharging only, GPU when a source exists)
     var cols = []
@@ -715,9 +719,12 @@ Panel {
               label: modelData.label
               cells: modelData.cells !== undefined ? modelData.cells : []
               columns: root.processColumns
-              commColor: modelData.key === "base" || modelData.key === "else"
-                ? root.segmentColor({ kind: modelData.key, key: modelData.key })
-                : root.segmentColor({ kind: "comm", key: modelData.key })
+              anchor: modelData.key === "system"
+              commColor: modelData.key === "system"
+                ? (root.bar ? root.bar.foreground : Color.foreground)
+                : (modelData.key === "base" || modelData.key === "else"
+                  ? root.segmentColor({ kind: modelData.key, key: modelData.key })
+                  : root.segmentColor({ kind: "comm", key: modelData.key }))
             }
           }
 
@@ -832,6 +839,7 @@ Panel {
     property string label: ""
     property var cells: []
     property var columns: []
+    property bool anchor: false
     property color commColor: root.bar ? root.bar.foreground : Color.foreground
 
     width: column.width
@@ -919,7 +927,9 @@ Panel {
                 : 0
               height: parent.height - Style.space(4)
               radius: height / 3
-              color: root.metricColor(cellSlot.modelData)
+              color: metricRow.anchor
+                ? (root.bar ? root.bar.foreground : Color.foreground)
+                : root.metricColor(cellSlot.modelData)
               opacity: cellSlot.cellData !== null ? cellSlot.cellData.intensity : 0
             }
           }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -146,12 +146,12 @@ Panel {
     return modeLabel()
   }
 
-  // Ink, not hue: one heat per process — foreground at 0.35..1.0 mapped
-  // from its CPU share against the busiest process, and that value follows
-  // the process everywhere (row mark, every bar segment). The system
-  // block/row is WHITE (the machine itself); ink fades monotonically down
-  // the table's rank. Identity is positional and by label; brightness is
-  // the process's heat (operator decisions, 2026-08-29).
+  // Ink, not hue: RANK-NORMALIZED heat — foreground at even steps from
+  // 1.0 (rank 1) down to 0.35 (last rank), and that value follows the
+  // process everywhere (row mark, every bar segment). The system block/row
+  // is WHITE (the machine itself). Magnitude lives in segment SIZE and the
+  // numeric cells; ink's only job is ORDER. Identity is positional and by
+  // label (operator decisions, 2026-08-29).
   function segmentInk(seg) {
     if (seg.kind === "system") return 1
     if (seg.ink !== undefined) return seg.ink
@@ -323,17 +323,22 @@ Panel {
     // rank. Segment SIZE still encodes each bar's own metric share; INK
     // encodes who the process is and how hot it runs. One writer: computed
     // here, once per refresh, onto plain numbers.
+    // RANK-NORMALIZED (operator decision, 2026-08-29): ink steps EVENLY by
+    // rank — rank 1 is white, the last rank sits at the 0.35 floor — not by
+    // share ratio. How much hotter one process runs than another is already
+    // encoded by segment SIZE; ink's only job is order.
     var heatMap = {}
-    var maxHeat = 0
     var cpuBar = resourceSplits.cpu
     // The cpu split is NULL until two samples exist (and stays null on AC
     // restarts) — a null bar means "no heat yet", not an error.
     if (cpuBar !== null && cpuBar !== undefined) {
+      var comms = []
       for (var hi = 0; hi < cpuBar.length; hi++)
-        if (cpuBar[hi].kind === "comm" && cpuBar[hi].share > maxHeat) maxHeat = cpuBar[hi].share
-      for (var hj = 0; hj < cpuBar.length; hj++)
-        if (cpuBar[hj].kind === "comm")
-          heatMap[cpuBar[hj].key] = 0.35 + 0.65 * (maxHeat > 0 ? cpuBar[hj].share / maxHeat : 0)
+        if (cpuBar[hi].kind === "comm") comms.push(cpuBar[hi])
+      for (var hj = 0; hj < comms.length; hj++) {
+        var step = comms.length > 1 ? 0.65 / (comms.length - 1) : 0
+        heatMap[comms[hj].key] = 1 - hj * step
+      }
     }
     var allBars = [resourceSplits.cpu, resourceSplits.ram, resourceSplits.watts, resourceSplits.gpu]
     for (var bi = 0; bi < allBars.length; bi++) {

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -24,7 +24,6 @@ Panel {
   property var systemRows: []
   property var resourceSplits: null
   property var colorMap: ({})
-  property var rowOrdinals: ({})
   property var processColumns: []
   // The identity palette — three collision-free theme hues; see the
   // rationale at the colorMap assignment below.
@@ -153,9 +152,10 @@ Panel {
 
   // Metric-type colors for the per-process cells: the three collision-free
   // hues, one per metric (CPU blue, RAM cyan, W magenta), so a column reads
-  // as one metric at a glance. W stays magenta here rather than categorical
-  // green/yellow/red: those thresholds grade SYSTEM draw (the Draw bar);
-  // per-process watts carry no honest absolute thresholds. GPU is reserved
+  // as one metric at a glance. W stays magenta rather than categorical
+  // green/yellow/red: per-process watts carry no honest absolute thresholds
+  // (the old system-level Draw meter that used them was removed in operator
+  // review — the stock pill already shows total draw). GPU is reserved
   // to accent for the future fdinfo cell (never emitted on this hardware;
   // accent may sit near blue on some themes — a documented follow-up
   // question for whoever adds GPU cells).
@@ -167,14 +167,15 @@ Panel {
   }
 
   // Segment/row colors, one resolver for every surface: comms take their
-  // assigned palette hue, the attribution floor takes accent, tails take
-  // muted, unknown keys fall back to the bar foreground.
+  // name-hashed palette hue — the table row's mark is the single color
+  // authority, and bars render the same hue at the same full strength —
+  // the system block takes foreground (the neutral machine), the GPU bar's
+  // rest takes muted, unknown keys fall back to the bar foreground.
   function segmentColor(seg) {
-    if (seg.kind === "base") return Color.accent
-    if (seg.kind === "rest" || seg.kind === "else") return Color.muted
+    if (seg.kind === "rest") return Color.muted
     if (seg.kind === "system") return root.bar ? root.bar.foreground : Color.foreground
     var k = seg.kind === "comm" && seg.slot !== undefined ? seg.slot.hue
-      : (seg.kind === "comm" && colorMap[seg.key] !== undefined ? colorMap[seg.key].hue : "")
+      : (seg.kind === "comm" && colorMap[seg.key] !== undefined ? colorMap[seg.key] : "")
     if (k === "blue") return Color.blue
     if (k === "cyan") return Color.cyan
     if (k === "magenta") return Color.magenta
@@ -313,9 +314,10 @@ Panel {
       else baseWatts += (draw - baseWatts) * 0.02
     }
     if (prevSnapshot) {
-      var procRows = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
-      var anchorRow = Model.buildSystemAnchorRow(prevSnapshot, snap, draw)
-      topProcesses = anchorRow !== null ? [anchorRow].concat(procRows) : procRows
+      // The system row (everything unattributed: idle floor + tail) comes
+      // first from the builder itself — folded there in operator review so
+      // table, bars, and model exports share ONE system concept.
+      topProcesses = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
     }
     // column set = the first row's cell metrics, in the builder's fixed
     // order (CPU, RAM, W discharging only, GPU when a source exists)
@@ -334,28 +336,28 @@ Panel {
     // themes and magenta on lumon only, so it cannot serve as a fourth hue;
     // bright_* variants equal their base hue on roughly half, so no six-key
     // collision-free set exists — retro-82's residual defect is its own
-    // blue == magenta, a theme-level reduction). Same comm = same key =
-    // same color in the CPU, RAM, and watts bars and its row meter.
-    // The shade-lattice assignment (one function, one visible set): accents,
-    // cell fills, and every bar segment read from it. Badges are the
-    // exhaustion path only — a comm with no free slot among nine — which
-    // the table's top-N practically never reaches.
-    var lattice = resourceSplits.lattice
-    colorMap = lattice.assignment
-    rowOrdinals = {}
-    for (var ui = 0; ui < lattice.unassigned.length; ui++)
-      rowOrdinals[lattice.unassigned[ui]] = ui + 2
+    // blue == magenta, a theme-level reduction). Identity is name→hue and
+    // nothing else: same comm = same key = same color on its table row's
+    // mark and in every bar segment, at full strength, per the operator
+    // review's table-is-the-color-authority rule. Hue collisions between
+    // comms are accepted (three hues, five rows) — labels disambiguate the
+    // table, gaps disambiguate the bars.
+    var cmap = {}
+    for (var ci2 = 0; ci2 < resourceSplits.order.length; ci2++) {
+      var comm = resourceSplits.order[ci2]
+      cmap[comm] = root.paletteKeys[Model.stableColorKey(comm, root.paletteKeys.length)]
+    }
+    colorMap = cmap
     // Vitals rows are rebuilt complete with their segments attached: a
     // property added to a plain JS object after the fact carries no change
     // signal, so a delegate that bound before the attach would stay null.
-    var rows = Model.buildSystemRows(prevSnapshot, snap, draw)
+    var rows = Model.buildSystemRows(prevSnapshot, snap)
     for (var si = 0; si < rows.length; si++) {
       var segsFor = null
       var intensityFor = 0.45
       if (rows[si].label === "CPU") { segsFor = resourceSplits.cpu; intensityFor = resourceSplits.intensity.cpu }
       else if (rows[si].label === "RAM") { segsFor = resourceSplits.ram; intensityFor = resourceSplits.intensity.ram }
       else if (rows[si].label === "GPU") { segsFor = resourceSplits.gpu; intensityFor = resourceSplits.intensity.gpu }
-      else if (rows[si].label === "Draw") intensityFor = 1
       rows[si] = { label: rows[si].label, value: rows[si].value, meter: rows[si].meter, segments: segsFor, barIntensity: intensityFor }
     }
     systemRows = rows
@@ -596,12 +598,11 @@ Panel {
         // General system state, kin to the battery stats above; the
         // attribution section below answers "who is eating it". Rows come
         // from the same sampler snapshots as everything else, so vitals and
-        // attribution can never disagree, and the Draw row appears only
-        // while discharging (on AC the battery flow is charge rate, not
-        // system draw). Meters reuse the battery bar's own idiom — a
-        // rounded track at foreground alpha with a foreground fill — no new
-        // widget. The Draw meter grades green under 20 W, yellow under 40,
-        // red beyond, at 50%/100% of the bar.
+        // attribution can never disagree. Meters reuse the battery bar's
+        // own idiom — a rounded track at foreground alpha with a foreground
+        // fill — no new widget. There is deliberately no Draw row: total
+        // draw is the stock pill's number (same sampler telemetry), and a
+        // second copy of it here was removed in operator review.
         PanelSeparator {
           foreground: root.bar.foreground
         }
@@ -626,9 +627,7 @@ Panel {
               segments: modelData.segments !== undefined ? modelData.segments : null
               meter: modelData.meter
               barIntensity: modelData.barIntensity !== undefined ? modelData.barIntensity : 0.45
-              fillColor: modelData.label === "Draw"
-                ? (modelData.meter < 0.5 ? Color.green : modelData.meter < 1 ? Color.yellow : Color.urgent)
-                : (root.bar ? root.bar.foreground : Color.foreground)
+              fillColor: root.bar ? root.bar.foreground : Color.foreground
             }
           }
         }
@@ -648,10 +647,12 @@ Panel {
             fontFamily: root.bar.fontFamily
           }
 
-          // The attribution model as one bar: base load (accent), the top
-          // processes in their assigned comm colors, and the tail (muted).
-          // Discharging only — on AC the battery flow is charge rate, not
-          // system draw, so there is no honest bar to draw.
+          // The attribution model as one bar, mirroring the table below:
+          // the system block first (everything unattributed, in foreground —
+          // the leading neutral segment the table's system row also wears),
+          // then the top processes biggest-to-lightest in their table-row
+          // colors. Discharging only — on AC the battery flow is charge
+          // rate, not system draw, so there is no honest bar to draw.
           Rectangle {
             visible: root.resourceSplits !== null && root.resourceSplits.watts !== null
             width: column.width
@@ -673,7 +674,6 @@ Panel {
                   width: modelData.share * Math.max(0, wattsSegmentRow.width - root.splitGapBudget)
                   height: parent.height
                   color: root.segmentColor(modelData)
-                  opacity: modelData.slot !== undefined ? modelData.slot.shade : 1
                 }
               }
             }
@@ -732,16 +732,11 @@ Panel {
               cells: modelData.cells !== undefined ? modelData.cells : []
               columns: root.processColumns
               anchor: modelData.key === "system"
-              badge: root.rowOrdinals[modelData.key] !== undefined ? root.rowOrdinals[modelData.key] : 0
-              shade: root.colorMap[modelData.key] !== undefined && root.colorMap[modelData.key].shade !== undefined
-                ? root.colorMap[modelData.key].shade : 1
               commColor: modelData.key === "system"
                 ? (root.bar ? root.bar.foreground : Color.foreground)
-                : (modelData.key === "base" || modelData.key === "else"
-                  ? root.segmentColor({ kind: modelData.key, key: modelData.key })
-                  : (root.colorMap[modelData.key] !== undefined
-                    ? Color[root.colorMap[modelData.key].hue]
-                    : root.segmentColor({ kind: "comm", key: modelData.key })))
+                : (root.colorMap[modelData.key] !== undefined
+                  ? Color[root.colorMap[modelData.key]]
+                  : root.segmentColor({ kind: "comm", key: modelData.key }))
             }
           }
 
@@ -840,14 +835,14 @@ Panel {
 
   // One graphic line per process on a FIXED grid, recalculated only on
   // basis change (column set) or panel width — never per sample. Comm
-  // column: the accent mark in its own slot plus a left-aligned label
-  // elided at the kernel's 15-char comm cap (Model.COMM_MAX_CHARS, sized
-  // once via TextMetrics). Metric cells: the remaining track split equally
-  // across the section's column set, so every row — including the base and
-  // tail rows' single W cell — lands in the same pixel columns as the
-  // header. Value text is right-aligned INSIDE its fixed cell: the same
-  // pixel column every refresh regardless of fill length, and fills are
-  // capped short of the text so type never sits on a fill. No width
+  // column: the identity mark in its own slot (the row's color — the single
+  // color authority the bars mirror) plus a left-aligned label elided at
+  // the kernel's 15-char comm cap (Model.COMM_MAX_CHARS, sized once via
+  // TextMetrics). Metric cells: the remaining track split equally across
+  // the section's column set, so every row lands in the same pixel columns
+  // as the header. Value text is right-aligned INSIDE its fixed cell: the
+  // same pixel column every refresh regardless of fill length, and fills
+  // are capped short of the text so type never sits on a fill. No width
   // Behaviors anywhere — fills step at the 1 Hz cadence, geometry never
   // moves. Fixed decimals (pct one place, watts one place, RAM auto-unit
   // in the slot) keep digit-count changes absorbed by the right alignment.
@@ -857,8 +852,6 @@ Panel {
     property var cells: []
     property var columns: []
     property bool anchor: false
-    property int badge: 0
-    property real shade: 1
     property color commColor: root.bar ? root.bar.foreground : Color.foreground
 
     width: column.width
@@ -879,32 +872,14 @@ Panel {
       x: 0
       anchors.verticalCenter: parent.verticalCenter
       color: metricRow.commColor
-      opacity: metricRow.shade
-    }
-
-    // Fixed badge micro-slot: reserved whether or not a badge shows, so a
-    // collision appearing or clearing mid-refresh cannot shift the line.
-    Item {
-      id: badgeSlot
-      x: commMark.width + Style.space(2)
-      width: Style.space(7)
-      height: parent.height
-
-      Text {
-        visible: parent.parent.badge >= 2
-        text: parent.parent.badge >= 2 ? String(parent.parent.badge) : ""
-        anchors.centerIn: parent
-        color: parent.parent.commColor
-        opacity: 0.9
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.caption
-      }
     }
 
     Text {
       id: rowLabel
       text: metricRow.label
-      x: badgeSlot.x + badgeSlot.width + Style.space(2)
+      // mark(3) + 5 + label + 8 = the header's 16-unit comm gutter, so the
+      // metric columns line up exactly beneath their headers
+      x: commMark.width + Style.space(5)
       width: commMetrics.advanceWidth
       anchors.verticalCenter: parent.verticalCenter
       color: root.bar ? root.bar.foreground : Color.foreground
@@ -969,7 +944,7 @@ Panel {
               color: metricRow.anchor
                 ? (root.bar ? root.bar.foreground : Color.foreground)
                 : root.metricColor(cellSlot.modelData)
-              opacity: cellSlot.cellData !== null ? cellSlot.cellData.intensity * metricRow.shade : 0
+              opacity: cellSlot.cellData !== null ? cellSlot.cellData.intensity : 0
             }
           }
         }
@@ -979,9 +954,9 @@ Panel {
 
   // A SYSTEM bar: one rounded track per resource with the label in the left
   // gutter and the value at the right edge. With segments the fill is the
-  // composition (comm colors, idle/available left as track), ramped by the
-  // resource's utilization; without segments it is a single intensity-graded
-  // fill (the categorical Draw row colors itself).
+  // composition (the table's colors: foreground system block first, then
+  // comm hues; idle/available left as track), ramped by the resource's
+  // utilization; without segments it is a single intensity-graded fill.
   component SplitBar: Item {
     id: splitBar
     property string label: ""
@@ -1049,8 +1024,6 @@ Panel {
             width: modelData.share * Math.max(0, splitSegments.width - root.splitGapBudget)
             height: splitSegments.height
             color: root.segmentColor(modelData)
-            opacity: modelData.slot !== undefined ? modelData.slot.shade : 1
-
           }
         }
       }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -711,6 +711,11 @@ Panel {
               columns: root.processColumns
               anchor: modelData.key === "system"
               commColor: root.bar ? root.bar.foreground : Color.foreground
+              // The mark rides the same load ladder as its bar segment:
+              // the row's CPU-cell intensity IS share/busiest-share, so
+              // mark, cells, and bar all dim together.
+              commInk: modelData.key === "system" || modelData.cells === undefined
+                || modelData.cells.length === 0 ? 1 : modelData.cells[0].intensity
             }
           }
 
@@ -828,6 +833,7 @@ Panel {
     property var columns: []
     property bool anchor: false
     property color commColor: root.bar ? root.bar.foreground : Color.foreground
+    property real commInk: 1
 
     width: column.width
     implicitHeight: Style.space(16)
@@ -847,6 +853,7 @@ Panel {
       x: 0
       anchors.verticalCenter: parent.verticalCenter
       color: metricRow.commColor
+      opacity: metricRow.commInk
     }
 
     Text {

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -17,7 +17,6 @@ Panel {
   property var systemInfo: ({})
   // Power Hungry: top-consumer attribution, panel-only by design. The bar
   // pill is untouched — this answers a question you ask with the panel open.
-  property real systemWatts: -1
   property real baseWatts: -1
   property var prevSnapshot: null
   property var topProcesses: []
@@ -177,8 +176,13 @@ Panel {
     // Keep last known good data if a refresh briefly returns nothing — happens
     // around AC plug/unplug events. Avoids the section collapsing mid-transition.
     if (Object.keys(next).length === 0) return
-    if (targetName === "battery") batteryInfo = next
-    else systemInfo = next
+    if (targetName === "battery") {
+      // The rate is SIGNED by the source (negative while discharging); the
+      // panel shows magnitude — direction lives in the state row. Strip the
+      // sign here, the single write point, so the value never flickers.
+      if (typeof next.rate === "string") next.rate = next.rate.replace(/^-/, "")
+      batteryInfo = next
+    } else systemInfo = next
   }
 
   function updateProfiles(raw) {
@@ -265,12 +269,11 @@ Panel {
   function onSample(raw) {
     var snap = Model.parseSnapshot(raw)
     if (!snap) return
-    if (snap.watts !== null) {
-      systemWatts = snap.watts
-      // Stock rate format ("0.6W", no space) so this row doesn't flicker
-      // against the batteryProc refresh at 1 Hz while the panel is open.
-      batteryInfo = Object.assign({}, batteryInfo, { rate: Math.round(snap.watts * 10) / 10 + "W" })
-    }
+    // NOTE: the sampler's watts feed the ATTRIBUTION here — the displayed
+    // rate comes only from batteryProc (the stock smoothed source), written
+    // in exactly one place. A second writer here (tried in v1) made the row
+    // flip sign and value at 1 Hz — two reads of the same telemetry with
+    // different conventions. Never two writers on one field.
     // A snapshot without a readable cputotal would diff nonsense percentages;
     // drop it and wait for the next one instead of storing it as a baseline.
     if (snap.cpuTotalJiffies === null) {

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -24,7 +24,11 @@ Panel {
   property var systemRows: []
   property var resourceSplits: null
   property var colorMap: ({})
+  property var rowOrdinals: ({})
   property var processColumns: []
+  // The identity palette — three collision-free theme hues; see the
+  // rationale at the colorMap assignment below.
+  readonly property var paletteKeys: ["blue", "cyan", "magenta"]
   property var profiles: []
   property string activeProfile: ""
   property int profileIndex: 0
@@ -172,7 +176,7 @@ Panel {
   function segmentColor(seg) {
     if (seg.kind === "base") return Color.accent
     if (seg.kind === "rest" || seg.kind === "else") return Color.muted
-    var k = seg.kind === "comm" ? colorMap[seg.key] : ""
+    var k = seg.kind === "group" ? seg.key : (seg.kind === "comm" ? colorMap[seg.key] : "")
     if (k === "blue") return Color.blue
     if (k === "cyan") return Color.cyan
     if (k === "magenta") return Color.magenta
@@ -325,7 +329,7 @@ Panel {
       }
     }
     processColumns = cols
-    resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
+    resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts, root.paletteKeys)
     // Palette keys map to Color singleton properties: the three
     // non-threshold hues that are universal AND mutually distinct across the
     // themes (reviewer finding, hex re-derived: accent equals blue on 17
@@ -334,7 +338,10 @@ Panel {
     // collision-free set exists — retro-82's residual defect is its own
     // blue == magenta, a theme-level reduction). Same comm = same key =
     // same color in the CPU, RAM, and watts bars and its row meter.
-    colorMap = Model.assignColorKeys(resourceSplits.order, ["blue", "cyan", "magenta"])
+    colorMap = Model.assignColorKeys(resourceSplits.order, root.paletteKeys)
+    // Ordinal badges for simultaneous same-hue rows: the hue is identity,
+    // the badge only breaks ties among what is visible right now.
+    rowOrdinals = Model.collisionOrdinals(resourceSplits.order, root.paletteKeys)
     // Vitals rows are rebuilt complete with their segments attached: a
     // property added to a plain JS object after the fact carries no change
     // signal, so a delegate that bound before the attach would stay null.
@@ -720,6 +727,7 @@ Panel {
               cells: modelData.cells !== undefined ? modelData.cells : []
               columns: root.processColumns
               anchor: modelData.key === "system"
+              badge: root.rowOrdinals[modelData.key] !== undefined ? root.rowOrdinals[modelData.key] : 0
               commColor: modelData.key === "system"
                 ? (root.bar ? root.bar.foreground : Color.foreground)
                 : (modelData.key === "base" || modelData.key === "else"
@@ -840,6 +848,7 @@ Panel {
     property var cells: []
     property var columns: []
     property bool anchor: false
+    property int badge: 0
     property color commColor: root.bar ? root.bar.foreground : Color.foreground
 
     width: column.width
@@ -863,9 +872,21 @@ Panel {
     }
 
     Text {
+      id: rowBadge
+      visible: metricRow.badge >= 2
+      text: metricRow.badge >= 2 ? String(metricRow.badge) : ""
+      x: commMark.width + Style.space(2)
+      anchors.verticalCenter: parent.verticalCenter
+      color: metricRow.commColor
+      opacity: 0.9
+      font.family: root.bar.fontFamily
+      font.pixelSize: Style.font.caption
+    }
+
+    Text {
       id: rowLabel
       text: metricRow.label
-      x: commMark.width + Style.space(5)
+      x: commMark.width + Style.space(5) + (metricRow.badge >= 2 ? rowBadge.implicitWidth + Style.space(2) : 0)
       width: commMetrics.advanceWidth
       anchors.verticalCenter: parent.verticalCenter
       color: root.bar ? root.bar.foreground : Color.foreground

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -22,8 +22,11 @@ Panel {
   property var topProcesses: []
   property var systemRows: []
   property var resourceSplits: null
-  property var heat: ({})
+  property var colorMap: ({})
   property var processColumns: []
+  // The identity palette — three collision-free theme hues; see the
+  // rationale at the colorMap assignment below.
+  readonly property var paletteKeys: ["blue", "cyan", "magenta"]
   // Composition-bar gap geometry: a constant separator width and a constant
   // budget for the maximum segment count, so fills scale identically across
   // refreshes and resources regardless of how many segments are visible.
@@ -146,20 +149,36 @@ Panel {
     return modeLabel()
   }
 
-  // Ink, not hue: RANK-NORMALIZED heat — foreground at even steps from
-  // 1.0 (rank 1) down to 0.35 (last rank), and that value follows the
-  // process everywhere (row mark, every bar segment). The system block/row
-  // is WHITE (the machine itself). Magnitude lives in segment SIZE and the
-  // numeric cells; ink's only job is ORDER. Identity is positional and by
-  // label (operator decisions, 2026-08-29).
-  function segmentInk(seg) {
-    if (seg.kind === "system") return 1
-    if (seg.ink !== undefined) return seg.ink
-    return 0.35
+  // Metric-type colors for the per-process cells: the three collision-free
+  // hues, one per metric (CPU blue, RAM cyan, W magenta), so a column reads
+  // as one metric at a glance. W stays magenta rather than categorical
+  // green/yellow/red: per-process watts carry no honest absolute thresholds
+  // (the old system-level Draw meter that used them was removed in operator
+  // review — the stock pill already shows total draw). GPU is reserved
+  // to accent for the future fdinfo cell (never emitted on this hardware;
+  // accent may sit near blue on some themes — a documented follow-up
+  // question for whoever adds GPU cells).
+  function metricColor(metric) {
+    if (metric === "CPU") return Color.blue
+    if (metric === "RAM") return Color.cyan
+    if (metric === "W") return Color.magenta
+    return Color.accent
   }
 
+  // Segment/row colors, one resolver for every surface: comms take their
+  // name-hashed palette hue — the table row's mark is the single color
+  // authority, and bars render the same hue at the same full strength —
+  // the system block takes foreground (the neutral machine), the GPU bar's
+  // rest takes muted, unknown keys fall back to the bar foreground.
   function segmentColor(seg) {
     if (seg.kind === "rest") return Color.muted
+    if (seg.kind === "system") return root.bar ? root.bar.foreground : Color.foreground
+    var k = seg.kind === "comm" && seg.slot !== undefined ? seg.slot.hue
+      : (seg.kind === "comm" && colorMap[seg.key] !== undefined ? colorMap[seg.key] : "")
+    if (k === "blue") return Color.blue
+    if (k === "cyan") return Color.cyan
+    if (k === "magenta") return Color.magenta
+    if (k === "accent") return Color.accent
     return root.bar ? root.bar.foreground : Color.foreground
   }
 
@@ -270,11 +289,11 @@ Panel {
   function onSample(raw) {
     var snap = Model.parseSnapshot(raw)
     if (!snap) return
-    // NOTE: the sampler's watts feed the ATTRIBUTION here — the displayed
-    // rate comes only from batteryProc (the stock smoothed source), written
-    // in exactly one place. A second writer here (tried in v1) made the row
-    // flip sign and value at 1 Hz — two reads of the same telemetry with
-    // different conventions. Never two writers on one field.
+    // The sampler's watts feed the ATTRIBUTION — the displayed rate comes
+    // only from batteryProc (the stock smoothed source), written in exactly
+    // one place. A second writer here (tried in v1) made the row flip sign
+    // and value at 1 Hz: two reads of the same telemetry with different
+    // conventions. Never two writers on one field.
     // A snapshot without a readable cputotal would diff nonsense percentages;
     // drop it and wait for the next one instead of storing it as a baseline.
     if (snap.cpuTotalJiffies === null) {
@@ -313,46 +332,25 @@ Panel {
       }
     }
     processColumns = cols
-    resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
-    // ONE HEAT PER PROCESS (operator decision, 2026-08-29): a process's ink
-    // is a single value — its share of the busiest process's CPU load,
-    // 0.35..1.0 — and that value follows it EVERYWHERE: the table row's
-    // mark, its segment in every composition bar. Like a heatmap of
-    // processes: the system leads in white (the machine itself), the top
-    // process glows brightest, and ink fades monotonically down the table's
-    // rank. Segment SIZE still encodes each bar's own metric share; INK
-    // encodes who the process is and how hot it runs. One writer: computed
-    // here, once per refresh, onto plain numbers.
-    // RANK-NORMALIZED (operator decision, 2026-08-29): ink steps EVENLY by
-    // rank — rank 1 is white, the last rank sits at the 0.35 floor — not by
-    // share ratio. How much hotter one process runs than another is already
-    // encoded by segment SIZE; ink's only job is order.
-    var heatMap = {}
-    var rankMap = {}
-    var cpuBar = resourceSplits.cpu
-    // The cpu split is NULL until two samples exist (and stays null on AC
-    // restarts) — a null bar means "no heat yet", not an error.
-    if (cpuBar !== null && cpuBar !== undefined) {
-      var comms = []
-      for (var hi = 0; hi < cpuBar.length; hi++)
-        if (cpuBar[hi].kind === "comm") comms.push(cpuBar[hi])
-      for (var hj = 0; hj < comms.length; hj++) {
-        var step = comms.length > 1 ? 0.65 / (comms.length - 1) : 0
-        heatMap[comms[hj].key] = 1 - hj * step
-        rankMap[comms[hj].key] = hj + 1
-      }
+    resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts, root.paletteKeys)
+    // Palette keys map to Color singleton properties: the three
+    // non-threshold hues that are universal AND mutually distinct across the
+    // themes (reviewer finding, hex re-derived: accent equals blue on 17
+    // themes and magenta on lumon only, so it cannot serve as a fourth hue;
+    // bright_* variants equal their base hue on roughly half, so no six-key
+    // collision-free set exists — retro-82's residual defect is its own
+    // blue == magenta, a theme-level reduction). Identity is name→hue and
+    // nothing else: same comm = same key = same color on its table row's
+    // mark and in every bar segment, at full strength, per the operator
+    // review's table-is-the-color-authority rule. Hue collisions between
+    // comms are accepted (three hues, five rows) — labels disambiguate the
+    // table, gaps disambiguate the bars.
+    var cmap = {}
+    for (var ci2 = 0; ci2 < resourceSplits.order.length; ci2++) {
+      var comm = resourceSplits.order[ci2]
+      cmap[comm] = root.paletteKeys[Model.stableColorKey(comm, root.paletteKeys.length)]
     }
-    var allBars = [resourceSplits.cpu, resourceSplits.ram, resourceSplits.watts, resourceSplits.gpu]
-    for (var bi = 0; bi < allBars.length; bi++) {
-      var bar = allBars[bi]
-      if (!bar) continue
-      for (var si3 = 0; si3 < bar.length; si3++)
-        if (bar[si3].kind === "comm") {
-          bar[si3].ink = heatMap[bar[si3].key] !== undefined ? heatMap[bar[si3].key] : 0.35
-          bar[si3].rank = rankMap[bar[si3].key] !== undefined ? rankMap[bar[si3].key] : 0
-        }
-    }
-    heat = heatMap
+    colorMap = cmap
     // Vitals rows are rebuilt complete with their segments attached: a
     // property added to a plain JS object after the fact carries no change
     // signal, so a delegate that bound before the attach would stay null.
@@ -541,7 +539,7 @@ Panel {
             id: barTrack
             anchors.fill: parent
             radius: height / 2
-            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.08)
+            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
           }
 
           Rectangle {
@@ -664,7 +662,7 @@ Panel {
             height: Style.space(6)
             radius: height / 2
             clip: true
-            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.08)
+            color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
 
             Row {
               id: wattsSegmentRow
@@ -679,7 +677,6 @@ Panel {
                   width: modelData.share * Math.max(0, wattsSegmentRow.width - root.splitGapBudget)
                   height: parent.height
                   color: root.segmentColor(modelData)
-                  opacity: root.segmentInk(modelData)
                 }
               }
             }
@@ -719,7 +716,7 @@ Panel {
                   text: parent.modelData
                   anchors.right: parent.right
                   anchors.rightMargin: Style.space(4)
-                  color: root.bar ? root.bar.foreground : Color.foreground
+                  color: root.metricColor(parent.modelData)
                   opacity: 0.8
                   font.family: root.bar.fontFamily
                   font.pixelSize: Style.font.caption
@@ -738,12 +735,11 @@ Panel {
               cells: modelData.cells !== undefined ? modelData.cells : []
               columns: root.processColumns
               anchor: modelData.key === "system"
-              commColor: root.bar ? root.bar.foreground : Color.foreground
-              // The mark IS the process's heat — the same one-writer value
-              // its bar segments use (root.heat), so mark and bars can
-              // never disagree about a process.
-              commInk: modelData.key === "system" ? 1
-                : (root.heat[modelData.key] !== undefined ? root.heat[modelData.key] : 0.35)
+              commColor: modelData.key === "system"
+                ? (root.bar ? root.bar.foreground : Color.foreground)
+                : (root.colorMap[modelData.key] !== undefined
+                  ? Color[root.colorMap[modelData.key]]
+                  : root.segmentColor({ kind: "comm", key: modelData.key }))
             }
           }
 
@@ -842,9 +838,8 @@ Panel {
 
   // One graphic line per process on a FIXED grid, recalculated only on
   // basis change (column set) or panel width — never per sample. Comm
-  // column: the identity mark in its own slot — foreground ink, since
-  // identity is carried by the label and by row order (system leads;
-  // processes descend by load) — plus a left-aligned label elided at
+  // column: the identity mark in its own slot (the row's color — the single
+  // color authority the bars mirror) plus a left-aligned label elided at
   // the kernel's 15-char comm cap (Model.COMM_MAX_CHARS, sized once via
   // TextMetrics). Metric cells: the remaining track split equally across
   // the section's column set, so every row lands in the same pixel columns
@@ -861,7 +856,6 @@ Panel {
     property var columns: []
     property bool anchor: false
     property color commColor: root.bar ? root.bar.foreground : Color.foreground
-    property real commInk: 1
 
     width: column.width
     implicitHeight: Style.space(16)
@@ -881,7 +875,6 @@ Panel {
       x: 0
       anchors.verticalCenter: parent.verticalCenter
       color: metricRow.commColor
-      opacity: metricRow.commInk
     }
 
     Text {
@@ -951,7 +944,9 @@ Panel {
                 : 0
               height: parent.height - Style.space(4)
               radius: height / 3
-              color: root.bar ? root.bar.foreground : Color.foreground
+              color: metricRow.anchor
+                ? (root.bar ? root.bar.foreground : Color.foreground)
+                : root.metricColor(cellSlot.modelData)
               opacity: cellSlot.cellData !== null ? cellSlot.cellData.intensity : 0
             }
           }
@@ -1028,24 +1023,10 @@ Panel {
           }
 
           Rectangle {
-            id: splitSeg
             required property var modelData
             width: modelData.share * Math.max(0, splitSegments.width - root.splitGapBudget)
             height: splitSegments.height
             color: root.segmentColor(modelData)
-            opacity: root.segmentInk(modelData)
-
-            // Rank numeral, rendered only where the segment is wide enough
-            // to hold it without crowding — the table is the legend, and
-            // this is its index echoed at the point of use.
-            Text {
-              visible: splitSeg.width >= Style.space(7) && modelData.rank !== undefined && modelData.rank > 0
-              text: modelData.rank !== undefined ? String(modelData.rank) : ""
-              anchors.centerIn: parent
-              color: root.bar ? root.bar.background : Color.background
-              font.family: root.bar.fontFamily
-              font.pixelSize: Style.font.caption
-            }
           }
         }
       }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -23,11 +23,7 @@ Panel {
   property var topProcesses: []
   property var systemRows: []
   property var resourceSplits: null
-  property var colorMap: ({})
   property var processColumns: []
-  // The identity palette — three collision-free theme hues; see the
-  // rationale at the colorMap assignment below.
-  readonly property var paletteKeys: ["blue", "cyan", "magenta"]
   // Composition-bar gap geometry: a constant separator width and a constant
   // budget for the maximum segment count, so fills scale identically across
   // refreshes and resources regardless of how many segments are visible.
@@ -150,36 +146,20 @@ Panel {
     return modeLabel()
   }
 
-  // Metric-type colors for the per-process cells: the three collision-free
-  // hues, one per metric (CPU blue, RAM cyan, W magenta), so a column reads
-  // as one metric at a glance. W stays magenta rather than categorical
-  // green/yellow/red: per-process watts carry no honest absolute thresholds
-  // (the old system-level Draw meter that used them was removed in operator
-  // review — the stock pill already shows total draw). GPU is reserved
-  // to accent for the future fdinfo cell (never emitted on this hardware;
-  // accent may sit near blue on some themes — a documented follow-up
-  // question for whoever adds GPU cells).
-  function metricColor(metric) {
-    if (metric === "CPU") return Color.blue
-    if (metric === "RAM") return Color.cyan
-    if (metric === "W") return Color.magenta
-    return Color.accent
+  // Ink, not hue: every surface speaks foreground-at-load. The system
+  // block/row is WHITE (the machine itself); a process's ink dims with its
+  // load — opacity 0.35..1.0 mapped from its share of the bar's busiest
+  // process. Identity is carried by ORDER (biggest to lightest, mirroring
+  // the table) and by label; brightness carries magnitude. This matches
+  // the shell's native monochrome language (operator decision, 2026-08-29).
+  function segmentInk(seg) {
+    if (seg.kind === "system") return 1
+    if (seg.ink !== undefined) return seg.ink
+    return 1
   }
 
-  // Segment/row colors, one resolver for every surface: comms take their
-  // name-hashed palette hue — the table row's mark is the single color
-  // authority, and bars render the same hue at the same full strength —
-  // the system block takes foreground (the neutral machine), the GPU bar's
-  // rest takes muted, unknown keys fall back to the bar foreground.
   function segmentColor(seg) {
     if (seg.kind === "rest") return Color.muted
-    if (seg.kind === "system") return root.bar ? root.bar.foreground : Color.foreground
-    var k = seg.kind === "comm" && seg.slot !== undefined ? seg.slot.hue
-      : (seg.kind === "comm" && colorMap[seg.key] !== undefined ? colorMap[seg.key] : "")
-    if (k === "blue") return Color.blue
-    if (k === "cyan") return Color.cyan
-    if (k === "magenta") return Color.magenta
-    if (k === "accent") return Color.accent
     return root.bar ? root.bar.foreground : Color.foreground
   }
 
@@ -329,25 +309,23 @@ Panel {
       }
     }
     processColumns = cols
-    resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts, root.paletteKeys)
-    // Palette keys map to Color singleton properties: the three
-    // non-threshold hues that are universal AND mutually distinct across the
-    // themes (reviewer finding, hex re-derived: accent equals blue on 17
-    // themes and magenta on lumon only, so it cannot serve as a fourth hue;
-    // bright_* variants equal their base hue on roughly half, so no six-key
-    // collision-free set exists — retro-82's residual defect is its own
-    // blue == magenta, a theme-level reduction). Identity is name→hue and
-    // nothing else: same comm = same key = same color on its table row's
-    // mark and in every bar segment, at full strength, per the operator
-    // review's table-is-the-color-authority rule. Hue collisions between
-    // comms are accepted (three hues, five rows) — labels disambiguate the
-    // table, gaps disambiguate the bars.
-    var cmap = {}
-    for (var ci2 = 0; ci2 < resourceSplits.order.length; ci2++) {
-      var comm = resourceSplits.order[ci2]
-      cmap[comm] = root.paletteKeys[Model.stableColorKey(comm, root.paletteKeys.length)]
+    resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
+    // Ink follows load (operator decision, 2026-08-29): every comm segment
+    // carries its own opacity — 0.35..1.0 mapped from its share of that
+    // bar's busiest process. System leads at full ink (white: the machine
+    // itself); brightness IS magnitude, order IS identity. The muted frame
+    // (rest) stays muted. Computed here, once per refresh, so delegates
+    // bind a plain number.
+    var allBars = [resourceSplits.cpu, resourceSplits.ram, resourceSplits.watts, resourceSplits.gpu]
+    for (var bi = 0; bi < allBars.length; bi++) {
+      var bar = allBars[bi]
+      if (!bar) continue
+      var maxComm = 0
+      for (var si2 = 0; si2 < bar.length; si2++)
+        if (bar[si2].kind === "comm" && bar[si2].share > maxComm) maxComm = bar[si2].share
+      for (var si3 = 0; si3 < bar.length; si3++)
+        if (bar[si3].kind === "comm") bar[si3].ink = 0.35 + 0.65 * (maxComm > 0 ? bar[si3].share / maxComm : 0)
     }
-    colorMap = cmap
     // Vitals rows are rebuilt complete with their segments attached: a
     // property added to a plain JS object after the fact carries no change
     // signal, so a delegate that bound before the attach would stay null.
@@ -713,7 +691,7 @@ Panel {
                   text: parent.modelData
                   anchors.right: parent.right
                   anchors.rightMargin: Style.space(4)
-                  color: root.metricColor(parent.modelData)
+                  color: root.bar ? root.bar.foreground : Color.foreground
                   opacity: 0.8
                   font.family: root.bar.fontFamily
                   font.pixelSize: Style.font.caption
@@ -732,11 +710,7 @@ Panel {
               cells: modelData.cells !== undefined ? modelData.cells : []
               columns: root.processColumns
               anchor: modelData.key === "system"
-              commColor: modelData.key === "system"
-                ? (root.bar ? root.bar.foreground : Color.foreground)
-                : (root.colorMap[modelData.key] !== undefined
-                  ? Color[root.colorMap[modelData.key]]
-                  : root.segmentColor({ kind: "comm", key: modelData.key }))
+              commColor: root.bar ? root.bar.foreground : Color.foreground
             }
           }
 
@@ -835,8 +809,9 @@ Panel {
 
   // One graphic line per process on a FIXED grid, recalculated only on
   // basis change (column set) or panel width — never per sample. Comm
-  // column: the identity mark in its own slot (the row's color — the single
-  // color authority the bars mirror) plus a left-aligned label elided at
+  // column: the identity mark in its own slot — foreground ink, since
+  // identity is carried by the label and by row order (system leads;
+  // processes descend by load) — plus a left-aligned label elided at
   // the kernel's 15-char comm cap (Model.COMM_MAX_CHARS, sized once via
   // TextMetrics). Metric cells: the remaining track split equally across
   // the section's column set, so every row lands in the same pixel columns
@@ -941,9 +916,7 @@ Panel {
                 : 0
               height: parent.height - Style.space(4)
               radius: height / 3
-              color: metricRow.anchor
-                ? (root.bar ? root.bar.foreground : Color.foreground)
-                : root.metricColor(cellSlot.modelData)
+              color: root.bar ? root.bar.foreground : Color.foreground
               opacity: cellSlot.cellData !== null ? cellSlot.cellData.intensity : 0
             }
           }
@@ -1024,6 +997,7 @@ Panel {
             width: modelData.share * Math.max(0, splitSegments.width - root.splitGapBudget)
             height: splitSegments.height
             color: root.segmentColor(modelData)
+            opacity: root.segmentInk(modelData)
           }
         }
       }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -652,6 +652,7 @@ Panel {
                   width: modelData.share * Math.max(0, wattsSegmentRow.width - root.splitGapBudget)
                   height: parent.height
                   color: root.segmentColor(modelData)
+                  opacity: root.segmentInk(modelData)
                 }
               }
             }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -181,6 +181,7 @@ Panel {
   function segmentColor(seg) {
     if (seg.kind === "base") return Color.accent
     if (seg.kind === "rest" || seg.kind === "else") return Color.muted
+    if (seg.kind === "system") return root.bar ? root.bar.foreground : Color.foreground
     var k = seg.kind === "comm" && seg.slot !== undefined ? seg.slot.hue
       : (seg.kind === "comm" && colorMap[seg.key] !== undefined ? colorMap[seg.key].hue : "")
     if (k === "blue") return Color.blue

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -24,6 +24,7 @@ Panel {
   property var systemRows: []
   property var resourceSplits: null
   property var colorMap: ({})
+  property var processColumns: []
   property var profiles: []
   property string activeProfile: ""
   property int profileIndex: 0
@@ -139,6 +140,21 @@ Panel {
     if (fullyCharged) return "Fully charged"
     if (rotatingPhrases) return activePhrases[phraseIndex % activePhrases.length]
     return modeLabel()
+  }
+
+  // Metric-type colors for the per-process cells: the three collision-free
+  // hues, one per metric (CPU blue, RAM cyan, W magenta), so a column reads
+  // as one metric at a glance. W stays magenta here rather than categorical
+  // green/yellow/red: those thresholds grade SYSTEM draw (the Draw bar);
+  // per-process watts carry no honest absolute thresholds. GPU is reserved
+  // to accent for the future fdinfo cell (never emitted on this hardware;
+  // accent may sit near blue on some themes — a documented follow-up
+  // question for whoever adds GPU cells).
+  function metricColor(metric) {
+    if (metric === "CPU") return Color.blue
+    if (metric === "RAM") return Color.cyan
+    if (metric === "W") return Color.magenta
+    return Color.accent
   }
 
   // Legible text on an arbitrary theme fill: pick whichever of the theme's
@@ -289,6 +305,16 @@ Panel {
       else baseWatts += (draw - baseWatts) * 0.02
     }
     if (prevSnapshot) topProcesses = Model.buildTopProcesses(prevSnapshot, snap, 5, draw, baseWatts)
+    // column set = the first row's cell metrics, in the builder's fixed
+    // order (CPU, RAM, W discharging only, GPU when a source exists)
+    var cols = []
+    for (var ci = 0; ci < topProcesses.length; ci++) {
+      if (topProcesses[ci].cells !== undefined && topProcesses[ci].cells.length > 0) {
+        cols = topProcesses[ci].cells.map(function(c) { return c.metric })
+        break
+      }
+    }
+    processColumns = cols
     resourceSplits = Model.buildResourceSplits(prevSnapshot, snap, 5, draw, baseWatts)
     // Palette keys map to Color singleton properties: the three
     // non-threshold hues that are universal AND mutually distinct across the
@@ -631,20 +657,43 @@ Panel {
             }
           }
 
+          // Column headers, learned once: CPU / RAM / W (discharging only).
+          // The column set is derived in onSample from the rows' own cells,
+          // so the header can never drift from what renders beneath it.
+          Row {
+            id: processHeader
+            visible: root.processColumns.length > 0
+            width: column.width
+
+            Repeater {
+              model: root.processColumns
+
+              Item {
+                required property var modelData
+                width: processHeader.width / root.processColumns.length
+                height: Style.space(12)
+
+                Text {
+                  text: parent.modelData
+                  x: Style.space(6)
+                  color: root.metricColor(parent.modelData)
+                  opacity: 0.8
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.caption
+                  font.bold: true
+                }
+              }
+            }
+          }
+
           Repeater {
             model: root.topProcesses
 
-            // The bar IS the row: comm-colored fill sized by impact, ramped
-            // by intensity, value text at the fill's end, and a thin RSS
-            // sub-bar beneath in the same comm color.
-            BarRow {
+            MetricRow {
               required property var modelData
               label: modelData.label
-              value: modelData.value
-              share: modelData.meter !== undefined ? modelData.meter : 0
-              intensity: modelData.intensity !== undefined ? modelData.intensity : 1
-              ramShare: modelData.ramShare !== undefined ? modelData.ramShare : 0
-              fillColor: modelData.key === "base" || modelData.key === "else"
+              cells: modelData.cells !== undefined ? modelData.cells : []
+              commColor: modelData.key === "base" || modelData.key === "else"
                 ? root.segmentColor({ kind: modelData.key, key: modelData.key })
                 : root.segmentColor({ kind: "comm", key: modelData.key })
             }
@@ -743,76 +792,92 @@ Panel {
     font.pixelSize: Style.font.bodySmall
   }
 
-  // A POWER HUNGRY row where the bar IS the row: a rounded track spans the
-  // width, the comm label sits in the left gutter, the comm-colored fill
-  // grows from the gutter sized by the row's impact and faded by its
-  // intensity ramp, the value text anchors just past the fill's end (always
-  // on the unfilled track, where the panel's own text color is legible in
-  // every theme), and a thin RSS sub-bar runs beneath in the same color.
-  component BarRow: Item {
-    id: barRow
+  // One graphic line per process: the comm label (with a small comm-colored
+  // accent mark preserving some identity cross-referencing to the SYSTEM
+  // composition bars) sits in the left gutter, and ONE track carries the
+  // metric cells — CPU, RAM, W (discharging only) — each a mini-meter in
+  // its own fixed column: metric-type color, fill normalized per metric,
+  // intensity ramped by the cell's magnitude within its column, value text
+  // at the fill's end on the unfilled track (the established legibility
+  // rule). The old two-line row (impact fill + RAM sub-bar) is gone.
+  component MetricRow: Item {
+    id: metricRow
     property string label: ""
-    property string value: ""
-    property real share: 0
-    property real intensity: 1
-    property real ramShare: 0
-    property color fillColor: root.bar ? root.bar.foreground : Color.foreground
+    property var cells: []
+    property color commColor: root.bar ? root.bar.foreground : Color.foreground
 
     width: column.width
-    implicitHeight: Style.space(16) + (ramShare > 0 ? Style.space(5) : 0)
+    implicitHeight: Style.space(16)
 
     Rectangle {
-      id: barTrack
-      width: parent.width
-      height: Style.space(16)
-      radius: height / 3
-      clip: true
-      color: Qt.rgba(barRow.fillColor.r, barRow.fillColor.g, barRow.fillColor.b, 0.08)
+      id: commMark
+      width: Style.space(3)
+      height: Style.space(10)
+      radius: width / 2
+      x: 0
+      anchors.verticalCenter: parent.verticalCenter
+      color: metricRow.commColor
+    }
 
-      Text {
-        id: barLabel
-        text: barRow.label
-        x: Style.space(6)
-        anchors.verticalCenter: parent.verticalCenter
-        color: root.bar ? root.bar.foreground : Color.foreground
-        opacity: 0.65
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.bodySmall
-      }
-
-      Rectangle {
-        id: barFill
-        x: barLabel.implicitWidth + Style.space(12)
-        width: Math.max(0, Math.min(share, 1) * (barTrack.width - x - valueText.width - Style.space(8)))
-        y: Style.space(2)
-        height: parent.height - Style.space(4)
-        radius: height / 3
-        color: barRow.fillColor
-        opacity: intensity
-      }
-
-      Text {
-        id: valueText
-        text: barRow.value
-        anchors.left: barFill.right
-        anchors.leftMargin: Style.space(6)
-        anchors.verticalCenter: parent.verticalCenter
-        color: root.bar ? root.bar.foreground : Color.foreground
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.bodySmall
-      }
+    Text {
+      id: rowLabel
+      text: metricRow.label
+      x: commMark.width + Style.space(5)
+      anchors.verticalCenter: parent.verticalCenter
+      color: root.bar ? root.bar.foreground : Color.foreground
+      opacity: 0.75
+      font.family: root.bar.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      elide: Text.ElideRight
+      width: Math.min(implicitWidth + Style.space(6), parent.width * 0.32)
     }
 
     Rectangle {
-      id: ramBar
-      visible: ramShare > 0
-      x: barLabel.implicitWidth + Style.space(12)
-      width: Math.min(ramShare, 1) * (parent.width - x - Style.space(8))
-      y: barTrack.height + Style.space(1)
-      height: Style.space(3)
-      radius: height / 2
-      color: barRow.fillColor
-      opacity: 0.7
+      id: cellTrack
+      x: rowLabel.x + rowLabel.width + Style.space(6)
+      width: parent.width - x
+      height: parent.height
+      radius: height / 3
+      color: Qt.rgba((root.bar ? root.bar.foreground : Color.foreground).r,
+                     (root.bar ? root.bar.foreground : Color.foreground).g,
+                     (root.bar ? root.bar.foreground : Color.foreground).b, 0.08)
+
+      Row {
+        id: cellRow
+        anchors.fill: parent
+
+        Repeater {
+          model: metricRow.cells
+
+          Item {
+            required property var modelData
+            width: cellRow.width / Math.max(1, metricRow.cells.length)
+            height: cellRow.height
+
+            Rectangle {
+              id: cellFill
+              x: Style.space(2)
+              y: Style.space(2)
+              width: Math.max(0, Math.min(1, parent.modelData.normalized)) * (parent.width - Style.space(4))
+              height: parent.height - Style.space(4)
+              radius: height / 3
+              color: root.metricColor(parent.modelData.metric)
+              opacity: parent.modelData.intensity
+            }
+
+            Text {
+              text: parent.modelData.value
+              anchors.left: parent.left
+              anchors.leftMargin: cellFill.width + Style.space(6)
+              anchors.verticalCenter: parent.verticalCenter
+              color: root.bar ? root.bar.foreground : Color.foreground
+              opacity: 0.75
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.bodySmall
+            }
+          }
+        }
+      }
     }
   }
 

--- a/shell/plugins/panels/power/sampler.sh
+++ b/shell/plugins/panels/power/sampler.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Power Hungry sampler: one pass over /proc, emitted as key\tvalue lines that
+# the power panel's Model.js parses. Consecutive snapshots are diffed for
+# per-process CPU share; watts come from the same source the stock panel
+# displays so the stats rows and the attribution always agree.
+#
+# Lines:
+#   watts\t<absolute battery flow in watts>
+#   cputotal\t<busy jiffies on the aggregate cpu line of /proc/stat>
+#   p\t<pid>\t<utime+stime jiffies>\t<comm>
+
+WATTS=""
+bat=""
+for b in /sys/class/power_supply/macsmc-battery /sys/class/power_supply/BAT*; do
+  if [[ -d $b ]]; then
+    bat=$b
+    break
+  fi
+done
+
+# omarchy-battery-status reads the same telemetry the stock panel shows, with
+# its smoothing, so prefer it over raw sysfs. Its rate is signed (negative
+# while discharging) and macsmc mirrors that sign in sysfs, so strip it here —
+# direction belongs to UPower on the QML side, never to this value.
+STOCK_RATE=$(omarchy-battery-status --shell 2>/dev/null | awk -F'\t' '$1=="rate"{gsub(/W/,"",$2); print $2}')
+if [[ -n $STOCK_RATE ]]; then
+  WATTS=${STOCK_RATE#-}
+elif [[ -n $bat && -f $bat/power_now ]]; then
+  # µW, negative while discharging on macsmc. An empty or garbage read (kernel
+  # races, permission hiccups) must omit the line entirely rather than emit a
+  # bogus -0.0 that would render as "-0 W".
+  raw=$(cat "$bat/power_now" 2>/dev/null)
+  if [[ $raw =~ ^-?[0-9]+$ ]]; then
+    WATTS=$(awk -v v="$raw" 'BEGIN{printf "%.1f", (v < 0 ? -v : v) / 1000000}')
+  fi
+fi
+if [[ -z ${WATTS:-} && -n $bat && -f $bat/current_now && -f $bat/voltage_now ]]; then
+  # µA × µV = pW, so watts needs 10^12, not 10^6. current_now is signed on
+  # macsmc, and the same numeric guard applies to both reads.
+  cnow=$(cat "$bat/current_now" 2>/dev/null)
+  vnow=$(cat "$bat/voltage_now" 2>/dev/null)
+  if [[ $cnow =~ ^-?[0-9]+$ && $vnow =~ ^-?[0-9]+$ ]]; then
+    WATTS=$(awk -v i="$cnow" -v u="$vnow" 'BEGIN{p=i*u; printf "%.1f", (p < 0 ? -p : p) / 1000000000000}')
+  fi
+fi
+
+if [[ -n $WATTS ]]; then
+  printf 'watts\t%s\n' "$WATTS"
+fi
+
+# Busy jiffies only: user+nice+system+irq+softirq+steal. Idle and iowait are
+# excluded so per-process shares are shares of CPU activity — with idle in the
+# denominator the idle time would surface as "everything else" watts. Guest
+# time is already counted inside user (kernels since 2.6.33, per proc(5)), so
+# summing the guest column as well would double-count it. The per-process side
+# matches: utime in /proc/<pid>/stat likewise includes guest time.
+printf 'cputotal\t%s\n' "$(awk '/^cpu /{print $2+$3+$4+$7+$8+$9}' /proc/stat)"
+
+# comm sits between the first "(" and the last ")" of a stat line and may
+# contain spaces, slashes, and unbalanced parens, so anchor at the last ")":
+# everything after it splits cleanly, with utime at field 12 and stime at 13
+# (shifted by two because pid and comm are fields 1 and 2 of the raw line).
+cat /proc/[0-9]*/stat 2>/dev/null | awk '
+{
+  tail = $0; sub(/.*\)/, "", tail)
+  head = substr($0, 1, length($0) - length(tail) - 1)
+  op = index(head, "(")
+  pid = substr(head, 1, op - 1); gsub(/^ +| +$/, "", pid)
+  comm = substr(head, op + 1)
+  split(tail, f, " ")
+  print "p\t" pid "\t" (f[12] + f[13]) "\t" comm
+}'

--- a/shell/plugins/panels/power/sampler.sh
+++ b/shell/plugins/panels/power/sampler.sh
@@ -7,7 +7,7 @@
 # Lines:
 #   watts\t<absolute battery flow in watts>
 #   cputotal\t<busy jiffies on the aggregate cpu line of /proc/stat>
-#   p\t<pid>\t<utime+stime jiffies>\t<comm>
+#   p\t<pid>\t<utime+stime jiffies>\t<comm>\t<rss kB>
 
 WATTS=""
 bat=""
@@ -56,11 +56,62 @@ fi
 # matches: utime in /proc/<pid>/stat likewise includes guest time.
 printf 'cputotal\t%s\n' "$(awk '/^cpu /{print $2+$3+$4+$7+$8+$9}' /proc/stat)"
 
+# System vitals. Two CPU denominators exist on purpose: cputotal above is
+# busy jiffies only (per-process shares must be shares of CPU activity), while
+# system CPU% needs busy over ALL ticks including idle and iowait — so the
+# vitals pair below carries its own all-ticks total. cpu_busy repeats
+# cputotal's value under a self-describing name; cputotal itself stays as the
+# attribution key so that consumer is untouched.
+awk '/^cpu /{
+  busy = $2+$3+$4+$7+$8+$9
+  printf "cpu_busy\t%d\ncpu_total\t%d\n", busy, busy+$5+$6
+}' /proc/stat
+
+# RAM: MemTotal/MemAvailable from /proc/meminfo, in kB. MemAvailable (not
+# MemFree) is what "how much can I still use" means, per proc(5).
+awk '
+  /^MemTotal:/ { total = $2 }
+  /^MemAvailable:/ { avail = $2 }
+  END {
+    if (total > 0) printf "mem_total_kb\t%d\n", total
+    if (avail > 0) printf "mem_avail_kb\t%d\n", avail
+  }' /proc/meminfo
+
+# GPU utilization: first user-readable source wins; when none exists the line
+# is simply omitted (echo silence, like watts) and the panel hides the row.
+# amdgpu exposes a busy percentage per card; nvidia-smi is probed only when
+# already on PATH and only behind a 50 ms timeout so a wedged driver can never
+# stall the 1 Hz sampling loop. debugfs nodes are root-only at runtime and
+# therefore disqualified as panel sources even where they exist.
+GPU=""
+for g in /sys/class/drm/card*/device/gpu_busy_percent; do
+  if [[ -r $g ]]; then
+    v=$(cat "$g" 2>/dev/null)
+    if [[ $v =~ ^[0-9]+$ ]]; then
+      GPU=$v
+      break
+    fi
+  fi
+done
+if [[ -z $GPU ]] && command -v nvidia-smi >/dev/null 2>&1; then
+  v=$(timeout 0.05 nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits 2>/dev/null | head -n1 | tr -d ' ')
+  [[ $v =~ ^[0-9]+$ ]] && GPU=$v
+fi
+if [[ -n $GPU ]]; then
+  printf 'gpu_pct\t%s\n' "$GPU"
+fi
+
 # comm sits between the first "(" and the last ")" of a stat line and may
 # contain spaces, slashes, and unbalanced parens, so anchor at the last ")":
 # everything after it splits cleanly, with utime at field 12 and stime at 13
 # (shifted by two because pid and comm are fields 1 and 2 of the raw line).
-cat /proc/[0-9]*/stat 2>/dev/null | awk '
+# rss comes from statm, read per pid inside the awk: a pid that exits
+# mid-scan makes getline return -1 (rss 0) instead of aborting — a plain
+# multi-file awk dies fatally on the first vanished /proc entry, which the
+# constant process churn on a busy box turns into intermittent empty or
+# truncated snapshots. rss is field 2 of statm in pages — pagesize varies
+# (16K on Asahi, 4K typical elsewhere), so multiply by getconf PAGESIZE.
+cat /proc/[0-9]*/stat 2>/dev/null | awk -v PG="$(getconf PAGESIZE)" '
 {
   tail = $0; sub(/.*\)/, "", tail)
   head = substr($0, 1, length($0) - length(tail) - 1)
@@ -68,5 +119,11 @@ cat /proc/[0-9]*/stat 2>/dev/null | awk '
   pid = substr(head, 1, op - 1); gsub(/^ +| +$/, "", pid)
   comm = substr(head, op + 1)
   split(tail, f, " ")
-  print "p\t" pid "\t" (f[12] + f[13]) "\t" comm
+  rss = 0
+  if ((getline mline < ("/proc/" pid "/statm")) > 0) {
+    split(mline, m, " ")
+    if ((m[2] + 0) > 0) rss = int(m[2] * PG / 1024)
+  }
+  close("/proc/" pid "/statm")
+  print "p\t" pid "\t" (f[12] + f[13]) "\t" comm "\t" rss
 }'


### PR DESCRIPTION



> **UPDATE 2 — grayscale by load.** The panel left the color palette
> entirely: every surface speaks foreground-at-load. The system block/row
> leads in white (the machine itself); a process's ink dims with its share
> of the bar's busiest process (0.35..1.0), in the table marks, the metric
> cells, and every composition bar segment. Identity is positional
> (biggest-to-lightest, mirroring the table) and by label; brightness is
> magnitude. This matches the shell's native monochrome language — and
> makes the panel theme-proof by construction (no theme can clash with
> ink). Suite unchanged at 138 asserts.

> **UPDATE — operator review round (latest).** After living with the panel,
> three simplifications landed on this branch (see the newest commit):
>
> 1. **The system-draw watts meter is gone.** It duplicated the stock
>    battery pill's number. The per-process attribution stays; the Color
>    surface loses its `green`/`yellow` keys (no remaining consumers).
> 2. **The composition bars mirror the table.** The shade lattice retired —
>    the table row's mark is the single color authority, bars render the
>    same hue at full strength, segments ordered biggest-to-lightest with
>    the system block leading. Canonical hue order is gone with the lattice.
> 3. **"base load" and "everything else" are one row now: System** (the
>    idle floor plus the unattributed tail), first in the table and on
>    every bar. The old floor-vs-tail distinction read as a mystery second
>    "system" — the one-reality invariant (System + processes = whole) is
>    unchanged and still fuzz-tested.
>
> Round-by-round notes below describe earlier states; where they mention
> the Draw meter, lattice shading, or canonical hue order, this update
> supersedes them. Suite now 138 asserts (the lattice's test machinery
> retired with it).

Stacked on #8860 (power-hungry): this PR's own delta is `git diff 76e0269c power-panel-vitals` — +1041/−30, the four files below. The first commits in the diff list belong to #8860.


### The problem

The Power Hungry panel answers "who is eating my battery". The companion
questions — "how hard is the machine working" and "how much memory does
the culprit hold" — still require other tools. This adds a compact SYSTEM
section with meters, and a per-process memory column on the attribution
rows, all riding PR #1's sampler so nothing can disagree.

### What this adds

- **Sampler keys**: `cpu_busy` + `cpu_total` (busy jiffies, and busy+idle
  ticks — see the two-denominators note), `mem_total_kb`/`mem_avail_kb`
  from `/proc/meminfo`, `gpu_pct` from the first user-readable GPU source,
  and per-pid RSS on the existing `p` lines from `/proc/<pid>/statm`.
- **`Model.buildSystemRows(prev, next, drawWatts)`**: pure, node-tested,
  returns `{label, value, meter}` rows in fixed order — CPU, RAM, GPU,
  Draw. `meter` is 0..1 for a progress bar or −1 when the row has no bar
  (a dash). CPU shows the stock `—` until a second snapshot exists; GPU
  appears only when a source was found; Draw appears only while
  discharging, meter scaled so the 20 W/40 W thresholds land at half and
  full bar.
- **`buildTopProcesses` rows carry metric cells** (CPU, RAM, W while
  discharging — one mini-meter per column in a fixed grid; the old
  joined-string payload was dead data and is gone): per-comm RAM
  aggregated exactly like jiffies, rendered as a RAM cell beside the CPU
  share.
- **Panel**: a SYSTEM section drawn with the battery progress bar's own
  track-and-fill idiom (rounded track at foreground alpha, foreground
  fill) scaled to a slim meter — no new widget, no new Ui component.
  Fills snap at the 1 Hz cadence: no width `Behavior`s anywhere in this
  feature (round 5 removed them; the stock battery bar's own animations
  are stock and untouched). The Draw meter's fill grades green under
  20 W, yellow under 40, red beyond, via the Color singleton's newly
  surfaced theme `green`/`yellow` keys (all themes define them; the
  mapping follows the existing `urgent`←red idiom). This meter is what
  consumes those keys, which is why the 6-line Color.qml change lives
  in this PR.

### Round 12: system-baseline-first, size-descending blocks

The reviewer's final ordering language, superseding round 11's
bar-follows-table correspondence: each composition bar now leads with a
**SYSTEM block** — the table's system-anchor concept made spatial, in
the same foreground treatment (cross-surface concept reuse: the anchor
row IS the machine, the leading block IS the machine) — then lays its
process blocks **largest-to-smallest by the bar's own metric**, then the
idle/available frame. The SYSTEM block measures what the old rest
segment measured: unattributed busy on the CPU bar, used memory beyond
the table set's RSS on the RAM bar. The W bar is unchanged — base-first
already satisfies the mandate, its else tail being a different concept.
The table keeps its single shared rank; per-bar order may differ from it
and between bars **by design** — bars are self-sorted visualizations,
the table is the ranking. Round 11's lasting contributions survive:
the one visible set, one ranking basis for the TABLE, and the death of
the old RSS-ranked membership. Lattice colors, separators, gap budget,
snap fills, no-text rules untouched — order only. Verified live on the
discharging path: the CPU bar's leading run is the foreground SYSTEM
block, followed by size-descending lattice-shaded process segments.

### Round 11: bars follow the process list order

**Superseded by round 12** (kept for the decision record): the round-11
correspondence asserts were REPLACED by round-12 size-descending,
SYSTEM-first asserts. On the CPU bar the two coincide — table rank IS
size there, which is why the ×50 permutation fuzz still passes — but the
RAM bar now self-sorts by RSS and legitimately diverges from table order.

The reviewer's decision: **correspondence over positional calm** — all
three composition bars lay their process segments out left-to-right
exactly as the table reads top-to-bottom, on the table's ONE shared
ranking basis (CPU busy-share). The RAM bar's historical divergence —
its own top-N ranked by RSS — is removed here: it shows the table's
comms with their RSS widths, the rest segment absorbing used memory the
table set doesn't cover. Base stays first on the watts bar, else/rest
follow the ranked processes, idle/available frame last; lattice colors,
separators, gap budget, snap fills, and no-text rules untouched — order
only. **The tradeoff, stated honestly**: round 9 introduced canonical
hue-major order because round 8's rank-coupled group order relocated
whole hue blocks — the right fix with the tool it had. With per-comm
lattice-colored segments that disease no longer exists: a rank swap now
moves exactly the swapped segments — discrete, meaningful motion, with
identity preserved by the stable colors. Positional stability was
sacrificed for list-correspondence, by reviewer choice. Correspondence
is asserted in tests (segment sequence == table rank sequence, including
under rank permutation, ×50 fuzz — carried into round 12 only in this
coincidental CPU-bar form; the round-12 SYSTEM-first/size-descending
asserts are the governing ones) and spot-checked live: the
bar's leading hue sequence matched the table's top accent sequence
(cyan, magenta = the two dominant comms); deeper per-segment pixel
extraction is unreliable at small widths (shade × intensity compositing
at 1 Hz) and left to the fuzzed Model guarantee.

### Round 10: the shade lattice, deterministic claim resolution

The reviewer's verdict on three hues: too much collision. Identity is
now a **nine-slot lattice** — the collision-free trio × three fixed
opacity steps (**0.5 / 0.75 / 1.0**; the lowest step stays clearly above
the panel's 0.12-alpha track at panel scale — verified live on the
validation theme, where four distinct slots rendered simultaneously in
both the table accents and the bars). Zero new RGB; the 22-theme
guarantee is intact. Both coordinates derive from the one FNV-1a hash:
**hue from the low bits, shade from the next bits**, decorrelation
tested over a realistic corpus.

**Assignment is deterministic claim resolution** over the visible set:
each comm's nine-slot preference list starts at its hash slot, walks the
SAME hue's other shades first (hue identity survives displacement; only
the shade yields), then the other hues in hash-derived cyclic order.
Claims process in claim-strength order — rank first, name lexicographic
— each taking its first free slot; greedy-by-strength IS the
displacement fixed point in a single pass, so termination is
structural. **Stability contract, stated honestly**: an uncontested
comm keeps its hash slot forever; a contested comm's displacement is
deterministic — top ranks are the most stable, and shades yield before
hues; assignment depends only on the visible set and its rank (fuzzed
×100: deterministic, unique slots, zero unassigned below exhaustion).
This supersedes round 8's "three hues, accepted collisions" language:
collisions are now resolved, not accepted. Badges are demoted to the
exhaustion path — more than nine visible comms — which a top-N table
practically never reaches; the round-9 fixed badge slot stays for that
path. One function over one visible set feeds every surface (accents at
their shade, cell fills with intensity × shade composed
multiplicatively, and bar segments), whose order becomes lattice order —
hue-major, shade-minor — making bar layout fully rank-independent below
exhaustion: segment order now changes only with membership. **Superseded
twice over**: round 11 coupled bar order back to table rank; round 12
settled the final semantics — bars self-sort (SYSTEM block first, then
size-descending by each bar's own metric), so order tracks per-bar size —
neither rank-independent nor table-coupled.

### Round 9: restored bar geometry, canonical order, badge slot discipline

Round 8 bought stable hues at two costs The reviewer caught ("lost a bit
of the geometries on the bars and horizontal space usage calmness").
Both reversed, hues kept. **Un-merge**: composition bars render
per-comm segments again, each in its stable hashed hue, separated by
constant track-colored gaps — the geometry reads through boundaries even
between same-hue neighbors. Gap width is a fixed Style constant; the
total budget comes from an exported `SPLIT_MAX_SEGMENTS` (top-N + rest +
idle; the watts bar's base + top-N + else fits the same count), so fills
scale identically across refreshes and resources regardless of how many
segments are visible. **Canonical order**: blue-block comms first, then
cyan, then magenta (rank only within a hue), then rest, then
idle/available — rank shuffles reorder members inside their hue block
and shares breathe, but hue blocks never relocate; verified by fuzzing
rank permutations and by a staged live shuffle (a burner process
reordered the top ranks: the RAM bar's hue sequence was pixel-stable;
the CPU bar's magenta block legitimately EMPTIED when its members left
the top-N — membership churn, not relocation, and canonical order never
inverted). **Badge slot**: the collision numeral renders in a fixed
reserved micro-slot after the accent mark — empty when unbadged — so
badges appearing or clearing mid-refresh cannot shift the line; the
label start is a constant offset. Steady-state motion re-certified
(round-5 proof repeated): text-zone diffs are content ticks (values
change at 1 Hz by design; positions are fixed right-aligned slots),
fills step ~0.7% of the block.

### Round 8: name-hashed stable identity colors

Colors followed table rank, so every rank shuffle swapped hues — nothing
learnable. Identity is now the process NAME: **FNV-1a** hashed into the
collision-free palette — chosen for exactly this job (short, well-known,
good distribution over short strings; no randomness, no seed state; the
multiply stays under 2^53 with an explicit uint32 fold so every QML JS
engine agrees bit-for-bit). Same comm = same hue everywhere and forever.
Verified live: a comm's accent mark is pixel-identical across refreshes
that shuffled the table's ranking.

Collisions get both reviewer strategies on their best surfaces. **Table
rows → ordinal badges**: among the visible set, the first member of a
hue stays clean and later members carry a tiny numeral in the gutter —
plain digits rather than superscript glyphs, because glyph coverage at
the panel's font size is a gamble plain digits never take; the hue is
identity, the badge only breaks simultaneous ties, and a lone member
never carries one. **Composition bars → grouped segments**: same-hue
comms merge into one segment per hue (share = sum of members, group
order = first appearance by rank; base/rest/idle/avail/else untouched) —
the bar honestly shows what color can distinguish while the table below
names the members. Grouped bars still sum to their whole (fuzz ×50).
Non-process rows (system anchor foreground, base load, everything-else
muted) never join the hash palette. The order-based assignColorKeys is
retired under the same signature; distribution over a 15-comm realistic
corpus spreads across all three hues with no pathological clustering.

### Round 7: one CPU denominator, system anchor row

Operator finding: "those boxes seem to be illustrating two different
realities" — process CPU cells measured share-of-work (busy jiffies,
>100% possible across cores) while the global CPU bar measured
share-of-capacity. Both honest, mutually unreconcilable. Process CPU
cells now use the single denominator the global bar and the CPU
composition bar already use: jiffies over ALL ticks including idle.
**Process cells plus the everything-else row now sum to the global CPU%
by construction** (fuzz-verified ×200). The multicore >100% honesty note
moves to this section: the old number was truthful about cross-core
jiffies; the new number is truthful about machine capacity — a semantic
switch, documented rather than silently dropped. Ranking is unchanged
(share-of-busy and share-of-total order identically within a snapshot;
the busy fraction is a common factor — asserted by test).

A **`system` anchor row** leads the table: the machine itself in theme
foreground (neutral — never literal white, no hardcoded RGB),
full-intensity cells on the same grid and scale — global CPU%, RAM
used%, and total draw while the watts basis is active (its W cell fills
the column: the draw IS the whole the rows below decompose). The
everything-else row becomes a whole-machine remainder row — CPU
remainder closing the sum to global CPU%, used RAM beyond the listed
processes' RSS (clamped at zero; shared-page double counting is the
standing disclosure), and the watts tail — and its existence is no
longer gated on watts display-noise alone. RAM now visibly reconciles:
the system row shows the whole, the rows show parts, and the gap is the
shared/kernel memory the draft has always disclosed. **Naming**: the
global row is `system`; the attribution floor row is renamed `base
load` — the two "system" concepts cannot be confused. The CPU
composition bar already shared the denominator and is unchanged; the
anchor-vs-rows reconciliation is asserted in tests (CPU exact; RAM with
the ≥ gap; W exact in the model — the DISPLAYED numbers round: whole
watts per cell and the anchor at ≥10 W, one decimal below, plus the
else-row's ≤0.5 W tail gate, so the visible sum can drift up to ~1.4 W
worst observed, >0.4 W on 18% of fuzz draws — a display bound, not a
model error) and spot-checked in the live capture
(system 32% ≈ 13.8% + 1.8% + 1.5% + remainder).

### Final round: the watts basis keys on battery state, not plug state

Earlier rounds keyed the W column, the Draw row, and the watts
attribution on `UPower.onBattery` — the daemon's plug-side composite. In
the marginal-adapter wedge (adapter latched online in UPower while
delivering nothing, battery actually draining) that wrongly took the AC
path and hid watts while the machine ran on battery. The basis is now
the battery device's own state: watts render whenever
`displayDevice.state === Discharging` — there the battery is the power
source, the sampled discharge rate is real system draw, and attribution
is valid, wedge included. Charging, full, and pending keep per-process
watts hidden (adapter input unreadable — physically unattributable).
The rule is one pure function (`Model.wattsBasis`, unit-tested including
the wedge and state flapping); the stock panel's own mode language (hero
label, stats rows, profile picker) still speaks plug-state and is
untouched. **The earlier caveat "drain-under-external-power takes the AC
path by design" is obsolete** — superseded by this keying. The wedge
cannot be staged on demand; it is unit-proven and the normal
charging/full paths are live-verified (W column correctly absent).

### Viz round 5: fixed tabular grid, static text, snap fills

Operator round-4 finding: "a bit much of moving horizontally." At the
1 Hz refresh, fill-anchored value text rode the fill edge, cells flexed
as widths recomputed, and the panel never sat still. The POWER HUNGRY
section now sits on a fixed grid, recalculated only on basis change
(AC↔DC column set — the one allowed motion) or panel width: the comm
column is sized once for the kernel's 15-char comm cap
(`Model.COMM_MAX_CHARS`, measured via TextMetrics, elided beyond) with
the identity accent mark in its own fixed slot; metric cells split the
remaining track equally (no metric starves at panel width — two columns
get ~200px, three ~135px, against values of ~40–55px); header labels
right-align into the same column slots as the values — the last column
lands exactly, intermediate labels sit within ~4px at scale 1 (known
residual, deliberately left). All value text is
right-aligned inside its fixed cell — same pixel column every refresh
regardless of fill length — and fills are capped short of the text so
type never sits on a fill. No width Behaviors on any fill in this
feature; fills step at the cadence, geometry never moves. The SYSTEM
composition bars lose their in-segment comm names (positions coupled to
segment boundaries = motion); their values were already right-anchored
and their segments already snap. The stock battery bar's animations are
stock and untouched. The motion proof: two captures 1.5 s apart with the
panel live — the value-text zone differs by 0.06% (antialiasing noise;
fill-anchored text would move ~40px), fills step ~1% of the block, and
the comm column's 2.3% is rank-reshuffle content change (which comm sits
in a row), not geometry.

### Viz round 4: one graphic line per process, metric cells

Round 3 drew two graphic lines per process (impact fill + RAM sub-bar) and
The reviewer read it as noise. Each POWER HUNGRY row is now ONE track of
metric bar-cells beneath fixed column headers (CPU, RAM, W while
discharging), so the layout is learned once and every process is a single
line. Cells use metric-type colors — CPU blue, RAM cyan, W magenta from
the collision-free set; W keeps magenta rather than categorical grading
because the green/yellow/red thresholds grade SYSTEM draw (the Draw bar),
and per-process watts carry no honest absolute thresholds. Normalization
per metric: CPU = process share clamped for display while the number
tells the multicore truth (200% possible); RAM = comm RSS / MemTotal;
W = attributed watts / measured draw; each cell's intensity ramps within
its own column (0.35 floor at zero, 1.0 at the column's max, W normalized
against the column's largest cell whichever row owns it). Comm identity
moves to a small accent mark on the row label — some cross-referencing to
the SYSTEM composition bars survives; full per-comm cell coloring was the
price of metric-colored columns, accepted per the clarity mandate. GPU is
a reserved column (accent) that never renders on driver-silent hardware;
the cell structure lights up when a future fdinfo builder supplies it.
Zero-state handling: zero-RSS comms omit the RAM cell; AC rows never
carry W cells; the column set derives from the rows themselves.

### Viz round 3: bars exclusively, in-bar numbers, intensity semantics

Plain text rows are gone. Every POWER HUNGRY row is now a full-width bar:
comm label in the left gutter, the comm-colored fill growing from the
gutter sized by the row's impact and faded by an intensity ramp (top row
full opacity, tail rows toward a 0.35 floor, normalized by the top share),
the value text anchored just past the fill's end, and a thin RSS sub-bar
beneath in the same color. SYSTEM bars put labels in the gutter and values
at the right edge, ramp their intensity with utilization (0.45 idle → 1.0
full — criticality as intensity of existing semantic colors; the
categorical green/yellow/red stays reserved for watts), and wide segments
carry their comm's name in whichever theme color contrasts more with the
fill.

**Text placement decision:** all text renders on the unfilled track in the
panel foreground — the same surface every stock panel row already proves
legible on all 22 themes. In-fill text contrast cannot be guaranteed
theme-wide (light themes put light backgrounds under pastel fills) without
hardcoded RGB, so the escape hatch is taken deliberately; wide segments'
in-fill names use a luminance pick between the theme's own foreground and
background — adaptive, still zero hardcoded RGB.

**Parity-launch note (ops):** running fork code with the stock
`OMARCHY_PATH` in its environment does NOT keep keybinds alive during
test mounts — `qs ipc -p <path>` (what `omarchy-shell` and therefore every
bind executes) keys the shell instance by its `-p` config path, and the
env var never enters instance matching. Verified empirically: a fork-path
shell with stock env answers fork-path pings and stays invisible to the
bind path. Test mounts must use the plain swap with the binds-dead caveat.

### Viz round 2: impact meters and resource splits

Every POWER HUNGRY row gains an **impact meter** — the share that ranks it
(CPU share on external power; while discharging the attributed watts, which
hold the same proportion by construction, so the fill matches both numbers
the row displays). The base and tail rows meter their slice of the whole
draw. Meters reuse the vitals row component with the row's comm color, so
each row doubles as its own legend entry for the bars.

The SYSTEM meters become **composition bars**: CPU segments = top comms +
other busy + idle (shares of all ticks, summing to exactly one, idle
rendered as the unfilled track); RAM = top comms by RSS + other used +
available (of MemTotal); GPU renders only when a source exists. While
discharging, POWER HUNGRY additionally shows **the attribution as one
bar** — base floor, top processes, tail — summing to the measured draw:
the model made visible, anchored directly above the rows that decompose
it.

**Comm colors are theme-semantic and stable across every surface.** The
palette is the three non-threshold hues every theme defines and no other
key collides with — blue, cyan, magenta (inventoried across all 22:
`accent` equals `blue` on 17 themes and `magenta` on lumon; orange/brown
exist on 19/22; and the `bright_*` variants equal their base hue on 54%
of theme-key pairs, so no six-key collision-free set exists).
They are assigned deterministically by top-process order through one
resolver (`segmentColor`) feeding bars and row meters alike, so a comm
cannot change color between surfaces; `accent` is demoted to the watts
base-segment only. Beyond three distinct comms the palette cycles and two
apps can share a hue — an accepted limit of theme palettes (retro-82
collapses blue==magenta within the palette by design), disambiguated by
row order, chosen over hardcoded RGB or a same-hue opacity ladder. The
watts base-segment rides `accent`, which shares its hue with the blue
comm on those 17 themes (magenta on lumon) — a pre-existing residual
this palette strictly reduces. green/yellow stay reserved
for Draw grading.

Split lists sum to their whole **by construction**: no display-noise
thresholding (a sub-pixel segment renders as nothing, which is
invisibility enough), fuzz-tested ×200 per resource. The one honest
exception: RAM sums above one when per-process RSS double-counting
exceeds the used slice (shared pages counted per process) — the bar
visibly overflows rather than being rescaled into a lie; asserted in
tests as expected behavior.

Segment delegates bind widths through ids, never `parent`: under this
Quickshell a Repeater delegate's `parent` resolves the zero-width
Repeater during construction and the binding never re-fires (found live,
fixed, and why the watts bar worked while the nested rows didn't).

### Why two CPU denominators

PR #1's `cputotal` deliberately excludes idle and iowait: per-process
shares must be shares of CPU *activity*, or idle time would surface as
"everything else" watts. System CPU% wants busy over *all* ticks. The
vitals pair carries its own all-ticks total, `cpu_busy` repeats the busy
value under a self-describing name, and `cputotal` stays untouched as the
attribution key. A maintainer squashing both PRs may drop the alias.

### Per-process memory semantics (the honest caveats)

- RSS comes from `/proc/<pid>/statm` field 2 × `getconf PAGESIZE` — never
  a hardcoded page size (Asahi runs 16K pages; assuming 4K would misread
  RAM 4×). Verified live: sampler-reported RSS matches statm exactly.
- **RSS sums double-count shared pages.** Ten processes sharing one libc
  each count it; the per-comm column is a size hint, not an addition that
  should sum to system RAM used. This is inherent to per-process memory
  accounting (the same caveat top/htop carry) and stated rather than
  hidden.
- Aggregated by comm like CPU share, from the newest snapshot (memory is
  a level, not a counter — no diffing).

### Sampler performance and robustness

- Full run measures **50–53 ms** (p50 51 ms) with statm included — the
  per-pid statm reads add ~2–5 ms over PR #1's sampler because /proc is
  page-cache hot; the 100 ms gate clears with headroom.
- The statm read uses `getline` per pid *inside* the existing awk pass.
  A naive multi-file awk over `/proc/[0-9]*/statm` dies **fatally** the
  first time a pid exits between glob expansion and open — under normal
  process churn that produced intermittent empty or truncated snapshots
  (reproduced, then fixed: `getline` on a vanished file returns −1 and
  the row simply reports rss 0).

### GPU honesty

The GPU row appears only when the sampler found a user-readable
utilization source. On the validation machine (Asahi) there is none — no
`/sys/class/devfreq/` entries, no `gpu_busy_percent` (AMD-only), no
nvidia-smi, and debugfs GPU nodes are root-only (`drwx------`),
disqualified for a user-space 1 Hz sampler. Absence renders as absence.

**Follow-up path (for whoever has the hardware):** per-process GPU time
is readable on amdgpu/i915 via DRM engine fdinfo —
`/proc/<pid>/fdinfo/<fd>` lines like `drm-engine-gpu: 12345678 ns` for
each DRM fd the process holds (what `amdgpu_top` and Hyprland's own
renderer stats use). On Asahi the driver does not expose engine usage
through fdinfo (checked 2026-08-27: Hyprland's fdinfo on this box carries
buffer statistics only), so per-process GPU is omitted rather than
invented. A future sampler pass could emit `p\t…\tgpu_ns` on hardware
that provides it.

### Cross-platform behavior

- **amdgpu**: `/sys/class/drm/card*/device/gpu_busy_percent`, first
  readable value wins — GPU row appears. (Shape per driver docs; not
  live-tested — no AMD hardware at hand; flagged for reviewers.)
- **NVIDIA**: `nvidia-smi --query-gpu=utilization.gpu` only when already
  on PATH, behind `timeout 0.05`, output validated numerically.
- **Asahi / plain Intel integrated**: no user-readable source → row
  omitted (live-verified absence).
- **RAM/CPU/Draw**: `/proc`-only; MemAvailable with a torn-read clamp so
  rows can never show negative or >100%.

### Testing

- Node harness: **156/156 green** across 11 suites — attribution
  invariant (fuzz ×300, ×200 with RAM), vitals, metric cells, watts
  basis, anchor reconciliation (fuzz ×200: CPU rows sum exactly to the
  global, RAM sums-or-exceeds, W whole in the model), lattice claim
  resolution (fuzz ×100), bar sums and permutation (fuzz ×50), and the
  round-12 SYSTEM-first/size-descending asserts. The suite grew
  86 → 105 → 177 through the viz rounds; the post-review cleanup retired
  the 22 asserts that targeted since-removed internals (buildRowImpact,
  assignColorKeys, collisionOrdinals, the joined value payload — those
  invariants live on through the shipped cell/lattice APIs) and added
  one aggregateCommShares share assert: 156. **Canonical home: the
  development workshop repo** (`upstream/tests/power-panel-test.js`,
  with `r12-smoke.js` beside it) — this PR links there rather than
  shipping test files into core.
- Viz round 3 live render (discharging window, ~35 W, theme `ai-engineer`):
  bars-as-rows with in-bar labels and value-at-fill-end confirmed by OCR;
  the intensity ramp confirmed by pixel sampling (full-opacity top fill
  vs a ~0.35-opacity tail fill of the same hue); comm colors and the
  yellow Draw grading intact; journal clean. The RSS sub-bar rides the
  same rendering path as the main fills (pixel-level confirmation at the
  3px scale is ambiguous and noted honestly).
- Sampler guard suite: 10/10; sampler itself unchanged this round (no new
  keys — splits derive from the same snapshots).
- `./test/all`: identical to baseline (3 pre-existing environmental
  failures only). Bar-facing diff still zero bytes.
- **Live render, discharging window** (adapter offline, ~35 W): the watts
  split bar rendered base(accent) + comm(blue) + tail(muted) with fill
  widths matching the attribution (471px ≈ 35 W base of 37 W); POWER
  HUNGRY rows carried watts · CPU% · RAM with impact meters; the SYSTEM
  CPU bar rendered segmented (blue comm + muted rest + idle-as-track,
  ~130px busy of 519px ≈ the live 25% CPU). Two rendering bugs were
  caught live and fixed along the way (post-hoc JS object property
  additions carry no change signal — rows are now built complete before
  assignment; and the parent-width binding staleness above). Journal
  clean throughout.
- Captures: segmented CPU bar `~/Pictures/screenshot-2026-08-27_14-47-34.png`,
  watts split + attribution rows `~/Pictures/screenshot-2026-08-27_14-38-28.png`,
  RAM columns + stock bar `~/Pictures/screenshot-2026-08-27_13-24-15.png`.

### Diff summary (`git diff 76e0269c power-panel-vitals --numstat` — vs PR #1's tip)

```
 shell/Commons/Color.qml                |  +14  −0
 shell/plugins/panels/power/Model.js    | +507 −19
 shell/plugins/panels/power/Panel.qml   | +460  −8
 shell/plugins/panels/power/sampler.sh  |  +60  −3   (viz round 1 only)
                                           ———————
 total (this PR)                        | +1041 −30
```

---

## Operator checklist before pushing

1. Open PR #1 first; rebase this branch once it lands.
2. ~~Discharge-window capture~~ done (`14-38-28.png` — watts split bar,
   impact meters, yellow Draw row at 37 W).
3. Optional: amdgpu box live-check of the `gpu_busy_percent` path.
4. Decide the `cputotal`/`cpu_busy` alias question for the squashed view.






