### PR TITLE
Add one-step Japanese input setup

### DIFF
--- a/bin/omarchy-setup-input-mozc
+++ b/bin/omarchy-setup-input-mozc
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# omarchy:summary=Set up Mozc Japanese input with Fcitx 5
+
+set -euo pipefail
+
+omarchy-pkg-add fcitx5-mozc
+omarchy-restart-xcompose
+
+fcitx_ready=false
+for _ in {1..50}; do
+  if fcitx5-remote --check; then
+    fcitx_ready=true
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ $fcitx_ready == false ]]; then
+  echo "Fcitx 5 is not running. Log in to an Omarchy desktop session and try again." >&2
+  exit 1
+fi
+
+group=$(fcitx5-remote -q)
+group_info=$(busctl --user --json=short call \
+  org.fcitx.Fcitx5 \
+  /controller \
+  org.fcitx.Fcitx.Controller1 \
+  InputMethodGroupInfo \
+  s "$group")
+
+if ! jq -e '.data[1] | any(.[0] == "mozc")' <<<"$group_info" >/dev/null; then
+  layout=$(jq -r '.data[0]' <<<"$group_info")
+  mapfile -t input_methods < <(jq -r '.data[1][] | @tsv' <<<"$group_info")
+
+  args=("$group" "$layout" "$((${#input_methods[@]} + 1))")
+  for input_method in "${input_methods[@]}"; do
+    IFS=$'\t' read -r name item_layout <<<"$input_method"
+    args+=("$name" "$item_layout")
+  done
+  args+=(mozc "")
+
+  busctl --user call \
+    org.fcitx.Fcitx5 \
+    /controller \
+    org.fcitx.Fcitx.Controller1 \
+    SetInputMethodGroupInfo \
+    'ssa(ss)' "${args[@]}" >/dev/null
+  busctl --user call \
+    org.fcitx.Fcitx5 \
+    /controller \
+    org.fcitx.Fcitx.Controller1 \
+    Save >/dev/null
+fi
+
+echo "Japanese input is ready. Press Ctrl+Space to switch between English and Japanese."

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -126,6 +126,8 @@
   "setup.monitors": {"icon":"󰍹","label":"Monitors","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/monitors.lua\""},
   "setup.keybindings": {"icon":"","label":"Keybindings","when":"[[ -f ~/.config/hypr/bindings.lua ]]","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/bindings.lua\""},
   "setup.input": {"icon":"","label":"Input","when":"[[ -f ~/.config/hypr/input.lua ]]","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/input.lua\""},
+  "setup.input-method": {"icon":"󰗊","label":"Input Method"},
+  "setup.input-method.mozc": {"icon":"󰗊","label":"Mozc (Japanese)","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-input-mozc"},
   "setup.network": {"icon":"󰛳","label":"Network","aliases":["network"]},
   "setup.network.dns": {"icon":"󰇖","label":"DNS","aliases":["dns"]},
   "setup.network.dns.dhcp": {"icon":"󰩟","label":"DHCP","checked":"[[ \"$(omarchy-dns)\" == \"DHCP\" ]]","action":"omarchy-dns DHCP"},

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -59,7 +59,7 @@ On Dell XPS laptops with a haptic touchpad, you can also set the click strength 
 
 ### Typing in Chinese, Japanese, and other languages
 
