### PR TITLE
Fix battery status reading the wrong device on multi-battery hardware

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -18,10 +18,17 @@ case "${1:-}" in
     ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
-[[ -z $battery ]] && exit 0
+# Read the aggregate battery, not an individual one: hardware with more than
+# one battery (e.g. ThinkPads with a Power Bridge bay) enumerates several BAT*
+# devices, and an idle/empty one sorts first alphabetically just as often as
+# the real one does. UPower's DisplayDevice already merges every battery into
+# one correct reading, the same source the rest of the shell (bar icon, panel
+# meter) uses — so this stays consistent with what's on screen.
+display_device_path="/org/freedesktop/UPower/devices/DisplayDevice"
+battery_info=$(upower -i "$display_device_path" 2>/dev/null)
 
-battery_info=$(upower -i "$battery")
+present=$(awk '/present:/ { print $2; exit }' <<<"$battery_info")
+[[ $present != "yes" ]] && exit 0
 
 percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$battery_info")
 capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$battery_info")
@@ -42,28 +49,47 @@ time_remaining=$(awk '/time to (empty|full)/ {
   exit
 }' <<<"$battery_info")
 power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
-native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
-battery_path="$power_supply_path/$native_path"
+state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
 
 # UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
 # the instantaneous sysfs reading when available so the open panel stays live.
-if [[ -r $battery_path/power_now ]]; then
-  power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
-elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
-  power_rate_raw=$(awk \
-    -v microamps="$(<"$battery_path/current_now")" \
-    -v microvolts="$(<"$battery_path/voltage_now")" \
-    'BEGIN { print microamps * microvolts / 1000000000000 }')
-fi
+# DisplayDevice has no native-path of its own, so sum every real battery's
+# live reading instead of one device's; an idle/empty battery reads 0 and
+# does not affect the total, so this is a no-op on single-battery hardware.
+have_live_rate=false
+live_rate_total=0
+for supply in "$power_supply_path"/BAT*; do
+  [[ -d $supply ]] || continue
+
+  reading=""
+  if [[ -r $supply/power_now ]]; then
+    reading=$(awk -v microwatts="$(<"$supply/power_now")" 'BEGIN { print microwatts / 1000000 }')
+  elif [[ -r $supply/current_now && -r $supply/voltage_now ]]; then
+    reading=$(awk \
+      -v microamps="$(<"$supply/current_now")" \
+      -v microvolts="$(<"$supply/voltage_now")" \
+      'BEGIN { print microamps * microvolts / 1000000000000 }')
+  fi
+
+  if [[ -n $reading ]]; then
+    have_live_rate=true
+    live_rate_total=$(awk -v total="$live_rate_total" -v reading="$reading" 'BEGIN { print total + reading }')
+  fi
+done
+[[ $have_live_rate == "true" ]] && power_rate_raw=$live_rate_total
 
 power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
   rounded = sprintf("%.1f", rate)
   sub(/\.0$/, "", rounded)
   print rounded
 }')
-state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
-threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+
+# Charge thresholds are ACPI-level policy, not a per-battery reading, so
+# UPower reports the same values on every battery device it exposes; reading
+# just the first one is fine here, unlike the aggregate fields above.
+threshold_info=$(upower -i "$(upower -e 2>/dev/null | grep BAT | head -n 1)" 2>/dev/null)
+threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$threshold_info")
+threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$threshold_info")
 
 [[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
 [[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)
@@ -107,7 +133,10 @@ if [[ $shell_output == "true" ]]; then
   printf 'size\t%s\n' "${capacity}Wh"
   printf 'time\t%s\n' "$time_remaining"
 
-  cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | head -1)
+  # Same reasoning as the live wattage above: take the highest reading rather
+  # than the first, so an idle/empty battery reporting 0 cycles doesn't hide
+  # a real battery's actual count.
+  cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | sort -rn | head -1)
 
   [[ -n $cycles ]] && printf 'cycles\t%s\n' "$cycles"
 

--- a/test/shell.d/battery-status-multi-battery-test.sh
+++ b/test/shell.d/battery-status-multi-battery-test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Reproduces a dual-battery laptop (e.g. a ThinkPad with a Power Bridge bay):
+# BAT0 is empty/idle and reports all-zero fields, BAT1 is the real battery.
+# upower's DisplayDevice correctly aggregates both into one reading; a naive
+# "first BAT* device" read does not, and lands on BAT0's zeroes instead.
+mkdir -p "$tmp_dir/bin"
+mkdir -p "$tmp_dir/power/BAT0"
+mkdir -p "$tmp_dir/power/BAT1"
+printf '0\n' >"$tmp_dir/power/BAT0/power_now"
+printf '900000\n' >"$tmp_dir/power/BAT1/current_now"
+printf '12000000\n' >"$tmp_dir/power/BAT1/voltage_now"
+
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *DisplayDevice ]]; then
+  cat <<'INFO'
+  present:              yes
+  state:                discharging
+  energy:               20.16 Wh
+  energy-full:          22.09 Wh
+  energy-rate:          5.573 W
+  time to empty:        3.6 hours
+  percentage:           91.2177%
+INFO
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *BAT0 ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  present:              yes
+  state:                not-charging
+  energy:               0 Wh
+  energy-full:          0 Wh
+  energy-rate:          0 W
+  percentage:           0%
+  charge-start-threshold: 75%
+  charge-end-threshold:   80%
+INFO
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *BAT1 ]]; then
+  cat <<'INFO'
+  native-path:          BAT1
+  present:              yes
+  state:                discharging
+  energy:               20.16 Wh
+  energy-full:          22.09 Wh
+  energy-rate:          5.573 W
+  time to empty:        3.6 hours
+  percentage:           91.2177%
+  charge-start-threshold: 75%
+  charge-end-threshold:   80%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'percentage\t91%' <<<"$shell_output" >/dev/null || fail "multi-battery status reports the aggregate percentage, not BAT0's 0%" "$shell_output"
+grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "multi-battery status reports the aggregate state, not BAT0's not-charging" "$shell_output"
+grep -Fx $'size\t22Wh' <<<"$shell_output" >/dev/null || fail "multi-battery status reports the aggregate capacity, not BAT0's 0Wh" "$shell_output"
+grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "multi-battery status sums live sysfs wattage across every battery" "$shell_output"
+grep -Fx $'threshold\t75-80%' <<<"$shell_output" >/dev/null || fail "multi-battery status still reports the charge threshold" "$shell_output"
+
+pass "multi-battery status reports the aggregate battery, not the first enumerated one"

