### PR TITLE
Count handler collisions from startup, not from the test's own rebuilds

### DIFF
--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -140,6 +140,30 @@ jq -e '
 }
 pass "shell IPC lists plugin metadata"
 
+# Sample the handler collisions from startup, before anything below mutates the
+# plugin set. Enabling a plugin, hot-reloading one, and rescanning all rebuild
+# the widgets by design, and each rebuild adds a further collision per screen
+# past the first -- so a count taken after them measures this test's own work
+# rather than the duplicate loads it means to catch. Asserted further down,
+# beside the other geometry checks.
+# Widgets load asynchronously, so wait for the count to stop moving instead of
+# guessing a sleep. No matches is the good case, and pipefail would otherwise
+# abort the run.
+count_handler_collisions() {
+  local n
+  n=$(grep -oE "another handler is registered for target [a-z.-]+" "$log" |
+    sort | uniq -c | sort -rn | head -1 | awk '{print $1}' || true)
+  printf '%s' "${n:-0}"
+}
+
+startup_handler_collisions=$(count_handler_collisions)
+for _ in {1..40}; do
+  sleep 0.25
+  settled=$(count_handler_collisions)
+  [[ $settled == "$startup_handler_collisions" ]] && break
+  startup_handler_collisions=$settled
+done
+
 jq '.name = "After Hot Reload"' "$hot_reload_dir/manifest.json" >"$hot_reload_dir/manifest.json.tmp"
 mv "$hot_reload_dir/manifest.json.tmp" "$hot_reload_dir/manifest.json"
 
@@ -285,13 +309,10 @@ pass "direct panel IPC opens and closes default panels"
 # past the first. Anything beyond that is two instances on the same screen —
 # the shape duplicate component loads produced, where a sync pass that ran
 # while a widget's asynchronous load was still in flight started a second one.
-# Checked before the reload below, which rebuilds widgets by design.
+# Sampled above, before the first rescan rebuilt the widgets.
 screens=$(hyprctl -j monitors 2>/dev/null | jq 'length' 2>/dev/null || true)
 [[ $screens =~ ^[0-9]+$ ]] && (( screens > 0 )) || screens=1
-# No matches is the good case, and pipefail would otherwise abort the run.
-worst=$(grep -oE "another handler is registered for target [a-z.-]+" "$log" |
-  sort | uniq -c | sort -rn | head -1 | awk '{print $1}' || true)
-worst=${worst:-0}
+worst=$startup_handler_collisions
 if (( worst > screens - 1 )); then
   grep "another handler is registered for target" "$log" | sed 's/^/  /' | head -20 >&2
   fail_with_log "each widget registers its IPC handler once per screen (saw $worst for $screens screen(s))"


### PR DESCRIPTION
## The problem

The IPC handler check in `runtime-smoke-test.sh` greps the whole shell log:

```bash
worst=$(grep -oE "another handler is registered for target [a-z.-]+" "$log" |
  sort | uniq -c | sort -rn | head -1 | awk '{print $1}' || true)
if (( worst > screens - 1 )); then
```

Its comment says it is *"checked before the reload below, which rebuilds widgets by design"* — but four widget-rebuilding actions run **above** it: a plugin is enabled, disabled, another is hot-reloaded, and `rescanPlugins` is called explicitly. Each fires `onPluginsChanged` → `syncPluginWidgets()`, and every rebuild adds another collision per screen past the first. The log accumulates across all of them, so the assertion measures the test's own work rather than the duplicate component loads it exists to catch.

## Evidence

Measured on a three-monitor machine, where the allowance is `screens - 1` = 2:

| Scenario | worst | Verdict |
|---|---|---|
| Clean shell, no test actions | 2 | within allowance |
| After one `rescanPlugins` | 4 | over |
| The test as written | 6 | over |

Launching the shell standalone with no test interference gives exactly 2 collisions per target, uniformly across all ten widgets — precisely the "one per screen past the first" the comment describes. The shell is behaving correctly; only the measurement is wrong.

This is invisible on a single screen, which is presumably why it reads green in CI and fails on a multi-monitor desktop.

## The change

Sample the count once, after the last read-only startup step and before anything mutates the plugin set, and assert on that value where the check already lives.

Widgets load asynchronously, so the sample waits for the count to stop moving rather than sleeping a guessed interval, which would be flaky on a slower machine.

## Testing

`test/shell` on this branch: **2720 passing, 1 failing**. The one failure is `omarchy-theme-install refuses a URL it cannot check`, which is unrelated and reproduces on pristine `c720f0b9` — it simulates a missing `omarchy-git-url-check` by dropping `$ROOT/bin` from `PATH`, but on a machine with Omarchy installed the command is also a real file in `/usr/bin` (along with 430 others), so it is always found. Happy to send a separate PR for that if you would like it isolated properly.

Because a test that passes is not automatically a test that still works, I verified the sample is not landing before the bars load and quietly reading zero:

```
DEBUG sampled startup collisions = 2 (screens=3)
ok - each widget registers its IPC handler once per screen
```

It reads the true startup value, so a genuine duplicate load taking it to 3 would still fail the check.
