### PR TITLE
fix(update): guard confirm_reboot in omarchy-update-restart under unattended runs

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -5,6 +5,11 @@
 echo
 
 confirm_reboot() {
+  if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == 1 ]]; then
+    echo "$1 Re-run 'omarchy update' in a terminal to confirm reboot."
+    return
+  fi
+
   gum confirm "$1" && { omarchy-system-reboot; exit 0; }
 }
 


### PR DESCRIPTION
### Problem
In #9079, running `omarchy update -y` in unattended mode can still hang on interactive input if the Linux kernel, Hyprland binary, or `reboot-required` state file is present.

While `omarchy-update` exports `OMARCHY_UPDATE_UNATTENDED=1` on `-y`, `confirm_reboot()` in `bin/omarchy-update-restart` was calling `gum confirm "$1"` unconditionally without an unattended check.

### Solution
Check `${OMARCHY_UPDATE_UNATTENDED:-}` in `confirm_reboot()`. When unattended, log the reboot notification and return without blocking, allowing the remaining update and shell reload steps to complete cleanly.

Fixes #9079