### PR TITLE
Key Claude limits cache by CLAUDE_CONFIG_DIR

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -797,7 +797,8 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
   # A panel that is opened and shut repeatedly must not turn into a request
   # per flick, so recent probe results are reused for a short window — and
   # kept as the answer of record when a later probe fails.
-  probe_cache = cache_root() / "claude-limits.json"
+  digest = hashlib.sha1(str(config_dir()).encode("utf-8")).hexdigest()[:16]
+  probe_cache = cache_root() / f"claude-limits-{digest}.json"
   cached = read_fresh_json(probe_cache, float("inf")) or {}
   fallback = usable_cached_limits(cached)
 

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -89,7 +89,8 @@ spec = importlib.util.spec_from_loader(loader.name, loader)
 collector = importlib.util.module_from_spec(spec)
 loader.exec_module(collector)
 
-cache = collector.cache_root() / "claude-limits.json"
+digest = __import__("hashlib").sha1(str(collector.config_dir()).encode("utf-8")).hexdigest()[:16]
+cache = collector.cache_root() / f"claude-limits-{digest}.json"
 cached = os.environ["CACHED"]
 if cached:
   cache.write_text(cached, encoding="utf-8")
@@ -167,7 +168,8 @@ spec = importlib.util.spec_from_loader(loader.name, loader)
 collector = importlib.util.module_from_spec(spec)
 loader.exec_module(collector)
 
-cache = collector.cache_root() / "claude-limits.json"
+digest = __import__("hashlib").sha1(str(collector.config_dir()).encode("utf-8")).hexdigest()[:16]
+cache = collector.cache_root() / f"claude-limits-{digest}.json"
 cache.write_text(os.environ["CACHED"], encoding="utf-8")
 
 probes = []


### PR DESCRIPTION
## Summary
- Scan caches were already per-projects-path; the limits probe used a fixed `claude-limits.json`.
- Key the probe cache by a digest of `config_dir()` so multi-account setups do not reuse another account’s numbers.

## Test plan
- [ ] `test/shell.d/agent-usage-claude-limits-test.sh`
- [ ] Two `CLAUDE_CONFIG_DIR` values get distinct cache files
