### PR TITLE
Sync the GNOME keyring on user password changes

### DIFF
--- a/bin/omarchy-user-password
+++ b/bin/omarchy-user-password
@@ -26,7 +26,19 @@ if ! grep -q '^password.*pam_gnome_keyring\.so' "$PASSWD_PAM"; then
   # The standard integration point (ArchWiki: GNOME/Keyring): an optional
   # password-stage line that re-encrypts the login keyring with the new
   # password as part of the passwd transaction itself.
-  echo 'password       optional       pam_gnome_keyring.so' | sudo tee -a "$PASSWD_PAM" >/dev/null
+  if ! echo 'password       optional       pam_gnome_keyring.so' | sudo tee -a "$PASSWD_PAM" >/dev/null; then
+    # Aborting here is the whole point: once the password changes without
+    # this line, the keyring can no longer be re-encrypted by any later
+    # password change (pam_gnome_keyring unlocks it with the OLD login
+    # password, which no longer matches). Better no change than a fresh
+    # orphaned keyring.
+    echo "Could not update $PASSWD_PAM, so the password was NOT changed."
+    echo "Without that line the keyring would fall out of sync. Re-run"
+    echo "this command and accept the sudo prompt, or run plain passwd"
+    echo "knowing the keyring will need manual recovery afterwards"
+    echo "(Passwords and Keys app, or resetting the keyring)."
+    exit 1
+  fi
   echo "Enabled GNOME keyring sync on password change."
 fi
 

--- a/bin/omarchy-user-password
+++ b/bin/omarchy-user-password
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# omarchy:summary=Change the user login password (syncs the GNOME keyring)
+# omarchy:requires-sudo=true
+
+# The menu's password change used to run plain `passwd`. That updates the login
+# password but never re-encrypts an existing GNOME login keyring, so the next
+# cold boot fails to decrypt it (SDDM log: "gkr-pam: couldn't unlock the login
+# keyring"). pam_gnome_keyring re-encrypts the keyring during a password change,
+# but only if it is wired into /etc/pam.d/passwd, which Arch's stock file is
+# not (issue #9147).
+
+# The stock /etc/pam.d/passwd (from the shadow package) includes system-auth and
+# has no pam_gnome_keyring line. Adding it once is idempotent: once present, the
+# grep below skips the append on every later run.
+
+PASSWD_PAM=/etc/pam.d/passwd
+
+if omarchy-cmd-missing gnome-keyring-daemon; then
+  # gnome-keyring is part of the default install, so reaching this means the
+  # package was deliberately removed; in that case plain passwd is correct.
+  exec passwd
+fi
+
+if ! grep -q '^password.*pam_gnome_keyring\.so' "$PASSWD_PAM"; then
+  # The standard integration point (ArchWiki: GNOME/Keyring): an optional
+  # password-stage line that re-encrypts the login keyring with the new
+  # password as part of the passwd transaction itself.
+  echo 'password       optional       pam_gnome_keyring.so' | sudo tee -a "$PASSWD_PAM" >/dev/null
+  echo "Enabled GNOME keyring sync on password change."
+fi
+
+passwd

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -364,5 +364,5 @@
   "update.hardware.bluetooth": {"icon":"󰂯","label":"Bluetooth","action":"omarchy-launch-floating-terminal-with-presentation omarchy-restart-bluetooth"},
   "update.hardware.trackpad": {"icon":"󰟸","label":"Trackpad","action":"omarchy-launch-floating-terminal-with-presentation omarchy-restart-trackpad"},
   "update.password.drive": {"icon":"","label":"Drive Encryption","action":"omarchy-launch-floating-terminal-with-presentation omarchy-drive-password"},
-  "update.password.user": {"icon":"","label":"User","action":"omarchy-launch-floating-terminal-with-presentation passwd"},
+  "update.password.user": {"icon":"󰈻","label":"User","action":"omarchy-launch-floating-terminal-with-presentation omarchy-user-password"},
 }

