### PR TITLE
Make agent provider switching scale

### DIFF
--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -436,7 +436,9 @@ Panel {
                 Text {
                   textFormat: Text.PlainText
                   anchors.centerIn: parent
-                  visible: heroMarkImage.status !== Image.Ready
+                  // Loading is transient; show the fallback only after every
+                  // artwork candidate has actually failed.
+                  visible: heroMark.candidateIndex >= heroMark.candidates.length
                   text: button.text
                   color: root.foreground
                   font.family: root.fontFamily
@@ -459,14 +461,15 @@ Panel {
           }
 
           // ---------- Provider switch ----------
-          Row {
+          Grid {
             id: providerSwitch
             visible: root.providers.length > 1
             width: parent.width
+            columns: Math.min(3, Math.max(1, root.providers.length))
             spacing: Style.spacing.md
 
-            readonly property real cellWidth: root.providers.length > 0
-              ? (width - spacing * (root.providers.length - 1)) / root.providers.length
+            readonly property real cellWidth: columns > 0
+              ? (width - spacing * (columns - 1)) / columns
               : 0
 
             Repeater {

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -14,4 +14,7 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+assert(/Grid \{\s*id: providerSwitch/.test(panelSource), 'agents provider switch wraps across rows')
+assert(/columns: Math\.min\(3, Math\.max\(1, root\.providers\.length\)\)/.test(panelSource), 'agents provider switch caps each row at three columns')
+assert(/visible: heroMark\.candidateIndex >= heroMark\.candidates\.length/.test(panelSource), 'agents hero fallback waits for every icon candidate to fail')
 JS


### PR DESCRIPTION
## What

- Wrap the Agents panel provider switcher into a grid capped at three columns per row.
- Keep the provider-name fallback hidden while an icon candidate is still loading; reveal it only after every candidate fails.

## Why

The current single-row layout divides the panel width across every provider. Names become clipped or overlap once users add more than the three built-in collectors. Switching providers can also briefly flash the text fallback while the selected provider's icon is loading.

The three-column grid keeps buttons readable as the provider list grows, while preserving the existing one-, two-, and three-provider layouts. Waiting for the candidate walk to finish removes the transient fallback flash without hiding a genuine missing-icon fallback.

## Verification

- `bash test/shell.d/agents-panel-test.sh`
- `git diff --check`
- `./test/shell` progressed through all Agents tests successfully; the aggregate run later stopped at the unrelated missing `omarchy-pkgs` checkout prerequisite.
- Live visual check with six providers: two rows of three, no clipping or overlap, stable provider artwork.
