### PR TITLE
Give slow displays 30s after a lock-screen wake before blanking

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -159,14 +159,21 @@ Item {
     runWake()
   }
 
-  function armBlankTimer() {
+  function armBlankTimer(customInterval) {
+    // Deliberate wakes need longer than a DisplayPort re-sync (~5–15s). A
+    // hard-coded 5s re-arm in runWake blanked slow panels before the lock
+    // screen could appear, looping forever until the user typed blind.
+    var ms = (typeof customInterval === "number" && customInterval > 0) ? customInterval : 5000
+    idleBlankTimer.interval = ms
     idleBlankTimer.armedAt = Date.now()
     idleBlankTimer.restart()
   }
 
   function runWake() {
     if (!wakeProcess.running) wakeProcess.running = true
-    if (lockRequested) armBlankTimer()
+    // After an intentional wake, give the panel time to finish DPMS
+    // renegotiation before blanking again.
+    if (lockRequested) armBlankTimer(30000)
   }
 
   function runBlank() {

--- a/test/shell.d/lock-blank-fingerprint-test.sh
+++ b/test/shell.d/lock-blank-fingerprint-test.sh
@@ -30,4 +30,14 @@ assert(
   !/onAuthenticatingChanged:/.test(serviceQml),
   'the combined authenticating state no longer drives the blank timer'
 )
+
+assert(
+  /function runWake\(\) \{[\s\S]*?if \(lockRequested\) armBlankTimer\(30000\)/.test(serviceQml),
+  'waking a locked session re-arms blanking with a 30s DPMS re-sync budget'
+)
+
+assert(
+  /function armBlankTimer\(customInterval\)/.test(serviceQml),
+  'blank timer accepts a custom interval for wake vs initial lock'
+)
 JS


### PR DESCRIPTION
## Summary
- `runWake` re-armed the blank timer at 5s on every mouse move while locked.
- Displays that take longer than 5s to renegotiate DPMS were blanked again before the lock screen appeared, looping until the user typed blind.
- Wake now re-arms with a 30s budget; initial lock still uses 5s.

Fixes #8847.

## Test plan
- [x] `bash test/shell.d/lock-blank-fingerprint-test.sh`
- [ ] On a slow DP monitor: lock, wait for blank, move mouse, confirm the lock screen stays visible long enough to type
