### PR TITLE
Add CODEOWNERS requiring org owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Merges to protected branches need sign-off from an org owner.
+* @dhh @ryanrhughes


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning all paths to @dhh and @ryanrhughes.

Paired with the "Protect release branches from automation" ruleset, which is being updated to require one approving review and code-owner review. Net effect: anyone with write on this repo — including the new Security team — needs sign-off from an org owner before merging to quattro, master, or dev. Org admins are bypass actors so owners are not deadlocked on each other.

CODEOWNERS is read from the base branch of a PR, so this only covers quattro until the same file lands on master and dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)