### PR TITLE
Install CS8409 speaker driver on pre-T2 MacBook Pros and iMacs

### DIFF
--- a/bin/omarchy-hw-apple-cs8409
+++ b/bin/omarchy-hw-apple-cs8409
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the computer is a 2016–2017 MacBook Pro with CS8409 audio
+# omarchy:hidden=true
+
+# Cirrus CS8409 + MAX98706/SSM3515/TAS5764L. In-tree snd_hda_codec_cs8409
+# does not program those amps. Covers the 2016–2017 13" and 15" MacBook Pros
+# (including the two-port 13" models that have no Touch Bar). T2 and later
+# use a different codec and must not get this driver.
+product_name=$(cat "${OMARCHY_DMI_PRODUCT_NAME:-/sys/class/dmi/id/product_name}" 2>/dev/null)
+[[ $product_name =~ MacBookPro13,[123]|MacBookPro14,[123] ]]

--- a/bin/omarchy-hw-apple-cs8409
+++ b/bin/omarchy-hw-apple-cs8409
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# omarchy:summary=Detect whether the computer is a 2016–2017 MacBook Pro with CS8409 audio
+# omarchy:summary=Detect whether the computer is a pre-T2 Mac with CS8409 audio
 # omarchy:hidden=true
 
-# Cirrus CS8409 + MAX98706/SSM3515/TAS5764L. In-tree snd_hda_codec_cs8409
-# does not program those amps. Covers the 2016–2017 13" and 15" MacBook Pros
-# (including the two-port 13" models that have no Touch Bar). T2 and later
-# use a different codec and must not get this driver.
+# Cirrus CS8409 + MAX98706/SSM3515/TAS5764L (or CS42L83 on iMac). In-tree
+# snd_hda_codec_cs8409 does not program those amps. Covers:
+# - 2016–2017 MacBook Pros (MacBookPro13,x / 14,x), including two-port 13"
+# - 2017–2019 iMacs (iMac18,x / iMac19,x) with the same CS8409 bridge
+# T2 and later use a different codec and must not get this driver.
 product_name=$(cat "${OMARCHY_DMI_PRODUCT_NAME:-/sys/class/dmi/id/product_name}" 2>/dev/null)
-[[ $product_name =~ MacBookPro13,[123]|MacBookPro14,[123] ]]
+[[ $product_name =~ MacBookPro13,[123]|MacBookPro14,[123]|iMac18,[123]|iMac19,[12] ]]

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -36,6 +36,7 @@ run_logged "$OMARCHY_INSTALL/hardware/asus/fix-z13-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-cs8409-audio.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"

--- a/install/hardware/apple/fix-cs8409-audio.sh
+++ b/install/hardware/apple/fix-cs8409-audio.sh
@@ -1,0 +1,8 @@
+# 2016–2017 MacBook Pros use CS8409 HDA. The in-tree codec driver leaves
+# the speaker amps unprogrammed; snd-hda-macbookpro-dkms is the Apple path.
+
+if omarchy-hw-apple-cs8409; then
+  echo "Detected MacBook with Cirrus CS8409 audio"
+
+  omarchy-pkg-add linux-headers snd-hda-macbookpro-dkms
+fi

--- a/install/hardware/apple/fix-cs8409-audio.sh
+++ b/install/hardware/apple/fix-cs8409-audio.sh
@@ -1,8 +1,9 @@
-# 2016–2017 MacBook Pros use CS8409 HDA. The in-tree codec driver leaves
-# the speaker amps unprogrammed; snd-hda-macbookpro-dkms is the Apple path.
+# Pre-T2 Macs with a Cirrus CS8409 HDA bridge (2016–2017 MacBook Pros and
+# 2017–2019 iMacs) leave the speaker amps unprogrammed under the in-tree
+# codec driver. snd-hda-macbookpro-dkms is the Apple path that enables them.
 
 if omarchy-hw-apple-cs8409; then
-  echo "Detected MacBook with Cirrus CS8409 audio"
+  echo "Detected Mac with Cirrus CS8409 audio"
 
   omarchy-pkg-add linux-headers snd-hda-macbookpro-dkms
 fi

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -35,7 +35,7 @@ It is necessary to disable Apple's Secure Boot in order to boot the bootable USB
 3. Select the orange EFI Boot device
 4. Proceed with the [install as normal](02-getting-started.md)
 
-The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, and an NVMe suspend fix for those same models.
+The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, the CS8409 speaker driver on 2016–2017 MacBook Pros, and an NVMe suspend fix for those same models.
 
 ### Known Limitations
 
