### PR TITLE
Keep launched apps on the workspace they started from

### DIFF
--- a/bin/omarchy-launch-on-workspace
+++ b/bin/omarchy-launch-on-workspace
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# omarchy:summary=Launch a command pinned to the currently active workspace
+# omarchy:hidden=true
+# omarchy:args=<command>
+
+set -euo pipefail
+
+if (($# == 0)); then
+  echo "Usage: omarchy-launch-on-workspace <command>" >&2
+  exit 1
+fi
+
+command=$1
+workspace=$(hyprctl activeworkspace -j 2>/dev/null | jq --raw-output '.id // empty')
+lua_command=$(jq -Rnr --arg value "$command" '$value | @json')
+
+# Pin at exec time so a slow app still maps on this workspace if you switch
+# away before its window appears. Global initial_workspace_tracking stays off
+# so portal file dialogs keep following the app that requested them.
+if [[ $workspace =~ ^[0-9]+$ ]] && hyprctl dispatch "hl.dsp.exec_cmd($lua_command, { workspace = \"$workspace silent\" })" >/dev/null 2>&1; then
+  :
+else
+  eval exec "$command"
+fi

--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -53,28 +53,32 @@ function o.cmd_missing(command)
   return not o.cmd_present(command)
 end
 
+local function spawn(command)
+  return "omarchy-launch-on-workspace " .. shell_quote(command)
+end
+
 local function command_from(value, description)
   if type(value) ~= "table" then
     return value
   end
 
   if value.omarchy then
-    return "omarchy-launch-" .. value.omarchy
+    return spawn("omarchy-launch-" .. value.omarchy)
   elseif value.focus and value.launch then
-    return o.launch_sole(value.focus, value.launch)
+    return spawn(o.launch_sole(value.focus, value.launch))
   elseif value.launch then
-    return o.launch(value.launch)
+    return spawn(o.launch(value.launch))
   elseif value.webapp then
     if value.focus then
-      return o.launch_webapp_sole(description, value.webapp)
+      return spawn(o.launch_webapp_sole(description, value.webapp))
     else
-      return o.launch_webapp(value.webapp)
+      return spawn(o.launch_webapp(value.webapp))
     end
   elseif value.tui then
     if value.focus then
-      return "omarchy-launch-or-focus-tui " .. shell_quote(value.tui)
+      return spawn("omarchy-launch-or-focus-tui " .. shell_quote(value.tui))
     else
-      return "omarchy-launch-tui " .. shell_quote(value.tui)
+      return spawn("omarchy-launch-tui " .. shell_quote(value.tui))
     end
   end
 

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -82,7 +82,10 @@ Item {
     // inherit wayland-wm@.service. Keeping gtk-launch as the desktop-entry
     // resolver supports IDs with spaces and entries that UWSM rejects.
     // Keep the .desktop suffix or ids like org.telegram.desktop won't resolve.
-    Util.execDetached("uwsm-app -- gtk-launch " + Util.shellQuote(id + ".desktop"))
+    // Pin to the workspace active at click time so a slow app (a game, a
+    // browser) still maps there if you switch away before the window appears.
+    var command = "uwsm-app -- gtk-launch " + Util.shellQuote(id + ".desktop")
+    Util.execDetached("omarchy-launch-on-workspace " + Util.shellQuote(command))
   }
 
   function remove(desktopId, name) {

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -99,9 +99,10 @@ assert(
 )
 
 assert(
-  /function launch\(desktopId, name\) \{[\s\S]*?uwsm-app[\s\S]*?\n  \}/.test(appLibraryQml) &&
-    appLibraryQml.includes('Util.execDetached("uwsm-app -- gtk-launch "'),
-  'app library launches desktop entries through gtk-launch in their own scope'
+  /function launch\(desktopId, name\) \{[\s\S]*?omarchy-launch-on-workspace[\s\S]*?\n  \}/.test(appLibraryQml) &&
+    appLibraryQml.includes('uwsm-app -- gtk-launch ') &&
+    appLibraryQml.includes('Util.execDetached("omarchy-launch-on-workspace "'),
+  'app library launches desktop entries through gtk-launch pinned to the current workspace'
 )
 
 assert(

--- a/test/shell.d/launch-on-workspace-test.sh
+++ b/test/shell.d/launch-on-workspace-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+grep -F 'return "omarchy-launch-on-workspace " .. shell_quote(command)' "$ROOT/default/hypr/helpers.lua" >/dev/null ||
+  fail "keybind app launches pin the workspace they were started from"
+pass "keybind app launches pin the workspace they were started from"
+
+grep -F 'initial_workspace_tracking = 0' "$ROOT/default/hypr/looknfeel.lua" >/dev/null ||
+  fail "global workspace tracking stays off so portal dialogs follow the requesting app"
+pass "global workspace tracking stays off so portal dialogs follow the requesting app"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ ${1:-} == "activeworkspace" && ${2:-} == "-j" ]]; then
+  if [[ -n ${OMARCHY_TEST_WORKSPACE_JSON:-} ]]; then
+    printf '%s\n' "$OMARCHY_TEST_WORKSPACE_JSON"
+  else
+    printf '%s\n' '{"id":3,"name":"3"}'
+  fi
+  exit 0
+fi
+
+if [[ ${1:-} == "dispatch" && ${2:-} == hl.dsp.exec_cmd* ]]; then
+  printf '%s\n' "${2:-}" >>"$OMARCHY_TEST_DISPATCH_LOG"
+  if [[ ${OMARCHY_TEST_DISPATCH_STATUS:-0} != 0 ]]; then
+    exit "$OMARCHY_TEST_DISPATCH_STATUS"
+  fi
+  printf 'ok\n'
+  exit 0
+fi
+
+exit 1
+SH
+
+chmod +x "$mock_bin/hyprctl"
+
+export PATH="$mock_bin:$PATH"
+export OMARCHY_TEST_DISPATCH_LOG="$test_tmp/dispatch.log"
+
+: >"$OMARCHY_TEST_DISPATCH_LOG"
+"$ROOT/bin/omarchy-launch-on-workspace" "uwsm-app -- gtk-launch 'steam.desktop'"
+grep -Fqx 'hl.dsp.exec_cmd("uwsm-app -- gtk-launch '\''steam.desktop'\''", { workspace = "3 silent" })' "$OMARCHY_TEST_DISPATCH_LOG" ||
+  fail "helper dispatches the command onto the active workspace" "$(<"$OMARCHY_TEST_DISPATCH_LOG")"
+pass "helper dispatches the command onto the active workspace"
+
+: >"$OMARCHY_TEST_DISPATCH_LOG"
+OMARCHY_TEST_WORKSPACE_JSON='{}' "$ROOT/bin/omarchy-launch-on-workspace" "echo launched" >"$test_tmp/fallback.out"
+[[ $(<"$test_tmp/fallback.out") == launched ]] ||
+  fail "helper runs the command directly when no workspace id is available" "$(<"$test_tmp/fallback.out")"
+[[ ! -s $OMARCHY_TEST_DISPATCH_LOG ]] ||
+  fail "helper does not dispatch when no workspace id is available"
+pass "helper runs the command directly when no workspace id is available"


### PR DESCRIPTION
## What

Pin user-initiated app launches to the workspace that was active when the launch started, so a slow app (a game, a browser) still maps there if you switch away before its window appears.

## Why

Omarchy sets `misc.initial_workspace_tracking = 0` so xdg-desktop-portal-gtk file dialogs follow the app that requested them (#6317). The documented trade-off is this bug: launch on workspace N, switch to M while it starts, window opens on M.

This keeps tracking off and stamps the workspace only on launcher/keybind execs via `omarchy-launch-on-workspace`, using Hyprland's Lua `exec_cmd` with `workspace = "N silent"`.

Related: https://github.com/omacom/omarchy/discussions/3165

## Testing

- `test/shell.d/launch-on-workspace-test.sh` and `test/shell.d/app-search-test.sh`
- Live: delayed `xdg-terminal-exec` launched on workspace 2, switched to 1 during the delay, window mapped on 2