### PR TITLE
Let users review and suppress recurring crash types

### DIFF
--- a/bin/omarchy-crash-ignore
+++ b/bin/omarchy-crash-ignore
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# omarchy:summary=List or change permanently ignored crash types
+# omarchy:args=[<signature> on|off]
+# omarchy:examples=omarchy crash ignore | omarchy crash ignore <signature> off
+
+set -euo pipefail
+umask 077
+
+readonly STATE_ROOT="${OMARCHY_CRASH_STATE_ROOT:-$HOME/.local/state/omarchy/crash-watch}"
+
+list() {
+  local rule signature metadata found=0
+
+  for rule in "$STATE_ROOT/ignored"/*; do
+    [[ -f $rule ]] || continue
+    signature=${rule##*/}
+    metadata="$STATE_ROOT/metadata/$signature.json"
+    if [[ -f $metadata ]]; then
+      jq -r --arg signature "$signature" \
+        '[$signature, (.name // "unknown"), (.signal // "unknown"), (.cmdline // "unknown")] | @tsv' \
+        "$metadata"
+    else
+      printf '%s\tunknown\tunknown\tdetails unavailable\n' "$signature"
+    fi
+    found=1
+  done
+
+  ((found)) || echo "No crash types ignored."
+}
+
+if (($# == 0)); then
+  list
+  exit 0
+fi
+
+signature=$1
+action=${2:-on}
+
+[[ $signature =~ ^[0-9a-f]{64}$ ]] || { echo "Not a crash signature: $signature" >&2; exit 1; }
+[[ $action == "on" || $action == "off" ]] || { echo "Not an action: $action" >&2; exit 1; }
+
+rule="$STATE_ROOT/ignored/$signature"
+if [[ $action == "on" ]]; then
+  mkdir -p "${rule%/*}"
+  touch "$rule"
+  echo "Ignored crash type $signature."
+else
+  rm -f "$rule"
+  echo "Crash type $signature will notify again."
+fi

--- a/bin/omarchy-crash-review
+++ b/bin/omarchy-crash-review
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# omarchy:summary=Review a process crash before deciding whether to diagnose it
+# omarchy:args=<pid> <signature>
+# omarchy:hidden=true
+
+set -euo pipefail
+umask 077
+
+pid=${1:?usage: omarchy-crash-review <pid> <signature>}
+signature=${2:?usage: omarchy-crash-review <pid> <signature>}
+
+[[ $pid =~ ^[0-9]+$ ]] || { echo "Not a PID: $pid" >&2; exit 1; }
+[[ $signature =~ ^[0-9a-f]{64}$ ]] || { echo "Not a crash signature: $signature" >&2; exit 1; }
+
+# A notification action has no terminal. Relaunch only validated numeric/hex
+# values, so the presentation wrapper never receives process-controlled text.
+if [[ ! -t 0 && -z ${OMARCHY_CRASH_REVIEW_INTERACTIVE:-} ]]; then
+  exec omarchy-launch-floating-terminal-with-presentation "omarchy-crash-review $pid $signature"
+fi
+
+readonly STATE_ROOT="${OMARCHY_CRASH_STATE_ROOT:-$HOME/.local/state/omarchy/crash-watch}"
+readonly metadata="$STATE_ROOT/metadata/$signature.json"
+
+if [[ ! -f $metadata ]]; then
+  echo "Crash details are no longer available."
+  exit 1
+fi
+
+name=$(jq -r '.name // "unknown"' "$metadata")
+exe=$(jq -r '.exe // "unknown"' "$metadata")
+signal=$(jq -r '.signal // "unknown"' "$metadata")
+cmdline=$(jq -r '.cmdline // "unknown"' "$metadata")
+count=$(jq -r '.count // 1' "$metadata")
+last_seen=$(jq -r '.last_seen // "unknown"' "$metadata")
+
+gum style --border rounded --padding "1 2" --width 100 \
+  "Process crashed: $name" \
+  "Signal: $signal" \
+  "Command: $cmdline" \
+  "Executable: $exe" \
+  "Seen $count time(s); last at $last_seen"
+
+action=$(gum choose --header "What would you like to do?" \
+  "Diagnose with AI" \
+  "Dismiss this occurrence" \
+  "Snooze this crash type" \
+  "Ignore this crash type from now on" \
+  "Mute all crashes from $name") || exit 0
+
+case "$action" in
+  "Diagnose with AI")
+    exec omarchy-agent-crash "$pid" "$name" "$exe" "$signal"
+    ;;
+  "Dismiss this occurrence")
+    ;;
+  "Snooze this crash type")
+    duration=$(gum choose --header "Snooze for how long?" \
+      "15 minutes" "1 hour" "4 hours" "Until tomorrow") || exit 0
+    case "$duration" in
+      "15 minutes") seconds=900 ;;
+      "1 hour") seconds=3600 ;;
+      "4 hours") seconds=14400 ;;
+      "Until tomorrow") seconds=86400 ;;
+    esac
+    mkdir -p "$STATE_ROOT/snoozed"
+    printf '%s\n' "$((EPOCHSECONDS + seconds))" >"$STATE_ROOT/snoozed/$signature"
+    echo "Snoozed $name crashes of this type for $duration."
+    ;;
+  "Ignore this crash type from now on")
+    omarchy-crash-ignore "$signature" on >/dev/null
+    echo "Ignored this $name crash type. Other $name crashes will still notify."
+    ;;
+  "Mute all crashes from $name")
+    omarchy-crash-mute "$name" on
+    ;;
+esac

