### PR TITLE
Add Super + Shift + J to toggle a wide 2/3 - 1/3 window split

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -5,11 +5,25 @@ o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-clos
 o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
 
 -- Toggle the active dwindle split between an even 50/50 and a wide 2/3 - 1/3.
--- splitratio 1.0 is even; the active window gets ratio / 2 of its parent's space.
+-- splitratio 1.0 is even; splitratio always grows the split's first (left/top)
+-- child, so we check which side the focused window is on and flip the ratio
+-- when it is the second (right/bottom) one.
 local split_wide = false
 o.bind("SUPER + SHIFT + J", "Toggle wide window split", function()
-  split_wide = not split_wide
-  hl.dispatch(hl.dsp.layout("splitratio " .. (split_wide and "1.3333" or "1.0") .. " exact"))
+  local ratio = split_wide and 1.3333 or 1.0
+  local aw = hl.get_active_window()
+  if aw then
+    for _, w in ipairs(hl.get_windows()) do
+      if w.workspace and w.workspace.id == aw.workspace.id and w.address ~= aw.address and w.at.x < aw.at.x then
+        ratio = 2 - ratio
+        break
+      end
+    end
+  end
+  local ok = pcall(hl.dispatch, hl.dsp.layout("splitratio " .. tostring(ratio) .. " exact"))
+  if ok then
+    split_wide = not split_wide
+  end
 end)
 
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -3,6 +3,15 @@ o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
 o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+
+-- Toggle the active dwindle split between an even 50/50 and a wide 2/3 - 1/3.
+-- splitratio 1.0 is even; the active window gets ratio / 2 of its parent's space.
+local split_wide = false
+o.bind("SUPER + SHIFT + J", "Toggle wide window split", function()
+  split_wide = not split_wide
+  hl.dispatch(hl.dsp.layout("splitratio " .. (split_wide and "1.3333" or "1.0") .. " exact"))
+end)
+
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))


### PR DESCRIPTION
Dwindle splits two windows 50/50. That is the wrong ratio for the most common two-window setup: one window you are working in, one you are only glancing at (docs, a terminal tailing logs, a chat window). The reading window wants two thirds.

Super + Shift + J toggles the active split between an even 50/50 and 2/3 - 1/3, so it pairs naturally with Super + J ("Toggle window split") on the same key.

```lua
local split_wide = false
o.bind("SUPER + SHIFT + J", "Toggle wide window split", function()
  local ratio = split_wide and 1.3333 or 1.0
  local aw = hl.get_active_window()
  if aw then
    for _, w in ipairs(hl.get_windows()) do
      if w.workspace and w.workspace.id == aw.workspace.id and w.address ~= aw.address and w.at.x < aw.at.x then
        ratio = 2 - ratio -- focused window is on the right; grow it instead of the left one
        break
      end
    end
  end
  local ok = pcall(hl.dispatch, hl.dsp.layout("splitratio " .. tostring(ratio) .. " exact"))
  if ok then
    split_wide = not split_wide
  end
end)
```

`splitratio 1.0` is an even split. `splitratio` always grows the split's first (left/top) child — not whichever window is focused — so the binding now checks the focused window's position and flips the ratio when it is the second (right/bottom) one, before dispatching. Using `exact` rather than a relative step means the two states are stable no matter how the split was dragged beforehand.

Notes:

* Super + Shift + J was unbound in `default/`, so nothing is displaced.
* Same scope as the existing Super + J: it acts on the active dwindle node. Under any other layout (e.g. `scrolling`), `splitratio` has no handler and Hyprland raises a Lua runtime error — the `pcall` above catches that so the binding is a true no-op there instead of showing an error notification.
* Hyprland has no getter for a node splitratio, so the toggle state is a module local. After `hyprctl reload` the first press may need a second press to resync. That is the same trade-off already accepted elsewhere, and it seemed better than adding a state file for a transient visual toggle. Happy to switch it to a `bin/omarchy-hyprland-window-split-toggle` script with state under `~/.local/state/omarchy/` if you prefer the script convention.

Verified on Omarchy with two tiled windows on a 1920x1200 display at 1.25 scale: the active window moves between 764px and 1020px of the 1536px logical width and back, repeatably, regardless of which of the two windows is focused.

**Update:** the original version always grew the left/top window and threw a runtime error under non-dwindle layouts. Fixed both above.
