### PR TITLE
Make Apple Magic Trackpad pointer feel closer to macOS

### DIFF
--- a/bin/omarchy-hw-apple-magic-mouse
+++ b/bin/omarchy-hw-apple-magic-mouse
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# omarchy:summary=Detect an Apple Magic Mouse on USB or Bluetooth.
+
+hid_dir="${OMARCHY_HID_DEVICES_DIR:-/sys/bus/hid/devices}"
+shopt -s nullglob
+for uevent in "$hid_dir"/*/uevent; do
+  # USB 0003 / Bluetooth 0005. Apple 05AC and the later Bluetooth vendor 004C.
+  # Mouse v1 030D, v2 0269, USB-C 0323. Same hid-magicmouse module as the trackpad.
+  if grep -qiE 'HID_ID=000[35]:0000(05AC|004C):0000(030D|0269|0323)' "$uevent"; then
+    exit 0
+  fi
+done
+exit 1

--- a/bin/omarchy-hw-apple-magic-trackpad
+++ b/bin/omarchy-hw-apple-magic-trackpad
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# omarchy:summary=Detect an Apple Magic Trackpad on USB or Bluetooth.
+
+hid_dir="${OMARCHY_HID_DEVICES_DIR:-/sys/bus/hid/devices}"
+shopt -s nullglob
+for uevent in "$hid_dir"/*/uevent; do
+  # USB 0003 / Bluetooth 0005. Apple 05AC and the later Bluetooth vendor 004C.
+  # Trackpad v1 030E, v2 0265, USB-C 2024 0324.
+  if grep -qiE 'HID_ID=000[35]:0000(05AC|004C):0000(0265|0324|030E)' "$uevent"; then
+    exit 0
+  fi
+done
+exit 1

