### PR TITLE
Take the login shell, and one whole process, out of the bar's Hyprland calls

### DIFF
--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -58,6 +58,17 @@ QtObject {
     Quickshell.execDetached(["bash", "-lc", command])
   }
 
+  // Run a program directly, with no shell in between. execDetached and execArgv
+  // both go through `bash -lc`, a login shell that sources /etc/profile and every
+  // script in /etc/profile.d before the program starts. That buys the session env
+  // a GUI target needs, and it is pure overhead for a tool like hyprctl that needs
+  // nothing from the profile and is already on PATH. Use this only for a fixed
+  // argv naming a system tool; anything a user could influence still wants the
+  // quoting rules execArgv documents.
+  function execProgram(argv) {
+    Quickshell.execDetached(argv)
+  }
+
   // Run an argv vector without a shell interpreting it: the constant `exec "$@"`
   // means the args only ever land in positional parameters, which bash expands
   // without re-tokenizing — so untrusted data ($(id), a filename) stays literal.

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -844,6 +844,14 @@ Item {
     Util.execDetached(command)
   }
 
+  // Same as run, for a fixed argv naming a system tool that needs nothing from
+  // the login shell. Skips the profile sourcing run pays for on every call.
+  function runProgram(argv) {
+    if (!argv || !argv.length) return
+
+    Util.execProgram(argv)
+  }
+
   function toggleTransparency() {
     var nextTransparent = !(root.requestedTransparent === true)
     if (root.shell && typeof root.shell.mutateShellConfig === "function") {

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -161,6 +161,7 @@ Widgets receive `bar` (the shell root), `moduleName` (string), and `settings` (o
 - `bar.vertical` — boolean shortcut
 - `bar.barSize` — 26 horizontal / 28 vertical
 - `bar.run(command)` — fire-and-forget bash exec (quote arguments with `Util.shellQuote` from `qs.Commons`)
+- `bar.runProgram(argv)` — same, for a fixed argv naming a system tool; skips the login shell `run` sources on every call
 - `bar.showTooltip(target, text)` / `bar.hideTooltip(target)` — shared tooltip popup
 - `bar.requestPopout(owner)` / `bar.releasePopout(owner)` — one-popup-at-a-time coordinator
 

--- a/shell/plugins/bar/widgets/KeyboardLayout.qml
+++ b/shell/plugins/bar/widgets/KeyboardLayout.qml
@@ -91,8 +91,8 @@ BarWidget {
   function cycleLayout() {
     if (!root.bar || root.layoutCount < 2 || root.syncNames.length === 0) return
     const next = (root.layoutIndex + 1) % root.layoutCount
-    root.bar.run(root.syncNames.map(name =>
-      "hyprctl switchxkblayout " + Util.shellQuote(name) + " " + next).join("; "))
+    root.syncNames.forEach(name =>
+      root.bar.runProgram(["hyprctl", "switchxkblayout", name, String(next)]))
     refreshTimer.restart()
   }
 

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -30,9 +30,12 @@ BarWidget {
     return ids
   }
 
+  // Straight down the socket this widget already holds open for
+  // Hyprland.workspaces, rather than out through the bar to a new process. The
+  // expression is the one tiling.lua binds, deliberately, so a click and the
+  // keybinding cannot drift apart.
   function focusWorkspace(id) {
-    if (!root.bar) return
-    root.bar.run("hyprctl dispatch " + Util.shellQuote("hl.dsp.focus({ workspace = \"" + id + "\" })"))
+    Hyprland.dispatch("hl.dsp.focus({ workspace = \"" + id + "\" })")
   }
 
   readonly property real trailingGap: root.vertical ? 0 : Style.spaceReal(1.5)

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -485,3 +485,36 @@ put_output=$(PATH="$put_tmp/bin:$ROOT/bin:$PATH" \
   fail "put places a widget through a ready shell" "$put_output"
 [[ $put_output == "omarchy.keyboard-layout is on the bar" ]] || fail "put reports the placed widget" "$put_output"
 pass "put places a widget through a ready shell"
+
+# A bar click that runs a system tool should not pay for a login shell first.
+# Util.execProgram hands the argv straight to Quickshell; run and execArgv keep
+# their `bash -lc` because the targets they launch need the session env.
+if ! rg -qU 'function execProgram\(argv\) \{\n\s*Quickshell\.execDetached\(argv\)\n\s*\}' "$ROOT/shell/Commons/Util.qml"; then
+  fail "Util.execProgram must run the argv without a shell in between"
+fi
+pass "Util.execProgram runs a program without a login shell"
+
+if ! rg -qU 'function runProgram\(argv\) \{[^}]*Util\.execProgram\(argv\)' "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "bar.runProgram must delegate to Util.execProgram"
+fi
+pass "bar.runProgram gives widgets the no-shell path"
+
+if rg -q 'bar\.run\("hyprctl' "$ROOT/shell/plugins/bar/widgets/Workspaces.qml" "$ROOT/shell/plugins/bar/widgets/KeyboardLayout.qml"; then
+  fail "hyprctl must not be launched through a login shell from the bar"
+fi
+pass "bar hyprctl calls skip the login shell"
+
+if ! rg -q 'Hyprland\.dispatch\("hl\.dsp\.focus' "$ROOT/shell/plugins/bar/widgets/Workspaces.qml"; then
+  fail "workspace focus must go down the socket the widget already holds"
+fi
+pass "workspace focus dispatches over the existing Hyprland socket"
+
+if rg -q 'hyprctl' "$ROOT/shell/plugins/bar/widgets/Workspaces.qml"; then
+  fail "workspace focus must not spawn hyprctl at all"
+fi
+pass "clicking a workspace spawns no process"
+
+if ! rg -q 'runProgram\(\["hyprctl", "switchxkblayout", name, String\(next\)\]\)' "$ROOT/shell/plugins/bar/widgets/KeyboardLayout.qml"; then
+  fail "keyboard layout switch must pass the device name as an argv element"
+fi
+pass "keyboard layout switch passes its device name literally"

--- a/test/shell.d/keyboard-layout-test.sh
+++ b/test/shell.d/keyboard-layout-test.sh
@@ -134,3 +134,36 @@ assertEqual(model.eventKeyboardName(rawEvent('hl-virtual-keyboard,English (US)')
 assertEqual(model.eventKeyboardName({ parse: () => { throw new Error('unsupported') }, data: 'kb,French' }), 'kb', 'a binding without parse falls back to the raw data')
 assertEqual(model.eventKeyboardName({}), '', 'an event with nothing in it names no keyboard')
 JS
+
+run_node_test <<'JS'
+const fs = require('fs')
+const widget = fs.readFileSync(path.join(root, 'shell/plugins/bar/widgets/KeyboardLayout.qml'), 'utf8')
+const cycleBody = widget.match(/function cycleLayout\(\) \{([\s\S]*?)\n  \}/)[1]
+const cycle = new Function('root', 'refreshTimer', cycleBody)
+const calls = []
+let refreshes = 0
+const state = {
+  bar: {runProgram: argv => calls.push(argv)},
+  layoutCount: 3,
+  layoutIndex: 2,
+  syncNames: ['main keyboard', "device'with;syntax"],
+}
+const timer = {restart: () => refreshes++}
+cycle(state, timer)
+assertDeepEqual(calls, [
+  ['hyprctl', 'switchxkblayout', 'main keyboard', '0'],
+  ['hyprctl', 'switchxkblayout', "device'with;syntax", '0'],
+], 'a click sends every synchronized keyboard the same wrapped index as literal arguments')
+assertEqual(refreshes, 1, 'the synchronized switch requests one follow-up reading')
+calls.length = 0
+state.layoutCount = 1
+cycle(state, timer)
+state.layoutCount = 3
+state.syncNames = []
+cycle(state, timer)
+state.syncNames = ['main keyboard']
+state.bar = null
+cycle(state, timer)
+assertEqual(calls.length, 0, 'a click with one layout, no synchronized devices, or no bar starts no process')
+assertEqual(refreshes, 1, 'a click that cannot switch requests no follow-up reading')
+JS


### PR DESCRIPTION
Workspace and keyboard-layout clicks currently launch `hyprctl` through `bar.run()` and its login shell, paying for `/etc/profile` and `/etc/profile.d` before the command starts. Workspace focus now dispatches over the widget's existing Hyprland connection. Keyboard-layout switching uses `bar.runProgram()` and `Util.execProgram()` to pass an argv directly to Quickshell.

A keyboard-layout click continues to synchronize every device sharing the selected layout list to the same wrapped absolute index. Each device name is passed as a literal argument to its own `hyprctl` invocation. Other bar launchers retain their existing login-shell behavior.

Validation: `bar-test.sh`, `keyboard-layout-test.sh`, and `hyprland-keyboard-layout-test.sh` pass. The keyboard test executes the switching function to verify synchronized devices, index wrapping, literal names containing shell syntax, and the existing guards. Independent review also exercised the full function chain through a mocked Quickshell call. `git diff --check` passes. Rebased onto current `quattro`; live graphical verification has not been repeated for this revision.
