### PR TITLE
Fix Bluetooth microphone routing during profile switches

### DIFF
--- a/bin/omarchy-audio-input-set-default
+++ b/bin/omarchy-audio-input-set-default
@@ -12,9 +12,53 @@ if [[ -z $node_id || -z $source_name ]]; then
   exit 1
 fi
 
-wpctl set-default "$node_id" 2>/dev/null || true
-pactl set-default-source "$source_name" 2>/dev/null || true
+wpctl_status=0
+pactl_status=0
+wpctl set-default "$node_id" 2>/dev/null || wpctl_status=$?
+pactl set-default-source "$source_name" 2>/dev/null || pactl_status=$?
 
-pactl list short source-outputs 2>/dev/null | awk '{ print $1 }' | while read -r output; do
-  [[ -n $output ]] && pactl move-source-output "$output" "$source_name" 2>/dev/null || true
-done
+if (( wpctl_status != 0 && pactl_status != 0 )); then
+  echo "Failed to set default audio input: $source_name" >&2
+  exit 1
+fi
+
+if ! source_outputs=$(pactl list short source-outputs 2>/dev/null); then
+  echo "Failed to list active audio input streams" >&2
+  exit 1
+fi
+
+move_failed=0
+while read -r output; do
+  [[ -n $output ]] || continue
+
+  max_attempts=1
+  if [[ $source_name == bluez_input.* ]]; then
+    max_attempts=5
+  fi
+
+  moved=false
+  for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
+    if pactl move-source-output "$output" "$source_name" 2>/dev/null; then
+      moved=true
+
+      # The first link starts WirePlumber's A2DP-to-HFP graph rebuild. Relink
+      # once after it settles because that initial asynchronous link can vanish.
+      if (( max_attempts > 1 && attempt == 1 )); then
+        sleep 0.2
+        continue
+      fi
+
+      break
+    fi
+
+    moved=false
+    (( attempt == max_attempts )) || sleep 0.2
+  done
+
+  if [[ $moved == false ]]; then
+    echo "Failed to move audio input stream $output to $source_name after $max_attempts attempts" >&2
+    move_failed=1
+  fi
+done < <(awk '{ print $1 }' <<<"$source_outputs")
+
+exit "$move_failed"

--- a/bin/omarchy-audio-input-set-default
+++ b/bin/omarchy-audio-input-set-default
@@ -28,13 +28,13 @@ report_bluetooth_failure() {
     "Reconnect the headset or select another input device." 2>/dev/null
 }
 
-if (( wpctl_status != 0 && pactl_status != 0 )) && [[ $is_bluetooth == true ]]; then
+if (( wpctl_status != 0 && pactl_status != 0 )) && [[ $is_bluetooth == "true" ]]; then
   report_bluetooth_failure "Failed to set default audio input: $source_name"
   exit 1
 fi
 
 if ! source_outputs=$(pactl list short source-outputs 2>/dev/null); then
-  if [[ $is_bluetooth == true ]]; then
+  if [[ $is_bluetooth == "true" ]]; then
     report_bluetooth_failure "Failed to list active audio input streams"
     list_status=1
   else
@@ -45,7 +45,7 @@ if ! source_outputs=$(pactl list short source-outputs 2>/dev/null); then
 fi
 
 bluetooth_card_name=""
-if [[ $is_bluetooth == true ]]; then
+if [[ $is_bluetooth == "true" ]]; then
   bluetooth_card_name=$(pactl --format=json list sources 2>/dev/null | jq -r --arg source "$source_name" \
     'first(.[] | select(.name == $source) | .properties["device.name"]) // empty' 2>/dev/null)
 fi
@@ -60,7 +60,7 @@ bluetooth_input_ready() {
 }
 
 move_failed=0
-if [[ $is_bluetooth == true && -n $source_outputs ]]; then
+if [[ $is_bluetooth == "true" && -n $source_outputs ]]; then
   pw-record --target "$source_name" --raw /dev/null >/dev/null 2>&1 &
   trigger_pid=$!
 
@@ -80,7 +80,7 @@ if [[ $is_bluetooth == true && -n $source_outputs ]]; then
     fi
   done
 
-  if [[ $input_ready == true ]]; then
+  if [[ $input_ready == "true" ]]; then
     while read -r source_output_id; do
       [[ -n $source_output_id ]] || continue
 
@@ -93,7 +93,7 @@ if [[ $is_bluetooth == true && -n $source_outputs ]]; then
         sleep 0.1
       done
 
-      if [[ $moved == false ]]; then
+      if [[ $moved == "false" ]]; then
         echo "Failed to move audio input stream $source_output_id to $source_name after 5 attempts" >&2
         move_failed=1
       fi

--- a/bin/omarchy-audio-input-set-default
+++ b/bin/omarchy-audio-input-set-default
@@ -36,10 +36,12 @@ fi
 if ! source_outputs=$(pactl list short source-outputs 2>/dev/null); then
   if [[ $is_bluetooth == true ]]; then
     report_bluetooth_failure "Failed to list active audio input streams"
-    exit 1
+    list_status=1
+  else
+    list_status=0
   fi
 
-  exit 0
+  exit "$list_status"
 fi
 
 bluetooth_card_name=""
