### PR TITLE
Detect LUKS drives with lsblk so password change works without root

### DIFF
--- a/bin/omarchy-drive-password
+++ b/bin/omarchy-drive-password
@@ -3,7 +3,7 @@
 # omarchy:summary=Set a new encryption password for a drive selected.
 # omarchy:requires-sudo=true
 
-encrypted_drives=$(blkid -t TYPE=crypto_LUKS -o device)
+encrypted_drives=$(lsblk -lnpo NAME,FSTYPE | awk '$2 == "crypto_LUKS" {print $1}')
 
 if [[ -n $encrypted_drives ]]; then
   if (( $(wc -l <<<"$encrypted_drives") == 1 )); then

--- a/test/shell.d/drive-password-test.sh
+++ b/test/shell.d/drive-password-test.sh
@@ -7,9 +7,9 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 tmp_dir=$(mktemp -d)
 trap 'rm -r "$tmp_dir"' EXIT
 
-cat >"$tmp_dir/blkid" <<'EOF'
+cat >"$tmp_dir/lsblk" <<'EOF'
 #!/bin/bash
-echo /dev/test-luks
+echo "/dev/test-luks crypto_LUKS"
 EOF
 
 cat >"$tmp_dir/gum" <<'EOF'
@@ -24,7 +24,7 @@ printf '%s\n' "$@" >"$TEST_ARGS"
 cat >"$TEST_STDIN"
 EOF
 
-chmod +x "$tmp_dir/blkid" "$tmp_dir/gum" "$tmp_dir/sudo"
+chmod +x "$tmp_dir/lsblk" "$tmp_dir/gum" "$tmp_dir/sudo"
 export PATH="$tmp_dir:$ROOT/bin:$PATH"
 export TEST_ARGS="$tmp_dir/args" TEST_INPUTS="$tmp_dir/inputs" TEST_STDIN="$tmp_dir/stdin"
 


### PR DESCRIPTION
## Summary
- `blkid -t TYPE=crypto_LUKS` as a normal user returns empty, so the menu claimed no encrypted drives before sudo cryptsetup.
- Discover LUKS devices with `lsblk` (same approach as other Omarchy scripts).

## Test plan
- [ ] `test/shell.d/drive-password-test.sh`
- [ ] On a LUKS install, Update/menu drive password lists the crypt device
