### PR TITLE
Fix Codex limits collector for CLI approval-policy churn

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -474,25 +474,40 @@ def _cached_local_stats(max_age):
     return stats
 
 
+def rpc_send(proc, payload, operation):
+  """Write one JSON-RPC frame. Raise immediately if the app-server is gone."""
+  try:
+    proc.stdin.write(json.dumps(payload) + "\n")
+    proc.stdin.flush()
+  except OSError as exc:
+    try:
+      proc.stdin.close()
+    except OSError:
+      pass
+    raise RuntimeError(f"Codex app-server exited before {operation}") from exc
+
+
 def rpc_request(proc, request_id, method, params=None, timeout=8):
   payload = {"id": request_id, "method": method, "params": params or {}}
-  proc.stdin.write(json.dumps(payload) + "\n")
-  proc.stdin.flush()
+  rpc_send(proc, payload, method)
   deadline = time.time() + timeout
   while time.time() < deadline:
     ready, _, _ = select.select([proc.stdout], [], [], 0.25)
     if not ready:
+      if proc.poll() is not None:
+        raise RuntimeError(f"Codex app-server exited before {method}")
       continue
     line = proc.stdout.readline()
     if not line:
-      break
+      raise RuntimeError(f"Codex app-server exited before {method}")
     try:
       message = json.loads(line)
     except Exception:
       continue
     if message.get("id") == request_id:
       return message
-  raise TimeoutError(method)
+  # Process still up but silent: keep the method name searchable, but name the stall.
+  raise TimeoutError(f"Codex app-server did not answer {method}")
 
 
 def limit_window(window):
@@ -518,6 +533,40 @@ def limit_window(window):
   }
 
 
+def codex_rpc_help(proc, stderr_file, exc):
+  """Explain an app-server RPC failure without leaking bare method names.
+
+  rpc_request used to raise TimeoutError(method), so a dead CLI left the panel
+  showing just "initialize". Prefer, in order:
+
+  1. The CLI's own stderr (names a dropped/renamed flag).
+  2. Exception text when the process is still running (stall / parse error).
+  3. The login hint when the process exited with nothing useful to say.
+  """
+  try:
+    proc.wait(timeout=1)
+  except Exception:
+    pass
+
+  detail = ""
+  if stderr_file is not None:
+    try:
+      stderr_file.seek(0)
+      detail = stderr_file.read()
+    except Exception:
+      detail = ""
+  lines = [line.strip() for line in detail.splitlines() if line.strip()]
+  if lines:
+    return f"codex app-server exited: {' '.join(lines)}"[:300]
+
+  text = str(exc).strip()
+  if proc.poll() is None:
+    # Still up: stall or unparseable payload. Not an auth problem.
+    return text[:300] or AUTH_HELP
+  # Exited cleanly with empty stderr — typical "not logged in" shape.
+  return AUTH_HELP
+
+
 def fetch_codex_rpc():
   result = {"limits": [], "tierLabel": "", "usageStatusText": "", "authHelpText": AUTH_HELP}
   codex = find_command("codex")
@@ -526,24 +575,30 @@ def fetch_codex_rpc():
     result["authHelpText"] = "codex not found in PATH"
     return result
 
+  # Regular file, not a PIPE: an unread stderr pipe can fill and deadlock a
+  # chatty app-server. Only read on failure after the process has exited.
+  stderr_file = tempfile.TemporaryFile("w+", errors="replace")
   try:
+    # -a never: non-interactive probe; never prompts. on-request is also valid
+    # on codex-cli >= 0.149, but never matches the old untrusted "do not ask"
+    # intent and is what the collector needs (it never starts a turn).
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "on-request", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
-      stderr=subprocess.DEVNULL,
+      stderr=stderr_file,
       text=True,
       env=ENV,
     )
   except Exception as exc:
+    stderr_file.close()
     result["usageStatusText"] = "Codex unavailable"
     result["authHelpText"] = str(exc)
     return result
 
   try:
     rpc_request(proc, 1, "initialize", {"clientInfo": {"name": "omarchy-agent-usage", "version": "1"}}, timeout=8)
-    proc.stdin.write(json.dumps({"method": "initialized", "params": {}}) + "\n")
-    proc.stdin.flush()
+    rpc_send(proc, {"method": "initialized", "params": {}}, "initialized")
     account_msg = rpc_request(proc, 2, "account/read", timeout=4)
     limits_msg = rpc_request(proc, 3, "account/rateLimits/read", timeout=4)
 
@@ -558,7 +613,7 @@ def fetch_codex_rpc():
         result["limits"].append(entry)
   except Exception as exc:
     result["usageStatusText"] = "Codex limits unavailable"
