### PR TITLE
Install playerctl for Voxtype pause_media

### DIFF
--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -8,7 +8,7 @@ set -e
 # Install voxtype and configure it for use.
 
 if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
-  omarchy-pkg-add wtype voxtype-bin
+  omarchy-pkg-add wtype playerctl voxtype-bin
 
   # Setup voxtype
   mkdir -p ~/.config/voxtype

--- a/migrations/1788166802.sh
+++ b/migrations/1788166802.sh
@@ -1,0 +1,4 @@
+echo "Install playerctl for existing Voxtype installs"
+
+omarchy-pkg-present voxtype-bin || exit 0
+omarchy-pkg-add playerctl

--- a/test/shell.d/voxtype-playerctl-test.sh
+++ b/test/shell.d/voxtype-playerctl-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Voxtype pause_media shells out to playerctl. #9244 adds it to a fresh
+# omarchy-voxtype-install; this also covers people who already installed Voxtype.
+
+install="$ROOT/bin/omarchy-voxtype-install"
+migration=$(grep -l "Install playerctl for existing Voxtype installs" "$ROOT"/migrations/*.sh | head -1)
+
+grep -q 'omarchy-pkg-add wtype playerctl voxtype-bin' "$install" ||
+  fail "voxtype-install installs playerctl with voxtype"
+pass "voxtype-install installs playerctl with voxtype"
+
+[[ -n $migration ]] || fail "a migration installs playerctl for existing Voxtype installs"
+[[ ! -x $migration ]] || fail "the migration is not executable"
+! grep -q '^#!' "$migration" || fail "the migration has no shebang"
+pass "a migration installs playerctl for existing Voxtype installs"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+
+cat >"$test_tmp/bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+[[ ${TEST_VOXTYPE_PRESENT:-0} == 1 ]]
+SH
+
+cat >"$test_tmp/bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg-add %s\n' "$*" >>"$CALL_LOG"
+SH
+
+chmod +x "$test_tmp/bin"/*
+
+run_migration() {
+  : >"$CALL_LOG"
+  PATH="$test_tmp/bin:$PATH" CALL_LOG="$CALL_LOG" TEST_VOXTYPE_PRESENT="${1:-0}" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+CALL_LOG="$test_tmp/calls.log"
+
+run_migration 0
+[[ ! -s $CALL_LOG ]] || fail "migration no-ops when Voxtype is not installed"
+pass "migration no-ops when Voxtype is not installed"
+
+run_migration 1
+grep -qxF 'pkg-add playerctl' "$CALL_LOG" ||
+  fail "migration installs playerctl when Voxtype is installed"
+pass "migration installs playerctl when Voxtype is installed"


### PR DESCRIPTION
## Problem

Voxtype ships `pause_media = true` and implements that by calling `playerctl`. `omarchy-voxtype-install` never installed it, so the journal shows `playerctl not found`.

#9244 adds `playerctl` to a fresh install. Anyone who already ran the installer still does not have the package.

## Change

Same installer line as #9244, plus a migration that `omarchy-pkg-add playerctl` when `voxtype-bin` is present.

If #9244 lands first, the installer hunk here is a no-op on rebase.

## How I verified

```text
bash test/shell.d/voxtype-playerctl-test.sh
# ok - voxtype-install installs playerctl with voxtype
# ok - a migration installs playerctl for existing Voxtype installs
# ok - migration no-ops when Voxtype is not installed
# ok - migration installs playerctl when Voxtype is installed
```

Not runtime-tested against a live Voxtype session.

Related: #9244
