### PR TITLE
Preload lock wallpaper for resume

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -95,8 +95,10 @@ Item {
       anchors.fill: parent
       source: root.loadBackground ? root.fileUrl(root.backgroundPath) : ""
       fillMode: Image.PreserveAspectCrop
-      asynchronous: true
-      cache: false
+      // Service.qml preloads this exact URL and output size while unlocked,
+      // so a recreated lock surface can paint the wallpaper on its first frame.
+      asynchronous: false
+      cache: true
       sourceSize.width: width
       sourceSize.height: height
     }

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -53,6 +53,12 @@ Item {
     return realScreenCount() > 0
   }
 
+  function backgroundFileUrl(path) {
+    if (!path) return ""
+    var encoded = String(path).split("/").map(encodeURIComponent).join("/")
+    return "file://" + encoded + "?v=" + backgroundVersion
+  }
+
   function queueSessionLock() {
     pendingSessionLock = true
     if (!sessionLockStabilizeTimer.running) logEvent("lock-pending: screen-stabilizing")
@@ -372,6 +378,23 @@ Item {
           root.backgroundVersion += 1
         }
       }
+    }
+  }
+
+  // Decode the exact wallpaper size for each active output while unlocked.
+  // A lock surface recreated after system resume can then paint its first
+  // frame from the shared image cache instead of exposing its fallback color.
+  Variants {
+    model: Quickshell.screens
+
+    Image {
+      required property var modelData
+      visible: false
+      asynchronous: true
+      cache: true
+      source: root.backgroundFileUrl(root.backgroundPath)
+      sourceSize.width: Math.max(1, modelData.width)
+      sourceSize.height: Math.max(1, modelData.height)
     }
   }
 

--- a/test/shell.d/lock-background-preload-test.sh
+++ b/test/shell.d/lock-background-preload-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(`${root}/shell/plugins/lock/Service.qml`, 'utf8')
+const viewQml = fs.readFileSync(`${root}/shell/plugins/lock/LockView.qml`, 'utf8')
+
+assert(
+  /Variants \{\s*model: Quickshell\.screens[\s\S]*Image \{[\s\S]*visible: false[\s\S]*source: root\.backgroundFileUrl\(root\.backgroundPath\)/.test(serviceQml),
+  'the lock service preloads one hidden wallpaper image per output'
+)
+
+assert(
+  /sourceSize\.width: Math\.max\(1, modelData\.width\)[\s\S]*sourceSize\.height: Math\.max\(1, modelData\.height\)/.test(serviceQml),
+  'preloaded wallpapers match each output size'
+)
+
+assert(
+  /source: root\.loadBackground \? root\.fileUrl\(root\.backgroundPath\) : ""[\s\S]*asynchronous: false[\s\S]*cache: true/.test(viewQml),
+  'lock surfaces synchronously reuse the preloaded cache entry'
+)
+
+assert(
+  /function backgroundFileUrl\(path\)[\s\S]*"file:\/\/" \+ encoded \+ "\?v=" \+ backgroundVersion/.test(serviceQml),
+  'the preloader uses the same cache-busted URL as LockView'
+)
+JS


### PR DESCRIPTION
## Problem

A lock output recreated after system resume can paint only `Color.background` while its wallpaper decodes asynchronously. On the affected dual-DisplayPort system this produced a gray lock screen for roughly two seconds, sometimes until input caused another visible frame.

`LockView` uses `asynchronous: true` and `cache: false` even though the service already knows the wallpaper and active output sizes while the session is unlocked.

Fixes #9182.

## Change

- preload the cache-busted lock wallpaper once per active output at the exact output size
- keep preloading asynchronous and invisible while the session is unlocked
- make recreated lock views synchronously reuse the same URL, size and shared image cache entry

The current background-version query remains the cache invalidation boundary, so changing wallpapers cannot reuse stale pixels.

## Verification

- `bash test/shell.d/lock-background-preload-test.sh`
- `bash test/shell.d/lock-password-overflow-test.sh`
- `bash test/shell.d/lock-fingerprint-indicator-test.sh`
- `git diff --check`
- hardware verification on two recreated NVIDIA/DisplayPort lock outputs: the local equivalent removed the flat gray resume frame and restored the blurred wallpaper immediately