### PR TITLE
Add sunset-based night light scheduling

### DIFF
--- a/bin/omarchy-menu-timezone
+++ b/bin/omarchy-menu-timezone
@@ -9,4 +9,5 @@ set -e
 timezone=$(timedatectl list-timezones | omarchy-menu-select "Set timezone" -- --width 520 --maxheight 520) || exit 1
 sudo timedatectl set-timezone "$timezone"
 omarchy-shell -q omarchy.clock refresh
+omarchy-shell -q nightlight refresh
 omarchy-notification-send "Timezone is now set to $timezone"

--- a/bin/omarchy-nightlight-schedule
+++ b/bin/omarchy-nightlight-schedule
@@ -1,0 +1,306 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Manage the automatic sunrise and sunset nightlight schedule
+# omarchy:hidden=true
+
+import argparse
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+STATE_PATH = Path(
+  os.environ.get(
+    "OMARCHY_NIGHTLIGHT_STATE",
+    Path.home() / ".local/state/omarchy/settings/nightlight.json",
+  )
+)
+ZONEINFO_DIR = Path(os.environ.get("OMARCHY_ZONEINFO_DIR", "/usr/share/zoneinfo"))
+SUN_ALTITUDE = -0.833
+
+
+def schedule_enabled() -> bool:
+  try:
+    state = json.loads(STATE_PATH.read_text())
+    return isinstance(state, dict) and state.get("mode") == "solar"
+  except (FileNotFoundError, json.JSONDecodeError, OSError):
+    return False
+
+
+def set_schedule_enabled(enabled: bool) -> None:
+  STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+  contents = json.dumps({"mode": "solar" if enabled else "manual"}) + "\n"
+  with tempfile.NamedTemporaryFile(
+    mode="w", dir=STATE_PATH.parent, delete=False
+  ) as state_file:
+    state_file.write(contents)
+    temporary_path = Path(state_file.name)
+  temporary_path.replace(STATE_PATH)
+
+
+def selected_timezone() -> str:
+  override = os.environ.get("OMARCHY_NIGHTLIGHT_TIMEZONE")
+  if override:
+    return override
+
+  result = subprocess.run(
+    ["timedatectl", "show", "-p", "Timezone", "--value"],
+    check=False,
+    capture_output=True,
+    text=True,
+  )
+  if result.returncode == 0 and result.stdout.strip():
+    return result.stdout.strip()
+
+  localtime = Path("/etc/localtime")
+  try:
+    resolved = localtime.resolve()
+    return str(resolved.relative_to(ZONEINFO_DIR))
+  except (OSError, ValueError):
+    raise RuntimeError("Unable to determine the selected timezone")
+
+
+def canonical_timezone(timezone_name: str) -> str:
+  timezone_path = ZONEINFO_DIR / timezone_name
+  try:
+    return str(timezone_path.resolve().relative_to(ZONEINFO_DIR))
+  except (OSError, ValueError):
+    return timezone_name
+
+
+def compact_coordinate(value: str, degree_digits: int) -> float:
+  sign = -1 if value[0] == "-" else 1
+  digits = value[1:]
+  degrees = int(digits[:degree_digits])
+  minutes = int(digits[degree_digits : degree_digits + 2])
+  seconds = int(digits[degree_digits + 2 :]) if len(digits) > degree_digits + 2 else 0
+  return sign * (degrees + minutes / 60 + seconds / 3600)
+
+
+def coordinates_for_timezone(timezone_name: str) -> tuple[float, float]:
+  canonical_name = canonical_timezone(timezone_name)
+  for table_name in ("zone1970.tab", "zone.tab"):
+    table_path = ZONEINFO_DIR / table_name
+    try:
+      lines = table_path.read_text().splitlines()
+    except OSError:
+      continue
+
+    for line in lines:
+      if not line or line.startswith("#"):
+        continue
+      fields = line.split("\t")
+      if len(fields) < 3 or fields[2] != canonical_name:
+        continue
+      match = re.fullmatch(r"([+-]\d+)([+-]\d+)", fields[1])
+      if not match:
+        break
+      return compact_coordinate(match.group(1), 2), compact_coordinate(match.group(2), 3)
+
+  if canonical_name in ("UTC", "Etc/UTC", "Etc/GMT"):
+    return 51.4779, 0.0
+
+  raise RuntimeError(f"No location data is available for timezone {timezone_name}")
+
+
+def julian_day(day: date) -> float:
+  year = day.year
+  month = day.month
+  if month <= 2:
+    year -= 1
+    month += 12
+  century = year // 100
+  correction = 2 - century + century // 4
+  return (
+    math.floor(365.25 * (year + 4716))
+    + math.floor(30.6001 * (month + 1))
+    + day.day
+    + correction
+    - 1524.5
+  )
+
+
+def solar_parameters(julian_centuries: float) -> tuple[float, float]:
+  geom_long = (
+    280.46646
+    + julian_centuries * (36000.76983 + julian_centuries * 0.0003032)
+  ) % 360
+  geom_anomaly = 357.52911 + julian_centuries * (
+    35999.05029 - 0.0001537 * julian_centuries
+  )
+  eccentricity = 0.016708634 - julian_centuries * (
+    0.000042037 + 0.0000001267 * julian_centuries
+  )
+  anomaly_radians = math.radians(geom_anomaly)
+  center = (
+    math.sin(anomaly_radians)
+    * (1.914602 - julian_centuries * (0.004817 + 0.000014 * julian_centuries))
+    + math.sin(2 * anomaly_radians) * (0.019993 - 0.000101 * julian_centuries)
+    + math.sin(3 * anomaly_radians) * 0.000289
+  )
+  true_long = geom_long + center
+  omega = 125.04 - 1934.136 * julian_centuries
+  apparent_long = true_long - 0.00569 - 0.00478 * math.sin(math.radians(omega))
+  mean_obliquity = 23 + (
+    26
+    + (
+      21.448
+      - julian_centuries
+      * (46.815 + julian_centuries * (0.00059 - julian_centuries * 0.001813))
+    )
+    / 60
+  ) / 60
+  obliquity = mean_obliquity + 0.00256 * math.cos(math.radians(omega))
+  declination = math.degrees(
+    math.asin(
+      math.sin(math.radians(obliquity))
+      * math.sin(math.radians(apparent_long))
+    )
+  )
+  y = math.tan(math.radians(obliquity) / 2) ** 2
+  equation = 4 * math.degrees(
+    y * math.sin(2 * math.radians(geom_long))
+    - 2 * eccentricity * math.sin(anomaly_radians)
+    + 4
+    * eccentricity
+    * y
+    * math.sin(anomaly_radians)
+    * math.cos(2 * math.radians(geom_long))
+    - 0.5 * y * y * math.sin(4 * math.radians(geom_long))
+    - 1.25 * eccentricity * eccentricity * math.sin(2 * anomaly_radians)
+  )
+  return equation, declination
+
+
+def event_utc(day: date, latitude: float, longitude: float, sunrise: bool) -> datetime | None:
+  day_julian = julian_day(day)
+  centuries = (day_julian - 2451545.0) / 36525
+  equation, declination = solar_parameters(centuries)
+  solar_noon_minutes = 720 - 4 * longitude - equation
+
+  centuries = (day_julian + solar_noon_minutes / 1440 - 2451545.0) / 36525
+  equation, declination = solar_parameters(centuries)
+  latitude_radians = math.radians(latitude)
+  declination_radians = math.radians(declination)
+  hour_angle_cosine = (
+    math.cos(math.radians(90.833))
+    / (math.cos(latitude_radians) * math.cos(declination_radians))
+    - math.tan(latitude_radians) * math.tan(declination_radians)
+  )
+  if hour_angle_cosine < -1 or hour_angle_cosine > 1:
+    return None
+
+  hour_angle = math.degrees(math.acos(hour_angle_cosine))
+  event_minutes = 720 - 4 * (longitude + (hour_angle if sunrise else -hour_angle)) - equation
+  return datetime.combine(day, time.min, timezone.utc) + timedelta(minutes=event_minutes)
+
+
+def is_night(now: datetime, latitude: float, longitude: float) -> bool:
+  utc_now = now.astimezone(timezone.utc)
+  midnight = datetime.combine(utc_now.date(), time.min, timezone.utc)
+  julian = julian_day(utc_now.date()) + (utc_now - midnight).total_seconds() / 86400
+  equation, declination = solar_parameters((julian - 2451545.0) / 36525)
+  utc_minutes = (
+    utc_now.hour * 60 + utc_now.minute + utc_now.second / 60 + utc_now.microsecond / 60000000
+  )
+  true_solar_minutes = (utc_minutes + equation + 4 * longitude) % 1440
+  hour_angle = true_solar_minutes / 4 - 180
+  latitude_radians = math.radians(latitude)
+  declination_radians = math.radians(declination)
+  elevation = math.degrees(
+    math.asin(
+      math.sin(latitude_radians) * math.sin(declination_radians)
+      + math.cos(latitude_radians)
+      * math.cos(declination_radians)
+      * math.cos(math.radians(hour_angle))
+    )
+  )
+  return elevation <= SUN_ALTITUDE
+
+
+def evaluate(at: str | None = None) -> dict:
+  timezone_name = selected_timezone()
+  try:
+    selected_zone = ZoneInfo(timezone_name)
+  except ZoneInfoNotFoundError as error:
+    raise RuntimeError(f"Unknown timezone {timezone_name}") from error
+
+  latitude, longitude = coordinates_for_timezone(timezone_name)
+  if at:
+    now = datetime.fromisoformat(at)
+    now = now.replace(tzinfo=selected_zone) if now.tzinfo is None else now.astimezone(selected_zone)
+  else:
+    now = datetime.now(selected_zone)
+  next_event = None
+  for offset in range(371):
+    event_day = now.date() + timedelta(days=offset)
+    for event_name, sunrise in (("sunrise", True), ("sunset", False)):
+      event = event_utc(event_day, latitude, longitude, sunrise)
+      if event and event > now.astimezone(timezone.utc):
+        candidate = (event, event_name)
+        if next_event is None or candidate[0] < next_event[0]:
+          next_event = candidate
+    if next_event and next_event[0].astimezone(selected_zone).date() <= event_day:
+      break
+
+  if next_event is None:
+    raise RuntimeError(f"Unable to calculate a solar event for timezone {timezone_name}")
+
+  return {
+    "scheduled": schedule_enabled(),
+    "timezone": timezone_name,
+    "latitude": round(latitude, 6),
+    "longitude": round(longitude, 6),
+    "night": is_night(now, latitude, longitude),
+    "nextEvent": next_event[1],
+    "nextEventAt": next_event[0].astimezone(selected_zone).isoformat(timespec="seconds"),
+  }
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("command", choices=("enable", "disable", "toggle", "enabled", "evaluate"))
+  parser.add_argument("--at")
+  args = parser.parse_args()
+
+  if args.command == "enabled":
+    return 0 if schedule_enabled() else 1
+  if args.command == "enable":
+    evaluate(args.at)
+    set_schedule_enabled(True)
+  elif args.command == "disable":
+    set_schedule_enabled(False)
+  elif args.command == "toggle":
+    enabling = not schedule_enabled()
+    if enabling:
+      evaluate(args.at)
+    set_schedule_enabled(enabling)
+
+  if args.command in ("enable", "disable", "toggle"):
+    print("enabled" if schedule_enabled() else "disabled")
+  else:
+    print(json.dumps(evaluate(args.at), separators=(",", ":")))
+  return 0
+
+
+if __name__ == "__main__":
+  try:
+    sys.exit(main())
+  except (OSError, RuntimeError) as error:
+    if len(sys.argv) > 1 and sys.argv[1] == "evaluate":
+      print(
+        json.dumps(
+          {"scheduled": schedule_enabled(), "error": str(error)},
+          separators=(",", ":"),
+        )
+      )
+      sys.exit(0)
+    print(f"Error: {error}", file=sys.stderr)
+    sys.exit(1)

