### PR TITLE
Warn on bad AQ_DRM_DEVICES in debug

### DIFF
--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -5,6 +5,89 @@
 # omarchy:examples=omarchy debug --print --no-sudo
 # omarchy:requires-sudo=true
 
+omarchy_debug_aq_drm_warn() {
+  local source=$1 value=$2
+
+  [[ -n $value ]] || return 0
+
+  if [[ $value == *by-path* || $value == *pci-0000:* ]]; then
+    printf 'WARNING: %s uses PCI by-path names; Aquamarine splits AQ_DRM_DEVICES on : and SDDM autologin loops\n' "$source"
+  elif [[ $value =~ /dev/dri/card[0-9] ]]; then
+    printf 'WARNING: %s pins /dev/dri/cardN, which rotates across reboots\n' "$source"
+  fi
+}
+
+omarchy_debug_aq_drm_from_file() {
+  local label=$1 file=$2
+  local line
+
+  [[ -f $file ]] || return 1
+
+  line=$(grep -E '^[[:space:]]*(export[[:space:]]+)?AQ_DRM_DEVICES=|hl\.env\(["'\''"]AQ_DRM_DEVICES' "$file" 2>/dev/null | grep -vE '^[[:space:]]*(#|--)' | head -n 1) || true
+  [[ -n $line ]] || return 1
+
+  printf '%s: %s\n' "$label" "$line"
+  omarchy_debug_aq_drm_warn "$label" "$line"
+  return 0
+}
+
+omarchy_debug_aq_drm_section() {
+  local process_value file found dropin_dir hypr_dir
+
+  if [[ -n ${AQ_DRM_DEVICES+x} ]]; then
+    process_value=$AQ_DRM_DEVICES
+    printf 'process: %s\n' "$process_value"
+  else
+    process_value=
+    printf 'process: (unset)\n'
+  fi
+  omarchy_debug_aq_drm_warn "process" "$process_value"
+
+  if ! omarchy_debug_aq_drm_from_file "uwsm env-hyprland" "$HOME/.config/uwsm/env-hyprland"; then
+    if [[ -f $HOME/.config/uwsm/env-hyprland ]]; then
+      printf 'uwsm env-hyprland: (not set)\n'
+    else
+      printf 'uwsm env-hyprland: (absent)\n'
+    fi
+  fi
+
+  dropin_dir=$HOME/.config/uwsm/env-hyprland.d
+  found=0
+  if [[ -d $dropin_dir ]]; then
+    for file in "$dropin_dir"/*; do
+      [[ -f $file ]] || continue
+      omarchy_debug_aq_drm_from_file "uwsm env-hyprland.d/$(basename "$file")" "$file" && found=1
+    done
+  fi
+  if (( found == 0 )); then
+    if [[ -d $dropin_dir ]]; then
+      printf 'uwsm env-hyprland.d: (not set)\n'
+    else
+      printf 'uwsm env-hyprland.d: (absent)\n'
+    fi
+  fi
+
+  hypr_dir=$HOME/.config/hypr
+  found=0
+  if [[ -d $hypr_dir ]]; then
+    for file in "$hypr_dir"/*.lua; do
+      [[ -f $file ]] || continue
+      omarchy_debug_aq_drm_from_file "hypr $(basename "$file")" "$file" && found=1
+    done
+  fi
+  if (( found == 0 )); then
+    if [[ -d $hypr_dir ]]; then
+      printf 'hypr lua: (not set)\n'
+    else
+      printf 'hypr lua: (absent)\n'
+    fi
+  fi
+}
+
+if [[ ${BASH_SOURCE[0]} != "$0" ]]; then
+  return 0
+fi
+
 NO_SUDO=false
 PRINT_ONLY=false
 
@@ -58,6 +141,11 @@ $(journalctl -b -p 4..1)
 INSTALLED PACKAGES
 =========================================
 $({ expac -S '%n %v (%r)' $(pacman -Qqe) 2>/dev/null; comm -13 <(pacman -Sql | sort) <(pacman -Qqe | sort) | xargs -r expac -Q '%n %v (AUR)'; } | sort)
+
+=========================================
+AQ_DRM_DEVICES
+=========================================
+$(omarchy_debug_aq_drm_section)
 EOF
 
 if [[ $PRINT_ONLY = "true" ]]; then

--- a/test/shell.d/debug-aq-drm-test.sh
+++ b/test/shell.d/debug-aq-drm-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+debug="$ROOT/bin/omarchy-debug"
+
+[[ -f $debug ]] || fail "omarchy-debug is in the tree"
+grep -q 'omarchy_debug_aq_drm_section' "$debug" || fail "omarchy-debug includes the AQ_DRM_DEVICES section"
+pass "omarchy-debug includes the AQ_DRM_DEVICES section"
+
+# shellcheck disable=SC1090
+source "$debug"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+HOME=$tmp
+unset AQ_DRM_DEVICES
+
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == *$'\nprocess: (unset)\n'* || $out == 'process: (unset)'* ]] || fail "unset process env is reported" "$out"
+[[ $out == *'uwsm env-hyprland: (absent)'* ]] || fail "missing uwsm env-hyprland is reported" "$out"
+[[ $out != *WARNING* ]] || fail "unset env does not warn" "$out"
+pass "unset AQ_DRM_DEVICES dumps without warning"
+
+AQ_DRM_DEVICES=
+export AQ_DRM_DEVICES
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == 'process: '$'\n'* || $out == $'process: \n'* ]] || fail "empty process env is reported" "$out"
+[[ $out != *WARNING* ]] || fail "empty env does not warn" "$out"
+pass "empty AQ_DRM_DEVICES dumps without warning"
+unset AQ_DRM_DEVICES
+
+AQ_DRM_DEVICES='/dev/dri/by-path/pci-0000:13:00.0-card'
+export AQ_DRM_DEVICES
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == *'process: /dev/dri/by-path/pci-0000:13:00.0-card'* ]] || fail "process by-path is dumped" "$out"
+[[ $out == *'WARNING: process uses PCI by-path names'* ]] || fail "process by-path warns" "$out"
+pass "process by-path AQ_DRM_DEVICES warns"
+unset AQ_DRM_DEVICES
+
+mkdir -p "$tmp/.config/uwsm"
+printf 'export AQ_DRM_DEVICES=/dev/dri/igpu\n' >"$tmp/.config/uwsm/env-hyprland"
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == *'uwsm env-hyprland: export AQ_DRM_DEVICES=/dev/dri/igpu'* ]] || fail "uwsm udev name is dumped" "$out"
+[[ $out != *WARNING* ]] || fail "colon-free udev name does not warn" "$out"
+pass "colon-free uwsm pin dumps without warning"
+
+printf 'export AQ_DRM_DEVICES=/dev/dri/by-path/pci-0000:13:00.0-card\n' >"$tmp/.config/uwsm/env-hyprland"
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == *'WARNING: uwsm env-hyprland uses PCI by-path names'* ]] || fail "uwsm by-path warns" "$out"
+pass "uwsm by-path pin warns"
+
+printf 'export AQ_DRM_DEVICES=/dev/dri/card1\n' >"$tmp/.config/uwsm/env-hyprland"
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == *'WARNING: uwsm env-hyprland pins /dev/dri/cardN'* ]] || fail "uwsm cardN warns" "$out"
+pass "uwsm cardN pin warns"
+
+printf '# AQ_DRM_DEVICES=/dev/dri/by-path/pci-0000:13:00.0-card\n' >"$tmp/.config/uwsm/env-hyprland"
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == *'uwsm env-hyprland: (not set)'* ]] || fail "comment-only uwsm file is ignored" "$out"
+[[ $out != *WARNING* ]] || fail "comment-only uwsm file does not warn" "$out"
+pass "comment-only uwsm file does not warn"
+
+mkdir -p "$tmp/.config/uwsm/env-hyprland.d"
+printf '# Rewrite PCI by-path AQ_DRM_DEVICES after user env-hyprland.\n' >"$tmp/.config/uwsm/env-hyprland.d/99-omarchy-aq-drm"
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == *'uwsm env-hyprland.d: (not set)'* ]] || fail "comment-only drop-in is ignored" "$out"
+[[ $out != *WARNING* ]] || fail "comment-only drop-in does not warn" "$out"
+pass "comment-only drop-in does not warn"
+
+printf 'export AQ_DRM_DEVICES=/dev/dri/by-path/pci-0000:03:00.0-card\n' >"$tmp/.config/uwsm/env-hyprland.d/10-user"
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == *'uwsm env-hyprland.d/10-user: export AQ_DRM_DEVICES=/dev/dri/by-path/pci-0000:03:00.0-card'* ]] || fail "drop-in by-path is dumped" "$out"
+[[ $out == *'WARNING: uwsm env-hyprland.d/10-user uses PCI by-path names'* ]] || fail "drop-in by-path warns" "$out"
+pass "uwsm drop-in by-path pin warns"
+
+rm -f "$tmp/.config/uwsm/env-hyprland" "$tmp/.config/uwsm/env-hyprland.d/10-user"
+mkdir -p "$tmp/.config/hypr"
+printf 'hl.env("AQ_DRM_DEVICES", "/dev/dri/by-path/pci-0000:13:00.0-card")\n' >"$tmp/.config/hypr/hyprland.lua"
+printf 'hl.env("XCURSOR_SIZE", "24")\n' >"$tmp/.config/hypr/envs.lua"
+out=$(omarchy_debug_aq_drm_section)
+[[ $out == *'hypr hyprland.lua: hl.env("AQ_DRM_DEVICES", "/dev/dri/by-path/pci-0000:13:00.0-card")'* ]] || fail "hypr lua by-path is dumped" "$out"
+[[ $out == *'WARNING: hypr hyprland.lua uses PCI by-path names'* ]] || fail "hypr lua by-path warns" "$out"
+[[ $out != *'hypr envs.lua'* ]] || fail "unrelated hypr lua is omitted" "$out"
+pass "hypr lua by-path pin warns"


### PR DESCRIPTION
**What**: `omarchy debug` now dumps `AQ_DRM_DEVICES` from the process and from uwsm/hypr env files, and warns on PCI by-path or `/dev/dri/cardN` pins.

**Why**: Related to #8776. A bad pin login-loops SDDM autologin with nothing in the debug log. Point 1 from that issue; #8786 covers the session sanitizer.

**How**: Sourceable helpers in `omarchy-debug` print the process value, `~/.config/uwsm/env-hyprland`, matching drop-ins, and matching `~/.config/hypr/*.lua`. Comments are ignored so the sanitizer drop-in does not false-warn. No `omarchy setup gpu` (product call).

**Verified**:
- `bash -n bin/omarchy-debug test/shell.d/debug-aq-drm-test.sh`
- `bash test/shell.d/debug-aq-drm-test.sh` (11 assertions, Git Bash on Windows)

NOT verified: `omarchy debug --print` on a live Omarchy install (`inxi`/`pacman`/`sudo dmesg`).