### PR TITLE
Keep idle lock handoff concealed

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -14,6 +14,7 @@ Item {
   property int failedAttempts: 0
   property bool inputEnabled: true
   property bool loadBackground: true
+  property bool concealAuthentication: false
   property string passwordText: ""
   property bool syncingPasswordText: false
 
@@ -42,6 +43,7 @@ Item {
   signal passwordTextEdited(string password)
   signal clearFailureRequested()
   signal wakeRequested()
+  signal pointerWakeRequested()
 
   // Cache-busts the lock background by appending `?v=`. Adding a query
   // string keeps Image's loader happy while forcing it to reload when the
@@ -88,12 +90,12 @@ Item {
 
   Rectangle {
     anchors.fill: parent
-    color: Color.background
+    color: root.concealAuthentication ? "black" : Color.background
 
     Image {
       id: wallpaper
       anchors.fill: parent
-      source: root.loadBackground ? root.fileUrl(root.backgroundPath) : ""
+      source: root.loadBackground && !root.concealAuthentication ? root.fileUrl(root.backgroundPath) : ""
       fillMode: Image.PreserveAspectCrop
       asynchronous: true
       cache: false
@@ -104,6 +106,7 @@ Item {
     MultiEffect {
       anchors.fill: wallpaper
       source: wallpaper
+      visible: !root.concealAuthentication
       autoPaddingEnabled: false
       blurEnabled: root.loadBackground && wallpaper.status === Image.Ready
       blur: 1.0
@@ -115,8 +118,9 @@ Item {
     MouseArea {
       anchors.fill: parent
       hoverEnabled: true
-      onClicked: { root.wakeRequested(); root.forcePasswordFocus() }
-      onPositionChanged: root.wakeRequested()
+      cursorShape: root.concealAuthentication ? Qt.BlankCursor : Qt.ArrowCursor
+      onClicked: { root.pointerWakeRequested(); root.forcePasswordFocus() }
+      onPositionChanged: root.pointerWakeRequested()
     }
 
     BorderSurface {
@@ -128,6 +132,7 @@ Item {
       borderSpec: root.inputBorderSpec
       radius: Style.cornerRadius
       clip: true
+      opacity: root.concealAuthentication ? 0 : 1
 
       TextInput {
         id: passwordInput

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -33,6 +33,10 @@ Item {
   property string lastEventAt: ""
   property bool strandedLock: false
   property bool strandedLockResolved: false
+  property bool idleTransitionConcealed: false
+  property bool idleTransitionPointerArmed: false
+
+  readonly property int idleTransitionPointerSettleMilliseconds: 2000
 
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
@@ -145,6 +149,28 @@ Item {
     return true
   }
 
+  function beginIdleLock() {
+    if (root.locked) return true
+
+    // Set this before requesting ext-session-lock so every output's first lock
+    // frame is black while the fullscreen screensaver is being replaced.
+    root.idleTransitionConcealed = true
+    root.idleTransitionPointerArmed = false
+    idleTransitionPointerTimer.stop()
+    root.logEvent("idle-transition-concealed")
+
+    if (beginLock()) return true
+
+    root.idleTransitionConcealed = false
+    return false
+  }
+
+  function armIdleTransitionPointer() {
+    if (!root.idleTransitionConcealed || !sessionLock.secure || !root.hasRealScreen()) return
+    root.idleTransitionPointerArmed = false
+    idleTransitionPointerTimer.restart()
+  }
+
   function finishUnlock() {
     if (!root.locked && !lockRequested) return
 
@@ -165,12 +191,23 @@ Item {
   }
 
   function runWake() {
+    idleTransitionConcealed = false
+    idleTransitionPointerArmed = false
+    idleTransitionPointerTimer.stop()
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
   }
 
   function runBlank() {
     if (!blankProcess.running) blankProcess.running = true
+  }
+
+  function handlePointerWake() {
+    // Lock-surface mapping reports the pointer's existing position. Ignore it
+    // until the secure multi-output lock has settled; later movement is real
+    // user input and may reveal the authentication view.
+    if (root.idleTransitionConcealed && !root.idleTransitionPointerArmed) return
+    runWake()
   }
 
   function submitPassword(value) {
@@ -239,6 +276,7 @@ Item {
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
         root.startFingerprint()
+        root.armIdleTransitionPointer()
       }
     }
 
@@ -263,7 +301,7 @@ Item {
 
     WlSessionLockSurface {
       id: lockSurface
-      color: Color.background
+      color: root.idleTransitionConcealed ? "black" : Color.background
 
       LockView {
         id: lockView
@@ -276,11 +314,13 @@ Item {
         failedAttempts: root.failedAttempts
         inputEnabled: root.lockRequested
         loadBackground: root.locked
+        concealAuthentication: root.idleTransitionConcealed
         passwordText: root.enteredPassword
         onPasswordTextEdited: function(password) { root.enteredPassword = password }
         onSubmitPassword: function(password) { root.submitPassword(password) }
         onClearFailureRequested: root.failureMessage = ""
         onWakeRequested: root.runWake()
+        onPointerWakeRequested: root.handlePointerWake()
       }
 
     }
@@ -432,6 +472,17 @@ Item {
   }
 
   Timer {
+    id: idleTransitionPointerTimer
+    interval: root.idleTransitionPointerSettleMilliseconds
+    repeat: false
+    onTriggered: {
+      if (!root.idleTransitionConcealed || !sessionLock.secure || !root.hasRealScreen()) return
+      root.idleTransitionPointerArmed = true
+      root.logEvent("idle-transition-pointer-armed")
+    }
+  }
+
+  Timer {
     id: sessionLockStabilizeTimer
     interval: 500
     repeat: false
@@ -468,6 +519,7 @@ Item {
     target: Quickshell
     function onScreensChanged() {
       root.requestSessionLock()
+      root.armIdleTransitionPointer()
 
       // A monitor still coming up has no workspace, so cannot answer yet.
       strandedLockRetryTimer.rearm()
@@ -516,6 +568,12 @@ Item {
       return "ok"
     }
 
+    function lockFromIdle(): string {
+      if (!root.passwordPamConfigured) return "missing-pam"
+      if (!root.locked && !root.beginIdleLock()) return "failed"
+      return "ok"
+    }
+
     function isLocked(): string {
       return root.locked ? "true" : "false"
     }
@@ -531,6 +589,8 @@ Item {
         passwordPam: root.passwordPamConfigured,
         fingerprint: root.fingerprintConfigured,
         authenticating: root.authenticating,
+        idleTransitionConcealed: root.idleTransitionConcealed,
+        idleTransitionPointerArmed: root.idleTransitionPointerArmed,
         lastEvent: root.lastEvent,
         lastEventAt: root.lastEventAt
       })

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -75,8 +75,11 @@ Item {
     screensaverLaunchGraceTimer.stop()
     root.idledThisCycle = false
     root.screensaverStartedThisCycle = false
-    resetScreensaverWindows()
-    runProcess(lockProcess, "lock", "omarchy-system-lock")
+
+    // Keep the fullscreen screensaver over the desktop until the concealed
+    // lock surface is secure on every output. If the lock request disappears,
+    // leave the already-dark screensaver mapped instead of exposing the session.
+    runProcess(lockProcess, "lock", "omarchy-shell lock lockFromIdle >/dev/null 2>&1 || exit 1; while [[ $(omarchy-shell lock isLocked 2>/dev/null) == true ]]; do [[ $(omarchy-shell lock status 2>/dev/null | jq -r '.secure // false') == true ]] && exec omarchy-system-lock; sleep 0.05; done; exit 1")
   }
 
   function startIdleCycle() {

--- a/test/shell.d/idle-lock-handoff-test.sh
+++ b/test/shell.d/idle-lock-handoff-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const idleQml = fs.readFileSync(`${root}/shell/plugins/services/idle/Service.qml`, 'utf8')
+const lockQml = fs.readFileSync(`${root}/shell/plugins/lock/Service.qml`, 'utf8')
+const viewQml = fs.readFileSync(`${root}/shell/plugins/lock/LockView.qml`, 'utf8')
+
+assert(
+  /lockFromIdle[\s\S]*while \[\[ \$\(omarchy-shell lock isLocked[\s\S]*\.secure \/\/ false[\s\S]*exec omarchy-system-lock/.test(idleQml),
+  'idle keeps the screensaver mapped until the concealed lock reports secure'
+)
+assert(
+  /function lockFromIdle\(\): string \{[\s\S]*root\.beginIdleLock\(\)/.test(lockQml),
+  'the idle service has a dedicated lock entry point'
+)
+assert(
+  /function beginIdleLock\(\)[\s\S]*idleTransitionConcealed = true[\s\S]*beginLock\(\)/.test(lockQml),
+  'idle concealment is enabled before ext-session-lock begins'
+)
+assert(
+  /concealAuthentication: root\.idleTransitionConcealed/.test(lockQml)
+    && /property bool concealAuthentication: false/.test(viewQml)
+    && /color: root\.concealAuthentication \? "black" : Color\.background/.test(viewQml)
+    && /opacity: root\.concealAuthentication \? 0 : 1/.test(viewQml),
+  'the lock surface conceals the wallpaper and password view during handoff'
+)
+assert(
+  /cursorShape: root\.concealAuthentication \? Qt\.BlankCursor : Qt\.ArrowCursor/.test(viewQml),
+  'the concealed handoff hides the pointer'
+)
+assert(
+  /function handlePointerWake\(\)[\s\S]*idleTransitionConcealed && !root\.idleTransitionPointerArmed[\s\S]*runWake\(\)/.test(lockQml),
+  'surface initialization cannot reveal a newly mapped concealed lock'
+)
+assert(
+  /id: idleTransitionPointerTimer[\s\S]*sessionLock\.secure[\s\S]*idleTransitionPointerArmed = true/.test(lockQml),
+  'real pointer wake is armed only after the secure lock settles'
+)
+assert(
+  /signal pointerWakeRequested\(\)[\s\S]*onClicked: \{ root\.pointerWakeRequested\(\); root\.forcePasswordFocus\(\) \}[\s\S]*onPositionChanged: root\.pointerWakeRequested\(\)/.test(viewQml),
+  'pointer activity uses the guarded wake path'
+)
+JS


### PR DESCRIPTION
## What changed

The normal idle path now asks the lock service for a concealed transition before removing the fullscreen screensaver. The lock surfaces paint black without loading the wallpaper or authentication field, hide the pointer, and ignore synthetic pointer initialization while they map.

The idle service keeps the screensaver over the desktop until ext-session-lock reports secure on every output. It then runs the existing `omarchy-system-lock` cleanup. Real keyboard input reveals authentication immediately, and pointer reveal is armed after the secure multi-output lock settles.

Fixes #9184 and supersedes #9185.

## Why

The current idle path removes the terminal screensaver before the secure lock-surface handoff completes. That can expose the password view or desktop before real DPMS standby.

This implementation does not request DPMS early and does not change suspend or hibernate. The existing five-second lock timer remains responsible for display standby.

## Verification

The focused idle handoff, idle, lock blanking, fingerprint, password-layout, and system-lock suites pass.

The exact normal idle sequence passed on an NVIDIA RTX 3080 Ti system with two DisplayPort outputs at 180 Hz and 200 Hz. The splash transitioned into genuine monitor standby without a password or desktop flash, and wake restored the synchronized lock views.

## Integration

PR #7780 adds compositor-side screensaver dismissal. When composed with this change, its callback must ignore the active-state signal caused by disabling the dismissal monitor after the idle cycle enters locking. The verified local composition applies that lifecycle guard.
