### PR TITLE
docs(mac): fix T1 chip model identifiers and remove non-Touch Bar A1708

### DIFF
--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -44,9 +44,8 @@ Members of the community are constantly working on solutions to these challenges
 #### Devices with T1 Chip
 
 The Apple T1 chip was introduced in late 2016 and used exclusively in the first-generation MacBook Pro models with Touch Bar.
-- MacBook Pro 13-inch (2016, two Thunderbolt 3 ports) – Model: A1706
-- MacBook Pro 13-inch (2016, four Thunderbolt 3 ports) – Model: A1708
-- MacBook Pro 15-inch (2016) – Model: A1707
+- MacBook Pro 13-inch (2016-2017, four Thunderbolt 3 ports) – Model: A1706
+- MacBook Pro 15-inch (2016-2017) – Model: A1707
 
 #### Known Issues
 


### PR DESCRIPTION
## Summary
Corrects inaccurate model mappings in `mac-support.md`:

- Fixes `A1706` port count (4 Thunderbolt 3 ports, Touch Bar).
- Removes `A1708` (2 Thunderbolt 3 ports, physical function keys) from the T1 list as it does not contain a T1 chip.
- Clarifies that `A1706` and `A1707` cover both 2016 and 2017 Touch Bar generations.