### PR TITLE
Add advanced display layout controls

### DIFF
--- a/bin/omarchy-monitor-layout
+++ b/bin/omarchy-monitor-layout
@@ -1,0 +1,223 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Read or apply the visual monitor layout
+# omarchy:group=monitor
+# omarchy:hidden=true
+
+"""Safe layout backend for the Display shell panel."""
+
+import json
+import math
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+
+CONFIG = pathlib.Path(os.environ.get("XDG_CONFIG_HOME", pathlib.Path.home() / ".config")) / "hypr" / "monitors.lua"
+BEGIN = "-- BEGIN omarchy.monitor (managed layout)"
+END = "-- END omarchy.monitor (managed layout)"
+LEGACY_BEGIN = "-- BEGIN anders.display-layout (managed)"
+LEGACY_END = "-- END anders.display-layout (managed)"
+OUTPUT_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
+MODE_RE = re.compile(r"^(preferred|[0-9]+x[0-9]+@[0-9]+(?:\.[0-9]+)?)$")
+
+
+def hypr_json(*args):
+    result = subprocess.run(["hyprctl", "-j", *args], check=True, text=True, capture_output=True)
+    return json.loads(result.stdout)
+
+
+def closest_mode(monitor, modes):
+    target_width = int(monitor.get("width", 0))
+    target_height = int(monitor.get("height", 0))
+    target_rate = float(monitor.get("refreshRate", 0))
+    best = None
+    best_score = math.inf
+    for mode in modes:
+        match = re.match(r"^(\d+)x(\d+)@(\d+(?:\.\d+)?)Hz?$", mode)
+        if not match:
+            continue
+        width, height, rate = int(match[1]), int(match[2]), float(match[3])
+        score = abs(width - target_width) * 1000 + abs(height - target_height) * 1000 + abs(rate - target_rate)
+        if score < best_score:
+            best, best_score = mode.removesuffix("Hz"), score
+    return best or "preferred"
+
+
+def monitors():
+    values = []
+    for monitor in hypr_json("monitors", "all"):
+        if monitor.get("disabled"):
+            continue
+        modes = monitor.get("availableModes") or []
+        values.append({
+            "name": monitor["name"],
+            "description": monitor.get("description") or monitor["name"],
+            "x": int(monitor.get("x", 0)),
+            "y": int(monitor.get("y", 0)),
+            "width": int(monitor.get("width", 0)),
+            "height": int(monitor.get("height", 0)),
+            "refreshRate": round(float(monitor.get("refreshRate", 60)), 3),
+            "scale": float(monitor.get("scale", 1)),
+            "transform": int(monitor.get("transform", 0)),
+            "mirror": "" if monitor.get("mirrorOf") in (None, "", "none") else str(monitor.get("mirrorOf")),
+            "focused": bool(monitor.get("focused")),
+            "modes": modes,
+            "mode": closest_mode(monitor, modes),
+        })
+    return values
+
+
+def logical_rect(item, connected):
+    x_text, y_text = item["position"].split("x", 1)
+    match = re.match(r"^(\d+)x(\d+)@", item["mode"])
+    if match:
+        width, height = int(match[1]), int(match[2])
+    else:
+        live = connected[item["name"]]
+        width, height = int(live["width"]), int(live["height"])
+    width = round(width / item["scale"])
+    height = round(height / item["scale"])
+    if item["transform"] % 2:
+        width, height = height, width
+    x, y = int(x_text), int(y_text)
+    return x, y, x + width, y + height
+
+
+def reject_invalid_geometry(layout, connected):
+    rectangles = [(item["name"], logical_rect(item, connected)) for item in layout if not item["mirror"]]
+    for index, (name, first) in enumerate(rectangles):
+        for other_name, second in rectangles[index + 1:]:
+            overlap = first[0] < second[2] and first[2] > second[0] and first[1] < second[3] and first[3] > second[1]
+            if overlap:
+                raise ValueError(f"displays overlap: {name} and {other_name}")
+    if len(rectangles) < 2:
+        return
+    visited = {0}
+    pending = [0]
+    while pending:
+        first = rectangles[pending.pop()][1]
+        for index, (_, second) in enumerate(rectangles):
+            if index in visited:
+                continue
+            vertical_overlap = min(first[3], second[3]) - max(first[1], second[1])
+            horizontal_overlap = min(first[2], second[2]) - max(first[0], second[0])
+            vertical_edge = first[2] == second[0] or second[2] == first[0]
+            horizontal_edge = first[3] == second[1] or second[3] == first[1]
+            if (vertical_edge and vertical_overlap > 0) or (horizontal_edge and horizontal_overlap > 0):
+                visited.add(index)
+                pending.append(index)
+    if len(visited) != len(rectangles):
+        raise ValueError("all displays must be connected edge-to-edge")
+
+
+def validate_layout(raw):
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("layout must contain at least one display")
+    connected = {monitor["name"]: monitor for monitor in monitors()}
+    seen = set()
+    clean = []
+    for item in raw:
+        name = str(item.get("name", ""))
+        mode = str(item.get("mode", ""))
+        x, y = int(item.get("x", 0)), int(item.get("y", 0))
+        scale = float(item.get("scale", 1))
+        transform = int(item.get("transform", 0))
+        mirror = str(item.get("mirror", "") or "")
+        if name not in connected or not OUTPUT_RE.fullmatch(name) or name in seen:
+            raise ValueError(f"invalid or duplicate output: {name}")
+        if not MODE_RE.fullmatch(mode):
+            raise ValueError(f"invalid mode for {name}: {mode}")
+        available = [str(value).removesuffix("Hz") for value in connected[name].get("modes", [])]
+        if mode != "preferred" and mode not in available:
+            raise ValueError(f"mode is not advertised by {name}: {mode}")
+        if not 0.5 <= scale <= 4 or transform not in range(8):
+            raise ValueError(f"invalid geometry for {name}")
+        if mirror and (mirror not in connected or mirror == name or not OUTPUT_RE.fullmatch(mirror)):
+            raise ValueError(f"invalid mirror source for {name}: {mirror}")
+        seen.add(name)
+        clean.append({"name": name, "mode": mode, "position": f"{x}x{y}", "scale": scale, "transform": transform, "mirror": mirror})
+    by_name = {item["name"]: item for item in clean}
+    for item in clean:
+        if item["mirror"] and item["mirror"] not in by_name:
+            raise ValueError(f'mirror source is not part of the layout: {item["mirror"]}')
+        if item["mirror"] and by_name[item["mirror"]]["mirror"]:
+            raise ValueError(f'mirror chains are not supported: {item["name"]}')
+    reject_invalid_geometry(clean, connected)
+    return clean
+
+
+def lua_quote(value):
+    return json.dumps(value, ensure_ascii=False)
+
+
+def managed_block(layout):
+    lines = [BEGIN, "-- Generated by the Omarchy Display panel."]
+    for item in layout:
+        scale = f'{item["scale"]:.3f}'.rstrip("0").rstrip(".")
+        fields = "output = %s, mode = %s, position = %s, scale = %s, transform = %d" % (
+            lua_quote(item["name"]), lua_quote(item["mode"]), lua_quote(item["position"]), scale, item["transform"])
+        if item["mirror"]:
+            fields += ", mirror = %s" % lua_quote(item["mirror"])
+        lines.append("hl.monitor({ " + fields + " })")
+    lines.append(END)
+    return "\n".join(lines)
+
+
+def replace_block(source, block):
+    current = re.compile(re.escape(BEGIN) + r".*?" + re.escape(END), re.DOTALL)
+    legacy = re.compile(re.escape(LEGACY_BEGIN) + r".*?" + re.escape(LEGACY_END), re.DOTALL)
+    if current.search(source):
+        return current.sub(block, source)
+    if legacy.search(source):
+        return legacy.sub(block, source)
+    return source.rstrip() + "\n\n" + block + "\n"
+
+
+def atomic_write(path, content):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing_mode = path.stat().st_mode if path.exists() else None
+    descriptor, temporary_name = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w") as handle:
+            handle.write(content)
+        if existing_mode is not None:
+            os.chmod(temporary_name, existing_mode)
+        os.replace(temporary_name, path)
+    finally:
+        if os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+
+
+def apply_layout(payload):
+    layout = validate_layout(json.loads(payload))
+    source = CONFIG.read_text()
+    atomic_write(CONFIG, replace_block(source, managed_block(layout)))
+    subprocess.run(["hyprctl", "reload"], check=True, capture_output=True, text=True)
+    errors = subprocess.run(["hyprctl", "configerrors"], check=True, capture_output=True, text=True).stdout.strip()
+    if errors:
+        atomic_write(CONFIG, source)
+        subprocess.run(["hyprctl", "reload"], check=False, capture_output=True)
+        raise RuntimeError(errors)
+
+
+def main():
+    command = sys.argv[1] if len(sys.argv) > 1 else "state"
+    if command == "state":
+        print(json.dumps({"monitors": monitors()}))
+    elif command == "apply" and len(sys.argv) == 3:
+        apply_layout(sys.argv[2])
+        print(json.dumps({"ok": True}))
+    else:
+        raise SystemExit("usage: omarchy-monitor-layout state|apply JSON")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(json.dumps({"ok": False, "error": str(error)}))
+        raise SystemExit(1)

