### PR TITLE
Generate themes from wallpapers with Matugen

### DIFF
--- a/bin/omarchy-theme-colors-from-wallpaper
+++ b/bin/omarchy-theme-colors-from-wallpaper
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# omarchy:summary=Generate a theme's colors.toml from a wallpaper
+# omarchy:args=<image> <theme-dir> [smart|dark|light]
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+IMAGE="${1:-}"
+THEME_DIR="${2:-}"
+MODE="${3:-smart}"
+MATUGEN_CONFIG="$OMARCHY_PATH/default/omarchy/matugen-theme.toml"
+
+if [[ -z $IMAGE || -z $THEME_DIR ]]; then
+  echo "Usage: omarchy-theme-colors-from-wallpaper <image> <theme-dir> [smart|dark|light]" >&2
+  exit 1
+fi
+
+if [[ $MODE != "smart" && $MODE != "dark" && $MODE != "light" ]]; then
+  echo "Error: mode must be smart, dark, or light." >&2
+  exit 1
+fi
+
+IMAGE=$(realpath -e -- "$IMAGE" 2>/dev/null) || {
+  echo "Error: wallpaper does not exist: $1" >&2
+  exit 1
+}
+
+if [[ ! -f $IMAGE ]]; then
+  echo "Error: wallpaper is not a regular file: $IMAGE" >&2
+  exit 1
+fi
+
+mkdir -p "$THEME_DIR"
+COLORS_OUTPUT="$THEME_DIR/colors.toml"
+[[ -f $COLORS_OUTPUT ]] && exit 0
+
+if omarchy-cmd-missing matugen; then
+  echo "Installing matugen for wallpaper palette generation..." >&2
+  omarchy-pkg-add matugen
+fi
+
+PALETTE_JSON=$(mktemp)
+COLORS_STAGE=$(mktemp "$THEME_DIR/.colors.toml.XXXXXXXX")
+
+cleanup() {
+  rm -f -- "$PALETTE_JSON" "$COLORS_STAGE"
+}
+trap cleanup EXIT
+
+if ! matugen --config "$MATUGEN_CONFIG" --mode "$MODE" --source-color-index 0 --dry-run --json hex image "$IMAGE" >"$PALETTE_JSON"; then
+  echo "Error: matugen could not extract a palette from $IMAGE" >&2
+  exit 1
+fi
+
+# Material roles supply contrast-aware surfaces and text. The custom colors in
+# matugen-theme.toml retain recognizable ANSI hues while Matugen harmonizes
+# them with the wallpaper's source color.
+if ! jq -er '
+  def hex:
+    select(type == "string" and test("^#[0-9a-fA-F]{6}$")) | ascii_downcase;
+  def color($name):
+    .colors[$name].default.color | hex;
+
+  .mode as $mode
+  | select($mode == "dark" or $mode == "light")
+  | {
+      mode: $mode,
+      accent: color("primary"),
+      selection: color("secondary_container"),
+      muted: color("outline_variant"),
+      background: color("surface"),
+      dark_background: (if $mode == "dark" then color("surface_container_lowest") else color("surface_container") end),
+      darker_background: (if $mode == "dark" then color("shadow") else color("surface_container_highest") end),
+      lighter_background: (if $mode == "dark" then color("surface_container") else color("surface_container_low") end),
+      foreground: color("on_surface"),
+      dark_foreground: color("outline"),
+      light_foreground: color("on_surface_variant"),
+      bright_foreground: color("on_surface"),
+      red: color("red"),
+      yellow: color("yellow"),
+      orange: color("orange"),
+      green: color("green"),
+      cyan: color("cyan"),
+      blue: color("blue"),
+      magenta: color("magenta"),
+      brown: color("brown"),
+      bright_red: (if $mode == "dark" then color("on_red_container") else color("red") end),
+      bright_yellow: (if $mode == "dark" then color("on_yellow_container") else color("yellow") end),
+      bright_green: (if $mode == "dark" then color("on_green_container") else color("green") end),
+      bright_cyan: (if $mode == "dark" then color("on_cyan_container") else color("cyan") end),
+      bright_blue: (if $mode == "dark" then color("on_blue_container") else color("blue") end),
+      bright_magenta: (if $mode == "dark" then color("on_magenta_container") else color("magenta") end)
+    }
+  | [
+      "mode = \(.mode | @json)",
+      "",
+      "accent = \(.accent | @json)",
+      "selection = \(.selection | @json)",
+      "muted = \(.muted | @json)",
+      "",
+      "background = \(.background | @json)",
+      "dark_background = \(.dark_background | @json)",
+      "darker_background = \(.darker_background | @json)",
+      "lighter_background = \(.lighter_background | @json)",
+      "",
+      "foreground = \(.foreground | @json)",
+      "dark_foreground = \(.dark_foreground | @json)",
+      "light_foreground = \(.light_foreground | @json)",
+      "bright_foreground = \(.bright_foreground | @json)",
+      "",
+      "red = \(.red | @json)",
+      "yellow = \(.yellow | @json)",
+      "orange = \(.orange | @json)",
+      "green = \(.green | @json)",
+      "cyan = \(.cyan | @json)",
+      "blue = \(.blue | @json)",
+      "magenta = \(.magenta | @json)",
+      "brown = \(.brown | @json)",
+      "",
+      "bright_red = \(.bright_red | @json)",
+      "bright_yellow = \(.bright_yellow | @json)",
+      "bright_green = \(.bright_green | @json)",
+      "bright_cyan = \(.bright_cyan | @json)",
+      "bright_blue = \(.bright_blue | @json)",
+      "bright_magenta = \(.bright_magenta | @json)"
+    ]
+  | .[]
+' "$PALETTE_JSON" >"$COLORS_STAGE"; then
+  echo "Error: matugen returned an incomplete or invalid palette." >&2
+  exit 1
+fi
+
+mv -- "$COLORS_STAGE" "$COLORS_OUTPUT"