@@ -51,7 +51,7 @@ The Apple T1 chip was introduced in late 2016 and used exclusively in the first-
 #### Known Issues
 
 - Touch Bar is non-functional
-- Sound is not functioning
+- Internal microphone capture is quiet and not fully wired up yet. Speakers and headphones work; the installer installs the CS8409 driver (`snd-hda-macbookpro-dkms`) automatically. Reboot once after install so the patched module replaces the silent in-tree codec.
 
 #### Devices with T2 Chip
 

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -35,7 +35,7 @@ It is necessary to disable Apple's Secure Boot in order to boot the bootable USB
 3. Select the orange EFI Boot device
 4. Proceed with the [install as normal](02-getting-started.md)
 
-The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, the CS8409 speaker driver on 2016–2017 MacBook Pros, and an NVMe suspend fix for those same models.
+The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, the CS8409 speaker driver on 2016–2017 MacBook Pros and 2017–2019 iMacs, and an NVMe suspend fix for those same MacBook models.
 
 ### Known Limitations
 
@@ -51,7 +51,7 @@ The Apple T1 chip was introduced in late 2016 and used exclusively in the first-
 #### Known Issues
 
 - Touch Bar is non-functional
-- Internal microphone capture is quiet and not fully wired up yet. Speakers and headphones work; the installer installs the CS8409 driver (`snd-hda-macbookpro-dkms`) automatically. Reboot once after install so the patched module replaces the silent in-tree codec.
+- Internal microphone capture is quiet and not fully wired up yet on the T1 MacBook Pros. Speakers and headphones work on those models and on 2017–2019 iMacs with the CS8409 bridge; the installer installs the CS8409 driver (`snd-hda-macbookpro-dkms`) automatically. Reboot once after install so the patched module replaces the silent in-tree codec.
 
 #### Devices with T2 Chip
 

--- a/migrations/1786889011.sh
+++ b/migrations/1786889011.sh
@@ -1,0 +1,8 @@
+echo "Install the CS8409 MacBook speaker driver"
+
+# 2016–2017 MacBook Pros only. T2 and other Apple hardware is unchanged.
+if ! omarchy-hw-apple-cs8409; then
+  exit 0
+fi
+
+omarchy-pkg-add linux-headers snd-hda-macbookpro-dkms

--- a/migrations/1786889011.sh
+++ b/migrations/1786889011.sh
@@ -1,6 +1,7 @@
-echo "Install the CS8409 MacBook speaker driver"
+echo "Install the CS8409 speaker driver on pre-T2 Macs"
 
-# 2016–2017 MacBook Pros only. T2 and other Apple hardware is unchanged.
+# 2016–2017 MacBook Pros and 2017–2019 iMacs with CS8409. T2 and other
+# Apple hardware is unchanged.
 if ! omarchy-hw-apple-cs8409; then
   exit 0
 fi

