### PR TITLE
Tell contributors to search open PRs before writing a fix

### DIFF
--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -51,6 +51,21 @@ the debug log URL (or attached log), and the capture.
 
 ## Submitting a PR
 
+Search the open PRs before writing a fix. The backlog is large enough that one
+bug draws several independent fixes: the lock screen losing password focus
+after suspend had four open PRs at once. A duplicate costs review time instead
+of saving it.
+
+```bash
+gh pr list --repo basecamp/omarchy --state open --search "password focus in:title"
+gh pr list --repo basecamp/omarchy --state open --search "lock screen suspend focus"
+```
+
+Search by symptom and again in a wider form — a PR describing the same area in
+different words will not match the first query. When an open PR already covers
+the change, add to that one rather than opening a competing one: confirm the
+bug on your hardware, review the approach, or contribute a test it lacks.
+
 Never develop against `/usr/share/omarchy`. Clone a working copy instead:
 
 ```bash


### PR DESCRIPTION
## Problem

`contributing.md` is the doc that governs submitting a fix upstream, and it ships in the `omarchy` skill — so it is what an agent on a user's machine reads before contributing. It covers forking, style, atomic commits, and running the tests, but says nothing about checking whether the fix already exists.

The backlog is large enough that the omission is expensive. Two clusters found without looking hard:

**Lock screen losing password focus after suspend — four open PRs:**

| PR | Approach |
|---|---|
| #7164 | refocus when `secure` becomes true |
| #7592 | 100ms polling `Timer` while unfocused |
| #8560 | `onActiveFocusChanged` reclaims focus |
| #8869 | 100ms polling `Timer` + `focus: true` |

**Wi-Fi password reveal toggle — two open PRs:** #7815 and #8019 add the same toggle.

I hit that lock bug, diagnosed it, wrote a fix and opened #9089 — the fifth PR on it — before finding the other four. I have closed it as a duplicate. Four people each spent real effort on the same twenty lines, and a maintainer now has to read and compare all of them. This is the fix for what actually went wrong.

## Change

Adds four sentences and two `gh` invocations to the existing `## Submitting a PR` section: search before writing, search twice because one query will not catch a PR that words the same area differently, and when an open PR already covers the change, add to it — confirm the bug on your hardware, review the approach, contribute a missing test — instead of opening a competing one.

Docs only, no code or test changes. Hard-wrapped at 78 columns to match the rest of the file.

Opened against `contributing.md` rather than `AGENTS.md` because the duplicate gets written before anyone opens the checkout.