### PR TITLE
Use double-dash Obsidian flag so its CLI works

### DIFF
--- a/config/obsidian/user-flags.conf
+++ b/config/obsidian/user-flags.conf
@@ -1,3 +1,3 @@
 # Obsidian reads this file through the Arch package wrapper.
--disable-gpu
+--disable-gpu
 --enable-wayland-ime


### PR DESCRIPTION
`config/obsidian/user-flags.conf` ships `-disable-gpu` with a single dash.

The Arch `obsidian` wrapper passes these flags before the subcommand, and Obsidian's CLI only filters out double-dash flags. The single-dash flag survives and is parsed as the command name, so every CLI call fails:

```
$ obsidian read file="Note"
Error: Command "-disable-gpu" not found.
```

Chromium accepts both `-flag` and `--flag`, so the GPU workaround is unchanged and the CLI starts working. Tested on Obsidian 1.13.7.