### PR TITLE
Support ELAN match-on-chip v2 fingerprint readers

### DIFF
--- a/bin/omarchy-hw-fingerprint-lib-package
+++ b/bin/omarchy-hw-fingerprint-lib-package
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# omarchy:summary=Names where the libfprint provider comes from and the package to install
+# omarchy:hidden=true
+
+# Prints "<source> <package>" for the package providing libfprint for the
+# fingerprint reader present on this machine: "repo libfprint" for ordinary
+# readers, or an alternate provider for a sensor stock libfprint has no
+# driver for.
+usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
+alternate_lib_package="libfprint-elanmoc2-git"
+
+# An installed replacement provider always wins, so re-running setup never
+# swaps a working alternate library back to stock.
+if pacman -Q "$alternate_lib_package" &>/dev/null; then
+  echo "aur $alternate_lib_package"
+  exit 0
+fi
+
+# Elan stamps "ELAN:ARM-M4" on several incompatible sensors, so match on the
+# exact USB ID rather than the product string. 04f3:0c4c is an ELAN
+# match-on-chip v2 reader whose elanmoc2 driver stock libfprint does not ship.
+for dev in "$usb_devices_path"/*; do
+  [[ -r $dev/idVendor && -r $dev/idProduct ]] || continue
+  if [[ $(<"$dev/idVendor") == "04f3" && $(<"$dev/idProduct") == "0c4c" ]]; then
+    echo "aur $alternate_lib_package"
+    exit 0
+  fi
+done
+
+echo "repo libfprint"

--- a/bin/omarchy-remove-security-fingerprint
+++ b/bin/omarchy-remove-security-fingerprint
@@ -34,6 +34,6 @@ remove_pam_config
 remove_lock_fingerprint_pam
 
 echo "Removing fingerprint packages..."
-omarchy-pkg-drop fprintd libfprint libfprint-git
+omarchy-pkg-drop fprintd libfprint libfprint-git libfprint-elanmoc2-git
 
 echo -e "\e[32mFingerprint authentication has been completely removed.\e[0m"

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -76,12 +76,31 @@ echo "Installing required packages..."
 
 # libfprint-git provides+conflicts libfprint; pacman -S --noconfirm
 # defaults the conflict prompt to N and aborts. Pre-remove it (deps-only,
-# so an installed fprintd stays put) so stock libfprint installs cleanly.
+# so an installed fprintd stays put) so another libfprint installs cleanly.
 if pacman -Q libfprint-git &>/dev/null; then
   sudo pacman -Rdd --noconfirm libfprint-git
 fi
 
-omarchy-pkg-add libfprint fprintd usbutils
+# Pick the library by hardware: most readers work with stock libfprint, but a
+# few exact USB IDs need a replacement provider (see omarchy-hw-fingerprint-
+# lib-package). The replacement conflicts+provides libfprint the same way
+# libfprint-git does, so pre-remove stock the same deps-only way first.
+read -r lib_source lib_package < <(omarchy-hw-fingerprint-lib-package)
+
+if [[ $lib_package != "libfprint" ]] && pacman -Q libfprint &>/dev/null; then
+  sudo pacman -Rdd --noconfirm libfprint
+fi
+
+# The library goes in before fprintd: fprintd depends on libfprint, and
+# installing fprintd first would pull stock libfprint back in over a
+# replacement provider.
+if [[ $lib_source == "aur" ]]; then
+  omarchy-pkg-aur-add "$lib_package"
+else
+  omarchy-pkg-add "$lib_package"
+fi
+
+omarchy-pkg-add fprintd usbutils
 
 # Enroll first fingerprint
 echo -e "\e[32m\nLet's setup your right index finger as the first fingerprint.\e[0m"

--- a/test/shell.d/fingerprint-lib-package-test.sh
+++ b/test/shell.d/fingerprint-lib-package-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+write_usb_devices() {
+  rm -rf "$tmp_dir/devices"
+  mkdir -p "$tmp_dir/devices"
+
+  local index=0
+  local spec
+  for spec in "$@"; do
+    local vendor=${spec%%:*}
+    local remainder=${spec#*:}
+    local product_id=${remainder%%:*}
+    local product=""
+    if [[ $remainder == *:* ]]; then
+      product=${remainder#*:}
+    fi
+    local dev="$tmp_dir/devices/1-$index"
+
+    mkdir -p "$dev"
+    printf '%s\n' "$vendor" >"$dev/idVendor"
+    printf '%s\n' "$product_id" >"$dev/idProduct"
+    [[ -n $product ]] && printf '%s\n' "$product" >"$dev/product"
+    index=$((index + 1))
+  done
+}
+
+lib_package() {
+  OMARCHY_USB_DEVICES_PATH="$tmp_dir/devices" "$ROOT/bin/omarchy-hw-fingerprint-lib-package"
+}
+
+assert_selects() {
+  local expected="$1"
+  local description="$2"
+  local actual
+
+  actual=$(lib_package) || fail "$description"
+  [[ $actual == "$expected" ]] || fail "$description" "expected: $expected\nactual:   $actual"
+  pass "$description"
+}
+
+# The exact USB ID of the ELAN match-on-chip v2 reader selects the
+# replacement provider, even though its product string is the same
+# "ELAN:ARM-M4" other Elan sensors carry.
+write_usb_devices '04f3:0c4c:ELAN:ARM-M4'
+assert_selects "aur libfprint-elanmoc2-git" "the 04f3:0c4c reader selects the replacement provider"
+
+# Neighbouring IDs are different hardware. Some work with stock libfprint and
+# some need other drivers, so only the exact pair may pick the replacement.
+write_usb_devices '04f3:0c4b:ELAN:ARM-M4'
+assert_selects "repo libfprint" "another 04f3 ELAN sensor keeps stock libfprint"
+
+write_usb_devices '04f3:0c4d:ELAN:ARM-M4'
+assert_selects "repo libfprint" "a third 04f3 ELAN sensor keeps stock libfprint"
+
+write_usb_devices '04f3:0c4'
+assert_selects "repo libfprint" "an ID sharing only a prefix keeps stock libfprint"
+
+# A self-named reader with no special ID is ordinary supported hardware.
+write_usb_devices '27c6:1234:Goodix Fingerprint USB Device'
+assert_selects "repo libfprint" "an ordinary reader keeps stock libfprint"
+
+write_usb_devices '04f3:0c3a:Fingerprint Device'
+assert_selects "repo libfprint" "an unknown ELAN fingerprint product keeps stock libfprint"
+
+mkdir -p "$tmp_dir/devices"
+assert_selects "repo libfprint" "a machine with no matching USB devices keeps stock libfprint"
+
+# Once the replacement provider is installed it wins over detection, so
+# re-running setup never swaps a working alternate library back to stock.
+mkdir -p "$tmp_dir/bin"
+cat >"$tmp_dir/bin/pacman" <<'EOF'
+#!/bin/bash
+[[ $1 == "-Q" && $2 == "libfprint-elanmoc2-git" ]] && exit 0
+exit 1
+EOF
+chmod +x "$tmp_dir/bin/pacman"
+
+installed_lib_package() {
+  PATH="$tmp_dir/bin:$PATH" OMARCHY_USB_DEVICES_PATH="$tmp_dir/devices" \
+    "$ROOT/bin/omarchy-hw-fingerprint-lib-package"
+}
+
+actual=$(installed_lib_package) || fail "an installed replacement provider is kept without a matching reader"
+[[ $actual == "aur libfprint-elanmoc2-git" ]] ||
+  fail "an installed replacement provider is kept without a matching reader" "expected: aur libfprint-elanmoc2-git\nactual:   $actual"
+pass "an installed replacement provider is kept without a matching reader"
+
+write_usb_devices '27c6:1234:Goodix Fingerprint USB Device'
+actual=$(installed_lib_package) || fail "an installed replacement provider is kept alongside another reader"
+[[ $actual == "aur libfprint-elanmoc2-git" ]] ||
+  fail "an installed replacement provider is kept alongside another reader" "expected: aur libfprint-elanmoc2-git\nactual:   $actual"
+pass "an installed replacement provider is kept alongside another reader"


### PR DESCRIPTION
## Summary

Add support for ELAN match-on-chip v2 fingerprint readers with USB ID `04f3:0c4c`.

These readers identify as `ELAN:ARM-M4`, but stock `libfprint` lacks the required `elanmoc2` driver. Setup detects the reader, but `fprintd` reports no usable device.

## Changes

- Detect `04f3:0c4c` by exact USB ID.
- Install and preserve `libfprint-elanmoc2-git`.
- Remove conflicting providers before installation.
- Remove the replacement provider during teardown.
- Add focused shell tests.

## Packaging

I understand that Omarchy is repackaging the most useful AUR packages itself. Preferably, `libfprint-elanmoc2-git` should be packaged in the Omarchy repositories rather than installed directly from the AUR. This PR uses the AUR package because it is not currently available in Omarchy repositories.

## Related Work

- [#6578](https://github.com/basecamp/omarchy/pull/6578) adds detection for other ELAN match-on-chip readers supported by stock `libfprint`.
- [#6664](https://github.com/basecamp/omarchy/pull/6664) discusses generic non-stock libfprint provider detection.
- [#7993](https://github.com/basecamp/omarchy/pull/7993) implements a similar hardware-specific provider flow for Goodix readers.
- [#8757](https://github.com/basecamp/omarchy/pull/8757) proposes broader support for fprintd-compatible backends.

This PR focuses specifically on making the `04f3:0c4c` ELAN reader work with the appropriate provider.

## Testing

```bash
./test/shell.d/fingerprint-lib-package-test.sh
```