### PR TITLE
fix(hypr): prevent screensaver dismissal from forcing underlying windows into fullscreen

### DIFF
--- a/default/hypr/apps/system.lua
+++ b/default/hypr/apps/system.lua
@@ -31,10 +31,15 @@ o.window("dev.tensaku.Tensaku", { float = true })
 o.window("dev.tensaku.Tensaku", { center = true })
 o.window("omacalc", { float = true })
 
--- Fullscreen screensaver.
-o.window("org.omarchy.screensaver", { fullscreen = true })
+-- Screensaver overlay (float and fill screen so dismissing does not fullscreen underlying windows).
 o.window("org.omarchy.screensaver", { float = true })
+o.window("org.omarchy.screensaver", { pin = true })
+o.window("org.omarchy.screensaver", { move = "0 0" })
+o.window("org.omarchy.screensaver", { size = "100% 100%" })
+o.window("org.omarchy.screensaver", { rounding = 0 })
+o.window("org.omarchy.screensaver", { no_border = true })
 o.window("org.omarchy.screensaver", { animation = "slide" })
+
 
 -- No transparency on media windows.
 o.window(


### PR DESCRIPTION
## Summary

Fixes #4845
Relates to #3218, #6917

Fixes an issue where dismissing the screensaver leaves underlying tiled windows (such as Chromium, media players, or terminal/editor windows) unexpectedly forced into fullscreen mode.

In Hyprland 0.55+ and 0.56+, compositor fullscreen state management interacts with `misc:on_focus_under_fullscreen = 1`. When `org.omarchy.screensaver` is launched with native `fullscreen = true`, dismissing or terminating it causes Hyprland to transfer/restore that fullscreen state to whatever window was active beneath it.

---

## What This PR Provides

### 1. Viewport Overlay Rules (`default/hypr/apps/system.lua`)
Transitions `org.omarchy.screensaver` away from compositor-level `fullscreen = true` to a pinned, borderless full-viewport floating overlay:
- **Declarative & Race-Free:** Never toggles Hyprland's native compositor fullscreen client state, eliminating state transfer races upon exit.
- **Universal Exit Handling:** Reliably avoids focus contamination across all exit paths (internal input trap `exit_screensaver`, `omarchy-system-lock` timer kills, and sleep/wake reap cycles).
- **Multi-Monitor Safe:** Covers displays cleanly without requiring manual IPC focus toggles or monitor-specific workarounds.

```lua
-- Screensaver overlay (float and fill screen so dismissing does not fullscreen underlying windows).
o.window("org.omarchy.screensaver", { float = true })
o.window("org.omarchy.screensaver", { pin = true })
o.window("org.omarchy.screensaver", { move = "0 0" })
o.window("org.omarchy.screensaver", { size = "100% 100%" })
o.window("org.omarchy.screensaver", { rounding = 0 })
o.window("org.omarchy.screensaver", { no_border = true })
o.window("org.omarchy.screensaver", { animation = "slide" })
```

---

## Related Context

- **Fixes:** #4845
- **Related to:** #3218, #6917
- **Affects:** Hyprland window rules / Screensaver idle management

---

## Testing & Verification

- [x] Tested on Hyprland 0.56.2 on a multi-monitor configuration (`eDP-1` + external `DP`).
- [x] Spawned screensaver over active media playback in Chromium and active terminal workspaces.
- [x] Dismissed screensaver via keyboard input, mouse motion, and external `SIGTERM` (`pkill`).
- [x] Confirmed underlying windows retain their exact tiled geometry with zero fullscreen contamination.