--- a/test/shell.d/cs8409-audio-test.sh
+++ b/test/shell.d/cs8409-audio-test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hw="$ROOT/bin/omarchy-hw-apple-cs8409"
+fix="$ROOT/install/hardware/apple/fix-cs8409-audio.sh"
+migration="$ROOT/migrations/1786889011.sh"
+manual="$ROOT/manual/44-mac-support.md"
+
+assert_hw() {
+  local model=$1 expect=$2 description=$3
+  local tmp
+  tmp=$(mktemp)
+  printf '%s\n' "$model" >"$tmp"
+  if OMARCHY_DMI_PRODUCT_NAME="$tmp" "$hw"; then
+    [[ $expect == yes ]] || fail "$description"
+  else
+    [[ $expect == no ]] || fail "$description"
+  fi
+  rm -f "$tmp"
+  pass "$description"
+}
+
+assert_hw MacBookPro14,3 yes "MacBookPro14,3 has CS8409 audio"
+assert_hw MacBookPro14,2 yes "MacBookPro14,2 has CS8409 audio"
+assert_hw MacBookPro14,1 yes "MacBookPro14,1 has CS8409 audio"
+assert_hw MacBookPro13,3 yes "MacBookPro13,3 has CS8409 audio"
+assert_hw MacBookPro13,2 yes "MacBookPro13,2 has CS8409 audio"
+assert_hw MacBookPro13,1 yes "MacBookPro13,1 has CS8409 audio"
+assert_hw MacBookPro15,1 no "MacBookPro15,1 is T2, not CS8409"
+assert_hw MacBook8,1 no "MacBook8,1 is SPI-only"
+
+grep -Fq 'fix-cs8409-audio.sh' "$ROOT/install/hardware/all.sh" ||
+  fail "hardware install runs the CS8409 hook"
+pass "CS8409 install hook is wired"
+
+grep -Fq 'snd-hda-macbookpro-dkms' "$fix" ||
+  fail "install hook names the omarchy-pkgs package"
+grep -Fq 'omarchy-hw-apple-cs8409' "$fix" ||
+  fail "install hook is gated on CS8409 detection"
+pass "install hook installs snd-hda-macbookpro-dkms"
+
+grep -Fq 'snd-hda-macbookpro-dkms' "$manual" ||
+  fail "Mac support chapter names the CS8409 package"
+! grep -q 'Sound is not functioning' "$manual" ||
+  fail "Mac support chapter no longer lists speakers as unsupported"
+pass "Mac support chapter documents CS8409 speakers"
+
+[[ -f $migration ]] || fail "CS8409 migration exists"
+grep -Fq 'omarchy-hw-apple-cs8409' "$migration" ||
+  fail "migration is gated on CS8409 detection"
+grep -Fq 'snd-hda-macbookpro-dkms' "$migration" ||
+  fail "migration installs the CS8409 package"
+! head -1 "$migration" | grep -q '^#!' ||
+  fail "migration has no shebang"
+pass "migration installs the driver on CS8409 hardware only"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+chmod +x "$stub_bin/omarchy-pkg-add"
+
+dmi="$test_tmp/dmi"
+printf 'MacBookPro14,1\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_INSTALL="$ROOT/install" \
+  bash -c 'source "$1"' _ "$fix"
+grep -Fq $'omarchy-pkg-add\tlinux-headers\tsnd-hda-macbookpro-dkms' "$calls" ||
+  fail "install hook adds headers and the CS8409 package on a two-port 13-inch"
+pass "install hook runs on MacBookPro14,1 (CS8409, no Touch Bar)"
+
+: >"$calls"
+printf 'MacBookPro15,1\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_INSTALL="$ROOT/install" \
+  bash -c 'source "$1"' _ "$fix"
+[[ ! -s $calls ]] || fail "T2 hardware skips the CS8409 package" "$(cat "$calls")"
+pass "install hook skips T2 hardware"
+
+: >"$calls"
+printf 'MacBookPro14,3\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  bash -euo pipefail "$migration" >/dev/null
+grep -Fq $'omarchy-pkg-add\tlinux-headers\tsnd-hda-macbookpro-dkms' "$calls" ||
+  fail "migration installs the CS8409 package on a 15-inch T1"
+pass "migration installs the driver on MacBookPro14,3"
+
+: >"$calls"
+printf 'MacBookPro16,1\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  bash -euo pipefail "$migration" >/dev/null
+[[ ! -s $calls ]] || fail "migration skips non-CS8409 hardware" "$(cat "$calls")"
+pass "migration skips non-CS8409 hardware"

--- a/test/shell.d/cs8409-audio-test.sh
+++ b/test/shell.d/cs8409-audio-test.sh
@@ -30,7 +30,13 @@ assert_hw MacBookPro14,1 yes "MacBookPro14,1 has CS8409 audio"
 assert_hw MacBookPro13,3 yes "MacBookPro13,3 has CS8409 audio"
 assert_hw MacBookPro13,2 yes "MacBookPro13,2 has CS8409 audio"
 assert_hw MacBookPro13,1 yes "MacBookPro13,1 has CS8409 audio"
+assert_hw iMac18,3 yes "iMac18,3 has CS8409 audio"
+assert_hw iMac18,2 yes "iMac18,2 has CS8409 audio"
+assert_hw iMac18,1 yes "iMac18,1 has CS8409 audio"
+assert_hw iMac19,1 yes "iMac19,1 has CS8409 audio"
+assert_hw iMac19,2 yes "iMac19,2 has CS8409 audio"
 assert_hw MacBookPro15,1 no "MacBookPro15,1 is T2, not CS8409"
+assert_hw iMacPro1,1 no "iMacPro1,1 is T2, not CS8409"
 assert_hw MacBook8,1 no "MacBook8,1 is SPI-only"
 
 grep -Fq 'fix-cs8409-audio.sh' "$ROOT/install/hardware/all.sh" ||