--- a/bin/omarchy-nightlight-schedule
+++ b/bin/omarchy-nightlight-schedule
@@ -182,24 +182,32 @@ def solar_parameters(julian_centuries: float) -> tuple[float, float]:
 def event_utc(day: date, latitude: float, longitude: float, sunrise: bool) -> datetime | None:
   day_julian = julian_day(day)
   centuries = (day_julian - 2451545.0) / 36525
-  equation, declination = solar_parameters(centuries)
+  equation, _ = solar_parameters(centuries)
   solar_noon_minutes = 720 - 4 * longitude - equation
 
   centuries = (day_julian + solar_noon_minutes / 1440 - 2451545.0) / 36525
-  equation, declination = solar_parameters(centuries)
-  latitude_radians = math.radians(latitude)
-  declination_radians = math.radians(declination)
-  hour_angle_cosine = (
-    math.cos(math.radians(90.833))
-    / (math.cos(latitude_radians) * math.cos(declination_radians))
-    - math.tan(latitude_radians) * math.tan(declination_radians)
+  equation, _ = solar_parameters(centuries)
+  noon = datetime.combine(day, time.min, timezone.utc) + timedelta(
+    minutes=720 - 4 * longitude - equation
   )
-  if hour_angle_cosine < -1 or hour_angle_cosine > 1:
+  start = noon - timedelta(hours=12) if sunrise else noon
+  end = noon if sunrise else noon + timedelta(hours=12)
+  lower = math.floor(start.timestamp())
+  upper = math.ceil(end.timestamp())
+  if (
+    is_night(datetime.fromtimestamp(lower, timezone.utc), latitude, longitude) != sunrise
+    or is_night(datetime.fromtimestamp(upper, timezone.utc), latitude, longitude) == sunrise
+  ):
     return None
 
-  hour_angle = math.degrees(math.acos(hour_angle_cosine))
-  event_minutes = 720 - 4 * (longitude + (hour_angle if sunrise else -hour_angle)) - equation
-  return datetime.combine(day, time.min, timezone.utc) + timedelta(minutes=event_minutes)
+  # Find the first whole second in the new state, using the same model as evaluate().
+  while upper - lower > 1:
+    middle = (lower + upper) // 2
+    if is_night(datetime.fromtimestamp(middle, timezone.utc), latitude, longitude) == sunrise:
+      lower = middle
+    else:
+      upper = middle
+  return datetime.fromtimestamp(upper, timezone.utc)
 
 
 def is_night(now: datetime, latitude: float, longitude: float) -> bool:
@@ -238,16 +246,19 @@ def evaluate(at: str | None = None) -> dict:
     now = now.replace(tzinfo=selected_zone) if now.tzinfo is None else now.astimezone(selected_zone)
   else:
     now = datetime.now(selected_zone)
+  # Match the whole-second event boundaries even for subsecond timer wakeups.
+  now = now.astimezone(timezone.utc).replace(microsecond=0)
   next_event = None
-  for offset in range(371):
+  # A solar calculation day can put its events on neighboring UTC dates.
+  for offset in range(-1, 371):
     event_day = now.date() + timedelta(days=offset)
     for event_name, sunrise in (("sunrise", True), ("sunset", False)):
       event = event_utc(event_day, latitude, longitude, sunrise)
-      if event and event > now.astimezone(timezone.utc):
+      if event and event > now:
         candidate = (event, event_name)
         if next_event is None or candidate[0] < next_event[0]:
           next_event = candidate
-    if next_event and next_event[0].astimezone(selected_zone).date() <= event_day:
+    if next_event and next_event[0] < datetime.combine(event_day, time.min, timezone.utc):
       break
 
   if next_event is None:

--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Toggle nightlight screen temperature
-# omarchy:args=[--status]
-# omarchy:examples=omarchy toggle nightlight
+# omarchy:args=[--status|--schedule|--manual]
+# omarchy:examples=omarchy toggle nightlight | omarchy toggle nightlight --schedule
 
 ON_TEMP=4000
 OFF_TEMP=6500
@@ -30,8 +30,42 @@ status_json() {
 }
 
 if [[ ${1:-} == "--status" ]]; then
-  status_json
+  schedule=false
+  omarchy-nightlight-schedule enabled && schedule=true
+  status_json | jq -c --argjson scheduled "$schedule" '. + {scheduled:$scheduled}'
   exit 0
+fi
+
+if [[ ${1:-} == "--schedule" ]]; then
+  schedule_result=$(omarchy-nightlight-schedule toggle) || {
+    omarchy-notification-send "Unable to configure automatic night light"
+    exit 1
+  }
+  if [[ $schedule_result == "enabled" ]]; then
+    timezone=$(timedatectl show -p Timezone --value 2>/dev/null)
+    if [[ -n $timezone ]]; then
+      omarchy-notification-send "Night light will follow sunset and sunrise in $timezone"
+    else
+      omarchy-notification-send "Night light will follow sunset and sunrise in the selected timezone"
+    fi
+  else
+    omarchy-notification-send "Automatic night light disabled"
+  fi
+  omarchy-shell -q nightlight refresh
+  exit 0
+fi
+
+if [[ ${1:-} == "--manual" ]]; then
+  if ! omarchy-nightlight-schedule disable >/dev/null; then
+    omarchy-notification-send "Unable to disable automatic night light"
+    exit 1
+  fi
+  omarchy-shell -q nightlight refresh
+  exit 0
+fi
+
+if ! omarchy-nightlight-schedule disable >/dev/null; then
+  omarchy-notification-send "Unable to disable automatic night light; applying a manual override"
 fi
 
 # Ensure hyprsunset is running

--- a/config/hypr/hyprsunset.conf
+++ b/config/hypr/hyprsunset.conf
@@ -5,9 +5,9 @@ profile {
     identity = true
 }
 
-# To enable auto switch to nightlight, add to your .config/hypr/autostart.lua:
-# o.launch_on_start("hyprsunset")
-# and use the following:
+# `omarchy toggle nightlight --schedule` follows sunset and sunrise for the
+# selected system timezone. For a fixed schedule instead, add
+# o.launch_on_start("hyprsunset") to ~/.config/hypr/autostart.lua and use:
 # profile {
 #     time = 20:00
 #     temperature = 4000

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -92,6 +92,7 @@
   "trigger.toggle.crash-capture": {"icon":"󱚡","label":"Crash Capture","action":"omarchy-toggle-crash-capture"},
   "trigger.toggle.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-toggle-screensaver"},
   "trigger.toggle.nightlight": {"icon":"󰔎","label":"Nightlight","action":"omarchy-toggle-nightlight"},
