### PR TITLE
Stop restoring a stale keyboard backlight on idle-cycle cancel

### DIFF
--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -103,7 +103,12 @@ Item {
     lockTimer.stop()
     screensaverLaunchGraceTimer.stop()
 
-    if (root.idledThisCycle) runProcess(wakeProcess, "wake", "omarchy-system-wake")
+    // Nothing to wake here. lockSystem ends the cycle, so a cancel only ever
+    // reaches this point for a cycle that never locked, and this service blanks
+    // nothing on its own: the screensaver is just a window, and the lock
+    // service owns both the blank and the matching restore. Running
+    // omarchy-system-wake anyway only re-applied brightnessctl's saved keyboard
+    // level over whatever the keyboard was showing (#7650).
 
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
@@ -198,8 +203,7 @@ Item {
       },
       processes: {
         screensaver: screensaverProcess.running,
-        lock: lockProcess.running,
-        wake: wakeProcess.running
+        lock: lockProcess.running
       },
       lastEvent: root.lastEvent,
       lastEventAt: root.lastEventAt
@@ -292,10 +296,6 @@ Item {
   Process {
     id: lockProcess
     onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "lock exitCode=" + exitCode + " status=" + exitStatus) }
-  }
-  Process {
-    id: wakeProcess
-    onExited: function(exitCode, exitStatus) { root.logEvent("process-exit", "wake exitCode=" + exitCode + " status=" + exitStatus) }
   }
 
   Process {

--- a/test/shell.d/idle-wake-test.sh
+++ b/test/shell.d/idle-wake-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+// Comments are allowed to name the commands; only code that runs them counts.
+const readCode = (file) => fs.readFileSync(file, 'utf8').replace(/^\s*\/\/.*$/gm, '')
+const idleQml = readCode(path.join(root, 'shell/plugins/services/idle/Service.qml'))
+
+// lockSystem ends the cycle, so cancelIdleCycle only ever runs for a cycle
+// that never locked -- and nothing was blanked during one of those.
+assert(
+  /function lockSystem\([^)]*\) \{[^}]*root\.idledThisCycle = false/.test(idleQml),
+  'locking ends the idle cycle'
+)
+
+// omarchy-system-wake restores the keyboard backlight from brightnessctl's
+// saved level. With no blank to undo, that only overwrote whatever the keyboard
+// was showing with a stale level (#7650), so the cancel path must not run it.
+assert(
+  !/omarchy-system-wake/.test(idleQml),
+  'cancelling an idle cycle does not run omarchy-system-wake'
+)
+
+// The lock service is the only shell plugin that blanks, so it has to stay the
+// only one that wakes: a wake with no matching blank restores a stale level.
+const wakers = []
+const walk = (dir) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) walk(full)
+    else if (entry.name.endsWith('.qml') && /omarchy-system-wake|omarchy-brightness-keyboard restore/.test(readCode(full))) {
+      wakers.push(path.relative(root, full))
+    }
+  }
+}
+walk(path.join(root, 'shell/plugins'))
+assertDeepEqual(wakers, ['shell/plugins/lock/Service.qml'], 'only the lock service wakes the keyboard backlight')
+JS


### PR DESCRIPTION
Refs #7650.

The idle service runs `omarchy-system-wake` whenever an idle cycle is cancelled, carried over from hypridle's `on-resume`. But `lockSystem` ends the cycle, so the cancel path only ever runs for a cycle that never locked, and the idle service blanks nothing on its own: the screensaver is just a window, and the lock service already pairs its own blank with a restore on unlock.

With nothing to undo, the only effect of that wake is `omarchy-brightness-keyboard restore` re-applying brightnessctl's saved level over whatever the keyboard is currently showing:

- any level set since the last lock is reverted on every screensaver dismiss;
- with a saved 0 (#7650) the backlight goes dark after every screensaver, not just after unlock. That is the path traced in https://github.com/omacom/omarchy/issues/7650#issuecomment-5469519955: a 1 s poller caught the zeroing coming from `omarchy-system-wake` right at `idle-cycle-cancel: screensaver-dismissed`, with no lock in between.

This drops the wake from the idle service and adds a test pinning the invariant: the lock service is the only shell plugin that blanks, so it has to stay the only one that wakes.

Complements #8134 / #8382 (which stop 0 from being saved in the first place); doesn't touch what #8119 changes in the lock plugin.

Tested with `./test/all` (the four shell files that fail here, config / snapper / theme-install-guards / unowned-system-paths, want an omarchy-pkgs checkout and fail the same way on a clean quattro) and by loading the patched service into a running shell: `omarchy-shell idle status` comes back without the `wake` process entry and the journal shows a single `service-ready` with no QML errors.
