### PR TITLE
Reset media marquee label when the scroll animation stops

### DIFF
--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -71,6 +71,11 @@ BarWidget {
           from: scrollClip.width
           to: -labelText.implicitWidth
           easing.type: Easing.Linear
+
+          // A stopped NumberAnimation leaves x wherever the marquee was, which
+          // parks a title that fits (or the frozen one under an open popup)
+          // outside the clip. Every stop path flips running, so reset here.
+          onRunningChanged: if (!running) labelText.x = 0
         }
       }
     }


### PR DESCRIPTION
## Problem

The media bar widget scrolls long titles with a `NumberAnimation on x` inside a clipped 180px item. When the marquee stops — a short title that fits replaces a long one, the player goes away and comes back, the popup opens, or the bar goes vertical — Qt leaves `x` at the last interpolated value instead of restoring it. The label ends up parked partly or fully outside the clip, so exactly the titles that *fit* show up as an empty gap next to the play glyph (#8991).

## Fix

Reset `labelText.x` to 0 from `scrollAnim`'s `onRunningChanged` whenever the animation stops. Every stop path flips `running`, Qt stops the underlying job before emitting the signal, and the animation reseeds `x` from `from` when it restarts, so scrolling behaviour is unchanged. Five-line diff, no restructuring.

## Verification

- `test/shell.d/media-test.sh` and `test/shell.d/qml-text-format-test.sh` pass; `bar-widget-contract-test.sh` skips without a compositor.
- Not visually verified in a running shell (developed on macOS without Qt/Quickshell) — please check long→short title, popup open/close, and a vertical bar after `omarchy-restart-shell`.

Fixes #8991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrGftF1S6Xymu7Z58TRd3M
