### PR TITLE
Detect Broadcom ControlVault fingerprint readers

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -8,7 +8,7 @@
 # ship fingerprint readers; multi-purpose vendors (e.g. Elan/STMicro, which
 # also make USB touchscreens) are left out to avoid nagging laptops with no
 # reader — those still match on the product string below when present.
-fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e "
+fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e 0a5c "
 usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
 
 # libfprint drives every reader it supports from userspace over libusb, so a

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -74,6 +74,9 @@ assert_detects "a reader is detected by an existing product-name match"
 write_usb_devices '27c6:1234'
 assert_detects "a reader is detected by an existing vendor match"
 
+write_usb_devices '0a5c:5843:58200'
+assert_detects "a Broadcom ControlVault reader is detected by its vendor"
+
 bind_driver() {
   local dev="$1" driver="$2"
 


### PR DESCRIPTION
## Summary

- add Broadcom vendor ID `0a5c` to the fingerprint-reader allowlist
- cover the Dell ControlVault 3 `0a5c:5843` device in the hardware detector tests

Fixes #9507

## Testing

- `bash test/shell.d/hw-fingerprint-test.sh`
- `bash -n bin/omarchy-hw-fingerprint test/shell.d/hw-fingerprint-test.sh`
- `git diff --check`
- `./test/cli` (metadata checks passed; the host then stopped at the existing `python: command not found` dependency)