### PR TITLE
Tag brave-origin windows as chromium-based browsers

### DIFF
--- a/default/hypr/apps/browser.lua
+++ b/default/hypr/apps/browser.lua
@@ -1,5 +1,5 @@
 -- Browser tags and styling.
-o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
+o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-(browser|origin)|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
 o.window("([fF]irefox|zen|librewolf)", { tag = "+firefox-based-browser" })
 o.window({ tag = "chromium-based-browser" }, { tag = "-default-opacity", tile = true, opacity = "1.0 0.985" })
 o.window({ tag = "firefox-based-browser" }, { tag = "-default-opacity", opacity = "1.0 0.985" })

--- a/test/shell.d/browser-tags-test.sh
+++ b/test/shell.d/browser-tags-test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+browser_lua="$ROOT/default/hypr/apps/browser.lua"
+
+extract_pattern() {
+  local tag=$1
+  grep -F "tag = \"+$tag\"" "$browser_lua" | head -n1 |
+    sed -n 's/^o\.window("\([^"]*\)".*$/\1/p'
+}
+
+chromium_pattern=$(extract_pattern chromium-based-browser)
+[[ -n $chromium_pattern ]] || fail "browser.lua declares a chromium-based-browser rule" "pattern not found"
+
+firefox_pattern=$(extract_pattern firefox-based-browser)
+[[ -n $firefox_pattern ]] || fail "browser.lua declares a firefox-based-browser rule" "pattern not found"
+
+matches() {
+  [[ $1 =~ $2 ]]
+}
+
+for appid in google-chrome chromium brave-browser brave-origin helium Vivaldi-stable microsoft-edge; do
+  matches "$appid" "$chromium_pattern" || fail "chromium rule tags $appid"
+done
+pass "chromium rule tags every chromium-based browser"
+
+for appid in firefox librewolf; do
+  matches "$appid" "$chromium_pattern" && fail "chromium rule keeps the firefox-based $appid untagged"
+done
+pass "chromium rule leaves firefox-based browsers untagged"
+
+for appid in firefox zen librewolf; do
+  matches "$appid" "$firefox_pattern" || fail "firefox rule tags $appid"
+done
+pass "firefox rule tags every firefox-based browser"
+
+for appid in brave-browser chromium; do
+  matches "$appid" "$firefox_pattern" && fail "firefox rule keeps the chromium-based $appid untagged"
+done
+pass "firefox rule leaves chromium-based browsers untagged"


### PR DESCRIPTION
Brave Origin is a chromium-based browser but was not covered by the window rule in `default/hypr/apps/browser.lua`, so its windows missed the chromium-based-browser tag (and the opacity/tile rules that follow it).

Extends the chromium rule's app-id pattern to include `brave-origin` alongside `brave-browser`, and adds `test/shell.d/browser-tags-test.sh` asserting the invariant: every chromium-based and firefox-based browser app-id is tagged to the right family, with no cross-tagging.