### PR TITLE
fix(notification): bound omarchy-notification-wait by wall clock

### DIFF
--- a/bin/omarchy-notification-wait
+++ b/bin/omarchy-notification-wait
@@ -7,6 +7,7 @@
 set -uo pipefail
 
 timeout=${1:-10}
+deadline=$((SECONDS + timeout))
 
 notification_server_ready() {
   busctl --user call \
@@ -18,12 +19,10 @@ notification_server_ready() {
 
 # The shell has to be up to serve the IPC, and it has to have claimed the
 # notification bus name before notify-send has anywhere to deliver.
-attempts=$((timeout * 10))
-while (( attempts > 0 )); do
+while (( SECONDS < deadline )); do
   if omarchy-shell notifications ping >/dev/null 2>&1 && notification_server_ready; then
     exit 0
   fi
-  attempts=$((attempts - 1))
   sleep 0.1
 done
 


### PR DESCRIPTION
Closes #8870

I noticed omarchy-notification-wait says its argument is
[timeout-seconds] but it actually uses timeout*10 attempts with
sleep 0.1. Each attempt also costs the omarchy-shell IPC timeout
(2s), so omarchy-notification-wait 10 was really blocking
omarchy-crash-watch for 3.5 minutes and then silently dropping the
crash. I fixed the helper to bound by wall clock (SECONDS +
timeout) so the budget finally means what it says.

I saw your suggested fix 1 for the caller at
bin/omarchy-crash-watch:33 to log the drop, but I am leaving that
for maintainers to decide, and I can do it too so lmk if you want
me to add it.