### PR TITLE
Fix per-app stream sliders ignoring pointer input

### DIFF
--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -1233,12 +1233,8 @@ Panel {
       }
     }
 
-    MouseArea {
-      anchors.fill: parent
-      hoverEnabled: true
-      acceptedButtons: Qt.NoButton
-      propagateComposedEvents: true
-      onContainsMouseChanged: if (containsMouse) {
+    HoverHandler {
+      onHoveredChanged: if (hovered) {
         root.cursorActive = true
         root.focusSection = "streams"
         root.selectedIndex = streamRow.rowIndex


### PR DESCRIPTION
Fixes #9538

## Problem

The per-application volume sliders under **Audio → Sources** don't respond to mouse presses or drags. `StreamRow` tracks hover (for the keyboard-cursor `focusSection`/`selectedIndex` state) with a full-row `MouseArea` declared *after* the stream's inline `PanelSlider`, so it stacks above the slider and keeps the slider's own `MouseArea` from receiving press/drag interaction.

## Fix

Replace the row-level `MouseArea` with a `HoverHandler` — the exact pattern the master output slider row and the input slider row in the same file already use, for the same reason. `HoverHandler` keeps the hover-driven cursor tracking without intercepting pointer events destined for the slider.

The device rows (`SinkRow`/`SourceRow`) keep their `MouseArea`s untouched: those are whole-row click targets (select default device) with no inner controls to cover.

## Verification

- The issue reporter verified this exact change on affected hardware via a cloned `omarchy.audio` plugin with hot reload: previously-dead Zen Browser and Wine stream sliders became interactive and correctly changed PipeWire stream volumes (details in #9538).
- `test/shell.d/audio-test.sh` and `test/shell.d/qml-text-format-test.sh` pass; the `qml-text-format-scan.py` tree scan is clean.
- I don't have a running Omarchy shell in this environment, so I could not re-verify visually myself; the change is mechanically identical to the HoverHandler blocks at the master output/input slider rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTqr6ZjXfNthXT719ag7Qc