### PR TITLE
Let idle screensaver and lock timings be disabled

### DIFF
--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -78,6 +78,19 @@ The Omarchy shell owns idle behavior, and the timings are a top-level `idle` blo
 
 Both numbers are seconds counted from the moment you went idle — not from each other. So with the defaults, the screensaver comes up after two and a half minutes and the lock screen takes over at five minutes, whether or not the screensaver ran. Save the file and the shell picks up the new timings right away.
 
+Either timing can be turned off on its own by setting it to `false` (`null` and `"off"` work too). On a desktop that never needs to lock but still wants the screensaver so the panel doesn't burn in:
+
+```json
+{
+  "idle": {
+    "screensaver": 150,
+    "lock": false
+  }
+}
+```
+
+Leave a key out entirely and it goes back to its default. Setting one to `0` is not "off" — it fires the instant you go idle.
+
 If you dismiss the screensaver before the lock deadline, that counts as activity and the pending lock is cancelled. You don't get locked out for glancing at your machine.
 
 To stop locking on idle entirely, `Super + Ctrl + I` — or `omarchy toggle idle` — flips stay awake on, and the coffee cup indicator appears in the bar. That's the one to hit before a long presentation or a build you want to watch. Hit it again to go back to normal. `omarchy toggle idle status` prints the current state as JSON if you need it from a script.

--- a/shell/README.md
+++ b/shell/README.md
@@ -276,7 +276,12 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    entries with their own values.
 7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
    are seconds since user idle began, so the default lock fires at 300s
-   even if the 150s screensaver starts first.
+   even if the 150s screensaver starts first. Either one can be turned off
+   on its own with `null`, `false`, or `"off"` (`"never"` also works) —
+   `"lock": false` keeps the screensaver and monitor blanking while never
+   locking. Omitting a key falls back to its default; `0` still means fire
+   the moment the session goes idle. Timings are clamped to 2147483 seconds,
+   the ceiling of the millisecond timer behind them.
 8. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,7 +1,38 @@
