### PR TITLE
Coerce bar set values to the widget manifest type

### DIFF
--- a/bin/omarchy-bar
+++ b/bin/omarchy-bar
@@ -331,6 +331,66 @@ cmd_move() {
   echo "Moved $id"
 }
 
+# Look up the type the widget's own manifest declares for this key. Empty when
+# the catalog has no schema entry (unknown widget, free-form key, or catalog
+# unavailable) — callers then keep the historical string encoding.
+bar_setting_type() {
+  local id="$1" key="$2"
+  omarchy-plugin-catalog 2>/dev/null | jq -r --arg id "$id" --arg key "$key" '
+    .[]
+    | select(.id == $id)
+    | (.barWidget.schema // [])[]
+    | select(.key == $key)
+    | .type // empty
+  ' | head -n1
+}
+
+# Encode a bare CLI value as JSON. Without --json, match the manifest type so
+# `omarchy bar set … alwaysShow true` stores a boolean rather than the string
+# "true" (which QML's `=== true` then ignores while still printing success).
+encode_setting_value() {
+  local id="$1" key="$2" value="$3" value_is_json="$4"
+  local value_json schema_type lowered
+
+  if [[ $value_is_json == "true" ]]; then
+    value_json=$(jq -cn --argjson value "$value" '$value') ||
+      fail "invalid JSON value: $value"
+    printf '%s' "$value_json"
+    return
+  fi
+
+  schema_type=$(bar_setting_type "$id" "$key")
+  case "$schema_type" in
+    boolean)
+      lowered=${value,,}
+      case "$lowered" in
+        true | 1 | yes | on)
+          printf 'true'
+          ;;
+        false | 0 | no | off)
+          printf 'false'
+          ;;
+        *)
+          fail "setting $key expects a boolean (true/false), got: $value"
+          ;;
+      esac
+      ;;
+    number | integer)
+      [[ $value =~ ^-?[0-9]+([.][0-9]+)?$ ]] ||
+        fail "setting $key expects a number, got: $value"
+      # --argjson keeps a real JSON number rather than a quoted string.
+      value_json=$(jq -cn --argjson value "$value" '$value') ||
+        fail "setting $key expects a number, got: $value"
+      printf '%s' "$value_json"
+      ;;
+    *)
+      # Strings, multiselect, and undeclared keys stay strings unless --json.
+      value_json=$(jq -cn --arg value "$value" '$value')
+      printf '%s' "$value_json"
+      ;;
+  esac
+}
+
 cmd_set() {
   local id="${1:-}"
   local key="${2:-}"
@@ -350,12 +410,7 @@ cmd_set() {
     fail "set does not accept --before or --after"
 
   local value_json
-  if [[ $value_is_json == "true" ]]; then
-    value_json=$(jq -cn --argjson value "$value" '$value') ||
-      fail "invalid JSON value: $value"
-  else
-    value_json=$(jq -cn --arg value "$value" '$value')
-  fi
+  value_json=$(encode_setting_value "$id" "$key" "$value" "$value_is_json")
 
   local result
   result=$(omarchy-shell shell setBarWidget "$id" "$key" "$value_json" "$(placement_json)")

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -298,6 +298,35 @@ HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar transparent toggle
 jq -e '.bar.transparent == false' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
 pass "shell config toggles bar transparency"
 
+# Manifest-declared booleans must not be stored as the string "true"/"false":
+# Indicators.qml reads alwaysShow with `=== true`, which rejects the string form
+# while the CLI still reports success.
+HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.indicators alwaysShow true
+grep -Fqx 'shell setBarWidget omarchy.indicators alwaysShow true {}' \
+  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls" ||
+  fail "bar set coerces a bare true to a JSON boolean for alwaysShow" \
+    "$(tail -5 "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls")"
+pass "bar set coerces bare true to a boolean for alwaysShow"
+
+HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.indicators alwaysShow false
+grep -Fqx 'shell setBarWidget omarchy.indicators alwaysShow false {}' \
+  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls" ||
+  fail "bar set coerces a bare false to a JSON boolean for alwaysShow"
+pass "bar set coerces bare false to a boolean for alwaysShow"
+
+if HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.indicators alwaysShow maybe 2>/dev/null; then
+  fail "bar set accepted a non-boolean for a boolean setting"
+fi
+pass "bar set rejects a non-boolean for alwaysShow"
+
+# Free-form string settings stay strings without --json.
+HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.clock format HH:mm
+grep -Fqx 'shell setBarWidget omarchy.clock format "HH:mm" {}' \
+  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls" ||
+  fail "bar set still stores string settings as JSON strings" \
+    "$(tail -5 "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls")"
+pass "bar set keeps free-form string settings as strings"
+
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.bluetooth enabled false --json
 grep -Fqx 'shell setBarWidget omarchy.bluetooth enabled false {}' \
   "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls"


### PR DESCRIPTION
## Summary

Fixes #9330.

`omarchy bar set <id> <key> <value>` without `--json` always encoded the value as a JSON **string** via `jq --arg`. For settings the widget manifest declares as `"type": "boolean"` (e.g. `omarchy.indicators` `alwaysShow`), that produces a value QML never acts on:

```qml
readonly property bool alwaysShowIndicators: setting("alwaysShow", false) === true
```

`\"true\" === true` is false, while the CLI still prints `Set alwaysShow on omarchy.indicators` and exits 0.

## Change

- Look up the key's type from `omarchy-plugin-catalog` / `barWidget.schema`.
- Coerce bare `true`/`false`/`on`/`off`/… to JSON booleans and numeric bare values to JSON numbers when the schema says so.
- Reject non-boolean text for boolean settings instead of writing an inert string.
- Free-form / undeclared keys and `--json` keep prior behavior.

## Test plan

- [x] `omarchy bar set omarchy.indicators alwaysShow true` → IPC `… alwaysShow true {}` (boolean, not `"true"`)
- [x] bare `false` same shape; bare `maybe` rejected
- [x] free-form `omarchy.clock format HH:mm` still a JSON string
- [x] `--json` path unchanged

```bash
# with shell mock recording IPC:
omarchy-bar set omarchy.indicators alwaysShow true
# expect: shell setBarWidget omarchy.indicators alwaysShow true {}
```