--- a/migrations/1788120000.sh
+++ b/migrations/1788120000.sh
@@ -1,0 +1,25 @@
+echo "Sync the GNOME keyring on future user password changes"
+
+# A password changed through Update > Password > User used to run plain
+# passwd, which never re-encrypts an existing encrypted login keyring, so
+# the next cold boot could not decrypt it (SDDM reset the login bar; the
+# journal showed "gkr-pam: couldn't unlock the login keyring").
+# omarchy-user-password now appends the pam_gnome_keyring password line to
+# /etc/pam.d/passwd before changing the password, so the keyring is
+# re-encrypted as part of the change itself.
+
+# That only helps future changes. A keyring that a past password change
+# already orphaned stays broken, so tell the user how to fix it instead of
+# leaving a silent trap.
+
+if omarchy-cmd-missing gnome-keyring-daemon; then
+  # gnome-keyring is part of the default install; without it there is no
+  # keyring to sync and plain passwd is the correct path.
+  exit 0
+fi
+
+if [[ -f $HOME/.local/share/keyrings/login.keyring ]]; then
+  echo "An encrypted login keyring was found on this machine."
+  echo "If SDDM rejects your password after a restart, open Update >"
+  echo "Password > User once and change the password to re-sync it."
+fi

--- a/migrations/1788120000.sh
+++ b/migrations/1788120000.sh
@@ -8,9 +8,10 @@ echo "Sync the GNOME keyring on future user password changes"
 # /etc/pam.d/passwd before changing the password, so the keyring is
 # re-encrypted as part of the change itself.
 
-# That only helps future changes. A keyring that a past password change
-# already orphaned stays broken, so tell the user how to fix it instead of
-# leaving a silent trap.
+# This migration installs that same PAM line for installs that never run
+# omarchy-user-password again, so a password changed through plain passwd
+# on the terminal is re-encrypted too. Idempotent: once the line is in the
+# stack, a later run (or another user on the same machine) skips the append.
 
 if omarchy-cmd-missing gnome-keyring-daemon; then
   # gnome-keyring is part of the default install; without it there is no
@@ -18,8 +19,38 @@ if omarchy-cmd-missing gnome-keyring-daemon; then
   exit 0
 fi
 
+PASSWD_PAM=/etc/pam.d/passwd
+
+if ! grep -q '^password.*pam_gnome_keyring\.so' "$PASSWD_PAM"; then
+  # Same line, same rationale as bin/omarchy-user-password (ArchWiki:
+  # GNOME/Keyring). Runs as the user; the sudo prompt is the user saying
+  # yes to the repair, which is what the update terminal is for.
+  if ! echo 'password       optional       pam_gnome_keyring.so' | sudo tee -a "$PASSWD_PAM" >/dev/null; then
+    # A migration that cannot finish must exit non-zero so it stays
+    # pending and stops the queue rather than silently half-fixing.
+    echo "Could not append the pam_gnome_keyring line to $PASSWD_PAM."
+    echo "The keyring sync is not installed. The migration will retry on"
+    echo "the next update once the sudo prompt is accepted."
+    exit 1
+  fi
+  echo "Enabled GNOME keyring sync on password change."
+fi
+
+# Machines where a past password change already orphaned the keyring are
+# NOT repaired by any of the above: pam_gnome_keyring unlocks the keyring
+# with the keyring's own old password, so once the login password has moved
+# on, another ordinary password change cannot re-sync it. Do not pretend
+# otherwise; point at real recovery instead.
+
 if [[ -f $HOME/.local/share/keyrings/login.keyring ]]; then
-  echo "An encrypted login keyring was found on this machine."
-  echo "If SDDM rejects your password after a restart, open Update >"
-  echo "Password > User once and change the password to re-sync it."
+  echo "Your login keyring may still hold your OLD password (for example if a"
+  echo "password was changed before this fix). If you are asked for a keyring"
+  echo "password at login, or SDDM rejects a password you know is right,"
+  echo "either:"
+  echo "  - open 'Passwords and Keys' (seahorse), right-click the Login"
+  echo "    keyring, 'Change Password', and set it back to your login"
+  echo "    password, then change your login password once through"
+  echo "    Update > Password > User; or"
+  echo "  - delete the login keyring in 'Passwords and Keys' to start a"
+  echo "    fresh one (saved Wi-Fi and browser passwords in it are lost)."
 fi

--- a/test/shell.d/user-password-test.sh
+++ b/test/shell.d/user-password-test.sh
@@ -62,4 +62,57 @@ bash -euo pipefail "$tmp_dir/leaf.sh" </dev/null >/dev/null
 [[ -e $TEST_PASSWD_RAN ]] || fail "second run still runs passwd"
 [[ ! -e $TEST_ARGS ]] || fail "second run does not append again"
 
