### PR TITLE
Make the default agent directory configurable

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -32,8 +32,11 @@ while (($#)); do
 done
 
 # Agents refuse to remember trust for $HOME, so launches from the keybinding or
-# menu start in the work directory instead of re-asking on every session.
-[[ $PWD == "$HOME" && -d $HOME/Work ]] && cd "$HOME/Work"
+# menu start in the configured agent directory instead of re-asking every time.
+if [[ $PWD == "$HOME" ]]; then
+  agent_directory=$(omarchy-default-agent-directory)
+  [[ -d $agent_directory ]] && cd "$agent_directory"
+fi
 
 agent=$(omarchy-default-agent)
 

--- a/bin/omarchy-default-agent-directory
+++ b/bin/omarchy-default-agent-directory
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# omarchy:summary=Set the default directory for coding agent launches
+# omarchy:args=[path]
+# omarchy:examples=omarchy default agent-directory ~/Projects
+
+directory_file="$HOME/.config/omarchy/defaults/agent-directory"
+
+if (($# == 0)); then
+  if [[ -f $directory_file ]]; then
+    read -r directory <"$directory_file"
+    [[ -n $directory ]] && echo "$directory"
+  else
+    echo "$HOME/Work"
+  fi
+  exit 0
+fi
+
+if (($# != 1)); then
+  echo "Usage: omarchy-default-agent-directory [path]" >&2
+  exit 1
+fi
+
+directory=$1
+if [[ $directory == "~" ]]; then
+  directory=$HOME
+elif [[ $directory == "~/"* ]]; then
+  directory="$HOME/${directory#\~/}"
+elif [[ $directory != /* ]]; then
+  directory="$PWD/$directory"
+fi
+
+mkdir -p "$directory" || exit 1
+directory=$(realpath -- "$directory") || exit 1
+
+mkdir -p "$(dirname "$directory_file")" || exit 1
+printf '%s\n' "$directory" >"$directory_file" || exit 1
+echo "$directory"

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -23,7 +23,7 @@ To wrap an additional CLI the same way, run `omarchy-mise-install <package> [com
 
 Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If the agent isn't installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification.
 
-Once you've chosen, `Super + Shift + Ctrl + A` launches the default agent in a dedicated terminal window (or brings up the picker if you haven't chosen yet). You can also launch it straight into a task with `omarchy agent prompt "Review this project"`. Agents launched this way run unattended in their respective don't-stop-to-ask modes, so be ready for them to actually do things! And since agents refuse to remember trust for your home directory, launches from `$HOME` start in `~/Work` instead.
+Once you've chosen, `Super + Shift + Ctrl + A` launches the default agent in a dedicated terminal window (or brings up the picker if you haven't chosen yet). You can also launch it straight into a task with `omarchy agent prompt "Review this project"`. Agents launched this way run unattended in their respective don't-stop-to-ask modes, so be ready for them to actually do things! And since agents refuse to remember trust for your home directory, launches from `$HOME` start in `~/Work` instead. Change that directory with `omarchy default agent-directory ~/Projects`.
 
 There are terminal shortcuts too: `a` runs the default agent inline in the current terminal, while `c`, `cx`, and `cy` start OpenCode, Claude Code, and Codex directly (again in their auto-approving modes). Theme changes sync to the agents as well: Claude Code, Pi, and OpenCode all follow along when you switch the Omarchy theme.
 

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -10,9 +10,11 @@ trap 'rm -rf "$test_tmp"' EXIT
 mock_bin="$test_tmp/bin"
 test_home="$test_tmp/home"
 agent_file="$test_home/.config/omarchy/defaults/agent"
+agent_directory_file="$test_home/.config/omarchy/defaults/agent-directory"
 notification_history="$test_tmp/notification-history"
 agent_open_log="$test_tmp/agent-open"
 launch_log="$test_tmp/launch"
+launch_directory_log="$test_tmp/launch-directory"
 inline_log="$test_tmp/inline"
 mise_log="$test_tmp/mise"
 mise_history="$test_tmp/mise-history"
@@ -34,6 +36,7 @@ SH
 cat >"$mock_bin/omarchy-launch-tui" <<'SH'
 #!/bin/bash
 printf '%s\0' "$@" >"$OMARCHY_TEST_AGENT_LAUNCH_LOG"
+pwd >"$OMARCHY_TEST_AGENT_LAUNCH_DIRECTORY_LOG"
 SH
 
 cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
@@ -85,6 +88,7 @@ export PATH="$mock_bin:$ROOT/bin:$PATH"
 export OMARCHY_TEST_NOTIFICATION_HISTORY="$notification_history"
 export OMARCHY_TEST_AGENT_OPEN_LOG="$agent_open_log"
 export OMARCHY_TEST_AGENT_LAUNCH_LOG="$launch_log"
+export OMARCHY_TEST_AGENT_LAUNCH_DIRECTORY_LOG="$launch_directory_log"
 export OMARCHY_TEST_AGENT_INLINE_LOG="$inline_log"
 export OMARCHY_TEST_MISE_LOG="$mise_log"
 export OMARCHY_TEST_MISE_HISTORY="$mise_history"
@@ -477,6 +481,30 @@ assert_bypass grok grok --permission-mode bypassPermissions
 assert_bypass agy agy --dangerously-skip-permissions
 assert_bypass copilot copilot --allow-all
 pass "agent launcher skips permission prompts for every supported agent"
+
+mkdir -p "$test_home/Work"
+(cd "$test_home" && omarchy-agent)
+[[ $(<"$launch_directory_log") == "$test_home/Work" ]] ||
+  fail "agent launcher defaults to the work directory"
+
+custom_agent_directory="$test_home/Projects with spaces"
+[[ $(omarchy-default-agent-directory "$custom_agent_directory") == "$custom_agent_directory" ]] ||
+  fail "agent directory setter prints the selected directory"
+[[ -d $custom_agent_directory && $(<"$agent_directory_file") == "$custom_agent_directory" ]] ||
+  fail "agent directory setter creates and persists the selected directory"
+[[ $(omarchy-default-agent-directory) == "$custom_agent_directory" ]] ||
+  fail "agent directory getter prints the configured directory"
+
+(cd "$test_home" && omarchy-agent)
+[[ $(<"$launch_directory_log") == "$custom_agent_directory" ]] ||
+  fail "agent launcher starts in the configured directory from home"
+
+elsewhere="$test_tmp/elsewhere"
+mkdir -p "$elsewhere"
+(cd "$elsewhere" && omarchy-agent)
+[[ $(<"$launch_directory_log") == "$elsewhere" ]] ||
+  fail "agent launcher preserves a non-home working directory"
+pass "agent launch directory is configurable"
 
 printf '%s\n' "opencode" >"$agent_file"
 omarchy-agent


### PR DESCRIPTION
## Summary

- add `omarchy default agent-directory [path]`
- retain `~/Work` as the backward-compatible default
- create and persist the selected directory in Omarchy defaults
- preserve the current directory when an agent is launched outside `$HOME`
- document and test the behavior, including paths containing spaces

Discussed in #9349.

## Testing

- `bash test/shell.d/default-agent-test.sh`
- `./test/cli`
- `./test/all`

The changed suites pass. The aggregate reports five environment/repository-state failures in `config-test.sh`, `launch-about-test.sh`, `network-qr-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`; running those same five tests from an untouched `upstream/quattro` worktree reproduces every failure.