### PR TITLE
Show what PAM asked for in the polkit dialog

### DIFF
--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -54,6 +54,10 @@ Item {
     return PolkitModel.authorizationLabel(message)
   }
 
+  function promptLabel(prompt) {
+    return PolkitModel.promptLabel(prompt)
+  }
+
   function loadPamConfig(raw) {
     fingerprintConfigured = PolkitModel.fingerprintConfiguredFromPamConfig(raw)
   }
@@ -336,7 +340,7 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            text: root.errorFlash ? "Wrong" : (root.submitted ? "Checking..." : "Enter password")
+            text: root.errorFlash ? "Wrong" : (root.submitted ? "Checking..." : root.promptLabel(root.currentPrompt))
             color: root.errorFlash ? Color.polkit.textError : root.foreground
             opacity: root.errorFlash ? 1 : 0.36
             font.family: root.fontFamily

--- a/shell/plugins/polkit/PolkitModel.js
+++ b/shell/plugins/polkit/PolkitModel.js
@@ -17,6 +17,28 @@ function fingerprintConfiguredFromPamConfig(raw) {
   return false
 }
 
+function promptLabel(prompt) {
+  // PAM decides what it is asking for, and it is not always a password. With
+  // pam_u2f in the stack this prompt is the security key's PIN; a placeholder
+  // that says "Enter password" invites the user to type their password into it,
+  // where it is spent as a failed PIN attempt. A key allows eight before it
+  // locks itself out for good, and recovery is a factory reset that destroys
+  // every credential on it. Show what PAM actually asked for.
+  var text = String(prompt || "").replace(/^\s+|\s+$/g, "")
+  if (!text) return "Enter password"
+
+  // PAM prompts carry their own punctuation ("Password: "), the dialog's own
+  // label does not.
+  text = text.replace(/\s*:\s*$/, "")
+  if (!text) return "Enter password"
+
+  // The several ways the stock modules phrase a password request all mean the
+  // one thing the dialog already had a good label for.
+  if (/^(unix )?password$/i.test(text) || /^enter password$/i.test(text)) return "Enter password"
+
+  return text
+}
+
 function authorizationLabel(message) {
   var text = String(message || "")
   var match = text.match(/^Authentication is (?:needed|required) to run [`']([^`']+)[`'] as /i)
@@ -26,6 +48,7 @@ function authorizationLabel(message) {
 if (typeof module !== "undefined") {
   module.exports = {
     promptLooksFingerprint: promptLooksFingerprint,
+    promptLabel: promptLabel,
     fingerprintConfiguredFromPamConfig: fingerprintConfiguredFromPamConfig,
     authorizationLabel: authorizationLabel
   }

--- a/test/shell.d/polkit-test.sh
+++ b/test/shell.d/polkit-test.sh
@@ -12,6 +12,37 @@ assert(polkit.promptLooksFingerprint('fprintd verification'), 'polkit detects fp
 assert(!polkit.promptLooksFingerprint('Password:'), 'polkit ignores password prompts')
 
 assertEqual(
+  polkit.promptLabel('Please enter the PIN: '),
+  'Please enter the PIN',
+  'polkit shows the security key PIN prompt PAM actually sent'
+)
+assertEqual(
+  polkit.promptLabel(''),
+  'Enter password',
+  'polkit falls back to its own label when PAM sends no prompt'
+)
+assertEqual(
+  polkit.promptLabel('Password: '),
+  'Enter password',
+  'polkit normalizes the stock password prompt'
+)
+assertEqual(
+  polkit.promptLabel('UNIX password:'),
+  'Enter password',
+  'polkit normalizes the pam_unix password prompt'
+)
+assertEqual(
+  polkit.promptLabel('   :  '),
+  'Enter password',
+  'polkit falls back when the prompt is only punctuation'
+)
+assertEqual(
+  polkit.promptLabel("julianduque's password:"),
+  "julianduque's password",
+  'polkit passes a qualified password prompt through'
+)
+
+assertEqual(
   polkit.authorizationLabel("Authentication is needed to run `/usr/bin/true' as the super user"),
   "Authorize running '/usr/bin/true'",
   'polkit shortens the standard pkexec message'


### PR DESCRIPTION
The polkit dialog always labels its input field `Enter password`, even when PAM is asking for something else. With `pam_u2f` in the polkit stack, PAM is asking for the security key's **PIN** — and the dialog tells the user to type their password into it.

## Why this is more than a mislabel

`pam_u2f` sends its own prompt text, straight out of the module:

```
Please enter the PIN:
Please touch the FIDO authenticator.
```

Every password typed into that field while `pam_u2f` owns the prompt is submitted to the key as a failed PIN attempt. A FIDO2 authenticator allows eight before it locks itself out permanently, and the only recovery is a factory reset that destroys every credential on it — so on a machine set up through *Setup › Security › Fido2*, an unlabeled prompt can walk a user toward bricking their key while every screen they can see says "password".

This is reachable from a stock configuration. `omarchy-setup-security-fido2` writes:

```
auth      sufficient pam_u2f.so cue authfile=/etc/fido2/fido2
auth      required pam_unix.so
```

into `/etc/pam.d/polkit-1`. Anything that authenticates through polkit then hits it — in the case that prompted this patch, 1Password's "unlock with system authentication":

```
polkitd[1365]: Operator of unix-session:2 FAILED to authenticate to gain authorization
  for action com.1password.1Password.unlock for unix-process:1663 [/opt/1Password/1password --silent]
polkit-agent-helper-1[4084510]: pam_unix(polkit-1:auth): auth could not identify password for [julianduque]
```

Each of those attempts cost a PIN retry. The key involved is now at 5 of 8.

## Root cause

Nothing upstream of the agent drops the information. polkit's agent-helper protocol forwards each PAM message with its type intact, and Quickshell surfaces it as `flow.inputPrompt`. `PolkitAgent.qml` even reads it:

```qml
currentPrompt = String(flow.inputPrompt || "")
currentSupplementary = String(flow.supplementaryMessage || "")
```

Both properties are then never referenced again. The placeholder is a literal:

```qml
text: root.errorFlash ? "Wrong" : (root.submitted ? "Checking..." : "Enter password")
```

## The change

`promptLabel()` in `PolkitModel.js` turns the PAM prompt into a placeholder, and the field binds to it:

- No prompt from PAM → `Enter password`, exactly as before.
- `Please enter the PIN:` → **`Please enter the PIN`** (trailing PAM punctuation trimmed).
- `Password:`, `UNIX password:`, `Enter password:` → `Enter password`, so the overwhelmingly common case reads identically to today and this is not a visible churn for users without a security key.
- Anything else PAM sends passes through, e.g. `julianduque's password`.

The fix is deliberately generic rather than a `pam_u2f` special case: it does the right thing for smartcards, `pam_yubico`, and any other module that asks for something that is not a password.

## Testing

- `test/shell.d/polkit-test.sh` extended with six cases covering the PIN prompt, the empty-prompt fallback, both stock password spellings, a punctuation-only prompt, and pass-through. All 14 assertions in the file pass.
- `qmllint shell/plugins/polkit/PolkitAgent.qml` is clean.
- `./test/all`: 3002 passing. The 4 failures are pre-existing and environmental — three want a sibling `omarchy-pkgs` checkout, one is `omarchy-plymouth-set` rejecting my checkout path. All four reproduce on unmodified `quattro` from the same directory.

No UI capture attached: the change swaps the binding on an existing `Text` with unchanged font, width, and `ElideRight`, so there is no layout delta to show, and pointing a live system at the checkout needs `omarchy dev link` plus a reboot. Happy to add captures if you'd like them.

## Deliberately left out

- **`currentSupplementary` is still unrendered.** It carries `PAM_TEXT_INFO`, which is where `cue`'s "Please touch the FIDO authenticator." arrives. Surfacing it needs a layout decision — the justification pill is a fixed-height, eliding single line already spoken for by the action description — so it seemed worth its own patch rather than riding along here.
- **No security-key display mode.** `fingerprintMode` hides the field entirely when `pam_fprintd` is in the stack, and an equivalent for `pam_u2f` would be a natural follow-up. `PolkitModel.js` already has an unused `promptLooksFingerprint()` that suggests prompt-driven detection was anticipated. Rendering the real prompt fixes the hazard on its own, so I kept this patch to that.
