### PR TITLE
Keep the sudo editor on one that blocks

### DIFF
--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -1,16 +1,29 @@
 #!/bin/bash
 
 # omarchy:summary=Launch the default editor selected via Omarchy defaults.
-# omarchy:args=[--inline] <path>
+# omarchy:args=[--inline|--sudo] <path>
 
 default_editor="$HOME/.local/state/omarchy/defaults/editor"
 
-if [[ ${1:-} == "--inline" ]]; then
-  inline=true
+# --inline runs a terminal editor in the caller's terminal rather than opening
+# one for it. --sudo is what SUDO_EDITOR points at: sudo hands the editor a
+# temporary copy and keeps whatever is on disk once the editor exits, so an
+# editor that detaches reads as "closed without changing anything" and the edit
+# is discarded with no error. That mode stays on a terminal editor, which also
+# keeps a graphical editor from being run as root.
+case "${1:-}" in
+--inline)
+  mode="inline"
   shift
-else
-  inline=false
-fi
+  ;;
+--sudo)
+  mode="sudo"
+  shift
+  ;;
+*)
+  mode="windowed"
+  ;;
+esac
 
 if [[ -f $default_editor ]]; then
   read -r editor <"$default_editor"
@@ -22,13 +35,17 @@ omarchy-cmd-present "$editor" || editor="nvim"
 
 case "${editor##*/}" in
 nvim | vim | nano | micro | hx | helix | fresh)
-  if [[ $inline == "true" ]]; then
-    exec "$editor" "$@"
-  else
+  if [[ $mode == "windowed" ]]; then
     exec omarchy-launch-tui "$editor" "$@"
+  else
+    exec "$editor" "$@"
   fi
   ;;
 *)
-  exec setsid uwsm-app -- "$editor" "$@"
+  if [[ $mode == "sudo" ]]; then
+    exec nvim "$@"
+  else
+    exec setsid uwsm-app -- "$editor" "$@"
+  fi
   ;;
 esac

--- a/default/bash/envs
+++ b/default/bash/envs
@@ -1,6 +1,17 @@
 # Editor used by CLI
 export EDITOR="${EDITOR:-omarchy-launch-editor --inline}"
-export SUDO_EDITOR="$EDITOR"
+
+# sudo keeps whatever is on disk once the editor exits, so an editor that
+# detaches -- every graphical one omarchy-default-editor offers -- reads as
+# "closed without changing anything" and sudoedit and visudo throw the edit
+# away with no error. Send the Omarchy default through --sudo, which stays on a
+# terminal editor. An EDITOR the user set themselves is left to them, and an
+# explicit SUDO_EDITOR still wins over both.
+if [[ $EDITOR == "omarchy-launch-editor --inline" ]]; then
+  export SUDO_EDITOR="${SUDO_EDITOR:-omarchy-launch-editor --sudo}"
+else
+  export SUDO_EDITOR="${SUDO_EDITOR:-$EDITOR}"
+fi
 
 # Used by terminal programs (like gh) to open URLs detached from the terminal
 # process tree. Shell-scoped on purpose: exporting BROWSER session-wide makes

--- a/test/shell.d/editor-env-test.sh
+++ b/test/shell.d/editor-env-test.sh
@@ -14,6 +14,18 @@ editor=$(EDITOR=helix bash -c 'source "$1"; printf "%s" "$EDITOR"' bash "$envs")
 [[ $editor == "helix" ]] || fail "bash env preserves the inherited editor" "actual: $editor"
 pass "bash env preserves the inherited editor"
 
+# sudo keeps whatever is on disk once the editor exits, so the sudo path has to
+# be an editor that blocks. --inline detaches a graphical editor, which reads
+# as "closed without changing anything" and loses the edit, so the Omarchy
+# default routes through --sudo instead.
 sudo_editor=$(env -u EDITOR -u SUDO_EDITOR bash -c 'source "$1"; printf "%s" "$SUDO_EDITOR"' bash "$envs")
