### PR TITLE
Keep four commands from building a path that climbs out of its directory

### DIFF
--- a/bin/omarchy-hook
+++ b/bin/omarchy-hook
@@ -10,6 +10,9 @@ if (( $# < 1 )); then
   exit 1
 fi
 
+source omarchy-path-guard || exit 1
+omarchy_reject_climbing_name "$1" "hook name" || exit 1
+
 HOOK=$1
 HOOK_PATH="$HOME/.config/omarchy/hooks/$1"
 HOOK_DIR="$HOOK_PATH.d"

--- a/bin/omarchy-hyprland-toggle
+++ b/bin/omarchy-hyprland-toggle
@@ -14,6 +14,10 @@ fi
 
 FLAG_NAME="$1"
 ACTION="${2:-toggle}"
+
+source omarchy-path-guard || exit 1
+omarchy_reject_climbing_name "$FLAG_NAME" "flag name" || exit 1
+
 FLAG_FILE="$HOME/.local/state/omarchy/toggles/hypr/$FLAG_NAME.lua"
 FLAG_SOURCE="$OMARCHY_PATH/default/hypr/toggles/$FLAG_NAME.lua"
 

--- a/bin/omarchy-path-guard
+++ b/bin/omarchy-path-guard
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# omarchy:summary=Reject a caller-supplied name that would climb out of the directory it is joined to.
+# omarchy:hidden=true
+
+# Several commands join an argument into a path they then write, delete or
+# execute. A name is safe when every component of it is an ordinary filename:
+# `crash-ignore/chromium` is a namespace omarchy-crash-mute relies on, so a
+# slash is allowed, while a `.` or `..` component is what reaches a directory
+# above the one the caller meant. `...` and `..foo` are ordinary filenames and
+# stay legal, as do the glob characters omarchy-state's clear pattern needs.
+omarchy_reject_climbing_name() {
+  local name=$1 label=${2:-name}
+
+  if [[ -z $name || $name == /* || $name == "." || $name == ".." ||
+    $name == ./* || $name == ../* || $name == */./* || $name == */../* ||
+    $name == */. || $name == */.. ]]; then
+    echo "Invalid $label: $name" >&2
+    return 1
+  fi
+
+  return 0
+}

--- a/bin/omarchy-state
+++ b/bin/omarchy-state
@@ -20,6 +20,9 @@ if [[ -z $STATE_NAME ]]; then
   exit 1
 fi
 
+source omarchy-path-guard || exit 1
+omarchy_reject_climbing_name "$STATE_NAME" "state name" || exit 1
+
 case "$COMMAND" in
 set) touch "$STATE_DIR/$STATE_NAME" ;;
 clear) find "$STATE_DIR" -maxdepth 1 -type f -name "$STATE_NAME" -delete ;;

--- a/bin/omarchy-toggle
+++ b/bin/omarchy-toggle
@@ -10,6 +10,10 @@ fi
 
 FLAG_NAME="$1"
 ACTION="${2:-toggle}"
