### PR TITLE
Support non-interactive updates with --yes

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -1,11 +1,26 @@
 #!/bin/bash
 
 # omarchy:summary=Update Omarchy and system packages
-# omarchy:args=[-y]
-# omarchy:examples=omarchy update | omarchy update -y
+# omarchy:args=[-y|--yes]
+# omarchy:examples=omarchy update | omarchy update --yes
 # omarchy:requires-sudo=true
 
 set -e
+
+if (( $# > 1 )); then
+  echo "Usage: omarchy update [-y|--yes]" >&2
+  exit 2
+fi
+
+case ${1:-} in
+  "") unset OMARCHY_UPDATE_UNATTENDED ;;
+  -y | --yes) export OMARCHY_UPDATE_UNATTENDED=1 ;;
+  *)
+    echo "Unknown option: $1" >&2
+    echo "Usage: omarchy update [-y|--yes]" >&2
+    exit 2
+    ;;
+esac
 
 if [[ -z ${OMARCHY_UPDATE_LOGGED:-} ]]; then
   script_command=$(printf '%q ' "$0" "$@")
@@ -21,11 +36,18 @@ trap 'omarchy-update-stay-awake stop' EXIT
 
 omarchy-update-requires-free-space
 
-# -y is a promise not to ask anything. Steps that would need an answer report
-# and move on instead of waiting on a prompt nobody is here to give.
-[[ ${1:-} != "-y" ]] || export OMARCHY_UPDATE_UNATTENDED=1
+# --yes/-y is a promise not to ask anything. Steps that would need an answer
+# skip optional work or fail with an actionable message instead of waiting.
+if [[ -n ${OMARCHY_UPDATE_UNATTENDED:-} ]]; then
+  echo "Starting the full Omarchy update non-interactively; prompts and optional actions will be skipped."
+  confirmed=true
+elif omarchy-update-confirm; then
+  confirmed=true
+else
+  confirmed=false
+fi
 
-if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
+if $confirmed; then
   # Before the snapshot: the cache is on the snapshotted subvolume, so pruning
   # after it frees nothing until that snapshot ages out.
   omarchy-update-pkg-prune

--- a/bin/omarchy-update-orphan-pkgs
+++ b/bin/omarchy-update-orphan-pkgs
@@ -12,7 +12,7 @@ echo -e "\e[32m\nOrphan system packages\e[0m"
 printf '  %s\n' "${orphans[@]}"
 echo
 
-if [[ ! -t 0 || ! -t 1 ]]; then
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == 1 || ! -t 0 || ! -t 1 ]]; then
   echo "${#orphans[@]} orphaned package(s) found. Re-run omarchy-update-orphan-pkgs in a terminal to review/remove them."
   echo
   exit 0

--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -5,7 +5,11 @@
 echo
 
 confirm_reboot() {
-  gum confirm "$1" && { omarchy-system-reboot; exit 0; }
+  if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == 1 ]]; then
+    echo "$1 Reboot when convenient."
+  else
+    gum confirm "$1" && { omarchy-system-reboot; exit 0; }
+  fi
 }
 
 running_kernel=$(uname -r)

--- a/bin/omarchy-update-stay-awake
+++ b/bin/omarchy-update-stay-awake
@@ -91,7 +91,10 @@ start() {
 
   if omarchy-cmd-present systemd-inhibit; then
     if (( EUID != 0 )); then
-      if [[ -t 0 ]]; then
+      if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == 1 ]]; then
+        sudo -n -v 2>/dev/null || true
+        inhibit_runner=(sudo -n)
+      elif [[ -t 0 ]]; then
         sudo -v
         inhibit_runner=(sudo)
       else

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -117,7 +117,7 @@ omarchy-update
   │    └─ acquire the update lock and run omarchy-update inside it
   ├─ omarchy-update-requires-free-space
   │    └─ abort below the configured free-space threshold on /
-  ├─ confirm unless -y
+  ├─ confirm unless --yes/-y; otherwise print a plain-text unattended summary
   ├─ omarchy-update-pkg-prune
   │    └─ trim the pacman cache to two versions per package, deliberately
   │       before the snapshot since the cache lives on the snapshotted subvolume
@@ -137,9 +137,7 @@ Important behavior:
 
 - In dev-link mode, `omarchy update` fast-forwards the active checkout from its
   configured upstream before changing system packages or running migrations.
