### PR TITLE
Feed bt-agent stdin so Bluetooth pairing authorization can be answered

### DIFF
--- a/bin/omarchy-bluetooth-device
+++ b/bin/omarchy-bluetooth-device
@@ -29,6 +29,31 @@ trust_device() {
   bluetoothctl trust "$address" >/dev/null 2>&1 || true
 }
 
+# Trust is what lets BlueZ reconnect a device on its own later, and that only
+# works once a bond (keys kept on both sides) exists. A device trusted without
+# one is worse than unknown: BlueZ auto-connects it, the pairing fails the same
+# way every few seconds, and the journal fills until the user forgets it. So
+# trust follows a bond, never precedes it.
+bonded() {
+  [[ $(timeout 5s bluetoothctl info "$address" 2>/dev/null) == *"Bonded: yes"* ]]
+}
+
+# The bond is not necessarily there when `pair` or `connect` return. Some
+# peripherals ignore a host-initiated pair and only bond through their own
+# security request once connected, so `pair` times out and the bond forms during
+# `connect`; and `connect` itself returns at once with InProgress when BlueZ is
+# already connecting a device it knows. Closing the window on either return
+# leaves a session-only pairing (Paired but not Bonded) that is gone at the next
+# disconnect. Waiting on the bond itself is what keeps the window open for as
+# long as the handshake actually takes.
+wait_for_bond() {
+  local deadline=$((SECONDS + ${OMARCHY_BLUETOOTH_BOND_WAIT_SECONDS:-15}))
+  until bonded; do
+    ((SECONDS < deadline)) || return 1
+    sleep 1
+  done
+}
+
 # bt-agent.service auto-accepts JustWorks pairing authorization, so the adapter
 # must not sit pairable outside a pair the user actually asked for. Nothing else
 # in Omarchy touches this property and BlueZ defaults it on, which leaves the
@@ -46,12 +71,12 @@ case "$action" in
     power_on
     timeout 5s bluetoothctl pairable on >/dev/null 2>&1 || true
     timeout 20s bluetoothctl pair "$address" >/dev/null 2>&1 || true
-    trust_device
     timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 || true
+    if wait_for_bond; then trust_device; fi
     ;;
   connect)
     power_on
-    trust_device
+    if bonded; then trust_device; fi
     timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 || true
     ;;
   disconnect)

--- a/bin/omarchy-bluetooth-device
+++ b/bin/omarchy-bluetooth-device
@@ -29,9 +29,22 @@ trust_device() {
   bluetoothctl trust "$address" >/dev/null 2>&1 || true
 }
 
+# bt-agent.service auto-accepts JustWorks pairing authorization, so the adapter
+# must not sit pairable outside a pair the user actually asked for. Nothing else
+# in Omarchy touches this property and BlueZ defaults it on, which leaves the
+# adapter permanently open to unsolicited pair attempts. Closing it on EXIT means
+# every invocation of this script converges the adapter to non-pairable, whatever
+# the action and whichever way it ends - normal return, `timeout` expiry, or a
+# signal - and only the pair window below opens it.
+pairable_off() {
+  timeout 5s bluetoothctl pairable off >/dev/null 2>&1 || true
+}
+trap pairable_off EXIT
+
 case "$action" in
   pair)
     power_on
+    timeout 5s bluetoothctl pairable on >/dev/null 2>&1 || true
     timeout 20s bluetoothctl pair "$address" >/dev/null 2>&1 || true
     trust_device
     timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 || true

--- a/default/systemd/user/bt-agent.service
+++ b/default/systemd/user/bt-agent.service
@@ -24,7 +24,14 @@ ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service
 # `pair` and closes it on every exit path; ExecStartPost clears it once more at
 # login, covering a session where that script has not run yet.
 ExecStart=/bin/sh -c 'yes | /usr/bin/bt-agent -c NoInputNoOutput'
