### PR TITLE
Idle-inhibit Steam games, not just the client window

### DIFF
--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -1,4 +1,7 @@
 o.window("steam", { float = true, idle_inhibit = "fullscreen" })
+-- Games launch as steam_app_<id>; FullMatch on "steam" alone never covers them,
+-- so gamepad sessions (no seat activity) still fire the screensaver.
+o.window("^steam_app_", { idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })

--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -1,7 +1,7 @@
 o.window("steam", { float = true, idle_inhibit = "fullscreen" })
--- Games launch as steam_app_<id>; FullMatch on "steam" alone never covers them,
--- so gamepad sessions (no seat activity) still fire the screensaver.
-o.window("^steam_app_", { idle_inhibit = "fullscreen" })
+-- Games launch as steam_app_<id>; Hyprland FullMatch on "steam" alone never
+-- covers them, so gamepad sessions (no seat activity) still fire the screensaver.
+o.window("steam_app_.*", { idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })

--- a/test/shell.d/steam-idle-inhibit-test.sh
+++ b/test/shell.d/steam-idle-inhibit-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const steam = fs.readFileSync(root + '/default/hypr/apps/steam.lua', 'utf8')
+
+assert(
+  /^o\.window\("steam_app_\.\*",\s*\{\s*idle_inhibit\s*=\s*"fullscreen"\s*\}/m.test(steam),
+  'Steam games (steam_app_<id>) get a fullscreen idle inhibitor'
+)
+assert(
+  /^o\.window\("steam",\s*\{[^}]*idle_inhibit\s*=\s*"fullscreen"/m.test(steam),
+  'the Steam client still gets a fullscreen idle inhibitor'
+)
+assert(
+  !/o\.window\("\^steam_app_/.test(steam),
+  'the game rule is not a start-anchored prefix that FullMatch would only hit as steam_app_'
+)
+assert(
+  !/^o\.window\("steam_app_\.\*",\s*\{[^}]*float\s*=\s*true/m.test(steam),
+  'Steam games are not forced floating by the idle-inhibit rule'
+)
+JS


### PR DESCRIPTION
## Summary
- Hyprland FullMatch on class `steam` never hits `steam_app_<id>` game windows, so gamepad play still fired the screensaver every ~150s.
- Add an idle inhibitor for `^steam_app_` alongside the existing Steam client rule.

Fixes #9636

## Test plan
- [ ] Fullscreen Steam game with a gamepad stays free of the screensaver past `idle.screensaver`
- [ ] Steam client / Big Picture rules still apply as before