### PR TITLE
Stop the workspace row rebuilding itself for no visible change

### DIFF
--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -3,32 +3,30 @@ import QtQuick.Layouts
 import Quickshell.Hyprland
 import qs.Commons
 import qs.Ui
+import "WorkspacesModel.js" as WorkspacesModel
 
 BarWidget {
   id: root
   moduleName: "omarchy.workspaces"
 
-  function workspaceById(id) {
-    var values = Hyprland.workspaces.values
-    for (var i = 0; i < values.length; i++) {
-      if (values[i].id === id) return values[i]
-    }
+  // A Repeater compares its model by identity, so this array is replaced only
+  // when the ids really differ. WorkspacesModel carries the reasoning and the
+  // tests.
+  property var ids: [1, 2, 3, 4, 5]
+  property var byId: ({})
 
-    return null
+  // Tracked as a binding so the dependency on Hyprland's workspace list is
+  // declared rather than guessed at through a signal name.
+  readonly property var liveWorkspaces: Hyprland.workspaces.values
+  onLiveWorkspacesChanged: root.refreshWorkspaces()
+
+  function refreshWorkspaces() {
+    var values = root.liveWorkspaces || []
+    root.byId = WorkspacesModel.byId(values)
+    root.ids = WorkspacesModel.stableIds(root.ids, WorkspacesModel.workspaceIds(values))
   }
 
-  function workspaceIds() {
-    var ids = [1, 2, 3, 4, 5]
-    var values = Hyprland.workspaces.values
-
-    for (var i = 0; i < values.length; i++) {
-      var id = values[i].id
-      if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
-    }
-
-    ids.sort(function(left, right) { return left - right })
-    return ids
-  }
+  Component.onCompleted: root.refreshWorkspaces()
 
   function focusWorkspace(id) {
     if (!root.bar) return
@@ -44,17 +42,17 @@ BarWidget {
     id: grid
     anchors.fill: parent
     anchors.rightMargin: root.trailingGap
-    columns: root.vertical ? 1 : root.workspaceIds().length
+    columns: root.vertical ? 1 : root.ids.length
     columnSpacing: root.vertical ? 0 : Style.space(1)
     rowSpacing: root.vertical ? Style.space(2) : 0
 
     Repeater {
-      model: root.workspaceIds()
+      model: root.ids
 
       WidgetButton {
         required property int modelData
 
-        readonly property var workspace: root.workspaceById(modelData)
+        readonly property var workspace: root.byId[modelData] || null
         readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
         readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
 

--- a/shell/plugins/bar/widgets/WorkspacesModel.js
+++ b/shell/plugins/bar/widgets/WorkspacesModel.js
@@ -1,0 +1,68 @@
+// Model math for the workspace row, kept Qt-free so it can be unit tested under
+// node (test/shell.d/workspaces-model-test.sh).
+
+// The row always offers 1-5, plus any other workspace up to 10 that exists.
+function workspaceIds(values) {
+  var ids = [1, 2, 3, 4, 5]
+  var list = values || []
+
+  for (var i = 0; i < list.length; i++) {
+    var id = list[i] && list[i].id
+    if (typeof id !== "number" || !isFinite(id)) continue
+    if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
+  }
+
+  ids.sort(function(left, right) { return left - right })
+  return ids
+}
+
+// A Repeater compares its model by identity, not by contents: hand it a new
+// array and it destroys every delegate and builds them again, however alike the
+// two arrays are. The row's model used to be a function call, allocating a fresh
+// array on every evaluation, and the binding re-ran whenever Hyprland created or
+// destroyed a workspace.
+//
+// That is exactly what switching to an empty workspace does. Moving between
+// workspaces that hold windows leaves the list alone and was smooth; pressing
+// SUPER+4 from an occupied workspace created 4 and rebuilt the whole row, then
+// destroyed it on the way out and rebuilt it again -- which is why the stutter
+// came and went rather than being there every time.
+//
+// So the caller keeps its array and only replaces it when the ids really
+// changed. Returns the array to keep, which is the old one whenever it still
+// describes the same row.
+function stableIds(previous, next) {
+  var before = previous || []
+
+  if (before.length === next.length) {
+    for (var i = 0; i < next.length; i++) {
+      if (before[i] !== next[i]) return next
+    }
+
+    return before
+  }
+
+  return next
+}
+
+// Built once per change rather than scanned inside each delegate, which made
+// drawing the row cost O(n^2) every time it was rebuilt.
+function byId(values) {
+  var map = ({})
+  var list = values || []
+
+  for (var i = 0; i < list.length; i++) {
+    var workspace = list[i]
+    if (workspace && typeof workspace.id === "number") map[workspace.id] = workspace
+  }
+
+  return map
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    byId: byId,
+    stableIds: stableIds,
+    workspaceIds: workspaceIds
+  }
+}

--- a/test/shell.d/workspaces-model-test.sh
+++ b/test/shell.d/workspaces-model-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# The workspace row is a Repeater, and a Repeater compares its model by
+# identity: hand it a new array and every delegate is destroyed and rebuilt,
+# however alike the two arrays are. The model used to be a function call
+# allocating a fresh array on each evaluation, re-run whenever Hyprland created
+# or destroyed a workspace -- so pressing SUPER+4 from an occupied workspace
+# rebuilt the whole row, and leaving 4 empty rebuilt it again, while moving
+# between workspaces that hold windows did not. That is the stutter that came
+# and went. These pin the array staying put.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+MODEL="$ROOT/shell/plugins/bar/widgets/WorkspacesModel.js"
+
+node --check "$MODEL" || fail "WorkspacesModel.js parses"
+pass "WorkspacesModel.js parses"
+
+node -e '
+const assert = require("assert")
+const M = require(process.argv[1])
+const ws = ids => ids.map(id => ({ id }))
+
+// The row always offers 1-5.
+assert.deepStrictEqual(M.workspaceIds(ws([])), [1, 2, 3, 4, 5])
+assert.deepStrictEqual(M.workspaceIds(ws([1, 2, 3])), [1, 2, 3, 4, 5])
+assert.deepStrictEqual(M.workspaceIds(ws([7, 1])), [1, 2, 3, 4, 5, 7])
+assert.deepStrictEqual(M.workspaceIds(ws([10])), [1, 2, 3, 4, 5, 10])
+
+// Out of range, and junk Hyprland should never send but might.
+assert.deepStrictEqual(M.workspaceIds(ws([11, 0, -3])), [1, 2, 3, 4, 5])
+assert.deepStrictEqual(M.workspaceIds([{}, null, { id: "2" }, { id: NaN }]), [1, 2, 3, 4, 5])
+assert.deepStrictEqual(M.workspaceIds(null), [1, 2, 3, 4, 5])
+
+// The one that matters. Creating or destroying a workspace inside 1-5 leaves
+// the row identical, so the array -- and every delegate built from it -- is
+// kept. This is the case that was rebuilding the row for no visible change.
+const start = M.workspaceIds(ws([1, 2, 3]))
+assert.strictEqual(M.stableIds(start, M.workspaceIds(ws([1, 2, 3, 4]))), start,
+  "creating an empty workspace inside 1-5 keeps the array")
+assert.strictEqual(M.stableIds(start, M.workspaceIds(ws([1]))), start,
+  "destroying one inside 1-5 keeps the array")
+assert.strictEqual(M.stableIds(start, M.workspaceIds(ws([1, 2, 3]))), start,
+  "an unchanged list keeps the array")
+
+// A workspace outside 1-5 really does change the row, and must not be kept.
+const grown = M.stableIds(start, M.workspaceIds(ws([1, 2, 3, 7])))
+assert.notStrictEqual(grown, start, "a workspace outside 1-5 replaces the array")
+assert.deepStrictEqual(grown, [1, 2, 3, 4, 5, 7])
+assert.strictEqual(M.stableIds(grown, M.workspaceIds(ws([1, 7]))), grown,
+  "the grown row is itself kept while it still describes the same ids")
+assert.notStrictEqual(M.stableIds(grown, M.workspaceIds(ws([1]))), grown,
+  "losing that workspace shrinks the row back")
+
+// Same length, different ids: length alone must not decide.
+assert.notStrictEqual(M.stableIds([1, 2, 3, 4, 5, 7], [1, 2, 3, 4, 5, 8]), null)
+assert.deepStrictEqual(M.stableIds([1, 2, 3, 4, 5, 7], [1, 2, 3, 4, 5, 8]), [1, 2, 3, 4, 5, 8])
+
+// A first run has nothing to compare against.
+assert.deepStrictEqual(M.stableIds(undefined, [1, 2, 3, 4, 5]), [1, 2, 3, 4, 5])
+
+// The lookup a delegate reads, built once instead of scanned per delegate.
+const map = M.byId(ws([1, 2, 3]))
+assert.strictEqual(map[2].id, 2)
+assert.strictEqual(map[9], undefined)
+assert.deepStrictEqual(M.byId(null), {})
+assert.deepStrictEqual(M.byId([null, {}, { id: "x" }]), {})
+' "$MODEL" || fail "the workspace row keeps its array unless the ids really change"
+pass "the workspace row keeps its array unless the ids really change"
+
+# The widget must actually use it, or the model is just a well-tested orphan.
+WIDGET="$ROOT/shell/plugins/bar/widgets/Workspaces.qml"
+grep -q 'WorkspacesModel.stableIds' "$WIDGET" ||
+  fail "the widget assigns its ids through stableIds"
+! grep -qE 'model: root\.workspaceIds\(\)|columns:.*workspaceIds\(\)' "$WIDGET" ||
+  fail "the widget no longer allocates a fresh model array in a binding"
+pass "the widget takes its model through stableIds"
+
+# The delegate reads the map built once per change rather than scanning the
+# workspace list itself, which made drawing the row cost O(n^2) per rebuild.
+grep -q 'root\.byId\[modelData\]' "$WIDGET" ||
+  fail "the delegate reads the prebuilt workspace map"
+! grep -q 'function workspaceById' "$WIDGET" ||
+  fail "the per-delegate workspace scan is gone"
+pass "the delegate reads a map built once per change"


### PR DESCRIPTION
Creating or leaving an empty workspace rebuilds the whole workspace row, even when the visible IDs have not changed. The row always includes workspaces 1–5, but `workspaceIds()` returns a new array whenever Hyprland's workspace list changes. `Repeater` treats that as a new model and replaces every delegate. `columns` calls the function again.

The row now keeps the same array until its IDs change. Creating workspace 4 leaves `[1,2,3,4,5]` intact; creating a workspace outside that range replaces it. A map built once per update also replaces the lookup each delegate used to perform over the workspace list.

The ID and lookup logic lives in `WorkspacesModel.js`, following the existing model modules so it can run under Node. `workspaces-model-test.sh` checks the fixed 1–5 range, additional workspaces arriving and leaving, invalid entries, and array identity. It also checks that different IDs with the same length are treated as a change and that the QML uses the stable array and lookup map. The test fails on the baseline, which has no model module.

`./test/shell` passed 218 of 222 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`.

This touches `Workspaces.qml` alongside #9419's click-dispatch change, so whichever lands second may need rebasing.
