### PR TITLE
Add Omafox to Firefox and Zen Browser for theme syncing

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -29,6 +29,11 @@ setup_firefox_wayland() {
   echo "MOZ_ENABLE_WAYLAND=1" > ~/.config/environment.d/omarchy-firefox-wayland.conf
 }
 
+setup_omafox() {
+  omarchy-pkg-aur-add omafox
+  omafox setup
+}
+
 case $1 in
 chromium)
   echo "Installing Chromium..."
@@ -81,6 +86,7 @@ firefox)
 
   browser_policy_setup_firefox_distribution /usr/lib/firefox/distribution
   setup_firefox_wayland
+  setup_omafox
   announce_browser_installed "Firefox"
   ;;
 zen)
@@ -89,6 +95,7 @@ zen)
 
   browser_policy_setup_firefox_distribution /opt/zen-browser/distribution
   setup_firefox_wayland
+  setup_omafox
   announce_browser_installed "Zen"
   ;;
 *)

--- a/default/firefox/policies.json
+++ b/default/firefox/policies.json
@@ -1,5 +1,11 @@
 {
   "policies": {
+    "ExtensionSettings": {
+      "@omafox": {
+        "installation_mode": "normal_installed",
+        "install_url": "https://addons.mozilla.org/firefox/downloads/latest/omafox/latest.xpi"
+      }
+    },
     "Preferences": {
       "apz.overscroll.enabled": {
         "Value": true,

--- a/install/helpers/browser-policy.sh
+++ b/install/helpers/browser-policy.sh
@@ -166,3 +166,43 @@ browser_policy_setup_firefox_distribution() {
   browser_policy_purge_dir "$distribution_dir"
   browser_policy_install_firefox_policies "$distribution_dir" "$policies"
 }
+
+browser_policy_ensure_firefox_omafox_policy() {
+  local distribution_dir=$1
+  local policy_file=$distribution_dir/policies.json
+  local tmp
+
+  browser_policy_setup_parent "$distribution_dir"
+  browser_policy_purge_dir "$distribution_dir"
+
+  if ! browser_policy_firefox_policy_file_ok "$policy_file"; then
+    browser_policy_install_firefox_policies "$distribution_dir"
+    return
+  fi
+
+  tmp=$(mktemp) || return 1
+  if ! as_root jq '
+    if type == "object" and
+      (.policies | type == "object") and
+      ((.policies.ExtensionSettings == null) or (.policies.ExtensionSettings | type == "object"))
+    then
+      .policies.ExtensionSettings["@omafox"] = {
+        "installation_mode": "normal_installed",
+        "install_url": "https://addons.mozilla.org/firefox/downloads/latest/omafox/latest.xpi"
+      }
+    else
+      error("policies.json does not contain a valid policies object")
+    end
+  ' "$policy_file" >"$tmp"; then
+    rm -f "$tmp"
+    printf 'Skipping invalid Firefox enterprise policy: %s\n' "$policy_file" >&2
+    return 0
+  fi
+
+  if as_root install -m 644 -o root -g root -T "$tmp" "$policy_file"; then
+    rm -f "$tmp"
+  else
+    rm -f "$tmp"
+    return 1
+  fi
+}

--- a/manual/23-browsers.md
+++ b/manual/23-browsers.md
@@ -30,9 +30,9 @@ These are Chromium-family only. Firefox and Zen don't get them.
 
 ## Firefox and Zen
 
-Firefox and Zen are a different family, so they get different treatment: Omarchy installs a policies file for sensible defaults and switches them into native Wayland mode, which you want for fractional scaling and smooth trackpad scrolling.
+Firefox and Zen are a different family, so they get different treatment: Omarchy installs a policies file for sensible defaults, installs Omafox to keep the browser theme synchronized with Omarchy, and switches them into native Wayland mode, which you want for fractional scaling and smooth trackpad scrolling.
 
-They don't get the Chromium extensions above, and they're not themed by Omarchy, so those parts of the experience are yours to set up.
+They don't get the Chromium-specific extensions above. Instead, Omafox applies the current Omarchy theme automatically through a Firefox extension and its local integration package.
 
 ## Removing one again
 

--- a/migrations/1787954420.sh
+++ b/migrations/1787954420.sh
@@ -1,0 +1,23 @@
+echo "Install Omafox for existing Firefox and Zen users"
+
+firefox_installed=false
+zen_installed=false
+
+omarchy-pkg-present firefox && firefox_installed=true
+omarchy-pkg-present zen-browser-bin && zen_installed=true
+
+if [[ $firefox_installed == "true" || $zen_installed == "true" ]]; then
+  source "$OMARCHY_PATH/install/helpers/browser-policy.sh"
+
+  omarchy-pkg-aur-add omafox
+
+  if [[ $firefox_installed == "true" ]]; then
+    browser_policy_ensure_firefox_omafox_policy /usr/lib/firefox/distribution
+  fi
+
+  if [[ $zen_installed == "true" ]]; then
+    browser_policy_ensure_firefox_omafox_policy /opt/zen-browser/distribution
+  fi
+
+  omafox setup
+fi

--- a/test/shell.d/browser-policy-dir-test.sh
+++ b/test/shell.d/browser-policy-dir-test.sh
@@ -275,6 +275,47 @@ fi
 [[ -d $dir_dist/policies.json ]] || fail "Firefox policy install leaves a planted policies.json directory in place"
 pass "Firefox policy install does not write into a planted policies.json directory"
 
+omafox_dist=$test_tmp/omafox-distribution
+mkdir -p "$omafox_dist"
+cat >"$omafox_dist/policies.json" <<'JSON'
+{
+  "policies": {
+    "DisableTelemetry": true,
+    "ExtensionSettings": {
+      "enterprise@example.com": {
+        "installation_mode": "force_installed",
+        "install_url": "https://example.com/enterprise.xpi"
+      }
+    }
+  }
+}
+JSON
+browser_policy_firefox_policy_file_ok() { return 0; }
+browser_policy_purge_dir() { :; }
+as_root() { unprivileged_as_root "$@"; }
+browser_policy_ensure_firefox_omafox_policy "$omafox_dist" ||
+  fail "Omafox policy setup merges into a valid existing Firefox policy"
+jq -e '
+  .policies.DisableTelemetry == true and
+  .policies.ExtensionSettings["enterprise@example.com"].installation_mode == "force_installed" and
+  .policies.ExtensionSettings["@omafox"] == {
+    "installation_mode": "normal_installed",
+    "install_url": "https://addons.mozilla.org/firefox/downloads/latest/omafox/latest.xpi"
+  }
+' "$omafox_dist/policies.json" >/dev/null ||
+  fail "Omafox policy setup preserves existing enterprise settings"
+pass "Omafox policy setup merges into an existing enterprise policy"
+
+printf '{not valid json\n' >"$omafox_dist/policies.json"
+browser_policy_ensure_firefox_omafox_policy "$omafox_dist" 2>/dev/null ||
+  fail "Omafox policy setup skips an invalid trusted policy"
+grep -Fxq '{not valid json' "$omafox_dist/policies.json" ||
+  fail "Omafox policy setup leaves an invalid trusted policy untouched"
+pass "Omafox policy setup does not replace an invalid trusted policy"
+
+unset -f browser_policy_firefox_policy_file_ok
+unset -f browser_policy_purge_dir
+
 grep -F 'exit "$failed"' "$ROOT/bin/omarchy-theme-set-browser" >/dev/null ||
   fail "omarchy-theme-set-browser exits non-zero when a policy write fails"
 pass "omarchy-theme-set-browser exits non-zero when a policy write fails"

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -68,6 +68,7 @@ omarchy-pkg-add|omarchy-pkg-aur-add)
   chromium) command=chromium ;;
   firefox) command=firefox ;;
   zen-browser-bin) command=zen-browser ;;
