### PR TITLE
Follow the icon theme inheritance chain when building the app icon index

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -17,9 +17,12 @@ Item {
   property var desktopHiddenEntryIds: ({})
 
   // Maps an icon name to a file on disk (e.g. "omacut" -> ".../apps/omacut.svg").
-  // Used as a fallback for icons that Qt's themed lookup misses because they were
-  // installed after this process started (its icon cache never re-scans). Refreshed
-  // whenever the app list changes, so newly installed apps get their icon live.
+  // Built by walking the icon theme's inheritance chain and limited to
+  // app/device icons, so a name resolves without the ambiguity an
+  // unconstrained themed lookup carries, and so icons installed after this
+  // process started are found at all (Qt's icon cache never re-scans).
+  // Refreshed whenever the app list changes, so newly installed apps get their
+  // icon live.
   property var iconIndex: ({})
   property var pendingIconIndex: ({})
 
@@ -120,19 +123,52 @@ Item {
   }
 
   function iconIndexScanCommand() {
-    // List app/device icons across the XDG icon dirs and /usr/share/pixmaps as
-    // "<path>" lines. Some desktop entries, such as Print Settings, use device
-    // icons like "printer" instead of app icons. SVGs are emitted before PNGs
-    // so the parser, which keeps the first hit per name, prefers scalable icons.
+    // List app/device icons as "<path>" lines, in icon-theme search order: the
+    // active theme, each theme it inherits depth-first in declared order, then
+    // hicolor, then /usr/share/pixmaps. Some desktop entries, such as Print
+    // Settings, use device icons like "printer" instead of app icons.
+    //
+    // The parser keeps the first hit per name, so this order is what picks the
+    // icon; walking every theme on disk instead let whichever one `find`
+    // reached first decide it. Depth-first is what the icon theme spec defines:
+    // a parent's own inheritance is searched before the next declared parent.
+    // A theme's icons may be spread across base directories, but only the first
+    // index.theme found defines it, so the walk takes that one and stops.
+    // hicolor is appended rather than followed through Inherits because it is
+    // the fallback of last resort and themes do list it early
+    // (Tela-circle-dark: "Inherits=hicolor,Adwaita,breeze").
+    //
+    // A theme is exhausted before the next is consulted, SVGs first and then
+    // PNGs within it, so a scalable icon further down the search order cannot
+    // outrank the configured theme's raster one. Each pass is reverse-sorted so
+    // "scalable" beats the numeric size directories; symbolic icons are dropped
+    // because that order would otherwise prefer a monochrome glyph.
     return [
+      'theme=$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "\'");',
+      ': "${theme:=hicolor}";',
       'dirs="$HOME/.icons $HOME/.local/share/icons";',
       'IFS=":"; for d in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do dirs="$dirs $d/icons"; done; unset IFS;',
-      'for ext in svg png; do',
+      'declare -A seen; order=();',
+      'visit() {',
+      '  local base parent;',
+      '  if [[ -z $1 || $1 == "hicolor" || -n ${seen[$1]+set} ]]; then return; fi;',
+      '  seen[$1]=1; order+=("$1");',
       '  for base in $dirs; do',
-      '    [[ -d $base ]] && find "$base" \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" 2>/dev/null;',
+      '    [[ -f $base/$1/index.theme ]] || continue;',
+      '    while IFS= read -r parent; do visit "$parent"; done < <(sed -n "s/^Inherits=//p" "$base/$1/index.theme" | head -1 | tr "," "\\n");',
+      '    break;',
       '  done;',
-      '  find /usr/share/pixmaps -maxdepth 1 -name "*.$ext" 2>/dev/null;',
-      'done'
+      '};',
+      'visit "$theme"; order+=(hicolor);',
+      'for name in "${order[@]}"; do',
+      '  for base in $dirs; do',
+      '    [[ -d $base/$name ]] || continue;',
+      '    for ext in svg png; do',
+      '      find "$base/$name" \\( -path "*/apps/*" -o -path "*/devices/*" \\) ! -path "*/symbolic/*" -name "*.$ext" 2>/dev/null | sort -r;',
+      '    done;',
+      '  done;',
+      'done;',
+      'for ext in svg png; do find /usr/share/pixmaps -maxdepth 1 -name "*.$ext" 2>/dev/null | sort -r; done'
     ].join(' ')
   }
 

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -147,3 +147,111 @@ assert(
   'menu refreshes the shared icon index when opened'
 )
 JS
+
+
+
+# The scan decides which file wins a basename, and iconSource() consults the
+# index before the themed lookup, so scan precedence is what picks the icon.
+# Run the command the QML actually ships against a fixture theme tree.
+require_command node
+
+scan_command=$(node -e '
+const fs = require("fs")
+const qml = fs.readFileSync(process.env.ROOT + "/shell/services/AppLibrary.qml", "utf8")
+const body = qml.match(/function iconIndexScanCommand\(\) \{([\s\S]*?)\n  \}/)
+if (!body) { console.error("iconIndexScanCommand not found"); process.exit(1) }
+process.stdout.write(new Function(body[1])())
+')
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+icons=$tmpdir/.local/share/icons
+home_icons=$tmpdir/.icons
+xdg_icons=$tmpdir/xdg/icons
+mkdir -p \
+  "$icons/OmaSelected/scalable/apps" "$icons/OmaSelected/16x16/apps" \
+  "$icons/OmaSelected/48x48/apps" "$icons/OmaSelected/symbolic/apps" \
+  "$icons/OmaParentA/scalable/apps" "$icons/OmaParentB/scalable/apps" \
+  "$icons/OmaGrandparent/scalable/apps" "$icons/OmaUnrelated/scalable/apps" \
+  "$icons/OmaNear/scalable/apps" "$icons/OmaFar/scalable/apps" \
+  "$icons/hicolor/scalable/apps" \
+  "$home_icons/OmaSplit" "$xdg_icons/OmaSplit/scalable/apps"
+
+# OmaParentA lists hicolor before a real parent, and OmaGrandparent inherits
+# back to the active theme: both shapes occur in shipped themes.
+printf '[Icon Theme]\nInherits=OmaParentA,OmaParentB,OmaSplit\n' > "$icons/OmaSelected/index.theme"
+printf '[Icon Theme]\nInherits=hicolor,OmaGrandparent\n' > "$icons/OmaParentA/index.theme"
+printf '[Icon Theme]\nInherits=OmaSelected\n'            > "$icons/OmaGrandparent/index.theme"
+
+# OmaSplit is defined twice. Only the copy in the earlier base directory
+# defines it, so OmaFar must never enter the search graph.
+printf '[Icon Theme]\nInherits=OmaNear\n' > "$home_icons/OmaSplit/index.theme"
+printf '[Icon Theme]\nInherits=OmaFar\n'  > "$xdg_icons/OmaSplit/index.theme"
+
+touch \
+  "$icons/OmaSelected/scalable/apps/oma-test-selected.svg" \
+  "$icons/OmaParentA/scalable/apps/oma-test-selected.svg" \
+  "$icons/OmaParentA/scalable/apps/oma-test-inherited.svg" \
+  "$icons/hicolor/scalable/apps/oma-test-inherited.svg" \
+  "$icons/OmaGrandparent/scalable/apps/oma-test-depth.svg" \
+  "$icons/OmaParentB/scalable/apps/oma-test-depth.svg" \
+  "$icons/OmaGrandparent/scalable/apps/oma-test-distant.svg" \
+  "$icons/hicolor/scalable/apps/oma-test-distant.svg" \
+  "$icons/hicolor/scalable/apps/oma-test-shipped.svg" \
+  "$icons/OmaUnrelated/scalable/apps/oma-test-unselected.svg" \
+  "$icons/OmaSelected/16x16/apps/oma-test-sized.svg" \
+  "$icons/OmaSelected/scalable/apps/oma-test-sized.svg" \
+  "$icons/OmaSelected/symbolic/apps/oma-test-mono.svg" \
+  "$icons/OmaSelected/48x48/apps/oma-test-mono.svg" \
+  "$icons/OmaNear/scalable/apps/oma-test-near.svg" \
+  "$icons/OmaFar/scalable/apps/oma-test-far.svg" \
+  "$icons/OmaSelected/48x48/apps/oma-test-format.png" \
+  "$icons/OmaParentA/scalable/apps/oma-test-format.svg"
+
+mkdir -p "$tmpdir/bin"
+printf '#!/bin/bash\necho "%s"\n' "'OmaSelected'" > "$tmpdir/bin/gsettings"
+chmod +x "$tmpdir/bin/gsettings"
+
+# An inheritance cycle would hang the walk rather than fail an assertion.
+run_scan() {
+  timeout 30 env -i HOME="$tmpdir" XDG_DATA_DIRS="$tmpdir/xdg" PATH="$tmpdir/bin:$PATH" \
+    bash -c "$scan_command"
+}
+
+run_scan > "$tmpdir/scan" || fail "icon index scan terminates on a theme inheritance cycle"
+pass "icon index scan terminates on a theme inheritance cycle"
+
+# What indexIconLine() keeps: the first path whose basename matches.
+indexed() {
+  awk -F/ -v want="$1" '{ name = $NF; sub(/\.[^.]*$/, "", name); if (name == want) { print; exit } }' "$tmpdir/scan"
+}
+
+expect_theme() {
+  local name=$1 theme=$2 description=$3
+  [[ $(indexed "$name") == *"/$theme/"* ]] || fail "$description" "$(indexed "$name")"
+  pass "$description"
+}
+
+expect_theme oma-test-selected OmaSelected "icon index prefers the active theme over the themes it inherits"
+expect_theme oma-test-inherited OmaParentA "icon index prefers an inherited theme over hicolor"
+expect_theme oma-test-depth OmaGrandparent "icon index exhausts a parent's own inheritance before the next declared parent"
+expect_theme oma-test-distant OmaGrandparent "icon index searches hicolor last even when a theme inherits it first"
+expect_theme oma-test-near OmaNear "icon index takes a theme's inheritance from the first index.theme in base order"
+expect_theme oma-test-format OmaSelected "icon index exhausts a theme before the next one, whatever formats they carry"
+expect_theme oma-test-shipped hicolor "icon index still covers icons an app ships under hicolor"
+expect_theme oma-test-sized scalable "icon index prefers scalable over a fixed-size directory"
+expect_theme oma-test-mono 48x48 "icon index never resolves an app name to a symbolic glyph"
+
+[[ -z $(indexed oma-test-far) ]] ||
+  fail "icon index ignores an Inherits shadowed by an earlier base directory" "$(indexed oma-test-far)"
+pass "icon index ignores an Inherits shadowed by an earlier base directory"
+
+[[ -z $(indexed oma-test-unselected) ]] ||
+  fail "icon index leaves names only an uninherited theme provides to the themed lookup" "$(indexed oma-test-unselected)"
+pass "icon index leaves names only an uninherited theme provides to the themed lookup"
+
+run_scan > "$tmpdir/scan-again"
+diff -q "$tmpdir/scan" "$tmpdir/scan-again" >/dev/null ||
+  fail "icon index scan returns the same order every run"
+pass "icon index scan returns the same order every run"


### PR DESCRIPTION
`AppLibrary` builds its icon index by walking every installed theme and taking the first matching basename. Since the index is consulted before the themed lookup, filesystem traversal order can select icons from a theme the user did not choose. With Papirus selected, only 2 of 150 desktop-entry icon names resolved into it; 118 names that Papirus supplied came from other themes.

The index now searches the active theme, its inherited themes in depth-first declaration order, and finally `hicolor`. It reads inheritance from the first `index.theme` in base-directory order and prevents cycles. `hicolor` stays last even when a theme lists it before other parents. Each theme is exhausted before the next, with SVGs before PNGs within a theme.

The index still takes precedence over the themed lookup and stays limited to apps/devices contexts. That avoids collisions with icons such as `zoom` in an actions context. Reverse sorting gives repeatable results and prefers scalable directories; symbolic icons are excluded. If reading the theme through `gsettings` fails, the index uses `hicolor`.

In the recorded comparison, 119 of the 150 names resolved into Papirus, 14 into `hicolor`, three into its parent `breeze`, 13 through `Quickshell.iconPath`, and one into pixmaps. The scan now costs what the active theme's chain costs rather than what happens to be installed: about 52,500 lines in 0.55 seconds here. The old full walk took 0.85 seconds for 104,959 lines when that comparison was recorded, and takes 0.29 seconds for 54,711 lines now that this machine has fewer unrelated themes, so with few themes installed the ordered scan is the slower of the two. Output is identical across runs.

`app-search-test.sh` runs the command embedded in the QML against fixture themes. It covers active and inherited theme precedence, inheritance depth and base-directory order, `hicolor` fallback, theme order across image formats, scalable and symbolic icons, cycles, and repeatable output. Removing the inheritance walk, changing it to breadth-first, or reading a shadowed `index.theme` each fails the corresponding ordering assertion.

`./test/shell` passed 217 of 221 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`. ShellCheck was clean on the generated command and reported only the existing `SC1091` finding on the test file.

Fixes #7552.

