### PR TITLE
Give the Secret portal a provider so Chromium can open its password store

### DIFF
--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -1,5 +1,6 @@
 run_logged "$OMARCHY_INSTALL/config/theme-system.sh"
 run_logged "$OMARCHY_INSTALL/config/browser-policy.sh"
+run_logged "$OMARCHY_INSTALL/config/secret-portal.sh"
 run_logged "$OMARCHY_INSTALL/config/increase-lockout-limit.sh"
 run_logged "$OMARCHY_INSTALL/config/lockscreen-pam.sh"
 run_logged "$OMARCHY_INSTALL/config/fix-powerprofilesctl-shebang.sh"

--- a/install/config/secret-portal.sh
+++ b/install/config/secret-portal.sh
@@ -1,0 +1,26 @@
+# Chromium asks xdg-desktop-portal for org.freedesktop.impl.portal.Secret to get
+# the key it encrypts saved passwords and cookies with. The only backend that
+# implements Secret is gnome-keyring.portal, and it ships gated `UseIn=gnome`,
+# so in a Hyprland session nothing answers: the browser records
+# os_crypt.portal.prev_init_success = false and greets the user with "Something
+# went wrong when opening your profile. Some features may be unavailable."
+#
+# Migration 1784508556 already noted that "on Hyprland the xdg-desktop-portal
+# Secret backend has no provider and fails" and pinned --password-store so the
+# backend at least stops changing underneath people. This gives it the provider,
+# which is the other half: gnome-keyring is already a base package and is
+# running as the secrets service, it was simply never wired to the portal.
+#
+# A file at /etc replaces the desktop-specific hyprland-portals.conf rather than
+# merging with it, so the Hyprland defaults are restated here.
+if [[ ! -f /etc/xdg-desktop-portal/portals.conf ]]; then
+  install -d -m 755 /etc/xdg-desktop-portal
+  cat >/etc/xdg-desktop-portal/portals.conf <<'PORTALS'
+# Omarchy: hand the Secret interface to gnome-keyring. Without it Chromium's
+# password store cannot initialise and the browser reports a broken profile.
+[preferred]
+default=hyprland;gtk
+org.freedesktop.impl.portal.Secret=gnome-keyring
+PORTALS
+  chmod 644 /etc/xdg-desktop-portal/portals.conf
+fi

--- a/migrations/1788162060.sh
+++ b/migrations/1788162060.sh
@@ -1,0 +1,24 @@
+echo "Give the Secret portal a provider so Chromium can open its password store"
+
+# Chromium asks xdg-desktop-portal for org.freedesktop.impl.portal.Secret. The
+# only backend implementing it is gnome-keyring.portal, gated `UseIn=gnome`, so
+# on Hyprland nothing answers and the browser reports a broken profile:
+# "Something went wrong when opening your profile. Some features may be
+# unavailable." Migration 1784508556 pinned --password-store so the backend
+# stopped changing; this supplies the provider it was asking for.
+#
+# Only written when the file is absent: a portals.conf already in place is the
+# user's, and replacing the Secret line under them could move where their
+# existing secrets are read from.
+if [[ ! -f /etc/xdg-desktop-portal/portals.conf ]]; then
+  sudo install -d -m 755 /etc/xdg-desktop-portal
+  sudo tee /etc/xdg-desktop-portal/portals.conf >/dev/null <<'PORTALS'
+# Omarchy: hand the Secret interface to gnome-keyring. Without it Chromium's
+# password store cannot initialise and the browser reports a broken profile.
+[preferred]
+default=hyprland;gtk
+org.freedesktop.impl.portal.Secret=gnome-keyring
+PORTALS
+  sudo chmod 644 /etc/xdg-desktop-portal/portals.conf
+  systemctl --user restart xdg-desktop-portal 2>/dev/null || true
+fi


### PR DESCRIPTION
## The symptom

Chrome on a fresh Omarchy greets the user with:

> Something went wrong when opening your profile. Some features may be unavailable.

## The cause

Chromium asks xdg-desktop-portal for `org.freedesktop.impl.portal.Secret` to get the key it encrypts saved passwords and cookies with. The only backend implementing that interface is `gnome-keyring.portal`, and it ships gated:

```ini
Interfaces=org.freedesktop.impl.portal.Secret
UseIn=gnome
```

The session is Hyprland, and `hyprland-portals.conf` prefers `hyprland;gtk` — neither of which implements Secret. So nothing answers, and Chromium records its own failure in `~/.config/google-chrome/Local State`:

```json
"os_crypt": {"portal": {"prev_desktop": "Hyprland", "prev_init_success": false}}
```

Migration `1784508556` already found this half of it —

> Chromium-based browsers auto-detect their os_crypt backend; on Hyprland the xdg-desktop-portal Secret backend has no provider and fails

— and pinned `--password-store=gnome-libsecret` so the backend stopped changing underneath people, which is what was costing them their cookies. This supplies the provider it was asking for. `gnome-keyring` is already in `omarchy-base.packages` and is already running as the `org.freedesktop.secrets` service; it was simply never wired to the portal.

## Measured

Omarchy 4.0.1-1, Hyprland 0.56.2, Chrome 141.

| | Secret portal | `prev_init_success` |
|---|---|---|
| before | no reply | `false` |
| after | `v u 1` | `true` |

```bash
busctl --user get-property org.freedesktop.portal.Desktop \
  /org/freedesktop/portal/desktop org.freedesktop.portal.Secret version
```

The secrets service itself was never broken — `secret-tool store` / `lookup` round-trips correctly either way. Only the portal route was unserved.

## The change

- `install/config/secret-portal.sh` for fresh installs, wired into `install/config/all.sh`
- a migration for existing machines

Both write only when `/etc/xdg-desktop-portal/portals.conf` is absent: a file already there is the user's, and changing the Secret assignment under them could move where existing secrets are read from. A config at `/etc` replaces the desktop-specific `hyprland-portals.conf` rather than merging with it, so the Hyprland defaults are restated alongside the new line.

## Caveat

Measurements above were taken with the same content at `~/.config/xdg-desktop-portal/portals.conf`, which takes precedence over `/etc`. The file contents and the resulting portal resolution are identical; only the path differs.