### PR TITLE
Bound omarchy-notification-wait by wall-clock timeout and log dropped…

### DIFF
--- a/bin/omarchy-crash-watch
+++ b/bin/omarchy-crash-watch
@@ -30,7 +30,10 @@ announce() {
   # notification server down with it and a toast sent into that gap is lost.
   # Wait for the restarted shell to claim the name again: the crash least
   # likely to be delivered is the one most worth reporting.
-  omarchy-notification-wait || return 1
+  if ! omarchy-notification-wait 5; then
+    echo "omarchy-crash-watch: notification server unavailable, dropped crash toast for $comm" >&2
+    return 1
+  fi
 
   # --exec rather than a libnotify action: the shell runs clicks from its own
   # hint and never emits ActionInvoked. Keeps the default "omarchy-action" app

--- a/bin/omarchy-notification-wait
+++ b/bin/omarchy-notification-wait
@@ -9,7 +9,7 @@ set -uo pipefail
 timeout=${1:-10}
 
 notification_server_ready() {
-  busctl --user call \
+  busctl --user --timeout=1 call \
     org.freedesktop.Notifications \
     /org/freedesktop/Notifications \
     org.freedesktop.Notifications \

--- a/bin/omarchy-notification-wait
+++ b/bin/omarchy-notification-wait
@@ -18,13 +18,17 @@ notification_server_ready() {
 
 # The shell has to be up to serve the IPC, and it has to have claimed the
 # notification bus name before notify-send has anywhere to deliver.
-attempts=$((timeout * 10))
-while (( attempts > 0 )); do
+# Bound execution by wall-clock seconds so hanging IPC calls do not extend
+# the wait far beyond the requested timeout.
+deadline=$((SECONDS + timeout))
+export OMARCHY_SHELL_IPC_TIMEOUT=0.5s
+
+while (( SECONDS < deadline )); do
   if omarchy-shell notifications ping >/dev/null 2>&1 && notification_server_ready; then
     exit 0
   fi
-  attempts=$((attempts - 1))
   sleep 0.1
 done
 
 exit 1
+

--- a/test/shell.d/crash-notification-wait-test.sh
+++ b/test/shell.d/crash-notification-wait-test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+
+# Create a stub omarchy-shell that sleeps to simulate an unresponsive IPC call.
+cat >"$TMPDIR/bin/omarchy-shell" <<'SH'
+#!/bin/bash
+sleep 10
+exit 1
+SH
+
+cat >"$TMPDIR/bin/busctl" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+chmod +x "$TMPDIR/bin/omarchy-shell" "$TMPDIR/bin/busctl"
+
+# Test omarchy-notification-wait timeout with wall-clock deadline.
+# A requested 1s timeout must complete in ~1-2 seconds even when omarchy-shell stalls.
+start_time=$SECONDS
+status=0
+PATH="$TMPDIR/bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-notification-wait" 1 >/dev/null 2>&1 || status=$?
+elapsed=$((SECONDS - start_time))
+
+(( status != 0 )) || fail "omarchy-notification-wait returns non-zero on timeout"
+(( elapsed < 4 )) || fail "omarchy-notification-wait took ${elapsed}s, exceeding wall-clock timeout budget"
+pass "omarchy-notification-wait enforces wall-clock deadline when shell stalls"
+
+# Test stderr drop logging in omarchy-crash-watch
+watch_bin="$TMPDIR/watch-bin"
+watch_home="$TMPDIR/watch-home"
+JOURNAL_ENTRIES="$TMPDIR/journal-entries"
+STDERR_LOG="$TMPDIR/stderr-log"
+
+mkdir -p "$watch_bin" "$watch_home"
+
+cat >"$watch_bin/journalctl" <<'SH'
+#!/bin/bash
+cat "$JOURNAL_ENTRIES"
+SH
+
+cat >"$watch_bin/omarchy-default-agent" <<'SH'
+#!/bin/bash
+echo claude
+SH
+
+cat >"$watch_bin/omarchy-notification-wait" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+chmod +x "$watch_bin/watch-bin" 2>/dev/null || true
+chmod +x "$watch_bin/journalctl" "$watch_bin/omarchy-default-agent" "$watch_bin/omarchy-notification-wait"
+
+require_command jq
+
+jq -cn --arg uid "$UID" \
+  '{_UID: $uid, COREDUMP_COMM: "testapp", COREDUMP_PID: "1234",
+    COREDUMP_EXE: "/usr/bin/testapp", COREDUMP_SIGNAL_NAME: "SIGSEGV"}' >"$JOURNAL_ENTRIES"
+
+PATH="$watch_bin:$ROOT/bin:$PATH" \
+JOURNAL_ENTRIES="$JOURNAL_ENTRIES" \
+HOME="$watch_home" \
+  "$ROOT/bin/omarchy-crash-watch" 2>"$STDERR_LOG" || true
+
+grep -Fq "omarchy-crash-watch: notification server unavailable, dropped crash toast for testapp" "$STDERR_LOG" ||
+  fail "omarchy-crash-watch logs dropped crash notifications to stderr"
+pass "omarchy-crash-watch logs dropped crash notifications to stderr"

--- a/test/shell.d/crash-notification-wait-test.sh
+++ b/test/shell.d/crash-notification-wait-test.sh
@@ -9,11 +9,10 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 mkdir -p "$TMPDIR/bin"
 
-# Create a stub omarchy-shell that sleeps to simulate an unresponsive IPC call.
-cat >"$TMPDIR/bin/omarchy-shell" <<'SH'
+# Create a stub qs that sleeps to simulate an unresponsive IPC call.
+cat >"$TMPDIR/bin/qs" <<'SH'
 #!/bin/bash
-sleep 10
-exit 1
+exec sleep 10
 SH
 
 cat >"$TMPDIR/bin/busctl" <<'SH'
@@ -21,13 +20,13 @@ cat >"$TMPDIR/bin/busctl" <<'SH'
 exit 1
 SH
 
-chmod +x "$TMPDIR/bin/omarchy-shell" "$TMPDIR/bin/busctl"
+chmod +x "$TMPDIR/bin/qs" "$TMPDIR/bin/busctl"
 
 # Test omarchy-notification-wait timeout with wall-clock deadline.
 # A requested 1s timeout must complete in ~1-2 seconds even when omarchy-shell stalls.
 start_time=$SECONDS
 status=0
-PATH="$TMPDIR/bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-notification-wait" 1 >/dev/null 2>&1 || status=$?
+OMARCHY_PATH="$ROOT" PATH="$TMPDIR/bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-notification-wait" 1 >/dev/null 2>&1 || status=$?
 elapsed=$((SECONDS - start_time))
 
 (( status != 0 )) || fail "omarchy-notification-wait returns non-zero on timeout"

--- a/test/shell.d/crash-notification-wait-test.sh
+++ b/test/shell.d/crash-notification-wait-test.sh
@@ -57,7 +57,6 @@ cat >"$watch_bin/omarchy-notification-wait" <<'SH'
 exit 1
 SH
 
-chmod +x "$watch_bin/watch-bin" 2>/dev/null || true
 chmod +x "$watch_bin/journalctl" "$watch_bin/omarchy-default-agent" "$watch_bin/omarchy-notification-wait"
 
 require_command jq

--- a/test/shell.d/crash-notification-wait-test.sh
+++ b/test/shell.d/crash-notification-wait-test.sh
@@ -10,6 +10,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 mkdir -p "$TMPDIR/bin"
 
 # Create a stub qs that sleeps to simulate an unresponsive IPC call.
+# The real omarchy-shell will invoke `timeout ... "$OMARCHY_SHELL_IPC_TIMEOUT" qs ...`
 cat >"$TMPDIR/bin/qs" <<'SH'
 #!/bin/bash
 exec sleep 10


### PR DESCRIPTION
### Problem (#8870, #8872)
Reported by @Dandroid-D:

`omarchy-notification-wait` used to calculate `attempts = timeout * 10` (e.g. 100 attempts for a 10s default). When `omarchy-shell` IPC stalled or quickshell crashed, each ping attempt took `OMARCHY_SHELL_IPC_TIMEOUT` (2s), expanding a 10-second wait into **over 3.5 minutes (210s–310s)**.

Because `omarchy-crash-watch` calls `announce()` synchronously inside the loop consuming core dumps, this stalled crash processing for 3.5 minutes and silently dropped crash notifications without printing anything to logs.

---

### Fix
1. **Wall-Clock Deadline**: Updated `omarchy-notification-wait` to measure absolute wall-clock time (`$SECONDS`) against a target deadline rather than counting loop iterations.
2. **Fast Probe Timeout**: Set `OMARCHY_SHELL_IPC_TIMEOUT=0.5s` inside `omarchy-notification-wait` so hanging IPC ping checks fail fast in 500ms instead of 2s.
3. **Journal Logging**: Added explicit stderr drop logging in `omarchy-crash-watch` (`echo "omarchy-crash-watch: notification server unavailable, dropped crash toast for $comm" >&2`) when the notification server fails to respond, making drops visible and greppable via `journalctl --user -u omarchy-crash-watch`.
4. **Regression Tests**: Added `test/shell.d/crash-notification-wait-test.sh` to verify wall-clock timeout bounds and stderr drop logging.

Fixes #8870
Fixes #8872

CC: @Dandroid-D @dhh @ryanrhughes @omarchybot
