### PR TITLE
Offer Thai as an install-time keyboard choice

### DIFF
--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -610,21 +610,10 @@ confirm_reboot() {
 }
 
 # Load the layout on the live VT and persist it for the installed system.
-# systemd-firstboot writes both the console KEYMAP and the XKB layout Hyprland
-# reads, matching what the ISO's configure_keyboard does at install time. A
-# keymap localectl doesn't know keeps the default rather than failing (defensive;
-# the picker no longer offers any such layout).
+# Shared with the form so ISO and first-boot cannot drift (omarchy_apply_keyboard).
 apply_keyboard() {
-  local keymap="$1"
-  [[ $(tty 2>/dev/null) == /dev/tty* ]] && loadkeys "$keymap" 2>/dev/null || true
-
-  if localectl --no-pager list-keymaps 2>/dev/null | grep -qix "$keymap"; then
-    systemd-firstboot --keymap="$keymap" --force >>"$LOG_FILE" 2>&1 || \
-      localectl set-keymap "$keymap" >>"$LOG_FILE" 2>&1 || \
-      log_step "could not persist keymap $keymap"
-  else
-    log_step "keymap $keymap unknown to localectl; keeping the default"
-  fi
+  omarchy_apply_keyboard "$1" >>"$LOG_FILE" 2>&1 || \
+    log_step "could not persist keymap $1"
 }
 
 # The same username/password/name/email form as the ISO configurator's Step 2.

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -610,10 +610,31 @@ confirm_reboot() {
 }
 
 # Load the layout on the live VT and persist it for the installed system.
-# Shared with the form so ISO and first-boot cannot drift (omarchy_apply_keyboard).
+# systemd-firstboot writes both the console KEYMAP and the XKB layout Hyprland
+# reads, matching what the ISO's configure_keyboard does at install time. A
+# keymap localectl doesn't know keeps the default rather than failing (defensive).
+#
+# XKB-only picker values (OMARCHY_XKB_ONLY_LAYOUTS) are the exception: kbd
+# ships no console map, so persist us (Latin passwords/LUKS) and then point
+# XKBLAYOUT at the chosen layout for Hyprland.
 apply_keyboard() {
-  omarchy_apply_keyboard "$1" >>"$LOG_FILE" 2>&1 || \
-    log_step "could not persist keymap $1"
+  local keymap="$1"
+
+  if omarchy_xkb_only_layout "$keymap"; then
+    apply_keyboard us
+    omarchy_write_xkblayout "$keymap"
+    return 0
+  fi
+
+  [[ $(tty 2>/dev/null) == /dev/tty* ]] && loadkeys "$keymap" 2>/dev/null || true
+
+  if localectl --no-pager list-keymaps 2>/dev/null | grep -qix "$keymap"; then
+    systemd-firstboot --keymap="$keymap" --force >>"$LOG_FILE" 2>&1 || \
+      localectl set-keymap "$keymap" >>"$LOG_FILE" 2>&1 || \
+      log_step "could not persist keymap $keymap"
+  else
+    log_step "keymap $keymap unknown to localectl; keeping the default"
+  fi
 }
 
 # The same username/password/name/email form as the ISO configurator's Step 2.

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -97,39 +97,16 @@ omarchy_console_keymap_for() {
   fi
 }
 
