### PR TITLE
[codex] OM-SEC-11: Confine screen recorder state to a private runtime

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -15,16 +15,10 @@
 # start.
 #
 # Env: OMARCHY_SCREENRECORD_DEBUG=true appends gpu-screen-recorder's stderr (and
-# the picker target it was launched with) to /tmp/omarchy-screenrecord.log so
-# users can attach a log when reporting capture failures.
+# the picker target it was launched with) to the private screen-recording
+# runtime directory instead of a shared file under /tmp.
 
-[[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
-OUTPUT_DIR="${OMARCHY_SCREENRECORD_DIR:-${XDG_VIDEOS_DIR:-$HOME/Videos}}"
-
-if [[ ! -d $OUTPUT_DIR ]]; then
-  omarchy-notification-send -u critical -t 3000 "Screen recording directory does not exist: $OUTPUT_DIR"
-  exit 1
-fi
+set -uo pipefail
 
 DESKTOP_AUDIO="false"
 MICROPHONE_AUDIO="false"
@@ -34,35 +28,342 @@ WEBCAM_SIZE="medium"
 RESOLUTION=""
 FULLSCREEN="false"
 STOP_RECORDING="false"
-RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
-REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
-LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "/tmp/omarchy-screenrecord.log" || echo "/dev/null")
 
-for arg in "$@"; do
-  case "$arg" in
-  --with-desktop-audio) DESKTOP_AUDIO="true" ;;
-  --with-microphone-audio) MICROPHONE_AUDIO="true" ;;
-  --with-webcam) WEBCAM="true" ;;
-  --webcam-device=*) WEBCAM_DEVICE="${arg#*=}" ;;
-  --webcam-size=*) WEBCAM_SIZE="${arg#*=}" ;;
-  --resolution=*) RESOLUTION="${arg#*=}" ;;
-  --fullscreen) FULLSCREEN="true" ;;
-  --stop-recording) STOP_RECORDING="true" ;;
+CURRENT_UID=""
+OUTPUT_DIR=""
+RUNTIME_BASE=""
+STATE_DIR=""
+STATE_FILE=""
+REGION_FILE=""
+LOG_FILE="/dev/null"
+
+RECORDING_PID="0"
+RECORDING_START="0"
+RECORDING_PATH=""
+WEBCAM_PID="0"
+WEBCAM_START="0"
+STATE_PUBLISHED="false"
+START_CLEANUP_ARMED="false"
+
+parse_args() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+    --with-desktop-audio) DESKTOP_AUDIO="true" ;;
+    --with-microphone-audio) MICROPHONE_AUDIO="true" ;;
+    --with-webcam) WEBCAM="true" ;;
+    --webcam-device=*) WEBCAM_DEVICE="${arg#*=}" ;;
+    --webcam-size=*) WEBCAM_SIZE="${arg#*=}" ;;
+    --resolution=*) RESOLUTION="${arg#*=}" ;;
+    --fullscreen) FULLSCREEN="true" ;;
+    --stop-recording) STOP_RECORDING="true" ;;
+    esac
+  done
+
+  case $WEBCAM_SIZE in
+  small | medium | large) ;;
+  *)
+    echo "Invalid webcam size: $WEBCAM_SIZE (expected small, medium, or large)" >&2
+    return 1
+    ;;
   esac
-done
+}
 
