### PR TITLE
omarchy #9586 sysfs battery thresholds

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -62,11 +62,27 @@ power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
   print rounded
 }')
 state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
-threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+
+# Kernel sysfs is the live threshold. UPower's charge-*-threshold fields on
+# ThinkPads are a built-in 75/80 default until ChargeThresholdEnabled is set
+# through UPower itself, so they can disagree with TLP or a manual sysfs write.
+read_sysfs_threshold() {
+  local file="$1"
+  [[ -r $file ]] || return 1
+  local value
+  value=$(<"$file")
+  [[ -n $value ]] || return 1
+  printf '%s' "$value"
+}
+
+threshold_start=$(read_sysfs_threshold "$battery_path/charge_control_start_threshold" || true)
+threshold_end=$(read_sysfs_threshold "$battery_path/charge_control_end_threshold" || true)
 
 [[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
 [[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)
+
+[[ -z $threshold_end ]] && threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+[[ -z $threshold_start ]] && threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
 
 ac_online=false
 for supply in "$power_supply_path"/*; do

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -81,8 +81,13 @@ threshold_end=$(read_sysfs_threshold "$battery_path/charge_control_end_threshold
 [[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
 [[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)
 
-[[ -z $threshold_end ]] && threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-[[ -z $threshold_start ]] && threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+# UPower is all-or-nothing: only when sysfs exposed neither attribute.
+# Per-field fallback mixes fabricated UPower start (e.g. 75) with end-only
+# sysfs devices (ASUS #7374) and renders inverted ranges like 75-60%.
+if [[ -z $threshold_start && -z $threshold_end ]]; then
+  threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+  threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+fi
 
 ac_online=false
 for supply in "$power_supply_path"/*; do

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -49,3 +49,54 @@ if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/
 fi
 
 pass "battery status owns capacity and remaining calculations"
+
+# ThinkPad UPower reports a built-in 75/80 default even when ChargeThresholdEnabled
+# is false. Live sysfs (TLP / a manual write) must win.
+printf '45\n' >"$tmp_dir/power/BAT0/charge_control_start_threshold"
+printf '65\n' >"$tmp_dir/power/BAT0/charge_control_end_threshold"
+mkdir -p "$tmp_dir/power/ADP1"
+printf 'Mains\n' >"$tmp_dir/power/ADP1/type"
+printf '1\n' >"$tmp_dir/power/ADP1/online"
+
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  state:                pending-charge
+  energy:               36.8 Wh
+  energy-full:          56.7 Wh
+  energy-rate:          0.0 W
+  percentage:           64%
+  charge-start-threshold: 75%
+  charge-end-threshold:   80%
+  charge-threshold-enabled: no
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+grep -Fx $'threshold\t45-65%' <<<"$shell_output" >/dev/null || fail "battery status prefers sysfs charge thresholds over UPower defaults"
+pass "battery status prefers sysfs charge thresholds over UPower defaults"
+grep -Fx $'state\tholding' <<<"$shell_output" >/dev/null || fail "battery status still reports holding from pending-charge"
+pass "battery status still reports holding from pending-charge"
+
+human_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status")
+grep -F 'Holding at 45-65%' <<<"$human_output" >/dev/null || fail "battery status holding line uses the live sysfs range"
+pass "battery status holding line uses the live sysfs range"
+
+# No sysfs threshold files: still accept UPower when that is all there is.
+rm -f "$tmp_dir/power/BAT0/charge_control_start_threshold" "$tmp_dir/power/BAT0/charge_control_end_threshold"
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+grep -Fx $'threshold\t75-80%' <<<"$shell_output" >/dev/null || fail "battery status falls back to UPower thresholds without sysfs"
+pass "battery status falls back to UPower thresholds without sysfs"

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -100,3 +100,10 @@ rm -f "$tmp_dir/power/BAT0/charge_control_start_threshold" "$tmp_dir/power/BAT0/
 shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
 grep -Fx $'threshold\t75-80%' <<<"$shell_output" >/dev/null || fail "battery status falls back to UPower thresholds without sysfs"
 pass "battery status falls back to UPower thresholds without sysfs"
+
+# End-only sysfs (ASUS #7374): do not mix UPower's fabricated start with sysfs end.
+rm -f "$tmp_dir/power/BAT0/charge_control_start_threshold"
+printf '60\n' >"$tmp_dir/power/BAT0/charge_control_end_threshold"
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+grep -Fx $'threshold\t60%' <<<"$shell_output" >/dev/null || fail "battery status keeps end-only sysfs without mixing UPower start"
+pass "battery status keeps end-only sysfs without mixing UPower start"


### PR DESCRIPTION
## What

- omarchy-battery-status reads live sysfs charge_control_{start,end}_threshold before UPower.
- Falls back to BAT* glob, then UPower if sysfs is empty.
- test/shell.d/battery-status-test.sh: UPower 75/80 vs sysfs 45/65 reports Holding at 45-65%; no-sysfs still uses UPower; 5 ok.

## Why

Fixes omacom/omarchy#9586. ThinkPad UPower reports a built-in 75/80 while ChargeThresholdEnabled is false, so TLP/sysfs thresholds never appeared.
