### PR TITLE
Fix background cycling for glob characters in omarchy-theme-set

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -85,7 +85,7 @@ choose_theme_background() {
   current_background=$(readlink "$CURRENT_BACKGROUND_LINK" 2>/dev/null || true)
   index=-1
   for i in "${!backgrounds[@]}"; do
-    if [[ ${backgrounds[$i]} == $current_background ]]; then
+    if [[ ${backgrounds[$i]} == "$current_background" ]]; then
       index=$i
       break
     fi

--- a/test/shell.d/theme-background-cycling-test.sh
+++ b/test/shell.d/theme-background-cycling-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+runtime_dir="$test_tmp/runtime"
+current_state="$test_home/.local/state/omarchy/current"
+mkdir -p "$test_home" "$runtime_dir"
+
+theme="tokyo-night"
+
+set_theme() {
+  HOME="$test_home" XDG_RUNTIME_DIR="$runtime_dir" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+    OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" "$1" >/dev/null
+}
+
+current_background() {
+  readlink "$current_state/background"
+}
+
+# Reapplying the active theme advances to the next background. That lookup
+# compares each candidate against the current symlink, so a filename holding
+# glob characters has to match itself as a literal string.
+set_theme "$theme"
+
+user_backgrounds="$test_home/.config/omarchy/backgrounds/$theme"
+mkdir -p "$user_backgrounds"
+seed=$(find "$current_state/theme/backgrounds" -maxdepth 1 -type f -print -quit)
+[[ -n $seed ]] || fail "test theme ships a background to copy"
+
+glob_background="$user_backgrounds/wall [4k].jpg"
+plain_background="$user_backgrounds/wall-plain.jpg"
+cp "$seed" "$glob_background"
+cp "$seed" "$plain_background"
+
+ln -nsf "$glob_background" "$current_state/background"
+set_theme "$theme"
+[[ $(current_background) != "$glob_background" ]] ||
+  fail "reapplying a theme advances off a background whose name holds glob characters"
+pass "reapplying a theme advances off a background whose name holds glob characters"
+
+# A filename without glob characters in the same position, so the test above
+# cannot pass merely because cycling is broken for everything.
+ln -nsf "$plain_background" "$current_state/background"
+set_theme "$theme"
+[[ $(current_background) != "$plain_background" ]] ||
+  fail "reapplying a theme advances off an ordinary background name"
+pass "reapplying a theme advances off an ordinary background name"


### PR DESCRIPTION
## Problem

Reapplying the active theme cycles to its next background. `choose_theme_background`
does that by finding the current background in the sorted candidate list:

```bash
if [[ ${backgrounds[$i]} == $current_background ]]; then
```

The right-hand side is unquoted, so inside `[[ ]]` it is a **pattern**, not a
literal string. Any wallpaper whose name contains `[`, `]`, `*` or `?` fails to
match itself, the lookup reports no match, and the caller falls back to
`backgrounds[0]`.

```
$ backgrounds=("/bg/a.jpg" "/bg/wall [4k].jpg"); current="/bg/wall [4k].jpg"
$ [[ ${backgrounds[1]} == $current ]] || echo "no match"
no match
```

The visible symptom is worse than picking the wrong wallpaper. User backgrounds
are globbed ahead of the theme's own, so a bracketed name frequently *is*
`backgrounds[0]` — and then the fallback lands on the file already on screen and
cycling silently does nothing at all. Bracketed filenames (`[4k]`, `[1920x1080]`,
`[oc]`) are common in wallpaper packs.

This is the same defect 5b69af6 ("Fix background cycling for glob characters")
fixed in `omarchy-theme-bg-next`, which carried the identical line.
`omarchy-theme-set` was left behind:

```
bin/omarchy-theme-set:88      if [[ ${backgrounds[$i]} == $current_background ]]; then
bin/omarchy-theme-bg-next:32    if [[ ${BACKGROUNDS[$i]} == "$CURRENT_BACKGROUND" ]]; then
```

## Change

Quote the right-hand side, matching the sibling command.

To be explicit, since d1845245 went the other way on purpose: this is not the
"quotes inside `[[ ]]`" style question. `[[ ]]` suppresses word splitting, so
the unary tests in this file (`-n`, `-f`, `-r`) are correct bare and are left
alone. The right-hand side of `==` is the one position where a bare variable
changes meaning, from string comparison to pattern match.

## Test

`test/shell.d/theme-background-cycling-test.sh` drives the real
`omarchy-theme-set` headlessly: it copies a theme background to
`wall [4k].jpg` under the user backgrounds directory, points the current
background at it, reapplies the theme, and asserts the background advanced. A
second case does the same with an ordinary filename in the same position, so
the first assertion cannot pass merely because cycling is broken for everything.

Verified the test fails on the unpatched command and passes with the fix:

```
$ bash test/shell.d/theme-background-cycling-test.sh     # before
not ok - reapplying a theme advances off a background whose name holds glob characters

$ bash test/shell.d/theme-background-cycling-test.sh     # after
ok - reapplying a theme advances off a background whose name holds glob characters
ok - reapplying a theme advances off an ordinary background name
```

## Validation

- `bash test/shell.d/theme-background-cycling-test.sh`
- `bash test/shell.d/theme-staging-test.sh`
- `bash test/shell.d/user-theme-test.sh`
- `bash test/shell.d/bin-style-test.sh`
- `bash -n bin/omarchy-theme-set test/shell.d/theme-background-cycling-test.sh`

`test/shell.d/theme-install-guards-test.sh` has one failing assertion
("refuses a URL it cannot check") on my machine, but it fails identically on a
clean `quattro` checkout and does not touch this command.

## Note

#7718 relocates this comparison into a new branch and preserves the bare
right-hand side, so whichever of the two lands second will want a one-line
rebase. That PR is not a prerequisite for this one — the bug is reproducible on
`quattro` today.
