### PR TITLE
Configure systemd-resolved through a drop-in instead of replacing its config

### DIFF
--- a/bin/omarchy-dns
+++ b/bin/omarchy-dns
@@ -19,6 +19,7 @@ if (( EUID == 0 )); then
 fi
 
 NM_DNS_CONF=/etc/NetworkManager/conf.d/20-omarchy-dns.conf
+RESOLVED_DNS_CONF=/etc/systemd/resolved.conf.d/20-omarchy-dns.conf
 
 provider_from_arg() {
   case "${1:-}" in
@@ -86,15 +87,25 @@ networkmanager_global_dns() {
 }
 
 resolved_dns() {
+  # Read our own drop-in where there is one, the way networkmanager_global_dns
+  # reads its own file. The main file is only consulted on a machine still
+  # carrying settings an older Omarchy wrote directly into it.
+  local file=/etc/systemd/resolved.conf
+  if [[ -f $RESOLVED_DNS_CONF ]]; then
+    file=$RESOLVED_DNS_CONF
+  fi
+
+  # An empty DNS= clears the servers before it, so the effective value is the
+  # last non-empty assignment rather than the first one seen.
   awk -F= '
     /^[[:space:]]*#/ { next }
     /^[[:space:]]*DNS[[:space:]]*=/ {
       value=$0
       sub(/^[^=]*=/, "", value)
-      print value
-      exit
+      if (value ~ /[^[:space:]]/) last = value
     }
-  ' /etc/systemd/resolved.conf 2>/dev/null || true
+    END { if (last != "") print last }
+  ' "$file" 2>/dev/null || true
 }
 
 current_dns_provider() {
@@ -143,6 +154,23 @@ split_dns_servers() {
       ipv4_dns+="${ipv4_dns:+ }$clean"
     fi
   done
+}
+
+# Own a drop-in, never /etc/systemd/resolved.conf itself, so DNSSEC=, Domains=
+# and anything else an administrator put there survives a provider change.
+# resolved collects DNS= and FallbackDNS= across the main file and its drop-ins
+# instead of letting the last one win, so each list is cleared with an empty
+# assignment before the new values. That is also what makes a DNS= line an older
+# Omarchy left in resolved.conf inert, without having to work out whether that
+# file was ours to delete.
+#
+# Every drop-in names DNSOverTLS= too. It decides how the servers selected here
+# are reached, so it belongs to the provider rather than to the administrator,
+# and inheriting a DNSOverTLS=yes from the main file would stop a custom
+# resolver that does not speak DoT from answering at all.
+write_resolved_dns() {
+  install -d -m 0755 "$(dirname "$RESOLVED_DNS_CONF")"
+  tee "$RESOLVED_DNS_CONF" >/dev/null
 }
 
 write_networkmanager_dns() {
@@ -262,9 +290,11 @@ case "$provider" in
 Cloudflare)
   write_networkmanager_dns "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001"
   set_connection_dns "1.1.1.1 1.0.0.1" "2606:4700:4700::1111 2606:4700:4700::1001"
-  tee /etc/systemd/resolved.conf >/dev/null <<'EOF'
+  write_resolved_dns <<'EOF'
 [Resolve]
+DNS=
 DNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com
+FallbackDNS=
 FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
 DNSOverTLS=opportunistic
 EOF
@@ -273,9 +303,11 @@ EOF
 Google)
   write_networkmanager_dns "8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844"
   set_connection_dns "8.8.8.8 8.8.4.4" "2001:4860:4860::8888 2001:4860:4860::8844"
-  tee /etc/systemd/resolved.conf >/dev/null <<'EOF'
+  write_resolved_dns <<'EOF'
 [Resolve]
+DNS=
 DNS=8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google
+FallbackDNS=
 FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
 DNSOverTLS=opportunistic
 EOF
@@ -284,8 +316,15 @@ EOF
 DHCP)
   clear_networkmanager_dns
   clear_connection_dns
-  tee /etc/systemd/resolved.conf >/dev/null <<'EOF'
+  # Clearing both lists is what neutralises servers an older Omarchy wrote
+  # straight into resolved.conf. Empty FallbackDNS= also turns off resolved's
+  # compiled-in fallback servers, which is the intent here: in DHCP mode DNS
+  # comes from the link, rather than quietly from a public resolver when the
+  # link supplies none.
+  write_resolved_dns <<'EOF'
 [Resolve]
