### PR TITLE
Clear the low-battery toast when the charger is connected

### DIFF
--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -14,6 +14,7 @@ Item {
   property string pendingPowerSource: ""
   property string activePowerProfile: ""
   readonly property bool powerSaverOnBattery: UPower.onBattery && activePowerProfile === "power-saver"
+  property bool lowBatteryClearPending: false
 
   PersistentProperties {
     id: persisted
@@ -33,10 +34,12 @@ Item {
     var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery)
     var wasNotified = persisted.notifiedLowBattery
     persisted.notifiedLowBattery = state.notifiedLowBattery
+    if (state.notifiedLowBattery) root.lowBatteryClearPending = false
+    else if (wasNotified) root.lowBatteryClearPending = true
     if (state.notify) sendLowBatteryWarning(state.level)
-    // Critical toasts ignore the -t timeout; clear the stuck "Time to recharge!"
-    // card as soon as we are no longer in the low-discharging state.
-    else if (wasNotified && !state.notifiedLowBattery) clearLowBatteryWarning()
+    // Dismissal can precede notification insertion or time out silently. Keep
+    // retrying on the existing poll until a new low-battery episode starts.
+    if (root.lowBatteryClearPending) clearLowBatteryWarning()
   }
 
   function sendLowBatteryWarning(level) {

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -36,7 +36,12 @@ Item {
     persisted.notifiedLowBattery = state.notifiedLowBattery
     if (state.notifiedLowBattery) root.lowBatteryClearPending = false
     else if (wasNotified) root.lowBatteryClearPending = true
-    if (state.notify) sendLowBatteryWarning(state.level)
+    if (state.notify) {
+      // Let an in-flight dismissal finish before posting a new warning.
+      // Leave the latch unset so its exit handler can recheck current power.
+      if (clearWarningProcess.running) persisted.notifiedLowBattery = false
+      else sendLowBatteryWarning(state.level)
+    }
     // Dismissal can precede notification insertion or time out silently. Keep
     // retrying on the existing poll until a new low-battery episode starts.
     if (root.lowBatteryClearPending) clearLowBatteryWarning()
@@ -76,7 +81,10 @@ Item {
   }
 
   Process { id: warningProcess }
-  Process { id: clearWarningProcess }
+  Process {
+    id: clearWarningProcess
+    onExited: if (!root.lowBatteryClearPending) root.checkBattery()
+  }
 
   Process {
     id: powerProfileProcess

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -31,8 +31,12 @@ Item {
 
   function checkBattery() {
     var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery)
+    var wasNotified = persisted.notifiedLowBattery
     persisted.notifiedLowBattery = state.notifiedLowBattery
     if (state.notify) sendLowBatteryWarning(state.level)
+    // Critical toasts ignore the -t timeout; clear the stuck "Time to recharge!"
+    // card as soon as we are no longer in the low-discharging state.
+    else if (wasNotified && !state.notifiedLowBattery) clearLowBatteryWarning()
   }
 
   function sendLowBatteryWarning(level) {
@@ -42,6 +46,15 @@ Item {
       String(level)
     ]
     warningProcess.running = true
+  }
+
+  function clearLowBatteryWarning() {
+    if (clearWarningProcess.running) return
+    clearWarningProcess.command = [
+      "omarchy-notification-dismiss",
+      "Time to recharge!"
+    ]
+    clearWarningProcess.running = true
   }
 
   function applyPowerProfile() {
@@ -60,6 +73,7 @@ Item {
   }
 
   Process { id: warningProcess }
+  Process { id: clearWarningProcess }
 
   Process {
     id: powerProfileProcess

--- a/test/shell.d/battery-clear-on-ac-test.sh
+++ b/test/shell.d/battery-clear-on-ac-test.sh
@@ -4,22 +4,11 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
-run_node_test <<'JS'
-const fs = require('fs')
-const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/services/battery/Service.qml'), 'utf8')
+service_qml="$ROOT/shell/plugins/services/battery/Service.qml"
 
-assert(
-  /function clearLowBatteryWarning\(\)/.test(serviceQml),
-  'battery service can dismiss the low-battery toast'
-)
+grep -q 'function clearLowBatteryWarning()' "$service_qml" || fail "battery service can dismiss the low-battery toast"
+grep -q 'Time to recharge!' "$service_qml" || fail "battery service dismisses by the Time to recharge! summary"
+grep -q 'omarchy-notification-dismiss' "$service_qml" || fail "battery service uses omarchy-notification-dismiss"
+grep -q 'clearLowBatteryWarning()' "$service_qml" || fail "battery service calls clear when leaving low-discharging"
 
-assert(
-  /omarchy-notification-dismiss[\s\S]*Time to recharge!/.test(serviceQml),
-  'battery service dismisses by the Time to recharge! summary'
-)
-
-assert(
-  /else if \(wasNotified && !state\.notifiedLowBattery\) clearLowBatteryWarning\(\)/.test(serviceQml),
-  'battery service clears the toast when leaving the low-discharging state'
-)
-JS
+pass "battery service clears the low-battery toast on AC"

--- a/test/shell.d/battery-clear-on-ac-test.sh
+++ b/test/shell.d/battery-clear-on-ac-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/services/battery/Service.qml'), 'utf8')
+
+assert(
+  /function clearLowBatteryWarning\(\)/.test(serviceQml),
+  'battery service can dismiss the low-battery toast'
+)
+
+assert(
+  /omarchy-notification-dismiss[\s\S]*Time to recharge!/.test(serviceQml),
+  'battery service dismisses by the Time to recharge! summary'
+)
+
+assert(
+  /else if \(wasNotified && !state\.notifiedLowBattery\) clearLowBatteryWarning\(\)/.test(serviceQml),
+  'battery service clears the toast when leaving the low-discharging state'
+)
+JS

--- a/test/shell.d/battery-clear-on-ac-test.sh
+++ b/test/shell.d/battery-clear-on-ac-test.sh
@@ -32,9 +32,13 @@ assertDeepEqual(dismissal.command, [], 'busy dismissal process is not overwritte
 dismissal.running = false
 state.checkBattery()
 assertEqual(dismissal.running, true, 'next poll retries dismissal after busy or silently timed-out process')
-dismissal.running = false
 next = { notifiedLowBattery: true, notify: true, level: 5 }
 state.checkBattery()
 assertEqual(state.lowBatteryClearPending, false, 'new low-battery episode cancels old dismissal intent')
-assertEqual(dismissal.running, false, 'old dismissal does not remove the new warning')
+assertEqual(warnings, 1, 'new warning waits for the in-flight dismissal')
+assertEqual(persisted.notifiedLowBattery, false, 'deferred warning remains eligible for the exit-handler recheck')
+dismissal.running = false
+state.checkBattery()
+assertEqual(warnings, 2, 'new warning is sent after dismissal finishes')
+assert(qml.includes('onExited: if (!root.lowBatteryClearPending) root.checkBattery()'), 'dismissal completion rechecks a deferred warning without a retry loop')
 JS

--- a/test/shell.d/battery-clear-on-ac-test.sh
+++ b/test/shell.d/battery-clear-on-ac-test.sh
@@ -1,14 +1,40 @@
 #!/bin/bash
-
 set -euo pipefail
-
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
-
-service_qml="$ROOT/shell/plugins/services/battery/Service.qml"
-
-grep -q 'function clearLowBatteryWarning()' "$service_qml" || fail "battery service can dismiss the low-battery toast"
-grep -q 'Time to recharge!' "$service_qml" || fail "battery service dismisses by the Time to recharge! summary"
-grep -q 'omarchy-notification-dismiss' "$service_qml" || fail "battery service uses omarchy-notification-dismiss"
-grep -q 'clearLowBatteryWarning()' "$service_qml" || fail "battery service calls clear when leaving low-discharging"
-
-pass "battery service clears the low-battery toast on AC"
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+const qml = fs.readFileSync(path.join(root, 'shell/plugins/services/battery/Service.qml'), 'utf8')
+const state = { lowBatteryClearPending: false }
+const persisted = { notifiedLowBattery: false }
+const dismissal = { running: false, command: [] }
+let next = { notifiedLowBattery: false, notify: false }
+let warnings = 0
+const context = vm.createContext({ root: state, persisted, clearWarningProcess: dismissal, UPower: {}, UPowerDeviceState: {}, batteryThreshold: 10, BatteryModel: { shouldWarnLowBattery: () => next }, sendLowBatteryWarning: () => warnings++ })
+for (const name of ['checkBattery', 'clearLowBatteryWarning']) {
+  const match = qml.match(new RegExp('function ' + name + '\\(([^)]*)\\) \\{([\\s\\S]*?)\\n  \\}'))
+  assert(match, name + ' exists')
+  state[name] = vm.runInContext('(function(' + match[1] + ') {' + match[2] + '})', context)
+  context[name] = state[name]
+}
+state.checkBattery()
+assertEqual(dismissal.running, false, 'AC startup without a warning does not dismiss anything')
+next = { notifiedLowBattery: true, notify: true, level: 5 }
+state.checkBattery()
+assertEqual(warnings, 1, 'low battery sends warning')
+next = { notifiedLowBattery: false, notify: false }
+state.checkBattery()
+assertDeepEqual(dismissal.command, ['omarchy-notification-dismiss', 'Time to recharge!'], 'leaving low battery invokes dismissal from checkBattery')
+assertEqual(state.lowBatteryClearPending, true, 'notification insertion race retains dismissal intent')
+dismissal.command = []
+state.checkBattery()
+assertDeepEqual(dismissal.command, [], 'busy dismissal process is not overwritten')
+dismissal.running = false
+state.checkBattery()
+assertEqual(dismissal.running, true, 'next poll retries dismissal after busy or silently timed-out process')
+dismissal.running = false
+next = { notifiedLowBattery: true, notify: true, level: 5 }
+state.checkBattery()
+assertEqual(state.lowBatteryClearPending, false, 'new low-battery episode cancels old dismissal intent')
+assertEqual(dismissal.running, false, 'old dismissal does not remove the new warning')
+JS


### PR DESCRIPTION
Critical "Time to recharge!" notifications ignore the send timeout and can remain visible after AC is connected. Leaving the low-discharging state now dismisses that notification and retains dismissal intent across the existing 30-second battery polls. This retries when notification insertion follows the first dismissal, the dismissal process is busy, or the quiet CLI times out without acknowledgement. A new low-battery episode cancels the previous dismissal intent and waits for an in-flight dismissal process to finish before sending its warning.

Fixes #8813.

Validation: `bash test/shell.d/battery-clear-on-ac-test.sh` and `bash test/shell.d/battery-test.sh` pass. The focused test executes the QML check and dismissal functions and covers the actual transition call, busy-process retry, and cancellation on a new low-battery episode.

Live Quickshell verification remains pending: trigger the critical notification, connect AC during notification delivery, and confirm eventual dismissal. This requires an Omarchy desktop, unavailable in the current macOS environment.
