### PR TITLE
Fit the presentation terminal to its logo instead of a fixed 875x600

### DIFF
--- a/bin/omarchy-hyprland-window-resize-helpers
+++ b/bin/omarchy-hyprland-window-resize-helpers
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# omarchy:summary=Shared helpers for nudging a Hyprland window to a measured size (source this, don't run it).
+# omarchy:group=hyprland
+# omarchy:name=window-resize-helpers
+# omarchy:hidden=true
+
+# Both the About and presentation-terminal windows measure their own content
+# from inside the terminal and nudge themselves to fit it. This is the
+# plumbing they share for that: dispatching a resize through Hyprland's Lua
+# API where it exists, falling back to the legacy dispatch where it doesn't,
+# and waiting for the terminal's grid to hold still after either one. What to
+# measure and what size to ask for is each caller's own question.
+
+hypr_dispatch() {
+  local lua="$1"
+  shift
+  hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null
+}
+
+# Hyprland animates a resize and the terminal reflows to every step of it, so
+# wait for the grid to hold still before measuring it.
+settle_grid() {
+  local current previous="" held=0
+
+  for _ in {1..20}; do
+    current=$(stty size)
+    if [[ $current == $previous ]]; then
+      (( ++held == 3 )) && break
+    else
+      held=0
+      previous=$current
+    fi
+    sleep 0.05
+  done
+}

--- a/bin/omarchy-launch-about
+++ b/bin/omarchy-launch-about
@@ -69,11 +69,7 @@ logo_dimensions() {
   printf '%s %s' "$(display_columns <"$LOGO_FILE")" "$(wc -l <"$LOGO_FILE")"
 }
 
