### PR TITLE
Let a click on °C/°F pin metric, imperial, or auto

### DIFF
--- a/shell/plugins/panels/weather/Model.js
+++ b/shell/plugins/panels/weather/Model.js
@@ -111,6 +111,14 @@ function countryUsesImperial(countryName) {
   return false
 }
 
+
+function nextTempUnitOverride(current) {
+  var unit = String(current || "")
+  if (unit === "metric") return "imperial"
+  if (unit === "imperial") return ""
+  return "metric"
+}
+
 function shouldUseImperial(unitOverride, localeName, countryName) {
   var unit = normalizedUnit(unitOverride)
   if (unit === "imperial") return true
@@ -279,6 +287,7 @@ if (typeof module !== "undefined") {
     localeUsesImperial: localeUsesImperial,
     countryUsesImperial: countryUsesImperial,
     shouldUseImperial: shouldUseImperial,
+    nextTempUnitOverride: nextTempUnitOverride,
     dayName: dayName,
     openMeteoForecastDays: openMeteoForecastDays,
     openMeteoCurrentCondition: openMeteoCurrentCondition,

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -147,6 +147,24 @@ Panel {
   readonly property string reportWind:      current ? (useImperial ? (current.windspeedMiles + " mph") : (current.windspeedKmph + " km/h")) : ""
   readonly property string reportHumidity:  current ? (current.humidity + "%") : ""
 
+
+  function persistSettings(values) {
+    var entry = { id: root.moduleName }
+    for (var existing in root.settings) if (existing !== "id") entry[existing] = root.settings[existing]
+    for (var key in values) entry[key] = values[key]
+    root.settings = entry
+    if (root.hostWidget && "settings" in root.hostWidget) root.hostWidget.settings = entry
+    if (root.bar && root.bar.shell && typeof root.bar.shell.updateEntryInline === "function")
+      root.bar.shell.updateEntryInline(root.moduleName, entry)
+  }
+
+  // Click the °C/°F label to pin metric or imperial (or return to auto). Timezone
+  // / reported-country changes otherwise flip the unit with no UI escape hatch.
+  function cycleTempUnit() {
+    var next = Model.nextTempUnitOverride(setting("unit", ""))
+    persistSettings({ unit: next })
+  }
+
   function refresh() {
     // Each full refresh cycle gets a fresh retry budget, so an earlier
     // exhausted round (e.g. waking with the network still down) doesn't
@@ -558,6 +576,7 @@ Panel {
               font.bold: true
             }
             Text {
+              id: tempUnitLabel
               textFormat: Text.PlainText
               text: root.current ? root.tempUnit : ""
               color: root.bar.foreground
@@ -565,6 +584,14 @@ Panel {
               font.pixelSize: Style.font.display
               anchors.top: tempBig.top
               anchors.topMargin: Style.space(10)
+
+              MouseArea {
+                anchors.fill: parent
+                anchors.margins: -Style.space(4)
+                cursorShape: Qt.PointingHandCursor
+                enabled: !!root.current
+                onClicked: root.cycleTempUnit()
+              }
             }
           }
         }

--- a/test/shell.d/weather-unit-cycle-test.sh
+++ b/test/shell.d/weather-unit-cycle-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+panel="$ROOT/shell/plugins/panels/weather/Panel.qml"
+model="$ROOT/shell/plugins/panels/weather/Model.js"
+
+grep -q 'function cycleTempUnit()' "$panel" || fail "weather panel can cycle the temperature unit"
+grep -q 'onClicked: root.cycleTempUnit()' "$panel" || fail "weather unit label is clickable"
+grep -q 'function nextTempUnitOverride' "$model" || fail "weather model exposes unit cycle helper"
+
+# Pure bash cycle checks mirroring Model.nextTempUnitOverride
+next_for() {
+  case "$1" in
+    metric) echo imperial ;;
+    imperial) echo "" ;;
+    *) echo metric ;;
+  esac
+}
+[[ $(next_for "") == "metric" ]] || fail "auto cycles to metric"
+[[ $(next_for metric) == "imperial" ]] || fail "metric cycles to imperial"
+[[ $(next_for imperial) == "" ]] || fail "imperial cycles back to auto"
+
+pass "weather temperature unit can be pinned from the panel"


### PR DESCRIPTION
## Summary
- Timezone / reported-country changes can flip the weather unit with no UI escape hatch, even though shell.json already accepts a `unit` override.
- Clicking the °C/°F label now cycles auto → metric → imperial → auto and persists via `updateEntryInline`.

Fixes #8690.

## Test plan
- [x] `bash test/shell.d/weather-unit-cycle-test.sh`
- [ ] Open weather panel, click the unit letter, confirm it pins and survives a shell restart

