### PR TITLE
Add screensaver plugin kind selected by idle.screensaverId

### DIFF
--- a/agents/skills/shell-dev.md
+++ b/agents/skills/shell-dev.md
@@ -22,7 +22,9 @@ Run `omarchy-restart-shell` after making changes to QML files.
   `activation` are optional.
 - Entry-point QML files are `Item`s (not `ShellRoot`), and accept the
   shell-injected properties `omarchyPath`, `shell`, `manifest`, and
-  `pluginRegistry` / `barWidgetRegistry` as appropriate.
+  `pluginRegistry` / `barWidgetRegistry` as appropriate. The exception is the
+  `screensaver` kind, whose entry point is an executable launcher the idle
+  service runs in place of `omarchy-launch-screensaver`.
 - Panel / overlay / menu plugins must expose `open(payloadJson)` and
   `close()` lifecycle methods for `shell summon` and `shell hide`.
 

--- a/bin/omarchy-plugin-validate
+++ b/bin/omarchy-plugin-validate
@@ -100,6 +100,7 @@ for kind_entry_point in \
   "menu:menu" \
   "overlay:overlay" \
   "panel:panel" \
+  "screensaver:screensaver" \
   "service:service"; do
   kind="${kind_entry_point%%:*}"
   entry_point="${kind_entry_point##*:}"
@@ -107,6 +108,17 @@ for kind_entry_point in \
   jq -e --arg ep "$entry_point" '.entryPoints | has($ep)' "$MANIFEST" >/dev/null 2>&1 \
     || fail "kind '$kind' requires an 'entryPoints.$entry_point' to load"
 done
+
+# The screensaver entry point is executed as a program, not loaded as QML. One
+# without the executable bit installs a screensaver that silently falls back to
+# the built-in terminal one, so refuse it here like a missing entry point. Git
+# checkouts preserve the bit, so a properly shipped launcher passes.
+if jq -e '(.kinds | index("screensaver")) != null' "$MANIFEST" >/dev/null 2>&1; then
+  ep=$(jq -r '.entryPoints.screensaver // empty' "$MANIFEST")
+  if [[ -n $ep && ! -x "$PLUGIN_DIR/$ep" ]]; then
+    fail "kind 'screensaver' requires its entry point to be executable: '$ep'"
+  fi
+fi
 
 # Refuse any symlink anywhere inside the plugin folder. Symlinks could point a
 # copied plugin back at arbitrary files on disk after it lands in the trusted

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -34,12 +34,19 @@ wait).
 | `overlay`    | Fullscreen overlay (e.g. background picker)    |
 | `menu`       | Summoned menu surface                          |
 | `service`    | Headless singleton, no UI                      |
+| `screensaver` | Executable that replaces the built-in idle screensaver |
 
 Only one full bar option is active at a time. The built-in `omarchy.bar` is
 used when `bar.id` is omitted or when a selected third-party bar cannot load.
+The `screensaver` kind mirrors that: exactly one is active, selected by
+`idle.screensaverId`, and the built-in terminal screensaver is used when the
+key is omitted or the selection cannot be resolved.
 Panels, overlays, and menus are loaded when summoned. Plugins can set the top-level manifest key `keepLoaded: true` to survive between summons, and to keep a service mounted across plugin hot-reload (so `omarchy.lock` is not destroyed while Hyprland still holds the session lock). First-party services are loaded at startup.
 
-Entry points are QML `Item`s. Panel, overlay, and menu entry points expose
+Entry points are QML `Item`s, except `screensaver`, whose entry point is an
+executable launcher the idle service runs instead of `omarchy-launch-screensaver`
+(it should open windows with the class `org.omarchy.screensaver` and must not
+take an idle inhibitor). Panel, overlay, and menu entry points expose
 `open(payloadJson)` and `close()` for summon/hide; on load the host injects
 `omarchyPath`, `shell`, `manifest`, and the registries (`pluginRegistry` /
 `barWidgetRegistry`) as properties.
