### PR TITLE
Keep config migrations from taking their staging file's identity

### DIFF
--- a/migrations/1780057136.sh
+++ b/migrations/1780057136.sh
@@ -71,7 +71,8 @@ ensure_kitty_binding() {
         }
         print
       }
-    ' "$config" >"$tmp" && mv "$tmp" "$config"
+    ' "$config" >"$tmp" && cat "$tmp" >"$config"
+    rm -f "$tmp"
   elif ! grep -Eq "^map[[:space:]]+$key_regex[[:space:]]" "$config"; then
     if grep -qxF 'map shift+insert paste_from_clipboard' "$config"; then
       tmp=$(mktemp)
@@ -87,7 +88,8 @@ ensure_kitty_binding() {
           print "map " key " " binding
           inserted = 1
         }
-      ' "$config" >"$tmp" && mv "$tmp" "$config"
+      ' "$config" >"$tmp" && cat "$tmp" >"$config"
+      rm -f "$tmp"
     else
       printf '\n%s\nmap %s %s\n' "$comment" "$key" "$binding" >>"$config"
     fi
@@ -112,7 +114,8 @@ ensure_foot_text_binding() {
       }
       index($0, sequence "=") == 1 { $0 = sequence "=" binding }
       { print }
-    ' "$config" >"$tmp" && mv "$tmp" "$config"
+    ' "$config" >"$tmp" && cat "$tmp" >"$config"
+    rm -f "$tmp"
   elif grep -qxF '[text-bindings]' "$config"; then
     tmp=$(mktemp)
     SEQUENCE="$sequence" BINDING="$binding" COMMENT="$comment" awk '
@@ -127,7 +130,8 @@ ensure_foot_text_binding() {
         print sequence "=" binding
         inserted = 1
       }
-    ' "$config" >"$tmp" && mv "$tmp" "$config"
+    ' "$config" >"$tmp" && cat "$tmp" >"$config"
+    rm -f "$tmp"
   else
     printf '\n[text-bindings]\n%s\n%s=%s\n' "$comment" "$sequence" "$binding" >>"$config"
   fi

--- a/migrations/1780294774.sh
+++ b/migrations/1780294774.sh
@@ -27,5 +27,6 @@ if [[ -f $config_file ]] && omarchy-cmd-present jq; then
         .
       end
     )
-  ' "$config_file" >"$tmp" && mv "$tmp" "$config_file" || rm -f "$tmp"
+  ' "$config_file" >"$tmp" && cat "$tmp" >"$config_file"
+  rm -f "$tmp"
 fi

--- a/migrations/1781063758.sh
+++ b/migrations/1781063758.sh
@@ -37,5 +37,6 @@ if [[ -f $hyprland_config ]] && ! grep -Fq '/default/hypr/bootstrap.lua' "$hyprl
     { print }
   ' "$hyprland_config" >"$tmp"
 
-  mv "$tmp" "$hyprland_config"
+  cat "$tmp" >"$hyprland_config"
+  rm -f "$tmp"
 fi

--- a/migrations/1781587663.sh
+++ b/migrations/1781587663.sh
@@ -16,7 +16,8 @@ if [[ -d $nvim_config_dir ]]; then
       printf '%s\n' 'require("config.remote_clipboard").setup()'
       cat "$nvim_options"
     } >"$tmp"
-    mv "$tmp" "$nvim_options"
+    cat "$tmp" >"$nvim_options"
+    rm -f "$tmp"
   fi
 fi
 

--- a/migrations/1784989000.sh
+++ b/migrations/1784989000.sh
@@ -35,5 +35,6 @@ if [[ -s $config_file ]]; then
       end;
 
     .bar.layout.center |= place_indicators_before_clock
-  ' "$config_file" >"$tmp" && mv "$tmp" "$config_file" || rm -f "$tmp"
+  ' "$config_file" >"$tmp" && cat "$tmp" >"$config_file"
+  rm -f "$tmp"
 fi

--- a/migrations/1785344985.sh
+++ b/migrations/1785344985.sh
@@ -43,5 +43,6 @@ if [[ -s $config_file ]]; then
     else
       .bar.layout.right |= insert_after("omarchy.tray"; { id: "omarchy.agents" })
     end
-  ' "$config_file" >"$tmp" && mv "$tmp" "$config_file" || rm -f "$tmp"
+  ' "$config_file" >"$tmp" && cat "$tmp" >"$config_file"
+  rm -f "$tmp"
 fi