+  omafox) command=omafox ;;
   cursor-bin) command=cursor ;;
   sublime-text-4) command=sublime_text ;;
   vim) command=vim ;;
@@ -121,7 +122,8 @@ done
 for setup_command in \
   omarchy-install-chromium-copy-url \
   omarchy-install-chromium-ytdlp \
-  omarchy-theme-set-browser; do
+  omarchy-theme-set-browser \
+  omafox; do
   ln -s omarchy-test-setup-call "$mock_bin/$setup_command"
 done
 
@@ -231,7 +233,7 @@ pass "Chromium browser installer restores the complete Omarchy setup"
 : >"$setup_log"
 rm -f "$installed_dir/firefox"
 OMARCHY_TEST_REAL_BROWSER_INSTALL=true omarchy-default-browser --install firefox >/dev/null
-[[ $(<"$install_log") == "pkg:firefox" ]] || fail "Firefox browser installer installs the package"
+[[ $(<"$install_log") == $'pkg:firefox\npkg:omafox' ]] || fail "Firefox browser installer installs Firefox and Omafox"
 [[ $(omarchy-default-browser) == "firefox" ]] || fail "Firefox becomes the default after its full installer succeeds"
 grep -Fxq 'sudo:install -d -m 0755 -o root -g root /usr/lib/firefox/distribution' "$setup_log" ||
   fail "Firefox browser installer creates its distribution directory"