@@ -49,40 +51,39 @@ if [[ $is_bluetooth == true ]]; then
 fi
 
 bluetooth_input_ready() {
-  local cards
+  local sources
   [[ -n $bluetooth_card_name ]] || return 1
-  cards=$(pactl --format=json list cards 2>/dev/null) || return 1
-  jq -e --arg card "$bluetooth_card_name" \
-    'any(.[]; .name == $card and ((.profiles[.active_profile].sources // 0) > 0))' \
-    <<<"$cards" >/dev/null 2>&1
+  sources=$(pactl --format=json list sources 2>/dev/null) || return 1
+  jq -e --arg card "$bluetooth_card_name" --arg loopback "$source_name" \
+    'any(.[]; .name != $loopback and .properties["device.name"] == $card and .properties["bluez5.loopback"] != "true")' \
+    <<<"$sources" >/dev/null 2>&1
 }
 
 move_failed=0
 while read -r source_output_id; do
   [[ -n $source_output_id ]] || continue
 
-  if [[ $is_bluetooth == false ]]; then
-    pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null
-    continue
-  fi
+  if [[ $is_bluetooth == true ]]; then
+    moved=false
+    max_attempts=15
+    for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
+      # Linking to the loopback asks WirePlumber to replace A2DP with a capture
+      # profile. Poll for its physical source, then relink after the graph exists.
+      pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null
+      sleep 0.2
 
-  moved=false
-  max_attempts=5
-  for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
-    # Linking to the loopback asks WirePlumber to replace A2DP with a capture
-    # profile. Poll that card's active profile, then relink once it has an input.
-    pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null
-    sleep 0.2
+      if bluetooth_input_ready && pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null; then
+        moved=true
+        break
+      fi
+    done
 
-    if bluetooth_input_ready && pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null; then
-      moved=true
-      break
+    if [[ $moved == false ]]; then
+      echo "Failed to move audio input stream $source_output_id to $source_name after $max_attempts attempts" >&2
+      move_failed=1
     fi
-  done
-
-  if [[ $moved == false ]]; then
-    echo "Failed to move audio input stream $source_output_id to $source_name after $max_attempts attempts" >&2
-    move_failed=1
+  else
+    pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null
   fi
 done < <(awk '{ print $1 }' <<<"$source_outputs")
 

--- a/bin/omarchy-audio-input-set-default
+++ b/bin/omarchy-audio-input-set-default
@@ -17,48 +17,77 @@ pactl_status=0
 wpctl set-default "$node_id" 2>/dev/null || wpctl_status=$?
 pactl set-default-source "$source_name" 2>/dev/null || pactl_status=$?
 
-if (( wpctl_status != 0 && pactl_status != 0 )); then
-  echo "Failed to set default audio input: $source_name" >&2
+is_bluetooth=false
+if [[ $source_name == bluez_input.* ]]; then
+  is_bluetooth=true
+fi
+
+report_bluetooth_failure() {
+  echo "$1" >&2
+  omarchy-notification-send -u critical "Bluetooth microphone unavailable" \
+    "Reconnect the headset or select another input device." 2>/dev/null
+}
+
+if (( wpctl_status != 0 && pactl_status != 0 )) && [[ $is_bluetooth == true ]]; then
+  report_bluetooth_failure "Failed to set default audio input: $source_name"
   exit 1
 fi
 
 if ! source_outputs=$(pactl list short source-outputs 2>/dev/null); then
-  echo "Failed to list active audio input streams" >&2
-  exit 1
+  if [[ $is_bluetooth == true ]]; then
+    report_bluetooth_failure "Failed to list active audio input streams"
+    exit 1
+  fi
+
+  exit 0
 fi
 
-move_failed=0
-while read -r output; do
-  [[ -n $output ]] || continue
+bluetooth_card_name=""
+if [[ $is_bluetooth == true ]]; then
+  bluetooth_card_name=$(pactl --format=json list sources 2>/dev/null | jq -r --arg source "$source_name" \
+    'first(.[] | select(.name == $source) | .properties["device.name"]) // empty' 2>/dev/null)
+fi
 
-  max_attempts=1
-  if [[ $source_name == bluez_input.* ]]; then
-    max_attempts=5
+bluetooth_input_ready() {
+  local cards
+  [[ -n $bluetooth_card_name ]] || return 1
+  cards=$(pactl --format=json list cards 2>/dev/null) || return 1
+  jq -e --arg card "$bluetooth_card_name" \
+    'any(.[]; .name == $card and ((.profiles[.active_profile].sources // 0) > 0))' \
+    <<<"$cards" >/dev/null 2>&1
+}
+
+move_failed=0
+while read -r source_output_id; do
+  [[ -n $source_output_id ]] || continue
+
+  if [[ $is_bluetooth == false ]]; then
+    pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null
+    continue
   fi
 
   moved=false
+  max_attempts=5
   for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
-    if pactl move-source-output "$output" "$source_name" 2>/dev/null; then
+    # Linking to the loopback asks WirePlumber to replace A2DP with a capture
+    # profile. Poll that card's active profile, then relink once it has an input.
+    pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null
+    sleep 0.2
+
+    if bluetooth_input_ready && pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null; then
       moved=true
-
-      # The first link starts WirePlumber's A2DP-to-HFP graph rebuild. Relink
-      # once after it settles because that initial asynchronous link can vanish.
-      if (( max_attempts > 1 && attempt == 1 )); then
-        sleep 0.2
-        continue
-      fi
-
       break
     fi
-
-    moved=false
-    (( attempt == max_attempts )) || sleep 0.2
   done
 
   if [[ $moved == false ]]; then
-    echo "Failed to move audio input stream $output to $source_name after $max_attempts attempts" >&2
+    echo "Failed to move audio input stream $source_output_id to $source_name after $max_attempts attempts" >&2
     move_failed=1
   fi
 done < <(awk '{ print $1 }' <<<"$source_outputs")
