### PR TITLE
Use Yaru-*-dark icon sets for every dark theme

### DIFF
--- a/test/shell.d/theme-dark-icons-test.sh
+++ b/test/shell.d/theme-dark-icons-test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+bad=()
+for colors in "$ROOT"/themes/*/colors.toml; do
+  mode=$(head -1 "$colors")
+  [[ $mode == *dark* ]] || continue
+  icons="$(dirname "$colors")/icons.theme"
+  [[ -f $icons ]] || continue
+  value=$(tr -d '[:space:]' <"$icons")
+  [[ $value == *-dark ]] || bad+=("$(basename "$(dirname "$colors")"):$value")
+done
+
+(( ${#bad[@]} == 0 )) || fail "dark themes must use Yaru-*-dark icons: ${bad[*]}"
+pass "dark themes ship Yaru-*-dark icon variants"

--- a/themes/catppuccin/icons.theme
+++ b/themes/catppuccin/icons.theme
@@ -1,1 +1,1 @@
-Yaru-purple
+Yaru-purple-dark

--- a/themes/ethereal/icons.theme
+++ b/themes/ethereal/icons.theme
@@ -1,1 +1,1 @@
-Yaru-blue
+Yaru-blue-dark

--- a/themes/everforest/icons.theme
+++ b/themes/everforest/icons.theme
@@ -1,1 +1,1 @@
-Yaru-sage
+Yaru-sage-dark

--- a/themes/gruvbox/icons.theme
+++ b/themes/gruvbox/icons.theme
@@ -1,1 +1,1 @@
-Yaru-olive
+Yaru-olive-dark

--- a/themes/hackerman/icons.theme
+++ b/themes/hackerman/icons.theme
@@ -1,1 +1,1 @@
-Yaru-blue
+Yaru-blue-dark

--- a/themes/kanagawa/icons.theme
+++ b/themes/kanagawa/icons.theme
@@ -1,1 +1,1 @@
-Yaru-blue
+Yaru-blue-dark

--- a/themes/last-horizon/icons.theme
+++ b/themes/last-horizon/icons.theme
@@ -1,1 +1,1 @@
-Yaru-purple
+Yaru-purple-dark

--- a/themes/lumon/icons.theme
+++ b/themes/lumon/icons.theme
@@ -1,1 +1,1 @@
-Yaru-blue
+Yaru-blue-dark

--- a/themes/matte-black/icons.theme
+++ b/themes/matte-black/icons.theme
@@ -1,1 +1,1 @@
-Yaru-red
+Yaru-red-dark

--- a/themes/miasma/icons.theme
+++ b/themes/miasma/icons.theme
@@ -1,1 +1,1 @@
-Yaru-wartybrown
+Yaru-wartybrown-dark

--- a/themes/nord/icons.theme
+++ b/themes/nord/icons.theme
@@ -1,1 +1,1 @@
-Yaru-blue
+Yaru-blue-dark

--- a/themes/osaka-jade/icons.theme
+++ b/themes/osaka-jade/icons.theme
@@ -1,1 +1,1 @@
-Yaru-sage
+Yaru-sage-dark

--- a/themes/retro-82/icons.theme
+++ b/themes/retro-82/icons.theme
@@ -1,1 +1,1 @@
-Yaru-wartybrown
+Yaru-wartybrown-dark

--- a/themes/ristretto/icons.theme
+++ b/themes/ristretto/icons.theme
@@ -1,1 +1,1 @@
-Yaru-yellow
+Yaru-yellow-dark

--- a/themes/tokyo-night/icons.theme
+++ b/themes/tokyo-night/icons.theme
@@ -1,1 +1,1 @@
-Yaru-magenta
+Yaru-magenta-dark

--- a/themes/vantablack/icons.theme
+++ b/themes/vantablack/icons.theme
@@ -1,1 +1,1 @@
-Yaru-gray
+Yaru-gray-dark


### PR DESCRIPTION
## Summary
- Dark themes were shipping light Yaru icon variants (`Yaru-purple`, `Yaru-blue`, …), so tray/symbolic icons drew dark ink on the dark bar and disappeared.
- Point every dark theme at the matching `Yaru-*-dark` set (solitude already did).

Fixes #8844.

## Test plan
- [x] `bash test/shell.d/theme-dark-icons-test.sh`
- [ ] Switch to catppuccin/nord/gruvbox and confirm tray icons are legible