@@ -45,6 +51,8 @@ pass "install hook installs snd-hda-macbookpro-dkms"
 
 grep -Fq 'snd-hda-macbookpro-dkms' "$manual" ||
   fail "Mac support chapter names the CS8409 package"
+grep -Fq '2017–2019 iMacs' "$manual" ||
+  fail "Mac support chapter documents iMac CS8409 speakers"
 ! grep -q 'Sound is not functioning' "$manual" ||
   fail "Mac support chapter no longer lists speakers as unsupported"
 pass "Mac support chapter documents CS8409 speakers"
@@ -106,6 +114,28 @@ PATH="$stub_bin:$ROOT/bin:$PATH" \
 grep -Fq $'omarchy-pkg-add\tlinux-headers\tsnd-hda-macbookpro-dkms' "$calls" ||
   fail "migration installs the CS8409 package on a 15-inch T1"
 pass "migration installs the driver on MacBookPro14,3"
+
+: >"$calls"
+printf 'iMac18,3\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_INSTALL="$ROOT/install" \
+  bash -c 'source "$1"' _ "$fix"
+grep -Fq $'omarchy-pkg-add\tlinux-headers\tsnd-hda-macbookpro-dkms' "$calls" ||
+  fail "install hook adds headers and the CS8409 package on iMac18,3"
+pass "install hook runs on iMac18,3 (CS8409)"
+
+: >"$calls"
+printf 'iMac18,3\n' >"$dmi"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi" \
+  bash -euo pipefail "$migration" >/dev/null
+grep -Fq $'omarchy-pkg-add\tlinux-headers\tsnd-hda-macbookpro-dkms' "$calls" ||
+  fail "migration installs the CS8409 package on iMac18,3"
+pass "migration installs the driver on iMac18,3"
 
 : >"$calls"
 printf 'MacBookPro16,1\n' >"$dmi"

--- a/test/shell.d/cs8409-audio-test.sh
+++ b/test/shell.d/cs8409-audio-test.sh
@@ -11,15 +11,16 @@ manual="$ROOT/manual/44-mac-support.md"
 
 assert_hw() {
   local model=$1 expect=$2 description=$3
-  local tmp
+  local tmp got
   tmp=$(mktemp)
   printf '%s\n' "$model" >"$tmp"
   if OMARCHY_DMI_PRODUCT_NAME="$tmp" "$hw"; then
-    [[ $expect == yes ]] || fail "$description"
+    got=yes
   else
-    [[ $expect == no ]] || fail "$description"
+    got=no
   fi
   rm -f "$tmp"
+  [[ $got == "$expect" ]] || fail "$description"
   pass "$description"
 }
 


### PR DESCRIPTION
## Summary
- Installs `snd-hda-macbookpro-dkms` (+ `linux-headers`) on pre-T2 Macs whose speakers stay silent under in-tree `snd_hda_codec_cs8409`: **MacBookPro13,x / 14,x** and **iMac18,x / iMac19,x**.
- Builds on @shawnyeager's work in #7140 (detector, install hook, migration, tests, manual). This PR rebases that onto current `quattro` and extends detection / docs / tests for iMacs.
- Depends on the matching package PR: https://github.com/omacom/omarchy-pkgs/pull/155 (or the follow-up that widens its description for iMacs).

In-tree CS8409 binds the codec but never programs the external amps / CS42L83 path, so PipeWire shows a healthy unmuted sink with no output. The DKMS module replaces `snd-hda-codec-cs8409` under `updates/` after reboot.

T2 Macs stay on `fix-t2.sh` / `apple-t2-audio-config` and are excluded (`iMacPro1,1`, `MacBookPro15,1`, etc.).

## Hardware note
Verified on **iMac18,3** (CS8409/CS42L83, codec subsystem `0x106b1000`) on linux 7.1.9: speakers work once the Apple CS8409 path is loaded. MacBook Pro coverage is from #7140 (MacBookPro14,3).

## Test plan
- [x] `./test/shell.d/cs8409-audio-test.sh` (MacBook + iMac match/skip cases, install hook, migration, manual wording)
- [ ] On iMac18/19 or MacBookPro13/14: install / migrate → reboot → `lsmod | grep cs8409`, `aplay -l` shows CS8409/CS42L83, speakers play
- [ ] T2 Mac (`MacBookPro15,1` / `iMacPro1,1`): hook and migration no-op

Supersedes / can close #7140 and draft #8285 once this and the pkgs package land together.

Made with [Cursor](https://cursor.com)