### PR TITLE
Set GDK_GL=gles on NVIDIA so GTK3 video playback works

### DIFF
--- a/default/hypr/nvidia.lua
+++ b/default/hypr/nvidia.lua
@@ -8,6 +8,11 @@ local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without
 -- lspci reads PCI config space, which resumes a runtime-suspended GPU, and on a
 -- hybrid laptop that wake alone outlasts Hyprland's 1.5s config reload budget.
 if o.shell_succeeds(o.shell_quote(nvidia)) then
+  -- GTK3 otherwise hands NVIDIA a desktop-GL EGL context that gst-gl cannot
+  -- share, so gtkglsink fails with EGL_BAD_CONTEXT and GTK3 video playback
+  -- (Nautilus space-preview via Sushi) never renders a frame.
+  hl.env("GDK_GL", "gles")
+
   if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
     hl.env("NVD_BACKEND", "direct")
     hl.env("LIBVA_DRIVER_NAME", "nvidia")


### PR DESCRIPTION
Fixes #8826.

On NVIDIA, pressing space on a video in Nautilus opens the Sushi preview window but the video never plays. GTK3 on Wayland hands NVIDIA a desktop-GL EGL context that gst-gl cannot share, so `gtkglsink` fails when the pipeline goes to `PAUSED`:

```text
gtkgstglwidget.c:688: Could not create OpenGL context: Failed to create a OpenGL context: EGL_BAD_CONTEXT
gstgtkglsink.c:270:gst_gtk_gl_sink_start:<gtkglsink0> error: Failed to initialize OpenGL with Gtk
ERROR: pipeline doesn't want to preroll.
```

`SushiMediaBin` has a fallback to the software `gtksink`, but it only fires when `gtkglsink` fails to construct or reports a software rasterizer. Here it constructs fine and only fails later in `gst_gtk_gl_sink_start()`, so the fallback never runs and the preview stays blank.

`GDK_GL=gles` makes GTK3 create a GLES context, which gst-gl can share. It goes in the outer NVIDIA branch since the problem is driver-wide, not GSP-specific.

### Verification

Reproduced and fixed on an RTX 5060 Ti (nvidia-utils 610.57.04), Omarchy 4.0.1-1, Hyprland 0.56.2, sushi 50.0-1, gtk3 1:3.24.52-1, using the same sink Sushi uses:

```bash
# fails: EGL_BAD_CONTEXT / Failed to initialize OpenGL with Gtk
gst-launch-1.0 playbin uri=file:///path/to/video.mp4 video-sink="glsinkbin sink=gtkglsink"

# works: video plays
GDK_GL=gles gst-launch-1.0 playbin uri=file:///path/to/video.mp4 video-sink="glsinkbin sink=gtkglsink"
```

Confirmed in the real UI by launching the previewer with `GDK_GL=gles` (via a local `~/.local/share/dbus-1/services/org.gnome.NautilusPreviewer.service` override): video previews now play, and the OpenGL error is gone from the journal.

### Tests

`./test/all` — the 5 failing shell test files (`bar-icon-geometry`, `config`, `snapper`, `theme-install-guards`, `unowned-system-paths`) fail identically on unmodified `quattro` on this machine, so they are pre-existing and unrelated to this change.
