### PR TITLE
Request MJPG for the webcam overlay when the camera offers it

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -71,17 +71,9 @@ start_webcam_overlay() {
     fi
   fi
 
-  # Try preferred 16:9 resolutions in order, use first available
-  local preferred_resolutions=("640x360" "1280x720" "1920x1080")
-  local capture_options="framerate=30"
-  local available_formats=$(v4l2-ctl --list-formats-ext -d "$WEBCAM_DEVICE" 2>/dev/null)
-
-  for resolution in "${preferred_resolutions[@]}"; do
-    if echo "$available_formats" | grep -q "$resolution"; then
-      capture_options="video_size=$resolution,$capture_options"
-      break
-    fi
-  done
+  local capture_options
+  capture_options=$(omarchy-capture-webcam-format "$WEBCAM_DEVICE")
+  [[ -n $capture_options ]] || capture_options="framerate=30"
 
   mpv "av://v4l2:$WEBCAM_DEVICE" \
     --profile=low-latency --untimed --no-cache \

--- a/bin/omarchy-capture-webcam-format
+++ b/bin/omarchy-capture-webcam-format
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# omarchy:summary=Pick v4l2 size and pixel format for the webcam overlay
+# omarchy:hidden=true
+
+# ffmpeg's v4l2 demuxer picks YUYV when input_format is unset. On common UVC
+# cameras that format is 5–10 fps at 720p, while the same size in MJPG is 30 fps.
+# Probe v4l2-ctl and request the compressed mode explicitly.
+#
+# Preferred 16:9 sizes stay 640x360, 1280x720, 1920x1080. A size is skipped when
+# it cannot deliver 30 fps, so a 640x360 YUYV@5 mode does not hide 1280x720 MJPG@30.
+
+device=${1:-}
+if [[ -z $device ]]; then
+  echo "usage: omarchy-capture-webcam-format <device>" >&2
+  exit 1
+fi
+
+target_fps=30
+preferred_sizes=(640x360 1280x720 1920x1080)
+
+lavf_name() {
+  case $1 in
+  MJPG | JPEG | MJPEG) printf '%s\n' mjpeg ;;
+  H264 | AVC1) printf '%s\n' h264 ;;
+  HEVC | H265) printf '%s\n' hevc ;;
+  NV12) printf '%s\n' nv12 ;;
+  NV21) printf '%s\n' nv21 ;;
+  YU12 | I420) printf '%s\n' yuv420p ;;
+  YUYV | YUY2) printf '%s\n' yuyv422 ;;
+  RGB3) printf '%s\n' rgb24 ;;
+  BGR3) printf '%s\n' bgr24 ;;
+  *) return 1 ;;
+  esac
+}
+
+is_compressed() {
+  case $1 in
+  MJPG | JPEG | MJPEG | H264 | AVC1 | HEVC | H265) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+emit() {
+  local fourcc=$1
+  local size=$2
+  local fps=$3
+  local opts="video_size=$size,framerate=$fps"
+  local lavf
+
+  if lavf=$(lavf_name "$fourcc"); then
+    opts+=",input_format=$lavf"
+  fi
+
+  printf '%s\n' "$opts"
+}
+
+formats=$(v4l2-ctl --list-formats-ext -d "$device" 2>/dev/null) || true
+if [[ -z $formats ]]; then
+  printf '%s\n' "framerate=$target_fps"
+  exit 0
+fi
+
+declare -A max_fps=()
+
+while read -r fourcc size fps; do
+  [[ -n $fourcc && -n $size && -n $fps ]] || continue
+  key="$fourcc $size"
+  if (( fps > ${max_fps[$key]:-0} )); then
+    max_fps[$key]=$fps
+  fi
+done < <(awk '
+  $1 ~ /^\[/ {
+    split($2, parts, "'\''")
+    fourcc = parts[2]
+    next
+  }
+  /Size: Discrete/ {
+    size = $3
+    next
+  }
+  /fps\)/ {
+    fps = 0
+    for (i = 1; i <= NF; i++) {
+      if ($i == "fps)") {
+        fps = $(i - 1)
+        gsub(/[()]/, "", fps)
+        fps = int(fps)
+        break
+      }
+    }
+    if (fourcc != "" && size != "" && fps > 0)
+      print fourcc, size, fps
+  }
+' <<<"$formats")
+
+if (( ${#max_fps[@]} == 0 )); then
+  printf '%s\n' "framerate=$target_fps"
+  exit 0
+fi
+
+best_at_size() {
+  local size=$1
+  local need_compressed=$2
+  local min_fps=$3
+  local fourcc key fps
+  local best_fourcc=""
+  local best_fps=0
+  local best_compressed=1
+
+  for key in "${!max_fps[@]}"; do
+    fourcc=${key%% *}
+    [[ ${key#* } == "$size" ]] || continue
+    fps=${max_fps[$key]}
+    (( fps >= min_fps )) || continue
+    if [[ $need_compressed == "true" ]] && ! is_compressed "$fourcc"; then
+      continue
+    fi
+
+    if (( fps > best_fps )); then
+      best_fourcc=$fourcc
+      best_fps=$fps
+      if is_compressed "$fourcc"; then
+        best_compressed=0
+      else
+        best_compressed=1
+      fi
+      continue
+    fi
+
+    if (( fps == best_fps )) && (( best_compressed == 1 )) && is_compressed "$fourcc"; then
+      best_fourcc=$fourcc
+      best_compressed=0
+    fi
+  done
+
+  [[ -n $best_fourcc ]] || return 1
+  emit "$best_fourcc" "$size" "$best_fps"
+}
+
+for size in "${preferred_sizes[@]}"; do
+  best_at_size "$size" true "$target_fps" && exit 0
+done
+
+for size in "${preferred_sizes[@]}"; do
+  best_at_size "$size" false "$target_fps" && exit 0
+done
+
+for size in "${preferred_sizes[@]}"; do
+  best_at_size "$size" false 1 && exit 0
+done
+
+printf '%s\n' "framerate=$target_fps"
+exit 0

--- a/test/shell.d/capture-webcam-format-test.sh
+++ b/test/shell.d/capture-webcam-format-test.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/v4l2-ctl" <<'SH'
+#!/bin/bash
+
+case $OMARCHY_TEST_WEBCAM_FORMATS in
+empty)
+  exit 0
+  ;;
+missing)
+  exit 1
+  ;;
+bison)
+  cat <<'FMT'
+ioctl: VIDIOC_ENUM_FMT
+Type: Video Capture
+
+[0]: 'MJPG' (Motion-JPEG, compressed)
+	Size: Discrete 1280x720
+		Interval: Discrete 0.033s (30.000 fps)
+	Size: Discrete 640x360
+		Interval: Discrete 0.033s (30.000 fps)
+	Size: Discrete 1920x1080
+		Interval: Discrete 0.033s (30.000 fps)
+[1]: 'YUYV' (YUYV 4:2:2)
+	Size: Discrete 1280x720
+		Interval: Discrete 0.100s (10.000 fps)
+	Size: Discrete 640x360
+		Interval: Discrete 0.033s (30.000 fps)
+	Size: Discrete 1920x1080
+		Interval: Discrete 0.200s (5.000 fps)
+FMT
+  ;;
+issue7300)
+  cat <<'FMT'
+ioctl: VIDIOC_ENUM_FMT
+Type: Video Capture
+
+[0]: 'MJPG' (Motion-JPEG, compressed)
+	Size: Discrete 1280x720
+		Interval: Discrete 0.033s (30.000 fps)
+[1]: 'YUYV' (YUYV 4:2:2)
+	Size: Discrete 1280x720
+		Interval: Discrete 0.200s (5.000 fps)
+FMT
+  ;;
+lowfps-small)
+  cat <<'FMT'
+ioctl: VIDIOC_ENUM_FMT
+Type: Video Capture
+
+[0]: 'YUYV' (YUYV 4:2:2)
+	Size: Discrete 640x360
+		Interval: Discrete 0.200s (5.000 fps)
+[1]: 'MJPG' (Motion-JPEG, compressed)
+	Size: Discrete 1280x720
+		Interval: Discrete 0.033s (30.000 fps)
+FMT
+  ;;
+yuyv-only)
+  cat <<'FMT'
+ioctl: VIDIOC_ENUM_FMT
+Type: Video Capture
+
+[0]: 'YUYV' (YUYV 4:2:2)
+	Size: Discrete 1280x720
+		Interval: Discrete 0.200s (5.000 fps)
+FMT
+  ;;
+h264)
+  cat <<'FMT'
+ioctl: VIDIOC_ENUM_FMT
+Type: Video Capture
+
+[0]: 'H264' (H.264, compressed)
+	Size: Discrete 1920x1080
+		Interval: Discrete 0.033s (30.000 fps)
+[1]: 'YUYV' (YUYV 4:2:2)
+	Size: Discrete 1920x1080
+		Interval: Discrete 0.033s (30.000 fps)
+FMT
+  ;;
+esac
+SH
+chmod +x "$stub_bin/v4l2-ctl"
+
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+
+assert_format() {
+  local description=$1
+  local fixture=$2
+  local expected=$3
+  local actual status=0
+
+  actual=$(OMARCHY_TEST_WEBCAM_FORMATS=$fixture omarchy-capture-webcam-format /dev/video0) || status=$?
+  [[ $status -eq 0 && $actual == "$expected" ]] ||
+    fail "$description" "expected ${expected@Q}, got status=$status output=${actual@Q}"
+  pass "$description"
+}
+
+assert_format "BisonCam prefers 640x360 MJPG at 30 fps over YUYV" \
+  bison "video_size=640x360,framerate=30,input_format=mjpeg"
+
+assert_format "issue #7300 camera requests 1280x720 MJPG instead of YUYV@5" \
+  issue7300 "video_size=1280x720,framerate=30,input_format=mjpeg"
+
+assert_format "skips a 5 fps 640x360 YUYV mode when 1280x720 MJPG@30 exists" \
+  lowfps-small "video_size=1280x720,framerate=30,input_format=mjpeg"
+
+assert_format "YUYV-only 720p still sets size, fps and input_format" \
+  yuyv-only "video_size=1280x720,framerate=5,input_format=yuyv422"
+
+assert_format "H264 wins over YUYV at the same 30 fps size" \
+  h264 "video_size=1920x1080,framerate=30,input_format=h264"
+
+assert_format "empty v4l2 output keeps the previous framerate=30 default" \
+  empty "framerate=30"
+
+assert_format "a missing v4l2-ctl still prints framerate=30" \
+  missing "framerate=30"
+
+status=0
+usage=$(omarchy-capture-webcam-format 2>/dev/null) || status=$?
+((status != 0)) && [[ -z $usage ]] ||
+  fail "missing device argument exits non-zero" "status=$status output=${usage@Q}"
+pass "missing device argument exits non-zero"
+
+grep -q 'omarchy-capture-webcam-format "$WEBCAM_DEVICE"' "$ROOT/bin/omarchy-capture-screenrecording" ||
+  fail "screenrecording overlay uses the webcam format helper"
+pass "screenrecording overlay uses the webcam format helper"


