### PR TITLE
Let the configured icon theme decide which icon the launcher draws

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -124,11 +124,45 @@ Item {
     // "<path>" lines. Some desktop entries, such as Print Settings, use device
     // icons like "printer" instead of app icons. SVGs are emitted before PNGs
     // so the parser, which keeps the first hit per name, prefers scalable icons.
+    //
+    // Because the parser keeps the first path it sees for a name, the order the
+    // paths arrive in is what decides which theme the launcher draws. Walking
+    // every icon root at once left that to readdir: with several themes under
+    // ~/.local/share/icons, that root is searched before /usr/share/icons, so an
+    // app's icon came from whichever theme was reached first and could change
+    // between rescans. The theme in org.gnome.desktop.interface icon-theme,
+    // which omarchy-theme-set-gnome writes, went unconsulted.
+    //
+    // So emit the configured theme first, then hicolor, where an application
+    // installs its own icon, and only then everything else, which is what finds
+    // an icon no theme covers.
+    //
+    // -L on the theme passes, because icon themes are built out of symlinked
+    // size directories -- Papirus's 128x128/apps is a symlink to ../64x64/apps
+    // -- and find does not descend those without it. The catch-all pass stays
+    // without -L: following every symlink under every icon root is much slower,
+    // and it only exists as a fallback.
     return [
-      'dirs="$HOME/.icons $HOME/.local/share/icons";',
-      'IFS=":"; for d in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do dirs="$dirs $d/icons"; done; unset IFS;',
+      'theme=$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "\'"); [[ -n $theme ]] || theme=hicolor;',
+      'roots="$HOME/.icons $HOME/.local/share/icons";',
+      'IFS=":"; for d in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do roots="$roots $d/icons"; done; unset IFS;',
+      // Within one theme, prefer the largest artwork. Themes carry less detail
+      // in their small buckets and find returns them in filesystem order, so
+      // without this a row rendered large could be handed a 24x24 icon.
+      // scalable outranks every fixed size; a path with no size in it keeps 0
+      // and sorts last, which is where /usr/share/pixmaps belongs.
+      'rank() { sed -E \'s|^|0\\t|; s|^0\\t(.*/scalable/.*)$|9999\\t\\1|; s|^0\\t(.*/([0-9]+)x[0-9]+(@[0-9]+x)?/.*)$|\\2\\t\\1|\' | sort -rn -s -k1,1 | cut -f2-; };',
+      'scan_theme() {',
+      '  for ext in svg png; do',
+      '    for base in $roots; do',
+      '      [[ -d "$base/$1" ]] && find -L "$base/$1" \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" 2>/dev/null;',
+      '    done;',
+      '  done | rank;',
+      '};',
+      'scan_theme "$theme";',
+      '[[ $theme == hicolor ]] || scan_theme hicolor;',
       'for ext in svg png; do',
-      '  for base in $dirs; do',
+      '  for base in $roots; do',
       '    [[ -d $base ]] && find "$base" \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" 2>/dev/null;',
       '  done;',
       '  find /usr/share/pixmaps -maxdepth 1 -name "*.$ext" 2>/dev/null;',

--- a/test/shell.d/icon-index-theme-test.sh
+++ b/test/shell.d/icon-index-theme-test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# The icon index keeps the first path it sees for a name, so what the launcher
+# draws is decided by the order the scan emits paths in. These run the command
+# AppLibrary builds, against a tree holding the same icon in three themes.
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+icons="$test_tmp/share/icons"
+home="$test_tmp/home"
+mkdir -p "$mock_bin" "$home/.icons" "$home/.local/share/icons"
+
+printf '#!/bin/bash\nprintf "%%s\\n" "'"'"'${OMARCHY_TEST_ICON_THEME:-Chosen}'"'"'"\n' >"$mock_bin/gsettings"
+chmod +x "$mock_bin/gsettings"
+
+icon() { mkdir -p "$(dirname "$1")"; : >"$1"; }
+
+# The chosen theme keeps its large sizes behind symlinks, the way Papirus does.
+icon "$icons/Chosen/64x64/apps/browser.svg"
+mkdir -p "$icons/Chosen/128x128"
+ln -s ../64x64/apps "$icons/Chosen/128x128/apps"
+icon "$icons/Chosen/scalable/devices/printer.svg"
+
+# A theme nobody selected, in the root that is searched first.
+icon "$home/.local/share/icons/Unselected/scalable/apps/browser.svg"
+icon "$home/.local/share/icons/Unselected/scalable/apps/only-here.svg"
+
+# An application shipping its own icon.
+icon "$icons/hicolor/256x256/apps/self-installed.png"
+
+# Pull the command out of the shell source so the test exercises what ships.
+scan_command=$(
+  python3 - "$ROOT/shell/services/AppLibrary.qml" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+block = src[src.index('function iconIndexScanCommand'):]
+block = block[block.index('return ['):block.index("].join(' ')")]
+parts = re.findall(r"^\s*'((?:[^'\\]|\\.)*)',?\s*$", block, re.M)
+print(' '.join(p.replace("\\'", "'").replace('\\\\', '\\') for p in parts))
+PY
+)
+
+run_scan() {
+  HOME="$home" XDG_DATA_DIRS="$test_tmp/share" PATH="$mock_bin:$PATH" \
+    OMARCHY_TEST_ICON_THEME="${1:-Chosen}" bash -c "$scan_command" 2>/dev/null
+}
+
+# Run it once; every check below reads the same output.
+scan_out="$test_tmp/scan"
+run_scan >"$scan_out"
+
+# Same rule as AppLibrary's parser: the first path seen for a name wins.
+resolve() {
+  awk -v want="$1" -F/ '{
+    base = $NF
+    sub(/\.[^.]*$/, "", base)
+    if (base == want) { print; found = 1; exit }
+  } END { if (!found) print "<unresolved>" }' "$scan_out"
+}
+
+got=$(resolve browser)
+[[ $got == "$icons/Chosen/"* ]] ||
+  fail "the configured icon theme wins over a theme that is merely present" "$got"
+pass "the configured icon theme wins over a theme that is merely present"
+
+got=$(resolve only-here)
+[[ $got == "$home/.local/share/icons/Unselected/"* ]] ||
+  fail "an icon no chosen theme carries is still found" "$got"
+pass "an icon no chosen theme carries is still found"
+
+got=$(resolve self-installed)
+[[ $got == "$icons/hicolor/"* ]] ||
+  fail "an application's own hicolor icon is found" "$got"
+pass "an application's own hicolor icon is found"
+
+# 128x128/apps is a symlink; find needs -L to descend into it at all.
+grep -q "Chosen/128x128/apps/browser.svg" "$scan_out" ||
+  fail "symlinked size directories inside a theme are searched" "$(grep Chosen "$scan_out" | head -3)"
+pass "symlinked size directories inside a theme are searched"
+
+# Within the theme, the larger artwork is emitted before the smaller one.
+order=$(grep -n "Chosen/\(128x128\|64x64\)/apps/browser.svg" "$scan_out" | head -2)
+[[ $(head -1 <<<"$order") == *"128x128"* ]] ||
+  fail "the largest artwork in a theme is preferred" "$order"
+pass "the largest artwork in a theme is preferred"
+
+got=$(resolve printer)
+[[ $got == *"/devices/"* ]] ||
+  fail "device icons are still indexed" "$got"
+pass "device icons are still indexed"


### PR DESCRIPTION
`indexIconLine()` keeps the first path it sees for a name, so the order `iconIndexScanCommand()` emits paths in is what decides which theme the launcher draws. The scan walked every icon root in one pass, which left that to readdir: `$HOME/.local/share/icons` is searched before `/usr/share/icons`, so on a machine with a few themes installed there an app's icon came from whichever theme was reached first, and could change between rescans. The theme in `org.gnome.desktop.interface icon-theme`, which `omarchy-theme-set-gnome` writes from the theme's `icons.theme`, was never read.

The scan now emits the configured theme first, then hicolor, where an application installs its own icon, and only then everything else, which is what finds an icon no theme covers. Within a theme the paths are ranked so scalable comes first and larger fixed sizes come before smaller ones, because themes carry less detail in their small buckets and a row rendered large could otherwise be handed a 24x24 icon.

The theme passes use `find -L`. Icon themes are built out of symlinked size directories — Papirus's `128x128/apps` is a symlink to `../64x64/apps` — and find does not descend those without it, so a large part of the configured theme was invisible to the scan even once it was reached. The catch-all pass stays without `-L`: following every symlink under every icon root is much slower, and that pass only exists as a fallback.

The ordering is done in the scan rather than in the parser so the parser keeps its single rule, that the first path for a name wins. Sorting in the parser would mean holding every path for every name to compare them, on a list that runs to hundreds of thousands of lines with a few themes installed.

## Testing

`icon-index-theme-test.sh` pulls the command out of `AppLibrary.qml` and runs it against a tree holding the same icon name in three themes, with `gsettings` stubbed: the configured theme wins over a theme that is merely installed, an icon no chosen theme carries is still found, an application's own hicolor icon is still found, a symlinked size directory inside a theme is searched, the larger artwork wins inside a theme, and device icons are still indexed. The first assertion fails on current quattro, resolving to the unselected theme.

Measured on this machine with `icon-theme` set to `Papirus` and several other themes under `~/.local/share/icons`, resolving the 152 non-absolute `Icon=` names from the installed desktop entries through the same first-hit-wins rule:

```
unpatched   resolved 146/152   from Papirus:   2   elsewhere: 144  (Nordzy-cyan-dark 67, WhiteSur-dark 22, Ant-Dark 18)
patched     resolved 146/152   from Papirus: 120   elsewhere:  26  (hicolor 14, WhiteSur 3, WhiteSur-dark 3)
```

The 26 that still come from elsewhere are correct: 14 are applications shipping their own hicolor icon, and the rest are names Papirus does not carry.

`./test/shell` — 218 of 222 files pass; the four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, `unowned-system-paths-test`) fail identically on unmodified quattro on this machine.

This comes out of https://github.com/VykosMolt/omarchy-desktop, where I have been running the Quattro shell as a plain Arch session and fixing what turned up. A couple of the other things I found there are worth sending separately, so more to follow.

Fixes #7552
