### PR TITLE
Add AirPlay audio output

### DIFF
--- a/config/pipewire/pipewire.conf.d/raop-discover.conf
+++ b/config/pipewire/pipewire.conf.d/raop-discover.conf
@@ -1,0 +1,27 @@
+# Expose AirPlay receivers -- Sonos, Apple TV, HomePod, AV receivers -- as
+# ordinary PipeWire sinks, so they appear in the output picker alongside local
+# devices. Discovery is mDNS, so this follows avahi-daemon.
+#
+# Needs the raop modules from pipewire-zeroconf; stock pipewire.conf never
+# loads raop-discover on its own, so installing the package alone does nothing.
+#
+# S16/44100 is the RAOP wire format. Stating it here keeps the resampler in
+# PipeWire, where it can be configured, rather than leaving each sink to
+# negotiate a rate it will convert away anyway.
+context.modules = [
+    {   name = libpipewire-module-raop-discover
+        args = {
+            stream.rules = [
+                {   matches = [ { raop.ip = "~.*" } ]
+                    actions = {
+                        create-stream = {
+                            audio.format = "S16"
+                            audio.rate = 44100
+                            audio.channels = 2
+                        }
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/install/config/firewall.sh
+++ b/install/config/firewall.sh
@@ -6,6 +6,10 @@ ufw default allow outgoing
 ufw allow 53317/udp
 ufw allow 53317/tcp
 
+# Allow ports for AirPlay output. Receivers poll these for timing, so the
+# traffic arrives unsolicited and deny-incoming drops it.
+ufw allow 6001:6002/udp comment 'AirPlay RAOP timing/control'
+
 # Allow Docker containers to use DNS on host.
 ufw allow in proto udp from 172.16.0.0/12 to 172.17.0.1 port 53 comment 'allow-docker-dns'
 ufw allow in proto udp from 192.168.0.0/16 to 172.17.0.1 port 53 comment 'allow-docker-dns'

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -37,6 +37,7 @@ pipewire
 pipewire-alsa
 pipewire-jack
 pipewire-pulse
+pipewire-zeroconf
 qt6-wayland
 snapper
 sof-firmware


### PR DESCRIPTION
Adds AirPlay output, so Sonos, HomePod, Apple TV and AV receivers appear in the output picker like any other device.

All three changes are required. If one is missing there's no audio and nothing in the logs explaining why, which is what made this annoying to work out.

### `pipewire-zeroconf`

Arch ships the RAOP modules in a separate package, so `libpipewire-module-raop-sink.so` isn't on disk without it.

### `config/pipewire/pipewire.conf.d/raop-discover.conf`

Installing the package isn't enough on its own. Stock `pipewire.conf` doesn't mention `raop` or `zeroconf` anywhere, and `/usr/share/pipewire/pipewire.conf.d/` is empty, so nothing loads the discover module.

```
package, no drop-in  ->  0 raop sinks
package + drop-in    ->  9 raop sinks
```

Follows the existing `config/wireplumber/wireplumber.conf.d/` pattern.

### `ufw allow 6001:6002/udp`

The receiver polls the sender for timing and retransmits. That traffic is unsolicited and conntrack has no entry for it, so `default deny incoming` drops it. What you see without the rule is a stream that connects, logs `mod.raop-sink: missing timeout`, and dies a few seconds later.

I checked this both ways. With the rule removed, a receiver couldn't open any connection back to the host: the probe request was accepted and nothing arrived at a local server I'd confirmed was listening. With the rule in place I got 40 seconds of playback and no `missing timeout` lines.

The two local ports don't change between networks, so there's no need to scope the rule to a subnet. Same shape as the LocalSend rule above it.

### Discovery doesn't need a firewall change

ufw's stock `before.rules` already accepts multicast mDNS:

```
-A ufw-before-input -p udp -d 224.0.0.251 --dport 5353 -j ACCEPT
```

I looked at `raop.transport = "tcp"` as a way to avoid the inbound rule, but none of the receivers support it. All ten devices I tested advertise `tp=UDP`: Sonos, HomePod, Apple TV, Denon and macOS.

### Known PipeWire bug

If a session fails or gets interrupted, the sink is destroyed and `raop-discover` doesn't bring it back. The mDNS record hasn't changed, so there's nothing to trigger a rebuild, and the device stays missing until `systemctl --user restart pipewire`.

I'm fairly confident this is a PipeWire bug rather than anything here. The receiver stayed reachable on tcp/1400 and tcp/7000 the whole time and kept advertising a full mDNS record. Rebooting the speaker made no difference, and restarting pipewire fixed it immediately.

It's the part I'd worry about most if this ships on by default, since the output list gets shorter as you use it. I'm happy to hold this until there's a fix upstream if you'd rather.

### Testing

pipewire 1.6.8, avahi 0.9-rc5, omarchy 4.0.1-1. Ten receivers: a Sonos Beam, two Amps and a One SL, two Apple TVs, two HomePods, a Denon AVR-S760H and a MacBook. Audio came out and the sockets stayed up across a 40 second stream.

### Side note

`omarchy-audio-output-switch` steps through one sink at a time, which works fine with two outputs but gets tedious at ten. Probably wants handling separately.