### PR DESCRIPTION
## What

Pick the v4l2 size/format for `omarchy screenrecord --with-webcam` from `v4l2-ctl --list-formats-ext` instead of asking ffmpeg to guess.

ffmpeg's v4l2 demuxer selects YUYV when `input_format` is unset. On common UVC cameras that raw mode is 5–10 fps at 720p, while MJPG at the same size is 30 fps. The overlay then looks choppy regardless of `--webcam-size`.

`omarchy-capture-webcam-format` now:

- Prefers a compressed 30 fps mode (MJPG / H264 / HEVC) at 640x360, then 1280x720, then 1920x1080
- Skips a preferred size that cannot do 30 fps, so a 640x360 YUYV@5 mode does not hide 1280x720 MJPG@30
- Falls back to the best remaining format (still setting `input_format`) or to `framerate=30` if probing fails

`start_webcam_overlay()` passes that string to mpv's `--demuxer-lavf-o`.

Closes #7300

## Tests

`test/shell.d/capture-webcam-format-test.sh` — stubbed `v4l2-ctl` fixtures for:

- 640x360 MJPG@30 vs YUYV@30 → MJPG 640x360
- #7300 camera (1280x720 MJPG@30 + YUYV@5, no 640x360) → MJPG 1280x720
- 640x360 YUYV@5 hiding 1280x720 MJPG@30 → skip the small size
- YUYV-only 720p@5 → still emits size, fps, `input_format=yuyv422`
- H264 vs YUYV at 1080p30 → H264
- empty / missing v4l2-ctl → `framerate=30`

`./test/cli` passed, including command metadata for the new hidden helper.

## Hardware check (no media attached)

UVC camera with both MJPG and YUYV. mpv launched with the same `--demuxer-lavf-o` the overlay uses; format read back with `v4l2-ctl --get-fmt-video` / `--get-parm` while mpv held the device:

| mpv `--demuxer-lavf-o` | Negotiated |
|---|---|
| helper output (`video_size=640x360,framerate=30,input_format=mjpeg`) | MJPG 640x360 @ 30 |
| old `video_size=640x360,framerate=30` | YUYV 640x360 @ 30 |
| old `video_size=1280x720,framerate=30` (#7300 path) | YUYV 1280x720 @ 10 |
| `video_size=1280x720,framerate=30,input_format=mjpeg` | MJPG 1280x720 @ 30 |

No screenshots or recordings attached.

- atavacron, Grok 4.6 (high)