--- a/bin/omarchy-crash-signature
+++ b/bin/omarchy-crash-signature
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# omarchy:summary=Create a stable signature for one kind of process crash
+# omarchy:hidden=true
+
+set -euo pipefail
+
+exe=${1:-unknown}
+signal=${2:-unknown}
+cmdline=${3:-unknown}
+
+# NUL separators make distinct field boundaries unambiguous. The executable,
+# signal and command line are all recorded by systemd-coredump and are stable
+# enough to distinguish one failure probe from another without making a broad
+# per-program mute.
+printf '%s\0%s\0%s\0' "$exe" "$signal" "$cmdline" | sha256sum | cut -d' ' -f1

--- a/bin/omarchy-crash-watch
+++ b/bin/omarchy-crash-watch
@@ -7,6 +7,7 @@
 # structured COREDUMP_* fields, which carry more than the core filenames do.
 
 set -uo pipefail
+umask 077
 
 # See systemd.journal-fields(7).
 readonly COREDUMP_MESSAGE_ID=fc2e22bc6ee647b6b90729ab34a250b1
@@ -21,10 +22,12 @@ readonly dedupe_seconds=${OMARCHY_CRASH_DEDUPE_SECONDS:-60}
 # Extended regex of process names never worth announcing.
 readonly ignore_pattern=${OMARCHY_CRASH_IGNORE:-}
 
+readonly STATE_ROOT="${OMARCHY_CRASH_STATE_ROOT:-$HOME/.local/state/omarchy/crash-watch}"
+
 declare -A last_notified
 
 announce() {
-  local comm=$1 pid=$2 exe=$3 signal=$4
+  local comm=$1 pid=$2 signature=$3
 
   # The shell owns org.freedesktop.Notifications, so a shell crash takes the
   # notification server down with it and a toast sent into that gap is lost.
@@ -41,8 +44,30 @@ announce() {
     --urgency critical \
     --glyph "$CRASH_GLYPH" \
     "Process crashed: $comm" \
-    "Click to diagnose with AI" \
-    --exec omarchy-agent-crash "$pid" "$comm" "$exe" "$signal"
+    "Click to review what happened" \
+    --exec omarchy-crash-review "$pid" "$signature"
+}
+
+record_crash() {
+  local signature=$1 name=$2 pid=$3 exe=$4 signal=$5 cmdline=$6
+  local metadata="$STATE_ROOT/metadata/$signature.json"
+  local count=1
+
+  mkdir -p "$STATE_ROOT/metadata"
+  [[ -f $metadata ]] && count=$(jq -r '(.count // 0) + 1' "$metadata" 2>/dev/null) || true
+  [[ $count =~ ^[0-9]+$ ]] || count=1
+
+  jq -n \
+    --arg name "$name" \
+    --arg pid "$pid" \
+    --arg exe "$exe" \
+    --arg signal "$signal" \
+    --arg cmdline "$cmdline" \
+    --arg last_seen "$(date --iso-8601=seconds)" \
+    --argjson count "$count" \
+    '{name: $name, pid: $pid, exe: $exe, signal: $signal,
+      cmdline: $cmdline, count: $count, last_seen: $last_seen}' >"$metadata.new"
+  mv "$metadata.new" "$metadata"
 }
 
 # -n 0 so a restart does not re-announce crashes already dealt with.
