### PR TITLE
Clear unowned running-kernel modules leftovers during update

### DIFF
--- a/bin/omarchy-update-system-pkgs-when-conflicted
+++ b/bin/omarchy-update-system-pkgs-when-conflicted
@@ -81,6 +81,43 @@ if grep -q 'unresolvable package conflicts detected' "$errors"; then
   exit 0
 fi
 
+# kernel-modules-hook restores the *running* kernel's module tree as unowned
+# files after a linux downgrade (release migration, channel switch). Pacman's
+# conflict check runs before PreTransaction hooks, so 10-linux-modules-pre never
+# clears them, and linux-modules-cleanup.service skips the running kver — every
+# omarchy update then fails with thousands of "exists in filesystem" lines until
+# reboot. When every reported conflict is an unowned path under that tree,
+# quarantine the whole tree once and retry.
+running_kver=${OMARCHY_RUNNING_KVER:-$(uname -r)}
+modules_root=${OMARCHY_MODULES_ROOT:-/usr/lib/modules}
+running_modules="$modules_root/$running_kver"
+filesystem_conflicts=$(grep -c ' exists in filesystem' "$errors" || true)
+
+mapfile -t module_leftovers < <(
+  grep -oP '^[a-z0-9@._+-]+: \K.+(?= exists in filesystem$)' "$errors" |
+    while IFS= read -r path; do
+      [[ $path == "$running_modules" || $path == "$running_modules"/* ]] || continue
+      pacman -Qo "$path" &>/dev/null || echo "$path"
+    done
+)
+
+if ((${#module_leftovers[@]} > 0)) &&
+  ((${#module_leftovers[@]} == filesystem_conflicts)) &&
+  [[ -e $running_modules || -L $running_modules ]]; then
+  echo -e "\e[33m\nClearing unowned modules for the running kernel (left by kernel-modules-hook after a downgrade):\e[0m"
+  sudo mkdir -p "$replaced${running_modules%/*}"
+  sudo mv -T --backup=numbered "$running_modules" "$replaced$running_modules"
+  moved+=("$running_modules")
+  echo "  $running_modules -> $replaced$running_modules"
+  echo
+
+  if OMARCHY_UPDATE_RETRY=1 omarchy-update-system-pkgs; then
+    moved=()
+    exit 0
+  fi
+  exit 1
+fi
+
 # Paths one of these packages installs that pacman doesn't own. Moving them out
 # of the way is what lets the upgrade through, and works on a leftover directory
 # as well as a file.
@@ -96,7 +133,7 @@ mapfile -t leftovers < <(
 
 # All of them or none: moving a subset leaves the retry blocked by the rest, and
 # the moved files inactive for nothing.
-((${#leftovers[@]} == $(grep -c ' exists in filesystem' "$errors"))) || exit 1
+((${#leftovers[@]} == filesystem_conflicts)) || exit 1
 
 echo -e "\e[33m\nTaking over files pacman doesn't own yet:\e[0m"
 for path in "${leftovers[@]}"; do

--- a/test/shell.d/update-file-conflict-test.sh
+++ b/test/shell.d/update-file-conflict-test.sh
@@ -46,6 +46,8 @@ replaced="$test_tmp/replaced"
 
 run_update() {
   OMARCHY_REPLACED_DIR="$replaced" \
+    OMARCHY_RUNNING_KVER="${OMARCHY_RUNNING_KVER:-}" \
+    OMARCHY_MODULES_ROOT="${OMARCHY_MODULES_ROOT:-}" \
     RETRY_FAILS="${RETRY_FAILS:-}" \
     RETRY_INSTALLS="${RETRY_INSTALLS:-}" \
     PACMAN_ATTEMPTS="$test_tmp/attempts" \
@@ -264,6 +266,61 @@ fi
 [[ -f $stray ]] ||
   fail "the handler moved a live file when run outside an update"
 pass "the handler refuses a report handed to it outside an update"
+
+# kernel-modules-hook leftovers: unowned files under the running kver's modules
+# tree, blamed on linux. Moving the whole tree once unblocks the upgrade.
+fresh_work
+kver="7.1.9-arch1-2"
+modules_root="$work/lib/modules"
+modules="$modules_root/$kver"
+mkdir -p "$modules/kernel"
+echo "unowned-mod" >"$modules/kernel/mod.ko"
+echo "dep" >"$modules/modules.dep"
+write_raw_report \
+  "linux: $modules/kernel/mod.ko exists in filesystem" \
+  "linux: $modules/modules.dep exists in filesystem"
+if ! OMARCHY_RUNNING_KVER="$kver" OMARCHY_MODULES_ROOT="$modules_root" \
+  run_update >"$test_tmp/out" 2>"$test_tmp/err"; then
+  fail "unowned running-kernel modules leftovers are not cleared" "$(cat "$test_tmp/err"; cat "$test_tmp/out")"
+fi
+[[ ! -e $modules ]] || fail "the running kernel modules tree is left in pacman's way"
+[[ -d $replaced$modules ]] || fail "the modules tree was not quarantined whole"
+grep -q "kernel-modules-hook" "$test_tmp/out" "$test_tmp/err" ||
+  fail "the handler does not name kernel-modules-hook leftovers"
+pass "unowned modules for the running kernel are quarantined as one tree"
+
+# A modules conflict mixed with an unrelated one must not move anything.
+fresh_work
+modules_root="$work/lib/modules"
+modules="$modules_root/$kver"
+mkdir -p "$modules"
+echo "mod" >"$modules/x"
+echo "other" >"$stray"
+write_raw_report \
+  "linux: $modules/x exists in filesystem" \
+  "some-package: $stray exists in filesystem"
+if OMARCHY_RUNNING_KVER="$kver" OMARCHY_MODULES_ROOT="$modules_root" \
+  run_update >"$test_tmp/out" 2>"$test_tmp/err"; then
+  fail "a modules leftover beside an unrelated conflict reports success"
+fi
+[[ -e $modules && -e $stray ]] ||
+  fail "a mixed conflict moved files even though the retry would still fail"
+pass "modules leftovers only clear when every reported conflict is under that tree"
+
+# Modules for a different kver than the running one are not auto-cleared: the
+# hook only restores the booted kernel, and wiping another tree is unrelated.
+fresh_work
+modules_root="$work/lib/modules"
+other_modules="$modules_root/6.0.0-other"
+mkdir -p "$other_modules"
+echo "old" >"$other_modules/x"
+write_raw_report "linux: $other_modules/x exists in filesystem"
+if OMARCHY_RUNNING_KVER="$kver" OMARCHY_MODULES_ROOT="$modules_root" \
+  run_update >"$test_tmp/out" 2>"$test_tmp/err"; then
+  fail "modules for a non-running kver are auto-cleared"
+fi
+[[ -e $other_modules ]] || fail "modules for a non-running kver were moved away"
+pass "only the running kernel's modules tree is eligible for auto-clear"
 
 # The happy path must not pay for any of this.
 fresh_work


### PR DESCRIPTION
## Summary

Fixes #9142.

After a kernel **downgrade** (e.g. omarchy-dev → stable release migration) while still booted into the newer kver, `kernel-modules-hook` restores `/usr/lib/modules/$(uname -r)/` as **unowned** files so the live system keeps working. Pacman's file-conflict check runs **before** PreTransaction hooks, so `10-linux-modules-pre` never clears them, and `linux-modules-cleanup.service` skips the running kver. The next `omarchy update` that re-offers that kernel fails with thousands of `exists in filesystem` lines and no recovery.

The existing conflict handler only auto-cleared leftovers blamed on `omarchy` / `omarchy-settings` packages, so `linux:` module conflicts fell through.

## Change

In `omarchy-update-system-pkgs-when-conflicted`, when **every** reported filesystem conflict is an unowned path under `/usr/lib/modules/$(uname -r)`, quarantine that modules tree once (same replace/restore path as other leftovers) and retry the upgrade.

## Test plan

- [x] Reproduced: old `omarchy*` -only parse yields 0 leftovers for `linux: .../modules/...` conflicts (update stays wedged)
- [x] After fix: whole running-kver tree quarantined; retry succeeds
- [x] Mixed / non-running-kver conflicts still refused
- [x] `./test/shell.d/update-file-conflict-test.sh` passes (existing + new cases)

```bash
./test/shell.d/update-file-conflict-test.sh
```
