### PR TITLE
Require interactive confirmation for AUR installs and updates

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -41,7 +41,7 @@ chromium)
   ;;
 chrome)
   echo "Installing Chrome..."
-  omarchy-pkg-aur-add google-chrome || exit 1
+  omarchy-pkg-aur-add --yes google-chrome || exit 1
 
   setup_chromium_policy_directory /etc/opt/chrome/policies/managed
   copy_chromium_flags ~/.config/chrome-flags.conf
@@ -50,7 +50,7 @@ chrome)
   ;;
 edge)
   echo "Installing Edge..."
-  omarchy-pkg-aur-add microsoft-edge-stable-bin || exit 1
+  omarchy-pkg-aur-add --yes microsoft-edge-stable-bin || exit 1
 
   setup_chromium_policy_directory /etc/opt/edge/policies/managed
   copy_chromium_flags ~/.config/microsoft-edge-stable-flags.conf
@@ -59,7 +59,7 @@ edge)
   ;;
 brave)
   echo "Installing Brave..."
-  omarchy-pkg-aur-add brave-bin || exit 1
+  omarchy-pkg-aur-add --yes brave-bin || exit 1
 
   setup_chromium_policy_directory /etc/brave/policies/managed
   copy_chromium_flags ~/.config/brave-flags.conf
@@ -68,7 +68,7 @@ brave)
   ;;
 brave-origin)
   echo "Installing Brave Origin..."
-  omarchy-pkg-aur-add brave-origin-bin || exit 1
+  omarchy-pkg-aur-add --yes brave-origin-bin || exit 1
 
   setup_chromium_policy_directory /etc/brave/policies/managed
   copy_chromium_flags ~/.config/brave-origin-flags.conf
@@ -85,7 +85,7 @@ firefox)
   ;;
 zen)
   echo "Installing Zen..."
-  omarchy-pkg-aur-add zen-browser-bin || exit 1
+  omarchy-pkg-aur-add --yes zen-browser-bin || exit 1
 
   browser_policy_setup_firefox_distribution /opt/zen-browser/distribution
   setup_firefox_wayland

--- a/bin/omarchy-install-editor-emacs
+++ b/bin/omarchy-install-editor-emacs
@@ -3,7 +3,7 @@
 # omarchy:summary=Install Emacs with Omarchy theme and font integration via the omarchy-emacs AUR package
 
 echo "Installing Emacs..."
-omarchy-pkg-aur-add omarchy-emacs && omarchy-install-emacs
+omarchy-pkg-aur-add --yes omarchy-emacs && omarchy-install-emacs
 
 # emacsclient opens a frame on the running daemon, not a second Emacs
 setsid uwsm-app -- gtk-launch emacsclient >/dev/null 2>&1 &

--- a/bin/omarchy-pkg-aur-add
+++ b/bin/omarchy-pkg-aur-add
@@ -1,13 +1,46 @@
 #!/bin/bash
 
-# omarchy:summary=Add the named packages to the system from the AUR if they're missing. Returns false if it couldn't be done.
-# omarchy:args=<packages...>
+# omarchy:summary=Add the named packages to the system from the AUR if they're missing, after an interactive confirmation. Returns false if it couldn't be done.
+# omarchy:args=<packages...> [--yes]
+# omarchy:examples=omarchy pkg aur add libfprint-goodix53x5 | omarchy pkg aur add --yes libfprint-goodix53x5
 
