### PR TITLE
Show browser shortcuts only when their extensions are enabled

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -325,10 +325,36 @@ dynamic_bindings() {
     done
 }
 
-# Hardcoded bindings, like the copy-url extension and such
+# The browser shortcuts come from unpacked Chromium extensions rather than
+# Hyprland. Only advertise one when an installed Chromium-family browser is
+# configured to load the extension that owns it.
+chromium_extension_enabled() {
+  local extension="$1" flags_file
+
+  [[ -d $OMARCHY_PATH/default/chromium/extensions/$extension ]] || return 1
+
+  for flags_file in \
+    "$HOME/.config/chromium-flags.conf" \
+    "$HOME/.config/chrome-flags.conf" \
+    "$HOME/.config/brave-flags.conf" \
+    "$HOME/.config/brave-origin-flags.conf" \
+    "$HOME/.config/microsoft-edge-stable-flags.conf"; do
+    if [[ -f $flags_file ]] && grep -Eq "^[[:space:]]*--load-extension=.*[/]extensions/$extension([,[:space:]]|$)" "$flags_file"; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 static_bindings() {
-  echo "SHIFT ALT,L,Copy URL from Web App,sendshortcut,SHIFT ALT,L,"
-  echo "SHIFT ALT,D,Download Video from Web App,sendshortcut,SHIFT ALT,D,"
+  if chromium_extension_enabled copy-url; then
+    echo "SHIFT ALT,L,Copy URL from Web App,sendshortcut,SHIFT ALT,L,"
+  fi
+
+  if chromium_extension_enabled yt-dlp; then
+    echo "SHIFT ALT,D,Download Video from Web App,sendshortcut,SHIFT ALT,D,"
+  fi
 }
 
 # Actions Omarchy binds to a second chord meant as an alternative, named one at
@@ -530,7 +556,17 @@ output_binding_records_uncached() {
 
 keybindings_cache_key() {
   {
-    printf 'v13\n'
+    printf 'v14\n'
+    if chromium_extension_enabled copy-url; then
+      printf 'copy-url:on\n'
+    else
+      printf 'copy-url:off\n'
+    fi
+    if chromium_extension_enabled yt-dlp; then
+      printf 'yt-dlp:on\n'
+    else
+      printf 'yt-dlp:off\n'
+    fi
     hyprctl devices 2>/dev/null | grep -F 'active keymap:'
     hyprctl binds 2>/dev/null
   } | sha256sum | awk '{ print $1 }'

--- a/manual/23-browsers.md
+++ b/manual/23-browsers.md
@@ -26,6 +26,8 @@ The Chromium-family browsers (Chromium itself, Chrome, Edge, and Brave) come wit
 
 Both extensions talk to Omarchy through a small native messaging host, which gets installed for you along with the browser. That's the piece that lets a web page's video end up in your home directory and a URL end up in your clipboard manager, which a normal extension can't do on its own.
 
+Their shortcuts appear in the `Super + K` keybindings menu only while at least one Chromium-family browser is configured to load the corresponding extension. Removing an extension from that browser's `--load-extension` flag removes its shortcut from the menu too.
+
 These are Chromium-family only. Firefox and Zen don't get them.
 
 ## Firefox and Zen

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -65,6 +65,32 @@ grep -q 'SUPER + F  *→ Full screen' <<<"$rendered" ||
   fail "a chord with no alternative renders on its own" "$rendered"
 pass "the keybindings menu renders its entries"
 
+! grep -q 'Copy URL from Web App' <<<"$rendered" ||
+  fail "an unloaded Copy URL extension stays out of the keybindings menu" "$rendered"
+! grep -q 'Download Video from Web App' <<<"$rendered" ||
+  fail "an unloaded Download Video extension stays out of the keybindings menu" "$rendered"
+pass "unloaded Chromium extensions stay out of the keybindings menu"
+
+cat >"$home/.config/chromium-flags.conf" <<EOF
+--load-extension=$ROOT/default/chromium/extensions/copy-url,$ROOT/default/chromium/extensions/yt-dlp
+EOF
+
+rendered=$(keybindings)
+grep -q 'SHIFT ALT + L  *→ Copy URL from Web App' <<<"$rendered" ||
+  fail "an enabled Copy URL extension advertises its shortcut" "$rendered"
+grep -q 'SHIFT ALT + D  *→ Download Video from Web App' <<<"$rendered" ||
+  fail "an enabled Download Video extension advertises its shortcut" "$rendered"
+pass "enabled Chromium extensions advertise their shortcuts"
+
+sed -i 's|,.*yt-dlp||' "$home/.config/chromium-flags.conf"
+
+rendered=$(keybindings)
+grep -q 'Copy URL from Web App' <<<"$rendered" ||
+  fail "the enabled Copy URL shortcut remains after the flags change" "$rendered"
+! grep -q 'Download Video from Web App' <<<"$rendered" ||
+  fail "the keybindings cache follows the current Chromium extension flags" "$rendered"
+pass "Chromium extension changes invalidate the keybindings cache"
+
 (( $(grep -c '→ Close window$' <<<"$rendered") == 1 )) ||
   fail "an alternative chord joins the row of the first one" "$rendered"
 grep -q 'SUPER + W / SUPER + Q  *→ Close window' <<<"$rendered" ||


### PR DESCRIPTION
## Summary

- show the Copy URL and Download Video rows only when a Chromium-family flags file loads the corresponding bundled extension
- include extension availability in the keybindings cache key so editing browser flags updates the menu immediately
- document when these extension-owned shortcuts appear in `Super + K`

Closes #8642

## Test plan

- `test/shell.d/keybindings-menu-test.sh`
- `./test/cli`
- live Hyprland/Quickshell verification with both extensions enabled: searching `Web App` shows both rows
- live verification without Chromium extension flags: searching `Web App` shows no matches