### PR TITLE
Clean up 1Password integrations on removal

### DIFF
--- a/bin/omarchy-remove-launcher-entry
+++ b/bin/omarchy-remove-launcher-entry
@@ -67,6 +67,10 @@ desktop_name="${desktop_file##*/}"
 desktop_name="${desktop_name%.desktop}"
 exec_line="$(sed -n 's/^Exec=//p' "$desktop_file" | head -1)"
 
+if [[ $desktop_file_name == "1password.desktop" ]]; then
+  exec omarchy-remove-service-1password
+fi
+
 if [[ $exec_line =~ omarchy-launch-webapp|omarchy-webapp-handler ]]; then
   OMARCHY_REMOVE_NOTIFY=false omarchy-webapp-remove "$desktop_name"
   exit 0

--- a/bin/omarchy-remove-service-1password
+++ b/bin/omarchy-remove-service-1password
@@ -5,8 +5,16 @@
 
 EXTENSION_ID="aeblfdkhhhdcdjpifhhbdiojplfjncoa"
 EXTENSION_FILE="/usr/share/chromium/extensions/$EXTENSION_ID.json"
+NATIVE_MESSAGING_MANIFEST="com.1password.1password.json"
 
 sudo rm -f "$EXTENSION_FILE"
+
+# Browsers keep the native-messaging registration in the user's profile, so
+# removing the packages alone leaves them pointing at the missing app.
+if [[ -d $HOME/.config ]]; then
+  find "$HOME/.config" -path "*/NativeMessagingHosts/$NATIVE_MESSAGING_MANIFEST" -delete
+fi
+
 omarchy-pkg-drop 1password 1password-cli
 
 echo ""

--- a/test/shell.d/launcher-remove-test.sh
+++ b/test/shell.d/launcher-remove-test.sh
@@ -22,6 +22,7 @@ SCRIPT
 
 write_fake_command omarchy-webapp-remove web
 write_fake_command omarchy-tui-remove tui
+write_fake_command omarchy-remove-service-1password onepassword
 write_fake_command omarchy-launch-floating-terminal-with-presentation terminal
 
 cat >"$tmp_dir/bin/omarchy-notification-send" <<'SCRIPT'
@@ -56,6 +57,12 @@ Name=Docker
 Exec=xdg-terminal-exec --app-id=TUI.tile -e lazydocker
 DESKTOP
 
+cat >"$tmp_dir/system/applications/1password.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=1Password
+Exec=1password
+DESKTOP
+
 cat >"$tmp_dir/system/applications/native.desktop" <<'DESKTOP'
 [Desktop Entry]
 Name=Native
@@ -75,6 +82,7 @@ export XDG_DATA_DIRS="$tmp_dir/system"
 
 "$ROOT/bin/omarchy-remove-launcher-entry" Basecamp.desktop Basecamp
 "$ROOT/bin/omarchy-remove-launcher-entry" Docker.desktop Docker
+"$ROOT/bin/omarchy-remove-launcher-entry" 1password.desktop 1Password
 "$ROOT/bin/omarchy-remove-launcher-entry" native.desktop Native
 "$ROOT/bin/omarchy-remove-launcher-entry" aliens.desktop Aliens
 
@@ -86,11 +94,14 @@ pass "launcher remove routes web apps by desktop name"
 [[ ${lines[1]} == "tui:false:Docker" ]] || fail "launcher remove routes TUIs by desktop name" "${lines[1]}"
 pass "launcher remove routes TUIs by desktop name"
 
-[[ ${lines[2]} == "terminal::echo Uninstalling Native...; sudo pacman -Rns native-pkg" ]] || fail "launcher remove opens package uninstall flow" "${lines[2]}"
+[[ ${lines[2]} == "onepassword::" ]] || fail "launcher remove routes 1Password through its dedicated remover" "${lines[2]}"
+pass "launcher remove routes 1Password through its dedicated remover"
+
+[[ ${lines[3]} == "terminal::echo Uninstalling Native...; sudo pacman -Rns native-pkg" ]] || fail "launcher remove opens package uninstall flow" "${lines[3]}"
 pass "launcher remove opens package uninstall flow"
 
 [[ ! -e $tmp_dir/data/applications/aliens.desktop ]] || fail "launcher remove deletes user-owned desktop files"
 pass "launcher remove deletes user-owned desktop files"
 
