### PR TITLE
Verify the session is secure before system lock succeeds

### DIFF
--- a/bin/omarchy-system-lock
+++ b/bin/omarchy-system-lock
@@ -5,7 +5,33 @@
 # omarchy:name=lock
 # omarchy:examples=omarchy system lock
 
-omarchy-shell lock lock >/dev/null
+lock_timeout=10
+
+lock_ipc() {
+  local limit=$1
+  shift
+
+  OMARCHY_SHELL_IPC_TIMEOUT="$limit" omarchy-shell "$@" 2>/dev/null
+}
+
+lock_state() {
+  jq -r 'if .secure == true then "secure"
+         elif .requested == true then "locking"
+         else "idle" end' \
+    <<<"$(lock_ipc 0.5s lock status)" 2>/dev/null
+}
+
+report_unsecured() {
+  printf 'omarchy-system-lock: the session was not locked (%s)\n' "$1" >&2
+
+  omarchy-notification-send -u critical -g 󰌾 \
+    "Screen did not lock" \
+    "The session is still unlocked ($1)." >/dev/null 2>&1 || true
+
+  exit 1
+}
+
+lock_reply=$(lock_ipc 1s lock lock)
 
 # Set keyboard layout to default (first layout)
 hyprctl switchxkblayout all 0 > /dev/null 2>&1
@@ -24,3 +50,28 @@ pkill -x ttfx 2>/dev/null || true
 # ttfx handles SIGTERM asynchronously, so keep its terminal alive until it exits.
 timeout 1s pidwait -x ttfx 2>/dev/null || true
 pkill -f '[o]rg.omarchy.screensaver' 2>/dev/null || true
+
+# Securing the session happens after the request returns, and the shell answers
+# a refusal on stdout with a zero exit, so neither the reply nor the exit status
+# on its own means the screen is locked. Without this the idle path reports
+# success for a lock that never armed, leaving the session exposed behind a
+# screen that blanks moments later. omarchy-system-sleep-lock polls the same way
+# against the budget logind imposes on it; nothing here is racing a suspend, so
+# a fixed deadline is enough.
+if [[ $lock_reply == "missing-pam" ]]; then
+  report_unsecured "no lock screen is configured"
+fi
+
+deadline=$((SECONDS + lock_timeout))
+
+while (( SECONDS < deadline )); do
+  case $(lock_state) in
+    secure) exit 0 ;;
+    locking) ;;
+    *) lock_ipc 1s lock lock >/dev/null ;;
+  esac
+
+  sleep 0.1
+done
+
+report_unsecured "the shell did not secure the session within ${lock_timeout}s"

--- a/test/shell.d/system-lock-test.sh
+++ b/test/shell.d/system-lock-test.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+require_command jq
+
+# Resolved before the mocks shadow it: the harness bounds the script with the
+# real timeout, while the script under test sees the mock.
+real_timeout=$(command -v timeout)
+
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -11,22 +17,59 @@ mock_bin="$tmpdir/bin"
 call_log="$tmpdir/calls"
 mkdir -p "$mock_bin"
 
-for command in omarchy-shell hyprctl pkill timeout; do
-  cat >"$mock_bin/$command" <<'SH'
+for command in hyprctl pkill timeout omarchy-notification-send; do
+  cat >"$mock_bin/$command" <<'MOCK'
 #!/bin/bash
 printf '%s %s\n' "$(basename "$0")" "$*" >>"$CALL_LOG"
-SH
+MOCK
 done
 
-cat >"$mock_bin/pgrep" <<'SH'
+# Answers `lock status` the way the shell does. SECURE_AFTER is how many polls
+# it takes to secure, so a lock that is still arming can be told apart from one
+# that never will.
+cat >"$mock_bin/omarchy-shell" <<'MOCK'
+#!/bin/bash
+printf '%s %s\n' "$(basename "$0")" "$*" >>"$CALL_LOG"
+
+if [[ ${1:-} == "lock" && ${2:-} == "status" ]]; then
+  polls=$(( $(cat "$POLL_COUNT" 2>/dev/null || echo 0) + 1 ))
+  printf '%s' "$polls" >"$POLL_COUNT"
+  if [[ ${SECURE_AFTER:-1} != never ]] && (( polls >= ${SECURE_AFTER:-1} )); then
+    printf '{"secure":true,"requested":true}\n'
+  else
+    printf '{"secure":false,"requested":false}\n'
+  fi
+  exit 0
+fi
+
+if [[ ${1:-} == "lock" && ${2:-} == "lock" ]]; then
+  [[ -n ${LOCK_REPLY:-} ]] && printf '%s\n' "$LOCK_REPLY"
+  exit 0
+fi
+MOCK
+
+cat >"$mock_bin/pgrep" <<'MOCK'
 #!/bin/bash
 exit 1