@@ -52,13 +77,14 @@ journalctl -f -n 0 -o json "MESSAGE_ID=$COREDUMP_MESSAGE_ID" 2>/dev/null |
     # IFS whitespace, so an empty field collapses into the next delimiter and
     # every field after it shifts along one. A process can set its own comm to
     # nothing, and that crash used to be read as somebody else's and dropped.
-    IFS=$'\t' read -r uid comm pid exe signal < <(
+    IFS=$'\t' read -r uid comm pid exe signal cmdline < <(
       jq -r 'def field: if . == null or . == "" then "-" else . end;
              [(._UID | field),
               (.COREDUMP_COMM | field),
               (.COREDUMP_PID | field),
               (.COREDUMP_EXE | field),
-              (.COREDUMP_SIGNAL_NAME | field)] | @tsv' <<<"$entry" 2>/dev/null
+              (.COREDUMP_SIGNAL_NAME | field),
+              (.COREDUMP_CMDLINE | field)] | @tsv' <<<"$entry" 2>/dev/null
     )
 
     [[ $pid =~ ^[0-9]+$ ]] || continue
@@ -94,16 +120,30 @@ journalctl -f -n 0 -o json "MESSAGE_ID=$COREDUMP_MESSAGE_ID" 2>/dev/null |
     # Never announce our own machinery, or it notifies about itself.
     [[ $name == omarchy-crash-* || $name == omarchy-agent-* ]] && continue
 
+    signature=$(omarchy-crash-signature "$exe" "$signal" "$cmdline")
+    record_crash "$signature" "$name" "$pid" "$exe" "$signal" "$cmdline"
+
+    [[ -f $STATE_ROOT/ignored/$signature ]] && continue
+
+    snoozed_until=0
+    [[ -f $STATE_ROOT/snoozed/$signature ]] && read -r snoozed_until <"$STATE_ROOT/snoozed/$signature"
+    [[ $snoozed_until =~ ^[0-9]+$ ]] || snoozed_until=0
+    if ((EPOCHSECONDS < snoozed_until)); then
+      continue
+    elif ((snoozed_until)); then
+      rm -f "$STATE_ROOT/snoozed/$signature"
+    fi
+
     # Muted at the end of a diagnosis, when the user was offered it and said
     # yes. A flag per program rather than one list, so omarchy-crash-mute can
     # lift one without reading, rewriting and re-parsing the rest.
     omarchy-toggle-enabled "crash-ignore/$name" && continue
 
     now=$EPOCHSECONDS
-    (((now - ${last_notified[$name]:-0}) < dedupe_seconds)) && continue
+    (((now - ${last_notified[$signature]:-0}) < dedupe_seconds)) && continue
 
     # Only a delivered toast starts the dedupe window. A failed send that
     # counted would suppress the rest of a crash loop for a minute, and
     # `journalctl -n 0` never replays what was missed.
-    announce "$name" "$pid" "$exe" "$signal" && last_notified[$name]=$now
+    announce "$name" "$pid" "$signature" && last_notified[$signature]=$now
   done

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -167,12 +167,7 @@ Everything goes through the same sender contract, so the pieces are small:
 
 - **Low battery** — `omarchy-battery-low` sends a critical toast and runs the
   `battery-low` hook.
-- **Crash capture** — `omarchy-crash-watch` follows the systemd-coredump
-  journal stream and announces each crashed program (deduped per minute) as a
-  critical toast whose click runs `omarchy-agent-crash` (via `--exec`, so a
-  hostile process name stays a discrete argument). It waits for the
-  server first: a shell crash takes the notification server down with it, and
-  that crash is the one most worth reporting.
+- **Crash capture** — `omarchy-crash-watch` follows the systemd-coredump journal stream and announces each crashed program (deduped per minute) as a critical toast. A click opens `omarchy-crash-review` with a local summary and recurrence count before the user chooses whether to diagnose with AI, dismiss, snooze that exact crash type, ignore it permanently, or mute every crash from the program. A crash type is the SHA-256 signature of its executable, signal, and command line, so ignoring a known probe does not hide unrelated failures in the same executable. Retained summaries, snooze deadlines, and ignore rules live under `~/.local/state/omarchy/crash-watch`; the state is private to the user because command lines can contain sensitive values. The watcher waits for the notification server first: a shell crash takes the server down with it, and that crash is the one most worth reporting.
 - **Pending migrations** — `omarchy-migrate-notify` (from its user service
   after `graphical-session.target`) waits for the server, then sends a
   critical toast whose click opens a terminal running `omarchy-migrate`,

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -35,11 +35,13 @@ Left-click the bar icon for the panel, right-click to launch your default agent.
 
 ### Crash diagnosis
 