-    result["authHelpText"] = str(exc)
+    result["authHelpText"] = codex_rpc_help(proc, stderr_file, exc)
   finally:
     try:
       proc.terminate()
@@ -568,6 +623,7 @@ def fetch_codex_rpc():
         proc.kill()
       except Exception:
         pass
+    stderr_file.close()
   return result
 
 

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -47,9 +47,9 @@ EOF
 result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" CODEX_ARGS_FILE="$TEST_HOME/codex-args" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
   "$ROOT/bin/omarchy-agent-usage-codex")
 
-# NUL-separated, so the assertion sees argument boundaries: a single "-a on-request"
+# NUL-separated, so the assertion sees argument boundaries: a single "-a never"
 # would flatten to the same text as two arguments but is not a policy codex accepts.
-expected_args=(-s read-only -a on-request app-server)
+expected_args=(-s read-only -a never app-server)
 mapfile -d '' -t codex_args <"$TEST_HOME/codex-args"
 
 [[ ${codex_args[*]@Q} == "${expected_args[*]@Q}" ]] ||
@@ -603,3 +603,115 @@ result=$(HOME="$INTERRUPTED_HOME" CODEX_HOME="$INTERRUPTED_HOME/.codex" XDG_CACH
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "9" ]] ||
   fail "Codex collector does not reuse a snapshot from an interrupted scan" "$result"
 pass "Codex collector does not cache an interrupted opencode scan"