@@ -239,14 +241,16 @@ grep -Fxq 'sudo:find /usr/lib/firefox/distribution -mindepth 1 -maxdepth 1 ! -us
   fail "Firefox browser installer drops non-root files from its distribution directory"
 grep -Fxq "sudo:install -m 644 -o root -g root -T $ROOT/default/firefox/policies.json /usr/lib/firefox/distribution/policies.json" "$setup_log" ||
   fail "Firefox browser installer copies policies.json without following a destination symlink"
+grep -Fxq 'omafox:setup' "$setup_log" || fail "Firefox browser installer sets up Omafox"
 [[ -e $installed_dir/firefox ]] || fail "Firefox browser installer marks firefox installed"
+[[ -e $installed_dir/omafox ]] || fail "Firefox browser installer marks omafox installed"
 pass "Firefox browser installer restores the complete Omarchy setup"
 
 : >"$install_log"
 : >"$setup_log"
 rm -f "$installed_dir/zen-browser"
 OMARCHY_TEST_REAL_BROWSER_INSTALL=true omarchy-default-browser --install zen >/dev/null
-[[ $(<"$install_log") == "pkg:zen-browser-bin" ]] || fail "Zen browser installer installs the package"
+[[ $(<"$install_log") == $'pkg:zen-browser-bin\npkg:omafox' ]] || fail "Zen browser installer installs Zen and Omafox"
 [[ $(omarchy-default-browser) == "zen" ]] || fail "Zen becomes the default after its full installer succeeds"
 grep -Fxq 'sudo:install -d -m 0755 -o root -g root /opt/zen-browser/distribution' "$setup_log" ||
   fail "Zen browser installer creates its distribution directory"
@@ -254,7 +258,9 @@ grep -Fxq 'sudo:find /opt/zen-browser/distribution -mindepth 1 -maxdepth 1 ! -us
   fail "Zen browser installer drops non-root files from its distribution directory"
 grep -Fxq "sudo:install -m 644 -o root -g root -T $ROOT/default/firefox/policies.json /opt/zen-browser/distribution/policies.json" "$setup_log" ||
   fail "Zen browser installer copies policies.json without following a destination symlink"
+grep -Fxq 'omafox:setup' "$setup_log" || fail "Zen browser installer sets up Omafox"
 [[ -e $installed_dir/zen-browser ]] || fail "Zen browser installer marks zen-browser installed"
+[[ -e $installed_dir/omafox ]] || fail "Zen browser installer marks omafox installed"
 pass "Zen browser installer restores the complete Omarchy setup"
 
 omarchy-default-browser zen

