### PR TITLE
Agents: Claude collector emits usageByHour (punchcard for the Claude tab)

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -90,6 +90,28 @@ def local_date_from_timestamp(value: Any) -> str:
     return local_date_string()
 
 
+def local_weekday_hour(value: Any) -> tuple[int, int] | None:
+  # Local-time (weekday, hour) for a record timestamp — weekday 0=Sunday —
+  # or None when the value carries no usable time. Mirrors the parsing
+  # order of local_date_from_timestamp so both grains always agree.
+  if value is None:
+    return None
+  try:
+    if isinstance(value, (int, float)):
+      seconds = float(value) / 1000.0 if float(value) > 10_000_000_000 else float(value)
+      stamp = dt.datetime.fromtimestamp(seconds)
+    else:
+      raw = str(value).strip()
+      if not raw:
+        return None
+      stamp = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+      if stamp.tzinfo is not None:
+        stamp = stamp.astimezone()
+  except Exception:
+    return None
+  return ((stamp.weekday() + 1) % 7, stamp.hour)
+
+
 def usage_token(usage: dict[str, Any], snake_key: str, camel_key: str) -> int:
   value = usage.get(snake_key, usage.get(camel_key, 0))
   try:
@@ -129,6 +151,7 @@ def scan_projects(projects_path: Path) -> dict[str, Any]:
   today_sessions: set[str] = set()
   today_tokens: dict[str, int] = {}
   usage_by_model: dict[str, dict[str, int]] = {}
+  usage_by_hour: dict[tuple[int, int], int] = {}
   prompts = 0
   today_prompt_count = 0
   today_token_total = 0
@@ -188,6 +211,16 @@ def scan_projects(projects_path: Path) -> dict[str, Any]:
             # legacy name shared with synced snapshots.
             recent[day]["messageCount"] += total
 
+          # usageByHour: all-time weekday × hour buckets in local time,
+          # feeding the agents-panel punchcard. Same message stream, same
+          # totals — just a different grain. Zero-token rows already
+          # filtered above.
+          stamp = entry.get("timestamp") or message.get("timestamp")
+          weekday_hour = local_weekday_hour(stamp)
+          if weekday_hour is not None:
+            hourly_key = (weekday_hour[0], weekday_hour[1])
+            usage_by_hour[hourly_key] = usage_by_hour.get(hourly_key, 0) + total
+
           if day == today:
             today_prompt_count += 1
             today_sessions.add(session_key)
@@ -202,6 +235,13 @@ def scan_projects(projects_path: Path) -> dict[str, Any]:
     "todayTotalTokens": today_token_total,
     "todayTokensByModel": today_tokens,
     "recentDays": [recent[day] for day in recent_dates],
+    # Sparse all-time weekday × hour punchcard buckets, local time, the
+    # same totals as modelUsage (one reality per record). Sorted by
+    # (weekday, hour); empty hours are absent, never zero.
+    "usageByHour": [
+      {"weekday": wd, "hour": hr, "tokens": usage_by_hour[(wd, hr)]}
+      for (wd, hr) in sorted(usage_by_hour)
+    ],
     "modelUsage": usage_by_model,
     "totalPrompts": prompts,
     "totalSessions": len(sessions),

--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -598,6 +598,13 @@ def merge_stats(base: dict[str, Any], extra: dict[str, Any]) -> dict[str, Any]:
       target[field] = number(target.get(field)) + number(count)
   merged["modelUsage"] = usage
 
+  # Extras grow the model totals without hourly buckets of their own, so a
+  # merged punchcard would cover less than the record it travels in. Drop
+  # the claim rather than emit grains that disagree; the reconcile gate in
+  # main() holds every printed record to exactly this.
+  if extra.get("modelUsage"):
+    merged.pop("usageByHour", None)
+
   by_date: dict[str, int] = {}
   for source in (base.get("recentDays") or [], extra.get("recentDays") or []):
     for day in source:
@@ -889,6 +896,28 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
 # -------------------------------------------------------------------- record
 
 
