### PR TITLE
Show individual batteries in power panel

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -115,6 +115,12 @@ function batteryPercentLabel(device) {
   return String(Math.round(pct * 100))
 }
 
+function batteryChargeLabel(device, states) {
+  var charge = batteryPercentLabel(device) + "%"
+  var state = batteryStateLabel(device, states)
+  return state ? charge + " · " + state : charge
+}
+
 function batteryCapacityLabel(device) {
   var cap = Number(device && device.energyCapacity)
   if (!isFinite(cap) || cap <= 0) return "—"
@@ -135,6 +141,7 @@ if (typeof module !== "undefined") {
     batteryName: batteryName,
     batteryStateLabel: batteryStateLabel,
     batteryPercentLabel: batteryPercentLabel,
+    batteryChargeLabel: batteryChargeLabel,
     batteryCapacityLabel: batteryCapacityLabel
   }
 }

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -89,6 +89,38 @@ function modeLabel(device, onBattery, states) {
   return "Charging"
 }
 
+function batteryName(device) {
+  var d = device || {}
+  var native = String(d.nativePath || "").split("/").filter(function (p) { return p.length > 0 }).pop()
+  if (native) return native
+  var model = String(d.model || "").trim()
+  return model || "Battery"
+}
+
+function batteryStateLabel(device, states) {
+  var d = device || {}
+  var s = states || {}
+  if (d.state === s.Charging) return "Charging"
+  if (d.state === s.Discharging) return "Discharging"
+  if (d.state === s.Empty) return "Empty"
+  if (d.state === s.FullyCharged) return "Full"
+  if (d.state === s.PendingCharge) return "Pending charge"
+  if (d.state === s.PendingDischarge) return "Pending discharge"
+  return ""
+}
+
+function batteryPercentLabel(device) {
+  var pct = Number(device && device.percentage)
+  if (!isFinite(pct)) return "—"
+  return String(Math.round(pct * 100))
+}
+
+function batteryCapacityLabel(device) {
+  var cap = Number(device && device.energyCapacity)
+  if (!isFinite(cap) || cap <= 0) return "—"
+  return cap.toFixed(1) + " Wh"
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampIndex: clampIndex,
@@ -99,6 +131,10 @@ if (typeof module !== "undefined") {
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,
-    modeLabel: modeLabel
+    modeLabel: modeLabel,
+    batteryName: batteryName,
+    batteryStateLabel: batteryStateLabel,
+    batteryPercentLabel: batteryPercentLabel,
+    batteryCapacityLabel: batteryCapacityLabel
   }
 }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -16,26 +16,70 @@ Panel {
   property var batteryInfo: ({})
   property var systemInfo: ({})
   property var profiles: []
+  // Physical battery devices on the system, in UPower enumeration order. The
+  // hero and progress bar above aggregate them via the display device; this
+  // list backs the per-battery breakdown shown when more than one exists.
+  readonly property var batteries: collectBatteries()
   property string activeProfile: ""
   property int profileIndex: 0
   property bool cursorActive: false
   readonly property bool showPercentage: setting("showPercentage", false) === true
   // With the percentage shown the button paints a text block wider than an
   // icon, so the open-panel mark takes the painted width instead of the
-  // icon-sized fraction of the slot the fallback assumes.
-  readonly property real openPanelIndicatorWidth: showPercentage && !button.vertical ? button.glyphPaintedWidth : 0
+  // icon-sized fraction of the slot the fallback assumes. The same applies
+  // whenever multiple batteries widen the button past a single icon.
+  readonly property real openPanelIndicatorWidth: (showPercentage || batteries.length > 1) && !button.vertical ? button.glyphPaintedWidth : 0
   readonly property bool batteryPresent: {
     var device = UPower.displayDevice
     return !!(device && device.isPresent)
   }
 
+  // Horizontal bars show every physical battery when the system has more than
+  // one (an icon and percentage each, in UPower order). Vertical bars and
+  // single-battery systems retain the compact aggregate display device.
+  readonly property string buttonText: {
+    if (batteries.length > 1 && !vertical) {
+      var parts = []
+      for (var i = 0; i < batteries.length; i++) {
+        var device = batteries[i]
+        parts.push(Model.batteryIcon(device, root.discharging, upowerStates()) + " " + Model.batteryPercentLabel(device) + "%")
+      }
+      return parts.join(" · ")
+    }
+    if (root.showPercentage && !vertical) return Math.round(root.batteryFraction * 100) + "% " + root.batteryIcon()
+    return root.batteryIcon()
+  }
+
+  // Bar button slot width, in icon slots. Each percentage block needs the same
+  // doubled slot the single-battery percentage view uses, scaled per battery.
+  readonly property int buttonSlotScale: batteries.length > 1 && !vertical
+    ? batteries.length * 2
+    : (showPercentage ? 2 : 1)
+
   function upowerStates() {
     return {
       Charging: UPowerDeviceState.Charging,
       Discharging: UPowerDeviceState.Discharging,
+      Empty: UPowerDeviceState.Empty,
       FullyCharged: UPowerDeviceState.FullyCharged,
-      PendingCharge: UPowerDeviceState.PendingCharge
+      PendingCharge: UPowerDeviceState.PendingCharge,
+      PendingDischarge: UPowerDeviceState.PendingDischarge
     }
+  }
+
+  // Collect the physical batteries (power supplies of type Battery) from the
+  // UPower device list. Requires a nativePath so the aggregated display device
+  // — which carries no path — can never sneak into the per-battery view.
+  function collectBatteries() {
+    var list = []
+    var devices = UPower.devices.values
+    for (var i = 0; i < devices.length; i++) {
+      var device = devices[i]
+      if (!device || device.type !== UPowerDeviceType.Battery) continue
+      if (!device.powerSupply || !device.nativePath) continue
+      list.push(device)
+    }
+    return list
   }
 
   function selectProfileByDelta(delta) {
@@ -277,10 +321,8 @@ Panel {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.showPercentage && !vertical
-      ? Math.round(root.batteryFraction * 100) + "% " + root.batteryIcon()
-      : root.batteryIcon()
-    slotSize: Style.bar.iconSlot * (root.showPercentage && !vertical ? 2 : 1)
+    text: root.buttonText
+    slotSize: Style.bar.iconSlot * root.buttonSlotScale
     tooltipText: ""
     onPressed: function(b) {
       if (!root.batteryPresent) return
@@ -415,6 +457,65 @@ Panel {
               alwaysRunToEnd: true
               NumberAnimation { from: 1.0; to: 0.55; duration: 950; easing.type: Easing.InOutSine }
               NumberAnimation { from: 0.55; to: 1.0; duration: 950; easing.type: Easing.InOutSine }
+            }
+          }
+        }
+
+        // ---------- Individual batteries ----------
+        // Systems with a single battery show everything in the hero and stats
+        // above. When more than one battery exists, the display device only
+        // aggregates them, so list each one separately here.
+        Column {
+          visible: root.batteries.length > 1
+          width: parent.width
+          spacing: Style.space(10)
+
+          PanelSectionHeader {
+            text: "BATTERIES"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Row {
+            id: batteryRow
+            width: parent.width
+            spacing: Style.space(20)
+
+            readonly property real cellWidth: root.batteries.length > 0
+              ? (width - spacing * (root.batteries.length - 1)) / root.batteries.length
+              : 0
+
+            Repeater {
+              model: root.batteries
+
+              Column {
+                required property var modelData
+                width: batteryRow.cellWidth
+                spacing: Style.spacing.labelGap
+
+                Text {
+                  textFormat: Text.PlainText
+                  text: Model.batteryName(modelData) + (modelData.model ? " — " + modelData.model : "")
+                  color: root.bar.foreground
+                  opacity: 0.9
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.caption
+                  font.bold: true
+                  font.letterSpacing: 0.8
+                  elide: Text.ElideRight
+                  width: parent.width
+                }
+
+                InfoPair {
+                  label: "Charge"
+                  value: Model.batteryPercentLabel(modelData) + "% · " + Model.batteryStateLabel(modelData, root.upowerStates())
+                }
+
+                InfoPair {
+                  label: "Size"
+                  value: Model.batteryCapacityLabel(modelData)
+                }
+              }
             }
           }
         }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -54,7 +54,7 @@ Panel {
   // doubled slot the single-battery percentage view uses, scaled per battery.
   readonly property int buttonSlotScale: batteries.length > 1 && !vertical
     ? batteries.length * 2
-    : (showPercentage ? 2 : 1)
+    : (showPercentage && !vertical ? 2 : 1)
 
   function upowerStates() {
     return {
@@ -76,7 +76,7 @@ Panel {
     for (var i = 0; i < devices.length; i++) {
       var device = devices[i]
       if (!device || device.type !== UPowerDeviceType.Battery) continue
-      if (!device.powerSupply || !device.nativePath) continue
+      if (!device.isPresent || !device.powerSupply || !device.nativePath) continue
       list.push(device)
     }
     return list
@@ -508,7 +508,7 @@ Panel {
 
                 InfoPair {
                   label: "Charge"
-                  value: Model.batteryPercentLabel(modelData) + "% · " + Model.batteryStateLabel(modelData, root.upowerStates())
+                  value: Model.batteryChargeLabel(modelData, root.upowerStates())
                 }
 
                 InfoPair {

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -59,6 +59,8 @@ assertEqual(power.batteryStateLabel({}, states), '', 'power leaves unknown batte
 assertEqual(power.batteryPercentLabel({ percentage: 0.423 }), '42', 'power formats battery percentage')
 assertEqual(power.batteryPercentLabel({ percentage: 0.999 }), '100', 'power rounds battery percentage up')
 assertEqual(power.batteryPercentLabel({}), '—', 'power reports missing battery percentage')
+assertEqual(power.batteryChargeLabel({ percentage: 0.42, state: states.Charging }, states), '42% · Charging', 'power formats charge and state')
+assertEqual(power.batteryChargeLabel({ percentage: 0.42 }, states), '42%', 'power omits the separator without a known state')
 
 assertEqual(power.batteryCapacityLabel({ energyCapacity: 19.02 }), '19.0 Wh', 'power formats battery capacity')
 assertEqual(power.batteryCapacityLabel({ energyCapacity: 0 }), '—', 'power reports zero battery capacity')
@@ -67,11 +69,13 @@ assertEqual(power.batteryCapacityLabel({}), '—', 'power reports missing batter
 assert(/UPowerDeviceState\.Empty/.test(panelSource), 'power maps empty battery state')
 assert(/UPowerDeviceState\.PendingDischarge/.test(panelSource), 'power maps pending-discharge battery state')
 assert(/UPowerDeviceType\.Battery/.test(panelSource), 'power filters physical batteries from the UPower device list')
+assert(/!device\.isPresent/.test(panelSource), 'power excludes absent physical batteries')
 assert(/UPower\.devices\.values/.test(panelSource), 'power enumerates the Quickshell UPower object model')
 assert(/root\.batteries\.length > 1/.test(panelSource), 'power only shows the per-battery breakdown on multi-battery systems')
 assert(/PanelSectionHeader[\s\S]*?text: "BATTERIES"/.test(panelSource), 'power heads the per-battery breakdown')
 assert(/Model\.batteryIcon\(device, root\.discharging, upowerStates\(\)\)/.test(panelSource), 'power lists each battery in the bar button')
 assert(/batteries\.length > 1 && !vertical/.test(panelSource), 'power keeps vertical bars on the compact aggregate battery')
+assert(/showPercentage && !vertical \? 2 : 1/.test(panelSource), 'power keeps percentage sizing compact on vertical bars')
 assert(/batteries\.length \* 2/.test(panelSource), 'power widens the bar button for multiple batteries')
 assert(/readonly property var batteries: collectBatteries\(\)/.test(panelSource), 'power reacts to changes in the UPower battery list')
 

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -8,7 +8,7 @@ run_node_test <<'JS'
 const fs = require('fs')
 const power = requireFromRoot('shell/plugins/panels/power/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/power/Panel.qml', 'utf8')
-const states = { Charging: 1, Discharging: 2, FullyCharged: 3, PendingCharge: 4 }
+const states = { Charging: 1, Discharging: 2, Empty: 3, FullyCharged: 4, PendingCharge: 5, PendingDischarge: 6 }
 
 assertEqual(power.selectProfileIndex(0, 1, ['balanced', 'performance']), 1, 'power advances profile selection')
 assertEqual(power.selectProfileIndex(1, 1, ['balanced', 'performance']), 1, 'power clamps profile selection')
@@ -41,6 +41,39 @@ assertEqual(
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Discharging }, true, states),
   'power shows battery icon when unplugged before battery state refreshes'
 )
+
+assertEqual(power.batteryName({ nativePath: 'BAT0' }), 'BAT0', 'power names battery from native path')
+assertEqual(power.batteryName({ nativePath: '/sys/devices/.../BAT1' }), 'BAT1', 'power extracts battery name from full native path')
+assertEqual(power.batteryName({ nativePath: '/sys/devices/.../BAT1/', model: 'AB12' }), 'BAT1', 'power ignores trailing slash in native path')
+assertEqual(power.batteryName({ model: 'AB12' }), 'AB12', 'power falls back to the model for battery name')
+assertEqual(power.batteryName({}), 'Battery', 'power defaults the battery name')
+
+assertEqual(power.batteryStateLabel({ state: states.Charging }, states), 'Charging', 'power labels charging battery')
+assertEqual(power.batteryStateLabel({ state: states.Discharging }, states), 'Discharging', 'power labels discharging battery')
+assertEqual(power.batteryStateLabel({ state: states.Empty }, states), 'Empty', 'power labels empty battery')
+assertEqual(power.batteryStateLabel({ state: states.FullyCharged }, states), 'Full', 'power labels full battery')
+assertEqual(power.batteryStateLabel({ state: states.PendingCharge }, states), 'Pending charge', 'power labels pending-charge battery')
+assertEqual(power.batteryStateLabel({ state: states.PendingDischarge }, states), 'Pending discharge', 'power labels pending-discharge battery')
+assertEqual(power.batteryStateLabel({}, states), '', 'power leaves unknown battery state unlabeled')
+
+assertEqual(power.batteryPercentLabel({ percentage: 0.423 }), '42', 'power formats battery percentage')
+assertEqual(power.batteryPercentLabel({ percentage: 0.999 }), '100', 'power rounds battery percentage up')
+assertEqual(power.batteryPercentLabel({}), '—', 'power reports missing battery percentage')
+
+assertEqual(power.batteryCapacityLabel({ energyCapacity: 19.02 }), '19.0 Wh', 'power formats battery capacity')
+assertEqual(power.batteryCapacityLabel({ energyCapacity: 0 }), '—', 'power reports zero battery capacity')
+assertEqual(power.batteryCapacityLabel({}), '—', 'power reports missing battery capacity')
+
+assert(/UPowerDeviceState\.Empty/.test(panelSource), 'power maps empty battery state')
+assert(/UPowerDeviceState\.PendingDischarge/.test(panelSource), 'power maps pending-discharge battery state')
+assert(/UPowerDeviceType\.Battery/.test(panelSource), 'power filters physical batteries from the UPower device list')
+assert(/UPower\.devices\.values/.test(panelSource), 'power enumerates the Quickshell UPower object model')
+assert(/root\.batteries\.length > 1/.test(panelSource), 'power only shows the per-battery breakdown on multi-battery systems')
+assert(/PanelSectionHeader[\s\S]*?text: "BATTERIES"/.test(panelSource), 'power heads the per-battery breakdown')
+assert(/Model\.batteryIcon\(device, root\.discharging, upowerStates\(\)\)/.test(panelSource), 'power lists each battery in the bar button')
+assert(/batteries\.length > 1 && !vertical/.test(panelSource), 'power keeps vertical bars on the compact aggregate battery')
+assert(/batteries\.length \* 2/.test(panelSource), 'power widens the bar button for multiple batteries')
+assert(/readonly property var batteries: collectBatteries\(\)/.test(panelSource), 'power reacts to changes in the UPower battery list')
 
 assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')


### PR DESCRIPTION
## Summary

- enumerate physical laptop batteries from Quickshell’s UPower object model
- show each battery’s icon and percentage in horizontal power widgets
- add a per-battery panel breakdown with name, model, charge state, percentage, and capacity
- preserve the existing aggregate display for single-battery systems and vertical bars

## Testing

- `bash test/shell.d/power-test.sh`
- `./test/shell` (all power tests pass; the local run retains unrelated environment failures for the missing `omarchy-pkgs` checkout and existing non-power checks)
- visually verified with BAT0 and BAT1 on a ThinkPad T470s

## Visual verification

![Power panel showing separate BAT0 and BAT1 readings](https://raw.githubusercontent.com/DegenApeDev/omarchy/pr-assets/8904/.github/pr-assets/omarchy-multi-battery-panel.png)