### PR TITLE
Read the default browser once, and recognise one that registered itself

### DIFF
--- a/bin/omarchy-default-browser
+++ b/bin/omarchy-default-browser
@@ -10,8 +10,44 @@ if [[ ${1:-} == "--install" ]]; then
   shift
 fi
 
+# Maps the program a desktop entry runs to the name this command answers with.
+# A browser that registers itself through xdg-settings gets a generated entry
+# (Zen installs userapp-Zen-<id>.desktop) whose name matches none of the packaged
+# ids below, so the entry has to be opened and its Exec read to tell which
+# browser it is.
+browser_from_exec() {
+  case "${1##*/}" in
+  chromium | chromium-browser) echo "chromium" ;;
+  google-chrome-stable | google-chrome) echo "chrome" ;;
+  brave | brave-browser) echo "brave" ;;
+  brave-origin) echo "brave-origin" ;;
+  microsoft-edge-stable | microsoft-edge) echo "edge" ;;
+  firefox) echo "firefox" ;;
+  zen | zen-browser) echo "zen" ;;
+  esac
+}
+
+browser_from_desktop_id() {
+  local dir entry exec_line
+  for dir in "${XDG_DATA_HOME:-$HOME/.local/share}/applications" ${XDG_DATA_DIRS//:/\/applications }/applications; do
+    entry="$dir/$1"
+    [[ -r $entry ]] || continue
+    exec_line=$(sed -n 's/^Exec=//p' "$entry" | head -n 1)
+    [[ -n $exec_line ]] || continue
+    browser_from_exec "${exec_line%% *}"
+    return
+  done
+}
+
 if (($# == 0)); then
-  case "$(env -u BROWSER xdg-settings get default-web-browser)" in
+  # Asked once. This used to run xdg-settings twice, because the unmatched arm
+  # ran it again to echo the raw value -- and the unmatched arm is the common
+  # one for any browser that registered itself. Every row of the Defaults >
+  # Browser menu runs this command in its checked guard, so the menu paid for
+  # the second call once per row.
+  current=$(env -u BROWSER xdg-settings get default-web-browser)
+
+  case "$current" in
   chromium.desktop) echo "chromium" ;;
   google-chrome.desktop) echo "chrome" ;;
   brave-browser.desktop) echo "brave" ;;
@@ -19,7 +55,13 @@ if (($# == 0)); then
   microsoft-edge.desktop) echo "edge" ;;
   firefox.desktop) echo "firefox" ;;
   zen.desktop) echo "zen" ;;
-  *) env -u BROWSER xdg-settings get default-web-browser ;;
+  *)
+    # A generated entry names the browser in its Exec rather than its filename.
+    # Falling back to the raw id keeps the previous answer for anything this
+    # cannot identify.
+    resolved=$(browser_from_desktop_id "$current")
+    printf '%s\n' "${resolved:-$current}"
+    ;;
   esac
   exit 0
 fi

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -312,3 +312,59 @@ if OMARCHY_TEST_INSTALL_FAIL=true omarchy-default-editor --install vim >"$test_t
 fi
 [[ $(omarchy-default-editor) == "$previous_editor" ]] || fail "failed installation preserves the default"
 pass "failed installation preserves the current default"
+
+# Every row of Defaults > Browser runs `omarchy-default-browser` in its checked
+# guard, so what the read costs and what it answers both matter.
+browser_call_log="$test_tmp/xdg-settings-log"
+cat >"$mock_bin/xdg-settings" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_XDG_LOG"
+case $1 in
+get) [[ -f $OMARCHY_TEST_BROWSER_FILE ]] && cat "$OMARCHY_TEST_BROWSER_FILE" ;;
+set) printf '%s\n' "$3" >"$OMARCHY_TEST_BROWSER_FILE" ;;
+esac
+SH
+chmod +x "$mock_bin/xdg-settings"
+export OMARCHY_TEST_XDG_LOG="$browser_call_log"
+
+for packaged in chromium.desktop:chromium google-chrome.desktop:chrome brave-browser.desktop:brave \
+  brave-origin.desktop:brave-origin microsoft-edge.desktop:edge firefox.desktop:firefox zen.desktop:zen; do
+  printf '%s\n' "${packaged%%:*}" >"$browser_file"
+  [[ $(omarchy-default-browser) == "${packaged##*:}" ]] || fail "${packaged%%:*} still reads as ${packaged##*:}"
+done
+pass "every packaged browser id still reads as its own name"
+
+# The unmatched arm is where the second call was, and it is the arm any browser
+# that registered itself lands in.
+: >"$browser_call_log"
+printf 'unmatched.desktop\n' >"$browser_file"
+omarchy-default-browser >/dev/null
+[[ $(wc -l <"$browser_call_log") -eq 1 ]] || fail "an unmatched browser id is read with a single xdg-settings call"
+pass "reading an unmatched browser id asks xdg-settings once"
+
+: >"$browser_call_log"
+printf 'firefox.desktop\n' >"$browser_file"
+omarchy-default-browser >/dev/null
+[[ $(wc -l <"$browser_call_log") -eq 1 ]] || fail "a packaged browser id is read with a single xdg-settings call"
+pass "reading a packaged browser id asks xdg-settings once"
+
+# A browser that registers itself gets a generated entry whose filename names no
+# browser. Zen installs exactly this.
+mkdir -p "$test_home/.local/share/applications"
+cat >"$test_home/.local/share/applications/userapp-Zen-81ROQ3.desktop" <<'DESKTOP'
+[Desktop Entry]
+Exec=/opt/zen-browser-bin/zen %u
+Name=Zen
+DESKTOP
+printf 'userapp-Zen-81ROQ3.desktop\n' >"$browser_file"
+[[ $(omarchy-default-browser) == "zen" ]] || fail "a browser registered under a generated id reads as itself"
+pass "a browser registered under a generated desktop id is recognised"
+
+: >"$browser_call_log"
+omarchy-default-browser >/dev/null
+[[ $(wc -l <"$browser_call_log") -eq 1 ]] || fail "a generated id is resolved without a second xdg-settings call"
+pass "resolving a generated id still asks xdg-settings once"
+
+printf 'something-else.desktop\n' >"$browser_file"
+[[ $(omarchy-default-browser) == "something-else.desktop" ]] || fail "an unrecognised id still reports itself"
+pass "an unrecognised desktop id still reports the raw value"


### PR DESCRIPTION
A browser registered through `xdg-settings` can have a generated desktop ID such as `userapp-Zen-81ROQ3.desktop`. `omarchy-default-browser` does not recognize that filename, so the Browser menu compares it with `zen` and never marks the Zen row as checked. The unmatched case also queries `xdg-settings` a second time, once for every menu row.

The command now reads the default once. When its desktop ID is not one of the packaged IDs, it reads the entry's `Exec` program to identify the browser. This avoids guessing from filenames, which could confuse Chrome with Chromium. An entry it still cannot identify is returned unchanged.

With Zen registered through `xdg-settings`, the recorded result changed from `userapp-Zen-81ROQ3.desktop` to `zen`, and the timing over ten runs went from 83.3 ms to 42.4 ms.

Six additions to `default-apps-test.sh` cover packaged IDs, generated Zen entries, unknown IDs, and a single query on both recognized and unmatched paths. The generated-entry and unmatched query-count cases fail on unmodified `quattro`.

`./test/shell` passed 217 of 221 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`. That run contained 2,898 assertions.
