### PR TITLE
Add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Report a vulnerability
+
+If you believe you have found a security vulnerability in Omarchy, please report it privately to the [Omarchy Security Team](https://omarchy.org/teams/#security) at [security@omarchy.org](mailto:security@omarchy.org?subject=Security%20report).
+
+Please do not report potential vulnerabilities publicly in GitHub Issues, Discord, or social media before they have been resolved. We aim to acknowledge reports within 24 hours and will keep you informed as we are able while we investigate and work toward a resolution.
+
+## What we consider a vulnerability
+
+We consider a bug a security vulnerability when it can be exploited to cross a meaningful security boundary: an untrusted or lower-privileged party gains access, permissions, or control they did not already have.
+
+Code that could be more robust but does not cross a security boundary is an improvement rather than a security vulnerability. We may still merge a proposed hardening fix and credit the reporter in our release notes.
+
+## What to include
+
+Please give us enough information to understand and reproduce the issue:
+
+- The affected component and Omarchy version.
+- An explanation of what an attacker can do before and after exploitation.
+- Steps to reproduce the issue and any proof of concept.
+- Your preferred contact details for follow-up.
+
+## Responsible disclosure
+
+Please act in good faith while investigating and reporting vulnerabilities:
+
+- Only test systems and accounts you own or have explicit permission to test.
+- Avoid privacy violations, disruption, data destruction, and service degradation.
+- Do not exploit a vulnerability beyond what is needed to demonstrate it.
+- Give us a reasonable opportunity to investigate and address the issue before publishing details.
+
+## Credit
+
+Researchers who privately report a confirmed security vulnerability and give us the opportunity to ship a fix are eligible for recognition on the [Omarchy security credits](https://omarchy.org/security/credits/) page. Eligibility depends on whether the report identifies a confirmed security vulnerability, not on its severity. For duplicate reports, only the first reporter is eligible for public credit.
+
+Accepted improvements that do not cross a security boundary may still be credited in our release notes.
+
+## Regular bugs and support
+
+For anything that is not a security vulnerability, please use the [Omarchy issue tracker](https://github.com/omacom/omarchy/issues).
+
+The complete public reporting guidance is available at [omarchy.org/security](https://omarchy.org/security/).

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,20 +1,24 @@
-# Security Policy
+# Security at Omarchy
 
 ## Report a vulnerability
 
-If you believe you have found a security vulnerability in Omarchy, please report it privately to the [Omarchy Security Team](https://omarchy.org/teams/#security) at [security@omarchy.org](mailto:security@omarchy.org?subject=Security%20report).
+If you believe you’ve found a security vulnerability in Omarchy, please tell the [Omarchy Security Team](https://omarchy.org/teams/#security) privately so we have an opportunity to investigate and fix it before it is made public.
 
-Please do not report potential vulnerabilities publicly in GitHub Issues, Discord, or social media before they have been resolved. We aim to acknowledge reports within 24 hours and will keep you informed as we are able while we investigate and work toward a resolution.
+[security@omarchy.org](mailto:security@omarchy.org?subject=Security%20report)
 
-## What we consider a vulnerability
+Please don’t report potential vulnerabilities publicly in GitHub Issues, Discord, or social media before they’ve been resolved.
 
-We consider a bug a security vulnerability when it can be exploited to cross a meaningful security boundary: an untrusted or lower-privileged party gains access, permissions, or control they did not already have.
+## What is a vulnerability?
 
-Code that could be more robust but does not cross a security boundary is an improvement rather than a security vulnerability. We may still merge a proposed hardening fix and credit the reporter in our release notes.
+We consider a bug a security vulnerability when it can be exploited to cross a meaningful security boundary: an untrusted or lower-privileged party gains access, permissions, or control they didn’t already have.
+
+Code that could be more robust but does not cross a security boundary is an improvement rather than a security vulnerability. We may still merge a proposed fix and credit the reporter in our release notes.
+
+Eligibility for our [security credits](https://omarchy.org/security/credits/) page depends on whether a report identifies a confirmed security vulnerability, not on its severity.
 
 ## What to include
 
-Please give us enough information to understand and reproduce the issue:
+Give us enough information to understand and reproduce the issue:
 
 - The affected component and Omarchy version.
 - An explanation of what an attacker can do before and after exploitation.
@@ -27,17 +31,17 @@ Please act in good faith while investigating and reporting vulnerabilities:
 
 - Only test systems and accounts you own or have explicit permission to test.
 - Avoid privacy violations, disruption, data destruction, and service degradation.
-- Do not exploit a vulnerability beyond what is needed to demonstrate it.
+- Don’t exploit a vulnerability beyond what is needed to demonstrate it.
 - Give us a reasonable opportunity to investigate and address the issue before publishing details.
 
-## Credit
+We’ll review your report and keep you informed as we’re able while we work toward a resolution.
 
-Researchers who privately report a confirmed security vulnerability and give us the opportunity to ship a fix are eligible for recognition on the [Omarchy security credits](https://omarchy.org/security/credits/) page. Eligibility depends on whether the report identifies a confirmed security vulnerability, not on its severity. For duplicate reports, only the first reporter is eligible for public credit.
+## Credits
 
-Accepted improvements that do not cross a security boundary may still be credited in our release notes.
+Researchers who privately report a confirmed security vulnerability and give us the chance to ship a fix are thanked on the [security credits](https://omarchy.org/security/credits/) page. Accepted improvements that don’t cross a security boundary may still be credited in our release notes.
+
+Credits link to each reporter’s X profile and show their avatar. For duplicate reports, only the first reporter is eligible for credit.
 
 ## Regular bugs and support
 
-For anything that is not a security vulnerability, please use the [Omarchy issue tracker](https://github.com/omacom/omarchy/issues).
-
-The complete public reporting guidance is available at [omarchy.org/security](https://omarchy.org/security/).
+For anything that isn’t a security vulnerability, please use the [Omarchy issue tracker](https://github.com/omacom/omarchy/issues).


### PR DESCRIPTION
## Summary

- add a GitHub-recognized security policy using the exact public guidance from `omarchy.org/security`
- preserve the site wording while translating its HTML structure to Markdown and making relative links absolute

## Verification

- `git diff --check`
- verified every public link in the policy returns HTTP 200