### PR TITLE
Tell agents to check open PRs before writing a fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,19 @@ guidance does not drift from the router.
 - Commits should be atomic: include only one coherent change or fix, and do not mix unrelated work.
 - Commit messages should be succinct and describe the change being made.
 
+# Pull Requests
+
+Search the open pull requests before writing a fix. The backlog is large enough that one bug attracts several independent fixes: the lock screen losing password focus after suspend had four open PRs (#7164, #7592, #8560, #8869) before a fifth was filed, and the Wi-Fi password reveal toggle has two (#7815, #8019). A duplicate costs review time instead of saving it.
+
+Search by symptom, then again in a wider form, because a PR describing the same area in different words will not match the first query:
+
+```bash
+gh pr list --state open --search "password focus in:title"
+gh pr list --state open --search "lock screen suspend focus"
+```
+
+When an open PR already covers the change, add to that one rather than opening a competing one: confirm the bug on your hardware, review the approach, or contribute a test it lacks, and say so in a comment.
+
 # Helper Commands
 
 Use these instead of raw shell commands:


### PR DESCRIPTION
## Problem

`AGENTS.md` says nothing about looking for existing work before opening a PR — no mention of pull requests, duplicates, or searching. With the backlog where it is, that omission is expensive: one bug draws several independent fixes that all have to be read and compared before any can be merged.

Two clusters found without looking hard:

**Lock screen losing password focus after suspend — four open PRs:**

| PR | Approach |
|---|---|
| #7164 | refocus on `secure` becoming true |
| #7592 | 100ms polling `Timer` while unfocused |
| #8560 | `onActiveFocusChanged` reclaims focus |
| #8869 | 100ms polling `Timer` + `focus: true` |

**Wi-Fi password reveal toggle — two open PRs:** #7815 and #8019 add the same toggle.

I am not reporting this from the outside. I hit the bug, diagnosed it, wrote a fix and opened #9089 — the fifth PR on that lock bug — before finding the other four. I have since closed it as a duplicate. This change is the fix for what actually went wrong, which was the process, not the patch.

## Change

Adds a `Pull Requests` section to `AGENTS.md`: search before writing, search twice because one query does not catch a PR that describes the same area in different words, and when an open PR already covers the change, add to it — confirm the bug, review the approach, contribute a missing test — rather than opening a competing one.

Docs only, no code or test changes. Written as full lines with a fenced `bash` block, matching the file's own Style section and the Refresh Pattern example.