### PR TITLE
fix(monitor): detect stranded outputs with no active scanout in omarchy-hyprland-monitor-modeless

### DIFF
--- a/bin/omarchy-hyprland-monitor-modeless
+++ b/bin/omarchy-hyprland-monitor-modeless
@@ -1,19 +1,30 @@
 #!/bin/bash
 
-# omarchy:summary=Returns true when Hyprland has an enabled monitor with no mode
+# omarchy:summary=Returns true when Hyprland has an enabled monitor with no mode or no active scanout
 # omarchy:hidden=true
 
 # A monitor powered off at boot answers with a partial EDID carrying no video
-# modes, so Hyprland brings it up at 0x0 and the screen stays black. Mirrors are
-# absent from plain `monitors`, hence `all` plus an explicit disabled filter.
+# modes (0x0), or drops link during atomic commit landing without a CRTC
+# (disabled != true, present in `monitors all` but absent from active `monitors`).
 #
-# Exits 0 modeless, 1 not, 2 when the compositor cannot say. Nothing fires an
-# event for this state, so a caller that gave up on an unanswered query would
-# leave the screen black for good.
-monitors=$(hyprctl monitors all -j 2>/dev/null) || exit 2
+# Exits 0 modeless/stranded, 1 active/recovered, 2 when the compositor cannot say.
 
-state=$(jq 'if any(.[]; .disabled != true and (.width == 0 or .height == 0)) then 0 else 1 end' \
-  <<<"$monitors" 2>/dev/null)
+active_monitors=$(hyprctl monitors -j 2>/dev/null) || exit 2
+all_monitors=$(hyprctl monitors all -j 2>/dev/null) || exit 2
+
+state=$(jq -n \
+  --argjson active "$active_monitors" \
+  --argjson all "$all_monitors" \
+  '
+    ($active | map(.name)) as $active_names |
+    if any($all[];
+      .disabled != true and (
+        .width == 0 or
+        .height == 0 or
+        (.name as $n | ($active_names | index($n) | not) and (.mirrorOf == "" or .mirrorOf == null))
+      )
+    ) then 0 else 1 end
+  ' 2>/dev/null)
 
 case $state in
   0 | 1) exit "$state" ;;


### PR DESCRIPTION
### Problem
In #9078, `omarchy-hyprland-monitor-modeless` only checks if `.width == 0 or .height == 0`.

When an external output drops link during an atomic commit or loses its CRTC, it reports a valid mode in `hyprctl monitors all -j` but is absent from actively scanned-out displays in `hyprctl monitors -j`. Because the query returned `1` ("recovered"), the recovery loop in `omarchy-hyprland-monitor-watch` exited immediately, leaving the monitor dark indefinitely.

### Solution
Compare actively scanned-out outputs against `hyprctl monitors all` to detect enabled non-mirrored outputs that have dropped scanout alongside 0x0 modes.

Fixes #9078