### PR TITLE
Backport constrained Quattro ownership bootstrap to rc

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -38,6 +38,10 @@ fail() {
   exit 1
 }
 
+# The functions in this marked block only resolve values; they never mutate the
+# system. Tests extract and execute this exact policy without sourcing the
+# self-contained upgrader's privileged top-level flow.
+# OMARCHY_UPGRADE_SELECTION_BEGIN
 normalize_channel() {
   case "${1:-}" in
     stable|master|main) echo stable ;;
@@ -55,18 +59,125 @@ valid_channel() {
 # omarchy-version-channel reads it. Order matters: mirror.omarchy.org is a
 # substring of both of the others.
 detect_installed_channel() {
-  [[ -f /etc/pacman.d/mirrorlist ]] || return 1
+  local mirrorlist=${1:-/etc/pacman.d/mirrorlist}
+  [[ -f $mirrorlist ]] || return 1
 
-  if grep -q 'https://stable-mirror.omarchy.org/' /etc/pacman.d/mirrorlist; then
+  if grep -q 'https://stable-mirror.omarchy.org/' "$mirrorlist"; then
     echo stable
-  elif grep -q 'https://rc-mirror.omarchy.org/' /etc/pacman.d/mirrorlist; then
+  elif grep -q 'https://rc-mirror.omarchy.org/' "$mirrorlist"; then
     echo rc
-  elif grep -q 'https://mirror.omarchy.org/' /etc/pacman.d/mirrorlist; then
+  elif grep -q 'https://mirror.omarchy.org/' "$mirrorlist"; then
     echo edge
   else
     return 1
   fi
 }
+
+parse_upgrade_arguments() {
+  while (($#)); do
+    case "$1" in
+      -y|--yes)
+        yes=1
+        shift
+        ;;
+      --reboot)
+        auto_reboot=1
+        shift
+        ;;
+      --dev)
+        use_dev_packages=1
+        shift
+        ;;
+      --channel)
+        channel_override="${2:-}"
+        channel_override_cli=1
+        shift 2
+        ;;
+      --user)
+        target_user="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        fail "Unknown option: $1"
+        ;;
+    esac
+  done
+}
+
+normalize_upgrade_dev_mode() {
+  case "$use_dev_packages" in
+    1|true|yes|on) use_dev_packages=1 ;;
+    0|false|no|off|"") use_dev_packages=0 ;;
+    *) fail "Invalid OMARCHY_UPGRADE_DEV value '$use_dev_packages'. Use 1/0, true/false, or pass --dev." ;;
+  esac
+}
+
+resolve_upgrade_channel() {
+  local installed_channel=${1:-}
+
+  # Land on the Quattro equivalent of wherever the machine already is, unless
+  # the caller said otherwise. Stable and rc carry the production package pair;
+  # edge carries the dev pair used while Quattro is still under development.
+  if [[ -z $channel_override ]] && (( ! use_dev_packages )); then
+    if [[ -z $installed_channel ]]; then
+      installed_channel=$(detect_installed_channel || true)
+    fi
+
+    case "$installed_channel" in
+      stable) channel_override=stable ;;
+      rc) channel_override=rc ;;
+      edge) channel_override=edge use_dev_packages=1 ;;
+    esac
+  fi
+
+  if (( use_dev_packages )); then
+    # The dev pair is published only to edge. Release candidates use the
+    # production pair from rc so they exercise the exact artifacts stable gets.
+    if [[ -n $channel_override ]]; then
+      if ! valid_channel "$channel_override"; then
+        fail "Invalid channel '$channel_override'. Use stable, rc, or edge."
+      fi
+      if [[ $(normalize_channel "$channel_override") != edge ]]; then
+        fail "--dev needs the edge package repo; use --channel edge."
+      fi
+    else
+      channel_override=edge
+    fi
+  fi
+
+  if { [[ -n $channel_override ]] || (( channel_override_cli )); } && ! valid_channel "$channel_override"; then
+    fail "Invalid channel '$channel_override'. Use stable, rc, or edge."
+  fi
+
+  channel=$(normalize_channel "${channel_override:-stable}")
+  case "$channel" in
+    stable)
+      mirror_server='https://stable-mirror.omarchy.org/$repo/os/$arch'
+      package_server='https://pkgs.omarchy.org/stable/$arch'
+      ;;
+    rc)
+      mirror_server='https://rc-mirror.omarchy.org/$repo/os/$arch'
+      package_server='https://pkgs.omarchy.org/rc/$arch'
+      ;;
+    edge)
+      mirror_server='https://mirror.omarchy.org/$repo/os/$arch'
+      package_server='https://pkgs.omarchy.org/edge/$arch'
+      ;;
+  esac
+}
+
+select_omarchy_package_names() {
+  if (( use_dev_packages )); then
+    printf '%s\n' 'omarchy-dev omarchy-settings-dev'
+  else
+    printf '%s\n' 'omarchy omarchy-settings'
+  fi
+}
+# OMARCHY_UPGRADE_SELECTION_END
 
 channel_override="${OMARCHY_UPGRADE_CHANNEL:-}"
 channel_override_cli=0
