### PR TITLE
Label Tailscale profiles by tailnet, not nickname

### DIFF
--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -59,8 +59,11 @@ function osIcon(os) {
 
 function accountLabel(account) {
   if (!account) return "Unknown account"
-  if (account.nickname) return String(account.nickname)
+  // Prefer tailnet: nickname is the Tailscale account identity and is identical
+  // across every profile of the same login, so ranking it first makes multi-
+  // tailnet switchers list indistinguishable rows (issue #9259).
   if (account.tailnet) return String(account.tailnet)
+  if (account.nickname) return String(account.nickname)
   if (account.account) return String(account.account)
   return String(account.id || "Unknown account")
 }

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -177,16 +177,75 @@ const accounts = tailscale.parseAccounts(JSON.stringify([
 
 assertEqual(accounts.accounts.length, 2, 'tailscale parses multiple connections')
 assertEqual(accounts.selectedAccountId, 'db1b', 'tailscale records selected connection id')
-assertEqual(accounts.selectedAccountLabel, 'Home', 'tailscale labels connections by nickname')
+assertEqual(accounts.selectedAccountLabel, 'dhh.github', 'tailscale labels the selected connection by tailnet')
 assertDeepEqual(
   accounts.accounts.map(account => account.nickname),
   ['Home', 'Work'],
   'tailscale preserves connection nicknames'
 )
+assertDeepEqual(
+  accounts.accounts.map(account => tailscale.accountLabel(account)),
+  ['dhh.github', '37signals.com'],
+  'tailscale labels each connection by its tailnet when both nickname and tailnet are set'
+)
 assertEqual(
   tailscale.accountLabel({ nickname: '', tailnet: 'tailnet.example', account: 'user@example', id: 'abcd' }),
   'tailnet.example',
   'tailscale labels connections by tailnet when nickname is missing'
+)
+assertEqual(
+  tailscale.accountLabel({ nickname: 'solo-nick', tailnet: '', account: '', id: 'solo' }),
+  'solo-nick',
+  'tailscale falls back to nickname when tailnet is empty'
+)
+assertEqual(
+  tailscale.accountLabel({ nickname: '', tailnet: '', account: 'user@example', id: 'acct' }),
+  'user@example',
+  'tailscale falls back to account when nickname and tailnet are empty'
+)
+assertEqual(
+  tailscale.accountLabel({ nickname: '', tailnet: '', account: '', id: 'only-id' }),
+  'only-id',
+  'tailscale falls back to id when nothing else is set'
+)
+assertEqual(
+  tailscale.accountLabel(null),
+  'Unknown account',
+  'tailscale labels a missing account as unknown'
+)
+
+// Issue #9259: tailscale switch --list --json returns the same nickname (account
+// identity) for every profile of one login; only tailnet differs. Preferring
+// nickname made the account switcher list identical rows.
+const multiTailnet = tailscale.parseAccounts(JSON.stringify([
+  {
+    id: '1982',
+    nickname: 'user@example.com',
+    tailnet: 'user@example.com',
+    account: 'user@example.com',
+    selected: false
+  },
+  {
+    id: '8833',
+    nickname: 'user@example.com',
+    tailnet: 'acme.com',
+    account: 'user@example.com',
+    selected: true
+  }
+]))
+
+assertEqual(multiTailnet.accounts.length, 2, 'tailscale parses multi-tailnet profiles for one login')
+assertEqual(multiTailnet.selectedAccountId, '8833', 'tailscale records the selected multi-tailnet profile id')
+assertEqual(multiTailnet.selectedAccountLabel, 'acme.com', 'tailscale labels the selected multi-tailnet profile by its tailnet')
+assertDeepEqual(
+  multiTailnet.accounts.map(account => tailscale.accountLabel(account)),
+  ['user@example.com', 'acme.com'],
+  'tailscale distinguishes multi-tailnet profiles that share one nickname'
+)
+assert(
+  multiTailnet.accounts.map(account => tailscale.accountLabel(account))[0] !==
+    multiTailnet.accounts.map(account => tailscale.accountLabel(account))[1],
+  'tailscale multi-tailnet switcher rows are not identical'
 )
 
 assertDeepEqual(


### PR DESCRIPTION
## Summary

Fixes #9259.

The Tailscale panel account switcher preferred `nickname` over `tailnet` when labelling profiles. `tailscale switch --list --json` returns the same `nickname` (account identity) for every profile of one login — only `tailnet` differs — so multi-tailnet users saw identical rows and could not tell which profile was which.

## Change

- `accountLabel()` now prefers `tailnet`, then `nickname`, then `account`, then `id`.
- Existing `parseAccounts` path picks this up automatically for `selectedAccountLabel` and each row's `accountText`.

## Evidence

Fixture from the issue (`nickname` identical, `tailnet` differs):

| | labels | selectedAccountLabel | identical rows? |
|---|---|---|---|
| **Before** | `user@example.com`, `user@example.com` | `user@example.com` | yes |
| **After** | `user@example.com`, `acme.com` | `acme.com` | no |

```bash
# before
{"labels":["user@example.com","user@example.com"],"selectedAccountLabel":"user@example.com","identical":true}
# after
{"labels":["user@example.com","acme.com"],"selectedAccountLabel":"acme.com","identical":false}
```

## Test plan

- [x] Bug repro fails on stock `accountLabel` (identical labels)
- [x] Same fixture distinguishes rows after the change
- [x] Fallback chain: empty tailnet → nickname → account → id → `"Unknown account"`
- [x] Existing multi-account parse still works (selected label is now the tailnet)
- [x] `bash test/shell.d/tailscale-test.sh` — 51 ok

```bash
bash test/shell.d/tailscale-test.sh
```