### PR TITLE
Offer Korean as an install-time keyboard choice

### DIFF
--- a/bin/omarchy-provision-first-run
+++ b/bin/omarchy-provision-first-run
@@ -83,6 +83,8 @@ run_first_run_step "set GTK primary paste" \
   bash "$OMARCHY_PATH/install/user/first-run/gtk-primary-paste.sh"
 run_first_run_step "apply speaker tuning" \
   bash "$OMARCHY_PATH/install/user/first-run/audio-tuning.sh"
+run_first_run_step "seed Korean input method" \
+  bash "$OMARCHY_PATH/install/user/first-run/korean-ime.sh"
 
 omarchy-notification-wait || log_first_run "Timed out waiting for notification service; continuing"
 # Each send returns only once the server has taken the toast, so sending in

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -616,6 +616,21 @@ confirm_reboot() {
 # the picker no longer offers any such layout).
 apply_keyboard() {
   local keymap="$1"
+
+  # Korean is the one choice that isn't a console keymap: kbd ships no Korean
+  # map, and Korean keyboards type Latin on the US map anyway — Hangul comes
+  # from the fcitx5 IME. Persist us for the console but kr as the XKB layout,
+  # which is how Hyprland and the per-user first-run recognize a Korean machine.
+  if [[ $keymap == "kr" ]]; then
+    apply_keyboard us
+    if grep -q '^XKBLAYOUT=' /etc/vconsole.conf 2>/dev/null; then
+      sed -i 's/^XKBLAYOUT=.*/XKBLAYOUT=kr/' /etc/vconsole.conf
+    else
+      echo "XKBLAYOUT=kr" >>/etc/vconsole.conf
+    fi
+    return 0
+  fi
+
   [[ $(tty 2>/dev/null) == /dev/tty* ]] && loadkeys "$keymap" 2>/dev/null || true
 
   if localectl --no-pager list-keymaps 2>/dev/null | grep -qix "$keymap"; then

--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -3,3 +3,9 @@
 --password-store=gnome-libsecret
 --enable-features=TouchpadOverscrollHistoryNavigation
 --load-extension=/usr/share/omarchy/default/chromium/extensions/copy-url,/usr/share/omarchy/default/chromium/extensions/yt-dlp,/usr/share/omarchy/default/chromium/extensions/whatsapp-slim
+
+# Chromium on native Wayland ignores the compositor's text-input protocol
+# unless told to use it, which leaves fcitx5 (Korean/Hangul and the ~/.XCompose
+# emoji + expansions) dead in every browser text field.
+--enable-wayland-ime
+--wayland-text-input-version=3

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -34,6 +34,7 @@ fakeroot
 fastfetch
 fcitx5
 fcitx5-gtk
+fcitx5-hangul
 fcitx5-qt
 fd
 ffmpegthumbnailer

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -57,6 +57,7 @@ Irish|ie
 Italian|it
 Japanese|jp106
 Kazakh|kazakh
+Korean|kr
 Kyrgyz|kyrgyz
 Lao|la-latin1
 Latvian|lv

--- a/install/user/first-run/korean-ime.sh
+++ b/install/user/first-run/korean-ime.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Seed the Korean input method for machines installed with the Korean keyboard
+# choice. There is no Korean console keymap, so the picker persists that choice
+# as XKBLAYOUT=kr in /etc/vconsole.conf (the console itself stays on us); this
+# is the marker read here. fcitx5 already runs in every session for the
+# XCompose sequences, so Korean only needs the hangul engine in this user's
+# input methods and a toggle key.
+#
+# The 한/영 key on Korean keyboards emits the Hangul keysym on every XKB
+# layout (xkb maps <HNGL> globally), so binding Hangul as the trigger makes
+# that key the Korean/English toggle without touching Caps Lock, which stays
+# the compose key. Control+space remains as a fallback for keyboards without a
+# dedicated 한/영 key.
+#
+# fcitx5 owns these two files: it writes a default profile the moment it starts,
+# and rewrites both when it saves. Hyprland's autostart runs first-run well
+# after graphical-session.target has started fcitx5, so the files always exist
+# by the time this runs and their mere presence proves nothing -- the guards
+# below test for the hangul engine instead. fcitx5 is stopped for the write
+# because its own save-on-exit would otherwise put the default group straight
+# back over what was just written.
+#
+# A no-op on non-Korean machines, and on any account that already lists hangul,
+# so a user's own fcitx5 setup survives a forced first-run rerun.
+
+set -euo pipefail
+
+xkb_layout=$(sed -n 's/^XKBLAYOUT=//p' /etc/vconsole.conf 2>/dev/null | tail -n 1)
+xkb_layout=${xkb_layout//[\"\']/}
+if [[ ${xkb_layout%%,*} != "kr" ]]; then
+  exit 0
+fi
+
+profile=~/.config/fcitx5/profile
+config=~/.config/fcitx5/config
+
+needs_profile() { ! grep -qx 'Name=hangul' "$profile" 2>/dev/null; }
+needs_config() { ! grep -qx '0=Hangul' "$config" 2>/dev/null; }
+
+if ! needs_profile && ! needs_config; then
+  exit 0
+fi
+
+mkdir -p ~/.config/fcitx5
+systemctl --user stop omarchy-fcitx5.service 2>/dev/null || true
+
+if needs_profile; then
+  cat >"$profile" <<'EOF'
+[Groups/0]
+# Group Name
+Name=Default
+# Layout
+Default Layout=us
+# Default Input Method
+DefaultIM=hangul
+
+[Groups/0/Items/0]
+# Name
+Name=keyboard-us
+# Layout
+Layout=
+
+[Groups/0/Items/1]
+# Name
+Name=hangul
+# Layout
+Layout=
+
+[GroupOrder]
+0=Default
+EOF
+  # fcitx5 writes the profile private; match it rather than leaving the group
+  # and world a copy of what this user types with.
+  chmod 600 "$profile"
+fi
+
+if needs_config; then
+  # fcitx5 writes list-valued options as their own section
+  # ([Hotkey/TriggerKeys] with 0=, 1= beneath it). A bare "TriggerKeys=" line
+  # under [Hotkey] would silently set the list empty -- no toggle key at all.
+  cat >"$config" <<'EOF'
+[Hotkey/TriggerKeys]
+# Hangul is what the 한/영 key on Korean keyboards emits.
+0=Hangul
+1=Control+space
+
+[Behavior]
+# Start in English; the trigger switches to Korean.
+ActiveByDefault=False
+EOF
+fi
+
+# Only bring it back up when there is a session to come back to; an update over
+# SSH has a user manager and no display, and the unit's own
+# ConditionEnvironment keeps it stopped there.
+systemctl --user start omarchy-fcitx5.service 2>/dev/null || true

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -61,6 +61,12 @@ On Dell XPS laptops with a haptic touchpad, you can also set the click strength 
 
 Omarchy runs the [fcitx5](https://fcitx-im.org/) input method framework as part of every session — it's what powers the CapsLock compose sequences. That means the plumbing for non-Latin input is already in place: install an input engine like `fcitx5-mozc` (Japanese) or `fcitx5-chinese-addons` (Chinese) with `omarchy pkg add`, plus `fcitx5-configtool` to add the engine to your input methods and set the key that switches between them.
 
+### Typing in Korean
+
+Korean is built in: pick _Korean_ as the keyboard layout during installation and the machine comes up with the [fcitx5-hangul](https://github.com/fcitx/fcitx5-hangul) engine configured. You type English until you press the 한/영 key (or Ctrl+Space on keyboards without one), which toggles Hangul on and off. Caps Lock stays the compose key, as on every other layout.
+
+On a machine installed with a different layout, the same setup is two steps away: run `omarchy pkg add fcitx5-configtool`, then add _Hangul_ to your input methods and set the toggle key. Some Korean keyboards (like Apple's Magic Keyboard) wire the 한/영 key as plain Caps Lock; there you'll want a custom toggle key, or an xkb option that remaps Caps Lock to the Hangul keysym.
+
 ### Use ALT as SUPER
 
 On some keyboards, it's not convenient to use the primary meta key (Windows/cmd key) as SUPER. You can change this to be ALT instead using this change:

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -65,6 +65,9 @@ XKBVARIANT=intl
 assert_input "latin layouts are left alone" "[de] [nodeadkeys] [$base_options]" 'XKBLAYOUT=de
 XKBVARIANT=nodeadkeys
 '
+assert_input "korean machines keep kr leading, since kr types latin" "[kr] [] [$base_options]" 'KEYMAP=us
+XKBLAYOUT=kr
+'
 assert_input "non-latin layout gains us in front" "[us,ara] [,] [$toggle_options]" 'XKBLAYOUT=ara
 '
 assert_input "prepended us keeps variants aligned" "[us,ru] [,phonetic] [$toggle_options]" 'XKBLAYOUT=ru

--- a/test/shell.d/setup-form-test.sh
+++ b/test/shell.d/setup-form-test.sh
@@ -133,6 +133,12 @@ assert_status 0 "keyboard prompt succeeds"
 grep -qF -- '--selected English (US)' "$GUM_ARGS" || fail "keyboard prompt preselects English (US)"
 pass "keyboard prompt maps the chosen label to its keymap"
 
+run_prompt omarchy_prompt_keyboard "0:Korean"
+assert_status 0 "keyboard prompt accepts Korean"
+[[ $(field keyboard) == "kr" ]] ||
+  fail "Korean resolves to kr, the XKB marker apply_keyboard persists in place of a console keymap kbd does not ship"
+pass "keyboard prompt maps Korean to the kr marker"
+
 run_prompt omarchy_prompt_keyboard "1:"
 assert_status "$OMARCHY_FORM_BACK" "keyboard prompt reports Esc as back"
 assert_returned "keyboard prompt survives Esc under set -e"


### PR DESCRIPTION
Korean is missing from the install-time keyboard picker because it never fit the picker's model: the list maps labels to console keymaps, kbd ships no Korean console keymap, and Korean input isn't a keymap anyway — Korean keyboards type Latin on the US map, and Hangul comes from an input method. Since Omarchy already runs fcitx5 in every session (for the XCompose sequences), Korean turns out to be one package and a little wiring away.

## What this does

Selecting **Korean** at install gives a machine that types English until the 한/영 key toggles Hangul, exactly the way Korean users expect. Caps Lock stays the compose key, like every other layout.

- `setup-form.sh` gains `Korean|kr`. There's no Korean console keymap, so `apply_keyboard` special-cases it: the console gets `us`, and `XKBLAYOUT=kr` is persisted in `/etc/vconsole.conf`. Hyprland's packaged input config already reads its layout from there, so `kr` flows through untouched (it's a Latin-typing layout, so no `us,`-prefix treatment).
- `fcitx5-hangul` joins the base packages next to the fcitx5 packages already shipped.
- A new first-run leaf, `install/user/first-run/korean-ime.sh`, seeds `~/.config/fcitx5/{profile,config}` for the new user when the machine's `XKBLAYOUT` is `kr`: hangul engine in the input methods, `Hangul` + `Control+space` as trigger keys, English active by default.
- The 한/영 key needs no per-keyboard handling: xkb maps `<HNGL>` to the Hangul keysym globally (`symbols/pc`), so it works on any layout on standard Korean keyboards. `Control+space` covers keyboards without a dedicated key.

The seeding is deliberate about the fact that fcitx5 owns those two files. fcitx5 writes a default profile the moment it starts, and Hyprland's autostart runs first-run well after `graphical-session.target` has started it — so the files always exist by then and their presence proves nothing. The leaf tests for the hangul engine instead, and stops fcitx5 across the write, because its save-on-exit would otherwise put the default group straight back over the seed. An account that already lists hangul is left alone, so a user's own fcitx5 setup survives a forced first-run rerun.

The first commit is a standalone fix this feature surfaced: Chromium browsers on native Wayland ignore the compositor's text-input protocol unless launched with `--enable-wayland-ime`, which leaves fcitx5 dead in every browser text field — that already breaks the shipped XCompose emoji/expansion sequences today, not just Korean. The flags are added to `config/chromium-flags.conf`.

## Testing

Verified end to end on a locally built ISO (`omarchy-iso-make --local-source`) in a QEMU VM: selected Korean in the installer, and the installed machine came up with `KEYMAP=us` / `XKBLAYOUT=kr`, a seeded fcitx5 profile, and Ctrl+Space switching straight into Hangul with no manual setup.

Unit coverage:

- `setup-form-test.sh`: Korean resolves to the `kr` marker.
- `hyprland-keyboard-layout-test.sh`: `XKBLAYOUT=kr` passes through Latin-led.
- The first-run leaf was exercised across its paths: seeds over the default profile fcitx5 creates for itself, unchanged on rerun, preserves an account that already has hangul, and no-ops on non-Korean machines.

## Companion change

The ISO configurator sources the same `setup-form.sh`, so it picks up the new entry, but `configure_keyboard` in **omarchy-iso** rejects any keymap `localectl` doesn't know — which silently drops Korean back to the default layout and leaves no marker for the first-run leaf. That repo also has a test asserting every configurator keymap is a known keymap, which this PR would otherwise break.

The matching change is ready and is what the ISO above was built with: resolve such layouts to a Latin console keymap for `KEYMAP`, then point `XKBLAYOUT` back at the chosen layout. Happy to open it as soon as this direction looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGyJjcWvARsM1szQ9Uq9bp
