### PR TITLE
Detect Broadcom ControlVault 3 fingerprint readers

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -9,6 +9,9 @@
 # also make USB touchscreens) are left out to avoid nagging laptops with no
 # reader — those still match on the product string below when present.
 fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e "
+# Exact IDs cover readers made by vendors whose wider USB catalog makes a
+# vendor-only match too broad. This is Dell's Broadcom ControlVault 3 reader.
+fingerprint_devices=" 0a5c:5843 "
 usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
 
 # libfprint drives every reader it supports from userspace over libusb, so a
@@ -48,7 +51,12 @@ for dev in "$usb_devices_path"/*; do
 
   if [[ -r $dev/idVendor ]]; then
     vendor=$(<"$dev/idVendor")
-    [[ $fingerprint_vendors == *" $vendor "* ]] &&
+    if [[ -r $dev/idProduct ]]; then
+      product_id=$(<"$dev/idProduct")
+    else
+      product_id=""
+    fi
+    [[ $fingerprint_vendors == *" $vendor "* || $fingerprint_devices == *" $vendor:$product_id "* ]] &&
       ! has_kernel_driver "$dev" && exit 0
   fi
 done

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -74,6 +74,12 @@ assert_detects "a reader is detected by an existing product-name match"
 write_usb_devices '27c6:1234'
 assert_detects "a reader is detected by an existing vendor match"
 
+write_usb_devices '0a5c:5843:58200'
+assert_detects "a Broadcom ControlVault 3 reader is detected by its device ID"
+
+write_usb_devices '0a5c:1234:Generic Broadcom Device'
+assert_rejects "an unrelated Broadcom device is not detected"
+
 bind_driver() {
   local dev="$1" driver="$2"
 
@@ -86,6 +92,10 @@ bind_driver() {
 write_usb_devices '27c6:1234'
 bind_driver '1-0/1-0:1.0' uvcvideo
 assert_rejects "a vendor guess bound to a kernel driver is rejected"
+
+write_usb_devices '0a5c:5843:58200'
+bind_driver '1-0/1-0:1.0' btusb
+assert_rejects "a ControlVault device ID bound to a kernel driver is rejected"
 
 write_usb_devices '27c6:1234'
 bind_driver '1-0/1-0:1.0' usbfs


### PR DESCRIPTION
## Summary

- detect Dell ControlVault 3 readers by the exact Broadcom USB ID 0a5c:5843
- keep the no-kernel-driver guard used by vendor-based detection
- avoid broad allowlisting of unrelated Broadcom USB devices
- cover the matching ID, an unrelated Broadcom device, and a kernel-bound ControlVault device

Fixes #9507

## Testing

- bash test/shell.d/hw-fingerprint-test.sh (14 assertions, ARM Linux VM)
- ./test/cli (ARM Linux VM)
- bash -n bin/omarchy-hw-fingerprint test/shell.d/hw-fingerprint-test.sh
- git diff --check