### PR TITLE
Stop a stuck PROCHOT from pinning T2 Macs at 800 MHz

### DIFF
--- a/default/systemd/system/omarchy-t2-prochot.service
+++ b/default/systemd/system/omarchy-t2-prochot.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ignore the SMC's stuck PROCHOT assertion on T2 Macs
+# The T2's SMC can leave the external PROCHOT line asserted, pinning every core
+# at its minimum frequency even though the CPU's own thermal status is clear.
+# Clearing BD PROCHOT in POWER_CTL makes the CPU ignore that line; firmware
+# restores the bit on resume, so this also runs after every sleep.
+After=suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/modprobe msr
+ExecStart=/bin/bash -c 'wrmsr -a 0x1fc $(( 0x$(rdmsr 0x1fc) & ~1 ))'
+
+[Install]
+WantedBy=multi-user.target suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target

--- a/install/hardware/apple/fix-t2.sh
+++ b/install/hardware/apple/fix-t2.sh
@@ -8,7 +8,8 @@ if lspci -nn | grep "106b:180[12]" >/dev/null; then
     linux-t2-headers \
     apple-t2-audio-config \
     apple-bcm-firmware \
-    t2fanrd
+    t2fanrd \
+    msr-tools
 
   # Enable T2 fan control
   systemctl enable t2fanrd.service
@@ -25,6 +26,13 @@ if lspci -nn | grep "106b:180[12]" >/dev/null; then
   mkdir -p /etc/mkinitcpio.conf.d
   echo "MODULES+=(t2bce_vhci usbhid hid_apple hid_generic xhci_pci xhci_hcd)" > \
     /etc/mkinitcpio.conf.d/apple-t2.conf
+
+  # The SMC can leave the external PROCHOT line asserted, which pins every core
+  # at its minimum frequency. Clear BD PROCHOT at boot and after each resume so
+  # the CPU ignores it.
+  install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-t2-prochot.service" \
+    /etc/systemd/system/omarchy-t2-prochot.service
+  systemctl enable omarchy-t2-prochot.service
 
   mkdir -p /etc/limine-entry-tool.d
   cat > /etc/limine-entry-tool.d/t2-mac.conf <<'EOF'

--- a/migrations/1788105580.sh
+++ b/migrations/1788105580.sh
@@ -1,0 +1,19 @@
+echo "Stop a stuck PROCHOT from pinning T2 Macs at 800 MHz"
+
+if ! lspci -nn | grep "106b:180[12]" >/dev/null; then
+  exit 0
+fi
+
+unit="${OMARCHY_T2_PROCHOT_UNIT:-/etc/systemd/system/omarchy-t2-prochot.service}"
+
+if [[ -f $unit ]]; then
+  exit 0
+fi
+
+# The SMC can leave the external PROCHOT line asserted, which pins every core
+# at its minimum frequency even though the CPU's own thermal status is clear.
+# Clearing BD PROCHOT at boot and after each resume makes the CPU ignore it.
+omarchy-pkg-add msr-tools
+sudo install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-t2-prochot.service" "$unit"
+sudo systemctl daemon-reload
+sudo systemctl enable --now omarchy-t2-prochot.service

--- a/test/shell.d/t2-hardware-test.sh
+++ b/test/shell.d/t2-hardware-test.sh
@@ -7,6 +7,8 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 fix_t2="$ROOT/install/hardware/apple/fix-t2.sh"
 other_packages="$ROOT/install/omarchy-other.packages"
 migration="$ROOT/migrations/1785944594.sh"
+prochot_unit="$ROOT/default/systemd/system/omarchy-t2-prochot.service"
+prochot_migration="$ROOT/migrations/1788105580.sh"
 
 grep -Fq 'KERNEL_CMDLINE[default]+=" intel_iommu=on iommu=pt pm_async=off mem_sleep_default=deep"' "$fix_t2" ||
   fail "T2 setup installs the suspend kernel parameters"
@@ -20,6 +22,16 @@ grep -Fq 'KERNEL_CMDLINE[default]+=" intel_iommu=on iommu=pt pm_async=off mem_sl
   fail "T2 setup leaves optional Touch Bar customization uninstalled"
 ! grep -qx 'tiny-dfr' "$other_packages" ||
   fail "the ISO no longer caches tiny-dfr"
+grep -Fq 'msr-tools' "$fix_t2" ||
+  fail "T2 setup installs msr-tools for the PROCHOT override"
+grep -Fq 'default/systemd/system/omarchy-t2-prochot.service' "$fix_t2" ||
+  fail "T2 setup installs the PROCHOT override unit"
+grep -Fq 'systemctl enable omarchy-t2-prochot.service' "$fix_t2" ||
+  fail "T2 setup enables the PROCHOT override unit"
+grep -Fq "wrmsr -a 0x1fc \$(( 0x\$(rdmsr 0x1fc) & ~1 ))" "$prochot_unit" ||
+  fail "the PROCHOT override unit clears BD PROCHOT on every core"
+grep -Fq 'WantedBy=multi-user.target suspend.target' "$prochot_unit" ||
+  fail "the PROCHOT override unit runs at boot and after resume"
 pass "fresh T2 setup uses t2bce-compatible suspend, fan, and Touch Bar defaults"
 
 test_tmp=$(mktemp -d)
