### PR TITLE
Add a notification for hyprpicker

### DIFF
--- a/bin/omarchy-capture-color
+++ b/bin/omarchy-capture-color
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+pkill hyprpicker || hyprpicker -a
+
+COLOR_HEX=$(wl-paste)
+
+omarchy-notification-send "Color copied" "$COLOR_HEX copied to clipboard"

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -38,7 +38,7 @@ o.bind("PRINT", "Screenshot", "omarchy-capture-screenshot")
 o.bind("ALT + PRINT", "Screenrecording", "omarchy-capture-screenrecording --stop-recording || omarchy-menu toggle trigger.capture.screenrecord")
 o.bind("SUPER + ALT + code:34", "Make webcam overlay smaller", "omarchy-capture-webcam-resize smaller")
 o.bind("SUPER + ALT + code:35", "Make webcam overlay larger", "omarchy-capture-webcam-resize larger")
-o.bind("SUPER + PRINT", "Color picker", "pkill hyprpicker || hyprpicker -a")
+o.bind("SUPER + PRINT", "Color picker", "omarchy-capture-color")
 o.bind("SUPER + CTRL + PRINT", "Extract text (OCR) from screenshot", "omarchy-capture-text")
 
 -- Keyboard control for the slurp region picker (see omarchy-capture-region).

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -61,7 +61,7 @@
   "trigger.capture.screenrecord": {"icon":"","label":"Screenrecord"},
   "trigger.capture.text": {"icon":"󰴑","label":"Text","action":"omarchy-capture-text"},
   "trigger.capture.qr": {"icon":"󰐲","label":"QR Code","action":"omarchy-capture-qr"},
-  "trigger.capture.color": {"icon":"󰃉","label":"Color","action":"pkill hyprpicker || hyprpicker -a"},
+  "trigger.capture.color": {"icon":"󰃉","label":"Color","action":"omarchy-capture-color"},
   "trigger.capture.screenrecord.no-audio": {"icon":"","label":"With no audio","action":"omarchy-capture-screenrecording"},
   "trigger.capture.screenrecord.desktop-audio": {"icon":"","label":"With desktop audio","action":"omarchy-capture-screenrecording --with-desktop-audio"},
   "trigger.capture.screenrecord.microphone": {"icon":"","label":"With desktop + microphone audio","action":"omarchy-capture-screenrecording --with-desktop-audio --with-microphone-audio"},


### PR DESCRIPTION
Replace the color picking action with a small script that adds a notification after you pick the color telling you what it is and that it has been copied to your clipboard. I opened a similar PR, but that was closed because it wasn't compatible with quattro. This one is.