### PR TITLE
Fix clipped left border on Display scale 1x pill

### DIFF
--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -765,26 +765,32 @@ Panel {
               }
             }
 
-            Grid {
-              id: scaleRow
+            Item {
               width: parent.width
-              columns: root.scaleValues.length
-              spacing: Style.spacing.xs
+              height: scaleRow.implicitHeight
 
-              readonly property real cellWidth: root.scaleValues.length > 0
-                ? (width - spacing * (columns - 1)) / columns
-                : 0
+              Grid {
+                id: scaleRow
+                width: parent.width - 2 * Style.spacing.xxs
+                x: Style.spacing.xxs
+                columns: root.scaleValues.length
+                spacing: Style.spacing.xs
 
-              Repeater {
-                model: root.scaleValues
+                readonly property real cellWidth: root.scaleValues.length > 0
+                  ? (width - spacing * (columns - 1)) / columns
+                  : 0
 
-                ScalePill {
-                  required property string modelData
-                  required property int index
+                Repeater {
+                  model: root.scaleValues
 
-                  scaleValue: modelData
-                  scaleIndex: index
-                  width: scaleRow.cellWidth
+                  ScalePill {
+                    required property string modelData
+                    required property int index
+
+                    scaleValue: modelData
+                    scaleIndex: index
+                    width: scaleRow.cellWidth
+                  }
                 }
               }
             }


### PR DESCRIPTION
The Display panel's scale row sits flush against a `ScrollView { clip: true }`. The **1x** pill is a bordered button at `x = 0`, so its left stroke lands on the clip edge and gets eaten. This is most obvious at 1.25× compositor scale with a larger text size (14px), where cell widths go fractional and antialiasing drops the 1px, 40%-alpha border.

A `Column` resets every child's `x` on layout, so `x: Style.spacing.hairline` on the `Grid` itself is discarded. Wrapping the row in an `Item` (which the `Column` is allowed to position) and insetting by `Style.spacing.xxs` (2px) keeps the stroke inside the clip. 1px (`hairline`) is not enough at 1.25×.

## Testing

- `omarchy dev link` against this branch, reboot, `omarchy plugin disable` of any `*.monitor` clone so stock `omarchy.monitor` is on the bar, then `omarchy restart shell`.
- Open Display on a 2560×1600 panel at 1.25× scale and 14px text size. **1x** has a full left border; **4x** still does. Alignment with the SCALE label is unchanged to the eye.
- No new automated coverage; this is layout-only QML. Visual check only.

## Screenshots

- Before: **1x** missing its left border
<img width="581" height="545" alt="image" src="https://github.com/user-attachments/assets/54fa432f-4950-41f1-885e-26474420b340" />

- After: **1x** fully boxed
<img width="586" height="538" alt="image" src="https://github.com/user-attachments/assets/c7a89da8-8903-47b6-a477-a4bddf4e798f" />

