### PR TITLE
Bind KP_Enter alongside RETURN

### DIFF
--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -1,6 +1,12 @@
 -- Essential application bindings.
 o.bind("SUPER + RETURN", "Terminal", { omarchy = "terminal" })
 o.bind("SUPER + SHIFT + RETURN", "Browser", { omarchy = "browser" })
+
+-- Some laptop keyboards and every numpad emit KP_Enter for Enter. Applications
+-- treat the two keys the same, so the bindings should too. The mirrors carry no
+-- description so the keybindings menu does not list each action twice.
+o.bind("SUPER + KP_Enter", nil, { omarchy = "terminal" })
+o.bind("SUPER + SHIFT + KP_Enter", nil, { omarchy = "browser" })
 o.bind("SUPER + SHIFT + F", "File manager", { omarchy = "nautilus" })
 o.bind("SUPER + ALT + SHIFT + F", "File manager (cwd)", { omarchy = "nautilus-cwd" })
 o.bind("SUPER + SHIFT + B", "Browser", { omarchy = "browser" })
@@ -11,6 +17,8 @@ if o.preinstalled_bindings_enabled() then
   -- Bindings for preinstalled Omarchy applications, TUIs, and web apps.
   o.bind("SUPER + ALT + RETURN", "Tmux", { omarchy = "terminal-tmux" })
   o.bind("SUPER + CTRL + RETURN", "Herdr", { omarchy = "terminal-herdr" })
+  o.bind("SUPER + ALT + KP_Enter", nil, { omarchy = "terminal-tmux" })
+  o.bind("SUPER + CTRL + KP_Enter", nil, { omarchy = "terminal-herdr" })
   o.bind("SUPER + SHIFT + M", "Music", { omarchy = "spotify" })
   o.bind("SUPER + SHIFT + ALT + M", "Music TUI", { tui = "cliamp", focus = true })
   o.bind("SUPER + SHIFT + D", "Docker", { tui = "omarchy-launch-docker-tui" })

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -56,6 +56,9 @@ hl.on("layer.opened", function(layer)
       selection_binds = {
         hl.bind("RETURN", hl.dsp.exec_cmd("omarchy-capture-region --take-window"), { description = "Capture highlighted window" }),
         hl.bind("CTRL + RETURN", hl.dsp.exec_cmd("omarchy-capture-region --take-fullscreen"), { description = "Capture entire screen" }),
+        -- Keypad Enter works the same way in terminals, so let it through too.
+        hl.bind("KP_Enter", hl.dsp.exec_cmd("omarchy-capture-region --take-window"), {}),
+        hl.bind("CTRL + KP_Enter", hl.dsp.exec_cmd("omarchy-capture-region --take-fullscreen"), {}),
         hl.bind("TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window next"), { description = "Select next window to capture" }),
         hl.bind("CTRL + TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window prev"), { description = "Select previous window to capture" }),
       }

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -109,6 +109,17 @@ grep -F 'hl.dsp.send_key_state({ mods = mods, key = key, state = "down" })' "$RO
   fail "universal clipboard shortcuts send explicit mods to the focused surface"
 pass "universal clipboard shortcuts send explicit mods to the focused surface"
 
+# Keyboards whose main Enter key emits KP_Enter (some laptops, and any numpad)
+# must reach the same dispatchers as RETURN. The mirrors stay description-less
+# so the keybindings menu does not list every action twice.
+grep -q 'KP_Enter' "$ROOT/default/hypr/bindings/applications.lua" ||
+  fail "application bindings answer to KP_Enter as well as RETURN"
+pass "application bindings answer both Enter keys"
+
+grep -q 'KP_Enter' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
+  fail "selection overlay bindings answer both Enter keys"
+pass "selection overlay answers both Enter keys"
+
 if grep -E 'send_key_state\(\{[^}]*window' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null; then
   fail "universal clipboard shortcuts do not target only normal windows"
 fi


### PR DESCRIPTION
Fixes #9030

Some laptop keyboards (e.g. Gateway GWTN141-10) emit `KP_Enter` for their main Enter key, and every numpad's Enter is `KP_Enter`. The default bindings declared only `RETURN`, so SUPER+Enter, SUPER+SHIFT+Enter, SUPER+ALT+Enter, and SUPER+CTRL+Enter did nothing on those keyboards.

Each `RETURN` application binding now gets a description-less `KP_Enter` mirror (no duplicate keybindings-menu entries), and the slurp selection overlay accepts `KP_Enter` and `CTRL + KP_Enter` for its capture actions.

Tests:
- `bash test/shell.d/hyprland-default-config-test.sh`
- `git diff --check`