### PR TITLE
Route sibling-package omarchy-* commands via a /usr/bin fallback (fixes #7185)

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -3,6 +3,21 @@
 set -o pipefail
 
 OMARCHY_BIN_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+# Sibling packages (omarchy-settings, omarchy-nvim, and any future omarchy-*
+# package) install their own omarchy-* binaries into /usr/bin without also
+# symlinking them into /usr/share/omarchy/bin, so their routes are invisible
+# to a dispatcher that only scans its own directory. Fall back to /usr/bin on
+# a production install so those routes still resolve. Dev-link and test
+# invocations set OMARCHY_SECONDARY_BIN_DIR themselves (empty disables it).
+if [[ -z ${OMARCHY_SECONDARY_BIN_DIR+set} ]]; then
+  if [[ $OMARCHY_BIN_DIR == "/usr/share/omarchy/bin" ]]; then
+    OMARCHY_SECONDARY_BIN_DIR="/usr/bin"
+  else
+    OMARCHY_SECONDARY_BIN_DIR=""
+  fi
+fi
+
 METADATA_SCAN_LIMIT=80
 
 COMMAND_KEYS=()
@@ -21,6 +36,7 @@ declare -A COMMAND_HIDDEN
 declare -A COMMAND_ALIASES
 declare -A COMMAND_HAS_SUMMARY
 declare -A COMMAND_METADATA_ERRORS
+declare -A COMMAND_ORIGIN
 declare -A ROUTE_TO_KEY
 declare -A ROUTE_IS_ALIAS
 declare -A BINARY_TO_KEY
@@ -164,6 +180,27 @@ register_route() {
   fi
 }
 
+resolve_binary_path() {
+  RESOLVED_BINARY_PATH=""
+  local binary="$1"
+  local candidate="$OMARCHY_BIN_DIR/$binary"
+
+  if [[ -f $candidate && -x $candidate ]]; then
+    RESOLVED_BINARY_PATH="$candidate"
+    return 0
+  fi
+
+  if [[ -n $OMARCHY_SECONDARY_BIN_DIR ]]; then
+    candidate="$OMARCHY_SECONDARY_BIN_DIR/$binary"
+    if [[ -f $candidate && -x $candidate ]]; then
+      RESOLVED_BINARY_PATH="$candidate"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
 register_command() {
   local file="$1"
   local file_binary="${file##*/}"
@@ -278,7 +315,10 @@ register_command() {
   [[ $hidden == "true" ]] || hidden="false"
 
   local key="$file_binary"
+  local origin="primary"
+  [[ $file != "$OMARCHY_BIN_DIR/"* ]] && origin="secondary"
   COMMAND_KEYS+=("$key")
+  COMMAND_ORIGIN["$key"]="$origin"
   COMMAND_ROUTE["$key"]="$route"
   COMMAND_FALLBACK_ROUTE["$key"]="$fallback_route"
   COMMAND_BINARY["$key"]="$file_binary"
@@ -318,14 +358,19 @@ load_commands() {
     register_command "$file"
   done
 
+  [[ -z $OMARCHY_SECONDARY_BIN_DIR ]] && return
+  for file in "$OMARCHY_SECONDARY_BIN_DIR"/omarchy-*; do
+    [[ -f $file && -x $file ]] || continue
+    [[ -n ${BINARY_TO_KEY[${file##*/}]} ]] && continue
+    register_command "$file"
+  done
 }
 
 load_command_by_binary() {
   local binary="$1"
-  local file="$OMARCHY_BIN_DIR/$binary"
 
-  [[ -f $file && -x $file ]] || return 1
-  register_command "$file"
+  resolve_binary_path "$binary" || return 1
+  register_command "$RESOLVED_BINARY_PATH"
 }
 
 load_child_commands_by_binary() {
@@ -334,6 +379,13 @@ load_child_commands_by_binary() {
 
   for file in "$OMARCHY_BIN_DIR/$binary"-*; do
     [[ -f $file && -x $file ]] || continue
+    register_command "$file"
+  done
+
+  [[ -z $OMARCHY_SECONDARY_BIN_DIR ]] && return
+  for file in "$OMARCHY_SECONDARY_BIN_DIR/$binary"-*; do
+    [[ -f $file && -x $file ]] || continue
+    [[ -n ${BINARY_TO_KEY[${file##*/}]} ]] && continue
     register_command "$file"
   done
 }
@@ -346,6 +398,12 @@ group_has_child_commands() {
     [[ -f $file && -x $file ]] && return 0
   done
 
+  if [[ -n $OMARCHY_SECONDARY_BIN_DIR ]]; then
+    for file in "$OMARCHY_SECONDARY_BIN_DIR/omarchy-$group"-*; do
+      [[ -f $file && -x $file ]] && return 0
+    done
+  fi
+
   return 1
 }
 
@@ -353,6 +411,7 @@ group_has_binary_commands() {
   local group="$1"
 
   [[ -x $OMARCHY_BIN_DIR/omarchy-$group ]] && return 0
+  [[ -n $OMARCHY_SECONDARY_BIN_DIR && -x $OMARCHY_SECONDARY_BIN_DIR/omarchy-$group ]] && return 0
   group_has_child_commands "$group"
 }
 
@@ -375,6 +434,8 @@ load_group_commands() {
 
   if [[ -f $OMARCHY_BIN_DIR/omarchy-$group && -x $OMARCHY_BIN_DIR/omarchy-$group ]]; then
     register_command "$OMARCHY_BIN_DIR/omarchy-$group"
+  elif [[ -n $OMARCHY_SECONDARY_BIN_DIR && -f $OMARCHY_SECONDARY_BIN_DIR/omarchy-$group && -x $OMARCHY_SECONDARY_BIN_DIR/omarchy-$group ]]; then
+    register_command "$OMARCHY_SECONDARY_BIN_DIR/omarchy-$group"
   fi
 
   for file in "$OMARCHY_BIN_DIR/omarchy-$group"-*; do
@@ -382,6 +443,12 @@ load_group_commands() {
     register_command "$file"
   done
 
+  [[ -z $OMARCHY_SECONDARY_BIN_DIR ]] && return
+  for file in "$OMARCHY_SECONDARY_BIN_DIR/omarchy-$group"-*; do
+    [[ -f $file && -x $file ]] || continue
+    [[ -n ${BINARY_TO_KEY[${file##*/}]} ]] && continue
+    register_command "$file"
+  done
 }
 
 resolve_direct_route() {
@@ -391,17 +458,16 @@ resolve_direct_route() {
   local prefix_count=0
   local route=""
   local binary=""
-  local candidate=""
 
   for (( prefix_count = argc; prefix_count >= 1; prefix_count-- )); do
     route="omarchy $(join_words " " "${args[@]:0:prefix_count}")"
 
     binary="omarchy-$(join_words "-" "${args[@]:0:prefix_count}")"
-    candidate="$OMARCHY_BIN_DIR/$binary"
-    if [[ -f $candidate && -x $candidate ]]; then
+    if resolve_binary_path "$binary"; then
       DIRECT_RESOLVED_BINARY="$binary"
       DIRECT_RESOLVED_COUNT="$prefix_count"
       DIRECT_RESOLVED_ROUTE="$route"
+      DIRECT_RESOLVED_PATH="$RESOLVED_BINARY_PATH"
       return 0
     fi
   done
@@ -704,20 +770,32 @@ show_commands_check() {
   done
 
   for key in "${COMMAND_KEYS[@]}"; do
+    local origin="${COMMAND_ORIGIN[$key]}"
+    local strict="true"
+    [[ $origin == "secondary" ]] && strict="false"
+
     if [[ ${COMMAND_HAS_SUMMARY[$key]} != "true" ]]; then
-      echo "Missing metadata summary: ${COMMAND_BINARY[$key]}" >&2
-      failures=$((failures + 1))
+      if [[ $strict == "true" ]]; then
+        echo "Missing metadata summary: ${COMMAND_BINARY[$key]}" >&2
+        failures=$((failures + 1))
+      else
+        echo "Missing metadata summary (foreign): ${COMMAND_BINARY[$key]}" >&2
+      fi
     fi
 
     if [[ -n ${COMMAND_METADATA_ERRORS[$key]} ]]; then
       while IFS= read -r error; do
         [[ -n $error ]] || continue
-        echo "Invalid metadata in ${COMMAND_BINARY[$key]}: $error" >&2
-        failures=$((failures + 1))
+        if [[ $strict == "true" ]]; then
+          echo "Invalid metadata in ${COMMAND_BINARY[$key]}: $error" >&2
+          failures=$((failures + 1))
+        else
+          echo "Invalid metadata in ${COMMAND_BINARY[$key]} (foreign): $error" >&2
+        fi
       done < <(pipe_values_as_lines "${COMMAND_METADATA_ERRORS[$key]}")
     fi
 
-    if [[ ! -x $OMARCHY_BIN_DIR/${COMMAND_BINARY[$key]} ]]; then
+    if ! resolve_binary_path "${COMMAND_BINARY[$key]}"; then
       echo "Missing binary: ${COMMAND_BINARY[$key]}" >&2
       failures=$((failures + 1))
     fi
@@ -952,7 +1030,7 @@ dispatch_fast_or_help() {
 
   if resolve_direct_route "$#" "${args[@]}"; then
     remaining=("${args[@]:DIRECT_RESOLVED_COUNT}")
-    binary_path="$OMARCHY_BIN_DIR/$DIRECT_RESOLVED_BINARY"
+    binary_path="$DIRECT_RESOLVED_PATH"
 
     if remaining_has_help_flag "${remaining[@]}"; then
       if ! load_command_by_binary "$DIRECT_RESOLVED_BINARY"; then
@@ -1027,11 +1105,11 @@ dispatch_or_help() {
       return 0
     fi
 
-    binary_path="$OMARCHY_BIN_DIR/${COMMAND_BINARY[$key]}"
-    if [[ ! -x $binary_path ]]; then
+    if ! resolve_binary_path "${COMMAND_BINARY[$key]}"; then
       echo "Binary is missing or not executable: ${COMMAND_BINARY[$key]}" >&2
       return 127
     fi
+    binary_path="$RESOLVED_BINARY_PATH"
 
     if (( ${#remaining[@]} == 0 )) && command_requires_args "$key"; then
       if (( RESOLVED_COUNT == 1 )) && group_exists "$1"; then

--- a/test/cli
+++ b/test/cli
@@ -807,3 +807,113 @@ assert_output_contains "a --help behind -- belongs to the command and still forw
 
 output=$("$TMPDIR/omarchy" parenthelp --helpme x--help)
 assert_output_contains "help lookalike tokens do not trigger help" "$output" "parenthelp-parent-ran args=[--helpme x--help]"
+
+# Sibling packages install their own omarchy-* binaries into /usr/bin without
+# symlinking them into /usr/share/omarchy/bin. On a production install the
+# dispatcher falls back to /usr/bin so those routes still resolve; here we
+# use the OMARCHY_SECONDARY_BIN_DIR env seam to drive that path against a
+# scratch directory instead of touching /usr/bin.
+make_tmpdir PRIMARY_DIR
+make_tmpdir SECONDARY_DIR
+ln -s "$CLI" "$PRIMARY_DIR/omarchy"
+
+{
+  printf '#!/bin/bash\n\n'
+  printf '# omarchy:summary=Secondary-only route\n'
+  printf 'echo "secondary-ok args=[$*]"\n'
+} >"$SECONDARY_DIR/omarchy-secondary-test"
+chmod +x "$SECONDARY_DIR/omarchy-secondary-test"
+
+{
+  printf '#!/bin/bash\n\n'
+  printf '# omarchy:group=sibling\n'
+  printf '# omarchy:name=child\n'
+  printf '# omarchy:summary=Secondary-only child in a shared group\n'
+  printf 'echo secondary-child-ok\n'
+} >"$SECONDARY_DIR/omarchy-sibling-child"
+chmod +x "$SECONDARY_DIR/omarchy-sibling-child"
+
+{
+  printf '#!/bin/bash\n\n'
+  printf '# omarchy:summary=Primary wins on name collision\n'
+  printf 'echo primary-wins\n'
+} >"$PRIMARY_DIR/omarchy-collision"
+chmod +x "$PRIMARY_DIR/omarchy-collision"
+
+{
+  printf '#!/bin/bash\n\n'
+  printf '# omarchy:summary=Would-be shadow in the secondary dir\n'
+  printf 'echo secondary-shadow\n'
+} >"$SECONDARY_DIR/omarchy-collision"
+chmod +x "$SECONDARY_DIR/omarchy-collision"
+
+secondary_env=(env "OMARCHY_SECONDARY_BIN_DIR=$SECONDARY_DIR")
+
+output=$("${secondary_env[@]}" "$PRIMARY_DIR/omarchy" secondary test)
+assert_output_contains "secondary-only route dispatches" "$output" "secondary-ok"
+
+output=$("${secondary_env[@]}" "$PRIMARY_DIR/omarchy" secondary test arg1 arg2)
+assert_output_contains "secondary-only route forwards args" "$output" "secondary-ok args=[arg1 arg2]"
+
+output=$("${secondary_env[@]}" "$PRIMARY_DIR/omarchy" sibling child)
+assert_output_contains "secondary-only child route dispatches" "$output" "secondary-child-ok"
+
+output=$("${secondary_env[@]}" "$PRIMARY_DIR/omarchy" sibling --help)
+assert_output_contains "group help finds secondary-only children" "$output" "omarchy sibling child"
+
+"${secondary_env[@]}" "$PRIMARY_DIR/omarchy" commands --all --json \
+  | jq -e '.commands[] | select(.route == "omarchy secondary test")' >/dev/null
+pass "commands --all lists secondary-dir commands"
+
+"${secondary_env[@]}" "$PRIMARY_DIR/omarchy" commands --check >/dev/null
+pass "commands --check accepts commands living only in the secondary dir"
+
+# A sibling-package binary with no summary metadata should surface as a
+# warning, not fail the check, so foreign hygiene issues do not break users
+# who just installed an unrelated optional package.
+make_tmpdir FOREIGN_DIR
+ln -s "$CLI" "$FOREIGN_DIR/omarchy"
+make_tmpdir FOREIGN_SECONDARY
+{
+  printf '#!/bin/bash\n\n'
+  printf 'echo no-metadata-here\n'
+} >"$FOREIGN_SECONDARY/omarchy-foreign-nometa"
+chmod +x "$FOREIGN_SECONDARY/omarchy-foreign-nometa"
+
+foreign_stderr=$(env "OMARCHY_SECONDARY_BIN_DIR=$FOREIGN_SECONDARY" "$FOREIGN_DIR/omarchy" commands --check 2>&1 >/dev/null)
+assert_output_contains "foreign missing-summary is reported" "$foreign_stderr" "Missing metadata summary (foreign): omarchy-foreign-nometa"
+if [[ $foreign_stderr == *"Command metadata check failed"* ]]; then
+  fail "foreign missing-summary does not fail the check"
+fi
+pass "foreign missing-summary does not fail the check"
+
+# Primary-tree missing-summary must still fail hard (regression guard).
+{
+  printf '#!/bin/bash\n\n'
+  printf 'echo no-primary-metadata\n'
+} >"$FOREIGN_DIR/omarchy-primary-nometa"
+chmod +x "$FOREIGN_DIR/omarchy-primary-nometa"
+
+if env "OMARCHY_SECONDARY_BIN_DIR=$FOREIGN_SECONDARY" "$FOREIGN_DIR/omarchy" commands --check >/dev/null 2>&1; then
+  fail "primary-tree missing-summary still fails commands --check"
+fi
+pass "primary-tree missing-summary still fails commands --check"
+
+output=$("${secondary_env[@]}" "$PRIMARY_DIR/omarchy" collision)
+assert_output_contains "primary wins on collision" "$output" "primary-wins"
+if [[ $output == *"secondary-shadow"* ]]; then
+  fail "primary-dir binary is not shadowed by a same-named secondary"
+fi
+pass "primary-dir binary is not shadowed by a same-named secondary"
+
+collision_json=$("${secondary_env[@]}" "$PRIMARY_DIR/omarchy" commands --all --json)
+if (( $(jq '[.commands[] | select(.binary == "omarchy-collision")] | length' <<<"$collision_json") != 1 )); then
+  fail "colliding binary name is registered only once"
+fi
+pass "colliding binary name is registered only once"
+
+output=$(env OMARCHY_SECONDARY_BIN_DIR= "$PRIMARY_DIR/omarchy" secondary test 2>&1 || true)
+if [[ $output != *"Unknown Omarchy command"* ]]; then
+  fail "empty OMARCHY_SECONDARY_BIN_DIR disables the fallback"
+fi
+pass "empty OMARCHY_SECONDARY_BIN_DIR disables the fallback"


### PR DESCRIPTION
Fixes #7185. Adjacent to #6977 and #7060 (both symptoms of the same split).

## Problem

`bin/omarchy` resolves subcommands by globbing its own directory (`OMARCHY_BIN_DIR`), so on a production install it only sees `/usr/share/omarchy/bin`. Sibling packages install their own `omarchy-*` binaries into `/usr/bin` without symlinking them into `/usr/share/omarchy/bin`, which puts every one of their routes out of the dispatcher's reach. Today that hides at least five commands — three from `omarchy-settings` (`omarchy-debug`, `omarchy-debug-idle`, `omarchy-upload-log`) and two from `omarchy-nvim` (`omarchy-nvim-setup`, `omarchy-nvim-refresh`) — and every optional package following the same pattern (`omarchy-emacs`, `omarchy-fish`, `omarchy-zsh`, future ones) hits the same wall. The three from `omarchy-settings` are the most user-visible because the bug template and the shipped `omarchy` agent skill both instruct people to run `omarchy debug --no-sudo --print`, which currently exits 127 on production installs.

The split is deliberate on the packaging side (`omarchy-settings` must be usable on the ISO live env before `omarchy` is installed), so `bin/omarchy`'s PKGBUILD deliberately excludes those three from the standard `install -Dm755 … + ln -s /usr/share/omarchy/bin/…` loop. Fixing this on the dispatcher side keeps the invariant in one place instead of asking every sibling-package PKGBUILD to remember to drop a symlink into a directory another package owns.

## Change

When the dispatcher runs as a production install (`OMARCHY_BIN_DIR == /usr/share/omarchy/bin`), also scan `/usr/bin/omarchy-*` as a secondary source. The primary directory always wins on name collision, so the `omarchy` package's own binaries stay authoritative.

The touch points are the six discovery/resolution paths in `bin/omarchy` — `load_commands`, `load_command_by_binary`, `load_child_commands_by_binary`, `group_has_child_commands`, `group_has_binary_commands`, `load_group_commands`, `resolve_direct_route` — plus the two `binary_path=` sites in `dispatch_fast_or_help`/`dispatch_or_help` and the missing-binary check in `commands --check`. All of those funnel through a single `resolve_binary_path` helper (primary first, then secondary), and `resolve_direct_route` now returns `DIRECT_RESOLVED_PATH` so the fast path can exec the right file without recomputing.

Dev-link and test invocations honour the env variable `OMARCHY_SECONDARY_BIN_DIR` themselves — set it to a directory to override, set it to the empty string to disable the fallback. The tests use that seam to drive the new code paths against scratch directories rather than `/usr/bin`.

## Metadata check behavior

Once sibling-package binaries become visible to the dispatcher, they also become visible to `omarchy commands --check`. `omarchy-nvim`'s two binaries ship without an `# omarchy:summary=` line today, so a strict check regressed from green to red on any machine with `omarchy-nvim` installed.

To avoid pinning the fix to a coordinated release with a sibling package, `commands --check` now tracks per-command origin (`primary` vs `secondary`). Missing-summary and metadata-validation errors from **primary** binaries still fail the check exactly as before — that guardrail on the project's own tree is untouched. The same errors from **secondary** binaries surface as warnings with a `(foreign)` tag and do not count toward the failure total. Missing-binary errors continue to fail regardless of origin. Happy to invert that decision if the preference is to fail hard and use it as pressure to fix sibling-package metadata.

## Tests

`test/cli` gains a block that reuses the existing symlink-into-tmpdir pattern:

- secondary-only top-level command dispatches and forwards args
- secondary-only child of a shared group dispatches
- group help renders and lists secondary-only children
- `commands --all --json` lists secondary-dir commands
- `commands --check` passes when a well-formed command lives only in secondary
- primary wins on name collision, no shadow execution, no double-register
- empty `OMARCHY_SECONDARY_BIN_DIR` disables the fallback
- foreign missing-summary is a warning, not a failure
- primary-tree missing-summary still fails the check (regression guard)

Full suite is green (`bash test/cli` — 126 tests pass).

## Verification against the real system

With `OMARCHY_SECONDARY_BIN_DIR=/usr/bin` (i.e. simulating a production install from a dev checkout), the previously-invisible routes now resolve on my machine:

```
$ OMARCHY_SECONDARY_BIN_DIR=/usr/bin ./bin/omarchy commands --all | grep -E '^  omarchy (debug|upload log|nvim setup|nvim refresh|debug idle)'
  omarchy debug idle [log-lines]         Show idle, screensaver, and lock diagnostics
  omarchy debug [--no-sudo] [--print]    Print debugging information
  omarchy nvim refresh                    Setup/refresh script for omarchy-nvim
  omarchy nvim setup                      Setup/refresh script for omarchy-nvim
  omarchy upload log <log-file>           Upload logs to logs.omarchy.org

$ OMARCHY_SECONDARY_BIN_DIR=/usr/bin ./bin/omarchy debug --help
Usage:
  omarchy debug [--no-sudo] [--print]
...

$ OMARCHY_SECONDARY_BIN_DIR=/usr/bin ./bin/omarchy commands --check
Missing metadata summary (foreign): omarchy-nvim-refresh
Missing metadata summary (foreign): omarchy-nvim-setup
Command metadata check passed (439 commands)
```

## Relationship to #7239

PR #7239 (open, targets `default/hypr/envs.lua`) fixes the *PATH-shadowing* side of #6977 — with it landed, an interactive shell in Hyprland has `/usr/bin` ahead of `/usr/share/omarchy/bin` on PATH, so `omarchy` resolves from `/usr/bin/omarchy`, and that dispatcher then scans `/usr/bin/omarchy-*` and finds everything. It functionally papers over #7185 for interactive shells. This PR fixes the dispatcher itself, so any invocation of `/usr/share/omarchy/bin/omarchy debug` (scripts, non-interactive shells, scoped `OMARCHY_PATH` uses) also routes correctly. The two are orthogonal — either can land first.
