### PR TITLE
fix: keep XDG desktop out of home

### DIFF
--- a/bin/omarchy-provision-user
+++ b/bin/omarchy-provision-user
@@ -95,10 +95,10 @@ for skill in "$OMARCHY_PATH"/default/agents/skills/*/; do
   ln -sfn "$skill" ~/.gemini/config/skills/"$name"
 done
 
-mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0
+mkdir -p ~/Downloads ~/Pictures ~/Videos ~/.config/gtk-3.0 ~/.local/share/desktop
 xdg-user-dirs-update --set TEMPLATES "$HOME"
 xdg-user-dirs-update --set PUBLICSHARE "$HOME"
-xdg-user-dirs-update --set DESKTOP "$HOME"
+xdg-user-dirs-update --set DESKTOP "$HOME/.local/share/desktop"
 rmdir ~/Templates ~/Public ~/Desktop 2>/dev/null || true
 touch ~/.config/gtk-3.0/bookmarks
 for dir in Downloads Projects Pictures Videos; do

--- a/migrations/1788246827.sh
+++ b/migrations/1788246827.sh
@@ -1,0 +1,6 @@
+echo "Move the XDG Desktop target out of the home directory"
+
+if [[ $(xdg-user-dir DESKTOP) == "$HOME" ]]; then
+  mkdir -p "$HOME/.local/share/desktop"
+  xdg-user-dirs-update --set DESKTOP "$HOME/.local/share/desktop"
+fi

--- a/test/shell.d/provision-user-test.sh
+++ b/test/shell.d/provision-user-test.sh
@@ -10,7 +10,12 @@ trap 'rm -rf "$test_tmp"' EXIT
 mock_bin="$test_tmp/bin"
 mkdir -p "$mock_bin" "$test_tmp/home"
 
-for command in xdg-user-dirs-update xdg-settings xdg-mime; do
+cat >"$mock_bin/xdg-user-dirs-update" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TEST_XDG_USER_DIRS_CALLS"
+SH
+
+for command in update-desktop-database xdg-settings xdg-mime; do
   printf '#!/bin/bash\nexit 0\n' >"$mock_bin/$command"
 done
 chmod +x "$mock_bin"/*
@@ -22,9 +27,17 @@ chmod +x "$mock_bin"/*
 mkdir -p "$test_tmp/install/user"
 : >"$test_tmp/install/user/all.sh"
 
+xdg_user_dirs_calls="$test_tmp/xdg-user-dirs-calls"
 HOME="$test_tmp/home" PATH="$mock_bin:$ROOT/bin:$PATH" OMARCHY_PATH="$ROOT" \
+  TEST_XDG_USER_DIRS_CALLS="$xdg_user_dirs_calls" \
   OMARCHY_INSTALL="$test_tmp/install" bash "$ROOT/bin/omarchy-provision-user" >/dev/null ||
   fail "omarchy-provision-user finishes"
+
+grep -qxF -- "--set DESKTOP $test_tmp/home/.local/share/desktop" "$xdg_user_dirs_calls" ||
+  fail "omarchy-provision-user points XDG Desktop at a hidden directory"
+[[ -d $test_tmp/home/.local/share/desktop ]] ||
+  fail "omarchy-provision-user creates the hidden Desktop directory"
+pass "omarchy-provision-user points XDG Desktop at a hidden directory"
 
 for skill in omarchy diagnose-crash; do
   link="$test_tmp/home/.gemini/config/skills/$skill"

--- a/test/shell.d/xdg-desktop-migration-test.sh
+++ b/test/shell.d/xdg-desktop-migration-test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+migration=$(grep -rl 'Move the XDG Desktop target out of the home directory' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "XDG Desktop migration exists"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/xdg-user-dir" <<'SH'
+#!/bin/bash
+[[ $1 == "DESKTOP" ]]
+source "$HOME/.config/user-dirs.dirs"
+printf '%s\n' "$XDG_DESKTOP_DIR"
+SH
+
+cat >"$mock_bin/xdg-user-dirs-update" <<'SH'
+#!/bin/bash
+[[ $1 == "--set" && $2 == "DESKTOP" ]]
+printf '%s\n' "$*" >>"$TEST_XDG_USER_DIRS_CALLS"
+printf 'XDG_DESKTOP_DIR="$HOME/.local/share/desktop"\n' >"$HOME/.config/user-dirs.dirs"
+SH
+chmod +x "$mock_bin"/*
+
+legacy_home="$test_tmp/legacy-home"
+mkdir -p "$legacy_home/.config" "$legacy_home/Desktop"
+printf 'XDG_DESKTOP_DIR="$HOME"\n' >"$legacy_home/.config/user-dirs.dirs"
+printf 'home shortcut\n' >"$legacy_home/steam.desktop"
+printf 'desktop shortcut\n' >"$legacy_home/Desktop/existing.desktop"
+
+calls="$test_tmp/xdg-user-dirs-calls"
+HOME="$legacy_home" PATH="$mock_bin:$PATH" TEST_XDG_USER_DIRS_CALLS="$calls" \
+  bash -euo pipefail "$migration" >/dev/null
+
+grep -qxF "XDG_DESKTOP_DIR=\"\$HOME/.local/share/desktop\"" "$legacy_home/.config/user-dirs.dirs" ||
+  fail "migration moves an exact HOME Desktop target to the hidden directory"
+[[ -d $legacy_home/.local/share/desktop ]] ||
+  fail "migration creates the hidden Desktop directory"
+[[ $(cat "$legacy_home/steam.desktop") == "home shortcut" ]] ||
+  fail "migration preserves desktop files already in HOME"
+[[ $(cat "$legacy_home/Desktop/existing.desktop") == "desktop shortcut" ]] ||
+  fail "migration preserves files in the old Desktop directory"
+pass "migration updates only the Desktop target without moving or deleting files"
+
+HOME="$legacy_home" PATH="$mock_bin:$PATH" TEST_XDG_USER_DIRS_CALLS="$calls" \
+  bash -euo pipefail "$migration" >/dev/null
+[[ $(wc -l <"$calls") -eq 1 ]] || fail "XDG Desktop migration is idempotent"
+pass "XDG Desktop migration is idempotent"
+
+custom_home="$test_tmp/custom-home"
+mkdir -p "$custom_home/.config"
+printf 'XDG_DESKTOP_DIR="$HOME/workspace"\n' >"$custom_home/.config/user-dirs.dirs"
+
+HOME="$custom_home" PATH="$mock_bin:$PATH" TEST_XDG_USER_DIRS_CALLS="$calls" \
+  bash -euo pipefail "$migration" >/dev/null
+
+grep -qxF "XDG_DESKTOP_DIR=\"\$HOME/workspace\"" "$custom_home/.config/user-dirs.dirs" ||
+  fail "migration preserves a custom XDG Desktop target"
+[[ $(wc -l <"$calls") -eq 1 ]] || fail "migration does not rewrite a custom XDG Desktop target"
+pass "migration preserves a custom XDG Desktop target"


### PR DESCRIPTION
## Summary

- point new installs at `$HOME/.local/share/desktop` instead of using the home directory as the XDG Desktop
- add an idempotent migration that only changes the legacy exact-`$HOME` setting
- preserve custom Desktop paths and leave existing `.desktop` files untouched
- add focused coverage for provisioning, migration, idempotency, and custom paths

Fixes #9556.

## Verification

- `bash -n bin/omarchy-provision-user migrations/1788246827.sh test/shell.d/provision-user-test.sh test/shell.d/xdg-desktop-migration-test.sh`
- `bash test/shell.d/provision-user-test.sh`
- `bash test/shell.d/xdg-desktop-migration-test.sh`
- `git diff --check`

The focused tests pass. I also attempted the repository-wide scripts, but the local macOS environment has Bash 3.2 and lacks the GNU/Linux tools expected by the Arch-focused test harness; CI should provide the authoritative full-suite result.

AI assistance from TRAE was used for repository analysis, test drafting, and review. I reviewed the complete diff and ran the verification above.