-- `-y` exports `OMARCHY_UPDATE_UNATTENDED=1` — a promise not to ask anything.
-  Steps that would prompt (orphan removal, conflict handoff) report and skip
-  instead of blocking.
+- `--yes` (or its short form `-y`) exports `OMARCHY_UPDATE_UNATTENDED=1` — a promise not to ask anything. It replaces the TUI confirmation with a plain-text summary. Steps that would prompt never block: optional work such as orphan removal is reported and skipped, while required decisions such as package conflict resolution fail with an actionable message.
 - The free-space requirement uses a 10 GiB threshold and stops the update before
   confirmation when it is not met. If free space cannot be determined, the
   check is silently skipped. Set `OMARCHY_UPDATE_FORCE=1` to bypass the check.

--- a/manual/30-updates.md
+++ b/manual/30-updates.md
@@ -8,6 +8,12 @@ When new releases are made, a circle arrow icon will appear to the right of your
 
 ![update-available](images/update-available.webp)
 
+### Non-interactive updates
+
+Run `omarchy update --yes` (or `omarchy update -y`) to update from a script or a shell without a TTY. This skips interactive prompts but still runs the complete update pipeline, including the transcript, snapshot, migrations, hooks, and restart checks. Optional actions that require an answer, such as removing orphaned packages, are reported and skipped.
+
+The command may still need non-interactive sudo authorization for system package updates.
+
 ### Four channels
 
 Omarchy is updated along four channels: stable, RC, edge, and dev. New installations start on the stable channel, which tracks the [official releases](https://github.com/basecamp/omarchy/releases/), as well as the [stable Omarchy Arch mirror](https://github.com/omacom-io/omarchy-mirror) that's running one month behind the latest, so we can catch any new incompatibilities that require config changes before they cause problems for people.

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -167,7 +167,7 @@ fi
 # pending, and the login notifier keeps prompting until a rerun goes through
 # with the affected profiles closed.
 while affected_profile_open; do
-  if ! gum confirm "Close the browser windows to repair the Copy URL shortcut, then continue"; then
+  if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == 1 ]] || ! gum confirm "Close the browser windows to repair the Copy URL shortcut, then continue"; then
     echo "A running browser would undo the Copy URL shortcut repair." >&2
     echo "Close the browser windows, then run: omarchy-migrate" >&2
     exit 1

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -71,6 +71,16 @@ run_migration && fail "migration defers while the affected profile is open"
   fail "migration leaves preferences alone while the affected profile is open"
 pass "migration defers the repair while the affected profile is open"
 
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+touch "${GUM_CALLED:?}"
+exit 99
+STUB
+GUM_CALLED="$test_dir/unattended-gum-called" OMARCHY_UPDATE_UNATTENDED=1 run_migration &&
+  fail "unattended migration defers while the affected profile is open"
+[[ ! -e $test_dir/unattended-gum-called ]] || fail "unattended migration does not prompt in the transcript pseudo-terminal"
+pass "unattended migration reports required interaction without prompting"
+
 # gum paints its prompt on stderr, so that stream has to stay attached:
 # suppressing it leaves gum reading keys behind an unpainted screen, which
 # reads as a hung update.

--- a/test/shell.d/update-disk-space-test.sh
+++ b/test/shell.d/update-disk-space-test.sh
@@ -116,7 +116,8 @@ pass "interactive update stops before confirmation with low disk space"
 
 rm -f "$snapshot_marker" "$gum_marker"
 output=$(OMARCHY_UPDATE_FORCE=1 run_update -y)
-[[ -z $output ]] || fail "forced update does not emit the free-space warning"
+[[ $output != *"You need at least 10 GiB free"* ]] || fail "forced update does not emit the free-space warning"
+[[ $output == *"Starting the full Omarchy update non-interactively"* ]] || fail "forced update prints the non-interactive summary"
 [[ ! -f $gum_marker ]] || fail "forced non-interactive update does not prompt"
 [[ -f $snapshot_marker ]] || fail "forced update continues with low disk space"
 pass "forced update skips the free-space requirement"
@@ -136,6 +137,7 @@ pass "interactive update keeps the normal confirmation prompt when space is suff
 
 rm -f "$snapshot_marker"
 output=$(TEST_DF_INVALID=1 run_update -y)
-[[ -z $output ]] || fail "failed disk-space detection remains silent"
+[[ $output != *"You need at least 10 GiB free"* ]] || fail "failed disk-space detection remains silent"
+[[ $output == *"Starting the full Omarchy update non-interactively"* ]] || fail "update prints the non-interactive summary after a skipped space check"
 [[ -f $snapshot_marker ]] || fail "failed disk-space detection does not block the update"
 pass "failed disk-space detection silently continues"

