### PR TITLE
Load I2C-HID internal keyboard modules into the initramfs

### DIFF
--- a/bin/omarchy-hw-i2c-hid-keyboard
+++ b/bin/omarchy-hw-i2c-hid-keyboard
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# omarchy:summary=Detect an internal keyboard on the I2C-HID bus instead of the PS/2 controller.
+
+devices="${OMARCHY_INPUT_DEVICES_PATH:-/proc/bus/input/devices}"
+
+[[ -r $devices ]] || exit 1
+
+# Blocks are separated by blank lines and list Phys before Handlers, so a
+# block's bus is known by the time its handlers are read. The keyboard is the
+# device claiming the kbd handler: a touchpad or touchscreen on the same I2C
+# controller claims mouse handlers instead, and the PS/2 stub some of these
+# laptops still expose is not on the i2c bus.
+awk '
+  /^P: Phys=i2c-/ { i2c = 1 }
+  /^H: Handlers=/ { if (i2c && $0 ~ /[= ]kbd([ ]|$)/) found = 1 }
+  /^[[:space:]]*$/ { i2c = 0 }
+  END { exit !found }
+' "$devices"

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -45,6 +45,7 @@ run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/fix-bcm43xx.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-surface-keyboard.sh"
+run_logged "$OMARCHY_INSTALL/hardware/fix-i2c-hid-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-yt6801-ethernet-adapter.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-tuxedo-backlight.sh"
 run_logged "$OMARCHY_INSTALL/hardware/speaker-tuning.sh"

--- a/install/hardware/fix-i2c-hid-keyboard.sh
+++ b/install/hardware/fix-i2c-hid-keyboard.sh
@@ -1,0 +1,22 @@
+# Laptops whose internal keyboard sits on the I2C-HID bus (e.g. ASUS ExpertBook
+# B3402FBA) have no working keyboard at the LUKS passphrase prompt: mkinitcpio's
+# keyboard hook collects USB and PS/2 drivers, but its '/hid/hid' glob misses
+# drivers/hid/i2c-hid/, and the I2C controller (drivers/mfd/) and GPIO pinctrl
+# (drivers/pinctrl/) modules the bus depends on are never pulled in either.
+# List them explicitly so the initramfs can take the passphrase.
+
+if omarchy-hw-i2c-hid-keyboard; then
+  echo "Detected internal keyboard on I2C-HID"
+
+  modules=(i2c_hid i2c_hid_acpi hid_multitouch)
+
+  # The I2C controller and GPIO interrupt drivers differ per platform
+  # (pinctrl_tigerlake, pinctrl_alderlake, pinctrl_amd, ...), so collect
+  # whatever the running system loaded, same as the Surface keyboard fix.
+  for module in $(lsmod | awk '$1 ~ /^(pinctrl_|intel_lpss)/ { print $1 }'); do
+    modules+=("$module")
+  done
+
+  mkdir -p /etc/mkinitcpio.conf.d
+  printf 'MODULES+=(%s)\n' "${modules[*]}" > /etc/mkinitcpio.conf.d/i2c_hid_keyboard_modules.conf
+fi

--- a/migrations/1788016214.sh
+++ b/migrations/1788016214.sh
@@ -1,0 +1,32 @@
+echo "Load I2C-HID internal keyboard modules into the boot image"
+
+# Laptops whose internal keyboard sits on the I2C-HID bus (e.g. ASUS ExpertBook
+# B3402FBA) have no working keyboard at the LUKS passphrase prompt: mkinitcpio's
+# keyboard hook collects USB and PS/2 drivers, but its '/hid/hid' glob misses
+# drivers/hid/i2c-hid/, and the I2C controller (drivers/mfd/) and GPIO pinctrl
+# (drivers/pinctrl/) modules the bus depends on are never pulled in either.
+# New installs get the module list from install/hardware/fix-i2c-hid-keyboard.sh;
+# this repairs existing machines and rebuilds the boot image.
+
+conf="${OMARCHY_I2C_HID_KEYBOARD_CONF:-/etc/mkinitcpio.conf.d/i2c_hid_keyboard_modules.conf}"
+
+omarchy-hw-i2c-hid-keyboard || exit 0
+
+# The conf doubles as the machine-wide marker: another user's migration run
+# must not repeat the rebuild once the modules are in place.
+[[ ! -f $conf ]] || exit 0
+
+omarchy-cmd-present limine-mkinitcpio || exit 0
+
+modules=(i2c_hid i2c_hid_acpi hid_multitouch)
+
+# The I2C controller and GPIO interrupt drivers differ per platform
+# (pinctrl_tigerlake, pinctrl_alderlake, pinctrl_amd, ...), so collect
+# whatever the running system loaded, same as the Surface keyboard fix.
+for module in $(lsmod | awk '$1 ~ /^(pinctrl_|intel_lpss)/ { print $1 }'); do
+  modules+=("$module")
+done
+
+sudo mkdir -p /etc/mkinitcpio.conf.d
+printf 'MODULES+=(%s)\n' "${modules[*]}" | sudo tee "$conf" >/dev/null
+sudo limine-mkinitcpio

