### PR TITLE
Make scrolling columns resizable at workspace edge

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -1,3 +1,13 @@
+local function scrolling_direction(workspace)
+  local opts = workspace.layout_opts
+  local direction = type(opts) == "table" and opts.direction or hl.get_config("scrolling.direction")
+  if direction == "left" or direction == "right" or direction == "up" or direction == "down" then
+    return direction
+  end
+
+  return "right"
+end
+
 local function horizontal_resize(pixel_delta, scrolling_delta)
   local window_resize = hl.dsp.window.resize({ x = pixel_delta, y = 0, relative = true })
   local column_resize = hl.dsp.layout("colresize " .. scrolling_delta)
@@ -8,12 +18,17 @@ local function horizontal_resize(pixel_delta, scrolling_delta)
       return
     end
 
+    -- colresize follows the tape axis, so only use it for horizontal scrolling.
+    -- A column at the workspace edge has no neighboring split to resize.
     if workspace.tiled_layout == "scrolling" then
-      -- A column at the workspace edge has no neighboring split to resize.
-      hl.dispatch(column_resize)
-    else
-      hl.dispatch(window_resize)
+      local direction = scrolling_direction(workspace)
+      if direction == "left" or direction == "right" then
+        hl.dispatch(column_resize)
+        return
+      end
     end
+
+    hl.dispatch(window_resize)
   end
 end
 

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -1,3 +1,22 @@
+local function horizontal_resize(pixel_delta, scrolling_delta)
+  local window_resize = hl.dsp.window.resize({ x = pixel_delta, y = 0, relative = true })
+  local column_resize = hl.dsp.layout("colresize " .. scrolling_delta)
+
+  return function()
+    local workspace = hl.get_active_special_workspace() or hl.get_active_workspace()
+    if not workspace then
+      return
+    end
+
+    if workspace.tiled_layout == "scrolling" then
+      -- A column at the workspace edge has no neighboring split to resize.
+      hl.dispatch(column_resize)
+    else
+      hl.dispatch(window_resize)
+    end
+  end
+end
+
 o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
