### PR TITLE
Refuse hibernation setup on Apple T2 Macs by default

### DIFF
--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -47,6 +47,15 @@ if [[ -f $MKINITCPIO_CONF ]] && grep -q "^HOOKS+=(resume)$" "$MKINITCPIO_CONF"; 
   exit 0
 fi
 
+if omarchy-hw-t2 && ! $FORCE; then
+  echo "Hibernation is unreliable on Apple T2 Macs: the T2 controller often" >&2
+  echo "fails to bring the internal keyboard and trackpad back after resuming" >&2
+  echo "from a hibernation image, and the machine can hang mid-hibernate and" >&2
+  echo "need a hard power-off. See https://wiki.t2linux.org/state/ for details." >&2
+  echo "Pass --force to set it up anyway." >&2
+  exit 0
+fi
+
 if ! $FORCE; then
   MEM_TOTAL_HUMAN=$(free --human | awk '/Mem/ {print $2}')
   if ! gum confirm "Use $MEM_TOTAL_HUMAN on boot drive to make hibernation available?"; then

--- a/bin/omarchy-hw-t2
+++ b/bin/omarchy-hw-t2
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the computer has an Apple T2 security chip.
+
+lspci -nn | grep -q "106b:180[12]"

--- a/manual/36-system-sleep.md
+++ b/manual/36-system-sleep.md
@@ -16,4 +16,6 @@ You toggle suspend by running `omarchy toggle suspend` from the terminal. That j
 
 You set up hibernation by running `omarchy hibernation setup` from the terminal. Hibernation creates a /swap subvolume on your boot drive the size of your physical RAM allocation, so make sure you have plenty of room to spare. On a 32GB machine, you'll always need 32GB+ free for this volume. Hibernation also requires the default Limine bootloader.
 
+On Apple T2 Macs, `omarchy hibernation setup` refuses by default: the T2 controller often fails to bring the internal keyboard and trackpad back after resuming from a hibernation image, and the machine can hang mid-hibernate and need a hard power-off. Pass `--force` if you want to set it up anyway.
+
 When set up, you'll see the hibernate option under _System_ (or `Super + Esc`), and then you can see if it works consistently on your system. If not, you can remove it again by running `omarchy hibernation remove`.

--- a/manual/36-system-sleep.md
+++ b/manual/36-system-sleep.md
@@ -16,6 +16,6 @@ You toggle suspend by running `omarchy toggle suspend` from the terminal. That j
 
 You set up hibernation by running `omarchy hibernation setup` from the terminal. Hibernation creates a /swap subvolume on your boot drive the size of your physical RAM allocation, so make sure you have plenty of room to spare. On a 32GB machine, you'll always need 32GB+ free for this volume. Hibernation also requires the default Limine bootloader.
 
-On Apple T2 Macs, `omarchy hibernation setup` refuses by default: the T2 controller often fails to bring the internal keyboard and trackpad back after resuming from a hibernation image, and the machine can hang mid-hibernate and need a hard power-off. Pass `--force` if you want to set it up anyway.
+On Apple T2 Macs, `omarchy hibernation setup` refuses by default: the T2 controller often fails to bring the internal keyboard and trackpad back after resuming from a hibernation image, and the machine can hang mid-hibernate and need a hard power-off. Pass `--force` if you want to set it up anyway. If you had already set up hibernation on a T2 Mac before this warning existed, a migration removes it for you on your next `omarchy update`.
 
 When set up, you'll see the hibernate option under _System_ (or `Super + Esc`), and then you can see if it works consistently on your system. If not, you can remove it again by running `omarchy hibernation remove`.

--- a/migrations/1788120123.sh
+++ b/migrations/1788120123.sh
@@ -1,0 +1,5 @@
+echo "Remove hibernation setup on Apple T2 Macs: it can hang the machine mid-hibernate and needs a hard power-off (https://wiki.t2linux.org/state/)"
+
+if omarchy-hw-t2; then
+  omarchy-hibernation-remove
+fi


### PR DESCRIPTION
Fixes #9237

## Problem

`omarchy hibernation setup` will happily configure hibernation (swapfile + resume kernel params) on Apple T2 Macs, and the System-menu *Hibernate* entry becomes available once it's set up. But T2 Macs don't reliably survive true hibernate (S4): the T2 controller, which also owns the internal keyboard/trackpad SPI bus, often fails to come back after resuming from a hibernation image, and the machine can hang mid-hibernate and need a hard power-off — see #9237 for a concrete case with journal evidence, and https://wiki.t2linux.org/state/ for the platform-level confirmation that hibernation isn't supported on T2.

Suspend-to-RAM (S3) is unaffected and already works on T2 via the existing `t2-wifi-suspend` sleep hook, so this only touches hibernation.

## Fix (2 commits)

**1. Block new setups.** Add `bin/omarchy-hw-t2`, a hardware-detection helper following the existing `omarchy-hw-*` convention (same `106b:1801`/`1802` PCI-ID check already used by the other Apple T2 install fixes). `omarchy-hibernation-setup` now refuses by default on T2 hardware, printing an explanation and a link to the t2linux wiki. `--force` still allows setting it up anyway. The check sits after the "already configured" early-return, so it's a no-op for anyone who already has hibernation configured, and after the internal `omarchy-system-factory-reset` caller (which already passes `--force`) so re-provisioning an existing T2 setup after factory reset is unaffected.

Since the System-menu *Hibernate* entry is gated on `omarchy-hibernation-available` (which checks for actual swap+resume configuration), this keeps that entry hidden by default on T2 Macs too, not just the setup command — but **only for machines that haven't configured hibernation yet**.

**2. Clean up existing setups.** Commit 1 alone doesn't help anyone who already ran `omarchy hibernation setup` on a T2 Mac before this fix shipped — their swapfile/resume config stays in place and Hibernate stays in the menu. Add a migration (`migrations/1788120123.sh`) that runs `omarchy-hibernation-remove` on T2 hardware, reusing its own confirm prompt and no-op-when-unconfigured behavior, so it applies automatically on the next `omarchy update` (or via the login migration notifier for anyone who updates another way).

One-line caveat added to `manual/36-system-sleep.md` covering both cases.

## Testing

`./test/cli` passes (116/116) after both commits. Manually verified on a real MacBookAir9,1 (T2):
- `omarchy-hw-t2` correctly detects the hardware.
- With hibernation already removed, `PATH=<checkout>/bin omarchy-hibernation-setup` (no `--force`) prints the warning and exits without configuring anything.
- The migration script, run directly against the same machine, correctly no-ops ("Hibernation is not set up") since nothing is configured.
- `omarchy-hibernation-available` exits 1 (unavailable) and the System-menu Hibernate entry is gone.

No existing test harness mocks hardware detection for `omarchy-hibernation-setup` or migrations, so this doesn't add a new automated regression test for either — happy to add one if there's a preferred pattern for mocking `omarchy-hw-*` in `test/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
