### PR TITLE
Deduplicate monitor outputs with matching EDIDs

### DIFF
--- a/bin/omarchy-hyprland-monitor-deduplicate
+++ b/bin/omarchy-hyprland-monitor-deduplicate
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# omarchy:hidden=true
+# omarchy:summary=Disable duplicate Hyprland outputs for the same physical monitor
+
+# A panel connected through more than one video input can be exposed as multiple
+# outputs with the same EDID identity. Keep the focused output (or the first
+# output when none is focused) and disable its duplicates.
+monitors_json=$(hyprctl monitors all -j) || exit 0
+
+duplicate_outputs=$(jq -r '
+  [ .[]
+    | select(.disabled != true)
+    | select((.make // "") != "" and (.model // "") != "" and (.serial // "") != "" and (.serial // "") != "0")
+    | { name, focused: (.focused == true), identity: [ .make, .model, .serial ] }
+  ]
+  | sort_by(.identity, .name)
+  | group_by(.identity)
+  | .[]
+  | select(length > 1)
+  | ((map(select(.focused)) + .) | .[0].name) as $keep
+  | .[]
+  | select(.name != $keep)
+  | .name
+' <<<"$monitors_json") || exit 0
+
+while read -r output; do
+  [[ -n $output ]] || continue
+  hyprctl eval "hl.monitor({ output = $(jq -Rn --arg output "$output" '$output'), disabled = true })" >/dev/null 2>&1 || true
+done <<<"$duplicate_outputs"

--- a/bin/omarchy-hyprland-monitor-watch
+++ b/bin/omarchy-hyprland-monitor-watch
@@ -13,13 +13,19 @@ sync_clamshell() {
   ) 9>"$LOCK"
 }
 
+deduplicate_outputs() {
+  omarchy-hyprland-monitor-deduplicate
+}
+
 sync_clamshell_after_monitor_change() {
   sync_clamshell
+  deduplicate_outputs
 
   (
     for delay in 1 3 7; do
       sleep "$delay"
       sync_clamshell
+      deduplicate_outputs
     done
   ) &
 }
@@ -108,6 +114,7 @@ while read -r event; do
     # to notice, same as at boot. Our own recovery reload lands here too, and is
     # a no-op while its loop still holds the pid.
     configreloaded\>\>*)
+      deduplicate_outputs
       recover_modeless
       ;;
   esac

--- a/test/shell.d/monitor-deduplicate-test.sh
+++ b/test/shell.d/monitor-deduplicate-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+bin_dir=$(mktemp -d)
+monitors_file=$(mktemp)
+calls_file=$(mktemp)
+
+cleanup() {
+  rm -rf "$bin_dir"
+  rm -f "$monitors_file" "$calls_file"
+}
+trap cleanup EXIT
+
+cat >"$bin_dir/hyprctl" <<'EOF'
+#!/bin/bash
+if [[ $* == "monitors all -j" ]]; then
+  cat "$FAKE_MONITORS"
+elif [[ $1 == "eval" ]]; then
+  printf '%s\n' "$2" >>"$FAKE_CALLS"
+else
+  exit 1
+fi
+EOF
+chmod +x "$bin_dir/hyprctl"
+
+run_deduplicate() {
+  : >"$calls_file"
+  FAKE_MONITORS="$monitors_file" FAKE_CALLS="$calls_file" PATH="$bin_dir:$PATH" \
+    bash "$ROOT/bin/omarchy-hyprland-monitor-deduplicate"
+}
+
+cat >"$monitors_file" <<'EOF'
+[
+  { "name": "DP-1", "make": "Dell Inc.", "model": "DELL U2720Q", "serial": "2PBGZ13", "disabled": false, "focused": false },
+  { "name": "DP-3", "make": "Dell Inc.", "model": "DELL U2720Q", "serial": "2PBGZ13", "disabled": false, "focused": true }
+]
+EOF
+run_deduplicate
+[[ $(<"$calls_file") == 'hl.monitor({ output = "DP-1", disabled = true })' ]] ||
+  fail "duplicate outputs keep the focused output" "calls: $(<"$calls_file")"
+pass "duplicate outputs keep the focused output"
+
+cat >"$monitors_file" <<'EOF'
+[
+  { "name": "DP-1", "make": "Dell Inc.", "model": "DELL U2720Q", "serial": "FIRST", "disabled": false, "focused": true },
+  { "name": "DP-3", "make": "Dell Inc.", "model": "DELL U2720Q", "serial": "SECOND", "disabled": false, "focused": false }
+]
+EOF
+run_deduplicate
+[[ ! -s $calls_file ]] || fail "separate monitors with the same model stay enabled" "calls: $(<"$calls_file")"
+pass "separate monitors with the same model stay enabled"
+
+cat >"$monitors_file" <<'EOF'
+[
+  { "name": "DP-1", "make": "Dell Inc.", "model": "DELL U2720Q", "serial": "2PBGZ13", "disabled": false, "focused": false },
+  { "name": "DP-3", "make": "Dell Inc.", "model": "DELL U2720Q", "serial": "2PBGZ13", "disabled": false, "focused": false }
+]
+EOF
+run_deduplicate
+[[ $(<"$calls_file") == 'hl.monitor({ output = "DP-3", disabled = true })' ]] ||
+  fail "duplicate outputs choose a stable output before focus exists" "calls: $(<"$calls_file")"
+pass "duplicate outputs choose a stable output before focus exists"
+
+cat >"$monitors_file" <<'EOF'
+[
+  { "name": "DP-1", "make": "Dell Inc.", "model": "DELL U2720Q", "serial": "2PBGZ13", "disabled": true, "focused": false },
+  { "name": "DP-3", "make": "Dell Inc.", "model": "DELL U2720Q", "serial": "2PBGZ13", "disabled": false, "focused": true }
+]
+EOF
+run_deduplicate
+[[ ! -s $calls_file ]] || fail "an already disabled duplicate stays untouched" "calls: $(<"$calls_file")"
+pass "an already disabled duplicate stays untouched"

--- a/test/shell.d/monitor-modeless-test.sh
+++ b/test/shell.d/monitor-modeless-test.sh
@@ -97,6 +97,12 @@ cat >"$fake_bin/omarchy-hyprland-monitor-clamshell" <<'SH'
 exit 0
 SH
 
+cat >"$fake_bin/omarchy-hyprland-monitor-deduplicate" <<'SH'
+#!/bin/bash
+
+exit 0
+SH
+
 chmod +x "$fake_bin"/*
 ln -s "$ROOT/bin/omarchy-hyprland-monitor-modeless" "$fake_bin/omarchy-hyprland-monitor-modeless"
 

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -31,6 +31,10 @@ grep -F 'sync_clamshell_after_monitor_change' "$monitor_watch" >/dev/null
 grep -F 'socat -U - "UNIX-CONNECT:$SOCKET"' "$monitor_watch" >/dev/null
 pass "monitor watcher reconciles clamshell state on startup"
 
+grep -F 'omarchy-hyprland-monitor-deduplicate' "$monitor_watch" >/dev/null
+grep -F 'deduplicate_outputs' "$monitor_watch" >/dev/null
+pass "monitor watcher removes duplicate outputs on startup and monitor changes"
+
 grep -F 'omarchy-hw-laptop && omarchy-hyprland-monitor-external-active' "$monitor_watch" >/dev/null
 grep -F 'sync_poll_state' "$monitor_watch" >/dev/null
 grep -F 'done < <(socat' "$monitor_watch" >/dev/null


### PR DESCRIPTION
## Problem
A single physical monitor connected through more than one video input can appear in Hyprland as multiple outputs with the same EDID identity. The default automatic monitor rule enables each output, creating a phantom adjacent display that splits workspaces and can capture the pointer.

## Fix
Add a hidden monitor helper, run by the existing monitor watcher at startup, on monitor changes, and after config reloads. It groups enabled outputs by non-empty make/model/serial identity, preserves the focused output (or a stable first output before focus exists), and disables the remaining duplicates through Hyprland’s Lua API.

Outputs with the same model but distinct serial numbers are left unchanged.

## Testing
- Added unit coverage for duplicate EDIDs, distinct same-model monitors, startup without focus, and already-disabled duplicates.
- Updated watcher test coverage and its fake helper dependency.
- Passed: `./test/cli`
- Passed: relevant monitor suites: `monitor-deduplicate-test.sh`, `monitor-modeless-test.sh`, and `monitor-recovery-test.sh`.
- Ran `./test/shell`: monitor suites pass; 3 unrelated pre-existing packaging checks fail because the local checkout has no `omarchy-pkgs` checkout (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`).