### PR TITLE
Stop omarchy-restart-terminal silently no-opping for foot

### DIFF
--- a/bin/omarchy-restart-terminal
+++ b/bin/omarchy-restart-terminal
@@ -13,3 +13,10 @@ fi
 if pgrep -x ghostty >/dev/null; then
   killall -SIGUSR2 ghostty
 fi
+
+# foot has no runtime config-reload mechanism, so a running instance keeps its
+# stale config no matter what this script does. Say so instead of silently
+# doing nothing for it.
+if pgrep -x foot >/dev/null; then
+  echo "foot has no config-reload mechanism; restart open foot windows to pick up changes." >&2
+fi

--- a/bin/omarchy-restart-terminal
+++ b/bin/omarchy-restart-terminal
@@ -14,9 +14,13 @@ if pgrep -x ghostty >/dev/null; then
   killall -SIGUSR2 ghostty
 fi
 
-# foot has no runtime config-reload mechanism, so a running instance keeps its
-# stale config no matter what this script does. Say so instead of silently
-# doing nothing for it.
-if pgrep -x foot >/dev/null; then
-  echo "foot has no config-reload mechanism; restart open foot windows to pick up changes." >&2
+# foot has no runtime config-reload mechanism, so a running instance keeps
+# reading foot.ini's font/padding/alpha/etc. from whenever it started no
+# matter what this script does. Say so instead of silently doing nothing --
+# but only when the user asked directly: a theme switch only ever touches
+# colors, which omarchy-theme-set-foot already applies live over OSC, so
+# foot needs no restart on that path and the warning would be noise fired
+# on every theme change.
+if [[ -z ${OMARCHY_THEME_SWITCHING:-} ]] && pgrep -x foot >/dev/null; then
+  echo "foot cannot reload foot.ini (font, padding, alpha, ...) at runtime; restart open foot windows to pick up those changes." >&2
 fi

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -333,6 +333,10 @@ post_theme_commands=(
 )
 
 if [[ $THEME_HEADLESS != "1" ]]; then
+  # Tell post-theme commands they are running as part of a theme switch, not
+  # a direct user request, so ones like omarchy-restart-terminal can skip
+  # warnings that only make sense when the user asked for a reload themselves.
+  export OMARCHY_THEME_SWITCHING=1
   run_parallel "${post_theme_commands[@]}"
 
   # Call hook on theme set

--- a/test/shell.d/restart-terminal-test.sh
+++ b/test/shell.d/restart-terminal-test.sh
@@ -73,6 +73,16 @@ pass "a running ghostty is sent SIGUSR2 to reload"
 OMARCHY_TEST_KITTY_RUNNING=0 OMARCHY_TEST_GHOSTTY_RUNNING=0 OMARCHY_TEST_FOOT_RUNNING=1 \
   run_restart_terminal >/dev/null 2>"$test_tmp/err.log" || fail "a running foot does not fail the script"
 [[ ! -s $test_tmp/killall.log ]] || fail "foot is never sent a signal, since it has none to reload with" "$(<"$test_tmp/killall.log")"
-grep -qF "foot has no config-reload mechanism" "$test_tmp/err.log" ||
-  fail "a running foot gets an explicit no-reload message instead of a silent no-op" "$(<"$test_tmp/err.log")"
-pass "a running foot gets an explicit no-reload message instead of a silent no-op"
+grep -qF "foot cannot reload foot.ini" "$test_tmp/err.log" ||
+  fail "a directly-invoked restart on a running foot gets an explicit no-reload message instead of a silent no-op" "$(<"$test_tmp/err.log")"
+pass "a directly-invoked restart on a running foot gets an explicit no-reload message instead of a silent no-op"
+
+# A theme switch only ever changes colors, which omarchy-theme-set-foot
+# already applies live over OSC -- foot needs no restart for that, so
+# omarchy-theme-set marks the run and the warning should stay quiet.
+: >"$test_tmp/killall.log"
+OMARCHY_THEME_SWITCHING=1 OMARCHY_TEST_KITTY_RUNNING=0 OMARCHY_TEST_GHOSTTY_RUNNING=0 OMARCHY_TEST_FOOT_RUNNING=1 \
+  run_restart_terminal >/dev/null 2>"$test_tmp/err.log" || fail "a running foot does not fail the script during a theme switch"
+[[ ! -s $test_tmp/err.log ]] ||
+  fail "the foot warning is skipped during a theme switch, since colors already updated live" "$(<"$test_tmp/err.log")"
+pass "the foot warning is skipped during a theme switch, since colors already updated live"

