### PR TITLE
Fix slider knob stopping short of the track end

### DIFF
--- a/shell/Ui/PanelSlider.qml
+++ b/shell/Ui/PanelSlider.qml
@@ -41,11 +41,15 @@ Item {
   readonly property real progress: Math.max(0, Math.min(1, (liveValue - minimum) / range))
   readonly property bool _hot: mouseArea.containsMouse || root.dragging
 
+  readonly property real knobCenter: track.x + track.width * progress
+
   Rectangle {
     id: track
     anchors.verticalCenter: parent.verticalCenter
     anchors.left: parent.left
     anchors.right: parent.right
+    anchors.leftMargin: root.knobSize / 2
+    anchors.rightMargin: root.knobSize / 2
     height: root.trackHeight
     radius: height / 2
     color: root.trackColor
@@ -75,8 +79,7 @@ Item {
       radius: 1
       color: root.tickColor
       anchors.verticalCenter: track.verticalCenter
-      x: Math.max(0, Math.min(track.width - width,
-                              track.width * (index / (root.tickCount - 1)) - width / 2))
+      x: track.x + track.width * (index / (root.tickCount - 1)) - width / 2
     }
   }
 
@@ -88,7 +91,7 @@ Item {
     color: root.knobColor
     borderSpec: Border.flat(root.bar ? root.bar.background : "#101315", Math.max(1, Style.space(2)))
     anchors.verticalCenter: track.verticalCenter
-    x: Math.max(0, Math.min(track.width - width, track.width * root.progress - width / 2))
+    x: root.knobCenter - width / 2
     scale: root._hot ? 1.15 : 1.0
 
     Behavior on x {
@@ -109,8 +112,9 @@ Item {
     acceptedButtons: Qt.LeftButton | Qt.RightButton
 
     function valueFromX(x) {
-      var clamped = Math.max(0, Math.min(track.width, x))
-      var raw = root.minimum + (clamped / track.width) * root.range
+      if (track.width <= 0) return root.minimum
+      var clamped = Math.max(0, Math.min(1, (x - track.x) / track.width))
+      var raw = root.minimum + clamped * root.range
       if (root.integer) raw = Math.round(raw)
       return Math.max(root.minimum, Math.min(root.maximum, raw))
     }


### PR DESCRIPTION
At 100% a slider still shows a bit of track past the knob, so it never quite looks finished.

The knob is kept inside the track, but the ticks and the fill are laid out across the track's full width, so the two don't agree at the ends. This measures them the same way and insets the track by half a knob, letting the knob sit at the very end without leaving the control.

<img width="494" height="426" alt="slider-knob-before-after" src="https://github.com/user-attachments/assets/fb4879db-7bb2-4f35-b694-cdca77bc7990" />


It's the shared slider, so this covers display brightness, text size, audio volume and the per-app mixer.
