### PR TITLE
Don't report Tailscale removal as done after a cancelled sudo

### DIFF
--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -8,6 +8,6 @@
 source omarchy-restart-gum
 
 cmd="$*"
-presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
+presentation_script="omarchy-show-logo; $cmd; status=\$?; if (( status == 0 )); then omarchy-show-done; elif (( status != 130 )); then omarchy-show-done --failed; fi"
 
 exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"

--- a/bin/omarchy-remove-service-tailscale
+++ b/bin/omarchy-remove-service-tailscale
@@ -3,9 +3,17 @@
 # omarchy:summary=Remove Tailscale and its bar plugin.
 # omarchy:requires-sudo=true
 
+set -euo pipefail
+
+# Authenticate before any teardown. Ctrl+C at the password prompt is PAM
+# exit 1, not 130; map it so the presentation wrapper does not show Done.
+if ! sudo -v; then
+  exit 130
+fi
+
 tailscale down 2>/dev/null || true
 systemctl --user disable --now omarchy-tailscale-receive.service 2>/dev/null || true
-sudo systemctl disable --now tailscaled.service 2>/dev/null || true
+sudo systemctl disable --now tailscaled.service
 omarchy-plugin-disable omarchy.tailscale
 omarchy-webapp-remove "Tailscale" 2>/dev/null || true
 omarchy-pkg-drop tailscale

--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# omarchy:summary=Display a "Done!" message and wait for user to press any key.
+# omarchy:summary=Display a "Done!" or "Failed" message and wait for a keypress.
+# omarchy:args=[--failed]
 
 # The device node is there whether or not a terminal is behind it, so opening
 # it is the only test that means anything.
@@ -13,6 +14,10 @@ while read -rsn 1 -t 0.1 _ </dev/tty; do :; done
 
 # Prompt on the terminal rather than stdout, or a caller that redirects us
 # leaves the user waiting on a prompt they were never shown.
-printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+if [[ ${1:-} == "--failed" ]]; then
+  printf '\n\033[31m● \033[0mFailed. Press any key to close...' >/dev/tty
+else
+  printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+fi
 read -rsn 1 </dev/tty
 echo >/dev/tty

--- a/test/shell.d/floating-terminal-test.sh
+++ b/test/shell.d/floating-terminal-test.sh
@@ -21,3 +21,8 @@ export PATH="$tmp_dir:$ROOT/bin:$PATH"
 launch=$(<"$TEST_LOG")
 [[ $launch == *"xdg-terminal-exec --app-id=org.omarchy.terminal"* ]] || fail "floating terminal launches Omarchy terminal" "$launch"
 pass "floating terminal launches Omarchy terminal"
+
+[[ $launch == *"status=\$?"* || $launch == *'status=$?'* ]] || fail "presentation wrapper captures the command status" "$launch"
+[[ $launch == *"omarchy-show-done --failed"* ]] || fail "presentation wrapper shows Failed on non-cancel errors" "$launch"
+[[ $launch == *"status == 0"* ]] || fail "presentation wrapper shows Done only on success" "$launch"
+pass "presentation wrapper distinguishes success, failure, and cancel"

--- a/test/shell.d/remove-service-tailscale-test.sh
+++ b/test/shell.d/remove-service-tailscale-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_path="$test_tmp/bin"
+mkdir -p "$mock_path"
+
+cat >"$mock_path/sudo" <<'EOF'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$TEST_TMP/calls"
+if [[ ${SUDO_FAIL:-} == 1 ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+cat >"$mock_path/tailscale" <<'EOF'
+#!/bin/bash
+printf 'tailscale %s\n' "$*" >>"$TEST_TMP/calls"
+EOF
+
+cat >"$mock_path/systemctl" <<'EOF'
+#!/bin/bash
+printf 'systemctl %s\n' "$*" >>"$TEST_TMP/calls"
+EOF
+
+cat >"$mock_path/omarchy-plugin-disable" <<'EOF'
+#!/bin/bash
+printf 'plugin-disable %s\n' "$*" >>"$TEST_TMP/calls"
+EOF
+
+cat >"$mock_path/omarchy-webapp-remove" <<'EOF'
+#!/bin/bash
+printf 'webapp-remove %s\n' "$*" >>"$TEST_TMP/calls"
+EOF
+
+cat >"$mock_path/omarchy-pkg-drop" <<'EOF'
+#!/bin/bash
+printf 'pkg-drop %s\n' "$*" >>"$TEST_TMP/calls"
+EOF
+
+chmod +x "$mock_path"/*
+
+run_remove() {
+  rm -f "$test_tmp/calls" "$test_tmp/out"
+  PATH="$mock_path:$PATH" TEST_TMP="$test_tmp" \
+    bash "$ROOT/bin/omarchy-remove-service-tailscale" >"$test_tmp/out" 2>&1 || return $?
+}
+
+status=0
+SUDO_FAIL=1 run_remove || status=$?
+(( status == 130 )) || fail "cancelled sudo exits 130 so the presentation wrapper skips Done" "status=$status"
+[[ -e $test_tmp/calls ]] || fail "cancelled sudo still invokes sudo -v"
+[[ $(<"$test_tmp/calls") == "sudo -v" ]] || fail "cancelled sudo does not tear Tailscale down" "$(<"$test_tmp/calls")"
+if grep -q 'Tailscale has been removed.' "$test_tmp/out"; then
+  fail "cancelled sudo does not claim Tailscale was removed" "$(<"$test_tmp/out")"
+fi
+pass "cancelled sudo aborts before teardown"
+
+status=0
+SUDO_FAIL=0 run_remove || status=$?
+(( status == 0 )) || fail "authenticated sudo removes Tailscale" "status=$status"
+expected=$'sudo -v\ntailscale down\nsystemctl --user disable --now omarchy-tailscale-receive.service\nsudo systemctl disable --now tailscaled.service\nplugin-disable omarchy.tailscale\nwebapp-remove Tailscale\npkg-drop tailscale'
+[[ $(<"$test_tmp/calls") == "$expected" ]] || fail "authenticated sudo tears Tailscale down in order" "$(<"$test_tmp/calls")"
+grep -qx 'Tailscale has been removed.' "$test_tmp/out" || fail "authenticated sudo reports Tailscale was removed" "$(<"$test_tmp/out")"
+pass "authenticated sudo removes Tailscale"


### PR DESCRIPTION
Fixes #9526

Cancelling sudo during Remove → Tailscale still printed `Tailscale has been removed.`, showed green **Done!**, and disabled the bar plugin / web app / Taildrop receive service. The package and `tailscaled` stayed installed because the privileged steps never ran.

`sudo` at a password prompt exits 1 on Ctrl+C (PAM `conversation failed`), not 130. The remove script swallowed that with `|| true`, kept going, and always echoed success. The presentation wrapper then treated every non-130 exit as success.

**Remove script:** authenticate with `sudo -v` before any teardown, map a cancelled prompt to exit 130, and stop swallowing `systemctl disable` failure.

**Presentation:** show **Done!** only on exit 0; on other non-cancel failures show **Failed** and still wait for a key so the error stays readable.

```
bash test/shell.d/remove-service-tailscale-test.sh
bash test/shell.d/floating-terminal-test.sh
./test/cli
```