### PR TITLE
Restore lock password focus whenever the screen wakes

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -67,6 +67,14 @@ Item {
     syncingPasswordText = false
   }
 
+  // The lock surface outlives a suspend, so the focus taken when the view was
+  // built can be gone by the time the machine resumes -- the compositor
+  // rebuilds the keyboard on the way back, and the view is never rebuilt to
+  // take focus again. Anything that wakes the screen has to leave the field
+  // ready to type into; previously only a click did, so waking the blanked
+  // screen with a mouse move left the password field swallowing keystrokes.
+  onWakeRequested: if (inputEnabled) forcePasswordFocus()
+
   onPasswordTextChanged: syncPasswordText()
   onInputEnabledChanged: {
     if (inputEnabled) Qt.callLater(forcePasswordFocus)
@@ -115,7 +123,7 @@ Item {
     MouseArea {
       anchors.fill: parent
       hoverEnabled: true
-      onClicked: { root.wakeRequested(); root.forcePasswordFocus() }
+      onClicked: root.wakeRequested()
       onPositionChanged: root.wakeRequested()
     }
 
@@ -131,6 +139,7 @@ Item {
 
       TextInput {
         id: passwordInput
+        objectName: "passwordInput"
         anchors.fill: parent
         anchors.topMargin: inputField.borderTop
         // Reserve the fingerprint icon's width on both sides so the centered

--- a/test/shell.d/fixtures/lock-password-focus/shell.qml
+++ b/test/shell.d/fixtures/lock-password-focus/shell.qml
@@ -1,0 +1,109 @@
+import QtQuick
+import QtQuick.Window
+import Quickshell
+import qs.Commons
+
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  readonly property string rootPath: Quickshell.env("OMARCHY_PATH")
+  property var failures: []
+
+  function fail(message) {
+    failures.push(String(message))
+  }
+
+  function assertTrue(condition, message) {
+    if (!condition) fail(message)
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    var payload = JSON.stringify({
+      ok: failures.length === 0,
+      failures: failures
+    })
+
+    if (resultPath) {
+      Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+    }
+  }
+
+  function findByObjectName(item, name) {
+    if (!item) return null
+    if (item.objectName === name) return item
+
+    var children = item.children || []
+    for (var i = 0; i < children.length; i++) {
+      var found = findByObjectName(children[i], name)
+      if (found) return found
+    }
+
+    return null
+  }
+
+  // Focus is scene state, so a real window is enough to hold it; it never shows.
+  Window {
+    id: host
+    width: 800
+    height: 600
+    visible: false
+  }
+
+  Timer {
+    interval: 1
+    running: true
+    repeat: false
+    onTriggered: {
+      try {
+        var component = Qt.createComponent("file://" + root.rootPath + "/shell/plugins/lock/LockView.qml", Component.PreferSynchronous)
+        if (component.status !== Component.Ready) {
+          root.fail("LockView failed to load: " + component.errorString())
+          return
+        }
+
+        var view = component.createObject(host.contentItem, { width: 800, height: 600, loadBackground: false })
+        if (!view) {
+          root.fail("LockView failed to instantiate: " + component.errorString())
+          return
+        }
+
+        var input = root.findByObjectName(view, "passwordInput")
+        root.assertTrue(input !== null, "password field exists in the lock view")
+
+        if (input) {
+          view.inputEnabled = true
+          view.forcePasswordFocus()
+          root.assertTrue(input.activeFocus, "password field takes focus when the lock view appears")
+
+          // The lock surface outlives a suspend, so focus can be gone by the
+          // time the machine resumes and the view is never rebuilt.
+          input.focus = false
+          root.assertTrue(!input.activeFocus, "precondition: focus can be lost while the view stays alive")
+
+          // Waking the blanked screen -- a mouse move, not a click. Every wake
+          // path goes through this signal, so a move must recover focus too.
+          view.wakeRequested()
+          root.assertTrue(input.activeFocus, "waking the lock screen restores focus to the password field")
+
+          // The lock preview reuses this view with input disabled; waking it
+          // must not hand focus to a field the user cannot type into.
+          view.inputEnabled = false
+          input.focus = false
+          view.wakeRequested()
+          root.assertTrue(!input.activeFocus, "waking does not focus the field while input is disabled")
+        }
+
+        view.destroy()
+      } catch (error) {
+        root.fail("lock password focus fixture threw: " + error)
+      } finally {
+        root.writeResult()
+      }
+    }
+  }
+}

--- a/test/shell.d/lock-password-focus-test.sh
+++ b/test/shell.d/lock-password-focus-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "lock password focus test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping lock password focus test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+config_dir="$TMPDIR/lock-password-focus"
+mkdir -p "$config_dir" "$TMPDIR/home"
+cp "$SHELL_TEST_DIR/fixtures/lock-password-focus/shell.qml" "$config_dir/shell.qml"
+ln -s "$ROOT/shell/Ui" "$config_dir/Ui"
+ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "lock password focus quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "lock password focus test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Lock password focus result:\n' >&2
+  jq . "$result" >&2
+  printf 'Lock password focus log:\n' >&2
+  sed -n '1,220p' "$log" >&2
+  fail "lock screen restores password focus when it wakes"
+fi
+
+pass "lock screen restores password focus when it wakes"


### PR DESCRIPTION
## Symptom

After resuming a laptop from suspend, the lock screen sometimes ignores keystrokes. The password field looks normal but swallows everything typed until you click it. Locking manually is unaffected — it only shows up coming back from sleep.

## Cause

`omarchy-system-sleep-lock` locks *before* suspending and waits for `secure`, so the session lock is already up when the machine goes down. The journal shows the lock surface then outlives the suspend — there is no second `lock-requested`/`secure=true` on the way back:

```
16:36:35  lock-requested → secure=true     ← locked before sleep
16:38:33  Finished System Suspend
16:39:00  secure=false → unlocked          ← password finally entered
```

So `LockView` is never rebuilt, and its `Component.onCompleted` focus never runs again. Meanwhile the compositor tears down and rebuilds the keyboard across the resume (an xkb keymap recompile lands ~5s after wake), which is where the field's keyboard focus goes.

That left `MouseArea.onClicked` as the only thing that could restore it:

```qml
onClicked: { root.wakeRequested(); root.forcePasswordFocus() }
onPositionChanged: root.wakeRequested()      // wakes the screen, never refocuses
```

`idleBlankTimer` has DPMS'd the display off by then, so you have to interact to see anything at all. Move the mouse and the panel lights up with an unfocused field; click and it works. Hence the intermittence — it depended on whether you happened to click or just move.

## Fix

Handle the wake signal itself, so every wake path recovers focus instead of just one:

```qml
onWakeRequested: if (inputEnabled) forcePasswordFocus()
```

The click handler no longer needs to special-case focus. Guarding on `inputEnabled` keeps the lock preview — which reuses this view with input disabled — from focusing a field the user cannot type into.

## Testing

Adds `test/shell.d/lock-password-focus-test.sh`, following the existing headless `LockView` fixtures. It focuses the field, drops focus the way a resume does while the view stays alive, wakes, and asserts focus came back; it also asserts waking does not focus the field while `inputEnabled` is false. Verified it fails without the change:

```
"failures": [ "waking the lock screen restores focus to the password field" ]
```

`./test/shell` passes 211/216. The 5 failures (`config`, `snapper`, `theme-install-guards`, `unowned-system-paths`, `windows-vm-mount-boundary`) reproduce unchanged on a clean checkout of master on this machine and are unrelated.

Not verified on real hardware across a live suspend/resume yet, since that needs a locked session to reproduce in the act — the automated coverage stands in for it.