### PR TITLE
Load nwg-displays workspace assignments

### DIFF
--- a/config/hypr/hyprland.lua
+++ b/config/hypr/hyprland.lua
@@ -12,11 +12,13 @@ dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/boo
 
 -- Load Omarchy defaults.
 require("default.hypr.omarchy")
+local require_optional = require("default.hypr.require_optional")
 
 -- Put your personal overrides in these files. They're loaded after Omarchy's
 -- defaults so package updates can improve the defaults without rewriting your
 -- ~/.config/hypr files.
 require("hypr.monitors")
+require_optional.module("hypr.workspaces")
 require("hypr.input")
 require("hypr.bindings")
 require("hypr.looknfeel")

--- a/migrations/1788129995.sh
+++ b/migrations/1788129995.sh
@@ -1,0 +1,22 @@
+echo "Enable workspace assignments from nwg-displays"
+
+hyprland_config="$HOME/.config/hypr/hyprland.lua"
+
+if [[ -f $hyprland_config ]] &&
+  grep -Fq 'require("hypr.monitors")' "$hyprland_config" &&
+  ! grep -Fq 'hypr.workspaces' "$hyprland_config"; then
+  tmp=$(mktemp)
+
+  awk '
+    { print }
+
+    !inserted && $0 == "require(\"hypr.monitors\")" {
+      print "local require_optional = require(\"default.hypr.require_optional\")"
+      print "require_optional.module(\"hypr.workspaces\")"
+      inserted = 1
+    }
+  ' "$hyprland_config" >"$tmp"
+
+  cat "$tmp" >"$hyprland_config"
+  rm -f "$tmp"
+fi

--- a/test/cli
+++ b/test/cli
@@ -614,6 +614,30 @@ grep -Fq 'dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/defaul
 grep -Fq 'o.window("Example", { workspace = "1" })' "$HYPR_MIGRATION_TMPDIR/.config/hypr/hyprland.lua" || fail "hyprland bootstrap migration preserves custom config"
 pass "hyprland bootstrap migration updates stale user entrypoint"
 
+make_tmpdir WORKSPACE_MIGRATION_TMPDIR
+mkdir -p "$WORKSPACE_MIGRATION_TMPDIR/.config/hypr"
+cat >"$WORKSPACE_MIGRATION_TMPDIR/.config/hypr/hyprland.lua" <<'LUA'
+dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/bootstrap.lua")
+
+require("default.hypr.omarchy")
+require("hypr.monitors")
+require("hypr.input")
+
+-- Keep this custom configuration.
+o.window("Example", { workspace = "1" })
+LUA
+
+HOME="$WORKSPACE_MIGRATION_TMPDIR" bash -euo pipefail "$ROOT/migrations/1788129995.sh" >/dev/null
+grep -Fq 'local require_optional = require("default.hypr.require_optional")' "$WORKSPACE_MIGRATION_TMPDIR/.config/hypr/hyprland.lua" || fail "workspace migration loads the optional module helper"
+grep -Fq 'require_optional.module("hypr.workspaces")' "$WORKSPACE_MIGRATION_TMPDIR/.config/hypr/hyprland.lua" || fail "workspace migration loads nwg-displays workspace assignments"
+grep -Fq 'o.window("Example", { workspace = "1" })' "$WORKSPACE_MIGRATION_TMPDIR/.config/hypr/hyprland.lua" || fail "workspace migration preserves custom config"
+
+before=$(sha256sum "$WORKSPACE_MIGRATION_TMPDIR/.config/hypr/hyprland.lua" | awk '{print $1}')
+HOME="$WORKSPACE_MIGRATION_TMPDIR" bash -euo pipefail "$ROOT/migrations/1788129995.sh" >/dev/null
+after=$(sha256sum "$WORKSPACE_MIGRATION_TMPDIR/.config/hypr/hyprland.lua" | awk '{print $1}')
+[[ $before == "$after" ]] || fail "workspace migration is idempotent"
+pass "workspace migration enables nwg-displays assignments for existing users"
+
 cp "$NEXT_THEME/colors.toml" "$CURRENT_THEME/colors.toml"
 cp "$NEXT_THEME/vscode-theme.json" "$CURRENT_THEME/vscode-theme.json"
 

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -185,9 +185,10 @@ pass "package-owned defaults live outside config"
 
 grep -F 'dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/bootstrap.lua")' "$ROOT/config/hypr/hyprland.lua" >/dev/null
 grep -F 'require("default.hypr.omarchy")' "$ROOT/config/hypr/hyprland.lua" >/dev/null
+grep -F 'require_optional.module("hypr.workspaces")' "$ROOT/config/hypr/hyprland.lua" >/dev/null
 grep -F 'package.path = home' "$ROOT/default/hypr/bootstrap.lua" >/dev/null
 grep -F '/.local/state/?.lua;' "$ROOT/default/hypr/bootstrap.lua" >/dev/null
-pass "Hyprland user entrypoint keeps package and state path bootstrap in defaults"
+pass "Hyprland user entrypoint loads defaults and optional workspace assignments"
 
 OMARCHY_PATH="$ROOT" lua <<'LUA'
 package.loaded["default.hypr.omarchy"] = true


### PR DESCRIPTION
## Summary

- load the `hypr.workspaces` module generated by nwg-displays when it exists
- migrate existing Hyprland entrypoints without affecting users who have no `workspaces.lua`
- add regression coverage for the default config and the idempotent migration

Fixes #9422

## Testing

- `bash -n migrations/1788129995.sh test/cli test/shell.d/config-test.sh`
- migration fixture covering insertion order, custom-config preservation, idempotence, and a missing config
- `git diff --check`

The complete `test/cli` and `config-test.sh` suites were not run locally because the available WSL image does not include their required `jq` and Lua executables.