### PR TITLE
Avoid redundant lock after encrypted hibernate

### DIFF
--- a/bin/omarchy-hibernation-boot-auth
+++ b/bin/omarchy-hibernation-boot-auth
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# omarchy:summary=Check whether hibernate resume requires interactive boot authentication
+# omarchy:args=[root-device] [kernel-cmdline]
+# omarchy:hidden=true
+
+root_source=${1:-$(findmnt -no SOURCE / 2>/dev/null)}
+root_source=${root_source%%\[*}
+cmdline=${2:-$(< /proc/cmdline)}
+
+# Omarchy's encrypted install maps the root filesystem directly through
+# dm-crypt and unlocks it with mkinitcpio's encrypt hook. With no cryptkey on
+# the kernel command line, restoring a hibernation image necessarily passes
+# through the interactive LUKS prompt first.
+[[ -n $root_source ]] || exit 1
+[[ $(lsblk -dnro TYPE -- "$root_source" 2>/dev/null) == crypt ]] || exit 1
+[[ " $cmdline " == *" cryptdevice="* ]] || exit 1
+[[ " $cmdline " != *" cryptkey="* ]] || exit 1

--- a/bin/omarchy-system-hibernate
+++ b/bin/omarchy-system-hibernate
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# omarchy:summary=Hibernate the system
+# omarchy:group=system
+
+set -uo pipefail
+
+log_hibernate_path() {
+  logger --tag omarchy-system-hibernate -- "$*" 2>/dev/null || true
+}
+
+# A session lock is still the only authentication after resume on an
+# unencrypted install, or on an encrypted install that unlocks automatically.
+# Those paths go straight through the ordinary sleep monitor.
+if ! omarchy-hibernation-boot-auth; then
+  log_hibernate_path "boot-auth=unavailable marker=none action=ordinary-hibernate"
+  exec systemctl hibernate
+fi
+
+# The user sleep monitor cannot learn the sleep operation from logind's
+# PrepareForSleep signal. Hold an advisory lock while this explicit hibernate
+# request is in flight so the monitor can distinguish it from suspend without
+# leaving stale state behind if either process dies.
+runtime_dir=${XDG_RUNTIME_DIR:-}
+if [[ -z $runtime_dir || ! -d $runtime_dir ]]; then
+  log_hibernate_path "boot-auth=interactive marker=unavailable reason=runtime-dir action=ordinary-hibernate"
+  exec systemctl hibernate
+fi
+
+marker="$runtime_dir/omarchy-hibernate-boot-auth.lock"
+if ! exec {marker_fd}>>"$marker"; then
+  log_hibernate_path "boot-auth=interactive marker=unavailable reason=open action=ordinary-hibernate"
+  exec systemctl hibernate
+fi
+if ! flock -n "$marker_fd"; then
+  log_hibernate_path "boot-auth=interactive marker=unavailable reason=already-held action=ordinary-hibernate"
+  exec systemctl hibernate
+fi
+
+cleanup_marker() {
+  flock -u "$marker_fd" 2>/dev/null || true
+  rm -f -- "$marker"
+}
+trap cleanup_marker EXIT INT TERM
+
+log_hibernate_path "boot-auth=interactive marker=held action=hibernate"
+systemctl hibernate
+status=$?
+log_hibernate_path "boot-auth=interactive marker=releasing hibernate-status=$status"
+exit "$status"

--- a/bin/omarchy-system-sleep-monitor
+++ b/bin/omarchy-system-sleep-monitor
@@ -10,10 +10,28 @@ consume_sleep_events() {
 
   while IFS= read -r line; do
     if [[ $line == *"boolean true"* ]]; then
+      if hibernate_boot_auth_active; then
+        printf 'omarchy-system-sleep-monitor: boot authentication replaces the hibernate session lock\n' >&2
+        return 0
+      fi
       "$sleep_lock"
       return 0
     fi
   done
+}
+
+hibernate_boot_auth_active() {
+  local marker marker_fd lock_status
+  [[ -n ${XDG_RUNTIME_DIR:-} ]] || return 1
+  marker="$XDG_RUNTIME_DIR/omarchy-hibernate-boot-auth.lock"
+  [[ -f $marker ]] || return 1
+
+  exec {marker_fd}<"$marker" || return 1
+  flock -n -E 75 "$marker_fd" 2>/dev/null
+  lock_status=$?
+  exec {marker_fd}>&-
+
+  (( lock_status == 75 ))
 }
 
 monitor_sleep_events() {

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -36,7 +36,7 @@
   "system.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-launch-screensaver force"},
   "system.lock": {"icon":"","label":"Lock","action":"omarchy-system-lock"},
   "system.suspend": {"icon":"󰒲","label":"Suspend","when":"! omarchy-toggle-enabled suspend-off","action":"systemctl suspend"},
-  "system.hibernate": {"icon":"󰤁","label":"Hibernate","when":"omarchy-hibernation-available","action":"systemctl hibernate"},
+  "system.hibernate": {"icon":"󰤁","label":"Hibernate","when":"omarchy-hibernation-available","action":"omarchy-system-hibernate"},
   "system.logout": {"icon":"󰍃","label":"Logout","action":"omarchy-system-logout"},
   "system.reboot": {"icon":"󰜉","label":"Reboot","action":"omarchy-system-reboot"},
   "system.shutdown": {"icon":"󰐥","label":"Shutdown","action":"omarchy-system-shutdown"},

--- a/test/shell.d/hibernation-boot-auth-test.sh
+++ b/test/shell.d/hibernation-boot-auth-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+lsblk_log="$test_tmp/lsblk-args"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/lsblk" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >"$LSBLK_LOG"
+printf '%s\n' "$ROOT_TYPE"
+SH
+chmod +x "$mock_bin/lsblk"
+
+boot_auth="$ROOT/bin/omarchy-hibernation-boot-auth"
+encrypted_cmdline='cryptdevice=UUID=abcd:omarchy_root root=/dev/mapper/omarchy_root resume=/dev/mapper/omarchy_root'
+
+ROOT_TYPE=crypt LSBLK_LOG="$lsblk_log" PATH="$mock_bin:$PATH" \
+  "$boot_auth" '/dev/mapper/omarchy_root[/@]' "$encrypted_cmdline" ||
+  fail "encrypted hibernate uses interactive boot authentication"
+pass "encrypted hibernate uses interactive boot authentication"
+
+grep -F -- '/dev/mapper/omarchy_root' "$lsblk_log" >/dev/null ||
+  fail "boot authentication strips the Btrfs subvolume from the root device"
+if grep -F -- '[/@]' "$lsblk_log" >/dev/null; then
+  fail "boot authentication strips the Btrfs subvolume from the root device"
+fi
+pass "boot authentication strips the Btrfs subvolume from the root device"
+
+if ROOT_TYPE=part LSBLK_LOG="$lsblk_log" PATH="$mock_bin:$PATH" \
+  "$boot_auth" /dev/nvme0n1p2 "$encrypted_cmdline"; then
+  fail "unencrypted hibernate keeps the session lock"
+fi
+pass "unencrypted hibernate keeps the session lock"
+
+if ROOT_TYPE=crypt LSBLK_LOG="$lsblk_log" PATH="$mock_bin:$PATH" \
+  "$boot_auth" /dev/mapper/omarchy_root "$encrypted_cmdline cryptkey=rootfs:/crypto_keyfile.bin"; then
+  fail "keyfile-backed hibernate keeps the session lock"
+fi
+pass "keyfile-backed hibernate keeps the session lock"
+
+if ROOT_TYPE=crypt LSBLK_LOG="$lsblk_log" PATH="$mock_bin:$PATH" \
+  "$boot_auth" /dev/mapper/omarchy_root 'rd.luks.name=abcd=omarchy_root root=/dev/mapper/omarchy_root'; then
+  fail "custom encrypted boot paths keep the session lock"
+fi
+pass "custom encrypted boot paths keep the session lock"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -129,6 +129,7 @@ assertDeepEqual(
 
 const defaultItems = menu.parseMenuJsonc(defaultMenuJsonc)
 const defaultById = Object.fromEntries(defaultItems.map(item => [item.id, item]))
+assertEqual(defaultById['system.hibernate'].action, 'omarchy-system-hibernate', 'menu hibernates through the authentication-aware command')
 
 // Needs the real menu: app rows sort after all menu items, and only at that
 // item count does the order tiebreak alone bury an installed app.

--- a/test/shell.d/sleep-monitor-test.sh
+++ b/test/shell.d/sleep-monitor-test.sh
@@ -66,6 +66,54 @@ if kill -0 "$producer_pid" 2>/dev/null; then
 fi
 pass "sleep monitor reaps its event producer"
 
+# An explicit encrypted hibernate already authenticates through the initramfs
+# LUKS prompt. The hibernate command holds this lock only for that operation,
+# allowing the monitor to skip a redundant desktop prompt.
+runtime_dir="$tmpdir/runtime"
+boot_auth_marker="$runtime_dir/omarchy-hibernate-boot-auth.lock"
+boot_auth_ready="$runtime_dir/boot-auth-ready"
+mkdir -p "$runtime_dir"
+(
+  exec 9>>"$boot_auth_marker"
+  flock 9
+  touch "$boot_auth_ready"
+  exec sleep 30
+) &
+boot_auth_pid=$!
+
+for _ in {1..100}; do
+  [[ -e $boot_auth_ready ]] && break
+  sleep 0.01
+done
+[[ -e $boot_auth_ready ]] || fail "sleep monitor test acquires the hibernate marker"
+
+OMARCHY_PATH="$mock_omarchy" \
+  XDG_RUNTIME_DIR="$runtime_dir" \
+  PATH="$mock_bin:$PATH" \
+  PRODUCER_PID_FILE="$producer_pid_file" \
+  LOCK_LOG="$lock_log" \
+  "$sleep_monitor"
+
+(( $(wc -l <"$lock_log") == 1 )) ||
+  fail "sleep monitor accepts interactive boot authentication for hibernate"
+pass "sleep monitor accepts interactive boot authentication for hibernate"
+
+kill "$boot_auth_pid" 2>/dev/null || true
+wait "$boot_auth_pid" 2>/dev/null || true
+
+# A leftover file without a live holder is not authority to skip locking.
+: >"$boot_auth_marker"
+OMARCHY_PATH="$mock_omarchy" \
+  XDG_RUNTIME_DIR="$runtime_dir" \
+  PATH="$mock_bin:$PATH" \
+  PRODUCER_PID_FILE="$producer_pid_file" \
+  LOCK_LOG="$lock_log" \
+  "$sleep_monitor"
+
+(( $(wc -l <"$lock_log") == 2 )) ||
+  fail "sleep monitor ignores a stale hibernate marker"
+pass "sleep monitor ignores a stale hibernate marker"
+
 # Terminating the monitor must also clean up the producer instead of orphaning
 # it under the user systemd instance.
 cat >"$mock_bin/dbus-monitor" <<'SH'

--- a/test/shell.d/system-hibernate-test.sh
+++ b/test/shell.d/system-hibernate-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+runtime_dir="$test_tmp/runtime"
+call_log="$test_tmp/calls"
+marker="$runtime_dir/omarchy-hibernate-boot-auth.lock"
+mkdir -p "$mock_bin" "$runtime_dir"
+
+cat >"$mock_bin/omarchy-hibernation-boot-auth" <<'SH'
+#!/bin/bash
+
+exit "${BOOT_AUTH_STATUS:-1}"
+SH
+
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+
+marker="$XDG_RUNTIME_DIR/omarchy-hibernate-boot-auth.lock"
+marker_state=missing
+if [[ -f $marker ]]; then
+  exec 9<"$marker"
+  flock -n -E 75 9 2>/dev/null
+  lock_status=$?
+  if (( lock_status == 75 )); then
+    marker_state=locked
+  else
+    marker_state=unlocked
+  fi
+fi
+printf 'systemctl %s marker=%s\n' "$*" "$marker_state" >>"$CALL_LOG"
+exit "${SYSTEMCTL_STATUS:-0}"
+SH
+chmod +x "$mock_bin/omarchy-hibernation-boot-auth" "$mock_bin/systemctl"
+
+run_hibernate() {
+  : >"$call_log"
+  set +e
+  BOOT_AUTH_STATUS="$1" SYSTEMCTL_STATUS="${2:-0}" \
+    XDG_RUNTIME_DIR="$runtime_dir" CALL_LOG="$call_log" PATH="$mock_bin:$PATH" \
+    "$ROOT/bin/omarchy-system-hibernate"
+  hibernate_status=$?
+  set -e
+}
+
+run_hibernate 0
+grep -Fx 'systemctl hibernate marker=locked' "$call_log" >/dev/null ||
+  fail "encrypted hibernate marks boot-authenticated sleep"
+pass "encrypted hibernate marks boot-authenticated sleep"
+
+[[ ! -e $marker ]] || fail "encrypted hibernate cleans its marker after resume"
+pass "encrypted hibernate cleans its marker after resume"
+
+run_hibernate 1
+grep -Fx 'systemctl hibernate marker=missing' "$call_log" >/dev/null ||
+  fail "unencrypted hibernate leaves session locking enabled"
+pass "unencrypted hibernate leaves session locking enabled"
+
+run_hibernate 0 42
+(( hibernate_status == 42 )) ||
+  fail "hibernate propagates a failed system request" "exit: $hibernate_status"
+[[ ! -e $marker ]] || fail "failed hibernate cleans its boot-auth marker"
+pass "failed hibernate cleans its boot-auth marker"


### PR DESCRIPTION
## Problem

On a stock encrypted Omarchy installation, hibernate resume currently asks for authentication twice: once in initramfs to unlock LUKS and again in the restored native session lock.

The sleep monitor sees only logind's generic `PrepareForSleep(true)` signal, so it locks before both suspend and hibernate. For stock interactive LUKS hibernate, the saved session is inaccessible until the boot prompt has already authenticated the user.

Fixes #8909. Related reports appeared in #3185 and #6850; neither has an open fix, and #3185 explicitly asked for a new issue if this reproduced on Quattro.

## Change

This adds `omarchy-system-hibernate` and routes the menu through it. The command recognizes only Omarchy's known interactive boot-auth path: a dm-crypt root, `cryptdevice=` on the kernel command line, and no `cryptkey=`. It holds a live advisory runtime lock while that explicit hibernate request is in flight, allowing the sleep monitor to skip its session lock only while the marker is actively held.

Unencrypted, keyfile-backed, and unknown or custom encryption paths still get the native session lock. Suspend and direct or unmarked sleep requests still lock normally. A stale marker file does nothing, and every detection or marker failure falls back to the existing secure lock path. The monitor remains running throughout and continues to own every other sleep event.

## Verification

The hibernation detection, command, sleep monitor, sleep lock, menu, CLI, and changed shell tests pass. Live detection on the reporting machine identifies its stock encrypted root as interactive boot-auth; unencrypted, keyfile, custom, missing-marker, and stale-marker cases are covered by fail-secure tests.

A later hardware trace still showed both prompts because the sleep monitor received no live marker and therefore correctly requested the desktop lock. The old wrapper did not log why the marker was absent, so that historical distinction cannot be reconstructed. Current detection and marker locking pass, the local GUI action is explicitly routed through the wrapper, and this revision logs every detection, marker, and fallback decision without recording authentication data. A final marker-aware hardware hibernate cycle remains pending.