-(( ${#lines[@]} == 3 )) || fail "launcher remove does not notify for user-owned desktop files" "$(printf '%s\n' "${lines[@]}")"
+(( ${#lines[@]} == 4 )) || fail "launcher remove does not notify for user-owned desktop files" "$(printf '%s\n' "${lines[@]}")"
 pass "launcher remove does not notify for user-owned desktop files"

--- a/test/shell.d/remove-service-1password-test.sh
+++ b/test/shell.d/remove-service-1password-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/home/.config/1Password"
+
+for browser_dir in \
+  chromium/NativeMessagingHosts \
+  google-chrome/Profile\ 1/NativeMessagingHosts \
+  BraveSoftware/Brave-Browser/NativeMessagingHosts \
+  microsoft-edge/NativeMessagingHosts \
+  vivaldi/NativeMessagingHosts; do
+  mkdir -p "$tmp_dir/home/.config/$browser_dir"
+  touch "$tmp_dir/home/.config/$browser_dir/com.1password.1password.json"
+done
+
+mkdir -p "$tmp_dir/home/.config/not-a-browser"
+touch "$tmp_dir/home/.config/not-a-browser/com.1password.1password.json"
+touch "$tmp_dir/home/.config/1Password/settings.json"
+
+cat >"$tmp_dir/bin/sudo" <<'SCRIPT'
+#!/bin/bash
+if [[ $1 == rm ]]; then
+  exit 0
+fi
+exec "$@"
+SCRIPT
+
+cat >"$tmp_dir/bin/omarchy-pkg-drop" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_LOG"
+SCRIPT
+
+chmod +x "$tmp_dir/bin/sudo" "$tmp_dir/bin/omarchy-pkg-drop"
+
+OMARCHY_TEST_LOG="$tmp_dir/pkg-drop.log" HOME="$tmp_dir/home" PATH="$tmp_dir/bin:$PATH" \
+  bash "$ROOT/bin/omarchy-remove-service-1password"
+
+for browser_dir in \
+  chromium/NativeMessagingHosts \
+  google-chrome/Profile\ 1/NativeMessagingHosts \
+  BraveSoftware/Brave-Browser/NativeMessagingHosts \
+  microsoft-edge/NativeMessagingHosts \
+  vivaldi/NativeMessagingHosts; do
+  [[ ! -e "$tmp_dir/home/.config/$browser_dir/com.1password.1password.json" ]] ||
+    fail "1Password removal deletes stale native-messaging manifests" "$browser_dir"
+done
+pass "1Password removal deletes stale native-messaging manifests"
+
+[[ -e "$tmp_dir/home/.config/not-a-browser/com.1password.1password.json" ]] ||
+  fail "1Password removal leaves unrelated configuration files alone"
+[[ -e "$tmp_dir/home/.config/1Password/settings.json" ]] ||
+  fail "1Password removal preserves the user's 1Password data"
+pass "1Password removal leaves unrelated configuration files alone"
+
+grep -Fxq '1password 1password-cli' "$tmp_dir/pkg-drop.log" ||
+  fail "1Password removal drops both packages"
+pass "1Password removal drops both packages"


### PR DESCRIPTION
Fixes #8916

The generic app-menu remover now routes the packaged `1password.desktop` entry through the dedicated 1Password remover. That remover deletes stale `com.1password.1password.json` manifests below browser `NativeMessagingHosts` directories while preserving the user's 1Password data.

Tests:
- `bash test/shell.d/launcher-remove-test.sh`
- `bash test/shell.d/remove-service-1password-test.sh`
- `bash -n bin/omarchy-remove-launcher-entry bin/omarchy-remove-service-1password test/shell.d/launcher-remove-test.sh test/shell.d/remove-service-1password-test.sh`