### PR TITLE
Defer XCompose reloads from migrations

### DIFF
--- a/migrations/1788102906.sh
+++ b/migrations/1788102906.sh
@@ -6,14 +6,14 @@ legacy_xcompose_pattern='^[[:space:]]*include[[:space:]]+"[^"]*/\.local/share/om
 
 # Omarchy 3 pointed the user's compose file through the checkout compatibility
 # link. Preserve their own sequences while moving that include to the packaged
-# tree. A failed live restart is harmless: the next graphical login reads the
-# repaired file.
+# tree. Do not restart fcitx5 from an unattended migration: X11 applications
+# can retain input-method objects owned by the old process and crash when they
+# use them later. The repaired file takes effect at the next graphical login.
 if [[ -f $xcompose ]] && grep -Eq "$legacy_xcompose_pattern" "$xcompose"; then
   xcompose_replacement=${packaged_xcompose//\\/\\\\}
   xcompose_replacement=${xcompose_replacement//&/\\&}
   xcompose_replacement=${xcompose_replacement//|/\\|}
   sed -i -E "s|^([[:space:]]*include[[:space:]]+\")[^\"]*/\\.local/share/omarchy/default/xcompose\"[[:space:]]*$|\\1$xcompose_replacement\"|" "$xcompose"
-  omarchy-restart-xcompose >/dev/null 2>&1 || true
 fi
 
 rules_dir=/etc/udev/rules.d

--- a/test/shell.d/legacy-power-udev-rules-migration-test.sh
+++ b/test/shell.d/legacy-power-udev-rules-migration-test.sh
@@ -162,15 +162,15 @@ for legacy_include in \
     fail "migration repoints $legacy_include at the active Omarchy tree" "$(cat "$xcompose")"
   grep -qF '<Multi_key> <space> <e> : "test@example.com"' "$xcompose" ||
     fail "migration discards the user's own compose sequences"
-  grep -qxF 'omarchy-restart-xcompose' "$CALLS" ||
-    fail "migration does not reload XCompose after rewriting its include" "$(cat "$CALLS")"
+  ! grep -qxF 'omarchy-restart-xcompose' "$CALLS" ||
+    fail "migration restarts XCompose in running applications" "$(cat "$CALLS")"
 done
-pass "migration repoints every legacy XCompose include and preserves custom sequences"
+pass "migration repoints every legacy XCompose include without restarting the input method"
 
 before=$(sha256sum "$xcompose")
 run_migration
 [[ $(sha256sum "$xcompose") == "$before" ]] || fail "migration changes an already repaired XCompose file"
-[[ ! -s $CALLS ]] || fail "migration restarts XCompose when nothing changed" "$(cat "$CALLS")"
+[[ ! -s $CALLS ]] || fail "migration acts when XCompose needs no repair" "$(cat "$CALLS")"
 pass "migration is idempotent on an already repaired XCompose file"
 
 reset_machine


### PR DESCRIPTION
## Summary

Stop the legacy XCompose migration from restarting fcitx5 while graphical applications are running.

The migration still repairs every supported Omarchy 3 include and preserves the user's custom compose sequences. The updated configuration is picked up at the next graphical login. This avoids invalidating XIM objects retained by X11 clients such as Steam, which can otherwise crash later when they create another input context.

The manual `omarchy-restart-xcompose` command is unchanged for users who explicitly choose a live reload.

Closes #9541

## Test plan

- `bash -n migrations/1788102906.sh test/shell.d/legacy-power-udev-rules-migration-test.sh`
- `./test/shell.d/legacy-power-udev-rules-migration-test.sh`
- `./test/all` (changed test passes; suite retains five unrelated baseline failures: three require an `omarchy-pkgs` checkout, plus the existing launch-about and network-QR assertions)

## Related work

PR #9282 changes the XCompose include layout for sandboxed applications. If it lands, its migration should likewise leave live input-method reloads to an explicit user action or the next graphical login.
