### PR TITLE
Restore brightness when the laptop lid opens

### DIFF
--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -32,7 +32,12 @@ o.bind_toggle("SUPER + CTRL + N", "Toggle nightlight", "nightlight")
 o.bind("SUPER + CTRL + Delete", "Toggle laptop display", "omarchy-hyprland-monitor-internal toggle")
 o.bind("SUPER + CTRL + ALT + Delete", "Toggle laptop display mirroring", "omarchy-hyprland-monitor-internal-mirror toggle")
 o.bind("switch:on:Lid Switch", nil, "omarchy-system-lid-close", { locked = true })
-o.bind("switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell", { locked = true })
+-- Lid open after suspend only reconciled clamshell state. That left the
+-- internal panel black on hardware where ACPI backlight restore is slow or
+-- incomplete (see #9628). omarchy-system-wake already turns the display back
+-- on, restores the keyboard backlight, and then runs the same clamshell
+-- reconciliation the previous binding did alone.
+o.bind("switch:off:Lid Switch", nil, "omarchy-system-wake", { locked = true })
 
 o.bind("PRINT", "Screenshot", "omarchy-capture-screenshot")
 o.bind("ALT + PRINT", "Screenrecording", "omarchy-capture-screenrecording --stop-recording || omarchy-menu toggle trigger.capture.screenrecord")

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -98,11 +98,13 @@ grep -F 'omarchy-hyprland-monitor-external-active' "$monitor_mirror" >/dev/null
 pass "internal mirror helper recovers when no active external display remains"
 
 grep -F 'switch:on:Lid Switch", nil, "omarchy-system-lid-close"' "$utilities" >/dev/null
-grep -F 'switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell"' "$utilities" >/dev/null
-pass "lid switch bindings lock on close and reconcile clamshell display state"
+grep -F 'switch:off:Lid Switch", nil, "omarchy-system-wake"' "$utilities" >/dev/null
+pass "lid switch bindings lock on close and wake displays on open"
 
+grep -F 'omarchy-brightness-display on' "$system_wake" >/dev/null
+grep -F 'omarchy-brightness-keyboard restore' "$system_wake" >/dev/null
 grep -F 'omarchy-hyprland-monitor-clamshell >/dev/null 2>&1 || true' "$system_wake" >/dev/null
-pass "system wake resyncs clamshell display state"
+pass "system wake restores display and keyboard brightness then resyncs clamshell"
 
 grep -F 'lock-pending: no-real-screen' "$lock_service" >/dev/null
 grep -F 'lock-pending: screen-stabilizing' "$lock_service" >/dev/null


### PR DESCRIPTION
## Summary

After suspend, opening the laptop lid only ran `omarchy-hyprland-monitor-clamshell`. That reconciles internal/external monitor state but does not turn the panel backlight back on or restore the keyboard backlight.

The idle wake path already does the full restore via `omarchy-system-wake`:

```bash
omarchy-brightness-display on
omarchy-brightness-keyboard restore
omarchy-hyprland-monitor-clamshell >/dev/null 2>&1 || true
```

On hardware where ACPI backlight restore is slow or incomplete (reported on MacBook10,1 in #9628), lid open left a black internal panel until a power-button press, while idle wake recovered cleanly.

## Fix

Point `switch:off:Lid Switch` at `omarchy-system-wake` so lid open gets the same restore sequence, then the same clamshell reconciliation wake already performs. Close path is unchanged (`omarchy-system-lid-close`).

## Tests

- `test/shell.d/monitor-recovery-test.sh` — binding now expects `omarchy-system-wake`; asserts wake restores display + keyboard brightness before clamshell
- `test/shell.d/lid-close-test.sh` — still passes (close path untouched)
- `test/shell.d/monitor-clamshell-scale-test.sh` — still passes

Fixes #9628