### PR TITLE
[codex] OM-SEC-16: Validate source roots before privileged publication

### DIFF
--- a/bin/omarchy-channel-set
+++ b/bin/omarchy-channel-set
@@ -1,10 +1,57 @@
-#!/bin/bash
+#!/bin/bash -p
 
 # omarchy:summary=Set the Omarchy package channel.
 # omarchy:args=<stable|rc|edge|dev>
 # omarchy:requires-sudo=true
 
+if [[ $- != *p* ]]; then
+  echo "Refusing an unsafe Bash startup for channel switching." >&2
+  exit 126
+fi
+
+require_privileged_bash_startup() {
+  [[ $- == *p* ]] || return 1
+  /usr/bin/env -i /usr/bin/bash -p -c '
+    [[ $1 =~ ^[1-9][0-9]*$ ]] || exit 1
+    mapfile -d "" -t argv <"/proc/$1/cmdline" || exit 1
+    executable=$(/usr/bin/readlink -e -- "/proc/$1/exe") || exit 1
+    [[ $executable == /usr/bin/bash ]]
+    [[ ${argv[0]:-} == /bin/bash || ${argv[0]:-} == /usr/bin/bash ]]
+    [[ ${argv[1]:-} == -p ]]
+  ' omarchy-bash-startup "$$"
+}
+if ! require_privileged_bash_startup; then
+  echo "Refusing an unsafe Bash startup for channel switching." >&2
+  exit 126
+fi
+unset -f require_privileged_bash_startup
+
 set -euo pipefail
+
+sanitize_bash_startup_environment() {
+  local environment_entry environment_name
+  local needs_reexec=0
+  local -a environment_unsets=(-u BASH_ENV -u ENV)
+
+  [[ -z ${BASH_ENV+x} && -z ${ENV+x} ]] || needs_reexec=1
+  while IFS= read -r -d '' environment_entry; do
+    environment_name="${environment_entry%%=*}"
+    if [[ $environment_name == BASH_FUNC_*%% ]]; then
+      environment_unsets+=(-u "$environment_name")
+      needs_reexec=1
+    fi
+  done < <(/usr/bin/env -0)
+
+  if (( needs_reexec )); then
+    exec /usr/bin/env "${environment_unsets[@]}" /usr/bin/bash -p "$0" "$@"
+  fi
+}
+sanitize_bash_startup_environment "$@"
+unset -f sanitize_bash_startup_environment
+
+cleanup_sudo_credentials() {
+  /usr/bin/sudo -k || true
+}
 
 usage() { echo "Usage: omarchy-channel-set [stable|rc|edge|dev]"; }
 fail() { echo "Error: $*" >&2; exit 1; }
@@ -17,7 +64,7 @@ It's exclusively intended for developers working on Omarchy itself.
 
 WARNING
 