+var DISABLED_SECONDS = -1
+
+// Timer.interval is a signed 32-bit millisecond count, so anything past this
+// many seconds wraps around and fires immediately -- the opposite of what a
+// very long timeout asks for.
+var MAX_SECONDS = 2147483
+
+var DISABLED_WORDS = ["off", "never", "none", "no", "false", "disabled"]
+
+function isDisabled(seconds) {
+  return seconds === DISABLED_SECONDS
+}
+
 function secondsFromConfig(value, fallback) {
+  if (value === null || value === false) return DISABLED_SECONDS
+  if (value === undefined || value === true) return fallback
+
+  if (typeof value === "string") {
+    var word = value.trim().toLowerCase()
+    if (word === "") return fallback
+    if (DISABLED_WORDS.indexOf(word) !== -1) return DISABLED_SECONDS
+  }
+
   var n = Number(value)
-  if (!isFinite(n) || n < 0) return fallback
-  return Math.floor(n)
+  if (!isFinite(n)) return fallback
+  if (n < 0) return DISABLED_SECONDS
+  return Math.min(Math.floor(n), MAX_SECONDS)
+}
+
+// The idle monitor arms once, at whichever timeout comes first; a disabled
+// timing does not get a say in when that is.
+function firstIdleTimeout(screensaverSeconds, lockSeconds) {
+  if (isDisabled(screensaverSeconds)) return isDisabled(lockSeconds) ? 0 : lockSeconds
+  if (isDisabled(lockSeconds)) return screensaverSeconds
+  return Math.min(screensaverSeconds, lockSeconds)
 }
 
 function eventParts(event, count) {
@@ -45,7 +76,11 @@ function screensaverWindowsAfter(windows, address, visible) {
 
 if (typeof module !== "undefined") {
   module.exports = {
+    DISABLED_SECONDS: DISABLED_SECONDS,
+    MAX_SECONDS: MAX_SECONDS,
+    isDisabled: isDisabled,
     secondsFromConfig: secondsFromConfig,
+    firstIdleTimeout: firstIdleTimeout,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter
   }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -19,9 +19,12 @@ Item {
   readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
   readonly property int screensaverTimeoutSeconds: secondsFromConfig(idleConfig.screensaver, defaultScreensaverSeconds)
   readonly property int lockTimeoutSeconds: secondsFromConfig(idleConfig.lock, defaultLockSeconds)
-  readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
-  readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
-  readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
+  readonly property bool screensaverConfigured: !IdleModel.isDisabled(screensaverTimeoutSeconds)
+  readonly property bool lockConfigured: !IdleModel.isDisabled(lockTimeoutSeconds)
+  readonly property bool anyIdleActionConfigured: screensaverConfigured || lockConfigured
+  readonly property int firstIdleTimeoutSeconds: IdleModel.firstIdleTimeout(screensaverTimeoutSeconds, lockTimeoutSeconds)
+  readonly property int screensaverDelaySeconds: screensaverConfigured ? Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds) : 0
+  readonly property int lockDelaySeconds: lockConfigured ? Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds) : 0
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
@@ -38,6 +41,10 @@ Item {
 
   function secondsFromConfig(value, fallback) {
     return IdleModel.secondsFromConfig(value, fallback)
+  }
+
+  function describeTimeout(seconds) {
+    return IdleModel.isDisabled(seconds) ? "off" : String(seconds)
   }
 
   function nowIso() {
@@ -85,16 +92,20 @@ Item {
       return
     }
 
-    logEvent("idle-cycle-start", "screensaver=" + root.screensaverTimeoutSeconds + " lock=" + root.lockTimeoutSeconds)
+    logEvent("idle-cycle-start", "screensaver=" + describeTimeout(root.screensaverTimeoutSeconds) + " lock=" + describeTimeout(root.lockTimeoutSeconds))
     root.idledThisCycle = true
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()
 
-    if (root.screensaverDelaySeconds === 0) launchScreensaver()
-    else screensaverTimer.restart()
+    if (root.screensaverConfigured) {
+      if (root.screensaverDelaySeconds === 0) launchScreensaver()
+      else screensaverTimer.restart()
+    }
 
-    if (root.lockDelaySeconds === 0) lockSystem("lock-timeout-immediate")
-    else lockTimer.restart()
+    if (root.lockConfigured) {
+      if (root.lockDelaySeconds === 0) lockSystem("lock-timeout-immediate")
+      else lockTimer.restart()
+    }
   }
 
   function cancelIdleCycle(reason) {
@@ -187,7 +198,9 @@ Item {
       inIdleCycle: root.idledThisCycle,
       screensaverStarted: root.screensaverStartedThisCycle,
       screensaver: root.screensaverTimeoutSeconds,
+      screensaverConfigured: root.screensaverConfigured,
       lock: root.lockTimeoutSeconds,
+      lockConfigured: root.lockConfigured,
       screensaverDelay: root.screensaverDelaySeconds,
       lockDelay: root.lockDelaySeconds,
       screensaverWindows: root.screensaverWindowCount,
@@ -249,7 +262,7 @@ Item {
 
   IdleMonitor {
     id: idleMonitor
-    enabled: root.idleEnabled
+    enabled: root.idleEnabled && root.anyIdleActionConfigured
     timeout: root.firstIdleTimeoutSeconds
     respectInhibitors: true
     onIsIdleChanged: root.handleIdleChanged()
@@ -266,7 +279,7 @@ Item {
     id: lockTimer
     interval: root.lockDelaySeconds * 1000
     repeat: false
-    onTriggered: if (root.idleEnabled && root.idledThisCycle) root.lockSystem("lock-timeout")
+    onTriggered: if (root.idleEnabled && root.idledThisCycle && root.lockConfigured) root.lockSystem("lock-timeout")
   }
 
   Timer {

--- a/test/acceptance.d/idle-test.sh
+++ b/test/acceptance.d/idle-test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+config="$HOME/.config/omarchy/shell.json"
+backup="$ARTIFACTS/shell.json.orig"
+
+[[ -f $config ]] || fail "shell.json exists to configure idle timings"
+cp "$config" "$backup"
+
+restore_config() {
+  cp "$backup" "$config"
+  omarchy-shell -q shell reloadConfig >/dev/null 2>&1 || true
+  hyprctl dispatch closewindow "class:^(org\.omarchy\.screensaver)$" >/dev/null 2>&1 || true
+}
+trap restore_config EXIT
+
+set_idle() {
+  local screensaver="$1" lock="$2"
+
+  jq --argjson screensaver "$screensaver" --argjson lock "$lock" \
+    '.idle = {screensaver: $screensaver, lock: $lock}' "$backup" >"$config.tmp"
+  mv "$config.tmp" "$config"
+  omarchy-shell shell reloadConfig >/dev/null
+}
+
+idle_status() {
+  omarchy-shell idle status
+}
+
+idle_field() {
+  idle_status | jq -r "$1"
+}
+
+idle_field_is() {
+  [[ $(idle_field "$1") == "$2" ]]
+}
+
+# The three spellings of "off" that used to parse as 0 -- which meant "fire the
+# moment the session goes idle", the most hostile reading of the user's intent.
+for spelling in false null '"off"'; do
+  set_idle 150 "$spelling"
+
+  wait_until "a lock disabled with $spelling is reported as unconfigured" 15 idle_field_is '.lockConfigured' false
+  [[ $(idle_field '.lock') == "-1" ]] ||
+    fail "a lock disabled with $spelling reports the disabled sentinel" "$(idle_status)"
+  pass "a lock disabled with $spelling reports the disabled sentinel"
+
+  # A disabled lock must not take the screensaver down with it.
+  idle_field_is '.screensaverConfigured' true ||
+    fail "a lock disabled with $spelling leaves the screensaver configured" "$(idle_status)"
+  pass "a lock disabled with $spelling leaves the screensaver configured"
+done
+
+# Timings are clamped to the signed 32-bit millisecond ceiling of the Timer
+# behind them; past it the interval wraps and fires immediately.
+set_idle 150 999999999
+wait_until "an oversized lock clamps to the timer ceiling" 15 idle_field_is '.lock' 2147483
+
+# An omitted timing still falls back to its default rather than disabling.
+jq 'del(.idle)' "$backup" >"$config.tmp" && mv "$config.tmp" "$config"
+omarchy-shell shell reloadConfig >/dev/null
+wait_until "an omitted lock keeps the default timing" 15 idle_field_is '.lock' 300
+idle_field_is '.lockConfigured' true || fail "an omitted lock stays configured" "$(idle_status)"
+pass "an omitted lock stays configured"
+
+# Everything below needs the compositor to actually report idle. Some
+# environments (headless VMs among them) never do, and a timing assertion there
+# would fail for reasons that have nothing to do with the timings.
+set_idle 2 false
+
+session_goes_idle() {
+  local deadline=$((SECONDS + 45))
+
+  while ((SECONDS < deadline)); do
+    [[ $(idle_field '.idle') == "true" ]] && return 0
+    sleep 2
+  done
+
+  return 1
+}
+
+if ! session_goes_idle; then
+  pass "session never reports idle here; skipping idle-cycle assertions"
+  exit 0
+fi
+
+# The regression itself: with the lock disabled, going idle must start the
+# screensaver and leave the session unlocked.
+wait_until "the screensaver still launches with the lock disabled" 60 \
+  window_present 'org\.omarchy\.screensaver'
+screenshot "success-screensaver-with-lock-disabled"
+
+[[ $(idle_field '.timers.lock') == "false" ]] ||
+  fail "a disabled lock never arms its timer" "$(idle_status)"
+pass "a disabled lock never arms its timer"
+
+lock_deadline=$((SECONDS + 30))
+while ((SECONDS < lock_deadline)); do
+  [[ $(omarchy-shell lock isLocked) == "false" ]] ||
+    fail "a disabled lock never locks the session" "$(idle_status)"
+  sleep 2
+done
+pass "a disabled lock never locks the session"
+
+hyprctl dispatch closewindow "class:^(org\.omarchy\.screensaver)$" >/dev/null
+wait_until "dismissing the screensaver ends the idle cycle" 30 idle_field_is '.inIdleCycle' false
+
+# A configured lock must still be scheduled, at its own offset from the
+# screensaver. Asserted on the armed timer rather than by letting it fire, so
+# the suite does not strand later tests behind a lock screen.
+set_idle 2 20
+
+wait_until "a configured lock arms its timer once idle" 60 idle_field_is '.timers.lock' true
+[[ $(idle_field '.lockDelay') == "18" ]] ||
+  fail "a configured lock keeps its offset from the screensaver" "$(idle_status)"
+pass "a configured lock keeps its offset from the screensaver"
+
+hyprctl dispatch closewindow "class:^(org\.omarchy\.screensaver)$" >/dev/null
+wait_until "the pending lock is cancelled with the screensaver" 30 idle_field_is '.timers.lock' false
+
+screenshot "success-idle-timings-disabled"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -8,8 +8,35 @@ run_node_test <<'JS'
 const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
 
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
-assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
+assertEqual(idle.secondsFromConfig(0, 10), 0, 'idle keeps a zero timeout immediate')
+assertEqual(idle.secondsFromConfig(undefined, 10), 10, 'idle defaults an unset timing')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
+assertEqual(idle.secondsFromConfig('', 10), 10, 'idle treats a blank timing as unset')
+assertEqual(idle.secondsFromConfig(true, 10), 10, 'idle treats true as unset')
+
+assertEqual(idle.secondsFromConfig(null, 10), idle.DISABLED_SECONDS, 'idle disables on null')
+assertEqual(idle.secondsFromConfig(false, 10), idle.DISABLED_SECONDS, 'idle disables on false')
+assertEqual(idle.secondsFromConfig('off', 10), idle.DISABLED_SECONDS, 'idle disables on off')
+assertEqual(idle.secondsFromConfig(' Never ', 10), idle.DISABLED_SECONDS, 'idle disables on never')
+assertEqual(idle.secondsFromConfig('-1', 10), idle.DISABLED_SECONDS, 'idle disables on negative seconds')
+
+assertEqual(
+  idle.secondsFromConfig(999999999, 10),
+  idle.MAX_SECONDS,
+  'idle clamps timings to the 32-bit timer ceiling'
+)
+
+assert(idle.isDisabled(idle.DISABLED_SECONDS), 'idle recognises the disabled sentinel')
+assert(!idle.isDisabled(0), 'idle does not treat zero as disabled')
+
+assertEqual(idle.firstIdleTimeout(150, 300), 150, 'idle arms at the earliest timing')
+assertEqual(idle.firstIdleTimeout(150, idle.DISABLED_SECONDS), 150, 'idle ignores a disabled lock')
+assertEqual(idle.firstIdleTimeout(idle.DISABLED_SECONDS, 300), 300, 'idle ignores a disabled screensaver')
+assertEqual(
+  idle.firstIdleTimeout(idle.DISABLED_SECONDS, idle.DISABLED_SECONDS),
+  0,
+  'idle has nothing to arm when both timings are disabled'
+)
 
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(


### PR DESCRIPTION
Closes #7178
Closes #7506

## The problem

`idle.screensaver` and `idle.lock` in `~/.config/omarchy/shell.json` have no way to say "off", and the values that *look* like off do the opposite. The parser is `secondsFromConfig()` in `shell/plugins/services/idle/IdleModel.js`:

```js
var n = Number(value)
if (!isFinite(n) || n < 0) return fallback
return Math.floor(n)
```

`Number(null)`, `Number(false)` and `Number("")` are all `0`, and a `0` timing means *fire the moment the session goes idle*. Behaviour on `quattro` before this PR:

| config value | result | why it matters |
|---|---|---|
| `null` | **0 → fires immediately** | `Number(null) === 0` |
| `false` | **0 → fires immediately** | `Number(false) === 0` |
| `""` | **0 → fires immediately** | `Number("") === 0` |
| `-1` | 300 (silent default) | looks like "off", silently isn't |
| `"off"` | 300 (silent default) | NaN → fallback |
| missing | 300 (default) | correct |
| `999999999` | returned as-is | overflows the Timer int |

So the three most intuitive spellings of "off" lock the screen instantly, and the next two silently keep the default — the user thinks it worked until they get locked out mid-task. Both timings share the parser, so `"screensaver": null` launches the screensaver instantly too.

The overflow is separate: `lockDelaySeconds * 1000` feeds a QML `Timer.interval`, a signed 32-bit millisecond count (max 2147483647 ms ≈ 24.8 days). Anything above that wraps and can fire immediately — again the opposite of intent.

Real case that surfaced it: a stationary desktop that should never idle-lock, but still needs the screensaver and monitor blanking for burn-in. The only workaround today is `"lock": 604800` — 7 days, picked to stay under the 32-bit ceiling.

## The change

Distinguish *unset* from *explicitly disabled*:

- `null`, `false`, `"off"`, `"never"` (also `"none"`, `"no"`, `"disabled"`), and negative numbers → **disabled**, via a `DISABLED_SECONDS = -1` sentinel
- missing, `undefined`, `true`, `""`, and unparseable strings → existing default, unchanged
- `0` → still 0, still fires immediately — deliberately left alone, since changing it would be a behaviour change
- everything else → clamped to `MAX_SECONDS = 2147483`

A disabled timing is *skipped* when the idle cycle starts rather than pushed out to a huge interval, so its `Timer` is never started at all. `firstIdleTimeout()` arbitrates which timing arms the `IdleMonitor`, ignoring disabled ones, and the monitor itself is disabled when both are off.

`"lock": false` now does what it reads as: screensaver and monitor blanking keep working, the session never locks.

## Judgement calls

- **`""` falls back to the default rather than disabling.** It's listed above as one of the "looks like off" values, but an empty string reads more like *unset* than a deliberate choice, and defaulting is the conservative side of a security-relevant decision — a stray empty value shouldn't silently stop a laptop locking. Documented as unset.
- **`0` left as-is.** It's a valid, if unusual, "lock immediately" and some config could rely on it. Changing it would be the behaviour change this PR is trying to avoid.
- **Clamp rather than reject** oversized values, so the 7-day workaround above keeps working instead of breaking on upgrade.
- **`enabled` in `idle status` still means stay-awake.** I added separate `screensaverConfigured` / `lockConfigured` booleans rather than overloading it, so `omarchy-debug-idle` and the runtime smoke test's `.enabled | type == "boolean"` check are unaffected. The numeric `screensaver` / `lock` fields keep their type and report `-1` when disabled.

No behaviour change for any config that works today.

## Testing

`test/shell.d/idle-test.sh` covers the whole table at the parser level — each disabled spelling, the unset fallbacks, `0` staying immediate, the clamp, and `firstIdleTimeout()` including the both-disabled case. `./test/cli` passes.

`test/acceptance.d/idle-test.sh` is new and covers the config surface on a real desktop. I ran it in the disposable VM (`omarchy-iso-test` against the published `omarchy-4.0.1.iso`, which is the version this was reported from), with local `shell/` synced in:

```
ok - a lock disabled with false is reported as unconfigured
ok - a lock disabled with false reports the disabled sentinel
ok - a lock disabled with false leaves the screensaver configured
ok - a lock disabled with null is reported as unconfigured
ok - a lock disabled with null reports the disabled sentinel
ok - a lock disabled with null leaves the screensaver configured
ok - a lock disabled with "off" is reported as unconfigured
ok - a lock disabled with "off" reports the disabled sentinel
ok - a lock disabled with "off" leaves the screensaver configured
ok - an oversized lock clamps to the timer ceiling
ok - an omitted lock keeps the default timing
ok - an omitted lock stays configured
```

Reverting just `IdleModel.js` and `Service.qml` to their `quattro` versions in that same VM fails the test on its first assertion, and reproduces the bug on a real installed system — `"lock": false` yields:

```json
{"lock": 0, "lockDelay": 0}
```

`lockDelay: 0` is `lockSystem("lock-timeout-immediate")` the moment the session goes idle.

### What the acceptance test does not cover

The idle-*cycle* assertions — screensaver launches, lock timer never arms, session stays unlocked across a real idle transition — skip in that VM, because the shell's `IdleMonitor` never reports idle there. That is pre-existing and unrelated to this change: with plain `{"screensaver": 2, "lock": 300}` and no disabled value anywhere, the shell still never goes idle in the guest, while a standalone Quickshell `IdleMonitor` with the same 2s timeout idles immediately in the same session. So the test skips rather than failing for a reason that has nothing to do with the timings, and those assertions will run on a machine whose session does idle. Worth a second pair of eyes from someone who can reproduce a real idle transition.
