### PR TITLE
Tile the Battle.net client instead of floating it

### DIFF
--- a/bin/omarchy-launch-battlenet
+++ b/bin/omarchy-launch-battlenet
@@ -8,6 +8,7 @@ set -e
 
 PREFIX="$HOME/Games/battlenet"
 LAUNCHER="$PREFIX/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"
+WINDOW_CLASS="steam_app_battlenet"
 
 with_mangohud=0
 for arg in "$@"; do
@@ -36,6 +37,77 @@ if [[ ! -f $LAUNCHER ]]; then
   echo "Battle.net is not installed. Run omarchy-install-gaming-battlenet first." >&2
   exit 1
 fi
+
+battlenet_clients_json() {
+  hyprctl clients -j 2>/dev/null || echo '[]'
+}
+
+battlenet_window_address() {
+  battlenet_clients_json | jq -r --arg c "$WINDOW_CLASS" '
+    .[] | select(.class == $c and (.title | test("^Battle\\.net"))) | .address
+  ' | head -n1
+}
+
+# Bring an already-mapped Battle.net window onto the focused workspace and
+# center it. A second umu-run just makes the client log "another instance is
+# running" and exit, which looks like a failed launch.
+focus_battlenet_window() {
+  local address=$1
+  [[ -n $address ]] || return 1
+
+  hyprctl dispatch "hl.dsp.focus({ window = \"address:$address\" })" >/dev/null 2>&1 ||
+    hyprctl dispatch focuswindow "address:$address" >/dev/null 2>&1 || true
+
+  local workspace
+  workspace=$(hyprctl activeworkspace -j 2>/dev/null | jq -r '.id // empty')
+  if [[ -n $workspace ]]; then
+    hyprctl dispatch "hl.dsp.window.move({ workspace = \"$workspace\" })" >/dev/null 2>&1 || true
+  fi
+
+  # Tiled windows are placed by the layout. Only floating leftovers (login,
+  # setup, or a pre-fix 1280x800 dialog) need an explicit on-screen center.
+  local floating
+  floating=$(battlenet_clients_json | jq -r --arg a "$address" '.[] | select(.address == $a) | .floating')
+  if [[ $floating == "true" ]]; then
+    local pos
+    pos=$(battlenet_clients_json | jq -r --arg a "$address" --argjson mons "$(hyprctl monitors -j 2>/dev/null || echo '[]')" '
+      .[] | select(.address == $a) as $w |
+      ($mons | map(select(.id == $w.monitor)) | .[0]) as $m |
+      if $m == null then
+        empty
+      else
+        "\((($m.x + ($m.width - $w.size[0]) / 2) | floor)) \((($m.y + ($m.height - $w.size[1]) / 2) | floor))"
+      end
+    ')
+    if [[ -n $pos ]]; then
+      local x y
+      read -r x y <<<"$pos"
+      hyprctl eval "hl.dispatch(hl.dsp.window.move({ x = $x, y = $y }))" >/dev/null 2>&1 || true
+    fi
+  fi
+}
+
+existing=$(battlenet_window_address)
+if [[ -n $existing ]]; then
+  focus_battlenet_window "$existing"
+  exit 0
+fi
+
+wait_for_battlenet_window() {
+  local i address
+  for ((i = 0; i < 30; i++)); do
+    sleep 1
+    address=$(battlenet_window_address)
+    if [[ -n $address ]]; then
+      focus_battlenet_window "$address"
+      return 0
+    fi
+  done
+}
+
+wait_for_battlenet_window &
+waiter=$!
+trap 'kill $waiter 2>/dev/null || true' EXIT
 
 env_args=(
   WINEPREFIX="$PREFIX"

--- a/default/applications/battlenet.desktop
+++ b/default/applications/battlenet.desktop
@@ -8,4 +8,4 @@ Icon=battle-net
 Terminal=false
 Categories=Game;
 StartupNotify=true
-StartupWMClass=battle.net.exe
+StartupWMClass=steam_app_battlenet

--- a/default/hypr/apps/battlenet.lua
+++ b/default/hypr/apps/battlenet.lua
@@ -1,16 +1,39 @@
 -- Battle.net launches under Proton; all its windows share class steam_app_battlenet.
 
--- The actual launcher: float-centered.
+-- Main client: tile it like every other app. Omarchy used to float it at
+-- 1280x800; Wine/Qt then sent an X11 ConfigureRequest that parked that dialog
+-- off the left edge (x ~= -2 * monitor width on 1080p with GDK_SCALE=2).
+-- Ignore those configure requests so the tiled size sticks.
+--
+-- Do not tile the login or setup windows: resizing the Qt shell during login
+-- destroys the CEF webview (empty logo box, WM_DESTROY on webViewWindow).
+
 o.window({ class = "^steam_app_battlenet$", title = "^Battle\\.net$" }, {
+  tile = true,
+  suppress_event = "maximize x11configurerequest",
+})
+
+o.window({ class = "^steam_app_battlenet$", title = "^Battle\\.net Login$" }, {
   float = true,
   center = true,
-  size = { 1280, 800 },
+  suppress_event = "maximize x11configurerequest",
 })
 
 -- Installer: drop decorations and backdrop blur/shadow so the Blizzard chrome
--- isn't framed by the WM.
+-- isn't framed by the WM. Same X11 configure trap as the launcher.
 o.window({ class = "^steam_app_battlenet$", title = "^Battle\\.net Setup$" }, {
+  float = true,
+  center = true,
   decorate = false,
   no_blur = true,
   no_shadow = true,
+  suppress_event = "maximize x11configurerequest",
+})
+
+-- Dropdowns and CEF children are empty-title 0x0 XWayland windows.
+-- Without stay_focused + min_size they close as soon as they open.
+o.window({ class = "^steam_app_battlenet$", title = "^$" }, {
+  float = true,
+  stay_focused = true,
+  min_size = { 1, 1 },
 })

--- a/test/shell.d/battlenet-test.sh
+++ b/test/shell.d/battlenet-test.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+require_command lua
+require_command jq
+
 install_script="$ROOT/bin/omarchy-install-gaming-battlenet"
+launch_script="$ROOT/bin/omarchy-launch-battlenet"
+rules_file="$ROOT/default/hypr/apps/battlenet.lua"
 
 [[ ! -f $ROOT/applications/battlenet.desktop ]] || fail "Battle.net launcher is not part of default application refresh"
 [[ -f $ROOT/default/applications/battlenet.desktop ]] || fail "Battle.net launcher template is available to the installer"
@@ -12,3 +17,206 @@ grep -F '$OMARCHY_PATH/default/applications/battlenet.desktop' "$install_script"
   fail "Battle.net installer installs the launcher from the installer-only template"
 
 pass "Battle.net launcher is only installed by the Battle.net installer"
+
+launcher_rule=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+o = {
+  window = function(match, rules)
+    if match.title == "^Battle\\.net$" then
+      print(match.class)
+      print(tostring(rules.tile))
+      print(tostring(rules.float))
+      print(tostring(rules.size))
+      print(rules.suppress_event)
+    end
+  end,
+}
+
+require("default.hypr.apps.battlenet")
+LUA
+)
+
+expected_launcher_rule=$'^steam_app_battlenet$\ntrue\nnil\nnil\nmaximize x11configurerequest'
+[[ $launcher_rule == "$expected_launcher_rule" ]] ||
+  fail "Battle.net launcher tiles and ignores X11 configure requests" "$launcher_rule"
+
+pass "Battle.net launcher tiles and ignores X11 configure requests"
+
+setup_rule=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+o = {
+  window = function(match, rules)
+    if match.title == "^Battle\\.net Setup$" then
+      print(match.class)
+      print(tostring(rules.float))
+      print(tostring(rules.center))
+      print(tostring(rules.decorate))
+      print(rules.suppress_event)
+    end
+  end,
+}
+
+require("default.hypr.apps.battlenet")
+LUA
+)
+
+expected_setup_rule=$'^steam_app_battlenet$\ntrue\ntrue\nfalse\nmaximize x11configurerequest'
+[[ $setup_rule == "$expected_setup_rule" ]] ||
+  fail "Battle.net setup floats on-screen without a tiled WM frame" "$setup_rule"
+
+pass "Battle.net setup floats on-screen without a tiled WM frame"
+
+login_rule=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+o = {
+  window = function(match, rules)
+    if match.title == "^Battle\\.net Login$" then
+      print(match.class)
+      print(tostring(rules.float))
+      print(tostring(rules.center))
+      print(tostring(rules.size))
+      print(rules.suppress_event)
+    end
+  end,
+}
+
+require("default.hypr.apps.battlenet")
+LUA
+)
+
+expected_login_rule=$'^steam_app_battlenet$\ntrue\ntrue\nnil\nmaximize x11configurerequest'
+[[ $login_rule == "$expected_login_rule" ]] ||
+  fail "Battle.net login dialog floats without the launcher size" "$login_rule"
+
+pass "Battle.net login dialog floats without the launcher size"
+
+grep -Fq 'StartupWMClass=steam_app_battlenet' "$ROOT/default/applications/battlenet.desktop" ||
+  fail "Battle.net desktop entry uses the Proton window class"
+pass "Battle.net desktop entry uses the Proton window class"
+
+child_rule=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+o = {
+  window = function(match, rules)
+    if match.title == "^$" then
+      print(match.class)
+      print(tostring(rules.float))
+      print(tostring(rules.stay_focused))
+      print(rules.min_size[1] .. "x" .. rules.min_size[2])
+    end
+  end,
+}
+
+require("default.hypr.apps.battlenet")
+LUA
+)
+
+expected_child_rule=$'^steam_app_battlenet$\ntrue\ntrue\n1x1'
+[[ $child_rule == "$expected_child_rule" ]] ||
+  fail "Battle.net empty-title children stay floating with a min size" "$child_rule"
+
+pass "Battle.net empty-title children stay floating with a min size"
+
+grep -Fq 'tile = true' "$rules_file" ||
+  fail "Battle.net main client must tile like other apps"
+pass "Battle.net main client tiles like other apps"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_home="$test_tmp/home"
+mkdir -p "$fake_home/Games/battlenet/drive_c/Program Files (x86)/Battle.net"
+touch "$fake_home/Games/battlenet/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/umu-run" <<'SH'
+#!/bin/bash
+printf 'umu:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+printenv WINEPREFIX PROTONPATH GAMEID PROTON_VERB >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+printf 'hyprctl:%s\n' "$*" >>"$OMARCHY_TEST_HYPR_LOG"
+
+case "$1" in
+  clients)
+    printf '%s\n' "${OMARCHY_TEST_CLIENTS_JSON:-[]}"
+    ;;
+  monitors)
+    printf '%s\n' "${OMARCHY_TEST_MONITORS_JSON:-[]}"
+    ;;
+  activeworkspace)
+    printf '{"id":5}\n'
+    ;;
+  dispatch|eval)
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+SH
+
+chmod +x "$mock_bin"/*
+
+launch_log="$test_tmp/launch.log"
+hypr_log="$test_tmp/hypr.log"
+
+PATH="$mock_bin:$PATH" HOME="$fake_home" \
+  OMARCHY_TEST_LOG="$launch_log" OMARCHY_TEST_HYPR_LOG="$hypr_log" \
+  OMARCHY_TEST_CLIENTS_JSON='[]' \
+  bash "$launch_script"
+
+grep -Fq "umu:$fake_home/Games/battlenet/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe" "$launch_log" ||
+  fail "Battle.net launcher starts umu-run when no window exists" "$(cat "$launch_log")"
+grep -Fxq "$fake_home/Games/battlenet" "$launch_log" || fail "Battle.net launcher sets WINEPREFIX"
+grep -Fxq "GE-Proton" "$launch_log" || fail "Battle.net launcher sets PROTONPATH"
+grep -Fxq "umu-battlenet" "$launch_log" || fail "Battle.net launcher sets GAMEID"
+
+pass "Battle.net launcher starts umu-run when no window exists"
+
+>"$launch_log"
+>"$hypr_log"
+
+existing_clients='[{"address":"0xabc","class":"steam_app_battlenet","title":"Battle.net","monitor":1,"size":[1280,800],"floating":false}]'
+existing_monitors='[{"id":1,"x":0,"y":0,"width":1920,"height":1080}]'
+
+PATH="$mock_bin:$PATH" HOME="$fake_home" \
+  OMARCHY_TEST_LOG="$launch_log" OMARCHY_TEST_HYPR_LOG="$hypr_log" \
+  OMARCHY_TEST_CLIENTS_JSON="$existing_clients" \
+  OMARCHY_TEST_MONITORS_JSON="$existing_monitors" \
+  bash "$launch_script"
+
+[[ -s $launch_log ]] && fail "Battle.net launcher must not start a second umu-run" "$(cat "$launch_log")"
+grep -Fq 'hl.dsp.focus({ window = "address:0xabc" })' "$hypr_log" ||
+  fail "Battle.net launcher focuses the existing window" "$(cat "$hypr_log")"
+grep -Fq 'hl.dsp.window.move({ workspace = "5" })' "$hypr_log" ||
+  fail "Battle.net launcher moves the existing window to the current workspace" "$(cat "$hypr_log")"
+grep -Fq 'hl.dsp.window.move({ x = 320, y = 140 })' "$hypr_log" &&
+  fail "Battle.net launcher must not center a tiled window" "$(cat "$hypr_log")"
+
+pass "Battle.net launcher focuses an already-running tiled window instead of starting a second client"
+
+>"$launch_log"
+>"$hypr_log"
+
+floating_clients='[{"address":"0xdef","class":"steam_app_battlenet","title":"Battle.net Login","monitor":1,"size":[362,719],"floating":true}]'
+
+PATH="$mock_bin:$PATH" HOME="$fake_home" \
+  OMARCHY_TEST_LOG="$launch_log" OMARCHY_TEST_HYPR_LOG="$hypr_log" \
+  OMARCHY_TEST_CLIENTS_JSON="$floating_clients" \
+  OMARCHY_TEST_MONITORS_JSON="$existing_monitors" \
+  bash "$launch_script"
+
+[[ -s $launch_log ]] && fail "Battle.net launcher must not start umu-run when a login window exists" "$(cat "$launch_log")"
+grep -Fq 'hl.dsp.window.move({ x = 779, y = 180 })' "$hypr_log" ||
+  fail "Battle.net launcher centers a floating login window" "$(cat "$hypr_log")"
+
+pass "Battle.net launcher centers a floating login window on the focused monitor"


### PR DESCRIPTION
## Summary

- Tile the main Battle.net window like other apps. The previous `float + center + size {1280, 800}` rule, combined with Wine's X11 ConfigureRequest under `GDK_SCALE=2` and `xwayland.force_zero_scaling`, parked the client at `x ~= -2 * monitor width` on 1080p. Launch looked like a brief splash, then nothing.
- Keep **Battle.net Login** and **Battle.net Setup** floating. Tiling those resizes the Qt shell and destroys the CEF login webview (empty logo box).
- Suppress `x11configurerequest` (and `maximize`) so Proton cannot shove the tiled window off-screen or undo the layout.
- Float empty-title XWayland children with `stay_focused` + `min_size` so dropdowns do not vanish, same pattern as Steam.
- `omarchy-launch-battlenet` focuses an already-running window and moves it to the current workspace. A second `umu-run` just logs "another instance is running" and exits.
- Desktop `StartupWMClass` is `steam_app_battlenet`, the class Proton actually uses.

## Reproduction

On Omarchy 4.0.1, 1920x1080, `GDK_SCALE=2`:

1. Install Battle.net from the menu, then launch it from the app launcher.
2. Before: Hyprland listed `steam_app_battlenet` / `Battle.net` as a 1280x800 float at **(-3520, 153)** — one `GDK_SCALE * monitor_width` off the left edge. After: the same window tiles on the current workspace and the CEF UI renders (home, games, friends).
3. Launching again focuses that window instead of spawning a second Proton prefix that immediately exits.

Login and setup stay floating dialogs. Games launched from Battle.net do not match `^Battle\.net$`, so they are unaffected.

## Tests

- `bash test/shell.d/battlenet-test.sh`
- `luac -p default/hypr/apps/battlenet.lua`
- `bash -n bin/omarchy-launch-battlenet`
- Live: tiled next to Steam at 941x1030 with a working CEF home/games view; second launch focused the existing window (`umu-run` count unchanged).