### PR TITLE
[codex] OM-SEC-22: Run opam before command-scoped cleanup authorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Three documentation trees, split by genre and audience:
 - Prefer `(( ))` over numeric operators inside `[[ ]]` (e.g., `(( count < 50 ))`, not `[[ $count -lt 50 ]]`)
 - Prefer a full `if`/`else` conditional for simple two-path control flow; don't rely on `exec` or `exit` in one branch to make following statements unreachable
 - For strings/paths with spaces, quote them instead of escaping spaces with `\ ` (e.g., `"$APP_DIR/Disk Usage.desktop"`, not `$APP_DIR/Disk\ Usage.desktop`)
-- Shebangs must use `#!/bin/bash` consistently (never `#!/usr/bin/env bash`)
+- Shebangs must use `#!/bin/bash` consistently (never `#!/usr/bin/env bash`). A security-sensitive entrypoint may use the exact `#!/bin/bash -p` form only when it must suppress `BASH_ENV` and exported-function startup injection before its first command; that exception must be explained at the boundary and covered by a regression that rejects an ordinary Bash launch with a decoy `-p` argument.
 - Scripts under `install/` and `migrations/` may be sourced and intentionally omit shebangs
 
 # Command Naming

--- a/bin/omarchy-dev-pkg-test
+++ b/bin/omarchy-dev-pkg-test
@@ -256,5 +256,7 @@ for PKG in "${PKGS[@]}"; do
 done
 
 # Install the built package set in one transaction so its
-# provides/conflicts/dependencies resolve as they do from the repository.
-/usr/bin/sudo -N -- /usr/bin/pacman -U --noconfirm -- "${built_pkgs[@]}"
+# provides/conflicts/dependencies resolve as they do from the repository. A
+# local development build is the explicitly selected source of these files;
+# allow it to replace leftovers from pre-package Omarchy installations.
+/usr/bin/sudo -N -- /usr/bin/pacman -U --noconfirm --overwrite='*' -- "${built_pkgs[@]}"

--- a/bin/omarchy-dev-pkg-test
+++ b/bin/omarchy-dev-pkg-test
@@ -7,6 +7,11 @@
 
 set -euo pipefail
 
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+unset BASH_ENV ENV CDPATH GLOBIGNORE
+umask 077
+
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   cat <<USAGE
 Usage: omarchy dev pkg-test [package-name] [path-to-checkout]
