### PR TITLE
Cycle a theme's backgrounds with up and down in the theme picker

### DIFF
--- a/bin/omarchy-dev-benchmark-theme-switcher
+++ b/bin/omarchy-dev-benchmark-theme-switcher
@@ -17,7 +17,7 @@ Usage:
   omarchy dev benchmark theme switcher [--repeat=<count>] [--keep-cache]
 
 Measure the non-interactive parts of the theme switcher:
-- theme preview index build (omarchy-theme-switcher before UI handoff)
+- theme image index build (omarchy-theme-switcher before UI handoff)
 - lazy selector row prep used by the interactive theme switcher
 - full thumbnail cache warmup cost (omarchy-menu-images --cache-only)
 
@@ -141,11 +141,11 @@ build_theme_index() {
 }
 
 prepare_selector_lazy() {
-  "${benchmark_env[@]}" "$OMARCHY_BIN_DIR/omarchy-menu-images" --prepare-only --lazy-thumbnails --show-labels --filterable "$preview_dir"
+  "${benchmark_env[@]}" "$OMARCHY_BIN_DIR/omarchy-menu-images" --prepare-only --lazy-thumbnails --show-labels --filterable --group-by-dir "$preview_dir"/*/
 }
 
 prepare_image_cache() {
-  "${thumbnail_env[@]}" "$OMARCHY_BIN_DIR/omarchy-menu-images" --cache-only "$thumbnail_preview_dir"
+  "${thumbnail_env[@]}" "$OMARCHY_BIN_DIR/omarchy-menu-images" --cache-only "$thumbnail_preview_dir"/*/
 }
 
 printf 'Theme switcher benchmark (%d warm runs each)\n\n' "$REPEAT"
@@ -157,4 +157,5 @@ run_case "selector prep warm (lazy)" prepare_selector_lazy
 printf '%-34s %s ms\n' "thumbnail cache cold" "$(format_ms "$(measure_once prepare_image_cache)")"
 run_case "thumbnail cache warm" prepare_image_cache
 
-printf '\nTheme previews: %d\n' "$(find -L "$preview_dir" -maxdepth 1 -type f 2>/dev/null | wc -l)"
+printf '\nThemes: %d\n' "$(find -L "$preview_dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)"
+printf 'Theme images: %d\n' "$(find -L "$preview_dir" -mindepth 2 -maxdepth 2 -type f 2>/dev/null | wc -l)"

--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 # omarchy:summary=Open a generic image selector menu
-# omarchy:args=[--selected <image>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>...
+# omarchy:args=[--selected <image>] [--print-name] [--show-labels] [--filterable] [--group-by-dir] [--item-label <name>] [--variant-label <name>] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>...
 
 selected_image=""
 print_name=false
 show_labels=false
 filterable=false
+group_by_dir=false
+item_label=""
+variant_label=""
 lazy_thumbnails=false
 prepare_only=false
 preload=false
