### PR TITLE
Install lib32 GPU drivers before Steam

### DIFF
--- a/bin/omarchy-install-gaming-steam
+++ b/bin/omarchy-install-gaming-steam
@@ -5,9 +5,13 @@
 
 set -e
 
+# Resolve lib32-vulkan-driver before Steam so --noconfirm cannot pick
+# lib32-nvidia-utils (and hard-pull nvidia-utils) on non-NVIDIA machines.
+echo "Installing graphics drivers for Steam..."
+omarchy-install-gaming-gpu-lib32
+
 echo "Installing Steam..."
 omarchy-pkg-add steam
-omarchy-install-gaming-gpu-lib32
 
 echo ""
 echo "Steam will start automatically now. This might take a while..."

--- a/test/shell.d/gaming-steam-install-order-test.sh
+++ b/test/shell.d/gaming-steam-install-order-test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+script="$ROOT/bin/omarchy-install-gaming-steam"
+[[ -x $script ]] || fail "omarchy-install-gaming-steam must be executable"
+
+gpu_line=$(grep -n 'omarchy-install-gaming-gpu-lib32' "$script" | head -1 | cut -d: -f1)
+steam_line=$(grep -n 'omarchy-pkg-add steam' "$script" | head -1 | cut -d: -f1)
+
+[[ -n $gpu_line && -n $steam_line ]] || fail "steam installer must call both gpu-lib32 and pkg-add steam"
+(( gpu_line < steam_line )) || fail "gpu-lib32 must run before steam so --noconfirm cannot pick lib32-nvidia-utils"
+
+pass "steam installer resolves vulkan drivers before installing steam"


### PR DESCRIPTION
## Summary
- Run `omarchy-install-gaming-gpu-lib32` before `omarchy-pkg-add steam` so `--noconfirm` cannot auto-pick `lib32-nvidia-utils` (and hard-pull `nvidia-utils`) on AMD/Intel-only machines.
- Steam's `lib32-vulkan-driver` dependency is what triggered the wrong provider; the GPU-aware helper already knew the right packages, it just ran too late.

Fixes #8856.

## Test plan
- [x] `bash test/shell.d/gaming-steam-install-order-test.sh`
- [ ] On a non-NVIDIA machine: install Steam via the menu and confirm `pacman -Q nvidia-utils` stays absent