### PR TITLE
Let cups-browsed removal proceed when CUPS isn’t running

### DIFF
--- a/migrations/1788009111.sh
+++ b/migrations/1788009111.sh
@@ -25,7 +25,9 @@ fi
 # keeps the migration pending so it can be retried.
 if queue_report=$(LC_ALL=C lpstat -v 2>&1); then
   :
-elif [[ $queue_report == "lpstat: No destinations added." ]]; then
+elif [[ $queue_report == "lpstat: No destinations added." ||
+  $queue_report == "lpstat: Scheduler is not running." ]]; then
+  # No queues to scrub when CUPS is down; still drop cups-browsed below.
   queue_report=""
 else
   printf '%s\n' "$queue_report" >&2


### PR DESCRIPTION
## Summary
- Migration `1788009111` only treated `lpstat: No destinations added.` as empty.
- When cups.service is down, `lpstat -v` returns `Scheduler is not running.` and left the migration pending forever.

## Test plan
- [ ] With cups stopped and cups-browsed present, migrate completes and drops the package
- [ ] Real queues still block removal when lpstat succeeds with destinations