+# A sudo stub that fails, the way a cancelled sudo prompt does. The command
+# must refuse to change the password: changing it without the keyring line
+# would orphan the keyring with no way back through a later change. Uses a
+# fresh PAM file, since the runs above already added the line to $pam_file.
+cat >"$tmp_dir/sudo-fail" <<'EOF'
+#!/bin/bash
+echo "sudo: a password is required" >&2
+exit 1
+EOF
+chmod +x "$tmp_dir/sudo-fail"
+
+pam_abort="$tmp_dir/etc/pam.d/passwd-abort"
+printf '#%%PAM-1.0\npassword include system-auth\n' >"$pam_abort"
+sed -e "s|/etc/pam.d/passwd|$pam_abort|g" -e "s|sudo tee|$tmp_dir/sudo-fail tee|g" \
+  "$ROOT/bin/omarchy-user-password" >"$tmp_dir/leaf-nofail.sh"
+rm -f "$TEST_PASSWD_RAN" "$TEST_ARGS"
+bash -euo pipefail "$tmp_dir/leaf-nofail.sh" </dev/null >"$tmp_dir/abort-msg" 2>&1 &&
+  fail "user password aborts when the PAM append is refused"
+[[ ! -e $TEST_PASSWD_RAN ]] || fail "aborted run does not change the password"
+grep -q "NOT changed" "$tmp_dir/abort-msg" ||
+  fail "abort message explains the refusal" "$(cat "$tmp_dir/abort-msg")"
+pass "user password aborts before passwd when the PAM append fails"
+
+# The migration installs the same PAM line idempotently, so a plain
+# `passwd` on the terminal is covered too. Runs as the user under
+# bash -euo pipefail, like omarchy-migrate does.
+migration="$ROOT/migrations/1788120000.sh"
+pam2="$tmp_dir/etc/pam.d/passwd-migration"
+mkdir -p "$tmp_dir/etc/pam.d"
+printf '#%%PAM-1.0\npassword include system-auth\n' >"$pam2"
+
+run_migration() {
+  local pam_target="$1"
+  sed -e "s|/etc/pam.d/passwd|$pam_target|g" -e "s|sudo tee|$tmp_dir/sudo tee|g" \
+    -e "s|omarchy-cmd-missing gnome-keyring-daemon|false|g" \
+    "$migration" >"$tmp_dir/migration.sh"
+  PATH="$tmp_dir:$PATH" HOME="$tmp_dir" \
+    bash -euo pipefail "$tmp_dir/migration.sh" </dev/null >/dev/null 2>&1
+}
+
+# The omarchy-cmd-missing substitution above makes the guard fail, so the
+# migration proceeds to the PAM append.
+run_migration "$pam2"
+grep -q '^password.*pam_gnome_keyring\.so' "$pam2" ||
+  fail "migration installs the keyring PAM line" "$(cat "$pam2")"
+pass "migration installs the keyring PAM line"
+
+lines_before=$(wc -l <"$pam2")
+run_migration "$pam2"
+(( $(wc -l <"$pam2") == lines_before )) ||
+  fail "migration is idempotent" "$(cat "$pam2")"
+pass "migration is idempotent"
+
 pass "user password wires the keyring into passwd PAM exactly once and runs passwd"

