### PR TITLE
Copy terminal selections straight to the clipboard

### DIFF
--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -6,6 +6,11 @@ TERM = "xterm-256color"
 [terminal]
 osc52 = "CopyPaste"
 
+[selection]
+# Copy selected text straight to the clipboard, so Ctrl+Shift+C stays free
+# for programs that use it as cancel/close.
+save_to_clipboard = true
+
 [font]
 normal = { family = "JetBrainsMono Nerd Font", style = "Regular" }
 bold = { family = "JetBrainsMono Nerd Font", style = "Bold" }

--- a/config/foot/foot.ini
+++ b/config/foot/foot.ini
@@ -5,6 +5,9 @@ font=JetBrainsMono Nerd Font:size=9
 pad=14x14
 initial-window-mode=windowed
 workers=0
+# Copy selected text to the clipboard as well as the primary selection,
+# so the copy keybinding stays free for programs that use it as cancel/close.
+selection-target=both
 
 [scrollback]
 lines=10000

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -22,6 +22,10 @@ cursor-style-blink = false
 # (all shell integration options must be passed together)
 shell-integration-features = no-cursor,ssh-env
 
+# Copy selected text straight to the clipboard, so the copy keybinding stays
+# free for programs that use it as cancel/close.
+copy-on-select = clipboard
+
 # Keyboard bindings
 keybind = shift+insert=paste_from_clipboard
 keybind = control+insert=copy_to_clipboard

--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -10,6 +10,10 @@ window_padding_width 14
 hide_window_decorations yes
 confirm_os_window_close 0
 
+# Copy selected text straight to the clipboard, so the copy keybinding stays
+# free for programs that use it as cancel/close.
+copy_on_select clipboard
+
 # Keybindings
 map ctrl+insert copy_to_clipboard
 map shift+insert paste_from_clipboard


### PR DESCRIPTION
Really enjoying the latest evolution of Omarchy. While exploring the defaults, I found one tweak that I believe could be a refinement.

The explicit copy keybinding in the terminals overlaps with cancel/close chords in certain programs (e.g. Ctrl+Shift+C, Ctrl+C, Super+C is intercepted by some TUIs before the terminal sees it), which makes copying unreliable depending on what's running. This enables copy-on-select in all four supported terminals, so highlighting text copies it to the system clipboard without needing any keybinding at all:

- **Alacritty:** `selection.save_to_clipboard = true`
- **foot:** `selection-target=both` (clipboard and primary, so middle-click paste keeps working)
- **kitty:** `copy_on_select clipboard`
- **Ghostty:** `copy-on-select = clipboard`

It works very cleanly, and doesn't misfire in vim/Neovim either — visual-mode selections are drawn by the editor, not the terminal, so moving the visual selector doesn't generate a new terminal selection or touch the clipboard.

The existing copy/paste keybindings are untouched and keep working. Config-only change to the defaults, matching the approach of the Shift+Return encoding fix — no migration, so existing users' configs are not modified.