### PR TITLE
Update plugin links to plugins.omarchy.org

### DIFF
--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -99,4 +99,4 @@ For the full picture, the source is the documentation: `shell/README.md` in the 
 
 Once you've made something you like, put it in a public git repo. That's the whole distribution mechanism — anyone can then run `omarchy plugin add` against your URL and have it running in seconds.
 
-To help people actually find it, list it at [omarchyplugins.com](https://omarchyplugins.com). That's the community directory of Omarchy shell plugins, and it's the first place to look when you're wondering whether someone has already built the widget you're about to write. Browse it before you start!
+To help people actually find it, list it at [plugins.omarchy.org](https://plugins.omarchy.org). That's the community directory of Omarchy shell plugins, and it's the first place to look when you're wondering whether someone has already built the widget you're about to write. Browse it before you start!


### PR DESCRIPTION
The Omarchy plugin directory has moved from `omarchyplugins.com` to `plugins.omarchy.org` (the old domain now 301-redirects to the new one).

This updates the shell-plugins manual chapter to point at the new domain. The omarchy-site repo already updated its built manual pages, but `bin/build-manual` pulls this chapter from here — without this change, a manual rebuild would revert those pages back to the old domain.

- Changed `[omarchyplugins.com](https://omarchyplugins.com)` → `[plugins.omarchy.org](https://plugins.omarchy.org)` in `manual/32-shell-plugins.md`