--- a/shell/plugins/panels/monitor/LayoutView.qml
+++ b/shell/plugins/panels/monitor/LayoutView.qml
@@ -1,0 +1,645 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Effects
+import QtQuick.Layouts
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+import "Model.js" as Model
+
+Item {
+  id: root
+
+  required property var bar
+  signal backRequested()
+  signal applied()
+
+  readonly property var scaleChoices: [0.75, 1, 1.25, 1.5, 1.6, 1.75, 2, 2.5, 3]
+  readonly property var rotationLabels: ["Landscape", "90°", "Upside down", "270°", "Flipped", "Flipped 90°", "Flipped 180°", "Flipped 270°"]
+
+  property var displays: []
+  property int selectedIndex: -1
+  property bool loading: false
+  property bool applying: false
+  property string errorText: ""
+  property string statusText: "Drag displays to arrange them"
+  property real layoutMinX: 0
+  property real layoutMinY: 0
+  property real canvasScale: 0.1
+  property real canvasOffsetX: 0
+  property real canvasOffsetY: 0
+
+  implicitHeight: content.implicitHeight
+
+  onSelectedIndexChanged: Qt.callLater(function() {
+    displayModeDropdown.sync()
+    mirrorTargetDropdown.sync()
+    resolutionDropdown.sync()
+    refreshDropdown.sync()
+    scaleDropdown.sync()
+    rotationDropdown.sync()
+  })
+
+  function cloneDisplay(display) {
+    var result = {}
+    for (var key in display) result[key] = display[key]
+    return result
+  }
+
+  function selectedDisplay() {
+    return selectedIndex >= 0 && selectedIndex < displays.length ? displays[selectedIndex] : null
+  }
+
+  function displayForName(name) {
+    for (var i = 0; i < displays.length; i++)
+      if (String(displays[i].name) === String(name)) return displays[i]
+    return null
+  }
+
+  function displayPosition(display) {
+    if (display && display.mirror) {
+      var source = displayForName(display.mirror)
+      if (source) return { x: Number(source.x), y: Number(source.y) }
+    }
+    return { x: Number(display.x), y: Number(display.y) }
+  }
+
+  function setDisplay(index, values) {
+    if (index < 0 || index >= displays.length) return
+    var next = displays.slice()
+    var changed = cloneDisplay(next[index])
+    for (var key in values) changed[key] = values[key]
+    next[index] = changed
+    displays = next
+    if (!changed.mirror && extendedDisplayCount() > 1) {
+      var position = Model.nearestValidPosition(displays, index, Number(changed.x), Number(changed.y))
+      changed.x = position.x
+      changed.y = position.y
+      next[index] = changed
+      displays = next.slice()
+    }
+    statusText = "Layout changed — apply when ready"
+  }
+
+  function extendedDisplayCount() {
+    var count = 0
+    for (var i = 0; i < displays.length; i++) if (!displays[i].mirror) count++
+    return count
+  }
+
+  function updateLayoutBounds() {
+    if (!displays.length || layoutCanvas.width <= 0) return
+    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (var i = 0; i < displays.length; i++) {
+      var display = displays[i]
+      if (display.mirror) continue
+      var size = Model.logicalSize(display)
+      minX = Math.min(minX, Number(display.x))
+      minY = Math.min(minY, Number(display.y))
+      maxX = Math.max(maxX, Number(display.x) + size[0])
+      maxY = Math.max(maxY, Number(display.y) + size[1])
+    }
+    if (!isFinite(minX)) return
+    layoutMinX = minX
+    layoutMinY = minY
+    var padding = Style.space(72)
+    canvasScale = Math.min(0.16,
+      Math.max(1, layoutCanvas.width - padding) / Math.max(1, maxX - minX),
+      Math.max(1, layoutCanvas.height - padding) / Math.max(1, maxY - minY)
+    )
+    canvasOffsetX = (layoutCanvas.width - (maxX - minX) * canvasScale) / 2
+    canvasOffsetY = (layoutCanvas.height - (maxY - minY) * canvasScale) / 2
+  }
+
+  function displayX(display) { return canvasOffsetX + (displayPosition(display).x - layoutMinX) * canvasScale }
+  function displayY(display) { return canvasOffsetY + (displayPosition(display).y - layoutMinY) * canvasScale }
+
+  function commitDrag(index, itemX, itemY) {
+    var desiredX = layoutMinX + (itemX - canvasOffsetX) / canvasScale
+    var desiredY = layoutMinY + (itemY - canvasOffsetY) / canvasScale
+    var position = Model.nearestValidPosition(displays, index, Math.round(desiredX / 20) * 20, Math.round(desiredY / 20) * 20)
+    setDisplay(index, position)
+  }
+
+  function resolutionOf(mode) {
+    var match = String(mode || "").match(/^(\d+x\d+)@/)
+    return match ? match[1] : "preferred"
+  }
+
+  function refreshOf(mode) {
+    var match = String(mode || "").match(/@(\d+(?:\.\d+)?)/)
+    return match ? match[1] : ""
+  }
+
+  function resolutionOptions(display) {
+    var options = [], seen = {}, modes = display && display.modes ? display.modes : []
+    for (var i = 0; i < modes.length; i++) {
+      var value = resolutionOf(modes[i])
+      if (seen[value]) continue
+      seen[value] = true
+      options.push({ value: value, label: value.replace("x", " × ") })
+    }
+    return options
+  }
+
+  function refreshOptions(display) {
+    var options = [], seen = {}, modes = display && display.modes ? display.modes : []
+    var resolution = display ? resolutionOf(display.mode) : ""
+    for (var i = 0; i < modes.length; i++) {
+      var mode = String(modes[i]).replace("Hz", "")
+      if (resolutionOf(mode) !== resolution) continue
+      var value = refreshOf(mode)
+      if (!value || seen[value]) continue
+      seen[value] = true
+      options.push({ value: value, label: value + " Hz" })
+    }
+    return options
+  }
+
+  function modeForResolution(display, resolution) {
+    var modes = display && display.modes ? display.modes : []
+    var preferredRate = Number(refreshOf(display ? display.mode : ""))
+    var best = "", bestDistance = Infinity
+    for (var i = 0; i < modes.length; i++) {
+      var mode = String(modes[i]).replace("Hz", "")
+      if (resolutionOf(mode) !== resolution) continue
+      var distance = Math.abs(Number(refreshOf(mode)) - preferredRate)
+      if (distance < bestDistance) { best = mode; bestDistance = distance }
+    }
+    return best
+  }
+
+  function scaleOptions() {
+    var options = []
+    for (var i = 0; i < scaleChoices.length; i++)
+      options.push({ value: String(scaleChoices[i]), label: Math.round(Number(scaleChoices[i]) * 100) + "%" })
+    return options
+  }
+
+  function rotationOptions() {
+    var options = []
+    for (var i = 0; i < rotationLabels.length; i++) options.push({ value: String(i), label: rotationLabels[i] })
+    return options
+  }
+
+  function mirrorSourceOptions(display) {
+    var options = []
+    for (var i = 0; i < displays.length; i++) {
+      var candidate = displays[i]
+      if (!display || candidate.name === display.name || candidate.mirror) continue
+      options.push({ value: String(candidate.name), label: String(candidate.name) })
+    }
+    return options
+  }
+
+  function displayModeOptions(display) {
+    var options = [{ value: "extend", label: "Extend desktop" }]
+    if ((display && display.mirror) || mirrorSourceOptions(display).length > 0)
+      options.push({ value: "mirror", label: "Mirror display" })
+    return options
+  }
+
+  function parseResult(raw) {
+    try { return JSON.parse(String(raw || "{}").trim() || "{}") }
+    catch (error) { return { ok: false, error: "The display service returned invalid data" } }
+  }
+
+  function refresh() {
+    if (stateProc.running) return
+    loading = true
+    errorText = ""
+    stateProc.running = true
+  }
+
+  function applyLayout() {
+    if (applying || !displays.length) return
+    var payload = []
+    for (var i = 0; i < displays.length; i++) {
+      var display = displays[i]
+      payload.push({
+        name: display.name,
+        mode: display.mode,
+        x: Math.round(display.x),
+        y: Math.round(display.y),
+        scale: Number(display.scale),
+        transform: Number(display.transform),
+        mirror: String(display.mirror || "")
+      })
+    }
+    applying = true
+    errorText = ""
+    applyProc.command = ["omarchy-monitor-layout", "apply", JSON.stringify(payload)]
+    applyProc.running = true
+  }
+
+  Component.onCompleted: refresh()
+
+  Process {
+    id: stateProc
+    command: ["omarchy-monitor-layout", "state"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var result = root.parseResult(text)
+        if (result.error) { root.errorText = result.error; return }
+        root.displays = result.monitors || []
+        root.selectedIndex = 0
+        for (var i = 0; i < root.displays.length; i++) if (root.displays[i].focused) root.selectedIndex = i
+        root.statusText = root.displays.length + (root.displays.length === 1 ? " display connected" : " displays connected")
+        Qt.callLater(root.updateLayoutBounds)
+      }
+    }
+    onExited: function(exitCode) {
+      root.loading = false
+      if (exitCode !== 0 && root.errorText === "") root.errorText = "Could not read the current display layout"
+    }
+  }
+
+  Process {
+    id: applyProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var result = root.parseResult(text)
+        if (result.error) root.errorText = result.error
+      }
+    }
+    onExited: function(exitCode) {
+      root.applying = false
+      if (exitCode === 0) {
+        root.statusText = "Layout saved"
+        root.applied()
+        root.refresh()
+      } else if (root.errorText === "") root.errorText = "The layout could not be applied"
+    }
+  }
+
+  Column {
+    id: content
+    width: parent.width
+    spacing: Style.space(14)
+
+    Item {
+      width: parent.width
+      implicitHeight: Math.max(backButton.height, headerLabels.implicitHeight, refreshButton.height)
+
+      Rectangle {
+        id: backButton
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(30)
+        height: width
+        radius: width / 2
+        color: backHover.hovered
+          ? Style.hoverFillFor(root.bar.foreground, Color.accent)
+          : "transparent"
+
+        Image {
+          id: backImage
+          anchors.centerIn: parent
+          width: Style.space(17)
+          height: width
+          source: "back.svg"
+          sourceSize.width: width * 2
+          sourceSize.height: height * 2
+          visible: false
+        }
+
+        MultiEffect {
+          anchors.fill: backImage
+          source: backImage
+          colorization: 1
+          colorizationColor: root.bar.foreground
+        }
+
+        HoverHandler { id: backHover }
+        TapHandler { onTapped: root.backRequested() }
+
+        ToolTip {
+          visible: backHover.hovered
+          text: "Back"
+          delay: 350
+        }
+      }
+
+      Column {
+        id: headerLabels
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: Style.space(2)
+        Text { anchors.horizontalCenter: parent.horizontalCenter; text: "Advanced"; color: root.bar.foreground; font.family: root.bar.fontFamily; font.pixelSize: Style.font.title; font.bold: true }
+        Text { anchors.horizontalCenter: parent.horizontalCenter; textFormat: Text.PlainText; text: root.statusText; color: Qt.darker(root.bar.foreground, 1.4); font.family: root.bar.fontFamily; font.pixelSize: Style.font.caption }
+      }
+
+      Rectangle {
+        id: refreshButton
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(30)
+        height: width
+        radius: width / 2
+        color: refreshHover.hovered
+          ? Style.hoverFillFor(root.bar.foreground, Color.accent)
+          : "transparent"
+        border.width: refreshFocus.activeFocus ? Math.max(1, Style.focusBorderWidth) : 0
+        border.color: Style.focusBorderFor(root.bar.foreground, Color.accent)
+        opacity: root.loading ? 0.55 : 1
+
+        Image {
+          id: refreshImage
+          anchors.centerIn: parent
+          width: Style.space(17)
+          height: width
+          source: "refresh.svg"
+          sourceSize.width: width * 2
+          sourceSize.height: height * 2
+          visible: false
+        }
+
+        MultiEffect {
+          anchors.fill: refreshImage
+          source: refreshImage
+          colorization: 1
+          colorizationColor: root.bar.foreground
+        }
+
+        HoverHandler { id: refreshHover }
+        TapHandler {
+          enabled: !root.loading && !root.applying
+          onTapped: root.refresh()
+        }
+        FocusScope {
+          id: refreshFocus
+          anchors.fill: parent
+        }
+
+        ToolTip {
+          visible: refreshHover.hovered
+          text: root.loading ? "Refreshing displays…" : "Refresh displays"
+          delay: 350
+        }
+      }
+    }
+
+    Rectangle {
+      id: layoutCanvas
+      width: parent.width
+      height: Style.space(230)
+      radius: Math.max(6, Style.cornerRadius)
+      color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.045)
+      border.color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.13)
+      clip: true
+      onWidthChanged: root.updateLayoutBounds()
+      onHeightChanged: root.updateLayoutBounds()
+
+      Text {
+        visible: !root.loading && root.displays.length === 0
+        anchors.centerIn: parent
+        text: "No active displays found"
+        color: Qt.darker(root.bar.foreground, 1.4)
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.body
+      }
+
+      Repeater {
+        model: root.displays
+
+        Rectangle {
+          id: screenCard
+          required property var modelData
+          required property int index
+          x: root.displayX(modelData)
+          y: root.displayY(modelData)
+          width: Math.max(72, Model.logicalSize(modelData)[0] * root.canvasScale)
+          height: Math.max(48, Model.logicalSize(modelData)[1] * root.canvasScale)
+          z: modelData.mirror ? 2 : 1
+          opacity: modelData.mirror ? 0.82 : 1
+          radius: Math.max(4, Style.cornerRadius * 0.7)
+          color: index === root.selectedIndex
+            ? Qt.rgba(Color.accent.r, Color.accent.g, Color.accent.b, 0.22)
+            : Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.09)
+          border.width: index === root.selectedIndex ? 2 : 1
+          border.color: index === root.selectedIndex ? Color.accent : Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.3)
+
+          Column {
+            anchors.centerIn: parent
+            width: parent.width - Style.space(12)
+            Text { width: parent.width; horizontalAlignment: Text.AlignHCenter; elide: Text.ElideRight; textFormat: Text.PlainText; text: screenCard.modelData.name; color: root.bar.foreground; font.family: root.bar.fontFamily; font.pixelSize: Style.font.body; font.bold: true }
+            Text {
+              width: parent.width
+              horizontalAlignment: Text.AlignHCenter
+              elide: Text.ElideRight
+              textFormat: Text.PlainText
+              text: screenCard.modelData.mirror ? "Mirrors " + screenCard.modelData.mirror : Model.modeDimensions(screenCard.modelData.mode).join(" × ") + "  ·  " + Math.round(Number(screenCard.modelData.scale) * 100) + "%"
+              color: Qt.darker(root.bar.foreground, 1.35)
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.caption
+            }
+          }
+
+          MouseArea {
+            anchors.fill: parent
+            cursorShape: screenCard.modelData.mirror ? Qt.PointingHandCursor : (pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor)
+            drag.target: screenCard.modelData.mirror ? null : screenCard
+            onPressed: root.selectedIndex = screenCard.index
+            onReleased: if (!screenCard.modelData.mirror) root.commitDrag(screenCard.index, screenCard.x, screenCard.y)
+          }
+        }
+      }
+    }
+
+    Text {
+      width: parent.width
+      visible: root.errorText !== ""
+      textFormat: Text.PlainText
+      text: root.errorText
+      color: root.bar.urgent
+      wrapMode: Text.Wrap
+      font.family: root.bar.fontFamily
+      font.pixelSize: Style.font.body
+    }
+
+    PanelSeparator { foreground: root.bar.foreground }
+
+    Column {
+      width: parent.width
+      spacing: Style.space(10)
+      visible: root.selectedDisplay() !== null
+
+      RowLayout {
+        width: parent.width
+        spacing: Style.space(8)
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: Style.space(2)
+
+          Text {
+            Layout.fillWidth: true
+            textFormat: Text.PlainText
+            text: root.selectedDisplay() ? root.selectedDisplay().description : ""
+            color: root.bar.foreground
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.body
+            font.bold: true
+            elide: Text.ElideRight
+          }
+
+          Text {
+            textFormat: Text.PlainText
+            text: root.selectedDisplay() && root.selectedDisplay().mirror
+              ? root.selectedDisplay().name + " · mirrors " + root.selectedDisplay().mirror
+              : root.selectedDisplay() ? root.selectedDisplay().name + " · " + Math.round(root.selectedDisplay().x) + ", " + Math.round(root.selectedDisplay().y) : ""
+            color: Qt.darker(root.bar.foreground, 1.4)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
+          }
+        }
+      }
+
+      GridLayout {
+        width: parent.width
+        columns: 2
+        columnSpacing: Style.space(12)
+        rowSpacing: Style.space(10)
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          visible: root.displays.length > 1
+          spacing: Style.space(5)
+
+          SettingLabel { text: "DISPLAY MODE" }
+
+          Dropdown {
+            id: displayModeDropdown
+            Layout.fillWidth: true
+            showLabel: false; foreground: root.bar.foreground; background: Color.popups.background; popupBorder: Color.popups.border; accent: Color.accent; fontFamily: root.bar.fontFamily
+            options: root.displayModeOptions(root.selectedDisplay())
+            Component.onCompleted: sync()
+            onOptionsChanged: sync()
+            function sync() { var display = root.selectedDisplay(); if (display) value = display.mirror ? "mirror" : "extend" }
+            onChanged: function(nextValue) {
+              var display = root.selectedDisplay()
+              if (!display) return
+              if (nextValue === "extend") root.setDisplay(root.selectedIndex, { mirror: "" })
+              else { var sources = root.mirrorSourceOptions(display); if (sources.length) root.setDisplay(root.selectedIndex, { mirror: sources[0].value }) }
+              Qt.callLater(mirrorTargetDropdown.sync)
+            }
+          }
+        }
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: Style.space(5)
+
+          SettingLabel { text: "RESOLUTION" }
+
+          Dropdown {
+            id: resolutionDropdown
+            Layout.fillWidth: true
+            showLabel: false; foreground: root.bar.foreground; background: Color.popups.background; popupBorder: Color.popups.border; accent: Color.accent; fontFamily: root.bar.fontFamily
+            options: root.resolutionOptions(root.selectedDisplay())
+            Component.onCompleted: sync()
+            onOptionsChanged: sync()
+            function sync() { var display = root.selectedDisplay(); if (display) value = root.resolutionOf(display.mode) }
+            onChanged: function(nextValue) { var mode = root.modeForResolution(root.selectedDisplay(), nextValue); if (mode) root.setDisplay(root.selectedIndex, { mode: mode }); Qt.callLater(refreshDropdown.sync) }
+          }
+        }
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: Style.space(5)
+
+          SettingLabel { text: "REFRESH RATE" }
+
+          Dropdown {
+            id: refreshDropdown
+            Layout.fillWidth: true
+            showLabel: false; foreground: root.bar.foreground; background: Color.popups.background; popupBorder: Color.popups.border; accent: Color.accent; fontFamily: root.bar.fontFamily
+            options: root.refreshOptions(root.selectedDisplay())
+            Component.onCompleted: sync()
+            onOptionsChanged: sync()
+            function sync() { var display = root.selectedDisplay(); if (display) value = root.refreshOf(display.mode) }
+            onChanged: function(nextValue) { var display = root.selectedDisplay(); if (display) root.setDisplay(root.selectedIndex, { mode: root.resolutionOf(display.mode) + "@" + nextValue }) }
+          }
+        }
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: Style.space(5)
+
+          SettingLabel { text: "SCALE" }
+
+          Dropdown {
+            id: scaleDropdown
+            Layout.fillWidth: true
+            showLabel: false; foreground: root.bar.foreground; background: Color.popups.background; popupBorder: Color.popups.border; accent: Color.accent; fontFamily: root.bar.fontFamily
+            options: root.scaleOptions()
+            Component.onCompleted: sync()
+            function sync() { var display = root.selectedDisplay(); if (display) value = String(display.scale) }
+            onChanged: function(nextValue) { root.setDisplay(root.selectedIndex, { scale: Number(nextValue) }) }
+          }
+        }
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: Style.space(5)
+
+          SettingLabel { text: "ORIENTATION" }
+
+          Dropdown {
+            id: rotationDropdown
+            Layout.fillWidth: true
+            showLabel: false; foreground: root.bar.foreground; background: Color.popups.background; popupBorder: Color.popups.border; accent: Color.accent; fontFamily: root.bar.fontFamily
+            options: root.rotationOptions()
+            Component.onCompleted: sync()
+            function sync() { var display = root.selectedDisplay(); if (display) value = String(Math.max(0, Math.min(7, Number(display.transform)))) }
+            onChanged: function(nextValue) { root.setDisplay(root.selectedIndex, { transform: Number(nextValue) }) }
+          }
+        }
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          visible: root.selectedDisplay() && root.selectedDisplay().mirror
+          spacing: Style.space(5)
+
+          SettingLabel { text: "MIRROR SOURCE" }
+
+          Dropdown {
+            id: mirrorTargetDropdown
+            Layout.fillWidth: true
+            showLabel: false; foreground: root.bar.foreground; background: Color.popups.background; popupBorder: Color.popups.border; accent: Color.accent; fontFamily: root.bar.fontFamily
+            options: root.mirrorSourceOptions(root.selectedDisplay())
+            Component.onCompleted: sync()
+            onOptionsChanged: sync()
+            function sync() { var display = root.selectedDisplay(); if (display && display.mirror) value = String(display.mirror) }
+            onChanged: function(nextValue) { root.setDisplay(root.selectedIndex, { mirror: String(nextValue) }) }
+          }
+        }
+      }
+    }
+
+    PanelSeparator { foreground: root.bar.foreground }
+
+    RowLayout {
+      width: parent.width
+      Text { Layout.fillWidth: true; text: "Saved in ~/.config/hypr/monitors.lua"; color: Qt.darker(root.bar.foreground, 1.4); font.family: root.bar.fontFamily; font.pixelSize: Style.font.caption }
+      Button {
+        text: root.applying ? "Applying…" : "Apply layout"
+        bordered: true
+        active: true
+        enabled: !root.applying && !root.loading && root.displays.length > 0
+        onClicked: root.applyLayout()
+      }
+    }
+  }
+
+  component SettingLabel: Text {
+    textFormat: Text.PlainText
+    color: Qt.darker(root.bar.foreground, 1.4)
+    font.family: root.bar.fontFamily
+    font.pixelSize: Style.font.caption
+    font.bold: true
+    font.letterSpacing: 0.8
+  }
+}

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -111,6 +111,96 @@ function parseDisplays(raw) {
   }
 }
 