@@ -52,18 +71,18 @@ o.bind("ALT + SHIFT + TAB", "Reveal active window on top", hl.dsp.window.bring_t
 o.bind("CTRL + ALT + TAB", "Focus on next monitor", hl.dsp.focus({ monitor = "+1" }))
 o.bind("CTRL + ALT + SHIFT + TAB", "Focus on previous monitor", hl.dsp.focus({ monitor = "-1" }))
 
-o.bind("SUPER + code:20", "Expand window left", hl.dsp.window.resize({ x = -100, y = 0, relative = true }))
-o.bind("SUPER + code:21", "Shrink window left", hl.dsp.window.resize({ x = 100, y = 0, relative = true }))
+o.bind("SUPER + code:20", "Expand window left", horizontal_resize(-100, "-0.05"))
+o.bind("SUPER + code:21", "Shrink window left", horizontal_resize(100, "+0.05"))
 o.bind("SUPER + SHIFT + code:20", "Shrink window up", hl.dsp.window.resize({ x = 0, y = -100, relative = true }))
 o.bind("SUPER + SHIFT + code:21", "Expand window down", hl.dsp.window.resize({ x = 0, y = 100, relative = true }))
 
-o.bind("SUPER + ALT + code:20", "Expand window left a little", hl.dsp.window.resize({ x = -25, y = 0, relative = true }))
-o.bind("SUPER + ALT + code:21", "Shrink window left a little", hl.dsp.window.resize({ x = 25, y = 0, relative = true }))
+o.bind("SUPER + ALT + code:20", "Expand window left a little", horizontal_resize(-25, "-0.0125"))
+o.bind("SUPER + ALT + code:21", "Shrink window left a little", horizontal_resize(25, "+0.0125"))
 o.bind("SUPER + SHIFT + ALT + code:20", "Shrink window up a little", hl.dsp.window.resize({ x = 0, y = -25, relative = true }))
 o.bind("SUPER + SHIFT + ALT + code:21", "Expand window down a little", hl.dsp.window.resize({ x = 0, y = 25, relative = true }))
 
-o.bind("SUPER + CTRL + code:20", "Expand window left a lot", hl.dsp.window.resize({ x = -300, y = 0, relative = true }))
-o.bind("SUPER + CTRL + code:21", "Shrink window left a lot", hl.dsp.window.resize({ x = 300, y = 0, relative = true }))
+o.bind("SUPER + CTRL + code:20", "Expand window left a lot", horizontal_resize(-300, "-0.15"))
+o.bind("SUPER + CTRL + code:21", "Shrink window left a lot", horizontal_resize(300, "+0.15"))
 o.bind("SUPER + CTRL + SHIFT + code:20", "Shrink window up a lot", hl.dsp.window.resize({ x = 0, y = -300, relative = true }))
 o.bind("SUPER + CTRL + SHIFT + code:21", "Expand window down a lot", hl.dsp.window.resize({ x = 0, y = 300, relative = true }))
 

--- a/test/shell.d/hyprland-resize-bindings-test.sh
+++ b/test/shell.d/hyprland-resize-bindings-test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command lua
+
+OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local function proxy()
+  return setmetatable({}, {
+    __index = function(self, key)
+      local value = proxy()
+      rawset(self, key, value)
+      return value
+    end,
+    __call = function()
+      return {}
+    end,
+  })
+end
+
+local bindings = {}
+local dispatched = {}
+local workspace = { tiled_layout = "scrolling" }
+local special_workspace
+
+local window_dispatchers = proxy()
+window_dispatchers.resize = function(args)
+  return { kind = "window", args = args }
+end
+
+local dispatchers = proxy()
+dispatchers.window = window_dispatchers
+dispatchers.layout = function(message)
+  return { kind = "layout", message = message }
+end
+
+hl = {
+  dsp = dispatchers,
+  bind = function() end,
+  dispatch = function(dispatcher)
+    table.insert(dispatched, dispatcher)
+  end,
+  get_active_workspace = function()
+    return workspace
+  end,
+  get_active_special_workspace = function()
+    return special_workspace
+  end,
+}
+
+o = {
+  bind = function(keys, _, dispatcher)
+    bindings[keys] = dispatcher
+  end,
+}
+
+require("default.hypr.bindings.tiling")
+
+local cases = {
+  { "SUPER + code:20", -100, "colresize -0.05" },
+  { "SUPER + code:21", 100, "colresize +0.05" },
+  { "SUPER + ALT + code:20", -25, "colresize -0.0125" },
+  { "SUPER + ALT + code:21", 25, "colresize +0.0125" },
+  { "SUPER + CTRL + code:20", -300, "colresize -0.15" },
+  { "SUPER + CTRL + code:21", 300, "colresize +0.15" },
+}
+
+local function run_binding(keys)
+  dispatched = {}
+  assert(type(bindings[keys]) == "function", "missing layout-aware binding: " .. keys)
+  bindings[keys]()
+  assert(#dispatched == 1, "binding did not dispatch exactly once: " .. keys)
+  return dispatched[1]
+end
+
+for _, case in ipairs(cases) do
+  local dispatcher = run_binding(case[1])
+  assert(dispatcher.kind == "layout", "scrolling resize did not use a layout message: " .. case[1])
+  assert(dispatcher.message == case[3], "unexpected scrolling resize delta: " .. case[1])
+end
+
+workspace.tiled_layout = "dwindle"
+for _, case in ipairs(cases) do
+  local dispatcher = run_binding(case[1])
+  assert(dispatcher.kind == "window", "dwindle resize did not use the window dispatcher: " .. case[1])
+  assert(dispatcher.args.x == case[2], "unexpected dwindle resize delta: " .. case[1])
+  assert(dispatcher.args.y == 0 and dispatcher.args.relative == true, "dwindle resize lost its existing options: " .. case[1])
+end
+
+workspace.tiled_layout = "scrolling"
+special_workspace = { tiled_layout = "dwindle" }
+assert(run_binding("SUPER + code:21").kind == "window", "active special workspace layout takes precedence")
+
+workspace = nil
+special_workspace = nil
+dispatched = {}
+bindings["SUPER + code:21"]()
+assert(#dispatched == 0, "resize dispatches without an active workspace")
+LUA
+
+pass "horizontal resize bindings follow the active workspace layout"

--- a/test/shell.d/hyprland-resize-bindings-test.sh
+++ b/test/shell.d/hyprland-resize-bindings-test.sh
@@ -24,6 +24,7 @@ local bindings = {}
 local dispatched = {}
 local workspace = { tiled_layout = "scrolling" }
 local special_workspace
+local configured_direction
 
 local window_dispatchers = proxy()
 window_dispatchers.resize = function(args)
@@ -47,6 +48,11 @@ hl = {
   end,
   get_active_special_workspace = function()
     return special_workspace
+  end,
+  get_config = function(key)
+    if key == "scrolling.direction" then
+      return configured_direction
+    end
   end,
 }
 
@@ -92,6 +98,24 @@ end
 workspace.tiled_layout = "scrolling"
 special_workspace = { tiled_layout = "dwindle" }
 assert(run_binding("SUPER + code:21").kind == "window", "active special workspace layout takes precedence")
+
+special_workspace = nil
+configured_direction = "left"
+assert(run_binding("SUPER + code:21").kind == "layout", "leftward scrolling still uses colresize")
+
+configured_direction = "up"
+assert(run_binding("SUPER + code:21").kind == "window", "upward scrolling keeps window.resize")
+
+configured_direction = "down"
+assert(run_binding("SUPER + code:21").kind == "window", "downward scrolling keeps window.resize")
+
+configured_direction = "right"
+workspace.layout_opts = { direction = "down" }
+assert(run_binding("SUPER + code:21").kind == "window", "workspace direction override takes precedence")
+
+workspace.layout_opts = { direction = "left" }
+configured_direction = "up"
+assert(run_binding("SUPER + code:21").kind == "layout", "horizontal workspace override uses colresize")
 
 workspace = nil
 special_workspace = nil


### PR DESCRIPTION
## Summary

- use the scrolling layout’s native `colresize` message for horizontal resize shortcuts
- keep `window.resize` on dwindle layouts and on vertical scrolling (`up`/`down`)
- cover normal, small, and large resize steps, plus scrolling direction, with a focused regression test

## Why

The generic horizontal resize dispatcher cannot grow the last visible scrolling column when there is no neighboring window on its right. This makes users open a temporary window, resize the original column, and close the temporary window again.

Routing the same shortcuts through `colresize` on scrolling workspaces changes the column width directly and works at the workspace edge. `colresize` follows the tape axis, so it is used only when the effective scrolling direction is `left` or `right`. Shortcut chords and non-scrolling behavior remain unchanged.

## Testing

- `bash test/shell.d/hyprland-resize-bindings-test.sh`
- `bash test/shell.d/hyprland-default-config-test.sh`
- `bash test/shell.d/hyprland-binding-conflicts-test.sh`
- live verified on Hyprland 0.56.2 by growing and restoring the rightmost scrolling column without a window to its right