-  gum confirm --default=false "Switch to dev channel?"
+  /usr/bin/gum confirm --default=false "Switch to dev channel?"
 }
 
 validate_dev_checkout() {
@@ -34,12 +81,43 @@ validate_dev_checkout() {
 
 link_dev_checkout() {
   local checkout="$1"
-  [[ -d $checkout/.git ]] || git clone https://github.com/basecamp/omarchy.git "$checkout"
+  [[ -d $checkout/.git ]] || /usr/bin/git clone https://github.com/basecamp/omarchy.git "$checkout"
 
-  omarchy-dev-link "$checkout" --no-reboot
+  /usr/bin/omarchy-dev-link "$checkout" --no-reboot
+}
+
+prepare_non_reusable_sudo() {
+  local wrapper=/usr/share/omarchy/default/omarchy/sudo-no-update/sudo
+  local current="$wrapper" canonical="" owner="" mode=""
+
+  LC_ALL=C /usr/bin/sudo -h 2>&1 | /usr/bin/grep -Eq '^usage: sudo .*\[[^]]*N[^]]*\]' ||
+    fail "This sudo does not support --no-update; refusing a mixed-trust channel switch."
+  [[ -f $wrapper && -x $wrapper && ! -L $wrapper ]] ||
+    fail "Trusted no-update sudo wrapper is missing."
+  canonical=$(/usr/bin/realpath -e -- "$wrapper") || fail "Cannot resolve the trusted no-update sudo wrapper."
+  [[ $canonical == "$wrapper" ]] || fail "Trusted no-update sudo wrapper is redirected."
+  while :; do
+    [[ ! -L $current ]] || fail "Trusted no-update sudo path contains a symlink."
+    read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$current") || fail "Cannot inspect the trusted no-update sudo path."
+    [[ $owner == "0" ]] && (( (8#$mode & 0022) == 0 )) ||
+      fail "Trusted no-update sudo path is writable by an untrusted account."
+    [[ $current == "/usr/share/omarchy" ]] && break
+    current=${current%/*}
+  done
+
+  PATH="${wrapper%/sudo}:/usr/bin:/usr/sbin:/bin:/sbin"
+  export PATH
 }
 
 (( $# > 0 )) || { usage; exit 1; }
+user_path="${PATH:-/usr/bin:/bin}"
+
+# Channel switching is a composite privileged workflow. Start cold, pin every
+# helper to the installed system paths, and make helper sudo calls non-caching
+# before any command that can execute user-controlled Git/tool configuration.
+prepare_non_reusable_sudo
+trap cleanup_sudo_credentials EXIT
+/usr/bin/sudo -k || exit 1
 
 dev_checkout=""
 channel="$1"
@@ -79,21 +157,31 @@ fi
 if [[ -n $dev_checkout ]]; then
   link_dev_checkout "$dev_checkout"
   export OMARCHY_PATH="$dev_checkout"
-  export PATH="$OMARCHY_PATH/bin:$PATH"
-  omarchy-state set reboot-required
+  /usr/bin/omarchy-state set reboot-required
 fi
 
-omarchy-refresh-pacman "$pacman_channel"
+# The refresh hook is executable user code. Defer it across this composite
+# workflow so a detached hook child cannot wait for the package switch or the
+# update pipeline to publish a sudo timestamp. The installed fixed path cannot
+# be replaced through the caller's PATH.
+OMARCHY_SUDO_NO_UPDATE=1 /usr/bin/omarchy-refresh-pacman "$pacman_channel" --defer-hook
 # --ask 4 accepts omarchy <-> omarchy-dev replacement prompts without file overwrites.
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -S --needed --noconfirm --ask 4 "${packages[@]}"
+/usr/bin/sudo -N -- /usr/bin/env PATH=/usr/bin:/usr/sbin:/bin:/sbin \
+  OMARCHY_UPDATE_PACMAN=1 /usr/bin/pacman -S --needed --noconfirm --ask 4 "${packages[@]}"
 
 if [[ -z $dev_checkout ]]; then
-  omarchy-dev-unlink --no-reboot
+  /usr/bin/omarchy-dev-unlink --no-reboot
   export OMARCHY_PATH=/usr/share/omarchy
 
   if (( leaving_dev )); then
-    omarchy-state set reboot-required
+    /usr/bin/omarchy-state set reboot-required
   fi
 fi
 
-omarchy-update -y
+PATH="$user_path" OMARCHY_SUDO_NO_UPDATE=1 /usr/bin/omarchy-update -y
+
+# This is the final action. The trusted refresh command re-resolves the source
+# root from root-owned /etc/omarchy.conf, invalidates first, and invokes the
+# hook exactly once. Its own EXIT cleanup also leaves any hook-authenticated
+# credential cold. If an earlier step fails, the deferred hook is skipped.
+PATH="$user_path" /usr/bin/omarchy-refresh-pacman --run-deferred-hook

--- a/bin/omarchy-dev-pkg-test
+++ b/bin/omarchy-dev-pkg-test
@@ -7,6 +7,11 @@
 
 set -euo pipefail
 
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+unset BASH_ENV ENV CDPATH GLOBIGNORE
+umask 077
+
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   cat <<USAGE
 Usage: omarchy dev pkg-test [package-name] [path-to-checkout]
@@ -37,7 +42,7 @@ remove_pkgver_function() {
   local pkgbuild="$1"
   local tmp="$pkgbuild.tmp"
 
-  awk '
+  /usr/bin/awk '
     /^pkgver\(\)[[:space:]]*\{/ {
       in_pkgver = 1
       depth = 0
@@ -55,7 +60,7 @@ remove_pkgver_function() {
     }
     { print }
   ' "$pkgbuild" >"$tmp"
-  mv "$tmp" "$pkgbuild"
+  /usr/bin/mv "$tmp" "$pkgbuild"
 }
 
 dev_package_name() {
@@ -82,6 +87,15 @@ else
 fi
 PKGBUILDS_ROOT="${OMARCHY_PKGBUILDS_DIR:-$HOME/Work/omarchy/omarchy-pkgs/pkgbuilds}"
 
+for argument in "${MAKEPKG_ARGS[@]}"; do
+  case $argument in
+    -- | --config | --config=* | PACMAN=* | PACMAN+=* | PACMAN_AUTH=* | PACMAN_AUTH+=* | MAKEPKG_CONF=* | BASH_ENV=* | ENV=*)
+      echo "Error: makepkg argument '$argument' would bypass the fixed privilege boundary." >&2
+      exit 2
+      ;;
+  esac
+done
+
 if [[ ! -d "$CHECKOUT" ]]; then
   echo "Error: checkout not found at $CHECKOUT" >&2
   exit 1
@@ -95,43 +109,152 @@ for PKG in "${PKGS[@]}"; do
   fi
 done
 
-build_dir=$(mktemp -d -t omarchy-dev-pkg-test.XXXXXX)
-trap 'rm -rf "$build_dir"' EXIT
+trusted_system_command() {
+  local command=$1 require_setuid=${2:-false}
+  local canonical owner mode links
+
+  [[ $command == /usr/bin/* && -f $command && -x $command && ! -L $command ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$command") || return 1
+  [[ $canonical == "$command" ]] || return 1
+  read -r owner mode links < <(/usr/bin/stat -Lc '%u %a %h' -- "$command") || return 1
+  [[ $owner == 0 && $links == 1 ]] || return 1
+  (( (8#$mode & 0022) == 0 )) || return 1
+  [[ $require_setuid != true ]] || (( (8#$mode & 04000) != 0 ))
+}
+
+for command in /usr/bin/realpath /usr/bin/stat /usr/bin/sudo /usr/bin/pacman /usr/bin/makepkg /usr/bin/setpriv; do
+  require_setuid=false
+  [[ $command != /usr/bin/sudo ]] || require_setuid=true
+  if ! trusted_system_command "$command" "$require_setuid"; then
+    echo "Refusing the package build because $command is not a trusted system command." >&2
+    exit 1
+  fi
+done
+
+/usr/bin/sudo -k >/dev/null || {
+  echo "Unable to start the package build with a cold sudo credential state." >&2
+  exit 1
+}
+if ! /usr/bin/sudo -N -V >/dev/null 2>&1; then
+  echo "This sudo does not support --no-update; refusing to run package build code." >&2
+  exit 1
+fi
+
+build_dir=$(/usr/bin/mktemp -d -t omarchy-dev-pkg-test.XXXXXX)
+
+cleanup() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  /usr/bin/rm -rf -- "$build_dir"
+  if ! /usr/bin/sudo -k >/dev/null 2>&1; then
+    echo "Failed to invalidate sudo credentials after the package build." >&2
+    (( status != 0 )) || status=1
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # pkgver=dev.<sha>[.dirty] so pacman -Q makes the source obvious.
-short_sha=$(git -C "$CHECKOUT" rev-parse --short HEAD 2>/dev/null || echo "local")
+short_sha=$(/usr/bin/git -C "$CHECKOUT" rev-parse --short HEAD 2>/dev/null || echo "local")
 dirty=""
-if [[ -d "$CHECKOUT/.git" ]] && [[ -n "$(git -C "$CHECKOUT" status --porcelain)" ]]; then
+if [[ -d "$CHECKOUT/.git" ]] && [[ -n "$(/usr/bin/git -C "$CHECKOUT" status --porcelain)" ]]; then
   dirty=".dirty"
 fi
 new_pkgver="dev.${short_sha}${dirty}"
 
+dependency_name() {
+  local dependency=$1 name=${1%%[<>=]*}
+  [[ $name =~ ^[a-z0-9][a-z0-9@._+:-]*$ ]] || return 1
+  printf '%s\n' "$name"
+}
+
+install_build_dependencies() {
+  local srcinfo=$1 architecture dependency status missing_output name
+  local dependencies=() missing=()
+  local -A seen=()
+  architecture=$(/usr/bin/uname -m)
+
+  while IFS= read -r line; do
+    if [[ $line =~ ^$'\t'(depends|makedepends|checkdepends)(_([a-zA-Z0-9_]+))?\ =\ (.+)$ ]]; then
+      [[ -z ${BASH_REMATCH[3]} || ${BASH_REMATCH[3]} == "$architecture" ]] || continue
+      dependency=${BASH_REMATCH[4]}
+      dependency_name "$dependency" >/dev/null || {
+        echo "Error: unsafe dependency in generated .SRCINFO: $dependency" >&2
+        return 1
+      }
+      dependencies+=("$dependency")
+    fi
+  done <"$srcinfo"
+
+  (( ${#dependencies[@]} )) || return 0
+  if missing_output=$(/usr/bin/pacman -T -- "${dependencies[@]}"); then
+    return 0
+  else
+    status=$?
+  fi
+  (( status == 127 )) || return "$status"
+
+  while IFS= read -r dependency; do
+    [[ -n $dependency ]] || continue
+    name=$(dependency_name "$dependency") || {
+      echo "Error: pacman returned an unsafe dependency name: $dependency" >&2
+      return 1
+    }
+    if [[ -z ${seen[$name]+x} ]]; then
+      seen[$name]=1
+      missing+=("$name")
+    fi
+  done <<<"$missing_output"
+  (( ${#missing[@]} )) || return 1
+  /usr/bin/sudo -N -- /usr/bin/pacman -S --asdeps --needed --noconfirm -- "${missing[@]}"
+}
+
+built_pkgs=()
 for PKG in "${PKGS[@]}"; do
   PKGBUILD_DIR="$PKGBUILDS_ROOT/$PKG"
   package_build_dir="$build_dir/$PKG"
-  mkdir -p "$package_build_dir"
-  cp -a "$PKGBUILD_DIR/." "$package_build_dir/"
+  /usr/bin/mkdir -p "$package_build_dir"
+  /usr/bin/cp -a "$PKGBUILD_DIR/." "$package_build_dir/"
 
   remove_pkgver_function "$package_build_dir/PKGBUILD"
-  sed -i "s/^pkgver=.*/pkgver=${new_pkgver}/" "$package_build_dir/PKGBUILD"
+  /usr/bin/sed -i "s/^pkgver=.*/pkgver=${new_pkgver}/" "$package_build_dir/PKGBUILD"
 
   echo "Building $PKG ${new_pkgver} from $CHECKOUT"
   echo "  build dir: $package_build_dir"
   echo "  PKGBUILD : $PKGBUILD_DIR/PKGBUILD"
   echo
 
+  srcinfo="$package_build_dir/.SRCINFO.omarchy"
   (
     cd "$package_build_dir"
-    OMARCHY_SRC="$CHECKOUT" makepkg -s --skipchecksums --noconfirm "${MAKEPKG_ARGS[@]}"
+    OMARCHY_SRC="$CHECKOUT" /usr/bin/setpriv --no-new-privs /usr/bin/makepkg --printsrcinfo
+  ) >"$srcinfo"
+  install_build_dependencies "$srcinfo"
+
+  (
+    cd "$package_build_dir"
+    # Dependency installation is deliberately separate. Even if a PKGBUILD
+    # mutates makepkg's internal NODEPS/PACMAN_AUTH variables, no_new_privs in
+    # the fixed launcher prevents any setuid program from granting it root.
+    OMARCHY_SRC="$CHECKOUT" /usr/bin/setpriv --no-new-privs /usr/bin/makepkg \
+      --nodeps --skipchecksums --noconfirm "${MAKEPKG_ARGS[@]}"
   )
 
-  # Install separately so we can pass --overwrite='*' (makepkg -i can't).
-  # Dev builds frequently conflict with files left behind by previous
-  # script-installed Omarchy versions; the build is the authoritative state.
-  built_pkg=$(ls -t "$package_build_dir"/*.pkg.tar.* 2>/dev/null | grep -v '\.sig$' | head -1)
+  built_pkg=""
+  for candidate in "$package_build_dir"/*.pkg.tar.*; do
+    [[ -f $candidate && $candidate != *.sig ]] || continue
+    [[ -z $built_pkg || $candidate -nt $built_pkg ]] && built_pkg=$candidate
+  done
   if [[ -z $built_pkg ]]; then
     echo "Error: no built package found in $package_build_dir" >&2
     exit 1
   fi
-  sudo pacman -U --noconfirm --overwrite='*' "$built_pkg"
+  built_pkgs+=("$built_pkg")
 done
+
+# Install the built package set in one transaction so its
+# provides/conflicts/dependencies resolve as they do from the repository.
+/usr/bin/sudo -N -- /usr/bin/pacman -U --noconfirm -- "${built_pkgs[@]}"

--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -4,13 +4,128 @@
 # omarchy:requires-sudo=true
 # omarchy:args=[--force] [--no-rebuild]
 
+set -e
+
+trusted_omarchy_source_root() {
+  local LC_ALL=C
+  local config=/etc/omarchy.conf default_root=/usr/share/omarchy configured_root=""
+  local canonical="" owner="" mode="" links="" size="" line="" extra=""
+  local encoded="" decoded="" expected="" character="" directory="" current_uid=""
+  local index=0 escaped=0 config_fd read_status=0
+  current_uid=$(/usr/bin/id -u) || return 1
+  trusted_directory_chain() {
+    local directory=$1 allow_user_owner=$2 canonical owner mode
+    while :; do
+      [[ -d $directory && ! -L $directory ]] || return 1
+      canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+      [[ $canonical == "$directory" ]] || return 1
+      read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+      if [[ $owner != 0 ]] && ! { [[ $allow_user_owner == true ]] && [[ $owner == "$current_uid" ]]; }; then return 1; fi
+      (( (8#$mode & 0022) == 0 )) || return 1
+      [[ $directory == / ]] && break
+      directory=${directory%/*}; [[ -n $directory ]] || directory=/
+    done
+  }
+  if [[ ! -e $config && ! -L $config ]]; then
+    configured_root=$default_root
+  else
+    [[ -f $config && ! -L $config ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$config") || return 1
+    [[ $canonical == "$config" ]] || return 1
+    trusted_directory_chain "${config%/*}" false || return 1
+    read -r owner mode links size < <(/usr/bin/stat -Lc '%u %a %h %s' -- "$config") || return 1
+    [[ $owner == 0 && $links == 1 ]] || return 1
+    (( (8#$mode & 0022) == 0 && size > 0 && size <= 4096 )) || return 1
+    exec {config_fd}<"$config" || return 1
+    if ! IFS= read -r line <&$config_fd; then exec {config_fd}<&-; return 1; fi
+    IFS= read -r extra <&$config_fd || read_status=$?
+    exec {config_fd}<&-
+    (( read_status != 0 )) && [[ -z $extra ]] || return 1
+    (( size == ${#line} + 1 )) || return 1
+    [[ $line == 'export OMARCHY_PATH="'*'"' ]] || return 1
+    encoded=${line#'export OMARCHY_PATH="'}; encoded=${encoded%'"'}
+    [[ $encoded != *[$'\n\r\t']* ]] || return 1
+    for (( index = 0; index < ${#encoded}; index++ )); do
+      character=${encoded:index:1}
+      if (( escaped )); then
+        case "$character" in '\' | '"' | '$' | '`') decoded+=$character ;; *) return 1 ;; esac
+        escaped=0
+      elif [[ $character == '\' ]]; then escaped=1
+      elif [[ $character == '"' ]]; then return 1
+      else decoded+=$character
+      fi
+    done
+    (( escaped == 0 )) || return 1
+    expected=$decoded
+    expected=${expected//\\/\\\\}; expected=${expected//\"/\\\"}
+    expected=${expected//\$/\\\$}; expected=${expected//\`/\\\`}
+    [[ $line == "export OMARCHY_PATH=\"$expected\"" ]] || return 1
+    configured_root=$decoded
+  fi
+  [[ $configured_root == /* && -d $configured_root && ! -L $configured_root ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$configured_root") || return 1
+  [[ $canonical == "$configured_root" ]] || return 1
+  if [[ $configured_root == "$default_root" ]]; then
+    trusted_directory_chain "$configured_root" false || return 1
+  else
+    trusted_directory_chain "$configured_root" true || return 1
+    owner=$(/usr/bin/stat -Lc '%u' -- "$configured_root") || return 1
+    [[ $owner == 0 || $owner == "$current_uid" ]] || return 1
+  fi
+  printf '%s\n' "$configured_root"
+}
+
+trusted_omarchy_source_file() {
+  local relative=$1 source="$OMARCHY_PATH/$1" canonical owner mode links directory current_uid
+  current_uid=$(/usr/bin/id -u) || return 1
+  [[ $relative != /* && $relative != *'/../'* && $relative != '../'* && $relative != *'/..' ]] || return 1
+  [[ -f $source && ! -L $source ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$source") || return 1
+  [[ $canonical == "$source" && $canonical == "$OMARCHY_PATH/"* ]] || return 1
+  read -r owner mode links < <(/usr/bin/stat -Lc '%u %a %h' -- "$source") || return 1
+  [[ $links == 1 ]] || return 1
+  (( (8#$mode & 0022) == 0 )) || return 1
+  if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then [[ $owner == 0 ]] || return 1
+  else [[ $owner == 0 || $owner == "$current_uid" ]] || return 1; fi
+  directory=${source%/*}
+  while [[ $directory == "$OMARCHY_PATH" || $directory == "$OMARCHY_PATH/"* ]]; do
+    [[ -d $directory && ! -L $directory ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+    [[ $canonical == "$directory" ]] || return 1
+    read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+    (( (8#$mode & 0022) == 0 )) || return 1
+    if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then [[ $owner == 0 ]] || return 1
+    else [[ $owner == 0 || $owner == "$current_uid" ]] || return 1; fi
+    [[ $directory == "$OMARCHY_PATH" ]] && break
+    directory=${directory%/*}
+  done
+  printf '%s\n' "$source"
+}
+
 FORCE=false
 NO_REBUILD=false
 for arg in "$@"; do
   case "$arg" in
     --force) FORCE=true ;;
     --no-rebuild) NO_REBUILD=true ;;
+    *) echo "Usage: omarchy-hibernation-setup [--force] [--no-rebuild]" >&2; exit 2 ;;
   esac
+done
+
+unset OMARCHY_PATH
+if ! OMARCHY_PATH=$(trusted_omarchy_source_root); then
+  echo "Refusing to configure hibernation from an untrusted Omarchy source root." >&2
+  exit 1
+fi
+export OMARCHY_PATH
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+
+for required_source in bin/omarchy-cmd-missing bin/omarchy-system-reboot; do
+  trusted_omarchy_source_file "$required_source" >/dev/null || {
+    echo "Refusing an untrusted hibernation helper: $required_source" >&2
+    exit 1
+  }
 done
 
 if [[ ! -f /sys/power/image_size ]]; then
@@ -21,7 +136,7 @@ fi
 # When --no-rebuild is set, the caller is responsible for the UKI rebuild
 # (e.g. running before limine-mkinitcpio-hook is installed during initial
 # install), so we only require limine-mkinitcpio when we'd invoke it ourselves.
-if ! $NO_REBUILD && omarchy-cmd-missing limine-mkinitcpio; then
+if ! $NO_REBUILD && "$OMARCHY_PATH/bin/omarchy-cmd-missing" limine-mkinitcpio; then
   echo "Skipping hibernation setup (requires Limine bootloader)"
   exit 0
 fi
@@ -31,15 +146,15 @@ SWAP_FILE="/swap/swapfile"
 RESUME_DROP_IN="/etc/limine-entry-tool.d/resume.conf"
 
 # Check if hibernation is already configured
-if [[ -f $MKINITCPIO_CONF ]] && grep -q "^HOOKS+=(resume)$" "$MKINITCPIO_CONF"; then
+if [[ -f $MKINITCPIO_CONF ]] && /usr/bin/grep -q "^HOOKS+=(resume)$" "$MKINITCPIO_CONF"; then
   # Fix empty resume_offset if btrfs map-swapfile failed during initial setup
-  if [[ -f $RESUME_DROP_IN ]] && grep -q 'resume_offset="$' "$RESUME_DROP_IN" && [[ -f $SWAP_FILE ]]; then
-    RESUME_OFFSET=$(sudo btrfs inspect-internal map-swapfile -r "$SWAP_FILE" 2>/dev/null)
+  if [[ -f $RESUME_DROP_IN ]] && /usr/bin/grep -q 'resume_offset="$' "$RESUME_DROP_IN" && [[ -f $SWAP_FILE ]]; then
+    RESUME_OFFSET=$(/usr/bin/sudo /usr/bin/btrfs inspect-internal map-swapfile -r "$SWAP_FILE" 2>/dev/null)
     if [[ -n $RESUME_OFFSET ]]; then
       echo "Fixing empty resume_offset ($RESUME_OFFSET)"
-      sudo sed -i "s/resume_offset=\"$/resume_offset=$RESUME_OFFSET\"/" "$RESUME_DROP_IN"
+      /usr/bin/sudo /usr/bin/sed -i "s/resume_offset=\"$/resume_offset=$RESUME_OFFSET\"/" "$RESUME_DROP_IN"
       if ! $NO_REBUILD; then
-        sudo limine-mkinitcpio
+        /usr/bin/sudo /usr/bin/env PATH=/usr/bin:/usr/sbin:/bin:/sbin /usr/bin/limine-mkinitcpio
       fi
     fi
   fi
@@ -48,8 +163,8 @@ if [[ -f $MKINITCPIO_CONF ]] && grep -q "^HOOKS+=(resume)$" "$MKINITCPIO_CONF"; 
 fi
 
 if ! $FORCE; then
-  MEM_TOTAL_HUMAN=$(free --human | awk '/Mem/ {print $2}')
-  if ! gum confirm "Use $MEM_TOTAL_HUMAN on boot drive to make hibernation available?"; then
+  MEM_TOTAL_HUMAN=$(/usr/bin/free --human | /usr/bin/awk '/Mem/ {print $2}')
+  if ! /usr/bin/gum confirm "Use $MEM_TOTAL_HUMAN on boot drive to make hibernation available?"; then
     exit 0
   fi
 fi
@@ -57,62 +172,59 @@ fi
 SWAP_SUBVOLUME="/swap"
 
 # Create btrfs subvolume for swap
-if ! sudo btrfs subvolume show "$SWAP_SUBVOLUME" &>/dev/null; then
+if ! /usr/bin/sudo /usr/bin/btrfs subvolume show "$SWAP_SUBVOLUME" &>/dev/null; then
   echo "Creating Btrfs subvolume"
-  sudo btrfs subvolume create "$SWAP_SUBVOLUME"
-  sudo chattr +C "$SWAP_SUBVOLUME"
+  /usr/bin/sudo /usr/bin/btrfs subvolume create "$SWAP_SUBVOLUME"
+  /usr/bin/sudo /usr/bin/chattr +C "$SWAP_SUBVOLUME"
 fi
 
 # Create swapfile
-if ! sudo swaplabel "$SWAP_FILE" &>/dev/null; then
+if ! /usr/bin/sudo /usr/bin/swaplabel "$SWAP_FILE" &>/dev/null; then
   echo "Creating swapfile in Btrfs subvolume"
-  MEM_TOTAL_KB="$(awk '/MemTotal/ {print $2}' /proc/meminfo)k"
-  sudo btrfs filesystem mkswapfile -s "$MEM_TOTAL_KB" "$SWAP_FILE"
+  MEM_TOTAL_KB="$(/usr/bin/awk '/MemTotal/ {print $2}' /proc/meminfo)k"
+  /usr/bin/sudo /usr/bin/btrfs filesystem mkswapfile -s "$MEM_TOTAL_KB" "$SWAP_FILE"
 fi
 
 # Add swapfile to fstab
-if ! grep -Fq "$SWAP_FILE" /etc/fstab; then
+if ! /usr/bin/grep -Fq "$SWAP_FILE" /etc/fstab; then
   echo "Adding swapfile to /etc/fstab"
-  sudo cp -a /etc/fstab "/etc/fstab.$(date +%Y%m%d%H%M%S).back"
-  printf "\n# Btrfs swapfile for system hibernation\n%s none swap defaults,pri=0 0 0\n" "$SWAP_FILE" | sudo tee -a /etc/fstab >/dev/null
+  /usr/bin/sudo /usr/bin/cp -a /etc/fstab "/etc/fstab.$(/usr/bin/date +%Y%m%d%H%M%S).back"
+  printf "\n# Btrfs swapfile for system hibernation\n%s none swap defaults,pri=0 0 0\n" "$SWAP_FILE" | /usr/bin/sudo /usr/bin/tee -a /etc/fstab >/dev/null
 fi
 
 # Enable swap
-if ! swapon --show | grep -q "$SWAP_FILE"; then
+if ! /usr/bin/swapon --show | /usr/bin/grep -q "$SWAP_FILE"; then
   echo "Enabling swap on $SWAP_FILE"
-  sudo swapon -p 0 "$SWAP_FILE"
+  /usr/bin/sudo /usr/bin/swapon -p 0 "$SWAP_FILE"
 fi
 
 # Add resume hook to mkinitcpio
-sudo mkdir -p /etc/mkinitcpio.conf.d
+/usr/bin/sudo /usr/bin/install -d -m 0755 -o root -g root /etc/mkinitcpio.conf.d
 echo "Adding resume hook to $MKINITCPIO_CONF"
-echo "HOOKS+=(resume)" | sudo tee "$MKINITCPIO_CONF" >/dev/null
-
-# Ensure keyboard backlight doesn't prevent sleep
-sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-backlight" /usr/lib/systemd/system-sleep/
+echo "HOOKS+=(resume)" | /usr/bin/sudo /usr/bin/tee "$MKINITCPIO_CONF" >/dev/null
 
 # Add resume= kernel parameters so the initramfs resume hook knows where to find the
 # hibernation image. Without these, resume happens late (after GPU drivers load) and fails.
 if [[ ! -f $RESUME_DROP_IN ]]; then
   echo "Adding resume kernel parameters"
-  sudo swapon -p 0 "$SWAP_FILE" 2>/dev/null
-  RESUME_DEVICE=$(findmnt -no SOURCE -T "$SWAP_FILE" | sed 's/\[.*\]//')
-  RESUME_OFFSET=$(sudo btrfs inspect-internal map-swapfile -r "$SWAP_FILE")
+  /usr/bin/sudo /usr/bin/swapon -p 0 "$SWAP_FILE" 2>/dev/null
+  RESUME_DEVICE=$(/usr/bin/findmnt -no SOURCE -T "$SWAP_FILE" | /usr/bin/sed 's/\[.*\]//')
+  RESUME_OFFSET=$(/usr/bin/sudo /usr/bin/btrfs inspect-internal map-swapfile -r "$SWAP_FILE")
   if [[ -n $RESUME_OFFSET ]]; then
-    sudo mkdir -p /etc/limine-entry-tool.d
-    echo "KERNEL_CMDLINE[default]+=\" resume=$RESUME_DEVICE resume_offset=$RESUME_OFFSET\"" | sudo tee "$RESUME_DROP_IN" >/dev/null
+    /usr/bin/sudo /usr/bin/install -d -m 0755 -o root -g root /etc/limine-entry-tool.d
+    echo "KERNEL_CMDLINE[default]+=\" resume=$RESUME_DEVICE resume_offset=$RESUME_OFFSET\"" | /usr/bin/sudo /usr/bin/tee "$RESUME_DROP_IN" >/dev/null
   else
     echo "Warning: Could not determine resume offset for $SWAP_FILE" >&2
   fi
 fi
 
 # Use ACPI alarm for RTC wakeup on s2idle systems (needed for suspend-then-hibernate)
-if grep -q "\[s2idle\]" /sys/power/mem_sleep 2>/dev/null; then
+if /usr/bin/grep -q "\[s2idle\]" /sys/power/mem_sleep 2>/dev/null; then
   LIMINE_DROP_IN="/etc/limine-entry-tool.d/rtc-alarm.conf"
   if [[ ! -f $LIMINE_DROP_IN ]]; then
     echo "Enabling ACPI RTC alarm for s2idle suspend"
-    sudo mkdir -p /etc/limine-entry-tool.d
-    echo 'KERNEL_CMDLINE[default]+=" rtc_cmos.use_acpi_alarm=1"' | sudo tee "$LIMINE_DROP_IN" >/dev/null
+    /usr/bin/sudo /usr/bin/install -d -m 0755 -o root -g root /etc/limine-entry-tool.d
+    echo 'KERNEL_CMDLINE[default]+=" rtc_cmos.use_acpi_alarm=1"' | /usr/bin/sudo /usr/bin/tee "$LIMINE_DROP_IN" >/dev/null
   fi
 fi
 
@@ -122,10 +234,10 @@ if ! $NO_REBUILD; then
   # binary on the ESP doesn't change here, so we don't need limine-update
   # (which would also re-deploy the binary and rebuild a second time).
   echo "Regenerating initramfs..."
-  sudo limine-mkinitcpio
+  /usr/bin/sudo /usr/bin/env PATH=/usr/bin:/usr/sbin:/bin:/sbin /usr/bin/limine-mkinitcpio
   echo
 fi
 
-if ! $FORCE && ! $NO_REBUILD && gum confirm "Reboot to enable hibernation?"; then
-  omarchy-system-reboot
+if ! $FORCE && ! $NO_REBUILD && /usr/bin/gum confirm "Reboot to enable hibernation?"; then
+  "$OMARCHY_PATH/bin/omarchy-system-reboot"
 fi

--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -6,7 +6,197 @@
 
 set -e
 
-source "$OMARCHY_PATH/install/helpers/browser-policy.sh"
+trusted_omarchy_source_root() {
+  local LC_ALL=C
+  local config=/etc/omarchy.conf default_root=/usr/share/omarchy configured_root=""
+  local canonical="" owner="" mode="" links="" size="" line="" extra=""
+  local encoded="" decoded="" expected="" character="" directory="" current_uid=""
+  local index=0 escaped=0 config_fd read_status=0
+  current_uid=$(/usr/bin/id -u) || return 1
+  trusted_directory_chain() {
+    local directory=$1 allow_user_owner=$2 canonical owner mode
+    while :; do
+      [[ -d $directory && ! -L $directory ]] || return 1
+      canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+      [[ $canonical == "$directory" ]] || return 1
+      read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+      if [[ $owner != 0 ]] && ! { [[ $allow_user_owner == true ]] && [[ $owner == "$current_uid" ]]; }; then return 1; fi
+      (( (8#$mode & 0022) == 0 )) || return 1
+      [[ $directory == / ]] && break
+      directory=${directory%/*}; [[ -n $directory ]] || directory=/
+    done
+  }
+  if [[ ! -e $config && ! -L $config ]]; then
+    configured_root=$default_root
+  else
+    [[ -f $config && ! -L $config ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$config") || return 1
+    [[ $canonical == "$config" ]] || return 1
+    trusted_directory_chain "${config%/*}" false || return 1
+    read -r owner mode links size < <(/usr/bin/stat -Lc '%u %a %h %s' -- "$config") || return 1
+    [[ $owner == 0 && $links == 1 ]] || return 1
+    (( (8#$mode & 0022) == 0 && size > 0 && size <= 4096 )) || return 1
+    exec {config_fd}<"$config" || return 1
+    if ! IFS= read -r line <&$config_fd; then exec {config_fd}<&-; return 1; fi
+    IFS= read -r extra <&$config_fd || read_status=$?
+    exec {config_fd}<&-
+    (( read_status != 0 )) && [[ -z $extra ]] || return 1
+    (( size == ${#line} + 1 )) || return 1
+    [[ $line == 'export OMARCHY_PATH="'*'"' ]] || return 1
+    encoded=${line#'export OMARCHY_PATH="'}; encoded=${encoded%'"'}
+    [[ $encoded != *[$'\n\r\t']* ]] || return 1
+    for (( index = 0; index < ${#encoded}; index++ )); do
+      character=${encoded:index:1}
+      if (( escaped )); then
+        case "$character" in '\' | '"' | '$' | '`') decoded+=$character ;; *) return 1 ;; esac
+        escaped=0
+      elif [[ $character == '\' ]]; then escaped=1
+      elif [[ $character == '"' ]]; then return 1
+      else decoded+=$character
+      fi
+    done
+    (( escaped == 0 )) || return 1
+    expected=$decoded
+    expected=${expected//\\/\\\\}; expected=${expected//\"/\\\"}
+    expected=${expected//\$/\\\$}; expected=${expected//\`/\\\`}
+    [[ $line == "export OMARCHY_PATH=\"$expected\"" ]] || return 1
+    configured_root=$decoded
+  fi
+  [[ $configured_root == /* && -d $configured_root && ! -L $configured_root ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$configured_root") || return 1
+  [[ $canonical == "$configured_root" ]] || return 1
+  if [[ $configured_root == "$default_root" ]]; then
+    trusted_directory_chain "$configured_root" false || return 1
+  else
+    trusted_directory_chain "$configured_root" true || return 1
+    owner=$(/usr/bin/stat -Lc '%u' -- "$configured_root") || return 1
+    [[ $owner == 0 || $owner == "$current_uid" ]] || return 1
+  fi
+  printf '%s\n' "$configured_root"
+}
+
+trusted_omarchy_source_file() {
+  local relative=$1 source="$OMARCHY_PATH/$1" canonical owner mode links directory current_uid
+  current_uid=$(/usr/bin/id -u) || return 1
+  [[ $relative != /* && $relative != *'/../'* && $relative != '../'* && $relative != *'/..' ]] || return 1
+  [[ -f $source && ! -L $source ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$source") || return 1
+  [[ $canonical == "$source" && $canonical == "$OMARCHY_PATH/"* ]] || return 1
+  read -r owner mode links < <(/usr/bin/stat -Lc '%u %a %h' -- "$source") || return 1
+  [[ $links == 1 ]] || return 1
+  (( (8#$mode & 0022) == 0 )) || return 1
+  if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then [[ $owner == 0 ]] || return 1
+  else [[ $owner == 0 || $owner == "$current_uid" ]] || return 1; fi
+  directory=${source%/*}
+  while [[ $directory == "$OMARCHY_PATH" || $directory == "$OMARCHY_PATH/"* ]]; do
+    [[ -d $directory && ! -L $directory ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+    [[ $canonical == "$directory" ]] || return 1
+    read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+    (( (8#$mode & 0022) == 0 )) || return 1
+    if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then [[ $owner == 0 ]] || return 1
+    else [[ $owner == 0 || $owner == "$current_uid" ]] || return 1; fi
+    [[ $directory == "$OMARCHY_PATH" ]] && break
+    directory=${directory%/*}
+  done
+  printf '%s\n' "$source"
+}
+
+usage() {
+  echo "Usage: omarchy-install-browser <chromium|chrome|brave|brave-origin|edge|firefox|zen>"
+}
+
+(( $# == 1 )) || { usage >&2; exit 2; }
+case $1 in chromium | chrome | brave | brave-origin | edge | firefox | zen) ;; *) usage; exit 1 ;; esac
+
+browser_policy_sudo_args=()
+case $1 in
+  chrome | brave | brave-origin | edge | zen) browser_policy_sudo_args=(-N) ;;
+esac
+
+unset OMARCHY_PATH
+if ! OMARCHY_PATH=$(trusted_omarchy_source_root); then
+  echo "Refusing to install a browser from an untrusted Omarchy source root." >&2
+  exit 1
+fi
+export OMARCHY_PATH
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+
+browser_policy_helper=$(trusted_omarchy_source_file install/helpers/browser-policy.sh) || {
+  echo "Refusing to source an untrusted browser-policy helper." >&2
+  exit 1
+}
+trusted_omarchy_source_file install/helpers/as-root.sh >/dev/null || {
+  echo "Refusing to source an untrusted privilege helper." >&2
+  exit 1
+}
+source "$browser_policy_helper"
+
+# The shared helper intentionally accepts an as_root implementation. Pin both
+# sudo and each privileged utility so neither caller PATH nor dev-link
+# secure_path can substitute a different root command.
+as_root() {
+  local command=${1:-}
+  shift || return 1
+  case $command in
+    find | install | rm) command="/usr/bin/$command" ;;
+    *) echo "Refusing unsupported privileged browser-policy command: $command" >&2; return 1 ;;
+  esac
+  if (( EUID == 0 )); then
+    "$command" "$@"
+  else
+    /usr/bin/sudo "${browser_policy_sudo_args[@]}" -- "$command" "$@"
+  fi
+}
+
+browser_policy_purge_dir() {
+  local dir=$1
+
+  if (( EUID == 0 )); then
+    /usr/bin/find "$dir" -mindepth 1 -maxdepth 1 ! -user root -exec /usr/bin/rm -rf -- {} +
+  else
+    /usr/bin/sudo "${browser_policy_sudo_args[@]}" -- /usr/bin/find "$dir" -mindepth 1 -maxdepth 1 ! -user root -exec /usr/bin/rm -rf -- {} +
+  fi
+}
+
+cleanup_sudo_credentials() {
+  /usr/bin/sudo -k || true
+}
+trap cleanup_sudo_credentials EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+required_sources=()
+case $1 in
+  chromium)
+    required_sources=(bin/omarchy-pkg-add)
+    ;;
+  chrome | edge | brave | brave-origin)
+    required_sources=(bin/omarchy-pkg-aur-add)
+    ;;
+  firefox)
+    required_sources=(bin/omarchy-pkg-add default/firefox/policies.json)
+    ;;
+  zen)
+    required_sources=(bin/omarchy-pkg-aur-add default/firefox/policies.json)
+    ;;
+esac
+if [[ $1 != firefox && $1 != zen ]]; then
+  required_sources+=(
+    config/chromium-flags.conf
+    bin/omarchy-install-chromium-copy-url
+    bin/omarchy-install-chromium-ytdlp
+    bin/omarchy-theme-set-browser
+  )
+fi
+for required_source in "${required_sources[@]}"; do
+  trusted_omarchy_source_file "$required_source" >/dev/null || {
+    echo "Refusing an untrusted browser-install source: $required_source" >&2
+    exit 1
+  }
+done
 
 setup_chromium_policy_directory() {
   browser_policy_setup_dir "$1"
@@ -17,82 +207,95 @@ announce_browser_installed() {
   echo "$1 browser installed. Make it the default via Setup > Defaults > Browser."
 }
 
+apply_browser_theme() {
+  # Without a terminal, the policy helper uses its exact NOPASSWD rule or
+  # pkexec; it cannot create a reusable password-authenticated sudo timestamp
+  # immediately before it refreshes a newly installed browser process.
+  "$OMARCHY_PATH/bin/omarchy-theme-set-browser" </dev/null
+  cleanup_sudo_credentials
+}
+
 copy_chromium_flags() {
-  mkdir -p ~/.config
-  cp -f "$OMARCHY_PATH/config/chromium-flags.conf" "$1"
-  omarchy-install-chromium-copy-url
-  omarchy-install-chromium-ytdlp
+  /usr/bin/mkdir -p ~/.config
+  /usr/bin/cp -f "$OMARCHY_PATH/config/chromium-flags.conf" "$1"
+  "$OMARCHY_PATH/bin/omarchy-install-chromium-copy-url"
+  "$OMARCHY_PATH/bin/omarchy-install-chromium-ytdlp"
 }
 
 setup_firefox_wayland() {
-  mkdir -p ~/.config/environment.d
+  /usr/bin/mkdir -p ~/.config/environment.d
   echo "MOZ_ENABLE_WAYLAND=1" > ~/.config/environment.d/omarchy-firefox-wayland.conf
 }
 
 case $1 in
 chromium)
   echo "Installing Chromium..."
-  omarchy-pkg-add chromium
+  "$OMARCHY_PATH/bin/omarchy-pkg-add" chromium
 
   setup_chromium_policy_directory /etc/chromium/policies/managed
+  cleanup_sudo_credentials
   copy_chromium_flags ~/.config/chromium-flags.conf
-  omarchy-theme-set-browser
+  /usr/bin/mkdir -p ~/.config/chromium
+  /usr/bin/touch ~/.config/chromium/'EULA Accepted'
+  apply_browser_theme
   announce_browser_installed "Chromium"
   ;;
 chrome)
   echo "Installing Chrome..."
-  omarchy-pkg-aur-add google-chrome || exit 1
+  "$OMARCHY_PATH/bin/omarchy-pkg-aur-add" google-chrome || exit 1
 
   setup_chromium_policy_directory /etc/opt/chrome/policies/managed
+  cleanup_sudo_credentials
   copy_chromium_flags ~/.config/chrome-flags.conf
-  omarchy-theme-set-browser
+  apply_browser_theme
   announce_browser_installed "Chrome"
   ;;
 edge)
   echo "Installing Edge..."
-  omarchy-pkg-aur-add microsoft-edge-stable-bin || exit 1
+  "$OMARCHY_PATH/bin/omarchy-pkg-aur-add" microsoft-edge-stable-bin || exit 1
 
   setup_chromium_policy_directory /etc/opt/edge/policies/managed
+  cleanup_sudo_credentials
   copy_chromium_flags ~/.config/microsoft-edge-stable-flags.conf
-  omarchy-theme-set-browser
+  apply_browser_theme
   announce_browser_installed "Edge"
   ;;
 brave)
   echo "Installing Brave..."
-  omarchy-pkg-aur-add brave-bin || exit 1
+  "$OMARCHY_PATH/bin/omarchy-pkg-aur-add" brave-bin || exit 1
 
   setup_chromium_policy_directory /etc/brave/policies/managed
+  cleanup_sudo_credentials
   copy_chromium_flags ~/.config/brave-flags.conf
-  omarchy-theme-set-browser
+  apply_browser_theme
   announce_browser_installed "Brave"
   ;;
 brave-origin)
   echo "Installing Brave Origin..."
-  omarchy-pkg-aur-add brave-origin-bin || exit 1
+  "$OMARCHY_PATH/bin/omarchy-pkg-aur-add" brave-origin-bin || exit 1
 
   setup_chromium_policy_directory /etc/brave/policies/managed
+  cleanup_sudo_credentials
   copy_chromium_flags ~/.config/brave-origin-flags.conf
-  omarchy-theme-set-browser
+  apply_browser_theme
   announce_browser_installed "Brave Origin"
   ;;
 firefox)
   echo "Installing Firefox..."
-  omarchy-pkg-add firefox || exit 1
+  "$OMARCHY_PATH/bin/omarchy-pkg-add" firefox || exit 1
 
   browser_policy_setup_firefox_distribution /usr/lib/firefox/distribution
+  cleanup_sudo_credentials
   setup_firefox_wayland
   announce_browser_installed "Firefox"
   ;;
 zen)
   echo "Installing Zen..."
-  omarchy-pkg-aur-add zen-browser-bin || exit 1
+  "$OMARCHY_PATH/bin/omarchy-pkg-aur-add" zen-browser-bin || exit 1
 
   browser_policy_setup_firefox_distribution /opt/zen-browser/distribution
+  cleanup_sudo_credentials
   setup_firefox_wayland
   announce_browser_installed "Zen"
-  ;;
-*)
-  echo "Usage: omarchy-install-browser <chromium|chrome|brave|brave-origin|edge|firefox|zen>"
-  exit 1
   ;;
 esac

--- a/bin/omarchy-refresh-limine
+++ b/bin/omarchy-refresh-limine
@@ -3,17 +3,159 @@
 # omarchy:summary=Overwrite the user config for the Limine bootloader and rebuild it.
 # omarchy:requires-sudo=true
 
-legacy_uki="/boot/EFI/Linux/$(cat /etc/machine-id)_linux.efi"
+set -e
 
-if sudo test -f /boot/EFI/Linux/omarchy_linux.efi && sudo test -f "$legacy_uki"; then
+trusted_omarchy_source_root() {
+  local LC_ALL=C
+  local config=/etc/omarchy.conf default_root=/usr/share/omarchy configured_root=""
+  local canonical="" owner="" mode="" links="" size="" line="" extra=""
+  local encoded="" decoded="" expected="" character="" directory="" current_uid=""
+  local index=0 escaped=0 config_fd read_status=0
+
+  current_uid=$(/usr/bin/id -u) || return 1
+  trusted_directory_chain() {
+    local directory=$1 allow_user_owner=$2 canonical owner mode
+    while :; do
+      [[ -d $directory && ! -L $directory ]] || return 1
+      canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+      [[ $canonical == "$directory" ]] || return 1
+      read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+      if [[ $owner != 0 ]] && ! { [[ $allow_user_owner == true ]] && [[ $owner == "$current_uid" ]]; }; then return 1; fi
+      (( (8#$mode & 0022) == 0 )) || return 1
+      [[ $directory == / ]] && break
+      directory=${directory%/*}; [[ -n $directory ]] || directory=/
+    done
+  }
+
+  if [[ ! -e $config && ! -L $config ]]; then
+    configured_root=$default_root
+  else
+    [[ -f $config && ! -L $config ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$config") || return 1
+    [[ $canonical == "$config" ]] || return 1
+    trusted_directory_chain "${config%/*}" false || return 1
+    read -r owner mode links size < <(/usr/bin/stat -Lc '%u %a %h %s' -- "$config") || return 1
+    [[ $owner == 0 && $links == 1 ]] || return 1
+    (( (8#$mode & 0022) == 0 && size > 0 && size <= 4096 )) || return 1
+    exec {config_fd}<"$config" || return 1
+    if ! IFS= read -r line <&$config_fd; then exec {config_fd}<&-; return 1; fi
+    IFS= read -r extra <&$config_fd || read_status=$?
+    exec {config_fd}<&-
+    (( read_status != 0 )) && [[ -z $extra ]] || return 1
+    (( size == ${#line} + 1 )) || return 1
+    [[ $line == 'export OMARCHY_PATH="'*'"' ]] || return 1
+    encoded=${line#'export OMARCHY_PATH="'}; encoded=${encoded%'"'}
+    [[ $encoded != *[$'\n\r\t']* ]] || return 1
+    for (( index = 0; index < ${#encoded}; index++ )); do
+      character=${encoded:index:1}
+      if (( escaped )); then
+        case "$character" in '\' | '"' | '$' | '`') decoded+=$character ;; *) return 1 ;; esac
+        escaped=0
+      elif [[ $character == '\' ]]; then escaped=1
+      elif [[ $character == '"' ]]; then return 1
+      else decoded+=$character
+      fi
+    done
+    (( escaped == 0 )) || return 1
+    expected=$decoded
+    expected=${expected//\\/\\\\}; expected=${expected//\"/\\\"}
+    expected=${expected//\$/\\\$}; expected=${expected//\`/\\\`}
+    [[ $line == "export OMARCHY_PATH=\"$expected\"" ]] || return 1
+    configured_root=$decoded
+  fi
+
+  [[ $configured_root == /* && -d $configured_root && ! -L $configured_root ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$configured_root") || return 1
+  [[ $canonical == "$configured_root" ]] || return 1
+  if [[ $configured_root == "$default_root" ]]; then
+    trusted_directory_chain "$configured_root" false || return 1
+  else
+    trusted_directory_chain "$configured_root" true || return 1
+    owner=$(/usr/bin/stat -Lc '%u' -- "$configured_root") || return 1
+    [[ $owner == 0 || $owner == "$current_uid" ]] || return 1
+  fi
+  printf '%s\n' "$configured_root"
+}
+
+trusted_omarchy_source_file() {
+  local relative=$1 source="$OMARCHY_PATH/$1" canonical owner mode links directory current_uid
+  current_uid=$(/usr/bin/id -u) || return 1
+  [[ $relative != /* && $relative != *'/../'* && $relative != '../'* && $relative != *'/..' ]] || return 1
+  [[ -f $source && ! -L $source ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$source") || return 1
+  [[ $canonical == "$source" && $canonical == "$OMARCHY_PATH/"* ]] || return 1
+  read -r owner mode links < <(/usr/bin/stat -Lc '%u %a %h' -- "$source") || return 1
+  [[ $links == 1 ]] || return 1
+  (( (8#$mode & 0022) == 0 )) || return 1
+  if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then [[ $owner == 0 ]] || return 1
+  else [[ $owner == 0 || $owner == "$current_uid" ]] || return 1; fi
+  directory=${source%/*}
+  while [[ $directory == "$OMARCHY_PATH" || $directory == "$OMARCHY_PATH/"* ]]; do
+    [[ -d $directory && ! -L $directory ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+    [[ $canonical == "$directory" ]] || return 1
+    read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+    (( (8#$mode & 0022) == 0 )) || return 1
+    if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then [[ $owner == 0 ]] || return 1
+    else [[ $owner == 0 || $owner == "$current_uid" ]] || return 1; fi
+    [[ $directory == "$OMARCHY_PATH" ]] && break
+    directory=${directory%/*}
+  done
+  printf '%s\n' "$source"
+}
+
+unset OMARCHY_PATH
+if ! OMARCHY_PATH=$(trusted_omarchy_source_root); then
+  echo "Refusing to refresh Limine from an untrusted Omarchy source root." >&2
+  exit 1
+fi
+export OMARCHY_PATH
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+
+limine_source=$(trusted_omarchy_source_file default/limine/limine.conf) || {
+  echo "Refusing to publish an untrusted Limine configuration." >&2
+  exit 1
+}
+
+machine_id=""
+IFS= read -r machine_id </etc/machine-id || {
+  echo "Unable to read the machine ID." >&2
+  exit 1
+}
+[[ $machine_id =~ ^[0-9a-fA-F]{32}$ ]] || {
+  echo "Refusing an invalid machine ID in /etc/machine-id." >&2
+  exit 1
+}
+# Stage the trusted source before moving the currently bootable configuration
+# or any legacy UKI out of the way. Explicit modes make publication independent
+# of umask and development-checkout metadata.
+staged=$(/usr/bin/sudo /usr/bin/mktemp /boot/.omarchy-limine.conf.XXXXXX) || exit 1
+cleanup_staged() {
+  [[ -n $staged ]] && /usr/bin/sudo /usr/bin/rm -f -- "$staged" 2>/dev/null || true
+}
+trap cleanup_staged EXIT
+/usr/bin/sudo /usr/bin/install -m 0644 -o root -g root -T -- /dev/stdin "$staged" <"$limine_source"
+
+legacy_uki="/boot/EFI/Linux/${machine_id}_linux.efi"
+if /usr/bin/sudo /usr/bin/test -f /boot/EFI/Linux/omarchy_linux.efi && /usr/bin/sudo /usr/bin/test -f "$legacy_uki"; then
   echo "Cleanup extra UKI"
-  sudo rm -f "$legacy_uki"
+  /usr/bin/sudo /usr/bin/rm -f -- "$legacy_uki"
 fi
 echo "Resetting limine config"
 
-sudo mv /boot/limine.conf /boot/limine.conf.bak
+had_config=false
+if /usr/bin/sudo /usr/bin/test -e /boot/limine.conf; then
+  had_config=true
+  /usr/bin/sudo /usr/bin/mv -f -- /boot/limine.conf /boot/limine.conf.bak
+fi
+if ! /usr/bin/sudo /usr/bin/mv -f -- "$staged" /boot/limine.conf; then
+  if $had_config && ! /usr/bin/sudo /usr/bin/mv -f -- /boot/limine.conf.bak /boot/limine.conf; then
+    echo "Critical: failed to restore /boot/limine.conf after publication failed." >&2
+  fi
+  exit 1
+fi
+staged=""
 
-sudo cp "$OMARCHY_PATH/default/limine/limine.conf" /boot/limine.conf
-
-sudo limine-update
-sudo limine-snapper-sync
+/usr/bin/sudo /usr/bin/env PATH=/usr/bin:/usr/sbin:/bin:/sbin /usr/bin/limine-update
+/usr/bin/sudo /usr/bin/env PATH=/usr/bin:/usr/sbin:/bin:/sbin /usr/bin/limine-snapper-sync

--- a/bin/omarchy-reinstall-pkgs
+++ b/bin/omarchy-reinstall-pkgs
@@ -5,14 +5,163 @@
 
 set -e
 
-# Reinstall all default Omarchy packages from the stable channel and downgrade any packages that are too new.
+user_path=${PATH:-/usr/bin:/usr/sbin:/bin:/sbin}
 
-# Set the package repository to the stable mirrors
-omarchy-refresh-pacman
+trusted_omarchy_source_root() {
+  local LC_ALL=C
+  local config=/etc/omarchy.conf default_root=/usr/share/omarchy configured_root=""
+  local canonical="" owner="" mode="" links="" size="" line="" extra=""
+  local encoded="" decoded="" expected="" character="" directory="" current_uid=""
+  local index=0 escaped=0 config_fd read_status=0
+  current_uid=$(/usr/bin/id -u) || return 1
+  trusted_directory_chain() {
+    local directory=$1 allow_user_owner=$2 canonical owner mode
+    while :; do
+      [[ -d $directory && ! -L $directory ]] || return 1
+      canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+      [[ $canonical == "$directory" ]] || return 1
+      read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+      if [[ $owner != 0 ]] && ! { [[ $allow_user_owner == true ]] && [[ $owner == "$current_uid" ]]; }; then return 1; fi
+      (( (8#$mode & 0022) == 0 )) || return 1
+      [[ $directory == / ]] && break
+      directory=${directory%/*}; [[ -n $directory ]] || directory=/
+    done
+  }
+  if [[ ! -e $config && ! -L $config ]]; then
+    configured_root=$default_root
+  else
+    [[ -f $config && ! -L $config ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$config") || return 1
+    [[ $canonical == "$config" ]] || return 1
+    trusted_directory_chain "${config%/*}" false || return 1
+    read -r owner mode links size < <(/usr/bin/stat -Lc '%u %a %h %s' -- "$config") || return 1
+    [[ $owner == 0 && $links == 1 ]] || return 1
+    (( (8#$mode & 0022) == 0 && size > 0 && size <= 4096 )) || return 1
+    exec {config_fd}<"$config" || return 1
+    if ! IFS= read -r line <&$config_fd; then exec {config_fd}<&-; return 1; fi
+    IFS= read -r extra <&$config_fd || read_status=$?
+    exec {config_fd}<&-
+    (( read_status != 0 )) && [[ -z $extra ]] || return 1
+    (( size == ${#line} + 1 )) || return 1
+    [[ $line == 'export OMARCHY_PATH="'*'"' ]] || return 1
+    encoded=${line#'export OMARCHY_PATH="'}; encoded=${encoded%'"'}
+    [[ $encoded != *[$'\n\r\t']* ]] || return 1
+    for (( index = 0; index < ${#encoded}; index++ )); do
+      character=${encoded:index:1}
+      if (( escaped )); then
+        case "$character" in '\' | '"' | '$' | '`') decoded+=$character ;; *) return 1 ;; esac
+        escaped=0
+      elif [[ $character == '\' ]]; then escaped=1
+      elif [[ $character == '"' ]]; then return 1
+      else decoded+=$character
+      fi
+    done
+    (( escaped == 0 )) || return 1
+    expected=$decoded
+    expected=${expected//\\/\\\\}; expected=${expected//\"/\\\"}
+    expected=${expected//\$/\\\$}; expected=${expected//\`/\\\`}
+    [[ $line == "export OMARCHY_PATH=\"$expected\"" ]] || return 1
+    configured_root=$decoded
+  fi
+  [[ $configured_root == /* && -d $configured_root && ! -L $configured_root ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$configured_root") || return 1
+  [[ $canonical == "$configured_root" ]] || return 1
+  if [[ $configured_root == "$default_root" ]]; then
+    trusted_directory_chain "$configured_root" false || return 1
+  else
+    trusted_directory_chain "$configured_root" true || return 1
+    owner=$(/usr/bin/stat -Lc '%u' -- "$configured_root") || return 1
+    [[ $owner == 0 || $owner == "$current_uid" ]] || return 1
+  fi
+  printf '%s\n' "$configured_root"
+}
 
-# Downgrade any packages to the stable setup
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Suu --noconfirm
+trusted_omarchy_source_file() {
+  local relative=$1 source="$OMARCHY_PATH/$1" canonical owner mode links directory current_uid
+  current_uid=$(/usr/bin/id -u) || return 1
+  [[ $relative != /* && $relative != *'/../'* && $relative != '../'* && $relative != *'/..' ]] || return 1
+  [[ -f $source && ! -L $source ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$source") || return 1
+  [[ $canonical == "$source" && $canonical == "$OMARCHY_PATH/"* ]] || return 1
+  read -r owner mode links < <(/usr/bin/stat -Lc '%u %a %h' -- "$source") || return 1
+  [[ $links == 1 ]] || return 1
+  (( (8#$mode & 0022) == 0 )) || return 1
+  if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then [[ $owner == 0 ]] || return 1
+  else [[ $owner == 0 || $owner == "$current_uid" ]] || return 1; fi
+  directory=${source%/*}
+  while [[ $directory == "$OMARCHY_PATH" || $directory == "$OMARCHY_PATH/"* ]]; do
+    [[ -d $directory && ! -L $directory ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+    [[ $canonical == "$directory" ]] || return 1
+    read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+    (( (8#$mode & 0022) == 0 )) || return 1
+    if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then [[ $owner == 0 ]] || return 1
+    else [[ $owner == 0 || $owner == "$current_uid" ]] || return 1; fi
+    [[ $directory == "$OMARCHY_PATH" ]] && break
+    directory=${directory%/*}
+  done
+  printf '%s\n' "$source"
+}
 
-# Ensure all packages are installed
-mapfile -t packages < <(grep -v '^#' "$OMARCHY_PATH/install/omarchy-base.packages" | grep -v '^$')
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm --needed "${packages[@]}"
+unset OMARCHY_PATH
+if ! OMARCHY_PATH=$(trusted_omarchy_source_root); then
+  echo "Refusing to reinstall packages from an untrusted Omarchy source root." >&2
+  exit 1
+fi
+export OMARCHY_PATH
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+
+package_file=$(trusted_omarchy_source_file install/omarchy-base.packages) || {
+  echo "Refusing an untrusted Omarchy package list." >&2
+  exit 1
+}
+pacman_config=$(trusted_omarchy_source_file default/pacman/pacman-stable.conf) || {
+  echo "Refusing an untrusted stable pacman configuration." >&2
+  exit 1
+}
+mirrorlist=$(trusted_omarchy_source_file default/pacman/mirrorlist-stable) || {
+  echo "Refusing an untrusted stable mirror list." >&2
+  exit 1
+}
+hook=$(trusted_omarchy_source_file bin/omarchy-hook) || {
+  echo "Refusing an untrusted Omarchy hook runner." >&2
+  exit 1
+}
+
+packages=()
+while IFS= read -r package || [[ -n $package ]]; do
+  [[ -z $package || $package == \#* ]] && continue
+  if [[ ! $package =~ ^[a-zA-Z0-9@._+:-]+$ || $package == -* ]]; then
+    echo "Refusing invalid package-list entry: $package" >&2
+    exit 1
+  fi
+  packages+=("$package")
+done <"$package_file"
+(( ${#packages[@]} > 0 )) || {
+  echo "Refusing an empty Omarchy package list." >&2
+  exit 1
+}
+
+cleanup_sudo_credentials() {
+  /usr/bin/sudo -k || true
+}
+trap cleanup_sudo_credentials EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# Keep every privileged reinstall operation in one phase. The user hook runs
+# only after the last transaction and an explicit timestamp invalidation, so a
+# detached hook child cannot wait for a later silent sudo authentication.
+/usr/bin/sudo /usr/bin/cp -f -- /etc/pacman.conf /etc/pacman.conf.bak
+/usr/bin/sudo /usr/bin/cp -f -- /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.bak
+/usr/bin/sudo /usr/bin/install -m 0644 -o root -g root -T -- /dev/stdin /etc/pacman.conf <"$pacman_config"
+/usr/bin/sudo /usr/bin/install -m 0644 -o root -g root -T -- /dev/stdin /etc/pacman.d/mirrorlist <"$mirrorlist"
+
+/usr/bin/sudo /usr/bin/env PATH=/usr/bin:/usr/sbin:/bin:/sbin OMARCHY_UPDATE_PACMAN=1 /usr/bin/pacman -Syyuu --noconfirm
+/usr/bin/sudo /usr/bin/env PATH=/usr/bin:/usr/sbin:/bin:/sbin OMARCHY_UPDATE_PACMAN=1 /usr/bin/pacman -Suu --noconfirm
+/usr/bin/sudo /usr/bin/env PATH=/usr/bin:/usr/sbin:/bin:/sbin OMARCHY_UPDATE_PACMAN=1 /usr/bin/pacman -Syu --noconfirm --needed -- "${packages[@]}"
+
+cleanup_sudo_credentials
+PATH="$user_path" "$hook" pre-refresh-pacman

--- a/bin/omarchy-theme-set-browser-policy
+++ b/bin/omarchy-theme-set-browser-policy
@@ -96,7 +96,7 @@ for policy_dir in "${POLICY_DIRS[@]}"; do
     failed=1
     continue
   }
-  printf '{"BrowserThemeColor": "#%s", "BrowserColorScheme": "device"}\n' "$color" >"$staged"
+  printf '{"BrowserThemeColor": "#%s"}\n' "$color" >"$staged"
 
   if [[ -L $dest || -d $dest ]]; then
     if ! rm -rf -- "$dest"; then

--- a/bin/omarchy-toggle-hybrid-gpu
+++ b/bin/omarchy-toggle-hybrid-gpu
@@ -3,11 +3,161 @@
 # omarchy:summary=Toggle dedicated vs integrated GPU mode via supergfxd (for hybrid gpu laptops, like Asus G14).
 # omarchy:requires-sudo=true
 
-if omarchy-cmd-missing supergfxctl; then
-  omarchy-pkg-add supergfxctl
+set -e
+
+trusted_omarchy_source_root() {
+  local LC_ALL=C
+  local config=/etc/omarchy.conf default_root=/usr/share/omarchy configured_root=""
+  local canonical="" owner="" mode="" links="" size="" line="" extra=""
+  local encoded="" decoded="" expected="" character="" directory="" current_uid=""
+  local index=0 escaped=0 config_fd read_status=0
+
+  current_uid=$(/usr/bin/id -u) || return 1
+
+  trusted_directory_chain() {
+    local directory=$1 allow_user_owner=$2 canonical owner mode
+
+    while :; do
+      [[ -d $directory && ! -L $directory ]] || return 1
+      canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+      [[ $canonical == "$directory" ]] || return 1
+      read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+      if [[ $owner != 0 ]] && ! { [[ $allow_user_owner == true ]] && [[ $owner == "$current_uid" ]]; }; then
+        return 1
+      fi
+      (( (8#$mode & 0022) == 0 )) || return 1
+      [[ $directory == / ]] && break
+      directory=${directory%/*}
+      [[ -n $directory ]] || directory=/
+    done
+  }
+
+  if [[ ! -e $config && ! -L $config ]]; then
+    configured_root=$default_root
+  else
+    [[ -f $config && ! -L $config ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$config") || return 1
+    [[ $canonical == "$config" ]] || return 1
+    trusted_directory_chain "${config%/*}" false || return 1
+    read -r owner mode links size < <(/usr/bin/stat -Lc '%u %a %h %s' -- "$config") || return 1
+    [[ $owner == 0 && $links == 1 ]] || return 1
+    (( (8#$mode & 0022) == 0 && size > 0 && size <= 4096 )) || return 1
+
+    exec {config_fd}<"$config" || return 1
+    if ! IFS= read -r line <&$config_fd; then
+      exec {config_fd}<&-
+      return 1
+    fi
+    IFS= read -r extra <&$config_fd || read_status=$?
+    exec {config_fd}<&-
+    (( read_status != 0 )) && [[ -z $extra ]] || return 1
+    (( size == ${#line} + 1 )) || return 1
+    [[ $line == 'export OMARCHY_PATH="'*'"' ]] || return 1
+    encoded=${line#'export OMARCHY_PATH="'}
+    encoded=${encoded%'"'}
+    [[ $encoded != *[$'\n\r\t']* ]] || return 1
+
+    for (( index = 0; index < ${#encoded}; index++ )); do
+      character=${encoded:index:1}
+      if (( escaped )); then
+        case "$character" in
+          '\' | '"' | '$' | '`') decoded+=$character ;;
+          *) return 1 ;;
+        esac
+        escaped=0
+      elif [[ $character == '\' ]]; then
+        escaped=1
+      elif [[ $character == '"' ]]; then
+        return 1
+      else
+        decoded+=$character
+      fi
+    done
+    (( escaped == 0 )) || return 1
+
+    expected=$decoded
+    expected=${expected//\\/\\\\}
+    expected=${expected//\"/\\\"}
+    expected=${expected//\$/\\\$}
+    expected=${expected//\`/\\\`}
+    [[ $line == "export OMARCHY_PATH=\"$expected\"" ]] || return 1
+    configured_root=$decoded
+  fi
+
+  [[ $configured_root == /* && -d $configured_root && ! -L $configured_root ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$configured_root") || return 1
+  [[ $canonical == "$configured_root" ]] || return 1
+  if [[ $configured_root == "$default_root" ]]; then
+    trusted_directory_chain "$configured_root" false || return 1
+  else
+    trusted_directory_chain "$configured_root" true || return 1
+    owner=$(/usr/bin/stat -Lc '%u' -- "$configured_root") || return 1
+    [[ $owner == 0 || $owner == "$current_uid" ]] || return 1
+  fi
+  printf '%s\n' "$configured_root"
+}
+
+trusted_omarchy_source_file() {
+  local relative=$1 source="$OMARCHY_PATH/$1" canonical owner mode links directory current_uid
+
+  current_uid=$(/usr/bin/id -u) || return 1
+  [[ $relative != /* && $relative != *'/../'* && $relative != '../'* && $relative != *'/..' ]] || return 1
+  [[ -f $source && ! -L $source ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$source") || return 1
+  [[ $canonical == "$source" && $canonical == "$OMARCHY_PATH/"* ]] || return 1
+  read -r owner mode links < <(/usr/bin/stat -Lc '%u %a %h' -- "$source") || return 1
+  [[ $links == 1 ]] || return 1
+  (( (8#$mode & 0022) == 0 )) || return 1
+  if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then
+    [[ $owner == 0 ]] || return 1
+  else
+    [[ $owner == 0 || $owner == "$current_uid" ]] || return 1
+  fi
+
+  directory=${source%/*}
+  while [[ $directory == "$OMARCHY_PATH" || $directory == "$OMARCHY_PATH/"* ]]; do
+    [[ -d $directory && ! -L $directory ]] || return 1
+    canonical=$(/usr/bin/realpath -e -- "$directory") || return 1
+    [[ $canonical == "$directory" ]] || return 1
+    read -r owner mode < <(/usr/bin/stat -Lc '%u %a' -- "$directory") || return 1
+    (( (8#$mode & 0022) == 0 )) || return 1
+    if [[ $OMARCHY_PATH == /usr/share/omarchy ]]; then
+      [[ $owner == 0 ]] || return 1
+    else
+      [[ $owner == 0 || $owner == "$current_uid" ]] || return 1
+    fi
+    [[ $directory == "$OMARCHY_PATH" ]] && break
+    directory=${directory%/*}
+  done
+  printf '%s\n' "$source"
+}
+
+unset OMARCHY_PATH
+if ! OMARCHY_PATH=$(trusted_omarchy_source_root); then
+  echo "Refusing to change GPU mode from an untrusted Omarchy source root." >&2
+  exit 1
+fi
+export OMARCHY_PATH
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+
+force_igpu_marker=/etc/omarchy/force-igpu
+force_igpu_hook=/usr/lib/systemd/system-sleep/omarchy-force-igpu
+delay_source=/usr/share/omarchy/default/systemd/system/supergfxd.service.d/delay-start.conf
+delay_drop_in=/etc/systemd/system/supergfxd.service.d/10-omarchy-delay-start.conf
+
+for required_source in bin/omarchy-cmd-missing bin/omarchy-pkg-add bin/omarchy-system-reboot; do
+  trusted_omarchy_source_file "$required_source" >/dev/null || {
+    echo "Refusing an untrusted GPU helper: $required_source" >&2
+    exit 1
+  }
+done
+
+if "$OMARCHY_PATH/bin/omarchy-cmd-missing" supergfxctl; then
+  "$OMARCHY_PATH/bin/omarchy-pkg-add" supergfxctl
 
   # Create config before starting service to prevent hang on first boot
-  sudo tee /etc/supergfxd.conf >/dev/null <<'CONF'
+  /usr/bin/sudo /usr/bin/tee /etc/supergfxd.conf >/dev/null <<'CONF'
 {
   "mode": "Hybrid",
   "vfio_enable": true,
@@ -19,17 +169,17 @@ if omarchy-cmd-missing supergfxctl; then
 }
 CONF
 
-  sudo systemctl enable --now supergfxd
+  /usr/bin/sudo /usr/bin/systemctl enable --now supergfxd
 fi
 
 gpu_mode=""
 for attempt in {1..3}; do
-  if gpu_mode=$(timeout --kill-after=1s 3s supergfxctl -g 2>/dev/null) && [[ -n $gpu_mode ]]; then
+  if gpu_mode=$(/usr/bin/timeout --kill-after=1s 3s /usr/bin/supergfxctl -g 2>/dev/null) && [[ -n $gpu_mode ]]; then
     break
   fi
 
   gpu_mode=""
-  (( attempt < 3 )) && sleep 1
+  (( attempt < 3 )) && /usr/bin/sleep 1
 done
 
 if [[ -z $gpu_mode ]]; then
@@ -39,35 +189,56 @@ fi
 
 case "$gpu_mode" in
 "Integrated")
-  if gum confirm "Enable dedicated GPU and reboot?"; then
+  if /usr/bin/gum confirm "Enable dedicated GPU and reboot?"; then
     # Switch to hybrid mode
-    sudo sed -i "s/\"mode\": \".*\"/\"mode\": \"Hybrid\"/" /etc/supergfxd.conf
+    /usr/bin/sudo /usr/bin/sed -i "s/\"mode\": \".*\"/\"mode\": \"Hybrid\"/" /etc/supergfxd.conf
 
-    # Let hybrid mode be the default after system sleep
-    sudo rm -rf /usr/lib/systemd/system-sleep/force-igpu
+    # Let hybrid mode be the default after system sleep. The hook itself is
+    # package-owned; only its activation marker is runtime state.
+    /usr/bin/sudo /usr/bin/rm -f -- "$force_igpu_marker"
 
     # Remove the startup delay override (not needed for Hybrid mode)
-    sudo rm -rf /etc/systemd/system/supergfxd.service.d/delay-start.conf
+    /usr/bin/sudo /usr/bin/rm -f -- "$delay_drop_in"
 
-    omarchy-system-reboot
+    # Retire copies made by older Omarchy releases.
+    /usr/bin/sudo /usr/bin/rm -f -- /usr/lib/systemd/system-sleep/force-igpu
+    /usr/bin/sudo /usr/bin/rm -f -- /etc/systemd/system/supergfxd.service.d/delay-start.conf
+
+    "$OMARCHY_PATH/bin/omarchy-system-reboot"
   fi
   ;;
 "Hybrid")
-  if gum confirm "Use only integrated GPU and reboot?"; then
-    # Switch to integrated mode and ensure vfio is enabled (needed for sleep/wake trick)
-    sudo sed -i "s/\"mode\": \".*\"/\"mode\": \"Integrated\"/" /etc/supergfxd.conf
-    sudo sed -i 's/"vfio_enable": false/"vfio_enable": true/' /etc/supergfxd.conf
+  if /usr/bin/gum confirm "Use only integrated GPU and reboot?"; then
+    if [[ ! -f $force_igpu_hook || -L $force_igpu_hook || ! -x $force_igpu_hook ]]; then
+      echo "$force_igpu_hook is missing. Update omarchy-settings before enabling Integrated mode." >&2
+      exit 1
+    fi
+    if [[ ! -f $delay_source || -L $delay_source ]]; then
+      echo "$delay_source is missing. Update omarchy-settings before enabling Integrated mode." >&2
+      exit 1
+    fi
 
-    # Force igpu mode after system sleep (or dgpu could get activated)
-    sudo mkdir -p /usr/lib/systemd/system-sleep
-    sudo cp -p "$OMARCHY_PATH/default/systemd/system-sleep/force-igpu" /usr/lib/systemd/system-sleep/
+    # Switch to integrated mode and ensure vfio is enabled (needed for sleep/wake trick)
+    /usr/bin/sudo /usr/bin/sed -i "s/\"mode\": \".*\"/\"mode\": \"Integrated\"/" /etc/supergfxd.conf
+    /usr/bin/sudo /usr/bin/sed -i 's/"vfio_enable": false/"vfio_enable": true/' /etc/supergfxd.conf
+
+    # Force iGPU mode after system sleep (or the dGPU could get activated).
+    # Static executable code stays package-owned; the marker is the state.
+    /usr/bin/sudo /usr/bin/install -d -m 0755 -o root -g root /etc/omarchy
+    /usr/bin/sudo /usr/bin/rm -f -- "$force_igpu_marker"
+    /usr/bin/sudo /usr/bin/install -m 0644 -o root -g root -T -- /dev/null "$force_igpu_marker"
 
     # Delay supergfxd startup to avoid race condition with display manager
     # that can cause system freeze when booting in Integrated mode
-    sudo mkdir -p /etc/systemd/system/supergfxd.service.d
-    sudo cp -p "$OMARCHY_PATH/default/systemd/system/supergfxd.service.d/delay-start.conf" /etc/systemd/system/supergfxd.service.d/
+    /usr/bin/sudo /usr/bin/install -d -m 0755 -o root -g root /etc/systemd/system/supergfxd.service.d
+    /usr/bin/sudo /usr/bin/rm -f -- "$delay_drop_in"
+    /usr/bin/sudo /usr/bin/ln -s -- "$delay_source" "$delay_drop_in"
 
-    omarchy-system-reboot
+    # Retire copies made by older Omarchy releases.
+    /usr/bin/sudo /usr/bin/rm -f -- /usr/lib/systemd/system-sleep/force-igpu
+    /usr/bin/sudo /usr/bin/rm -f -- /etc/systemd/system/supergfxd.service.d/delay-start.conf
+
+    "$OMARCHY_PATH/bin/omarchy-system-reboot"
   fi
   ;;
 *)

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1,11 +1,62 @@
-#!/bin/bash
+#!/bin/bash -p
 
 # omarchy:summary=Upgrade a legacy Omarchy install to the package-backed Omarchy quattro layout.
 # omarchy:args=[--yes] [--reboot] [--dev] [--channel stable|rc|edge] [--user USER]
 # omarchy:examples=omarchy upgrade to quattro | omarchy upgrade to quattro --dev
 # omarchy:requires-sudo=true
 
+# Bash evaluates BASH_ENV and imports exported functions before reading the
+# first script line. Only Bash invoked with -p suppresses both early enough;
+# require it in the interpreter-option position so a hostile BASH_ENV cannot
+# set privileged mode and smuggle an unrelated later "-p" argument through
+# this gate. Never continue or restart from an unsafe interpreter.
+require_privileged_bash_startup() {
+  [[ $- == *p* ]] || return 1
+  /usr/bin/env -i /usr/bin/bash -p -c '
+    [[ $1 =~ ^[1-9][0-9]*$ ]] || exit 1
+    mapfile -d "" -t argv <"/proc/$1/cmdline" || exit 1
+    executable=$(/usr/bin/readlink -e -- "/proc/$1/exe") || exit 1
+    [[ $executable == /usr/bin/bash ]]
+    [[ ${argv[0]:-} == /bin/bash || ${argv[0]:-} == /usr/bin/bash ]]
+    [[ ${argv[1]:-} == -p ]]
+  ' omarchy-bash-startup "$$"
+}
+if ! require_privileged_bash_startup; then
+  /usr/bin/printf '%s\n' 'Error: run this upgrade directly, or invoke it with /usr/bin/bash -p.' >&2
+  /usr/bin/false
+else
+unset -f require_privileged_bash_startup
+# Privileged-shell mode ignores exported functions but leaves their serialized
+# BASH_FUNC_* entries in the environment, where a later packaged #!/bin/bash
+# child would import them. Re-exec only from this already-safe interpreter with
+# those entries removed, preserving every unrelated environment variable.
+if /usr/bin/env | /usr/bin/grep -q '^BASH_FUNC_.*%%='; then
+  if [[ -z ${BASH_SOURCE[0]:-} || ! -r ${BASH_SOURCE[0]} ]]; then
+    /usr/bin/printf '%s\n' 'Error: exported Bash functions require running this upgrade from its script file.' >&2
+    exit 1
+  fi
+
+  clean_environment=(/usr/bin/env -u BASH_ENV -u ENV)
+  while IFS= read -r environment_line; do
+    if [[ $environment_line == BASH_FUNC_*%%=* ]]; then
+      clean_environment+=(-u "${environment_line%%=*}")
+    fi
+  done < <(/usr/bin/env)
+  exec "${clean_environment[@]}" /usr/bin/bash -p -- "${BASH_SOURCE[0]}" "$@"
+fi
+
+# These startup hooks were ignored by -p; remove them before any child shell.
+unset BASH_ENV ENV
+
 set -euo pipefail
+
+# Caller startup code may execute before this file's first line. Keep command
+# lookup deterministic, and more importantly never publish a reusable sudo
+# timestamp for a pre-existing or newly detached process to consume.
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+
+readonly OMARCHY_PACKAGING_KEY_FINGERPRINT=40DFB630FF42BCFFB047046CF0134EE680CAC571
 
 usage() {
   cat <<'USAGE'
@@ -13,7 +64,7 @@ Usage: omarchy-upgrade-to-quattro [--yes] [--reboot] [--dev] [--channel stable|r
 
 Upgrade any pre-quattro Omarchy install to the package-backed Omarchy quattro layout.
 This script is intentionally self-contained so it can be shipped as a command
-in Omarchy 3.8.x or run directly with curl | bash on older systems.
+in Omarchy 3.8.x or run with curl | /usr/bin/bash -p on older systems.
 
 Options:
   -y, --yes                 Do not prompt before upgrading
@@ -57,11 +108,11 @@ valid_channel() {
 detect_installed_channel() {
   [[ -f /etc/pacman.d/mirrorlist ]] || return 1
 
-  if grep -q 'https://stable-mirror.omarchy.org/' /etc/pacman.d/mirrorlist; then
+  if /usr/bin/grep -q 'https://stable-mirror.omarchy.org/' /etc/pacman.d/mirrorlist; then
     echo stable
-  elif grep -q 'https://rc-mirror.omarchy.org/' /etc/pacman.d/mirrorlist; then
+  elif /usr/bin/grep -q 'https://rc-mirror.omarchy.org/' /etc/pacman.d/mirrorlist; then
     echo rc
-  elif grep -q 'https://mirror.omarchy.org/' /etc/pacman.d/mirrorlist; then
+  elif /usr/bin/grep -q 'https://mirror.omarchy.org/' /etc/pacman.d/mirrorlist; then
     echo edge
   else
     return 1
@@ -147,11 +198,11 @@ if { [[ -n $channel_override ]] || (( channel_override_cli )); } && ! valid_chan
   fail "Invalid channel '$channel_override'. Use stable, rc, or edge."
 fi
 
-if ! command -v pacman >/dev/null 2>&1; then
+if [[ ! -x /usr/bin/pacman ]]; then
   fail "This upgrade is only supported on Arch/Omarchy systems with pacman."
 fi
 
-if ! command -v sudo >/dev/null 2>&1 && (( EUID != 0 )); then
+if [[ ! -x /usr/bin/sudo ]] && (( EUID != 0 )); then
   fail "sudo is required when not running as root."
 fi
 
@@ -159,7 +210,7 @@ if [[ -z $target_user ]]; then
   if (( EUID == 0 )); then
     target_user="${SUDO_USER:-}"
   else
-    target_user="${USER:-$(id -un)}"
+    target_user="${USER:-$(/usr/bin/id -un)}"
   fi
 fi
 
@@ -167,38 +218,42 @@ if [[ -z $target_user || $target_user == root ]]; then
   fail "Could not determine the non-root Omarchy user. Re-run with --user USER."
 fi
 
-if ! getent passwd "$target_user" >/dev/null; then
+if ! /usr/bin/getent passwd "$target_user" >/dev/null; then
   fail "User '$target_user' does not exist."
 fi
 
-target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=$(/usr/bin/getent passwd "$target_user" | /usr/bin/cut -d: -f6)
 [[ -n $target_home && -d $target_home ]] || fail "Home directory for '$target_user' was not found."
-target_uid=$(id -u "$target_user")
+target_uid=$(/usr/bin/id -u "$target_user")
 target_runtime_dir="/run/user/$target_uid"
+trusted_package_path="/usr/share/omarchy/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin"
 package_path="/usr/share/omarchy/bin:/usr/local/bin:/usr/bin:/bin:$target_home/.local/bin"
 
 as_root() {
+  if (( privilege_boundary_crossed )); then
+    fail "Internal error: privileged work was attempted after the user-code boundary."
+  fi
+
   if (( EUID == 0 )); then
     "$@"
   else
-    sudo "$@"
+    # --no-update authorizes this command without publishing a reusable
+    # timestamp to the invoking user or any detached sibling process.
+    /usr/bin/sudo -N -- "$@"
   fi
 }
 
 run_as_user() {
   if (( EUID == 0 )); then
-    if command -v sudo >/dev/null 2>&1; then
-      sudo -u "$target_user" -H "$@"
-    else
-      runuser -u "$target_user" -- "$@"
-    fi
+    /usr/bin/runuser -u "$target_user" -- /usr/bin/env \
+      HOME="$target_home" USER="$target_user" LOGNAME="$target_user" "$@"
   else
     "$@"
   fi
 }
 
 run_as_user_session() {
-  run_as_user env \
+  run_as_user /usr/bin/env \
     HOME="$target_home" \
     USER="$target_user" \
     LOGNAME="$target_user" \
@@ -213,12 +268,15 @@ run_as_user_session() {
 # Run an Omarchy command as the user with the package-backed paths, without
 # assuming a live session. Extra NAME=VALUE args extend the environment.
 run_as_user_omarchy() {
-  run_as_user env \
+  local command_path="$package_path"
+  [[ ${OMARCHY_TRUSTED_COMMAND_PATH:-0} == 1 ]] && command_path="$trusted_package_path"
+
+  run_as_user /usr/bin/env \
     HOME="$target_home" \
     USER="$target_user" \
     LOGNAME="$target_user" \
     OMARCHY_PATH=/usr/share/omarchy \
-    PATH="$package_path" \
+    PATH="$command_path" \
     "$@"
 }
 
@@ -247,14 +305,14 @@ mark_packages_explicit() {
 }
 
 target_hyprland_pid() {
-  pgrep -u "$target_uid" -x Hyprland 2>/dev/null | head -n1 || true
+  /usr/bin/pgrep -u "$target_uid" -x Hyprland 2>/dev/null | /usr/bin/head -n1 || true
 }
 
 target_process_env() {
   local name="$1" pid value
   pid=$(target_hyprland_pid)
   [[ -n $pid && -r /proc/$pid/environ ]] || return 1
-  value=$(tr '\0' '\n' <"/proc/$pid/environ" 2>/dev/null | awk -v name="$name" '
+  value=$(/usr/bin/tr '\0' '\n' <"/proc/$pid/environ" 2>/dev/null | /usr/bin/awk -v name="$name" '
     BEGIN { prefix = name "=" }
     index($0, prefix) == 1 { print substr($0, length(prefix) + 1); exit }
   ' || true)
@@ -281,7 +339,7 @@ discover_wayland_display() {
   fi
 
   local candidates=()
-  mapfile -t candidates < <(find "$target_runtime_dir" -maxdepth 1 -type s -name 'wayland-*' -printf '%f\n' 2>/dev/null || true)
+  mapfile -t candidates < <(/usr/bin/find "$target_runtime_dir" -maxdepth 1 -type s -name 'wayland-*' -printf '%f\n' 2>/dev/null || true)
   (( ${#candidates[@]} == 1 )) || return 1
   printf '%s\n' "${candidates[0]}"
 }
@@ -306,7 +364,7 @@ discover_hyprland_signature() {
   fi
 
   local candidates=()
-  mapfile -t candidates < <(find "$target_runtime_dir/hypr" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null || true)
+  mapfile -t candidates < <(/usr/bin/find "$target_runtime_dir/hypr" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null || true)
   (( ${#candidates[@]} == 1 )) || return 1
   printf '%s\n' "${candidates[0]}"
 }
@@ -347,23 +405,67 @@ Make sure you have a backup.
 
 EOF
 
-  gum confirm "Continue with upgrade?" </dev/tty || exit 0
+  /usr/bin/gum confirm "Continue with upgrade?" </dev/tty || exit 0
 fi
 
-sudo_keepalive_pid=""
+privilege_boundary_crossed=0
 hyprland_config_reload_suppressed=0
 upgrade_started=0
 upgrade_completed=0
 
+open_privilege_window() {
+  (( ! privilege_boundary_crossed )) || fail "Internal error: sudo cannot be reopened after the user-code boundary."
+
+  [[ -x /usr/bin/sudo ]] || (( EUID == 0 )) || fail "sudo is required when not running as root."
+  if (( EUID == 0 )); then
+    [[ ! -x /usr/bin/sudo ]] ||
+      /usr/bin/runuser -u "$target_user" -- /usr/bin/sudo -k ||
+      fail "Could not invalidate the target user's existing sudo timestamp."
+    return 0
+  fi
+
+  /usr/bin/sudo -k || fail "Could not invalidate the existing sudo timestamp."
+  LC_ALL=C /usr/bin/sudo -h 2>&1 | /usr/bin/grep -Eq '^usage: sudo .*\[[^]]*N[^]]*\]' ||
+    fail "This sudo does not support --no-update; refusing to publish a reusable credential."
+}
+
+close_privilege_window() {
+  local invalidation_status=0
+
+  (( ! privilege_boundary_crossed )) || return 0
+
+  # Defense in depth: no command above updates a timestamp, but invalidate the
+  # desktop user's ticket again before any user-controlled upgrade step.
+  if [[ -x /usr/bin/sudo ]]; then
+    if (( EUID == 0 )); then
+      /usr/bin/runuser -u "$target_user" -- /usr/bin/sudo -k || invalidation_status=$?
+    else
+      /usr/bin/sudo -k || invalidation_status=$?
+    fi
+  fi
+
+  ((invalidation_status == 0)) || return "$invalidation_status"
+  privilege_boundary_crossed=1
+}
+
 cleanup_on_exit() {
   local exit_status=$?
 
-  if (( hyprland_config_reload_suppressed )); then
-    restore_hyprland_config_reload >/dev/null 2>&1 || true
+  # A killed retry of an older upgrader may have left this active. Never return
+  # with pacman still accepting unsigned Omarchy packages, even when a later
+  # upgrade step fails.
+  if (( upgrade_started && ! privilege_boundary_crossed )); then
+    remove_insecure_omarchy_siglevels >/dev/null 2>&1 || true
   fi
 
-  if [[ -n ${sudo_keepalive_pid:-} ]]; then
-    kill "$sudo_keepalive_pid" 2>/dev/null || true
+  # Revoke sudo before any best-effort session/user cleanup. This also covers
+  # failures and signals in the privileged phase, and invalidates a credential
+  # that predated this invocation. If
+  # invalidation itself fails, do not cross into user-controlled cleanup code.
+  close_privilege_window >/dev/null 2>&1 || true
+
+  if (( privilege_boundary_crossed && hyprland_config_reload_suppressed )); then
+    restore_hyprland_config_reload >/dev/null 2>&1 || true
   fi
 
   # set -e aborts without a word, and the last thing on screen is a green
@@ -378,13 +480,74 @@ cleanup_on_exit() {
 }
 trap cleanup_on_exit EXIT
 
-if (( EUID != 0 )); then
-  sudo -v
-  while true; do sudo -n true; sleep 60; done 2>/dev/null &
-  sudo_keepalive_pid=$!
-fi
+backup_suffix=$(/usr/bin/date +%Y%m%d%H%M%S)
 
-backup_suffix=$(date +%Y%m%d%H%M%S)
+remove_insecure_omarchy_siglevels() {
+  [[ -f /etc/pacman.conf ]] || return 0
+  if ! /usr/bin/awk '
+    BEGIN { in_omarchy = 0 }
+    /^[[:space:]]*\[omarchy\][[:space:]]*$/ { in_omarchy = 1; print; next }
+    /^[[:space:]]*\[/ { in_omarchy = 0 }
+    in_omarchy && /^[[:space:]]*SigLevel[[:space:]]*=.*((Package|Database)?Optional|(Package|Database)?Never|TrustAll)([[:space:]]|$)/ {
+      print "SigLevel = Required DatabaseOptional"
+      next
+    }
+    { print }
+  ' /etc/pacman.conf |
+    as_root /usr/bin/install -T -o root -g root -m 0644 /dev/stdin /etc/pacman.conf; then
+    return 1
+  fi
+}
+
+disable_insecure_t2_repository() (
+  [[ -f /etc/pacman.conf ]] || return 0
+  local section backup
+
+  section=$(/usr/bin/awk '
+    found && /^[[:space:]]*\[/ { exit }
+    /^[[:space:]]*\[arch-mact2\][[:space:]]*$/ { found = 1 }
+    found { print }
+  ' /etc/pacman.conf) || return 1
+  [[ -n $section ]] || return 0
+  /usr/bin/grep -Eq '^[[:space:]]*SigLevel[[:space:]]*=.*((Package)?(Never|Optional)|TrustAll)([[:space:]]|$)' <<<"$section" || return 0
+
+  backup="/etc/pacman.d/arch-mact2.omarchy-disabled.$backup_suffix.txt"
+  as_root /usr/bin/install -T -o root -g root -m 0600 /dev/stdin "$backup" <<<"$section" || return 1
+  /usr/bin/awk '
+    /^[[:space:]]*\[arch-mact2\][[:space:]]*$/ { drop = 1; next }
+    drop && /^[[:space:]]*\[/ { drop = 0 }
+    !drop { print }
+  ' /etc/pacman.conf |
+    as_root /usr/bin/install -T -o root -g root -m 0644 /dev/stdin /etc/pacman.conf || return 1
+  warn "Disabled the unauthenticated arch-mact2 repository; preserved its section at $backup"
+)
+
+installed_omarchy_primary_fingerprint() {
+  as_root /usr/bin/gpg --homedir /etc/pacman.d/gnupg --batch --with-colons \
+    --fingerprint "$OMARCHY_PACKAGING_KEY_FINGERPRINT" 2>/dev/null |
+    /usr/bin/awk -F: '
+      $1 == "pub" && !seen { seen = 1; next }
+      seen && $1 == "fpr" { print $10; exit }
+    '
+}
+
+bootstrap_omarchy_packaging_key() {
+  local actual
+  log "Establishing the pinned Omarchy packaging key"
+
+  actual=$(installed_omarchy_primary_fingerprint || true)
+  if [[ $actual != "$OMARCHY_PACKAGING_KEY_FINGERPRINT" ]]; then
+    as_root /usr/bin/pacman-key --recv-keys "$OMARCHY_PACKAGING_KEY_FINGERPRINT" \
+      --keyserver hkps://keys.openpgp.org ||
+      fail "Could not retrieve the pinned Omarchy packaging key; no package transaction was attempted."
+    actual=$(installed_omarchy_primary_fingerprint || true)
+  fi
+
+  [[ $actual == "$OMARCHY_PACKAGING_KEY_FINGERPRINT" ]] ||
+    fail "The retrieved Omarchy packaging key fingerprint did not match $OMARCHY_PACKAGING_KEY_FINGERPRINT."
+  as_root /usr/bin/pacman-key --lsign-key "$OMARCHY_PACKAGING_KEY_FINGERPRINT" ||
+    fail "Could not locally trust the verified Omarchy packaging key."
+}
 
 configure_pacman_channel() {
   log "Configuring Omarchy pacman repositories ($channel)"
@@ -403,15 +566,12 @@ configure_pacman_channel() {
 
   # Replace the normal Omarchy package repository. Dev package mode uses the
   # edge channel and resolves omarchy-dev / omarchy-settings-dev from [omarchy].
-  local tmp
-
-  tmp=$(mktemp)
   awk -v server="$package_server" '
     BEGIN { in_omarchy = 0; wrote = 0 }
     /^[[:space:]]*\[omarchy\][[:space:]]*$/ {
       if (!wrote) {
         print "[omarchy]"
-        print "SigLevel = Optional TrustAll"
+        print "SigLevel = Required DatabaseOptional"
         print "Server = " server
         wrote = 1
       }
@@ -424,13 +584,30 @@ configure_pacman_channel() {
       if (!wrote) {
         print ""
         print "[omarchy]"
-        print "SigLevel = Optional TrustAll"
+        print "SigLevel = Required DatabaseOptional"
         print "Server = " server
       }
     }
-  ' /etc/pacman.conf >"$tmp"
-  as_root install -m 0644 "$tmp" /etc/pacman.conf
-  rm -f "$tmp"
+  ' /etc/pacman.conf |
+    as_root install -T -m 0644 /dev/stdin /etc/pacman.conf
+}
+
+verify_effective_omarchy_package_policy() {
+  local policy
+  policy=$(/usr/bin/pacman-conf --repo omarchy SigLevel 2>/dev/null) ||
+    fail "Could not resolve the effective Omarchy repository signature policy."
+  if [[ -z ${policy//[$' \t\n\r']/} ]]; then
+    policy=$(/usr/bin/pacman-conf SigLevel 2>/dev/null) ||
+      fail "Could not resolve the inherited package signature policy."
+  fi
+  policy=${policy//$'\n'/ }
+  policy=${policy//$'\t'/ }
+  [[ " $policy " == *" PackageRequired "* &&
+    " $policy " == *" PackageTrustedOnly "* &&
+    " $policy " != *" PackageOptional "* &&
+    " $policy " != *" PackageNever "* &&
+    " $policy " != *" PackageTrustAll "* ]] ||
+    fail "The effective Omarchy repository policy does not require trusted package signatures."
 }
 
 install_keyrings() {
@@ -447,12 +624,7 @@ install_keyrings() {
   # server's copy isn't newer, leaving stale checksums that no amount of
   # re-downloading can satisfy.
 
-  as_root pacman -Syy --noconfirm archlinux-keyring omarchy-keyring || {
-    warn "Keyring package install failed; attempting to trust the Omarchy packaging key directly."
-    as_root pacman-key --recv-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 --keyserver keys.openpgp.org || true
-    as_root pacman-key --lsign-key 40DFB630FF42BCFFB047046CF0134EE680CAC571 || true
-    as_root pacman -Syy --noconfirm archlinux-keyring omarchy-keyring
-  }
+  as_root pacman -Syy --noconfirm archlinux-keyring omarchy-keyring
 }
 
 remove_legacy_installer_package() {
@@ -658,19 +830,40 @@ configure_lock_authentication() {
   [[ -n $apply_lock ]] || fail "Neither omarchy-apply-lock nor omarchy-setup-lock is available under /usr/share/omarchy/bin; lock screen authentication could not be configured."
 
   log "Configuring lock screen authentication"
-  as_root env \
+  as_root /usr/bin/env \
     OMARCHY_INSTALL_USER="$target_user" \
     OMARCHY_PATH=/usr/share/omarchy \
-    PATH="$package_path" \
+    PATH="$trusted_package_path" \
     "$apply_lock"
 }
 
 create_pre_upgrade_snapshot() {
-  # 127 means Snapper is deliberately absent. Any other failure already said
-  # what went wrong, and a missing snapshot is not worth blocking the upgrade
-  # over, but it must not pass for one either.
-  omarchy-snapshot create || (($? == 127)) ||
-    echo -e "\e[33mContinuing the upgrade without a snapshot.\e[0m" >&2
+  local config list_output
+  local configs=()
+
+  [[ -x /usr/bin/snapper ]] || return 0
+
+  # Do not invoke the legacy user-path wrapper here. Its former implementation
+  # (`omarchy-snapshot create || (($? == 127)) || ...`) could execute a
+  # user-controlled command inside the trusted system-package phase.
+  if ! list_output=$(as_root /usr/bin/snapper --csvout list-configs); then
+    warn "Could not list Snapper configurations. Continuing the upgrade without a snapshot."
+    return 0
+  fi
+  mapfile -t configs < <(printf '%s\n' "$list_output" | /usr/bin/awk -F, 'NR > 1 { print $1 }')
+  ((${#configs[@]})) || {
+    warn "No Snapper configurations were found. Continuing the upgrade without a snapshot."
+    return 0
+  }
+
+  log "Creating pre-upgrade system snapshot"
+  for config in "${configs[@]}"; do
+    if ! as_root /usr/bin/snapper -c "$config" create -c number -d "Before Omarchy Quattro upgrade" ||
+      ! as_root /usr/bin/snapper -c "$config" cleanup number; then
+      warn "Could not complete the '$config' snapshot. Continuing the upgrade without a complete snapshot."
+      return 0
+    fi
+  done
 }
 
 remove_conflicting_legacy_packages() {
@@ -732,19 +925,24 @@ install_omarchy_quattro_packages() {
   )
   local base_packages=()
 
-  log "Upgrading system packages and installing Omarchy quattro packages"
+  log "Adopting legacy system files into Omarchy quattro package ownership"
   (( use_dev_packages )) && log "Using dev packages [omarchy-dev / omarchy-settings-dev]"
   # --noconfirm answers "no" to conflict-removal prompts. --ask 4 preselects
   # removing the conflicting package, which is required for legacy packages like
   # ttf-jetbrains-mono-nerd -> ttf-jetbrains-mono-nerd-basic.
-  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --needed --noconfirm --ask 4 --overwrite='*' "${core_packages[@]}"
+  # omarchy-settings owns the static system paths written directly by 3.x. This
+  # is their one-time ownership bridge; no later package operation overwrites.
+  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -S --noconfirm --ask 4 --overwrite='*' "$settings_package"
+
+  log "Upgrading system packages and installing Omarchy quattro packages"
+  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --needed --noconfirm --ask 4 "${core_packages[@]}"
   mark_packages_explicit "${core_packages[@]}"
 
   if [[ -f /usr/share/omarchy/install/omarchy-base.packages ]]; then
     log "Installing Omarchy quattro default package set"
     mapfile -t base_packages < <(sed -e 's/[[:space:]]*#.*$//' -e '/^[[:space:]]*$/d' /usr/share/omarchy/install/omarchy-base.packages)
     if (( ${#base_packages[@]} )); then
-      as_root pacman -S --needed --noconfirm --ask 4 --overwrite='*' "${base_packages[@]}"
+      as_root pacman -S --needed --noconfirm --ask 4 "${base_packages[@]}"
       mark_packages_explicit "${base_packages[@]}"
     fi
   else
@@ -763,7 +961,7 @@ install_omarchy_quattro_packages() {
     libpulse
     wireplumber
   )
-  as_root pacman -S --needed --noconfirm --ask 4 --overwrite='*' "${audio_packages[@]}"
+  as_root pacman -S --needed --noconfirm --ask 4 "${audio_packages[@]}"
   mark_packages_explicit "${audio_packages[@]}"
 }
 
@@ -1092,7 +1290,9 @@ cleanup_retired_services() {
   done
   as_root systemctl disable systemd-networkd-wait-online.service >/dev/null 2>&1 || true
   as_root systemctl mask systemd-networkd-wait-online.service >/dev/null 2>&1 || true
+}
 
+cleanup_retired_user_services() {
   cleanup_retired_user_unit_files
   if [[ -S $target_runtime_dir/bus ]]; then
     run_as_user_session systemctl --user disable "${retired_user_units[@]}" >/dev/null 2>&1 || true
@@ -1123,19 +1323,16 @@ run_as_user_wayland_session() {
 }
 
 run_hyprctl_session() {
-  local hyprctl_bin
-  hyprctl_bin=/usr/bin/hyprctl
-  [[ -x $hyprctl_bin ]] || hyprctl_bin=$(command -v hyprctl || true)
-  [[ -n $hyprctl_bin ]] || return 1
+  [[ -x /usr/bin/hyprctl ]] || return 1
 
-  run_as_user_wayland_session "$hyprctl_bin" "$@"
+  run_as_user_wayland_session /usr/bin/hyprctl "$@"
 }
 
 suppress_hyprland_config_reload() {
   # Say so up front when the session cannot be reached at all. Otherwise this
   # silently does nothing and the only evidence is the config error bar that
   # shows up minutes later.
-  if ! run_as_user_wayland_session true >/dev/null 2>&1; then
+  if ! run_as_user_wayland_session /usr/bin/true >/dev/null 2>&1; then
     warn "Could not reach the live Hyprland session; it will report config errors during the swap, and the Omarchy shell will start after reboot."
     return 0
   fi
@@ -1193,10 +1390,11 @@ run_post_upgrade_migrations() {
   local pending_status
 
   log "Running Omarchy migrations"
-  if ! run_as_user_omarchy OMARCHY_UPGRADE_TO_QUATTRO_LIVE=1 omarchy-migrate; then
+  [[ -x /usr/share/omarchy/bin/omarchy-migrate ]] || fail "The packaged Omarchy migration command is unavailable."
+  if ! OMARCHY_TRUSTED_COMMAND_PATH=1 run_as_user_omarchy OMARCHY_UPGRADE_TO_QUATTRO_LIVE=1 omarchy-migrate; then
     fail "Omarchy migrations did not complete. Fix the error above and rerun the upgrade before rebooting."
   fi
-  if run_as_user_omarchy omarchy-migrate --pending >/dev/null; then
+  if OMARCHY_TRUSTED_COMMAND_PATH=1 run_as_user_omarchy omarchy-migrate --pending >/dev/null; then
     fail "Omarchy migrations are still pending. Rerun the upgrade before rebooting."
   else
     pending_status=$?
@@ -1208,58 +1406,58 @@ run_post_upgrade_migrations() {
 
 run_final_system_package_upgrade() {
   log "Checking for remaining system package updates"
-  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm --ask 4 \
-    --overwrite '/etc/docker/daemon.json' \
-    --overwrite '/etc/gnupg/dirmngr.conf' \
-    --overwrite '/etc/mkinitcpio.conf.d/omarchy_hooks.conf' \
-    --overwrite '/etc/mkinitcpio.conf.d/thunderbolt_module.conf' \
-    --overwrite '/etc/modprobe.d/omarchy-usb-autosuspend.conf' \
-    --overwrite '/etc/sddm.conf.d/10-theme.conf' \
-    --overwrite '/etc/sddm.conf.d/10-wayland.conf' \
-    --overwrite '/etc/sudoers.d/omarchy-asdcontrol' \
-    --overwrite '/etc/sudoers.d/omarchy-passwd-tries' \
-    --overwrite '/etc/sudoers.d/omarchy-tzupdate' \
-    --overwrite '/etc/sysctl.d/90-omarchy-file-watchers.conf' \
-    --overwrite '/etc/sysctl.d/99-omarchy-sysctl.conf' \
-    --overwrite '/etc/systemd/logind.conf.d/10-ignore-power-button.conf' \
-    --overwrite '/etc/systemd/resolved.conf.d/10-disable-multicast.conf' \
-    --overwrite '/etc/systemd/resolved.conf.d/20-docker-dns.conf' \
-    --overwrite '/etc/systemd/system.conf.d/10-faster-shutdown.conf' \
-    --overwrite '/etc/systemd/system/user@.service.d/10-faster-shutdown.conf' \
-    --overwrite '/etc/systemd/system/docker.service.d/no-block-boot.conf' \
-    --overwrite '/etc/systemd/system/plocate-updatedb.service.d/ac-only.conf' \
-    --overwrite '/etc/systemd/system.conf.d/20-omarchy-nofile.conf' \
-    --overwrite '/etc/systemd/user.conf.d/20-omarchy-nofile.conf' \
-    --overwrite '/usr/lib/systemd/system-sleep/unmount-fuse' \
-    --overwrite '/usr/share/plymouth/themes/omarchy/*' \
-    --overwrite '/usr/share/sddm/hyprland.lua' \
-    --overwrite '/usr/share/sddm/themes/omarchy/*'
+  as_root env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm --ask 4
 }
 
-run_post_upgrade_update_steps() {
-  local update_output update_status
+run_cold_aur_update() {
+  local aur_update_bin=/usr/share/omarchy/bin/omarchy-update-aur-pkgs
 
-  if PATH="$package_path" command -v omarchy-update-aur-pkgs >/dev/null 2>&1; then
-    if ! run_as_user_omarchy omarchy-update-aur-pkgs; then
+  # Build scripts are user-controlled. Yay may still request a visible package
+  # installation authorization, but its fixed sudo wrapper uses --no-update so
+  # neither the build nor a detached child receives a reusable timestamp.
+  if [[ -x $aur_update_bin ]]; then
+    if ! run_as_user_omarchy OMARCHY_SUDO_NO_UPDATE=1 "$aur_update_bin"; then
       warn "Could not update AUR packages; running omarchy-update after reboot may still update AUR packages."
     fi
   fi
+}
 
-  if PATH="$package_path" command -v omarchy-update-mise >/dev/null 2>&1; then
-    if ! run_as_user_omarchy omarchy-update-mise; then
+run_post_upgrade_update_steps() {
+  local mise_update_bin=/usr/share/omarchy/bin/omarchy-update-mise
+  local update_available_bin=/usr/share/omarchy/bin/omarchy-update-available
+  local update_output update_status
+
+  if [[ -x $mise_update_bin ]]; then
+    if ! run_as_user_omarchy "$mise_update_bin"; then
       warn "Could not update mise tools; running omarchy-update after reboot may still update mise-managed tools."
     fi
   fi
 
-  if PATH="$package_path" command -v omarchy-update-available >/dev/null 2>&1; then
+  if [[ -x $update_available_bin ]]; then
     log "Refreshing update indicator state"
     update_status=0
-    update_output=$(run_as_user_omarchy omarchy-update-available 2>&1) || update_status=$?
+    update_output=$(run_as_user_omarchy "$update_available_bin" 2>&1) || update_status=$?
 
     if (( update_status == 0 )); then
       warn "Updates are still available after the upgrade; run omarchy-update after reboot:"
       printf '%s\n' "$update_output" >&2
     fi
+  fi
+}
+
+request_reboot() {
+  # This is deliberately a direct systemd/logind request, never a new sudo
+  # authentication after running migrations, mise, theme hooks, and other
+  # user-controlled code. An already-root invocation stays root; it has no
+  # target-user credential to publish and remains reliable when headless.
+  /usr/bin/systemctl reboot
+}
+
+confirm_reboot() {
+  if (( EUID == 0 )); then
+    run_as_user /usr/bin/gum confirm "$1"
+  else
+    /usr/bin/gum confirm "$1"
   fi
 }
 
@@ -1287,8 +1485,8 @@ apply_firewall_defaults() {
   fi
 
   log "Applying Omarchy firewall defaults"
-  as_root env OMARCHY_PATH=/usr/share/omarchy PATH="$package_path" \
-    bash -euo pipefail "$firewall_script" ||
+  as_root /usr/bin/env OMARCHY_PATH=/usr/share/omarchy PATH="$trusted_package_path" \
+    /usr/bin/bash -euo pipefail "$firewall_script" ||
     warn "Could not apply firewall defaults; run 'sudo bash $firewall_script' after reboot."
 }
 
@@ -1338,10 +1536,6 @@ apply_system_transition() {
         done
       '
   fi
-  as_root install -d -m 0755 /usr/lib/chromium
-  printf '%s\n' '{"distribution":{"require_eula":false},"browser":{"theme":{"color_scheme":0,"color_scheme2":0}}}' | \
-    as_root tee /usr/lib/chromium/initial_preferences >/dev/null
-
   # Deliberately do NOT add the user to the docker group. That group is
   # root-equivalent, so it is opt-in now (Setup > Security > Sudoless Docker);
   # re-granting it on upgrade would silently undo that default for everyone.
@@ -1392,14 +1586,7 @@ EOF
   apply_firewall_defaults
 
   log "Normalizing SDDM login configuration"
-  # The omarchy package already installed 10-theme.conf and 10-wayland.conf.
   as_root install -d -m 0755 /etc/sddm.conf.d
-  cat <<'EOF' | as_root tee /etc/sddm.conf.d/99-omarchy-login.conf >/dev/null
-[Users]
-RememberLastUser=true
-RememberLastSession=true
-EOF
-
   local autologin_user
   if should_enable_sddm_autologin; then
     if as_root test -f /etc/sddm.conf.d/autologin.conf; then
@@ -2342,16 +2529,27 @@ refresh_current_theme_after_upgrade() {
     warn "Could not apply browser theme colour. Run 'omarchy theme set \"$theme_name\"' after reboot if Chromium's theme looks stale."
 }
 
-# Everything below mutates the system, so a non-zero exit from here on leaves a
-# half-upgraded machine that must not be rebooted.
+# Everything below begins the upgrade lifecycle. Suppress live Hyprland reloads
+# before anything touches the legacy config
+# trees. This path executes only fixed /usr/bin session plumbing and hyprctl,
+# before any sudo credential exists.
 upgrade_started=1
-
-# Suppress live Hyprland reloads before anything touches the legacy config
-# trees; the swap windows otherwise surface transient "source= globbing error"
-# popups in the running session.
 suppress_hyprland_config_reload
+
+# Cold-invalidate any older ticket, then authorize each trusted system/package
+# command with sudo --no-update. No reusable credential exists at any point,
+# even if caller startup code already spawned a detached waiter.
+open_privilege_window
 create_pre_upgrade_snapshot
+
+# Repair the active policy left by an interrupted legacy upgrader before any
+# package transaction. From this point onward a failure may stop the upgrade,
+# but it cannot authorize an unsigned Omarchy package transaction.
+remove_insecure_omarchy_siglevels
+disable_insecure_t2_repository
 configure_pacman_channel
+bootstrap_omarchy_packaging_key
+verify_effective_omarchy_package_policy
 install_keyrings
 remove_legacy_installer_package
 remove_legacy_limine_configs
@@ -2363,19 +2561,31 @@ preserve_kernel_cmdline_root
 configure_snapper_policy
 configure_lock_authentication
 migrate_1password_beta_package
-cleanup_legacy_user_paths
 apply_system_transition
+cleanup_retired_services
+remove_retired_default_packages
+run_final_system_package_upgrade
+
+# This is the irreversible trust boundary. The already-cold target user's
+# fixed-path sudo timestamp is invalidated again before user-controlled code.
+# No call below may use as_root or publish a reusable sudo timestamp. Packaged
+# migrations may authenticate only through their fixed sudo --no-update shim.
+close_privilege_window || fail "Could not invalidate sudo before running user upgrade steps."
+
+cleanup_legacy_user_paths
 apply_user_transition
 apply_user_hardware_transition
 run_as_user_omarchy omarchy-refresh-applications ||
   warn "Could not refresh application launchers; run 'omarchy refresh applications' after reboot."
 run_as_user_omarchy omarchy-bar defaults ||
   warn "Could not restore the default bar widgets; run 'omarchy bar defaults' after reboot."
-cleanup_retired_services
+cleanup_retired_user_services
 ensure_sleep_lock_service
-remove_retired_default_packages
-run_final_system_package_upgrade
+# omarchy-migrate starts from another fixed-path sudo -k and routes any
+# migration authentication through sudo --no-update, preserving chronological
+# migration order without publishing a ticket to earlier migrations.
 run_post_upgrade_migrations
+run_cold_aur_update
 run_post_upgrade_update_steps
 refresh_current_theme_after_upgrade
 # Do not force-reload Hyprland in the live upgraded session. The legacy
@@ -2396,9 +2606,10 @@ if (( boot_cmdline_unsafe )); then
   warn "Skipping reboot: root= could not be confirmed in the boot entries. Repair the kernel cmdline (see the warnings above) before rebooting, or the system will drop to an emergency shell."
 elif (( auto_reboot )); then
   log "Rebooting because --reboot was passed"
-  as_root systemctl reboot
-elif gum confirm "Reboot to complete Quattro upgrade now?" </dev/tty; then
-  as_root systemctl reboot
+  request_reboot
+elif confirm_reboot "Reboot to complete Quattro upgrade now?" </dev/tty; then
+  request_reboot
 else
   echo "Not rebooting. Please reboot manually after confirming there were no errors."
+fi
 fi

--- a/install/post-install/pacman.sh
+++ b/install/post-install/pacman.sh
@@ -10,4 +10,5 @@ if [[ -f $OMARCHY_PATH/etc-overrides/cups-cups-files.conf && -f /etc/cups/cups-f
   rm -f /etc/cups/cups-files.conf.pacnew
 fi
 
-source "$OMARCHY_INSTALL/hardware/pacman.sh"
+# No hardware repository overrides are currently required. In particular, T2
+# packages must continue resolving through the signed Omarchy repository.

--- a/manual/31-dotfiles.md
+++ b/manual/31-dotfiles.md
@@ -37,8 +37,8 @@ Omarchy fires hooks at a handful of moments, and you can hang your own scripts o
 | Event | When it runs |
 | ----- | ------------ |
 | `post-boot` | Right after the desktop has started |
-| `post-update` | During `omarchy update`, after packages and migrations |
-| `pre-refresh-pacman` | Before `omarchy refresh pacman` re-syncs the package config |
+| `post-update` | At the end of `omarchy update`, after privileged work |
+| `pre-refresh-pacman` | After `omarchy refresh pacman` finishes; after the complete switch/update when changing channels (legacy name) |
 | `theme-set` | After a theme change (theme name in `$1`) |
 | `font-set` | After a font change (font name in `$1`) |
 | `battery-low` | When the battery gets low (percentage in `$1`) |

--- a/test/shell.d/channel-test.sh
+++ b/test/shell.d/channel-test.sh
@@ -4,8 +4,31 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+if [[ ${OMARCHY_CHANNEL_TEST_NS:-0} != 1 ]]; then
+  exec unshare --user --map-root-user --mount \
+    env OMARCHY_CHANNEL_TEST_NS=1 bash "$0"
+fi
+
 test_tmp=$(mktemp -d)
-trap 'rm -rf "$test_tmp"' EXIT
+fixed_paths_bound=0
+sudo_wrapper_tree_bound=0
+cleanup() {
+  if (( fixed_paths_bound )); then
+    umount /usr/bin/gum
+    umount /usr/bin/git
+    umount /usr/bin/omarchy-dev-link
+    umount /usr/bin/omarchy-dev-unlink
+    umount /usr/bin/omarchy-state
+    umount /usr/bin/omarchy-refresh-pacman
+    umount /usr/bin/omarchy-update
+    umount /usr/bin/sudo
+  fi
+  if (( sudo_wrapper_tree_bound )); then
+    umount /usr/share/omarchy
+  fi
+  rm -rf "$test_tmp"
+}
+trap cleanup EXIT
 
 stub_bin="$test_tmp/bin"
 log_file="$test_tmp/channel.log"
@@ -23,12 +46,18 @@ write_stub omarchy-refresh-pacman '#!/bin/bash
 printf "refresh" >>"$OMARCHY_CHANNEL_TEST_LOG"
 for arg in "$@"; do printf "\t%s" "$arg" >>"$OMARCHY_CHANNEL_TEST_LOG"; done
 printf "\n" >>"$OMARCHY_CHANNEL_TEST_LOG"
+if [[ ${1:-} == "--run-deferred-hook" ]]; then
+  omarchy-hook pre-refresh-pacman
+fi
 '
 
 write_stub sudo '#!/bin/bash
 printf "sudo" >>"$OMARCHY_CHANNEL_TEST_LOG"
 for arg in "$@"; do printf "\t%s" "$arg" >>"$OMARCHY_CHANNEL_TEST_LOG"; done
 printf "\n" >>"$OMARCHY_CHANNEL_TEST_LOG"
+if [[ ${1:-} == "-h" ]]; then
+  echo "usage: sudo [-ABbEHkNnPS] command"
+fi
 '
 
 write_stub omarchy-dev-unlink '#!/bin/bash
@@ -47,6 +76,13 @@ write_stub omarchy-update '#!/bin/bash
 printf "update" >>"$OMARCHY_CHANNEL_TEST_LOG"
 for arg in "$@"; do printf "\t%s" "$arg" >>"$OMARCHY_CHANNEL_TEST_LOG"; done
 printf "\tOMARCHY_PATH=%s" "$OMARCHY_PATH" >>"$OMARCHY_CHANNEL_TEST_LOG"
+printf "\n" >>"$OMARCHY_CHANNEL_TEST_LOG"
+exit "${OMARCHY_TEST_UPDATE_STATUS:-0}"
+'
+
+write_stub omarchy-hook '#!/bin/bash
+printf "hook" >>"$OMARCHY_CHANNEL_TEST_LOG"
+for arg in "$@"; do printf "\t%s" "$arg" >>"$OMARCHY_CHANNEL_TEST_LOG"; done
 printf "\n" >>"$OMARCHY_CHANNEL_TEST_LOG"
 '
 
@@ -87,6 +123,24 @@ case "${OMARCHY_TEST_PACKAGES:-}" in
 esac
 '
 
+# Channel-set deliberately invokes the three trust-boundary commands through
+# fixed installed paths. Bind the stubs over those paths only in this private
+# mount namespace so the behavior tests exercise that contract.
+mount -t tmpfs -o mode=0755 tmpfs /usr/share/omarchy
+mkdir -p /usr/share/omarchy/default/omarchy/sudo-no-update
+cp "$ROOT/default/omarchy/sudo-no-update/sudo" /usr/share/omarchy/default/omarchy/sudo-no-update/sudo
+chmod 0755 /usr/share/omarchy/default/omarchy/sudo-no-update/sudo
+sudo_wrapper_tree_bound=1
+mount --bind "$stub_bin/gum" /usr/bin/gum
+mount --bind "$stub_bin/git" /usr/bin/git
+mount --bind "$stub_bin/omarchy-dev-link" /usr/bin/omarchy-dev-link
+mount --bind "$stub_bin/omarchy-dev-unlink" /usr/bin/omarchy-dev-unlink
+mount --bind "$stub_bin/omarchy-state" /usr/bin/omarchy-state
+mount --bind "$stub_bin/omarchy-refresh-pacman" /usr/bin/omarchy-refresh-pacman
+mount --bind "$stub_bin/omarchy-update" /usr/bin/omarchy-update
+mount --bind "$stub_bin/sudo" /usr/bin/sudo
+fixed_paths_bound=1
+
 run_channel() {
   : >"$log_file"
   OMARCHY_CHANNEL_TEST_LOG="$log_file" \
@@ -105,24 +159,27 @@ assert_log_line() {
 }
 
 run_channel stable
-assert_log_line $'refresh\tstable' "stable refreshes the stable pacman channel"
-assert_log_line $'sudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy\tomarchy-settings' "stable installs stable Omarchy packages"
+assert_log_line $'refresh\tstable\t--defer-hook' "stable refreshes the stable pacman channel with its user hook deferred"
+assert_log_line $'sudo\t-N\t--\t/usr/bin/env\tPATH=/usr/bin:/usr/sbin:/bin:/sbin\tOMARCHY_UPDATE_PACMAN=1\t/usr/bin/pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy\tomarchy-settings' "stable installs stable Omarchy packages without publishing a timestamp"
 assert_log_line $'unlink\t--no-reboot' "stable restores the package-backed Omarchy path without an early reboot prompt"
 assert_log_line $'update\t-y\tOMARCHY_PATH=/usr/share/omarchy' "stable runs the normal update pipeline from the package-backed path"
+assert_log_line $'refresh\t--run-deferred-hook' "stable reaches the deferred refresh-hook boundary after updating"
+assert_log_line $'hook\tpre-refresh-pacman' "stable runs the deferred refresh hook exactly once"
+[[ $(grep -c $'^hook\tpre-refresh-pacman$' "$log_file") == 1 ]] || fail "stable ran the deferred refresh hook more than once" "$(cat "$log_file")"
 if grep -q $'^state\tset\treboot-required$' "$log_file"; then
   fail "stable does not require reboot when already package-backed" "$(cat "$log_file")"
 fi
 pass "stable does not require reboot when already package-backed"
 
 run_channel rc
-assert_log_line $'refresh\trc' "rc refreshes the rc pacman channel"
-assert_log_line $'sudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy\tomarchy-settings' "rc installs rc Omarchy packages"
+assert_log_line $'refresh\trc\t--defer-hook' "rc refreshes the rc pacman channel"
+assert_log_line $'sudo\t-N\t--\t/usr/bin/env\tPATH=/usr/bin:/usr/sbin:/bin:/sbin\tOMARCHY_UPDATE_PACMAN=1\t/usr/bin/pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy\tomarchy-settings' "rc installs rc Omarchy packages"
 assert_log_line $'unlink\t--no-reboot' "rc restores the package-backed Omarchy path without an early reboot prompt"
 assert_log_line $'update\t-y\tOMARCHY_PATH=/usr/share/omarchy' "rc runs the normal update pipeline from the package-backed path"
 
 OMARCHY_TEST_PATH="$ROOT" run_channel edge
-assert_log_line $'refresh\tedge' "edge refreshes the edge pacman channel"
-assert_log_line $'sudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev' "edge installs development Omarchy packages"
+assert_log_line $'refresh\tedge\t--defer-hook' "edge refreshes the edge pacman channel"
+assert_log_line $'sudo\t-N\t--\t/usr/bin/env\tPATH=/usr/bin:/usr/sbin:/bin:/sbin\tOMARCHY_UPDATE_PACMAN=1\t/usr/bin/pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev' "edge installs development Omarchy packages"
 assert_log_line $'unlink\t--no-reboot' "edge unlinks dev without an early reboot prompt"
 assert_log_line $'state\tset\treboot-required' "edge marks reboot required when leaving dev"
 assert_log_line $'update\t-y\tOMARCHY_PATH=/usr/share/omarchy' "edge runs the normal update pipeline from the package-backed path"
@@ -137,7 +194,7 @@ if run_channel dev >"$test_tmp/occupied.out" 2>"$test_tmp/occupied.err"; then
 fi
 
 grep -q "already exists and is not a git checkout" "$test_tmp/occupied.err" || fail "dev explains occupied checkout paths" "$(cat "$test_tmp/occupied.err")"
-if grep -Fx $'refresh\tedge' "$log_file" >/dev/null; then
+if grep -Fx $'refresh\tedge\t--defer-hook' "$log_file" >/dev/null; then
   fail "dev validates checkout path before changing packages" "$(cat "$log_file")"
 fi
 pass "dev refuses occupied non-checkout paths before package changes"
@@ -145,13 +202,13 @@ pass "dev refuses occupied non-checkout paths before package changes"
 rmdir "$checkout"
 run_channel dev
 assert_log_line $'gum\tconfirm\t--default=false\tSwitch to dev channel?' "dev asks for confirmation"
-assert_log_line $'refresh\tedge' "dev refreshes the edge pacman channel"
-assert_log_line $'sudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev' "dev installs development Omarchy packages"
+assert_log_line $'refresh\tedge\t--defer-hook' "dev refreshes the edge pacman channel"
+assert_log_line $'sudo\t-N\t--\t/usr/bin/env\tPATH=/usr/bin:/usr/sbin:/bin:/sbin\tOMARCHY_UPDATE_PACMAN=1\t/usr/bin/pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev' "dev installs development Omarchy packages"
 assert_log_line $'git\tclone\thttps://github.com/basecamp/omarchy.git\t'"$checkout" "dev clones the source checkout to ~/omarchy"
 assert_log_line $'link\t'"$checkout"$'\t--no-reboot' "dev links ~/omarchy without an early reboot prompt"
 assert_log_line $'state\tset\treboot-required' "dev defers the reboot prompt to the update pipeline"
 assert_log_line $'update\t-y\tOMARCHY_PATH='"$checkout" "dev runs the normal update pipeline from the source checkout"
-[[ $(grep -E '^(git|link|state|refresh|sudo|update)' "$log_file") == $'git\tclone\thttps://github.com/basecamp/omarchy.git\t'"$checkout"$'\nlink\t'"$checkout"$'\t--no-reboot\nstate\tset\treboot-required\nrefresh\tedge\nsudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev\nupdate\t-y\tOMARCHY_PATH='"$checkout" ]] ||
+[[ $(grep -E '^(git|link|state|refresh|sudo[[:space:]]-N|update|hook)' "$log_file") == $'git\tclone\thttps://github.com/basecamp/omarchy.git\t'"$checkout"$'\nlink\t'"$checkout"$'\t--no-reboot\nstate\tset\treboot-required\nrefresh\tedge\t--defer-hook\nsudo\t-N\t--\t/usr/bin/env\tPATH=/usr/bin:/usr/sbin:/bin:/sbin\tOMARCHY_UPDATE_PACMAN=1\t/usr/bin/pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev\nupdate\t-y\tOMARCHY_PATH='"$checkout"$'\nrefresh\t--run-deferred-hook\nhook\tpre-refresh-pacman' ]] ||
   fail "dev activates the checkout before changing or updating packages" "$(cat "$log_file")"
 pass "dev activates the checkout before changing or updating packages"
 
@@ -165,6 +222,19 @@ if grep -q $'^git\tclone\t' "$log_file"; then
 fi
 assert_log_line $'link\t'"$checkout"$'\t--no-reboot' "switching back to dev links ~/omarchy"
 pass "switching back to dev reuses the existing ~/omarchy checkout"
+
+OMARCHY_TEST_UPDATE_STATUS=1
+export OMARCHY_TEST_UPDATE_STATUS
+if run_channel stable >"$test_tmp/update-fail.out" 2>"$test_tmp/update-fail.err"; then
+  fail "channel switch with a failed update unexpectedly succeeded"
+fi
+unset OMARCHY_TEST_UPDATE_STATUS
+if grep -qxF $'refresh\t--run-deferred-hook' "$log_file" ||
+  grep -qxF $'hook\tpre-refresh-pacman' "$log_file"; then
+  fail "failed channel update ran the deferred refresh hook" "$(cat "$log_file")"
+fi
+grep -qxF $'sudo\t-k' "$log_file" || fail "failed channel update did not invalidate sudo credentials" "$(cat "$log_file")"
+pass "failed channel updates invalidate credentials and skip the deferred hook"
 
 current_channel() {
   OMARCHY_TEST_VERSION_CHANNEL="$1" \

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -15,6 +15,8 @@ terminal_log="$test_tmp/terminal-log"
 notification_log="$test_tmp/notification-log"
 setup_log="$test_tmp/setup-log"
 browser_file="$test_tmp/browser"
+browser_source="$test_tmp/browser-source"
+browser_installer="$test_tmp/omarchy-install-browser"
 mkdir -p "$mock_bin" "$test_home/.config" "$installed_dir"
 
 cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
@@ -57,7 +59,7 @@ cat >"$mock_bin/omarchy-test-installer" <<'SH'
 installer=${0##*/}
 
 if [[ $installer == "omarchy-install-browser" && ${OMARCHY_TEST_REAL_BROWSER_INSTALL:-false} == "true" ]]; then
-  exec "$ROOT/bin/omarchy-install-browser" "$@"
+  exec "$OMARCHY_TEST_BROWSER_INSTALLER" "$@"
 fi
 
 case $installer in
@@ -127,6 +129,30 @@ done
 
 chmod +x "$mock_bin"/*
 
+# This is a behavior test for browser/default orchestration, not the privileged
+# source-root boundary (covered by trusted-source-publication-security-test).
+# Give its isolated installer an explicit source fixture and fixed sudo stub so
+# the production command can keep ignoring caller OMARCHY_PATH and PATH.
+mkdir -p "$browser_source"/{bin,config,default/firefox,install/helpers}
+cp "$ROOT/config/chromium-flags.conf" "$browser_source/config/chromium-flags.conf"
+cp "$ROOT/default/firefox/policies.json" "$browser_source/default/firefox/policies.json"
+cp "$ROOT/install/helpers/browser-policy.sh" "$browser_source/install/helpers/browser-policy.sh"
+cp "$ROOT/install/helpers/as-root.sh" "$browser_source/install/helpers/as-root.sh"
+for command in \
+  omarchy-pkg-add omarchy-pkg-aur-add \
+  omarchy-install-chromium-copy-url omarchy-install-chromium-ytdlp \
+  omarchy-theme-set-browser; do
+  ln -s "$mock_bin/$command" "$browser_source/bin/$command"
+done
+sed \
+  -e '/^trusted_omarchy_source_root() {/,/^}/c\
+trusted_omarchy_source_root() { printf '\''%s\\n'\'' "$OMARCHY_TEST_SOURCE_ROOT"; }' \
+  -e '/^trusted_omarchy_source_file() {/,/^}/c\
+trusted_omarchy_source_file() { printf '\''%s\\n'\'' "$OMARCHY_TEST_SOURCE_ROOT/$1"; }' \
+  -e 's#/usr/bin/sudo#"$OMARCHY_TEST_SUDO"#g' \
+  "$ROOT/bin/omarchy-install-browser" >"$browser_installer"
+chmod 0755 "$browser_installer"
+
 export HOME="$test_home"
 export PATH="$mock_bin:$ROOT/bin:$PATH"
 export OMARCHY_PATH="$ROOT"
@@ -136,6 +162,9 @@ export OMARCHY_TEST_TERMINAL_LOG="$terminal_log"
 export OMARCHY_TEST_NOTIFICATION_LOG="$notification_log"
 export OMARCHY_TEST_SETUP_LOG="$setup_log"
 export OMARCHY_TEST_BROWSER_FILE="$browser_file"
+export OMARCHY_TEST_BROWSER_INSTALLER="$browser_installer"
+export OMARCHY_TEST_SOURCE_ROOT="$browser_source"
+export OMARCHY_TEST_SUDO="$mock_bin/sudo"
 
 assert_missing_opens_installer() {
   local type=$1
@@ -206,15 +235,17 @@ rm -f "$installed_dir/chromium"
 OMARCHY_TEST_REAL_BROWSER_INSTALL=true omarchy-default-browser --install chromium >/dev/null
 [[ $(<"$install_log") == "pkg:chromium" ]] || fail "Chromium browser installer installs the package"
 [[ $(omarchy-default-browser) == "chromium" ]] || fail "Chromium becomes the default after its full installer succeeds"
-cmp -s "$ROOT/config/chromium-flags.conf" "$test_home/.config/chromium-flags.conf" ||
+cmp -s "$browser_source/config/chromium-flags.conf" "$test_home/.config/chromium-flags.conf" ||
   fail "Chromium browser installer copies the default flags"
-grep -Fxq 'sudo:install -d -m 0755 -o root -g root /etc/chromium' "$setup_log" ||
+[[ -f "$test_home/.config/chromium/EULA Accepted" ]] ||
+  fail "Chromium browser installer records per-user EULA acceptance"
+grep -Fxq 'sudo:-- /usr/bin/install -d -m 0755 -o root -g root /etc/chromium' "$setup_log" ||
   fail "Chromium browser installer creates a root-owned Chromium policy parent"
-grep -Fxq 'sudo:install -d -m 0755 -o root -g root /etc/chromium/policies' "$setup_log" ||
+grep -Fxq 'sudo:-- /usr/bin/install -d -m 0755 -o root -g root /etc/chromium/policies' "$setup_log" ||
   fail "Chromium browser installer creates a root-owned Chromium policies parent"
-grep -Fxq 'sudo:install -d -m 0755 -o root -g root /etc/chromium/policies/managed' "$setup_log" ||
+grep -Fxq 'sudo:-- /usr/bin/install -d -m 0755 -o root -g root /etc/chromium/policies/managed' "$setup_log" ||
   fail "Chromium browser installer creates a root-owned managed policy directory"
-grep -Fxq 'sudo:find /etc/chromium/policies/managed -mindepth 1 -maxdepth 1 ! -user root -exec rm -rf -- {} +' "$setup_log" ||
+grep -Fxq 'sudo:-- /usr/bin/find /etc/chromium/policies/managed -mindepth 1 -maxdepth 1 ! -user root -exec /usr/bin/rm -rf -- {} +' "$setup_log" ||
   fail "Chromium browser installer drops non-root files from its policy directory"
 if grep -E 'groupadd|usermod|omarchy-browser-policy' "$setup_log" >/dev/null; then
   fail "Chromium browser installer does not create a browser-policy group" "$(cat "$setup_log")"
@@ -233,11 +264,11 @@ rm -f "$installed_dir/firefox"
 OMARCHY_TEST_REAL_BROWSER_INSTALL=true omarchy-default-browser --install firefox >/dev/null
 [[ $(<"$install_log") == "pkg:firefox" ]] || fail "Firefox browser installer installs the package"
 [[ $(omarchy-default-browser) == "firefox" ]] || fail "Firefox becomes the default after its full installer succeeds"
-grep -Fxq 'sudo:install -d -m 0755 -o root -g root /usr/lib/firefox/distribution' "$setup_log" ||
+grep -Fxq 'sudo:-- /usr/bin/install -d -m 0755 -o root -g root /usr/lib/firefox/distribution' "$setup_log" ||
   fail "Firefox browser installer creates its distribution directory"
-grep -Fxq 'sudo:find /usr/lib/firefox/distribution -mindepth 1 -maxdepth 1 ! -user root -exec rm -rf -- {} +' "$setup_log" ||
+grep -Fxq 'sudo:-- /usr/bin/find /usr/lib/firefox/distribution -mindepth 1 -maxdepth 1 ! -user root -exec /usr/bin/rm -rf -- {} +' "$setup_log" ||
   fail "Firefox browser installer drops non-root files from its distribution directory"
-grep -Fxq "sudo:install -m 644 -o root -g root -T $ROOT/default/firefox/policies.json /usr/lib/firefox/distribution/policies.json" "$setup_log" ||
+grep -Fxq "sudo:-- /usr/bin/install -m 644 -o root -g root -T $browser_source/default/firefox/policies.json /usr/lib/firefox/distribution/policies.json" "$setup_log" ||
   fail "Firefox browser installer copies policies.json without following a destination symlink"
 [[ -e $installed_dir/firefox ]] || fail "Firefox browser installer marks firefox installed"
 pass "Firefox browser installer restores the complete Omarchy setup"
@@ -248,11 +279,11 @@ rm -f "$installed_dir/zen-browser"
 OMARCHY_TEST_REAL_BROWSER_INSTALL=true omarchy-default-browser --install zen >/dev/null
 [[ $(<"$install_log") == "pkg:zen-browser-bin" ]] || fail "Zen browser installer installs the package"
 [[ $(omarchy-default-browser) == "zen" ]] || fail "Zen becomes the default after its full installer succeeds"
-grep -Fxq 'sudo:install -d -m 0755 -o root -g root /opt/zen-browser/distribution' "$setup_log" ||
+grep -Fxq 'sudo:-N -- /usr/bin/install -d -m 0755 -o root -g root /opt/zen-browser/distribution' "$setup_log" ||
   fail "Zen browser installer creates its distribution directory"
-grep -Fxq 'sudo:find /opt/zen-browser/distribution -mindepth 1 -maxdepth 1 ! -user root -exec rm -rf -- {} +' "$setup_log" ||
+grep -Fxq 'sudo:-N -- /usr/bin/find /opt/zen-browser/distribution -mindepth 1 -maxdepth 1 ! -user root -exec /usr/bin/rm -rf -- {} +' "$setup_log" ||
   fail "Zen browser installer drops non-root files from its distribution directory"
-grep -Fxq "sudo:install -m 644 -o root -g root -T $ROOT/default/firefox/policies.json /opt/zen-browser/distribution/policies.json" "$setup_log" ||
+grep -Fxq "sudo:-N -- /usr/bin/install -m 644 -o root -g root -T $browser_source/default/firefox/policies.json /opt/zen-browser/distribution/policies.json" "$setup_log" ||
   fail "Zen browser installer copies policies.json without following a destination symlink"
 [[ -e $installed_dir/zen-browser ]] || fail "Zen browser installer marks zen-browser installed"
 pass "Zen browser installer restores the complete Omarchy setup"

--- a/test/shell.d/desktop-entry-launch-test.sh
+++ b/test/shell.d/desktop-entry-launch-test.sh
@@ -39,7 +39,27 @@ cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
 printf '%s\n' "$1" >"$OMARCHY_TEST_PRESENTATION"
 SH
 
+cat >"$mock_bin/sudo" <<'SH'
+#!/bin/bash
+if [[ ${1:-} == -h ]]; then
+  printf 'usage: sudo [-ABbEHkNnPS] command\n'
+  exit 0
+fi
+[[ ${1:-} == -k ]] && exit 0
+exit 90
+SH
+
 chmod +x "$mock_bin"/*
+
+font_script="$test_tmp/omarchy-install-font"
+sed \
+  -e "s#/usr/bin/omarchy-launch-floating-terminal-with-presentation#$mock_bin/omarchy-launch-floating-terminal-with-presentation#g" \
+  -e "s#/usr/bin/omarchy-pkg-add#$mock_bin/omarchy-pkg-add#g" \
+  -e "s#/usr/bin/omarchy-font-set#$mock_bin/omarchy-font-set#g" \
+  -e "s#/usr/bin/sudo#$mock_bin/sudo#g" \
+  -e "s#/usr/bin/sleep#/usr/bin/true#g" \
+  "$ROOT/bin/omarchy-install-font" >"$font_script"
+chmod 0755 "$font_script"
 
 export HOME="$test_home"
 export OMARCHY_TEST_LOG="$test_tmp/launch.log"
@@ -146,7 +166,7 @@ grep -Fxq 'pkg:alpha' "$OMARCHY_TEST_LOG" ||
   fail "install-app still installs after quoting a hostile display name"
 pass "install-app does not run extra commands from a quote in the display name"
 
-bash "$ROOT/bin/omarchy-install-font" "Cascadia Mono" "ttf-cascadia-mono-nerd" "CaskaydiaMono Nerd Font"
+"$font_script" "Cascadia Mono" "ttf-cascadia-mono-nerd" "CaskaydiaMono Nerd Font"
 presentation_command=$(<"$OMARCHY_TEST_PRESENTATION")
 [[ $presentation_command == *'echo Installing\ Cascadia\ Mono...;'* ]] ||
   fail "install-font shell-quotes the display name" "$presentation_command"
@@ -160,7 +180,7 @@ grep -Fxq 'font:CaskaydiaMono Nerd Font' "$OMARCHY_TEST_LOG" ||
   fail "install-font passes the family name through as one argument"
 pass "install-font shell-quotes the display name and family"
 
-bash "$ROOT/bin/omarchy-install-font" "Foo's App" "alpha" "Foo's Font"
+"$font_script" "Foo's App" "alpha" "Foo's Font"
 : >"$OMARCHY_TEST_LOG"
 run_presentation >"$test_tmp/font-apostrophe.out"
 grep -Fxq 'pkg:alpha' "$OMARCHY_TEST_LOG" ||
@@ -169,7 +189,7 @@ grep -Fxq "font:Foo's Font" "$OMARCHY_TEST_LOG" ||
   fail "install-font still sets the family when it has an apostrophe"
 pass "install-font still installs when the name or family has an apostrophe"
 
-bash "$ROOT/bin/omarchy-install-font" "a'; echo PWNED; echo '" "alpha" "a'; echo PWNED; echo '"
+"$font_script" "a'; echo PWNED; echo '" "alpha" "a'; echo PWNED; echo '"
 : >"$OMARCHY_TEST_LOG"
 run_presentation >"$test_tmp/font-inject.out"
 if grep -Fxq 'PWNED' "$test_tmp/font-inject.out"; then
@@ -206,7 +226,7 @@ grep -Fq 'omarchy-pkg-add alpha beta' "$OMARCHY_TEST_PRESENTATION" ||
   fail "install-and-launch keeps its package list under an inherited errexit" "$(<"$OMARCHY_TEST_PRESENTATION")"
 pass "the installers build their command under an inherited errexit"
 
-bash "$ROOT/bin/omarchy-install-font" "Example Font" "alpha; echo PWNED" "Example Family"
+"$font_script" "Example Font" "alpha; echo PWNED" "Example Family"
 : >"$OMARCHY_TEST_LOG"
 run_presentation >"$test_tmp/font-pkg-inject.out"
 if grep -Fxq 'PWNED' "$test_tmp/font-pkg-inject.out"; then
@@ -216,7 +236,7 @@ grep -Fxq 'pkg:alpha; echo PWNED' "$OMARCHY_TEST_LOG" ||
   fail "install-font hands a hostile package to the package helper as one argument" "$(<"$OMARCHY_TEST_LOG")"
 pass "install-font does not run extra commands from its package"
 
-bash "$ROOT/bin/omarchy-install-font" "Example Font" "alpha" "Example Family"
+"$font_script" "Example Font" "alpha" "Example Family"
 : >"$OMARCHY_TEST_LOG"
 if OMARCHY_TEST_PKG_STATUS=1 run_presentation; then
   fail "install-font propagates package installation failure"

--- a/test/shell.d/hybrid-gpu-test.sh
+++ b/test/shell.d/hybrid-gpu-test.sh
@@ -2,11 +2,34 @@
 
 source "$(dirname "$0")/base-test.sh"
 
+toggle="$ROOT/bin/omarchy-toggle-hybrid-gpu"
+force_hook="$ROOT/default/systemd/system-sleep/force-igpu"
+hibernation="$ROOT/bin/omarchy-hibernation-setup"
+
+if grep -Eq 'cp .*systemd/system-sleep|rm -[^ ]*r[^ ]* .*systemd/system-sleep' "$toggle" "$hibernation"; then
+  fail "runtime commands still create or recursively remove static hooks under /usr"
+fi
+grep -F 'force_igpu_marker=/etc/omarchy/force-igpu' "$toggle" >/dev/null ||
+  fail "hybrid GPU mode has no runtime activation marker"
+grep -F 'force_igpu_hook=/usr/lib/systemd/system-sleep/omarchy-force-igpu' "$toggle" >/dev/null ||
+  fail "hybrid GPU mode does not use the package-owned hook"
+grep -F 'delay_source=/usr/share/omarchy/default/systemd/system/supergfxd.service.d/delay-start.conf' "$toggle" >/dev/null ||
+  fail "hybrid GPU mode does not use the package-owned delay source"
+marker_line=$(grep -nF '[[ -f /etc/omarchy/force-igpu ]] || exit 0' "$force_hook" | cut -d: -f1)
+case_line=$(grep -nF 'case "$1" in' "$force_hook" | cut -d: -f1)
+[[ -n $marker_line && -n $case_line ]] && (( marker_line < case_line )) ||
+  fail "the package-owned force-iGPU hook runs before checking its activation marker"
+pass "hybrid GPU sleep behavior keeps executable code package-owned"
+
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
 fake_bin="$test_tmp/bin"
-mkdir -p "$fake_bin"
+source_root="$test_tmp/source"
+test_command="$test_tmp/omarchy-toggle-hybrid-gpu"
+mkdir -p "$fake_bin" "$source_root/bin" \
+  "$source_root/default/systemd/system-sleep" \
+  "$source_root/default/systemd/system/supergfxd.service.d"
 
 cat >"$fake_bin/omarchy-cmd-missing" <<'STUB'
 #!/bin/bash
@@ -16,6 +39,11 @@ STUB
 cat >"$fake_bin/sleep" <<'STUB'
 #!/bin/bash
 :
+STUB
+
+cat >"$fake_bin/timeout" <<'STUB'
+#!/bin/bash
+exec /usr/bin/timeout "$@"
 STUB
 
 cat >"$fake_bin/gum" <<'STUB'
@@ -40,8 +68,34 @@ STUB
 
 chmod +x "$fake_bin"/*
 
+ln -s "$fake_bin/omarchy-cmd-missing" "$source_root/bin/omarchy-cmd-missing"
+for command in omarchy-pkg-add omarchy-system-reboot; do
+  cat >"$source_root/bin/$command" <<'STUB'
+#!/bin/bash
+:
+STUB
+  chmod 0755 "$source_root/bin/$command"
+done
+printf 'test hook\n' >"$source_root/default/systemd/system-sleep/force-igpu"
+printf 'test override\n' >"$source_root/default/systemd/system/supergfxd.service.d/delay-start.conf"
+
+# Source authorization/publication is covered in the focused security suite.
+# This legacy test isolates only retry/timeout behavior by replacing the two
+# resolver functions and fixed interactive/query executables in a scratch copy.
+sed \
+  -e '/^trusted_omarchy_source_root() {/,/^}/c\
+trusted_omarchy_source_root() { printf '\''%s\\n'\'' "$OMARCHY_TEST_SOURCE_ROOT"; }' \
+  -e '/^trusted_omarchy_source_file() {/,/^}/c\
+trusted_omarchy_source_file() { printf '\''%s\\n'\'' "$OMARCHY_TEST_SOURCE_ROOT/$1"; }' \
+  -e "s#/usr/bin/timeout#$fake_bin/timeout#g" \
+  -e "s#/usr/bin/supergfxctl#$fake_bin/supergfxctl#g" \
+  -e "s#/usr/bin/sleep#$fake_bin/sleep#g" \
+  -e "s#/usr/bin/gum#$fake_bin/gum#g" \
+  "$ROOT/bin/omarchy-toggle-hybrid-gpu" >"$test_command"
+chmod 0755 "$test_command"
+
 TEST_TMP="$test_tmp" SUCCEED_ON_ATTEMPT=3 \
-  PATH="$fake_bin:$PATH" bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" >/dev/null
+  OMARCHY_TEST_SOURCE_ROOT="$source_root" bash "$test_command" >/dev/null
 
 [[ $(<"$test_tmp/attempts") == "3" ]] || fail "hybrid GPU mode query retries transient failures"
 pass "hybrid GPU mode query recovers from a transient supergfxd failure"
@@ -51,7 +105,7 @@ rm -f "$test_tmp/attempts"
 set +e
 error=$(
   TEST_TMP="$test_tmp" \
-    PATH="$fake_bin:$PATH" bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" 2>&1 >/dev/null
+    OMARCHY_TEST_SOURCE_ROOT="$source_root" bash "$test_command" 2>&1 >/dev/null
 )
 status=$?
 set -e
@@ -70,7 +124,7 @@ STUB
 chmod +x "$fake_bin/supergfxctl"
 
 set +e
-output=$(TEST_TMP="$test_tmp" PATH="$fake_bin:$PATH" timeout 25s bash "$ROOT/bin/omarchy-toggle-hybrid-gpu" 2>&1)
+output=$(TEST_TMP="$test_tmp" OMARCHY_TEST_SOURCE_ROOT="$source_root" timeout 25s bash "$test_command" 2>&1)
 status=$?
 set -e
 

--- a/test/shell.d/launch-about-test.sh
+++ b/test/shell.d/launch-about-test.sh
@@ -15,6 +15,7 @@ sed '/^presize_window$/,$d' "$about" >"$tmp_dir/about.bash"
 
 export HOME="$tmp_dir/home"
 export PATH="$ROOT/bin:$PATH"
+unset NO_COLOR
 mkdir -p "$HOME/.config/omarchy/branding"
 printf '%s\n' '████████' '████████' >"$HOME/.config/omarchy/branding/about.txt"
 

--- a/test/shell.d/trusted-source-publication-security-test.sh
+++ b/test/shell.d/trusted-source-publication-security-test.sh
@@ -1,0 +1,399 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command unshare
+require_command chroot
+require_command setpriv
+require_command cc
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf -- "$test_tmp"' EXIT
+rootfs=$test_tmp/root
+fixture=$test_tmp/fixture
+mkdir -p "$rootfs" "$fixture"
+
+cat >"$fixture/sudo.c" <<'C'
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char *live = "/run/sudo-live";
+
+int main(int argc, char **argv) {
+  int noninteractive = 0;
+  int index = 1;
+
+  if (setgid(0) != 0 || setuid(0) != 0) return 120;
+  if (argc == 2 && strcmp(argv[1], "-k") == 0) {
+    unlink(live);
+    return 0;
+  }
+  if (index < argc && strcmp(argv[index], "-n") == 0) {
+    noninteractive = 1;
+    index++;
+  }
+  if (index < argc && strcmp(argv[index], "--") == 0) index++;
+  if (noninteractive && access(live, F_OK) != 0) return 1;
+
+  int fd = open(live, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+  if (fd < 0) return 121;
+  close(fd);
+  if (index >= argc) return 2;
+  execv(argv[index], &argv[index]);
+  return errno == ENOENT ? 127 : 126;
+}
+C
+cc -O2 -Wall -Wextra -o "$fixture/sudo" "$fixture/sudo.c"
+chmod 4755 "$fixture/sudo"
+
+cat >"$fixture/namespace-test.sh" <<'TEST'
+#!/bin/bash
+set -euo pipefail
+[[ ${OMARCHY_TEST_DEBUG:-false} != true ]] || set -x
+
+rootfs=$1
+repo=$2
+fixture=$3
+
+mount --make-rprivate /
+mkdir -p \
+  "$rootfs"/{boot,dev,etc,home,host-bin,host-lib,opt,proc,run,sys/power,tmp,usr/bin,usr/lib,usr/share,var} \
+  "$rootfs/usr/lib/systemd" "$rootfs/usr/lib/firefox"
+# The production scripts use Bash process substitution, which is opened via
+# /dev/fd after dropping to the modeled desktop uid. Normalize these traversal
+# boundaries independently of the caller's umask.
+chmod 0755 "$rootfs" "$rootfs"/{boot,dev,etc,home,opt,proc,run,sys,usr,var} "$rootfs/usr"/{bin,lib,share}
+chmod 1777 "$rootfs/tmp"
+touch "$rootfs/dev/null"
+ln -s /proc/self/fd "$rootfs/dev/fd"
+ln -s /proc/self/fd/0 "$rootfs/dev/stdin"
+
+mount --bind /usr/bin "$rootfs/host-bin"
+mount --bind /usr/lib "$rootfs/host-lib"
+mount --bind /dev/null "$rootfs/dev/null"
+mount -t proc proc "$rootfs/proc"
+mount -t tmpfs -o mode=0755,suid tmpfs "$rootfs/usr/bin"
+cleanup_namespace() {
+  umount "$rootfs/dev/null" "$rootfs/proc" "$rootfs/usr/bin" "$rootfs/host-bin" "$rootfs/host-lib" 2>/dev/null || true
+  chown -R 0:0 "$rootfs" 2>/dev/null || true
+}
+trap cleanup_namespace EXIT
+ln -s usr/bin "$rootfs/bin"
+ln -s usr/lib "$rootfs/lib"
+ln -s usr/lib "$rootfs/lib64"
+ln -s bin "$rootfs/usr/sbin"
+
+for entry in /usr/lib/*; do
+  name=${entry##*/}
+  [[ $name == systemd || $name == firefox ]] && continue
+  ln -s "/host-lib/$name" "$rootfs/usr/lib/$name"
+done
+
+host_commands=(
+  awk bash cat chmod cp date dirname env find free grep id install ln mkdir mktemp mv
+  readlink realpath rm sed setpriv sleep stat test tee timeout touch true
+)
+for command in "${host_commands[@]}"; do
+  ln -s "/host-bin/$command" "$rootfs/usr/bin/$command"
+done
+
+install -m 4755 "$fixture/sudo" "$rootfs/usr/bin/sudo"
+
+make_stub() {
+  local name=$1
+  shift
+  rm -f "$rootfs/usr/bin/$name"
+  {
+    echo '#!/bin/bash'
+    printf '%s\n' "$@"
+  } >"$rootfs/usr/bin/$name"
+  chmod 0755 "$rootfs/usr/bin/$name"
+}
+
+make_stub gum 'exit 0'
+make_stub supergfxctl 'printf "Hybrid\n"'
+make_stub systemctl 'exit 0'
+make_stub limine-update 'exit 0'
+make_stub limine-snapper-sync 'exit 0'
+make_stub limine-mkinitcpio 'exit 0'
+make_stub btrfs \
+  'if [[ $* == *"map-swapfile"* ]]; then printf "123\n"; fi' \
+  'exit 0'
+make_stub swaplabel 'exit 0'
+make_stub swapon \
+  'if [[ ${1:-} == --show ]]; then printf "/swap/swapfile\n"; fi' \
+  'exit 0'
+make_stub findmnt 'printf "/dev/mapper/root[/root]\n"'
+make_stub pacman \
+  'printf "TX" >>/run/pacman-args' \
+  'printf " <%s>" "$@" >>/run/pacman-args' \
+  'printf "\n" >>/run/pacman-args'
+make_stub install \
+  '[[ ! -e /run/fail-install ]] || exit 77' \
+  'args=()' \
+  'while (( $# )); do' \
+  '  case $1 in -o|-g) shift 2 ;; *) args+=("$1"); shift ;; esac' \
+  'done' \
+  'exec /host-bin/install "${args[@]}"'
+
+mkdir -p "$rootfs/usr/share/omarchy"/{bin,config,default/firefox,default/limine,default/pacman,default/systemd/system-sleep,default/systemd/system/supergfxd.service.d,install/helpers}
+cp "$repo/install/helpers/browser-policy.sh" "$rootfs/usr/share/omarchy/install/helpers/browser-policy.sh"
+cp "$repo/install/helpers/as-root.sh" "$rootfs/usr/share/omarchy/install/helpers/as-root.sh"
+printf 'GOOD FORCE IGPU\n' >"$rootfs/usr/share/omarchy/default/systemd/system-sleep/force-igpu"
+printf 'GOOD KEYBOARD\n' >"$rootfs/usr/share/omarchy/default/systemd/system-sleep/keyboard-backlight"
+printf 'GOOD DELAY\n' >"$rootfs/usr/share/omarchy/default/systemd/system/supergfxd.service.d/delay-start.conf"
+install -Dm755 "$rootfs/usr/share/omarchy/default/systemd/system-sleep/force-igpu" \
+  "$rootfs/usr/lib/systemd/system-sleep/omarchy-force-igpu"
+install -Dm755 "$rootfs/usr/share/omarchy/default/systemd/system-sleep/keyboard-backlight" \
+  "$rootfs/usr/lib/systemd/system-sleep/omarchy-keyboard-backlight"
+printf 'GOOD LIMINE\n' >"$rootfs/usr/share/omarchy/default/limine/limine.conf"
+printf '{"policies":{"GOOD":true}}\n' >"$rootfs/usr/share/omarchy/default/firefox/policies.json"
+printf 'GOOD FLAGS\n' >"$rootfs/usr/share/omarchy/config/chromium-flags.conf"
+printf 'GOOD PACMAN\n' >"$rootfs/usr/share/omarchy/default/pacman/pacman-stable.conf"
+printf 'GOOD MIRROR\n' >"$rootfs/usr/share/omarchy/default/pacman/mirrorlist-stable"
+printf 'good-package\n' >"$rootfs/usr/share/omarchy/install/omarchy-base.packages"
+
+make_source_stub() {
+  local name=$1
+  shift
+  {
+    echo '#!/bin/bash'
+    printf '%s\n' "$@"
+  } >"$rootfs/usr/share/omarchy/bin/$name"
+  chmod 0755 "$rootfs/usr/share/omarchy/bin/$name"
+}
+make_source_stub omarchy-cmd-missing 'exit 1'
+make_source_stub omarchy-pkg-add \
+  '/usr/bin/sudo /usr/bin/true' \
+  'printf "PKG %s\n" "$*" >>/run/browser-trace'
+make_source_stub omarchy-pkg-aur-add \
+  '/usr/bin/sudo /usr/bin/true' \
+  'printf "AUR %s\n" "$*" >>/run/browser-trace'
+make_source_stub omarchy-system-reboot 'printf "REBOOT\n" >>/run/reboot-trace'
+make_source_stub omarchy-install-chromium-copy-url 'printf "COPY URL\n" >>/run/browser-trace'
+make_source_stub omarchy-install-chromium-ytdlp 'printf "YTDLP\n" >>/run/browser-trace'
+make_source_stub omarchy-theme-set-browser \
+  'if /usr/bin/sudo -n /usr/bin/touch /browser-reused; then exit 91; fi' \
+  'printf "THEME COLD\n" >>/run/browser-trace'
+make_source_stub omarchy-hook \
+  'if /usr/bin/sudo -n /usr/bin/touch /hook-reused; then printf "HOOK REUSED\n" >>/run/hook-trace; exit 92; fi' \
+  'printf "HOOK BLOCKED %s\n" "$*" >>/run/hook-trace'
+
+# The fixture represents a packaged, root-owned source tree. Normalize it
+# independently of the shell that launched this test so permissive and
+# restrictive caller umasks cannot create either writable or unreadable
+# package fixtures.
+find "$rootfs/usr/share/omarchy" -type d -exec chmod 0755 {} +
+find "$rootfs/usr/share/omarchy" -type f -exec chmod 0644 {} +
+find "$rootfs/usr/share/omarchy/bin" -type f -exec chmod 0755 {} +
+
+mkdir -p "$rootfs/malicious/bin" "$rootfs/malicious/default/systemd/system-sleep" "$rootfs/malicious/default/limine" "$rootfs/malicious/install/helpers"
+printf 'PWNED\n' >"$rootfs/malicious/default/systemd/system-sleep/force-igpu"
+printf 'PWNED\n' >"$rootfs/malicious/default/systemd/system-sleep/keyboard-backlight"
+printf 'PWNED\n' >"$rootfs/malicious/default/limine/limine.conf"
+cat >"$rootfs/malicious/bin/sudo" <<'STUB'
+#!/bin/bash
+touch /malicious-path-ran
+exit 93
+STUB
+chmod 0755 "$rootfs/malicious/bin/sudo"
+cat >"$rootfs/malicious/install/helpers/browser-policy.sh" <<'STUB'
+touch /malicious-helper-ran
+STUB
+
+cp "$repo/bin/omarchy-toggle-hybrid-gpu" "$rootfs/run/toggle"
+cp "$repo/bin/omarchy-refresh-limine" "$rootfs/run/limine"
+cp "$repo/bin/omarchy-hibernation-setup" "$rootfs/run/hibernate"
+cp "$repo/bin/omarchy-install-browser" "$rootfs/run/browser"
+cp "$repo/bin/omarchy-reinstall-pkgs" "$rootfs/run/reinstall"
+chmod 0755 "$rootfs/run"/{toggle,limine,hibernate,browser,reinstall}
+
+printf '0123456789abcdef0123456789abcdef\n' >"$rootfs/etc/machine-id"
+printf 'root:x:0:0:root:/root:/bin/bash\ntest:x:1000:1000:test:/home/test:/bin/bash\n' >"$rootfs/etc/passwd"
+printf 'root:x:0:\ntest:x:1000:\n' >"$rootfs/etc/group"
+cat >"$rootfs/etc/supergfxd.conf" <<'CONF'
+{"mode": "Hybrid", "vfio_enable": false}
+CONF
+printf '/swap/swapfile none swap defaults 0 0\n' >"$rootfs/etc/fstab"
+printf '1\n' >"$rootfs/sys/power/image_size"
+printf 'deep\n' >"$rootfs/sys/power/mem_sleep"
+mkdir -p "$rootfs/home/test"
+chown 1000:1000 "$rootfs/home/test"
+chmod 0700 "$rootfs/home/test"
+mkdir -p "$rootfs/etc/pacman.d" "$rootfs/etc/systemd/system" "$rootfs/usr/lib/systemd/system-sleep"
+printf 'OLD PACMAN\n' >"$rootfs/etc/pacman.conf"
+printf 'OLD MIRROR\n' >"$rootfs/etc/pacman.d/mirrorlist"
+
+# These model ordinary root-owned system and attacker-controlled fixtures that
+# the desktop user must be able to traverse or read. Keep their modes realistic
+# regardless of the umask inherited by the namespace helper.
+chmod 0755 \
+  "$rootfs/etc/pacman.d" "$rootfs/etc/systemd" "$rootfs/etc/systemd/system" \
+  "$rootfs/sys/power" "$rootfs/usr/lib/firefox" "$rootfs/usr/lib/systemd" \
+  "$rootfs/usr/lib/systemd/system-sleep"
+chmod 0644 \
+  "$rootfs/etc/machine-id" "$rootfs/etc/passwd" "$rootfs/etc/group" \
+  "$rootfs/etc/supergfxd.conf" "$rootfs/etc/fstab" "$rootfs/etc/pacman.conf" \
+  "$rootfs/etc/pacman.d/mirrorlist" "$rootfs/sys/power/image_size" \
+  "$rootfs/sys/power/mem_sleep"
+find "$rootfs/malicious" -type d -exec chmod 0755 {} +
+find "$rootfs/malicious" -type f -exec chmod 0644 {} +
+chmod 0755 "$rootfs/malicious/bin/sudo"
+chmod 1777 "$rootfs/run"
+
+run_user() {
+  local bash_args=()
+  [[ ${OMARCHY_TEST_DEBUG:-false} != true ]] || bash_args=(-x)
+  chroot "$rootfs" /usr/bin/setpriv --reuid=1000 --regid=1000 --clear-groups \
+    /usr/bin/env -i HOME=/home/test USER=test LOGNAME=test \
+    OMARCHY_PATH=/malicious PATH=/malicious/bin:/usr/bin \
+    /usr/bin/bash "${bash_args[@]}" "$@"
+}
+
+rm -f "$rootfs/etc/omarchy.conf" "$rootfs/run/sudo-live"
+umask 000
+run_user /run/toggle
+grep -Fxq 'GOOD FORCE IGPU' "$rootfs/usr/lib/systemd/system-sleep/omarchy-force-igpu"
+[[ -f $rootfs/etc/omarchy/force-igpu && ! -L $rootfs/etc/omarchy/force-igpu ]]
+[[ $(stat -c %a "$rootfs/etc/omarchy/force-igpu") == 644 ]]
+[[ $(stat -c %u:%g "$rootfs/etc/omarchy/force-igpu") == 0:0 ]]
+delay_link="$rootfs/etc/systemd/system/supergfxd.service.d/10-omarchy-delay-start.conf"
+[[ -L $delay_link ]]
+[[ $(readlink "$delay_link") == /usr/share/omarchy/default/systemd/system/supergfxd.service.d/delay-start.conf ]]
+[[ ! -e $rootfs/usr/lib/systemd/system-sleep/force-igpu ]]
+[[ ! -e $rootfs/etc/systemd/system/supergfxd.service.d/delay-start.conf ]]
+[[ ! -e $rootfs/malicious-path-ran ]]
+echo 'PASS toggle'
+
+printf 'OLD LIMINE\n' >"$rootfs/boot/limine.conf"
+run_user /run/limine
+grep -Fxq 'GOOD LIMINE' "$rootfs/boot/limine.conf"
+grep -Fxq 'OLD LIMINE' "$rootfs/boot/limine.conf.bak"
+[[ $(stat -c %a "$rootfs/boot/limine.conf") == 644 ]]
+[[ $(stat -c %u:%g "$rootfs/boot/limine.conf") == 0:0 ]]
+echo 'PASS limine'
+
+printf 'STILL BOOTABLE\n' >"$rootfs/boot/limine.conf"
+touch "$rootfs/run/fail-install"
+if run_user /run/limine >"$rootfs/run/limine-fail.out" 2>&1; then exit 31; fi
+rm -f "$rootfs/run/fail-install"
+grep -Fxq 'STILL BOOTABLE' "$rootfs/boot/limine.conf"
+echo 'PASS limine-failure'
+
+run_user /run/hibernate --force --no-rebuild
+grep -Fxq 'GOOD KEYBOARD' "$rootfs/usr/lib/systemd/system-sleep/omarchy-keyboard-backlight"
+[[ $(stat -c %a "$rootfs/usr/lib/systemd/system-sleep/omarchy-keyboard-backlight") == 755 ]]
+[[ $(stat -c %u:%g "$rootfs/usr/lib/systemd/system-sleep/omarchy-keyboard-backlight") == 0:0 ]]
+[[ ! -e $rootfs/usr/lib/systemd/system-sleep/keyboard-backlight ]]
+echo 'PASS hibernate'
+
+run_user /run/browser firefox
+grep -Fxq 'PKG firefox' "$rootfs/run/browser-trace"
+grep -q '"GOOD":true' "$rootfs/usr/lib/firefox/distribution/policies.json"
+[[ $(stat -c %u:%g "$rootfs/usr/lib/firefox/distribution/policies.json") == 0:0 ]]
+[[ ! -e $rootfs/malicious-helper-ran && ! -e $rootfs/browser-reused ]]
+[[ ! -e $rootfs/run/sudo-live ]]
+echo 'PASS browser'
+
+rm -f "$rootfs/run/pacman-args" "$rootfs/run/hook-trace" "$rootfs/run/sudo-live"
+run_user /run/reinstall
+grep -Fxq 'HOOK BLOCKED pre-refresh-pacman' "$rootfs/run/hook-trace"
+[[ ! -e $rootfs/hook-reused && ! -e $rootfs/run/sudo-live ]]
+[[ $(grep -c '^TX' "$rootfs/run/pacman-args") == 3 ]]
+grep -Fq '<--needed> <--> <good-package>' "$rootfs/run/pacman-args"
+echo 'PASS reinstall'
+
+printf '%s\n' '--config' >"$rootfs/usr/share/omarchy/install/omarchy-base.packages"
+rm -f "$rootfs/run/pacman-args"
+if run_user /run/reinstall >"$rootfs/run/reinstall-invalid.out" 2>&1; then exit 32; fi
+[[ ! -e $rootfs/run/pacman-args ]]
+echo 'PASS package-injection'
+printf 'good-package\n' >"$rootfs/usr/share/omarchy/install/omarchy-base.packages"
+
+mv "$rootfs/usr/share/omarchy/default/limine/limine.conf" "$rootfs/usr/share/omarchy/default/limine/limine.conf.real"
+ln -s /malicious/default/limine/limine.conf "$rootfs/usr/share/omarchy/default/limine/limine.conf"
+printf 'SOURCE LINK UNCHANGED\n' >"$rootfs/boot/limine.conf"
+if run_user /run/limine >"$rootfs/run/source-symlink.out" 2>&1; then exit 36; fi
+grep -Fxq 'SOURCE LINK UNCHANGED' "$rootfs/boot/limine.conf"
+rm "$rootfs/usr/share/omarchy/default/limine/limine.conf"
+mv "$rootfs/usr/share/omarchy/default/limine/limine.conf.real" "$rootfs/usr/share/omarchy/default/limine/limine.conf"
+echo 'PASS source-symlink'
+
+dev='/home/test/Dév $pace "quote" `tick` \\slash'
+mkdir -p "$rootfs$dev/default/limine"
+printf 'DEV LIMINE\n' >"$rootfs$dev/default/limine/limine.conf"
+chown -R 1000:1000 "$rootfs$dev"
+chmod -R go-w "$rootfs$dev"
+quoted=$dev
+quoted=${quoted//\\/\\\\}; quoted=${quoted//\"/\\\"}
+quoted=${quoted//\$/\\\$}; quoted=${quoted//\`/\\\`}
+printf 'export OMARCHY_PATH="%s"\n' "$quoted" >"$rootfs/etc/omarchy.conf"
+chmod 0644 "$rootfs/etc/omarchy.conf"
+printf 'PRE DEV\n' >"$rootfs/boot/limine.conf"
+run_user /run/limine
+grep -Fxq 'DEV LIMINE' "$rootfs/boot/limine.conf"
+echo 'PASS dev-link'
+
+printf 'export OMARCHY_PATH="/malicious"\n' >"$rootfs/etc/omarchy-target"
+ln -sf omarchy-target "$rootfs/etc/omarchy.conf"
+printf 'UNCHANGED\n' >"$rootfs/boot/limine.conf"
+if run_user /run/limine >"$rootfs/run/config-symlink.out" 2>&1; then exit 33; fi
+grep -Fxq 'UNCHANGED' "$rootfs/boot/limine.conf"
+echo 'PASS config-symlink'
+
+rm -f "$rootfs/etc/omarchy.conf"
+printf 'export OMARCHY_PATH="/malicious"\n' >"$rootfs/etc/omarchy.conf"
+chmod 0666 "$rootfs/etc/omarchy.conf"
+if run_user /run/limine >"$rootfs/run/config-mode.out" 2>&1; then exit 34; fi
+grep -Fxq 'UNCHANGED' "$rootfs/boot/limine.conf"
+echo 'PASS config-mode'
+
+chmod 0644 "$rootfs/etc/omarchy.conf"
+printf 'export OMARCHY_PATH=/malicious\n' >"$rootfs/etc/omarchy.conf"
+if run_user /run/limine >"$rootfs/run/config-grammar.out" 2>&1; then exit 35; fi
+grep -Fxq 'UNCHANGED' "$rootfs/boot/limine.conf"
+echo 'PASS config-grammar'
+TEST
+chmod 0755 "$fixture/namespace-test.sh"
+
+output=$(unshare --user --map-auto --map-root-user --mount --pid --fork --kill-child \
+  "$fixture/namespace-test.sh" "$rootfs" "$ROOT" "$fixture" 2>&1) ||
+  fail "trusted-source publication namespace regression completes" "$output"
+
+expected=(
+  'PASS toggle'
+  'PASS limine'
+  'PASS limine-failure'
+  'PASS hibernate'
+  'PASS browser'
+  'PASS reinstall'
+  'PASS package-injection'
+  'PASS source-symlink'
+  'PASS dev-link'
+  'PASS config-symlink'
+  'PASS config-mode'
+  'PASS config-grammar'
+)
+for marker in "${expected[@]}"; do
+  grep -Fxq "$marker" <<<"$output" || fail "focused namespace case completed: $marker" "$output"
+done
+
+pass "inherited source and PATH cannot publish privileged boot, browser, or package content"
+pass "sleep-hook executable code remains package-owned while runtime state stays minimal"
+pass "root-authorized default and escaped dev-link sources remain supported"
+pass "unsafe config boundaries and package option injection fail before privileged transactions"
+pass "reinstall invalidates sudo before its final user hook"
+
+for command in \
+  bin/omarchy-toggle-hybrid-gpu \
+  bin/omarchy-refresh-limine \
+  bin/omarchy-hibernation-setup \
+  bin/omarchy-install-browser \
+  bin/omarchy-reinstall-pkgs; do
+  [[ $(stat -c %a "$ROOT/$command") == 755 ]] || fail "$command remains executable"
+done
+pass "all hardened user-facing commands retain mode 0755"

--- a/test/shell.d/unowned-system-paths-test.sh
+++ b/test/shell.d/unowned-system-paths-test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# A file Omarchy writes into /usr belongs to nobody, and the
-# day a package starts shipping that same path, pacman refuses the upgrade for
-# everyone who has the file. omarchy-update-system-pkgs-when-conflicted recovers from
-# that, but the cheaper answer is to ship the file in the package instead.
+# A file Omarchy writes into /usr belongs to nobody, and the day a package
+# starts shipping that same path, pacman refuses the upgrade for everyone who
+# has the file. The safe answer is to package static system state from the
+# beginning; ordinary updates deliberately do not move or overwrite conflicts.
 #
 # This flags a script writing such a path unless a PKGBUILD installs it, or it
 # is recorded below with the reason it cannot be packaged.
@@ -27,19 +27,11 @@ allowed = {
   # Symlinks into another package's icon theme; owning them would mean owning
   # paths inside Yaru.
   "/usr/share/icons/Yaru/scalable/actions",
-  # Hardware-conditional sleep hooks, installed only on the machines that need
-  # them so the hook does not exist where it does not apply.
-  "/usr/lib/systemd/system-sleep",
   # Written through a variable, so the scan below cannot see them at the point
   # they are written. Both drop configuration into another project's tree rather
   # than Omarchy's, which is why neither is a candidate for omarchy-settings.
   "/usr/share/chromium/extensions",
   "/usr/lib/firefox/distribution",
-  # Static content that belongs in omarchy-settings. It cannot move there in the
-  # same release that first ships omarchy-update-system-pkgs-when-conflicted: the
-  # upgrade carrying the handler is the one that would hit the conflict, and the
-  # handler only helps once it is on disk. Package it the release after.
-  "/usr/lib/chromium/initial_preferences",
 }
 
 # One-time 3.x upgrade. It runs before this rule existed and cannot be made to

--- a/test/shell.d/update-disk-space-test.sh
+++ b/test/shell.d/update-disk-space-test.sh
@@ -9,8 +9,55 @@ unset OMARCHY_UPDATE_FORCE
 unset TEST_AVAILABLE_BYTES
 unset TEST_DF_INVALID
 
-test_tmp=$(mktemp -d)
-trap 'rm -rf "$test_tmp"' EXIT
+if [[ -z ${OMARCHY_UPDATE_DISK_TEST_NS:-} ]]; then
+  outer_uid=$(id -u)
+  outer_gid=$(id -g)
+  subuid=$(awk -F: -v user="$(id -un)" '$1 == user { print $2; exit }' /etc/subuid)
+  subgid=$(awk -F: -v group="$(id -gn)" '$1 == group { print $2; exit }' /etc/subgid)
+  if [[ -z $subuid || -z $subgid ]]; then
+    pass "no subordinate uid/gid range; skipping authorized update disk-space test"
+    exit 0
+  fi
+  exec unshare --user --mount \
+    --map-users "0:$outer_uid:1" --map-users "1:$subuid:65536" \
+    --map-groups "0:$outer_gid:1" --map-groups "1:$subgid:65536" \
+    env OMARCHY_UPDATE_DISK_TEST_NS=setup bash "$0"
+elif [[ $OMARCHY_UPDATE_DISK_TEST_NS == setup ]]; then
+  mount -t tmpfs -o mode=0755 tmpfs /run
+  namespace_tmp=$(mktemp -d -p /run omarchy-update-disk-space.XXXXXXXX)
+  chmod 0755 "$namespace_tmp"
+  mkdir -p "$namespace_tmp/default/omarchy/sudo-no-update"
+  cp "$ROOT/default/omarchy/sudo-no-update/sudo" "$namespace_tmp/default/omarchy/sudo-no-update/sudo"
+  chmod 0755 "$namespace_tmp/default/omarchy/sudo-no-update/sudo"
+  cat >"$namespace_tmp/fixed-sudo" <<'STUB'
+#!/bin/bash
+if [[ ${1:-} == "-h" ]]; then
+  echo 'usage: sudo [-ABbEHkNnPS] command'
+fi
+exit 0
+STUB
+  chmod 0755 "$namespace_tmp/fixed-sudo"
+  mount --bind "$namespace_tmp/fixed-sudo" /usr/bin/sudo
+  mount -t tmpfs -o mode=0755 tmpfs /etc
+  printf 'export OMARCHY_PATH="%s"\n' "$namespace_tmp" >/etc/omarchy.conf
+  chmod 0644 /etc/omarchy.conf
+  chown -R 1000:1000 "$namespace_tmp"
+
+  set +e
+  setpriv --reuid 1000 --regid 1000 --clear-groups \
+    env OMARCHY_UPDATE_DISK_TEST_NS=run OMARCHY_AUTHORIZED_TEST_ROOT="$namespace_tmp" bash "$0"
+  status=$?
+  set -e
+
+  umount /usr/bin/sudo
+  umount /etc
+  rm -rf "$namespace_tmp"
+  umount /run
+  exit "$status"
+fi
+
+test_tmp="$OMARCHY_AUTHORIZED_TEST_ROOT"
+trap 'rm -rf "$test_tmp"/*' EXIT
 
 stub_bin="$test_tmp/bin"
 test_home="$test_tmp/home"


### PR DESCRIPTION
## Summary

A caller-controlled `OMARCHY_PATH` could select files later copied or installed by root.

Finding: **OM-SEC-16**

## Security impact

Attacker-selected source bytes can cross into root-owned system state, allowing privileged configuration replacement or code execution.

## Remediation

Privileged publication uses canonical fixed or explicitly authorized roots with root-owned, non-writable ancestry; runtime scripts no longer publish generic static system files.

The reviewed implementation applies these concrete controls:

- Privileged workflows derive the source root from root-owned /etc/omarchy.conf or the fixed packaged tree.
- The exact config grammar, canonical path, ownership, modes, links, and ancestor chain are checked.
- Bash privileged startup suppresses BASH_ENV/exported-function injection where required.
- Root consumes validated source through inherited descriptors rather than reopening mutable paths.
- Package lists validate names and use an option terminator.
- Static executable root state is package-owned; runtime commands no longer publish the sleep hooks.
- omarchy-settings and omarchy-settings-dev both own the live static hooks.

## Validation

The baseline publisher accepted attacker paths; trusted-root, symlink, ownership, package-payload, and dev-link regressions pass.

**Detailed regression coverage:** trusted-source-publication-security-test.sh, unowned-system-paths-test.sh, hybrid-gpu-test.sh, quattro-ownership-bridge-test.sh, and the extracted archives pass.

Current status: Fixed. An explicitly root-authorized dev link intentionally trusts that user's checkout.

All changed shell files on this branch pass `bash -n`, and `git diff --check` passes.

## Coordination

This is one finding in a coordinated 21-finding disclosure sent to the Omarchy security team. The corresponding Markdown report contains the affected-code analysis and safe reproduction.

The matching `omarchy-settings` payload ownership change must ship in the coordinated release.

