### PR TITLE
Resolve bar clicks only against the slot's own surface

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -760,9 +760,15 @@ Item {
   }
 
   function moduleClickTargetAt(slot, localX, localY) {
+    // clickTargets is shared by every bar surface. Only consider targets on
+    // the slot's own window so a click on one output's bar does not fire a
+    // widget at the same global point on an overlapping output's bar. A slot
+    // without a window yet keeps the unfiltered scan rather than nothing.
+    var window = slotWindow(slot)
     for (var i = clickTargets.length - 1; i >= 0; i--) {
       var target = clickTargets[i]
       if (!moduleTargetClickable(target)) continue
+      if (window && !targetBelongsToWindow(target, window)) continue
 
       var targetPoint = { x: localX, y: localY }
       try {

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -199,6 +199,14 @@ assert(
   'bar tabs between panels within one bar surface'
 )
 
+// clickTargets is shared by every bar surface, so a click on one output's bar
+// must only resolve to widgets on that bar: with overlapping outputs the
+// surface that registered last would otherwise win every contested click.
+assert(
+  /function moduleClickTargetAt\(slot, localX, localY\) \{[\s\S]*?var window = slotWindow\(slot\)[\s\S]*?if \(window && !targetBelongsToWindow\(target, window\)\) continue/.test(barSource),
+  'bar clicks resolve only to widgets on the slot\'s own bar surface'
+)
+
 // A positional hotkey means "the third panel in this section", so it counts the
 // panels the bar actually draws. Reusing the tab-order walk is what keeps the
 // count honest: a widget with no panel and a hidden one are already passed over


### PR DESCRIPTION
## Problem

`Bar.moduleClickTargetAt` scans `clickTargets` — an array shared by every bar surface (one per monitor) — and returns the first clickable target whose rect contains the mapped point, without checking which window the target belongs to. `mapToItem` maps across windows via scene coordinates without complaining, so with overlapping outputs (mirrored, or hand-positioned) a left click on one bar activates the widget at the same global point on the other bar; the surface that registered last wins every contested click. The same function drives `cursorShape`, so the hover cursor was wrong in the same way. Only left clicks were affected because `ModuleSlot`'s pointer only accepts `Qt.LeftButton`; tooltips and `KeyboardPanel.pressTargetAt` already filter by window.

## Fix

Resolve the slot's window once with `slotWindow(slot)` and skip any target that does not belong to it, mirroring the filter `KeyboardPanel.pressTargetAt` already applies. If the slot has no window yet, the scan stays unfiltered rather than rejecting every target — `targetBelongsToWindow` is always false against a null window, and an unconditional filter would turn the whole bar into a dead zone during that transient.

Adds a source assertion to `test/shell.d/bar-test.sh` in the file's existing idiom; it fails against the pre-fix source and passes now.

## Verification

- `test/shell.d/bar-test.sh` passes (89 ok, including the new assertion); `bar-icon-geometry-test.sh` and `bar-widget-contract-test.sh` skip without a compositor.
- Not verified in a running shell — developed on macOS without Quickshell. Needs a runtime check with two overlapping outputs: click a widget on each bar and confirm only that bar's widget fires, and that the hand cursor only appears over the hovered bar's own widgets.

Fixes #8658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrGftF1S6Xymu7Z58TRd3M
