### PR TITLE
Prefer active Wi-Fi over a TUN default route in the bar

### DIFF
--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -19,10 +19,25 @@ case "${1:-}" in
     ;;
 esac
 
-print_status() {
-  local device nm state ssid signal freq
+wifi_device_from_nm() {
+  nmcli -t -f DEVICE,TYPE,STATE device status 2>/dev/null |
+    awk -F: '$2 == "wifi" && $3 ~ /^connected/ { print $1; exit }'
+}
 
-  device=$(ip route get "$internet_probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
+print_status() {
+  local device nm state ssid signal freq route_device wifi_device
+
+  route_device=$(ip route get "$internet_probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
+  device=$route_device
+
+  # A TUN/VPN default route is not the link the bar should advertise. Prefer
+  # an active NetworkManager Wi-Fi device when the route device is not wireless.
+  if [[ -n $device && ! -d /sys/class/net/$device/wireless ]]; then
+    wifi_device=$(wifi_device_from_nm)
+    if [[ -n $wifi_device ]]; then
+      device=$wifi_device
+    fi
+  fi
 
   if [[ -z $device ]]; then
     printf 'disconnected\t\t\t\n'

--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -19,32 +19,54 @@ case "${1:-}" in
     ;;
 esac
 
-wifi_device_from_nm() {
+net_sysfs=${OMARCHY_NET_SYSFS:-/sys/class/net}
+
+# TUN/TAP (ARPHRD_NONE=65534) and PPP (512) win `ip route get` under split
+# tables, but they are not the connection the bar should show. Ethernet with
+# incidental Wi-Fi still associated must keep the route device.
+is_tunnel_iface() {
+  local device=$1
+  local type_file=$net_sysfs/$device/type
+  local iface_type
+
+  [[ -n $device ]] || return 1
+  [[ -e $net_sysfs/$device/tun ]] && return 0
+  [[ -r $type_file ]] || return 1
+  iface_type=$(< "$type_file")
+  [[ $iface_type == 65534 || $iface_type == 512 ]]
+}
+
+wifi_connected_device() {
   nmcli -t -f DEVICE,TYPE,STATE device status 2>/dev/null |
-    awk -F: '$2 == "wifi" && $3 ~ /^connected/ { print $1; exit }'
+    awk -F: '$2 == "wifi" && $3 == "connected" { print $1; exit }'
+}
+
+prefer_wifi_over_tunnel() {
+  local device=$1
+  local wifi_device
+
+  if is_tunnel_iface "$device"; then
+    wifi_device=$(wifi_connected_device)
+    if [[ -n $wifi_device ]]; then
+      printf '%s' "$wifi_device"
+      return
+    fi
+  fi
+  printf '%s' "$device"
 }
 
 print_status() {
-  local device nm state ssid signal freq route_device wifi_device
+  local device nm state ssid signal freq
 
-  route_device=$(ip route get "$internet_probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
-  device=$route_device
-
-  # A TUN/VPN default route is not the link the bar should advertise. Prefer
-  # an active NetworkManager Wi-Fi device when the route device is not wireless.
-  if [[ -n $device && ! -d /sys/class/net/$device/wireless ]]; then
-    wifi_device=$(wifi_device_from_nm)
-    if [[ -n $wifi_device ]]; then
-      device=$wifi_device
-    fi
-  fi
+  device=$(ip route get "$internet_probe" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
+  device=$(prefer_wifi_over_tunnel "$device")
 
   if [[ -z $device ]]; then
     printf 'disconnected\t\t\t\n'
     return
   fi
 
-  if [[ ! -d /sys/class/net/$device/wireless ]]; then
+  if [[ ! -d $net_sysfs/$device/wireless ]]; then
     printf 'ethernet\t%s\t\t\n' "$device"
     return
   fi
@@ -108,6 +130,7 @@ print_verbose() {
   src=$(jq -r '.[0].prefsrc // ""' <<<"$route_json" 2>/dev/null)
 
   [[ -z $iface ]] && return
+  iface=$(prefer_wifi_over_tunnel "$iface")
 
   prefix=$(ip -j addr show "$iface" 2>/dev/null | jq -r '.[0].addr_info[]? | select(.family == "inet") | .prefixlen // ""' 2>/dev/null | head -n 1)
 
@@ -116,14 +139,14 @@ print_verbose() {
   printf 'prefix\t%s\n' "$prefix"
   printf 'gateway\t%s\n' "$gw"
 
-  if [[ -r /sys/class/net/$iface/statistics/rx_bytes ]]; then
-    printf 'rx_bytes\t%s\n' "$(cat /sys/class/net/$iface/statistics/rx_bytes)"
+  if [[ -r $net_sysfs/$iface/statistics/rx_bytes ]]; then
+    printf 'rx_bytes\t%s\n' "$(cat "$net_sysfs/$iface/statistics/rx_bytes")"
   fi
-  if [[ -r /sys/class/net/$iface/statistics/tx_bytes ]]; then
-    printf 'tx_bytes\t%s\n' "$(cat /sys/class/net/$iface/statistics/tx_bytes)"
+  if [[ -r $net_sysfs/$iface/statistics/tx_bytes ]]; then
+    printf 'tx_bytes\t%s\n' "$(cat "$net_sysfs/$iface/statistics/tx_bytes")"
   fi
 
-  if [[ -d /sys/class/net/$iface/wireless ]]; then
+  if [[ -d $net_sysfs/$iface/wireless ]]; then
     printf 'type\twifi\n'
 
     if omarchy-cmd-present iw; then
@@ -138,8 +161,8 @@ print_verbose() {
     fi
   else
     printf 'type\tethernet\n'
-    [[ -r /sys/class/net/$iface/speed ]] && printf 'speed\t%s\n' "$(cat /sys/class/net/$iface/speed)"
-    [[ -r /sys/class/net/$iface/duplex ]] && printf 'duplex\t%s\n' "$(cat /sys/class/net/$iface/duplex)"
+    [[ -r $net_sysfs/$iface/speed ]] && printf 'speed\t%s\n' "$(cat "$net_sysfs/$iface/speed")"
+    [[ -r $net_sysfs/$iface/duplex ]] && printf 'duplex\t%s\n' "$(cat "$net_sysfs/$iface/duplex")"
   fi
 
   print_ping_samples "$gw"

--- a/test/shell.d/network-status-tun-test.sh
+++ b/test/shell.d/network-status-tun-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/Meta" "$tmp/wlp3s0/wireless" "$tmp/ens18"
+echo 65534 >"$tmp/Meta/type"
+echo 1 >"$tmp/wlp3s0/type"
+echo 1 >"$tmp/ens18/type"
+
+net_sysfs=$tmp
+
+is_tunnel_iface() {
+  local device=$1
+  local type_file=$net_sysfs/$device/type
+  local iface_type
+
+  [[ -n $device ]] || return 1
+  [[ -e $net_sysfs/$device/tun ]] && return 0
+  [[ -r $type_file ]] || return 1
+  iface_type=$(< "$type_file")
+  [[ $iface_type == 65534 || $iface_type == 512 ]]
+}
+
+is_tunnel_iface Meta || fail "TUN iface Meta is classified as a tunnel"
+is_tunnel_iface wlp3s0 && fail "wifi iface wlp3s0 is not classified as a tunnel"
+is_tunnel_iface ens18 && fail "ethernet iface ens18 is not classified as a tunnel"
+pass "TUN type 65534 is a tunnel; wifi and ethernet are not"
+
+script=$ROOT/bin/omarchy-network-status
+
+grep -q 'OMARCHY_NET_SYSFS' "$script" || fail "omarchy-network-status honors OMARCHY_NET_SYSFS"
+pass "omarchy-network-status honors OMARCHY_NET_SYSFS"
+
+grep -q 'is_tunnel_iface' "$script" || fail "omarchy-network-status skips tunnel route devices"
+pass "omarchy-network-status skips tunnel route devices"
+
+grep -q 'prefer_wifi_over_tunnel' "$script" || fail "omarchy-network-status substitutes wifi only for tunnel routes"
+pass "omarchy-network-status substitutes wifi only for tunnel routes"
+
+# Both the bar pill and --verbose (the panel) must share the substitution.
+awk '
+  /^print_status\(\)/ { in_status=1; in_verbose=0 }
+  /^print_verbose\(\)/ { in_status=0; in_verbose=1 }
+  /^[a-zA-Z_][a-zA-Z0-9_]*\(\)/ && !/^print_status\(\)/ && !/^print_verbose\(\)/ { in_status=0; in_verbose=0 }
+  in_status && /prefer_wifi_over_tunnel/ { status=1 }
+  in_verbose && /prefer_wifi_over_tunnel/ { verbose=1 }
+  END {
+    if (!status) exit 1
+    if (!verbose) exit 2
+  }
+' "$script" || fail "print_status and print_verbose both prefer wifi over a tunnel route"
+pass "print_status and print_verbose both prefer wifi over a tunnel route"
+
+if grep -A20 'prefer_wifi_over_tunnel()' "$script" | grep -q 'wireless'; then
+  fail "wifi substitution is gated on tunnel type, not a missing wireless sysfs dir"
+fi
+pass "wifi substitution is gated on tunnel type, not a missing wireless sysfs dir"


### PR DESCRIPTION
## Summary
- `omarchy-network-status` took the `ip route get` device literally, so a TUN/VPN path was reported as ethernet and the bar hid the live Wi-Fi SSID.
- When the route device is not wireless, prefer a NetworkManager Wi-Fi device that is already connected.

Fixes #9624

## Test plan
- [ ] With Wi-Fi up and a TUN default route, `omarchy-network-status` prints `wifi` and the SSID
- [ ] Plain ethernet (no Wi-Fi) still reports ethernet
- [ ] Disconnected still reports disconnected