### PR TITLE
Fix media playPause resuming the wrong player after a stale stream

### DIFF
--- a/shell/plugins/services/media/MediaModel.js
+++ b/shell/plugins/services/media/MediaModel.js
@@ -119,6 +119,37 @@ function osdMessage(player, fallback) {
   return label || fallback
 }
 
+// Among currently-paused players, the one that was most recently seen
+// actually playing. `lastActiveAt` maps playerKey() -> timestamp, updated by
+// the caller each time a player is observed playing (see Service.qml's
+// syncPlayingOrder). This is used as a recency-based tiebreaker so a player
+// that merely happens to be open (e.g. Spotify sitting idle) doesn't win a
+// play/pause command over whatever was actually paused, once any explicit
+// preferred-player tracking has been lost (e.g. its playback stream or MPRIS
+// instance went away while paused).
+function mostRecentlyActivePlayer(players, lastActiveAt) {
+  var list = Array.isArray(players) ? players : []
+  var active = lastActiveAt || {}
+  var best = null
+  var bestAt = -1
+
+  for (var i = 0; i < list.length; i++) {
+    var p = list[i]
+    if (!p || isProxyPlayer(p) || !hasMetadata(p)) continue
+
+    var key = playerKey(p)
+    var at = key ? active[key] : undefined
+    if (at === undefined) continue
+
+    if (at > bestAt) {
+      best = p
+      bestAt = at
+    }
+  }
+
+  return best
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     isProxyPlayer: isProxyPlayer,
@@ -137,6 +168,7 @@ if (typeof module !== "undefined") {
     trackSignature: trackSignature,
     trackChanged: trackChanged,
     labelFor: labelFor,
-    osdMessage: osdMessage
+    osdMessage: osdMessage,
+    mostRecentlyActivePlayer: mostRecentlyActivePlayer
   }
 }

--- a/shell/plugins/services/media/MediaModel.js
+++ b/shell/plugins/services/media/MediaModel.js
@@ -150,6 +150,26 @@ function mostRecentlyActivePlayer(players, lastActiveAt) {
   return best
 }
 
+// Orders the two paused-player fallbacks by which signal is newer. An explicit
+// preference (a media-key target or a player picked from the menu) normally
+// wins, but it goes stale: if the headphones paused Spotify hours ago and you
+// then watched (and paused) a browser video, a play/pause key should resume
+// the browser, not Spotify. So when another player was observed playing after
+// the preference was set, that player is tried first. `preferredAt` is the
+// timestamp the preference was set; `lastActiveAt` maps playerKey() ->
+// last-observed-playing timestamp. Nulls are dropped from the result.
+function recencyOrderedFallbacks(preferred, preferredAt, recentlyActive, lastActiveAt) {
+  var active = lastActiveAt || {}
+  if (!preferred || !recentlyActive) return [preferred || recentlyActive].filter(function (p) { return !!p })
+
+  var key = playerKey(recentlyActive)
+  if (key === playerKey(preferred)) return [preferred]
+
+  var at = key ? active[key] : undefined
+  if (at !== undefined && at > (preferredAt || 0)) return [recentlyActive, preferred]
+  return [preferred, recentlyActive]
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     isProxyPlayer: isProxyPlayer,
@@ -169,6 +189,7 @@ if (typeof module !== "undefined") {
     trackChanged: trackChanged,
     labelFor: labelFor,
     osdMessage: osdMessage,
-    mostRecentlyActivePlayer: mostRecentlyActivePlayer
+    mostRecentlyActivePlayer: mostRecentlyActivePlayer,
+    recencyOrderedFallbacks: recencyOrderedFallbacks
   }
 }

