### PR TITLE
Exec mise wrappers by resolved path, not by name

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -23,7 +23,16 @@ cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
 mise use -g --quiet "$package" || exit 1
-exec mise x "$package" -- "$bin" "\$@"
+
+# Resolve the binary to an absolute path. Passing the bare name lets mise
+# re-resolve it through PATH, which can land back on this wrapper and exec
+# forever when ~/.local/bin precedes mise's install dir.
+resolved=\$(mise which "$bin" 2>/dev/null)
+if [[ -n \$resolved ]]; then
+  exec mise x "$package" -- "\$resolved" "\$@"
+else
+  exec mise x "$package" -- "$bin" "\$@"
+fi
 EOF
 
 chmod +x "$HOME/.local/bin/$command"

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -61,6 +61,11 @@ if [[ $1 == "where" ]]; then
   exit
 fi
 
+if [[ $1 == "which" ]]; then
+  [[ -n ${OMARCHY_TEST_MISE_WHICH:-} ]] && printf '%s\n' "$OMARCHY_TEST_MISE_WHICH"
+  exit
+fi
+
 [[ ${OMARCHY_TEST_MISE_FAIL:-false} != "true" ]]
 SH
 
@@ -108,8 +113,27 @@ assert_lazy_stub() {
   "$test_home/.local/bin/$command" --version
   mapfile -t mise_calls <"$mise_history"
 
-  [[ ${mise_calls[0]} == "use -g --quiet $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
+  # The stub resolves the binary to an absolute path before exec'ing it, so the
+  # name is never handed back to mise to look up through PATH.
+  [[ ${mise_calls[0]} == "use -g --quiet $package" && ${mise_calls[1]} == "which $command" &&
+    ${mise_calls[2]} == "x $package -- $command --version" ]] ||
     fail "$command lazy stub preserves its mise package"
+}
+
+# A stub must never exec the bare command name when mise can resolve it: with
+# ~/.local/bin ahead of mise's install dir on PATH, the name finds the stub
+# again and it execs itself forever.
+assert_stub_execs_resolved_path() {
+  local package=$1
+  local command=$2
+
+  : >"$mise_history"
+  "$ROOT/bin/omarchy-mise-install" "$package" "$command"
+  OMARCHY_TEST_MISE_WHICH="/opt/resolved/$command" "$test_home/.local/bin/$command" --version
+  mapfile -t mise_calls <"$mise_history"
+
+  [[ ${mise_calls[2]} == "x $package -- /opt/resolved/$command --version" ]] ||
+    fail "$command lazy stub execs the resolved path, not the bare name"
 }
 
 assert_lazy_stub "$grok_package" grok
@@ -117,6 +141,9 @@ assert_lazy_stub "$omp_package" omp
 assert_lazy_stub "$crush_package" crush
 assert_lazy_stub "$ori_package" ori
 pass "custom agent lazy stubs preserve their mise packages"
+
+assert_stub_execs_resolved_path "$grok_package" grok
+pass "lazy stubs exec the resolved binary path"
 
 source "$ROOT/install/user/mise.sh"
 grep -Fx "$agy_package agy" "$stub_log" >/dev/null || fail "user setup creates the Antigravity lazy stub"


### PR DESCRIPTION
[`4480a142`](https://github.com/omacom/omarchy/commit/4480a1423634c87b93d868329a5b2300b1e9b920) moved the generated stubs from `exec "$bin"` to
`exec mise x "$package" -- "$bin"` so the tool would resolve from mise's install
dir rather than by name through PATH. That narrowed the loop but did not close
it: mise still looks the **bare name** up in PATH, so it can find the stub again
and exec itself forever, in the same PID, pinning a core.

### Reproducing

Four conditions, all required:

1. `~/.local/bin` precedes the tool's mise install dir on `PATH`;
2. that install dir is **already** on `PATH` — otherwise `mise x` prepends it and
   the name resolves correctly;
3. `~/.local/share/mise/shims` is on `PATH`;
4. the environment carries none of mise's session variables (`__MISE_DIFF`,
   `__MISE_SESSION`, `MISE_SHELL`).

```bash
omarchy-mise-install gh

GH=$(dirname "$(mise which gh)")
SH="$HOME/.local/share/mise/shims"

env -i HOME="$HOME" PATH="$HOME/.local/bin:$GH:$SH:/bin" timeout 5 gh --version
echo "rc=$?"   # rc=124 — hangs, ~100% CPU, never prints a version
```

Condition 4 is why this hides: from an interactive shell (session vars set) the
same command returns in ~50ms. Only non-interactive children hit it — a systemd
service, a git subprocess, an agent runner.

Verified minimal by delta-debugging a 31-entry `PATH` captured from a real stuck
process; dropping any one of conditions 1-3 fixes it:

| `PATH` | result |
| --- | --- |
| `wrapper : install : shims` | **loops** (killed at 5s) |
| `wrapper : install` (no shims) | ok, 55ms |
| `wrapper : shims` (no install dir) | ok, 64ms |
| `wrapper` alone | ok, 61ms |
| `install : shims : … : wrapper` (wrapper last) | ok, 54ms |

### Impact

Hit on Omarchy 4.0.2-1 as `gh auth git-credential get` spinning for **85 minutes**
and burning **35 minutes of CPU**, with the git operation behind it hung the whole
time — git had invoked the `gh` stub as its `credential.helper`. The same loop
broke an agent runner's tool probes: each probe spawned a stub, spun, and was
killed on timeout, so it dropped all three of its providers.

argv alternates on a single PID, no children, state flipping S/R:

```
/bin/bash /home/<user>/.local/bin/gh auth git-credential get
...
mise x gh -- gh auth git-credential get          <-- same PID, mid-exec
```

### The change

Resolve the binary with `mise which` and exec that absolute path, so the name is
never handed back for lookup. When resolution fails the stub falls back to the
previous line, keeping today's behavior rather than breaking a tool mise cannot
locate.

Generating a stub from the patched script in an identical sandbox: **62ms**
instead of hanging. Generating one from `main` in that same sandbox still loops,
so the before/after is attributable to this change alone.

### Tests

`test/shell.d/default-agent-test.sh` asserted the stub called mise exactly twice,
which encoded the old contract; updated for the `mise which` call, with the mise
mock taught to answer `which`. Added `assert_stub_execs_resolved_path`, which
fails against `main` and passes here.

`./test/all` shows the same 4 failures before and after this change
(`omarchy-pkgs` checkout missing ×3, and a widget IPC handler count) — all
environmental on my machine, none related.
