### PR TITLE
Skip the orphan prompt when omarchy update runs with -y

### DIFF
--- a/bin/omarchy-update-orphan-pkgs
+++ b/bin/omarchy-update-orphan-pkgs
@@ -12,7 +12,9 @@ echo -e "\e[32m\nOrphan system packages\e[0m"
 printf '  %s\n' "${orphans[@]}"
 echo
 
-if [[ ! -t 0 || ! -t 1 ]]; then
+# omarchy update -y keeps a TTY but promises not to ask. Treat unattended
+# the same as a non-interactive pipe: report and move on.
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == 1 || ! -t 0 || ! -t 1 ]]; then
   echo "${#orphans[@]} orphaned package(s) found. Re-run omarchy-update-orphan-pkgs in a terminal to review/remove them."
   echo
   exit 0

--- a/test/shell.d/update-orphan-test.sh
+++ b/test/shell.d/update-orphan-test.sh
@@ -39,3 +39,11 @@ write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then exit 0; fi; exit 1'
 run_orphan_checker >"$test_tmp/none.out" 2>"$test_tmp/none.err"
 [[ ! -s $test_tmp/none.out ]] || fail "orphan checker stays quiet when no orphans exist"
 pass "orphan checker stays quiet without orphans"
+
+# -y leaves stdin/stdout as TTYs in a real terminal, so the unattended flag
+# has to be checked explicitly or gum confirm blocks forever.
+write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then printf "old-lib\n"; exit 0; fi; exit 1'
+write_stub gum 'echo "gum should not be called under -y" >&2; exit 99'
+OMARCHY_UPDATE_UNATTENDED=1 run_orphan_checker >"$test_tmp/unattended.out" 2>"$test_tmp/unattended.err"
+grep -q 'Re-run omarchy-update-orphan-pkgs in a terminal' "$test_tmp/unattended.out" || fail "unattended orphan step must not prompt"
+pass "orphan checker skips the prompt under OMARCHY_UPDATE_UNATTENDED"

--- a/test/shell.d/update-orphan-test.sh
+++ b/test/shell.d/update-orphan-test.sh
@@ -23,7 +23,7 @@ SH
 }
 
 run_orphan_checker() {
-  HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-orphan-pkgs"
+  HOME="$test_home" PATH="$stub_bin:$PATH" "$BASH" "$ROOT/bin/omarchy-update-orphan-pkgs"
 }
 
 write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then printf "old-lib\nunused-tool\n"; exit 0; fi; exit 1'
@@ -44,6 +44,22 @@ pass "orphan checker stays quiet without orphans"
 # has to be checked explicitly or gum confirm blocks forever.
 write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then printf "old-lib\n"; exit 0; fi; exit 1'
 write_stub gum 'echo "gum should not be called under -y" >&2; exit 99'
-OMARCHY_UPDATE_UNATTENDED=1 run_orphan_checker >"$test_tmp/unattended.out" 2>"$test_tmp/unattended.err"
+# Match update-package-conflict-test.sh: script gives both streams a PTY.
+# Its command syntax differs on macOS, where these shell tests also run.
+cat >"$test_tmp/terminal.sh" <<'SH'
+[[ -t 0 && -t 1 ]] || exit 70
+exec "$BASH" "$ROOT/bin/omarchy-update-orphan-pkgs"
+SH
+export ORPHAN_PTY_RUNNER="$test_tmp/terminal.sh"
+if [[ $(uname -s) == "Darwin" ]]; then
+  HOME="$test_home" PATH="$stub_bin:$PATH" OMARCHY_UPDATE_UNATTENDED=1 \
+    script -q "$test_tmp/unattended.out" "$BASH" "$ORPHAN_PTY_RUNNER" >/dev/null 2>&1
+else
+  HOME="$test_home" PATH="$stub_bin:$PATH" OMARCHY_UPDATE_UNATTENDED=1 \
+    script -qec 'bash "$ORPHAN_PTY_RUNNER"' "$test_tmp/unattended.out" >/dev/null 2>&1
+fi
+if grep -q 'gum should not be called' "$test_tmp/unattended.out"; then
+  fail "unattended orphan step invoked gum on a terminal"
+fi
 grep -q 'Re-run omarchy-update-orphan-pkgs in a terminal' "$test_tmp/unattended.out" || fail "unattended orphan step must not prompt"
 pass "orphan checker skips the prompt under OMARCHY_UPDATE_UNATTENDED"


### PR DESCRIPTION
## Summary
- `omarchy update -y` sets `OMARCHY_UPDATE_UNATTENDED` but still has a TTY, so the orphan step waited on `gum confirm` forever after the upgrade finished.
- Treat the unattended flag like a non-interactive pipe: report orphans and move on.

Addresses the orphan-package prompt in #8780. The separate restart-prompt path is outside this change.

## Test plan
- [x] `bash test/shell.d/update-orphan-test.sh` (bash 5)
- [ ] Run `omarchy update -y` with orphans present; confirm it exits without prompting



### Review follow-up — 12 September 2026

The regression now runs the checker through `script` with both input and output attached to a PTY, and explicitly rejects a gum invocation. The runner verifies both descriptors are terminals before invoking the checker. All three focused checks pass on Bash 5/macOS; removing the unattended condition makes the new regression fail. The Linux invocation follows the existing `update-package-conflict-test.sh` helper; a complete live Omarchy update remains unverified.
