### PR TITLE
Link README to the current manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Read more at [omarchy.org](https://omarchy.org).
 ## The Omarchy Manual
 
 The manual lives in [`manual/`](manual/), which is its authoritative source. It's
-mirrored to [learn.omacom.io](https://learn.omacom.io/2/the-omarchy-manual), where
-its screenshots are also hosted.
+published at [omarchy.org/manual](https://omarchy.org/manual/), where its
+screenshots are also hosted.
 
 - [Welcome to Omarchy!](manual/01-welcome-to-omarchy.md)
 


### PR DESCRIPTION
## Problem

The README describes `learn.omacom.io/2/the-omarchy-manual` as the mirror for the repository's authoritative `manual/` source. That URL now identifies itself as the preserved Omarchy 3 manual, while the current repository manual is published at https://omarchy.org/manual/.

## Solution

Point the README at the current manual URL. The change leaves the local manual TOC and all historical URLs untouched.

## Verification

- Confirmed the current live manual has the same 51-chapter table of contents and opening content as `manual/`.
- Checked all 90 tracked Markdown files (399 relative links): 0 unresolved local links.
- `git diff --check`

No Omarchy host, package, installer, or desktop-session script was executed.