--- a/test/shell.d/restart-terminal-test.sh
+++ b/test/shell.d/restart-terminal-test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# pgrep/killall act on real system processes, so shadow them with stubs
+# controlled entirely by env vars instead of depending on which terminal
+# emulators happen to be running on the machine the suite executes on.
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/pgrep" <<'SH'
+#!/bin/bash
+case "$2" in
+  kitty) [[ ${OMARCHY_TEST_KITTY_RUNNING:-0} == 1 ]] ;;
+  ghostty) [[ ${OMARCHY_TEST_GHOSTTY_RUNNING:-0} == 1 ]] ;;
+  foot) [[ ${OMARCHY_TEST_FOOT_RUNNING:-0} == 1 ]] ;;
+  *) exit 1 ;;
+esac
+SH
+
+cat >"$stub_bin/killall" <<SH
+#!/bin/bash
+printf '%s\n' "\$*" >>"$test_tmp/killall.log"
+SH
+
+chmod +x "$stub_bin/pgrep" "$stub_bin/killall"
+
+home="$test_tmp/home"
+alacritty_toml="$home/.config/alacritty/alacritty.toml"
+mkdir -p "$(dirname "$alacritty_toml")"
+printf 'stale\n' >"$alacritty_toml"
+touch -d "1 hour ago" "$alacritty_toml"
+
+run_restart_terminal() {
+  PATH="$stub_bin:$PATH" HOME="$home" "$ROOT/bin/omarchy-restart-terminal"
+}
+
+: >"$test_tmp/killall.log"
+OMARCHY_TEST_KITTY_RUNNING=0 OMARCHY_TEST_GHOSTTY_RUNNING=0 OMARCHY_TEST_FOOT_RUNNING=0 \
+  run_restart_terminal >"$test_tmp/out.log" 2>"$test_tmp/err.log" || fail "no running emulators: exits cleanly"
+
+[[ $(stat -c %Y "$alacritty_toml") -gt $(date -d '1 hour ago' +%s) ]] ||
+  fail "an existing alacritty.toml is touched to trigger its live-reload watch"
+pass "an existing alacritty.toml is touched to trigger its live-reload watch"
+
+[[ ! -s $test_tmp/killall.log ]] || fail "no killall calls when kitty/ghostty are not running" "$(<"$test_tmp/killall.log")"
+[[ ! -s $test_tmp/err.log ]] || fail "no foot message when foot is not running" "$(<"$test_tmp/err.log")"
+pass "nothing runs for terminals that are not open"
+
+rm -f "$alacritty_toml"
+OMARCHY_TEST_KITTY_RUNNING=0 OMARCHY_TEST_GHOSTTY_RUNNING=0 OMARCHY_TEST_FOOT_RUNNING=0 \
+  run_restart_terminal >/dev/null 2>&1 || fail "a missing alacritty.toml does not fail the script"
+pass "a missing alacritty.toml does not fail the script"
+
+: >"$test_tmp/killall.log"
+OMARCHY_TEST_KITTY_RUNNING=1 OMARCHY_TEST_GHOSTTY_RUNNING=0 OMARCHY_TEST_FOOT_RUNNING=0 \
+  run_restart_terminal >/dev/null 2>"$test_tmp/err.log" || fail "a running kitty does not fail the script"
+[[ $(<"$test_tmp/killall.log") == "-SIGUSR1 kitty" ]] || fail "a running kitty is sent SIGUSR1 to reload" "$(<"$test_tmp/killall.log")"
+pass "a running kitty is sent SIGUSR1 to reload"
+
+: >"$test_tmp/killall.log"
+OMARCHY_TEST_KITTY_RUNNING=0 OMARCHY_TEST_GHOSTTY_RUNNING=1 OMARCHY_TEST_FOOT_RUNNING=0 \
+  run_restart_terminal >/dev/null 2>"$test_tmp/err.log" || fail "a running ghostty does not fail the script"
+[[ $(<"$test_tmp/killall.log") == "-SIGUSR2 ghostty" ]] || fail "a running ghostty is sent SIGUSR2 to reload" "$(<"$test_tmp/killall.log")"
+pass "a running ghostty is sent SIGUSR2 to reload"
+
+: >"$test_tmp/killall.log"
+OMARCHY_TEST_KITTY_RUNNING=0 OMARCHY_TEST_GHOSTTY_RUNNING=0 OMARCHY_TEST_FOOT_RUNNING=1 \
+  run_restart_terminal >/dev/null 2>"$test_tmp/err.log" || fail "a running foot does not fail the script"
+[[ ! -s $test_tmp/killall.log ]] || fail "foot is never sent a signal, since it has none to reload with" "$(<"$test_tmp/killall.log")"
+grep -qF "foot has no config-reload mechanism" "$test_tmp/err.log" ||
+  fail "a running foot gets an explicit no-reload message instead of a silent no-op" "$(<"$test_tmp/err.log")"
+pass "a running foot gets an explicit no-reload message instead of a silent no-op"


### PR DESCRIPTION
## Summary
- `omarchy-restart-terminal` handled alacritty (touch to trigger its live-reload watch), kitty (SIGUSR1), and ghostty (SIGUSR2), but had no branch for foot at all. foot has no runtime config-reload mechanism upstream, so a running instance kept its stale `foot.ini` settings (font, padding, alpha, ...) with zero feedback that anything was wrong.
- Prints an explicit stderr message when foot is running and the restart was asked for directly, naming what foot actually can't reload (`foot.ini`'s font/padding/alpha) rather than implying it can't reload anything.
- This script also runs automatically on every theme switch via `omarchy-theme-set`, alongside `omarchy-theme-set-foot`, which already applies theme colors to running foot instances live over OSC sequences. A theme switch never touches `foot.ini` itself, so foot needs no restart on that path — `omarchy-theme-set` now marks its post-theme-command run with `OMARCHY_THEME_SWITCHING`, and the warning is skipped when that's set, so switching themes doesn't nag foot users about a reload they don't need.

Fixes #9444

## Test plan
- [x] `test/shell.d/restart-terminal-test.sh` (new): stubs `pgrep`/`killall` hermetically so it doesn't depend on which terminal emulators happen to be running on the test machine — covers alacritty touch, kitty SIGUSR1, ghostty SIGUSR2, the foot message on a direct invocation, the warning being skipped under `OMARCHY_THEME_SWITCHING`, a missing alacritty.toml, and the case where nothing is running
- [x] `./test/cli` passes
- [x] `./test/shell` shows no new failures (3 pre-existing failures on `quattro` unrelated to this change: `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`)
- [x] Verified live: spawned a real `foot` process — direct invocation prints the new message, a simulated theme-switch invocation (`OMARCHY_THEME_SWITCHING=1`) stays silent, and an actual `omarchy-theme-set` run with foot open produces no warning while the running foot window is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