@@ -79,6 +91,14 @@ cat >"$stub_bin/limine-mkinitcpio" <<'SH'
 #!/bin/bash
 
 echo 'limine-mkinitcpio' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
 SH
 
 chmod +x "$stub_bin"/*
@@ -212,3 +232,50 @@ grep -Fxq 'limine-mkinitcpio' "$calls" ||
   fail "T2 rerun migration rebuilds the boot image"
 [[ -f $repair_marker ]] || fail "T2 rerun migration records the machine-wide repair"
 pass "T2 rerun migration repairs installs the broken hardware check skipped"
+
+prochot_unit_target="$test_tmp/system/omarchy-t2-prochot.service"
+rm -rf "$test_tmp/system"
+: >"$calls"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  T2_HARDWARE=1 \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_T2_PROCHOT_UNIT="$prochot_unit_target" \
+  bash -euo pipefail "$prochot_migration" >/dev/null
+
+cmp -s "$prochot_unit" "$prochot_unit_target" ||
+  fail "T2 PROCHOT migration installs the shipped unit"
+grep -Fq $'omarchy-pkg-add\tmsr-tools' "$calls" ||
+  fail "T2 PROCHOT migration installs msr-tools"
+grep -Fq $'systemctl\tdaemon-reload' "$calls" ||
+  fail "T2 PROCHOT migration reloads systemd"
+grep -Fq $'systemctl\tenable\t--now\tomarchy-t2-prochot.service' "$calls" ||
+  fail "T2 PROCHOT migration enables and starts the override"
+pass "T2 PROCHOT migration unpins existing installs"
+
+: >"$calls"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  T2_HARDWARE=1 \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_T2_PROCHOT_UNIT="$prochot_unit_target" \
+  bash -euo pipefail "$prochot_migration" >/dev/null
+
+[[ ! -s $calls ]] || fail "an already repaired T2 install is left unchanged" "$(cat "$calls")"
+pass "T2 PROCHOT migration is idempotent"
+
+rm -rf "$test_tmp/system"
+: >"$calls"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  T2_HARDWARE=0 \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_T2_PROCHOT_UNIT="$prochot_unit_target" \
+  bash -euo pipefail "$prochot_migration" >/dev/null
+
+[[ ! -e $prochot_unit_target ]] || fail "non-T2 systems get no PROCHOT override"
+[[ ! -s $calls ]] || fail "non-T2 systems skip the PROCHOT repair" "$(cat "$calls")"
+pass "T2 PROCHOT migration skips unrelated hardware"


### PR DESCRIPTION
## Summary

- On T2 Macs the SMC can leave the external PROCHOT line asserted. The CPU then honors it and every core sits at its 800 MHz minimum even under an all-core load, while the package is cool (65 °C) and the CPU's own thermal status is clear. The MSRs tell the story: `CORE_PERF_LIMIT_REASONS` (0x64F) reports PROCHOT as the active limit, `THERM_STATUS` (0x19C) shows the external PROCHOT event but no thermal event, and `POWER_CTL` (0x1FC) has BD PROCHOT enabled. Nothing in userspace (governor, EPP, thermald, RAPL limits) is involved.
- Ship `omarchy-t2-prochot.service`, a oneshot that clears BD PROCHOT in `POWER_CTL` on every core so the CPU ignores that line. Firmware restores the bit on resume, so the unit is also wanted by the sleep targets and runs after each wake. Install `msr-tools` with the other T2 packages, install and enable the unit from `fix-t2.sh`, and migrate existing installs.
- Extend `t2-hardware-test.sh` to cover the fresh setup, the unit contents, the migration, its idempotency, and the non-T2 path.

The CPU keeps all of its own protections (thermal throttling, power limits); only the platform-driven PROCHOT input is ignored. This is the same override the `throttled` project applies on ThinkPads for the same symptom.

## Verification

- `bash test/shell.d/t2-hardware-test.sh` (9 passing)
- `./test/all`: only the pre-existing environment failures also present on `quattro` (missing `omarchy-pkgs` checkout, theme-install URL check)
- MacBookPro16,1, linux-t2 7.1.8, Omarchy 4.0.1, on AC, battery full: after a day of use with several suspend cycles the machine was pinned at 800 MHz on all 16 threads under load. Running the migration (which installs and starts the unit) cleared BD PROCHOT; `CORE_PERF_LIMIT_REASONS` dropped the PROCHOT bit and the same load immediately ran at 3.8–4.0 GHz.
- After a subsequent deep-sleep cycle the unit re-ran on resume (`suspend.target`), BD PROCHOT stayed cleared and the cores ran at 3.5–4.5 GHz under load.
