### PR TITLE
Prefer nvidia_wmi_ec_backlight over cosmetic nvidia_0

### DIFF
--- a/bin/omarchy-hw-display
+++ b/bin/omarchy-hw-display
@@ -18,6 +18,15 @@ for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/amdgpu_bl* "
   fi
 done
 
+# On some NVIDIA Optimus / discrete-mux laptops (e.g. ASUS TUF), both nvidia_0 and
+# nvidia_wmi_ec_backlight appear. nvidia_0 is often a no-op cosmetic node; the WMI EC
+# backlight drives the panel. Prefer WMI only when the chosen device is still nvidia_0,
+# so amdgpu_bl*/intel_backlight/gmux keep their higher priority (AMD+NVIDIA hybrids can
+# expose a fake WMI node alongside a real amdgpu_bl*).
+if [[ $device == "nvidia_0" && -e $backlight_path/nvidia_wmi_ec_backlight ]]; then
+  device=nvidia_wmi_ec_backlight
+fi
+
 if [[ -n $device ]]; then
   printf '%s\n' "$device"
 else

--- a/test/shell.d/hw-display-test.sh
+++ b/test/shell.d/hw-display-test.sh
@@ -41,6 +41,26 @@ device=$(hw_display)
 [[ $device == "nvidia_wmi_ec_backlight" ]] || fail "an unknown backlight falls back to the first device" "actual: $device"
 pass "an unknown backlight falls back to the first device"
 
+write_backlights nvidia_0 nvidia_wmi_ec_backlight
+device=$(hw_display)
+[[ $device == "nvidia_wmi_ec_backlight" ]] || fail "nvidia_wmi beats cosmetic nvidia_0" "actual: $device"
+pass "nvidia_wmi beats cosmetic nvidia_0"
+
+write_backlights nvidia_0
+device=$(hw_display)
+[[ $device == "nvidia_0" ]] || fail "nvidia_0 alone remains usable" "actual: $device"
+pass "nvidia_0 alone remains usable"
+
+write_backlights amdgpu_bl0 nvidia_0 nvidia_wmi_ec_backlight
+device=$(hw_display)
+[[ $device == "amdgpu_bl0" ]] || fail "amdgpu still outranks nvidia_wmi" "actual: $device"
+pass "amdgpu still outranks nvidia_wmi"
+
+write_backlights intel_backlight nvidia_0 nvidia_wmi_ec_backlight
+device=$(hw_display)
+[[ $device == "intel_backlight" ]] || fail "intel still outranks nvidia_wmi" "actual: $device"
+pass "intel still outranks nvidia_wmi"
+
 write_backlights appletb_backlight gmux_backlight
 device=$(hw_display)
 [[ $device == "gmux_backlight" ]] || fail "a T2 Mac uses gmux instead of the Touch Bar" "actual: $device"


### PR DESCRIPTION
## Summary
- On some NVIDIA discrete-mux / Optimus laptops (reproduced on ASUS TUF Gaming F17 FX707VV4), both `nvidia_0` and `nvidia_wmi_ec_backlight` appear under `/sys/class/backlight`. `ls | head` picks `nvidia_0`, which is often a no-op cosmetic node, so brightness keys and the Omarchy brightness control appear broken.
- Prefer `nvidia_wmi_ec_backlight` only when the chosen device is still `nvidia_0`. Existing priority for `gmux` / `amdgpu_bl*` / `intel_backlight` / `acpi_video*` is unchanged, so AMD+NVIDIA hybrids that expose a fake WMI node alongside a real `amdgpu_bl*` keep working.
- Adds shell tests for the dual-NVIDIA case and for amdgpu/intel still winning when WMI is also present.

## Test plan
- [x] `./test/shell.d/hw-display-test.sh` (new cases pass)
- [ ] On affected hardware (discrete mux): `omarchy-hw-display` prints `nvidia_wmi_ec_backlight` when both nodes exist; brightness keys change the panel
- [ ] On hybrid / Intel path: still selects `intel_backlight` when present
- [ ] On AMD+NVIDIA: still selects `amdgpu_bl*` when present alongside WMI


Made with [Cursor](https://cursor.com)