### PR TITLE
fix(hypr): route Super+J through split-toggle helper to prevent crash on scrolling workspaces

### DIFF
--- a/bin/omarchy-hyprland-window-split-toggle
+++ b/bin/omarchy-hyprland-window-split-toggle
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle window split orientation on supported layouts
+# omarchy:hidden=true
+
+set -euo pipefail
+
+layout=$(hyprctl activeworkspace -j 2>/dev/null | jq -r '.tiledLayout // "dwindle"')
+
+if [[ $layout == "dwindle" ]]; then
+  hyprctl dispatch 'hl.dsp.layout("togglesplit")' >/dev/null 2>&1 || \
+    hyprctl dispatch layoutmsg togglesplit >/dev/null 2>&1 || true
+else
+  omarchy-notification-send -g 󱂬 "Split toggle is not supported on $layout layout" >/dev/null 2>&1 || true
+fi

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -2,7 +2,7 @@ o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+o.bind("SUPER + J", "Toggle window split", "omarchy-hyprland-window-split-toggle")
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))


### PR DESCRIPTION
### Problem
In #9146, pressing `Super + J` on a workspace using the `scrolling` layout produces a Lua runtime error (`no such layoutmsg for scrolling`) because `togglesplit` is only supported by the Dwindle layout engine.

### Solution
- Add `bin/omarchy-hyprland-window-split-toggle` to check the active workspace's `tiledLayout`.
- Dispatch `togglesplit` when in `dwindle` layout, and notify gracefully when on unsupported layouts.
- Point `Super + J` in `default/hypr/bindings/tiling.lua` to the new wrapper.

Fixes #9146