### PR TITLE
Resolve the invoking user's home in removal cleanup scripts

### DIFF
--- a/bin/omarchy-remove-ai-chatgpt
+++ b/bin/omarchy-remove-ai-chatgpt
@@ -5,13 +5,23 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 omarchy-pkg-drop openai-codex-desktop
 
 # Not ~/.cache/codex-runtimes: the Codex CLI resolves its own runtime under
 # there, and it ships in a different package that survives this one.
 rm -rf \
-  "$HOME/.config/Codex" \
-  "$HOME/.cache/Codex"
+  "$target_home/.config/Codex" \
+  "$target_home/.cache/Codex"
 
 echo ""
 echo "ChatGPT has been removed."

--- a/bin/omarchy-remove-ai-grok-bot
+++ b/bin/omarchy-remove-ai-grok-bot
@@ -5,12 +5,22 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 omarchy-pkg-drop grok-bot
 
 # Not ~/.grok: that is the Grok CLI, which is installed and used on its own.
 rm -rf \
-  "$HOME/.config/Grok Bot" \
-  "$HOME/.grokbot"
+  "$target_home/.config/Grok Bot" \
+  "$target_home/.grokbot"
 
 echo ""
 echo "Grok Bot has been removed."

--- a/bin/omarchy-remove-ai-lm-studio
+++ b/bin/omarchy-remove-ai-lm-studio
@@ -5,23 +5,33 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 omarchy-pkg-drop lmstudio-bin
 
 # LM Studio's home is relocatable and the pointer is the only record of where
 # the models went, so it has to be read before it is deleted with everything else.
 lmstudio_home=""
-if [[ -f $HOME/.lmstudio-home-pointer ]]; then
-  read -r lmstudio_home <"$HOME/.lmstudio-home-pointer" || true
+if [[ -f $target_home/.lmstudio-home-pointer ]]; then
+  read -r lmstudio_home <"$target_home/.lmstudio-home-pointer" || true
 fi
 
 rm -rf \
