### PR TITLE
Restart fprintd after resume so it re-enumerates the reader

### DIFF
--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -53,6 +53,39 @@ EOF
   fi
 }
 
+# libfprint enumerates USB once, at startup, and ships no hotplug support:
+#
+#   $ strings /usr/lib/libfprint-2.so* | grep -ci hotplug
+#   0
+#
+# So a long-lived fprintd never re-probes the bus. When a reader is
+# re-enumerated across suspend the daemon keeps a handle nothing answers to and
+# reports "No devices available" — with a healthy sleep inhibitor and nothing
+# at all in `journalctl -u fprintd`, which is what makes it hard to recognise.
+# Restarting it clears the stale state; doing so on every resume means the
+# state cannot outlive a single wake.
+#
+# try-restart, not restart: when fprintd is not running there is nothing stale
+# to clear, and starting it here would put its activation inside a sleep
+# transition, where logind refuses it its own delay inhibitor (see #7229).
+setup_fprintd_resume_unit() {
+  echo "Configuring fprintd to re-probe the reader after resume..."
+  sudo tee /etc/systemd/system/fprintd-resume.service >/dev/null <<'EOF'
+[Unit]
+Description=Restart fprintd after resume so it re-enumerates the reader
+After=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl try-restart fprintd.service
+
+[Install]
+WantedBy=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
+EOF
+  sudo systemctl daemon-reload
+  sudo systemctl enable fprintd-resume.service >/dev/null
+}
+
 setup_lock_fingerprint_pam() {
   echo "Configuring lock screen for fingerprint authentication..."
   sudo tee /etc/pam.d/omarchy-lock-fingerprint >/dev/null <<'EOF'
@@ -100,6 +133,7 @@ if sudo fprintd-enroll "$USER"; then
     # pam_fprintd with nothing to match.
     setup_pam_config
     setup_lock_fingerprint_pam
+    setup_fprintd_resume_unit
     echo -e "\e[32m\nPerfect! Fingerprint authentication is now configured.\e[0m"
     echo "You can use your fingerprint for sudo, polkit, and lock screen (Super + Ctrl + L)."
   else

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -82,6 +82,15 @@ ExecStart=/usr/bin/systemctl try-restart fprintd.service
 [Install]
 WantedBy=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
 EOF
+  # A wedged fprintd does not answer SIGTERM: clearing one takes the full stop
+  # timeout and then SIGKILL. At the default 90s that lands squarely on the
+  # wake path, so the restart above would make resume slower than the bug.
+  sudo mkdir -p /etc/systemd/system/fprintd.service.d
+  sudo tee /etc/systemd/system/fprintd.service.d/stop-timeout.conf >/dev/null <<'EOF'
+[Service]
+TimeoutStopSec=3s
+EOF
+
   sudo systemctl daemon-reload
   sudo systemctl enable fprintd-resume.service >/dev/null
 }


### PR DESCRIPTION
## Problem

Fingerprint authentication dies on this ThinkPad after enough suspend cycles, in a way that looks nothing like a failure. Everything you would check is healthy:

```console
$ systemctl show fprintd -p MainPID -p ActiveEnterTimestamp --value
115096
Fri 2026-08-28 17:19:26 CEST          # ~16 hours old, never exited

$ systemd-inhibit --list | grep -i fprint
net.reactivated.Fprint  0  root  115096  fprintd  sleep  Suspend fingerprint readers  delay

$ journalctl -u fprintd --since "16 hours ago" | wc -l
0
```

And yet:

```console
$ fprintd-list "$USER"
No devices available
```

The reader was on the bus the entire time — at a new address:

```console
$ lsusb | grep 06cb
Bus 001 Device 010: ID 06cb:00bd Synaptics, Inc. Prometheus MIS Touch Fingerprint Reader
                # 008 the day before
```

## Cause

libfprint enumerates USB once, at startup, and ships no hotplug support:

```console
$ strings /usr/lib/libfprint-2.so* | grep -ci hotplug
0
```

A daemon that outlives a re-enumeration therefore keeps a handle nothing answers to. `systemctl restart fprintd` clears it instantly and is the only cure I found.

The daemon reaches this state on its own. @xe-nvdk counted fprintd's idle exits on a second reader (`06cb:00fc`): 19 in the cycles before the wedging suspend, 0 in every cycle after it. A wedged instance stops exiting, so it does not need `--no-timeout` or any other keep-resident mitigation to become long-lived — those only make the failure easier to notice. (An earlier version of this section claimed the opposite; his counts corrected it.)

