### PR TITLE
Fail clearly when trackpad reset finds no supported driver

### DIFF
--- a/bin/omarchy-restart-trackpad
+++ b/bin/omarchy-restart-trackpad
@@ -3,6 +3,8 @@
 # omarchy:summary=Reset the trackpad by unbinding and rebinding its driver.
 # omarchy:requires-sudo=true
 
+reset=0
+
 for dev in /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-*; do
   [[ -e $dev ]] || continue
   I2C_DEVICE=$(basename "$dev")
@@ -11,10 +13,17 @@ for dev in /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-*; do
   sleep 1
   echo "$I2C_DEVICE" | sudo tee /sys/bus/i2c/drivers/i2c_hid_acpi/bind > /dev/null
   echo "Done"
+  reset=1
 done
 
 # Also try THC path
 if lsmod | grep -q intel_quicki2c; then
   echo "Reloading intel_quicki2c..."
   sudo modprobe -r intel_quicki2c && sudo modprobe intel_quicki2c
+  reset=1
+fi
+
+if (( reset == 0 )); then
+  echo "No supported trackpad driver found to reset (need i2c_hid_acpi or intel_quicki2c)." >&2
+  exit 1
 fi

--- a/test/shell.d/restart-trackpad-unsupported-test.sh
+++ b/test/shell.d/restart-trackpad-unsupported-test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -r "$tmp_dir"' EXIT
+
+# Fake an empty i2c driver glob and no intel_quicki2c module.
+cat >"$tmp_dir/lsmod" <<'INNER'
+#!/bin/bash
+exit 0
+INNER
+cat >"$tmp_dir/sudo" <<'INNER'
+#!/bin/bash
+exit 0
+INNER
+chmod +x "$tmp_dir/lsmod" "$tmp_dir/sudo"
+
+# Point the script's glob at an empty directory by running under a fake root
+# is hard; instead wrap: create a copy that uses no matching devices.
+export PATH="$tmp_dir:$PATH"
+
+# Create a disposable copy that looks for devices under $tmp_dir
+script="$tmp_dir/omarchy-restart-trackpad"
+sed "s|/sys/bus/i2c/drivers/i2c_hid_acpi/i2c-\\*|$tmp_dir/no-such-i2c-\\*|g" \
+  "$ROOT/bin/omarchy-restart-trackpad" >"$script"
+chmod +x "$script"
+
+if "$script" >/dev/null 2>"$tmp_dir/err"; then
+  fail "restart-trackpad should fail when no supported driver is present"
+fi
+grep -F 'No supported trackpad driver' "$tmp_dir/err" >/dev/null ||
+  fail "restart-trackpad should explain the unsupported driver case"
+
+pass "restart-trackpad fails clearly when no supported driver is present"


### PR DESCRIPTION
## Summary
- Update → Hardware → Trackpad only resets `i2c_hid_acpi` / `intel_quicki2c`.
- Unsupported hardware (e.g. Apple bcm5974) exited 0 with no output, looking successful.

## Test plan
- [ ] `test/shell.d/restart-trackpad-unsupported-test.sh`
- [ ] Supported i2c path still resets as before