-Omarchy runs the [fcitx5](https://fcitx-im.org/) input method framework as part of every session — it's what powers the CapsLock compose sequences. That means the plumbing for non-Latin input is already in place: install an input engine like `fcitx5-mozc` (Japanese) or `fcitx5-chinese-addons` (Chinese) with `omarchy pkg add`, plus `fcitx5-configtool` to add the engine to your input methods and set the key that switches between them.
+Omarchy runs the [fcitx5](https://fcitx-im.org/) input method framework as part of every session — it's what powers the CapsLock compose sequences. For Japanese, select _Setup > Input Method > Mozc (Japanese)_ in the Omarchy menu to install and configure Mozc, then press `Ctrl + Space` to switch between English and Japanese. For other languages, install an input engine like `fcitx5-chinese-addons` with `omarchy pkg add`, plus `fcitx5-configtool` to add the engine to your input methods and set the key that switches between them.
 
 ### Use ALT as SUPER
 

--- a/test/acceptance.d/input-japanese-test.sh
+++ b/test/acceptance.d/input-japanese-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+result_file=/tmp/omarchy-acceptance-japanese-input
+reader_script=/tmp/omarchy-acceptance-japanese-reader
+
+cleanup() {
+  close_windows '^org\.omarchy\.ime-test$'
+  rm -f "$result_file" "$reader_script"
+}
+
+trap cleanup EXIT
+
+if [[ -n ${OMARCHY_ACCEPTANCE_SUDO_PASSWORD:-} ]]; then
+  OMARCHY_ACCEPTANCE_SUDO_PASSWORD="$OMARCHY_ACCEPTANCE_SUDO_PASSWORD" ROOT="$ROOT" SHELL=/bin/bash \
+    script -qec 'printf "%s\n" "$OMARCHY_ACCEPTANCE_SUDO_PASSWORD" | sudo -S -v 2>/dev/null &&
+      if [[ ! -e /var/lib/pacman/sync/core.db ]]; then sudo pacman -Sy --noconfirm; fi &&
+      "$ROOT/bin/omarchy-setup-input-mozc"' /dev/null </dev/null
+else
+  "$ROOT/bin/omarchy-setup-input-mozc"
+fi
+pacman -Q fcitx5-mozc >/dev/null || fail "Mozc is installed"
+pass "Mozc is installed"
+
+group=$(fcitx5-remote -q)
+group_info=$(busctl --user --json=short call \
+  org.fcitx.Fcitx5 \
+  /controller \
+  org.fcitx.Fcitx.Controller1 \
+  InputMethodGroupInfo \
+  s "$group")
+jq -e '.data[1] | any(.[0] == "mozc")' <<<"$group_info" >/dev/null || fail "Mozc is registered with Fcitx 5"
+pass "Mozc is registered with Fcitx 5"
+
+cat >"$reader_script" <<'EOF'
+#!/bin/bash
+IFS= read -r value
+printf '%s' "$value" > /tmp/omarchy-acceptance-japanese-input
+sleep 5
+EOF
+chmod +x "$reader_script"
+
+launch_app "foot --app-id=org.omarchy.ime-test $reader_script"
+wait_until "Japanese input test terminal opens" 15 window_present '^org\.omarchy\.ime-test$'
+
+fcitx5-remote -c
+wtype -M ctrl -k space -m ctrl
+wtype "nihongo"
+wtype -k space
+sleep 1
+screenshot "success-input-japanese-conversion"
+wtype -k Return -k Return
+
+wait_until "Mozc converts romaji to Japanese" 15 grep -Fxq "日本語" "$result_file"
+
+trap - EXIT
+cleanup

--- a/test/shell.d/input-japanese-test.sh
+++ b/test/shell.d/input-japanese-test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+mkdir -p "$work/bin"
+log="$work/calls"
+: >"$log"
+
+cat >"$work/bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg-add %s\n' "$*" >>"$TEST_LOG"
+SH
+
+cat >"$work/bin/omarchy-restart-xcompose" <<'SH'
+#!/bin/bash
+printf 'restart-fcitx5\n' >>"$TEST_LOG"
+SH
+
+cat >"$work/bin/fcitx5-remote" <<'SH'
+#!/bin/bash
+case "$1" in
+  --check) exit 0 ;;
+  -q) printf 'Default\n' ;;
+  *) exit 1 ;;
+esac
+SH
+
+cat >"$work/bin/busctl" <<'SH'
+#!/bin/bash
+printf 'busctl' >>"$TEST_LOG"
+printf ' <%s>' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+
+case " $* " in
+  *" InputMethodGroupInfo "*)
+    if [[ ${MOZC_PRESENT:-false} == "true" ]]; then
+      printf '%s\n' '{"type":"sa(ss)","data":["us",[["keyboard-us",""],["mozc",""]]]}'
+    else
+      printf '%s\n' '{"type":"sa(ss)","data":["us",[["keyboard-us",""],["keyboard-jp","jp"]]]}'
+    fi
+    ;;
+esac
+SH
+
+chmod +x "$work/bin/omarchy-pkg-add" "$work/bin/omarchy-restart-xcompose" "$work/bin/fcitx5-remote" "$work/bin/busctl"
+
+export TEST_LOG="$log"
+export PATH="$work/bin:$PATH"
+
+"$ROOT/bin/omarchy-setup-input-mozc" >"$work/output"
+
+grep -Fx 'pkg-add fcitx5-mozc' "$log" >/dev/null ||
+  fail "Japanese input installs the Mozc engine"
+grep -Fx 'restart-fcitx5' "$log" >/dev/null ||
+  fail "Japanese input restarts Fcitx so it discovers the newly installed engine"
+grep -F '<SetInputMethodGroupInfo> <ssa(ss)> <Default> <us> <3> <keyboard-us> <> <keyboard-jp> <jp> <mozc> <>' "$log" >/dev/null ||
+  fail "Japanese input preserves the current group and appends Mozc" "$(cat "$log")"
+grep -F '<Save>' "$log" >/dev/null ||
+  fail "Japanese input asks Fcitx to save the updated group"
+grep -F 'Japanese input is ready' "$work/output" >/dev/null ||
+  fail "Japanese input reports when setup is complete"
+pass "Japanese input installs and registers Mozc"
+
+: >"$log"
+MOZC_PRESENT=true "$ROOT/bin/omarchy-setup-input-mozc" >"$work/output-existing"
+
+grep -Fx 'pkg-add fcitx5-mozc' "$log" >/dev/null ||
+  fail "Japanese input keeps package installation idempotent"
+! grep -F '<SetInputMethodGroupInfo>' "$log" >/dev/null ||
+  fail "Japanese input does not duplicate an existing Mozc entry" "$(cat "$log")"
+grep -F 'Japanese input is ready' "$work/output-existing" >/dev/null ||
+  fail "Japanese input reports an existing setup as ready"
+pass "Japanese input setup is idempotent"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -202,6 +202,10 @@ assert(
   'menu keeps Input as a direct config action'
 )
 assert(
+  defaultById['setup.input-method.mozc'].action.includes('omarchy-setup-input-mozc'),
+  'menu exposes Mozc Japanese input setup under Setup > Input Method'
+)
+assert(
   defaultById['setup.direct-boot'].action.includes('omarchy-setup-direct-boot'),
   'menu places Direct Boot directly under Setup'
 )


