### PR TITLE
Dropbox widget: scan the team root, not the member folder

### DIFF
--- a/shell/plugins/panels/dropbox/status.py
+++ b/shell/plugins/panels/dropbox/status.py
@@ -15,6 +15,9 @@ PLAN_QUOTAS = {
   "essentials": 3_000_000_000_000,
 }
 
+# Dropbox's own bookkeeping, not user content.
+SKIP_DIRS = {".dropbox.cache"}
+
 
 def read_info():
   info_path = Path.home() / ".dropbox" / "info.json"
@@ -49,7 +52,10 @@ def scan_dropbox(path, limit):
   recent = []
   try:
     for root, dirs, files in os.walk(path):
-      dirs[:] = [name for name in dirs if not os.path.islink(os.path.join(root, name))]
+      dirs[:] = [
+        name for name in dirs
+        if not os.path.islink(os.path.join(root, name)) and name not in SKIP_DIRS
+      ]
       for name in files:
         file_path = os.path.join(root, name)
         if os.path.islink(file_path):
@@ -92,6 +98,12 @@ def main():
   info = read_info()
   account = dropbox_account(info)
   account_path = account.get("path") if isinstance(account.get("path"), str) else ""
+  # A team account syncs into root_path; `path` is only the member folder, and
+  # team folders are its siblings. The member folder is empty whenever every
+  # subfolder of it is excluded by selective sync.
+  root_path = account.get("root_path") if isinstance(account.get("root_path"), str) else ""
+  if root_path and Path(root_path).exists():
+    account_path = root_path
   plan = account.get("subscription_type") if isinstance(account.get("subscription_type"), str) else ""
   quota = PLAN_QUOTAS.get(plan.lower(), 0)
   authenticated = account_path != "" and Path(account_path).exists()


### PR DESCRIPTION
## What's wrong

On a Dropbox **team** account the widget panel shows `No synced files found.` and
`Stored 0 B` while the account is syncing normally. Nothing errors and nothing is
logged — `dropbox-cli status` says `Up to date`, the files are on disk, and
Nautilus shows sync emblems. Only the panel reads empty.

`status.py` walks the account path from `~/.dropbox/info.json`, which for a team
account carries two keys:

```json
{"business": {"path": "/home/<user>/<Team> Dropbox/<Member>",
              "root_path": "/home/<user>/<Team> Dropbox",
              "is_team": true, "subscription_type": "Business"}}
```

It used `path` — the member folder. Team folders are **siblings** of it under
`root_path`, not children:

```
<Team> Dropbox/            <- root_path: everything syncs here
├── <Member>/              <- path: the member folder, what was walked
│   ├── Apps/              <- excluded via selective sync
│   └── _archive/          <- excluded via selective sync
└── <Team> Team Folder/    <- 5161 files, 517 MB, never visited
```

With every subfolder of the member folder excluded by selective sync, the walk
finds nothing at all.

## Reproduction

1. Link a Dropbox Business/team account.
2. Selective-sync so every subfolder of the member folder is excluded while a
   team folder still syncs. (Any team account whose member folder is empty on
   disk reproduces it.)
3. Add the Dropbox widget to the bar and open the panel.

## Fix

`root_path` is present only for team accounts, so preferring it when it exists
leaves personal accounts untouched. Running the helper directly, before and
after:

```
path       = '/home/<user>/<Team> Dropbox/<Member>'   used=0.0 MB    files=0
root_path  = '/home/<user>/<Team> Dropbox'            used=534.8 MB  files=25
```

The second change skips `.dropbox.cache`. It sits at the root of the sync
folder, so it only becomes reachable once the walk starts at `root_path` —
Dropbox rewrites its blobs on every sync, which put them straight to the top of
`Recent files`:

```
.dropbox.cache/new_files/75a4b5654f0829fac14554a1fea34932
.dropbox.cache/new_files/5de449d580ba3096dba8a591dcef97a1
.dropbox.cache/new_files/c82fa107bfbc6d991d6ef216f361ce8c
```

They inflated `usedBytes` too.

## Notes

Context for why an empty panel matters rather than being cosmetic: with the
widget in the bar, Dropbox's own tray icon is suppressed (#7423), so the panel
is the whole desktop surface for Dropbox.

Unrelated to this patch but visible in the same file: `PLAN_QUOTAS` has no
`business` key, so a team account gets `quotaKnown: false` and `Stored` renders
with no denominator. That is the same class of problem as #7597, so I have left
it alone here.

## System

| | |
|---|---|
| Omarchy | 4.0.1-1 |
| Hyprland | v0.56.2 |
| quickshell | 0.3.1-1 |
| dropbox | 264.4.3421-1 (self-updated to 266.4.3911 in `~/.dropbox-dist`) |
| dropbox-cli | 2024.04.17-2 |
| python | 3.14.7 |
| account | Dropbox Business (team) |

Running on this machine since the change.

---

Patch prepared by Claude Opus 5 via Claude Code.
