### PR TITLE
Clock: optional locale setting for day and month names

### DIFF
--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -62,10 +62,12 @@ BarWidget {
   // stock names.
   readonly property string localeName: Model.localeName(setting("locale", ""))
   readonly property var timeLocale: localeName ? Qt.locale(localeName) : null
+  readonly property var abbreviatedNames: Model.abbreviatedNames(timeLocale)
 
   function formatted(date) {
     var format = activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate()))
-    return timeLocale ? date.toLocaleString(timeLocale, format) : Qt.formatDateTime(date, format)
+    if (!timeLocale) return Qt.formatDateTime(date, format)
+    return Model.stripAbbreviationPeriods(date.toLocaleString(timeLocale, format), abbreviatedNames)
   }
 
   // ---- Calendar popup. Shape contract for shell.summon/hide/toggle

--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -56,8 +56,16 @@ BarWidget {
       root.bar.shell.updateEntryInline(root.moduleName, entry)
   }
 
+  // Qt renders day and month names in English whenever it is handed an
+  // explicit format string. An optional "locale" setting ("nb_NO", "de_DE",
+  // ...) formats the label through that locale instead; unset keeps the
+  // stock names.
+  readonly property string localeName: Model.localeName(setting("locale", ""))
+  readonly property var timeLocale: localeName ? Qt.locale(localeName) : null
+
   function formatted(date) {
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
+    var format = activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate()))
+    return timeLocale ? date.toLocaleString(timeLocale, format) : Qt.formatDateTime(date, format)
   }
 
   // ---- Calendar popup. Shape contract for shell.summon/hide/toggle

--- a/shell/plugins/panels/clock/Model.js
+++ b/shell/plugins/panels/clock/Model.js
@@ -9,6 +9,28 @@ var MS_PER_DAY = 86400000
 // Locale.Saturday, so a locale's firstDayOfWeek can be passed straight in.
 var WEEKDAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]
 
+// The locale to format day and month names in, from the "locale" setting.
+// "nb_NO", "nb-NO.UTF-8" and "nb_NO.utf8" all mean nb_NO; blank, C and POSIX
+// mean "not set", which keeps the stock English names.
+//
+// This lives here rather than in the QML because it is pure string math, and
+// because both the bar label and the calendar need the same answer.
+function localeName(value) {
+  var name = String(value || "").trim().split(".")[0].replace(/-/g, "_")
+  return (name === "C" || name === "POSIX") ? "" : name
+}
+
+// How the calendar's hero date is written follows the locale's own order,
+// read off its short date format: month-first locales (en_US, "M/d/yy") keep
+// "MMMM d"; day-first ones get "d MMMM", with the ordinal period where the
+// short form uses periods ("dd.MM.yyyy" gives "25. august").
+function heroDateFormat(shortDateFormat) {
+  var f = String(shortDateFormat || "")
+  var d = f.search(/d/), m = f.search(/M/)
+  if (d < 0 || m < 0 || m < d) return "MMMM d"
+  return /d\./.test(f) ? "d. MMMM" : "d MMMM"
+}
+
 // ---- Bar label formats. Right-clicking the clock walks these in order and
 //      writes the result back to shell.json, so the label the bar shows and
 //      the format the config stores are always the same thing.
