### PR TITLE
Refresh the bar clock on wake so it does not sit stale after suspend

### DIFF
--- a/bin/omarchy-system-wake
+++ b/bin/omarchy-system-wake
@@ -8,3 +8,10 @@
 omarchy-brightness-display on
 omarchy-brightness-keyboard restore
 omarchy-hyprland-monitor-clamshell >/dev/null 2>&1 || true
+
+# The bar clock ticks on a monotonic timer, which does not advance while the
+# machine is suspended — after resume the next tick can be up to a minute
+# late, leaving a stale label (omarchy issue #7608). The wake path runs this
+# script on unlock and on idle-wake, so nudge the clock to recompute now.
+# Best effort: the shell is not always running.
+omarchy-shell -q omarchy.clock refresh >/dev/null 2>&1 || true

--- a/test/shell.d/system-wake-test.sh
+++ b/test/shell.d/system-wake-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# omarchy-system-wake runs on every wake path (unlock and idle-wake). The bar
+# clock ticks on a monotonic timer that does not advance during suspend, so
+# after resume its label can stay stale for up to a minute (issue #7608). The
+# wake script must nudge the clock over shell IPC to recompute immediately.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+SHELL_LOG="$TMPDIR/omarchy-shell.log"
+BRIGHTNESS_LOG="$TMPDIR/brightness.log"
+
+cat >"$TMPDIR/bin/omarchy-shell" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_SHELL_LOG"
+SH
+
+# The wake script restores display and keyboard brightness; stub those so the
+# test only checks the clock nudge.
+cat >"$TMPDIR/bin/omarchy-brightness-display" <<'SH'
+#!/bin/bash
+printf 'display %s\n' "$*" >>"$BRIGHTNESS_LOG"
+SH
+
+cat >"$TMPDIR/bin/omarchy-brightness-keyboard" <<'SH'
+#!/bin/bash
+printf 'keyboard %s\n' "$*" >>"$BRIGHTNESS_LOG"
+SH
+
+chmod +x \
+  "$TMPDIR/bin/omarchy-shell" \
+  "$TMPDIR/bin/omarchy-brightness-display" \
+  "$TMPDIR/bin/omarchy-brightness-keyboard"
+
+PATH="$TMPDIR/bin:$PATH" \
+OMARCHY_SHELL_LOG="$SHELL_LOG" \
+BRIGHTNESS_LOG="$BRIGHTNESS_LOG" \
+  "$ROOT/bin/omarchy-system-wake" >/dev/null 2>&1 || true
+
+grep -Fqx -- '-q omarchy.clock refresh' "$SHELL_LOG" \
+  || fail "system wake refreshes the bar clock over shell IPC"
+pass "system wake refreshes the bar clock over shell IPC"
+
+grep -Fq -- 'display on' "$BRIGHTNESS_LOG" \
+  || fail "system wake still restores the display"
+pass "system wake still restores the display"


### PR DESCRIPTION
Fixes #7608.

## Problem

After waking from suspend (and unlocking), the top bar date/time stays frozen at the pre-sleep values for 30–60+ seconds before eventually updating.

Root cause: the clock widget ticks off a monotonic timer (`SystemClock`). Linux monotonic time does not advance while the machine is suspended, so a tick deadline armed just before sleep only fires up to a full interval after resume — for the minute-precision clock that is up to 60s of a stale label.

## Change

`omarchy-system-wake` runs on every wake path Omarchy drives — unlock (lock service) and idle-wake (idle service) — so it now nudges the clock to recompute immediately:

```bash
omarchy-shell -q omarchy.clock refresh >/dev/null 2>&1 || true
```

The clock widget already exposes that IPC handler (`IpcHandler { target: "omarchy.clock" }` → `broadcast("refresh")`), so no QML changes are needed. Best-effort `|| true` because the shell is not always running (e.g. headless wake paths).

## Test

Adds `test/shell.d/system-wake-test.sh`, which stubs `omarchy-shell` and the brightness commands and asserts the wake script pokes the clock and still restores the display:

```
ok - system wake refreshes the bar clock over shell IPC
ok - system wake still restores the display
```

- `bash -n bin/omarchy-system-wake test/shell.d/system-wake-test.sh` — clean
- `bash test/shell.d/system-wake-test.sh` — passes
- `./test/cli` — exits 0
- `git diff --check` — clean

Note: this covers the wake paths Omarchy drives (unlock + idle-wake). A resume with no lock flow at all would not run the script; a logind `PrepareForSleep` listener would be the follow-up if that gap matters.