### PR TITLE
Wait for apps to flush state before powering off or rebooting

### DIFF
--- a/bin/omarchy-hyprland-window-close-all
+++ b/bin/omarchy-hyprland-window-close-all
@@ -2,11 +2,33 @@
 
 # omarchy:summary=Close all open windows
 
+wait_for_exit=false
+if [[ ${1:-} == "--wait" ]]; then
+  wait_for_exit=true
+fi
+
+# Captured before dispatching so a slow sequence of close requests does not
+# eat into the wait budget.
+deadline=$(( $(date +%s) + ${OMARCHY_CLOSE_ALL_TIMEOUT:-10} ))
+
 hyprctl clients -j | \
   jq -r ".[].address" | \
   while read -r addr; do
     hyprctl dispatch "hl.dsp.window.close({ window = \"address:$addr\" })" >/dev/null
   done
+
+if [[ $wait_for_exit == true ]]; then
+  # Closing is asynchronous: the dispatch returns as soon as closing is
+  # requested, while apps may need seconds to flush state (browsers write
+  # their session on close). Shutdown and reboot call --wait so the scheduled
+  # poweroff does not kill apps mid-write; the wait is bounded, so a window
+  # that refuses to close cannot stall a shutdown (issue #7085).
+  while (( $(date +%s) < deadline )); do
+    remaining=$(hyprctl clients -j 2>/dev/null | jq 'length' 2>/dev/null || echo 1)
+    [[ $remaining == 0 ]] && break
+    sleep 0.2
+  done
+fi
 
 # Move to first workspace
 hyprctl dispatch 'hl.dsp.focus({ workspace = "1" })' >/dev/null 2>&1 || hyprctl dispatch workspace 1

--- a/bin/omarchy-system-reboot
+++ b/bin/omarchy-system-reboot
@@ -5,13 +5,14 @@
 # omarchy:aliases=omarchy reboot
 
 # Schedule the reboot in the user manager so closing the terminal's systemd
-# scope cannot terminate it before it runs.
-systemd-run --user --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl reboot --no-wall || exit 1
+# scope cannot terminate it before it runs. The timer fires after the
+# close-all wait (default 10s) has run its course, so apps get to flush state
+# before the machine reboots (issue #7085).
+systemd-run --user --collect --quiet --on-active="15s" --timer-property=AccuracySec=100ms systemctl reboot --no-wall || exit 1
 
 omarchy-osd -i reboot -m "Rebooting" -d 5000
 
 omarchy-state clear re*-required
 
-# Now close all windows
-omarchy-hyprland-window-close-all
-sleep 1 # Allow apps like Chrome to shutdown correctly
+# Now close all windows and wait for them to exit
+omarchy-hyprland-window-close-all --wait

--- a/bin/omarchy-system-shutdown
+++ b/bin/omarchy-system-shutdown
@@ -5,13 +5,14 @@
 # omarchy:aliases=omarchy shutdown
 
 # Schedule the shutdown in the user manager so closing the terminal's systemd
-# scope cannot terminate it before it runs.
-systemd-run --user --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl poweroff --no-wall || exit 1
+# scope cannot terminate it before it runs. The timer fires after the
+# close-all wait (default 10s) has run its course, so apps get to flush state
+# before the machine powers off (issue #7085).
+systemd-run --user --collect --quiet --on-active="15s" --timer-property=AccuracySec=100ms systemctl poweroff --no-wall || exit 1
 
 omarchy-osd -i shutdown -m "Shutting down" -d 5000
 
 omarchy-state clear re*-required
 
-# Now close all windows
-omarchy-hyprland-window-close-all
-sleep 1 # Allow apps like Chrome to shutdown correctly
+# Now close all windows and wait for them to exit
+omarchy-hyprland-window-close-all --wait

--- a/test/shell.d/hyprland-window-close-all-test.sh
+++ b/test/shell.d/hyprland-window-close-all-test.sh
@@ -1,33 +1,82 @@
 #!/bin/bash
 
-source "$(dirname "$0")/base-test.sh"
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
 mock_bin="$test_tmp/bin"
 hyprctl_log="$test_tmp/hyprctl.log"
+clients_log="$test_tmp/clients-calls.log"
 mkdir -p "$mock_bin"
 
+# The mock empties the client list once it has been polled a few times, so the
+# --wait path observes windows disappearing; the poll count in CLIENTS_CALLS_LOG
+# proves the wait actually ran. Use a marker file to change behavior between
+# cases: "empty" makes the list disappear after the given number of calls,
+# "sticky" never empties it (for the timeout-bounded case).
 cat >"$mock_bin/hyprctl" <<'SH'
 #!/bin/bash
 
 if [[ $1 == "clients" ]]; then
-  printf '[{"address":"0xabc"},{"address":"0xdef"}]\n'
+  echo x >>"$CLIENTS_CALLS_LOG"
+  calls=$(wc -l <"$CLIENTS_CALLS_LOG")
+  empty_after=${CLIENTS_EMPTY_AFTER:-0}
+  if (( empty_after == 0 || calls < empty_after )); then
+    printf '[{"address":"0xabc"},{"address":"0xdef"}]\n'
+  else
+    printf '[]\n'
+  fi
 else
   printf '%s\n' "$*" >>"$HYPRCTL_LOG"
 fi
 SH
 chmod +x "$mock_bin/hyprctl"
 