-  "$HOME/.config/LM Studio" \
-  "$HOME/.config/LM-Studio" \
-  "$HOME/.lmstudio" \
-  "$HOME/.lmstudio-home-pointer"
+  "$target_home/.config/LM Studio" \
+  "$target_home/.config/LM-Studio" \
+  "$target_home/.lmstudio" \
+  "$target_home/.lmstudio-home-pointer"
 
 if [[ -n $lmstudio_home && $lmstudio_home == /* && -d $lmstudio_home ]] &&
-  [[ $lmstudio_home != "/" && $lmstudio_home != "$HOME" ]]; then
+  [[ $lmstudio_home != "/" && $lmstudio_home != "$target_home" ]]; then
   rm -rf "$lmstudio_home"
 fi
 

--- a/bin/omarchy-remove-ai-ollama
+++ b/bin/omarchy-remove-ai-ollama
@@ -5,6 +5,16 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 # The service is what holds the models open, so it goes before the package.
 sudo systemctl disable --now ollama.service 2>/dev/null || true
 
@@ -12,7 +22,7 @@ sudo systemctl disable --now ollama.service 2>/dev/null || true
 omarchy-pkg-drop ollama ollama-cuda ollama-rocm ollama-vulkan
 
 sudo rm -rf /var/lib/ollama
-rm -rf "$HOME/.ollama"
+rm -rf "$target_home/.ollama"
 
 echo ""
 echo "Ollama and its models have been removed."

--- a/bin/omarchy-remove-ai-t3-code
+++ b/bin/omarchy-remove-ai-t3-code
@@ -5,14 +5,24 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 omarchy-pkg-drop t3code-bin
 
 # T3 Code drives agents that keep their own state -- ~/.claude.json, ~/.grok,
 # ~/.local/share/opencode -- and those outlive it, so only its own goes.
 rm -rf \
-  "$HOME/.config/t3code" \
-  "$HOME/.t3"
-rm -f "$HOME/.config/t3code-flags.conf"
+  "$target_home/.config/t3code" \
+  "$target_home/.t3"
+rm -f "$target_home/.config/t3code-flags.conf"
 
 echo ""
 echo "T3 Code has been removed."

--- a/bin/omarchy-remove-gaming-heroic
+++ b/bin/omarchy-remove-gaming-heroic
@@ -5,13 +5,23 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 omarchy-pkg-drop heroic-games-launcher-bin
 
 rm -rf \
-  "$HOME/.config/heroic" \
-  "$HOME/.local/share/heroic" \
-  "$HOME/.cache/heroic" \
-  "$HOME/Games/Heroic"
+  "$target_home/.config/heroic" \
+  "$target_home/.local/share/heroic" \
+  "$target_home/.cache/heroic" \
+  "$target_home/Games/Heroic"
 
 echo ""
 echo "Heroic and its data have been removed."

--- a/bin/omarchy-remove-gaming-lutris
+++ b/bin/omarchy-remove-gaming-lutris
@@ -5,17 +5,27 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 omarchy-pkg-drop lutris wine-staging wine-mono wine-gecko winetricks python-protobuf umu-launcher
 
 rm -rf \
-  "$HOME/.config/lutris" \
-  "$HOME/.local/share/lutris" \
-  "$HOME/.cache/lutris" \
-  "$HOME/.local/share/umu" \
-  "$HOME/.cache/umu" \
-  "$HOME/.wine" \
-  "$HOME/.cache/wine" \
-  "$HOME/.cache/winetricks"
+  "$target_home/.config/lutris" \
+  "$target_home/.local/share/lutris" \
+  "$target_home/.cache/lutris" \
+  "$target_home/.local/share/umu" \
+  "$target_home/.cache/umu" \
+  "$target_home/.wine" \
+  "$target_home/.cache/wine" \
+  "$target_home/.cache/winetricks"
 
 echo ""
 echo "Lutris, Wine, umu-launcher, and their configs have been removed."

--- a/bin/omarchy-remove-gaming-minecraft
+++ b/bin/omarchy-remove-gaming-minecraft
@@ -5,13 +5,23 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 omarchy-pkg-drop minecraft-launcher
 
 rm -rf \
-  "$HOME/.minecraft" \
-  "$HOME/.config/Minecraft Launcher" \
-  "$HOME/.local/share/minecraft-launcher" \
-  "$HOME/.cache/minecraft"
+  "$target_home/.minecraft" \
+  "$target_home/.config/Minecraft Launcher" \
+  "$target_home/.local/share/minecraft-launcher" \
+  "$target_home/.cache/minecraft"
 
 echo ""
 echo "Minecraft and its data have been removed."

--- a/bin/omarchy-remove-gaming-retroarch
+++ b/bin/omarchy-remove-gaming-retroarch
@@ -5,6 +5,16 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 omarchy-pkg-drop \
   retroarch \
   retroarch-assets-glui retroarch-assets-ozone retroarch-assets-xmb \
@@ -28,9 +38,9 @@ omarchy-pkg-drop \
   retroarch-joypad-autoconfig-git
 
 rm -rf \
-  "$HOME/.config/retroarch" \
-  "$HOME/.local/share/retroarch" \
-  "$HOME/.cache/retroarch"
+  "$target_home/.config/retroarch" \
+  "$target_home/.local/share/retroarch" \
+  "$target_home/.cache/retroarch"
 
 echo ""
 echo "RetroArch and its cores have been removed."

--- a/bin/omarchy-remove-gaming-steam
+++ b/bin/omarchy-remove-gaming-steam
@@ -5,13 +5,23 @@
 
 set -e
 
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before touching their data (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
 omarchy-pkg-drop steam
 
 rm -rf \
-  "$HOME/.steam" \
-  "$HOME/.local/share/Steam" \
-  "$HOME/.config/steam" \
-  "$HOME/.cache/steam"
+  "$target_home/.steam" \
+  "$target_home/.local/share/Steam" \
+  "$target_home/.config/steam" \
+  "$target_home/.cache/steam"
 
 echo ""
 echo "Steam and its data have been removed."


### PR DESCRIPTION
Fixes #9569

## Problem

The ten `omarchy-remove-{ai,gaming}-*` scripts delete per-user data (`~/.config/heroic`, `~/.steam`, `~/.ollama`, …) through `$HOME`, but they are marked `omarchy:requires-sudo=true` and can arrive under `sudo` or `pkexec` — the escalation path `default/agents/skills/omarchy/SKILL.md` itself prescribes when no terminal is available. There `$HOME` is root's: `omarchy-pkg-drop` succeeds (its internal `sudo pacman` is a no-op as root), the script prints its success message, and the user's real data — 2.0 GB of Proton runtimes in the reported case — silently survives.

## Fix

Each affected script derives the invoking user before touching any home path, with the exact derivation `omarchy-apply-lock` already uses (`OMARCHY_INSTALL_USER` → `SUDO_USER` → `PKEXEC_UID` via getent → `$USER`), then resolves that user's home with `getent` and removes *their* data. Direct invocation is unchanged (`target_home` == `$HOME`).

Covered: `ai-chatgpt`, `ai-grok-bot`, `ai-lm-studio` (including its relocatable-home pointer guard), `ai-ollama`, `ai-t3-code`, `gaming-heroic`, `gaming-lutris`, `gaming-minecraft`, `gaming-retroarch`, `gaming-steam`.

Deliberately not covered, same family but different concerns: `omarchy-remove-security-sshd` judges the wrong user's `authorized_keys` under escalation (security decision — filing separately), and `omarchy-remove-service-sunshine` additionally calls `systemctl --user` as root, which needs more than a home-path fix.

## Verification

- `bash -n` on all ten scripts.
- `./test/cli` passes (116 ok).
- The derivation block was exercised under three simulated environments — `PKEXEC_UID` set with `HOME=/root`, `SUDO_USER` set with `HOME=/root`, and plain direct invocation — resolving to the invoking user's home in all three.
- Not run: live removal of each package (no Omarchy install in this environment); the reporter's diagnosis in #9569 documents the pkexec case empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTqr6ZjXfNthXT719ag7Qc