### PR TITLE
Fix context menus for Wine tray items

### DIFF
--- a/bin/omarchy-tray-context-menu
+++ b/bin/omarchy-tray-context-menu
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# omarchy:summary=Open a Wine tray item's native context menu
+# omarchy:args=<item-id> <x> <y>
+# omarchy:hidden=true
+
+set -euo pipefail
+
+item_id=${1:-}
+x=${2:-0}
+y=${3:-0}
+
+if [[ $item_id != wine-* || ! $x =~ ^-?[0-9]+$ || ! $y =~ ^-?[0-9]+$ ]]; then
+  exit 2
+fi
+
+mapfile -t registered_items < <(
+  busctl --user --json=short get-property \
+    org.kde.StatusNotifierWatcher \
+    /StatusNotifierWatcher \
+    org.kde.StatusNotifierWatcher \
+    RegisteredStatusNotifierItems |
+    jq -r '.data[]'
+)
+
+for registered_item in "${registered_items[@]}"; do
+  service=${registered_item%%/*}
+  object_path=/${registered_item#*/}
+
+  registered_id=$(
+    busctl --user --json=short get-property \
+      "$service" "$object_path" org.kde.StatusNotifierItem Id 2>/dev/null \
+      | jq -r '.data // empty'
+  ) || continue
+
+  if [[ $registered_id != $item_id ]]; then
+    continue
+  fi
+
+  menu_path=$(
+    busctl --user --json=short get-property \
+      "$service" "$object_path" org.kde.StatusNotifierItem Menu 2>/dev/null \
+      | jq -r '.data // empty'
+  ) || continue
+
+  if [[ $menu_path != "/NO_DBUSMENU" ]]; then
+    exit 3
+  fi
+
+  busctl --user -- call \
+    "$service" "$object_path" org.kde.StatusNotifierItem ContextMenu ii "$x" "$y"
+  exit 0
+done
+
+exit 4

--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -115,6 +115,20 @@ BarWidget {
   }
 
   function openTrayMenu(item, anchorItem, mouse) {
+    // Wine exposes Windows tray menus through ContextMenu(), while advertising
+    // /NO_DBUSMENU as its Menu path. Let Wine draw that native menu instead of
+    // asking Quickshell to parse the sentinel as a DBusMenu.
+    if (TrayModel.usesNativeContextMenu(item)) {
+      var globalPoint = anchorItem.mapToGlobal(mouse.x, mouse.y)
+      Quickshell.execDetached([
+        root.bar.omarchyPath + "/bin/omarchy-tray-context-menu",
+        String(item.id || ""),
+        String(Math.round(globalPoint.x)),
+        String(Math.round(globalPoint.y))
+      ])
+      return
+    }
+
     if (!item || !item.menu) {
       var point = anchorItem.QsWindow.contentItem.mapFromItem(anchorItem, mouse.x, mouse.y)
       item.display(anchorItem.QsWindow.window, point.x, point.y)

--- a/shell/plugins/bar/widgets/TrayModel.js
+++ b/shell/plugins/bar/widgets/TrayModel.js
@@ -30,6 +30,10 @@ function layoutHasWidget(layout, id) {
   return false
 }
 
+function usesNativeContextMenu(item) {
+  return !!item && String(item.id || "").indexOf("wine-") === 0
+}
+
 // LocalSend's item shows no state, offers only Open and Quit, and its primary
 // click is a no-op, so Share > Receive is the whole surface. Hiding it by hand
 // doesn't stick either: LocalSend picks a fresh tray id every launch.
@@ -43,6 +47,7 @@ if (typeof module !== "undefined") {
     itemNamed: itemNamed,
     entryId: entryId,
     layoutHasWidget: layoutHasWidget,
+    usesNativeContextMenu: usesNativeContextMenu,
     ownedByOmarchy: ownedByOmarchy
   }
 }

--- a/test/shell.d/tray-context-menu-test.sh
+++ b/test/shell.d/tray-context-menu-test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+args_file="$tmpdir/busctl-args"
+command="$ROOT/bin/omarchy-tray-context-menu"
+
+printf '%s\n' \
+  '#!/bin/bash' \
+  'printf "%s\n" "$@" >>"$OMARCHY_TEST_BUSCTL_ARGS"' \
+  'case "$*" in' \
+  '  *"RegisteredStatusNotifierItems") printf '\''{"type":"as","data":[":1.10/StatusNotifierItem"]}\n'\'' ;;' \
+  '  *" org.kde.StatusNotifierItem Id") printf '\''{"type":"s","data":"%s"}\n'\'' "${OMARCHY_TEST_ITEM_ID:-wine-test}" ;;' \
+  '  *" org.kde.StatusNotifierItem Menu") printf '\''{"type":"o","data":"%s"}\n'\'' "${OMARCHY_TEST_MENU_PATH:-/NO_DBUSMENU}" ;;' \
+  '  "--user -- call "*) ;;' \
+  '  *) exit 99 ;;' \
+  'esac' \
+  >"$tmpdir/busctl"
+chmod +x "$tmpdir/busctl"
+
+run_context_menu() {
+  local expected_status=$1
+  shift
+
+  : >"$args_file"
+  set +e
+  OMARCHY_TEST_BUSCTL_ARGS="$args_file" PATH="$tmpdir:$PATH" "$command" "$@"
+  local actual_status=$?
+  set -e
+
+  ((actual_status == expected_status)) ||
+    fail "tray context menu exits with status $expected_status" "actual: $actual_status"
+}
+
+assert_no_context_call() {
+  if grep -Fxq -- "call" "$args_file"; then
+    fail "tray context menu does not call ContextMenu" "$(cat "$args_file")"
+  fi
+}
+
+run_context_menu 2 native-test not-a-number 20
+[[ ! -s $args_file ]] || fail "tray context menu rejects malformed input before DBus" "$(cat "$args_file")"
+pass "tray context menu rejects malformed input before DBus"
+
+OMARCHY_TEST_ITEM_ID=wine-other run_context_menu 4 wine-test 10 20
+assert_no_context_call
+pass "tray context menu ignores unknown item ids"
+
+OMARCHY_TEST_MENU_PATH=/MenuBar run_context_menu 3 wine-test 10 20
+assert_no_context_call
+pass "tray context menu refuses items with a real DBus menu"
+
+run_context_menu 0 wine-test 33 44
+actual_call=$(tail -n 10 "$args_file" | paste -sd ' ')
+expected_call="--user -- call :1.10 /StatusNotifierItem org.kde.StatusNotifierItem ContextMenu ii 33 44"
+[[ $actual_call == "$expected_call" ]] ||
+  fail "tray context menu preserves the native call coordinates" "$actual_call"
+pass "tray context menu calls Wine's native menu with exact coordinates"

