### PR TITLE
Quote omarchy-launch-or-focus-tui and -webapp arguments like install-app

### DIFF
--- a/bin/omarchy-launch-or-focus-tui
+++ b/bin/omarchy-launch-or-focus-tui
@@ -9,6 +9,13 @@ else
   APP_ID="org.omarchy.$(basename "$1")"
 fi
 
-LAUNCH_COMMAND="omarchy-launch-tui $@"
+# omarchy-launch-or-focus re-parses this string with eval, so every argument
+# must be shell-quoted before being joined into it -- an unquoted argument
+# here would let its shell metacharacters (command substitution in
+# particular, since eval's leading `exec` swallows anything chained after a
+# bare `;`) execute instead of being passed through as inert data.
+QUOTED_ARGS=""
+(($# > 0)) && printf -v QUOTED_ARGS '%q ' "$@"
+LAUNCH_COMMAND="omarchy-launch-tui ${QUOTED_ARGS% }"
 
 exec omarchy-launch-or-focus "$APP_ID" "$LAUNCH_COMMAND"

--- a/bin/omarchy-launch-or-focus-webapp
+++ b/bin/omarchy-launch-or-focus-webapp
@@ -10,6 +10,13 @@ fi
 
 WINDOW_PATTERN="$1"
 shift
-LAUNCH_COMMAND="omarchy-launch-webapp $@"
+# omarchy-launch-or-focus re-parses this string with eval, so every argument
+# must be shell-quoted before being joined into it -- an unquoted argument
+# here would let its shell metacharacters (command substitution in
+# particular, since eval's leading `exec` swallows anything chained after a
+# bare `;`) execute instead of being passed through as inert data.
+QUOTED_ARGS=""
+(($# > 0)) && printf -v QUOTED_ARGS '%q ' "$@"
+LAUNCH_COMMAND="omarchy-launch-webapp ${QUOTED_ARGS% }"
 
 exec omarchy-launch-or-focus "$WINDOW_PATTERN" "$LAUNCH_COMMAND"

--- a/test/shell.d/launch-or-focus-eval-quoting-test.sh
+++ b/test/shell.d/launch-or-focus-eval-quoting-test.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# omarchy-launch-or-focus-tui and omarchy-launch-or-focus-webapp build
+# LAUNCH_COMMAND for omarchy-launch-or-focus, which re-parses it with eval.
+# Both quote their arguments with printf %q before joining, so this is
+# exercised with hyprctl and setsid stubbed: a guard that stopped working
+# shows up either as setsid receiving a mangled/split argument list, or as a
+# command-substitution payload actually running instead of being passed
+# through as inert text.
+#
+# Plain ; command chaining is not a usable check here: eval's leading exec
+# replaces the process before a later ;-joined command would run, so it
+# proves nothing either way. Command substitution runs during eval's
+# re-parse, before exec ever starts, so it is the payload that actually
+# exercises the guard.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+# No matching window, so omarchy-launch-or-focus always falls through to its
+# eval branch.
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+[[ $1 == clients ]] && { echo '[]'; exit 0; }
+exit 0
+SH
+
+# Records exactly what argv it receives instead of actually starting a
+# session leader -- this is the sink omarchy-launch-or-focus execs into.
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+printf '%s\n' "$#" >"$OMARCHY_TEST_SETSID_CALLS"
+printf '%s\n' "$@" >>"$OMARCHY_TEST_SETSID_CALLS"
+SH
+
+chmod +x "$mock_bin"/*
+
+setsid_calls="$test_tmp/setsid-calls"
+injected="$test_tmp/injected"
+
+run_tui() {
+  : >"$setsid_calls"
+  rm -f "$injected"
+  PATH="$mock_bin:$ROOT/bin:$PATH" OMARCHY_TEST_SETSID_CALLS="$setsid_calls" \
+    bash "$ROOT/bin/omarchy-launch-or-focus-tui" "$@" >"$test_tmp/out" 2>&1
+}
+
+run_webapp() {
+  : >"$setsid_calls"
+  rm -f "$injected"
+  PATH="$mock_bin:$ROOT/bin:$PATH" OMARCHY_TEST_SETSID_CALLS="$setsid_calls" \
+    bash "$ROOT/bin/omarchy-launch-or-focus-webapp" "$@" >"$test_tmp/out" 2>&1
+}
+
+# Normal arguments reach setsid split exactly as given: an argument count,
+# then one argument per line.
+run_tui --app-id=org.omarchy.about omarchy-launch-about --render
+mapfile -t got <"$setsid_calls"
+expected=(4 omarchy-launch-tui --app-id=org.omarchy.about omarchy-launch-about --render)
+[[ ${got[*]} == "${expected[*]}" ]] ||
+  fail "omarchy-launch-or-focus-tui passes normal arguments through unchanged" "$(cat "$setsid_calls")"
+
+pass "omarchy-launch-or-focus-tui passes normal arguments through unchanged"
+
+# A command substitution embedded in an argument must reach setsid as inert
+# text, not run during eval's re-parse.
+payload="\$(touch $injected)"
+run_tui "some-command" "$payload"
+[[ ! -e $injected ]] ||
+  fail "omarchy-launch-or-focus-tui does not execute a command substitution in its arguments"
+grep -qxF "$payload" "$setsid_calls" ||
+  fail "omarchy-launch-or-focus-tui passes the command substitution through as literal text" "$(cat "$setsid_calls")"
+
+pass "omarchy-launch-or-focus-tui neutralizes a command substitution in its arguments"
+
+# Same two guarantees for omarchy-launch-or-focus-webapp.
+run_webapp MyApp "https://example.com" "--user-agent=test"
+mapfile -t got <"$setsid_calls"
+expected=(3 omarchy-launch-webapp https://example.com --user-agent=test)
+[[ ${got[*]} == "${expected[*]}" ]] ||
+  fail "omarchy-launch-or-focus-webapp passes normal arguments through unchanged" "$(cat "$setsid_calls")"
+
+pass "omarchy-launch-or-focus-webapp passes normal arguments through unchanged"
+
+run_webapp MyApp "$payload"
+[[ ! -e $injected ]] ||
+  fail "omarchy-launch-or-focus-webapp does not execute a command substitution in its arguments"
+grep -qxF "$payload" "$setsid_calls" ||
+  fail "omarchy-launch-or-focus-webapp passes the command substitution through as literal text" "$(cat "$setsid_calls")"
+
+pass "omarchy-launch-or-focus-webapp neutralizes a command substitution in its arguments"


### PR DESCRIPTION
`omarchy-launch-or-focus` re-parses its second argument with `eval exec setsid $LAUNCH_COMMAND`. Two of its callers built that string by interpolating `"$@"` directly (`"cmd $@"`), with no quoting: `omarchy-launch-or-focus-tui` and `omarchy-launch-or-focus-webapp`.

Every current caller of these two scripts already passes safely-quoted values -- `helpers.lua`'s `shell_quote()`, or static hardcoded text -- so there's no live trigger today. But the pattern itself doesn't hold up as a general-purpose entry point: any future caller passing a dynamic, unquoted argument to either script would have it re-interpreted by the shell during `eval`'s re-parse instead of passed through as inert data.

This quotes each argument with `printf %q` before joining, the same pattern already used elsewhere in this codebase for the identical shape of problem (`omarchy-install-app`/`omarchy-install-font` after #7843, `omarchy-remove-launcher-entry`). Both scripts now build `LAUNCH_COMMAND` the same way those already do.

No behavior change: the real `omarchy-launch-about` call path produces a byte-identical `LAUNCH_COMMAND` before and after this change. `shellcheck` also flags the prior code as `SC2124` ("assigning an array to a string"); the new code is clean. Includes a regression test (`test/shell.d/launch-or-focus-eval-quoting-test.sh`) following this repo's established mock-binary/`base-test.sh` convention, verified to fail against the prior code and pass against this change.
