### PR TITLE
Detect fingerprint enrollment by the enrolled entries, not the word "finger"

### DIFF
--- a/bin/omarchy-apply-lock
+++ b/bin/omarchy-apply-lock
@@ -34,7 +34,7 @@ auth       required                    pam_faillock.so authsucc
 account    include                     system-local-login
 EOF
 
-if omarchy-cmd-present fprintd-list && fprintd-list "$target_user" 2>/dev/null | grep -qi finger; then
+if omarchy-hw-fingerprint-enrolled "$target_user"; then
   echo "Configuring lock screen fingerprint authentication..."
   as_root tee /etc/pam.d/omarchy-lock-fingerprint >/dev/null <<'EOF'
 #%PAM-1.0

--- a/bin/omarchy-hw-fingerprint-enrolled
+++ b/bin/omarchy-hw-fingerprint-enrolled
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# omarchy:summary=Returns true when a user has fingerprints enrolled
+# omarchy:hidden=true
+
+user=${1:-$USER}
+
+# fprintd arrives with the fingerprint setup, so a machine that never ran it has
+# nothing to ask.
+omarchy-cmd-present fprintd-list || exit 1
+
+# fprintd-list states an empty enrollment in prose — "User kalle has no fingers
+# enrolled for Goodix MOC Fingerprint Sensor." — so matching the word "finger"
+# reads as enrolled either way. Enrolled fingers are listed one per line as
+# " - #0: right-index-finger"; that shape is what separates the two.
+fprintd-list "$user" 2>/dev/null | grep -qE '^[[:space:]]*-[[:space:]]*#[0-9]+:'

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -377,7 +377,7 @@ Item {
 
   Process {
     id: fingerprintCheckProc
-    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && command -v fprintd-list >/dev/null 2>&1 && fprintd-list \"$USER\" 2>/dev/null | grep -qi finger; then echo yes; else echo no; fi"]
+    command: ["bash", "-c", "if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && omarchy-hw-fingerprint-enrolled; then echo yes; else echo no; fi"]
     stdout: StdioCollector { id: fingerprintCheckStdout; waitForEnd: true }
     onExited: {
       root.fingerprintConfigured = String(fingerprintCheckStdout.text || "").trim() === "yes"

--- a/test/shell.d/hw-fingerprint-enrolled-test.sh
+++ b/test/shell.d/hw-fingerprint-enrolled-test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+
+# The fixture prints what fprintd-list prints, format strings and all:
+# " - #%d: %s" per enrolled finger, and "User %s has no fingers enrolled for
+# %s." when there are none.
+stub_fprintd_list() {
+  cat >"$tmp_dir/bin/fprintd-list"
+  chmod +x "$tmp_dir/bin/fprintd-list"
+}
+
+drop_fprintd_list() {
+  rm -f "$tmp_dir/bin/fprintd-list"
+}
+
+fingerprint_enrolled() {
+  PATH="$tmp_dir/bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-hw-fingerprint-enrolled" "$@"
+}
+
+assert_enrolled() {
+  local description="$1"
+
+  fingerprint_enrolled alice || fail "$description"
+  pass "$description"
+}
+
+assert_not_enrolled() {
+  local description="$1"
+
+  if fingerprint_enrolled alice; then
+    fail "$description"
+  fi
+  pass "$description"
+}
+
+stub_fprintd_list <<'STUB'
+#!/bin/bash
+cat <<'OUT'
+found 1 devices
+Device at /net/reactivated/Fprint/Device/0
+Using device /net/reactivated/Fprint/Device/0
+Fingerprints for user alice on Goodix MOC Fingerprint Sensor (press):
+ - #0: right-index-finger
+OUT
+STUB
+assert_enrolled "a user with an enrolled finger reads as enrolled"
+
+# The reason this command exists: the empty-enrollment message names fingers
+# too, so any match on the word alone reports the opposite of the truth.
+stub_fprintd_list <<'STUB'
+#!/bin/bash
+cat <<'OUT'
+found 1 devices
+Device at /net/reactivated/Fprint/Device/0
+Using device /net/reactivated/Fprint/Device/0
+User alice has no fingers enrolled for Goodix MOC Fingerprint Sensor.
+OUT
+STUB
+assert_not_enrolled "an empty enrollment does not read as enrolled"
+
+stub_fprintd_list <<'STUB'
+#!/bin/bash
+echo "found 0 devices" >&2
+exit 1
+STUB
+assert_not_enrolled "a machine with no reader does not read as enrolled"
+
+drop_fprintd_list
+assert_not_enrolled "a machine without fprintd does not read as enrolled"


### PR DESCRIPTION
On a machine with a fingerprint reader and **no fingers enrolled**, the lock screen forks four failing PAM sessions per second for as long as it is up. On mine that was 26,078 journal lines in three days:

```
omarchy-shell[...]: quickshell.service.pam.subprocess: Starting pam session for user "kalle" with config "omarchy-lock-fingerprint" in dir "/etc/pam.d"
omarchy-shell[...]: quickshell.service.pam.subprocess: Error while authenticating: "Authentication service cannot retrieve authentication info" (code 9)
```

## Cause

`fprintd-list` states an empty enrollment in prose. Its two format strings:

```
Fingerprints for user %s on %s (%s):
 - #%d: %s
User %s has no fingers enrolled for %s.
```

Both existing callers matched with `grep -qi finger`, which the *empty* message satisfies just as well as the populated one:

- `bin/omarchy-apply-lock:37`
- `shell/plugins/lock/Service.qml:380`

Run the gate verbatim on a machine with nothing enrolled and it reports enrolled:

```console
$ fprintd-list "$USER"
found 1 devices
Device at /net/reactivated/Fprint/Device/0
Using device /net/reactivated/Fprint/Device/0
User kalle has no fingers enrolled for Goodix MOC Fingerprint Sensor.

$ if [[ -f /etc/pam.d/omarchy-lock-fingerprint ]] && command -v fprintd-list >/dev/null 2>&1 \
    && fprintd-list "$USER" 2>/dev/null | grep -qi finger; then echo yes; else echo no; fi
yes
```

The two failures compound. `omarchy-apply-lock` writes `/etc/pam.d/omarchy-lock-fingerprint` on a machine with nothing enrolled, which is the file the lock gate then tests for. The gate sets `fingerprintConfigured`, `startFingerprint()` runs `pam_fprintd`, PAM returns `PAM_AUTHINFO_UNAVAIL` immediately because nothing is enrolled, and `handleFingerprintFinished` re-arms `fingerprintRetryTimer` — `interval: 250`, no backoff, no attempt cap:

```qml
} else if (fingerprintConfigured) {
  fingerprintRetryTimer.restart()
}
```

Nothing breaks the loop, because the condition it retries on never changes.

## Fix

Match the per-finger listing (` - #0: right-index-finger`) rather than the word, behind a shared `omarchy-hw-fingerprint-enrolled` so both callers agree on what "enrolled" means. Users who do have fingers enrolled see no change.

## Testing

New `test/shell.d/hw-fingerprint-enrolled-test.sh` stubs `fprintd-list` with both real output shapes and covers the reader-less and fprintd-less paths. The empty-enrollment case fails against the old predicate and passes against the new one.

`./test/all` passes apart from three pre-existing failures that need a sibling `omarchy-pkgs` checkout (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`), which fail identically on a clean `quattro` here.

Omarchy 4.0.2-1, Goodix MOC Fingerprint Sensor, fprintd 1.94.5-2.