### PR TITLE
Fail terminal install before rewriting the default

### DIFF
--- a/bin/omarchy-install-terminal
+++ b/bin/omarchy-install-terminal
@@ -5,7 +5,7 @@
 # omarchy:requires-sudo=true
 
 if (($# == 0)); then
-  echo "Usage: omarchy-install-terminal [alacritty|foot|ghostty|kitty]"
+  echo "Usage: omarchy-install-terminal [alacritty|foot|ghostty|kitty]" >&2
   exit 1
 fi
 
@@ -18,35 +18,44 @@ foot) desktop_id="foot.desktop" ;;
 ghostty) desktop_id="com.mitchellh.ghostty.desktop" ;;
 kitty) desktop_id="kitty.desktop" ;;
 *)
-  echo "Unknown terminal: $package"
+  echo "Unknown terminal: $package" >&2
   exit 1
   ;;
 esac
 
 echo "Installing $package..."
 
-# Install package
-if omarchy-pkg-add $package; then
-  # Copy custom desktop entries with X-TerminalArg* keys
-  if [[ $package == "alacritty" ]]; then
-    mkdir -p ~/.local/share/applications
-    cp "$OMARCHY_PATH/default/alacritty/$desktop_id" ~/.local/share/applications/
-  elif [[ $package == "foot" ]]; then
-    mkdir -p ~/.local/share/applications
-    cp "$OMARCHY_PATH/applications/$desktop_id" ~/.local/share/applications/
-  fi
+# Install first; never rewrite the default terminal or seed config unless the
+# package actually landed. A zero exit from omarchy-pkg-add without the package
+# present (or a swallowed non-zero) used to point xdg-terminal-exec at a binary
+# that does not exist — Super+Return then fails with no terminal left (issue #9356).
+if ! omarchy-pkg-add "$package"; then
+  echo "Failed to install $package" >&2
+  exit 1
+fi
 
-  # Copy default config for optional terminals when missing
-  if [[ ! -e ~/.config/$package ]]; then
-    cp -Rpf "$OMARCHY_PATH/config/$package" ~/.config/
-  fi
+if ! omarchy-pkg-present "$package"; then
+  echo "Failed to install $package" >&2
+  exit 1
+fi
 
-  # Update xdg-terminals.list to prioritize the proper terminal
-  cat >~/.config/xdg-terminals.list <<EOF
+# Copy custom desktop entries with X-TerminalArg* keys
+if [[ $package == "alacritty" ]]; then
+  mkdir -p ~/.local/share/applications
+  cp "$OMARCHY_PATH/default/alacritty/$desktop_id" ~/.local/share/applications/
+elif [[ $package == "foot" ]]; then
+  mkdir -p ~/.local/share/applications
+  cp "$OMARCHY_PATH/applications/$desktop_id" ~/.local/share/applications/
+fi
+
+# Copy default config for optional terminals when missing
+if [[ ! -e ~/.config/$package ]]; then
+  cp -Rpf "$OMARCHY_PATH/config/$package" ~/.config/
+fi
+
+# Update xdg-terminals.list to prioritize the proper terminal
+cat >~/.config/xdg-terminals.list <<EOF
 # Terminal emulator preference order for xdg-terminal-exec
 # The first found and valid terminal will be used
 $desktop_id
 EOF
-else
-  echo "Failed to install $package"
-fi

