### PR TITLE
Fall back to color8 for a derived theme selection color

### DIFF
--- a/bin/omarchy-theme-colors-from-alacritty
+++ b/bin/omarchy-theme-colors-from-alacritty
@@ -120,7 +120,12 @@ background=${background:-$color0}
 foreground=${foreground:-$color7}
 color0=$background
 color7=$foreground
-selection_background=${selection_background:-$foreground}
+# A theme with no [colors.selection] used to fall back to the foreground, which
+# renders every selection as text-on-text. Follow the same chain
+# omarchy-theme-color applies for an unset selection instead: color8, then
+# color0, then background. The normal colors are validated above, so color8 is
+# always set by the time this runs.
+selection_background=${selection_background:-${color8:-${color0:-$background}}}
 accent=$color4
 
 mkdir -p "$THEME_SOURCE"

--- a/test/shell.d/theme-colors-from-alacritty-test.sh
+++ b/test/shell.d/theme-colors-from-alacritty-test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# A theme installed with `omarchy theme install` often ships only an
+# alacritty.toml, so omarchy-theme-colors-from-alacritty derives its colors.toml.
+# An alacritty.toml with no [colors.selection] must not end up with a selection
+# equal to the foreground: the generated colors.toml is what downstream
+# templates read, so a selection that matches the foreground renders every
+# highlight as invisible text-on-text.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+generate() {
+  local theme="$1"
+
+  bash "$ROOT/bin/omarchy-theme-colors-from-alacritty" "$theme"
+}
+
+color_of() {
+  local theme="$1" key="$2"
+
+  sed -n "s/^$key = \"\(.*\)\"$/\1/p" "$theme/colors.toml"
+}
+
+write_alacritty() {
+  local theme="$1"
+  mkdir -p "$theme"
+
+  cat >"$theme/alacritty.toml" <<TOML
+[colors.primary]
+background = "#1a1b26"
+foreground = "#c0caf5"
+
+[colors.normal]
+black = "#15161e"
+red = "#f7768e"
+green = "#9ece6a"
+yellow = "#e0af68"
+blue = "#7aa2f7"
+magenta = "#bb9af7"
+cyan = "#7dcfff"
+white = "#a9b1d6"
+
+[colors.bright]
+black = "#414868"
+red = "#f7768e"
+green = "#9ece6a"
+yellow = "#e0af68"
+blue = "#7aa2f7"
+magenta = "#bb9af7"
+cyan = "#7dcfff"
+white = "#c0caf5"
+TOML
+}
+
+assert_color() {
+  local theme="$1" key="$2" expected="$3" description="$4"
+  local actual
+  actual=$(color_of "$theme" "$key")
+
+  [[ $actual == "$expected" ]] || fail "$description" "expected: $expected
+actual:   $actual"
+  pass "$description"
+}
+
+# Without [colors.selection], the selection falls through to color8 rather than
+# the foreground.
+missing=$test_tmp/missing
+write_alacritty "$missing"
+generate "$missing"
+
+assert_color "$missing" selection "#414868" \
+  "selection falls back to color8 when [colors.selection] is absent"
+
+foreground=$(color_of "$missing" foreground)
+[[ $(color_of "$missing" selection) != "$foreground" ]] ||
+  fail "selection never equals foreground" "both are $foreground"
+pass "selection never equals foreground"
+
+# A theme that does declare a selection background keeps it.
+declared=$test_tmp/declared
+write_alacritty "$declared"
+cat >>"$declared/alacritty.toml" <<'TOML'
+
+[colors.selection]
+background = "#283457"
+TOML
+generate "$declared"
+
+assert_color "$declared" selection "#283457" \
+  "a declared [colors.selection] background is preserved"
+
+# Without [colors.bright], color8 falls back to normal black, and the selection
+# follows it there rather than to the foreground.
+no_bright=$test_tmp/no-bright
+mkdir -p "$no_bright"
+cat >"$no_bright/alacritty.toml" <<'TOML'
+[colors.primary]
+background = "#1a1b26"
+foreground = "#c0caf5"
+
+[colors.normal]
+black = "#15161e"
+red = "#f7768e"
+green = "#9ece6a"
+yellow = "#e0af68"
+blue = "#7aa2f7"
+magenta = "#bb9af7"
+cyan = "#7dcfff"
+white = "#a9b1d6"
+TOML
+generate "$no_bright"
+
+assert_color "$no_bright" selection "#15161e" \
+  "selection follows color8 to normal black when [colors.bright] is absent"


### PR DESCRIPTION
### Symptom

A theme installed with `omarchy theme install` that ships only an `alacritty.toml` with no `[colors.selection]` block ends up with `selection` equal to `foreground` in its generated `colors.toml`. Every highlight that keys off that value renders as invisible text-on-text: Neovim's `Visual` and `LspReferenceText`, the selected item in `gum confirm`/`gum choose` prompts, and btop's selected process row.

### Root cause

`bin/omarchy-theme-colors-from-alacritty` defaulted an absent selection background to the foreground:

```bash
selection_background=${selection_background:-$foreground}
```

Because the theme now has a `colors.toml`, `omarchy-theme-color`'s own fallback chain for an unset `selection` never gets a chance to run. The key is already set, just set to the one value it should never take.

### Fix

Use the same chain `omarchy-theme-color` applies at `bin/omarchy-theme-color:229` for an unset selection, so the generator and the reader agree:

```bash
selection_background=${selection_background:-${color8:-${color0:-$background}}}
```

`color8` is `[colors.bright].black`, or `[colors.normal].black` when the theme ships no bright palette. The normal colors are validated earlier in the script, so `color8` is always set by the time this runs; the rest of the chain mirrors the canonical one rather than stopping short of it.

A theme that does declare `[colors.selection]` is unaffected.

### Verified

Locally on bash 5.3, running the script directly against synthetic theme directories:

- Reproduced the bug on the unmodified script: a theme with no `[colors.selection]` generated `selection = "#c0caf5"`, identical to its `foreground`.
- After the change, the same theme generates `selection = "#414868"`, its `color8`.
- A theme that declares `[colors.selection].background` still gets exactly that value.
- A theme with no `[colors.bright]` gets its `[colors.normal].black`, confirming the chain follows `color8` rather than reaching the foreground.
- Added `test/shell.d/theme-colors-from-alacritty-test.sh` covering those three cases. It fails on the unfixed script with `expected: #414868 / actual: #c0caf5` and passes with the fix, so it is a real regression test rather than a restatement of current behavior.
- `bash -n` on both changed files, and `test/shell.d/bin-style-test.sh` passes.
- `theme-install-guards-test.sh`, `user-theme-test.sh` and `vscode-theme-test.sh` pass.

### Not verified

I do not have an Omarchy system to test on, so this was not exercised through a real `omarchy theme install` or `omarchy theme set`, and I did not confirm the downstream rendering in Neovim, gum or btop; that part rests on the issue reporter's account and on the generated `colors.toml` now carrying the intended value.

`test/shell.d/theme-staging-test.sh` fails on my macOS checkout, but it fails identically on unmodified `quattro`, so it is an environment limitation rather than a regression from this change. I also could not complete a full `test/shell` run locally: unrelated Linux-dependent files hang partway through on macOS.