--- a/test/shell.d/omafox-browser-integration-test.sh
+++ b/test/shell.d/omafox-browser-integration-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+calls="$test_tmp/calls"
+migration="$ROOT/migrations/1787954420.sh"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+[[ " ${OMARCHY_TEST_INSTALLED_PACKAGES:-} " == *" $1 "* ]]
+SH
+
+cat >"$mock_bin/omarchy-pkg-aur-add" <<'SH'
+#!/bin/bash
+printf 'package:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+SH
+
+cat >"$mock_bin/omafox" <<'SH'
+#!/bin/bash
+printf 'omafox:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+SH
+
+cat >"$mock_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+SH
+
+chmod +x "$mock_bin"/*
+
+export PATH="$mock_bin:$PATH"
+export OMARCHY_PATH="$ROOT"
+export OMARCHY_TEST_CALLS="$calls"
+
+jq -e '
+  .policies.ExtensionSettings["@omafox"] == {
+    "installation_mode": "normal_installed",
+    "install_url": "https://addons.mozilla.org/firefox/downloads/latest/omafox/latest.xpi"
+  }
+' "$ROOT/default/firefox/policies.json" >/dev/null || fail "Firefox policy normally installs Omafox from AMO"
+pass "Firefox policy normally installs Omafox from AMO"
+
+run_migration() {
+  : >"$calls"
+  OMARCHY_TEST_INSTALLED_PACKAGES=$1 bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration ""
+[[ ! -s $calls ]] || fail "Omafox migration skips systems without Firefox or Zen" "$(<"$calls")"
+pass "Omafox migration skips systems without Firefox or Zen"
+
+run_migration "firefox"
+grep -Fxq 'package:omafox' "$calls" || fail "Omafox migration installs the package for Firefox"
+grep -Fq '/usr/lib/firefox/distribution/policies.json' "$calls" || fail "Omafox migration installs the Firefox policy"
+if grep -Fq '/opt/zen-browser/distribution/policies.json' "$calls"; then
+  fail "Omafox migration does not install a Zen policy when Zen is absent"
+fi
+grep -Fxq 'omafox:setup' "$calls" || fail "Omafox migration configures the Firefox user"
+pass "Omafox migration configures existing Firefox installs"
+
+run_migration "zen-browser-bin"
+grep -Fxq 'package:omafox' "$calls" || fail "Omafox migration installs the package for Zen"
+grep -Fq '/opt/zen-browser/distribution/policies.json' "$calls" || fail "Omafox migration installs the Zen policy"
+if grep -Fq '/usr/lib/firefox/distribution/policies.json' "$calls"; then
+  fail "Omafox migration does not install a Firefox policy when Firefox is absent"
+fi
+grep -Fxq 'omafox:setup' "$calls" || fail "Omafox migration configures the Zen user"
+pass "Omafox migration configures existing Zen installs"
+
+run_migration "firefox zen-browser-bin"
+[[ $(grep -Fxc 'package:omafox' "$calls") == 1 ]] || fail "Omafox migration installs the package once when both browsers exist"
+grep -Fq '/usr/lib/firefox/distribution/policies.json' "$calls" || fail "Omafox migration refreshes the Firefox policy"
+grep -Fq '/opt/zen-browser/distribution/policies.json' "$calls" || fail "Omafox migration refreshes the Zen policy"
+[[ $(grep -Fxc 'omafox:setup' "$calls") == 1 ]] || fail "Omafox migration runs setup once when both browsers exist"
+pass "Omafox migration configures both installed browsers in one pass"


### PR DESCRIPTION
### Summary
- Add the [Omafox](https://github.com/cover/omafox) [AUR package](https://aur.archlinux.org/packages/omafox) and [Firefox/Zen extension](https://addons.mozilla.org/en-US/firefox/addon/omafox/) which keeps the theme in sync with Omarchy

### Test plan
- `bash test/shell.d/default-apps-test.sh`
- `bash test/shell.d/browser-policy-dir-test.sh`
- `bash test/shell.d/omafox-browser-integration-test.sh`