### PR TITLE
Fall back to an installed Chromium-family browser in omarchy-launch-webapp

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -5,9 +5,34 @@
 
 browser=$(xdg-settings get default-web-browser)
 
-case $browser in
-google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
-*) browser="chromium.desktop" ;;
-esac
+browser_exec() {
+  sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/"$1" 2>/dev/null | head -1
+}
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+is_chromium_family() {
+  case $1 in
+  *chrome* | *chromium* | *brave* | *edge* | *opera* | *vivaldi* | *helium*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+exec_line=""
+if is_chromium_family "${browser,,}"; then
+  exec_line=$(browser_exec "$browser")
+fi
+
+if [[ -z $exec_line ]]; then
+  for candidate in chromium chromium-browser google-chrome brave-browser microsoft-edge vivaldi opera helium; do
+    exec_line=$(browser_exec "$candidate.desktop")
+    if [[ -n $exec_line ]]; then
+      break
+    fi
+  done
+fi
+
+if [[ -n $exec_line ]]; then
+  exec setsid uwsm-app -- $exec_line --app="$1" "${@:2}"
+else
+  echo "Error: no Chromium-family browser installed. Web apps require one (chromium, google-chrome, brave, microsoft-edge, vivaldi, opera, or helium) for app mode." >&2
+  exit 1
+fi

--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -3,7 +3,7 @@
 # omarchy:summary=Launch a URL as a web app in the default supported browser
 # omarchy:args=<url>
 
-browser=$(xdg-settings get default-web-browser)
+browser=$(env -u BROWSER xdg-settings get default-web-browser)
 
 browser_exec() {
   sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/"$1" 2>/dev/null | head -1
@@ -34,5 +34,6 @@ if [[ -n $exec_line ]]; then
   exec setsid uwsm-app -- $exec_line --app="$1" "${@:2}"
 else
   echo "Error: no Chromium-family browser installed. Web apps require one (chromium, google-chrome, brave, microsoft-edge, vivaldi, opera, or helium) for app mode." >&2
+  omarchy-notification-send -u low -t 5000 "Web app failed to launch" "No Chromium-family browser is installed. Web apps need one (e.g. Chrome, Brave, Edge) for app mode."
   exit 1
 fi

--- a/test/shell.d/launch-webapp-test.sh
+++ b/test/shell.d/launch-webapp-test.sh
@@ -22,7 +22,12 @@ EOF
 
 cat >"$mock_bin/xdg-settings" <<'SH'
 #!/bin/bash
-printf '%s\n' "$OMARCHY_TEST_BROWSER"
+printf '%s\n' "${BROWSER:-$OMARCHY_TEST_BROWSER}"
+SH
+
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf 'notify:%s\n' "$*" >>"$OMARCHY_TEST_LAUNCH"
 SH
 
 cat >"$mock_bin/sed" <<'SH'
@@ -85,10 +90,19 @@ launch_webapp "firefox.desktop" "https://messenger.com" "--user-data-dir=/tmp/x"
 assert_launch "/usr/bin/google-chrome-stable --app=https://messenger.com --user-data-dir=/tmp/x" \
   "extra arguments pass through to the browser"
 
+write_desktop "evil-chrome.desktop" "/usr/bin/evil-chrome %u"
+export BROWSER=evil-chrome.desktop
+launch_webapp "firefox.desktop" "https://messenger.com"
+unset BROWSER
+assert_launch "/usr/bin/google-chrome-stable --app=https://messenger.com" \
+  "the BROWSER environment variable does not skew browser detection"
+
 rm "$test_home/.local/share/applications/google-chrome.desktop" "$test_home/.local/share/applications/com.google.Chrome.desktop"
 
 output=$(launch_webapp "firefox.desktop" "https://messenger.com" 2>&1) && status=0 || status=$?
 [[ $status -eq 1 ]] || fail "a missing chromium-family browser exits with an error" "exit: $status, output: $output"
 [[ $output == *"no Chromium-family browser installed"* ]] ||
   fail "a missing chromium-family browser prints a clear error" "output: $output"
-pass "a missing chromium-family browser exits with a clear error"
+grep -F "notify:" "$test_tmp/launch" >/dev/null ||
+  fail "a missing chromium-family browser sends a notification" "log: $(cat "$test_tmp/launch")"
+pass "a missing chromium-family browser exits with a clear error and sends a notification"

--- a/test/shell.d/launch-webapp-test.sh
+++ b/test/shell.d/launch-webapp-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$mock_bin" "$test_home/.local/share/applications"
+
+write_desktop() {
+  local name="$1" exec_line="$2"
+
+  cat >"$test_home/.local/share/applications/$name" <<EOF
+[Desktop Entry]
+Exec=$exec_line
+EOF
+}
+
+cat >"$mock_bin/xdg-settings" <<'SH'
+#!/bin/bash
+printf '%s\n' "$OMARCHY_TEST_BROWSER"
+SH
+
+cat >"$mock_bin/sed" <<'SH'
+#!/bin/bash
+# Hide the real system desktop entries so only the mock HOME ones resolve.
+args=()
+for arg in "$@"; do
+  [[ $arg == /usr/share/applications/* ]] || args+=("$arg")
+done
+if ((${#args[@]} == 0)); then
+  exit 0
+fi
+exec /usr/bin/sed "${args[@]}"
+SH
+
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$mock_bin/uwsm-app" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_LAUNCH"
+SH
+
+chmod +x "$mock_bin"/*
+
+launch_webapp() {
+  : >"$test_tmp/launch"
+  HOME="$test_home" PATH="$mock_bin:$PATH" OMARCHY_TEST_BROWSER="$1" \
+    OMARCHY_TEST_LAUNCH="$test_tmp/launch" \
+    bash "$ROOT/bin/omarchy-launch-webapp" "${@:2}"
+}
+
+assert_launch() {
+  local expected="$1" description="$2"
+
+  grep -F -- "$expected" "$test_tmp/launch" >/dev/null ||
+    fail "$description" "launch: $(cat "$test_tmp/launch")"
+  pass "$description"
+}
+
+write_desktop "firefox.desktop" "/usr/lib/firefox/firefox %u"
+write_desktop "com.google.Chrome.desktop" "/opt/google/chrome/chrome %U"
+write_desktop "google-chrome.desktop" "/usr/bin/google-chrome-stable %U"
+
+launch_webapp "com.google.Chrome.desktop" "https://messenger.com"
+assert_launch "/opt/google/chrome/chrome --app=https://messenger.com" \
+  "a chromium-family default browser is used with --app"
+
+launch_webapp "firefox.desktop" "https://messenger.com"
+assert_launch "/usr/bin/google-chrome-stable --app=https://messenger.com" \
+  "a firefox default falls back to an installed chromium-family browser"
+
+launch_webapp "chromium.desktop" "https://messenger.com"
+assert_launch "/usr/bin/google-chrome-stable --app=https://messenger.com" \
+  "a default browser without an installed entry falls back to an installed chromium-family browser"
+
+launch_webapp "firefox.desktop" "https://messenger.com" "--user-data-dir=/tmp/x"
+assert_launch "/usr/bin/google-chrome-stable --app=https://messenger.com --user-data-dir=/tmp/x" \
+  "extra arguments pass through to the browser"
+
+rm "$test_home/.local/share/applications/google-chrome.desktop" "$test_home/.local/share/applications/com.google.Chrome.desktop"
+
+output=$(launch_webapp "firefox.desktop" "https://messenger.com" 2>&1) && status=0 || status=$?
+[[ $status -eq 1 ]] || fail "a missing chromium-family browser exits with an error" "exit: $status, output: $output"
+[[ $output == *"no Chromium-family browser installed"* ]] ||
+  fail "a missing chromium-family browser prints a clear error" "output: $output"
+pass "a missing chromium-family browser exits with a clear error"


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
Fixes #7034

## Problem

`omarchy-launch-webapp` whitelists Chromium-family browsers and falls back to a hardcoded `chromium.desktop` for anything else. When the default browser is not Chromium-family (e.g. Firefox) and Chromium itself is not installed, the `sed` extraction of the desktop file's `Exec=` returns an empty string, and the command degrades to:

```
uwsm-app -- --app=https://example.com
```

`uwsm` then treats `--app=...` as the executable path and fails with a confusing error:

```
error: path "--app=https://example.com" does not exist!
```

## Fix

- Keep using the default browser when it is Chromium-family (case-insensitive match, so Flatpak IDs like `com.google.Chrome.desktop` also work) and its desktop entry resolves to an `Exec=`
- Otherwise fall back to the first installed Chromium-family browser (chromium, chromium-browser, google-chrome, brave-browser, microsoft-edge, vivaldi, opera, helium)
- If no Chromium-family browser is installed, exit with a clear error instead of an opaque uwsm failure

Note: I deliberately did not fall back to opening the URL as a regular tab in Firefox, since Firefox does not support `--app` mode and the contract here is a standalone web app window. Happy to switch to a tab fallback if maintainers prefer that behavior.

## Testing

- Verified locally on Omarchy 4.0.1 with `firefox.desktop` as default browser and only Google Chrome installed: `omarchy-launch-webapp https://lumo.proton.me` now launches in Chrome app mode (previously failed with the uwsm error above)
- `./test/cli` passes fully
- `./test/shell` has 5 failing files on a clean checkout in this dev environment (missing `omarchy-pkgs` checkout for packaging-coverage assertions); verified they fail identically with my change stashed, so they are unrelated

## Update after #9206

#9206 independently proposes the same core fix. To make consolidation easier, this PR also incorporates its two good ideas:

- `env -u BROWSER xdg-settings` so the `BROWSER` environment variable cannot skew default-browser detection
- A desktop notification via `omarchy-notification-send` on the no-browser error path, in addition to the stderr message

This PR still differs from #9206 in: case-insensitive default-browser matching (Flatpak-style IDs like `com.google.Chrome.desktop`), arg-passthrough coverage, and a test suite that masks `/usr/share/applications` so results are hermetic on machines with Chromium-family browsers installed.