### PR TITLE
Set StartupWMClass on Chromium web app launchers

### DIFF
--- a/applications/Basecamp.desktop
+++ b/applications/Basecamp.desktop
@@ -5,4 +5,5 @@ Exec=omarchy-launch-webapp https://launchpad.37signals.com
 Terminal=false
 Type=Application
 Icon=basecamp
+StartupWMClass=chrome-launchpad.37signals.com__-Default
 StartupNotify=true

--- a/applications/Discord.desktop
+++ b/applications/Discord.desktop
@@ -5,4 +5,5 @@ Exec=omarchy-launch-webapp https://discord.com/channels/@me
 Terminal=false
 Type=Application
 Icon=omarchy-discord
+StartupWMClass=chrome-discord.com__channels_@me-Default
 StartupNotify=true

--- a/applications/Google Contacts.desktop
+++ b/applications/Google Contacts.desktop
@@ -5,4 +5,5 @@ Exec=omarchy-launch-webapp https://contacts.google.com/
 Terminal=false
 Type=Application
 Icon=google-contacts
+StartupWMClass=chrome-contacts.google.com__-Default
 StartupNotify=true

--- a/applications/Google Maps.desktop
+++ b/applications/Google Maps.desktop
@@ -5,4 +5,5 @@ Exec=omarchy-launch-webapp https://maps.google.com
 Terminal=false
 Type=Application
 Icon=google-maps
+StartupWMClass=chrome-maps.google.com__-Default
 StartupNotify=true

--- a/applications/Google Messages.desktop
+++ b/applications/Google Messages.desktop
@@ -5,4 +5,5 @@ Exec=omarchy-launch-webapp https://messages.google.com/web/conversations
 Terminal=false
 Type=Application
 Icon=google-messages
+StartupWMClass=chrome-messages.google.com__web_conversations-Default
 StartupNotify=true

--- a/applications/Google Photos.desktop
+++ b/applications/Google Photos.desktop
@@ -5,4 +5,5 @@ Exec=omarchy-launch-webapp https://photos.google.com/
 Terminal=false
 Type=Application
 Icon=google-photos
+StartupWMClass=chrome-photos.google.com__-Default
 StartupNotify=true

--- a/applications/HEY.desktop
+++ b/applications/HEY.desktop
@@ -5,5 +5,6 @@ Exec=omarchy-webapp-handler-hey %u
 Terminal=false
 Type=Application
 Icon=hey
+StartupWMClass=chrome-app.hey.com__-Default
 StartupNotify=true
 MimeType=x-scheme-handler/mailto

--- a/applications/WhatsApp.desktop
+++ b/applications/WhatsApp.desktop
@@ -5,4 +5,5 @@ Exec=omarchy-launch-webapp https://web.whatsapp.com/
 Terminal=false
 Type=Application
 Icon=whatsapp
+StartupWMClass=chrome-web.whatsapp.com__-Default
 StartupNotify=true

--- a/applications/X.desktop
+++ b/applications/X.desktop
@@ -5,4 +5,5 @@ Exec=omarchy-launch-webapp https://x.com/
 Terminal=false
 Type=Application
 Icon=x
+StartupWMClass=chrome-x.com__-Default
 StartupNotify=true

--- a/applications/YouTube.desktop
+++ b/applications/YouTube.desktop
@@ -5,4 +5,5 @@ Exec=omarchy-launch-webapp https://youtube.com/
 Terminal=false
 Type=Application
 Icon=youtube
+StartupWMClass=chrome-youtube.com__-Default
 StartupNotify=true

--- a/applications/Zoom.desktop
+++ b/applications/Zoom.desktop
@@ -5,5 +5,6 @@ Exec=omarchy-webapp-handler-zoom %u
 Terminal=false
 Type=Application
 Icon=zoom
+StartupWMClass=chrome-app.zoom.us__wc_home-Default
 StartupNotify=true
 MimeType=x-scheme-handler/zoommtg;x-scheme-handler/zoomus

--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -136,6 +136,50 @@ desktop_exec_arg() {
   printf '"%s"' "$escaped"
 }
 
