### PR TITLE
fix(toggle): invert on/off semantics in omarchy-toggle-bar

### DIFF
--- a/bin/omarchy-toggle-bar
+++ b/bin/omarchy-toggle-bar
@@ -4,7 +4,20 @@
 # omarchy:args=[toggle|on|off]
 # omarchy:examples=omarchy toggle bar | omarchy toggle bar off | omarchy toggle bar on
 
-omarchy-toggle bar-off "${1:-toggle}"
+case "${1:-toggle}" in
+  on)
+    omarchy-toggle bar-off off
+    ;;
+  off)
+    omarchy-toggle bar-off on
+    ;;
+  toggle|"")
+    omarchy-toggle bar-off toggle
+    ;;
+  *)
+    omarchy-toggle bar-off "$1"
+    ;;
+esac
 
 # The shell's watch on the toggles directory can miss flag changes that land in
 # quick succession, stranding the bar off screen until the shell restarts.


### PR DESCRIPTION
### Problem
In #9007, `omarchy toggle bar on` hides the top bar, and `omarchy toggle bar off` shows it. This is inverted compared to all other `omarchy toggle <feature> [on|off]` commands.

### Cause
`omarchy-toggle-bar` delegates to `omarchy-toggle bar-off "${1:-toggle}"`. Because the underlying flag is named `bar-off`, enabling the flag (`on`) creates `~/.local/state/omarchy/toggles/bar-off` which shifts the bar off-screen.

### Solution
In `bin/omarchy-toggle-bar`, translate `on` to `off` and `off` to `on` when forwarding to the `bar-off` toggle:
- `omarchy toggle bar on` -> removes `bar-off` flag (shows the bar)
- `omarchy toggle bar off` -> creates `bar-off` flag (hides the bar)
- `omarchy toggle bar [toggle]` -> toggles the `bar-off` flag

Fixes #9007