--- a/test/shell.d/update-lock-test.sh
+++ b/test/shell.d/update-lock-test.sh
@@ -51,6 +51,16 @@ for command in \
 done
 write_stub omarchy-update-available 'exit 1'
 write_stub pkexec 'exec "$@"'
+write_stub sudo '
+if [[ $1 == "-n" ]]; then
+  shift
+  if [[ ${1:-} == "-v" ]]; then
+    exit 0
+  else
+    exec "$@"
+  fi
+fi
+exit 1'
 
 # omarchy-update should hold the lock before snapshotting, so a second update
 # cannot even enter its pre-update snapshot.
@@ -135,9 +145,10 @@ exec "$@"'
   terminal_driver="$test_tmp/terminal-stay-awake"
   cat >"$terminal_driver" <<'SH'
 #!/bin/bash
+[[ -t 0 ]] || exit 97
 omarchy-update-stay-awake start
 for _ in {1..200}; do
-  grep -q '^systemd-inhibit ' "$SUDO_LOG" && break
+  grep -q 'systemd-inhibit ' "$SUDO_LOG" && break
   sleep 0.05
 done
 SH
@@ -151,6 +162,38 @@ SH
   [[ ! -e $pkexec_marker ]] || fail "terminal sleep inhibition does not use pkexec"
   run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
   pass "terminal updates use sudo instead of Polkit for sleep inhibition"
+
+  unattended_sudo_log="$test_tmp/unattended-sudo.log"
+  sudo_prompt_marker="$test_tmp/sudo-prompted"
+  rm -f "$pkexec_marker"
+  write_stub sudo '
+printf "%s\n" "$*" >>"$SUDO_LOG"
+if [[ $1 == "-n" && ${2:-} == "-v" ]]; then
+  exit 1
+elif [[ $1 == "-v" ]]; then
+  touch "$SUDO_PROMPT_MARKER"
+  sleep 10
+  exit 1
+elif [[ $1 == "-n" ]]; then
+  shift
+  exec "$@"
+fi
+exit 1'
+
+  set +e
+  SUDO_LOG="$unattended_sudo_log" SUDO_PROMPT_MARKER="$sudo_prompt_marker" PKEXEC_MARKER="$pkexec_marker" \
+    INHIBIT_PID_FILE="$terminal_inhibit_pid_file" OMARCHY_UPDATE_UNATTENDED=1 \
+    run_with_lock_env timeout 3 script -qefc "$terminal_driver" /dev/null >/dev/null
+  unattended_status=$?
+  set -e
+
+  (( unattended_status == 0 )) || fail "unattended terminal sleep inhibition does not wait for a sudo password"
+  grep -qx -- '-n -v' "$unattended_sudo_log" || fail "unattended sleep inhibition validates sudo non-interactively"
+  grep -q '^-n systemd-inhibit ' "$unattended_sudo_log" || fail "unattended sleep inhibition invokes sudo non-interactively"
+  [[ ! -e $sudo_prompt_marker ]] || fail "unattended sleep inhibition never reaches prompt-capable sudo"
+  [[ ! -e $pkexec_marker ]] || fail "unattended terminal sleep inhibition does not use pkexec"
+  run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
+  pass "unattended terminal updates do not prompt for sudo"
 fi
 
 # Update-owned Stay Awake state must be cleared before the restart helper can

--- a/test/shell.d/update-orphan-test.sh
+++ b/test/shell.d/update-orphan-test.sh
@@ -35,6 +35,12 @@ grep -q '^  old-lib$' "$test_tmp/noninteractive.out" || fail "orphan checker lis
 grep -q 'Re-run omarchy-update-orphan-pkgs in a terminal' "$test_tmp/noninteractive.out" || fail "orphan checker does not remove packages non-interactively"
 pass "orphan checker only reports orphans non-interactively"
 
