### PR TITLE
Refuse toggle and web app names that contain a slash

### DIFF
--- a/bin/omarchy-hyprland-toggle
+++ b/bin/omarchy-hyprland-toggle
@@ -14,6 +14,16 @@ fi
 
 FLAG_NAME="$1"
 ACTION="${2:-toggle}"
+
+# The name becomes a filename in two paths. A slash would turn it into
+# directory levels, so a typo like ../foo would make off delete a .lua outside
+# the toggle directory. Refuse it, the same way omarchy-webapp-install and
+# omarchy-theme-set refuse names with a slash.
+if [[ $FLAG_NAME == */* ]]; then
+  echo "Flag name cannot contain '/': $FLAG_NAME" >&2
+  exit 1
+fi
+
 FLAG_FILE="$HOME/.local/state/omarchy/toggles/hypr/$FLAG_NAME.lua"
 FLAG_SOURCE="$OMARCHY_PATH/default/hypr/toggles/$FLAG_NAME.lua"
 

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -50,6 +50,14 @@ if [[ -z $APP_NAME ]]; then
   exit 1
 fi
 
+# Same rule as omarchy-webapp-install: the name becomes a filename. A slash
+# would turn the fallback paths below into directory levels, so a mistyped name
+# could delete a .desktop or icon outside the directories this command owns.
+if [[ $APP_NAME == */* ]]; then
+  echo "App name cannot contain '/': $APP_NAME" >&2
+  exit 1
+fi
+
 icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
 desktop_file=$(path_for_web_app "$APP_NAME")
 rm -f "${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}"

--- a/test/shell.d/launcher-toggle-name-guard-test.sh
+++ b/test/shell.d/launcher-toggle-name-guard-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+stub_bin="$test_tmp/bin"
+test_root="$test_tmp/omarchy"
+mkdir -p "$test_home/.local/share/applications" \
+  "$test_home/.local/state/omarchy/toggles/hypr" \
+  "$stub_bin" \
+  "$test_root/default/hypr/toggles"
+
+for stub in hyprctl update-desktop-database omarchy-notification-send; do
+  printf '#!/bin/bash\n:\n' >"$stub_bin/$stub"
+  chmod +x "$stub_bin/$stub"
+done
+
+echo '-- example flag' >"$test_root/default/hypr/toggles/example.lua"
+
+run_toggle() {
+  HOME="$test_home" OMARCHY_PATH="$test_root" PATH="$stub_bin:/usr/bin" \
+    "$ROOT/bin/omarchy-hyprland-toggle" "$@"
+}
+
+run_remove() {
+  HOME="$test_home" OMARCHY_REMOVE_NOTIFY=false PATH="$stub_bin:/usr/bin" \
+    "$ROOT/bin/omarchy-webapp-remove" "$@"
+}
+
+# A slashed toggle name used to leave the toggle directory. The toggle
+# directory must exist for the escape to resolve, so keep it in place.
+victim="$test_home/.local/state/omarchy/victim.lua"
+echo 'keep me' >"$victim"
+
+output=$(run_toggle '../../victim' off 2>&1) &&
+  fail "hyprland-toggle rejects a flag name containing a slash"
+[[ $output == *"Flag name cannot contain '/'"* ]] ||
+  fail "hyprland-toggle says why it refused a slashed name" "$output"
+[[ -f $victim ]] ||
+  fail "hyprland-toggle leaves a file outside the toggle directory alone"
+pass "hyprland-toggle rejects a flag name that escapes the toggle directory"
+
+flag="$test_home/.local/state/omarchy/toggles/hypr/example.lua"
+
+run_toggle example on >/dev/null
+[[ -f $flag ]] || fail "hyprland-toggle still enables a plain flag name"
+run_toggle example off >/dev/null
+[[ ! -f $flag ]] || fail "hyprland-toggle still disables a plain flag name"
+pass "hyprland-toggle still toggles plain flag names"
+
+# A slashed web app name used to escape the applications directory through
+# the rebuilt fallback path.
+victim="$test_home/.local/victim.desktop"
+echo '[Desktop Entry]' >"$victim"
+
+output=$(run_remove '../../victim' 2>&1) &&
+  fail "webapp-remove rejects an app name containing a slash"
+[[ $output == *"App name cannot contain '/'"* ]] ||
+  fail "webapp-remove says why it refused a slashed name" "$output"
+[[ -f $victim ]] ||
+  fail "webapp-remove leaves a file outside the applications directory alone"
+pass "webapp-remove rejects an app name that escapes the applications directory"


### PR DESCRIPTION
`omarchy-hyprland-toggle` joins the flag name into two paths unchecked:

```
FLAG_FILE="$HOME/.local/state/omarchy/toggles/hypr/$FLAG_NAME.lua"
FLAG_SOURCE="$OMARCHY_PATH/default/hypr/toggles/$FLAG_NAME.lua"
```

`omarchy-hyprland-toggle ../../victim off` deletes `victim.lua` two levels above the toggle directory and exits 0. `on` with the same name copies to a mirrored path outside `toggles/hypr`. Hyprland never sources that file (`default/hypr/toggles.lua` only walks `toggles/hypr`), so `on` just leaves a stray copy. The delete is the part that matters.

`omarchy-webapp-remove` has the same shape in its fallback. When the name is not in the index, the path is rebuilt from the raw name:

```
rm -f "${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}"
```

`omarchy-webapp-remove ../../victim` deletes `victim.desktop` outside the applications directory and exits 0.

This is not a security fix. Both commands run as the user on the user's own files, and no caller in the repo passes untrusted input: the toggle callers use fixed names, and `omarchy-webapp-remove` gets a basename from the picker or from `omarchy-remove-launcher-entry`. It is a footgun guard for a mistyped or scripted name, and it brings these two commands in line with `omarchy-webapp-install` and `omarchy-theme-set`, which already refuse names with a slash.

What changed:

- `omarchy-hyprland-toggle` rejects a flag name containing a slash before building its paths.
- `omarchy-webapp-remove` rejects an app name containing a slash, with the same message as `omarchy-webapp-install`.
- Both print the refusal on stderr.

Tests: new `test/shell.d/launcher-toggle-name-guard-test.sh`. Both refusals say why they refused and leave a file outside the guarded directory untouched, and plain names still toggle and remove. `webapp-name` (including the nested legacy launcher case), `webapp-install-escaping`, and `toggle` all pass. The new test fails on the pre-fix scripts.