### PR TITLE
Leave a locked session's display to the lock screen

### DIFF
--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -12,6 +12,12 @@ function eventParts(event, count) {
   return String(event && event.data ? event.data : "").split(",")
 }
 
+// The idle service wakes the display only for a cycle it put to sleep, and
+// never while the session is locked: the lock screen owns the display then.
+function wakeAfterIdle(idledThisCycle, sessionLocked) {
+  return !!idledThisCycle && !sessionLocked
+}
+
 function screensaverWindowsAfter(windows, address, visible) {
   var key = String(address || "")
   if (!key) {
@@ -47,6 +53,7 @@ if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
+    wakeAfterIdle: wakeAfterIdle,
     screensaverWindowsAfter: screensaverWindowsAfter
   }
 }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -25,6 +25,12 @@ Item {
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
+  // The lock plugin is a service in this same process, so its state is readable
+  // directly: no subprocess round trip, and no reading as unlocked when an IPC
+  // call fails.
+  readonly property var lockService: shell && shell.firstPartyServiceFor ? shell.firstPartyServiceFor("omarchy.lock") : null
+  readonly property bool sessionLocked: !!(lockService && lockService.locked)
+
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
   property bool hasPendingStayAwakePersist: false
@@ -103,7 +109,14 @@ Item {
     lockTimer.stop()
     screensaverLaunchGraceTimer.stop()
 
-    if (root.idledThisCycle) runProcess(wakeProcess, "wake", "omarchy-system-wake")
+    // A locked session's display belongs to the lock screen: it lights the
+    // panel for input that reaches it and blanks it again afterwards. The idle
+    // monitor resuming is not evidence of input while locked - Hyprland also
+    // reports activity when an idle inhibitor appears, with nobody at the
+    // machine - and waking on that lights the display with nothing left to
+    // blank it again.
+    if (IdleModel.wakeAfterIdle(root.idledThisCycle, root.sessionLocked)) runProcess(wakeProcess, "wake", "omarchy-system-wake")
+    else if (root.idledThisCycle) logEvent("wake-skipped", "session-locked")
 
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
@@ -185,6 +198,7 @@ Item {
       stayAwakeStatePath: root.stayAwakeStatePath,
       idle: idleMonitor.isIdle,
       inIdleCycle: root.idledThisCycle,
+      sessionLocked: root.sessionLocked,
       screensaverStarted: root.screensaverStartedThisCycle,
       screensaver: root.screensaverTimeoutSeconds,
       lock: root.lockTimeoutSeconds,

--- a/test/shell.d/fixtures/idle-lock-wake/shell.qml
+++ b/test/shell.d/fixtures/idle-lock-wake/shell.qml
@@ -1,0 +1,136 @@
+import QtQuick
+import Quickshell
+
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  readonly property string rootPath: Quickshell.env("OMARCHY_PATH")
+  property var failures: []
+
+  function fail(message) {
+    failures.push(String(message))
+  }
+
+  function assertTrue(condition, message) {
+    if (!condition) fail(message)
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    var payload = JSON.stringify({
+      ok: failures.length === 0,
+      failures: failures
+    })
+
+    if (resultPath) {
+      Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+    }
+  }
+
+  // Stand-ins for the lock service and for the shell that hands services out,
+  // shaped like the real ones as far as the idle service reads them. Services
+  // register by reassigning _services, as shell.qml does, so the fixture can
+  // check that the idle service picks up a lock service that arrives after it.
+  // The timeouts keep the real IdleMonitor and lock timer from ever firing
+  // against the developer's session if this instance outlives the test.
+  QtObject {
+    id: fakeLock
+    property bool locked: true
+  }
+
+  QtObject {
+    id: fakeShell
+    property var shellConfig: ({ idle: { screensaver: 86400, lock: 86400 } })
+    property var _services: ({})
+    function serviceFor(pluginId) {
+      return _services[String(pluginId)] || null
+    }
+    function firstPartyServiceFor(pluginId) {
+      return serviceFor(pluginId)
+    }
+  }
+
+  Item { id: host }
+
+  Timer {
+    interval: 1
+    running: true
+    repeat: false
+    onTriggered: {
+      try {
+        var component = Qt.createComponent("file://" + root.rootPath + "/shell/plugins/services/idle/Service.qml", Component.PreferSynchronous)
+        if (component.status !== Component.Ready) {
+          root.fail("idle service failed to load: " + component.errorString())
+          return
+        }
+
+        var idle = component.createObject(host, { shell: fakeShell })
+        if (!idle) {
+          root.fail("idle service failed to instantiate: " + component.errorString())
+          return
+        }
+
+        root.assertTrue(idle.sessionLocked === false, "idle service reads unlocked before any lock service exists")
+
+        // The lock service registers after the idle service, the way shell.qml
+        // can load them in either order.
+        var services = ({})
+        services["omarchy.lock"] = fakeLock
+        fakeShell._services = services
+        root.assertTrue(idle.sessionLocked === true, "idle service picks up a lock service registered after it")
+
+        // Locked: the monitor's "active" ends the cycle, but the display is left
+        // to the lock screen.
+        idle.idledThisCycle = true
+        idle.handleActiveSignal()
+        var locked = JSON.parse(idle.statusJson())
+        root.assertTrue(locked.sessionLocked === true, "idle status reports the locked session")
+        root.assertTrue(locked.processes.wake === false, "no wake process is spawned while the session is locked")
+        root.assertTrue(locked.lastEvent === "wake-skipped: session-locked",
+          "the skipped wake is logged, got " + locked.lastEvent)
+        root.assertTrue(locked.inIdleCycle === false, "the idle cycle still ends while locked")
+
+        // Unlocked: the same signal wakes the display as before.
+        fakeLock.locked = false
+        root.assertTrue(idle.sessionLocked === false, "idle service follows the lock service back to unlocked")
+        idle.idledThisCycle = true
+        idle.handleActiveSignal()
+        var unlocked = JSON.parse(idle.statusJson())
+        root.assertTrue(unlocked.sessionLocked === false, "idle status reports the unlocked session")
+        root.assertTrue(unlocked.processes.wake === true, "the wake process is spawned once the session is unlocked")
+        root.assertTrue(unlocked.lastEvent === "process-start: wake omarchy-system-wake",
+          "the wake is logged as started, got " + unlocked.lastEvent)
+
+        // Let the spawned wake finish before tearing the service down, or the
+        // Process dies with it and the test's marker never lands.
+        root.idle = idle
+        finishTimer.start()
+      } catch (error) {
+        root.fail("idle lock wake fixture threw: " + error)
+        root.writeResult()
+      }
+    }
+  }
+
+  property var idle: null
+  property int finishPolls: 0
+
+  Timer {
+    id: finishTimer
+    interval: 50
+    repeat: true
+    onTriggered: {
+      root.finishPolls++
+      var status = JSON.parse(root.idle.statusJson())
+      if (status.processes.wake && root.finishPolls < 100) return
+      root.assertTrue(!status.processes.wake, "the wake process exits within five seconds")
+      finishTimer.stop()
+      root.idle.destroy()
+      root.writeResult()
+    }
+  }
+}

--- a/test/shell.d/idle-lock-wake-test.sh
+++ b/test/shell.d/idle-lock-wake-test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "idle lock wake test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping idle lock wake test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+wake_marker="$TMPDIR/wake-called"
+config_dir="$TMPDIR/idle-lock-wake"
+fake_bin="$TMPDIR/bin"
+mkdir -p "$config_dir" "$TMPDIR/home" "$fake_bin"
+cp "$SHELL_TEST_DIR/fixtures/idle-lock-wake/shell.qml" "$config_dir/shell.qml"
+
+# The fixture drives the real idle service, so an unlocked cancel spawns the
+# real wake command. Shadow it: the test wants to know it ran, not to wake
+# the developer's display.
+cat >"$fake_bin/omarchy-system-wake" <<SH
+#!/bin/bash
+touch "$wake_marker"
+SH
+chmod +x "$fake_bin/omarchy-system-wake"
+
+# The idle service spawns its commands through a login shell, and the profile
+# of a machine dev-linked to another checkout puts that checkout's bin first.
+# Refuse to run the real wake against the developer's display.
+resolved=$(HOME="$TMPDIR/home" PATH="$fake_bin:$ROOT/bin:$PATH" bash -lc 'command -v omarchy-system-wake' 2>/dev/null || true)
+if [[ $resolved != "$fake_bin/omarchy-system-wake" ]]; then
+  pass "login shell resolves omarchy-system-wake to ${resolved:-nothing}; skipping idle lock wake test"
+  exit 0
+fi
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+PATH="$fake_bin:$ROOT/bin:$PATH" \
+  timeout 15 quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "idle lock wake quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "idle lock wake test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Idle lock wake result:\n' >&2
+  jq . "$result" >&2
+  printf 'Idle lock wake log:\n' >&2
+  sed -n '1,220p' "$log" >&2
+  fail "idle service leaves a locked session's display to the lock screen"
+fi
+
+# The unlocked cancel is the only one allowed to reach the wake command, and
+# the fixture ran it last; the marker proves the spawn went all the way through.
+for _ in {1..30}; do
+  [[ -e $wake_marker ]] && break
+  sleep 0.1
+done
+[[ -e $wake_marker ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "the unlocked cancel runs omarchy-system-wake"
+}
+
+pass "idle service leaves a locked session's display to the lock screen"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
+const fs = require('fs')
 const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
 
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
@@ -32,6 +33,30 @@ assertDeepEqual(
   idle.screensaverWindowsAfter({ a: true }, '', false),
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
+)
+
+assertEqual(idle.wakeAfterIdle(true, false), true, 'idle wakes the display after a cycle it ran')
+assertEqual(idle.wakeAfterIdle(true, true), false, 'idle leaves a locked session\'s display to the lock screen')
+assertEqual(idle.wakeAfterIdle(false, false), false, 'idle does not wake a display it never put to sleep')
+assertEqual(idle.wakeAfterIdle(false, true), false, 'idle does not wake a locked display it never put to sleep')
+
+// Hyprland sends ext-idle "resumed" the moment an idle inhibitor appears, so a
+// browser starting media on a background workspace reads as activity at a
+// blanked lock screen. Waking there lights the display with nothing to blank
+// it again. The compositor fixture proves the behaviour; these keep the wiring
+// honest on machines where that fixture has to skip.
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/services/idle/Service.qml'), 'utf8')
+assert(
+  /wakeAfterIdle\(root\.idledThisCycle, root\.sessionLocked\)[^\n]*runProcess\(wakeProcess/.test(serviceQml),
+  'the idle service consults the lock before waking the display'
+)
+assert(
+  !/if \(root\.idledThisCycle\) runProcess\(wakeProcess/.test(serviceQml),
+  'no unconditional display wake remains in the idle service'
+)
+assert(
+  /sessionLocked:[^\n]*lockService[^\n]*\.locked/.test(serviceQml),
+  'the idle service reads the lock state from the in-process lock service'
 )
 JS
 


### PR DESCRIPTION
## What happens

Lock the session and let the lock screen blank the display. Later the panel comes back on at the lock screen with nobody at the machine, and stays on until someone touches the keyboard or mouse - on an OLED, that is the lock screen burning in for hours. `omarchy debug idle` shows a single `idle-monitor: active` → `idle-cycle-cancel: activity` → `process-start: wake omarchy-system-wake` with no input anywhere around it.

## Why

The idle service treats its `IdleMonitor` resuming as user activity and runs `omarchy-system-wake`, which turns DPMS back on. But the monitor is `respectInhibitors: true`, and Hyprland's ext-idle-notify implementation sends `resumed` to an idled notification the moment an idle inhibitor appears (`src/protocols/IdleNotify.cpp`: `update()` while inhibited calls `reset()`, which sends `resumed`). So any client taking an idle inhibitor - a browser starting media on a background workspace, a wake lock, an XWayland app suspending the screensaver - counts as activity with nobody there.

Unlocked that is harmless. Locked it is the whole bug: the lock screen only re-arms its blank timer for pointer, click or key events delivered to its own surface, and none happened, so the display stays lit indefinitely.

Reproduced on Hyprland 0.56.2 / Omarchy 4.0.1 with nobody at the desk: lock, wait for `idle-monitor: idle`, then start a silent `mpv` clip into the locked session from SSH. Hyprland logs `New idle inhibitor registered`, the idle service logs `active` and runs the wake in the same second, the panel lights, and it is still lit after mpv exits. An evdev witness on every input device saw nothing throughout. The same run *before* the monitor idles does nothing, as the Hyprland code predicts.

## Fix

While the session is locked, the display belongs to the lock screen, so `cancelIdleCycle()` no longer runs `omarchy-system-wake`; it logs `wake-skipped: session-locked` instead and still ends the cycle. The decision lives in `IdleModel.wakeAfterIdle()` so it is unit-testable, and `sessionLocked` is added to `omarchy-shell idle status` since `omarchy debug idle` prints that and not the lock's status.

The lock state comes from the lock service in-process, `shell.firstPartyServiceFor("omarchy.lock")`, the same call the Stay Awake, DND, night-light and media widgets use for their services. The `omarchy-shell lock isLocked` shell-out on the screensaver line answers from the same `locked` property, but only after a subprocess round trip, and it reads as unlocked whenever the IPC call fails; a synchronous decision needs the direct read. The idle service never blanks a display itself - the only DPMS-off in the tree is the lock's own blank timer - so skipping its wake cannot strand a display that nothing else can restore: Hyprland's `key_press_enables_dpms` / `mouse_move_enables_dpms` light the panel on keys, motion and gestures, the lock surface's own click and key handlers run the lock's wake, and `finishUnlock` runs it unconditionally (fingerprint unlock at a blanked panel included). Clamshell reconciliation, which `omarchy-system-wake` also does, has the lid switch bind, `omarchy-hyprland-monitor-watch` and the sleep lock as independent owners.

Why this layer: making the lock screen re-blank on a resume it did not ask for would still flash the panel; refusing inside `omarchy-system-wake` while locked would break the lock's own wake, which runs the same command; the Hyprland behaviour is protocol-legal and not ours to change; and `respectInhibitors: false` would bring the screensaver back over video playback.

One deliberate consequence: Hyprland does not enable DPMS for scroll (`axis`) or bare button events, only for keys, motion and gesture starts, so a scroll-wheel nudge at a blanked lock screen used to light the panel *only* through this accidental idle wake (and then never blanked again). After this change it does nothing; a click or any pointer motion still wakes. If a scroll wake is wanted, it belongs in `LockView` as a wheel handler that emits `wakeRequested`, which I am happy to follow up with.

#7131 adds a byte-identical `lockService` line with its own comment and a `lockInFlight` property; #7132 reads the same service through `firstPartyServiceFor` inside a function. Whichever lands second conflicts in the property block and in `statusJson`, and the two names should collapse into one.

## Tests

- `test/shell.d/idle-test.sh`: unit cases for `wakeAfterIdle`, plus source assertions that keep the wiring honest on machines where the compositor fixture has to skip.
- `test/shell.d/idle-lock-wake-test.sh` (new, compositor-backed like the lock fixtures): loads the real `Service.qml` into a throwaway quickshell with a stand-in shell whose services register by reassignment, as `shell.qml` does. The lock service is registered *after* the idle service and the fixture checks `sessionLocked` follows, so a future `serviceFor` that caches would fail here rather than silently disable the fix. Then it drives `handleActiveSignal()` twice: locked, no wake process is spawned and the skip is logged; unlocked, the wake process spawns and a PATH-shadowed `omarchy-system-wake` actually runs (marker file). The fake config uses day-long timeouts and the service is destroyed once the wake exits, so an orphaned fixture can never lock the developer's session; the test skips if the login shell would not resolve the shadow (a machine dev-linked to another checkout); the launch is under `timeout 15`. Against the unpatched service the fixture fails on all eight assertions.
- `./test/shell`: the same six pre-existing environmental failures with and without this change (packaging checkout, Claude usage collector, network guard, bar icon geometry); everything else passes.
