### PR TITLE
[Security] Keep the update transcript out of world-writable /tmp

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -7,9 +7,30 @@
 
 set -e
 
+# Transcript must not land on a world-writable predictable path. A local user
+# who pre-creates /tmp/omarchy-update.log as a symlink can redirect script(1)
+# into ~/.bashrc or ~/.ssh/authorized_keys. Prefer the private runtime dir;
+# fall back to a 0700 cache directory under $HOME when XDG_RUNTIME_DIR is unset.
+omarchy_update_log_path() {
+  local dir
+  if [[ -n ${XDG_RUNTIME_DIR:-} && -d $XDG_RUNTIME_DIR && ! -L $XDG_RUNTIME_DIR ]]; then
+    dir="$XDG_RUNTIME_DIR/omarchy-update"
+  else
+    dir="${HOME}/.cache/omarchy/update"
+  fi
+  mkdir -p -m 700 "$dir"
+  printf '%s' "$dir/update.log"
+}
+
 if [[ -z ${OMARCHY_UPDATE_LOGGED:-} ]]; then
   script_command=$(printf '%q ' "$0" "$@")
-  exec env OMARCHY_UPDATE_LOGGED=1 script -qefc "$script_command" "/tmp/omarchy-update.log"
+  update_log=$(omarchy_update_log_path)
+  # Refuse to follow a planted symlink at the log path.
+  if [[ -L $update_log ]]; then
+    rm -f "$update_log"
+  fi
+  exec env OMARCHY_UPDATE_LOGGED=1 OMARCHY_UPDATE_LOG="$update_log" \
+    script -qefc "$script_command" "$update_log"
 fi
 
 if ! omarchy-update-lock held; then

--- a/bin/omarchy-update-analyze-logs
+++ b/bin/omarchy-update-analyze-logs
@@ -2,7 +2,25 @@
 
 # omarchy:summary=Check the update log for known failure conditions
 
-update_log="/tmp/omarchy-update.log"
+set -euo pipefail
+
+omarchy_update_log_path() {
+  local dir
+  if [[ -n ${XDG_RUNTIME_DIR:-} && -d $XDG_RUNTIME_DIR && ! -L $XDG_RUNTIME_DIR ]]; then
+    dir="$XDG_RUNTIME_DIR/omarchy-update"
+  else
+    dir="${HOME}/.cache/omarchy/update"
+  fi
+  printf '%s' "$dir/update.log"
+}
+
+# Prefer the path the current update exported; otherwise resolve the same
+# private location omarchy-update uses for new transcripts.
+update_log="${OMARCHY_UPDATE_LOG:-$(omarchy_update_log_path)}"
+
+if [[ ! -f $update_log || -L $update_log ]]; then
+  exit 0
+fi
 
 # Check for initramfs generation failure
 if grep -q "Updating linux initcpios" "$update_log"; then

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -22,7 +22,7 @@ The design goal is:
 | Path | Owner | Purpose |
 | --- | --- | --- |
 | `${XDG_RUNTIME_DIR:-/tmp}/omarchy-update.lock` | user | Prevent overlapping update runs. Owned by `omarchy-update-lock`; compatibility wrappers inherit/respect it. |
-| `/tmp/omarchy-update.log` | user | Transcript of `omarchy update`, used by `omarchy-update-analyze-logs`. |
+| `${XDG_RUNTIME_DIR}/omarchy-update/update.log (or ~/.cache/omarchy/update/update.log)` | user | Transcript of `omarchy update`, used by `omarchy-update-analyze-logs`. |
 | `~/.local/state/omarchy/current/` | user | Generated active theme, selected theme name, and current background symlink. |
 | `~/.local/state/omarchy/migrations/` | user | Per-user migration markers. |
 | `~/.local/state/omarchy/reboot-required` | user | Optional reboot marker checked by `omarchy-update-restart`. |
