### PR TITLE
FIX: Deterministic false failures in the shell smoke test

### DIFF
--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -51,10 +51,17 @@ ln -s "$ROOT/config" "$test_root/config"
 ln -s "$ROOT/bin" "$test_root/bin"
 
 # Every plugin under ~/.config/omarchy/plugins hot-reloads, whoever wrote it.
+# Built in a staging directory and moved into place as a single rename so the
+# plugin watcher sees one atomic directory creation instead of a mkdir plus
+# two separate file writes — the multi-step version fires onLocalPluginChanged
+# more than once right after startup, each triggering its own full
+# reloadPlugins() pass and inflating the IPC-handler-collision count below
+# with duplicates unrelated to the number of screens.
 hot_reload_id="acme.hot-reload"
+hot_reload_staging="$TMPDIR/.hot-reload-staging"
 hot_reload_dir="$test_home/.config/omarchy/plugins/$hot_reload_id"
-mkdir -p "$hot_reload_dir"
-cat >"$hot_reload_dir/manifest.json" <<JSON
+mkdir -p "$hot_reload_staging" "$test_home/.config/omarchy/plugins"
+cat >"$hot_reload_staging/manifest.json" <<JSON
 {
   "schemaVersion": 1,
   "id": "$hot_reload_id",
@@ -65,7 +72,7 @@ cat >"$hot_reload_dir/manifest.json" <<JSON
   "omarchy": {"clonedFrom": "omarchy.emojis"}
 }
 JSON
-cat >"$hot_reload_dir/Overlay.qml" <<'QML'
+cat >"$hot_reload_staging/Overlay.qml" <<'QML'
 import QtQuick
 
 Item {
@@ -73,6 +80,7 @@ Item {
   function close() {}
 }
 QML
+mv "$hot_reload_staging" "$hot_reload_dir"
 
 cat >"$stub_bin/omarchy-update-available" <<'SH'
 #!/bin/bash
@@ -139,6 +147,12 @@ jq -e '
   fail_with_log "shell IPC lists plugin metadata"
 }
 pass "shell IPC lists plugin metadata"
+
+# Snapshot the log right after the initial widget registration burst lands,
+# so the collision check below (which runs after several deliberate reloads —
+# the hot-reload rename, plugin enable/disable, and an explicit rescan) only
+# looks at the one registration pass it's actually meant to validate.
+startup_log_lines=$(wc -l < "$log")
 
 jq '.name = "After Hot Reload"' "$hot_reload_dir/manifest.json" >"$hot_reload_dir/manifest.json.tmp"
 mv "$hot_reload_dir/manifest.json.tmp" "$hot_reload_dir/manifest.json"
@@ -285,15 +299,21 @@ pass "direct panel IPC opens and closes default panels"
 # past the first. Anything beyond that is two instances on the same screen —
 # the shape duplicate component loads produced, where a sync pass that ran
 # while a widget's asynchronous load was still in flight started a second one.
-# Checked before the reload below, which rebuilds widgets by design.
+# Restricted to the startup portion of the log captured above: everything
+# after it is one or more deliberate reloads (hot-reload rename, plugin
+# enable/disable, rescanPlugins), each of which legitimately reproduces the
+# same one-collision-per-screen pattern and would otherwise inflate the count
+# with duplicates unrelated to this check.
 screens=$(hyprctl -j monitors 2>/dev/null | jq 'length' 2>/dev/null || true)
 [[ $screens =~ ^[0-9]+$ ]] && (( screens > 0 )) || screens=1
 # No matches is the good case, and pipefail would otherwise abort the run.
