### PR TITLE
Match Obsidian's dotted window class in the focus binding

### DIFF
--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -15,7 +15,7 @@ if o.preinstalled_bindings_enabled() then
   o.bind("SUPER + SHIFT + ALT + M", "Music TUI", { tui = "cliamp", focus = true })
   o.bind("SUPER + SHIFT + D", "Docker", { tui = "omarchy-launch-docker-tui" })
   o.bind("SUPER + SHIFT + G", "Signal", { omarchy = "signal" })
-  o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "^obsidian$" })
+  o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "^(md\\.obsidian\\.)?obsidian$" })
   o.bind("SUPER + SHIFT + W", "Omawrite", { launch = "omawrite" })
   o.bind("SUPER + SHIFT + SLASH", "Passwords", { omarchy = "1password" })
 


### PR DESCRIPTION
## Problem

`SUPER + SHIFT + O` looks dead once Obsidian is running (#8902). The binding is `{ launch = "obsidian", focus = "^obsidian$" }`, which `omarchy-launch-or-focus` wraps as `\b^obsidian$\b` against each window's class and title. That matches a window whose class is exactly `obsidian`, but current Obsidian builds report the class `md.obsidian.Obsidian`, so the focus branch never matches, the script relaunches Obsidian every time, and Obsidian's single-instance lock swallows the new process without raising the existing window.

## Fix

Change the pattern to `^(md\.obsidian\.)?obsidian$` (Lua literal `"^(md\\.obsidian\\.)?obsidian$"`). It matches both the bare `obsidian` class and `md.obsidian.Obsidian`, case-insensitively, while keeping the anchors.

The anchors are deliberate: #1838 anchored this binding because a window titled "Obsidian is great!" stole the key, and ec593886 re-anchored it after the script went back to `\b` matching. Dropping them to a bare `obsidian` would fix #8902 but reintroduce that false match.

Fed through the exact jq expression from `bin/omarchy-launch-or-focus`:

| client | `^obsidian$` (old) | `^(md\.obsidian\.)?obsidian$` (new) |
|---|---|---|
| class `obsidian` | ✅ | ✅ |
| class `md.obsidian.Obsidian` | ❌ (the bug) | ✅ |
| firefox, title "Obsidian - Mozilla Firefox" | ❌ | ❌ |
| class `obsidianite` | ❌ | ❌ |
| class `org.obsidian.foo` | ❌ | ❌ |

## Verification

- jq matrix above against the expression in `bin/omarchy-launch-or-focus:13`.
- `applications.lua` is required from `$OMARCHY_PATH/default/hypr/bindings/` via `default.hypr.omarchy`, not copied into `~/.config`, so the change reaches existing installs on update; no migration needed.
- `test/shell.d/launch-1password-test.sh` and `test/shell.d/hyprland-default-config-test.sh` pass.
- Not exercised against a running Hyprland (developed on macOS). A quick `hyprctl clients -j | jq -r '.[].class' | grep -i obsidian` on an Omarchy box before/after would confirm the class value.

Fixes #8902

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrGftF1S6Xymu7Z58TRd3M
