### PR TITLE
Stop factory-reset from sudoing the path that started it

### DIFF
--- a/bin/omarchy-system-factory-reset
+++ b/bin/omarchy-system-factory-reset
@@ -34,12 +34,17 @@ TOP_MNT=/run/omarchy-system-factory-reset/top
 NEXT_NAME=@omarchy-reset-next
 LOG_FILE=/var/log/omarchy-system-factory-reset.log
 
+# The path etc/sudoers.d names for other helpers, and the path this must
+# elevate even when a copy on PATH started the script. sudo runs this path,
+# not $0, so a file the user can write cannot become the root half.
+PACKAGED_PATH=/usr/bin/omarchy-system-factory-reset
+
 # Self-elevate so the menu entry (and a bare shell invocation) need no sudo
 # prefix. The caller's gum theme vars are forwarded as `env` arguments rather
 # than via `sudo -E`, so styling survives even under an env_reset sudoers.
 if (( EUID != 0 )); then
   mapfile -t gum_env < <(env | grep '^GUM_' || true)
-  exec sudo env "${gum_env[@]}" "$0" "$@"
+  exec sudo env "${gum_env[@]}" "$PACKAGED_PATH" "$@"
 fi
 
 export PATH="$OMARCHY_PATH/bin:$PATH"

--- a/test/shell.d/factory-reset-packaged-path-test.sh
+++ b/test/shell.d/factory-reset-packaged-path-test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+helper="$ROOT/bin/omarchy-system-factory-reset"
+
+grep -Fx 'PACKAGED_PATH=/usr/bin/omarchy-system-factory-reset' "$helper" >/dev/null ||
+  fail "omarchy-system-factory-reset names the packaged path"
+
+grep -F 'exec sudo env "${gum_env[@]}" "$PACKAGED_PATH" "$@"' "$helper" >/dev/null ||
+  fail "omarchy-system-factory-reset elevates the packaged path, not \$0"
+
+if grep -F 'exec sudo env "${gum_env[@]}" "$0" "$@"' "$helper" >/dev/null; then
+  fail "omarchy-system-factory-reset no longer sudoes \$0"
+fi
+
+pass "factory-reset elevates /usr/bin/omarchy-system-factory-reset"
+
+if (( EUID == 0 )); then
+  pass "running as root; skipping the elevation checks, which would start a real reset"
+  exit 0
+fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >"$ELEVATION_LOG"
+SH
+chmod +x "$stub_bin/sudo"
+
+copy="$stub_bin/omarchy-system-factory-reset"
+cp "$helper" "$copy"
+chmod +x "$copy"
+
+elevation_log="$test_tmp/elevation"
+: >"$elevation_log"
+
+# A copy on PATH is how a writable directory in front of /usr/bin would start
+# this. $0 is that copy. sudo must still be asked to run the packaged file.
+env -i HOME="$test_tmp" USER=tester PATH="$stub_bin:/usr/bin" \
+  ELEVATION_LOG="$elevation_log" \
+  "$copy"
+
+got=$(cat "$elevation_log")
+[[ $got == "sudo env /usr/bin/omarchy-system-factory-reset" ]] ||
+  fail "a writable copy still elevates the packaged path" "got: $got"
+
+pass "a writable copy sudoes /usr/bin/omarchy-system-factory-reset, not itself"
+
+: >"$elevation_log"
+env -i HOME="$test_tmp" USER=tester PATH="$stub_bin:/usr/bin" \
+  ELEVATION_LOG="$elevation_log" \
+  bash -c 'omarchy-system-factory-reset'
+
+got=$(cat "$elevation_log")
+[[ $got == "sudo env /usr/bin/omarchy-system-factory-reset" ]] ||
+  fail "a PATH lookup still elevates the packaged path" "got: $got"
+
+pass "a PATH lookup sudoes the packaged path"
+
+: >"$elevation_log"
+env -i HOME="$test_tmp" USER=tester PATH="$stub_bin:/usr/bin" \
+  GUM_FOREGROUND=212 ELEVATION_LOG="$elevation_log" \
+  "$copy"
+
+got=$(cat "$elevation_log")
+[[ $got == "sudo env GUM_FOREGROUND=212 /usr/bin/omarchy-system-factory-reset" ]] ||
+  fail "gum theme vars are still forwarded" "got: $got"
+
+pass "gum theme vars are forwarded on the packaged path"


### PR DESCRIPTION
`omarchy-system-factory-reset` raises itself like this:

```
if (( EUID != 0 )); then
  mapfile -t gum_env < <(env | grep '^GUM_' || true)
  exec sudo env "${gum_env[@]}" "$0" "$@"
fi
```

`$0` is whichever path started the script. On bash that is the full path even when the command was found by name on PATH. A file of the same name in a directory the user can write, sitting in front of `/usr/bin`, is then what sudo runs as root. `omarchy-dns` and `omarchy-theme-set-browser-policy` already avoid this by re-execing a fixed `/usr/bin/...` path. Factory-reset did not.

The prompt still asks for a password. The bug is that the password is for a path the caller can write, not for the packaged helper.

What changed:

- The privileged half always runs `/usr/bin/omarchy-system-factory-reset`.
- Gum theme vars are still forwarded the same way.

Tests: new `test/shell.d/factory-reset-packaged-path-test.sh`. A source check pins the packaged path. A writable copy, and a PATH lookup of that copy, both ask sudo to run `/usr/bin/omarchy-system-factory-reset` rather than the copy. Gum vars still ride along. All 4 pass. The elevation cases stub sudo, so nothing here starts a real reset.