### PR TITLE
Update the tagline to Beautiful, Fun & Agentic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Omarchy
 
-Omarchy is a beautiful, modern & opinionated Linux distribution by DHH.
+Omarchy is a beautiful, fun & agentic Linux distribution by DHH.
 
 Read more at [omarchy.org](https://omarchy.org).
 

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -449,7 +449,7 @@ greeter_screen() {
     rows=$(stty size 2>/dev/null </dev/tty | awk '{print $1}')
     [[ $rows =~ ^[0-9]+$ ]] || rows=${LINES:-24}
 
-    tagline="Beautiful, Modern & Opinionated Linux by DHH"
+    tagline="Beautiful, Fun & Agentic Linux by DHH"
     hint="Press Return to Start Setup"
 
     printf '%s%s' "$HIDE_CURSOR" "$CLEAR"

--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -13,7 +13,7 @@ description: >
 
 # Omarchy Skill
 
-Manage [Omarchy](https://omarchy.org/) Linux systems - a beautiful, modern, opinionated Arch Linux distribution with Hyprland.
+Manage [Omarchy](https://omarchy.org/) Linux systems - a beautiful, fun, agentic Arch Linux distribution with Hyprland.
 
 This skill is for end-user customization on installed systems.
 It is not for contributing to Omarchy source code.


### PR DESCRIPTION
The tagline is now "Beautiful, Fun & Agentic Linux by DHH" on omarchy.org, the X header, and the ISO installer — this brings the distro repo along:

- `bin/omarchy-provision-owner` — the setup screen tagline
- `README.md` — the lowercase sentence form
- `default/agents/skills/omarchy/SKILL.md` — the comma-style variant in the agent skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