+DNS=
+FallbackDNS=
 DNSOverTLS=no
 EOF
   ;;
@@ -308,10 +347,13 @@ Custom)
   # omarchy:heredoc-expands paths=none -- $dns_servers is a normalized,
   # single-line DNS server list; the //,/ turns its comma separators into the
   # spaces resolved.conf wants. It is written as data, not a path or command.
-  tee /etc/systemd/resolved.conf >/dev/null <<EOF
+  write_resolved_dns <<EOF
 [Resolve]
+DNS=
 DNS=${dns_servers//,/ }
+FallbackDNS=
 FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
+DNSOverTLS=no
 EOF
   ;;
 esac

--- a/test/shell.d/dns-resolved-dropin-test.sh
+++ b/test/shell.d/dns-resolved-dropin-test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+dns="$ROOT/bin/omarchy-dns"
+
+# The whole point: /etc/systemd/resolved.conf is an administrator's file, and a
+# provider change must not carry off the DNSSEC=, Domains= or LLMNR settings
+# that happen to share it.
+if grep -nE '(tee|>)[[:space:]]*/etc/systemd/resolved\.conf([[:space:]]|$)' "$dns"; then
+  fail "omarchy-dns never writes /etc/systemd/resolved.conf"
+fi
+grep -Fx 'RESOLVED_DNS_CONF=/etc/systemd/resolved.conf.d/20-omarchy-dns.conf' "$dns" >/dev/null ||
+  fail "omarchy-dns owns a resolved drop-in beside its NetworkManager one"
+pass "omarchy-dns writes a drop-in instead of replacing resolved.conf"
+
+# resolved collects DNS= and FallbackDNS= across the main file and its drop-ins
+# rather than letting the last one win, so a drop-in that only assigns would add
+# its servers to whatever an older Omarchy left behind.
+incomplete=$(awk '
+  /write_resolved_dns <</ { block++; in_block = 1; has_dns = 0; has_fallback = 0; next }
+  in_block && /^EOF$/ {
+    if (!has_dns || !has_fallback) print "drop-in " block
+    in_block = 0
+    next
+  }
+  in_block && /^DNS=$/ { has_dns = 1 }
+  in_block && /^FallbackDNS=$/ { has_fallback = 1 }
+  END { if (block != 4) print "expected four drop-ins, found " block }
+' "$dns")
+[[ -z $incomplete ]] ||
+  fail "every resolved drop-in clears both server lists before assigning" "$incomplete"
+pass "resolved drop-ins clear both server lists before assigning"
+
+# DNSOverTLS decides how the servers selected here are reached, so every mode
+# names it rather than inheriting whatever the main file happens to say. A
+# custom resolver that does not speak DoT would otherwise stop answering the
+# moment an administrator had set DNSOverTLS=yes.
+modes=$(awk '
+  /write_resolved_dns <</ { in_block = 1; mode = "DHCP"; tls = "(unset)"; next }
+  in_block && /^EOF$/ { print mode "=" tls; in_block = 0; next }
+  in_block {
+    if ($0 ~ /cloudflare-dns\.com/) mode = "Cloudflare"
+    else if ($0 ~ /dns\.google/) mode = "Google"
+    else if ($0 ~ /dns_servers/) mode = "Custom"
+    if ($0 ~ /^DNSOverTLS=/) { tls = $0; sub(/^DNSOverTLS=/, "", tls) }
+  }
+' "$dns")
+
+expected=$'Cloudflare=opportunistic\nGoogle=opportunistic\nDHCP=no\nCustom=no'
+[[ $modes == "$expected" ]] ||
+  fail "every mode pins the transport its own servers are reached over" "got:$(printf '\n%s' "$modes")"
+pass "every mode pins the transport its own servers are reached over"
+
+# Reporting has to follow the settings to the drop-in, or a machine that still
+# carries an older Omarchy's servers in the main file answers with them.
+if (( EUID == 0 )) || unshare --user --map-root-user true 2>/dev/null; then
+  probe() {
+    local main=$1 dropin=$2 fixture
+    fixture=$(mktemp -d)
+    mkdir -p "$fixture/systemd/resolved.conf.d" "$fixture/nm"
+    printf '%s' "$main" >"$fixture/systemd/resolved.conf"
+    if [[ -n $dropin ]]; then
+      printf '%s' "$dropin" >"$fixture/systemd/resolved.conf.d/20-omarchy-dns.conf"
+    fi
+
+    unshare --user --map-root-user --mount bash -c '
+      mount --bind "$1/systemd" /etc/systemd
+      mount --bind "$1/nm" /etc/NetworkManager
+      bash "$2"
+    ' _ "$fixture" "$dns" 2>/dev/null
+    rm -rf "$fixture"
+  }
+
+  stale_main=$'[Resolve]\nDNS=1.1.1.1#cloudflare-dns.com\nDNSSEC=yes\n'
+
+  [[ $(probe "$stale_main" $'[Resolve]\nDNS=\nFallbackDNS=\nDNSOverTLS=no\n') == "DHCP" ]] ||
+    fail "selecting DHCP reports DHCP even where an older Omarchy wrote servers into resolved.conf"
+  pass "selecting DHCP reports DHCP over servers left in the main file"
+
+  [[ $(probe "$stale_main" $'[Resolve]\nDNS=\nDNS=8.8.8.8#dns.google\nFallbackDNS=\n') == "Google" ]] ||
+    fail "a drop-in provider outranks servers left in the main file"
+  pass "a drop-in provider outranks servers left in the main file"
+
+  [[ $(probe $'[Resolve]\nDNS=8.8.8.8#dns.google\n' "") == "Google" ]] ||
+    fail "a machine with no drop-in yet still reports from resolved.conf"
+  pass "a machine with no drop-in yet still reports from resolved.conf"
+
+  [[ $(probe "$stale_main" $'[Resolve]\nDNS=\nDNS=192.168.1.1\nFallbackDNS=\n') == "Custom" ]] ||
+    fail "a drop-in naming servers Omarchy does not ship reports Custom"
+  pass "a drop-in naming servers Omarchy does not ship reports Custom"
+else
+  pass "no unprivileged user namespace; skipping the reporting probes"
+fi


### PR DESCRIPTION
Choosing a DNS provider overwrites `/etc/systemd/resolved.conf`, losing any `DNSSEC=`, `Domains=`, `LLMNR=`, or other settings an administrator put there. Choosing DHCP writes another replacement file rather than restoring those settings.

The script now writes `/etc/systemd/resolved.conf.d/20-omarchy-dns.conf` and leaves the main file alone. Each provider clears `DNS=` and `FallbackDNS=` before assigning its servers, because resolved combines these lists across configuration files. Without the empty assignments, the new servers would be added to any old ones still in the main file. This also handles configurations written by earlier Omarchy versions without trying to guess whether the main file is safe to delete.

DHCP keeps a drop-in that clears both lists. Removing the drop-in would reactivate servers an older Omarchy wrote into the main file. Clearing `FallbackDNS=` also disables resolved's built-in fallback servers, so DHCP mode now relies on DNS supplied by the link. That is a behavior change. Clearing `DNS=` also disables reading `/etc/resolv.conf`; NetworkManager supplies per-link DNS over D-Bus, and `reload_dns_stack` requests that update with `nmcli general reload dns-full`.

Every drop-in also names `DNSOverTLS=`, because it decides how the servers selected here are reached: `opportunistic` for Cloudflare and Google, `no` for DHCP and Custom. The old full-file replacement left Custom on resolved's default of `no`; a drop-in that stayed silent would instead inherit an administrator's `DNSOverTLS=yes` and stop a custom server that does not speak DoT from answering. The test pins all four values.

`resolved_dns()` now reads the drop-in when present and uses its last non-empty `DNS=` assignment. Otherwise, a stale Cloudflare entry in the main file would still be reported after selecting DHCP. Machines without a drop-in continue to use the main file for reporting.

`dns-resolved-dropin-test.sh` checks DHCP over a stale main file, a drop-in overriding the old provider, reporting without a drop-in, and an unrecognized provider reporting Custom. These probes bind fixture directories over `/etc/systemd` and `/etc/NetworkManager` inside a user and mount namespace; they skip where unprivileged namespaces are unavailable. Write checks are static because the root path fixes `PATH`: they verify that the main file is never replaced and every provider clears both lists.

`./test/shell` passed 218 of 222 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`. `dns-sudoers-test.sh` passed. ShellCheck, `bash -n`, and `git diff --check` were clean.

This changes resolved's configuration files. The separate work on saved NetworkManager profile DNS settings is tracked in #8908 and touches the same script.

