### PR TITLE
Document re-enabling BitLocker after dual-boot installation

### DIFF
--- a/manual/50-dual-boot-install.md
+++ b/manual/50-dual-boot-install.md
@@ -37,8 +37,12 @@ When you finish your Omarchy install, you'll notice that the Limine bootloader i
 
 In order to do that, run `limine-scan` and follow the prompts to add whichever items you'd like to your limine config. Then when you boot, you'll see your normal options for Omarchy, as well as Windows Boot Manager or others.
 
-## Bitlocker
+## BitLocker
 
-It's important to note that this install method is not compatible with Bitlocker as it encrypts the entire drive, not just the partition. If you encounter an error stating that Bitlocker is enabled, boot to Windows, go to **Settings -> Privacy & Security -> Device encryption** and toggle Bitlocker off. It may take some time to decrypt the drive.
+The current free-space installer will not proceed when it detects BitLocker on the selected disk. If you encounter this error, boot into Windows, go to **Settings -> Privacy & Security -> Device encryption**, and toggle BitLocker off. Wait for Windows to finish decrypting the volume before retrying the installation. Suspending BitLocker protection is not enough to satisfy this installer check.
+
+After Omarchy is installed, you can turn BitLocker back on for the Windows volume. Make sure you select only the Windows volume and leave the Omarchy partitions unchanged. When enabling it, save the recovery key somewhere accessible outside the encrypted Windows volume.
+
+If you want to start Windows with Limine, run `limine-scan` and successfully boot Windows from the new entry before turning BitLocker back on, because changing the Windows boot path afterward can alter TPM measurements and trigger recovery. Keep the recovery key available, and suspend BitLocker before changing Secure Boot or TPM settings, installing UEFI/BIOS or TPM firmware updates outside Windows, or changing the Windows boot path.
 
  ![dual-boot-7](images/dual-boot-7.webp)


### PR DESCRIPTION
## Why

Omarchy recommends an encrypted installation, but the current dual-boot guide tells users to turn BitLocker off and never tells them that they can turn it back on after installing Omarchy. A user following the guide literally can therefore finish with an encrypted Omarchy installation but an unintentionally unencrypted Windows volume.

An unencrypted Windows volume has no BitLocker protection for data at rest, so someone with physical access to a lost or stolen machine could read its files without signing in to Windows.

This change adds the missing post-install guidance so users can restore BitLocker protection for Windows, save the recovery key outside the encrypted volume, and avoid changing the Windows boot path after protection is enabled.

## What changed

- Explain that turning BitLocker off is a requirement of the current free-space installer check.
- Tell users they can turn BitLocker back on for the Windows volume after installing Omarchy while leaving the Omarchy partitions unchanged.
- Tell users who want Windows in Limine to add and test that entry before turning BitLocker back on.
- Warn that later boot-path, TPM, Secure Boot, or firmware changes can trigger BitLocker recovery.

The existing manual says this installation method is incompatible with BitLocker because BitLocker encrypts the entire drive rather than a partition. In practice, the current [Omarchy ISO configurator](https://github.com/omacom-io/omarchy-iso/blob/quattro/configs/airootfs/root/configurator) checks the selected disk for a BitLocker signature and aborts the free-space installation when it finds one. A suspended volume remains detectable, so users currently need to turn BitLocker off and wait for Windows to finish decrypting it before installation. This installer restriction does not continue after Omarchy is installed.

After installation, I verified that BitLocker fully encrypted and protected the selected Windows volume while the separate Omarchy EFI and LUKS partitions remained unchanged. Windows also rebooted successfully through its direct UEFI Windows Boot Manager entry with TPM protection enabled and Secure Boot disabled.

Microsoft documents both [BitLocker's TPM platform validation profiles](https://learn.microsoft.com/en-us/windows/security/operating-system-security/data-protection/bitlocker/configure) and that [suspending and resuming protection reseals the key to changed boot measurements](https://learn.microsoft.com/en-us/windows/security/operating-system-security/data-protection/bitlocker/faq). This supports the updated warning about configuring the intended Windows boot path before turning BitLocker back on and keeping the recovery key available.

## Testing

- `git diff --check` passes.
- `./test/all` was run. The CLI suite passed. The shell suite reported six unrelated environment-dependent failures in `config-test.sh`, `launch-about-test.sh`, `network-qr-test.sh`, `snapper-test.sh`, `theme-install-guards-test.sh`, and `unowned-system-paths-test.sh`. Three explicitly require a separate `omarchy-pkgs` checkout. This PR changes only the published Markdown manual.
