### PR TITLE
foot: render light themes into [colors-light] so foot reports the right color-theme mode

### DIFF
--- a/bin/omarchy-theme-color
+++ b/bin/omarchy-theme-color
@@ -16,6 +16,7 @@
 #
 # Theme mode precedence: `mode` key, legacy `theme_type` key, a light.mode
 # file beside the colors.toml, background luminance auto-detect, dark.
+# The value is lowercased; anything but light/dark falls to auto-detect.
 
 COLORS_FILE="$HOME/.local/state/omarchy/current/theme/colors.toml"
 OUTPUT=""
@@ -118,10 +119,17 @@ alias_theme_color() {
 }
 
 resolve_theme_mode() {
-  local bg_hex lum
+  local declared bg_hex lum
 
-  [[ ${THEME_COLORS[mode]} ]] || THEME_COLORS[mode]="${THEME_COLORS[theme_type]}"
-  [[ ${THEME_COLORS[mode]} ]] && return
+  # foot rejects anything outside light/dark, so only those two values
+  # may leave the resolver.
+  declared="${THEME_COLORS[mode]:-${THEME_COLORS[theme_type]}}"
+  declared="${declared,,}"
+
+  if [[ $declared == "light" || $declared == "dark" ]]; then
+    THEME_COLORS[mode]="$declared"
+    return
+  fi
 
   if [[ -f $COLORS_DIR/light.mode ]]; then
     THEME_COLORS[mode]="light"

--- a/default/themed/foot.ini.tpl
+++ b/default/themed/foot.ini.tpl
@@ -1,4 +1,6 @@
-[colors-dark]
+initial-color-theme={{ mode }}
+
+[colors-{{ mode }}]
 foreground={{ foreground_strip }}
 background={{ background_strip }}
 selection-foreground={{ selection_foreground_strip }}

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -92,6 +92,8 @@ red = "#f7768e"
 blue = "#7aa2f7"
 ```
 
+`mode` is `light` or `dark`. The resolver lowercases the value and auto-detects from the background when it is neither.
+
 Any key can be referenced from a template with `{{ key }}`. The foundational
 shell palette is loaded from:
 

--- a/migrations/1787993824.sh
+++ b/migrations/1787993824.sh
@@ -5,11 +5,19 @@ echo "Re-render the current theme so foot reports the right color-theme mode"
 # is only rewritten when the theme changes, which on an install that already
 # settled on a theme may be never, so re-render once to reach it.
 staged_foot="$HOME/.local/state/omarchy/current/theme/foot.ini"
+theme_name_path="$HOME/.local/state/omarchy/current/theme.name"
 
 [[ -f $staged_foot ]] || exit 0
 
 if grep -q '^initial-color-theme=' "$staged_foot"; then
   exit 0
 fi
+
+# omarchy-theme-remove deletes a theme without switching away, so the current
+# one may be gone, and omarchy-theme-set exits 1 on a name it cannot find --
+# which under the runner's bash -euo pipefail aborts the whole migration run.
+[[ -s $theme_name_path ]] || exit 0
+theme_name=$(<"$theme_name_path")
+[[ -d $OMARCHY_PATH/themes/$theme_name || -d $HOME/.config/omarchy/themes/$theme_name ]] || exit 0
 
 omarchy-theme-refresh

--- a/migrations/1787993824.sh
+++ b/migrations/1787993824.sh
@@ -1,0 +1,15 @@
+echo "Re-render the current theme so foot reports the right color-theme mode"
+
+# The foot template wrote every palette into [colors-dark], so foot answered the
+# CSI ?996n query with "dark" even under a light theme. The generated foot.ini
+# is only rewritten when the theme changes, which on an install that already
+# settled on a theme may be never, so re-render once to reach it.
+staged_foot="$HOME/.local/state/omarchy/current/theme/foot.ini"
+
+[[ -f $staged_foot ]] || exit 0
+
+if grep -q '^initial-color-theme=' "$staged_foot"; then
+  exit 0
+fi
+
+omarchy-theme-refresh

--- a/test/cli
+++ b/test/cli
@@ -424,6 +424,14 @@ if rg -q '\{\{[^}]+\}\}' "$LEGACY_NEXT_THEME"; then
 fi
 pass "legacy short palette renders the complete generated theme"
 
+# foot answers the CSI ?996n color-scheme query from whichever section
+# initial-color-theme names, so both have to follow the theme's own mode.
+grep -qFx 'initial-color-theme=light' "$NEXT_THEME/foot.ini" || fail "a light theme selects foot's light color theme"
+grep -qFx '[colors-light]' "$NEXT_THEME/foot.ini" || fail "a light theme renders its palette into foot's light section"
+grep -qFx 'initial-color-theme=dark' "$LEGACY_NEXT_THEME/foot.ini" || fail "a dark theme selects foot's dark color theme"
+grep -qFx '[colors-dark]' "$LEGACY_NEXT_THEME/foot.ini" || fail "a dark theme renders its palette into foot's dark section"
+pass "foot's generated config follows the theme's mode"
+
 osc_summary=$("$ROOT/bin/omarchy-theme-osc" "$NEXT_THEME/colors.toml" | python -c 'import sys; data = sys.stdin.buffer.read(); print(data.count(b"]4;"), b"]4;1;#ff0000" in data, b"]4;7;#ffffff" in data, b"]4;15;#eeeeee" in data, b"]12;#eeeeee" in data, b"]17;#808080" in data, b"]19;#eeeeee" in data)')
 [[ $osc_summary == "16 True True True True True True" ]] || fail "theme OSC aliases semantic colors to ANSI palette"
 pass "theme OSC aliases semantic colors to ANSI palette"

--- a/test/cli
+++ b/test/cli
@@ -408,6 +408,16 @@ bright_foreground #ffffff
 EOF
 pass "legacy short palette resolves every canonical neutral color"
 
+# foot rejects anything outside light/dark, so the mode must be normalized.
+MODE_COLORS_FILE="$PI_TMPDIR/mode-colors.toml"
+printf 'mode = "Light"\nbackground = "#101010"\n' >"$MODE_COLORS_FILE"
+[[ $("$ROOT/bin/omarchy-theme-color" --file "$MODE_COLORS_FILE" mode) == "light" ]] || fail "a capitalized mode is lowercased"
+printf 'mode = "sepia"\nbackground = "#fffcf0"\n' >"$MODE_COLORS_FILE"
+[[ $("$ROOT/bin/omarchy-theme-color" --file "$MODE_COLORS_FILE" mode) == "light" ]] || fail "an unknown mode falls back to background luminance"
+printf 'theme_type = "DARK"\nbackground = "#fffcf0"\n' >"$MODE_COLORS_FILE"
+[[ $("$ROOT/bin/omarchy-theme-color" --file "$MODE_COLORS_FILE" mode) == "dark" ]] || fail "a legacy theme_type is lowercased"
+pass "theme mode is normalized to light or dark"
+
 LEGACY_THEME_HOME="$PI_TMPDIR/legacy-theme-home"
 LEGACY_NEXT_THEME="$LEGACY_THEME_HOME/.local/state/omarchy/current/next-theme"
 mkdir -p "$LEGACY_NEXT_THEME"


### PR DESCRIPTION
Fixes #8905.

## Problem

`default/themed/foot.ini.tpl` renders every theme's palette into `[colors-dark]`. foot reports its active color-theme section to applications (`CSI ?996n` / mode 2031, contour protocol), and treats the primary theme as dark by convention. So on a light theme (Flexoki Light, background `FFFCF0`) foot answers "dark", and 996-aware TUIs such as hunk render dark on a light background. The theme already declares `mode = "light"` in `colors.toml`; the template ignored it.

## Fix

`foot.ini.tpl` renders the palette into `[colors-{{ mode }}]` and sets `initial-color-theme={{ mode }}`. The line lands at `[main]` scope because foot's `include` gives the file its own section scope (foot.ini(5)). `mode` is already a template token from `omarchy-theme-color --all`, resolved for every theme (explicit key, legacy markers, luminance fallback, default dark).

Themes that ship a static `foot.ini` are on `INSTALLED_THEME_DENIED` and always go through the template, so this covers every theme.

## Validation

- `test/shell.d/theme-staging-test.sh` passes.
- Template rendered with `mode` resolved from a live Flexoki Light `colors.toml` (Omarchy 4.0.1, foot 1.27.0): the include starts with `initial-color-theme=light` + `[colors-light]`.

Known limitations: a foot window that is already open does not re-read its config, so it keeps the old reported mode until reopened (the existing OSC repaint still fixes its colors). And only the active mode's section is rendered, so foot's manual color-theme toggle lands on foot's stock palette for the other mode.
