### PR TITLE
Show the Codex CLI's error instead of "initialize" when the usage RPC fails

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -518,6 +518,40 @@ def limit_window(window):
   }
 
 
+def codex_rpc_help(proc, stderr_file, exc):
+  """Explain an app-server RPC failure in terms the user can act on.
+
+  rpc_request() raises TimeoutError(method), so a bare str(exc) surfaces in the
+  panel as a lone word like "initialize" or "account/read". Do better, in order:
+
+  1. If the CLI exited and printed to stderr, quote it. That names a flag a
+     codex-cli upgrade dropped or renamed, the common cause of a hard exit.
+  2. If the CLI exited without a word, fall back to the login hint: that is the
+     "not logged in" shape and `codex login` is the fix.
+  3. If the process is still running, the RPC stalled or returned something this
+     collector could not parse. That is not an auth problem and must not send
+     the user to `codex login`; the raw exception text is cryptic but true and
+     searchable, so keep it.
+  """
+  try:
+    proc.wait(timeout=1)
+  except Exception:
+    pass
+  if proc.poll() is None:
+    return str(exc)[:300] or AUTH_HELP
+  detail = ""
+  if stderr_file is not None:
+    try:
+      stderr_file.seek(0)
+      detail = stderr_file.read()
+    except Exception:
+      detail = ""
+  lines = [line.strip() for line in detail.splitlines() if line.strip()]
+  if lines:
+    return f"codex app-server exited: {' '.join(lines)}"[:300]
+  return AUTH_HELP
+
+
 def fetch_codex_rpc():
   result = {"limits": [], "tierLabel": "", "usageStatusText": "", "authHelpText": AUTH_HELP}
   codex = find_command("codex")
@@ -526,16 +560,21 @@ def fetch_codex_rpc():
     result["authHelpText"] = "codex not found in PATH"
     return result
 
+  # A regular file, not a PIPE: the app-server can log to stderr while it runs,
+  # and an unread pipe would deadlock it once the buffer filled. Only read on
+  # failure, and only once the process has exited (see codex_rpc_help).
+  stderr_file = tempfile.TemporaryFile("w+", errors="replace")
   try:
     proc = subprocess.Popen(
       [codex, "-s", "read-only", "-a", "on-request", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
-      stderr=subprocess.DEVNULL,
+      stderr=stderr_file,
       text=True,
       env=ENV,
     )
   except Exception as exc:
+    stderr_file.close()
     result["usageStatusText"] = "Codex unavailable"
     result["authHelpText"] = str(exc)
     return result
@@ -558,7 +597,7 @@ def fetch_codex_rpc():
         result["limits"].append(entry)
   except Exception as exc:
     result["usageStatusText"] = "Codex limits unavailable"
-    result["authHelpText"] = str(exc)
+    result["authHelpText"] = codex_rpc_help(proc, stderr_file, exc)
   finally:
     try:
       proc.terminate()
@@ -568,6 +607,7 @@ def fetch_codex_rpc():
         proc.kill()
       except Exception:
         pass
+    stderr_file.close()
   return result
 
 

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -603,3 +603,112 @@ result=$(HOME="$INTERRUPTED_HOME" CODEX_HOME="$INTERRUPTED_HOME/.codex" XDG_CACH
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "9" ]] ||
   fail "Codex collector does not reuse a snapshot from an interrupted scan" "$result"
 pass "Codex collector does not cache an interrupted opencode scan"