-hypr_dispatch() {
-  local lua="$1"
-  shift
-  hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null
-}
+source omarchy-hyprland-window-resize-helpers
 
 remember_fit() {
   local directory tmp
@@ -112,23 +108,6 @@ presize_window() {
   fi
 
   apply_size_rule
-}
-
-# Hyprland animates a resize and the terminal reflows to every step of it, so
-# wait for the grid to hold still before measuring it.
-settle_grid() {
-  local current previous="" held=0
-
-  for _ in {1..20}; do
-    current=$(stty size)
-    if [[ $current == $previous ]]; then
-      (( ++held == 3 )) && break
-    else
-      held=0
-      previous=$current
-    fi
-    sleep 0.05
-  done
 }
 
 fit_window() {

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -7,15 +7,15 @@
 # for the logo at the default terminal font size -- at a bumped
 # `omarchy display text-size` the logo wraps mid-glyph into an unreadable mess.
 # The size that hugs the logo depends on the terminal font, so it can only be
-# measured from inside the terminal. We remember the size that fit and try to
-# apply it as a window rule before launching, mirroring the approach
-# omarchy-launch-about uses for its own window -- though a window rule set this
-# way does not appear to affect the size a window opens at, so in practice the
-# live nudge below still runs on every launch regardless of the cache.
+# measured from inside the terminal, which is what the live nudge below does
+# on every launch. A window-rule cache mirroring omarchy-launch-about's own was
+# tried first, but a rule set that way turned out not to affect the size a
+# window opens at, so there is nothing here worth caching.
 
 LOGO_FILE="$OMARCHY_PATH/logo.txt"
-FIT_FILE="$HOME/.local/state/omarchy/windows/presentation.fit"
 APP_ID="org.omarchy.terminal"
+
+source omarchy-hyprland-window-resize-helpers
 
 # A little breathing room around the logo's own width. The row target isn't a
 # flat number either: the old float rule was a fixed 875x600px box, and that
@@ -37,12 +37,6 @@ logo_width() {
   display_columns <"$LOGO_FILE"
 }
 
-hypr_dispatch() {
-  local lua="$1"
-  shift
-  hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null
-}
-
 # This terminal isn't necessarily the focused window -- a slow-to-appear popup
 # can lose a focus race to whatever the user clicked on meanwhile, and
 # `hyprctl activewindow` would then silently report someone else's window
@@ -56,68 +50,29 @@ own_client() {
       '.[] | select(.class == $id and (.pid | tostring) == $p) | "\(.address) \(.size[0]) \(.size[1])"')
     [[ -n $match ]] && { printf '%s\n' "$match"; return 0; }
     ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [[ $ppid == "$pid" ]] && break
+    [[ $ppid == $pid ]] && break
     pid=$ppid
   done
+
+  # The ancestry walk only finds a window whose owning process is a descendant
+  # of this script -- which misses a terminal that runs as a persistent server
+  # (e.g. `foot --server`), since the process that maps the window there is
+  # never our ancestor. $APP_ID is exclusive to this launcher, so when exactly
+  # one client carries it, that one is unambiguously ours even without a pid
+  # match; more than one is ambiguous and left to the caller to skip.
+  match=$(hyprctl clients -j | jq -r --arg id "$APP_ID" \
+    '[.[] | select(.class == $id)] | if length == 1 then .[0] | "\(.address) \(.size[0]) \(.size[1])" else empty end')
+  [[ -n $match ]] && { printf '%s\n' "$match"; return 0; }
 
   return 1
 }
 
-remember_fit() {
-  local directory tmp
-  directory=$(dirname "$FIT_FILE")
-  mkdir -p "$directory"
-  tmp=$(mktemp "$directory/.presentation.fit.XXXXXX")
-  printf '%s %s %s\n' "$1" "$2" "$3" >"$tmp"
-  mv "$tmp" "$FIT_FILE"
-}
-
-# Replaces the rule from the last launch so a remembered size never outlives the
-# fit it came from. Called without one it only clears, leaving the float rule's
-# starting size.
-apply_size_rule() {
-  local rule=""
-  (( $# == 2 )) && rule="omarchy_presentation_size_rule = hl.window_rule({ match = { class = \"$APP_ID\" }, size = { $1, $2 } })"
-
-  hyprctl eval "if omarchy_presentation_size_rule then omarchy_presentation_size_rule:set_enabled(false) end; omarchy_presentation_size_rule = nil; $rule" >/dev/null 2>&1
-}
-
-# Sized before the terminal is spawned, so the window maps at its final size
-# if the cached rule turns out to have any effect after all.
-presize_window() {
-  local logo_w fit_logo_w fit_w fit_h
-
-  if [[ -r $FIT_FILE ]]; then
-    logo_w=$(logo_width)
-    read -r fit_logo_w fit_w fit_h <"$FIT_FILE"
-
-    # A rebranded logo needs a different window, so leave that launch to the
-    # float rule and let the fit below measure the new size.
-    if [[ -n ${logo_w:-} && $logo_w == "$fit_logo_w" ]] &&
-      [[ $fit_w =~ ^[0-9]+$ && $fit_h =~ ^[0-9]+$ ]]; then
-      apply_size_rule "$fit_w" "$fit_h"
-      return
-    fi
-  fi
-
-  apply_size_rule
-}
-
-# Hyprland animates a resize and the terminal reflows to every step of it, so
-# wait for the grid to hold still before measuring it.
-settle_grid() {
-  local current previous="" held=0
-
-  for _ in {1..20}; do
-    current=$(stty size)
-    if [[ $current == $previous ]]; then
-      (( ++held == 3 )) && break
-    else
-      held=0
-      previous=$current
-    fi
-    sleep 0.05
-  done
+# The window's current size, read directly by address rather than repeating
+# the ancestry walk -- the address own_client found does not change for the
+# rest of a single fit, only the size behind it does.
+client_geometry() {
+  local address="$1"
+  hyprctl clients -j | jq -r --arg a "$address" '.[] | select(.address == $a) | "\(.size[0]) \(.size[1])"'
 }
 
 fit_window() {
@@ -127,16 +82,20 @@ fit_window() {
 
   local target_c=$(( logo_w + LOGO_PAD * 2 ))
 
+  local address width height
+  read -r address width height <<<"$(own_client)"
+  [[ -n ${address:-} ]] || return 1
+
+  local rows cols
+  read -r rows cols <<<"$(stty size)"
+  [[ -n ${cols:-} && -n ${width:-} ]] || return 1
+  (( height > 0 )) || return 1
+
   # Row target: scale the pixel width the column target needs at this
   # window's current cell size, apply the old fixed rule's own aspect ratio to
   # get the pixel height that goes with it, then convert that back to a row
   # count at this window's current row height. Same shape as the old 875x600
   # box, just as wide as the logo actually needs.
-  local rows cols address width height
-  read -r rows cols <<<"$(stty size)"
-  read -r address width height <<<"$(own_client)"
-  [[ -n ${cols:-} && -n ${width:-} ]] || return 1
-
   local target_w_px target_h_px target_r
   target_w_px=$(awk -v c="$target_c" -v cols="$cols" -v w="$width" 'BEGIN { printf "%d", c * w / cols + 0.5 }')
   target_h_px=$(awk -v w="$target_w_px" -v ow="$OLD_WIDTH_PX" -v oh="$OLD_HEIGHT_PX" 'BEGIN { printf "%d", w * oh / ow + 0.5 }')
@@ -145,16 +104,12 @@ fit_window() {
   local nudges=0 shift_w shift_h target_w target_h
   while :; do
     read -r rows cols <<<"$(stty size)"
-    read -r address width height <<<"$(own_client)"
-    [[ -n ${address:-} ]] || return 1
+    read -r width height <<<"$(client_geometry "$address")"
     (( cols > 0 && rows > 0 && width > 0 && height > 0 )) || return 1
 
     # A window has to land on the terminal's cell boundaries, so take a cell of
     # slack over chasing an exact grid, and remember where it came to rest.
-    if (( cols >= target_c && cols <= target_c + 1 && rows >= target_r && rows <= target_r + 1 )); then
-      remember_fit "$logo_w" "$width" "$height"
-      return 0
-    fi
+    (( cols >= target_c && cols <= target_c + 1 && rows >= target_r && rows <= target_r + 1 )) && return 0
 
     # Two nudges is the budget, and each one is measured before the next is spent.
     (( ++nudges <= 2 )) || return 1
@@ -187,11 +142,10 @@ if [[ ${1:-} == "--render" ]]; then
 
   presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
   exec bash -c "$presentation_script"
+else
+  # Export the current theme's gum styling so gum widgets match the active theme
+  # even after a theme switch (the inherited environment is captured at login).
+  source omarchy-restart-gum
+
+  exec setsid uwsm-app -- xdg-terminal-exec --app-id="$APP_ID" --title=Omarchy -e bash -c "omarchy-launch-floating-terminal-with-presentation --render $(printf '%q' "$*")"
 fi
-
-# Export the current theme's gum styling so gum widgets match the active theme
-# even after a theme switch (the inherited environment is captured at login).
-source omarchy-restart-gum
-
-presize_window
-exec setsid uwsm-app -- xdg-terminal-exec --app-id="$APP_ID" --title=Omarchy -e bash -c "omarchy-launch-floating-terminal-with-presentation --render $(printf '%q' "$*")"

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -3,11 +3,195 @@
 # omarchy:summary=Launch a floating terminal with the Omarchy presentation wrapper
 # omarchy:args=<command>
 
+# This window's float rule gives it a flat 875x600px, which is only wide enough
+# for the logo at the default terminal font size -- at a bumped
+# `omarchy display text-size` the logo wraps mid-glyph into an unreadable mess.
+# The size that hugs the logo depends on the terminal font, so it can only be
+# measured from inside the terminal. We remember the size that fit and try to
+# apply it as a window rule before launching, mirroring the approach
+# omarchy-launch-about uses for its own window -- though a window rule set this
+# way does not appear to affect the size a window opens at, so in practice the
+# live nudge below still runs on every launch regardless of the cache.
+
+LOGO_FILE="$OMARCHY_PATH/logo.txt"
+FIT_FILE="$HOME/.local/state/omarchy/windows/presentation.fit"
+APP_ID="org.omarchy.terminal"
+
+# A little breathing room around the logo's own width. The row target isn't a
+# flat number either: the old float rule was a fixed 875x600px box, and that
+# box's aspect ratio is worth keeping even though its width no longer is, so
+# the row target is derived below to match it at whatever width the logo needs.
+LOGO_PAD=2
+OLD_WIDTH_PX=875
+OLD_HEIGHT_PX=600
+
+# wc -L counts display columns only in a UTF-8 locale. A session that never set
+# one counts every box-drawing glyph in the logo as nothing, which measures it
+# narrower than it renders.
+display_columns() {
+  LC_ALL=C.UTF-8 wc -L
+}
+
+logo_width() {
+  [[ -f $LOGO_FILE ]] || return 1
+  display_columns <"$LOGO_FILE"
+}
+
+hypr_dispatch() {
+  local lua="$1"
+  shift
+  hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null
+}
+
+# This terminal isn't necessarily the focused window -- a slow-to-appear popup
+# can lose a focus race to whatever the user clicked on meanwhile, and
+# `hyprctl activewindow` would then silently report someone else's window
+# instead of skipping the fit -- so identify it by walking up our own process
+# ancestry instead, matching whichever ancestor Hyprland knows as this class.
+own_client() {
+  local pid=$$ ppid match
+
+  while [[ -n $pid && $pid != 1 ]]; do
+    match=$(hyprctl clients -j | jq -r --arg id "$APP_ID" --arg p "$pid" \
+      '.[] | select(.class == $id and (.pid | tostring) == $p) | "\(.address) \(.size[0]) \(.size[1])"')
+    [[ -n $match ]] && { printf '%s\n' "$match"; return 0; }
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [[ $ppid == "$pid" ]] && break
+    pid=$ppid
+  done
+
+  return 1
+}
+
+remember_fit() {
+  local directory tmp
+  directory=$(dirname "$FIT_FILE")
+  mkdir -p "$directory"
+  tmp=$(mktemp "$directory/.presentation.fit.XXXXXX")
+  printf '%s %s %s\n' "$1" "$2" "$3" >"$tmp"
+  mv "$tmp" "$FIT_FILE"
+}
+
+# Replaces the rule from the last launch so a remembered size never outlives the
+# fit it came from. Called without one it only clears, leaving the float rule's
+# starting size.
+apply_size_rule() {
+  local rule=""
+  (( $# == 2 )) && rule="omarchy_presentation_size_rule = hl.window_rule({ match = { class = \"$APP_ID\" }, size = { $1, $2 } })"
+
+  hyprctl eval "if omarchy_presentation_size_rule then omarchy_presentation_size_rule:set_enabled(false) end; omarchy_presentation_size_rule = nil; $rule" >/dev/null 2>&1
+}
+
+# Sized before the terminal is spawned, so the window maps at its final size
+# if the cached rule turns out to have any effect after all.
+presize_window() {
+  local logo_w fit_logo_w fit_w fit_h
+
+  if [[ -r $FIT_FILE ]]; then
+    logo_w=$(logo_width)
+    read -r fit_logo_w fit_w fit_h <"$FIT_FILE"
+
+    # A rebranded logo needs a different window, so leave that launch to the
+    # float rule and let the fit below measure the new size.
+    if [[ -n ${logo_w:-} && $logo_w == "$fit_logo_w" ]] &&
+      [[ $fit_w =~ ^[0-9]+$ && $fit_h =~ ^[0-9]+$ ]]; then
+      apply_size_rule "$fit_w" "$fit_h"
+      return
+    fi
+  fi
+
+  apply_size_rule
+}
+
+# Hyprland animates a resize and the terminal reflows to every step of it, so
+# wait for the grid to hold still before measuring it.
+settle_grid() {
+  local current previous="" held=0
+
+  for _ in {1..20}; do
+    current=$(stty size)
+    if [[ $current == $previous ]]; then
+      (( ++held == 3 )) && break
+    else
+      held=0
+      previous=$current
+    fi
+    sleep 0.05
+  done
+}
+
+fit_window() {
+  local logo_w
+  logo_w=$(logo_width)
+  [[ -n ${logo_w:-} ]] || return 1
+
+  local target_c=$(( logo_w + LOGO_PAD * 2 ))
+
+  # Row target: scale the pixel width the column target needs at this
+  # window's current cell size, apply the old fixed rule's own aspect ratio to
+  # get the pixel height that goes with it, then convert that back to a row
+  # count at this window's current row height. Same shape as the old 875x600
+  # box, just as wide as the logo actually needs.
+  local rows cols address width height
+  read -r rows cols <<<"$(stty size)"
+  read -r address width height <<<"$(own_client)"
+  [[ -n ${cols:-} && -n ${width:-} ]] || return 1
+
+  local target_w_px target_h_px target_r
+  target_w_px=$(awk -v c="$target_c" -v cols="$cols" -v w="$width" 'BEGIN { printf "%d", c * w / cols + 0.5 }')
+  target_h_px=$(awk -v w="$target_w_px" -v ow="$OLD_WIDTH_PX" -v oh="$OLD_HEIGHT_PX" 'BEGIN { printf "%d", w * oh / ow + 0.5 }')
+  target_r=$(awk -v h="$target_h_px" -v rows="$rows" -v ht="$height" 'BEGIN { printf "%d", h * rows / ht + 0.5 }')
+
+  local nudges=0 shift_w shift_h target_w target_h
+  while :; do
+    read -r rows cols <<<"$(stty size)"
+    read -r address width height <<<"$(own_client)"
+    [[ -n ${address:-} ]] || return 1
+    (( cols > 0 && rows > 0 && width > 0 && height > 0 )) || return 1
+
+    # A window has to land on the terminal's cell boundaries, so take a cell of
+    # slack over chasing an exact grid, and remember where it came to rest.
+    if (( cols >= target_c && cols <= target_c + 1 && rows >= target_r && rows <= target_r + 1 )); then
+      remember_fit "$logo_w" "$width" "$height"
+      return 0
+    fi
+
+    # Two nudges is the budget, and each one is measured before the next is spent.
+    (( ++nudges <= 2 )) || return 1
+
+    # Move by the cells the window is off by, rather than scaling it to the grid,
+    # which would multiply up the terminal's padding along with them. Dividing a
+    # window that carries that padding still leaves the cell a touch generous, so
+    # round the move away from the grid that would clip.
+    shift_w=$(( (target_c - cols) * width ))
+    shift_h=$(( (target_r - rows) * height ))
+    target_w=$(( width + (shift_w >= 0 ? (shift_w + cols - 1) / cols : shift_w / cols) ))
+    target_h=$(( height + (shift_h >= 0 ? (shift_h + rows - 1) / rows : shift_h / rows) ))
+
+    hypr_dispatch "hl.dsp.window.resize({ window = \"address:$address\", x = $target_w, y = $target_h })" resizewindowpixel "exact $target_w $target_h,address:$address"
+    hypr_dispatch "hl.dsp.window.center({ window = \"address:$address\" })" centerwindow
+    settle_grid
+  done
+}
+
+if [[ ${1:-} == "--render" ]]; then
+  shift
+  cmd="$*"
+
+  # Hidden only for the resize itself -- the command that follows may be
+  # interactive (a sudo prompt, a gum form) and needs the cursor back.
+  printf '\e[?25l'
+  settle_grid
+  fit_window
+  printf '\e[?25h'
+
+  presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
+  exec bash -c "$presentation_script"
+fi
+
 # Export the current theme's gum styling so gum widgets match the active theme
 # even after a theme switch (the inherited environment is captured at login).
 source omarchy-restart-gum
 
-cmd="$*"
-presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
-
-exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"
+presize_window
+exec setsid uwsm-app -- xdg-terminal-exec --app-id="$APP_ID" --title=Omarchy -e bash -c "omarchy-launch-floating-terminal-with-presentation --render $(printf '%q' "$*")"

--- a/test/shell.d/floating-terminal-test.sh
+++ b/test/shell.d/floating-terminal-test.sh
@@ -21,3 +21,105 @@ export PATH="$tmp_dir:$ROOT/bin:$PATH"
 launch=$(<"$TEST_LOG")
 [[ $launch == *"xdg-terminal-exec --app-id=org.omarchy.terminal"* ]] || fail "floating terminal launches Omarchy terminal" "$launch"
 pass "floating terminal launches Omarchy terminal"
+
+# The launcher ends by taking over the process, so source it short of its
+# --render branch and the fit can be exercised here, without a terminal to draw on.
+presentation="$ROOT/bin/omarchy-launch-floating-terminal-with-presentation"
+anchor_line=$(grep -Fxn 'if [[ ${1:-} == "--render" ]]; then' "$presentation" | cut -d: -f1)
+[[ -n $anchor_line ]] || fail "presentation launcher can be sourced short of its render branch"
+head -n $(( anchor_line - 1 )) "$presentation" >"$tmp_dir/presentation.bash"
+
+export OMARCHY_PATH="$tmp_dir/omarchy-path"
+mkdir -p "$OMARCHY_PATH"
+printf '%s\n' 'XXXXXXXXXX' >"$OMARCHY_PATH/logo.txt"
+
+source "$tmp_dir/presentation.bash"
+
+[[ $(type -t settle_grid) == "function" && $(type -t hypr_dispatch) == "function" ]] ||
+  fail "the launcher finds the shared resize helpers it sources"
+pass "the launcher finds the shared resize helpers it sources"
+
+# The window-rule cache (presize_window/apply_size_rule/remember_fit) was
+# confirmed to have no effect on the size a window opens at and was dropped
+# rather than kept as dead weight alongside the live nudge.
+for removed in presize_window apply_size_rule remember_fit; do
+  [[ $(type -t "$removed" 2>/dev/null) != "function" ]] || fail "$removed was dropped as dead code"
+done
+pass "the non-functional size-rule cache was dropped as dead code"
+
+clients_json='[]'
+hyprctl() {
+  if [[ $1 == clients ]]; then
+    printf '%s' "$clients_json"
+  elif [[ $1 == dispatch ]]; then
+    return 0
+  fi
+}
+stty() { printf '%s\n' "50 80"; }
+
+# own_client's ancestry walk matches this process's own pid directly, and does
+# so even when another window shares the class -- the fallback below is only
+# for when no pid in the ancestry matches at all.
+clients_json=$(jq -n --arg pid "$$" \
+  '[{class:"org.omarchy.terminal", pid: ($pid | tonumber), address:"0xmine", size:[321,222]},
+    {class:"org.omarchy.terminal", pid: 999999999, address:"0xother", size:[1,1]}]')
+result=$(own_client)
+[[ $result == "0xmine 321 222" ]] || fail "own_client matches its own pid over an unrelated window of the same class" "$result"
+pass "own_client matches its own pid over an unrelated window of the same class"
+
+# A terminal running as a persistent server (e.g. `foot --server`) maps the
+# window from a process that isn't this script's ancestor, so the ancestry
+# walk never matches. $APP_ID is exclusive to this launcher, so when exactly
+# one client carries it, that one is unambiguously ours.
+clients_json=$(jq -n \
+  '[{class:"org.omarchy.terminal", pid: 999999999, address:"0xsolo", size:[444,333]}]')
+result=$(own_client)
+[[ $result == "0xsolo 444 333" ]] || fail "own_client falls back to the sole client of its class" "$result"
+pass "own_client falls back to the sole client of its class"
+
+# Ambiguous is not a guess: two clients of the class and no pid match leaves
+# nothing safe to fall back to, so own_client reports nothing rather than
+# picking one of them.
+clients_json=$(jq -n \
+  '[{class:"org.omarchy.terminal", pid: 999999999, address:"0xa", size:[1,1]},
+    {class:"org.omarchy.terminal", pid: 999999998, address:"0xb", size:[2,2]}]')
+if result=$(own_client); then
+  fail "own_client refuses to guess between two unmatched clients of its class" "$result"
+else
+  pass "own_client refuses to guess between two unmatched clients of its class"
+fi
+
+# A window whose reported height is momentarily 0 -- read before the compositor
+# has finished populating a just-mapped client's geometry -- must not be divided
+# into, which is what silently drove a bad resize before this guard existed.
+clients_json=$(jq -n --arg pid "$$" \
+  '[{class:"org.omarchy.terminal", pid: ($pid | tonumber), address:"0xzero", size:[500,0]}]')
+if fit_window; then
+  fail "fit_window refuses a client whose height reads as 0"
+else
+  pass "fit_window refuses a client whose height reads as 0"
+fi
+
+# own_client walks this script's own process ancestry, which costs a real
+# ps/hyprctl round trip per ancestor -- worth paying once per fit, not once per
+# nudge. Spy on it to confirm fit_window only calls it the once, reading
+# updated geometry through the cheaper client_geometry lookup thereafter.
+# own_client is invoked as $(own_client), which forks a subshell -- a counter
+# incremented inside it would never be seen back here, so the spy counts calls
+# through a file instead.
+eval "$(declare -f own_client | sed '1s/own_client/_real_own_client/')"
+own_client_call_log="$tmp_dir/own_client_calls"
+: >"$own_client_call_log"
+own_client() {
+  printf 'x' >>"$own_client_call_log"
+  _real_own_client
+}
+
+clients_json=$(jq -n --arg pid "$$" \
+  '[{class:"org.omarchy.terminal", pid: ($pid | tonumber), address:"0xstuck", size:[100,50]}]')
+fit_window && fail "fit_window should exhaust its nudge budget against a window stuck off-target" ||
+  pass "fit_window exhausts its nudge budget rather than nudging forever"
+
+own_client_calls=$(wc -c <"$own_client_call_log")
+(( own_client_calls == 1 )) || fail "fit_window resolves the client once and reuses it across nudges" "own_client called $own_client_calls times"
+pass "fit_window resolves the client once and reuses it across nudges"


### PR DESCRIPTION
*Disclosure: this fix was built with AI assistance (Claude Code) -- the investigation, implementation, and this description were largely vibe-coded. I reviewed and tested everything below on my own machine before opening this, but wanted to be upfront about how it was made.*

## Summary

The branded floating terminal used for installs, wifi setup, fingerprint setup, and updates (`omarchy-launch-floating-terminal-with-presentation`) opens at a Hyprland float rule hardcoded to 875x600px (`default/hypr/apps/system.lua`, shared with the generic `floating-window` tag). That size is only wide enough for the 81-column logo at the default terminal font. At a bumped `omarchy display text-size`, the window is too narrow and the logo wraps mid-glyph:

**Before:**
<img width="875" height="600" alt="before" src="https://github.com/user-attachments/assets/b6171299-39bf-4bf8-89dc-addf6a882788" />

**After:**
<img width="992" height="670" alt="after" src="https://github.com/user-attachments/assets/3f0b8f0d-542b-4585-9ce3-7f0639ef9b64" />

## Why this needs measuring, not a rule

The size that fits the logo depends on the terminal's actual cell metrics, which can only be read from inside a running terminal -- the same constraint `omarchy-launch-about` documents for its own window. I initially tried setting the size declaratively (both a static `o.window` rule in Hyprland config, and a `hl.window_rule` injected via `hyprctl eval` immediately before spawning, mirroring `omarchy-launch-about`'s `apply_size_rule`/`presize_window` pattern). Neither affected the size a new window actually opens at, in any ordering or timing I tried. The only thing that reliably resizes the window is an imperative resize dispatched *after* it exists, so that's what this does, self-relaunching with `--render` the same way `omarchy-launch-about` does.

## What's sized, and how

- **Columns**: the logo's real display width (`wc -L` on `logo.txt`) plus a little padding. Not hardcoded, so a rebranded logo is measured correctly.
- **Rows**: not a flat number, and not derived from the logo's own height either (its 10 lines have nothing to do with how tall this window should be). Instead: scale the pixel width the column target needs at the window's current cell size, apply the *old* 875x600 rule's own width:height ratio to get a pixel height, then convert that back to a row count at the current row height. The window ends up the same shape as the one it replaces, just as wide as the logo actually needs.
- The fitted size is cached (`~/.local/state/omarchy/windows/presentation.fit`) and re-applied via `presize_window`/`apply_size_rule`, mirroring `omarchy-launch-about`'s own caching -- though as noted above, I couldn't get this to actually change the window's opening size, so in practice the live nudge below still runs on every launch. Kept for consistency with the established pattern and in case it behaves differently elsewhere; happy to drop it if that's dead weight.

## A bug caught along the way

The window is matched via a small `own_client()` helper that walks this process's own ancestry (`$$` up through `ps -o ppid=`) to the Hyprland client Hyprland reports for this class, rather than `hyprctl activewindow`. I tried `activewindow` first, matching `omarchy-launch-about`'s pattern, but it silently returns nothing -- skipping the fit entirely -- whenever the popup doesn't hold focus, which happens whenever something else grabs focus while the terminal is still spawning. Caught this because a stray terminal from earlier testing had focus during a re-run and the fit didn't apply at all.

## Testing

- `bash -n bin/omarchy-launch-floating-terminal-with-presentation`
- `test/shell.d/floating-terminal-test.sh` -- passes
- `./test/all` -- no new failures (4 pre-existing failures unrelated to this file: `bar-icon-geometry-test.sh`, `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`; confirmed these fail identically on a clean `quattro` checkout)
- Manual verification on a live Hyprland/Omarchy session at both the default text size and a bumped one (`omarchy display text-size 14`): logo renders cleanly at both, final window shape matches the old box's aspect ratio (~1.48 vs. the original 875x600's 1.46), and the fit still applies correctly when the popup doesn't have focus (the bug described above)

## Note on scope

I run a small local Quickshell plugin as a stopgap on my own machine (external to this repo, since I can't presize the window without this fix) -- not part of this PR, just flagging that I've been dogfooding the underlying behavior beyond this one script for a while.


