### PR TITLE
Run the screensaver exit handler exactly once

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -7,6 +7,13 @@ screensaver_in_focus() {
 }
 
 exit_screensaver() {
+  # The pkill below matches the parent terminal (its command line carries the
+  # screensaver class), and the dying terminal signals us back. With a trap
+  # still armed that signal re-enters this handler — nesting until bash
+  # overflows its stack. Silence every trapped signal first so the cleanup
+  # runs exactly once.
+  trap '' SIGINT SIGTERM SIGHUP SIGQUIT
+
   hyprctl eval 'hl.config({ cursor = { invisible = false } })' &>/dev/null || hyprctl keyword cursor:invisible false &>/dev/null || true
   pkill -x ttfx 2>/dev/null
   pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null

--- a/test/shell.d/screensaver-exit-test.sh
+++ b/test/shell.d/screensaver-exit-test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+log="$tmp_dir/log"
+
+# A slow cursor restore keeps the exit handler running long enough for a
+# second signal to arrive while it is still working.
+cat >"$tmp_dir/bin/hyprctl" <<EOF
+#!/bin/bash
+if [[ \$1 == "activewindow" ]]; then
+  printf '%s\n' '{"class":"org.omarchy.screensaver"}'
+  exit 0
+fi
+
+if [[ \$2 == *'invisible = false'* || \$2 == 'cursor:invisible false' ]]; then
+  printf 'cursor-restore\n' >>"$log"
+  sleep 0.3
+fi
+
+printf 'signal\n' >>"$tmp_dir/armed"
+exit 0
+EOF
+
+cat >"$tmp_dir/bin/pgrep" <<'SCRIPT'
+#!/bin/bash
+exit 0
+SCRIPT
+
+cat >"$tmp_dir/bin/pkill" <<EOF
+#!/bin/bash
+printf 'pkill:%s\n' "\$*" >>"$log"
+EOF
+
+cat >"$tmp_dir/bin/ttfx" <<EOF
+#!/bin/bash
+printf 'ttfx-start\n' >>"$log"
+sleep 10
+EOF
+
+chmod +x "$tmp_dir/bin/"*
+
+PATH="$tmp_dir/bin:$PATH" bash "$ROOT/bin/omarchy-screensaver" </dev/null >"$tmp_dir/out" 2>&1 &
+script_pid=$!
+
+for _ in {1..100}; do
+  grep -q '^signal$' "$tmp_dir/armed" 2>/dev/null && break
+  kill -0 "$script_pid" 2>/dev/null || break
+  sleep 0.05
+done
+grep -q '^signal$' "$tmp_dir/armed" || fail "screensaver arms its exit handler" "$(cat "$tmp_dir/armed" 2>/dev/null || true)"
+
+# Once armed, the script spends its time inside the 1s read of its dismiss
+# loop; give it a full cycle so the dismissal lands there.
+sleep 1.2
+
+# Dismiss the screensaver. While the exit handler is still running, the
+# terminal it is killing echoes a hangup back, the way a real terminal does
+# when the cleanup pkill takes it down.
+kill -TERM "$script_pid" 2>/dev/null || true
+sleep 0.05
+kill -HUP "$script_pid" 2>/dev/null || true
+
+set +e
+wait "$script_pid"
+status=$?
+set -e
+
+(( status == 0 )) || fail "screensaver exits cleanly after dismiss signals" "exit status $status"
+
+restorations=$(grep -c '^cursor-restore$' "$log" || true)
+(( restorations <= 1 )) ||
+  fail "dismissing the screensaver restores the cursor exactly once" "$(printf '%s\n' "$log")"
+pass "dismissing the screensaver restores the cursor exactly once"
+
+grep -q '^pkill:-x ttfx$' "$log" || fail "dismissing the screensaver stops ttfx"
+pass "dismissing the screensaver stops ttfx"


### PR DESCRIPTION
Fixes #8985

`exit_screensaver` pkills the parent terminal (its command line carries the screensaver class), and the dying terminal signals the script back. With the trap still armed, that echo re-entered the handler — nesting until bash overflowed its stack (~63,500 frames, SIGSEGV).

The handler now silences SIGINT/SIGTERM/SIGHUP/SIGQUIT before signalling other screensaver processes, so the cleanup restores the cursor, stops ttfx, and exits exactly once.

Tests:
- `bash test/shell.d/screensaver-exit-test.sh` — dismisses a stubbed screensaver whose cleanup echoes a SIGHUP back (the way a dying terminal does) and asserts the cursor is restored exactly once and the script exits 0; it fails on the unpatched handler
- `bash -n bin/omarchy-screensaver test/shell.d/screensaver-exit-test.sh`
- `git diff --check`