### PR TITLE
Count gamepad input and audio playback as idle activity

### DIFF
--- a/bin/omarchy-idle-activity
+++ b/bin/omarchy-idle-activity
@@ -1,0 +1,235 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Report activity the compositor cannot see, for the idle service
+# omarchy:args=[--no-gamepad] [--no-audio] [--gamepad-grace <seconds>] [--once]
+# omarchy:hidden=true
+
+"""Report the activity Hyprland's idle timer cannot observe for itself.
+
+The idle service asks the compositor when the user went idle, which covers
+keyboards, mice, and touchpads. Two things it cannot cover:
+
+  * Gamepads. libinput classifies joystick devices as unhandled and never
+    reports them as seats' pointer or keyboard input, so ext-idle-notify keeps
+    counting up through an entire play session on a controller. Reading the
+    evdev nodes directly is the only way to see that input.
+
+  * Media playback. Staying awake through a film relies on the player holding
+    a Wayland idle inhibitor. Players that do are fine; XWayland clients cannot
+    hold one at all, and the org.freedesktop.ScreenSaver D-Bus API that many
+    reach for instead has no owner on an Omarchy session, so those requests
+    fail silently. An uncorked sink input is the reliable evidence that sound
+    is actually being produced.
+
+Python rather than bash because both signals need work bash cannot do: evdev
+delivers fixed-width binary structs on several descriptors at once, which needs
+struct unpacking behind select().
+
+Prints ACTIVE or IDLE on every state change, plus a periodic heartbeat so a
+reader that missed a line resynchronises without restarting the probe.
+"""
+
+import argparse
+import os
+import select
+import struct
+import subprocess
+import sys
+import time
+
+# struct input_event: struct timeval, __u16 type, __u16 code, __s32 value
+EVENT = struct.Struct("llHHi")
+EV_KEY = 0x01
+EV_ABS = 0x03
+
+# Analogue sticks rest a few hundred units off centre and wander there, so only
+# a deliberate push counts. Hats report -1/0/1 and need every change.
+STICK_DEADZONE = 3000
+ABS_HAT_FIRST = 0x10
+ABS_HAT_LAST = 0x17
+
+DEVICE_SCAN_INTERVAL = 5.0
+AUDIO_POLL_INTERVAL = 5.0
+HEARTBEAT_INTERVAL = 15.0
+DEFAULT_GAMEPAD_GRACE = 120.0
+
+
+def parse_gamepad_nodes(devices):
+    """Event nodes whose device also carries a js* handler, marking a joystick.
+
+    A pad presents several nodes -- the Xbox pads also expose a keyboard, a
+    mouse, and a consumer-control node, and libinput does handle those. Only the
+    node sharing a line with js* is the stick-and-button device it ignores.
+    """
+    nodes = set()
+
+    for line in devices.splitlines():
+        if not line.startswith("H: Handlers="):
+            continue
+
+        handlers = line.split("=", 1)[1].split()
+        if not any(handler.startswith("js") for handler in handlers):
+            continue
+
+        for handler in handlers:
+            if handler.startswith("event"):
+                nodes.add("/dev/input/" + handler)
+
+    return nodes
+
+
+def gamepad_event_nodes():
+    try:
+        with open("/proc/bus/input/devices") as devices:
+            return parse_gamepad_nodes(devices.read())
+    except OSError:
+        return set()
+
+
+class Gamepads:
+    """Open evdev nodes for every attached pad, and report deliberate input."""
+
+    def __init__(self):
+        self.descriptors = {}
+        self.axes = {}
+
+    def rescan(self):
+        wanted = gamepad_event_nodes()
+
+        for path in list(self.descriptors):
+            if path not in wanted:
+                self.forget(path)
+
+        for path in wanted - set(self.descriptors):
+            try:
+                self.descriptors[path] = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+            except OSError:
+                pass  # unplugged mid-scan, or the user is not in the input group
+
+    def forget(self, path):
+        descriptor = self.descriptors.pop(path, None)
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+        for key in [key for key in self.axes if key[0] == path]:
+            del self.axes[key]
+
+    def moved(self, path, code, value):
+        key = (path, code)
+        previous = self.axes.get(key)
+        self.axes[key] = value
+
+        # The first sample only establishes where this axis rests.
+        if previous is None:
+            return False
+        if ABS_HAT_FIRST <= code <= ABS_HAT_LAST:
+            return value != previous
+        return abs(value - previous) > STICK_DEADZONE
+
+    def poll(self, timeout):
+        if not self.descriptors:
+            time.sleep(timeout)
+            return False
+
+        paths = {descriptor: path for path, descriptor in self.descriptors.items()}
+        try:
+            readable, _, _ = select.select(list(paths), [], [], timeout)
+        except (OSError, ValueError):
+            return False
+
+        active = False
+        for descriptor in readable:
+            path = paths[descriptor]
+            try:
+                data = os.read(descriptor, EVENT.size * 64)
+            except OSError:
+                self.forget(path)
+                continue
+
+            for offset in range(0, len(data) - EVENT.size + 1, EVENT.size):
+                _, _, kind, code, value = EVENT.unpack_from(data, offset)
+                if kind == EV_KEY:
+                    active = True
+                elif kind == EV_ABS and self.moved(path, code, value):
+                    active = True
+
+        return active
+
+
+def audio_playing():
+    """True while any sink input is uncorked, meaning sound is being produced."""
+    try:
+        listing = subprocess.run(
+            ["pactl", "list", "sink-inputs"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=dict(os.environ, LC_ALL="C"),
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+    return any(line.strip() == "Corked: no" for line in listing.splitlines())
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument("--no-gamepad", action="store_true")
+    parser.add_argument("--no-audio", action="store_true")
+    parser.add_argument("--gamepad-grace", type=float, default=DEFAULT_GAMEPAD_GRACE)
+    parser.add_argument("--once", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    options = parse_args(argv)
+    watch_gamepad = not options.no_gamepad
+    watch_audio = not options.no_audio
+    grace = max(0.0, options.gamepad_grace)
+
+    if options.once:
+        playing = watch_audio and audio_playing()
+        print("ACTIVE" if playing else "IDLE", flush=True)
+        return 0
+
+    gamepads = Gamepads()
+    last_scan = last_audio_poll = last_report = 0.0
+    last_gamepad_input = None
+    playing = False
+    reported = None
+
+    while True:
+        now = time.monotonic()
+
+        if watch_gamepad and now - last_scan >= DEVICE_SCAN_INTERVAL:
+            gamepads.rescan()
+            last_scan = now
+
+        if watch_audio and now - last_audio_poll >= AUDIO_POLL_INTERVAL:
+            playing = audio_playing()
+            last_audio_poll = now
+
+        if watch_gamepad:
+            if gamepads.poll(1.0):
+                last_gamepad_input = time.monotonic()
+        else:
+            time.sleep(1.0)
+
+        now = time.monotonic()
+        in_play = last_gamepad_input is not None and now - last_gamepad_input < grace
+        active = bool(in_play or (watch_audio and playing))
+
+        if active != reported or now - last_report >= HEARTBEAT_INTERVAL:
+            reported = active
+            last_report = now
+            print("ACTIVE" if active else "IDLE", flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -168,7 +168,9 @@ Rules:
 5. Third-party enabled ⇔ present; for full bar options that means `bar.id`.
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
-7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+7. `idle.screensaver` and `idle.lock` are seconds since user idle began;
+   `idle.inhibitWhenGamepadActive`, `idle.inhibitWhenAudioPlaying`, and
+   `idle.gamepadGrace` cover the activity the compositor cannot see.
 8. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -80,6 +80,25 @@ Both numbers are seconds counted from the moment you went idle — not from each
 
 If you dismiss the screensaver before the lock deadline, that counts as activity and the pending lock is cancelled. You don't get locked out for glancing at your machine.
 
+Idle means idle, not merely "nobody touched the keyboard". The compositor counts only the input libinput handles, and that leaves out two everyday cases. Gamepads are one: joystick devices are neither pointers nor keyboards, so an entire evening on a controller registers as nothing at all. Media playback is the other, since staying awake through a film depends on the player asking to, and not every player does. Omarchy watches both directly, so a game on a controller and a video in a browser tab each keep the screen up on their own.
+
+Both are on by default, and either can be turned off in the same `idle` block:
+
+```json
+{
+  "version": 1,
+  "idle": {
+    "screensaver": 150,
+    "lock": 300,
+    "inhibitWhenGamepadActive": true,
+    "inhibitWhenAudioPlaying": false,
+    "gamepadGrace": 120
+  }
+}
+```
+
+`gamepadGrace` is how long a controller keeps the machine awake after the last button or stick you actually moved, so setting the pad down for a moment doesn't lock you out. Turn `inhibitWhenAudioPlaying` off if you'd rather music in the background didn't hold the lock screen back.
+
 To stop locking on idle entirely, `Super + Ctrl + I` — or `omarchy toggle idle` — flips stay awake on, and the coffee cup indicator appears in the bar. That's the one to hit before a long presentation or a build you want to watch. Hit it again to go back to normal. `omarchy toggle idle status` prints the current state as JSON if you need it from a script.
 
 This is about locking and the screensaver, not power. Suspend and hibernation have their own setup in [system sleep](36-system-sleep.md).

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -43,10 +43,47 @@ function screensaverWindowsAfter(windows, address, visible) {
   }
 }
 
+var DEFAULT_GAMEPAD_GRACE_SECONDS = 120
+
+// The compositor's idle timer only sees what libinput reports, which leaves
+// gamepads and media playback invisible to it. omarchy-idle-activity watches
+// both; these shape the call and read its answers.
+function activitySettings(idleConfig) {
+  var config = idleConfig || {}
+
+  return {
+    gamepad: config.inhibitWhenGamepadActive === undefined ? true : !!config.inhibitWhenGamepadActive,
+    audio: config.inhibitWhenAudioPlaying === undefined ? true : !!config.inhibitWhenAudioPlaying,
+    gamepadGrace: secondsFromConfig(config.gamepadGrace, DEFAULT_GAMEPAD_GRACE_SECONDS)
+  }
+}
+
+function activityWatchWanted(settings) {
+  return !!(settings && (settings.gamepad || settings.audio))
+}
+
+function activityCommand(settings) {
+  var command = ["omarchy-idle-activity"]
+
+  if (!settings.gamepad) command.push("--no-gamepad")
+  if (!settings.audio) command.push("--no-audio")
+  command.push("--gamepad-grace", String(settings.gamepadGrace))
+
+  return command
+}
+
+function isActivityLine(line) {
+  return String(line).trim() === "ACTIVE"
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
-    screensaverWindowsAfter: screensaverWindowsAfter
+    screensaverWindowsAfter: screensaverWindowsAfter,
+    activitySettings: activitySettings,
+    activityWatchWanted: activityWatchWanted,
+    activityCommand: activityCommand,
+    isActivityLine: isActivityLine
   }
 }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -24,6 +24,8 @@ Item {
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
+  readonly property var activitySettings: IdleModel.activitySettings(idleConfig)
+  readonly property bool watchActivity: IdleModel.activityWatchWanted(root.activitySettings)
 
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
@@ -35,6 +37,7 @@ Item {
   property string lastEventAt: ""
   property var screensaverWindows: ({})
   property int screensaverWindowCount: 0
+  property bool externalActivity: false
 
   function secondsFromConfig(value, fallback) {
     return IdleModel.secondsFromConfig(value, fallback)
@@ -173,8 +176,36 @@ Item {
     logEvent("idle-monitor", idleMonitor.isIdle ? "idle" : "active")
     if (!root.idleEnabled) return
 
-    if (idleMonitor.isIdle) startIdleCycle()
-    else handleActiveSignal()
+    if (!idleMonitor.isIdle) {
+      handleActiveSignal()
+      return
+    }
+
+    // A controller or a playing film is real use, however long the compositor
+    // has gone without seeing a key or a mouse move.
+    if (root.externalActivity) {
+      logEvent("idle-suppressed", "gamepad or audio active")
+      return
+    }
+
+    startIdleCycle()
+  }
+
+  function setExternalActivity(active) {
+    if (root.externalActivity === active) return
+
+    root.externalActivity = active
+    logEvent("external-activity", active ? "gamepad or audio in use" : "cleared")
+
+    // Play resumed, so abandon whatever countdown is already running.
+    if (active) {
+      if (root.idledThisCycle) cancelIdleCycle("external-activity")
+      return
+    }
+
+    // Play stopped while the compositor still sees no input, so the countdown
+    // suppressed back when it reported idle has to start now.
+    if (root.idleEnabled && idleMonitor.isIdle && !root.idledThisCycle) startIdleCycle()
   }
 
   function statusJson() {
@@ -184,6 +215,7 @@ Item {
       stayAwakeStateLoaded: root.stayAwakeStateLoaded,
       stayAwakeStatePath: root.stayAwakeStatePath,
       idle: idleMonitor.isIdle,
+      externalActivity: root.externalActivity,
       inIdleCycle: root.idledThisCycle,
       screensaverStarted: root.screensaverStartedThisCycle,
       screensaver: root.screensaverTimeoutSeconds,
@@ -296,6 +328,51 @@ Item {
   Process {
     id: wakeProcess
     onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "wake exitCode=" + exitCode + " status=" + exitStatus) }
+  }
+
+  Process {
+    id: activityProcess
+    property string signature: ""
+    stdout: SplitParser {
+      onRead: function(line) { root.setExternalActivity(IdleModel.isActivityLine(line)) }
+    }
+    onExited: function(exitCode, exitStatus) {
+      root.logEvent("process-exit", "idle-activity exitCode=" + exitCode + " status=" + exitStatus)
+      root.setExternalActivity(false)
+    }
+  }
+
+  // Owns the probe's lifetime: starts it, restarts it after a crash so a failed
+  // probe degrades to plain compositor idling rather than pinning the screen
+  // awake, and relaunches it when settings change its arguments.
+  Timer {
+    id: activitySupervisor
+    interval: 5000
+    repeat: true
+    running: true
+    triggeredOnStart: true
+    onTriggered: {
+      if (!(root.idleEnabled && root.watchActivity)) {
+        if (activityProcess.running) {
+          activityProcess.running = false
+          root.setExternalActivity(false)
+        }
+        return
+      }
+
+      var command = IdleModel.activityCommand(root.activitySettings)
+      var signature = JSON.stringify(command)
+
+      if (activityProcess.running) {
+        if (activityProcess.signature === signature) return
+        activityProcess.running = false
+        return
+      }
+
+      activityProcess.signature = signature
+      activityProcess.command = command
+      activityProcess.running = true
+    }
   }
 
   Process {

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -33,7 +33,140 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+
+assertDeepEqual(
+  idle.activitySettings({}),
+  { gamepad: true, audio: true, gamepadGrace: 120 },
+  'idle watches gamepads and audio by default'
+)
+assertDeepEqual(
+  idle.activitySettings({ inhibitWhenAudioPlaying: false, gamepadGrace: '45.7' }),
+  { gamepad: true, audio: false, gamepadGrace: 45 },
+  'idle honours configured activity settings'
+)
+
+assertEqual(idle.activityWatchWanted({ gamepad: false, audio: true }), true, 'idle watches when audio alone is enabled')
+assertEqual(idle.activityWatchWanted({ gamepad: false, audio: false }), false, 'idle skips the probe when both signals are off')
+
+assertDeepEqual(
+  idle.activityCommand({ gamepad: true, audio: true, gamepadGrace: 120 }),
+  ['omarchy-idle-activity', '--gamepad-grace', '120'],
+  'idle probes both signals without extra flags'
+)
+assertDeepEqual(
+  idle.activityCommand({ gamepad: false, audio: true, gamepadGrace: 30 }),
+  ['omarchy-idle-activity', '--no-gamepad', '--gamepad-grace', '30'],
+  'idle disables the gamepad signal on request'
+)
+
+assertEqual(idle.isActivityLine('ACTIVE\n'), true, 'idle reads an ACTIVE probe line')
+assertEqual(idle.isActivityLine('IDLE'), false, 'idle reads an IDLE probe line')
 JS
+
+# The probe carries the gamepad and audio detection the compositor cannot do.
+run_python_test() {
+  python3 - "$ROOT/bin/omarchy-idle-activity" <<'PYTEST'
+import importlib.machinery
+import importlib.util
+import os
+import struct
+import sys
+
+loader = importlib.machinery.SourceFileLoader("idle_activity", sys.argv[1])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+probe = importlib.util.module_from_spec(spec)
+loader.exec_module(probe)
+
+failures = []
+
+
+def check(description, actual, expected):
+    if actual != expected:
+        failures.append("%s (got %r, want %r)" % (description, actual, expected))
+
+
+DEVICES = """I: Bus=0005 Vendor=045e Product=028e
+N: Name="Xbox Wireless Controller"
+H: Handlers=event25 js0
+B: EV=20001b
+
+I: Bus=0005 Vendor=045e Product=028e
+N: Name="Xbox Wireless Controller Keyboard"
+H: Handlers=sysrq kbd event27
+B: EV=100013
+
+I: Bus=0005 Vendor=045e Product=028e
+N: Name="Xbox Wireless Controller Mouse"
+H: Handlers=event28 mouse3
+B: EV=7
+"""
+
+check(
+    "probe picks the joystick node and ignores the pad's keyboard and mouse nodes",
+    probe.parse_gamepad_nodes(DEVICES),
+    {"/dev/input/event25"},
+)
+check("probe finds no joystick without a js handler", probe.parse_gamepad_nodes(""), set())
+
+
+def feed(batches):
+    """Replay batches of input_events through one fake evdev descriptor."""
+    read_end, write_end = os.pipe()
+    pads = probe.Gamepads()
+    pads.descriptors = {"/fake": read_end}
+    seen = []
+    try:
+        for batch in batches:
+            os.write(write_end, b"".join(batch))
+            seen.append(pads.poll(0.2))
+    finally:
+        os.close(write_end)
+        os.close(read_end)
+    return seen
+
+
+def event(kind, code, value):
+    return probe.EVENT.pack(0, 0, kind, code, value)
+
+
+check("probe counts a button press", feed([[event(probe.EV_KEY, 0x130, 1)]]), [True])
+check(
+    "probe treats the first axis sample as a resting baseline",
+    feed([[event(probe.EV_ABS, 0, 512)]]),
+    [False],
+)
+check(
+    "probe ignores analogue stick drift",
+    feed([[event(probe.EV_ABS, 0, 0)], [event(probe.EV_ABS, 0, 200)]]),
+    [False, False],
+)
+check(
+    "probe counts a deliberate stick push",
+    feed([[event(probe.EV_ABS, 0, 0)], [event(probe.EV_ABS, 0, 12000)]]),
+    [False, True],
+)
+check(
+    "probe counts a d-pad press despite its tiny range",
+    feed([[event(probe.EV_ABS, 0x10, 0)], [event(probe.EV_ABS, 0x10, 1)]]),
+    [False, True],
+)
+
+if failures:
+    for failure in failures:
+        print(failure, file=sys.stderr)
+    sys.exit(1)
+PYTEST
+}
+
+if run_python_test; then
+  pass "Idle activity probe reads gamepad input the compositor ignores"
+else
+  fail "Idle activity probe reads gamepad input the compositor ignores"
+fi
+
+[[ $("$ROOT/bin/omarchy-idle-activity" --once --no-audio) == "IDLE" ]] ||
+  fail "Idle activity probe reports idle when every signal is disabled"
+pass "Idle activity probe reports idle when every signal is disabled"
 
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT


### PR DESCRIPTION
The screensaver comes up and the lock screen takes over mid-game, while a controller is actively in use and a video is playing.

## Why it happens

The idle service asks the compositor when the user went idle, so it sees only what libinput reports. Two everyday cases fall outside that.

**Gamepads are not seat input.** libinput classifies joystick devices as unhandled, so they never reset `ext-idle-notify`. The split is visible on a connected Xbox pad — the pad presents four nodes, and Hyprland lists three of them:

```
$ hyprctl devices | grep -i xbox
    xbox-wireless-controller-mouse
    xbox-wireless-controller-keyboard
    xbox-wireless-controller-consumer-control

$ grep -A4 'Xbox Wireless Controller"' /proc/bus/input/devices | grep Handlers
H: Handlers=event25 js0
```

`event25` is the sticks and buttons. It is the one node Hyprland does not see, so an entire session on a controller counts as no input at all: screensaver at `idle.screensaver`, lock at `idle.lock`, mid-game.

**Media playback depends on the player asking.** Staying awake through a film relies on a Wayland idle inhibitor. Players that take one are fine. XWayland clients cannot take one at all, and the `org.freedesktop.ScreenSaver` D-Bus API that players reach for instead has no owner on an Omarchy session:

```
$ busctl --user call org.freedesktop.ScreenSaver /org/freedesktop/ScreenSaver \
    org.freedesktop.ScreenSaver Inhibit ss "test" "probe"
Call failed: The name is not activatable
```

So those requests fail silently and nothing cross-checks whether sound is actually coming out.

## The change

`omarchy-idle-activity` watches both signals directly and prints `ACTIVE`/`IDLE`:

- **Gamepads** — reads the evdev nodes that share a device with a `js*` handler, which is what marks the node libinput drops. Buttons and hats count immediately; analogue axes need to clear a deadzone, since sticks rest off-centre and wander there. The first sample on an axis only establishes where it rests.
- **Audio** — an uncorked sink input, the reliable evidence that sound is being produced rather than merely that a player is open.

The service suppresses the countdown while either reports activity, and starts it as soon as they clear, so walking away from a paused machine still locks on the normal schedule. A supervising timer restarts a crashed probe, and a probe that will not run degrades to today's compositor-only behaviour rather than pinning the screen awake.

Python for the probe because both signals need work bash cannot do: evdev delivers fixed-width binary structs across several descriptors at once, which needs struct unpacking behind `select()`.

## Configuration

Both default to on. `idle.inhibitWhenGamepadActive` and `idle.inhibitWhenAudioPlaying` turn them off; `idle.gamepadGrace` (default 120s) sets how long a pad keeps the machine awake after the last input you actually made, so setting the pad down mid-game doesn't lock you out a second later.

## Verification

Reproduced and fixed on Omarchy 4.0.1, Hyprland 0.56.2, with an Xbox Wireless Controller over Bluetooth.

With the change running in the live shell, the probe holds the node Hyprland ignores, and the countdown is suppressed while the game plays audio:

```
$ ls -l /proc/$(pgrep -f omarchy-idle-activity)/fd | grep input
3 -> /dev/input/event25

$ omarchy-shell idle status | jq '{idle, externalActivity, inIdleCycle, lastEvent}'
{
  "idle": false,
  "externalActivity": true,
  "inIdleCycle": false,
  "lastEvent": "external-activity: gamepad or audio in use"
}
```

Setting `inhibitWhenAudioPlaying: false` with no controller input flips `externalActivity` back to `false` and normal idling resumes, confirming the suppression clears rather than latching.

`./test/all` passes at 202/207, the same five files failing before and after this branch (four need an `omarchy-pkgs` checkout that isn't present; `runtime-smoke-test` and `theme-install-guards-test` fail on the clean base here too). New coverage in `test/shell.d/idle-test.sh` exercises the settings/command model and replays synthetic `input_event` structs through the probe for button, drift, deliberate push, and d-pad cases.
