### PR TITLE
Clear stale graphical-session before uwsm so SDDM autologin is not a blank screen

### DIFF
--- a/bin/omarchy-hyprland-session-start
+++ b/bin/omarchy-hyprland-session-start
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# omarchy:summary=Start the Hyprland session via uwsm after clearing a stale graphical-session target
+# omarchy:hidden=true
+
+set -euo pipefail
+
+# SDDM starts a Wayland greeter compositor (start-hyprland) before autologin.
+# On slower iGPUs — notably Apple Intel Haswell (Macmini7,1 / Iris 5100) — that
+# greeter can leave graphical-session.target active with no user compositor.
+# uwsm then refuses: "A compositor or graphical-session* target is already active!"
+# and SDDM's helper exits 1 (blank screen). Recurs when omarchy-settings restores
+# the packaged session file.
+#
+# Clear the leftover target only when Hyprland is not actually running, then
+# hand off to uwsm so logout (uwsm stop) still works.
+
+systemctl_user() {
+  systemctl --user "$@"
+}
+
+compositor_running() {
+  pgrep -u "$UID" -x Hyprland >/dev/null 2>&1 || pgrep -u "$UID" -x hyprland >/dev/null 2>&1
+}
+
+if systemctl_user is-active --quiet graphical-session.target; then
+  if ! compositor_running; then
+    systemctl_user stop graphical-session.target graphical-session-pre.target || true
+  fi
+fi
+
+exec uwsm start -e -D Hyprland hyprland.desktop

--- a/default/wayland-sessions/omarchy.desktop
+++ b/default/wayland-sessions/omarchy.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=Omarchy (Hyprland uwsm)
 Comment=Omarchy Hyprland session managed by uwsm
-Exec=uwsm start -g -1 -e -D Hyprland hyprland.desktop
+Exec=/usr/bin/omarchy-hyprland-session-start
 TryExec=uwsm
 Type=Application
+DesktopNames=Hyprland

--- a/test/shell.d/hyprland-session-start-test.sh
+++ b/test/shell.d/hyprland-session-start-test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+desktop="$ROOT/default/wayland-sessions/omarchy.desktop"
+starter="$ROOT/bin/omarchy-hyprland-session-start"
+
+grep -Fx 'Exec=/usr/bin/omarchy-hyprland-session-start' "$desktop" >/dev/null ||
+  fail "session desktop starts through omarchy-hyprland-session-start"
+grep -F 'uwsm start -g -1' "$desktop" >/dev/null &&
+  fail "session desktop must not call uwsm -g -1 (races the SDDM greeter)"
+pass "session desktop uses the uwsm session wrapper"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_bin="$test_tmp/bin"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/uwsm" <<'BASH'
+#!/bin/bash
+printf 'UWSM:%s\n' "$*" >"${FAKE_LOG_DIR}/uwsm"
+exit 0
+BASH
+
+cat >"$fake_bin/systemctl" <<'BASH'
+#!/bin/bash
+printf 'SYSTEMCTL:%s\n' "$*" >>"${FAKE_LOG_DIR}/systemctl"
+
+if [[ $1 == --user && $2 == is-active && $4 == graphical-session.target ]]; then
+  if [[ ${FAKE_GRAPHICAL_ACTIVE:-0} == 1 ]]; then
+    exit 0
+  fi
+  exit 3
+fi
+
+exit 0
+BASH
+
+cat >"$fake_bin/pgrep" <<'BASH'
+#!/bin/bash
+if [[ ${FAKE_COMPOSITOR_RUNNING:-0} == 1 ]]; then
+  exit 0
+fi
+exit 1
+BASH
+
+chmod 0755 "$fake_bin/uwsm" "$fake_bin/systemctl" "$fake_bin/pgrep"
+
+run_starter() {
+  FAKE_LOG_DIR="$test_tmp" PATH="$fake_bin:$PATH" "$starter"
+}
+
+: >"$test_tmp/systemctl"
+FAKE_GRAPHICAL_ACTIVE=0 FAKE_COMPOSITOR_RUNNING=0 run_starter
+grep -Fx 'UWSM:start -e -D Hyprland hyprland.desktop' "$test_tmp/uwsm" >/dev/null ||
+  fail "wrapper execs uwsm without -g when graphical-session is idle"
+grep -F 'stop graphical-session.target' "$test_tmp/systemctl" >/dev/null &&
+  fail "wrapper must not stop an inactive graphical-session target"
+pass "idle graphical-session starts uwsm without a stop"
+
+: >"$test_tmp/systemctl"
+FAKE_GRAPHICAL_ACTIVE=1 FAKE_COMPOSITOR_RUNNING=0 run_starter
+grep -F 'stop graphical-session.target graphical-session-pre.target' "$test_tmp/systemctl" >/dev/null ||
+  fail "wrapper stops a leftover graphical-session target when Hyprland is not running"
+grep -Fx 'UWSM:start -e -D Hyprland hyprland.desktop' "$test_tmp/uwsm" >/dev/null ||
+  fail "wrapper still execs uwsm after clearing a stale target"
+pass "stale graphical-session without compositor is cleared before uwsm"
+
+: >"$test_tmp/systemctl"
+FAKE_GRAPHICAL_ACTIVE=1 FAKE_COMPOSITOR_RUNNING=1 run_starter
+grep -F 'stop graphical-session.target' "$test_tmp/systemctl" >/dev/null &&
+  fail "wrapper must not stop graphical-session while Hyprland is running"
+pass "live compositor is left alone"
+
+# Sabotage: the stale-target stop is the actual fix. If it disappears, this fails.
+if ! grep -F 'systemctl_user stop graphical-session.target graphical-session-pre.target' "$starter" >/dev/null; then
+  fail "wrapper still contains the stale graphical-session stop"
+fi
+pass "stale-target stop is present in the wrapper"


### PR DESCRIPTION
Fixes https://github.com/omacom/omarchy/issues/9589

## Problem

SDDM autologin starts the packaged Omarchy session (`uwsm start -g -1 ... hyprland.desktop`) after the Wayland greeter compositor (`start-hyprland` + `hyprland.lua`). On slower Intel Apple iGPUs — reproduced on **Mac mini Macmini7,1** (i7-4578U, Haswell Iris 5100 / i915) — `graphical-session.target` is already active with **no user Hyprland**. uwsm then exits:

```
A compositor or graphical-session* target is already active!
```

SDDM's helper exits 1 and the screen stays blank. `omarchy-settings` restores the packaged desktop file on update, so a local `Exec=/usr/bin/start-hyprland` workaround does not last.

Not #8200 (logout with a non-uwsm session). This is the inverse: uwsm never owns the session. Not #8152 (PAM/install crash loop).

## Approach

Keep uwsm (logout via `uwsm stop` still works):

- `default/wayland-sessions/omarchy.desktop` now `Exec=/usr/bin/omarchy-hyprland-session-start`
- Wrapper stops leftover `graphical-session.target` / `graphical-session-pre.target` **only when Hyprland is not running**, then `exec uwsm start -e -D Hyprland hyprland.desktop` (no `-g -1`)

## Tests

`test/shell.d/hyprland-session-start-test.sh`:

- idle target → uwsm, no stop
- active target, no compositor → stop, then uwsm
- live compositor → no stop
- sabotage: removing the stop fails the stale-target case

## Risk

- Session still uwsm-managed; should not regress #8200.
- If Hyprland is already up, the wrapper does not tear the session down.
- Hardware note: confirmed on Macmini7,1; likely a greeter/session race that faster GPUs win.

## Exclusions

No SDDM greeter compositor rewrite, no autologin ISO changes.