### PR TITLE
Set the Windows VM guest timezone to match the host

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -1121,6 +1121,25 @@ migrate_legacy_compose() {
   rm -f "$LEGACY_COMPOSE_FILE"
 }
 
+# dockur/windows applies TZ only to the Linux side of the container — the
+# Windows guest finishes its unattended install on the Microsoft default
+# timezone (US Pacific). Seed the OEM script dockur runs at the end of the
+# installation to put the guest on the host timezone instead, translating the
+# IANA name via CLDR's windowsZones table (keyed by original tzdb names, so
+# the zone's tzdb Link aliases are tried too). If the name can't be mapped,
+# write nothing and the install proceeds exactly as today.
+write_oem_timezone_script() {
+  local tz="$1" map name win_tz
+  map=$(curl -fsSL --max-time 15 https://raw.githubusercontent.com/unicode-org/cldr/main/common/supplemental/windowsZones.xml) || return 0
+  for name in "$tz" $(awk -v z="$tz" '$1 == "L" && ($2 == z || $3 == z) { print ($2 == z) ? $3 : $2 }' /usr/share/zoneinfo/tzdata.zi); do
+    win_tz=$(awk -F'"' -v z="$name" '/mapZone/ && index(" " $6 " ", " " z " ") { print $2; exit }' <<<"$map")
+    [[ -n $win_tz ]] && break
+  done
+  [[ -n $win_tz ]] || return 0
+  mkdir -p "$HOME/.windows/oem"
+  printf 'tzutil /s "%s"\r\n' "$win_tz" >"$HOME/.windows/oem/install.bat"
+}
+
 # --- prerequisites -----------------------------------------------------------
 
 check_prerequisites() {
@@ -1305,6 +1324,8 @@ EOF
 
   local tz
   tz=$(timedatectl show -p Timezone --value 2>/dev/null || echo UTC)
+
+  write_oem_timezone_script "$tz"
 
   # Write the root-owned compose from the validated settings (one prompt if
   # sudoless Docker is off). The writer pins the familiar home directories (or

--- a/test/shell.d/windows-vm-test.sh
+++ b/test/shell.d/windows-vm-test.sh
@@ -27,3 +27,9 @@ rg -q 'tag = "-default-opacity"' "$windows_vm_rules" ||
 rg -q 'opacity = "1 1"' "$windows_vm_rules" ||
   fail "Windows VM stays fully opaque"
 pass "Windows VM stays fully opaque"
+
+# The guest would otherwise finish the unattended install on the Windows
+# default timezone (US Pacific) regardless of the host's.
+rg -q 'tzutil /s' "$windows_vm_command" ||
+  fail "Windows VM install sets the guest timezone to match the host"
+pass "Windows VM install sets the guest timezone to match the host"


### PR DESCRIPTION
The Windows VM installer passes the host timezone as `TZ` into the container, but dockur/windows only applies `TZ` to the Linux side — the guest finishes its unattended install on the Microsoft default (US Pacific). Every timestamp Explorer shows is then hours off from the host, and files the guest saves into the shared folder get wrong (even future) mtimes on the host.

This seeds an OEM `install.bat` — dockur's supported post-install hook, picked up from `oem/` inside the storage folder — that runs `tzutil /s` with the host's timezone during the final installation step. The Windows timezone name is resolved from the CLDR windowsZones table, chasing tzdb Link records so renamed zones (`Asia/Kolkata`, `Europe/Kyiv`, …) and plain `UTC` resolve too. If the mapping fails, nothing is written and installation proceeds on the Windows default as before. No changes to the privileged compose/mount machinery.

Verified on a fresh dockur/windows 11 unattended install (host on `America/Sao_Paulo`): the guest reported `Pacific Standard Time` before the hook and `E. South America Standard Time` after, with the guest clock matching the host. Existing installs are unaffected (fix applies at install time); they can run `tzutil /s "<zone>"` inside Windows once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
