### PR TITLE
Raise maximum output volume to 125%

### DIFF
--- a/bin/omarchy-audio-output-volume
+++ b/bin/omarchy-audio-output-volume
@@ -5,6 +5,7 @@
 # omarchy:examples=omarchy audio output volume raise | omarchy audio output volume lower | omarchy audio output volume mute-toggle | omarchy audio output volume +1
 
 action="${1:-}"
+max_volume=125
 
 if [[ -z $action ]]; then
   echo "Usage: omarchy-audio-output-volume <raise|lower|mute-toggle|+N|-N>"
@@ -63,7 +64,7 @@ elif [[ $action =~ ^([+-])([0-9]+)$ ]]; then
 
   if [[ $direction == "+" ]]; then
     next=$((current + step))
-    ((next <= 100)) || next=100
+    ((next <= max_volume)) || next=$max_volume
   else
     next=$((current - step))
     ((next >= 0)) || next=0

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -144,6 +144,7 @@ Panel {
   }
 
   readonly property real outputVolume: volumeSink && volumeSink.audio ? volumeSink.audio.volume : 0
+  readonly property real outputVolumeMaximum: 1.25
   readonly property bool outputMuted: volumeSink && volumeSink.audio ? volumeSink.audio.muted : false
   readonly property real inputVolume: source && source.audio ? source.audio.volume : 0
   readonly property bool inputMuted: source && source.audio ? source.audio.muted : false
@@ -425,7 +426,7 @@ Panel {
 
   function setOutputVolume(v) {
     if (!volumeSink || !volumeSink.audio) return outputVolume
-    var volume = Math.max(0, Math.min(1, v))
+    var volume = Math.max(0, Math.min(outputVolumeMaximum, v))
     volumeSink.audio.volume = volume
     return volume
   }
@@ -831,7 +832,7 @@ Panel {
                 anchors.leftMargin: Style.space(6)
                 anchors.rightMargin: Style.space(6)
                 minimum: 0
-                maximum: 1
+                maximum: root.outputVolumeMaximum
                 step: 0.05
                 value: root.outputVolume
                 opacity: root.outputMuted ? 0.5 : 1.0

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -47,3 +47,11 @@ assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spo
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
 JS
+
+grep -Fq 'readonly property real outputVolumeMaximum: 1.25' "$ROOT/shell/plugins/panels/audio/Panel.qml" ||
+  fail "audio panel allows 125% master output volume"
+pass "audio panel allows 125% master output volume"
+
+grep -Fq 'max_volume=125' "$ROOT/bin/omarchy-audio-output-volume" ||
+  fail "audio volume command allows 125% output volume"
+pass "audio volume command allows 125% output volume"


### PR DESCRIPTION
## Summary

- allow the master output slider to reach 125%
- align media-key volume increases with the same 125% ceiling
- add regression coverage for both caps

## Testing

- `bash test/shell.d/audio-test.sh`
- `bash -n bin/omarchy-audio-output-volume`
- `git diff --check`
- visually verified the master slider and OSD at 125% in a live Omarchy shell
- `./test/shell` (205/211 test files passed; six unrelated baseline/environment checks failed: config, launch-about, screenshot-sanity, snapper, theme-install-guards, and unowned-system-paths)