### PR TITLE
Use subl for the Sublime Text default editor

### DIFF
--- a/bin/omarchy-default-editor
+++ b/bin/omarchy-default-editor
@@ -25,7 +25,7 @@ case "$1" in
 code) selection="code"; editor="code"; name="VSCode"; glyph= ;;
 cursor) selection="cursor"; editor="cursor"; name="Cursor"; glyph= ;;
 zed | zeditor) selection="zed"; editor="zeditor"; name="Zed"; glyph= ;;
-sublime_text) selection="sublime_text"; editor="sublime_text"; name="Sublime Text"; glyph= ;;
+sublime_text | subl) selection="sublime_text"; editor="subl"; name="Sublime Text"; glyph= ;;
 helix) selection="helix"; editor="helix"; name="Helix"; glyph= ;;
 vim) selection="vim"; editor="vim"; name="Vim"; glyph= ;;
 emacs) selection="emacs"; editor="emacs"; name="Emacs"; glyph= ;;

--- a/bin/omarchy-default-editor
+++ b/bin/omarchy-default-editor
@@ -17,6 +17,9 @@ if (($# == 0)); then
     read -r editor <"$editor_file"
   fi
 
+  # sublime-text-4 ships `subl`; older defaults stored `sublime_text`.
+  [[ $editor == sublime_text ]] && editor=subl
+
   [[ -n $editor ]] && echo "$editor" || echo "nvim"
   exit 0
 fi

--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -18,6 +18,9 @@ else
   editor="nvim"
 fi
 
+# sublime-text-4 ships `subl` on PATH, not `sublime_text`.
+[[ $editor == sublime_text ]] && editor=subl
+
 omarchy-cmd-present "$editor" || editor="nvim"
 
 case "${editor##*/}" in

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -164,7 +164,7 @@
   "setup.default.editor.vscode": {"icon":"","label":"VSCode","checked":"[[ \"$(omarchy-default-editor)\" == \"code\" ]]","action":"omarchy-default-editor code"},
   "setup.default.editor.cursor": {"icon":"","label":"Cursor","checked":"[[ \"$(omarchy-default-editor)\" == \"cursor\" ]]","action":"omarchy-default-editor cursor"},
   "setup.default.editor.zed": {"icon":"","label":"Zed","checked":"[[ \"$(omarchy-default-editor)\" == \"zeditor\" ]]","action":"omarchy-default-editor zed"},
-  "setup.default.editor.sublime": {"icon":"","label":"Sublime Text","checked":"[[ \"$(omarchy-default-editor)\" == \"sublime_text\" ]]","action":"omarchy-default-editor sublime_text"},
+  "setup.default.editor.sublime": {"icon":"","label":"Sublime Text","when":"omarchy-cmd-present subl","checked":"[[ \"$(omarchy-default-editor)\" == \"subl\" ]]","action":"omarchy-default-editor sublime_text"},
   "setup.default.editor.helix": {"icon":"","label":"Helix","checked":"[[ \"$(omarchy-default-editor)\" == \"helix\" ]]","action":"omarchy-default-editor helix"},
   "setup.default.editor.vim": {"icon":"","label":"Vim","checked":"[[ \"$(omarchy-default-editor)\" == \"vim\" ]]","action":"omarchy-default-editor vim"},
   "setup.default.editor.emacs": {"icon":"","label":"Emacs","checked":"[[ \"$(omarchy-default-editor)\" == \"emacs\" ]]","action":"omarchy-default-editor emacs"},

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -164,7 +164,7 @@
   "setup.default.editor.vscode": {"icon":"","label":"VSCode","checked":"[[ \"$(omarchy-default-editor)\" == \"code\" ]]","action":"omarchy-default-editor code"},
   "setup.default.editor.cursor": {"icon":"","label":"Cursor","checked":"[[ \"$(omarchy-default-editor)\" == \"cursor\" ]]","action":"omarchy-default-editor cursor"},
   "setup.default.editor.zed": {"icon":"","label":"Zed","checked":"[[ \"$(omarchy-default-editor)\" == \"zeditor\" ]]","action":"omarchy-default-editor zed"},
-  "setup.default.editor.sublime": {"icon":"","label":"Sublime Text","when":"omarchy-cmd-present subl","checked":"[[ \"$(omarchy-default-editor)\" == \"subl\" ]]","action":"omarchy-default-editor sublime_text"},
+  "setup.default.editor.sublime": {"icon":"","label":"Sublime Text","checked":"[[ \"$(omarchy-default-editor)\" == \"subl\" ]]","action":"omarchy-default-editor sublime_text"},
   "setup.default.editor.helix": {"icon":"","label":"Helix","checked":"[[ \"$(omarchy-default-editor)\" == \"helix\" ]]","action":"omarchy-default-editor helix"},
   "setup.default.editor.vim": {"icon":"","label":"Vim","checked":"[[ \"$(omarchy-default-editor)\" == \"vim\" ]]","action":"omarchy-default-editor vim"},
   "setup.default.editor.emacs": {"icon":"","label":"Emacs","checked":"[[ \"$(omarchy-default-editor)\" == \"emacs\" ]]","action":"omarchy-default-editor emacs"},

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -69,7 +69,7 @@ omarchy-pkg-add|omarchy-pkg-aur-add)
   firefox) command=firefox ;;
   zen-browser-bin) command=zen-browser ;;
   cursor-bin) command=cursor ;;
-  sublime-text-4) command=sublime_text ;;
+  sublime-text-4) command=subl ;;
   vim) command=vim ;;
   neovim) command=nvim ;;
   esac
@@ -169,7 +169,7 @@ editor_cases=(
   'code code editor:vscode'
   'cursor cursor pkg:cursor-bin'
   'zed zeditor editor:zed'
-  'sublime_text sublime_text pkg:sublime-text-4'
+  'sublime_text subl pkg:sublime-text-4'
   'helix helix editor:helix'
   'vim vim pkg:vim'
   'emacs emacs editor:emacs'


### PR DESCRIPTION
## Summary
- `sublime-text-4` puts `subl` on PATH, not `sublime_text`, so Defaults → Editor hid Sublime and `omarchy-launch-editor` fell back to Neovim.
- Store and launch `subl`, map a legacy `sublime_text` default, and gate the menu row on `subl`.

Fixes #9643

## Test plan
- [ ] After installing Sublime, Defaults → Editor lists Sublime Text
- [ ] Choosing it writes `subl` and `omarchy-launch-editor` opens Sublime
- [ ] An older `sublime_text` default file still launches via `subl`