### PR TITLE
Detect Apple bcm5974 trackpads in omarchy-hw-touchpad

### DIFF
--- a/bin/omarchy-hw-touchpad
+++ b/bin/omarchy-hw-touchpad
@@ -2,5 +2,7 @@
 
 # omarchy:summary=Print the detected Hyprland touchpad or trackpad device name
 
-device=$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad"; "i"))] | first // empty')
+# Apple's bcm5974 driver reports the built-in trackpad to libinput under the
+# bare driver name, so match it alongside the conventional touchpad names.
+device=$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad|bcm5974"; "i"))] | first // empty')
 [[ -n $device ]] && echo "$device"


### PR DESCRIPTION
Fixes #9190.

On 2013/2014-era MacBooks the built-in trackpad is exposed to libinput/Hyprland as `bcm5974`, the bare kernel driver name. `omarchy-hw-touchpad` only matched device names containing `touchpad` or `trackpad`, so detection came up empty and every command chained through it (`omarchy toggle touchpad on|off|toggle`) reported "No touchpad device found" and did nothing.

**Fix:** add `bcm5974` to the name pattern in the jq filter, with a comment explaining why it's there. Verified the filter picks `bcm5974` out of a device list while ignoring regular mice.