### PR TITLE
Clear special permission bits during Windows VM migration

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,7 +580,8 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  # Clear special bits explicitly: numeric chmod modes leave them unchanged.
+  chmod u=rwx,go=,a-s -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
@@ -1015,7 +1016,7 @@ prepare_user_mount_sources() {
     echo "omarchy-windows-vm: storage and shared must be different directories" >&2
     return 1
   }
-  chmod 0700 -- "$storage" "$shared"
+  chmod u=rwx,go=,a-s -- "$storage" "$shared"
 }
 
 storage_space_path() {

--- a/test/shell.d/windows-vm-compose-test.sh
+++ b/test/shell.d/windows-vm-compose-test.sh
@@ -112,6 +112,7 @@ pass "pkexec target is only the canonical packaged regular file, never a PATH sy
 reset_case
 external_shared="$TMPDIR/external-shared"
 mkdir -m 0755 -p "$HOME/.windows" "$external_shared" "$HOME/.config/windows"
+chmod g+s "$external_shared"
 ln -s "$external_shared" "$HOME/Windows"
 touch "$HOME/.windows/existing-disk" "$external_shared/existing-shared-file"
 LEGACY_COMPOSE_FILE="$HOME/.config/windows/docker-compose.yml"


### PR DESCRIPTION
## Problem

Existing Windows VM installs can fail to start when the shared directory has the setgid bit set, for example mode 2700. The migration hardens the directory with numeric `chmod 0700`, but numeric modes leave unspecified special bits unchanged. The subsequent exact-mode check sees 2700 instead of 700 and aborts the migration, causing the Quickshell Windows launcher to report only that startup failed.

## Solution

Use an explicit symbolic mode that sets owner permissions, removes group/other permissions, and clears all special bits before validating the mount sources. Apply the same hardening to both the user-side and privileged migration paths.

## Testing

- `bash test/shell.d/windows-vm-compose-test.sh`
- `./test/all` (the existing environment-dependent failures remain in `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`, and `windows-vm-mount-boundary-test.sh`)

The focused Windows VM test now covers migration from a setgid shared directory.