### PR TITLE
fix(theme): establish OMARCHY_PATH in entry points for non-interactive shells

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 set -o pipefail
+if [[ -z ${OMARCHY_PATH:-} ]]; then
+  if [[ -f /etc/omarchy.conf ]]; then
+    . /etc/omarchy.conf
+  fi
+  : "${OMARCHY_PATH:=/usr/share/omarchy}"
+  export OMARCHY_PATH
+fi
+
 
 OMARCHY_BIN_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 METADATA_SCAN_LIMIT=80

--- a/bin/omarchy-theme-list
+++ b/bin/omarchy-theme-list
@@ -3,7 +3,20 @@
 # omarchy:summary=List available themes
 # omarchy:examples=omarchy theme list | omarchy theme set "Tokyo Night"
 
+if [[ -z ${OMARCHY_PATH:-} ]]; then
+  if [[ -f /etc/omarchy.conf ]]; then
+    . /etc/omarchy.conf
+  fi
+  : "${OMARCHY_PATH:=/usr/share/omarchy}"
+  export OMARCHY_PATH
+fi
+
+if [[ ! -d "$OMARCHY_PATH/themes" && ! -d "$HOME/.config/omarchy/themes" ]]; then
+  echo "Error: themes directory not found at $OMARCHY_PATH/themes" >&2
+  exit 1
+fi
+
 {
-  find ~/.config/omarchy/themes/ -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -printf '%f\n'
-  find "$OMARCHY_PATH/themes/" -mindepth 1 -maxdepth 1 -type d -printf '%f\n'
+  [[ -d "$HOME/.config/omarchy/themes" ]] && find ~/.config/omarchy/themes/ -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -printf '%f\n'
+  [[ -d "$OMARCHY_PATH/themes" ]] && find "$OMARCHY_PATH/themes/" -mindepth 1 -maxdepth 1 -type d -printf '%f\n'
 } | sort -u | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g'

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -4,6 +4,14 @@
 # omarchy:args=<theme-name>
 # omarchy:examples=omarchy theme list | omarchy theme set "Tokyo Night"
 
+if [[ -z ${OMARCHY_PATH:-} ]]; then
+  if [[ -f /etc/omarchy.conf ]]; then
+    . /etc/omarchy.conf
+  fi
+  : "${OMARCHY_PATH:=/usr/share/omarchy}"
+  export OMARCHY_PATH
+fi
+
 if [[ -z $1 ]]; then
   echo "Usage: omarchy-theme-set <theme-name>"
   exit 1


### PR DESCRIPTION
### Problem
In #9065, `omarchy theme list` and `omarchy theme set` fail in non-interactive environments (scripts, cron, SSH, CI, AI agents) because `$OMARCHY_PATH` is only exported by `~/.bashrc` in interactive login sessions.

When `$OMARCHY_PATH` is unset:
- `omarchy theme list` queries `/themes/`, outputs a find error to stderr, and silently exits `0` with an empty list.
- `omarchy theme set <name>` queries `/themes/<name>` and falsely reports that the theme does not exist.

### Solution
1. In `bin/omarchy` (the root entry dispatcher), establish `OMARCHY_PATH` if unset before executing sub-commands.
2. In `bin/omarchy-theme-list` and `bin/omarchy-theme-set`, check and fallback `OMARCHY_PATH` from `/etc/omarchy.conf` or `/usr/share/omarchy`.
3. In `bin/omarchy-theme-list`, exit with code `1` if neither system nor user theme directories exist.

Fixes #9065