### PR TITLE
Mirror Enter keybindings onto KP_Enter

### DIFF
--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -1,6 +1,12 @@
 -- Essential application bindings.
 o.bind("SUPER + RETURN", "Terminal", { omarchy = "terminal" })
 o.bind("SUPER + SHIFT + RETURN", "Browser", { omarchy = "browser" })
+-- Some keyboards emit KP_Enter for their only Enter key, and full-size
+-- keyboards have a numpad Enter; applications treat both like Return. Mirror
+-- the RETURN bindings without descriptions so the keybindings menu doesn't
+-- list duplicates.
+o.bind("SUPER + KP_Enter", nil, { omarchy = "terminal" })
+o.bind("SUPER + SHIFT + KP_Enter", nil, { omarchy = "browser" })
 o.bind("SUPER + SHIFT + F", "File manager", { omarchy = "nautilus" })
 o.bind("SUPER + ALT + SHIFT + F", "File manager (cwd)", { omarchy = "nautilus-cwd" })
 o.bind("SUPER + SHIFT + B", "Browser", { omarchy = "browser" })
@@ -11,6 +17,8 @@ if o.preinstalled_bindings_enabled() then
   -- Bindings for preinstalled Omarchy applications, TUIs, and web apps.
   o.bind("SUPER + ALT + RETURN", "Tmux", { omarchy = "terminal-tmux" })
   o.bind("SUPER + CTRL + RETURN", "Herdr", { omarchy = "terminal-herdr" })
+  o.bind("SUPER + ALT + KP_Enter", nil, { omarchy = "terminal-tmux" })
+  o.bind("SUPER + CTRL + KP_Enter", nil, { omarchy = "terminal-herdr" })
   o.bind("SUPER + SHIFT + M", "Music", { omarchy = "spotify" })
   o.bind("SUPER + SHIFT + ALT + M", "Music TUI", { tui = "cliamp", focus = true })
   o.bind("SUPER + SHIFT + D", "Docker", { tui = "omarchy-launch-docker-tui" })

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -56,6 +56,9 @@ hl.on("layer.opened", function(layer)
       selection_binds = {
         hl.bind("RETURN", hl.dsp.exec_cmd("omarchy-capture-region --take-window"), { description = "Capture highlighted window" }),
         hl.bind("CTRL + RETURN", hl.dsp.exec_cmd("omarchy-capture-region --take-fullscreen"), { description = "Capture entire screen" }),
+        -- KP_Enter mirrors for keyboards where Enter emits KP_Enter (and numpad Enter).
+        hl.bind("KP_Enter", hl.dsp.exec_cmd("omarchy-capture-region --take-window")),
+        hl.bind("CTRL + KP_Enter", hl.dsp.exec_cmd("omarchy-capture-region --take-fullscreen")),
         hl.bind("TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window next"), { description = "Select next window to capture" }),
         hl.bind("CTRL + TAB", hl.dsp.exec_cmd("omarchy-capture-region --select-window prev"), { description = "Select previous window to capture" }),
       }


### PR DESCRIPTION
Fixes #9030.

Keyboards like the Gateway GWTN141-10 emit `KP_Enter` (keysym `0xff8d`) for their only Enter key, and full-size keyboards emit it from the numpad Enter. Applications treat it like Return, but the default bindings were declared only for `RETURN`, so SUPER+Enter (Terminal), SUPER+SHIFT+Enter (Browser), SUPER+ALT+Enter (Tmux), and SUPER+CTRL+Enter (Herdr) never matched, and neither did Enter in the capture selection overlay. Reproducible on any hardware: SUPER + numpad-Enter does nothing.

**Fix:** mirror the `RETURN` bindings onto `KP_Enter`:
- `default/hypr/bindings/applications.lua`: the four launcher bindings (Tmux/Herdr mirrors stay under the same `preinstalled_bindings_enabled()` guard)
- `default/hypr/bindings/utilities.lua`: the capture-window / capture-fullscreen binds in the slurp selection overlay

The mirrors are registered **without descriptions**, and `omarchy-menu-keybindings` only lists described binds (`if opts.description and opts.description ~= ""`), so the keybindings menu shows no duplicates.

Both files pass `luac -p`.