### PR TITLE
Discover LUKS drives via lsblk, not blkid

### DIFF
--- a/bin/omarchy-drive-password
+++ b/bin/omarchy-drive-password
@@ -3,7 +3,11 @@
 # omarchy:summary=Set a new encryption password for a drive selected.
 # omarchy:requires-sudo=true
 
-encrypted_drives=$(blkid -t TYPE=crypto_LUKS -o device)
+# lsblk reads FSTYPE from udev/sysfs without probing raw headers, so it works
+# unprivileged. blkid -t TYPE=crypto_LUKS needs root (or a warm cache) and is
+# what the desktop menu runs as, so it used to report "No encrypted drives
+# available" on every LUKS install (issue #9384).
+encrypted_drives=$(lsblk -lnpo NAME,FSTYPE 2>/dev/null | awk '$2 == "crypto_LUKS" { print $1 }')
 
 if [[ -n $encrypted_drives ]]; then
   if (( $(wc -l <<<"$encrypted_drives") == 1 )); then

--- a/test/shell.d/drive-password-test.sh
+++ b/test/shell.d/drive-password-test.sh
@@ -2,14 +2,31 @@
 
 set -euo pipefail
 
+# omarchy-drive-password must discover crypto_LUKS devices without root.
+# The desktop menu launches it unprivileged; blkid -t TYPE=crypto_LUKS cannot
+# probe headers as a normal user and reported "No encrypted drives available"
+# on every LUKS install (issue #9384).
+
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 tmp_dir=$(mktemp -d)
 trap 'rm -r "$tmp_dir"' EXIT
 
+cat >"$tmp_dir/lsblk" <<'EOF'
+#!/bin/bash
+# Default: one LUKS device. Override via OMARCHY_TEST_LSBLK_OUT.
+if [[ -n ${OMARCHY_TEST_LSBLK_OUT+x} ]]; then
+  printf '%s' "$OMARCHY_TEST_LSBLK_OUT"
+  exit 0
+fi
+printf '%s\n' '/dev/test-luks crypto_LUKS'
+EOF
+
+# blkid must not be consulted — if the script regresses to it, fail loudly.
 cat >"$tmp_dir/blkid" <<'EOF'
 #!/bin/bash
-echo /dev/test-luks
+echo "blkid should not be used for LUKS discovery" >&2
+exit 99
 EOF
 
 cat >"$tmp_dir/gum" <<'EOF'
@@ -24,26 +41,75 @@ printf '%s\n' "$@" >"$TEST_ARGS"
 cat >"$TEST_STDIN"
 EOF
 
-chmod +x "$tmp_dir/blkid" "$tmp_dir/gum" "$tmp_dir/sudo"
+cat >"$tmp_dir/omarchy-drive-select" <<'EOF'
+#!/bin/bash
+# Echo the second device from the multi-drive list the script passes through.
+printf '%s\n' "$1" | awk 'NR == 2 { print; exit }'
+EOF
+
+chmod +x "$tmp_dir/lsblk" "$tmp_dir/blkid" "$tmp_dir/gum" "$tmp_dir/sudo" "$tmp_dir/omarchy-drive-select"
 export PATH="$tmp_dir:$ROOT/bin:$PATH"
 export TEST_ARGS="$tmp_dir/args" TEST_INPUTS="$tmp_dir/inputs" TEST_STDIN="$tmp_dir/stdin"
 
+# --- empty passphrase rejected, no cryptsetup --------------------------------
+rm -f "$TEST_ARGS" "$TEST_STDIN"
 printf '\n' >"$TEST_INPUTS"
 if "$ROOT/bin/omarchy-drive-password" >/dev/null; then
   fail "drive password rejects an empty passphrase"
 fi
 [[ ! -e $TEST_ARGS ]] || fail "drive password does not run cryptsetup for an empty passphrase"
+pass "drive password rejects an empty passphrase"
 
+# --- mismatched confirmation rejected ----------------------------------------
+rm -f "$TEST_ARGS" "$TEST_STDIN"
 printf 'secret123\n*\n' >"$TEST_INPUTS"
 if "$ROOT/bin/omarchy-drive-password" >/dev/null; then
   fail "drive password rejects a mismatched confirmation"
 fi
 [[ ! -e $TEST_ARGS ]] || fail "drive password does not run cryptsetup for a mismatched confirmation"
+pass "drive password rejects a mismatched confirmation"
 
+# --- happy path: single LUKS device via lsblk --------------------------------
+rm -f "$TEST_ARGS" "$TEST_STDIN"
 printf 'new password\nnew password\n' >"$TEST_INPUTS"
 "$ROOT/bin/omarchy-drive-password" >/dev/null
 
 [[ $(<"$TEST_STDIN") == "new password" ]] || fail "drive password passes the validated passphrase without a newline"
 grep -F 'cryptsetup luksChangeKey' "$TEST_ARGS" >/dev/null || fail "drive password changes the LUKS key"
 grep -Fx /dev/test-luks "$TEST_ARGS" >/dev/null || fail "drive password targets the selected drive"
