### PR TITLE
Add Oma, voice control for the desktop, as an optional service

### DIFF
--- a/bin/omarchy-install-service-voice
+++ b/bin/omarchy-install-service-voice
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# omarchy:summary=Install Oma, voice control for the desktop, and enable its bar widget.
+
+# Speech becomes actions rather than text: you say "put my email on workspace
+# three and go there" and the windows move. Voxtype already covers dictation on
+# F9; this is the other half, on SUPER + SHIFT + V.
+#
+# The add-on lives outside the omarchy package because it carries a Python
+# daemon, a user service and a paid API dependency, none of which belong in the
+# base install. This script is the supported way in, following the same shape as
+# the other optional services.
+
+set -euo pipefail
+
+REPO="https://github.com/wombatoperator/omarchy-voice.git"
+SRC="${XDG_DATA_HOME:-$HOME/.local/share}/omarchy-voice-src"
+
+echo -e "\nInstalling dependencies..."
+# websockets drives the realtime session; wtype types and presses keys; grim and
+# tesseract are how it reads the screen back to you.
+omarchy-pkg-add python-websockets wtype grim tesseract tesseract-data-eng
+
+echo -e "\nFetching Oma..."
+if [[ -d $SRC/.git ]]; then
+  git -C "$SRC" pull --ff-only
+else
+  rm -rf "$SRC"
+  git clone --depth 1 "$REPO" "$SRC"
+fi
+
+echo -e "\nInstalling..."
+"$SRC/install.sh"
+
+echo -e "\nAdding the listening indicator to the bar..."
+omarchy-plugin-enable voice.indicator 2>/dev/null ||
+  omarchy bar put voice.indicator --section right 2>/dev/null ||
+  echo "  Add it later with: omarchy bar put voice.indicator --section right"
+
+cat <<'DONE'
+
+Oma is installed.
+
+  1. Put your OpenAI API key in ~/.config/omarchy-voice/env:
+       OPENAI_API_KEY=sk-...
+  2. systemctl --user start omarchy-voice
+  3. Press SUPER + SHIFT + V and talk to it.
+
+  omarchy-voice doctor   checks every moving part
+  omarchy-voice log -f   shows what it heard and did
+
+The microphone starts off. While it is on, room audio streams to OpenAI; while
+it is off, no recorder is running at all.
+DONE


### PR DESCRIPTION
Voxtype turns speech into text on F9. This is the other half — speech into **actions** — on `SUPER + SHIFT + V`.

```
you   "put my email on workspace three, then go there"
      → hypr_query(clients)
      → hl.dsp.window.move({ workspace = "3", window = "address:0x55d4..." })
      → hl.dsp.focus({ workspace = "3" })
it    "Moved HEY to workspace 3."
```

```
you   "what's going on in the news today?"
      → compose_windows(columns, [AP News, Reuters, BBC News])
      → read_screen
it    "Reuters shows US strikes on Iran's Larak Island, with a claim Kharg
       Island was also targeted..."
```

## Shape

One script, following `sunshine` / `tailscale` / `nordvpn`: opt-in, nothing added to the base install, no new dependency for anyone who doesn't run it. The daemon lives in its own repository because it carries a Python service, a user unit and a paid API dependency — none of which belong in omarchy itself.

**Diff is 1 file, +54.**

## Why an LLM rather than a phrase grammar

What it knows about the machine is read *off the machine* instead of remembered:

| Source | Contributes |
|---|---|
| `/usr/share/hypr/stubs/hl.meta.lua` | every dispatcher, from Hyprland's own type stub |
| `default/hypr/bindings/*.lua` | version-correct call syntax |
| `omarchy commands --json` | the CLI surface |
| `hyprctl -j` + `.desktop` files | live monitors, workspaces, windows, apps |

So it writes `hl.dsp.focus({ workspace = "3" })` rather than the `hyprctl dispatch workspace 1` syntax 0.56 retired — and stays correct across updates instead of aging into wrong guesses. `omarchy-voice manifest` prints exactly what it knows.

## Safety

An open microphone is untrusted input, so the model's decisions are not trusted blindly. Every tool call passes a local policy gate first:

- **Refused outright:** `rm -rf`, `dd`, `mkfs`, `sudo`, `pkexec`, `ssh`, `passwd`, curl-piped-to-shell, `git push`
- **Held for spoken confirmation:** shutdown, reboot, suspend, package installs, `omarchy update`, closing everything
- **Blocked as process execution:** `hl.dsp.exec_cmd` / `exec_raw`, and command lines passed to app launch. Apps launch by desktop id; URLs must be http(s)
- **Off by default:** the shell tool

Confirmation is not the model's to grant: a gated tool and `confirm_last` in the same response is rejected, the phrase is matched as a whole utterance so "don't confirm" does not confirm, and the bar-widget path releases the hold locally without asking the model at all.

The microphone starts off and there is no always-on mode. While it is on, room audio streams to OpenAI and the bar says so; while it is off, no recorder process exists — muting kills `pw-record` rather than capturing and discarding.

## Happy to adjust

If you'd rather this were an issue, a wiki entry, or shaped differently — say so and I'll follow. Opening it as a PR because that seemed the most concrete way to put it in front of you.

Repository: https://github.com/wombatoperator/omarchy-voice · MIT · 154 tests