### PR TITLE
Allow plugins to specify package dependencies (optional + required)

### DIFF
--- a/bin/omarchy-plugin-add
+++ b/bin/omarchy-plugin-add
@@ -58,6 +58,117 @@ plugin_id_manifest() {
   '
 }
 
+# PKGBUILD-style dependencies declared in the manifest:
+#
+#   "dependencies": {
+#     "pacman": ["gum"],
+#     "aur": ["some-aur-package"],
+#     "optdepends": {
+#       "pacman": ["brightnessctl: needed for the brightness slider"],
+#       "aur": ["google-chrome: needed for the browser widget"]
+#     }
+#   }
+#
+# Required ones are plain package-name arrays split by source (pacman repo vs
+# AUR); optional ones use the PKGBUILD "name: reason" optdepends strings. Both
+# are checked against the local pacman database (AUR packages live there too
+# once installed) and offered for install when missing.
+install_dependency_group() {
+  local installer="$1"
+  shift
+  (( $# )) || return 0
+  echo "Installing: $*"
+  if "$installer" "$@"; then
+    echo "Installed: $*"
+  else
+    echo "Could not install: $*" >&2
+    echo "Install manually for the plugin to work" >&2
+  fi
+}
+
+check_plugin_dependencies() {
+  local manifest="$1" id="$2"
+  local -a required_pacman=() required_aur=() optional_pacman=() optional_aur=()
+  local source pkg entry name reason
+
+  for source in pacman aur; do
+    while IFS= read -r pkg; do
+      [[ -n $pkg ]] || continue
+      omarchy-pkg-missing "$pkg" || continue
+      if [[ $source == pacman ]]; then
+        required_pacman+=("$pkg")
+      else
+        required_aur+=("$pkg")
+      fi
+    done < <(jq -r --arg src "$source" '((.dependencies // {})[$src] // [])[]' "$manifest")
+  done
+
+  for source in pacman aur; do
+    while IFS= read -r entry; do
+      [[ -n $entry ]] || continue
+      name="${entry%%:*}"
+      reason=""
+      if [[ $entry == *:* ]]; then
+        reason="${entry#*:}"
+        reason="${reason#"${reason%%[![:space:]]*}"}"
+      fi
+      name="${name#"${name%%[![:space:]]*}"}"
+      name="${name%"${name##*[![:space:]]}"}"
+      [[ -n $name ]] || continue
+      omarchy-pkg-missing "$name" || continue
+      if [[ $source == pacman ]]; then
+        optional_pacman+=("$name:$reason")
+      else
+        optional_aur+=("$name:$reason")
+      fi
+    done < <(jq -r --arg src "$source" '((.dependencies.optdepends // {})[$src] // [])[]' "$manifest")
+  done
+
+  if (( ${#required_pacman[@]} == 0 && ${#required_aur[@]} == 0 )) &&
+    (( ${#optional_pacman[@]} == 0 && ${#optional_aur[@]} == 0 )); then
+    return 0
+  fi
+
+  echo
+  echo "Dependencies for '$id' missing from this system:"
+
+  if (( ${#required_pacman[@]} || ${#required_aur[@]} )); then
+    echo "  Required:"
+    for pkg in "${required_pacman[@]}"; do echo "    - $pkg"; done
+    for pkg in "${required_aur[@]}"; do echo "    - $pkg (AUR)"; done
+  fi
+
+  if (( ${#optional_pacman[@]} || ${#optional_aur[@]} )); then
+    echo "  Optional:"
+    for entry in "${optional_pacman[@]}" "${optional_aur[@]}"; do
+      name="${entry%%:*}"
+      reason="${entry#*:}"
+      echo "    - $name${reason:+ ($reason)}"
+    done
+  fi
+
+  if (( ${#required_pacman[@]} || ${#required_aur[@]} )); then
+    if (( ASSUME_YES )); then
+      install_dependency_group omarchy-pkg-add "${required_pacman[@]}"
+      install_dependency_group omarchy-pkg-aur-add "${required_aur[@]}"
+    elif interactive && confirm "Install the required dependencies for '$id'?"; then
+      install_dependency_group omarchy-pkg-add "${required_pacman[@]}"
+      install_dependency_group omarchy-pkg-aur-add "${required_aur[@]}"
+    else
+      echo "Skipping required dependencies; '$id' may not work until they are installed." >&2
+    fi
+  fi
+
+  if (( ${#optional_pacman[@]} || ${#optional_aur[@]} )); then
+    if (( ASSUME_YES )); then
+      echo "Skipping optional dependencies (pass them to omarchy pkg add to install)."
+    elif interactive && confirm "Install the optional dependencies for '$id'?"; then
+      install_dependency_group omarchy-pkg-add "${optional_pacman[@]%%:*}"
+      install_dependency_group omarchy-pkg-aur-add "${optional_aur[@]%%:*}"
+    fi
+  fi
+}
+
 url=""
 enable_after=""
 
@@ -136,6 +247,7 @@ if [[ -n $existing_manifest ]]; then
   rm -rf "$stage"
   fail "plugin id '$id' is already used by $existing_manifest"
 fi
+check_plugin_dependencies "$stage/manifest.json" "$id"
 
 target="$PLUGINS_DIR/$id"
 if [[ -e $target || -L $target ]]; then

--- a/bin/omarchy-plugin-validate
+++ b/bin/omarchy-plugin-validate
@@ -22,7 +22,8 @@ Usage: omarchy plugin validate <plugin-folder>
 
 Checks a plugin folder's manifest.json against the schema the shell enforces:
 schemaVersion, required fields, safe relative entry points that exist, an entry
-point for each kind that needs one, no symlinks, and an id that is not reserved.
+point for each kind that needs one, no symlinks, an id that is not reserved,
+and PKGBUILD-style Arch dependencies (pacman/AUR, required and optdepends).
 Exits 0 if valid — handy for plugin authors before publishing.
 USAGE
   exit 0
@@ -72,6 +73,38 @@ jq -e '
   end
 ' "$MANIFEST" >/dev/null 2>&1 \
   || fail "'barWidget.defaultSection' must be left, center, or right"
+
+# Optional Arch package dependencies, PKGBUILD-style: required ones are plain
+# package-name arrays split by source (pacman repo vs AUR), optional ones use
+# the PKGBUILD "name: reason" optdepends strings. The installer reads these to
+# offer installs; validation keeps malformed declarations out.
+jq -e 'if has("dependencies") then (.dependencies | type) == "object" else true end' "$MANIFEST" >/dev/null 2>&1 \
+  || fail "'dependencies' must be an object"
+
+for source in pacman aur; do
+  jq -e --arg source "$source" '
+    if ((.dependencies | type) == "object") and (.dependencies | has($source)) then
+      (.dependencies[$source] | type) == "array" and
+      all(.dependencies[$source][]; (type) == "string" and length > 0)
+    else true end' "$MANIFEST" >/dev/null 2>&1 \
+    || fail "'dependencies.$source' must be an array of package names"
+done
+
+jq -e '
+  if ((.dependencies | type) == "object") and (.dependencies | has("optdepends")) then
+    (.dependencies.optdepends | type) == "object"
+  else true end' "$MANIFEST" >/dev/null 2>&1 \
+  || fail "'dependencies.optdepends' must be an object with pacman/aur arrays"
+
+for source in pacman aur; do
+  jq -e --arg source "$source" '
+    if ((.dependencies | type) == "object") and
+      (((.dependencies.optdepends // {}) | has($source))) then
+      all(.dependencies.optdepends[$source][];
+        (type) == "string" and test("^[^[:space:]][^:]*:[[:space:]]*[^[:space:]]"))
+    else true end' "$MANIFEST" >/dev/null 2>&1 \
+    || fail "'dependencies.optdepends.$source' entries must be 'name: reason' strings"
+done
 
 # Read each entry point as a JSON-encoded string (one per line), then decode it,
 # so a value that itself contains a newline stays one literal path instead of

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -20,7 +20,14 @@ wait).
   "author": "You",
   "description": "A clock that does cool things",
   "kinds": ["bar-widget"],
-  "entryPoints": { "barWidget": "Widget.qml" }
+  "entryPoints": { "barWidget": "Widget.qml" },
+  "dependencies": {
+    "pacman": ["jq"],
+    "aur": ["some-aur-package"],
+    "optdepends": {
+      "pacman": ["brightnessctl: needed for the brightness slider"]
+    }
+  }
 }
 ```
 
@@ -45,6 +52,28 @@ Entry points are QML `Item`s. Panel, overlay, and menu entry points expose
 `open(payloadJson)` and `close()` for summon/hide; on load the host injects
 `omarchyPath`, `shell`, `manifest`, and the registries (`pluginRegistry` /
 `barWidgetRegistry`) as properties.
+
+A plugin may declare the Arch packages it needs with a `dependencies` block,
+formatted like a PKGBUILD: required packages are plain name arrays split by
+source (`pacman` for repo packages, `aur` for AUR packages), and optional ones
+use the PKGBUILD `optdepends` strings of `"name: reason"`. When `omarchy plugin
+add` finds declared packages missing from the system, it lists them with their
+reasons and asks whether to install them — required ones through
+`omarchy-pkg-add` / `omarchy-pkg-aur-add`, optional ones only if you accept.
+With `--yes`, required packages are installed automatically and optional ones
+are skipped. A missing package never blocks the install itself: the plugin
+lands and can be enabled once its dependencies are in place.
+
+```json
+"dependencies": {
+  "pacman": ["jq"],
+  "aur": ["some-aur-package"],
+  "optdepends": {
+    "pacman": ["brightnessctl: needed for the brightness slider"],
+    "aur": ["google-chrome: needed for the browser widget"]
+  }
+}
+```
 
 Full schema: [`shell/services/PluginRegistry.qml`](../shell/services/PluginRegistry.qml).
 

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -85,15 +85,15 @@ A plugin is a directory with a `manifest.json` and some QML. The manifest declar
 
 A plugin can declare several kinds at once — the media plugin is both a `service` and a `bar-widget`. Bar widgets get an extra `barWidget` block with a display name, a category, an optional `defaultSection`, and `allowMultiple`, which says whether it makes sense to have more than one on the bar. Most widgets set it to `false`; spacers and indicators set it to `true`.
 
+A plugin can also declare the Arch packages it needs with a `dependencies` block, formatted like a PKGBUILD: required packages are plain name arrays split by source (`pacman` for repo packages, `aur` for AUR packages), and optional ones use the PKGBUILD `optdepends` strings of `"name: reason"` explaining why each package is needed. When someone runs `omarchy plugin add` and those packages are missing from the system, the installer lists them and asks whether to install them — with `--yes` it installs the required ones automatically and skips the optional ones. A missing package never blocks the install itself, so a plugin can be added first and its dependencies put in place later.
+
 Before you publish anything, check it:
 
 ```
 omarchy plugin validate ./my-plugin
 ```
 
-That runs the same checks the shell does at load time: the schema version, the required fields, an id that isn't reserved, entry points that are safe relative paths and actually exist, an entry point for every kind you claimed, and no symlinks anywhere inside the folder.
-
-For the full picture, the source is the documentation: `shell/README.md` in the Omarchy repo covers the manifest schema, the shell's IPC contract, and the exact shape of `shell.json`, and `shell/plugins/README.md` lists every first-party plugin with its id, kinds, and entry points.
+That runs the same checks the shell does at load time: the schema version, the required fields, an id that isn't reserved, entry points that are safe relative paths and actually exist, an entry point for every kind you claimed, no symlinks anywhere inside the folder, and a well-formed `dependencies` block.
 
 ## Sharing yours with the world
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -67,6 +67,12 @@ shell should load it. Minimal example:
     "schema": [
       { "key": "format", "type": "string", "label": "Format" }
     ]
+  },
+  "dependencies": {
+    "pacman": ["jq"],
+    "optdepends": {
+      "pacman": ["brightnessctl: needed for the brightness slider"]
+    }
   }
 }
 ```
@@ -81,6 +87,15 @@ Supported `kinds`:
 | `menu`       | A summoned menu surface                                      |
 | `service`    | A headless singleton, no UI                                  |
 | `bar`        | A full bar option that can replace the built-in `omarchy.bar` |
+
+Plugins can declare the Arch packages they need with a `dependencies` block
+(PKGBUILD-style): required packages are plain name arrays split by source
+(`pacman` for repo packages, `aur` for AUR packages), and optional ones use
+the PKGBUILD `optdepends` strings of `"name: reason"`. When `omarchy plugin
+add` finds declared packages missing from the system, it lists them with
+their reasons and asks whether to install them. See
+[../docs/omarchy-shell.md](../docs/omarchy-shell.md) for the full
+contract.
 
 Only one `bar` plugin is active at a time. Missing or invalid selections fall
 back to the built-in `omarchy.bar`, so users always have a safe path home.

--- a/test/shell.d/plugin-add-test.sh
+++ b/test/shell.d/plugin-add-test.sh
@@ -175,3 +175,75 @@ for good in \
     fail "plugin add did not reach git clone for a legitimate URL: $good" "$output"
 done
 pass "plugin add lets legitimate git URLs reach git clone"
+
+# --- Manifest dependencies (PKGBUILD-style) ---------------------------------
+#
+# A plugin may declare required pacman/AUR packages plus PKGBUILD-style
+# "name: reason" optdepends. With --yes the installer installs missing
+# required packages through omarchy-pkg-add / omarchy-pkg-aur-add and skips
+# the optional ones; the stubs record what was offered so the contract is
+# observable without touching the real system.
+
+dep_stubs="$TMPDIR/dep-stubs"
+mkdir -p "$dep_stubs"
+dep_log="$TMPDIR/dep-install.log"
+: >"$dep_log"
+cat >"$dep_stubs/omarchy-shell" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+cat >"$dep_stubs/omarchy-pkg-missing" <<'STUB'
+#!/bin/bash
+# report every package as missing so the install path always runs
+exit 0
+STUB
+cat >"$dep_stubs/omarchy-pkg-add" <<STUB
+#!/bin/bash
+echo "pacman \$*" >>"$dep_log"
+STUB
+cat >"$dep_stubs/omarchy-pkg-aur-add" <<STUB
+#!/bin/bash
+echo "aur \$*" >>"$dep_log"
+STUB
+chmod +x "$dep_stubs"/*
+
+dep_home="$TMPDIR/dep-home"
+mkdir -p "$dep_home/.config/omarchy/plugins"
+dep_incoming="$TMPDIR/dep-incoming"
+mkdir -p "$dep_incoming"
+cat >"$dep_incoming/manifest.json" <<'JSON'
+{
+  "schemaVersion": 1,
+  "id": "acme.deps",
+  "name": "Deps",
+  "version": "1.0.0",
+  "kinds": ["bar-widget"],
+  "entryPoints": { "barWidget": "Widget.qml" },
+  "dependencies": {
+    "pacman": ["jq", "gum"],
+    "aur": ["some-aur-package"],
+    "optdepends": {
+      "pacman": ["brightnessctl: needed for the brightness slider"],
+      "aur": ["google-chrome: needed for the browser widget"]
+    }
+  }
+}
+JSON
+printf 'import QtQuick\nItem {}\n' >"$dep_incoming/Widget.qml"
+git -C "$dep_incoming" init -q
+git -C "$dep_incoming" add .
+git -C "$dep_incoming" -c user.name=Test -c user.email=test@example.com commit -qm "Initial"
+
+output=$(HOME="$dep_home" OMARCHY_PATH="$ROOT" PATH="$dep_stubs:$ROOT/bin:$PATH" \
+  omarchy-plugin-add "$dep_incoming" --yes 2>&1) ||
+  fail "plugin add succeeds when required dependencies install" "$output"
+grep -qF "pacman jq gum" "$dep_log" ||
+  fail "plugin add installs required pacman dependencies" "$(cat "$dep_log")"
+grep -qF "aur some-aur-package" "$dep_log" ||
+  fail "plugin add installs required AUR dependencies" "$(cat "$dep_log")"
+if grep -qF "brightnessctl" "$dep_log" || grep -qF "google-chrome" "$dep_log"; then
+  fail "plugin add skips optional dependencies under --yes" "$(cat "$dep_log")"
+fi
+[[ -d $dep_home/.config/omarchy/plugins/acme.deps ]] ||
+  fail "plugin add still installs the plugin alongside its dependencies" "$output"
+pass "plugin add installs required dependencies and skips optional ones under --yes"

--- a/test/shell.d/plugin-validate-test.sh
+++ b/test/shell.d/plugin-validate-test.sh
@@ -115,3 +115,55 @@ output=$(validate "$dir") && fail "validate refuses an entry point file that is 
 grep -qF "entry point file not found" <<<"$output" \
   || fail "validate reports a missing file as a missing file" "$output"
 pass "validate refuses an entry point file that is not there"
+
+# --- PKGBUILD-style Arch dependencies ---------------------------------------
+#
+# The installer reads 'dependencies' to offer missing packages for install.
+# Required ones are plain name arrays split by source; optional ones use the
+# PKGBUILD "name: reason" optdepends strings. Validation keeps malformed
+# declarations out before anything is offered to the user.
+dir=$(write_plugin "deps-ok" '["bar-widget"]' '{"barWidget": "Widget.qml"}')
+jq '. + {
+  "dependencies": {
+    "pacman": ["jq", "gum"],
+    "aur": ["some-aur-package"],
+    "optdepends": {
+      "pacman": ["brightnessctl: needed for the brightness slider"],
+      "aur": ["google-chrome: needed for the browser widget"]
+    }
+  }
+}' "$dir/manifest.json" >"$dir/manifest.tmp" && mv "$dir/manifest.tmp" "$dir/manifest.json"
+validate "$dir" >/dev/null || fail "validate accepts a well-formed dependencies block"
+pass "validate accepts a well-formed dependencies block"
+
+dir=$(write_plugin "deps-not-object" '["bar-widget"]' '{"barWidget": "Widget.qml"}')
+jq '. + {"dependencies": ["jq"]}' "$dir/manifest.json" >"$dir/manifest.tmp" \
+  && mv "$dir/manifest.tmp" "$dir/manifest.json"
+output=$(validate "$dir") && fail "validate refuses a non-object dependencies block" "$output"
+grep -qF "'dependencies' must be an object" <<<"$output" \
+  || fail "validate explains the dependencies object contract" "$output"
+pass "validate refuses a non-object dependencies block"
+
+dir=$(write_plugin "deps-bad-pacman" '["bar-widget"]' '{"barWidget": "Widget.qml"}')
+jq '. + {"dependencies": {"pacman": "jq"}}' "$dir/manifest.json" >"$dir/manifest.tmp" \
+  && mv "$dir/manifest.tmp" "$dir/manifest.json"
+output=$(validate "$dir") && fail "validate refuses a non-array pacman dependency list" "$output"
+grep -qF "'dependencies.pacman' must be an array of package names" <<<"$output" \
+  || fail "validate explains the pacman dependency array contract" "$output"
+pass "validate refuses a non-array pacman dependency list"
+
+dir=$(write_plugin "deps-bad-optdep" '["bar-widget"]' '{"barWidget": "Widget.qml"}')
+jq '. + {"dependencies": {"optdepends": {"pacman": ["brightnessctl no reason here"]}}}' \
+  "$dir/manifest.json" >"$dir/manifest.tmp" && mv "$dir/manifest.tmp" "$dir/manifest.json"
+output=$(validate "$dir") && fail "validate refuses an optdepends entry without a reason" "$output"
+grep -qF "'dependencies.optdepends.pacman' entries must be 'name: reason' strings" <<<"$output" \
+  || fail "validate explains the optdepends string contract" "$output"
+pass "validate refuses an optdepends entry without a reason"
+
+dir=$(write_plugin "deps-bad-optdep-shape" '["bar-widget"]' '{"barWidget": "Widget.qml"}')
+jq '. + {"dependencies": {"optdepends": "brightnessctl: x"}}' \
+  "$dir/manifest.json" >"$dir/manifest.tmp" && mv "$dir/manifest.tmp" "$dir/manifest.json"
+output=$(validate "$dir") && fail "validate refuses a non-object optdepends block" "$output"
+grep -qF "'dependencies.optdepends' must be an object with pacman/aur arrays" <<<"$output" \
+  || fail "validate explains the optdepends object contract" "$output"
+pass "validate refuses a non-object optdepends block"


### PR DESCRIPTION
Allow plugins to specify Pacman + AUR dependencies - optional or required. The user is then prompted whether they wish to install these during the installation process (similar to installing PKGBUILDs from the AUR).