@@ -14,7 +17,7 @@ cache_only=false
 image_dirs=()
 
 usage() {
-  echo "Usage: omarchy-menu-images [--selected <image>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>..."
+  echo "Usage: omarchy-menu-images [--selected <image>] [--print-name] [--show-labels] [--filterable] [--group-by-dir] [--item-label <name>] [--variant-label <name>] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>..."
 }
 
 while (( $# > 0 )); do
@@ -39,6 +42,24 @@ while (( $# > 0 )); do
     --filterable)
       filterable=true
       shift
+      ;;
+    --group-by-dir)
+      group_by_dir=true
+      shift
+      ;;
+    --item-label | --variant-label)
+      if (( $# < 2 )); then
+        usage >&2
+        exit 1
+      fi
+
+      if [[ $1 == "--item-label" ]]; then
+        item_label="$2"
+      else
+        variant_label="$2"
+      fi
+
+      shift 2
       ;;
     --lazy-thumbnails)
       lazy_thumbnails=true
@@ -76,8 +97,9 @@ selection_file=$(mktemp)
 done_file=$(mktemp)
 pending_file=$(mktemp)
 pending_video_file=$(mktemp)
+lazy_file=$(mktemp)
 rm -f "$done_file"
-trap 'rm -f "$selection_file" "$done_file" "$pending_file" "$pending_video_file"' EXIT
+trap 'rm -f "$selection_file" "$done_file" "$pending_file" "$pending_video_file" "$lazy_file"' EXIT
 
 image_dirs_env=""
 for dir in "${image_dirs[@]}"; do
@@ -112,11 +134,12 @@ cache_key=$(printf '%s' "$image_dirs_env" | md5sum | cut -d ' ' -f 1)
 rows_cache_file="$cache_dir/$cache_key.rows"
 rows_signature_file="$cache_dir/$cache_key.signature"
 rows_fast_signature_file="$cache_dir/$cache_key.fast-signature"
-rows_signature="v4"$'\n'
-rows_fast_signature="v3"$'\n'
+rows_signature="v4"$'\n'"group-by-dir:$group_by_dir"$'\n'
+rows_fast_signature="v3"$'\n'"group-by-dir:$group_by_dir"$'\n'
 rows_cacheable=true
 rows_cache_hit=false
 image_files=()
+image_groups=()
 
 for dir in "${image_dirs[@]}"; do
   [[ -d $dir ]] && rows_fast_signature+="$dir:$(stat -Lc '%Y' "$dir")"$'\n'
@@ -130,8 +153,12 @@ else
     if [[ -d $dir ]]; then
       rows_signature+="$dir:$(stat -Lc '%Y' "$dir")"$'\n'
 
+      group=${dir%/}
+      group=${group##*/}
+
       while IFS= read -r -d '' image; do
         image_files+=("$image")
+        image_groups+=("$group")
         image_signature=$(stat -Lc '%s:%Y' "$image") || continue
         rows_signature+="$image:$image_signature"$'\n'
       done < <(find -L "$dir" -maxdepth 1 -type f \
@@ -225,7 +252,7 @@ thumbnail_for() {
       rows_cacheable=false
 
       if [[ $prepare_only != true ]]; then
-        generate_thumbnail "$image" "$thumbnail" >/dev/null 2>&1 &
+        printf '%s\0%s\0' "$image" "$thumbnail" >>"$lazy_file"
       fi
 
       printf '%s' "$image"
@@ -242,32 +269,55 @@ thumbnail_for() {
   printf '%s' "$thumbnail"
 }
 
-# Each vips run is single-threaded, so still images can fill every core.
-# ffmpegthumbnailer leaves FFmpeg's automatic threading on, so a full-width fan
-# out of those would put a codec thread pool on every core at once.
+# Drain one queued thumbnail class with bounded parallelism.
+drain_thumbnails() {
+  local queue="$1"
+  local jobs="${2:-$(nproc)}"
+
+  [[ -s $queue ]] || return 0
+
+  export -f generate_thumbnail is_video_path
+  xargs -a "$queue" -0 -n 2 -P "$jobs" \
+    bash -c 'generate_thumbnail "$1" "$2"' _ >/dev/null 2>&1 || true
+}
+
+# Still images can fill every core because each vips run is single-threaded.
+# Video jobs stay narrower because ffmpegthumbnailer uses its own codec threads.
 drain_pending_thumbnails() {
   local video_jobs
 
-  export -f generate_thumbnail is_video_path
+  drain_thumbnails "$pending_file"
 
-  if [[ -s $pending_file ]]; then
-    xargs -a "$pending_file" -0 -n 2 -P "$(nproc)" \
-      bash -c 'generate_thumbnail "$1" "$2"' _ >/dev/null 2>&1 || true
-  fi
+  video_jobs=$(( $(nproc) / 4 ))
+  (( video_jobs > 0 )) || video_jobs=1
+  drain_thumbnails "$pending_video_file" "$video_jobs"
+}
 
-  if [[ -s $pending_video_file ]]; then
-    video_jobs=$(( $(nproc) / 4 ))
-    (( video_jobs > 0 )) || video_jobs=1
-    xargs -a "$pending_video_file" -0 -n 2 -P "$video_jobs" \
-      bash -c 'generate_thumbnail "$1" "$2"' _ >/dev/null 2>&1 || true
-  fi
+# Rows already point at the original images, so these only need to land before
+# the next open. One bounded batch keeps a picker carrying every theme's
+# backgrounds from forking a generator per image the moment it opens.
+drain_lazy_thumbnails() {
+  local queue
+
+  [[ -s $lazy_file ]] || return 0
+
+  queue=$(mktemp)
+  mv "$lazy_file" "$queue"
+
+  # Detached from stdout: a caller reading our selection back over a pipe must
+  # not wait on the generators.
+  (
+    trap 'rm -f "$queue"' EXIT
+    drain_thumbnails "$queue"
+  ) >/dev/null 2>&1 &
 }
 
 if [[ $rows_cache_hit != true && -f $rows_cache_file && -f $rows_signature_file ]] && cmp -s "$rows_signature_file" <(printf '%s' "$rows_signature"); then
   rows=$(<"$rows_cache_file")
   printf '%s' "$rows_fast_signature" >"$rows_fast_signature_file"
 elif [[ $rows_cache_hit != true ]]; then
-  for image in "${image_files[@]}"; do
+  for index in "${!image_files[@]}"; do
+    image="${image_files[$index]}"
     thumbnail=$(thumbnail_for "$image")
     [[ -n $thumbnail ]] || continue
     # Cached rows are trusted on the directory's mtime alone, which a file
@@ -280,27 +330,34 @@ elif [[ $rows_cache_hit != true ]]; then
       rows_cacheable=false
     fi
 
+    row="$image"$'\t'"$thumbnail"
+    [[ $group_by_dir == true ]] && row+=$'\t'"${image_groups[$index]}"
+
     if [[ -z $rows ]]; then
-      rows="$image"$'\t'"$thumbnail"
+      rows="$row"
     else
-      rows+=$'\n'"$image"$'\t'"$thumbnail"
+      rows+=$'\n'"$row"
     fi
   done
 
   drain_pending_thumbnails
+  drain_lazy_thumbnails
 
   if [[ -s $pending_file || -s $pending_video_file ]]; then
     pruned=""
-    while IFS=$'\t' read -r row_image row_thumbnail; do
+    while IFS=$'\t' read -r row_image row_thumbnail row_group; do
       if [[ ! -e $row_thumbnail ]]; then
         rows_cacheable=false
         continue
       fi
 
+      row="$row_image"$'\t'"$row_thumbnail"
+      [[ -n $row_group ]] && row+=$'\t'"$row_group"
+
       if [[ -z $pruned ]]; then
-        pruned="$row_image"$'\t'"$row_thumbnail"
+        pruned="$row"
       else
-        pruned+=$'\n'"$row_image"$'\t'"$row_thumbnail"
+        pruned+=$'\n'"$row"
       fi
     done <<<"$rows"
     rows="$pruned"
@@ -345,7 +402,9 @@ if ! open_result=$(omarchy-shell image-selector open \
      "$selection_file" \
      "$done_file" \
      "$show_labels" \
-     "$filterable"); then
+     "$filterable" \
+     "$item_label" \
+     "$variant_label"); then
   echo "Image selector failed to accept request" >&2
   exit 1
 fi
@@ -362,8 +421,14 @@ done
 if [[ -s $selection_file ]]; then
   if [[ $print_name == true ]]; then
     selection=$(<"$selection_file")
-    selection=${selection##*/}
-    printf '%s\n' "${selection%.*}"
+
+    if [[ $group_by_dir == true ]]; then
+      selection=${selection%/*}
+      printf '%s\n' "${selection##*/}"
+    else
+      selection=${selection##*/}
+      printf '%s\n' "${selection%.*}"
+    fi
   else
     cat "$selection_file"
   fi

--- a/bin/omarchy-plymouth-switcher
+++ b/bin/omarchy-plymouth-switcher
@@ -17,4 +17,4 @@ current=$(omarchy-plymouth-current)
 selected=""
 [[ -n $current && -e $preview_dir/$current.png ]] && selected="$preview_dir/$current.png"
 
-exec omarchy-menu-images --print-name --show-labels --selected "$selected" "$preview_dir"
+exec omarchy-menu-images --print-name --show-labels --item-label theme --selected "$selected" "$preview_dir"

--- a/bin/omarchy-theme-bg-switcher
+++ b/bin/omarchy-theme-bg-switcher
@@ -9,6 +9,7 @@ theme_name=$(cat "$HOME/.local/state/omarchy/current/theme.name" 2>/dev/null)
 current_background=$(readlink -f "$HOME/.local/state/omarchy/current/background" 2>/dev/null)
 
 omarchy-menu-images \
+  --item-label background \
   --selected "$current_background" \
   "$HOME/.local/state/omarchy/current/theme/backgrounds" \
   "$HOME/.config/omarchy/backgrounds/$theme_name"

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # omarchy:summary=Apply an Omarchy theme
-# omarchy:args=<theme-name>
-# omarchy:examples=omarchy theme list | omarchy theme set "Tokyo Night"
+# omarchy:args=<theme-name> [background]
+# omarchy:examples=omarchy theme list | omarchy theme set "Tokyo Night" | omarchy theme set nord 1-city-view.webp
 
 if [[ -z $1 ]]; then
-  echo "Usage: omarchy-theme-set <theme-name>"
+  echo "Usage: omarchy-theme-set <theme-name> [background]"
   exit 1
 fi
 
@@ -97,6 +97,18 @@ choose_theme_background() {
   )
 
   (( ${#backgrounds[@]} > 0 )) || return 1
+
+  # Matched by name: the picker points at a theme's own directory, while what is
+  # applied here is the staged copy. Anything the theme does not carry falls
+  # through to the rotation.
+  if [[ -n $REQUESTED_BACKGROUND ]]; then
+    for i in "${!backgrounds[@]}"; do
+      if [[ ${backgrounds[$i]##*/} == "${REQUESTED_BACKGROUND##*/}" ]]; then
+        CHOSEN_THEME_BACKGROUND="${backgrounds[$i]}"
+        return 0
+      fi
+    done
+  fi
 
   current_background=$(readlink "$CURRENT_BACKGROUND_LINK" 2>/dev/null || true)
   if [[ $theme_path != $CURRENT_THEME_PATH && ${current_background%/*} == $current_theme_backgrounds ]]; then
@@ -275,6 +287,7 @@ report_ignored_theme_files() {
 }
 
 THEME_NAME=$(echo "$1" | sed -E 's/<[^>]+>//g' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+REQUESTED_BACKGROUND="${2:-}"
 THEME_HEADLESS=0
 if [[ ${OMARCHY_THEME_HEADLESS:-} == "1" || ${OMARCHY_THEME_OFFLINE:-} == "1" ]]; then
   THEME_HEADLESS=1

--- a/bin/omarchy-theme-switcher
+++ b/bin/omarchy-theme-switcher
@@ -2,6 +2,9 @@
 
 # omarchy:summary=Open the Omarchy theme switcher
 
+# Prints the chosen theme and the background the user stopped on, tab separated,
+# or nothing when the picker is dismissed.
+
 preload=false
 
 if [[ $1 == "--preload" ]]; then
@@ -11,6 +14,7 @@ fi
 
 USER_THEMES_PATH="$HOME/.config/omarchy/themes"
 OMARCHY_THEMES_PATH="$OMARCHY_PATH/themes"
+USER_BACKGROUNDS_PATH="$HOME/.config/omarchy/backgrounds"
 CACHE_PATH="${XDG_CACHE_HOME:-$HOME/.cache}/omarchy/theme-selector"
 preview_dir="$CACHE_PATH/previews"
 signature_file="$CACHE_PATH/signature"
@@ -18,12 +22,32 @@ fast_signature_file="$CACHE_PATH/fast-signature"
 
 mkdir -p "$preview_dir"
 
+# The line omarchy-theme-set draws before staging: a symlink in a stranger's
+# theme points wherever its author chose. Staging drops those, so offering them
+# would show an image outside the theme and then apply something else.
+theme_came_from_a_repo() {
+  local theme_path="$1"
+
+  [[ ! -L $theme_path && -d $theme_path/.git ]]
+}
+
+follow_links_in() {
+  local theme_path="$1"
+
+  if theme_came_from_a_repo "$theme_path"; then
+    printf '%s' "-P"
+  else
+    printf '%s' "-L"
+  fi
+}
+
 find_preview() {
   local theme_path="$1"
+  local follow="${2:--L}"
   local preview preview_name
 
   for preview_name in preview.png preview.jpg preview.jpeg preview.webp preview.gif preview.bmp preview.mp4 preview.m4v preview.mov preview.webm preview.mkv preview.avi; do
-    preview=$(find -L "$theme_path" -maxdepth 1 -type f -iname "$preview_name" -print -quit 2>/dev/null)
+    preview=$(find "$follow" "$theme_path" -maxdepth 1 -type f -iname "$preview_name" -print -quit 2>/dev/null)
 
     if [[ -n $preview ]]; then
       printf '%s\n' "$preview"
@@ -32,23 +56,92 @@ find_preview() {
   done
 
   if [[ -d $theme_path/backgrounds ]]; then
-    find -L "$theme_path/backgrounds" -maxdepth 1 -type f \
+    find "$follow" "$theme_path/backgrounds" -maxdepth 1 -type f \
       \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' -o -iname '*.bmp' -o -iname '*.webp' \
          -o -iname '*.mp4' -o -iname '*.m4v' -o -iname '*.mov' -o -iname '*.webm' -o -iname '*.mkv' -o -iname '*.avi' \) \
       -print 2>/dev/null | sort | head -n 1
   fi
 }
 
-add_theme_preview() {
+# Every image the picker offers for one theme, NUL separated: the preview, then
+# its backgrounds, in the precedence omarchy-theme-set stages them with -- so
+# what the picker shows is what selecting it can produce.
+theme_images() {
   local theme_name="$1"
-  local preview="$2"
-  local extension="${preview##*.}"
-  extension="${extension,,}"
+  local theme_path="$2"
+  local backgrounds=()
+  local -A seen=()
+  local background dir name preview follow dir_follow
 
-  [[ -n $preview ]] || return
-  [[ -e $preview_dir/$theme_name.$extension ]] && return
+  follow=$(follow_links_in "$theme_path")
 
-  ln -s "$preview" "$preview_dir/$theme_name.$extension"
+  for dir in "$USER_BACKGROUNDS_PATH/$theme_name" "$theme_path/backgrounds" "$OMARCHY_THEMES_PATH/$theme_name/backgrounds"; do
+    [[ -d $dir ]] || continue
+
+    # Only the theme's own directory is held to that line.
+    if [[ $dir == "$theme_path/backgrounds" ]]; then
+      dir_follow="$follow"
+    else
+      dir_follow="-L"
+    fi
+
+    while IFS= read -r -d '' background; do
+      name=${background##*/}
+      [[ -n ${seen[$name]} ]] && continue
+      seen[$name]=1
+      backgrounds+=("$background")
+    done < <(
+      find "$dir_follow" "$dir" -maxdepth 1 -type f \
+        \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' -o -iname '*.bmp' -o -iname '*.webp' \
+           -o -iname '*.mp4' -o -iname '*.m4v' -o -iname '*.mov' -o -iname '*.webm' -o -iname '*.mkv' -o -iname '*.avi' \) \
+        -print0 2>/dev/null | sort -z
+    )
+  done
+
+  preview=$(find_preview "$theme_path" "$follow")
+
+  if [[ -z $preview ]]; then
+    preview=$(find_preview "$OMARCHY_THEMES_PATH/$theme_name")
+  fi
+
+  # find_preview falls back to a first background, which is already listed below.
+  if [[ -n $preview && -z ${seen[${preview##*/}]} ]]; then
+    printf '%s\0' "$preview"
+  fi
+
+  (( ${#backgrounds[@]} > 0 )) && printf '%s\0' "${backgrounds[@]}"
+}
+
+# One directory of symlinks per theme: --group-by-dir turns each into a single
+# carousel item named for the directory, and the prefix fixes the cycle order.
+add_theme_images() {
+  local theme_name="$1"
+  local theme_path="$2"
+  local theme_dir="$preview_dir/$theme_name"
+  local image
+  local index=0
+
+  [[ -d $theme_dir ]] && return
+
+  mkdir -p "$theme_dir"
+
+  while IFS= read -r -d '' image; do
+    ln -s "$image" "$(printf '%s/%03d-%s' "$theme_dir" "$index" "${image##*/}")"
+    index=$(( index + 1 ))
+  done < <(theme_images "$theme_name" "$theme_path")
+}
+
+# A theme directory's mtime misses a background added inside it, so stat the
+# backgrounds directories too -- in one call, since this runs before every open.
+background_signature() {
+  local dir
+  local dirs=()
+
+  for dir in "$USER_BACKGROUNDS_PATH"/*/ "$USER_THEMES_PATH"/*/backgrounds "$OMARCHY_THEMES_PATH"/*/backgrounds; do
+    [[ -d $dir ]] && dirs+=("${dir%/}")
+  done
+
+  (( ${#dirs[@]} > 0 )) && stat -Lc '%n:%Y' "${dirs[@]}" 2>/dev/null
 }
 
 fast_signature="v2"$'\n'
@@ -61,6 +154,7 @@ for theme_dir in "$USER_THEMES_PATH" "$OMARCHY_THEMES_PATH"; do
     done < <(find -L "$theme_dir" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -print0 2>/dev/null | sort -z)
   fi
 done
+fast_signature+="$(background_signature)"$'\n'
 
 if [[ ! -f $fast_signature_file ]] || ! cmp -s "$fast_signature_file" <(printf '%s' "$fast_signature"); then
   theme_signature=""
@@ -85,44 +179,67 @@ if [[ ! -f $fast_signature_file ]] || ! cmp -s "$fast_signature_file" <(printf '
   mkdir -p "$preview_dir"
 
   while IFS= read -r theme_path; do
-    theme_name=${theme_path##*/}
-    preview=$(find_preview "$theme_path")
-
-    if [[ -z $preview ]]; then
-      preview=$(find_preview "$OMARCHY_THEMES_PATH/$theme_name")
-    fi
-
-    add_theme_preview "$theme_name" "$preview"
+    add_theme_images "${theme_path##*/}" "$theme_path"
   done < <(find -L "$USER_THEMES_PATH" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -print 2>/dev/null | sort)
 
   while IFS= read -r theme_path; do
-    theme_name=${theme_path##*/}
-    preview=$(find_preview "$theme_path")
-    add_theme_preview "$theme_name" "$preview"
+    add_theme_images "${theme_path##*/}" "$theme_path"
   done < <(find -L "$OMARCHY_THEMES_PATH" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null | sort)
 
   printf '%s' "$theme_signature" >"$signature_file"
   printf '%s' "$fast_signature" >"$fast_signature_file"
 fi
 
+theme_dirs=()
+for theme_dir in "$preview_dir"/*/; do
+  [[ -d $theme_dir ]] && theme_dirs+=("${theme_dir%/}")
+done
+
+(( ${#theme_dirs[@]} > 0 )) || exit 0
+
+# The preview the picker has always opened on, not whichever background is up.
 current_theme=$(cat "$HOME/.local/state/omarchy/current/theme.name" 2>/dev/null)
-selected_preview=""
-for extension in png jpg jpeg webp gif bmp mp4 m4v mov webm mkv avi; do
-  if [[ -e $preview_dir/$current_theme.$extension ]]; then
-    selected_preview="$preview_dir/$current_theme.$extension"
+selected_image=""
+
+for link in "$preview_dir/$current_theme"/*; do
+  if [[ -e $link ]]; then
+    selected_image="$link"
     break
   fi
 done
+
 menu_args=(
-  --print-name
   --show-labels
   --filterable
+  --group-by-dir
+  --item-label theme
+  --variant-label background
   --lazy-thumbnails
-  --selected "$selected_preview"
+  --selected "$selected_image"
 )
 
 if [[ $preload == true ]]; then
   menu_args+=(--preload)
 fi
 
-exec omarchy-menu-images "${menu_args[@]}" "$preview_dir"
+selection=$(omarchy-menu-images "${menu_args[@]}" "${theme_dirs[@]}")
+
+if [[ -n $selection ]]; then
+  theme_name=${selection%/*}
+  # Resolve only the picker-cache link. The target may itself be a user-owned
+  # alias whose basename must survive so theme staging can match it exactly.
+  background=$(readlink "$selection")
+  background_dir=${background%/*}
+  background_name=${background##*/}
+  theme_name=${theme_name##*/}
+
+  # A real preview means the user declined to choose a background, so preserve
+  # the theme's normal rotation. If the theme has no preview, its first variant
+  # is an actual background and must be applied like every other one.
+  if [[ ${selection##*/} == 000-* && ${background_name,,} =~ ^preview\.(png|jpg|jpeg|webp|gif|bmp|mp4|m4v|mov|webm|mkv|avi)$ ]] &&
+     [[ $background_dir == "$USER_THEMES_PATH/$theme_name" || $background_dir == "$OMARCHY_THEMES_PATH/$theme_name" ]]; then
+    background=""
+  fi
+
+  printf '%s\t%s\n' "$theme_name" "$background"
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -101,7 +101,7 @@
   "trigger.tests.disk-speedtest": {"icon":"󰋊","label":"Disk Speed Test","action":"omarchy-shell shell summon omarchy.disk-speedtest"},
 
   // Style
-  "style.theme": {"icon":"󰸌","label":"Theme","aliases":["theme","themes"],"action":"theme=$(omarchy-theme-switcher); [[ -n $theme ]] && omarchy-theme-set \"$theme\""},
+  "style.theme": {"icon":"󰸌","label":"Theme","aliases":["theme","themes"],"action":"IFS=$'\\t' read -r theme background < <(omarchy-theme-switcher); [[ -n $theme ]] && omarchy-theme-set \"$theme\" \"$background\""},
   "style.background": {"icon":"","label":"Background","aliases":["background","wallpaper"],"action":"background=$(omarchy-theme-bg-switcher); [[ -n $background ]] && omarchy-theme-bg-set \"$background\""},
   "style.unlock": {"icon":"󰟵","label":"Unlock","aliases":["unlock"],"action":"unlock=$(omarchy-plymouth-switcher); if [[ $unlock == default ]]; then omarchy-launch-floating-terminal-with-presentation omarchy-plymouth-reset; elif [[ -n $unlock ]]; then omarchy-launch-floating-terminal-with-presentation \"omarchy-plymouth-set-by-theme $(printf %q \"$unlock\")\"; fi"},
   "style.font": {"icon":"","label":"Font","provider":"fonts"},

--- a/manual/06-themes.md
+++ b/manual/06-themes.md
@@ -4,7 +4,7 @@ Omarchy comes with twenty-two beautiful themes. You can select between them via 
 
 Each theme styles the desktop, terminal, neovim, activity screen (btop), Chromium, and the entire Omarchy shell: top bar, menu, notifications, OSD, and the lock screen. (For Obsidian, you must manually select the Omarchy theme via _Appearance > Themes_ inside the app).
 
-Themes have a set of background images that you can pick between using `Super + Ctrl + Space`.
+Themes have a set of background images that you can pick between using `Super + Ctrl + Space`. You can also see them from the theme selector itself: left and right move between themes, and up and down cycle through the backgrounds that theme ships, so you can see exactly what you're picking before you pick it. The background you stop on is the one you get.
 
 You can find even more themes on [the extra themes page](https://omarchy.org/themes/) or even [make your own theme](43-making-your-own-theme.md).
 

--- a/manual/39-backgrounds.md
+++ b/manual/39-backgrounds.md
@@ -2,7 +2,7 @@
 
 Every theme ships with its own set of backgrounds, and you can add extras of your own in `~/.config/omarchy/backgrounds/[theme]`. If you want to add an extra background image to, say, the nord theme, you just put the file in `~/.config/omarchy/backgrounds/nord`.
 
-You can do this most easily by going to _Install > Style > Background_ in the Omarchy Menu. That'll bring up the folder where the backgrounds for that theme is stored. Hit `Super + Shift + F` to start another file manager, find your background, copy it over.  Now it'll be included in the choices of backgrounds you can select between using `Super + Ctrl + Space`.
+You can do this most easily by going to _Install > Style > Background_ in the Omarchy Menu. That'll bring up the folder where the backgrounds for that theme is stored. Hit `Super + Shift + F` to start another file manager, find your background, copy it over.  Now it'll be included in the choices of backgrounds you can select between using `Super + Ctrl + Space`, and in the ones you cycle through with up and down in the theme selector.
 
 Backgrounds can be videos as well as stills. Drop an `mp4`, `m4v`, `mov`, `webm`, `mkv`, or `avi` file in the same folder and it appears alongside the images, playing on a loop. Only your first monitor's wallpaper plays a video's sound track, through the default audio output at the system volume, and the lock screen stays silent. Playback stops on its own whenever nothing can see it — while a fullscreen window covers that monitor, while the screensaver is up, and once a locked screen has gone dark — but a video wallpaper still costs far more power than a still one, and each monitor decodes its own copy.
 

--- a/shell/plugins/README.md
+++ b/shell/plugins/README.md
@@ -59,19 +59,30 @@ Two ways to drive it:
 
 - Shell-level summon: `omarchy-shell shell summon omarchy.image-picker '<jsonPayload>'`.
   The payload can carry `imageDirs`, `imageRows`, `selectedImage`,
-  `selectionFile`, `doneFile`, `showLabels`, `filterable`. Best for
-  in-shell callers that already speak JSON.
-- Direct IPC target: `omarchy-shell image-selector open <imageDirs> <imageRowsB64> <selectedImage> <selectionFile> <doneFile> <showLabels> <filterable>`.
+  `selectionFile`, `doneFile`, `showLabels`, `filterable`, `itemLabel`,
+  `variantLabel`. The last two name what each axis moves between ("theme",
+  "background") for the arrow-key hint; only the caller knows those. Best
+  for in-shell callers that already speak JSON.
+- Direct IPC target: `omarchy-shell image-selector open <imageDirs> <imageRowsB64> <selectedImage> <selectionFile> <doneFile> <showLabels> <filterable> <itemLabel> <variantLabel>`.
   Positional args; `imageRowsB64` is base64-encoded so embedded newlines /
   tabs survive the bash argv handoff. This is what `omarchy-menu-images`
   uses. Colors come from the central shell theme singleton; there is no
   per-call override surface.
 
+A row is `filePath \t thumbnailPath \t group`, where the group is
+optional. Rows sharing a group collapse into one carousel item: the first
+is what the carousel shows, the rest are variants the picker cycles
+through with up/down while left/right still walks the items. That is how
+the theme picker offers a theme's backgrounds — `omarchy-menu-images
+--group-by-dir` groups each image directory under its own name, and
+`omarchy-theme-switcher` hands it one directory per theme.
+
 The selection round-trip remains file-based: callers create a
 `selection_file` and `done_file` (both `mktemp`), pass the paths, and
-poll `done_file` for existence. The plugin writes the chosen path into
-`selection_file` and touches `done_file` when it's done. `cancel` IPC
-clears it without writing a selection.
+poll `done_file` for existence. The plugin writes the chosen path — the
+variant the user stopped on, for a grouped item — into `selection_file`
+and touches `done_file` when it's done. `cancel` IPC clears it without
+writing a selection.
 
 The plugin has `keepLoaded: true` so the layer-shell window survives
 between summons within a single shell session.

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -144,7 +144,7 @@ Item {
 
   Process {
     id: themeSwitchProc
-    command: ["bash", "-c", "theme=$(omarchy-theme-switcher); [[ -n $theme ]] && omarchy-theme-set \"$theme\" >/dev/null 2>&1 &"]
+    command: ["bash", "-c", "IFS=$'\\t' read -r theme background < <(omarchy-theme-switcher); [[ -n $theme ]] && omarchy-theme-set \"$theme\" \"$background\" >/dev/null 2>&1 &"]
     onExited: root.refreshBackground()
   }
 

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -19,10 +19,14 @@ Item {
   property string selectionFile: Quickshell.env("OMARCHY_IMAGE_SELECTOR_SELECTION_FILE") || Quickshell.env("OMARCHY_BACKGROUND_SELECTION_FILE")
   property string selectedImage: Quickshell.env("OMARCHY_IMAGE_SELECTOR_SELECTED")
   property int selectedIndex: 0
+  property int selectedVariant: 0
   property bool imagesLoaded: false
   property bool opened: false
   property bool showLabels: false
   property bool filterable: false
+  // Only the caller knows whether left and right walk themes or wallpapers.
+  property string itemLabel: ""
+  property string variantLabel: ""
   property bool layoutSettled: false
   property bool requestActive: false
   property int requestSerial: 0
@@ -44,7 +48,21 @@ Item {
   property int sliceHeight: 432
   property int sliceSpacing: -30
   property int skewOffset: 28
-  property int bottomChromeHeight: showLabels ? (filterable ? 104 : 74) : (filterable ? 60 : 30)
+  // The vertical peek is a slice turned on its side, so both axes expose the
+  // same fraction of a neighbour and retuning one carries the other.
+  readonly property real peekScale: expandedHeight / expandedWidth
+  readonly property int variantPeekHeight: Math.round(sliceWidth * peekScale)
+  readonly property int variantPeekOverlap: Math.round(-sliceSpacing * peekScale)
+  // Reserved from the whole model: a theme shipping one background would
+  // otherwise shift the preview whenever selection landed on it.
+  readonly property bool hasVariants: ImagePickerModel.maxVariantCount(imageArray) > 1
+  readonly property int variantPeekInset: hasVariants ? variantPeekHeight - variantPeekOverlap : 0
+  readonly property int columnHeight: expandedHeight + 2 * variantPeekInset
+  // Leaning the taller column at the preview's old rate keeps its edges put.
+  readonly property real columnSkew: skewOffset * (columnHeight / expandedHeight)
+  readonly property bool showsNavigationHint: imageArray.length > 1 || hasVariants
+  readonly property int navigationHintHeight: showsNavigationHint ? Style.space(20) : 0
+  property int bottomChromeHeight: (showLabels ? (filterable ? 104 : 74) : (filterable ? 60 : 30)) + navigationHintHeight
 
   onOpenedChanged: if (!opened) layoutSettled = false
 
@@ -68,22 +86,47 @@ Item {
 
   function currentPath() {
     if (imageArray.length === 0 || !itemMatches(selectedIndex)) return ""
-    return imageArray[selectedIndex].filePath
+    var variant = ImagePickerModel.variantAt(imageArray, selectedIndex, selectedVariant)
+    return variant ? variant.filePath : ""
   }
 
-  function nameForPath(path) {
-    return ImagePickerModel.nameForPath(path)
+  function variantCount(index) {
+    return ImagePickerModel.variantCount(imageArray, index)
   }
 
-  function labelForPath(path) {
-    return ImagePickerModel.labelForPath(path)
+  function variantThumbnail(index, variant) {
+    var value = ImagePickerModel.variantAt(imageArray, index, variant)
+    return value ? value.thumbnailPath : ""
+  }
+
+  function variantPeek(offset) {
+    if (variantCount(selectedIndex) <= 1) return ""
+    return variantThumbnail(selectedIndex, selectedVariant + offset)
+  }
+
+  function cycleVariant(direction) {
+    var count = variantCount(selectedIndex)
+    if (count <= 1) return
+
+    selectedVariant = (selectedVariant + direction + count) % count
+  }
+
+  function navigationHintText() {
+    var hints = []
+
+    if (imageArray.length > 1)
+      hints.push("\u2190 \u2192" + (itemLabel ? "  " + itemLabel : ""))
+
+    if (variantCount(selectedIndex) > 1)
+      hints.push("\u2191 \u2193" + (variantLabel ? "  " + variantLabel : ""))
+
+    return hints.join("\u2003\u2003")
   }
 
   function currentLabel() {
-    var path = currentPath()
-    if (!path) return filterText ? "No matches" : ""
+    if (!currentPath()) return filterText ? "No matches" : ""
 
-    return labelForPath(path)
+    return ImagePickerModel.labelForItem(imageArray, selectedIndex)
   }
 
   function itemMatches(index) {
@@ -110,6 +153,7 @@ Item {
     if (index === selectedIndex && immediate !== true) return
 
     selectedIndex = index
+    selectedVariant = 0
   }
 
   function selectAdjacent(direction) {
@@ -131,7 +175,10 @@ Item {
 
     if (!itemMatches(selectedIndex)) {
       var first = ImagePickerModel.nextSelectedIndexForFilter(imageArray, selectedIndex, filterText)
-      if (first >= 0) selectedIndex = first
+      if (first >= 0) {
+        selectedIndex = first
+        selectedVariant = 0
+      }
     }
   }
 
@@ -195,10 +242,12 @@ Item {
 
   function loadRows(rows, reveal) {
     var newImages = ImagePickerModel.loadRows(rows)
+    var location = root.locateSelectedImage(newImages)
 
     root.loadedImageRows = rows
-    root.selectedIndex = root.indexForSelectedImage(newImages)
+    root.selectedIndex = location.index
     root.imageArray = newImages
+    root.selectedVariant = location.variant
     root.imagesLoaded = true
 
     if (reveal !== false) {
@@ -207,7 +256,7 @@ Item {
     }
   }
 
-  function openSelector(nextImageDirs, nextImageRows, nextSelectedImage, nextSelectionFile, nextDoneFile, nextShowLabels, nextFilterable) {
+  function openSelector(nextImageDirs, nextImageRows, nextSelectedImage, nextSelectionFile, nextDoneFile, nextShowLabels, nextFilterable, nextItemLabel, nextVariantLabel) {
     if (requestActive && doneFile && doneFile !== nextDoneFile)
       finishDoneFile(doneFile)
 
@@ -221,11 +270,15 @@ Item {
     requestActive = !!doneFile
     showLabels = nextShowLabels === true || nextShowLabels === "true"
     filterable = nextFilterable === true || nextFilterable === "true"
+    itemLabel = nextItemLabel || ""
+    variantLabel = nextVariantLabel || ""
     filterText = ""
     layoutSettled = false
 
     if (imageRows && imageRows === loadedImageRows && imageArray.length > 0) {
-      root.select(root.selectedImageIndex(), true)
+      var location = root.locateSelectedImage(imageArray)
+      root.select(location.index, true)
+      root.selectedVariant = location.variant
       imagesLoaded = true
       opened = true
       root.revealWhenSettled(requestSerial)
@@ -237,6 +290,7 @@ Item {
       var rowsSerial = requestSerial
       imageArray = []
       selectedIndex = 0
+      selectedVariant = 0
       imagesLoaded = true
       opened = true
       Qt.callLater(function() {
@@ -248,6 +302,7 @@ Item {
 
     imageArray = []
     selectedIndex = 0
+    selectedVariant = 0
     imagesLoaded = false
     opened = false
     startImageScan(requestSerial, imageDirs)
@@ -269,12 +324,8 @@ Item {
     loadImagesProc.running = true
   }
 
-  function indexForSelectedImage(images) {
-    return ImagePickerModel.indexForSelectedImage(images, selectedImage)
-  }
-
-  function selectedImageIndex() {
-    return indexForSelectedImage(imageArray)
+  function locateSelectedImage(images) {
+    return ImagePickerModel.locateImage(images, selectedImage)
   }
 
   Process {
@@ -316,7 +367,8 @@ Item {
     var doneF = String(args.doneFile || "")
     var labels = args.showLabels === true || args.showLabels === "true"
     var filter = args.filterable === true || args.filterable === "true"
-    openSelector(dirs, rows, sel, selFile, doneF, labels, filter)
+    openSelector(dirs, rows, sel, selFile, doneF, labels, filter,
+                 String(args.itemLabel || ""), String(args.variantLabel || ""))
   }
 
   function close() {
@@ -339,7 +391,9 @@ Item {
     layoutSettled = false
 
     if (imageRows && imageRows === loadedImageRows && imageArray.length > 0) {
-      selectedIndex = selectedImageIndex()
+      var location = root.locateSelectedImage(imageArray)
+      selectedIndex = location.index
+      selectedVariant = location.variant
       imagesLoaded = true
     } else if (imageRows) {
       loadRows(imageRows, false)
@@ -386,7 +440,7 @@ Item {
       id: card
       visible: root.opened && root.imagesLoaded && root.layoutSettled && root.imageArray.length > 0
       width: Math.min(parent.width - 80, root.expandedWidth + 13 * (root.sliceWidth + root.sliceSpacing) + 40)
-      height: root.expandedHeight + Style.space(30) + root.bottomChromeHeight
+      height: root.columnHeight + Style.space(30) + root.bottomChromeHeight
       anchors.centerIn: parent
 
         MouseArea { anchors.fill: parent; onClicked: {} }
@@ -426,6 +480,12 @@ Item {
             } else if (event.key === Qt.Key_Right || event.key === Qt.Key_Tab) {
               root.selectAdjacent(1)
               event.accepted = true
+            } else if (event.key === Qt.Key_Up) {
+              root.cycleVariant(-1)
+              event.accepted = true
+            } else if (event.key === Qt.Key_Down) {
+              root.cycleVariant(1)
+              event.accepted = true
             } else if (root.filterable && event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
               root.updateFilter(root.filterText + event.text)
               event.accepted = true
@@ -444,7 +504,7 @@ Item {
               readonly property var imageData: root.imageArray[index]
               readonly property string filePath: imageData ? imageData.filePath : ""
               readonly property string fileName: imageData ? imageData.fileName : ""
-              readonly property string thumbnailPath: imageData ? imageData.thumbnailPath : ""
+              readonly property string thumbnailPath: selected ? root.variantThumbnail(index, root.selectedVariant) : (imageData ? imageData.thumbnailPath : "")
 
               readonly property bool matched: root.itemMatches(index)
               readonly property int relativeIndex: root.filteredPosition(index) - root.selectedFilteredPosition()
@@ -457,81 +517,24 @@ Item {
               x: selected ? carousel.previewX : (relativeIndex < 0 ? carousel.previewX + relativeIndex * carousel.itemStep : carousel.previewX + root.expandedWidth + root.sliceSpacing + (relativeIndex - 1) * carousel.itemStep)
               width: selected ? root.expandedWidth : root.sliceWidth
               height: selected ? root.expandedHeight : root.sliceHeight
-              y: selected ? 0 : (root.expandedHeight - root.sliceHeight) / 2
+              y: root.variantPeekInset + (selected ? 0 : (root.expandedHeight - root.sliceHeight) / 2)
               z: selected ? 100 : 50 - Math.min(Math.abs(relativeIndex), 40)
 
-              readonly property real skAbs: Math.abs(root.skewOffset)
-              readonly property real topLeft: root.skewOffset >= 0 ? skAbs : 0
-              readonly property real topRight: root.skewOffset >= 0 ? width : width - skAbs
-              readonly property real bottomRight: root.skewOffset >= 0 ? width - skAbs : width
-              readonly property real bottomLeft: root.skewOffset >= 0 ? 0 : skAbs
-
-              Item {
-                id: maskShape
+              // The selected item leans as part of the column it shares with
+              // its bands; every other slice is its own column.
+              SkewedImage {
                 anchors.fill: parent
-                visible: false
-                layer.enabled: true
-
-                Shape {
-                  anchors.fill: parent
-                  antialiasing: true
-                  preferredRendererType: Shape.CurveRenderer
-                  ShapePath {
-                    fillColor: "white"
-                    strokeColor: "transparent"
-                    startX: item.topLeft; startY: 0
-                    PathLine { x: item.topRight; y: 0 }
-                    PathLine { x: item.bottomRight; y: item.height }
-                    PathLine { x: item.bottomLeft; y: item.height }
-                    PathLine { x: item.topLeft; y: 0 }
-                  }
-                }
-              }
-
-              Item {
-                anchors.fill: parent
-                layer.enabled: true
-                layer.smooth: true
-                layer.effect: MultiEffect {
-                  maskEnabled: true
-                  maskSource: maskShape
-                  maskThresholdMin: 0.3
-                  maskSpreadAtMin: 0.3
-                }
-
-                Image {
-                  id: image
-                  anchors.fill: parent
-                  // Load only the initial/visited nearby images, but keep the
-                  // source once activated so Qt does not tear textures down as
-                  // selection moves through the carousel.
-                  source: item.sourceActivated && item.thumbnailPath ? Util.fileUrl(item.thumbnailPath) : ""
-                  fillMode: Image.PreserveAspectCrop
-                  asynchronous: false
-                  cache: true
-                  smooth: true
-                }
-
-                Rectangle {
-                  anchors.fill: parent
-                  color: Util.alpha(root.dimColor, item.selected ? 0 : 0.42)
-                }
-              }
-
-              Shape {
-                anchors.fill: parent
-                antialiasing: true
-                preferredRendererType: Shape.CurveRenderer
-                ShapePath {
-                  fillColor: "transparent"
-                  strokeColor: item.selected ? root.selectedBorder : root.unselectedBorder
-                  strokeWidth: item.selected ? 3 : 1
-                  startX: item.topLeft; startY: 0
-                  PathLine { x: item.topRight; y: 0 }
-                  PathLine { x: item.bottomRight; y: item.height }
-                  PathLine { x: item.bottomLeft; y: item.height }
-                  PathLine { x: item.topLeft; y: 0 }
-                }
+                // Load only the initial/visited nearby images, but keep the
+                // source once activated so Qt does not tear textures down as
+                // selection moves through the carousel.
+                source: item.sourceActivated ? item.thumbnailPath : ""
+                skewOffset: item.selected ? root.columnSkew : root.skewOffset
+                columnHeight: item.selected ? root.columnHeight : item.height
+                columnTop: item.selected ? root.variantPeekInset : 0
+                dimColor: root.dimColor
+                dimOpacity: item.selected ? 0 : 0.42
+                borderColor: item.selected ? root.selectedBorder : root.unselectedBorder
+                borderWidth: item.selected ? 3 : 1
               }
 
               MouseArea {
@@ -540,6 +543,41 @@ Item {
                 onClicked: item.selected ? root.applySelected() : root.select(index)
               }
             }
+          }
+
+          // The vertical answer to the slices fanned out either side.
+          SkewedImage {
+            visible: root.variantCount(root.selectedIndex) > 1
+            x: carousel.previewX
+            y: 0
+            z: 90
+            width: root.expandedWidth
+            height: root.variantPeekHeight
+            source: root.variantPeek(-1)
+            skewOffset: root.columnSkew
+            columnHeight: root.columnHeight
+            columnTop: 0
+            dimColor: root.dimColor
+            dimOpacity: 0.42
+            borderColor: root.unselectedBorder
+            borderWidth: 1
+          }
+
+          SkewedImage {
+            visible: root.variantCount(root.selectedIndex) > 1
+            x: carousel.previewX
+            y: root.columnHeight - root.variantPeekHeight
+            z: 90
+            width: root.expandedWidth
+            height: root.variantPeekHeight
+            source: root.variantPeek(1)
+            skewOffset: root.columnSkew
+            columnHeight: root.columnHeight
+            columnTop: root.columnHeight - root.variantPeekHeight
+            dimColor: root.dimColor
+            dimOpacity: 0.42
+            borderColor: root.unselectedBorder
+            borderWidth: 1
           }
         }
 
@@ -563,9 +601,25 @@ Item {
 
         Text {
           textFormat: Text.PlainText
+          id: navigationHint
+          visible: root.showsNavigationHint
+          // A hidden label still holds its slot, which the chrome has no room for.
+          anchors.top: root.showLabels ? selectedLabel.bottom : carousel.bottom
+          anchors.topMargin: Style.space(root.showLabels ? 10 : 16)
+          anchors.horizontalCenter: carousel.horizontalCenter
+          text: root.navigationHintText()
+          color: root.foreground
+          opacity: 0.5
+          style: Text.Outline
+          styleColor: Util.alpha(root.dimColor, 0.7)
+          font.pixelSize: Style.font.subtitle
+        }
+
+        Text {
+          textFormat: Text.PlainText
           visible: root.filterable && root.filterText
-          anchors.top: selectedLabel.bottom
-          anchors.topMargin: Style.space(8)
+          anchors.top: navigationHint.bottom
+          anchors.topMargin: Style.space(6)
           anchors.horizontalCenter: carousel.horizontalCenter
           width: root.expandedWidth
           text: root.filterText

--- a/shell/plugins/image-picker/ImagePickerModel.js
+++ b/shell/plugins/image-picker/ImagePickerModel.js
@@ -2,17 +2,25 @@ function nameForPath(path) {
   return String(path || "").split("/").pop().replace(/\.[^/.]+$/, "")
 }
 
-function labelForPath(path) {
-  return nameForPath(path).replace(/[-_]+/g, " ").replace(/\b\w/g, function(match) { return match.toUpperCase() })
+function titleize(name) {
+  return String(name || "").replace(/[-_]+/g, " ").replace(/\b\w/g, function(match) { return match.toUpperCase() })
 }
 
+function labelForPath(path) {
+  return titleize(nameForPath(path))
+}
+
+// A row is `filePath \t thumbnailPath \t group`, the group optional. Rows
+// sharing a group collapse into one carousel item; the rest of the group
+// becomes variants the picker cycles through with up/down.
 function loadRows(rows) {
   var images = []
   var seen = {}
-  var paths = String(rows || "").split("\n")
+  var groups = {}
+  var lines = String(rows || "").split("\n")
 
-  for (var i = 0; i < paths.length; i++) {
-    var row = paths[i]
+  for (var i = 0; i < lines.length; i++) {
+    var row = lines[i]
     if (!row) continue
 
     var columns = row.split("\t")
@@ -20,17 +28,77 @@ function loadRows(rows) {
     if (!path) continue
 
     var fileName = path.split("/").pop()
-    if (seen[fileName]) continue
-    seen[fileName] = true
+    var group = columns[2] || ""
+    var key = group + "\n" + fileName
+    if (seen[key]) continue
+    seen[key] = true
 
-    images.push({
+    var variant = {
       filePath: path,
       fileName: fileName,
       thumbnailPath: columns[1] || path
+    }
+
+    if (group && groups.hasOwnProperty(group)) {
+      images[groups[group]].variants.push(variant)
+      continue
+    }
+
+    if (group) groups[group] = images.length
+
+    images.push({
+      filePath: variant.filePath,
+      fileName: variant.fileName,
+      thumbnailPath: variant.thumbnailPath,
+      group: group,
+      variants: [variant]
     })
   }
 
   return images
+}
+
+function variantsOf(images, index) {
+  if (!Array.isArray(images) || index < 0 || index >= images.length) return []
+  return images[index].variants || [images[index]]
+}
+
+function variantCount(images, index) {
+  return variantsOf(images, index).length
+}
+
+function variantAt(images, index, variant) {
+  var variants = variantsOf(images, index)
+  if (variants.length === 0) return null
+
+  var position = variant % variants.length
+  if (position < 0) position += variants.length
+
+  return variants[position]
+}
+
+function maxVariantCount(images) {
+  var values = Array.isArray(images) ? images : []
+  var most = 0
+
+  for (var i = 0; i < values.length; i++) {
+    most = Math.max(most, variantCount(values, i))
+  }
+
+  return most
+}
+
+// A grouped item's own file is only the first of several; the group is what the
+// user is choosing.
+function nameForItem(images, index) {
+  if (!Array.isArray(images) || index < 0 || index >= images.length) return ""
+
+  var item = images[index]
+  return item.group ? item.group : nameForPath(item.filePath)
+}
+
+function labelForItem(images, index) {
+  return titleize(nameForItem(images, index))
 }
 
 function itemMatches(images, index, filterText) {
@@ -38,9 +106,9 @@ function itemMatches(images, index, filterText) {
   var needle = String(filterText || "").toLowerCase()
   if (!needle) return true
 
-  var path = String(images[index].filePath || "")
-  return nameForPath(path).toLowerCase().indexOf(needle) !== -1
-      || labelForPath(path).toLowerCase().indexOf(needle) !== -1
+  var name = nameForItem(images, index)
+  return name.toLowerCase().indexOf(needle) !== -1
+      || titleize(name).toLowerCase().indexOf(needle) !== -1
 }
 
 function firstMatchingIndex(images, filterText) {
@@ -68,13 +136,21 @@ function selectedFilteredPosition(images, selectedIndex, filterText) {
   return itemMatches(images, selectedIndex, filterText) ? filteredPosition(images, selectedIndex, filterText) : 0
 }
 
-function indexForSelectedImage(images, selectedImage) {
+// Which item a path sits in, and which of that item's variants.
+function locateImage(images, selectedImage) {
   var values = Array.isArray(images) ? images : []
   for (var i = 0; i < values.length; i++) {
-    if (values[i].filePath === selectedImage) return i
+    var variants = variantsOf(values, i)
+    for (var variant = 0; variant < variants.length; variant++) {
+      if (variants[variant].filePath === selectedImage) return { index: i, variant: variant }
+    }
   }
 
-  return 0
+  return { index: 0, variant: 0 }
+}
+
+function indexForSelectedImage(images, selectedImage) {
+  return locateImage(images, selectedImage).index
 }
 
 function nextSelectedIndexForFilter(images, selectedIndex, filterText) {
@@ -87,10 +163,17 @@ if (typeof module !== "undefined") {
     nameForPath: nameForPath,
     labelForPath: labelForPath,
     loadRows: loadRows,
+    variantsOf: variantsOf,
+    variantCount: variantCount,
+    variantAt: variantAt,
+    maxVariantCount: maxVariantCount,
+    nameForItem: nameForItem,
+    labelForItem: labelForItem,
     itemMatches: itemMatches,
     firstMatchingIndex: firstMatchingIndex,
     filteredPosition: filteredPosition,
     selectedFilteredPosition: selectedFilteredPosition,
+    locateImage: locateImage,
     indexForSelectedImage: indexForSelectedImage,
     nextSelectedIndexForFilter: nextSelectedIndexForFilter
   }

--- a/shell/plugins/image-picker/SkewedImage.qml
+++ b/shell/plugins/image-picker/SkewedImage.qml
@@ -1,0 +1,97 @@
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Shapes
+import qs.Commons
+
+// One image clipped to the carousel's leaning quad. The lean belongs to the
+// column rather than the quad: `columnTop` places this quad inside a column
+// `columnHeight` tall, so a short band leans like the tall preview above it.
+Item {
+  id: root
+
+  property string source: ""
+  property real skewOffset: 0
+  property real columnHeight: height
+  property real columnTop: 0
+  property real dimOpacity: 0
+  property color dimColor: "black"
+  property color borderColor: "transparent"
+  property int borderWidth: 0
+
+  readonly property real skewAbs: Math.abs(skewOffset)
+  readonly property real span: width - skewAbs
+
+  function leftAt(offset) {
+    var progress = columnHeight > 0 ? offset / columnHeight : 0
+    return skewOffset >= 0 ? skewAbs * (1 - progress) : skewAbs * progress
+  }
+
+  readonly property real topLeft: leftAt(columnTop)
+  readonly property real bottomLeft: leftAt(columnTop + height)
+  readonly property real topRight: topLeft + span
+  readonly property real bottomRight: bottomLeft + span
+
+  Item {
+    id: maskShape
+    anchors.fill: parent
+    visible: false
+    layer.enabled: true
+
+    Shape {
+      anchors.fill: parent
+      antialiasing: true
+      preferredRendererType: Shape.CurveRenderer
+      ShapePath {
+        fillColor: "white"
+        strokeColor: "transparent"
+        startX: root.topLeft; startY: 0
+        PathLine { x: root.topRight; y: 0 }
+        PathLine { x: root.bottomRight; y: root.height }
+        PathLine { x: root.bottomLeft; y: root.height }
+        PathLine { x: root.topLeft; y: 0 }
+      }
+    }
+  }
+
+  Item {
+    anchors.fill: parent
+    layer.enabled: true
+    layer.smooth: true
+    layer.effect: MultiEffect {
+      maskEnabled: true
+      maskSource: maskShape
+      maskThresholdMin: 0.3
+      maskSpreadAtMin: 0.3
+    }
+
+    Image {
+      anchors.fill: parent
+      source: root.source ? Util.fileUrl(root.source) : ""
+      fillMode: Image.PreserveAspectCrop
+      asynchronous: false
+      cache: true
+      smooth: true
+    }
+
+    Rectangle {
+      anchors.fill: parent
+      color: Util.alpha(root.dimColor, root.dimOpacity)
+    }
+  }
+
+  Shape {
+    anchors.fill: parent
+    antialiasing: true
+    preferredRendererType: Shape.CurveRenderer
+    ShapePath {
+      fillColor: "transparent"
+      strokeColor: root.borderColor
+      strokeWidth: root.borderWidth
+      startX: root.topLeft; startY: 0
+      PathLine { x: root.topRight; y: 0 }
+      PathLine { x: root.bottomRight; y: root.height }
+      PathLine { x: root.bottomLeft; y: root.height }
+      PathLine { x: root.topLeft; y: 0 }
+    }
+  }
+}

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -1529,7 +1529,9 @@ ShellRoot {
                   selectionFile: string,
                   doneFile: string,
                   showLabels: string,
-                  filterable: string): string {
+                  filterable: string,
+                  itemLabel: string,
+                  variantLabel: string): string {
       var payload = JSON.stringify({
         imageDirs: imageDirs,
         imageRows: Util.decodeBase64(imageRowsB64),
@@ -1537,7 +1539,9 @@ ShellRoot {
         selectionFile: selectionFile,
         doneFile: doneFile,
         showLabels: showLabels,
-        filterable: filterable
+        filterable: filterable,
+        itemLabel: itemLabel,
+        variantLabel: variantLabel
       })
       return shell.summon("omarchy.image-picker", payload) ? "ok" : "unknown"
     }

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -7,8 +7,8 @@ const fs = require('fs')
 const backgroundQml = fs.readFileSync(path.join(root, 'shell/plugins/background/Background.qml'), 'utf8')
 
 assert(
-  /theme=\$\(omarchy-theme-switcher\); \[\[ -n \$theme \]\] && omarchy-theme-set \\"\$theme\\" >\/dev\/null 2>&1 &/.test(backgroundQml),
-  'background theme switcher starts theme application asynchronously after selection'
+  /read -r theme background < <\(omarchy-theme-switcher\); \[\[ -n \$theme \]\] && omarchy-theme-set \\"\$theme\\" \\"\$background\\" >\/dev\/null 2>&1 &/.test(backgroundQml),
+  'background theme switcher applies the picked theme and background asynchronously after selection'
 )
 
 assert(

--- a/test/shell.d/image-picker-test.sh
+++ b/test/shell.d/image-picker-test.sh
@@ -24,9 +24,27 @@ const images = picker.loadRows(rows)
 assertDeepEqual(
   images,
   [
-    { filePath: '/themes/a/nord-river.png', fileName: 'nord-river.png', thumbnailPath: '/cache/nord-river.jpg' },
-    { filePath: '/themes/a/gruvbox-dark.jpeg', fileName: 'gruvbox-dark.jpeg', thumbnailPath: '/themes/a/gruvbox-dark.jpeg' },
-    { filePath: '/themes/a/plain', fileName: 'plain', thumbnailPath: '/themes/a/plain' }
+    {
+      filePath: '/themes/a/nord-river.png',
+      fileName: 'nord-river.png',
+      thumbnailPath: '/cache/nord-river.jpg',
+      group: '',
+      variants: [{ filePath: '/themes/a/nord-river.png', fileName: 'nord-river.png', thumbnailPath: '/cache/nord-river.jpg' }]
+    },
+    {
+      filePath: '/themes/a/gruvbox-dark.jpeg',
+      fileName: 'gruvbox-dark.jpeg',
+      thumbnailPath: '/themes/a/gruvbox-dark.jpeg',
+      group: '',
+      variants: [{ filePath: '/themes/a/gruvbox-dark.jpeg', fileName: 'gruvbox-dark.jpeg', thumbnailPath: '/themes/a/gruvbox-dark.jpeg' }]
+    },
+    {
+      filePath: '/themes/a/plain',
+      fileName: 'plain',
+      thumbnailPath: '/themes/a/plain',
+      group: '',
+      variants: [{ filePath: '/themes/a/plain', fileName: 'plain', thumbnailPath: '/themes/a/plain' }]
+    }
   ],
   'image picker parses rows and dedupes by file name'
 )
@@ -42,13 +60,87 @@ assertEqual(picker.filteredPosition(images, 2, 'dark'), 1, 'image picker compute
 assertEqual(picker.selectedFilteredPosition(images, 2, 'dark'), 0, 'image picker selected filtered position falls back when selected is hidden')
 assertEqual(picker.nextSelectedIndexForFilter(images, 0, 'dark'), 1, 'image picker moves selection to first match when filter hides current item')
 
+assertEqual(picker.variantCount(images, 0), 1, 'an ungrouped row is a single variant')
+assertEqual(picker.maxVariantCount(images), 1, 'ungrouped rows never carry variants')
+
+// A third column groups rows into one carousel item: the theme picker hands one
+// group per theme, carrying that theme's preview and every background it ships.
+const groupedRows = [
+  '/previews/nord/000-preview.png\t/cache/nord-preview.jpg\tnord',
+  '/previews/nord/001-city.webp\t/cache/nord-city.jpg\tnord',
+  '/previews/nord/002-moon.jpg\t/cache/nord-moon.jpg\tnord',
+  '/previews/nord/002-moon.jpg\t/cache/duplicate.jpg\tnord',
+  '/previews/rose-pine/000-preview.png\t/cache/rose-preview.jpg\trose-pine',
+  '/previews/rose-pine/001-city.webp\t/cache/rose-city.jpg\trose-pine'
+].join('\n')
+
+const grouped = picker.loadRows(groupedRows)
+assertEqual(grouped.length, 2, 'grouped rows collapse into one item per group')
+assertEqual(picker.variantCount(grouped, 0), 3, 'a group carries every row as a variant')
+assertEqual(grouped[0].filePath, '/previews/nord/000-preview.png', 'a grouped item leads with its first row')
+assertEqual(
+  grouped[1].variants[1].filePath,
+  '/previews/rose-pine/001-city.webp',
+  'the same file name in two groups is kept in both'
+)
+
+assertEqual(picker.variantAt(grouped, 0, 1).thumbnailPath, '/cache/nord-city.jpg', 'variants resolve to their own thumbnail')
+assertEqual(picker.variantAt(grouped, 0, 3).filePath, '/previews/nord/000-preview.png', 'variant lookup wraps forward')
+assertEqual(picker.variantAt(grouped, 0, -1).filePath, '/previews/nord/002-moon.jpg', 'variant lookup wraps backward')
+assertEqual(picker.maxVariantCount(grouped), 3, 'the widest group decides whether the carousel makes room to peek')
+
+assertEqual(picker.nameForItem(grouped, 1), 'rose-pine', 'a grouped item is named for its group')
+assertEqual(picker.labelForItem(grouped, 1), 'Rose Pine', 'a grouped item is labelled for its group')
+assertEqual(picker.labelForItem(images, 0), 'Nord River', 'an ungrouped item is still labelled for its file')
+assert(picker.itemMatches(grouped, 1, 'rose'), 'filtering a grouped item matches the group, not the variant file')
+assert(!picker.itemMatches(grouped, 1, 'city'), 'filtering a grouped item ignores its variant file names')
+
+assertDeepEqual(
+  picker.locateImage(grouped, '/previews/rose-pine/001-city.webp'),
+  { index: 1, variant: 1 },
+  'a path locates both its item and its variant'
+)
+assertDeepEqual(
+  picker.locateImage(grouped, '/previews/gone.png'),
+  { index: 0, variant: 0 },
+  'an unknown path opens the picker on the first item'
+)
+
 const imagePickerQml = fs.readFileSync(path.join(root, 'shell/plugins/image-picker/ImagePicker.qml'), 'utf8')
 assert(
   /function preloadRows[\s\S]*if \(opened \|\| requestActive\) return/.test(imagePickerQml),
   'image picker ignores cache preloads while a request is visible'
 )
+const skewedImageQml = fs.readFileSync(path.join(root, 'shell/plugins/image-picker/SkewedImage.qml'), 'utf8')
 assert(
-  /source: item\.sourceActivated && item\.thumbnailPath \? Util\.fileUrl\(item\.thumbnailPath\) : ""[\s\S]*asynchronous: false/.test(imagePickerQml),
+  /source: item\.sourceActivated \? item\.thumbnailPath : ""/.test(imagePickerQml) &&
+    /asynchronous: false/.test(skewedImageQml),
   'image picker loads activated thumbnails synchronously to avoid carousel flicker'
+)
+
+// The peek bands and the preview have to lean at one angle, which they only do
+// while they share a column: their own heights differ by a factor of seven.
+assert(
+  /columnHeight: item\.selected \? root\.columnHeight : item\.height/.test(imagePickerQml) &&
+    /skewOffset: item\.selected \? root\.columnSkew : root\.skewOffset/.test(imagePickerQml),
+  'the selected preview leans as part of the column it shares with its peek bands'
+)
+assert(
+  /variantPeekHeight: Math\.round\(sliceWidth \* peekScale\)/.test(imagePickerQml) &&
+    /variantPeekOverlap: Math\.round\(-sliceSpacing \* peekScale\)/.test(imagePickerQml),
+  'the vertical peek is derived from the horizontal slice geometry'
+)
+assert(
+  /hints\.push\("\\u2191 \\u2193" \+ \(variantLabel/.test(imagePickerQml),
+  'the arrow hint names the axis the caller gave it'
+)
+assert(
+  /event\.key === Qt\.Key_Up\)\s*\{\s*root\.cycleVariant\(-1\)/.test(imagePickerQml) &&
+    /event\.key === Qt\.Key_Down\)\s*\{\s*root\.cycleVariant\(1\)/.test(imagePickerQml),
+  'image picker cycles the selected item variants with up and down'
+)
+assert(
+  /selected \? root\.variantThumbnail\(index, root\.selectedVariant\)/.test(imagePickerQml),
+  'image picker shows the selected variant in the expanded preview'
 )
 JS

--- a/test/shell.d/menu-images-test.sh
+++ b/test/shell.d/menu-images-test.sh
@@ -139,3 +139,37 @@ PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" VIPSTHUMBNAIL_CALLS_FILE="$t
 
 (( $(wc -l <"$tmp/calls") == 6 )) || fail "image menu releases thumbnail locks after generation"
 pass "image menu owns locks for exactly one generator lifetime"
+
+# --group-by-dir hands the picker a third column so every image under one
+# directory collapses into a single carousel item -- one theme, its preview and
+# its backgrounds -- rather than one item per file.
+grouped="$tmp/grouped"
+mkdir -p "$grouped/nord" "$grouped/rose-pine"
+printf 'image' >"$grouped/nord/000-preview.png"
+printf 'image' >"$grouped/nord/001-city.png"
+printf 'image' >"$grouped/rose-pine/000-preview.png"
+
+rm -rf "$cache_home"
+PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" \
+  "$ROOT/bin/omarchy-menu-images" --cache-only --group-by-dir "$grouped/nord" "$grouped/rose-pine"
+
+grouped_key=$(printf '%s\n%s' "$grouped/nord" "$grouped/rose-pine" | md5sum | cut -d ' ' -f 1)
+grouped_rows="$cache_dir/$grouped_key.rows"
+
+[[ -f $grouped_rows ]] || fail "image menu caches grouped rows"
+(( $(awk 'END { print NR }' "$grouped_rows") == 3 )) || fail "image menu keeps every grouped image as its own row"
+[[ $(awk -F '\t' 'NR == 1 { print $3 }' "$grouped_rows") == "nord" ]] ||
+  fail "image menu names a grouped row for its directory"
+(( $(awk -F '\t' '$3 == "nord"' "$grouped_rows" | wc -l) == 2 )) ||
+  fail "image menu groups every image in a directory under that directory"
+[[ $(awk -F '\t' 'END { print $3 }' "$grouped_rows") == "rose-pine" ]] ||
+  fail "image menu groups each directory separately"
+pass "image menu groups rows by directory"
+
+rm -rf "$cache_home"
+PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" \
+  "$ROOT/bin/omarchy-menu-images" --cache-only "$grouped/nord" "$grouped/rose-pine"
+
+(( $(awk -F '\t' 'NF == 2' "$grouped_rows" | wc -l) == 3 )) ||
+  fail "image menu leaves ungrouped rows at two columns"
+pass "image menu only groups rows when asked to"

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -442,7 +442,7 @@ selector_done_file=$(mktemp "$TMPDIR/selector-done.XXXXXX")
 rm -f "$selector_done_file"
 selector_open=""
 for _ in {1..80}; do
-  selector_open=$(shell_ipc image-selector open "" "$selector_rows_b64" "" "$selector_selection_file" "$selector_done_file" false false 2>/dev/null || true)
+  selector_open=$(shell_ipc image-selector open "" "$selector_rows_b64" "" "$selector_selection_file" "$selector_done_file" false false "" "" 2>/dev/null || true)
   if [[ $selector_open == "ok" ]]; then
     break
   fi

--- a/test/shell.d/theme-set-background-test.sh
+++ b/test/shell.d/theme-set-background-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# omarchy-theme-set takes the background the theme picker left the user looking
+# at. It is matched by name against the backgrounds the theme actually staged --
+# the picker points at a theme's own directory, not at the staged copy -- and
+# anything the theme does not carry falls back to the usual rotation.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+state="$home/.local/state/omarchy/current"
+theme="$home/.config/omarchy/themes/sample"
+
+mkdir -p "$state" "$theme/backgrounds"
+printf 'image' >"$theme/backgrounds/1-first.png"
+printf 'image' >"$theme/backgrounds/2-second.png"
+printf 'preview' >"$theme/preview.png"
+
+cat >"$theme/colors.toml" <<'TOML'
+mode = "dark"
+background = "#1a1b26"
+foreground = "#a9b1d6"
+TOML
+
+set_theme() {
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+    OMARCHY_THEME_HEADLESS=1 XDG_RUNTIME_DIR="$test_tmp" \
+    bash "$ROOT/bin/omarchy-theme-set" "$@" 2>"$test_tmp/stderr"
+}
+
+current_background() {
+  basename -- "$(readlink "$state/background")"
+}
+
+set_theme sample
+[[ $(current_background) == "1-first.png" ]] ||
+  fail "a theme with no background asked for starts at its first background" "$(current_background)"
+pass "theme set falls back to the first background"
+
+set_theme sample "$theme/backgrounds/2-second.png"
+[[ $(current_background) == "2-second.png" ]] ||
+  fail "theme set applies the background it was handed" "$(current_background)"
+[[ $(readlink "$state/background") == "$state/theme/backgrounds/2-second.png" ]] ||
+  fail "theme set applies the staged copy of the background it was handed"
+pass "theme set applies the background the picker returned"
+
+# What the picker returns when the user never left a theme's preview.
+set_theme sample "$theme/preview.png"
+[[ $(current_background) == "1-first.png" ]] ||
+  fail "an image the theme does not carry rotates instead of pinning" "$(current_background)"
+pass "theme set rotates past a background the theme does not carry"
+
+set_theme sample ""
+[[ $(current_background) == "2-second.png" ]] ||
+  fail "an empty background keeps rotating through the theme" "$(current_background)"
+pass "theme set still rotates when handed no background"

--- a/test/shell.d/theme-switcher-test.sh
+++ b/test/shell.d/theme-switcher-test.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# The theme picker offers one directory of images per theme: that theme's
+# preview first, then every background it ships and every background the user
+# added for it. omarchy-menu-images --group-by-dir turns each directory into a
+# single carousel item, so up/down walks a theme's backgrounds.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+omarchy="$test_tmp/omarchy"
+stub_bin="$test_tmp/bin"
+previews="$test_tmp/cache/omarchy/theme-selector/previews"
+state="$home/.local/state/omarchy/current"
+
+mkdir -p "$stub_bin" "$state" \
+  "$omarchy/themes/nord/backgrounds" \
+  "$omarchy/themes/plain/backgrounds" \
+  "$home/.config/omarchy/themes/mine/backgrounds" \
+  "$home/.config/omarchy/backgrounds/nord"
+
+printf 'preview' >"$omarchy/themes/nord/preview.png"
+printf 'image' >"$omarchy/themes/nord/backgrounds/1-city.webp"
+printf 'image' >"$omarchy/themes/nord/backgrounds/2-moon.jpg"
+printf 'video' >"$omarchy/themes/nord/backgrounds/3-motion.mp4"
+printf 'image' >"$home/.config/omarchy/backgrounds/nord/0-mine.png"
+
+# A theme with no preview of its own: the picker falls back to its first
+# background, which must not then show up twice.
+printf 'image' >"$omarchy/themes/plain/backgrounds/1-only.webp"
+
+printf 'preview' >"$home/.config/omarchy/themes/mine/preview.png"
+printf 'image' >"$home/.config/omarchy/themes/mine/backgrounds/1-mine.webp"
+
+# A theme the user wrote is theirs to fill however they like, symlinks included.
+ln -s "$omarchy/themes/nord/backgrounds/1-city.webp" "$home/.config/omarchy/themes/mine/backgrounds/2-linked.webp"
+
+# A theme installed from a git repo came from a stranger, and omarchy-theme-set
+# drops the symlinks in one rather than stage a file from anywhere on disk.
+cloned="$home/.config/omarchy/themes/cloned"
+mkdir -p "$cloned/backgrounds" "$cloned/.git"
+printf 'preview' >"$cloned/preview.png"
+printf 'image' >"$cloned/backgrounds/1-own.webp"
+ln -s "$omarchy/themes/nord/backgrounds/2-moon.jpg" "$cloned/backgrounds/2-linked.jpg"
+
+cat >"$stub_bin/omarchy-menu-images" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$@" >"$MENU_IMAGES_ARGS"
+[[ -n ${MENU_IMAGES_SELECTION:-} ]] && printf '%s\n' "$MENU_IMAGES_SELECTION"
+EOF
+chmod +x "$stub_bin/omarchy-menu-images"
+
+switch() {
+  HOME="$home" OMARCHY_PATH="$omarchy" PATH="$stub_bin:$PATH" \
+    XDG_CACHE_HOME="$test_tmp/cache" MENU_IMAGES_ARGS="$test_tmp/args" \
+    bash "$ROOT/bin/omarchy-theme-switcher"
+}
+
+links_for() {
+  local theme="$1"
+  local link
+
+  for link in "$previews/$theme"/*; do
+    [[ -e $link ]] || continue
+    printf '%s\n' "${link##*/}"
+  done
+}
+
+echo nord >"$state/theme.name"
+ln -nsf "$omarchy/themes/nord/backgrounds/2-moon.jpg" "$state/background"
+
+switch >/dev/null
+
+[[ $(links_for nord) == "000-preview.png
+001-0-mine.png
+002-1-city.webp
+003-2-moon.jpg
+004-3-motion.mp4" ]] || fail "theme picker offers a theme's preview, then its backgrounds" "$(links_for nord)"
+pass "theme picker collects a theme's preview and backgrounds"
+
+[[ $(readlink "$previews/nord/001-0-mine.png") == "$home/.config/omarchy/backgrounds/nord/0-mine.png" ]] ||
+  fail "theme picker offers the backgrounds a user added for a theme"
+pass "theme picker includes user backgrounds"
+
+[[ $(links_for plain) == "000-1-only.webp" ]] ||
+  fail "theme picker does not repeat the background it fell back to for a preview" "$(links_for plain)"
+pass "theme picker keeps a fallback preview out of the list twice"
+
+[[ $(links_for mine) == "000-preview.png
+001-1-mine.webp
+002-2-linked.webp" ]] || fail "theme picker offers a user theme, symlinks and all" "$(links_for mine)"
+pass "theme picker includes user themes"
+
+[[ $(links_for cloned) == "000-preview.png
+001-1-own.webp" ]] ||
+  fail "theme picker offers a symlink an installed theme would never get to stage" "$(links_for cloned)"
+pass "theme picker holds an installed theme to what it can stage"
+
+grep -qx -- '--group-by-dir' "$test_tmp/args" || fail "theme picker groups the picker's rows by theme"
+[[ $(grep -A1 -x -- '--item-label' "$test_tmp/args" | tail -n 1) == "theme" ]] ||
+  fail "theme picker names what left and right walk"
+[[ $(grep -A1 -x -- '--variant-label' "$test_tmp/args" | tail -n 1) == "background" ]] ||
+  fail "theme picker names what up and down walk"
+grep -qx -- "$previews/nord" "$test_tmp/args" || fail "theme picker passes one directory per theme"
+[[ $(grep -A1 -x -- '--selected' "$test_tmp/args" | tail -n 1) == "$previews/nord/000-preview.png" ]] ||
+  fail "theme picker opens on the current theme's preview, not on the background that is up"
+pass "theme picker opens on the current theme's preview"
+
+# A background added for a theme is a new image under that theme, and a theme
+# directory's own mtime never saw it.
+sleep 1
+printf 'image' >"$home/.config/omarchy/backgrounds/nord/3-late.png"
+switch >/dev/null
+
+[[ $(links_for nord) == "000-preview.png
+001-0-mine.png
+002-3-late.png
+003-1-city.webp
+004-2-moon.jpg
+005-3-motion.mp4" ]] || fail "theme picker picks up a background added after the last open" "$(links_for nord)"
+pass "theme picker rebuilds when a background is added"
+
+selection=$(MENU_IMAGES_SELECTION="$previews/nord/003-1-city.webp" switch)
+[[ $selection == "nord"$'\t'"$omarchy/themes/nord/backgrounds/1-city.webp" ]] ||
+  fail "theme picker reports the theme and the background the user stopped on" "$selection"
+pass "theme picker reports the picked theme and background"
+
+selection=$(MENU_IMAGES_SELECTION="$previews/mine/002-2-linked.webp" switch)
+[[ $selection == "mine"$'\t'"$home/.config/omarchy/themes/mine/backgrounds/2-linked.webp" ]] ||
+  fail "theme picker preserves a user background alias for staged-name matching" "$selection"
+pass "theme picker preserves aliased background names"
+
+selection=$(MENU_IMAGES_SELECTION="$previews/nord/005-3-motion.mp4" switch)
+[[ $selection == "nord"$'\t'"$omarchy/themes/nord/backgrounds/3-motion.mp4" ]] ||
+  fail "theme picker reports a video background like any other variant" "$selection"
+pass "theme picker carries video backgrounds through grouped selection"
+
+# Stopping on a dedicated preview declines to choose a background and preserves
+# the theme's normal rotation.
+selection=$(MENU_IMAGES_SELECTION="$previews/nord/000-preview.png" switch)
+[[ $selection == "nord"$'\t' ]] ||
+  fail "theme picker reports no background when the user never left the preview" "$selection"
+pass "theme picker reports no background for a theme's preview"
+
+# A theme without a dedicated preview displays its first real background. That
+# visible background must be applied explicitly rather than silently rotating.
+selection=$(MENU_IMAGES_SELECTION="$previews/plain/000-1-only.webp" switch)
+[[ $selection == "plain"$'\t'"$omarchy/themes/plain/backgrounds/1-only.webp" ]] ||
+  fail "a theme without a preview applies the background it displays" "$selection"
+pass "theme picker applies the displayed fallback background"
+
+[[ -z $(MENU_IMAGES_SELECTION="" switch) ]] || fail "theme picker reports nothing when dismissed"
+pass "theme picker reports nothing when dismissed"

--- a/test/shell.d/video-background-test.sh
+++ b/test/shell.d/video-background-test.sh
@@ -180,7 +180,6 @@ assert(
 )
 assert(
   themeSwitcher.includes("-iname '*.mp4'") &&
-    themeSwitcher.includes('mp4 m4v mov webm mkv avi') &&
     themeSwitcher.includes('preview.mp4'),
   'theme switcher previews video-only themes, named preview files included'
 )
@@ -325,6 +324,7 @@ NEXT_THEME_PATH="$transition_home/.local/state/omarchy/current/next-theme"
 CURRENT_BACKGROUND_LINK="$transition_home/.local/state/omarchy/current/background"
 BACKGROUND_TRANSITION_CACHE="$transition_home/.cache/omarchy/background-transitions"
 THEME_NAME="video-test"
+REQUESTED_BACKGROUND=""
 HOME="$transition_home"
 mkdir -p "$CURRENT_THEME_PATH/backgrounds" "$NEXT_THEME_PATH/backgrounds" "$HOME/.config/omarchy/backgrounds/$THEME_NAME"
 printf 'old image\n' >"$CURRENT_THEME_PATH/backgrounds/old.png"


### PR DESCRIPTION
### Problem

The theme picker shows one image per theme, so selecting a theme also selects an unseen wallpaper through the theme's normal rotation. To inspect a theme's other backgrounds, users must first apply it and then open the separate background picker.

### Solution

Up and down now cycle the highlighted theme's backgrounds inside the theme picker. Left and right continue to cycle themes. If the user stops on a background, that exact background is applied; leaving a theme on its preview preserves the existing rotation behavior.

<img width="1440" height="900" alt="theme-picker-1-preview" src="https://github.com/user-attachments/assets/5e05d300-b961-4fdc-b7a3-0a76bfa4842b" />

The vertical axis uses the same neighboring-image treatment as the horizontal carousel: bands above and below preview the previous and next background, and labels explain what each arrow pair controls.

<img width="1440" height="900" alt="theme-picker-2-background" src="https://github.com/user-attachments/assets/5c5637e5-102a-4901-87dd-2fe98329d249" />

### Implementation

- Image-selector rows gain an optional group column. Rows in the same group become variants of one carousel item; ungrouped callers retain existing behavior.
- `omarchy-menu-images --group-by-dir` groups each directory under its name. `--item-label` and `--variant-label` name the two axes.
- `omarchy-theme-switcher` stages one directory of links per theme: preview first, then the theme's backgrounds and matching user backgrounds. The selected theme and optional background are returned together.
- `omarchy-theme-set <theme> [background]` matches an explicit background against the staged theme. Unknown or omitted backgrounds retain the existing rotation behavior.
- Installed themes remain restricted to files that theme staging can safely carry; user-authored and stock themes retain their existing link behavior.
- Lazy still-image thumbnails drain through one bounded batch. Native video wallpapers remain supported and use their own narrower thumbnail queue so FFmpeg codec threads cannot fan out across every core.
- MP4, M4V, MOV, WebM, MKV, and AVI files participate in grouped theme variants and named previews.

### Compatibility

The image-selector IPC gains optional item and variant label arguments. The CLI and QML caller ship together, and the public IPC documentation is updated.

The picker is 705px tall to accommodate the vertical preview bands; it remains usable on 768px-tall displays.

### Testing

Affected tests pass:

- `test/shell.d/menu-images-test.sh`
- `test/shell.d/theme-switcher-test.sh`
- `test/shell.d/theme-set-background-test.sh`
- `test/shell.d/image-picker-test.sh`
- `test/shell.d/background-test.sh`
- `test/shell.d/runtime-smoke-test.sh`
- `test/shell.d/video-background-test.sh`

The full shell suite was also run. Its remaining failures are outside this diff: the existing bar-icon geometry check, three checks requiring a separate `omarchy-pkgs` checkout, and the locate integration test encountering a non-UTF-8 indexed file. All picker, theme, background, runtime, and video-wallpaper tests pass.

The picker was also verified in the running UI with stock themes, installed themes, and user-added per-theme backgrounds.
