### PR TITLE
Fix inverted on/off arguments in omarchy toggle bar

### DIFF
--- a/bin/omarchy-toggle-bar
+++ b/bin/omarchy-toggle-bar
@@ -4,7 +4,17 @@
 # omarchy:args=[toggle|on|off]
 # omarchy:examples=omarchy toggle bar | omarchy toggle bar off | omarchy toggle bar on
 
-omarchy-toggle bar-off "${1:-toggle}"
+ACTION="${1:-toggle}"
+
+# The underlying flag is named for the hidden state, so an explicit on/off
+# from the user is the inverse of what gets passed through. A bare toggle
+# flips the flag either way and needs no inversion.
+case "$ACTION" in
+  on) ACTION="off" ;;
+  off) ACTION="on" ;;
+esac
+
+omarchy-toggle bar-off "$ACTION"
 
 # The shell's watch on the toggles directory can miss flag changes that land in
 # quick succession, stranding the bar off screen until the shell restarts.

--- a/test/acceptance.d/session-test.sh
+++ b/test/acceptance.d/session-test.sh
@@ -30,16 +30,16 @@ wait_until "background layer is on screen" 30 layer_on_screen "omarchy-backgroun
 # Hiding parks the bar off-screen without unmapping its layer surface, and
 # revealing brings that same surface back on-screen.
 restore_bar_visibility() {
-  omarchy-toggle-bar off >/dev/null 2>&1 || true
+  omarchy-toggle-bar on >/dev/null 2>&1 || true
 }
 trap restore_bar_visibility EXIT
 
-omarchy-toggle-bar on
+omarchy-toggle-bar off
 wait_until "hidden bar layer stays mapped" 15 layer_present "omarchy-bar"
 wait_until "hidden bar layer parks off screen" 15 layer_off_screen "omarchy-bar"
 screenshot "success-bar-hidden"
 
-omarchy-toggle-bar off
+omarchy-toggle-bar on
 wait_until "revealed bar layer returns on screen" 15 layer_on_screen "omarchy-bar"
 screenshot "success-bar-revealed"
 trap - EXIT

--- a/test/shell.d/toggle-test.sh
+++ b/test/shell.d/toggle-test.sh
@@ -40,14 +40,14 @@ HOME="$test_home" omarchy-toggle example toggle
 [[ ! -f $flag ]] || fail "generic toggle flips enabled state off"
 pass "generic toggle flips enabled state off"
 
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on enables bar-off toggle"
-pass "bar on enables bar-off toggle"
-
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on is idempotent"
-pass "bar on is idempotent"
+HOME="$test_home" omarchy-toggle-bar off
+[[ -f $bar_flag ]] || fail "bar off enables bar-off toggle"
+pass "bar off enables bar-off toggle"
 
 HOME="$test_home" omarchy-toggle-bar off
-[[ ! -f $bar_flag ]] || fail "bar off disables bar-off toggle"
-pass "bar off disables bar-off toggle"
+[[ -f $bar_flag ]] || fail "bar off is idempotent"
+pass "bar off is idempotent"
+
+HOME="$test_home" omarchy-toggle-bar on
+[[ ! -f $bar_flag ]] || fail "bar on disables bar-off toggle"
+pass "bar on disables bar-off toggle"


### PR DESCRIPTION
## Screenshots

**`omarchy toggle bar on`** — bar visible:
<img width="2560" height="70" alt="toggle-bar-on" src="https://github.com/user-attachments/assets/0284814b-595f-4304-89bd-8a3af472b183" />

**`omarchy toggle bar off`** — bar hidden:
<img width="2560" height="70" alt="toggle-bar-off" src="https://github.com/user-attachments/assets/5bf8c607-03c4-4495-b1f5-961ef0b32656" />

## Summary
- `bin/omarchy-toggle-bar` forwarded the user's `on`/`off` straight through to the underlying `bar-off` flag, which is named for the hidden state. So `omarchy toggle bar on` set `bar-off` (bar hidden) and `omarchy toggle bar off` cleared it (bar shown) — the opposite of what the words say. The bare `toggle` form was unaffected. Now inverts `on`/`off` before forwarding to the flag.
- `test/shell.d/toggle-test.sh` had encoded the buggy behavior as the expected result; updated to assert the corrected mapping.
- `test/acceptance.d/session-test.sh` used the old mapping too: its EXIT trap restored visibility with `off`, the hide step used `on`, and the reveal step used `off`. Swapped all three so the trap does not hide the bar on exit.
Fixes #9323 
## Test plan
- [x] `test/shell.d/toggle-test.sh` passes with the corrected mapping
- [x] `./test/cli` passes
- [x] Verified visually on a live desktop: `omarchy-toggle-bar off` hides the real bar and `omarchy-toggle-bar on` restores it (screenshots above), state restored afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)