@@ -37,7 +42,7 @@ remove_pkgver_function() {
   local pkgbuild="$1"
   local tmp="$pkgbuild.tmp"
 
-  awk '
+  /usr/bin/awk '
     /^pkgver\(\)[[:space:]]*\{/ {
       in_pkgver = 1
       depth = 0
@@ -55,7 +60,7 @@ remove_pkgver_function() {
     }
     { print }
   ' "$pkgbuild" >"$tmp"
-  mv "$tmp" "$pkgbuild"
+  /usr/bin/mv "$tmp" "$pkgbuild"
 }
 
 dev_package_name() {
@@ -82,6 +87,15 @@ else
 fi
 PKGBUILDS_ROOT="${OMARCHY_PKGBUILDS_DIR:-$HOME/Work/omarchy/omarchy-pkgs/pkgbuilds}"
 
+for argument in "${MAKEPKG_ARGS[@]}"; do
+  case $argument in
+    -- | --config | --config=* | PACMAN=* | PACMAN+=* | PACMAN_AUTH=* | PACMAN_AUTH+=* | MAKEPKG_CONF=* | BASH_ENV=* | ENV=*)
+      echo "Error: makepkg argument '$argument' would bypass the fixed privilege boundary." >&2
+      exit 2
+      ;;
+  esac
+done
+
 if [[ ! -d "$CHECKOUT" ]]; then
   echo "Error: checkout not found at $CHECKOUT" >&2
   exit 1
@@ -95,43 +109,152 @@ for PKG in "${PKGS[@]}"; do
   fi
 done
 
-build_dir=$(mktemp -d -t omarchy-dev-pkg-test.XXXXXX)
-trap 'rm -rf "$build_dir"' EXIT
+trusted_system_command() {
+  local command=$1 require_setuid=${2:-false}
+  local canonical owner mode links
+
+  [[ $command == /usr/bin/* && -f $command && -x $command && ! -L $command ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$command") || return 1
+  [[ $canonical == "$command" ]] || return 1
+  read -r owner mode links < <(/usr/bin/stat -Lc '%u %a %h' -- "$command") || return 1
+  [[ $owner == 0 && $links == 1 ]] || return 1
+  (( (8#$mode & 0022) == 0 )) || return 1
+  [[ $require_setuid != true ]] || (( (8#$mode & 04000) != 0 ))
+}
+
+for command in /usr/bin/realpath /usr/bin/stat /usr/bin/sudo /usr/bin/pacman /usr/bin/makepkg /usr/bin/setpriv; do
+  require_setuid=false
+  [[ $command != /usr/bin/sudo ]] || require_setuid=true
+  if ! trusted_system_command "$command" "$require_setuid"; then
+    echo "Refusing the package build because $command is not a trusted system command." >&2
+    exit 1
+  fi
+done
+
+/usr/bin/sudo -k >/dev/null || {
+  echo "Unable to start the package build with a cold sudo credential state." >&2
+  exit 1
+}
+if ! /usr/bin/sudo -N -V >/dev/null 2>&1; then
+  echo "This sudo does not support --no-update; refusing to run package build code." >&2
+  exit 1
+fi
+
+build_dir=$(/usr/bin/mktemp -d -t omarchy-dev-pkg-test.XXXXXX)
+
+cleanup() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  /usr/bin/rm -rf -- "$build_dir"
+  if ! /usr/bin/sudo -k >/dev/null 2>&1; then
+    echo "Failed to invalidate sudo credentials after the package build." >&2
+    (( status != 0 )) || status=1
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # pkgver=dev.<sha>[.dirty] so pacman -Q makes the source obvious.
-short_sha=$(git -C "$CHECKOUT" rev-parse --short HEAD 2>/dev/null || echo "local")
+short_sha=$(/usr/bin/git -C "$CHECKOUT" rev-parse --short HEAD 2>/dev/null || echo "local")
 dirty=""
-if [[ -d "$CHECKOUT/.git" ]] && [[ -n "$(git -C "$CHECKOUT" status --porcelain)" ]]; then
+if [[ -d "$CHECKOUT/.git" ]] && [[ -n "$(/usr/bin/git -C "$CHECKOUT" status --porcelain)" ]]; then
   dirty=".dirty"
 fi
 new_pkgver="dev.${short_sha}${dirty}"
 
+dependency_name() {
+  local dependency=$1 name=${1%%[<>=]*}
+  [[ $name =~ ^[a-z0-9][a-z0-9@._+:-]*$ ]] || return 1
+  printf '%s\n' "$name"
+}
+
+install_build_dependencies() {
+  local srcinfo=$1 architecture dependency status missing_output name
+  local dependencies=() missing=()
+  local -A seen=()
+  architecture=$(/usr/bin/uname -m)
+
+  while IFS= read -r line; do
+    if [[ $line =~ ^$'\t'(depends|makedepends|checkdepends)(_([a-zA-Z0-9_]+))?\ =\ (.+)$ ]]; then
+      [[ -z ${BASH_REMATCH[3]} || ${BASH_REMATCH[3]} == "$architecture" ]] || continue
+      dependency=${BASH_REMATCH[4]}
+      dependency_name "$dependency" >/dev/null || {
+        echo "Error: unsafe dependency in generated .SRCINFO: $dependency" >&2
+        return 1
+      }
+      dependencies+=("$dependency")
+    fi
+  done <"$srcinfo"
+
+  (( ${#dependencies[@]} )) || return 0
+  if missing_output=$(/usr/bin/pacman -T -- "${dependencies[@]}"); then
+    return 0
+  else
+    status=$?
+  fi
+  (( status == 127 )) || return "$status"
+
+  while IFS= read -r dependency; do
+    [[ -n $dependency ]] || continue
+    name=$(dependency_name "$dependency") || {
+      echo "Error: pacman returned an unsafe dependency name: $dependency" >&2
+      return 1
+    }
+    if [[ -z ${seen[$name]+x} ]]; then
+      seen[$name]=1
+      missing+=("$name")
+    fi
+  done <<<"$missing_output"
+  (( ${#missing[@]} )) || return 1
+  /usr/bin/sudo -N -- /usr/bin/pacman -S --asdeps --needed --noconfirm -- "${missing[@]}"
+}
+
+built_pkgs=()
 for PKG in "${PKGS[@]}"; do
   PKGBUILD_DIR="$PKGBUILDS_ROOT/$PKG"
   package_build_dir="$build_dir/$PKG"
-  mkdir -p "$package_build_dir"
-  cp -a "$PKGBUILD_DIR/." "$package_build_dir/"
+  /usr/bin/mkdir -p "$package_build_dir"
+  /usr/bin/cp -a "$PKGBUILD_DIR/." "$package_build_dir/"
 
   remove_pkgver_function "$package_build_dir/PKGBUILD"
-  sed -i "s/^pkgver=.*/pkgver=${new_pkgver}/" "$package_build_dir/PKGBUILD"
+  /usr/bin/sed -i "s/^pkgver=.*/pkgver=${new_pkgver}/" "$package_build_dir/PKGBUILD"
 
   echo "Building $PKG ${new_pkgver} from $CHECKOUT"
   echo "  build dir: $package_build_dir"
   echo "  PKGBUILD : $PKGBUILD_DIR/PKGBUILD"
   echo
 
+  srcinfo="$package_build_dir/.SRCINFO.omarchy"
   (
     cd "$package_build_dir"
-    OMARCHY_SRC="$CHECKOUT" makepkg -s --skipchecksums --noconfirm "${MAKEPKG_ARGS[@]}"
+    OMARCHY_SRC="$CHECKOUT" /usr/bin/setpriv --no-new-privs /usr/bin/makepkg --printsrcinfo
+  ) >"$srcinfo"
+  install_build_dependencies "$srcinfo"
+
+  (
+    cd "$package_build_dir"
+    # Dependency installation is deliberately separate. Even if a PKGBUILD
+    # mutates makepkg's internal NODEPS/PACMAN_AUTH variables, no_new_privs in
+    # the fixed launcher prevents any setuid program from granting it root.
+    OMARCHY_SRC="$CHECKOUT" /usr/bin/setpriv --no-new-privs /usr/bin/makepkg \
+      --nodeps --skipchecksums --noconfirm "${MAKEPKG_ARGS[@]}"
   )
 
-  # Install separately so we can pass --overwrite='*' (makepkg -i can't).
-  # Dev builds frequently conflict with files left behind by previous
-  # script-installed Omarchy versions; the build is the authoritative state.
-  built_pkg=$(ls -t "$package_build_dir"/*.pkg.tar.* 2>/dev/null | grep -v '\.sig$' | head -1)
+  built_pkg=""
+  for candidate in "$package_build_dir"/*.pkg.tar.*; do
+    [[ -f $candidate && $candidate != *.sig ]] || continue
+    [[ -z $built_pkg || $candidate -nt $built_pkg ]] && built_pkg=$candidate
+  done
   if [[ -z $built_pkg ]]; then
     echo "Error: no built package found in $package_build_dir" >&2
     exit 1
   fi
-  sudo pacman -U --noconfirm --overwrite='*' "$built_pkg"
+  built_pkgs+=("$built_pkg")
 done
+
+# Install the built package set in one transaction so its
+# provides/conflicts/dependencies resolve as they do from the repository.
+/usr/bin/sudo -N -- /usr/bin/pacman -U --noconfirm -- "${built_pkgs[@]}"

--- a/bin/omarchy-makepkg-unprivileged
+++ b/bin/omarchy-makepkg-unprivileged
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Run makepkg with kernel-enforced privilege escalation disabled.
+# omarchy:hidden=true
+
+# Internal makepkg boundary for AUR and local PKGBUILD execution. no_new_privs
+# is inherited by every child, so neither makepkg internals nor PKGBUILD code
+# can turn a setuid sudo invocation into root authority.
+
+set -euo pipefail
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+unset BASH_ENV ENV CDPATH GLOBIGNORE
+
+[[ -x /usr/bin/setpriv && -x /usr/bin/makepkg ]] || {
+  echo "Required package-build isolation tools are unavailable." >&2
+  exit 1
+}
+
+exec /usr/bin/setpriv --no-new-privs /usr/bin/makepkg "$@"

--- a/bin/omarchy-pkg-add
+++ b/bin/omarchy-pkg-add
@@ -1,21 +1,82 @@
-#!/bin/bash
+#!/bin/bash -p
 
 # omarchy:summary=Install Arch packages if they are missing
 # omarchy:args=<packages...>
 # omarchy:examples=omarchy pkg add jq ripgrep
 # omarchy:requires-sudo=true
 
-if omarchy-pkg-missing "$@"; then
+if [[ $- != *p* ]]; then
+  echo "Refusing an unsafe Bash startup for package installation." >&2
+  exit 126
+fi
+
+require_privileged_bash_startup() {
+  /usr/bin/env -i /usr/bin/bash -p -c '
+    [[ $1 =~ ^[1-9][0-9]*$ ]] || exit 1
+    mapfile -d "" -t argv <"/proc/$1/cmdline" || exit 1
+    executable=$(/usr/bin/readlink -e -- "/proc/$1/exe") || exit 1
+    [[ $executable == /usr/bin/bash ]]
+    [[ ${argv[0]:-} == /bin/bash || ${argv[0]:-} == /usr/bin/bash ]]
+    [[ ${argv[1]:-} == -p ]]
+  ' omarchy-bash-startup "$$"
+}
+require_privileged_bash_startup || {
+  echo "Refusing an unsafe Bash startup for package installation." >&2
+  exit 126
+}
+unset -f require_privileged_bash_startup
+
+sanitize_bash_startup_environment() {
+  local environment_entry environment_name
+  local needs_reexec=0
+  local -a environment_unsets=(-u BASH_ENV -u ENV)
+
+  [[ -z ${BASH_ENV+x} && -z ${ENV+x} ]] || needs_reexec=1
+  while IFS= read -r -d '' environment_entry; do
+    environment_name="${environment_entry%%=*}"
+    if [[ $environment_name == BASH_FUNC_*%% ]]; then
+      environment_unsets+=(-u "$environment_name")
+      needs_reexec=1
+    fi
+  done < <(/usr/bin/env -0)
+
+  if ((needs_reexec)); then
+    exec /usr/bin/env "${environment_unsets[@]}" /usr/bin/bash -p "$0" "$@"
+  fi
+}
+sanitize_bash_startup_environment "$@"
+unset -f sanitize_bash_startup_environment
+unset BASH_ENV ENV
+
+set -euo pipefail
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+
+case "${OMARCHY_SUDO_NO_UPDATE:-0}" in
+  0|"") sudo_args=() ;;
+  1) sudo_args=(-N) ;;
+  *)
+    echo "Invalid OMARCHY_SUDO_NO_UPDATE value." >&2
+    exit 2
+    ;;
+esac
+
+(($# > 0)) || {
+  echo "Usage: omarchy-pkg-add <packages...>" >&2
+  exit 2
+}
+
+if /usr/bin/omarchy-pkg-missing "$@"; then
   if (( EUID == 0 )); then
-    pacman -S --noconfirm --needed "$@" || exit 1
+    /usr/bin/pacman -S --noconfirm --needed -- "$@" || exit 1
   else
-    sudo pacman -S --noconfirm --needed "$@" || exit 1
+    /usr/bin/sudo "${sudo_args[@]}" -- /usr/bin/pacman -S --noconfirm --needed -- "$@" || exit 1
   fi
 fi
 
 for pkg in "$@"; do
   # Secondary check to handle states where pacman doesn't actually register an error
-  if ! pacman -Q "$pkg" &>/dev/null; then
+  if ! /usr/bin/pacman -Q -- "$pkg" &>/dev/null; then
     echo -e "\033[31mError: Package '$pkg' did not install\033[0m" >&2
     exit 1
   fi

--- a/bin/omarchy-pkg-aur-add
+++ b/bin/omarchy-pkg-aur-add
@@ -3,16 +3,96 @@
 # omarchy:summary=Add the named packages to the system from the AUR if they're missing. Returns false if it couldn't be done.
 # omarchy:args=<packages...>
 
-if omarchy-pkg-missing "$@"; then
-  yay -S --noconfirm --needed "$@" || exit 1
-fi
+set -euo pipefail
 
-for pkg in "$@"; do
-  # Secondary check to handle states where pacman doesn't actually register an error
-  if ! pacman -Q "$pkg" &>/dev/null; then
-    echo -e "\033[31mError: Package '$pkg' did not install\033[0m" >&2
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+unset BASH_ENV ENV CDPATH GLOBIGNORE
+umask 077
+
+trusted_system_command() {
+  local command=$1 require_setuid=${2:-false}
+  local canonical owner mode links
+
+  [[ $command == /usr/bin/* && -f $command && -x $command && ! -L $command ]] || return 1
+  canonical=$(/usr/bin/realpath -e -- "$command") || return 1
+  [[ $canonical == "$command" ]] || return 1
+  read -r owner mode links < <(/usr/bin/stat -Lc '%u %a %h' -- "$command") || return 1
+  [[ $owner == 0 && $links == 1 ]] || return 1
+  (( (8#$mode & 0022) == 0 )) || return 1
+  [[ $require_setuid != true ]] || (( (8#$mode & 04000) != 0 ))
+}
+
+cleanup_sudo_credentials() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  if ! /usr/bin/sudo -k >/dev/null 2>&1; then
+    echo "Failed to invalidate sudo credentials after the AUR operation." >&2
+    (( status != 0 )) || status=1
+  fi
+  exit "$status"
+}
+
+trap cleanup_sudo_credentials EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+for command in /usr/bin/realpath /usr/bin/stat /usr/bin/sudo /usr/bin/yay /usr/bin/pacman /usr/bin/makepkg /usr/bin/omarchy-makepkg-unprivileged /usr/bin/setpriv /usr/bin/git /usr/bin/gpg; do
+  require_setuid=false
+  [[ $command != /usr/bin/sudo ]] || require_setuid=true
+  if ! trusted_system_command "$command" "$require_setuid"; then
+    echo "Refusing the AUR operation because $command is not a trusted system command." >&2
     exit 1
   fi
 done
 
-exit 0
+# This intentionally revokes even a timestamp that existed before invocation.
+# sudo cannot selectively invalidate only credentials created by one workflow;
+# preserving one would let build code reuse authority this command did not create.
+/usr/bin/sudo -k >/dev/null || {
+  echo "Unable to start the AUR build with a cold sudo credential state." >&2
+  exit 1
+}
+if ! /usr/bin/sudo -N -V >/dev/null 2>&1; then
+  echo "This sudo does not support --no-update; refusing to run an AUR build." >&2
+  exit 1
+fi
+
+(( $# > 0 )) || {
+  echo "Usage: omarchy-pkg-aur-add <packages...>" >&2
+  exit 2
+}
+
+packages=()
+missing_packages=()
+for package in "$@"; do
+  if [[ ! $package =~ ^[a-z0-9][a-z0-9@._+:-]*$ ]]; then
+    echo "Invalid AUR package name: $package" >&2
+    exit 2
+  fi
+  packages+=("$package")
+  if ! /usr/bin/pacman -Q -- "$package" &>/dev/null; then
+    missing_packages+=("$package")
+  fi
+done
+
+if (( ${#missing_packages[@]} )); then
+  # Command-line settings override hostile user config. -N makes each sudo
+  # authorization command-scoped; disabling sudoloop prevents refreshes.
+  /usr/bin/yay \
+    --sudo /usr/bin/sudo --sudoflags=-N --sudoloop=false \
+    --pacman /usr/bin/pacman --makepkg /usr/bin/omarchy-makepkg-unprivileged \
+    --mflags=--nodeps \
+    --git /usr/bin/git --gpg /usr/bin/gpg \
+    --config /etc/pacman.conf --nomakepkgconf --noremovemake \
+    -S --noconfirm --needed -- "${missing_packages[@]}"
+fi
+
+for package in "${packages[@]}"; do
+  # Secondary check to handle states where pacman doesn't actually register an error.
+  if ! /usr/bin/pacman -Q -- "$package" &>/dev/null; then
+    echo -e "\033[31mError: Package '$package' did not install\033[0m" >&2
+    exit 1
+  fi
+done

--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -3,27 +3,61 @@
 # omarchy:summary=Show a fuzzy-finder TUI for picking new AUR packages to install.
 # omarchy:requires-sudo=true
 
+set -euo pipefail
+
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+unset BASH_ENV ENV CDPATH GLOBIGNORE
+
+cleanup_sudo_credentials() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  if ! /usr/bin/sudo -k >/dev/null 2>&1; then
+    echo "Failed to invalidate sudo credentials after the AUR package picker." >&2
+    (( status != 0 )) || status=1
+  fi
+  exit "$status"
+}
+
+trap cleanup_sudo_credentials EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+/usr/bin/sudo -k >/dev/null || {
+  echo "Unable to start AUR discovery with a cold sudo credential state." >&2
+  exit 1
+}
+if ! /usr/bin/sudo -N -V >/dev/null 2>&1; then
+  echo "This sudo does not support --no-update; refusing to run the AUR package picker." >&2
+  exit 1
+fi
+
 fzf_args=(
   --multi
-  --preview 'yay -Siia {1}'
+  --preview '/usr/bin/yay --sudo /usr/bin/sudo --sudoflags=-N --sudoloop=false -Siia -- {1}'
   --preview-label='alt-p: toggle description, alt-b/B: toggle PKGBUILD, alt-j/k: scroll, tab: multi-select'
   --preview-label-pos='bottom'
   --preview-window 'down:65%:wrap'
   --bind 'alt-p:toggle-preview'
   --bind 'alt-d:preview-half-page-down,alt-u:preview-half-page-up'
   --bind 'alt-k:preview-up,alt-j:preview-down'
-  --bind 'alt-b:change-preview:yay -Gpa {1} | tail -n +5'
-  --bind 'alt-B:change-preview:yay -Siia {1}'
+  --bind 'alt-b:change-preview:/usr/bin/yay --sudo /usr/bin/sudo --sudoflags=-N --sudoloop=false -Gpa -- {1} | /usr/bin/tail -n +5'
+  --bind 'alt-B:change-preview:/usr/bin/yay --sudo /usr/bin/sudo --sudoflags=-N --sudoloop=false -Siia -- {1}'
   --color 'pointer:green,marker:green'
 )
 
-pkg_names=$(yay -Slqa | fzf "${fzf_args[@]}")
+pkg_names=$(/usr/bin/yay --sudo /usr/bin/sudo --sudoflags=-N --sudoloop=false -Slqa | /usr/bin/fzf "${fzf_args[@]}")
 
 if [[ -n $pkg_names ]]; then
-  # Add aur/ prefix to each package name and convert to space-separated for yay
-  source omarchy-sudo-keepalive
-
-  echo "$pkg_names" | sed 's/^/aur\//' | tr '\n' ' ' | xargs yay -S --noconfirm
-  sudo updatedb
-  omarchy-show-done
+  mapfile -t packages <<<"$pkg_names"
+  for package in "${packages[@]}"; do
+    [[ $package =~ ^[a-z0-9][a-z0-9@._+:-]*$ ]] || {
+      echo "Invalid AUR package selection: $package" >&2
+      exit 2
+    }
+  done
+  /usr/bin/omarchy-pkg-aur-add "${packages[@]}"
+  /usr/bin/sudo -N -- /usr/bin/updatedb
+  /usr/bin/omarchy-show-done
 fi

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -3,9 +3,39 @@
 # omarchy:summary=Show a fuzzy-finder TUI for picking new Arch and OPR packages to install.
 # omarchy:requires-sudo=true
 
+set -euo pipefail
+
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+unset BASH_ENV ENV CDPATH GLOBIGNORE
+
+cleanup_sudo_credentials() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  if ! /usr/bin/sudo -k >/dev/null 2>&1; then
+    echo "Failed to invalidate sudo credentials after the package picker." >&2
+    (( status != 0 )) || status=1
+  fi
+  exit "$status"
+}
+
+trap cleanup_sudo_credentials EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+/usr/bin/sudo -k >/dev/null || {
+  echo "Unable to start package discovery with a cold sudo credential state." >&2
+  exit 1
+}
+if ! /usr/bin/sudo -N -V >/dev/null 2>&1; then
+  echo "This sudo does not support --no-update; refusing to run the package picker." >&2
+  exit 1
+fi
+
 fzf_args=(
   --multi
-  --preview 'pacman -Sii {1}'
+  --preview '/usr/bin/pacman -Sii -- {1}'
   --preview-label='alt-p: toggle description, alt-j/k: scroll, tab: multi-select'
   --preview-label-pos='bottom'
   --preview-window 'down:65%:wrap'
@@ -15,12 +45,16 @@ fzf_args=(
   --color 'pointer:green,marker:green'
 )
 
-pkg_names=$(pacman -Slq | fzf "${fzf_args[@]}")
+pkg_names=$(/usr/bin/pacman -Slq | /usr/bin/fzf "${fzf_args[@]}")
 
 if [[ -n $pkg_names ]]; then
-  source omarchy-sudo-keepalive
-
-  # Convert newline-separated selections to space-separated for pacman
-  echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -S --noconfirm
-  omarchy-show-done
+  mapfile -t packages <<<"$pkg_names"
+  for package in "${packages[@]}"; do
+    [[ $package =~ ^[a-z0-9][a-z0-9@._+:-]*$ ]] || {
+      echo "Invalid package selection: $package" >&2
+      exit 2
+    }
+  done
+  /usr/bin/sudo -N -- /usr/bin/pacman -S --noconfirm -- "${packages[@]}"
+  /usr/bin/omarchy-show-done
 fi

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -3,9 +3,37 @@
 # omarchy:summary=Show a fuzzy-finder TUI for picking packages installed on the system to be removed.
 # omarchy:requires-sudo=true
 
+set -euo pipefail
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export PATH
+unset BASH_ENV ENV CDPATH GLOBIGNORE
+
+cleanup_sudo_credentials() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  if ! /usr/bin/sudo -k >/dev/null 2>&1; then
+    echo "Failed to invalidate sudo credentials after the package remover." >&2
+    (( status != 0 )) || status=1
+  fi
+  exit "$status"
+}
+trap cleanup_sudo_credentials EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+/usr/bin/sudo -k >/dev/null || {
+  echo "Unable to start package discovery with a cold sudo credential state." >&2
+  exit 1
+}
+if ! /usr/bin/sudo -N -V >/dev/null 2>&1; then
+  echo "This sudo does not support --no-update; refusing to run the package remover." >&2
+  exit 1
+fi
+
 fzf_args=(
   --multi
-  --preview 'yay -Qi {1}'
+  --preview '/usr/bin/yay -Qi -- {1}'
   --preview-label='alt-p: toggle description, alt-j/k: scroll, tab: multi-select'
   --preview-label-pos='bottom'
   --preview-window 'down:65%:wrap'
@@ -15,10 +43,16 @@ fzf_args=(
   --color 'pointer:red,marker:red'
 )
 
-pkg_names=$(yay -Qqe | fzf "${fzf_args[@]}")
+pkg_names=$(/usr/bin/yay -Qqe | /usr/bin/fzf "${fzf_args[@]}")
 
 if [[ -n $pkg_names ]]; then
-  # Convert newline-separated selections to space-separated for yay
-  echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns --noconfirm
-  omarchy-show-done
+  mapfile -t packages <<<"$pkg_names"
+  for package in "${packages[@]}"; do
+    [[ $package =~ ^[a-z0-9][a-z0-9@._+:-]*$ ]] || {
+      echo "Invalid package selection: $package" >&2
+      exit 2
+    }
+  done
+  /usr/bin/sudo -N -- /usr/bin/pacman -Rns --noconfirm -- "${packages[@]}"
+  /usr/bin/omarchy-show-done
 fi

--- a/bin/omarchy-remove-dev-env
+++ b/bin/omarchy-remove-dev-env
@@ -4,8 +4,33 @@
 # omarchy:args=<ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala>
 # omarchy:requires-sudo=true
 
-if [[ -z $1 ]]; then
+set -uo pipefail
+
+cleanup_sudo_credentials() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  if ! /usr/bin/sudo -k >/dev/null 2>&1; then
+    echo "Failed to invalidate sudo credentials after development environment removal." >&2
+    (( status != 0 )) || status=1
+  fi
+  exit "$status"
+}
+trap cleanup_sudo_credentials EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [[ -z ${1:-} ]]; then
   echo "Usage: omarchy-remove-dev-env <ruby|node|bun|deno|go|php|laravel|symfony|python|elixir|phoenix|zig|rust|java|dotnet|ocaml|clojure|scala>" >&2
+  exit 1
+fi
+
+/usr/bin/sudo -k >/dev/null || {
+  echo "Unable to start development environment removal with a cold sudo credential state." >&2
+  exit 1
+}
+if ! /usr/bin/sudo -N -V >/dev/null 2>&1; then
+  echo "This sudo does not support --no-update; refusing to run development environment removal." >&2
   exit 1
 fi
 
@@ -90,7 +115,10 @@ ocaml)
   echo -e "Removing OCaml...\n"
   opam switch remove default -y 2>/dev/null || true
   rm -rf ~/.opam 2>/dev/null || true
-  sudo rm -f /usr/local/bin/opam 2>/dev/null || true
+  if ! /usr/bin/sudo -N -- /usr/bin/rm -f /usr/local/bin/opam; then
+    echo "Failed to remove the system opam launcher." >&2
+    exit 1
+  fi
   ;;
 clojure)
   echo -e "Removing Clojure...\n"

--- a/bin/omarchy-update-aur-pkgs
+++ b/bin/omarchy-update-aur-pkgs
@@ -62,11 +62,15 @@ if /usr/bin/pacman -Qem >/dev/null; then
   if /usr/bin/omarchy-pkg-aur-accessible; then
     echo -e "\e[32m\nUpdate AUR packages\e[0m"
 
-    # A user's yay config can select another sudo command and enable a
-    # timestamp-refresh loop. Pin both settings on the command line. AUR build
-    # code may run before package authentication, so this boundary applies to
-    # standalone invocations as well as the top-level update.
-    /usr/bin/yay --sudo /usr/bin/sudo --sudoflags=-N --sudoloop=false \
+    # Command-line settings override hostile user configuration. Keep package
+    # resolution on fixed system tools and put every PKGBUILD under
+    # no_new_privs before yay authenticates its package transaction.
+    /usr/bin/yay \
+      --sudo /usr/bin/sudo --sudoflags=-N --sudoloop=false \
+      --pacman /usr/bin/pacman --makepkg /usr/bin/omarchy-makepkg-unprivileged \
+      --mflags=--nodeps \
+      --git /usr/bin/git --gpg /usr/bin/gpg \
+      --config /etc/pacman.conf --nomakepkgconf --noremovemake \
       -Sua --noconfirm --cleanafter --ignore gcc14,gcc14-libs
     /usr/bin/sudo -k || exit 1
     trap - EXIT

--- a/bin/omarchy-update-aur-pkgs
+++ b/bin/omarchy-update-aur-pkgs
@@ -1,11 +1,75 @@
-#!/bin/bash
+#!/bin/bash -p
 
 # omarchy:summary=Update AUR packages if any are installed
 
-if pacman -Qem >/dev/null; then
-  if omarchy-pkg-aur-accessible; then
+if [[ $- != *p* ]]; then
+  echo "Refusing an unsafe Bash startup for the AUR update." >&2
+  exit 126
+fi
+
+require_privileged_bash_startup() {
+  [[ $- == *p* ]] || return 1
+  /usr/bin/env -i /usr/bin/bash -p -c '
+    [[ $1 =~ ^[1-9][0-9]*$ ]] || exit 1
+    mapfile -d "" -t argv <"/proc/$1/cmdline" || exit 1
+    executable=$(/usr/bin/readlink -e -- "/proc/$1/exe") || exit 1
+    [[ $executable == /usr/bin/bash ]]
+    [[ ${argv[0]:-} == /bin/bash || ${argv[0]:-} == /usr/bin/bash ]]
+    [[ ${argv[1]:-} == -p ]]
+  ' omarchy-bash-startup "$$"
+}
+if ! require_privileged_bash_startup; then
+  echo "Refusing an unsafe Bash startup for the AUR update." >&2
+  exit 126
+fi
+unset -f require_privileged_bash_startup
+
+set -e
+
+sanitize_bash_startup_environment() {
+  local environment_entry environment_name
+  local needs_reexec=0
+  local -a environment_unsets=(-u BASH_ENV -u ENV)
+
+  [[ -z ${BASH_ENV+x} && -z ${ENV+x} ]] || needs_reexec=1
+  while IFS= read -r -d '' environment_entry; do
+    environment_name="${environment_entry%%=*}"
+    if [[ $environment_name == BASH_FUNC_*%% ]]; then
+      environment_unsets+=(-u "$environment_name")
+      needs_reexec=1
+    fi
+  done < <(/usr/bin/env -0)
+
+  if (( needs_reexec )); then
+    exec /usr/bin/env "${environment_unsets[@]}" /usr/bin/bash -p "$0" "$@"
+  fi
+}
+sanitize_bash_startup_environment "$@"
+unset -f sanitize_bash_startup_environment
+
+cleanup_sudo_credentials() {
+  /usr/bin/sudo -k || true
+}
+
+LC_ALL=C /usr/bin/sudo -h 2>&1 | /usr/bin/grep -Eq '^usage: sudo .*\[[^]]*N[^]]*\]' || {
+  echo "This sudo does not support --no-update; refusing a mixed-trust AUR update." >&2
+  exit 1
+}
+trap cleanup_sudo_credentials EXIT
+/usr/bin/sudo -k || exit 1
+
+if /usr/bin/pacman -Qem >/dev/null; then
+  if /usr/bin/omarchy-pkg-aur-accessible; then
     echo -e "\e[32m\nUpdate AUR packages\e[0m"
-    yay -Sua --noconfirm --cleanafter --ignore gcc14,gcc14-libs
+
+    # A user's yay config can select another sudo command and enable a
+    # timestamp-refresh loop. Pin both settings on the command line. AUR build
+    # code may run before package authentication, so this boundary applies to
+    # standalone invocations as well as the top-level update.
+    /usr/bin/yay --sudo /usr/bin/sudo --sudoflags=-N --sudoloop=false \
+      -Sua --noconfirm --cleanafter --ignore gcc14,gcc14-libs
+    /usr/bin/sudo -k || exit 1
+    trap - EXIT
     echo
   else
     echo -e "\e[31m\nAUR is unavailable (so skipping updates)\e[0m"

--- a/default/omarchy/sudo-no-update/sudo
+++ b/default/omarchy/sudo-no-update/sudo
@@ -1,0 +1,27 @@
+#!/bin/bash -p
+
+# Internal update/migration sudo boundary. Authentication may authorize this
+# command, but -N prevents it from publishing a timestamp that detached user
+# code can silently reuse.
+
+if [[ $- != *p* ]]; then
+  echo "Refusing an unsafe Bash startup for the sudo boundary." >&2
+  exit 126
+fi
+
+require_privileged_bash_startup() {
+  [[ $- == *p* ]] || return 1
+  /usr/bin/env -i /usr/bin/bash -p -c '
+    [[ $1 =~ ^[1-9][0-9]*$ ]] || exit 1
+    mapfile -d "" -t argv <"/proc/$1/cmdline" || exit 1
+    executable=$(/usr/bin/readlink -e -- "/proc/$1/exe") || exit 1
+    [[ $executable == /usr/bin/bash ]]
+    [[ ${argv[0]:-} == /bin/bash || ${argv[0]:-} == /usr/bin/bash ]]
+    [[ ${argv[1]:-} == -p ]]
+  ' omarchy-bash-startup "$$"
+}
+if ! require_privileged_bash_startup; then
+  echo "Refusing an unsafe Bash startup for the sudo boundary." >&2
+  exit 126
+fi
+exec /usr/bin/sudo -N -- "$@"

--- a/default/omarchy/sudo-no-update/sudo
+++ b/default/omarchy/sudo-no-update/sudo
@@ -24,4 +24,19 @@ if ! require_privileged_bash_startup; then
   echo "Refusing an unsafe Bash startup for the sudo boundary." >&2
   exit 126
 fi
-exec /usr/bin/sudo -N -- "$@"
+
+# Preserve the update sleep inhibitor's one non-command operation, while
+# keeping every command argument behind `--` so caller data cannot become a
+# sudo option.
+case "${1:-}" in
+  -v | --validate)
+    if (( $# != 1 )); then
+      echo "The sudo boundary accepts validation without additional options." >&2
+      exit 2
+    fi
+    exec /usr/bin/sudo -N "$1"
+    ;;
+  *)
+    exec /usr/bin/sudo -N -- "$@"
+    ;;
+esac

--- a/test/shell.d/aur-package-sudo-security-test.sh
+++ b/test/shell.d/aur-package-sudo-security-test.sh
@@ -12,7 +12,7 @@ if [[ ${OMARCHY_AUR_SUDO_SECURITY_NS:-0} != 1 ]]; then
   outer_uid=$(id -u)
   outer_gid=$(id -g)
   subuid=$(awk -F: -v user="$(id -un)" '$1 == user { print $2; exit }' /etc/subuid)
-  subgid=$(awk -F: -v group="$(id -gn)" '$1 == group { print $2; exit }' /etc/subgid)
+  subgid=$(awk -F: -v user="$(id -un)" '$1 == user { print $2; exit }' /etc/subgid)
   if [[ -z $subuid || -z $subgid ]]; then
     pass "no subordinate uid/gid range; skipping AUR/package sudo namespace proof"
     exit 0
@@ -98,6 +98,10 @@ int main(int argc, char **argv) {
     event("SUDO:no-new-privs-denied");
     return 1;
   }
+  if (argc == 2 && strcmp(argv[1], "-h") == 0) {
+    puts("usage: sudo [-ABbEHkNnPS] command");
+    return 0;
+  }
   if (argc == 2 && strcmp(argv[1], "-k") == 0) {
     event("SUDO:invalidate");
     if (unlink(required("TEST_SUDO_TOKEN")) && errno != ENOENT) return 125;
@@ -105,6 +109,10 @@ int main(int argc, char **argv) {
   }
   if (index < argc && strcmp(argv[index], "-N") == 0) { no_update = 1; index++; }
   if (index < argc && strcmp(argv[index], "-n") == 0) { noninteractive = 1; index++; }
+  if (index < argc && strcmp(argv[index], "-v") == 0) {
+    event(no_update ? "SUDO:validate-no-update" : "SUDO:validate-reusable");
+    return no_update ? 0 : 125;
+  }
   if (index < argc && strcmp(argv[index], "-V") == 0) {
     event("SUDO:check-no-update");
     return getenv("TEST_SUDO_NO_N") ? 2 : 0;
@@ -212,6 +220,10 @@ fi
 
 [[ ${TEST_YAY_FAIL_BEFORE_BUILD:-0} != 1 ]] || exit 73
 /usr/bin/setsid --fork "$HOME/attack" >/dev/null 2>&1
+if [[ " $* " != *' --pacman /usr/bin/pacman '* ]]; then
+  /usr/bin/sudo -N -- "$HOME/hostile-bin/pacman"
+  exit
+fi
 [[ " $* " == *' --makepkg /usr/bin/omarchy-makepkg-unprivileged '* ]] || exit 74
 [[ " $* " == *' --mflags=--nodeps '* ]] || exit 75
 # Model a PKGBUILD that directly restores normal PACMAN_AUTH and calls absolute
@@ -277,7 +289,11 @@ cat >"$stub_bin/omarchy-show-done" <<'STUB'
 #!/bin/bash
 printf 'DONE\n' >>"$TEST_EVENT_LOG"
 STUB
-chmod 0755 "$stub_bin"/{pacman,yay,fzf,makepkg,updatedb,omarchy-show-done}
+cat >"$stub_bin/omarchy-pkg-aur-accessible" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+chmod 0755 "$stub_bin"/{pacman,yay,fzf,makepkg,updatedb,omarchy-show-done,omarchy-pkg-aur-accessible}
 
 # Isolate /usr/bin so this test can install the newly added package-owned
 # launcher without creating anything on the host. Unvalidated utilities are
@@ -319,7 +335,7 @@ done
 "$host_bin/cp" -a "$stub_bin/sudo" /usr/bin/sudo
 "$host_bin/chown" 0:0 /usr/bin/sudo
 "$host_bin/chmod" 4755 /usr/bin/sudo
-for command in pacman yay makepkg fzf updatedb omarchy-show-done; do
+for command in pacman yay makepkg fzf updatedb omarchy-show-done omarchy-pkg-aur-accessible; do
   "$host_bin/cp" -a "$stub_bin/$command" "/usr/bin/$command"
   "$host_bin/chown" 0:0 "/usr/bin/$command"
   "$host_bin/chmod" 0755 "/usr/bin/$command"
@@ -349,11 +365,15 @@ cat >"$test_home/hostile-bin/sudo" <<'STUB'
 touch "$HOME/hostile-path-sudo-ran"
 exit 92
 STUB
+cat >"$test_home/hostile-bin/pacman" <<'STUB'
+#!/bin/bash
+touch "$HOME/hostile-pacman-ran"
+STUB
 chmod 0755 "$test_home/hostile-bin"/*
 chown -R 1000:1000 "$test_home/hostile-bin"
 chmod 0700 "$test_home/hostile-bin"
 cat >"$test_home/.config/yay/config.json" <<'JSON'
-{"sudobin":"/home/test/hostile-bin/sudo","sudoflags":"","sudoloop":true,"makepkgbin":"/home/test/hostile-bin/makepkg"}
+{"sudobin":"/home/test/hostile-bin/sudo","sudoflags":"","sudoloop":true,"pacmanbin":"/home/test/hostile-bin/pacman","makepkgbin":"/home/test/hostile-bin/makepkg"}
 JSON
 cat >"$test_home/.config/yay/init.lua" <<'LUA'
 -- A real yay init hook is user code. The fixture launches the polling child
@@ -441,6 +461,20 @@ assert_cold() {
   ! grep -q '^SUDO:publish-token$' "$event_log" || fail "$label published a reusable sudo timestamp"
 }
 
+set +e
+run_user /usr/bin/bash "$ROOT/default/omarchy/sudo-no-update/sudo" -p /usr/bin/true \
+  >"$test_tmp/unsafe-wrapper.out" 2>"$test_tmp/unsafe-wrapper.err"
+unsafe_wrapper_status=$?
+set -e
+(( unsafe_wrapper_status == 126 )) ||
+  fail "the privileged-Bash exception accepted an ordinary shell with a decoy -p argument"
+grep -Fq 'Refusing an unsafe Bash startup' "$test_tmp/unsafe-wrapper.err" ||
+  fail "the rejected sudo boundary did not explain its startup failure"
+run_user "$ROOT/default/omarchy/sudo-no-update/sudo" -v
+grep -Fxq 'SUDO:validate-no-update' "$event_log" ||
+  fail "the privileged sudo boundary did not preserve validation mode"
+pass "the privileged sudo boundary validates startup and preserves its supported option"
+
 # Generic AUR helper: a pre-existing global timestamp and hostile yay/PATH/
 # exported-function configuration are all cold before build code. The fixed
 # CLI still completes the legitimate root installation using no-update.
@@ -522,6 +556,19 @@ active_session=""
 [[ ! -e $token ]] || fail "generic AUR TERM left sudo live"
 [[ ! -e $protected_dir/generic-signal ]] || fail "generic AUR signal child reused root"
 pass "generic AUR signal cleanup invalidates the credential"
+
+# The updater has its own yay call and must pin the same package tools as the
+# generic helper. Without --pacman, the fixture models yay asking sudo to run
+# the command selected by the user's configuration.
+reset_case aur-update
+run_user env TEST_ATTACK_LABEL=aur-update TEST_PROTECTED_TARGET="$protected_dir/aur-update" \
+  "$ROOT/bin/omarchy-update-aur-pkgs"
+assert_cold aur-update
+grep -q 'YAY:.* <--pacman> </usr/bin/pacman>.* <--makepkg> </usr/bin/omarchy-makepkg-unprivileged>' "$event_log" ||
+  fail "AUR updater did not pin yay's privileged package tools"
+[[ ! -e $test_home/hostile-pacman-ran ]] ||
+  fail "AUR updater let user configuration select a root pacman command"
+pass "AUR updater pins privileged tools and isolates package builds"
 
 # Official picker: fzf starts the original polling exploit, then returns two
 # ordinary selections. Both installs happen in one fixed no-update transaction.
@@ -645,6 +692,8 @@ grep -q '^MAKEPKG:.* <--printsrcinfo>' "$event_log" ||
 grep -q '^MAKEPKG:.* <--nodeps>' "$event_log" ||
   fail "dev build did not enforce a dependency-free build phase"
 grep -q 'PACMAN:0:.* <-U>' "$event_log" || fail "dev build did not install the built package"
+grep -q 'PACMAN:0:.* <-U>.* <--overwrite=\*>' "$event_log" ||
+  fail "dev build did not preserve replacement of legacy conflicting files"
 grep -q 'PACMAN:0:.* <-S>.* <dev-dependency>' "$event_log" ||
   fail "dev build did not install validated dependencies as one no-update batch"
 grep -Fxq 'SUDO:no-new-privs-denied' "$event_log" ||
@@ -727,23 +776,3 @@ active_session=""
 [[ ! -e $token ]] || fail "OCaml removal TERM left sudo live"
 [[ ! -e $protected_dir/remove-ocaml-signal ]] || fail "OCaml signal child reused root"
 pass "OCaml removal failure and signal paths invalidate credentials"
-
-# OM-SEC-22 ends after every OCaml removal outcome has revoked authorization.
-# Other generic AUR callers are covered by their own finding-specific PRs.
-exit 0
-
-# Current generic callers with later privileged phases must retain a no-update
-# boundary. Migrations already run under their package-owned no-update wrapper.
-grep -qF 'browser_policy_sudo_args=(-N)' "$ROOT/bin/omarchy-install-browser" ||
-  fail "AUR browser policy setup can authenticate with reusable sudo"
-grep -qF 'enable_non_reusable_sudo' "$ROOT/bin/omarchy-migrate" ||
-  fail "AUR migration caller lost its no-update wrapper"
-! rg -q 'source[[:space:]]+omarchy-sudo-keepalive' "$ROOT/bin" ||
-  fail "a package picker still sources the reusable sudo keepalive"
-pass "generic AUR callers do not publish later reusable credentials"
-
-reset_case legacy-keepalive
-run_user env TEST_ATTACK_LABEL=legacy-keepalive TEST_PROTECTED_TARGET="$protected_dir/legacy-keepalive" \
-  bash "$ROOT/bin/omarchy-sudo-keepalive" >/dev/null 2>&1
-[[ ! -e $token ]] || fail "legacy keepalive command retained a reusable token"
-pass "legacy keepalive command is non-reusable"

--- a/test/shell.d/aur-package-sudo-security-test.sh
+++ b/test/shell.d/aur-package-sudo-security-test.sh
@@ -1,0 +1,749 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command unshare
+require_command setpriv
+require_command gcc
+
+if [[ ${OMARCHY_AUR_SUDO_SECURITY_NS:-0} != 1 ]]; then
+  outer_uid=$(id -u)
+  outer_gid=$(id -g)
+  subuid=$(awk -F: -v user="$(id -un)" '$1 == user { print $2; exit }' /etc/subuid)
+  subgid=$(awk -F: -v group="$(id -gn)" '$1 == group { print $2; exit }' /etc/subgid)
+  if [[ -z $subuid || -z $subgid ]]; then
+    pass "no subordinate uid/gid range; skipping AUR/package sudo namespace proof"
+    exit 0
+  fi
+  exec unshare --user --mount \
+    --map-users "0:$outer_uid:1" --map-users "1:$subuid:65536" \
+    --map-groups "0:$outer_gid:1" --map-groups "1:$subgid:65536" \
+    env OMARCHY_AUR_SUDO_SECURITY_NS=1 bash "$0"
+fi
+
+[[ $(id -u) == 0 ]] || fail "package sudo proof did not enter its root namespace"
+
+test_tmp=$(mktemp -d)
+mount -t tmpfs -o mode=0755,suid tmpfs "$test_tmp"
+stub_bin=$test_tmp/bin
+test_home=$test_tmp/home
+protected_dir=$test_tmp/protected
+event_log=$test_tmp/events
+token=$test_tmp/sudo-token
+installed=$test_tmp/installed
+mkdir -p "$stub_bin" "$test_home/.config/yay" "$protected_dir"
+touch "$event_log" "$installed"
+chown -R 1000:1000 "$test_home"
+chown 1000:1000 "$event_log" "$installed"
+chmod 0700 "$test_home"
+chmod 0755 "$stub_bin" "$protected_dir"
+chmod 0600 "$event_log" "$installed"
+
+mounted=()
+persistent_pids=()
+active_session=""
+cleanup() {
+  local status=$? pid pid_file index
+  trap - EXIT
+  if [[ $active_session =~ ^[1-9][0-9]*$ ]]; then
+    kill -TERM -- "-$active_session" 2>/dev/null || kill -TERM "$active_session" 2>/dev/null || true
+    kill -KILL -- "-$active_session" 2>/dev/null || kill -KILL "$active_session" 2>/dev/null || true
+  fi
+  for pid_file in "$test_home"/*.pid; do
+    [[ -s $pid_file ]] || continue
+    persistent_pids+=("$(<"$pid_file")")
+  done
+  for pid in "${persistent_pids[@]}"; do kill "$pid" 2>/dev/null || true; done
+  for (( index=${#mounted[@]}-1; index>=0; index-- )); do
+    umount -l "${mounted[index]}" 2>/dev/null || true
+  done
+  rm -rf "$test_tmp"/* 2>/dev/null || true
+  umount -l "$test_tmp" 2>/dev/null || true
+  rmdir "$test_tmp" 2>/dev/null || true
+  exit "$status"
+}
+trap cleanup EXIT
+
+cat >"$test_tmp/sudo.c" <<'C'
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char *required(const char *name) {
+  const char *value = getenv(name);
+  if (!value || !*value) exit(125);
+  return value;
+}
+static void event(const char *message) {
+  int fd = open(required("TEST_EVENT_LOG"), O_WRONLY | O_APPEND);
+  if (fd < 0) exit(125);
+  dprintf(fd, "%s\n", message);
+  close(fd);
+}
+static int has_token(void) { return access(required("TEST_SUDO_TOKEN"), F_OK) == 0; }
+static int create_token(void) {
+  int fd = open(required("TEST_SUDO_TOKEN"), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+  if (fd < 0) return 125;
+  close(fd);
+  return 0;
+}
+int main(int argc, char **argv) {
+  int index = 1, no_update = 0, noninteractive = 0;
+  if (geteuid() != 0) {
+    event("SUDO:no-new-privs-denied");
+    return 1;
+  }
+  if (argc == 2 && strcmp(argv[1], "-k") == 0) {
+    event("SUDO:invalidate");
+    if (unlink(required("TEST_SUDO_TOKEN")) && errno != ENOENT) return 125;
+    return 0;
+  }
+  if (index < argc && strcmp(argv[index], "-N") == 0) { no_update = 1; index++; }
+  if (index < argc && strcmp(argv[index], "-n") == 0) { noninteractive = 1; index++; }
+  if (index < argc && strcmp(argv[index], "-V") == 0) {
+    event("SUDO:check-no-update");
+    return getenv("TEST_SUDO_NO_N") ? 2 : 0;
+  }
+  if (index < argc && strcmp(argv[index], "--") == 0) index++;
+  if (noninteractive && !has_token()) {
+    event("SUDO:deny-noninteractive");
+    return 1;
+  }
+  if (!no_update && !noninteractive) {
+    event("SUDO:publish-token");
+    if (create_token()) return 125;
+  } else if (no_update) {
+    event("SUDO:grant-no-update");
+  }
+  if (index >= argc || setgid(0) || setuid(0)) return 125;
+  execv(argv[index], &argv[index]);
+  return errno == ENOENT ? 127 : 126;
+}
+C
+gcc -O2 -Wall -Wextra -o "$stub_bin/sudo" "$test_tmp/sudo.c"
+chown 0:0 "$stub_bin/sudo"
+chmod 4755 "$stub_bin/sudo"
+
+cat >"$test_home/payload" <<'PAYLOAD'
+package-picker-payload
+PAYLOAD
+chown 1000:1000 "$test_home/payload"
+chmod 0600 "$test_home/payload"
+
+cat >"$test_home/attack" <<'ATTACK'
+#!/bin/bash
+pid_file=$HOME/attack-${TEST_ATTACK_LABEL:-generic}.pid
+printf '%s\n' "$$" >"$pid_file"
+if [[ ${TEST_ATTACK_SINGLE_ATTEMPT:-0} == 1 ]]; then
+  if /usr/bin/sudo -n -- /usr/bin/install -o 0 -g 0 -m 0600 \
+      "$HOME/payload" "$TEST_PROTECTED_TARGET" 2>/dev/null; then
+    printf 'ATTACK:root-reused\n' >>"$TEST_EVENT_LOG"
+  else
+    printf 'ATTACK:first-attempt-denied\n' >>"$TEST_EVENT_LOG"
+  fi
+  exit 0
+fi
+for _ in {1..120}; do
+  if /usr/bin/sudo -n -- /usr/bin/install -o 0 -g 0 -m 0600 \
+      "$HOME/payload" "$TEST_PROTECTED_TARGET" 2>/dev/null; then
+    printf 'ATTACK:root-reused\n' >>"$TEST_EVENT_LOG"
+    exit 0
+  fi
+  /usr/bin/sleep 0.005
+done
+printf 'ATTACK:blocked\n' >>"$TEST_EVENT_LOG"
+ATTACK
+chmod 0755 "$test_home/attack"
+
+cat >"$stub_bin/pacman" <<'STUB'
+#!/bin/bash
+printf -v trace 'PACMAN:%s:' "$(/usr/bin/id -u)"
+for argument in "$@"; do printf -v trace '%s <%s>' "$trace" "$argument"; done
+printf '%s\n' "$trace" >>"$TEST_EVENT_LOG"
+case " $* " in
+  *' -Slq '*) printf 'safe-one\nsafe-two\n'; exit 0 ;;
+  *' -Sii '*) exit 0 ;;
+esac
+if [[ ${1:-} == -Q ]]; then
+  package=${3:-}
+  /usr/bin/grep -Fxq "$package" "$TEST_INSTALLED"
+  exit
+fi
+if [[ ${1:-} == -T ]]; then
+  shift
+  [[ ${1:-} != -- ]] || shift
+  printf '%s\n' "$@"
+  exit 127
+fi
+if [[ " $* " == *' -S '* || " $* " == *' -U '* || " $* " == *' -Rns '* ]]; then
+  [[ $(/usr/bin/id -u) == 0 ]] || exit 71
+  [[ ${TEST_PACMAN_FAIL:-0} != 1 ]] || exit 72
+  if [[ ${TEST_PACMAN_SKIP_INSTALL:-0} != 1 ]]; then
+    for argument in "$@"; do
+      [[ $argument =~ ^[a-z0-9][a-z0-9@._+:-]*$ ]] || continue
+      printf '%s\n' "$argument" >>"$TEST_INSTALLED"
+    done
+  fi
+fi
+STUB
+
+cat >"$stub_bin/yay" <<'STUB'
+#!/bin/bash
+trace=YAY:
+for argument in "$@"; do printf -v trace '%s <%s>' "$trace" "$argument"; done
+printf '%s\n' "$trace" >>"$TEST_EVENT_LOG"
+if [[ " $* " == *' -Slqa '* ]]; then
+  [[ ${TEST_START_DISCOVERY_ATTACK:-0} != 1 ]] || \
+    /usr/bin/setsid --fork "$HOME/attack" >/dev/null 2>&1
+  printf 'safe-aur\nsafe-extra\n'
+  exit 0
+fi
+if [[ " $* " == *' -Qqe '* ]]; then
+  [[ ${TEST_START_DISCOVERY_ATTACK:-0} != 1 ]] || \
+    /usr/bin/setsid --fork "$HOME/attack" >/dev/null 2>&1
+  printf 'safe-one\nsafe-two\n'
+  exit 0
+fi
+
+[[ ${TEST_YAY_FAIL_BEFORE_BUILD:-0} != 1 ]] || exit 73
+/usr/bin/setsid --fork "$HOME/attack" >/dev/null 2>&1
+[[ " $* " == *' --makepkg /usr/bin/omarchy-makepkg-unprivileged '* ]] || exit 74
+[[ " $* " == *' --mflags=--nodeps '* ]] || exit 75
+# Model a PKGBUILD that directly restores normal PACMAN_AUTH and calls absolute
+# sudo. no_new_privs on the fixed makepkg launcher must make setuid ineffective.
+targets=(); after_delimiter=0
+for argument in "$@"; do
+  if (( after_delimiter )); then targets+=("$argument"); fi
+  [[ $argument != -- ]] || after_delimiter=1
+done
+for target in "${targets[@]}"; do
+  TEST_MAKEPKG_GENERIC=1 /usr/bin/omarchy-makepkg-unprivileged --nodeps "$target"
+done
+if [[ ${TEST_YAY_BLOCK:-0} == 1 ]]; then
+  printf 'ready\n' >"$TEST_READY"
+  trap 'exit 143' TERM
+  while :; do /usr/bin/sleep 0.05; done
+fi
+[[ ${TEST_YAY_BUILD_FAIL:-0} != 1 ]] || exit 76
+/usr/bin/sudo -N -- /usr/bin/pacman -S --noconfirm -- "${targets[@]}"
+STUB
+
+cat >"$stub_bin/fzf" <<'STUB'
+#!/bin/bash
+printf 'FZF\n' >>"$TEST_EVENT_LOG"
+/usr/bin/cat >/dev/null
+[[ ${TEST_START_DISCOVERY_ATTACK:-0} != 1 ]] || \
+  /usr/bin/setsid --fork "$HOME/attack" >/dev/null 2>&1
+if [[ ${TEST_FZF_BLOCK:-0} == 1 ]]; then
+  printf 'ready\n' >"$TEST_READY"
+  trap 'exit 143' TERM
+  while :; do /usr/bin/sleep 0.05; done
+fi
+[[ ${TEST_FZF_FAIL:-0} != 1 ]] || exit 77
+printf '%b' "${TEST_SELECTION:-}"
+STUB
+
+cat >"$stub_bin/makepkg" <<'STUB'
+#!/bin/bash
+trace=MAKEPKG:
+for argument in "$@"; do printf -v trace '%s <%s>' "$trace" "$argument"; done
+printf '%s\n' "$trace" >>"$TEST_EVENT_LOG"
+/usr/bin/setsid --fork "$HOME/attack" >/dev/null 2>&1
+# This is the direct makepkg-internal override: an ordinary sudo call must be
+# denied by the kernel-enforced no_new_privs boundary.
+if /usr/bin/sudo -- /usr/bin/pacman -S --asdeps -- bypass-dependency; then
+  exit 78
+fi
+[[ ${TEST_MAKEPKG_GENERIC:-0} != 1 ]] || exit 0
+if [[ " $* " == *' --printsrcinfo '* ]]; then
+  printf 'pkgbase = test-package\n\tmakedepends = dev-dependency>=1\n\tpkgname = test-package\n'
+  exit 0
+fi
+[[ ${TEST_MAKEPKG_FAIL:-0} != 1 ]] || exit 81
+/usr/bin/touch "$PWD/dev-package.pkg.tar.zst"
+STUB
+
+cat >"$stub_bin/updatedb" <<'STUB'
+#!/bin/bash
+[[ $(/usr/bin/id -u) == 0 ]] || exit 82
+printf 'UPDATEDB:no-update\n' >>"$TEST_EVENT_LOG"
+STUB
+cat >"$stub_bin/omarchy-show-done" <<'STUB'
+#!/bin/bash
+printf 'DONE\n' >>"$TEST_EVENT_LOG"
+STUB
+chmod 0755 "$stub_bin"/{pacman,yay,fzf,makepkg,updatedb,omarchy-show-done}
+
+# Isolate /usr/bin so this test can install the newly added package-owned
+# launcher without creating anything on the host. Unvalidated utilities are
+# symlinked to a read-only bind of the original tree; every command production
+# explicitly validates is copied as a namespace-root-owned regular file.
+host_bin=$test_tmp/host-bin
+mkdir -p "$host_bin"
+mount --bind /usr/bin "$host_bin"
+mounted+=("$host_bin")
+export TEST_HOST_BIN=$host_bin
+mount -t tmpfs -o mode=0755,suid tmpfs /usr/bin
+mounted+=(/usr/bin)
+
+host_commands=(
+  awk bash cat chmod chown cp dirname env grep head id install ln mkdir mktemp
+  mv printf readlink rg rm sed setsid sleep tail touch true uname
+)
+for command in "${host_commands[@]}"; do
+  "$host_bin/ln" -s "$host_bin/$command" "/usr/bin/$command"
+done
+
+"$host_bin/rm" -f /usr/bin/rm
+cat > /usr/bin/rm <<'STUB'
+#!/bin/bash
+if [[ " $* " == *' /usr/local/bin/opam '* ]]; then
+  printf 'REMOVE-OPAM:%s\n' "$(/usr/bin/id -u)" >>"$TEST_EVENT_LOG"
+  [[ ${TEST_RM_FAIL:-0} != 1 ]] || exit 83
+  exit 0
+fi
+exec "$TEST_HOST_BIN/rm" "$@"
+STUB
+"$host_bin/chown" 0:0 /usr/bin/rm
+"$host_bin/chmod" 0755 /usr/bin/rm
+for command in realpath stat setpriv git gpg; do
+  "$host_bin/cp" -a "$host_bin/$command" "/usr/bin/$command"
+  "$host_bin/chown" 0:0 "/usr/bin/$command"
+  "$host_bin/chmod" 0755 "/usr/bin/$command"
+done
+"$host_bin/cp" -a "$stub_bin/sudo" /usr/bin/sudo
+"$host_bin/chown" 0:0 /usr/bin/sudo
+"$host_bin/chmod" 4755 /usr/bin/sudo
+for command in pacman yay makepkg fzf updatedb omarchy-show-done; do
+  "$host_bin/cp" -a "$stub_bin/$command" "/usr/bin/$command"
+  "$host_bin/chown" 0:0 "/usr/bin/$command"
+  "$host_bin/chmod" 0755 "/usr/bin/$command"
+done
+"$host_bin/cp" -a "$ROOT/bin/omarchy-pkg-aur-add" /usr/bin/omarchy-pkg-aur-add
+"$host_bin/cp" -a "$ROOT/bin/omarchy-makepkg-unprivileged" /usr/bin/omarchy-makepkg-unprivileged
+"$host_bin/chown" 0:0 /usr/bin/omarchy-pkg-aur-add /usr/bin/omarchy-makepkg-unprivileged
+"$host_bin/chmod" 0755 /usr/bin/omarchy-pkg-aur-add /usr/bin/omarchy-makepkg-unprivileged
+
+base_env=(
+  HOME="$test_home"
+  USER=test LOGNAME=test
+  PATH="$test_home/hostile-bin:/usr/bin:/bin"
+  TEST_EVENT_LOG="$event_log"
+  TEST_SUDO_TOKEN="$token"
+  TEST_INSTALLED="$installed"
+  TEST_HOST_BIN="$host_bin"
+)
+mkdir -p "$test_home/hostile-bin"
+cat >"$test_home/hostile-bin/yay" <<'STUB'
+#!/bin/bash
+touch "$HOME/hostile-path-yay-ran"
+exit 91
+STUB
+cat >"$test_home/hostile-bin/sudo" <<'STUB'
+#!/bin/bash
+touch "$HOME/hostile-path-sudo-ran"
+exit 92
+STUB
+chmod 0755 "$test_home/hostile-bin"/*
+chown -R 1000:1000 "$test_home/hostile-bin"
+chmod 0700 "$test_home/hostile-bin"
+cat >"$test_home/.config/yay/config.json" <<'JSON'
+{"sudobin":"/home/test/hostile-bin/sudo","sudoflags":"","sudoloop":true,"makepkgbin":"/home/test/hostile-bin/makepkg"}
+JSON
+cat >"$test_home/.config/yay/init.lua" <<'LUA'
+-- A real yay init hook is user code. The fixture launches the polling child
+-- when yay starts so the test does not depend on a Lua interpreter.
+LUA
+
+run_user() {
+  setpriv --reuid=1000 --regid=1000 --clear-groups \
+    env -i "${base_env[@]}" \
+    'BASH_FUNC_yay%%=() { touch "$HOME/exported-yay-ran"; }' \
+    'BASH_FUNC_fzf%%=() { touch "$HOME/exported-fzf-ran"; }' \
+    "$@"
+}
+
+# A backgrounded Bash function gives $! for the wrapper subshell, not for the
+# setsid process it waits on. Launch setpriv itself in the background so the
+# recorded PID is also the new session/process-group ID and signal tests cannot
+# orphan their blocked fixture under the user manager.
+start_user_session() {
+  setpriv --reuid=1000 --regid=1000 --clear-groups \
+    env -i "${base_env[@]}" \
+    'BASH_FUNC_yay%%=() { touch "$HOME/exported-yay-ran"; }' \
+    'BASH_FUNC_fzf%%=() { touch "$HOME/exported-fzf-ran"; }' \
+    "$@" &
+  session=$!
+  active_session=$session
+}
+
+stop_case_attackers() {
+  local pid pid_file remaining
+  local pids=()
+
+  for pid_file in "$test_home"/attack-*.pid; do
+    [[ -s $pid_file ]] || continue
+    pid=$(<"$pid_file")
+    [[ $pid =~ ^[1-9][0-9]*$ ]] || continue
+    pids+=("$pid")
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+
+  for _ in {1..200}; do
+    remaining=0
+    for pid in "${pids[@]}"; do
+      kill -0 "$pid" 2>/dev/null && remaining=1
+    done
+    (( remaining )) || break
+    sleep 0.005
+  done
+  for pid in "${pids[@]}"; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  rm -f "$test_home"/attack-*.pid
+}
+
+reset_case() {
+  local label=$1
+  # Detached discovery/build children are intentionally not shell jobs. Drain
+  # the previous case before truncating shared logs so a late final denial can
+  # never be misattributed to the next unsupported/failure scenario.
+  stop_case_attackers
+  : >"$event_log"
+  : >"$installed"
+  chown 1000:1000 "$event_log" "$installed"
+  rm -f "$token" "$protected_dir"/* "$test_home"/*-ran "$test_home/ready"
+  export TEST_ATTACK_LABEL=$label
+  export TEST_PROTECTED_TARGET="$protected_dir/$label"
+}
+
+wait_for_attack() {
+  for _ in {1..140}; do
+    grep -q '^ATTACK:' "$event_log" 2>/dev/null && return 0
+    sleep 0.005
+  done
+  return 1
+}
+
+assert_cold() {
+  local label=$1
+  if ! wait_for_attack; then
+    /usr/bin/tail -80 "$event_log" >&2 || true
+    fail "$label did not exercise the polling child"
+  fi
+  [[ ! -e $protected_dir/$label ]] || fail "$label let user code reuse root authority"
+  [[ ! -e $token ]] || fail "$label left a reusable sudo timestamp"
+  ! grep -q '^SUDO:publish-token$' "$event_log" || fail "$label published a reusable sudo timestamp"
+}
+
+# Generic AUR helper: a pre-existing global timestamp and hostile yay/PATH/
+# exported-function configuration are all cold before build code. The fixed
+# CLI still completes the legitimate root installation using no-update.
+reset_case generic
+touch "$token"
+chown 0:0 "$token"
+umask 000
+run_user env TEST_ATTACK_LABEL=generic TEST_PROTECTED_TARGET="$protected_dir/generic" \
+  bash "$ROOT/bin/omarchy-pkg-aur-add" safe-aur
+assert_cold generic
+grep -Fxq safe-aur "$installed" || fail "generic AUR install did not complete"
+grep -q 'YAY:.* <--sudo> </usr/bin/sudo>.* <--sudoflags=-N>.* <--sudoloop=false>' "$event_log" ||
+  fail "generic helper did not override hostile yay sudo settings"
+grep -q 'YAY:.* <--pacman> </usr/bin/pacman>.* <--makepkg> </usr/bin/omarchy-makepkg-unprivileged>' "$event_log" ||
+  fail "generic helper did not pin yay's unprivileged package tools"
+grep -Fxq 'SUDO:no-new-privs-denied' "$event_log" ||
+  fail "direct PKGBUILD sudo override did not reach the kernel boundary"
+[[ ! -e $test_home/hostile-path-yay-ran && ! -e $test_home/exported-yay-ran ]] ||
+  fail "generic helper used caller command resolution"
+pass "generic AUR build cannot reuse pre-existing or later installation authority"
+
+reset_case generic-multi
+run_user env TEST_ATTACK_LABEL=generic-multi TEST_PROTECTED_TARGET="$protected_dir/generic-multi" \
+  bash "$ROOT/bin/omarchy-pkg-aur-add" safe-aur safe-extra
+assert_cold generic-multi
+grep -Fxq safe-aur "$installed" && grep -Fxq safe-extra "$installed" ||
+  fail "generic multi-package install did not complete"
+(( $(grep -c '^SUDO:no-new-privs-denied$' "$event_log") >= 2 )) ||
+  fail "each sequential PKGBUILD did not retain no_new_privs"
+pass "sequential AUR builds cannot restore privileged makepkg behavior"
+
+# Verification stays fail closed when yay reports success without registering
+# the package, and build/install failures still revoke.
+reset_case verify
+if run_user env TEST_ATTACK_LABEL=verify TEST_PROTECTED_TARGET="$protected_dir/verify" \
+    TEST_PACMAN_SKIP_INSTALL=1 bash "$ROOT/bin/omarchy-pkg-aur-add" safe-aur; then
+  fail "generic helper accepted an unregistered package"
+fi
+assert_cold verify
+reset_case build-fail
+if run_user env TEST_ATTACK_LABEL=build-fail TEST_PROTECTED_TARGET="$protected_dir/build-fail" \
+    TEST_YAY_BUILD_FAIL=1 bash "$ROOT/bin/omarchy-pkg-aur-add" safe-aur; then
+  fail "generic helper ignored a build failure"
+fi
+assert_cold build-fail
+reset_case install-fail
+if run_user env TEST_ATTACK_LABEL=install-fail TEST_PROTECTED_TARGET="$protected_dir/install-fail" \
+    TEST_PACMAN_FAIL=1 bash "$ROOT/bin/omarchy-pkg-aur-add" safe-aur; then
+  fail "generic helper ignored an install failure"
+fi
+assert_cold install-fail
+pass "AUR build, install, and registration failures remain fail closed"
+
+# Unsupported -N must be detected before yay or other user-controlled build
+# machinery starts.
+reset_case unsupported
+if run_user env TEST_ATTACK_LABEL=unsupported TEST_PROTECTED_TARGET="$protected_dir/unsupported" \
+    TEST_SUDO_NO_N=1 bash "$ROOT/bin/omarchy-pkg-aur-add" safe-aur; then
+  fail "generic helper ran without sudo no-update support"
+fi
+! grep -q '^YAY:' "$event_log" || fail "unsupported sudo reached yay build code"
+[[ ! -e $token ]] || fail "unsupported sudo left a credential live"
+pass "unsupported sudo fails before AUR code"
+
+reset_case generic-signal
+touch "$token"; chown 0:0 "$token"
+ready=$test_home/ready
+set +e
+start_user_session /usr/bin/setsid bash -c \
+  'exec env TEST_ATTACK_LABEL=generic-signal TEST_PROTECTED_TARGET="$1" TEST_YAY_BLOCK=1 TEST_READY="$2" bash "$3" safe-aur' \
+  generic-signal "$protected_dir/generic-signal" "$ready" "$ROOT/bin/omarchy-pkg-aur-add"
+set -e
+for _ in {1..200}; do [[ -e $ready ]] && break; sleep 0.005; done
+[[ -e $ready ]] || fail "generic AUR signal fixture did not become ready"
+kill -TERM -- "-$session" 2>/dev/null || kill -TERM "$session"
+set +e; wait "$session"; signal_status=$?; set -e
+active_session=""
+(( signal_status != 0 )) || fail "generic AUR TERM unexpectedly succeeded"
+[[ ! -e $token ]] || fail "generic AUR TERM left sudo live"
+[[ ! -e $protected_dir/generic-signal ]] || fail "generic AUR signal child reused root"
+pass "generic AUR signal cleanup invalidates the credential"
+
+# Official picker: fzf starts the original polling exploit, then returns two
+# ordinary selections. Both installs happen in one fixed no-update transaction.
+reset_case official-picker
+touch "$token"; chown 0:0 "$token"
+run_user env TEST_ATTACK_LABEL=official-picker TEST_PROTECTED_TARGET="$protected_dir/official-picker" \
+  TEST_START_DISCOVERY_ATTACK=1 TEST_SELECTION=$'safe-one\nsafe-two\n' \
+  bash "$ROOT/bin/omarchy-pkg-install"
+assert_cold official-picker
+grep -q 'PACMAN:0:.* <-S>.* <--> <safe-one> <safe-two>' "$event_log" ||
+  fail "official picker did not preserve multi-selection install"
+[[ ! -e $test_home/exported-fzf-ran ]] || fail "official picker used an exported fzf function"
+pass "official package picker keeps discovery code outside reusable sudo authority"
+
+# AUR picker routes through the hardened generic helper, then updatedb is also
+# command-scoped. The discovery child and build child both remain unprivileged.
+reset_case aur-picker
+run_user env TEST_ATTACK_LABEL=aur-picker TEST_PROTECTED_TARGET="$protected_dir/aur-picker" \
+  TEST_START_DISCOVERY_ATTACK=1 TEST_SELECTION=$'safe-aur\n' \
+  bash "$ROOT/bin/omarchy-pkg-aur-install"
+assert_cold aur-picker
+grep -Fxq 'UPDATEDB:no-update' "$event_log" || fail "AUR picker did not run updatedb"
+grep -Fxq safe-aur "$installed" || fail "AUR picker did not route through generic install"
+pass "AUR picker uses the generic cold build boundary and no-update updatedb"
+
+# Removal discovery has the same fzf extension boundary. Multi-select is
+# passed after -- to one no-update pacman transaction; injected selections are
+# rejected rather than becoming pacman options.
+reset_case remove-picker
+run_user env TEST_ATTACK_LABEL=remove-picker TEST_PROTECTED_TARGET="$protected_dir/remove-picker" \
+  TEST_START_DISCOVERY_ATTACK=1 TEST_SELECTION=$'safe-one\nsafe-two\n' \
+  bash "$ROOT/bin/omarchy-pkg-remove"
+assert_cold remove-picker
+grep -q 'PACMAN:0:.* <-Rns>.* <--> <safe-one> <safe-two>' "$event_log" ||
+  fail "package remover did not preserve safe multi-selection"
+reset_case remove-injection
+if run_user env TEST_ATTACK_LABEL=remove-injection TEST_PROTECTED_TARGET="$protected_dir/remove-injection" \
+    TEST_SELECTION=$'--config\n' bash "$ROOT/bin/omarchy-pkg-remove"; then
+  fail "package remover accepted an option-like selection"
+fi
+! grep -q 'PACMAN:0:.* <-Rns>' "$event_log" || fail "invalid removal selection reached pacman"
+[[ ! -e $token ]] || fail "invalid removal selection left sudo live"
+pass "package remover keeps discovery cold and rejects option injection"
+
+reset_case remove-fail
+if run_user env TEST_ATTACK_LABEL=remove-fail TEST_PROTECTED_TARGET="$protected_dir/remove-fail" \
+    TEST_START_DISCOVERY_ATTACK=1 TEST_SELECTION=$'safe-one\n' TEST_PACMAN_FAIL=1 \
+    bash "$ROOT/bin/omarchy-pkg-remove"; then
+  fail "package remover ignored pacman failure"
+fi
+assert_cold remove-fail
+reset_case remove-empty
+run_user env TEST_ATTACK_LABEL=remove-empty TEST_PROTECTED_TARGET="$protected_dir/remove-empty" \
+  TEST_SELECTION='' bash "$ROOT/bin/omarchy-pkg-remove"
+[[ ! -e $token ]] || fail "empty removal selection left sudo live"
+pass "package remover failure and empty selection leave no credential"
+
+# No selection, cancellation, failure, and unsupported sudo all leave the
+# picker cold; unsupported support probing precedes fzf execution.
+reset_case no-selection
+run_user env TEST_ATTACK_LABEL=no-selection TEST_PROTECTED_TARGET="$protected_dir/no-selection" \
+  TEST_SELECTION='' bash "$ROOT/bin/omarchy-pkg-install"
+[[ ! -e $token ]] || fail "empty picker selection left sudo live"
+reset_case picker-fail
+if run_user env TEST_ATTACK_LABEL=picker-fail TEST_PROTECTED_TARGET="$protected_dir/picker-fail" \
+    TEST_FZF_FAIL=1 bash "$ROOT/bin/omarchy-pkg-install"; then
+  fail "picker ignored fzf failure"
+fi
+[[ ! -e $token ]] || fail "fzf failure left sudo live"
+reset_case picker-unsupported
+if run_user env TEST_ATTACK_LABEL=picker-unsupported TEST_PROTECTED_TARGET="$protected_dir/picker-unsupported" \
+    TEST_SUDO_NO_N=1 bash "$ROOT/bin/omarchy-pkg-install"; then
+  fail "picker accepted unsupported sudo"
+fi
+! grep -q '^FZF$' "$event_log" || fail "picker ran fzf before validating sudo -N"
+pass "picker cancellation and failures clean up before publication"
+
+# Signal the whole picker session so both the user-configurable fzf and parent
+# receive TERM; the parent EXIT trap must invalidate the pre-existing token.
+reset_case picker-signal
+touch "$token"; chown 0:0 "$token"
+ready=$test_home/ready
+set +e
+start_user_session /usr/bin/setsid bash -c \
+  'exec env TEST_ATTACK_LABEL=picker-signal TEST_PROTECTED_TARGET="$1" TEST_FZF_BLOCK=1 TEST_READY="$2" bash "$3"' \
+  picker-signal "$protected_dir/picker-signal" "$ready" "$ROOT/bin/omarchy-pkg-install"
+set -e
+for _ in {1..200}; do [[ -e $ready ]] && break; sleep 0.005; done
+[[ -e $ready ]] || fail "picker signal fixture did not become ready"
+kill -TERM -- "-$session" 2>/dev/null || kill -TERM "$session"
+set +e; wait "$session"; signal_status=$?; set -e
+active_session=""
+(( signal_status != 0 )) || fail "picker TERM unexpectedly succeeded"
+[[ ! -e $token ]] || fail "picker TERM left sudo live"
+pass "picker signal cleanup invalidates the credential"
+
+# The local package development flow discovers dependencies while no_new_privs
+# is active, installs a validated batch with -N, then builds without dependency
+# installation and uses -N again for pacman -U. It must work before the new
+# package-owned launcher has itself been installed.
+/usr/bin/rm -f /usr/bin/omarchy-makepkg-unprivileged
+[[ ! -e /usr/bin/omarchy-makepkg-unprivileged ]] || fail "could not model pre-launcher release"
+reset_case dev
+checkout=$test_home/checkout
+pkgbuild_root=$test_home/pkgbuilds
+mkdir -p "$checkout" "$pkgbuild_root/test-package"
+cat >"$pkgbuild_root/test-package/PKGBUILD" <<'PKGBUILD'
+pkgname=test-package
+pkgver=1
+pkgrel=1
+arch=(any)
+package() { :; }
+PKGBUILD
+chown -R 1000:1000 "$checkout" "$pkgbuild_root"
+run_user env TEST_ATTACK_LABEL=dev TEST_PROTECTED_TARGET="$protected_dir/dev" \
+  OMARCHY_PKGBUILDS_DIR="$pkgbuild_root" \
+  bash "$ROOT/bin/omarchy-dev-pkg-test" test-package "$checkout"
+assert_cold dev
+grep -q '^MAKEPKG:.* <--printsrcinfo>' "$event_log" ||
+  fail "dev build did not generate dependency metadata under isolation"
+grep -q '^MAKEPKG:.* <--nodeps>' "$event_log" ||
+  fail "dev build did not enforce a dependency-free build phase"
+grep -q 'PACMAN:0:.* <-U>' "$event_log" || fail "dev build did not install the built package"
+grep -q 'PACMAN:0:.* <-S>.* <dev-dependency>' "$event_log" ||
+  fail "dev build did not install validated dependencies as one no-update batch"
+grep -Fxq 'SUDO:no-new-privs-denied' "$event_log" ||
+  fail "dev PKGBUILD direct sudo override did not reach no_new_privs"
+pass "local PKGBUILD dependencies and installation use only no-update sudo"
+
+reset_case dev-bypass
+if run_user env TEST_ATTACK_LABEL=dev-bypass TEST_PROTECTED_TARGET="$protected_dir/dev-bypass" \
+    OMARCHY_PKGBUILDS_DIR="$pkgbuild_root" \
+    bash "$ROOT/bin/omarchy-dev-pkg-test" test-package "$checkout" --config /tmp/evil; then
+  fail "dev build accepted a makepkg config override"
+fi
+! grep -q '^MAKEPKG:' "$event_log" || fail "dev config bypass reached build code"
+pass "developer makepkg overrides cannot replace the no-update policy"
+
+# OCaml removal executes user-owned opam first. Its detached child sees a cold
+# credential before the final fixed sudo -N rm and after command completion.
+cat >"$test_home/hostile-bin/opam" <<'STUB'
+#!/bin/bash
+# A synchronous child performs and records the first denied attempt. Only then
+# do we launch the detached poller whose lifetime crosses the final sudo call.
+TEST_ATTACK_SINGLE_ATTEMPT=1 "$HOME/attack"
+first_pid=$(/usr/bin/cat "$HOME/attack-${TEST_ATTACK_LABEL:-generic}.pid")
+/usr/bin/setsid --fork "$HOME/attack" >/dev/null 2>&1
+for _ in {1..200}; do
+  detached_pid=$(/usr/bin/cat "$HOME/attack-${TEST_ATTACK_LABEL:-generic}.pid" 2>/dev/null || true)
+  [[ $detached_pid != "$first_pid" && $detached_pid =~ ^[1-9][0-9]*$ ]] && break
+  /usr/bin/sleep 0.005
+done
+[[ ${detached_pid:-} != "$first_pid" && ${detached_pid:-} =~ ^[1-9][0-9]*$ ]] || exit 85
+if [[ ${TEST_OPAM_BLOCK:-0} == 1 ]]; then
+  printf 'ready\n' >"$TEST_READY"
+  trap 'exit 143' TERM
+  while :; do /usr/bin/sleep 0.05; done
+fi
+[[ ${TEST_OPAM_FAIL:-0} != 1 ]] || exit 84
+STUB
+chown 1000:1000 "$test_home/hostile-bin/opam"
+chmod 0755 "$test_home/hostile-bin/opam"
+
+reset_case remove-ocaml
+touch "$token"; chown 0:0 "$token"
+run_user env TEST_ATTACK_LABEL=remove-ocaml TEST_PROTECTED_TARGET="$protected_dir/remove-ocaml" \
+  bash "$ROOT/bin/omarchy-remove-dev-env" ocaml
+assert_cold remove-ocaml
+grep -Fxq 'REMOVE-OPAM:0' "$event_log" || fail "OCaml removal did not complete its fixed root cleanup"
+! grep -q '^SUDO:publish-token$' "$event_log" || fail "OCaml removal published a reusable token"
+pass "user-owned opam cannot reuse the final OCaml cleanup authorization"
+
+reset_case remove-ocaml-unsupported
+if run_user env TEST_ATTACK_LABEL=remove-ocaml-unsupported \
+    TEST_PROTECTED_TARGET="$protected_dir/remove-ocaml-unsupported" TEST_SUDO_NO_N=1 \
+    bash "$ROOT/bin/omarchy-remove-dev-env" ocaml; then
+  fail "OCaml removal accepted unsupported sudo"
+fi
+! grep -q '^ATTACK:' "$event_log" || fail "unsupported sudo reached user-owned opam"
+pass "OCaml removal validates no-update before user code"
+
+reset_case remove-ocaml-fail
+if run_user env TEST_ATTACK_LABEL=remove-ocaml-fail TEST_PROTECTED_TARGET="$protected_dir/remove-ocaml-fail" \
+    TEST_RM_FAIL=1 bash "$ROOT/bin/omarchy-remove-dev-env" ocaml; then
+  fail "OCaml removal ignored fixed root cleanup failure"
+fi
+assert_cold remove-ocaml-fail
+
+reset_case remove-ocaml-signal
+touch "$token"; chown 0:0 "$token"
+ready=$test_home/ready
+set +e
+start_user_session /usr/bin/setsid bash -c \
+  'exec env TEST_ATTACK_LABEL=remove-ocaml-signal TEST_PROTECTED_TARGET="$1" TEST_OPAM_BLOCK=1 TEST_READY="$2" bash "$3" ocaml' \
+  remove-ocaml-signal "$protected_dir/remove-ocaml-signal" "$ready" "$ROOT/bin/omarchy-remove-dev-env"
+set -e
+for _ in {1..200}; do [[ -e $ready ]] && break; sleep 0.005; done
+[[ -e $ready ]] || fail "OCaml removal signal fixture did not become ready"
+kill -TERM -- "-$session" 2>/dev/null || kill -TERM "$session"
+set +e; wait "$session"; signal_status=$?; set -e
+active_session=""
+(( signal_status != 0 )) || fail "OCaml removal TERM unexpectedly succeeded"
+[[ ! -e $token ]] || fail "OCaml removal TERM left sudo live"
+[[ ! -e $protected_dir/remove-ocaml-signal ]] || fail "OCaml signal child reused root"
+pass "OCaml removal failure and signal paths invalidate credentials"
+
+# OM-SEC-22 ends after every OCaml removal outcome has revoked authorization.
+# Other generic AUR callers are covered by their own finding-specific PRs.
+exit 0
+
+# Current generic callers with later privileged phases must retain a no-update
+# boundary. Migrations already run under their package-owned no-update wrapper.
+grep -qF 'browser_policy_sudo_args=(-N)' "$ROOT/bin/omarchy-install-browser" ||
+  fail "AUR browser policy setup can authenticate with reusable sudo"
+grep -qF 'enable_non_reusable_sudo' "$ROOT/bin/omarchy-migrate" ||
+  fail "AUR migration caller lost its no-update wrapper"
+! rg -q 'source[[:space:]]+omarchy-sudo-keepalive' "$ROOT/bin" ||
+  fail "a package picker still sources the reusable sudo keepalive"
+pass "generic AUR callers do not publish later reusable credentials"
+
+reset_case legacy-keepalive
+run_user env TEST_ATTACK_LABEL=legacy-keepalive TEST_PROTECTED_TARGET="$protected_dir/legacy-keepalive" \
+  bash "$ROOT/bin/omarchy-sudo-keepalive" >/dev/null 2>&1
+[[ ! -e $token ]] || fail "legacy keepalive command retained a reusable token"
+pass "legacy keepalive command is non-reusable"


### PR DESCRIPTION
## Summary

User-controlled `opam` code ran before a later privileged cleanup and could wait to reuse that authorization.

Finding: **OM-SEC-22**

## Security impact

User-controlled opam code can wait for cleanup authentication and use it to execute arbitrary commands as root.

## Remediation

The workflow validates no-update support, starts cold, runs opam without reusable authority, and performs the exact root cleanup through `sudo -N` with final invalidation.

The reviewed implementation applies these concrete controls:

- The command validates --no-update support and starts cold.
- User-owned opam runs without a reusable credential.
- The final fixed root removal uses sudo --no-update.
- EXIT and signal paths invalidate credentials.

## Validation

The baseline detached-opam exploit succeeded; success, unsupported-sudo, cleanup-failure, polling, and signal tests pass.

**Detailed regression coverage:** aur-package-sudo-security-test.sh covers success, unsupported sudo, root-cleanup failure, detached polling, and TERM.

Current status: Fixed.

All changed shell files on this branch pass `bash -n`, and `git diff --check` passes.

## Coordination

This is one finding in a coordinated 21-finding disclosure sent to the Omarchy security team. The corresponding Markdown report contains the affected-code analysis and safe reproduction.

Carries the package-helper foundation needed by the shared regression; the finding-specific change is the OCaml removal boundary.

