### PR TITLE
Fix XDG Secret portal keyring access

### DIFF
--- a/config/xdg-desktop-portal/hyprland-portals.conf
+++ b/config/xdg-desktop-portal/hyprland-portals.conf
@@ -1,0 +1,3 @@
+[preferred]
+default=hyprland;gtk
+org.freedesktop.impl.portal.Secret=gnome-keyring

--- a/migrations/1788261467.sh
+++ b/migrations/1788261467.sh
@@ -1,0 +1,23 @@
+echo "Expose GNOME Keyring to sandboxed apps through the Secret portal"
+
+portal_dir="${XDG_CONFIG_HOME:-$HOME/.config}/xdg-desktop-portal"
+portal_config="$portal_dir/hyprland-portals.conf"
+generic_config="$portal_dir/portals.conf"
+
+# Only apply if not configured yet
+if [[ -e $portal_config || -L $portal_config ]]; then
+  echo "Portal already configured, skipping..."
+  exit 0
+elif [[ -e $generic_config || -L $generic_config ]]; then
+  echo "Portal already configured, skipping..."
+  exit 0
+fi
+
+install -Dm644 "$OMARCHY_PATH/config/xdg-desktop-portal/hyprland-portals.conf" "$portal_config"
+
+# Activate the backend immediately in a live desktop
+if systemctl --user is-active --quiet xdg-desktop-portal.service 2>/dev/null; then
+  if ! systemctl --user restart xdg-desktop-portal.service; then
+    echo "Failed to restart xdg-desktop-portal" >&2
+  fi
+fi


### PR DESCRIPTION
## Problem

Omarchy already installs GNOME Keyring and libsecret, but its Hyprland portal selection is not configured to route org.freedesktop.impl.portal.Secret to GNOME Keyring. As a result, applications using OS-keystore-backed authentication through XDG portals, primarily Flatpaks, cannot access the keyring.

Authentication may therefore fail, and this was observed with Zotero 10.0.1: the login gets stuck on “Waiting for login…” because it cannot save the sync API key in the OS keystore (see [here](https://forums.zotero.org/discussion/133418/zotero-10-0-1-linux-sync-account-fails)), cause xdg-portal is not configured correctly.

## Changes

This PR adds the missing configuration for xdg-portal to properly handle authentication with gnome-keyring. The migration preserves existing desktop-specific and generic user portal configurations.