### PR TITLE
Apply the configured keyboard layout on the SDDM greeter

### DIFF
--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -1,58 +1,15 @@
 -- https://wiki.hypr.land/Configuring/Basics/Variables/#input
 
-local function read_vconsole()
-  local values = {}
-  local file = io.open("/etc/vconsole.conf", "r")
-  if not file then
-    return values
-  end
-
-  for line in file:lines() do
-    local key, value = line:match("^%s*([%w_]+)%s*=%s*(.-)%s*$")
-    if key and value then
-      value = value:gsub("%s+#.*$", "")
-      value = value:gsub('^"(.*)"$', "%1")
-      value = value:gsub("^'(.*)'$", "%1")
-      values[key] = value
-    end
-  end
-
-  file:close()
-  return values
-end
-
--- Layouts that can't type Latin letters. Keep in sync with the list in
--- etc/mkinitcpio.conf.d/omarchy_hooks.conf.
-local non_latin_layouts =
-  " af am ara bd bg by et ge gr il in iq ir kg kh kz la lk mk mm mn mv np rs ru sy th tj ua "
-
-local vconsole = read_vconsole()
-
-local kb_layout = vconsole.XKBLAYOUT or "us"
-local kb_variant = vconsole.XKBVARIANT or ""
--- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
--- Both Shifts together is the usual home for it, but it's easy to hit by
--- accident while typing. The _cancel variant sets Caps Lock the same way and
--- releases it on the next lone Shift, so a misfire clears itself.
-local kb_options = "compose:caps,shift:both_capslock_cancel"
-
--- Hyprland resolves keybindings against the first entry in kb_layout, not the
--- layout that's currently active, so Omarchy's Latin-keysym bindings (SUPER + W
--- and friends) only fire when a Latin layout leads. Installing with a non-Latin
--- one would otherwise leave the desktop unusable.
-if non_latin_layouts:find(" " .. kb_layout:match("^[^,]*") .. " ", 1, true) then
-  kb_layout = "us," .. kb_layout
-  kb_variant = "," .. kb_variant
-  -- Reach the original layout with Left Alt + Right Alt.
-  kb_options = kb_options .. ",grp:alts_toggle"
-end
+-- The layout resolution lives in default/hypr/keyboard.lua so the SDDM greeter
+-- can share it and type passwords with the same layout as the session.
+local keyboard = require("default.hypr.keyboard")
 
 hl.config({
   input = {
-    kb_layout = kb_layout,
-    kb_variant = kb_variant,
+    kb_layout = keyboard.kb_layout,
+    kb_variant = keyboard.kb_variant,
     kb_model = "",
-    kb_options = kb_options,
+    kb_options = keyboard.kb_options,
     kb_rules = "",
     follow_mouse = 1,
     sensitivity = 0,

--- a/default/hypr/keyboard.lua
+++ b/default/hypr/keyboard.lua
@@ -1,0 +1,58 @@
+-- Resolve the keyboard layout from /etc/vconsole.conf into the values a
+-- Hyprland input block expects. Shared by the user session
+-- (default/hypr/input.lua) and the SDDM greeter (default/sddm/hyprland.lua) so
+-- text and passwords are typed with the same layout in both places.
+-- https://wiki.hypr.land/Configuring/Basics/Variables/#input
+
+local function read_vconsole()
+  local values = {}
+  local file = io.open("/etc/vconsole.conf", "r")
+  if not file then
+    return values
+  end
+
+  for line in file:lines() do
+    local key, value = line:match("^%s*([%w_]+)%s*=%s*(.-)%s*$")
+    if key and value then
+      value = value:gsub("%s+#.*$", "")
+      value = value:gsub('^"(.*)"$', "%1")
+      value = value:gsub("^'(.*)'$", "%1")
+      values[key] = value
+    end
+  end
+
+  file:close()
+  return values
+end
+
+-- Layouts that can't type Latin letters. Keep in sync with the list in
+-- etc/mkinitcpio.conf.d/omarchy_hooks.conf.
+local non_latin_layouts =
+  " af am ara bd bg by et ge gr il in iq ir kg kh kz la lk mk mm mn mv np rs ru sy th tj ua "
+
+local vconsole = read_vconsole()
+
+local kb_layout = vconsole.XKBLAYOUT or "us"
+local kb_variant = vconsole.XKBVARIANT or ""
+-- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
+-- Both Shifts together is the usual home for it, but it's easy to hit by
+-- accident while typing. The _cancel variant sets Caps Lock the same way and
+-- releases it on the next lone Shift, so a misfire clears itself.
+local kb_options = "compose:caps,shift:both_capslock_cancel"
+
+-- Hyprland resolves keybindings against the first entry in kb_layout, not the
+-- layout that's currently active, so Omarchy's Latin-keysym bindings (SUPER + W
+-- and friends) only fire when a Latin layout leads. Installing with a non-Latin
+-- one would otherwise leave the desktop unusable.
+if non_latin_layouts:find(" " .. kb_layout:match("^[^,]*") .. " ", 1, true) then
+  kb_layout = "us," .. kb_layout
+  kb_variant = "," .. kb_variant
+  -- Reach the original layout with Left Alt + Right Alt.
+  kb_options = kb_options .. ",grp:alts_toggle"
+end
+
+return {
+  kb_layout = kb_layout,
+  kb_variant = kb_variant,
+  kb_options = kb_options,
+}

--- a/default/sddm/hyprland.lua
+++ b/default/sddm/hyprland.lua
@@ -1,6 +1,27 @@
 -- Minimal Hyprland config for the SDDM Wayland greeter.
 -- SDDM starts the greeter itself after the compositor is ready.
+
+-- Type the password with the same keyboard layout as the user session. The
+-- greeter runs without bootstrap.lua, so reach Omarchy's Lua modules by hand.
+-- Guard every step: a greeter that errors out locks everyone out, so any
+-- failure falls back to Hyprland's default layout instead.
+local input = {}
+if package and require and pcall then
+  package.path = (os.getenv("OMARCHY_PATH") or "/usr/share/omarchy")
+    .. "/?.lua;" .. package.path
+  local ok, keyboard = pcall(require, "default.hypr.keyboard")
+  if ok and type(keyboard) == "table" then
+    input = {
+      kb_layout = keyboard.kb_layout,
+      kb_variant = keyboard.kb_variant,
+      kb_options = keyboard.kb_options,
+    }
+  end
+end
+
 hl.config({
+  input = input,
+
   misc = {
     disable_hyprland_logo = true,
     disable_splash_rendering = true,

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -74,12 +74,72 @@ assert_input "non-latin layout in front gains us even when us trails" "[us,il,us
 '
 
 hooks_conf="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
-input_lua="$ROOT/default/hypr/input.lua"
+keyboard_lua="$ROOT/default/hypr/keyboard.lua"
 
 hooks_layouts=$(awk -F')' '/\) ;;$/ { gsub(/[[:space:]|]+/, "\n", $1); print $1 }' "$hooks_conf" | grep '^[a-z]\+$' | sort)
-lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$input_lua" | grep -o '"[^"]*"' | tr -d '"' | tr ' ' '\n' | grep '^[a-z]\+$' | sort)
+lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$keyboard_lua" | grep -o '"[^"]*"' | tr -d '"' | tr ' ' '\n' | grep '^[a-z]\+$' | sort)
 
 [[ -n $hooks_layouts ]] || fail "non-latin layout list is readable from omarchy_hooks.conf"
 [[ $hooks_layouts == "$lua_layouts" ]] ||
   fail "non-latin layout lists stay in sync" "$(diff <(echo "$hooks_layouts") <(echo "$lua_layouts"))"
 pass "non-latin layout lists stay in sync with the initramfs hook"
+
+# The SDDM greeter runs its own minimal Hyprland without bootstrap.lua, so it
+# must reach the shared resolver on its own and hand the greeter the same layout
+# the session uses. Otherwise the password field falls back to us/QWERTY.
+greeter_input() {
+  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua <<'LUA'
+local vconsole = os.getenv("OMARCHY_VCONSOLE")
+local real_open = io.open
+
+io.open = function(path, mode)
+  if path ~= "/etc/vconsole.conf" then
+    return real_open(path, mode)
+  end
+
+  if not vconsole then
+    return nil
+  end
+
+  local file = io.tmpfile()
+  file:write(vconsole)
+  file:seek("set")
+  return file
+end
+
+hl = {
+  config = function(config)
+    local input = config.input
+    print(("[%s] [%s] [%s]"):format(
+      input.kb_layout or "nil",
+      input.kb_variant or "nil",
+      input.kb_options or "nil"
+    ))
+  end,
+}
+
+require("default.sddm.hyprland")
+LUA
+}
+
+assert_greeter() {
+  local description="$1"
+  local expected="$2"
+  local actual
+
+  if (( $# > 2 )); then
+    actual=$(greeter_input "$3")
+  else
+    actual=$(greeter_input)
+  fi
+
+  [[ $actual == "$expected" ]] ||
+    fail "$description" "expected: $expected"$'\n'"actual:   $actual"
+  pass "$description"
+}
+
+assert_greeter "greeter types the configured latin layout" "[fr] [] [$base_options]" 'XKBLAYOUT=fr
+'
+assert_greeter "greeter mirrors the session for non-latin layouts" "[us,ru] [,] [$toggle_options]" 'XKBLAYOUT=ru
+'
+assert_greeter "greeter falls back to us without vconsole" "[us] [] [$base_options]"


### PR DESCRIPTION
## Problem

The SDDM Wayland greeter starts its own minimal Hyprland from `default/sddm/hyprland.lua`, which only sets `misc`/`animations`. The layout resolution from `/etc/vconsole.conf` lives solely in `default/hypr/input.lua` (the user session), so **the greeter always falls back to `us`/QWERTY**.

Anyone whose configured layout differs from US (e.g. `fr`, `de`) gets a QWERTY password field on the login/lock greeter, even though `localectl`, the console and the session are all correct. Switching the greeter to `hyprland.lua` (as the current wayland conf does) does not help, because that file never applied a layout in the first place.

## Fix

- Extract the vconsole → `kb_layout`/`kb_variant`/`kb_options` resolution into a new pure module `default/hypr/keyboard.lua` (single source of truth).
- `default/hypr/input.lua` now consumes it (behavior unchanged for the session).
- `default/sddm/hyprland.lua` loads the same module and applies the layout to the greeter, so the password field matches the session.

The greeter loads the module **defensively**: it runs without `bootstrap.lua`, so it extends `package.path` by hand and guards every step (`package`/`require`/`pcall`). Any failure falls back to Hyprland's default layout rather than breaking the login screen.

## Tests

`test/shell.d/hyprland-keyboard-layout-test.sh`:
- the non-latin-list sync check now reads `keyboard.lua`;
- added three greeter cases: configured latin layout passes through, non-latin mirrors the session (`us,` prepended + `grp:alts_toggle`), and a missing `vconsole.conf` falls back to `us`.

All keyboard tests pass. The pre-existing failures on a bare clone (missing `omarchy-pkgs` sibling checkout, live-Quickshell IPC, VM mounts) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)