### PR TITLE
Report every battery in the machine, not just the first

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -5,6 +5,7 @@
 
 shell_output=false
 power_supply_path="${OMARCHY_POWER_SUPPLY_PATH:-/sys/class/power_supply}"
+display_device="/org/freedesktop/UPower/devices/DisplayDevice"
 
 case "${1:-}" in
   "")
@@ -18,13 +19,90 @@ case "${1:-}" in
     ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
-[[ -z $battery ]] && exit 0
+mapfile -t batteries < <(upower -e 2>/dev/null | grep BAT)
+(( ${#batteries[@]} == 0 )) && exit 0
 
-battery_info=$(upower -i "$battery")
+battery_names=()
+battery_paths=()
+battery_percentages=()
+battery_states=()
+battery_sizes=()
+battery_rates=()
+battery_cycles=()
+threshold_start=""
+threshold_end=""
 
-percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$battery_info")
-capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$battery_info")
+# Reads the value column of the first `upower -i` line carrying $2 as a literal
+# substring. Keys are matched with their trailing colon so "energy-full:" never
+# picks up "energy-full-design:".
+info_field() {
+  awk -v key="$2" -v column="${3:-2}" 'index($0, key) { print $column; exit }' <<<"$1"
+}
+
+# Instantaneous draw for one battery in watts. UPower's own energy-rate can lag
+# the kernel telemetry by tens of seconds, so prefer sysfs when it is readable.
+sysfs_power_rate() {
+  local path="$1"
+
+  if [[ -r $path/power_now ]]; then
+    awk -v microwatts="$(<"$path/power_now")" 'BEGIN { print microwatts / 1000000 }'
+  elif [[ -r $path/current_now && -r $path/voltage_now ]]; then
+    awk \
+      -v microamps="$(<"$path/current_now")" \
+      -v microvolts="$(<"$path/voltage_now")" \
+      'BEGIN { print microamps * microvolts / 1000000000000 }'
+  fi
+}
+
+format_watts() {
+  awk -v rate="${1:-0}" 'BEGIN {
+    rounded = sprintf("%.1f", rate)
+    sub(/\.0$/, "", rounded)
+    print rounded
+  }'
+}
+
+for battery in "${batteries[@]}"; do
+  info=$(upower -i "$battery" 2>/dev/null)
+  [[ -n $info ]] || continue
+
+  native_path=$(info_field "$info" "native-path:")
+  battery_path="$power_supply_path/$native_path"
+  rate=$(sysfs_power_rate "$battery_path")
+  [[ -n $rate ]] || rate=$(info_field "$info" "energy-rate:")
+  # Charge thresholds hang off the individual packs, never off the composite
+  # device, so they have to be picked up here.
+  if [[ -z $threshold_end ]]; then
+    threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$info")
+    threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$info")
+  fi
+
+  cycles=$(info_field "$info" "charge-cycles:")
+  [[ $cycles == "N/A" ]] && cycles=""
+  if [[ -z $cycles && -r $battery_path/cycle_count ]]; then
+    cycles=$(<"$battery_path/cycle_count")
+  fi
+
+  battery_names+=("${native_path:-$(basename "$battery")}")
+  battery_paths+=("$battery_path")
+  battery_percentages+=("$(awk -v value="$(info_field "$info" "percentage:")" 'BEGIN { print int(value + 0.5) }')")
+  battery_states+=("$(info_field "$info" "state:")")
+  battery_sizes+=("$(awk -v value="$(info_field "$info" "energy-full:")" 'BEGIN { printf "%d", value }')")
+  battery_rates+=("$(format_watts "$rate")")
+  battery_cycles+=("$cycles")
+done
+
+# UPower's DisplayDevice is the composite of every battery in the machine, so a
+# ThinkPad carrying an internal cell plus a hot-swap pack reports one runtime,
+# one capacity, and one percentage instead of whichever pack enumerated first.
+# Fall back to that first pack only when the composite is unavailable.
+battery_info=$(upower -i "$display_device" 2>/dev/null)
+if [[ -z $(info_field "$battery_info" "percentage:") ]]; then
+  battery_info=$(upower -i "${batteries[0]}")
+fi
+
+percentage=$(awk -v value="$(info_field "$battery_info" "percentage:")" 'BEGIN { print int(value + 0.5) }')
+capacity=$(awk -v value="$(info_field "$battery_info" "energy-full:")" 'BEGIN { printf "%d", value }')
 time_remaining=$(awk '/time to (empty|full)/ {
   value = $4
   unit = $5
@@ -41,30 +119,17 @@ time_remaining=$(awk '/time to (empty|full)/ {
   }
   exit
 }' <<<"$battery_info")
-power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
-native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
-battery_path="$power_supply_path/$native_path"
+state=$(info_field "$battery_info" "state:")
 
-# UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
-# the instantaneous sysfs reading when available so the open panel stays live.
-if [[ -r $battery_path/power_now ]]; then
-  power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
-elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
-  power_rate_raw=$(awk \
-    -v microamps="$(<"$battery_path/current_now")" \
-    -v microvolts="$(<"$battery_path/voltage_now")" \
-    'BEGIN { print microamps * microvolts / 1000000000000 }')
-fi
+# The composite draw is the sum of what each pack is actually doing right now;
+# an idle pack contributing 0W is the point, not a rounding error.
+power_rate_raw=""
+for rate in "${battery_rates[@]}"; do
+  power_rate_raw=$(awk -v total="${power_rate_raw:-0}" -v rate="$rate" 'BEGIN { print total + rate }')
+done
+[[ -n $power_rate_raw ]] || power_rate_raw=$(info_field "$battery_info" "energy-rate:")
 
-power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
-  rounded = sprintf("%.1f", rate)
-  sub(/\.0$/, "", rounded)
-  print rounded
-}')
-state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
-threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-
+power_rate=$(format_watts "$power_rate_raw")
 [[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
 [[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)
 
@@ -107,7 +172,17 @@ if [[ $shell_output == "true" ]]; then
   printf 'size\t%s\n' "${capacity}Wh"
   printf 'time\t%s\n' "$time_remaining"
 
-  cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | head -1)
+  # Packs wear at their own pace, so a machine with two of them has two counts
+  # to report and no honest way to collapse them into one number.
+  cycles=""
+  for count in "${battery_cycles[@]}"; do
+    [[ -n $count ]] || continue
+    if [[ -n $cycles ]]; then
+      cycles="$cycles · $count"
+    else
+      cycles="$count"
+    fi
+  done
 
   [[ -n $cycles ]] && printf 'cycles\t%s\n' "$cycles"
 
@@ -118,6 +193,20 @@ if [[ $shell_output == "true" ]]; then
       printf 'threshold\t%s%%\n' "$threshold_end"
     fi
   fi
+
+  # Per-pack detail behind numbered keys, so the panel can break the composite
+  # down without a second protocol. Consumers that only want the totals above
+  # can keep ignoring these.
+  printf 'batteries\t%s\n' "${#battery_names[@]}"
+  for i in "${!battery_names[@]}"; do
+    index=$((i + 1))
+    printf 'battery.%s.name\t%s\n' "$index" "${battery_names[i]}"
+    printf 'battery.%s.percentage\t%s%%\n' "$index" "${battery_percentages[i]}"
+    printf 'battery.%s.state\t%s\n' "$index" "${battery_states[i]}"
+    printf 'battery.%s.size\t%sWh\n' "$index" "${battery_sizes[i]}"
+    printf 'battery.%s.rate\t%sW\n' "$index" "${battery_rates[i]}"
+    [[ -n ${battery_cycles[i]} ]] && printf 'battery.%s.cycles\t%s\n' "$index" "${battery_cycles[i]}"
+  done
 
   exit 0
 fi
@@ -131,7 +220,7 @@ if [[ $charge_holding == "true" ]]; then
 
   echo "Battery ${percentage}%  ·  Holding at ${threshold_label}  ·  ${power_rate}W / ${capacity}Wh"
 elif [[ $state == "charging" ]]; then
-  echo "Battery ${percentage}%  ·  ${time_remaining} to full  ·   ${power_rate}W / ${capacity}Wh"
+  echo "Battery ${percentage}%  ·  ${time_remaining} to full  ·   ${power_rate}W / ${capacity}Wh"
 else
-  echo "Battery ${percentage}%  ·  ${time_remaining} left  ·   ${power_rate}W / ${capacity}Wh"
+  echo "Battery ${percentage}%  ·  ${time_remaining} left  ·   ${power_rate}W / ${capacity}Wh"
 fi

--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -52,7 +52,7 @@ The panels aren't read-outs. They're where you actually do the thing:
 - **Audio** has a master volume slider, an output-device picker, and a per-app mixer, so you can turn down that one browser tab without touching everything else.
 - **Network** scans for Wi-Fi, shows signal strength, connects, and lets you pick a DNS provider.
 - **Bluetooth** lists your devices with connect/disconnect and battery levels.
-- **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info.
+- **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info. On a machine with more than one battery — a ThinkPad with an internal cell and a hot-swap pack, say — the headline figures cover the whole machine and a **Batteries** section breaks out each pack.
 - **Display** carries a brightness slider, text size, monitor scaling presets, and — when you have more than one screen — per-monitor controls. See [monitors](33-monitors.md) for the deeper story.
 - **Clock** opens a month grid with ISO week numbers and month stepping.
 

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -89,6 +89,41 @@ function modeLabel(device, onBattery, states) {
   return "Charging"
 }
 
+function fractionFromPercentage(text) {
+  var value = parseFloat(String(text || "").replace("%", ""))
+  if (!isFinite(value)) return 0
+  return Math.max(0, Math.min(1, value / 100))
+}
+
+// omarchy-battery-status reports the composite of every pack in the machine as
+// the top-level keys, then repeats each pack behind numbered ones. Machines
+// with a single battery still emit one entry; the panel decides whether a
+// breakdown is worth drawing.
+function batteryList(info) {
+  var source = info || {}
+  var count = Number(source.batteries || 0)
+  if (!isFinite(count) || count <= 0) return []
+
+  var list = []
+  for (var i = 1; i <= count; i++) {
+    var prefix = "battery." + i + "."
+    var name = source[prefix + "name"]
+    if (!name) continue
+
+    var percentage = source[prefix + "percentage"] || ""
+    list.push({
+      name: String(name),
+      percentage: percentage,
+      fraction: fractionFromPercentage(percentage),
+      state: source[prefix + "state"] || "",
+      size: source[prefix + "size"] || "",
+      rate: source[prefix + "rate"] || "",
+      cycles: source[prefix + "cycles"] || ""
+    })
+  }
+  return list
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampIndex: clampIndex,
@@ -97,6 +132,8 @@ if (typeof module !== "undefined") {
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
+    fractionFromPercentage: fractionFromPercentage,
+    batteryList: batteryList,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,
     modeLabel: modeLabel

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -24,6 +24,9 @@ Panel {
   // icon, so the open-panel mark takes the painted width instead of the
   // icon-sized fraction of the slot the fallback assumes.
   readonly property real openPanelIndicatorWidth: showPercentage && !button.vertical ? button.glyphPaintedWidth : 0
+  // The status command reports every pack in the machine, not just the first
+  // one it enumerates; this is the per-pack breakdown behind the composite.
+  readonly property var batteries: Model.batteryList(root.batteryInfo)
   readonly property bool batteryPresent: {
     var device = UPower.displayDevice
     return !!(device && device.isPresent)
@@ -447,6 +450,68 @@ Panel {
             InfoPair {
               label: root.chargeThresholdActive ? "Battery state" : (root.discharging ? "Discharging" : "Charging")
               value: root.chargeThresholdActive ? "Holding" : (root.batteryFull ? "-" : (root.batteryInfo.rate || ""))
+            }
+          }
+        }
+
+        // ---------- Per-battery breakdown ----------
+        // Everything above is UPower's composite of the whole machine. A
+        // ThinkPad carrying an internal cell plus a hot-swap slice hides which
+        // pack is doing the work behind that one number, so break it out. A
+        // single-battery machine gets no section: the row would only restate
+        // the hero.
+        Column {
+          id: batteryBreakdown
+          visible: root.batteries.length > 1
+          width: parent.width
+          spacing: Style.space(10)
+
+          PanelSeparator {
+            foreground: root.bar.foreground
+          }
+
+          PanelSectionHeader {
+            text: "BATTERIES"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Repeater {
+            model: root.batteries
+
+            Column {
+              required property var modelData
+
+              width: batteryBreakdown.width
+              spacing: Style.spacing.labelGap
+
+              InfoPair {
+                label: modelData.name
+                value: modelData.percentage + "  ·  " + modelData.rate
+              }
+
+              Item {
+                width: parent.width
+                implicitHeight: Style.space(4)
+
+                Rectangle {
+                  id: cellTrack
+                  anchors.fill: parent
+                  radius: height / 2
+                  color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
+                }
+
+                Rectangle {
+                  anchors.left: cellTrack.left
+                  anchors.verticalCenter: cellTrack.verticalCenter
+                  height: cellTrack.height
+                  radius: cellTrack.radius
+                  color: root.batteryFillColor
+                  width: Math.max(cellTrack.height, cellTrack.width * modelData.fraction)
+
+                  Behavior on width { NumberAnimation { duration: 320; easing.type: Easing.OutCubic } }
+                }
+              }
             }
           }
         }

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -44,6 +44,101 @@ grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status re
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
 grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
 
+pass "battery status reports a single pack"
+
+# A ThinkPad with an internal cell and a hot-swap slice: reading whichever pack
+# enumerates first reports 5% and 22Wh on a machine that is actually at 11% of
+# 46Wh, so the composite has to come from UPower's DisplayDevice.
+multi_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir" "$multi_dir"' EXIT
+
+mkdir -p "$multi_dir/bin"
+mkdir -p "$multi_dir/power/BAT0" "$multi_dir/power/BAT1"
+printf '0\n' >"$multi_dir/power/BAT0/power_now"
+printf '6\n' >"$multi_dir/power/BAT0/cycle_count"
+printf '20514000\n' >"$multi_dir/power/BAT1/power_now"
+printf '12\n' >"$multi_dir/power/BAT1/cycle_count"
+cat >"$multi_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  case "$2" in
+    */DisplayDevice)
+      cat <<'INFO'
+  battery
+    present:             yes
+    state:               discharging
+    energy:              5.06 Wh
+    energy-full:         46.75 Wh
+    energy-rate:         19.972 W
+    charge-cycles:       N/A
+    time to empty:       15.2 minutes
+    percentage:          10.8235%
+INFO
+      exit 0
+      ;;
+    */battery_BAT0)
+      cat <<'INFO'
+  native-path:          BAT0
+    state:               pending-charge
+    energy:              1.23 Wh
+    energy-full:         22.96 Wh
+    energy-rate:         0 W
+    charge-cycles:       6
+    percentage:          5%
+    charge-start-threshold:        75%
+    charge-end-threshold:          80%
+INFO
+      exit 0
+      ;;
+    */battery_BAT1)
+      cat <<'INFO'
+  native-path:          BAT1
+    state:               discharging
+    energy:              3.89 Wh
+    energy-full:         23.79 Wh
+    energy-rate:         20.514 W
+    charge-cycles:       12
+    percentage:          16%
+    charge-start-threshold:        75%
+    charge-end-threshold:          80%
+INFO
+      exit 0
+      ;;
+  esac
+fi
+
+exit 1
+STUB
+chmod +x "$multi_dir/bin/upower"
+
+multi_output=$(OMARCHY_POWER_SUPPLY_PATH="$multi_dir/power" PATH="$multi_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'percentage\t11%' <<<"$multi_output" >/dev/null || fail "battery status reports the composite percentage" "$multi_output"
+grep -Fx $'size\t46Wh' <<<"$multi_output" >/dev/null || fail "battery status sums capacity across packs" "$multi_output"
+grep -Fx $'rate\t20.5W' <<<"$multi_output" >/dev/null || fail "battery status sums draw across packs" "$multi_output"
+grep -Fx $'time\t15m' <<<"$multi_output" >/dev/null || fail "battery status reports the composite runtime" "$multi_output"
+grep -Fx $'cycles\t6 · 12' <<<"$multi_output" >/dev/null || fail "battery status reports every cycle count" "$multi_output"
+grep -Fx $'threshold\t75-80%' <<<"$multi_output" >/dev/null || fail "battery status keeps charge thresholds off the composite device" "$multi_output"
+
+grep -Fx $'batteries\t2' <<<"$multi_output" >/dev/null || fail "battery status counts the packs" "$multi_output"
+grep -Fx $'battery.1.name\tBAT0' <<<"$multi_output" >/dev/null || fail "battery status names the first pack" "$multi_output"
+grep -Fx $'battery.1.percentage\t5%' <<<"$multi_output" >/dev/null || fail "battery status breaks out the first pack" "$multi_output"
+grep -Fx $'battery.1.rate\t0W' <<<"$multi_output" >/dev/null || fail "battery status reports an idle pack as drawing nothing" "$multi_output"
+grep -Fx $'battery.1.cycles\t6' <<<"$multi_output" >/dev/null || fail "battery status breaks out per-pack cycles" "$multi_output"
+grep -Fx $'battery.2.name\tBAT1' <<<"$multi_output" >/dev/null || fail "battery status names the second pack" "$multi_output"
+grep -Fx $'battery.2.percentage\t16%' <<<"$multi_output" >/dev/null || fail "battery status breaks out the second pack" "$multi_output"
+grep -Fx $'battery.2.rate\t20.5W' <<<"$multi_output" >/dev/null || fail "battery status breaks out per-pack draw" "$multi_output"
+grep -Fx $'battery.2.size\t23Wh' <<<"$multi_output" >/dev/null || fail "battery status breaks out per-pack capacity" "$multi_output"
+
+pass "battery status aggregates every pack in the machine"
+
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"
 fi

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -42,6 +42,26 @@ assertEqual(
   'power shows battery icon when unplugged before battery state refreshes'
 )
 
+assertDeepEqual(
+  power.batteryList({
+    percentage: '11%',
+    batteries: '2',
+    'battery.1.name': 'BAT0', 'battery.1.percentage': '5%', 'battery.1.state': 'pending-charge', 'battery.1.size': '22Wh', 'battery.1.rate': '0W', 'battery.1.cycles': '6',
+    'battery.2.name': 'BAT1', 'battery.2.percentage': '16%', 'battery.2.state': 'discharging', 'battery.2.size': '23Wh', 'battery.2.rate': '20.5W', 'battery.2.cycles': '12'
+  }),
+  [
+    { name: 'BAT0', percentage: '5%', fraction: 0.05, state: 'pending-charge', size: '22Wh', rate: '0W', cycles: '6' },
+    { name: 'BAT1', percentage: '16%', fraction: 0.16, state: 'discharging', size: '23Wh', rate: '20.5W', cycles: '12' }
+  ],
+  'power breaks the composite battery down per pack'
+)
+assertDeepEqual(power.batteryList({ percentage: '51%' }), [], 'power reports no packs when the status command predates the breakdown')
+assertEqual(power.fractionFromPercentage('120%'), 1, 'power clamps a per-pack fraction')
+assertEqual(power.fractionFromPercentage(''), 0, 'power treats a missing per-pack percentage as empty')
+
+assert(/visible: root\.batteries\.length > 1/.test(panelSource), 'power hides the breakdown on single-battery machines')
+assert(/readonly property var batteries: Model\.batteryList\(root\.batteryInfo\)/.test(panelSource), 'power sources the breakdown from the status command')
+
 assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')
 assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon')


### PR DESCRIPTION
## The bug

`omarchy-battery-status` picks its battery with `upower -e | grep BAT | head -n 1`, so on a machine with two packs it reports one. ThinkPads with an internal cell plus a hot-swap slice are the common case.

On my X280 the power panel read **5% · 22Wh · cycles 6 · 0W · no time left** while the machine was actually at **11% of 46Wh, drawing 20W, 15 minutes from empty** — the internal pack happened to enumerate first and happened to be idle.

The panel contradicted itself on the same surface, too: the hero percentage comes from this command, but the progress bar under it reads `UPower.displayDevice`, which is already the composite. The text said 5% next to a bar drawn at 11%.

## The fix

Take the headline figures from UPower's `DisplayDevice` — the composite of every pack, which UPower already maintains and which the bar icon and the low-battery service were using all along — and sum the instantaneous sysfs draw across all packs rather than reading one.

Two details do not come from the composite:

- **Charge thresholds** hang off the individual packs; `DisplayDevice` does not carry them, so they are still read from a real battery (falling back to sysfs as before).
- **Cycle counts** are reported per pack (`6 · 12`). Packs wear at their own pace and there is no honest way to collapse two counts into one number.

## Showing both

The status command now also emits each pack behind numbered keys (`batteries`, `battery.1.name`, `battery.1.percentage`, …), and the power panel breaks the composite down into a `BATTERIES` section when there is more than one:

<img width="361" height="355" alt="image" src="https://github.com/user-attachments/assets/b7356236-b2b0-445a-9ff1-474e1bfb86aa" />

Single-battery machines are untouched: one entry means no section, so the panel looks exactly as it does today. An older `omarchy-battery-status` that emits no entries at all is handled the same way, so a half-updated tree degrades rather than breaks.

## See also
[https://github.com/omacom/omarchy/pull/9106](https://github.com/omacom/omarchy/pull/9106)

## Verification

- `test/shell.d/battery-status-test.sh` — the existing single-battery scenario is unchanged and still passes; a new two-battery scenario stubs `upower` with `BAT0`/`BAT1`/`DisplayDevice` and asserts the composite figures, the joined cycle counts, the thresholds staying off the composite device, and every per-pack key.
- `test/shell.d/power-test.sh` — `Model.batteryList` parsing, fraction clamping, the empty case, and the panel bindings.
- `./test/shell` and `./test/cli` pass. Six shell files fail on this machine both with and without the change (`bar-icon-geometry`, `config`, `snapper`, `theme-install-guards`, `unowned-system-paths`, `windows-vm-mount-boundary`); they are environment checks against an unlinked checkout, not regressions here.
- Verified in the running UI on a two-battery ThinkPad: the shell was restarted against this checkout, the panel opened over IPC, and the result screenshotted. Hero percentage and progress bar now agree, capacity reads 46Wh, and both packs appear with correct fills.
