### PR TITLE
Keep fcitx5 aligned with Hyprland keyboard layouts

### DIFF
--- a/bin/omarchy-fcitx5-layout-sync
+++ b/bin/omarchy-fcitx5-layout-sync
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# omarchy:summary=Keep fcitx5's keyboard engine in sync with Hyprland's active XKB layout.
+
+set -euo pipefail
+
+readonly FCITX_SERVICE=org.fcitx.Fcitx5
+readonly FCITX_PATH=/controller
+readonly FCITX_INTERFACE=org.fcitx.Fcitx.Controller1
+readonly SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
+readonly STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
+readonly MANAGED_ENGINES_FILE="$STATE_DIR/fcitx5-hyprland-layouts"
+
+declare -a layout_engines=() managed_engines=()
+
+load_layout_engines() {
+  local layouts variants layout variant engine
+  local -a layout_list variant_list
+
+  layouts=$(hyprctl getoption input:kb_layout -j | jq -r '.str')
+  variants=$(hyprctl getoption input:kb_variant -j | jq -r '.str')
+  IFS=',' read -r -a layout_list <<<"$layouts"
+  IFS=',' read -r -a variant_list <<<"$variants"
+
+  layout_engines=()
+  managed_engines=()
+  for index in "${!layout_list[@]}"; do
+    layout=${layout_list[$index]//[[:space:]]/}
+    [[ -n $layout ]] || continue
+
+    variant=${variant_list[$index]:-}
+    variant=${variant//[[:space:]]/}
+    engine="keyboard-$layout"
+    [[ -n $variant ]] && engine+="-$variant"
+
+    # Keep one engine per Hyprland index for event mapping, even if two slots
+    # intentionally use the same layout. The fcitx5 group itself is unique.
+    layout_engines+=("$engine")
+    [[ " ${managed_engines[*]} " == *" $engine "* ]] || managed_engines+=("$engine")
+  done
+}
+
+arrays_equal() {
+  local left_name=$1 right_name=$2
+  local -n left=$left_name right=$right_name
+
+  [[ ${#left[@]} -eq ${#right[@]} ]] || return 1
+  for index in "${!left[@]}"; do
+    [[ ${left[$index]} == "${right[$index]}" ]] || return 1
+  done
+}
+
+configure_managed_group() {
+  local group group_info default_im default_layout current_im marker
+  local previous_group previous_layout
+  local -a current_engines previous_engines command
+
+  ((${#managed_engines[@]})) || return 0
+
+  group=$(fcitx5-remote -q)
+  group_info=$(busctl --user --json=short call \
+    "$FCITX_SERVICE" "$FCITX_PATH" "$FCITX_INTERFACE" \
+    FullInputMethodGroupInfo s "$group")
+
+  default_im=$(jq -r '.data[1]' <<<"$group_info")
+  default_layout=$(jq -r '.data[2]' <<<"$group_info")
+  mapfile -t current_engines < <(jq -r '.data[4][][0]' <<<"$group_info")
+
+  if [[ -f $MANAGED_ENGINES_FILE ]]; then
+    previous_group=$(sed -n '1s/^group=//p' "$MANAGED_ENGINES_FILE")
+    previous_layout=$(sed -n '2s/^layout=//p' "$MANAGED_ENGINES_FILE")
+    mapfile -s 2 -t previous_engines <"$MANAGED_ENGINES_FILE"
+    [[ $group == "$previous_group" && $default_layout == "$previous_layout" ]] || return 0
+    arrays_equal current_engines previous_engines || return 0
+  elif [[ $group != Default || $default_layout != us || $default_im != keyboard-us ]] ||
+    [[ ${#current_engines[@]} -ne 1 || ${current_engines[0]} != keyboard-us ]]; then
+    # A non-default group belongs to the user. It may contain language engines
+    # whose order and default must not be rewritten behind their back.
+    return 0
+  fi
+
+  arrays_equal current_engines managed_engines && return 0
+
+  current_im=$(fcitx5-remote -n)
+  command=(busctl --user call "$FCITX_SERVICE" "$FCITX_PATH" "$FCITX_INTERFACE"
+    SetInputMethodGroupInfo 'ssa(ss)' "$group" "$default_layout" "${#managed_engines[@]}")
+  for engine in "${managed_engines[@]}"; do
+    command+=("$engine" "")
+  done
+  "${command[@]}" >/dev/null
+
+  # SetInputMethodGroupInfo chooses one of the new items as the default. Put the
+  # user's current keyboard back before following Hyprland's active index.
+  [[ -n $current_im ]] && fcitx5-remote -s "$current_im"
+
+  mkdir -p "$STATE_DIR"
+  marker=$(mktemp "$STATE_DIR/.fcitx5-hyprland-layouts.XXXXXX")
+  printf 'group=%s\nlayout=%s\n' "$group" "$default_layout" >"$marker"
+  printf '%s\n' "${managed_engines[@]}" >>"$marker"
+  mv "$marker" "$MANAGED_ENGINES_FILE"
+}
+
+active_layout_index() {
+  local keyboard_name=${1:-}
+
+  hyprctl devices -j | jq -r --arg keyboard "$keyboard_name" '
+    [.keyboards[]
+      | select(.name | test("^(hl-virtual-keyboard|power-button|sleep-button|lid-switch|video-bus)") | not)
+      | select($keyboard == "" or .name == $keyboard)]
+    | if length == 0 then empty
+      elif $keyboard == "" then max_by(.active_layout_index).active_layout_index
+      else .[0].active_layout_index
+      end
+  '
+}
+
+sync_active_layout() {
+  local keyboard_name=${1:-} index target current_im
+
+  [[ $keyboard_name != hl-virtual-keyboard* ]] || return 0
+  index=$(active_layout_index "$keyboard_name")
+  [[ $index =~ ^[0-9]+$ ]] || return 0
+  target=${layout_engines[$index]:-}
+  [[ -n $target ]] || return 0
+
+  current_im=$(fcitx5-remote -n)
+  [[ $current_im == keyboard-* ]] || return 0
+  [[ $current_im == "$target" ]] || fcitx5-remote -s "$target"
+}
+
+wait_for_fcitx5() {
+  for _ in {1..50}; do
+    fcitx5-remote --check >/dev/null 2>&1 && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+refresh_layouts() {
+  load_layout_engines
+  configure_managed_group
+  sync_active_layout
+}
+
+wait_for_fcitx5
+refresh_layouts
+[[ ${1:-} == --once ]] && exit 0
+
+while read -r event; do
+  case "$event" in
+  activelayout\>\>*)
+    payload=${event#*>>}
+    sync_active_layout "${payload%%,*}"
+    ;;
+  configreloaded\>\>*)
+    refresh_layouts
+    ;;
+  esac
+done < <(socat -U - "UNIX-CONNECT:$SOCKET")
+
+# Let systemd restart us if the compositor's event socket disappeared without
+# graphical-session.target stopping (for example, during a compositor restart).
+exit 1

--- a/default/systemd/user/omarchy-fcitx5-layout-sync.service
+++ b/default/systemd/user/omarchy-fcitx5-layout-sync.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Keep fcitx5 aligned with Hyprland keyboard layouts
+After=omarchy-fcitx5.service
+BindsTo=omarchy-fcitx5.service
+PartOf=graphical-session.target
+ConditionEnvironment=HYPRLAND_INSTANCE_SIGNATURE
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-fcitx5-layout-sync
+Restart=on-failure
+RestartSec=2

--- a/default/systemd/user/omarchy-fcitx5.service
+++ b/default/systemd/user/omarchy-fcitx5.service
@@ -9,6 +9,7 @@ After=graphical-session.target
 # The wayland connection dies with the compositor, so follow the session rather
 # than linger against a socket that is gone.
 PartOf=graphical-session.target
+Wants=omarchy-fcitx5-layout-sync.service
 # After= is ordering only -- it does not stop anything from starting this unit
 # while the target is inactive. An `omarchy update` over SSH has a live user
 # manager (pam_systemd) and no graphical session, and a fcitx5 started there

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -61,6 +61,8 @@ On Dell XPS laptops with a haptic touchpad, you can also set the click strength 
 
 Omarchy runs the [fcitx5](https://fcitx-im.org/) input method framework as part of every session — it's what powers the CapsLock compose sequences. That means the plumbing for non-Latin input is already in place: install an input engine like `fcitx5-mozc` (Japanese) or `fcitx5-chinese-addons` (Chinese) with `omarchy pkg add`, plus `fcitx5-configtool` to add the engine to your input methods and set the key that switches between them.
 
+When the default fcitx5 group contains only Omarchy's keyboard engines, Omarchy keeps its active engine aligned with the layout selected by Hyprland. This makes `kb_layout = "us,dk"` and XKB group-switching shortcuts work in applications that receive their input through fcitx5 as well as native Wayland applications. Once you customize the fcitx5 group, Omarchy leaves its contents alone; add a keyboard engine matching each Hyprland layout in `fcitx5-configtool` if you want Hyprland to keep switching those engines.
+
 ### Use ALT as SUPER
 
 On some keyboards, it's not convenient to use the primary meta key (Windows/cmd key) as SUPER. You can change this to be ALT instead using this change:

--- a/test/shell.d/fcitx5-layout-sync-test.sh
+++ b/test/shell.d/fcitx5-layout-sync-test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+export HOME="$TEST_HOME/home"
+export XDG_RUNTIME_DIR="$TEST_HOME/run"
+export XDG_STATE_HOME="$TEST_HOME/state"
+export HYPRLAND_INSTANCE_SIGNATURE=test
+mkdir -p "$HOME" "$XDG_RUNTIME_DIR/hypr/test" "$TEST_HOME/bin"
+
+export MOCK_LOG="$TEST_HOME/calls"
+export MOCK_LAYOUTS=us,ir
+export MOCK_VARIANTS=
+export MOCK_ACTIVE_INDEX=1
+export MOCK_CURRENT_IM=keyboard-us
+export MOCK_GROUP_INFO='{"type":"sssa{sv}a(sssssssbsa{sv})","data":["Default","keyboard-us","us",{},[["keyboard-us","Keyboard - English (US)","","input-keyboard","en","en","keyboard",true,"",{}]]]}'
+
+make_mock() {
+  local name=$1 body=$2
+  printf '#!/bin/bash\n%s\n' "$body" >"$TEST_HOME/bin/$name"
+  chmod +x "$TEST_HOME/bin/$name"
+}
+
+make_mock hyprctl 'case "$1:$2" in
+  getoption:input:kb_layout) jq -nc --arg str "$MOCK_LAYOUTS" '\''{str:$str}'\'' ;;
+  getoption:input:kb_variant) jq -nc --arg str "$MOCK_VARIANTS" '\''{str:$str}'\'' ;;
+  devices:-j) jq -nc --argjson index "$MOCK_ACTIVE_INDEX" '\''{keyboards:[{name:"at-translated-set-2-keyboard",active_layout_index:$index},{name:"hl-virtual-keyboard-fcitx5",active_layout_index:0}]}'\'' ;;
+esac'
+
+make_mock fcitx5-remote 'case "${1:-}" in
+  --check) exit 0 ;;
+  -q) echo Default ;;
+  -n) echo "$MOCK_CURRENT_IM" ;;
+  -s) printf "remote %s\\n" "$2" >>"$MOCK_LOG" ;;
+esac'
+
+make_mock busctl 'printf "busctl" >>"$MOCK_LOG"; printf " <%s>" "$@" >>"$MOCK_LOG"; printf "\\n" >>"$MOCK_LOG"
+[[ " $* " == *" FullInputMethodGroupInfo "* ]] && printf "%s\\n" "$MOCK_GROUP_INFO"
+exit 0'
+
+PATH="$TEST_HOME/bin:$PATH" "$ROOT/bin/omarchy-fcitx5-layout-sync" --once
+
+grep -F '<SetInputMethodGroupInfo> <ssa(ss)> <Default> <us> <2> <keyboard-us> <> <keyboard-ir> <>' "$MOCK_LOG" >/dev/null ||
+  fail "the untouched fcitx5 group did not gain every Hyprland keyboard layout"
+grep -Fx 'remote keyboard-ir' "$MOCK_LOG" >/dev/null ||
+  fail "fcitx5 did not follow the active physical keyboard layout"
+grep -Fx 'group=Default' "$XDG_STATE_HOME/omarchy/fcitx5-hyprland-layouts" >/dev/null
+grep -Fx 'layout=us' "$XDG_STATE_HOME/omarchy/fcitx5-hyprland-layouts" >/dev/null
+grep -Fx 'keyboard-us' "$XDG_STATE_HOME/omarchy/fcitx5-hyprland-layouts" >/dev/null
+grep -Fx 'keyboard-ir' "$XDG_STATE_HOME/omarchy/fcitx5-hyprland-layouts" >/dev/null
+pass "default fcitx5 group follows Hyprland's active XKB layout"
+
+: >"$MOCK_LOG"
+export MOCK_GROUP_INFO='{"type":"sssa{sv}a(sssssssbsa{sv})","data":["Default","pinyin","us",{},[["keyboard-us","Keyboard - English (US)","","input-keyboard","en","en","keyboard",true,"",{}],["pinyin","Pinyin","","input-keyboard","zh","zh","pinyin",true,"",{}]]]}'
+rm "$XDG_STATE_HOME/omarchy/fcitx5-hyprland-layouts"
+
+PATH="$TEST_HOME/bin:$PATH" "$ROOT/bin/omarchy-fcitx5-layout-sync" --once
+
+grep -F '<SetInputMethodGroupInfo>' "$MOCK_LOG" >/dev/null &&
+  fail "a customized fcitx5 group was overwritten"
+pass "custom fcitx5 input-method groups remain user-owned"
+
+: >"$MOCK_LOG"
+export MOCK_CURRENT_IM=pinyin
+
+PATH="$TEST_HOME/bin:$PATH" "$ROOT/bin/omarchy-fcitx5-layout-sync" --once
+
+grep -F 'remote keyboard-ir' "$MOCK_LOG" >/dev/null &&
+  fail "Hyprland layout changes displaced an active language input method"
+pass "active non-keyboard input methods are not displaced"

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -70,6 +70,16 @@ grep -Fx 'WantedBy=graphical-session.target' "$fcitx_service" >/dev/null ||
   fail "fcitx5 is never pulled in at login without a WantedBy"
 grep -Fx 'ConditionEnvironment=WAYLAND_DISPLAY' "$fcitx_service" >/dev/null ||
   fail "an update over SSH has a live user manager and no display; starting fcitx5 there wedges the unit active-but-blind, and Wants= will not replace it at graphical login"
+grep -Fx 'Wants=omarchy-fcitx5-layout-sync.service' "$fcitx_service" >/dev/null ||
+  fail "fcitx5 is not paired with the service that follows Hyprland's active keyboard layout"
+
+fcitx_layout_sync_service="$ROOT/default/systemd/user/omarchy-fcitx5-layout-sync.service"
+grep -Fx 'After=omarchy-fcitx5.service' "$fcitx_layout_sync_service" >/dev/null ||
+  fail "layout synchronization can run before fcitx5 owns its controller bus name"
+grep -Fx 'BindsTo=omarchy-fcitx5.service' "$fcitx_layout_sync_service" >/dev/null ||
+  fail "layout synchronization can outlive the fcitx5 process it controls"
+grep -Fx 'ConditionEnvironment=HYPRLAND_INSTANCE_SIGNATURE' "$fcitx_layout_sync_service" >/dev/null ||
+  fail "layout synchronization starts without a Hyprland event socket"
 
 fcitx_migration="$ROOT/migrations/1785167800.sh"
 grep -F 'is-active --quiet graphical-session.target' "$fcitx_migration" >/dev/null ||


### PR DESCRIPTION
## Summary

- keep fcitx5's keyboard engine aligned with Hyprland `activelayout` events
- add the configured XKB layouts only to an untouched or previously Omarchy-managed fcitx5 group
- preserve customized groups and active non-keyboard input methods, while ignoring fcitx5's virtual-keyboard events
- document how synchronization interacts with custom fcitx5 groups

## Testing

- `test/shell.d/fcitx5-layout-sync-test.sh`
- `test/shell.d/systemd-test.sh`
- `./test/all` (new coverage passes; the suite retains five unrelated baseline failures: three require the separate `omarchy-pkgs` checkout, two upstream test files are not executable, and the headless terminal-size animation assertion fails)

Closes #9552