+
+if (( move_failed != 0 )); then
+  report_bluetooth_failure "Bluetooth audio input did not become ready: $source_name"
+fi
 
 exit "$move_failed"

--- a/bin/omarchy-audio-input-set-default
+++ b/bin/omarchy-audio-input-set-default
@@ -55,37 +55,62 @@ bluetooth_input_ready() {
   [[ -n $bluetooth_card_name ]] || return 1
   sources=$(pactl --format=json list sources 2>/dev/null) || return 1
   jq -e --arg card "$bluetooth_card_name" --arg loopback "$source_name" \
-    'any(.[]; .name != $loopback and .properties["device.name"] == $card and .properties["bluez5.loopback"] != "true")' \
+    'any(.[]; .name != $loopback and .properties["device.name"] == $card and .properties["media.class"] == "Audio/Source" and .properties["bluez5.loopback"] != "true")' \
     <<<"$sources" >/dev/null 2>&1
 }
 
 move_failed=0
-while read -r source_output_id; do
-  [[ -n $source_output_id ]] || continue
+if [[ $is_bluetooth == true && -n $source_outputs ]]; then
+  pw-record --target "$source_name" --raw /dev/null >/dev/null 2>&1 &
+  trigger_pid=$!
 
-  if [[ $is_bluetooth == true ]]; then
-    moved=false
-    max_attempts=15
-    for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
-      # Linking to the loopback asks WirePlumber to replace A2DP with a capture
-      # profile. Poll for its physical source, then relink after the graph exists.
-      pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null
-      sleep 0.2
+  stop_trigger() {
+    kill "$trigger_pid" 2>/dev/null
+    wait "$trigger_pid" 2>/dev/null
+    return 0
+  }
+  trap stop_trigger EXIT
 
-      if bluetooth_input_ready && pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null; then
-        moved=true
-        break
-      fi
-    done
-
-    if [[ $moved == false ]]; then
-      echo "Failed to move audio input stream $source_output_id to $source_name after $max_attempts attempts" >&2
-      move_failed=1
+  input_ready=false
+  for (( attempt = 1; attempt <= 15; attempt++ )); do
+    sleep 0.2
+    if bluetooth_input_ready; then
+      input_ready=true
+      break
     fi
+  done
+
+  if [[ $input_ready == true ]]; then
+    while read -r source_output_id; do
+      [[ -n $source_output_id ]] || continue
+
+      moved=false
+      for (( attempt = 1; attempt <= 5; attempt++ )); do
+        if pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null; then
+          moved=true
+          break
+        fi
+        sleep 0.1
+      done
+
+      if [[ $moved == false ]]; then
+        echo "Failed to move audio input stream $source_output_id to $source_name after 5 attempts" >&2
+        move_failed=1
+      fi
+    done < <(awk '{ print $1 }' <<<"$source_outputs")
   else
-    pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null
+    echo "Bluetooth audio input did not become ready after 15 attempts: $source_name" >&2
+    move_failed=1
   fi
-done < <(awk '{ print $1 }' <<<"$source_outputs")
+
+  stop_trigger
+  trap - EXIT
+else
+  while read -r source_output_id; do
+    [[ -n $source_output_id ]] || continue
+    pactl move-source-output "$source_output_id" "$source_name" 2>/dev/null
+  done < <(awk '{ print $1 }' <<<"$source_outputs")
+fi
 
 if (( move_failed != 0 )); then
   report_bluetooth_failure "Bluetooth audio input did not become ready: $source_name"

--- a/bin/omarchy-audio-input-set-default
+++ b/bin/omarchy-audio-input-set-default
@@ -55,7 +55,7 @@ bluetooth_input_ready() {
   [[ -n $bluetooth_card_name ]] || return 1
   sources=$(pactl --format=json list sources 2>/dev/null) || return 1
   jq -e --arg card "$bluetooth_card_name" --arg loopback "$source_name" \
-    'any(.[]; .name != $loopback and .properties["device.name"] == $card and .properties["media.class"] == "Audio/Source" and .properties["bluez5.loopback"] != "true")' \
+    'any(.[]; .name != $loopback and (.monitor_source // "") == "" and .properties["device.name"] == $card and .properties["device.class"] != "monitor" and .properties["media.class"] == "Audio/Source" and .properties["bluez5.loopback"] != "true")' \
     <<<"$sources" >/dev/null 2>&1
 }
 

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -69,9 +69,9 @@ if [[ $* == "--format=json list sources" ]]; then
   (( polls += 1 ))
   printf '%s\n' "$polls" >"$AUDIO_SOURCE_POLLS"
   if (( polls >= ${AUDIO_SOURCE_READY_AFTER:-3} )) && [[ -f $AUDIO_TRIGGER_STATE ]]; then
-    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"true"}},{"name":"bluez_output.AA_BB_CC_DD_EE_FF.1.monitor","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Sink","device.class":"monitor"}},{"name":"bluez_input.AA_BB_CC_DD_EE_FF.0","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"false"}}]\n'
+    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","monitor_source":"","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"true"}},{"name":"bluez_output.AA_BB_CC_DD_EE_FF.1.monitor","monitor_source":"bluez_output.AA_BB_CC_DD_EE_FF.1","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","device.class":"monitor"}},{"name":"bluez_input.AA_BB_CC_DD_EE_FF.0","monitor_source":"","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","device.class":"sound","bluez5.loopback":"false"}}]\n'
   else
