### PR TITLE
Wake the lock screen on resume and keep wake keys out of the password

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -177,7 +177,14 @@ Item {
         }
 
         Keys.onPressed: function(event) {
+          // A key hit at a dark panel is there to wake it, not to type. The
+          // wake clears displaysBlank, so read it first.
+          var wasBlank = root.displaysBlank
           root.wakeRequested()
+          if (wasBlank) {
+            event.accepted = true
+            return
+          }
           if (event.key === Qt.Key_Escape || (event.modifiers & Qt.ControlModifier && event.key === Qt.Key_U)) {
             root.passwordTextEdited("")
             event.accepted = true

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -497,6 +497,27 @@ Item {
     }
   }
 
+  // Suspend freezes the shell, so the first tick after resume sees the clock
+  // jump. Wake the panel right away instead of leaving the user at a dark
+  // lock screen pressing keys to bring it back.
+  Timer {
+    id: resumeWatchTimer
+    interval: 1000
+    repeat: true
+    running: root.lockRequested
+    property double lastTick: 0
+    onRunningChanged: lastTick = 0
+    onTriggered: {
+      var now = Date.now()
+      var resumed = lastTick > 0 && now - lastTick > interval + 2000
+      lastTick = now
+      if (resumed) {
+        root.logEvent("resume-detected")
+        root.runWake()
+      }
+    }
+  }
+
   Timer {
     id: sessionLockStabilizeTimer
     interval: 500

--- a/test/shell.d/lock-wake-after-resume-test.sh
+++ b/test/shell.d/lock-wake-after-resume-test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+const viewQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/LockView.qml'), 'utf8')
+
+// The lock knows when it blanked the panel and when a wake brought it back.
+assert(/property bool displaysBlank: false/.test(serviceQml), 'the lock tracks whether it blanked the panel')
+assert(
+  /function runBlank\(\) \{\s*root\.displaysBlank = true/.test(serviceQml),
+  'blanking the panel marks the displays as blank'
+)
+assert(
+  /function runWake\(\) \{\s*root\.displaysBlank = false/.test(serviceQml),
+  'a wake clears the blank state'
+)
+
+// Keys hit at a dark panel wake it instead of landing in the password field.
+assert(/property bool displaysBlank: false/.test(viewQml), 'the lock view knows when the panel is blank')
+assert(/displaysBlank: root\.screenBlank\(/.test(serviceQml), 'the lock view is told when its panel is blank')
+assert(
+  /Keys\.onPressed: function\(event\) \{[\s\S]*?var wasBlank = root\.displaysBlank\s*root\.wakeRequested\(\)\s*if \(wasBlank\) \{\s*event\.accepted = true\s*return\s*\}/.test(viewQml),
+  'a key pressed at a blank panel is consumed after requesting the wake, judged before the wake clears the state'
+)
+
+// Resume is detected from the clock jump the frozen shell sees on its first
+// tick back, and the panel is woken without waiting for input.
+assert(
+  /id: resumeWatchTimer[\s\S]*?running: root\.lockRequested[\s\S]*?now - lastTick > interval \+ 2000[\s\S]*?if \(resumed\) \{[\s\S]*?root\.runWake\(\)/.test(serviceQml),
+  'the lock wakes the panel on its own after resume'
+)
+JS


### PR DESCRIPTION
## Summary

Two things made the first unlock after resume slower than it needed to be:

- When the lock had blanked the panel before the machine went to sleep, it stayed dark after resume until the user touched something. The lock now runs a one-second timer while locked; the first tick after resume sees the wall clock jump the frozen shell missed and wakes the panel itself, so the lock screen is lit by the time the user looks at it.
- The key pressed to wake a dark panel went straight into the password field, so the first attempt failed. The lock already tracks that it blanked the panel (`displaysBlank`, set by `runBlank()`, cleared by `runWake()`, on unlock, or when a display comes back) and hands that to the view: a key pressed while the panel is dark requests the wake and is consumed, the way hyprlock behaves. The view reads the flag before it asks for the wake, since the wake clears it.

`test/shell.d/lock-wake-after-resume-test.sh` pins both behaviours.

## Verification

- `bash test/shell.d/lock-wake-after-resume-test.sh` and the existing `lock-*`, `sleep-*` and `system-lock` tests (68 passing)
- Run as a cloned plugin on a MacBookPro16,1 across several suspend cycles: keys hit while the panel is still dark no longer land in the password field, and the panel wakes on its own after resume without touching the keyboard.