-ExecStartPost=-/usr/bin/timeout 5 /usr/bin/bluetoothctl pairable off
+# The settle delay is load-bearing. ExecStartPost runs as soon as ExecStart is
+# SPAWNED - before bt-agent has registered with bluez - and registering the
+# default agent leaves the adapter pairable, so clearing it at that instant logs
+# "Changing pairable off succeeded" and is then immediately undone. Confirmed
+# from the journal, where that line precedes "Agent registered", and by the
+# adapter reading `Pairable: true` afterwards. Clearing it once registration has
+# settled sticks.
+ExecStartPost=-/bin/sh -c 'sleep 3; exec /usr/bin/timeout 5 /usr/bin/bluetoothctl pairable off'
 Restart=on-failure
 RestartSec=2
 

--- a/default/systemd/user/bt-agent.service
+++ b/default/systemd/user/bt-agent.service
@@ -11,11 +11,15 @@ Type=simple
 # If bluetoothd is unavailable (for example in VMs or machines without a
 # usable adapter), skip cleanly instead of entering a restart loop.
 ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service
-# NoInputNoOutput auto-accepts pair requests. Safe because the adapter
-# is only `pairable: true` when the user explicitly opens the omarchy
-# bluetoothPanel and starts scanning; outside that window bluez refuses
-# inbound pair attempts at a lower layer.
-ExecStart=/usr/bin/bt-agent -c NoInputNoOutput
+# The capability alone does NOT auto-accept. For JustWorks pairing bluez calls
+# the agent's RequestAuthorization, and bt-agent answers that by prompting
+# "Authorize this device pairing (yes/no)?" on stdin no matter which -c it was
+# given. Under systemd stdin is /dev/null, so the prompt is never answered and
+# every pairing times out. Piping `yes` is what actually makes it auto-accept.
+# Safe because the adapter is only `pairable: true` when the user explicitly
+# opens the omarchy bluetoothPanel and starts scanning; outside that window
+# bluez refuses inbound pair attempts at a lower layer.
+ExecStart=/bin/sh -c 'yes | /usr/bin/bt-agent -c NoInputNoOutput'
 Restart=on-failure
 RestartSec=2
 

--- a/default/systemd/user/bt-agent.service
+++ b/default/systemd/user/bt-agent.service
@@ -16,10 +16,15 @@ ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service
 # "Authorize this device pairing (yes/no)?" on stdin no matter which -c it was
 # given. Under systemd stdin is /dev/null, so the prompt is never answered and
 # every pairing times out. Piping `yes` is what actually makes it auto-accept.
-# Safe because the adapter is only `pairable: true` when the user explicitly
-# opens the omarchy bluetoothPanel and starts scanning; outside that window
-# bluez refuses inbound pair attempts at a lower layer.
+#
+# Auto-accepting is only safe while the adapter is not pairable outside a pair
+# the user actually asked for. That guard did NOT previously exist: nothing in
+# the tree ever set `Pairable` and bluez defaults it on, so the adapter sat open
+# permanently (#7889). omarchy-bluetooth-device now opens the window only around
+# `pair` and closes it on every exit path; ExecStartPost clears it once more at
+# login, covering a session where that script has not run yet.
 ExecStart=/bin/sh -c 'yes | /usr/bin/bt-agent -c NoInputNoOutput'
