### PR TITLE
Clear set-ID bits when securing the Windows VM mount sources

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,7 +580,9 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  # Symbolic, because a numeric mode leaves S_ISGID standing on a directory and
+  # the mode check below then rejects a source we were asked to secure.
+  chmod u=rwx,go=,a-s -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
@@ -588,6 +590,7 @@ prepare_caller_mounts() {
   storage_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$storage_fd" 2>/dev/null) || storage_mode=""
   shared_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$shared_fd" 2>/dev/null) || shared_mode=""
   if [[ $storage_mode != 700 || $shared_mode != 700 ]]; then
+    echo "omarchy-windows-vm: could not secure mount sources to mode 700 (storage=$storage_mode shared=$shared_mode)" >&2
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
@@ -1015,7 +1018,7 @@ prepare_user_mount_sources() {
     echo "omarchy-windows-vm: storage and shared must be different directories" >&2
     return 1
   }
-  chmod 0700 -- "$storage" "$shared"
+  chmod u=rwx,go=,a-s -- "$storage" "$shared"
 }
 
 storage_space_path() {
@@ -1058,7 +1061,7 @@ write_credentials() {
   local username="$1" password="$2" old_umask dir tmp
   dir=$(dirname -- "$CREDENTIALS_FILE")
   mkdir -p "$dir" || return 1
-  chmod 0700 "$dir" || return 1
+  chmod u=rwx,go=,a-s -- "$dir" || return 1
   old_umask=$(umask)
   umask 077
   tmp=$(mktemp "$dir/.credentials.XXXXXX") || { umask "$old_umask"; return 1; }

--- a/test/shell.d/windows-vm-compose-test.sh
+++ b/test/shell.d/windows-vm-compose-test.sh
@@ -176,6 +176,22 @@ resolve_caller
 find "$CALLER_DATA_ROOT" -name 'rejected-*' -print -quit | grep -q . && fail "source was quarantined"
 pass "invalid second source leaves paths and anchors untouched and leaks no FD"
 
+# A set-ID bit on either source must not survive the privacy step. `chmod 0700`
+# leaves S_ISGID standing on a directory, and the exact mode 700 the elevated
+# path then demands would reject a source it had just been asked to secure.
+reset_case
+mkdir -p "$HOME/.windows" "$HOME/Windows"
+chmod 2700 "$HOME/.windows"
+chmod 6700 "$HOME/Windows"
+prepare_user_mount_sources
+[[ $(stat -Lc '%a' "$HOME/.windows") == 700 ]] || fail "setgid storage source was not cleared to 700"
+[[ $(stat -Lc '%a' "$HOME/Windows") == 700 ]] || fail "setuid/setgid shared source was not cleared to 700"
+chmod 2700 "$HOME/.windows"
+write 4G 2 64G setgid pw UTC
+resolve_caller
+[[ $(stat -Lc '%a' "$EXPECTED_STORAGE") == 700 && $(stat -Lc '%a' "$EXPECTED_SHARED") == 700 ]] || fail "mount leaves are not private after a set-ID source"
+pass "a set-ID bit on either source is cleared instead of failing the mount"
+
 # Distinct caller-owned symlink targets are supported and remain links.
 reset_case
 external_storage="$TMPDIR/external-storage"
@@ -476,6 +492,13 @@ unset -f mv
 [[ $(cat "$CREDENTIALS_FILE") == "$credentials_before" ]] || fail "failed credentials rename replaced the live file"
 ! find "$credentials_dir" -name '.credentials.*' -print -quit | grep -q . || fail "failed credentials write left a temporary file"
 pass "credentials are atomically replaced as a private regular file"
+
+# The directory holding the plaintext password is hardened the same way, so a
+# set-ID bit inherited from its parent cannot hand new credentials a group.
+chmod 2755 "$credentials_dir"
+write_credentials dave 'another-pw'
+[[ $(stat -c '%a' "$credentials_dir") == 700 ]] || fail "credentials directory kept a set-ID bit"
+pass "a set-ID bit on the credentials directory is cleared"
 
 # Free-space accounting follows the real storage target.
 reset_case


### PR DESCRIPTION
Closes #9374. Closes #9540. Closes #9567.

`omarchy-windows-vm launch` and `install` abort — the first with `❌ Failed to start Windows VM!`, the second with `❌ Failed to write the Windows VM configuration.` — when `~/Windows` or `~/.windows` carries the setgid bit. Nothing is written to stderr, so `status` reporting RUNNING and a working web console leave no way to tell what refused.

`prepare_caller_mounts()` hardens both pinned sources with `chmod 0700` and then asserts `stat -Lc '%a'` is exactly `700`. `chmod` with a numeric mode does not clear `S_ISGID` on a directory: the kernel preserves it whenever the caller is in the file's group or holds `CAP_FSETID`, which root always does. A directory at `2700` stays `2700`, `chmod` still returns 0, and the `!= 700` branch rejects a source the same function had just been asked to secure — then returns 1 without a message.

Symbolic modes clear the set-ID bits, so the check now sees the mode the chmod was meant to produce. The same substitution applies at the two other sites that make these directories private: `prepare_user_mount_sources()`, which prepares the very directories the elevated path re-checks, and `write_credentials()`, where a set-ID bit would hand the directory holding the plaintext RDP password a group it was never meant to have.

The mode-verification branch gains a diagnostic. It stays reachable for reasons a user can act on, and returning silently is what made this take three separate reports to characterise.

Reviewed by Codex at xhigh, which confirmed the mode arithmetic across every set-ID combination and pointed out that the existing suites start these directories at `0755` and so pass against the broken chmod too; the regression cases added here start them at `2700`/`6700` and fail without the fix.