--- a/bin/omarchy-theme-from-wallpaper
+++ b/bin/omarchy-theme-from-wallpaper
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+# omarchy:name=from-wallpaper
+# omarchy:summary=Create an Omarchy theme from a wallpaper
+# omarchy:args=<image> [--name <name>] [--mode smart|dark|light] [--apply] [--force]
+# omarchy:examples=omarchy theme from-wallpaper ~/Pictures/wall.jpg | omarchy theme from-wallpaper ~/Pictures/wall.jpg --name aurora --apply
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+IMAGE_INPUT=""
+THEME_NAME=""
+MODE="smart"
+APPLY=false
+FORCE=false
+
+usage() {
+  echo "Usage: omarchy-theme-from-wallpaper <image> [--name <name>] [--mode smart|dark|light] [--apply] [--force]"
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --name)
+      if (( $# < 2 )); then
+        echo "Error: --name requires a value." >&2
+        exit 1
+      fi
+      THEME_NAME="$2"
+      shift 2
+      ;;
+    --mode)
+      if (( $# < 2 )); then
+        echo "Error: --mode requires smart, dark, or light." >&2
+        exit 1
+      fi
+      MODE="$2"
+      shift 2
+      ;;
+    --apply)
+      APPLY=true
+      shift
+      ;;
+    --force)
+      FORCE=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      if (( $# != 1 )) || [[ -n $IMAGE_INPUT ]]; then
+        usage >&2
+        exit 1
+      fi
+      IMAGE_INPUT="$1"
+      shift
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n $IMAGE_INPUT ]]; then
+        echo "Error: only one wallpaper can be used at a time." >&2
+        exit 1
+      fi
+      IMAGE_INPUT="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z $IMAGE_INPUT ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ $MODE != "smart" && $MODE != "dark" && $MODE != "light" ]]; then
+  echo "Error: mode must be smart, dark, or light." >&2
+  exit 1
+fi
+
+IMAGE=$(realpath -e -- "$IMAGE_INPUT" 2>/dev/null) || {
+  echo "Error: wallpaper does not exist: $IMAGE_INPUT" >&2
+  exit 1
+}
+
+if [[ ! -f $IMAGE ]]; then
+  echo "Error: wallpaper is not a regular file: $IMAGE" >&2
+  exit 1
+fi
+
+IMAGE_EXTENSION="${IMAGE##*.}"
+IMAGE_EXTENSION="${IMAGE_EXTENSION,,}"
+case "$IMAGE_EXTENSION" in
+  jpg | jpeg | png | gif | bmp | webp) ;;
+  *)
+    echo "Error: wallpaper must be a jpg, jpeg, png, gif, bmp, or webp image." >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z $THEME_NAME ]]; then
+  IMAGE_NAME="${IMAGE##*/}"
+  IMAGE_NAME="${IMAGE_NAME%.*}"
+  THEME_SLUG=$(printf '%s' "$IMAGE_NAME" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+  THEME_NAME="wallpaper-${THEME_SLUG:-theme}"
+else
+  THEME_NAME=$(printf '%s' "$THEME_NAME" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+fi
+
+if ! (LC_ALL=C; [[ $THEME_NAME =~ ^[a-z0-9_][a-z0-9._+-]*$ ]]); then
+  echo "Error: theme names may only use ASCII letters, digits, '.', '_', '+', and '-', and cannot start with '.' or '-'." >&2
+  exit 1
+fi
+
+THEMES_DIR="$HOME/.config/omarchy/themes"
+THEME_PATH="$THEMES_DIR/$THEME_NAME"
+
+if [[ -e $THEME_PATH || -L $THEME_PATH ]]; then
+  if [[ $FORCE == false ]]; then
+    echo "Error: theme '$THEME_NAME' already exists. Pass --force to replace it." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$THEMES_DIR"
+STAGING_DIR=$(mktemp -d "$THEMES_DIR/.${THEME_NAME}.XXXXXXXX")
+BACKUP_PATH=""
+
+cleanup() {
+  if [[ -n $STAGING_DIR && ( -e $STAGING_DIR || -L $STAGING_DIR ) ]]; then
+    rm -rf -- "$STAGING_DIR"
+  fi
+
+  if [[ -n $BACKUP_PATH && ( -e $BACKUP_PATH || -L $BACKUP_PATH ) ]]; then
+    if [[ ! -e $THEME_PATH && ! -L $THEME_PATH ]]; then
+      mv -- "$BACKUP_PATH" "$THEME_PATH"
+    fi
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$STAGING_DIR/backgrounds"
+cp -- "$IMAGE" "$STAGING_DIR/backgrounds/wallpaper.$IMAGE_EXTENSION"
+omarchy-theme-colors-from-wallpaper "$IMAGE" "$STAGING_DIR" "$MODE"
+
+if [[ -e $THEME_PATH || -L $THEME_PATH ]]; then
+  BACKUP_PATH=$(mktemp -d "$THEMES_DIR/.${THEME_NAME}.backup.XXXXXXXX")
+  rmdir -- "$BACKUP_PATH"
+  mv -- "$THEME_PATH" "$BACKUP_PATH"
+fi
+
+mv -- "$STAGING_DIR" "$THEME_PATH"
+STAGING_DIR=""
+
+if [[ -n $BACKUP_PATH ]]; then
+  rm -rf -- "$BACKUP_PATH"
+  BACKUP_PATH=""
+fi
+
+trap - EXIT
+
+if [[ $APPLY == true ]]; then
+  omarchy-theme-set "$THEME_NAME"
+fi
+
+printf '%s\n' "$THEME_NAME"

--- a/default/omarchy/matugen-theme.toml
+++ b/default/omarchy/matugen-theme.toml
@@ -1,0 +1,11 @@
+[config.custom_colors]
+red = { color = "#ef5350", blend = true }
+orange = { color = "#ff9800", blend = true }
+yellow = { color = "#fbc02d", blend = true }
+green = { color = "#66bb6a", blend = true }
+cyan = { color = "#26c6da", blend = true }
+blue = { color = "#42a5f5", blend = true }
+magenta = { color = "#ab47bc", blend = true }
+brown = { color = "#8d6e63", blend = true }
+
+[templates]

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -45,6 +45,14 @@ Making a new app follow theme changes means adding its restart/retint command
 to that list. Runs serialize on a `flock`, so scripted theme changes queue
 instead of racing.
 
+## Wallpaper-derived themes
+
+`omarchy theme from-wallpaper <image>` creates a normal user theme under `~/.config/omarchy/themes/`; `--apply` then hands that theme to the unchanged activation flow above. The source image is resolved before generation and copied into the theme's `backgrounds/` directory, so a generated theme remains usable if the original image moves and the theme switcher can use that image as its preview.
+
+Palette extraction uses Matugen as an optional dependency installed on first use. `default/omarchy/matugen-theme.toml` adds harmonized red, orange, yellow, green, cyan, blue, magenta, and brown source colors, while `omarchy-theme-colors-from-wallpaper` maps Matugen's contrast-aware Material roles into Omarchy's semantic background, foreground, selection, and accent steps. Smart mode lets Matugen select light or dark from the image; the CLI also accepts an explicit `--mode light` or `--mode dark`.
+
+Generation happens in a temporary sibling of the final theme directory. Omarchy only moves it into place after the image and a schema-complete `colors.toml` have both been written successfully. Existing themes require `--force`; even then, the previous directory is retained as a temporary backup until the replacement move succeeds.
+
 ## What an installed theme may not ship
 
 `themes/<name>/` in this repo is Omarchy's own code and is trusted. So is a theme the user wrote by hand in `~/.config/omarchy/themes/<name>/`: it is their machine and their file, and both stage in full.

--- a/manual/43-making-your-own-theme.md
+++ b/manual/43-making-your-own-theme.md
@@ -6,6 +6,22 @@ The main file you have to tweak is `colors.toml`. That defines the color set tha
 
 You can also use the included Aether application to create a new theme using a lovely GUI interface to play with colors and search for backgrounds. Just start it via the apps menu on `Super + Alt + Space`.
 
+### Create a theme from a wallpaper
+
+You can turn an image into a complete theme from the command line:
+
+```bash
+omarchy theme from-wallpaper ~/Pictures/wall.jpg
+```
+
+This creates `~/.config/omarchy/themes/wallpaper-wall`, copies the image into the theme, and prints the new theme name. It does not change the running desktop unless you pass `--apply`:
+
+```bash
+omarchy theme from-wallpaper ~/Pictures/wall.jpg --name aurora --apply
+```
+
+Omarchy installs Matugen the first time it is needed. Matugen picks a dark or light palette from the image by default; use `--mode dark` or `--mode light` to override that choice. Existing themes are never overwritten unless you explicitly pass `--force`.
+
 ### What an installed theme can contain
 
 A theme you write yourself in `~/.config/omarchy/themes` can contain whatever you like — it's your machine and your file, and Omarchy applies all of it.

--- a/test/shell.d/theme-from-wallpaper-test.sh
+++ b/test/shell.d/theme-from-wallpaper-test.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+matugen_calls="$test_tmp/matugen-calls"
+package_calls="$test_tmp/package-calls"
+theme_calls="$test_tmp/theme-calls"
+mkdir -p "$mock_bin" "$test_home/.config/omarchy/themes" "$test_tmp/images"
+
+cat >"$mock_bin/omarchy-cmd-missing" <<'STUB'
+#!/bin/bash
+[[ ${OMARCHY_TEST_MATUGEN_MISSING:-false} == "true" ]]
+STUB
+
+cat >"$mock_bin/omarchy-pkg-add" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_PACKAGE_CALLS"
+STUB
+
+cat >"$mock_bin/omarchy-theme-set" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_THEME_CALLS"
+STUB
+
+cat >"$mock_bin/matugen" <<'STUB'
+#!/bin/bash
+
+printf '%s\n' --call-- "$@" >>"$OMARCHY_TEST_MATUGEN_CALLS"
+[[ ${OMARCHY_TEST_MATUGEN_FAIL:-false} == "true" ]] && exit 1
+
+requested_mode="smart"
+while (( $# > 0 )); do
+  if [[ $1 == "--mode" ]]; then
+    requested_mode="$2"
+    break
+  fi
+  shift
+done
+
+if [[ $requested_mode == "light" ]]; then
+  mode="light"
+else
+  mode="dark"
+fi
+
+cat <<JSON
+{
+  "mode": "$mode",
+  "colors": {
+    "primary": {"default": {"color": "#123456"}},
+    "secondary_container": {"default": {"color": "#234567"}},
+    "outline_variant": {"default": {"color": "#345678"}},
+    "surface": {"default": {"color": "#222222"}},
+    "surface_container_lowest": {"default": {"color": "#111111"}},
+    "surface_container": {"default": {"color": "#eeeeee"}},
+    "surface_container_highest": {"default": {"color": "#dddddd"}},
+    "surface_container_low": {"default": {"color": "#f8f8f8"}},
+    "shadow": {"default": {"color": "#000000"}},
+    "on_surface": {"default": {"color": "#f0f0f0"}},
+    "outline": {"default": {"color": "#777777"}},
+    "on_surface_variant": {"default": {"color": "#cccccc"}},
+    "red": {"default": {"color": "#aa0000"}},
+    "yellow": {"default": {"color": "#aaaa00"}},
+    "orange": {"default": {"color": "#aa5500"}},
+    "green": {"default": {"color": "#00aa00"}},
+    "cyan": {"default": {"color": "#00aaaa"}},
+    "blue": {"default": {"color": "#0000aa"}},
+    "magenta": {"default": {"color": "#aa00aa"}},
+    "brown": {"default": {"color": "#775533"}},
+    "on_red_container": {"default": {"color": "#ffaaaa"}},
+    "on_yellow_container": {"default": {"color": "#ffffaa"}},
+    "on_green_container": {"default": {"color": "#aaffaa"}},
+    "on_cyan_container": {"default": {"color": "#aaffff"}},
+    "on_blue_container": {"default": {"color": "#aaaaff"}},
+    "on_magenta_container": {"default": {"color": "#ffaaff"}}
+  }
+}
+JSON
+STUB
+
+chmod +x "$mock_bin"/*
+
+run_theme() {
+  : >"$test_tmp/stdout"
+  : >"$test_tmp/stderr"
+
+  HOME="$test_home" PATH="$mock_bin:$ROOT/bin:/usr/bin" OMARCHY_PATH="$ROOT" \
+    OMARCHY_TEST_MATUGEN_CALLS="$matugen_calls" OMARCHY_TEST_PACKAGE_CALLS="$package_calls" \
+    OMARCHY_TEST_THEME_CALLS="$theme_calls" \
+    OMARCHY_TEST_MATUGEN_MISSING="${OMARCHY_TEST_MATUGEN_MISSING:-false}" \
+    OMARCHY_TEST_MATUGEN_FAIL="${OMARCHY_TEST_MATUGEN_FAIL:-false}" \
+    "$BASH" "$ROOT/bin/omarchy-theme-from-wallpaper" "$@" >"$test_tmp/stdout" 2>"$test_tmp/stderr"
+}
+
+wallpaper="$test_tmp/images/Sky View.WEBP"
+printf 'wallpaper fixture\n' >"$wallpaper"
+ln -s "$wallpaper" "$test_tmp/current-wallpaper"
+: >"$matugen_calls"
+: >"$package_calls"
+: >"$theme_calls"
+
+OMARCHY_TEST_MATUGEN_MISSING=true run_theme "$test_tmp/current-wallpaper" ||
+  fail "a wallpaper theme is generated" "$(cat "$test_tmp/stderr")"
+
+theme_path="$test_home/.config/omarchy/themes/wallpaper-sky-view"
+[[ $(cat "$test_tmp/stdout") == "wallpaper-sky-view" ]] ||
+  fail "the generated theme name is printed" "$(cat "$test_tmp/stdout")"
+[[ -f $theme_path/backgrounds/wallpaper.webp ]] ||
+  fail "the resolved wallpaper is copied with a supported extension"
+cmp -s "$wallpaper" "$theme_path/backgrounds/wallpaper.webp" ||
+  fail "the generated theme owns a byte-for-byte copy of the wallpaper"
+grep -Fxq "matugen" "$package_calls" ||
+  fail "matugen is installed on demand" "$(cat "$package_calls")"
+grep -Fxq "$ROOT/default/omarchy/matugen-theme.toml" "$matugen_calls" ||
+  fail "palette generation uses Omarchy's isolated Matugen config" "$(cat "$matugen_calls")"
+grep -Fxq "$(realpath -e -- "$wallpaper")" "$matugen_calls" ||
+  fail "Matugen receives the resolved image path so smart mode can inspect its extension" "$(cat "$matugen_calls")"
+grep -Fxq "smart" "$matugen_calls" ||
+  fail "wallpaper themes use smart mode by default" "$(cat "$matugen_calls")"
+
+colors_file="$theme_path/colors.toml"
+expected_keys=(
+  accent selection muted
+  background dark_background darker_background lighter_background
+  foreground dark_foreground light_foreground bright_foreground
+  red yellow orange green cyan blue magenta brown
+  bright_red bright_yellow bright_green bright_cyan bright_blue bright_magenta
+)
+
+grep -Fxq 'mode = "dark"' "$colors_file" ||
+  fail "smart mode records Matugen's chosen mode" "$(cat "$colors_file")"
+for key in "${expected_keys[@]}"; do
+  grep -Eq "^${key} = \"#[0-9a-f]{6}\"$" "$colors_file" ||
+    fail "the generated palette includes $key as a valid hex color" "$(cat "$colors_file")"
+done
+grep -Fxq 'dark_background = "#111111"' "$colors_file" ||
+  fail "dark themes use Matugen's lowest surface for dark_background" "$(cat "$colors_file")"
+grep -Fxq 'darker_background = "#000000"' "$colors_file" ||
+  fail "dark themes use Matugen's shadow for darker_background" "$(cat "$colors_file")"
+grep -Fxq 'bright_red = "#ffaaaa"' "$colors_file" ||
+  fail "dark themes use the brighter custom-color container text" "$(cat "$colors_file")"
+
+HOME="$test_home" OMARCHY_PATH="$ROOT" "$BASH" "$ROOT/bin/omarchy-theme-color" --file "$colors_file" --all >/dev/null ||
+  fail "the generated colors.toml is accepted by the shared theme resolver"
+
+pass "a symlinked wallpaper generates a schema-complete standalone theme"
+
+printf 'keep me\n' >"$theme_path/canary"
+: >"$matugen_calls"
+if run_theme "$wallpaper"; then
+  fail "an existing theme requires --force"
+fi
+[[ $(cat "$theme_path/canary") == "keep me" ]] ||
+  fail "refusing an overwrite leaves the existing theme untouched"
+[[ ! -s $matugen_calls ]] ||
+  fail "an existing theme is refused before palette generation" "$(cat "$matugen_calls")"
+
+pass "existing themes are protected by default"
+
+aurora_path="$test_home/.config/omarchy/themes/aurora"
+mkdir -p "$aurora_path"
+printf 'old theme\n' >"$aurora_path/canary"
+: >"$matugen_calls"
+: >"$theme_calls"
+run_theme "$wallpaper" --name Aurora --mode light --force --apply ||
+  fail "a named light theme can replace and apply an existing theme" "$(cat "$test_tmp/stderr")"
+
+[[ $(cat "$test_tmp/stdout") == "aurora" ]] ||
+  fail "explicit theme names are normalized and printed" "$(cat "$test_tmp/stdout")"
+[[ ! -e $aurora_path/canary ]] ||
+  fail "--force replaces the previous theme only after generation"
+grep -Fxq "aurora" "$theme_calls" ||
+  fail "--apply sends the generated theme through the normal setter" "$(cat "$theme_calls")"
+grep -Fxq 'mode = "light"' "$aurora_path/colors.toml" ||
+  fail "an explicit light mode reaches colors.toml" "$(cat "$aurora_path/colors.toml")"
+grep -Fxq 'dark_background = "#eeeeee"' "$aurora_path/colors.toml" ||
+  fail "light themes use a darker surface container" "$(cat "$aurora_path/colors.toml")"
+grep -Fxq 'darker_background = "#dddddd"' "$aurora_path/colors.toml" ||
+  fail "light themes use the highest surface container for the darker step" "$(cat "$aurora_path/colors.toml")"
+grep -Fxq 'bright_red = "#aa0000"' "$aurora_path/colors.toml" ||
+  fail "light themes keep readable base colors for bright ANSI slots" "$(cat "$aurora_path/colors.toml")"
+
+pass "mode, naming, replacement, and optional application are explicit"
+
+safe_path="$test_home/.config/omarchy/themes/safe"
+mkdir -p "$safe_path"
+printf 'original\n' >"$safe_path/colors.toml"
+printf 'still safe\n' >"$safe_path/canary"
+
+if OMARCHY_TEST_MATUGEN_FAIL=true run_theme "$wallpaper" --name safe --force; then
+  fail "a failed palette extraction fails the command"
+fi
+[[ $(cat "$safe_path/colors.toml") == "original" ]] ||
+  fail "a generation failure preserves the existing palette"
+[[ $(cat "$safe_path/canary") == "still safe" ]] ||
+  fail "a generation failure preserves the entire existing theme"
+if find "$test_home/.config/omarchy/themes" -maxdepth 1 -name '.safe.*' -print -quit | grep -q .; then
+  fail "a generation failure cleans its temporary theme"
+fi
+
+pass "failed generation is transactional even with --force"
+
+: >"$matugen_calls"
+printf 'not an image\n' >"$test_tmp/images/readme.txt"
+for invalid_args in \
+  "$wallpaper|--mode|dusk" \
+  "$wallpaper|--name|../escape" \
+  "$test_tmp/images/readme.txt"; do
+  IFS='|' read -r -a args <<<"$invalid_args"
+  if run_theme "${args[@]}"; then
+    fail "invalid wallpaper arguments are rejected: $invalid_args"
+  fi
+done
+[[ ! -s $matugen_calls ]] ||
+  fail "invalid input is rejected before Matugen runs" "$(cat "$matugen_calls")"
+
+pass "invalid modes, names, and image types are rejected before generation"


### PR DESCRIPTION
## Summary

- add omarchy theme from-wallpaper with smart, dark, and light palette modes
- generate a schema-complete colors.toml from contrast-aware Material roles and wallpaper-harmonized ANSI colors
- copy the wallpaper into a normal user theme and optionally apply it through the existing theme pipeline
- install Matugen only on first use, protect existing themes behind --force, and replace them transactionally
- document the command and palette mapping

## Verification

- focused theme-from-wallpaper shell test passes
- full test/cli passes
- test/shell: 218/222 files pass; three packaging checks require a separate omarchy-pkgs checkout, and the unrelated SSH retry timing test passed when rerun alone
- Matugen 4.2.0 integration tested with dark and near-white images; smart mode selected dark and light respectively
- generated dark theme applied in a live Omarchy VM; desktop, bar, notifications, menu, and wallpaper were visually checked before restoring the original state

Closes #8745