### PR TITLE
Point the rc channel at the rc package repository

### DIFF
--- a/bin/omarchy-version-channel
+++ b/bin/omarchy-version-channel
@@ -14,6 +14,8 @@ fi
 
 if grep -q "https://pkgs.omarchy.org/stable/" /etc/pacman.conf; then
   pkgs="stable"
+elif grep -q "https://pkgs.omarchy.org/rc/" /etc/pacman.conf; then
+  pkgs="rc"
 elif grep -q "https://pkgs.omarchy.org/edge/" /etc/pacman.conf; then
   pkgs="edge"
 else

--- a/default/pacman/pacman-rc.conf
+++ b/default/pacman/pacman-rc.conf
@@ -26,4 +26,4 @@ Include = /etc/pacman.d/mirrorlist
 Include = /etc/pacman.d/mirrorlist
 
 [omarchy]
-Server = https://pkgs.omarchy.org/edge/$arch
+Server = https://pkgs.omarchy.org/rc/$arch

--- a/migrations/1788112314.sh
+++ b/migrations/1788112314.sh
@@ -1,0 +1,12 @@
+echo "Point rc-channel installs at the rc package repository"
+
+# pacman-rc.conf shipped with [omarchy] pointing at the edge repository, a
+# leftover from when release candidates published there. Candidates now publish
+# to the dedicated rc channel, so a machine on the rc mirror was taking its
+# omarchy packages from edge. Repoint only a conf that still carries the
+# shipped pairing: an administrator who chose another combination keeps it.
+if grep -q "https://rc-mirror.omarchy.org/" /etc/pacman.d/mirrorlist &&
+  grep -q "^Server = https://pkgs.omarchy.org/edge/" /etc/pacman.conf; then
+  sudo sed -i "s|^Server = https://pkgs.omarchy.org/edge/|Server = https://pkgs.omarchy.org/rc/|" /etc/pacman.conf
+  echo "Switched the [omarchy] repository to the rc channel to match this machine's rc mirror."
+fi


### PR DESCRIPTION
pacman-rc.conf shipped with `[omarchy]` on `pkgs.omarchy.org/edge` — a leftover from when release candidates published there. Candidates now publish to a dedicated rc channel, so a machine switched to rc with `omarchy-refresh-pacman` was pairing the rc Arch mirror with **edge** omarchy packages, and `omarchy-version-channel` couldn't name the rc repository at all (an rc install reported `rc / unknown`).

Three parts:

- `default/pacman/pacman-rc.conf`: `[omarchy]` server moves to `https://pkgs.omarchy.org/rc/$arch`, so channel switching and fresh rc installs land on the candidate packages.
- `bin/omarchy-version-channel`: recognizes the rc package repository, so an rc install reports `rc` instead of `rc / unknown`.
- `migrations/1788112314.sh`: repoints machines already on the rc channel. It only rewrites the shipped pairing (rc mirror + edge `[omarchy]`); an administrator's deliberate combination is left alone, and edge/stable machines don't match the guard.

Companion to omacom-io/omarchy-iso@d2e764d (the RC ISO builder-side fix, already on quattro). Intended to be cherry-picked onto `v4-0-2` for the next 4.0.2 candidate.