### PR TITLE
fix: quote shell comparison operands

### DIFF
--- a/bin/omarchy-audio-output-switch
+++ b/bin/omarchy-audio-output-switch
@@ -52,7 +52,7 @@ else
   icon_state="high"
 fi
 
-if [[ $next_sink_name != $current_sink_name ]]; then
+if [[ $next_sink_name != "$current_sink_name" ]]; then
   omarchy-audio-output-set-default "$(jq -r '.index' <<<"$next_sink")" "$next_sink_name"
 fi
 

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -112,7 +112,7 @@ if [[ $shell_output == "true" ]]; then
   [[ -n $cycles ]] && printf 'cycles\t%s\n' "$cycles"
 
   if [[ -n $threshold_end ]]; then
-    if [[ -n $threshold_start && $threshold_start != $threshold_end ]]; then
+    if [[ -n $threshold_start && $threshold_start != "$threshold_end" ]]; then
       printf 'threshold\t%s-%s%%\n' "$threshold_start" "$threshold_end"
     else
       printf 'threshold\t%s%%\n' "$threshold_end"
@@ -123,7 +123,7 @@ if [[ $shell_output == "true" ]]; then
 fi
 
 if [[ $charge_holding == "true" ]]; then
-  if [[ -n $threshold_start && $threshold_start != $threshold_end ]]; then
+  if [[ -n $threshold_start && $threshold_start != "$threshold_end" ]]; then
     threshold_label="${threshold_start}-${threshold_end}%"
   else
     threshold_label="${threshold_end}%"

--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -236,7 +236,7 @@ disable_internal() {
   local config
   config=$(printf 'hl.monitor({ output = "%s", disabled = true })' "$INTERNAL")
 
-  if [[ ! -f $CLAMSHELL_FLAG ]] || [[ $(< "$CLAMSHELL_FLAG") != $config ]]; then
+  if [[ ! -f $CLAMSHELL_FLAG ]] || [[ $(< "$CLAMSHELL_FLAG") != "$config" ]]; then
     printf '%s\n' "$config" >"$CLAMSHELL_FLAG"
     hyprctl reload >/dev/null 2>&1 || true
   fi

--- a/bin/omarchy-launch-about
+++ b/bin/omarchy-launch-about
@@ -121,7 +121,7 @@ settle_grid() {
 
   for _ in {1..20}; do
     current=$(stty size)
-    if [[ $current == $previous ]]; then
+    if [[ $current == "$previous" ]]; then
       (( ++held == 3 )) && break
     else
       held=0
@@ -353,7 +353,7 @@ if [[ ${1:-} == "--render" ]]; then
     build_sheen
     while play_sheen && rest_sheen; do :; done
     # A rebranded logo changes the content dimensions, so measure again.
-    if [[ $(stat -c %Y "$LOGO_FILE" 2>/dev/null) != $logo_stamp ]]; then
+    if [[ $(stat -c %Y "$LOGO_FILE" 2>/dev/null) != "$logo_stamp" ]]; then
       fitted=false
       passes=0
     fi

--- a/bin/omarchy-remove-browser
+++ b/bin/omarchy-remove-browser
@@ -9,7 +9,7 @@ set_fallback_default_browser() {
   local current_browser
   current_browser=$(env -u BROWSER xdg-settings get default-web-browser)
 
-  if [[ $current_browser != $1 ]]; then
+  if [[ $current_browser != "$1" ]]; then
     return
   fi
 

--- a/bin/omarchy-remove-launcher-entry
+++ b/bin/omarchy-remove-launcher-entry
@@ -57,7 +57,7 @@ is_user_desktop_file() {
 
   desktop_dir="${desktop_file%/*}"
   for dir in "${user_desktop_dirs[@]}"; do
-    [[ $desktop_dir == $dir ]] && return 0
+    [[ $desktop_dir == "$dir" ]] && return 0
   done
 
   return 1

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -85,7 +85,7 @@ choose_theme_background() {
   current_background=$(readlink "$CURRENT_BACKGROUND_LINK" 2>/dev/null || true)
   index=-1
   for i in "${!backgrounds[@]}"; do
-    if [[ ${backgrounds[$i]} == $current_background ]]; then
+    if [[ ${backgrounds[$i]} == "$current_background" ]]; then
       index=$i
       break
     fi

--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -42,7 +42,7 @@ fi
 # Query the current temperature
 CURRENT_TEMP=$(current_temp)
 
-if [[ -z $CURRENT_TEMP || $CURRENT_TEMP == $OFF_TEMP ]]; then
+if [[ -z $CURRENT_TEMP || $CURRENT_TEMP == "$OFF_TEMP" ]]; then
   TARGET_TEMP=$ON_TEMP
 else
   TARGET_TEMP=$OFF_TEMP

--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -15,7 +15,7 @@ for kernel in /usr/lib/modules/*/vmlinuz; do
   if [[ -f $kernel ]] && pacman -Qo "$kernel" &>/dev/null; then
     installed_kernel=$(basename "$(dirname "$kernel")")
 
-    if [[ $installed_kernel == $running_kernel ]]; then
+    if [[ $installed_kernel == "$running_kernel" ]]; then
       kernel_updated=false
       break
     fi

--- a/bin/omarchy-version-channel
+++ b/bin/omarchy-version-channel
@@ -20,7 +20,7 @@ else
   pkgs="unknown"
 fi
 
-if [[ $mirror == $pkgs ]]; then
+if [[ $mirror == "$pkgs" ]]; then
   echo $mirror
 else
   echo "$mirror / $pkgs"


### PR DESCRIPTION
## Summary

Quote the right-hand operands in Bash equality and inequality comparisons across command scripts.

## Why

Unquoted right-hand operands in `[[ ... == ... ]]` and `[[ ... != ... ]]` are treated as glob patterns. Values containing `*`, `?`, or bracket expressions could therefore change the result of these conditionals unexpectedly.

## Scope

This is a focused ShellCheck cleanup limited to ten scripts under `bin/`. 

## Validation

- ShellCheck reports no remaining `SC2053` findings under `bin/`.
- `git diff --check` passes.

---

<em><sub>AI assisted by Pi + gpt-5.6-luna + low thinking level</sub></em>