### PR TITLE
Read the default terminal back from the file that sets it

### DIFF
--- a/bin/omarchy-default-terminal
+++ b/bin/omarchy-default-terminal
@@ -11,8 +11,25 @@ if [[ ${1:-} == "--install" ]]; then
 fi
 
 if (($# == 0)); then
-  desktop_id=$(xdg-terminal-exec --print-id 2>/dev/null || true)
-  desktop_id=${desktop_id%%:*}
+  # Read back the file this command writes. Asking xdg-terminal-exec to resolve
+  # it instead answers with an empty string and a zero exit wherever that tool
+  # is missing or is a shim that only knows how to exec one terminal, so the
+  # menu showed nothing selected on machines that had a default all along.
+  desktop_id=""
+  if [[ -r ~/.config/xdg-terminals.list ]]; then
+    while IFS= read -r line; do
+      [[ -z $line || $line == \#* ]] && continue
+      desktop_id=$line
+      break
+    done <~/.config/xdg-terminals.list
+  fi
+
+  # Nothing written yet: fall back to whatever the system resolves.
+  if [[ -z $desktop_id ]]; then
+    desktop_id=$(xdg-terminal-exec --print-id 2>/dev/null || true)
+    desktop_id=${desktop_id%%:*}
+  fi
+
   case "$desktop_id" in
   Alacritty.desktop) echo "alacritty" ;;
   foot.desktop) echo "foot" ;;

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -287,6 +287,38 @@ for entry in "${terminal_cases[@]}"; do
 done
 pass "terminal defaults install every missing terminal before selection"
 
+# The getter has to answer from the file the setter writes. Resolving through
+# xdg-terminal-exec, which is not on this test's PATH and need not be on a real
+# machine's either, is what left the menu with nothing selected.
+[[ $(omarchy-default-terminal) == "kitty" ]] ||
+  fail "the default terminal is read back from xdg-terminals.list" "got: $(omarchy-default-terminal)"
+pass "the default terminal is read back from xdg-terminals.list"
+
+printf '# only a comment\n\nfoot.desktop\n' >"$test_home/.config/xdg-terminals.list"
+[[ $(omarchy-default-terminal) == "foot" ]] ||
+  fail "reading the default terminal skips comments and blank lines" "got: $(omarchy-default-terminal)"
+pass "reading the default terminal skips comments and blank lines"
+
+# A terminal Omarchy does not name is still the honest answer.
+printf 'org.wezfurlong.wezterm.desktop\n' >"$test_home/.config/xdg-terminals.list"
+[[ $(omarchy-default-terminal) == "org.wezfurlong.wezterm.desktop" ]] ||
+  fail "an unrecognised default terminal is reported as its desktop id" "got: $(omarchy-default-terminal)"
+pass "an unrecognised default terminal is reported as its desktop id"
+
+# Nothing written yet: the system resolver still gets its turn.
+rm -f "$test_home/.config/xdg-terminals.list"
+cat >"$mock_bin/xdg-terminal-exec" <<'SH'
+#!/bin/bash
+[[ $1 == "--print-id" ]] && echo "Alacritty.desktop:/usr/share/applications/Alacritty.desktop"
+SH
+chmod +x "$mock_bin/xdg-terminal-exec"
+[[ $(omarchy-default-terminal) == "alacritty" ]] ||
+  fail "an unset default terminal falls back to the system resolver" "got: $(omarchy-default-terminal)"
+rm -f "$mock_bin/xdg-terminal-exec"
+pass "an unset default terminal falls back to the system resolver"
+
+omarchy-default-terminal kitty >/dev/null
+
 for entry in "${editor_cases[@]}"; do
   read -r selection command installer <<<"$entry"
   rm -f "$installed_dir/$command"


### PR DESCRIPTION
`omarchy-default-terminal` can print nothing and exit successfully when `xdg-terminal-exec` is missing or is a local shim that does not support `--print-id`. The Terminal menu compares each row with that output, so no terminal appears checked.

The command now reads `~/.config/xdg-terminals.list` first, which is the file it writes when setting the default. It skips comments and blank lines and takes the first entry. If no default has been written there, it still asks `xdg-terminal-exec`; an unrecognized terminal is still reported by its desktop ID.

Four additions to `default-apps-test.sh` cover reading the saved default, skipping comments and blank lines, returning an unknown ID unchanged, and falling back to the resolver. The readback assertion fails on unmodified `quattro` with an empty result.

`./test/shell` passed 217 of 221 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`. The menu, terminal-keybinding migration, and Quattro upgrade tests passed. ShellCheck, `bash -n`, and `git diff --check` were clean.

This is separate from #9365, which fixes setting a default after a package fails to install.
