### PR TITLE
Rearm idle monitor after timeout changes

### DIFF
--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -25,6 +25,15 @@ Item {
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
+  // Quickshell updates IdleMonitor.timeout without replacing the underlying
+  // ext-idle-notification, which leaves the live monitor silent. Pulse it off
+  // across an event-loop turn so a shell.json timeout change registers a new
+  // notification instead of silently disabling screensaver and lock events.
+  onFirstIdleTimeoutSecondsChanged: if (root.idleEnabled) {
+    root.logEvent("idle-monitor-rearm", "timeout=" + root.firstIdleTimeoutSeconds)
+    idleMonitorRearmTimer.restart()
+  }
+
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
   property bool hasPendingStayAwakePersist: false
@@ -192,6 +201,7 @@ Item {
       lockDelay: root.lockDelaySeconds,
       screensaverWindows: root.screensaverWindowCount,
       timers: {
+        idleMonitorRearm: idleMonitorRearmTimer.running,
         screensaver: screensaverTimer.running,
         lock: lockTimer.running,
         screensaverLaunchGrace: screensaverLaunchGraceTimer.running
@@ -249,10 +259,16 @@ Item {
 
   IdleMonitor {
     id: idleMonitor
-    enabled: root.idleEnabled
+    enabled: root.idleEnabled && !idleMonitorRearmTimer.running
     timeout: root.firstIdleTimeoutSeconds
     respectInhibitors: true
     onIsIdleChanged: root.handleIdleChanged()
+  }
+
+  Timer {
+    id: idleMonitorRearmTimer
+    interval: 150
+    repeat: false
   }
 
   Timer {

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
+const fs = require('fs')
 const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
+const serviceSource = fs.readFileSync(root + '/shell/plugins/services/idle/Service.qml', 'utf8')
 
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
@@ -33,6 +35,23 @@ assertDeepEqual(
   { windows: { a: true }, count: 1 },
   'idle leaves screensaver windows unchanged without an address'
 )
+
+assert(
+  /onFirstIdleTimeoutSecondsChanged:[\s\S]*?idleMonitorRearmTimer\.restart\(\)/.test(serviceSource),
+  'idle re-arms its monitor when the configured first timeout changes'
+)
+
+const idleMonitor = serviceSource.slice(serviceSource.indexOf('  IdleMonitor {'))
+  .split('\n  }', 1)[0]
+assert(
+  /enabled: root\.idleEnabled && !idleMonitorRearmTimer\.running/.test(idleMonitor),
+  'idle monitor stays disabled for the re-arm timer turn'
+)
+
+const rearmTimer = serviceSource.slice(serviceSource.indexOf('    id: idleMonitorRearmTimer'))
+  .split('\n  }', 1)[0]
+assert(/interval: 150/.test(rearmTimer), 'idle re-arm spans a tested event-loop delay')
+assert(/repeat: false/.test(rearmTimer), 'idle re-arm only pulses the monitor once per timeout change')
 JS
 
 test_tmp=$(mktemp -d)


### PR DESCRIPTION
## Summary

Re-arm Quickshell's `IdleMonitor` when a live `shell.json` edit changes the effective first idle timeout.

Changing `idle.screensaver` or `idle.lock` updates the QML timeout immediately, but affected Quickshell sessions can leave the underlying Wayland idle notification silent. The shell then reports the new values while screensaver, lock, and display-idle events never fire until a restart.

The idle service now pulses the monitor off for 150 ms and declaratively re-enables it with the new timeout. This spans the event-loop delay validated in the issue reproduction, remains gated by Stay Awake, coalesces rapid edits by restarting the one-shot timer, and exposes the re-arm state in idle diagnostics.

Closes #9496

## Test plan

- `bash test/shell.d/idle-test.sh`
- `/usr/lib/qt6/bin/qmllint -I /usr/lib/qt6/qml -I shell shell/plugins/services/idle/Service.qml` (only existing `QProcess::ExitStatus` import warnings)
- `./test/shell` (changed test passes; suite retains five unrelated baseline failures: three require an `omarchy-pkgs` checkout, plus the existing launch-about and network-QR assertions)
