### PR TITLE
Prevent clipboard capture hangs

### DIFF
--- a/shell/plugins/clipboard/capture.sh
+++ b/shell/plugins/clipboard/capture.sh
@@ -10,7 +10,7 @@ STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
 IMAGE_DIR="$STATE_DIR/clipboard-images"
 mkdir -p "$IMAGE_DIR"
 
-types=$(wl-paste --list-types 2>/dev/null || true)
+types=$(timeout 2s wl-paste --list-types 2>/dev/null || true)
 
 if [[ ${CLIPBOARD_STATE:-} == "sensitive" ]] || grep -qx 'x-kde-passwordManagerHint' <<<"$types"; then
   exit 0
@@ -102,5 +102,5 @@ for mime in image/png image/jpeg image/webp image/gif image/bmp image/tiff; do
 done
 
 if grep -q '^text/' <<<"$types" || grep -qx 'UTF8_STRING' <<<"$types" || grep -qx 'STRING' <<<"$types"; then
-  wl-paste --type text --no-newline 2>/dev/null | emit_text
+  timeout 2s wl-paste --type text --no-newline 2>/dev/null | emit_text
 fi

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -255,8 +255,10 @@ SH
 cat >"$TMPDIR/bin/wl-paste" <<'SH'
 #!/bin/bash
 if [[ $1 == "--list-types" ]]; then
+  [[ ${WL_PASTE_STALL:-} == "list-types" ]] && sleep 10
   printf '%b' "${WL_PASTE_TYPES:-text/plain\n}"
 elif [[ $1 == "--type" && $2 == "text" ]]; then
+  [[ ${WL_PASTE_STALL:-} == "text" ]] && sleep 10
   printf '%s' "${WL_PASTE_TEXT:-terminal copy}"
 fi
 SH
@@ -291,6 +293,26 @@ pass "clipboard capture records normal text events"
 capture_output=$(printf 'closing app copy' | WL_PASTE_TEXT="stale read" XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" "$ROOT/shell/plugins/clipboard/capture.sh" text)
 [[ $capture_output == '{"type":"text","text":"closing app copy"}' ]] || fail "clipboard capture records watched text from stdin"
 pass "clipboard capture records watched text from stdin"
+
+if capture_output=$(printf 'watched copy after stalled types' | WL_PASTE_STALL="list-types" XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" timeout --preserve-status 4s "$ROOT/shell/plugins/clipboard/capture.sh" text); then
+  capture_status=0
+else
+  capture_status=$?
+fi
+[[ $capture_status -eq 0 ]] || fail "clipboard watched text survives a stalled type query" "capture exited with status $capture_status"
+[[ $capture_output == '{"type":"text","text":"watched copy after stalled types"}' ]] || fail "clipboard watched text remains intact after a stalled type query"
+pass "clipboard watched text survives a stalled type query"
+pass "clipboard watched text remains intact after a stalled type query"
+
+if capture_output=$(WL_PASTE_STALL="text" XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" timeout --preserve-status 4s "$ROOT/shell/plugins/clipboard/capture.sh"); then
+  capture_status=0
+else
+  capture_status=$?
+fi
+[[ $capture_status -eq 124 ]] || fail "clipboard snapshot text read uses its internal timeout" "capture exited with status $capture_status"
+[[ -z $capture_output ]] || fail "clipboard snapshot timeout emits no partial entry" "actual: $capture_output"
+pass "clipboard snapshot text read uses its internal timeout"
+pass "clipboard snapshot timeout emits no partial entry"
 
 capture_output=$(printf '%s' 'UTF-16 clipboard - fixed' | iconv -f UTF-8 -t UTF-16LE | XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" "$ROOT/shell/plugins/clipboard/capture.sh" text)
 [[ $capture_output == '{"type":"text","text":"UTF-16 clipboard - fixed"}' ]] || fail "clipboard capture decodes UTF-16LE text"


### PR DESCRIPTION
## Problem
- `wl-paste --watch` waits for each `capture.sh` callback to exit before processing the next clipboard event.
- `capture.sh` called `wl-paste --list-types` without a timeout on every invocation, including watched text whose payload was already available on stdin.
- If that nested read stalls when a clipboard owner disappears mid-transfer, the callback never exits and subsequent text clipboard history silently stops, while the separate image watcher can continue.
- The snapshot `wl-paste --type text` read was also unbounded.

## Summary
- Bound clipboard MIME queries and snapshot text reads to the existing two-second capture timeout.
- Added deterministic fake `wl-paste` stalls for type queries and text reads.
- Verified watched stdin remains intact and timed-out snapshots emit no entry.

## Reproduction
- Before the fix, both paths were reproduced deterministically with an isolated fake `wl-paste`; the harness used temporary HOME/XDG paths and did not touch the live clipboard.
- A controlled three-second `--list-types` stall kept watched text blocked for the full 3.024 seconds even though its payload was already available on stdin.
- A controlled three-second snapshot `--type text` stall kept capture blocked for the full 3.013 seconds.
- These results showed that callback lifetime followed the dependency stall with no internal bound. We did not reproduce the intermittent real clipboard-owner disappearance race itself.
- The added watched-text regression hit its outer watchdog before the production timeout changes and passes afterward.

## Verification
- `bash -n shell/plugins/clipboard/capture.sh test/shell.d/clipboard-test.sh` (Bubblewrap): pass
- `bash test/shell.d/clipboard-test.sh` (Bubblewrap): pass
- `git diff --check` (Bubblewrap): pass
- `./test/shell` (Bubblewrap): clipboard coverage passes; suite overall is blocked by three tests requiring an external `omarchy-pkgs` checkout, one test requiring ambient `OMARCHY_PATH`, and network auto-detection in the isolated network namespace
- `./test/all` (Bubblewrap): CLI suite passes; shell suite has the same unrelated sandbox limitations

Fixes #9443
Source issue: https://github.com/omacom/omarchy/issues/9443