-    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"true"}},{"name":"bluez_output.AA_BB_CC_DD_EE_FF.1.monitor","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Sink","device.class":"monitor"}}]\n'
+    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","monitor_source":"","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"true"}},{"name":"bluez_output.AA_BB_CC_DD_EE_FF.1.monitor","monitor_source":"bluez_output.AA_BB_CC_DD_EE_FF.1","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","device.class":"monitor"}}]\n'
   fi
 elif [[ $* == "list short source-outputs" ]]; then
   printf '71\tPipeWire\n'
@@ -86,6 +86,7 @@ elif [[ $1 == "move-source-output" && $3 == bluez_input.* ]]; then
   [[ ! -f $AUDIO_ATTEMPTS ]] || attempts=$(<"$AUDIO_ATTEMPTS")
   (( attempts += 1 ))
   printf '%s\n' "$attempts" >"$AUDIO_ATTEMPTS"
+  (( attempts > ${AUDIO_MOVE_FAILURES:-0} ))
 elif [[ $1 == "move-source-output" && ${AUDIO_ALSA_MOVE_FAIL:-0} == "1" ]]; then
   exit 1
 fi
@@ -121,7 +122,8 @@ audio_trigger_state="$tmp_dir/trigger-state"
 run_input_switch() {
   AUDIO_CALLS="$audio_calls" AUDIO_ATTEMPTS="$audio_attempts" AUDIO_SOURCE_POLLS="$audio_source_polls" \
     AUDIO_EARLY_MOVE="$audio_early_move" AUDIO_TRIGGER_STATE="$audio_trigger_state" \
-    AUDIO_SOURCE_READY_AFTER="${AUDIO_SOURCE_READY_AFTER:-3}" AUDIO_ALSA_MOVE_FAIL="${AUDIO_ALSA_MOVE_FAIL:-0}" \
+    AUDIO_SOURCE_READY_AFTER="${AUDIO_SOURCE_READY_AFTER:-3}" AUDIO_MOVE_FAILURES="${AUDIO_MOVE_FAILURES:-0}" \
+    AUDIO_ALSA_MOVE_FAIL="${AUDIO_ALSA_MOVE_FAIL:-0}" \
     PATH="$tmp_dir/bin:$PATH" \
     "$ROOT/bin/omarchy-audio-input-set-default" "$@"
 }
@@ -141,6 +143,30 @@ grep -Fq 'pw-record stopped' "$audio_calls" ||
 ! grep -Fq 'set-card-profile' "$audio_calls" ||
   fail "audio leaves Bluetooth profile selection and restoration to WirePlumber" "$(<"$audio_calls")"
 pass "audio waits for the physical Bluetooth source without forcing a profile"
+
+: >"$audio_calls"
+: >"$audio_attempts"
+rm -f "$audio_source_polls" "$audio_early_move"
+AUDIO_MOVE_FAILURES=2 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF
+[[ $(<"$audio_attempts") == "3" ]] ||
+  fail "audio retries a transient move after Bluetooth becomes ready" "$(<"$audio_calls")"
+[[ ! -e $audio_trigger_state ]] ||
+  fail "audio stops its Bluetooth trigger after a retried move" "$(<"$audio_calls")"
+pass "audio retries transient moves after Bluetooth becomes ready"
+
+: >"$audio_calls"
+: >"$audio_attempts"
+rm -f "$audio_source_polls" "$audio_early_move"
+if AUDIO_MOVE_FAILURES=5 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF 2>/dev/null; then
+  fail "audio reports exhausted post-readiness move retries"
+fi
+[[ $(<"$audio_attempts") == "5" ]] ||
+  fail "audio bounds post-readiness move retries" "$(<"$audio_calls")"
+grep -Fq 'omarchy-notification-send -u critical Bluetooth microphone unavailable' "$audio_calls" ||
+  fail "audio notifies when post-readiness moves are exhausted" "$(<"$audio_calls")"
+[[ ! -e $audio_trigger_state ]] ||
+  fail "audio stops its Bluetooth trigger after move failure" "$(<"$audio_calls")"
+pass "audio reports exhausted post-readiness move retries"
 
 : >"$audio_calls"
 : >"$audio_attempts"

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -64,16 +64,24 @@ cat >"$tmp_dir/bin/pactl" <<'EOF'
 printf 'pactl %s\n' "$*" >>"$AUDIO_CALLS"
 
 if [[ $* == "--format=json list sources" ]]; then
-  attempts=0
-  [[ ! -f $AUDIO_ATTEMPTS ]] || attempts=$(<"$AUDIO_ATTEMPTS")
-  if (( attempts >= ${AUDIO_SOURCE_READY_AFTER:-3} )); then
-    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","bluez5.loopback":"true"}},{"name":"bluez_input.AA_BB_CC_DD_EE_FF.0","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","bluez5.loopback":"false"}}]\n'
+  polls=0
+  [[ ! -f $AUDIO_SOURCE_POLLS ]] || polls=$(<"$AUDIO_SOURCE_POLLS")
+  (( polls += 1 ))
+  printf '%s\n' "$polls" >"$AUDIO_SOURCE_POLLS"
+  if (( polls >= ${AUDIO_SOURCE_READY_AFTER:-3} )); then
+    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"true"}},{"name":"bluez_output.AA_BB_CC_DD_EE_FF.1.monitor","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Sink","device.class":"monitor"}},{"name":"bluez_input.AA_BB_CC_DD_EE_FF.0","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"false"}}]\n'
   else
-    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","bluez5.loopback":"true"}}]\n'
+    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"true"}},{"name":"bluez_output.AA_BB_CC_DD_EE_FF.1.monitor","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Sink","device.class":"monitor"}}]\n'
   fi
 elif [[ $* == "list short source-outputs" ]]; then
   printf '71\tPipeWire\n'
 elif [[ $1 == "move-source-output" && $3 == bluez_input.* ]]; then
