### PR TITLE
Stop mise wrappers from re-executing themselves (breaks Claude Code detection in T3 Code)

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -23,7 +23,7 @@ cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
 mise use -g --quiet "$package" || exit 1
-exec mise x "$package" -- "$bin" "\$@"
+exec mise x "$package" -- "\$(mise which "$bin")" "\$@"
 EOF
 
 chmod +x "$HOME/.local/bin/$command"


### PR DESCRIPTION
## Problem

The wrapper generated by `bin/omarchy-mise-install` runs:

```bash
exec mise x "$package" -- "$bin" "$@"
```

`mise x` resolves `$bin` via PATH. If `~/.local/bin` appears **before** `~/.local/share/mise/installs/<tool>/latest`, `$bin` resolves to the wrapper itself and it re-executes forever. mise only *prepends* the install dir when it is not already on PATH — if the dir is already present further down, it keeps its position, so `~/.local/bin/claude` keeps winning.

Interactive shells never see this: `mise activate` puts the install dir first. Non-shell launchers (Electron apps, `.desktop` entries, systemd units) do.

### Concrete case: T3 Code cannot detect Claude Code

[T3 Code](https://github.com/pingdotgg/t3code) spawns `claude --version` (4 s timeout) to detect the Claude Agent CLI. Its server process derives PATH from a login shell, which on Omarchy comes out as:

```
~/.bun/bin:~/.local/bin:…:~/.local/share/mise/installs/claude/latest:…:~/.local/share/mise/shims:…
```

`claude` → `~/.local/bin/claude` (the wrapper) → `mise x claude -- claude` → `~/.local/bin/claude` → … The probe spins, printing `mise ~/.config/mise/config.toml tools: claude@2.1.248` thousands of times, until T3 kills it. Its trace log shows:

```
"Claude Agent CLI version probe exited with a non-zero status." {"exitCode":1,"stdoutLength":8100,...}
runClaudeCommand … durationMs 4003 … "InterruptError: All fibers interrupted"
```

and the UI reports Claude as not installed. Same applies to `codex` and every other wrapper.

### Reproduce

```bash
PATH=~/.local/bin:/usr/bin:~/.local/share/mise/installs/claude/latest timeout 5 claude --version
echo $?   # 124, CPU pegged, stdout full of repeated "mise … tools: claude@…" lines
```

## Fix

Hand `mise x` the absolute path from `mise which` instead of a bare name, so no PATH lookup happens. `mise x` is kept so the tool environment it sets up (e.g. `node` for npm-backed packages) is unchanged.

```bash
exec mise x "$package" -- "\$(mise which "$bin")" "\$@"
```

Verified with the exact T3 Code PATH: old form loops until timeout (rc=124), new form answers in ~12 ms; T3 Code then detects Claude Code normally. `mise which` also resolves `codex` and `gh` (bin name ≠ package name) correctly.

https://claude.ai/code/session_01Er7PXFnS9TZEM4ahK184Dt