@@ -167,6 +174,8 @@ Rules:
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+   `idle.screensaverId` selects a `screensaver`-kind plugin the way `bar.id`
+   selects a bar option; omit it for the built-in terminal screensaver.
 8. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -94,6 +94,8 @@ You can start it on demand from _System > Screensaver_ (`Super + Esc`), which fo
 
 The logo it draws is yours to change, under _Style > Screensaver_. Upload a png or svg and Omarchy converts it to ASCII. See [branding](41-branding.md).
 
+If you'd rather run a different screensaver entirely, install a plugin that declares the `screensaver` kind — `omarchy plugin add` and `omarchy plugin enable` work the same as for any other plugin — and the idle service will run it instead of the built-in one. The selection lives in `shell.json` as `idle.screensaverId`, exactly one screensaver plugin is active at a time, and removing the key (or the plugin) puts the built-in screensaver back. The idle-to-lock behavior is unchanged either way: the lock still fires at `idle.lock` no matter what the screensaver is doing, and dismissing a screensaver window with the class `org.omarchy.screensaver` still cancels the pending lock. `omarchy toggle screensaver` turns a plugin screensaver off the same way it does the built-in one; _System > Screensaver_ (the forced launch) keeps starting the built-in screensaver.
+
 ### The lock screen
 
 `Super + Ctrl + L` locks the machine. That runs the lock screen from the Omarchy shell, blanks the display, resets your keyboard layout to the first one so you're not typing your password in the wrong alphabet, and — if you have it running — locks 1Password on the way out.

--- a/shell/README.md
+++ b/shell/README.md
@@ -81,9 +81,17 @@ Supported `kinds`:
 | `menu`       | A summoned menu surface                                      |
 | `service`    | A headless singleton, no UI                                  |
 | `bar`        | A full bar option that can replace the built-in `omarchy.bar` |
+| `screensaver` | An executable that replaces the built-in idle screensaver     |
 
 Only one `bar` plugin is active at a time. Missing or invalid selections fall
 back to the built-in `omarchy.bar`, so users always have a safe path home.
+The `screensaver` kind works the same way: exactly one is active, selected by
+`idle.screensaverId`, and a missing or invalid selection falls back to the
+built-in terminal screensaver. Its entry point is an executable launcher run
+by the idle service, not a QML file; the launcher should give its windows the
+class `org.omarchy.screensaver` so dismissal cancels the pending lock and
+locking cleans them up, and it must not take an idle inhibitor or the machine
+will never lock.
 Panels, overlays, and menus are loaded when summoned. Plugins that need
 to outlive a single summon can set `keepLoaded: true` (e.g. the image
 picker keeps its overlay window mounted between summons). The same flag
@@ -271,7 +279,8 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    like `Clock` and `AudioPanel` forward.
 5. **Third-party enabled ⇔ present.** A third-party plugin is enabled iff
    its id appears somewhere in shell.json. For full bar options, that means
-   `bar.id`; for bar widgets, plugin enable/disable adds/removes layout entries;
+   `bar.id`; for screensaver options, `idle.screensaverId`;
+   for bar widgets, plugin enable/disable adds/removes layout entries;
    other plugin kinds are enabled the same way. First-party non-bar plugins
    are enabled unless listed in `disabledPlugins[]`.
 6. **Multiple instances** are allowed when a manifest sets
@@ -280,7 +289,9 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    entries with their own values.
 7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
    are seconds since user idle began, so the default lock fires at 300s
-   even if the 150s screensaver starts first.
+   even if the 150s screensaver starts first. `idle.screensaverId` selects
+   a `screensaver`-kind plugin the way `bar.id` selects a bar option; omit
+   it for the built-in terminal screensaver.
 8. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,3 +1,29 @@
