### PR TITLE
fix(shell): report failed desktop entry launches

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -31,6 +31,7 @@ Item {
   // down.
   property bool launchOsdOpen: false
   property string launchOsdMessage: ""
+  property string launchName: ""
 
   // Emitted whenever the visible application set may have changed: desktop
   // entries appeared or vanished, or the hidden-entry filters reloaded.
@@ -78,11 +79,13 @@ Item {
     var id = String(desktopId || "")
     if (!id) return
     root.beginLaunchFeedback(name)
+    root.launchName = String(name || "application")
+    launchProcess.command = ["uwsm-app", "--", "gtk-launch", id + ".desktop"]
+    launchProcess.running = true
     // Start gtk-launch inside a scope under app-graphical.slice so apps do not
     // inherit wayland-wm@.service. Keeping gtk-launch as the desktop-entry
     // resolver supports IDs with spaces and entries that UWSM rejects.
     // Keep the .desktop suffix or ids like org.telegram.desktop won't resolve.
-    Util.execDetached("uwsm-app -- gtk-launch " + Util.shellQuote(id + ".desktop"))
   }
 
   function remove(desktopId, name) {
@@ -185,6 +188,19 @@ Item {
   QtObject {
     id: hiddenEntryOutput
     property string text: ""
+  }
+
+  // Keep the desktop-entry launch attached long enough to observe gtk-launch's
+  // exit status. This lets the shell report failures instead of discarding
+  // them with a detached command.
+  Process {
+    id: launchProcess
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        Quickshell.execDetached(["omarchy-notification-send", "-u", "critical", "Unable to launch " + root.launchName, "The application command could not be found."])
+        root.closeLaunchFeedback(root.launchSerial)
+      }
+    }
   }
 
   // Both scans must run in non-login shells. A login shell sources the user's

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -99,13 +99,17 @@ assert(
 )
 
 assert(
-  /function launch\(desktopId, name\) \{[\s\S]*?uwsm-app[\s\S]*?\n  \}/.test(appLibraryQml) &&
-    appLibraryQml.includes('Util.execDetached("uwsm-app -- gtk-launch "'),
-  'app library launches desktop entries through gtk-launch in their own scope'
+  /function launch\(desktopId, name\) \{[\s\S]*?launchProcess\.command = \["uwsm-app", "--", "gtk-launch"[\s\S]*?launchProcess\.running = true[\s\S]*?\n  \}/.test(appLibraryQml),
+  'app library launches desktop entries through a monitored gtk-launch process'
 )
 
 assert(
-  appLibraryQml.includes('Util.shellQuote(id + ".desktop")'),
+  /id: launchProcess[\s\S]*?onExited: function\(exitCode\)[\s\S]*?exitCode !== 0[\s\S]*?omarchy-notification-send/.test(appLibraryQml),
+  'app library reports failed desktop entry launches'
+)
+
+assert(
+  appLibraryQml.includes('id + ".desktop"'),
   'app library launches by full file name so ids ending in .desktop (org.telegram.desktop) resolve'
 )
 


### PR DESCRIPTION
## Summary

When an application launcher points to a missing command, clicking it from the Omarchy app menu gives no useful feedback. The launch is detached and its output is discarded, so the user sees the menu close and then nothing happens.

This change monitors the desktop-entry launch and shows a critical notification when `gtk-launch` exits unsuccessfully.

## What I found

I looked around before making this change. PR #5964 is related, but it removes stale `.desktop` entries when their backing package has been uninstalled. This PR covers the separate case where an entry is still present but its `Exec=` command cannot be found.

## Changes

- Run the app launch through a monitored Quickshell `Process`.
- Report unsuccessful launches with an `omarchy-notification-send` notification.
- Close the pending "Launching..." feedback when the launch fails.
- Add shell test coverage for the monitored launch and failure notification.

## Testing

```
❯ mkdir -p ~/.local/share/applications
cat > ~/.local/share/applications/omarchy-missing-command-test.desktop <<'EOF'
[Desktop Entry]
Type=Application
Name=Omarchy Missing Command Test
Exec=omarchy-command-that-does-not-exist
Icon=application-x-executable
Terminal=false
Categories=Utility;
EOF
```

Then try to launch to get this:

<img width="580" height="144" alt="image" src="https://github.com/user-attachments/assets/a82ee908-9fff-498c-9daa-410dc47a9e3f" />

Curious if this is the preferred feedback mechanism, or if the shell should surface the original `gtk-launch` error instead. Happy to adjust if needed.


---

<em><sub>AI assisted by Pi + gpt-5.6-luna + low thinking level</sub></em>