### PR TITLE
Clear set-ID bits from Windows VM mount sources

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,7 +580,7 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  chmod a-s,u=rwx,go= -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1

--- a/test/shell.d/windows-vm-mount-boundary-test.sh
+++ b/test/shell.d/windows-vm-mount-boundary-test.sh
@@ -87,11 +87,13 @@ TEST_PASSWD_HOME=/home/alice
 resolve_caller || fail "valid root PKEXEC_UID/home boundary was rejected"
 pass "root dispatch rejects missing/invalid uid, passwd, owner, symlink, and writable-parent boundaries without mutation"
 
-# Put each familiar source on its own filesystem. Both start with legacy 0755
-# permissions and world-readable payloads to prove migration hardens the leaves.
+# Put each familiar source on its own filesystem. Both start with legacy 2755
+# permissions and world-readable payloads to prove migration clears set-ID bits
+# while hardening the leaves.
 mkdir /home/storage-target /home/shared-target
 mount -t tmpfs -o uid=1000,gid=1000,mode=0755,size=3g storage-test /home/storage-target
 mount -t tmpfs -o uid=1000,gid=1000,mode=0755,size=64m shared-test /home/shared-target
+chmod 2755 /home/storage-target /home/shared-target
 ln -s /home/storage-target /home/alice/.windows
 ln -s /home/shared-target /home/alice/Windows
 chown -h 1000:1000 /home/alice/.windows /home/alice/Windows
@@ -103,6 +105,8 @@ chmod 0644 /home/storage-target/disk.img /home/shared-target/shared.txt
 home_dev=$(command stat -Lc '%d' /home/alice)
 storage_dev=$(command stat -Lc '%d' /home/storage-target)
 [[ $home_dev != "$storage_dev" ]] || fail "storage target did not land on a separate filesystem"
+[[ $(command stat -Lc '%u:%a' /home/storage-target) == 1000:2755 &&
+  $(command stat -Lc '%u:%a' /home/shared-target) == 1000:2755 ]] || fail "test sources did not start with setgid permissions"
 
 with_vm_lock prepare_caller_mounts || fail "root could not create verified production bind anchors"
 resolve_caller


### PR DESCRIPTION
## Summary

- Explicitly clear set-ID bits while normalizing the pinned Windows VM storage and shared directories to mode `700`.
- Preserve the existing strict permission verification before creating Docker-facing bind mounts.
- Extend the mount-boundary regression test to cover legacy directories starting with mode `2755`.

## Testing

- `bash test/shell.d/windows-vm-mount-boundary-test.sh`
- `bash test/shell.d/windows-vm-test.sh`
- `./test/cli`
- `bash -n bin/omarchy-windows-vm test/shell.d/windows-vm-mount-boundary-test.sh`
- Verified setuid, setgid, and sticky-bit mode combinations normalize to `700`.

Fixes #9374