### PR TITLE
Switch Bluetooth headsets to HFP when selecting their input

### DIFF
--- a/bin/omarchy-audio-input-set-default
+++ b/bin/omarchy-audio-input-set-default
@@ -12,9 +12,76 @@ if [[ -z $node_id || -z $source_name ]]; then
   exit 1
 fi
 
-wpctl set-default "$node_id" 2>/dev/null || true
-pactl set-default-source "$source_name" 2>/dev/null || true
+# Bluetooth headsets advertise capture only on an HFP/HSP profile. Selecting
+# their input while the card is still on A2DP changes the default source in
+# metadata but leaves the microphone silent (see #9380). Switch the owning
+# bluez card to a duplex headset profile before claiming the source.
+ensure_bluetooth_headset_profile() {
+  local source=$1
+  local mac card profiles active sources_on_active profile
 
-pactl list short source-outputs 2>/dev/null | awk '{ print $1 }' | while read -r output; do
-  [[ -n $output ]] && pactl move-source-output "$output" "$source_name" 2>/dev/null || true
+  # bluez_input.AA_BB_… / bluez_output.AA_BB_….a2dp-sink / bluez_card.AA_BB_…
+  [[ $source == bluez_* ]] || return 0
+
+  mac=$(printf '%s' "$source" | grep -oE '[0-9A-Fa-f]{2}(_[0-9A-Fa-f]{2}){5}' | head -n1)
+  [[ -n $mac ]] || return 0
+
+  card="bluez_card.$mac"
+
+  # pactl "Profiles:" block lists "name: Description (sinks: N, sources: M, …)".
+  # Prefer a profile that exposes a source (duplex headset). Fall back to any
+  # headset-head-unit* name WirePlumber still advertises.
+  profiles=$(
+    timeout 2 pactl list cards 2>/dev/null | awk -v card="$card" '
+      $1 == "Name:" && $2 == card { in_card = 1; next }
+      in_card && $1 == "Name:" { in_card = 0 }
+      in_card && $1 == "Active" && $2 == "Profile:" {
+        print "ACTIVE", $3
+        next
+      }
+      in_card && /^[\t ]+[a-z0-9-]+: / {
+        name = $1
+        sub(/:$/, "", name)
+        sources = 0
+        line = $0
+        sub(/.*sources: /, "", line)
+        sub(/[^0-9].*/, "", line)
+        if (line ~ /^[0-9]+$/) sources = line + 0
+        print "PROFILE", name, sources
+      }
+    '
+  )
+
+  active=$(printf '%s\n' "$profiles" | awk '$1 == "ACTIVE" { print $2; exit }')
+  # Already on a capture-capable profile — leave codec choice alone.
+  if [[ -n $active ]]; then
+    sources_on_active=$(printf '%s\n' "$profiles" | awk -v a="$active" '$1 == "PROFILE" && $2 == a { print $3; exit }')
+    if [[ -n $sources_on_active && $sources_on_active != 0 ]]; then
+      return 0
+    fi
+  fi
+
+  profile=$(
+    printf '%s\n' "$profiles" | awk '
+      $1 == "PROFILE" && $3 + 0 > 0 {
+        if ($2 ~ /^headset-head-unit/) { print $2; found = 1; exit }
+        if (!fallback) fallback = $2
+      }
+      END { if (!found && fallback) print fallback }
+    '
+  )
+
+  [[ -n $profile ]] || return 0
+  [[ $profile == "$active" ]] && return 0
+
+  timeout 2 pactl set-card-profile "$card" "$profile" 2>/dev/null || true
+}
+
+ensure_bluetooth_headset_profile "$source_name"
+
+timeout 2 wpctl set-default "$node_id" 2>/dev/null || true
+timeout 2 pactl set-default-source "$source_name" 2>/dev/null || true
+
+timeout 2 pactl list short source-outputs 2>/dev/null | awk '{ print $1 }' | while read -r output; do
+  [[ -n $output ]] && timeout 2 pactl move-source-output "$output" "$source_name" 2>/dev/null || true
 done

