### PR TITLE
Add region screenshot indicator

### DIFF
--- a/manual/12-screenshots-recording.md
+++ b/manual/12-screenshots-recording.md
@@ -21,6 +21,8 @@ Files land in `~/Pictures` by default, named `screenshot-2026-08-13_14-22-05.png
 
 From the terminal, `omarchy screenshot` takes the same shot, and you can be explicit about it: `omarchy capture screenshot region` for freeform only, `windows` to snap to window and monitor rectangles, or `fullscreen` to skip the picker entirely and grab the focused monitor. A second argument of `copy` puts the shot only on the clipboard, and `save` only on disk.
 
+For a mouse-first shortcut, hover the indicator area beside the clock and click the camera icon. Drag over a region and release to copy it straight to the clipboard without saving a file or opening the editor.
+
 ### Driving the picker from the keyboard
 
 While the selection is up, you don't have to use the mouse at all:

--- a/shell/plugins/bar/indicators/Screenshot.qml
+++ b/shell/plugins/bar/indicators/Screenshot.qml
@@ -1,0 +1,18 @@
+import QtQuick
+import qs.Ui
+
+BarIndicator {
+  id: root
+
+  active: false
+  activeText: ""
+  inactiveText: ""
+  activeTooltipText: "Copy Region Screenshot"
+  inactiveTooltipText: "Copy Region Screenshot"
+
+  onPressed: function() {
+    if (root.bar) {
+      root.bar.run("omarchy-capture-screenshot region copy")
+    }
+  }
+}

--- a/shell/plugins/bar/widgets/Indicators.manifest.json
+++ b/shell/plugins/bar/widgets/Indicators.manifest.json
@@ -32,6 +32,11 @@
             "description": "Voice typing status"
           },
           {
+            "value": "Screenshot",
+            "label": "Screenshot",
+            "description": "Copy a selected region to the clipboard"
+          },
+          {
             "value": "ScreenRecording",
             "label": "Screen recording",
             "description": "GPU screen recorder status"

--- a/shell/plugins/bar/widgets/Indicators.qml
+++ b/shell/plugins/bar/widgets/Indicators.qml
@@ -8,7 +8,7 @@ BarWidget {
   id: root
   moduleName: "omarchy.indicators"
 
-  readonly property var defaultIndicatorEntries: [ "Dictation", "ScreenRecording", "Reminder", "NightLight", "Dnd", "StayAwake" ]
+  readonly property var defaultIndicatorEntries: [ "Dictation", "Screenshot", "ScreenRecording", "Reminder", "NightLight", "Dnd", "StayAwake" ]
   readonly property var indicatorEntries: indicatorEntriesFromSettings(settings)
   property var activeIndicatorIds: []
   property var indicatorActiveStates: ({})

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -198,6 +198,14 @@ ShellRoot {
         root.assertTrue(root.commandCount("omarchy-capture-screenrecording --stop-recording") === 1, "Screen Recording left click stops active recording")
       }
 
+      var screenshot = root.createIndicator("Screenshot")
+      if (screenshot) {
+        screenshot.moduleName = "Screenshot"
+        root.injectBar(screenshot)
+        screenshot.triggerPress(Qt.LeftButton)
+        root.assertTrue(root.commandCount("omarchy-capture-screenshot region copy") === 1, "Screenshot left click copies a selected region")
+      }
+
       var dictation = root.createIndicator("Dictation")
       if (dictation) {
         dictation.moduleName = "Dictation"


### PR DESCRIPTION
## Summary

- add a camera indicator that launches `omarchy-capture-screenshot region copy`
- include it in the default hover-only indicator tray and indicator settings
- document the mouse-first clipboard workflow
- cover the click command in the indicator contract test

## Validation

- `./test/shell.d/indicator-contract-test.sh`
- `git diff --check`
- manifest JSON validation with `jq`
- live shell visual check: hovering expanded the indicator tray and rendered the muted camera icon with correct spacing
- `./test/all` was also run; relevant shell, plugin, bar geometry, runtime smoke, and screenshot checks passed. Two environment-specific checks could not complete cleanly on this installed Omarchy host: `theme-install-guards-test.sh` sees the host `/usr/bin/omarchy-git-url-check`, and `windows-vm-mount-boundary-test.sh` is blocked by managed mount namespace restrictions.