### PR TITLE
Read migrations and browser policies from the trusted Omarchy tree

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -6,7 +6,59 @@
 
 set -e
 
-source "$OMARCHY_PATH/install/helpers/browser-policy.sh"
+# Browser policy setup installs files as root, so the helper and the policy
+# files it installs must come from a trusted tree. The packaged tree is always
+# trusted. A linked checkout is trusted only when /etc/omarchy.conf is a
+# root-owned regular file whose only line names that checkout, which is what
+# omarchy-dev-link writes. omarchy-plymouth-set uses the same rule. Keep this
+# block in step with omarchy-refresh-limine, omarchy-refresh-pacman,
+# omarchy-toggle-hybrid-gpu, omarchy-hibernation-setup, omarchy-migrate, and
+# install/helpers/browser-policy.sh.
+omarchy_privileged_source_root() {
+  local packaged=/usr/share/omarchy
+  local path=${OMARCHY_PATH:-$packaged}
+  local conf=/etc/omarchy.conf
+  local uid mode
+  local -a lines
+
+  if [[ $path == "$packaged" ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  if [[ ! -f $conf || -L $conf ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  uid=$(stat -c %u -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  mode=$(stat -c %a -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( uid != 0 )) || (( 8#$mode & 0022 )); then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  mapfile -t lines <"$conf" || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( ${#lines[@]} == 1 )) && [[ ${lines[0]} == "export OMARCHY_PATH=\"$path\"" ]]; then
+    printf '%s\n' "$path"
+    return
+  fi
+
+  printf '%s\n' "$packaged"
+}
+
+SOURCE_ROOT=$(omarchy_privileged_source_root)
+
+source "$SOURCE_ROOT/install/helpers/browser-policy.sh"
 
 setup_chromium_policy_directory() {
   browser_policy_setup_dir "$1"

--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -5,6 +5,58 @@
 
 set -euo pipefail
 
+# Migrations run with the caller's sudo credentials inside the update flow, so
+# the tree they are read from must be trusted. The packaged tree is always
+# trusted. A linked checkout is trusted only when /etc/omarchy.conf is a
+# root-owned regular file whose only line names that checkout, which is what
+# omarchy-dev-link writes. omarchy-plymouth-set uses the same rule. Keep this
+# block in step with omarchy-refresh-limine, omarchy-refresh-pacman,
+# omarchy-toggle-hybrid-gpu, omarchy-hibernation-setup,
+# omarchy-install-browser, and install/helpers/browser-policy.sh.
+omarchy_privileged_source_root() {
+  local packaged=/usr/share/omarchy
+  local path=${OMARCHY_PATH:-$packaged}
+  local conf=/etc/omarchy.conf
+  local uid mode
+  local -a lines
+
+  if [[ $path == "$packaged" ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  if [[ ! -f $conf || -L $conf ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  uid=$(stat -c %u -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  mode=$(stat -c %a -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( uid != 0 )) || (( 8#$mode & 0022 )); then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  mapfile -t lines <"$conf" || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( ${#lines[@]} == 1 )) && [[ ${lines[0]} == "export OMARCHY_PATH=\"$path\"" ]]; then
+    printf '%s\n' "$path"
+    return
+  fi
+
+  printf '%s\n' "$packaged"
+}
+
+SOURCE_ROOT=$(omarchy_privileged_source_root)
+
 mode="run"
 
 usage() {
@@ -30,7 +82,7 @@ done
 
 OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
 STATE_DIR="${OMARCHY_MIGRATION_STATE:-$HOME/.local/state/omarchy/migrations}"
-MIGRATIONS_DIR="$OMARCHY_PATH/migrations"
+MIGRATIONS_DIR="$SOURCE_ROOT/migrations"
 
 migration_entries() {
   [[ -d $MIGRATIONS_DIR ]] || return 0
@@ -90,7 +142,7 @@ while IFS=$'\t' read -r name file marker <&3; do
 
   if [[ ! -f $marker ]]; then
     echo -e "\e[32m\nRunning migration (${name%.sh})\e[0m"
-    OMARCHY_PATH="$OMARCHY_PATH" bash -euo pipefail "$file" 3<&-
+    OMARCHY_PATH="$SOURCE_ROOT" bash -euo pipefail "$file" 3<&-
     mkdir -p "$(dirname "$marker")"
     touch "$marker"
   fi

--- a/install/helpers/browser-policy.sh
+++ b/install/helpers/browser-policy.sh
@@ -4,6 +4,57 @@
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/as-root.sh"
 
+# Policy files are installed as root, so they must come from a trusted tree.
+# The packaged tree is always trusted. A linked checkout is trusted only when
+# /etc/omarchy.conf is a root-owned regular file whose only line names that
+# checkout, which is what omarchy-dev-link writes. omarchy-plymouth-set uses
+# the same rule. Keep this block in step with omarchy-refresh-limine,
+# omarchy-refresh-pacman, omarchy-toggle-hybrid-gpu, omarchy-hibernation-setup,
+# omarchy-migrate, and omarchy-install-browser.
+omarchy_privileged_source_root() {
+  local packaged=/usr/share/omarchy
+  local path=${OMARCHY_PATH:-$packaged}
+  local conf=/etc/omarchy.conf
+  local uid mode
+  local -a lines
+
+  if [[ $path == "$packaged" ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  if [[ ! -f $conf || -L $conf ]]; then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  uid=$(stat -c %u -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  mode=$(stat -c %a -- "$conf" 2>/dev/null) || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( uid != 0 )) || (( 8#$mode & 0022 )); then
+    printf '%s\n' "$packaged"
+    return
+  fi
+
+  mapfile -t lines <"$conf" || {
+    printf '%s\n' "$packaged"
+    return
+  }
+  if (( ${#lines[@]} == 1 )) && [[ ${lines[0]} == "export OMARCHY_PATH=\"$path\"" ]]; then
+    printf '%s\n' "$path"
+    return
+  fi
+
+  printf '%s\n' "$packaged"
+}
+
+BROWSER_POLICY_SOURCE_ROOT=$(omarchy_privileged_source_root)
+
 BROWSER_POLICY_MANAGED_DIRS=(
   /etc/chromium/policies/managed
   /etc/opt/chrome/policies/managed
@@ -153,14 +204,14 @@ browser_policy_firefox_hardened() {
 
 browser_policy_install_firefox_policies() {
   local distribution_dir=$1
-  local policies=${2:-$OMARCHY_PATH/default/firefox/policies.json}
+  local policies=${2:-$BROWSER_POLICY_SOURCE_ROOT/default/firefox/policies.json}
 
   as_root install -m 644 -o root -g root -T "$policies" "$distribution_dir/policies.json"
 }
 
 browser_policy_setup_firefox_distribution() {
   local distribution_dir=$1
-  local policies=${2:-$OMARCHY_PATH/default/firefox/policies.json}
+  local policies=${2:-$BROWSER_POLICY_SOURCE_ROOT/default/firefox/policies.json}
 
   browser_policy_setup_parent "$distribution_dir"
   browser_policy_purge_dir "$distribution_dir"

--- a/migrations/1784809451.sh
+++ b/migrations/1784809451.sh
@@ -2,7 +2,7 @@ echo "Configure locate to skip Btrfs snapshots and index Btrfs subvolumes"
 
 OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
 locate_config_script="$OMARCHY_PATH/install/config/locate.sh"
-UPDATEDB_CONF_PATH="${OMARCHY_UPDATEDB_CONF_PATH:-/etc/updatedb.conf}"
+UPDATEDB_CONF_PATH=/etc/updatedb.conf
 
 as_root() {
   if (( EUID == 0 )); then
@@ -20,7 +20,11 @@ if grep -q '^PRUNE_BIND_MOUNTS = "no"' "$UPDATEDB_CONF_PATH" &&
   exit 0
 fi
 
-as_root env OMARCHY_UPDATEDB_CONF_PATH="$UPDATEDB_CONF_PATH" bash -euo pipefail "$locate_config_script"
+# The config path is pinned so a caller-chosen OMARCHY_UPDATEDB_CONF_PATH
+# cannot steer the root rewrite at a file the caller named. locate.sh keeps
+# its own override for tests, but sudo does not pass the caller's value
+# through, so the root side always edits /etc/updatedb.conf.
+as_root bash -euo pipefail "$locate_config_script"
 
 # Rebuild the index with the new exclusions; pruning /.snapshots turns
 # multi-hour runs on snapshot-heavy systems back into one-minute runs. Restart

--- a/test/shell.d/locate-test.sh
+++ b/test/shell.d/locate-test.sh
@@ -130,11 +130,19 @@ chmod +x "$fake_bin/systemctl"
 conf="$test_tmp/migration-updatedb.conf"
 stock_conf "$conf"
 
+# The migration pins /etc/updatedb.conf so a caller cannot name the file the
+# root step rewrites. Test against a copy whose pinned path points at the
+# stand-in conf. The sudo stub execs locate.sh with the caller's environment,
+# where real sudo would strip OMARCHY_UPDATEDB_CONF_PATH and leave locate.sh
+# on its own default.
+migration_copy="$test_tmp/locate-migration"
+sed "s#/etc/updatedb.conf#$conf#g" "$locate_migration" >"$migration_copy"
+
 TEST_LOG="$test_tmp/calls.log" \
 PATH="$fake_bin:$PATH" \
 OMARCHY_PATH="$ROOT" \
 OMARCHY_UPDATEDB_CONF_PATH="$conf" \
-  bash -euo pipefail "$locate_migration" >/dev/null
+  bash -euo pipefail "$migration_copy" >/dev/null
 
 grep -qFx 'PRUNE_BIND_MOUNTS = "no"' "$conf" || fail "locate migration rewrites updatedb.conf"
 grep -qF 'PRUNEPATHS = "/.snapshots /afs' "$conf" || fail "locate migration prunes /.snapshots"
@@ -147,7 +155,7 @@ TEST_LOG="$test_tmp/calls.log" \
 PATH="$fake_bin:$PATH" \
 OMARCHY_PATH="$ROOT" \
 OMARCHY_UPDATEDB_CONF_PATH="$conf" \
-  bash -euo pipefail "$locate_migration" >/dev/null
+  bash -euo pipefail "$migration_copy" >/dev/null
 
 [[ ! -s $test_tmp/calls.log ]] || fail "locate migration skips already-configured installs"
 pass "locate migration is a no-op once updatedb.conf is configured"
@@ -162,7 +170,7 @@ TEST_LOG="$test_tmp/calls.log" \
 PATH="$fake_bin:$PATH" \
 OMARCHY_PATH="$test_tmp/empty" \
 OMARCHY_UPDATEDB_CONF_PATH="$conf" \
-  bash -euo pipefail "$locate_migration" >/dev/null ||
+  bash -euo pipefail "$migration_copy" >/dev/null ||
   fail "locate migration survives a tree without the locate config script"
 
 [[ ! -s $test_tmp/calls.log ]] || fail "locate migration touches nothing without the locate config script"

--- a/test/shell.d/migrate-scope-test.sh
+++ b/test/shell.d/migrate-scope-test.sh
@@ -9,7 +9,41 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 test_root="$test_tmp/omarchy"
 test_home="$test_tmp/home"
-mkdir -p "$test_root/migrations" "$test_home"
+stub_bin="$test_tmp/bin"
+conf="$test_tmp/omarchy.conf"
+mkdir -p "$test_root/migrations" "$test_home" "$stub_bin"
+
+# omarchy-migrate reads migrations from the packaged tree, or from a checkout
+# that a root-owned /etc/omarchy.conf names. Run a copy whose conf path points
+# at a stand-in, and authorize each scratch tree the way omarchy-dev-link
+# would. stat is stubbed to report the stand-in as root-owned, which is the
+# part of dev-link only root can do for real.
+migrate_copy="$test_tmp/omarchy-migrate"
+sed "s#/etc/omarchy.conf#$conf#g" "$ROOT/bin/omarchy-migrate" >"$migrate_copy"
+chmod +x "$migrate_copy"
+
+cat >"$stub_bin/stat" <<'SH'
+#!/bin/bash
+for last; do :; done
+if [[ $last == "$TEST_CONF" ]]; then
+  case " $* " in
+    *" %u "*) echo 0 ;;
+    *" %a "*) echo 644 ;;
+  esac
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+SH
+chmod +x "$stub_bin/stat"
+
+authorize() {
+  printf 'export OMARCHY_PATH="%s"\n' "$1" >"$conf"
+  chmod 0644 "$conf"
+}
+
+run_migrate() {
+  TEST_CONF="$conf" PATH="$stub_bin:$PATH" "$migrate_copy" "$@"
+}
 
 cat >"$test_root/migrations/100-first.sh" <<'SH'
 [[ $OMARCHY_PATH == "$TEST_EXPECTED_OMARCHY_PATH" ]]
@@ -22,7 +56,8 @@ SH
 
 calls="$test_tmp/calls"
 
-if ! HOME="$test_home" OMARCHY_PATH="$test_root" "$ROOT/bin/omarchy-migrate" --pending >"$test_tmp/pending.out"; then
+authorize "$test_root"
+if ! HOME="$test_home" OMARCHY_PATH="$test_root" run_migrate --pending >"$test_tmp/pending.out"; then
   fail "migration runner reports pending migrations before state exists"
 fi
 grep -q '^100-first\.sh$' "$test_tmp/pending.out" || fail "migration runner lists first pending migration filename"
@@ -33,7 +68,7 @@ HOME="$test_home" \
 OMARCHY_PATH="$test_root" \
 TEST_EXPECTED_OMARCHY_PATH="$test_root" \
 TEST_CALLS="$calls" \
-  "$ROOT/bin/omarchy-migrate" >"$test_tmp/first-run.out"
+  run_migrate >"$test_tmp/first-run.out"
 [[ $(sed -n '1p' "$calls") == "first" ]] || fail "migration runner runs first migration"
 [[ $(sed -n '2p' "$calls") == "second" ]] || fail "migration runner runs second migration"
 [[ -f $test_home/.local/state/omarchy/migrations/100-first.sh ]] || fail "migration runner records first migration marker"
@@ -44,11 +79,11 @@ HOME="$test_home" \
 OMARCHY_PATH="$test_root" \
 TEST_EXPECTED_OMARCHY_PATH="$test_root" \
 TEST_CALLS="$calls" \
-  "$ROOT/bin/omarchy-migrate" >"$test_tmp/second-run.out"
+  run_migrate >"$test_tmp/second-run.out"
 [[ $(wc -l <"$calls") -eq 2 ]] || fail "migration runner skips completed migrations"
 pass "migration runner skips completed migrations"
 
-if HOME="$test_home" OMARCHY_PATH="$test_root" "$ROOT/bin/omarchy-migrate" --pending >"$test_tmp/not-pending.out"; then
+if HOME="$test_home" OMARCHY_PATH="$test_root" run_migrate --pending >"$test_tmp/not-pending.out"; then
   fail "migration runner reports no pending migrations after state exists"
 fi
 pass "migration runner detects no pending migrations"
@@ -63,11 +98,12 @@ false
 echo after-fail >>"$TEST_CALLS"
 SH
 
+authorize "$failure_root"
 set +e
 HOME="$failure_home" \
 OMARCHY_PATH="$failure_root" \
 TEST_CALLS="$calls" \
-  "$ROOT/bin/omarchy-migrate" >"$test_tmp/failure.out" 2>"$test_tmp/failure.err"
+  run_migrate >"$test_tmp/failure.out" 2>"$test_tmp/failure.err"
 failure_status=$?
 set -e
 [[ $failure_status -ne 0 ]] || fail "migration runner exits non-zero when a migration fails"
@@ -89,11 +125,12 @@ cat >"$stdin_root/migrations/200-after.sh" <<'SH'
 echo after-reader >>"$TEST_CALLS"
 SH
 
+authorize "$stdin_root"
 printf 'migration input\n' | \
   HOME="$stdin_home" \
   OMARCHY_PATH="$stdin_root" \
   TEST_CALLS="$stdin_calls" \
-  "$ROOT/bin/omarchy-migrate" >"$test_tmp/stdin.out"
+  run_migrate >"$test_tmp/stdin.out"
 
 grep -q '^reader:migration input$' "$stdin_calls" ||
   fail "migration runner preserves the caller's stdin for a migration" "$(cat "$stdin_calls")"

--- a/test/shell.d/migrate-wrapper-test.sh
+++ b/test/shell.d/migrate-wrapper-test.sh
@@ -10,7 +10,34 @@ trap 'rm -rf "$test_tmp"' EXIT
 test_root="$test_tmp/omarchy"
 test_home="$test_tmp/home"
 stub_bin="$test_tmp/bin"
+conf="$test_tmp/omarchy.conf"
 mkdir -p "$test_root/migrations" "$test_home" "$stub_bin"
+
+# omarchy-migrate reads migrations from the packaged tree, or from a checkout
+# that a root-owned /etc/omarchy.conf names. Run a copy whose conf path points
+# at a stand-in, and authorize the scratch tree the way omarchy-dev-link
+# would. stat is stubbed to report the stand-in as root-owned, which is the
+# part of dev-link only root can do for real.
+migrate_copy="$test_tmp/omarchy-migrate"
+sed "s#/etc/omarchy.conf#$conf#g" "$ROOT/bin/omarchy-migrate" >"$migrate_copy"
+chmod +x "$migrate_copy"
+
+cat >"$stub_bin/stat" <<'SH'
+#!/bin/bash
+for last; do :; done
+if [[ $last == "$TEST_CONF" ]]; then
+  case " $* " in
+    *" %u "*) echo 0 ;;
+    *" %a "*) echo 644 ;;
+  esac
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+SH
+chmod +x "$stub_bin/stat"
+
+printf 'export OMARCHY_PATH="%s"\n' "$test_root" >"$conf"
+chmod 0644 "$conf"
 
 cat >"$stub_bin/omarchy-notification-dismiss" <<'SH'
 #!/bin/bash
@@ -25,10 +52,11 @@ SH
 run_migrate() {
   HOME="$test_home" \
   OMARCHY_PATH="$test_root" \
+  TEST_CONF="$conf" \
   PATH="$stub_bin:$ROOT/bin:$PATH" \
   TEST_CALLS="$test_tmp/calls" \
   TEST_DISMISSALS="$test_tmp/dismissals" \
-    "$ROOT/bin/omarchy-migrate" "$@"
+    "$migrate_copy" "$@"
 }
 
 : >"$test_tmp/calls"

--- a/test/shell.d/privileged-source-update-test.sh
+++ b/test/shell.d/privileged-source-update-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+grep -F 'omarchy_privileged_source_root()' "$ROOT/bin/omarchy-migrate" >/dev/null ||
+  fail "omarchy-migrate resolves its tree through a trusted source root"
+grep -F 'MIGRATIONS_DIR="$SOURCE_ROOT/migrations"' "$ROOT/bin/omarchy-migrate" >/dev/null ||
+  fail "omarchy-migrate lists migrations from the trusted source root"
+grep -F 'OMARCHY_PATH="$SOURCE_ROOT" bash -euo pipefail "$file"' "$ROOT/bin/omarchy-migrate" >/dev/null ||
+  fail "omarchy-migrate passes the trusted source root to each migration"
+if grep -F 'MIGRATIONS_DIR="$OMARCHY_PATH/migrations"' "$ROOT/bin/omarchy-migrate" >/dev/null; then
+  fail "omarchy-migrate no longer reads migrations from a caller-controlled OMARCHY_PATH"
+fi
+pass "omarchy-migrate reads migrations from the trusted tree, not a caller-controlled OMARCHY_PATH"
+
+grep -F 'source "$SOURCE_ROOT/install/helpers/browser-policy.sh"' "$ROOT/bin/omarchy-install-browser" >/dev/null ||
+  fail "omarchy-install-browser sources the browser policy helper from the trusted source root"
+if grep -F 'source "$OMARCHY_PATH/install/helpers/browser-policy.sh"' "$ROOT/bin/omarchy-install-browser" >/dev/null; then
+  fail "omarchy-install-browser no longer sources helpers from a caller-controlled OMARCHY_PATH"
+fi
+pass "omarchy-install-browser sources its privileged helper from the trusted tree"
+
+grep -F 'omarchy_privileged_source_root()' "$ROOT/install/helpers/browser-policy.sh" >/dev/null ||
+  fail "browser-policy.sh resolves policy files through a trusted source root"
+if grep -F 'local policies=${2:-$OMARCHY_PATH/default/firefox/policies.json}' "$ROOT/install/helpers/browser-policy.sh" >/dev/null; then
+  fail "browser-policy.sh no longer installs policies from a caller-controlled OMARCHY_PATH"
+fi
+pass "browser policy installs read the packaged tree, not a caller-controlled OMARCHY_PATH"
+
+grep -Fx 'UPDATEDB_CONF_PATH=/etc/updatedb.conf' "$ROOT/migrations/1784809451.sh" >/dev/null ||
+  fail "the locate migration pins the config the root step rewrites"
+if grep -E 'env OMARCHY_UPDATEDB_CONF_PATH|\$\{OMARCHY_UPDATEDB_CONF_PATH' "$ROOT/migrations/1784809451.sh" >/dev/null; then
+  fail "the locate migration no longer forwards a caller-chosen config path to root"
+fi
+pass "the locate migration does not let the caller name the file root rewrites"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+evil="$test_tmp/evil-tree"
+mkdir -p "$evil/migrations" "$evil/default/firefox" "$test_tmp/home"
+
+cat >"$evil/migrations/9999999999.sh" <<'SH'
+echo evil >>"$TEST_CALLS"
+SH
+
+# A poisoned OMARCHY_PATH with no dev-link authorization must fall back to the
+# packaged tree. --pending only lists, so this never executes real migrations.
+output=$(HOME="$test_tmp/home" OMARCHY_PATH="$evil" "$ROOT/bin/omarchy-migrate" --pending 2>/dev/null) || true
+[[ $output != *"9999999999"* ]] ||
+  fail "omarchy-migrate --pending ignores migrations from a poisoned OMARCHY_PATH" "$output"
+[[ $output != *"$evil"* ]] ||
+  fail "omarchy-migrate --pending never touches the poisoned tree" "$output"
+pass "omarchy-migrate ignores a poisoned OMARCHY_PATH"
+
+if (( EUID == 0 )); then
+  pass "running as root; skipping the browser policy elevation check, which would install into system browser directories"
+  exit 0
+fi
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$ELEVATION_LOG"
+SH
+chmod +x "$stub_bin/sudo"
+
+printf 'not the packaged policies\n' >"$evil/default/firefox/policies.json"
+elevation_log="$test_tmp/elevation"
+: >"$elevation_log"
+
+(
+  export OMARCHY_PATH="$evil" PATH="$stub_bin:/usr/bin" ELEVATION_LOG="$elevation_log"
+  source "$ROOT/install/helpers/browser-policy.sh"
+  browser_policy_install_firefox_policies "$test_tmp/dist"
+) >/dev/null 2>&1 || true
+
+if grep -F "$evil" "$elevation_log"; then
+  fail "browser policy install does not come from a poisoned OMARCHY_PATH" \
+    "$(cat "$elevation_log")"
+fi
+grep -F "sudo install -m 644 -o root -g root -T /usr/share/omarchy/default/firefox/policies.json" "$elevation_log" >/dev/null ||
+  fail "browser policy install comes from the packaged tree" \
+    "$(cat "$elevation_log")"
+pass "browser policy install ignores a poisoned OMARCHY_PATH"


### PR DESCRIPTION
`omarchy-migrate` runs every pending migration from `$OMARCHY_PATH` with the caller's sudo credentials a prompt away:

```
OMARCHY_PATH="$OMARCHY_PATH" bash -euo pipefail "$file"
```

`omarchy-install-browser` sources its policy helper from the same caller-controlled path, and the helper installs the default Firefox policy as root:

```
source "$OMARCHY_PATH/install/helpers/browser-policy.sh"
as_root install -m 644 -o root -g root -T "$policies" "$distribution_dir/policies.json"
```

A caller who points `OMARCHY_PATH` at a tree they can write, then types the sudo password for an update or a browser install, runs their own script as root or installs their own mandatory browser policy. The session environment is user-writable by definition, and migration markers live under `~/.local/state`, so any migration can be made pending again.

`omarchy-plymouth-set` and the refresh helpers already refuse a user-owned source tree unless a root-owned `/etc/omarchy.conf` names that checkout. The update flow did not.

What changed:

- `omarchy-migrate` lists and runs migrations from the trusted source root, and passes that root to each migration.
- `omarchy-install-browser` sources the browser policy helper from the trusted source root.
- `browser-policy.sh` installs the default policy files from the trusted source root.
- The locate migration pins `/etc/updatedb.conf` instead of forwarding a caller-chosen `OMARCHY_UPDATEDB_CONF_PATH` into the root shell.

A linked checkout still works when `/etc/omarchy.conf` is a root-owned regular file whose only line names that checkout, which is what `omarchy-dev-link` writes. Setting `OMARCHY_PATH` by hand without `omarchy dev link` no longer moves the migration queue.

Tests: new `test/shell.d/privileged-source-update-test.sh` pins the trusted-tree behavior and shows a poisoned `OMARCHY_PATH` is ignored, with sudo stubbed so nothing touches the real system. `migrate-scope` and `migrate-wrapper` now authorize their scratch trees through a stand-in conf, the way `omarchy-dev-link` would. `locate-test` runs the pinned migration against a stand-in `updatedb.conf`. All pass, along with `migrate-notify` and `bin-style`.
