### PR TITLE
Keep the GETAC V110G3 touchpad alive across S3

### DIFF
--- a/bin/omarchy-hw-getac-v110g3
+++ b/bin/omarchy-hw-getac-v110g3
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# omarchy:summary=Detect GETAC V110G3 laptops whose Synaptics touchpad dies after S3.
+
+vendor="${OMARCHY_DMI_SYS_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+product="${OMARCHY_DMI_PRODUCT_NAME:-/sys/class/dmi/id/product_name}"
+
+grep -qix "GETAC" "$vendor" 2>/dev/null &&
+  grep -qix "V110G3" "$product" 2>/dev/null

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -36,6 +36,8 @@ run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-display.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-z13-touchpad.sh"
 
+run_logged "$OMARCHY_INSTALL/hardware/getac/fix-v110g3-touchpad.sh"
+
 run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"

--- a/install/hardware/getac/fix-v110g3-touchpad.sh
+++ b/install/hardware/getac/fix-v110g3-touchpad.sh
@@ -1,0 +1,22 @@
+# Synaptics touchpad S3 resume fix for GETAC V110G3.
+#
+# After S3 the i8042 controller wedges and the pad dies on both PS/2 and
+# RMI4/SMBus (ENXIO); reloading psmouse or rmi_smbus does not recover it.
+# i8042.nomux=1 moves the pad off the muxed AUX port onto the standard one.
+# psmouse.synaptics_intertouch=1 alone does not survive S3; the two together
+# do. Confirmed on V110G3 (Launchpad #2162967). Other GETAC models need their
+# own confirmation.
+
+drop_in="${OMARCHY_GETAC_V110G3_LIMINE_CONF:-/etc/limine-entry-tool.d/getac-v110g3-touchpad.conf}"
+
+if omarchy-hw-getac-v110g3; then
+  if [[ ! -f $drop_in ]] ||
+    ! grep -q 'i8042.nomux=1' "$drop_in" ||
+    ! grep -q 'psmouse.synaptics_intertouch=1' "$drop_in"; then
+    sudo mkdir -p "$(dirname "$drop_in")"
+    cat <<'EOF' | sudo tee "$drop_in" >/dev/null
+# GETAC V110G3 Synaptics touchpad S3 resume
+KERNEL_CMDLINE[default]+=" i8042.nomux=1 psmouse.synaptics_intertouch=1"
+EOF
+  fi
+fi

--- a/migrations/1788129995.sh
+++ b/migrations/1788129995.sh
@@ -1,0 +1,14 @@
+echo "Keep the GETAC V110G3 Synaptics touchpad alive across S3 resume"
+
+omarchy-hw-getac-v110g3 || exit 0
+
+source "$OMARCHY_PATH/install/hardware/getac/fix-v110g3-touchpad.sh"
+
+omarchy-cmd-present limine-mkinitcpio || exit 0
+
+rebuild_marker="${OMARCHY_GETAC_V110G3_REBUILD_MARKER:-/var/lib/omarchy/migrations/1788129995}"
+[[ ! -e $rebuild_marker ]] || exit 0
+
+sudo limine-mkinitcpio
+sudo install -Dm644 /dev/null "$rebuild_marker"
+omarchy-state set reboot-required

--- a/migrations/1788129995.sh
+++ b/migrations/1788129995.sh
@@ -4,10 +4,16 @@ omarchy-hw-getac-v110g3 || exit 0
 
 source "$OMARCHY_PATH/install/hardware/getac/fix-v110g3-touchpad.sh"
 
-omarchy-cmd-present limine-mkinitcpio || exit 0
-
+running_cmdline="${OMARCHY_GETAC_V110G3_RUNNING_CMDLINE:-/proc/cmdline}"
 rebuild_marker="${OMARCHY_GETAC_V110G3_REBUILD_MARKER:-/var/lib/omarchy/migrations/1788129995}"
 [[ ! -e $rebuild_marker ]] || exit 0
+
+if [[ -r $running_cmdline ]] &&
+  grep -Eq '(^| )i8042.nomux=1( |$)' "$running_cmdline" &&
+  grep -Eq '(^| )psmouse.synaptics_intertouch=1( |$)' "$running_cmdline"; then
+  sudo install -Dm644 /dev/null "$rebuild_marker"
+  exit 0
+fi
 
 sudo limine-mkinitcpio
 sudo install -Dm644 /dev/null "$rebuild_marker"