+  polls=0
+  [[ ! -f $AUDIO_SOURCE_POLLS ]] || polls=$(<"$AUDIO_SOURCE_POLLS")
+  if (( polls < ${AUDIO_SOURCE_READY_AFTER:-3} )); then
+    printf 'early\n' >"$AUDIO_EARLY_MOVE"
+    exit 1
+  fi
   attempts=0
   [[ ! -f $AUDIO_ATTEMPTS ]] || attempts=$(<"$AUDIO_ATTEMPTS")
   (( attempts += 1 ))
@@ -84,6 +92,14 @@ fi
 EOF
 chmod +x "$tmp_dir/bin/pactl"
 
+cat >"$tmp_dir/bin/pw-record" <<'EOF'
+#!/bin/bash
+printf 'pw-record %s\n' "$*" >>"$AUDIO_CALLS"
+trap 'exit 0' TERM INT
+while true; do sleep 1; done
+EOF
+chmod +x "$tmp_dir/bin/pw-record"
+
 cat >"$tmp_dir/bin/omarchy-notification-send" <<'EOF'
 #!/bin/bash
 printf 'omarchy-notification-send %s\n' "$*" >>"$AUDIO_CALLS"
@@ -92,9 +108,12 @@ chmod +x "$tmp_dir/bin/omarchy-notification-send"
 
 audio_calls="$tmp_dir/calls"
 audio_attempts="$tmp_dir/attempts"