--- a/test/shell.d/install-terminal-test.sh
+++ b/test/shell.d/install-terminal-test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# omarchy-install-terminal must not rewrite xdg-terminals.list or seed config
+# when the package never lands (issue #9356). Failure must exit non-zero so
+# omarchy-default-terminal --install does not point Super+Return at a missing
+# binary.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+home="$test_tmp/home"
+omarchy_path="$test_tmp/omarchy"
+mkdir -p "$mock_bin" "$home/.config" \
+  "$omarchy_path/config/ghostty" \
+  "$omarchy_path/config/kitty" \
+  "$omarchy_path/config/alacritty" \
+  "$omarchy_path/config/foot" \
+  "$omarchy_path/default/alacritty" \
+  "$omarchy_path/applications"
+
+echo 'ghostty-config' >"$omarchy_path/config/ghostty/config"
+echo 'kitty-config' >"$omarchy_path/config/kitty/kitty.conf"
+echo 'alacritty-config' >"$omarchy_path/config/alacritty/alacritty.toml"
+echo 'foot-config' >"$omarchy_path/config/foot/foot.ini"
+printf '[Desktop Entry]\nName=Alacritty\n' >"$omarchy_path/default/alacritty/Alacritty.desktop"
+printf '[Desktop Entry]\nName=Foot\n' >"$omarchy_path/applications/foot.desktop"
+
+# Pre-existing default terminal the failure path must leave alone.
+cat >"$home/.config/xdg-terminals.list" <<'EOF'
+# Terminal emulator preference order for xdg-terminal-exec
+kitty.desktop
+EOF
+original_list=$(cat "$home/.config/xdg-terminals.list")
+
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg-add %s\n' "$*" >>"$OMARCHY_INSTALL_TERMINAL_LOG"
+if [[ ${OMARCHY_PKG_ADD_EXIT:-1} -eq 0 ]]; then
+  exit 0
+fi
+echo "Error: Package '$1' did not install" >&2
+exit "${OMARCHY_PKG_ADD_EXIT:-1}"
+SH
+
+cat >"$mock_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+if [[ -f $OMARCHY_INSTALLED_DIR/$1 ]]; then
+  exit 0
+fi
+exit 1
+SH
+
+chmod +x "$mock_bin"/*
+
+export HOME="$home"
+export OMARCHY_PATH="$omarchy_path"
+export OMARCHY_INSTALL_TERMINAL_LOG="$test_tmp/log"
+export OMARCHY_INSTALLED_DIR="$test_tmp/installed"
+export OMARCHY_PKG_ADD_EXIT=1
+export PATH="$mock_bin:$PATH"
+mkdir -p "$OMARCHY_INSTALLED_DIR"
+: >"$OMARCHY_INSTALL_TERMINAL_LOG"
+
+installer="$ROOT/bin/omarchy-install-terminal"
+
+# --- Failure: pkg-add exits non-zero ------------------------------------------
+export OMARCHY_PKG_ADD_EXIT=1
+if HOME="$home" "$installer" ghostty >"$test_tmp/fail.out" 2>"$test_tmp/fail.err"; then
+  fail "install-terminal must exit non-zero when pkg-add fails" "$(cat "$test_tmp/fail.out"; cat "$test_tmp/fail.err")"
+fi
+grep -Fq 'Failed to install ghostty' "$test_tmp/fail.err" ||
+  fail "install-terminal reports the failure on stderr" "$(cat "$test_tmp/fail.err")"
+[[ $(cat "$home/.config/xdg-terminals.list") == "$original_list" ]] ||
+  fail "failed install must not rewrite xdg-terminals.list" "$(cat "$home/.config/xdg-terminals.list")"
+[[ ! -e $home/.config/ghostty ]] ||
+  fail "failed install must not seed ~/.config/ghostty"
+grep -qx 'pkg-add ghostty' "$OMARCHY_INSTALL_TERMINAL_LOG" ||
+  fail "failed install still attempted pkg-add"
+pass "pkg-add failure leaves defaults and config untouched and exits non-zero"
+
+# --- Failure: pkg-add exits 0 but package never present (issue #9356 shape) ---
+: >"$OMARCHY_INSTALL_TERMINAL_LOG"
+export OMARCHY_PKG_ADD_EXIT=0
+if HOME="$home" "$installer" ghostty >"$test_tmp/lie.out" 2>"$test_tmp/lie.err"; then
+  fail "install-terminal must exit non-zero when pkg-add succeeds without the package" "$(cat "$test_tmp/lie.out"; cat "$test_tmp/lie.err")"
+fi
+grep -Fq 'Failed to install ghostty' "$test_tmp/lie.err" ||
+  fail "missing package after pkg-add is reported as failure" "$(cat "$test_tmp/lie.err")"
+[[ $(cat "$home/.config/xdg-terminals.list") == "$original_list" ]] ||
+  fail "lying pkg-add must not rewrite xdg-terminals.list" "$(cat "$home/.config/xdg-terminals.list")"
+[[ ! -e $home/.config/ghostty ]] ||
+  fail "lying pkg-add must not seed ~/.config/ghostty"
+pass "pkg-add exit 0 without package present does not mutate terminal defaults"
+
+# --- Success path -------------------------------------------------------------
+: >"$OMARCHY_INSTALL_TERMINAL_LOG"
+export OMARCHY_PKG_ADD_EXIT=0
+touch "$OMARCHY_INSTALLED_DIR/ghostty"
+HOME="$home" "$installer" ghostty >"$test_tmp/ok.out" 2>"$test_tmp/ok.err" ||
+  fail "successful install must exit 0" "$(cat "$test_tmp/ok.out"; cat "$test_tmp/ok.err")"
+[[ $(tail -n 1 "$home/.config/xdg-terminals.list") == "com.mitchellh.ghostty.desktop" ]] ||
+  fail "successful install sets the ghostty desktop id" "$(cat "$home/.config/xdg-terminals.list")"
+[[ -f $home/.config/ghostty/config ]] ||
+  fail "successful install seeds the ghostty config"
+grep -qx 'ghostty-config' "$home/.config/ghostty/config" ||
+  fail "seeded ghostty config matches the packaged default"
+pass "successful install rewrites the default terminal and seeds config"
+
+# --- Idempotent config seed ---------------------------------------------------
+echo 'user-custom' >"$home/.config/ghostty/config"
+touch "$OMARCHY_INSTALLED_DIR/ghostty"
+HOME="$home" "$installer" ghostty >/dev/null 2>&1 ||
+  fail "re-install with existing config must succeed"
+grep -qx 'user-custom' "$home/.config/ghostty/config" ||
+  fail "existing terminal config must not be overwritten"
+pass "existing terminal config is left alone on re-install"
+
+# --- Unknown terminal ---------------------------------------------------------
+if HOME="$home" "$installer" not-a-term >"$test_tmp/unknown.out" 2>"$test_tmp/unknown.err"; then
+  fail "unknown terminal must exit non-zero"
+fi
+grep -Fq 'Unknown terminal' "$test_tmp/unknown.err" ||
+  fail "unknown terminal is reported" "$(cat "$test_tmp/unknown.err")"
+pass "unknown terminal is rejected"
+
+# --- default-terminal cascade: failed install must not rewrite list ----------
+cp "$ROOT/bin/omarchy-default-terminal" "$mock_bin/omarchy-default-terminal"
+cp "$ROOT/bin/omarchy-install-terminal" "$mock_bin/omarchy-install-terminal"
+chmod +x "$mock_bin/omarchy-default-terminal" "$mock_bin/omarchy-install-terminal"
+
+cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+exit 0
+SH
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+: # no-op
+SH
+cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+eval "$*"
+SH
+chmod +x "$mock_bin/omarchy-cmd-missing" "$mock_bin/omarchy-notification-send" \
+  "$mock_bin/omarchy-launch-floating-terminal-with-presentation"
+
+# Reset defaults to kitty; package still absent.
+cat >"$home/.config/xdg-terminals.list" <<'EOF'
+# Terminal emulator preference order for xdg-terminal-exec
+kitty.desktop
+EOF
+rm -f "$OMARCHY_INSTALLED_DIR/ghostty"
+export OMARCHY_PKG_ADD_EXIT=1
+
+if HOME="$home" OMARCHY_PATH="$omarchy_path" PATH="$mock_bin:$PATH" \
+  omarchy-default-terminal --install ghostty >"$test_tmp/cascade.out" 2>"$test_tmp/cascade.err"; then
+  fail "default-terminal --install must fail when the package never lands" "$(cat "$test_tmp/cascade.out"; cat "$test_tmp/cascade.err")"
+fi
+[[ $(tail -n 1 "$home/.config/xdg-terminals.list") == "kitty.desktop" ]] ||
+  fail "failed default-terminal install must keep the previous default" "$(cat "$home/.config/xdg-terminals.list")"
+pass "default-terminal --install preserves the previous default when install fails"


### PR DESCRIPTION
## Summary

Fixes #9356.

`omarchy install terminal ghostty` on aarch64 (where ghostty is unavailable) still rewrote `~/.config/xdg-terminals.list` to `com.mitchellh.ghostty.desktop` and seeded `~/.config/ghostty/`, so Super+Return / `xdg-terminal-exec` pointed at a binary that does not exist. Two cooperating bugs:

1. The success branch ran whenever `omarchy-pkg-add` exited 0 — including the historical “skip unavailable package, exit 0” shape — without checking the package was present.
2. The failure branch printed `Failed to install …` but **exited 0**, so `omarchy-default-terminal --install` (which does `omarchy-install-terminal || exit 1`) continued and rewrote the default anyway.

## Change

- Require `omarchy-pkg-add` success **and** `omarchy-pkg-present` before copying desktop entries, seeding config, or rewriting `xdg-terminals.list`.
- Exit non-zero on failure (stderr message kept).

## Evidence

Isolated `HOME` + stub `omarchy-pkg-add` that exits 0 without installing (issue shape):

| | exit | `xdg-terminals.list` tail | `~/.config/ghostty` |
|---|---|---|---|
| **Before** | 0 | `com.mitchellh.ghostty.desktop` | created |
| **After** | 1 | `kitty.desktop` (unchanged) | absent |

```text
# before
Installing ghostty...
Skipping 'ghostty': not available in the repos on this system
EXIT:0
→ xdg-terminals.list → com.mitchellh.ghostty.desktop

# after
Installing ghostty...
Skipping 'ghostty': not available in the repos on this system
Failed to install ghostty
EXIT:1
→ xdg-terminals.list left at kitty.desktop
```

Cascade: stock `omarchy-default-terminal --install ghostty` after a failed install also rewrote the list to ghostty while exiting 0; with the fix it preserves `kitty.desktop` and exits non-zero.

## Test plan

- [x] `pkg-add` non-zero → no list rewrite, no config seed, exit 1
- [x] `pkg-add` exit 0 without package present → same (issue #9356 shape)
- [x] Successful install sets desktop id + seeds config
- [x] Existing config is not overwritten on re-install
- [x] Unknown terminal rejected
- [x] `omarchy-default-terminal --install` preserves previous default when install fails
- [x] `bash test/shell.d/install-terminal-test.sh`
- [x] `bash test/shell.d/default-apps-test.sh`

```bash
bash test/shell.d/install-terminal-test.sh
bash test/shell.d/default-apps-test.sh
```