@@ -76,76 +187,9 @@ auto_reboot=0
 boot_cmdline_unsafe=0
 use_dev_packages=${OMARCHY_UPGRADE_DEV:-0}
 
-while (($#)); do
-  case "$1" in
-    -y|--yes)
-      yes=1
-      shift
-      ;;
-    --reboot)
-      auto_reboot=1
-      shift
-      ;;
-    --dev)
-      use_dev_packages=1
-      shift
-      ;;
-    --channel)
-      channel_override="${2:-}"
-      channel_override_cli=1
-      shift 2
-      ;;
-    --user)
-      target_user="${2:-}"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      fail "Unknown option: $1"
-      ;;
-  esac
-done
-
-case "$use_dev_packages" in
-  1|true|yes|on) use_dev_packages=1 ;;
-  0|false|no|off|"") use_dev_packages=0 ;;
-  *) fail "Invalid OMARCHY_UPGRADE_DEV value '$use_dev_packages'. Use 1/0, true/false, or pass --dev." ;;
-esac
-
-# Land on the Quattro equivalent of wherever the machine already is, unless the
-# caller said otherwise. Stable and rc machines get the production packages;
-# rc pulls them from the edge package repo while keeping its own Arch mirror.
-# Only edge takes the dev packages, since that is the channel they ship on.
-if [[ -z $channel_override ]] && (( ! use_dev_packages )); then
-  case "$(detect_installed_channel || true)" in
-    stable) channel_override=stable ;;
-    rc) channel_override=rc ;;
-    edge) channel_override=edge use_dev_packages=1 ;;
-  esac
-fi
-
-if (( use_dev_packages )); then
-  # The dev packages are only published to the edge package repo, which the rc
-  # and edge channels both point at; only stable is incompatible. rc keeps its
-  # own Arch mirror either way.
-  if [[ -n $channel_override ]]; then
-    if ! valid_channel "$channel_override"; then
-      fail "Invalid channel '$channel_override'. Use stable, rc, or edge."
-    fi
-    if [[ $(normalize_channel "$channel_override") == stable ]]; then
-      fail "--dev needs the edge package repo; use --channel rc or --channel edge."
-    fi
-  else
-    channel_override=edge
-  fi
-fi
-
-if { [[ -n $channel_override ]] || (( channel_override_cli )); } && ! valid_channel "$channel_override"; then
-  fail "Invalid channel '$channel_override'. Use stable, rc, or edge."
-fi
+parse_upgrade_arguments "$@"
+normalize_upgrade_dev_mode
+resolve_upgrade_channel
 
 if ! command -v pacman >/dev/null 2>&1; then
   fail "This upgrade is only supported on Arch/Omarchy systems with pacman."