+function modeDimensions(mode) {
+  var match = String(mode || '').match(/^(\d+)x(\d+)@/)
+  return match ? [Number(match[1]), Number(match[2])] : [1920, 1080]
+}
+
+function logicalSize(display) {
+  var dimensions = modeDimensions(display.mode)
+  var width = Math.round(dimensions[0] / Number(display.scale || 1))
+  var height = Math.round(dimensions[1] / Number(display.scale || 1))
+  if (Number(display.transform) % 2 === 1) {
+    var swap = width
+    width = height
+    height = swap
+  }
+  return [width, height]
+}
+
+function rectAt(displays, index, movedIndex, movedX, movedY) {
+  var display = displays[index]
+  var size = logicalSize(display)
+  var x = index === movedIndex ? movedX : Number(display.x)
+  var y = index === movedIndex ? movedY : Number(display.y)
+  return { left: x, top: y, right: x + size[0], bottom: y + size[1] }
+}
+
+function rectsTouch(first, second) {
+  var verticalOverlap = Math.min(first.bottom, second.bottom) - Math.max(first.top, second.top)
+  var horizontalOverlap = Math.min(first.right, second.right) - Math.max(first.left, second.left)
+  var verticalEdge = first.right === second.left || second.right === first.left
+  var horizontalEdge = first.bottom === second.top || second.bottom === first.top
+  return (verticalEdge && verticalOverlap > 0) || (horizontalEdge && horizontalOverlap > 0)
+}
+
+function overlapsAt(displays, index, x, y) {
+  if (displays[index].mirror) return false
+  var candidate = rectAt(displays, index, index, x, y)
+  for (var i = 0; i < displays.length; i++) {
+    if (i === index || displays[i].mirror) continue
+    var other = rectAt(displays, i, -1, 0, 0)
+    if (candidate.left < other.right && candidate.right > other.left
+        && candidate.top < other.bottom && candidate.bottom > other.top) return true
+  }
+  return false
+}
+
+function layoutConnectedAt(displays, movedIndex, movedX, movedY) {
+  var extended = []
+  for (var i = 0; i < displays.length; i++) if (!displays[i].mirror) extended.push(i)
+  if (extended.length < 2) return true
+  var visited = [extended[0]]
+  for (var cursor = 0; cursor < visited.length; cursor++) {
+    var current = visited[cursor]
+    var currentRect = rectAt(displays, current, movedIndex, movedX, movedY)
+    for (var candidateIndex = 0; candidateIndex < extended.length; candidateIndex++) {
+      var candidate = extended[candidateIndex]
+      if (visited.indexOf(candidate) >= 0) continue
+      if (rectsTouch(currentRect, rectAt(displays, candidate, movedIndex, movedX, movedY))) visited.push(candidate)
+    }
+  }
+  return visited.length === extended.length
+}
+
+function nearestValidPosition(displays, index, desiredX, desiredY) {
+  if (displays[index].mirror) return { x: Number(displays[index].x), y: Number(displays[index].y) }
+  var size = logicalSize(displays[index])
+  var xChoices = [desiredX]
+  var yChoices = [desiredY]
+  for (var i = 0; i < displays.length; i++) {
+    if (i === index || displays[i].mirror) continue
+    var otherSize = logicalSize(displays[i])
+    xChoices.push(Number(displays[i].x) - size[0], Number(displays[i].x) + otherSize[0])
+    yChoices.push(Number(displays[i].y) - size[1], Number(displays[i].y) + otherSize[1])
+  }
+  var best = null
+  var bestDistance = Infinity
+  for (var xIndex = 0; xIndex < xChoices.length; xIndex++) {
+    for (var yIndex = 0; yIndex < yChoices.length; yIndex++) {
+      var x = Math.round(xChoices[xIndex])
+      var y = Math.round(yChoices[yIndex])
+      if (overlapsAt(displays, index, x, y) || !layoutConnectedAt(displays, index, x, y)) continue
+      var distance = Math.pow(x - desiredX, 2) + Math.pow(y - desiredY, 2)
+      if (distance < bestDistance) {
+        best = { x: x, y: y }
+        bestDistance = distance
+      }
+    }
+  }
+  return best || { x: Number(displays[index].x), y: Number(displays[index].y) }
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampBrightness: clampBrightness,
@@ -119,6 +209,11 @@ if (typeof module !== "undefined") {
     matchingScaleIndex: matchingScaleIndex,
     availableScales: availableScales,
     brightnessName: brightnessName,
-    parseDisplays: parseDisplays
+    parseDisplays: parseDisplays,
+    modeDimensions: modeDimensions,
+    logicalSize: logicalSize,
+    overlapsAt: overlapsAt,
+    layoutConnectedAt: layoutConnectedAt,
+    nearestValidPosition: nearestValidPosition
   }
 }

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -26,6 +26,7 @@ Panel {
   property string monitorScale: ""
   property var displays: []
   property int enabledDisplayCount: 0
+  property bool layoutEditorOpen: false
 
   // Carry sub-notch touchpad deltas between wheel events.
   property real wheelAccumulator: 0
@@ -227,6 +228,10 @@ Panel {
     function toggle() { root.toggle() }
     function show() { root.open() }
     function hide() { root.close() }
+    function arrange() {
+      root.open()
+      root.layoutEditorOpen = true
+    }
   }
 
   function refresh() {
@@ -365,6 +370,8 @@ Panel {
         selectedIndex = 0
       }
       cursorActive = false
+    } else {
+      layoutEditorOpen = false
     }
   }
 
