### PR TITLE
Validate pane counts before creating layouts

### DIFF
--- a/default/bash/fns/herdr
+++ b/default/bash/fns/herdr
@@ -109,6 +109,10 @@ hdlm() {
 # Usage: hsl <pane_count> <command>
 hsl() {
   [[ -z $1 || -z $2 ]] && { echo "Usage: hsl <pane_count> <command>"; return 1; }
+  if [[ ! $1 =~ ^[1-9][0-9]*$ ]]; then
+    echo "Usage: hsl <pane_count> <command>"
+    return 1
+  fi
   [[ -z $HERDR_PANE_ID ]] && { echo "You must start herdr to use hsl."; return 1; }
 
   local count="$1"

--- a/default/bash/fns/tmux
+++ b/default/bash/fns/tmux
@@ -97,6 +97,10 @@ tdlm() {
 # Usage: tsl <pane_count> <command>
 tsl() {
   [[ -z $1 || -z $2 ]] && { echo "Usage: tsl <pane_count> <command>"; return 1; }
+  if [[ ! $1 =~ ^[1-9][0-9]*$ ]]; then
+    echo "Usage: tsl <pane_count> <command>"
+    return 1
+  fi
   [[ -z $TMUX ]] && { echo "You must start tmux to use tsl."; return 1; }
 
   local count="$1"

--- a/test/shell.d/herdr-functions-test.sh
+++ b/test/shell.d/herdr-functions-test.sh
@@ -5,6 +5,28 @@ set -euo pipefail
 source "$(dirname "$0")/base-test.sh"
 source "$ROOT/default/bash/fns/herdr"
 
+assert_invalid_pane_count() {
+  local function_name="$1"
+  local count="$2"
+  local expected="Usage: $function_name <pane_count> <command>"
+  local output status=0
+
+  if [[ $function_name == tsl ]]; then
+    output=$(TMUX= bash -c 'source "$1"; tsl "$2" echo' _ "$ROOT/default/bash/fns/tmux" "$count" 2>&1) || status=$?
+  else
+    output=$(HERDR_PANE_ID= bash -c 'source "$1"; hsl "$2" echo' _ "$ROOT/default/bash/fns/herdr" "$count" 2>&1) || status=$?
+  fi
+
+  (( status != 0 )) || fail "$function_name rejects an invalid pane count"
+  [[ $output == *"$expected"* ]] || fail "$function_name prints usage for an invalid pane count" "$output"
+  pass "$function_name rejects an invalid pane count"
+}
+
+assert_invalid_pane_count tsl not-a-number
+assert_invalid_pane_count tsl 0
+assert_invalid_pane_count hsl not-a-number
+assert_invalid_pane_count hsl 0
+
 test_dir=$(mktemp -d)
 trap 'rm -rf -- "$test_dir"' EXIT
 


### PR DESCRIPTION
Fixes #8920

Reject zero, negative, and non-numeric pane counts before checking the tmux or Herdr session. Invalid input now prints the existing usage line instead of silently reaching layout logic or reporting an unrelated session error.

Tests:
- `bash test/shell.d/herdr-functions-test.sh`
- `bash -n default/bash/fns/tmux default/bash/fns/herdr test/shell.d/herdr-functions-test.sh`
- `git diff --check