-# Persist a picker value into vconsole.conf. Optional second argument is a
-# target root whose etc/vconsole.conf is written (ISO-style systemd-firstboot
-# --root); omit it to write the running system. XKB-only layouts persist us
-# for the console, then point XKBLAYOUT at the chosen layout.
-omarchy_apply_keyboard() {
+# After a Latin console keymap is persisted, point XKBLAYOUT at an XKB-only
+# picker value (no matching kbd map). Optional second arg is the vconsole file.
+omarchy_write_xkblayout() {
   local keymap=$1
-  local root=${2:-}
-  local vconsole=/etc/vconsole.conf
-  local console_map firstboot_args=()
+  local vconsole=${2:-/etc/vconsole.conf}
 
-  console_map=$(omarchy_console_keymap_for "$keymap")
-  [[ -n $root ]] && vconsole="$root/etc/vconsole.conf"
-
-  [[ $(tty 2>/dev/null) == /dev/tty* ]] && loadkeys "$console_map" 2>/dev/null || true
-
-  if ! localectl --no-pager list-keymaps 2>/dev/null | grep -qix "$console_map"; then
-    return 1
-  fi
-
-  [[ -n $root ]] && firstboot_args+=(--root="$root")
-  if ! systemd-firstboot "${firstboot_args[@]}" --keymap="$console_map" --force; then
-    # A --root caller is a test or an offline target; never fall through to
-    # localectl, which always writes the running system.
-    [[ -n $root ]] && return 1
-    localectl set-keymap "$console_map" || return 1
-  fi
-
-  if omarchy_xkb_only_layout "$keymap"; then
-    if grep -q '^XKBLAYOUT=' "$vconsole" 2>/dev/null; then
-      sed -i "s/^XKBLAYOUT=.*/XKBLAYOUT=$keymap/" "$vconsole"
-    else
-      echo "XKBLAYOUT=$keymap" >>"$vconsole"
-    fi
+  if grep -q '^XKBLAYOUT=' "$vconsole" 2>/dev/null; then
+    sed -i "s/^XKBLAYOUT=.*/XKBLAYOUT=$keymap/" "$vconsole"
+  else
+    echo "XKBLAYOUT=$keymap" >>"$vconsole"
   fi
 }
 

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -75,8 +75,63 @@ Spanish|es
 Spanish (Latin American)|la-latin1
 Swedish|sv-latin1
 Tajik|tj_alt-UTF8
+Thai (Kedmanee)|th
 Turkish|trq
 Ukrainian|ua'
+
+# Picker values that are XKB layouts, not kbd console keymaps. The live
+# console and LUKS prompt stay on us so Latin passwords remain typeable;
+# XKBLAYOUT carries the choice into Hyprland. The ISO configurator parses
+# this assignment the same way it reads OMARCHY_KEYBOARD_LAYOUTS.
+OMARCHY_XKB_ONLY_LAYOUTS="th"
+
+omarchy_xkb_only_layout() {
+  [[ " $OMARCHY_XKB_ONLY_LAYOUTS " == *" $1 "* ]]
+}
+
+omarchy_console_keymap_for() {
+  if omarchy_xkb_only_layout "$1"; then
+    printf '%s\n' us
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
+# Persist a picker value into vconsole.conf. Optional second argument is a
+# target root whose etc/vconsole.conf is written (ISO-style systemd-firstboot
+# --root); omit it to write the running system. XKB-only layouts persist us
+# for the console, then point XKBLAYOUT at the chosen layout.
+omarchy_apply_keyboard() {
+  local keymap=$1
+  local root=${2:-}
+  local vconsole=/etc/vconsole.conf
+  local console_map firstboot_args=()
+
+  console_map=$(omarchy_console_keymap_for "$keymap")
+  [[ -n $root ]] && vconsole="$root/etc/vconsole.conf"
+
+  [[ $(tty 2>/dev/null) == /dev/tty* ]] && loadkeys "$console_map" 2>/dev/null || true
+
+  if ! localectl --no-pager list-keymaps 2>/dev/null | grep -qix "$console_map"; then
+    return 1
+  fi
+
+  [[ -n $root ]] && firstboot_args+=(--root="$root")
+  if ! systemd-firstboot "${firstboot_args[@]}" --keymap="$console_map" --force; then
+    # A --root caller is a test or an offline target; never fall through to
+    # localectl, which always writes the running system.
+    [[ -n $root ]] && return 1
+    localectl set-keymap "$console_map" || return 1
+  fi
+
+  if omarchy_xkb_only_layout "$keymap"; then
+    if grep -q '^XKBLAYOUT=' "$vconsole" 2>/dev/null; then
+      sed -i "s/^XKBLAYOUT=.*/XKBLAYOUT=$keymap/" "$vconsole"
+    else
+      echo "XKBLAYOUT=$keymap" >>"$vconsole"
+    fi
+  fi
+}
 
 OMARCHY_USERNAME_PATTERN='^[a-z_][a-z0-9_-]*[$]?$'
 OMARCHY_RESERVED_USERNAMES='^(root|bin|daemon|mail|ftp|http|nobody|dbus|systemd-coredump|systemd-network|systemd-oom|systemd-journal-remote|systemd-resolve|systemd-timesync|tss|uuidd|alpm|git|avahi|cups|cups-browsed|lp|_talkd|polkitd|rtkit|qemu|brltty|gluster|rpc|libvirt-qemu|pcscd|nvidia-persistenced|sddm)$'

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -57,6 +57,12 @@ hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
 
 On Dell XPS laptops with a haptic touchpad, you can also set the click strength to low, mid, or high under _Trigger > Hardware > Touchpad Haptics_.
 
+### Typing in Thai
+
+Pick _Thai (Kedmanee)_ as the keyboard layout during installation (or first-boot owner setup). The console, disk encryption prompt, and login password stay on the US layout so Latin passphrases remain typeable. The desktop comes up English until you press Left Alt and Right Alt together — the same switch as other non-Latin layouts — or click the layout chip on the menu bar. Caps Lock stays the compose key.
+
+Thai is a regular keyboard layout, not an input method: you do not need fcitx5-configtool. Other Thai maps (Pattachote, Manoonchai) still go in `kb_variant` under _Setup > Input_.
+
 ### Typing in Chinese, Japanese, and other languages
 
 Omarchy runs the [fcitx5](https://fcitx-im.org/) input method framework as part of every session — it's what powers the CapsLock compose sequences. That means the plumbing for non-Latin input is already in place: install an input engine like `fcitx5-mozc` (Japanese) or `fcitx5-chinese-addons` (Chinese) with `omarchy pkg add`, plus `fcitx5-configtool` to add the engine to your input methods and set the key that switches between them.

--- a/test/shell.d/apply-keyboard-test.sh
+++ b/test/shell.d/apply-keyboard-test.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+require_command systemd-firstboot
+require_command localectl
+
+source "$ROOT/install/provisioning/setup-form.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -r "$tmp_dir"' EXIT
+
+resolved_input() {
+  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local vconsole = os.getenv("OMARCHY_VCONSOLE")
+local real_open = io.open
+
+io.open = function(path, mode)
+  if path ~= "/etc/vconsole.conf" then
+    return real_open(path, mode)
+  end
+
+  if not vconsole then
+    return nil
+  end
+
+  local file = io.tmpfile()
+  file:write(vconsole)
+  file:seek("set")
+  return file
+end
+
+hl = {
+  config = function(config)
+    local input = config.input
+    print(("[%s] [%s] [%s]"):format(input.kb_layout, input.kb_variant, input.kb_options))
+  end,
+}
+
+o = { window = function() end }
+
+require("default.hypr.input")
+LUA
+}
+
+vconsole_lines() {
+  grep -E '^(KEYMAP|XKBLAYOUT)=' "$1/etc/vconsole.conf"
+}
+
+make_root() {
+  local root=$1
+  mkdir -p "$root/etc"
+  printf '%s\n' 'KEYMAP=us' 'FONT=default8x16' >"$root/etc/vconsole.conf"
+}
+
+toggle_options="compose:caps,shift:both_capslock_cancel,grp:alts_toggle"
+
+# First-boot persist is the shipped omarchy_apply_keyboard: real systemd-firstboot
+# --root, then the XKBLAYOUT overwrite for xkb-only picker values.
+
+thai_root="$tmp_dir/thai"
+make_root "$thai_root"
+omarchy_apply_keyboard th "$thai_root" || fail "omarchy_apply_keyboard persists Thai"
+vconsole_lines "$thai_root" | grep -qx 'KEYMAP=us' ||
+  fail "Thai keeps a US console keymap" "$(vconsole_lines "$thai_root")"
+vconsole_lines "$thai_root" | grep -qx 'XKBLAYOUT=th' ||
+  fail "Thai writes XKBLAYOUT=th for Hyprland" "$(vconsole_lines "$thai_root")"
+[[ $(grep -c '^XKBLAYOUT=' "$thai_root/etc/vconsole.conf") == 1 ]] ||
+  fail "Thai leaves a single XKBLAYOUT line"
+pass "omarchy_apply_keyboard persists Thai as KEYMAP=us XKBLAYOUT=th"
+
+desktop=$(resolved_input "$(<"$thai_root/etc/vconsole.conf")")
+[[ $desktop == "[us,th] [,] [$toggle_options]" ]] ||
+  fail "Hyprland duals Thai from the persisted vconsole" "expected: [us,th] [,] [$toggle_options]
+actual:   $desktop"
+pass "persisted Thai vconsole becomes a us,th Hyprland session"
+
+de_root="$tmp_dir/de"
+make_root "$de_root"
+omarchy_apply_keyboard de "$de_root" || fail "omarchy_apply_keyboard persists German"
+vconsole_lines "$de_root" | grep -qx 'KEYMAP=de' ||
+  fail "German still writes KEYMAP=de" "$(vconsole_lines "$de_root")"
+vconsole_lines "$de_root" | grep -qx 'XKBLAYOUT=de' ||
+  fail "German still writes XKBLAYOUT=de" "$(vconsole_lines "$de_root")"
+pass "omarchy_apply_keyboard leaves console keymaps on themselves"
+
+unknown_root="$tmp_dir/unknown"
+make_root "$unknown_root"
+before=$(<"$unknown_root/etc/vconsole.conf")
+if omarchy_apply_keyboard definitely-not-a-keymap "$unknown_root"; then
+  fail "unknown picker values must not persist"
+fi
+[[ $(<"$unknown_root/etc/vconsole.conf") == "$before" ]] ||
+  fail "unknown picker values leave vconsole.conf untouched"
+pass "unknown layouts are refused without rewriting vconsole.conf"
+
+grep -q 'omarchy_apply_keyboard "\$1"' "$ROOT/bin/omarchy-provision-owner" ||
+  fail "first-boot apply_keyboard calls the shared persist helper"
+pass "omarchy-provision-owner apply_keyboard uses omarchy_apply_keyboard"
+
+printf '%s\n' "$OMARCHY_KEYBOARD_LAYOUTS" | grep -qx 'Thai (Kedmanee)|th' ||
+  fail "the picker lists Thai (Kedmanee)"
+awk -F'|' '
+  $1 == "Tajik" { tajik = 1; next }
+  $1 == "Thai (Kedmanee)" { if (!tajik) exit 1; thai = 1; next }
+  $1 == "Turkish" { if (!thai) exit 1; exit 0 }
+  END { exit thai && tajik ? 0 : 1 }
+' <<<"$OMARCHY_KEYBOARD_LAYOUTS" ||
+  fail "Thai (Kedmanee) sits alphabetically between Tajik and Turkish"
+pass "Thai (Kedmanee) is on the shared picker between Tajik and Turkish"

--- a/test/shell.d/apply-keyboard-test.sh
+++ b/test/shell.d/apply-keyboard-test.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 require_command lua
-require_command systemd-firstboot
-require_command localectl
 
 source "$ROOT/install/provisioning/setup-form.sh"
 
@@ -48,60 +46,50 @@ require("default.hypr.input")
 LUA
 }
 
-vconsole_lines() {
-  grep -E '^(KEYMAP|XKBLAYOUT)=' "$1/etc/vconsole.conf"
-}
-
-make_root() {
-  local root=$1
-  mkdir -p "$root/etc"
-  printf '%s\n' 'KEYMAP=us' 'FONT=default8x16' >"$root/etc/vconsole.conf"
-}
-
 toggle_options="compose:caps,shift:both_capslock_cancel,grp:alts_toggle"
+owner="$ROOT/bin/omarchy-provision-owner"
 
-# First-boot persist is the shipped omarchy_apply_keyboard: real systemd-firstboot
-# --root, then the XKBLAYOUT overwrite for xkb-only picker values.
+# The original persist path must still be in apply_keyboard. Thai only adds a
+# branch in front; it must not replace loadkeys / systemd-firstboot / localectl.
+grep -q 'loadkeys "$keymap"' "$owner" || fail "apply_keyboard still loadkeys the chosen console map"
+grep -q 'systemd-firstboot --keymap="$keymap" --force' "$owner" ||
+  fail "apply_keyboard still persists known console maps with systemd-firstboot"
+grep -q 'localectl set-keymap "$keymap"' "$owner" ||
+  fail "apply_keyboard still falls back to localectl set-keymap"
+grep -q 'keeping the default' "$owner" ||
+  fail "apply_keyboard still keeps the default for unknown console maps"
+pass "apply_keyboard keeps the existing console persist path"
 
-thai_root="$tmp_dir/thai"
-make_root "$thai_root"
-omarchy_apply_keyboard th "$thai_root" || fail "omarchy_apply_keyboard persists Thai"
-vconsole_lines "$thai_root" | grep -qx 'KEYMAP=us' ||
-  fail "Thai keeps a US console keymap" "$(vconsole_lines "$thai_root")"
-vconsole_lines "$thai_root" | grep -qx 'XKBLAYOUT=th' ||
-  fail "Thai writes XKBLAYOUT=th for Hyprland" "$(vconsole_lines "$thai_root")"
-[[ $(grep -c '^XKBLAYOUT=' "$thai_root/etc/vconsole.conf") == 1 ]] ||
-  fail "Thai leaves a single XKBLAYOUT line"
-pass "omarchy_apply_keyboard persists Thai as KEYMAP=us XKBLAYOUT=th"
+grep -q 'omarchy_xkb_only_layout "$keymap"' "$owner" ||
+  fail "apply_keyboard special-cases XKB-only picker values"
+grep -q 'apply_keyboard us' "$owner" ||
+  fail "XKB-only layouts reuse apply_keyboard us for the Latin console"
+grep -q 'omarchy_write_xkblayout "$keymap"' "$owner" ||
+  fail "XKB-only layouts then write XKBLAYOUT via the shared helper"
+pass "Thai persist is an added branch, not a replacement of apply_keyboard"
 
-desktop=$(resolved_input "$(<"$thai_root/etc/vconsole.conf")")
+# After apply_keyboard us, vconsole has KEYMAP=us and XKBLAYOUT=us. The new
+# helper only rewrites XKBLAYOUT; that is the first-boot Thai step.
+vconsole="$tmp_dir/vconsole.conf"
+printf '%s\n' 'KEYMAP=us' 'XKBLAYOUT=us' 'FONT=default8x16' >"$vconsole"
+omarchy_write_xkblayout th "$vconsole"
+grep -qx 'KEYMAP=us' "$vconsole" || fail "writing XKBLAYOUT leaves KEYMAP=us" "$(<"$vconsole")"
+grep -qx 'XKBLAYOUT=th' "$vconsole" || fail "writing XKBLAYOUT sets th" "$(<"$vconsole")"
+[[ $(grep -c '^XKBLAYOUT=' "$vconsole") == 1 ]] || fail "a single XKBLAYOUT line remains"
+grep -qx 'FONT=default8x16' "$vconsole" || fail "other vconsole lines are left alone"
+pass "omarchy_write_xkblayout points XKBLAYOUT at th without touching KEYMAP"
+
+desktop=$(resolved_input "$(<"$vconsole")")
 [[ $desktop == "[us,th] [,] [$toggle_options]" ]] ||
-  fail "Hyprland duals Thai from the persisted vconsole" "expected: [us,th] [,] [$toggle_options]
+  fail "Hyprland duals Thai from the first-boot vconsole" "expected: [us,th] [,] [$toggle_options]
 actual:   $desktop"
-pass "persisted Thai vconsole becomes a us,th Hyprland session"
+pass "first-boot Thai vconsole becomes a us,th Hyprland session"
 
-de_root="$tmp_dir/de"
-make_root "$de_root"
-omarchy_apply_keyboard de "$de_root" || fail "omarchy_apply_keyboard persists German"
-vconsole_lines "$de_root" | grep -qx 'KEYMAP=de' ||
-  fail "German still writes KEYMAP=de" "$(vconsole_lines "$de_root")"
-vconsole_lines "$de_root" | grep -qx 'XKBLAYOUT=de' ||
-  fail "German still writes XKBLAYOUT=de" "$(vconsole_lines "$de_root")"
-pass "omarchy_apply_keyboard leaves console keymaps on themselves"
-
-unknown_root="$tmp_dir/unknown"
-make_root "$unknown_root"
-before=$(<"$unknown_root/etc/vconsole.conf")
-if omarchy_apply_keyboard definitely-not-a-keymap "$unknown_root"; then
-  fail "unknown picker values must not persist"
-fi
-[[ $(<"$unknown_root/etc/vconsole.conf") == "$before" ]] ||
-  fail "unknown picker values leave vconsole.conf untouched"
-pass "unknown layouts are refused without rewriting vconsole.conf"
-
-grep -q 'omarchy_apply_keyboard "\$1"' "$ROOT/bin/omarchy-provision-owner" ||
-  fail "first-boot apply_keyboard calls the shared persist helper"
-pass "omarchy-provision-owner apply_keyboard uses omarchy_apply_keyboard"
+missing="$tmp_dir/missing.conf"
+printf '%s\n' 'KEYMAP=us' >"$missing"
+omarchy_write_xkblayout th "$missing"
+grep -qx 'XKBLAYOUT=th' "$missing" || fail "helper appends XKBLAYOUT when the key is absent"
+pass "omarchy_write_xkblayout appends XKBLAYOUT when it is missing"
 
 printf '%s\n' "$OMARCHY_KEYBOARD_LAYOUTS" | grep -qx 'Thai (Kedmanee)|th' ||
   fail "the picker lists Thai (Kedmanee)"

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -65,6 +65,9 @@ XKBVARIANT=intl
 assert_input "latin layouts are left alone" "[de] [nodeadkeys] [$base_options]" 'XKBLAYOUT=de
 XKBVARIANT=nodeadkeys
 '
+assert_input "thai duals as us,th from XKBLAYOUT" "[us,th] [,] [$toggle_options]" 'KEYMAP=us
+XKBLAYOUT=th
+'
 assert_input "non-latin layout gains us in front" "[us,ara] [,] [$toggle_options]" 'XKBLAYOUT=ara
 '
 assert_input "prepended us keeps variants aligned" "[us,ru] [,phonetic] [$toggle_options]" 'XKBLAYOUT=ru

--- a/test/shell.d/setup-form-test.sh
+++ b/test/shell.d/setup-form-test.sh
@@ -133,6 +133,22 @@ assert_status 0 "keyboard prompt succeeds"
 grep -qF -- '--selected English (US)' "$GUM_ARGS" || fail "keyboard prompt preselects English (US)"
 pass "keyboard prompt maps the chosen label to its keymap"
 
+run_prompt omarchy_prompt_keyboard "0:Thai (Kedmanee)"
+assert_status 0 "keyboard prompt accepts Thai (Kedmanee)"
+[[ $(field keyboard) == "th" ]] ||
+  fail "Thai (Kedmanee) resolves to th, the XKB marker apply_keyboard persists in place of a console keymap kbd does not ship"
+[[ $(field keyboard_label) == "Thai (Kedmanee)" ]] || fail "keyboard prompt keeps the Thai label for the summary"
+grep -qx 'Thai (Kedmanee)' "$tmp_dir/stdin.1" || fail "keyboard prompt offers Thai (Kedmanee)"
+pass "keyboard prompt maps Thai (Kedmanee) to the th marker"
+
+omarchy_xkb_only_layout th || fail "th is an xkb-only layout"
+if omarchy_xkb_only_layout us; then
+  fail "us is a console keymap, not xkb-only"
+fi
+[[ $(omarchy_console_keymap_for th) == "us" ]] || fail "xkb-only layouts load the US console map"
+[[ $(omarchy_console_keymap_for de) == "de" ]] || fail "console keymaps load themselves"
+pass "xkb-only layouts keep a Latin console"
+
 run_prompt omarchy_prompt_keyboard "1:"
 assert_status "$OMARCHY_FORM_BACK" "keyboard prompt reports Esc as back"
 assert_returned "keyboard prompt survives Esc under set -e"


### PR DESCRIPTION
Thai is missing from the install-time keyboard picker because the list maps labels to console keymaps and kbd ships no Thai map. Thai typing is still a normal XKB layout (`th`, Kedmanee by default) — not an IME — and Hyprland already knows what to do with `XKBLAYOUT=th`: `default/hypr/input.lua` prefixes `us,` for non-Latin layouts (Thai is already on that list) and adds `grp:alts_toggle`.

Selecting **Thai (Kedmanee)** now persists `KEYMAP=us` and `XKBLAYOUT=th`. The console, LUKS prompt, and login password stay Latin. The first session comes up `us,th` with Left Alt + Right Alt to switch. Caps Lock stays compose.

`apply_keyboard` in `omarchy-provision-owner` keeps its existing `loadkeys` / `systemd-firstboot` / `localectl` path. Thai is an extra branch: reuse `apply_keyboard us`, then `omarchy_write_xkblayout`. XKB-only picker values are named in `OMARCHY_XKB_ONLY_LAYOUTS` in `setup-form.sh` so the ISO configurator can persist them the same way.

Companion: https://github.com/omacom/omarchy-iso/pull/141. Without it, `configure_keyboard` rejects `th` and a fresh ISO install stays US. First-boot owner setup on an already-installed machine uses this package alone.

Not in this PR: post-install wizard, Pattachote/Manoonchai, fcitx5, Thai UI locale.

Related: https://github.com/omacom/omarchy/discussions/8050, https://github.com/omacom/omarchy/discussions/7677. Same installer hole as #9299, but Thai is xkb rather than an IME.

## Testing

- `test/shell.d/setup-form-test.sh` — picker maps Thai (Kedmanee) → `th`; German still → `de`; English (US) still leads
- `test/shell.d/apply-keyboard-test.sh` — original persist path still present; `omarchy_write_xkblayout` rewrites only XKBLAYOUT; that vconsole duals as `us,th` in `default/hypr/input.lua`
- `test/shell.d/hyprland-keyboard-layout-test.sh` — `XKBLAYOUT=th` → `us,th`