### PR TITLE
Judge the invoking user's authorized keys when removing SSH access

### DIFF
--- a/bin/omarchy-remove-security-sshd
+++ b/bin/omarchy-remove-security-sshd
@@ -5,7 +5,17 @@
 
 set -e
 
-AUTHORIZED_KEYS="$HOME/.ssh/authorized_keys"
+# Under sudo or pkexec $HOME is root's, so resolve the invoking user's home
+# before judging their authorized keys (same derivation as omarchy-apply-lock).
+target_user=${OMARCHY_INSTALL_USER:-${SUDO_USER:-}}
+if [[ -z $target_user && -n ${PKEXEC_UID:-} ]]; then
+  target_user=$(getent passwd "$PKEXEC_UID" | cut -d: -f1)
+fi
+target_user=${target_user:-$USER}
+target_home=$(getent passwd "$target_user" | cut -d: -f6)
+target_home=${target_home:-$HOME}
+
+AUTHORIZED_KEYS="$target_home/.ssh/authorized_keys"
 
 echo -e "\e[32mRemoving SSH server access.\n\e[0m"
 


### PR DESCRIPTION
Fixes #9572

## Problem

`omarchy-remove-security-sshd` promises to "optionally remove authorized keys" but resolves the file through `$HOME`. Under `sudo`/`pkexec` (the script carries `requires-sudo=true`, and `pkexec` is the SKILL.md-prescribed path for terminal-less callers) that is `/root/.ssh/authorized_keys`: the prompt is silently skipped when root has no keys — leaving the invoking user's keys authorized and live again the moment sshd is re-enabled — or, worse, targets root's keys when root has them.

## Fix

The same target-user derivation `omarchy-apply-lock` uses (`OMARCHY_INSTALL_USER` → `SUDO_USER` → `PKEXEC_UID` via getent → `$USER`), then `AUTHORIZED_KEYS` points at that user's home. Direct invocation is unchanged.

Split from #9571 (the same `$HOME`-under-escalation class in the data-removal scripts) because this one changes a security decision rather than cleanup coverage; related hardening context: #9267, #9255.

## Verification

- `bash -n` clean; `./test/cli` passes (116 ok).
- The derivation resolves the invoking user's home under simulated `PKEXEC_UID`+`HOME=/root`, `SUDO_USER`+`HOME=/root`, and direct invocation.
- Not run: a live sshd teardown (no Omarchy install in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTqr6ZjXfNthXT719ag7Qc