### PR TITLE
Keep the screensaver wordmark across monitor scales

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -13,6 +13,10 @@ fi
 focused=$(omarchy-hyprland-monitor-focused)
 terminal=$(xdg-terminal-exec --print-id)
 
+# omarchy_screensaver_font_size scales each terminal's font to the monitor so
+# the wordmark keeps its physical size (and column budget) at any DPI scale.
+. "${OMARCHY_PATH:-/usr/share/omarchy}/default/bash/fns/screensaver"
+
 case $terminal in
 *Alacritty* | *ghostty* | *foot* | *kitty*) ;;
 *)
@@ -49,25 +53,27 @@ wait_for_screensaver_window() {
   done
 }
 
-for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
+while read -r m scale; do
+  [[ -n $m ]] || continue
   hypr_focus_monitor "$m"
+  font=$(omarchy_screensaver_font_size "${scale:-1}")
 
   case $terminal in
   *Alacritty*)
-    hypr_exec alacritty --class=org.omarchy.screensaver --config-file "$OMARCHY_PATH/default/alacritty/screensaver.toml" -e omarchy-screensaver
+    hypr_exec alacritty --class=org.omarchy.screensaver --config-file "$OMARCHY_PATH/default/alacritty/screensaver.toml" --option "font.size=$font" -e omarchy-screensaver
     ;;
   *ghostty*)
-    hypr_exec ghostty --class=org.omarchy.screensaver --config-file="$OMARCHY_PATH/default/ghostty/screensaver" --font-size=18 -e omarchy-screensaver
+    hypr_exec ghostty --class=org.omarchy.screensaver --config-file="$OMARCHY_PATH/default/ghostty/screensaver" --font-size="$font" -e omarchy-screensaver
     ;;
   *foot*)
-    hypr_exec foot --app-id=org.omarchy.screensaver --config="$OMARCHY_PATH/default/foot/screensaver.ini" -e omarchy-screensaver
+    hypr_exec foot --app-id=org.omarchy.screensaver --config="$OMARCHY_PATH/default/foot/screensaver.ini" --font="JetBrainsMono Nerd Font:size=$font" -e omarchy-screensaver
     ;;
   *kitty*)
-    hypr_exec kitty --class=org.omarchy.screensaver --override font_size=18 --override window_padding_width=0 -e omarchy-screensaver
+    hypr_exec kitty --class=org.omarchy.screensaver --override "font_size=$font" --override window_padding_width=0 -e omarchy-screensaver
     ;;
   esac
 
   wait_for_screensaver_window
-done
+done < <(hyprctl monitors -j | jq -r '.[] | "\(.name) \(.scale // 1)"')
 
 hypr_focus_monitor "$focused"

--- a/default/bash/fns/screensaver
+++ b/default/bash/fns/screensaver
@@ -1,0 +1,17 @@
+# Font size for the screensaver wordmark on a monitor of the given scale.
+# Usage: omarchy_screensaver_font_size <scale>
+omarchy_screensaver_font_size() {
+  local scale="${1:-1}"
+
+  # The wordmark is roughly 1178 physical px wide at font 18. Shrinking the
+  # font by the monitor's scale keeps that physical size — and with it the
+  # column budget the art needs — constant on every display. A fixed 18pt
+  # font did not scale: at scale 2, a 1080p panel offered only 66 of the 81
+  # columns the art needs and centred-cropped the wordmark down to "MARCH".
+  awk -v scale="$scale" 'BEGIN {
+    size = int(18 / scale + 0.5)
+    if (size < 6) size = 6
+    if (size > 18) size = 18
+    print size
+  }'
+}

--- a/test/shell.d/screensaver-font-size-test.sh
+++ b/test/shell.d/screensaver-font-size-test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command awk
+
+source "$ROOT/default/bash/fns/screensaver"
+
+assert_font_size() {
+  local scale="$1" expected="$2"
+  local actual
+  actual=$(omarchy_screensaver_font_size "$scale")
+  [[ $actual == "$expected" ]] ||
+    fail "screensaver font size for scale $scale" "expected $expected, got $actual"
+  pass "screensaver font size for scale $scale is $expected"
+}
+
+# The wordmark fills ~1178 physical px at font 18. Shrinking the font by the
+# monitor scale keeps that physical size — and with it, the column budget —
+# the same on every display, which a fixed 18pt font did not: at scale 2 a
+# 1080p panel offered only 66 of the 81 columns the art needs.
+assert_font_size 1 18
+assert_font_size 2 9
+assert_font_size 1.25 14
+assert_font_size 1.5 12
+assert_font_size 3 6
+assert_font_size 4 6
+
+# Sub-unity scales (fractional UI zoom) are capped at the shipped default.
+assert_font_size 0.5 18
+
+# The launcher hands each terminal the computed size; no fixed 18 survives in
+# the launch paths.
+launcher="$ROOT/bin/omarchy-launch-screensaver"
+grep -F 'omarchy_screensaver_font_size' "$launcher" >/dev/null ||
+  fail "screensaver launcher sizes its terminal fonts from the monitor scale"
+for literal in '--font-size=18' 'font_size=18' 'size = 18.0'; do
+  if grep -Fq -- "$literal" "$launcher"; then
+    fail "screensaver launcher does not hardcode $literal"
+  fi
+done
+pass "screensaver launcher sizes its terminal fonts from the monitor scale"


### PR DESCRIPTION
Fixes #9027

The screensaver launchers hardcoded an 18pt font, but the wordmark needs 81 columns. On a 1080p/143-DPI panel, Omarchy's own `omarchy_monitor_scale = "auto"` resolves to scale 2, whose 960-column logical viewport fits only 66 columns — `ttfx` centre-cropped the art down to "MARCH".

Each terminal launch now sizes its font from the target monitor's scale (`18 / scale`, clamped to 6–18) via a new `omarchy_screensaver_font_size` helper in `default/bash/fns/screensaver`. The wordmark's physical size — and therefore its column budget — stays constant on every display: scale 1 keeps the shipped 18, scale 2 gets 9, and sub-unity scales cap at 18.

- foot gets `--font="JetBrainsMono Nerd Font:size=$font"`, Alacritty `--option font.size=$font`, and Ghostty/Kitty their existing flags with the computed value
- per-monitor scales are honored (mixed-scale setups launch each terminal with its own size)

Tests:
- `bash test/shell.d/screensaver-font-size-test.sh`
- `bash -n bin/omarchy-launch-screensaver default/bash/fns/screensaver`
- `git diff --check`