+  "trigger.toggle.automatic-nightlight": {"icon":"󰖨","label":"Sunset Nightlight","checked":"omarchy-nightlight-schedule enabled","action":"omarchy-toggle-nightlight --schedule"},
   "trigger.toggle.top-bar": {"icon":"󰍜","label":"Menu Bar","action":"omarchy-toggle-bar"},
   "trigger.toggle.battery-percentage": {"icon":"󰁹","label":"Battery Percentage","when":"omarchy-hw-laptop","action":"omarchy-shell omarchy.power togglePercentage"},
   "trigger.toggle.workspace-layout": {"icon":"󱂬","label":"Workspace Layout","action":"omarchy-hyprland-workspace-layout-toggle"},

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -11,6 +11,7 @@ From the terminal, the same switches are `omarchy toggle <thing>`. Run `omarchy 
 | Toggle | Hotkey | Command |
 | ------ | ------ | ------- |
 | Night light | `Super + Ctrl + N` | `omarchy toggle nightlight` |
+| Automatic night light | — | `omarchy toggle nightlight --schedule` |
 | Silence notifications | `Super + Ctrl + ,` | `omarchy toggle notification silencing` |
 | Stay awake (no idle lock) | `Super + Ctrl + I` | `omarchy toggle idle` |
 | Crash capture | — | `omarchy toggle crash-capture` |
@@ -42,6 +43,8 @@ Inactive indicators are hidden. Hover the area around them and they fade in dimm
 ### Night light
 
 `Super + Ctrl + N` warms the screen to 4000K, and hitting it again puts it back to 6500K. It's driven by hyprsunset, which the toggle starts for you if it isn't already running.
+
+Right-click the night light indicator to open its mode panel, where **Daylight**, **Night Light**, and **Sunset** stay in a fixed order as you switch between them. Sunset mode turns night light on at sunset and off at sunrise. You can also choose **Sunset Nightlight** from _Trigger > Toggle_ or run `omarchy toggle nightlight --schedule`. Omarchy uses the representative location for your selected system timezone and follows daylight-saving changes automatically. Selecting a different timezone updates the schedule; using the regular night light toggle returns to manual control.
 
 By default hyprsunset does nothing to your screen at all. `~/.config/hypr/hyprsunset.conf` ships with an identity profile precisely so the display stays untouched until you ask for warmth. If you'd rather have it switch by the clock, replace that with a time profile:
 

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -46,6 +46,8 @@ Inactive indicators are hidden. Hover the area around them and they fade in dimm
 
 Right-click the night light indicator to open its mode panel, where **Daylight**, **Night Light**, and **Sunset** stay in a fixed order as you switch between them. Sunset mode turns night light on at sunset and off at sunrise. You can also choose **Sunset Nightlight** from _Trigger > Toggle_ or run `omarchy toggle nightlight --schedule`. Omarchy uses the representative location for your selected system timezone and follows daylight-saving changes automatically. Selecting a different timezone updates the schedule; using the regular night light toggle returns to manual control.
 
+Sunset mode rechecks the display temperature when the laptop wakes, so sleeping through sunset or sunrise does not leave the screen in the previous mode.
+
 By default hyprsunset does nothing to your screen at all. `~/.config/hypr/hyprsunset.conf` ships with an identity profile precisely so the display stays untouched until you ask for warmth. If you'd rather have it switch by the clock, replace that with a time profile:
 
 ```

