### PR TITLE
Clear stale agent login guidance after successful probes

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -826,11 +826,13 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
   fetched_at = number(cached.get("fetchedAtMs")) / 1000
   if fallback and not force and time.time() - fetched_at < PROBE_MIN_INTERVAL_SECONDS:
     result["limits"] = fallback
+    result["authHelpText"] = ""
     return result
 
   probe = probe_limits(access_token)
   if probe["ok"]:
     result["limits"] = probe["limits"]
+    result["authHelpText"] = ""
     write_json(probe_cache, {"fetchedAtMs": round(time.time() * 1000), "limits": probe["limits"]})
     return result
 

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -549,6 +549,7 @@ def fetch_codex_rpc():
 
     account = (account_msg.get("result") or {}).get("account") or {}
     limits = (limits_msg.get("result") or {}).get("rateLimits") or {}
+    result["authHelpText"] = ""
     plan = limits.get("planType") or account.get("planType") or account.get("type") or ""
     result["tierLabel"] = str(plan) if plan else ""
 

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -196,6 +196,8 @@ payload='{"five_hour":{"utilization":44.0}}'
 reused=$(probe_with_cache false "$fresh" "$payload")
 [[ $(jq -r '.probes' <<<"$reused") == "0" && $(jq -c '[.result.limits[].percent]' <<<"$reused") == "[0.11]" ]] ||
   fail "Claude collector reuses a cache younger than the probe interval" "$reused"
+[[ $(jq -r '.result.authHelpText' <<<"$reused") == "" ]] ||
+  fail "Claude collector clears login guidance when reusing authenticated limits" "$reused"
 pass "Claude collector reuses a cache younger than the probe interval"
 
 # --force is someone pressing refresh, and its help text promises the caches are
@@ -205,6 +207,8 @@ forced=$(probe_with_cache true "$fresh" "$payload")
   fail "Claude collector re-probes on --force despite a fresh cache" "$forced"
 [[ $(jq -c '[.result.limits[].percent]' <<<"$forced") == "[0.44]" ]] ||
   fail "Claude collector returns the forced probe's numbers" "$forced"
+[[ $(jq -r '.result.authHelpText' <<<"$forced") == "" ]] ||
+  fail "Claude collector clears login guidance after a successful probe" "$forced"
 pass "Claude collector re-probes on --force despite a fresh cache"
 
 # A probe that lands becomes the next run's fallback.

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -68,6 +68,10 @@ pass "Codex collector does not double-count cache or reasoning tokens"
   fail "Codex collector identifies itself with an empty limits list" "$result"
 pass "Codex collector identifies itself with an empty limits list"
 
+[[ $(jq -r '.authHelpText' <<<"$result") == "" ]] ||
+  fail "Codex collector clears login guidance after successful account RPCs" "$result"
+pass "Codex collector clears login guidance after successful account RPCs"
+
 # Pi and omp can both spend a Codex subscription without creating native
 # Codex sessions. Their compatible JSONL transcripts must be included.
 PI_HOME=$(mktemp -d)


### PR DESCRIPTION
## What

Clear `authHelpText` when Claude and Codex successfully retrieve authenticated usage data.

- Claude clears stale login guidance after a successful limits probe or while reusing a fresh authenticated limits cache.
- Codex clears it after both account RPCs complete, even when the account currently returns no rate-limit windows.

## Why

Both collectors initialize `authHelpText` with login instructions. Successful paths populated limits and plan data but left that default text behind, so consumers that render `authHelpText` independently can incorrectly tell an authenticated user to log in again.

Failure and signed-out paths retain their existing actionable guidance.

## Verification

- `bash test/shell.d/agent-usage-claude-limits-test.sh`
- `bash test/shell.d/agent-usage-codex-scanner-test.sh`
- `git diff --check`
