### PR TITLE
Reapply clamshell disable after idle wake

### DIFF
--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -112,6 +112,11 @@ current_internal_scale() {
   hyprctl monitors all -j | jq -r --arg internal "$INTERNAL" '.[] | select(.name == $internal and .disabled != true) | .scale' | head -1
 }
 
+internal_enabled() {
+  [[ -n $INTERNAL ]] || return 1
+  hyprctl monitors all -j | jq -e --arg internal "$INTERNAL" '.[] | select(.name == $internal and .disabled != true)' >/dev/null 2>&1
+}
+
 store_internal_scale() {
   local scale="$1"
   valid_scale "$scale" || return 0
@@ -236,9 +241,20 @@ disable_internal() {
   local config
   config=$(printf 'hl.monitor({ output = "%s", disabled = true })' "$INTERNAL")
 
+  local changed=0
   if [[ ! -f $CLAMSHELL_FLAG ]] || [[ $(< "$CLAMSHELL_FLAG") != $config ]]; then
     printf '%s\n' "$config" >"$CLAMSHELL_FLAG"
+    changed=1
+  fi
+
+  if (( changed )); then
     hyprctl reload >/dev/null 2>&1 || true
+  elif internal_enabled; then
+    # Idle/DPMS wake can relight the panel without touching the flag. Reloading
+    # identical config is skipped above, which leaves an extended layout until
+    # the next lid open/close. Apply disable at runtime the same way
+    # enable_internal applies enable.
+    hyprctl eval "$config" >/dev/null 2>&1 || true
   fi
 }
 

--- a/test/shell.d/monitor-clamshell-scale-test.sh
+++ b/test/shell.d/monitor-clamshell-scale-test.sh
@@ -265,6 +265,20 @@ OMARCHY_TEST_INTERNAL_SCALE=1.6 OMARCHY_TEST_EXTERNAL_ACTIVE=true OMARCHY_TEST_C
 [[ $(<"$scale_state") == "1.6" ]] || fail "clamshell disable remembers internal scale value"
 pass "clamshell disable remembers internal scale"
 
+# Regression: idle/DPMS wake can re-enable the panel while the clamshell flag
+# is already correct. Skipping apply then leaves an extended layout until the
+# next lid open/close, which is the only path that rewrites the flag.
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_SCALE=1.6 OMARCHY_TEST_EXTERNAL_ACTIVE=true OMARCHY_TEST_CLAMSHELL=true run_clamshell
+grep -F 'hl.monitor({ output = "eDP-1", disabled = true })' "$eval_log" >/dev/null || fail "clamshell disable reapplies when the panel is on with a matching flag"
+! grep -Fx 'reload' "$eval_log" >/dev/null || fail "clamshell disable does not reload identical config to recover a drifted panel"
+pass "clamshell disable reapplies when idle-wake relights the internal panel"
+
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_DISABLED=true OMARCHY_TEST_EXTERNAL_ACTIVE=true OMARCHY_TEST_CLAMSHELL=true run_clamshell
+[[ ! -s $eval_log ]] || fail "clamshell disable is a no-op when the panel is already off" "$(cat "$eval_log")"
+pass "clamshell disable is a no-op when the panel is already off"
+
 : >"$eval_log"
 OMARCHY_TEST_INTERNAL_DISABLED=true run_clamshell
 grep -F 'scale = 1.6' "$eval_log" >/dev/null || fail "clamshell recovery uses remembered internal scale"

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -83,7 +83,9 @@ grep -F 'hyprctl dispatch "hl.dsp.dpms({ action = \"$action\", monitor = \"$INTE
 grep -F 'hyprctl monitors all -j' "$clamshell" >/dev/null
 grep -F 'omarchy-hyprland-monitor-external-active' "$clamshell" >/dev/null
 grep -F 'omarchy-hw-clamshell' "$clamshell" >/dev/null
+grep -F 'elif internal_enabled; then' "$clamshell" >/dev/null
 pass "clamshell monitor sync disables laptop output and force-recovers it"
+pass "clamshell disable reapplies when the compositor relights a flagged panel"
 
 grep -F "hyprctl dispatch 'hl.dsp.dpms({ action = \"enable\" })' >/dev/null 2>&1 || true" "$monitor_internal" >/dev/null
 grep -F 'omarchy-hyprland-monitor-laptop' "$monitor_internal" >/dev/null


### PR DESCRIPTION
## Problem

With the lid closed and only the external monitor on, idle/DPMS wake can relight the laptop panel. The session comes back as an extended layout. Opening and closing the lid restores clamshell.

`omarchy-hyprland-monitor-clamshell` already writes `disabled = true` for the internal output. Wake can relight that panel without changing the flag, so the reconciler sees identical config, skips reload, and leaves the extended layout. Lid open/close rewrites the flag, so a reload actually applies.

Fixes #9179.

## Change

If the clamshell flag is already correct but Hyprland still has the internal output enabled, apply disable at runtime with `hyprctl eval` instead of no-op.

## Verification

- `bash test/shell.d/monitor-clamshell-scale-test.sh`
- `bash test/shell.d/monitor-recovery-test.sh`
- `bash test/shell.d/lid-close-test.sh`