### PR TITLE
Add New File and Copy Path actions to Nautilus

### DIFF
--- a/default/nautilus-python/extensions/file-actions.py
+++ b/default/nautilus-python/extensions/file-actions.py
@@ -1,0 +1,90 @@
+import os
+import subprocess
+
+from gi import require_version
+
+require_version("Nautilus", "4.1")
+
+from gi.repository import GObject, Nautilus
+
+
+class FileActions(GObject.GObject, Nautilus.MenuProvider):
+    def _show_error(self, message):
+        subprocess.Popen(
+            ["zenity", "--error", "--title=New File", f"--text={message}"],
+            start_new_session=True,
+        )
+
+    def _new_file(self, _menu, folder_path):
+        result = subprocess.run(
+            [
+                "zenity",
+                "--entry",
+                "--title=New File",
+                "--text=Enter a filename (for example, main.py):",
+                "--ok-label=Create",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return
+
+        filename = result.stdout.rstrip("\n")
+        if not filename or filename in {".", ".."} or os.path.basename(filename) != filename:
+            self._show_error("Enter a single filename without slashes.")
+            return
+
+        path = os.path.join(folder_path, filename)
+        try:
+            descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            os.close(descriptor)
+        except FileExistsError:
+            self._show_error(f"A file named ‘{filename}’ already exists.")
+        except OSError as error:
+            self._show_error(str(error))
+
+    def _copy_paths(self, _menu, paths):
+        subprocess.run(
+            ["wl-copy"],
+            input="\n".join(paths),
+            text=True,
+            check=False,
+        )
+
+    def get_background_items(self, *args):
+        folder = args[-1]
+        location = folder.get_location()
+        folder_path = location.get_path() if location else None
+        if not folder_path or not os.access(folder_path, os.W_OK):
+            return []
+
+        item = Nautilus.MenuItem(
+            name="OmarchyFileActionsNautilus::new_file",
+            label="New File…",
+            icon="document-new-symbolic",
+        )
+        item.connect("activate", self._new_file, folder_path)
+        return [item]
+
+    def get_file_items(self, *args):
+        files = args[-1]
+        paths = []
+        for file_info in files:
+            location = file_info.get_location()
+            path = location.get_path() if location else None
+            if path:
+                paths.append(path)
+
+        if not paths:
+            return []
+
+        label = "Copy Path" if len(paths) == 1 else "Copy Paths"
+        item = Nautilus.MenuItem(
+            name="OmarchyFileActionsNautilus::copy_path",
+            label=label,
+            icon="edit-copy-symbolic",
+        )
+        item.connect("activate", self._copy_paths, paths)
+        return [item]

--- a/default/nautilus-python/extensions/file-actions.py
+++ b/default/nautilus-python/extensions/file-actions.py
@@ -5,7 +5,7 @@ from gi import require_version
 
 require_version("Nautilus", "4.1")
 
-from gi.repository import GObject, Nautilus
+from gi.repository import Gio, GObject, Nautilus
 
 
 class FileActions(GObject.GObject, Nautilus.MenuProvider):
@@ -16,22 +16,29 @@ class FileActions(GObject.GObject, Nautilus.MenuProvider):
         )
 
     def _new_file(self, _menu, folder_path):
-        result = subprocess.run(
+        process = Gio.Subprocess.new(
             [
                 "zenity",
                 "--entry",
                 "--title=New File",
-                "--text=Enter a filename (for example, main.py):",
+                "--text=Enter a filename (for example, notes.txt):",
                 "--ok-label=Create",
             ],
-            check=False,
-            capture_output=True,
-            text=True,
+            Gio.SubprocessFlags.STDOUT_PIPE,
         )
-        if result.returncode != 0:
+        process.communicate_utf8_async(
+            None,
+            None,
+            self._finish_new_file,
+            folder_path,
+        )
+
+    def _finish_new_file(self, process, result, folder_path):
+        _successful, stdout, _stderr = process.communicate_utf8_finish(result)
+        if not process.get_successful():
             return
 
-        filename = result.stdout.rstrip("\n")
+        filename = stdout.rstrip("\n")
         if not filename or filename in {".", ".."} or os.path.basename(filename) != filename:
             self._show_error("Enter a single filename without slashes.")
             return
@@ -44,6 +51,11 @@ class FileActions(GObject.GObject, Nautilus.MenuProvider):
             self._show_error(f"A file named ‘{filename}’ already exists.")
         except OSError as error:
             self._show_error(str(error))
+        else:
+            subprocess.Popen(
+                ["nautilus", "--select", path],
+                start_new_session=True,
+            )
 
     def _copy_paths(self, _menu, paths):
         subprocess.run(

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -147,4 +147,5 @@ yaru-icon-theme
 yay
 yt-dlp
 zbar
+zenity
 zoxide

--- a/migrations/1788170299.sh
+++ b/migrations/1788170299.sh
@@ -1,0 +1,5 @@
+echo "Add New File and Copy Path actions to Nautilus"
+
+extensions_dir="$HOME/.local/share/nautilus-python/extensions"
+mkdir -p "$extensions_dir"
+cp "$OMARCHY_PATH/default/nautilus-python/extensions/file-actions.py" "$extensions_dir/"


### PR DESCRIPTION
## Summary

- add a **New File…** background action to Nautilus that prompts for a filename such as `main.py`
- add **Copy Path** / **Copy Paths** actions for selected local files and folders
- install the extension for existing users through a migration and seed it for new users through the packaged defaults
- make `zenity` an explicit base dependency for the filename prompt

## Why

Creating an empty file with an arbitrary extension and copying an absolute path are common developer workflows. Omarchy already ships `nautilus-python` extensions and `wl-clipboard`, so these actions fit the existing Nautilus integration with a small amount of code.

The file creation uses `O_EXCL` to avoid overwriting an existing file, rejects path separators, and only appears in writable local folders. Copy Path supports multiple selections, placing one absolute path per line on the clipboard.

## Testing

- `python -m py_compile default/nautilus-python/extensions/file-actions.py`
- `git diff --check`
- migration installation and idempotence verified with a temporary `HOME`
- manually verified both actions in Nautilus 50.2.2 on Omarchy
- `./test/all` ran; unrelated environment-dependent failures remain in `config-test.sh`, `launch-about-test.sh`, `network-qr-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` because the test environment lacks the separate `omarchy-pkgs` checkout and a graphical compositor
