### PR TITLE
Highlight each monitor's own active workspace in the bar

### DIFF
--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import Quickshell
 import Quickshell.Hyprland
 import qs.Commons
 import qs.Ui
@@ -7,6 +8,18 @@ import qs.Ui
 BarWidget {
   id: root
   moduleName: "omarchy.workspaces"
+
+  // A bar surface exists per monitor, so highlight the workspace active on
+  // this widget's own monitor rather than Hyprland.focusedWorkspace, which
+  // would mark the same workspace on every screen. Falls back to the focused
+  // workspace until the window has a screen Hyprland knows about.
+  readonly property var barWindow: root.QsWindow ? root.QsWindow.window : null
+  readonly property var barMonitor: barWindow && barWindow.screen ? Hyprland.monitorFor(barWindow.screen) : null
+  readonly property int activeWorkspaceId: {
+    if (barMonitor && barMonitor.activeWorkspace) return barMonitor.activeWorkspace.id
+    if (Hyprland.focusedWorkspace) return Hyprland.focusedWorkspace.id
+    return 0
+  }
 
   function workspaceById(id) {
     var values = Hyprland.workspaces.values
@@ -56,7 +69,7 @@ BarWidget {
 
         readonly property var workspace: root.workspaceById(modelData)
         readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
-        readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
+        readonly property bool focused: root.activeWorkspaceId === modelData
 
         bar: root.bar
         text: focused ? "\uDB85\uDCFB" : (modelData === 10 ? "0" : String(modelData))


### PR DESCRIPTION
Fixes #8183
Fixes #8364

## Problem

`omarchy.workspaces` highlights `Hyprland.focusedWorkspace`, and the bar runs one surface per monitor. With two or more monitors every bar therefore marks the same workspace — the globally focused one — so the bar on the non-focused monitor points at a workspace that isn't on that screen, and the workspace that *is* showing there sits dimmed as if it were empty.

Top bar is the laptop panel on workspace 1, bottom bar is a second monitor on workspace 5. Both mark 1:

![before](https://raw.githubusercontent.com/mikebenner/omarchy/assets/pr-8997/workspaces-before.png)

## Fix

Resolve the widget's own monitor through its bar window's screen (`QsWindow.window.screen` → `Hyprland.monitorFor`, the same idiom `Bar.slotWindow` and the tray use) and highlight that monitor's `activeWorkspace`. Falls back to `Hyprland.focusedWorkspace` until the window has a screen Hyprland knows about, so single-monitor behaviour and startup are unchanged.

Only the `focused` binding changes; occupancy dimming, the 1–5 baseline, glyphs and click-to-focus are untouched.

Same two monitors with this change — each bar marks its own workspace:

![after](https://raw.githubusercontent.com/mikebenner/omarchy/assets/pr-8997/after.png)

## Verification

- Reproduced and captured on a real second output without extra hardware: `hyprctl output create headless` gives the shell a second bar surface, `grim -o HEADLESS-1` captures it, `hyprctl output remove HEADLESS-1` tears it down.
- Loaded the changed file into the running shell: no QML warnings.
- `./test/all` — the same 4 pre-existing `test/shell` failures as on `quattro` (`config`, `snapper`, `theme-install-guards`, `unowned-system-paths`, all wanting an `omarchy-pkgs` checkout); nothing new.
- I've run this change as a cloned widget on a multi-monitor setup since 2026-08-27.

Still present in Omarchy 4.0.2-1 (2026-08-31). Local workaround is `omarchy plugin clone omarchy.workspaces` plus this same `focused` binding.