### PR TITLE
Debounce unforced lock wake calls immediately following display blanking

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -41,7 +41,7 @@ Item {
   signal submitPassword(string password)
   signal passwordTextEdited(string password)
   signal clearFailureRequested()
-  signal wakeRequested()
+  signal wakeRequested(bool force)
 
   // Cache-busts the lock background by appending `?v=`. Adding a query
   // string keeps Image's loader happy while forcing it to reload when the
@@ -115,8 +115,8 @@ Item {
     MouseArea {
       anchors.fill: parent
       hoverEnabled: true
-      onClicked: { root.wakeRequested(); root.forcePasswordFocus() }
-      onPositionChanged: root.wakeRequested()
+      onClicked: { root.wakeRequested(true); root.forcePasswordFocus() }
+      onPositionChanged: root.wakeRequested(false)
     }
 
     BorderSurface {
@@ -163,7 +163,7 @@ Item {
         onTextChanged: {
           if (!root.syncingPasswordText) root.passwordTextEdited(text)
           if (text.length > 0) {
-            root.wakeRequested()
+            root.wakeRequested(true)
           }
           if (text.length > 0 && root.failureMessage.length > 0) root.clearFailureRequested()
         }
@@ -175,7 +175,7 @@ Item {
         }
 
         Keys.onPressed: function(event) {
-          root.wakeRequested()
+          root.wakeRequested(true)
           if (event.key === Qt.Key_Escape || (event.modifiers & Qt.ControlModifier && event.key === Qt.Key_U)) {
             root.passwordTextEdited("")
             event.accepted = true

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -164,12 +164,16 @@ Item {
     idleBlankTimer.restart()
   }
 
-  function runWake() {
+  property double lastBlankedAt: 0
+
+  function runWake(force) {
+    if (!force && locked && (Date.now() - lastBlankedAt) < 1500) return
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
   }
 
   function runBlank() {
+    lastBlankedAt = Date.now()
     if (!blankProcess.running) blankProcess.running = true
   }
 
@@ -280,7 +284,7 @@ Item {
         onPasswordTextEdited: function(password) { root.enteredPassword = password }
         onSubmitPassword: function(password) { root.submitPassword(password) }
         onClearFailureRequested: root.failureMessage = ""
-        onWakeRequested: root.runWake()
+        onWakeRequested: root.runWake(true)
       }
 
     }

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -284,7 +284,7 @@ Item {
         onPasswordTextEdited: function(password) { root.enteredPassword = password }
         onSubmitPassword: function(password) { root.submitPassword(password) }
         onClearFailureRequested: root.failureMessage = ""
-        onWakeRequested: root.runWake(true)
+        onWakeRequested: function(force) { root.runWake(force) }
       }
 
     }

--- a/test/shell.d/lock-blank-fingerprint-test.sh
+++ b/test/shell.d/lock-blank-fingerprint-test.sh
@@ -30,4 +30,9 @@ assert(
   !/onAuthenticatingChanged:/.test(serviceQml),
   'the combined authenticating state no longer drives the blank timer'
 )
+
+assert(
+  /function runWake\(force\) \{\s*if \(!force && locked && \(Date\.now\(\) - lastBlankedAt\) < 1500\) return/.test(serviceQml),
+  'runWake ignores unforced wake events during the 1.5s post-blanking debounce window'
+)
 JS

--- a/test/shell.d/lock-blank-fingerprint-test.sh
+++ b/test/shell.d/lock-blank-fingerprint-test.sh
@@ -35,4 +35,21 @@ assert(
   /function runWake\(force\) \{\s*if \(!force && locked && \(Date\.now\(\) - lastBlankedAt\) < 1500\) return/.test(serviceQml),
   'runWake ignores unforced wake events during the 1.5s post-blanking debounce window'
 )
+
+const lockViewQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/LockView.qml'), 'utf8')
+
+assert(
+  /signal wakeRequested\(bool force\)/.test(lockViewQml),
+  'LockView wakeRequested signal takes a force parameter'
+)
+
+assert(
+  /onPositionChanged: root\.wakeRequested\(false\)/.test(lockViewQml),
+  'LockView passes false for pointer motion wake requests'
+)
+
+assert(
+  /onClicked: \{ root\.wakeRequested\(true\);/.test(lockViewQml),
+  'LockView passes true for deliberate mouse click wake requests'
+)
 JS


### PR DESCRIPTION
### Problem (#8863)
On AMD APU setups with Radeon HDMI audio codecs (`snd_hda_codec_hdmi`), disabling DPMS (`omarchy-brightness-display off`) causes the kernel driver to emit `SW_VIDEOOUT_INSERT` evdev switch events on `/dev/input/eventX` ("HD-Audio Generic HDMI/DP").

The input subsystem treats this hardware switch event as user activity, firing `runWake()` (`omarchy-system-wake`) and re-enabling DPMS in a continuous 5–8 second flap loop.

---

### Fix
1. **Post-Blanking Debounce**: Added a 1.5s post-blanking window (`Date.now() - lastBlankedAt < 1500`) in [Service.qml](file:///d:/projects/omarchy/shell/plugins/lock/Service.qml#L167-L170). Unforced/automated wake calls occurring within 1.5s of `runBlank()` are ignored to swallow hardware HPD/audio switch events.
2. **Explicit User Interaction Unchanged**: User interaction (`LockView` mouse click, typing, password submission) passes `force = true` (`runWake(true)`), waking the screen immediately without delay.
3. **Automated Tests**: Updated [test/shell.d/lock-blank-fingerprint-test.sh](file:///d:/projects/omarchy/test/shell.d/lock-blank-fingerprint-test.sh#L34-L37) to assert `runWake` post-blanking debounce logic.

Fixes #8863