--- a/test/shell.d/battery-status-multi-battery-test.sh
+++ b/test/shell.d/battery-status-multi-battery-test.sh
@@ -8,15 +8,23 @@ tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 
 # Reproduces a dual-battery laptop (e.g. a ThinkPad with a Power Bridge bay):
-# BAT0 is empty/idle and reports all-zero fields, BAT1 is the real battery.
-# upower's DisplayDevice correctly aggregates both into one reading; a naive
-# "first BAT* device" read does not, and lands on BAT0's zeroes instead.
+# BAT0 reports near-zero upower fields, BAT1 is the real battery. upower's
+# DisplayDevice correctly aggregates both into one reading; a naive "first
+# BAT* device" read does not, and lands on BAT0's zeroes instead.
+#
+# The sysfs telemetry deliberately gives BOTH batteries distinguishable
+# nonzero values: BAT0 draws 4.2W with 12 cycles, BAT1 draws 10.8W with 347
+# cycles. That way the assertions below can tell summing every device (15W)
+# apart from picking just one (4.2W or 10.8W), and the max cycle count (347)
+# apart from the first enumerated one (12).
 mkdir -p "$tmp_dir/bin"
 mkdir -p "$tmp_dir/power/BAT0"
 mkdir -p "$tmp_dir/power/BAT1"
-printf '0\n' >"$tmp_dir/power/BAT0/power_now"
+printf '4200000\n' >"$tmp_dir/power/BAT0/power_now"
+printf '12\n' >"$tmp_dir/power/BAT0/cycle_count"
 printf '900000\n' >"$tmp_dir/power/BAT1/current_now"
 printf '12000000\n' >"$tmp_dir/power/BAT1/voltage_now"
+printf '347\n' >"$tmp_dir/power/BAT1/cycle_count"
 
 cat >"$tmp_dir/bin/upower" <<'STUB'
 #!/bin/bash
@@ -80,7 +88,8 @@ shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PA
 grep -Fx $'percentage\t91%' <<<"$shell_output" >/dev/null || fail "multi-battery status reports the aggregate percentage, not BAT0's 0%" "$shell_output"
 grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "multi-battery status reports the aggregate state, not BAT0's not-charging" "$shell_output"
 grep -Fx $'size\t22Wh' <<<"$shell_output" >/dev/null || fail "multi-battery status reports the aggregate capacity, not BAT0's 0Wh" "$shell_output"
-grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "multi-battery status sums live sysfs wattage across every battery" "$shell_output"
+grep -Fx $'rate\t15W' <<<"$shell_output" >/dev/null || fail "multi-battery status sums live sysfs wattage across every battery, not just one device's" "$shell_output"
+grep -Fx $'cycles\t347' <<<"$shell_output" >/dev/null || fail "multi-battery status reports the highest cycle count, not the first enumerated one" "$shell_output"
 grep -Fx $'threshold\t75-80%' <<<"$shell_output" >/dev/null || fail "multi-battery status still reports the charge threshold" "$shell_output"
 
 pass "multi-battery status reports the aggregate battery, not the first enumerated one"

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -22,6 +22,7 @@ fi
 if [[ $1 == "-i" ]]; then
   cat <<'INFO'
   native-path:          BAT0
+  present:              yes
   state:                discharging
   energy:               28.3 Wh
   energy-full:          56.7 Wh


### PR DESCRIPTION
`omarchy-battery-status` picks the first `BAT*` device from `upower -e` and reads percentage, state, capacity, rate, time, and cycles from it directly. On hardware with more than one battery (e.g. a ThinkPad with a Power Bridge bay), the first-enumerated device can be an idle/empty one — so the panel shows a correct icon and meter (both driven by UPower's DisplayDevice elsewhere in the shell) alongside a completely wrong detail row: in the reported case, 0% with 0W/0Wh and no time remaining while the battery was actually near full.

## Fix

- Read UPower's **DisplayDevice** instead — the same aggregate source the bar icon and panel meter already use — so the detail row matches what's on screen.
- Sum the live sysfs wattage refinement across every `BAT*` device (DisplayDevice has no `native-path` of its own); an idle battery reading 0 doesn't affect the total, so this is a no-op on single-battery hardware.
- Take the max cycle count across devices rather than the first, so an idle battery reporting 0 doesn't hide the real count.
- Charge thresholds still come from an individual device: they're per-ACPI-device policy, and UPower reports the same value on every battery object.

## Tests

Added `test/shell.d/battery-status-multi-battery-test.sh`, which stubs a dual-battery machine (idle BAT0 with all-zero fields, real BAT1) and verifies the status output reports the aggregate reading rather than BAT0's zeroes. Both battery test files pass; the full shell suite shows no new failures versus `quattro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Guuwe3XxYQGY1A9rJizAim
