### PR TITLE
Fix Style submenu navigation in the menu acceptance test

### DIFF
--- a/test/acceptance.d/menu-test.sh
+++ b/test/acceptance.d/menu-test.sh
@@ -75,7 +75,7 @@ wtype -k Return
 wait_until "style submenu is visible" 15 screen_contains "Theme"
 screenshot "success-menu-03-style-submenu"
 
-wtype -k Down -k Down -k Down -k Return
+wtype -k Down -k Down -k Down -k Down -k Return
 sleep 1
 screenshot "success-menu-04-menu-bar-submenu"
 


### PR DESCRIPTION
The menu acceptance test walks the Style submenu with blind Down-key presses. d411c90a restored the Unlock entry to that submenu the same day the test landed (1de4c890), so Down×3 now selects Font instead of Menu Bar — the test opens the font picker, applies a font, and the "menu bar position changes to left" assertion times out on every run.

One more Down reaches Menu Bar (Theme → Background → Unlock → Font → Menu Bar). Validated against a 4.0.2-rc install in the omarchy-iso acceptance harness: full suite green (136 assertions), including the bar moving left and restoring.