-if omarchy-pkg-missing "$@"; then
-  yay -S --noconfirm --needed "$@" || exit 1
+skip_confirmation=0
+packages=()
+
+for arg in "$@"; do
+  if [[ $arg == "--yes" ]]; then
+    skip_confirmation=1
+  else
+    packages+=("$arg")
+  fi
+done
+
+if (( ${#packages[@]} == 0 )); then
+  echo "Usage: omarchy pkg aur add <packages...> [--yes]" >&2
+  exit 1
 fi
 
-for pkg in "$@"; do
+if omarchy-pkg-missing "${packages[@]}"; then
+  # AUR PKGBUILDs are unsigned and run as this user before any sudo prompt,
+  # so installing from the AUR is a trust decision for a human, not for a
+  # script or agent (see manual/48-security.md).
+  if (( skip_confirmation == 0 )); then
+    if [[ ! -t 0 ]]; then
+      echo "AUR installs need an interactive confirmation." >&2
+      echo "The AUR is unsigned: PKGBUILDs run as your user before any sudo" >&2
+      echo "prompt. Run this yourself in a terminal, or pass --yes to accept" >&2
+      echo "that risk on purpose." >&2
+      exit 1
+    fi
+    echo "The AUR is unsigned: the PKGBUILDs for ${packages[*]} run as your user."
+    if ! gum confirm "Install ${packages[*]} from the AUR?"; then
+      exit 1
+    fi
+  fi
+  yay -S --noconfirm --needed "${packages[@]}" || exit 1
+fi
+
+for pkg in "${packages[@]}"; do
   # Secondary check to handle states where pacman doesn't actually register an error
   if ! pacman -Q "$pkg" &>/dev/null; then
     echo -e "\033[31mError: Package '$pkg' did not install\033[0m" >&2

--- a/bin/omarchy-update-aur-pkgs
+++ b/bin/omarchy-update-aur-pkgs
@@ -1,10 +1,31 @@
 #!/bin/bash
 
-# omarchy:summary=Update AUR packages if any are installed
+# omarchy:summary=Update AUR packages if any are installed, after an interactive confirmation
+# omarchy:args=[--yes]
+
+skip_confirmation=0
+if [[ ${1:-} == "--yes" ]]; then
+  skip_confirmation=1
+fi
 
 if pacman -Qem >/dev/null; then
   if omarchy-pkg-aur-accessible; then
+    # An AUR update re-runs each PKGBUILD as this user, so it gets the same
+    # human confirmation as an install (see manual/48-security.md).
+    if (( skip_confirmation == 0 )) && [[ ! -t 0 ]]; then
+      echo -e "\e[33m\nAUR updates skipped: PKGBUILDs re-run as your user, which needs an interactive confirmation\e[0m"
+      echo
+      exit 0
+    fi
     echo -e "\e[32m\nUpdate AUR packages\e[0m"
+    if (( skip_confirmation == 0 )); then
+      echo "AUR packages re-run their PKGBUILDs as your user:"
+      pacman -Qemq
+      if ! gum confirm "Update AUR packages?"; then
+        echo
+        exit 0
+      fi
+    fi
     yay -Sua --noconfirm --cleanafter --ignore gcc14,gcc14-libs
     echo
   else

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1240,7 +1240,9 @@ run_post_upgrade_update_steps() {
   local update_output update_status
 
   if PATH="$package_path" command -v omarchy-update-aur-pkgs >/dev/null 2>&1; then
-    if ! run_as_user_omarchy omarchy-update-aur-pkgs; then
+    # The upgrade already has the user's consent, so AUR updates within it skip
+    # the interactive confirmation omarchy-update-aur-pkgs now asks for.
+    if ! run_as_user_omarchy omarchy-update-aur-pkgs --yes; then
       warn "Could not update AUR packages; running omarchy-update after reboot may still update AUR packages."
     fi
   fi

--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -52,6 +52,8 @@ matching guide before starting:
 
 For privileged commands, follow the Privilege Escalation rules below: `sudo` when a terminal is available for the password prompt, `pkexec` when it is not. Do not wrap commands that already manage privilege elevation themselves.
 
+Never install packages from the AUR without an explicit user request. Prefer `omarchy pkg add` (signed repositories). `omarchy pkg aur add` asks the user to confirm because AUR PKGBUILDs are unsigned and run as the user, and it fails by design when no terminal is available for the prompt.
+
 **For end-user customization tasks, NEVER modify anything in `/usr/share/omarchy/`** - but READING is safe and encouraged.
 
 This directory is owned by the omarchy package. Any local changes will be
@@ -253,7 +255,7 @@ When user requests system changes:
 2. **Is it a config edit?** Edit in `~/.config/`, never `/usr/share/omarchy/`
 3. **Is it a theme customization?** Follow [`theming.md`](theming.md); create a NEW custom theme directory
 4. **Is it automation?** Follow [`hooks.md`](hooks.md); use `omarchy hook install` and the hook `.d` directories
-5. **Is it a package install?** Use `omarchy pkg add <pkgs...>` (or `omarchy pkg aur add <pkgs...>` for AUR-only packages)
+5. **Is it a package install?** Use `omarchy pkg add <pkgs...>` (or `omarchy pkg aur add <pkgs...>` for AUR-only packages — only with an explicit user request; it prompts the user to confirm, see Critical Safety Rules)
 6. **Is it built-in shell/plugin code?** Follow [`plugins.md`](plugins.md); clone it with `omarchy plugin clone`, never edit the packaged copy
 7. **Unsure if command exists?** Run `omarchy commands` (or `omarchy <group> --help` for one group)
 

--- a/manual/48-security.md
+++ b/manual/48-security.md
@@ -24,6 +24,12 @@ Sometimes you want `sudo` to stop asking, most often when an AI agent is doing a
 
 Be clear-eyed about this one: while it's on, anything running as your user can do anything as root without being asked. That's the whole point, and it's also the whole risk.
 
+## The AUR
+
+The Arch User Repository is where anything not packaged in the official repositories (or Omarchy's own) lives, and it's unsigned. Installing an AUR package means downloading its PKGBUILD recipe and running it as your user _before_ any sudo prompt appears, so a malicious recipe is arbitrary code execution. That's why the base install doesn't touch the AUR at all, and why Omarchy asks you to confirm every AUR install.
+
+When you run `omarchy pkg aur add <package>` in a terminal, you get a yes/no prompt before anything is fetched and built. AUR updates re-run the recipes, so `omarchy update` asks the same way when AUR packages are due. Scripts and agents can't answer prompts, so they fail by design. Pass `--yes` to skip the confirmation when you've already decided to trust a package.
+
 ## Signing Keys
 
 The public key for all ISO signatures and Omarchy repo package is `40DFB630FF42BCFFB047046CF0134EE680CAC571` ([verify at openpgp.org](https://keys.openpgp.org/search?q=pkgs%40omarchy.org)). The `omarchy/omarchy-keyring` package contains this as well and will be used to rollout any potential updates seamlessly.

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -63,6 +63,9 @@ fi
 case $installer in
 omarchy-pkg-add|omarchy-pkg-aur-add)
   package=$1
+  if [[ $package == "--yes" ]]; then
+    package=$2
+  fi
   printf 'pkg:%s\n' "$package" >>"$OMARCHY_TEST_INSTALL_LOG"
   case $package in
   chromium) command=chromium ;;

--- a/test/shell.d/pkg-aur-add-gate-test.sh
+++ b/test/shell.d/pkg-aur-add-gate-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_path="$test_tmp/aur-gate-bin"
+mkdir -p "$mock_path"
+
+# pacman reports every queried package missing until yay has run, so the
+# pre-install check proceeds and the post-install check passes.
+cat >"$mock_path/pacman" <<'EOF'
+#!/bin/bash
+if [[ -e "$TEST_TMP/yay-ran" ]]; then
+  exit 0
+fi
+exit 1
+EOF
+
+cat >"$mock_path/yay" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >"$TEST_TMP/yay-command"
+touch "$TEST_TMP/yay-ran"
+EOF
+
+chmod +x "$mock_path/pacman" "$mock_path/yay"
+
+# The test runner has no terminal, so an unflagged call is the non-interactive
+# caller the gate exists to stop.
+gate_status=0
+PATH="$mock_path:$ROOT/bin:$PATH" TEST_TMP="$test_tmp" \
+  "$ROOT/bin/omarchy-pkg-aur-add" some-aur-pkg </dev/null 2>"$test_tmp/gate-stderr" || gate_status=$?
+(( gate_status == 1 )) || fail "non-interactive AUR install is refused"
+if [[ -e $test_tmp/yay-ran ]]; then
+  fail "refused AUR install never reaches yay"
+fi
+grep -q "interactive confirmation" "$test_tmp/gate-stderr" || fail "refusal explains how to proceed"
+pass "non-interactive AUR installs are refused with guidance"
+
+rm -f "$test_tmp/yay-ran" "$test_tmp/yay-command"
+PATH="$mock_path:$ROOT/bin:$PATH" TEST_TMP="$test_tmp" \
+  "$ROOT/bin/omarchy-pkg-aur-add" --yes first-aur-pkg second-aur-pkg
+[[ $(<"$test_tmp/yay-command") == "-S --noconfirm --needed first-aur-pkg second-aur-pkg" ]] ||
+  fail "--yes passes the packages straight to yay"
+pass "--yes installs without a prompt"
+
+rm -f "$test_tmp/yay-ran" "$test_tmp/yay-command"
+PATH="$mock_path:$ROOT/bin:$PATH" TEST_TMP="$test_tmp" \
+  "$ROOT/bin/omarchy-pkg-aur-add" flag-position-pkg --yes
+[[ $(<"$test_tmp/yay-command") == "-S --noconfirm --needed flag-position-pkg" ]] ||
+  fail "--yes is accepted after package names"
+pass "--yes works in any argument position"
+
+usage_status=0
+PATH="$mock_path:$ROOT/bin:$PATH" TEST_TMP="$test_tmp" \
+  "$ROOT/bin/omarchy-pkg-aur-add" --yes 2>/dev/null || usage_status=$?
+(( usage_status == 1 )) || fail "no packages named is a usage error"
+pass "asking for --yes without packages is a usage error"


### PR DESCRIPTION
### Summary

Adds an interactive confirmation prompt before building/installing or updating AUR packages, while providing a `--yes` bypass flag for callers that already have explicit user consent.

### Motivation

AUR packages execute user-contributed `PKGBUILD` scripts during build and installation. Requiring explicit human consent ensures unattended tools and agents do not silently pull and execute untrusted AUR scripts.

### Changes

- **`bin/omarchy-pkg-aur-add`**: Added interactive confirmation prompt with `gum confirm` before invoking `yay`. Supports `--yes` flag to bypass.
- **`bin/omarchy-update-aur-pkgs`**: Prompts before running AUR upgrades, with non-interactive fallback notices and `--yes` support.
- **`bin/omarchy-install-browser` & `bin/omarchy-install-editor-emacs`**: Pass `--yes` since the user explicitly selected the application from a menu/installer.
- **`bin/omarchy-upgrade-to-quattro`**: Passes `--yes` during orchestrated system upgrades.
- **`default/agents/skills/omarchy/SKILL.md`**: Added guidance on AUR package safety.
- **`manual/48-security.md`**: Documented AUR risks and the confirmation gate in the security chapter.
- **`test/shell.d/pkg-aur-add-gate-test.sh`**: Added automated tests for prompt behavior and bypass flag.