### PR TITLE
fix(brightness): pass target monitor to DPMS dispatch in omarchy-brightness-display

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -60,14 +60,19 @@ fi
 step="$1"
 
 if [[ $step == "off" ]]; then
-  hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })' >/dev/null 2>&1
+  if [[ -n $monitor ]]; then
+    hyprctl dispatch "hl.dsp.dpms({ action = \"disable\", monitor = \"$monitor\" })" >/dev/null 2>&1
+  else
+    hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })' >/dev/null 2>&1
+  fi
   exit 0
 elif [[ $step == "on" ]]; then
-  # Skip the dispatch when every active display is already lit: a redundant
-  # DPMS enable right after system resume forces another modeset, which blanks
-  # the panel for a beat (visible flash at the unlock screen).
-  hyprctl monitors -j 2>/dev/null | jq -e '[.[] | select(.disabled == false)] | length > 0 and all(.dpmsStatus)' >/dev/null 2>&1 && exit 0
-  hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })' >/dev/null 2>&1
+  if [[ -n $monitor ]]; then
+    hyprctl dispatch "hl.dsp.dpms({ action = \"enable\", monitor = \"$monitor\" })" >/dev/null 2>&1
+  else
+    hyprctl monitors -j 2>/dev/null | jq -e '[.[] | select(.disabled == false)] | length > 0 and all(.dpmsStatus)' >/dev/null 2>&1 && exit 0
+    hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })' >/dev/null 2>&1
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
### Problem
In #9077, running `omarchy brightness display --monitor <output> off` blanks all connected monitors instead of only the specified display.

### Cause
`bin/omarchy-brightness-display` parses and resolves `$monitor`, but the `off` and `on` branches dispatched global `hl.dsp.dpms({ action = "disable" })` calls without passing the `monitor` parameter.

### Solution
Pass `monitor = "$monitor"` into `hl.dsp.dpms` so that DPMS disable/enable calls target the requested monitor output, consistent with `omarchy-hyprland-monitor-clamshell`.

Fixes #9077