### PR TITLE
Match sshd -T keywords case-insensitively when verifying SSH hardening

### DIFF
--- a/bin/omarchy-setup-security-sshd
+++ b/bin/omarchy-setup-security-sshd
@@ -172,9 +172,11 @@ CONF
 
   # Syntax alone is insufficient because sshd uses the first value it reads for
   # these settings. An earlier administrator rule could leave passwords enabled.
+  # Match keywords case-insensitively: OpenSSH 9.x dumps them lowercase, 10.x
+  # in CamelCase.
   if ! effective_config=$(sudo sshd -T) ||
-    ! grep -qxF "passwordauthentication no" <<<"$effective_config" ||
-    ! grep -qxF "kbdinteractiveauthentication no" <<<"$effective_config"; then
+    ! grep -qixF "passwordauthentication no" <<<"$effective_config" ||
+    ! grep -qixF "kbdinteractiveauthentication no" <<<"$effective_config"; then
     echo -e "\e[31msshd did not apply the password-authentication restrictions; removing the ineffective config.\e[0m" >&2
     sudo rm -f "$config"
     return 1

--- a/test/shell.d/setup-security-sshd-test.sh
+++ b/test/shell.d/setup-security-sshd-test.sh
@@ -29,8 +29,14 @@ case $1 in
   [[ ${SSHD_SYNTAX_VALID:-1} == 1 ]]
   ;;
 -T)
-  printf 'passwordauthentication %s\n' "${SSHD_PASSWORD_AUTH:-no}"
-  printf 'kbdinteractiveauthentication %s\n' "${SSHD_KBD_AUTH:-no}"
+  # OpenSSH 10.x dumps keywords in CamelCase; 9.x dumped them lowercase.
+  if [[ ${SSHD_DUMP_LOWERCASE:-0} == 1 ]]; then
+    printf 'passwordauthentication %s\n' "${SSHD_PASSWORD_AUTH:-no}"
+    printf 'kbdinteractiveauthentication %s\n' "${SSHD_KBD_AUTH:-no}"
+  else
+    printf 'PasswordAuthentication %s\n' "${SSHD_PASSWORD_AUTH:-no}"
+    printf 'KbdInteractiveAuthentication %s\n' "${SSHD_KBD_AUTH:-no}"
+  fi
   ;;
 *)
   exit 2
@@ -81,6 +87,12 @@ grep -qxF "KbdInteractiveAuthentication no" "$config" || fail "SSH setup disable
 grep -qxF "systemctl reload sshd.service" "$test_dir/success.calls" || fail "SSH setup reloads the validated config"
 grep -q "Password logins are off" <<<"$output" || fail "SSH setup reports hardening after it succeeds"
 pass "SSH setup authorizes a key and disables password logins"
+
+output=$(SSHD_DUMP_LOWERCASE=1 run_setup success-legacy)
+config="$test_dir/success-legacy/root/etc/ssh/sshd_config.d/10-omarchy-hardening.conf"
+[[ -e $config ]] || fail "SSH setup accepts the lowercase sshd -T dump of OpenSSH 9.x"
+grep -q "Password logins are off" <<<"$output" || fail "SSH setup reports hardening on OpenSSH 9.x"
+pass "SSH setup verifies settings across sshd -T keyword casings"
 
 if SSHD_PASSWORD_AUTH=yes run_setup ineffective >"$test_dir/ineffective.output" 2>&1; then
   fail "SSH setup must fail when password authentication remains effective"


### PR DESCRIPTION
## Problem

`omarchy-setup-security-sshd` (#9200) verifies its hardening drop-in took effect by grepping `sshd -T` for `passwordauthentication no` / `kbdinteractiveauthentication no`. OpenSSH 10.x changed the `sshd -T` dump to print keywords in CamelCase (`PasswordAuthentication no`), where 9.x printed them lowercase.

The case-sensitive grep therefore never matches on OpenSSH 10.x (current Arch ships 10.5p1): the script concludes the config is ineffective, deletes the drop-in, and prints `sshd did not apply the password-authentication restrictions; removing the ineffective config.` — leaving password authentication enabled on every fresh install that runs the wizard. Reproduced on a fresh v4-0-2 ISO install and confirmed against openssh 10.5p1-1: the drop-in *was* effective (`sshd -T` reports `PasswordAuthentication no`); only the verification is broken.

## Fix

Make both greps case-insensitive (`grep -qixF`), accepting either casing.

The unit test passed because its `sshd -T` stub emitted the old lowercase format. The stub now emits the OpenSSH 10.x CamelCase dump by default, with a legacy-lowercase scenario so both casings stay covered — the updated test fails against the unfixed script.

## Tests

- `test/shell.d/setup-security-sshd-test.sh` — all pass; fails as expected with the fix reverted
- Full `./test/shell`: only pre-existing environmental failures (missing omarchy-pkgs checkout, live-session smoke test)

Intended to be picked into 4-0-2.