--- a/test/shell.d/user-password-test.sh
+++ b/test/shell.d/user-password-test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -r "$tmp_dir"' EXIT
+
+# The command writes to /etc/pam.d/passwd, an absolute path we must not touch
+# outside an Omarchy machine. Follow the brcmfmac-supplicant pattern: copy the
+# leaf into the sandbox and rewrite the absolute paths into it.
+pam_file="$tmp_dir/etc/pam.d/passwd"
+mkdir -p "$tmp_dir/etc/pam.d"
+printf '#%%PAM-1.0\npassword include system-auth\n' >"$pam_file"
+
+# A full copy with the absolute paths rewritten; do not source the original,
+# or it would touch the real /etc/pam.d/passwd.
+{
+  echo '#!/bin/bash'
+  sed -e "s|/etc/pam.d/passwd|$pam_file|g" "$ROOT/bin/omarchy-user-password"
+} >"$tmp_dir/leaf.sh"
+
+cat >"$tmp_dir/gnome-keyring-daemon" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat >"$tmp_dir/sudo" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$@" >"$TEST_ARGS"
+# tee -a emulation: the caller pipes the new line in on stdin
+cat >>"$3"
+EOF
+
+cat >"$tmp_dir/passwd" <<'EOF'
+#!/bin/bash
+printf 'passwd ran\n' >"$TEST_PASSWD_RAN"
+EOF
+
+chmod +x "$tmp_dir/gnome-keyring-daemon" "$tmp_dir/sudo" "$tmp_dir/passwd"
+export PATH="$tmp_dir:$ROOT/bin:$PATH"
+export TEST_ARGS="$tmp_dir/args" TEST_PASSWD_RAN="$tmp_dir/ran"
+
+# First run: the keyring line is appended once and passwd still runs.
+bash -euo pipefail "$tmp_dir/leaf.sh" </dev/null >/dev/null
+
+grep -q '^password.*pam_gnome_keyring\.so' "$pam_file" ||
+  fail "user password adds the keyring sync line to the passwd PAM stack"
+[[ -e $TEST_PASSWD_RAN ]] || fail "user password still runs passwd"
+grep -Fxq "tee" "$TEST_ARGS" && grep -Fxq -- "-a" "$TEST_ARGS" &&
+  grep -Fxq "$pam_file" "$TEST_ARGS" ||
+  fail "user password appends the keyring line via sudo tee -a"
+
+# Second run: idempotent, no duplicate line, passwd still runs.
+lines_before=$(wc -l <"$pam_file")
+rm -f "$TEST_PASSWD_RAN" "$TEST_ARGS"
+bash -euo pipefail "$tmp_dir/leaf.sh" </dev/null >/dev/null
+
+(( $(wc -l <"$pam_file") == lines_before )) ||
+  fail "user password does not append the keyring line twice"
+[[ -e $TEST_PASSWD_RAN ]] || fail "second run still runs passwd"
+[[ ! -e $TEST_ARGS ]] || fail "second run does not append again"
+
+pass "user password wires the keyring into passwd PAM exactly once and runs passwd"


### PR DESCRIPTION
Fixes #9147

## What broke

Changing the login password through Update > Password > User ran plain `passwd`. That updates the login password but never re-encrypts an existing encrypted GNOME login keyring. On the next cold boot SDDM cannot decrypt the keyring and the login bar resets silently; the journal shows `gkr-pam: couldn't unlock the login keyring`.

## Why this tree

- `bin/omarchy-user-password` (new): wires the standard `pam_gnome_keyring.so` password line into `/etc/pam.d/passwd` (idempotently, guarded by `grep`) and then runs `passwd`. With that line present, pam_gnome_keyring re-encrypts the login keyring with the new password as part of the passwd transaction itself (the standard integration documented on the ArchWiki GNOME/Keyring page). `pam_gnome_keyring.so` ships with `gnome-keyring`, which is already in `install/omarchy-base.packages`. If gnome-keyring has been removed, the command falls back to plain `passwd`.
- `default/omarchy/omarchy-menu.jsonc`: the Update > Password > User row now points at `omarchy-user-password`.
- `migrations/1788120000.sh`: existing installs get the same PAM wiring on their next update (idempotent append, non-zero exit if the append is refused so it stays pending per the migration guide). A machine with an orphaned login keyring gets an accurate recovery hint instead: no further password change can re-sync an already-mismatched keyring, so it points at 'Passwords and Keys' (set the keyring password back, or recreate the keyring with the data-loss consequence stated). Mode 0644, no shebang, leading echo, no shell restart.
- `test/shell.d/user-password-test.sh`: covers append-once idempotence, the `sudo tee -a` call shape, and that `passwd` still runs, following the leaf-rewrite sandbox pattern used by `brcmfmac-supplicant-test.sh`.

## Tests

- `test/shell.d/user-password-test.sh`: passes. RED→GREEN checked: with the append block removed the test fails on "adds the keyring sync line", with the fix restored it passes.
- `omarchy commands --check`: passes, 439 commands (metadata lint for the new command).
- The menu JSONC parses cleanly after the one-row edit.
- Full `./test/cli` and `./test/shell` were also exercised on this development machine (macOS); the suites are bash-5 based and most files pass, but the remaining failures are pre-existing environment gaps on this machine (missing `lua`, `magick`, `flock`, real `sudo`, a live shell) that reproduce identically on an unmodified checkout. They are unrelated to this change, which touches only the new command, its menu row, and the new migration/test.

## Verification limits stated honestly

- The PAM line and idempotence logic are verified by the new test; the actual SDDM cold-boot unlock path needs real hardware with an encrypted keyring, which this development machine does not have. I have not run a cold-boot login with this change.
- Deliberately not included: touching the existing `install/login/sddm.sh` behavior that strips `pam_gnome_keyring` from `/etc/pam.d/sddm`. That strip is intentional (it stops password logins from creating an encrypted keyring on the passwordless-default design) and this fix works purely on the passwd side, so the two do not conflict.

