### PR TITLE
shell: add configurable mouse wheel scroll speed to menu lists

### DIFF
--- a/shell/Ui/WheelScrollArea.qml
+++ b/shell/Ui/WheelScrollArea.qml
@@ -1,0 +1,34 @@
+import QtQuick
+
+// Configurable mouse wheel scroll speed for Qt Quick lists.
+//
+// A Qt Quick ListView/GridView (both Flickable) scroll by a small fixed amount
+// per wheel tick, with no external way to configure it, which feels slow on
+// long lists. This transparent MouseArea sits ON TOP of the list — after it in
+// the stacking order — so it captures the wheel before the Flickable does, and
+// scrolls the target manually at a configurable speed. Place it after the list,
+// inside the same parent Item, e.g.:
+//
+//   WheelScrollArea { flickable: myList }
+//
+// speed is the divisor of the visible height used as the step: the larger it
+// is, the slower each wheel click scrolls.
+MouseArea {
+  id: root
+
+  required property Flickable flickable
+  property real speed: 8
+
+  anchors.fill: parent
+  acceptedButtons: Qt.NoButton
+
+  onWheel: function(wheel) {
+    if (wheel.angleDelta.y === 0) return
+    if (root.flickable.contentHeight <= root.flickable.height) return
+    var step = root.flickable.height / root.speed
+    root.flickable.contentY = Math.max(0, Math.min(
+      root.flickable.contentY - wheel.angleDelta.y / 120.0 * step,
+      root.flickable.contentHeight - root.flickable.height))
+    wheel.accepted = true
+  }
+}

--- a/shell/Ui/qmldir
+++ b/shell/Ui/qmldir
@@ -31,4 +31,5 @@ SpeedTestOverlay 1.0 SpeedTestOverlay.qml
 TextField 1.0 TextField.qml
 Toggle 1.0 Toggle.qml
 ToggleSwitch 1.0 ToggleSwitch.qml
+WheelScrollArea 1.0 WheelScrollArea.qml
 WidgetButton 1.0 WidgetButton.qml

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -338,6 +338,10 @@ Item {
               width: parent.width
             }
           }
+
+          WheelScrollArea {
+            flickable: resultGrid
+          }
         }
       }
     }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1468,6 +1468,10 @@ Item {
               width: Style.space(320)
             }
           }
+
+          WheelScrollArea {
+            flickable: resultList
+          }
         }
 
         Item {


### PR DESCRIPTION
## Summary

The mouse wheel scroll inside the Omarchy apps menu and emoji picker is very slow: each wheel tick moves only a tiny fixed amount, because Qt Quick `ListView`/`GridView` (both `Flickable`) have no external way to configure the wheel step. This is most noticeable on the long apps list and the emoji grid.

This PR adds a reusable `WheelScrollArea` component to the `qs.Ui` module: a transparent `MouseArea` placed on top of a `Flickable` (after it in the stacking order, so it captures the wheel before the list does) that scrolls the target manually at a configurable speed. It is wired into:

- `shell/plugins/menu/Menu.qml` — apps menu list
- `shell/plugins/emojis/Emojis.qml` — emoji picker grid

## Key details

- `acceptedButtons: Qt.NoButton` lets clicks reach the rows below.
- `speed` (default 8) is the divisor of the visible height used as the step; larger = slower per wheel click.
- Any future list can opt in with `WheelScrollArea { flickable: myList }`.

## Testing

- `./test/shell` — `manifest entrypoints load` passes; the menu and emoji plugin entry points instantiate with the new component.
- The 5 remaining shell test failures are pre-existing on `quattro` (verified by stashing the change and re-running).