-Omarchy watches systemd-coredump for process crashes. When something segfaults, you'll get a "Process crashed" notification — click it, and the crash is handed to your default agent along with Omarchy's diagnose-crash skill, which walks the agent through establishing the facts from the core dump and deciding whether the crash is worth reporting upstream. You can also run it by hand against any PID from `coredumpctl list` with `omarchy agent crash <pid>`.
+Omarchy watches systemd-coredump for process crashes. When something segfaults, you'll get a "Process crashed" notification. Click it to see what crashed, the signal and command, and how often the same failure has occurred. From there you can diagnose it with your default agent, dismiss it, snooze that crash type, ignore it permanently, or mute every crash from the program. The agent receives the crash details along with Omarchy's diagnose-crash skill, which walks it through establishing the facts from the core dump and deciding whether the crash is worth reporting upstream. You can also run a diagnosis by hand against any PID from `coredumpctl list` with `omarchy agent crash <pid>`.
 
 The watching is on by default. Turn it off under _Trigger > Toggle > Crash Capture_ (or with `omarchy toggle crash-capture`) and the notifications stop; `omarchy agent crash <pid>` still works by hand.
 
 Crashes can also be silenced one program at a time, which is what the diagnosis offers you at the end. `omarchy crash mute hyprland` stops the notifications for that program only, `omarchy crash mute hyprland off` brings them back, and `omarchy crash mute` on its own lists what you've muted. It takes the binary's path as happily as its name, so `omarchy crash mute /usr/bin/hyprland` does the same thing. Quote a name with a space in it, as in `omarchy crash mute 'Some App'`. Everything else still notifies, and the muted program still crashes — this hides the reminder, it doesn't fix anything.
+
+An ignored crash type is narrower than a program mute: it matches the executable, signal, and command line together. Run `omarchy crash ignore` to list permanent ignore rules and `omarchy crash ignore <signature> off` to make one notify again. Snoozes expire automatically.
 
 ### Desktop apps
 

--- a/test/shell.d/crash-capture-test.sh
+++ b/test/shell.d/crash-capture-test.sh
@@ -96,11 +96,12 @@ reset_entries() {
 # One core dump as systemd-coredump journals it. The UID must be this user's, or
 # the watcher discards it as somebody else's crash before anything under test.
 crash_entry() {
-  local comm="$1" exe="$2"
+  local comm="$1" exe="$2" cmdline="${3:-$2 --test}"
 
-  jq -cn --arg uid "$UID" --arg comm "$comm" --arg exe "$exe" \
+  jq -cn --arg uid "$UID" --arg comm "$comm" --arg exe "$exe" --arg cmdline "$cmdline" \
     '{_UID: $uid, COREDUMP_COMM: $comm, COREDUMP_PID: "4242",
-      COREDUMP_EXE: $exe, COREDUMP_SIGNAL_NAME: "SIGSEGV"}' >>"$JOURNAL_ENTRIES"
+      COREDUMP_EXE: $exe, COREDUMP_SIGNAL_NAME: "SIGSEGV",
+      COREDUMP_CMDLINE: $cmdline}' >>"$JOURNAL_ENTRIES"
 }
 
 # The stubbed journalctl ends after the entries, so the watcher's loop ends too.
@@ -140,6 +141,41 @@ run_watch
 announced hyprland ||
   fail "a crash nobody muted still announces itself"
 pass "a crash nobody muted still announces itself"
