### PR TITLE
Clear setgid when hardening Windows VM storage directories

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,7 +580,9 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  # Drop setgid/setuid bits too: chmod 0700 alone leaves a setgid dir as 2700,
+  # which then fails the exact-mode privacy check below.
+  chmod a-s,u=rwx,go= -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
@@ -1015,7 +1017,7 @@ prepare_user_mount_sources() {
     echo "omarchy-windows-vm: storage and shared must be different directories" >&2
     return 1
   }
-  chmod 0700 -- "$storage" "$shared"
+  chmod a-s,u=rwx,go= -- "$storage" "$shared"
 }
 
 storage_space_path() {


### PR DESCRIPTION
## Summary
- `chmod 0700` on a setgid directory leaves mode `2700`, so the exact `700` privacy check failed and launch aborted.
- Use `chmod a-s,u=rwx,go=` when hardening storage/shared leaves.

## Test plan
- [ ] Launch Windows VM from a setgid-inherited storage path
- [ ] Existing windows-vm mount/compose privacy tests still pass
