### PR TITLE
Use Quickshell OSD for Voxtype on Omarchy

### DIFF
--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -15,6 +15,7 @@ if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
   cp "$OMARCHY_PATH/default/voxtype/config.toml" ~/.config/voxtype/
 
   voxtype setup --download --no-post-install
+  voxtype setup quickshell
   if omarchy-hw-vulkan; then
     voxtype setup gpu --enable || true
   fi

--- a/default/voxtype/config.toml
+++ b/default/voxtype/config.toml
@@ -10,6 +10,12 @@
 # Required for `voxtype record toggle` and `voxtype status` commands.
 state_file = "auto"
 
+[osd]
+# Use Omarchy's native Quickshell desktop stack for a cohesive OSD.
+frontend = "quickshell"
+palette = "omarchy"
+layout = "minimal"
+
 [hotkey]
 # Hotkey is configured in Hyprland. Default is Super + Ctrl + X
 enabled = false


### PR DESCRIPTION
 Omarchy places a strong emphasis on visual consistency and polish, but the default VoxType installation currently uses the GTK4 OSD.

On my Omarchy 4.0.2 system, I switched VoxType to:

```toml
[osd]
frontend = "quickshell"
palette = "omarchy"
layout = "minimal"
```

The result is much more beautiful and feels significantly better integrated with the Omarchy desktop. It matches Omarchy's visual language, colors, spacing and overall level of polish much more naturally than the default GTK4 OSD.

It also works much better with a multi-monitor setup. In my testing, the Quickshell OSD follows the monitor associated with the currently focused workspace, whereas the GTK4 OSD always appeared on the monitor positioned at 0x0, even when focus was on another display.

Here is a screenshot of the Quickshell OSD with the Omarchy palette and minimal layout:
<img width="540" height="136" alt="screenshot-2026-09-01_10-17-50" src="https://github.com/user-attachments/assets/a713bfee-1ab6-443a-81f8-995d98043413" />


Would it be possible to:

- use the Quickshell frontend by default when VoxType is installed through Omarchy;
- enable palette = "omarchy" by default;
- use a minimal layout by default;
- or at least make this the recommended Omarchy configuration?

The GTK4 frontend could remain the fallback for non-Omarchy environments.