@@ -310,23 +354,6 @@ discover_hyprland_signature() {
   (( ${#candidates[@]} == 1 )) || return 1
   printf '%s\n' "${candidates[0]}"
 }
-
-channel=$(normalize_channel "${channel_override:-stable}")
-
-case "$channel" in
-  stable)
-    mirror_server='https://stable-mirror.omarchy.org/$repo/os/$arch'
-    package_server='https://pkgs.omarchy.org/stable/$arch'
-    ;;
-  rc)
-    mirror_server='https://rc-mirror.omarchy.org/$repo/os/$arch'
-    package_server='https://pkgs.omarchy.org/edge/$arch'
-    ;;
-  edge)
-    mirror_server='https://mirror.omarchy.org/$repo/os/$arch'
-    package_server='https://pkgs.omarchy.org/edge/$arch'
-    ;;
-esac
 
 if (( ! yes )); then
   printf '\033[2J\033[3J\033[H' >/dev/tty
@@ -712,12 +739,8 @@ migrate_1password_beta_package() {
 }
 
 install_omarchy_quattro_packages() {
-  local omarchy_package=omarchy
-  local settings_package=omarchy-settings
-  if (( use_dev_packages )); then
-    omarchy_package=omarchy-dev
-    settings_package=omarchy-settings-dev
-  fi
+  local omarchy_package settings_package
+  read -r omarchy_package settings_package < <(select_omarchy_package_names)
 
   local core_packages=(
     omarchy-keyring

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -729,19 +729,24 @@ install_omarchy_quattro_packages() {
   )
   local base_packages=()
 
-  log "Upgrading system packages and installing Omarchy quattro packages"
+  log "Adopting legacy system files into Omarchy quattro package ownership"
   (( use_dev_packages )) && log "Using dev packages [omarchy-dev / omarchy-settings-dev]"
   # --noconfirm answers "no" to conflict-removal prompts. --ask 4 preselects
   # removing the conflicting package, which is required for legacy packages like
   # ttf-jetbrains-mono-nerd -> ttf-jetbrains-mono-nerd-basic.
-  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --needed --noconfirm --ask 4 --overwrite='*' "${core_packages[@]}"
+  # omarchy-settings owns the static system paths written directly by 3.x. This
+  # is their one-time ownership bridge; no later package operation overwrites.
+  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -S --noconfirm --ask 4 --overwrite='*' "$settings_package"
+
+  log "Upgrading system packages and installing Omarchy quattro packages"
+  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --needed --noconfirm --ask 4 "${core_packages[@]}"
   mark_packages_explicit "${core_packages[@]}"
 
   if [[ -f /usr/share/omarchy/install/omarchy-base.packages ]]; then
     log "Installing Omarchy quattro default package set"
     mapfile -t base_packages < <(sed -e 's/[[:space:]]*#.*$//' -e '/^[[:space:]]*$/d' /usr/share/omarchy/install/omarchy-base.packages)
     if (( ${#base_packages[@]} )); then
-      as_root pacman -S --needed --noconfirm --ask 4 --overwrite='*' "${base_packages[@]}"
+      as_root pacman -S --needed --noconfirm --ask 4 "${base_packages[@]}"
       mark_packages_explicit "${base_packages[@]}"
     fi
   else
@@ -760,7 +765,7 @@ install_omarchy_quattro_packages() {
     libpulse
     wireplumber
   )
-  as_root pacman -S --needed --noconfirm --ask 4 --overwrite='*' "${audio_packages[@]}"
+  as_root pacman -S --needed --noconfirm --ask 4 "${audio_packages[@]}"
   mark_packages_explicit "${audio_packages[@]}"
 }
 
@@ -1197,32 +1202,7 @@ run_post_upgrade_migrations() {
 
 run_final_system_package_upgrade() {
   log "Checking for remaining system package updates"
-  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm --ask 4 \
-    --overwrite '/etc/docker/daemon.json' \
-    --overwrite '/etc/gnupg/dirmngr.conf' \
-    --overwrite '/etc/mkinitcpio.conf.d/omarchy_hooks.conf' \
-    --overwrite '/etc/mkinitcpio.conf.d/thunderbolt_module.conf' \
-    --overwrite '/etc/modprobe.d/omarchy-usb-autosuspend.conf' \
-    --overwrite '/etc/sddm.conf.d/10-theme.conf' \
-    --overwrite '/etc/sddm.conf.d/10-wayland.conf' \
-    --overwrite '/etc/sudoers.d/omarchy-asdcontrol' \
-    --overwrite '/etc/sudoers.d/omarchy-passwd-tries' \
-    --overwrite '/etc/sudoers.d/omarchy-tzupdate' \
-    --overwrite '/etc/sysctl.d/90-omarchy-file-watchers.conf' \
-    --overwrite '/etc/sysctl.d/99-omarchy-sysctl.conf' \
-    --overwrite '/etc/systemd/logind.conf.d/10-ignore-power-button.conf' \
-    --overwrite '/etc/systemd/resolved.conf.d/10-disable-multicast.conf' \
-    --overwrite '/etc/systemd/resolved.conf.d/20-docker-dns.conf' \
-    --overwrite '/etc/systemd/system.conf.d/10-faster-shutdown.conf' \
-    --overwrite '/etc/systemd/system/user@.service.d/10-faster-shutdown.conf' \
-    --overwrite '/etc/systemd/system/docker.service.d/no-block-boot.conf' \
-    --overwrite '/etc/systemd/system/plocate-updatedb.service.d/ac-only.conf' \
-    --overwrite '/etc/systemd/system.conf.d/20-omarchy-nofile.conf' \
-    --overwrite '/etc/systemd/user.conf.d/20-omarchy-nofile.conf' \
-    --overwrite '/usr/lib/systemd/system-sleep/unmount-fuse' \
-    --overwrite '/usr/share/plymouth/themes/omarchy/*' \
-    --overwrite '/usr/share/sddm/hyprland.lua' \
-    --overwrite '/usr/share/sddm/themes/omarchy/*'
+  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm --ask 4
 }
 
 run_post_upgrade_update_steps() {
@@ -1313,9 +1293,6 @@ apply_system_transition() {
   as_root gtk-update-icon-cache /usr/share/icons/Yaru >/dev/null 2>&1 || true
 
   as_root install -d -m 0777 /etc/chromium/policies/managed
-  as_root install -d -m 0755 /usr/lib/chromium
-  printf '%s\n' '{"browser":{"theme":{"color_scheme":0,"color_scheme2":0}}}' | \
-    as_root tee /usr/lib/chromium/initial_preferences >/dev/null
 
   if getent group docker >/dev/null; then
     as_root usermod -aG docker "$target_user"
@@ -1368,14 +1345,6 @@ EOF
   apply_firewall_defaults
 
   log "Normalizing SDDM login configuration"
-  # The omarchy package already installed 10-theme.conf and 10-wayland.conf.
-  as_root install -d -m 0755 /etc/sddm.conf.d
-  cat <<'EOF' | as_root tee /etc/sddm.conf.d/99-omarchy-login.conf >/dev/null
-[Users]
-RememberLastUser=true
-RememberLastSession=true
-EOF
-
   local autologin_user
   if should_enable_sddm_autologin; then
     if as_root test -f /etc/sddm.conf.d/autologin.conf; then

--- a/test/upgrade-to-quattro-ownership-test.sh
+++ b/test/upgrade-to-quattro-ownership-test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+upgrade_to_quattro="$ROOT/bin/omarchy-upgrade-to-quattro"
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+overwrite_count=$(awk '!/^[[:space:]]*#/ && /--overwrite/ { count++ } END { print count + 0 }' "$upgrade_to_quattro")
+(( overwrite_count == 1 )) || fail "upgrade uses overwrite only for the one-time ownership bridge"
+
+grep -F "pacman -S --noconfirm --ask 4 --overwrite='*' \"\$settings_package\"" "$upgrade_to_quattro" >/dev/null ||
+  fail "ownership bridge installs only omarchy-settings"
+grep -F 'pacman -Syu --needed --noconfirm --ask 4 "${core_packages[@]}"' "$upgrade_to_quattro" >/dev/null ||
+  fail "core installation returns to ordinary ownership checks"
+grep -F 'pacman -S --needed --noconfirm --ask 4 "${base_packages[@]}"' "$upgrade_to_quattro" >/dev/null ||
+  fail "default package installation uses ordinary ownership checks"
+grep -F 'pacman -S --needed --noconfirm --ask 4 "${audio_packages[@]}"' "$upgrade_to_quattro" >/dev/null ||
+  fail "audio package installation uses ordinary ownership checks"
+grep -F 'pacman -Syu --noconfirm --ask 4' "$upgrade_to_quattro" >/dev/null ||
+  fail "final package upgrade uses ordinary ownership checks"
+pass "upgrade confines overwrite to omarchy-settings ownership adoption"
+
+if grep -F '/usr/lib/chromium/initial_preferences' "$upgrade_to_quattro" >/dev/null; then
+  fail "upgrade does not create an unowned Chromium preferences file"
+fi
+pass "upgrade does not create an unowned Chromium preferences file"
+
+if grep -F '/etc/sddm.conf.d/99-omarchy-login.conf' "$upgrade_to_quattro" >/dev/null; then
+  fail "upgrade does not create an unowned SDDM defaults file"
+fi
+pass "upgrade leaves SDDM login defaults to the package and SDDM itself"

--- a/test/upgrade-to-quattro-ownership-test.sh
+++ b/test/upgrade-to-quattro-ownership-test.sh
@@ -38,3 +38,84 @@ if grep -F '/etc/sddm.conf.d/99-omarchy-login.conf' "$upgrade_to_quattro" >/dev/
   fail "upgrade does not create an unowned SDDM defaults file"
 fi
 pass "upgrade leaves SDDM login defaults to the package and SDDM itself"
+
+# Extract only the explicitly marked, non-mutating policy functions. Refuse to
+# execute anything if either boundary changes or a mutating command enters the
+# block, so a refactor cannot accidentally turn this unit test into an upgrade.
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+selection_library="$test_tmp/selection-functions.sh"
+mirrorlist="$test_tmp/mirrorlist"
+
+(( $(grep -c '^# OMARCHY_UPGRADE_SELECTION_BEGIN$' "$upgrade_to_quattro") == 1 )) ||
+  fail "the upgrade selection test has one extraction start boundary"
+(( $(grep -c '^# OMARCHY_UPGRADE_SELECTION_END$' "$upgrade_to_quattro") == 1 )) ||
+  fail "the upgrade selection test has one extraction end boundary"
+
+awk '
+  /^# OMARCHY_UPGRADE_SELECTION_BEGIN$/ { copying = 1; next }
+  /^# OMARCHY_UPGRADE_SELECTION_END$/ { exit }
+  copying { print }
+' "$upgrade_to_quattro" >"$selection_library"
+
+[[ -s $selection_library ]] || fail "the upgrade selection policy extracts as a non-empty library"
+if grep -Ev '^[[:space:]]*(#|$)' "$selection_library" |
+  grep -Eq '(^|[[:space:];|&])(sudo|pacman|rm|mv|cp|install|tee|curl|wget|systemctl|reboot|shutdown|mount|umount|chown|chmod)([[:space:];|&]|$)'; then
+  fail "the upgrade selection policy contains a system-mutating command"
+fi
+bash -n "$selection_library" || fail "the extracted upgrade selection policy has valid Bash syntax"
+source "$selection_library"
+
+selection_for() {
+  local installed_server=$1
+  shift
+
+  printf 'Server = %s\n' "$installed_server" >"$mirrorlist"
+
+  (
+    channel_override=
+    channel_override_cli=0
+    target_user=
+    yes=0
+    auto_reboot=0
+    boot_cmdline_unsafe=0
+    use_dev_packages=0
+
+    parse_upgrade_arguments "$@"
+    normalize_upgrade_dev_mode
+    installed_channel=$(detect_installed_channel "$mirrorlist" || true)
+    resolve_upgrade_channel "$installed_channel"
+    read -r omarchy_package settings_package < <(select_omarchy_package_names)
+    printf '%s|%s|%s|%s|%s|%s\n' \
+      "$channel" "$use_dev_packages" "$mirror_server" "$package_server" \
+      "$omarchy_package" "$settings_package"
+  )
+}
+
+stable_selection='stable|0|https://stable-mirror.omarchy.org/$repo/os/$arch|https://pkgs.omarchy.org/stable/$arch|omarchy|omarchy-settings'
+rc_selection='rc|0|https://rc-mirror.omarchy.org/$repo/os/$arch|https://pkgs.omarchy.org/rc/$arch|omarchy|omarchy-settings'
+edge_dev_selection='edge|1|https://mirror.omarchy.org/$repo/os/$arch|https://pkgs.omarchy.org/edge/$arch|omarchy-dev|omarchy-settings-dev'
+edge_production_selection='edge|0|https://mirror.omarchy.org/$repo/os/$arch|https://pkgs.omarchy.org/edge/$arch|omarchy|omarchy-settings'
+
+[[ $(selection_for 'https://stable-mirror.omarchy.org/core/os/x86_64') == "$stable_selection" ]] ||
+  fail "stable upgrades select stable production artifacts"
+[[ $(selection_for 'https://rc-mirror.omarchy.org/core/os/x86_64') == "$rc_selection" ]] ||
+  fail "rc upgrades select release-candidate production artifacts"
+[[ $(selection_for 'https://mirror.omarchy.org/core/os/x86_64') == "$edge_dev_selection" ]] ||
+  fail "edge upgrades select the edge dev pair"
+[[ $(selection_for 'https://stable-mirror.omarchy.org/core/os/x86_64' --channel rc) == "$rc_selection" ]] ||
+  fail "explicit rc upgrades select release-candidate production artifacts"
+[[ $(selection_for 'https://stable-mirror.omarchy.org/core/os/x86_64' --channel edge) == "$edge_production_selection" ]] ||
+  fail "explicit edge selection preserves the production package pair"
+[[ $(selection_for 'https://stable-mirror.omarchy.org/core/os/x86_64' --dev) == "$edge_dev_selection" ]] ||
+  fail "dev package mode selects edge"
+
+for incompatible_channel in stable rc; do
+  if selection_for 'https://mirror.omarchy.org/core/os/x86_64' --dev --channel "$incompatible_channel" >"$test_tmp/out" 2>"$test_tmp/err"; then
+    fail "dev package mode accepts the $incompatible_channel channel"
+  fi
+  grep -Fq -- '--dev needs the edge package repo; use --channel edge.' "$test_tmp/err" ||
+    fail "dev package mode does not explain why $incompatible_channel is incompatible"
+done
+
+pass "upgrade channels select their matching package artifacts"


### PR DESCRIPTION
## Release gate: do not merge yet

This 3.x release-candidate bootstrap must not merge until the fixes in omacom/omarchy#9070 and omacom/omarchy-pkgs#239 have shipped together as v4.0.2. Merging it earlier could send a 3.x user through the ownership transition with the older 4.0.1 package payload.

## What changed

- The 3.x to Quattro upgrader uses `--overwrite='*'` exactly once, only while installing `omarchy-settings` to adopt the known legacy configuration paths.
- The core package install, audio transition, and final package sync use normal Pacman semantics with no overwrite.
- Stable, rc, and edge upgrades select their matching package repositories; rc uses the production release-candidate pair and dev packages are edge-only.
- A focused regression test prevents wildcard overwrite from spreading back into steady-state installs.

This is only the legacy launcher side of the transition. #9070 supplies the Quattro-side fail-closed updater and exact legacy cleanup, while omacom/omarchy-pkgs#239 supplies the package-owned static system state.

## Proof

```bash
bash test/upgrade-to-quattro-ownership-test.sh
```

## Rollout

After v4.0.2 is published, merge this PR. Existing 3.x release-candidate users should run `omarchy update` before selecting the Quattro upgrade so their branch-local launcher contains this constrained ownership bridge. The official `https://omarchy.org/upgrade-to-quattro` endpoint already fetches the Quattro implementation directly.

Companion 3.x channel PRs: `master` #9072 and `dev` #9071.