+
+signature=$("$ROOT/bin/omarchy-crash-signature" /usr/bin/hyprland SIGSEGV "/usr/bin/hyprland --test")
+metadata="$watch_home/.local/state/omarchy/crash-watch/metadata/$signature.json"
+[[ -f $metadata ]] ||
+  fail "the watcher does not retain a summary for the review opened by the notification"
+[[ $(jq -r .count "$metadata") == "1" ]] ||
+  fail "the first occurrence has the wrong recurrence count"
+grep -Fq -- "--exec omarchy-crash-review 4242 $signature" "$NOTIFY_LOG" ||
+  fail "clicking the toast still launches AI directly instead of opening the crash review"
+pass "a crash notification opens a retained local summary before AI"
+
+mkdir -p "$watch_home/.local/state/omarchy/crash-watch/ignored"
+touch "$watch_home/.local/state/omarchy/crash-watch/ignored/$signature"
+run_watch
+! announced hyprland ||
+  fail "ignoring one crash signature does not stop that crash type from announcing"
+[[ $(jq -r .count "$metadata") == "2" ]] ||
+  fail "an ignored recurrence is not counted in its local summary"
+pass "ignoring one crash type keeps counting it without announcing it"
+rm -f "$watch_home/.local/state/omarchy/crash-watch/ignored/$signature"
+
+mkdir -p "$watch_home/.local/state/omarchy/crash-watch/snoozed"
+printf '%s\n' "$((EPOCHSECONDS + 3600))" >"$watch_home/.local/state/omarchy/crash-watch/snoozed/$signature"
+run_watch
+! announced hyprland ||
+  fail "a snoozed crash type still announces before the snooze expires"
+pass "snoozing suppresses only that crash type until its deadline"
+
+printf '%s\n' "$((EPOCHSECONDS - 1))" >"$watch_home/.local/state/omarchy/crash-watch/snoozed/$signature"
+run_watch
+announced hyprland ||
+  fail "a crash stays silent after its snooze deadline"
+[[ ! -f $watch_home/.local/state/omarchy/crash-watch/snoozed/$signature ]] ||
+  fail "an expired snooze is left behind as stale state"
+pass "an expired snooze restores notifications and cleans itself up"
 
 mute hyprland on
 run_watch
