### PR TITLE
Keep SDDM auto-login off encrypted roots in the quattro upgrade

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1281,24 +1281,15 @@ apply_firewall_defaults() {
     warn "Could not apply firewall defaults; run 'sudo bash $firewall_script' after reboot."
 }
 
-root_filesystem_encrypted() {
-  local root_source root_type
-
-  root_source=$(findmnt -n -o SOURCE / 2>/dev/null || true)
-  [[ $root_source == /dev/mapper/* ]] && return 0
-
-  if [[ -n $root_source ]]; then
-    root_type=$(lsblk -no TYPE "$root_source" 2>/dev/null | head -n1 || true)
-    [[ $root_type == crypt ]] && return 0
-  fi
-
-  as_root bash -c '[[ -s /etc/crypttab ]] && grep -qvE "^[[:space:]]*(#|$)" /etc/crypttab' >/dev/null 2>&1
-}
-
 should_enable_sddm_autologin() {
+  # Auto-login cannot hand a password to pam_gnome_keyring, so it breaks GNOME
+  # Keyring auto-unlock ("gkr-pam: no password is available for user"). An
+  # encrypted root is not a reason to want it — the LUKS passphrase is a
+  # separate boot-time prompt — so only a prior auto-login decision carries
+  # over: an autologin.conf already on disk, or the legacy seamless-login
+  # service this upgrade replaces.
   as_root test -f /etc/sddm.conf.d/autologin.conf && return 0
-  as_root systemctl is-enabled omarchy-seamless-login.service >/dev/null 2>&1 && return 0
-  root_filesystem_encrypted
+  as_root systemctl is-enabled omarchy-seamless-login.service >/dev/null 2>&1
 }
 
 apply_system_transition() {

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -98,6 +98,19 @@ function_body() {
   awk -v name="$1" '$0 == name "() {" { inside = 1; next } inside && $0 == "}" { exit } inside' "$upgrade_to_quattro"
 }
 
+# Auto-login cannot hand a password to pam_gnome_keyring, so an install whose
+# root lives inside LUKS must not have it switched on just for being encrypted.
+# Only a prior auto-login decision (the file, or the legacy seamless-login
+# service) may carry one forward.
+if function_body should_enable_sddm_autologin | grep -F 'root_filesystem_encrypted' >/dev/null; then
+  fail "quattro upgrade does not tie SDDM auto-login to an encrypted root"
+fi
+if ! function_body should_enable_sddm_autologin | grep -F '/etc/sddm.conf.d/autologin.conf' >/dev/null ||
+  ! function_body should_enable_sddm_autologin | grep -F 'omarchy-seamless-login.service' >/dev/null; then
+  fail "quattro upgrade keeps prior auto-login decisions"
+fi
+pass "quattro upgrade keeps password login on encrypted roots"
+
 if function_body cleanup_retired_services | grep -F 'systemctl disable iwd' >/dev/null; then
   fail "Omarchy 4 upgrade does not retire iwd in a step separate from the NetworkManager enable"
 fi


### PR DESCRIPTION
Fixes #8963

`should_enable_sddm_autologin` treated an encrypted root as a reason to enable SDDM auto-login during the quattro upgrade. Auto-login can never hand a password to `pam_gnome_keyring`, so on LUKS systems the upgrade silently broke GNOME Keyring auto-unlock (`gkr-pam: no password is available for user`).

Auto-login now carries forward only an explicit prior decision — an existing `/etc/sddm.conf.d/autologin.conf`, or the legacy `omarchy-seamless-login` service this upgrade replaces. An encrypted root is no longer treated as consent (the LUKS passphrase is a separate boot-time prompt). The now-unused `root_filesystem_encrypted` helper is removed.

Tests:
- `bash test/shell.d/upgrade-to-quattro-test.sh` — asserts the auto-login decision no longer consults root encryption while still honoring prior auto-login state
- `bash -n bin/omarchy-upgrade-to-quattro`
- `git diff --check`