### PR TITLE
Fix typo in navigation manual: 'you to do' -> 'you can do'

### DIFF
--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -1,6 +1,6 @@
 # Navigation
 
-Everything in Omarchy happens via the keyboard — _EVERYTHING!_ When the system first starts, you literally can't do a thing with the mouse alone. But you can hit `Super + Space` to reveal the Omarchy Menu and from here you to do just about everything.
+Everything in Omarchy happens via the keyboard — _EVERYTHING!_ When the system first starts, you literally can't do a thing with the mouse alone. But you can hit `Super + Space` to reveal the Omarchy Menu and from here you can do just about everything.
 
 But the Omarchy menu is not even intended to be the main way to operate the system most of the time. We can get faster than that! All the most important applications are bound directly to individual hotkeys. You start the terminal with `Super + Return` and a browser with `Super + Shift + Return`. Try doing one after the other, and you'll see the magic of Hyprland's tiling in action:
 


### PR DESCRIPTION
Fixes a small typo on the Navigation page of the manual.

Changed "from here you to do just about everything" to "from here you can do just about everything".