### PR TITLE
Add battery charge limit picker to the power panel

### DIFF
--- a/bin/omarchy-battery-limit-get
+++ b/bin/omarchy-battery-limit-get
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Print the current battery charge limit percentage.
+# omarchy:hidden=true
+
+power_supply_path="${OMARCHY_POWER_SUPPLY_PATH:-/sys/class/power_supply}"
+
+for threshold in "$power_supply_path"/BAT*/charge_control_end_threshold; do
+  if [[ -r $threshold ]]; then
+    cat "$threshold"
+    exit 0
+  fi
+done
+
+exit 1

--- a/bin/omarchy-battery-limit-set
+++ b/bin/omarchy-battery-limit-set
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# omarchy:summary=Set the battery charge limit
+# omarchy:args=<80|90|100>
+# omarchy:examples=omarchy battery limit-set 80 | omarchy battery limit-set 100
+
+set -euo pipefail
+
+# Whenever this runs as root — invoked directly through the passwordless
+# sudoers rule, or re-execed by require_root below — sudo's secure_path decides
+# where a bare helper resolves, and a dev link (etc/sudoers.d/omarchy-dev-path)
+# prepends a user-writable checkout bin/ to it. Every helper this script calls
+# by bare name (install, cat) is a system tool, never an omarchy-* command, so
+# pin PATH to trusted system directories and keep root from resolving one out
+# of that checkout. The unprivileged wrapper phase keeps the caller's PATH so
+# it can still find sudo/pkexec.
+if (( EUID == 0 )); then
+  export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
+fi
+
+STATE_FILE=/etc/omarchy/battery-limit
+
+usage() {
+  echo "Usage: omarchy-battery-limit-set <80|90|100>" >&2
+}
+
+# Validate before any elevation so a bad argument never reaches sudo/pkexec,
+# and so the check can be exercised without root.
+if (( $# != 1 )); then
+  usage
+  exit 2
+fi
+
+case "$1" in
+80 | 90 | 100)
+  limit="$1"
+  ;;
+*)
+  usage
+  exit 2
+  ;;
+esac
+
+# The path etc/sudoers.d/omarchy-battery-limit names. The privileged half
+# always runs from there rather than from whichever copy was invoked, so the
+# rule matches even where $OMARCHY_PATH points at a checkout.
+PACKAGED_PATH=/usr/bin/omarchy-battery-limit-set
+
+# True when sudo would run this exact command without stopping for a password.
+# `sudo -l` on its own reports whether a command is permitted, which the blanket
+# %wheel rule answers yes to for everything; the long listing prints the matched
+# entry's tags, so !authenticate is the grant in
+# etc/sudoers.d/omarchy-battery-limit and nothing else. Listing runs nothing
+# and, under -n, prompts for nothing, so a machine whose omarchy-settings
+# predates that file falls through to polkit instead of dying on a password
+# prompt it has no terminal to show.
+sudo_grants_passwordless() {
+  sudo -n -l -l "$PACKAGED_PATH" "$@" 2>/dev/null | grep -q '!authenticate'
+}
+
+require_root() {
+  if (( EUID == 0 )); then
+    return
+  elif [[ -t 0 ]] || sudo_grants_passwordless "$@"; then
+    # A terminal can carry sudo's own password prompt. Without one, sudo is
+    # right only where the grant reaches; polkit can at least put a prompt on
+    # screen, and offer to authenticate as someone else.
+    exec sudo "$PACKAGED_PATH" "$@"
+  else
+    exec pkexec "$PACKAGED_PATH" "$@"
+  fi
+}
+
+require_root "$limit"
+
+power_supply_path="${OMARCHY_POWER_SUPPLY_PATH:-/sys/class/power_supply}"
+
+wrote=false
+for threshold in "$power_supply_path"/BAT*/charge_control_end_threshold; do
+  [[ -e $threshold ]] || continue
+  echo "$limit" >"$threshold"
+  wrote=true
+done
+
+if [[ $wrote == "false" ]]; then
+  echo "Error: no battery on this machine exposes a charge limit (charge_control_end_threshold)." >&2
+  exit 1
+fi
+
+# Persist the choice so omarchy-battery-limit.service can restore it at boot
+# on hardware whose embedded controller forgets the threshold across cycles.
+install -d -m 0755 /etc/omarchy
+printf '%s\n' "$limit" >"$STATE_FILE"
+chmod 0644 "$STATE_FILE"

