### PR TITLE
Set kernel.kptr_restrict=1 in the shipped sysctl drop-in

### DIFF
--- a/etc/sysctl.d/99-omarchy-sysctl.conf
+++ b/etc/sysctl.d/99-omarchy-sysctl.conf
@@ -1,6 +1,12 @@
 # Solve common flakiness with SSH (MTU discovery on flaky links).
 net.ipv4.tcp_mtu_probing=1
 
+# Hide kernel pointers from unprivileged readers of /proc (e.g. /proc/kallsyms).
+# Root still sees them. Matches the hardening intent of Arch defaults like
+# kernel.yama.ptrace_scope and kernel.dmesg_restrict without changing desktop
+# behaviour for ordinary users.
+kernel.kptr_restrict=1
+
 # Tune reclaim for swap on zram, which is orders of magnitude faster than the
 # disk swapfile these defaults assume.
 

--- a/migrations/1788139000.sh
+++ b/migrations/1788139000.sh
@@ -1,0 +1,9 @@
+echo "Hide kernel pointers from unprivileged /proc readers"
+
+# Package updates deliver etc/sysctl.d/99-omarchy-sysctl.conf with
+# kernel.kptr_restrict=1, but existing boots keep the prior runtime value until
+# the next reboot unless we load the file now. Apply only our drop-in so an
+# unrelated invalid key elsewhere cannot fail the migration.
+if [[ -r /etc/sysctl.d/99-omarchy-sysctl.conf ]]; then
+  sudo sysctl -p /etc/sysctl.d/99-omarchy-sysctl.conf >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/sysctl-kptr-restrict-test.sh
+++ b/test/shell.d/sysctl-kptr-restrict-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Omarchy ships hardening-adjacent sysctls in etc/sysctl.d/. kptr_restrict=1
+# must stay present so unprivileged readers cannot harvest kernel addresses
+# from /proc while root workflows keep working.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+conf="$ROOT/etc/sysctl.d/99-omarchy-sysctl.conf"
+[[ -f $conf ]] || fail "99-omarchy-sysctl.conf is packaged under etc/sysctl.d"
+
+grep -Eq '^[[:space:]]*kernel\.kptr_restrict[[:space:]]*=[[:space:]]*1[[:space:]]*$' "$conf" ||
+  fail "99-omarchy-sysctl.conf sets kernel.kptr_restrict=1" "$(grep kptr "$conf" || true)"
+
+# Do not ship a looser value that would undo distro/admin hardening.
+! grep -Eq '^[[:space:]]*kernel\.kptr_restrict[[:space:]]*=[[:space:]]*0[[:space:]]*$' "$conf" ||
+  fail "99-omarchy-sysctl.conf must not set kptr_restrict=0"
+
+pass "sysctl drop-in hides kernel pointers from unprivileged users"
+
+migration="$ROOT/migrations/1788139000.sh"
+[[ -f $migration ]] || fail "a migration applies the kptr_restrict drop-in on existing installs"
+grep -q '99-omarchy-sysctl.conf' "$migration" ||
+  fail "migration loads the omarchy sysctl drop-in specifically"
+grep -q 'sysctl -p' "$migration" ||
+  fail "migration applies the drop-in at runtime rather than only on next boot"
+
+pass "migration reapplies the sysctl drop-in without waiting for reboot"


### PR DESCRIPTION
## Summary

Fixes #9194.

Omarchy already ships performance/network sysctls in `etc/sysctl.d/99-omarchy-sysctl.conf`. Arch defaults leave `kernel.kptr_restrict=0`, which exposes kernel addresses in `/proc` (e.g. `/proc/kallsyms`) to unprivileged users and weakens KASLR against local exploits.

## Change

- Set `kernel.kptr_restrict=1` in `etc/sysctl.d/99-omarchy-sysctl.conf` (root still sees pointers).
- Migration `1788139000.sh` applies the drop-in at update time so existing boots do not wait for reboot.

## Test plan

- [x] Conf contains `kernel.kptr_restrict=1`
- [x] `sudo sysctl -w kernel.kptr_restrict=1` applies cleanly on GCP VM
- [x] `./test/shell.d/sysctl-kptr-restrict-test.sh` passes

```bash
./test/shell.d/sysctl-kptr-restrict-test.sh
```