-worst=$(grep -oE "another handler is registered for target [a-z.-]+" "$log" |
+worst=$(head -n "$startup_log_lines" "$log" |
+  grep -oE "another handler is registered for target [a-z.-]+" |
   sort | uniq -c | sort -rn | head -1 | awk '{print $1}' || true)
 worst=${worst:-0}
 if (( worst > screens - 1 )); then
-  grep "another handler is registered for target" "$log" | sed 's/^/  /' | head -20 >&2
+  head -n "$startup_log_lines" "$log" |
+    grep "another handler is registered for target" | sed 's/^/  /' | head -20 >&2
   fail_with_log "each widget registers its IPC handler once per screen (saw $worst for $screens screen(s))"
 fi
 pass "each widget registers its IPC handler once per screen"


### PR DESCRIPTION
# Overview
`test/shell.d/runtime-smoke-test.sh`'s IPC-handler-collision check - which tolerates up to `screens - 1` "another handler is registered for target X" warnings per widget to account for the bar being legitimately instantiated once per screen - deterministically failed on this 2-screen desktop with "saw 3 for 2 screen(s)" on a clean checkout, for two compounding reasons:
1. The test built its synthetic hot-reload plugin fixture via three separate filesystem operations (`mkdir` + two file writes) directly inside `~/.config/omarchy/plugins`, the same directory quickshell's `PluginRegistry.qml` watches with `inotifywait`, causing a spurious `onLocalPluginChanged` -> full `reloadPlugins()` immediately after startup and superimposing an extra, unintended registration pass on top of the legitimate one; and
2. Even after eliminating that, the check greps the *entire* accumulated log at the end of the script, by which point two more fully legitimate, by-design reloads had already run earlier (the deliberate manifest-rename hot-reload test and an explicit `rescanPlugins` IPC call), each contributing its own `screens - 1` collisions per target and superimposing to `1 (startup) + 1 (rename) + 1 (rescan) = 3` - arithmetic, not flakiness, which is why it failed 100% of the time rather than intermittently.

The fix applies both changes together: the fixture is now built in a staging directory outside the watched tree and moved into place with a single atomic `mv`, removing the spurious startup reload; and the check now snapshots the log's line count right after the initial "shell IPC lists plugin metadata" pass (the first point at which the legitimate startup registration burst is guaranteed to be flushed) and restricts its `grep` to only that startup slice via `head -n`, so it measures exactly the one registration pass it was always meant to validate regardless of how many more by-design reloads the rest of the script performs afterward. Both changes were necessary - the atomic-move fix alone still left "saw 3" failing because the log-scoping issue was untouched - and were verified by three consecutive clean passes of the test in isolation plus a full `./test/shell` re-run showing the failure count drop from 4 files to the 3 pre-existing, unrelated environmental failures, with no stray quickshell processes or unintended working-tree changes left behind.

## Verification

The focused smoke test passes after the fix. The full `./test/shell` run now reports only the three pre-existing environment-dependent failures that require an `omarchy-pkgs` checkout.

<details>
<summary>Before — deterministic false failure on two monitors</summary>

```text
ok - shell IPC lists plugin metadata
ok - installed plugin changes reload without an explicit rescan
ok - shell IPC routes built-in ids to enabled clones
ok - shell IPC returns effective shell config
ok - shell IPC summon and hide contract works
ok - plugin IPC contracts respond
ok - image selector IPC survives plugin rescan
ok - default bar layout renders expected module slots
ok - runtime geometry keeps update before indicators
ok - direct panel IPC opens and closes default panels
not ok - each widget registers its IPC handler once per screen (saw 3 for 2 screen(s))
```

The log contained three registration passes for every target: startup, the intentional manifest hot reload, and the explicit `rescanPlugins` reload.

</details>

<details>
<summary>After — focused smoke test passes</summary>

```text
ok - shell IPC lists plugin metadata
ok - installed plugin changes reload without an explicit rescan
ok - shell IPC routes built-in ids to enabled clones
ok - shell IPC returns effective shell config
ok - shell IPC summon and hide contract works
ok - plugin IPC contracts respond
ok - image selector IPC survives plugin rescan
ok - default bar layout renders expected module slots
ok - runtime geometry keeps update before indicators
ok - direct panel IPC opens and closes default panels
ok - each widget registers its IPC handler once per screen
Disabled omarchy.audio
ok - bar remove reloads shell config and updates bar layout
ok - bar put places a widget after the one it names
ok - bar put leaves a widget already on the bar alone
```

</details>