@@ -488,8 +495,11 @@ Panel {
     bar: root.bar
     open: root.opened
     focusTarget: keyCatcher
-    contentWidth: panel.fittedContentWidth(Style.space(380))
-    contentHeight: panel.fittedContentHeight(panelColumn.implicitHeight, Style.space(560))
+    contentWidth: panel.fittedContentWidth(Style.space(root.layoutEditorOpen ? 620 : 380))
+    contentHeight: panel.fittedContentHeight(
+      root.layoutEditorOpen && layoutLoader.item ? layoutLoader.item.implicitHeight : panelColumn.implicitHeight,
+      Style.space(root.layoutEditorOpen ? 700 : 560)
+    )
 
     PanelKeyCatcher {
       id: keyCatcher
@@ -504,12 +514,16 @@ Panel {
         }
       }
       onActivateRequested: if (root.cursorActive) root.activateCursor()
-      onCloseRequested: root.close()
+      onCloseRequested: {
+        if (root.layoutEditorOpen) root.layoutEditorOpen = false
+        else root.close()
+      }
       onTabRequested: function(direction) { root.switchPanel(direction) }
 
       ScrollView {
         id: scrollArea
         anchors.fill: parent
+        visible: !root.layoutEditorOpen
         clip: true
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
         ScrollBar.vertical.policy: panelColumn.implicitHeight > height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
@@ -788,6 +802,18 @@ Panel {
                 }
               }
             }