+ExecStartPost=-/usr/bin/timeout 5 /usr/bin/bluetoothctl pairable off
 Restart=on-failure
 RestartSec=2
 

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -275,7 +275,11 @@ Panel {
 
   function connectDevice(device) {
     if (!device || device.connected) return
-    if (device.paired || device.bonded || device.trusted) runDeviceAction(device, "connect", "connecting")
+    // Trusted on its own does not make a device connectable. Trusted without a
+    // bond - a pair that failed after trusting, or a bond the peripheral has
+    // since dropped - is a device BlueZ already auto-connects and fails every
+    // few seconds; only a pair, with the pairing window open, gets it out.
+    if (device.paired || device.bonded) runDeviceAction(device, "connect", "connecting")
     else runDeviceAction(device, "pair", "connecting")
   }
 

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -50,6 +50,14 @@ assert(/sibling\.owesDiscoveryStop = true/.test(stopTimer[0]), 'bluetooth moves 
 assert(/onDiscoveringChanged[\s\S]{0,120}owesDiscoveryStop = false/.test(panelSource), 'bluetooth settles the stop it owes once discovery is confirmed down')
 assert(/Component\.onDestruction: \{[\s\S]{0,400}owesDiscoveryStop = true[\s\S]{0,200}discovering = false/.test(panelSource), 'bluetooth passes the stop it owes to a sibling when an instance is destroyed')
 
+// A device trusted without a bond is stuck: BlueZ auto-connects it and the
+// pairing fails every few seconds, and a plain connect never opens the pairing
+// window that would let it bond. Only pair does, so trust alone must route there.
+const connectDevice = panelSource.match(/function connectDevice\(device\) \{[\s\S]*?\n  \}/)
+assert(connectDevice, 'bluetooth has connectDevice')
+assert(/if \(device\.paired \|\| device\.bonded\) runDeviceAction\(device, "connect"/.test(connectDevice[0]), 'bluetooth connects only a device with a pairing or a bond')
+assert(!/trusted/.test(connectDevice[0].replace(/\/\/.*/g, '')), 'bluetooth does not take trust alone as connectable')
+
 assert(bluetooth.isUuidLike('0000110b-0000-1000-8000-00805f9b34fb'), 'bluetooth detects UUID-like names')
 assert(bluetooth.isAddressLike('AA:BB:CC:DD:EE:FF'), 'bluetooth detects address-like names')
 assertEqual(bluetooth.normalizedAddress('AA:BB_CC-dd-ee-ff'), 'aabbccddeeff', 'bluetooth normalizes BlueZ and PipeWire address formats')

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -165,6 +165,8 @@ if [[ $1 == "show" ]]; then
   [[ -n ${2:-} && -f "$POWERED_FILE.$2" ]] && state="$POWERED_FILE.$2"
   printf '\tPowered: %s\n' "$(cat "$state")"
 fi
+# The bond is what pair waits on and trust follows; MOCK_BONDED stands in for it.
+[[ $1 == "info" ]] && printf '\tBonded: %s\n' "${MOCK_BONDED:-no}"
 exit 0
 SH
 
@@ -190,7 +192,7 @@ bluetooth_run() {
   echo "$powered" >"$POWERED_FILE"
   : >"$device_tmp/log"
   PATH="$mock_bin:$ROOT/bin:$PATH" BLUETOOTHCTL_LOG="$device_tmp/log" \
-    OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=0 "$@" ||
+    OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=0 OMARCHY_BLUETOOTH_BOND_WAIT_SECONDS=0 "$@" ||
     fail "$* exits cleanly with Powered: $powered"
   printf '%s' "$device_tmp/log"
 }
@@ -299,6 +301,52 @@ pass "bluetooth does not open the pairing window to connect"
 [[ $(tail -n1 "$connect_window_log") == "pairable off" ]] ||
   fail "bluetooth closes the pairing window even when it never opened it" "$(cat "$connect_window_log")"
 pass "bluetooth closes the pairing window even when it never opened it"
+
+# The window has to outlast the handshake, not the commands. Some peripherals
+# ignore a host-initiated pair and bond only through their own security request
+# once connected, and connect itself returns at once with InProgress when BlueZ
+# is already connecting a device it knows. Closing on either return leaves
+# Paired-but-not-Bonded: a session key gone at the next disconnect. So the
+# script asks the device for its bond after connecting and before it closes.
+pair_log=$(bluetooth_run yes "$ROOT/bin/omarchy-bluetooth-device" pair AA:BB:CC:DD:EE:FF)
+
+awk '/^connect AA:BB:CC:DD:EE:FF$/ { connected = 1 }
+     /^pairable off$/ { closed = 1 }
+     /^info AA:BB:CC:DD:EE:FF$/ && connected && !closed { ok = 1 }
+     END { exit ok ? 0 : 1 }' "$pair_log" ||
+  fail "bluetooth checks for the bond after connecting and before closing the window" "$(cat "$pair_log")"
+pass "bluetooth checks for the bond after connecting and before closing the window"
+
+# Trust is what makes BlueZ reconnect a device on its own, and only a bond can
+# honour that. Trusting a device that never bonded leaves BlueZ auto-connecting
+# it and failing every few seconds until the user forgets it.
+grep -q "^trust " "$pair_log" &&
+  fail "bluetooth does not trust a device that never bonded" "$(cat "$pair_log")"
+pass "bluetooth does not trust a device that never bonded"
+
+bonded_pair_log=$(MOCK_BONDED=yes bluetooth_run yes "$ROOT/bin/omarchy-bluetooth-device" pair AA:BB:CC:DD:EE:FF)
+
+awk '/^info AA:BB:CC:DD:EE:FF$/ { seen = 1 }
+     /^trust AA:BB:CC:DD:EE:FF$/ && !done { ok = seen; done = 1 }
+     END { exit ok ? 0 : 1 }' "$bonded_pair_log" ||
+  fail "bluetooth trusts a device once it reports a bond" "$(cat "$bonded_pair_log")"
+pass "bluetooth trusts a device once it reports a bond"
+
+[[ $(tail -n1 "$bonded_pair_log") == "pairable off" ]] ||
+  fail "bluetooth closes the pairing window after the bond" "$(cat "$bonded_pair_log")"
+pass "bluetooth closes the pairing window after the bond"
+
+# The same rule on connect: a known device that lost its bond must not be
+# re-trusted into that loop by a plain connect, while a bonded one still is.
+connect_log=$(bluetooth_device_log yes)
+grep -q "^trust " "$connect_log" &&
+  fail "bluetooth does not trust an unbonded device on connect" "$(cat "$connect_log")"
+pass "bluetooth does not trust an unbonded device on connect"
+
+bonded_connect_log=$(MOCK_BONDED=yes bluetooth_device_log yes)
+grep -qx "trust AA:BB:CC:DD:EE:FF" "$bonded_connect_log" ||
+  fail "bluetooth trusts a bonded device on connect" "$(cat "$bonded_connect_log")"
+pass "bluetooth trusts a bonded device on connect"
 
 # Blocking hits every radio at once, so the read has to span them too. A bare
 # bluetoothctl show reports the default controller and misses a powered dongle.

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -263,6 +263,43 @@ grep -qx "connect AA:BB:CC:DD:EE:FF" "$unpowered_log" ||
   fail "bluetooth connects once the adapter is up" "$(cat "$unpowered_log")"
 pass "bluetooth connects once the adapter is up"
 
+# bt-agent answers RequestAuthorization with an unconditional yes, so a
+# permanently pairable adapter would accept unsolicited pair attempts with no
+# user action at all. The window must open only for a pair the user asked for,
+# and must close again however the script ends.
+# One shared log file is truncated per run, so each assertion block re-runs the
+# action it is about rather than reusing an earlier path.
+pair_log=$(bluetooth_run yes "$ROOT/bin/omarchy-bluetooth-device" pair AA:BB:CC:DD:EE:FF)
+
+grep -qx "pairable on" "$pair_log" ||
+  fail "bluetooth opens the pairing window for an explicit pair" "$(cat "$pair_log")"
+pass "bluetooth opens the pairing window for an explicit pair"
+
+# Ordering matters: opening it after the attempt would be useless.
+# Decide in END only - an `exit` inside a rule still runs END, so an END that
+# exits too would clobber the status the rule just set.
+awk '/^pairable on$/ { seen = 1 }
+     /^pair AA:BB:CC:DD:EE:FF$/ && !done { ok = seen; done = 1 }
+     END { exit ok ? 0 : 1 }' "$pair_log" ||
+  fail "bluetooth opens the window before attempting to pair" "$(cat "$pair_log")"
+pass "bluetooth opens the window before attempting to pair"
+
+[[ $(tail -n1 "$pair_log") == "pairable off" ]] ||
+  fail "bluetooth closes the pairing window when the pair finishes" "$(cat "$pair_log")"
+pass "bluetooth closes the pairing window when the pair finishes"
+
+# An already-bonded device needs no pairability, so connect must never widen it,
+# and still has to leave the adapter closed on the way out.
+connect_window_log=$(bluetooth_device_log yes)
+
+grep -q "pairable on" "$connect_window_log" &&
+  fail "bluetooth does not open the pairing window to connect" "$(cat "$connect_window_log")"
+pass "bluetooth does not open the pairing window to connect"
+
+[[ $(tail -n1 "$connect_window_log") == "pairable off" ]] ||
+  fail "bluetooth closes the pairing window even when it never opened it" "$(cat "$connect_window_log")"
+pass "bluetooth closes the pairing window even when it never opened it"
+
 # Blocking hits every radio at once, so the read has to span them too. A bare
 # bluetoothctl show reports the default controller and misses a powered dongle.
 echo yes >"$POWERED_FILE.11:22:33:44:55:66"

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -12,6 +12,21 @@ pass "bt-agent skips when bluetooth.service is inactive"
 grep -Fx 'Restart=on-failure' "$service" >/dev/null
 pass "bt-agent still restarts after runtime failures"
 
+# The agent answers RequestAuthorization with an unconditional yes, so it must
+# not leave the adapter pairable for anyone in radio range.
+grep -q 'bluetoothctl pairable off' "$service" >/dev/null ||
+  fail "bt-agent closes the pairing window it opens"
+pass "bt-agent closes the pairing window it opens"
+
+# And it must wait first. ExecStartPost runs when ExecStart is SPAWNED, before
+# the agent has registered with bluez, and registering the default agent leaves
+# the adapter pairable - so an immediate clear reports success and is undone a
+# moment later. Guard the delay, because losing it fails silently: the unit still
+# starts, the journal still says "succeeded", and the adapter stays open.
+grep -qE 'ExecStartPost=.*sleep [0-9]+;.*bluetoothctl pairable off' "$service" ||
+  fail "bt-agent defers the pairing-window close until the agent has registered"
+pass "bt-agent defers the pairing-window close until the agent has registered"
+
 sleep_service="$ROOT/default/systemd/user/omarchy-sleep-lock.service"
 grep -Fx 'ExecStart=/usr/bin/omarchy-system-sleep-monitor' "$sleep_service" >/dev/null
 pass "sleep lock service uses the package-backed monitor path"


### PR DESCRIPTION
## What's wrong

`default/systemd/user/bt-agent.service` says `-c NoInputNoOutput` auto-accepts pair requests. It does not.

For JustWorks pairing bluez calls the agent's `RequestAuthorization`, and bluez-tools' `bt-agent` implements that by prompting

```
Authorize this device pairing (yes/no)?
```

on **stdin**, regardless of the capability it was started with. Under systemd stdin is `/dev/null`, so the prompt is never answered and every pairing times out.

This is the only pairing agent Omarchy ships — the Quickshell shell registers none, and `install/user/first-run/enable-user-units.sh` enables this unit — so on a stock install no BLE peripheral that needs JustWorks authorization can pair.

## Symptom

The device is left trusted-but-unbonded, then reconnects and drops roughly once per second, filling the journal:

```
bluetoothd: profiles/deviceinfo/deviceinfo.c:read_pnpid_cb() Error reading PNP_ID value:
            Request attribute has encountered an unlikely error
bluetoothd: profiles/input/hog-lib.c:info_read_cb() HID Information read failed: ...
bt-agent:   Authorize this device pairing (yes/no)? Device: Logi M850 L (DB:D8:...)
```

Those ATT errors are insufficient-authentication surfacing: HID-over-GATT needs an encrypted link, which needs a bond that never formed.

## The fix

Pipe `yes` into the agent, which is what actually makes it auto-accept — the behaviour the unit's `Description` and comment already claim. The existing safety rationale is unchanged and kept in the comment.

## Verification

Omarchy 4.0.1, bluez 5.87, Logitech M850 L (BLE HID). Pairing failed in a loop for several minutes with the stock unit. With stdin fed, `bluetoothctl pair` completed immediately:

```
Paired: yes
Bonded: yes
Connected: yes
```

Only stdin differed between the two attempts.

## Relationship to existing issues

- #7879 — "Bluetooth panel treats trusted-but-unbonded devices as paired and never retries pairing" describes the **aftermath**: `omarchy-bluetooth-device pair` trusts the address even when pairing failed, so the device is thereafter only ever connected, never re-paired. This PR removes the reason the first pair fails for BLE HID devices in the first place. The two are complementary — #7879 is still worth fixing on its own, since any other pair failure leads to the same trap.
- #6992 — reports this same unit broken for an unrelated packaging reason (orphaned `bluez-tools`).