### PR TITLE
Keep the image selector fast when vips cannot read an image

### DIFF
--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -177,16 +177,39 @@ generate_thumbnail() {
   fi
 }
 
+declare -A thumbnail_index=()
+thumbnail_index_loaded=false
+
+# index.tsv keeps every image this cache has seen, so it grows without limit
+# while a directory stays small. One read of the file costs less than one scan
+# per image, which was O(images x index) and controlled the whole cold path.
+load_thumbnail_index() {
+  [[ $thumbnail_index_loaded == true ]] && return
+  thumbnail_index_loaded=true
+
+  [[ -f $index_file ]] || return
+
+  local indexed_path indexed_signature indexed_hash key
+  while IFS=$'\t' read -r indexed_path indexed_signature indexed_hash; do
+    [[ -n $indexed_path && -n $indexed_hash ]] || continue
+    key="$indexed_path"$'\t'"$indexed_signature"
+    # The first entry wins, as it did in the awk scan this replaced.
+    [[ -n ${thumbnail_index[$key]-} ]] || thumbnail_index["$key"]="$indexed_hash"
+  done <"$index_file"
+}
+
 thumbnail_for() {
   local image="$1"
-  local signature hash thumbnail
+  local signature hash thumbnail key
 
   signature=$(stat -Lc '%s:%Y' "$image") || return
-  hash=$(awk -F '\t' -v path="$image" -v sig="$signature" '$1 == path && $2 == sig { print $3; exit }' "$index_file" 2>/dev/null)
+  key="$image"$'\t'"$signature"
+  hash="${thumbnail_index[$key]-}"
 
   if [[ -z $hash ]]; then
     hash=$(printf '%s\t%s' "$image" "$signature" | md5sum | cut -d ' ' -f 1)
     printf '%s\t%s\t%s\n' "$image" "$signature" "$hash" >>"$index_file"
+    thumbnail_index["$key"]="$hash"
   fi
 
   thumbnail="$cache_dir/$hash.jpg"
@@ -233,6 +256,10 @@ if [[ $rows_cache_hit != true && -f $rows_cache_file && -f $rows_signature_file 
   rows=$(<"$rows_cache_file")
   printf '%s' "$rows_fast_signature" >"$rows_fast_signature_file"
 elif [[ $rows_cache_hit != true ]]; then
+  # thumbnail_for runs in a command substitution. It inherits this map, but it
+  # cannot fill it. Load the index here, once, before the loop calls out.
+  load_thumbnail_index
+
   for image in "${image_files[@]}"; do
     thumbnail=$(thumbnail_for "$image")
     thumbnail_status=$?

--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -166,8 +166,14 @@ generate_thumbnail() {
   # the lock after this shell is killed.
   if VIPS_CONCURRENCY=1 vipsthumbnail "$image" --size 1536x864 --smartcrop=centre --path "$tmp[Q=82,strip]" {lock_fd}>&-; then
     mv -f "$tmp" "$thumbnail"
+    rm -f "$thumbnail.failed"
   else
+    # Record the refusal so later runs stop retrying this image and stop
+    # treating it as a thumbnail that is still on its way. The marker is keyed
+    # by the same size:mtime hash as the thumbnail, so a repaired or replaced
+    # image gets a new hash, and the retry happens on its own.
     rm -f "$tmp" "$thumbnail"
+    : >"$thumbnail.failed"
   fi
 }
 
@@ -186,6 +192,17 @@ thumbnail_for() {
   thumbnail="$cache_dir/$hash.jpg"
 
   if [[ ! -f $thumbnail ]]; then
+    # An image vips already refused is settled, not pending. A retry on every
+    # run holds rows_cacheable down forever, and one unreadable image then
+    # costs every other image in the directory its cached row. Exit 2 tells the
+    # caller that this row is stable although it carries the source path:
+    # thumbnail_for runs in a command substitution, so it cannot clear
+    # rows_cacheable itself.
+    if [[ -f $thumbnail.failed ]]; then
+      printf '%s' "$image"
+      return 2
+    fi
+
     if [[ $lazy_thumbnails == true && $cache_only != true ]]; then
       rows_cacheable=false
 
@@ -218,8 +235,9 @@ if [[ $rows_cache_hit != true && -f $rows_cache_file && -f $rows_signature_file 
 elif [[ $rows_cache_hit != true ]]; then
   for image in "${image_files[@]}"; do
     thumbnail=$(thumbnail_for "$image")
+    thumbnail_status=$?
     [[ -n $thumbnail ]] || continue
-    if [[ $lazy_thumbnails == true && $cache_only != true && $thumbnail == $image ]]; then
+    if [[ $lazy_thumbnails == true && $cache_only != true && $thumbnail == $image && $thumbnail_status -ne 2 ]]; then
       rows_cacheable=false
     fi
 
@@ -236,7 +254,9 @@ elif [[ $rows_cache_hit != true ]]; then
     pruned=""
     while IFS=$'\t' read -r row_image row_thumbnail; do
       if [[ ! -e $row_thumbnail ]]; then
-        rows_cacheable=false
+        # A refusal that vips already recorded does not clear on a later run.
+        # Drop the row, but keep the rest of the directory cacheable.
+        [[ -f $row_thumbnail.failed ]] || rows_cacheable=false
         continue
       fi
 


### PR DESCRIPTION
## What

Two changes keep the image selector fast when a directory holds an image that
vips cannot read.

The image selector draws the theme menu (`SUPER + SHIFT + CTRL + SPACE`) and the
background menu (`SUPER + CTRL + SPACE`). On a machine with 136 themes, the theme
menu took 1.5 seconds to open. It now takes 0.18 seconds.

## Why

The selector makes one row for each image in a directory. Each row points to a
thumbnail. The selector writes these rows to a cache and reads the cache on the
next open.

The selector keeps the cache only when each thumbnail is on disk. This rule is
correct for a thumbnail that vips did not make yet. The row for that image points
to the source image, so the row is not stable.

But vips refuses some images. A 0-byte file is one example. Such an image never
gets a thumbnail. The selector cannot see a difference between this refusal and
work that is not complete. Thus the selector does this on each open:

1. It runs vips against the image again.
2. It finds no thumbnail again.
3. It deletes the row cache for the full directory.

The selector never recovers. One image that vips refuses makes all the other
images slow.

The cost increases with the number of themes, because the selector builds all the
rows again on each open. This is why the problem shows only on a large theme
collection.

## How to see the problem

```
: > ~/.config/omarchy/themes/<any-theme>/preview.png
```

Open the theme menu two times. The second open is as slow as the first one. The
file `~/.cache/omarchy/image-selector/<key>.rows` is absent after each open.

## The changes

**1. Keep one unreadable image from voiding every cached row**

`generate_thumbnail` writes a marker file when vips refuses an image.
`thumbnail_for` reads the marker and reports the row as stable. The other images
keep their cached rows. The selector drops the refused image from the menu.

The marker uses the same size:mtime hash as the thumbnail. A repaired image gets
a new hash, so vips runs against it again. No manual step is necessary.

**2. Read the thumbnail index once, not once per image**

`index.tsv` maps each image and its size:mtime to a thumbnail hash. It holds each
image the cache has seen, and nothing removes old entries. The file grows while a
directory stays small: 4400 lines for 154 images on the machine in the report.

The lookup ran one `awk` process for each image, and each process read the full
file. The cost was the image count multiplied by the index size. The `awk` calls
alone took 1.05 s of the 1.35 s cold path.

The index now goes into a map, one read, before the loop. The map is built in the
parent shell on purpose. `thumbnail_for` runs in a command substitution, so a load
inside it is lost after each call, and the file is read once per image again.

## Measurements

Machine with 136 themes and 156 preview images, index of 4454 lines.

| Step | Before | After |
| --- | --- | --- |
| Row preparation, theme menu | 1352 ms | 11 ms |
| Key press to menu handoff | 1510 ms | 183 ms |
| Cold path, 154 images (change 2 only) | 1058 ms | 634 ms |

Change 1 gives the large number, because the cold path now runs one time instead
of on each open. Change 2 makes that one cold path less expensive, and it helps
each user who adds a new theme.

## Tests

- A directory of 41 images with one 0-byte file keeps its row cache. Three
  further opens keep it.
- The 40 good images stay in the rows. The 0-byte file does not.
- Each cached row points to a thumbnail that exists.
- On a directory of 30 good images, the row set is the same as before the change.
- `index.tsv` is byte-identical to the file the old code writes. Thumbnails from
  an installed version stay valid after the upgrade.

## Note on staleness

A repaired image enters the rows when the selector builds the rows again. The
fast signature reads the directory mtime, so an in-place overwrite of one file is
not visible. This behaviour is not new: the current code ignores an in-place
overwrite of any image in the same way. The marker follows the same rule as every
other row.
