### PR TITLE
Fix sunshine service enable/disable using nonexistent alias unit name

### DIFF
--- a/bin/omarchy-install-service-sunshine
+++ b/bin/omarchy-install-service-sunshine
@@ -71,7 +71,13 @@ enable_hyprland_autostart() {
 
 echo "Installing Sunshine..."
 omarchy-pkg-add sunshine
-systemctl --user enable --now sunshine
+# The sunshine package ships its unit as app-dev.lizardbyte.app.Sunshine.service.
+# It declares Alias=sunshine.service, but systemd only honors that alias once the
+# unit has been enabled by its real name at least once, so "enable --now sunshine"
+# fails cold ("Unit sunshine.service does not exist") and — combined with `set -e`
+# above — silently skips every step after it (firewall rules, admin webapp,
+# Hyprland autostart).
+systemctl --user enable --now app-dev.lizardbyte.app.Sunshine.service
 
 echo "Opening Sunshine firewall ports..."
 open_ufw_ports

--- a/bin/omarchy-remove-service-sunshine
+++ b/bin/omarchy-remove-service-sunshine
@@ -59,7 +59,7 @@ disable_hyprland_autostart() {
   fi
 }
 
-systemctl --user disable --now sunshine 2>/dev/null || true
+systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service 2>/dev/null || true
 omarchy-pkg-drop sunshine
 omarchy-webapp-remove "$SUNSHINE_ADMIN_APP" 2>/dev/null || true
 disable_hyprland_autostart


### PR DESCRIPTION
## The bug

`omarchy-install-service-sunshine` runs:

```bash
systemctl --user enable --now sunshine
```

But the `sunshine` package installs its systemd user unit as `app-dev.lizardbyte.app.Sunshine.service`, not `sunshine.service`. The unit declares `Alias=sunshine.service` in `[Install]`, but systemd only resolves an alias once the unit has already been enabled by its real name at least once — you can't cold-enable a unit purely by an alias it hasn't been given yet.

So on a fresh install, that line fails:

```
Failed to enable unit: Unit sunshine.service does not exist
```

Because the script has `set -e`, this abort happens *silently* and skips everything after it:
- the Moonlight firewall ports (`open_ufw_ports`) never get opened
- the Sunshine Admin web app never gets installed
- the Hyprland autostart entry never gets added

Net effect: running the installer leaves Sunshine installed but **not** enabled to start on boot, and none of the rest of the setup (firewall, admin webapp, autostart) applied — with no visible error, since the script just stops.

## Verification

Reproduced on a machine running `sunshine 2026.516.143833-4`:

```
$ systemctl --user enable --now sunshine
Failed to enable unit: Unit sunshine.service does not exist

$ systemctl --user enable --now app-dev.lizardbyte.app.Sunshine.service
Created symlink '.../sunshine.service' → '.../app-dev.lizardbyte.app.Sunshine.service'.
Created symlink '.../graphical-session.target.wants/app-dev.lizardbyte.app.Sunshine.service' → ...
```

Enabling by the real unit name succeeds, and afterward the `sunshine.service` alias resolves correctly too (confirmed with `systemctl --user status sunshine`).

## The fix

Use the real unit name in both the install and remove scripts, so the whole install flow (firewall, admin webapp, autostart) actually runs, and the service is genuinely enabled.