### PR TITLE
[Security] Shell-quote install helpers before bash -c

### DIFF
--- a/bin/omarchy-install-and-launch
+++ b/bin/omarchy-install-and-launch
@@ -14,8 +14,9 @@ if [[ -z $name || -z $packages || -z $desktop_id ]]; then
 fi
 
 printf -v install_message '%q' "Installing ${name}..."
+printf -v packages_q '%q' "$packages"
 printf -v desktop_id_arg '%q' "$desktop_id"
 
 # The subshell keeps & from backgrounding the package installation too.
 exec omarchy-launch-floating-terminal-with-presentation \
-  "echo ${install_message}; omarchy-pkg-add ${packages} && (setsid uwsm-app -- gtk-launch ${desktop_id_arg} >/dev/null 2>&1 &)"
+  "echo ${install_message}; omarchy-pkg-add ${packages_q} && (setsid uwsm-app -- gtk-launch ${desktop_id_arg} >/dev/null 2>&1 &)"

--- a/bin/omarchy-install-app
+++ b/bin/omarchy-install-app
@@ -12,4 +12,8 @@ if [[ -z $name || -z $packages ]]; then
   exit 1
 fi
 
-exec omarchy-launch-floating-terminal-with-presentation "echo 'Installing ${name}...'; omarchy-pkg-add ${packages}"
+printf -v install_message '%q' "Installing ${name}..."
+printf -v packages_q '%q' "$packages"
+
+exec omarchy-launch-floating-terminal-with-presentation \
+  "echo ${install_message}; omarchy-pkg-add ${packages_q}"

--- a/bin/omarchy-install-font
+++ b/bin/omarchy-install-font
@@ -13,5 +13,12 @@ if [[ -z $name || -z $package || -z $family ]]; then
   exit 1
 fi
 
+# Every piece that reaches bash -c must be %q-quoted. Unquoted interpolation
+# lets `omarchy-install-font x 'pkg; id' y` run arbitrary commands, and
+# omarchy-pkg-add then escalates via sudo.
+printf -v install_message '%q' "Installing ${name}..."
+printf -v package_q '%q' "$package"
+printf -v family_q '%q' "$family"
+
 exec omarchy-launch-floating-terminal-with-presentation \
-  "echo 'Installing ${name}...'; omarchy-pkg-add ${package} && sleep 2 && omarchy-font-set '${family}'"
+  "echo ${install_message}; omarchy-pkg-add ${package_q} && sleep 2 && omarchy-font-set ${family_q}"

--- a/test/shell.d/install-helpers-quote-test.sh
+++ b/test/shell.d/install-helpers-quote-test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+# Capture the script string the floating-terminal helper would run.
+cat >"$stub_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_INSTALL_QUOTE_CAPTURE"
+SH
+chmod +x "$stub_bin/omarchy-launch-floating-terminal-with-presentation"
+
+export PATH="$stub_bin:$PATH"
+export OMARCHY_INSTALL_QUOTE_CAPTURE="$test_tmp/capture"
+
+: >"$OMARCHY_INSTALL_QUOTE_CAPTURE"
+bash "$ROOT/bin/omarchy-install-font" 'Cascadia' 'ttf-good; touch INJECTED' 'Family'
+captured=$(<"$OMARCHY_INSTALL_QUOTE_CAPTURE")
+[[ $captured == *'ttf-good\;\ touch\ INJECTED'* || $captured == *"ttf-good; touch INJECTED"* ]] || true
+# %q will escape the semicolon and space so it is one word for bash -c
+[[ $captured == *omarchy-pkg-add* ]] || fail "font install still calls pkg-add" "$captured"
+# The dangerous form is an unquoted semicolon between pkg-add and touch.
+if [[ $captured =~ omarchy-pkg-add\ ttf-good\;\ touch ]]; then
+  fail "font package argument was not shell-quoted" "$captured"
+fi
+# Accept bash %q form (backslashes) — must not contain bare `; touch`
+if [[ $captured == *'; touch INJECTED'* && $captured != *'\;'* && $captured != *"';"* ]]; then
+  fail "font package left a bare shell metacharacter sequence" "$captured"
+fi
+# Stronger: the capture must include a quoted/escaped package token, not raw
+case $captured in
+  *'omarchy-pkg-add ttf-good; touch'*) fail "font package was interpolated raw" "$captured" ;;
+esac
+pass "omarchy-install-font shell-quotes the package name"
+
+: >"$OMARCHY_INSTALL_QUOTE_CAPTURE"
+bash "$ROOT/bin/omarchy-install-app" 'App' 'pkg$(id)'
+captured=$(<"$OMARCHY_INSTALL_QUOTE_CAPTURE")
+case $captured in
+  *'omarchy-pkg-add pkg$(id)'*) fail "app packages were interpolated raw" "$captured" ;;
+esac
+pass "omarchy-install-app shell-quotes the package list"
+
+: >"$OMARCHY_INSTALL_QUOTE_CAPTURE"
+bash "$ROOT/bin/omarchy-install-and-launch" 'App' 'pkg; id' 'desktop'
+captured=$(<"$OMARCHY_INSTALL_QUOTE_CAPTURE")
+case $captured in
+  *'omarchy-pkg-add pkg; id'*) fail "and-launch packages were interpolated raw" "$captured" ;;
+esac
+pass "omarchy-install-and-launch shell-quotes the package list"


### PR DESCRIPTION
## Summary
- `omarchy-install-font` / `omarchy-install-app` interpolated names and packages into a string run by `bash -c`
- `omarchy-install-and-launch` quoted the message and desktop id but left packages raw
- A crafted package argument became arbitrary commands that `omarchy-pkg-add` then escalated via sudo
- `%q`-quote every interpolated piece

## Test plan
- [x] `bash test/shell.d/install-helpers-quote-test.sh`
- [ ] Menu-driven font/app installs still work with normal package names


Made with [Cursor](https://cursor.com)