### PR TITLE
Add theme startup sounds

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -22,7 +22,8 @@ OMARCHY_THEMES_PATH="$OMARCHY_PATH/themes"
 # loads its neovim.lua at startup, so no .lua from such a theme is staged at all.
 # Each terminal config names the program the terminal launches, and vscode.json
 # names an extension omarchy-theme-set-vscode installs, a VS Code extension being
-# arbitrary JavaScript. Everything else a theme ships is colour and is kept.
+# arbitrary JavaScript. Everything else a theme ships is declarative data and
+# is kept; startup.wav is parsed into bounded raw PCM before playback.
 #
 # Adding a template for another terminal, or for another editor that loads Lua,
 # means adding it here. test/shell.d/theme-staging-test.sh fails on a generated

--- a/bin/omarchy-theme-startup-sound
+++ b/bin/omarchy-theme-startup-sound
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# omarchy:summary=Play the current theme's startup sound, if it ships one
+# omarchy:examples=omarchy theme startup sound
+
+# A theme names its startup sound startup.<ext> and Hyprland runs this at login.
+# The file may come from a stranger's repo through `omarchy theme install`, so it
+# is treated as data and nothing more: it is handed to pw-play, which decodes
+# through libsndfile and has no scripting, playlist or network support, rather
+# than to mpv. Before that the file has to be a regular file under the staged
+# theme, carry an audio extension, be identified as audio by its contents and fit
+# under the size cap. Playback is cut off at a fixed number of seconds, so a
+# theme cannot turn a login into an hour of noise.
+
+THEME_PATH="$HOME/.local/state/omarchy/current/theme"
+SOUND_EXTENSIONS=(wav flac ogg oga opus mp3)
+MAX_SOUND_BYTES=$((10 * 1024 * 1024))
+MAX_SOUND_SECONDS=15
+SINK_WAIT_SECONDS=10
+
+find_startup_sound() {
+  local extension candidate
+
+  for extension in "${SOUND_EXTENSIONS[@]}"; do
+    candidate="$THEME_PATH/startup.$extension"
+
+    if [[ -L $candidate ]]; then
+      echo "Refusing $candidate: a startup sound cannot be a symlink" >&2
+      return 1
+    fi
+
+    if [[ -f $candidate ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+sound_is_playable() {
+  local sound="$1"
+  local size mime
+
+  size=$(stat -c %s -- "$sound")
+  if (( size > MAX_SOUND_BYTES )); then
+    echo "Refusing $sound: larger than $MAX_SOUND_BYTES bytes" >&2
+    return 1
+  fi
+
+  mime=$(file -b --mime-type -- "$sound")
+  case "$mime" in
+    audio/* | application/ogg) ;;
+    *)
+      echo "Refusing $sound: identified as $mime, not audio" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Hyprland starts this before WirePlumber has necessarily brought a sink up.
+wait_for_audio_sink() {
+  local waited=0
+
+  while ! wpctl inspect @DEFAULT_AUDIO_SINK@ >/dev/null 2>&1; do
+    (( waited < SINK_WAIT_SECONDS * 2 )) || return 1
+    sleep 0.5
+    waited=$((waited + 1))
+  done
+}
+
+if omarchy-toggle-enabled startup-sound-off; then
+  exit 0
+fi
+
+sound=$(find_startup_sound) || exit 0
+sound_is_playable "$sound" || exit 1
+wait_for_audio_sink || exit 0
+
+timeout "$MAX_SOUND_SECONDS" pw-play "$sound" >/dev/null 2>&1

--- a/bin/omarchy-theme-startup-sound
+++ b/bin/omarchy-theme-startup-sound
@@ -1,80 +1,162 @@
 #!/bin/bash
 
-# omarchy:summary=Play the current theme's startup sound, if it ships one
-# omarchy:examples=omarchy theme startup sound
+# omarchy:summary=Play the current theme's startup sound, if enabled
 
-# A theme names its startup sound startup.<ext> and Hyprland runs this at login.
-# The file may come from a stranger's repo through `omarchy theme install`, so it
-# is treated as data and nothing more: it is handed to pw-play, which decodes
-# through libsndfile and has no scripting, playlist or network support, rather
-# than to mpv. Before that the file has to be a regular file under the staged
-# theme, carry an audio extension, be identified as audio by its contents and fit
-# under the size cap. Playback is cut off at a fixed number of seconds, so a
-# theme cannot turn a login into an hour of noise.
+# A startup sound may come from a stranger's theme repo. Keep those bytes out
+# of native media decoders: accept one small, canonical PCM WAV layout, copy its
+# samples into a private file, and give pw-play raw PCM instead of the container.
 
 THEME_PATH="$HOME/.local/state/omarchy/current/theme"
-SOUND_EXTENSIONS=(wav flac ogg oga opus mp3)
-MAX_SOUND_BYTES=$((10 * 1024 * 1024))
+SOUND_PATH="$THEME_PATH/startup.wav"
 MAX_SOUND_SECONDS=15
+PLAYER_TIMEOUT_SECONDS=$((MAX_SOUND_SECONDS + 2))
+WAVE_HEADER_BYTES=44
+MAX_SOUND_BYTES=$((WAVE_HEADER_BYTES + MAX_SOUND_SECONDS * 48000 * 2 * 2))
+MAX_STREAM_VOLUME=0.25
 SINK_WAIT_SECONDS=10
+COMMAND_KILL_GRACE=1s
 
-find_startup_sound() {
-  local extension candidate
+WAVE_CHANNELS=""
+WAVE_SAMPLE_RATE=""
+WAVE_DATA_BYTES=""
+snapshot_dir=""
 
-  for extension in "${SOUND_EXTENSIONS[@]}"; do
-    candidate="$THEME_PATH/startup.$extension"
+cleanup() {
+  if [[ -n $snapshot_dir && -d $snapshot_dir ]]; then
+    rm -rf -- "$snapshot_dir"
+  fi
+}
 
-    if [[ -L $candidate ]]; then
-      echo "Refusing $candidate: a startup sound cannot be a symlink" >&2
-      return 1
-    fi
-
-    if [[ -f $candidate ]]; then
-      echo "$candidate"
-      return 0
-    fi
-  done
-
+refuse_invalid_wave() {
+  echo "Refusing $SOUND_PATH: startup.wav must be canonical 16-bit PCM WAV audio" >&2
   return 1
+}
+
+startup_sound_exists() {
+  if [[ -L $SOUND_PATH ]]; then
+    echo "Refusing $SOUND_PATH: a startup sound cannot be a symlink" >&2
+    return 1
+  elif [[ -e $SOUND_PATH && ! -f $SOUND_PATH ]]; then
+    echo "Refusing $SOUND_PATH: a startup sound must be a regular file" >&2
+    return 1
+  else
+    [[ -f $SOUND_PATH ]]
+  fi
+}
+
+# Copy at most one byte beyond the limit. Validation and playback then use only
+# this private snapshot, so a concurrent theme switch cannot swap the decoder's
+# input after it has been checked.
+snapshot_startup_sound() {
+  local snapshot="$1"
+
+  if [[ -L $SOUND_PATH || ! -f $SOUND_PATH ]]; then
+    echo "Refusing $SOUND_PATH: the startup sound changed before it could be checked" >&2
+    return 1
+  fi
+
+  if ! timeout --kill-after="$COMMAND_KILL_GRACE" 2s \
+    dd if="$SOUND_PATH" of="$snapshot" bs=64K count="$((MAX_SOUND_BYTES + 1))" \
+      iflag=nofollow,count_bytes status=none; then
+    echo "Refusing $SOUND_PATH: the startup sound could not be copied safely" >&2
+    return 1
+  fi
 }
 
 sound_is_playable() {
   local sound="$1"
-  local size mime
+  local -a header
+  local file_size riff_size fmt_size audio_format channels sample_rate
+  local byte_rate block_align bits_per_sample data_size expected_block_align
 
-  size=$(stat -c %s -- "$sound")
-  if (( size > MAX_SOUND_BYTES )); then
-    echo "Refusing $sound: larger than $MAX_SOUND_BYTES bytes" >&2
+  file_size=$(stat -c %s -- "$sound") || return 1
+  if (( file_size > MAX_SOUND_BYTES )); then
+    echo "Refusing $SOUND_PATH: larger than $MAX_SOUND_BYTES bytes" >&2
     return 1
   fi
 
-  mime=$(file -b --mime-type -- "$sound")
-  case "$mime" in
-    audio/* | application/ogg) ;;
-    *)
-      echo "Refusing $sound: identified as $mime, not audio" >&2
-      return 1
-      ;;
-  esac
+  read -r -a header < <(od -An -v -tu1 -w44 -N"$WAVE_HEADER_BYTES" -- "$sound")
+  if (( ${#header[@]} != WAVE_HEADER_BYTES )); then
+    refuse_invalid_wave
+    return 1
+  fi
+
+  # Exact canonical layout: RIFF(size) WAVE fmt\x20(16, PCM, mono/stereo,
+  # rate, byte rate, alignment, 16-bit) data(size), followed by samples.
+  if (( header[0] != 82 || header[1] != 73 || header[2] != 70 || header[3] != 70 ||
+        header[8] != 87 || header[9] != 65 || header[10] != 86 || header[11] != 69 ||
+        header[12] != 102 || header[13] != 109 || header[14] != 116 || header[15] != 32 ||
+        header[36] != 100 || header[37] != 97 || header[38] != 116 || header[39] != 97 )); then
+    refuse_invalid_wave
+    return 1
+  fi
+
+  riff_size=$((header[4] | header[5] << 8 | header[6] << 16 | header[7] << 24))
+  fmt_size=$((header[16] | header[17] << 8 | header[18] << 16 | header[19] << 24))
+  audio_format=$((header[20] | header[21] << 8))
+  channels=$((header[22] | header[23] << 8))
+  sample_rate=$((header[24] | header[25] << 8 | header[26] << 16 | header[27] << 24))
+  byte_rate=$((header[28] | header[29] << 8 | header[30] << 16 | header[31] << 24))
+  block_align=$((header[32] | header[33] << 8))
+  bits_per_sample=$((header[34] | header[35] << 8))
+  data_size=$((header[40] | header[41] << 8 | header[42] << 16 | header[43] << 24))
+  expected_block_align=$((channels * 2))
+
+  if (( fmt_size != 16 || audio_format != 1 ||
+        (channels != 1 && channels != 2) ||
+        (sample_rate != 44100 && sample_rate != 48000) ||
+        bits_per_sample != 16 || block_align != expected_block_align ||
+        byte_rate != sample_rate * block_align ||
+        riff_size != file_size - 8 || data_size != file_size - WAVE_HEADER_BYTES ||
+        data_size == 0 || data_size % block_align != 0 )); then
+    refuse_invalid_wave
+    return 1
+  fi
+
+  if (( data_size > MAX_SOUND_SECONDS * byte_rate )); then
+    echo "Refusing $SOUND_PATH: longer than $MAX_SOUND_SECONDS seconds" >&2
+    return 1
+  fi
+
+  WAVE_CHANNELS=$channels
+  WAVE_SAMPLE_RATE=$sample_rate
+  WAVE_DATA_BYTES=$data_size
 }
 
 # Hyprland starts this before WirePlumber has necessarily brought a sink up.
+# Each probe has its own hard deadline as well as the overall wait deadline.
 wait_for_audio_sink() {
-  local waited=0
+  local deadline=$((SECONDS + SINK_WAIT_SECONDS))
 
-  while ! wpctl inspect @DEFAULT_AUDIO_SINK@ >/dev/null 2>&1; do
-    (( waited < SINK_WAIT_SECONDS * 2 )) || return 1
+  while ! timeout --kill-after=0.1s 0.5s wpctl inspect @DEFAULT_AUDIO_SINK@ >/dev/null 2>&1; do
+    (( SECONDS < deadline )) || return 1
     sleep 0.5
-    waited=$((waited + 1))
   done
 }
 
-if omarchy-toggle-enabled startup-sound-off; then
-  exit 0
-fi
-
-sound=$(find_startup_sound) || exit 0
-sound_is_playable "$sound" || exit 1
+# Third-party themes can carry the sound, so playback requires an explicit
+# opt-in instead of letting a newly selected theme make noise by default.
+omarchy-toggle-enabled startup-sound-enabled || exit 0
+startup_sound_exists || exit 0
 wait_for_audio_sink || exit 0
 
-timeout "$MAX_SOUND_SECONDS" pw-play "$sound" >/dev/null 2>&1
+umask 077
+snapshot_dir=$(mktemp -d "${XDG_RUNTIME_DIR:-/tmp}/omarchy-startup-sound.XXXXXX") || exit 1
+trap cleanup EXIT
+
+snapshot="$snapshot_dir/startup.wav"
+raw_sound="$snapshot_dir/startup.raw"
+
+snapshot_startup_sound "$snapshot" || exit 1
+sound_is_playable "$snapshot" || exit 1
+tail -c +$((WAVE_HEADER_BYTES + 1)) -- "$snapshot" >"$raw_sound" || exit 1
+
+if (( $(stat -c %s -- "$raw_sound") != WAVE_DATA_BYTES )); then
+  echo "Refusing $SOUND_PATH: the startup sound changed while being prepared" >&2
+  exit 1
+fi
+
+timeout --kill-after="$COMMAND_KILL_GRACE" "$PLAYER_TIMEOUT_SECONDS" \
+  pw-play --raw --format=s16 --rate="$WAVE_SAMPLE_RATE" --channels="$WAVE_CHANNELS" \
+    --volume="$MAX_STREAM_VOLUME" "$raw_sound" \
+    >/dev/null 2>&1

--- a/bin/omarchy-toggle-startup-sound
+++ b/bin/omarchy-toggle-startup-sound
@@ -5,10 +5,10 @@
 # nf-md-volume_high, escaped so this file reads without a Nerd Font.
 readonly SOUND_GLYPH=$'\U000f057e'
 
-omarchy-toggle startup-sound-off
+omarchy-toggle startup-sound-enabled
 
-if omarchy-toggle-enabled startup-sound-off; then
-  omarchy-notification-send -g "$SOUND_GLYPH" "Startup sound disabled"
-else
+if omarchy-toggle-enabled startup-sound-enabled; then
   omarchy-notification-send -g "$SOUND_GLYPH" "Startup sound enabled"
+else
+  omarchy-notification-send -g "$SOUND_GLYPH" "Startup sound disabled"
 fi

--- a/bin/omarchy-toggle-startup-sound
+++ b/bin/omarchy-toggle-startup-sound
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle the theme startup sound played at login
+
+# nf-md-volume_high, escaped so this file reads without a Nerd Font.
+readonly SOUND_GLYPH=$'\U000f057e'
+
+omarchy-toggle startup-sound-off
+
+if omarchy-toggle-enabled startup-sound-off; then
+  omarchy-notification-send -g "$SOUND_GLYPH" "Startup sound disabled"
+else
+  omarchy-notification-send -g "$SOUND_GLYPH" "Startup sound enabled"
+fi

--- a/default/agents/skills/omarchy/theming.md
+++ b/default/agents/skills/omarchy/theming.md
@@ -33,14 +33,8 @@ the terminal configs `alacritty.toml`, `foot.ini`, `ghostty.conf` and
 (names a VS Code extension to install). Those are regenerated from `colors.toml`
 through `$OMARCHY_PATH/default/themed/*.tpl`, and named on stderr.
 
-Everything else a cloned theme ships is kept, including `btop.theme`,
-`chromium.theme`, `helix.toml`, `icons.theme`, `keyboard.rgb`, `shell.toml` and
-a `startup.<ext>` sound (`wav`, `flac`, `ogg`, `oga`, `opus` or `mp3`), which
-`omarchy-theme-startup-sound` plays at login through `pw-play` after checking it
-really is audio, is under 10 MiB, and cutting it off at 15 seconds.
-`omarchy toggle startup sound` turns startup sounds off for every theme.
-Omarchy tells a cloned theme from the user's own by the `.git` directory a clone
-leaves behind.
+Everything else a cloned theme ships is kept, including `btop.theme`, `chromium.theme`, `helix.toml`, `icons.theme`, `keyboard.rgb`, `shell.toml` and a `startup.wav` sound. Startup sounds are off by default; `omarchy toggle startup sound` opts in. `omarchy-theme-startup-sound` accepts only canonical mono or stereo 16-bit PCM at 44.1 or 48 kHz for up to 15 seconds, extracts the raw samples into a private snapshot, and gives those to `pw-play --raw` under a hard timeout and volume cap, avoiding native container and codec parsing.
+Omarchy tells a cloned theme from the user's own by the `.git` directory a clone leaves behind.
 
 To change how Omarchy themes an app for every theme, write the template rather
 than the theme: `~/.config/omarchy/themed/<config-name>.tpl` overrides the

--- a/default/agents/skills/omarchy/theming.md
+++ b/default/agents/skills/omarchy/theming.md
@@ -34,7 +34,11 @@ the terminal configs `alacritty.toml`, `foot.ini`, `ghostty.conf` and
 through `$OMARCHY_PATH/default/themed/*.tpl`, and named on stderr.
 
 Everything else a cloned theme ships is kept, including `btop.theme`,
-`chromium.theme`, `helix.toml`, `icons.theme`, `keyboard.rgb` and `shell.toml`.
+`chromium.theme`, `helix.toml`, `icons.theme`, `keyboard.rgb`, `shell.toml` and
+a `startup.<ext>` sound (`wav`, `flac`, `ogg`, `oga`, `opus` or `mp3`), which
+`omarchy-theme-startup-sound` plays at login through `pw-play` after checking it
+really is audio, is under 10 MiB, and cutting it off at 15 seconds.
+`omarchy toggle startup sound` turns startup sounds off for every theme.
 Omarchy tells a cloned theme from the user's own by the `.git` directory a clone
 leaves behind.
 

--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -8,6 +8,7 @@ hl.on("hyprland.start", function()
   hl.exec_cmd("omarchy-powerprofiles-init")
   hl.exec_cmd(o.launch("omarchy-hyprland-monitor-watch"))
   hl.exec_cmd(o.launch("udiskie --automount --no-notify --no-tray"))
+  hl.exec_cmd("omarchy-theme-startup-sound")
 
   -- Run post-boot hooks after startup config has loaded.
   hl.exec_cmd("sleep 2 && omarchy-hook post-boot")

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -90,6 +90,7 @@
   "trigger.toggle.idle-lock": {"icon":"󰅶","label":"Stay Awake","action":"omarchy-toggle-idle"},
   "trigger.toggle.notifications": {"icon":"󰂛","label":"Notifications","action":"omarchy-toggle-notification-silencing"},
   "trigger.toggle.crash-capture": {"icon":"󱚡","label":"Crash Capture","action":"omarchy-toggle-crash-capture"},
+  "trigger.toggle.startup-sound": {"icon":"󰕾","label":"Startup Sound","action":"omarchy-toggle-startup-sound"},
   "trigger.toggle.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-toggle-screensaver"},
   "trigger.toggle.nightlight": {"icon":"󰔎","label":"Nightlight","action":"omarchy-toggle-nightlight"},
   "trigger.toggle.top-bar": {"icon":"󰍜","label":"Menu Bar","action":"omarchy-toggle-bar"},

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -11,7 +11,7 @@ ship `backgrounds/` (users overlay their own via
 `~/.config/omarchy/backgrounds/<name>/`; the active image is the
 `~/.local/state/omarchy/current/background` symlink), `preview.png` and
 `preview-unlock.png` for the theme switcher, `icons.theme`, `keyboard.rgb`,
-`unlock.png`, and a `light.mode` marker file.
+`unlock.png`, a `light.mode` marker file, and a [startup sound](#startup-sound).
 
 A theme installed from a git repo is held to a much shorter list; see [What an installed theme may not ship](#what-an-installed-theme-may-not-ship).
 
@@ -64,6 +64,18 @@ A theme predating `colors.toml` is not left without a palette: its `alacritty.to
 The restriction lives in `omarchy-theme-set` rather than in `omarchy-theme-install` on purpose. Filtering at staging also covers themes installed before the rule existed and files a theme gains later through `omarchy theme update`.
 
 What this does not cover: a theme distributed as an archive rather than a git repo, extracted into `~/.config/omarchy/themes/` by hand, is indistinguishable from one the user wrote and stages in full. `omarchy theme install` only takes git URLs, so the supported path is always filtered, but the check is a statement about where a theme came from and not a sandbox.
+
+## Startup sound
+
+A theme can ship one sound that plays when the session starts, named `startup.<ext>` with `<ext>` one of `wav`, `flac`, `ogg`, `oga`, `opus` or `mp3`. `default/hypr/autostart.lua` runs `omarchy-theme-startup-sound` on `hyprland.start`; it reads the sound from the staged theme at `~/.local/state/omarchy/current/theme/`, waits up to ten seconds for WirePlumber to expose a default sink, and plays it. `omarchy toggle startup sound` sets the `startup-sound-off` toggle flag, which the command honours before it looks for a file.
+
+The sound is the one theme file a stranger's repo can ship that is neither colour nor code, and it is handled as data throughout:
+
+- It is staged like any other file — a cloned theme's `startup.ogg` is kept, a symlinked one is dropped by `stage_installed_theme` — and `omarchy-theme-startup-sound` refuses a symlink again at play time, since the staged directory is user-writable state.
+- It is played with `pw-play`, which decodes through libsndfile and understands nothing but audio. `mpv` is deliberately not used: it reads `~/.config/mpv/scripts`, follows playlists, and fetches URLs, all of which an untrusted file could steer.
+- Before playback the file must carry one of the listed extensions, be identified as `audio/*` (or `application/ogg`) by `file --mime-type`, and be no larger than 10 MiB. Playback runs under `timeout` and is cut off after 15 seconds.
+
+`test/shell.d/theme-startup-sound-test.sh` covers each refusal against a stub `pw-play`.
 
 ## `colors.toml`
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -67,15 +67,22 @@ What this does not cover: a theme distributed as an archive rather than a git re
 
 ## Startup sound
 
-A theme can ship one sound that plays when the session starts, named `startup.<ext>` with `<ext>` one of `wav`, `flac`, `ogg`, `oga`, `opus` or `mp3`. `default/hypr/autostart.lua` runs `omarchy-theme-startup-sound` on `hyprland.start`; it reads the sound from the staged theme at `~/.local/state/omarchy/current/theme/`, waits up to ten seconds for WirePlumber to expose a default sink, and plays it. `omarchy toggle startup sound` sets the `startup-sound-off` toggle flag, which the command honours before it looks for a file.
+A theme can ship one sound named `startup.wav`. `default/hypr/autostart.lua` runs `omarchy-theme-startup-sound` on `hyprland.start`; the command waits up to ten seconds for WirePlumber to expose a default sink and plays the sound only after the user opts in with `omarchy toggle startup sound`. Startup sounds are off by default so selecting a visual theme never unexpectedly makes noise.
 
-The sound is the one theme file a stranger's repo can ship that is neither colour nor code, and it is handled as data throughout:
+The sound is the one theme file a stranger's repo can ship that is neither colour nor code, so its processing deliberately avoids general-purpose media decoders:
 
-- It is staged like any other file — a cloned theme's `startup.ogg` is kept, a symlinked one is dropped by `stage_installed_theme` — and `omarchy-theme-startup-sound` refuses a symlink again at play time, since the staged directory is user-writable state.
-- It is played with `pw-play`, which decodes through libsndfile and understands nothing but audio. `mpv` is deliberately not used: it reads `~/.config/mpv/scripts`, follows playlists, and fetches URLs, all of which an untrusted file could steer.
-- Before playback the file must carry one of the listed extensions, be identified as `audio/*` (or `application/ogg`) by `file --mime-type`, and be no larger than 10 MiB. Playback runs under `timeout` and is cut off after 15 seconds.
+- A cloned theme's regular `startup.wav` is staged, while `stage_installed_theme` drops symlinks. At playback, `omarchy-theme-startup-sound` copies no more than one byte beyond the 2,880,044-byte valid-file limit into a private runtime snapshot without following a final symlink.
+- The snapshot must be a canonical 44-byte-header RIFF/WAVE file containing signed 16-bit little-endian PCM, one or two channels, a sample rate of 44.1 or 48 kHz, no metadata or extra chunks, and no more than 15 seconds of samples.
+- The command extracts only the sample bytes and invokes `pw-play --raw` with the validated format values. This bypasses libsndfile and other container or codec parsers entirely.
+- Playback uses a private sample file with an exact validated length, a 25% stream-volume cap, and a `timeout --kill-after` deadline. WirePlumber probes and the bounded snapshot copy have hard deadlines too.
 
-`test/shell.d/theme-startup-sound-test.sh` covers each refusal against a stub `pw-play`.
+Convert another audio file to the accepted layout with:
+
+```bash
+ffmpeg -i input.ext -t 15 -map_metadata -1 -ac 2 -ar 48000 -c:a pcm_s16le -fflags +bitexact -flags:a +bitexact startup.wav
+```
+
+`test/shell.d/theme-startup-sound-test.sh` covers the format boundary, known malicious fixtures, timeout enforcement, opt-in state, and concurrent theme replacement against a stub `pw-play`.
 
 ## `colors.toml`
 

--- a/manual/43-making-your-own-theme.md
+++ b/manual/43-making-your-own-theme.md
@@ -30,9 +30,9 @@ Themes supplied with `unlock.png` and `preview-unlock.png` images will be listed
 
 ### Startup sound
 
-A theme can play a short sound when you log in. Add a file called `startup.wav`, `startup.flac`, `startup.ogg`, `startup.oga`, `startup.opus` or `startup.mp3` to the root of your theme and it plays once the audio system is up. Keep it short and small: playback stops after 15 seconds and files over 10 MB are ignored. You can try it out without logging in again with `omarchy theme startup sound`.
+A theme can play a short sound when you log in. Add a file called `startup.wav` to the root of your theme. For safety, it must be a plain 16-bit PCM WAV with one or two channels, a 44.1 or 48 kHz sample rate, no metadata chunks, and no more than 15 seconds of audio. Convert another audio file to that exact layout with `ffmpeg -i input.ext -t 15 -map_metadata -1 -ac 2 -ar 48000 -c:a pcm_s16le -fflags +bitexact -flags:a +bitexact startup.wav`.
 
-If you'd rather log in quietly whatever the theme says, turn startup sounds off under _Toggle > Startup Sound_ in the Omarchy menu, or with `omarchy toggle startup sound`.
+Startup sounds are off by default. Enable them under _Toggle > Startup Sound_ in the Omarchy menu, or with `omarchy toggle startup sound`, then try the current theme's sound without logging in again with `omarchy theme startup sound`. Playback is capped at 25% stream volume and stops after 15 seconds.
 
 ### Theming apps Omarchy doesn't cover
 

--- a/manual/43-making-your-own-theme.md
+++ b/manual/43-making-your-own-theme.md
@@ -12,7 +12,7 @@ A theme you write yourself in `~/.config/omarchy/themes` can contain whatever yo
 
 A theme you install from someone else's repo with `omarchy theme install` keeps everything that's colour, and loses the handful of files that would run code on your machine: any `.lua` file, the terminal configs (`alacritty.toml`, `foot.ini`, `ghostty.conf`, `kitty.conf`), and `vscode.json`. A theme's `hyprland.lua` is Lua your compositor runs at login, a terminal config names the program your terminal starts, and `vscode.json` names a VSCode extension to install. Installing someone's theme should change what your desktop looks like, never what it runs.
 
-Everything else still works exactly as the theme author wrote it — `btop.theme`, `chromium.theme`, `helix.toml`, `icons.theme`, `shell.toml`, the backgrounds and the previews are all kept. Only what was dropped gets regenerated from `colors.toml` on your machine.
+Everything else still works exactly as the theme author wrote it — `btop.theme`, `chromium.theme`, `helix.toml`, `icons.theme`, `shell.toml`, the backgrounds, the previews and the startup sound are all kept. Only what was dropped gets regenerated from `colors.toml` on your machine.
 
 Omarchy tells the two apart by whether the theme has its own git repo inside it, which is what `omarchy theme install` leaves behind when it clones. So a theme you wrote stays yours, and one you pulled off the internet stays colours.
 
@@ -27,6 +27,12 @@ If you'd like to color-match the file manager icons to your theme, add a file ca
 ### Unlock image
 
 Themes supplied with `unlock.png` and `preview-unlock.png` images will be listed under _Style > Unlock_. Your `unlock.png` should preferably be a transparent png. And you can create the preview image using `omarchy plymouth preview`.
+
+### Startup sound
+
+A theme can play a short sound when you log in. Add a file called `startup.wav`, `startup.flac`, `startup.ogg`, `startup.oga`, `startup.opus` or `startup.mp3` to the root of your theme and it plays once the audio system is up. Keep it short and small: playback stops after 15 seconds and files over 10 MB are ignored. You can try it out without logging in again with `omarchy theme startup sound`.
+
+If you'd rather log in quietly whatever the theme says, turn startup sounds off under _Toggle > Startup Sound_ in the Omarchy menu, or with `omarchy toggle startup sound`.
 
 ### Theming apps Omarchy doesn't cover
 

--- a/test/shell.d/theme-staging-test.sh
+++ b/test/shell.d/theme-staging-test.sh
@@ -99,8 +99,8 @@ assert_staged backgrounds/1-real.png "an image in backgrounds/ is staged"
 assert_not_staged unlock.png "a symlink is not followed out of the theme"
 assert_not_staged vscode.json "vscode.json names an extension to install and is not staged"
 
-# A startup sound is data that omarchy-theme-startup-sound checks again before
-# playing, so it is kept; a symlinked one is refused like any other symlink.
+# A startup sound is kept as data. The playback command accepts only canonical
+# PCM and extracts raw samples rather than sending the container to a decoder.
 assert_staged startup.wav "the theme's startup sound is staged"
 assert_not_staged startup.ogg "a symlinked startup sound is not followed"
 

--- a/test/shell.d/theme-staging-test.sh
+++ b/test/shell.d/theme-staging-test.sh
@@ -84,7 +84,9 @@ printf 'png\n' >"$hostile/preview.png"
 printf 'png\n' >"$hostile/backgrounds/1-real.png"
 printf '%s\n' "$marker" >"$hostile/backgrounds/payload.sh"
 printf '# notes\n' >"$hostile/README.md"
+printf 'RIFF\n' >"$hostile/startup.wav"
 ln -s /etc/hostname "$hostile/unlock.png"
+ln -s /etc/hostname "$hostile/startup.ogg"
 
 set_theme hostile || fail "omarchy-theme-set applies a theme that ships disallowed files"
 
@@ -96,6 +98,11 @@ assert_staged backgrounds/1-real.png "an image in backgrounds/ is staged"
 
 assert_not_staged unlock.png "a symlink is not followed out of the theme"
 assert_not_staged vscode.json "vscode.json names an extension to install and is not staged"
+
+# A startup sound is data that omarchy-theme-startup-sound checks again before
+# playing, so it is kept; a symlinked one is refused like any other symlink.
+assert_staged startup.wav "the theme's startup sound is staged"
+assert_not_staged startup.ogg "a symlinked startup sound is not followed"
 
 assert_staged icons.theme "the theme's icon set name is staged"
 grep -q 'Yaru-red' "$(staged icons.theme)" || fail "the staged icons.theme is the theme's"

--- a/test/shell.d/theme-startup-sound-test.sh
+++ b/test/shell.d/theme-startup-sound-test.sh
@@ -2,14 +2,11 @@
 
 set -euo pipefail
 
-# A theme's startup sound may have arrived through `omarchy theme install`, so
-# omarchy-theme-startup-sound treats it as data: it plays only a regular file
-# with an audio extension that really is audio and fits under the size cap, and
-# it hands the file to pw-play rather than a player that runs scripts.
+# A theme's startup sound may have arrived through `omarchy theme install`.
+# Only a canonical PCM WAV is accepted, and pw-play receives raw samples so its
+# native container decoders never parse the untrusted file.
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
-
-require_command file
 
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
@@ -18,33 +15,96 @@ home="$test_tmp/home"
 theme="$home/.local/state/omarchy/current/theme"
 stubs="$test_tmp/bin"
 log="$test_tmp/pw-play.log"
-mkdir -p "$theme" "$stubs"
+timeout_log="$test_tmp/timeout.log"
+pid_file="$test_tmp/pw-play.pid"
+notification_log="$test_tmp/notification.log"
+runtime="$test_tmp/runtime"
+mkdir -p "$theme" "$stubs" "$runtime"
 
-cat >"$stubs/pw-play" <<'STUB'
+write_pw_play_stub() {
+  cat >"$stubs/pw-play" <<'STUB'
 #!/bin/bash
-printf '%s\n' "$*" >>"$PW_PLAY_LOG"
+printf 'args=%s\n' "$*" >>"$PW_PLAY_LOG"
+
+if [[ -n ${REPLACE_SOUND_WITH:-} ]]; then
+  cp -- "$REPLACE_SOUND_WITH" "$ORIGINAL_SOUND"
+fi
+
+raw_sound=${!#}
+printf 'payload=%s\n' "$(base64 -w 0 -- "$raw_sound")" >>"$PW_PLAY_LOG"
 STUB
+  chmod +x "$stubs/pw-play"
+}
+
+write_pw_play_stub
 
 cat >"$stubs/wpctl" <<'STUB'
 #!/bin/bash
 exit 0
 STUB
 
-chmod +x "$stubs"/*
+cat >"$stubs/omarchy-notification-send" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFICATION_LOG"
+STUB
 
-# The smallest thing libmagic calls WAVE audio: a RIFF header with no samples.
+# Keep ordinary calls unchanged, but shorten the playback deadline so a player
+# that ignores TERM can be exercised without adding 16 seconds to this test.
+cat >"$stubs/timeout" <<'STUB'
+#!/bin/bash
+original=("$@")
+kill_after=""
+
+if [[ ${1:-} == --kill-after=* ]]; then
+  kill_after=$1
+  shift
+fi
+
+duration=${1:-}
+shift || true
+
+printf '%s\n' "${original[*]}" >>"$TIMEOUT_LOG"
+
+if [[ ${1:-} == "pw-play" ]]; then
+  [[ -n $kill_after ]] || exit 98
+  exec /usr/bin/timeout --kill-after=0.1s 0.2s "$@"
+else
+  exec /usr/bin/timeout "${original[@]}"
+fi
+STUB
+
+chmod +x "$stubs/wpctl" "$stubs/timeout" "$stubs/omarchy-notification-send"
+
+# Canonical 48-byte stereo WAV: one 48 kHz, signed 16-bit PCM frame whose raw
+# sample bytes are 01 02 03 04.
 write_wav() {
-  printf 'RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00\x80\xbb\x00\x00\x00\xee\x02\x00\x04\x00\x10\x00data\x00\x00\x00\x00' >"$1"
+  printf 'RIFF\x28\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00\x80\xbb\x00\x00\x00\xee\x02\x00\x04\x00\x10\x00data\x04\x00\x00\x00\x01\x02\x03\x04' >"$1"
+}
+
+write_other_wav() {
+  printf 'RIFF\x28\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00\x80\xbb\x00\x00\x00\xee\x02\x00\x04\x00\x10\x00data\x04\x00\x00\x00\x09\x0a\x0b\x0c' >"$1"
+}
+
+write_mono_wav() {
+  printf 'RIFF\x26\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00\x80\xbb\x00\x00\x00\x77\x01\x00\x02\x00\x10\x00data\x02\x00\x00\x00\x05\x06' >"$1"
+}
+
+enable_startup_sound() {
+  mkdir -p "$home/.local/state/omarchy/toggles"
+  touch "$home/.local/state/omarchy/toggles/startup-sound-enabled"
 }
 
 play() {
   : >"$log"
-  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stubs:$ROOT/bin:$PATH" PW_PLAY_LOG="$log" \
+  : >"$timeout_log"
+  HOME="$home" OMARCHY_PATH="$ROOT" XDG_RUNTIME_DIR="$runtime" PATH="$stubs:$ROOT/bin:$PATH" \
+    PW_PLAY_LOG="$log" TIMEOUT_LOG="$timeout_log" NOTIFICATION_LOG="$notification_log" \
+    REPLACE_SOUND_WITH="${REPLACE_SOUND_WITH:-}" ORIGINAL_SOUND="$theme/startup.wav" \
     bash "$ROOT/bin/omarchy-theme-startup-sound" 2>"$test_tmp/stderr"
 }
 
 played() {
-  [[ -s $log ]]
+  grep -q '^args=' "$log"
 }
 
 reset_theme() {
@@ -52,43 +112,96 @@ reset_theme() {
   mkdir -p "$theme"
 }
 
-# No sound in the theme: nothing plays and nothing fails.
+# Sounds are opt-in because selecting a visual theme should not make noise by
+# default, especially when that theme came from a stranger's repository.
+write_wav "$theme/startup.wav"
+play || fail "omarchy-theme-startup-sound succeeds while startup sounds are disabled"
+played && fail "nothing is played before startup sounds are explicitly enabled"
+[[ ! -s $timeout_log ]] || fail "disabled startup sounds do not probe or copy anything"
+pass "theme startup sounds are disabled by default"
+
+: >"$notification_log"
+HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stubs:$ROOT/bin:$PATH" NOTIFICATION_LOG="$notification_log" \
+  bash "$ROOT/bin/omarchy-toggle-startup-sound"
+[[ -f $home/.local/state/omarchy/toggles/startup-sound-enabled ]] || fail "the startup sound toggle creates the opt-in flag"
+grep -q 'Startup sound enabled' "$notification_log" || fail "enabling startup sounds is reported"
+
+HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stubs:$ROOT/bin:$PATH" NOTIFICATION_LOG="$notification_log" \
+  bash "$ROOT/bin/omarchy-toggle-startup-sound"
+[[ ! -f $home/.local/state/omarchy/toggles/startup-sound-enabled ]] || fail "the startup sound toggle removes the opt-in flag"
+grep -q 'Startup sound disabled' "$notification_log" || fail "disabling startup sounds is reported"
+pass "the startup sound toggle controls the positive opt-in flag"
+
+enable_startup_sound
+play || fail "omarchy-theme-startup-sound plays an enabled canonical startup.wav" "$(cat "$test_tmp/stderr")"
+grep -q '^args=--raw --format=s16 --rate=48000 --channels=2 --volume=0.25 ' "$log" ||
+  fail "pw-play receives fixed raw PCM arguments" "$(cat "$log")"
+grep -qx 'payload=AQIDBA==' "$log" || fail "pw-play receives samples without the WAV container" "$(cat "$log")"
+grep -q '^--kill-after=1s 17 pw-play ' "$timeout_log" ||
+  fail "playback has a hard kill deadline" "$(cat "$timeout_log")"
+grep -q 'dd .*iflag=nofollow,count_bytes' "$timeout_log" ||
+  fail "the bounded snapshot refuses a final symlink" "$(cat "$timeout_log")"
+pass "a canonical PCM WAV is played as bounded raw samples"
+
+# Mono is supported without asking libsndfile to discover its channel map.
+reset_theme
+write_mono_wav "$theme/startup.wav"
+play || fail "omarchy-theme-startup-sound plays canonical mono PCM"
+grep -q -- '--channels=1 --volume=0.25' "$log" || fail "mono metadata is passed explicitly" "$(cat "$log")"
+grep -qx 'payload=BQY=' "$log" || fail "mono payload reaches raw playback" "$(cat "$log")"
+pass "canonical mono PCM is played without container decoding"
+
+# No sound in the theme is a quiet success.
+reset_theme
 play || fail "omarchy-theme-startup-sound succeeds when the theme has no sound"
 played && fail "nothing is played when the theme has no startup sound"
 pass "a theme without a startup sound logs in quietly"
 
-# A real sound file is handed to pw-play by path.
-write_wav "$theme/startup.wav"
-play || fail "omarchy-theme-startup-sound plays a theme's startup.wav"
-grep -qx -- "$theme/startup.wav" "$log" || fail "pw-play receives the staged sound path" "$(cat "$log")"
-pass "a theme's startup sound is played with pw-play"
+# Other extensions are never opened, even when their contents are WAV bytes.
+write_wav "$theme/startup.mp3"
+play || fail "omarchy-theme-startup-sound ignores compressed startup sound formats"
+played && fail "a startup.mp3 is not sent to the player"
+pass "only startup.wav is considered"
 
-# The startup-sound-off toggle wins over the theme.
-mkdir -p "$home/.local/state/omarchy/toggles"
-touch "$home/.local/state/omarchy/toggles/startup-sound-off"
-play || fail "omarchy-theme-startup-sound succeeds when startup sounds are off"
-played && fail "nothing is played while startup-sound-off is set"
-rm "$home/.local/state/omarchy/toggles/startup-sound-off"
-pass "the startup-sound-off toggle silences every theme"
-
-# Only an audio extension is looked for, so a script named startup.sh is never
-# opened at all.
-reset_theme
-printf '#!/bin/bash\necho payload\n' >"$theme/startup.sh"
-play || fail "omarchy-theme-startup-sound ignores a file without an audio extension"
-played && fail "a startup.sh is not played"
-pass "a startup sound needs an audio extension"
-
-# An audio extension on something that is not audio is refused by content.
+# A WAV name on non-audio content is rejected by the exact header parser.
 reset_theme
 printf '#!/bin/bash\necho payload\n' >"$theme/startup.wav"
-play && fail "omarchy-theme-startup-sound refuses a startup.wav that is a shell script"
+play && fail "omarchy-theme-startup-sound refuses a shell script named startup.wav"
 played && fail "a shell script named startup.wav is not played"
-grep -q 'not audio' "$test_tmp/stderr" || fail "the refusal names the detected type" "$(cat "$test_tmp/stderr")"
-pass "a startup sound has to be audio by content, not just by name"
+grep -q 'canonical 16-bit PCM WAV' "$test_tmp/stderr" ||
+  fail "the refusal names the accepted format" "$(cat "$test_tmp/stderr")"
+pass "a startup sound must match the canonical WAV layout"
 
-# A symlink is refused even though staging should already have dropped it: the
-# staged theme is user-writable state.
+# The previous MIME gate accepted any audio container under a .wav name.
+reset_theme
+printf 'FORM\x00\x00\x00\x04AIFF' >"$theme/startup.wav"
+play && fail "omarchy-theme-startup-sound refuses AIFF content named startup.wav"
+played && fail "mislabeled AIFF is not played"
+pass "an audio MIME type cannot bypass the WAV format restriction"
+
+# This 1,024-channel WAVE_FORMAT_EXTENSIBLE file triggered PipeWire's
+# pre-validation channel-map overflow when handed to pw-play as a container.
+reset_theme
+printf %s 'UklGRjwAAABXQVZFZm10ICgAAAD+/wAEgLsAAAAA3AUACBAAFgAQAAEAAAABAAAAAAAQAIAAAKoAOJtxZGF0YQAAAAA=' |
+  base64 -d >"$theme/startup.wav"
+play && fail "omarchy-theme-startup-sound refuses the high-channel exploit fixture"
+played && fail "the high-channel exploit fixture never reaches pw-play"
+grep -q 'canonical 16-bit PCM WAV' "$test_tmp/stderr" ||
+  fail "the exploit fixture is rejected as non-canonical" "$(cat "$test_tmp/stderr")"
+pass "the high-channel decoder exploit is rejected before pw-play"
+
+# This malformed RIFF file loops forever inside libsndfile 1.2.2. The exact
+# layout check rejects it without invoking any container parser.
+reset_theme
+printf %s 'UklGRiEAAABXQVZFZm10IBAAAAABAAEAAABXQSAAVkYqZm1SSU5GT/9gACsA//////////////////////////f//////0ZPUk0AAFdSQUlGRqOt3L5NSU1NPgD///+x////////////////////////////////N/+8Pv81/4gAAF0AAAAAAP////8AAEABAEYA////TwBGKmZtUg==' |
+  base64 -d >"$theme/startup.wav"
+play && fail "omarchy-theme-startup-sound refuses the libsndfile hang fixture"
+played && fail "the libsndfile hang fixture never reaches pw-play"
+grep -q 'canonical 16-bit PCM WAV' "$test_tmp/stderr" ||
+  fail "the hang fixture is rejected as non-canonical" "$(cat "$test_tmp/stderr")"
+pass "the native decoder hang fixture is rejected before pw-play"
+
+# A symlink is refused even though theme staging should already have dropped it.
 reset_theme
 write_wav "$test_tmp/elsewhere.wav"
 ln -s "$test_tmp/elsewhere.wav" "$theme/startup.wav"
@@ -97,7 +210,8 @@ played && fail "a symlinked startup sound is not played"
 grep -q 'symlink' "$test_tmp/stderr" || fail "the refusal names the symlink" "$(cat "$test_tmp/stderr")"
 pass "a symlinked startup sound is not followed"
 
-# A sound over the size cap is refused before its contents are inspected.
+# Copying stops one byte beyond the cap, so an arbitrarily large source cannot
+# consume unbounded temporary storage before it is rejected.
 reset_theme
 write_wav "$theme/startup.wav"
 truncate -s 11M "$theme/startup.wav"
@@ -106,23 +220,49 @@ played && fail "an oversized startup sound is not played"
 grep -q 'larger than' "$test_tmp/stderr" || fail "the refusal names the size cap" "$(cat "$test_tmp/stderr")"
 pass "a startup sound over the size cap is refused"
 
-# Every accepted extension is found, and only the first one plays.
-for extension in flac ogg oga opus mp3; do
-  reset_theme
-  write_wav "$theme/startup.$extension"
-  play || fail "omarchy-theme-startup-sound plays startup.$extension"
-  grep -qx -- "$theme/startup.$extension" "$log" || fail "pw-play receives startup.$extension" "$(cat "$log")"
-done
-pass "every accepted audio extension is played"
+# A structurally valid 16-second file is rejected before playback. Its sparse
+# sample body keeps the fixture cheap.
+reset_theme
+printf 'RIFF\x24\x11\x2b\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00\x44\xac\x00\x00\x10\xb1\x02\x00\x04\x00\x10\x00data\x00\x11\x2b\x00' >"$theme/startup.wav"
+truncate -s 2822444 "$theme/startup.wav"
+play && fail "omarchy-theme-startup-sound refuses audio longer than 15 seconds"
+played && fail "overlong audio is not played"
+grep -q 'longer than 15 seconds' "$test_tmp/stderr" || fail "the refusal names the duration cap" "$(cat "$test_tmp/stderr")"
+pass "the WAV header cannot claim more than 15 seconds of samples"
+
+# Mutating the staged pathname once pw-play starts cannot change the private raw
+# file that was validated and passed to it.
+reset_theme
+write_wav "$theme/startup.wav"
+write_other_wav "$test_tmp/replacement.wav"
+REPLACE_SOUND_WITH="$test_tmp/replacement.wav" play || fail "a concurrent theme change does not disrupt playback"
+grep -qx 'payload=AQIDBA==' "$log" || fail "the player consumes the validated snapshot" "$(cat "$log")"
+cmp -s "$theme/startup.wav" "$test_tmp/replacement.wav" || fail "the race fixture replaced the staged pathname"
+unset REPLACE_SOUND_WITH
+pass "playback uses the validated snapshot rather than reopening the theme path"
+
+# A player stuck in native code and ignoring TERM must still die shortly after
+# the playback timeout. The timeout stub above compresses 17 seconds to 0.2.
+cat >"$stubs/pw-play" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$$" >"$PW_PLAY_PID_FILE"
+trap '' TERM
+while :; do :; done
+STUB
+chmod +x "$stubs/pw-play"
 
 reset_theme
 write_wav "$theme/startup.wav"
-write_wav "$theme/startup.ogg"
-play || fail "omarchy-theme-startup-sound plays a theme with two sounds"
-(( $(wc -l <"$log") == 1 )) || fail "only one startup sound plays" "$(cat "$log")"
-pass "a theme with several startup sounds plays one"
+start=$SECONDS
+PW_PLAY_PID_FILE="$pid_file" play && fail "a killed player reports a successful playback"
+(( SECONDS - start < 3 )) || fail "the hard kill deadline returns promptly"
+[[ -s $pid_file ]] || fail "the stubborn player started"
+stubborn_pid=$(cat "$pid_file")
+kill -0 "$stubborn_pid" 2>/dev/null && fail "the stubborn player survived the hard kill deadline"
+pass "a player that ignores TERM is forcibly killed"
 
 # Without a default sink there is nothing to play to, and login must not hang.
+write_pw_play_stub
 cat >"$stubs/wpctl" <<'STUB'
 #!/bin/bash
 exit 1
@@ -133,4 +273,6 @@ start=$SECONDS
 play || fail "omarchy-theme-startup-sound exits cleanly without an audio sink"
 played && fail "nothing is played without an audio sink"
 (( SECONDS - start <= 12 )) || fail "the wait for an audio sink gives up in time"
+grep -q '^--kill-after=0.1s 0.5s wpctl ' "$timeout_log" ||
+  fail "each sink probe has its own hard deadline" "$(cat "$timeout_log")"
 pass "a session without an audio sink gives up quietly"

--- a/test/shell.d/theme-startup-sound-test.sh
+++ b/test/shell.d/theme-startup-sound-test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# A theme's startup sound may have arrived through `omarchy theme install`, so
+# omarchy-theme-startup-sound treats it as data: it plays only a regular file
+# with an audio extension that really is audio and fits under the size cap, and
+# it hands the file to pw-play rather than a player that runs scripts.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command file
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+theme="$home/.local/state/omarchy/current/theme"
+stubs="$test_tmp/bin"
+log="$test_tmp/pw-play.log"
+mkdir -p "$theme" "$stubs"
+
+cat >"$stubs/pw-play" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$PW_PLAY_LOG"
+STUB
+
+cat >"$stubs/wpctl" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+
+chmod +x "$stubs"/*
+
+# The smallest thing libmagic calls WAVE audio: a RIFF header with no samples.
+write_wav() {
+  printf 'RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00\x80\xbb\x00\x00\x00\xee\x02\x00\x04\x00\x10\x00data\x00\x00\x00\x00' >"$1"
+}
+
+play() {
+  : >"$log"
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stubs:$ROOT/bin:$PATH" PW_PLAY_LOG="$log" \
+    bash "$ROOT/bin/omarchy-theme-startup-sound" 2>"$test_tmp/stderr"
+}
+
+played() {
+  [[ -s $log ]]
+}
+
+reset_theme() {
+  rm -rf "$theme"
+  mkdir -p "$theme"
+}
+
+# No sound in the theme: nothing plays and nothing fails.
+play || fail "omarchy-theme-startup-sound succeeds when the theme has no sound"
+played && fail "nothing is played when the theme has no startup sound"
+pass "a theme without a startup sound logs in quietly"
+
+# A real sound file is handed to pw-play by path.
+write_wav "$theme/startup.wav"
+play || fail "omarchy-theme-startup-sound plays a theme's startup.wav"
+grep -qx -- "$theme/startup.wav" "$log" || fail "pw-play receives the staged sound path" "$(cat "$log")"
+pass "a theme's startup sound is played with pw-play"
+
+# The startup-sound-off toggle wins over the theme.
+mkdir -p "$home/.local/state/omarchy/toggles"
+touch "$home/.local/state/omarchy/toggles/startup-sound-off"
+play || fail "omarchy-theme-startup-sound succeeds when startup sounds are off"
+played && fail "nothing is played while startup-sound-off is set"
+rm "$home/.local/state/omarchy/toggles/startup-sound-off"
+pass "the startup-sound-off toggle silences every theme"
+
+# Only an audio extension is looked for, so a script named startup.sh is never
+# opened at all.
+reset_theme
+printf '#!/bin/bash\necho payload\n' >"$theme/startup.sh"
+play || fail "omarchy-theme-startup-sound ignores a file without an audio extension"
+played && fail "a startup.sh is not played"
+pass "a startup sound needs an audio extension"
+
+# An audio extension on something that is not audio is refused by content.
+reset_theme
+printf '#!/bin/bash\necho payload\n' >"$theme/startup.wav"
+play && fail "omarchy-theme-startup-sound refuses a startup.wav that is a shell script"
+played && fail "a shell script named startup.wav is not played"
+grep -q 'not audio' "$test_tmp/stderr" || fail "the refusal names the detected type" "$(cat "$test_tmp/stderr")"
+pass "a startup sound has to be audio by content, not just by name"
+
+# A symlink is refused even though staging should already have dropped it: the
+# staged theme is user-writable state.
+reset_theme
+write_wav "$test_tmp/elsewhere.wav"
+ln -s "$test_tmp/elsewhere.wav" "$theme/startup.wav"
+play || fail "omarchy-theme-startup-sound exits cleanly on a symlinked sound"
+played && fail "a symlinked startup sound is not played"
+grep -q 'symlink' "$test_tmp/stderr" || fail "the refusal names the symlink" "$(cat "$test_tmp/stderr")"
+pass "a symlinked startup sound is not followed"
+
+# A sound over the size cap is refused before its contents are inspected.
+reset_theme
+write_wav "$theme/startup.wav"
+truncate -s 11M "$theme/startup.wav"
+play && fail "omarchy-theme-startup-sound refuses an oversized sound"
+played && fail "an oversized startup sound is not played"
+grep -q 'larger than' "$test_tmp/stderr" || fail "the refusal names the size cap" "$(cat "$test_tmp/stderr")"
+pass "a startup sound over the size cap is refused"
+
+# Every accepted extension is found, and only the first one plays.
+for extension in flac ogg oga opus mp3; do
+  reset_theme
+  write_wav "$theme/startup.$extension"
+  play || fail "omarchy-theme-startup-sound plays startup.$extension"
+  grep -qx -- "$theme/startup.$extension" "$log" || fail "pw-play receives startup.$extension" "$(cat "$log")"
+done
+pass "every accepted audio extension is played"
+
+reset_theme
+write_wav "$theme/startup.wav"
+write_wav "$theme/startup.ogg"
+play || fail "omarchy-theme-startup-sound plays a theme with two sounds"
+(( $(wc -l <"$log") == 1 )) || fail "only one startup sound plays" "$(cat "$log")"
+pass "a theme with several startup sounds plays one"
+
+# Without a default sink there is nothing to play to, and login must not hang.
+cat >"$stubs/wpctl" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+reset_theme
+write_wav "$theme/startup.wav"
+start=$SECONDS
+play || fail "omarchy-theme-startup-sound exits cleanly without an audio sink"
+played && fail "nothing is played without an audio sink"
+(( SECONDS - start <= 12 )) || fail "the wait for an audio sink gives up in time"
+pass "a session without an audio sink gives up quietly"


### PR DESCRIPTION
## Summary

- let a theme provide a short `startup.wav` — canonical 16-bit PCM, mono or stereo, 44.1/48 kHz, one file, no other formats — played when Hyprland starts
- playback is opt-in: nothing plays until `omarchy toggle startup sound` (or _Toggle > Startup Sound_ in the menu) sets the `startup-sound-enabled` flag, so a newly installed theme cannot make noise by default
- keep third-party theme bytes out of native media decoders: the WAV header is validated field by field in shell, the file is snapshotted into a private runtime directory (symlinks refused, copy size-capped and timed out), and `pw-play` receives raw PCM samples at a capped volume rather than the container
- bound the blast radius: 15-second duration cap enforced from the header and the byte cap, playback under `timeout` with kill-after, volume clamped to 0.25, and a quiet give-up when no default audio sink appears within 10 seconds
- validation and playback use only the snapshot, so a concurrent theme switch cannot swap the decoder's input after it has been checked
- document the theme format and security boundaries

## Tests

- `bash test/shell.d/theme-startup-sound-test.sh`
- `bash test/shell.d/theme-staging-test.sh`
- `./test/cli`