### PR TITLE
Never let bar and panel error diagnostics block their fallbacks

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -253,9 +253,16 @@ ShellRoot {
     onActiveChanged: if (!active) shell.bar = null
     onStatusChanged: {
       if (status === Loader.Error) {
-        var detail = errorString && errorString() ? errorString() : ""
-        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId + ":", detail)
-        shell.failedBarId = shell.activeBarId
+        // Record the failure before any diagnostics: activeBarId resolves
+        // back to the default bar off failedBarId, so nothing thrown while
+        // gathering the error detail may block that assignment.
+        var failedId = shell.activeBarId
+        shell.failedBarId = failedId
+        // Loader has no errorString member; an unqualified lookup of an
+        // undefined name throws ReferenceError, so probe with typeof.
+        var detail = typeof errorString === "function" && errorString() ? errorString() : ""
+        if (!detail && sourceComponent) detail = sourceComponent.errorString()
+        console.warn("bar option " + failedId + " failed to load, falling back to " + shell.defaultBarId + ":", detail)
       }
     }
   }
@@ -639,13 +646,17 @@ ShellRoot {
         }
         onStatusChanged: {
           if (status === Loader.Error) {
-            // Loader.errorString() reflects the source-load failure even when
-            // sourceComponent is null. Surface both so the user sees something
-            // actionable instead of a panel that silently refuses to open.
-            var detail = errorString && errorString() ? errorString() : ""
+            // Hide the panel before any diagnostics so a failure while
+            // gathering the error detail cannot leave it stuck open.
+            shell.hide(panelEntry.pluginId)
+            // Loader has no errorString member; an unqualified lookup of an
+            // undefined name throws ReferenceError, so probe with typeof.
+            // Fall back to the component's error when one is available so the
+            // user sees something actionable instead of a panel that silently
+            // refuses to open.
+            var detail = typeof errorString === "function" && errorString() ? errorString() : ""
             if (!detail && sourceComponent) detail = sourceComponent.errorString()
             console.warn("panel plugin " + panelEntry.pluginId + " failed to load:", detail)
-            shell.hide(panelEntry.pluginId)
           }
         }
         Component.onDestruction: shell.unregisterPanelLoader(panelEntry.pluginId)


### PR DESCRIPTION
Fixes #9116.

When a custom bar option fails to load, `pluginBarLoader.onStatusChanged` is supposed to record `failedBarId` so `activeBarId` resolves back to the default bar. But `QtQuick.Loader` has no `errorString` member, and in QML an unqualified lookup of an undefined name throws `ReferenceError` (the `errorString &&` guard can't help because the throw happens at the lookup itself). The handler aborted on its first line, so:

- the diagnostic never printed (the real load error was swallowed), and
- `failedBarId` was never set, so the fallback never ran and the session was left with **no bar at all**.

**Fix, in both the bar loader (line ~257) and the panel plugin loader (line ~646) which had the same unguarded pattern:**

1. Apply the recovery state change first (`shell.failedBarId` for the bar, `shell.hide(...)` for panels) so nothing thrown while gathering diagnostics can ever block it again.
2. Probe with `typeof errorString === \"function\"` before calling, falling back to `sourceComponent.errorString()` when available.

The bar handler captures `activeBarId` before assigning `failedBarId`, since the assignment reactively flips `activeBarId` to the default and the warning should name the bar that actually failed.