### PR TITLE
Keep desktop shortcuts out of home

### DIFF
--- a/bin/omarchy-provision-user
+++ b/bin/omarchy-provision-user
@@ -95,10 +95,11 @@ for skill in "$OMARCHY_PATH"/default/agents/skills/*/; do
   ln -sfn "$skill" ~/.gemini/config/skills/"$name"
 done
 
-mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0
+desktop_dir="$HOME/.local/share/desktop"
+mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0 "$desktop_dir"
 xdg-user-dirs-update --set TEMPLATES "$HOME"
 xdg-user-dirs-update --set PUBLICSHARE "$HOME"
-xdg-user-dirs-update --set DESKTOP "$HOME"
+xdg-user-dirs-update --set DESKTOP "$desktop_dir"
 rmdir ~/Templates ~/Public ~/Desktop 2>/dev/null || true
 touch ~/.config/gtk-3.0/bookmarks
 for dir in Downloads Projects Pictures Videos; do

--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -2000,11 +2000,12 @@ mkdir -p "$HOME/.config/omarchy/branding"
 [[ -f $root/icon.txt ]] && cp "$root/icon.txt" "$HOME/.config/omarchy/branding/about.txt"
 [[ -f $root/logo.txt ]] && cp "$root/logo.txt" "$HOME/.config/omarchy/branding/screensaver.txt"
 
-mkdir -p "$HOME/Downloads" "$HOME/Pictures" "$HOME/Videos" "$HOME/Projects" "$HOME/.config/gtk-3.0"
+desktop_dir="$HOME/.local/share/desktop"
+mkdir -p "$HOME/Downloads" "$HOME/Pictures" "$HOME/Videos" "$HOME/Projects" "$HOME/.config/gtk-3.0" "$desktop_dir"
 if command -v xdg-user-dirs-update >/dev/null 2>&1; then
   xdg-user-dirs-update --set TEMPLATES "$HOME" || true
   xdg-user-dirs-update --set PUBLICSHARE "$HOME" || true
-  xdg-user-dirs-update --set DESKTOP "$HOME" || true
+  xdg-user-dirs-update --set DESKTOP "$desktop_dir" || true
 fi
 rmdir "$HOME/Templates" "$HOME/Public" "$HOME/Desktop" 2>/dev/null || true
 touch "$HOME/.config/gtk-3.0/bookmarks"

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -203,7 +203,7 @@ It only does the things `/etc/skel` can't:
   directory there (currently `omarchy` and `diagnose-crash`) so new skills
   need no edit. Symlinks (not copies) so `omarchy dev link` against a dev
   checkout repoints them correctly.
-- `xdg-user-dirs-update` (Templates/Public/Desktop folded back into `$HOME`)
+- `xdg-user-dirs-update` (Templates/Public folded back into `$HOME`; Desktop redirected to `~/.local/share/desktop`)
   and `~/.config/gtk-3.0/bookmarks` (needs `$HOME` expansion).
 - Hyprland's package-owned default input reads `XKBLAYOUT` / `XKBVARIANT`
   from `/etc/vconsole.conf`; no per-user Hyprland config rewrite is needed.

--- a/migrations/1788129995.sh
+++ b/migrations/1788129995.sh
@@ -1,0 +1,14 @@
+echo "Keep desktop shortcuts out of the home directory"
+
+user_dirs="$HOME/.config/user-dirs.dirs"
+desktop_dir="$HOME/.local/share/desktop"
+
+[[ -f $user_dirs ]] || exit 0
+
+unset XDG_DESKTOP_DIR
+source "$user_dirs"
+
+[[ ${XDG_DESKTOP_DIR:-} == $HOME ]] || exit 0
+
+mkdir -p "$desktop_dir"
+xdg-user-dirs-update --set DESKTOP "$desktop_dir"

--- a/test/shell.d/provision-user-test.sh
+++ b/test/shell.d/provision-user-test.sh
@@ -10,7 +10,15 @@ trap 'rm -rf "$test_tmp"' EXIT
 mock_bin="$test_tmp/bin"
 mkdir -p "$mock_bin" "$test_tmp/home"
 
-for command in xdg-user-dirs-update xdg-settings xdg-mime; do
+export XDG_USER_DIR_CALLS="$test_tmp/xdg-user-dir-calls"
+
+cat >"$mock_bin/xdg-user-dirs-update" <<'STUB'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$XDG_USER_DIR_CALLS"
+STUB
+
+for command in xdg-settings xdg-mime; do
   printf '#!/bin/bash\nexit 0\n' >"$mock_bin/$command"
 done
 chmod +x "$mock_bin"/*
@@ -33,3 +41,10 @@ for skill in omarchy diagnose-crash; do
 done
 
 pass "omarchy-provision-user provisions Antigravity skills"
+
+desktop_dir="$test_tmp/home/.local/share/desktop"
+[[ -d $desktop_dir ]] || fail "omarchy-provision-user creates the hidden desktop directory"
+grep -qxF -- "--set DESKTOP $desktop_dir" "$XDG_USER_DIR_CALLS" ||
+  fail "omarchy-provision-user keeps desktop shortcuts out of the home directory" "$(cat "$XDG_USER_DIR_CALLS")"
+
+pass "omarchy-provision-user keeps desktop shortcuts out of the home directory"

--- a/test/shell.d/xdg-desktop-dir-migration-test.sh
+++ b/test/shell.d/xdg-desktop-dir-migration-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1788129995.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mock_bin="$test_dir/bin"
+home="$test_dir/home"
+user_dirs="$home/.config/user-dirs.dirs"
+calls="$test_dir/xdg-user-dir-calls"
+mkdir -p "$mock_bin" "$home/.config"
+
+cat >"$mock_bin/xdg-user-dirs-update" <<'STUB'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$XDG_USER_DIR_CALLS"
+printf 'XDG_DESKTOP_DIR="%s"\n' "$3" >"$HOME/.config/user-dirs.dirs"
+STUB
+chmod +x "$mock_bin/xdg-user-dirs-update"
+
+run_migration() {
+  HOME="$home" XDG_USER_DIR_CALLS="$calls" PATH="$mock_bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+}
+
+printf 'XDG_DESKTOP_DIR="$HOME"\n' >"$user_dirs"
+run_migration
+
+desktop_dir="$home/.local/share/desktop"
+[[ -d $desktop_dir ]] || fail "desktop migration creates the hidden desktop directory"
+grep -qxF -- "--set DESKTOP $desktop_dir" "$calls" ||
+  fail "desktop migration redirects the legacy home desktop" "$(cat "$calls")"
+pass "desktop migration redirects the legacy home desktop"
+
+run_migration
+(( $(wc -l <"$calls") == 1 )) || fail "desktop migration is idempotent" "$(cat "$calls")"
+pass "desktop migration is idempotent"
+
+custom_desktop="$home/Custom Desktop"
+printf 'XDG_DESKTOP_DIR="%s"\n' "$custom_desktop" >"$user_dirs"
+run_migration
+
+[[ $(cat "$user_dirs") == "XDG_DESKTOP_DIR=\"$custom_desktop\"" ]] ||
+  fail "desktop migration preserves a customized desktop directory" "$(cat "$user_dirs")"
+(( $(wc -l <"$calls") == 1 )) || fail "desktop migration does not call xdg-user-dirs-update for a customized desktop"
+pass "desktop migration preserves a customized desktop directory"


### PR DESCRIPTION
## Summary

- redirect the XDG desktop from `$HOME` to `~/.local/share/desktop` for new users and Omarchy 3 upgrades
- migrate existing users only when their desktop directory still resolves exactly to `$HOME`
- preserve customized desktop directories and keep the migration idempotent
- document the hidden desktop target

## Testing

- `bash test/shell.d/provision-user-test.sh`
- `bash test/shell.d/xdg-desktop-dir-migration-test.sh`
- `./test/all` (the changed tests pass; six unrelated environment-dependent tests fail because this checkout lacks `omarchy-pkgs` fixtures or the sandbox lacks the required terminal, network, or privilege state)

Closes #9556
