### PR TITLE
Default the acceptance suite's OMARCHY_PATH to the installed tree alone

### DIFF
--- a/test/acceptance
+++ b/test/acceptance
@@ -19,21 +19,12 @@ mkdir -p "$OMARCHY_ACCEPTANCE_DIR"
 # the session environment is inherited.
 export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=$XDG_RUNTIME_DIR/bus}"
-# The suite acts on the running session, and qs matches shell instances by
-# config path — pointed at any other tree, every omarchy-shell call reads as
-# "not running". So default OMARCHY_PATH to the tree the session was started
-# from, then this checkout for standalone use, then the installed tree for
-# when only test/ was synced in (omarchy-iso-test's --sync-omarchy).
-if [[ -z ${OMARCHY_PATH:-} ]]; then
-  OMARCHY_PATH=$(systemctl --user show-environment 2>/dev/null | sed -n 's/^OMARCHY_PATH=//p' | tail -1)
-fi
-if [[ -z $OMARCHY_PATH ]]; then
-  OMARCHY_PATH=$ROOT
-fi
-if [[ ! -f $OMARCHY_PATH/shell/shell.qml && -f /usr/share/omarchy/shell/shell.qml ]]; then
-  OMARCHY_PATH=/usr/share/omarchy
-fi
-export OMARCHY_PATH
+# The suite verifies the installed product the session is running, so default
+# OMARCHY_PATH to the installed tree — never this checkout, which may hold
+# only test/ (omarchy-iso-test's --sync-omarchy). qs matches shell instances
+# by config path, so a suite pointed at any other tree reads the session
+# shell as "not running". Callers testing a different tree pass it explicitly.
+export OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
 
 export PATH="$OMARCHY_PATH/bin:$PATH"
 


### PR DESCRIPTION
#9240 merged just before its final revision was force-pushed, so quattro got the intermediate defaulting (session-environment lookup, then the suite's own checkout). VM testing verifies the finished product — the installed tree is always the default; anything else is passed explicitly.