### PR TITLE
Refocus lock screen when session secures

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -238,6 +238,7 @@ Item {
         root.pendingSessionLock = false
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
+        lockView.forcePasswordFocus()
         root.startFingerprint()
       }
     }

--- a/test/shell.d/lock-focus-test.sh
+++ b/test/shell.d/lock-focus-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+const secureHandlerStart = serviceQml.indexOf('onSecureStateChanged:')
+const lockHandlerStart = serviceQml.indexOf('onLockStateChanged:', secureHandlerStart)
+const secureHandler = serviceQml.slice(secureHandlerStart, lockHandlerStart)
+const secureBlockMatch = secureHandler.match(/if \(secure\) \{([\s\S]*?)\n      \}/)
+const secureBlock = secureBlockMatch ? secureBlockMatch[1] : ''
+
+assert(
+  secureBlock.includes('lockView.forcePasswordFocus()'),
+  'the password field regains focus when the compositor secures the lock surface'
+)
+JS


### PR DESCRIPTION
## Summary

- refocus the password field when `WlSessionLock.secure` becomes true and keyboard input reaches the lock surface
- retain the existing early focus request while closing the secure-state race
- add focused regression coverage for the lock service's secure handler

Fixes #9418

## Testing

- `bash test/shell.d/lock-focus-test.sh`
- `bash test/shell.d/lock-blank-fingerprint-test.sh`
- `bash test/shell.d/lock-stranded-recovery-test.sh`
- `bash test/shell.d/monitor-recovery-test.sh`
- `git diff --cached --check`