### PR TITLE
Add safe display arrangement controls

### DIFF
--- a/bin/omarchy-monitor-arrange
+++ b/bin/omarchy-monitor-arrange
@@ -1,0 +1,373 @@
+#!/bin/bash
+
+# omarchy:summary=Validate, apply, or persist a multi-monitor arrangement for the display panel
+# omarchy:group=monitor
+# omarchy:args=<validate|apply|persist> (reads a JSON layout array on stdin)
+
+set -euo pipefail
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
+ARRANGE_LOG="$STATE_DIR/monitor-arrange.log"
+MONITORS_LUA="${OMARCHY_MONITORS_LUA:-$HOME/.config/hypr/monitors.lua}"
+MANAGED_BEGIN="-- omarchy-display-panel:managed:begin"
+MANAGED_END="-- omarchy-display-panel:managed:end"
+
+usage() {
+  cat <<'EOF'
+Usage: omarchy-monitor-arrange <command> < layout.json
+
+Commands:
+  validate   Read a JSON layout array from stdin; print it normalized, or
+             fail on stderr with a reason. Makes no changes.
+  apply      Read a JSON layout array from stdin; apply it live via
+             `hyprctl eval hl.monitor(...)`, addressed by description
+             (desc:...) wherever possible. Transient: does not touch
+             monitors.lua. Prints {"success":bool,"message":string}.
+  persist    Read a JSON layout array from stdin; back up monitors.lua and
+             rewrite its managed block to match. Does not touch live
+             Hyprland state. Prints {"success":bool,"message":string}.
+
+Layout entry shape:
+  {
+    "identity": "desc:<description>" | "<connector-name>",
+    "mode": "WIDTHxHEIGHT@REFRESH" | "preferred",
+    "x": <integer>, "y": <integer>,
+    "scale": <number>, "transform": <0-7>, "enabled": <bool>
+  }
+
+`apply` is also how a caller reverts: feed it the pre-change layout captured
+before the original apply. `persist` is the confirm step, called only after
+the caller has verified the applied layout actually stuck.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+# One jq program does full structural + range validation and fills defaults,
+# so `apply`/`persist` never have to re-derive what "valid" means. Fails
+# closed: `error(...)` aborts the whole filter and jq exits non-zero with the
+# message on stderr, which is surfaced to the caller as-is.
+read -r -d '' VALIDATE_FILTER <<'JQ' || true
+if (type != "array") then
+  error("layout must be a JSON array")
+elif (length == 0) then
+  error("layout must contain at least one monitor")
+else . end
+| map(
+    if (type != "object") then
+      error("each layout entry must be an object")
+    else . end
+    | (.identity // "") as $identity
+    | if ($identity | type) != "string" or ($identity | length) == 0 then
+        error("identity is required")
+      else . end
+    | (.mode // "preferred") as $mode
+    | if ($mode | test("^preferred$|^[0-9]+x[0-9]+@[0-9]+(\\.[0-9]+)?$")) | not then
+        error("mode must be \"preferred\" or WIDTHxHEIGHT@REFRESH: " + $identity)
+      else . end
+    | (.x // 0) as $x
+    | (.y // 0) as $y
+    | if ($x | type) != "number" or ($x | floor) != $x then
+        error("x must be an integer: " + $identity)
+      elif ($y | type) != "number" or ($y | floor) != $y then
+        error("y must be an integer: " + $identity)
+      else . end
+    | (.scale // 1) as $scale
+    | if ($scale | type) != "number" or $scale <= 0 or $scale > 10 then
+        error("scale must be a number in (0, 10]: " + $identity)
+      else . end
+    | (.transform // 0) as $transform
+    | if ($transform | type) != "number" or ($transform | floor) != $transform
+         or $transform < 0 or $transform > 7 then
+        error("transform must be an integer 0-7: " + $identity)
+      else . end
+    | (if (.enabled == null) then true else .enabled end) as $enabled
+    | if ($enabled | type) != "boolean" then
+        error("enabled must be a boolean: " + $identity)
+      else . end
+    | {
+        identity: $identity,
+        mode: $mode,
+        x: ($x | floor),
+        y: ($y | floor),
+        scale: $scale,
+        transform: ($transform | floor),
+        enabled: $enabled
+      }
+  )
+| . as $normalized
+| if (($normalized | map(.identity) | unique | length) != ($normalized | length)) then
+    error("layout has duplicate monitor identities")
+  elif (($normalized | map(select(.enabled)) | length) == 0) then
+    error("layout disables every monitor")
+  else $normalized end
+JQ
+
+# Reads the raw layout from stdin, prints the normalized array on stdout, or
+# fails the whole script with jq's error message on stderr.
+validate_layout() {
+  local raw
+  raw=$(cat)
+  jq -e -c "$VALIDATE_FILTER" <<<"$raw"
+}
+
+# ---------------------------------------------------------------------------
+# Identity -> safe Lua string literal
+# ---------------------------------------------------------------------------
+
+# `identity` is interpolated into a Lua string literal handed to `hyprctl
+# eval`. A `desc:` identity carries a monitor's free-form EDID description
+# (manufacturer/model text), which can contain characters a naive
+# interpolation would let break out of the string. Fail closed rather than
+# attempt to escape everything: reject control characters, quotes, and
+# backslashes instead of guessing at a safe encoding. A bare connector name
+# is restricted to the same charset omarchy-hyprland-monitor-scaling already
+# requires for the same reason.
+lua_output_literal() {
+  local identity="$1"
+
+  if [[ $identity == desc:* ]]; then
+    local desc="${identity#desc:}"
+    if [[ -z $desc ]]; then
+      echo "Refusing empty monitor description" >&2
+      return 1
+    fi
+    if [[ $desc == *$'\n'* || $desc == *$'\t'* || $desc == *'"'* || $desc == *'\'* ]]; then
+      echo "Refusing unsafe monitor description: $desc" >&2
+      return 1
+    fi
+    printf 'desc:%s' "$desc"
+    return 0
+  fi
+
+  if [[ $identity =~ ^[A-Za-z0-9._-]+$ ]]; then
+    printf '%s' "$identity"
+    return 0
+  fi
+
+  echo "Refusing unsafe monitor identity: $identity" >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Audit log (mirrors omarchy-hyprland-monitor-scaling's audit trail)
+# ---------------------------------------------------------------------------
+
+cmdline_for_pid() {
+  local pid="$1"
+
+  [[ -r /proc/$pid/cmdline ]] || return 0
+  tr '\0\t\n' '   ' <"/proc/$pid/cmdline" | sed -E 's/[[:space:]]+/ /g; s/[[:space:]]+$//'
+}
+
+audit_arrange() {
+  local action="$1"
+  local detail="$2"
+  local parent_pid="$PPID"
+  local grandparent_pid
+  local parent_cmd
+  local grandparent_cmd
+
+  mkdir -p "$STATE_DIR" || return 0
+
+  grandparent_pid=$(ps -o ppid= -p "$parent_pid" 2>/dev/null | tr -d ' ')
+  parent_cmd=$(cmdline_for_pid "$parent_pid")
+  grandparent_cmd=$(cmdline_for_pid "$grandparent_pid")
+
+  if ! printf 'at=%s\taction=%s\tdetail=%s\tpid=%s\tppid=%s\tparent=%s\tgppid=%s\tgrandparent=%s\n' \
+    "$(date --iso-8601=seconds)" \
+    "$action" \
+    "$detail" \
+    "$$" \
+    "$parent_pid" \
+    "$parent_cmd" \
+    "$grandparent_pid" \
+    "$grandparent_cmd" >>"$ARRANGE_LOG"; then
+    return 0
+  fi
+}
+
+json_result() {
+  local success="$1"
+  local message="$2"
+
+  jq -n -c --argjson success "$success" --arg message "$message" '{success: $success, message: $message}'
+}
+
+# ---------------------------------------------------------------------------
+# apply: transient, live only
+# ---------------------------------------------------------------------------
+
+cmd_apply() {
+  local normalized
+  if ! normalized=$(validate_layout); then
+    json_result false "invalid layout"
+    return 1
+  fi
+
+  local statements=()
+  local identity mode x y scale transform enabled output_literal disabled_field
+  local entry
+  while IFS= read -r entry; do
+    identity=$(jq -r '.identity' <<<"$entry")
+    mode=$(jq -r '.mode' <<<"$entry")
+    x=$(jq -r '.x' <<<"$entry")
+    y=$(jq -r '.y' <<<"$entry")
+    scale=$(jq -r '.scale' <<<"$entry")
+    transform=$(jq -r '.transform' <<<"$entry")
+    enabled=$(jq -r '.enabled' <<<"$entry")
+
+    if ! output_literal=$(lua_output_literal "$identity"); then
+      json_result false "unsafe monitor identity: $identity"
+      return 1
+    fi
+
+    disabled_field=""
+    [[ $enabled == "false" ]] && disabled_field=", disabled = true"
+
+    statements+=("hl.monitor({ output = \"$output_literal\", mode = \"$mode\", position = \"${x}x${y}\", scale = $scale, transform = $transform$disabled_field })")
+  done < <(jq -c '.[]' <<<"$normalized")
+
+  local combined
+  combined=$(IFS='; '; echo "${statements[*]}")
+
+  local result
+  result=$(hyprctl eval "$combined" 2>&1) || {
+    audit_arrange "apply-failed" "$result"
+    json_result false "$result"
+    return 1
+  }
+
+  if [[ $result != "ok" ]]; then
+    audit_arrange "apply-rejected" "$result"
+    json_result false "$result"
+    return 1
+  fi
+
+  audit_arrange "apply" "${#statements[@]} monitor(s)"
+  json_result true "applied ${#statements[@]} monitor(s)"
+}
+
+# ---------------------------------------------------------------------------
+# persist: managed-block rewrite, live untouched
+# ---------------------------------------------------------------------------
+
+render_lua_entry() {
+  local entry="$1"
+  local identity mode x y scale transform enabled output_literal disabled_field
+
+  identity=$(jq -r '.identity' <<<"$entry")
+  mode=$(jq -r '.mode' <<<"$entry")
+  x=$(jq -r '.x' <<<"$entry")
+  y=$(jq -r '.y' <<<"$entry")
+  scale=$(jq -r '.scale' <<<"$entry")
+  transform=$(jq -r '.transform' <<<"$entry")
+  enabled=$(jq -r '.enabled' <<<"$entry")
+
+  output_literal=$(lua_output_literal "$identity") || return 1
+
+  disabled_field=""
+  [[ $enabled == "false" ]] && disabled_field=", disabled = true"
+
+  printf 'hl.monitor({ output = "%s", mode = "%s", position = "%sx%s", scale = %s, transform = %s%s })\n' \
+    "$output_literal" "$mode" "$x" "$y" "$scale" "$transform" "$disabled_field"
+}
+
+cmd_persist() {
+  local normalized
+  if ! normalized=$(validate_layout); then
+    json_result false "invalid layout"
+    return 1
+  fi
+
+  local block=""
+  local entry line
+  while IFS= read -r entry; do
+    line=$(render_lua_entry "$entry") || {
+      json_result false "unsafe monitor identity in layout"
+      return 1
+    }
+    # Command substitution strips the trailing newline render_lua_entry
+    # printed, so it has to be put back explicitly or every entry after the
+    # first collapses onto one line.
+    block+="$line"$'\n'
+  done < <(jq -c '.[]' <<<"$normalized")
+
+  mkdir -p "$(dirname "$MONITORS_LUA")"
+
+  if [[ -f $MONITORS_LUA ]]; then
+    local begin_count end_count
+    begin_count=$(grep -c -F -- "$MANAGED_BEGIN" "$MONITORS_LUA" || true)
+    end_count=$(grep -c -F -- "$MANAGED_END" "$MONITORS_LUA" || true)
+
+    if (( begin_count > 1 || end_count > 1 )); then
+      json_result false "monitors.lua has more than one managed block marker; refusing to guess"
+      return 1
+    fi
+
+    if (( begin_count == 1 && end_count == 0 )) || (( begin_count == 0 && end_count == 1 )); then
+      json_result false "monitors.lua has an unbalanced managed block marker; refusing to guess"
+      return 1
+    fi
+
+    local backup="${MONITORS_LUA}.bak.$(date +%s)"
+    cp "$MONITORS_LUA" "$backup"
+
+    local rewritten
+    rewritten=$(mktemp)
+    if (( begin_count == 1 && end_count == 1 )); then
+      # Replace strictly between the two markers, leaving everything else in
+      # the file — a user's own hl.env calls, comments, whatever precedes or
+      # follows — byte-for-byte untouched.
+      awk -v begin="$MANAGED_BEGIN" -v end="$MANAGED_END" -v block="$block" '
+        $0 == begin { print; printf "%s", block; skipping = 1; next }
+        $0 == end { skipping = 0; print; next }
+        skipping { next }
+        { print }
+      ' "$MONITORS_LUA" >"$rewritten"
+    else
+      # No managed block yet: adopt the file by appending one, leaving all
+      # existing content untouched rather than rewriting anything in place.
+      cp "$MONITORS_LUA" "$rewritten"
+      {
+        printf '\n%s\n' "$MANAGED_BEGIN"
+        printf '%s' "$block"
+        printf '%s\n' "$MANAGED_END"
+      } >>"$rewritten"
+    fi
+    mv "$rewritten" "$MONITORS_LUA"
+    audit_arrange "persist" "updated $MONITORS_LUA (backup: $backup)"
+  else
+    {
+      printf '%s\n' "$MANAGED_BEGIN"
+      printf '%s' "$block"
+      printf '%s\n' "$MANAGED_END"
+    } >"$MONITORS_LUA"
+    audit_arrange "persist" "created $MONITORS_LUA"
+  fi
+
+  json_result true "persisted arrangement to $MONITORS_LUA"
+}
+
+# ---------------------------------------------------------------------------
+
+case "${1:-}" in
+  validate)
+    validate_layout
+    ;;
+  apply)
+    cmd_apply
+    ;;
+  persist)
+    cmd_persist
+    ;;
+  -h | --help | "")
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/bin/omarchy-monitor-state
+++ b/bin/omarchy-monitor-state
@@ -21,3 +21,26 @@ omarchy-hyprland-monitor-scaling 2>/dev/null || echo
 
 printf '%s\n' "$monitors_json" | jq -c \
   '[.[] | {name, enabled:(.disabled != true), focused:(.focused == true), width, height}]'
+
+# Extended per-display detail for the display-panel arrangement UI, added as a
+# new trailing line rather than reshaping line 8 above: existing consumers
+# that read this output by line index (the shell panel, monitor-state-test.sh)
+# stay correct without change, and only a panel that knows to look for a 9th
+# line reads the richer shape. Identity is exposed as `description`/`serial`
+# rather than `name` because DisplayLink-backed connector names (DVI-I-1,
+# DVI-I-2, ...) can be reassigned across reconnects; callers that persist or
+# re-address a monitor should key off description, matching the `desc:`
+# selectors monitors.lua and omarchy-hyprland-monitor-scaling already use.
+printf '%s\n' "$monitors_json" | jq -c \
+  '[.[] | {
+     name,
+     description: (.description // ""),
+     serial: (.serial // ""),
+     enabled: (.disabled != true),
+     focused: (.focused == true),
+     x, y, width, height,
+     scale,
+     transform,
+     currentMode: (if (.width // 0) > 0 then "\(.width)x\(.height)@\(.refreshRate)" else "" end),
+     availableModes: (.availableModes // [])
+   }]'

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -111,6 +111,268 @@ function parseDisplays(raw) {
   }
 }
 
+// ---------- Display-panel arrangement additions ----------
+//
+// These back the arrangement canvas and per-monitor resolution/scale/
+// rotation controls. Identity is `desc:<description>` (falling back to the
+// connector name only when a monitor has no EDID description) to match
+// omarchy-monitor-arrange's addressing and monitors.lua's existing `desc:`
+// selectors — connector names on a DisplayLink dock get reassigned across
+// reconnects, so they can't be used as a stable key.
+
+function parseMode(modeString) {
+  var s = String(modeString || "")
+  var m = s.match(/^([0-9]+)x([0-9]+)@([0-9.]+)(?:Hz)?$/i)
+  if (!m) return { width: 0, height: 0, refresh: 0, raw: s }
+  return {
+    width: parseInt(m[1], 10),
+    height: parseInt(m[2], 10),
+    refresh: parseFloat(m[3]),
+    raw: s
+  }
+}
+
+function rotateDimensions(width, height, transform) {
+  var t = Number(transform) || 0
+  if (t === 1 || t === 3) return { width: height, height: width }
+  return { width: width, height: height }
+}
+
+function monitorIdentity(display) {
+  if (!display) return ""
+  var desc = String(display.description || "").trim()
+  return desc ? "desc:" + desc : String(display.name || "")
+}
+
+// Parses omarchy-monitor-state's extended (9th) line: description/serial
+// identity plus position/scale/transform/mode/availableModes per display.
+function parseExtendedDisplays(raw) {
+  var displays = []
+  try {
+    var parsed = raw ? JSON.parse(String(raw)) : []
+    if (Array.isArray(parsed)) displays = parsed
+  } catch (e) {
+    displays = []
+  }
+  if (!Array.isArray(displays)) displays = []
+
+  var normalized = []
+  var count = 0
+  for (var i = 0; i < displays.length; i++) {
+    var d = displays[i]
+    if (!d) continue
+    var enabled = !!d.enabled
+    if (enabled) count++
+    normalized.push({
+      name: d.name || "",
+      description: d.description || "",
+      serial: d.serial || "",
+      enabled: enabled,
+      focused: !!d.focused,
+      x: Number(d.x) || 0,
+      y: Number(d.y) || 0,
+      width: Number(d.width) || 0,
+      height: Number(d.height) || 0,
+      scale: Number(d.scale) || 1,
+      transform: Number(d.transform) || 0,
+      currentMode: d.currentMode || "",
+      availableModes: Array.isArray(d.availableModes) ? d.availableModes : []
+    })
+  }
+
+  return {
+    displays: normalized,
+    enabledDisplayCount: count
+  }
+}
+
+function arrangementBounds(monitors) {
+  var minX = 0
+  var minY = 0
+  var maxX = 0
+  var maxY = 0
+  var hasAny = false
+
+  for (var i = 0; i < monitors.length; i++) {
+    var d = monitors[i]
+    if (!d || !d.enabled) continue
+    var dims = rotateDimensions(d.width, d.height, d.transform)
+    var left = Number(d.x) || 0
+    var top = Number(d.y) || 0
+    var right = left + dims.width / Number(d.scale || 1)
+    var bottom = top + dims.height / Number(d.scale || 1)
+
+    if (!hasAny) {
+      minX = left
+      minY = top
+      maxX = right
+      maxY = bottom
+      hasAny = true
+    } else {
+      if (left < minX) minX = left
+      if (top < minY) minY = top
+      if (right > maxX) maxX = right
+      if (bottom > maxY) maxY = bottom
+    }
+  }
+
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY)
+  }
+}
+
+function arrangementCanvasScale(bounds, canvasWidth, canvasHeight, padding) {
+  var pad = Number(padding) || 0
+  var availW = Math.max(1, canvasWidth - pad * 2)
+  var availH = Math.max(1, canvasHeight - pad * 2)
+  var scaleX = bounds.width > 0 ? availW / bounds.width : 1
+  var scaleY = bounds.height > 0 ? availH / bounds.height : 1
+  return Math.min(scaleX, scaleY)
+}
+
+function paddedBounds(bounds, fraction) {
+  var f = Math.max(0, Number(fraction) || 0)
+  var extraX = bounds.width * f
+  var extraY = bounds.height * f
+  return {
+    x: bounds.x - extraX,
+    y: bounds.y - extraY,
+    width: bounds.width + extraX * 2,
+    height: bounds.height + extraY * 2
+  }
+}
+
+function logicalFromCanvas(canvasDelta, scale) {
+  return Number(canvasDelta) / Number(scale || 1)
+}
+
+// Lays out enabled+disabled tiles scaled to fit the canvas, centered on both
+// axes (rather than pinned to the top-left corner) so the arrangement reads
+// as centered regardless of how lopsided the real layout is.
+function scaleArrangement(monitors, bounds, canvasWidth, canvasHeight, padding, selectedIdentity) {
+  var scale = arrangementCanvasScale(bounds, canvasWidth, canvasHeight, padding)
+  var pad = Number(padding) || 0
+  var usedW = bounds.width * scale
+  var usedH = bounds.height * scale
+  var offsetX = pad + Math.max(0, (canvasWidth - pad * 2 - usedW) / 2)
+  var offsetY = pad + Math.max(0, (canvasHeight - pad * 2 - usedH) / 2)
+
+  var result = []
+  for (var i = 0; i < monitors.length; i++) {
+    var d = monitors[i]
+    if (!d) continue
+    var dims = rotateDimensions(d.width, d.height, d.transform)
+    var logicalW = dims.width / Number(d.scale || 1)
+    var logicalH = dims.height / Number(d.scale || 1)
+    var identity = monitorIdentity(d)
+    result.push({
+      identity: identity,
+      name: d.name,
+      x: offsetX + ((Number(d.x) || 0) - bounds.x) * scale,
+      y: offsetY + ((Number(d.y) || 0) - bounds.y) * scale,
+      width: logicalW * scale,
+      height: logicalH * scale,
+      enabled: !!d.enabled,
+      focused: !!d.focused,
+      selected: identity === selectedIdentity
+    })
+  }
+  return result
+}
+
+function compactModes(modes, current, limit) {
+  var result = []
+  var seen = {}
+  var max = Math.max(1, Number(limit) || 6)
+  function add(mode) {
+    var value = String(mode || "")
+    if (!value || seen[value] || result.length >= max) return
+    seen[value] = true
+    result.push(value)
+  }
+  add(current)
+  for (var i = 0; i < (modes || []).length && result.length < max; i++) add(modes[i])
+  return result
+}
+
+function modeOptions(modes, current, limit) {
+  return compactModes(modes, current, limit).map(function(value) {
+    var parsed = parseMode(value)
+    var label = parsed.width > 0
+      ? (parsed.width + "×" + parsed.height + " " + Math.round(parsed.refresh) + "Hz")
+      : value
+    return { label: label, value: value }
+  })
+}
+
+// Diffs pending per-identity edits against live state, dropping any pending
+// entry that no longer differs (e.g. the user dialed a value back to what it
+// already was) so `dirty`/the Apply footer only reflect real changes.
+function diffPending(displaysByIdentity, pending) {
+  var out = {}
+  var keys = Object.keys(pending || {})
+  for (var i = 0; i < keys.length; i++) {
+    var identity = keys[i]
+    var cur = displaysByIdentity[identity]
+    var pend = pending[identity]
+    if (!cur || !pend) continue
+
+    var changes = {}
+    if (pend.enabled !== undefined && pend.enabled !== cur.enabled) changes.enabled = pend.enabled
+    if (pend.mode && pend.mode !== cur.currentMode) changes.mode = pend.mode
+    if (pend.scale !== undefined && normalizeScale(pend.scale) !== normalizeScale(cur.scale)) changes.scale = pend.scale
+    if (pend.transform !== undefined && Number(pend.transform) !== Number(cur.transform)) changes.transform = Number(pend.transform)
+    if (pend.x !== undefined && Number(pend.x) !== Number(cur.x)) changes.x = Number(pend.x)
+    if (pend.y !== undefined && Number(pend.y) !== Number(cur.y)) changes.y = Number(pend.y)
+
+    if (Object.keys(changes).length > 0) out[identity] = changes
+  }
+  return out
+}
+
+function isDirty(pendingDiff) {
+  return Object.keys(pendingDiff || {}).length > 0
+}
+
+// Builds the JSON layout array omarchy-monitor-arrange expects (apply and
+// persist share this shape), merging live display state with pending edits.
+function buildArrangeLayout(displays, pendingDiff) {
+  var diff = pendingDiff || {}
+  var layout = []
+  for (var i = 0; i < displays.length; i++) {
+    var d = displays[i]
+    if (!d) continue
+    var identity = monitorIdentity(d)
+    var changes = diff[identity] || {}
+    layout.push({
+      identity: identity,
+      mode: changes.mode || d.currentMode || "preferred",
+      x: changes.x !== undefined ? changes.x : d.x,
+      y: changes.y !== undefined ? changes.y : d.y,
+      scale: Number(changes.scale !== undefined ? changes.scale : d.scale) || 1,
+      transform: Number(changes.transform !== undefined ? changes.transform : d.transform) || 0,
+      enabled: changes.enabled !== undefined ? changes.enabled : d.enabled
+    })
+  }
+  return layout
+}
+
+// Parses {"success":bool,"message":string} from omarchy-monitor-arrange.
+function parseArrangeResult(raw) {
+  try {
+    var parsed = JSON.parse(String(raw || "{}"))
+    return {
+      success: !!parsed.success,
+      message: String(parsed.message || "")
+    }
+  } catch (e) {
+    return { success: false, message: "invalid backend response" }
+  }
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampBrightness: clampBrightness,
@@ -119,6 +381,21 @@ if (typeof module !== "undefined") {
     matchingScaleIndex: matchingScaleIndex,
     availableScales: availableScales,
     brightnessName: brightnessName,
-    parseDisplays: parseDisplays
+    parseDisplays: parseDisplays,
+    parseMode: parseMode,
+    rotateDimensions: rotateDimensions,
+    monitorIdentity: monitorIdentity,
+    parseExtendedDisplays: parseExtendedDisplays,
+    arrangementBounds: arrangementBounds,
+    arrangementCanvasScale: arrangementCanvasScale,
+    paddedBounds: paddedBounds,
+    logicalFromCanvas: logicalFromCanvas,
+    scaleArrangement: scaleArrangement,
+    compactModes: compactModes,
+    modeOptions: modeOptions,
+    diffPending: diffPending,
+    isDirty: isDirty,
+    buildArrangeLayout: buildArrangeLayout,
+    parseArrangeResult: parseArrangeResult
   }
 }

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -18,40 +18,154 @@ Panel {
   property int pendingBrightnessPercent: 0
   property bool brightnessSetQueued: false
   property bool brightnessAvailable: false
-  property string internalMonitor: ""
-  property string externalMonitor: ""
   property string focusedMonitor: ""
-  property bool internalEnabled: false
-  property bool mirrorEnabled: false
-  property string monitorScale: ""
   property var displays: []
   property int enabledDisplayCount: 0
 
   // Carry sub-notch touchpad deltas between wheel events.
   property real wheelAccumulator: 0
 
-  // Cursor model shared by keyboard and mouse. Sections:
-  //   "brightness" - single slider row, selectedIndex = -1 sentinel
-  //                  (mirrors Audio's slider rows). Only present if a
-  //                  controllable backlight was detected.
-  //   "scale"      - 6 Button scale presets; treated as a single
-  //                  horizontal row from j/k's perspective. h/l moves
-  //                  between presets, identical to bluetooth's header.
-  //   "monitors"   - vertical display row list for enabling/disabling displays;
-  //                  j/k walks each row.
+  // ---------------------------------------------------------------------
+  // Arrangement + per-monitor selection and pending edits
+  // ---------------------------------------------------------------------
+  // Identity is desc:<description> (falling back to connector name), never
+  // the raw connector name alone: matches Model.monitorIdentity and stays
+  // valid across a DisplayLink reconnect that renumbers connectors.
+  property string selectedIdentity: ""
+  property var pendingChanges: ({})   // { identity: { enabled, mode, scale, transform, x, y } }
+
+  readonly property var displayByIdentity: {
+    var map = {}
+    for (var i = 0; i < displays.length; i++) {
+      var d = displays[i]
+      if (d) map[Model.monitorIdentity(d)] = d
+    }
+    return map
+  }
+
+  readonly property var selectedDisplay: displayByIdentity[selectedIdentity] || null
+
+  readonly property var arrangementDisplays: {
+    var result = []
+    for (var i = 0; i < displays.length; i++) {
+      var d = displays[i]
+      if (!d) continue
+      var identity = Model.monitorIdentity(d)
+      var pending = pendingChanges[identity] || {}
+      result.push(Object.assign({}, d, {
+        x: pending.x !== undefined ? pending.x : d.x,
+        y: pending.y !== undefined ? pending.y : d.y,
+        scale: pending.scale !== undefined ? pending.scale : d.scale,
+        transform: pending.transform !== undefined ? pending.transform : d.transform,
+        enabled: pending.enabled !== undefined ? pending.enabled : d.enabled
+      }))
+    }
+    return result
+  }
+
+  readonly property var pendingDiff: Model.diffPending(displayByIdentity, pendingChanges)
+  readonly property bool dirty: Model.isDirty(pendingDiff)
+
+  function monitorValue(identity, field, fallback) {
+    var pending = pendingChanges[identity]
+    if (pending && pending[field] !== undefined) return pending[field]
+    var live = displayByIdentity[identity]
+    if (!live) return fallback
+    if (field === "enabled") return live.enabled
+    if (field === "mode") return live.currentMode
+    if (field === "scale") return live.scale
+    if (field === "transform") return live.transform
+    if (field === "x") return live.x
+    if (field === "y") return live.y
+    return fallback
+  }
+
+  function setPendingField(identity, field, value) {
+    var clone = {}
+    var names = Object.keys(root.pendingChanges)
+    for (var i = 0; i < names.length; i++) {
+      var n = names[i]
+      clone[n] = Object.assign({}, root.pendingChanges[n])
+    }
+    if (!clone[identity]) clone[identity] = {}
+    clone[identity][field] = value
+    root.pendingChanges = clone
+  }
+
+  function clearPending() {
+    root.pendingChanges = {}
+  }
+
+  function selectMonitor(identity) {
+    root.selectedIdentity = identity
+  }
+
+  function snapLogical(value) {
+    return Math.round(Number(value) / 10) * 10
+  }
+
+  // ---------------------------------------------------------------------
+  // Safe apply / preview / revert, through omarchy-monitor-arrange
+  // ---------------------------------------------------------------------
+  // "Apply" pushes the pending layout live (transient, via `arrange apply`)
+  // and starts a preview countdown; "Keep" persists it to monitors.lua
+  // (`arrange persist`), "Revert" re-applies the pre-change snapshot. An
+  // unconfirmed preview auto-reverts so a bad layout can't strand the user.
+  readonly property int previewSeconds: 12
+  property bool previewActive: false
+  property int previewRemaining: 0
+  property var liveSnapshot: []
+  property string statusText: ""
+
+  function startApply() {
+    if (!root.dirty) return
+    root.liveSnapshot = Model.buildArrangeLayout(root.displays, {})
+    var layout = Model.buildArrangeLayout(root.displays, root.pendingDiff)
+    runArrange(arrangeApplyProc, "apply", layout)
+  }
+
+  function keepApplied() {
+    var layout = Model.buildArrangeLayout(root.displays, root.pendingDiff)
+    runArrange(arrangePersistProc, "persist", layout)
+  }
+
+  function revertPreview() {
+    previewCountdown.stop()
+    if (root.previewActive) runArrange(arrangeRevertProc, "apply", root.liveSnapshot)
+    root.previewActive = false
+    root.previewRemaining = 0
+    root.clearPending()
+  }
+
+  function primaryAction() {
+    if (root.previewActive) root.keepApplied()
+    else root.startApply()
+  }
+
+  function secondaryAction() {
+    if (root.previewActive) root.revertPreview()
+    else root.clearPending()
+  }
+
+  function runArrange(proc, command, layout) {
+    proc.command = ["bash", "-c", "omarchy-monitor-arrange " + command + " <<< \"$1\"", "--", JSON.stringify(layout)]
+    if (!proc.running) proc.running = true
+  }
+
+  // ---------------------------------------------------------------------
+  // Keyboard cursor model
+  // ---------------------------------------------------------------------
+  // Sections:
+  //   "brightness" - single slider row, selectedIndex = -1 sentinel.
+  //   "textsize"   - single slider row, selectedIndex = -1 sentinel.
+  //   "canvas"     - arrangement tiles; only present with 2+ displays.
+  //   "enable"/"mode"/"scale"/"rotation" - single rows for the selected
+  //                  monitor; only present once a monitor is selected.
+  //   "actions"    - Apply/Cancel (or Keep/Revert) footer, 2 entries.
   // Mouse hover on a target updates root state via the components' `hovered`
   // signal so keyboard cursor and pointer share one highlight.
-  readonly property var scalePresets: ["1", "1.25", "1.6", "2", "3", "4"]
-  readonly property var scaleValues: {
-    for (var i = 0; i < displays.length; i++) {
-      var display = displays[i]
-      if (display && display.focused)
-        return Model.availableScales(scalePresets, display.width, display.height)
-    }
-    return scalePresets
-  }
-  property string focusSection: "scale"
-  property int selectedIndex: 0
+  property string focusSection: "brightness"
+  property int selectedIndex: -1
   property bool cursorActive: false
 
   // Text size slider — curated macOS-style notches (px). The panel snaps to
@@ -76,22 +190,20 @@ Panel {
     var list = []
     if (brightnessAvailable) list.push("brightness")
     list.push("textsize")
-    list.push("scale")
-    if (displays.length > 1) list.push("monitors")
+    if (displays.length > 1) list.push("canvas")
+    if (selectedDisplay) list.push("enable", "mode", "scale", "rotation")
+    if (dirty || previewActive) list.push("actions")
     return list
   }
 
   function sectionCount(section) {
-    if (section === "brightness") return 0  // only the slider sentinel at -1
-    if (section === "textsize") return 0    // slider sentinel at -1, like brightness
-    if (section === "scale") return scaleValues.length
-    if (section === "monitors") return displays.length
-    return 0
+    if (section === "canvas") return displays.length
+    if (section === "actions") return 2
+    return 0  // brightness/textsize/enable/mode/scale/rotation are lone rows
   }
 
   function sectionIsSingleRow(section) {
-    // brightness and text size are lone sliders; scale presets sit horizontally.
-    return section === "brightness" || section === "textsize" || section === "scale"
+    return section !== "canvas"
   }
 
   function sectionFirstIndex(section) {
@@ -129,15 +241,21 @@ Panel {
     }
   }
 
-  // h/l: in scale section, walks the preset row; everywhere else, no-op
-  // because adjustBrightness handles horizontal motion on the brightness
-  // slider.
+  // h/l: canvas walks tiles left-to-right by array order; actions walks
+  // Apply/Cancel; everywhere else, no-op because adjustBrightness/
+  // adjustTextSize handle horizontal motion on their own sliders.
   function moveCursorH(delta) {
-    if (focusSection !== "scale") return
-    var next = selectedIndex + delta
-    if (next < 0) next = 0
-    if (next > scaleValues.length - 1) next = scaleValues.length - 1
-    selectedIndex = next
+    if (focusSection === "canvas" && displays.length > 0) {
+      var next = selectedIndex + delta
+      if (next < 0) next = 0
+      if (next > displays.length - 1) next = displays.length - 1
+      selectedIndex = next
+      root.selectMonitor(Model.monitorIdentity(displays[selectedIndex]))
+      return
+    }
+    if (focusSection === "actions") {
+      selectedIndex = Math.max(0, Math.min(1, selectedIndex + delta))
+    }
   }
 
   function adjustBrightness(delta) {
@@ -147,15 +265,21 @@ Panel {
   }
 
   function activateCursor() {
-    if (focusSection === "scale" && selectedIndex >= 0 && selectedIndex < scaleValues.length) {
-      setScale(scaleValues[selectedIndex])
+    if (focusSection === "canvas" && selectedIndex >= 0 && selectedIndex < displays.length) {
+      root.selectMonitor(Model.monitorIdentity(displays[selectedIndex]))
       return
     }
-    if (focusSection === "monitors" && selectedIndex >= 0 && selectedIndex < displays.length) {
-      var d = displays[selectedIndex]
-      if (d) toggleDisplay(d.name, d.enabled)
+    if (focusSection === "enable" && selectedDisplay) {
+      var identity = root.selectedIdentity
+      root.setPendingField(identity, "enabled", !monitorValue(identity, "enabled", selectedDisplay.enabled))
+      return
     }
-    // brightness: no separate action; the slider value is the action.
+    if (focusSection === "actions") {
+      if (selectedIndex === 0) root.primaryAction()
+      else if (selectedIndex === 1) root.secondaryAction()
+    }
+    // brightness/textsize: no separate action; the slider value is the action.
+    // mode/scale/rotation: opened via click; no keyboard-activate shortcut yet.
   }
 
   function clampCursor() {
@@ -168,9 +292,8 @@ Panel {
     }
     var count = sectionCount(focusSection)
     if (sectionIsSingleRow(focusSection)) {
-      // brightness/text size use the -1 sentinel; scale clamps into the presets.
       if (focusSection === "brightness" || focusSection === "textsize") selectedIndex = -1
-      else if (selectedIndex < 0 || selectedIndex >= count) selectedIndex = 0
+      else if (selectedIndex < 0 || selectedIndex >= Math.max(1, count)) selectedIndex = 0
       return
     }
     if (count === 0) {
@@ -212,8 +335,10 @@ Panel {
       brightness: root.brightnessPercent,
       brightnessAvailable: root.brightnessAvailable,
       focusedMonitor: root.focusedMonitor,
-      scale: root.monitorScale,
-      displays: root.displays
+      displays: root.displays,
+      pendingDiff: root.pendingDiff,
+      dirty: root.dirty,
+      previewActive: root.previewActive
     })
   }
 
@@ -261,28 +386,6 @@ Panel {
     }))
   }
 
-  function normalizeScale(scale) {
-    return Model.normalizeScale(scale)
-  }
-
-  function activeScaleIndex() {
-    for (var i = 0; i < displays.length; i++) {
-      var display = displays[i]
-      if (display && display.focused)
-        return Model.matchingScaleIndex(scaleValues, monitorScale, display.width, display.height)
-    }
-    return -1
-  }
-
-  function effectiveScale(scale) {
-    for (var i = 0; i < displays.length; i++) {
-      var display = displays[i]
-      if (display && display.focused)
-        return Model.cleanScale(scale, display.width, display.height)
-    }
-    return normalizeScale(scale)
-  }
-
   // Playful mood-name for a given brightness percent. Bands intentionally
   // span ~10–20 points so casual tweaks change the label, while small
   // nudges within one band don't.
@@ -291,22 +394,12 @@ Panel {
   }
 
   function updateDisplays(displaysJson) {
-    var parsed = Model.parseDisplays(displaysJson)
+    var parsed = Model.parseExtendedDisplays(displaysJson)
     root.displays = parsed.displays
     root.enabledDisplayCount = parsed.enabledDisplayCount
-  }
-
-  function toggleDisplay(name, enabled) {
-    if (!name) return
-    if (enabled && root.enabledDisplayCount <= 1) return
-
-    actionProc.command = ["hyprctl", "keyword", "monitor", name + (enabled ? ",disable" : ",preferred,auto,auto")]
-    if (!actionProc.running) actionProc.running = true
-  }
-
-  function setScale(scale) {
-    actionProc.command = ["bash", "-c", "omarchy-hyprland-monitor-scaling " + scale]
-    if (!actionProc.running) actionProc.running = true
+    if ((!root.selectedIdentity || !root.displayByIdentity[root.selectedIdentity]) && parsed.displays.length > 0) {
+      root.selectMonitor(Model.monitorIdentity(parsed.displays[0]))
+    }
   }
 
   // ---- Text size (shell base font + GTK text-scaling, via one CLI) ----
@@ -357,20 +450,14 @@ Panel {
   onOpenedChanged: {
     if (opened) {
       refresh()
-      if (brightnessAvailable) {
-        focusSection = "brightness"
-        selectedIndex = -1
-      } else {
-        focusSection = "scale"
-        selectedIndex = 0
-      }
+      focusSection = brightnessAvailable ? "brightness" : "textsize"
+      selectedIndex = -1
       cursorActive = false
     }
   }
 
   onBrightnessAvailableChanged: clampCursor()
   onDisplaysChanged: clampCursor()
-  onScaleValuesChanged: clampCursor()
   onVisibleSectionsChanged: clampCursor()
 
   // Only poll while the panel is open; the bar glyph tracks monitor count via
@@ -393,13 +480,15 @@ Panel {
         var brightness = String(lines[0] || "").trim()
         root.brightnessAvailable = brightness !== "unavailable" && brightness !== ""
         root.brightnessPercent = root.brightnessAvailable ? Math.max(0, Math.min(100, parseInt(brightness, 10))) : 0
-        root.internalMonitor = String(lines[1] || "").trim()
-        root.externalMonitor = String(lines[2] || "").trim()
-        root.internalEnabled = String(lines[3] || "").trim() !== ""
-        root.mirrorEnabled = String(lines[4] || "").trim() === root.externalMonitor && root.externalMonitor !== ""
         root.focusedMonitor = String(lines[5] || "").trim()
-        root.monitorScale = root.normalizeScale(String(lines[6] || "").trim())
-        root.updateDisplays(String(lines[7] || "[]").trim())
+        // Line 9 (index 8) is the extended per-display shape the arrangement
+        // canvas and detail controls need — description/serial identity,
+        // position, scale, transform, mode. Lines 1-4/6 (internal/external
+        // connector names, mirror state, legacy scale) aren't read here
+        // since the extended shape already carries everything this panel
+        // needs per display; they stay in omarchy-monitor-state's output
+        // for older consumers.
+        root.updateDisplays(String(lines[8] || "[]").trim())
       }
     }
   }
@@ -429,8 +518,57 @@ Panel {
     }
   }
 
+  // Preview countdown: an applied-but-unconfirmed layout auto-reverts if the
+  // user never taps Keep. Interval matches displaylink.service's observed
+  // RestartUSec=5s crash/restart bounce plus margin, so a transient
+  // DisplayLink drop during apply doesn't eat the whole confirm window.
+  Timer {
+    id: previewCountdown
+    interval: 1000
+    running: root.previewActive && root.previewRemaining > 0
+    repeat: true
+    onTriggered: {
+      root.previewRemaining = Math.max(0, root.previewRemaining - 1)
+      if (root.previewRemaining <= 0) root.revertPreview()
+    }
+  }
+
   Process {
-    id: actionProc
+    id: arrangeApplyProc
+    stdout: StdioCollector { waitForEnd: true }
+    onRunningChanged: {
+      if (running) return
+      var res = Model.parseArrangeResult(arrangeApplyProc.stdout.text)
+      if (res.success) {
+        root.previewActive = true
+        root.previewRemaining = root.previewSeconds
+      } else {
+        root.previewActive = false
+        root.statusText = res.message
+      }
+    }
+  }
+
+  Process {
+    id: arrangePersistProc
+    stdout: StdioCollector { waitForEnd: true }
+    onRunningChanged: {
+      if (running) return
+      var res = Model.parseArrangeResult(arrangePersistProc.stdout.text)
+      root.previewActive = false
+      root.previewRemaining = 0
+      if (res.success) root.clearPending()
+      else root.statusText = res.message
+      root.refresh()
+    }
+  }
+
+  // Re-applies the pre-change snapshot on revert/timeout. A failure here
+  // still clears the local preview state (handled by revertPreview's
+  // caller) rather than get stuck showing a countdown that already hit
+  // zero; the next refresh() reports whatever Hyprland actually settled on.
+  Process {
+    id: arrangeRevertProc
     stdout: StdioCollector { waitForEnd: true }
     onRunningChanged: if (!running) root.refresh()
   }
@@ -488,7 +626,7 @@ Panel {
     bar: root.bar
     open: root.opened
     focusTarget: keyCatcher
-    contentWidth: panel.fittedContentWidth(Style.space(380))
+    contentWidth: panel.fittedContentWidth(Style.space(430))
     contentHeight: panel.fittedContentHeight(panelColumn.implicitHeight, Style.space(560))
 
     PanelKeyCatcher {
@@ -500,7 +638,7 @@ Panel {
         else if (dx !== 0) {
           if (root.focusSection === "brightness") root.adjustBrightness(dx * 5)
           else if (root.focusSection === "textsize") root.adjustTextSize(dx)
-          else if (root.focusSection === "scale") root.moveCursorH(dx)
+          else root.moveCursorH(dx)
         }
       }
       onActivateRequested: if (root.cursorActive) root.activateCursor()
@@ -725,72 +863,7 @@ Panel {
             }
           }
 
-          // ---------- Scale ----------
-          PanelSeparator {
-            foreground: root.bar.foreground
-          }
-
-          Column {
-            width: parent.width
-            spacing: Style.space(10)
-
-            Item {
-              width: parent.width
-              implicitHeight: Math.max(scaleHeader.implicitHeight, scaleMonitor.implicitHeight)
-
-              PanelSectionHeader {
-                id: scaleHeader
-                text: "SCALE"
-                foreground: root.bar.foreground
-                fontFamily: root.bar.fontFamily
-                anchors.left: parent.left
-                anchors.verticalCenter: parent.verticalCenter
-              }
-
-              // Name the monitor SCALE targets, since it only applies to the
-              // focused one.
-              Text {
-                id: scaleMonitor
-                textFormat: Text.PlainText
-                text: root.focusedMonitor
-                // Only worth naming when more than one display is in play.
-                visible: root.focusedMonitor !== "" && root.enabledDisplayCount > 1
-                color: Qt.darker(root.bar.foreground, 1.4)
-                font.family: root.bar.fontFamily
-                font.pixelSize: Style.font.caption
-                font.bold: true
-                anchors.right: parent.right
-                anchors.rightMargin: Style.space(6)
-                anchors.verticalCenter: parent.verticalCenter
-              }
-            }
-
-            Grid {
-              id: scaleRow
-              width: parent.width
-              columns: root.scaleValues.length
-              spacing: Style.spacing.xs
-
-              readonly property real cellWidth: root.scaleValues.length > 0
-                ? (width - spacing * (columns - 1)) / columns
-                : 0
-
-              Repeater {
-                model: root.scaleValues
-
-                ScalePill {
-                  required property string modelData
-                  required property int index
-
-                  scaleValue: modelData
-                  scaleIndex: index
-                  width: scaleRow.cellWidth
-                }
-              }
-            }
-          }
-
-          // ---------- Monitors ----------
+          // ---------- Arrangement (hidden with only one display) ----------
           PanelSeparator {
             visible: root.displays.length > 1
             foreground: root.bar.foreground
@@ -802,21 +875,450 @@ Panel {
             visible: root.displays.length > 1
 
             PanelSectionHeader {
-              text: "DISPLAYS"
+              text: "ARRANGEMENT"
               foreground: root.bar.foreground
               fontFamily: root.bar.fontFamily
             }
 
-            Repeater {
-              model: root.displays
+            CursorSurface {
+              id: canvasSurface
+              width: parent.width
+              height: Style.space(104)
+              hasCursor: root.cursorActive && root.focusSection === "canvas"
+              foreground: root.bar.foreground
+              outline: true
+              current: root.focusSection === "canvas"
 
-              MonitorRow {
-                required property var modelData
-                required property int index
+              // Keep bounds anchored to the live layout while dragging. If
+              // they followed pending coordinates, the viewport would move
+              // with the tile and make upward/leftward motion feel stuck.
+              readonly property var bounds: Model.paddedBounds(Model.arrangementBounds(root.displays), 0.2)
+              readonly property real canvasScale: Model.arrangementCanvasScale(
+                bounds, width - Style.space(12), height - Style.space(12), Style.space(6))
+              readonly property var scaledDisplays: Model.scaleArrangement(
+                root.arrangementDisplays, bounds, width - Style.space(12), height - Style.space(12), Style.space(6), root.selectedIdentity)
 
-                width: panelColumn.width
-                display: modelData
-                rowIndex: index
+              Rectangle {
+                id: canvasRect
+                anchors.fill: parent
+                anchors.margins: Style.space(6)
+                color: Style.hoverFillFor(root.bar.foreground, Color.accent)
+                radius: Style.space(6)
+                border.width: 0
+
+                Repeater {
+                  model: canvasSurface.scaledDisplays
+
+                  Rectangle {
+                    required property var modelData
+                    required property int index
+
+                    x: modelData.x
+                    y: modelData.y
+                    width: Math.max(Style.space(28), modelData.width)
+                    height: Math.max(Style.space(18), modelData.height)
+                    color: modelData.selected
+                      ? Style.selectedFillFor(root.bar.foreground, Color.accent)
+                      : Style.hoverFillFor(root.bar.foreground, Color.accent)
+                    border.color: modelData.selected ? Color.accent : Qt.darker(root.bar.foreground, 1.6)
+                    border.width: modelData.selected ? 2 : 1
+                    radius: Style.space(4)
+                    opacity: modelData.enabled ? 1.0 : 0.45
+
+                    Text {
+                      anchors.centerIn: parent
+                      textFormat: Text.PlainText
+                      text: modelData.name
+                      color: root.bar.foreground
+                      font.family: root.bar.fontFamily
+                      font.pixelSize: Style.font.caption
+                      font.bold: true
+                      elide: Text.ElideRight
+                      horizontalAlignment: Text.AlignHCenter
+                      width: parent.width - Style.space(4)
+                    }
+
+                    MouseArea {
+                      id: tileMouse
+                      anchors.fill: parent
+                      hoverEnabled: true
+                      cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+
+                      property real startCanvasX: 0
+                      property real startCanvasY: 0
+                      property real startLogicalX: 0
+                      property real startLogicalY: 0
+                      property bool dragged: false
+
+                      onPressed: function(mouse) {
+                        dragged = false
+                        var pos = mapToItem(canvasRect, mouse.x, mouse.y)
+                        startCanvasX = pos.x
+                        startCanvasY = pos.y
+                        startLogicalX = root.monitorValue(modelData.identity, "x", 0)
+                        startLogicalY = root.monitorValue(modelData.identity, "y", 0)
+                        root.selectMonitor(modelData.identity)
+                        root.cursorActive = true
+                        root.focusSection = "canvas"
+                        root.selectedIndex = index
+                      }
+
+                      onPositionChanged: function(mouse) {
+                        if (!pressed) return
+                        var pos = mapToItem(canvasRect, mouse.x, mouse.y)
+                        var canvasDx = pos.x - startCanvasX
+                        var canvasDy = pos.y - startCanvasY
+                        if (Math.abs(canvasDx) > 2 || Math.abs(canvasDy) > 2) dragged = true
+                        root.setPendingField(modelData.identity, "x",
+                          root.snapLogical(startLogicalX + Model.logicalFromCanvas(canvasDx, canvasSurface.canvasScale)))
+                        root.setPendingField(modelData.identity, "y",
+                          root.snapLogical(startLogicalY + Model.logicalFromCanvas(canvasDy, canvasSurface.canvasScale)))
+                      }
+
+                      onReleased: function(mouse) {
+                        if (!dragged) root.selectMonitor(modelData.identity)
+                      }
+                      onContainsMouseChanged: if (containsMouse) {
+                        root.cursorActive = true
+                        root.focusSection = "canvas"
+                        root.selectedIndex = index
+                      }
+                    }
+                  }
+                }
+              }
+
+              HoverHandler {
+                onHoveredChanged: if (hovered) {
+                  root.cursorActive = true
+                  root.focusSection = "canvas"
+                }
+              }
+            }
+          }
+
+          // ---------- Selected monitor: enable / resolution / scale / rotation ----------
+          PanelSeparator {
+            visible: !!root.selectedDisplay
+            foreground: root.bar.foreground
+          }
+
+          Column {
+            visible: !!root.selectedDisplay
+            width: parent.width
+            spacing: Style.space(10)
+
+            PanelSectionHeader {
+              text: root.selectedDisplay
+                ? (root.selectedDisplay.name + (root.selectedDisplay.description ? " · " + root.selectedDisplay.description : "")).toUpperCase()
+                : "DISPLAY"
+              foreground: root.bar.foreground
+              fontFamily: root.bar.fontFamily
+            }
+
+            // Enabled
+            CursorSurface {
+              id: enableRow
+              width: parent.width
+              height: Style.space(22) + Style.spacing.xl
+              hasCursor: root.cursorActive && root.focusSection === "enable"
+              foreground: root.bar.foreground
+              outline: true
+
+              Row {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: Style.space(12)
+                anchors.rightMargin: Style.space(12)
+                spacing: Style.space(8)
+
+                Text {
+                  text: "Enabled"
+                  color: root.bar.foreground
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.body
+                  width: parent.width - Style.space(22)
+                  anchors.verticalCenter: parent.verticalCenter
+                }
+
+                Text {
+                  textFormat: Text.PlainText
+                  text: root.selectedDisplay && root.monitorValue(root.selectedIdentity, "enabled", root.selectedDisplay.enabled) ? "󰄬" : ""
+                  color: root.bar.foreground
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.subtitle
+                  width: Style.space(14)
+                  horizontalAlignment: Text.AlignRight
+                  anchors.verticalCenter: parent.verticalCenter
+                }
+              }
+
+              MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onContainsMouseChanged: if (containsMouse) {
+                  root.cursorActive = true
+                  root.focusSection = "enable"
+                  root.selectedIndex = -1
+                }
+                onClicked: {
+                  if (!root.selectedDisplay) return
+                  var current = root.monitorValue(root.selectedIdentity, "enabled", root.selectedDisplay.enabled)
+                  if (current && root.enabledDisplayCount <= 1) return
+                  root.setPendingField(root.selectedIdentity, "enabled", !current)
+                }
+              }
+            }
+
+            // Resolution
+            CursorSurface {
+              id: modeRow
+              width: parent.width
+              height: Style.space(22) + Style.spacing.xl
+              hasCursor: root.cursorActive && root.focusSection === "mode"
+              foreground: root.bar.foreground
+              outline: true
+
+              Text {
+                text: "Resolution"
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.body
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(12)
+                anchors.verticalCenter: parent.verticalCenter
+              }
+
+              // Equal-width dropdowns: mode/scale/rotation all share this
+              // literal width rather than sizing to their own content, so
+              // the three rows line up.
+              Dropdown {
+                id: modeDropdown
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(12)
+                anchors.verticalCenter: parent.verticalCenter
+                width: Style.space(170)
+                showLabel: false
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                hasCursor: modeRow.hasCursor
+                enabled: root.selectedDisplay && (root.selectedDisplay.availableModes || []).length > 0
+                options: root.selectedDisplay
+                  ? Model.modeOptions(root.selectedDisplay.availableModes || [], root.selectedDisplay.currentMode, 6)
+                  : []
+                value: root.selectedDisplay
+                  ? root.monitorValue(root.selectedIdentity, "mode", root.selectedDisplay.currentMode)
+                  : ""
+                onChanged: function(mode) {
+                  if (!root.selectedDisplay) return
+                  root.setPendingField(root.selectedIdentity, "mode", mode)
+                  // Dropdown owns `value` once selected, which breaks this
+                  // binding — restore it so the row keeps tracking pending/
+                  // live state (e.g. after Cancel or selecting another tile).
+                  modeDropdown.value = Qt.binding(function() {
+                    return root.selectedDisplay
+                      ? root.monitorValue(root.selectedIdentity, "mode", root.selectedDisplay.currentMode)
+                      : ""
+                  })
+                }
+              }
+
+              HoverHandler {
+                onHoveredChanged: if (hovered) {
+                  root.cursorActive = true
+                  root.focusSection = "mode"
+                  root.selectedIndex = -1
+                }
+              }
+            }
+
+            // Scale
+            CursorSurface {
+              id: scaleRow
+              width: parent.width
+              height: Style.space(22) + Style.spacing.xl
+              hasCursor: root.cursorActive && root.focusSection === "scale"
+              foreground: root.bar.foreground
+              outline: true
+
+              Text {
+                text: "Scale"
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.body
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(12)
+                anchors.verticalCenter: parent.verticalCenter
+              }
+
+              Dropdown {
+                id: scaleDropdown
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(12)
+                anchors.verticalCenter: parent.verticalCenter
+                width: Style.space(170)
+                showLabel: false
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                hasCursor: scaleRow.hasCursor
+                enabled: !!root.selectedDisplay
+
+                readonly property var currentMode: root.selectedDisplay
+                  ? Model.parseMode(root.monitorValue(root.selectedIdentity, "mode", root.selectedDisplay.currentMode))
+                  : { width: 0, height: 0 }
+
+                options: {
+                  if (!root.selectedDisplay) return []
+                  var presets = ["1", "1.25", "1.6", "2", "3", "4"]
+                  var scales = Model.availableScales(presets, currentMode.width, currentMode.height)
+                  return scales.map(function(s) {
+                    return { value: s, label: Model.cleanScale(s, currentMode.width, currentMode.height) + "x" }
+                  })
+                }
+                value: root.selectedDisplay
+                  ? String(root.monitorValue(root.selectedIdentity, "scale", root.selectedDisplay.scale))
+                  : ""
+                onChanged: function(scale) {
+                  if (!root.selectedDisplay) return
+                  root.setPendingField(root.selectedIdentity, "scale", scale)
+                  scaleDropdown.value = Qt.binding(function() {
+                    return root.selectedDisplay
+                      ? String(root.monitorValue(root.selectedIdentity, "scale", root.selectedDisplay.scale))
+                      : ""
+                  })
+                }
+              }
+
+              HoverHandler {
+                onHoveredChanged: if (hovered) {
+                  root.cursorActive = true
+                  root.focusSection = "scale"
+                  root.selectedIndex = -1
+                }
+              }
+            }
+
+            // Rotation
+            CursorSurface {
+              id: rotationRow
+              width: parent.width
+              height: Style.space(22) + Style.spacing.xl
+              hasCursor: root.cursorActive && root.focusSection === "rotation"
+              foreground: root.bar.foreground
+              outline: true
+
+              Text {
+                text: "Rotation"
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.body
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(12)
+                anchors.verticalCenter: parent.verticalCenter
+              }
+
+              Dropdown {
+                id: rotationDropdown
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(12)
+                anchors.verticalCenter: parent.verticalCenter
+                width: Style.space(170)
+                showLabel: false
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                hasCursor: rotationRow.hasCursor
+                enabled: !!root.selectedDisplay
+                options: [
+                  { value: "0", label: "0°" },
+                  { value: "1", label: "90°" },
+                  { value: "2", label: "180°" },
+                  { value: "3", label: "270°" }
+                ]
+                value: root.selectedDisplay
+                  ? String(root.monitorValue(root.selectedIdentity, "transform", root.selectedDisplay.transform))
+                  : "0"
+                onChanged: function(transform) {
+                  if (!root.selectedDisplay) return
+                  root.setPendingField(root.selectedIdentity, "transform", parseInt(transform, 10))
+                  rotationDropdown.value = Qt.binding(function() {
+                    return root.selectedDisplay
+                      ? String(root.monitorValue(root.selectedIdentity, "transform", root.selectedDisplay.transform))
+                      : "0"
+                  })
+                }
+              }
+
+              HoverHandler {
+                onHoveredChanged: if (hovered) {
+                  root.cursorActive = true
+                  root.focusSection = "rotation"
+                  root.selectedIndex = -1
+                }
+              }
+            }
+          }
+
+          // ---------- Apply / Cancel (relabels to Keep / Revert mid-preview) ----------
+          PanelSeparator {
+            visible: root.dirty || root.previewActive
+            foreground: root.bar.foreground
+          }
+
+          Column {
+            visible: root.dirty || root.previewActive
+            width: parent.width
+            spacing: Style.space(8)
+
+            Text {
+              visible: root.statusText !== "" && !root.previewActive
+              width: parent.width
+              text: root.statusText
+              color: Color.accent
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.caption
+              wrapMode: Text.Wrap
+            }
+
+            Row {
+              width: parent.width
+              spacing: Style.spacing.sm
+
+              Button {
+                text: root.previewActive ? "Keep" : "Apply"
+                fontSize: Style.font.body
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                horizontalPadding: Style.spacing.md
+                verticalPadding: Style.spacing.controlPaddingY
+                bordered: true
+                hasCursor: root.cursorActive && root.focusSection === "actions" && root.selectedIndex === 0
+                onHovered: function(isHovered) {
+                  if (!isHovered) return
+                  root.cursorActive = true
+                  root.focusSection = "actions"
+                  root.selectedIndex = 0
+                }
+                onClicked: root.primaryAction()
+              }
+
+              Button {
+                text: root.previewActive ? ("Revert (" + root.previewRemaining + "s)") : "Cancel"
+                fontSize: Style.font.body
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                horizontalPadding: Style.spacing.md
+                verticalPadding: Style.spacing.controlPaddingY
+                bordered: true
+                hasCursor: root.cursorActive && root.focusSection === "actions" && root.selectedIndex === 1
+                onHovered: function(isHovered) {
+                  if (!isHovered) return
+                  root.cursorActive = true
+                  root.focusSection = "actions"
+                  root.selectedIndex = 1
+                }
+                onClicked: root.secondaryAction()
               }
             }
           }
@@ -827,103 +1329,6 @@ Panel {
           }
         }
       }
-    }
-  }
-
-  component ScalePill: Button {
-    id: pill
-    required property string scaleValue
-    required property int scaleIndex
-
-    text: root.effectiveScale(scaleValue) + "x"
-    fontSize: Style.font.caption
-    foreground: root.bar.foreground
-    fontFamily: root.bar.fontFamily
-    horizontalPadding: Style.spacing.sm
-    verticalPadding: Style.spacing.controlPaddingY
-    bordered: true
-
-    active: root.activeScaleIndex() === scaleIndex
-    hasCursor: root.cursorActive && root.focusSection === "scale" && root.selectedIndex === scaleIndex
-
-    onClicked: root.setScale(scaleValue)
-    onHovered: function(isHovered) {
-      if (!isHovered || root.reflowingText) return
-      root.cursorActive = true
-      root.focusSection = "scale"
-      root.selectedIndex = pill.scaleIndex
-    }
-  }
-
-  component MonitorRow: CursorSurface {
-    id: monitorRow
-    required property var display
-    required property int rowIndex
-
-    readonly property bool isFocused: display && display.focused
-    readonly property bool canToggle: display && (!display.enabled || root.enabledDisplayCount > 1)
-
-    hasCursor: root.cursorActive && root.focusSection === "monitors" && root.selectedIndex === rowIndex
-    onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(monitorRow)
-    current: isFocused
-    foreground: root.bar.foreground
-    fill: Style.hoverFillFor(root.bar.foreground, Color.accent)
-    currentFill: Style.selectedFillFor(root.bar.foreground, Color.accent)
-    implicitHeight: monitorInner.implicitHeight + Style.spacing.xl
-    opacity: canToggle ? 1.0 : 0.45
-
-    Row {
-      id: monitorInner
-      anchors.left: parent.left
-      anchors.right: parent.right
-      anchors.verticalCenter: parent.verticalCenter
-      anchors.leftMargin: Style.space(6)
-      anchors.rightMargin: Style.space(6)
-      spacing: Style.space(8)
-
-      Text {
-        text: "󰍹"
-        color: root.bar.foreground
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.title
-        width: Style.space(22)
-        horizontalAlignment: Text.AlignHCenter
-        anchors.verticalCenter: parent.verticalCenter
-      }
-
-      Text {
-        textFormat: Text.PlainText
-        text: monitorRow.display.name + (monitorRow.display.focused ? " · focused" : "")
-        color: root.bar.foreground
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.body
-        elide: Text.ElideRight
-        width: parent.width - Style.space(22) - Style.space(14) - Style.space(16)
-        anchors.verticalCenter: parent.verticalCenter
-      }
-
-      Text {
-        textFormat: Text.PlainText
-        text: monitorRow.display.enabled ? "󰄬" : ""
-        color: root.bar.foreground
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.subtitle
-        width: Style.space(14)
-        horizontalAlignment: Text.AlignRight
-        anchors.verticalCenter: parent.verticalCenter
-      }
-    }
-
-    MouseArea {
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: monitorRow.canToggle ? Qt.PointingHandCursor : Qt.ArrowCursor
-      onContainsMouseChanged: if (containsMouse && !root.reflowingText) {
-        root.cursorActive = true
-        root.focusSection = "monitors"
-        root.selectedIndex = monitorRow.rowIndex
-      }
-      onClicked: if (monitorRow.canToggle) root.toggleDisplay(monitorRow.display.name, monitorRow.display.enabled)
     }
   }
 }

--- a/test/shell.d/monitor-arrange-test.sh
+++ b/test/shell.d/monitor-arrange-test.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+test_bin=$(mktemp -d)
+fake_home=$(mktemp -d)
+hyprctl_log="$fake_home/hyprctl.log"
+hyprctl_result_file="$fake_home/hyprctl-result"
+
+cleanup() {
+  rm -rf "$test_bin" "$fake_home"
+}
+trap cleanup EXIT
+
+# The fake hyprctl records every `eval` argument it was given and answers
+# with whatever this test staged in $hyprctl_result_file, so each case can
+# drive both a successful and a rejected Hyprland response.
+cat >"$test_bin/hyprctl" <<'EOF'
+#!/bin/bash
+if [[ $1 == eval ]]; then
+  printf '%s\n' "$2" >>"$HYPRCTL_LOG"
+  cat "$HYPRCTL_RESULT_FILE"
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$test_bin"/*
+
+arrange() {
+  local command="$1" payload="$2"
+
+  printf '%s' "$payload" | HOME="$fake_home" \
+    XDG_STATE_HOME="$fake_home/state" \
+    OMARCHY_MONITORS_LUA="$fake_home/monitors.lua" \
+    HYPRCTL_LOG="$hyprctl_log" HYPRCTL_RESULT_FILE="$hyprctl_result_file" \
+    PATH="$test_bin:$PATH" \
+    bash "$ROOT/bin/omarchy-monitor-arrange" "$command"
+}
+
+two_monitor_layout='[
+  { "identity": "desc:LG Electronics LG ULTRAGEAR+ 510RMLM6U896", "mode": "3440x1440@59.97", "x": 0, "y": 0, "scale": 1.25, "transform": 0, "enabled": true },
+  { "identity": "eDP-1", "mode": "3000x2000@59.98", "x": 626, "y": 1152, "scale": 2, "transform": 0, "enabled": true }
+]'
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+result=$(arrange validate "$two_monitor_layout") || fail "validate accepts a well-formed layout" "$result"
+[[ $(jq -c '.' <<<"$result") == "$(jq -c '.' <<<"$two_monitor_layout")" ]] ||
+  fail "validate normalizes a well-formed layout unchanged" "$result"
+pass "validate accepts and normalizes a well-formed two-monitor layout"
+
+if arrange validate '{"identity": "eDP-1"}' >/dev/null 2>&1; then
+  fail "validate rejects a non-array payload"
+fi
+pass "validate rejects a non-array payload"
+
+if arrange validate '[{"mode": "1920x1080@60"}]' >/dev/null 2>&1; then
+  fail "validate rejects an entry missing identity"
+fi
+pass "validate rejects an entry missing identity"
+
+if arrange validate '[{"identity": "eDP-1", "mode": "not-a-mode"}]' >/dev/null 2>&1; then
+  fail "validate rejects a malformed mode string"
+fi
+pass "validate rejects a malformed mode string"
+
+if arrange validate '[{"identity": "eDP-1", "scale": 0}]' >/dev/null 2>&1; then
+  fail "validate rejects a zero scale"
+fi
+pass "validate rejects an out-of-range scale"
+
+if arrange validate '[{"identity": "eDP-1", "transform": 8}]' >/dev/null 2>&1; then
+  fail "validate rejects an out-of-range transform"
+fi
+pass "validate rejects an out-of-range transform"
+
+if arrange validate '[{"identity": "eDP-1", "enabled": false}]' >/dev/null 2>&1; then
+  fail "validate rejects a layout that disables every monitor"
+fi
+pass "validate rejects a layout that disables every monitor"
+
+if arrange validate '[{"identity": "dup"}, {"identity": "dup"}]' >/dev/null 2>&1; then
+  fail "validate rejects duplicate identities"
+fi
+pass "validate rejects duplicate identities"
+
+# ---------------------------------------------------------------------------
+# apply: transient, addressed by desc:, native Lua eval (not `keyword monitor`)
+# ---------------------------------------------------------------------------
+
+echo "ok" >"$hyprctl_result_file"
+: >"$hyprctl_log"
+result=$(arrange apply "$two_monitor_layout") || fail "apply succeeds when hyprctl answers ok" "$result"
+[[ $(jq -r '.success' <<<"$result") == "true" ]] || fail "apply reports success" "$result"
+
+eval_arg=$(cat "$hyprctl_log")
+[[ $eval_arg == *'hl.monitor('* ]] || fail "apply uses Lua eval" "$eval_arg"
+[[ $eval_arg != *'keyword monitor'* ]] || fail "apply must not fall back to keyword monitor" "$eval_arg"
+[[ $eval_arg == *'output = "desc:LG Electronics LG ULTRAGEAR+ 510RMLM6U896"'* ]] ||
+  fail "apply addresses the external monitor by description" "$eval_arg"
+[[ $eval_arg == *'output = "eDP-1"'* ]] || fail "apply addresses the laptop panel by connector name" "$eval_arg"
+[[ $eval_arg == *'position = "0x0"'* ]] || fail "apply carries explicit position" "$eval_arg"
+[[ $eval_arg == *'transform = 0'* ]] || fail "apply carries transform" "$eval_arg"
+pass "apply issues one hyprctl eval with hl.monitor(...) calls addressed by desc:/connector name"
+
+echo "ok" >"$hyprctl_result_file"
+: >"$hyprctl_log"
+disabling_layout='[
+  { "identity": "eDP-1", "mode": "preferred", "x": 0, "y": 0, "scale": 1, "transform": 0, "enabled": true },
+  { "identity": "DP-1", "mode": "preferred", "x": 1920, "y": 0, "scale": 1, "transform": 0, "enabled": false }
+]'
+result=$(arrange apply "$disabling_layout") || fail "apply succeeds with one disabled monitor" "$result"
+eval_arg=$(cat "$hyprctl_log")
+[[ $eval_arg == *'output = "DP-1"'*', disabled = true'* ]] ||
+  fail "apply sets disabled = true via hl.monitor, not a keyword disable" "$eval_arg"
+pass "apply uses the native disabled field for a turned-off monitor"
+
+echo 'monitor not found' >"$hyprctl_result_file"
+: >"$hyprctl_log"
+result=$(arrange apply "$two_monitor_layout") && fail "apply reports failure when hyprctl rejects the change"
+[[ $(jq -r '.success' <<<"$result") == "false" ]] || fail "apply reports success=false on hyprctl rejection" "$result"
+pass "apply surfaces a non-ok hyprctl response as a failed, non-zero result"
+
+result=$(arrange apply '[{"identity": "desc:has \" a quote", "enabled": true}]') && \
+  fail "apply refuses an identity that cannot be safely embedded in the Lua eval string"
+[[ $(jq -r '.success' <<<"$result") == "false" ]] || fail "apply's refusal is reported as success=false" "$result"
+pass "apply refuses a description containing a quote rather than embed it unescaped"
+
+# ---------------------------------------------------------------------------
+# persist: managed-block rewrite, live untouched
+# ---------------------------------------------------------------------------
+
+: >"$hyprctl_log"
+monitors_lua="$fake_home/monitors.lua"
+cat >"$monitors_lua" <<'LUA'
+-- See https://wiki.hypr.land/Configuring/Basics/Monitors/
+local omarchy_gdk_scale = 1
+local omarchy_monitor_scale = 1
+
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+LUA
+
+result=$(arrange persist "$two_monitor_layout") || fail "persist succeeds against a file with no managed block yet" "$result"
+[[ $(jq -r '.success' <<<"$result") == "true" ]] || fail "persist reports success" "$result"
+[[ -z $(cat "$hyprctl_log" 2>/dev/null) ]] || fail "persist must never call hyprctl" "$(cat "$hyprctl_log")"
+
+grep -qF 'hl.env("GDK_SCALE"' "$monitors_lua" ||
+  fail "persist leaves pre-existing content above the managed block untouched"
+grep -qF -- '-- omarchy-display-panel:managed:begin' "$monitors_lua" ||
+  fail "persist appends a managed block on first adoption"
+grep -qF 'output = "desc:LG Electronics LG ULTRAGEAR+ 510RMLM6U896"' "$monitors_lua" ||
+  fail "persist writes the arrangement into the managed block"
+backup=$(compgen -G "$fake_home/monitors.lua.bak.*" | head -n1)
+[[ -n $backup ]] || fail "persist backs up the previous file before rewriting"
+diff -q "$backup" <(cat <<'LUA'
+-- See https://wiki.hypr.land/Configuring/Basics/Monitors/
+local omarchy_gdk_scale = 1
+local omarchy_monitor_scale = 1
+
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+LUA
+) >/dev/null || fail "persist's backup matches the pre-rewrite file exactly"
+pass "persist adopts a hand-written monitors.lua by appending a managed block and backing up first"
+
+before_second_persist=$(cat "$monitors_lua")
+result=$(arrange persist "$two_monitor_layout") || fail "persist succeeds on a file that already has a managed block" "$result"
+occurrences=$(grep -c -F -- '-- omarchy-display-panel:managed:begin' "$monitors_lua")
+(( occurrences == 1 )) || fail "persist rewrites the existing managed block instead of appending a second one" "$occurrences"
+[[ $(cat "$monitors_lua") == "$before_second_persist" ]] ||
+  fail "persist is idempotent when re-applying the same layout"
+pass "persist rewrites its own managed block in place on subsequent calls, without duplicating it"
+
+single_monitor_layout='[{ "identity": "eDP-1", "mode": "preferred", "x": 0, "y": 0, "scale": 1, "transform": 3, "enabled": true }]'
+result=$(arrange persist "$single_monitor_layout") || fail "persist succeeds when reducing to one monitor" "$result"
+grep -qF 'LG ULTRAGEAR' "$monitors_lua" && fail "persist's managed block must fully replace, not merge with, the previous layout"
+grep -qF 'transform = 3' "$monitors_lua" || fail "persist reflects the new layout's transform"
+pass "persist fully replaces the managed block's contents on each call"

--- a/test/shell.d/monitor-state-test.sh
+++ b/test/shell.d/monitor-state-test.sh
@@ -52,13 +52,13 @@ assert_line() {
 assert_line_count() {
   local description="$1"
 
-  (( ${#state_lines[@]} == 8 )) ||
-    fail "$description" "expected 8 lines, got ${#state_lines[@]}"
+  (( ${#state_lines[@]} == 9 )) ||
+    fail "$description" "expected 9 lines, got ${#state_lines[@]}"
 }
 
 extended='[
-  { "name": "eDP-1", "mirrorOf": "none", "disabled": false, "focused": false, "width": 1920, "height": 1080 },
-  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440 }
+  { "name": "eDP-1", "description": "Panasonic Industry Company TDM13O56", "serial": "Panasonic Industry Company", "mirrorOf": "none", "disabled": false, "focused": false, "width": 1920, "height": 1080, "x": 0, "y": 0, "scale": 1, "transform": 0, "refreshRate": 60.00, "availableModes": ["1920x1080@60.00Hz"] },
+  { "name": "DP-1", "description": "LG Electronics LG ULTRAGEAR 101NTKF0A749", "serial": "LG Electronics", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "x": 1920, "y": 0, "scale": 1.25, "transform": 0, "refreshRate": 59.95, "availableModes": ["2560x1440@59.95Hz", "1920x1080@60.00Hz"] }
 ]'
 
 # Omarchy mirrors by pointing the external at the internal, so `mirrorOf` lands
@@ -115,3 +115,23 @@ monitor_state "$clamshell"
 [[ ${state_lines[7]-} == '[{"name":"eDP-1","enabled":false,"focused":false,"width":0,"height":0},{"name":"DP-1","enabled":true,"focused":true,"width":2560,"height":1440}]' ]] ||
   fail "monitor state lists every display for the panel" "actual: ${state_lines[7]-<missing>}"
 pass "monitor state lists every display with its enabled and focused state"
+
+# Line 9 (index 8) is additive: a richer per-display shape for the display
+# panel's arrangement UI, keyed by description/serial rather than connector
+# name so a DisplayLink reconnect that renumbers DVI-I-1/DVI-I-2 doesn't
+# invalidate identity. It must not disturb line 8 above, which existing
+# consumers already read by index.
+monitor_state "$extended"
+[[ ${state_lines[8]-} == '[{"name":"eDP-1","description":"Panasonic Industry Company TDM13O56","serial":"Panasonic Industry Company","enabled":true,"focused":false,"x":0,"y":0,"width":1920,"height":1080,"scale":1,"transform":0,"currentMode":"1920x1080@60.00","availableModes":["1920x1080@60.00Hz"]},{"name":"DP-1","description":"LG Electronics LG ULTRAGEAR 101NTKF0A749","serial":"LG Electronics","enabled":true,"focused":true,"x":1920,"y":0,"width":2560,"height":1440,"scale":1.25,"transform":0,"currentMode":"2560x1440@59.95","availableModes":["2560x1440@59.95Hz","1920x1080@60.00Hz"]}]' ]] ||
+  fail "monitor state lists extended per-display detail keyed by description" "actual: ${state_lines[8]-<missing>}"
+pass "monitor state's extended line carries description/serial identity and mode detail"
+
+# A monitor with no EDID description (rare virtual/headless outputs) still
+# answers with empty strings rather than dropping the field or erroring.
+no_description='[
+  { "name": "HEADLESS-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 1920, "height": 1080, "x": 0, "y": 0, "scale": 1, "transform": 0, "refreshRate": 60.00 }
+]'
+monitor_state "$no_description"
+[[ ${state_lines[8]-} == '[{"name":"HEADLESS-1","description":"","serial":"","enabled":true,"focused":true,"x":0,"y":0,"width":1920,"height":1080,"scale":1,"transform":0,"currentMode":"1920x1080@60.00","availableModes":[]}]' ]] ||
+  fail "monitor state falls back to empty identity fields without EDID" "actual: ${state_lines[8]-<missing>}"
+pass "monitor state tolerates a monitor with no description/serial/availableModes"

--- a/test/shell.d/monitor-test.sh
+++ b/test/shell.d/monitor-test.sh
@@ -75,4 +75,121 @@ assertDeepEqual(
 )
 
 assertDeepEqual(monitor.parseDisplays('{'), { displays: [], enabledDisplayCount: 0 }, 'monitor handles invalid display JSON')
+
+// ---------- Display-panel arrangement additions ----------
+
+assertDeepEqual(monitor.parseMode('3440x1440@59.97'), { width: 3440, height: 1440, refresh: 59.97, raw: '3440x1440@59.97' }, 'monitor parses a mode string')
+assertDeepEqual(monitor.parseMode('2560x1440@60Hz'), { width: 2560, height: 1440, refresh: 60, raw: '2560x1440@60Hz' }, 'monitor parses a mode string with an Hz suffix')
+assertDeepEqual(monitor.parseMode('preferred'), { width: 0, height: 0, refresh: 0, raw: 'preferred' }, 'monitor treats a non-numeric mode as unparsed')
+
+assertDeepEqual(monitor.rotateDimensions(1920, 1080, 0), { width: 1920, height: 1080 }, 'monitor keeps dimensions for transform 0')
+assertDeepEqual(monitor.rotateDimensions(1920, 1080, 1), { width: 1080, height: 1920 }, 'monitor swaps dimensions for a 90-degree transform')
+assertDeepEqual(monitor.rotateDimensions(1920, 1080, 2), { width: 1920, height: 1080 }, 'monitor keeps dimensions for a 180-degree transform')
+assertDeepEqual(monitor.rotateDimensions(1920, 1080, 3), { width: 1080, height: 1920 }, 'monitor swaps dimensions for a 270-degree transform')
+
+assertEqual(
+  monitor.monitorIdentity({ name: 'DVI-I-1', description: 'LG Electronics LG ULTRAGEAR 101NTKF0A749' }),
+  'desc:LG Electronics LG ULTRAGEAR 101NTKF0A749',
+  'monitor keys identity off description when one is available'
+)
+assertEqual(
+  monitor.monitorIdentity({ name: 'eDP-1', description: '' }),
+  'eDP-1',
+  'monitor falls back to connector name without a description'
+)
+
+const extended = monitor.parseExtendedDisplays(JSON.stringify([
+  {
+    name: 'DVI-I-1', description: 'LG Electronics LG ULTRAGEAR+ 510RMLM6U896', serial: 'LG Electronics',
+    enabled: true, focused: false, x: 0, y: 0, width: 3440, height: 1440, scale: 1.25, transform: 0,
+    currentMode: '3440x1440@59.97', availableModes: ['3440x1440@59.97', '2560x1080@59.97']
+  },
+  {
+    name: 'eDP-1', description: '', serial: '',
+    enabled: false, focused: true, x: 626, y: 1152, width: 3000, height: 2000, scale: 2, transform: 0,
+    currentMode: '3000x2000@59.98', availableModes: []
+  }
+]))
+assertEqual(extended.enabledDisplayCount, 1, 'monitor counts only enabled displays in the extended shape')
+assertEqual(extended.displays.length, 2, 'monitor parses every extended display entry')
+assertEqual(extended.displays[1].description, '', 'monitor tolerates a missing description in the extended shape')
+assertDeepEqual(monitor.parseExtendedDisplays('not json'), { displays: [], enabledDisplayCount: 0 }, 'monitor handles invalid extended display JSON')
+
+const twoMonitors = [
+  { name: 'DVI-I-1', description: 'LG Electronics LG ULTRAGEAR+ 510RMLM6U896', enabled: true, x: 0, y: 0, width: 3440, height: 1440, scale: 1.25, transform: 0 },
+  { name: 'eDP-1', description: '', enabled: true, x: 2752, y: 0, width: 3000, height: 2000, scale: 2, transform: 3 }
+]
+const bounds = monitor.arrangementBounds(twoMonitors)
+assertEqual(bounds.x, 0, 'monitor arrangement bounds start at the leftmost enabled monitor')
+assertEqual(Math.round(bounds.width), 3752, 'monitor arrangement bounds span every enabled monitor, rotation included')
+
+const boundsSkipsDisabled = monitor.arrangementBounds([
+  { name: 'DP-1', description: '', enabled: false, x: -5000, y: -5000, width: 1920, height: 1080, scale: 1, transform: 0 },
+  { name: 'eDP-1', description: '', enabled: true, x: 0, y: 0, width: 1920, height: 1080, scale: 1, transform: 0 }
+])
+assertEqual(boundsSkipsDisabled.x, 0, 'monitor arrangement bounds ignore disabled monitors')
+
+const scaled = monitor.scaleArrangement(twoMonitors, bounds, 200, 100, 4, 'eDP-1')
+assertEqual(scaled.length, 2, 'monitor scales every monitor into canvas tiles')
+assert(scaled[1].selected, 'monitor marks the selected tile by identity')
+assert(!scaled[0].selected, 'monitor leaves unselected tiles unmarked')
+assertEqual(scaled[0].identity, 'desc:LG Electronics LG ULTRAGEAR+ 510RMLM6U896', 'monitor tiles carry description-based identity')
+// Centered, not pinned to the corner: some positive margin on the leading edge
+// whenever the arrangement doesn't already fill the canvas.
+assert(scaled[0].x >= 0, 'monitor centers the arrangement horizontally rather than pinning it to the corner')
+
+const padded = monitor.paddedBounds({ x: 0, y: 10, width: 100, height: 50 }, 0.2)
+assertDeepEqual(padded, { x: -20, y: 0, width: 140, height: 70 }, 'monitor pads arrangement bounds without moving with a dragged tile')
+assertEqual(monitor.logicalFromCanvas(25, 0.5), 50, 'monitor converts canvas drag distance back to logical monitor coordinates')
+
+assertDeepEqual(monitor.compactModes(['a', 'b', 'a', 'c'], 'c', 6), ['c', 'a', 'b'], 'monitor de-duplicates modes and leads with the current one')
+assertDeepEqual(monitor.compactModes(['a', 'b', 'c', 'd'], '', 2), ['a', 'b'], 'monitor caps the compacted mode list to the limit')
+
+assertDeepEqual(
+  monitor.modeOptions(['3440x1440@59.97', '2560x1080@59.97'], '3440x1440@59.97', 6),
+  [
+    { label: '3440×1440 60Hz', value: '3440x1440@59.97' },
+    { label: '2560×1080 60Hz', value: '2560x1080@59.97' }
+  ],
+  'monitor formats mode options with rounded refresh rates'
+)
+
+const liveByIdentity = { 'eDP-1': { enabled: true, currentMode: '3000x2000@59.98', scale: 2, transform: 0, x: 626, y: 1152 } }
+assertDeepEqual(
+  monitor.diffPending(liveByIdentity, { 'eDP-1': { scale: 2 } }),
+  {},
+  'monitor drops a pending value that already matches live state'
+)
+assertDeepEqual(
+  monitor.diffPending(liveByIdentity, { 'eDP-1': { scale: 1.25, transform: 1 } }),
+  { 'eDP-1': { scale: 1.25, transform: 1 } },
+  'monitor keeps pending values that actually differ from live state'
+)
+assert(!monitor.isDirty({}), 'monitor reports clean with no pending diff')
+assert(monitor.isDirty({ 'eDP-1': { scale: 1.25 } }), 'monitor reports dirty with a pending diff')
+
+const liveDisplays = [
+  { name: 'DVI-I-1', description: 'LG Electronics LG ULTRAGEAR+ 510RMLM6U896', enabled: true, currentMode: '3440x1440@59.97', x: 0, y: 0, scale: 1.25, transform: 0 },
+  { name: 'eDP-1', description: '', enabled: true, currentMode: '3000x2000@59.98', x: 626, y: 1152, scale: 2, transform: 0 }
+]
+assertDeepEqual(
+  monitor.buildArrangeLayout(liveDisplays, {}),
+  [
+    { identity: 'desc:LG Electronics LG ULTRAGEAR+ 510RMLM6U896', mode: '3440x1440@59.97', x: 0, y: 0, scale: 1.25, transform: 0, enabled: true },
+    { identity: 'eDP-1', mode: '3000x2000@59.98', x: 626, y: 1152, scale: 2, transform: 0, enabled: true }
+  ],
+  'monitor builds an arrange layout matching live state with no pending edits'
+)
+assertDeepEqual(
+  monitor.buildArrangeLayout(liveDisplays, { 'eDP-1': { transform: 3, scale: 1.6 } }),
+  [
+    { identity: 'desc:LG Electronics LG ULTRAGEAR+ 510RMLM6U896', mode: '3440x1440@59.97', x: 0, y: 0, scale: 1.25, transform: 0, enabled: true },
+    { identity: 'eDP-1', mode: '3000x2000@59.98', x: 626, y: 1152, scale: 1.6, transform: 3, enabled: true }
+  ],
+  'monitor overlays pending edits onto the live layout by identity'
+)
+
+assertDeepEqual(monitor.parseArrangeResult('{"success":true,"message":"applied 2 monitor(s)"}'), { success: true, message: 'applied 2 monitor(s)' }, 'monitor parses a successful arrange result')
+assertDeepEqual(monitor.parseArrangeResult('not json'), { success: false, message: 'invalid backend response' }, 'monitor treats an unparsable arrange result as a failure')
+assertDeepEqual(monitor.parseArrangeResult(''), { success: false, message: '' }, 'monitor treats an empty arrange result as an unsuccessful, message-less result')
 JS


### PR DESCRIPTION
## Summary

- add a compact, centered multi-monitor arrangement canvas with drag positioning
- add equal-width resolution, scale, rotation, and enable controls for the selected display
- hide arrangement controls for single-display setups and keep Apply/Cancel pinned at the bottom
- preview layout changes for 12 seconds with Keep/Revert and automatic rollback
- address monitors by stable EDID description where available and persist a managed `monitors.lua` block with backup
- preserve the existing brightness and text-size controls

## Safety

- live changes use Hyprland 0.56 `hyprctl eval` with `hl.monitor(...)`, not the removed `keyword monitor` path
- layout JSON is validated before apply or persistence
- a layout that disables every display is rejected
- unsafe monitor identities and malformed managed blocks fail closed

## Testing

- `bash test/shell.d/monitor-test.sh` (56 assertions)
- `bash test/shell.d/monitor-state-test.sh`
- `bash test/shell.d/monitor-arrange-test.sh`
- `qmllint shell/plugins/panels/monitor/Panel.qml`
- `git diff --check`
- `./test/shell` was also run; it reached the existing `config-test.sh` environment prerequisite and reported the separate `omarchy-pkgs` checkout was not present (`OMARCHY_PKGS_PATH` unset).

Co-developed with Claude through Herdr; implementation and tests were reviewed and completed in the Omarchy contribution checkout.