### PR TITLE
Wait for the Windows VM RDP service before connecting

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -897,8 +897,15 @@ __priv_up() { assert_mounts_safe && dc up -d; }
 
 __priv_down() { dc down; }
 
-# Bring the VM up and wait until the guest reports it is ready, all under a
-# single elevation so the readiness poll does not prompt on every iteration.
+# A successful TCP connection proves the forwarded RDP service is listening.
+# Keep this password-free: the privileged readiness path must not receive the
+# user's guest credentials or launch an authenticated FreeRDP process as root.
+rdp_port_ready() {
+  timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/3389' >/dev/null 2>&1
+}
+
+# Bring the VM up and wait until the guest reports it booted and its RDP service
+# accepts connections, all under one elevation so polling never prompts again.
 __priv_up_wait() {
   assert_mounts_safe || return 1
   local status
@@ -909,17 +916,27 @@ __priv_up_wait() {
 
   # docker logs persists across restarts, so anchor the scan to the current
   # start time; an empty --since would match a stale "started successfully".
-  local started_at count=0
+  local started_at count=0 boot_reported=0
   while true; do
-    started_at=$(docker inspect --format='{{.State.StartedAt}}' "$CONTAINER" 2>/dev/null)
-    if [[ -n $started_at ]] && docker logs --since "$started_at" "$CONTAINER" 2>&1 | grep -qi "windows started successfully"; then
+    if ((boot_reported == 0)); then
+      started_at=$(docker inspect --format='{{.State.StartedAt}}' "$CONTAINER" 2>/dev/null)
+      if [[ -n $started_at ]] && docker logs --since "$started_at" "$CONTAINER" 2>&1 | grep -qi "windows started successfully"; then
+        boot_reported=1
+      fi
+    fi
+    if ((boot_reported == 1)) && rdp_port_ready; then
       return 0
     fi
     sleep 2
-    ((++count > 60)) && {
-      echo "Timeout: Windows VM did not report ready within 2 minutes" >&2
+    ((++count))
+    if ((count > 60)); then
+      if ((boot_reported == 1)); then
+        echo "Timeout: Windows VM booted but RDP did not become reachable within 2 minutes" >&2
+      else
+        echo "Timeout: Windows VM did not report ready within 2 minutes" >&2
+      fi
       return 1
-    }
+    fi
   done
 }
 

--- a/test/shell.d/windows-vm-readiness-test.sh
+++ b/test/shell.d/windows-vm-readiness-test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+source "$ROOT/bin/omarchy-windows-vm" help >/dev/null 2>&1
+
+assert_mounts_safe() { return 0; }
+sleep() { return 0; }
+
+container_status="stopped"
+boot_after=2
+rdp_after=2
+events="$test_dir/events"
+log_count="$test_dir/log-count"
+rdp_count=0
+
+dc() {
+  [[ $* == "up -d" ]] || return 1
+  printf '%s\n' "up" >>"$events"
+  container_status="running"
+}
+
+docker() {
+  if [[ $1 == "inspect" && $* == *".State.Status"* ]]; then
+    printf '%s\n' "$container_status"
+  elif [[ $1 == "inspect" && $* == *".State.StartedAt"* ]]; then
+    printf '%s\n' "2026-09-01T00:00:00Z"
+  elif [[ $1 == "logs" ]]; then
+    local count=0
+    [[ -f $log_count ]] && count=$(<"$log_count")
+    ((++count))
+    printf '%s\n' "$count" >"$log_count"
+    printf '%s\n' "log" >>"$events"
+    if ((count >= boot_after)); then
+      printf '%s\n' "Windows started successfully"
+    fi
+  else
+    return 1
+  fi
+}
+
+rdp_port_ready() {
+  ((++rdp_count))
+  printf '%s\n' "rdp" >>"$events"
+  ((rdp_count >= rdp_after))
+}
+
+__priv_up_wait || fail "readiness wait succeeds after the boot log and RDP listener are both ready"
+[[ $(paste -sd, "$events") == "up,log,log,rdp,rdp" ]] || fail "RDP is not probed until the current boot reports success"
+pass "readiness waits for RDP after the current boot reports success"
+
+: >"$events"
+printf '%s\n' 0 >"$log_count"
+container_status="running"
+boot_after=1
+rdp_after=1
+rdp_count=0
+__priv_up_wait || fail "an already running VM with RDP ready is accepted"
+[[ $(paste -sd, "$events") == "log,rdp" ]] || fail "an already running VM is not started again"
+pass "an already running VM is checked without another compose up"
+
+: >"$events"
+printf '%s\n' 0 >"$log_count"
+container_status="running"
+boot_after=1
+rdp_after=1000
+rdp_count=0
+if __priv_up_wait 2>"$test_dir/timeout-error"; then
+  fail "a VM whose RDP listener never starts times out"
+fi
+grep -q "booted but RDP did not become reachable" "$test_dir/timeout-error" || fail "RDP timeout explains which readiness phase failed"
+((rdp_count > 1)) || fail "RDP readiness is polled rather than checked once"
+pass "RDP readiness timeout is bounded and diagnostic"


### PR DESCRIPTION
## Summary

- keep the current-start container log check as the boot precondition
- after that message appears, poll the forwarded 127.0.0.1:3389 TCP listener before returning from up_wait
- retain the existing two-minute bound and report whether boot or RDP readiness timed out
- keep guest credentials out of the privileged probe and never launch FreeRDP as root

This closes the interval where dockurr/windows has logged Windows started successfully but the guest RDP service is not listening yet.

Fixes #9515

## Testing

- test/shell.d/windows-vm-readiness-test.sh
- test/shell.d/windows-vm-test.sh
- test/shell.d/windows-vm-compose-test.sh
- test/shell.d/windows-vm-mount-boundary-test.sh
- ./test/cli
- bash -n bin/omarchy-windows-vm test/shell.d/windows-vm-readiness-test.sh
- git diff --check

All runtime and CLI tests passed in the ARM Linux Omarchy VM. The readiness test covers delayed boot reporting, delayed RDP listening, an already-running container, and a bounded RDP timeout.