### PR TITLE
fix: wrap WlSessionLockSurface in Component for per-screen instantiation

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -227,10 +227,41 @@ Item {
     }
   }
 
+  // Quickshell instantiates `surface` once per output when locked becomes true.
+  // Keep the definition as an explicit Component so each screen gets its own
+  // WlSessionLockSurface / LockView tree. A single live surface instance reused
+  // across outputs triggers Qt's "Cannot use same item on different windows"
+  // path and SIGSEGV on multi-monitor idle lock (issue #8973).
+  Component {
+    id: lockSurfaceComponent
+
+    WlSessionLockSurface {
+      color: Color.background
+
+      LockView {
+        anchors.fill: parent
+        backgroundPath: root.backgroundPath
+        backgroundVersion: root.backgroundVersion
+        fingerprintConfigured: root.fingerprintConfigured
+        authenticatingPassword: root.authenticatingPassword
+        failureMessage: root.failureMessage
+        failedAttempts: root.failedAttempts
+        inputEnabled: root.lockRequested
+        loadBackground: root.locked
+        passwordText: root.enteredPassword
+        onPasswordTextEdited: function(password) { root.enteredPassword = password }
+        onSubmitPassword: function(password) { root.submitPassword(password) }
+        onClearFailureRequested: root.failureMessage = ""
+        onWakeRequested: root.runWake()
+      }
+    }
+  }
+
   WlSessionLock {
     id: sessionLock
 
     locked: false
+    surface: lockSurfaceComponent
 
     onSecureStateChanged: {
       root.logEvent("secure=" + secure)
@@ -259,30 +290,6 @@ Item {
         root.resetAuthenticationState()
         root.runWake()
       }
-    }
-
-    WlSessionLockSurface {
-      id: lockSurface
-      color: Color.background
-
-      LockView {
-        id: lockView
-        anchors.fill: parent
-        backgroundPath: root.backgroundPath
-        backgroundVersion: root.backgroundVersion
-        fingerprintConfigured: root.fingerprintConfigured
-        authenticatingPassword: root.authenticatingPassword
-        failureMessage: root.failureMessage
-        failedAttempts: root.failedAttempts
-        inputEnabled: root.lockRequested
-        loadBackground: root.locked
-        passwordText: root.enteredPassword
-        onPasswordTextEdited: function(password) { root.enteredPassword = password }
-        onSubmitPassword: function(password) { root.submitPassword(password) }
-        onClearFailureRequested: root.failureMessage = ""
-        onWakeRequested: root.runWake()
-      }
-
     }
   }
 

--- a/test/shell.d/lock-surface-per-screen-test.sh
+++ b/test/shell.d/lock-surface-per-screen-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+// Quickshell creates one WlSessionLockSurface per output from the lock's
+// `surface` Component. A single live surface instance shared across monitors
+// reparents the same QQuickItem tree onto every lock window and crashes Qt
+// ("Cannot use same item on different windows") on multi-monitor idle lock.
+assert(
+  /Component\s*\{\s*id:\s*lockSurfaceComponent[\s\S]*WlSessionLockSurface\s*\{/.test(serviceQml),
+  'the lock surface is defined as a Component so each output gets its own tree'
+)
+
+assert(
+  /WlSessionLock\s*\{[\s\S]*surface:\s*lockSurfaceComponent/.test(serviceQml),
+  'WlSessionLock uses the per-screen surface Component'
+)
+
+// A nested live surface (not wrapped in Component) is the failing pattern.
+assert(
+  !/WlSessionLock\s*\{[\s\S]*?WlSessionLockSurface\s*\{[\s\S]*?id:\s*lockSurface/.test(serviceQml),
+  'WlSessionLock does not keep a single live lockSurface instance as a child'
+)
+
+// Each surface still hosts a LockView bound to the shared lock state so
+// password entry mirrors across screens without sharing QQuickItems.
+assert(
+  /id:\s*lockSurfaceComponent[\s\S]*LockView\s*\{[\s\S]*passwordText:\s*root\.enteredPassword/.test(serviceQml),
+  'each surface LockView still mirrors password entry through enteredPassword'
+)
+
+assert(
+  /id:\s*lockSurfaceComponent[\s\S]*onPasswordTextEdited:/.test(serviceQml),
+  'each surface LockView still writes password edits back to the lock service'
+)
+JS


### PR DESCRIPTION
Fixes #8973

Quickshell instantiates the lock surface once per output when locked becomes true. Previously, WlSessionLockSurface was a direct child of WlSessionLock, causing Qt to reparent the same QQuickItem across multiple lock-screen windows.

This triggers Qt's SIGSEGV path: "Cannot use same item on different windows" on multi-monitor idle lock.

The fix wraps the surface definition in an explicit Component, ensuring each monitor gets its own independently instantiated WlSessionLockSurface/LockView tree while preserving password entry synchronization through the shared service state.