+# Chromium --app= windows advertise chrome-<host>_<path>-<profile> (slashes in
+# the path become underscores, spaces in the profile directory become
+# underscores). An empty path is "/". The host is lowercased the way GURL does.
+chromium_webapp_startup_class() {
+  local url=$1
+  local profile=${2:-Default}
+  local rest host path app
+
+  rest=${url#*://}
+  authority=${rest%%/*}
+  host=${authority##*@}
+  [[ $host == *:* && $host != \[* ]] && host=${host%%:*}
+  if [[ $rest == "$authority" ]]; then
+    path="/"
+  else
+    path=${rest#"$authority"}
+    path=${path%%\?*}
+    path=${path%%#*}
+    [[ -z $path ]] && path="/"
+  fi
+  host=${host,,}
+  app=${host}_${path}
+  app=${app//\//_}
+  printf 'chrome-%s-%s' "$app" "${profile// /_}"
+}
+
+profile_directory_from_exec() {
+  local exec=$1
+
+  if [[ $exec =~ --profile-directory=\"([^\"]+)\" ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return
+  fi
+  if [[ $exec =~ --profile-directory=\'([^\']+)\' ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return
+  fi
+  if [[ $exec =~ --profile-directory=([^[:space:]]+) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return
+  fi
+  printf 'Default'
+}
+
 if (( $# < 3 )); then
   echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")
@@ -216,6 +260,8 @@ mkdir -p "$DESKTOP_DIR"
 name_field=$(desktop_string_escape "$APP_NAME")
 exec_field=$(desktop_string_escape "$EXEC_COMMAND")
 icon_field=$(desktop_string_escape "$ICON_VALUE")
+startup_class=$(chromium_webapp_startup_class "$APP_URL" "$(profile_directory_from_exec "$EXEC_COMMAND")")
+startup_field=$(desktop_string_escape "$startup_class")
 
 cat >"$DESKTOP_FILE" <<EOF
 [Desktop Entry]
@@ -226,6 +272,7 @@ Exec=$exec_field
 Terminal=false
 Type=Application
 Icon=$icon_field
+StartupWMClass=$startup_field
 StartupNotify=true
 EOF
 

--- a/test/shell.d/webapp-install-test.sh
+++ b/test/shell.d/webapp-install-test.sh
@@ -29,6 +29,8 @@ desktop=$(desktop_for Example)
 grep -Fxq 'Name=Example' "$desktop" || fail "webapp install writes the app name"
 grep -Fxq 'Exec=omarchy-launch-webapp "https://example.com"' "$desktop" ||
   fail "webapp install launches the https URL" "$(cat "$desktop")"
+grep -Fxq 'StartupWMClass=chrome-example.com__-Default' "$desktop" ||
+  fail "webapp install writes Chromium's --app= window class" "$(cat "$desktop")"
 pass "webapp install writes an https desktop entry"
 
 if install_webapp "Plain" "example.org/app" "webapp" >"$tmpdir/out" 2>"$tmpdir/err"; then
@@ -38,6 +40,8 @@ else
 fi
 grep -Fxq 'Exec=omarchy-launch-webapp "https://example.org/app"' "$(desktop_for Plain)" ||
   fail "webapp install stores the prefixed https URL" "$(cat "$(desktop_for Plain)")"
+grep -Fxq 'StartupWMClass=chrome-example.org__app-Default' "$(desktop_for Plain)" ||
+  fail "webapp install encodes the path in StartupWMClass" "$(cat "$(desktop_for Plain)")"
 pass "webapp install prefixes a schemeless URL with https"
 
 if install_webapp "Local" "https://localhost:47990" "webapp" "omarchy-launch-webapp https://localhost:47990 --ignore-certificate-errors" >"$tmpdir/out" 2>"$tmpdir/err"; then
@@ -47,7 +51,20 @@ else
 fi
 grep -Fxq 'Exec=omarchy-launch-webapp https://localhost:47990 --ignore-certificate-errors' "$(desktop_for Local)" ||
   fail "webapp install writes the custom exec" "$(cat "$(desktop_for Local)")"
+grep -Fxq 'StartupWMClass=chrome-localhost__-Default' "$(desktop_for Local)" ||
+  fail "webapp install strips a non-default port from StartupWMClass" "$(cat "$(desktop_for Local)")"
 pass "webapp install keeps a custom https exec"
+
+if install_webapp "Work" "https://web.whatsapp.com/" "webapp" \
+  'omarchy-launch-webapp --profile-directory="Profile 1" https://web.whatsapp.com/' \
+  >"$tmpdir/out" 2>"$tmpdir/err"; then
+  :
+else
+  fail "webapp install keeps a profile-directory exec" "$(cat "$tmpdir/err")"
+fi
+grep -Fxq 'StartupWMClass=chrome-web.whatsapp.com__-Profile_1' "$(desktop_for Work)" ||
+  fail "webapp install puts the profile directory in StartupWMClass" "$(cat "$(desktop_for Work)")"
+pass "webapp install encodes --profile-directory in StartupWMClass"
 
 for url in "javascript:alert(1)" "file:///etc/passwd" "data:text/html,hi" "ftp://example.com" "ext://x"; do
   if install_webapp "Bad" "$url" "webapp" >"$tmpdir/out" 2>"$tmpdir/err"; then


### PR DESCRIPTION
Grok (xAI) writing with Sean.

Chromium `--app=` windows advertise `chrome-<host>_<path>-<profile>` (slashes in the path become `_`, spaces in the profile directory become `_`). They do not use the desktop file's id, so a switcher or taskbar cannot match the window to its launcher: the icon falls back to the generic gear, and the name is a mangled class like `Com time Profile 1`.

`omarchy-webapp-install` now writes `StartupWMClass` using that Chromium formula. If the exec line carries `--profile-directory`, that profile is used; otherwise `Default`. The stock web app desktop files get the same key so WhatsApp, Basecamp, and the rest match without a reinstall.

This does not distinguish ordinary Chromium *browser* windows per profile. On Wayland those all report app id `chromium`. Web apps include the profile in the class.

`bash test/shell.d/webapp-install-test.sh` (also covered by `./test/all`; the other `./test/all` failures here are missing `omarchy-pkgs` and a live compositor, not this change).
