### PR TITLE
Disarm the screensaver's signal traps before its cleanup runs

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -7,14 +7,20 @@ screensaver_in_focus() {
 }
 
 exit_screensaver() {
+  # The pkill below hangs up this script's own pty, and bash re-enters a trap for
+  # the signal it is already handling, so disarm before killing anything.
+  trap : SIGINT SIGTERM SIGHUP SIGQUIT
+
   hyprctl eval 'hl.config({ cursor = { invisible = false } })' &>/dev/null || hyprctl keyword cursor:invisible false &>/dev/null || true
   pkill -x ttfx 2>/dev/null
   pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null
   exit 0
 }
 
-# Exit the screensaver on signals and input from keyboard and mouse
-trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
+# Exit the screensaver on signals and input from keyboard and mouse. The disarm
+# repeats here because bash re-enters at the call boundary, before the function's
+# own first line has run.
+trap 'trap : SIGINT SIGTERM SIGHUP SIGQUIT; exit_screensaver' SIGINT SIGTERM SIGHUP SIGQUIT
 
 printf '\033]11;rgb:00/00/00\007'  # Set background color to black
 


### PR DESCRIPTION
`exit_screensaver` closes the terminal that owns this script's own pty, and bash re-enters a trap for the signal it is already handling — SIGWINCH and SIGCHLD have their own machinery, HUP, INT, TERM and QUIT do not — so every hangup arriving while the handler is still running nests it one level deeper. Under a terminal that keeps hanging the pty up, that runs until bash exhausts its stack and dies with SIGSEGV, which is what the cores on #8386 show: the oldest frame is `zread` from this script's `read -n1 -t 1`, then `run_pending_traps` → `parse_and_execute` → `execute_command_internal` around 21,500 times over.

The disarm has to be the trap's own first command. At the top of the function it is one command too late, because bash can re-enter at the call boundary before the function body starts. Driving the unmodified script from a real pty on an Omarchy 4.0.1-1 worker (bash 5.3.15-1) under a sustained hangup, eight runs each: the shipped handler segfaulted 8 of 8, disarming as the function's first statement 2 of 8, disarming as the trap's first command 0 of 8 — and 0 of 23 over every run of that shape. The function keeps a disarm of its own so the direct call from the read loop cleans up once rather than twice.

`trap :` rather than `trap ''`, because an ignored disposition survives `exec`: `trap ''` would leave the `hyprctl` and `pkill` children spawned afterwards immune to SIGTERM as well.

What this does not do is explain why the reporter's terminal hangs the pty up thousands of times. Nothing in this repository produces that, and the fix does not depend on knowing: the handler is safe at any count.

This touches the same handler as #6813 and conflicts with it textually. That PR's guard — a `shutdown` flag and `trap ''` inside `request_shutdown` — has the same late-disarm window, and measured the same way it segfaulted 4 of 8 runs, so the disarm still needs to move ahead of the function call if #6813 lands instead.

Reviewed by Codex GPT-5.6 at xhigh reasoning, which found the pre-disarm re-entry window independently and is why the disarm moved into the trap string.

Fixes #8386
