### PR TITLE
fix(font): reset explicit kitty bold/italic font variants to auto on font set

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -32,6 +32,7 @@ fi
 
 if [[ -f ~/.config/kitty/kitty.conf ]]; then
   sed -i "s/^font_family .*/font_family $font_name/g" ~/.config/kitty/kitty.conf
+  sed -i -E "s/^(bold_font|italic_font|bold_italic_font) .*/\1 auto/g" ~/.config/kitty/kitty.conf
   pkill -USR1 kitty
 fi
 


### PR DESCRIPTION
Fixes #9167

### Problem
When `omarchy font set <font>` is executed, it updates `font_family` in `~/.config/kitty/kitty.conf`, but leaves any explicit `bold_font`, `italic_font`, or `bold_italic_font` configuration lines untouched. This causes bold/italic text in Kitty to continue rendering with the previous font family.

### Solution
Update `omarchy-font-set` to reset `bold_font`, `italic_font`, and `bold_italic_font` in `~/.config/kitty/kitty.conf` to `auto` so Kitty automatically derives the corresponding bold and italic weights from the newly selected `font_family`.