### PR TITLE
Replace Em Dash with Arrow

### DIFF
--- a/default/xcompose
+++ b/default/xcompose
@@ -26,4 +26,4 @@ include "%L"
 <Multi_key> <m> <b> : "🤯" # blowing
 
 # Typography
-<Multi_key> <space> <space> : "—"
+<Multi_key> <space> <space> : "→"


### PR DESCRIPTION
The world has changed immensely in 15 months. Anyone who still writes by hand will not be caught dead using an em dash, possibly the most vilified glyph of these times. The arrow `→` maintains the spirit of productivity, professionalism, and ease of use.