### PR TITLE
Use universal paste for Voxtype output

### DIFF
--- a/default/voxtype/config.toml
+++ b/default/voxtype/config.toml
@@ -58,10 +58,14 @@ translate = false
 # threads = 4
 
 [output]
-# Primary output mode: "type" or "clipboard"
-# - type: Simulates keyboard input at cursor position (requires ydotool)
+# Primary output mode: "type", "clipboard", or "paste"
+# - type: Simulates keyboard input at cursor position (requires wtype or ydotool)
 # - clipboard: Copies text to clipboard (requires wl-copy)
-mode = "type"
+# - paste: Copies to clipboard, then pastes at the cursor (requires wl-copy and wtype)
+mode = "paste"
+
+# Use Omarchy's universal paste shortcut so this works in terminals too
+paste_keys = "super+v"
 
 # Fall back to clipboard if typing fails
 fallback_to_clipboard = true

--- a/test/shell.d/voxtype-default-config-test.sh
+++ b/test/shell.d/voxtype-default-config-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+config="$ROOT/default/voxtype/config.toml"
+
+grep -Fxq 'mode = "paste"' "$config" || fail "Voxtype pastes transcriptions by default"
+grep -Fxq 'paste_keys = "super+v"' "$config" || fail "Voxtype uses Omarchy universal paste"
+
+pass "Voxtype default output works across regular and terminal applications"


### PR DESCRIPTION
## Status

Draft while the appropriate mitigation is discussed in #10050 and upstream in https://github.com/peteonrails/voxtype/issues/695.

Further isolation points to wtype's keycode-allocation bug rather than Fcitx/Mozc itself: https://github.com/atx/wtype/issues/71

## Summary

- make Voxtype paste transcriptions instead of injecting each character through wtype
- route the paste through Omarchy's universal `Super+V` shortcut so regular apps and terminals both work
- add coverage for the default output settings

## Why

For arbitrary Unicode text, wtype creates a temporary keymap by assigning unique characters to successive keycodes. Some applications interpret particular keycodes as conventional physical keys, causing longer CJK transcriptions to lose characters, delete preceding text, or potentially trigger key actions. Paste mode transfers the transcription as text and avoids that keycode path.

Using Omarchy's universal paste shortcut preserves terminal support: Omarchy translates it to `Ctrl+V` for regular windows and `Shift+Insert` for terminals.

## Testing

- `bash test/shell.d/voxtype-default-config-test.sh`
- `voxtype --config default/voxtype/config.toml config` (Voxtype resolves the mode as `Paste`)
- `./test/all` (222/226 test files pass; the four failures are existing environment-dependent checks: missing `omarchy-pkgs` checkout, `launch-about-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`)