--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -77,3 +77,28 @@ hl.config({
 -- Scroll nicely in the terminal.
 o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
 o.window("com.mitchellh.ghostty", { scroll_touchpad = 0.2 })
+
+-- Apple Magic Trackpad. Keep adaptive accel and the default sensitivity even
+-- if the user raises the global pointer speed; a high global sensitivity makes
+-- small moves jumpy on this large pad. Unknown names are ignored.
+-- Device blocks take input / input.touchpad keys flattened.
+local magic_trackpad = {
+  sensitivity = 0.0,
+  accel_profile = "adaptive",
+  clickfinger_behavior = true,
+}
+
+for _, name in ipairs({
+  "apple-inc.-magic-trackpad",
+  "apple-inc.-magic-trackpad-1",
+  "apple-inc.-magic-trackpad-2",
+  "apple-inc.-magic-trackpad-2-1",
+  "apple-inc.-magic-trackpad-usb-c",
+  "apple-inc.-magic-trackpad-usb-c-1",
+}) do
+  local cfg = { name = name }
+  for key, value in pairs(magic_trackpad) do
+    cfg[key] = value
+  end
+  hl.device(cfg)
+end

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -39,6 +39,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-magic-trackpad.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-magic-trackpad.sh
+++ b/install/hardware/apple/fix-magic-trackpad.sh
@@ -1,0 +1,53 @@
+# Apple Magic Trackpad: closer to macOS pointer feel.
+#
+# hid-magicmouse turns a resting thumb plus one moving finger into two-finger
+# scroll or a right-click. libinput can ignore that thumb, but only if the
+# kernel stops emulating those gestures first. Stock libinput quirks also set
+# AttrTouchSizeRange=20:10 on these pads, which disables size-based palm/thumb
+# filtering.
+#
+# The same kernel module drives Magic Mouse, whose touch-surface scroll depends
+# on emulate_scroll_wheel, so the module options are skipped when a Magic Mouse
+# is present. The libinput quirks match Magic Trackpad devices by name and
+# are safe to install always.
+
+quirks="${OMARCHY_MAGIC_TRACKPAD_QUIRKS:-/etc/libinput/omarchy-magic-trackpad.quirks}"
+modprobe_conf="${OMARCHY_HID_MAGICMOUSE_CONF:-/etc/modprobe.d/omarchy-magic-trackpad.conf}"
+
+write_file() {
+  local dest=$1
+  if (( EUID == 0 )); then
+    mkdir -p "$(dirname "$dest")"
+    cat >"$dest"
+  else
+    sudo mkdir -p "$(dirname "$dest")"
+    sudo tee "$dest" >/dev/null
+  fi
+}
+
+write_file "$quirks" <<'EOF'
+# Omarchy: ignore a light resting thumb on Apple Magic Trackpad.
+# Stock libinput 50-system-apple.quirks uses AttrTouchSizeRange=20:10, which
+# turns size-based palm/thumb filtering off and trusts device firmware.
+[Apple Magic Trackpad]
+MatchName=*Magic Trackpad*
+MatchUdevType=touchpad
+AttrSizeHint=162x115
+AttrTouchSizeRange=40:20
+AttrThumbSizeThreshold=550
+AttrPalmSizeThreshold=750
+AttrThumbPressureThreshold=70
+AttrPalmPressureThreshold=160
+EOF
+
+if omarchy-hw-apple-magic-mouse || ! omarchy-hw-apple-magic-trackpad; then
+  return 0
+fi
+
+write_file "$modprobe_conf" <<'EOF'
+# Let libinput own two-finger scroll and multi-finger clicks on Magic Trackpad.
+# hid-magicmouse otherwise treats a resting thumb as a second finger.
+# Skipped when a Magic Mouse is present: that device still needs kernel
+# surface-scroll emulation.
+options hid_magicmouse emulate_scroll_wheel=0 emulate_3button=0 scroll_acceleration=0
+EOF

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -57,6 +57,18 @@ hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
 
 On Dell XPS laptops with a haptic touchpad, you can also set the click strength to low, mid, or high under _Trigger > Hardware > Touchpad Haptics_.
 
+### Apple Magic Trackpad
+
+Omarchy ships Magic Trackpad defaults that ignore a resting thumb (the way macOS does) and keep small pointer moves precise:
+
+- libinput size/pressure thresholds drop a light edge rest so it is not treated as a second finger
+- `hid-magicmouse` kernel two-finger scroll and 3-button emulation are turned off so libinput can own those gestures
+- Hyprland keeps adaptive acceleration and the default sensitivity on the pad even if you raise the global pointer speed in `input.lua`
+
+Two-finger right-click and two-finger scroll still work through libinput. The kernel module options are skipped when an Apple Magic Mouse is also connected, because that mouse still needs kernel surface-scroll emulation.
+
+Override any of this in `~/.config/hypr/input.lua` the same way as other input settings.
+
 ### Typing in Chinese, Japanese, and other languages
 
 Omarchy runs the [fcitx5](https://fcitx-im.org/) input method framework as part of every session — it's what powers the CapsLock compose sequences. That means the plumbing for non-Latin input is already in place: install an input engine like `fcitx5-mozc` (Japanese) or `fcitx5-chinese-addons` (Chinese) with `omarchy pkg add`, plus `fcitx5-configtool` to add the engine to your input methods and set the key that switches between them.

--- a/migrations/1788129995.sh
+++ b/migrations/1788129995.sh
@@ -1,0 +1,24 @@
+echo "Make Apple Magic Trackpad pointer feel closer to macOS"
+
+# Install-time quirk only reaches machines set up after it shipped. See
+# install/hardware/apple/fix-magic-trackpad.sh for why hid-magicmouse kernel
+# emulation and the stock libinput size range fight a resting thumb.
+source "$OMARCHY_PATH/install/hardware/apple/fix-magic-trackpad.sh"
+
+modprobe_conf="${OMARCHY_HID_MAGICMOUSE_CONF:-/etc/modprobe.d/omarchy-magic-trackpad.conf}"
+sysfs="${OMARCHY_HID_MAGICMOUSE_SYSFS:-/sys/module/hid_magicmouse/parameters}"
+
+# The module reads modprobe.d on load. Applying the same values to sysfs makes
+# a currently connected trackpad pick them up without a reboot. Magic Mouse
+# installs never write the conf, so they are not touched here either.
+if [[ -f $modprobe_conf && -f $sysfs/emulate_scroll_wheel ]]; then
+  if (( EUID == 0 )); then
+    printf 'N\n' >"$sysfs/emulate_scroll_wheel"
+    printf 'N\n' >"$sysfs/emulate_3button"
+    printf 'N\n' >"$sysfs/scroll_acceleration"
+  else
+    printf 'N\n' | sudo tee "$sysfs/emulate_scroll_wheel" >/dev/null
+    printf 'N\n' | sudo tee "$sysfs/emulate_3button" >/dev/null
+    printf 'N\n' | sudo tee "$sysfs/scroll_acceleration" >/dev/null
+  fi
+fi

--- a/test/shell.d/magic-trackpad-test.sh
+++ b/test/shell.d/magic-trackpad-test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-magic-trackpad.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1788129995.sh"
+input_lua="$ROOT/default/hypr/input.lua"
+
+grep -q 'apple/fix-magic-trackpad.sh' "$all" ||
+  fail "the Magic Trackpad quirk runs during hardware setup"
+pass "the Magic Trackpad quirk runs during hardware setup"
+
+grep -q 'apple-inc.-magic-trackpad' "$input_lua" ||
+  fail "Hyprland defaults pin Magic Trackpad sensitivity"
+grep -q 'accel_profile = "adaptive"' "$input_lua" ||
+  fail "Hyprland defaults keep adaptive accel on the Magic Trackpad"
+pass "Hyprland defaults pin Magic Trackpad pointer feel"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+hid_dir="$test_tmp/hid"
+quirks="$test_tmp/etc/libinput/omarchy-magic-trackpad.quirks"
+modprobe_conf="$test_tmp/etc/modprobe.d/omarchy-magic-trackpad.conf"
+sysfs="$test_tmp/sys/hid_magicmouse"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+chmod +x "$stub_bin"/*
+
+add_hid() {
+  local id=$1
+  local dir="$hid_dir/$id"
+  mkdir -p "$dir"
+  printf 'HID_ID=%s\nHID_NAME=fixture\n' "$id" >"$dir/uevent"
+}
+
+run_leaf() {
+  rm -rf "$test_tmp/etc" "$hid_dir"
+  mkdir -p "$test_tmp/etc" "$hid_dir"
+  for id in "$@"; do
+    add_hid "$id"
+  done
+
+  TEST_LOG="$calls" PATH="$stub_bin:$ROOT/bin:$PATH" \
+    OMARCHY_HID_DEVICES_DIR="$hid_dir" \
+    OMARCHY_MAGIC_TRACKPAD_QUIRKS="$quirks" \
+    OMARCHY_HID_MAGICMOUSE_CONF="$modprobe_conf" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$leaf"
+}
+
+run_leaf "0003:000005AC:00000265"
+[[ -f $quirks ]] || fail "a Magic Trackpad install writes libinput quirks"
+grep -q 'AttrTouchSizeRange=40:20' "$quirks" ||
+  fail "libinput quirks re-enable size-based thumb filtering"
+grep -q 'emulate_scroll_wheel=0' "$modprobe_conf" ||
+  fail "a Magic Trackpad install disables hid-magicmouse scroll emulation"
+grep -q 'emulate_3button=0' "$modprobe_conf" ||
+  fail "a Magic Trackpad install disables hid-magicmouse 3-button emulation"
+pass "a Magic Trackpad install writes quirks and kernel options"
+
+run_leaf
+[[ -f $quirks ]] || fail "libinput quirks are installed even without the pad present"
+[[ ! -f $modprobe_conf ]] || fail "kernel options wait until a Magic Trackpad is present"
+pass "kernel options are skipped when no Magic Trackpad is connected"
+
+run_leaf "0003:000005AC:00000265" "0005:0000004C:00000269"
+[[ -f $quirks ]] || fail "quirks still install next to a Magic Mouse"
+[[ ! -f $modprobe_conf ]] ||
+  fail "kernel options are skipped when a Magic Mouse is present" "$(cat "$modprobe_conf")"
+pass "a Magic Mouse keeps kernel surface-scroll emulation"
+
+run_leaf "0005:0000004C:00000324"
+grep -q 'emulate_scroll_wheel=0' "$modprobe_conf" ||
+  fail "a Bluetooth USB-C Magic Trackpad is recognized"
+pass "Bluetooth USB-C Magic Trackpad IDs are recognized"
+
+run_migration() {
+  rm -rf "$test_tmp/etc" "$hid_dir"
+  mkdir -p "$test_tmp/etc" "$hid_dir"
+  : >"$calls"
+  for id in "$@"; do
+    add_hid "$id"
+  done
+
+  TEST_LOG="$calls" PATH="$stub_bin:$ROOT/bin:$PATH" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_HID_DEVICES_DIR="$hid_dir" \
+    OMARCHY_MAGIC_TRACKPAD_QUIRKS="$quirks" \
+    OMARCHY_HID_MAGICMOUSE_CONF="$modprobe_conf" \
+    OMARCHY_HID_MAGICMOUSE_SYSFS="$sysfs" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -rf "$sysfs"
+run_migration "0003:000005AC:00000265"
+[[ -f $quirks ]] || fail "the migration writes libinput quirks"
+grep -q 'emulate_scroll_wheel=0' "$modprobe_conf" ||
+  fail "the migration writes hid-magicmouse options"
+[[ ! -e $sysfs/emulate_scroll_wheel ]] ||
+  fail "the migration does not invent sysfs nodes"
+pass "the migration installs Magic Trackpad config without a loaded module"
+
+mkdir -p "$sysfs"
+printf 'Y\n' >"$sysfs/emulate_scroll_wheel"
+printf 'Y\n' >"$sysfs/emulate_3button"
+printf 'Y\n' >"$sysfs/scroll_acceleration"
+run_migration "0003:000005AC:00000265"
+[[ $(<"$sysfs/emulate_scroll_wheel") == N ]] ||
+  fail "the migration applies kernel options to a loaded module" "$(cat "$sysfs/emulate_scroll_wheel")"
+[[ $(<"$sysfs/emulate_3button") == N ]] ||
+  fail "the migration turns off 3-button emulation live"
+pass "the migration applies hid-magicmouse options without a reboot"
+
+printf 'Y\n' >"$sysfs/emulate_scroll_wheel"
+printf 'Y\n' >"$sysfs/emulate_3button"
+printf 'Y\n' >"$sysfs/scroll_acceleration"
+run_migration "0003:000005AC:0000030D"
+[[ -f $quirks ]] || fail "the migration still writes quirks on a Magic Mouse machine"
+[[ ! -f $modprobe_conf ]] || fail "the migration leaves Magic Mouse kernel options alone"
+[[ $(<"$sysfs/emulate_scroll_wheel") == Y ]] ||
+  fail "the migration does not rewrite Magic Mouse sysfs"
+pass "the migration leaves Magic Mouse kernel emulation alone"


### PR DESCRIPTION
On Linux, a Magic Trackpad treats a light resting thumb as a second finger. That becomes two-finger scroll or a right-click, and small pointer moves feel jumpy compared with macOS.

Two layers cause it:

- `hid-magicmouse` kernel two-finger scroll and 3-button emulation fire as soon as a second contact exists, before libinput can classify it as a thumb.
- Stock libinput `50-system-apple.quirks` sets `AttrTouchSizeRange=20:10` on these pads, which turns size-based palm/thumb filtering off.

This change:

- Installs `/etc/libinput/omarchy-magic-trackpad.quirks` so a light edge rest is ignored. Harmless on machines without the pad (match is by device name).
- Writes `/etc/modprobe.d/omarchy-magic-trackpad.conf` (`emulate_scroll_wheel=0`, `emulate_3button=0`) when a Magic Trackpad is present, so libinput owns two-finger scroll and click. Two-finger right-click still works through `clickfinger_behavior`.
- Skips those kernel options when an Apple Magic Mouse is also connected. That mouse still needs kernel surface-scroll emulation (same module).
- Pins Hyprland adaptive accel and sensitivity `0` on the common Magic Trackpad device names, so raising the global pointer speed does not make this large pad jumpy.
- Migrates existing installs and applies the kernel params live via sysfs when the module is loaded, so a reboot is not required for that half.

Tested on a USB Magic Trackpad 2 (05AC:0265) on Omarchy 4.0.1. Resting-thumb scroll/right-click stopped, and fine text selection became usable.

`test/shell.d/magic-trackpad-test.sh` covers install and migration for trackpad-only, mouse-present, no-device, and Bluetooth USB-C IDs.