### PR TITLE
Read omarchy-version from the pacman local db

### DIFF
--- a/bin/omarchy-version
+++ b/bin/omarchy-version
@@ -17,10 +17,19 @@ if [[ $omarchy_path != "/usr/share/omarchy" ]]; then
   exit 0
 fi
 
+# pacman -Q boots ALPM (~200ms) for a one-line version. The local db is
+# world-readable directories named <pkg>-<ver>. Tests override the path.
+pacman_local=${OMARCHY_PACMAN_LOCAL:-/var/lib/pacman/local}
+
+version=
 # The edge channel installs omarchy-dev instead of omarchy, so check both.
 for package in omarchy-dev omarchy; do
-  version=$(pacman -Q "$package" 2>/dev/null | awk '{ print $2 }')
-  [[ -n $version ]] && break
+  for dir in "$pacman_local/${package}"-[0-9]*; do
+    [[ -d $dir ]] || continue
+    version=${dir##*/}
+    version=${version#"${package}-"}
+    break 2
+  done
 done
 
 [[ -n $version ]] || exit 1

--- a/test/shell.d/version-test.sh
+++ b/test/shell.d/version-test.sh
@@ -7,46 +7,61 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
-stub_bin="$test_tmp/bin"
-mkdir -p "$stub_bin"
+# Packaged installs used to call `pacman -Q`, which boots ALPM (~200ms) on every
+# fastfetch. Version now reads /var/lib/pacman/local directly; tests drive a
+# fake local db so we never need a stubbed pacman.
+local_db="$test_tmp/pacman-local"
 
-# The edge channel installs omarchy-dev. Older builds did not declare
-# provides=(omarchy), so a query for plain omarchy finds nothing there.
-cat >"$stub_bin/pacman" <<'STUB'
-#!/bin/bash
-[[ $1 == "-Q" ]] || exit 1
-shift
-for package in "$@"; do
-  case ",${OMARCHY_TEST_PACKAGES:-}," in
-    *",$package,"*)
-      echo "$package ${OMARCHY_TEST_VERSION:-4.0.0-1}"
-      exit 0
-      ;;
-  esac
-done
-echo "error: package '$1' was not found" >&2
-exit 1
-STUB
-chmod +x "$stub_bin/pacman"
+reset_db() {
+  rm -rf "$local_db"
+  mkdir -p "$local_db"
+}
+
+install_pkg() {
+  mkdir -p "$local_db/${1}-${2}"
+}
 
 version() {
-  OMARCHY_TEST_PACKAGES="$1" \
-    OMARCHY_PATH="${2:-/usr/share/omarchy}" \
-    PATH="$stub_bin:$PATH" \
+  OMARCHY_PACMAN_LOCAL="$local_db" \
+    OMARCHY_PATH="${1:-/usr/share/omarchy}" \
     "$ROOT/bin/omarchy-version"
 }
 
-[[ $(version omarchy) == "4.0.0-1" ]] || fail "version reports the stable package"
+reset_db
+install_pkg omarchy 4.0.0-1
+[[ $(version) == "4.0.0-1" ]] || fail "version reports the stable package"
 pass "version reports the stable package"
 
-[[ $(version omarchy-dev) == "4.0.0-1" ]] || fail "version reports the edge package"
+reset_db
+install_pkg omarchy-dev 4.0.0-1
+[[ $(version) == "4.0.0-1" ]] || fail "version reports the edge package"
 pass "version reports the edge package"
 
+# The edge channel installs omarchy-dev. Prefer it when both are present.
+reset_db
+install_pkg omarchy-dev 4.1.0-1
+install_pkg omarchy 4.0.0-1
+[[ $(version) == "4.1.0-1" ]] || fail "version prefers the edge package when both are installed"
+pass "version prefers the edge package when both are installed"
+
+# omarchy-[0-9]* must not swallow a longer prefix such as omarchy-foo.
+reset_db
+install_pkg omarchy-foo 9.9.9-1
+install_pkg omarchy 4.0.0-1
+[[ $(version) == "4.0.0-1" ]] || fail "version ignores similarly prefixed packages"
+pass "version ignores similarly prefixed packages"
+
+reset_db
+install_pkg omarchy "1:4.0.0-1"
+[[ $(version) == "1:4.0.0-1" ]] || fail "version reports an epoch"
+pass "version reports an epoch"
+
 # A checkout reports its hash instead, so packages are irrelevant there.
-[[ $(version "" "$test_tmp/checkout") == "dev" ]] || fail "version reports a dev checkout"
+[[ $(version "$test_tmp/checkout") == "dev" ]] || fail "version reports a dev checkout"
 pass "version reports a dev checkout"
 
-if version "" >/dev/null 2>&1; then
+reset_db
+if version >/dev/null 2>&1; then
   fail "version fails when no Omarchy package is installed"
 fi
 pass "version fails when no Omarchy package is installed"
@@ -55,8 +70,8 @@ pass "version fails when no Omarchy package is installed"
 # the update under set -e.
 snapshot_desc=$(
   set -e
-  PATH="$stub_bin:$PATH" OMARCHY_TEST_PACKAGES="" OMARCHY_PATH=/usr/share/omarchy \
-    bash -c 'DESC="$(omarchy-version 2>/dev/null || echo unknown)"; echo "$DESC"' 2>/dev/null
+  OMARCHY_PACMAN_LOCAL="$local_db" OMARCHY_PATH=/usr/share/omarchy \
+    bash -c 'DESC="$('"$ROOT"'/bin/omarchy-version 2>/dev/null || echo unknown)"; echo "$DESC"'
 ) || fail "snapshot survives an unknown version"
 
 [[ $snapshot_desc == "unknown" ]] || fail "snapshot labels an unknown version" "actual: $snapshot_desc"


### PR DESCRIPTION
## Problem

`omarchy-version` calls `pacman -Q` for a one-line lookup. ALPM startup is ~200ms, and the default fastfetch config invokes this on every run.

## Change

Read `/var/lib/pacman/local/<pkg>-<ver>/` instead. Same package order as before (`omarchy-dev`, then `omarchy`). The glob is `${package}-[0-9]*`, so a sibling like `omarchy-foo` cannot match.

Tests drive a fake local db via `OMARCHY_PACMAN_LOCAL` instead of stubbing `pacman`.

## How I verified

```text
bash test/shell.d/version-test.sh
# ok - version reports the stable package
# ok - version reports the edge package
# ok - version prefers the edge package when both are installed
# ok - version ignores similarly prefixed packages
# ok - version reports an epoch
# ok - version reports a dev checkout
# ok - version fails when no Omarchy package is installed
# ok - snapshot survives an unknown version
```

Not timed on a real Omarchy install (this host has no pacman). The issue's 214ms to 9ms measurement is the runtime evidence.

Fixes #9315