--- a/test/shell.d/tray-test.sh
+++ b/test/shell.d/tray-test.sh
@@ -11,6 +11,9 @@ assert(tray.itemNamed({ id: 'dropbox-client' }, 'dropbox'), 'tray matches item i
 assert(tray.itemNamed({ title: 'Dropbox' }, 'dropbox'), 'tray matches item titles')
 assert(tray.itemNamed({ tooltipTitle: 'LocalSend' }, 'localsend'), 'tray matches item tooltips')
 assert(!tray.itemNamed({ id: 'nextcloud' }, 'dropbox'), 'tray ignores items named for something else')
+assert(tray.usesNativeContextMenu({ id: 'wine-0x10106-0' }), 'tray routes Wine items to their native context menu')
+assert(!tray.usesNativeContextMenu({ id: 'nextcloud', title: 'wine-helper' }), 'tray keeps native-menu detection scoped to the item id')
+assert(!tray.usesNativeContextMenu(null), 'tray rejects missing items for native context menus')
 
 const layout = {
   left: [{ id: 'omarchy.menu' }],


### PR DESCRIPTION
## What changed

- Route Wine status notifier items to their native `ContextMenu` method instead of trying to render `/NO_DBUSMENU` as a DBusMenu
- Resolve the current item through `StatusNotifierWatcher`, verify both its Wine id and `/NO_DBUSMENU` sentinel, then forward the click's screen coordinates
- Leave regular DBusMenu tray items on the existing path
- Cover Wine detection plus malformed arguments, stale ids, real DBus menus, and the exact native call coordinates

## Why

Battle.net running through GE-Proton registers a live status notifier item like this:

```text
Id:   wine-0x200d4-0
Menu: /NO_DBUSMENU
```

The current tray treats that sentinel as a real DBusMenu object. Right-clicking therefore logs DBus `UnknownMethod` errors and renders nothing, which also makes Battle.net's `Exit` action inaccessible.

The [freedesktop Status Notifier Item specification](https://specifications.freedesktop.org/status-notifier-item/latest-single/#status-notifier-item-methods-contextmenu) defines `ContextMenu(INT x, INT y)` for exactly this right-click fallback, with coordinates in screen space.

## Verification

- `bash test/shell.d/tray-test.sh`
- `bash test/shell.d/tray-context-menu-test.sh`
- `./test/cli`
- `./test/all`: both new tray test files pass in the full run. Seven unrelated host-environment checks initially failed; each was rerun successfully with its expected companion checkout or host access. The URL-checker absence case also passes with an isolated PATH, because this Omarchy machine already has the checker installed globally.
- Live Battle.net item: confirmed `wine-0x200d4-0` and `/NO_DBUSMENU`, ran the exact helper from this branch, and visually confirmed the native menu opens with its `Exit` action

The branch is rebased onto current `quattro`.
