### PR TITLE
Add speaker tuning for the ThinkPad X1 Carbon Gen 11

### DIFF
--- a/default/audio/tunings/thinkpad-x1-carbon-gen11/filter-chain.conf
+++ b/default/audio/tunings/thinkpad-x1-carbon-gen11/filter-chain.conf
@@ -1,0 +1,95 @@
+# Lenovo ThinkPad X1 Carbon Gen 11 speaker tuning.
+#
+# Biquad chain built by ear against the raw internal speaker sink (Cirrus
+# CS35L41 via sof-hda-dsp) -- no reference profile existed to fit against, see
+# tuning.conf. limiter_headroom_db and dynamic_range_delta_lu were measured
+# electrically off the physical sink's monitor; bass_group_delay_swing_ms was
+# computed from these exact biquad coefficients.
+#
+# alr/boost are off, as this format's convention expects (see docs/audio-
+# tuning.md): an earlier pass with boost on measured 0.0 dBFS peaks on a hot
+# master -- no headroom -- and on real (non-synthetic) hot-mastered tracks it
+# was audibly clipping. g_in=1.0/th=0.891/boost=0 below measured -1.0 dBFS
+# worst case and sounded clean on the same material.
+#
+# Channels are wired explicitly because the limiter is a stereo plugin; a mono
+# graph is duplicated per channel and would limit each side independently,
+# shifting the stereo image on bass transients. (Same reasoning as the Dell
+# XPS 14/16 tuning this format is modeled on.)
+
+context.modules = [
+  { name = libpipewire-module-filter-chain
+    args = {
+      node.description = "Laptop Speakers"
+      media.name       = "Laptop Speakers"
+
+      filter.graph = {
+        nodes = [
+          { type = builtin name = s0_l label = bq_highpass  control = { "Freq" = 100.0  "Q" = 0.7071067811865476 } }
+          { type = builtin name = s1_l label = bq_lowshelf  control = { "Freq" = 180.0  "Q" = 0.7071067811865476 "Gain" = 7.5 } }
+          { type = builtin name = s2_l label = bq_peaking   control = { "Freq" = 90.0   "Q" = 1.4 "Gain" = 2.5 } }
+          { type = builtin name = s3_l label = bq_peaking   control = { "Freq" = 400.0  "Q" = 1.2 "Gain" = -3.0 } }
+          { type = builtin name = s4_l label = bq_peaking   control = { "Freq" = 2500.0 "Q" = 1.0 "Gain" = 2.5 } }
+          { type = builtin name = s5_l label = bq_peaking   control = { "Freq" = 4000.0 "Q" = 1.5 "Gain" = -2.5 } }
+          { type = builtin name = s6_l label = bq_highshelf control = { "Freq" = 9000.0 "Q" = 0.7071067811865476 "Gain" = -3.0 } }
+
+          { type = builtin name = s0_r label = bq_highpass  control = { "Freq" = 100.0  "Q" = 0.7071067811865476 } }
+          { type = builtin name = s1_r label = bq_lowshelf  control = { "Freq" = 180.0  "Q" = 0.7071067811865476 "Gain" = 7.5 } }
+          { type = builtin name = s2_r label = bq_peaking   control = { "Freq" = 90.0   "Q" = 1.4 "Gain" = 2.5 } }
+          { type = builtin name = s3_r label = bq_peaking   control = { "Freq" = 400.0  "Q" = 1.2 "Gain" = -3.0 } }
+          { type = builtin name = s4_r label = bq_peaking   control = { "Freq" = 2500.0 "Q" = 1.0 "Gain" = 2.5 } }
+          { type = builtin name = s5_r label = bq_peaking   control = { "Freq" = 4000.0 "Q" = 1.5 "Gain" = -2.5 } }
+          { type = builtin name = s6_r label = bq_highshelf control = { "Freq" = 9000.0 "Q" = 0.7071067811865476 "Gain" = -3.0 } }
+
+          { type   = lv2
+            name   = limiter
+            plugin = "http://lsp-plug.in/plugins/lv2/limiter_stereo"
+            control = {
+              "alr"   = 0
+              "boost" = 0
+              "g_in"  = 1.0
+              "th"    = 0.891
+            }
+          }
+        ]
+
+        links = [
+          { output = "s0_l:Out" input = "s1_l:In" }
+          { output = "s1_l:Out" input = "s2_l:In" }
+          { output = "s2_l:Out" input = "s3_l:In" }
+          { output = "s3_l:Out" input = "s4_l:In" }
+          { output = "s4_l:Out" input = "s5_l:In" }
+          { output = "s5_l:Out" input = "s6_l:In" }
+          { output = "s6_l:Out" input = "limiter:in_l" }
+
+          { output = "s0_r:Out" input = "s1_r:In" }
+          { output = "s1_r:Out" input = "s2_r:In" }
+          { output = "s2_r:Out" input = "s3_r:In" }
+          { output = "s3_r:Out" input = "s4_r:In" }
+          { output = "s4_r:Out" input = "s5_r:In" }
+          { output = "s5_r:Out" input = "s6_r:In" }
+          { output = "s6_r:Out" input = "limiter:in_r" }
+        ]
+
+        inputs  = [ "s0_l:In" "s0_r:In" ]
+        outputs = [ "limiter:out_l" "limiter:out_r" ]
+      }
+
+      audio.channels = 2
+      audio.position = [ FL FR ]
+
+      capture.props = {
+        node.name   = "omarchy_speaker_tuning"
+        media.class = Audio/Sink
+      }
+      playback.props = {
+        node.name     = "omarchy_speaker_tuning_output"
+        node.passive  = true
+        target.object = "@SPEAKER_SINK@"
+        node.dont-move = true
+        node.dont-fallback = true
+        node.linger = true
+      }
+    }
+  }
+]

