### PR TITLE
Defer plugin reloads while session is locked

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -56,6 +56,18 @@ ShellRoot {
   property var shellConfig: builtinShellConfig
   property bool pluginReloading: false
   property bool pluginReloadPending: false
+  property bool pluginReloadDeferredForLock: false
+  readonly property bool sessionLocked: {
+    var lockService = shell.firstPartyServiceFor("omarchy.lock")
+    return lockService ? lockService.locked : false
+  }
+
+  onSessionLockedChanged: {
+    if (shell.sessionLocked || !shell.pluginReloadDeferredForLock) return
+    shell.pluginReloadDeferredForLock = false
+    console.log("Session unlocked, applying deferred plugin reload")
+    Qt.callLater(shell.reloadPlugins)
+  }
 
   Timer {
     id: localPluginReloadTimer
@@ -737,6 +749,15 @@ ShellRoot {
   }
 
   function reloadPlugins() {
+    // ext-session-lock keeps the compositor locked when its client disappears.
+    // The lock client lives in the service set below, so keep it alive and
+    // coalesce local plugin changes until the user can unlock normally.
+    if (shell.sessionLocked) {
+      if (!shell.pluginReloadDeferredForLock)
+        console.log("Plugin reload deferred while session is locked")
+      shell.pluginReloadDeferredForLock = true
+      return
+    }
     if (shell.pluginReloading || shell.pluginRegistry.scanning) {
       shell.pluginReloadPending = true
       return

--- a/test/shell.d/plugin-reload-lock-test.sh
+++ b/test/shell.d/plugin-reload-lock-test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const shellQml = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+
+assert(
+  /readonly property bool sessionLocked:[\s\S]*firstPartyServiceFor\("omarchy\.lock"\)[\s\S]*lockService\.locked/.test(shellQml),
+  'plugin reload state follows the built-in lock service'
+)
+
+const reloadStart = shellQml.indexOf('function reloadPlugins()')
+const reloadEnd = shellQml.indexOf('function finishPluginReload()', reloadStart)
+assert(reloadStart !== -1 && reloadEnd !== -1, 'the plugin reload lifecycle is present')
+
+const reloadFunction = shellQml.slice(reloadStart, reloadEnd)
+const lockGuard = reloadFunction.indexOf('if (shell.sessionLocked)')
+const serviceUnload = reloadFunction.indexOf('shell.unloadPluginServices()')
+assert(
+  lockGuard !== -1 && serviceUnload !== -1 && lockGuard < serviceUnload,
+  'an active session lock is checked before plugin services are unloaded'
+)
+
+assert(
+  /if \(shell\.sessionLocked\) \{[\s\S]*shell\.pluginReloadDeferredForLock = true[\s\S]*return[\s\S]*\}/.test(reloadFunction),
+  'a plugin reload is queued instead of destroying an active lock client'
+)
+
+assert(
+  /onSessionLockedChanged:[\s\S]*if \(shell\.sessionLocked \|\| !shell\.pluginReloadDeferredForLock\) return[\s\S]*shell\.pluginReloadDeferredForLock = false[\s\S]*Qt\.callLater\(shell\.reloadPlugins\)/.test(shellQml),
+  'the queued plugin reload runs after the session unlocks'
+)
+JS


### PR DESCRIPTION
## Problem

Saving any file in a local shell plugin triggers a full plugin reload. That reload destroys every plugin service, including `omarchy.lock`.

If the session is already secure, `ext-session-lock` deliberately leaves the compositor locked when its client disappears. The shell recreates the lock service, but the session can remain behind Hyprland's failsafe with no working prompt. This is a separate path from the dead-shell recovery added in #6692: the shell process is alive and deliberately unloads its own lock client.

A background editor or coding agent can trigger this simply by saving a plugin file while the user is away and the screen has locked.

## Fix

- Reflect the built-in lock service's active state in the shell host.
- Defer and coalesce destructive plugin reloads while that service is locked.
- Automatically apply the pending reload once the user unlocks normally.

This keeps the lock client alive without losing local-plugin hot reloads.

## Verification

- `bash test/shell.d/plugin-reload-lock-test.sh`
- `bash test/shell.d/lock-stranded-recovery-test.sh`
- `bash test/shell.d/runtime-smoke-test.sh`
- `./test/cli`

Filed by GPT-5 via Codex.
