### PR TITLE
Only point the session at NVIDIA when NVIDIA is driving the screen

### DIFF
--- a/bin/omarchy-hw-nvidia-drives-display
+++ b/bin/omarchy-hw-nvidia-drives-display
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether an NVIDIA GPU is driving the screen the session renders on, rather than merely being present.
+
+# Read sysfs rather than shelling out to lspci or nvidia-smi, both of which
+# resume a runtime-suspended GPU. A connector's status file is served from the
+# driver's cached state, so asking does not power the card up.
+drm_class_path="${OMARCHY_DRM_CLASS_PATH:-/sys/class/drm}"
+
+shopt -s nullglob
+
+nvidia_connected=0
+foreign_panel=0
+
+for card in "$drm_class_path"/card[0-9]*; do
+  [[ ${card##*/} == *-* ]] && continue
+  [[ -r $card/device/vendor ]] || continue
+
+  vendor=$(<"$card/device/vendor")
+
+  for connector in "$card"-*; do
+    [[ -r $connector/status ]] || continue
+    [[ $(<"$connector/status") == "connected" ]] || continue
+
+    if [[ $vendor == "0x10de" ]]; then
+      nvidia_connected=1
+      continue
+    fi
+
+    # A built-in panel on another card means the compositor is rendering there,
+    # and these variables are session-wide. On a laptop whose external ports are
+    # wired to the discrete card, docking lights up an NVIDIA connector without
+    # moving the rendering off the integrated GPU.
+    name=${connector##*/}
+    case ${name#card*-} in
+      eDP* | LVDS* | DSI*) foreign_panel=1 ;;
+    esac
+  done
+done
+
+((nvidia_connected && !foreign_panel))

--- a/default/hypr/nvidia.lua
+++ b/default/hypr/nvidia.lua
@@ -3,11 +3,18 @@ local paths = require("default.hypr.paths")
 local nvidia = paths.omarchy_path .. "/bin/omarchy-hw-nvidia"
 local nvidia_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-gsp"
 local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without-gsp"
+local nvidia_drives_display = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-drives-display"
 
 -- These detectors read cached sysfs IDs rather than shelling out to lspci.
 -- lspci reads PCI config space, which resumes a runtime-suspended GPU, and on a
 -- hybrid laptop that wake alone outlasts Hyprland's 1.5s config reload budget.
-if o.shell_succeeds(o.shell_quote(nvidia)) then
+--
+-- Naming NVIDIA here points every GL and VA-API client in the session at that
+-- card, so it has to be the card actually driving the screen. On a hybrid laptop
+-- the panel hangs off the integrated GPU while the discrete card sits in runtime
+-- suspend, and setting these there means the first GL application to start wakes
+-- it and holds it awake. Having an NVIDIA GPU is not the same as rendering on it.
+if o.shell_succeeds(o.shell_quote(nvidia)) and o.shell_succeeds(o.shell_quote(nvidia_drives_display)) then
   if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
     hl.env("NVD_BACKEND", "direct")
     hl.env("LIBVA_DRIVER_NAME", "nvidia")

--- a/test/shell.d/hw-nvidia-test.sh
+++ b/test/shell.d/hw-nvidia-test.sh
@@ -97,3 +97,96 @@ assert_detects "a non-display NVIDIA function is not a GPU" no no no
 
 write_pci_devices
 assert_detects "a machine with no PCI devices detects nothing" no no no
+
+# Whether an NVIDIA card is present and whether it is driving a screen are
+# different questions. On a hybrid laptop the panel hangs off the integrated GPU
+# and the discrete card sits in runtime suspend, and naming NVIDIA in the session
+# environment there wakes it for every GL client.
+#
+# Connector status is read from the driver's cached state, so the detector can
+# ask without powering the card up. That is the whole point of it.
+write_drm_cards() {
+  rm -rf "$tmp_dir/drm"
+  mkdir -p "$tmp_dir/drm"
+
+  local spec card vendor connector status
+  for spec in "$@"; do
+    IFS='|' read -r card vendor connector status <<<"$spec"
+    mkdir -p "$tmp_dir/drm/$card/device"
+    printf '%s\n' "$vendor" >"$tmp_dir/drm/$card/device/vendor"
+    if [[ -n $connector ]]; then
+      mkdir -p "$tmp_dir/drm/$card-$connector"
+      printf '%s\n' "$status" >"$tmp_dir/drm/$card-$connector/status"
+    fi
+  done
+}
+
+drives_display() {
+  OMARCHY_DRM_CLASS_PATH="$tmp_dir/drm" "$ROOT/bin/omarchy-hw-nvidia-drives-display"
+}
+
+# A hybrid laptop: the panel is on the Intel card, the NVIDIA card has an unused
+# output. This is the case that was setting the variables.
+write_drm_cards 'card0|0x10de|HDMI-A-1|disconnected' 'card1|0x8086|eDP-1|connected'
+if drives_display; then
+  fail "an NVIDIA card with no connected output is not driving the display"
+fi
+pass "an idle discrete NVIDIA card does not count as driving the display"
+
+# Docking that laptop lights up an NVIDIA connector, but the panel is still on
+# the Intel card and the compositor still renders there. hl.env is session-wide,
+# so naming NVIDIA would charge the internal display for the external one.
+write_drm_cards 'card0|0x10de|HDMI-A-1|connected' 'card1|0x8086|eDP-1|connected'
+if drives_display; then
+  fail "a built-in panel on another card keeps the session off NVIDIA"
+fi
+pass "docking a hybrid laptop does not move the session onto NVIDIA"
+
+# A laptop whose panel is wired to the NVIDIA card has nowhere else to render.
+write_drm_cards 'card0|0x10de|eDP-1|connected' 'card1|0x8086||'
+drives_display || fail "a panel on the NVIDIA card is driven by NVIDIA"
+pass "a panel on the NVIDIA card still names NVIDIA"
+
+# A desktop: an integrated card is present but drives nothing, and the monitor
+# hangs off NVIDIA. No built-in panel is involved, so nothing changes here.
+write_drm_cards 'card0|0x10de|DP-1|connected' 'card1|0x8086|DP-1|disconnected'
+drives_display || fail "an idle integrated card does not keep the session off NVIDIA"
+pass "a desktop with an unused integrated card still names NVIDIA"
+
+write_drm_cards 'card0|0x10de|DP-1|connected' 'card1|0x8086|DP-2|connected'
+drives_display || fail "a monitor on the integrated card is not a built-in panel"
+pass "a desktop driving monitors from both cards still names NVIDIA"
+
+write_drm_cards 'card0|0x10de|DP-1|connected'
+drives_display || fail "a single NVIDIA card with a connected output is driving the display"
+pass "an NVIDIA-only machine still names NVIDIA"
+
+# No NVIDIA at all, and an NVIDIA card carrying no connectors whatsoever.
+write_drm_cards 'card0|0x8086|eDP-1|connected'
+if drives_display; then
+  fail "a machine without an NVIDIA card is not driving a display with one"
+fi
+pass "a machine with no NVIDIA card answers no"
+
+write_drm_cards 'card0|0x10de||'
+if drives_display; then
+  fail "an NVIDIA card with no connectors is not driving a display"
+fi
+pass "an NVIDIA card with no connectors answers no"
+
+# Telling a card from a connector is a name comparison, so a dash further up the
+# path must not hide every card from it.
+mkdir -p "$tmp_dir/drm-alt/card0/device" "$tmp_dir/drm-alt/card0-DP-1"
+printf '0x10de\n' >"$tmp_dir/drm-alt/card0/device/vendor"
+printf 'connected\n' >"$tmp_dir/drm-alt/card0-DP-1/status"
+OMARCHY_DRM_CLASS_PATH="$tmp_dir/drm-alt" "$ROOT/bin/omarchy-hw-nvidia-drives-display" ||
+  fail "a dash in the sysfs path does not hide the card"
+pass "the detector reads cards from a path containing a dash"
+
+# The gate itself: nvidia.lua must require both answers before it names NVIDIA
+# for the whole session.
+grep -q 'omarchy-hw-nvidia-drives-display' "$ROOT/default/hypr/nvidia.lua" ||
+  fail "nvidia.lua asks whether NVIDIA drives the display"
+grep -qE 'shell_succeeds\(o\.shell_quote\(nvidia\)\) and o\.shell_succeeds\(o\.shell_quote\(nvidia_drives_display\)\)' "$ROOT/default/hypr/nvidia.lua" ||
+  fail "nvidia.lua requires both a present NVIDIA card and one driving the display"
+pass "nvidia.lua only names NVIDIA when NVIDIA drives the display"


### PR DESCRIPTION
`nvidia.lua` sets `NVD_BACKEND`, `LIBVA_DRIVER_NAME`, and `__GLX_VENDOR_LIBRARY_NAME` whenever the machine has an NVIDIA GPU. On a hybrid laptop whose display is driven by the integrated GPU, those session-wide variables still send GL and VA-API clients to the discrete card. The first client has to wake it, and it stays powered while in use.

`nvidia.lua` now also checks `omarchy-hw-nvidia-drives-display`. The new detector answers yes when an NVIDIA connector reports `connected` and no built-in panel (`eDP`, `LVDS` or `DSI`) on another card does. A panel on another card means the compositor renders there, and `hl.env` is session-wide, so docking a laptop whose external ports are wired to the discrete card does not name NVIDIA. An NVIDIA-only machine, a laptop with its panel on the NVIDIA card, and a desktop with a monitor on NVIDIA still get the variables. It reads the driver's cached connector state; the measured check took 3 ms and left the suspended card asleep. PRIME offload remains available when the integrated GPU is driving the display.

The comparison used an Arrow Lake iGPU driving `eDP-1` and an RTX 5070 Ti Mobile with no connected output. With the variables explicitly removed using `env -u`, `glxinfo -B` reported the Intel renderer; with them set, it reported NVIDIA. Cold runs waited for the discrete card to return to suspend between measurements:

```
                        run 1     run 2    card afterwards
without the variables    75 ms     85 ms   suspended
with the variables     2675 ms   2733 ms   active
```

With the card already awake, the same comparison was 80 ms versus 153 ms.

Ten new assertions in `hw-nvidia-test.sh` cover an idle discrete card, the docked hybrid laptop, a panel on the NVIDIA card, desktops with an unused integrated card and with monitors on both cards, an NVIDIA-only machine, absent and connector-less NVIDIA cards, a DRM path containing a dash, and the requirement for both detectors in `nvidia.lua`. They fail on the baseline, which has no display-driving detector. The docked case was confirmed on live hardware in the thread below (Dell G15 5515, both external outputs on NVIDIA, panel on AMD).

`./test/shell` passed 217 of 221 files. The four failures (`config-test`, `runtime-smoke-test`, `snapper-test`, and `unowned-system-paths-test`) also failed on unmodified `quattro`.

This is independent of #9482, which changes `omarchy-hw-hybrid-gpu`; the two have no files in common.