+
+# A codex that exits before speaking the protocol (rejected flag, crash, etc.)
+# must not leave the panel showing the bare RPC method name "initialize".
+EXIT_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$EXIT_HOME"' EXIT
+mkdir -p "$EXIT_HOME/bin"
+cat >"$EXIT_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+echo "error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'" >&2
+echo "  [possible values: on-request, never]" >&2
+exit 2
+EOF
+chmod +x "$EXIT_HOME/bin/codex"
+
+result=$(HOME="$EXIT_HOME" CODEX_HOME="$EXIT_HOME/.codex" XDG_CACHE_HOME="$EXIT_HOME/.cache" XDG_DATA_HOME="$EXIT_HOME/.local/share" \
+  PATH="$EXIT_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --limits-only)
+
+[[ $(jq -r '.usageStatusText' <<<"$result") == "Codex limits unavailable" ]] ||
+  fail "Codex collector reports limits unavailable when app-server rejects argv" "$result"
+help=$(jq -r '.authHelpText' <<<"$result")
+[[ $help == *"invalid value 'untrusted'"* ]] ||
+  fail "Codex collector surfaces the CLI's own error" "$result"
+[[ $help != "initialize" ]] ||
+  fail "Codex collector must not leak the raw RPC method name" "$result"
+pass "Codex collector surfaces a rejected app-server call instead of the RPC method name"
+
+# EOF on stdout during initialize (process died) is reported as an exit, not a bare method.
+DEAD_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$EXIT_HOME" "$DEAD_HOME"' EXIT
+mkdir -p "$DEAD_HOME/bin"
+cat >"$DEAD_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+exec 1>&-
+sleep 2
+EOF
+chmod +x "$DEAD_HOME/bin/codex"
+
+result=$(HOME="$DEAD_HOME" CODEX_HOME="$DEAD_HOME/.codex" XDG_CACHE_HOME="$DEAD_HOME/.cache" XDG_DATA_HOME="$DEAD_HOME/.local/share" \
+  PATH="$DEAD_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --limits-only)
+
+help=$(jq -r '.authHelpText' <<<"$result")
+[[ $help == "Codex app-server exited before initialize" ]] ||
+  fail "Codex collector identifies an app-server that exits during startup" "$result"
+pass "Codex collector identifies an app-server that exits during startup"
+
+# Failure while sending the initialized notification after initialize answered.
+HALF_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$EXIT_HOME" "$DEAD_HOME" "$HALF_HOME"' EXIT
+mkdir -p "$HALF_HOME/bin"
+cat >"$HALF_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+read -r request
+exec 0<&-
+jq -cn --argjson id "$(jq -r '.id' <<<"$request")" '{id: $id, result: {}}'
+sleep 2
+EOF
+chmod +x "$HALF_HOME/bin/codex"
+
+result=$(HOME="$HALF_HOME" CODEX_HOME="$HALF_HOME/.codex" XDG_CACHE_HOME="$HALF_HOME/.cache" XDG_DATA_HOME="$HALF_HOME/.local/share" \
+  PATH="$HALF_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --limits-only)
+
+help=$(jq -r '.authHelpText' <<<"$result")
+[[ $help == "Codex app-server exited before initialized" ]] ||
+  fail "Codex collector translates failure to send the initialized notification" "$result"
+pass "Codex collector translates failure to send the initialized notification"
+
+# Silent clean exit with no stderr: fall back to the login hint.
+SILENT_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$EXIT_HOME" "$DEAD_HOME" "$HALF_HOME" "$SILENT_HOME"' EXIT
+mkdir -p "$SILENT_HOME/bin"
+cat >"$SILENT_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$SILENT_HOME/bin/codex"
+
+result=$(HOME="$SILENT_HOME" CODEX_HOME="$SILENT_HOME/.codex" XDG_CACHE_HOME="$SILENT_HOME/.cache" XDG_DATA_HOME="$SILENT_HOME/.local/share" \
+  PATH="$SILENT_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --limits-only)
+
+help=$(jq -r '.authHelpText' <<<"$result")
+[[ $help == "Run \`codex login\` to authenticate." ]] ||
+  fail "Codex collector falls back to the login hint when the CLI is silent" "$result"
+pass "Codex collector falls back to the login hint when the app-server says nothing"
+
+# Live app-server that stalls on account/read: keep a clear stall message, not login.
+STALL_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$CACHE_HOME" "$FRESH_HOME" "$MALFORMED_HOME" "$UNWRITABLE_HOME" "$INTERRUPTED_HOME" "$EXIT_HOME" "$DEAD_HOME" "$HALF_HOME" "$SILENT_HOME" "$STALL_HOME"' EXIT
+mkdir -p "$STALL_HOME/bin"
+cat >"$STALL_HOME/bin/codex" <<'EOF'
+#!/bin/bash
+while read -r request; do
+  id=$(jq -r '.id // empty' <<<"$request")
+  method=$(jq -r '.method // empty' <<<"$request")
+  case "$method" in
+    initialize) jq -cn --argjson id "$id" '{id: $id, result: {}}' ;;
+    account/read) : ;;
+  esac
+done
+EOF
+chmod +x "$STALL_HOME/bin/codex"
+
+result=$(HOME="$STALL_HOME" CODEX_HOME="$STALL_HOME/.codex" XDG_CACHE_HOME="$STALL_HOME/.cache" XDG_DATA_HOME="$STALL_HOME/.local/share" \
+  PATH="$STALL_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --limits-only)
+
+help=$(jq -r '.authHelpText' <<<"$result")
+[[ $help != "Run \`codex login\` to authenticate." ]] ||
+  fail "Codex collector must not blame auth when the app-server is merely stalled" "$result"
+[[ $help == "Codex app-server did not answer account/read" ]] ||
+  fail "Codex collector names the stalled RPC method clearly" "$result"
+[[ $help != "account/read" && $help != "initialize" ]] ||
+  fail "Codex collector must not leak a bare method name" "$result"
+pass "Codex collector names a stalled RPC instead of leaking the method name"


### PR DESCRIPTION
## Problem

With codex-cli >= 0.149 (reporter: 0.151.0), the agents panel shows **CODEX LIMITS UNAVAILABLE** and the auth-help card reads the bare word `initialize`. Token stats still render; only limits/plan are missing.

`bin/omarchy-agent-usage-codex` used to spawn:

```
codex -s read-only -a untrusted app-server
```

Current CLI rejects `untrusted` (`possible values: on-request, never`), exits immediately, and `rpc_request()` raises `TimeoutError("initialize")`, which was stored verbatim as `authHelpText`.

Related: #8849 #8868 #8721 #8656. Primary flag change already landed on quattro as #7649 (`on-request`); this PR finishes the residual failure mode (early exit still looked like a hang / leaked method name) and prefers `never` for a non-interactive probe that never starts a turn.

## Fix

- Spawn with `-a never` (valid on current CLI; same "do not prompt" intent as the old `untrusted`).
- Detect app-server exit during send/read immediately (`rpc_send` / `rpc_request`) instead of waiting out the timeout.
- Capture stderr on failure and prefer the CLI's own message over bare method names; fall back to the login hint only when the process exits silently.
- Timeouts on a live process become `Codex app-server did not answer <method>`.

## Verification

- `bash test/shell.d/agent-usage-codex-scanner-test.sh` (26 ok)
- `bash test/shell.d/agent-usage-update-test.sh`
- `python3 -m py_compile bin/omarchy-agent-usage-codex`
- GCE Debian 12 worker, PATH-isolated collector:

| collector | result |
| --- | --- |
| v4.0.1 (`-a untrusted`) | `usageStatusText: Codex limits unavailable`, `authHelpText: initialize`, `limits: []` |
| this branch (`-a never` + exit detection) | `tierLabel: pro`, weekly limit 8%, empty status |

## Notes

Stable tag `v4.0.1` still has `untrusted`. `v4-0-2` / `quattro` already had `on-request` from #7649; this is additive resilience + clearer panel text.

Fixes #8971