### PR TITLE
Keep discovery from moving a Bluetooth row out from under the pointer

### DIFF
--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -99,8 +99,26 @@ function deviceRow(d) {
   }
 }
 
-function deviceLists(devices) {
+// Keeps rows already listed in `order` where they are and appends the rest by
+// label. An empty order is just the sort.
+function sortedWithPinnedOrder(devices, order) {
+  var rank = {}
+  for (var i = 0; i < order.length; i++) rank[order[i]] = i
+
+  var pinned = []
+  var arrived = []
+  for (var j = 0; j < devices.length; j++) {
+    if (rank[devices[j].address] === undefined) arrived.push(devices[j])
+    else pinned.push(devices[j])
+  }
+
+  pinned.sort(function(a, b) { return rank[a.address] - rank[b.address] })
+  return pinned.concat(sortedByLabel(arrived))
+}
+
+function deviceLists(devices, pinnedOrder) {
   var values = toArray(devices)
+  var order = pinnedOrder || []
   var connected = []
   var known = []
   var discovered = []
@@ -113,10 +131,11 @@ function deviceLists(devices) {
     else discovered.push(d)
   }
 
+  // Connected devices render above the scroll area, not in the pinned list.
   return {
     connected: sortedByLabel(connected),
-    known: sortedByLabel(known),
-    discovered: sortedByLabel(discovered)
+    known: sortedWithPinnedOrder(known, order),
+    discovered: sortedWithPinnedOrder(discovered, order)
   }
 }
 

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -50,7 +50,12 @@ Panel {
     return Model.hasHumanName(device)
   }
 
-  readonly property var deviceGroups: Model.deviceLists(devices)
+  // Row order held while the pointer is on the scroll list, empty otherwise.
+  // A click acts on whatever row is under the pointer, so a device found
+  // mid-scan must not sort in above the row being aimed at and take it.
+  property var pinnedOrder: []
+
+  readonly property var deviceGroups: Model.deviceLists(devices, pinnedOrder)
   readonly property var connectedDevices: deviceGroups.connected || []
   readonly property var knownDevices: deviceGroups.known || []
   readonly property var discoveredDevices: deviceGroups.discovered || []
@@ -417,6 +422,10 @@ Panel {
       else { focusSection = "header" }
       actionFocused = false
       cursorActive = false
+    } else {
+      // Hiding the list leaves HoverHandler.hovered set, so the pointer never
+      // reports leaving and the order would stay pinned into the next open.
+      pinnedOrder = []
     }
   }
 
@@ -824,6 +833,12 @@ Panel {
           onCurrentIndexChanged: if (currentIndex >= 0) Qt.callLater(keepCurrentVisible)
           function keepCurrentVisible() {
             if (currentIndex >= 0) positionViewAtIndex(currentIndex, ListView.Contain)
+          }
+
+          HoverHandler {
+            onHoveredChanged: root.pinnedOrder = hovered
+              ? root.scrollRows.map(function(row) { return row.dev.address })
+              : []
           }
 
           delegate: Item {

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -92,6 +92,53 @@ assertDeepEqual(arrayLikeLists.connected.map(bluetooth.deviceLabel), ['Earbuds']
 assertDeepEqual(arrayLikeLists.known.map(bluetooth.deviceLabel), ['Trackpad'], 'bluetooth groups known devices from array-like values')
 assertDeepEqual(arrayLikeLists.discovered.map(bluetooth.deviceLabel), ['Gamepad'], 'bluetooth groups discovered devices from array-like values')
 
+// A click acts on whatever row is under the pointer when the button goes down,
+// so nothing found mid-scan may take a row that is already on screen.
+const scanning = [
+  { name: 'Marshall', address: 'm' },
+  { name: 'Pixel Buds', address: 'p' },
+  { name: 'Sony WH-1000XM4', address: 's' }
+]
+const addresses = function(list) { return list.map(function(d) { return d.address }) }
+const onScreen = addresses(bluetooth.deviceLists(scanning).discovered)
+assertDeepEqual(onScreen, ['m', 'p', 's'], 'bluetooth sorts discovered devices by label while the pointer is away')
+
+assertDeepEqual(
+  addresses(bluetooth.deviceLists(scanning.concat([{ name: 'Anker Soundcore', address: 'a' }]), onScreen).discovered),
+  ['m', 'p', 's', 'a'],
+  'bluetooth appends a device found mid-scan instead of sorting it above the rows on screen'
+)
+
+// BlueZ often resolves a name after the device first appears, which resorts the
+// list exactly as an arrival does.
+assertDeepEqual(
+  addresses(bluetooth.deviceLists([
+    { name: 'Marshall', address: 'm' },
+    { name: 'AirPods Pro', address: 'p' },
+    { name: 'Sony WH-1000XM4', address: 's' }
+  ], onScreen).discovered),
+  ['m', 'p', 's'],
+  'bluetooth holds a row in place when its label changes under the pointer'
+)
+
+assertDeepEqual(
+  addresses(bluetooth.deviceLists(scanning.concat([{ name: 'Anker Soundcore', address: 'a' }]), []).discovered),
+  ['a', 'm', 'p', 's'],
+  'bluetooth sorts the list again once the pointer leaves'
+)
+
+// A pin that outlived the pointer would ignore every later discovery result.
+assert(
+  /HoverHandler \{[\s\S]{0,200}root\.pinnedOrder = hovered/.test(panelSource),
+  'bluetooth pins the row order only while the pointer is on the list'
+)
+const openedHandler = panelSource.match(/onOpenedChanged: \{[\s\S]*?\n  \}/)
+assert(openedHandler, 'bluetooth has the panel open handler')
+assert(
+  /pinnedOrder = \[\]/.test(openedHandler[0]),
+  'bluetooth releases the pinned order when the panel closes'
+)
+
 assertDeepEqual(
   bluetooth.deviceRow({ name: 'Deadbeef', address: '1', connected: false }),
   { address: '1', name: 'Deadbeef', deviceName: '', connected: false, state: -1, batteryAvailable: false, battery: 0, pairing: false },


### PR DESCRIPTION
A Bluetooth device arriving during discovery can move another row out from under the pointer. The discovered list is sorted by label on each scan report, and a click uses whichever device occupies that row when the button goes down. A late name update can move the row too.

The list now captures its address order when the pointer enters. Existing rows keep their positions, new devices go at the end, and normal label sorting resumes when the pointer leaves. The order is also released when the panel closes, because hiding it does not clear `HoverHandler.hovered`.

The ordering is applied in `deviceLists()` so the view, section headers, and keyboard cursor use the same groups. Device state can still update while the pointer rests over the list.

`bluetooth-test.sh` covers new arrivals, late name changes, and releasing the order on hover-exit and close. The arrival and rename cases fail on unmodified `quattro`. A recorded live check used nested Hyprland and a Qt 6 harness with the real `Model.js`, a `ListView`, and the same pointer handlers. With the pointer left on the third row, the unpatched list changed the device under it from `s` to `m`; the patched list kept `s` there through both updates and sorted again on exit.

`./test/shell` passed 217 of 221 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`.

#7475 also touches these files for a scroll-position reset. It addresses a separate problem, but the changes may need rebasing against each other.

Fixes #9321.