+
+# A codex-cli that rejects the app-server invocation (a flag dropped or renamed
+# in a later release) exits before answering the RPC. The panel must show the
+# CLI's own complaint, not the bare RPC method name the TimeoutError carries.
+RPCERR_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$RPCERR_HOME"' EXIT
+mkdir -p "$RPCERR_HOME/bin"
+cat >"$RPCERR_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+echo "error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'" >&2
+echo "  [possible values: on-request, never]" >&2
+exit 2
+EOF
+chmod +x "$RPCERR_HOME/bin/codex"
+
+result=$(HOME="$RPCERR_HOME" CODEX_HOME="$RPCERR_HOME/.codex" XDG_CACHE_HOME="$RPCERR_HOME/.cache" XDG_DATA_HOME="$RPCERR_HOME/.local/share" \
+  PATH="$RPCERR_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(jq -r '.limits | length' <<<"$result") == "0" && $(jq -r '.usageStatusText' <<<"$result") == "Codex limits unavailable" ]] ||
+  fail "Codex collector reports limits unavailable when the app-server call is rejected" "$result"
+help=$(jq -r '.authHelpText' <<<"$result")
+[[ $help == *"invalid value 'untrusted'"* ]] ||
+  fail "Codex collector surfaces the CLI's own error in the auth-help text" "$result"
+[[ $help == *"possible values: on-request, never"* ]] ||
+  fail "Codex collector keeps the stderr line that names the accepted values" "$result"
+[[ $help != "initialize" ]] ||
+  fail "Codex collector must not leak the raw RPC method name" "$result"
+pass "Codex collector surfaces a rejected app-server call instead of the RPC method name"
+
+# A codex-cli that exits cleanly without speaking the protocol (not logged in,
+# say) leaves no stderr to quote; the panel falls back to the login hint.
+RPCSILENT_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$RPCERR_HOME" "$RPCSILENT_HOME"' EXIT
+mkdir -p "$RPCSILENT_HOME/bin"
+cat >"$RPCSILENT_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$RPCSILENT_HOME/bin/codex"
+
+result=$(HOME="$RPCSILENT_HOME" CODEX_HOME="$RPCSILENT_HOME/.codex" XDG_CACHE_HOME="$RPCSILENT_HOME/.cache" XDG_DATA_HOME="$RPCSILENT_HOME/.local/share" \
+  PATH="$RPCSILENT_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+help=$(jq -r '.authHelpText' <<<"$result")
+[[ $(jq -r '.usageStatusText' <<<"$result") == "Codex limits unavailable" ]] ||
+  fail "Codex collector reports limits unavailable when the CLI is silent" "$result"
+[[ $help == "Run \`codex login\` to authenticate." ]] ||
+  fail "Codex collector falls back to the login hint when the CLI is silent" "$result"
+pass "Codex collector falls back to the login hint when the app-server says nothing"
+
+# A live app-server that answers initialize and then stalls is up and may well
+# be authenticated: the failure is not an auth problem, so the panel must keep
+# the (searchable) stalled-method text rather than send the user to codex login.
+RPCHANG_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$RPCERR_HOME" "$RPCSILENT_HOME" "$RPCHANG_HOME"' EXIT
+mkdir -p "$RPCHANG_HOME/bin"
+cat >"$RPCHANG_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+while read -r request; do
+  id=$(jq -r '.id // empty' <<<"$request")
+  method=$(jq -r '.method // empty' <<<"$request")
+  case "$method" in
+    initialize) jq -cn --argjson id "$id" '{id: $id, result: {}}' ;;
+    account/read) : ;; # up, but never answers, so the collector times this out
+  esac
+done
+EOF
+chmod +x "$RPCHANG_HOME/bin/codex"
+
+result=$(HOME="$RPCHANG_HOME" CODEX_HOME="$RPCHANG_HOME/.codex" XDG_CACHE_HOME="$RPCHANG_HOME/.cache" XDG_DATA_HOME="$RPCHANG_HOME/.local/share" \
+  PATH="$RPCHANG_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+help=$(jq -r '.authHelpText' <<<"$result")
+[[ $help != "Run \`codex login\` to authenticate." ]] ||
+  fail "Codex collector must not blame auth when the app-server is merely stalled" "$result"
+[[ $help == "account/read" ]] ||
+  fail "Codex collector keeps the stalled-method text for a live app-server" "$result"
+pass "Codex collector does not send a stalled but live app-server to codex login"
+
+# A live, authenticated app-server whose rate-limit payload this collector can't
+# parse: still not an auth problem. Keep the parse error, don't say "log in".
+RPCBADLIM_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$RPCERR_HOME" "$RPCSILENT_HOME" "$RPCHANG_HOME" "$RPCBADLIM_HOME"' EXIT
+mkdir -p "$RPCBADLIM_HOME/bin"
+cat >"$RPCBADLIM_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+while read -r request; do
+  id=$(jq -r '.id // empty' <<<"$request")
+  method=$(jq -r '.method // empty' <<<"$request")
+  case "$method" in
+    initialize) jq -cn --argjson id "$id" '{id: $id, result: {}}' ;;
+    account/read) jq -cn --argjson id "$id" '{id: $id, result: {account: {planType: "plus"}}}' ;;
+    account/rateLimits/read)
+      jq -cn --argjson id "$id" '{id: $id, result: {rateLimits: {primary: {usedPercent: "not-a-number", windowDurationMins: 300}}}}'
+      ;;
+  esac
+done
+EOF
+chmod +x "$RPCBADLIM_HOME/bin/codex"
+
+result=$(HOME="$RPCBADLIM_HOME" CODEX_HOME="$RPCBADLIM_HOME/.codex" XDG_CACHE_HOME="$RPCBADLIM_HOME/.cache" XDG_DATA_HOME="$RPCBADLIM_HOME/.local/share" \
+  PATH="$RPCBADLIM_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+help=$(jq -r '.authHelpText' <<<"$result")
+[[ $help != "Run \`codex login\` to authenticate." ]] ||
+  fail "Codex collector must not blame auth for an unparseable rate-limit payload" "$result"
+[[ $help == *"could not convert"* ]] ||
+  fail "Codex collector keeps the parse error for a live app-server" "$result"
+pass "Codex collector keeps the parse error instead of a login hint for a live app-server"


### PR DESCRIPTION
## Fixes: #8849

## What happened

The agents bar panel's Codex tab shows the usage status `CODEX LIMITS UNAVAILABLE`, and the auth-help card reads `initialize`, it doesn't give the user any indication on what's going on.

## Root cause

`rpc_request()` in `bin/omarchy-agent-usage-codex` raises `TimeoutError(method)` when the `codex app-server` process never answers, and `fetch_codex_rpc()` stored that exception verbatim:

```python
except Exception as exc:
    result["usageStatusText"] = "Codex limits unavailable"
    result["authHelpText"] = str(exc)   # -> "initialize"
```

So *any* RPC failure surfaces the raw method name. The common trigger is a `codex-cli` upgrade that drops or renames a flag the collector passes (e.g. `-a untrusted`), removed in codex-cli 0.149 in favour of `on-request`/`never` (the flag value itself is fixed separately in #7649). The CLI exits immediately:

```
error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'
  [possible values: on-request, never]
```

`initialize` never gets a response, `rpc_request()` raises, and the panel shows `initialize`.

## Change

- Capture the app-server's stderr to a temp file (a regular file, not a `PIPE`, so an unread buffer can't deadlock a server that logs while it runs) instead of `subprocess.DEVNULL`.
- On RPC failure, `codex_rpc_help()` picks the most actionable text, in order:
  1. **The CLI exited and printed to stderr.** Quote it, all non-empty lines, so clap's `[possible values: ...]` line survives:
     ```
     Codex limits unavailable
     codex app-server exited: error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>' [possible values: on-request, never]
     ```
  2. **The CLI exited without a word.** The "not logged in" shape, so keep the existing `Run \`codex login\` to authenticate.` hint.
  3. **The process is still running.** The RPC stalled or returned something the collector couldn't parse. That is not an auth problem, so it must not send the user to `codex login`; keep the raw exception text (cryptic but true and searchable, and exactly what the panel showed before this change).

The flag value passed to `codex app-server` is unchanged here. That is #7649's fix.

## Tests

`test/shell.d/agent-usage-codex-scanner-test.sh` gains cases for each branch:

- stub `codex` writes a two-line clap error and exits: asserts both stderr lines reach `authHelpText` and the bare method name does not.
- stub `codex` exits `0` without speaking the protocol: asserts `usageStatusText` is `Codex limits unavailable` and `authHelpText` is the `codex login` hint.
- stub `codex` answers `initialize` then never answers `account/read` (process stays up): asserts `authHelpText` keeps the stalled method name and is **not** the login hint.
- stub `codex` returns a rate-limit window with a non-numeric `usedPercent` (process stays up): asserts `authHelpText` keeps the parse error and is **not** the login hint.

`./test/shell` and `./test/cli` pass.

Fixes #8849.
