### PR TITLE
Escape the values written into retro game desktop files

### DIFF
--- a/bin/omarchy-games-retro-install
+++ b/bin/omarchy-games-retro-install
@@ -53,12 +53,46 @@ desktop_dir="$HOME/.local/share/applications"
 desktop_file="$desktop_dir/$desktop_id.desktop"
 mkdir -p "$desktop_dir"
 
+desktop_string_escape() {
+  # The game name comes from a file name, and a file name can hold a newline.
+  # A raw newline in a desktop value would start a new key line, so a game named
+  # on two lines could add keys of its own to its launcher entry. Escape
+  # backslash first, then tab, CR and LF, and a leading space, the same way
+  # omarchy-webapp-install escapes every value it writes.
+  local value="$1"
+
+  value=${value//\\/\\\\}
+  value=${value//$'\t'/\\t}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\n'/\\n}
+  [[ $value == " "* ]] && value="\\s${value# }"
+
+  printf '%s' "$value"
+}
+
+desktop_exec_arg() {
+  # One argument of the Exec line, double-quoted as the desktop spec wants.
+  # Inside the quotes a backslash, double quote, backtick or dollar sign takes
+  # another backslash, and a literal % becomes %%, so a path with those
+  # characters cannot step outside its argument or ask for a field code.
+  local escaped
+  escaped=$(printf '%s' "$1" \
+    | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/`/\\`/g' -e 's/\$/\\$/g' -e 's/%/%%/g')
+  printf '"%s"' "$escaped"
+}
+
+name_field=$(desktop_string_escape "$desktop_name")
+comment_field=$(desktop_string_escape "Play $game_name with RetroArch")
+# The paths are quoted as one Exec argument each, then the whole line gets the
+# file escaping the launcher undoes first, so the two layers work together.
+exec_field=$(desktop_string_escape "retroarch -L $(desktop_exec_arg "$core_path") $(desktop_exec_arg "$game_path")")
+
 cat >"$desktop_file" <<EOF
 [Desktop Entry]
 Version=1.0
-Name=$desktop_name
-Comment=Play $game_name with RetroArch
-Exec=retroarch -L "$core_path" "$game_path"
+Name=$name_field
+Comment=$comment_field
+Exec=$exec_field
 Terminal=false
 Type=Application
 Icon=retro-gaming

--- a/test/shell.d/retro-desktop-escape-test.sh
+++ b/test/shell.d/retro-desktop-escape-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+stub_bin="$test_tmp/bin"
+mkdir -p "$test_home" "$stub_bin"
+
+for stub in omarchy-notification-send update-desktop-database; do
+  printf '#!/bin/bash\n:\n' >"$stub_bin/$stub"
+  chmod +x "$stub_bin/$stub"
+done
+
+core="$test_tmp/mgba_libretro.so"
+printf 'core\n' >"$core"
+
+run_install() {
+  HOME="$test_home" PATH="$stub_bin:/usr/bin" \
+    "$ROOT/bin/omarchy-games-retro-install" "$core" "$1"
+}
+
+# A newline in a game file name used to become a new key line in the launcher
+# entry. A name like this one would add a key of its own to the file.
+game="$test_tmp/"$'pwn\nX-Omarchy-Hole=injected.sfc'
+printf 'rom\n' >"$game"
+
+run_install "$game" >/dev/null 2>&1 || true
+
+desktop_file="$test_home/.local/share/applications/pwn-x-omarchy-hole-injected.desktop"
+[[ -f $desktop_file ]] || fail "retro-install writes a desktop entry for the game"
+
+if grep -q '^X-Omarchy-Hole=' "$desktop_file"; then
+  fail "retro-install keeps a newline in a name from adding a key line"
+fi
+grep -qF 'Name=Pwn\nX-Omarchy-Hole=injected' "$desktop_file" ||
+  fail "retro-install keeps a name with a newline on one escaped line"
+grep -q "^Exec=retroarch -L " "$desktop_file" ||
+  fail "retro-install keeps the Exec line whole when the path holds a newline"
+pass "retro-install escapes a newline in a game name instead of adding a key line"
+
+# A double quote in a file name used to step outside its quoted Exec argument.
+game="$test_tmp/"$'qu"ote.sfc'
+printf 'rom\n' >"$game"
+
+run_install "$game" >/dev/null 2>&1 || true
+
+desktop_file="$test_home/.local/share/applications/qu-ote.desktop"
+[[ -f $desktop_file ]] || fail "retro-install writes a desktop entry for the game"
+grep '^Exec=' "$desktop_file" | grep -qF 'qu\\"ote.sfc"' ||
+  fail "retro-install escapes a double quote in a game path on the Exec line"
+pass "retro-install keeps a double quote inside its Exec argument"
+
+# A plain game keeps the same entry this command always wrote.
+game="$test_tmp/Zelda.sfc"
+printf 'rom\n' >"$game"
+
+run_install "$game" >/dev/null 2>&1 || true
+
+desktop_file="$test_home/.local/share/applications/zelda.desktop"
+[[ -f $desktop_file ]] || fail "retro-install writes a desktop entry for a plain game"
+grep -qF 'Name=Zelda' "$desktop_file" ||
+  fail "retro-install writes the plain name"
+grep -qF "Exec=retroarch -L \"$core\" \"$game\"" "$desktop_file" ||
+  fail "retro-install writes the same Exec line as before for plain paths"
+pass "retro-install writes the same entry as before for a plain game"


### PR DESCRIPTION
`omarchy-games-retro-install` builds a launcher entry from the game's file name and writes the pieces straight into the `.desktop` file:

```
Name=$desktop_name
Comment=Play $game_name with RetroArch
Exec=retroarch -L "$core_path" "$game_path"
```

A file name can hold a newline or a double quote. A newline starts a new key line inside the entry, so a game file named `pwn` + newline + `Exec=touch pwned` + newline + `X-Pad=.sfc` writes a second `Exec=` line into the launcher file. That line is not just noise: GLib-based launchers run it. I checked with `gio launch` on the file this command wrote, and it ran `touch pwned` instead of retroarch. A double quote steps outside its quoted argument on the Exec line, and the launcher then refuses to load the entry at all. Odd characters like these can arrive inside a downloaded game archive, so the person installing the game may never see them.

The old Exec line also broke on tamer paths. `%` and `\` are special to the launcher, so a game like `100% Cool $5 back\lash.sfc` got its path mangled and never started.

`omarchy-webapp-install` already passes every value it writes through `desktop_string_escape` and `desktop_exec_arg`. This command did not.

What changed:

- `omarchy-games-retro-install` gained the same two helpers, and the Name, Comment and Exec values now pass through them before the file is written. Plain names and paths like `Super Mario World (USA).sfc` keep the exact entry this command always wrote, byte for byte.
- As a side benefit, paths with `%` or `\` now reach retroarch as one intact argument, so those games launch.

Tests: new `test/shell.d/retro-desktop-escape-test.sh`. A newline in a game name no longer adds a key line, a double quote in a path stays inside its Exec argument, and a plain game still gets the same entry as before.