### PR TITLE
Delete the previous word with Ctrl+W in the shell's filter fields

### DIFF
--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -100,6 +100,7 @@ QtObject {
   // Standard Qt text-editing keys shared by every searchable panel's filter:
   //   Backspace       delete previous character
   //   Ctrl+Backspace  delete previous word (Qt DeleteStartOfWord)
+  //   Ctrl+W          delete previous word (terminal werase)
   //   Ctrl+U          clear the whole field
   // True only when the event would actually change the text, so an empty
   // filter never swallows the key — panels keep their own empty-filter
@@ -108,7 +109,8 @@ QtObject {
     if (!text) return false
     // Alt/Meta-modified sequences belong to other shortcuts — never edit here.
     if (event.modifiers & (Qt.AltModifier | Qt.MetaModifier)) return false
-    if (event.key === Qt.Key_U)                     // Ctrl+U only (not Ctrl+Shift+U → Unicode input)
+    // Ctrl only, never Ctrl+Shift — Ctrl+Shift+U is Unicode input.
+    if (event.key === Qt.Key_U || event.key === Qt.Key_W)
       return event.modifiers === Qt.ControlModifier
     return event.key === Qt.Key_Backspace           // plain, Shift, or Ctrl Backspace
   }
@@ -116,8 +118,8 @@ QtObject {
   // New filter text after applying an edit key. Assumes editsFilter(event, text).
   function editedFilter(event, text) {
     if (event.key === Qt.Key_U) return ""                        // Ctrl+U: clear
-    if (event.modifiers & Qt.ControlModifier)                    // Ctrl+Backspace: word
-      return text.replace(/\s+$/, "").replace(/\S+$/, "")
+    if (event.key === Qt.Key_W || (event.modifiers & Qt.ControlModifier))
+      return text.replace(/\s+$/, "").replace(/\S+$/, "")        // Ctrl+W / Ctrl+Backspace: word
     return text.slice(0, -1)                                     // Backspace: char
   }
 


### PR DESCRIPTION
The filter field already takes `Ctrl+U` to clear itself - that is the terminal's
kill-line. `Ctrl+W` is its sibling on the other half of that pair (werase, or
`unix-word-rubout` in readline), and today it does nothing. This adds it, doing
the same word delete `Ctrl+Backspace` already does.

Five lines in `shell/Commons/Util.qml`: both conditions it needs already existed
and only needed widening, so there is no new code path and still one copy of the
word-delete expression. The two helpers are shared, so it lands in the menu,
clipboard, emojis, image picker and reminders at once, with no changes at the
call sites.

`Ctrl+W` on an empty filter stays inert, so the menu's `Backspace`/`Left`
back-navigation is untouched. `Ctrl+Shift+W` stays inert too, matching the way
`Ctrl+U` is matched today.

`./test/all`: 1 of 221 test files failed (bar-icon-geometry-test.sh). The same
failure happens on a clean origin/quattro and on the feature-branch. Referenced
is a video of a live test:

https://github.com/user-attachments/assets/3e427d95-ee12-44f7-81e6-dbdb9e4914d8

