### PR TITLE
Decode wallpapers at the size the screen can show

### DIFF
--- a/shell/Ui/BackgroundMedia.qml
+++ b/shell/Ui/BackgroundMedia.qml
@@ -6,6 +6,7 @@ Item {
 
   property string path: ""
   property int version: 0
+  property size sourceSize: Qt.size(version > 0 ? width : 0, version > 0 ? height : 0)
   property bool playbackEnabled: true
   property bool audioEnabled: false
   // Bumped when the file behind an unchanged path may have been replaced.
@@ -80,8 +81,7 @@ Item {
       fillMode: Image.PreserveAspectCrop
       asynchronous: true
       cache: root.version === 0
-      sourceSize.width: root.version > 0 ? width : 0
-      sourceSize.height: root.version > 0 ? height : 0
+      sourceSize: root.sourceSize
     }
   }
 }

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -266,6 +266,10 @@ Item {
         reloads: root.displayedReloads
         playbackEnabled: !root.sessionObscured && !root.powerSaverActive && !panel.fullscreenHere
         audioEnabled: panel.firstScreen
+        // Decode still wallpapers near the screen resolution. The 1.6x box
+        // leaves room to crop wide images without scaling them back up.
+        sourceSize.width: Math.ceil(width * Screen.devicePixelRatio * 1.6)
+        sourceSize.height: Math.ceil(height * Screen.devicePixelRatio * 1.6)
         onReadyChanged: {
           if (ready && root.finishingTransition) {
             root.incomingBackground = ""
@@ -284,6 +288,8 @@ Item {
         cache: false
         smooth: true
         mipmap: true
+        sourceSize.width: base.sourceSize.width
+        sourceSize.height: base.sourceSize.height
         visible: root.oldBackground !== "" && root.revealProgress < 1
         onStatusChanged: panel.maybeStartReveal()
       }
@@ -310,6 +316,8 @@ Item {
           cache: false
           smooth: true
           mipmap: true
+          sourceSize.width: base.sourceSize.width
+          sourceSize.height: base.sourceSize.height
           onStatusChanged: panel.maybeStartReveal()
         }
       }

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -19,3 +19,34 @@ assert(
   'background theme transition applies pending colors even if image reveal stalls'
 )
 JS
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const backgroundQml = fs.readFileSync(path.join(root, 'shell/plugins/background/Background.qml'), 'utf8')
+
+assert(
+  /sourceSize\.width: Math\.ceil\(width \* Screen\.devicePixelRatio \* 1\.6\)/.test(backgroundQml) &&
+    /sourceSize\.height: Math\.ceil\(height \* Screen\.devicePixelRatio \* 1\.6\)/.test(backgroundQml),
+  'background decodes the wallpaper to the screen size rather than the file size'
+)
+
+assert(
+  (backgroundQml.match(/sourceSize\.width: base\.sourceSize\.width/g) || []).length === 2 &&
+    (backgroundQml.match(/sourceSize\.height: base\.sourceSize\.height/g) || []).length === 2,
+  'background transition frames decode at the same size as the wallpaper they cross-fade'
+)
+
+const images = backgroundQml.split(/\bImage\s*\{/).slice(1)
+assert(
+  images.length === 2 && images.every(image => image.includes('sourceSize.width') && image.includes('sourceSize.height')),
+  'both background transition Images cap their decode size'
+)
+
+const mediaQml = fs.readFileSync(path.join(root, 'shell/Ui/BackgroundMedia.qml'), 'utf8')
+assert(
+  mediaQml.includes('property size sourceSize: Qt.size(version > 0 ? width : 0, version > 0 ? height : 0)') &&
+    mediaQml.includes('sourceSize: root.sourceSize'),
+  'BackgroundMedia forwards the wallpaper decode size while preserving the lock screen default'
+)
+JS


### PR DESCRIPTION
Desktop still wallpapers and their transition frames decode at native file resolution, even when the display can show much less. Their `sourceSize` is now capped at 1.6 times the screen dimensions, including `Screen.devicePixelRatio`, and both transition frames share the base wallpaper's decode size. The extra room accommodates aspect cropping without immediately scaling wide images back up.

The desktop now renders its base wallpaper through `BackgroundMedia`, so that component exposes a `sourceSize` property and forwards it to its still-image loader. Its default retains the existing lock-screen sizing behavior. Video playback, audio selection, and pause conditions continue to use the existing video path.

`background-test.sh` and `video-background-test.sh` pass, including checks for shared transition sizing, the media component's default sizing, and preserved video behavior. `git diff --check` passes. Rebased onto current `quattro`; live graphical verification has not been repeated for this revision.
