### PR TITLE
Answer org.gnome.Console activations so Nautilus can open a terminal

### DIFF
--- a/bin/omarchy-cmd-console
+++ b/bin/omarchy-cmd-console
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Answer org.gnome.Console activations by opening the default terminal.
+# omarchy:hidden=true
+
+# Nautilus hands "Open in Console" (Ctrl+.) to the org.gnome.Console D-Bus
+# service over org.freedesktop.Application. That service is GNOME Console, which
+# Omarchy does not ship, so the shortcut and its menu entry are both inert. This
+# stands in for it and opens the terminal xdg-terminal-exec selects.
+#
+# GApplication exports org.freedesktop.Application at the object path derived
+# from the application id, which is exactly the interface Nautilus calls, so
+# there is no hand-rolled D-Bus plumbing here.
+
+import os
+import subprocess
+import sys
+
+import gi
+
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio  # noqa: E402
+
+
+def open_terminal(directory):
+    if not os.path.isdir(directory):
+        directory = os.path.dirname(directory) or os.path.expanduser("~")
+
+    try:
+        subprocess.Popen(
+            ["setsid", "uwsm-app", "--", "xdg-terminal-exec", f"--dir={directory}"],
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as error:
+        print(f"omarchy-cmd-console: {error}", file=sys.stderr)
+
+
+class Console(Gio.Application):
+    def __init__(self):
+        super().__init__(
+            application_id="org.gnome.Console",
+            # IS_SERVICE matters: without it run() reads the empty argv as a
+            # plain launch and fires activate as well as the incoming Open, so a
+            # single request opens two terminals.
+            flags=Gio.ApplicationFlags.HANDLES_OPEN | Gio.ApplicationFlags.IS_SERVICE,
+        )
+        self.set_inactivity_timeout(3000)
+
+    def do_open(self, files, n_files, hint):
+        self.hold()
+        for file in files:
+            path = file.get_path()
+            if path:
+                open_terminal(path)
+        self.release()
+
+    def do_activate(self):
+        self.hold()
+        open_terminal(os.path.expanduser("~"))
+        self.release()
+
+
+if __name__ == "__main__":
+    sys.exit(Console().run(sys.argv))

--- a/bin/omarchy-refresh-applications
+++ b/bin/omarchy-refresh-applications
@@ -10,6 +10,24 @@ if omarchy-cmd-present alacritty; then
   cp "$OMARCHY_PATH/default/alacritty/Alacritty.desktop" ~/.local/share/applications/
 fi
 
+# Nautilus hands "Open in Console" (Ctrl+.) to the org.gnome.Console D-Bus
+# service, which GNOME Console provides. Omarchy ships foot instead, so stand in
+# for that service -- unless the real Console is installed, in which case get out
+# of its way rather than shadowing it.
+console_desktop=~/.local/share/applications/org.gnome.Console.desktop
+console_service=~/.local/share/dbus-1/services/org.gnome.Console.service
+
+if omarchy-pkg-present gnome-console; then
+  rm -f "$console_desktop" "$console_service"
+else
+  cp "$OMARCHY_PATH/default/applications/org.gnome.Console.desktop" "$console_desktop"
+
+  # The service file needs an absolute Exec, which differs under a dev link.
+  mkdir -p ~/.local/share/dbus-1/services
+  sed "s|@BIN@|$OMARCHY_PATH/bin/omarchy-cmd-console|" \
+    "$OMARCHY_PATH/default/dbus-1/services/org.gnome.Console.service" >"$console_service"
+fi
+
 if [[ -f "$OMARCHY_PATH/install/user/mise.sh" ]]; then
   bash "$OMARCHY_PATH/install/user/mise.sh"
 fi

--- a/default/applications/org.gnome.Console.desktop
+++ b/default/applications/org.gnome.Console.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Console
+Comment=Opens the default terminal for apps that ask for GNOME Console
+Exec=omarchy-cmd-console
+DBusActivatable=true
+NoDisplay=true
+Terminal=false

--- a/default/dbus-1/services/org.gnome.Console.service
+++ b/default/dbus-1/services/org.gnome.Console.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.gnome.Console
+Exec=@BIN@

--- a/migrations/1788035178.sh
+++ b/migrations/1788035178.sh
@@ -1,0 +1,3 @@
+echo "Open in Console from Nautilus now opens the default terminal"
+
+omarchy-refresh-applications


### PR DESCRIPTION
Nautilus's "Open in Console" (`Ctrl+.`) does nothing on Omarchy. Reported in #3845 (Dec 2025).

## Root cause

Nautilus doesn't spawn a terminal for this action — it activates a D-Bus service:

| | |
|---|---|
| Bus name | `org.gnome.Console` |
| Interface | `org.freedesktop.Application` |
| Object path | `/org/gnome/Console` |

Those are compiled into the binary. Omarchy ships foot rather than `gnome-console`, so nothing claims that name and the call goes nowhere.

The context-menu entry is the same action (`view.current-directory-console`) and is declared `hidden-when="action-disabled"`, so it isn't greyed out — it's absent. That's why the breakage is easy to miss: there's no visible affordance suggesting anything is wrong.

Worth flagging for anyone implementing this: providing the D-Bus service **alone is not enough**. Nautilus looks up the app's desktop entry before dispatching, so with a `.service` but no `.desktop`, `Activate()` over D-Bus succeeds while `Ctrl+.` still silently does nothing. Both files are required.

## What this does

Stands in for that service with a small `Gio.Application` whose `application_id` is `org.gnome.Console` — GApplication exports `org.freedesktop.Application` at the derived object path, so it's exactly the interface Nautilus calls with no hand-rolled D-Bus plumbing. It opens whatever `xdg-terminal-exec` selects, which Omarchy already configures via `default/xdg-terminal-exec`.

Deployed user-level through the existing `omarchy-refresh-applications`. If `gnome-console` is installed, the stand-in is removed rather than shadowing the real thing; it comes back if that package is removed.

## Testing

- `./test/cli` — 0 failures
- `Ctrl+.` in Nautilus opens foot at the current folder
- D-Bus `Open` with a folder URI → one terminal, correct directory
- Both guard branches (`gnome-console` present / absent), and re-running is idempotent
- Verified on Omarchy 4.0.1-1, nautilus 50.2.2, foot, Hyprland

## Relationship to #7772

#7772 asks for `SUPER+RETURN` to open a terminal in the focused Nautilus folder, and needs a nautilus-python extension plus window-title matching because Hyprland grabs that key before Nautilus sees it — from that direction, Nautilus genuinely won't tell you where it is.

This is the reverse direction: Nautilus initiates and hands over the folder URI, so no extension, state file, or heuristics are involved. The two don't overlap or conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)