### PR TITLE
Do not activate mise shims globally in UWSM session

### DIFF
--- a/default/uwsm/env.d/10-omarchy
+++ b/default/uwsm/env.d/10-omarchy
@@ -14,6 +14,3 @@ fi
 
 # Optional user overrides kept for compatibility with older installs.
 [ -f "$HOME/.config/uwsm/default" ] && . "$HOME/.config/uwsm/default"
-
-# Activate mise if present on the system
-omarchy-cmd-present mise && eval "$(mise activate bash --shims)"

--- a/test/shell.d/browser-env-test.sh
+++ b/test/shell.d/browser-env-test.sh
@@ -24,3 +24,37 @@ pass "uwsm session env leaves BROWSER unset"
 
 ! grep -q "export BROWSER" "$uwsm_env" || fail "uwsm env.d fallback leaves BROWSER unset"
 pass "uwsm env.d fallback leaves BROWSER unset"
+
+# Global mise shims must not be activated session-wide in UWSM env, which would
+# place user-installed toolchains (e.g. Python) before system binaries and crash
+# native apps (like Blender) that link against system runtimes.
+! grep -q "mise activate" "$uwsm_env" || fail "uwsm session env leaves mise shims un-activated"
+pass "uwsm session env leaves mise shims un-activated"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mock_bin="$tmpdir/bin"
+mkdir -p "$mock_bin"
+cat >"$mock_bin/mise" <<'EOF'
+#!/bin/bash
+if [[ "$*" == *"activate"*"--shims"* ]]; then
+  echo 'export PATH="/fake/mise/shims:$PATH"'
+fi
+EOF
+chmod +x "$mock_bin/mise"
+
+cat >"$mock_bin/omarchy-cmd-present" <<'EOF'
+#!/bin/bash
+command -v "$1" >/dev/null 2>&1
+EOF
+chmod +x "$mock_bin/omarchy-cmd-present"
+
+uwsm_path=$(PATH="$mock_bin:/usr/bin" HOME="$tmpdir" bash -c '
+  export OMARCHY_PATH="'"$ROOT"'"
+  . "$1"
+  printf "%s" "$PATH"
+' bash "$uwsm_env")
+
+[[ $uwsm_path != *"/fake/mise/shims"* ]] || fail "uwsm env does not prepend mise shims" "actual: $uwsm_path"
+pass "uwsm env does not prepend mise shims"


### PR DESCRIPTION
## Summary

Fixes #9158.

### Root Cause
`default/uwsm/env.d/10-omarchy` previously executed:
```bash
omarchy-cmd-present mise && eval "$(mise activate bash --shims)"
```
`mise activate bash --shims` outputs `export PATH="$HOME/.local/share/mise/shims:$PATH"`, which prepended mise shims to `PATH` session-wide across the graphical session and systemd user services.

When a user installed a developer runtime like Python via Mise (e.g. `mise use -g python@latest`), native desktop applications with embedded Python interpreters (such as Blender) picked up the global Mise Python standard library rather than Arch's system Python runtime. This caused ABI mismatches (failing to import `math`, `_posixsubprocess`, etc.) and crashed Blender on startup with SIGSEGV.

### Resolution
- Removed `eval "$(mise activate bash --shims)"` from `default/uwsm/env.d/10-omarchy`.
- `default/bash/env-bootstrap` (sourced at session start) already appends `~/.local/share/mise/shims` and `~/.local/bin` to the end of `PATH`, ensuring system binaries in `/usr/bin` retain precedence for GUI application launches while keeping user tools accessible.
- Interactive shells continue to receive interactive Mise activation via `default/bash/init`.
- Added test coverage in `test/shell.d/browser-env-test.sh` to verify that UWSM session environment does not globally activate mise shims ahead of system `PATH`.

### Validation
- Validated test suite passes inside an unprivileged Bubblewrap sandbox container.