### PR TITLE
Harden RetroArch desktop launcher paths

### DIFF
--- a/bin/omarchy-games-retro-install
+++ b/bin/omarchy-games-retro-install
@@ -46,6 +46,37 @@ if [[ ! -f $core_path ]]; then
   exit 1
 fi
 
+# Desktop Entry values are line-oriented, and Exec arguments have their own
+# quoting rules. Reject control characters before serializing either path.
+if [[ $game_path == *[[:cntrl:]]* || $core_path == *[[:cntrl:]]* ]]; then
+  echo "Game and core paths cannot contain control characters." >&2
+  exit 1
+fi
+
+desktop_string_escape() {
+  # Desktop Entry "string" value (freedesktop Desktop Entry Spec, "Value types"):
+  # a raw newline would start a new key line and let a value inject a second
+  # Exec. Escape backslash first, then tab/CR/LF and a leading space.
+  local value="$1"
+
+  value=${value//\\/\\\\}
+  value=${value//$'\t'/\\t}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\n'/\\n}
+  [[ $value == " "* ]] && value="\\s${value# }"
+
+  printf '%s' "$value"
+}
+
+desktop_exec_arg() {
+  # One Exec argument, double-quoted per the freedesktop Exec spec. Escape the
+  # syntax characters before the whole Exec value is escaped for the file.
+  local escaped
+  escaped=$(printf '%s' "$1" \
+    | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/`/\\`/g' -e 's/\$/\\$/g' -e 's/%/%%/g')
+  printf '"%s"' "$escaped"
+}
+
 game_name=$(printf '%s' "${game_path##*/}" | sed 's/\.[^.]*$//; s/[[:space:]]*([^)]*)//g; s/[[:space:]]\+/ /g; s/^ //; s/ $//' | perl -Mopen=locale -pe 's/(^|[[:space:]])([^[:space:]])/$1\U$2/g')
 desktop_name="$game_name"
 desktop_id=$(printf '%s' "$desktop_name" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-' | sed 's/^-//; s/-$//')
@@ -53,12 +84,16 @@ desktop_dir="$HOME/.local/share/applications"
 desktop_file="$desktop_dir/$desktop_id.desktop"
 mkdir -p "$desktop_dir"
 
+name_field=$(desktop_string_escape "$desktop_name")
+comment_field=$(desktop_string_escape "Play $game_name with RetroArch")
+exec_field=$(desktop_string_escape "retroarch -L $(desktop_exec_arg "$core_path") $(desktop_exec_arg "$game_path")")
+
 cat >"$desktop_file" <<EOF
 [Desktop Entry]
 Version=1.0
-Name=$desktop_name
-Comment=Play $game_name with RetroArch
-Exec=retroarch -L "$core_path" "$game_path"
+Name=$name_field
+Comment=$comment_field
+Exec=$exec_field
 Terminal=false
 Type=Application
 Icon=retro-gaming

--- a/test/shell.d/retro-install-desktop-entry-test.sh
+++ b/test/shell.d/retro-install-desktop-entry-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command desktop-file-validate
+require_command gio
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+rom_dir="$test_tmp/roms"
+applications="$test_home/.local/share/applications"
+core_path="$test_tmp/fake-core.so"
+mkdir -p "$mock_bin" "$test_home" "$rom_dir"
+: >"$core_path"
+
+for command in omarchy-notification-send update-desktop-database; do
+  cat >"$mock_bin/$command" <<'SH'
+#!/bin/bash
+exit 0
+SH
+done
+
+cat >"$mock_bin/retroarch" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >"$OMARCHY_TEST_ARGV"
+SH
+
+chmod +x "$mock_bin"/*
+
+install_game() {
+  HOME="$test_home" \
+    PATH="$mock_bin:$ROOT/bin:$PATH" \
+    "$ROOT/bin/omarchy-games-retro-install" "$core_path" "$1"
+}
+
+malicious_rom="$rom_dir/Hostile"$'\n'"Exec=sh -c \"echo PWNED\".sfc"
+: >"$malicious_rom"
+
+if install_game "$malicious_rom" >"$test_tmp/malicious.out" 2>"$test_tmp/malicious.err"; then
+  fail "retro install refuses a ROM path containing a control character"
+fi
+grep -Fqx 'Game and core paths cannot contain control characters.' "$test_tmp/malicious.err" ||
+  fail "retro install explains why the ROM path was refused" "$(<"$test_tmp/malicious.err")"
+[[ ! -e $applications ]] ||
+  fail "retro install does not create a desktop entry for a hostile ROM name"
+pass "retro install refuses a ROM path containing a control character"
+
+safe_rom="$rom_dir/Game \"100%\" \\ Test.sfc"
+: >"$safe_rom"
+export OMARCHY_TEST_ARGV="$test_tmp/retroarch-args"
+install_game "$safe_rom" >"$test_tmp/safe.out" 2>"$test_tmp/safe.err"
+
+safe_desktop="$applications/game-100-test.desktop"
+[[ -f $safe_desktop ]] ||
+  fail "retro install creates a desktop entry for a normal ROM name"
+desktop-file-validate "$safe_desktop" >"$test_tmp/validate.out" 2>"$test_tmp/validate.err" ||
+  fail "retro install writes a valid desktop entry for special characters" "$(<"$test_tmp/validate.err")"
+(( $(grep -c '^Exec=' "$safe_desktop") == 1 )) ||
+  fail "retro install writes exactly one Exec key" "$(<"$safe_desktop")"
+pass "retro install writes a valid desktop entry for special characters"
+
+: >"$OMARCHY_TEST_ARGV"
+HOME="$test_home" PATH="$mock_bin:$ROOT/bin:$PATH" \
+  gio launch "$safe_desktop" >"$test_tmp/gio.out" 2>"$test_tmp/gio.err" ||
+  fail "the generated desktop entry launches through gio" "$(<"$test_tmp/gio.err")"
+
+for ((attempt = 0; attempt < 100; attempt++)); do
+  [[ -s $OMARCHY_TEST_ARGV ]] && break
+  sleep 0.01
+done
+
+grep -Fxq -- "$safe_rom" "$OMARCHY_TEST_ARGV" ||
+  fail "desktop-entry escaping preserves a ROM path with quotes, percent, and backslash" "$(<"$OMARCHY_TEST_ARGV")"
+pass "desktop-entry escaping preserves a ROM path with quotes, percent, and backslash"


### PR DESCRIPTION
## Summary

- Reject control characters in game and core paths before creating a desktop launcher.
- Escape Desktop Entry string values and Exec arguments according to their respective formats.
- Add regression coverage for injected newlines and special-character ROM names.

## Security impact

A newline in a ROM path could previously introduce additional Desktop Entry keys, including a second `Exec` directive. The launcher now refuses control characters and preserves quotes, percent signs, backslashes, spaces, and other supported path characters without changing the resulting RetroArch argument.

## Testing

- `bash test/shell.d/retro-install-desktop-entry-test.sh`
- `./test/cli`
- `bash -n bin/omarchy-games-retro-install test/shell.d/retro-install-desktop-entry-test.sh`
- `git diff --check`

`./test/shell` also ran; four unrelated environment checks remain unavailable because this checkout does not include the separate `omarchy-pkgs` repository (plus one independent launch-about check). The new focused test passes.