### PR TITLE
Service install scripts fail silently

### DIFF
--- a/bin/omarchy-install-service-dropbox
+++ b/bin/omarchy-install-service-dropbox
@@ -2,6 +2,8 @@
 
 # omarchy:summary=Install and start the Dropbox service. Must then be authenticated via the web.
 
+set -e
+
 echo "Installing all dependencies..."
 omarchy-pkg-add dropbox dropbox-cli libappindicator-gtk3 python-gpgme nautilus-dropbox
 

--- a/bin/omarchy-install-service-nordvpn
+++ b/bin/omarchy-install-service-nordvpn
@@ -3,6 +3,8 @@
 # omarchy:summary=Install the NordVPN service with optional GUI.
 # omarchy:requires-sudo=true
 
+set -e
+
 echo "Installing NordVPN..."
 omarchy-pkg-add nordvpn-bin
 

--- a/bin/omarchy-install-service-once
+++ b/bin/omarchy-install-service-once
@@ -3,6 +3,8 @@
 # omarchy:summary=Install the ONCE service, enable its background service, and launch the TUI.
 # omarchy:requires-sudo=true
 
+set -e
+
 echo "Installing ONCE..."
 omarchy-pkg-add once-bin
 

--- a/bin/omarchy-install-service-tailscale
+++ b/bin/omarchy-install-service-tailscale
@@ -3,6 +3,8 @@
 # omarchy:summary=Install the Tailscale mesh VPN service and a web app for the Tailscale Admin Console.
 # omarchy:requires-sudo=true
 
+set -e
+
 echo -e "\nInstalling Tailscale..."
 omarchy-pkg-add tailscale
 


### PR DESCRIPTION
# Service install scripts fail silently

bin/omarchy-install-service-{**dropbox,nordvpn,once,tailscale**} don't declare errexit. omarchy-pkg-add failures get swallowed and the script proceeds to enable systemd units and wire up bar entries that lead to nothing.

Related: #9123.
