### PR TITLE
Publish agent usage snapshots from headless machines

### DIFF
--- a/bin/omarchy-agent-usage-snapshot
+++ b/bin/omarchy-agent-usage-snapshot
@@ -1,0 +1,148 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Publish AI agent usage for cross-device aggregation
+# omarchy:args=[--output <path>] [--device-id <id>] [--force] [--except <agent>] [agent...]
+# omarchy:examples=omarchy agent usage-snapshot --output ~/Sync/agent-usage/server.json | omarchy agent usage-snapshot --device-id server
+"""Refresh agent usage and publish the panel's cross-device snapshot format."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--output", help="atomically write the snapshot to this path instead of stdout")
+  parser.add_argument("--device-id", help="stable device name stored in the snapshot")
+  parser.add_argument("--force", action="store_true", help="force collectors to refresh cached data")
+  parser.add_argument("--except", dest="excluded", action="append", default=[], metavar="AGENT")
+  parser.add_argument("agents", nargs="*", help="publish only these agents")
+  return parser.parse_args()
+
+
+def safe_device_id(raw: str | None) -> str:
+  value = (raw or os.environ.get("HOSTNAME") or os.uname().nodename or os.environ.get("HOST") or os.environ.get("USER") or "device").strip()
+  value = re.sub(r"[^A-Za-z0-9_.-]+", "-", value)
+  value = re.sub(r"^[._-]+|[._-]+$", "", value)
+  return (value or "device")[:80]
+
+
+def number_value(value: Any) -> int:
+  try:
+    return round(float(value or 0))
+  except (TypeError, ValueError):
+    return 0
+
+
+def clone_container(value: Any, fallback: list[Any] | dict[str, Any]) -> list[Any] | dict[str, Any]:
+  if isinstance(value, type(fallback)):
+    return value
+  return fallback
+
+
+def provider_snapshot(record: dict[str, Any]) -> dict[str, Any]:
+  provider_id = str(record["id"])
+  return {
+    "providerId": provider_id,
+    "providerName": str(record.get("name") or provider_id),
+    "ready": record.get("ready") is True,
+    "hasLocalStats": record.get("hasLocalStats") is not False,
+    "hasPromptStats": record.get("hasPromptStats") is not False,
+    "scope": str(record.get("scope") or "device"),
+    "todayPrompts": number_value(record.get("todayPrompts")),
+    "todaySessions": number_value(record.get("todaySessions")),
+    "todayTotalTokens": number_value(record.get("todayTotalTokens")),
+    "todayTokensByModel": clone_container(record.get("todayTokensByModel"), {}),
+    "recentDays": clone_container(record.get("recentDays"), []),
+    "totalPrompts": number_value(record.get("totalPrompts")),
+    "totalSessions": number_value(record.get("totalSessions")),
+    "activeDays": number_value(record.get("activeDays")),
+    "activeDates": clone_container(record.get("activeDates"), []),
+    "modelUsage": clone_container(record.get("modelUsage"), {}),
+  }
+
+
+def refresh_usage(args: argparse.Namespace) -> None:
+  command = ["omarchy-agent-usage-update"]
+  if args.force:
+    command.append("--force")
+  for agent in args.excluded:
+    command.extend(["--except", agent])
+  command.extend(args.agents)
+  subprocess.run(command, check=True)
+
+
+def load_providers(args: argparse.Namespace) -> dict[str, Any]:
+  state_home = Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local/state"))
+  usage_dir = state_home / "omarchy/agents/usage"
+  requested = set(args.agents)
+  excluded = set(args.excluded)
+  providers: dict[str, Any] = {}
+
+  for path in sorted(usage_dir.glob("*.json")):
+    if requested and path.stem not in requested:
+      continue
+    if path.stem in excluded:
+      continue
+    try:
+      record = json.loads(path.read_text())
+      if not isinstance(record, dict) or not record.get("id"):
+        raise ValueError("missing agent id")
+      providers[str(record["id"])] = provider_snapshot(record)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as error:
+      print(f"omarchy-agent-usage-snapshot: ignoring {path.name}: {error}", file=sys.stderr)
+
+  return providers
+
+
+def snapshot_text(args: argparse.Namespace) -> str:
+  snapshot = {
+    "schemaVersion": 1,
+    "deviceId": safe_device_id(args.device_id),
+    "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+    "providers": load_providers(args),
+  }
+  return json.dumps(snapshot, indent=2, sort_keys=True) + "\n"
+
+
+def write_snapshot(path_value: str, content: str) -> None:
+  path = Path(os.path.expandvars(os.path.expanduser(path_value)))
+  path.parent.mkdir(parents=True, exist_ok=True)
+  with tempfile.NamedTemporaryFile("w", dir=path.parent, prefix=f".{path.name}.", delete=False) as temp:
+    temp.write(content)
+    temp.flush()
+    os.fsync(temp.fileno())
+    temp_path = Path(temp.name)
+  try:
+    temp_path.replace(path)
+  except BaseException:
+    temp_path.unlink(missing_ok=True)
+    raise
+
+
+def main() -> int:
+  args = parse_args()
+  try:
+    refresh_usage(args)
+    content = snapshot_text(args)
+    if args.output:
+      write_snapshot(args.output, content)
+    else:
+      sys.stdout.write(content)
+  except (OSError, subprocess.CalledProcessError) as error:
+    print(f"omarchy-agent-usage-snapshot: {error}", file=sys.stderr)
+    return 1
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -33,6 +33,8 @@ The top bar grows an agents icon the first time Omarchy finds AI coding usage on
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 
+On a headless machine, publish a compatible privacy-reduced snapshot with `omarchy agent usage-snapshot --device-id server --output ~/Sync/agent-usage/server.json`. The command refreshes the collectors first and writes the file atomically for Syncthing, rsync, or another folder-sync tool.
+
 ### Crash diagnosis
 
 Omarchy watches systemd-coredump for process crashes. When something segfaults, you'll get a "Process crashed" notification — click it, and the crash is handed to your default agent along with Omarchy's diagnose-crash skill, which walks the agent through establishing the facts from the core dump and deciding whether the crash is worth reporting upstream. You can also run it by hand against any PID from `coredumpctl list` with `omarchy agent crash <pid>`.

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -144,6 +144,16 @@ when its stats are account-global rather than machine-local (Fireworks'
 billing API); those merge by taking the widest value instead of summing, so
 the same account synced from two machines is not counted twice.
 
+Headless machines can publish the same privacy-reduced snapshot without Quickshell. Point `--output` at a directory shared with the desktop and run it from a timer or cron job:
+
+```bash
+omarchy agent usage-snapshot \
+  --device-id build-server \
+  --output ~/Sync/agent-usage/build-server.json
+```
+
+The command refreshes the collectors first and replaces the output atomically, so readers never observe a partial JSON file. Without `--output`, it prints the snapshot to stdout. Use positional agent names or `--except <agent>` to limit what is published. Snapshots contain aggregate usage metrics only; subscription limits, authentication state, balances, and collector errors stay local.
+
 One caveat on "all-time": the Codex collector only reads native session files
 touched in the last 30 days, and Fireworks requests the last 30 days from its
 billing API, so their totals and day counts cover that window. Claude's cover

--- a/test/shell.d/agent-usage-snapshot-test.sh
+++ b/test/shell.d/agent-usage-snapshot-test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+require_command python3
+
+test_home=$(mktemp -d)
+test_bin=$(mktemp -d)
+trap 'rm -rf "$test_home" "$test_bin"' EXIT
+
+usage_dir="$test_home/.local/state/omarchy/agents/usage"
+update_log="$test_home/update.log"
+mkdir -p "$usage_dir"
+
+cat >"$test_bin/omarchy-agent-usage-update" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >"$UPDATE_LOG"
+if [[ ${FAIL_UPDATE:-0} == "1" ]]; then
+  exit 1
+else
+  exit 0
+fi
+EOF
+chmod +x "$test_bin/omarchy-agent-usage-update"
+
+cat >"$usage_dir/claude.json" <<'EOF'
+{
+  "id": "claude",
+  "name": "Claude Code",
+  "ready": true,
+  "todayPrompts": 3,
+  "todaySessions": 2,
+  "todayTotalTokens": 42,
+  "todayTokensByModel": { "claude-test": 42 },
+  "recentDays": [{ "date": "2026-08-31", "messageCount": 3 }],
+  "totalPrompts": 9,
+  "totalSessions": 4,
+  "activeDays": 2,
+  "activeDates": ["2026-08-30", "2026-08-31"],
+  "modelUsage": { "claude-test": { "inputTokens": 30, "outputTokens": 12 } },
+  "limits": { "secret": "not-for-sync" },
+  "authError": "not-for-sync"
+}
+EOF
+
+cat >"$usage_dir/codex.json" <<'EOF'
+{
+  "id": "codex",
+  "name": "Codex",
+  "scope": "device",
+  "hasLocalStats": false,
+  "hasPromptStats": false,
+  "totalPrompts": "7"
+}
+EOF
+
+printf '%s\n' '{not-json' >"$usage_dir/broken.json"
+
+snapshot=$(HOME="$test_home" XDG_STATE_HOME="" HOSTNAME="Headless Build Server" UPDATE_LOG="$update_log" PATH="$test_bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-usage-snapshot" 2>"$test_home/stderr")
+
+jq -e '
+  .schemaVersion == 1 and
+  .deviceId == "Headless-Build-Server" and
+  (.updatedAt | test("Z$")) and
+  .providers.claude.providerName == "Claude Code" and
+  .providers.claude.todayTotalTokens == 42 and
+  .providers.codex.totalPrompts == 7 and
+  .providers.codex.hasLocalStats == false and
+  (.providers.claude | has("limits") | not) and
+  (.providers.claude | has("authError") | not)
+' >/dev/null <<<"$snapshot" || fail "snapshot publishes compatible usage metrics without private collector state"
+pass "snapshot publishes compatible usage metrics without private collector state"
+
+grep -q 'ignoring broken.json' "$test_home/stderr" || fail "snapshot reports malformed usage records"
+pass "snapshot reports malformed usage records"
+
+output_path="$test_home/sync/nested-server.json"
+HOME="$test_home" XDG_STATE_HOME="" UPDATE_LOG="$update_log" PATH="$test_bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-usage-snapshot" --output "$output_path" --device-id nested-server --force --except codex claude 2>/dev/null
+
+[[ $(jq -r '.deviceId' "$output_path") == "nested-server" ]] || fail "snapshot writes the requested device ID"
+[[ $(jq -r '.providers | keys | join(",")' "$output_path") == "claude" ]] || fail "snapshot filters providers requested by the caller"
+[[ $(<"$update_log") == "--force --except codex claude" ]] || fail "snapshot forwards collector selection and refresh flags"
+pass "snapshot atomically publishes selected agents to a file"
+
+printf '%s\n' 'keep-existing' >"$output_path"
+if HOME="$test_home" XDG_STATE_HOME="" FAIL_UPDATE=1 UPDATE_LOG="$update_log" PATH="$test_bin:$PATH" \
+  "$ROOT/bin/omarchy-agent-usage-snapshot" --output "$output_path" 2>/dev/null; then
+  fail "snapshot reports a collector refresh failure"
+fi
+[[ $(<"$output_path") == "keep-existing" ]] || fail "failed refresh leaves the previous snapshot intact"
+pass "failed refresh leaves the previous snapshot intact"


### PR DESCRIPTION
## Summary

- add omarchy agent usage-snapshot for machines without Quickshell
- refresh the existing agent collectors, then emit the same schema consumed by synced aggregation
- select only aggregate usage metrics so limits, authentication state, balances, and collector errors stay local
- support stdout, atomic --output publishing, stable --device-id values, agent selection, and --except filters
- document timer/cron usage for Syncthing, rsync, and other synced folders

The original issue predates the generic agent collector architecture. Building the snapshot from current usage records makes this work for Claude, Codex, Fireworks, and future collectors instead of coupling it to the old Claude-only scanner.

Fixes #6441

## Testing

- test/shell.d/agent-usage-snapshot-test.sh (macOS Bash 5 and ARM Linux VM)
- ./test/cli (ARM Linux VM)
- python3 -m py_compile bin/omarchy-agent-usage-snapshot
- bash -n test/shell.d/agent-usage-snapshot-test.sh
- git diff --check

The focused test covers malformed records, privacy-field exclusion, provider filtering and flag forwarding, atomic file publication, and preserving the previous snapshot when refresh fails.