### PR TITLE
Recover screen-recording indicator after stuck probes

### DIFF
--- a/shell/plugins/bar/indicators/ScreenRecording.qml
+++ b/shell/plugins/bar/indicators/ScreenRecording.qml
@@ -13,10 +13,23 @@ BarIndicator {
   activeTooltipText: "Stop recording"
   inactiveTooltipText: "Screen Recording"
 
+  // pgrep is fast; if the Process never leaves running (onExited lost after an
+  // abrupt recorder death, handler throw, etc.), refresh() would bail forever
+  // and the icon stay stuck on the last known state. Cap each probe and keep
+  // polling so a killed gpu-screen-recorder is noticed without a shell restart.
   function refresh() {
-    if (!root.bar || statusProc.running) return
+    if (!root.bar)
+      return
+
+    if (statusProc.running) {
+      if (!probeWatchdog.running)
+        probeWatchdog.restart()
+      return
+    }
+
     statusProc.command = ["pgrep", "--quiet", "-f", "^gpu-screen-recorder"]
     statusProc.running = true
+    probeWatchdog.restart()
   }
 
   onBarChanged: refresh()
@@ -25,17 +38,43 @@ BarIndicator {
   Connections {
     target: root.indicatorHost
     ignoreUnknownSignals: true
-    function onRefreshRequested() { root.refresh() }
+    function onRefreshRequested() {
+      root.refresh()
+    }
   }
 
   Process {
     id: statusProc
-    onExited: function(exitCode) {
+    onExited: function (exitCode) {
+      probeWatchdog.stop()
       root.recording = exitCode === 0
     }
   }
 
-  onPressed: function() {
+  Timer {
+    id: probeWatchdog
+    interval: 2000
+    repeat: false
+    onTriggered: {
+      if (!statusProc.running)
+        return
+      // Drop the stuck Process handle so the next poll can start a fresh pgrep.
+      statusProc.running = false
+      root.refresh()
+    }
+  }
+
+  Timer {
+    id: pollTimer
+    // Abnormal kills skip omarchy-capture-screenrecording's indicator toggle;
+    // poll so the bar catches up without waiting for another IPC refresh.
+    interval: 2000
+    running: true
+    repeat: true
+    onTriggered: root.refresh()
+  }
+
+  onPressed: function () {
     if (root.bar) {
       root.bar.run(root.recording ? "omarchy-capture-screenrecording --stop-recording" : "omarchy-menu toggle trigger.capture.screenrecord")
     }

--- a/test/shell.d/screenrecording-indicator-test.sh
+++ b/test/shell.d/screenrecording-indicator-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# ScreenRecording.qml must not freeze on the last known state when a pgrep
+# Process never leaves running, and must notice an abnormally killed recorder
+# without waiting for omarchy.indicators refresh.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+indicator="$ROOT/shell/plugins/bar/indicators/ScreenRecording.qml"
+[[ -f $indicator ]] || fail "ScreenRecording indicator is present"
+
+grep -q 'probeWatchdog' "$indicator" ||
+  fail "indicator watches for a stuck status Process"
+grep -q 'statusProc.running = false' "$indicator" ||
+  fail "stuck-probe path clears Process.running so refresh can run again"
+grep -q 'pollTimer' "$indicator" ||
+  fail "indicator polls recording state on a timer"
+grep -Eq 'interval:[[:space:]]*2000' "$indicator" ||
+  fail "probe/poll intervals stay short enough to recover without a shell restart"
+
+# refresh must not permanently no-op solely because running is true without a
+# way to clear it.
+if ! grep -A20 'function refresh' "$indicator" | grep -q 'probeWatchdog'; then
+  fail "refresh arms the stuck-probe watchdog when a probe is already running"
+fi
+
+grep -q 'onExited' "$indicator" || fail "indicator still updates recording from pgrep exit code"
+grep -q 'omarchy-capture-screenrecording --stop-recording' "$indicator" ||
+  fail "active click still stops the recorder"
+
+pass "ScreenRecording indicator recovers from stuck probes and polls after crashes"


### PR DESCRIPTION
## Summary

Fixes #9205.

`ScreenRecording.qml` polls with a one-shot `Process` (`pgrep`). `refresh()` returns early while `statusProc.running` is true. If `onExited` never fires cleanly (abrupt recorder kill, handler glitch, etc.), that flag stays true forever — no further probes run and the bar icon freezes on "recording" even when no `gpu-screen-recorder` process exists. Workaround was `omarchy restart shell`.

## Change

- Arm a 2s watchdog when a probe starts; if still `running`, force `statusProc.running = false` and refresh again.
- Add a 2s poll timer so kills that skip `omarchy-capture-screenrecording`'s indicator toggle still update the bar.

## Test plan

- [x] Static contract: watchdog + poll + stuck-clear path present
- [x] Existing `screenrecording-test.sh` still passes
- [x] Verified on GCP VM

```bash
./test/shell.d/screenrecording-indicator-test.sh
./test/shell.d/screenrecording-test.sh
```
