### PR TITLE
Complete bar and plugin ids on the omarchy CLI

### DIFF
--- a/default/bash/completions
+++ b/default/bash/completions
@@ -1,3 +1,156 @@
+_omarchy_add_candidates() {
+  local item
+  for item in "$@"; do
+    [[ -n $item && -z ${seen[$item]:-} ]] || continue
+    seen[$item]=1
+    candidates+=("$item")
+  done
+}
+
+_omarchy_plugin_catalog_json() {
+  local catalog_bin="$bin_dir/omarchy-plugin-catalog"
+  [[ -x $catalog_bin ]] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  local omarchy_root
+  omarchy_root=$(dirname -- "$bin_dir")
+  OMARCHY_PATH="${OMARCHY_PATH:-$omarchy_root}" "$catalog_bin" 2>/dev/null
+}
+
+_omarchy_add_bar_layout_ids() {
+  local config="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/shell.json"
+  [[ -f $config ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  local line
+  while IFS= read -r line; do
+    _omarchy_add_candidates "$line"
+  done < <(jq -r '.bar.layout // {} | to_entries[] | .value[]? |
+    if type == "object" then (.id // empty) else . end' "$config" 2>/dev/null)
+}
+
+_omarchy_add_plugin_ids() {
+  local kind="${1:-}"
+  local first_party="${2:-}"
+  local catalog
+  catalog=$(_omarchy_plugin_catalog_json) || return 0
+  [[ -n $catalog ]] || return 0
+  local line
+  while IFS= read -r line; do
+    _omarchy_add_candidates "$line"
+  done < <(jq -r --arg kind "$kind" --arg firstParty "$first_party" '
+    .[]
+    | select($kind == "" or (.kinds | index($kind)))
+    | select($firstParty != "true" or .firstParty == true)
+    | .id
+  ' <<<"$catalog" 2>/dev/null)
+}
+
+_omarchy_add_user_plugin_ids() {
+  local user_dir="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/plugins"
+  [[ -d $user_dir ]] || return 0
+  local dir
+  for dir in "$user_dir"/*/; do
+    [[ -d $dir ]] || continue
+    _omarchy_add_candidates "$(basename -- "$dir")"
+  done
+}
+
+_omarchy_add_id_candidates() {
+  local command_name="$1"
+  local verb="$2"
+
+  case "$command_name" in
+  omarchy-bar)
+    case "$verb" in
+    set | move)
+      _omarchy_add_bar_layout_ids
+      ;;
+    put)
+      _omarchy_add_plugin_ids bar-widget
+      ;;
+    use)
+      _omarchy_add_plugin_ids bar
+      ;;
+    esac
+    ;;
+  omarchy-plugin-enable | omarchy-plugin-disable)
+    _omarchy_add_plugin_ids
+    ;;
+  omarchy-plugin-clone)
+    _omarchy_add_plugin_ids "" true
+    ;;
+  omarchy-plugin-remove | omarchy-plugin-update)
+    _omarchy_add_user_plugin_ids
+    ;;
+  esac
+}
+
+_omarchy_add_args_from() {
+  local command_path="$1"
+  local first_arg_index="$2"
+  [[ -x $command_path ]] || return 0
+
+  local args spec alt token actual alts value match current_arg_index j
+  args=$(grep -m 1 '^# omarchy:args=' "$command_path" 2>/dev/null) || return 0
+  args="${args#*omarchy:args=}"
+  [[ -n $args ]] || return 0
+  current_arg_index=$((COMP_CWORD - first_arg_index))
+  (( current_arg_index >= 0 )) || return 0
+
+  alts="${args// | /$'\n'}"
+  while IFS= read -r alt; do
+    read -r -a spec <<<"$alt"
+    match=true
+
+    for ((j = 0; j < current_arg_index; j++)); do
+      token="${spec[j]:-}"
+      actual="${COMP_WORDS[first_arg_index + j]:-}"
+      if [[ -z $token ]]; then
+        match=false
+        break
+      fi
+
+      if [[ $token == \<*\> || $token == \[*\] ]]; then
+        value="${token#<}"
+        value="${value#\[}"
+        value="${value%>}"
+        value="${value%\]}"
+        if [[ $value == *"|"* ]]; then
+          [[ " ${value//|/ } " == *" $actual "* ]] || match=false
+        fi
+      elif [[ $token != "$actual" ]]; then
+        match=false
+      fi
+    done
+
+    [[ $match == true ]] || continue
+
+    token="${spec[current_arg_index]:-}"
+    [[ -n $token ]] || continue
+
+    if [[ $token == \<*\> || $token == \[*\] ]]; then
+      value="${token#<}"
+      value="${value#\[}"
+      value="${value%>}"
+      value="${value%\]}"
+      if [[ $value == *"|"* ]]; then
+        read -r -a spec <<<"${value//|/ }"
+        _omarchy_add_candidates "${spec[@]}"
+      elif [[ $value == "id" || $value == "source-id" ]]; then
+        _omarchy_add_id_candidates "${command_path##*/}" "${COMP_WORDS[first_arg_index]:-}"
+      elif [[ $value == --* ]]; then
+        _omarchy_add_candidates "$value"
+        if [[ ${spec[current_arg_index + 1]:-} == "[placement]" ]]; then
+          _omarchy_add_candidates --section --index --before --after --from-section --from-index
+        fi
+      elif [[ $value == "placement" ]]; then
+        _omarchy_add_candidates --section --index --before --after --from-section --from-index
+      fi
+    else
+      _omarchy_add_candidates "$token"
+    fi
+  done <<<"$alts"
+}
+
 _omarchy_complete() {
   COMPREPLY=()
   local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -22,6 +175,11 @@ _omarchy_complete() {
   shopt -s nullglob
   for file in "$bin_dir/$prefix"-*; do
     [[ -f $file && -x $file ]] || continue
+    # Hidden siblings of a resolved command (omarchy-bar-text-color next to
+    # omarchy-bar) used to steal this slot and hide the command's own verbs.
+    if (( COMP_CWORD > 1 )) && grep -q -m 1 '^# omarchy:hidden=true' "$file" 2>/dev/null; then
+      continue
+    fi
     basename="${file##*/}"
     rest="${basename#"$prefix"-}"
     next="${rest%%-*}"
@@ -33,88 +191,44 @@ _omarchy_complete() {
   shopt -u nullglob
 
   if (( COMP_CWORD == 1 )); then
-    candidates+=("commands")
+    _omarchy_add_candidates commands
   fi
 
   if [[ ${COMP_WORDS[1]:-} == "commands" ]] && (( COMP_CWORD >= 2 )); then
-    candidates+=("--all" "--json" "--markdown" "--check")
+    _omarchy_add_candidates --all --json --markdown --check
   fi
 
-  if (( ${#candidates[@]} == 0 )); then
-    local command_prefix command_path first_arg_index n j
-    for ((n = COMP_CWORD - 1; n >= 0; n--)); do
-      command_prefix="omarchy"
-      for ((j = 1; j <= n; j++)); do
-        part="${COMP_WORDS[j]}"
-        [[ -z $part || $part == -* ]] && continue
-        command_prefix+="-$part"
-      done
-
-      command_path="$bin_dir/$command_prefix"
-      if [[ -x $command_path ]]; then
-        first_arg_index=$((n + 1))
-        break
-      fi
+  local command_prefix command_path first_arg_index n j
+  for ((n = COMP_CWORD - 1; n >= 0; n--)); do
+    command_prefix="omarchy"
+    for ((j = 1; j <= n; j++)); do
+      part="${COMP_WORDS[j]}"
+      [[ -z $part || $part == -* ]] && continue
+      command_prefix+="-$part"
     done
 
-    if [[ -n ${command_path:-} && -x $command_path ]]; then
-      local args spec alt token actual alts value match current_arg_index
-      args=$(grep -m 1 '^# omarchy:args=' "$command_path" 2>/dev/null)
-      args="${args#*omarchy:args=}"
-      current_arg_index=$((COMP_CWORD - first_arg_index))
-
-      alts="${args// | /$'\n'}"
-      while IFS= read -r alt; do
-        read -r -a spec <<<"$alt"
-        match=true
-
-        for ((j = 0; j < current_arg_index; j++)); do
-          token="${spec[j]:-}"
-          actual="${COMP_WORDS[first_arg_index + j]:-}"
-          if [[ -z $token ]]; then
-            match=false
-            break
-          fi
-
-          if [[ $token == \<*\> || $token == \[*\] ]]; then
-            value="${token#<}"
-            value="${value#\[}"
-            value="${value%>}"
-            value="${value%\]}"
-            if [[ $value == *"|"* ]]; then
-              [[ " ${value//|/ } " == *" $actual "* ]] || match=false
-            fi
-          elif [[ $token != "$actual" ]]; then
-            match=false
-          fi
-        done
-
-        [[ $match == true ]] || continue
-
-        token="${spec[current_arg_index]:-}"
-        [[ -n $token ]] || continue
-
-        if [[ $token == \<*\> || $token == \[*\] ]]; then
-          value="${token#<}"
-          value="${value#\[}"
-          value="${value%>}"
-          value="${value%\]}"
-          if [[ $value == *"|"* ]]; then
-            read -r -a spec <<<"${value//|/ }"
-            for actual in "${spec[@]}"; do
-              [[ -n ${seen[$actual]:-} ]] && continue
-              seen[$actual]=1
-              candidates+=("$actual")
-            done
-          fi
-        else
-          [[ -n ${seen[$token]:-} ]] && continue
-          seen[$token]=1
-          candidates+=("$token")
-        fi
-      done <<<"$alts"
+    command_path="$bin_dir/$command_prefix"
+    if [[ -x $command_path ]]; then
+      first_arg_index=$((n + 1))
+      break
     fi
+  done
+
+  # Always merge args-spec literals with glob hits. Otherwise a hidden child
+  # binary (or any omarchy-<cmd>-*) hides verbs declared on omarchy-<cmd>.
+  if [[ -n ${command_path:-} && -x $command_path ]]; then
+    _omarchy_add_args_from "$command_path" "$first_arg_index"
   fi
+
+  local prev="${COMP_WORDS[COMP_CWORD - 1]:-}"
+  case "$prev" in
+  --section | --from-section)
+    _omarchy_add_candidates left center right
+    ;;
+  --before | --after)
+    _omarchy_add_bar_layout_ids
+    ;;
+  esac
 
   if (( ${#candidates[@]} > 0 )); then
     local IFS=$'\n'

--- a/test/shell.d/cli-completions-test.sh
+++ b/test/shell.d/cli-completions-test.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_home=$(mktemp -d)
+trap 'rm -rf "$test_home"' EXIT
+
+export HOME="$test_home"
+export OMARCHY_PATH="$ROOT"
+export PATH="$ROOT/bin:$PATH"
+unset XDG_CONFIG_HOME
+
+mkdir -p "$test_home/.config/omarchy/plugins/acme.weather" \
+  "$test_home/.config/omarchy/plugins/acme.neon-bar"
+
+cat >"$test_home/.config/omarchy/plugins/acme.weather/manifest.json" <<'JSON'
+{
+  "schemaVersion": 1,
+  "id": "acme.weather",
+  "name": "Weather",
+  "kinds": ["bar-widget"],
+  "entryPoints": { "barWidget": "BarWidget.qml" },
+  "barWidget": { "displayName": "Weather", "defaultSection": "center" }
+}
+JSON
+
+cat >"$test_home/.config/omarchy/plugins/acme.neon-bar/manifest.json" <<'JSON'
+{
+  "schemaVersion": 1,
+  "id": "acme.neon-bar",
+  "name": "Neon bar",
+  "kinds": ["bar"],
+  "entryPoints": { "bar": "Bar.qml" }
+}
+JSON
+
+cat >"$test_home/.config/omarchy/shell.json" <<'JSON'
+{
+  "version": 1,
+  "bar": {
+    "layout": {
+      "left": [{ "id": "omarchy.clock" }],
+      "center": [],
+      "right": ["acme.weather"]
+    }
+  }
+}
+JSON
+
+source "$ROOT/default/bash/completions"
+
+complete_omarchy() {
+  local line="$1"
+  COMP_LINE="$line"
+  COMP_POINT=${#line}
+  read -r -a COMP_WORDS <<<"$line"
+  if [[ $line == *" " ]]; then
+    COMP_WORDS+=("")
+  fi
+  COMP_CWORD=$((${#COMP_WORDS[@]} - 1))
+  COMPREPLY=()
+  set +e
+  _omarchy_complete
+  set -e
+}
+
+has_reply() {
+  local want="$1"
+  local got
+  for got in "${COMPREPLY[@]+"${COMPREPLY[@]}"}"; do
+    [[ $got == "$want" ]] && return 0
+  done
+  return 1
+}
+
+assert_has() {
+  local want="$1"
+  local line="$2"
+  has_reply "$want" || fail "completion for [$line] includes $want" "${COMPREPLY[*]:-<none>}"
+}
+
+assert_lacks() {
+  local want="$1"
+  local line="$2"
+  has_reply "$want" && fail "completion for [$line] does not include $want" "${COMPREPLY[*]:-<none>}"
+  return 0
+}
+
+complete_omarchy "omarchy bar "
+assert_has set "omarchy bar "
+assert_has move "omarchy bar "
+assert_has put "omarchy bar "
+assert_has use "omarchy bar "
+assert_has position "omarchy bar "
+assert_lacks text "omarchy bar "
+pass "omarchy bar completes its verbs instead of hidden bar-text-color"
+
+complete_omarchy "omarchy bar s"
+assert_has set "omarchy bar s"
+assert_lacks text "omarchy bar s"
+pass "omarchy bar s completes set"
+
+complete_omarchy "omarchy bar position "
+assert_has top "omarchy bar position "
+assert_has bottom "omarchy bar position "
+pass "omarchy bar position completes edges"
+
+complete_omarchy "omarchy bar set "
+assert_has omarchy.clock "omarchy bar set "
+assert_has acme.weather "omarchy bar set "
+assert_lacks omarchy.media "omarchy bar set "
+assert_lacks acme.neon-bar "omarchy bar set "
+pass "omarchy bar set completes widgets on the bar"
+
+complete_omarchy "omarchy bar move "
+assert_has omarchy.clock "omarchy bar move "
+assert_lacks omarchy.media "omarchy bar move "
+pass "omarchy bar move completes widgets on the bar"
+
+complete_omarchy "omarchy bar put "
+assert_has omarchy.clock "omarchy bar put "
+assert_has omarchy.media "omarchy bar put "
+assert_has acme.weather "omarchy bar put "
+assert_lacks acme.neon-bar "omarchy bar put "
+pass "omarchy bar put completes bar-widget plugin ids"
+
+complete_omarchy "omarchy bar use "
+assert_has omarchy.bar "omarchy bar use "
+assert_has acme.neon-bar "omarchy bar use "
+assert_lacks omarchy.clock "omarchy bar use "
+pass "omarchy bar use completes bar option ids"
+
+complete_omarchy "omarchy bar set omarchy.clock format HH:mm "
+assert_has --json "omarchy bar set omarchy.clock format HH:mm "
+assert_has --section "omarchy bar set omarchy.clock format HH:mm "
+pass "omarchy bar set offers --json and placement flags after the value"
+
+complete_omarchy "omarchy bar move omarchy.clock --section "
+assert_has left "omarchy bar move omarchy.clock --section "
+assert_has center "omarchy bar move omarchy.clock --section "
+assert_has right "omarchy bar move omarchy.clock --section "
+pass "omarchy bar --section completes left/center/right"
+
+complete_omarchy "omarchy bar put omarchy.media --after "
+assert_has omarchy.clock "omarchy bar put omarchy.media --after "
+assert_has acme.weather "omarchy bar put omarchy.media --after "
+pass "omarchy bar --after completes widgets on the bar"
+
+complete_omarchy "omarchy plugin "
+assert_has enable "omarchy plugin "
+assert_has disable "omarchy plugin "
+assert_has clone "omarchy plugin "
+assert_lacks catalog "omarchy plugin "
+pass "omarchy plugin completes its verbs and hides catalog"
+
+complete_omarchy "omarchy plugin enable "
+assert_has acme.weather "omarchy plugin enable "
+assert_has acme.neon-bar "omarchy plugin enable "
+assert_has omarchy.clock "omarchy plugin enable "
+pass "omarchy plugin enable completes catalog ids"
+
+complete_omarchy "omarchy plugin disable "
+assert_has acme.weather "omarchy plugin disable "
+assert_has omarchy.clock "omarchy plugin disable "
+pass "omarchy plugin disable completes catalog ids"
+
+complete_omarchy "omarchy plugin clone "
+assert_has omarchy.clock "omarchy plugin clone "
+assert_lacks acme.weather "omarchy plugin clone "
+pass "omarchy plugin clone completes first-party plugin ids"
+
+complete_omarchy "omarchy plugin remove "
+assert_has acme.weather "omarchy plugin remove "
+assert_has acme.neon-bar "omarchy plugin remove "
+assert_lacks omarchy.clock "omarchy plugin remove "
+pass "omarchy plugin remove completes installed user plugin ids"


### PR DESCRIPTION
## Problem

`omarchy bar set` never autocompleted. Two reasons, neither of them a bash limitation:

1. The completer globbed `omarchy-bar-*` first. `omarchy-bar-text-color` made `omarchy bar <tab>` offer only `text`, so the args spec on `omarchy-bar` (`set`, `move`, `put`, …) was never consulted.
2. Even after typing `set` by hand, `<id>` is an opaque placeholder. Widget ids live in `shell.json` and the plugin catalog, and the completer never looked them up.

## Change

- Always merge `# omarchy:args=` literals with glob hits, so a sibling binary cannot hide a command's own verbs.
- Skip hidden children once a group is selected (`omarchy-bar-text-color`, `omarchy-plugin-catalog`).
- Fill `<id>` from cheap JSON:
  - `bar set` / `bar move` / `--before` / `--after`: widgets already on the bar (`~/.config/omarchy/shell.json`, ~2ms)
  - `bar put`: catalog ids with `kinds: ["bar-widget"]`
  - `bar use`: catalog ids with `kinds: ["bar"]`
  - `plugin enable` / `disable`: catalog ids
  - `plugin clone`: first-party catalog ids
  - `plugin remove` / `update`: `~/.config/omarchy/plugins/*`
- Also complete `--json` and placement flags (`--section left|center|right`, …).

`omarchy-plugin-catalog` is ~13ms for 60 plugins on this machine. Tab completion feels slow around 100ms, so this does not load QML or talk to the running shell.

Setting *keys* (`symbols`, `format`, …) are still not completed. Those are schema-less writes on the layout entry, and most plugins (including first-party `omarchy.clock`) do not declare `barWidget.schema`. That can be a follow-up.

## Tests

`test/shell.d/cli-completions-test.sh` covers the collision, layout vs catalog id sets, and plugin verbs.

`./test/cli` passed. `./test/shell` failures here are the usual missing `omarchy-pkgs` checkout / unrelated guards, not this change.