### PR TITLE
Add GitHub Copilot usage to agents widget

### DIFF
--- a/bin/omarchy-agent-usage-copilot
+++ b/bin/omarchy-agent-usage-copilot
@@ -1,0 +1,185 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the GitHub Copilot CLI usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect GitHub Copilot CLI usage into one display-ready JSON record.
+
+Local token stats come from the numeric assistant usage events in
+~/.copilot/session-store.db. The collector does not read session messages,
+responses, repository names, or tool output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+AGENT_ID = "copilot"
+AGENT_NAME = "GitHub Copilot"
+
+
+def number(value: Any) -> int:
+  try:
+    return max(0, round(float(value or 0)))
+  except (TypeError, ValueError):
+    return 0
+
+
+def empty_bucket() -> dict[str, int]:
+  return {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  }
+
+
+def base_record(**overrides: Any) -> dict[str, Any]:
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": datetime.now(timezone.utc).isoformat(),
+    "ready": False,
+    "hasLocalStats": False,
+    "hasPromptStats": False,
+    "todayPrompts": 0,
+    "todaySessions": 0,
+    "todayTotalTokens": 0,
+    "todayTokensByModel": {},
+    "recentDays": [],
+    "totalPrompts": 0,
+    "totalSessions": 0,
+    "activeDays": 0,
+    "activeDates": [],
+    "modelUsage": {},
+    "limits": [],
+  }
+  record.update(overrides)
+  return record
+
+
+def local_day(raw: Any) -> str:
+  text = str(raw or "")
+  if not text:
+    return ""
+  try:
+    parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+  except ValueError:
+    return ""
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=timezone.utc)
+  return parsed.astimezone().date().isoformat()
+
+
+def scan(database: Path, now: datetime | None = None) -> dict[str, Any]:
+  current = now.astimezone() if now else datetime.now().astimezone()
+  today = current.date().isoformat()
+  recent_dates = [(current.date() - timedelta(days=offset)).isoformat() for offset in range(6, -1, -1)]
+  recent = {day: {"date": day, "messageCount": 0} for day in recent_dates}
+  today_tokens_by_model: dict[str, int] = {}
+  model_usage: dict[str, dict[str, int]] = {}
+  today_sessions: set[str] = set()
+  total_sessions: set[str] = set()
+  active_dates: set[str] = set()
+  today_prompts = 0
+  today_total_tokens = 0
+  total_prompts = 0
+
+  connection = sqlite3.connect(database.resolve().as_uri() + "?mode=ro", uri=True)
+  try:
+    rows = connection.execute(
+      """
+      SELECT session_id, model, input_tokens, output_tokens,
+             cache_read_tokens, cache_write_tokens, created_at
+      FROM assistant_usage_events
+      """
+    )
+    for session_id, model, raw_input, raw_output, raw_cache_read, raw_cache_write, created_at in rows:
+      day = local_day(created_at)
+      if not day:
+        continue
+
+      cache_read = number(raw_cache_read)
+      cache_write = number(raw_cache_write)
+      input_tokens = max(0, number(raw_input) - cache_read - cache_write)
+      output_tokens = number(raw_output)
+      total_tokens = input_tokens + output_tokens + cache_read + cache_write
+      if total_tokens == 0:
+        continue
+
+      session = str(session_id or "")
+      model_id = str(model or "unknown")
+      total_prompts += 1
+      total_sessions.add(session)
+      active_dates.add(day)
+
+      bucket = model_usage.setdefault(model_id, empty_bucket())
+      bucket["inputTokens"] += input_tokens
+      bucket["outputTokens"] += output_tokens
+      bucket["cacheReadInputTokens"] += cache_read
+      bucket["cacheCreationInputTokens"] += cache_write
+
+      if day in recent:
+        recent[day]["messageCount"] += total_tokens
+      if day == today:
+        today_prompts += 1
+        today_sessions.add(session)
+        today_total_tokens += total_tokens
+        today_tokens_by_model[model_id] = today_tokens_by_model.get(model_id, 0) + total_tokens
+  finally:
+    connection.close()
+
+  return base_record(
+    ready=True,
+    hasLocalStats=True,
+    hasPromptStats=True,
+    todayPrompts=today_prompts,
+    todaySessions=len(today_sessions),
+    todayTotalTokens=today_total_tokens,
+    todayTokensByModel=today_tokens_by_model,
+    recentDays=[recent[day] for day in recent_dates],
+    totalPrompts=total_prompts,
+    totalSessions=len(total_sessions),
+    activeDays=len(active_dates),
+    activeDates=sorted(active_dates),
+    modelUsage=model_usage,
+  )
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Print the GitHub Copilot CLI usage record as JSON")
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  copilot_home = Path(os.environ.get("COPILOT_HOME") or (Path.home() / ".copilot"))
+  parser.add_argument("--database", default=str(copilot_home / "session-store.db"))
+  args = parser.parse_args()
+
+  database = Path(args.database).expanduser()
+  if not database.is_file():
+    record = base_record(
+      usageStatusText="GitHub Copilot unavailable",
+      authHelpText="Use GitHub Copilot CLI once to create local usage data.",
+    )
+  else:
+    try:
+      record = scan(database)
+    except sqlite3.Error as error:
+      record = base_record(
+        usageStatusText="GitHub Copilot usage unavailable",
+        authHelpText="Could not read GitHub Copilot CLI's local usage database.",
+      )
+      print(f"omarchy-agent-usage-copilot: {error}", file=sys.stderr)
+
+  print(json.dumps(record, separators=(",", ":")))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/bin/omarchy-agent-usage-copilot
+++ b/bin/omarchy-agent-usage-copilot
@@ -12,16 +12,26 @@ responses, repository names, or tool output.
 from __future__ import annotations
 
 import argparse
