### PR TITLE
Clarify that "grab key from github" in sshd setup authorizes EVERY machine that publishes public key on your github a/c

### DIFF
--- a/bin/omarchy-setup-security-sshd
+++ b/bin/omarchy-setup-security-sshd
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Set up the OpenSSH server, open the firewall, and authorize an SSH key
+# omarchy:summary=Set up the OpenSSH server, open the firewall, and authorize SSH keys
 # omarchy:args=[--key=<public-key>] [--gh-keys <github-username>]
 # omarchy:examples=omarchy-setup-security-sshd | omarchy-setup-security-sshd --gh-keys dhh | omarchy-setup-security-sshd --key="ssh-ed25519 AAAA... user@host"
 # omarchy:requires-sudo=true
@@ -38,7 +38,7 @@ while (( $# > 0 )); do
     echo "Usage: omarchy-setup-security-sshd [--key=<public-key>] [--gh-keys <github-username>]"
     echo
     echo "Sets up the OpenSSH server, opens the SSH port in the UFW firewall,"
-    echo "and authorizes an SSH key (from GitHub, pasted, or passed via --key)."
+    echo "and authorizes SSH keys (all keys from GitHub, or one pasted/passed via --key)."
     echo
     echo "Passing --key or --gh-keys skips the prompts, so the command can run"
     echo "unattended from a script or a fresh machine's first login."
@@ -99,12 +99,49 @@ authorize_key() {
   fi
 }
 
+preview_github_keys() {
+  local username="$1" keys="$2" key count=0 import_scope
+
+  echo "GitHub user '$username' publishes these SSH keys:"
+  while IFS= read -r key; do
+    [[ -z $key ]] && continue
+
+    if valid_key "$key"; then
+      echo "  $(ssh-keygen -lf /dev/stdin <<<"$key")"
+      count=$((count + 1))
+    fi
+  done <<<"$keys"
+
+  if (( count == 0 )); then
+    echo -e "\e[31mNo valid SSH keys found for GitHub user '$username'.\e[0m" >&2
+    exit 1
+  fi
+
+  if (( count == 1 )); then
+    import_scope="this key"
+  else
+    import_scope="all $count keys"
+  fi
+
+  echo
+  echo "Importing $import_scope lets anyone holding a matching private key log in"
+  echo "to this machine as '$USER' without a password."
+}
+
 authorize_keys_from_github() {
-  local username="$1" keys added=0
+  local username="$1" confirmation="${2:-}" keys added=0
 
   echo "Fetching keys from https://github.com/$username.keys..."
   if ! keys=$(curl -fsSL "https://github.com/$username.keys") || [[ -z $keys ]]; then
     echo -e "\e[31mCould not fetch any SSH keys for GitHub user '$username'.\e[0m" >&2
+    exit 1
+  fi
+
+  preview_github_keys "$username" "$keys"
+
+  if [[ $confirmation == "confirm" ]] &&
+    ! gum confirm --default=false "Authorize all displayed GitHub SSH keys?"; then
+    echo "GitHub key import cancelled."
     exit 1
   fi
 
@@ -128,7 +165,7 @@ prompt_for_github_user() {
     exit 1
   fi
 
-  authorize_keys_from_github "$username"
+  authorize_keys_from_github "$username" confirm
 }
 
 authorize_pasted_key() {
@@ -198,15 +235,15 @@ if [[ -n $KEY ]]; then
 elif [[ -n $GITHUB_USER ]]; then
   authorize_keys_from_github "$GITHUB_USER"
 else
-  case $(gum choose "Grab key from GitHub" "Paste key manually" --header "How would you like to add your SSH key?") in
-  "Grab key from GitHub") prompt_for_github_user ;;
-  "Paste key manually") authorize_pasted_key ;;
+  case $(gum choose "Import all SSH keys from GitHub" "Paste one SSH key manually" --header "How would you like to authorize SSH access?") in
+  "Import all SSH keys from GitHub") prompt_for_github_user ;;
+  "Paste one SSH key manually") authorize_pasted_key ;;
   *) exit 1 ;;
   esac
 fi
 
 disable_password_auth
 
-echo -e "\e[32m\nPerfect! The SSH server is running and your key is authorized.\e[0m"
+echo -e "\e[32m\nPerfect! The SSH server is running and key-based login is authorized.\e[0m"
 echo "Password logins are off; this machine now accepts authorized keys only."
 echo "You can now connect with: ssh $USER@$(hostname)"

--- a/test/shell.d/setup-security-sshd-test.sh
+++ b/test/shell.d/setup-security-sshd-test.sh
@@ -22,6 +22,28 @@ cat >"$stub_bin/systemctl" <<'STUB'
 #!/bin/bash
 printf 'systemctl %s\n' "$*" >>"${CALL_LOG:?}"
 STUB
+cat >"$stub_bin/curl" <<'STUB'
+#!/bin/bash
+printf '%s\n' "${GITHUB_KEYS:?}"
+STUB
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+case $1 in
+choose)
+  printf '%s\n' "Import all SSH keys from GitHub"
+  ;;
+input)
+  printf '%s\n' "${GITHUB_USER:-simonallfrey}"
+  ;;
+confirm)
+  printf 'gum %s\n' "$*" >>"${CALL_LOG:?}"
+  [[ ${GUM_CONFIRM:-yes} == "yes" ]]
+  ;;
+*)
+  exit 2
+  ;;
+esac
+STUB
 cat >"$stub_bin/sshd" <<'STUB'
 #!/bin/bash
 case $1 in