@@ -282,6 +304,8 @@ if (typeof module !== "undefined") {
   module.exports = {
     dateKey: dateKey,
     keyForDate: keyForDate,
+    localeName: localeName,
+    heroDateFormat: heroDateFormat,
     normalizedWeekStart: normalizedWeekStart,
     weekStartSettingName: weekStartSettingName,
     toggledWeekStart: toggledWeekStart,

--- a/shell/plugins/panels/clock/Model.js
+++ b/shell/plugins/panels/clock/Model.js
@@ -24,6 +24,26 @@ function localeName(value) {
 // read off its short date format: month-first locales (en_US, "M/d/yy") keep
 // "MMMM d"; day-first ones get "d MMMM", with the ordinal period where the
 // short form uses periods ("dd.MM.yyyy" gives "25. august").
+// Several locales abbreviate day and month names with a trailing period
+// ("tir.", "aug."), which next to an ordinal ("30.") stacks up as clutter in
+// a bar label. Given the locale's short names, this takes the period off
+// those and nothing else, so the ordinal in the format string survives.
+function abbreviatedNames(locale) {
+  var out = []
+  if (!locale) return out
+  for (var d = 1; d <= 7; d++) out.push(String(locale.dayName(d, Locale.ShortFormat)))
+  for (var m = 1; m <= 12; m++) out.push(String(locale.monthName(m, Locale.ShortFormat)))
+  return out.filter(function (n) { return /\.$/.test(n) })
+}
+function stripAbbreviationPeriods(text, names) {
+  var out = String(text)
+  for (var i = 0; i < names.length; i++) {
+    var bare = names[i].slice(0, -1)
+    if (bare) out = out.split(names[i]).join(bare)
+  }
+  return out
+}
+
 function heroDateFormat(shortDateFormat) {
   var f = String(shortDateFormat || "")
   var d = f.search(/d/), m = f.search(/M/)
@@ -305,6 +325,7 @@ if (typeof module !== "undefined") {
     dateKey: dateKey,
     keyForDate: keyForDate,
     localeName: localeName,
+    stripAbbreviationPeriods: stripAbbreviationPeriods,
     heroDateFormat: heroDateFormat,
     normalizedWeekStart: normalizedWeekStart,
     weekStartSettingName: weekStartSettingName,

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -64,10 +64,15 @@ Panel {
   // convention. Clicking the grid's "W" heading writes the choice back to
   // shell.json.
   readonly property int weekStart: Model.normalizedWeekStart(setting("weekStartDay", null), Qt.locale().firstDayOfWeek)
-  // The interface is English throughout, so day names are not taken from the
-  // system locale. Where the week starts still is: that is a regional
-  // convention rather than a translation, and it stays overridable above.
-  readonly property var labelLocale: Qt.locale("en_US")
+  // Day and month names follow the same "locale" setting the bar label uses,
+  // so the calendar and the clock above it never disagree about what today
+  // is called; unset means the interface's English. Where the week starts is
+  // read separately, above: that is a regional convention rather than a
+  // translation, and it stays overridable.
+  readonly property var labelLocale: {
+    var name = Model.localeName(setting("locale", ""))
+    return name ? Qt.locale(name) : Qt.locale("en_US")
+  }
   readonly property string nextWeekStartLabel: labelLocale.dayName(Model.toggledWeekStart(weekStart), Locale.LongFormat)
   readonly property var weekdays: Model.weekdayOrder(weekStart)
   readonly property var weeks: Model.monthGrid(viewYear, viewMonth, weekStart, todayKey)
@@ -217,9 +222,11 @@ Panel {
     setWeekStart(Model.toggledWeekStart(root.weekStart))
   }
 
-  // English short day names, matching the rest of the interface.
+  // Short day names in the configured language. Several locales abbreviate
+  // with a trailing period ("man.", "tir.") which reads as clutter once these
+  // are column headings set in small caps, so the period comes off.
   function weekdayLabel(weekday) {
-    return String(labelLocale.dayName(weekday, Locale.ShortFormat)).toUpperCase()
+    return String(labelLocale.dayName(weekday, Locale.ShortFormat)).replace(/\.$/, "").toUpperCase()
   }
 
   SystemClock {
@@ -313,7 +320,9 @@ Panel {
                 id: heroDate
                 textFormat: Text.PlainText
                 anchors.verticalCenter: parent.verticalCenter
-                text: Qt.formatDate(root.today, "MMMM d")
+                // "August 25" in English; day-first locales get "25 August"
+                // or "25. august", following their own short date order.
+                text: root.today.toLocaleDateString(root.labelLocale, Model.heroDateFormat(root.labelLocale.dateFormat(Locale.ShortFormat)))
                 color: heroMouse.containsMouse
                   ? Style.hoverStateColor(root.contentForeground, Color.accent)
                   : root.contentForeground
@@ -721,7 +730,7 @@ Panel {
                 // "MAY 2026" and a "SEPTEMBER 2026".
                 width: Style.space(130)
                 horizontalAlignment: Text.AlignHCenter
-                text: Qt.formatDate(root.viewDate, "MMMM yyyy").toUpperCase()
+                text: root.viewDate.toLocaleDateString(root.labelLocale, "MMMM yyyy").toUpperCase()
                 color: Qt.darker(root.contentForeground, 1.4)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body

--- a/shell/plugins/panels/clock/manifest.json
+++ b/shell/plugins/panels/clock/manifest.json
@@ -15,6 +15,18 @@
     "displayName": "Clock",
     "description": "Date/time label with a calendar popup",
     "category": "Time",
-    "allowMultiple": false
+    "allowMultiple": false,
+    "defaults": {
+      "locale": ""
+    },
+    "schema": [
+      {
+        "key": "locale",
+        "type": "string",
+        "label": "Locale for day and month names",
+        "defaultValue": "",
+        "description": "Empty keeps English. A locale name such as nb_NO or de_DE formats the bar label and the calendar in that language."
+      }
+    ]
   }
 }


### PR DESCRIPTION
## What

Adds an opt-in `locale` setting to the clock bar widget. When set (`"locale": "nb_NO"`, `de_DE`, …) the bar label and the calendar popup format day and month names through that `QLocale`; when unset nothing changes — the bar still goes through `Qt.formatDateTime` and the calendar keeps `Qt.locale("en_US")`.

- `Model.js`: `localeName()` normalises the setting (`nb-NO.UTF-8` → `nb_NO`; blank/`C`/`POSIX` → unset), `heroDateFormat()` picks the hero date's order from the locale's own short date format.
- `BarWidget.qml`: `formatted()` uses `date.toLocaleString(locale, format)` only when a locale is set.
- `BarWidget.qml`/`Model.js`: short day and month names that the locale abbreviates with a period (`tir.`, `aug.`) lose it in the bar label, so `ddd d. MMM` reads `tir 30. aug` rather than `tir. 30. aug.`; the ordinal from the format string is untouched.
- `Panel.qml`: `labelLocale` follows the setting; the hero date becomes `25. august` / `25 August` / `August 25` by locale; short weekday headings drop a trailing period (`man.` → `MAN`).
- `manifest.json`: declares the setting in `defaults` and `schema` so it shows up in settings.

## Why

`Qt.formatDateTime` with a format string always renders English names, so a Norwegian (or German, or French) desktop gets `Tuesday 25. Aug` in the bar and an English calendar no matter what `LC_TIME` says. Reading the environment would change behaviour for everyone; a setting keeps the current English default and lets those who want their language ask for it.

## Test

- No `locale` in shell.json: bar and calendar identical to before (checked against 4.0.1 output for `dddd HH:mm`, `d MMMM 'W'ww yyyy`, hero `MMMM d`).
- `omarchy bar set omarchy.clock locale nb_NO`: bar `tirsdag 14:30` (`dddd HH:mm`) / `tir 25. aug 14:30` (`ddd d. MMM HH:mm`), calendar hero `25. august`, headings `MAN TIR ONS …`, month line `AUGUST 2026`.
- `locale: en_US` explicitly: identical to unset (`Tuesday 14:30`, hero `August 25`). `locale: de_DE`: `Dienstag 14:30` / `Di 25. Aug 14:30`, hero `25. August`, heading `MO`. `en_GB`: hero `25 August`.
- The locale table above was produced with a small `qml6` script over `Qt.locale(name)`; the unset column with `Qt.formatDateTime`/`Qt.formatDate` on the same date.
- `node -e` checks on `localeName`/`heroDateFormat` for `M/d/yy`, `dd.MM.yyyy`, `dd/MM/yyyy`, `yyyy-MM-dd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2vGBcjauThiQrttbet9ZB

