### PR TITLE
Constrain Omawrite's save dialog

### DIFF
--- a/default/hypr/apps/omawrite.lua
+++ b/default/hypr/apps/omawrite.lua
@@ -1,0 +1,4 @@
+o.window(
+  { class = "^omawrite$", title = "^Save File$" },
+  { float = true, center = true, size = { 875, 600 } }
+)

--- a/test/shell.d/omawrite-window-rule-test.sh
+++ b/test/shell.d/omawrite-window-rule-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+
+rule=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local emitted
+hl = { window_rule = function(value) emitted = value end }
+
+require("default.hypr.helpers")
+require("default.hypr.apps.omawrite")
+
+print(table.concat({
+  emitted.match.class,
+  emitted.match.title,
+  tostring(emitted.float),
+  tostring(emitted.center),
+  emitted.size[1] .. "x" .. emitted.size[2],
+}, "\t"))
+LUA
+)
+
+IFS=$'\t' read -r class title float center size <<<"$rule"
+[[ $class == "^omawrite$" && $title == "^Save File$" ]] ||
+  fail "the window rule targets only Omawrite's save dialog" "$rule"
+[[ $float == "true" && $center == "true" ]] || fail "the save dialog floats and centers" "$rule"
+[[ $size == "875x600" ]] || fail "the save dialog fits a scaled laptop display" "$rule"
+pass "Omawrite's save dialog opens at a bounded floating size"


### PR DESCRIPTION
Keeps Omawrite's save dialog inside scaled laptop displays. Fixes #9046.

<<<< AI wording below >>>>

## Problem

Omawrite can create a 1231x950 save dialog on a 1280x832 logical display, clipping its title and action controls beyond the monitor work area.

## Fix

Match only Omawrite's `Save File` window and apply the reporter-validated floating, centered 875x600 geometry.

## Verification

- `bash -n test/shell.d/omawrite-window-rule-test.sh`
- `git diff --check`
- The semantic Lua test checks the emitted class, title, float, center, and size properties.
- The focused test cannot run here because `lua` is not installed.
- Live verification at 2x scale is pending, so this PR is a draft.
