### PR TITLE
Include pahole in the offline ISO package set

### DIFF
--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -23,6 +23,7 @@ limine-snapper-sync
 linux
 linux-firmware
 linux-headers
+pahole
 linux-ptl
 linux-ptl-headers
 macbook12-spi-driver-dkms


### PR DESCRIPTION
## Summary

Omarchy installations are required to work fully offline. During hardware finalization, installing kernel headers can require `pahole`, but it was not included in the package list used to build the ISO's offline mirror. The missing artifact caused the finalizer to stop even though the package is part of the normal Arch repositories.

## Changes

- Add `pahole` to `install/omarchy-other.packages`, so the ISO builder includes it in the offline package mirror.
- Keep the installer strictly offline; no online fallback is introduced.

## Validation

- `bash -n bin/omarchy-pkg-add`
- `grep -qx 'pahole' install/omarchy-other.packages`
- `bash test/shell.d/bin-style-test.sh`
- `bash test/shell.d/synaptic-touchpad-test.sh`
- `bash test/shell.d/update-pacman-guard-test.sh`
- `git diff --check`