+// The launcher path rides in as $1, never spliced into the script, so no
+// configured value can escape or unbalance the isLocked guard (the same
+// argv-over-interpolation idiom as Util.execArgv). A missing or non-executable
+// launcher falls back to the built-in screensaver; a locked session launches
+// nothing at all. The screensaver-off toggle is enforced here so every
+// screensaver plugin honors it; the built-in fallback also checks it itself,
+// keeping that path identical to what ran before plugin selection existed.
+var SCREENSAVER_LAUNCH_SCRIPT = '[[ $(omarchy-shell lock isLocked 2>/dev/null) == "true" ]] && exit 0\n'
+  + 'if [[ -n $1 && -x $1 ]] && ! omarchy-toggle-enabled screensaver-off; then\n'
+  + '  "$1"\n'
+  + 'else\n'
+  + '  omarchy-launch-screensaver\n'
+  + 'fi'
+
+function screensaverIdFromConfig(value) {
+  if (typeof value !== "string") return ""
+  return value.trim()
+}
+
+function screensaverLaunch(launcherPath) {
+  return {
+    command: SCREENSAVER_LAUNCH_SCRIPT,
+    args: ["omarchy-idle-screensaver", String(launcherPath || "")]
+  }
+}
+
 function secondsFromConfig(value, fallback) {
   var n = Number(value)
   if (!isFinite(n) || n < 0) return fallback
@@ -45,6 +71,8 @@ function screensaverWindowsAfter(windows, address, visible) {
 
 if (typeof module !== "undefined") {
   module.exports = {
+    screensaverIdFromConfig: screensaverIdFromConfig,
+    screensaverLaunch: screensaverLaunch,
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -25,6 +25,19 @@ Item {
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
+  // A screensaver-kind plugin selected by idle.screensaverId replaces the
+  // built-in terminal screensaver, the way bar.id selects a full bar option.
+  // A missing or invalid selection resolves to "" and the launch script falls
+  // back to omarchy-launch-screensaver, so users always have a safe path home.
+  readonly property string selectedScreensaverId: IdleModel.screensaverIdFromConfig(idleConfig.screensaverId)
+  readonly property string screensaverLauncherPath: {
+    if (!selectedScreensaverId || !shell || !shell.pluginRegistry) return ""
+    var revision = shell.pluginRegistry.registryRevision
+    var manifest = shell.pluginRegistry.installedPlugins[selectedScreensaverId] || null
+    if (!manifest || !Array.isArray(manifest.kinds) || manifest.kinds.indexOf("screensaver") === -1) return ""
+    return shell.pluginRegistry.entryPointPath(manifest, "screensaver")
+  }
+
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
   property bool hasPendingStayAwakePersist: false
@@ -51,13 +64,14 @@ Item {
     console.log("omarchy idle " + root.lastEventAt + " " + root.lastEvent)
   }
 
-  function runProcess(process, label, command) {
+  function runProcess(process, label, command, args) {
     if (process.running) {
       logEvent("process-skip", label + " already running")
       return false
     }
-    logEvent("process-start", label + " " + command)
-    process.command = ["bash", "-lc", command]
+    var argv = args || []
+    logEvent("process-start", label + " " + command + (argv.length > 1 ? " [" + argv.slice(1).join(", ") + "]" : ""))
+    process.command = ["bash", "-lc", command].concat(argv)
     process.running = true
     return true
   }
@@ -65,7 +79,8 @@ Item {
   function launchScreensaver() {
     root.screensaverStartedThisCycle = true
     screensaverLaunchGraceTimer.restart()
-    runProcess(screensaverProcess, "screensaver", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || omarchy-launch-screensaver")
+    var launch = IdleModel.screensaverLaunch(root.screensaverLauncherPath)
+    runProcess(screensaverProcess, "screensaver", launch.command, launch.args)
   }
 
   function lockSystem(reason) {
@@ -188,6 +203,8 @@ Item {
       screensaverStarted: root.screensaverStartedThisCycle,
       screensaver: root.screensaverTimeoutSeconds,
       lock: root.lockTimeoutSeconds,
+      screensaverId: root.selectedScreensaverId,
+      screensaverLauncher: root.screensaverLauncherPath,
       screensaverDelay: root.screensaverDelaySeconds,
       lockDelay: root.lockDelaySeconds,
       screensaverWindows: root.screensaverWindowCount,

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -90,7 +90,7 @@ QtObject {
     return manifest
   }
 
-  function entryPointUrl(manifest, kind) {
+  function entryPointPath(manifest, kind) {
     if (!Util.isPlainObject(manifest)) return ""
     var ep = manifest.entryPoints ? manifest.entryPoints[kind] : null
     if (!ep) return ""
@@ -104,13 +104,18 @@ QtObject {
       console.warn("PluginRegistry: entry point escapes sourceDir: " + resolved)
       return ""
     }
-    return Util.fileUrl(resolved)
+    return resolved
+  }
+
+  function entryPointUrl(manifest, kind) {
+    var resolved = entryPointPath(manifest, kind)
+    return resolved ? Util.fileUrl(resolved) : ""
   }
 
   // Enabled = the plugin id is referenced somewhere in shell.json. That can
-  // be either the active bar option in `bar.id`, a layout entry inside
-  // `bar.layout.*` (bar widgets), or a top-level entry in `plugins[]` (panels,
-  // overlays, services).
+  // be the active bar option in `bar.id`, the active screensaver option in
+  // `idle.screensaverId`, a layout entry inside `bar.layout.*` (bar widgets),
+  // or a top-level entry in `plugins[]` (panels, overlays, services).
   //
   // Special cases (implicitly always enabled, no shell.json entry needed):
   //   - the built-in bar option (`omarchy.bar`) is active when `bar.id` is
@@ -131,6 +136,15 @@ QtObject {
           selectedBar = Util.canonicalWidgetId(String(config.bar.id || ""))
         if (!selectedBar) selectedBar = "omarchy.bar"
         return selectedBar === key
+      }
+      if (Array.isArray(manifest.kinds) && manifest.kinds.indexOf("screensaver") !== -1) {
+        // Like the bar option, exactly one screensaver plugin is active at a
+        // time; no selection means the built-in terminal screensaver, which is
+        // not a plugin, so nothing is enabled by default.
+        var selectedScreensaver = ""
+        if (Util.isPlainObject(config) && Util.isPlainObject(config.idle))
+          selectedScreensaver = Util.canonicalWidgetId(String(config.idle.screensaverId || ""))
+        return selectedScreensaver === key
       }
       if (isDisabled(config, key)) return false
       if (manifest.__isFirstParty) return true
@@ -459,6 +473,7 @@ QtObject {
       return false
     }
     var isBarOption = manifest && Array.isArray(manifest.kinds) && manifest.kinds.indexOf("bar") !== -1
+    var isScreensaverOption = manifest && Array.isArray(manifest.kinds) && manifest.kinds.indexOf("screensaver") !== -1
     var isBarWidget = manifest && Array.isArray(manifest.kinds) && manifest.kinds.indexOf("bar-widget") !== -1
     var hasNonWidgetKind = manifest && Array.isArray(manifest.kinds)
       && manifest.kinds.some(function(kind) { return kind !== "bar-widget" })
@@ -489,6 +504,20 @@ QtObject {
         } else if (Util.canonicalWidgetId(String(config.bar.id || "")) === key) {
           if (clonedFrom && clonedFrom !== "omarchy.bar") config.bar.id = clonedFrom
           else delete config.bar.id
+        }
+        return
+      }
+
+      if (isScreensaverOption) {
+        // Selection is enablement, like the bar option: enabling makes this
+        // the one active screensaver plugin, disabling falls back to the
+        // built-in terminal screensaver.
+        if (value) {
+          if (!Util.isPlainObject(config.idle)) config.idle = {}
+          config.idle.screensaverId = key
+        } else if (Util.isPlainObject(config.idle)
+            && Util.canonicalWidgetId(String(config.idle.screensaverId || "")) === key) {
+          delete config.idle.screensaverId
         }
         return
       }

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -33,10 +33,108 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+
+assertEqual(idle.screensaverIdFromConfig(undefined), '', 'idle treats a missing screensaverId as no selection')
+assertEqual(idle.screensaverIdFromConfig('   '), '', 'idle treats a blank screensaverId as no selection')
+assertEqual(idle.screensaverIdFromConfig(42), '', 'idle treats a non-string screensaverId as no selection')
+assertEqual(idle.screensaverIdFromConfig(' acme.saver '), 'acme.saver', 'idle trims the configured screensaverId')
+
+const launch = idle.screensaverLaunch('/plugins/acme.saver/bin/launch')
+assertDeepEqual(
+  launch.args,
+  ['omarchy-idle-screensaver', '/plugins/acme.saver/bin/launch'],
+  'idle passes the screensaver launcher as an argument, never spliced into the script'
+)
+assert(launch.command.indexOf('isLocked') !== -1, 'idle screensaver launch keeps the isLocked guard')
+assert(launch.command.indexOf('omarchy-launch-screensaver') !== -1, 'idle screensaver launch keeps the built-in fallback')
+assertDeepEqual(
+  idle.screensaverLaunch('').args,
+  ['omarchy-idle-screensaver', ''],
+  'idle screensaver launch tolerates no selected launcher'
+)
 JS
 
+# Exercise the exact launch script the idle service hands to bash, with the
+# launcher path in $1 the way Service.qml passes it. omarchy-shell is stubbed
+# so the isLocked guard can be steered from the environment.
+launch_script=$(node -e '
+  const idle = require(process.argv[1] + "/shell/plugins/services/idle/IdleModel.js")
+  process.stdout.write(idle.screensaverLaunch("x").command)
+' "$ROOT")
+
+guard_tmp=$(mktemp -d)
+trap 'rm -rf "$guard_tmp"' EXIT
+
+mkdir -p "$guard_tmp/bin"
+cat >"$guard_tmp/bin/omarchy-shell" <<'SH'
+#!/bin/bash
+echo "${OMARCHY_TEST_IS_LOCKED:-false}"
+SH
+cat >"$guard_tmp/bin/omarchy-launch-screensaver" <<'SH'
+#!/bin/bash
+touch "$OMARCHY_TEST_BUILTIN_RAN"
+SH
+cat >"$guard_tmp/bin/omarchy-toggle-enabled" <<'SH'
+#!/bin/bash
+[[ ${OMARCHY_TEST_SCREENSAVER_OFF:-0} == "1" ]]
+SH
+chmod +x "$guard_tmp/bin"/*
+
+builtin_marker="$guard_tmp/builtin-ran"
+plugin_marker="$guard_tmp/plugin-ran"
+
+cat >"$guard_tmp/plugin launcher" <<SH
+#!/bin/bash
+touch "$plugin_marker"
+SH
+chmod +x "$guard_tmp/plugin launcher"
+
+run_launch_script() {
+  rm -f "$builtin_marker" "$plugin_marker"
+  PATH="$guard_tmp/bin:$PATH" OMARCHY_TEST_BUILTIN_RAN="$builtin_marker" \
+    OMARCHY_TEST_IS_LOCKED="$1" bash -c "$launch_script" omarchy-idle-screensaver "$2"
+}
+
+run_launch_script false ""
+[[ -e $builtin_marker ]] || fail "launch script without a selection runs the built-in screensaver"
+pass "launch script without a selection runs the built-in screensaver"
+
+run_launch_script false "$guard_tmp/plugin launcher"
+[[ -e $plugin_marker && ! -e $builtin_marker ]] || fail "launch script runs the selected launcher instead of the built-in"
+pass "launch script runs the selected launcher instead of the built-in"
+
+run_launch_script false "$guard_tmp/missing-launcher"
+[[ -e $builtin_marker && ! -e $plugin_marker ]] || fail "launch script falls back to the built-in when the launcher is missing"
+pass "launch script falls back to the built-in when the launcher is missing"
+
+chmod 644 "$guard_tmp/plugin launcher"
+run_launch_script false "$guard_tmp/plugin launcher"
+[[ -e $builtin_marker && ! -e $plugin_marker ]] || fail "launch script falls back to the built-in when the launcher is not executable"
+pass "launch script falls back to the built-in when the launcher is not executable"
+chmod 755 "$guard_tmp/plugin launcher"
+
+run_launch_script true "$guard_tmp/plugin launcher"
+[[ ! -e $plugin_marker && ! -e $builtin_marker ]] || fail "locked session launches no screensaver at all"
+run_launch_script true ""
+[[ ! -e $builtin_marker ]] || fail "locked session launches no built-in screensaver either"
+pass "locked session launches no screensaver at all"
+
+# The screensaver-off toggle reaches plugin screensavers through the launch
+# script, so a plugin launcher cannot run while the toggle is on. The built-in
+# fallback enforces the toggle itself, exactly as it did before.
+OMARCHY_TEST_SCREENSAVER_OFF=1 run_launch_script false "$guard_tmp/plugin launcher"
+[[ ! -e $plugin_marker ]] || fail "screensaver-off toggle keeps the plugin launcher from running"
+pass "screensaver-off toggle keeps the plugin launcher from running"
+
+# The launcher path is an argv element, not part of the script, so a hostile
+# path cannot break out of the guard: it fails the -x test and falls back.
+run_launch_script false '"; touch '"$guard_tmp"'/escaped; #'
+[[ ! -e $guard_tmp/escaped ]] || fail "launch script never evaluates the launcher path as shell"
+[[ -e $builtin_marker ]] || fail "hostile launcher path still falls back to the built-in"
+pass "launch script never evaluates the launcher path as shell"
+
 test_tmp=$(mktemp -d)
-trap 'rm -rf "$test_tmp"' EXIT
+trap 'rm -rf "$test_tmp" "$guard_tmp"' EXIT
 
 test_home="$test_tmp/home"
 mkdir -p "$test_home"

--- a/test/shell.d/plugin-validate-test.sh
+++ b/test/shell.d/plugin-validate-test.sh
@@ -32,7 +32,12 @@ JSON
 
   while IFS= read -r entry; do
     [[ -n $entry ]] || continue
+    mkdir -p "$(dirname "$dir/$entry")"
     touch "$dir/$entry"
+    # The screensaver entry point must carry the executable bit; the bit is
+    # meaningless to the QML kinds, so setting it everywhere keeps this helper
+    # kind-agnostic.
+    chmod 755 "$dir/$entry"
   done < <(jq -r '.[]' <<<"$entry_points")
 
   printf '%s\n' "$dir"
@@ -64,8 +69,18 @@ bar-widget:barWidget
 menu:menu
 overlay:overlay
 panel:panel
+screensaver:screensaver
 service:service
 KINDS
+
+# A screensaver entry point is executed, not loaded as QML, so it must carry
+# the executable bit.
+dir=$(write_plugin "limp-screensaver" '["screensaver"]' '{"screensaver": "bin/launch"}')
+chmod 644 "$dir/bin/launch"
+output=$(validate "$dir") && fail "validate refuses a non-executable screensaver entry point" "$output"
+grep -qF "kind 'screensaver' requires its entry point to be executable" <<<"$output" \
+  || fail "validate explains the screensaver executability contract" "$output"
+pass "validate refuses a non-executable screensaver entry point"
 
 # A plugin that is both a bar and a widget owes an entry point for each.
 dir=$(write_plugin "both" '["bar","bar-widget"]' '{"bar": "Bar.qml", "barWidget": "Widget.qml"}')

--- a/test/shell.d/plugins-test.sh
+++ b/test/shell.d/plugins-test.sh
@@ -14,6 +14,7 @@ const kindEntryPoints = {
   'menu': 'menu',
   'overlay': 'overlay',
   'panel': 'panel',
+  'screensaver': 'screensaver',
   'service': 'service'
 }
 


### PR DESCRIPTION
## Problem

The only way to change what the idle screensaver runs is to fork the idle service: `omarchy plugin clone omarchy.idle` and edit one line of `Service.qml`. That clone also takes over the **lock** scheduling — `lockTimer`, `lockSystem()`, the dismissed-screensaver cancel logic — so users who just want flying toasters end up maintaining a fork of security-relevant lock code that stops receiving upstream fixes.

The demand is real and it keeps arriving as one-off additions: #7606 (Neo Matrix, CBonsai, Pipes, Lavat), #6750 (Splinterm, closed unmerged), #8078 (typed-words screensaver), #7766 (FIGlet branding picker), plus discussions #8403 and #2941 asking to pin or modify the effect list. Each of those hardcodes one more screensaver into the core. A single extension point replaces the whole accretion pattern: the specific screensavers become plugins anyone can ship.

#6086 was closed with: *"Quattro idle timing now belongs to the native shell service and shell configuration."* This PR puts screensaver selection exactly there — the selection is a `shell.json` key, and the resolution and launch live in the native idle service. No bash-side override, no environment variables, no PATH shadowing.

## A working example

[jfryman/omarchy-flying-toasters](https://github.com/jfryman/omarchy-flying-toasters)
is a real screensaver built against this PR — the After Dark flying toasters,
drawn in the terminal, with sprites and colours sampled from the 1989 sprite
sheet.

Its two branches are the before-and-after this PR is arguing about:

- [`main`](https://github.com/jfryman/omarchy-flying-toasters/tree/main) is what
  a screensaver has to look like **today**: a `service` plugin carrying a fork of
  `omarchy.idle`, so it owns `lockTimer`, `lockSystem()` and the dismissal-cancel
  logic purely to change which command launches.
- [`screensaver-plugin-kind`](https://github.com/jfryman/omarchy-flying-toasters/tree/screensaver-plugin-kind)
  is the same screensaver **under this PR**: `kinds: ["screensaver"]`, one entry
  point, and `Service.qml` and `IdleModel.js` deleted outright. Lock scheduling
  goes back to the stock idle service.

The diff between those branches is the case for this change: the same screensaver,
minus a fork of security-relevant lock code.

## The mechanism: a `screensaver` plugin kind, modeled on `bar`

Omarchy already solved "swap a built-in for a plugin, safely" once: `bar` is a kind, exactly one is active, it is selected by `bar.id`, and a missing or invalid selection falls back to the built-in bar so users always have a safe path home. This PR applies the same shape to the screensaver:

- A plugin declares `kinds: ["screensaver"]` and `entryPoints: { "screensaver": "bin/my-launcher" }`. The entry point is an **executable**, not QML — the idle service runs it in place of `omarchy-launch-screensaver`.
- `idle.screensaverId` in `shell.json` selects it, next to the existing `idle.screensaver` / `idle.lock` timings. `omarchy plugin enable <id>` sets the key; `disable` clears it; enabled ⇔ selected, exactly like `bar.id`.
- Missing key, unknown id, wrong kind, missing or non-executable entry point → the built-in terminal screensaver runs, unchanged. **An install with no config change behaves identically to today.**
- `omarchy plugin add` / `update` / `remove` work unchanged — a screensaver is a normal git-repo plugin. `omarchy-plugin-validate` now requires the `screensaver` kind to carry an executable `entryPoints.screensaver` (git checkouts preserve the bit), refusing broken plugins at install time instead of silently falling back.

The launcher contract, documented in the shell README and manual: open windows with the class `org.omarchy.screensaver` (so dismissing one cancels the pending auto-lock and locking reaps it), and never take a Wayland idle inhibitor (the idle monitor honors inhibitors, so an inhibiting screensaver would keep the machine from ever locking — true today for any manually launched player as well).

## Lock safety

The launch is the only thing that changes; the lock path is untouched bytes. The analysis:

1. **The `isLocked` guard cannot be escaped.** The service used to build one command string; it now runs a *constant* script and passes the resolved launcher path as an argv element (`["bash", "-lc", script, "omarchy-idle-screensaver", path]`) — the same argv-over-interpolation idiom as `Util.execArgv`, and the same pattern #7926 ("Run notification click actions as safe argv") applied across `bin/` — a path that arrives as an argv element cannot become shell syntax. No configured value is ever spliced into shell syntax, so no quoting trick, `#`, `}` or newline in a path can comment out or unbalance the guard. The shipped test suite runs the byte-exact script with a hostile path (`"; touch escaped; #`) and proves it is never evaluated: it fails the `-x` test and the built-in screensaver runs instead.
2. **A locked session launches nothing.** The guard is checked before either branch, as before.
3. **A broken screensaver still locks the machine.** `startIdleCycle()` arms `lockTimer` independently of the screensaver launch, and `lockTimer.onTriggered` calls `lockSystem()` regardless of what the launch did. If the selected launcher exits without opening a window, `screensaverLaunchGraceTimer` cancels the idle cycle only when the compositor saw real activity (`!idleMonitor.isIdle`); a genuinely idle machine keeps the cycle armed and locks at the deadline. A launcher that opens a window without the `org.omarchy.screensaver` class loses only the dismiss-cancels-lock convenience — the failure direction is *lock still fires*, never *lock skipped*.
4. **The `screensaver-off` toggle is enforced centrally.** The launch script checks it before running a plugin launcher, so every plugin honors `omarchy toggle screensaver` without having to implement it; the built-in fallback path keeps its own check, byte-identical behavior to today.
5. **Arbitrary execution is not new surface.** A screensaver plugin is user-installed code, the same trust boundary as every plugin and hook; the entry-point path is validated by the existing manifest machinery (relative, no `..`, inside the plugin dir, no symlinks anywhere in the plugin) plus a launch-time `-x` check.

## What this replaces

With this in place, a screensaver like the flying-toasters plugin drops from "clone of `omarchy.idle` with `Service.qml` + `IdleModel.js`" to a manifest and two scripts — no forked lock code, and `omarchy plugin add` still distributes it.

## Scope and known interactions

- The diff touches `PluginRegistry.qml` (selection + `entryPointPath`), the idle service, `omarchy-plugin-validate`, tests, and docs. Larger than a config-string key — but a command string in `shell.json` would be spliced into the service's `bash -lc` line and survive round-trips through `shellConfigMutator`, which any loaded plugin can call; a validated entry-point path behind the existing manifest machinery avoids creating that persistence vector.
- #7193 (native Wayland screensaver client) keeps `omarchy-launch-screensaver` as its stable entry point, which is exactly the fallback this PR calls — the two compose: the native client becomes the better built-in, and plugins keep replacing it via selection.
- Forced launches (_System > Screensaver_, `omarchy-launch-screensaver force`, `omarchy-branding-screensaver`) still operate the built-in screensaver; routing them through the selection is left out of scope deliberately (they are bash-side and the branding preview is specifically about the built-in's ASCII art).

## Tests

- `test/shell.d/idle-test.sh`: model tests for the new config reads, plus bash tests that execute the byte-exact launch script the service hands to `Process` — built-in fallback with no selection, plugin launcher wins, missing/non-executable launcher falls back, locked session launches nothing, toggle gates plugin launchers, hostile path never evaluated (path-with-spaces covered by the launcher fixture).
- `test/shell.d/plugin-validate-test.sh`: `screensaver:screensaver` added to the kind/entry-point table; new case refusing a non-executable screensaver entry point.
- `./test/all`: passes except four pre-existing environment failures (`bar-icon-geometry`, `config`, `snapper`, `unowned-system-paths` — the omarchy-pkgs-checkout/graphical ones also reported in #9055) that fail identically on an unmodified `quattro` checkout.
- Live-session verification: the exact `["bash","-lc",script,...]` argv the patched service builds was executed against a real screensaver-kind launcher (the flying-toasters plugin) — fullscreen window with class `org.omarchy.screensaver` on the live Hyprland session, dismissed by a keypress; and the built-in launcher verified unchanged. The QML resolution path itself was validated with qmllint and the shipped tests; it was not exercised in a running shell (no `omarchy dev link` on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4VoHwTicwuJ768PKPgUE6