-case $WEBCAM_SIZE in
-small | medium | large) ;;
-*)
-  echo "Invalid webcam size: $WEBCAM_SIZE (expected small, medium, or large)" >&2
-  exit 1
-  ;;
-esac
+trusted_path_ancestors() {
+  local path="$1" owner mode mode_value
+  while :; do
+    [[ -d $path && ! -L $path ]] || return 1
+    owner=$(/usr/bin/stat -c '%u' -- "$path") || return 1
+    mode=$(/usr/bin/stat -c '%a' -- "$path") || return 1
+    mode_value=$((8#$mode))
+    if [[ $owner == "$CURRENT_UID" ]]; then
+      ((!(mode_value & 022))) || return 1
+    elif [[ $owner == "0" ]]; then
+      if ((mode_value & 022)); then
+        ((mode_value == 01777)) || return 1
+      fi
+    else
+      # A mapped or foreign-owned ancestor is trustworthy only when even its
+      # owner cannot modify directory entries (for example / in a userns).
+      ((!(mode_value & 0222))) || return 1
+    fi
+    [[ $path == "/" ]] && return 0
+    path=$(/usr/bin/dirname -- "$path") || return 1
+  done
+}
+
+runtime_dir_safe() {
+  local directory="$1" canonical owner mode
+  [[ $directory == /* && -d $directory && ! -L $directory ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+  [[ $canonical == "$directory" ]] || return 1
+  owner=$(/usr/bin/stat -c '%u' -- "$directory") || return 1
+  mode=$(/usr/bin/stat -c '%a' -- "$directory") || return 1
+  [[ $owner == "$CURRENT_UID" && $mode == "700" ]] || return 1
+  trusted_path_ancestors "$directory"
+}
+
+resolve_runtime_base() {
+  local fallback="/run/user/$CURRENT_UID"
+  if [[ -n ${XDG_RUNTIME_DIR:-} ]] && runtime_dir_safe "$XDG_RUNTIME_DIR"; then
+    RUNTIME_BASE=$XDG_RUNTIME_DIR
+  elif runtime_dir_safe "$fallback"; then
+    RUNTIME_BASE=$fallback
+  else
+    echo "Screen recording requires a private mode-0700 user runtime directory." >&2
+    return 1
+  fi
+}
+
+initialize_runtime_state() {
+  CURRENT_UID=$(/usr/bin/id -u) || return 1
+  [[ $CURRENT_UID =~ ^[0-9]+$ ]] || return 1
+  resolve_runtime_base || return 1
+
+  STATE_DIR="$RUNTIME_BASE/omarchy-screenrecord"
+  if [[ ! -e $STATE_DIR && ! -L $STATE_DIR ]]; then
+    /usr/bin/mkdir -- "$STATE_DIR" 2>/dev/null ||
+      [[ -d $STATE_DIR && ! -L $STATE_DIR ]] || return 1
+    /usr/bin/chmod 0700 -- "$STATE_DIR" || return 1
+  fi
+  runtime_dir_safe "$STATE_DIR" || {
+    echo "Refusing unsafe screen-recording runtime state: $STATE_DIR" >&2
+    return 1
+  }
+
+  STATE_FILE="$STATE_DIR/recording.state"
+  REGION_FILE="$STATE_DIR/region"
+  if [[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]]; then
+    LOG_FILE="$STATE_DIR/screenrecording.log"
+  fi
+}
+
+resolve_account_home() {
+  local entry entry_uid canonical owner mode
+  entry=$(/usr/bin/getent passwd "$CURRENT_UID") || return 1
+  IFS=: read -r _ _ entry_uid _ _ ACCOUNT_HOME _ <<<"$entry"
+  [[ $entry_uid == "$CURRENT_UID" && $ACCOUNT_HOME == /* ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$ACCOUNT_HOME") || return 1
+  [[ $canonical == "$ACCOUNT_HOME" && -d $ACCOUNT_HOME && ! -L $ACCOUNT_HOME ]] || return 1
+  owner=$(/usr/bin/stat -c '%u' -- "$ACCOUNT_HOME") || return 1
+  mode=$(/usr/bin/stat -c '%a' -- "$ACCOUNT_HOME") || return 1
+  [[ $owner == "$CURRENT_UID" ]] && ! ((8#$mode & 022)) || return 1
+  trusted_path_ancestors "$ACCOUNT_HOME"
+}
+
+user_dirs_config_safe() {
+  local config_home="$1" config_file="$2" canonical owner mode links
+  [[ -d $config_home && ! -L $config_home ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$config_home") || return 1
+  [[ $canonical == "$config_home" ]] || return 1
+  owner=$(/usr/bin/stat -c '%u' -- "$config_home") || return 1
+  mode=$(/usr/bin/stat -c '%a' -- "$config_home") || return 1
+  [[ $owner == "$CURRENT_UID" ]] && ! ((8#$mode & 022)) || return 1
+  [[ -f $config_file && ! -L $config_file ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$config_file") || return 1
+  [[ $canonical == "$config_file" && ${canonical%/*} == "$config_home" ]] || return 1
+  owner=$(/usr/bin/stat -c '%u' -- "$config_file") || return 1
+  mode=$(/usr/bin/stat -c '%a' -- "$config_file") || return 1
+  links=$(/usr/bin/stat -c '%h' -- "$config_file") || return 1
+  [[ $owner == "$CURRENT_UID" && $links == "1" ]] && ! ((8#$mode & 022))
+}
+
+initialize_output_dir() {
+  local configured canonical owner mode config_home config_file
+  local HOME XDG_VIDEOS_DIR=""
+  if [[ -n ${OMARCHY_SCREENRECORD_DIR:-} ]]; then
+    configured=$OMARCHY_SCREENRECORD_DIR
+  else
+    resolve_account_home || return 1
+    HOME=$ACCOUNT_HOME
+    config_home="$ACCOUNT_HOME/.config"
+    config_file="$config_home/user-dirs.dirs"
+    if user_dirs_config_safe "$config_home" "$config_file"; then
+      source "$config_file"
+    fi
+    configured="${XDG_VIDEOS_DIR:-$ACCOUNT_HOME/Videos}"
+  fi
+  [[ $configured != *$'\n'* && $configured != *$'\r'* && $configured != *$'\t'* ]] || return 1
+  [[ -d $configured ]] || {
+    omarchy-notification-send -u critical -t 3000 "Screen recording directory does not exist: $configured"
+    return 1
+  }
+  canonical=$(/usr/bin/realpath -e -- "$configured") || return 1
+  [[ -d $canonical && ! -L $canonical ]] || return 1
+  owner=$(/usr/bin/stat -c '%u' -- "$canonical") || return 1
+  mode=$(/usr/bin/stat -c '%a' -- "$canonical") || return 1
+  [[ $owner == "$CURRENT_UID" ]] && ! ((8#$mode & 022)) || {
+    echo "Refusing a recording directory writable by another local account: $canonical" >&2
+    return 1
+  }
+  trusted_path_ancestors "$canonical" || {
+    echo "Refusing a recording directory below an unsafe path: $canonical" >&2
+    return 1
+  }
+  OUTPUT_DIR=$canonical
+}
+
+private_runtime_file_safe() {
+  local file="$1" owner mode links canonical
+  [[ -f $file && ! -L $file ]] || return 1
+  owner=$(/usr/bin/stat -c '%u' -- "$file") || return 1
+  mode=$(/usr/bin/stat -c '%a' -- "$file") || return 1
+  links=$(/usr/bin/stat -c '%h' -- "$file") || return 1
+  canonical=$(/usr/bin/realpath -e -- "$file") || return 1
+  [[ $owner == "$CURRENT_UID" && $mode == "600" && $links == "1" ]] || return 1
+  [[ $canonical == "$file" && ${canonical%/*} == "$STATE_DIR" ]]
+}
+
+atomic_create_runtime_file() {
+  local file="$1" contents="$2" temporary
+  [[ ! -e $file && ! -L $file ]] || return 1
+  temporary=$(/usr/bin/mktemp "$STATE_DIR/.private.XXXXXXXX") || return 1
+  if ! printf '%s\n' "$contents" >"$temporary" ||
+    ! set_private_mode "$temporary" ||
+    ! /usr/bin/ln -- "$temporary" "$file"; then
+    /usr/bin/rm -- "$temporary" 2>/dev/null || true
+    return 1
+  fi
+  if ! /usr/bin/rm -- "$temporary" || ! private_runtime_file_safe "$file"; then
+    /usr/bin/rm -- "$file" 2>/dev/null || true
+    return 1
+  fi
+}
+
+set_private_mode() {
+  /usr/bin/chmod 0600 -- "$1"
+}
+
+remove_private_runtime_file() {
+  local file="$1"
+  [[ ! -e $file && ! -L $file ]] && return 0
+  private_runtime_file_safe "$file" || return 1
+  /usr/bin/rm -- "$file"
+}
+
+ensure_debug_log() {
+  [[ $LOG_FILE != "/dev/null" ]] || return 0
+  if [[ -e $LOG_FILE || -L $LOG_FILE ]]; then
+    private_runtime_file_safe "$LOG_FILE" || {
+      echo "Refusing unsafe screen-recording debug log: $LOG_FILE" >&2
+      return 1
+    }
+  else
+    atomic_create_runtime_file "$LOG_FILE" "" || return 1
+  fi
+}
+
+read_process_stat() {
+  local pid="$1" stat_line remainder
+  local -a fields=()
+  [[ $pid =~ ^[1-9][0-9]*$ && -r /proc/$pid/stat ]] || return 1
+  stat_line=$(</proc/$pid/stat) || return 1
+  remainder=${stat_line##*) }
+  [[ $remainder != "$stat_line" ]] || return 1
+  read -r -a fields <<<"$remainder"
+  ((${#fields[@]} > 19)) || return 1
+  [[ ${fields[19]} =~ ^[1-9][0-9]*$ ]] || return 1
+  PROCESS_STATE=${fields[0]}
+  PROCESS_START=${fields[19]}
+}
+
+process_owned_by_current_uid() {
+  local pid="$1" label real effective saved filesystem
+  while read -r label real effective saved filesystem; do
+    if [[ $label == "Uid:" ]]; then
+      [[ $real == "$CURRENT_UID" && $effective == "$CURRENT_UID" &&
+        $saved == "$CURRENT_UID" && $filesystem == "$CURRENT_UID" ]]
+      return
+    fi
+  done <"/proc/$pid/status"
+  return 1
+}
+
+process_matches() {
+  local pid="$1" expected_start="$2"
+  read_process_stat "$pid" || return 1
+  [[ $PROCESS_START == "$expected_start" && $PROCESS_STATE != "Z" && $PROCESS_STATE != "X" ]] || return 1
+  process_owned_by_current_uid "$pid" || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+signal_bound_process() {
+  local pid="$1" start="$2" signal="$3"
+  process_matches "$pid" "$start" || return 0
+  kill -s "$signal" "$pid" 2>/dev/null
+}
+
+wait_for_bound_process_exit() {
+  local pid="$1" start="$2" attempts="$3" index
+  for ((index = 0; index < attempts; index++)); do
+    process_matches "$pid" "$start" || return 0
+    /usr/bin/sleep 0.1
+  done
+  ! process_matches "$pid" "$start"
+}
+
+write_region_state() {
+  local region="$1"
+  [[ $region =~ ^[0-9]+x[0-9]+\+-?[0-9]+\+-?[0-9]+$ ]] || return 1
+  remove_private_runtime_file "$REGION_FILE" || return 1
+  atomic_create_runtime_file "$REGION_FILE" "$region"
+}
+
+cleanup_region_state() {
+  remove_private_runtime_file "$REGION_FILE"
+}
+
+read_recording_state() {
+  local line pattern tab=$'\t'
+  local -a lines=()
+  private_runtime_file_safe "$STATE_FILE" || return 1
+  mapfile -t lines <"$STATE_FILE" || return 1
+  ((${#lines[@]} == 1)) || return 1
+  line=${lines[0]}
+  printf '%s\n' "$line" | /usr/bin/cmp -s - "$STATE_FILE" || return 1
+  pattern="^version=1${tab}pid=([1-9][0-9]*)${tab}start=([1-9][0-9]*)${tab}webcam_pid=(0|[1-9][0-9]*)${tab}webcam_start=(0|[1-9][0-9]*)${tab}file=(/[^[:cntrl:]]+)$"
+  [[ $line =~ $pattern ]] || return 1
+  RECORDING_PID=${BASH_REMATCH[1]}
+  RECORDING_START=${BASH_REMATCH[2]}
+  WEBCAM_PID=${BASH_REMATCH[3]}
+  WEBCAM_START=${BASH_REMATCH[4]}
+  RECORDING_PATH=${BASH_REMATCH[5]}
+  if [[ $WEBCAM_PID == "0" ]]; then
+    [[ $WEBCAM_START == "0" ]] || return 1
+  else
+    [[ $WEBCAM_START != "0" ]] || return 1
+  fi
+}
+
+publish_recording_state() {
+  local contents
+  [[ $RECORDING_PATH != *$'\n'* && $RECORDING_PATH != *$'\r'* && $RECORDING_PATH != *$'\t'* ]] || return 1
+  contents="version=1"$'\t'"pid=$RECORDING_PID"$'\t'"start=$RECORDING_START"$'\t'"webcam_pid=$WEBCAM_PID"$'\t'"webcam_start=$WEBCAM_START"$'\t'"file=$RECORDING_PATH"
+  atomic_create_runtime_file "$STATE_FILE" "$contents"
+}
+
+output_file_safe_in_directory() {
+  local file="$1" canonical owner mode links
+  [[ $file == /* && -f $file && ! -L $file ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$file") || return 1
+  owner=$(/usr/bin/stat -c '%u' -- "$file") || return 1
+  mode=$(/usr/bin/stat -c '%a' -- "$file") || return 1
+  links=$(/usr/bin/stat -c '%h' -- "$file") || return 1
+  [[ $canonical == "$file" && ${canonical%/*} == "$OUTPUT_DIR" ]] || return 1
+  [[ $owner == "$CURRENT_UID" && $mode == "600" && $links == "1" ]]
+}
+
+recording_path_safe() {
+  local file="$1" basename
+  output_file_safe_in_directory "$file" || return 1
+  basename=${file##*/}
+  [[ $basename =~ ^screenrecording-[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}\.mp4$ ]]
+}
 
 start_webcam_overlay() {
-  cleanup_webcam
+  local target="$1" available_formats capture_options="framerate=30" waited=0 resolution
+  local -a preferred_resolutions=("640x360" "1280x720" "1920x1080")
 
-  # Auto-detect first available webcam if none specified
   if [[ -z $WEBCAM_DEVICE ]]; then
     WEBCAM_DEVICE=$(omarchy-capture-webcam-list | sed -n '1s/[[:space:]].*//p')
     if [[ -z $WEBCAM_DEVICE ]]; then
@@ -71,13 +372,9 @@ start_webcam_overlay() {
     fi
   fi
 
-  # Try preferred 16:9 resolutions in order, use first available
-  local preferred_resolutions=("640x360" "1280x720" "1920x1080")
-  local capture_options="framerate=30"
-  local available_formats=$(v4l2-ctl --list-formats-ext -d "$WEBCAM_DEVICE" 2>/dev/null)
-
+  available_formats=$(v4l2-ctl --list-formats-ext -d "$WEBCAM_DEVICE" 2>/dev/null)
   for resolution in "${preferred_resolutions[@]}"; do
-    if echo "$available_formats" | grep -q "$resolution"; then
+    if grep -q "$resolution" <<<"$available_formats"; then
       capture_options="video_size=$resolution,$capture_options"
       break
     fi
@@ -90,26 +387,35 @@ start_webcam_overlay() {
     --title="WebcamOverlay" --wayland-app-id="WebcamOverlay-$WEBCAM_SIZE" \
     --no-border --no-audio --no-osc --osd-level=0 \
     --really-quiet &>/dev/null &
+  WEBCAM_PID=$!
+  if ! read_process_stat "$WEBCAM_PID" || ! process_owned_by_current_uid "$WEBCAM_PID"; then
+    kill -TERM "$WEBCAM_PID" 2>/dev/null || true
+    WEBCAM_PID="0"
+    return 1
+  fi
+  WEBCAM_START=$PROCESS_START
 
-  # The move has to settle before gpu-screen-recorder starts, or the camera is
-  # recorded sliding into its corner. Waiting for the map is what the blind
-  # second was partly guessing at, so the remainder is trimmed to hold the
-  # pre-capture delay where it was: starting later costs the first words spoken.
-  local waited=0
   while ((waited < 40)) && ! hyprctl clients -j | jq -e 'any(.[]; .title == "WebcamOverlay")' >/dev/null 2>&1; do
-    sleep 0.05
+    /usr/bin/sleep 0.05
     ((waited++))
   done
 
-  [[ ${1:-} == region:* ]] && echo "${1#region:}" >"$REGION_FILE"
-  omarchy-capture-webcam-resize "$WEBCAM_SIZE"
-
-  sleep 0.6
+  if [[ $target == region:* ]]; then
+    write_region_state "${target#region:}" || return 1
+  else
+    cleanup_region_state || return 1
+  fi
+  XDG_RUNTIME_DIR="$RUNTIME_BASE" omarchy-capture-webcam-resize "$WEBCAM_SIZE"
+  /usr/bin/sleep 0.6
 }
 
-cleanup_webcam() {
-  pkill -f "WebcamOverlay" 2>/dev/null
-  rm -f "$REGION_FILE"
+cleanup_bound_webcam() {
+  if [[ $WEBCAM_PID != "0" && $WEBCAM_START != "0" ]]; then
+    signal_bound_process "$WEBCAM_PID" "$WEBCAM_START" TERM || true
+    wait_for_bound_process_exit "$WEBCAM_PID" "$WEBCAM_START" 10 ||
+      signal_bound_process "$WEBCAM_PID" "$WEBCAM_START" KILL || true
+  fi
+  cleanup_region_state
 }
 
 default_resolution() {
@@ -122,35 +428,49 @@ default_resolution() {
   fi
 }
 
-# Echoes "monitor:NAME" when the selection matches an entire monitor (prefer
-# -w <monitor> over a region capture — same kms backend, but no scaling math
-# and full native res), otherwise "region:WxH+X+Y". Returns non-zero if the
-# user cancelled the picker.
 select_capture_target() {
   local target
   target=$(omarchy-capture-region smart --match-monitor) || return 1
-
   if [[ $target == monitor:* ]]; then
     echo "$target"
     return
   fi
-
   [[ $target =~ ^(-?[0-9]+),(-?[0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]] || return 1
-
-  # gpu-screen-recorder wants region geometry in the compositor's logical
-  # coordinate space — same space slurp returns — so pass the values through
-  # untouched. (gsr scales to physical pixels itself based on the monitor.)
   echo "region:${BASH_REMATCH[3]}x${BASH_REMATCH[4]}+${BASH_REMATCH[1]}+${BASH_REMATCH[2]}"
 }
 
-start_screenrecording() {
-  local capture_args=()
-  local target
+cleanup_pending_start() {
+  if [[ $STATE_PUBLISHED != "true" ]]; then
+    if [[ $RECORDING_PID != "0" && $RECORDING_START != "0" ]]; then
+      signal_bound_process "$RECORDING_PID" "$RECORDING_START" TERM || true
+      wait_for_bound_process_exit "$RECORDING_PID" "$RECORDING_START" 10 ||
+        signal_bound_process "$RECORDING_PID" "$RECORDING_START" KILL || true
+    fi
+    cleanup_bound_webcam || true
+    remove_private_runtime_file "$STATE_FILE" 2>/dev/null || true
+  fi
+  START_CLEANUP_ARMED="false"
+}
 
-  # Opt-in path for HDR, external-GPU monitors, and window capture (all things
-  # the portal backend supports and the kms backend doesn't). Default flow uses
-  # slurp + the kms backend, which avoids the EGL DMA-BUF modifier import
-  # failures the portal path can hit on some configurations.
+cleanup_interrupted_start() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  cleanup_pending_start
+  exit "$status"
+}
+
+start_screenrecording() {
+  local target filename audio_devices="" log_header attempt
+  local -a capture_args=() audio_args=()
+
+  START_CLEANUP_ARMED="true"
+  trap cleanup_interrupted_start EXIT HUP INT TERM
+  cleanup_region_state || {
+    echo "Refusing unsafe stale screen-recording region state." >&2
+    return 1
+  }
+  ensure_debug_log || return 1
+
   if [[ $FULLSCREEN == "true" ]]; then
     target="monitor:$(omarchy-hyprland-monitor-focused)"
     capture_args=(-w "${target#monitor:}" -s "${RESOLUTION:-$(default_resolution)}")
@@ -159,11 +479,8 @@ start_screenrecording() {
     capture_args=(-w portal -s "${RESOLUTION:-$(default_resolution)}")
   else
     target=$(select_capture_target) || return 1
-
     case $target in
-    monitor:*)
-      capture_args=(-w "${target#monitor:}" -s "${RESOLUTION:-$(default_resolution)}")
-      ;;
+    monitor:*) capture_args=(-w "${target#monitor:}" -s "${RESOLUTION:-$(default_resolution)}") ;;
     region:*)
       capture_args=(-w "${target#region:}")
       [[ -n $RESOLUTION ]] && capture_args+=(-s "$RESOLUTION")
@@ -171,118 +488,226 @@ start_screenrecording() {
     esac
   fi
 
-  [[ $WEBCAM == "true" ]] && start_webcam_overlay "$target"
+  if [[ $WEBCAM == "true" ]]; then
+    start_webcam_overlay "$target" || return 1
+  fi
 
-  local filename="$OUTPUT_DIR/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4"
-  local audio_devices=""
-  local audio_args=()
-
+  filename="$OUTPUT_DIR/screenrecording-$(/usr/bin/date +'%Y-%m-%d_%H-%M-%S').mp4"
+  [[ ! -e $filename && ! -L $filename ]] || {
+    echo "Refusing to overwrite an existing screen recording: $filename" >&2
+    return 1
+  }
   [[ $DESKTOP_AUDIO == "true" ]] && audio_devices+="default_output"
-
   if [[ $MICROPHONE_AUDIO == "true" ]]; then
-    # Merge audio tracks into one - separate tracks only play one at a time in most players
     [[ -n $audio_devices ]] && audio_devices+="|"
     audio_devices+="default_input"
   fi
-
   [[ -n $audio_devices ]] && audio_args+=(-a "$audio_devices" -ac aac)
 
-  echo "===== $(date '+%F %T') args: $* target: $target =====" >>"$LOG_FILE"
+  log_header="===== $(/usr/bin/date '+%F %T') args: $* target: $target ====="
+  if [[ $LOG_FILE != "/dev/null" ]]; then
+    printf '%s\n' "$log_header" >>"$LOG_FILE" || return 1
+  fi
+
   gpu-screen-recorder "${capture_args[@]}" -k auto -f 60 -fm cfr -fallback-cpu-encoding yes -o "$filename" "${audio_args[@]}" 2>>"$LOG_FILE" &
-  local pid=$!
+  RECORDING_PID=$!
+  if ! read_process_stat "$RECORDING_PID" || ! process_owned_by_current_uid "$RECORDING_PID"; then
+    return 1
+  fi
+  RECORDING_START=$PROCESS_START
+  RECORDING_PATH=$filename
 
-  while kill -0 $pid 2>/dev/null && [[ ! -f $filename ]]; do
-    sleep 0.2
+  for ((attempt = 0; attempt < 75; attempt++)); do
+    [[ -e $filename || -L $filename ]] && break
+    process_matches "$RECORDING_PID" "$RECORDING_START" || return 1
+    /usr/bin/sleep 0.2
   done
+  process_matches "$RECORDING_PID" "$RECORDING_START" || return 1
+  if [[ ! -e $filename && ! -L $filename ]]; then
+    echo "Screen recorder did not create its output within 15 seconds." >&2
+    return 1
+  fi
+  recording_path_safe "$filename" || return 1
+  publish_recording_state || return 1
+  process_matches "$RECORDING_PID" "$RECORDING_START" || {
+    remove_private_runtime_file "$STATE_FILE" || true
+    return 1
+  }
+  STATE_PUBLISHED="true"
+  toggle_screenrecording_indicator || true
+}
 
-  if kill -0 $pid 2>/dev/null; then
-    echo "$filename" >"$RECORDING_FILE"
-    toggle_screenrecording_indicator
+finalize_recording() {
+  local latest="$1" processed
+  local -a video_codec=(-c:v copy) args=()
+  recording_path_safe "$latest" || return 1
+
+  if ffprobe -v error -select_streams v:0 -read_intervals %+0.2 -show_entries packet=flags -of csv=p=0 "$latest" 2>/dev/null | grep -q D; then
+    video_codec=(-c:v libx264 -preset veryfast -crf 20)
+  fi
+  args=(-y -ss 0.1 -i "$latest" "${video_codec[@]}")
+  recording_path_safe "$latest" || return 1
+  if ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$latest" 2>/dev/null | grep -q audio; then
+    args+=(-af "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05,loudnorm=I=-14:TP=-1.5:LRA=11")
+  fi
+
+  processed=$(/usr/bin/mktemp "$OUTPUT_DIR/.omarchy-screenrecord-processed.XXXXXXXX.mp4") || return 1
+  if ! set_private_mode "$processed"; then
+    cleanup_created_output_temp "$processed"
+    return 1
+  fi
+  if recording_path_safe "$latest" && ffmpeg "${args[@]}" "$processed" -loglevel quiet 2>/dev/null; then
+    if output_file_safe_in_directory "$processed" && recording_path_safe "$latest" &&
+      /usr/bin/mv -T -- "$processed" "$latest"; then
+      return 0
+    fi
+    cleanup_created_output_temp "$processed"
+    return 1
+  else
+    cleanup_created_output_temp "$processed"
   fi
 }
 
-stop_screenrecording() {
-  pkill -SIGINT -f "^gpu-screen-recorder" # SIGINT required to save video properly
+cleanup_created_output_temp() {
+  local file="$1"
+  [[ $file == "$OUTPUT_DIR"/.omarchy-screenrecord-processed.*.mp4 ]] || return 1
+  [[ ! -e $file && ! -L $file ]] && return 0
+  /usr/bin/rm -- "$file"
+}
 
-  # Wait a maximum of 5 seconds to finish before hard killing
-  local count=0
-  while pgrep -f "^gpu-screen-recorder" >/dev/null && ((count < 50)); do
-    sleep 0.1
-    count=$((count + 1))
-  done
-
-  toggle_screenrecording_indicator
-  cleanup_webcam
-
-  if pgrep -f "^gpu-screen-recorder" >/dev/null; then
-    pkill -9 -f "^gpu-screen-recorder"
-    omarchy-notification-send -u critical -t 5000 "Screen recording error" "Recording process had to be force-killed. Video may be corrupted."
+create_preview() {
+  local filename="$1" preview
+  recording_path_safe "$filename" || return 1
+  preview=$(/usr/bin/mktemp "$STATE_DIR/preview.XXXXXXXX.png") || return 1
+  if ! set_private_mode "$preview"; then
+    cleanup_created_preview "$preview"
+    return 1
+  fi
+  if recording_path_safe "$filename" &&
+    ffmpeg -y -i "$filename" -ss 00:00:00.1 -vframes 1 -q:v 2 "$preview" -loglevel quiet 2>/dev/null &&
+    private_runtime_file_safe "$preview"; then
+    printf '%s\n' "$preview"
   else
-    finalize_recording
-    local filename=$(cat "$RECORDING_FILE" 2>/dev/null)
-    echo "$filename"
-    local preview="${filename%.mp4}-preview.png"
+    cleanup_created_preview "$preview"
+    return 1
+  fi
+}
 
-    # Generate a preview thumbnail from the first frame
-    ffmpeg -y -i "$filename" -ss 00:00:00.1 -vframes 1 -q:v 2 "$preview" -loglevel quiet 2>/dev/null
+cleanup_created_preview() {
+  local file="$1"
+  [[ $file == "$STATE_DIR"/preview.*.png ]] || return 1
+  [[ ! -e $file && ! -L $file ]] && return 0
+  /usr/bin/rm -- "$file"
+}
 
-    omarchy-notification-send "Screen recording saved" "Open with Super + Alt + , (or click this)" \
-      -t 10000 --image "${preview:-$filename}" \
-      --exec mpv -- "$filename"
+stop_screenrecording() {
+  local forced="false" preview="" status=0
+  process_matches "$RECORDING_PID" "$RECORDING_START" || return 1
 
-    # The shell loads the thumbnail into memory when the toast appears and never
-    # re-reads the file, so the preview only has to outlive that load -- not the
-    # toast. Clear it out of the recordings directory a moment later.
-    (
-      sleep 2
-      rm -f "$preview"
-    ) &
+  signal_bound_process "$RECORDING_PID" "$RECORDING_START" INT || return 1
+  if ! wait_for_bound_process_exit "$RECORDING_PID" "$RECORDING_START" 50; then
+    signal_bound_process "$RECORDING_PID" "$RECORDING_START" KILL || true
+    wait_for_bound_process_exit "$RECORDING_PID" "$RECORDING_START" 10 || true
+    forced="true"
   fi
 
-  rm -f "$RECORDING_FILE"
+  toggle_screenrecording_indicator || true
+  cleanup_bound_webcam || status=1
+
+  if [[ $forced == "true" ]]; then
+    omarchy-notification-send -u critical -t 5000 "Screen recording error" "Recording process had to be force-killed. Video may be corrupted."
+  elif recording_path_safe "$RECORDING_PATH"; then
+    finalize_recording "$RECORDING_PATH" || status=1
+    if recording_path_safe "$RECORDING_PATH"; then
+      printf '%s\n' "$RECORDING_PATH"
+      preview=$(create_preview "$RECORDING_PATH") || preview=""
+      omarchy-notification-send "Screen recording saved" "Open with Super + Alt + , (or click this)" \
+        -t 10000 --image "${preview:-$RECORDING_PATH}" \
+        --exec mpv -- "$RECORDING_PATH"
+      if [[ -n $preview ]]; then
+        (
+          /usr/bin/sleep 2
+          remove_private_runtime_file "$preview" 2>/dev/null || true
+        ) &
+      fi
+    else
+      status=1
+    fi
+  else
+    echo "Refusing unsafe screen-recording output state." >&2
+    status=1
+  fi
+
+  remove_private_runtime_file "$STATE_FILE" || status=1
+  return "$status"
 }
 
 toggle_screenrecording_indicator() {
   omarchy-shell -q omarchy.indicators refresh
 }
 
-screenrecording_active() {
-  pgrep -f "^gpu-screen-recorder" >/dev/null
+cleanup_stale_state() {
+  cleanup_bound_webcam || return 1
+  remove_private_runtime_file "$STATE_FILE"
 }
 
-finalize_recording() {
-  local latest
-  latest=$(cat "$RECORDING_FILE" 2>/dev/null)
-  [[ -f $latest ]] || return
+dispatch_screenrecording() {
+  if [[ -e $STATE_FILE || -L $STATE_FILE ]]; then
+    read_recording_state || {
+      echo "Refusing malformed or unsafe screen-recording state: $STATE_FILE" >&2
+      return 1
+    }
+    if process_matches "$RECORDING_PID" "$RECORDING_START"; then
+      stop_screenrecording
+      return
+    fi
 
-  # Re-encode only when the first GOP contains discardable warmup packets — stream copy can't
-  # trim those (it rewinds to the keyframe). Clean recordings stay on the fast stream-copy path.
-  local video_codec=(-c:v copy)
-  if ffprobe -v error -select_streams v:0 -read_intervals %+0.2 -show_entries packet=flags -of csv=p=0 "$latest" 2>/dev/null | grep -q D; then
-    video_codec=(-c:v libx264 -preset veryfast -crf 20)
+    cleanup_stale_state || {
+      echo "Could not safely clean stale screen-recording state." >&2
+      return 1
+    }
+    toggle_screenrecording_indicator || true
+    [[ $STOP_RECORDING == "true" ]] && return 1
+  elif [[ $STOP_RECORDING == "true" ]]; then
+    return 1
   fi
 
-  # Trim the first frame, and normalize audio to -14 LUFS if present, in a single pass
-  local args=(-y -ss 0.1 -i "$latest" "${video_codec[@]}")
-  if ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$latest" 2>/dev/null | grep -q audio; then
-    # Hard-mute the first 400ms to drop the PipeWire capture-open pop (a near-clipping
-    # transient around 130-200ms that a gentle fade-in can't attenuate enough), then a
-    # 50ms fade avoids a click at the boundary before loudnorm normalizes the rest.
-    args+=(-af "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05,loudnorm=I=-14:TP=-1.5:LRA=11")
-  fi
-
-  local processed="${latest%.mp4}-processed.mp4"
-  if ffmpeg "${args[@]}" "$processed" -loglevel quiet 2>/dev/null; then
-    mv "$processed" "$latest"
-  else
-    rm -f "$processed"
-  fi
+  start_screenrecording
 }
 
-if screenrecording_active; then
-  stop_screenrecording
-elif [[ $STOP_RECORDING == "true" ]]; then
-  exit 1
-else
-  start_screenrecording || cleanup_webcam
+with_state_lock() {
+  local descriptor status=0
+  exec {descriptor}<"$STATE_DIR/." || return 1
+  /usr/bin/flock -x "$descriptor" || {
+    exec {descriptor}<&-
+    return 1
+  }
+  dispatch_screenrecording || status=$?
+  if ((status != 0)) && [[ $START_CLEANUP_ARMED == "true" ]]; then
+    cleanup_pending_start
+    trap - EXIT HUP INT TERM
+  fi
+  /usr/bin/flock -u "$descriptor" || status=1
+  exec {descriptor}<&-
+  return "$status"
+}
+
+main() {
+  local old_umask status=0
+  parse_args "$@" || return 1
+  old_umask=$(umask)
+  umask 077
+  initialize_runtime_state || status=1
+  if ((status == 0)); then
+    initialize_output_dir || status=1
+  fi
+  if ((status == 0)); then
+    with_state_lock || status=$?
+  fi
+  umask "$old_umask"
+  return "$status"
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
 fi

--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -40,14 +40,64 @@ PROCESSING="${2:-slurp}"
 # hardware cursors) are baked into the frames grim captures, so force
 # hardware cursors until after grim runs and restore the setting on exit.
 NO_HW_CURSORS=$(hyprctl getoption cursor:no_hardware_cursors -j | jq '.int')
+GRIM_PID=""
+FRAME_REQUEST_PID=""
+OUTPUT_FRAME_FALLBACK_USED=0
+
+request_output_frame() {
+  local cursor_position cursor_x cursor_y
+
+  hyprctl eval 'hl.dispatch(hl.dsp.no_op())' &>/dev/null && return 0
+  (( OUTPUT_FRAME_FALLBACK_USED == 0 )) || return 0
+
+  # Legacy Hyprland has no Lua no-op dispatcher. Moving back immediately keeps
+  # the user's pointer in place while still scheduling the frame grim needs.
+  cursor_position=$(hyprctl cursorpos) || return 0
+  cursor_x=${cursor_position%,*}
+  cursor_y=${cursor_position#*, }
+  hyprctl dispatch movecursor "$((cursor_x + 1))" "$cursor_y" &>/dev/null || true
+  hyprctl dispatch movecursor "$cursor_x" "$cursor_y" &>/dev/null || true
+  OUTPUT_FRAME_FALLBACK_USED=1
+}
 
 set_no_hw_cursors() {
-  hyprctl eval "hl.config({ cursor = { no_hardware_cursors = $1 } })" &>/dev/null ||
-    hyprctl keyword cursor:no_hardware_cursors "$1" &>/dev/null
+  if hyprctl eval "hl.config({ cursor = { no_hardware_cursors = $1 } })" &>/dev/null ||
+    hyprctl keyword cursor:no_hardware_cursors "$1" &>/dev/null; then
+    # Changing this cursor setting does not itself damage an output. grim then
+    # waits for a frame on an otherwise still desktop.
+    request_output_frame
+  fi
+}
+
+run_grim() {
+  local status=0
+
+  /usr/bin/timeout --foreground --signal=TERM --kill-after=2s 15s grim "$@" &
+  GRIM_PID=$!
+  (
+    # Registering the screencopy request races the frame scheduled above. Keep
+    # asking briefly while grim is alive so at least one request lands after it
+    # has attached; timeout remains the fail-closed backstop.
+    for _ in {1..30}; do
+      /usr/bin/kill -0 "$GRIM_PID" 2>/dev/null || exit 0
+      /usr/bin/sleep 0.05
+      request_output_frame
+    done
+  ) &
+  FRAME_REQUEST_PID=$!
+
+  wait "$GRIM_PID" || status=$?
+  GRIM_PID=""
+  kill "$FRAME_REQUEST_PID" 2>/dev/null || true
+  wait "$FRAME_REQUEST_PID" 2>/dev/null || true
+  FRAME_REQUEST_PID=""
+  return "$status"
 }
 
 cleanup() {
-  [[ -n $FREEZE_PID ]] && kill $FREEZE_PID 2>/dev/null
+  [[ -z $FRAME_REQUEST_PID ]] || kill "$FRAME_REQUEST_PID" 2>/dev/null
+  [[ -z $GRIM_PID ]] || kill "$GRIM_PID" 2>/dev/null
+  [[ -n $FREEZE_PID ]] && kill "$FREEZE_PID" 2>/dev/null
   set_no_hw_cursors "$NO_HW_CURSORS"
 }
 trap cleanup EXIT
@@ -62,7 +112,7 @@ FILEPATH="$OUTPUT_DIR/$FILENAME"
 
 case "$PROCESSING" in
   slurp)
-    grim -g "$SELECTION" "$FILEPATH" || exit 1
+    run_grim -g "$SELECTION" "$FILEPATH" || exit 1
     echo "$FILEPATH"
     wl-copy --type image/png <"$FILEPATH"
 
@@ -73,10 +123,10 @@ case "$PROCESSING" in
       --exec "$SCREENSHOT_EDITOR" "$FILEPATH" || true
     ;;
   copy)
-    grim -g "$SELECTION" - | wl-copy --type image/png
+    run_grim -g "$SELECTION" - | wl-copy --type image/png
     ;;
   save)
-    grim -g "$SELECTION" "$FILEPATH" || exit 1
+    run_grim -g "$SELECTION" "$FILEPATH" || exit 1
     echo "$FILEPATH"
     ;;
 esac

--- a/bin/omarchy-capture-webcam-resize
+++ b/bin/omarchy-capture-webcam-resize
@@ -8,7 +8,14 @@
 set -euo pipefail
 
 readonly MARGIN=40
-readonly REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
+
+CURRENT_UID=$(/usr/bin/id -u)
+RUNTIME_BASE=${XDG_RUNTIME_DIR:-/run/user/$CURRENT_UID}
+[[ $RUNTIME_BASE == /* && -d $RUNTIME_BASE && ! -L $RUNTIME_BASE ]] || exit 0
+[[ $(/usr/bin/realpath -e -- "$RUNTIME_BASE") == "$RUNTIME_BASE" ]] || exit 0
+[[ $(/usr/bin/stat -c '%u:%a' -- "$RUNTIME_BASE") == "$CURRENT_UID:700" ]] || exit 0
+readonly STATE_DIR="$RUNTIME_BASE/omarchy-screenrecord"
+readonly REGION_FILE="$STATE_DIR/region"
 
 usage() {
   echo "Usage: omarchy-capture-webcam-resize <smaller|larger|reset|small|medium|large>" >&2
@@ -66,7 +73,19 @@ anchor_y=$monitor_y
 anchor_width=$monitor_width
 anchor_height=$monitor_height
 
-if [[ -f $REGION_FILE ]] && region=$(<"$REGION_FILE"); then
+region=""
+if [[ -d $STATE_DIR && ! -L $STATE_DIR ]] &&
+  [[ $(/usr/bin/realpath -e -- "$STATE_DIR") == "$STATE_DIR" ]] &&
+  [[ $(/usr/bin/stat -c '%u:%a' -- "$STATE_DIR") == "$CURRENT_UID:700" ]] &&
+  [[ -f $REGION_FILE && ! -L $REGION_FILE ]] &&
+  [[ $(/usr/bin/stat -c '%u:%a:%h' -- "$REGION_FILE") == "$CURRENT_UID:600:1" ]]; then
+  mapfile -t region_lines <"$REGION_FILE"
+  if ((${#region_lines[@]} == 1)) && printf '%s\n' "${region_lines[0]}" | /usr/bin/cmp -s - "$REGION_FILE"; then
+    region=${region_lines[0]}
+  fi
+fi
+
+if [[ -n $region ]]; then
   if [[ $region =~ ^([0-9]+)x([0-9]+)\+(-?[0-9]+)\+(-?[0-9]+)$ ]]; then
     anchor_width=${BASH_REMATCH[1]}
     anchor_height=${BASH_REMATCH[2]}

--- a/default/agents/skills/omarchy/capture.md
+++ b/default/agents/skills/omarchy/capture.md
@@ -32,9 +32,7 @@ Recordings land in the configured Videos directory (override with
 `OMARCHY_SCREENRECORD_DIR`). Resize a live webcam overlay with
 `omarchy capture webcam resize <smaller|larger|reset|small|medium|large>`.
 
-If recording fails to start, rerun with `OMARCHY_SCREENRECORD_DEBUG=true` to
-collect a log at `/tmp/omarchy-screenrecord.log` worth attaching to a bug
-report.
+If recording fails to start, rerun with `OMARCHY_SCREENRECORD_DEBUG=true` to collect a private `screenrecording.log` under `$XDG_RUNTIME_DIR/omarchy-screenrecord/` worth attaching to a bug report.
 
 ## Text Capture (OCR)
 

--- a/test/shell.d/screenrecording-security-test.sh
+++ b/test/shell.d/screenrecording-security-test.sh
@@ -1,0 +1,536 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+SCRIPT="$ROOT/bin/omarchy-capture-screenrecording"
+test_dir=$(mktemp -d)
+tracked_pids=()
+cleanup() {
+  local pid
+  for pid in "${tracked_pids[@]:-}"; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  rm -rf "$test_dir"
+}
+trap cleanup EXIT
+
+stub_bin="$test_dir/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/gpu-screen-recorder" <<'PY'
+#!/usr/bin/python3
+import os
+import signal
+import sys
+import time
+
+args = sys.argv[1:]
+output = args[args.index("-o") + 1]
+with open(os.environ["RECORDER_PID_LOG"], "a", encoding="utf-8") as log:
+    log.write(f"{os.getpid()}\n")
+
+def finish(signum, _frame):
+    with open(os.environ["RECORDER_SIGNAL_LOG"], "a", encoding="utf-8") as log:
+        log.write(f"{os.getpid()}:{signum}\n")
+    raise SystemExit(0)
+
+signal.signal(signal.SIGINT, finish)
+signal.signal(signal.SIGTERM, finish)
+delay = float(os.environ.get("RECORDER_OUTPUT_DELAY", "0"))
+deadline = time.monotonic() + delay
+while time.monotonic() < deadline:
+    time.sleep(0.02)
+with open(output, "w", encoding="utf-8") as recording:
+    recording.write("RECORDED\n")
+while True:
+    time.sleep(0.05)
+PY
+
+cat >"$stub_bin/mpv" <<'PY'
+#!/usr/bin/python3
+import os
+import signal
+import time
+
+with open(os.environ["WEBCAM_PID_LOG"], "a", encoding="utf-8") as log:
+    log.write(f"{os.getpid()}\n")
+signal.signal(signal.SIGTERM, lambda _signum, _frame: exit(0))
+while True:
+    time.sleep(0.05)
+PY
+
+cat >"$stub_bin/ffprobe" <<'SH'
+#!/bin/bash
+printf 'ffprobe\t%s\n' "$*" >>"$MEDIA_LOG"
+[[ $* == *packet=flags* && ${FFPROBE_DISCARDABLE:-false} == "true" ]] && printf 'D\n'
+[[ $* == *stream=codec_type* && ${FFPROBE_AUDIO:-false} == "true" ]] && printf 'audio\n'
+exit 0
+SH
+
+cat >"$stub_bin/ffmpeg" <<'SH'
+#!/bin/bash
+args=("$@")
+output=${args[${#args[@]} - 3]}
+printf 'ffmpeg\t%s\n' "$*" >>"$MEDIA_LOG"
+if [[ $output == *preview.*.png ]]; then
+  [[ ${FFMPEG_FAIL_PREVIEW:-false} != "true" ]] || exit 1
+  printf 'PREVIEW\n' >"$output"
+  [[ ${FFMPEG_UNSAFE_PREVIEW:-false} != "true" ]] || /usr/bin/chmod 0644 "$output"
+else
+  [[ ${FFMPEG_FAIL_PROCESS:-false} != "true" ]] || exit 1
+  printf 'PROCESSED\n' >"$output"
+  [[ ${FFMPEG_UNSAFE_PROCESS:-false} != "true" ]] || /usr/bin/chmod 0644 "$output"
+fi
+SH
+
+cat >"$stub_bin/omarchy-hyprland-monitor-focused" <<'SH'
+#!/bin/bash
+echo DP-1
+SH
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+case ${1:-} in
+clients) printf '[{"title":"WebcamOverlay"}]\n' ;;
+monitors) printf '[{"focused":true,"width":1920,"height":1080}]\n' ;;
+esac
+SH
+
+cat >"$stub_bin/v4l2-ctl" <<'SH'
+#!/bin/bash
+printf '640x360\n'
+SH
+
+cat >"$stub_bin/omarchy-capture-webcam-resize" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+printf 'shell\t%s\n' "$*" >>"$UI_LOG"
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf 'notify\t%s\n' "$*" >>"$UI_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+export PATH="$stub_bin:$PATH"
+export RECORDER_PID_LOG="$test_dir/recorder.pids"
+export RECORDER_SIGNAL_LOG="$test_dir/recorder.signals"
+export WEBCAM_PID_LOG="$test_dir/webcam.pids"
+export MEDIA_LOG="$test_dir/media.log"
+export UI_LOG="$test_dir/ui.log"
+
+wait_for_file() {
+  local file="$1" index
+  for ((index = 0; index < 200; index++)); do
+    [[ -s $file ]] && return 0
+    /usr/bin/sleep 0.01
+  done
+  return 1
+}
+
+wait_for_dead() {
+  local pid="$1" index
+  for ((index = 0; index < 200; index++)); do
+    kill -0 "$pid" 2>/dev/null || return 0
+    /usr/bin/sleep 0.01
+  done
+  return 1
+}
+
+process_start() {
+  local pid="$1" stat_line remainder
+  local -a fields=()
+  stat_line=$(</proc/$pid/stat)
+  remainder=${stat_line##*) }
+  read -r -a fields <<<"$remainder"
+  printf '%s\n' "${fields[19]}"
+}
+
+new_case() {
+  local name="$1"
+  CASE_DIR="$test_dir/cases/$name"
+  XDG_RUNTIME_DIR="$CASE_DIR/runtime"
+  OMARCHY_SCREENRECORD_DIR="$CASE_DIR/Videos"
+  STATE_DIR="$XDG_RUNTIME_DIR/omarchy-screenrecord"
+  STATE_FILE="$STATE_DIR/recording.state"
+  mkdir -m 0700 -p "$XDG_RUNTIME_DIR" "$OMARCHY_SCREENRECORD_DIR"
+  export XDG_RUNTIME_DIR OMARCHY_SCREENRECORD_DIR
+  : >"$RECORDER_PID_LOG"
+  : >"$RECORDER_SIGNAL_LOG"
+  : >"$WEBCAM_PID_LOG"
+  : >"$MEDIA_LOG"
+  : >"$UI_LOG"
+  unset RECORDER_OUTPUT_DELAY FFMPEG_FAIL_PROCESS FFMPEG_FAIL_PREVIEW
+  unset FFMPEG_UNSAFE_PROCESS FFMPEG_UNSAFE_PREVIEW FFPROBE_DISCARDABLE FFPROBE_AUDIO
+}
+
+load_state_fields() {
+  local line pattern tab=$'\t'
+  line=$(<"$STATE_FILE")
+  pattern="^version=1${tab}pid=([1-9][0-9]*)${tab}start=([1-9][0-9]*)${tab}webcam_pid=(0|[1-9][0-9]*)${tab}webcam_start=(0|[1-9][0-9]*)${tab}file=(/[^[:cntrl:]]+)$"
+  [[ $line =~ $pattern ]] || fail "test fixture could not parse recording state" "$line"
+  STATE_PID=${BASH_REMATCH[1]}
+  STATE_START=${BASH_REMATCH[2]}
+  STATE_WEBCAM_PID=${BASH_REMATCH[3]}
+  STATE_WEBCAM_START=${BASH_REMATCH[4]}
+  STATE_PATH=${BASH_REMATCH[5]}
+}
+
+initialize_empty_state_dir() {
+  "$SCRIPT" --stop-recording >/dev/null 2>&1 || true
+  [[ -d $STATE_DIR ]] || fail "screen recorder initializes its private state directory"
+}
+
+write_state() {
+  local pid="$1" start="$2" path="$3" webcam_pid="${4:-0}" webcam_start="${5:-0}"
+  printf 'version=1\tpid=%s\tstart=%s\twebcam_pid=%s\twebcam_start=%s\tfile=%s\n' \
+    "$pid" "$start" "$webcam_pid" "$webcam_start" "$path" >"$STATE_FILE"
+  chmod 0600 "$STATE_FILE"
+}
+
+new_case lifecycle
+OMARCHY_SCREENRECORD_DEBUG=true "$SCRIPT" --fullscreen >"$CASE_DIR/start.output"
+[[ $(stat -c '%a:%u' "$STATE_DIR") == "700:$(id -u)" ]] ||
+  fail "recording runtime boundary is caller-owned mode 0700"
+[[ $(stat -c '%a:%u:%h' "$STATE_FILE") == "600:$(id -u):1" ]] ||
+  fail "recording state is a private single-link mode-0600 file"
+[[ $(wc -l <"$STATE_FILE") == 1 ]] || fail "recording state is not exactly one line"
+[[ $(stat -c '%a' "$STATE_DIR/screenrecording.log") == 600 ]] ||
+  fail "debug log is not private"
+load_state_fields
+tracked_pids+=("$STATE_PID")
+kill -0 "$STATE_PID" 2>/dev/null || fail "published recorder PID is not live"
+[[ $(process_start "$STATE_PID") == "$STATE_START" ]] || fail "state does not bind the recorder start time"
+stop_output=$("$SCRIPT" --stop-recording)
+wait_for_dead "$STATE_PID" || fail "authenticated recorder survives a normal stop"
+[[ $stop_output == "$STATE_PATH" ]] || fail "successful stop does not print the recorded path" "$stop_output"
+[[ $(<"$STATE_PATH") == "PROCESSED" ]] || fail "successful recording is not finalized"
+[[ ! -e $STATE_FILE && ! -L $STATE_FILE ]] || fail "successful stop leaves recording state"
+pass "real stubbed start/stop lifecycle uses private PID-bound state and finalizes safely"
+
+new_case codec-failure
+"$SCRIPT" --fullscreen >/dev/null
+load_state_fields
+tracked_pids+=("$STATE_PID")
+FFMPEG_FAIL_PROCESS=true "$SCRIPT" --stop-recording >/dev/null
+wait_for_dead "$STATE_PID" || fail "recorder survives codec failure stop"
+[[ $(<"$STATE_PATH") == "RECORDED" ]] || fail "codec failure damages the original recording"
+! find "$OMARCHY_SCREENRECORD_DIR" -name '.omarchy-screenrecord-processed.*' -print -quit | grep -q . ||
+  fail "codec failure leaks a processed temporary"
+[[ ! -e $STATE_FILE ]] || fail "codec failure leaves recording state"
+pass "codec failure preserves the original and cleans process/state temporaries"
+
+new_case media-validation-failure
+"$SCRIPT" --fullscreen >/dev/null
+load_state_fields
+tracked_pids+=("$STATE_PID")
+if FFMPEG_UNSAFE_PROCESS=true "$SCRIPT" --stop-recording >/dev/null 2>&1; then
+  fail "unsafe codec output validation reports success"
+fi
+wait_for_dead "$STATE_PID" || fail "recorder survives codec-output validation failure"
+! find "$OMARCHY_SCREENRECORD_DIR" -name '.omarchy-screenrecord-processed.*' -print -quit | grep -q . ||
+  fail "validation failure leaks a processed temporary"
+[[ ! -e $STATE_FILE ]] || fail "validation failure leaves recording state"
+
+new_case preview-validation-failure
+"$SCRIPT" --fullscreen >/dev/null
+load_state_fields
+tracked_pids+=("$STATE_PID")
+FFMPEG_UNSAFE_PREVIEW=true "$SCRIPT" --stop-recording >/dev/null
+wait_for_dead "$STATE_PID" || fail "recorder survives preview validation failure"
+! find "$STATE_DIR" -name 'preview.*.png' -print -quit | grep -q . ||
+  fail "preview validation failure leaks a private temporary"
+pass "media validation failures clean processed and preview temporaries"
+
+new_case missing-output
+"$SCRIPT" --fullscreen >/dev/null
+load_state_fields
+tracked_pids+=("$STATE_PID")
+rm -- "$STATE_PATH"
+: >"$MEDIA_LOG"
+if "$SCRIPT" --stop-recording >/dev/null 2>&1; then
+  fail "missing recorded output reports a successful stop"
+fi
+wait_for_dead "$STATE_PID" || fail "missing output leaves the authenticated recorder running"
+[[ ! -s $MEDIA_LOG ]] || fail "missing output is passed to a media parser"
+[[ ! -e $STATE_FILE ]] || fail "missing output leaves stale state"
+
+new_case replaced-output
+"$SCRIPT" --fullscreen >/dev/null
+load_state_fields
+tracked_pids+=("$STATE_PID")
+replacement_target="$CASE_DIR/attacker-selected.mp4"
+printf 'DO-NOT-CHANGE\n' >"$replacement_target"
+rm -- "$STATE_PATH"
+ln -s "$replacement_target" "$STATE_PATH"
+: >"$MEDIA_LOG"
+if "$SCRIPT" --stop-recording >/dev/null 2>&1; then
+  fail "replaced recorded output reports a successful stop"
+fi
+wait_for_dead "$STATE_PID" || fail "replaced output leaves the authenticated recorder running"
+[[ $(<"$replacement_target") == "DO-NOT-CHANGE" ]] || fail "replacement target is modified"
+[[ ! -s $MEDIA_LOG ]] || fail "replaced output is passed to a media parser"
+pass "missing or replaced output still stops only the bound recorder without media access"
+
+new_case malformed-state
+initialize_empty_state_dir
+state_target="$CASE_DIR/state-target"
+printf 'victim-state\n' >"$state_target"
+ln -s "$state_target" "$STATE_FILE"
+if "$SCRIPT" --stop-recording >/dev/null 2>&1; then fail "symlinked recording state is accepted"; fi
+[[ $(<"$state_target") == "victim-state" ]] || fail "symlinked state target is modified"
+[[ -L $STATE_FILE ]] || fail "unsafe state symlink is silently replaced"
+rm -- "$STATE_FILE"
+printf 'not-state\n' >"$STATE_FILE"
+chmod 0600 "$STATE_FILE"
+if "$SCRIPT" --stop-recording >/dev/null 2>&1; then fail "malformed recording state is accepted"; fi
+[[ $(<"$STATE_FILE") == "not-state" ]] || fail "malformed state is rewritten"
+rm -- "$STATE_FILE"
+printf 'version=1\npid=1\n' >"$STATE_FILE"
+chmod 0600 "$STATE_FILE"
+if "$SCRIPT" --stop-recording >/dev/null 2>&1; then fail "multiline recording state is accepted"; fi
+[[ $(wc -l <"$STATE_FILE") == 2 ]] || fail "multiline state is rewritten"
+rm -- "$STATE_FILE"
+/usr/bin/sleep 30 &
+wrong_mode_pid=$!
+tracked_pids+=("$wrong_mode_pid")
+wrong_mode_start=$(process_start "$wrong_mode_pid")
+wrong_mode_path="$OMARCHY_SCREENRECORD_DIR/screenrecording-2026-08-31_12-00-00.mp4"
+printf 'UNCHANGED\n' >"$wrong_mode_path"
+write_state "$wrong_mode_pid" "$wrong_mode_start" "$wrong_mode_path"
+chmod 0644 "$STATE_FILE"
+if "$SCRIPT" --stop-recording >/dev/null 2>&1; then fail "permissive recording state mode is accepted"; fi
+kill -0 "$wrong_mode_pid" 2>/dev/null || fail "unsafe-mode state signals its selected PID"
+[[ $(stat -c '%a' "$STATE_FILE") == 644 ]] || fail "unsafe-mode state is rewritten"
+pass "symlinked, malformed, multiline, and permissive-mode state is rejected unchanged"
+
+new_case pid-reuse
+initialize_empty_state_dir
+/usr/bin/sleep 30 &
+reused_pid=$!
+tracked_pids+=("$reused_pid")
+reused_start=$(process_start "$reused_pid")
+reused_path="$OMARCHY_SCREENRECORD_DIR/screenrecording-2026-08-31_12-00-00.mp4"
+printf 'UNCHANGED\n' >"$reused_path"
+write_state "$reused_pid" "$((reused_start + 1))" "$reused_path"
+: >"$MEDIA_LOG"
+if "$SCRIPT" --stop-recording >/dev/null 2>&1; then fail "PID start-time mismatch is accepted"; fi
+kill -0 "$reused_pid" 2>/dev/null || fail "PID-reuse defense signals the mismatched process"
+[[ ! -s $MEDIA_LOG ]] || fail "stale PID state reaches media tools"
+[[ ! -e $STATE_FILE ]] || fail "stale PID state is not cleaned"
+pass "PID reuse/start-time mismatch is rejected without signaling the recycled process"
+
+new_case prefix-collision
+initialize_empty_state_dir
+prefix_dir="$CASE_DIR/Videos-evil"
+mkdir -m 0700 "$prefix_dir"
+prefix_path="$prefix_dir/screenrecording-2026-08-31_12-00-00.mp4"
+"$stub_bin/gpu-screen-recorder" -o "$prefix_path" &
+prefix_pid=$!
+tracked_pids+=("$prefix_pid")
+wait_for_file "$prefix_path" || fail "prefix-collision recorder did not create output"
+prefix_start=$(process_start "$prefix_pid")
+write_state "$prefix_pid" "$prefix_start" "$prefix_path"
+: >"$MEDIA_LOG"
+if "$SCRIPT" --stop-recording >/dev/null 2>&1; then fail "output-directory prefix collision reports success"; fi
+wait_for_dead "$prefix_pid" || fail "prefix collision leaves the bound recorder alive"
+[[ $(<"$prefix_path") == "RECORDED" ]] || fail "prefix-collision path is modified"
+[[ ! -s $MEDIA_LOG ]] || fail "prefix-collision path reaches media tools"
+pass "output-directory escapes and prefix collisions never reach media processing"
+
+new_case webcam-pre-recorder-failure
+for offset in 0 1 2 3; do
+  collision="$OMARCHY_SCREENRECORD_DIR/screenrecording-$(/usr/bin/date -d "+$offset seconds" +'%Y-%m-%d_%H-%M-%S').mp4"
+  printf 'EXISTING\n' >"$collision"
+done
+if "$SCRIPT" --fullscreen --resolution=0x0 --with-webcam --webcam-device=/dev/video42 >/dev/null 2>&1; then
+  fail "post-webcam filename collision reports success"
+fi
+wait_for_file "$WEBCAM_PID_LOG" || fail "webcam failure regression did not launch the overlay"
+webcam_pid=$(tail -n 1 "$WEBCAM_PID_LOG")
+tracked_pids+=("$webcam_pid")
+wait_for_dead "$webcam_pid" || fail "post-webcam/pre-recorder failure leaks the camera process"
+[[ ! -s $RECORDER_PID_LOG ]] || fail "filename collision launches the recorder"
+[[ ! -e $STATE_FILE && ! -e $STATE_DIR/region ]] || fail "webcam launch failure leaves runtime state"
+pass "post-webcam/pre-recorder failures clean the bound camera process and state"
+
+new_case interrupted-start
+export RECORDER_OUTPUT_DELAY=5
+"$SCRIPT" --fullscreen >/dev/null 2>&1 &
+runner_pid=$!
+wait_for_file "$RECORDER_PID_LOG" || fail "interrupted start did not launch recorder"
+interrupted_pid=$(tail -n 1 "$RECORDER_PID_LOG")
+tracked_pids+=("$runner_pid" "$interrupted_pid")
+kill -TERM "$runner_pid"
+wait "$runner_pid" 2>/dev/null || true
+wait_for_dead "$interrupted_pid" || fail "signal during start leaks the recorder process"
+[[ ! -e $STATE_FILE ]] || fail "signal during start leaves published state"
+unset RECORDER_OUTPUT_DELAY
+pass "signals during startup clean the exact pending recorder"
+
+new_case startup-timeout
+timeout_script="$CASE_DIR/omarchy-capture-screenrecording"
+sed 's/attempt < 75/attempt < 3/' "$SCRIPT" >"$timeout_script"
+chmod 0755 "$timeout_script"
+export RECORDER_OUTPUT_DELAY=5
+if "$timeout_script" --fullscreen >"$CASE_DIR/timeout.output" 2>"$CASE_DIR/timeout.error"; then
+  fail "a recorder that never publishes output reports successful startup"
+fi
+wait_for_file "$RECORDER_PID_LOG" || fail "startup-timeout regression did not launch the recorder"
+timeout_recorder_pid=$(tail -n 1 "$RECORDER_PID_LOG")
+tracked_pids+=("$timeout_recorder_pid")
+wait_for_dead "$timeout_recorder_pid" || fail "startup timeout leaks the pending recorder"
+[[ ! -e $STATE_FILE ]] || fail "startup timeout publishes stale recording state"
+grep -qF 'did not create its output' "$CASE_DIR/timeout.error" ||
+  fail "startup timeout lacks a useful error"
+unset RECORDER_OUTPUT_DELAY
+pass "recorder startup is bounded and cleans a process that never creates output"
+
+new_case concurrent
+"$SCRIPT" --fullscreen >/dev/null 2>&1 &
+first_runner=$!
+"$SCRIPT" --fullscreen >/dev/null 2>&1 &
+second_runner=$!
+first_status=0
+second_status=0
+wait "$first_runner" || first_status=$?
+wait "$second_runner" || second_status=$?
+((first_status == 0 && second_status == 0)) ||
+  fail "serialized concurrent toggle invocations fail" "$first_status/$second_status"
+[[ $(wc -l <"$RECORDER_PID_LOG") == 1 ]] || fail "concurrent invocations launch multiple recorders"
+concurrent_pid=$(<"$RECORDER_PID_LOG")
+tracked_pids+=("$concurrent_pid")
+wait_for_dead "$concurrent_pid" || fail "concurrent toggle leaves recorder running"
+[[ ! -e $STATE_FILE ]] || fail "concurrent toggle leaves recording state"
+pass "concurrent invocations serialize and cannot cross recorder sessions"
+
+(
+  source "$SCRIPT"
+  CURRENT_UID=$(id -u)
+  unsafe_runtime="$test_dir/unsafe-runtime"
+  mkdir -m 0777 "$unsafe_runtime"
+  if runtime_dir_safe "$unsafe_runtime"; then
+    exit 1
+  fi
+  safe_runtime="$test_dir/safe-runtime"
+  mkdir -m 0700 "$safe_runtime"
+  runtime_dir_safe "$safe_runtime"
+  ln -s "$safe_runtime" "$test_dir/runtime-link"
+  if runtime_dir_safe "$test_dir/runtime-link"; then
+    exit 1
+  fi
+  if runtime_dir_safe "/run/user/$CURRENT_UID"; then
+    XDG_RUNTIME_DIR=$unsafe_runtime
+    resolve_runtime_base
+    [[ $RUNTIME_BASE == "/run/user/$CURRENT_UID" ]]
+  fi
+) || fail "runtime validator accepts unsafe mode or symlink fallback"
+pass "runtime selection rejects unsafe or symlinked fallback boundaries"
+
+(
+  source "$SCRIPT"
+  CURRENT_UID=$(id -u)
+  config_home="$test_dir/config-home"
+  mkdir -m 0700 -p "$config_home/.config"
+  chmod 0700 "$config_home/.config"
+  printf 'XDG_VIDEOS_DIR="$HOME/Videos"\n' >"$config_home/.config/user-dirs.dirs"
+  chmod 0600 "$config_home/.config/user-dirs.dirs"
+  user_dirs_config_safe "$config_home/.config" "$config_home/.config/user-dirs.dirs"
+  mv "$config_home/.config/user-dirs.dirs" "$config_home/real-user-dirs"
+  ln -s "$config_home/real-user-dirs" "$config_home/.config/user-dirs.dirs"
+  if user_dirs_config_safe "$config_home/.config" "$config_home/.config/user-dirs.dirs"; then
+    exit 1
+  fi
+) || fail "user-dirs config validator accepts a symlinked source file"
+pass "user-dirs shell config is sourced only from a private regular account-owned path"
+
+(
+  source "$SCRIPT"
+  CURRENT_UID=$(id -u)
+  STATE_DIR="$test_dir/chmod-runtime"
+  OUTPUT_DIR="$test_dir/chmod-output"
+  mkdir -m 0700 "$STATE_DIR" "$OUTPUT_DIR"
+  recording="$OUTPUT_DIR/screenrecording-2026-08-31_12-00-00.mp4"
+  printf 'ORIGINAL\n' >"$recording"
+  chmod 0600 "$recording"
+  set_private_mode() { return 1; }
+  if finalize_recording "$recording"; then
+    exit 1
+  fi
+  if create_preview "$recording" >/dev/null; then
+    exit 1
+  fi
+  ! find "$OUTPUT_DIR" -name '.omarchy-screenrecord-processed.*' -print -quit | grep -q .
+  ! find "$STATE_DIR" -name 'preview.*.png' -print -quit | grep -q .
+) || fail "injected private-mode failure leaks media temporaries"
+pass "injected chmod failures clean all newly allocated media temporaries"
+
+! rg -n '\b(pgrep|pkill)\b|/tmp/omarchy-screenrecord' "$SCRIPT" >/dev/null ||
+  fail "screen recorder retains system-wide process authorization or shared predictable state"
+pass "screen recorder contains no system-wide process matching or shared predictable state"
+
+cross_uid_probe="$test_dir/cross-uid-screenrecord-probe.sh"
+cat >"$cross_uid_probe" <<'PROBE'
+#!/bin/bash
+set -euo pipefail
+
+mount --bind "$PROBE_ROOT" /mnt
+mount -t tmpfs -o mode=1777 tmpfs /tmp
+mkdir -m 0755 /tmp/stubs
+cat >/tmp/stubs/omarchy-notification-send <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod 0755 /tmp/stubs/omarchy-notification-send
+
+mkdir -m 0700 /tmp/runtime-victim /tmp/Videos
+chown 1000:1000 /tmp/runtime-victim /tmp/Videos
+target=/tmp/Videos/attacker-selected.mp4
+printf 'VICTIM-ORIGINAL\n' >"$target"
+chown 1000:1000 "$target"
+chmod 0600 "$target"
+
+setpriv --reuid=1001 --regid=1001 --clear-groups bash -c 'printf "%s\n" "$1" > /tmp/omarchy-screenrecord-filename' _ "$target"
+[[ $(stat -c '%u' /tmp/omarchy-screenrecord-filename) == 1001 ]]
+
+if setpriv --reuid=1000 --regid=1000 --clear-groups env PATH=/tmp/stubs:/usr/bin XDG_RUNTIME_DIR=/tmp/runtime-victim OMARCHY_SCREENRECORD_DIR=/tmp/Videos /mnt/bin/omarchy-capture-screenrecording --stop-recording 2>/dev/null; then
+  exit 2
+fi
+
+[[ $(<"$target") == "VICTIM-ORIGINAL" ]]
+[[ $(stat -c '%u' /tmp/omarchy-screenrecord-filename) == 1001 ]]
+[[ $(< /tmp/omarchy-screenrecord-filename) == "$target" ]]
+[[ $(stat -c '%u:%a' /tmp/runtime-victim/omarchy-screenrecord) == "1000:700" ]]
+
+foreign_state=/tmp/runtime-victim/omarchy-screenrecord/recording.state
+printf 'version=1\tpid=1\tstart=1\twebcam_pid=0\twebcam_start=0\tfile=%s\n' "$target" >"$foreign_state"
+chown 1001:1001 "$foreign_state"
+chmod 0600 "$foreign_state"
+if setpriv --reuid=1000 --regid=1000 --clear-groups env PATH=/tmp/stubs:/usr/bin XDG_RUNTIME_DIR=/tmp/runtime-victim OMARCHY_SCREENRECORD_DIR=/tmp/Videos /mnt/bin/omarchy-capture-screenrecording --stop-recording 2>/dev/null; then
+  exit 3
+fi
+[[ $(stat -c '%u' "$foreign_state") == 1001 ]]
+[[ $(<"$target") == "VICTIM-ORIGINAL" ]]
+rm -- "$foreign_state"
+if setpriv --reuid=1001 --regid=1001 --clear-groups touch /tmp/runtime-victim/omarchy-screenrecord/recording.state 2>/dev/null; then
+  exit 4
+fi
+PROBE
+chmod +x "$cross_uid_probe"
+
+if unshare --user --map-auto --map-root-user true 2>/dev/null; then
+  if PROBE_ROOT="$ROOT" unshare --user --map-auto --map-root-user --mount "$cross_uid_probe"; then
+    pass "a second UID cannot steer stop/finalization through pre-created shared state"
+  else
+    fail "second-UID shared-state probe fails under available user/mount namespaces"
+  fi
+else
+  pass "user/mount namespaces unavailable; skipping second-UID shared-state probe"
+fi

--- a/test/shell.d/screenrecording-test.sh
+++ b/test/shell.d/screenrecording-test.sh
@@ -229,10 +229,12 @@ if [[ -s $OMARCHY_TEST_HYPRCTL_ARGS ]]; then
 fi
 pass "webcam resize ignores other windows"
 
-region_file="$XDG_RUNTIME_DIR/omarchy-screenrecord-region"
+mkdir -m 0700 "$XDG_RUNTIME_DIR/omarchy-screenrecord"
+region_file="$XDG_RUNTIME_DIR/omarchy-screenrecord/region"
 
 : >"$OMARCHY_TEST_HYPRCTL_ARGS"
 echo "800x600+100+100" >"$region_file"
+chmod 0600 "$region_file"
 "$ROOT/bin/omarchy-capture-webcam-resize" reset
 
 printf '%s\n' \
@@ -251,6 +253,7 @@ printf '%s\n' \
 for region in "not-a-region" ""; do
   : >"$OMARCHY_TEST_HYPRCTL_ARGS"
   printf '%s' "$region" >"$region_file"
+  chmod 0600 "$region_file"
   "$ROOT/bin/omarchy-capture-webcam-resize" reset
 
   if ! cmp -s "$OMARCHY_TEST_HYPRCTL_ARGS" "$expected_hyprctl_args"; then
@@ -263,6 +266,7 @@ pass "webcam falls back to the monitor for an unusable region"
 # ladder, so the three sizes stay distinct and each one fits inside the margins
 : >"$OMARCHY_TEST_HYPRCTL_ARGS"
 echo "200x1200+0+0" >"$region_file"
+chmod 0600 "$region_file"
 for size in small medium large; do
   "$ROOT/bin/omarchy-capture-webcam-resize" "$size"
 done

--- a/test/shell.d/screenshot-sanity-test.sh
+++ b/test/shell.d/screenshot-sanity-test.sh
@@ -20,6 +20,13 @@ trap cleanup EXIT
 
 require_compositor "screenshot sanity test"
 
+# A secure ext-session-lock intentionally replaces the bar with the lock view,
+# so a compositor screenshot cannot prove bar rendering until the user unlocks.
+if "$ROOT/bin/omarchy-hyprland-session-locked"; then
+  pass "session is locked; skipping screenshot sanity test"
+  exit 0
+fi
+
 if ! command -v quickshell >/dev/null 2>&1; then
   pass "quickshell not installed; skipping screenshot sanity test"
   exit 0


### PR DESCRIPTION
## Summary

A second local UID could plant the global filename state and make the victim finalizer rewrite an attacker-selected victim-owned media file.

Finding: **OM-SEC-11**

## Security impact

A second local account can redirect finalization onto a victim-owned media file and cause the victim process to overwrite it.

## Remediation

State moved to a validated private runtime directory and is locked, atomic, mode 0600, and bound to PID/start time/owner/token/output. Finalization is confined to the configured recording directory.

The reviewed implementation applies these concrete controls:

- All state is inside a validated private runtime directory.
- State publication is locked, atomic, single-record, and mode 0600.
- The recorder identity includes PID, process start time, owner, token, and expected output.
- Finalization stays inside the configured recording directory and refuses stale, malformed, linked, foreign, or swapped state.
- Startup/finalization are bounded and signal cleanup is identity-aware.

## Validation

The baseline cross-UID overwrite succeeded; PID reuse, path escape, symlink, malformed state, codec/startup failures, cancellation, concurrency, and signal tests pass.

**Detailed regression coverage:** screenrecording-security-test.sh plus screenrecording-test.sh cover two-UID poisoning, PID reuse, path escape, symlinks, malformed state, startup timeout, codec failure, cancellation, signals, and normal finalization.

Current status: Fixed.

All changed shell files on this branch pass `bash -n`, and `git diff --check` passes.

## Coordination

This is one finding in a coordinated 21-finding disclosure sent to the Omarchy security team. The corresponding Markdown report contains the affected-code analysis and safe reproduction.

This branch is independently reviewable against `quattro`.