### PR DESCRIPTION
## Summary

- add _Setup > Input Method > Mozc (Japanese)_ to the Omarchy menu
- install `fcitx5-mozc`, restart Fcitx 5, and append Mozc to the current input-method group
- document the setup and add shell plus desktop acceptance coverage

## Why

Japanese input is not optional for Japanese-speaking users. Windows and macOS finish setup with a working Japanese IME, while Omarchy currently requires users to discover the package and configure Fcitx 5 manually.

This keeps the first change deliberately small: it adds a one-step setup action rather than changing the main installer.

## Scope

This PR intentionally treats input-method setup separately from locale and UI internationalization. These concerns may be connected during initial setup, but users may need Japanese input regardless of their system locale or UI language.

Keeping this change focused also makes it possible to improve the input experience incrementally without first deciding the broader locale and i18n architecture.

Naming the menu item after the input engine rather than equating Japanese input with Mozc also leaves room to add options such as _Hazkey (Japanese)_ or _Rime (Chinese)_ alongside it in the future.

## Testing

- `bash test/shell.d/input-japanese-test.sh`
- `bash test/shell.d/menu-test.sh`
- `bash test/shell.d/menu-guards-test.sh`
- `./test/cli`
- QEMU/KVM desktop acceptance: installed Mozc, registered it with Fcitx 5, and converted `nihongo` to `日本語` in a real terminal

The broader VM suite still has unrelated existing environment/OCR failures; the new Japanese input acceptance test passes end to end.

## Related PRs

- #11719 adds one-step Korean input setup with Hangul.
- #12312 adds one-step Traditional Chinese input setup with Chewing.

These PRs share the Input Method parent menu and the Fcitx 5 registration flow. This PR remains focused on Mozc setup; shared setup logic can be extracted in a follow-up. If a sibling PR lands first, I will adjust the shared menu entry and documentation accordingly.
