### PR TITLE
Add Super+A agents menu

### DIFF
--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -1,5 +1,6 @@
 o.bind("SUPER + SPACE", "Omarchy menu", "omarchy-menu toggle")
 o.bind("SUPER + ALT + SPACE", "Apps menu", "omarchy-menu toggle apps")
+o.bind("SUPER + A", "Agents menu", "omarchy-menu summon agents")
 o.bind("SUPER + CTRL + E", "Emojis", "omarchy-shell shell toggle omarchy.emojis")
 o.bind("SUPER + CTRL + C", "Capture menu", "omarchy-menu toggle capture")
 o.bind("SUPER + CTRL + O", "Toggle menu", "omarchy-menu toggle toggle")

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -22,6 +22,7 @@
 
   // Root Menu
   "apps": {"icon":"󰀻","label":"Apps","aliases":["app","applications"],"provider":"apps"},
+  "agents": {"icon":"󱚤","label":"Agents"},
   "learn": {"icon":"󰧑","label":"Learn"},
   "trigger": {"icon":"󱓞","label":"Trigger"},
   "style": {"icon":"","label":"Style"},
@@ -51,6 +52,16 @@
   "learn.tmux-keybindings": {"icon":"","label":"Tmux","action":"omarchy-menu-tmux-keybindings"},
   "learn.herdr-keybindings": {"icon":"","label":"Herdr","action":"omarchy-menu-herdr-keybindings"},
   "learn.community": {"icon":"󰙯","label":"Community","action":"omarchy-launch-discord-community"},
+
+  // Agents
+  "agents.chatgpt": {"icon":"","iconFont":"omarchy","label":"ChatGPT","description":"Web","action":"omarchy-launch-webapp 'https://chatgpt.com'"},
+  "agents.claude": {"icon":"󰛄","label":"Claude","description":"Web","action":"omarchy-launch-webapp 'https://claude.ai'"},
+  "agents.grok": {"icon":"","iconFont":"omarchy","label":"Grok","description":"Web","action":"omarchy-launch-webapp 'https://grok.com'"},
+  "agents.gemini": {"icon":"󰫢","label":"Gemini","description":"Web","action":"omarchy-launch-webapp 'https://gemini.google.com'"},
+  "agents.pi": {"icon":"","iconFont":"omarchy","label":"Pi","description":"Terminal","action":"omarchy-launch-tui pi"},
+  "agents.codex": {"icon":"","iconFont":"omarchy","label":"Codex","description":"Terminal","action":"omarchy-launch-tui codex"},
+  "agents.claude-code": {"icon":"󰛄","label":"Claude Code","description":"Terminal","action":"omarchy-launch-tui claude"},
+  "agents.opencode": {"icon":"","iconFont":"omarchy","label":"OpenCode","description":"Terminal","action":"omarchy-launch-tui opencode"},
 
   // Trigger
   "trigger.emoji": {"icon":"","label":"Emoji","aliases":["emoji","emojis"],"action":"omarchy-menu-emoji"},

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -8,6 +8,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | ----------------------- | --------------------- |
 | `Super + Space`           | Omarchy menu (apps and everything else)    |
 | `Super + Alt + Space` | Apps menu |
+| `Super + A` | Agents menu |
 | `Super + Escape` | System menu (suspend, restart, etc)  |
 | `Super + Ctrl + L` | Lock computer |
 | `Super + W` or `Super + Q` | Close window             |

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -19,11 +19,15 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 
 To wrap an additional CLI the same way, run `omarchy-mise-install <package> [command-name]`. The stubs are kept current along with everything else mise manages when you run `omarchy update` (or the `mup` alias).
 
+### The agents menu
+
+`Super + A` opens the Agents menu: ChatGPT, Claude, Grok, and Gemini as web apps, plus Pi, Codex, Claude Code, and OpenCode in a terminal. The same list is on the Omarchy menu (`Super + Space`).
+
 ### The default agent
 
 Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If the agent isn't installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification.
 
