### PR TITLE
Open the Tailscale admin console from the panel mark

### DIFF
--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -1,3 +1,5 @@
+var HOSTED_ADMIN_URL = "https://login.tailscale.com/admin/machines"
+
 function filterIPv4(ips) {
   var result = []
   if (!ips || typeof ips.length !== "number") return result
@@ -270,6 +272,28 @@ function parseStatus(raw) {
   }
 }
 
+// Where to send someone who wants to manage this tailnet. The hosted console
+// only administers tailnets on Tailscale's own control plane; a self-hosted
+// control server (Headscale and friends) has no console at that address, so
+// its own URL is the closest thing to one.
+function adminUrlFromControlUrl(controlUrl) {
+  var value = String(controlUrl || "").trim().replace(/\/+$/, "")
+  if (value === "") return HOSTED_ADMIN_URL
+  if (/^https?:\/\/(controlplane|login)\.tailscale\.com$/i.test(value)) return HOSTED_ADMIN_URL
+  return value
+}
+
+function controlUrlFromPrefs(raw) {
+  var text = String(raw || "").trim()
+  if (text === "") return ""
+  try {
+    var parsed = JSON.parse(text)
+    return String((parsed && parsed.ControlURL) || "")
+  } catch (e) {
+    return ""
+  }
+}
+
 function parseAccounts(raw) {
   var text = String(raw || "").trim()
   if (text === "") return { accounts: [], selectedAccountId: "", selectedAccountLabel: "" }
@@ -320,6 +344,8 @@ if (typeof module !== "undefined") {
     mullvadRegionOptions: mullvadRegionOptions,
     mullvadCountryOptions: mullvadCountryOptions,
     parseStatus: parseStatus,
-    parseAccounts: parseAccounts
+    parseAccounts: parseAccounts,
+    adminUrlFromControlUrl: adminUrlFromControlUrl,
+    controlUrlFromPrefs: controlUrlFromPrefs
   }
 }

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -304,6 +304,12 @@ Panel {
     close()
   }
 
