### PR TITLE
Simplify DaVinci Resolve window rules

### DIFF
--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -8,4 +8,6 @@ o.window(".*[Rr]esolve.*", {
   opacity = "1 1",
 })
 
-o.window({ class = ".*[Rr]esolve.*", title = "^DaVinci Resolve( Studio)? - .+$" }, { fullscreen = true })
+-- Maximized keeps the bar clear of Resolve's menu without fullscreen blanketing
+-- the workspace, so other windows there can still be raised above it.
+o.window({ class = ".*[Rr]esolve.*", title = "^DaVinci Resolve( Studio)? - .+$" }, { maximize = true })

--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -8,6 +8,11 @@ o.window(".*[Rr]esolve.*", {
   opacity = "1 1",
 })
 
--- Maximized keeps the bar clear of Resolve's menu without fullscreen blanketing
--- the workspace, so other windows there can still be raised above it.
+-- Maximize rather than fullscreen: the bar still clears Resolve's menu, but
+-- other windows on the workspace can be raised above it.
 o.window({ class = ".*[Rr]esolve.*", title = "^DaVinci Resolve( Studio)? - .+$" }, { maximize = true })
+
+-- Resolve is XWayland-only, so Hyprland honours the geometry its dialogs ask
+-- for: undersized file pickers on HiDPI, off-screen on mixed-scale layouts.
+o.window({ class = ".*[Rr]esolve.*", title = "^(Open|Save As|Find Directory|Project Media Location)$" }, { tag = "+floating-window" })
+o.window({ class = ".*[Rr]esolve.*", title = "^Create New Project$" }, { center = true })

--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -2,7 +2,6 @@
 -- translucency distorts colour-critical grading work.
 o.window(".*[Rr]esolve.*", {
   float = true,
-  stay_focused = true,
   -- Prevent modal dialog pointer warps when focus follows the mouse.
   no_follow_mouse = true,
   tag = "-default-opacity",
@@ -10,5 +9,3 @@ o.window(".*[Rr]esolve.*", {
 })
 
 o.window({ class = ".*[Rr]esolve.*", title = "^DaVinci Resolve( Studio)? - .+$" }, { fullscreen = true })
--- Resolve exposes the Voiceover panel under the generic "Dialog" title.
-o.window({ class = ".*[Rr]esolve.*", title = "^(DaVinci Resolve( Studio)? - .+|Project Manager|Preferences|Find Directory|Dialog)$" }, { stay_focused = false })


### PR DESCRIPTION
`stay_focused = true` on every Resolve window has needed its release allowlist extended three times (Project Manager, Preferences/Find Directory, Dialog), and any dialog not on it still blocks the screenshot layer's pointer input and fights sibling dialogs for focus. It was added in fb564e3a to keep dialogs usable when the main window is clicked, but that is already covered without it: Hyprland keeps floating dialogs visible above the maximized main window, and when a modal's parent is clicked Qt re-activates the modal and Hyprland re-raises it. `no_follow_mouse` (#6919) handles the hover case. Drop it and the allowlist.

Two dialog fixes ride along as separate commits:

- **Maximize the main window instead of fullscreening it.** The bar still clears Resolve's menu, but other windows on the workspace can be raised above it.
- **Size and centre Resolve's dialogs.** Resolve is XWayland-only, so Hyprland places its dialogs at the geometry they request: the Qt file pickers open undersized on HiDPI and "Create New Project" can land off-screen on mixed-scale layouts. Give the pickers the standard `floating-window` treatment and centre Create New Project.

Running as local overrides on Omarchy 4.0.1 / Hyprland 0.56.2 / Resolve Studio 21.0.4 on a mixed 1.6×/2× two-monitor layout. Verified: Preferences stays usable and on top when the main window is clicked, Super+Shift+S works with a dialog open, file pickers open at the standard size, Create New Project opens on screen and above the Project Manager. `./test/cli` passes.

Related: #5887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNE3nM4zgeFoGwEABc7hEF