--- a/test/shell.d/hw-i2c-hid-keyboard-test.sh
+++ b/test/shell.d/hw-i2c-hid-keyboard-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+devices_file="$test_tmp/devices"
+
+has_i2c_keyboard() {
+  OMARCHY_INPUT_DEVICES_PATH="$devices_file" "$ROOT/bin/omarchy-hw-i2c-hid-keyboard"
+}
+
+: >"$devices_file"
+if has_i2c_keyboard; then
+  fail "an empty device list has no I2C-HID keyboard"
+fi
+pass "I2C-HID keyboard detection handles an empty device list"
+
+cat >"$devices_file" <<'EOF'
+N: Name="AT Translated Set 2 keyboard"
+P: Phys=isa0060/serio0/input0
+H: Handlers=sysrq kbd leds event3 
+
+EOF
+if has_i2c_keyboard; then
+  fail "a PS/2-only keyboard is not reported as I2C-HID"
+fi
+pass "I2C-HID keyboard detection ignores PS/2 keyboards"
+
+cat >"$devices_file" <<'EOF'
+N: Name="ASUE140C:00 04F3:3145 Touchpad"
+P: Phys=i2c-ASUE140C:00
+H: Handlers=event15 mouse2 
+
+EOF
+if has_i2c_keyboard; then
+  fail "an I2C touchpad without a kbd handler is not reported as a keyboard"
+fi
+pass "I2C-HID keyboard detection ignores I2C touchpads"
+
+cat >"$devices_file" <<'EOF'
+N: Name="ASUE140C:00 04F3:3145 Touchpad"
+P: Phys=i2c-ASUE140C:00
+H: Handlers=event15 mouse2 
+
+N: Name="AT Translated Set 2 keyboard"
+P: Phys=isa0060/serio0/input0
+H: Handlers=sysrq kbd leds event3 
+
+EOF
+if has_i2c_keyboard; then
+  fail "a PS/2 keyboard after an I2C touchpad is not attributed to the I2C bus"
+fi
+pass "I2C-HID keyboard detection keeps device blocks separate"
+
+cat >"$devices_file" <<'EOF'
+N: Name="AT Translated Set 2 keyboard"
+P: Phys=isa0060/serio0/input0
+H: Handlers=sysrq kbd leds event3 
+
+N: Name="ASUE140C:00 04F3:3145 Keyboard"
+P: Phys=i2c-ASUE140C:00
+H: Handlers=sysrq kbd leds event23 
+
+EOF
+has_i2c_keyboard || fail "an I2C-HID keyboard alongside a PS/2 stub is detected"
+pass "I2C-HID keyboard detection finds a keyboard on the I2C bus"
+
+cat >"$devices_file" <<'EOF'
+N: Name="Power Button"
+P: Phys=PNP0C0C/button/input0
+H: Handlers=kbd event1 
+
+EOF
+if has_i2c_keyboard; then
+  fail "a non-I2C kbd handler is not reported as an I2C-HID keyboard"
+fi
+pass "I2C-HID keyboard detection ignores kbd handlers off the I2C bus"


### PR DESCRIPTION
## Problem

Laptops whose internal keyboard sits on the I2C-HID bus have no working keyboard at the LUKS passphrase prompt. An external USB keyboard works, which makes the failure easy to misdiagnose.

The cause: mkinitcpio's `keyboard` hook collects USB host controllers, `usbhid`, and PS/2 drivers, but its `/hid/hid` glob misses `drivers/hid/i2c-hid/`, and the modules the I2C bus itself depends on live outside the hook's search paths entirely:

| Module | Path | Picked up by the hook? |
|---|---|---|
| `i2c_hid`, `i2c_hid_acpi` | `drivers/hid/i2c-hid/` | no (glob wants `/hid/hid`) |
| `intel_lpss`, `intel_lpss_pci` | `drivers/mfd/` | no |
| `pinctrl_*` (GPIO interrupts) | `drivers/pinctrl/` | no |

These laptops often still expose an "AT Translated Set 2 keyboard" PS/2 stub for ACPI events, so the initramfs *looks* like it has a keyboard — but the real key matrix is on I2C and stays dead until the rootfs loads the modules.

Confirmed on an ASUS ExpertBook B3402FBA (`ASUE140C:00 04F3:3145 Keyboard` via `i2c_hid_acpi`); adding the modules to `MODULES` fixes the passphrase prompt.

## Fix

Same shape as the existing Surface and MacBook SPI keyboard fixes:

- `bin/omarchy-hw-i2c-hid-keyboard` detects a `kbd` handler on an `i2c-` phys path in `/proc/bus/input/devices`. Deliberately generic rather than a DMI match, so every affected model benefits.
- `install/hardware/fix-i2c-hid-keyboard.sh` writes the module list to `/etc/mkinitcpio.conf.d/i2c_hid_keyboard_modules.conf` on new installs. The platform-specific controller modules (`pinctrl_tigerlake` vs `pinctrl_alderlake` vs `pinctrl_amd`, `intel_lpss*`) are collected from the running system, same as the Surface fix.
- A migration repairs existing installs and rebuilds the boot image via `limine-mkinitcpio`; the drop-in doubles as the machine-wide idempotency marker.
- `test/shell.d/hw-i2c-hid-keyboard-test.sh` covers the detector, including the PS/2-stub and i2c-touchpad-without-kbd edge cases.

The modules are listed without mkinitcpio's optional `?` suffix on purpose: if a future kernel renames one, the image build fails loudly and the previous UKI stays bootable, instead of silently producing an image with a dead passphrase prompt.

## Testing

- Detector self-test on the affected B3402FBA (exit 0) and on the fixture cases in the new shell test (6/6 pass).
- `./test/cli` passes; `./test/all` shows only the pre-existing environmental failures (missing `omarchy-pkgs` checkout etc.), identical on a clean `quattro` checkout.
- Verified end-to-end on the affected machine: all five modules present in the rebuilt UKI, loaded by `/init` via `modprobe -qab $MODULES` before the `encrypt` hook runs, and after a reboot the internal keyboard works at the LUKS passphrase prompt.