--- a/migrations/1786099804.sh
+++ b/migrations/1786099804.sh
@@ -29,7 +29,8 @@ if [[ -s $config_file ]]; then
     | (if (.disabledPlugins? | type) == "array" then
       .disabledPlugins |= map(rename)
     else . end)
-  ' "$config_file" >"$tmp" && mv "$tmp" "$config_file" || rm -f "$tmp"
+  ' "$config_file" >"$tmp" && cat "$tmp" >"$config_file"
+  rm -f "$tmp"
 fi
 
 rm -rf "$HOME/.cache/omarchy/model-usage"

--- a/test/shell.d/migration-config-rewrite-test.sh
+++ b/test/shell.d/migration-config-rewrite-test.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# A migration that edits a config's contents must leave the file itself alone.
+# Replacing it with the temp file it staged the new contents in hands the
+# config that file's identity: mktemp's 0600, and a regular file where a
+# dotfile manager had put a symlink.
+
+hyprland_migration=$(grep -rl 'Update Hyprland Lua entrypoint to load Omarchy bootstrap' "$ROOT/migrations" | head -n 1)
+[[ -n $hyprland_migration ]] || fail "Hyprland bootstrap migration exists"
+
+clock_migration=$(grep -rl 'Remove leading zero from bar clock date' "$ROOT/migrations" | head -n 1)
+[[ -n $clock_migration ]] || fail "bar clock date migration exists"
+
+run_migration() {
+  local migration=$1 home=$2
+
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+# The comment and the package.path assignment under it are what the awk
+# rewrite keys off, so this is a config it actually edits.
+seed_hyprland() {
+  local home=$1
+
+  mkdir -p "$home/.config/hypr"
+  cat >"$home/.config/hypr/hyprland.lua" <<'LUA'
+-- Load user modules from ~/.config and Omarchy defaults from $OMARCHY_PATH.
+package.path = os.getenv("HOME")
+  .. "/.config/hypr/?.lua;"
+  .. package.path
+
+require("autostart")
+LUA
+}
+
+seed_shell_json() {
+  local home=$1
+
+  mkdir -p "$home/.config/omarchy"
+  cat >"$home/.config/omarchy/shell.json" <<'JSON'
+{
+  "bar": {
+    "layout": {
+      "center": [
+        { "id": "omarchy.clock", "formatAlt": "dd MMMM 'W'ww yyyy" }
+      ]
+    }
+  }
+}
+JSON
+}
+
+home="$TMPDIR/mode"
+seed_hyprland "$home"
+seed_shell_json "$home"
+chmod 644 "$home/.config/hypr/hyprland.lua" "$home/.config/omarchy/shell.json"
+
+run_migration "$hyprland_migration" "$home"
+run_migration "$clock_migration" "$home"
+
+grep -Fq '/default/hypr/bootstrap.lua' "$home/.config/hypr/hyprland.lua" ||
+  fail "Hyprland migration rewrote the config"
+[[ $(stat -c '%a' "$home/.config/hypr/hyprland.lua") == "644" ]] ||
+  fail "Hyprland migration keeps the config mode" "mode is now $(stat -c '%a' "$home/.config/hypr/hyprland.lua")"
+pass "Hyprland migration keeps the config mode"
+
+[[ $(jq -r '.bar.layout.center[0].formatAlt' "$home/.config/omarchy/shell.json") == "d MMMM 'W'ww yyyy" ]] ||
+  fail "clock migration rewrote the config"
+[[ $(stat -c '%a' "$home/.config/omarchy/shell.json") == "644" ]] ||
+  fail "clock migration keeps the config mode" "mode is now $(stat -c '%a' "$home/.config/omarchy/shell.json")"
+pass "clock migration keeps the config mode"
+
+# A dotfile manager owns the file and leaves a symlink in ~/.config.
+home="$TMPDIR/symlink"
+dotfiles="$home/dotfiles"
+mkdir -p "$dotfiles/hypr" "$dotfiles/omarchy"
+seed_hyprland "$home"
+seed_shell_json "$home"
+mv "$home/.config/hypr/hyprland.lua" "$dotfiles/hypr/hyprland.lua"
+mv "$home/.config/omarchy/shell.json" "$dotfiles/omarchy/shell.json"
+ln -s "$dotfiles/hypr/hyprland.lua" "$home/.config/hypr/hyprland.lua"
+ln -s "$dotfiles/omarchy/shell.json" "$home/.config/omarchy/shell.json"
+
+run_migration "$hyprland_migration" "$home"
+run_migration "$clock_migration" "$home"
+
+[[ -L "$home/.config/hypr/hyprland.lua" ]] ||
+  fail "Hyprland migration keeps a dotfiles symlink"
+grep -Fq '/default/hypr/bootstrap.lua' "$dotfiles/hypr/hyprland.lua" ||
+  fail "Hyprland migration writes through the symlink"
+pass "Hyprland migration writes through a dotfiles symlink"
+
+[[ -L "$home/.config/omarchy/shell.json" ]] ||
+  fail "clock migration keeps a dotfiles symlink"
+[[ $(jq -r '.bar.layout.center[0].formatAlt' "$dotfiles/omarchy/shell.json") == "d MMMM 'W'ww yyyy" ]] ||
+  fail "clock migration writes through the symlink"
+pass "clock migration writes through a dotfiles symlink"
+
+# The two migrations above stand in for the rest: the whole directory has to
+# stay on the write-through pattern, or the next one reintroduces this.
+staged=$(grep -rn 'mv "\$tmp"' "$ROOT/migrations" || true)
+[[ -z $staged ]] ||
+  fail "no migration replaces a config with its staging file" "$staged"
+pass "no migration replaces a config with its staging file"


### PR DESCRIPTION
Fixes #9326.

Seven migrations rewrite a user config by staging the new contents in `mktemp` and renaming that file over the original:

    tmp=$(mktemp)
    jq '…' "$config_file" >"$tmp" && mv "$tmp" "$config_file"

A same-filesystem `mv` is a rename, so the config keeps the staging file's inode — and with it, the staging file's identity rather than its own.

The reported symptom is the mode: `mktemp` creates at 0600, so a config that was 0644 comes back 0600 and a dotfile manager that records modes re-tracks it as private. There is a second, louder consequence the issue does not mention: the rename also replaces a **symlink**. `1785189600.sh` already names it in a comment next to the correct pattern — "Write through the path instead of replacing it, so a tmux.conf symlinked out of a dotfiles repo keeps pointing where it pointed."

Ran against an unfixed `migrations/1781063758.sh` with `~/.config/hypr/hyprland.lua` symlinked into a dotfiles directory:

    unfixed: symlink? NO (replaced by a regular file)
    unfixed: dotfiles copy still original? UNCHANGED - edit lost to the dotfiles repo

    fixed: symlink? YES
    fixed: dotfiles copy rewritten? YES

So on those setups the migration silently did not migrate anything the user keeps: it wrote a detached copy into `~/.config` and left the tracked file behind, which the next `chezmoi apply` reverts.

`1781043107.sh`, `1785189600.sh` and `1785633225.sh` already write through the path with `cat "$tmp" >"$file"`. This applies that same pattern to the remaining ten sites across seven migrations (`1780057136.sh` ×4, `1780294774.sh`, `1781063758.sh`, `1781587663.sh`, `1784989000.sh`, `1785344985.sh`, `1786099804.sh`) and removes the staging file afterwards, which `mv` used to do implicitly. The `&&` guard is kept, so a failed `jq`/`awk` still leaves the config untouched.

Verification — `test/shell.d/migration-config-rewrite-test.sh` runs the Hyprland bootstrap and bar clock migrations against a temporary home, first on plain 0644 configs and then on configs owned by a dotfiles directory and symlinked into `~/.config`:

    ok - Hyprland migration keeps the config mode
    ok - clock migration keeps the config mode
    ok - Hyprland migration writes through a dotfiles symlink
    ok - clock migration writes through a dotfiles symlink
    ok - no migration replaces a config with its staging file

Reverting only `migrations/` and re-running:

    mode is now 600
    not ok - Hyprland migration keeps the config mode

The last assertion is a grep over the whole directory, so the five migrations not exercised directly are covered against a reintroduction.

`terminal-keybinding-migration-test.sh` — the existing test over `1780057136.sh`, the file with four of the ten sites — still passes, as do the other migration tests except five that fail identically on unmodified `quattro` here (`bluetooth`, `legacy-power-udev-rules`, `mise-wrapper-quiet`, `security-fido2`, `sshd-hardening`); those are GNU-vs-BSD artifacts of running the suite on macOS, not related to this change.