### PR TITLE
Name format-drive partitions correctly for mmcblk and loop

### DIFF
--- a/default/bash/fns/drives
+++ b/default/bash/fns/drives
@@ -29,15 +29,17 @@ iso2sd() {
   sudo eject "$drive"
 }
 
-# Format an entire drive for a single partition using exFAT
-# First partition path for a block device (nvme/mmcblk/loop/md use a `p` separator).
+# First partition path for a device. The kernel separates the partition number with
+# `p` when the device name ends in a digit: nvme0n1p1 and md127p1, but sda1 and md/data1.
 format-drive-partition() {
-  case "$1" in
-  *nvme* | *mmcblk* | *loop* | *md*) printf '%s\n' "${1}p1" ;;
-  *) printf '%s\n' "${1}1" ;;
-  esac
+  if [[ $1 == *[0-9] ]]; then
+    printf '%s\n' "${1}p1"
+  else
+    printf '%s\n' "${1}1"
+  fi
 }
 
+# Format an entire drive for a single partition using exFAT
 format-drive() {
   if (( $# != 2 )); then
     echo "Usage: format-drive <device> <name>"

--- a/default/bash/fns/drives
+++ b/default/bash/fns/drives
@@ -30,6 +30,14 @@ iso2sd() {
 }
 
 # Format an entire drive for a single partition using exFAT
+# First partition path for a block device (nvme/mmcblk/loop/md use a `p` separator).
+format-drive-partition() {
+  case "$1" in
+  *nvme* | *mmcblk* | *loop* | *md*) printf '%s\n' "${1}p1" ;;
+  *) printf '%s\n' "${1}1" ;;
+  esac
+}
+
 format-drive() {
   if (( $# != 2 )); then
     echo "Usage: format-drive <device> <name>"
@@ -47,7 +55,7 @@ format-drive() {
       sudo parted -s "$1" mkpart primary 1MiB 100%
       sudo parted -s "$1" set 1 msftdata on
 
-      partition="$([[ $1 == *"nvme"* ]] && echo "${1}p1" || echo "${1}1")"
+      partition="$(format-drive-partition "$1")"
       sudo partprobe "$1" || true
       sudo udevadm settle || true
 

--- a/test/shell.d/format-drive-partition-test.sh
+++ b/test/shell.d/format-drive-partition-test.sh
@@ -20,3 +20,6 @@ expect_partition /dev/nvme0n1 /dev/nvme0n1p1
 expect_partition /dev/mmcblk0 /dev/mmcblk0p1
 expect_partition /dev/loop0 /dev/loop0p1
 expect_partition /dev/md0 /dev/md0p1
+expect_partition /dev/md127 /dev/md127p1
+expect_partition /dev/md/data /dev/md/data1
+expect_partition /dev/nbd0 /dev/nbd0p1

--- a/test/shell.d/format-drive-partition-test.sh
+++ b/test/shell.d/format-drive-partition-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+source "$ROOT/default/bash/fns/drives"
+
+expect_partition() {
+  local device="$1"
+  local want="$2"
+  local got
+  got=$(format-drive-partition "$device")
+  [[ $got == "$want" ]] || fail "format-drive-partition $device" "expected $want, got $got"
+  pass "format-drive-partition $device → $want"
+}
+
+expect_partition /dev/sda /dev/sda1
+expect_partition /dev/vdb /dev/vdb1
+expect_partition /dev/nvme0n1 /dev/nvme0n1p1
+expect_partition /dev/mmcblk0 /dev/mmcblk0p1
+expect_partition /dev/loop0 /dev/loop0p1
+expect_partition /dev/md0 /dev/md0p1


### PR DESCRIPTION
## Summary
- `format-drive` now uses a shared `format-drive-partition` helper that adds the `p` separator for nvme, mmcblk, loop, and md devices (#8918).
- Classic SCSI/SATA paths still append `1` (`/dev/sda1`).

## Test plan
- [x] `test/shell.d/format-drive-partition-test.sh` covers sda/vdb/nvme/mmcblk/loop/md.
- [ ] On a spare mmcblk card, `format-drive /dev/mmcblk0 Label` finishes `mkfs.exfat` on `/dev/mmcblk0p1`.

Fixes #8918