### PR TITLE
Auto-create /etc/1password/custom_allowed_browsers on install

### DIFF
--- a/bin/omarchy-install-service-1password
+++ b/bin/omarchy-install-service-1password
@@ -24,6 +24,10 @@ install_chromium_extension() {
 echo "Installing 1Password..."
 omarchy-pkg-add 1password 1password-cli
 
+echo "Configuring 1Password custom allowed browsers..."
+sudo mkdir -p /etc/1password
+sudo touch /etc/1password/custom_allowed_browsers
+
 echo "Installing 1Password extension for Chromium..."
 install_chromium_extension
 


### PR DESCRIPTION
## Problem

The current out-of-box experience for 1Password browser integration is less than ideal for non-Chromium browsers (e.g. Zen Browser). The user gets no clear error, the browser extension simply doesn't connect. To fix it, the user has to:

1. Realize the issue is a missing allowed-browsers file (not obvious from 1Password's UI)
2. Hunt down https://support.1password.com/additional-browsers/?linux to learn the mechanism
3. Manually run `sudo mkdir /etc/1password` and `sudo touch /etc/1password/custom_allowed_browsers`

This is unnecessary troubleshooting friction that can be eliminated at install time.

## Fix

Create `/etc/1password/custom_allowed_browsers` (and its parent directory) automatically during `omarchy-install-service-1password`. The directory and file need to exist before users or future scripts can populate it with browser hashes.

> **Note:** This PR creates the scaffolding only — the file is intentionally left empty. A follow-up can extend the installer to detect Zen Browser and write its binary hash into the file automatically.

## References

- https://support.1password.com/additional-browsers/?linux


- https://docs.zen-browser.app/guides/1password

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwwncBCa5nQpFy3apgqxvw

<img width="1335" height="825" alt="screenshot-2026-08-29_18-51-45" src="https://github.com/user-attachments/assets/203682b1-9dea-41a9-a642-924d9ca57979" />
