### PR TITLE
Add package-managed hook discovery

### DIFF
--- a/bin/omarchy-hook
+++ b/bin/omarchy-hook
@@ -1,28 +1,109 @@
 #!/bin/bash
 
-# omarchy:summary=Run a named hook from ~/.config/omarchy/hooks/<name> and ~/.config/omarchy/hooks/<name>.d/.
+# omarchy:summary=Run package, core, and user hooks for a named event
 # omarchy:args=[name] [args...]
 
 set -e
 
-if (( $# < 1 )); then
-  echo "Usage: omarchy-hook [name] [args...]"
-  exit 1
-fi
+omarchy_hook_roots() {
+  local data_dirs=${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
+  local -a xdg_data_dirs candidates=("$OMARCHY_PATH/hooks") seen
+  local data_dir candidate canonical seen_root
 
-HOOK=$1
-HOOK_PATH="$HOME/.config/omarchy/hooks/$1"
-HOOK_DIR="$HOOK_PATH.d"
-shift
+  IFS=: read -r -a xdg_data_dirs <<<"$data_dirs"
 
-if [[ -f $HOOK_PATH ]]; then
-  bash "$HOOK_PATH" "$@" || echo "Hook failed: $HOOK_PATH"
-fi
-
-if [[ -d $HOOK_DIR ]]; then
-  for hook in "$HOOK_DIR"/*; do
-    [[ -f $hook ]] || continue
-    [[ $hook == *.sample ]] && continue
-    bash "$hook" "$@" || echo "Hook failed: $hook"
+  for data_dir in "${xdg_data_dirs[@]}"; do
+    [[ $data_dir == /* ]] || continue
+    candidates+=("$data_dir/omarchy/hooks")
   done
+
+  candidates+=("$HOME/.config/omarchy/hooks")
+
+  for candidate in "${candidates[@]}"; do
+    if ! canonical=$(realpath -m -- "$candidate" 2>/dev/null); then
+      continue
+    fi
+
+    for seen_root in "${seen[@]}"; do
+      [[ $canonical == "$seen_root" ]] && continue 2
+    done
+
+    seen+=("$canonical")
+    printf '%s\0' "$canonical"
+  done
+}
+
+omarchy_system_hook_seen() {
+  local name=$1
+  local seen_name
+
+  for seen_name in "${OMARCHY_SEEN_SYSTEM_HOOKS[@]}"; do
+    [[ $name == "$seen_name" ]] && return 0
+  done
+
+  return 1
+}
+
+omarchy_run_hook_file() {
+  local name=$1
+  local path=$2
+  local shadow_duplicates=$3
+  shift 3
+
+  if [[ $shadow_duplicates == "true" ]]; then
+    omarchy_system_hook_seen "$name" && return
+    OMARCHY_SEEN_SYSTEM_HOOKS+=("$name")
+  fi
+
+  bash "$path" "$@" || echo "Hook failed: $path"
+}
+
+omarchy_run_hook_root() {
+  local root=$1
+  local event=$2
+  local shadow_duplicates=$3
+  local hook_path="$root/$event"
+  local hook_dir="$hook_path.d"
+  local hook
+  shift 3
+
+  if [[ -f $hook_path ]]; then
+    omarchy_run_hook_file flat "$hook_path" "$shadow_duplicates" "$@"
+  fi
+
+  if [[ -d $hook_dir ]]; then
+    for hook in "$hook_dir"/*; do
+      [[ -f $hook ]] || continue
+      [[ $hook == *.sample ]] && continue
+      omarchy_run_hook_file "directory/${hook##*/}" "$hook" "$shadow_duplicates" "$@"
+    done
+  fi
+}
+
+omarchy_hook_main() {
+  if (( $# < 1 )); then
+    echo "Usage: omarchy-hook [name] [args...]"
+    exit 1
+  fi
+
+  local event=$1
+  local user_root root shadow_duplicates
+  local -a OMARCHY_SEEN_SYSTEM_HOOKS=()
+  shift
+
+  user_root=$(realpath -m -- "$HOME/.config/omarchy/hooks")
+
+  while IFS= read -r -d '' root; do
+    if [[ $root == "$user_root" ]]; then
+      shadow_duplicates=false
+    else
+      shadow_duplicates=true
+    fi
+
+    omarchy_run_hook_root "$root" "$event" "$shadow_duplicates" "$@"
+  done < <(omarchy_hook_roots)
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  omarchy_hook_main "$@"
 fi

--- a/bin/omarchy-hook
+++ b/bin/omarchy-hook
@@ -5,24 +5,132 @@
 
 set -e
 
+omarchy_hook_event_valid() (
+  LC_ALL=C
+  [[ $1 =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+)
+
+omarchy_realpath() {
+  local mode=$1
+  local path=$2
+
+  OMARCHY_REALPATH=
+  case $mode in
+  existing)
+    IFS= read -r -d '' OMARCHY_REALPATH < <(/usr/bin/realpath -z -e -- "$path" 2>/dev/null)
+    ;;
+  lexical)
+    IFS= read -r -d '' OMARCHY_REALPATH < <(/usr/bin/realpath -z -m -s -- "$path" 2>/dev/null)
+    ;;
+  missing)
+    IFS= read -r -d '' OMARCHY_REALPATH < <(/usr/bin/realpath -z -m -- "$path" 2>/dev/null)
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+}
+
+omarchy_package_hook_path_trusted() {
+  local root=$1
+  local path=$2
+  local expected_type=$3
+  local lexical canonical probe parent metadata owner hex mode type
+  local -a chain=()
+
+  omarchy_realpath lexical "$path" || return 1
+  lexical=$OMARCHY_REALPATH
+  omarchy_realpath existing "$path" || return 1
+  canonical=$OMARCHY_REALPATH
+
+  [[ $lexical == "$canonical" ]] || return 1
+  [[ $canonical == "$root" || $canonical == "$root/"* ]] || return 1
+
+  probe=$canonical
+  while :; do
+    chain=("$probe" "${chain[@]}")
+    [[ $probe == / ]] && break
+    parent=${probe%/*}
+    [[ -n $parent ]] || parent=/
+    probe=$parent
+  done
+
+  for probe in "${chain[@]}"; do
+    metadata=$(/usr/bin/stat -c '%u:%f' -- "$probe" 2>/dev/null) || return 1
+    owner=${metadata%%:*}
+    hex=${metadata#*:}
+    mode=$((16#$hex))
+    type=$((mode & 0170000))
+
+    (( owner == 0 || owner == EUID )) || return 1
+    (( type != 0120000 )) || return 1
+
+    if [[ $probe != "$canonical" ]]; then
+      (( type == 0040000 )) || return 1
+    fi
+
+    if (( mode & 0022 )); then
+      if [[ $probe == "$root" || $probe == "$root/"* ]]; then
+        return 1
+      fi
+
+      (( type == 0040000 && (mode & 01000) )) || return 1
+    fi
+  done
+
+  case $expected_type in
+  directory)
+    (( type == 0040000 )) || return 1
+    ;;
+  file)
+    (( type == 0100000 )) || return 1
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+
+  OMARCHY_TRUSTED_HOOK_PATH=$canonical
+}
+
+omarchy_warn_unsafe_package_hook_path() {
+  printf 'Skipping unsafe package hook path: %q\n' "$1" >&2
+}
+
 omarchy_hook_roots() {
   local data_dirs=${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
-  local -a xdg_data_dirs candidates=("$OMARCHY_PATH/hooks") seen
-  local data_dir candidate canonical seen_root
+  local -a xdg_data_dirs candidates=("$OMARCHY_PATH/hooks") candidate_types=(core) seen
+  local data_dir candidate candidate_type canonical lexical seen_root user_root
+  local i
 
-  IFS=: read -r -a xdg_data_dirs <<<"$data_dirs"
+  omarchy_realpath missing "$HOME/.config/omarchy/hooks" || return
+  user_root=$OMARCHY_REALPATH
+
+  IFS=: read -r -d '' -a xdg_data_dirs < <(printf '%s\0' "$data_dirs")
 
   for data_dir in "${xdg_data_dirs[@]}"; do
     [[ $data_dir == /* ]] || continue
     candidates+=("$data_dir/omarchy/hooks")
+    candidate_types+=(package)
   done
 
-  candidates+=("$HOME/.config/omarchy/hooks")
+  for ((i = 0; i < ${#candidates[@]}; i++)); do
+    candidate=${candidates[$i]}
+    candidate_type=${candidate_types[$i]}
 
-  for candidate in "${candidates[@]}"; do
-    if ! canonical=$(realpath -m -- "$candidate" 2>/dev/null); then
-      continue
+    omarchy_realpath missing "$candidate" || continue
+    canonical=$OMARCHY_REALPATH
+
+    if [[ $candidate_type == package ]]; then
+      omarchy_realpath lexical "$candidate" || continue
+      lexical=$OMARCHY_REALPATH
+      if [[ $lexical != "$canonical" ]]; then
+        [[ ! -e $candidate && ! -L $candidate ]] || omarchy_warn_unsafe_package_hook_path "$candidate"
+        continue
+      fi
     fi
+
+    [[ $canonical == "$user_root" ]] && continue
 
     for seen_root in "${seen[@]}"; do
       [[ $canonical == "$seen_root" ]] && continue 2
@@ -31,6 +139,8 @@ omarchy_hook_roots() {
     seen+=("$canonical")
     printf '%s\0' "$canonical"
   done
+
+  printf '%s\0' "$user_root"
 }
 
 omarchy_system_hook_seen() {
@@ -55,27 +165,75 @@ omarchy_run_hook_file() {
     OMARCHY_SEEN_SYSTEM_HOOKS+=("$name")
   fi
 
-  bash "$path" "$@" || echo "Hook failed: $path"
+  /bin/bash "$path" "$@" || echo "Hook failed: $path"
 }
 
 omarchy_run_hook_root() {
   local root=$1
   local event=$2
   local shadow_duplicates=$3
+  local validate_package_paths=$4
   local hook_path="$root/$event"
   local hook_dir="$hook_path.d"
-  local hook
-  shift 3
+  local hook trusted_hook
+  shift 4
 
-  if [[ -f $hook_path ]]; then
-    omarchy_run_hook_file flat "$hook_path" "$shadow_duplicates" "$@"
+  if [[ $validate_package_paths == true ]]; then
+    if [[ ! -e $root && ! -L $root ]]; then
+      return
+    elif omarchy_package_hook_path_trusted "$root" "$root" directory; then
+      root=$OMARCHY_TRUSTED_HOOK_PATH
+      hook_path="$root/$event"
+      hook_dir="$hook_path.d"
+    else
+      omarchy_warn_unsafe_package_hook_path "$root"
+      return
+    fi
   fi
 
-  if [[ -d $hook_dir ]]; then
+  if [[ -f $hook_path || -L $hook_path ]]; then
+    if [[ $validate_package_paths == true ]]; then
+      if omarchy_package_hook_path_trusted "$root" "$hook_path" file; then
+        trusted_hook=$OMARCHY_TRUSTED_HOOK_PATH
+        omarchy_run_hook_file flat "$trusted_hook" "$shadow_duplicates" "$@"
+      else
+        omarchy_warn_unsafe_package_hook_path "$hook_path"
+      fi
+    elif [[ -f $hook_path ]]; then
+      omarchy_run_hook_file flat "$hook_path" "$shadow_duplicates" "$@"
+    fi
+  fi
+
+  if [[ -d $hook_dir || -L $hook_dir ]]; then
+    if [[ $validate_package_paths == true ]]; then
+      if omarchy_package_hook_path_trusted "$root" "$hook_dir" directory; then
+        hook_dir=$OMARCHY_TRUSTED_HOOK_PATH
+      else
+        omarchy_warn_unsafe_package_hook_path "$hook_dir"
+        return
+      fi
+    elif [[ ! -d $hook_dir ]]; then
+      return
+    fi
+
     for hook in "$hook_dir"/*; do
-      [[ -f $hook ]] || continue
+      [[ -f $hook || -L $hook ]] || continue
       [[ $hook == *.sample ]] && continue
-      omarchy_run_hook_file "directory/${hook##*/}" "$hook" "$shadow_duplicates" "$@"
+
+      if [[ $validate_package_paths == true ]]; then
+        if omarchy_package_hook_path_trusted "$root" "$hook" file; then
+          trusted_hook=$OMARCHY_TRUSTED_HOOK_PATH
+        else
+          omarchy_warn_unsafe_package_hook_path "$hook"
+          continue
+        fi
+      elif [[ -f $hook ]]; then
+        trusted_hook=$hook
+      else
+        continue
+      fi
+
+      omarchy_run_hook_file "directory/${hook##*/}" "$trusted_hook" "$shadow_duplicates" "$@"
     done
   fi
 }
@@ -86,22 +244,35 @@ omarchy_hook_main() {
     exit 1
   fi
 
-  local event=$1
-  local user_root root shadow_duplicates
-  local -a OMARCHY_SEEN_SYSTEM_HOOKS=()
+  local event=$1 core_root user_root root shadow_duplicates validate_package_paths
+  local -a OMARCHY_SEEN_SYSTEM_HOOKS=() roots=()
   shift
 
-  user_root=$(realpath -m -- "$HOME/.config/omarchy/hooks")
+  if ! omarchy_hook_event_valid "$event"; then
+    printf 'Invalid hook event: %q\n' "$event" >&2
+    return 2
+  fi
 
-  while IFS= read -r -d '' root; do
+  omarchy_realpath missing "$OMARCHY_PATH/hooks"
+  core_root=$OMARCHY_REALPATH
+  omarchy_realpath missing "$HOME/.config/omarchy/hooks"
+  user_root=$OMARCHY_REALPATH
+  mapfile -d '' -t roots < <(omarchy_hook_roots)
+
+  for root in "${roots[@]}"; do
     if [[ $root == "$user_root" ]]; then
       shadow_duplicates=false
+      validate_package_paths=false
+    elif [[ $root == "$core_root" ]]; then
+      shadow_duplicates=true
+      validate_package_paths=false
     else
       shadow_duplicates=true
+      validate_package_paths=true
     fi
 
-    omarchy_run_hook_root "$root" "$event" "$shadow_duplicates" "$@"
-  done < <(omarchy_hook_roots)
+    omarchy_run_hook_root "$root" "$event" "$shadow_duplicates" "$validate_package_paths" "$@"
+  done
 }
 
 if [[ ${BASH_SOURCE[0]} == "$0" ]]; then

--- a/bin/omarchy-hook-install
+++ b/bin/omarchy-hook-install
@@ -8,6 +8,11 @@
 
 set -e
 
+omarchy_hook_event_valid() (
+  LC_ALL=C
+  [[ $1 =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+)
+
 if (( $# != 2 )); then
   echo "Usage: omarchy-hook-install <type> <file>"
   exit 1
@@ -15,8 +20,14 @@ fi
 
 HOOK_TYPE=$1
 HOOK_FILE=$2
+
+if ! omarchy_hook_event_valid "$HOOK_TYPE"; then
+  printf 'Invalid hook event: %q\n' "$HOOK_TYPE" >&2
+  exit 2
+fi
+
 HOOK_DIR="$HOME/.config/omarchy/hooks/$HOOK_TYPE.d"
-HOOK_NAME=$(basename "$HOOK_FILE")
+HOOK_NAME=$(basename -- "$HOOK_FILE")
 HOOK_PATH="$HOOK_DIR/$HOOK_NAME"
 
 if [[ ! -f $HOOK_FILE ]]; then
@@ -25,7 +36,6 @@ if [[ ! -f $HOOK_FILE ]]; then
 fi
 
 mkdir -p "$HOOK_DIR"
-cp "$HOOK_FILE" "$HOOK_PATH"
-chmod 755 "$HOOK_PATH"
+install -m 755 -T -- "$HOOK_FILE" "$HOOK_PATH"
 
 echo "Installed $HOOK_TYPE hook: $HOOK_PATH"

--- a/default/agents/skills/omarchy/hooks.md
+++ b/default/agents/skills/omarchy/hooks.md
@@ -1,13 +1,8 @@
 # Automation Hooks
 
-Read this before setting up scripts that run on system events (theme changes,
-updates, boot, low battery, etc.).
+Read this before setting up scripts that run on system events (theme changes, updates, boot, low battery, etc.).
 
-Hooks live in `~/.config/omarchy/hooks/<name>.d/` — one directory per event,
-holding any number of independent scripts. Install with
-`omarchy hook install <name> <script>` (copies the script in and makes it
-executable). The runner also executes a flat `~/.config/omarchy/hooks/<name>`
-file first, if one exists.
+User hooks live in `~/.config/omarchy/hooks/<name>.d/` — one directory per event, holding any number of independent scripts. Install with `omarchy hook install <name> <script>` (copies the script in and makes it executable). The runner also executes a flat `~/.config/omarchy/hooks/<name>` file first, if one exists.
 
 ```
 ~/.config/omarchy/hooks/
@@ -20,9 +15,26 @@ file first, if one exists.
 ```
 
 Example hook script:
+
 ```bash
 #!/bin/bash
 THEME_NAME=$1
 echo "Theme changed to: $THEME_NAME"
 # Add custom actions here
 ```
+
+## Package-managed hooks
+
+Packages can install hooks under `omarchy/hooks/` in an absolute directory from `${XDG_DATA_DIRS:-/usr/local/share:/usr/share}`. For example, a package can install `/usr/share/omarchy/hooks/theme-set.d/50-windows-xp`. These hooks remain available when `omarchy dev link` points `$OMARCHY_PATH` at a source checkout.
+
+The active Omarchy tree can also ship hooks under `$OMARCHY_PATH/hooks/`. The runner canonicalizes hook roots, so the normal `/usr/share/omarchy` tree is not run twice when it appears through both `$OMARCHY_PATH` and `XDG_DATA_DIRS`.
+
+Hook roots run in this order:
+
+1. The active core or development tree at `$OMARCHY_PATH/hooks`.
+2. Package-managed data directories, in `XDG_DATA_DIRS` order. Empty and relative entries are ignored; an unset or empty variable defaults to `/usr/local/share:/usr/share`.
+3. The user's `~/.config/omarchy/hooks` directory.
+
+Within each root, the flat `<name>` hook runs first, followed by regular files in `<name>.d/` in filename order. A hook in the active tree shadows a package hook with the same relative name, and a hook in an earlier XDG data directory shadows one in a later directory. This prevents a core hook present in both a development checkout and the installed package from running twice. User hooks are a separate customization layer and always run after system hooks, even when their filenames match. Canonically identical roots run only once.
+
+Files ending in `.sample` are skipped. A failing hook is reported but does not prevent later hooks from running. All hooks run as the user who invoked the Omarchy command, including package-managed hooks.

--- a/default/agents/skills/omarchy/hooks.md
+++ b/default/agents/skills/omarchy/hooks.md
@@ -27,6 +27,8 @@ echo "Theme changed to: $THEME_NAME"
 
 Packages can install hooks under `omarchy/hooks/` in an absolute directory from `${XDG_DATA_DIRS:-/usr/local/share:/usr/share}`. For example, a package can install `/usr/share/omarchy/hooks/theme-set.d/50-windows-xp`. These hooks remain available when `omarchy dev link` points `$OMARCHY_PATH` at a source checkout.
 
+Package hook paths are executable trust boundaries. The runner accepts an XDG package root only when it and every existing path component are owned by root or the invoking user and cannot be written by another user; a sticky shared ancestor such as `/tmp` is allowed only above the package root. Symlinked XDG package roots, event directories, and hook files are skipped. The explicit active-tree and user roots retain symlink support.
+
 The active Omarchy tree can also ship hooks under `$OMARCHY_PATH/hooks/`. The runner canonicalizes hook roots, so the normal `/usr/share/omarchy` tree is not run twice when it appears through both `$OMARCHY_PATH` and `XDG_DATA_DIRS`.
 
 Hook roots run in this order:

--- a/default/agents/skills/omarchy/hooks.md
+++ b/default/agents/skills/omarchy/hooks.md
@@ -2,7 +2,25 @@
 
 Read this before setting up scripts that run on system events (theme changes, updates, boot, low battery, etc.).
 
-User hooks live in `~/.config/omarchy/hooks/<name>.d/` — one directory per event, holding any number of independent scripts. Install with `omarchy hook install <name> <script>` (copies the script in and makes it executable). The runner also executes a flat `~/.config/omarchy/hooks/<name>` file first, if one exists.
+## Supported hook paths
+
+For an event named `<name>`, `omarchy-hook` recognizes these path shapes:
+
+| Layer | Flat hook | Hook directory |
+| ----- | --------- | -------------- |
+| Active Omarchy tree | `$OMARCHY_PATH/hooks/<name>` | `$OMARCHY_PATH/hooks/<name>.d/*` |
+| Package data directory | `<data-dir>/omarchy/hooks/<name>` | `<data-dir>/omarchy/hooks/<name>.d/*` |
+| User configuration | `$HOME/.config/omarchy/hooks/<name>` | `$HOME/.config/omarchy/hooks/<name>.d/*` |
+
+`<data-dir>` is each absolute entry in `${XDG_DATA_DIRS:-/usr/local/share:/usr/share}`. With the default value, package hooks are therefore read from `/usr/local/share/omarchy/hooks/` and `/usr/share/omarchy/hooks/`. Empty and relative entries are ignored. `XDG_DATA_HOME` is not searched; per-user hooks belong under `$HOME/.config/omarchy/hooks/`.
+
+The flat hook and `<name>.d/` form can coexist in the same root. The flat hook runs first, followed by non-hidden regular files directly inside `<name>.d/` in filename order. Nested directories, names beginning with `.`, and directory entries ending in `.sample` are ignored. The runner invokes hook files with `/bin/bash`, so the executable bit is not required, although `omarchy hook install` sets it.
+
+Event names must start with an ASCII letter or number and may contain only ASCII letters, numbers, `.`, `_`, and `-`. Empty names, names beginning with punctuation, path separators, whitespace, and other characters are rejected by both the runner and installer.
+
+## Available events
+
+User hooks can be installed with `omarchy hook install <name> <script>`, which preserves the script's basename, copies it to `$HOME/.config/omarchy/hooks/<name>.d/`, and makes it executable. Rename a hidden script or one ending in `.sample` before installing it, since those names are intentionally skipped. Omarchy currently emits these events:
 
 ```
 ~/.config/omarchy/hooks/
@@ -25,9 +43,17 @@ echo "Theme changed to: $THEME_NAME"
 
 ## Package-managed hooks
 
-Packages can install hooks under `omarchy/hooks/` in an absolute directory from `${XDG_DATA_DIRS:-/usr/local/share:/usr/share}`. For example, a package can install `/usr/share/omarchy/hooks/theme-set.d/50-windows-xp`. These hooks remain available when `omarchy dev link` points `$OMARCHY_PATH` at a source checkout.
+Distribution packages should normally install hooks below `/usr/share/omarchy/hooks/`; locally administered hooks can use `/usr/local/share/omarchy/hooks/`. For example, a package can install `/usr/share/omarchy/hooks/theme-set.d/50-windows-xp`. Additional absolute data directories can be supplied through `XDG_DATA_DIRS`. These hooks remain available when `omarchy dev link` points `$OMARCHY_PATH` at a source checkout.
 
-Package hook paths are executable trust boundaries. The runner accepts an XDG package root only when it and every existing path component are owned by root or the invoking user and cannot be written by another user; a sticky shared ancestor such as `/tmp` is allowed only above the package root. Symlinked XDG package roots, event directories, and hook files are skipped. The explicit active-tree and user roots retain symlink support.
+Package hook paths are executable trust boundaries. A package hook path is supported only when all of the following are true:
+
+- No component in the path from `/` through the hook file is a symlink.
+- Every path component is owned by root or the invoking user.
+- The package root (`<data-dir>/omarchy/hooks`) and everything below it are not group- or other-writable.
+- A group- or other-writable directory above the package root has the sticky bit set, as `/tmp` normally does.
+- The package root and event directory are directories, and the hook itself is a regular file.
+
+Existing paths that fail these checks are reported and skipped before duplicate-hook shadowing is applied, so an unsafe entry cannot suppress a safe hook with the same name in a later package root. Missing package roots are skipped silently. The explicit active-tree and user roots are trusted separately: their symlinks are supported, and the package ownership and mode checks do not apply to them.
 
 The active Omarchy tree can also ship hooks under `$OMARCHY_PATH/hooks/`. The runner canonicalizes hook roots, so the normal `/usr/share/omarchy` tree is not run twice when it appears through both `$OMARCHY_PATH` and `XDG_DATA_DIRS`.
 
@@ -37,6 +63,6 @@ Hook roots run in this order:
 2. Package-managed data directories, in `XDG_DATA_DIRS` order. Empty and relative entries are ignored; an unset or empty variable defaults to `/usr/local/share:/usr/share`.
 3. The user's `~/.config/omarchy/hooks` directory.
 
-Within each root, the flat `<name>` hook runs first, followed by regular files in `<name>.d/` in filename order. A hook in the active tree shadows a package hook with the same relative name, and a hook in an earlier XDG data directory shadows one in a later directory. This prevents a core hook present in both a development checkout and the installed package from running twice. User hooks are a separate customization layer and always run after system hooks, even when their filenames match. Canonically identical roots run only once.
+Within each root, the flat `<name>` hook runs first, followed by non-hidden regular files in `<name>.d/` in filename order. A hook in the active tree shadows a package hook with the same relative name, and a hook in an earlier XDG data directory shadows one in a later directory. This prevents a core hook present in both a development checkout and the installed package from running twice. User hooks are a separate customization layer and always run after system hooks, even when their filenames match. Canonically identical roots run only once.
 
-Files ending in `.sample` are skipped. A failing hook is reported but does not prevent later hooks from running. All hooks run as the user who invoked the Omarchy command, including package-managed hooks.
+Directory entries ending in `.sample` are skipped. A failing hook is reported but does not prevent later hooks from running. All hooks run as the user who invoked the Omarchy command, including package-managed hooks.

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -59,7 +59,7 @@ Current generated theme state lives under
 may intentionally version in a dotfile manager, such as user themes, hooks,
 shell layout, plugins, and themed template overrides.
 
-Independently packaged event hooks live under `omarchy/hooks/` in the absolute data directories listed by `XDG_DATA_DIRS`, such as `/usr/share/omarchy/hooks/`. Hook discovery does not rely only on `$OMARCHY_PATH`, so package-provided integrations remain available while `omarchy dev link` points the active Omarchy tree at a checkout. See [`default/agents/skills/omarchy/hooks.md`](../default/agents/skills/omarchy/hooks.md) for lookup order and hook layout.
+Independently packaged event hooks live under `omarchy/hooks/` in trusted absolute data directories listed by `XDG_DATA_DIRS`, such as `/usr/share/omarchy/hooks/`. Hook discovery does not rely only on `$OMARCHY_PATH`, so package-provided integrations remain available while `omarchy dev link` points the active Omarchy tree at a checkout. Unsafe writable paths and symlinked package hook paths are ignored. See [`default/agents/skills/omarchy/hooks.md`](../default/agents/skills/omarchy/hooks.md) for lookup order, trust requirements, and hook layout.
 
 ## Build-time map (repo → installed paths)
 

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -59,6 +59,8 @@ Current generated theme state lives under
 may intentionally version in a dotfile manager, such as user themes, hooks,
 shell layout, plugins, and themed template overrides.
 
+Independently packaged event hooks live under `omarchy/hooks/` in the absolute data directories listed by `XDG_DATA_DIRS`, such as `/usr/share/omarchy/hooks/`. Hook discovery does not rely only on `$OMARCHY_PATH`, so package-provided integrations remain available while `omarchy dev link` points the active Omarchy tree at a checkout. See [`default/agents/skills/omarchy/hooks.md`](../default/agents/skills/omarchy/hooks.md) for lookup order and hook layout.
+
 ## Build-time map (repo → installed paths)
 
 ```

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -59,7 +59,7 @@ Current generated theme state lives under
 may intentionally version in a dotfile manager, such as user themes, hooks,
 shell layout, plugins, and themed template overrides.
 
-Independently packaged event hooks live under `omarchy/hooks/` in trusted absolute data directories listed by `XDG_DATA_DIRS`, such as `/usr/share/omarchy/hooks/`. Hook discovery does not rely only on `$OMARCHY_PATH`, so package-provided integrations remain available while `omarchy dev link` points the active Omarchy tree at a checkout. Unsafe writable paths and symlinked package hook paths are ignored. See [`default/agents/skills/omarchy/hooks.md`](../default/agents/skills/omarchy/hooks.md) for lookup order, trust requirements, and hook layout.
+Independently packaged event hooks use `<data-dir>/omarchy/hooks/<event>` or `<data-dir>/omarchy/hooks/<event>.d/*`, where `<data-dir>` is a trusted absolute directory listed by `XDG_DATA_DIRS`, such as `/usr/share`. `XDG_DATA_HOME` is not searched. Hook discovery does not rely only on `$OMARCHY_PATH`, so package-provided integrations remain available while `omarchy dev link` points the active Omarchy tree at a checkout. Unsafe writable paths and symlinked package hook paths are ignored. See [`default/agents/skills/omarchy/hooks.md`](../default/agents/skills/omarchy/hooks.md) for the complete supported path matrix, lookup order, and trust requirements.
 
 ## Build-time map (repo → installed paths)
 

--- a/manual/31-dotfiles.md
+++ b/manual/31-dotfiles.md
@@ -32,7 +32,7 @@ That starts the command as part of the session, so it's properly cleaned up when
 
 ### Running scripts on system events
 
-Omarchy fires hooks at a handful of moments, and you can hang your own scripts off them. They live in `~/.config/omarchy/hooks/<event>.d/`, one directory per event, and every executable file in there runs when the event happens:
+Omarchy fires hooks at a handful of moments, and you can hang your own scripts off them. User hooks live under `~/.config/omarchy/hooks/`:
 
 | Event | When it runs |
 | ----- | ------------ |
@@ -43,9 +43,11 @@ Omarchy fires hooks at a handful of moments, and you can hang your own scripts o
 | `font-set` | After a font change (font name in `$1`) |
 | `battery-low` | When the battery gets low (percentage in `$1`) |
 
-Each of those directories already holds a `.sample` file showing the shape of a hook — drop the `.sample` from the name to put it to work. To install a script you've written elsewhere, use `omarchy hook install post-boot ~/my-hook`, which copies it in and makes it executable.
+For each event, the runner supports one flat `~/.config/omarchy/hooks/<event>` hook plus any non-hidden regular files directly inside `~/.config/omarchy/hooks/<event>.d/`. The flat hook runs first, then the directory files run in filename order. Nested directories, names beginning with `.`, and directory entries ending in `.sample` are skipped. Event names must start with an ASCII letter or number and can otherwise contain ASCII letters, numbers, `.`, `_`, and `-`.
 
-Software packages can provide their own Omarchy hooks too. Package and Omarchy hooks run first; your hooks run afterward so they can react to or customize packaged behavior. For safety, package hook paths must be controlled by root or your account and cannot use symlinks or shared-writable directories.
+Each event directory already holds a `.sample` file showing the shape of a hook — drop the `.sample` from the name to put it to work. To install a script you've written elsewhere, use `omarchy hook install post-boot ~/my-hook`, which preserves its basename, copies it in, and makes it executable. Rename a hidden script or one ending in `.sample` before installing it.
+
+Software packages can provide the same flat and directory forms under `$OMARCHY_PATH/hooks/` or `<data-dir>/omarchy/hooks/`, where `<data-dir>` is an absolute entry in `XDG_DATA_DIRS`. The default package roots are `/usr/local/share/omarchy/hooks/` and `/usr/share/omarchy/hooks/`; `XDG_DATA_HOME` is not searched. The active Omarchy tree runs first, package roots run in `XDG_DATA_DIRS` order, and your hooks under `~/.config/omarchy/hooks/` always run last so they can react to or customize packaged behavior. For safety, package hook paths cannot contain symlinks, must be controlled by root or your account, and cannot be shared-writable at or below the package hook root. A sticky shared directory such as `/tmp` is supported only as an ancestor above that root.
 
 ### Adding your own menu entries
 

--- a/manual/31-dotfiles.md
+++ b/manual/31-dotfiles.md
@@ -45,6 +45,8 @@ Omarchy fires hooks at a handful of moments, and you can hang your own scripts o
 
 Each of those directories already holds a `.sample` file showing the shape of a hook — drop the `.sample` from the name to put it to work. To install a script you've written elsewhere, use `omarchy hook install post-boot ~/my-hook`, which copies it in and makes it executable.
 
+Software packages can provide their own Omarchy hooks too. Package and Omarchy hooks run first; your hooks run afterward so they can react to or customize packaged behavior.
+
 ### Adding your own menu entries
 
 The Omarchy menu (`Super + Space`) can be extended with your own rows by editing `~/.config/omarchy/extensions/omarchy-menu.jsonc`. Entries are keyed by a dotted id, and the id is what places them in the tree, so `personal` shows up on the root menu and `personal.notes` shows up inside it:

--- a/manual/31-dotfiles.md
+++ b/manual/31-dotfiles.md
@@ -45,7 +45,7 @@ Omarchy fires hooks at a handful of moments, and you can hang your own scripts o
 
 Each of those directories already holds a `.sample` file showing the shape of a hook — drop the `.sample` from the name to put it to work. To install a script you've written elsewhere, use `omarchy hook install post-boot ~/my-hook`, which copies it in and makes it executable.
 
-Software packages can provide their own Omarchy hooks too. Package and Omarchy hooks run first; your hooks run afterward so they can react to or customize packaged behavior.
+Software packages can provide their own Omarchy hooks too. Package and Omarchy hooks run first; your hooks run afterward so they can react to or customize packaged behavior. For safety, package hook paths must be controlled by root or your account and cannot use symlinks or shared-writable directories.
 
 ### Adding your own menu entries
 

--- a/test/shell.d/hook-test.sh
+++ b/test/shell.d/hook-test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+source "$ROOT/bin/omarchy-hook"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+core_root="$test_tmp/core"
+vendor_one="$test_tmp/vendor-one"
+vendor_two="$test_tmp/vendor-two"
+hook_log="$test_tmp/hooks.log"
+mkdir -p "$test_home" "$core_root" "$vendor_one" "$vendor_two"
+
+make_hook() {
+  local path=$1
+  local label=$2
+  local status=${3:-0}
+
+  mkdir -p "$(dirname -- "$path")"
+  printf '#!/bin/bash\nprintf "%%s\\n" "%s" >>"$HOOK_LOG"\nexit %s\n' "$label" "$status" >"$path"
+}
+
+assert_lines() {
+  local description=$1
+  local expected=$2
+  local actual
+
+  actual=$(<"$hook_log")
+  if [[ $actual == "$expected" ]]; then
+    pass "$description"
+  else
+    fail "$description" "expected:\n$expected\nactual:\n$actual"
+  fi
+}
+
+make_hook "$vendor_one/omarchy/hooks/test-event" "vendor-one-flat"
+make_hook "$vendor_one/omarchy/hooks/test-event.d/10-failing" "vendor-one-failing" 1
+make_hook "$vendor_one/omarchy/hooks/test-event.d/20-after-failure" "vendor-one-after-failure"
+make_hook "$vendor_one/omarchy/hooks/test-event.d/30-shared" "vendor-one-shared"
+make_hook "$vendor_one/omarchy/hooks/test-event.d/30-ignored.sample" "sample"
+make_hook "$vendor_one/omarchy/hooks/test-event.d/40-vendor-shared" "vendor-one-xdg-shared"
+make_hook "$vendor_two/omarchy/hooks/test-event.d/10-vendor-two" "vendor-two"
+make_hook "$vendor_two/omarchy/hooks/test-event.d/40-vendor-shared" "vendor-two-xdg-shared"
+make_hook "$core_root/hooks/test-event" "core-flat"
+make_hook "$core_root/hooks/test-event.d/10-core" "core-directory"
+make_hook "$core_root/hooks/test-event.d/30-shared" "core-shared"
+make_hook "$test_home/.config/omarchy/hooks/test-event" "user-flat"
+make_hook "$test_home/.config/omarchy/hooks/test-event.d/10-user" "user-directory"
+make_hook "$test_home/.config/omarchy/hooks/test-event.d/30-shared" "user-shared"
+
+hook_output=$(
+  HOME="$test_home" \
+    OMARCHY_PATH="$core_root" \
+    XDG_DATA_DIRS="$vendor_one:$vendor_two" \
+    HOOK_LOG="$hook_log" \
+    "$ROOT/bin/omarchy-hook" test-event
+)
+
+expected_order=$(printf '%s\n' \
+  core-flat \
+  core-directory \
+  core-shared \
+  vendor-one-failing \
+  vendor-one-after-failure \
+  vendor-one-xdg-shared \
+  vendor-two \
+  user-flat \
+  user-directory \
+  user-shared)
+assert_lines "vendor, dev-tree, flat, directory, and user hooks run in order" "$expected_order"
+
+[[ $hook_output == *"Hook failed: $vendor_one/omarchy/hooks/test-event.d/10-failing"* ]] || fail "hook failure is reported"
+pass "hook failure is reported"
+[[ $hook_output != *sample* ]] || fail "sample hook is skipped"
+pass "sample hook is skipped and later hooks continue"
+
+if grep -Fxq core-shared "$hook_log" && grep -Fxq user-shared "$hook_log" && ! grep -Fq vendor-one-shared "$hook_log"; then
+  pass "core hooks shadow vendor duplicates while matching user hooks still run"
+else
+  fail "core hooks shadow vendor duplicates while matching user hooks still run"
+fi
+
+if grep -Fxq vendor-one-xdg-shared "$hook_log" && ! grep -Fq vendor-two-xdg-shared "$hook_log"; then
+  pass "earlier XDG data directories shadow later duplicate hook names"
+else
+  fail "earlier XDG data directories shadow later duplicate hook names"
+fi
+
+: >"$hook_log"
+make_hook "$vendor_one/omarchy/hooks/vendor-event" "vendor-flat"
+HOME="$test_tmp/empty-home" \
+  OMARCHY_PATH="$core_root" \
+  XDG_DATA_DIRS="$vendor_one" \
+  HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" vendor-event
+assert_lines "package-managed flat hook runs" "vendor-flat"
+
+: >"$hook_log"
+production_root="$test_tmp/production-data"
+make_hook "$production_root/omarchy/hooks/test-event.d/10-once" "production-once"
+HOME="$test_tmp/empty-home" \
+  OMARCHY_PATH="$production_root/omarchy" \
+  XDG_DATA_DIRS="$production_root:$production_root/" \
+  HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" test-event
+assert_lines "production OMARCHY_PATH and duplicate XDG roots run once" "production-once"
+
+root_list() {
+  local root
+  while IFS= read -r -d '' root; do
+    printf '%s\n' "$root"
+  done < <(omarchy_hook_roots)
+}
+
+HOME="$test_home"
+OMARCHY_PATH="$core_root"
+unset XDG_DATA_DIRS
+unset_roots=$(root_list)
+expected_default_roots=$(printf '%s\n' \
+  "$core_root/hooks" \
+  /usr/local/share/omarchy/hooks \
+  /usr/share/omarchy/hooks \
+  "$test_home/.config/omarchy/hooks")
+[[ $unset_roots == "$expected_default_roots" ]] || fail "unset XDG_DATA_DIRS uses standard defaults" "expected:\n$expected_default_roots\nactual:\n$unset_roots"
+pass "unset XDG_DATA_DIRS uses standard defaults"
+
+XDG_DATA_DIRS=
+empty_roots=$(root_list)
+[[ $empty_roots == "$expected_default_roots" ]] || fail "empty XDG_DATA_DIRS uses standard defaults" "expected:\n$expected_default_roots\nactual:\n$empty_roots"
+pass "empty XDG_DATA_DIRS uses standard defaults"
+
+ln -s "$vendor_one" "$test_tmp/vendor-one-link"
+XDG_DATA_DIRS="relative::also-relative:$vendor_one:$vendor_one/:$test_tmp/vendor-one-link"
+filtered_roots=$(root_list)
+expected_filtered_roots=$(printf '%s\n' \
+  "$core_root/hooks" \
+  "$vendor_one/omarchy/hooks" \
+  "$test_home/.config/omarchy/hooks")
+[[ $filtered_roots == "$expected_filtered_roots" ]] || fail "relative, empty, and canonical duplicate data entries are ignored" "expected:\n$expected_filtered_roots\nactual:\n$filtered_roots"
+pass "relative, empty, and canonical duplicate data entries are ignored"

--- a/test/shell.d/hook-test.sh
+++ b/test/shell.d/hook-test.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 source "$ROOT/bin/omarchy-hook"
 
+umask 022
+
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
@@ -108,6 +110,150 @@ HOME="$test_tmp/empty-home" \
   HOOK_LOG="$hook_log" \
   "$ROOT/bin/omarchy-hook" test-event
 assert_lines "production OMARCHY_PATH and duplicate XDG roots run once" "production-once"
+
+: >"$hook_log"
+mkdir -p "$core_root/hooks/stdin-event.d"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'IFS= read -r input || true' \
+  'printf "core-read:%s\n" "$input" >>"$HOOK_LOG"' \
+  >"$core_root/hooks/stdin-event.d/10-read"
+make_hook "$vendor_one/omarchy/hooks/stdin-event.d/20-vendor" "vendor-after-read"
+make_hook "$test_home/.config/omarchy/hooks/stdin-event.d/30-user" "user-after-read"
+printf '%s\n' caller-input | \
+  HOME="$test_home" \
+    OMARCHY_PATH="$core_root" \
+    XDG_DATA_DIRS="$vendor_one" \
+    HOOK_LOG="$hook_log" \
+    "$ROOT/bin/omarchy-hook" stdin-event
+expected_stdin_order=$(printf '%s\n' \
+  core-read:caller-input \
+  vendor-after-read \
+  user-after-read)
+assert_lines "hooks inherit caller stdin without consuming root discovery" "$expected_stdin_order"
+
+: >"$hook_log"
+make_hook "$core_root/escaped-event" "escaped-event"
+if HOME="$test_home" OMARCHY_PATH="$core_root" XDG_DATA_DIRS="$vendor_one" HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" ../escaped-event >/dev/null 2>&1; then
+  fail "hook runner rejects a traversing event name"
+fi
+[[ ! -s $hook_log ]] || fail "a traversing event name executes no hook"
+pass "hook runner rejects a traversing event name"
+
+if HOME="$test_home" OMARCHY_PATH="$core_root" XDG_DATA_DIRS="$vendor_one" HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" "" >/dev/null 2>&1; then
+  fail "hook runner rejects an empty event name"
+fi
+pass "hook runner rejects an empty event name"
+
+install_source="$test_tmp/install-source"
+make_hook "$install_source" "installed-hook"
+if HOME="$test_home" "$ROOT/bin/omarchy-hook-install" ../escaped "$install_source" >/dev/null 2>&1; then
+  fail "hook installer rejects a traversing event name"
+fi
+[[ ! -e $test_home/.config/omarchy/escaped.d/install-source ]] || fail "hook installer writes nothing for a traversing event name"
+pass "hook installer rejects a traversing event name"
+
+if HOME="$test_home" "$ROOT/bin/omarchy-hook-install" "" "$install_source" >/dev/null 2>&1; then
+  fail "hook installer rejects an empty event name"
+fi
+[[ ! -e $test_home/.config/omarchy/hooks/.d/install-source ]] || fail "hook installer writes nothing for an empty event name"
+pass "hook installer rejects an empty event name"
+
+install_victim="$test_tmp/install-victim"
+printf '%s\n' "victim" >"$install_victim"
+mkdir -p "$test_home/.config/omarchy/hooks/install-event.d"
+ln -s "$install_victim" "$test_home/.config/omarchy/hooks/install-event.d/install-source"
+HOME="$test_home" "$ROOT/bin/omarchy-hook-install" install-event "$install_source" >/dev/null
+[[ ! -L $test_home/.config/omarchy/hooks/install-event.d/install-source ]] || fail "hook installer replaces a destination symlink"
+[[ $(<"$install_victim") == "victim" ]] || fail "hook installer leaves a destination symlink target untouched"
+pass "hook installer replaces a destination symlink without following it"
+
+: >"$hook_log"
+unsafe_vendor="$test_tmp/shared-vendor"
+make_hook "$unsafe_vendor/omarchy/hooks/trust-event.d/10-shared" "unsafe-package"
+make_hook "$vendor_two/omarchy/hooks/trust-event.d/10-shared" "safe-package"
+make_hook "$test_home/.config/omarchy/hooks/trust-event.d/20-user" "user-safe"
+chmod 0777 "$unsafe_vendor"
+HOME="$test_home" \
+  OMARCHY_PATH="$core_root" \
+  XDG_DATA_DIRS="$unsafe_vendor:$vendor_two" \
+  HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" trust-event 2>"$test_tmp/unsafe-hook.err"
+expected_trusted_order=$(printf '%s\n' safe-package user-safe)
+assert_lines "unsafe package roots are skipped without shadowing trusted hooks" "$expected_trusted_order"
+grep -Fq "Skipping unsafe package hook path:" "$test_tmp/unsafe-hook.err" || fail "unsafe package root is reported"
+pass "unsafe package root is reported"
+
+: >"$hook_log"
+make_hook "$vendor_one/omarchy/hooks/writable-event" "unsafe-writable-flat"
+make_hook "$vendor_one/omarchy/hooks/writable-event.d/10-shared" "unsafe-writable-directory"
+make_hook "$vendor_two/omarchy/hooks/writable-event" "safe-flat-after-writable"
+make_hook "$vendor_two/omarchy/hooks/writable-event.d/10-shared" "safe-directory-after-writable"
+make_hook "$test_home/.config/omarchy/hooks/writable-event.d/20-user" "user-after-writable"
+chmod 0666 "$vendor_one/omarchy/hooks/writable-event"
+chmod 0777 "$vendor_one/omarchy/hooks/writable-event.d"
+HOME="$test_home" \
+  OMARCHY_PATH="$core_root" \
+  XDG_DATA_DIRS="$vendor_one:$vendor_two" \
+  HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" writable-event 2>"$test_tmp/writable-hook.err"
+expected_writable_order=$(printf '%s\n' safe-flat-after-writable safe-directory-after-writable user-after-writable)
+assert_lines "writable package paths do not shadow later trusted hooks" "$expected_writable_order"
+writable_warning_count=$(grep -Fc "Skipping unsafe package hook path:" "$test_tmp/writable-hook.err")
+(( writable_warning_count == 2 )) || fail "writable package paths are reported"
+pass "writable package paths are reported"
+
+: >"$hook_log"
+make_hook "$test_tmp/outside-flat" "outside-flat"
+make_hook "$test_tmp/outside-directory/10-outside" "outside-directory"
+ln -s "$test_tmp/outside-flat" "$vendor_one/omarchy/hooks/symlink-event"
+ln -s "$test_tmp/outside-directory" "$vendor_one/omarchy/hooks/symlink-event.d"
+make_hook "$vendor_two/omarchy/hooks/symlink-event" "safe-flat-after-symlink"
+make_hook "$test_home/.config/omarchy/hooks/symlink-event.d/20-user" "user-after-symlinks"
+HOME="$test_home" \
+  OMARCHY_PATH="$core_root" \
+  XDG_DATA_DIRS="$vendor_one:$vendor_two" \
+  HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" symlink-event 2>"$test_tmp/symlink-hook.err"
+expected_symlink_order=$(printf '%s\n' safe-flat-after-symlink user-after-symlinks)
+assert_lines "package hook symlinks do not shadow later trusted hooks" "$expected_symlink_order"
+symlink_warning_count=$(grep -Fc "Skipping unsafe package hook path:" "$test_tmp/symlink-hook.err")
+(( symlink_warning_count == 2 )) || fail "unsafe package hook symlinks are reported"
+pass "unsafe package hook symlinks are reported"
+
+: >"$hook_log"
+ln -s "$vendor_one" "$test_tmp/package-root-link"
+HOME="$test_home" \
+  OMARCHY_PATH="$core_root" \
+  XDG_DATA_DIRS="$test_tmp/package-root-link" \
+  HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" vendor-event 2>"$test_tmp/symlink-root.err"
+[[ ! -s $hook_log ]] || fail "a symlinked XDG package root executes no hook"
+grep -Fq "Skipping unsafe package hook path:" "$test_tmp/symlink-root.err" || fail "a symlinked XDG package root is reported"
+pass "symlinked XDG package roots are skipped"
+
+: >"$hook_log"
+newline_vendor="$test_tmp/vendor"$'\n'"newline"
+make_hook "$newline_vendor/omarchy/hooks/newline-event" "newline-package"
+HOME="$test_home" \
+  OMARCHY_PATH="$core_root" \
+  XDG_DATA_DIRS="$newline_vendor" \
+  HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" newline-event
+assert_lines "newlines in XDG data paths are preserved" "newline-package"
+
+: >"$hook_log"
+make_hook "$vendor_one/omarchy/hooks/alias-event.d/10-shared" "vendor-before-user"
+make_hook "$test_home/.config/omarchy/hooks/alias-event.d/10-shared" "user-still-runs"
+HOME="$test_home" \
+  OMARCHY_PATH="$test_home/.config/omarchy" \
+  XDG_DATA_DIRS="$vendor_one" \
+  HOOK_LOG="$hook_log" \
+  "$ROOT/bin/omarchy-hook" alias-event
+expected_alias_order=$(printf '%s\n' vendor-before-user user-still-runs)
+assert_lines "the canonical user root always runs last as the user layer" "$expected_alias_order"
 
 root_list() {
   local root


### PR DESCRIPTION
## Summary

- discover system hooks from the active `$OMARCHY_PATH` and `${XDG_DATA_DIRS}/omarchy/hooks`
- run package/core hooks before user hooks while shadowing duplicate system hook names
- document package-managed hook layout, ordering, and development-tree behavior
- add focused coverage for ordering, fallback paths, deduplication, shadowing, failures, and sample hooks

## Tests

- `bash test/shell.d/hook-test.sh`
- `./test/cli`
- `./test/shell` (the new hook suite passes; the aggregate run still reports six unrelated environment/baseline failures in config, snapper, unowned-system-paths, theme-install-guards, launch-about, and windows-vm-mount-boundary)