### PR TITLE
Prefer mute over device class for the audio bar glyph

### DIFF
--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -100,6 +100,21 @@ function sinkGlyph(node) {
   return "󰓃"
 }
 
+// Bar / OSD glyph for the default sink. Mute wins over device class so
+// headphones can show as muted; an unbound sink uses the device glyph
+// instead of the muted speaker (null .audio used to look like mute).
+function outputBarIcon(node, volume, muted) {
+  if (!node) return ""
+  if (muted) return ""
+  if (!node.audio) return sinkGlyph(node)
+  if (isHeadphones(node)) return "󰋋"
+  var v = volume === undefined || volume === null ? 0 : Number(volume)
+  if (v >= 0.67) return ""
+  if (v >= 0.34) return ""
+  if (v > 0) return ""
+  return ""
+}
+
 function sourceGlyph(node) {
   if (!node) return "󰍬"
   var p = nodeProps(node)
@@ -244,6 +259,7 @@ if (typeof module !== "undefined") {
     nodeProps: nodeProps,
     nodeLabel: nodeLabel,
     isHeadphones: isHeadphones,
+  outputBarIcon: outputBarIcon,
     sinkGlyph: sinkGlyph,
     sourceGlyph: sourceGlyph,
     friendlyStreamLabel: friendlyStreamLabel,

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -401,14 +401,8 @@ Panel {
   function outputIcon(volume) {
     // Match the old Waybar pulseaudio glyph set. The Material Design speaker
     // icons render visually smaller in JetBrainsMono Nerd Font.
-    if (!sink || !sink.audio) return ""
-    if (isHeadphones(sink)) return "󰋋"
-    if (outputMuted) return ""
     var v = volume === undefined ? outputVolume : volume
-    if (v >= 0.67) return ""
-    if (v >= 0.34) return ""
-    if (v > 0) return ""
-    return ""
+    return Model.outputBarIcon(sink, v, outputMuted)
   }
 
   function inputIcon() {
@@ -573,8 +567,23 @@ Panel {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
-  PwObjectTracker { objects: root.candidateSinks }
-  PwObjectTracker { objects: root.candidateSources }
+
+  // Default sink/source can appear after shell start (Bluetooth). Keep them
+  // in the tracker set even if they are briefly missing from nodes.values,
+  // otherwise .audio stays null and the bar paints the muted glyph.
+  readonly property var trackedSinkObjects: {
+    var list = candidateSinks.slice()
+    if (sink && list.indexOf(sink) < 0) list.push(sink)
+    return list
+  }
+  readonly property var trackedSourceObjects: {
+    var list = candidateSources.slice()
+    if (source && list.indexOf(source) < 0) list.push(source)
+    return list
+  }
+
+  PwObjectTracker { objects: root.trackedSinkObjects }
+  PwObjectTracker { objects: root.trackedSourceObjects }
   PwObjectTracker { objects: root.audioStreams }
 
   PwNodePeakMonitor {

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -28,6 +28,12 @@ assertEqual(
 const headphones = { ready: true, name: 'bluez_output.airpods', properties: { 'device.product.name': 'AirPods Headphones' } }
 assert(audio.isHeadphones(headphones), 'audio detects headphone devices')
 assertEqual(audio.sinkGlyph(headphones), '󰋋', 'audio uses headphone sink glyph')
+
+assertEqual(audio.outputBarIcon(headphones, 0.4, true), '', 'audio shows muted glyph for muted headphones')
+assertEqual(audio.outputBarIcon(headphones, 0.4, false), '󰋋', 'audio shows headphones glyph when unmuted')
+const unbound = { ready: true, name: 'bluez_output.airpods', properties: { 'device.product.name': 'AirPods Headphones' } }
+assertEqual(audio.outputBarIcon(unbound, 0, false), '󰋋', 'audio uses device glyph when sink.audio is unbound')
+assertEqual(audio.outputBarIcon(null, 0, false), '', 'audio shows muted glyph with no sink')
 assert(audio.sourceGlyph({ ready: true, properties: { 'device.icon-name': 'camera-webcam' } }).length > 0, 'audio maps webcam source glyph')
 
 assertEqual(audio.friendlyStreamLabel('spotify'), 'Spotify', 'audio normalizes known stream labels')
@@ -47,3 +53,8 @@ assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spo
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
 JS
+
+panel_qml="$ROOT/shell/plugins/panels/audio/Panel.qml"
+grep -q 'Model.outputBarIcon(sink' "$panel_qml" || fail "audio panel delegates bar icon to Model.outputBarIcon"
+grep -q 'trackedSinkObjects' "$panel_qml" || fail "audio panel tracks the default sink for mid-session devices"
+pass "audio panel mute icon and sink tracking"


### PR DESCRIPTION
## Summary
- Mute state now wins over the headphones glyph, so a muted headset can show as muted.
- An unbound sink (`.audio` null, common for Bluetooth connected after shell start) uses the device glyph instead of the muted speaker.
- Keep the default sink/source in `PwObjectTracker` so mid-session devices bind without a shell restart.

Fixes #8744.

## Test plan
- [x] `bash test/shell.d/audio-test.sh`
- [ ] Connect Bluetooth headphones after boot; confirm bar is not the muted glyph while unmuted
- [ ] Mute headphones; confirm muted glyph appears