-PATH="$mock_bin:$PATH" HYPRCTL_LOG="$hyprctl_log" "$ROOT/bin/omarchy-hyprland-window-close-all"
+run_close_all() {
+  PATH="$mock_bin:$PATH" \
+  HYPRCTL_LOG="$hyprctl_log" \
+  CLIENTS_CALLS_LOG="$clients_log" \
+  CLIENTS_EMPTY_AFTER="${1:-0}" \
+  OMARCHY_CLOSE_ALL_TIMEOUT="${2:-10}" \
+    "$ROOT/bin/omarchy-hyprland-window-close-all" "${3:-}"
+}
 
-expected_log="$test_tmp/expected.log"
-cat >"$expected_log" <<'EOF'
+expected_dispatch() {
+  cat >"$test_tmp/expected.log" <<'EOF'
 dispatch hl.dsp.window.close({ window = "address:0xabc" })
 dispatch hl.dsp.window.close({ window = "address:0xdef" })
 dispatch hl.dsp.focus({ workspace = "1" })
 EOF
+}
 
-diff -u "$expected_log" "$hyprctl_log" || fail "close-all targets each window with the Lua dispatcher"
+# --- Plain path (keybind): close requests only, no waiting -----------------
+: >"$hyprctl_log"
+: >"$clients_log"
+run_close_all 0 10
+expected_dispatch
+diff -u "$test_tmp/expected.log" "$hyprctl_log" || fail "close-all targets each window with the Lua dispatcher"
 pass "close-all targets each window with the Lua dispatcher"
+[[ $(wc -l <"$clients_log") == 1 ]] || fail "plain close-all does not wait for windows to exit"
+pass "plain close-all does not wait for windows to exit"
+
+# --- --wait path: polls until the client list empties ----------------------
+: >"$hyprctl_log"
+: >"$clients_log"
+run_close_all 4 10 --wait
+expected_dispatch
+diff -u "$test_tmp/expected.log" "$hyprctl_log" || fail "--wait still targets each window with the Lua dispatcher"
+pass "--wait still targets each window with the Lua dispatcher"
+[[ $(wc -l <"$clients_log") -ge 3 ]] || fail "--wait polls until windows have exited"
+pass "--wait polls until windows have exited"
+
+# --- --wait path with a window that never closes: bounded by the timeout ----
+: >"$hyprctl_log"
+: >"$clients_log"
+if run_close_all 0 1 --wait; then
+  pass "--wait with a stuck window still completes within the timeout"
+else
+  fail "--wait with a stuck window still completes within the timeout"
+fi

--- a/test/shell.d/system-shutdown-test.sh
+++ b/test/shell.d/system-shutdown-test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Shutdown and reboot arm the poweroff/reboot timer in the user manager before
+# closing windows. The timer must fire after the close-all wait has run its
+# course, or a heavy session is killed mid-flush and its state is lost on the
+# next launch (issue #7085). Pin that invariant: the armed timer outlasts the
+# close-all wait timeout.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+close_all_timeout=$(sed -n 's/.*OMARCHY_CLOSE_ALL_TIMEOUT:-\([0-9][0-9]*\)}.*/\1/p' \
+  "$ROOT/bin/omarchy-hyprland-window-close-all" | head -n1)
+[[ -n $close_all_timeout ]] || fail "close-all declares a wait timeout"
+pass "close-all declares a wait timeout"
+
+for script in omarchy-system-shutdown omarchy-system-reboot; do
+  armed=$(sed -n 's/.*--on-active="\([0-9][0-9]*\)s".*/\1/p' "$ROOT/bin/$script" | head -n1)
+  [[ -n $armed ]] || fail "$script arms a poweroff timer"
+  (( armed > close_all_timeout )) ||
+    fail "$script arms its timer ($armed s) past the close-all wait ($close_all_timeout s)"
+  pass "$script arms its timer past the close-all wait"
+done


### PR DESCRIPTION
Fixes #7085

## Problem

`omarchy shutdown` / `omarchy reboot` arm the poweroff/reboot timer in the user
manager **before** dispatching close-all, and the previous `close-all` fired the
close requests and immediately returned (`sleep 1` was the only grace period).
Closing is asynchronous: apps like browsers write their session state only after
the WM forwards the close request. With 2s to poweroff and no wait, heavy
sessions were killed mid-write and lost state on the next launch — exactly the
"close, wait for exit, then reboot" workaround the reporter verified.

## Fix

- `omarchy-hyprland-window-close-all --wait` — new optional flag: after
  dispatching close requests, poll `hyprctl clients` until the list empties.
  Bounded (`OMARCHY_CLOSE_ALL_TIMEOUT`, default 10s) so a window that refuses
  to close cannot stall a shutdown. Plain invocations (e.g. the Ctrl+Alt+Delete
  "Close all windows" keybind) keep their instant behavior.
- `omarchy-system-shutdown` / `omarchy-system-reboot` — arm the timer at 15s
  (past the 10s wait budget) and call `close-all --wait`, dropping the old
  1s sleep.

## Tests

- `hyprland-window-close-all-test.sh` — extended with a mock whose client list
  empties after N polls: asserts the plain path doesn't wait, `--wait` polls
  until windows exit, and a stuck window still completes within the timeout.
- `system-shutdown-test.sh` — new: pins the invariant that both scripts arm
  their timers past the close-all wait timeout.

All 8 assertions pass; `bash -n` and `./test/cli` are clean.