+
+            Button {
+              width: parent.width
+              text: "Advanced"
+              fontSize: Style.font.caption
+              foreground: root.bar.foreground
+              fontFamily: root.bar.fontFamily
+              horizontalPadding: Style.spacing.sm
+              verticalPadding: Style.spacing.controlPaddingY
+              bordered: true
+              onClicked: root.layoutEditorOpen = true
+            }
           }
 
           // ---------- Monitors ----------
@@ -824,6 +850,19 @@ Panel {
           Item {
             width: parent.width
             height: Style.space(4)
+          }
+        }
+      }
+
+      Loader {
+        id: layoutLoader
+        anchors.fill: parent
+        active: root.layoutEditorOpen
+        sourceComponent: Component {
+          LayoutView {
+            bar: root.bar
+            onBackRequested: root.layoutEditorOpen = false
+            onApplied: root.refresh()
           }
         }
       }

--- a/shell/plugins/panels/monitor/back.svg
+++ b/shell/plugins/panels/monitor/back.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M15 5l-7 7 7 7" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/shell/plugins/panels/monitor/manifest.json
+++ b/shell/plugins/panels/monitor/manifest.json
@@ -4,7 +4,7 @@
   "name": "Display",
   "version": "1.0.0",
   "author": "Omarchy",
-  "description": "Brightness slider and laptop display controls",
+  "description": "Brightness, text scaling, and visual display layout controls",
   "kinds": [
     "bar-widget"
   ],
