### PR TITLE
Point the dev-channel checkout clone at omacom/omarchy

### DIFF
--- a/bin/omarchy-channel-set
+++ b/bin/omarchy-channel-set
@@ -34,7 +34,7 @@ validate_dev_checkout() {
 
 link_dev_checkout() {
   local checkout="$1"
-  [[ -d $checkout/.git ]] || git clone https://github.com/basecamp/omarchy.git "$checkout"
+  [[ -d $checkout/.git ]] || git clone https://github.com/omacom/omarchy.git "$checkout"
 
   omarchy-dev-link "$checkout" --no-reboot
 }

--- a/test/shell.d/channel-test.sh
+++ b/test/shell.d/channel-test.sh
@@ -147,11 +147,11 @@ run_channel dev
 assert_log_line $'gum\tconfirm\t--default=false\tSwitch to dev channel?' "dev asks for confirmation"
 assert_log_line $'refresh\tedge' "dev refreshes the edge pacman channel"
 assert_log_line $'sudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev' "dev installs development Omarchy packages"
-assert_log_line $'git\tclone\thttps://github.com/basecamp/omarchy.git\t'"$checkout" "dev clones the source checkout to ~/omarchy"
+assert_log_line $'git\tclone\thttps://github.com/omacom/omarchy.git\t'"$checkout" "dev clones the source checkout to ~/omarchy"
 assert_log_line $'link\t'"$checkout"$'\t--no-reboot' "dev links ~/omarchy without an early reboot prompt"
 assert_log_line $'state\tset\treboot-required' "dev defers the reboot prompt to the update pipeline"
 assert_log_line $'update\t-y\tOMARCHY_PATH='"$checkout" "dev runs the normal update pipeline from the source checkout"
-[[ $(grep -E '^(git|link|state|refresh|sudo|update)' "$log_file") == $'git\tclone\thttps://github.com/basecamp/omarchy.git\t'"$checkout"$'\nlink\t'"$checkout"$'\t--no-reboot\nstate\tset\treboot-required\nrefresh\tedge\nsudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev\nupdate\t-y\tOMARCHY_PATH='"$checkout" ]] ||
+[[ $(grep -E '^(git|link|state|refresh|sudo|update)' "$log_file") == $'git\tclone\thttps://github.com/omacom/omarchy.git\t'"$checkout"$'\nlink\t'"$checkout"$'\t--no-reboot\nstate\tset\treboot-required\nrefresh\tedge\nsudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev\nupdate\t-y\tOMARCHY_PATH='"$checkout" ]] ||
   fail "dev activates the checkout before changing or updating packages" "$(cat "$log_file")"
 pass "dev activates the checkout before changing or updating packages"
 


### PR DESCRIPTION
Same rename as #9080 and #9087 (`basecamp/omarchy` → `omacom/omarchy`), split
out separately because this one is coupled to a test rather than a plain
reference swap.

`bin/omarchy-channel-set`'s `dev` channel clones the source repo directly to
`~/omarchy`:

```bash
[[ -d $checkout/.git ]] || git clone https://github.com/basecamp/omarchy.git "$checkout"
```

`test/shell.d/channel-test.sh` asserts that exact clone command, including the
URL, verbatim — so fixing the script without the test would fail CI, and
fixing the test without the script would just pin the stale URL harder. Both
move together in this commit.

## Verified before changing anything

`git ls-remote https://github.com/basecamp/omarchy.git HEAD` resolves
correctly today (GitHub's git smart-HTTP protocol follows the org rename), so
this isn't fixing a live clone failure — it's the same future-proofing as the
other two PRs.

## Testing

`bash test/shell.d/channel-test.sh` — all 33 assertions pass, including "dev
clones the source checkout to ~/omarchy" and "dev activates the checkout
before changing or updating packages," against the updated URL.

`./test/all` — same 5 pre-existing, unrelated failures as a clean `quattro`
checkout (see #9087 for detail); `channel-test.sh` is not among them.
