### PR TITLE
Tell contributors to search open PRs before writing a fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,19 @@ guidance does not drift from the router.
 - Commits should be atomic: include only one coherent change or fix, and do not mix unrelated work.
 - Commit messages should be succinct and describe the change being made.
 
+# Pull Requests
+
+Search the open pull requests before writing a fix. The backlog is large enough that one bug draws several independent fixes: the lock screen losing password focus after suspend had four open PRs (#7164, #7592, #8560, #8869) before a fifth was filed. A duplicate costs review time instead of saving it.
+
+Search by symptom, then again in wider terms, because a PR describing the same area in different words will not match the first query:
+
+```bash
+gh pr list --state open --search "password focus in:title"
+gh pr list --state open --search "lock screen suspend focus"
+```
+
+When an open PR already covers the change, add to that one rather than opening a competing one: confirm the bug on your hardware, review the approach, or contribute a test it lacks.
+
 # Helper Commands
 
 Use these instead of raw shell commands:


### PR DESCRIPTION
## Problem

`AGENTS.md` is where upstream work lands — `contributing.md` already calls it "the authority on contributions", and #6718 makes the handoff explicit ("for upstream source work, clone and follow its AGENTS.md"). It says nothing about checking whether a fix already exists.

The result: the lock screen losing password focus after suspend has four open PRs (#7164, #7592, #8560, #8869). I opened a fifth (#9089, now closed) before finding them. Four people fixed the same twenty lines and a maintainer has to compare all of them.

## Why here and not `contributing.md`

#8609 and #6959 add duplicate-check guidance to `default/agents/skills/omarchy/contributing.md`. Two problems with that location:

- It lives inside the `omarchy` skill, whose description says it **excludes source development**. An agent asked to write a fix correctly decides the skill doesn't apply and never loads the file — that is exactly what happened in my session, with the skill installed.
- #6718 deletes `contributing.md` outright.

`AGENTS.md` is loaded by anyone working in the checkout, survives #6718, and is the file #6718 routes contributors to. #6959's `bug.yml` checkbox remains the right control for the *issue* path; this covers the *PR* path.

## Change

A `# Pull Requests` section after `# Git`: search before writing, search twice with different wording, and when an open PR covers the change, add to it — confirm the bug, review the approach, contribute a missing test — instead of opening a competing one. Docs only, +13/−0, full lines per the file's own Style section.