### PR TITLE
Dropbox install not flagged as needing sudo

### DIFF
--- a/bin/omarchy-install-service-dropbox
+++ b/bin/omarchy-install-service-dropbox
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Install and start the Dropbox service. Must then be authenticated via the web.
+# omarchy:requires-sudo=true
 
 echo "Installing all dependencies..."
 omarchy-pkg-add dropbox dropbox-cli libappindicator-gtk3 python-gpgme nautilus-dropbox


### PR DESCRIPTION
omarchy-install-service-dropbox is the only bin/omarchy-install-service-* without `# omarchy:requires-sudo=true`. omarchy-remove-service-dropbox has it.

The directive is what the install menu reads to flag entries that need sudo. Without it, the menu shows no warning before the user clicks.