-pass "drive password rejects empty and mismatched passphrases and passes validated input to cryptsetup"
+pass "drive password discovers a single LUKS device via lsblk and passes validated input to cryptsetup"
+
+# --- no LUKS devices: message + exit 1, never touch blkid --------------------
+rm -f "$TEST_ARGS" "$TEST_STDIN"
+export OMARCHY_TEST_LSBLK_OUT=""
+out=$("$ROOT/bin/omarchy-drive-password" 2>&1) && rc=0 || rc=$?
+unset OMARCHY_TEST_LSBLK_OUT
+(( rc == 1 )) || fail "no LUKS devices exits 1" "rc=$rc out=$out"
+[[ $out == *"No encrypted drives available."* ]] || fail "no LUKS devices prints the expected message" "$out"
+[[ ! -e $TEST_ARGS ]] || fail "no LUKS devices does not run cryptsetup"
+pass "drive password reports no encrypted drives when lsblk finds none"
+
+# --- multi-device: select path, still no blkid --------------------------------
+rm -f "$TEST_ARGS" "$TEST_STDIN"
+export OMARCHY_TEST_LSBLK_OUT=$'/dev/nvme0n1p2 crypto_LUKS\n/dev/sda3 crypto_LUKS\n'
+printf 'chosen\nchosen\n' >"$TEST_INPUTS"
+"$ROOT/bin/omarchy-drive-password" >/dev/null
+unset OMARCHY_TEST_LSBLK_OUT
+grep -Fx /dev/sda3 "$TEST_ARGS" >/dev/null || fail "multi-device path uses the selected LUKS device" "$(cat "$TEST_ARGS" 2>/dev/null || true)"
+grep -F 'cryptsetup luksChangeKey' "$TEST_ARGS" >/dev/null || fail "multi-device path still changes the LUKS key"
+pass "drive password offers a chooser when lsblk reports multiple LUKS devices"
+
+# --- non-LUKS rows are ignored -----------------------------------------------
+rm -f "$TEST_ARGS" "$TEST_STDIN"
+export OMARCHY_TEST_LSBLK_OUT=$'/dev/sda1 vfat\n/dev/sda2 ext4\n/dev/sda3 crypto_LUKS\n/dev/sdb1 xfs\n'
+printf 'only\nonly\n' >"$TEST_INPUTS"
+"$ROOT/bin/omarchy-drive-password" >/dev/null
+unset OMARCHY_TEST_LSBLK_OUT
+grep -Fx /dev/sda3 "$TEST_ARGS" >/dev/null || fail "only crypto_LUKS rows are candidates" "$(cat "$TEST_ARGS" 2>/dev/null || true)"
+pass "drive password ignores non-LUKS lsblk rows"
+
+# --- stock blkid regression guard: script source must not call blkid ---------
+if grep -E -q '^[^#]*\bblkid\b' "$ROOT/bin/omarchy-drive-password"; then
+  fail "omarchy-drive-password must not call blkid for discovery"
+fi
+pass "omarchy-drive-password discovers LUKS via lsblk, not blkid"


### PR DESCRIPTION
## Summary

Fixes #9384.

`omarchy drive password` (and the **Drive Encryption** menu entry) always printed `No encrypted drives available.` on LUKS installs when run as a normal user. Discovery used:

```bash
encrypted_drives=$(blkid -t TYPE=crypto_LUKS -o device)
```

Unprivileged `blkid` cannot read raw partition headers, exits 2, and returns empty output — so the script never reached the password prompt. `cryptsetup` itself is already elevated via `sudo`; only the **listing** step was broken.

## Change

Discover candidates with `lsblk` (FSTYPE from udev/sysfs, no root), matching `omarchy-provision-owner` / `omarchy-system-factory-reset`:

```bash
encrypted_drives=$(lsblk -lnpo NAME,FSTYPE 2>/dev/null | awk '$2 == "crypto_LUKS" { print $1 }')
```

## Evidence (GCP VM `omarchy-repro`, us-central1-a)

Host: `omarchy-repro`, kernel `6.8.0-1066-gcp`, user `fresh` (unprivileged). Created a real LUKS2 loop device and cleared `/run/blkid` so a warm cache could not hide the bug:

```text
=== UNPRIVILEGED blkid (no cache warm) ===
blkid_out=[]
blkid_rc=2

=== UNPRIVILEGED lsblk ===
lsblk_out=[/dev/loop6]

=== stock discovery (exact script line) ===
stock_encrypted_drives=[]
RESULT=STOCK_FAIL:No encrypted drives available.

=== fixed discovery ===
fixed_encrypted_drives=[/dev/loop6]
RESULT=FIXED_PROCEED
FIXED_SCRIPT_BRANCH=would_prompt_for_password
FIXED_SCRIPT_TARGET=/dev/loop6
```

Reproduction steps on the VM:

```bash
dd if=/dev/zero of=luks.img bs=1M count=64
LOOP=$(sudo losetup --find --show luks.img)
printf 'testpass' | sudo cryptsetup luksFormat --type luks2 --batch-mode "$LOOP" -
sudo rm -rf /run/blkid   # do not warm the cache with root blkid
blkid -t TYPE=crypto_LUKS -o device   # empty, exit 2
lsblk -lnpo NAME,FSTYPE | awk '$2 == "crypto_LUKS" {print $1}'  # /dev/loopN
```

## Tests

`test/shell.d/drive-password-test.sh` now covers:

| Case | Expected |
|---|---|
| Empty passphrase | reject, no cryptsetup |
| Mismatched confirmation | reject, no cryptsetup |
| Single LUKS via lsblk | `luksChangeKey` on that device |
| No LUKS rows | `No encrypted drives available.`, exit 1 |
| Multiple LUKS rows | chooser path, selected device |
| Mixed FSTYPEs | only `crypto_LUKS` candidates |
| Source guard | script must not call `blkid` |

A stub `blkid` that exits 99 ensures any regression to blkid fails the suite.

```text
$ bash test/shell.d/drive-password-test.sh
ok - drive password rejects an empty passphrase
ok - drive password rejects a mismatched confirmation
ok - drive password discovers a single LUKS device via lsblk and passes validated input to cryptsetup
ok - drive password reports no encrypted drives when lsblk finds none
ok - drive password offers a chooser when lsblk reports multiple LUKS devices
ok - drive password ignores non-LUKS lsblk rows
ok - omarchy-drive-password discovers LUKS via lsblk, not blkid
```