+def usage_grain_divergence(stats: dict[str, Any]) -> str | None:
+  # Reconcile-or-abort: usageByHour and modelUsage are two grains of one
+  # message stream, so their all-time token totals must agree exactly. A
+  # timestamp one grain placed and the other rejected, or anything else
+  # that drifts them, means the record would tell two stories — refuse it
+  # rather than print a punchcard the totals contradict. None when the
+  # record claims no punchcard at all.
+  hourly = stats.get("usageByHour")
+  if not isinstance(hourly, list):
+    return None
+  hour_total = sum(number(entry.get("tokens")) for entry in hourly if isinstance(entry, dict))
+  model_total = sum(
+    number(count)
+    for bucket in (stats.get("modelUsage") or {}).values()
+    if isinstance(bucket, dict)
+    for count in bucket.values()
+  )
+  if hour_total == model_total:
+    return None
+  return f"usageByHour tokens {hour_total} != modelUsage tokens {model_total}"
+
+
 def main() -> int:
   parser = argparse.ArgumentParser()
   parser.add_argument("--force", action="store_true", help="rescan transcripts and re-probe limits, ignoring caches")
@@ -918,6 +947,14 @@ def main() -> int:
   opencode = scan_opencode_usage(scan_age)
   if opencode is not None:
     stats = merge_stats(stats, opencode)
+
+  # The emit gate runs before anything else touches disk or network: a
+  # divergent record costs no limits probe, and omarchy-agent-usage-update
+  # keeps the last good record when this exits nonzero without printing.
+  divergence = usage_grain_divergence(stats)
+  if divergence is not None:
+    print(f"Refusing to emit a Claude usage record with disagreeing grains: {divergence}", file=sys.stderr)
+    return 1
 
   access_token, expires_at_ms, plan = oauth_login(claude_dir)
   limits = collect_limits(access_token, expires_at_ms, args.force)

