### PR TITLE
Snapshot every package operation with snap-pac and keep ten

### DIFF
--- a/default/snapper/root
+++ b/default/snapper/root
@@ -1,10 +1,11 @@
-# Omarchy snapshots root only for pre-update recovery — kept to 5, no timeline
+# Omarchy snapshots root for pre-update and per-package-operation recovery via
+# snap-pac — kept to 10 (a pre/post pair takes two slots), no timeline
 SUBVOLUME="/"
 FSTYPE="btrfs"
 
 NUMBER_CLEANUP="yes"
 NUMBER_MIN_AGE="0"
-NUMBER_LIMIT="5"
+NUMBER_LIMIT="10"
 NUMBER_LIMIT_IMPORTANT="5"
 
 TIMELINE_CREATE="no"

--- a/etc/limine-entry-tool.d/omarchy-defaults.conf
+++ b/etc/limine-entry-tool.d/omarchy-defaults.conf
@@ -17,11 +17,11 @@ FIND_BOOTLOADERS=yes
 
 BOOT_ORDER="*, *fallback, Snapshots"
 
-# Snapper is configured with NUMBER_LIMIT="5" (see default/snapper/root), but
-# limine-snapper-sync can see the newly created sixth snapshot before cleanup
-# restores the retained snapshot count to 5. Allow for that creation window:
-#   Snapshot limit mismatch: 6 Snapper snapshots exceed configured
-#   MAX_SNAPSHOT_ENTRIES=5
-MAX_SNAPSHOT_ENTRIES=6
+# Snapper is configured with NUMBER_LIMIT="10" (see default/snapper/root), but
+# limine-snapper-sync can see the newly created eleventh snapshot before cleanup
+# restores the retained snapshot count to 10. Allow for that creation window:
+#   Snapshot limit mismatch: 11 Snapper snapshots exceed configured
+#   MAX_SNAPSHOT_ENTRIES=10
+MAX_SNAPSHOT_ENTRIES=11
 
 SNAPSHOT_FORMAT_CHOICE=5

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -38,6 +38,7 @@ pipewire-alsa
 pipewire-jack
 pipewire-pulse
 qt6-wayland
+snap-pac
 snapper
 sof-firmware
 thermald

--- a/manual/47-system-snapshots.md
+++ b/manual/47-system-snapshots.md
@@ -1,6 +1,6 @@
 # System snapshots
 
-We create snapshots automatically on every Omarchy update, but should you want to create your own, you can use `omarchy-snapshot create`.
+We create snapshots automatically on every Omarchy update, and snap-pac adds a pre/post pair around every package operation, so a bad install or update can be rolled back from the boot loader. Should you want to create your own, you can use `omarchy-snapshot create`.
 
 To boot and restore a snapshot, you select it from the Limine boot loader. (If you're currently booting straight into the Omarchy decryption screen, you'll need to select Limine as a boot option via the BIOS first).
 

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -9,11 +9,11 @@ limine_defaults="$ROOT/etc/limine-entry-tool.d/omarchy-defaults.conf"
 limine_notify_autostart="$ROOT/config/autostart/limine-snapper-notify.desktop"
 
 grep -Fx 'NUMBER_CLEANUP="yes"' "$template" >/dev/null
-grep -Fx 'NUMBER_LIMIT="5"' "$template" >/dev/null
+grep -Fx 'NUMBER_LIMIT="10"' "$template" >/dev/null
 grep -Fx 'TIMELINE_CREATE="no"' "$template" >/dev/null
 ! grep -Eq '^TIMELINE_(CLEANUP|LIMIT_)' "$template" || fail "Snapper template keeps timeline cleanup details out of the default config"
-grep -Fx 'MAX_SNAPSHOT_ENTRIES=6' "$limine_defaults" >/dev/null || fail "Limine allows for a snapshot created before Snapper cleanup"
-pass "Snapper and Limine retain update snapshots without a transient limit mismatch"
+grep -Fx 'MAX_SNAPSHOT_ENTRIES=11' "$limine_defaults" >/dev/null || fail "Limine allows for a snapshot created before Snapper cleanup"
+pass "Snapper and Limine retain operation snapshots without a transient limit mismatch"
 
 grep -Fx '[Desktop Entry]' "$limine_notify_autostart" >/dev/null
 grep -Fx 'Hidden=true' "$limine_notify_autostart" >/dev/null


### PR DESCRIPTION
### Summary

Enables automatic pre/post system snapshots on every package operation via `snap-pac` and adjusts Snapper/Limine retention defaults to keep 10 snapshots (5 transactions).

### Motivation

Omarchy already ships Snapper, cleanup timers, and Limine bootloader snapshot integration with timeline snapshots intentionally disabled. Adding `snap-pac` complements this design by automatically snapshotting before and after every `pacman`/`yay` package installation, upgrade, or removal, allowing bad package transactions to be rolled back directly from the Limine bootloader.

### Changes

- **`install/omarchy-other.packages`**: Added `snap-pac` to default package set.
- **`default/snapper/root`**: Increased `NUMBER_LIMIT` from 5 to 10 (and documented that pre/post pairs take two slots per transaction).
- **`etc/limine-entry-tool.d/omarchy-defaults.conf`**: Increased `MAX_SNAPSHOT_ENTRIES` from 6 to 11 to maintain the 1-snapshot buffer for the transient creation window before Snapper cleanup runs.
- **`manual/47-system-snapshots.md`**: Documented `snap-pac` pre/post transaction snapshots and bootloader rollback.
- **`test/shell.d/snapper-test.sh`**: Updated assertions for retention limits and Limine sync.