### PR TITLE
Move screenrecording state files out of predictable /tmp paths

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -15,8 +15,9 @@
 # start.
 #
 # Env: OMARCHY_SCREENRECORD_DEBUG=true appends gpu-screen-recorder's stderr (and
-# the picker target it was launched with) to /tmp/omarchy-screenrecord.log so
-# users can attach a log when reporting capture failures.
+# the picker target it was launched with) to omarchy-screenrecord.log in
+# ${XDG_RUNTIME_DIR:-/tmp} so users can attach a log when reporting capture
+# failures.
 
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR:-$HOME/Videos}}"
@@ -34,9 +35,9 @@ WEBCAM_SIZE="medium"
 RESOLUTION=""
 FULLSCREEN="false"
 STOP_RECORDING="false"
-RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
+RECORDING_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-filename"
 REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
-LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "/tmp/omarchy-screenrecord.log" || echo "/dev/null")
+LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord.log" || echo "/dev/null")
 
 for arg in "$@"; do
   case "$arg" in

--- a/default/agents/skills/omarchy/capture.md
+++ b/default/agents/skills/omarchy/capture.md
@@ -33,8 +33,8 @@ Recordings land in the configured Videos directory (override with
 `omarchy capture webcam resize <smaller|larger|reset|small|medium|large>`.
 
 If recording fails to start, rerun with `OMARCHY_SCREENRECORD_DEBUG=true` to
-collect a log at `/tmp/omarchy-screenrecord.log` worth attaching to a bug
-report.
+collect a log at `${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord.log` worth
+attaching to a bug report.
 
 ## Text Capture (OCR)
 

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -38,7 +38,8 @@ drag-and-drop in the web form, so save the capture and hand the user the file
 path to attach (`gh` cannot upload media).
 
 For screen-recording failures specifically, rerun with
-`OMARCHY_SCREENRECORD_DEBUG=true` and attach `/tmp/omarchy-screenrecord.log`.
+`OMARCHY_SCREENRECORD_DEBUG=true` and attach the `omarchy-screenrecord.log`
+file in `${XDG_RUNTIME_DIR:-/tmp}`.
 
 File the issue with `gh` when available:
 


### PR DESCRIPTION
Fixes #8372

## Problem

RECORDING_FILE was pinned to a fixed /tmp path, and the debug LOG_FILE as well. In a world-writable directory any local user can pre-create or truncate those paths between the writing and the reading, since the same path is reused across runs.

When the recording user stops a recording, stop_screenrecording reads that file and feeds its content into finalize_recording, which drives ffmpeg -y -i <path>, mv, and rm -f based on the stored path. A planted path can therefore redirect those operations at files owned by the recording user. The fixed /tmp debug log is the same family of issue: a local user can pre-create or truncate it, and the recording process appends to whatever that path points at.

## Fix

Move both files to the same uid-scoped location REGION_FILE already uses in this script and omarchy-update-stay-awake uses elsewhere:

- RECORDING_FILE -> ${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-filename
- LOG_FILE -> ${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord.log

XDG_RUNTIME_DIR is user-private (mode 0700, owned by the user), so a local attacker can no longer pre-create or truncate these paths. REGION_FILE in the same script already used exactly this pattern, so this makes the three state files consistent.

Also updated the two docs that referenced the fixed /tmp log path (default/agents/skills/omarchy/capture.md and contributing.md).

## Testing

- bash -n clean on the modified script
- test/shell.d/screenrecording-test.sh passes (18/18 assertions)
- test/shell.d/logging-test.sh passes
- ./test/cli passes
- Full ./test/shell run: 2571 assertions pass; the 19 failing files on this headless container are pre-existing environmental failures (missing lua, fonts, compositor) and fail identically on an unpatched checkout of the same commit.