-[[ $sudo_editor == "omarchy-launch-editor --inline" ]] || fail "sudo uses the default editor" "actual: $sudo_editor"
-pass "sudo uses the default editor"
+[[ $sudo_editor == "omarchy-launch-editor --sudo" ]] || fail "sudo gets an editor that blocks" "actual: $sudo_editor"
+pass "sudo gets an editor that blocks until the edit is done"
+
+sudo_editor=$(env -u SUDO_EDITOR EDITOR=helix bash -c 'source "$1"; printf "%s" "$SUDO_EDITOR"' bash "$envs")
+[[ $sudo_editor == "helix" ]] || fail "sudo follows an editor the user set" "actual: $sudo_editor"
+pass "sudo follows an editor the user set"
+
+sudo_editor=$(env -u EDITOR SUDO_EDITOR=nano bash -c 'source "$1"; printf "%s" "$SUDO_EDITOR"' bash "$envs")
+[[ $sudo_editor == "nano" ]] || fail "an explicit sudo editor wins" "actual: $sudo_editor"
+pass "an explicit sudo editor wins"

--- a/test/shell.d/launch-editor-sudo-test.sh
+++ b/test/shell.d/launch-editor-sudo-test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+launcher="$ROOT/bin/omarchy-launch-editor"
+chooser="$ROOT/bin/omarchy-default-editor"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+home="$test_tmp/home"
+mkdir -p "$stub_bin" "$home/.local/state/omarchy/defaults"
+
+# Every command the launcher can hand the file to logs its own argv, so the
+# assertions read the process that would actually have run.
+for stub in nvim vim nano micro hx helix fresh code cursor zeditor sublime_text \
+  emacs setsid uwsm-app omarchy-launch-tui; do
+  cat >"$stub_bin/$stub" <<SH
+#!/bin/bash
+printf '%s %s\n' "$stub" "\$*" >>"\$LAUNCH_LOG"
+SH
+  chmod +x "$stub_bin/$stub"
+done
+
+# Without this the launcher falls back to nvim for every editor and the run
+# proves nothing about the editor that was chosen.
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$stub_bin/omarchy-cmd-present"
+
+launch_with() {
+  local editor="$1"
+  shift
+
+  printf '%s\n' "$editor" >"$home/.local/state/omarchy/defaults/editor"
+  : >"$test_tmp/log"
+  LAUNCH_LOG="$test_tmp/log" HOME="$home" PATH="$stub_bin:$PATH" \
+    bash "$launcher" "$@" /etc/sudoers.tmp >/dev/null 2>&1 || true
+  cat "$test_tmp/log"
+}
+
+# The editors the menu can actually put in that state file, read off the
+# chooser so an editor added there is covered here without a second edit.
+mapfile -t editors < <(grep -oE 'editor="[a-z_]+"' "$chooser" | cut -d'"' -f2 | sort -u)
+((${#editors[@]} >= 8)) ||
+  fail "the chooser's editor list was read" "got: ${editors[*]}"
+
+for editor in "${editors[@]}"; do
+  launched=$(launch_with "$editor" --sudo)
+
+  [[ $launched == *"/etc/sudoers.tmp"* ]] ||
+    fail "--sudo hands $editor the file to edit" "got: $launched"
+
+  # setsid and uwsm-app both return before the editor is done, which is what
+  # loses the edit. Neither belongs anywhere on the sudo path.
+  [[ $launched != *"setsid"* && $launched != *"uwsm-app"* ]] ||
+    fail "--sudo does not detach the editor for $editor" "got: $launched"
+
+  # omarchy-launch-tui opens a separate terminal window and returns, so it is
+  # no better here than detaching outright.
+  [[ $launched != *"omarchy-launch-tui"* ]] ||
+    fail "--sudo does not hand $editor to a separate terminal" "got: $launched"
+done
+
+pass "--sudo blocks for every editor the chooser offers"
+
+# The windowed and inline paths are unchanged: a graphical editor still gets
+# detached when it is not sudo asking.
+windowed=$(launch_with code)
+[[ $windowed == "setsid uwsm-app -- code /etc/sudoers.tmp" ]] ||
+  fail "a graphical editor is still detached when launched windowed" "got: $windowed"
+
+windowed=$(launch_with nvim)
+[[ $windowed == "omarchy-launch-tui nvim /etc/sudoers.tmp" ]] ||
+  fail "a terminal editor is still opened in a terminal when launched windowed" "got: $windowed"
+
+inline=$(launch_with nvim --inline)
+[[ $inline == "nvim /etc/sudoers.tmp" ]] ||
+  fail "--inline still runs a terminal editor in place" "got: $inline"
+
+pass "the windowed and inline paths are unchanged"


### PR DESCRIPTION
## The bug

`sudo visudo` and `sudoedit` silently throw away your edits if your Omarchy default editor is a graphical one.

sudo never lets the editor touch the real file. It copies the file to a temp path, runs the editor, **waits for the editor to exit**, then keeps whatever is on disk. That last step only works if the editor command stays running until you close it.

`default/bash/envs` sets `SUDO_EDITOR="$EDITOR"`, which is `omarchy-launch-editor --inline`. That script only runs inline for `nvim|vim|nano|micro|hx|helix|fresh`; everything else takes the `*)` branch and runs `exec setsid uwsm-app -- "$editor"` — detached, returns instantly. So visudo sees an editor that closed without changing anything, prints `unchanged`, and deletes the temp copy. The editor window then opens on a file that is already gone.

Of the eight editors `omarchy default editor` offers, **five detach**: `code`, `cursor`, `zed`, `sublime_text`, `emacs`. Only `nvim`, `vim`, `helix` block — and since `nvim` is the default, the bug stays hidden.

Measured on a 4.0.0.alpha machine, `visudo` on a temp sudoers file with a stubbed `uwsm-app`:

```
===== default editor = nvim =====
(blocks correctly — killed at the 6s timeout)

===== default editor = code =====
visudo: t.sudoers.tmp unchanged        elapsed=0s
uwsm-app called: code -- t.sudoers.tmp
```

Zero seconds, `unchanged`, edit gone.

## The fix

A `--sudo` mode on `omarchy-launch-editor` that never detaches: a terminal editor runs in place, anything else falls back to `nvim`. Falling back beats honouring the choice here — the alternative is running a full graphical IDE as root over an elevated Wayland connection.

`default/bash/envs` then points `SUDO_EDITOR` at it, but only when Omarchy is the one supplying `EDITOR`:

```bash
if [[ $EDITOR == "omarchy-launch-editor --inline" ]]; then
  export SUDO_EDITOR="${SUDO_EDITOR:-omarchy-launch-editor --sudo}"
else
  export SUDO_EDITOR="${SUDO_EDITOR:-$EDITOR}"
fi
```

An `EDITOR` the user exported themselves is left to them, and an explicit `SUDO_EDITOR` still wins over both. The `--inline` and windowed paths are untouched, so normal editor launching is unchanged.

## Verified

Same scenario as the repro — default editor `code`, `SUDO_EDITOR` taken from the real `default/bash/envs`:

```
SUDO_EDITOR=[omarchy-launch-editor --sudo]
Nvim: Caught deadly signal 'SIGTERM'
elapsed=6s
```

It now blocks for the full timeout and had to be killed, and `uwsm-app` is never called. Before, the same run finished in 0s with the edit discarded.

## Tests

- `test/shell.d/launch-editor-sudo-test.sh` (new) — reads the editor list off `omarchy-default-editor` so an editor added there is covered without a second edit, and asserts `--sudo` never reaches `setsid`, `uwsm-app`, or `omarchy-launch-tui` (a separate terminal window returns just as early). Also pins the windowed and `--inline` paths so this does not change ordinary launching.
- `test/shell.d/editor-env-test.sh` — updated for the new `SUDO_EDITOR`, plus cases for a user-set `EDITOR` and an explicit `SUDO_EDITOR`.

`test/cli` passes in full. `test/shell`: 216 of 222 files pass; the 6 failures (`ascii`, `branding-about-animation`, `config`, `legacy-power-udev-rules-migration`, `snapper`, `unowned-system-paths`) fail identically on a clean `quattro`.

Independent of #9500, which fixes a different editor bug (`visudo` as root finding no editor at all). No file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)