+  // The browser takes over from here, so get the panel out of the way.
+  function openAdminConsole() {
+    tailscale.openAdminConsole()
+    close()
+  }
+
   function openSelectedPeerCopyMenu() {
     if (!peerColumn || peerIndex < 0 || peerIndex >= peerColumn.children.length) return
     var item = peerColumn.children[peerIndex]
@@ -427,6 +433,7 @@ Panel {
         else if (t === "n" || t === "N") tailscale.copyPeerName(root.selectedPeer())
         else if (t === "d" || t === "D") tailscale.copyPeerDnsName(root.selectedPeer())
         else if (t === "s" || t === "S") root.sendPeerFile(root.selectedPeer())
+        else if (t === "a" || t === "A") root.openAdminConsole()
       }
 
       Flickable {
@@ -462,14 +469,35 @@ Panel {
               foreground: root.foreground
               fontFamily: root.fontFamily
               iconOpacity: tailscale.active ? 1.0 : 0.5
-              // Status only — the switch owns toggling, mouse and keyboard alike.
+              // Status, plus a shortcut to the admin console. The switch still
+              // owns toggling, mouse and keyboard alike — the mark never does.
               iconComponent: Component {
-                TailscaleIcon {
-                  iconSize: Style.font.display
-                  color: root.iconColor
-                  badgeColor: root.urgent
-                  crossed: !tailscale.active && !tailscale.needsLogin
-                  warning: tailscale.needsLogin
+                Item {
+                  implicitWidth: heroIcon.implicitWidth
+                  implicitHeight: heroIcon.implicitHeight
+
+                  TailscaleIcon {
+                    id: heroIcon
+                    color: root.iconColor
+                    iconSize: Style.font.display
+                    badgeColor: root.urgent
+                    crossed: !tailscale.active && !tailscale.needsLogin
+                    warning: tailscale.needsLogin
+                  }
+
+                  MouseArea {
+                    id: adminMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.openAdminConsole()
+
+                    PanelToolTip {
+                      visible: adminMouse.containsMouse
+                      text: "Open admin console"
+                      fontFamily: root.fontFamily
+                    }
+                  }
                 }
               }
 

--- a/shell/plugins/panels/tailscale/README.md
+++ b/shell/plugins/panels/tailscale/README.md
@@ -6,6 +6,7 @@ Native Omarchy bar widget for Tailscale.
 
 - Shows Tailscale connection state in the bar
 - Left click opens a keyboard-friendly panel
+- Click the Tailscale mark in the panel to open the admin console in your browser — the hosted console, or your own control server for a self-hosted tailnet
 - Right click toggles Tailscale on/off
 - Switch between available Tailscale connections when multiple are available
 - Browse machines from `tailscale status --json`
@@ -22,6 +23,7 @@ Inside the panel:
 - `n`: copy selected peer name
 - `d`: copy selected peer DNS name
 - `s`: send files to selected peer
+- `a`: open the admin console
 - `t`: toggle Tailscale
 - `r`: refresh status
 - `esc`: close

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -41,6 +41,12 @@ Item {
   property string actionStatus: ""
   property string lastError: ""
 
+  // The status JSON carries no control-plane URL, so it comes from the daemon's
+  // prefs and decides whether the admin console is Tailscale's hosted one or a
+  // self-hosted control server.
+  property string controlUrl: ""
+  readonly property string adminUrl: Model.adminUrlFromControlUrl(controlUrl)
+
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 30, 5, 3600)
   readonly property bool busy: whichProcess.running || statusProcess.running || mullvadExitNodesProcess.running || accountsProcess.running || actionProcess.running || loginProcess.running || switchProcess.running || operatorProcess.running || exitNodeProcess.running
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
@@ -49,6 +55,7 @@ Item {
   property string _statusError: ""
   property string _accountsOutput: ""
   property string _accountsError: ""
+  property string _prefsOutput: ""
   property string _mullvadExitNodesOutput: ""
   property string _mullvadExitNodesError: ""
   property string _actionOutput: ""
@@ -183,6 +190,16 @@ Item {
       _lastAccountsRefreshMs = now
       accountsProcess.command = ["tailscale", "switch", "--list", "--json"]
       accountsProcess.running = true
+      launched = true
+    }
+    // The control URL only moves when the connection does, so read it once and
+    // again on the forced refresh that follows an account switch — not on the
+    // interval, which would spawn a process every tick for a value that stands
+    // still for the life of a login.
+    if ((forceAccounts === true || controlUrl === "") && !prefsProcess.running) {
+      _prefsOutput = ""
+      prefsProcess.command = ["tailscale", "debug", "prefs"]
+      prefsProcess.running = true
       launched = true
     }
     // Arm on the launch that needs watching and leave it alone after that.
@@ -363,6 +380,10 @@ Item {
     actionProcess.running = true
   }
 
+  function openAdminConsole() {
+    Quickshell.execDetached(["omarchy-launch-browser", adminUrl])
+  }
+
   function openAuthUrlFrom(text, allowFallback) {
     if (_loginUrlOpened) return true
     var match = String(text || "").match(/https?:\/\/\S+/)
@@ -431,6 +452,7 @@ Item {
       if (statusProcess.running) statusProcess.running = false
       if (mullvadExitNodesProcess.running) mullvadExitNodesProcess.running = false
       if (accountsProcess.running) accountsProcess.running = false
+      if (prefsProcess.running) prefsProcess.running = false
     }
   }
 
@@ -505,6 +527,19 @@ Item {
           root.lastError = elideStatus(stderr || stdout || "Could not list Tailscale connections")
         }
       }
+    }
+  }
+
+  Process {
+    // A daemon too old for `debug prefs`, or one that refuses it, just leaves
+    // the control URL empty and the admin link pointing at the hosted console.
+    id: prefsProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: prefsStdout; waitForEnd: true; onStreamFinished: root._prefsOutput = text }
+    onExited: function(exitCode) {
+      if (exitCode !== 0) return
+      root.controlUrl = Model.controlUrlFromPrefs(String(prefsStdout.text || root._prefsOutput || ""))
     }
   }
 

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -11,6 +11,21 @@ const panelSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Pane
 
 assert(/function toggleTailscale\(\): string \{ tailscale\.toggleTailscale\(\); return "ok" \}/.test(panelSource), 'tailscale exposes the connection toggle over IPC')
 
+const serviceSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Service.qml', 'utf8')
+assert(/Quickshell\.execDetached\(\["omarchy-launch-browser", adminUrl\]\)/.test(serviceSource), 'tailscale opens the admin console in the default browser')
+assert(/command = \["tailscale", "debug", "prefs"\]/.test(serviceSource), 'tailscale reads the control URL from daemon prefs')
+
+assertEqual(tailscale.adminUrlFromControlUrl(''), 'https://login.tailscale.com/admin/machines', 'tailscale falls back to the hosted admin console without a control URL')
+assertEqual(tailscale.adminUrlFromControlUrl('https://controlplane.tailscale.com'), 'https://login.tailscale.com/admin/machines', 'tailscale sends the hosted control plane to the hosted admin console')
+assertEqual(tailscale.adminUrlFromControlUrl('https://controlplane.tailscale.com/'), 'https://login.tailscale.com/admin/machines', 'tailscale ignores a trailing slash on the control URL')
+assertEqual(tailscale.adminUrlFromControlUrl('https://headscale.example.com'), 'https://headscale.example.com', 'tailscale points a self-hosted tailnet at its own control server')
+assertEqual(tailscale.adminUrlFromControlUrl('https://headscale.example.com/'), 'https://headscale.example.com', 'tailscale trims a self-hosted control URL')
+assertEqual(tailscale.controlUrlFromPrefs('{"ControlURL":"https://headscale.example.com"}'), 'https://headscale.example.com', 'tailscale reads the control URL out of prefs')
+assertEqual(tailscale.controlUrlFromPrefs('not json'), '', 'tailscale ignores unreadable prefs')
+assert(/onClicked: root\.openAdminConsole\(\)/.test(panelSource), 'tailscale opens the admin console from the panel mark')
+assert(/t === "a" \|\| t === "A"\) root\.openAdminConsole\(\)/.test(panelSource), 'tailscale binds the admin console to the a key')
+assert(/function openAdminConsole\(\) \{\s*tailscale\.openAdminConsole\(\)\s*close\(\)/.test(panelSource), 'tailscale closes the panel when the admin console opens')
+
 assertDeepEqual(
   tailscale.filterIPv4(['100.64.0.1', 'fd7a:115c:a1e0::1', '192.168.1.2']),
   ['100.64.0.1'],


### PR DESCRIPTION
## The problem

Machine management — renaming, key expiry, ACLs, approving a subnet route — all lives in the Tailscale admin console, and reaching it from the panel meant leaving it to type the URL by hand.

## The change

Click the Tailscale mark at the top of the panel, or press `a`, to open the admin console in the default browser via `omarchy-launch-browser`. The panel closes behind it the same way `sendPeerFile` closes it for a Taildrop send: the browser has taken over.

The mark was status-only decoration (`iconComponent` in the `PanelHero`), so this costs no existing gesture. The toggle switch still owns turning Tailscale on and off, from both mouse and keyboard, and the bar icon's left/right/middle click behaviour is untouched.

## Self-hosted control servers

Which console opens comes from the daemon's own prefs rather than a hardcoded URL. `tailscale status --json` carries no control-plane URL, so `tailscale debug prefs` supplies `ControlURL`:

- empty, or `controlplane`/`login.tailscale.com` → the hosted console at `https://login.tailscale.com/admin/machines`
- anything else → that control server's own URL, since a self-hosted control server (Headscale and friends) has no console at Tailscale's address

The control URL only moves when the connection does, so it is read once at startup and again on the forced refresh that follows an account switch — never on the refresh interval, which would spawn a process every tick for a value that stands still for the life of a login. The poll watchdog stops it like the other three polls. A daemon too old for `debug prefs`, or one that refuses it, exits nonzero and leaves the link pointing at the hosted console.

## Tests

The URL derivation lives in `Model.js` as two pure functions and is covered in `test/shell.d/tailscale-test.sh` — hosted control plane, empty prefs, trailing slashes, a self-hosted URL, and unparseable prefs. Further assertions cover the wiring: the browser launch, the prefs read, both entry points, and the panel close.

Verified live against a hosted tailnet; the self-hosted path is covered by unit tests only, as I have no Headscale server to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)