### PR TITLE
Keep SSH setup from disabling passwords on a writable home

### DIFF
--- a/bin/omarchy-setup-security-sshd
+++ b/bin/omarchy-setup-security-sshd
@@ -148,9 +148,22 @@ authorize_pasted_key() {
 disable_password_auth() {
   local config=/etc/ssh/sshd_config.d/10-omarchy-hardening.conf
   local effective_config
+  local home_mode
 
   if [[ ! -s $AUTHORIZED_KEYS ]]; then
     echo -e "\e[31mCannot disable SSH password authentication without an authorized key.\e[0m" >&2
+    return 1
+  fi
+
+  # Under StrictModes, sshd's default, a group- or world-writable home
+  # directory makes sshd ignore authorized_keys. ~/.ssh and the keys file
+  # are tightened in authorize_key; the home directory is not ours to change.
+  home_mode=$(stat -c '%a' "$HOME" 2>/dev/null) || {
+    echo -e "\e[31mCannot disable SSH password authentication: could not inspect the permissions on $HOME.\e[0m" >&2
+    return 1
+  }
+  if (( 8#$home_mode & 8#022 )); then
+    echo -e "\e[31mCannot disable SSH password authentication: $HOME is group- or world-writable, so sshd would ignore the authorized key.\e[0m" >&2
     return 1
   fi
 

--- a/test/shell.d/setup-security-sshd-test.sh
+++ b/test/shell.d/setup-security-sshd-test.sh
@@ -70,6 +70,9 @@ run_setup() {
   local root="$test_dir/$scenario/root"
 
   mkdir -p "$home" "$root"
+  if [[ -n ${HOME_MODE:-} ]]; then
+    chmod "$HOME_MODE" "$home"
+  fi
   : >"$test_dir/$scenario.calls"
 
   HOME="$home" TEST_ROOT="$root" CALL_LOG="$test_dir/$scenario.calls" \
@@ -115,3 +118,18 @@ fi
 ! grep -q "Password logins are off" "$test_dir/invalid.output" ||
   fail "SSH setup must not claim rejected hardening succeeded"
 pass "SSH setup fails safely when sshd rejects the config"
+
+# StrictModes makes sshd ignore authorized_keys under a group-writable home,
+# so disabling passwords would leave SSH with neither passwords nor keys.
+if HOME_MODE=775 run_setup loose-home >"$test_dir/loose-home.output" 2>&1; then
+  fail "SSH setup must fail when the home directory is group-writable"
+fi
+[[ ! -e $test_dir/loose-home/root/etc/ssh/sshd_config.d/10-omarchy-hardening.conf ]] ||
+  fail "SSH setup must not disable passwords when sshd would ignore the key"
+! grep -qF "systemctl reload sshd.service" "$test_dir/loose-home.calls" ||
+  fail "SSH setup must not reload hardening when the home directory is group-writable"
+! grep -q "Password logins are off" "$test_dir/loose-home.output" ||
+  fail "SSH setup must not claim hardening succeeded under a group-writable home"
+grep -q "group- or world-writable" "$test_dir/loose-home.output" ||
+  fail "SSH setup explains why it refused to disable passwords"
+pass "SSH setup leaves passwords on when the home directory is group-writable"


### PR DESCRIPTION
## Why

OpenSSH StrictModes is on by default. When `$HOME` is group-writable or world-writable, sshd ignores `authorized_keys`.

`omarchy-setup-security-sshd` already runs `chmod 700` on `~/.ssh` and `chmod 600` on the keys file. It then writes `PasswordAuthentication no` to `/etc/ssh/sshd_config.d/10-omarchy-hardening.conf` and prints that password logins are off. If `$HOME` is mode `775` or `777`, that write closes the only login sshd still accepted. New SSH sessions get neither a key nor a password.

`migrations/1788124236.sh` already refuses to harden in that case. The skip text tells you to run `omarchy-setup-security-sshd`. That command still writes the drop-in.

The patch adds the same home-mode check to `disable_password_auth`.

## Scope

`bin/omarchy-setup-security-sshd`, `disable_password_auth` only.

After the empty-key return, the function stats `$HOME`. If `stat` fails, the function returns 1. If the mode has group-write or other-write (`8#022`), the function returns 1. It does not write `10-omarchy-hardening.conf` and does not reload sshd.

`test/shell.d/setup-security-sshd-test.sh` adds a `HOME_MODE` hook on `run_setup` and a `775` case named `loose-home`. That case must fail the command, leave the drop-in unwritten, skip `systemctl reload sshd.service`, and print the writable-home error.

This PR does not chmod `$HOME`. It does not check ownership or ACLs. It does not include the rewrite in https://github.com/omacom/omarchy/pull/9463 that proves key-only access before it starts sshd.

## Tradeoffs

If the function returns 1, sshd stays enabled and port 22 stays open. Password logins stay on. The authorized key stays in place and StrictModes still ignores it. That is the machine's prior state. A chmod of `$HOME` would make the key work, but the home directory is not this command's to change. The migration made the same call.

A `700` or `755` home still hardens. Those are the modes Arch `HOME_MODE` and a typical umask create.

## Blast Radius

The check runs for every `omarchy-setup-security-sshd` invocation, including the Setup menu and the `--key` or `--gh-keys` flags.

On a default Omarchy install `$HOME` is `700`. Mode `755` is also safe. The new return fires only when `$HOME` has group-write or world-write. A user at the desktop still has local login. The unattended flags are the case where a false "passwords are off" line matters more.

The predicate matches the migration. A `775` home that the migration already skips now gets the same refusal from the command the skip text names.

## Verification

Ran `./test/shell.d/setup-security-sshd-test.sh` on `af887538`. All five cases passed, including `SSH setup leaves passwords on when the home directory is group-writable`.