### PR TITLE
fix(network): calculate speedtest rate using actual elapsed interval

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -93,6 +93,7 @@ done
 
 rx_before=$(cat "/sys/class/net/$iface/statistics/rx_bytes")
 tx_before=$(cat "/sys/class/net/$iface/statistics/tx_bytes")
+t_before=$EPOCHREALTIME
 
 any_alive() {
   local pid
@@ -109,22 +110,26 @@ while any_alive; do
   sleep 1
   rx_after=$(cat "/sys/class/net/$iface/statistics/rx_bytes")
   tx_after=$(cat "/sys/class/net/$iface/statistics/tx_bytes")
+  t_after=$EPOCHREALTIME
 
   if [[ $direction == "down" ]]; then
-    rate=$(awk -v before="$rx_before" -v after="$rx_after" 'BEGIN {
-      if (after < before) print 0
-      else print (after - before) * 8 / 1000000
+    rate=$(awk -v before="$rx_before" -v after="$rx_after" -v t0="$t_before" -v t1="$t_after" 'BEGIN {
+      el = t1 - t0
+      if (after < before || el <= 0) print 0
+      else print (after - before) * 8 / 1000000 / el
     }')
   else
-    rate=$(awk -v before="$tx_before" -v after="$tx_after" 'BEGIN {
-      if (after < before) print 0
-      else print (after - before) * 8 / 1000000
+    rate=$(awk -v before="$tx_before" -v after="$tx_after" -v t0="$t_before" -v t1="$t_after" 'BEGIN {
+      el = t1 - t0
+      if (after < before || el <= 0) print 0
+      else print (after - before) * 8 / 1000000 / el
     }')
   fi
 
   format_mbps "$rate"
   rx_before=$rx_after
   tx_before=$tx_after
+  t_before=$t_after
 done
 
 wait 2>/dev/null || true


### PR DESCRIPTION
### Problem
In #9144, `omarchy-network-speedtest` divides byte deltas by a nominal 1.0 seconds. Because each loop iteration incurs subshell and command invocation overhead on top of `sleep 1`, the real elapsed interval is ~1.01s+, causing reported throughput to be inflated by ~1% and manufacturing artificial rate jitter.

### Solution
Capture the timestamp using Bash's builtin `$EPOCHREALTIME` at the start and end of each sample interval and divide by the actual elapsed duration `(t1 - t0)`.

Fixes #9144