### PR TITLE
Add Wi-Fi disconnect and forget actions that match Bluetooth

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -91,7 +91,7 @@ Panel {
   // comparisons on the matching `*Kind`/`*Reason` being non-empty so a
   // hidden-SSID row (ssid == "") doesn't collide with the "" defaults.
   property string actionSsid: ""
-  property string actionKind: ""  // "connect" | "disconnect" | "forget"
+  property string actionKind: ""  // "connect" | "disconnect" | "forget-after-disconnect" | "forget"
   property string failureSsid: ""
   property string failureReason: ""
   property string passwordSsid: ""
@@ -378,7 +378,8 @@ Panel {
       selectedIndex = 0
     }
 
-    if (selectedIndex < 0 || selectedIndex >= wifiNetworks.length || !canForgetNetwork(wifiNetworks[selectedIndex])) {
+    if (selectedIndex < 0 || selectedIndex >= wifiNetworks.length
+        || (!wifiNetworks[selectedIndex].connected && !canForgetNetwork(wifiNetworks[selectedIndex]))) {
       wifiActionFocused = false
     }
   }
@@ -408,7 +409,8 @@ Panel {
 
   function selectWifiActionByDelta(delta) {
     if (selectedIndex < 0 || selectedIndex >= wifiNetworks.length) return
-    if (!canForgetNetwork(wifiNetworks[selectedIndex])) {
+    var net = wifiNetworks[selectedIndex]
+    if (!net || (!net.connected && !canForgetNetwork(net))) {
       wifiActionFocused = false
       return
     }
@@ -423,7 +425,7 @@ Panel {
     if (busy || selectedIndex < 0 || selectedIndex >= wifiNetworks.length) return
     var net = wifiNetworks[selectedIndex]
     if (!net) return
-    if (wifiActionFocused && canForgetNetwork(net)) { forget(net); return }
+    if (wifiActionFocused && (net.connected || canForgetNetwork(net))) { forget(net); return }
     // Only act on a row that still resolves. disconnect() falls back to
     // connectedWifiNetwork when handed null, so a row left stale by scan churn
     // would otherwise tear down whatever is connected now instead.
@@ -593,6 +595,10 @@ Panel {
   }
 
   function syncWifiNetworks() {
+    var preserveSelection = focusSection === "wifi"
+      && selectedIndex >= 0
+      && selectedIndex < wifiNetworks.length
+    var selectedSsid = preserveSelection ? wifiNetworks[selectedIndex].ssid : ""
     var nets = []
     var networks = wifiNetworkObjects || []
 
@@ -603,7 +609,25 @@ Panel {
       var row = Model.wifiRow(network)
       if (row) nets.push(row)
     }
-    wifiNetworks = Model.sortWifiRows(nets)
+    var sorted = Model.sortWifiRows(nets)
+
+    // Connection and known-state changes re-sort rows. Move the numeric cursor
+    // to the same SSID before publishing the new list so a focused X cannot
+    // jump to a different saved network at the old index.
+    if (preserveSelection) {
+      var nextSelectedIndex = -1
+      for (var j = 0; j < sorted.length; j++) {
+        if (sorted[j] && sorted[j].ssid === selectedSsid) {
+          nextSelectedIndex = j
+          break
+        }
+      }
+
+      if (nextSelectedIndex >= 0) selectedIndex = nextSelectedIndex
+      else wifiActionFocused = false
+    }
+
+    wifiNetworks = sorted
     wifiStationAvailable = !!wifiDevice
     scanning = false
   }
@@ -753,7 +777,23 @@ Panel {
     if (!network || actionKind === "" || actionSsid !== (network.name || "")) return
     if (actionKind === "connect" && network.connected) clearNetworkAction()
     else if (actionKind === "disconnect" && !network.connected && !network.stateChanging) clearNetworkAction()
+    else if (actionKind === "forget-after-disconnect" && !network.connected && !network.stateChanging) {
+      var ssid = actionSsid
+      Qt.callLater(function() { root.continueForgetAfterDisconnect(ssid) })
+    }
     else if (actionKind === "forget" && !network.known && !network.stateChanging) clearNetworkAction()
+  }
+
+  function continueForgetAfterDisconnect(ssid) {
+    if (actionKind !== "forget-after-disconnect" || actionSsid !== ssid) return
+    var network = networkForSsid(ssid)
+    if (!network || network.connected || network.stateChanging) return
+    if (!network.known) { clearNetworkAction(); return }
+
+    // Flip the phase first so a fast knownChanged signal completes the
+    // intended Forget action instead of re-entering the disconnect phase.
+    actionKind = "forget"
+    network.forget()
   }
 
   function connectDirectly(ssid) {
@@ -798,7 +838,15 @@ Panel {
   }
 
   function forget(net) {
-    runNetworkAction("forget", net ? networkForSsid(net.ssid) : null, function(network) { network.forget() })
+    var network = net ? networkForSsid(net.ssid) : null
+    if (!network || !network.known) return
+
+    if (network.connected) {
+      runNetworkAction("forget-after-disconnect", network, function(current) { current.disconnect() })
+      return
+    }
+
+    runNetworkAction("forget", network, function(current) { current.forget() })
   }
 
   implicitWidth: button.implicitWidth
@@ -943,7 +991,7 @@ Panel {
       if (!root.actionKind) return
       var reason
       if (root.actionKind === "connect") reason = "Timed out connecting"
-      else if (root.actionKind === "disconnect") reason = "Timed out disconnecting"
+      else if (root.actionKind === "disconnect" || root.actionKind === "forget-after-disconnect") reason = "Timed out disconnecting"
       else reason = "Timed out forgetting"
       root.failureSsid = root.actionSsid
       root.failureReason = reason
@@ -1600,16 +1648,18 @@ Panel {
 
     readonly property bool isConnected: net && net.connected
     readonly property bool isKnown: !!(net && net.known)
+    readonly property string actionTooltip: isConnected ? "Disconnect" : "Connect"
     readonly property bool requiresCredentials: net ? root.requiresCredentials(net.security) : false
     readonly property bool isEnterprise: net
       ? (net.security === WifiSecurityType.Wpa2Eap || net.security === WifiSecurityType.WpaEap)
       : false
     readonly property bool canForget: root.canForgetNetwork(net)
-    readonly property bool isSelected: root.focusSection === "wifi" && root.selectedIndex === index
-    readonly property bool forgetFocused: isSelected && root.wifiActionFocused && canForget
-    readonly property bool forgetVisible: canForget && (!requiresCredentials || forgetFocused || rightMouse.containsMouse)
+    readonly property bool rowSelected: root.cursorActive && root.focusSection === "wifi" && root.selectedIndex === index
+    readonly property bool actionAvailable: isConnected || canForget
+    readonly property bool actionFocused: rowSelected && root.wifiActionFocused && actionAvailable
+    readonly property bool actionVisible: (isConnected || canForget) && (rowMouse.containsMouse || rowSelected)
 
-    hasCursor: root.cursorActive && isSelected && !root.wifiActionFocused
+    hasCursor: rowSelected && !root.wifiActionFocused
     current: isConnected
     foreground: root.bar.foreground
     fill: root.hoverFill
@@ -1651,7 +1701,7 @@ Panel {
       if (!net) return ""
       if (isPasswordOpen) return ""
       if (isBusy && root.actionKind === "connect") return "Connecting…"
-      if (isBusy && root.actionKind === "disconnect") return "Disconnecting…"
+      if (isBusy && (root.actionKind === "disconnect" || root.actionKind === "forget-after-disconnect")) return "Disconnecting…"
       if (isBusy && root.actionKind === "forget") return "Forgetting…"
       if (isFailed) return root.failureReason || "Failed"
       if (isConnected) return "Connected"
@@ -1703,6 +1753,12 @@ Panel {
       }
     }
 
+    PanelToolTip {
+      visible: row.actionTooltip !== "" && rowMouse.containsMouse && !root.wifiActionFocused
+      text: row.actionTooltip
+      fontFamily: root.bar.fontFamily
+    }
+
     Item {
       id: rowBody
       anchors.left: parent.left
@@ -1723,54 +1779,51 @@ Panel {
         anchors.verticalCenter: parent.verticalCenter
       }
 
-      // The right edge shows a lock for networks that require credentials and
-      // reveals Forget on hover. Known passwordless networks show Forget
-      // directly rather than reserving an invisible or misleading target.
+      // The right edge shows a lock for networks that require credentials, then
+      // swaps it for the same hover/focus Forget action used by Bluetooth.
       Item {
         id: rightAction
-        visible: row.requiresCredentials || row.canForget
+        visible: row.requiresCredentials || row.actionVisible
         width: Style.space(22)
-        implicitHeight: lockIndicator.implicitHeight
+        implicitHeight: Math.max(lockIndicator.implicitHeight, forgetBtn.implicitHeight)
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
 
         Text {
           id: lockIndicator
           textFormat: Text.PlainText
-          visible: row.requiresCredentials || row.forgetVisible
+          visible: row.requiresCredentials && !row.actionVisible
           width: parent.width
           anchors.verticalCenter: parent.verticalCenter
           horizontalAlignment: Text.AlignHCenter
-          text: row.forgetVisible ? "󰅙" : "󰌾"
-          color: row.forgetVisible ? root.bar.urgent : Qt.darker(root.bar.foreground, 1.4)
+          text: "󰌾"
+          color: Qt.darker(root.bar.foreground, 1.4)
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.subtitle
         }
 
-        BorderSurface {
-          anchors.fill: parent
-          visible: row.forgetFocused
-          color: Style.hoverFillFor(root.bar.urgent, root.bar.urgent)
-          borderSpec: Border.controlSpec("hover-cursor", root.bar.urgent, root.bar.urgent)
-          radius: Style.cornerRadius
-          z: -1
-        }
-
-        MouseArea {
-          id: rightMouse
-          anchors.fill: parent
-          hoverEnabled: true
-          acceptedButtons: Qt.LeftButton
-          enabled: row.canForget && !root.busy
-          cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-          onContainsMouseChanged: if (containsMouse) { root.cursorActive = true; root.focusSection = "wifi"; root.selectedIndex = row.index; root.wifiActionFocused = true }
-          onClicked: if (row.net) root.forget(row.net)
-        }
-
-        PanelToolTip {
-          visible: rightMouse.containsMouse || row.forgetFocused
-          text: "Forget network"
+        PanelActionButton {
+          id: forgetBtn
+          anchors.centerIn: parent
+          visible: row.actionVisible
+          enabled: row.actionAvailable && !root.busy
+          iconText: "󰅙"
+          tooltipText: "Forget"
+          foreground: root.bar.foreground
+          hoverColor: root.bar.foreground
           fontFamily: root.bar.fontFamily
+          hasCursor: row.actionFocused
+          onHovered: function(isHovered) {
+            if (!isHovered) {
+              if (rowMouse.containsMouse) root.wifiActionFocused = false
+              return
+            }
+            root.cursorActive = true
+            root.focusSection = "wifi"
+            root.selectedIndex = row.index
+            root.wifiActionFocused = true
+          }
+          onClicked: if (row.net) root.forget(row.net)
         }
       }
 

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -229,25 +229,174 @@ assert(
   /networkFailureReason\(reason, requiresCredentials\(network\.security\)\)/.test(panelSource),
   'network failure copy uses the live network credential requirement'
 )
+
+// A connection or known-state change re-sorts the projected rows. Preserve
+// the selected SSID through that sort so a focused X never jumps to another
+// saved network at the same numeric index.
+const syncWifiNetworksFunction = panelSource.match(/function syncWifiNetworks\(\) \{[\s\S]*?\n {2}\}/)
+assert(syncWifiNetworksFunction, 'network has a Wi-Fi row synchronization helper')
+var Model = network
+var wifiNetworks = [
+  { connected: true, known: true, ssid: 'Alpha', signal: 50, security: security.Open },
+  { connected: false, known: true, ssid: 'Beta', signal: 90, security: security.Open }
+]
+var wifiNetworkObjects = [
+  { connected: false, known: true, name: 'Alpha', signalStrength: 0.5, security: security.Open },
+  { connected: false, known: true, name: 'Beta', signalStrength: 0.9, security: security.Open }
+]
+var selectedIndex = 0
+var focusSection = 'wifi'
+var wifiActionFocused = true
+var wifiDevice = {}
+var wifiStationAvailable = false
+var scanning = true
+function checkActionCompletion() {}
+eval(syncWifiNetworksFunction[0])
+syncWifiNetworks()
+assertEqual(wifiNetworks[selectedIndex].ssid, 'Alpha', 'network selection follows the SSID when rows re-sort')
+
+wifiNetworkObjects = [wifiNetworkObjects[1]]
+syncWifiNetworks()
+assertEqual(wifiActionFocused, false, 'network clears X focus when the selected SSID disappears')
+
 assert(
   /readonly property bool canForget: root\.canForgetNetwork\(net\)/.test(panelSource),
   'network rows derive forget eligibility from the tested model helper'
 )
+const networkRowStart = panelSource.indexOf('component NetworkRow: CursorSurface {')
+const detailValueStart = panelSource.indexOf('component DetailValue: InfoValue {')
+assert(networkRowStart >= 0 && detailValueStart > networkRowStart, 'network exposes its Wi-Fi row component')
+const networkRow = panelSource.slice(networkRowStart, detailValueStart)
+
 const rightAction = panelSource.match(/Item \{\s*id: rightAction\b[\s\S]*?\n {6}\}/)
 assert(rightAction, 'network has a right-edge action target')
 assert(
-  /visible: row\.requiresCredentials \|\| row\.canForget/.test(rightAction[0]),
-  'network keeps a forget target for known passwordless networks'
+  /visible: row\.requiresCredentials \|\| row\.actionVisible/.test(rightAction[0]),
+  'network keeps the right edge available for locks and revealed row actions'
 )
-const lockIndicator = panelSource.match(/Text \{\s*id: lockIndicator\b[\s\S]*?\n {8}\}/)
-assert(lockIndicator, 'network has a lock/forget indicator')
+const lockIndicator = networkRow.match(/Text \{\s*id: lockIndicator\b[\s\S]*?\n {8}\}/)
+assert(lockIndicator, 'network has a lock indicator')
 assert(
-  /visible: row\.requiresCredentials \|\| row\.forgetVisible/.test(lockIndicator[0]),
-  'network hides the lock on passwordless networks until showing their forget action'
+  /visible: row\.requiresCredentials && !row\.actionVisible/.test(lockIndicator[0]),
+  'network replaces a secured row lock while its trailing action is revealed'
 )
 assert(
-  /forgetVisible: canForget && \(!requiresCredentials \|\| forgetFocused \|\| rightMouse\.containsMouse\)/.test(panelSource),
-  'network shows the forget action directly for known passwordless networks'
+  /readonly property bool actionVisible: \(isConnected \|\| canForget\) && \(rowMouse\.containsMouse \|\| rowSelected\)/.test(networkRow),
+  'network reveals a trailing X for connected and saved rows on hover or keyboard focus'
+)
+assert(
+  /readonly property string actionTooltip:[\s\S]{0,220}isConnected[\s\S]{0,220}"Disconnect"/.test(networkRow) &&
+    /PanelToolTip \{[\s\S]*?rowMouse\.containsMouse[\s\S]*?text: row\.actionTooltip/.test(networkRow),
+  'network shows the row Disconnect tooltip while a connected row is hovered'
+)
+assert(
+  /(?:iconText|text):[^\n]*"󰅙"/.test(networkRow) &&
+    /(?:root\.)?forget\(row\.net\)/.test(networkRow),
+  'network trailing X invokes Forget for connected and saved rows'
+)
+assert(
+  /if \(row\.isConnected\) \{\s*root\.disconnectRow\(row\.net\.ssid\)/.test(networkRow),
+  'network row click disconnects a connected row'
+)
+
+// Right/Left navigation must expose the X for a connected row as well as the
+// existing Forget action. Execute the real helper body against a connected
+// row so this fails if navigation still gates solely on canForgetNetwork().
+const selectWifiAction = panelSource.match(/function selectWifiActionByDelta\(delta\) \{[\s\S]*?\n {2}\}/)
+assert(selectWifiAction, 'network has horizontal Wi-Fi action navigation')
+selectedIndex = 0
+var wifiNetworks = [{ connected: true, known: true, security: security.Open }]
+var wifiActionFocused = false
+function canForgetNetwork(net) { return network.canForgetNetwork(net) }
+eval(selectWifiAction[0])
+selectWifiActionByDelta(1)
+assertEqual(wifiActionFocused, true, 'network Right focuses the X on a connected row')
+selectWifiActionByDelta(-1)
+assertEqual(wifiActionFocused, false, 'network Left returns from a focused row action')
+wifiNetworks = [{ connected: false, known: false, security: security.Open }]
+wifiActionFocused = false
+selectWifiActionByDelta(1)
+assertEqual(wifiActionFocused, false, 'network unknown rows have no trailing X action')
+
+const activateSelectedFunction = panelSource.match(/function activateSelected\(\) \{[\s\S]*?\n {2}\}/)
+assert(activateSelectedFunction, 'network has keyboard activation for the selected Wi-Fi row')
+var busy = false
+wifiActionFocused = false
+wifiNetworks = [{ connected: true, known: true, ssid: 'Home', security: security.Open }]
+var actionCalls = []
+function disconnectRow(ssid) { actionCalls.push('disconnect:' + ssid) }
+function forget(net) { actionCalls.push('forget:' + net.ssid) }
+eval(activateSelectedFunction[0])
+activateSelected()
+assertDeepEqual(actionCalls, ['disconnect:Home'], 'network Enter disconnects a connected row')
+
+actionCalls = []
+wifiActionFocused = true
+activateSelected()
+assertDeepEqual(actionCalls, ['forget:Home'], 'network Right+Enter forgets a connected row')
+
+actionCalls = []
+wifiActionFocused = true
+wifiNetworks = [{ connected: false, known: true, ssid: 'Saved', security: security.Open }]
+selectedIndex = 0
+activateSelected()
+assertDeepEqual(actionCalls, ['forget:Saved'], 'network Right+Enter forgets a saved disconnected row')
+
+const forgetFunction = panelSource.match(/function forget\(net\) \{[\s\S]*?\n {2}\}/)
+assert(forgetFunction, 'network has a Forget action')
+var liveNetwork = {
+  name: 'Home',
+  connected: true,
+  known: true,
+  stateChanging: false,
+  disconnect: function() { forgetCalls.push('disconnect') },
+  forget: function() { forgetCalls.push('forget') }
+}
+var forgetCalls = []
+function networkForSsid(ssid) { return ssid === 'Home' ? liveNetwork : null }
+function runNetworkAction(kind, network, callback) {
+  forgetCalls.push('phase:' + kind)
+  if (network) callback(network)
+}
+eval(forgetFunction[0])
+forget({ ssid: 'Home' })
+assertDeepEqual(
+  forgetCalls,
+  ['phase:forget-after-disconnect', 'disconnect'],
+  'network starts connected Forget by disconnecting without racing the serialized Forget action'
+)
+
+forgetCalls = []
+liveNetwork.connected = false
+forget({ ssid: 'Home' })
+assertDeepEqual(
+  forgetCalls,
+  ['phase:forget', 'forget'],
+  'network forgets an already disconnected saved network directly'
+)
+
+const continueForget = panelSource.match(/function continueForgetAfterDisconnect\(ssid\) \{[\s\S]*?\n {2}\}/)
+assert(continueForget, 'network has a second Forget phase after connected-network disconnection')
+var actionKind = 'forget-after-disconnect'
+var actionSsid = 'Home'
+var clearCount = 0
+function clearNetworkAction() { clearCount += 1; actionKind = ''; actionSsid = '' }
+forgetCalls = []
+liveNetwork.forget = function() { forgetCalls.push('forget-during:' + actionKind) }
+eval(continueForget[0])
+continueForgetAfterDisconnect('Home')
+assertDeepEqual(
+  forgetCalls,
+  ['forget-during:forget'],
+  'network enters the Forget phase before deleting the disconnected profile'
+)
+assertEqual(clearCount, 0, 'network keeps the action pending until profile deletion completes')
+
+const checkActionCompletionFunction = panelSource.match(/function checkActionCompletion\(network\) \{[\s\S]*?\n {2}\}/)
+assert(
+  checkActionCompletionFunction &&
+    /actionKind === "forget-after-disconnect"[\s\S]*!network\.connected[\s\S]*!network\.stateChanging[\s\S]*continueForgetAfterDisconnect/.test(checkActionCompletionFunction[0]),
+  'network waits for disconnection to settle before continuing Forget'
 )
 
 const reasons = { NoSecrets: 1, WifiAuthTimeout: 2, WifiNetworkLost: 3, WifiClientDisconnected: 4, WifiClientFailed: 5 }
@@ -260,7 +409,7 @@ assertEqual(network.networkFailureReason(99, true, reasons), 'Failed to connect'
 assertEqual(network.canForgetNetwork({ known: true, connected: false, security: security.Owe }), true, 'network can forget known disconnected OWE networks')
 assertEqual(network.canForgetNetwork({ known: true, connected: false, security: security.Open }), true, 'network can forget known disconnected open networks')
 assertEqual(network.canForgetNetwork({ known: false, connected: false, security: security.Owe }), false, 'network cannot forget unknown networks')
-assertEqual(network.canForgetNetwork({ known: true, connected: true, security: security.Owe }), false, 'network cannot forget the connected network')
+assertEqual(network.canForgetNetwork({ known: true, connected: true, security: security.Owe }), false, 'network keeps connected profiles out of the direct Forget path')
 
 assertEqual(network.shouldRepromptPassphrase(reasons.NoSecrets, true, reasons), true, 'network reprompts when required credentials are missing')
 assertEqual(network.shouldRepromptPassphrase(reasons.NoSecrets, false, reasons), false, 'network does not ask a passwordless network for missing secrets')


### PR DESCRIPTION
## Summary

- Make the connected Wi-Fi row act like Bluetooth: hovering shows a `Disconnect` tooltip, while clicking the row or pressing Enter disconnects it.
- Reveal a trailing X for connected and saved networks on pointer hover or keyboard focus; clicking it or pressing Right then Enter forgets the saved profile.
- Serialize Forget on the active network as disconnect-then-forget, and preserve keyboard selection by SSID when connection-state changes reorder the rows.
- Add regression coverage for pointer/keyboard action availability, active-network Forget sequencing, and selection stability.

## How to Test

### Automated

- `bash test/shell.d/network-test.sh` — passes; covers connected-row Disconnect, connected/saved-row Forget, unknown-row exclusion, disconnect-then-forget sequencing, and selection stability across row reordering.
- `qmllint -I shell shell/plugins/panels/network/Panel.qml` — passes with no diagnostics.
- `git diff --check origin/quattro...HEAD` — passes.
- `./test/all` — `test/cli` passes and the changed network test passes. The shell aggregate reports the same seven host/baseline failures seen before this change: `config-test.sh`, `launch-about-test.sh`, `network-qr-test.sh`, `plugin-add-test.sh`, `snapper-test.sh`, `theme-install-guards-test.sh`, and `unowned-system-paths-test.sh` (7 of 220 test files on the rebased tree).

### Manual QA for Engineering

Prerequisites: run this branch as the active Omarchy checkout on a machine with NetworkManager, one disposable connected Wi-Fi profile, and one disposable saved but disconnected profile. Know the credentials before testing Forget. Restart the shell with `omarchy-restart-shell` after loading the branch.

1. Open the Wi-Fi panel and hover the connected network row. Expect a `Disconnect` tooltip and a trailing X.
2. Click the connected row body. Expect the network to disconnect while its saved profile remains under Known Networks.
3. Reconnect, select the connected row with the keyboard, and press Enter. Expect the same disconnect behavior.
4. Reconnect again, select the connected row, press Right to focus the X, then press Enter. Expect the UI to finish disconnecting before forgetting the profile; the SSID must leave Known Networks without the selection jumping to another row.
5. Hover the saved disconnected profile and click its X. Expect the saved profile to be forgotten directly.
6. Hover and keyboard-focus an unknown network. Expect no trailing X; Enter should retain the existing Connect/password behavior.

Live validation was completed on an Omarchy desktop by installing the candidate as a reversible `dev.network` clone. Connected-row Disconnect and connected-network Forget/reconnect were exercised successfully, after which the built-in `omarchy.network` panel and original shell configuration were restored.

### Manual QA for Product Owners

Use a disposable Wi-Fi network for Forget testing because Forget removes its stored credentials.

1. Open the Wi-Fi panel while connected. Hover the connected row and confirm the `Disconnect` tooltip and X appear.
2. Click the row away from the X and confirm Wi-Fi disconnects without forgetting the network.
3. Reconnect, then click the X and confirm the panel disconnects and forgets the network.
4. Confirm a saved disconnected network also reveals an X, while an unknown network does not.
5. Repeat with the keyboard: Up/Down selects a row, Enter performs Connect/Disconnect, Right focuses the X, and Enter activates Forget.