-Once you've chosen, `Super + Shift + Ctrl + A` launches the default agent in a dedicated terminal window (or brings up the picker if you haven't chosen yet). You can also launch it straight into a task with `omarchy agent prompt "Review this project"`. Agents launched this way run unattended in their respective don't-stop-to-ask modes, so be ready for them to actually do things! And since agents refuse to remember trust for your home directory, launches from `$HOME` start in `~/Work` instead.
+Once you've chosen a default, `Super + Shift + Ctrl + A` launches that agent in a dedicated terminal window (or brings up the picker if you haven't chosen yet). You can also launch it straight into a task with `omarchy agent prompt "Review this project"`. Agents launched this way run unattended in their respective don't-stop-to-ask modes, so be ready for them to actually do things! And since agents refuse to remember trust for your home directory, launches from `$HOME` start in `~/Work` instead.
 
 There are terminal shortcuts too: `a` runs the default agent inline in the current terminal, while `c`, `cx`, and `cy` start OpenCode, Claude Code, and Codex directly (again in their auto-approving modes). Theme changes sync to the agents as well: Claude Code, Pi, and OpenCode all follow along when you switch the Omarchy theme.
 

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -247,6 +247,23 @@ assertDeepEqual(
   ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Grok', 'omp', 'OpenCode', 'Ori', 'Pi'],
   'menu sorts coding agents alphabetically'
 )
+assert(defaultById.agents && !defaultById.agents.action, 'menu places Agents on the root menu as a submenu')
+assertDeepEqual(
+  defaultItems
+    .filter(item => item.parent === 'agents')
+    .map(item => [item.id, item.label, item.description, item.action]),
+  [
+    ['agents.chatgpt', 'ChatGPT', 'Web', "omarchy-launch-webapp 'https://chatgpt.com'"],
+    ['agents.claude', 'Claude', 'Web', "omarchy-launch-webapp 'https://claude.ai'"],
+    ['agents.grok', 'Grok', 'Web', "omarchy-launch-webapp 'https://grok.com'"],
+    ['agents.gemini', 'Gemini', 'Web', "omarchy-launch-webapp 'https://gemini.google.com'"],
+    ['agents.pi', 'Pi', 'Terminal', 'omarchy-launch-tui pi'],
+    ['agents.codex', 'Codex', 'Terminal', 'omarchy-launch-tui codex'],
+    ['agents.claude-code', 'Claude Code', 'Terminal', 'omarchy-launch-tui claude'],
+    ['agents.opencode', 'OpenCode', 'Terminal', 'omarchy-launch-tui opencode']
+  ],
+  'menu launches web apps and coding CLIs from Agents'
+)
 const expectedDefaults = {
   browser: ['Chromium', 'Chrome', 'Brave', 'Brave Origin', 'Edge', 'Firefox', 'Zen'],
   terminal: ['Alacritty', 'Foot', 'Ghostty', 'Kitty'],


### PR DESCRIPTION
## Summary

Adds a dedicated Agents menu on `Super + A` (also reachable from the Omarchy menu) so you can launch the common AI surfaces from one place.

**Web apps**
- ChatGPT (`https://chatgpt.com`)
- Claude (`https://claude.ai`)
- Grok (`https://grok.com`)
- Gemini (`https://gemini.google.com`)

**Terminal CLIs** (via `omarchy-launch-tui`; first run still installs the mise stub)
- Pi
- Codex
- Claude Code
- OpenCode

`Super + A` is unbound today. This does not change `Super + Q` (close window), `Super + Ctrl + A` (audio panel), `Super + Shift + A` (ChatGPT), or `Super + Shift + Ctrl + A` (default coding agent).

## Test plan

- [x] `bash test/shell.d/menu-test.sh`
- [x] `bash test/shell.d/hyprland-binding-conflicts-test.sh`
- [x] `bash test/shell.d/hyprland-default-config-test.sh`
- [ ] Press `Super + A` and confirm the Agents list opens
- [ ] Launch a web row and a terminal row
- [ ] Confirm `Super + Space` also shows Agents on the root menu