### PR TITLE
Keep terminals from inheriting another window's fullscreen

### DIFF
--- a/default/hypr/apps/terminals.lua
+++ b/default/hypr/apps/terminals.lua
@@ -4,5 +4,10 @@
 -- The class is matched in full, so foot's other app-id needs spelling out.
 o.window(
   "(Alacritty|kitty|com.mitchellh.ghostty|foot|org\\.codeberg\\.dnkl\\.foot|wezterm|org\\.omarchy\\..*|TUI\\..*)",
-  { tag = "+terminal" }
+  {
+    tag = "+terminal",
+    -- Opening a terminal while another client is fullscreen must not inherit
+    -- that fullscreen state (Hyprland's syncfullscreen / focus-under path).
+    fullscreen = false,
+  }
 )

--- a/test/shell.d/terminal-nofullscreen-test.sh
+++ b/test/shell.d/terminal-nofullscreen-test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+file="$ROOT/default/hypr/apps/terminals.lua"
+grep -q 'tag = "+terminal"' "$file" || fail "terminals still tagged"
+grep -q 'fullscreen = false' "$file" || fail "terminals must refuse inherited fullscreen"
+pass "terminal windows do not inherit fullscreen from the focused client"


### PR DESCRIPTION
## Summary
- Opening a terminal while another client is fullscreen was mapping the terminal fullscreen too.
- Force `fullscreen = false` on the terminal window tag so Super+Return stays windowed.

Fixes #8751.

## Test plan
- [x] `bash test/shell.d/terminal-nofullscreen-test.sh`
- [ ] Fullscreen mpv/browser, press Super+Return, confirm the terminal is not fullscreen


