### PR TITLE
Route Chromium notifications through the system center

### DIFF
--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -1,5 +1,5 @@
 --ozone-platform=wayland
 --ozone-platform-hint=wayland
 --password-store=gnome-libsecret
---enable-features=TouchpadOverscrollHistoryNavigation
+--enable-features=TouchpadOverscrollHistoryNavigation,SystemNotifications
 --load-extension=/usr/share/omarchy/default/chromium/extensions/copy-url,/usr/share/omarchy/default/chromium/extensions/yt-dlp,/usr/share/omarchy/default/chromium/extensions/whatsapp-slim

--- a/migrations/1788129995.sh
+++ b/migrations/1788129995.sh
@@ -1,0 +1,21 @@
+echo "Route Chromium browser notifications through the system notification center"
+
+flag_files=(
+  "$HOME/.config/chromium-flags.conf"
+  "$HOME/.config/chrome-flags.conf"
+  "$HOME/.config/microsoft-edge-stable-flags.conf"
+  "$HOME/.config/brave-flags.conf"
+  "$HOME/.config/brave-origin-flags.conf"
+)
+
+for flag_file in "${flag_files[@]}"; do
+  [[ -f $flag_file ]] || continue
+  grep -Eq '^--disable-features=([^,]*,)*SystemNotifications([,<]|$)' "$flag_file" && continue
+  grep -Eq '^--enable-features=([^,]*,)*SystemNotifications([,<]|$)' "$flag_file" && continue
+
+  if grep -q '^--enable-features=' "$flag_file"; then
+    sed -i '0,/^--enable-features=/{/^--enable-features=/s/$/,SystemNotifications/;}' "$flag_file"
+  else
+    printf '%s\n' '--enable-features=SystemNotifications' >>"$flag_file"
+  fi
+done

--- a/test/shell.d/chromium-system-notifications-migration-test.sh
+++ b/test/shell.d/chromium-system-notifications-migration-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1788129995.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+config_dir="$home/.config"
+mkdir -p "$config_dir"
+
+run_migration() {
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+printf '%s\n' \
+  '--ozone-platform=wayland' \
+  '--ozone-platform-hint=wayland' \
+  '--password-store=gnome-libsecret' \
+  '--enable-features=TouchpadOverscrollHistoryNavigation' \
+  '--load-extension=/one,/two' >"$config_dir/chromium-flags.conf"
+printf '%s\n' '--ozone-platform=wayland' >"$config_dir/brave-flags.conf"
+printf '%s\n' '--enable-features=ExistingFeature' >"$config_dir/brave-origin-flags.conf"
+printf '%s\n' '--disable-features=SystemNotifications' >"$config_dir/chrome-flags.conf"
+
+run_migration
+
+grep -Fxq -- '--enable-features=TouchpadOverscrollHistoryNavigation,SystemNotifications' "$config_dir/chromium-flags.conf" ||
+  fail "migration adds system notifications to Chromium's existing feature list"
+grep -Fxq -- '--ozone-platform=wayland' "$config_dir/chromium-flags.conf" ||
+  fail "migration leaves flags before Chromium's feature list unchanged"
+grep -Fxq -- '--load-extension=/one,/two' "$config_dir/chromium-flags.conf" ||
+  fail "migration leaves flags after Chromium's feature list unchanged"
+[[ $(grep -o 'SystemNotifications' "$config_dir/chromium-flags.conf" | wc -l) -eq 1 ]] ||
+  fail "migration changes only Chromium's feature list"
+grep -Fxq -- '--enable-features=SystemNotifications' "$config_dir/brave-flags.conf" ||
+  fail "migration adds a feature list when Brave does not have one"
+grep -Fxq -- '--enable-features=ExistingFeature,SystemNotifications' "$config_dir/brave-origin-flags.conf" ||
+  fail "migration preserves custom Brave Origin features"
+[[ $(<"$config_dir/chrome-flags.conf") == '--disable-features=SystemNotifications' ]] ||
+  fail "migration preserves an explicit system-notification opt-out"
+pass "migration enables system notifications without discarding browser flag choices"
+
+run_migration
+
+[[ $(grep -o 'SystemNotifications' "$config_dir/chromium-flags.conf" | wc -l) -eq 1 ]] ||
+  fail "migration is idempotent for an existing feature list"
+[[ $(grep -o 'SystemNotifications' "$config_dir/brave-flags.conf" | wc -l) -eq 1 ]] ||
+  fail "migration is idempotent for an added feature list"
+pass "migration does not duplicate the system notification feature"


### PR DESCRIPTION
## Summary

- Enable Chromium's `SystemNotifications` feature in the shared browser flags so
  Chromium- family notifications use Omarchy's freedesktop notification service
  instead of opening a browser-owned tiled window.
- Migrate existing Chromium, Chrome, Edge, Brave, and Brave Origin flag files.
- Preserve custom enabled features and explicit `SystemNotifications` opt-outs.
- Add regression coverage for migration safety and idempotence.

## Verification

- `bash test/shell.d/chromium-system-notifications-migration-test.sh`
- `bash test/shell.d/default-apps-test.sh`
- `bash -n migrations/1788129995.sh test/shell.d/chromium-system-notifications-migration-
test.sh`
- `git diff --check`

## Diagnosis

In a running Quattro session, Quickshell owned `org.freedesktop.Notifications`,
but Chromium and Brave were started without Chromium's `SystemNotifications`
feature. Browser notifications consequently used Chromium's fallback
message-center window, which Hyprland tiled as a normal rowser window.

Explicitly enabling `SystemNotifications` routes these notifications through
Omarchy's existing notification center.

---
🤖 Built with [OpenAI Codex](https://developers.openai.com/codex/).
