### PR TITLE
Keep idle lock transition blank

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -14,6 +14,7 @@ Item {
   property int failedAttempts: 0
   property bool inputEnabled: true
   property bool loadBackground: true
+  property bool concealAuthentication: false
   property string passwordText: ""
   property bool syncingPasswordText: false
 
@@ -42,6 +43,7 @@ Item {
   signal passwordTextEdited(string password)
   signal clearFailureRequested()
   signal wakeRequested()
+  signal pointerWakeRequested()
 
   // Cache-busts the lock background by appending `?v=`. Adding a query
   // string keeps Image's loader happy while forcing it to reload when the
@@ -88,12 +90,12 @@ Item {
 
   Rectangle {
     anchors.fill: parent
-    color: Color.background
+    color: root.concealAuthentication ? "black" : Color.background
 
     Image {
       id: wallpaper
       anchors.fill: parent
-      source: root.loadBackground ? root.fileUrl(root.backgroundPath) : ""
+      source: root.loadBackground && !root.concealAuthentication ? root.fileUrl(root.backgroundPath) : ""
       fillMode: Image.PreserveAspectCrop
       asynchronous: true
       cache: false
@@ -104,6 +106,7 @@ Item {
     MultiEffect {
       anchors.fill: wallpaper
       source: wallpaper
+      visible: !root.concealAuthentication
       autoPaddingEnabled: false
       blurEnabled: root.loadBackground && wallpaper.status === Image.Ready
       blur: 1.0
@@ -115,8 +118,9 @@ Item {
     MouseArea {
       anchors.fill: parent
       hoverEnabled: true
-      onClicked: { root.wakeRequested(); root.forcePasswordFocus() }
-      onPositionChanged: root.wakeRequested()
+      cursorShape: root.concealAuthentication ? Qt.BlankCursor : Qt.ArrowCursor
+      onClicked: { root.pointerWakeRequested(); root.forcePasswordFocus() }
+      onPositionChanged: root.pointerWakeRequested()
     }
 
     BorderSurface {
@@ -128,6 +132,7 @@ Item {
       borderSpec: root.inputBorderSpec
       radius: Style.cornerRadius
       clip: true
+      opacity: root.concealAuthentication ? 0 : 1
 
       TextInput {
         id: passwordInput

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -33,6 +33,10 @@ Item {
   property string lastEventAt: ""
   property bool strandedLock: false
   property bool strandedLockResolved: false
+  property bool displayBlanked: false
+  property bool pointerWakeArmed: false
+
+  readonly property int pointerWakeSettleSeconds: 1
 
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
@@ -154,6 +158,8 @@ Item {
     pendingSessionLockTimer.stop()
     resetAuthenticationState()
     idleBlankTimer.stop()
+    displayBlanked = false
+    pointerWakeArmed = false
     sessionLock.locked = false
     logEvent("unlocked")
     runWake()
@@ -165,12 +171,34 @@ Item {
   }
 
   function runWake() {
+    displayBlanked = false
+    pointerWakeArmed = false
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
   }
 
   function runBlank() {
+    displayBlanked = true
+    pointerWakeArmed = false
     if (!blankProcess.running) blankProcess.running = true
+  }
+
+  function handlePointerWake() {
+    // Mapping the lock surface reports the pointer position before any real
+    // user motion. Ignore that initialization until compositor-side idle has
+    // settled; the next actual pointer activity wakes normally.
+    if (displayBlanked && !pointerWakeArmed) return
+    runWake()
+  }
+
+  function handlePointerWakeMonitorChanged() {
+    if (!root.displayBlanked) return
+
+    if (pointerWakeMonitor.isIdle) {
+      root.pointerWakeArmed = true
+    } else if (root.pointerWakeArmed) {
+      root.runWake()
+    }
   }
 
   function submitPassword(value) {
@@ -276,11 +304,13 @@ Item {
         failedAttempts: root.failedAttempts
         inputEnabled: root.lockRequested
         loadBackground: root.locked
+        concealAuthentication: root.displayBlanked
         passwordText: root.enteredPassword
         onPasswordTextEdited: function(password) { root.enteredPassword = password }
         onSubmitPassword: function(password) { root.submitPassword(password) }
         onClearFailureRequested: root.failureMessage = ""
         onWakeRequested: root.runWake()
+        onPointerWakeRequested: root.handlePointerWake()
       }
 
     }
@@ -373,6 +403,14 @@ Item {
         }
       }
     }
+  }
+
+  IdleMonitor {
+    id: pointerWakeMonitor
+    enabled: root.displayBlanked
+    timeout: root.pointerWakeSettleSeconds
+    respectInhibitors: false
+    onIsIdleChanged: root.handlePointerWakeMonitorChanged()
   }
 
   Process {
@@ -516,6 +554,15 @@ Item {
       return "ok"
     }
 
+    function lockAndBlank(): string {
+      if (!root.passwordPamConfigured) return "missing-pam"
+      if (!root.locked && !root.beginLock()) return "failed"
+
+      idleBlankTimer.stop()
+      root.runBlank()
+      return "ok"
+    }
+
     function isLocked(): string {
       return root.locked ? "true" : "false"
     }
@@ -531,6 +578,9 @@ Item {
         passwordPam: root.passwordPamConfigured,
         fingerprint: root.fingerprintConfigured,
         authenticating: root.authenticating,
+        displayBlanked: root.displayBlanked,
+        authenticationConcealed: root.displayBlanked,
+        pointerWakeArmed: root.pointerWakeArmed,
         lastEvent: root.lastEvent,
         lastEventAt: root.lastEventAt
       })

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -76,7 +76,10 @@ Item {
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()
-    runProcess(lockProcess, "lock", "omarchy-system-lock")
+    // The screensaver is already dark. Ask the lock service to keep real DPMS
+    // off while the secure surface replaces it, then run the normal cleanup
+    // path regardless of whether that optional IPC request succeeded.
+    runProcess(lockProcess, "lock", "omarchy-shell lock lockAndBlank >/dev/null 2>&1 || true; omarchy-system-lock")
   }
 
   function startIdleCycle() {

--- a/test/shell.d/idle-lock-blank-transition-test.sh
+++ b/test/shell.d/idle-lock-blank-transition-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const idleQml = fs.readFileSync(`${root}/shell/plugins/services/idle/Service.qml`, 'utf8')
+const lockQml = fs.readFileSync(`${root}/shell/plugins/lock/Service.qml`, 'utf8')
+const viewQml = fs.readFileSync(`${root}/shell/plugins/lock/LockView.qml`, 'utf8')
+
+assert(
+  /omarchy-shell lock lockAndBlank >\/dev\/null 2>&1 \|\| true; omarchy-system-lock/.test(idleQml),
+  'idle lock requests a dark transition without bypassing normal lock cleanup'
+)
+
+assert(
+  /function lockAndBlank\(\): string \{[\s\S]*idleBlankTimer\.stop\(\)[\s\S]*root\.runBlank\(\)/.test(lockQml),
+  'the lock service blanks immediately for an already-dark idle transition'
+)
+
+assert(
+  /function runBlank\(\) \{[\s\S]*?displayBlanked = true[\s\S]*?pointerWakeArmed = false/.test(lockQml),
+  'blanking resets pointer wake arming'
+)
+
+assert(
+  /concealAuthentication: root\.displayBlanked/.test(lockQml)
+    && /property bool concealAuthentication: false/.test(viewQml)
+    && /color: root\.concealAuthentication \? "black" : Color\.background/.test(viewQml)
+    && /opacity: root\.concealAuthentication \? 0 : 1/.test(viewQml),
+  'the lock surface stays visually black while real DPMS catches up'
+)
+
+assert(
+  /cursorShape: root\.concealAuthentication \? Qt\.BlankCursor : Qt\.ArrowCursor/.test(viewQml),
+  'the concealed transition cannot expose a live pointer over black'
+)
+
+assert(
+  /function handlePointerWake\(\)[\s\S]*if \(displayBlanked && !pointerWakeArmed\) return[\s\S]*runWake\(\)/.test(lockQml),
+  'surface initialization cannot wake a newly blanked lock'
+)
+
+assert(
+  /id: pointerWakeMonitor[\s\S]*enabled: root\.displayBlanked[\s\S]*timeout: root\.pointerWakeSettleSeconds[\s\S]*onIsIdleChanged: root\.handlePointerWakeMonitorChanged\(\)/.test(lockQml),
+  'compositor-side idle arms real pointer wake after initialization settles'
+)
+
+assert(
+  /signal pointerWakeRequested\(\)[\s\S]*onClicked: \{ root\.pointerWakeRequested\(\); root\.forcePasswordFocus\(\) \}[\s\S]*onPositionChanged: root\.pointerWakeRequested\(\)/.test(viewQml),
+  'pointer activity uses the guarded wake path'
+)
+JS


### PR DESCRIPTION
## Superseded

This closed pull request used immediate DPMS blanking during the idle lock transition. Hardware testing showed that it did not reliably prevent the visible lock handoff, and its input and display-power state were too tightly coupled.

The implementation was removed and the fork branch was deleted. The verified replacement is #9632, which keeps the screensaver mapped until the concealed session lock is secure and leaves normal delayed DPMS behavior unchanged.

The separate pre-sleep transition is tracked by #9231. This pull request must not be used for suspend or hibernate.
