### PR TITLE
Update basecamp/omarchy references to omacom/omarchy in contributing.md

### DIFF
--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -3,13 +3,14 @@
 Read this when the user wants to report an Omarchy bug, suggest a feature, or
 contribute a fix upstream.
 
-Omarchy lives at https://github.com/basecamp/omarchy. Route requests to the
-right place:
+Omarchy lives at https://github.com/omacom/omarchy (renamed from
+basecamp/omarchy; the old name still redirects, but link the current
+one). Route requests to the right place:
 
 - **Verified bugs** -> GitHub issues. Issues are for validated bugs only, not
   support requests.
 - **Feature ideas and suggestions** ->
-  https://github.com/basecamp/omarchy/discussions/categories/suggestions
+  https://github.com/omacom/omarchy/discussions/categories/suggestions
 - **Support and "is this a bug?" questions** -> the Discord community at
   https://omarchy.org/discord. Start here when the problem isn't clearly a bug
   in Omarchy itself.
@@ -43,7 +44,7 @@ For screen-recording failures specifically, rerun with
 File the issue with `gh` when available:
 
 ```bash
-gh issue create --repo basecamp/omarchy --title "..." --body "..."
+gh issue create --repo omacom/omarchy --title "..." --body "..."
 ```
 
 Include: what happened, what was expected, steps to reproduce, system details,
@@ -54,7 +55,7 @@ the debug log URL (or attached log), and the capture.
 Never develop against `/usr/share/omarchy`. Clone a working copy instead:
 
 ```bash
-gh repo fork basecamp/omarchy --clone
+gh repo fork omacom/omarchy --clone
 cd omarchy
 ```
 


### PR DESCRIPTION
`basecamp/omarchy` renamed to `omacom/omarchy`. The old org still redirects
today, so these links aren't broken yet, but a stale reference risks breaking
if the old name is ever reused, and `gh` commands that hardcode it (the two
examples in this file) stop being copy-pasteable the day the redirect goes
away.

Updates all four references in `default/agents/skills/omarchy/contributing.md`
(the repo link, the discussions link, and the two example `gh` commands) to
the current org.

Scope note: a broader grep turns up `basecamp/omarchy` in several other files
(shell scripts, a systemd unit, a Hyprland app config, `.github/ISSUE_TEMPLATE/config.yml`),
some of which may be functional rather than just prose. Left those out of this
PR to keep it to one coherent change; happy to follow up separately if useful.

## Testing

`./test/all` shows 5 pre-existing failures unrelated to this change (3 need a
sibling `omarchy-pkgs` checkout not present in this environment; 2 look
environment-dependent). Confirmed all 5 reproduce identically on `quattro`
with this commit removed, so nothing here is a regression. This change only
touches prose/URLs in one markdown file.
