### PR TITLE
[Security] Generate secrets for Docker DB containers

### DIFF
--- a/bin/omarchy-install-docker-dbs
+++ b/bin/omarchy-install-docker-dbs
@@ -3,26 +3,82 @@
 # omarchy:summary=Install one of the supported databases in a Docker container with the suitable development options.
 # omarchy:requires-sudo=true
 
+set -euo pipefail
+
 options=("MySQL" "PostgreSQL" "Redis" "MongoDB" "MariaDB" "MSSQL")
+CREDS_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/docker-dbs"
+
+generate_secret() {
+  # URL-safe enough for DB passwords; avoid characters that complicate shell/DSN quoting.
+  openssl rand -base64 24 | tr -d '\n' | tr '+/' 'AB'
+}
+
+write_creds() {
+  local name=$1
+  shift
+  mkdir -p -m 700 "$CREDS_DIR"
+  local file="$CREDS_DIR/${name}.env"
+  umask 077
+  printf '%s\n' "$@" >"$file"
+  chmod 600 "$file"
+  echo "Credentials written to $file (mode 600)."
+}
 
 if (( $# == 0 )); then
-  choices=$(printf "%s\n" "${options[@]}" | gum choose --header "Select database (return to install, esc to cancel)") || main_menu
+  choices=$(printf "%s\n" "${options[@]}" | gum choose --header "Select database (return to install, esc to cancel)") || exit 0
 else
-  choices="$@"
+  choices="$*"
 fi
 
-if [[ -n $choices ]]; then
-  for db in $choices; do
-    echo "Installing $db..."
-    case $db in
-    MySQL) sudo docker run -d --restart unless-stopped -p "127.0.0.1:3306:3306" --name=mysql8 -e MYSQL_ROOT_PASSWORD= -e MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.4 ;;
-    PostgreSQL) sudo docker run -d --restart unless-stopped -p "127.0.0.1:5432:5432" --name=postgres18 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:18 ;;
-    MariaDB) sudo docker run -d --restart unless-stopped -p "127.0.0.1:3306:3306" --name=mariadb11 -e MARIADB_ROOT_PASSWORD= -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=true mariadb:11.8 ;;
-    Redis) sudo docker run -d --restart unless-stopped -p "127.0.0.1:6379:6379" --name=redis redis:7 ;;
-    MongoDB) sudo docker run -d --restart unless-stopped -p "127.0.0.1:27017:27017" --name mongodb -e MONGO_INITDB_ROOT_USERNAME=admin -e MONGO_INITDB_ROOT_PASSWORD=admin123 mongo:noble ;;
-    MSSQL) sudo docker run -d --restart unless-stopped -p "127.0.0.1:1433:1433" --name mssql -e MSSQL_PID=Developer -e ACCEPT_EULA=Y -e "MSSQL_SA_PASSWORD=@dmin123" mcr.microsoft.com/mssql/server:2022-CU12-ubuntu-22.04 ;;
-    esac
-  done
-else
+if [[ -z $choices ]]; then
   echo "No databases selected for installation."
+  exit 0
 fi
+
+for db in $choices; do
+  echo "Installing $db..."
+  case $db in
+  MySQL)
+    password=$(generate_secret)
+    write_creds mysql "MYSQL_ROOT_PASSWORD=$password" "MYSQL_HOST=127.0.0.1" "MYSQL_PORT=3306"
+    sudo docker run -d --restart unless-stopped -p "127.0.0.1:3306:3306" --name=mysql8 \
+      -e "MYSQL_ROOT_PASSWORD=$password" mysql:8.4
+    ;;
+  PostgreSQL)
+    password=$(generate_secret)
+    write_creds postgres "POSTGRES_PASSWORD=$password" "POSTGRES_USER=postgres" "POSTGRES_HOST=127.0.0.1" "POSTGRES_PORT=5432"
+    sudo docker run -d --restart unless-stopped -p "127.0.0.1:5432:5432" --name=postgres18 \
+      -e "POSTGRES_PASSWORD=$password" postgres:18
+    ;;
+  MariaDB)
+    password=$(generate_secret)
+    write_creds mariadb "MARIADB_ROOT_PASSWORD=$password" "MARIADB_HOST=127.0.0.1" "MARIADB_PORT=3306"
+    sudo docker run -d --restart unless-stopped -p "127.0.0.1:3306:3306" --name=mariadb11 \
+      -e "MARIADB_ROOT_PASSWORD=$password" mariadb:11.8
+    ;;
+  Redis)
+    password=$(generate_secret)
+    write_creds redis "REDIS_PASSWORD=$password" "REDIS_HOST=127.0.0.1" "REDIS_PORT=6379"
+    sudo docker run -d --restart unless-stopped -p "127.0.0.1:6379:6379" --name=redis \
+      redis:7 redis-server --requirepass "$password"
+    ;;
+  MongoDB)
+    password=$(generate_secret)
+    write_creds mongodb "MONGO_INITDB_ROOT_USERNAME=admin" "MONGO_INITDB_ROOT_PASSWORD=$password" "MONGO_HOST=127.0.0.1" "MONGO_PORT=27017"
+    sudo docker run -d --restart unless-stopped -p "127.0.0.1:27017:27017" --name mongodb \
+      -e MONGO_INITDB_ROOT_USERNAME=admin -e "MONGO_INITDB_ROOT_PASSWORD=$password" mongo:noble
+    ;;
+  MSSQL)
+    # MSSQL requires complexity: upper, lower, digit, symbol, length >= 8.
+    password="Ad$(openssl rand -hex 12)!"
+    write_creds mssql "MSSQL_SA_PASSWORD=$password" "MSSQL_HOST=127.0.0.1" "MSSQL_PORT=1433"
+    sudo docker run -d --restart unless-stopped -p "127.0.0.1:1433:1433" --name mssql \
+      -e MSSQL_PID=Developer -e ACCEPT_EULA=Y -e "MSSQL_SA_PASSWORD=$password" \
+      mcr.microsoft.com/mssql/server:2022-CU12-ubuntu-22.04
+    ;;
+  *)
+    echo "Unknown database: $db" >&2
+    exit 1
+    ;;
+  esac
+done