--- a/test/shell.d/agent-usage-claude-hours-test.sh
+++ b/test/shell.d/agent-usage-claude-hours-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+projects="$TEST_HOME/.claude/projects/example"
+mkdir -p "$projects"
+
+# Two fixed UTC timestamps; expected weekday/hour derive from the same TZ
+# the collector uses, so the assert is exact on any runner.
+T1="2026-08-28T12:00:00Z"
+T2="2026-08-28T14:30:00Z"
+W1=$(date -d "$T1" +%w)   # 0=Sunday, matching the emitted contract
+H1=$(date -d "$T1" +%H)
+W2=$(date -d "$T2" +%w)
+H2=$(date -d "$T2" +%H)
+
+cat >"$projects/session.jsonl" <<EOF
+{"timestamp":"$T1","type":"assistant","sessionId":"session-1","uuid":"e1","message":{"id":"m1","role":"assistant","model":"claude-test","usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5}}}
+{"timestamp":"$T2","type":"assistant","sessionId":"session-1","uuid":"e2","message":{"id":"m2","role":"assistant","model":"claude-test","usage":{"input_tokens":7,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":3}}}
+{"timestamp":"$T2","type":"assistant","sessionId":"session-1","uuid":"e3","message":{"id":"m3","role":"assistant","model":"claude-test","usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}}
+EOF
+
+result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force)
+
+[[ $(jq -r '.usageByHour | length' <<<"$result") == "2" ]] ||
+  fail "usageByHour emits two distinct weekday-hour buckets" "$result"
+pass "usageByHour emits two distinct weekday-hour buckets"
+
+[[ $(jq -c '[.usageByHour[] | [.weekday, .hour, .tokens]]' <<<"$result") == "[[$W1,$H1,15],[$W2,$H2,10]]" ]] ||
+  fail "buckets carry local weekday/hour and summed tokens, sorted" "$result"
+pass "buckets carry local weekday/hour and summed tokens, sorted"
+
+[[ $(jq -r '[.usageByHour[].tokens] | add' <<<"$result") == "25" ]] ||
+  fail "hour buckets sum to the record's total (one reality)" "$result"
+pass "hour buckets sum to the record's total (one reality)"
+
+jq -e '.usageByHour | all((.tokens | floor) == .tokens) and all(.tokens > 0)' <<<"$result" >/dev/null ||
+  fail "every bucket is a positive integer (zero and fractional cells absent)"
+pass "every bucket is a positive integer (zero and fractional cells absent)"
+
+pass "collector runs cleanly on a synthetic transcript"

--- a/test/shell.d/agent-usage-claude-hours-test.sh
+++ b/test/shell.d/agent-usage-claude-hours-test.sh
@@ -46,3 +46,49 @@ jq -e '.usageByHour | all((.tokens | floor) == .tokens) and all(.tokens > 0)' <<
 pass "every bucket is a positive integer (zero and fractional cells absent)"
 
 pass "collector runs cleanly on a synthetic transcript"
+
+# A message whose timestamp no grain can place still reaches modelUsage
+# while usageByHour skips it. Grains that disagree must abort the record —
+# empty stdout, nonzero exit, the divergence named on stderr — so the
+# update writer keeps the last good record instead of shipping two
+# realities in one.
+DIVERGENT_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$DIVERGENT_HOME"' EXIT
+mkdir -p "$DIVERGENT_HOME/.claude/projects/example"
+cat >"$DIVERGENT_HOME/.claude/projects/example/session.jsonl" <<EOF
+{"type":"assistant","sessionId":"session-1","uuid":"e1","message":{"id":"m1","role":"assistant","model":"claude-test","usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5}}}
+EOF
+
+divergent=$(HOME="$DIVERGENT_HOME" XDG_CACHE_HOME="$DIVERGENT_HOME/.cache" XDG_DATA_HOME="$DIVERGENT_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force 2>"$TEST_HOME/divergent.stderr")
+divergent_status=$?
+
+[[ $divergent_status != "0" && -z $divergent ]] ||
+  fail "hour-vs-model divergence aborts the record instead of printing it" "$divergent"
+pass "hour-vs-model divergence aborts the record instead of printing it"
+
+grep -q "usageByHour tokens 0 != modelUsage tokens 15" "$TEST_HOME/divergent.stderr" ||
+  fail "the abort names the divergence with expected vs actual" "$(cat "$TEST_HOME/divergent.stderr")"
+pass "the abort names the divergence with expected vs actual"
+
+# Pi sessions feed modelUsage but carry no hourly buckets, so a merged
+# record can no longer reconcile its punchcard — it must drop the claim,
+# not undercount it, while the model totals keep every source.
+MERGED_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$DIVERGENT_HOME" "$MERGED_HOME"' EXIT
+mkdir -p "$MERGED_HOME/.claude/projects/example" "$MERGED_HOME/.pi/agent/sessions/project"
+cp "$projects/session.jsonl" "$MERGED_HOME/.claude/projects/example/session.jsonl"
+cat >"$MERGED_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF
+{"type":"message","id":"pi-1","timestamp":"$T1","message":{"role":"assistant","provider":"anthropic","api":"anthropic-messages","model":"claude-pi","usage":{"input":10,"output":4,"cacheRead":3,"cacheWrite":2,"totalTokens":19}}}
+EOF
+
+merged=$(HOME="$MERGED_HOME" XDG_CACHE_HOME="$MERGED_HOME/.cache" XDG_DATA_HOME="$MERGED_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force)
+
+[[ $(jq -r '.usageByHour' <<<"$merged") == "null" ]] ||
+  fail "a merged record drops the punchcard it can no longer reconcile" "$merged"
+pass "a merged record drops the punchcard it can no longer reconcile"
+
+[[ $(jq -r '[.modelUsage[] | [.inputTokens, .outputTokens, .cacheReadInputTokens, .cacheCreationInputTokens] | add] | add' <<<"$merged") == "44" ]] ||
+  fail "merged model totals still carry every source" "$merged"
+pass "merged model totals still carry every source"


### PR DESCRIPTION
Companion to #8862 (first collector adoption of `usageByHour`): the Claude collector's transcript scan now aggregates all-time weekday × hour token buckets in local time and emits them in the record — so the punchcard section renders for the first-party Claude tab with zero panel changes.

Held as a draft until #8862's field contract settles, per the grain-split discussion.

- Bin script only: `bin/omarchy-agent-usage-claude`
- Bucket totals share the message stream and reconcile with `modelUsage` (one reality per record)
- Test: `test/shell.d/agent-usage-claude-hours-test.sh` (TZ-pinned fixture, bucket geometry, sum invariant, zero-row absence)
