### PR TITLE
Keep speed tests loaded during process cleanup

### DIFF
--- a/shell/plugins/panels/disk-speedtest/manifest.json
+++ b/shell/plugins/panels/disk-speedtest/manifest.json
@@ -8,6 +8,7 @@
   "kinds": [
     "panel"
   ],
+  "keepLoaded": true,
   "entryPoints": {
     "panel": "Panel.qml"
   }

--- a/shell/plugins/panels/speedtest/manifest.json
+++ b/shell/plugins/panels/speedtest/manifest.json
@@ -8,6 +8,7 @@
   "kinds": [
     "panel"
   ],
+  "keepLoaded": true,
   "entryPoints": {
     "panel": "Panel.qml"
   }

--- a/test/shell.d/speedtest-lifecycle-test.sh
+++ b/test/shell.d/speedtest-lifecycle-test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+for (const plugin of ['speedtest', 'disk-speedtest']) {
+  const manifestPath = path.join(root, 'shell/plugins/panels', plugin, 'manifest.json')
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+  assertEqual(manifest.keepLoaded, true, `${manifest.id} stays loaded during process cleanup`)
+}
+JS


### PR DESCRIPTION
## Problem

Starting speed test and closing before it's finished produces infinite download processes. 

## Summary

- keep the network and disk speed-test panels loaded after dismissal
- let their existing SIGTERM and onExited cleanup finish before Quickshell can destroy the Process object
- add a lifecycle manifest regression test for both panels

## Before and after

Reproduced on packaged Omarchy 4.0.2 by summoning the network speed test and dismissing it during the upload phase. Four `/bin/bash /usr/share/omarchy/bin/omarchy-network-speedtest up` workers remained reparented to the user systemd process after 4m18s.

Repeated against this branch with the same mid-upload dismissal. After three seconds, no network-speedtest Bash workers, Netflix curl processes, or dd producers remained.

## Test

- `bash test/shell.d/speedtest-lifecycle-test.sh`