--- a/default/audio/tunings/thinkpad-x1-carbon-gen11/tuning.conf
+++ b/default/audio/tunings/thinkpad-x1-carbon-gen11/tuning.conf
@@ -1,0 +1,48 @@
+## Lenovo ThinkPad X1 Carbon Gen 11 internal speakers.
+##
+## Seven biquads and a lookahead limiter, applied as a PipeWire filter-chain in
+## front of the internal speaker sink. The stock Linux path already loads
+## Lenovo's Cirrus CS35L41 smart-amplifier protection firmware (via SOF /
+## sof-hda-dsp); this adds the perceptual voicing that firmware does not
+## attempt on its own -- these speakers are notably bass-light and top-heavy
+## without it.
+
+description="Lenovo ThinkPad X1 Carbon Gen 11 speakers"
+
+## Lenovo keys Cirrus speaker firmware per exact CTO (Configure To Order) SKU,
+## which is too narrow here -- two Gen 11 units can carry different SKUs for
+## unrelated reasons (CPU/RAM/screen config) while sharing the same speakers
+## and amp. Matched on product_family instead, which is constant across the
+## whole Gen 11 line regardless of configuration.
+match_dmi=("ThinkPad X1 Carbon Gen 11")
+sink_pattern='^alsa_output.*skl_hda_dsp_generic.*HiFi__Speaker__sink$'
+
+## Provenance. There was no reference to copy (no Windows install on the
+## validating unit, and no existing community EQ preset for this exact model),
+## so this was built by ear rather than fitted to a measured target curve --
+## unlike the Dell XPS 14/16 tuning this format is modeled on. magnitude_rms_db
+## is intentionally omitted below: there is no reference/target to report
+## deviation from. Everything else was measured, not guessed:
+##
+##  - The high-pass corner (100 Hz) and the safety of the low-shelf/peak boost
+##    around it are backed by an acoustic distortion sweep (mic-sweep, built-in
+##    mic -- fine for this comparative measurement, since the mic's own
+##    response cancels across the volume sweep at a fixed frequency). At 80 Hz
+##    the raw driver output is noise-floor-dominated -- there is nothing there
+##    worth preserving. 100-200 Hz show healthy, *decreasing* THD as level
+##    rises (e.g. 100 Hz: 41% at 40% volume falling to 3.4% at 100% volume on
+##    the raw, untuned driver), i.e. no runaway breakup already present in that
+##    range before this tuning adds gain to it.
+##  - limiter_headroom_db and dynamic_range_delta_lu were captured electrically
+##    off the physical speaker sink's monitor, per docs/audio-tuning.md.
+##  - bass_group_delay_swing_ms was computed analytically from the biquad
+##    coefficients (RBJ Audio EQ Cookbook forms, 48 kHz).
+derived_from="ear-tuned interactively against the raw speakers, no reference profile"
+validated_by="dipunm"
+validated_on="2026-08-31"
+validated_hardware="ThinkPad X1 Carbon Gen 11 (21HMCTO1WW)"
+
+## magnitude_rms_db intentionally omitted -- see derived_from above.
+bass_group_delay_swing_ms="4.91"
+limiter_headroom_db="1.0"    ## worst-case peak on a hot master vs -1 dBFS
+dynamic_range_delta_lu="0.1"  ## vs this unit's own untuned speakers (no external reference existed to compare against)


