### PR TITLE
hypr: add idle_inhibit rule for VLC media player

### DIFF
--- a/default/hypr/apps/vlc.lua
+++ b/default/hypr/apps/vlc.lua
@@ -1,0 +1,1 @@
+o.window("vlc", { idle_inhibit = "focus" })


### PR DESCRIPTION
### Summary
    Prevents the screensaver and idle lock from activating during
  video playback in VLC media player.

    ### Details
    VLC 3.x on Arch runs under XWayland and relies on legacy X11/D-Bus
  screensaver calls, which do not emit native Wayland idle inhibition
  signals to Hyprland. Adding `idle_inhibit = "focus"` ensures idle is
  inhibited while VLC is active and focused.