### PR TITLE
Count omp and pi profile sessions in the agent usage collectors

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -337,11 +337,27 @@ def today_prompts_from_history(claude_dir: Path) -> tuple[int, int]:
 # provider, model, and token usage on every assistant message.
 
 
+# `omp --profile=<name>` (and pi's equivalent) relocates the whole agent tree
+# under <base>/profiles/<name>/, so a subscription driven entirely through a
+# profile leaves the default root empty and its usage uncounted. Sessions are
+# keyed by file path, so a profile adds sessions rather than double-counting
+# the default root.
+def pi_session_roots() -> list[Path]:
+  roots: list[Path] = []
+  for base in (Path.home() / ".pi", Path.home() / ".omp"):
+    roots.append(base / "agent" / "sessions")
+    profiles = base / "profiles"
+    try:
+      # Sorted so the scan order does not depend on directory order.
+      roots.extend(sorted(child / "agent" / "sessions" for child in profiles.iterdir() if child.is_dir()))
+    except OSError:
+      # No profiles directory, or it is unreadable: the default root stands.
+      pass
+  return roots
+
+
 def scan_pi_usage(max_age_seconds: float) -> dict[str, Any] | None:
-  roots = [
-    Path.home() / ".pi" / "agent" / "sessions",
-    Path.home() / ".omp" / "agent" / "sessions",
-  ]
+  roots = pi_session_roots()
   cache_file = cache_root() / "claude-pi-sessions.json"
   cached = read_fresh_json(cache_file, max_age_seconds)
   if cached is not None:

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -135,11 +135,27 @@ def add_usage(day, session_key, model, input_tokens, output_tokens, cache_read, 
     today_tokens_by_model[model] = today_tokens_by_model.get(model, 0) + total
 
 
+# `omp --profile=<name>` (and pi's equivalent) relocates the whole agent tree
+# under <base>/profiles/<name>/, so a subscription driven entirely through a
+# profile leaves the default root empty and its usage uncounted. Each root is
+# scanned separately and sessions are keyed by path, so a profile adds
+# sessions rather than double-counting the default one.
+def pi_session_roots():
+  roots = []
+  for base in (Path.home() / ".pi", Path.home() / ".omp"):
+    roots.append(base / "agent" / "sessions")
+    profiles = base / "profiles"
+    try:
+      # Sorted so the scan order does not depend on directory order.
+      roots.extend(sorted(child / "agent" / "sessions" for child in profiles.iterdir() if child.is_dir()))
+    except OSError:
+      # No profiles directory, or it is unreadable: the default root stands.
+      pass
+  return roots
+
+
 def scan_pi_sessions():
-  roots = [
-    Path.home() / ".pi" / "agent" / "sessions",
-    Path.home() / ".omp" / "agent" / "sessions",
-  ]
+  roots = pi_session_roots()
   rg = find_command("rg") or "rg"
   for root in roots:
     if not root.exists():

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -107,7 +107,8 @@ pass "Claude collector ignores prefix-colliding providers, user messages, and ma
 # Claude Code transcripts. Their compatible JSONL sessions must be included.
 PI_HOME=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME" "$HISTORY_HOME" "$OPENCODE_HOME" "$PI_HOME"' EXIT
-mkdir -p "$PI_HOME/.pi/agent/sessions/project" "$PI_HOME/.omp/agent/sessions/project"
+mkdir -p "$PI_HOME/.pi/agent/sessions/project" "$PI_HOME/.omp/agent/sessions/project" \
+  "$PI_HOME/.omp/profiles/work/agent/sessions/project"
 
 cat >"$PI_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF
 {"type":"message","id":"pi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"anthropic","api":"anthropic-messages","model":"claude-pi","usage":{"input":10,"output":4,"cacheRead":3,"cacheWrite":2,"totalTokens":19}}}
@@ -117,15 +118,20 @@ EOF
 cat >"$PI_HOME/.omp/agent/sessions/project/omp.jsonl" <<EOF
 { "type": "message", "id": "omp-1", "timestamp": "$timestamp", "message": { "role": "assistant", "provider": "anthropic", "model": "claude-omp", "usage": { "input": 20, "output": 5, "cacheRead": 4, "cacheWrite": 1, "totalTokens": 30 } } }
 EOF
+# `omp --profile=<name>` moves the whole agent tree under profiles/<name>/, so a
+# subscription spent entirely through a profile leaves the default root empty.
+cat >"$PI_HOME/.omp/profiles/work/agent/sessions/project/omp-profile.jsonl" <<EOF
+{"type":"message","id":"omp-profile-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"anthropic","model":"claude-omp-profile","usage":{"input":7,"output":3,"cacheRead":2,"cacheWrite":1,"totalTokens":13}}}
+EOF
 
 result=$(HOME="$PI_HOME" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
-[[ $(jq -r '.todayTotalTokens' <<<"$result") == "49" ]] ||
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "62" ]] ||
   fail "Claude collector counts usage from pi and omp sessions" "$result"
-[[ $(jq -c '.modelUsage' <<<"$result") == '{"claude-omp":{"cacheCreationInputTokens":1,"cacheReadInputTokens":4,"inputTokens":20,"outputTokens":5},"claude-pi":{"cacheCreationInputTokens":2,"cacheReadInputTokens":3,"inputTokens":10,"outputTokens":4}}' ]] ||
+[[ $(jq -c '.modelUsage' <<<"$result") == '{"claude-omp":{"cacheCreationInputTokens":1,"cacheReadInputTokens":4,"inputTokens":20,"outputTokens":5},"claude-omp-profile":{"cacheCreationInputTokens":1,"cacheReadInputTokens":2,"inputTokens":7,"outputTokens":3},"claude-pi":{"cacheCreationInputTokens":2,"cacheReadInputTokens":3,"inputTokens":10,"outputTokens":4}}' ]] ||
   fail "Claude collector filters pi and omp sessions to Anthropic providers" "$result"
-pass "Claude collector counts pi and omp subscription usage"
+pass "Claude collector counts pi and omp subscription usage, profiles included"
 
 # Collectors overlap in practice: the update command backgrounds one per agent
 # while the panel refreshes on its own. Two writers aiming at one cache file

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -72,7 +72,8 @@ pass "Codex collector identifies itself with an empty limits list"
 # Codex sessions. Their compatible JSONL transcripts must be included.
 PI_HOME=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME" "$PI_HOME"' EXIT
-mkdir -p "$PI_HOME/bin" "$PI_HOME/.pi/agent/sessions/project" "$PI_HOME/.omp/agent/sessions/project"
+mkdir -p "$PI_HOME/bin" "$PI_HOME/.pi/agent/sessions/project" "$PI_HOME/.omp/agent/sessions/project" \
+  "$PI_HOME/.omp/profiles/codex/agent/sessions/project"
 cp "$TEST_HOME/bin/codex" "$PI_HOME/bin/codex"
 cat >"$PI_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF
 {"type":"message","id":"pi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"openai-codex","api":"openai-codex-responses","model":"gpt-pi","usage":{"input":10,"output":4,"cacheRead":3,"cacheWrite":2,"totalTokens":19}}}
@@ -81,15 +82,20 @@ cat >"$PI_HOME/.omp/agent/sessions/project/omp.jsonl" <<EOF
 { "type": "message", "id": "omp-1", "timestamp": "$timestamp", "message": { "role": "assistant", "provider": "openai-codex", "model": "gpt-omp", "usage": { "input": 20, "output": 5, "cacheRead": 4, "cacheWrite": 1, "totalTokens": 30 } } }
 {"type":"message","id":"other-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"anthropic","model":"claude-test","usage":{"input":999,"output":999}}}
 EOF
+# `omp --profile=<name>` moves the whole agent tree under profiles/<name>/, so a
+# subscription spent entirely through a profile leaves the default root empty.
+cat >"$PI_HOME/.omp/profiles/codex/agent/sessions/project/omp-profile.jsonl" <<EOF
+{"type":"message","id":"omp-profile-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"openai-codex","model":"gpt-omp-profile","usage":{"input":7,"output":3,"cacheRead":2,"cacheWrite":1,"totalTokens":13}}}
+EOF
 
 result=$(HOME="$PI_HOME" CODEX_HOME="$PI_HOME/.codex" XDG_DATA_HOME="$PI_HOME/.local/share" \
   PATH="$PI_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
 
-[[ $(jq -r '.todayTotalTokens' <<<"$result") == "49" ]] ||
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "62" ]] ||
   fail "Codex collector counts usage from pi and omp sessions" "$result"
-[[ $(jq -c '.modelUsage' <<<"$result") == '{"gpt-pi":{"inputTokens":10,"outputTokens":4,"cacheReadInputTokens":3,"cacheCreationInputTokens":2},"gpt-omp":{"inputTokens":20,"outputTokens":5,"cacheReadInputTokens":4,"cacheCreationInputTokens":1}}' ]] ||
+[[ $(jq -c '.modelUsage' <<<"$result") == '{"gpt-pi":{"inputTokens":10,"outputTokens":4,"cacheReadInputTokens":3,"cacheCreationInputTokens":2},"gpt-omp":{"inputTokens":20,"outputTokens":5,"cacheReadInputTokens":4,"cacheCreationInputTokens":1},"gpt-omp-profile":{"inputTokens":7,"outputTokens":3,"cacheReadInputTokens":2,"cacheCreationInputTokens":1}}' ]] ||
   fail "Codex collector filters pi and omp sessions to Codex providers" "$result"
-pass "Codex collector counts pi and omp subscription usage"
+pass "Codex collector counts pi and omp subscription usage, profiles included"
 
 # A subscription burned entirely through opencode has no native session files;
 # usage must come from opencode's message database, filtered to OpenAI.


### PR DESCRIPTION
## The problem

`omp --profile=<name>` (and pi's equivalent) relocates the whole agent tree under `<base>/profiles/<name>/`. The Claude and Codex collectors only ever scanned `<base>/agent/sessions`:

```python
roots = [
  Path.home() / ".pi" / "agent" / "sessions",
  Path.home() / ".omp" / "agent" / "sessions",
]
```

So a subscription driven entirely through a profile is invisible to the agents panel — no tokens by day, no tokens by model, no prompt or session counts. On my machine `omp --profile=codex` had 916 session files with 125,638 `openai-codex` assistant messages under `~/.omp/profiles/codex/agent/sessions`, none of it counted.

What made it hard to spot is that the Codex tab was not empty: it was showing the *opencode* fallback numbers only, which quietly stop the day you switch away from opencode.

## The fix

`pi_session_roots()` discovers the profile roots alongside the default one, in both collectors. Sessions are already keyed by file path, so a profile adds sessions instead of double-counting the default root, and a missing or unreadable `profiles/` directory leaves today's behavior untouched.

The helper is duplicated across the two scripts, matching how `cache_root()` and `read_fresh_json()` are already duplicated there.

## Verification

Real data on an Arch box running omarchy 4.0.2, `omarchy-agent-usage-codex --force`, before → after:

| | before | after |
|---|---|---|
| `totalPrompts` | 71,833 | 134,265 |
| `totalSessions` | 1,305 | 2,221 |
| `todayPrompts` | 0 | 1,505 |
| `todayTotalTokens` | 0 | 114,008,332 |

The last two days of `recentDays` went from `0` / `0` to real numbers. The Claude collector picked up the profile's Anthropic subagent traffic the same way (10 more prompts today, in my case).

Both scanner tests grow a profile session and assert it lands in `todayTotalTokens` and `modelUsage`. `agent-usage-codex-scanner-test.sh`, `agent-usage-claude-scanner-test.sh`, `agent-usage-claude-limits-test.sh`, `agent-usage-fireworks-scanner-test.sh`, `agent-usage-update-test.sh` and `agents-rename-migration-test.sh` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zFbJcDEEpV5BAmsH6kAB3