### PR TITLE
Install playerctl alongside voxtype so pause_media actually works

### DIFF
--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -8,7 +8,7 @@ set -e
 # Install voxtype and configure it for use.
 
 if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
-  omarchy-pkg-add wtype voxtype-bin
+  omarchy-pkg-add wtype playerctl voxtype-bin
 
   # Setup voxtype
   mkdir -p ~/.config/voxtype


### PR DESCRIPTION
## Summary
- `default/voxtype/config.toml` ships `pause_media = true` by default, but Voxtype implements that by shelling out to `playerctl`, and `omarchy-voxtype-install` never installed it — so the feature silently failed on every fresh install.
- Confirmed via `journalctl --user -u voxtype`: `WARN playerctl not found or failed to run: No such file or directory (os error 2)`.
- Fix: add `playerctl` to the `omarchy-pkg-add` call in `bin/omarchy-voxtype-install`.

## Test plan
- [x] `./test/all` — same 5 pre-existing failures as on `quattro` before this change (all unrelated: missing `omarchy-pkgs` checkout / snapper / theme-install-guards / unowned-system-paths / windows-vm-mount-boundary), none touching voxtype
- [x] Manually installed `playerctl` and confirmed dictation now pauses a Chromium tab's MPRIS player (Google Music) and resumes it after

Fixes #9243