@@ -112,7 +112,7 @@ High-level flow:
 
 ```text
 omarchy-update
-  ├─ ensure transcript logging through script(1) → /tmp/omarchy-update.log
+  ├─ ensure transcript logging through script(1) → ${XDG_RUNTIME_DIR}/omarchy-update/update.log (or ~/.cache/omarchy/update/update.log)
   ├─ omarchy-update-lock
   │    └─ acquire the update lock and run omarchy-update inside it
   ├─ omarchy-update-requires-free-space
@@ -145,7 +145,7 @@ Important behavior:
   check is silently skipped. Set `OMARCHY_UPDATE_FORCE=1` to bypass the check.
 - `omarchy update` checks/runs migrations in the same visible terminal via
   `omarchy-migrate` after pacman finishes.
-- A failure should leave enough output in `/tmp/omarchy-update.log` and the
+- A failure should leave enough output in `${XDG_RUNTIME_DIR}/omarchy-update/update.log (or ~/.cache/omarchy/update/update.log)` and the
   terminal transcript to debug.
 
 ## Path 2: direct `sudo pacman -Syu` attempt
@@ -284,7 +284,7 @@ scripts.
 | `omarchy-update-aur-pkgs` | Updates AUR packages with `yay -Sua` if foreign packages exist and AUR is reachable. | **Question.** Omarchy is package-backed now, but users may still install AUR packages. Keep for now. |
 | `omarchy-update-mise` | Runs `MISE_MINIMUM_RELEASE_AGE=0 mise up` for mise-managed tools — the override of mise's release-age cooldown is the point. | **Keep.** Mise-managed tools are intentionally part of the blessed update path. |
 | `omarchy-update-orphan-pkgs` | Lists orphans and prompts before removal; noninteractive mode never removes. | **Keep for now.** Safe because it is prompt-only. |
-| `omarchy-update-analyze-logs` | Scans `/tmp/omarchy-update.log` for known failure patterns, currently initramfs generation. | **Keep/expand.** Useful safety net; should grow only for high-signal checks. |
+| `omarchy-update-analyze-logs` | Scans `${XDG_RUNTIME_DIR}/omarchy-update/update.log (or ~/.cache/omarchy/update/update.log)` for known failure patterns, currently initramfs generation. | **Keep/expand.** Useful safety net; should grow only for high-signal checks. |
 | `omarchy-update-restart` | Prompts for reboot after kernel/Hyprland updates, restarts components with `restart-*-required` markers, and always restarts the shell. | **Keep.** Important final step; may eventually include service-restart checks. |
 | `omarchy-update-firmware` | Manual firmware update command using fwupd. Not part of the normal update pipeline. | **Keep separate.** Firmware is not a routine system update step. |
 | `omarchy-update-time` | Restarts `systemd-timesyncd`. | **Question.** Not really an update command. Consider renaming/moving under system/time maintenance. |

--- a/test/shell.d/update-log-path-test.sh
+++ b/test/shell.d/update-log-path-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+export HOME="$test_tmp/home"
+export XDG_RUNTIME_DIR="$test_tmp/run"
+mkdir -p "$HOME" "$XDG_RUNTIME_DIR"
+
+# Source the path helper the same way the scripts resolve it.
+path_from_update=$(bash -c '
+  omarchy_update_log_path() {
+    local dir
+    if [[ -n ${XDG_RUNTIME_DIR:-} && -d $XDG_RUNTIME_DIR && ! -L $XDG_RUNTIME_DIR ]]; then
+      dir="$XDG_RUNTIME_DIR/omarchy-update"
+    else
+      dir="${HOME}/.cache/omarchy/update"
+    fi
+    mkdir -p -m 700 "$dir"
+    printf "%s" "$dir/update.log"
+  }
+  omarchy_update_log_path
+')
+
+[[ $path_from_update == "$XDG_RUNTIME_DIR/omarchy-update/update.log" ]] ||
+  fail "update log resolves under XDG_RUNTIME_DIR" "$path_from_update"
+pass "update log resolves under XDG_RUNTIME_DIR"
+
+# Analyze-logs must ignore a symlink at the log path (the attack /tmp used to allow).
+mkdir -p "$XDG_RUNTIME_DIR/omarchy-update"
+ln -s "$HOME/.bashrc" "$XDG_RUNTIME_DIR/omarchy-update/update.log"
+touch "$HOME/.bashrc"
+OMARCHY_UPDATE_LOG="$XDG_RUNTIME_DIR/omarchy-update/update.log" \
+  bash "$ROOT/bin/omarchy-update-analyze-logs"
+# Still a symlink — analyze refused to read it; bashrc untouched content-wise.
+[[ -L $XDG_RUNTIME_DIR/omarchy-update/update.log ]] ||
+  fail "analyze-logs must not replace a planted symlink"
+pass "analyze-logs refuses to read a planted symlink"
+
+# Without XDG_RUNTIME_DIR, fall back under $HOME/.cache, never /tmp.
+unset XDG_RUNTIME_DIR
+fallback=$(bash -c '
+  omarchy_update_log_path() {
+    local dir
+    if [[ -n ${XDG_RUNTIME_DIR:-} && -d $XDG_RUNTIME_DIR && ! -L $XDG_RUNTIME_DIR ]]; then
+      dir="$XDG_RUNTIME_DIR/omarchy-update"
+    else
+      dir="${HOME}/.cache/omarchy/update"
+    fi
+    mkdir -p -m 700 "$dir"
+    printf "%s" "$dir/update.log"
+  }
+  omarchy_update_log_path
+')
+[[ $fallback == "$HOME/.cache/omarchy/update/update.log" ]] ||
+  fail "update log falls back under \$HOME/.cache" "$fallback"
+[[ $fallback != /tmp/* ]] || fail "update log must not fall back under /tmp" "$fallback"
+pass "update log falls back under \$HOME/.cache, not /tmp"
+
+if grep -E '^[^#]* /tmp/omarchy-update\.log' "$ROOT/bin/omarchy-update" >/dev/null; then
+  fail "omarchy-update still hard-codes /tmp/omarchy-update.log"
+fi
+pass "omarchy-update no longer hard-codes /tmp/omarchy-update.log"


### PR DESCRIPTION
## Summary
- `omarchy update` always wrote `/tmp/omarchy-update.log`
- A local user who pre-created that path as a symlink could redirect `script(1)` into the victim's files
- Stage the log under `$XDG_RUNTIME_DIR/omarchy-update/` (or a 0700 cache under `~/.cache/omarchy/update`); analyze-logs follows the same path and refuses symlinks

## Test plan
- [x] `bash test/shell.d/update-log-path-test.sh`
- [ ] Run `omarchy update -y` (or a dry path) and confirm the transcript is not under `/tmp/omarchy-update.log`