+audio_source_polls="$tmp_dir/source-polls"
+audio_early_move="$tmp_dir/early-move"
 
 run_input_switch() {
-  AUDIO_CALLS="$audio_calls" AUDIO_ATTEMPTS="$audio_attempts" \
+  AUDIO_CALLS="$audio_calls" AUDIO_ATTEMPTS="$audio_attempts" AUDIO_SOURCE_POLLS="$audio_source_polls" \
+    AUDIO_EARLY_MOVE="$audio_early_move" \
     AUDIO_SOURCE_READY_AFTER="${AUDIO_SOURCE_READY_AFTER:-3}" AUDIO_ALSA_MOVE_FAIL="${AUDIO_ALSA_MOVE_FAIL:-0}" \
     PATH="$tmp_dir/bin:$PATH" \
     "$ROOT/bin/omarchy-audio-input-set-default" "$@"
@@ -102,19 +121,22 @@ run_input_switch() {
 
 : >"$audio_calls"
 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF
-[[ $(<"$audio_attempts") == "4" ]] ||
-  fail "audio waits for the physical Bluetooth source before its final move" "$(<"$audio_calls")"
+[[ $(<"$audio_attempts") == "1" ]] ||
+  fail "audio moves the active stream once after Bluetooth is ready" "$(<"$audio_calls")"
+[[ ! -e $audio_early_move ]] ||
+  fail "audio does not move active streams during the Bluetooth graph rebuild" "$(<"$audio_calls")"
 ! grep -Fq 'set-card-profile' "$audio_calls" ||
   fail "audio leaves Bluetooth profile selection and restoration to WirePlumber" "$(<"$audio_calls")"
 pass "audio waits for the physical Bluetooth source without forcing a profile"
 
 : >"$audio_calls"
 : >"$audio_attempts"
+rm -f "$audio_source_polls" "$audio_early_move"
 if AUDIO_SOURCE_READY_AFTER=99 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF 2>/dev/null; then
   fail "audio reports an exhausted Bluetooth capture move"
 fi
-[[ $(<"$audio_attempts") == "15" ]] ||
-  fail "audio bounds Bluetooth capture move retries" "$(<"$audio_calls")"
+[[ ! -s $audio_attempts ]] ||
+  fail "audio leaves active streams untouched when Bluetooth readiness is exhausted" "$(<"$audio_calls")"
 grep -Fq 'omarchy-notification-send -u critical Bluetooth microphone unavailable' "$audio_calls" ||
   fail "audio notifies when Bluetooth capture routing is exhausted" "$(<"$audio_calls")"
 pass "audio reports an exhausted Bluetooth capture move after bounded retries"

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -63,23 +63,41 @@ cat >"$tmp_dir/bin/pactl" <<'EOF'
 
 printf 'pactl %s\n' "$*" >>"$AUDIO_CALLS"
 
-if [[ $* == "list short source-outputs" ]]; then
+if [[ $* == "--format=json list sources" ]]; then
+  printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF"}}]\n'
+elif [[ $* == "--format=json list cards" ]]; then
+  attempts=0
+  [[ ! -f $AUDIO_ATTEMPTS ]] || attempts=$(<"$AUDIO_ATTEMPTS")
+  if (( attempts >= ${AUDIO_PROFILE_READY_AFTER:-1} )); then
+    printf '[{"name":"bluez_card.AA_BB_CC_DD_EE_FF","active_profile":"duplex","profiles":{"duplex":{"sources":1}}}]\n'
+  else
+    printf '[{"name":"bluez_card.AA_BB_CC_DD_EE_FF","active_profile":"playback","profiles":{"playback":{"sources":0}}}]\n'
+  fi
+elif [[ $* == "list short source-outputs" ]]; then
   printf '71\tPipeWire\n'
 elif [[ $1 == "move-source-output" && $3 == bluez_input.* ]]; then
   attempts=0
   [[ ! -f $AUDIO_ATTEMPTS ]] || attempts=$(<"$AUDIO_ATTEMPTS")
   (( attempts += 1 ))
   printf '%s\n' "$attempts" >"$AUDIO_ATTEMPTS"
-  (( attempts > ${AUDIO_MOVE_FAILURES:-0} ))
+elif [[ $1 == "move-source-output" && ${AUDIO_ALSA_MOVE_FAIL:-0} == "1" ]]; then
+  exit 1
 fi
 EOF
 chmod +x "$tmp_dir/bin/pactl"
+
+cat >"$tmp_dir/bin/omarchy-notification-send" <<'EOF'
+#!/bin/bash
+printf 'omarchy-notification-send %s\n' "$*" >>"$AUDIO_CALLS"
+EOF
+chmod +x "$tmp_dir/bin/omarchy-notification-send"
 
 audio_calls="$tmp_dir/calls"
 audio_attempts="$tmp_dir/attempts"
 
 run_input_switch() {
-  AUDIO_CALLS="$audio_calls" AUDIO_ATTEMPTS="$audio_attempts" AUDIO_MOVE_FAILURES="${AUDIO_MOVE_FAILURES:-0}" \
+  AUDIO_CALLS="$audio_calls" AUDIO_ATTEMPTS="$audio_attempts" \
+    AUDIO_PROFILE_READY_AFTER="${AUDIO_PROFILE_READY_AFTER:-1}" AUDIO_ALSA_MOVE_FAIL="${AUDIO_ALSA_MOVE_FAIL:-0}" \
     PATH="$tmp_dir/bin:$PATH" \
     "$ROOT/bin/omarchy-audio-input-set-default" "$@"
 }
@@ -92,11 +110,13 @@ pass "audio retries a Bluetooth capture move after its graph is rebuilt"
 
 : >"$audio_calls"
 : >"$audio_attempts"
-if AUDIO_MOVE_FAILURES=5 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF 2>/dev/null; then
+if AUDIO_PROFILE_READY_AFTER=99 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF 2>/dev/null; then
   fail "audio reports an exhausted Bluetooth capture move"
 fi
 [[ $(<"$audio_attempts") == "5" ]] ||
   fail "audio bounds Bluetooth capture move retries" "$(<"$audio_calls")"
+grep -Fq 'omarchy-notification-send -u critical Bluetooth microphone unavailable' "$audio_calls" ||
+  fail "audio notifies when Bluetooth capture routing is exhausted" "$(<"$audio_calls")"
 pass "audio reports an exhausted Bluetooth capture move after bounded retries"
 
 : >"$audio_calls"
@@ -104,3 +124,8 @@ run_input_switch 44 alsa_input.usb-Generic_USB_Audio-00.mono-fallback
 [[ $(grep -Fc 'pactl move-source-output 71 alsa_input.usb-Generic_USB_Audio-00.mono-fallback' "$audio_calls") == "1" ]] ||
   fail "audio moves an ordinary capture stream once" "$(<"$audio_calls")"
 pass "audio moves an ordinary capture stream once"
+
+if ! AUDIO_ALSA_MOVE_FAIL=1 run_input_switch 44 alsa_input.usb-Generic_USB_Audio-00.mono-fallback; then
+  fail "audio keeps ordinary capture stream moves best effort"
+fi
+pass "audio keeps ordinary capture stream moves best effort"

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -68,7 +68,7 @@ if [[ $* == "--format=json list sources" ]]; then
   [[ ! -f $AUDIO_SOURCE_POLLS ]] || polls=$(<"$AUDIO_SOURCE_POLLS")
   (( polls += 1 ))
   printf '%s\n' "$polls" >"$AUDIO_SOURCE_POLLS"
-  if (( polls >= ${AUDIO_SOURCE_READY_AFTER:-3} )); then
+  if (( polls >= ${AUDIO_SOURCE_READY_AFTER:-3} )) && [[ -f $AUDIO_TRIGGER_STATE ]]; then
     printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"true"}},{"name":"bluez_output.AA_BB_CC_DD_EE_FF.1.monitor","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Sink","device.class":"monitor"}},{"name":"bluez_input.AA_BB_CC_DD_EE_FF.0","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"false"}}]\n'
   else
     printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Source","bluez5.loopback":"true"}},{"name":"bluez_output.AA_BB_CC_DD_EE_FF.1.monitor","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","media.class":"Audio/Sink","device.class":"monitor"}}]\n'
@@ -95,7 +95,13 @@ chmod +x "$tmp_dir/bin/pactl"
 cat >"$tmp_dir/bin/pw-record" <<'EOF'
 #!/bin/bash
 printf 'pw-record %s\n' "$*" >>"$AUDIO_CALLS"
-trap 'exit 0' TERM INT
+printf 'running\n' >"$AUDIO_TRIGGER_STATE"
+stop_trigger() {
+  rm -f "$AUDIO_TRIGGER_STATE"
+  printf 'pw-record stopped\n' >>"$AUDIO_CALLS"
+  exit 0
+}
+trap stop_trigger TERM INT
 while true; do sleep 1; done
 EOF
 chmod +x "$tmp_dir/bin/pw-record"
@@ -110,10 +116,11 @@ audio_calls="$tmp_dir/calls"
 audio_attempts="$tmp_dir/attempts"
 audio_source_polls="$tmp_dir/source-polls"
 audio_early_move="$tmp_dir/early-move"
+audio_trigger_state="$tmp_dir/trigger-state"
 
 run_input_switch() {
   AUDIO_CALLS="$audio_calls" AUDIO_ATTEMPTS="$audio_attempts" AUDIO_SOURCE_POLLS="$audio_source_polls" \
-    AUDIO_EARLY_MOVE="$audio_early_move" \
+    AUDIO_EARLY_MOVE="$audio_early_move" AUDIO_TRIGGER_STATE="$audio_trigger_state" \
     AUDIO_SOURCE_READY_AFTER="${AUDIO_SOURCE_READY_AFTER:-3}" AUDIO_ALSA_MOVE_FAIL="${AUDIO_ALSA_MOVE_FAIL:-0}" \
     PATH="$tmp_dir/bin:$PATH" \
     "$ROOT/bin/omarchy-audio-input-set-default" "$@"
@@ -125,6 +132,12 @@ run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF
   fail "audio moves the active stream once after Bluetooth is ready" "$(<"$audio_calls")"
 [[ ! -e $audio_early_move ]] ||
   fail "audio does not move active streams during the Bluetooth graph rebuild" "$(<"$audio_calls")"
+[[ ! -e $audio_trigger_state ]] ||
+  fail "audio stops its Bluetooth readiness trigger after routing succeeds" "$(<"$audio_calls")"
+grep -Fq 'pw-record stopped' "$audio_calls" ||
+  fail "audio reaps its Bluetooth readiness trigger" "$(<"$audio_calls")"
+[[ $(grep -E '^(pw-record |pactl move-source-output)' "$audio_calls") == $'pw-record --target bluez_input.AA:BB:CC:DD:EE:FF --raw /dev/null\npactl move-source-output 71 bluez_input.AA:BB:CC:DD:EE:FF\npw-record stopped' ]] ||
+  fail "audio triggers Bluetooth before moving the active stream" "$(<"$audio_calls")"
 ! grep -Fq 'set-card-profile' "$audio_calls" ||
   fail "audio leaves Bluetooth profile selection and restoration to WirePlumber" "$(<"$audio_calls")"
 pass "audio waits for the physical Bluetooth source without forcing a profile"
@@ -139,6 +152,10 @@ fi
   fail "audio leaves active streams untouched when Bluetooth readiness is exhausted" "$(<"$audio_calls")"
 grep -Fq 'omarchy-notification-send -u critical Bluetooth microphone unavailable' "$audio_calls" ||
   fail "audio notifies when Bluetooth capture routing is exhausted" "$(<"$audio_calls")"
+[[ ! -e $audio_trigger_state ]] ||
+  fail "audio stops its Bluetooth readiness trigger after timeout" "$(<"$audio_calls")"
+grep -Fq 'pw-record stopped' "$audio_calls" ||
+  fail "audio reaps its timed-out Bluetooth readiness trigger" "$(<"$audio_calls")"
 pass "audio reports an exhausted Bluetooth capture move after bounded retries"
 
 : >"$audio_calls"

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -47,3 +47,60 @@ assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spo
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
 JS
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+
+cat >"$tmp_dir/bin/wpctl" <<'EOF'
+#!/bin/bash
+printf 'wpctl %s\n' "$*" >>"$AUDIO_CALLS"
+EOF
+chmod +x "$tmp_dir/bin/wpctl"
+
+cat >"$tmp_dir/bin/pactl" <<'EOF'
+#!/bin/bash
+
+printf 'pactl %s\n' "$*" >>"$AUDIO_CALLS"
+
+if [[ $* == "list short source-outputs" ]]; then
+  printf '71\tPipeWire\n'
+elif [[ $1 == "move-source-output" && $3 == bluez_input.* ]]; then
+  attempts=0
+  [[ ! -f $AUDIO_ATTEMPTS ]] || attempts=$(<"$AUDIO_ATTEMPTS")
+  (( attempts += 1 ))
+  printf '%s\n' "$attempts" >"$AUDIO_ATTEMPTS"
+  (( attempts > ${AUDIO_MOVE_FAILURES:-0} ))
+fi
+EOF
+chmod +x "$tmp_dir/bin/pactl"
+
+audio_calls="$tmp_dir/calls"
+audio_attempts="$tmp_dir/attempts"
+
+run_input_switch() {
+  AUDIO_CALLS="$audio_calls" AUDIO_ATTEMPTS="$audio_attempts" AUDIO_MOVE_FAILURES="${AUDIO_MOVE_FAILURES:-0}" \
+    PATH="$tmp_dir/bin:$PATH" \
+    "$ROOT/bin/omarchy-audio-input-set-default" "$@"
+}
+
+: >"$audio_calls"
+run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF
+[[ $(<"$audio_attempts") == "2" ]] ||
+  fail "audio retries a Bluetooth capture move after its graph is rebuilt" "$(<"$audio_calls")"
+pass "audio retries a Bluetooth capture move after its graph is rebuilt"
+
+: >"$audio_calls"
+: >"$audio_attempts"
+if AUDIO_MOVE_FAILURES=5 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF 2>/dev/null; then
+  fail "audio reports an exhausted Bluetooth capture move"
+fi
+[[ $(<"$audio_attempts") == "5" ]] ||
+  fail "audio bounds Bluetooth capture move retries" "$(<"$audio_calls")"
+pass "audio reports an exhausted Bluetooth capture move after bounded retries"
+
+: >"$audio_calls"
+run_input_switch 44 alsa_input.usb-Generic_USB_Audio-00.mono-fallback
+[[ $(grep -Fc 'pactl move-source-output 71 alsa_input.usb-Generic_USB_Audio-00.mono-fallback' "$audio_calls") == "1" ]] ||
+  fail "audio moves an ordinary capture stream once" "$(<"$audio_calls")"
+pass "audio moves an ordinary capture stream once"

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -64,14 +64,12 @@ cat >"$tmp_dir/bin/pactl" <<'EOF'
 printf 'pactl %s\n' "$*" >>"$AUDIO_CALLS"
 
 if [[ $* == "--format=json list sources" ]]; then
-  printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF"}}]\n'
-elif [[ $* == "--format=json list cards" ]]; then
   attempts=0
   [[ ! -f $AUDIO_ATTEMPTS ]] || attempts=$(<"$AUDIO_ATTEMPTS")
-  if (( attempts >= ${AUDIO_PROFILE_READY_AFTER:-1} )); then
-    printf '[{"name":"bluez_card.AA_BB_CC_DD_EE_FF","active_profile":"duplex","profiles":{"duplex":{"sources":1}}}]\n'
+  if (( attempts >= ${AUDIO_SOURCE_READY_AFTER:-3} )); then
+    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","bluez5.loopback":"true"}},{"name":"bluez_input.AA_BB_CC_DD_EE_FF.0","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","bluez5.loopback":"false"}}]\n'
   else
-    printf '[{"name":"bluez_card.AA_BB_CC_DD_EE_FF","active_profile":"playback","profiles":{"playback":{"sources":0}}}]\n'
+    printf '[{"name":"bluez_input.AA:BB:CC:DD:EE:FF","properties":{"device.name":"bluez_card.AA_BB_CC_DD_EE_FF","bluez5.loopback":"true"}}]\n'
   fi
 elif [[ $* == "list short source-outputs" ]]; then
   printf '71\tPipeWire\n'
@@ -97,23 +95,25 @@ audio_attempts="$tmp_dir/attempts"
 
 run_input_switch() {
   AUDIO_CALLS="$audio_calls" AUDIO_ATTEMPTS="$audio_attempts" \
-    AUDIO_PROFILE_READY_AFTER="${AUDIO_PROFILE_READY_AFTER:-1}" AUDIO_ALSA_MOVE_FAIL="${AUDIO_ALSA_MOVE_FAIL:-0}" \
+    AUDIO_SOURCE_READY_AFTER="${AUDIO_SOURCE_READY_AFTER:-3}" AUDIO_ALSA_MOVE_FAIL="${AUDIO_ALSA_MOVE_FAIL:-0}" \
     PATH="$tmp_dir/bin:$PATH" \
     "$ROOT/bin/omarchy-audio-input-set-default" "$@"
 }
 
 : >"$audio_calls"
 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF
-[[ $(<"$audio_attempts") == "2" ]] ||
-  fail "audio retries a Bluetooth capture move after its graph is rebuilt" "$(<"$audio_calls")"
-pass "audio retries a Bluetooth capture move after its graph is rebuilt"
+[[ $(<"$audio_attempts") == "4" ]] ||
+  fail "audio waits for the physical Bluetooth source before its final move" "$(<"$audio_calls")"
+! grep -Fq 'set-card-profile' "$audio_calls" ||
+  fail "audio leaves Bluetooth profile selection and restoration to WirePlumber" "$(<"$audio_calls")"
+pass "audio waits for the physical Bluetooth source without forcing a profile"
 
 : >"$audio_calls"
 : >"$audio_attempts"
-if AUDIO_PROFILE_READY_AFTER=99 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF 2>/dev/null; then
+if AUDIO_SOURCE_READY_AFTER=99 run_input_switch 43 bluez_input.AA:BB:CC:DD:EE:FF 2>/dev/null; then
   fail "audio reports an exhausted Bluetooth capture move"
 fi
-[[ $(<"$audio_attempts") == "5" ]] ||
+[[ $(<"$audio_attempts") == "15" ]] ||
   fail "audio bounds Bluetooth capture move retries" "$(<"$audio_calls")"
 grep -Fq 'omarchy-notification-send -u critical Bluetooth microphone unavailable' "$audio_calls" ||
   fail "audio notifies when Bluetooth capture routing is exhausted" "$(<"$audio_calls")"


### PR DESCRIPTION
## Summary

- trigger WirePlumber Bluetooth profile autoswitch with a temporary capture stream before moving active application streams
- wait for the card's physical, non-monitor Bluetooth source before routing applications, with bounded move retries and an actionable failure notification
- leave profile selection and A2DP restoration to WirePlumber, while preserving the existing best-effort path for ALSA and USB inputs

## Why

Moving an existing capture stream directly to the stable `bluez_input.*` loopback can race WirePlumber while it replaces the A2DP graph with HFP. The initial link may disappear before its format is established, leaving the selected microphone silent.

The helper now uses a disposable `pw-record` stream to request the profile transition without disturbing existing application streams. Once the corresponding physical Bluetooth source exists, it moves those streams and removes the trigger. No card profile is forced, so WirePlumber can restore A2DP when capture ends.

## Testing

- `bash test/shell.d/audio-test.sh`
- `bash -n bin/omarchy-audio-input-set-default test/shell.d/audio-test.sh`
- `git diff --check upstream/quattro...HEAD`
- `env -u WAYLAND_DISPLAY -u HYPRLAND_INSTANCE_SIGNATURE ./test/all` (all 221 test files passed)

Fixes #9380