### PR TITLE
Show Bluetooth Alias ahead of the hardware Name

### DIFF
--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -1,6 +1,6 @@
 function deviceLabel(device) {
   if (!device) return ""
-  return String(device.deviceName || device.name || "").trim()
+  return String(device.name || device.deviceName || "").trim()
 }
 
 function toArray(values) {

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -97,8 +97,16 @@ assertDeepEqual(
   { address: '1', name: 'Deadbeef', deviceName: '', connected: false, state: -1, batteryAvailable: false, battery: 0, pairing: false },
   'bluetooth projects device rows with primitives only'
 )
+// BlueZ Alias is the user-facing rename and arrives as Quickshell's writable
+// `name`; the read-only `deviceName` is the hardware-advertised Name, which is
+// only what to show when nothing renamed the device.
 assertEqual(
-  bluetooth.deviceLabel(bluetooth.deviceRow({ name: 'Generic', deviceName: 'MX Master 3S', address: '2', connected: true })),
+  bluetooth.deviceLabel(bluetooth.deviceRow({ name: 'My Custom Name', deviceName: 'MX Master 3S', address: '2', connected: true })),
+  'My Custom Name',
+  'bluetooth shows the alias ahead of the hardware name'
+)
+assertEqual(
+  bluetooth.deviceLabel(bluetooth.deviceRow({ deviceName: 'MX Master 3S', address: '2', connected: true })),
   'MX Master 3S',
   'bluetooth keeps deviceName in row projections so labels survive QObject-free rows'
 )


### PR DESCRIPTION
## Summary
- The Bluetooth panel preferred BlueZ `Name` (`deviceName`) over `Alias` (`name`), so user renames never appeared.
- Prefer the alias, falling back to the hardware name when unset.

Fixes #9603

## Test plan
- [ ] `bluetoothctl set-alias "My Custom Name"` then open the Bluetooth panel — custom name shows
- [ ] A device without an alias still shows its hardware name