### PR TITLE
Anchor the clock and weather popups under their widgets

### DIFF
--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -239,7 +239,9 @@ Panel {
     owner: root.barIdentity
     bar: root.bar
     open: root.opened
-    centerOnBar: true
+    // Anchor under the widget rather than the middle of the bar, so the
+    // popup follows wherever the widget is placed.
+    centerOnBar: false
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(560))
     contentHeight: panel.fittedContentHeight(calendarColumn.implicitHeight)

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -490,7 +490,9 @@ Panel {
     owner: root.barIdentity
     bar: root.bar
     open: root.opened
-    centerOnBar: true
+    // Anchor under the widget rather than the middle of the bar, so the
+    // popup follows wherever the widget is placed.
+    centerOnBar: false
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(480))
     contentHeight: panel.fittedContentHeight(weatherColumn.implicitHeight)


### PR DESCRIPTION
Of the twelve panels under `shell/plugins/panels/`, `clock` and `weather` are the only two that set `centerOnBar: true`. The other ten leave it at its default and open under the widget that was clicked.

That inconsistency shows up as soon as the widget is not near the middle of the bar: click the clock at one end and the calendar opens in the centre of the screen, which reads as if some other control responded. Anchoring makes it follow the widget, wherever it is placed — centre stays centre for anyone whose clock sits there.

`KeyboardPanel` already positions from `anchorScreenPos` and clamps the result into the screen:

```qml
x = Math.max(margin, Math.min(x, screenW - contentWidth - margin))
```

so anchoring cannot push a popup off an edge. The centred setting was not guarding against that; it was only discarding the anchor.

**Verified** on an Apple Silicon MacBook at `scale=2.00`, on a bar with the clock right of centre: both popups open under their widgets, nothing clips, and neither overflows the screen edge. `clock-test.sh`, `weather-test.sh`, `bar-test.sh`, `agents-panel-test.sh` and `bar-widget-contract-test.sh` all pass.

Found by @tayowrld in the Apple Silicon fork (omarchy-mac/omarchy-mac#241), where the clock sits at the right by default and the mismatch is obvious. It is not Mac-specific — any bar layout that moves the clock or weather widget off centre hits it.
