### PR TITLE
Give TUI windows a terminal-sized touchpad scroll rule

### DIFF
--- a/bin/omarchy-launch-tui
+++ b/bin/omarchy-launch-tui
@@ -10,4 +10,17 @@ else
   APP_ID="org.omarchy.$(basename $1)"
 fi
 
+# TUI windows run under their own app id, so the per-terminal scroll_touchpad
+# rules never reach them — agent windows included — and a fullscreen TUI also
+# misses foot's scrollback multiplier. Size a one-off rule here, where the
+# terminal is known: under foot a TUI needs roughly the product a regular foot
+# terminal scrolls with.
+case $(xdg-terminal-exec --print-id 2>/dev/null || true) in
+*foot*) scroll_touchpad=10 ;;
+*ghostty*) scroll_touchpad=0.2 ;;
+*) scroll_touchpad=1.5 ;;
+esac
+
+hyprctl eval "hl.window_rule({ match = { class = [[^${APP_ID}\$]] }, scroll_touchpad = ${scroll_touchpad} })" >/dev/null 2>&1 || true
+
 exec setsid uwsm-app -- xdg-terminal-exec --app-id=$APP_ID -e "$1" "${@:2}"

--- a/test/shell.d/launch-tui-touchpad-test.sh
+++ b/test/shell.d/launch-tui-touchpad-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+
+cat >"$tmp_dir/bin/xdg-terminal-exec" <<'SCRIPT'
+#!/bin/bash
+if [[ $1 == --print-id ]]; then
+  printf '%s\n' "$OMARCHY_TEST_TERMINAL_ID"
+  exit 0
+fi
+exit 0
+SCRIPT
+
+cat >"$tmp_dir/bin/hyprctl" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TEST_LOG"
+exit 0
+SCRIPT
+
+cat >"$tmp_dir/bin/setsid" <<'SCRIPT'
+#!/bin/bash
+printf 'launch:%s\n' "$*" >>"$TEST_LOG"
+SCRIPT
+
+chmod +x "$tmp_dir/bin/"*
+
+launch() {
+  TEST_LOG="$tmp_dir/log" PATH="$tmp_dir/bin:$PATH" \
+    "$ROOT/bin/omarchy-launch-tui" "$@"
+}
+
+# TUI windows run under their own app id, so the per-terminal scroll_touchpad
+# rules never reach them — agent windows included — and a fullscreen TUI also
+# misses foot's scrollback multiplier. The launcher sizes a one-off rule to
+# the terminal it is about to run, so a TUI scrolls like a regular terminal.
+for pair in "foot.desktop:10" "ghostty.desktop:0.2" "kitty.desktop:1.5"; do
+  terminal=${pair%%:*}
+  multiplier=${pair##*:}
+  : >"$tmp_dir/log"
+  OMARCHY_TEST_TERMINAL_ID="$terminal" launch --app-id=org.omarchy.agent claude
+  grep -Fq 'match = { class = [[^org.omarchy.agent$]] }' "$tmp_dir/log" ||
+    fail "the agent TUI gets a scroll rule for $terminal"
+  grep -Fq "scroll_touchpad = $multiplier" "$tmp_dir/log" ||
+    fail "the $terminal agent TUI scrolls like a regular terminal" "$(cat "$tmp_dir/log")"
+done
+pass "the agent TUI scrolls like a regular terminal"
+
+# The same defect reaches every TUI launch (the window's class is not a
+# terminal), so the rule is not agent-specific: htop under foot scrolls like
+# a regular terminal too.
+: >"$tmp_dir/log"
+OMARCHY_TEST_TERMINAL_ID="foot.desktop" launch htop
+grep -Fq 'class = [[^org.omarchy.htop$]]' "$tmp_dir/log" ||
+  fail "other TUIs keep scrolling like a regular terminal" "$(cat "$tmp_dir/log")"
+grep -Fq 'scroll_touchpad = 10' "$tmp_dir/log" ||
+  fail "other TUIs keep scrolling like a regular terminal" "$(cat "$tmp_dir/log")"
+pass "other TUIs keep scrolling like a regular terminal"


### PR DESCRIPTION
Fixes #9008

TUI windows (`org.omarchy.agent` and every other `omarchy-launch-tui` launch) run under their own app id, so the per-terminal `scroll_touchpad` window rules never reach them — on a touchpad they scrolled at ~1x where a regular `foot` terminal scrolls at ~10x (Hyprland's 1.5 rule times foot's 7.0 scrollback multiplier, which a fullscreen TUI never sees).

`omarchy-launch-tui` now knows the terminal it is about to launch (`xdg-terminal-exec --print-id`) and sets a one-off `hl.window_rule` for the app id sized to that terminal's behaviour: foot 10, ghostty 0.2, others 1.5. Outside a Hyprland session the eval is best-effort and changes nothing.

Verified \`hyprctl eval 'hl.window_rule({...})'\` against Hyprland 0.56.2 on this branch's parser.

Tests:
- `bash test/shell.d/launch-tui-touchpad-test.sh`
- `bash -n bin/omarchy-launch-tui`
- `git diff --check`