### PR TITLE
Stop two properties shadowing members Item already has

### DIFF
--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -60,6 +60,10 @@ PanelWindow {
   // mapped and child items have completed layout.
   property Item focusTarget: null
 
+  // Shadows contentItem on the base window type on purpose: this is the
+  // container idiom, and it is what puts children declared inside this
+  // component into the holder rather than straight onto the window surface.
+  // Renaming it would move that decision out to every call site.
   default property alias contentItem: contentHolder.children
 
   readonly property var coordinatorKey: owner || root

--- a/shell/Ui/PopupCard.qml
+++ b/shell/Ui/PopupCard.qml
@@ -62,6 +62,10 @@ PopupWindow {
     else root.open = false
   }
 
+  // Shadows contentItem on the base window type on purpose: this is the
+  // container idiom, and it is what puts children declared inside this
+  // component into the holder rather than straight onto the window surface.
+  // Renaming it would move that decision out to every call site.
   default property alias contentItem: contentHolder.children
 
   visible: open || card.opacity > 0

--- a/shell/plugins/bar/indicators/Dictation.qml
+++ b/shell/plugins/bar/indicators/Dictation.qml
@@ -5,21 +5,21 @@ import qs.Ui
 BarIndicator {
   id: root
 
-  property string state: "idle"
+  property string mode: "idle"
   property string icon: ""
 
-  active: state === "recording"
+  active: mode === "recording"
   activeText: icon
   inactiveText: "󰍬"
-  activeTooltipText: state
+  activeTooltipText: mode
   inactiveTooltipText: "Dictate"
 
   function update(raw) {
     var data = extractData(raw)
 
-    state = String(data.alt || data.class || "idle")
-    if (state === "recording") icon = "󰍬"
-    else if (state === "transcribing") icon = "󰔟"
+    mode = String(data.alt || data.class || "idle")
+    if (mode === "recording") icon = "󰍬"
+    else if (mode === "transcribing") icon = "󰔟"
     else icon = ""
   }
 

--- a/shell/plugins/bar/indicators/NightLight.qml
+++ b/shell/plugins/bar/indicators/NightLight.qml
@@ -6,7 +6,7 @@ BarIndicator {
 
   readonly property var nightlightService: bar?.shell?.firstPartyServiceFor("omarchy.nightlight")
 
-  active: nightlightService ? nightlightService.enabled : false
+  active: nightlightService ? nightlightService.nightlightOn : false
   activeText: "󰔎"
   inactiveText: "󰔎"
   activeTooltipText: "Day Light"

--- a/shell/plugins/services/nightlight/Service.qml
+++ b/shell/plugins/services/nightlight/Service.qml
@@ -15,7 +15,7 @@ Item {
 
   property bool stateLoaded: false
   property var temperature: null
-  readonly property bool enabled: stateLoaded && NightlightModel.isNightlight(temperature)
+  readonly property bool nightlightOn: stateLoaded && NightlightModel.isNightlight(temperature)
 
   property bool hasPendingTemperature: false
   property int pendingTemperature: 0
@@ -29,7 +29,7 @@ Item {
   }
 
   function toggle() {
-    setNightlight(!enabled)
+    setNightlight(!nightlightOn)
   }
 
   function applyTemperature(temp) {
@@ -89,7 +89,7 @@ Item {
     target: "nightlight"
 
     function status(): string {
-      return JSON.stringify({ enabled: root.enabled, temperature: root.temperature })
+      return JSON.stringify({ enabled: root.nightlightOn, temperature: root.temperature })
     }
 
     function refresh(): void {
@@ -107,7 +107,7 @@ Item {
     }
 
     function toggle(): string {
-      var enabling = !root.enabled
+      var enabling = !root.nightlightOn
       root.setNightlight(enabling)
       return enabling ? "enabled" : "disabled"
     }

--- a/test/shell.d/nightlight-test.sh
+++ b/test/shell.d/nightlight-test.sh
@@ -90,3 +90,47 @@ if rg -q 'omarchy.indicators' "$ROOT/bin/omarchy-toggle-nightlight"; then
   fail "nightlight toggle leaves indicator refresh to the nightlight service"
 fi
 pass "nightlight toggle leaves indicator refresh to the nightlight service"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+// Item already has `enabled` and `state`. Redeclaring either shadows the base
+// for QML while the C++ side keeps its own, so the two disagree as soon as
+// anything in the chain drives the state machine or disables a subtree.
+const service = fs.readFileSync(path.join(root, 'shell/plugins/services/nightlight/Service.qml'), 'utf8')
+
+assert(
+  !/property\s+bool\s+enabled\s*:/.test(service),
+  'the nightlight service does not shadow Item.enabled'
+)
+
+assert(
+  /readonly property bool nightlightOn:/.test(service) && /var enabling = !root\.nightlightOn/.test(service),
+  'the nightlight service reports its own state under its own name'
+)
+
+// The IPC payload is read outside the shell, so the key it publishes stays put.
+assert(
+  service.includes('JSON.stringify({ enabled: root.nightlightOn, temperature: root.temperature })'),
+  'the nightlight IPC status still answers with an enabled key'
+)
+
+const indicator = fs.readFileSync(path.join(root, 'shell/plugins/bar/indicators/NightLight.qml'), 'utf8')
+
+assert(
+  indicator.includes('nightlightService.nightlightOn') && !indicator.includes('nightlightService.enabled'),
+  'the night light indicator reads the renamed property'
+)
+
+const dictation = fs.readFileSync(path.join(root, 'shell/plugins/bar/indicators/Dictation.qml'), 'utf8')
+
+assert(
+  !/property\s+string\s+state\s*:/.test(dictation) && /property string mode:/.test(dictation),
+  'the dictation indicator does not shadow Item.state'
+)
+
+assert(
+  /active: mode === "recording"/.test(dictation) && /activeTooltipText: mode/.test(dictation),
+  'the dictation indicator drives itself from the renamed property'
+)
+JS


### PR DESCRIPTION
`Dictation.qml` declares `state` and the nightlight service declares `enabled`, both of which already belong to `Item`. They are being used for dictation and nightlight status rather than QML's state machine or input handling. Neither currently causes a visible failure, but both shadow the base properties.

The dictation property is now `mode`; the nightlight property is `nightlightOn`, including its reader in the indicator. The nightlight IPC response still uses `{enabled, temperature}` so existing command callers receive the same data.

`PopupCard` and `KeyboardPanel` keep their `contentItem` aliases because those deliberately route child objects into a container. Comments explain those two remaining overrides.

`qmllint` no longer reports the dictation or nightlight warnings; the two intentional `contentItem` warnings remain. Six additions to `nightlight-test.sh` cover the renamed properties, their readers, and the unchanged IPC key. The first assertion fails on unmodified `quattro`.

`./test/shell` passed 217 of 221 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`.
