### PR TITLE
Discover and normalize web app icons

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -50,8 +50,43 @@ install_user_icon() {
 }
 
 download_icon() {
-  curl -fsSL --max-time 10 -o "$2" "$1" 2>/dev/null &&
-    [[ -s $2 && $(file -b --mime-type "$2") == image/* ]]
+  local source_url="$1" dest="$2"
+  local temp mime_type
+
+  temp=$(mktemp) || return 1
+
+  if ! curl -fsSL --max-time 10 -o "$temp" "$source_url" 2>/dev/null || [[ ! -s $temp ]]; then
+    rm -f "$temp"
+    return 1
+  fi
+
+  mime_type=$(file -b --mime-type "$temp")
+  case $mime_type in
+  image/png)
+    mv "$temp" "$dest"
+    ;;
+  image/*)
+    if ! magick "${temp}[0]" "$dest" 2>/dev/null; then
+      rm -f "$temp" "$dest"
+      return 1
+    fi
+    rm -f "$temp"
+    ;;
+  *)
+    rm -f "$temp"
+    return 1
+    ;;
+  esac
+}
+
+link_href_for_rel() {
+  local page="$1" rel="$2"
+
+  grep -oiE '<link[^>]*>' <<<"$page" |
+    grep -iE "rel[[:space:]]*=[[:space:]]*[\"']([^\"']*[[:space:]])?$rel([[:space:]][^\"']*)?[\"']" |
+    grep -oiE "href[[:space:]]*=[[:space:]]*[\"'][^\"']+" |
+    head -1 |
+    sed -E "s/^href[[:space:]]*=[[:space:]]*[\"']//I"
 }
 
 # Chromium --app= treats javascript:, file:, and data: as a document to
@@ -88,10 +123,11 @@ fetch_site_icon() {
   origin=$(sed -E 's|^(https?://[^/]+).*|\1|' <<<"$site_url")
 
   # Prefer the site's own high-res icon (apple-touch-icon is typically 180px+),
-  # then the well-known path, then Google's favicon service as a last resort.
+  # then its standard favicon declaration, the well-known paths, and finally
+  # Google's favicon service.
   page=$(curl -fsSL --max-time 5 "$site_url" 2>/dev/null | head -c 100000 | tr '\n' ' ')
-  icon_url=$(grep -oiE "<link[^>]*rel=[\"'][^\"']*apple-touch-icon[^\"']*[\"'][^>]*>" <<<"$page" |
-    grep -oiE "href=[\"'][^\"']+" | head -1 | sed -E "s/^href=[\"']//")
+  icon_url=$(link_href_for_rel "$page" "apple-touch-icon")
+  [[ -n $icon_url ]] || icon_url=$(link_href_for_rel "$page" "icon")
 
   case $icon_url in
   http://* | https://*) ;;
@@ -102,6 +138,7 @@ fetch_site_icon() {
 
   { [[ -n $icon_url ]] && download_icon "$icon_url" "$dest"; } ||
     download_icon "$origin/apple-touch-icon.png" "$dest" ||
+    download_icon "$origin/favicon.ico" "$dest" ||
     download_icon "https://www.google.com/s2/favicons?domain=${site_url}&sz=256" "$dest"
 }
 

--- a/test/shell.d/webapp-install-test.sh
+++ b/test/shell.d/webapp-install-test.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+require_command file
+require_command magick
+
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -122,3 +125,71 @@ grep -Fq 'must be http or https' "$tmpdir/err" ||
   fail "interactive webapp install refuses before fetching the URL" "$(cat "$tmpdir/curl-log")"
 [[ ! -e $(desktop_for Evil) ]] || fail "interactive webapp install writes no desktop file"
 pass "interactive webapp install refuses a bad URL before fetching it"
+
+# Sites commonly declare an SVG through rel="icon" without providing an
+# apple-touch-icon. The installer should discover it and store a real PNG for
+# the hicolor icon theme rather than SVG data under a misleading .png name.
+icon_stubs="$tmpdir/icon-stubs"
+mkdir -p "$icon_stubs"
+
+cat >"$tmpdir/icon-page.html" <<'HTML'
+<!doctype html>
+<html>
+  <head>
+    <link href="/favicon.svg" type="image/svg+xml" rel="icon">
+  </head>
+</html>
+HTML
+
+cat >"$tmpdir/favicon.svg" <<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#2296f3"/>
+</svg>
+SVG
+
+cat >"$icon_stubs/curl" <<'CURL'
+#!/bin/bash
+
+output=""
+url="${!#}"
+
+while (( $# > 0 )); do
+  case $1 in
+  -o)
+    output="$2"
+    shift 2
+    ;;
+  *) shift ;;
+  esac
+done
+
+if [[ -z $output ]]; then
+  cat "$ICON_PAGE_FIXTURE"
+elif [[ $url == "https://example.com/favicon.svg" ]]; then
+  cp "$ICON_SVG_FIXTURE" "$output"
+else
+  exit 1
+fi
+CURL
+
+cat >"$icon_stubs/gtk-update-icon-cache" <<'CACHE'
+#!/bin/bash
+exit 0
+CACHE
+
+chmod +x "$icon_stubs"/*
+
+if ICON_PAGE_FIXTURE="$tmpdir/icon-page.html" ICON_SVG_FIXTURE="$tmpdir/favicon.svg" \
+  PATH="$icon_stubs:$PATH" install_webapp "SVG Icon" "https://example.com/app" "" \
+  >"$tmpdir/out" 2>"$tmpdir/err"; then
+  :
+else
+  fail "webapp install discovers a standard SVG favicon" "$(cat "$tmpdir/err")"
+fi
+
+icon="$home/.local/share/icons/hicolor/256x256/apps/svg-icon.png"
+[[ $(file -b --mime-type "$icon") == "image/png" ]] ||
+  fail "webapp install stores the SVG favicon as a real PNG" "$(file "$icon")"
+grep -Fxq 'Icon=svg-icon' "$(desktop_for "SVG Icon")" ||
+  fail "webapp install references the converted favicon" "$(cat "$(desktop_for "SVG Icon")")"
+pass "webapp install discovers and converts a standard SVG favicon"


### PR DESCRIPTION
## Summary

Web app installation only checked `apple-touch-icon`, ignoring the standard `rel="icon"` tag.

This change:

- Detects standard favicon declarations.
- Converts SVG and WebP icons to real PNG files.
- Adds `/favicon.ico` as a fallback.
- Adds a regression test.

Threads reproduces the format issue: its WebP icon was previously saved with a `.png` extension.

## Testing

Web-app tests, style checks, and the CLI suite pass.

Related: #7588 and #7599