### PR TITLE
Update remaining basecamp/omarchy references to omacom/omarchy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Suggestion
-    url: https://github.com/basecamp/omarchy/discussions/categories/suggestions
+    url: https://github.com/omacom/omarchy/discussions/categories/suggestions
     about: Suggest a new feature, change to existing feature, or other ideas in Discussions.
   - name: Support
     url: https://omarchy.org/discord

--- a/bin/omarchy-update-confirm
+++ b/bin/omarchy-update-confirm
@@ -8,7 +8,7 @@ gum style --border normal --padding "1 2" \
   "• You cannot stop the update once you start!" \
   "• Make sure you're connected to power or have a full battery" \
   "" \
-  "What's new: https://github.com/basecamp/omarchy/releases/latest"
+  "What's new: https://github.com/omacom/omarchy/releases/latest"
 
 echo
 

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -959,7 +959,7 @@ populate_legacy_hypr_defaults() {
     tmp_dir=$(mktemp -d)
     archive_dir="$tmp_dir/archive"
     mkdir -p "$archive_dir"
-    if curl -fsSL https://github.com/basecamp/omarchy/archive/refs/heads/master.tar.gz | tar -xz -C "$archive_dir" &&
+    if curl -fsSL https://github.com/omacom/omarchy/archive/refs/heads/master.tar.gz | tar -xz -C "$archive_dir" &&
       [[ -d $archive_dir/omarchy-master/default/hypr ]]; then
       cp -a "$archive_dir/omarchy-master/default/hypr/." "$shim_hypr_dir/"
     fi

--- a/default/agents/skills/diagnose-crash/reporting.md
+++ b/default/agents/skills/diagnose-crash/reporting.md
@@ -40,8 +40,8 @@ useful; filing there yourself is not part of this.
 A duplicate issue costs a maintainer more time than no report at all.
 
 ```bash
-gh search issues --repo basecamp/omarchy "<program> crash"
-gh issue list --repo basecamp/omarchy --state all --search "<signal> <program>"
+gh search issues --repo omacom/omarchy "<program> crash"
+gh issue list --repo omacom/omarchy --state all --search "<signal> <program>"
 ```
 
 Search on the crashing program, the signal, and distinctive symbols from the
@@ -59,7 +59,7 @@ more than another duplicate.
 If a plausible match comes back, read it properly first:
 
 ```bash
-gh issue view <number> --repo basecamp/omarchy --comments
+gh issue view <number> --repo omacom/omarchy --comments
 ```
 
 Confirm it is genuinely the same failure. The same program crashing is not the
@@ -74,7 +74,7 @@ A comment that only says the bug happens to you too is noise. If that is all you
 have, tell the user so and file nothing.
 
 ```bash
-gh issue comment <number> --repo basecamp/omarchy --body "..."
+gh issue comment <number> --repo omacom/omarchy --body "..."
 ```
 
 ## Filing a new issue
@@ -82,7 +82,7 @@ gh issue comment <number> --repo basecamp/omarchy --body "..."
 Only when the search turns up nothing that matches:
 
 ```bash
-gh issue create --repo basecamp/omarchy --title "..." --body "..."
+gh issue create --repo omacom/omarchy --title "..." --body "..."
 ```
 
 Include what happened, what was expected, steps to reproduce, system details from

--- a/default/hypr/apps/jetbrains.lua
+++ b/default/hypr/apps/jetbrains.lua
@@ -1,2 +1,2 @@
--- Disable mouse focus (see https://github.com/basecamp/omarchy/pull/5183#issuecomment-4189299971).
+-- Disable mouse focus (see https://github.com/omacom/omarchy/pull/5183#issuecomment-4189299971).
 o.window("^(jetbrains-.*)$", { no_follow_mouse = true })

--- a/default/systemd/user/omarchy-speaker-tuning.service
+++ b/default/systemd/user/omarchy-speaker-tuning.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Omarchy speaker tuning filter-chain
-Documentation=https://github.com/basecamp/omarchy/blob/master/docs/audio-tuning.md
+Documentation=https://github.com/omacom/omarchy/blob/master/docs/audio-tuning.md
 # WirePlumber does the linking, so starting before it is up risks the output being
 # linked before the speaker device has been discovered.
 After=pipewire.service wireplumber.service

--- a/manual/30-updates.md
+++ b/manual/30-updates.md
@@ -2,7 +2,7 @@
 
 Omarchy and your packages are kept up to date via _Update > Omarchy_ in the Omarchy menu (`Super + Space`).
 
-Omarchy itself is installed as regular pacman packages from the [Omarchy Package Repository](https://github.com/omacom-io/omarchy-pkgs), so an update installs [the latest Omarchy release](https://github.com/basecamp/omarchy/releases), runs any pending migrations to get your system in sync with the latest, and updates all system packages from the [Omarchy Arch Mirror](https://github.com/omacom-io/omarchy-mirror) and [AUR](https://aur.archlinux.org/) (if you have installed any AUR packages).
+Omarchy itself is installed as regular pacman packages from the [Omarchy Package Repository](https://github.com/omacom-io/omarchy-pkgs), so an update installs [the latest Omarchy release](https://github.com/omacom/omarchy/releases), runs any pending migrations to get your system in sync with the latest, and updates all system packages from the [Omarchy Arch Mirror](https://github.com/omacom-io/omarchy-mirror) and [AUR](https://aur.archlinux.org/) (if you have installed any AUR packages).
 
 When new releases are made, a circle arrow icon will appear to the right of your clock. Click it and the update process will start.
 
@@ -10,7 +10,7 @@ When new releases are made, a circle arrow icon will appear to the right of your
 
 ### Four channels
 
-Omarchy is updated along four channels: stable, RC, edge, and dev. New installations start on the stable channel, which tracks the [official releases](https://github.com/basecamp/omarchy/releases/), as well as the [stable Omarchy Arch mirror](https://github.com/omacom-io/omarchy-mirror) that's running one month behind the latest, so we can catch any new incompatibilities that require config changes before they cause problems for people.
+Omarchy is updated along four channels: stable, RC, edge, and dev. New installations start on the stable channel, which tracks the [official releases](https://github.com/omacom/omarchy/releases/), as well as the [stable Omarchy Arch mirror](https://github.com/omacom-io/omarchy-mirror) that's running one month behind the latest, so we can catch any new incompatibilities that require config changes before they cause problems for people.
 
 But if you'd like to help spot those potential issues, you can run on the edge channel. That'll keep your Omarchy packages tracking the latest development builds, and lets you update to the latest Arch packages as soon as they're available. You should only do this if you're experienced with Linux, and know how to recover a system that has problems.
 

--- a/manual/49-omarchy-on.md
+++ b/manual/49-omarchy-on.md
@@ -6,15 +6,15 @@
 
 ### Apple Virtual Machine
 
-You can also install Omarchy inside a Parallels VM. Quite the cumbersome process, but there's [a user-driven guide](https://github.com/basecamp/omarchy/discussions/452) for that too.
+You can also install Omarchy inside a Parallels VM. Quite the cumbersome process, but there's [a user-driven guide](https://github.com/omacom/omarchy/discussions/452) for that too.
 
 ### VirtualBox
 
-VirtualBox is a popular VM runner. [You can run Omarchy inside that too](https://github.com/basecamp/omarchy/discussions/176). But performance probably won't be great.
+VirtualBox is a popular VM runner. [You can run Omarchy inside that too](https://github.com/omacom/omarchy/discussions/176). But performance probably won't be great.
 
 ### VMware Workstation on Windows 11
 
-Another popular VM runner for Windows. [Omarchy has been setup inside of that as well](https://github.com/basecamp/omarchy/discussions/572).
+Another popular VM runner for Windows. [Omarchy has been setup inside of that as well](https://github.com/omacom/omarchy/discussions/572).
 
 ### Steam Deck
 


### PR DESCRIPTION
Follow-up to #9080, which fixed the same stale `basecamp/omarchy` → `omacom/omarchy`
reference in `default/agents/skills/omarchy/contributing.md`. A repo-wide grep
turned up eight more files with the same pre-rename org name:

- `manual/30-updates.md` — two release links
- `manual/49-omarchy-on.md` — three `discussions/<number>` links (numeric IDs
  are unaffected by the rename, only the org prefix changes)
- `default/systemd/user/omarchy-speaker-tuning.service` — the `Documentation=` URL
- `default/agents/skills/diagnose-crash/reporting.md` — five `gh` command examples
  (same pattern already fixed in `contributing.md`)
- `default/hypr/apps/jetbrains.lua` — a code comment linking the PR that explains
  the window rule
- `bin/omarchy-update-confirm` — the "What's new" release link shown before an update
- `.github/ISSUE_TEMPLATE/config.yml` — the Suggestion contact link
- `bin/omarchy-upgrade-to-quattro` — the archive-tarball URL in
  `populate_legacy_hypr_defaults`

## Why these and not the other two

Two more files reference the org (`bin/omarchy-channel-set`'s dev-channel
`git clone`, and `test/shell.d/channel-test.sh`, which asserts that exact
clone URL verbatim). Left those for a separate PR since the fix there has to
touch the test in the same commit or it breaks, which is a different shape of
change from a plain reference swap.

## Verified before changing anything

None of these are live breakage — confirmed via `curl` and `git ls-remote`
that GitHub's redirect covers the web UI, the `codeload` archive-tarball
endpoint, and the git smart-HTTP clone protocol identically today. So this is
future-proofing (the redirect could go away, or the old org name could get
reused), not a bug fix.

For `omarchy-upgrade-to-quattro` specifically: it fetches the `master` branch
by name (not the current default `quattro`), which looked like it might be a
second, unrelated bug — but the function is `populate_legacy_hypr_defaults`,
and `master` still exists upstream, so that's deliberately pulling legacy
content for a compatibility shim. Left the branch name alone; only the org
changed.

## Testing

`./test/all` — same 5 pre-existing, unrelated failures as on a clean `quattro`
checkout (3 need a sibling `omarchy-pkgs` checkout not present here, 2 look
environment-dependent). Nothing new.
