### PR TITLE
Clear setgid when securing Windows VM mounts

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,7 +580,9 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  # The container can leave /shared setgid. GNU chmod preserves setgid on
+  # directories unless the mode starts with =, so clear all inherited bits.
+  chmod =0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
@@ -1015,7 +1017,7 @@ prepare_user_mount_sources() {
     echo "omarchy-windows-vm: storage and shared must be different directories" >&2
     return 1
   }
-  chmod 0700 -- "$storage" "$shared"
+  chmod =0700 -- "$storage" "$shared"
 }
 
 storage_space_path() {

--- a/test/shell.d/windows-vm-compose-test.sh
+++ b/test/shell.d/windows-vm-compose-test.sh
@@ -53,7 +53,10 @@ reset_case() {
 }
 
 # Fixed protected anchors consume the pinned source inodes.
+mkdir -p "$HOME/.windows" "$HOME/Windows"
+chmod 02755 "$HOME/Windows"
 prepare_user_mount_sources
+[[ $(stat -Lc '%a' "$HOME/Windows") == 700 ]] || fail "user preflight preserved the container's setgid bit"
 write 4G 2 64G alice s3cret Europe/Copenhagen
 resolve_caller
 [[ -f $COMPOSE ]] || fail "writer produced a compose file"

--- a/test/shell.d/windows-vm-mount-boundary-test.sh
+++ b/test/shell.d/windows-vm-mount-boundary-test.sh
@@ -87,11 +87,13 @@ TEST_PASSWD_HOME=/home/alice
 resolve_caller || fail "valid root PKEXEC_UID/home boundary was rejected"
 pass "root dispatch rejects missing/invalid uid, passwd, owner, symlink, and writable-parent boundaries without mutation"
 
-# Put each familiar source on its own filesystem. Both start with legacy 0755
-# permissions and world-readable payloads to prove migration hardens the leaves.
+# Put each familiar source on its own filesystem. Both start world-readable,
+# and shared is setgid as the VM container can leave it, to prove migration
+# clears inherited special bits while hardening the leaves.
 mkdir /home/storage-target /home/shared-target
 mount -t tmpfs -o uid=1000,gid=1000,mode=0755,size=3g storage-test /home/storage-target
 mount -t tmpfs -o uid=1000,gid=1000,mode=0755,size=64m shared-test /home/shared-target
+chmod 02755 /home/shared-target
 ln -s /home/storage-target /home/alice/.windows
 ln -s /home/shared-target /home/alice/Windows
 chown -h 1000:1000 /home/alice/.windows /home/alice/Windows


### PR DESCRIPTION
Fix protected-mount setup for existing Windows VM shared directories carrying the setgid bit.

GNU `chmod 0700` preserves setgid on directories. When the shared directory is mode `2700`, the launcher therefore reads it back as `2700`, rejects it because it is not exactly `700`, and aborts before starting the VM or FreeRDP.

Use `chmod =0700` during both user preflight and privileged mount preparation so inherited special bits are explicitly cleared.

Add regression coverage for setgid shared directories in the compose and privileged mount-boundary suites.

Tests:

- `bash test/shell.d/windows-vm-compose-test.sh`
- `bash test/shell.d/windows-vm-mount-boundary-test.sh`
- `OMARCHY_PKGS_PATH=/tmp/omarchy-pkgs-codex ./test/all`
