### PR TITLE
Lock directly from the idle service

### DIFF
--- a/bin/omarchy-system-lock
+++ b/bin/omarchy-system-lock
@@ -5,7 +5,12 @@
 # omarchy:name=lock
 # omarchy:examples=omarchy system lock
 
-omarchy-shell lock lock >/dev/null
+# The idle service can request the in-process lock first, avoiding a child IPC
+# call back into the Quickshell process that spawned it. In that case this
+# helper still owns all of the post-request session cleanup below.
+if [[ ${1:-} != "--skip-shell-request" ]]; then
+  omarchy-shell lock lock >/dev/null
+fi
 
 # Set keyboard layout to default (first layout)
 hyprctl switchxkblayout all 0 > /dev/null 2>&1

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -68,6 +68,17 @@ Item {
     runProcess(screensaverProcess, "screensaver", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || omarchy-launch-screensaver")
   }
 
+  function requestShellLock() {
+    if (!root.shell || typeof root.shell.firstPartyServiceFor !== "function") return false
+
+    var lockService = root.shell.firstPartyServiceFor("omarchy.lock")
+    if (!lockService) return false
+    if (lockService.locked) return true
+    if (typeof lockService.beginLock !== "function") return false
+
+    return lockService.beginLock()
+  }
+
   function lockSystem(reason) {
     logEvent("lock-system", reason || "requested")
     screensaverTimer.stop()
@@ -76,7 +87,15 @@ Item {
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()
-    runProcess(lockProcess, "lock", "omarchy-system-lock")
+
+    // An IPC call from a child spawned by this Quickshell process can fail to
+    // re-enter the lock handler. Request the session lock in-process first;
+    // the helper still performs the keyboard, 1Password, and screensaver work.
+    var requestedDirectly = requestShellLock()
+    logEvent("lock-request", requestedDirectly ? "direct" : "ipc-fallback")
+    runProcess(lockProcess, "lock", requestedDirectly
+      ? "omarchy-system-lock --skip-shell-request"
+      : "omarchy-system-lock")
   }
 
   function startIdleCycle() {

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -35,6 +35,32 @@ assertDeepEqual(
 )
 JS
 
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceSource = fs.readFileSync(root + '/shell/plugins/services/idle/Service.qml', 'utf8')
+const requestShellLock = serviceSource.slice(serviceSource.indexOf('  function requestShellLock()'))
+  .split('\n  }', 1)[0]
+assert(
+  /firstPartyServiceFor\("omarchy\.lock"\)/.test(requestShellLock),
+  'idle resolves the in-process lock service instead of relying on self-IPC'
+)
+assert(
+  /return lockService\.beginLock\(\)/.test(requestShellLock),
+  'idle directly requests a session lock from the lock service'
+)
+
+const lockSystem = serviceSource.slice(serviceSource.indexOf('  function lockSystem(reason)'))
+  .split('\n  }', 1)[0]
+assert(
+  /var requestedDirectly = requestShellLock\(\)/.test(lockSystem),
+  'idle requests the session lock before launching its cleanup helper'
+)
+assert(
+  /requestedDirectly[\s\S]*?omarchy-system-lock --skip-shell-request[\s\S]*?: "omarchy-system-lock"/.test(lockSystem),
+  'idle skips redundant self-IPC after a direct request and retains an IPC fallback'
+)
+JS
+
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 

--- a/test/shell.d/system-lock-test.sh
+++ b/test/shell.d/system-lock-test.sh
@@ -27,6 +27,8 @@ chmod +x "$mock_bin"/*
 PATH="$mock_bin:$PATH" CALL_LOG="$call_log" "$ROOT/bin/omarchy-system-lock"
 mapfile -t shutdown < <(rg '^(pkill|timeout) ' "$call_log")
 
+rg -q '^omarchy-shell lock lock$' "$call_log" ||
+  fail "system lock requests the shell lock during a regular invocation"
 [[ ${shutdown[0]} == "pkill -x ttfx" ]] ||
   fail "system lock stops ttfx before closing its terminal" "calls: ${shutdown[*]}"
 [[ ${shutdown[1]} == "timeout 1s pidwait -x ttfx" ]] ||
@@ -34,3 +36,15 @@ mapfile -t shutdown < <(rg '^(pkill|timeout) ' "$call_log")
 [[ ${shutdown[2]} == "pkill -f [o]rg.omarchy.screensaver" ]] ||
   fail "system lock closes the screensaver terminal after ttfx exits" "calls: ${shutdown[*]}"
 pass "system lock waits for ttfx before closing its terminal"
+
+: >"$call_log"
+PATH="$mock_bin:$PATH" CALL_LOG="$call_log" "$ROOT/bin/omarchy-system-lock" --skip-shell-request
+
+if rg -q '^omarchy-shell ' "$call_log"; then
+  fail "system lock can skip a session-lock request already made in-process"
+fi
+rg -q '^hyprctl switchxkblayout all 0$' "$call_log" ||
+  fail "system lock still resets the keyboard layout after an in-process request"
+rg -q '^pkill -f \[o\]rg\.omarchy\.screensaver$' "$call_log" ||
+  fail "system lock still closes the screensaver after an in-process request"
+pass "system lock preserves cleanup while skipping a redundant shell request"


### PR DESCRIPTION
## Summary

Request the session lock directly from the loaded `omarchy.lock` service when the idle timeout fires.

The idle service previously spawned `omarchy-system-lock`, which called IPC back into the same Quickshell process that launched it. On affected sessions that self-referential call exited successfully without reaching the lock handler, leaving the desktop unlocked. The idle path now invokes `beginLock()` in-process before launching the helper. The helper can skip only the redundant shell request while retaining its keyboard-layout reset, 1Password lock, and screensaver cleanup. If the lock service is unexpectedly unavailable, the existing IPC path remains as a fallback.

Manual `omarchy system lock` behavior is unchanged.

Closes #9480

## Test plan

- `bash test/shell.d/idle-test.sh`
- `bash test/shell.d/system-lock-test.sh`
- `bash -n bin/omarchy-system-lock test/shell.d/idle-test.sh test/shell.d/system-lock-test.sh`
- `/usr/lib/qt6/bin/qmllint -I /usr/lib/qt6/qml -I shell shell/plugins/services/idle/Service.qml` (only existing `QProcess::ExitStatus` import warnings)
- `./test/shell` (changed tests pass; suite retains five unrelated baseline failures: three require an `omarchy-pkgs` checkout, plus the existing launch-about and network-QR assertions)