### PR TITLE
fix(lockscreen): keep password input focused after suspend/wake

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -131,6 +131,7 @@ Item {
 
       TextInput {
         id: passwordInput
+        focus: true
         anchors.fill: parent
         anchors.topMargin: inputField.borderTop
         // Reserve the fingerprint icon's width on both sides so the centered
@@ -215,5 +216,14 @@ Item {
         verticalAlignment: Text.AlignVCenter
       }
     }
+  }
+
+  Timer {
+	  interval: 100
+	  running: root.inputEnabled && !root.authenticatingPassword && !passwordInput.activeFocus
+	  repeat: true
+	  onTriggered: {
+		  root.forcePasswordFocus()
+	  }
   }
 }


### PR DESCRIPTION
When waking the system from suspend, the lock screen completely fails to regain keyboard focus. The password input becomes entirely unresponsive, and the user is effectively locked out of the session, forcing them to switch to a TTY to restart the display manager. 

Solution:

- Added focus: true to the TextInput to ensure default focus behavior.
- Added a fallback Timer at the root level of LockView.qml. It polls every 100ms to force focus on the password input only if the lock screen is active but the input lacks activeFocus. The timer automatically stops (running = false) the moment activeFocus is acquired.