+
+source omarchy-path-guard || exit 1
+omarchy_reject_climbing_name "$FLAG_NAME" "flag name" || exit 1
+
 FLAG="$HOME/.local/state/omarchy/toggles/$FLAG_NAME"
 
 enable() {

--- a/test/cli
+++ b/test/cli
@@ -807,3 +807,52 @@ assert_output_contains "a --help behind -- belongs to the command and still forw
 
 output=$("$TMPDIR/omarchy" parenthelp --helpme x--help)
 assert_output_contains "help lookalike tokens do not trigger help" "$output" "parenthelp-parent-ran args=[--helpme x--help]"
+
+# omarchy-hook, omarchy-hyprland-toggle, omarchy-toggle and omarchy-state each
+# join an argument into a path they then execute, delete or write. Each escape
+# below reached outside the directory the command meant to work in.
+make_tmpdir GUARD_TMPDIR
+GUARD_HOME="$GUARD_TMPDIR/home"
+mkdir -p "$GUARD_HOME/.local/state/omarchy/toggles/hypr" "$GUARD_HOME/.config/omarchy/hooks"
+
+printf '#!/bin/bash\necho escaped\n' >"$GUARD_TMPDIR/outside-hook"
+chmod +x "$GUARD_TMPDIR/outside-hook"
+printf 'victim\n' >"$GUARD_TMPDIR/outside.lua"
+
+output=$(HOME="$GUARD_HOME" "$ROOT/bin/omarchy-hook" ../../../../outside-hook 2>&1 || true)
+[[ $output != *escaped* ]] || fail "omarchy-hook runs a script above the hooks directory"
+pass "omarchy-hook will not run a script outside the hooks directory"
+
+HOME="$GUARD_HOME" OMARCHY_PATH="$ROOT" "$ROOT/bin/omarchy-hyprland-toggle" ../../../../../../outside off >/dev/null 2>&1 || true
+[[ -f "$GUARD_TMPDIR/outside.lua" ]] || fail "omarchy-hyprland-toggle deletes a .lua above the toggles directory"
+pass "omarchy-hyprland-toggle will not delete a file outside the toggles directory"
+
+HOME="$GUARD_HOME" "$ROOT/bin/omarchy-toggle" ../../../../../outside-toggle on >/dev/null 2>&1 || true
+[[ ! -e "$GUARD_TMPDIR/outside-toggle" ]] || fail "omarchy-toggle writes a flag outside the state directory"
+pass "omarchy-toggle will not write a flag outside the state directory"
+
+HOME="$GUARD_HOME" "$ROOT/bin/omarchy-state" set ../../../../outside-state >/dev/null 2>&1 || true
+[[ ! -e "$GUARD_TMPDIR/outside-state" ]] || fail "omarchy-state writes a file outside the state directory"
+pass "omarchy-state will not write a file outside the state directory"
+
+# omarchy-crash-mute keeps a flag per program under crash-ignore/, so a slash is
+# a namespace rather than an escape. Only a dot component climbs.
+HOME="$GUARD_HOME" "$ROOT/bin/omarchy-toggle" "crash-ignore/chromium" on >/dev/null 2>&1
+[[ -f "$GUARD_HOME/.local/state/omarchy/toggles/crash-ignore/chromium" ]] || fail "omarchy-toggle keeps the crash-ignore namespace working"
+pass "omarchy-toggle still writes a flag inside a nested namespace"
+
+HOME="$GUARD_HOME" "$ROOT/bin/omarchy-toggle" "crash-ignore/../../escape" on >/dev/null 2>&1 || true
+[[ ! -e "$GUARD_HOME/.local/state/omarchy/escape" ]] || fail "omarchy-toggle allows a dot component to climb out of a namespace"
+pass "omarchy-toggle rejects a name that climbs out of its namespace"
+
+# A leading dot is an ordinary filename, and omarchy-state's clear takes a glob.
+for legal_name in 'weird...name' '..leading'; do
+  HOME="$GUARD_HOME" "$ROOT/bin/omarchy-state" set "$legal_name" >/dev/null 2>&1 || true
+  [[ -f "$GUARD_HOME/.local/state/omarchy/$legal_name" ]] || fail "omarchy-state accepts the ordinary filename $legal_name"
+done
+pass "omarchy-state still accepts ordinary names that begin with dots"
+
+HOME="$GUARD_HOME" "$ROOT/bin/omarchy-state" set globbed >/dev/null 2>&1
+HOME="$GUARD_HOME" "$ROOT/bin/omarchy-state" clear 'globb*' >/dev/null 2>&1
+[[ ! -e "$GUARD_HOME/.local/state/omarchy/globbed" ]] || fail "omarchy-state clear still matches a glob"
+pass "omarchy-state clear still takes a glob pattern"


### PR DESCRIPTION
`omarchy-hook`, `omarchy-hyprland-toggle`, `omarchy-toggle`, and `omarchy-state` put an argument into a path they execute, delete, or write. A name containing `..` can take that operation outside its intended directory.

The four commands now source `omarchy-path-guard`, which rejects empty or absolute names and any `.` or `..` path component. A slash alone remains valid because the crash helpers use names such as `crash-ignore/chromium`. Names such as `...` and `..leading`, and glob patterns used by `omarchy-state clear`, remain valid too. The source call exits on failure, including in commands that do not use `set -e`.

These escapes were reproduced on unmodified `quattro` with `HOME` set to a scratch directory:

```
omarchy-hook ../../../../outside-hook
  executed the script outside the hooks directory
omarchy-hyprland-toggle ../../../../../../outside off
  deleted outside.lua
omarchy-toggle ../../../../../outside-toggle on
  created a file outside the state directory
omarchy-state set ../../../../outside-state
  created a file outside the state directory
```

Eight additions to `test/cli` check those operations are rejected, nested crash-ignore names still work, traversal inside them is rejected, dot-prefixed names remain valid, and state-clearing globs still match. The first escape test fails on the baseline.

`./test/cli` passed, including command metadata checks. `./test/shell` passed 217 of 221 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`. `crash-capture-test.sh` also passed with the guard in place.
