### PR TITLE
Change the tagline to "Beautiful, Fun & Opinionated"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Omarchy
 
-Omarchy is a beautiful, modern & opinionated Linux distribution by DHH.
+Omarchy is a beautiful, fun & opinionated Linux distribution by DHH.
 
 Read more at [omarchy.org](https://omarchy.org).
 

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -449,7 +449,7 @@ greeter_screen() {
     rows=$(stty size 2>/dev/null </dev/tty | awk '{print $1}')
     [[ $rows =~ ^[0-9]+$ ]] || rows=${LINES:-24}
 
-    tagline="Beautiful, Modern & Opinionated Linux by DHH"
+    tagline="Beautiful, Fun & Opinionated Linux by DHH"
     hint="Press Return to Start Setup"
 
     printf '%s%s' "$HIDE_CURSOR" "$CLEAR"

--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -13,7 +13,7 @@ description: >
 
 # Omarchy Skill
 
-Manage [Omarchy](https://omarchy.org/) Linux systems - a beautiful, modern, opinionated Arch Linux distribution with Hyprland.
+Manage [Omarchy](https://omarchy.org/) Linux systems - a beautiful, fun, opinionated Arch Linux distribution with Hyprland.
 
 This skill is for end-user customization on installed systems.
 It is not for contributing to Omarchy source code.


### PR DESCRIPTION
Omarchy's tagline is now "Beautiful, Fun & Opinionated". Three files state it: the first-boot greeter in `bin/omarchy-provision-owner`, the opening line of `README.md`, and the description in `default/agents/skills/omarchy/SKILL.md`, which ships to installed machines as an agent skill. Those are every textual occurrence in the repository; nothing assembles or templates it from pieces, and the skill's `description:` frontmatter carries trigger metadata rather than the tagline.

The greeter centres the line from its own length (`tpad=$(( (cols - ${#tagline}) / 2 ))`), on the full splash and on the narrow-console fallback taken while the VT is still too small for the logo, so the three characters it loses move the tagline one column on each and nothing else — no row, no logo padding, and not the ttfx canvas width, which is measured from the console rather than from the text. Between 41 and 43 columns the new tagline now fits where the old one wrapped.

The install side of the same frame lives in the ISO, which carries its own copy of the string in `configs/airootfs/root/configurator`, and nothing generates one from the other: the vendoring between the repositories covers the setup form, not the greeter. omacom/omarchy-iso#136 is the other half, and the two want to land together — an ISO built against a runtime package that still said "Modern" would show "Fun" through the install and "Modern" at the deferred first boot that finishes it, and no screen check would catch it, because they all wait on "Opinionated" and both strings contain it.

## One thing left undone, deliberately

Four screenshots in the manual still show the old tagline: `manual/images/navigation-browser-terminal.webp`, `navigation-fourway-tiling.webp`, `navigation-stacked.webp`, and `navigation-popped-window.webp`, which carries it only in the browser tab title. All four are photographs of omarchy.org in Chromium, and the site is a different repository that still serves "Beautiful, Modern & Opinionated" — so a screenshot retaken today would show the old tagline again, and editing the text into the image would depict a page that does not exist. They are stale in other ways too: they advertise "Omarchy 3.8 has been released!" and an Omarchy 3 video, against a tree at 4.0.0.alpha. Refreshing them is worth doing once the site changes, and it is a bigger job than this one.

An OCR pass over all 237 tracked images found no others.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.