@@ -372,6 +408,85 @@ refusal=$(HOME="$mute_home" PATH="$failing_bin:$ROOT/bin:$PATH" \
 ! grep -Fq "Muted crash notifications" <<<"$refusal" ||
   fail "a mute that could not be written still reports success, so the user believes a program is silenced when it is not"
 pass "a mute that could not be written is not reported as one"
+
+# The click-through review is deliberately local: it shows the retained facts
+# and asks before spending agent time or granting the agent access to the core.
+review_bin="$TMPDIR/review-bin"
+REVIEW_ACTIONS="$TMPDIR/review-actions"
+REVIEW_AGENT_LOG="$TMPDIR/review-agent-log"
+REVIEW_LAUNCH_LOG="$TMPDIR/review-launch-log"
+mkdir -p "$review_bin"
+
+cat >"$review_bin/gum" <<'SH'
+#!/bin/bash
+[[ ${1:-} == "style" ]] && exit 0
+[[ ${1:-} == "choose" ]] || exit 1
+head -n 1 "$REVIEW_ACTIONS"
+tail -n +2 "$REVIEW_ACTIONS" >"$REVIEW_ACTIONS.next"
+mv "$REVIEW_ACTIONS.next" "$REVIEW_ACTIONS"
+SH
+
+cat >"$review_bin/omarchy-agent-crash" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$REVIEW_AGENT_LOG"
+SH
+
+cat >"$review_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$REVIEW_LAUNCH_LOG"
+SH
+
+chmod +x "$review_bin/gum" "$review_bin/omarchy-agent-crash" \
+  "$review_bin/omarchy-launch-floating-terminal-with-presentation"
+
+run_review() {
+  HOME="$watch_home" \
+  PATH="$review_bin:$ROOT/bin:$PATH" \
+  REVIEW_ACTIONS="$REVIEW_ACTIONS" \
+  REVIEW_AGENT_LOG="$REVIEW_AGENT_LOG" \
+  REVIEW_LAUNCH_LOG="$REVIEW_LAUNCH_LOG" \
+  OMARCHY_CRASH_REVIEW_INTERACTIVE=1 \
+    "$ROOT/bin/omarchy-crash-review" 4242 "$signature"
+}
+
+printf '%s\n' "Diagnose with AI" >"$REVIEW_ACTIONS"
+run_review
+grep -Fqx "4242 hyprland /usr/bin/hyprland SIGSEGV" "$REVIEW_AGENT_LOG" ||
+  fail "choosing diagnosis does not hand the reviewed facts to the existing agent flow"
+pass "the review launches AI only after diagnosis is chosen"
+
+rm -f "$watch_home/.local/state/omarchy/crash-watch/ignored/$signature"
+printf '%s\n' "Ignore this crash type from now on" >"$REVIEW_ACTIONS"
+run_review >/dev/null
+[[ -f $watch_home/.local/state/omarchy/crash-watch/ignored/$signature ]] ||
+  fail "the review's permanent ignore does not write the signature rule the watcher reads"
+pass "the review can permanently ignore one exact crash type"
+
+ignore_list=$(HOME="$watch_home" PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-crash-ignore")
+grep -Fq "$signature" <<<"$ignore_list" && grep -Fq $'hyprland\tSIGSEGV' <<<"$ignore_list" ||
+  fail "a permanent crash-type ignore cannot be identified later from its list"
+HOME="$watch_home" PATH="$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-crash-ignore" "$signature" off >/dev/null
+[[ ! -f $watch_home/.local/state/omarchy/crash-watch/ignored/$signature ]] ||
+  fail "a permanent crash-type ignore cannot be removed"
+pass "permanent crash-type ignores can be listed and removed"
+
+rm -f "$watch_home/.local/state/omarchy/crash-watch/snoozed/$signature"
+printf '%s\n' "Snooze this crash type" "1 hour" >"$REVIEW_ACTIONS"
+before=$EPOCHSECONDS
+run_review >/dev/null
+read -r snoozed_until <"$watch_home/.local/state/omarchy/crash-watch/snoozed/$signature"
+((snoozed_until >= before + 3600)) ||
+  fail "the review's one-hour snooze does not persist a one-hour deadline"
+pass "the review can snooze one exact crash type"
+
+HOME="$watch_home" \
+PATH="$review_bin:$ROOT/bin:$PATH" \
+REVIEW_LAUNCH_LOG="$REVIEW_LAUNCH_LOG" \
+  "$ROOT/bin/omarchy-crash-review" 4242 "$signature"
+grep -Fqx "omarchy-crash-review 4242 $signature" "$REVIEW_LAUNCH_LOG" ||
+  fail "a notification click does not open the crash review in a floating terminal"
+pass "the notification action opens the review in a themed floating terminal"
 
 skill="$ROOT/default/agents/skills/diagnose-crash/SKILL.md"
 grep -Fq 'omarchy-crash-mute' "$skill" ||


### PR DESCRIPTION
## Motivation

Crash notifications currently hand a crash directly to the default AI agent when clicked. That is useful for a new failure, but it becomes noisy when the same known crash keeps recurring and the user has already decided not to investigate or fix it.

The case that motivated this change was a crash repeatedly triggered while Claude was performing an operation. It was not a crash I planned to address, but each occurrence still offered the same direct diagnosis path. Muting the whole program would be too broad because a different crash from that executable could still be actionable.

## What changed

- Open a local crash review before launching the AI diagnosis.
- Retain a private summary and recurrence count for each crash type.
- Define a crash type from the executable, signal, and command line, hashed as a SHA-256 signature.
- Let users dismiss one occurrence, snooze a crash type, ignore that exact crash type permanently, or mute all crashes from the program.
- Keep counting ignored recurrences without showing another notification.
- Deduplicate notifications by crash signature rather than only by program name.
- Document the review and ignore flows and cover them in the crash capture tests.

This keeps unrelated failures visible: ignoring one known probe does not suppress every crash from the same executable.

## Testing

- `bash test/shell.d/crash-capture-test.sh` passes.
- Built and installed the development package locally, generated a real `SIGSEGV` core dump from `/usr/bin/sleep`, and verified that the notification opened the new review flow.
- `./test/all` was also run. The crash coverage passes; the suite reports four failures outside the touched area: `launch-about-test.sh`, `network-qr-test.sh`, `plugin-add-test.sh` (GPG state is read-only in the sandbox), and `snapper-test.sh` (the sibling `omarchy-iso` checkout is unavailable).
