### PR TITLE
Hide notifications during screensaver

### DIFF
--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -17,6 +17,16 @@ Item {
   // Injected by omarchy-shell (the first-party service loader).
   property var shell: null
 
+  // Notification popups are layer-shell overlays, while the fullscreen
+  // screensaver is a normal Wayland client. Hide the overlays whenever the
+  // enabled idle service reports a screensaver window. Resolve through the
+  // registry so this also follows a user-cloned idle service.
+  readonly property string idleServiceId: shell && shell.pluginRegistry
+    ? shell.pluginRegistry.resolveEnabledId("omarchy.idle")
+    : "omarchy.idle"
+  readonly property var idleService: shell ? shell.serviceFor(idleServiceId) : null
+  readonly property bool screensaverActive: !!idleService && idleService.screensaverWindowCount > 0
+
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
   readonly property string home: Quickshell.env("HOME")
   // History + DND live under XDG_STATE_HOME: they're persistent user state
@@ -956,7 +966,7 @@ Item {
       id: popupWindow
       required property var modelData
       screen: modelData
-      visible: popupModel.count > 0
+      visible: popupModel.count > 0 && !service.screensaverActive
 
       WlrLayershell.namespace: "omarchy-notifications"
       WlrLayershell.layer: WlrLayer.Overlay
@@ -1027,7 +1037,9 @@ Item {
             Timer {
               interval: 50
               repeat: true
-              running: cardSlot.ticking
+              // A hidden toast should retain the visible lifetime it had left
+              // and resume its countdown after the screensaver closes.
+              running: cardSlot.ticking && !service.screensaverActive
               onTriggered: {
                 if (cardSlot.lifetime <= 0) return
                 cardSlot.remainingLifetime -= 50.0 / cardSlot.lifetime

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -7,6 +7,20 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const notifications = requireFromRoot('shell/plugins/notifications/NotificationLogic.js')
+const screensaverServiceQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/Service.qml'), 'utf8')
+
+assert(
+  /resolveEnabledId\("omarchy\.idle"\)/.test(screensaverServiceQml),
+  'notifications follow the enabled idle service, including a user clone'
+)
+assert(
+  /visible:\s*popupModel\.count\s*>\s*0\s*&&\s*!service\.screensaverActive/.test(screensaverServiceQml),
+  'notification popup surfaces are hidden while the screensaver is active'
+)
+assert(
+  /running:\s*cardSlot\.ticking\s*&&\s*!service\.screensaverActive/.test(screensaverServiceQml),
+  'notification popup lifetimes pause while the screensaver is active'
+)
 
 assert(notifications.isChromiumDerived('Brave Browser', ''), 'notifications detect chromium-derived apps by name')
 assert(notifications.isChromiumDerived('', 'microsoft-edge'), 'notifications detect chromium-derived apps by icon')


### PR DESCRIPTION
## What changed

Notification popup surfaces are now hidden whenever the enabled idle service reports a live screensaver window. Popup countdowns pause while hidden, so a notification returns with its remaining visible lifetime after the screensaver is dismissed.

The idle service is resolved through the plugin registry, which keeps this working when someone has cloned `omarchy.idle` for customization.

Fixes #9623.

## Why

The fullscreen terminal screensaver is a normal Wayland client, while notification popups use the overlay layer. The compositor therefore draws notifications above the screensaver unless the notification service explicitly unmaps them. That can expose private notification contents on a screen intended to conceal the session.

## Testing

The notification and notification-send focused suites pass. On a two-DisplayPort system, a persistent critical notification was visible before the test, absent from both animated screensaver outputs, and restored after mouse input dismissed the screensaver. Compositor inspection also reported zero `omarchy-notifications` layer surfaces while both screensaver windows were mapped.
