### PR TITLE
Wait for real output before shell launch

### DIFF
--- a/bin/omarchy-launch-shell-ready
+++ b/bin/omarchy-launch-shell-ready
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# omarchy:summary=Launch the Omarchy shell after Hyprland has a real output
+# omarchy:hidden=true
+
+ready_attempts=${OMARCHY_HYPRLAND_READY_ATTEMPTS:-40}
+ready_delay=${OMARCHY_HYPRLAND_READY_DELAY:-0.25}
+
+real_output_ready() {
+  hyprctl monitors all -j | jq -e '
+    any(.[]; .disabled != true and (.width // 0) > 0 and (.height // 0) > 0)
+  ' >/dev/null 2>&1
+}
+
+for (( attempt = 1; attempt <= ready_attempts; attempt++ )); do
+  if real_output_ready; then
+    omarchy-hyprland-monitor-clamshell || true
+    exec omarchy-launch-shell
+  fi
+
+  if (( attempt < ready_attempts )); then
+    sleep "$ready_delay"
+  fi
+done
+
+logger -t omarchy-shell "Starting Omarchy shell before Hyprland reported a real output."
+omarchy-hyprland-monitor-clamshell || true
+exec omarchy-launch-shell

--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -3,7 +3,7 @@ hl.on("hyprland.start", function()
   hl.exec_cmd("systemctl --user import-environment $(env | cut -d'=' -f 1)")
   hl.exec_cmd("dbus-update-activation-environment --systemd --all")
 
-  hl.exec_cmd("omarchy-launch-shell")
+  hl.exec_cmd("omarchy-launch-shell-ready")
   hl.exec_cmd("omarchy-provision-first-run")
   hl.exec_cmd("omarchy-powerprofiles-init")
   hl.exec_cmd(o.launch("omarchy-hyprland-monitor-watch"))

--- a/test/shell.d/launch-shell-ready-test.sh
+++ b/test/shell.d/launch-shell-ready-test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+command="$ROOT/bin/omarchy-launch-shell-ready"
+[[ -x $command ]] || fail "launch-shell-ready helper is installed"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mock_bin="$tmpdir/bin"
+call_log="$tmpdir/calls"
+hyprctl_count="$tmpdir/hyprctl-count"
+mkdir -p "$mock_bin"
+: >"$call_log"
+printf '0\n' >"$hyprctl_count"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+count=$(<"$HYPRCTL_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" >"$HYPRCTL_COUNT"
+
+if (( count == 1 )); then
+  printf '[{"name":"placeholder","disabled":false,"width":0,"height":0}]\n'
+else
+  printf '[{"name":"DP-1","disabled":false,"width":2560,"height":1440}]\n'
+fi
+SH
+
+for command_name in omarchy-hyprland-monitor-clamshell omarchy-launch-shell; do
+  cat >"$mock_bin/$command_name" <<SH
+#!/bin/bash
+printf '%s\n' '$command_name' >>"\$CALL_LOG"
+SH
+done
+chmod +x "$mock_bin"/*
+
+CALL_LOG="$call_log" HYPRCTL_COUNT="$hyprctl_count" PATH="$mock_bin:$PATH" \
+  OMARCHY_HYPRLAND_READY_ATTEMPTS=3 OMARCHY_HYPRLAND_READY_DELAY=0 \
+  "$command"
+
+mapfile -t calls <"$call_log"
+(( ${#calls[@]} == 2 )) ||
+  fail "helper records display-ready launch calls" "calls: ${calls[*]}"
+[[ ${calls[0]} == "omarchy-hyprland-monitor-clamshell" ]] ||
+  fail "helper reconciles clamshell state after a real output appears" "calls: ${calls[*]}"
+pass "helper reconciles clamshell state after a real output appears"
+
+[[ ${calls[1]} == "omarchy-launch-shell" ]] ||
+  fail "helper launches shell after display reconciliation" "calls: ${calls[*]}"
+pass "helper launches shell after display reconciliation"
+
+(( $(<"$hyprctl_count") == 2 )) ||
+  fail "helper waits past placeholder outputs" "hyprctl calls: $(<"$hyprctl_count")"
+pass "helper waits past placeholder outputs"
+
+: >"$call_log"
+printf '0\n' >"$hyprctl_count"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+count=$(<"$HYPRCTL_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" >"$HYPRCTL_COUNT"
+printf '[{"name":"placeholder","disabled":false,"width":0,"height":0}]\n'
+SH
+chmod +x "$mock_bin/hyprctl"
+
+CALL_LOG="$call_log" HYPRCTL_COUNT="$hyprctl_count" PATH="$mock_bin:$PATH" \
+  OMARCHY_HYPRLAND_READY_ATTEMPTS=3 OMARCHY_HYPRLAND_READY_DELAY=0 \
+  "$command"
+
+mapfile -t calls <"$call_log"
+(( ${#calls[@]} == 2 )) ||
+  fail "helper records fallback launch calls" "calls: ${calls[*]}"
+[[ ${calls[0]} == "omarchy-hyprland-monitor-clamshell" ]] ||
+  fail "helper reconciles clamshell state before fallback launch" "calls: ${calls[*]}"
+pass "helper reconciles clamshell state before fallback launch"
+
+[[ ${calls[1]} == "omarchy-launch-shell" ]] ||
+  fail "helper falls back to launching shell after bounded attempts" "calls: ${calls[*]}"
+pass "helper falls back to launching shell after bounded attempts"
+
+(( $(<"$hyprctl_count") == 3 )) ||
+  fail "helper bounds output readiness checks" "hyprctl calls: $(<"$hyprctl_count")"
+pass "helper bounds output readiness checks"
+
+autostart="$ROOT/default/hypr/autostart.lua"
+ready_line=$(grep -n 'hl\.exec_cmd("omarchy-launch-shell-ready")' "$autostart" | cut -d: -f1 || true)
+direct_shell_line=$(grep -n 'hl\.exec_cmd("omarchy-launch-shell")' "$autostart" | cut -d: -f1 || true)
+
+[[ -n $ready_line ]] || fail "autostart launches shell through the display-ready helper"
+pass "autostart launches shell through the display-ready helper"
+
+[[ -z $direct_shell_line ]] ||
+  fail "autostart does not also launch the shell directly"
+pass "autostart does not also launch the shell directly"


### PR DESCRIPTION
## What changed

Launch Omarchy shell through a new `omarchy-launch-shell-ready` helper. The helper waits until Hyprland reports at least one enabled real output before starting the shell, then reconciles clamshell monitor state and launches `omarchy-launch-shell`.

If no real output appears after the bounded wait, it logs and falls back to launching the shell.

## Why

When logging in docked with the laptop lid closed, Hyprland can start before the external display is fully available. Omarchy shell may then start against Qt's placeholder screen:

`There are no outputs - creating placeholder screen`

That leaves the user logged in but looking at a blank screen. Waiting for a real output before shell launch fixes the docked clamshell login path.

fixes #9529

## Verification

- Reproduced locally: docked laptop, lid closed, reboot, login caused blank screen.
- Verified locally: same flow works after the change.
- `bash ./test/shell.d/launch-shell-ready-test.sh`
- `bash ./test/shell.d/bin-style-test.sh`
- `bash ./test/cli`
- `bash -n bin/omarchy-launch-shell-ready test/shell.d/launch-shell-ready-test.sh`
- `git diff --check`

`bash ./test/all` was also run. It still fails due to missing local `omarchy-pkgs` checkout / `OMARCHY_PKGS_PATH`, unrelated to this change.