### PR TITLE
Keep fingerprint unlock alive when the probe cannot reach fprintd

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -22,6 +22,10 @@ Item {
   property bool fingerprintAuthenticating: false
   property bool passwordPamConfigured: false
   property bool fingerprintConfigured: false
+  // A probe that could not reach fprintd says nothing about whether a print is
+  // enrolled, so it is counted rather than believed. See fingerprintCheckProc.
+  property int fingerprintProbeMisses: 0
+  readonly property int fingerprintProbeMissLimit: 10
   property bool previewVisible: false
   property string enteredPassword: ""
   property string pendingPassword: ""
@@ -120,7 +124,9 @@ Item {
     failedAttempts = 0
     authenticatingPassword = false
     fingerprintAuthenticating = false
+    fingerprintProbeMisses = 0
     fingerprintRetryTimer.stop()
+    fingerprintProbeRetryTimer.stop()
     if (passwordPam.active) passwordPam.abort()
     if (fingerprintPam.active) fingerprintPam.abort()
   }
@@ -222,7 +228,7 @@ Item {
     if (!lockRequested) return
     if (result === PamResult.Success) {
       finishUnlock()
-    } else if (fingerprintConfigured) {
+    } else if (fingerprintConfigured && fingerprintProbeMisses === 0) {
       fingerprintRetryTimer.restart()
     }
   }
@@ -349,7 +355,9 @@ Item {
 
     onError: function(error) {
       root.fingerprintAuthenticating = false
-      if (root.lockRequested && root.fingerprintConfigured) fingerprintRetryTimer.restart()
+      if (root.lockRequested && root.fingerprintConfigured && root.fingerprintProbeMisses === 0) {
+        fingerprintRetryTimer.restart()
+      }
     }
   }
 
@@ -358,6 +366,16 @@ Item {
     interval: 250
     repeat: false
     onTriggered: root.startFingerprint()
+  }
+
+  // Slower than fingerprintRetryTimer on purpose: that one waits for a finger,
+  // this one waits for a daemon to come back. Ten tries at a second covers the
+  // resume window without adding a second tight retry loop.
+  Timer {
+    id: fingerprintProbeRetryTimer
+    interval: 1000
+    repeat: false
+    onTriggered: root.refreshFingerprintStatus()
   }
 
   Process {
@@ -377,10 +395,54 @@ Item {
 
   Process {
     id: fingerprintCheckProc
-    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && command -v fprintd-list >/dev/null 2>&1 && fprintd-list \"$USER\" 2>/dev/null | grep -qi finger; then echo yes; else echo no; fi"]
+    // Three states, because "the probe returned nothing useful" and "this user
+    // has no print enrolled" are not the same answer:
+    //
+    //   no      - definitive: no PAM config, no fprintd-list, or fprintd
+    //             answered and the user has nothing enrolled
+    //   yes     - fprintd answered and listed at least one enrolled print
+    //   unknown - fprintd could not be reached, so the question is unanswered
+    //
+    // unknown is what the resume window produces. fprintd is D-Bus activated,
+    // and an activation request made while it is stopping, or while systemd is
+    // still working through the resume, fails outright:
+    //
+    //   Impossible to get devices: GDBus.Error:...NameHasNoOwner: Could not
+    //   activate remote peer 'net.reactivated.Fprint': activation request failed
+    //
+    // Keyed on the output rather than the exit status: fprintd-list returns 0
+    // and 1 inconsistently for identical input (fprintd 1.94.5), so trusting
+    // the status would strand a working reader on a flaky 1.
+    //
+    // The enrolled test is ' - #' rather than a looser match on "finger"
+    // because both the negative message ("has no fingers enrolled") and the
+    // device name ("Goodix MOC Fingerprint Sensor") contain it.
+    command: ["bash", "-c", "if [[ ! -f /etc/pam.d/omarchy-lock-fingerprint ]] || ! command -v fprintd-list >/dev/null 2>&1; then echo no; else out=$(fprintd-list \"$USER\" 2>/dev/null); if grep -q ' - #' <<<\"$out\"; then echo yes; elif grep -qi 'no fingers enrolled' <<<\"$out\"; then echo no; else echo unknown; fi; fi"]
     stdout: StdioCollector { id: fingerprintCheckStdout; waitForEnd: true }
     onExited: {
-      root.fingerprintConfigured = String(fingerprintCheckStdout.text || "").trim() === "yes"
+      var answer = String(fingerprintCheckStdout.text || "").trim()
+
+      // Hold the previous answer and ask again rather than tearing fingerprint
+      // down over a daemon that is on its way back. Without this a single miss
+      // is terminal for the whole lock: fingerprintConfigured gates the retry
+      // in handleFingerprintFinished, and nothing re-probes until the next
+      // beginLock. Bounded so a genuinely broken fprintd still settles.
+      if (answer === "unknown") {
+        root.fingerprintProbeMisses += 1
+        if (root.lockRequested && root.fingerprintProbeMisses <= root.fingerprintProbeMissLimit) {
+          // Nothing can reach the reader until the daemon is back, so let the
+          // probe own the wait. Leaving the 250ms finger retry armed spins PAM
+          // subprocesses against a daemon that is not there, which is the
+          // amplifier behind #7176 and the overlapping-claim crash in #7172.
+          fingerprintRetryTimer.stop()
+          fingerprintProbeRetryTimer.restart()
+          return
+        }
+        answer = "no"
+      }
+
+      root.fingerprintProbeMisses = 0
+      root.fingerprintConfigured = answer === "yes"
       if (root.lockRequested && root.fingerprintConfigured) root.startFingerprint()
       else if (!root.fingerprintConfigured && fingerprintPam.active) fingerprintPam.abort()
     }

--- a/test/shell.d/lock-fingerprint-probe-test.sh
+++ b/test/shell.d/lock-fingerprint-probe-test.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const os = require('os')
+const { execFileSync } = require('child_process')
+
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+// Run the real expression rather than a copy of it, so the fixtures below
+// cannot drift away from what the lock screen actually executes.
+const commandMatch = serviceQml.match(/command: (\["bash", "-c", "(?:[^"\\]|\\.)*"\])/g)
+  .map((line) => JSON.parse(line.replace(/^command: /, '')))
+  .find((command) => command[2].includes('fprintd-list'))
+
+assert(commandMatch !== undefined, 'the fingerprint probe is a bash command in Service.qml')
+
+const probeScript = commandMatch[2]
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omarchy-fingerprint-probe-'))
+
+// PATH is reduced to the sandbox so a system fprintd-list cannot answer for a
+// stub, and grep is linked in because the probe genuinely shells out to it.
+const grepPath = execFileSync('bash', ['-c', 'command -v grep'], { encoding: 'utf8' }).trim()
+
+function runProbe({ fprintdOutput, fprintdStatus = 0, pamConfig = true, fprintdListOnPath = true }) {
+  const binDir = fs.mkdtempSync(path.join(workDir, 'bin-'))
+  const pamPath = path.join(binDir, 'omarchy-lock-fingerprint')
+  if (pamConfig) fs.writeFileSync(pamPath, '')
+
+  fs.symlinkSync(grepPath, path.join(binDir, 'grep'))
+
+  if (fprintdListOnPath) {
+    const lines = fprintdOutput.split('\n').map((line) => `printf '%s\\n' ${JSON.stringify(line)}`)
+    fs.writeFileSync(
+      path.join(binDir, 'fprintd-list'),
+      `#!/bin/bash\n${lines.join('\n')}\nexit ${fprintdStatus}\n`,
+      { mode: 0o755 }
+    )
+  }
+
+  // Only the PAM path is rewritten; the decision logic runs verbatim.
+  const script = probeScript.split('/etc/pam.d/omarchy-lock-fingerprint').join(pamPath)
+
+  return execFileSync('/bin/bash', ['-c', script], {
+    env: { PATH: binDir, USER: 'tester' },
+    encoding: 'utf8',
+  }).trim()
+}
+
+const ENROLLED = [
+  'found 1 devices',
+  'Device at /net/reactivated/Fprint/Device/0',
+  'Using device /net/reactivated/Fprint/Device/0',
+  'Fingerprints for user tester on Goodix MOC Fingerprint Sensor (press):',
+  ' - #0: right-index-finger',
+].join('\n')
+
+const NO_PRINTS = [
+  'found 1 devices',
+  'Device at /net/reactivated/Fprint/Device/0',
+  'Using device /net/reactivated/Fprint/Device/0',
+  'User tester has no fingers enrolled for Goodix MOC Fingerprint Sensor.',
+].join('\n')
+
+const UNREACHABLE =
+  'Impossible to get devices: GDBus.Error:org.freedesktop.DBus.Error.NameHasNoOwner: ' +
+  "Could not activate remote peer 'net.reactivated.Fprint': activation request failed"
+
+try {
+  assertEqual(
+    runProbe({ fprintdOutput: ENROLLED }),
+    'yes',
+    'an enrolled print reads as configured'
+  )
+
+  // Both the negative message and the device name contain "finger", so a
+  // looser match reports a reader the account cannot actually use.
+  assertEqual(
+    runProbe({ fprintdOutput: NO_PRINTS }),
+    'no',
+    'a user with no prints reads as not configured'
+  )
+
+  // The resume window: fprintd is D-Bus activated and the activation request
+  // can fail outright while it is stopping or while systemd finishes resuming.
+  assertEqual(
+    runProbe({ fprintdOutput: UNREACHABLE, fprintdStatus: 1 }),
+    'unknown',
+    'an unreachable fprintd reads as unknown, not as unconfigured'
+  )
+
+  // fprintd-list returns 0 and 1 inconsistently for identical input
+  // (fprintd 1.94.5), so the exit status must not decide this.
+  assertEqual(
+    runProbe({ fprintdOutput: ENROLLED, fprintdStatus: 1 }),
+    'yes',
+    'a non-zero exit alongside enrolled output still reads as configured'
+  )
+
+  assertEqual(
+    runProbe({ fprintdOutput: ENROLLED, pamConfig: false }),
+    'no',
+    'a missing PAM config reads as not configured'
+  )
+
+  assertEqual(
+    runProbe({ fprintdOutput: ENROLLED, fprintdListOnPath: false }),
+    'no',
+    'a missing fprintd-list reads as not configured'
+  )
+} finally {
+  fs.rmSync(workDir, { recursive: true, force: true })
+}
+
+// An unknown answer must not reach fingerprintConfigured: that flag gates the
+// retry in handleFingerprintFinished and the startFingerprint guard, so one
+// miss would otherwise disable fingerprint for the rest of the lock.
+assert(
+  /if \(answer === "unknown"\) \{[\s\S]*?fingerprintProbeRetryTimer\.restart\(\)\s*\n\s*return/.test(serviceQml),
+  'an unknown probe re-arms the probe retry instead of settling the answer'
+)
+
+assert(
+  /root\.fingerprintProbeMisses \+= 1[\s\S]*?root\.fingerprintProbeMisses <= root\.fingerprintProbeMissLimit/.test(serviceQml),
+  'the unknown retries are bounded by a miss limit'
+)
+
+assert(
+  /fingerprintProbeRetryTimer[\s\S]*?interval: 1000/.test(serviceQml),
+  'the probe retry is slower than the 250ms finger retry'
+)
+
+// Holding fingerprintConfigured true across an unknown keeps startFingerprint
+// callable, so the 250ms retry has to be held off explicitly or it storms PAM
+// subprocesses against a daemon that is not there.
+assert(
+  /answer === "unknown"[\s\S]*?fingerprintRetryTimer\.stop\(\)/.test(serviceQml),
+  'an unknown probe stops the fast finger retry'
+)
+
+assert(
+  /fingerprintConfigured && (?:root\.)?fingerprintProbeMisses === 0/.test(serviceQml) &&
+    serviceQml.match(/fingerprintProbeMisses === 0/g).length === 2,
+  'both retry re-arms are suppressed while a probe miss is outstanding'
+)
+
+assert(
+  /resetAuthenticationState[\s\S]*?fingerprintProbeMisses = 0[\s\S]*?fingerprintProbeRetryTimer\.stop\(\)/.test(serviceQml),
+  'unlocking clears the miss count and stops the probe retry'
+)
+JS


### PR DESCRIPTION
Fixes #9453.

### The problem

`fingerprintCheckProc` decides whether fingerprint unlock is available by shelling out to `fprintd-list`, and collapses every non-matching result into "not configured". But "the probe could not reach fprintd" and "this user has no print enrolled" are different answers, and only one of them should switch fingerprint off.

fprintd is D-Bus activated, so an activation request made while it is stopping — or while systemd is still working through a resume — can fail outright:

```
Impossible to get devices: GDBus.Error:org.freedesktop.DBus.Error.NameHasNoOwner:
Could not activate remote peer 'net.reactivated.Fprint': activation request failed
```

That reads as "not configured", and it is terminal: `fingerprintConfigured` gates the retry in `handleFingerprintFinished`, and nothing re-probes until the next `beginLock()`. One transient miss disables fingerprint for the rest of the lock, with no prompt and no indication why.

### The change

Report three states — `yes` / `no` / `unknown` — and on `unknown` hold the previous answer and re-probe on a bounded 1s timer instead of tearing fingerprint down.

Three details worth calling out:

**Keyed on output, not exit status.** `fprintd-list` returns 0 and 1 inconsistently for identical input (seen on fprintd 1.94.5 for a user with no prints). Trusting the status would strand a working reader on a flaky `1` — a worse failure than the one being fixed. There is a test for exactly that case.

**`' - #'` rather than a looser match on "finger".** Both the negative message (`has no fingers enrolled`) and the device name (`Goodix MOC Fingerprint Sensor`) contain "finger", so the current expression reports an unenrolled user as configured. Distinguishing `unknown` from `no` requires getting this right. This matches the change #7158 makes to the same expression, arrived at independently.

**The 250ms retry is held off while a miss is outstanding.** Holding `fingerprintConfigured` true across an `unknown` keeps `startFingerprint()` callable, so without a guard the fast finger retry storms PAM subprocesses against a daemon that is not there — the amplifier behind #7176 and the overlapping-claim crash in #7172. I hit this on the first live run: **7 fingerprint PAM sessions in two seconds**, down to **2** with the guard. The probe timer owns the wait; normal retries resume once the daemon answers.

### Verification

`test/shell.d/lock-fingerprint-probe-test.sh` extracts the probe expression from `Service.qml` and runs it against a stubbed `fprintd-list` in a sandboxed `PATH`, so the fixtures cannot drift from what the lock screen actually executes. Six behavioural cases (enrolled, no prints, unreachable, non-zero exit with valid output, missing PAM config, missing `fprintd-list`) plus structural assertions on the unknown handling, the bound, and the retry suppression. The test fails against the unpatched file.

Verified in the running UI (`agents/skills/visual-verification.md`) with this exact file installed as a plugin clone. Mask fprintd, lock, unmask while still locked:

```
before   fprintd restored, 24.3s locked with a healthy daemon
         0 fingerprint prompts, 0 D-Bus activations, 0 PAM sessions
         (fingerprint dead until the next lock)

after    fprintd restored at +3s
         Starting Fingerprint Authentication Daemon...
         Relaying pam message: "Place your right index finger on the fingerprint reader"
         unlocked by fingerprint inside the same lock
```

`./test/all`: the new file passes. Four files fail — `bar-icon-geometry`, `config`, `snapper`, `unowned-system-paths` — and all four fail identically on a clean `quattro` checkout here, so they look environment-dependent rather than related to this change.

### Relationship to #7158

#7158 covers the same area far more thoroughly (retry pacing, resume detection, an unavailable notice) and I would rather see it land than this. It does not close this particular hole though: `fingerprintConfigured = ... === "yes"` is unchanged there, and a miss now costs more, because that PR adds `fingerprintRetryTimer.stop()` on the unconfigured branch and gates its new `fingerprintSleepWatch` on `running: lockRequested && fingerprintConfigured` — so one unreachable probe also switches off the resume detector it adds. I have left a note on the PR. This change is small and standalone; if #7158 lands first I am happy to rebase this onto it or close it in favour of folding the three-state probe in there.

### Environment

Omarchy 4.0.2-1, Quickshell 0.3.1-1, fprintd 1.94.5-2, libfprint 1.94.100-1, kernel 7.1.9-arch1-2, Goodix 27c6:609c.
