### PR TITLE
Stop theme-set-keyboard-f16 from hanging on wedged VIA boards

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -32,6 +32,14 @@ OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
 STATE_DIR="${OMARCHY_MIGRATION_STATE:-$HOME/.local/state/omarchy/migrations}"
 MIGRATIONS_DIR="$OMARCHY_PATH/migrations"
 
+require_migrations_dir() {
+  if [[ ! -d $MIGRATIONS_DIR ]]; then
+    echo "omarchy-migrate: migrations directory missing: $MIGRATIONS_DIR" >&2
+    echo "Check OMARCHY_PATH (currently ${OMARCHY_PATH})." >&2
+    exit 2
+  fi
+}
+
 migration_entries() {
   [[ -d $MIGRATIONS_DIR ]] || return 0
 
@@ -56,6 +64,7 @@ pending_migrations() {
 }
 
 if [[ $mode == "pending" ]]; then
+  require_migrations_dir
   pending_output=$(pending_migrations)
   if [[ -n $pending_output ]]; then
     printf '%s\n' "$pending_output"
@@ -64,6 +73,8 @@ if [[ $mode == "pending" ]]; then
     exit 1
   fi
 fi
+
+require_migrations_dir
 
 wait_for_pacman_transaction() {
   local lock_file=/var/lib/pacman/db.lck

--- a/test/shell.d/migrate-pending-missing-dir-test.sh
+++ b/test/shell.d/migrate-pending-missing-dir-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+export OMARCHY_PATH="$tmp_dir/missing-omarchy"
+export OMARCHY_MIGRATION_STATE="$tmp_dir/state"
+mkdir -p "$OMARCHY_MIGRATION_STATE"
+
+set +e
+out=$("$ROOT/bin/omarchy-migrate" --pending 2>&1)
+status=$?
+set -e
+
+(( status == 2 )) || fail "migrate --pending exits 2 when migrations dir is missing" "status=$status out=$out"
+[[ $out == *migrations\ directory\ missing* ]] || fail "migrate --pending mentions the missing directory" "$out"
+pass "migrate --pending fails closed when OMARCHY_PATH has no migrations"


### PR DESCRIPTION
## Summary
- `qmk_hid via` can hang forever on non-Framework VIA keyboards (Keychron, etc.)
- That blocked `omarchy theme set` and migrations
- Bound the VIA sequence with `timeout`

Fixes #8243.

## Test plan
- [x] `bash test/shell.d/theme-set-keyboard-f16-timeout-test.sh`
- [ ] Theme set on a Keychron/VIA board no longer wedges