### PR TITLE
Make launch-or-focus execute argv directly

### DIFF
--- a/bin/omarchy-launch-or-focus
+++ b/bin/omarchy-launch-or-focus
@@ -1,36 +1,25 @@
 #!/bin/bash
 
 # omarchy:summary=Launch an app or focus an existing window matching a pattern
-# omarchy:args=<window-pattern> [<launch-command> | -- <command> [args...]]
+# omarchy:args=<window-pattern> [<command> [args...]]
 
 if (($# == 0)); then
-  echo "Usage: omarchy-launch-or-focus <window-pattern> [<launch-command> | -- <command> [args...]]"
+  echo "Usage: omarchy-launch-or-focus <window-pattern> [<command> [args...]]"
   exit 1
 fi
 
 WINDOW_PATTERN="$1"
 shift
 
-if [[ ${1:-} == "--" ]]; then
-  shift
-  if (( $# == 0 )); then
-    echo "omarchy-launch-or-focus: -- requires a command" >&2
-    exit 1
-  fi
+if (( $# > 0 )); then
   LAUNCH_ARGV=("$@")
-  LAUNCH_COMMAND=""
 else
-  LAUNCH_ARGV=()
-  LAUNCH_COMMAND="${1:-"uwsm-app -- $WINDOW_PATTERN"}"
+  LAUNCH_ARGV=(uwsm-app -- "$WINDOW_PATTERN")
 fi
 WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"
 else
-  if (( ${#LAUNCH_ARGV[@]} > 0 )); then
-    exec setsid "${LAUNCH_ARGV[@]}"
-  else
-    eval exec setsid $LAUNCH_COMMAND
-  fi
+  exec setsid "${LAUNCH_ARGV[@]}"
 fi

--- a/bin/omarchy-launch-or-focus
+++ b/bin/omarchy-launch-or-focus
@@ -1,19 +1,36 @@
 #!/bin/bash
 
 # omarchy:summary=Launch an app or focus an existing window matching a pattern
-# omarchy:args=<window-pattern> <launch-command>
+# omarchy:args=<window-pattern> [<launch-command> | -- <command> [args...]]
 
 if (($# == 0)); then
-  echo "Usage: omarchy-launch-or-focus [window-pattern] [launch-command]"
+  echo "Usage: omarchy-launch-or-focus <window-pattern> [<launch-command> | -- <command> [args...]]"
   exit 1
 fi
 
 WINDOW_PATTERN="$1"
-LAUNCH_COMMAND="${2:-"uwsm-app -- $WINDOW_PATTERN"}"
+shift
+
+if [[ ${1:-} == "--" ]]; then
+  shift
+  if (( $# == 0 )); then
+    echo "omarchy-launch-or-focus: -- requires a command" >&2
+    exit 1
+  fi
+  LAUNCH_ARGV=("$@")
+  LAUNCH_COMMAND=""
+else
+  LAUNCH_ARGV=()
+  LAUNCH_COMMAND="${1:-"uwsm-app -- $WINDOW_PATTERN"}"
+fi
 WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"
 else
-  eval exec setsid $LAUNCH_COMMAND
+  if (( ${#LAUNCH_ARGV[@]} > 0 )); then
+    exec setsid "${LAUNCH_ARGV[@]}"
+  else
+    eval exec setsid $LAUNCH_COMMAND
+  fi
 fi

--- a/bin/omarchy-launch-or-focus-tui
+++ b/bin/omarchy-launch-or-focus-tui
@@ -9,6 +9,4 @@ else
   APP_ID="org.omarchy.$(basename "$1")"
 fi
 
-LAUNCH_COMMAND="omarchy-launch-tui $@"
-
-exec omarchy-launch-or-focus "$APP_ID" "$LAUNCH_COMMAND"
+exec omarchy-launch-or-focus "$APP_ID" -- omarchy-launch-tui "$@"

--- a/bin/omarchy-launch-or-focus-tui
+++ b/bin/omarchy-launch-or-focus-tui
@@ -9,4 +9,4 @@ else
   APP_ID="org.omarchy.$(basename "$1")"
 fi
 
-exec omarchy-launch-or-focus "$APP_ID" -- omarchy-launch-tui "$@"
+exec omarchy-launch-or-focus "$APP_ID" omarchy-launch-tui "$@"

--- a/bin/omarchy-launch-or-focus-webapp
+++ b/bin/omarchy-launch-or-focus-webapp
@@ -11,4 +11,4 @@ fi
 WINDOW_PATTERN="$1"
 shift
 
-exec omarchy-launch-or-focus "$WINDOW_PATTERN" -- omarchy-launch-webapp "$@"
+exec omarchy-launch-or-focus "$WINDOW_PATTERN" omarchy-launch-webapp "$@"

--- a/bin/omarchy-launch-or-focus-webapp
+++ b/bin/omarchy-launch-or-focus-webapp
@@ -10,6 +10,5 @@ fi
 
 WINDOW_PATTERN="$1"
 shift
-LAUNCH_COMMAND="omarchy-launch-webapp $@"
 
-exec omarchy-launch-or-focus "$WINDOW_PATTERN" "$LAUNCH_COMMAND"
+exec omarchy-launch-or-focus "$WINDOW_PATTERN" -- omarchy-launch-webapp "$@"

--- a/config/omarchy/extensions/omarchy-menu.jsonc
+++ b/config/omarchy/extensions/omarchy-menu.jsonc
@@ -26,5 +26,5 @@
   //
   // Example: replace the default About action by reusing the same id. Existing
   // fields are kept unless overridden.
-  // "about": {"icon":"","label":"About","action":"omarchy-launch-or-focus-tui \"zsh -c 'fastfetch; read -k 1'\""},
+  // "about": {"icon":"","label":"About","action":"omarchy-launch-or-focus-tui zsh -c 'fastfetch; read -k 1'"},
 }

--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -128,7 +128,7 @@ function o.launch_webapp_sole(name, url)
 end
 
 function o.launch_sole(match, command)
-  return "omarchy-launch-or-focus " .. shell_quote(match) .. " " .. shell_quote(o.launch(command))
+  return "omarchy-launch-or-focus " .. shell_quote(match) .. " bash -c " .. shell_quote(o.launch(command))
 end
 
 function o.bind_toggle(keys, description, toggle, options)

--- a/test/shell.d/launch-or-focus-webapp-test.sh
+++ b/test/shell.d/launch-or-focus-webapp-test.sh
@@ -23,12 +23,11 @@ ARGS_FILE="$args_file" PATH="$test_dir/bin:$PATH" \
   '--profile-directory=Profile 2'
 
 mapfile -d '' -t args <"$args_file"
-[[ ${#args[@]} == 5 ]] || fail "webapp launcher preserves argument count" "got ${#args[@]} arguments"
+[[ ${#args[@]} == 4 ]] || fail "webapp launcher preserves argument count" "got ${#args[@]} arguments"
 [[ ${args[0]} == '^chrome-teams[.]microsoft[.]com__-Profile_2$' ]] || fail "webapp launcher preserves window pattern"
-[[ ${args[1]} == "--" ]] || fail "webapp launcher selects argv mode"
-[[ ${args[2]} == "omarchy-launch-webapp" ]] || fail "webapp launcher forwards the launch command"
-[[ ${args[3]} == "https://teams.microsoft.com" ]] || fail "webapp launcher preserves URL"
-[[ ${args[4]} == "--profile-directory=Profile 2" ]] || fail "webapp launcher preserves flags containing spaces"
+[[ ${args[1]} == "omarchy-launch-webapp" ]] || fail "webapp launcher forwards the launch command"
+[[ ${args[2]} == "https://teams.microsoft.com" ]] || fail "webapp launcher preserves URL"
+[[ ${args[3]} == "--profile-directory=Profile 2" ]] || fail "webapp launcher preserves flags containing spaces"
 pass "webapp launcher forwards URL and flags as discrete arguments"
 
 ARGS_FILE="$args_file" PATH="$test_dir/bin:$PATH" \
@@ -39,15 +38,23 @@ ARGS_FILE="$args_file" PATH="$test_dir/bin:$PATH" \
   '--literal=*'
 
 mapfile -d '' -t args <"$args_file"
-[[ ${#args[@]} == 7 ]] || fail "TUI launcher preserves argument count" "got ${#args[@]} arguments"
+[[ ${#args[@]} == 6 ]] || fail "TUI launcher preserves argument count" "got ${#args[@]} arguments"
 [[ ${args[0]} == "org.custom" ]] || fail "TUI launcher forwards the app ID as the window pattern"
-[[ ${args[1]} == "--" ]] || fail "TUI launcher selects argv mode"
-[[ ${args[2]} == "omarchy-launch-tui" ]] || fail "TUI launcher forwards the launch command"
-[[ ${args[3]} == "--app-id=org.custom" ]] || fail "TUI launcher preserves its app ID flag"
-[[ ${args[4]} == "command-name" ]] || fail "TUI launcher preserves the command"
-[[ ${args[5]} == "argument with spaces" ]] || fail "TUI launcher preserves spaces"
-[[ ${args[6]} == '--literal=*' ]] || fail "TUI launcher preserves glob characters"
+[[ ${args[1]} == "omarchy-launch-tui" ]] || fail "TUI launcher forwards the launch command"
+[[ ${args[2]} == "--app-id=org.custom" ]] || fail "TUI launcher preserves its app ID flag"
+[[ ${args[3]} == "command-name" ]] || fail "TUI launcher preserves the command"
+[[ ${args[4]} == "argument with spaces" ]] || fail "TUI launcher preserves spaces"
+[[ ${args[5]} == '--literal=*' ]] || fail "TUI launcher preserves glob characters"
 pass "TUI launcher forwards arguments without reparsing"
+
+launch_sole=$(lua - "$ROOT/default/hypr/helpers.lua" <<'LUA'
+dofile(arg[1])
+print(o.launch_sole("^obsidian$", "obsidian --flag"))
+LUA
+)
+[[ $launch_sole == "omarchy-launch-or-focus '^obsidian$' bash -c 'uwsm-app -- obsidian --flag'" ]] ||
+  fail "Hyprland launch helper requests shell evaluation explicitly" "got: $launch_sole"
+pass "Hyprland launch helper requests shell evaluation explicitly"
 
 cat >"$test_dir/bin/hyprctl" <<'STUB'
 #!/bin/bash
@@ -61,7 +68,7 @@ chmod +x "$test_dir/bin/hyprctl" "$test_dir/bin/setsid"
 
 ARGS_FILE="$args_file" PATH="$test_dir/bin:$PATH" \
   "$ROOT/bin/omarchy-launch-or-focus" \
-  'missing-window' -- command-name 'argument with spaces' '--literal=*'
+  'missing-window' command-name 'argument with spaces' '--literal=*'
 
 mapfile -d '' -t args <"$args_file"
 [[ ${#args[@]} == 3 ]] || fail "argv launch mode preserves argument count" "got ${#args[@]} arguments"
@@ -69,3 +76,13 @@ mapfile -d '' -t args <"$args_file"
 [[ ${args[1]} == "argument with spaces" ]] || fail "argv launch mode preserves spaces"
 [[ ${args[2]} == '--literal=*' ]] || fail "argv launch mode does not expand glob characters"
 pass "launch-or-focus argv mode executes arguments without reparsing"
+
+ARGS_FILE="$args_file" PATH="$test_dir/bin:$PATH" \
+  "$ROOT/bin/omarchy-launch-or-focus" 'default-command'
+
+mapfile -d '' -t args <"$args_file"
+[[ ${#args[@]} == 3 ]] || fail "default launch preserves argument count" "got ${#args[@]} arguments"
+[[ ${args[0]} == "uwsm-app" ]] || fail "default launch uses uwsm-app"
+[[ ${args[1]} == "--" ]] || fail "default launch terminates uwsm-app options"
+[[ ${args[2]} == "default-command" ]] || fail "default launch uses the window pattern as its command"
+pass "launch-or-focus retains its default launch command"

--- a/test/shell.d/launch-or-focus-webapp-test.sh
+++ b/test/shell.d/launch-or-focus-webapp-test.sh
@@ -31,6 +31,24 @@ mapfile -d '' -t args <"$args_file"
 [[ ${args[4]} == "--profile-directory=Profile 2" ]] || fail "webapp launcher preserves flags containing spaces"
 pass "webapp launcher forwards URL and flags as discrete arguments"
 
+ARGS_FILE="$args_file" PATH="$test_dir/bin:$PATH" \
+  "$ROOT/bin/omarchy-launch-or-focus-tui" \
+  --app-id=org.custom \
+  command-name \
+  'argument with spaces' \
+  '--literal=*'
+
+mapfile -d '' -t args <"$args_file"
+[[ ${#args[@]} == 7 ]] || fail "TUI launcher preserves argument count" "got ${#args[@]} arguments"
+[[ ${args[0]} == "org.custom" ]] || fail "TUI launcher forwards the app ID as the window pattern"
+[[ ${args[1]} == "--" ]] || fail "TUI launcher selects argv mode"
+[[ ${args[2]} == "omarchy-launch-tui" ]] || fail "TUI launcher forwards the launch command"
+[[ ${args[3]} == "--app-id=org.custom" ]] || fail "TUI launcher preserves its app ID flag"
+[[ ${args[4]} == "command-name" ]] || fail "TUI launcher preserves the command"
+[[ ${args[5]} == "argument with spaces" ]] || fail "TUI launcher preserves spaces"
+[[ ${args[6]} == '--literal=*' ]] || fail "TUI launcher preserves glob characters"
+pass "TUI launcher forwards arguments without reparsing"
+
 cat >"$test_dir/bin/hyprctl" <<'STUB'
 #!/bin/bash
 printf '[]\n'

--- a/test/shell.d/launch-or-focus-webapp-test.sh
+++ b/test/shell.d/launch-or-focus-webapp-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin"
+args_file="$test_dir/args"
+
+cat >"$test_dir/bin/omarchy-launch-or-focus" <<'STUB'
+#!/bin/bash
+printf '%s\0' "$@" >"$ARGS_FILE"
+STUB
+chmod +x "$test_dir/bin/omarchy-launch-or-focus"
+
+ARGS_FILE="$args_file" PATH="$test_dir/bin:$PATH" \
+  "$ROOT/bin/omarchy-launch-or-focus-webapp" \
+  '^chrome-teams[.]microsoft[.]com__-Profile_2$' \
+  'https://teams.microsoft.com' \
+  '--profile-directory=Profile 2'
+
+mapfile -d '' -t args <"$args_file"
+[[ ${#args[@]} == 5 ]] || fail "webapp launcher preserves argument count" "got ${#args[@]} arguments"
+[[ ${args[0]} == '^chrome-teams[.]microsoft[.]com__-Profile_2$' ]] || fail "webapp launcher preserves window pattern"
+[[ ${args[1]} == "--" ]] || fail "webapp launcher selects argv mode"
+[[ ${args[2]} == "omarchy-launch-webapp" ]] || fail "webapp launcher forwards the launch command"
+[[ ${args[3]} == "https://teams.microsoft.com" ]] || fail "webapp launcher preserves URL"
+[[ ${args[4]} == "--profile-directory=Profile 2" ]] || fail "webapp launcher preserves flags containing spaces"
+pass "webapp launcher forwards URL and flags as discrete arguments"
+
+cat >"$test_dir/bin/hyprctl" <<'STUB'
+#!/bin/bash
+printf '[]\n'
+STUB
+cat >"$test_dir/bin/setsid" <<'STUB'
+#!/bin/bash
+printf '%s\0' "$@" >"$ARGS_FILE"
+STUB
+chmod +x "$test_dir/bin/hyprctl" "$test_dir/bin/setsid"
+
+ARGS_FILE="$args_file" PATH="$test_dir/bin:$PATH" \
+  "$ROOT/bin/omarchy-launch-or-focus" \
+  'missing-window' -- command-name 'argument with spaces' '--literal=*'
+
+mapfile -d '' -t args <"$args_file"
+[[ ${#args[@]} == 3 ]] || fail "argv launch mode preserves argument count" "got ${#args[@]} arguments"
+[[ ${args[0]} == "command-name" ]] || fail "argv launch mode preserves command"
+[[ ${args[1]} == "argument with spaces" ]] || fail "argv launch mode preserves spaces"
+[[ ${args[2]} == '--literal=*' ]] || fail "argv launch mode does not expand glob characters"
+pass "launch-or-focus argv mode executes arguments without reparsing"


### PR DESCRIPTION
## Problem

On `quattro`, `omarchy-launch-or-focus` accepts its launch command as one string and reparses it with `eval`. The web-app and TUI wrappers flatten their argument arrays to fit that interface:

```bash
LAUNCH_COMMAND="omarchy-launch-webapp $@"
```

That loses the original argument boundaries. For example, `--profile-directory=Profile 2` becomes `--profile-directory=Profile` plus a separate `2`, so Chromium opens the `Profile` profile instead of `Profile 2`. Shell metacharacters can also be interpreted instead of forwarded literally.

## Change

Make `omarchy-launch-or-focus` accept a window pattern followed by a command and its arguments. It stores the command as a Bash array and executes it directly, without `eval`.

All tracked callers are migrated in the same change:

- The web-app and TUI wrappers forward their arguments directly.
- The Hyprland `launch_sole` helper uses `bash -c` explicitly because it intentionally constructs shell source.
- The extension-menu TUI example passes `zsh`, `-c`, and the script as separate arguments.

The default launch behavior remains unchanged for ordinary single-name patterns.

## Compatibility

This intentionally breaks custom calls that pass an entire launch command as one argument:

```bash
omarchy-launch-or-focus pattern "command arg"
```

They must pass discrete arguments:

```bash
omarchy-launch-or-focus pattern command arg
```

Callers that intentionally need expansion, pipelines, redirections, or other shell syntax must request a shell explicitly:

```bash
omarchy-launch-or-focus pattern bash -c 'command "$VALUE" | other >output'
```

A multiword window pattern can also no longer double as the default launch command; provide the launch command separately.

## Existing backward-compatible alternatives

[#8171](https://github.com/omacom/omarchy/pull/8171) and [#9490](https://github.com/omacom/omarchy/pull/9490) preserve the current public interface. Both serialize each wrapper argument with `printf %q` before the existing `eval` reparses the command string.

Those PRs are the smallest backward-compatible fixes and also cover both web-app and TUI forwarding. They solve the immediate correctness and injection problems, but retain the command-string serialization and `eval` architecture.

## Backward-compatible alternative

Both interfaces could coexist by keeping the existing second argument as a command string and using `--` to select direct argv:

```bash
omarchy-launch-or-focus pattern "legacy command string"
omarchy-launch-or-focus pattern -- command args...
```

Applied on top of this PR, the compatibility layer would be:

```diff
diff --git a/bin/omarchy-launch-or-focus b/bin/omarchy-launch-or-focus
@@
-# omarchy:args=<window-pattern> [<command> [args...]]
+# omarchy:args=<window-pattern> [<launch-command> | -- <command> [args...]]
@@
-if (( $# > 0 )); then
+if [[ ${1:-} == "--" ]]; then
+  shift
+  if (( $# == 0 )); then
+    echo "omarchy-launch-or-focus: -- requires a command" >&2
+    exit 1
+  fi
   LAUNCH_ARGV=("$@")
+  LAUNCH_COMMAND=""
 else
-  LAUNCH_ARGV=(uwsm-app -- "$WINDOW_PATTERN")
+  LAUNCH_ARGV=()
+  LAUNCH_COMMAND="${1:-"uwsm-app -- $WINDOW_PATTERN"}"
 fi
@@
-  exec setsid "${LAUNCH_ARGV[@]}"
+  if (( ${#LAUNCH_ARGV[@]} > 0 )); then
+    exec setsid "${LAUNCH_ARGV[@]}"
+  else
+    eval exec setsid $LAUNCH_COMMAND
+  fi
 fi
diff --git a/bin/omarchy-launch-or-focus-webapp b/bin/omarchy-launch-or-focus-webapp
@@
-exec omarchy-launch-or-focus "$WINDOW_PATTERN" omarchy-launch-webapp "$@"
+exec omarchy-launch-or-focus "$WINDOW_PATTERN" -- omarchy-launch-webapp "$@"
diff --git a/bin/omarchy-launch-or-focus-tui b/bin/omarchy-launch-or-focus-tui
@@
-exec omarchy-launch-or-focus "$APP_ID" omarchy-launch-tui "$@"
+exec omarchy-launch-or-focus "$APP_ID" -- omarchy-launch-tui "$@"
diff --git a/default/hypr/helpers.lua b/default/hypr/helpers.lua
@@
-  return "omarchy-launch-or-focus " .. shell_quote(match) .. " bash -c " .. shell_quote(o.launch(command))
+  return "omarchy-launch-or-focus " .. shell_quote(match) .. " -- bash -c " .. shell_quote(o.launch(command))
```

This preserves external command-string callers while giving migrated callers exact argv semantics. Its cost is retaining `eval` and maintaining two interfaces.

## Tests

The focused shell test covers:

- web-app and TUI argument forwarding;
- arguments containing spaces and literal glob characters;
- explicit shell evaluation from the Hyprland helper;
- the default launch command.

All focused checks pass.

## Related upstream work

- [#1977](https://github.com/omacom/omarchy/issues/1977) reported missing browser-profile argument forwarding; [#1980](https://github.com/omacom/omarchy/pull/1980) introduced the current string flattening while addressing it.
- [#3390](https://github.com/omacom/omarchy/pull/3390) reported the same failure for a profile name containing a space.