### PR TITLE
Add a Grok usage collector to the agents panel

### DIFF
--- a/bin/omarchy-agent-usage-grok
+++ b/bin/omarchy-agent-usage-grok
@@ -1,0 +1,384 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Grok usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Grok CLI usage into one display-ready JSON record.
+
+Grok ships no usage or rate-limit endpoint: the CLI has no `usage`
+subcommand and never exposes the account's allowance, so this record carries
+local stats only -- the shape Claude's collector falls back to when it cannot
+reach Anthropic's endpoint. The panel draws tokens by day, tokens by model,
+prompts, and sessions; the limits section stays empty.
+
+Every number comes from ~/.grok/sessions/<encoded-cwd>/<session-id>/updates.jsonl,
+where the CLI writes one `turn_completed` update per prompt carrying that
+turn's token usage broken down by model.
+"""
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+AGENT_ID = "grok"
+AGENT_NAME = "Grok"
+AUTH_HELP = "Run `grok login` to sign in."
+
+# A scan this recent is only reused to dedup concurrent collector runs (the
+# update command backgrounds one per agent while the panel refreshes on its
+# own); every periodic widget refresh lands a real rescan, however low
+# refreshIntervalSec is set. --limits-only promises only fresh limits, and
+# this agent has none to fetch, so it may reuse a scan for far longer.
+SCAN_REUSE_SECONDS = 20
+LIMITS_ONLY_REUSE_SECONDS = 900
+
+# Only sessions touched inside this window are scanned, so a long-lived
+# ~/.grok does not cost a full-tree read on every refresh. All-time totals
+# therefore cover this window, the same caveat the Codex collector carries.
+SCAN_WINDOW_DAYS = 30
+
+# The marker that lets a multi-megabyte updates.jsonl line be skipped without
+# a JSON parse. It is an accelerator, not the authority: the parsed
+# sessionUpdate below decides what actually counts.
+TURN_MARKER = '"turn_completed"'
+
+
+def number(value):
+  try:
+    return int(value or 0)
+  except Exception:
+    return 0
+
+
+def grok_home():
+  return Path(os.environ.get("GROK_HOME") or (Path.home() / ".grok"))
+
+
+def local_day(value):
+  if value is None:
+    return datetime.now().strftime("%Y-%m-%d")
+  if isinstance(value, (int, float)):
+    # Grok writes seconds at the top level and milliseconds in _meta.
+    if value > 10_000_000_000:
+      value = value / 1000
+    return datetime.fromtimestamp(value).strftime("%Y-%m-%d")
+  text = str(value)
+  try:
+    if text.endswith("Z"):
+      parsed = datetime.fromisoformat(text[:-1] + "+00:00")
+    else:
+      parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is not None:
+      parsed = parsed.astimezone()
+    return parsed.strftime("%Y-%m-%d")
+  except Exception:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def model_name(raw):
+  value = str(raw or "").strip()
+  return value if value else "grok"
+
+
+now = datetime.now()
+today = now.strftime("%Y-%m-%d")
+recent_dates = [(now - timedelta(days=offset)).strftime("%Y-%m-%d") for offset in range(6, -1, -1)]
+recent = {day: {"date": day, "messageCount": 0} for day in recent_dates}
+today_tokens_by_model = {}
+model_usage = {}
+today_sessions = set()
+active_days = set()
+
+today_prompts = 0
+today_total_tokens = 0
+total_prompts = 0
+total_sessions = set()
+# Grok prompt ids are UUIDs unique to a turn, so a session forked with
+# --fork-session -- which replays the transcript under a new session id --
+# contributes its shared turns once rather than twice.
+seen_prompts = set()
+
+
+def split_buckets(usage):
+  """Grok's four disjoint token buckets, from its overlapping ones.
+
+  cachedReadTokens and cacheCreationTokens are both counted inside
+  inputTokens (records satisfy totalTokens == inputTokens + outputTokens), so
+  the plain input bucket is what is left after removing them. Reasoning
+  tokens stay folded into output, the way the Codex collector keeps them.
+  """
+  cache_read = number(usage.get("cachedReadTokens"))
+  cache_write = number(usage.get("cacheCreationTokens"))
+  input_tokens = max(0, number(usage.get("inputTokens")) - cache_read - cache_write)
+  output_tokens = number(usage.get("outputTokens"))
+  return input_tokens, output_tokens, cache_read, cache_write
+
+
+def add_turn(day, session_key, usage):
+  """Record one completed turn: one prompt, tokens split across its models."""
+  global today_prompts, today_total_tokens, total_prompts
+
+  # A turn that switched models mid-flight reports each one separately, and
+  # the top-level counters are their sum, so only one of the two is read.
+  per_model = usage.get("modelUsage")
+  if not isinstance(per_model, dict) or not per_model:
+    per_model = {model_name(usage.get("model")): usage}
+
+  turn_total = 0
+  counted = False
+  for raw_model, model_stats in per_model.items():
+    if not isinstance(model_stats, dict):
+      continue
+    input_tokens, output_tokens, cache_read, cache_write = split_buckets(model_stats)
+    if not (input_tokens or output_tokens or cache_read or cache_write):
+      continue
+    counted = True
+    model = model_name(raw_model)
+    bucket = model_usage.setdefault(model, {
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "cacheReadInputTokens": 0,
+      "cacheCreationInputTokens": 0,
+    })
+    bucket["inputTokens"] += input_tokens
+    bucket["outputTokens"] += output_tokens
+    bucket["cacheReadInputTokens"] += cache_read
+    bucket["cacheCreationInputTokens"] += cache_write
+
+    total = input_tokens + output_tokens + cache_read + cache_write
+    turn_total += total
+    if day == today:
+      today_tokens_by_model[model] = today_tokens_by_model.get(model, 0) + total
+
+  # A turn that burned no tokens is not a prompt worth counting.
+  if not counted:
+    return
+
+  # One turn_completed is one prompt, however many models served it.
+  total_prompts += 1
+  total_sessions.add(session_key)
+  active_days.add(day)
+
+  if day in recent:
+    recent[day]["messageCount"] += turn_total
+
+  if day == today:
+    today_prompts += 1
+    today_sessions.add(session_key)
+    today_total_tokens += turn_total
+
+
+def session_files():
+  root = grok_home() / "sessions"
+  if not root.is_dir():
+    return []
+  cutoff = time.time() - SCAN_WINDOW_DAYS * 24 * 60 * 60
+  found = []
+  # sessions/<url-encoded-cwd>/<session-id>/updates.jsonl
+  for path in root.glob("*/*/updates.jsonl"):
+    try:
+      if path.stat().st_mtime >= cutoff:
+        found.append(path)
+    except OSError:
+      continue
+  return found
+
+
+def scan_sessions():
+  for path in session_files():
+    session_id = path.parent.name
+    try:
+      with path.open(errors="replace") as handle:
+        for index, raw in enumerate(handle):
+          if TURN_MARKER not in raw:
+            continue
+          try:
+            entry = json.loads(raw)
+          except Exception:
+            continue
+          params = entry.get("params") or {}
+          update = params.get("update") or {}
+          if not isinstance(update, dict) or update.get("sessionUpdate") != "turn_completed":
+            continue
+          usage = update.get("usage")
+          if not isinstance(usage, dict) or not usage:
+            continue
+
+          prompt_key = str(update.get("prompt_id") or "") or f"{path}:{index}"
+          if prompt_key in seen_prompts:
+            continue
+          seen_prompts.add(prompt_key)
+
+          meta = params.get("_meta") or {}
+          stamp = entry.get("timestamp") or meta.get("agentTimestampMs")
+          if stamp is None:
+            try:
+              stamp = path.stat().st_mtime
+            except OSError:
+              stamp = None
+          add_turn(local_day(stamp), str(params.get("sessionId") or session_id), usage)
+    except OSError:
+      continue
+
+
+def cache_root():
+  root = Path(os.environ.get("XDG_CACHE_HOME") or (Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root.mkdir(parents=True, exist_ok=True)
+  return root
+
+
+def scan_cache_paths():
+  digest = hashlib.sha1(str(grok_home()).encode("utf-8")).hexdigest()[:16]
+  root = cache_root()
+  return root / f"grok-scan-{digest}.json", root / f"grok-scan-{digest}.lock"
+
+
+def read_fresh_json(path, max_age_seconds):
+  if max_age_seconds <= 0 or not path.exists():
+    return None
+  try:
+    # A negative age means the mtime is in the future: the clock moved
+    # backwards since the write, so the cache's freshness cannot be trusted.
+    age = time.time() - path.stat().st_mtime
+    if 0 <= age <= max_age_seconds:
+      return json.loads(path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  return None
+
+
+def write_json(path, payload):
+  # A temp name unique to this writer, not derived from the target: several
+  # collectors can run at once, and a shared temp path means the second
+  # replace finds the first one's file already moved away.
+  handle_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+  tmp = Path(tmp_name)
+  try:
+    with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+      handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    # mkstemp opens at 0600; nothing in the cache is sensitive, so open it
+    # up to the usual 0644.
+    tmp.chmod(0o644)
+    tmp.replace(path)
+  except BaseException:
+    tmp.unlink(missing_ok=True)
+    raise
+
+
+# The cache payload is a versioned envelope around the local-stats dict, so a
+# corrupted or foreign-shaped file is a cache miss (rescan + rewrite) instead
+# of a crash or a garbage record.
+def read_cached_stats(cache_file, max_age_seconds):
+  cached = read_fresh_json(cache_file, max_age_seconds)
+  if not isinstance(cached, dict) or cached.get("schemaVersion") != 1:
+    return None
+  # today* fields only mean "today" on the day they were scanned. A cache
+  # from another local date (midnight passed, or the clock moved) is a miss,
+  # not merely old, whatever its mtime says.
+  if cached.get("scanDate") != today:
+    return None
+  stats = cached.get("stats")
+  if not isinstance(stats, dict):
+    return None
+  if not all(key in stats for key in ("todayPrompts", "todayTotalTokens", "recentDays", "activeDates", "modelUsage")):
+    return None
+  return stats
+
+
+def write_cached_stats(cache_file, stats):
+  try:
+    write_json(cache_file, {"schemaVersion": 1, "scanDate": today, "stats": stats})
+  except Exception as exc:
+    print(f"omarchy-agent-usage-grok: could not write usage cache ({exc})", file=sys.stderr)
+
+
+def local_stats():
+  """Snapshot the aggregated local usage into the record's stats dict."""
+  return {
+    "todayPrompts": today_prompts,
+    "todaySessions": len(today_sessions),
+    "todayTotalTokens": today_total_tokens,
+    "todayTokensByModel": today_tokens_by_model,
+    "recentDays": [recent[day] for day in recent_dates],
+    "totalPrompts": total_prompts,
+    "totalSessions": len(total_sessions),
+    # Days with any recorded usage, for the all-time "N days" summary. The
+    # dates travel too: merging snapshots from several machines needs their
+    # union, which a count alone cannot give.
+    "activeDays": len(active_days),
+    "activeDates": sorted(active_days),
+    "modelUsage": model_usage,
+  }
+
+
+def cached_local_stats(max_age):
+  """Local stats, with the cache as a pure optimization.
+
+  The cache must never take the collector down: any cache-layer failure
+  (unwritable cache root, lock errors, disk full) degrades to a direct scan
+  and a warning on stderr. The JSON record is the contract; the cache is not.
+  """
+  try:
+    return _cached_local_stats(max_age)
+  except Exception as exc:
+    print(f"omarchy-agent-usage-grok: cache unavailable ({exc}); scanning directly", file=sys.stderr)
+    scan_sessions()
+    return local_stats()
+
+
+def _cached_local_stats(max_age):
+  cache_file, lock_file = scan_cache_paths()
+
+  cached = read_cached_stats(cache_file, max_age)
+  if cached is not None:
+    return cached
+
+  with lock_file.open("w") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    cached = read_cached_stats(cache_file, max_age)
+    if cached is not None:
+      return cached
+    scan_sessions()
+    stats = local_stats()
+    write_cached_stats(cache_file, stats)
+    return stats
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  # --force rescans and rewrites the cache. --limits-only is kept for CLI
+  # compatibility with the panel's refreshLimits() call; this agent exposes
+  # no limits, so it only widens how long a scan may be reused.
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  args = parser.parse_args()
+
+  max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else SCAN_REUSE_SECONDS)
+  stats = cached_local_stats(max_age)
+
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": datetime.now(timezone.utc).isoformat(),
+    "ready": True,
+    "hasLocalStats": True,
+    "hasPromptStats": True,
+    # No endpoint to ask, so no allowance to draw and nothing to retry.
+    "limits": [],
+    "tierLabel": "",
+    "usageStatusText": "",
+    "authHelpText": AUTH_HELP,
+  }
+  record.update(stats)
+  print(json.dumps(record, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+  main()

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -55,10 +55,13 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `grok` | None: the CLI exposes no usage endpoint | native Grok CLI session files, one `turn_completed` update per prompt |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
-falls back to local stats only. A non-default Claude directory is honored via
-`CLAUDE_CONFIG_DIR`, Codex via `CODEX_HOME`. Fireworks reads
+falls back to local stats only. Grok has no endpoint to sign in to for usage,
+so its tab is local stats permanently: no limit meters, no plan line. A
+non-default Claude directory is honored via `CLAUDE_CONFIG_DIR`, Codex via
+`CODEX_HOME`, Grok via `GROK_HOME`. Fireworks reads
 `FIREWORKS_API_KEY` and `FIREWORKS_ACCOUNT_ID` first, then
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
@@ -144,7 +147,7 @@ when its stats are account-global rather than machine-local (Fireworks'
 billing API); those merge by taking the widest value instead of summing, so
 the same account synced from two machines is not counted twice.
 
-One caveat on "all-time": the Codex collector only reads native session files
-touched in the last 30 days, and Fireworks requests the last 30 days from its
-billing API, so their totals and day counts cover that window. Claude's cover
-every transcript still on disk.
+One caveat on "all-time": the Codex and Grok collectors only read native
+session files touched in the last 30 days, and Fireworks requests the last 30
+days from its billing API, so their totals and day counts cover that window.
+Claude's cover every transcript still on disk.

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -21,7 +21,8 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
-        "fireworks": { "enabled": true }
+        "fireworks": { "enabled": true },
+        "grok": { "enabled": true }
       },
       "refreshIntervalSec": 900,
       "syncMode": "Off",

--- a/test/shell.d/agent-usage-grok-scanner-test.sh
+++ b/test/shell.d/agent-usage-grok-scanner-test.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+GROK_HOME="$TEST_HOME/.grok"
+CACHE_HOME="$TEST_HOME/.cache"
+export TZ=UTC
+
+collect() {
+  HOME="$TEST_HOME" GROK_HOME="$GROK_HOME" XDG_CACHE_HOME="$CACHE_HOME" \
+    "$ROOT/bin/omarchy-agent-usage-grok" --force
+}
+
+# One turn_completed update, written the way the Grok CLI writes it. Callers
+# pass the day offset so fixtures land on a date the record can be asserted
+# against whenever the suite runs.
+turn() {
+  local session=$1 prompt=$2 days_ago=$3 model=$4 input=$5 output=$6 cache_read=$7
+  local stamp
+  stamp=$(date -d "$days_ago days ago" +%s)
+
+  jq -nc \
+    --arg session "$session" --arg prompt "$prompt" --arg model "$model" \
+    --argjson stamp "$stamp" --argjson input "$input" \
+    --argjson output "$output" --argjson cache_read "$cache_read" \
+    '{
+      timestamp: $stamp,
+      method: "_x.ai/session/update",
+      params: {
+        sessionId: $session,
+        update: {
+          sessionUpdate: "turn_completed",
+          prompt_id: $prompt,
+          usage: {
+            inputTokens: $input,
+            outputTokens: $output,
+            cachedReadTokens: $cache_read,
+            cacheCreationTokens: 0,
+            modelUsage: {
+              ($model): {
+                inputTokens: $input,
+                outputTokens: $output,
+                cachedReadTokens: $cache_read,
+                cacheCreationTokens: 0
+              }
+            }
+          }
+        }
+      }
+    }'
+}
+
+write_session() {
+  local session=$1
+  local dir="$GROK_HOME/sessions/%2Fhome%2Fdev/$session"
+
+  mkdir -p "$dir"
+  cat >"$dir/updates.jsonl"
+}
+
+# An empty ~/.grok must still print a valid record. The panel hides an agent
+# with no usage on its own, so the collector never needs to suppress itself.
+mkdir -p "$GROK_HOME"
+empty=$(collect)
+[[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.totalPrompts | tostring)' <<<"$empty") == "grok:true:0" ]] ||
+  fail "Grok collector prints a valid record with no sessions" "$empty"
+pass "Grok collector prints a valid record with no sessions"
+
+# Two turns today plus one six days back, so the weekly chart, the model
+# breakdown, and the today counters can all be checked at once.
+{
+  turn "session-a" "prompt-1" 0 "grok-4.6-build" 1000 100 600
+  turn "session-a" "prompt-2" 0 "grok-4.6-build" 500 50 200
+  turn "session-a" "prompt-3" 6 "grok-4.6" 300 30 100
+} | write_session "session-a"
+
+record=$(collect)
+
+# Cache-read and cache-creation tokens are reported inside inputTokens, so the
+# plain input bucket is what is left once they are removed: (1000-600) +
+# (500-200) = 700 for the build model, 300-100 = 200 for the other.
+[[ $(jq -r '.modelUsage["grok-4.6-build"] | "\(.inputTokens):\(.outputTokens):\(.cacheReadInputTokens)"' <<<"$record") == "700:150:800" ]] ||
+  fail "Grok collector splits overlapping token buckets" "$record"
+pass "Grok collector splits overlapping token buckets"
+
+[[ $(jq -r '.modelUsage["grok-4.6"].inputTokens' <<<"$record") == "200" ]] ||
+  fail "Grok collector keeps a second model in its own bucket" "$record"
+pass "Grok collector keeps a second model in its own bucket"
+
+# Today's two turns: (400+100+600) + (300+50+200) = 1650.
+[[ $(jq -r '"\(.todayPrompts):\(.todaySessions):\(.todayTotalTokens)"' <<<"$record") == "2:1:1650" ]] ||
+  fail "Grok collector counts today's prompts, sessions, and tokens" "$record"
+pass "Grok collector counts today's prompts, sessions, and tokens"
+
+[[ $(jq -r '.recentDays | length' <<<"$record") == "7" ]] &&
+  [[ $(jq -r '.recentDays[-1].messageCount' <<<"$record") == "1650" ]] &&
+  [[ $(jq -r '.recentDays[0].messageCount' <<<"$record") == "330" ]] ||
+  fail "Grok collector fills the seven-day chart" "$record"
+pass "Grok collector fills the seven-day chart"
+
+[[ $(jq -r '"\(.totalPrompts):\(.totalSessions):\(.activeDays)"' <<<"$record") == "3:1:2" ]] ||
+  fail "Grok collector totals prompts, sessions, and active days" "$record"
+pass "Grok collector totals prompts, sessions, and active days"
+
+# `grok --fork-session` replays a transcript under a new session id. The
+# shared turns carry their original prompt ids, so they must not be counted a
+# second time.
+{
+  turn "session-b" "prompt-1" 0 "grok-4.6-build" 1000 100 600
+  turn "session-b" "prompt-4" 0 "grok-4.6-build" 10 5 0
+} | write_session "session-b"
+
+forked=$(collect)
+[[ $(jq -r '"\(.totalPrompts):\(.todayTotalTokens)"' <<<"$forked") == "4:1665" ]] ||
+  fail "Grok collector counts a forked session's replayed turns once" "$forked"
+pass "Grok collector counts a forked session's replayed turns once"
+
+# A turn that switched models mid-flight is still one prompt.
+{
+  turn "session-c" "prompt-5" 0 "grok-4.6" 100 10 0 |
+    jq -c '.params.update.usage.modelUsage["grok-4.6-fast"] = {inputTokens: 20, outputTokens: 2, cachedReadTokens: 0, cacheCreationTokens: 0}'
+} | write_session "session-c"
+
+multi=$(collect)
+[[ $(jq -r '.totalPrompts' <<<"$multi") == "5" ]] &&
+  [[ $(jq -r '.modelUsage["grok-4.6-fast"].inputTokens' <<<"$multi") == "20" ]] ||
+  fail "Grok collector counts a multi-model turn as one prompt" "$multi"
+pass "Grok collector counts a multi-model turn as one prompt"
+
+# Sessions untouched for longer than the scan window are skipped, which is
+# what keeps a long-lived ~/.grok from being reread in full on every refresh.
+turn "session-old" "prompt-old" 45 "grok-4.6" 900 90 0 | write_session "session-old"
+touch -d "45 days ago" "$GROK_HOME/sessions/%2Fhome%2Fdev/session-old/updates.jsonl"
+
+windowed=$(collect)
+[[ $(jq -r '.totalPrompts' <<<"$windowed") == "5" ]] ||
+  fail "Grok collector skips sessions outside the scan window" "$windowed"
+pass "Grok collector skips sessions outside the scan window"
+
+# A malformed line must not take the scan down with it.
+printf 'not json at all\n{"params":{"update":{"sessionUpdate":"turn_completed"}}}\n' \
+  >>"$GROK_HOME/sessions/%2Fhome%2Fdev/session-c/updates.jsonl"
+
+survived=$(collect)
+[[ $(jq -r '.totalPrompts' <<<"$survived") == "5" ]] ||
+  fail "Grok collector survives malformed and usage-less lines" "$survived"
+pass "Grok collector survives malformed and usage-less lines"


### PR DESCRIPTION
Adds a `grok` collector to the agents panel, so the Grok CLI gets a tab
alongside Claude, Codex and the rest instead of silently missing from the bar
for anyone whose subscription is Grok.

## What it reads

Grok ships no usage or rate-limit endpoint — the CLI has no `usage`
subcommand and never exposes the account allowance — so every number comes
from the CLI's own session logs at
`~/.grok/sessions/<encoded-cwd>/<session-id>/updates.jsonl`, where one
`turn_completed` update is written per prompt carrying that turn's token
usage broken down by model.

That makes the record local-stats-only: `hasLocalStats` and `hasPromptStats`
are true, `limits` stays empty, and `tierLabel`/`usageStatusText` stay empty
so `heroMeta()` renders the neutral "Subscription" line rather than a warning
card. This is the same shape Claude's collector already falls back to when it
can't reach Anthropic's endpoint, so the panel needs no changes to draw it.

## Details worth a reviewer's eye

**Token buckets are de-overlapped.** Grok's counters nest:
`cachedReadTokens` and `cacheCreationTokens` are both counted *inside*
`inputTokens` (records satisfy `totalTokens == inputTokens + outputTokens`).
The panel wants four disjoint buckets, so plain input is what remains after
subtracting the two cache buckets. Reasoning tokens stay folded into output,
matching how the Codex collector treats them. Verified against hand-summed
raw turns.

**Forked sessions are deduped.** `grok --fork-session` replays prior turns
into the new session's log, so turns are deduped on `prompt_id` and a fork
doesn't inflate prompt counts or token totals.

**One prompt per turn.** A `turn_completed` served by more than one model
counts once as a prompt, with its tokens split across models in
`todayTokensByModel` / `modelUsage`.

**Scan cache**, mirroring the Codex collector: flock-guarded, atomic write,
`{schemaVersion, scanDate, stats}` envelope so today's counters don't survive
midnight, and it degrades to a direct scan on any cache failure. Without it
the widget rereads every session file on each refresh. `--force` bypasses it.
The scan window is 30 days by mtime, so "all time" carries the same caveat
the README already documents for the other scanners.

`GROK_HOME` is honored, the way the Codex collector honors `CODEX_HOME`.

## Not included: the icon

I deliberately did not add `shell/plugins/agents/assets/grok.svg` — I wasn't
going to approximate xAI's mark by hand and ship it. Grok falls back to the
default bar glyph, which the plugin already supports. Happy to add the real
asset if a maintainer wants to drop one in, or to take a patch on the branch.

## Tests

`test/shell.d/agent-usage-grok-scanner-test.sh` — 10 assertions, all passing:
valid record with no sessions present, the bucket split, a second model in
its own bucket, today's prompts/sessions/tokens, the seven-day chart,
totals/active days, forked-session dedup, a multi-model turn counting as one
prompt, the scan-window skip, and surviving malformed lines. Fixtures are
built with `jq -nc` under `TZ=UTC` with `GROK_HOME`/`XDG_CACHE_HOME`
redirected, so nothing touches the runner's real state.

`./test/all` shows no new failures.