--- a/shell/plugins/services/media/Service.qml
+++ b/shell/plugins/services/media/Service.qml
@@ -11,6 +11,7 @@ Item {
   property var shell: null
   property string preferredPlayerKey: ""
   property var playerStartedAt: ({})
+  property var playerLastActiveAt: ({})
   property var pendingTrackOsd: null
   property int playSerial: 0
 
@@ -105,6 +106,7 @@ Item {
     var next = {}
     var alive = {}
     var serial = playSerial
+    var lastActive = {}
 
     for (var i = 0; i < players.length; i++) {
       var p = players[i]
@@ -112,7 +114,10 @@ Item {
       if (!key) continue
 
       alive[key] = true
+      if (playerLastActiveAt[key] !== undefined) lastActive[key] = playerLastActiveAt[key]
       if (!p.isPlaying) continue
+
+      lastActive[key] = Date.now()
 
       if (playerStartedAt[key] === undefined) {
         serial += 1
@@ -126,6 +131,11 @@ Item {
 
     playSerial = serial
     playerStartedAt = next
+    playerLastActiveAt = lastActive
+  }
+
+  function mostRecentlyActivePlayer() {
+    return MediaModel.mostRecentlyActivePlayer(players, playerLastActiveAt)
   }
 
   function orderedSourcePlayers() {
@@ -226,9 +236,13 @@ Item {
     }
 
     if (preferred && preferred.isPlaying) return preferred
+    // preferred/recentlyActive come before streamCandidate: a player's playback
+    // stream can linger in PipeWire long after it's paused (Spotify does this
+    // indefinitely), so "has a stream" is not a reliable signal of relevance
+    // and must not outrank knowing who you actually just interacted with.
     var streamCandidate = streamPlayer || streamProxy
-    var streamPreferred = preferred && playerHasPlaybackStream(preferred) ? preferred : null
-    return oldestPlayingPlayer(true) || oldestPlayingPlayer(false) || streamPreferred || streamCandidate || preferred || trackPlayer || trackProxy || controllablePlayer || controllableProxy || identityPlayer || identityProxy || null
+    var recentlyActive = mostRecentlyActivePlayer()
+    return oldestPlayingPlayer(true) || oldestPlayingPlayer(false) || preferred || recentlyActive || streamCandidate || trackPlayer || trackProxy || controllablePlayer || controllableProxy || identityPlayer || identityProxy || null
   }
 
   function labelFor(player) {

--- a/shell/plugins/services/media/Service.qml
+++ b/shell/plugins/services/media/Service.qml
@@ -10,6 +10,9 @@ Item {
 
   property var shell: null
   property string preferredPlayerKey: ""
+  // When preferredPlayerKey was last set. A preference older than another
+  // player's most recent playback is stale and must not win over it.
+  property double preferredAt: 0
   property var playerStartedAt: ({})
   property var playerLastActiveAt: ({})
   property var pendingTrackOsd: null
@@ -127,7 +130,7 @@ Item {
       }
     }
 
-    if (preferredPlayerKey && !alive[preferredPlayerKey]) preferredPlayerKey = ""
+    if (preferredPlayerKey && !alive[preferredPlayerKey]) setPreferred("")
 
     playSerial = serial
     playerStartedAt = next
@@ -241,8 +244,12 @@ Item {
     // indefinitely), so "has a stream" is not a reliable signal of relevance
     // and must not outrank knowing who you actually just interacted with.
     var streamCandidate = streamPlayer || streamProxy
-    var recentlyActive = mostRecentlyActivePlayer()
-    return oldestPlayingPlayer(true) || oldestPlayingPlayer(false) || preferred || recentlyActive || streamCandidate || trackPlayer || trackProxy || controllablePlayer || controllableProxy || identityPlayer || identityProxy || null
+    // Between the two, the newer signal wins: a preference set after the other
+    // player last played keeps priority, but a stale one (e.g. Spotify paused
+    // by the headphones hours ago) loses to whatever you actually watched most
+    // recently. See MediaModel.recencyOrderedFallbacks.
+    var recencyPicks = MediaModel.recencyOrderedFallbacks(preferred, preferredAt, mostRecentlyActivePlayer(), playerLastActiveAt)
+    return oldestPlayingPlayer(true) || oldestPlayingPlayer(false) || recencyPicks[0] || recencyPicks[1] || streamCandidate || trackPlayer || trackProxy || controllablePlayer || controllableProxy || identityPlayer || identityProxy || null
   }
 
   function labelFor(player) {
@@ -298,10 +305,15 @@ Item {
     trackOsdTimer.restart()
   }
 
+  function setPreferred(key) {
+    preferredPlayerKey = key || ""
+    preferredAt = key ? Date.now() : 0
+  }
+
   function selectPlayer(key) {
     var player = playerForKey(key)
     if (!player || !hasMetadata(player)) return false
-    preferredPlayerKey = playerKey(player)
+    setPreferred(playerKey(player))
     return true
   }
 
@@ -347,7 +359,7 @@ Item {
     var currentKey = playerKey(current)
     var nextKey = playerKey(next)
 
-    preferredPlayerKey = nextKey
+    setPreferred(nextKey)
 
     if (transferPlayback && currentWasPlaying && next && nextKey !== currentKey) {
       var nextWasPlaying = next.isPlaying
@@ -438,7 +450,7 @@ Item {
       }
     }
 
-    if (handled && key) preferredPlayerKey = key
+    if (handled && key) setPreferred(key)
     if (showFeedback !== false)
       scheduleOsd(actionLabel, iconName, player, handled && (action === "next" || action === "previous"), beforeTrackSignature)
     return handled

--- a/test/shell.d/media-test.sh
+++ b/test/shell.d/media-test.sh
@@ -40,4 +40,29 @@ assert(media.trackChanged(trackSignature, { ...track, trackTitle: 'Next song' })
 assertEqual(media.labelFor({ trackTitle: 'Song', identity: 'Spotify' }), 'Song', 'media labels players by track first')
 assertEqual(media.osdMessage({ trackTitle: 'Song', trackArtist: 'Artist' }, 'Fallback'), 'Song - Artist', 'media builds OSD messages')
 assertEqual(media.osdMessage(null, 'Fallback'), 'Fallback', 'media falls back OSD messages')
+
+const browser = { dbusName: 'org.mpris.MediaPlayer2.brave.instance1', identity: 'Brave', trackTitle: 'A video' }
+const spotify = { dbusName: 'org.mpris.MediaPlayer2.spotify', identity: 'Spotify', trackTitle: 'A song' }
+const proxy = { dbusName: 'org.mpris.MediaPlayer2.playerctld', identity: 'playerctld', trackTitle: 'Proxied' }
+
+assertEqual(
+  media.mostRecentlyActivePlayer([browser, spotify], { [media.playerKey(browser)]: 100, [media.playerKey(spotify)]: 50 }),
+  browser,
+  'media prefers the player most recently observed playing'
+)
+assertEqual(
+  media.mostRecentlyActivePlayer([browser, spotify], { [media.playerKey(spotify)]: 50 }),
+  spotify,
+  'media picks the only player with recorded recency'
+)
+assertEqual(
+  media.mostRecentlyActivePlayer([browser, spotify], {}),
+  null,
+  'media has no recency opinion when nothing was ever observed playing'
+)
+assertEqual(
+  media.mostRecentlyActivePlayer([proxy], { [media.playerKey(proxy)]: 100 }),
+  null,
+  'media excludes proxy players from recency selection'
+)
 JS

--- a/test/shell.d/media-test.sh
+++ b/test/shell.d/media-test.sh
@@ -65,4 +65,34 @@ assertEqual(
   null,
   'media excludes proxy players from recency selection'
 )
+assertDeepEqual(
+  media.recencyOrderedFallbacks(spotify, 100, browser, { [media.playerKey(browser)]: 50 }),
+  [spotify, browser],
+  'media keeps a preference that is newer than the other player\'s last playback'
+)
+assertDeepEqual(
+  media.recencyOrderedFallbacks(spotify, 100, browser, { [media.playerKey(browser)]: 200 }),
+  [browser, spotify],
+  'media demotes a stale preference behind a player that played more recently'
+)
+assertDeepEqual(
+  media.recencyOrderedFallbacks(spotify, 100, spotify, { [media.playerKey(spotify)]: 200 }),
+  [spotify],
+  'media collapses preference and recency when they name the same player'
+)
+assertDeepEqual(
+  media.recencyOrderedFallbacks(null, 0, browser, { [media.playerKey(browser)]: 50 }),
+  [browser],
+  'media falls back to recency alone when nothing is preferred'
+)
+assertDeepEqual(
+  media.recencyOrderedFallbacks(spotify, 100, null, {}),
+  [spotify],
+  'media falls back to the preference alone when nothing was observed playing'
+)
+assertDeepEqual(
+  media.recencyOrderedFallbacks(spotify, 100, browser, {}),
+  [spotify, browser],
+  'media keeps the preference first when the other player has no recorded recency'
+)
 JS


### PR DESCRIPTION
## Summary
- Pressing a media play/pause key (e.g. a Bluetooth headset button) can pause the currently-playing app correctly, but a later "resume" sometimes resumes a different, unrelated app instead (observed: pausing a browser tab, then a later play resumes Spotify even though Spotify was never touched).
- Root cause (commit 1): `selectActivePlayer()`'s fallback, once nothing is actively playing, ranked "has a lingering PipeWire playback stream" above the specific player that was actually preferred/last interacted with. Some players (Spotify, in testing) keep their PipeWire stream open indefinitely even while paused, while others (Brave/Chromium) tear theirs down shortly after pausing — so once enough time passes, the idle-but-still-"streaming" player wins by default regardless of relevance.
- Fix (commit 1): track each player's last-observed-playing timestamp (`playerLastActiveAt`) and use recency, ahead of the generic stream-presence heuristic, as the tiebreaker. The pure selection logic lives in `MediaModel.js` (`mostRecentlyActivePlayer`) alongside the other testable helpers used by `Service.qml`.
- Root cause (commit 2): after living with commit 1 for a few days the wrong player could still win via the *preferred-player* path. Pausing Spotify from the headphones records Spotify as `preferredPlayerKey`, and that preference never expired. A browser video watched and paused hours later then lost to Spotify on the next play key, because `preferred` was consulted before `recentlyActive`.
- Fix (commit 2): record when the preference was set (`preferredAt`) and, among paused players, try whichever signal is newer first: the preferred player if it was chosen after the other player last played, otherwise the most recently active player. The ordering is `MediaModel.recencyOrderedFallbacks`, unit tested next to `mostRecentlyActivePlayer`. An explicit pick from the menu or a media key still wins as long as nothing else has played since.

## Test plan
- [x] `./test/shell` — full suite passes apart from pre-existing failures (`bar-icon-geometry`, `config`, `snapper`, `theme-install-guards`, `unowned-system-paths`, `windows-vm-mount-boundary`), which reproduce identically on a clean `quattro` checkout with no changes.
- [x] Unit tests in `test/shell.d/media-test.sh` for `mostRecentlyActivePlayer` (recency tiebreak, single-recorded-player fallback, no-data case, proxy exclusion) and `recencyOrderedFallbacks` (fresh preference wins, stale preference demoted, same-player collapse, each side alone, other player with no recorded recency).
- [x] Manually reproduced the original bug live (Brave paused, Spotify with a lingering stream), confirmed the fix resumes the correct player even after Brave's stream had gone idle/torn down, across a full shell restart.
- [x] Manually reproduced the second bug (Spotify paused via headphones, then a YouTube tab watched and paused hours later; play key resumed Spotify). Ran the commit 2 logic as a local plugin override since 4 Sept; the play key has resumed the most recently watched player since.
