### PR TITLE
Isolate /var/lib/docker on a top-level Btrfs subvolume

### DIFF
--- a/bin/omarchy-btrfs-isolate-docker
+++ b/bin/omarchy-btrfs-isolate-docker
@@ -1,0 +1,244 @@
+#!/bin/bash
+
+# omarchy:summary=Put /var/lib/docker on its own top-level Btrfs subvolume so root snapshots and rollbacks leave container data alone
+# omarchy:args=[--migrate]
+# omarchy:examples=omarchy btrfs isolate-docker | sudo omarchy-btrfs-isolate-docker --migrate
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+migrate=0
+while (($#)); do
+  case "$1" in
+  --migrate)
+    migrate=1
+    shift
+    ;;
+  -h | --help)
+    cat <<'EOF'
+Usage: omarchy-btrfs-isolate-docker [--migrate]
+
+Create a top-level @docker Btrfs subvolume, mount it at /var/lib/docker, and
+record it in /etc/fstab so Snapper snapshots of @ (and limine-snapper-restore
+rollbacks) no longer carry or revert Docker image layers and volumes.
+
+--migrate  stop Docker, move an existing /var/lib/docker tree into the new
+           subvolume, then start Docker again. Use on installs that already
+           wrote data into the root subvolume.
+EOF
+    exit 0
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    exit 1
+    ;;
+  esac
+done
+
+if ((EUID != 0)); then
+  echo "Error: omarchy-btrfs-isolate-docker must run as root" >&2
+  exit 1
+fi
+
+DOCKER_DIR=/var/lib/docker
+SUBVOL_NAME=@docker
+FSTAB=/etc/fstab
+
+root_is_omarchy_btrfs() {
+  [[ $(findmnt -no FSTYPE /) == btrfs ]] && findmnt -no OPTIONS / | grep -q 'subvol=/@\(,\|$\)'
+}
+
+docker_already_isolated() {
+  # Mounted from the dedicated subvolume, or the path is already that subvolume
+  # and listed in fstab (install-time create before first mount).
+  local source opts
+  source=$(findmnt -no SOURCE --target "$DOCKER_DIR" 2>/dev/null || true)
+  opts=$(findmnt -no OPTIONS --target "$DOCKER_DIR" 2>/dev/null || true)
+  if [[ -n $source && $opts == *subvol=/@docker* ]]; then
+    return 0
+  fi
+  if [[ -n $source && $opts == *subvol=@docker* ]]; then
+    return 0
+  fi
+  grep -Eq '^[^#].*[[:space:]]/var/lib/docker[[:space:]].*subvol=/@docker' "$FSTAB" 2>/dev/null
+}
+
+root_device() {
+  local source
+  source=$(findmnt -no SOURCE /)
+  # SOURCE may be /dev/nvme0n1p2[/@] — strip the subvol suffix.
+  source=${source%%\[*}
+  printf '%s\n' "$source"
+}
+
+root_uuid() {
+  findmnt -no UUID /
+}
+
+# Match compress/ssd flags from the root mount so @docker does not fight the
+# rest of the filesystem's mount options.
+docker_mount_options() {
+  local opts
+  opts=$(findmnt -no OPTIONS /)
+  # Drop subvol* and the snapper-related defaults we do not want on a data vol.
+  opts=$(printf '%s\n' "$opts" | tr ',' '\n' | grep -Ev '^(subvol|subvolid)=' | paste -sd, -)
+  if [[ -n $opts ]]; then
+    printf 'subvol=/@docker,%s\n' "$opts"
+  else
+    printf 'subvol=/@docker\n'
+  fi
+}
+
+ensure_fstab() {
+  local uuid options line
+  uuid=$(root_uuid)
+  [[ -n $uuid ]] || {
+    echo "Error: could not read UUID of /" >&2
+    exit 1
+  }
+  options=$(docker_mount_options)
+  line="UUID=$uuid $DOCKER_DIR btrfs $options 0 0"
+
+  if grep -Eq '^[^#].*[[:space:]]/var/lib/docker[[:space:]]' "$FSTAB"; then
+    return 0
+  fi
+
+  cp -a "$FSTAB" "$FSTAB.$(date +%Y%m%d%H%M%S).back"
+  printf '\n# Docker data — top-level subvolume so root Snapper rollbacks leave it alone\n%s\n' "$line" >>"$FSTAB"
+}
+
+create_top_level_subvolume() {
+  local device top
+  device=$(root_device)
+  [[ -n $device && -b $device ]] || {
+    echo "Error: could not determine the btrfs root device" >&2
+    exit 1
+  }
+
+  top=$(mktemp -d)
+  mount -o subvolid=5 "$device" "$top"
+  if [[ -d $top/$SUBVOL_NAME ]]; then
+    if btrfs subvolume show "$top/$SUBVOL_NAME" >/dev/null 2>&1; then
+      umount "$top"
+      rmdir "$top" 2>/dev/null || true
+      return 0
+    fi
+    umount "$top"
+    rmdir "$top" 2>/dev/null || true
+    echo "Error: $SUBVOL_NAME exists on the top level and is not a btrfs subvolume" >&2
+    exit 1
+  fi
+  btrfs subvolume create "$top/$SUBVOL_NAME" >/dev/null
+  umount "$top"
+  rmdir "$top" 2>/dev/null || true
+}
+
+path_is_empty() {
+  local dir=$1
+  [[ -d $dir ]] || return 0
+  [[ -z $(ls -A "$dir" 2>/dev/null) ]]
+}
+
+mount_docker_subvolume() {
+  local device options
+  mkdir -p "$DOCKER_DIR"
+  if findmnt -no TARGET --target "$DOCKER_DIR" 2>/dev/null | grep -qx "$DOCKER_DIR"; then
+    return 0
+  fi
+  # Prefer an explicit device+options mount: fstab UUID lookup needs udev
+  # by-uuid links that a chroot or early boot may not have yet. fstab still
+  # carries the UUID form for normal boots after install.
+  device=$(root_device)
+  options=$(docker_mount_options)
+  if ! mount -t btrfs -o "$options" "$device" "$DOCKER_DIR"; then
+    mount "$DOCKER_DIR"
+  fi
+}
+
+stop_docker() {
+  if command -v systemctl >/dev/null; then
+    systemctl stop docker.service docker.socket 2>/dev/null || true
+  fi
+}
+
+start_docker() {
+  if command -v systemctl >/dev/null; then
+    systemctl start docker.socket 2>/dev/null || true
+    systemctl start docker.service 2>/dev/null || true
+  fi
+}
+
+migrate_existing_tree() {
+  local staging
+  stop_docker
+
+  if findmnt -no TARGET --target "$DOCKER_DIR" 2>/dev/null | grep -qx "$DOCKER_DIR"; then
+    echo "Error: $DOCKER_DIR is already a mount point; unmount it before --migrate" >&2
+    exit 1
+  fi
+
+  if [[ -d $DOCKER_DIR ]] && ! path_is_empty "$DOCKER_DIR"; then
+    staging="${DOCKER_DIR}.omarchy-migrate-$$"
+    mv "$DOCKER_DIR" "$staging"
+  else
+    staging=""
+    rm -rf "$DOCKER_DIR"
+  fi
+
+  create_top_level_subvolume
+  ensure_fstab
+  mkdir -p "$DOCKER_DIR"
+  mount_docker_subvolume
+
+  if [[ -n $staging ]]; then
+    # Preserve ownership, xattrs, hardlinks; docker layer stores need them.
+    rsync -aHAX --info=stats2 "$staging"/ "$DOCKER_DIR"/
+    rm -rf "$staging"
+  fi
+
+  start_docker
+}
+
+install_fresh() {
+  if docker_already_isolated; then
+    echo "Docker data is already isolated on its own Btrfs subvolume"
+    return 0
+  fi
+
+  if [[ -d $DOCKER_DIR ]] && ! path_is_empty "$DOCKER_DIR"; then
+    echo "Error: $DOCKER_DIR is not empty. Re-run with --migrate to move existing data." >&2
+    exit 1
+  fi
+
+  # Drop an empty plain directory so the mount can take its place.
+  if [[ -d $DOCKER_DIR ]]; then
+    rmdir "$DOCKER_DIR"
+  fi
+
+  create_top_level_subvolume
+  ensure_fstab
+  mount_docker_subvolume
+  echo "Isolated $DOCKER_DIR on Btrfs subvolume $SUBVOL_NAME"
+}
+
+if ! root_is_omarchy_btrfs; then
+  echo "Skipping Docker Btrfs isolation (root is not the Omarchy @ subvolume layout)"
+  exit 0
+fi
+
+if ! command -v btrfs >/dev/null; then
+  echo "Error: btrfs-progs is required" >&2
+  exit 1
+fi
+
+if ((migrate)); then
+  if docker_already_isolated; then
+    echo "Docker data is already isolated on its own Btrfs subvolume"
+    exit 0
+  fi
+  migrate_existing_tree
+  echo "Migrated $DOCKER_DIR onto Btrfs subvolume $SUBVOL_NAME"
+  exit 0
+fi
+
+install_fresh

--- a/bin/omarchy-system-factory-reset-finish
+++ b/bin/omarchy-system-factory-reset-finish
@@ -6,8 +6,9 @@
 
 # Runs once, early on the first boot after omarchy-system-factory-reset, via
 # omarchy-system-factory-reset-finish.service (armed by /var/lib/omarchy/provisioning/wipe-pending).
-# Ordered before home.mount/var-log.mount so @home and @log can be dropped and
-# recreated as empty subvolumes instead of rm -rf'd file by file.
+# Ordered before home.mount/var-log.mount/var-lib-docker.mount so @home, @log,
+# and @docker can be dropped and recreated as empty subvolumes instead of
+# rm -rf'd file by file.
 #
 # The root is already a fresh clone of @factory (staged by
 # omarchy-system-factory-reset); this deletes the previous root (@omarchy-old-*),
@@ -149,6 +150,12 @@ main() {
   log "recreating @home and @log"
   recreate_subvolume @home || abort "could not recreate @home"
   recreate_subvolume @log || abort "could not recreate @log"
+  # @docker is a top-level data subvolume (install/config/docker.sh). A wipe that
+  # leaves the seller's container layers and volumes behind is incomplete.
+  if [[ -d $TOP_MNT/@docker ]] || grep -Eq '^[^#].*[[:space:]]/var/lib/docker[[:space:]]' /etc/fstab 2>/dev/null; then
+    log "recreating @docker"
+    recreate_subvolume @docker || abort "could not recreate @docker"
+  fi
 
   repair_snapshots_dir
 

--- a/install/config/docker.sh
+++ b/install/config/docker.sh
@@ -11,6 +11,13 @@
 #
 #   omarchy-setup-security-sudoless-docker   (Setup > Security > Sudoless Docker)
 #
-# Nothing to do here now that the group is no longer granted, but the file stays
-# as the recorded home of this decision and a hook for future daemon config.
-:
+# Docker packages land via omarchy-base.packages before this runs; the socket is
+# enabled later in enable-services.sh. Carve /var/lib/docker out of the root
+# Snapper subvolume first so the first daemon start never writes layers into @.
+# See bin/omarchy-btrfs-isolate-docker and issue #8953.
+
+if [[ -x ${OMARCHY_PATH:-/usr/share/omarchy}/bin/omarchy-btrfs-isolate-docker ]]; then
+  "$OMARCHY_PATH/bin/omarchy-btrfs-isolate-docker" || true
+elif command -v omarchy-btrfs-isolate-docker >/dev/null; then
+  omarchy-btrfs-isolate-docker || true
+fi

--- a/install/provisioning/omarchy-system-factory-reset-finish.service
+++ b/install/provisioning/omarchy-system-factory-reset-finish.service
@@ -1,15 +1,15 @@
 # Finishes an omarchy-system-factory-reset reset on the first boot after it: drops
 # the previous root, recreates @home/@log, and scrubs state. Ordered before
-# home.mount/var-log.mount so those subvolumes can be deleted and recreated
-# while unmounted. Armed by /var/lib/omarchy/provisioning/wipe-pending; installed to
-# /etc/systemd/system by omarchy-system-factory-reset.
+# home.mount/var-log.mount/var-lib-docker.mount so those subvolumes can be
+# deleted and recreated while unmounted. Armed by /var/lib/omarchy/provisioning/wipe-pending;
+# installed to /etc/systemd/system by omarchy-system-factory-reset.
 
 [Unit]
 Description=Omarchy factory reset wipe
 DefaultDependencies=no
 ConditionPathExists=/var/lib/omarchy/provisioning/wipe-pending
 After=systemd-remount-fs.service
-Before=sysinit.target home.mount var-log.mount var-cache-pacman-pkg.mount shutdown.target
+Before=sysinit.target home.mount var-log.mount var-cache-pacman-pkg.mount var-lib-docker.mount shutdown.target
 Conflicts=shutdown.target
 
 [Service]

--- a/manual/47-system-snapshots.md
+++ b/manual/47-system-snapshots.md
@@ -14,6 +14,8 @@ When you arrive inside, a notification will popup notifying you that you're in a
 
 This will restore your root filesystem, but not your `/home`. So it works for reverting a broken system update, but not for recovering lost personal files.
 
+Btrfs snapshots do not recurse into nested or sibling subvolumes. Omarchy already keeps `/home`, `/var/log`, and the pacman package cache on their own subvolumes for that reason. `/var/lib/docker` is the same: image layers and named volumes live on a top-level `@docker` subvolume so a root rollback after a bad package update does not silently rewind or wipe container data. Existing installs that still keep Docker inside `@` can move it with `sudo omarchy-btrfs-isolate-docker --migrate`.
+
 This also means that your `~/.config` directory is kept as-is. So if you're rolling back to an earlier version of a library or application that stores configuration files in a new format, you'll have to sort that out manually.
 
 _Note: This feature is only available on installations using the Limine boot loader, which has been the default since Omarchy 2.0. It's not available if you're on GRUB or systemd-boot._

--- a/migrations/1788028303.sh
+++ b/migrations/1788028303.sh
@@ -1,0 +1,34 @@
+echo "Isolate /var/lib/docker on its own Btrfs subvolume so root Snapper rollbacks leave container data alone"
+
+# Machine-wide: one apply per install. The helper is idempotent if another user
+# already ran it, but the marker keeps every user's migration state aligned with
+# the rest of omarchy-migrate.
+machine_marker="${OMARCHY_DOCKER_SUBVOL_MIGRATION_MARKER:-/var/lib/omarchy/migrations/1788028303}"
+
+[[ ! -e $machine_marker ]] || exit 0
+
+if [[ $(findmnt -no FSTYPE / 2>/dev/null) != btrfs ]]; then
+  sudo mkdir -p "$(dirname "$machine_marker")"
+  sudo touch "$machine_marker"
+  exit 0
+fi
+
+# Only the stock Omarchy layout (root mounted as subvol=@) gets the isolation.
+# Other layouts are left alone rather than inventing a mount scheme for them.
+if ! findmnt -no OPTIONS / | grep -q 'subvol=/@\(,\|$\)'; then
+  sudo mkdir -p "$(dirname "$machine_marker")"
+  sudo touch "$machine_marker"
+  exit 0
+fi
+
+if omarchy-cmd-missing omarchy-btrfs-isolate-docker; then
+  echo "omarchy-btrfs-isolate-docker is not available yet; skip until the next update ships it" >&2
+  exit 0
+fi
+
+# --migrate moves an existing tree (typical after docker has already run). Fresh
+# installs that never started docker take the empty path inside the helper.
+sudo omarchy-btrfs-isolate-docker --migrate
+
+sudo mkdir -p "$(dirname "$machine_marker")"
+sudo touch "$machine_marker"

--- a/test/shell.d/btrfs-isolate-docker-test.sh
+++ b/test/shell.d/btrfs-isolate-docker-test.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+helper="$ROOT/bin/omarchy-btrfs-isolate-docker"
+migration="$ROOT/migrations/1788028303.sh"
+docker_install="$ROOT/install/config/docker.sh"
+factory_finish="$ROOT/bin/omarchy-system-factory-reset-finish"
+factory_unit="$ROOT/install/provisioning/omarchy-system-factory-reset-finish.service"
+
+[[ -x $helper ]] || fail "omarchy-btrfs-isolate-docker is executable"
+pass "omarchy-btrfs-isolate-docker is executable"
+
+grep -q 'subvol=/@docker' "$helper" || fail "helper mounts the top-level @docker subvolume"
+grep -q 'subvolid=5' "$helper" || fail "helper creates @docker on the btrfs top level"
+grep -q -- '--migrate' "$helper" || fail "helper supports migrating an existing docker tree"
+grep -q 'root_is_omarchy_btrfs' "$helper" || fail "helper gates on the Omarchy @ root layout"
+pass "helper creates and mounts a top-level @docker subvolume"
+
+# Nested-under-@ would be orphaned when limine-snapper-restore renames @; the
+# helper must not use that pattern.
+if grep -qE 'btrfs subvolume create .*/var/lib/docker' "$helper"; then
+  fail "helper must not nest docker under @ (orphaned on root rename/rollback)"
+fi
+pass "helper does not nest docker under the root subvolume"
+
+grep -F 'omarchy-btrfs-isolate-docker' "$docker_install" >/dev/null ||
+  fail "install/config/docker.sh invokes the isolation helper before docker starts"
+pass "install/config/docker.sh invokes the isolation helper"
+
+grep -F 'omarchy-btrfs-isolate-docker --migrate' "$migration" >/dev/null ||
+  fail "migration migrates existing docker data onto @docker"
+grep -F 'OMARCHY_DOCKER_SUBVOL_MIGRATION_MARKER' "$migration" >/dev/null ||
+  fail "migration records a machine-wide completion marker"
+pass "migration migrates existing installs idempotently"
+
+grep -F 'var-lib-docker.mount' "$factory_unit" >/dev/null ||
+  fail "factory-reset finish waits for var-lib-docker.mount"
+grep -F '@docker' "$factory_finish" >/dev/null ||
+  fail "factory-reset finish recreates @docker"
+pass "factory reset wipes @docker with the rest of the machine"
+
+grep -F '@docker' "$ROOT/manual/47-system-snapshots.md" >/dev/null ||
+  fail "snapshot manual documents docker isolation"
+grep -F 'omarchy-btrfs-isolate-docker --migrate' "$ROOT/manual/47-system-snapshots.md" >/dev/null ||
+  fail "snapshot manual points existing installs at the migrate command"
+pass "snapshot manual documents docker isolation"
+
+# Migration on a non-btrfs host: mark complete, do not invoke the helper.
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+cat >"$test_tmp/bin/findmnt" <<'STUB'
+#!/bin/bash
+if [[ $* == *FSTYPE* ]]; then
+  printf 'ext4\n'
+  exit 0
+fi
+exit 1
+STUB
+cat >"$test_tmp/bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+chmod +x "$test_tmp/bin"/*
+
+marker="$test_tmp/marker"
+PATH="$test_tmp/bin:/usr/bin:/bin" \
+  OMARCHY_DOCKER_SUBVOL_MIGRATION_MARKER="$marker" \
+  bash "$migration"
+[[ -f $marker ]] || fail "migration marks non-btrfs installs complete without isolating"
+pass "migration marks non-btrfs installs complete without isolating"
+
+# Already-marked migration is a no-op even on btrfs.
+cat >"$test_tmp/bin/findmnt" <<'STUB'
+#!/bin/bash
+if [[ $* == *FSTYPE* ]]; then
+  printf 'btrfs\n'
+  exit 0
+fi
+if [[ $* == *OPTIONS* ]]; then
+  printf 'rw,relatime,subvol=/@\n'
+  exit 0
+fi
+exit 1
+STUB
+cat >"$test_tmp/bin/omarchy-btrfs-isolate-docker" <<'STUB'
+#!/bin/bash
+echo "helper-ran" >>"${HELPER_LOG:?}"
+STUB
+chmod +x "$test_tmp/bin/omarchy-btrfs-isolate-docker" "$test_tmp/bin/findmnt"
+helper_log="$test_tmp/helper-log"
+PATH="$test_tmp/bin:/usr/bin:/bin" \
+  OMARCHY_DOCKER_SUBVOL_MIGRATION_MARKER="$marker" \
+  HELPER_LOG="$helper_log" \
+  bash "$migration"
+[[ ! -f $helper_log ]] || fail "migration must not re-run after the machine marker exists"
+pass "migration is a no-op once the machine marker exists"
+
+# First run on an Omarchy btrfs root invokes --migrate.
+rm -f "$marker" "$helper_log"
+cat >"$test_tmp/bin/omarchy-cmd-missing" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+chmod +x "$test_tmp/bin/omarchy-cmd-missing"
+PATH="$test_tmp/bin:/usr/bin:/bin" \
+  OMARCHY_DOCKER_SUBVOL_MIGRATION_MARKER="$marker" \
+  HELPER_LOG="$helper_log" \
+  bash "$migration"
+[[ -f $helper_log ]] || fail "migration runs the helper on an Omarchy btrfs root"
+grep -q helper-ran "$helper_log" || fail "migration ran the isolation helper"
+[[ -f $marker ]] || fail "migration writes the machine marker after success"
+pass "migration runs the helper once on an Omarchy btrfs root"
+
+# Helper refuses non-root (skip when the suite itself is already root).
+if ((EUID != 0)); then
+  if "$helper" >/dev/null 2>&1; then
+    fail "helper must refuse to run as a non-root user"
+  fi
+  pass "helper refuses to run as a non-root user"
+else
+  pass "helper refuses to run as a non-root user (skipped under root)"
+fi


### PR DESCRIPTION
## Problem

Omarchy's default Btrfs layout keeps `/var/lib/docker` inside the `@` root subvolume. Snapper snapshots of `@` therefore include Docker image layers and volumes, and `limine-snapper-restore` rollbacks silently revert container state along with the package update the user meant to undo. CoW churn from layers also bloats retained snapshots.

Reproduced on a GCE VM with an Omarchy-like `@` / `@home` / `@log` / `@pkg` layout: after writing Docker volume data, snapshotting `@`, mutating data, and rolling `@` back, both root **and** Docker volume contents reverted.

## Fix

- New `omarchy-btrfs-isolate-docker` creates a **top-level** `@docker` subvolume (sibling of `@home`/`@log`/`@pkg`), mounts it at `/var/lib/docker`, and records a UUID fstab entry. Nested-under-`@` was rejected: rename-style root rollback orphans nested subvolumes under the old `@`.
- `install/config/docker.sh` runs the helper before `docker.socket` is enabled so the first daemon start never writes into `@`.
- Migration `1788028303.sh` runs `omarchy-btrfs-isolate-docker --migrate` on existing Omarchy Btrfs installs (machine marker, idempotent).
- Factory reset recreates `@docker` and orders before `var-lib-docker.mount`.
- Manual note in `47-system-snapshots.md`.

## Verification

GCE Debian 12 + 10G Btrfs disk, chroot of `@` layout:

| step | result |
| --- | --- |
| Bug (docker plain dir in `@`) | rollback restored `IMPORTANT-DB-DATA-v1` with root |
| After `--migrate` | mount `subvol=/@docker`, data preserved |
| Snapshot of `@` | docker volume file **absent** from snapshot |
| Rollback `@` after docker write v2 | root → v1, docker → **v2** (`FIX_VERIFIED`) |
| `bash test/shell.d/btrfs-isolate-docker-test.sh` | 12 ok |

## Notes

- Helper no-ops when root is not `subvol=/@`.
- `--migrate` stops docker, rsyncs existing tree, restarts socket/service.

Fixes #8953