### PR TITLE
fix(sudo): avoid sudo -v password prompt under unattended runs and set verifypw=any

### DIFF
--- a/bin/omarchy-sudo-passwordless
+++ b/bin/omarchy-sudo-passwordless
@@ -46,7 +46,7 @@ else
   echo ""
 
   if gum confirm "Enable passwordless sudo for ${MINUTES} minutes? This is a significant security risk!"; then
-    echo "${USER} ALL=(ALL) NOPASSWD: ALL" | sudo tee "$NOPASSWD_FILE" > /dev/null
+    printf '%s ALL=(ALL) NOPASSWD: ALL\nDefaults:%s verifypw=any\n' "$USER" "$USER" | sudo tee "$NOPASSWD_FILE" > /dev/null
     sudo chmod 440 "$NOPASSWD_FILE"
     sudo systemd-run --on-active=${MINUTES}m --timer-property=AccuracySec=1s --unit="$TIMER_NAME" \
       rm "$NOPASSWD_FILE"

--- a/bin/omarchy-update-stay-awake
+++ b/bin/omarchy-update-stay-awake
@@ -91,8 +91,11 @@ start() {
 
   if omarchy-cmd-present systemd-inhibit; then
     if (( EUID != 0 )); then
-      if [[ -t 0 ]]; then
-        sudo -v
+      if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == 1 ]]; then
+        sudo -n -v 2>/dev/null || true
+        inhibit_runner=(sudo -n)
+      elif [[ -t 0 ]]; then
+        sudo -n -v 2>/dev/null || sudo -v
         inhibit_runner=(sudo)
       else
         inhibit_runner=(pkexec)


### PR DESCRIPTION
### Problem
In #9066, running `omarchy update` on a system with `omarchy sudo passwordless` still prompts for a sudo password in `omarchy-update-stay-awake` and hangs if no human is present.

### Cause
1. Sudo's default `verifypw=all` demands a password if any rule (such as Arch's default `%wheel` rule) requires one, ignoring the `NOPASSWD: ALL` drop-in when `sudo -v` is executed.
2. `omarchy-update` runs through `script`, allocating a PTY, so `[[ -t 0 ]]` evaluates true even in unattended runs.

### Solution
- Set `Defaults:<user> verifypw=any` in `bin/omarchy-sudo-passwordless` so `sudo -v` honors the passwordless grant.
- In `bin/omarchy-update-stay-awake`, use non-blocking `sudo -n -v` when `OMARCHY_UPDATE_UNATTENDED=1` is exported.

Fixes #9066