## Fix

A unit ordered after the sleep targets, enabled by `omarchy setup security fingerprint` alongside the PAM configuration it already writes.

It also caps `fprintd.service`'s stop timeout at 3s. A wedged fprintd does not answer SIGTERM, so at Omarchy's inherited default the restart would cost more on the wake path than the bug it repairs; the cap lets systemd reach for SIGKILL promptly. This part is orthogonal to the mechanism and worth keeping whichever of the neighbouring PRs lands — none of the others sets it.

`try-restart` rather than `restart`: when fprintd is not running there is nothing stale to clear, and *starting* it here would place its activation inside a sleep transition, which is precisely where logind refuses it its own delay inhibitor.

A unit rather than a script in `/usr/lib/systemd/system-sleep/`: systemd-sleep(8) calls those hooks "hacks" and points at inhibitor locks instead, and a hook runs *inside* the transition, which is the wrong moment to ask systemd to restart a service. I tried the hook first and it does not work — on systemd 261 `/etc/systemd/system-sleep/` is not read at all, and the man page documents only the `/usr/lib` path.

## Verified

Omarchy 4.0.1, systemd 261, kernel 7.1.9-arch1-2, ThinkPad X390 Yoga, Synaptics `06cb:00bd`, `mem_sleep=deep`.

The same shape is now confirmed on two further readers, both s2idle: `06cb:00fc` (X1 Carbon Gen 9, @xe-nvdk, with the kernel trace below) and `06cb:0123` (X1 Carbon Gen 13, @k7cfo in #8818). Three Synaptics variants and both sleep modes, which points at libfprint rather than at one firmware.

@xe-nvdk's kernel-side capture of the re-enumeration this PR is built on — the part I could only infer here:

```
usb 3-3: USB disconnect, device number 2
usb 3-3: New USB device found, idVendor=06cb, idProduct=00fc
fprintd: Ignoring device due to initialization error: unsupported firmware version
fprintd: Async command sending failed: USB error … No such device [-4]
```

Stop-timeout cap, on this machine:

```console
$ systemctl show fprintd -p TimeoutStopUSec --value
3s
```

```console
$ # across one systemd suspend/resume with the unit enabled
PID before: 252757
PID after:  253978

$ journalctl -u fprintd-resume
Starting Restart fprintd after resume so it re-enumerates the reader...
fprintd-resume.service: Deactivated successfully.
Finished Restart fprintd after resume so it re-enumerates the reader.

$ fprintd-list "$USER"
Fingerprints for user maxmad on Synaptics Sensors (press):
 - #0: right-index-finger

$ systemd-inhibit --list | grep -i fprint
net.reactivated.Fprint  0  root  253978  fprintd  sleep  ...    # the new instance
```

## What this does not claim

The original silent failure takes hours and several sleep cycles to appear here, and I could not provoke it on demand. Four attempts failed: unbinding and rebinding the USB driver, toggling `authorized` on the device, and short RTC-timed suspends — none of them re-addressed the reader the way an overnight run of suspends did.

So this is preventive rather than demonstrated against a reproduction: it makes the observed stale state unable to survive a wake. If someone has a reliable reproducer I would like to run against it.

## Overlap with #7158 and #8818

Both opened alongside this one and land on the same unit at resume:

- **#7158** installs a post-resume sleep hook running `timeout … try-restart fprintd.service` — functionally this PR, as a hook rather than a unit — plus retry backoff and an "unavailable" notice in the lock screen.
- **#8818** installs a post-resume hook that *stops* fprintd PID-selectively and leaves startup to the next D-Bus activation.

@spencerbull's review of #8818 makes the collision explicit: systemd runs `/usr/lib/systemd/system-sleep/` in parallel (he measured two hooks 53 µs apart), so a stop and a restart would race with no ordering to rely on. This PR's unit is ordered `After=suspend.target` rather than being a hook, so it is outside that parallel set, but it still acts on the same unit at the same moment.

I would rather see #7158 land than this: its first layer covers the same failure, and it also fixes the retry storm afterwards, which nothing here addresses. If a unit is preferred over a hook, this is the unit; otherwise the `TimeoutStopSec` cap is the piece worth salvaging.

Related: #7229 (the inhibitor race), #8531 (the lock-side fix for it), #7158, #8818.

