### PR TITLE
fix(bindings): mirror RETURN bindings to KP_Enter

### DIFF
--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -1,6 +1,8 @@
 -- Essential application bindings.
 o.bind("SUPER + RETURN", "Terminal", { omarchy = "terminal" })
+o.bind("SUPER + KP_Enter", "Terminal", { omarchy = "terminal" })
 o.bind("SUPER + SHIFT + RETURN", "Browser", { omarchy = "browser" })
+o.bind("SUPER + SHIFT + KP_Enter", "Browser", { omarchy = "browser" })
 o.bind("SUPER + SHIFT + F", "File manager", { omarchy = "nautilus" })
 o.bind("SUPER + ALT + SHIFT + F", "File manager (cwd)", { omarchy = "nautilus-cwd" })
 o.bind("SUPER + SHIFT + B", "Browser", { omarchy = "browser" })
@@ -10,7 +12,9 @@ o.bind("SUPER + SHIFT + N", "Editor", { omarchy = "editor" })
 if o.preinstalled_bindings_enabled() then
   -- Bindings for preinstalled Omarchy applications, TUIs, and web apps.
   o.bind("SUPER + ALT + RETURN", "Tmux", { omarchy = "terminal-tmux" })
+  o.bind("SUPER + ALT + KP_Enter", "Tmux", { omarchy = "terminal-tmux" })
   o.bind("SUPER + CTRL + RETURN", "Herdr", { omarchy = "terminal-herdr" })
+  o.bind("SUPER + CTRL + KP_Enter", "Herdr", { omarchy = "terminal-herdr" })
   o.bind("SUPER + SHIFT + M", "Music", { omarchy = "spotify" })
   o.bind("SUPER + SHIFT + ALT + M", "Music TUI", { tui = "cliamp", focus = true })
   o.bind("SUPER + SHIFT + D", "Docker", { tui = "omarchy-launch-docker-tui" })

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -55,7 +55,9 @@ hl.on("layer.opened", function(layer)
     if selection_layers == 1 then
       selection_binds = {
         hl.bind("RETURN", hl.dsp.exec_cmd("omarchy-capture-region --take-window"), { description = "Capture highlighted window" }),
+        hl.bind("KP_Enter", hl.dsp.exec_cmd("omarchy-capture-region --take-window"), { description = "Capture highlighted window" }),
         hl.bind("CTRL + RETURN", hl.dsp.exec_cmd("omarchy-capture-region --take-fullscreen"), { description = "Capture entire screen" }),
+        hl.bind("CTRL + KP_Enter", hl.dsp.exec_cmd("omarchy-capture-region --take-fullscreen"), { description = "Capture entire screen" }),
         hl.bind("TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window next"), { description = "Select next window to capture" }),
         hl.bind("CTRL + TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window prev"), { description = "Select previous window to capture" }),
       }


### PR DESCRIPTION
### Problem
In #9030, certain laptops (and full-size keyboards with numpads) emit `KP_Enter` (evdev `KEY_KPENTER` 96, keysym `0xff8d`) for their Enter key rather than `Return`.

Because Omarchy's application and capture bindings in `default/hypr/bindings/` were only declared for `RETURN`, shortcuts like `SUPER + Enter` (Terminal), `SUPER + SHIFT + Enter` (Browser), `SUPER + ALT + Enter` (Tmux), and `SUPER + CTRL + Enter` (Herdr) never matched.

### Solution
Mirror the `RETURN` keybindings to `KP_Enter` in:
- `default/hypr/bindings/applications.lua` (Terminal, Browser, Tmux, Herdr)
- `default/hypr/bindings/utilities.lua` (Slurp region capture overlay)

Fixes #9030