### PR DESCRIPTION
## Summary

- Adds a PipeWire filter-chain speaker tuning for the Lenovo ThinkPad X1 Carbon Gen 11 (Cirrus CS35L41 via sof-hda-dsp), same format as the Dell XPS 14/16 tuning.
- No reference profile existed to fit against (no Windows install on the validating unit, no existing community EQ preset for this exact model), so the EQ shape was built by ear against the raw speakers rather than fitted to a measured target curve. `tuning.conf` discloses this explicitly and intentionally omits `magnitude_rms_db`, since there is no reference/target to report deviation from.
- What *was* measured rather than guessed:
  - An acoustic distortion sweep (`mic-sweep`, built-in mic — valid for this comparative measurement since the mic's own response cancels across a volume sweep at a fixed frequency) backs the 100 Hz high-pass and the safety of the bass boost around it. 80 Hz is noise-floor-dominated on the raw driver; 100–200 Hz show healthy, *decreasing* THD as level rises on the untuned speakers (e.g. 100 Hz: 41% THD at 40% volume falling to 3.4% at 100% volume).
  - `limiter_headroom_db` and `dynamic_range_delta_lu` were captured electrically off the physical speaker sink's monitor, per `docs/audio-tuning.md`.
  - `bass_group_delay_swing_ms` was computed analytically from the biquad coefficients (RBJ Audio EQ Cookbook forms, 48 kHz): 4.91 ms swing across 30–300 Hz.
- An earlier pass left `alr`/`boost` on for extra loudness. That measured 0.0 dBFS peaks (no headroom) on a hot-master test, and was audibly clipping on real hot-mastered tracks. Reverted to `boost=0`, matching this format's usual fixed-tone convention — measured a clean -1.0 dBFS worst case and sounded clean on the same material.

## Test plan

- [x] `OMARCHY_PATH=<checkout> omarchy-audio-tuning match` — resolves to this tuning on the validating hardware
- [x] `OMARCHY_PATH=<checkout> omarchy-audio-tuning on --force` — installs, waits for the sink, verifies it links to the physical speaker sink
- [x] `OMARCHY_PATH=<checkout> omarchy-audio-tuning status` — reports installed/active/matched correctly
- [x] `./test/all` — no new failures introduced (4 pre-existing failures on `main` are all missing-`omarchy-pkgs`-checkout environment issues, unrelated to this change; confirmed identical on a clean baseline)
- [x] Listened live on the target hardware through several iterations, including a hot-master clipping check that caught and fixed the headroom issue described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01538fxoWrdMd6KBox49vwid