### PR TITLE
Preserve existing Snapper configs when normalizing root

### DIFF
--- a/install/config/snapper.sh
+++ b/install/config/snapper.sh
@@ -16,8 +16,26 @@ fi
 
 install -m 0644 "$template" "$SNAPPER_CONFIG_PATH"
 
+# Merge SNAPPER_CONFIGS so a prior user config (commonly "home" on @/@home
+# layouts) is not silently dropped. root is always first and always present;
+# every other existing entry is preserved in order without duplicating root.
 mkdir -p "$(dirname "$SNAPPER_CONF_PATH")"
-printf '%s\n' 'SNAPPER_CONFIGS="root"' >"$SNAPPER_CONF_PATH"
+existing=""
+if [[ -f $SNAPPER_CONF_PATH ]]; then
+  # conf.d/snapper is KEY=value assignments; source only to read SNAPPER_CONFIGS.
+  existing="$(
+    # shellcheck disable=SC1090
+    . "$SNAPPER_CONF_PATH" 2>/dev/null
+    printf '%s' "${SNAPPER_CONFIGS:-}"
+  )"
+fi
+merged="root"
+for config in $existing; do
+  if [[ $config != "root" ]]; then
+    merged+=" $config"
+  fi
+done
+printf 'SNAPPER_CONFIGS="%s"\n' "$merged" >"$SNAPPER_CONF_PATH"
 chmod 0644 "$SNAPPER_CONF_PATH"
 
 systemctl disable --now snapper-timeline.timer >/dev/null 2>&1 || true

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -71,6 +71,52 @@ grep -Fx 'systemctl disable --now snapper-timeline.timer' "$test_tmp/calls.log" 
 grep -Fx 'systemctl enable --now snapper-cleanup.timer limine-snapper-sync.service' "$test_tmp/calls.log" >/dev/null || fail "snapshot configure enables cleanup and Limine snapshot sync"
 pass "snapshot configure normalizes Snapper policy and services"
 
+# #9619: re-running snapper.sh must keep non-root configs (e.g. home) registered.
+# Truncating SNAPPER_CONFIGS="root" silently drops them from snapperd and from
+# omarchy-snapshot create, which enumerates configs via snapper list-configs.
+mkdir -p "$test_tmp/etc/conf.d" "$test_tmp/etc/snapper/configs"
+printf 'SNAPPER_CONFIGS="root home"\n' >"$test_tmp/etc/conf.d/snapper"
+: >"$test_tmp/calls.log"
+TEST_LOG="$test_tmp/calls.log" \
+PATH="$fake_bin:$PATH" \
+OMARCHY_SNAPPER_CONFIGURE_TEST=1 \
+OMARCHY_PATH="$ROOT" \
+OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/etc/snapper/configs/root" \
+OMARCHY_SNAPPER_CONF_PATH="$test_tmp/etc/conf.d/snapper" \
+  bash -euo pipefail "$ROOT/install/config/snapper.sh" >/dev/null
+grep -Fx 'SNAPPER_CONFIGS="root home"' "$test_tmp/etc/conf.d/snapper" >/dev/null ||
+  fail "snapshot configure preserves existing non-root Snapper configs" \
+    "got: $(cat "$test_tmp/etc/conf.d/snapper")"
+pass "snapshot configure preserves existing non-root Snapper configs"
+
+# home-only registry still gets root prepended, without losing home.
+printf 'SNAPPER_CONFIGS="home"\n' >"$test_tmp/etc/conf.d/snapper"
+TEST_LOG="$test_tmp/calls.log" \
+PATH="$fake_bin:$PATH" \
+OMARCHY_SNAPPER_CONFIGURE_TEST=1 \
+OMARCHY_PATH="$ROOT" \
+OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/etc/snapper/configs/root" \
+OMARCHY_SNAPPER_CONF_PATH="$test_tmp/etc/conf.d/snapper" \
+  bash -euo pipefail "$ROOT/install/config/snapper.sh" >/dev/null
+grep -Fx 'SNAPPER_CONFIGS="root home"' "$test_tmp/etc/conf.d/snapper" >/dev/null ||
+  fail "snapshot configure guarantees root while keeping other configs" \
+    "got: $(cat "$test_tmp/etc/conf.d/snapper")"
+pass "snapshot configure guarantees root while keeping other configs"
+
+# Idempotent on an already-merged file: no duplicated root.
+printf 'SNAPPER_CONFIGS="root home extra"\n' >"$test_tmp/etc/conf.d/snapper"
+TEST_LOG="$test_tmp/calls.log" \
+PATH="$fake_bin:$PATH" \
+OMARCHY_SNAPPER_CONFIGURE_TEST=1 \
+OMARCHY_PATH="$ROOT" \
+OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/etc/snapper/configs/root" \
+OMARCHY_SNAPPER_CONF_PATH="$test_tmp/etc/conf.d/snapper" \
+  bash -euo pipefail "$ROOT/install/config/snapper.sh" >/dev/null
+grep -Fx 'SNAPPER_CONFIGS="root home extra"' "$test_tmp/etc/conf.d/snapper" >/dev/null ||
+  fail "snapshot configure is idempotent and does not duplicate root" \
+    "got: $(cat "$test_tmp/etc/conf.d/snapper")"
+pass "snapshot configure is idempotent and does not duplicate root"
+
 setup_system="$ROOT/bin/omarchy-apply-system"
 grep -F 'config/all.sh' "$setup_system" >/dev/null ||
   fail "system setup runs the config phase"


### PR DESCRIPTION
## Summary

`install/config/snapper.sh` rewrote `/etc/conf.d/snapper` as `SNAPPER_CONFIGS="root"` on every run. That silently de-registered any other config the user had (commonly `home` on `@`/`@home` layouts). After that:

- `snapperd` no longer knows about `home`
- `omarchy-snapshot create` enumerates configs via `snapper list-configs`, so `/home` is dropped from pre-update snapshots while the UI still reports success

## Fix

Merge instead of truncate:

- guarantee `root` is present and listed first
- keep every other existing entry in order
- do not duplicate `root`
- fresh installs with no prior file still write `root` alone

## Tests

- `test/shell.d/snapper-test.sh` — three new regressions:
  - preserves `SNAPPER_CONFIGS="root home"`
  - prepends `root` to a `home`-only registry
  - stays idempotent on `root home extra` (no duplicated root)
- also re-ran `snapper-timeline-leak-test.sh` and `snapshot-create-test.sh`
- before/after reproduction (isolated tmp + stubs): prior script wrote `root` only; fixed script keeps `root home`
- same merge path exercised in a clean `bash:5` container

```
OMARCHY_PKGS_PATH=... OMARCHY_ISO_PATH=... bash test/shell.d/snapper-test.sh
```

Fixes #9619