### PR TITLE
Add Yii3 development environment

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -2,12 +2,12 @@
 
 # omarchy:summary=Install a supported development environment
 # omarchy:name=dev-env
-# omarchy:args=<ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>
+# omarchy:args=<ruby|node|bun|deno|go|laravel|symfony|yii3|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>
 # omarchy:examples=omarchy install dev-env ruby | omarchy install dev-env node
 # omarchy:requires-sudo=true
 
 if [[ -z $1 ]]; then
-  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>" >&2
+  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|yii3|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>" >&2
   exit 1
 fi
 
@@ -92,6 +92,13 @@ symfony)
   install_php
   omarchy-pkg-add symfony-cli
   echo -e "\nYou can now run: symfony new --webapp myproject"
+  ;;
+yii3)
+  echo -e "Installing PHP for Yii3...\n"
+  install_php
+  echo -e "\nYou can now create a web app: composer create-project yiisoft/app myproject"
+  echo "Or create an API app: composer create-project yiisoft/app-api my-api"
+  echo "Or create a console app: composer create-project yiisoft/app-console my-console"
   ;;
 python)
   echo -e "Installing Python...\n"

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -272,6 +272,7 @@
   "install.development.php.php": {"icon":"","label":"PHP","disabled":"omarchy-pkg-present php","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env php'"},
   "install.development.php.laravel": {"icon":"","label":"Laravel","disabled":"[[ -x $HOME/.config/composer/vendor/bin/laravel ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env laravel'"},
   "install.development.php.symfony": {"icon":"","label":"Symfony","disabled":"omarchy-pkg-present symfony-cli","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env symfony'"},
+  "install.development.php.yii3": {"icon":"","label":"Yii3","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env yii3'"},
   "install.development.elixir.elixir": {"icon":"","label":"Elixir","disabled":"[[ -d $HOME/.local/share/mise/installs/elixir ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env elixir'"},
   "install.development.elixir.phoenix": {"icon":"","label":"Phoenix","disabled":"compgen -G \"$HOME/.mix/archives/phx_new*\"","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env phoenix'"},
 

--- a/manual/18-development-tools.md
+++ b/manual/18-development-tools.md
@@ -10,7 +10,7 @@ You can set the system-wide default editor under `Setup > Defaults > Editor`.
 
 ## Environment
 
-Omarchy supports setting up a whole host of development environments through the _Install > Development_ section of the Omarchy Menu (`Super + Space`). You'll of course find _Ruby on Rails_, but also all three major runtimes for JavaScript (Node.js, Bun, Deno), as well as popular PHP frameworks like Laravel and Symfony. Oh, and there's Go, Rust, Python, Java, Elixir (with Phoenix), .NET, OCaml, Zig, Clojure, and Scala too. It's a very broad selection!
+Omarchy supports setting up a whole host of development environments through the _Install > Development_ section of the Omarchy Menu (`Super + Space`). You'll of course find _Ruby on Rails_, but also all three major runtimes for JavaScript (Node.js, Bun, Deno), as well as popular PHP frameworks like Laravel, Symfony, and Yii3. Oh, and there's Go, Rust, Python, Java, Elixir (with Phoenix), .NET, OCaml, Zig, Clojure, and Scala too. It's a very broad selection!
 
 The majority of these environments are managed by [Mise](https://mise.jdx.dev/). It's a tool that lets you install and run multiple versions of a programming language on the same machine. It's like rbenv or rvm for Ruby or virtualenv for Python, but it works for a bunch of different environments.
 

--- a/test/shell.d/dev-env-test.sh
+++ b/test/shell.d/dev-env-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mkdir -p "$test_tmp/bin" "$test_tmp/home"
+
+cat >"$test_tmp/bin/omarchy-pkg-add" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TEST_LOG"
+SCRIPT
+
+cat >"$test_tmp/bin/sudo" <<'SCRIPT'
+#!/bin/bash
+exit 0
+SCRIPT
+
+cat >"$test_tmp/bin/composer" <<'SCRIPT'
+#!/bin/bash
+echo "composer must not create a project during setup" >&2
+exit 1
+SCRIPT
+
+chmod +x "$test_tmp/bin/omarchy-pkg-add" "$test_tmp/bin/sudo" "$test_tmp/bin/composer"
+
+export HOME="$test_tmp/home"
+export PATH="$test_tmp/bin:$PATH"
+export TEST_LOG="$test_tmp/packages"
+
+output=$("$ROOT/bin/omarchy-install-dev-env" yii3)
+
+[[ $(<"$TEST_LOG") == "php composer php-sqlite xdebug" ]] ||
+  fail "Yii3 setup installs the shared PHP toolchain" "$(<"$TEST_LOG")"
+pass "Yii3 setup installs the shared PHP toolchain"
+
+for command in \
+  "composer create-project yiisoft/app myproject" \
+  "composer create-project yiisoft/app-api my-api" \
+  "composer create-project yiisoft/app-console my-console"; do
+  [[ $output == *"$command"* ]] || fail "Yii3 setup shows every project template" "$command"
+done
+pass "Yii3 setup shows the web, API, and console project templates"
+
+yii3_install_row=$(grep '^  "install.development.php.yii3":' "$ROOT/default/omarchy/omarchy-menu.jsonc")
+[[ $yii3_install_row == *'"icon":"","label":"Yii3"'* ]] ||
+  fail "Yii3 has its branded PHP install menu entry" "$yii3_install_row"
+[[ $yii3_install_row == *"omarchy-install-dev-env yii3"* ]] ||
+  fail "Yii3 menu entry launches its development setup" "$yii3_install_row"
+[[ $yii3_install_row != *'"disabled"'* ]] ||
+  fail "Yii3 setup stays available without a global installed artifact" "$yii3_install_row"
+pass "Yii3 setup stays available in the PHP install menu"
+
+if grep -q '^  "remove.development.php.yii3":' "$ROOT/default/omarchy/omarchy-menu.jsonc"; then
+  fail "Yii3 does not claim to remove project-local dependencies"
+fi
+pass "Yii3 has no misleading removal entry"


### PR DESCRIPTION
Adds [Yii3](https://www.yiiframework.com/) under Install > Development > PHP, provisions the shared PHP toolchain, and shows the official web, API, and console project creation commands.

For the menu I've used logo from NerdFont (Yii is there for a long time already) so it looks nice.

_// Yii is one of the oldest and most popular frameworks in PHP, and Yii3 is its latest modern major version._