+require_command script
+output=$(OMARCHY_UPDATE_UNATTENDED=1 HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-orphan-pkgs" /dev/null)
+[[ $output != *"gum should not be called"* ]] || fail "unattended orphan checker does not prompt inside the update pseudo-terminal"
+[[ $output == *"orphaned package(s) found"* ]] || fail "unattended orphan checker reports orphans inside the update pseudo-terminal"
+pass "unattended orphan checker does not mistake the transcript pseudo-terminal for a person"
+
 write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then exit 0; fi; exit 1'
 run_orphan_checker >"$test_tmp/none.out" 2>"$test_tmp/none.err"
 [[ ! -s $test_tmp/none.out ]] || fail "orphan checker stays quiet when no orphans exist"

--- a/test/shell.d/update-restart-test.sh
+++ b/test/shell.d/update-restart-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+gum_marker="$test_tmp/gum"
+reboot_marker="$test_tmp/reboot"
+mkdir -p "$stub_bin" "$test_home"
+
+write_stub() {
+  local name="$1"
+  local body="$2"
+
+  cat >"$stub_bin/$name" <<SH
+#!/bin/bash
+$body
+SH
+  chmod +x "$stub_bin/$name"
+}
+
+write_stub uname 'echo test-kernel'
+write_stub pacman 'exit 1'
+write_stub pgrep 'exit 1'
+write_stub readlink 'exit 1'
+write_stub gum 'touch "$GUM_MARKER"; exit 99'
+write_stub omarchy-system-reboot 'touch "$REBOOT_MARKER"'
+write_stub omarchy-restart-shell 'exit 0'
+
+output=$(
+  HOME="$test_home" \
+    PATH="$stub_bin:$PATH" \
+    GUM_MARKER="$gum_marker" \
+    REBOOT_MARKER="$reboot_marker" \
+    OMARCHY_UPDATE_UNATTENDED=1 \
+    "$ROOT/bin/omarchy-update-restart"
+)
+
+[[ $output == *"Linux kernel has been updated. Reboot? Reboot when convenient."* ]] ||
+  fail "unattended restart check reports a required reboot"
+[[ ! -f $gum_marker ]] || fail "unattended restart check does not prompt"
+[[ ! -f $reboot_marker ]] || fail "unattended restart check does not reboot"
+[[ $output == *"Restarting shell"* ]] || fail "unattended restart check still completes service restarts"
+pass "unattended restart checks report without prompting"

--- a/test/shell.d/update-sequence-test.sh
+++ b/test/shell.d/update-sequence-test.sh
@@ -80,11 +80,18 @@ expected_steps() {
     omarchy-update-restart
 }
 
-run_update -y || fail "an update where everything works reports a failure"
+run_update --yes || fail "an update where everything works reports a failure"
 diff <(expected_steps) <(steps_run) >"$test_tmp/order" ||
   fail "an update where everything works does not run every step in order" "$(cat "$test_tmp/order")"
+grep -q '^Starting the full Omarchy update non-interactively' "$test_tmp/out" ||
+  fail "a non-interactive update prints a plain-text summary"
 pass "an update where every step works runs all of them, in order"
 
+grep -q '^omarchy-update-system-pkgs unattended=1$' "$test_tmp/steps" ||
+  fail "--yes does not mark the update unattended"
+run_update -y || fail "the short unattended flag reports a failure"
+diff <(expected_steps) <(steps_run) >"$test_tmp/order" ||
+  fail "-y does not run the same full update as --yes" "$(cat "$test_tmp/order")"
 grep -q '^omarchy-update-system-pkgs unattended=1$' "$test_tmp/steps" ||
   fail "-y does not mark the update unattended"
 run_update </dev/null || fail "a confirmed update reports a failure"
@@ -92,7 +99,7 @@ diff <(expected_steps confirmed) <(steps_run) >"$test_tmp/order" ||
   fail "a confirmed update runs a different set of steps" "$(cat "$test_tmp/order")"
 grep -q '^omarchy-update-system-pkgs unattended=$' "$test_tmp/steps" ||
   fail "an update a person confirmed is treated as unattended"
-pass "-y is what marks an update unattended, not the update itself"
+pass "--yes and -y mark an update unattended, not the update itself"
 
 # Migrations ship with the packages the upgrade installs and are written against
 # them. Running them against what is still on disk is the failure this ordering


### PR DESCRIPTION
## Summary

Fixes #9501

- add `omarchy update --yes` as the long form of the existing unattended `-y` mode
- replace the confirmation TUI with a plain-text summary while retaining the complete update pipeline
- prevent orphan cleanup, reboot checks, and interactive migrations from prompting inside the transcript pseudo-terminal
- document unattended updates and their sudo requirements

## Test plan

- `bash test/shell.d/update-sequence-test.sh`
- `bash test/shell.d/update-disk-space-test.sh`
- `bash test/shell.d/update-orphan-test.sh`
- `bash test/shell.d/update-restart-test.sh`
- `bash test/shell.d/copy-url-shortcut-migration-test.sh`
- `./test/cli` (passes through command metadata and routing checks; host lacks the later `python` dependency)
- `./test/shell` (all changed update/migration tests pass; aggregate has 22 unrelated host dependency/checkout failures, including missing Lua, gio, and omarchy-pkgs)
- `git diff --check`