@@ -13,7 +13,7 @@
   },
   "barWidget": {
     "displayName": "Display",
-    "description": "Brightness slider and laptop display controls",
+    "description": "Brightness, text scaling, and visual display layout controls",
     "category": "System",
     "allowMultiple": false
   }

--- a/shell/plugins/panels/monitor/refresh.svg
+++ b/shell/plugins/panels/monitor/refresh.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M20 6v5h-5M4 18v-5h5M5.6 9A7 7 0 0 1 18.8 7.2L20 11M4 13l1.2 3.8A7 7 0 0 0 18.4 15"
+        stroke="#ffffff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/test/shell.d/monitor-layout-test.sh
+++ b/test/shell.d/monitor-layout-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+python3 - "$ROOT" <<'PY'
+import importlib.machinery
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+from unittest import mock
+
+
+root = pathlib.Path(sys.argv[1])
+script = root / "bin" / "omarchy-monitor-layout"
+loader = importlib.machinery.SourceFileLoader("monitor_layout", str(script))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+backend = importlib.util.module_from_spec(spec)
+loader.exec_module(backend)
+
+connected = [
+    {
+        "name": "DP-1",
+        "description": "First",
+        "width": 2560,
+        "height": 1440,
+        "modes": ["2560x1440@144.00Hz"],
+    },
+    {
+        "name": "DP-2",
+        "description": "Second",
+        "width": 1920,
+        "height": 1080,
+        "modes": ["1920x1080@60.00Hz"],
+    },
+]
+
+layout = [
+    {"name": "DP-1", "mode": "2560x1440@144.00", "x": 0, "y": 0, "scale": 1, "transform": 0},
+    {"name": "DP-2", "mode": "1920x1080@60.00", "x": 2560, "y": 0, "scale": 1, "transform": 0},
+]
+
+with mock.patch.object(backend, "monitors", return_value=connected):
+    clean = backend.validate_layout(layout)
+assert len(clean) == 2
+print("ok - monitor layout accepts advertised modes on connected edges")
+
+overlap = [dict(layout[0]), dict(layout[1], x=2000)]
+with mock.patch.object(backend, "monitors", return_value=connected):
+    try:
+        backend.validate_layout(overlap)
+    except ValueError as error:
+        assert "overlap" in str(error)
+    else:
+        raise AssertionError("overlapping layout was accepted")
+print("ok - monitor layout rejects overlaps")
+
+legacy = "-- user settings\n\n" + backend.LEGACY_BEGIN + "\nold\n" + backend.LEGACY_END + "\n"
+updated = backend.replace_block(legacy, backend.managed_block(clean))
+assert backend.LEGACY_BEGIN not in updated
+assert updated.count(backend.BEGIN) == 1
+assert "-- user settings" in updated
+print("ok - monitor layout migrates Omarview blocks without touching user settings")
+
+payload = json.dumps(layout)
+with tempfile.TemporaryDirectory() as directory:
+    config = pathlib.Path(directory) / "monitors.lua"
+    original = "-- exact original\n"
+    config.write_text(original)
+    results = [mock.Mock(stdout=""), mock.Mock(stdout="bad config"), mock.Mock(stdout="")]
+    with (
+        mock.patch.object(backend, "CONFIG", config),
+        mock.patch.object(backend, "monitors", return_value=connected),
+        mock.patch.object(backend.subprocess, "run", side_effect=results),
+    ):
+        try:
+            backend.apply_layout(payload)
+        except RuntimeError as error:
+            assert "bad config" in str(error)
+        else:
+            raise AssertionError("invalid Hyprland configuration was accepted")
+    assert config.read_text() == original
+print("ok - monitor layout restores monitors.lua after a Hyprland config error")
+PY

