### PR TITLE
Stop privileged copies from following a caller-controlled OMARCHY_PATH

### DIFF
--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -4,6 +4,56 @@
 # omarchy:requires-sudo=true
 # omarchy:args=[--force] [--no-rebuild]
 
+# Privileged copies must not follow a caller-controlled OMARCHY_PATH. The
+# packaged tree is always trusted. A linked checkout is trusted only when
+# /etc/omarchy.conf is a root-owned regular file whose only line names that
+# checkout, which is what omarchy-dev-link writes. omarchy-plymouth-set uses
+# the same rule. Keep this block in step with omarchy-refresh-limine,
+# omarchy-refresh-pacman, and omarchy-toggle-hybrid-gpu.
+omarchy_privileged_source_root() {
+  local packaged=/usr/share/omarchy
+  local path=${OMARCHY_PATH:-$packaged}
+  local conf=/etc/omarchy.conf
+  local uid mode
+  local -a lines
+
+  if [[ $path == "$packaged" ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  if [[ ! -f $conf || -L $conf ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  uid=$(stat -c %u -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  mode=$(stat -c %a -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( uid != 0 )) || (( 8#$mode & 0022 )); then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  mapfile -t lines <"$conf" || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( ${#lines[@]} == 1 )) && [[ ${lines[0]} == "export OMARCHY_PATH=\"$path\"" ]]; then
+    printf '%s\n' "$path"
+    return
+  fi
+
+  printf '%s\n' "$packaged"
+}
+
+SOURCE_ROOT=$(omarchy_privileged_source_root)
+
 FORCE=false
 NO_REBUILD=false
 for arg in "$@"; do
@@ -89,7 +139,7 @@ echo "Adding resume hook to $MKINITCPIO_CONF"
 echo "HOOKS+=(resume)" | sudo tee "$MKINITCPIO_CONF" >/dev/null
 
 # Ensure keyboard backlight doesn't prevent sleep
-sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
+sudo cp -p "$SOURCE_ROOT/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
 
 # Add resume= kernel parameters so the initramfs resume hook knows where to find the
 # hibernation image. Without these, resume happens late (after GPU drivers load) and fails.

--- a/bin/omarchy-refresh-limine
+++ b/bin/omarchy-refresh-limine
@@ -3,6 +3,56 @@
 # omarchy:summary=Overwrite the user config for the Limine bootloader and rebuild it.
 # omarchy:requires-sudo=true
 
+# Privileged copies must not follow a caller-controlled OMARCHY_PATH. The
+# packaged tree is always trusted. A linked checkout is trusted only when
+# /etc/omarchy.conf is a root-owned regular file whose only line names that
+# checkout, which is what omarchy-dev-link writes. omarchy-plymouth-set uses
+# the same rule. Keep this block in step with omarchy-refresh-pacman,
+# omarchy-toggle-hybrid-gpu, and omarchy-hibernation-setup.
+omarchy_privileged_source_root() {
+  local packaged=/usr/share/omarchy
+  local path=${OMARCHY_PATH:-$packaged}
+  local conf=/etc/omarchy.conf
+  local uid mode
+  local -a lines
+
+  if [[ $path == "$packaged" ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  if [[ ! -f $conf || -L $conf ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  uid=$(stat -c %u -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  mode=$(stat -c %a -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( uid != 0 )) || (( 8#$mode & 0022 )); then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  mapfile -t lines <"$conf" || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( ${#lines[@]} == 1 )) && [[ ${lines[0]} == "export OMARCHY_PATH=\"$path\"" ]]; then
+    printf '%s\n' "$path"
+    return
+  fi
+
+  printf '%s\n' "$packaged"
+}
+
+SOURCE_ROOT=$(omarchy_privileged_source_root)
+
 legacy_uki="/boot/EFI/Linux/$(cat /etc/machine-id)_linux.efi"
 
 if sudo test -f /boot/EFI/Linux/omarchy_linux.efi && sudo test -f "$legacy_uki"; then
@@ -13,7 +63,7 @@ echo "Resetting limine config"
 
 sudo mv /boot/limine.conf /boot/limine.conf.bak
 
-sudo cp "$OMARCHY_PATH/default/limine/limine.conf" /boot/limine.conf
+sudo cp "$SOURCE_ROOT/default/limine/limine.conf" /boot/limine.conf
 
 sudo limine-update
 sudo limine-snapper-sync

--- a/bin/omarchy-refresh-pacman
+++ b/bin/omarchy-refresh-pacman
@@ -3,6 +3,56 @@
 # omarchy:summary=Overwrite the package configuration for /etc/pacman with the Omarchy default of using its dedicated mirrors and repositories, then update all packages.
 # omarchy:requires-sudo=true
 
+# Privileged copies must not follow a caller-controlled OMARCHY_PATH. The
+# packaged tree is always trusted. A linked checkout is trusted only when
+# /etc/omarchy.conf is a root-owned regular file whose only line names that
+# checkout, which is what omarchy-dev-link writes. omarchy-plymouth-set uses
+# the same rule. Keep this block in step with omarchy-refresh-limine,
+# omarchy-toggle-hybrid-gpu, and omarchy-hibernation-setup.
+omarchy_privileged_source_root() {
+  local packaged=/usr/share/omarchy
+  local path=${OMARCHY_PATH:-$packaged}
+  local conf=/etc/omarchy.conf
+  local uid mode
+  local -a lines
+
+  if [[ $path == "$packaged" ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  if [[ ! -f $conf || -L $conf ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  uid=$(stat -c %u -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  mode=$(stat -c %a -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( uid != 0 )) || (( 8#$mode & 0022 )); then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  mapfile -t lines <"$conf" || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( ${#lines[@]} == 1 )) && [[ ${lines[0]} == "export OMARCHY_PATH=\"$path\"" ]]; then
+    printf '%s\n' "$path"
+    return
+  fi
+
+  printf '%s\n' "$packaged"
+}
+
+SOURCE_ROOT=$(omarchy_privileged_source_root)
+
 sudo cp -f /etc/pacman.conf /etc/pacman.conf.bak
 sudo cp -f /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
 
@@ -16,8 +66,8 @@ fi
 echo "Setting channel to $channel"
 echo
 
-sudo cp -f "$OMARCHY_PATH/default/pacman/pacman-$channel.conf" /etc/pacman.conf
-sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$channel" /etc/pacman.d/mirrorlist
+sudo cp -f "$SOURCE_ROOT/default/pacman/pacman-$channel.conf" /etc/pacman.conf
+sudo cp -f "$SOURCE_ROOT/default/pacman/mirrorlist-$channel" /etc/pacman.d/mirrorlist
 
 # Allow user customization of /etc/pacman.conf before the upgrade runs
 omarchy-hook pre-refresh-pacman

--- a/bin/omarchy-toggle-hybrid-gpu
+++ b/bin/omarchy-toggle-hybrid-gpu
@@ -3,6 +3,56 @@
 # omarchy:summary=Toggle dedicated vs integrated GPU mode via supergfxd (for hybrid gpu laptops, like Asus G14).
 # omarchy:requires-sudo=true
 
+# Privileged copies must not follow a caller-controlled OMARCHY_PATH. The
+# packaged tree is always trusted. A linked checkout is trusted only when
+# /etc/omarchy.conf is a root-owned regular file whose only line names that
+# checkout, which is what omarchy-dev-link writes. omarchy-plymouth-set uses
+# the same rule. Keep this block in step with omarchy-refresh-limine,
+# omarchy-refresh-pacman, and omarchy-hibernation-setup.
+omarchy_privileged_source_root() {
+  local packaged=/usr/share/omarchy
+  local path=${OMARCHY_PATH:-$packaged}
+  local conf=/etc/omarchy.conf
+  local uid mode
+  local -a lines
+
+  if [[ $path == "$packaged" ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  if [[ ! -f $conf || -L $conf ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  uid=$(stat -c %u -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  mode=$(stat -c %a -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( uid != 0 )) || (( 8#$mode & 0022 )); then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  mapfile -t lines <"$conf" || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( ${#lines[@]} == 1 )) && [[ ${lines[0]} == "export OMARCHY_PATH=\"$path\"" ]]; then
+    printf '%s\n' "$path"
+    return
+  fi
+
+  printf '%s\n' "$packaged"
+}
+
+SOURCE_ROOT=$(omarchy_privileged_source_root)
+
 if omarchy-cmd-missing supergfxctl; then
   omarchy-pkg-add supergfxctl
 
@@ -60,12 +110,12 @@ case "$gpu_mode" in
 
     # Force igpu mode after system sleep (or dgpu could get activated)
     sudo mkdir -p /usr/lib/systemd/system-sleep
-    sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/force-igpu" /usr/lib/systemd/system-sleep/
+    sudo cp -p "$SOURCE_ROOT/default/systemd/system-sleep/force-igpu" /usr/lib/systemd/system-sleep/
 
     # Delay supergfxd startup to avoid race condition with display manager
     # that can cause system freeze when booting in Integrated mode
     sudo mkdir -p /etc/systemd/system/supergfxd.service.d
-    sudo cp -p "$OMARCHY_PATH/default/systemd/system/supergfxd.service.d/delay-start.conf" /etc/systemd/system/supergfxd.service.d/
+    sudo cp -p "$SOURCE_ROOT/default/systemd/system/supergfxd.service.d/delay-start.conf" /etc/systemd/system/supergfxd.service.d/
 
     omarchy-system-reboot
   fi

--- a/test/shell.d/privileged-source-copy-test.sh
+++ b/test/shell.d/privileged-source-copy-test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+helpers=(
+  "$ROOT/bin/omarchy-refresh-limine"
+  "$ROOT/bin/omarchy-refresh-pacman"
+  "$ROOT/bin/omarchy-toggle-hybrid-gpu"
+  "$ROOT/bin/omarchy-hibernation-setup"
+)
+
+for helper in "${helpers[@]}"; do
+  grep -F 'omarchy_privileged_source_root()' "$helper" >/dev/null ||
+    fail "$(basename "$helper") resolves privileged copies through a trusted source root"
+  if grep -E 'sudo cp.*\$OMARCHY_PATH/' "$helper" >/dev/null; then
+    fail "$(basename "$helper") no longer sudo-copies from a caller-controlled OMARCHY_PATH"
+  fi
+done
+
+grep -F 'sudo cp "$SOURCE_ROOT/default/limine/limine.conf" /boot/limine.conf' \
+  "$ROOT/bin/omarchy-refresh-limine" >/dev/null ||
+  fail "omarchy-refresh-limine copies limine.conf from the trusted source root"
+
+grep -F 'sudo cp -f "$SOURCE_ROOT/default/pacman/pacman-$channel.conf" /etc/pacman.conf' \
+  "$ROOT/bin/omarchy-refresh-pacman" >/dev/null ||
+  fail "omarchy-refresh-pacman copies pacman.conf from the trusted source root"
+
+grep -F 'sudo cp -p "$SOURCE_ROOT/default/systemd/system-sleep/force-igpu"' \
+  "$ROOT/bin/omarchy-toggle-hybrid-gpu" >/dev/null ||
+  fail "omarchy-toggle-hybrid-gpu copies force-igpu from the trusted source root"
+
+grep -F 'sudo cp -p "$SOURCE_ROOT/default/systemd/system-sleep/keyboard-backlight"' \
+  "$ROOT/bin/omarchy-hibernation-setup" >/dev/null ||
+  fail "omarchy-hibernation-setup copies keyboard-backlight from the trusted source root"
+
+pass "privileged copies read the packaged tree, not a caller-controlled OMARCHY_PATH"
+
+if (( EUID == 0 )); then
+  pass "running as root; skipping the elevation checks, which would rewrite boot and pacman files"
+  exit 0
+fi
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+evil="$test_tmp/evil-tree"
+mkdir -p "$stub_bin" \
+  "$evil/default/limine" \
+  "$evil/default/pacman"
+
+printf 'not the packaged limine\n' >"$evil/default/limine/limine.conf"
+printf 'not the packaged pacman\n' >"$evil/default/pacman/pacman-stable.conf"
+printf 'not the packaged mirrorlist\n' >"$evil/default/pacman/mirrorlist-stable"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$ELEVATION_LOG"
+SH
+chmod +x "$stub_bin/sudo"
+
+cat >"$stub_bin/omarchy-hook" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$stub_bin/omarchy-hook"
+
+elevation_log="$test_tmp/elevation"
+: >"$elevation_log"
+
+HOME="$test_tmp" OMARCHY_PATH="$evil" ELEVATION_LOG="$elevation_log" \
+  PATH="$stub_bin:/usr/bin" \
+  "$ROOT/bin/omarchy-refresh-limine" >/dev/null 2>&1 || true
+
+if grep -F "$evil" "$elevation_log"; then
+  fail "omarchy-refresh-limine does not sudo-copy from a poisoned OMARCHY_PATH" \
+    "$(cat "$elevation_log")"
+fi
+grep -F "sudo cp /usr/share/omarchy/default/limine/limine.conf /boot/limine.conf" "$elevation_log" >/dev/null ||
+  fail "omarchy-refresh-limine sudo-copies the packaged limine.conf" \
+    "$(cat "$elevation_log")"
+
+pass "omarchy-refresh-limine ignores a poisoned OMARCHY_PATH"
+
+: >"$elevation_log"
+HOME="$test_tmp" OMARCHY_PATH="$evil" ELEVATION_LOG="$elevation_log" \
+  PATH="$stub_bin:/usr/bin" \
+  "$ROOT/bin/omarchy-refresh-pacman" stable >/dev/null 2>&1 || true
+
+if grep -F "$evil" "$elevation_log"; then
+  fail "omarchy-refresh-pacman does not sudo-copy from a poisoned OMARCHY_PATH" \
+    "$(cat "$elevation_log")"
+fi
+grep -F "sudo cp -f /usr/share/omarchy/default/pacman/pacman-stable.conf /etc/pacman.conf" "$elevation_log" >/dev/null ||
+  fail "omarchy-refresh-pacman sudo-copies the packaged pacman.conf" \
+    "$(cat "$elevation_log")"
+
+pass "omarchy-refresh-pacman ignores a poisoned OMARCHY_PATH"


### PR DESCRIPTION
`omarchy-refresh-limine`, `omarchy-refresh-pacman`, `omarchy-toggle-hybrid-gpu`, and `omarchy-hibernation-setup` expand `$OMARCHY_PATH` as the user, then `sudo cp` that path onto a root-owned target:

```
sudo cp "$OMARCHY_PATH/default/limine/limine.conf" /boot/limine.conf
sudo cp -f "$OMARCHY_PATH/default/pacman/pacman-$channel.conf" /etc/pacman.conf
sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/force-igpu" /usr/lib/systemd/system-sleep/
sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
```

A caller who sets `OMARCHY_PATH` to a tree they can write, then types the sudo password for "refresh Limine" or "refresh pacman", installs their file as the bootloader config, the package config, or a sleep hook systemd later runs as root. `omarchy-plymouth-set` already refuses a user-owned source tree unless a root-owned `/etc/omarchy.conf` names that checkout. These copies did not.

The prompt still asks for a password. The bug is that the copy source is a path the caller chose.

What changed:

- All four helpers copy from `/usr/share/omarchy` by default.
- A linked checkout is used only when `/etc/omarchy.conf` is a root-owned regular file whose only line names that checkout, which is what `omarchy-dev-link` writes. Same rule as plymouth-set.

Tests: new `test/shell.d/privileged-source-copy-test.sh`. A source check pins every remaining sudo-copy. With a fake tree in `OMARCHY_PATH`, refresh-limine and refresh-pacman still ask sudo to copy from `/usr/share/omarchy`. All 3 pass. The elevation cases stub sudo, so nothing here writes `/boot` or `/etc`.