--- a/shell/Ui/BarIndicator.qml
+++ b/shell/Ui/BarIndicator.qml
@@ -13,9 +13,10 @@ BarIconButton {
   property string indicatorBlock: "single"
   property var indicatorHost: null
   property var activeOverride: null
+  property bool alwaysRevealInactive: false
   readonly property bool effectiveActive: activeOverride === null || activeOverride === undefined ? active : activeOverride === true
   readonly property bool belongsInBlock: indicatorBlock === "active" ? effectiveActive : (indicatorBlock === "inactive" ? !effectiveActive : true)
-  readonly property bool inactiveRevealed: !effectiveActive && !!indicatorHost && indicatorHost.revealInactiveIndicators
+  readonly property bool inactiveRevealed: !effectiveActive && (alwaysRevealInactive || (!!indicatorHost && indicatorHost.revealInactiveIndicators))
 
   function extractData(raw) {
     return Util.parseModuleJson(raw)

--- a/shell/plugins/bar/indicators/NightLight.qml
+++ b/shell/plugins/bar/indicators/NightLight.qml
@@ -1,20 +1,172 @@
 import QtQuick
+import qs.Commons
 import qs.Ui
 
-BarIndicator {
+Panel {
   id: root
 
   readonly property var nightlightService: bar?.shell?.firstPartyServiceFor("omarchy.nightlight")
+  readonly property bool active: nightlightService ? nightlightService.enabled : false
+  readonly property var modeOptions: ["daylight", "nightlight", "sunset"]
+  readonly property string mode: nightlightService && nightlightService.scheduled
+    ? "sunset"
+    : (root.active ? "nightlight" : "daylight")
+  property string indicatorBlock: "single"
+  property var indicatorHost: null
+  property var activeOverride: null
+  readonly property bool fixedPosition: true
+  property int cursorIndex: 0
 
-  active: nightlightService ? nightlightService.enabled : false
-  activeText: "󰔎"
-  inactiveText: "󰔎"
-  activeTooltipText: "Day Light"
-  inactiveTooltipText: "Night Light"
+  manageIpc: false
+  implicitWidth: indicator.implicitWidth
+  implicitHeight: indicator.implicitHeight
+  visible: indicator.visible
 
-  function toggle() {
+  function toggleTemperature() {
     if (root.nightlightService) root.nightlightService.setNightlight(!root.active)
   }
 
-  onPressed: function() { root.toggle() }
+  function triggerPress(button) {
+    if (button === Qt.RightButton) root.toggle()
+    else indicator.triggerPress(button)
+  }
+
+  function openSettings() {
+    Qt.callLater(function() { root.toggle() })
+  }
+
+  function selectMode(mode) {
+    if (!root.nightlightService) return
+    if (mode === "sunset") root.nightlightService.setScheduleEnabled(true)
+    else root.nightlightService.setNightlight(mode === "nightlight")
+  }
+
+  function moveCursor(delta) {
+    cursorIndex = Math.max(0, Math.min(modeOptions.length - 1, cursorIndex + delta))
+  }
+
+  onOpenedChanged: {
+    if (opened) cursorIndex = Math.max(0, modeOptions.indexOf(mode))
+  }
+
+  BarIndicator {
+    id: indicator
+
+    anchors.fill: parent
+    bar: root.bar
+    moduleName: root.moduleName
+    settings: root.settings
+    indicatorBlock: root.indicatorBlock
+    indicatorHost: root.indicatorHost
+    activeOverride: root.opened ? null : root.activeOverride
+    alwaysRevealInactive: true
+    active: root.active
+    activeText: "󰔎"
+    inactiveText: "󰔎"
+    activeTooltipText: "Night Light · Right-click for modes"
+    inactiveTooltipText: "Night Light · Right-click for modes"
+
+    onPressed: function(button) {
+      if (button === Qt.RightButton) root.toggle()
+      else root.toggleTemperature()
+    }
+  }
+
+  MouseArea {
+    anchors.fill: indicator
+    acceptedButtons: Qt.RightButton
+    cursorShape: Qt.PointingHandCursor
+    onClicked: root.openSettings()
+  }
+
+  KeyboardPanel {
+    id: panel
+    anchorItem: indicator
+    owner: root
+    bar: root.bar
+    open: root.opened
+    focusTarget: keyCatcher
+    contentWidth: panel.fittedContentWidth(Style.space(360))
+    contentHeight: panel.fittedContentHeight(content.implicitHeight)
+
+    PanelKeyCatcher {
+      id: keyCatcher
+      anchors.fill: parent
+      onMoveRequested: function(dx, dy) { root.moveCursor(dx !== 0 ? dx : dy) }
+      onActivateRequested: root.selectMode(root.modeOptions[root.cursorIndex])
+      onCloseRequested: root.close()
+
+      Column {
+        id: content
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: Style.space(14)
+
+        PanelHero {
+          title: "Night Light"
+          meta: root.mode === "sunset"
+            ? "Follows sunset and sunrise"
+            : (root.mode === "nightlight" ? "Warm display · 4000K" : "Daylight display · 6500K")
+          detail: root.mode === "sunset" && root.nightlightService
+            ? root.nightlightService.scheduleTimezone
+            : ""
+          foreground: root.barForeground
+          fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
+          iconComponent: Component {
+            Text {
+              text: "󰔎"
+              color: root.barForeground
+              font.family: root.bar ? root.bar.fontFamily : Style.font.family
+              font.pixelSize: Style.font.display
+            }
+          }
+        }
+
+        PanelSeparator {
+          foreground: root.barForeground
+        }
+
+        Column {
+          width: parent.width
+          spacing: Style.space(8)
+
+          PanelSectionHeader {
+            text: "MODE"
+            foreground: root.barForeground
+            fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
+          }
+
+          ButtonGroup {
+            options: [
+              { value: "daylight", label: "Daylight" },
+              { value: "nightlight", label: "Night Light" },
+              { value: "sunset", label: "Sunset" }
+            ]
+            value: root.mode
+            cursorIndex: root.cursorIndex
+            foreground: root.barForeground
+            background: Color.popups.background
+            accent: Color.accent
+            fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
+            focusable: false
+            onChanged: function(value) { root.selectMode(value) }
+            onHovered: function(index, hovered) { if (hovered) root.cursorIndex = index }
+          }
+        }
+
+        Text {
+          visible: root.mode === "sunset" && root.nightlightService && root.nightlightService.nextEventAt !== ""
+          width: parent.width
+          textFormat: Text.PlainText
+          text: root.nightlightService
+            ? "Next: " + root.nightlightService.nextEvent + " · " + Qt.formatDateTime(new Date(root.nightlightService.nextEventAt), "ddd h:mm AP")
+            : ""
+          color: Qt.darker(root.barForeground, 1.4)
+          font.family: root.bar ? root.bar.fontFamily : Style.font.family
+          font.pixelSize: Style.font.bodySmall
+          horizontalAlignment: Text.AlignHCenter
+        }
+      }
+    }
+  }
 }

--- a/shell/plugins/bar/widgets/Indicators.qml
+++ b/shell/plugins/bar/widgets/Indicators.qml
@@ -10,6 +10,8 @@ BarWidget {
 
   readonly property var defaultIndicatorEntries: [ "Dictation", "ScreenRecording", "Reminder", "NightLight", "Dnd", "StayAwake" ]
   readonly property var indicatorEntries: indicatorEntriesFromSettings(settings)
+  readonly property var fixedIndicatorEntries: entriesByFixedPosition(true)
+  readonly property var dynamicIndicatorEntries: entriesByFixedPosition(false)
   property var activeIndicatorIds: []
   property var indicatorActiveStates: ({})
   property bool indicatorAreaHovered: false
@@ -38,6 +40,19 @@ BarWidget {
       copy[key] = entry[key]
     }
     return copy
+  }
+
+  function isFixedIndicatorId(id) {
+    return String(id || "") === "NightLight"
+  }
+
+  function entriesByFixedPosition(fixed) {
+    var result = []
+    for (var i = 0; i < indicatorEntries.length; i++) {
+      var entry = indicatorEntries[i]
+      if (isFixedIndicatorId(entryId(entry)) === fixed) result.push(entry)
+    }
+    return result
   }
 
   function indicatorEntriesFromSettings(settings) {
@@ -76,6 +91,7 @@ BarWidget {
   }
 
   function hasIndicatorId(id) {
+    if (isFixedIndicatorId(id)) return false
     for (var i = 0; i < indicatorEntries.length; i++) {
       if (entryId(indicatorEntries[i]) === id) return true
     }
@@ -159,11 +175,11 @@ BarWidget {
   onIndicatorEntriesChanged: syncActiveIndicatorOrder()
 
   implicitWidth: root.vertical
-    ? Math.max(activeVerticalBlock.implicitWidth, inactiveVerticalArea.implicitWidth)
-    : activeHorizontalBlock.implicitWidth + inactiveHorizontalArea.implicitWidth
+    ? Math.max(activeVerticalBlock.implicitWidth, inactiveVerticalArea.implicitWidth, fixedVerticalBlock.implicitWidth)
+    : activeHorizontalBlock.implicitWidth + inactiveHorizontalArea.implicitWidth + fixedHorizontalBlock.implicitWidth
   implicitHeight: root.vertical
-    ? activeVerticalBlock.implicitHeight + inactiveVerticalArea.implicitHeight
-    : Math.max(activeHorizontalBlock.implicitHeight, inactiveHorizontalArea.implicitHeight)
+    ? activeVerticalBlock.implicitHeight + inactiveVerticalArea.implicitHeight + fixedVerticalBlock.implicitHeight
+    : Math.max(activeHorizontalBlock.implicitHeight, inactiveHorizontalArea.implicitHeight, fixedHorizontalBlock.implicitHeight)
 
   IpcHandler {
     target: "omarchy.indicators"
@@ -171,6 +187,7 @@ BarWidget {
     function refresh(): void {
       root.broadcast("refresh")
     }
+
   }
 
   Timer {
@@ -207,7 +224,7 @@ BarWidget {
         id: inactiveHorizontalBlock
         anchors.verticalCenter: parent.verticalCenter
         indicatorsModule: root
-        indicatorEntries: root.indicatorEntries
+        indicatorEntries: root.dynamicIndicatorEntries
         indicatorBlock: "inactive"
         horizontal: true
         reportActiveState: !root.vertical
@@ -224,6 +241,15 @@ BarWidget {
       indicatorModel: activeIndicatorModel
       horizontal: true
       reportActiveState: !root.vertical
+    }
+
+    IndicatorBlock {
+      id: fixedHorizontalBlock
+      indicatorsModule: root
+      indicatorEntries: root.fixedIndicatorEntries
+      indicatorBlock: "single"
+      horizontal: true
+      reportActiveState: false
     }
   }
 
@@ -250,7 +276,7 @@ BarWidget {
         id: inactiveVerticalBlock
         anchors.horizontalCenter: parent.horizontalCenter
         indicatorsModule: root
-        indicatorEntries: root.indicatorEntries
+        indicatorEntries: root.dynamicIndicatorEntries
         indicatorBlock: "inactive"
         horizontal: false
         reportActiveState: root.vertical
@@ -267,6 +293,15 @@ BarWidget {
       indicatorModel: activeIndicatorModel
       horizontal: false
       reportActiveState: root.vertical
+    }
+
+    IndicatorBlock {
+      id: fixedVerticalBlock
+      indicatorsModule: root
+      indicatorEntries: root.fixedIndicatorEntries
+      indicatorBlock: "single"
+      horizontal: false
+      reportActiveState: false
     }
   }
 

--- a/shell/plugins/services/nightlight/Service.qml
+++ b/shell/plugins/services/nightlight/Service.qml
@@ -17,19 +17,78 @@ Item {
   property var temperature: null
   readonly property bool enabled: stateLoaded && NightlightModel.isNightlight(temperature)
 
+  property bool scheduleLoaded: false
+  property bool scheduled: false
+  property string scheduleTimezone: ""
+  property string nextEvent: ""
+  property string nextEventAt: ""
+  property string scheduleError: ""
+  property bool manualScheduleDisablePending: false
+  property bool scheduleEnablePending: false
+
   property bool hasPendingTemperature: false
   property int pendingTemperature: 0
 
   function refresh() {
     if (!statusProbe.running) statusProbe.running = true
+    if (!root.manualScheduleDisablePending && !scheduleProbe.running) scheduleProbe.running = true
   }
 
   function setNightlight(value) {
+    disableSchedule()
     applyTemperature(value ? nightTemperature : dayTemperature)
   }
 
   function toggle() {
     setNightlight(!enabled)
+  }
+
+  function disableSchedule() {
+    if (root.scheduleLoaded && !root.scheduled) return
+
+    root.manualScheduleDisablePending = true
+    scheduleProbe.running = false
+    root.scheduled = false
+    root.scheduleLoaded = true
+    scheduleTimer.stop()
+    if (!scheduleDisableProcess.running) scheduleDisableProcess.running = true
+  }
+
+  function setScheduleEnabled(value) {
+    if (!value) {
+      disableSchedule()
+      return
+    }
+    if (root.scheduled || root.scheduleEnablePending) return
+
+    root.scheduleEnablePending = true
+    if (!scheduleEnableProcess.running) scheduleEnableProcess.running = true
+  }
+
+  function applySchedule(data) {
+    root.scheduleLoaded = true
+    root.scheduled = data.scheduled === true
+    root.scheduleError = data.error ? String(data.error) : ""
+    root.scheduleTimezone = data.timezone ? String(data.timezone) : ""
+    root.nextEvent = data.nextEvent ? String(data.nextEvent) : ""
+    root.nextEventAt = data.nextEventAt ? String(data.nextEventAt) : ""
+
+    scheduleTimer.stop()
+    if (!root.scheduled) return
+    if (root.scheduleError !== "") {
+      console.warn("Night light schedule:", root.scheduleError)
+      scheduleTimer.interval = 15 * 60 * 1000
+      scheduleTimer.restart()
+      return
+    }
+
+    var target = data.night === true ? root.nightTemperature : root.dayTemperature
+    if (root.temperature !== target) root.applyTemperature(target)
+
+    var eventTime = Date.parse(root.nextEventAt)
+    var delay = isNaN(eventTime) ? 15 * 60 * 1000 : eventTime - Date.now() + 1000
+    scheduleTimer.interval = Math.max(1000, Math.min(6 * 60 * 60 * 1000, delay))
+    scheduleTimer.restart()
   }
 
   function applyTemperature(temp) {
@@ -83,13 +142,68 @@ Item {
     }
   }
 
+  Process {
+    id: scheduleProbe
+    command: ["omarchy-nightlight-schedule", "evaluate"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        if (root.manualScheduleDisablePending) return
+
+        try {
+          root.applySchedule(JSON.parse(text))
+        } catch (error) {
+          root.scheduleLoaded = true
+          root.scheduleError = "Invalid schedule response"
+          console.warn("Night light schedule:", root.scheduleError)
+          scheduleTimer.interval = 15 * 60 * 1000
+          scheduleTimer.restart()
+        }
+      }
+    }
+  }
+
+  Process {
+    id: scheduleDisableProcess
+    command: ["omarchy-nightlight-schedule", "disable"]
+    onExited: function(exitCode) {
+      root.manualScheduleDisablePending = false
+      if (exitCode !== 0) console.warn("Night light schedule: unable to save manual mode")
+      root.refresh()
+    }
+  }
+
+  Process {
+    id: scheduleEnableProcess
+    command: ["omarchy-nightlight-schedule", "enable"]
+    onExited: function(exitCode) {
+      root.scheduleEnablePending = false
+      if (exitCode !== 0) console.warn("Night light schedule: unable to enable sunset mode")
+      root.refresh()
+    }
+  }
+
+  Timer {
+    id: scheduleTimer
+    repeat: false
+    onTriggered: root.refresh()
+  }
+
   Component.onCompleted: refresh()
 
   IpcHandler {
     target: "nightlight"
 
     function status(): string {
-      return JSON.stringify({ enabled: root.enabled, temperature: root.temperature })
+      return JSON.stringify({
+        enabled: root.enabled,
+        temperature: root.temperature,
+        scheduled: root.scheduled,
+        timezone: root.scheduleTimezone,
+        nextEvent: root.nextEvent,
+        nextEventAt: root.nextEventAt,
+        scheduleError: root.scheduleError
+      })
     }
 
     function refresh(): void {

--- a/shell/plugins/services/nightlight/Service.qml
+++ b/shell/plugins/services/nightlight/Service.qml
@@ -31,7 +31,6 @@ Item {
 
   function refresh() {
     if (!statusProbe.running) statusProbe.running = true
-    if (!root.manualScheduleDisablePending && !scheduleProbe.running) scheduleProbe.running = true
   }
 
   function setNightlight(value) {
@@ -126,6 +125,8 @@ Item {
         root.temperature = null
         root.stateLoaded = true
       }
+      // Evaluate against the freshly read display state, not a pre-sleep cache.
+      if (!root.manualScheduleDisablePending && !scheduleProbe.running) scheduleProbe.running = true
     }
   }
 
@@ -187,6 +188,20 @@ Item {
     id: scheduleTimer
     repeat: false
     onTriggered: root.refresh()
+  }
+
+  Timer {
+    interval: 1000
+    running: root.scheduled
+    repeat: true
+    property double lastTick: Date.now()
+    onTriggered: {
+      // Qt's countdowns pause during suspend; wall time still crosses sunset.
+      var now = Date.now()
+      var elapsed = now - lastTick
+      lastTick = now
+      if (elapsed > 5000 || elapsed < 0) root.refresh()
+    }
   }
 
   Component.onCompleted: refresh()

--- a/shell/plugins/services/nightlight/Service.qml
+++ b/shell/plugins/services/nightlight/Service.qml
@@ -23,8 +23,8 @@ Item {
   property string nextEvent: ""
   property string nextEventAt: ""
   property string scheduleError: ""
-  property bool manualScheduleDisablePending: false
-  property bool scheduleEnablePending: false
+  // Keep the latest selection while an older mode is still being persisted.
+  property var requestedSchedule: null
 
   property bool hasPendingTemperature: false
   property int pendingTemperature: 0
@@ -34,7 +34,7 @@ Item {
   }
 
   function setNightlight(value) {
-    disableSchedule()
+    setScheduleEnabled(false)
     applyTemperature(value ? nightTemperature : dayTemperature)
   }
 
@@ -42,26 +42,25 @@ Item {
     setNightlight(!enabled)
   }
 
-  function disableSchedule() {
-    if (root.scheduleLoaded && !root.scheduled) return
+  function setScheduleEnabled(value) {
+    if (root.requestedSchedule === null && root.scheduleLoaded && root.scheduled === value) return
 
-    root.manualScheduleDisablePending = true
+    root.requestedSchedule = value
     scheduleProbe.running = false
-    root.scheduled = false
-    root.scheduleLoaded = true
     scheduleTimer.stop()
-    if (!scheduleDisableProcess.running) scheduleDisableProcess.running = true
+    if (!value) {
+      root.scheduled = false
+      root.scheduleLoaded = true
+    }
+    root.persistSchedule()
   }
 
-  function setScheduleEnabled(value) {
-    if (!value) {
-      disableSchedule()
-      return
-    }
-    if (root.scheduled || root.scheduleEnablePending) return
+  function persistSchedule() {
+    if (scheduleChangeProcess.running || root.requestedSchedule === null) return
 
-    root.scheduleEnablePending = true
-    if (!scheduleEnableProcess.running) scheduleEnableProcess.running = true
+    scheduleChangeProcess.enabling = root.requestedSchedule
+    scheduleChangeProcess.command = ["omarchy-nightlight-schedule", root.requestedSchedule ? "enable" : "disable"]
+    scheduleChangeProcess.running = true
   }
 
   function applySchedule(data) {
@@ -126,7 +125,7 @@ Item {
         root.stateLoaded = true
       }
       // Evaluate against the freshly read display state, not a pre-sleep cache.
-      if (!root.manualScheduleDisablePending && !scheduleProbe.running) scheduleProbe.running = true
+      if (root.requestedSchedule === null && !scheduleProbe.running) scheduleProbe.running = true
     }
   }
 
@@ -149,7 +148,7 @@ Item {
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
-        if (root.manualScheduleDisablePending) return
+        if (root.requestedSchedule !== null) return
 
         try {
           root.applySchedule(JSON.parse(text))
@@ -165,21 +164,16 @@ Item {
   }
 
   Process {
-    id: scheduleDisableProcess
-    command: ["omarchy-nightlight-schedule", "disable"]
+    id: scheduleChangeProcess
+    property bool enabling: false
     onExited: function(exitCode) {
-      root.manualScheduleDisablePending = false
-      if (exitCode !== 0) console.warn("Night light schedule: unable to save manual mode")
-      root.refresh()
-    }
-  }
-
-  Process {
-    id: scheduleEnableProcess
-    command: ["omarchy-nightlight-schedule", "enable"]
-    onExited: function(exitCode) {
-      root.scheduleEnablePending = false
-      if (exitCode !== 0) console.warn("Night light schedule: unable to enable sunset mode")
+      if (exitCode !== 0) console.warn("Night light schedule: unable to save " + (scheduleChangeProcess.enabling ? "sunset" : "manual") + " mode")
+      // Finish the in-flight write before persisting any newer selection.
+      if (root.requestedSchedule !== scheduleChangeProcess.enabling) {
+        root.persistSchedule()
+        return
+      }
+      root.requestedSchedule = null
       root.refresh()
     }
   }

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -36,8 +36,16 @@ ShellRoot {
   QtObject {
     id: nightlightService
     property bool enabled: false
+    property bool scheduled: false
+    property string scheduleTimezone: "America/Los_Angeles"
+    property string nextEvent: "sunrise"
+    property string nextEventAt: "2026-08-31T06:26:10-07:00"
     function setNightlight(value) {
       enabled = !!value
+      scheduled = false
+    }
+    function setScheduleEnabled(value) {
+      scheduled = !!value
     }
   }
 
@@ -59,6 +67,9 @@ ShellRoot {
     property color barForeground: "white"
     property color urgent: "red"
     property bool foregroundAnimationEnabled: false
+    property string position: "top"
+    property var activePopout: null
+    property var clickTargets: []
     property bool centerSectionRevealHeld: false
     property bool centerHoverRevealSuppressed: false
     property var shell: mockShell
@@ -67,8 +78,17 @@ ShellRoot {
     }
     function showTooltip(target, text) {}
     function hideTooltip(target) {}
-    function registerClickTarget(target) {}
-    function unregisterClickTarget(target) {}
+    function registerClickTarget(target) {
+      if (clickTargets.indexOf(target) !== -1) return
+      var next = clickTargets.slice()
+      next.push(target)
+      clickTargets = next
+    }
+    function unregisterClickTarget(target) {
+      clickTargets = clickTargets.filter(function(item) { return item !== target })
+    }
+    function requestPopout(owner) { activePopout = owner }
+    function releasePopout(owner) { if (activePopout === owner) activePopout = null }
   }
 
   QtObject {
@@ -143,6 +163,7 @@ ShellRoot {
     }
 
     Qt.callLater(function() {
+      root.assertTrue(typeof tray.isFixedIndicatorId === "function" && tray.isFixedIndicatorId("NightLight"), "indicator tray reserves a fixed slot for Night Light")
       root.assertTrue(tray.implicitWidth === 0, "inactive indicator tray starts collapsed")
       mockBar.centerSectionRevealHeld = true
 
@@ -183,8 +204,33 @@ ShellRoot {
       if (nightLight) {
         nightLight.moduleName = "NightLight"
         root.injectBar(nightLight)
+        root.assertTrue(nightLight.fixedPosition === true, "Night Light declares a fixed indicator position")
         nightLight.triggerPress(Qt.LeftButton)
         root.assertTrue(nightlightService.enabled === true, "Night Light left click toggles the nightlight service")
+        nightLight.triggerPress(Qt.RightButton)
+        root.assertTrue(nightLight.opened === true, "Night Light right click opens its settings panel")
+        nightLight.close()
+        nightlightService.enabled = false
+        mockBar.activePopout = ({ name: "another panel" })
+        var registeredNightLightTarget = null
+        for (var i = 0; i < mockBar.clickTargets.length; i++) {
+          if (mockBar.clickTargets[i].moduleName === "NightLight") registeredNightLightTarget = mockBar.clickTargets[i]
+        }
+        root.assertTrue(registeredNightLightTarget !== null, "Night Light registers its inner bar click target")
+        if (registeredNightLightTarget) {
+          root.assertTrue(registeredNightLightTarget.opacity !== 0, "inactive Night Light registered target remains visible")
+          root.assertTrue(registeredNightLightTarget.interactive !== false, "inactive Night Light registered target remains interactive")
+          var forwardable = registeredNightLightTarget.triggerPress
+            && registeredNightLightTarget.opacity !== 0
+            && registeredNightLightTarget.interactive !== false
+          root.assertTrue(forwardable, "inactive Night Light remains a forwardable bar click target")
+          if (forwardable) registeredNightLightTarget.triggerPress(Qt.RightButton)
+        }
+        root.assertTrue(nightLight.opened === true, "Night Light opens from a right click forwarded by another panel")
+        root.assertTrue(JSON.stringify(nightLight.modeOptions) === '["daylight","nightlight","sunset"]', "Night Light panel keeps mode controls in a stable order")
+        nightlightService.enabled = false
+        nightlightService.scheduled = true
+        root.assertTrue(JSON.stringify(nightLight.modeOptions) === '["daylight","nightlight","sunset"]', "Night Light mode changes do not reorder panel controls")
       }
 
       var screenRecording = root.createIndicator("ScreenRecording")

--- a/test/shell.d/fixtures/nightlight-mode/schedule-command
+++ b/test/shell.d/fixtures/nightlight-mode/schedule-command
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+case ${1:-} in
+  enable)
+    sleep 0.1
+    printf 'solar\n' >"$OMARCHY_NIGHTLIGHT_STATE"
+    ;;
+  disable)
+    printf 'manual\n' >"$OMARCHY_NIGHTLIGHT_STATE"
+    ;;
+  *)
+    printf 'Unexpected fixture command: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+printf '%s\n' "$1" >>"$OMARCHY_NIGHTLIGHT_STATE.writes"

--- a/test/shell.d/fixtures/nightlight-mode/shell.qml
+++ b/test/shell.d/fixtures/nightlight-mode/shell.qml
@@ -1,0 +1,54 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "Nightlight"
+
+ShellRoot {
+  id: harness
+
+  property int temperature: 6500
+
+  Service {
+    id: service
+
+    function refresh() {}
+
+    function runApply(temp) {
+      harness.temperature = temp
+    }
+  }
+
+  Component.onCompleted: Qt.callLater(function() {
+    service.scheduleLoaded = true
+    service.setScheduleEnabled(true)
+    service.setNightlight(true)
+    settled.start()
+  })
+
+  Timer {
+    id: settled
+    interval: 20
+    repeat: true
+    onTriggered: {
+      if (service.requestedSchedule !== null) return
+      stop()
+      savedMode.running = true
+    }
+  }
+
+  Process {
+    id: savedMode
+    command: ["bash", "-c", 'cat "$OMARCHY_NIGHTLIGHT_STATE" "$OMARCHY_NIGHTLIGHT_STATE.writes"']
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        if (text.trim() !== "manual\nenable\ndisable" || harness.temperature !== 4000) {
+          console.log("RESULT fail newer manual selection lost: " + text + " temperature=" + harness.temperature)
+        } else {
+          console.log("RESULT pass")
+        }
+        Qt.quit()
+      }
+    }
+  }
+}

--- a/test/shell.d/fixtures/nightlight-resume/shell.qml
+++ b/test/shell.d/fixtures/nightlight-resume/shell.qml
@@ -1,0 +1,109 @@
+import QtQuick
+import Quickshell
+import "Nightlight"
+
+ShellRoot {
+  id: harness
+
+  property double now: Date.parse("2026-08-30T12:00:00-07:00")
+  property int displayTemperature: 6500
+  property int stage: 0
+  property int evaluations: 0
+
+  function fail(message) {
+    console.log("RESULT fail " + message)
+    Qt.quit()
+  }
+
+  Component.onCompleted: {
+    // Advance wall time without advancing Qt's timers, as system suspend does.
+    serviceLoader.active = true
+  }
+
+  Loader {
+    id: serviceLoader
+    active: false
+    sourceComponent: Component {
+      Service {
+        shell: harness
+
+        function refresh() {
+          harness.evaluations += 1
+          temperature = harness.displayTemperature
+          var night = harness.now >= Date.parse("2026-08-30T19:20:00-07:00")
+            && harness.now < Date.parse("2026-08-31T06:25:00-07:00")
+          applySchedule({
+            scheduled: true,
+            night: night,
+            timezone: "America/Los_Angeles",
+            nextEvent: night ? "sunrise" : "sunset",
+            nextEventAt: night ? "2026-08-31T06:25:00-07:00"
+              : (harness.stage === 0 ? "2026-08-30T19:20:00-07:00" : "2026-08-31T19:19:00-07:00")
+          })
+        }
+
+        function runApply(temp) {
+          harness.displayTemperature = temp
+        }
+      }
+    }
+  }
+
+  Timer {
+    interval: 1500
+    running: true
+    repeat: true
+    onTriggered: {
+      if (harness.stage === 0) {
+        if (harness.displayTemperature !== 6500) {
+          harness.fail("daylight did not start at 6500K")
+          return
+        }
+        if (harness.evaluations !== 1) {
+          harness.fail("an unchanged wall clock repeatedly evaluated the schedule")
+          return
+        }
+        harness.stage = 1
+        harness.now = Date.parse("2026-08-30T22:00:00-07:00")
+      } else if (harness.stage === 1) {
+        if (harness.displayTemperature !== 4000) {
+          harness.fail("waking after sunset left the display at " + harness.displayTemperature + "K")
+          return
+        }
+        harness.stage = 2
+        harness.displayTemperature = 6500
+        harness.now = Date.parse("2026-08-30T23:00:00-07:00")
+      } else if (harness.stage === 2) {
+        if (harness.displayTemperature !== 4000) {
+          harness.fail("a nighttime display reset was not corrected after wake")
+          return
+        }
+        harness.stage = 3
+        harness.now = Date.parse("2026-08-31T08:00:00-07:00")
+      } else if (harness.stage === 3) {
+        if (harness.displayTemperature !== 6500) {
+          harness.fail("waking after sunrise left the display at " + harness.displayTemperature + "K")
+          return
+        }
+        harness.stage = 4
+        harness.now = Date.parse("2026-08-30T22:00:00-07:00")
+      } else if (harness.stage === 4) {
+        if (harness.displayTemperature !== 4000) {
+          harness.fail("moving the clock backward into nighttime did not warm the display")
+          return
+        }
+        harness.stage = 5
+        serviceLoader.item.scheduled = false
+        harness.displayTemperature = 6500
+        harness.now = Date.parse("2026-08-30T23:00:00-07:00")
+      } else {
+        if (harness.displayTemperature !== 6500) {
+          harness.fail("resume overrode manual daylight mode")
+          return
+        }
+        console.log("RESULT pass")
+        Qt.quit()
+      }
+    }
+  }
+}

--- a/test/shell.d/indicator-contract-test.sh
+++ b/test/shell.d/indicator-contract-test.sh
@@ -75,4 +75,9 @@ if rg -q 'Indicators.qml.*Binding loop detected for property "implicitWidth"' "$
   fail "indicator tray avoids implicit-width binding loops"
 fi
 
+if rg -q 'Plugin widget omarchy.indicators failed|Indicator loader error' "$log"; then
+  sed -n '1,200p' "$log" >&2
+  fail "indicator tray loads every configured indicator"
+fi
+
 pass "QML indicator contract checks pass"

--- a/test/shell.d/nightlight-mode-test.sh
+++ b/test/shell.d/nightlight-mode-test.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+const source = fs.readFileSync(path.join(root, 'shell/plugins/services/nightlight/Service.qml'), 'utf8')
+
+function service(scheduled) {
+  const context = vm.createContext({
+    root: {
+      scheduleLoaded: true,
+      scheduled,
+      requestedSchedule: null,
+      nightTemperature: 4000,
+      dayTemperature: 6500,
+      temperature: 6500
+    },
+    statusProbe: { running: false },
+    scheduleProbe: { running: false },
+    scheduleTimer: { stop() {}, restart() {} },
+    scheduleChangeProcess: { running: false, command: [] },
+    warnings: []
+  })
+  context.console = { warn: message => context.warnings.push(message) }
+
+  for (const match of source.matchAll(/^  function (\w+)\(([^)]*)\) \{([\s\S]*?)^  \}/gm)) {
+    vm.runInContext(`root.${match[1]} = function(${match[2]}) {${match[3]}}`, context)
+  }
+  for (const key of Object.keys(context.root)) {
+    Object.defineProperty(context, key, {
+      get: () => context.root[key],
+      set: value => { context.root[key] = value }
+    })
+  }
+  const exits = {}
+  for (const name of ['scheduleChangeProcess', 'statusProbe']) {
+    const match = source.match(new RegExp(`id: ${name}\\b[\\s\\S]*?(onExited: function\\(exitCode\\) \\{[\\s\\S]*?^    \\})`, 'm'))
+    if (match) exits[name] = vm.runInContext(`(${match[1].replace('onExited: ', '')})`, context)
+  }
+  const scheduleOutput = source.match(/id: scheduleProbe[\s\S]*?onStreamFinished: \{([\s\S]*?)^      \}/m)
+  const finishSchedule = vm.runInContext(`(function(text) {${scheduleOutput[1]}})`, context)
+  vm.runInContext('root.applyTemperature = function(temp) { root.temperature = temp }', context)
+
+  let persisted = scheduled
+  const writes = []
+  function finishWrite(exitCode = 0) {
+    const process = context.scheduleChangeProcess
+    assertEqual(process.running, true, 'a mode write is in flight')
+    const enabling = process.command[1] === 'enable'
+    if (exitCode === 0) persisted = enabling
+    writes.push(enabling)
+    process.running = false
+    exits.scheduleChangeProcess(exitCode)
+  }
+  function settle() {
+    for (let count = 0; count < 5; count++) {
+      if (!context.scheduleChangeProcess.running) break
+      finishWrite()
+    }
+    assertEqual(context.root.requestedSchedule, null, 'the latest mode request settles')
+    return persisted
+  }
+  return { context, finishWrite, settle, writes, finishStatus: exits.statusProbe, finishSchedule }
+}
+
+for (const warm of [true, false]) {
+  const test = service(false)
+  test.context.root.setScheduleEnabled(true)
+  test.context.root.setNightlight(warm)
+  assertEqual(test.settle(), false, `manual ${warm ? 'night light' : 'daylight'} wins over pending Sunset`)
+  assertEqual(test.context.root.temperature, warm ? 4000 : 6500, 'the latest manual temperature is retained')
+  assertDeepEqual(test.writes, [true, false], 'manual mode is persisted after the older enable completes')
+}
+
+{
+  const test = service(true)
+  test.context.root.setNightlight(false)
+  test.context.root.setScheduleEnabled(true)
+  assertEqual(test.settle(), true, 'Sunset wins over pending manual persistence')
+  assertDeepEqual(test.writes, [false, true], 'Sunset waits for the older disable to complete')
+}
+
+{
+  const test = service(false)
+  test.context.root.setScheduleEnabled(true)
+  test.context.root.setNightlight(true)
+  test.context.root.setScheduleEnabled(true)
+  assertEqual(test.settle(), true, 'Sunset wins after enable-manual-enable')
+  assertDeepEqual(test.writes, [true], 'superseded requests do not cause extra writes')
+}
+
+{
+  const test = service(true)
+  test.context.root.setNightlight(true)
+  test.context.root.setScheduleEnabled(true)
+  test.context.root.setNightlight(false)
+  assertEqual(test.settle(), false, 'manual mode wins after manual-enable-manual')
+  assertEqual(test.context.root.temperature, 6500, 'the newest manual temperature wins too')
+  assertDeepEqual(test.writes, [false], 'a superseded enable does not run')
+}
+
+{
+  const test = service(false)
+  test.context.root.setScheduleEnabled(true)
+  test.finishStatus(0)
+  assertEqual(test.context.scheduleProbe.running, false, 'status completion cannot evaluate an intermediate mode')
+  test.context.root.setNightlight(false)
+  test.finishSchedule(JSON.stringify({ scheduled: true, night: true }))
+  assertEqual(test.context.root.scheduled, false, 'a stale solar response cannot reselect Sunset during a manual request')
+  assertEqual(test.context.root.temperature, 6500, 'a stale solar response cannot override manual daylight')
+  test.finishWrite(1)
+  assertEqual(test.settle(), false, 'the latest manual request survives a failed older enable')
+  assertEqual(test.context.warnings.length, 1, 'a failed mode write is reported')
+}
+JS
+
+require_compositor "nightlight mode persistence runtime test"
+require_command quickshell
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir "$test_tmp/bin"
+cp "$SHELL_TEST_DIR/fixtures/nightlight-mode/shell.qml" "$test_tmp/shell.qml"
+cp "$SHELL_TEST_DIR/fixtures/nightlight-mode/schedule-command" "$test_tmp/bin/omarchy-nightlight-schedule"
+chmod +x "$test_tmp/bin/omarchy-nightlight-schedule"
+ln -s "$ROOT/shell/plugins/services/nightlight" "$test_tmp/Nightlight"
+
+output=$(PATH="$test_tmp/bin:$PATH" OMARCHY_NIGHTLIGHT_STATE="$test_tmp/mode" \
+  timeout 10 quickshell -p "$test_tmp" --no-color 2>&1) || {
+  printf '%s\n' "$output" >&2
+  fail "nightlight mode persistence fixture exits cleanly"
+}
+if ! grep -q "RESULT pass" <<<"$output"; then
+  printf '%s\n' "$output" >&2
+  fail "manual mode wins after an in-flight Sunset write"
+fi
+pass "manual mode wins after an in-flight Sunset write"

--- a/test/shell.d/nightlight-probe-test.sh
+++ b/test/shell.d/nightlight-probe-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+const source = fs.readFileSync(path.join(root, 'shell/plugins/services/nightlight/Service.qml'), 'utf8')
+const context = vm.createContext({
+  root: {
+    temperature: 4000,
+    nightTemperature: 4000,
+    dayTemperature: 6500,
+    manualScheduleDisablePending: false
+  },
+  statusProbe: { running: false },
+  scheduleProbe: { running: false },
+  scheduleTimer: { stop() {}, restart() {} },
+  applied: []
+})
+
+// Run the service's actual functions and exit handler, controlling only process completion order.
+for (const match of source.matchAll(/^  function (\w+)\(([^)]*)\) \{([\s\S]*?)^  \}/gm)) {
+  vm.runInContext(`root.${match[1]} = function(${match[2]}) {${match[3]}}`, context)
+}
+const statusExit = source.match(/id: statusProbe[\s\S]*?(onExited: function\(exitCode\) \{[\s\S]*?^    \})/m)
+assert(statusExit !== null, 'nightlight status probe has an exit handler')
+vm.runInContext(`finishStatus = ${statusExit[1].replace('onExited: ', '')}`, context)
+vm.runInContext('root.applyTemperature = function(temp) { applied.push(temp); root.temperature = temp }', context)
+
+context.root.refresh()
+assertEqual(context.statusProbe.running, true, 'refresh reads the actual display temperature')
+assertEqual(context.scheduleProbe.running, false, 'schedule waits for the display probe instead of using cached night temperature')
+
+// The display reverted to daylight while asleep, although the cache still said 4000K.
+context.root.temperature = 6500
+context.statusProbe.running = false
+context.finishStatus(0)
+assertEqual(context.scheduleProbe.running, true, 'completed display probe starts schedule evaluation')
+context.root.applySchedule({
+  scheduled: true,
+  night: true,
+  nextEvent: 'sunrise',
+  nextEventAt: '2026-08-31T06:25:00-07:00'
+})
+assertDeepEqual(context.applied, [4000], 'nighttime resume corrects a display reset despite the formerly warm cache')
+
+context.scheduleProbe.running = false
+context.root.manualScheduleDisablePending = true
+context.finishStatus(0)
+assertEqual(context.scheduleProbe.running, false, 'pending manual mode does not restart automatic scheduling')
+
+context.root.manualScheduleDisablePending = false
+context.finishStatus(1)
+assertEqual(context.root.temperature, null, 'failed display probe invalidates cached temperature')
+assertEqual(context.scheduleProbe.running, true, 'failed display probe still lets sunset mode restore hyprsunset')
+JS

--- a/test/shell.d/nightlight-probe-test.sh
+++ b/test/shell.d/nightlight-probe-test.sh
@@ -13,7 +13,7 @@ const context = vm.createContext({
     temperature: 4000,
     nightTemperature: 4000,
     dayTemperature: 6500,
-    manualScheduleDisablePending: false
+    requestedSchedule: null
   },
   statusProbe: { running: false },
   scheduleProbe: { running: false },
@@ -48,11 +48,11 @@ context.root.applySchedule({
 assertDeepEqual(context.applied, [4000], 'nighttime resume corrects a display reset despite the formerly warm cache')
 
 context.scheduleProbe.running = false
-context.root.manualScheduleDisablePending = true
+context.root.requestedSchedule = false
 context.finishStatus(0)
 assertEqual(context.scheduleProbe.running, false, 'pending manual mode does not restart automatic scheduling')
 
-context.root.manualScheduleDisablePending = false
+context.root.requestedSchedule = null
 context.finishStatus(1)
 assertEqual(context.root.temperature, null, 'failed display probe invalidates cached temperature')
 assertEqual(context.scheduleProbe.running, true, 'failed display probe still lets sunset mode restore hyprsunset')

--- a/test/shell.d/nightlight-resume-test.sh
+++ b/test/shell.d/nightlight-resume-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_compositor "nightlight resume runtime test"
+require_command quickshell
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+cp "$SHELL_TEST_DIR/fixtures/nightlight-resume/shell.qml" "$test_tmp/shell.qml"
+mkdir "$test_tmp/Nightlight"
+cp "$ROOT/shell/plugins/services/nightlight/NightlightModel.js" "$test_tmp/Nightlight/"
+# Keep the real QML timers and scheduling code, replacing only the wall clock.
+sed 's/Date.now()/root.shell.now/g' "$ROOT/shell/plugins/services/nightlight/Service.qml" >"$test_tmp/Nightlight/Service.qml"
+
+output=$(timeout 15 quickshell -p "$test_tmp" --no-color 2>&1) || {
+  printf '%s\n' "$output" >&2
+  fail "nightlight resume fixture exits cleanly"
+}
+
+if ! grep -q "RESULT pass" <<<"$output"; then
+  printf '%s\n' "$output" >&2
+  fail "sunset mode restores the correct temperature after sleep"
+fi
+
+pass "sunset mode restores the correct temperature after sleep"

--- a/test/shell.d/nightlight-solar-test.sh
+++ b/test/shell.d/nightlight-solar-test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command python3
+
+python3 - <<'PY'
+import json
+import os
+import subprocess
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+class SolarScheduleTest(unittest.TestCase):
+  def evaluate(self, zone, at):
+    result = subprocess.run(
+      [str(Path(os.environ["ROOT"]) / "bin/omarchy-nightlight-schedule"),
+       "evaluate", "--at", at.isoformat() if isinstance(at, datetime) else at],
+      env={
+        **os.environ,
+        "OMARCHY_NIGHTLIGHT_STATE": "/dev/null",
+        "OMARCHY_NIGHTLIGHT_TIMEZONE": zone,
+        "OMARCHY_ZONEINFO_DIR": "/usr/share/zoneinfo",
+      },
+      check=True,
+      capture_output=True,
+      text=True,
+    )
+    schedule = json.loads(result.stdout)
+    self.assertNotIn("error", schedule)
+    return schedule
+
+  def test_advertised_sunset_changes_night_state(self):
+    zone = "America/Los_Angeles"
+    schedule = self.evaluate(zone, "2026-03-20T12:00:00-07:00")
+    self.assertEqual(schedule["nextEvent"], "sunset")
+    sunset = datetime.fromisoformat(schedule["nextEventAt"])
+    self.assertTrue(self.evaluate(zone, sunset + timedelta(seconds=1))["night"])
+
+  def test_apia_includes_todays_sunset(self):
+    schedule = self.evaluate("Pacific/Apia", "2026-08-30T17:00:00+13:00")
+    self.assertEqual(schedule["nextEvent"], "sunset")
+    self.assertTrue(schedule["nextEventAt"].startswith("2026-08-30T18:"))
+
+  def assert_transition(self, zone, schedule):
+    event = datetime.fromisoformat(schedule["nextEventAt"])
+    was_night = schedule["nextEvent"] == "sunrise"
+    for offset in (-1, -0.000001, 0, 0.999999, 1):
+      with self.subTest(zone=zone, event=event, offset=offset):
+        at = event + timedelta(seconds=offset)
+        result = self.evaluate(zone, at)
+        self.assertEqual(result["night"], was_night if offset < 0 else not was_night)
+        self.assertGreater(datetime.fromisoformat(result["nextEventAt"]), at)
+        if offset < 0:
+          self.assertEqual(result["nextEventAt"], schedule["nextEventAt"])
+          self.assertEqual(result["nextEvent"], schedule["nextEvent"])
+
+  def test_boundaries_across_seasons_timezones_and_dst(self):
+    cases = (
+      ("America/Los_Angeles", "2026-03-20"),
+      ("America/Los_Angeles", "2026-06-21"),
+      ("America/Los_Angeles", "2026-09-22"),
+      ("America/Los_Angeles", "2026-12-21"),
+      ("America/Los_Angeles", "2026-03-08"),
+      ("America/Los_Angeles", "2026-11-01"),
+      ("Europe/London", "2026-03-29"),
+      ("Europe/London", "2026-10-25"),
+      ("Pacific/Apia", "2026-08-30"),
+      ("Pacific/Kiritimati", "2026-08-30"),
+      ("Pacific/Honolulu", "2026-08-30"),
+      ("Pacific/Auckland", "2026-08-30"),
+      ("Pacific/Chatham", "2026-08-30"),
+      ("Asia/Tokyo", "2026-08-30"),
+      ("Australia/Sydney", "2026-04-05"),
+      ("Australia/Sydney", "2026-10-04"),
+    )
+    for zone, day in cases:
+      with self.subTest(zone=zone, day=day):
+        schedule = self.evaluate(zone, day + "T00:00:00")
+        self.assertEqual(schedule["nextEvent"], "sunrise")
+        self.assertTrue(schedule["nextEventAt"].startswith(day))
+        self.assert_transition(zone, schedule)
+        sunset = self.evaluate(zone, schedule["nextEventAt"])
+        self.assertEqual(sunset["nextEvent"], "sunset")
+        self.assertTrue(sunset["nextEventAt"].startswith(day))
+        self.assert_transition(zone, sunset)
+
+  def test_polar_day_and_night_find_the_next_real_crossing(self):
+    zone = "Arctic/Longyearbyen"
+    for at, night, next_event in (
+      ("2026-06-21T12:00:00", False, "sunset"),
+      ("2026-12-21T12:00:00", True, "sunrise"),
+    ):
+      with self.subTest(at=at):
+        schedule = self.evaluate(zone, at)
+        self.assertEqual(schedule["night"], night)
+        self.assertEqual(schedule["nextEvent"], next_event)
+        event = datetime.fromisoformat(schedule["nextEventAt"])
+        self.assertGreater((event.replace(tzinfo=None) - datetime.fromisoformat(at)).days, 20)
+        self.assert_transition(zone, schedule)
+
+
+unittest.main()
+PY

--- a/test/shell.d/nightlight-test.sh
+++ b/test/shell.d/nightlight-test.sh
@@ -21,6 +21,8 @@ trap 'rm -rf "$TMPDIR"' EXIT
 mkdir -p "$TMPDIR/bin"
 STATE="$TMPDIR/hyprsunset-temp"
 SHELL_LOG="$TMPDIR/omarchy-shell-log"
+NOTIFICATION_LOG="$TMPDIR/notification-log"
+SCHEDULE_STATE="$TMPDIR/nightlight.json"
 
 cat >"$TMPDIR/bin/hyprctl" <<'SH'
 #!/bin/bash
@@ -47,14 +49,47 @@ cat >"$TMPDIR/bin/omarchy-shell" <<'SH'
 printf '%s\n' "$*" >>"$OMARCHY_SHELL_LOG"
 SH
 
-chmod +x "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/pgrep" "$TMPDIR/bin/omarchy-shell"
+cat >"$TMPDIR/bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_NOTIFICATION_LOG"
+SH
+
+chmod +x "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/pgrep" "$TMPDIR/bin/omarchy-shell" "$TMPDIR/bin/omarchy-notification-send"
 
 nightlight_cli() {
-  PATH="$TMPDIR/bin:$PATH" \
+  PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
   HYPRSUNSET_STATE="$STATE" \
   OMARCHY_SHELL_LOG="$SHELL_LOG" \
+  OMARCHY_NOTIFICATION_LOG="$NOTIFICATION_LOG" \
+  OMARCHY_NIGHTLIGHT_STATE="${OMARCHY_NIGHTLIGHT_STATE_OVERRIDE:-$SCHEDULE_STATE}" \
+  OMARCHY_NIGHTLIGHT_TIMEZONE="America/Los_Angeles" \
     "$ROOT/bin/omarchy-toggle-nightlight" "$@"
 }
+
+nightlight_schedule() {
+  OMARCHY_NIGHTLIGHT_STATE="$SCHEDULE_STATE" \
+  OMARCHY_NIGHTLIGHT_TIMEZONE="America/Los_Angeles" \
+    "$ROOT/bin/omarchy-nightlight-schedule" "$@"
+}
+
+schedule_at_noon=$(nightlight_schedule evaluate --at "2026-08-30T12:00:00-07:00")
+[[ $(jq -r .night <<<"$schedule_at_noon") == "false" ]] || fail "solar schedule recognizes daylight"
+[[ $(jq -r .nextEvent <<<"$schedule_at_noon") == "sunset" ]] || fail "solar schedule finds sunset after daylight"
+[[ $(jq -r .nextEventAt <<<"$schedule_at_noon") == 2026-08-30T19:2[01]:*-07:00 ]] || fail "solar schedule calculates Los Angeles sunset"
+pass "solar schedule calculates daylight and the next sunset"
+
+schedule_at_night=$(nightlight_schedule evaluate --at "2026-08-30T22:00:00-07:00")
+[[ $(jq -r .night <<<"$schedule_at_night") == "true" ]] || fail "solar schedule recognizes night"
+[[ $(jq -r .nextEvent <<<"$schedule_at_night") == "sunrise" ]] || fail "solar schedule finds sunrise after night"
+pass "solar schedule calculates night and the next sunrise"
+
+nightlight_schedule enable >/dev/null
+nightlight_schedule enabled || fail "solar schedule persists enabled mode"
+nightlight_schedule disable >/dev/null
+if nightlight_schedule enabled; then
+  fail "solar schedule persists manual mode"
+fi
+pass "solar schedule persists automatic and manual modes"
 
 nightlight_status() {
   printf '%s\n' "$1" >"$STATE"
@@ -73,6 +108,9 @@ pass "nightlight status reports identity temperature as disabled"
 [[ $(nightlight_status 6500 | jq -r .enabled) == "false" ]] || fail "nightlight status reports daylight temperature as disabled"
 pass "nightlight status reports daylight temperature as disabled"
 
+[[ $(nightlight_status 6500 | jq -r .scheduled) == "false" ]] || fail "nightlight status reports manual scheduling"
+pass "nightlight status reports manual scheduling"
+
 printf '6500\n' >"$STATE"
 : >"$SHELL_LOG"
 nightlight_cli >/dev/null
@@ -85,6 +123,35 @@ pass "nightlight toggle nudges the shell nightlight service"
 nightlight_cli >/dev/null
 [[ $(<"$STATE") == 6500 ]] || fail "nightlight toggle restores daylight from night light"
 pass "nightlight toggle restores daylight from night light"
+
+nightlight_schedule enable >/dev/null
+nightlight_cli >/dev/null
+if nightlight_schedule enabled; then
+  fail "manual nightlight toggle disables automatic mode"
+fi
+[[ $(<"$STATE") == 4000 ]] || fail "manual nightlight toggle still applies after disabling automatic mode"
+pass "manual nightlight toggle disables automatic mode"
+
+mkdir "$TMPDIR/unwritable-schedule-state"
+printf '6500\n' >"$STATE"
+OMARCHY_NIGHTLIGHT_STATE_OVERRIDE="$TMPDIR/unwritable-schedule-state" nightlight_cli >/dev/null 2>&1
+[[ $(<"$STATE") == 4000 ]] || fail "manual nightlight toggle survives schedule persistence failure"
+grep -Fq 'Unable to disable automatic night light; applying a manual override' "$NOTIFICATION_LOG" ||
+  fail "manual nightlight toggle reports schedule persistence failure"
+pass "manual nightlight toggle survives schedule persistence failure"
+
+nightlight_cli --schedule >/dev/null
+nightlight_schedule enabled || fail "nightlight schedule option enables automatic mode"
+grep -Fq 'Night light will follow sunset and sunrise in America/Los_Angeles' "$NOTIFICATION_LOG" ||
+  fail "nightlight schedule option describes its timezone"
+grep -Fqx -- '-q nightlight refresh' "$SHELL_LOG" || fail "nightlight schedule refreshes the shell service"
+pass "nightlight schedule option enables automatic mode"
+
+nightlight_cli --manual >/dev/null
+if nightlight_schedule enabled; then
+  fail "nightlight manual option disables automatic mode"
+fi
+pass "nightlight manual option disables automatic mode"
 
 if rg -q 'omarchy.indicators' "$ROOT/bin/omarchy-toggle-nightlight"; then
   fail "nightlight toggle leaves indicator refresh to the nightlight service"

--- a/test/shell.d/timezone-test.sh
+++ b/test/shell.d/timezone-test.sh
@@ -34,7 +34,10 @@ grep -F 'sudo timedatectl set-timezone "$timezone"' "$timezone_menu" >/dev/null 
 grep -F 'omarchy-shell -q omarchy.clock refresh' "$timezone_menu" >/dev/null ||
   fail "timezone menu refreshes the namespaced clock IPC target"
 
+grep -F 'omarchy-shell -q nightlight refresh' "$timezone_menu" >/dev/null ||
+  fail "timezone menu refreshes the solar nightlight schedule"
+
 ! grep -F 'omarchy-shell -q Clock refresh' "$timezone_menu" >/dev/null ||
   fail "timezone menu no longer refreshes the retired Clock IPC target"
 
-pass "timezone menu refreshes clock after timezone changes"
+pass "timezone menu refreshes clock and nightlight after timezone changes"


### PR DESCRIPTION
## Summary

- add timezone-aware sunrise and sunset scheduling for Night Light
- add a fixed-position Night Light indicator with a right-click mode panel
- keep manual controls, timezone refreshes, CLI status, menu entries, and documentation in sync
- cover solar calculations, schedule persistence, fixed indicator placement, and panel interactions

## Tests

- `./test/cli`
- `bash test/shell.d/qml-text-format-test.sh`
- `bash test/shell.d/indicator-contract-test.sh`
- `bash test/shell.d/nightlight-test.sh`
- `bash test/shell.d/timezone-test.sh`

The aggregate shell suite also ran; its remaining failures require the unavailable sibling `omarchy-pkgs` checkout (`config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`).

## Screenshot

![Night Light Sunset mode selected](https://github.com/user-attachments/assets/31293d23-0277-48c9-9117-bfc2a7bc19e8)
