### PR TITLE
fix: address high-confidence shellcheck findings

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -33,7 +33,9 @@ done
 
 # Agents refuse to remember trust for $HOME, so launches from the keybinding or
 # menu start in the work directory instead of re-asking on every session.
-[[ $PWD == "$HOME" && -d $HOME/Work ]] && cd "$HOME/Work"
+if [[ $PWD == "$HOME" && -d $HOME/Work ]]; then
+  cd "$HOME/Work" || exit
+fi
 
 agent=$(omarchy-default-agent)
 

--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -164,7 +164,7 @@ generate_thumbnail() {
   # Callers fan out one generator per image, so keep each vips single-threaded.
   # Close the lock fd for vips: an orphaned or hung vips must not keep holding
   # the lock after this shell is killed.
-  if VIPS_CONCURRENCY=1 vipsthumbnail "$image" --size 1536x864 --smartcrop=centre --path "$tmp[Q=82,strip]" {lock_fd}>&-; then
+  if VIPS_CONCURRENCY=1 vipsthumbnail "$image" --size 1536x864 --smartcrop=centre --path "${tmp}[Q=82,strip]" {lock_fd}>&-; then
     mv -f "$tmp" "$thumbnail"
   else
     rm -f "$tmp" "$thumbnail"
@@ -219,7 +219,7 @@ elif [[ $rows_cache_hit != true ]]; then
   for image in "${image_files[@]}"; do
     thumbnail=$(thumbnail_for "$image")
     [[ -n $thumbnail ]] || continue
-    if [[ $lazy_thumbnails == true && $cache_only != true && $thumbnail == $image ]]; then
+    if [[ $lazy_thumbnails == true && $cache_only != true && $thumbnail == "$image" ]]; then
       rows_cacheable=false
     fi
 

--- a/install/config/increase-lockout-limit.sh
+++ b/install/config/increase-lockout-limit.sh
@@ -1,4 +1,4 @@
-# /etc/pam.d/{system-auth,sddm-autologin} are upstream-owned and the changes
+# The upstream-owned /etc/pam.d/{system-auth,sddm-autologin} files receive changes
 # are insertions, not full-file overrides, so they stay scripted.
 sed -i 's|^\(auth\s\+required\s\+pam_faillock.so\)\s\+preauth.*$|\1 preauth silent deny=10 unlock_time=120|' \
            /etc/pam.d/system-auth

--- a/migrations/1780057136.sh
+++ b/migrations/1780057136.sh
@@ -57,7 +57,7 @@ ensure_kitty_binding() {
 
   key_regex=$(printf '%s\n' "$key" | sed 's/[][\\.^$*+?{}|()\/]/\\&/g')
 
-  if grep -Eq "^map[[:space:]]+$key_regex[[:space:]].*13;[24]u" "$config"; then
+  if grep -Eq "^map[[:space:]]+${key_regex}[[:space:]].*13;[24]u" "$config"; then
     tmp=$(mktemp)
     KEY="$key" BINDING="$binding" awk '
       BEGIN {
@@ -72,7 +72,7 @@ ensure_kitty_binding() {
         print
       }
     ' "$config" >"$tmp" && mv "$tmp" "$config"
-  elif ! grep -Eq "^map[[:space:]]+$key_regex[[:space:]]" "$config"; then
+  elif ! grep -Eq "^map[[:space:]]+${key_regex}[[:space:]]" "$config"; then
     if grep -qxF 'map shift+insert paste_from_clipboard' "$config"; then
       tmp=$(mktemp)
       KEY="$key" BINDING="$binding" COMMENT="$comment" awk '

--- a/test/shell.d/branding-about-animation-test.sh
+++ b/test/shell.d/branding-about-animation-test.sh
@@ -44,7 +44,7 @@ for index in "${!SHEEN_FRAMES[@]}"; do
   frame_lit=0
   while IFS= read -r drawn; do
     [[ -n $drawn ]] || continue
-    [[ $drawn == "$esc[$((top + row));${left}H"* ]] || misplaced=$((misplaced + 1))
+    [[ $drawn == "${esc}[$((top + row));${left}H"* ]] || misplaced=$((misplaced + 1))
 
     rest=${drawn#*H}
     [[ $rest == "$base"* ]] || unbased=$((unbased + 1))
@@ -95,7 +95,7 @@ pass "a glint arrives from off the logo"
 
 settled=""
 for row in "${!expected[@]}"; do
-  settled+="$esc[$((top + row));${left}H$base${expected[row]}$SHEEN_BAND$base"
+  settled+="${esc}[$((top + row));${left}H$base${expected[row]}$SHEEN_BAND$base"
 done
 [[ ${SHEEN_FRAMES[-1]} == "$settled" ]] || fail "a glint settles back to the logo it was given"
 pass "a glint settles back to the logo it was given"

--- a/test/shell.d/brcmfmac-supplicant-test.sh
+++ b/test/shell.d/brcmfmac-supplicant-test.sh
@@ -68,7 +68,7 @@ chmod +x "$stub_bin"/*
 # grep -q gate would go silent here the way #6608 did.
 run_leaf() {
   local vendor="$1" wifi_id="${2:-}" t2="${3:-0}"
-  rm -rf "$test_tmp/etc"
+  rm -rf "${test_tmp:?}/etc"
   mkdir -p "$test_tmp/etc"
   printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
 
@@ -133,7 +133,7 @@ run_migration() {
 # A T2 install from before the quirk shipped has no config at all, so this is
 # the case that proves the T2 gate itself still fires -- and it is the piped
 # grep, run under pipefail, that #6608 was about.
-rm -rf "$test_tmp/etc"
+rm -rf "${test_tmp:?}/etc"
 run_migration "Apple Inc." 4488 1
 grep -q '^options brcmfmac feature_disable=0x82000$' "$conf" 2>/dev/null ||
   fail "the migration fixes a T2 install that never got the quirk" "$(ls -R "$test_tmp/etc" 2>&1)"
@@ -149,7 +149,7 @@ run_migration "Apple Inc." 4488 1
 pass "the migration is idempotent"
 
 # The machine this was written for, with no T2 to fall back on.
-rm -rf "$test_tmp/etc"
+rm -rf "${test_tmp:?}/etc"
 run_migration "Apple Inc." 43ba 0
 grep -q '^options brcmfmac feature_disable=0x82000$' "$conf" 2>/dev/null ||
   fail "the migration fixes an install on a Mac without a T2" "$(ls -R "$test_tmp/etc" 2>&1)"
@@ -171,7 +171,7 @@ grep -qx 'options brcmfmac feature_disable=0x82000' "$conf" ||
   fail "a commented-out option does not count as applied" "$(cat "$conf")"
 pass "a commented-out option does not count as applied"
 
-rm -rf "$test_tmp/etc"
+rm -rf "${test_tmp:?}/etc"
 run_migration "Apple Inc." 43a0 0
 [[ ! -e $conf ]] || fail "the migration skips a Mac brcmfmac does not drive" "$(cat "$conf")"
 [[ ! -s $calls ]] || fail "the migration escalates nothing on unaffected Macs" "$(cat "$calls")"


### PR DESCRIPTION
## Summary

Fix a small set of high-confidence ShellCheck findings that affect shell expansion, path handling, cleanup safety, and migration correctness.

## Changes

- Guard the work-directory `cd` in `bin/omarchy-agent`.
- Prevent ambiguous filename expansion in `bin/omarchy-menu-images`.
- Quote the thumbnail path comparison to avoid unintended pattern matching.
- Fix ambiguous variable expansion in `migrations/1780057136.sh`.
- Fix equivalent escape and array expansions in the animation test.
- Protect test cleanup commands with `${test_tmp:?}` before `rm -rf`.
- Clarify a PAM migration comment that ShellCheck interpreted as a malformed shebang.

## Why

These are localized fixes with clear behavior. They reduce the risk of continuing after a failed directory change, accidentally broadening a destructive test cleanup path, or applying a command to an incorrectly expanded path or regex.

## Validation

- `shellcheck -s bash` passes on all touched files except for two intentional informational `SC2016` notices.
- `test/shell.d/branding-about-animation-test.sh` passes.
- `test/shell.d/brcmfmac-supplicant-test.sh` passes.
- `git diff --check` passes.

---

<em><sub>AI assisted by Pi + gpt-5.6-luna + low thinking level</sub></em>