### PR TITLE
Fix test failures caused by host assumptions

### DIFF
--- a/test/acceptance.d/security-test.sh
+++ b/test/acceptance.d/security-test.sh
@@ -58,7 +58,17 @@ verify_sshd_hardening() {
   rm -f "$key_file" "$key_file.pub"
   ssh-keygen -t ed25519 -N "" -q -C "omarchy-acceptance" -f "$key_file"
 
-  if ! omarchy-setup-security-sshd --key="$(cat "$key_file.pub")" >"$ARTIFACTS/setup-security-sshd.log" 2>&1; then
+  # sudo keys its cached credential on the calling terminal and, absent one, on
+  # the caller's parent process alone, so a timestamp validated in this shell
+  # never reaches the setup command's own sudo calls when the suite runs
+  # without a terminal (omarchy-iso-test drives it over ssh with no pty). Give
+  # the exercise a pseudo-terminal and validate the password on it first, so
+  # every sudo underneath shares that terminal's credential.
+  if ! OMARCHY_ACCEPTANCE_SUDO_PASSWORD="$OMARCHY_ACCEPTANCE_SUDO_PASSWORD" \
+    OMARCHY_ACCEPTANCE_SSHD_KEY="$(cat "$key_file.pub")" SHELL=/bin/bash \
+    script -qec 'printf "%s\n" "$OMARCHY_ACCEPTANCE_SUDO_PASSWORD" | sudo -S -v 2>/dev/null &&
+      omarchy-setup-security-sshd --key="$OMARCHY_ACCEPTANCE_SSHD_KEY"' /dev/null \
+    </dev/null >"$ARTIFACTS/setup-security-sshd.log" 2>&1; then
     fail "omarchy-setup-security-sshd completes unattended" "$(tail -5 "$ARTIFACTS/setup-security-sshd.log")"
   fi
   pass "omarchy-setup-security-sshd completes unattended"

--- a/test/shell.d/theme-install-guards-test.sh
+++ b/test/shell.d/theme-install-guards-test.sh
@@ -71,8 +71,15 @@ done
 pass "a URL naming a transport git does not implement never reaches git"
 
 # The checker is a separate command, so its absence has to refuse the URL rather
-# than wave it through to git.
-if install_theme "https://github.com/example/omarchy-cool-theme.git" "$mock_bin:$PATH"; then
+# than wave it through to git. Installed machines carry the packaged checker in
+# /usr/bin, so absence is simulated by shadowing it with a stub that reports
+# command-not-found instead of thinning the PATH.
+missing_checker_bin="$test_tmp/missing-checker-bin"
+mkdir -p "$missing_checker_bin"
+printf '#!/bin/bash\nexit 127\n' >"$missing_checker_bin/omarchy-git-url-check"
+chmod +x "$missing_checker_bin/omarchy-git-url-check"
+
+if install_theme "https://github.com/example/omarchy-cool-theme.git" "$missing_checker_bin:$mock_bin:$ROOT/bin:$PATH"; then
   fail "omarchy-theme-install refuses a URL it cannot check"
 fi
 

--- a/test/shell.d/windows-vm-mount-boundary-test.sh
+++ b/test/shell.d/windows-vm-mount-boundary-test.sh
@@ -15,6 +15,10 @@ fi
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
+# The checkout may live under /home, which the tmpfs below hides, so take a
+# mount-safe copy of the helper before the mounts land.
+cp "$ROOT/bin/omarchy-windows-vm" "$test_tmp/omarchy-windows-vm"
+
 # Hide host state before creating the production paths used by the root helper.
 mount -t tmpfs -o mode=0755,size=8m run-test /run
 mkdir -p /run/lock
@@ -27,7 +31,7 @@ mount -t tmpfs -o uid=0,gid=0,mode=0710,size=1g home-alice /home/alice
 export HOME=/home/alice
 unset OMARCHY_WINDOWS_DIR
 set -- help
-source "$ROOT/bin/omarchy-windows-vm" >/dev/null 2>&1
+source "$test_tmp/omarchy-windows-vm" >/dev/null 2>&1
 
 # The namespace maps the host filesystem's uid 0 to nobody. Only / remains on
 # that filesystem; all paths the helper mutates are isolated tmpfs mounts.


### PR DESCRIPTION
Three tests failed on a real machine but passed in development, each because of an assumption about the host that only holds in a dev checkout. All three changes are test-only; no product code is touched.

## The fixes

**`windows-vm-mount-boundary-test.sh` — copy the helper before the test hides `/home`**

The test tmpfs-mounts over `/home` before sourcing `$ROOT/bin/omarchy-windows-vm`. When the checkout lives under `/home` — as it does on any installed machine (`~/.local/share/omarchy`) — the mount hides the repo, the `source` fails, and `set -e` aborts the file with **no output at all**, not even a `not ok` line. Now takes a mount-safe copy into the test tmpdir before the mounts land.

**`theme-install-guards-test.sh` — shadow the URL checker instead of thinning `PATH`**

The "refuses a URL it cannot check" case simulated a missing `omarchy-git-url-check` by dropping `$ROOT/bin` from `PATH`. But 4.x packages that command at `/usr/bin/omarchy-git-url-check`, so it was always found via the ambient `PATH` and the guard was never exercised — this subtest failed on **every** installed 4.x machine. Now shadows it with a stub that exits 127, so the scenario holds regardless of host.

**`security-test.sh` — give the sshd exercise a terminal for sudo**

Without a terminal, sudo keys its cached credential on the *parent process* of each call. The `sudo -S -v` the test performs only covers sudo calls made directly by the test shell, so the `sudo` calls inside `omarchy-setup-security-sshd` (a grandchild) found no credential, had no terminal to prompt on, and died with `sudo: a terminal is required`. This is why the acceptance suite failed under `omarchy-iso-test`, which drives it over ssh with no pty. Now runs the exercise under `script(1)` and validates the password on that pseudo-terminal first, so every sudo underneath shares the terminal-keyed credential.

## Validation

Verified in the live 4.0.2-rc acceptance VM — the environment that reproduces all three conditions (tree under `/home`, packaged checker in `/usr/bin`, ssh with no pty). The guest's `test/` tree was wiped and re-synced from this branch first, so nothing stale could pass:

- `windows-vm-mount-boundary-test.sh` — all 9 assertions pass
- `theme-install-guards-test.sh` — all 12 assertions pass, including the previously-dead missing-checker guard
- `security-test.sh` — all 8 assertions pass from a cold `sudo -K` state over ssh with no tty
- **Full acceptance suite — 118 passed, 0 failed, "acceptance suite passed in 78s"** (this suite previously failed on the sshd exercise)
- Full `./test/shell` on the dev host — green

## Not addressed here

Two unrelated environmental failures surfaced while validating, left for separate changes:

- `config-test`, `snapper-test`, `unowned-system-paths-test` hard-fail when no `omarchy-pkgs` / `omarchy-iso` sibling checkout exists (e.g. on an end-user machine or in the VM). They pass with `OMARCHY_PKGS_PATH` / `OMARCHY_ISO_PATH` set. Worth deciding whether these should skip instead of fail.
- `ascii-test` and `branding-about-animation-test` fail in the VM because non-interactive ssh sessions get no locale (`LANG=` empty, POSIX ctype), breaking wide-character column measurement. Both pass under `LC_ALL=en_US.UTF-8`.