### PR TITLE
Hand the presentation terminal Omarchy's BROWSER default

### DIFF
--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -7,6 +7,13 @@
 # even after a theme switch (the inherited environment is captured at login).
 source omarchy-restart-gum
 
+# The presentation script itself runs as `bash -c`, which is non-interactive
+# and never sources default/bash/envs, so the shell-scoped BROWSER default is
+# missing inside this terminal. Tools that open a URL from that process tree
+# (an agent's OAuth flow, for one) would otherwise abort. Re-apply the same
+# default interactive shells get; a BROWSER the caller exported still wins.
+export BROWSER="${BROWSER:-omarchy-launch-browser}"
+
 cmd="$*"
 presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
 

--- a/test/shell.d/floating-terminal-test.sh
+++ b/test/shell.d/floating-terminal-test.sh
@@ -9,15 +9,22 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 cat >"$tmp_dir/setsid" <<'SCRIPT'
 #!/bin/bash
-printf '%s\n' "$*" >"$TEST_LOG"
+printf 'browser=%s\n' "${BROWSER:-UNSET}" >"$TEST_LOG"
+printf 'args=%s\n' "$*" >>"$TEST_LOG"
 SCRIPT
 chmod +x "$tmp_dir/setsid"
 
 export TEST_LOG="$tmp_dir/log"
 export PATH="$tmp_dir:$ROOT/bin:$PATH"
 
-"$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "echo hello"
+env -u BROWSER "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "echo hello"
 
 launch=$(<"$TEST_LOG")
 [[ $launch == *"xdg-terminal-exec --app-id=org.omarchy.terminal"* ]] || fail "floating terminal launches Omarchy terminal" "$launch"
-pass "floating terminal launches Omarchy terminal"
+grep -Fxq 'browser=omarchy-launch-browser' <<<"$launch" || fail "floating terminal hands the terminal Omarchy's BROWSER default" "$launch"
+pass "floating terminal hands the terminal Omarchy's browser default"
+
+BROWSER=custom-browser "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "echo hello"
+launch=$(<"$TEST_LOG")
+grep -Fxq 'browser=custom-browser' <<<"$launch" || fail "floating terminal preserves a user BROWSER override" "$launch"
+pass "floating terminal preserves a user BROWSER override"


### PR DESCRIPTION
Fixes #8961

The presentation script runs as `bash -c`, which is non-interactive and never sources `default/bash/envs`. The shell-scoped `BROWSER` default was therefore missing inside the floating terminal, so tools that open a URL from that process tree (an agent's OAuth flow) aborted instead of opening a browser.

The launcher now exports the same `${BROWSER:-omarchy-launch-browser}` default interactive shells get; any BROWSER the caller exported still wins.

Tests:
- `bash test/shell.d/floating-terminal-test.sh`
- `bash test/shell.d/browser-env-test.sh`
- `bash -n bin/omarchy-launch-floating-terminal-with-presentation test/shell.d/floating-terminal-test.sh`
- `git diff --check`