### PR TITLE
fix(service): enable Sunshine by canonical unit name and open admin UI port

### DIFF
--- a/bin/omarchy-install-service-sunshine
+++ b/bin/omarchy-install-service-sunshine
@@ -5,7 +5,7 @@
 
 set -e
 
-TCP_PORTS=(47984 47989 48010)
+TCP_PORTS=(47984 47989 47990 48010)
 UDP_PORTS=(5353 47998 47999 48000 48002 48010)
 PRIVATE_CIDRS=(10.0.0.0/8 172.16.0.0/12 192.168.0.0/16)
 UFW_COMMENT="omarchy-sunshine"
@@ -13,8 +13,6 @@ SUNSHINE_ADMIN_APP="Sunshine Admin"
 SUNSHINE_ADMIN_URL="https://localhost:47990"
 SUNSHINE_ADMIN_EXEC="omarchy-launch-webapp $SUNSHINE_ADMIN_URL --ignore-certificate-errors"
 SUNSHINE_ICON_SOURCE="/usr/share/sunshine/web/images/logo-sunshine-45.png"
-HYPR_AUTOSTART_FILE="$HOME/.config/hypr/autostart.lua"
-HYPR_AUTOSTART_ENTRY='o.launch_on_start("sunshine")'
 
 open_ufw_port_for_private_lans() {
   local proto="$1"
@@ -60,18 +58,10 @@ install_admin_webapp() {
   omarchy-webapp-install "$SUNSHINE_ADMIN_APP" "$SUNSHINE_ADMIN_URL" "$SUNSHINE_ICON_SOURCE" "$SUNSHINE_ADMIN_EXEC"
 }
 
-enable_hyprland_autostart() {
-  mkdir -p "$(dirname "$HYPR_AUTOSTART_FILE")"
-  touch "$HYPR_AUTOSTART_FILE"
-
-  if ! grep -Fxq "$HYPR_AUTOSTART_ENTRY" "$HYPR_AUTOSTART_FILE"; then
-    printf '\n%s\n' "$HYPR_AUTOSTART_ENTRY" >>"$HYPR_AUTOSTART_FILE"
-  fi
-}
-
 echo "Installing Sunshine..."
 omarchy-pkg-add sunshine
-systemctl --user enable --now sunshine
+systemctl --user daemon-reload
+systemctl --user enable --now app-dev.lizardbyte.app.Sunshine.service
 
 echo "Opening Sunshine firewall ports..."
 open_ufw_ports
@@ -79,9 +69,6 @@ open_ufw_ports
 echo "Installing Sunshine admin web app..."
 install_admin_webapp
 $SUNSHINE_ADMIN_EXEC >/dev/null 2>&1 &
-
-echo "Enabling Sunshine autostart..."
-enable_hyprland_autostart
 
 echo ""
 echo "Sunshine has been installed and its Moonlight streaming ports are open for private LANs and Tailscale."


### PR DESCRIPTION
### Problem
In #9099, running `omarchy install service sunshine` fails on fresh installs with:
`Failed to enable unit: Unit sunshine.service does not exist`

### Cause
1. The `sunshine` package installs `/usr/lib/systemd/user/app-dev.lizardbyte.app.Sunshine.service`. The `sunshine.service` alias declared in the unit's `[Install]` section is only created once enabled; enabling by alias before it is enabled fails.
2. Port 47990 (the Sunshine Web Admin interface) was omitted from `TCP_PORTS`, preventing pairing over LAN/Tailscale.
3. `enable_hyprland_autostart` was creating a redundant launch entry when the systemd unit is already `WantedBy=graphical-session.target`.

### Solution
- Call `systemctl --user daemon-reload` and enable `app-dev.lizardbyte.app.Sunshine.service`.
- Add `47990` to `TCP_PORTS`.
- Remove redundant `autostart.lua` entry.

Fixes #9099