--- a/test/shell.d/monitor-test.sh
+++ b/test/shell.d/monitor-test.sh
@@ -75,4 +75,18 @@ assertDeepEqual(
 )
 
 assertDeepEqual(monitor.parseDisplays('{'), { displays: [], enabledDisplayCount: 0 }, 'monitor handles invalid display JSON')
+
+const landscape = { name: 'DP-1', mode: '2560x1440@144.00', x: 0, y: 0, scale: 1, transform: 0, mirror: '' }
+const portrait = { name: 'DP-2', mode: '1920x1080@60.00', x: 2560, y: 0, scale: 1, transform: 1, mirror: '' }
+
+assertDeepEqual(monitor.modeDimensions(landscape.mode), [2560, 1440], 'monitor parses layout mode dimensions')
+assertDeepEqual(monitor.logicalSize(portrait), [1080, 1920], 'monitor swaps logical dimensions for portrait rotation')
+assertEqual(monitor.overlapsAt([landscape, portrait], 1, 2000, 0), true, 'monitor layout rejects overlapping displays')
+assertEqual(monitor.layoutConnectedAt([landscape, portrait], 1, 2560, 0), true, 'monitor layout accepts touching display edges')
+assertEqual(monitor.layoutConnectedAt([landscape, portrait], 1, 3000, 0), false, 'monitor layout rejects disconnected displays')
+assertDeepEqual(
+  monitor.nearestValidPosition([landscape, portrait], 1, 2700, 200),
+  { x: 2560, y: 200 },
+  'monitor layout snaps a dragged display back to the nearest connected edge'
+)
 JS


### PR DESCRIPTION
## Summary

- add an Advanced view to the existing Display panel instead of introducing another bar widget
- support visual monitor arrangement, extend/mirror modes, resolution, refresh rate, scale, and orientation
- validate layouts before atomically updating `~/.config/hypr/monitors.lua`, migrate legacy Omarview-managed blocks, and roll back when Hyprland reports configuration errors

## Verification

- `./test/cli`
- `bash test/shell.d/qml-text-format-test.sh`
- `bash test/shell.d/monitor-test.sh`
- `bash test/shell.d/monitor-layout-test.sh`
- `bash test/shell.d/monitor-state-test.sh`
- `bash test/shell.d/manifest-entrypoints-test.sh`
- `bash test/shell.d/plugins-test.sh`
- live visual verification at 2560×1600 with 1.6× scaling

The compact Display view remains unchanged apart from the Advanced entry point. The editor uses the shell theme tokens and keeps the back/refresh actions as icon-only SVG controls.