@@ -63,21 +85,37 @@ chmod +x "$stub_bin"/*
 
 ssh-keygen -q -t ed25519 -N "" -f "$test_dir/key"
 public_key=$(<"$test_dir/key.pub")
+ssh-keygen -q -t ed25519 -N "" -f "$test_dir/second-key"
+second_public_key=$(<"$test_dir/second-key.pub")
+github_keys="$public_key"$'\n'"$second_public_key"
+first_fingerprint=$(ssh-keygen -lf "$test_dir/key.pub" | awk '{ print $2 }')
+second_fingerprint=$(ssh-keygen -lf "$test_dir/second-key.pub" | awk '{ print $2 }')
 
 run_setup() {
   local scenario="$1"
+  local mode="${2:-key}"
   local home="$test_dir/$scenario/home"
   local root="$test_dir/$scenario/root"
+  local -a args
+
+  if [[ $mode == "interactive" ]]; then
+    args=()
+  elif [[ $mode == "github-flag" ]]; then
+    args=(--gh-keys simonallfrey)
+  else
+    args=(--key="$public_key")
+  fi
 
   mkdir -p "$home" "$root"
   : >"$test_dir/$scenario.calls"
 
-  HOME="$home" TEST_ROOT="$root" CALL_LOG="$test_dir/$scenario.calls" \
+  HOME="$home" USER=tester TEST_ROOT="$root" CALL_LOG="$test_dir/$scenario.calls" \
+    GITHUB_KEYS="${GITHUB_KEYS:-}" GUM_CONFIRM="${GUM_CONFIRM:-yes}" \
     SSHD_SYNTAX_VALID="${SSHD_SYNTAX_VALID:-1}" \
     SSHD_PASSWORD_AUTH="${SSHD_PASSWORD_AUTH:-no}" \
     SSHD_KBD_AUTH="${SSHD_KBD_AUTH:-no}" \
     PATH="$stub_bin:$PATH" \
-    bash "$ROOT/bin/omarchy-setup-security-sshd" --key="$public_key"
+    bash "$ROOT/bin/omarchy-setup-security-sshd" "${args[@]}"
 }
 
 output=$(run_setup success)
@@ -87,6 +125,39 @@ grep -qxF "KbdInteractiveAuthentication no" "$config" || fail "SSH setup disable
 grep -qxF "systemctl reload sshd.service" "$test_dir/success.calls" || fail "SSH setup reloads the validated config"
 grep -q "Password logins are off" <<<"$output" || fail "SSH setup reports hardening after it succeeds"
 pass "SSH setup authorizes a key and disables password logins"
+
+output=$(GITHUB_KEYS="$github_keys" run_setup github-interactive interactive)
+authorized_keys="$test_dir/github-interactive/home/.ssh/authorized_keys"
+grep -qxF "$public_key" "$authorized_keys" || fail "GitHub setup authorizes the first published key"
+grep -qxF "$second_public_key" "$authorized_keys" || fail "GitHub setup authorizes the second published key"
+grep -q "GitHub user 'simonallfrey' publishes these SSH keys:" <<<"$output" ||
+  fail "GitHub setup identifies the account whose keys will be imported"
+grep -qF "$first_fingerprint" <<<"$output" || fail "GitHub setup previews the first key fingerprint"
+grep -qF "$second_fingerprint" <<<"$output" || fail "GitHub setup previews the second key fingerprint"
+grep -q "Importing all 2 keys lets anyone holding a matching private key log in" <<<"$output" ||
+  fail "GitHub setup explains that every fetched key grants login access"
+grep -q "to this machine as 'tester' without a password" <<<"$output" ||
+  fail "GitHub setup identifies the local account and passwordless access"
+grep -qxF "gum confirm --default=false Authorize all displayed GitHub SSH keys?" \
+  "$test_dir/github-interactive.calls" || fail "GitHub setup requires a default-no confirmation"
+pass "Interactive GitHub setup previews and confirms all published keys"
+
+if GITHUB_KEYS="$github_keys" GUM_CONFIRM=no run_setup github-cancel interactive \
+  >"$test_dir/github-cancel.output" 2>&1; then
+  fail "GitHub setup must stop when key authorization is declined"
+fi
+[[ ! -e $test_dir/github-cancel/home/.ssh/authorized_keys ]] ||
+  fail "Declining GitHub key authorization must not write authorized_keys"
+grep -q "GitHub key import cancelled" "$test_dir/github-cancel.output" ||
+  fail "GitHub setup reports that the import was cancelled"
+pass "Interactive GitHub setup leaves authorized_keys untouched when declined"
+
+output=$(GITHUB_KEYS="$github_keys" run_setup github-flag github-flag)
+grep -q "Importing all 2 keys lets anyone holding a matching private key log in" <<<"$output" ||
+  fail "Noninteractive GitHub setup explains that every fetched key grants login access"
+! grep -q '^gum confirm ' "$test_dir/github-flag.calls" ||
+  fail "The explicit --gh-keys flag must remain noninteractive"
+pass "Noninteractive GitHub setup discloses the import without prompting"
 
 output=$(SSHD_DUMP_LOWERCASE=1 run_setup success-legacy)
 config="$test_dir/success-legacy/root/etc/ssh/sshd_config.d/10-omarchy-hardening.conf"


### PR DESCRIPTION
## What changed

- Rename the interactive option so it says that every SSH key published by the GitHub account will be imported.
- Preview each fetched key's fingerprint and explain that every matching private-key holder gets passwordless login as the local user.
- Require a default-no confirmation before the interactive path writes any keys.
- Keep the explicit `--gh-keys` path unattended while giving it the same preview and disclosure.
- Remove singular-key wording from the command help and success message.

## Why

The current prompt asks how to add "your SSH key" and offers to "Grab key from GitHub", but `https://github.com/<username>.keys` can return multiple keys and the command authorizes all of them. The singular wording does not make the resulting login authorization clear before it is applied.

## Tests

- `test/shell.d/setup-security-sshd-test.sh`
- `./test/cli`