-SH
+MOCK
 chmod +x "$mock_bin"/*
 
-PATH="$mock_bin:$PATH" CALL_LOG="$call_log" "$ROOT/bin/omarchy-system-lock"
-mapfile -t shutdown < <(rg '^(pkill|timeout) ' "$call_log")
+run_lock() {
+  local rc=0
+  : >"$call_log"
+  : >"$tmpdir/polls"
+  PATH="$mock_bin:$PATH" CALL_LOG="$call_log" POLL_COUNT="$tmpdir/polls" \
+    SECURE_AFTER="${SECURE_AFTER:-1}" LOCK_REPLY="${LOCK_REPLY:-}" \
+    "$real_timeout" -k 5s 40s "$ROOT/bin/omarchy-system-lock" 2>"$tmpdir/stderr" || rc=$?
+  return "$rc"
+}
 
+rc=0
+run_lock || rc=$?
+(( rc == 0 )) || fail "system lock succeeds once the session is secure" "exit $rc, $(<"$tmpdir/stderr")"
+pass "system lock succeeds once the session is secure"
+
+mapfile -t shutdown < <(rg '^(pkill|timeout) ' "$call_log")
 [[ ${shutdown[0]} == "pkill -x ttfx" ]] ||
   fail "system lock stops ttfx before closing its terminal" "calls: ${shutdown[*]}"
 [[ ${shutdown[1]} == "timeout 1s pidwait -x ttfx" ]] ||
@@ -34,3 +77,53 @@ mapfile -t shutdown < <(rg '^(pkill|timeout) ' "$call_log")
 [[ ${shutdown[2]} == "pkill -f [o]rg.omarchy.screensaver" ]] ||
   fail "system lock closes the screensaver terminal after ttfx exits" "calls: ${shutdown[*]}"
 pass "system lock waits for ttfx before closing its terminal"
+
+# The lock is secured after the request returns, so a session still arming must
+# not be mistaken for one that failed.
+rc=0
+SECURE_AFTER=3 run_lock || rc=$?
+(( rc == 0 )) || fail "system lock waits for a session that is still arming" "exit $rc"
+pass "system lock waits for a session that is still arming"
+
+# The shell reports a lock it can never perform on stdout, with a zero exit.
+rc=0
+LOCK_REPLY=missing-pam run_lock || rc=$?
+(( rc == 1 )) || fail "system lock fails when no lock screen is configured" "exit $rc"
+grep -q "no lock screen is configured" "$tmpdir/stderr" ||
+  fail "system lock says why the session was not locked" "$(<"$tmpdir/stderr")"
+grep -q "^omarchy-notification-send .*Screen did not lock" "$call_log" ||
+  fail "system lock warns on screen when it could not lock"
+pass "system lock fails when no lock screen is configured"
+
+# The earliest exit in the script, so the one most likely to strand the work
+# that has to happen whether or not the session ends up secured.
+rg -q '^pkill -f \[o\]rg\.omarchy\.screensaver$' "$call_log" ||
+  fail "a lock the shell refuses still tears down the screensaver"
+rg -q '^hyprctl switchxkblayout all 0$' "$call_log" ||
+  fail "a lock the shell refuses still resets the keyboard layout"
+pass "a lock the shell refuses still runs the rest of the lock sequence"
+
+# The failure this exists to catch: the request is accepted, nothing secures,
+# and the old script reported success anyway.
+started=$SECONDS
+rc=0
+SECURE_AFTER=never run_lock || rc=$?
+elapsed=$((SECONDS - started))
+
+(( rc == 1 )) || fail "system lock fails when the session never becomes secure" "exit $rc"
+(( rc != 124 && rc != 137 )) || fail "system lock gives up on its own" "still running after ${elapsed}s"
+pass "system lock fails when the session never becomes secure"
+
+grep -q "did not secure the session" "$tmpdir/stderr" ||
+  fail "system lock reports the deadline it gave up on" "$(<"$tmpdir/stderr")"
+pass "system lock reports the deadline it gave up on"
+
+(( $(grep -c '^omarchy-shell lock lock$' "$call_log") > 1 )) ||
+  fail "system lock re-requests a lock the shell dropped" "$(grep -c '^omarchy-shell lock lock$' "$call_log") request(s)"
+pass "system lock re-requests a lock the shell dropped"
+
+# Locking 1Password and closing the screensaver still have to happen even when
+# the session itself could not be secured.
+rg -q '^pkill -f \[o\]rg\.omarchy\.screensaver$' "$call_log" ||
+  fail "system lock still closes the screensaver when the lock fails"
+pass "system lock still closes the screensaver when the lock fails"


### PR DESCRIPTION
`omarchy-system-lock` can report success before the session is secure. It discards the lock request's reply, and the shell can return exit 0 even when it cannot lock. In the observed idle-lock failure, the helper exited successfully without the usual lock handshake. Five minutes later the display blanked on its own timeout, leaving an unlocked session behind a blank screen.

The command now polls `lock status` until `.secure` is true. It repeats the request if the shell reports that none is pending, fails immediately for `missing-pam`, and reports other failures on stderr and through a critical notification when the ten-second deadline expires. Keyboard-layout reset, the 1Password lock, and screensaver teardown still run before either exit path.

This follows the success condition already used by `omarchy-system-sleep-lock`. The polling helpers remain separate because the sleep path bounds each call against logind's inhibitor window, while this command uses a fixed deadline. A failed lock can now delay the lid-close helper's clamshell reconciliation by up to ten seconds; the sleep-lock command remains the pre-suspend gate.

`system-lock-test.sh` covers immediate and delayed success, `missing-pam`, a lock that never secures, repeated requests, failure notifications, and cleanup on refusal. Its missing-lock case fails on unmodified `quattro`, which exits 0 instead of 1.

`./test/shell` passed 217 of 221 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`. The lid-close, idle, and both sleep-lock suites passed. ShellCheck, `bash -n`, and `git diff --check` were clean.