--- a/test/shell.d/docker-dbs-secrets-test.sh
+++ b/test/shell.d/docker-dbs-secrets-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+# Drop the leading sudo and run docker stub directly when requested.
+if [[ $1 == docker ]]; then
+  shift
+  exec docker "$@"
+fi
+exec "$@"
+SH
+chmod +x "$stub_bin/sudo"
+
+cat >"$stub_bin/docker" <<'SH'
+#!/bin/bash
+printf 'docker' >>"$OMARCHY_DOCKER_DBS_LOG"
+for arg in "$@"; do
+  printf '\t%s' "$arg" >>"$OMARCHY_DOCKER_DBS_LOG"
+done
+printf '\n' >>"$OMARCHY_DOCKER_DBS_LOG"
+SH
+chmod +x "$stub_bin/docker"
+
+cat >"$stub_bin/openssl" <<'SH'
+#!/bin/bash
+# Deterministic "random" for the test.
+if [[ $1 == rand && $2 == -base64 ]]; then
+  echo 'TESTSECRET+/BASE64VALUE=='
+  exit 0
+fi
+if [[ $1 == rand && $2 == -hex ]]; then
+  echo 'aabbccddeeff001122334455'
+  exit 0
+fi
+exec /usr/bin/openssl "$@"
+SH
+chmod +x "$stub_bin/openssl"
+
+export HOME="$test_tmp/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+export PATH="$stub_bin:$PATH"
+export OMARCHY_DOCKER_DBS_LOG="$test_tmp/docker.log"
+mkdir -p "$HOME"
+
+: >"$OMARCHY_DOCKER_DBS_LOG"
+bash "$ROOT/bin/omarchy-install-docker-dbs" PostgreSQL >/dev/null
+
+creds="$XDG_CONFIG_HOME/omarchy/docker-dbs/postgres.env"
+[[ -f $creds ]] || fail "postgres credentials file was written"
+[[ $(stat -f '%Lp' "$creds" 2>/dev/null || stat -c '%a' "$creds") == *600 ]] ||
+  fail "credentials file must be mode 600" "$(ls -l "$creds")"
+grep -q 'POSTGRES_PASSWORD=' "$creds" || fail "credentials file carries POSTGRES_PASSWORD"
+grep -q 'POSTGRES_HOST_AUTH_METHOD=trust' "$OMARCHY_DOCKER_DBS_LOG" &&
+  fail "postgres must not use trust auth" "$(cat "$OMARCHY_DOCKER_DBS_LOG")"
+grep -q 'POSTGRES_PASSWORD=' "$OMARCHY_DOCKER_DBS_LOG" ||
+  fail "postgres docker run must pass POSTGRES_PASSWORD" "$(cat "$OMARCHY_DOCKER_DBS_LOG")"
+pass "PostgreSQL gets a generated password and no trust auth"
+
+: >"$OMARCHY_DOCKER_DBS_LOG"
+bash "$ROOT/bin/omarchy-install-docker-dbs" MongoDB >/dev/null
+grep -q 'admin123' "$OMARCHY_DOCKER_DBS_LOG" &&
+  fail "MongoDB must not use the hardcoded admin123 password" "$(cat "$OMARCHY_DOCKER_DBS_LOG")"
+grep -q 'admin123' "$XDG_CONFIG_HOME/omarchy/docker-dbs/mongodb.env" &&
+  fail "MongoDB creds file must not contain admin123"
+pass "MongoDB no longer uses hardcoded admin123"
+
+# Static guarantee the script itself dropped empty-password / trust flags.
+grep -E 'ALLOW_EMPTY|HOST_AUTH_METHOD=trust|admin123|@dmin123' "$ROOT/bin/omarchy-install-docker-dbs" &&
+  fail "install-docker-dbs still contains empty/hardcoded credential flags" ||
+  pass "install-docker-dbs source has no empty/hardcoded credential flags"


### PR DESCRIPTION
## Summary
- MySQL/MariaDB allowed empty root passwords, Postgres used `trust`, Mongo used `admin`/`admin123`, MSSQL used a fixed SA password
- Anything on the machine that can reach the loopback ports got database superuser
- Generate per-install secrets, require auth for every engine, and write credentials to `~/.config/omarchy/docker-dbs/*.env` mode 0600

## Test plan
- [x] `bash test/shell.d/docker-dbs-secrets-test.sh`
- [ ] Install PostgreSQL via the menu; confirm the container requires the password from the env file