### PR TITLE
fix(hypr): prevent SUPER+J runtime error on scrolling layout

### DIFF
--- a/bin/omarchy-hyprland-window-togglesplit
+++ b/bin/omarchy-hyprland-window-togglesplit
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle window split on dwindle; notify instead of erroring on other layouts
+
+CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+
+if [[ "$CURRENT_LAYOUT" == "dwindle" ]]; then
+  hyprctl dispatch 'hl.dsp.layout("togglesplit")'
+else
+  omarchy-notification-send -g 󱂬 "Split toggle unavailable on scrolling"
+fi

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -2,7 +2,7 @@ o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+o.bind("SUPER + J", "Toggle window split", "omarchy-hyprland-window-togglesplit")
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))


### PR DESCRIPTION
## Problem
SUPER+J always sent the dwindle-only `togglesplit` layout message.
Once a workspace was on the scrolling layout (toggled via SUPER+L),
pressing SUPER+J threw a Lua runtime error popup instead of doing
anything:

    Runtime error in lua: ?.? no such layoutmsg for scrolling

## Fix
Added `bin/omarchy-hyprland-window-togglesplit`, a small script that
checks `hyprctl activeworkspace -j | jq -r .tiledLayout` before acting:

- **dwindle** → dispatches `hyprctl dispatch 'hl.dsp.layout("togglesplit")'`
  (unchanged behavior)
- **any other layout** → shows `omarchy-notification-send` with a short
  message instead of letting the runtime error surface

`default/hypr/bindings/tiling.lua` now points SUPER+J at this script,
the same pattern already used by SUPER+L
(`omarchy-hyprland-workspace-layout-toggle`).

## Testing
- SUPER+L → scrolling, SUPER+J → clean one-line notification, no error
- SUPER+L → back to dwindle, SUPER+J → split toggles normally

Before:
<img width="321" height="162" alt="screenshot-2026-08-29_15-54-08" src="https://github.com/user-attachments/assets/992bfefb-2cd7-475f-9509-3cb94d7026d3" />
After:
<img width="486" height="105" alt="image" src="https://github.com/user-attachments/assets/a5d6fdb0-979a-4f9d-98ea-76c4d34a2af5" />
