### PR TITLE
Fix bar hand cursor never appearing until the slot's first click

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -1665,7 +1665,16 @@ Item {
       acceptedButtons: Qt.LeftButton
       enabled: slot.visible && slot.width > 0 && slot.height > 0
       propagateComposedEvents: true
-      cursorShape: root.moduleClickTargetAt(slot, mouseX, mouseY) ? Qt.PointingHandCursor : Qt.ArrowCursor
+      // moduleHover, not mouseX/mouseY: without hoverEnabled (deliberately
+      // off -- a hover-enabled MouseArea here would block hover from the
+      // widget-internal MouseAreas below, killing tooltips and hover
+      // styling), mouseX/mouseY only update while a button is pressed, so
+      // this binding used to evaluate at stale coordinates and the hand
+      // cursor never appeared until the slot's first click. The undefined
+      // branch resets the cursor claim so widgets that set their own
+      // cursor beneath are no longer shadowed.
+      cursorShape: root.moduleClickTargetAt(slot, moduleHover.point.position.x, moduleHover.point.position.y)
+        ? Qt.PointingHandCursor : undefined
       // Do not assign drag.target here: ModuleSlot is owned by Row/Column
       // positioners, and mutating slot.x/slot.y can leave stale offsets that
       // make neighboring modules overlap after a small aborted drag.


### PR DESCRIPTION
Fixes #9047.

## Problem

`modulePointer`'s `cursorShape` binding reads `mouseX/mouseY`, but the MouseArea has no `hoverEnabled` — so those coordinates only update while a button is pressed. The binding evaluates at (0,0) until the slot's first click, then freezes at the press point:

- No pointing-hand cursor on hover until each slot's first click of a session.
- After a click, the hand sticks — including over the slot's non-clickable padding.
- A transient (0,0) hit during startup (slots still overlapping before the positioner runs) latches `hasCursor` on, so the slot's stale Arrow permanently shadows any cursor widgets beneath set themselves.

## Fix

Feed the binding from the slot's existing `moduleHover` HoverHandler — it tracks live, slot-local hover coordinates without stealing hover from the widget-internal MouseAreas below — and reset the cursor claim (`undefined`) when not over a click target, so widget-set cursors underneath show through.

`hoverEnabled: true` on `modulePointer` was considered and rejected: it blocks hover from reaching widget-internal MouseAreas, breaking tooltips (`WidgetButton` `onEntered → bar.showTooltip`), `containsMouse` styling, and indicator hover-reveal — presumably why it was off in the first place.

## Verification

Root cause and fix were verified against Qt 6.11.2 / quickshell 0.3.1 / Hyprland 0.56.2 with offscreen QML test harnesses reproducing the stale-coordinate behavior, the startup `hasCursor` latch, the click-"fix", the tooltip breakage under naive `hoverEnabled`, and correct behavior with this change (hand on first hover, arrow over padding, hover still reaching inner MouseAreas, click/drag unaffected — `onPositionChanged` already guards on `mouse.buttons`). Full analysis in #9047.

`./test/all`: the two failures in my environment (`bar icons share slot and baseline geometry` off-center by 0.59px, and the omarchy-pkgs checkout probe) are identical on an unmodified checkout — no new failures from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xzm1qFSqGkG6wJj7J1EBU