### PR TITLE
Stop menu commands waiting forever for an answer that never comes

### DIFF
--- a/bin/omarchy-menu-handshake
+++ b/bin/omarchy-menu-handshake
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# omarchy:summary=Shared tempfile handshake for the menu commands (source this, don't run it).
+# omarchy:hidden=true
+
+# The menu commands hand the shell a done file and block until it appears. The
+# shell is the only writer, so when it goes away between the request and the
+# write -- a crash, a theme change, or omarchy-restart-shell -- nothing ever
+# completes the handshake, and a plain `while [[ ! -e $done_file ]]` waits for
+# the life of the session. Left alone these accumulate: each survivor wakes 20
+# to 100 times a second and holds the CPU out of its deeper idle states, so a
+# handful are enough to spin up the fans on an otherwise idle machine.
+#
+# Watching which shell owns the request, rather than only whether some shell is
+# running, also covers the restart case: a fresh instance answers IPC happily
+# but knows nothing about a menu the previous one was asked for, so it will
+# never write that done file either.
+
+# Print the pid of the Quickshell instance serving $OMARCHY_PATH.
+# Matches on the process name so the lookup cannot match its own caller the way
+# a `pgrep -f` over the command line would.
+menu_shell_pid() {
+  local pid
+
+  for pid in $(pgrep -x quickshell); do
+    if tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null | grep -q -- "$OMARCHY_PATH/shell"; then
+      echo "$pid"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# Block until the shell completes the handshake for $done_file.
+# Returns 1 if the shell that owned the request exits first.
+wait_for_menu_done() {
+  local done_file=$1 shell_pid=$2 interval=${3:-0.05}
+  local last_check=$SECONDS
+
+  while [[ ! -e $done_file ]]; do
+    sleep "$interval"
+
+    # Check the owner about once a second rather than every tick, so the file
+    # test stays the fast path for a menu somebody is actively using.
+    if (( SECONDS != last_check )); then
+      last_check=$SECONDS
+
+      if ! kill -0 "$shell_pid" 2>/dev/null; then
+        if [[ -e $done_file ]]; then
+          # It wrote the file and exited between our two checks.
+          break
+        else
+          echo "${0##*/}: the shell exited before answering" >&2
+          return 1
+        fi
+      fi
+    fi
+  done
+
+  return 0
+}

--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -3,6 +3,8 @@
 # omarchy:summary=Open a generic image selector menu
 # omarchy:args=[--selected <image>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>...
 
+source omarchy-menu-handshake
+
 selected_image=""
 print_name=false
 show_labels=false
@@ -281,6 +283,11 @@ if [[ $preload == true ]]; then
   exit 0
 fi
 
+if ! shell_pid=$(menu_shell_pid); then
+  echo "Image selector failed to accept request" >&2
+  exit 1
+fi
+
 if ! open_result=$(omarchy-shell image-selector open \
      "" \
      "$rows_b64" \
@@ -298,9 +305,9 @@ if [[ $open_result != "ok" ]]; then
   exit 1
 fi
 
-while [[ ! -e $done_file ]]; do
-  sleep 0.01
-done
+if ! wait_for_menu_done "$done_file" "$shell_pid" 0.01; then
+  exit 1
+fi
 
 if [[ -s $selection_file ]]; then
   if [[ $print_name == true ]]; then

--- a/bin/omarchy-menu-input
+++ b/bin/omarchy-menu-input
@@ -8,6 +8,8 @@
 
 set -euo pipefail
 
+source omarchy-menu-handshake
+
 prompt="${1:-Input}"
 if (( $# > 0 )); then
   shift
@@ -45,11 +47,19 @@ payload=$(perl -MEncode=decode -MJSON::PP=encode_json -e '
   print encode_json($payload)
 ' "$prompt" "$selection_file" "$done_file" "$menu_width")
 
-omarchy-shell shell summon omarchy.menu "$payload" >/dev/null
+if ! shell_pid=$(menu_shell_pid); then
+  echo "${0##*/}: no running Omarchy shell to show the menu" >&2
+  exit 1
+fi
 
-while [[ ! -e $done_file ]]; do
-  sleep 0.05
-done
+if ! omarchy-shell shell summon omarchy.menu "$payload" >/dev/null; then
+  echo "${0##*/}: the shell did not accept the menu request" >&2
+  exit 1
+fi
+
+if ! wait_for_menu_done "$done_file" "$shell_pid"; then
+  exit 1
+fi
 
 if [[ -s $selection_file ]]; then
   cat "$selection_file"

--- a/bin/omarchy-menu-select
+++ b/bin/omarchy-menu-select
@@ -14,6 +14,8 @@
 
 set -euo pipefail
 
+source omarchy-menu-handshake
+
 if (( $# < 1 )); then
   echo "Usage: omarchy-menu-select <prompt> [option...] [-- menu args...]" >&2
   exit 1
@@ -86,11 +88,19 @@ payload=$(perl -MEncode=decode -MJSON::PP=encode_json,decode_json -e '
   print encode_json($payload)
 ' "$prompt" "$options_json" "$selection_file" "$done_file" "$menu_width" "$menu_maxheight")
 
-omarchy-shell shell summon omarchy.menu "$payload" >/dev/null
+if ! shell_pid=$(menu_shell_pid); then
+  echo "${0##*/}: no running Omarchy shell to show the menu" >&2
+  exit 1
+fi
 
-while [[ ! -e $done_file ]]; do
-  sleep 0.05
-done
+if ! omarchy-shell shell summon omarchy.menu "$payload" >/dev/null; then
+  echo "${0##*/}: the shell did not accept the menu request" >&2
+  exit 1
+fi
+
+if ! wait_for_menu_done "$done_file" "$shell_pid"; then
+  exit 1
+fi
 
 if [[ -s $selection_file ]]; then
   cat "$selection_file"

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -68,6 +68,7 @@ Item {
   property bool cursorActive: false
   property int requestSerial: 0
   property int applySerial: 0
+  property var doneFilesToRelease: []
   property var items: ({})
   property var itemOrder: []
   property var navStack: []
@@ -132,6 +133,22 @@ Item {
       resultProc.command = ["bash", "-c", "printf '%s\\n' " + Util.shellQuote(selection) + " > " + Util.shellQuote(activeSelectionFile) + "; : > " + Util.shellQuote(activeDoneFile)]
     }
     resultProc.running = true
+  }
+
+  // Releasing a done file uses its own process and queue so it can never race
+  // resultProc, which may still be writing the result of an earlier request.
+  function releaseNextDoneFile() {
+    if (releaseProc.running || doneFilesToRelease.length === 0) return
+
+    var path = doneFilesToRelease.shift()
+    releaseProc.command = ["bash", "-c", ": > " + Util.shellQuote(path)]
+    releaseProc.running = true
+  }
+
+  function finishDoneFile(path) {
+    if (!path) return
+    doneFilesToRelease.push(path)
+    releaseNextDoneFile()
   }
 
   function runAction(action) {
@@ -859,12 +876,20 @@ Item {
   }
 
   function openDmenu(payload) {
+    // This overwrites the request fields wholesale, so a request still waiting
+    // on an answer loses its slot here. Nothing would ever write its done file
+    // and its caller would wait for the life of the session, so retire it
+    // first -- the same guard ImagePicker.openSelector already makes.
+    var nextDoneFile = String(payload.doneFile || "")
+    if (requestActive && doneFile && doneFile !== nextDoneFile)
+      finishDoneFile(doneFile)
+
     requestSerial += 1
     mode = payload.mode === "input" ? "input" : "select"
     dmenuPrompt = String(payload.prompt || (mode === "input" ? "Input" : "Select"))
     dmenuOptions = Array.isArray(payload.options) ? payload.options : []
     selectionFile = String(payload.selectionFile || "")
-    doneFile = String(payload.doneFile || "")
+    doneFile = nextDoneFile
     requestActive = !!doneFile
     dmenuWidth = Math.max(1, Number(payload.width || 300))
     dmenuMaxHeight = Math.max(0, Number(payload.maxHeight || 0))
@@ -937,6 +962,11 @@ Item {
       }
       root.startNextProvider()
     }
+  }
+
+  Process {
+    id: releaseProc
+    onExited: root.releaseNextDoneFile()
   }
 
   Process {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -852,6 +852,13 @@ Item {
   }
 
   function openExistingMenu(initialMenu) {
+    // Turning back into a regular menu drops any request still waiting on an
+    // answer. Setting mode first also clears dmenuActive, so a later cancel()
+    // would not finish it either -- retire it here or its caller waits for
+    // the life of the session.
+    if (requestActive && doneFile)
+      finishDoneFile(doneFile)
+
     requestSerial += 1
     mode = "menu"
     requestActive = false

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -411,6 +411,10 @@ assert(
   'released done files queue behind their own process so they cannot race a result still being written'
 )
 assert(
+  /function openExistingMenu\(initialMenu\) \{[\s\S]*?if \(requestActive && doneFile\)\s*\n\s*finishDoneFile\(doneFile\)[\s\S]*?mode = "menu"/.test(menuQml),
+  'turning back into a regular menu retires a pending request, which clearing dmenuActive would otherwise strand beyond the reach of cancel()'
+)
+assert(
   /omarchy-launch-floating-terminal-with-presentation "omarchy-plugin-remove/.test(pluginPicker),
   'plugin picker removes where the confirmation and backup path are visible'
 )

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -402,6 +402,15 @@ assert(
   'menu select mode reads a leading icon and a trailing subtext off an option'
 )
 assert(
+  /function openDmenu\(payload\) \{[\s\S]*?if \(requestActive && doneFile && doneFile !== nextDoneFile\)\s*\n\s*finishDoneFile\(doneFile\)/.test(menuQml),
+  'a dmenu request that displaces another retires it, so the caller it replaced stops waiting on a done file nobody will write'
+)
+assert(
+  /function finishDoneFile\(path\)[\s\S]*?doneFilesToRelease\.push\(path\)/.test(menuQml)
+    && /function releaseNextDoneFile\(\)[\s\S]*?if \(releaseProc\.running \|\| doneFilesToRelease\.length === 0\) return/.test(menuQml),
+  'released done files queue behind their own process so they cannot race a result still being written'
+)
+assert(
   /omarchy-launch-floating-terminal-with-presentation "omarchy-plugin-remove/.test(pluginPicker),
   'plugin picker removes where the confirmation and backup path are visible'
 )


### PR DESCRIPTION
## The problem

`omarchy-menu-select`, `omarchy-menu-input`, and `omarchy-menu-images` hand the shell a done file and then block until it appears:

```bash
omarchy-shell shell summon omarchy.menu "$payload" >/dev/null

while [[ ! -e $done_file ]]; do
  sleep 0.05
done
```

The shell is the only thing that ever creates that file. If it goes away between the summon and the write — a crash, a theme change, `omarchy-restart-shell` — nothing completes the handshake and the loop runs for the life of the session. Nothing upstream of it notices, because the parent menu script is blocked on the same wait.

Two related gaps in the same few lines:

- the `summon` exit status is discarded, so a request the shell never accepted falls into the identical wait
- a shell *restart* is invisible even to a liveness check: the new instance answers IPC normally but knows nothing about a menu the previous one was summoned for, so it will never write that done file either

## How it showed up

Four of these, 74–80 minutes old, on an idle laptop:

```
11485  omarchy-menu-keybindings
11750   └─ omarchy-menu-keybindings
11752       └─ omarchy-menu-select Keybindings -- --width 800 --height 500   (01:20:58)
14695  ... x3 more identical chains
```

`quickshell` had started at 16:58:53; the three oldest waiters were summoned at 16:53–16:54, so the instance that owned their menus was gone. They had been polling ever since.

Individually they are ~1% CPU, which is easy to miss. Collectively they were adding ~1,200 context switches/sec and keeping cores out of their deeper idle states. Killing the twelve processes took the package temperature from 85°C to 71°C and dropped context switches from 3,450/s to 2,252/s, on a machine where the busiest process was otherwise 3%. The visible symptom was fans at ~5,000 RPM with nothing running.

The image selector polls at `sleep 0.01`, so a stuck one of those spins at 100 Hz.

## The change

Moves the handshake into a shared, hidden `omarchy-menu-handshake` (following the `omarchy-shell-config` precedent) and gives it two things the inline loop lacked:

- **`menu_shell_pid`** — resolves the Quickshell instance serving `$OMARCHY_PATH`. It matches on the process name via `pgrep -x` rather than `pgrep -f` over the command line, which would otherwise match the caller's own shell.
- **`wait_for_menu_done`** — polls the done file as before, but re-checks about once a second that the *specific* instance that owned the request is still alive, and gives up when it is not. Using the pid as the identity covers restarts as well as crashes. It uses `SECONDS` for that cadence so the existing 0.05 s and 0.01 s intervals both keep their responsiveness.

A failed `summon` now reports and exits instead of falling into the wait.

The file test stays the fast path, so an interactive menu is as responsive as before; the liveness check only runs on the once-a-second tick.

## Testing

`test/cli` passes, including `all executable bins have slim self-documenting metadata`.

Nine unit tests against the helper on a live Omarchy session, all passing:

| Case | Expected | Result |
|---|---|---|
| `menu_shell_pid` finds the running shell | pid of `quickshell` | pass |
| done file appears normally | returns 0 promptly | pass |
| **shell dies mid-wait, done file never written** | **returns 1, does not spin** | **pass** |
| shell already gone before the wait starts | returns 1 | pass |
| shell writes the done file then dies immediately | still returns 0 | pass |

The third case is the bug. Against the original loop the same scenario was still spinning when a 6-second cap killed it (`exit=124`); with the change it gives up in under 5 seconds.

End to end on a live session, opening a menu and then running `omarchy-restart-shell` under it:

```
=== control (packaged bin) ===
  menu is open (pid 582420), restarting shell...
  RESULT: STILL RUNNING after 12s -> stuck waiter

=== patched ===
  menu is open (pid 584865), restarting shell...
  RESULT: exited after ~1s, rc=1
  stderr: omarchy-menu-select: the shell exited before answering
```

---

## Second cause: a request displaced by the next one

Running the first commit on a live machine turned up a waiter that survived it: 82 minutes old, with the *same* Quickshell instance up the whole time, so the liveness check was correctly seeing a healthy owner and waiting.

`Menu.qml`'s `openDmenu` overwrites the request fields wholesale:

```qml
function openDmenu(payload) {
  requestSerial += 1
  ...
  selectionFile = String(payload.selectionFile || "")
  doneFile = String(payload.doneFile || "")
  requestActive = !!doneFile
```

A request still waiting for an answer loses its slot right there. Nothing is left holding its done file, so nobody will ever write it and its caller waits for the life of the session. Opening the same menu twice in a row is enough — which makes this a more common way to strand a waiter than a shell restart, and it explains the original report, where three near-identical keybindings chains were summoned within about a minute of each other and all three were still waiting an hour later.

`ImagePicker.openSelector` already guards exactly this:

```qml
if (requestActive && doneFile && doneFile !== nextDoneFile)
  finishDoneFile(doneFile)
```

The menu plugin never got the same treatment. The second commit adds it, along with the release queue and dedicated process that make it safe — a displaced done file must not be written through `resultProc`, which may still be writing the result of an earlier request.

The two commits cover different halves and neither subsumes the other: supersession strands a waiter while the shell is perfectly healthy, and a crash or restart strands one that nothing is going to displace.

### Tests

`test/shell.d/menu-test.sh` gains two assertions, in the file's existing style. Verified they fail against the unfixed `Menu.qml` and pass with it:

```
not ok - a dmenu request that displaces another retires it, ...   (without the fix)
ok     - a dmenu request that displaces another retires it, ...   (with it)
ok     - released done files queue behind their own process ...
```

Full `test/shell` run: **2692 passing, 5 failing**. None of the five come from this branch — every one of them reproduces identically on pristine `c720f0b9` in a clean worktree:

- `omarchy-pkgs checkout ...` (×3) — wants a sibling `omarchy-pkgs` checkout this machine does not have
- `each widget registers its IPC handler once per screen (saw 6 for 3 screen(s))` — pre-existing
- `omarchy-theme-install refuses a URL it cannot check` — pre-existing


---

## Third cause: a request stranded by returning to a regular route

Auditing for other instances of the same shape turned up one more, and it is the worst of the three.

```qml
function openExistingMenu(initialMenu) {
  requestSerial += 1
  mode = "menu"
  requestActive = false
  selectionFile = ""
  doneFile = ""
```

`openRoute` reaches this whenever the menu opens on a normal route, so summoning the menu while a select or input is pending drops that request. Worse, `mode` is set to `"menu"` before the clear, which takes `dmenuActive` false — so `cancel()`'s `if (root.dmenuActive) root.finishRequest(null)` no longer recognises it, and nothing can retire it afterwards. Unlike the supersession case there is no later event that cleans up.

The third commit finishes the pending request before those fields are cleared.

### Audit

I swept for the general shape — blocking on something another process must produce, with no guard for it never arriving — rather than for copies of the loop:

- The handshake exists in exactly three commands (`omarchy-menu-select`, `-input`, `-images`), all now sharing `omarchy-menu-handshake`, and three QML files.
- `ImagePicker.qml` is correct at all four of its clearing sites; it finishes the pending request before clearing every time. It was already the reference implementation.
- `Menu.qml` had three sites: `finishRequest` was correct, `openDmenu` and `openExistingMenu` were not. Both are fixed here.
- Other waiting loops were checked and are sound: `omarchy-screensaver`'s terminal-resize wait is bounded by a deadline, `omarchy-provision-owner`'s retry is interactive with a console escape, and `compositor_alive` is bounded to three attempts.

### Known remaining edge

If the menu plugin itself is destroyed while a request is pending (`rescanPlugins`, or disabling the plugin), the caller is still stranded: Quickshell is alive, so the process check sees a healthy owner, and there is no `Component.onDestruction` hook. I have not tried to patch it here, since writing a file through a `Process` while the component is being torn down is not reliable. Flagging it rather than shipping a guard that only looks like one.

Each of the three commits has a regression test in `test/shell.d/menu-test.sh`, and I verified each one fails against the unfixed source and passes with it.