### PR TITLE
Give visudo an editor that Omarchy actually installs

### DIFF
--- a/etc/sudoers.d/omarchy-editor
+++ b/etc/sudoers.d/omarchy-editor
@@ -1,0 +1,13 @@
+# Omarchy installs nvim and ships no vi, vim, or nano, but sudo's built-in
+# fallback is still the compiled-in /usr/bin/vi. The EDITOR and SUDO_EDITOR
+# exports live in default/bash/envs, which is the login user's shell, so a root
+# shell carries neither -- and `visudo` there died with "no editor found
+# (editor path = /usr/bin/vi)" instead of opening an editor. Name editors this
+# system actually has.
+#
+# env_editor is on by default, so SUDO_EDITOR, VISUAL, and EDITOR still win
+# wherever they are set and a user who picked nano keeps nano. This list is
+# only the fallback for shells carrying none of them. Each entry is
+# fully-qualified because sudo ignores a bare command name here, and sudo walks
+# the list in order, skipping any that is not installed.
+Defaults editor=/usr/bin/nvim:/usr/bin/vim:/usr/bin/nano:/usr/bin/vi

--- a/test/shell.d/sudoers-editor-test.sh
+++ b/test/shell.d/sudoers-editor-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+sudoers_file="$ROOT/etc/sudoers.d/omarchy-editor"
+packages="$ROOT/install/omarchy-base.packages"
+
+# One Defaults setting, matched whole. This file exists to give visudo a
+# fallback editor, so anything else landing in it -- a grant especially -- is a
+# change of purpose rather than a tweak of this one.
+settings=$(grep -vE '^[[:space:]]*(#|$)' "$sudoers_file")
+[[ $settings == "Defaults editor="* ]] ||
+  fail "editor sudoers file carries exactly the editor fallback and nothing else" "got: $settings"
+(($(grep -c . <<<"$settings") == 1)) ||
+  fail "editor sudoers file carries exactly one setting" "got: $settings"
+
+if command -v visudo >/dev/null; then
+  visudo -cf "$sudoers_file" >/dev/null || fail "editor sudoers setting parses"
+fi
+
+pass "editor sudoers file sets nothing but the fallback editor"
+
+# sudo takes a colon-separated list here and skips entries that are not
+# installed, but only matches a fully-qualified path -- a bare "nvim" would
+# parse and then never match, putting the fallback back at /usr/bin/vi.
+editors=${settings#Defaults editor=}
+IFS=: read -r -a editor_paths <<<"$editors"
+((${#editor_paths[@]} > 0)) || fail "editor fallback names at least one editor"
+
+for editor in "${editor_paths[@]}"; do
+  [[ $editor == /* ]] ||
+    fail "editor fallback names $editor by absolute path, which is all sudo matches"
+done
+
+# The whole point of the fallback is that a root shell with no EDITOR still
+# reaches an editor that is on the box. Only the first entry is guaranteed to
+# be there, so it has to be one the base install pulls in.
+[[ ${editor_paths[0]} == "/usr/bin/nvim" ]] ||
+  fail "editor fallback tries nvim first" "got: ${editor_paths[0]}"
+grep -Fxq nvim "$packages" ||
+  fail "the first editor in the fallback is a package the base install carries"
+
+pass "editor fallback names installed editors by absolute path, nvim first"


### PR DESCRIPTION
## The bug

On a stock Omarchy, `visudo` from a root shell cannot open an editor:

```
[root@omarchy ~]# visudo
visudo: no editor found (editor path = /usr/bin/vi)
```

Omarchy installs `nvim` (`install/omarchy-base.packages`) and ships no `vi`, `vim`, or `nano`, but sudo's compiled-in fallback editor is still `/usr/bin/vi`:

```
$ for e in vi vim nvim nano; do printf '%s: ' $e; command -v $e || echo MISSING; done
vi: MISSING
vim: MISSING
nvim: /usr/bin/nvim
nano: MISSING
```

`EDITOR`/`SUDO_EDITOR` are exported from `default/bash/envs`, which is the login user's shell. A root shell carries neither, so `visudo` falls straight through to the missing `/usr/bin/vi`. `sudoedit` fails the same way.

## The fix

A new `etc/sudoers.d/omarchy-editor` naming editors this system actually has:

```
Defaults editor=/usr/bin/nvim:/usr/bin/vim:/usr/bin/nano:/usr/bin/vi
```

`env_editor` is on by default in this sudo build, so a `SUDO_EDITOR`, `VISUAL`, or `EDITOR` that *is* set still wins — a user who picked nano keeps nano. The list is only the fallback for shells carrying none of them. Entries are fully-qualified because sudo ignores a bare command name here, and sudo walks the list in order, skipping any that is not installed.

No PKGBUILD change is needed: `omarchy-settings` already does `cp -a etc/. "$pkgdir/etc/"` and chmods `etc/sudoers.d/*` to `0440`.

## Verified on a real Omarchy machine (4.0.0.alpha, sudo 1.9.17p2)

Before, as root:

```
EDITOR=[] VISUAL=[] SUDO_EDITOR=[]
visudo: no editor found (editor path = /usr/bin/vi)
```

After installing the drop-in, as root with `EDITOR`/`VISUAL`/`SUDO_EDITOR` all unset:

```
--- editor processes while visudo is open ---
/usr/bin/nvim -- /etc/sudoers.tmp
```

An editor named in the environment still wins (stand-in for nano, which is not installed):

```
--- SUDO_EDITOR set ---   FAKE-NANO OPENED: -- /etc/sudoers.tmp
--- EDITOR set ---        FAKE-NANO OPENED: -- /etc/sudoers.tmp
--- VISUAL set ---        FAKE-NANO OPENED: -- /etc/sudoers.tmp
```

`sudoedit` as root is fixed by the same drop-in:

```
/usr/bin/nvim /var/tmp/hostname.1rh8f1XQ
```

The everyday `sudo visudo` path is unchanged — `SUDO_EDITOR` survives `env_reset` and resolves through `omarchy-launch-editor`:

```
dom shell: EDITOR=[omarchy-launch-editor --inline] SUDO_EDITOR=[omarchy-launch-editor --inline]
nvim -- /etc/sudoers.tmp
```

And the whole tree still parses:

```
$ sudo visudo -c
/etc/sudoers: parsed OK
/etc/sudoers.d/omarchy-editor: parsed OK
...
```

## Tests

Adds `test/shell.d/sudoers-editor-test.sh`, following `browser-policy-sudoers-test.sh`: the file carries exactly one `Defaults editor=` setting and nothing else, it parses under `visudo -cf`, every entry is an absolute path (a bare `nvim` would parse and then never match, silently restoring the `/usr/bin/vi` fallback), and the first entry is an editor the base install actually carries.

`test/shell` on the target machine: 216 of 222 files pass. The 6 failures (`ascii`, `branding-about-animation`, `config`, `legacy-power-udev-rules-migration`, `snapper`, `unowned-system-paths`) fail identically on a clean checkout of `quattro` with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
