### PR TITLE
Answer an abandoned menu request before starting the next one

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -22,6 +22,14 @@ Item {
     var payload = ({})
     try { payload = JSON.parse(payloadJson || "{}") } catch (e) { payload = ({}) }
 
+    // A select/input request left in flight when a new summon arrives
+    // (e.g. the trigger key repeated before the prior one was answered)
+    // would otherwise have its doneFile silently abandoned by
+    // openDmenu/openExistingMenu below, leaving the caller that's still
+    // polling for it (bin/omarchy-menu-select) blocked forever. Answer it
+    // as cancelled first so every summon always resolves.
+    if (root.requestActive) root.finishRequest(null)
+
     if (payload.fontFamily) root.fontFamily = payload.fontFamily
 
     if (payload.mode === "select" || payload.mode === "input") {


### PR DESCRIPTION
## Summary

Repeating a menu-summoning keybinding (e.g. `Super+K` for the Keybindings
cheat sheet) before the previous popup was answered leaks a permanently
stuck `omarchy-menu-select` process per extra press. On a real system this
accumulates into hundreds of orphaned processes over time.

Fixes #9057.

## Root cause

`bin/omarchy-menu-select` creates a `doneFile`, asks the shell to summon
`omarchy.menu`, then polls for that file:

```bash
while [[ ! -e $done_file ]]; do
  sleep 0.05
done
```

In `shell/plugins/menu/Menu.qml`, `open(payloadJson)` dispatches to either
`openDmenu()` (select/input requests) or `openRoute()` → `openExistingMenu()`
(plain menu routes). Both unconditionally overwrite
`selectionFile`/`doneFile`/`requestActive` with the new request's values:

```qml
function openDmenu(payload) {
  ...
  selectionFile = String(payload.selectionFile || "")
  doneFile = String(payload.doneFile || "")
  requestActive = !!doneFile
  ...
}
```

```qml
function openExistingMenu(initialMenu) {
  ...
  requestActive = false
  selectionFile = ""
  doneFile = ""
  ...
}
```

If a request is already in flight (its caller is still polling for a
`doneFile` that hasn't been written yet), neither function finishes it —
they just drop the reference to its files. Nothing will ever create that
`doneFile`, so the earlier `omarchy-menu-select` process spins in its
`sleep 0.05` loop forever.

`cancel()` already handles this correctly for the normal close path:

```qml
function cancel() {
  if (root.dmenuActive) root.finishRequest(null)
  opened = false
  filterText = ""
}
```

`open()` just doesn't call it before replacing the in-flight request.

## Fix

Finish any active request as cancelled at the top of `open()`, before
dispatching to either `openDmenu()` or `openRoute()`:

```qml
if (root.requestActive) root.finishRequest(null)
```

This reuses the existing `finishRequest()` plumbing (same as `cancel()`),
so the superseded request's `doneFile` is always written and its caller
exits (with an empty selection, i.e. as if cancelled) instead of hanging.

## Repro

```bash
for i in $(seq 1 20); do
  /usr/share/omarchy/bin/omarchy-menu-keybindings >/dev/null 2>&1 &
done
sleep 2
ps aux | grep -c '[o]marchy-menu-select'
```

Before this change, that count grows by one per invocation and never
drops. Full diagnostics and root-cause writeup are in #9057.

## Test plan

- [ ] Reviewer confirms in a running desktop: spam the Keybindings
      keybinding several times without dismissing, then check
      `ps aux | grep omarchy-menu-select` drops back to 0 shortly after.
- [ ] `omarchy restart shell` after the change, exercise the menu normally
      (open, select, cancel, reopen) to confirm no regression to the usual
      flow.
- Not run here: `./test/all` and the graphical acceptance suite, which per
  `agents/skills/acceptance-tests.md` require a disposable VM via the
  sibling `omarchy-iso` repo, not available in this environment.