### PR TITLE
fix(shell): keep notification dismiss button visible

### DIFF
--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -204,15 +204,15 @@ BorderSurface {
     anchors.rightMargin: root.borderRight + Style.space(3)
     width: Style.space(18)
     height: Style.space(18)
-    visible: opacity > 0
-    opacity: root.hovered ? 1 : 0
+    visible: true
+    opacity: 1
 
     Behavior on opacity { NumberAnimation { duration: 100 } }
 
     Text {
       anchors.centerIn: parent
       text: "✕"
-      color: closeArea.containsMouse ? Color.notifications.text : root.dimColor
+      color: Color.notifications.text
       font.pixelSize: Math.round(Style.font.caption * 1.44)
     }
 

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -7,6 +7,10 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const notifications = requireFromRoot('shell/plugins/notifications/NotificationLogic.js')
+const notificationCard = fs.readFileSync(path.join(root, 'shell/plugins/notifications/components/NotificationCard.qml'), 'utf8')
+
+assert(notificationCard.includes('visible: true') && notificationCard.includes('opacity: 1'), 'notification close button is always visible')
+assert(notificationCard.includes('color: Color.notifications.text'), 'notification close button uses notification text color')
 
 assert(notifications.isChromiumDerived('Brave Browser', ''), 'notifications detect chromium-derived apps by name')
 assert(notifications.isChromiumDerived('', 'microsoft-edge'), 'notifications detect chromium-derived apps by icon')


### PR DESCRIPTION
## Summary

Critical notifications with an action, including crash notifications that offer AI diagnosis, are difficult to dismiss without invoking the action. The close button was only revealed on hover and was rendered in a dimmed color, making it easy to miss.

## Changes

- Keep the notification close button visible instead of revealing it only on hover.
- Use the notification text color so the button remains visible across themes.
- Preserve the existing behavior: left-click invokes the notification action, while the close button and right-click dismiss it.
- Add test coverage for the close button visibility and color.

## Why

The crash watcher sends a critical notification that stays on screen until it is dismissed or opened:

```text
Process crashed: <program>
Click to diagnose with AI
```

The notification needs to remain persistent so the AI diagnosis is not missed, but users also need an obvious way to dismiss it if they do not want to open the assistant.

## Testing

_Using the Ristretto theme_

Before:

<img width="586" height="152" alt="image" src="https://github.com/user-attachments/assets/e4dea9f5-0b05-462b-8cd4-1c10ec0decb3" />

After:

<img width="583" height="162" alt="image" src="https://github.com/user-attachments/assets/daa39e8b-1efb-4716-9e65-0e86e65b0407" />


---

<em><sub>AI assisted by Pi + gpt-5.6-luna + low thinking level</sub></em>