--- a/test/shell.d/getac-v110g3-touchpad-test.sh
+++ b/test/shell.d/getac-v110g3-touchpad-test.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+detector="$ROOT/bin/omarchy-hw-getac-v110g3"
+leaf="$ROOT/install/hardware/getac/fix-v110g3-touchpad.sh"
+all="$ROOT/install/hardware/all.sh"
+migration=$(grep -l "getac/fix-v110g3-touchpad" "$ROOT"/migrations/*.sh | head -1)
+
+grep -q 'run_logged .*hardware/getac/fix-v110g3-touchpad.sh' "$all" ||
+  fail "the GETAC V110G3 touchpad quirk runs during hardware setup"
+pass "the GETAC V110G3 touchpad quirk runs during hardware setup"
+
+[[ -n $migration ]] || fail "a migration enables the quirk on existing installs"
+pass "a migration enables the quirk on existing installs"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+exec "$@"
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+
+(( ${LIMINE_MKINITCPIO_INSTALLED:-1} == 1 ))
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'state %s\n' "$*" >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+vendor_file="$test_tmp/sys_vendor"
+product_file="$test_tmp/product_name"
+drop_in="$test_tmp/getac-v110g3-touchpad.conf"
+rebuild_marker="$test_tmp/rebuild-complete"
+
+write_dmi() {
+  printf '%s\n' "${1-GETAC}" >"$vendor_file"
+  printf '%s\n' "${2-V110G3}" >"$product_file"
+}
+
+run_detector() {
+  write_dmi "$@"
+  OMARCHY_DMI_SYS_VENDOR="$vendor_file" \
+    OMARCHY_DMI_PRODUCT_NAME="$product_file" \
+    bash "$detector"
+}
+
+run_detector || fail "the detector matches GETAC V110G3"
+pass "the detector matches GETAC V110G3"
+
+run_detector "GETAC" "V110G4" && fail "the detector rejects another GETAC model"
+pass "the detector rejects another GETAC model"
+
+run_detector "Dell" "V110G3" && fail "the detector rejects another vendor"
+pass "the detector rejects another vendor"
+
+run_detector "Getac" "V110G3" || fail "the detector matches GETAC case-insensitively"
+pass "the detector matches GETAC case-insensitively"
+
+write_dmi "GETAC" "V110G3"
+OMARCHY_DMI_SYS_VENDOR="$test_tmp/absent" \
+  OMARCHY_DMI_PRODUCT_NAME="$product_file" \
+  bash "$detector" && fail "the detector fails closed when the vendor attribute is missing"
+pass "the detector fails closed when the vendor attribute is missing"
+
+OMARCHY_DMI_SYS_VENDOR="$vendor_file" \
+  OMARCHY_DMI_PRODUCT_NAME="$test_tmp/absent" \
+  bash "$detector" && fail "the detector fails closed when the product attribute is missing"
+pass "the detector fails closed when the product attribute is missing"
+
+run_leaf() {
+  : >"$calls"
+  rm -f "$drop_in"
+  write_dmi "${1-GETAC}" "${2-V110G3}"
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_DMI_SYS_VENDOR="$vendor_file" \
+    OMARCHY_DMI_PRODUCT_NAME="$product_file" \
+    OMARCHY_GETAC_V110G3_LIMINE_CONF="$drop_in" \
+    bash -c 'source "$1"' bash "$leaf"
+}
+
+run_leaf || fail "the leaf writes the Limine drop-in on the target machine"
+grep -Fq 'KERNEL_CMDLINE[default]+=" i8042.nomux=1 psmouse.synaptics_intertouch=1"' "$drop_in" ||
+  fail "the leaf writes the Limine drop-in on the target machine"
+pass "the leaf writes the Limine drop-in on the target machine"
+
+run_leaf "Dell" "XPS 13" || fail "the leaf no-ops on other hardware"
+[[ -e $drop_in ]] && fail "the leaf no-ops on other hardware"
+pass "the leaf no-ops on other hardware"
+
+run_leaf || fail "the leaf is idempotent when the drop-in is already complete"
+: >"$calls"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_SYS_VENDOR="$vendor_file" \
+  OMARCHY_DMI_PRODUCT_NAME="$product_file" \
+  OMARCHY_GETAC_V110G3_LIMINE_CONF="$drop_in" \
+  bash -c 'source "$1"' bash "$leaf"
+[[ ! -s $calls ]] || fail "the leaf leaves a complete drop-in alone" "$(cat "$calls")"
+pass "the leaf leaves a complete drop-in alone"
+
+run_migration() {
+  : >"$calls"
+  write_dmi "${1-GETAC}" "${2-V110G3}"
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_DMI_SYS_VENDOR="$vendor_file" \
+    OMARCHY_DMI_PRODUCT_NAME="$product_file" \
+    OMARCHY_GETAC_V110G3_LIMINE_CONF="$drop_in" \
+    OMARCHY_GETAC_V110G3_REBUILD_MARKER="$rebuild_marker" \
+    LIMINE_MKINITCPIO_INSTALLED="${3-1}" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -f "$drop_in" "$rebuild_marker"
+run_migration || fail "the migration writes the drop-in, rebuilds, and asks for a reboot"
+grep -Fq 'KERNEL_CMDLINE[default]+=" i8042.nomux=1 psmouse.synaptics_intertouch=1"' "$drop_in" ||
+  fail "the migration writes the Limine drop-in"
+grep -Fxq 'limine-mkinitcpio' "$calls" || fail "the migration rebuilds the boot image"
+grep -q 'state set reboot-required' "$calls" || fail "the migration asks for a reboot"
+[[ -f $rebuild_marker ]] || fail "the migration records the machine-wide repair"
+pass "the migration writes the drop-in, rebuilds, and asks for a reboot"
+
+: >"$calls"
+run_migration || fail "a recorded rebuild is not repeated"
+[[ ! -s $calls ]] || fail "a recorded rebuild is not repeated" "$(cat "$calls")"
+pass "the migration is machine-idempotent across users"
+
+rm -f "$rebuild_marker"
+: >"$calls"
+run_migration || fail "an interrupted rebuild is retried"
+grep -Fxq 'limine-mkinitcpio' "$calls" || fail "an interrupted rebuild is retried"
+! grep -Eq $'sudo\ttee\t' "$calls" || fail "rebuild retry leaves a complete drop-in alone" "$(cat "$calls")"
+pass "the migration retries an interrupted boot image rebuild"
+
+rm -f "$drop_in" "$rebuild_marker"
+run_migration "ThinkPad" "X1" || fail "the migration no-ops on other hardware"
+[[ -e $drop_in ]] && fail "the migration no-ops on other hardware"
+[[ -e $rebuild_marker ]] && fail "an untouched machine is not marked as repaired"
+[[ ! -s $calls ]] || fail "the migration no-ops on other hardware" "$(cat "$calls")"
+pass "the migration no-ops on other hardware"
+
+rm -f "$drop_in" "$rebuild_marker"
+: >"$calls"
+run_migration "GETAC" "V110G3" 0 || fail "installs without limine-mkinitcpio still write the drop-in"
+grep -Fq 'i8042.nomux=1' "$drop_in" || fail "installs without limine-mkinitcpio still write the drop-in"
+grep -Fxq 'limine-mkinitcpio' "$calls" && fail "installs without limine-mkinitcpio skip the rebuild"
+[[ -e $rebuild_marker ]] && fail "installs without limine-mkinitcpio are not marked as repaired"
+pass "the migration skips the rebuild when limine-mkinitcpio is missing"

--- a/test/shell.d/getac-v110g3-touchpad-test.sh
+++ b/test/shell.d/getac-v110g3-touchpad-test.sh
@@ -37,12 +37,7 @@ cat >"$stub_bin/limine-mkinitcpio" <<'SH'
 #!/bin/bash
 
 echo 'limine-mkinitcpio' >>"$TEST_LOG"
-SH
-
-cat >"$stub_bin/omarchy-cmd-present" <<'SH'
-#!/bin/bash
-
-(( ${LIMINE_MKINITCPIO_INSTALLED:-1} == 1 ))
+exit "${TEST_LIMINE_MKINITCPIO_STATUS:-0}"
 SH
 
 cat >"$stub_bin/omarchy-state" <<'SH'
@@ -57,6 +52,8 @@ vendor_file="$test_tmp/sys_vendor"
 product_file="$test_tmp/product_name"
 drop_in="$test_tmp/getac-v110g3-touchpad.conf"
 rebuild_marker="$test_tmp/rebuild-complete"
+running_cmdline="$test_tmp/cmdline"
+printf 'quiet splash\n' >"$running_cmdline"
 
 write_dmi() {
   printf '%s\n' "${1-GETAC}" >"$vendor_file"
@@ -135,7 +132,8 @@ run_migration() {
     OMARCHY_DMI_PRODUCT_NAME="$product_file" \
     OMARCHY_GETAC_V110G3_LIMINE_CONF="$drop_in" \
     OMARCHY_GETAC_V110G3_REBUILD_MARKER="$rebuild_marker" \
-    LIMINE_MKINITCPIO_INSTALLED="${3-1}" \
+    OMARCHY_GETAC_V110G3_RUNNING_CMDLINE="$running_cmdline" \
+    TEST_LIMINE_MKINITCPIO_STATUS="${3-0}" \
     bash -euo pipefail "$migration" >/dev/null
 }
 
@@ -168,9 +166,19 @@ run_migration "ThinkPad" "X1" || fail "the migration no-ops on other hardware"
 pass "the migration no-ops on other hardware"
 
 rm -f "$drop_in" "$rebuild_marker"
-: >"$calls"
-run_migration "GETAC" "V110G3" 0 || fail "installs without limine-mkinitcpio still write the drop-in"
-grep -Fq 'i8042.nomux=1' "$drop_in" || fail "installs without limine-mkinitcpio still write the drop-in"
-grep -Fxq 'limine-mkinitcpio' "$calls" && fail "installs without limine-mkinitcpio skip the rebuild"
-[[ -e $rebuild_marker ]] && fail "installs without limine-mkinitcpio are not marked as repaired"
-pass "the migration skips the rebuild when limine-mkinitcpio is missing"
+printf 'i8042.nomux=1 psmouse.synaptics_intertouch=1\n' >"$running_cmdline"
+run_migration || fail "an already-live cmdline still writes the drop-in"
+grep -Fq 'KERNEL_CMDLINE[default]+=" i8042.nomux=1 psmouse.synaptics_intertouch=1"' "$drop_in" ||
+  fail "an already-live cmdline still writes the drop-in"
+grep -Fxq 'limine-mkinitcpio' "$calls" && fail "an already-live cmdline skips the rebuild"
+grep -q 'state set reboot-required' "$calls" && fail "an already-live cmdline does not ask for a reboot"
+[[ -f $rebuild_marker ]] || fail "an already-live cmdline records the machine-wide repair"
+pass "the migration writes the drop-in without rebuilding when the cmdline is already live"
+
+rm -f "$drop_in" "$rebuild_marker"
+printf 'quiet splash\n' >"$running_cmdline"
+run_migration "GETAC" "V110G3" 1 && fail "a failing boot image rebuild fails the migration"
+grep -Fq 'i8042.nomux=1' "$drop_in" || fail "a failing boot image rebuild still writes the drop-in"
+grep -Fxq 'limine-mkinitcpio' "$calls" || fail "a failing boot image rebuild still attempts the rebuild"
+[[ -e $rebuild_marker ]] && fail "a failing boot image rebuild is not marked as repaired"
+pass "the migration stays pending when the boot image rebuild fails"


### PR DESCRIPTION
On GETAC V110G3, S3 resume wedges the i8042 controller. The Synaptics pad then dies on both PS/2 and RMI4/SMBus and does not come back without a reboot.

`psmouse.synaptics_intertouch=1` alone does not survive S3. `i8042.nomux=1` together with InterTouch does — it moves the pad off the muxed AUX port onto the standard one. Same finding as [Launchpad #2162967](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2162967).

Gated on DMI vendor `GETAC` + product `V110G3` only. Fresh installs get a Limine cmdline drop-in; existing installs get the same via migration, then a boot-image rebuild.

Confirmed on V110G3, BIOS R1.00.030514, Synaptics SYN0c2a.