### PR TITLE
Let the menu ask what kind of connection this is without pricing the details

### DIFF
--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -2,9 +2,10 @@
 
 # omarchy:summary=Print active network status for the shell
 # omarchy:group=network
-# omarchy:args=[--verbose]
+# omarchy:args=[--verbose|--type]
 
 verbose=false
+type_only=false
 internet_probe=1.1.1.1
 
 case "${1:-}" in
@@ -13,39 +14,61 @@ case "${1:-}" in
   --verbose)
     verbose=true
     ;;
+  --type)
+    type_only=true
+    ;;
   *)
-    echo "Usage: omarchy-network-status [--verbose]" >&2
+    echo "Usage: omarchy-network-status [--verbose|--type]" >&2
     exit 2
     ;;
 esac
 
+# --type answers with the first field alone. The menu's QR row asks only whether
+# this is wifi, and filling in SSID, signal and frequency for that costs a second
+# nmcli call and an iw call it never reads. The nmcli call that decides connected
+# from disconnected is still made, so the field it prints is the same field the
+# full line would have started with.
 print_status() {
   local device nm state ssid signal freq
 
   device=$(ip route get "$internet_probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
 
   if [[ -z $device ]]; then
-    printf 'disconnected\t\t\t\n'
+    print_line disconnected "" "" ""
     return
   fi
 
   if [[ ! -d /sys/class/net/$device/wireless ]]; then
-    printf 'ethernet\t%s\t\t\n' "$device"
+    print_line ethernet "$device" "" ""
     return
   fi
 
   nm=$(nmcli -t -f GENERAL.STATE,GENERAL.CONNECTION dev show "$device" 2>/dev/null)
   state=$(awk -F: '$1 == "GENERAL.STATE" { print $2; exit }' <<<"$nm")
+
+  if [[ $state != 100* ]]; then
+    print_line disconnected "" "" ""
+    return
+  fi
+
+  if [[ $type_only == "true" ]]; then
+    print_line wifi "" "" ""
+    return
+  fi
+
   ssid=$(awk -F: '$1 == "GENERAL.CONNECTION" { print $2; exit }' <<<"$nm")
   signal=$(nmcli -t -f IN-USE,SIGNAL dev wifi list ifname "$device" --rescan no 2>/dev/null | awk -F: '$1 == "*" { print $2; exit }')
   freq=$(iw dev "$device" link 2>/dev/null | awk '/freq:/ { print $2; exit }')
 
-  if [[ $state != 100* ]]; then
-    printf 'disconnected\t\t\t\n'
-    return
-  fi
+  print_line wifi "${ssid:-$device}" "$signal" "$freq"
+}
 
-  printf 'wifi\t%s\t%s\t%s\n' "${ssid:-$device}" "$signal" "$freq"
+print_line() {
+  if [[ $type_only == "true" ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4"
+  fi
 }
 
 ping_latency_ms() {

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -132,7 +132,7 @@
   "setup.network.dns.cloudflare": {"icon":"󰅟","label":"Cloudflare","checked":"[[ \"$(omarchy-dns)\" == \"Cloudflare\" ]]","action":"omarchy-dns Cloudflare"},
   "setup.network.dns.google": {"icon":"󰊭","label":"Google","checked":"[[ \"$(omarchy-dns)\" == \"Google\" ]]","action":"omarchy-dns Google"},
   "setup.network.dns.custom": {"icon":"","label":"Custom","checked":"[[ \"$(omarchy-dns)\" == \"Custom\" ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-dns Custom'"},
-  "setup.network.qr": {"icon":"󰐲","label":"QR Code","aliases":["wifi-qr"],"when":"[[ $(omarchy-network-status) == wifi* ]]","action":"omarchy-shell shell summon omarchy.wifiqr"},
+  "setup.network.qr": {"icon":"󰐲","label":"QR Code","aliases":["wifi-qr"],"when":"[[ $(omarchy-network-status --type) == wifi ]]","action":"omarchy-shell shell summon omarchy.wifiqr"},
   "setup.default": {"icon":"","label":"Defaults","aliases":["default","defaults"]},
   "setup.default.agent": {"icon":"󰚩","label":"Agent","title":"Default Agent"},
   "setup.default.agent.agy": {"icon":"󰫢","label":"Antigravity","checked":"[[ \"$(omarchy-default-agent)\" == \"agy\" ]]","action":"omarchy-default-agent agy"},

--- a/test/shell.d/network-status-test.sh
+++ b/test/shell.d/network-status-test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/sys/wlan0/wireless" "$tmp/sys/eth0"
+
+call_log="$tmp/calls"
+
+cat >"$tmp/bin/ip" <<'SH'
+#!/bin/bash
+printf 'ip\n' >>"$NS_CALL_LOG"
+printf '1.1.1.1 via 192.168.1.1 dev %s src 192.168.1.50\n' "$NS_DEVICE"
+SH
+
+cat >"$tmp/bin/nmcli" <<'SH'
+#!/bin/bash
+if [[ $* == *GENERAL.STATE* ]]; then
+  printf 'nmcli-show\n' >>"$NS_CALL_LOG"
+  printf 'GENERAL.STATE:%s\nGENERAL.CONNECTION:%s\n' "$NS_NM_STATE" "$NS_SSID"
+else
+  printf 'nmcli-wifi-list\n' >>"$NS_CALL_LOG"
+  printf '*:72\n'
+fi
+SH
+
+cat >"$tmp/bin/iw" <<'SH'
+#!/bin/bash
+printf 'iw\n' >>"$NS_CALL_LOG"
+printf '\tfreq: 5220\n'
+SH
+
+chmod +x "$tmp/bin/ip" "$tmp/bin/nmcli" "$tmp/bin/iw"
+
+export PATH="$tmp/bin:$ROOT/bin:$PATH"
+export NS_CALL_LOG="$call_log"
+export NS_NM_STATE="100 (connected)"
+export NS_SSID="Example"
+
+# The command reads /sys/class/net directly, so the wireless branch can only be
+# exercised with a wireless interface this machine actually has. Find one rather
+# than assume a name, and skip the branch on a machine with no wifi.
+wireless_device=""
+for candidate in /sys/class/net/*/wireless; do
+  [[ -d $candidate ]] || continue
+  candidate=${candidate%/wireless}
+  wireless_device=${candidate##*/}
+  break
+done
+
+run_case() {
+  export NS_DEVICE="$1"
+  : >"$call_log"
+}
+
+if [[ -n $wireless_device ]]; then
+  run_case "$wireless_device"
+  output=$(omarchy-network-status)
+  [[ $output == wifi$'\t'* ]] || fail "the full line still starts with the connection type"
+  pass "the full line still starts with the connection type"
+
+  run_case "$wireless_device"
+  output=$(omarchy-network-status --type)
+  [[ $output == "wifi" ]] || fail "--type answers with the type alone, got: $output"
+  pass "--type answers with the connection type alone"
+
+  run_case "$wireless_device"
+  omarchy-network-status >/dev/null
+  full_calls=$(wc -l <"$call_log")
+
+  run_case "$wireless_device"
+  omarchy-network-status --type >/dev/null
+  type_calls=$(wc -l <"$call_log")
+
+  (( type_calls < full_calls )) || fail "--type runs fewer commands than the full line ($type_calls vs $full_calls)"
+  pass "--type runs fewer commands than the full line"
+
+  run_case "$wireless_device"
+  omarchy-network-status --type >/dev/null
+  grep -q 'nmcli-wifi-list' "$call_log" && fail "--type must not scan the wifi list for a signal it does not print"
+  grep -q '^iw$' "$call_log" && fail "--type must not ask iw for a frequency it does not print"
+  pass "--type skips the signal and frequency lookups"
+
+  run_case "$wireless_device"
+  omarchy-network-status --type >/dev/null
+  grep -q 'nmcli-show' "$call_log" || fail "--type still asks whether the device is connected"
+  pass "--type still distinguishes connected from disconnected"
+
+  NS_NM_STATE="30 (disconnected)"
+  run_case "$wireless_device"
+  output=$(omarchy-network-status --type)
+  [[ $output == "disconnected" ]] || fail "--type reports a disconnected wireless device as disconnected, got: $output"
+  pass "--type reports a disconnected wireless device the same way the full line does"
+  NS_NM_STATE="100 (connected)"
+fi
+
+output=$(omarchy-network-status --nonsense 2>&1 || true)
+[[ $output == *"--verbose|--type"* ]] || fail "usage names both modes"
+pass "usage names both modes"


### PR DESCRIPTION
The QR row in Setup > Network runs `omarchy-network-status` whenever the menu opens, then reads only whether its output starts with `wifi`. Producing the full line also queries SSID, signal, and frequency, which the guard does not use.

The new `--type` mode returns just the connection type. It still calls `nmcli dev show` to distinguish connected and disconnected wireless devices, but skips the Wi-Fi list and `iw` calls. The full output used by the panels is unchanged.

On Wi-Fi, the recorded timing over ten runs was 50.0 ms for the full line and 26.2 ms for `--type`. The full output was byte-identical before and after.

`network-status-test.sh` stubs `ip`, `nmcli`, and `iw` to check the returned type and command counts, including the disconnected case. It verifies that the two detail queries are skipped and the connection-state query remains. Wireless cases find an interface through `/sys/class/net/*/wireless` and skip if none is available. The test fails on the baseline, where `--type` is a usage error.

`./test/shell` passed 218 of 222 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`.
