### PR TITLE
Restore focus after the sole monitor round-trips through FALLBACK

### DIFF
--- a/default/hypr/monitor-focus.lua
+++ b/default/hypr/monitor-focus.lua
@@ -1,0 +1,132 @@
+-- Hyprland clears focus when the sole monitor drops onto the headless FALLBACK,
+-- and doesn't put it back when the real one returns, so the session takes no
+-- keyboard input until you switch workspace by hand. Upstream considers this
+-- intended, see hyprwm/Hyprland discussion #15554.
+
+local fallback_monitor = "FALLBACK"
+local restore_delay_ms = 500
+
+local went_headless = false
+local restore_generation = 0
+-- Ids, not objects. The objects don't survive the migration.
+local saved_workspace_id = nil
+local saved_window_address = nil
+
+-- A newer monitor event makes a pending restore stale.
+local function invalidate_pending()
+  restore_generation = restore_generation + 1
+end
+
+local function forget_saved()
+  saved_workspace_id = nil
+  saved_window_address = nil
+end
+
+local function focused_window()
+  for _, window in ipairs(hl.get_windows()) do
+    if window.active then
+      return window
+    end
+  end
+end
+
+-- Lowest focus_history_id is the most recently focused window.
+local function most_recent_window(workspace_id)
+  local best = nil
+  for _, window in ipairs(hl.get_workspace_windows(workspace_id) or {}) do
+    if not best or window.focus_history_id < best.focus_history_id then
+      best = window
+    end
+  end
+  return best
+end
+
+local function current_workspace_id()
+  for _, monitor in ipairs(hl.get_monitors()) do
+    if monitor.focused then
+      return monitor.active_workspace and monitor.active_workspace.id
+    end
+  end
+end
+
+local function other_workspace(target_id)
+  for _, workspace in ipairs(hl.get_workspaces()) do
+    if workspace.id ~= target_id and not tostring(workspace.name):match("^special:") then
+      return workspace
+    end
+  end
+end
+
+local function restore_focus(workspace_id, window_address)
+  local workspace = hl.get_workspace(workspace_id)
+  if not workspace then
+    return
+  end
+
+  -- Refocusing the workspace Hyprland already records as focused is a no-op.
+  if current_workspace_id() == workspace_id then
+    local via = other_workspace(workspace_id)
+    if via then
+      hl.dispatch(hl.dsp.focus({ workspace = via }))
+    end
+  end
+  hl.dispatch(hl.dsp.focus({ workspace = workspace }))
+
+  -- The selector needs the address: prefix, a bare address resolves to nil.
+  local window = window_address and hl.get_window("address:" .. window_address)
+  window = window or most_recent_window(workspace_id)
+  if window then
+    hl.dispatch(hl.dsp.focus({ window = window }))
+  end
+end
+
+hl.on("monitor.removed", function(monitor)
+  if monitor.name == fallback_monitor then
+    return
+  end
+
+  invalidate_pending()
+
+  -- Hyprland still reports the pre-lock window as active here.
+  local window = focused_window()
+  local workspace = window and window.workspace or monitor.active_workspace
+  if not workspace then
+    forget_saved()
+    return
+  end
+
+  saved_workspace_id = workspace.id
+  saved_window_address = window and window.address or nil
+end)
+
+hl.on("monitor.added", function(monitor)
+  if monitor.name == fallback_monitor then
+    invalidate_pending()
+    went_headless = true
+    return
+  end
+
+  if not went_headless then
+    -- An ordinary hotplug, nothing to put back.
+    forget_saved()
+    return
+  end
+
+  went_headless = false
+  local workspace_id, window_address = saved_workspace_id, saved_window_address
+  forget_saved()
+
+  if not workspace_id then
+    return
+  end
+
+  -- The monitor needs a moment to settle before focus will stick.
+  invalidate_pending()
+  local generation = restore_generation
+
+  hl.timer(function()
+    if generation == restore_generation then
+      restore_focus(workspace_id, window_address)
+    end
+  end, { timeout = restore_delay_ms, type = "oneshot" })
+end)

--- a/default/hypr/omarchy.lua
+++ b/default/hypr/omarchy.lua
@@ -18,6 +18,7 @@ require("default.hypr.looknfeel")
 require("default.hypr.qconsole")
 require("default.hypr.input")
 require("default.hypr.windows")
+require("default.hypr.monitor-focus")
 
 -- Current theme overrides.
 require_optional.module("omarchy.current.theme.hyprland")


### PR DESCRIPTION
Fixes #9153.

## Why

If the only monitor stays powered off long enough to drop its link, Hyprland moves everything onto a headless `FALLBACK` monitor and clears focus. When the real monitor comes back it doesn't focus anything again.

The result is a session that looks fine but takes no keyboard input. The window keeps its focus border, the bar still names it, `hyprctl activewindow` still reports it, and nothing you type reaches any client. You have to switch workspace or window by hand to get it back. On a stock idle setup you hit this every time you leave the machine for more than about 10 minutes.

Upstream considers it intended, so it isn't going to be fixed there:

> I don't think we enforce focus on monitor addition to not disrupt current state. With lua I think the workaround is totally reasonable
>
> vaxerski, in [discussion #15554](https://github.com/hyprwm/Hyprland/discussions/15554)

Omarchy's idle lock is what powers the display down, so it seemed fair to handle it here.

## What

New `default/hypr/monitor-focus.lua`, required from `default/hypr/omarchy.lua`.

It remembers the focused workspace and window when a real monitor goes away, then puts focus back once the monitor returns.

- Only a `FALLBACK` round trip counts. Unplugging one of several monitors leaves things alone, since `FALLBACK` only appears when no real output is left.
- Ids are stored, not objects. The objects don't survive the migration.
- Focusing the workspace Hyprland already records as focused is a no-op, so in that case it hops through another workspace to make focus land. This runs behind the lock screen, so you don't see it.
- If the saved window is gone by the time the monitor is back, it falls back to the workspace's most recently focused window.
- A pending restore is invalidated by any newer monitor event, so a fast second cycle can't replay a stale snapshot.

## How it was verified

On Omarchy `4.0.1-1`, Hyprland `0.56.2-1`, single LG UltraGear on `HDMI-A-1`, NVIDIA RTX 4070.

Two real occurrences, a 4h52m lock and a 22m36s one. Both restored focus straight away, no manual workspace switch. Socket trace from the second:

```
19:00:53 activewindow>>,          <-- focus cleared by the migration
19:00:55 monitoradded>>HDMI-A-1
19:00:55 monitorremoved>>FALLBACK
19:00:56 workspace>>2             <-- the hop
19:00:56 workspace>>1             <-- back where I was
19:01:03 (unlocked, typing worked)
```

Before the change, the same wake produced no `activewindow` event at all after the monitor returned, and input stayed dead until a manual switch.

`restore_focus` was also exercised directly for the branches a real wake doesn't reach in one run: hop taken when the target workspace is already current, hop skipped when it isn't, and the most recently focused window used when the saved address no longer resolves.

## Left out

No retry if the restore itself doesn't take. One dispatch 500ms after the monitor is back was enough in both real runs, and retries risk yanking you off a workspace you've since moved to. Could we add one later if it turns out to be flaky on other hardware? 🤔

The 500ms delay is inherited from the workaround in the upstream discussion. I didn't tune it, it worked first time here.