--- a/bin/omarchy-hw-battery-charge-limit
+++ b/bin/omarchy-hw-battery-charge-limit
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Returns true when a battery exposes a charge limit control.
+
+power_supply_path="${OMARCHY_POWER_SUPPLY_PATH:-/sys/class/power_supply}"
+
+for threshold in "$power_supply_path"/BAT*/charge_control_end_threshold; do
+  [[ -r $threshold ]] && exit 0
+done
+
+exit 1

--- a/default/systemd/system/omarchy-battery-limit.service
+++ b/default/systemd/system/omarchy-battery-limit.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Restore the Omarchy battery charge limit
+# Some embedded controllers forget the charge threshold across power cycles.
+# omarchy-battery-limit-set saves the choice to /etc/omarchy/battery-limit, and
+# this unit re-applies it at boot. No saved limit, nothing to do.
+ConditionPathExists=/etc/omarchy/battery-limit
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c '/usr/bin/omarchy-battery-limit-set "$(cat /etc/omarchy/battery-limit)"'
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/sudoers.d/omarchy-battery-limit
+++ b/etc/sudoers.d/omarchy-battery-limit
@@ -1,0 +1,4 @@
+# Picking a charge limit in the power panel applies it with one click, so it
+# must not stop for a password. Only the fixed presets are covered: the setter
+# rejects any other value before it ever elevates.
+%wheel ALL=(root) NOPASSWD: /usr/bin/omarchy-battery-limit-set 80, /usr/bin/omarchy-battery-limit-set 90, /usr/bin/omarchy-battery-limit-set 100

--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -52,7 +52,7 @@ The panels aren't read-outs. They're where you actually do the thing:
 - **Audio** has a master volume slider, an output-device picker, and a per-app mixer, so you can turn down that one browser tab without touching everything else.
 - **Network** scans for Wi-Fi, shows signal strength, connects, and lets you pick a DNS provider.
 - **Bluetooth** lists your devices with connect/disconnect and battery levels.
-- **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info.
+- **Power** shows battery stats, switches power profiles (it remembers a separate choice for battery and AC), and prints some system info. On laptops whose battery supports charge limiting, it also offers a charge-limit picker — cap charging at 80% or 90% instead of 100% to spare the battery when you live on the charger. The choice persists across reboots.
 - **Display** carries a brightness slider, text size, monitor scaling presets, and — when you have more than one screen — per-monitor controls. See [monitors](33-monitors.md) for the deeper story.
 - **Clock** opens a month grid with ISO week numbers and month stepping.
 

--- a/migrations/1788175955.sh
+++ b/migrations/1788175955.sh
@@ -1,0 +1,16 @@
+echo "Install the battery charge-limit sudoers rule and boot-restore service"
+
+# The one-click charge-limit picker elevates omarchy-battery-limit-set through
+# the passwordless grant in etc/sudoers.d/omarchy-battery-limit. The package
+# owns that file for fresh installs; existing installs pick it up here.
+sudo install -D -m 440 "$OMARCHY_PATH/etc/sudoers.d/omarchy-battery-limit" /etc/sudoers.d/omarchy-battery-limit
+
+# Only laptops whose battery exposes charge_control_end_threshold get the
+# boot-restore unit; everywhere else there is nothing for it to re-apply.
+# Idempotent: install over an identical copy and re-enabling an enabled unit
+# both no-op.
+if omarchy-hw-battery-charge-limit; then
+  sudo install -D -m 644 "$OMARCHY_PATH/default/systemd/system/omarchy-battery-limit.service" /etc/systemd/system/omarchy-battery-limit.service
+  sudo systemctl daemon-reload
+  sudo systemctl enable omarchy-battery-limit.service >/dev/null 2>&1 || true
+fi

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -38,6 +38,12 @@ function parseProfiles(raw, previousIndex) {
   }
 }
 
