### PR TITLE
Authorize SSH keys into the invoking user's home

### DIFF
--- a/bin/omarchy-setup-security-sshd
+++ b/bin/omarchy-setup-security-sshd
@@ -7,7 +7,26 @@
 
 set -e
 
-AUTHORIZED_KEYS="$HOME/.ssh/authorized_keys"
+# The authorized keys belong to the person who ran the setup, not to the
+# account the command finally executes as. Under sudo or pkexec, $HOME points
+# at root and would silently authorize the key for root instead. Resolve the
+# invoking user and their real home before touching the machine, and refuse
+# an invocation where neither can be determined.
+if [[ -n ${PKEXEC_UID:-} ]]; then
+  invoking_user=$(getent passwd "$PKEXEC_UID" 2>/dev/null | cut -d: -f1 || true)
+elif [[ -n ${SUDO_USER:-} && $SUDO_USER != root ]]; then
+  invoking_user=$SUDO_USER
+else
+  invoking_user=${USER:-$(id -un)}
+fi
+invoking_home=$({ getent passwd "$invoking_user" 2>/dev/null || true; } | cut -d: -f6)
+
+if [[ -z $invoking_user || -z ${invoking_home:-} ]]; then
+  echo "omarchy-setup-security-sshd: could not resolve the invoking user's home; refusing to authorize keys into a privileged home." >&2
+  exit 1
+fi
+
+AUTHORIZED_KEYS="$invoking_home/.ssh/authorized_keys"
 KEY=""
 GITHUB_USER=""
 
@@ -86,8 +105,8 @@ authorize_key() {
     return 1
   fi
 
-  mkdir -p "$HOME/.ssh"
-  chmod 700 "$HOME/.ssh"
+  mkdir -p "$invoking_home/.ssh"
+  chmod 700 "$invoking_home/.ssh"
   touch "$AUTHORIZED_KEYS"
   chmod 600 "$AUTHORIZED_KEYS"
 
@@ -162,4 +181,4 @@ else
 fi
 
 echo -e "\e[32m\nPerfect! The SSH server is running and your key is authorized.\e[0m"
-echo "You can now connect with: ssh $USER@$(hostname)"
+echo "You can now connect with: ssh $invoking_user@$(hostname)"

--- a/test/shell.d/sshd-setup-keys-test.sh
+++ b/test/shell.d/sshd-setup-keys-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command ssh-keygen
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+invoker_home="$tmp_dir/home-invoker"
+privileged_home="$tmp_dir/home-root"
+mkdir -p "$invoker_home" "$privileged_home" "$tmp_dir/bin"
+
+# A key ssh-keygen itself accepts, so the fixture cannot encode the answer.
+ssh-keygen -q -t ed25519 -N '' -f "$tmp_dir/keypair" >/dev/null
+key=$(cat "$tmp_dir/keypair.pub")
+
+cat >"$tmp_dir/bin/sudo" <<'SCRIPT'
+#!/bin/bash
+printf 'sudo:%s\n' "$*" >>"$TEST_LOG"
+exit 0
+SCRIPT
+
+cat >"$tmp_dir/bin/omarchy-pkg-add" <<'SCRIPT'
+#!/bin/bash
+printf 'pkg-add:%s\n' "$*" >>"$TEST_LOG"
+SCRIPT
+
+cat >"$tmp_dir/bin/omarchy-cmd-missing" <<'SCRIPT'
+#!/bin/bash
+exit 0
+SCRIPT
+
+cat >"$tmp_dir/bin/getent" <<EOF
+#!/bin/bash
+if [[ \$1 == passwd && ( \$2 == 4242 || \$2 == invoker ) ]]; then
+  printf 'invoker:x:4242:4242:Invoker:%s\n' "$invoker_home"
+  exit 0
+fi
+exit 2
+EOF
+
+chmod +x "$tmp_dir/bin/"*
+
+export TEST_LOG="$tmp_dir/log"
+log="$TEST_LOG"
+
+# Launched through a privilege prompt, $HOME points at root while the keys
+# belong to the user who started the setup (pkexec exposes their uid).
+PATH="$tmp_dir/bin:$PATH" PKEXEC_UID=4242 HOME="$privileged_home" \
+  bash "$ROOT/bin/omarchy-setup-security-sshd" --key="$key"
+
+grep -Fxq 'pkg-add:openssh' "$log" || fail "sshd setup still installs the server" "$(cat "$log")"
+grep -Fxq 'sudo:systemctl enable --now sshd.service' "$log" ||
+  fail "sshd setup still enables the server before authorizing keys" "$(cat "$log")"
+
+[[ -f $invoker_home/.ssh/authorized_keys ]] ||
+  fail "sshd setup writes the key to the invoking user's authorized_keys" "$(cat "$log")"
+grep -Fxq "$key" "$invoker_home/.ssh/authorized_keys" ||
+  fail "sshd setup authorizes the passed key" "$(cat "$invoker_home/.ssh/authorized_keys")"
+pass "sshd setup authorizes the invoking user's key"
+
+if [[ -e $privileged_home/.ssh ]]; then
+  fail "sshd setup leaves the privileged home untouched" "$(cat "$log")"
+fi
+pass "sshd setup leaves the privileged home untouched"


### PR DESCRIPTION
Fixes #9034

`omarchy-setup-security-sshd\ derived `AUTHORIZED_KEYS` from `$HOME`. Launched through `pkexec` (or run under `sudo`), `$HOME` is `/root`, so a valid `--key` enabled sshd but wrote the key to `/root/.ssh/authorized_keys` — leaving the invoking user without SSH access and unintentionally authorizing root.

The script now resolves the invoking account before touching the machine (from `PKEXEC_UID`, else `SUDO_USER`, else the current user), reads their home from `getent`, and refuses to proceed when neither can be determined. `$HOME` is no longer trusted.

Tests:
- `bash test/shell.d/sshd-setup-keys-test.sh` — runs the setup simulating a pkexec launch (privileged `$HOME`, invoking uid exposed) and asserts the key lands in the invoking user's `authorized_keys` while the privileged home stays untouched; it fails on the unpatched script
- `bash -n bin/omarchy-setup-security-sshd`
- `git diff --check`