+import fcntl
+import hashlib
 import json
 import os
 import sqlite3
 import sys
+import tempfile
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 AGENT_ID = "copilot"
-AGENT_NAME = "GitHub Copilot"
+AGENT_NAME = "GitHub Copilot CLI"
+SCAN_REUSE_SECONDS = 20
+LIMITS_ONLY_REUSE_SECONDS = 900
+
+
+class CopilotUsageError(Exception):
+  pass
 
 
 def number(value: Any) -> int:
@@ -40,15 +50,25 @@ def empty_bucket() -> dict[str, int]:
   }
 
 
+def cache_root() -> Path:
+  root = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root.mkdir(parents=True, exist_ok=True)
+  return root
+
+
 def base_record(**overrides: Any) -> dict[str, Any]:
   record = {
     "schemaVersion": 1,
     "id": AGENT_ID,
     "name": AGENT_NAME,
+    "tabLabel": "Copilot",
     "updatedAt": datetime.now(timezone.utc).isoformat(),
     "ready": False,
     "hasLocalStats": False,
     "hasPromptStats": False,
+    "tierLabel": "CLI usage",
+    "usageStatusText": "",
+    "authHelpText": "",
     "todayPrompts": 0,
     "todaySessions": 0,
     "todayTotalTokens": 0,
@@ -78,6 +98,19 @@ def local_day(raw: Any) -> str:
   return parsed.astimezone().date().isoformat()
 
 
+def table_columns(connection: sqlite3.Connection, table: str) -> set[str]:
+  try:
+    return {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")}
+  except sqlite3.Error:
+    return set()
+
+
+def required_columns(columns: set[str], required: set[str], table: str) -> None:
+  missing = sorted(required - columns)
+  if missing:
+    raise CopilotUsageError(f"{table} is missing required columns: {', '.join(missing)}")
+
+
 def scan(database: Path, now: datetime | None = None) -> dict[str, Any]:
   current = now.astimezone() if now else datetime.now().astimezone()
   today = current.date().isoformat()
@@ -92,16 +125,38 @@ def scan(database: Path, now: datetime | None = None) -> dict[str, Any]:
   today_total_tokens = 0
   total_prompts = 0
 
-  connection = sqlite3.connect(database.resolve().as_uri() + "?mode=ro", uri=True)
+  connection = sqlite3.connect(database.resolve().as_uri() + "?mode=ro", uri=True, timeout=2)
   try:
+    connection.execute("PRAGMA query_only = ON")
+    usage_columns = table_columns(connection, "assistant_usage_events")
+    required_columns(
+      usage_columns,
+      {
+        "session_id",
+        "model",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "created_at",
+      },
+      "assistant_usage_events",
+    )
+    can_count_prompts = "turn_index" in usage_columns
+
+    turn_columns = table_columns(connection, "turns")
+    can_count_prompts = can_count_prompts and {"session_id", "turn_index", "timestamp"}.issubset(turn_columns)
+    turn_select = ", turn_index" if can_count_prompts else ""
     rows = connection.execute(
-      """
+      f"""
       SELECT session_id, model, input_tokens, output_tokens,
-             cache_read_tokens, cache_write_tokens, created_at
+             cache_read_tokens, cache_write_tokens, created_at{turn_select}
       FROM assistant_usage_events
       """
     )
-    for session_id, model, raw_input, raw_output, raw_cache_read, raw_cache_write, created_at in rows:
+    usage_turns: set[tuple[str, int]] = set()
+    for row in rows:
+      session_id, model, raw_input, raw_output, raw_cache_read, raw_cache_write, created_at = row[:7]
       day = local_day(created_at)
       if not day:
         continue
@@ -116,9 +171,14 @@ def scan(database: Path, now: datetime | None = None) -> dict[str, Any]:
 
       session = str(session_id or "")
       model_id = str(model or "unknown")
-      total_prompts += 1
-      total_sessions.add(session)
+      if session:
+        total_sessions.add(session)
       active_dates.add(day)
+      if can_count_prompts and session and row[7] is not None:
+        try:
+          usage_turns.add((session, int(row[7])))
+        except (TypeError, ValueError):
+          pass
 
       bucket = model_usage.setdefault(model_id, empty_bucket())
       bucket["inputTokens"] += input_tokens
@@ -129,17 +189,31 @@ def scan(database: Path, now: datetime | None = None) -> dict[str, Any]:
       if day in recent:
         recent[day]["messageCount"] += total_tokens
       if day == today:
-        today_prompts += 1
-        today_sessions.add(session)
         today_total_tokens += total_tokens
         today_tokens_by_model[model_id] = today_tokens_by_model.get(model_id, 0) + total_tokens
+
+    if can_count_prompts and usage_turns:
+      for session_id, turn_index, timestamp in connection.execute(
+        "SELECT session_id, turn_index, timestamp FROM turns"
+      ):
+        try:
+          key = (str(session_id or ""), int(turn_index))
+        except (TypeError, ValueError):
+          continue
+        if key not in usage_turns:
+          continue
+        total_prompts += 1
+        if local_day(timestamp) == today:
+          today_prompts += 1
+          if key[0]:
+            today_sessions.add(key[0])
   finally:
     connection.close()
 
   return base_record(
-    ready=True,
+    ready=bool(total_sessions or active_dates),
     hasLocalStats=True,
-    hasPromptStats=True,
+    hasPromptStats=can_count_prompts,
     todayPrompts=today_prompts,
     todaySessions=len(today_sessions),
     todayTotalTokens=today_total_tokens,
@@ -153,10 +227,74 @@ def scan(database: Path, now: datetime | None = None) -> dict[str, Any]:
   )
 
 
+def scan_cache_paths(database: Path) -> tuple[Path, Path]:
+  digest = hashlib.sha1(str(database.resolve()).encode("utf-8")).hexdigest()[:16]
+  root = cache_root()
+  return root / f"copilot-scan-{digest}.json", root / f"copilot-scan-{digest}.lock"
+
+
+def read_cached_stats(cache_file: Path, max_age_seconds: float, scan_date: str) -> dict[str, Any] | None:
+  if max_age_seconds <= 0 or not cache_file.exists():
+    return None
+  try:
+    age = time.time() - cache_file.stat().st_mtime
+    if age < 0 or age > max_age_seconds:
+      return None
+    cached = json.loads(cache_file.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  if not isinstance(cached, dict) or cached.get("schemaVersion") != 1 or cached.get("scanDate") != scan_date:
+    return None
+  stats = cached.get("stats")
+  return stats if isinstance(stats, dict) else None
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+  handle_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+  tmp = Path(tmp_name)
+  try:
+    with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+      handle.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n")
+    tmp.chmod(0o600)
+    tmp.replace(path)
+  except BaseException:
+    tmp.unlink(missing_ok=True)
+    raise
+
+
+def cached_scan(database: Path, max_age_seconds: float) -> dict[str, Any]:
+  try:
+    return _cached_scan(database, max_age_seconds)
+  except OSError as error:
+    print(f"omarchy-agent-usage-copilot: cache unavailable ({error}); scanning directly", file=sys.stderr)
+    return scan(database)
+
+
+def _cached_scan(database: Path, max_age_seconds: float) -> dict[str, Any]:
+  cache_file, lock_file = scan_cache_paths(database)
+  scan_date = datetime.now().astimezone().date().isoformat()
+  cached = read_cached_stats(cache_file, max_age_seconds, scan_date)
+  if cached is not None:
+    return cached
+
+  with lock_file.open("w") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    cached = read_cached_stats(cache_file, max_age_seconds, scan_date)
+    if cached is not None:
+      return cached
+    stats = scan(database)
+    try:
+      write_json(cache_file, {"schemaVersion": 1, "scanDate": scan_date, "stats": stats})
+    except OSError as error:
+      print(f"omarchy-agent-usage-copilot: could not write usage cache ({error})", file=sys.stderr)
+    return stats
+
+
 def main() -> int:
   parser = argparse.ArgumentParser(description="Print the GitHub Copilot CLI usage record as JSON")
   parser.add_argument("--force", action="store_true")
   parser.add_argument("--limits-only", action="store_true")
+  parser.add_argument("--cache-seconds", type=float, default=SCAN_REUSE_SECONDS)
   copilot_home = Path(os.environ.get("COPILOT_HOME") or (Path.home() / ".copilot"))
   parser.add_argument("--database", default=str(copilot_home / "session-store.db"))
   args = parser.parse_args()
@@ -169,11 +307,13 @@ def main() -> int:
     )
   else:
     try:
-      record = scan(database)
-    except sqlite3.Error as error:
+      max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else args.cache_seconds)
+      record = cached_scan(database, max_age)
+      record["updatedAt"] = datetime.now(timezone.utc).isoformat()
+    except (CopilotUsageError, sqlite3.Error, OSError) as error:
       record = base_record(
         usageStatusText="GitHub Copilot usage unavailable",
-        authHelpText="Could not read GitHub Copilot CLI's local usage database.",
+        authHelpText="Could not read GitHub Copilot CLI's local usage metadata.",
       )
       print(f"omarchy-agent-usage-copilot: {error}", file=sys.stderr)
 

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -29,7 +29,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 ### The agents panel
 
-The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
+The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, GitHub Copilot CLI, and Fireworks are covered out of the box.
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -247,6 +247,7 @@ Item {
     return {
       providerId: String(record.id),
       providerName: String(record.name || record.id),
+      providerTabLabel: String((synced && stats.providerTabLabel) || record.tabLabel || record.name || record.id),
       ready: record.ready === true || synced,
       usageStatusText: String(record.usageStatusText || ""),
       authHelpText: String(record.authHelpText || ""),
@@ -559,6 +560,7 @@ Item {
       providers[id] = {
         providerId: id,
         providerName: "",
+        providerTabLabel: "",
         ready: false,
         hasLocalStats: false,
         hasPromptStats: false,
@@ -587,6 +589,7 @@ Item {
         var acc = providerAcc(String(providerId))
         acc.devices[device] = true
         if (stats.providerName && acc.providerName === "") acc.providerName = String(stats.providerName)
+        if (stats.providerTabLabel && acc.providerTabLabel === "") acc.providerTabLabel = String(stats.providerTabLabel)
         acc.ready = acc.ready || stats.ready === true
         acc.hasLocalStats = acc.hasLocalStats || stats.hasLocalStats !== false
         // Snapshots from before the field existed only came from agents that
@@ -632,6 +635,7 @@ Item {
       outProviders[id] = {
         providerId: acc.providerId,
         providerName: acc.providerName,
+        providerTabLabel: acc.providerTabLabel || acc.providerName,
         ready: acc.ready || providerDevices.length > 0,
         hasLocalStats: acc.hasLocalStats,
         hasPromptStats: acc.hasPromptStats,
@@ -665,6 +669,7 @@ Item {
     return {
       providerId: String(record.id),
       providerName: String(record.name || record.id),
+      providerTabLabel: String(record.tabLabel || record.name || record.id),
       ready: record.ready === true,
       hasLocalStats: record.hasLocalStats !== false,
       hasPromptStats: record.hasPromptStats !== false,

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -477,7 +477,7 @@ Panel {
                 required property int index
 
                 width: providerSwitch.cellWidth
-                text: modelData.providerName
+                text: modelData.providerTabLabel
                 selected: index === root.providerIndex
                 hasCursor: root.cursorActive && index === root.providerIndex
                 bordered: true

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -57,7 +57,9 @@ light surfaces — and the bar glyph stands in when there is none.
 | `copilot` | Not available | numeric usage events in `$COPILOT_HOME/session-store.db` (default `~/.copilot/session-store.db`) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
 
-The Copilot collector reads only numeric usage metadata: model, timestamp, token counts, and session id. It does not read prompts, responses, repository names, or tool output.
+The Copilot provider covers GitHub Copilot CLI activity retained on this machine, not Copilot usage from IDEs, cloud agents, or other surfaces. It reads only numeric usage metadata: model, timestamps, token counts, session id, and turn index. It does not select prompts, responses, repository names, or tool output. Tokens include every primary-agent and subagent model call; prompt counts represent completed user turns with retained turn metadata. Its all-time token totals cover everything still retained in Copilot CLI's database.
+
+Copilot account limits are not available through a stable local interface, so this collector reports local token history without a subscription meter. The exact AI-credit consumption recorded by Copilot CLI is intentionally not displayed: the Agents panel currently presents token history consistently across providers.
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -54,7 +54,10 @@ light surfaces — and the bar glyph stands in when there is none.
 |---|---|---|
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
+| `copilot` | Not available | numeric usage events in `$COPILOT_HOME/session-store.db` (default `~/.copilot/session-store.db`) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+
+The Copilot collector reads only numeric usage metadata: model, timestamp, token counts, and session id. It does not read prompts, responses, repository names, or tool output.
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -128,6 +131,7 @@ edit `shell.json` directly):
 omarchy bar set omarchy.agents providers '{
   "claude": { "enabled": true },
   "codex": { "enabled": false },
+  "copilot": { "enabled": true },
   "fireworks": { "enabled": true }
 }' --json
 ```

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, GitHub Copilot, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -21,6 +21,7 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
+        "copilot": { "enabled": true },
         "fireworks": { "enabled": true }
       },
       "refreshIntervalSec": 900,

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, GitHub Copilot, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, GitHub Copilot CLI, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {

--- a/test/shell.d/agent-usage-copilot-scanner-test.sh
+++ b/test/shell.d/agent-usage-copilot-scanner-test.sh
@@ -4,13 +4,15 @@ source "$(dirname "$0")/base-test.sh"
 
 require_command jq
 require_command python3
-require_command sqlite3
 
 TEST_HOME=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME"' EXIT
 
-database="$TEST_HOME/copilot-state/session-store.db"
-mkdir -p "$(dirname "$database")"
+export HOME="$TEST_HOME"
+export COPILOT_HOME="$TEST_HOME/copilot-state"
+export XDG_CACHE_HOME="$TEST_HOME/.cache"
+database="$COPILOT_HOME/session-store.db"
+mkdir -p "$COPILOT_HOME"
 
 python3 - "$database" <<'PY'
 import sqlite3
@@ -28,60 +30,315 @@ connection = sqlite3.connect(database)
 connection.execute("""
   CREATE TABLE assistant_usage_events (
     session_id TEXT NOT NULL,
+    turn_index INTEGER,
     model TEXT NOT NULL,
     input_tokens INTEGER,
     output_tokens INTEGER,
     cache_read_tokens INTEGER,
     cache_write_tokens INTEGER,
+    reasoning_tokens INTEGER,
     created_at TEXT
   )
 """)
+connection.execute("""
+  CREATE TABLE turns (
+    session_id TEXT NOT NULL,
+    turn_index INTEGER NOT NULL,
+    timestamp TEXT
+  )
+""")
 connection.executemany(
-  "INSERT INTO assistant_usage_events VALUES (?, ?, ?, ?, ?, ?, ?)",
+  "INSERT INTO assistant_usage_events VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
   [
-    ("session-today", "gpt-test", 100, 20, 60, 10, timestamp(0)),
-    ("session-today", "gpt-test", 50, 10, 20, 5, timestamp(0)),
-    ("session-yesterday", "claude-test", 40, 5, 10, 0, timestamp(1)),
-    ("session-old", "gpt-old", 10, 2, 0, 0, timestamp(8)),
-    ("session-empty", "gpt-empty", None, None, None, None, timestamp(0)),
+    ("session-today", 0, "gpt-test", 100, 20, 60, 10, 7, timestamp(0)),
+    ("session-today", 0, "claude-test", 50, 10, 20, 5, 3, timestamp(0)),
+    ("session-today", 1, "gpt-test", 40, 5, 10, 0, 2, timestamp(0)),
+    ("session-internal", 99, "gpt-test", 30, 5, 0, 0, 1, timestamp(0)),
+    ("session-old", 0, "gpt-old", 10, 2, 0, 0, 1, timestamp(8)),
+    ("session-empty", 0, "gpt-empty", None, None, None, None, None, timestamp(0)),
+    ("session-invalid", 0, "gpt-invalid", 50, 10, 0, 0, 0, "not-a-date"),
+  ],
+)
+connection.executemany(
+  "INSERT INTO turns VALUES (?, ?, ?)",
+  [
+    ("session-today", 0, timestamp(0)),
+    # This turn began yesterday, though its model call completed today.
+    ("session-today", 1, timestamp(1)),
+    ("session-old", 0, timestamp(8)),
+    ("session-without-usage", 0, timestamp(0)),
   ],
 )
 connection.commit()
 connection.close()
 PY
 
-result=$(HOME="$TEST_HOME" COPILOT_HOME="$(dirname "$database")" "$ROOT/bin/omarchy-agent-usage-copilot")
+result=$("$ROOT/bin/omarchy-agent-usage-copilot" --force)
 
-[[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.hasPromptStats | tostring)' <<<"$result") == "copilot:true:true" ]] ||
-  fail "Copilot collector reads its local usage database" "$result"
-pass "Copilot collector reads its local usage database"
+[[ $(jq -r '.id + ":" + .name + ":" + .tabLabel + ":" + .tierLabel' <<<"$result") == \
+  "copilot:GitHub Copilot CLI:Copilot:CLI usage" ]] ||
+  fail "Copilot collector identifies its CLI-only scope" "$result"
+pass "Copilot collector identifies its CLI-only scope"
 
-[[ $(jq -c '{todayPrompts, todaySessions, todayTotalTokens, totalPrompts, totalSessions, activeDays}' <<<"$result") == \
-  '{"todayPrompts":2,"todaySessions":1,"todayTotalTokens":180,"totalPrompts":4,"totalSessions":3,"activeDays":3}' ]] ||
-  fail "Copilot collector aggregates prompts, sessions, days, and tokens" "$result"
-pass "Copilot collector aggregates prompts, sessions, days, and tokens"
+[[ $(jq -c '{ready, hasLocalStats, hasPromptStats, todayPrompts, todaySessions, todayTotalTokens, totalPrompts, totalSessions, activeDays}' <<<"$result") == \
+  '{"ready":true,"hasLocalStats":true,"hasPromptStats":true,"todayPrompts":1,"todaySessions":1,"todayTotalTokens":260,"totalPrompts":3,"totalSessions":3,"activeDays":2}' ]] ||
+  fail "Copilot collector separates user turns from model-call usage" "$result"
+pass "Copilot collector separates user turns from model-call usage"
 
 [[ $(jq -c '.modelUsage["gpt-test"]' <<<"$result") == \
-  '{"inputTokens":55,"outputTokens":30,"cacheReadInputTokens":80,"cacheCreationInputTokens":15}' ]] ||
-  fail "Copilot collector separates fresh and cached input tokens" "$result"
-pass "Copilot collector separates fresh and cached input tokens"
+  '{"inputTokens":90,"outputTokens":30,"cacheReadInputTokens":70,"cacheCreationInputTokens":10}' ]] ||
+  fail "Copilot collector separates fresh and cached input without adding reasoning twice" "$result"
+pass "Copilot collector separates fresh and cached input without adding reasoning twice"
 
 today=$(date +%Y-%m-%d)
-yesterday=$(date -d yesterday +%Y-%m-%d)
-[[ $(jq -r --arg day "$today" '.recentDays[] | select(.date == $day) | .messageCount' <<<"$result") == "180" ]] &&
-  [[ $(jq -r --arg day "$yesterday" '.recentDays[] | select(.date == $day) | .messageCount' <<<"$result") == "45" ]] ||
-  fail "Copilot collector builds the seven-day usage series" "$result"
-pass "Copilot collector builds the seven-day usage series"
+yesterday=$(python3 -c 'from datetime import date, timedelta; print(date.today() - timedelta(days=1))')
+[[ $(jq -r --arg day "$today" '.recentDays[] | select(.date == $day) | .messageCount' <<<"$result") == "260" ]] &&
+  [[ $(jq -r --arg day "$yesterday" '.recentDays[] | select(.date == $day) | .messageCount' <<<"$result") == "0" ]] ||
+  fail "Copilot collector attributes tokens to model-call dates" "$result"
+pass "Copilot collector attributes tokens to model-call dates"
 
-missing=$(HOME="$TEST_HOME/missing" "$ROOT/bin/omarchy-agent-usage-copilot" --force --limits-only)
+partial="$TEST_HOME/partial.db"
+python3 - "$partial" <<'PY'
+import sqlite3
+import sys
+from datetime import datetime
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("""
+  CREATE TABLE assistant_usage_events (
+    session_id TEXT, model TEXT, input_tokens INTEGER, output_tokens INTEGER,
+    cache_read_tokens INTEGER, cache_write_tokens INTEGER, created_at TEXT
+  )
+""")
+connection.execute(
+  "INSERT INTO assistant_usage_events VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ("retained-session", "gpt-retained", 10, 2, 0, 0, datetime.now().astimezone().isoformat()),
+)
+connection.commit()
+connection.close()
+PY
+
+partial_result=$("$ROOT/bin/omarchy-agent-usage-copilot" --database "$partial" --force)
+[[ $(jq -c '{ready, hasLocalStats, hasPromptStats, totalPrompts, totalSessions, todayTotalTokens}' <<<"$partial_result") == \
+  '{"ready":true,"hasLocalStats":true,"hasPromptStats":false,"totalPrompts":0,"totalSessions":1,"todayTotalTokens":12}' ]] ||
+  fail "Copilot collector keeps token history when user-turn metadata is unavailable" "$partial_result"
+pass "Copilot collector keeps token history when user-turn metadata is unavailable"
+
+empty="$TEST_HOME/empty.db"
+python3 - "$empty" <<'PY'
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("""
+  CREATE TABLE assistant_usage_events (
+    session_id TEXT, turn_index INTEGER, model TEXT, input_tokens INTEGER,
+    output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER,
+    created_at TEXT
+  )
+""")
+connection.execute("CREATE TABLE turns (session_id TEXT, turn_index INTEGER, timestamp TEXT)")
+connection.commit()
+connection.close()
+PY
+
+empty_result=$("$ROOT/bin/omarchy-agent-usage-copilot" --database "$empty" --force)
+[[ $(jq -c '{ready, hasLocalStats, hasPromptStats, totalSessions}' <<<"$empty_result") == \
+  '{"ready":false,"hasLocalStats":true,"hasPromptStats":true,"totalSessions":0}' ]] ||
+  fail "Copilot collector keeps a readable empty database hidden" "$empty_result"
+pass "Copilot collector keeps a readable empty database hidden"
+
+missing=$(COPILOT_HOME="$TEST_HOME/missing" "$ROOT/bin/omarchy-agent-usage-copilot" --force --limits-only)
 [[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.totalPrompts | tostring)' <<<"$missing") == "copilot:false:0" ]] ||
   fail "Copilot collector prints a hidden record before first use" "$missing"
 pass "Copilot collector prints a hidden record before first use"
 
 malformed="$TEST_HOME/malformed.db"
-sqlite3 "$malformed" "CREATE TABLE unrelated (id INTEGER);"
-broken=$("$ROOT/bin/omarchy-agent-usage-copilot" --database "$malformed" 2>/dev/null)
+python3 - "$malformed" <<'PY'
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("CREATE TABLE assistant_usage_events (session_id TEXT, model TEXT)")
+connection.commit()
+connection.close()
+PY
+
+broken=$("$ROOT/bin/omarchy-agent-usage-copilot" --database "$malformed" --force 2>/dev/null)
 [[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + .usageStatusText' <<<"$broken") == \
   "copilot:false:GitHub Copilot usage unavailable" ]] ||
-  fail "Copilot collector handles an incompatible database" "$broken"
-pass "Copilot collector handles an incompatible database"
+  fail "Copilot collector reports an incompatible core schema" "$broken"
+pass "Copilot collector reports an incompatible core schema"
+
+uncached=$(XDG_CACHE_HOME=/dev/null "$ROOT/bin/omarchy-agent-usage-copilot" --database "$partial" --force 2>/dev/null)
+[[ $(jq -r '(.ready | tostring) + ":" + (.todayTotalTokens | tostring)' <<<"$uncached") == "true:12" ]] ||
+  fail "Copilot collector scans directly when its cache is unavailable" "$uncached"
+pass "Copilot collector scans directly when its cache is unavailable"
+
+wal_result=$(COLLECTOR="$ROOT/bin/omarchy-agent-usage-copilot" DATABASE="$TEST_HOME/wal.db" python3 - <<'PY'
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sqlite3
+from datetime import datetime
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+connection = sqlite3.connect(os.environ["DATABASE"])
+connection.execute("PRAGMA journal_mode = WAL")
+connection.execute("""
+  CREATE TABLE assistant_usage_events (
+    session_id TEXT, model TEXT, input_tokens INTEGER, output_tokens INTEGER,
+    cache_read_tokens INTEGER, cache_write_tokens INTEGER, created_at TEXT
+  )
+""")
+connection.execute(
+  "INSERT INTO assistant_usage_events VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ("wal-session", "gpt-wal", 25, 5, 0, 0, datetime.now().astimezone().isoformat()),
+)
+connection.commit()
+print(json.dumps(collector.scan(collector.Path(os.environ["DATABASE"]))))
+connection.close()
+PY
+)
+
+[[ $(jq -r '(.ready | tostring) + ":" + (.todayTotalTokens | tostring)' <<<"$wal_result") == "true:30" ]] ||
+  fail "Copilot collector reads committed data from an active WAL database" "$wal_result"
+pass "Copilot collector reads committed data from an active WAL database"
+
+# A normal refresh reuses a recent scan, while --force bypasses it.
+cached=$("$ROOT/bin/omarchy-agent-usage-copilot" --force)
+python3 - "$database" <<'PY'
+import sqlite3
+import sys
+from datetime import datetime
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute(
+  "INSERT INTO assistant_usage_events VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+  ("session-new", 0, "gpt-new", 10, 1, 0, 0, 0, datetime.now().astimezone().isoformat()),
+)
+connection.execute(
+  "INSERT INTO turns VALUES (?, ?, ?)",
+  ("session-new", 0, datetime.now().astimezone().isoformat()),
+)
+connection.commit()
+connection.close()
+PY
+
+reused=$("$ROOT/bin/omarchy-agent-usage-copilot")
+[[ $(jq -r '.totalSessions' <<<"$reused") == "$(jq -r '.totalSessions' <<<"$cached")" ]] ||
+  fail "Copilot collector reuses a recent scan" "$reused"
+pass "Copilot collector reuses a recent scan"
+
+forced=$("$ROOT/bin/omarchy-agent-usage-copilot" --force)
+[[ $(jq -r '.totalSessions' <<<"$forced") == "4" ]] ||
+  fail "Copilot collector bypasses its scan cache on --force" "$forced"
+pass "Copilot collector bypasses its scan cache on --force"
+
+# A 30-second-old cache is valid for --limits-only but not a normal refresh.
+cache_file=$(COLLECTOR="$ROOT/bin/omarchy-agent-usage-copilot" DATABASE="$database" python3 - <<'PY'
+import importlib.machinery
+import importlib.util
+import os
+from pathlib import Path
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+print(collector.scan_cache_paths(Path(os.environ["DATABASE"]))[0])
+PY
+)
+python3 - "$cache_file" <<'PY'
+import os
+import sys
+import time
+
+past = time.time() - 30
+os.utime(sys.argv[1], (past, past))
+PY
+
+python3 - "$database" <<'PY'
+import sqlite3
+import sys
+from datetime import datetime
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute(
+  "INSERT INTO assistant_usage_events VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+  ("session-limits-only", 0, "gpt-new", 12, 2, 0, 0, 0, datetime.now().astimezone().isoformat()),
+)
+connection.commit()
+connection.close()
+PY
+
+limits_only=$("$ROOT/bin/omarchy-agent-usage-copilot" --limits-only)
+[[ $(jq -r '.todayTotalTokens' <<<"$limits_only") == "$(jq -r '.todayTotalTokens' <<<"$forced")" ]] ||
+  fail "Copilot collector reuses local stats for --limits-only" "$limits_only"
+pass "Copilot collector reuses local stats for --limits-only"
+
+normal=$("$ROOT/bin/omarchy-agent-usage-copilot")
+[[ $(jq -r '.todayTotalTokens' <<<"$normal") == "$(( $(jq -r '.todayTotalTokens' <<<"$forced") + 14 ))" ]] ||
+  fail "Copilot collector expires a normal scan after 20 seconds" "$normal"
+pass "Copilot collector expires a normal scan after 20 seconds"
+
+# Even a fresh cache belongs to the day it was scanned, not merely its mtime.
+python3 - "$cache_file" <<'PY'
+import json
+import sys
+from datetime import date, timedelta
+
+path = sys.argv[1]
+cached = json.loads(open(path, encoding="utf-8").read())
+cached["scanDate"] = (date.today() - timedelta(days=1)).isoformat()
+open(path, "w", encoding="utf-8").write(json.dumps(cached))
+PY
+
+python3 - "$database" <<'PY'
+import sqlite3
+import sys
+from datetime import datetime
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute(
+  "INSERT INTO assistant_usage_events VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+  ("session-next-day-cache", 0, "gpt-new", 5, 1, 0, 0, 0, datetime.now().astimezone().isoformat()),
+)
+connection.commit()
+connection.close()
+PY
+
+new_day=$("$ROOT/bin/omarchy-agent-usage-copilot" --limits-only)
+[[ $(jq -r '.todayTotalTokens' <<<"$new_day") == "$(( $(jq -r '.todayTotalTokens' <<<"$normal") + 6 ))" ]] ||
+  fail "Copilot collector rejects a cache from another local day" "$new_day"
+pass "Copilot collector rejects a cache from another local day"
+
+# Parallel refreshes serialize through one lock and leave one intact cache.
+rm -f "$cache_file"
+pids=()
+for index in $(seq 1 8); do
+  "$ROOT/bin/omarchy-agent-usage-copilot" >"$TEST_HOME/concurrent-$index.json" &
+  pids+=($!)
+done
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
+
+for output in "$TEST_HOME"/concurrent-*.json; do
+  jq -e '.id == "copilot" and .ready == true' "$output" >/dev/null ||
+    fail "Copilot collector writes valid output during concurrent scans" "$output"
+done
+[[ -z $(find "$XDG_CACHE_HOME/omarchy/agent-usage" -name '*.tmp' -print -quit) ]] ||
+  fail "Copilot collector leaves no temporary cache files"
+[[ $(stat -c '%a' "$cache_file") == "600" ]] ||
+  fail "Copilot collector keeps cached usage private" "$(stat -c '%a' "$cache_file")"
+pass "Copilot collector serializes concurrent scans and writes atomically"
+
+grep -q 'text: modelData.providerTabLabel' "$ROOT/shell/plugins/agents/Panel.qml" ||
+  fail "Agents panel uses the provider's compact tab label"
+pass "Agents panel keeps long provider names out of compact tabs"

--- a/test/shell.d/agent-usage-copilot-scanner-test.sh
+++ b/test/shell.d/agent-usage-copilot-scanner-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+require_command sqlite3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+database="$TEST_HOME/copilot-state/session-store.db"
+mkdir -p "$(dirname "$database")"
+
+python3 - "$database" <<'PY'
+import sqlite3
+import sys
+from datetime import datetime, time, timedelta
+
+database = sys.argv[1]
+local_zone = datetime.now().astimezone().tzinfo
+today = datetime.now().astimezone().date()
+
+def timestamp(days_ago):
+  return datetime.combine(today - timedelta(days=days_ago), time(12), local_zone).isoformat()
+
+connection = sqlite3.connect(database)
+connection.execute("""
+  CREATE TABLE assistant_usage_events (
+    session_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cache_read_tokens INTEGER,
+    cache_write_tokens INTEGER,
+    created_at TEXT
+  )
+""")
+connection.executemany(
+  "INSERT INTO assistant_usage_events VALUES (?, ?, ?, ?, ?, ?, ?)",
+  [
+    ("session-today", "gpt-test", 100, 20, 60, 10, timestamp(0)),
+    ("session-today", "gpt-test", 50, 10, 20, 5, timestamp(0)),
+    ("session-yesterday", "claude-test", 40, 5, 10, 0, timestamp(1)),
+    ("session-old", "gpt-old", 10, 2, 0, 0, timestamp(8)),
+    ("session-empty", "gpt-empty", None, None, None, None, timestamp(0)),
+  ],
+)
+connection.commit()
+connection.close()
+PY
+
+result=$(HOME="$TEST_HOME" COPILOT_HOME="$(dirname "$database")" "$ROOT/bin/omarchy-agent-usage-copilot")
+
+[[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.hasPromptStats | tostring)' <<<"$result") == "copilot:true:true" ]] ||
+  fail "Copilot collector reads its local usage database" "$result"
+pass "Copilot collector reads its local usage database"
+
+[[ $(jq -c '{todayPrompts, todaySessions, todayTotalTokens, totalPrompts, totalSessions, activeDays}' <<<"$result") == \
+  '{"todayPrompts":2,"todaySessions":1,"todayTotalTokens":180,"totalPrompts":4,"totalSessions":3,"activeDays":3}' ]] ||
+  fail "Copilot collector aggregates prompts, sessions, days, and tokens" "$result"
+pass "Copilot collector aggregates prompts, sessions, days, and tokens"
+
+[[ $(jq -c '.modelUsage["gpt-test"]' <<<"$result") == \
+  '{"inputTokens":55,"outputTokens":30,"cacheReadInputTokens":80,"cacheCreationInputTokens":15}' ]] ||
+  fail "Copilot collector separates fresh and cached input tokens" "$result"
+pass "Copilot collector separates fresh and cached input tokens"
+
+today=$(date +%Y-%m-%d)
+yesterday=$(date -d yesterday +%Y-%m-%d)
+[[ $(jq -r --arg day "$today" '.recentDays[] | select(.date == $day) | .messageCount' <<<"$result") == "180" ]] &&
+  [[ $(jq -r --arg day "$yesterday" '.recentDays[] | select(.date == $day) | .messageCount' <<<"$result") == "45" ]] ||
+  fail "Copilot collector builds the seven-day usage series" "$result"
+pass "Copilot collector builds the seven-day usage series"
+
+missing=$(HOME="$TEST_HOME/missing" "$ROOT/bin/omarchy-agent-usage-copilot" --force --limits-only)
+[[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.totalPrompts | tostring)' <<<"$missing") == "copilot:false:0" ]] ||
+  fail "Copilot collector prints a hidden record before first use" "$missing"
+pass "Copilot collector prints a hidden record before first use"
+
+malformed="$TEST_HOME/malformed.db"
+sqlite3 "$malformed" "CREATE TABLE unrelated (id INTEGER);"
+broken=$("$ROOT/bin/omarchy-agent-usage-copilot" --database "$malformed" 2>/dev/null)
+[[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + .usageStatusText' <<<"$broken") == \
+  "copilot:false:GitHub Copilot usage unavailable" ]] ||
+  fail "Copilot collector handles an incompatible database" "$broken"
+pass "Copilot collector handles an incompatible database"


### PR DESCRIPTION
## Summary

- add a standalone GitHub Copilot CLI collector backed by its local `session-store.db`
- show token history from every primary-agent and subagent model call while counting prompts as completed, usage-bearing user turns
- support `COPILOT_HOME`, live WAL reads, defensive schema discovery, token-only fallback when turn metadata is unavailable, and day-aware cached scans
- keep cached usage private and make caching a pure optimization
- enable Copilot by default, identify it explicitly as CLI-local usage, and use a compact provider tab label
- avoid reading prompt/response content, repository names, tool output, account credentials, or undocumented quota endpoints

This intentionally reports GitHub Copilot CLI activity retained on the machine, not account-wide usage from IDEs or cloud agents. Account limits and AI-credit UI are out of scope because no stable local interface exposes the subscription allowance.

## Testing

- `./test/shell.d/agent-usage-copilot-scanner-test.sh`
- `./test/cli`
- `./test/shell` (all except three existing packaging checks that require a neighboring `omarchy-pkgs` checkout: `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`)
- live four-provider Agents panel verification with Claude, Codex, Copilot, and Fireworks

The focused collector coverage includes multi-model/subagent fan-out, completed-turn counting, timestamp boundaries, token category splitting, partial and incompatible schemas, missing/empty databases, custom `COPILOT_HOME`, live WAL reads, cache failure fallback, cache timing and midnight invalidation, private cache permissions, and concurrent scans.

## Screenshot

![Agents panel showing GitHub Copilot CLI usage](https://github.com/user-attachments/assets/0cee2a74-694c-4274-8bfb-1db2fdf69745)
