### PR TITLE
Start the Herdr server with the graphical session

### DIFF
--- a/default/systemd/user/herdr.service
+++ b/default/systemd/user/herdr.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Herdr terminal workspace server
+Documentation=https://herdr.dev
+# Herdr panes inherit the environment of the server process that creates them,
+# and the CLI auto-starts a server on first contact from wherever that happens
+# to be. After a reboot that first contact can come from an SSH login with no
+# WAYLAND_DISPLAY — from then on every pane and agent loses Wayland clipboard
+# access (image paste fails silently) and GUI launches from panes crash
+# (herdrdev/herdr#2448, #2859). Starting the server with the graphical session
+# gives it one defined, correct birth; SSH logins then attach instead of
+# spawning a broken server.
+#
+# Wait for the compositor: uwsm imports WAYLAND_DISPLAY into the user manager
+# before it reaches graphical-session.target.
+After=graphical-session.target
+# Stop with the session so the next login gets a fresh server with fresh
+# credentials — group membership changes (e.g. Sudoless Docker) and environment
+# only reach panes through a server born after them.
+PartOf=graphical-session.target
+# After= is ordering only. A start outside the session (an `omarchy update`
+# over SSH re-running enable --now) would create exactly the clipboard-blind
+# server this unit exists to prevent. Skip it; the unit stays enabled and
+# starts for real at graphical login. Headless/remote use keeps working
+# unchanged through the CLI's own auto-start.
+ConditionEnvironment=WAYLAND_DISPLAY
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/herdr server
+ExecStop=/usr/bin/herdr server stop
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -18,4 +18,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  herdr.service

--- a/migrations/1788114152.sh
+++ b/migrations/1788114152.sh
@@ -1,0 +1,21 @@
+echo "Run the Herdr server as a graphical-session user unit"
+
+# The Herdr server permanently inherits the environment of whoever starts it,
+# and the CLI auto-starts one on first contact from wherever that happens to
+# be. After a reboot that can be an SSH login with no WAYLAND_DISPLAY, leaving
+# every pane and agent without Wayland clipboard access and crashing GUI
+# launches (herdrdev/herdr#2448, #2859). The unit gives the server one defined
+# birth inside the graphical session; SSH logins then attach instead of
+# spawning a broken server.
+#
+# Enable only, without --now: a CLI-started server is very likely running right
+# now — probably hosting the pane this update runs in — and a second server
+# would fight it for the socket. The unit takes over at the next login, when
+# the old server is gone; PartOf keeps the handover clean from then on.
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# Report what systemctl actually said; "could not enable" on its own gives
+# nothing to act on.
+if ! error=$(systemctl --user enable herdr.service 2>&1); then
+  echo "Could not enable herdr.service: $error"
+fi


### PR DESCRIPTION
## Problem

The Herdr server permanently inherits the environment of whoever starts it, and the CLI auto-starts one on first contact from wherever that happens to be. After a reboot, that first contact can come from an SSH login with no `WAYLAND_DISPLAY` — from then on **every pane and agent loses Wayland clipboard access** (image paste fails silently with "No images found in clipboard") and GUI apps launched from panes crash. This is https://github.com/herdrdev/herdr/issues/2448 and https://github.com/herdrdev/herdr/issues/2859; the maintainers' stated workaround is "stop that session and restart Herdr from the graphical terminal", which users have to rediscover every time they lose the lottery.

Hit this in the wild today: rebooted after an `omarchy update`, the first thing to touch herdr was an SSH session from a second machine, and image paste into Claude Code was broken for the rest of the day with no error pointing anywhere near the cause. Diagnosis details in https://github.com/herdrdev/herdr/issues/2448#issuecomment-5470366662.

Herdr's own fix (env refresh on local attach, https://github.com/herdrdev/herdr/pull/2854) is blocked on a wire-protocol bump, and even once merged it only heals panes created *after* the first local attach.

## Fix

Ship a user unit bound to `graphical-session.target`, following the existing `omarchy-fcitx5.service` pattern:

- **starts at graphical login** with the compositor's environment — SSH logins then *attach* to a healthy server instead of birthing a broken one
- **`PartOf=` stops it at logout**, so the next login gets a server with fresh credentials — group membership changes (e.g. the new Sudoless Docker opt-in) only reach panes through a server born after them
- **`ConditionEnvironment=WAYLAND_DISPLAY`** keeps an out-of-session start (an update over SSH re-running `enable --now`) from recreating exactly the server this prevents
- headless and `herdr --remote` use keep working unchanged through the CLI's own auto-start — the condition makes the unit inert there

The migration enables without `--now`: a CLI-started server is very likely hosting the pane the update runs in, and a second server would fight it for the socket. The unit takes over at the next login (same applies-at-reboot shape as the docker group migration).

## Trade-offs

- Herdr becomes always-on at graphical login (~tens of MB idle) instead of on-demand. Given herdr ships in the base install and its snapshot restore now also runs predictably at login, this seemed like the right default — happy to gate it differently if you'd rather.
- The pre-login SSH edge (server born over SSH before the user ever reaches the desktop) remains until herdrdev/herdr#2854 lands; the unit and that PR complement each other.

## Testing

Running on a real 4.0.1 install (x86): after reboot the unit is active with `WAYLAND_DISPLAY=wayland-1` in its environment, herdr's snapshot restore brought agent panes back under the systemd server, clipboard/image paste works in panes, and SSH sessions attach cleanly. Migration semantics verified against a live CLI-started server (enable-only, no socket fight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9DfFm2kNZWgN9g9xgX2Q6