### PR TITLE
Allow user agent usage collectors

### DIFF
--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -10,6 +10,7 @@
 # panel picks up any record that appears here.
 
 USAGE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/usage"
+USER_BIN_DIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
 mkdir -p "$USAGE_DIR"
 
 flags=()
@@ -56,6 +57,19 @@ for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
   [[ -x $collector ]] || continue
   agent="${collector##*/omarchy-agent-usage-}"
   [[ $agent == "update" ]] && continue
+  user_collector="$USER_BIN_DIR/omarchy-agent-usage-$agent"
+  [[ -x $user_collector ]] && collector="$user_collector"
+  wanted "$agent" || continue
+  collect "$collector" "$agent" &
+  pids+=($!)
+done
+
+# User collectors can add providers without modifying the Omarchy install.
+for collector in "$USER_BIN_DIR"/omarchy-agent-usage-*; do
+  [[ -x $collector ]] || continue
+  agent="${collector##*/omarchy-agent-usage-}"
+  [[ $agent == "update" ]] && continue
+  [[ -e $OMARCHY_PATH/bin/omarchy-agent-usage-$agent ]] && continue
   wanted "$agent" || continue
   collect "$collector" "$agent" &
   pids+=($!)

--- a/test/shell.d/agent-usage-update-test.sh
+++ b/test/shell.d/agent-usage-update-test.sh
@@ -9,6 +9,7 @@ FAKE_OMARCHY=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME" "$FAKE_OMARCHY"' EXIT
 
 mkdir -p "$FAKE_OMARCHY/bin"
+mkdir -p "$TEST_HOME/.local/bin"
 
 cat >"$FAKE_OMARCHY/bin/omarchy-agent-usage-good" <<'EOF'
 #!/bin/bash
@@ -33,15 +34,31 @@ EOF
 
 chmod +x "$FAKE_OMARCHY/bin/"omarchy-agent-usage-*
 
+cat >"$TEST_HOME/.local/bin/omarchy-agent-usage-good" <<'EOF'
+#!/bin/bash
+echo '{"schemaVersion":1,"id":"good","name":"User Override","totalPrompts":4}'
+EOF
+
+cat >"$TEST_HOME/.local/bin/omarchy-agent-usage-custom" <<'EOF'
+#!/bin/bash
+echo '{"schemaVersion":1,"id":"custom","name":"Custom Agent","totalPrompts":2}'
+EOF
+
+chmod +x "$TEST_HOME/.local/bin/"omarchy-agent-usage-*
+
 usage_dir="$TEST_HOME/.local/state/omarchy/agents/usage"
 
 HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" \
   "$ROOT/bin/omarchy-agent-usage-update" --except skipped 2>/dev/null && fail "update reports a failing collector"
 pass "update reports a failing collector"
 
-[[ $(jq -r '.name' "$usage_dir/good.json") == "Good Agent" ]] ||
-  fail "update writes each collector's record to the usage directory"
-pass "update writes each collector's record to the usage directory"
+[[ $(jq -r '.name' "$usage_dir/good.json") == "User Override" ]] ||
+  fail "update prefers a user collector over the packaged collector"
+pass "update prefers a user collector over the packaged collector"
+
+[[ $(jq -r '.name' "$usage_dir/custom.json") == "Custom Agent" ]] ||
+  fail "update discovers providers supplied only by user collectors"
+pass "update discovers providers supplied only by user collectors"
 
 [[ ! -e $usage_dir/noisy.json ]] ||
   fail "update refuses records that are not valid JSON"


### PR DESCRIPTION
## What

Discover executable `omarchy-agent-usage-*` collectors from `${XDG_BIN_HOME:-$HOME/.local/bin}` in addition to packaged collectors. A user collector with the same provider id overrides the packaged one; a collector with a new id adds a provider record the existing dynamic panel discovery already understands.

## Why

The Agents panel record contract is already provider-agnostic, but the updater only executes collectors shipped inside Omarchy. This lets users and third-party packages add providers without editing `/usr/share/omarchy` or maintaining a fork.

## Verification

- Extended `agent-usage-update-test.sh` to cover user-only collectors and packaged-collector overrides
- `test/shell.d/agent-usage-update-test.sh`
- `git diff --check`