+function parseChargeLimit(raw) {
+  var value = parseInt(String(raw || "").trim())
+  if (isNaN(value) || value < 0 || value > 100) return null
+  return value
+}
+
 function profileIcon(name) {
   if (name === "power-saver") return "󰌪"
   if (name === "balanced") return "󰊚"
@@ -95,6 +101,7 @@ if (typeof module !== "undefined") {
     selectProfileIndex: selectProfileIndex,
     parseKeyValue: parseKeyValue,
     parseProfiles: parseProfiles,
+    parseChargeLimit: parseChargeLimit,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -138,6 +138,7 @@ Panel {
     if (!batteryProc.running) batteryProc.running = true
     if (!profilesProc.running) profilesProc.running = true
     if (!systemProc.running) systemProc.running = true
+    if (chargeLimitSupported && !thresholdReadProc.running) thresholdReadProc.running = true
   }
 
   function updateKeyValue(raw, targetName) {
@@ -169,6 +170,26 @@ Panel {
     actionProc.running = true
   }
 
+  // Charge limit (the battery's end threshold in sysfs), selectable from
+  // chargeLimitOptions. Read/set through the omarchy-battery-limit-* commands
+  // so the first capable battery is targeted instead of assuming BAT0, and
+  // read straight from sysfs rather than upower, which caches and can report
+  // a "75-80%" start-end range. Support is probed once per panel open via
+  // omarchy-hw-battery-charge-limit and cached in chargeLimitSupported.
+  property string chargeLimitRaw: ""
+  readonly property int chargeLimit: {
+    var parsed = Model.parseChargeLimit(root.chargeLimitRaw)
+    return parsed === null ? 100 : parsed
+  }
+  readonly property var chargeLimitOptions: [80, 90, 100]
+  property bool chargeLimitSupported: false
+
+  function setChargeLimit(value) {
+    if (thresholdProc.running) return
+    thresholdProc.command = ["omarchy-battery-limit-set", String(value)]
+    thresholdProc.running = true
+  }
+
   function togglePercentage() {
     root.settings = Object.assign({}, root.settings, { showPercentage: !root.showPercentage })
     if (root.bar && root.bar.shell) root.bar.shell.updateEntryInline(root.moduleName, root.settings)
@@ -193,6 +214,7 @@ Panel {
       }
 
       refresh()
+      if (!chargeLimitCheckProc.running) chargeLimitCheckProc.running = true
       var idx = profiles.indexOf(activeProfile)
       profileIndex = idx >= 0 ? idx : 0
       cursorActive = false
@@ -226,6 +248,26 @@ Panel {
   Process {
     id: actionProc
     onExited: root.refresh()
+  }
+
+  Process {
+    id: thresholdProc
+    onExited: root.refresh()
+  }
+
+  Process {
+    id: thresholdReadProc
+    command: ["omarchy-battery-limit-get"]
+    stdout: StdioCollector { waitForEnd: true; onStreamFinished: root.chargeLimitRaw = text.trim() }
+  }
+
+  Process {
+    id: chargeLimitCheckProc
+    command: ["omarchy-hw-battery-charge-limit"]
+    onExited: function(exitCode) {
+      root.chargeLimitSupported = exitCode === 0
+      if (root.chargeLimitSupported && !thresholdReadProc.running) thresholdReadProc.running = true
+    }
   }
 
   Timer { interval: 5000; running: root.opened; repeat: true; onTriggered: root.refresh() }
@@ -499,6 +541,54 @@ Panel {
                     root.profileIndex = index
                   }
                 }
+              }
+            }
+          }
+        }
+
+        // ---------- Charge limit picker ----------
+        PanelSeparator {
+          visible: root.chargeLimitSupported
+          foreground: root.bar.foreground
+        }
+
+        Column {
+          visible: root.chargeLimitSupported
+          width: parent.width
+          spacing: Style.space(10)
+
+          PanelSectionHeader {
+            text: "CHARGE LIMIT — " + root.chargeLimit + "%"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          Row {
+            id: chargeLimitRow
+            width: parent.width
+            spacing: Style.space(6)
+
+            readonly property real cellWidth: (width - spacing * (root.chargeLimitOptions.length - 1)) / root.chargeLimitOptions.length
+            readonly property var labels: ({ 80: "Max conserve", 90: "Conserve", 100: "Max battery" })
+            readonly property var icons: ({ 80: "󰹦", 90: "󰌪", 100: "󰁹" })
+
+            Repeater {
+              model: root.chargeLimitOptions
+              Button {
+                required property var modelData
+                width: chargeLimitRow.cellWidth
+                iconText: chargeLimitRow.icons[modelData] || ""
+                iconSize: Style.font.title
+                text: chargeLimitRow.labels[modelData] || ""
+                fontSize: Style.font.bodySmall
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                horizontalPadding: Style.space(2)
+                verticalPadding: Style.spacing.controlPaddingY + Style.space(2)
+                bordered: true
+                active: root.chargeLimit === modelData
+                selected: root.chargeLimit === modelData
+                onClicked: root.setChargeLimit(modelData)
               }
             }
           }

--- a/test/shell.d/battery-limit-test.sh
+++ b/test/shell.d/battery-limit-test.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+setter="$ROOT/bin/omarchy-battery-limit-set"
+getter="$ROOT/bin/omarchy-battery-limit-get"
+hw="$ROOT/bin/omarchy-hw-battery-charge-limit"
+sudoers_file="$ROOT/etc/sudoers.d/omarchy-battery-limit"
+rule='%wheel ALL=(root) NOPASSWD: /usr/bin/omarchy-battery-limit-set 80, /usr/bin/omarchy-battery-limit-set 90, /usr/bin/omarchy-battery-limit-set 100'
+
+# Exactly one rule, matched whole. A second line -- or the same command with
+# its argument dropped, which sudoers reads as "any arguments" -- would widen
+# the grant while leaving this line in place.
+rules=$(grep -vE '^[[:space:]]*(#|$)' "$sudoers_file")
+[[ $rules == "$rule" ]] ||
+  fail "battery-limit sudoers file carries exactly the three-preset rule and nothing else" "got: $rules"
+
+if command -v visudo >/dev/null; then
+  visudo -cf "$sudoers_file" >/dev/null || fail "battery-limit sudoers rule parses"
+fi
+
+grep -Fx 'PACKAGED_PATH=/usr/bin/omarchy-battery-limit-set' "$setter" >/dev/null ||
+  fail "omarchy-battery-limit-set elevates the path the sudoers rule names"
+
+# `sudo -l` on its own answers whether a command is permitted, not whether it
+# is passwordless, and Omarchy ships a blanket %wheel rule that permits
+# everything. Only the long listing prints the matched entry's tags.
+grep -E 'sudo -n -l -l' "$setter" >/dev/null ||
+  fail "omarchy-battery-limit-set reads the grant from the long sudo listing"
+
+pass "battery-limit sudoers rule is scoped to the three presets"
+
+# The privileged half runs as root under sudo's secure_path, and a dev link
+# (etc/sudoers.d/omarchy-dev-path) prepends a user-writable checkout bin/ to
+# it. Every helper the script calls by bare name is a system tool, so once it
+# holds root the script pins PATH to trusted system directories and never
+# resolves one of them out of the checkout.
+grep -Eq '^\s*export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin' "$setter" ||
+  fail "omarchy-battery-limit-set pins PATH to trusted system directories when it holds root"
+# require_root carries its own `(( EUID == 0 ))`, so matching that text alone
+# would pass with the pin deleted. Anchor on the unindented guard and require
+# the pin to be the line it opens.
+gated=$(grep -A1 -E '^if \(\( EUID == 0 \)\); then$' "$setter" || true)
+[[ $gated == *"export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin"* ]] ||
+  fail "omarchy-battery-limit-set gates the trusted-PATH pin on holding root"
+
+pass "omarchy-battery-limit-set pins PATH to trusted system directories when root"
+
+# Argument validation runs before require_root, so a rejected value never
+# reaches sudo/pkexec -- and these checks never need root.
+check_reject() {
+  local description="$1"
+  shift
+  local output status
+
+  if output=$("$setter" "$@" </dev/null 2>&1); then
+    status=0
+  else
+    status=$?
+  fi
+
+  (( status == 2 )) || fail "$description exits 2" "got exit $status: $output"
+  [[ $output == "Usage: omarchy-battery-limit-set"* ]] ||
+    fail "$description prints usage to stderr" "got: $output"
+}
+
+check_reject "no argument"
+check_reject "unsupported preset" 50
+check_reject "non-numeric argument" full
+check_reject "extra arguments" 80 90
+
+pass "omarchy-battery-limit-set rejects anything but 80, 90, 100 with exit 2"
+
+# require_root returns immediately for root, so the stubs below would not
+# stand between the script and this machine's real sysfs and /etc.
+if (( EUID == 0 )); then
+  pass "running as root; skipping the elevation checks, which would write to sysfs"
+else
+  test_tmp=$(mktemp -d)
+  trap 'rm -rf "$test_tmp"' EXIT
+
+  stub_bin="$test_tmp/bin"
+  mkdir -p "$stub_bin"
+
+  # pkexec stands in for the exec at the end of require_root, so the sysfs
+  # writes below it never run and real pkexec is never reached.
+  cat >"$stub_bin/pkexec" <<'SH'
+#!/bin/bash
+printf 'pkexec %s\n' "$*" >"$ELEVATION_LOG"
+SH
+  chmod +x "$stub_bin/pkexec"
+
+  # The sudo stub plays both parts: it answers the passwordless probe from
+  # STUB_GRANTED, the presets etc/sudoers.d/omarchy-battery-limit covers on
+  # this machine, and logs the elevation otherwise. STUB_GRANTED empty stands
+  # for an install whose omarchy-settings predates the file.
+  cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+if [[ $1 == -n && $2 == -l ]]; then
+  for granted in ${STUB_GRANTED-80 90 100}; do
+    [[ ${!#} == "$granted" ]] || continue
+    echo "    Options: !authenticate"
+    exit 0
+  done
+  echo "    Matched: ${!#}"
+  exit 0
+fi
+printf 'sudo %s\n' "$*" >"$ELEVATION_LOG"
+SH
+  chmod +x "$stub_bin/sudo"
+
+  elevation_for() {
+    : >"$test_tmp/elevation"
+    ELEVATION_LOG="$test_tmp/elevation" \
+    PATH="$stub_bin:$PATH" \
+      bash "$setter" "$1" </dev/null >/dev/null
+    cat "$test_tmp/elevation"
+  }
+
+  for preset in 80 90 100; do
+    elevation=$(elevation_for "$preset")
+    [[ $elevation == "sudo /usr/bin/omarchy-battery-limit-set $preset" ]] ||
+      fail "omarchy-battery-limit-set takes the passwordless sudo grant for $preset without a terminal" "got: $elevation"
+  done
+
+  pass "omarchy-battery-limit-set elevates the presets through sudo, not polkit"
+
+  # A dev-linked checkout elevates the packaged path like everyone else,
+  # rather than handing sudo a path no rule can name and losing the grant.
+  dev_linked=$(OMARCHY_PATH="$test_tmp/checkout" elevation_for 80)
+  [[ $dev_linked == "sudo /usr/bin/omarchy-battery-limit-set 80" ]] ||
+    fail "omarchy-battery-limit-set elevates the system install wherever OMARCHY_PATH points" "got: $dev_linked"
+
+  # The grant is what makes sudo passwordless, so its absence -- an install
+  # still on an older omarchy-settings, or a user outside %wheel the rule
+  # cannot match -- has to route to polkit.
+  ungranted=$(STUB_GRANTED="" elevation_for 80)
+  [[ $ungranted == "pkexec /usr/bin/omarchy-battery-limit-set 80" ]] ||
+    fail "omarchy-battery-limit-set falls back to polkit where the sudoers grant is not installed" "got: $ungranted"
+
+  pass "omarchy-battery-limit-set falls back to polkit wherever the grant does not reach"
+
+  rm -rf "$test_tmp"
+  trap - EXIT
+fi
+
+# The hw gate and the getter read sysfs through OMARCHY_POWER_SUPPLY_PATH, so
+# point them at a fixture instead of depending on this machine's battery.
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/BAT0"
+
+if OMARCHY_POWER_SUPPLY_PATH="$fixture" "$hw"; then
+  fail "hw battery-charge-limit exits 1 when no battery exposes the threshold file"
+fi
+pass "hw battery-charge-limit exits 1 without a charge_control_end_threshold"
+
+if output=$(OMARCHY_POWER_SUPPLY_PATH="$fixture" "$getter" 2>&1); then
+  fail "battery-limit-get exits 1 when no battery exposes the threshold file"
+fi
+[[ -z $output ]] ||
+  fail "battery-limit-get stays silent when it finds nothing" "got: $output"
+pass "battery-limit-get exits 1 silently without a charge_control_end_threshold"
+
+printf '80\n' >"$fixture/BAT0/charge_control_end_threshold"
+
+OMARCHY_POWER_SUPPLY_PATH="$fixture" "$hw" ||
+  fail "hw battery-charge-limit exits 0 when a battery exposes the threshold file"
+pass "hw battery-charge-limit exits 0 with a readable charge_control_end_threshold"
+
+value=$(OMARCHY_POWER_SUPPLY_PATH="$fixture" "$getter")
+[[ $value == "80" ]] ||
+  fail "battery-limit-get prints the threshold of the first battery" "got: $value"
+pass "battery-limit-get prints the current charge limit"
+
+mkdir -p "$fixture/BAT1"
+printf '90\n' >"$fixture/BAT1/charge_control_end_threshold"
+
+value=$(OMARCHY_POWER_SUPPLY_PATH="$fixture" "$getter")
+[[ $value == "80" || $value == "90" ]] ||
+  fail "battery-limit-get prints one battery's threshold when several exist" "got: $value"
+pass "battery-limit-get reads the first battery when several exist"

--- a/test/shell.d/power-charge-limit-test.sh
+++ b/test/shell.d/power-charge-limit-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const power = requireFromRoot('shell/plugins/panels/power/Model.js')
+const panelSource = fs.readFileSync(root + '/shell/plugins/panels/power/Panel.qml', 'utf8')
+
+assertEqual(power.parseChargeLimit('80'), 80, 'charge limit parses a plain integer')
+assertEqual(power.parseChargeLimit('90\n'), 90, 'charge limit trims trailing newline')
+assertEqual(power.parseChargeLimit(''), null, 'charge limit rejects empty output')
+assertEqual(power.parseChargeLimit('abc'), null, 'charge limit rejects non-numeric output')
+assertEqual(power.parseChargeLimit('150'), null, 'charge limit rejects values above 100')
+assertEqual(power.parseChargeLimit('-5'), null, 'charge limit rejects negative values')
+
+assert(/command: \["omarchy-battery-limit-get"\]/.test(panelSource), 'charge limit reads via omarchy-battery-limit-get')
+assert(/command = \["omarchy-battery-limit-set", String\(value\)\]/.test(panelSource), 'charge limit sets via omarchy-battery-limit-set')
+assert(/command: \["omarchy-hw-battery-charge-limit"\]/.test(panelSource), 'charge limit probes support via omarchy-hw-battery-charge-limit')
+assert(!/charge_control_end_threshold/.test(panelSource), 'charge limit does not hardcode the sysfs path')
+assert(!/sudo/.test(panelSource), 'charge limit does not self-elevate in the shell')
+
+assert(/root\.chargeLimitSupported = exitCode === 0/.test(panelSource), 'charge limit caches support from the probe exit code')
+assert(/onOpenedChanged:[\s\S]*?chargeLimitCheckProc\.running = true/.test(panelSource), 'charge limit probes support once per panel open')
+assert(/function refresh\(\) \{[\s\S]*?if \(chargeLimitSupported && !thresholdReadProc\.running\) thresholdReadProc\.running = true/.test(panelSource), 'charge limit refresh is gated on support')
+assertEqual(panelSource.match(/visible: root\.chargeLimitSupported/g).length, 2, 'charge limit hides the separator and section when unsupported')
+assert(/chargeLimitOptions: \[80, 90, 100\]/.test(panelSource), 'charge limit offers 80, 90, and 100 percent')
+assert(/"CHARGE LIMIT — " \+ root\.chargeLimit \+ "%"/.test(panelSource), 'charge limit header shows the current limit')
+JS


### PR DESCRIPTION
## What

Adds a charge limit picker (80 / 90 / 100%) to the power panel, so laptops that expose `charge_control_end_threshold` can cap charging with one click instead of dropping to a root shell.

## How

- **Capability gating**: new `omarchy-hw-battery-charge-limit` exits 0 only when a battery actually exposes `charge_control_end_threshold` (asus-wmi, thinkpad_acpi, Framework, etc.). The panel probes it once per open and hides the picker entirely on unsupported hardware and desktops.
- **Reading**: new hidden `omarchy-battery-limit-get` prints the current end threshold from the first capable battery. Direct sysfs read rather than upower, which can report a phantom "75-80%" start/end range.
- **Writing**: new `omarchy-battery-limit-set <80|90|100>` follows the `omarchy-dns` privilege pattern exactly — args validated before elevation, re-execs via `sudo` when a terminal is available, `pkexec` otherwise, PATH pinned to trusted directories when root. Writes every capable battery.
- **Passwordless grant**: `etc/sudoers.d/omarchy-battery-limit` covers exactly the three fixed presets, mirroring the existing `omarchy-dns` rule, so the one-click panel toggle never prompts. Any other value is rejected before elevation.
- **Persistence**: the setter saves the choice to `/etc/omarchy/battery-limit`, and a new `omarchy-battery-limit.service` oneshot re-applies it at boot for hardware whose embedded controller forgets thresholds across power cycles. No-op when no limit has been saved (`ConditionPathExists`).
- **Migration**: existing installs get the sudoers rule unconditionally and the systemd unit only on capable hardware.

## Tests

- `test/shell.d/battery-limit-test.sh` — sudoers rule scope and syntax, arg rejection (exit 2), sudo/pkexec elevation routing, sysfs fixture coverage for the hw check and getter.
- `test/shell.d/power-charge-limit-test.sh` — `parseChargeLimit` unit tests plus panel source assertions (correct commands, no hardcoded sysfs paths, no sudo in the shell, probe-once-per-open gating).
- `./test/cli` and `./test/shell` pass.

## Notes

- The panel picker is ported from a locally-run clone of the power panel that has been in daily use on an ASUS (asus-wmi) machine.
- Visual verification done: picker confirmed working in the running shell on asus-wmi hardware (see comment below).