--- a/test/shell.d/audio-input-set-default-test.sh
+++ b/test/shell.d/audio-input-set-default-test.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+command="$ROOT/bin/omarchy-audio-input-set-default"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mock_bin="$tmpdir/bin"
+mkdir -p "$mock_bin"
+call_log="$tmpdir/calls.log"
+: >"$call_log"
+
+# Pactl card dump shaped like a real bluez headset still on A2DP.
+write_cards() {
+  cat >"$tmpdir/cards.txt" <<'CARDS'
+Card #2
+	Name: bluez_card.AA_BB_CC_DD_EE_FF
+	Driver: module-bluez5-device.c
+	Owner Module: 28
+	Properties:
+		device.description = "HUAWEI FreeBuds Pro"
+	Profiles:
+		a2dp-sink: High Fidelity Playback (A2DP Sink, codec AAC) (sinks: 1, sources: 0, priority: 40, available: yes)
+		headset-head-unit: Headset Head Unit (HSP/HFP, codec CVSD) (sinks: 1, sources: 1, priority: 30, available: yes)
+		headset-head-unit-msbc: Headset Head Unit (HSP/HFP, codec mSBC) (sinks: 1, sources: 1, priority: 30, available: yes)
+		off: Off (sinks: 0, sources: 0, priority: 0, available: yes)
+	Active Profile: a2dp-sink
+	Ports:
+		speaker-output: Speaker (type: Speaker, priority: 0, latency offset: 0 usec, available)
+			Part of profile(s): a2dp-sink, headset-head-unit, headset-head-unit-msbc
+		speaker-input: Microphone (type: Mic, priority: 0, latency offset: 0 usec, available)
+			Part of profile(s): headset-head-unit, headset-head-unit-msbc
+CARDS
+}
+
+cat >"$mock_bin/timeout" <<'SH'
+#!/bin/bash
+# Drop the duration argument and run the rest — tests do not need real timeouts.
+shift
+exec "$@"
+SH
+chmod +x "$mock_bin/timeout"
+
+cat >"$mock_bin/wpctl" <<'SH'
+#!/bin/bash
+printf 'wpctl %s\n' "$*" >>"$CALL_LOG"
+SH
+chmod +x "$mock_bin/wpctl"
+
+cat >"$mock_bin/pactl" <<'SH'
+#!/bin/bash
+printf 'pactl %s\n' "$*" >>"$CALL_LOG"
+case "$1 $2" in
+  "list cards")
+    cat "$CARDS_FILE"
+    ;;
+  "list short")
+    # No active capture clients in these unit tests.
+    ;;
+  "set-card-profile"|"set-default-source"|"move-source-output")
+    ;;
+  *)
+    ;;
+esac
+SH
+chmod +x "$mock_bin/pactl"
+
+run_helper() {
+  : >"$call_log"
+  CALL_LOG="$call_log" CARDS_FILE="$tmpdir/cards.txt" \
+    PATH="$mock_bin:$PATH" \
+    "$command" "$@"
+  mapfile -t calls <"$call_log"
+}
+
+write_cards
+
+# Non-Bluetooth source: never touch card profiles.
+run_helper 43 alsa_input.pci-0000_00_1f.3.analog-stereo
+printf '%s\n' "${calls[@]}" | grep -q 'set-card-profile' &&
+  fail "non-bluetooth input does not change a card profile" "calls: ${calls[*]}"
+printf '%s\n' "${calls[@]}" | grep -Fxq 'wpctl set-default 43' ||
+  fail "non-bluetooth input still sets the default via wpctl" "calls: ${calls[*]}"
+printf '%s\n' "${calls[@]}" | grep -Fxq 'pactl set-default-source alsa_input.pci-0000_00_1f.3.analog-stereo' ||
+  fail "non-bluetooth input still sets the default via pactl" "calls: ${calls[*]}"
+pass "non-bluetooth input does not change a card profile"
+
+# Bluez source still on A2DP: switch to a headset profile that has a source.
+run_helper 99 bluez_input.AA_BB_CC_DD_EE_FF.0
+printf '%s\n' "${calls[@]}" | grep -Fxq 'pactl set-card-profile bluez_card.AA_BB_CC_DD_EE_FF headset-head-unit' ||
+  fail "bluetooth input on A2DP switches the card to headset-head-unit" "calls: ${calls[*]}"
+printf '%s\n' "${calls[@]}" | grep -Fxq 'wpctl set-default 99' ||
+  fail "bluetooth input still sets the default via wpctl" "calls: ${calls[*]}"
+printf '%s\n' "${calls[@]}" | grep -Fxq 'pactl set-default-source bluez_input.AA_BB_CC_DD_EE_FF.0' ||
+  fail "bluetooth input still sets the default via pactl" "calls: ${calls[*]}"
+pass "bluetooth input on A2DP switches the card to headset-head-unit"
+
+# Prefer headset-head-unit* over a generic duplex name when both have sources.
+cat >"$tmpdir/cards.txt" <<'CARDS'
+Card #2
+	Name: bluez_card.AA_BB_CC_DD_EE_FF
+	Profiles:
+		a2dp-sink: High Fidelity Playback (A2DP Sink) (sinks: 1, sources: 0, available: yes)
+		handsfree-head-unit: Handsfree (sinks: 1, sources: 1, available: yes)
+		headset-head-unit-msbc: Headset Head Unit (HSP/HFP, codec mSBC) (sinks: 1, sources: 1, available: yes)
+	Active Profile: a2dp-sink
+CARDS
+run_helper 99 bluez_input.AA_BB_CC_DD_EE_FF.0
+printf '%s\n' "${calls[@]}" | grep -Fxq 'pactl set-card-profile bluez_card.AA_BB_CC_DD_EE_FF headset-head-unit-msbc' ||
+  fail "bluetooth input prefers headset-head-unit* when several duplex profiles exist" "calls: ${calls[*]}"
+pass "bluetooth input prefers headset-head-unit* when several duplex profiles exist"
+
+# Already on a duplex profile: leave it alone.
+cat >"$tmpdir/cards.txt" <<'CARDS'
+Card #2
+	Name: bluez_card.AA_BB_CC_DD_EE_FF
+	Profiles:
+		a2dp-sink: High Fidelity Playback (A2DP Sink) (sinks: 1, sources: 0, available: yes)
+		headset-head-unit: Headset Head Unit (HSP/HFP) (sinks: 1, sources: 1, available: yes)
+	Active Profile: headset-head-unit
+CARDS
+run_helper 99 bluez_input.AA_BB_CC_DD_EE_FF.0
+printf '%s\n' "${calls[@]}" | grep -q 'set-card-profile' &&
+  fail "bluetooth input already on HFP does not re-set the profile" "calls: ${calls[*]}"
+pass "bluetooth input already on HFP does not re-set the profile"
+
+# Output-style bluez name still resolves the same card MAC.
+write_cards
+run_helper 12 bluez_output.AA_BB_CC_DD_EE_FF.a2dp-sink
+printf '%s\n' "${calls[@]}" | grep -Fxq 'pactl set-card-profile bluez_card.AA_BB_CC_DD_EE_FF headset-head-unit' ||
+  fail "bluetooth output-shaped name still switches the card for capture" "calls: ${calls[*]}"
+pass "bluetooth output-shaped name still switches the card for capture"


### PR DESCRIPTION
## Summary

Selecting a Bluetooth headset under **Input** in the audio panel called `omarchy-audio-input-set-default`, which only set the default source. If the card was still on A2DP (playback-only), PipeWire metadata updated and the row highlighted, but the microphone stayed silent until the user manually ran:

```bash
pactl set-card-profile bluez_card.<MAC> headset-head-unit
```

## Fix

Before claiming a `bluez_*` source, `omarchy-audio-input-set-default` now:

1. Derives `bluez_card.<MAC>` from the source name
2. Reads the card's profiles via `pactl list cards`
3. If the active profile exposes **no sources**, switches to a duplex profile (`headset-head-unit*` preferred, otherwise any profile with `sources > 0`)
4. Then sets the default source and moves active source-outputs as before

Non-Bluetooth sources are unchanged. Cards already on an HFP/HSP profile are left alone.

## Tests

```
bash test/shell.d/audio-input-set-default-test.sh
bash test/shell.d/audio-test.sh
```

- non-Bluetooth input does not touch card profiles
- A2DP bluez input switches to `headset-head-unit`
- prefers `headset-head-unit*` when several duplex profiles exist
- already-on-HFP does not re-set the profile
- output-shaped bluez name still resolves the same card MAC

Fixes #9380