### PR TITLE
Keep clipboard contents alive when applications close

### DIFF
--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -8,6 +8,7 @@ hl.on("hyprland.start", function()
   hl.exec_cmd("omarchy-powerprofiles-init")
   hl.exec_cmd(o.launch("omarchy-hyprland-monitor-watch"))
   hl.exec_cmd(o.launch("udiskie --automount --no-notify --no-tray"))
+  hl.exec_cmd(o.launch("wl-clip-persist --clipboard regular"))
 
   -- Run post-boot hooks after startup config has loaded.
   hl.exec_cmd("sleep 2 && omarchy-hook post-boot")

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -137,6 +137,7 @@ uwsm
 whois
 wireless-regdb
 wireplumber
+wl-clip-persist
 wl-clipboard
 wtype
 woff2-font-awesome


### PR DESCRIPTION
## Problem
When copying text or content in XWayland applications (e.g. ONLYOFFICE DesktopEditors, GIMP, Inkscape, Wine) or certain Wayland clients, closing the source window immediately destroys the active Wayland selection offer. While Omarchy records the entry into history (`~/.local/state/omarchy/clipboard-history.json`), the active system clipboard buffer becomes blank until the user manually triggers `Super + Ctrl + V` to re-select it.

## Fix
Add `wl-clip-persist` to `install/omarchy-base.packages` and launch `wl-clip-persist --clipboard regular` as part of the default session autostart in `default/hypr/autostart.lua`. This transparently preserves the regular clipboard selection across application closures without altering existing history capture behavior or keybindings.

## Verification
- `./test/cli` (All suites passed)
- `bash test/shell.d/clipboard-test.sh` (All 68 assertions passed)
- `bash test/shell.d/hyprland-default-config-test.sh` (All assertions passed)
- Tested with ONLYOFFICE and terminal pasting across window closures.