### PR TITLE
Allow user to decide battery percentage position

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -52,7 +52,7 @@ The panels aren't read-outs. They're where you actually do the thing:
 - **Audio** has a master volume slider, an output-device picker, and a per-app mixer, so you can turn down that one browser tab without touching everything else.
 - **Network** scans for Wi-Fi, shows signal strength, connects, and lets you pick a DNS provider.
 - **Bluetooth** lists your devices with connect/disconnect and battery levels.
-- **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info. When the bar percentage is on, it reads left-to-right by default; set the `percentagePosition` option to `right` on the widget to place the percentage after the icon instead.
+- **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info.
 - **Display** carries a brightness slider, text size, monitor scaling presets, and — when you have more than one screen — per-monitor controls. See [monitors](33-monitors.md) for the deeper story.
 - **Clock** opens a month grid with ISO week numbers and month stepping.
 

--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -52,7 +52,7 @@ The panels aren't read-outs. They're where you actually do the thing:
 - **Audio** has a master volume slider, an output-device picker, and a per-app mixer, so you can turn down that one browser tab without touching everything else.
 - **Network** scans for Wi-Fi, shows signal strength, connects, and lets you pick a DNS provider.
 - **Bluetooth** lists your devices with connect/disconnect and battery levels.
-- **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info.
+- **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info. When the bar percentage is on, it reads left-to-right by default; set the `percentagePosition` option to `right` on the widget to place the percentage after the icon instead.
 - **Display** carries a brightness slider, text size, monitor scaling presets, and — when you have more than one screen — per-monitor controls. See [monitors](33-monitors.md) for the deeper story.
 - **Clock** opens a month grid with ISO week numbers and month stepping.
 

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -20,6 +20,10 @@ Panel {
   property int profileIndex: 0
   property bool cursorActive: false
   readonly property bool showPercentage: setting("showPercentage", false) === true
+  // Whether the percentage text sits before ("left") or after ("right") the
+  // battery icon in the bar. Defaults to before the icon, matching the
+  // historical Waybar layout.
+  readonly property string percentagePosition: setting("percentagePosition", "left") === "right" ? "right" : "left"
   // With the percentage shown the button paints a text block wider than an
   // icon, so the open-panel mark takes the painted width instead of the
   // icon-sized fraction of the slot the fallback assumes.
@@ -278,7 +282,9 @@ Panel {
     anchors.fill: parent
     bar: root.bar
     text: root.showPercentage && !vertical
-      ? Math.round(root.batteryFraction * 100) + "% " + root.batteryIcon()
+      ? root.percentagePosition === "right"
+          ? root.batteryIcon() + " " + Math.round(root.batteryFraction * 100) + "%"
+          : Math.round(root.batteryFraction * 100) + "% " + root.batteryIcon()
       : root.batteryIcon()
     slotSize: Style.bar.iconSlot * (root.showPercentage && !vertical ? 2 : 1)
     tooltipText: ""

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -44,7 +44,9 @@ assertEqual(
 
 assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')
-assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon')
+assert(/percentagePosition === "right"/.test(panelSource), 'power reads the percentage position setting')
+assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon by default')
+assert(/root\.batteryIcon\(\) \+ " " \+ Math\.round\(root\.batteryFraction \* 100\) \+ "%"/.test(panelSource), 'power places the percentage after the battery icon when requested')
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')


### PR DESCRIPTION
## Summary

Adds a `percentagePosition` option to the bar power widget (`omarchy.power`) so the battery percentage can render either before or after the battery icon.

## Motivation

The built-in power widget hardcodes the percentage before the icon (`85% 󰁹`). There was no way to place the percentage after the icon. This small option makes the layout configurable via the widget's inline settings.

## Changes

- **`shell/plugins/panels/power/Panel.qml`** — read a new `percentagePosition` setting (`"left"` or `"right"`, defaulting to `"left"` = percentage before the icon, matching the historical layout) and use it when composing the bar button text.
- **`test/shell.d/power-test.sh`** — assert the new setting is read and that both orderings render.
- **`manual/05-the-top-bar.md`** — document the new option on the Power widget.

## Usage

In `~/.config/omarchy/shell.json`, on the `omarchy.power` bar entry:

```json
{ "id": "omarchy.power", "showPercentage": true, "percentagePosition": "right" }
```

or via the CLI:

```bash
omarchy bar set omarchy.power percentagePosition right
```

Default behavior is unchanged: percentage still renders before the icon unless `percentagePosition` is set to `right`.

## Verification

`./test/shell.d/power-test.sh` passes, including the updated and new assertions.