### PR TITLE
Let shell.json rewrite the urgency a notification sender declared

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -169,7 +169,12 @@ Rules:
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
-8. `version: 1` is required.
+8. `notifications.rules[]` rewrites the urgency a sender declared, applied at
+   ingest so popup lifetime, do-not-disturb and history all read the corrected
+   value. Each rule filters on the fields it names (`app`, `appIcon`, `summary`,
+   `body`, `urgency`), a `~` suffix making the value a regular expression, and
+   `set.urgency` carries the replacement. Rules apply in order; the last match wins.
+9. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -62,6 +62,28 @@ Nothing is lost, though. A silenced notification is written straight into your n
 
 Two kinds of message still get through: Omarchy's own confirmation toasts for something you just did ("Theme changed", "Screenshot saved"), and critical alerts sent from the command line. Chat apps that mark everything critical to force their way in front of you don't qualify.
 
+### Notification urgency
+
+Senders pick their own urgency, and some of them lie about it. An app that marks every message critical gets a toast that never goes away on its own, because critical notifications stay up until you dismiss them. You can correct a sender with a top-level `notifications` block in `~/.config/omarchy/shell.json`:
+
+```json
+{
+  "version": 1,
+  "notifications": {
+    "rules": [
+      { "app": "Brave Origin", "urgency": "critical", "set": { "urgency": "normal" } },
+      { "app": "Brave Origin", "summary~": "Alex|Sam", "set": { "urgency": "critical" } }
+    ]
+  }
+}
+```
+
+A rule filters on the fields it names — `app`, `appIcon`, `summary`, `body`, and the incoming `urgency` — and every field it names has to match. Add a `~` to a field name to match a regular expression instead of the exact text. What the rule changes goes in `set`. The urgency names are `low`, `normal` and `critical`.
+
+Rules apply in order and the last match wins, so the pair above reads as "everything that browser marks critical is really only normal, except messages from these two people, which really are critical". The name to match is the one the sender declares for itself; if you are not sure what that is, read it out of the `app` field of your recent notifications in `~/.local/state/omarchy/notifications/history/`.
+
+The correction happens the moment a notification arrives, before anything else looks at it. A remapped notification gets the on-screen lifetime of its new urgency, and it faces do not disturb as the new urgency too.
+
 ### Idle
 
 The Omarchy shell owns idle behavior, and the timings are a top-level `idle` block in `~/.config/omarchy/shell.json`:

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -115,10 +115,13 @@ function summaryStartsWithGlyph(summary) {
   return spaces >= 2
 }
 
-function shouldBypassDnd(notification, criticalUrgency) {
-  var appName = String((notification && notification.appName) || "")
+// Takes the snapshot rather than the live notification so it reads the urgency
+// mapUrgency() settled on: a rule that maps a sender below critical has to stop
+// it bypassing do-not-disturb too, or the mapping only half applies.
+function shouldBypassDnd(entry, criticalUrgency) {
+  var appName = String((entry && entry.app) || "")
   if (appName === "omarchy-action") return true
-  return appName === "notify-send" && notification && notification.urgency === criticalUrgency
+  return appName === "notify-send" && entry && entry.urgency === criticalUrgency
 }
 
 function isEphemeralApp(appName) {
@@ -180,12 +183,66 @@ function shouldRenderCompactGlyph(glyph, iconSource, singleLineToast) {
   return String(glyph || "").length > 0 && String(iconSource || "").length === 0 && !!singleLineToast
 }
 
-function snapshotOf(notification, timestamp) {
+var URGENCY_VALUES = { low: 0, normal: 1, critical: 2 }
+
+// Fields a rule may match on, each compared against the same-named snapshot
+// field. A `~` suffix makes the value a regular expression instead of an exact
+// match, following mako's `summary~` / `body~` convention.
+var RULE_MATCH_FIELDS = ["app", "appIcon", "summary", "body"]
+
+// Every matcher a rule carries has to match, so a rule narrows as fields are
+// added to it. A rule that names no matcher at all therefore matches
+// everything, which is the only way to express a blanket remap.
+function ruleMatches(rule, entry) {
+  if (rule.urgency !== undefined && URGENCY_VALUES[rule.urgency] !== entry.urgency) return false
+
+  for (var i = 0; i < RULE_MATCH_FIELDS.length; i++) {
+    var field = RULE_MATCH_FIELDS[i]
+    var value = String(entry[field] || "")
+    if (rule[field] !== undefined && String(rule[field]) !== value) return false
+
+    var pattern = rule[field + "~"]
+    if (pattern === undefined) continue
+    try {
+      if (!new RegExp(String(pattern)).test(value)) return false
+    } catch (error) {
+      // A pattern the user mistyped must not take the notification down with
+      // it: the rule simply does not apply.
+      return false
+    }
+  }
+
+  return true
+}
+
+// Senders lie about urgency — chat apps mark routine messages critical to force
+// visibility — and every downstream decision (popup lifetime, do-not-disturb
+// bypass, card styling, history) reads urgency. Correcting it once, here at
+// ingest, keeps all of them honest rather than special-casing each in turn.
+//
+// Rules apply in order and the last match wins, so a broad rule can be narrowed
+// by a later, more specific one.
+function mapUrgency(entry, rules) {
+  var source = entry || {}
+  var urgency = source.urgency
+  if (!Array.isArray(rules)) return urgency
+
+  for (var i = 0; i < rules.length; i++) {
+    var rule = rules[i] || {}
+    if (!ruleMatches(rule, source)) continue
+    var mapped = URGENCY_VALUES[(rule.set || {}).urgency]
+    if (mapped !== undefined) urgency = mapped
+  }
+
+  return urgency
+}
+
+function snapshotOf(notification, timestamp, rules) {
   var n = notification || {}
   var id = n.id || 0
   var expireTimeout = Number(n.expireTimeout || 0)
   if (!isFinite(expireTimeout) || expireTimeout < 0) expireTimeout = 0
-  return {
+  var snapshot = {
     id: id,
     originalId: id,
     app: n.appName || "",
@@ -199,6 +256,10 @@ function snapshotOf(notification, timestamp) {
     expireTimeout: expireTimeout,
     timestamp: timestamp === undefined ? Date.now() : timestamp
   }
+  // Map before anyone reads it: this snapshot is what the popup, the
+  // do-not-disturb check and the history entry all consume.
+  snapshot.urgency = mapUrgency(snapshot, rules)
+  return snapshot
 }
 
 // Everything the popup card draws, and therefore everything an in-place
@@ -227,8 +288,8 @@ function popupRowChanged(row, updated) {
 // the popup it took over: the file name is the timestamp and id the popup was
 // first persisted under, and the restore, replace and archive paths all key
 // off that name. Only what the card draws comes from the updated object.
-function replacementSnapshot(notification, originalId, timestamp) {
-  var updated = snapshotOf(notification, timestamp)
+function replacementSnapshot(notification, originalId, timestamp, rules) {
+  var updated = snapshotOf(notification, timestamp, rules)
   updated.id = originalId
   updated.originalId = originalId
   return updated
@@ -459,6 +520,7 @@ if (typeof module !== "undefined") {
     execArgvFromHints: execArgvFromHints,
     parseExecArgv: parseExecArgv,
     shouldRenderCompactGlyph: shouldRenderCompactGlyph,
+    mapUrgency: mapUrgency,
     snapshotOf: snapshotOf,
     popupRoles: popupRoles,
     popupRowChanged: popupRowChanged,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -99,6 +99,12 @@ Item {
   readonly property int normalPopupDuration: 8000
   readonly property int maxPopupDuration: 30000
 
+  // Rules that correct the urgency senders declare, applied once at ingest by
+  // NotificationLogic.mapUrgency(). Read straight off shellConfig so they
+  // hot-reload with the rest of shell.json.
+  readonly property var notificationsConfig: shell && shell.shellConfig && shell.shellConfig.notifications ? shell.shellConfig.notifications : ({})
+  readonly property var urgencyRules: Array.isArray(notificationsConfig.rules) ? notificationsConfig.rules : []
+
   function durationFor(urgency, expireTimeout) {
     switch (urgency) {
     case NotificationUrgency.Critical:
@@ -127,12 +133,12 @@ Item {
   //     Trusted because it's almost always omarchy or system shell scripts —
   //     chat apps set app_name to their brand (Discord/Slack/Vesktop), which
   //     falls outside this rule.
-  function shouldBypassDnd(notification) {
-    return NotificationLogic.shouldBypassDnd(notification, NotificationUrgency.Critical)
+  function shouldBypassDnd(entry) {
+    return NotificationLogic.shouldBypassDnd(entry, NotificationUrgency.Critical)
   }
 
   function snapshotOf(notification) {
-    return NotificationLogic.snapshotOf(notification, Date.now())
+    return NotificationLogic.snapshotOf(notification, Date.now(), service.urgencyRules)
   }
 
   // A notification nobody looks back at:
@@ -170,7 +176,7 @@ Item {
     // DND bypass rules: chat apps abuse urgency=critical to force
     // visibility, so critical alone isn't enough — we also require the
     // sender to be CLI-style. See shouldBypassDnd().
-    if (service.doNotDisturb && !shouldBypassDnd(notification)) {
+    if (service.doNotDisturb && !shouldBypassDnd(snapshot)) {
       // The toast never shows, so the only record a silenced notification
       // can leave is a history entry. Write it straight into history —
       // "what did I miss while silenced" is exactly what history is for.
@@ -206,7 +212,7 @@ Item {
     writeHistoryFile(written, function() {
       var updated = null
       try {
-        updated = NotificationLogic.replacementSnapshot(notification, written.originalId, written.timestamp)
+        updated = NotificationLogic.replacementSnapshot(notification, written.originalId, written.timestamp, service.urgencyRules)
       } catch (e) {
         // Torn down by the server while the write was queued.
       }
@@ -260,7 +266,7 @@ Item {
 
     var updated
     try {
-      updated = NotificationLogic.replacementSnapshot(notification, originalId, timestamp)
+      updated = NotificationLogic.replacementSnapshot(notification, originalId, timestamp, service.urgencyRules)
     } catch (e) {
       // Object torn down by the server while the signal was in flight.
       return

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -187,11 +187,11 @@ assert(notifications.shouldRenderCompactGlyph('K', '', true), 'notifications ren
 assert(!notifications.shouldRenderCompactGlyph('K', '', false), 'notifications give glyph hints with bodies the large icon slot')
 assert(!notifications.shouldRenderCompactGlyph('K', 'file:///tmp/image.png', true), 'notifications keep image-backed glyph hints in the icon slot')
 
-assert(notifications.shouldBypassDnd({ appName: 'omarchy-action', urgency: 1 }, 2), 'omarchy action toasts bypass DND')
-assert(notifications.shouldBypassDnd({ appName: 'notify-send', urgency: 2 }, 2), 'critical notify-send bypasses DND')
-assert(!notifications.shouldBypassDnd({ appName: 'notify-send', urgency: 1 }, 2), 'normal notify-send does not bypass DND')
-assert(!notifications.shouldBypassDnd({ appName: 'Slack', urgency: 2 }, 2), 'critical app notifications do not bypass DND')
-assert(!notifications.shouldBypassDnd({ appName: 'omarchy-menu-keybindings', urgency: 1 }, 2), 'omarchy command app names do not bypass DND')
+assert(notifications.shouldBypassDnd({ app: 'omarchy-action', urgency: 1 }, 2), 'omarchy action toasts bypass DND')
+assert(notifications.shouldBypassDnd({ app: 'notify-send', urgency: 2 }, 2), 'critical notify-send bypasses DND')
+assert(!notifications.shouldBypassDnd({ app: 'notify-send', urgency: 1 }, 2), 'normal notify-send does not bypass DND')
+assert(!notifications.shouldBypassDnd({ app: 'Slack', urgency: 2 }, 2), 'critical app notifications do not bypass DND')
+assert(!notifications.shouldBypassDnd({ app: 'omarchy-menu-keybindings', urgency: 1 }, 2), 'omarchy command app names do not bypass DND')
 assert(!notifications.isEphemeralApp('omarchy-menu-keybindings'), 'notifications treat omarchy command app names as normal apps')
 
 // The click action's argv form: parsed from the persisted omarchy-exec-argv
@@ -722,5 +722,125 @@ assert(
 assert(
   !/pendingModel|pastModel/.test(serviceQml),
   'notifications service keeps no in-memory history models'
+)
+
+assertEqual(
+  notifications.mapUrgency(
+    { app: 'Brave Origin', urgency: 2 },
+    [{ app: 'Brave Origin', urgency: 'critical', set: { urgency: 'normal' } }]
+  ),
+  1,
+  'notifications remap a matching sender from critical down to normal'
+)
+
+assertEqual(
+  notifications.mapUrgency(
+    { app: 'Slack', urgency: 2 },
+    [{ app: 'Brave Origin', set: { urgency: 'normal' } }]
+  ),
+  2,
+  'notifications leave a non-matching sender untouched'
+)
+
+assertEqual(
+  notifications.mapUrgency(
+    { app: 'Brave Origin', urgency: 0 },
+    [{ app: 'Brave Origin', set: { urgency: 'normal' } }]
+  ),
+  1,
+  'notifications apply a rule without an urgency matcher to any urgency'
+)
+
+assertEqual(
+  notifications.mapUrgency(
+    { app: 'Brave Origin', summary: 'Manuel Rivero', urgency: 1 },
+    [{ 'summary~': 'Manuel|Rafael', set: { urgency: 'critical' } }]
+  ),
+  2,
+  'notifications match a rule by regular expression on the summary'
+)
+
+assertEqual(
+  notifications.mapUrgency(
+    { app: 'Brave Origin', summary: 'unrelated', urgency: 2 },
+    [{ app: 'Brave Origin', 'summary~': 'Manuel', set: { urgency: 'normal' } }]
+  ),
+  2,
+  'notifications require every matcher in a rule to match'
+)
+
+assertEqual(
+  notifications.mapUrgency(
+    { app: 'Brave Origin', summary: 'Manuel Rivero', urgency: 2 },
+    [
+      { app: 'Brave Origin', set: { urgency: 'normal' } },
+      { 'summary~': 'Manuel', set: { urgency: 'critical' } }
+    ]
+  ),
+  2,
+  'notifications let a later matching rule win over an earlier one'
+)
+
+assertEqual(
+  notifications.mapUrgency(
+    { app: 'Brave Origin', urgency: 2 },
+    [{ app: 'Brave Origin', set: { urgency: 'catastrophic' } }]
+  ),
+  2,
+  'notifications ignore a rule that sets an unknown urgency name'
+)
+
+assertEqual(
+  notifications.mapUrgency({ app: 'Brave Origin', urgency: 2 }, undefined),
+  2,
+  'notifications leave urgency untouched when no rules are configured'
+)
+
+assertEqual(
+  notifications.mapUrgency(
+    { app: 'Brave Origin', summary: 'anything', urgency: 2 },
+    [{ 'summary~': '[', set: { urgency: 'normal' } }]
+  ),
+  2,
+  'notifications skip a rule whose regular expression does not compile'
+)
+
+const remapBrave = [{ app: 'Brave Origin', set: { urgency: 'normal' } }]
+
+assertEqual(
+  notifications.snapshotOf({ appName: 'Brave Origin', urgency: 2 }, 1000, remapBrave).urgency,
+  1,
+  'notifications snapshot a sender with its urgency already remapped'
+)
+
+assertEqual(
+  notifications.replacementSnapshot({ appName: 'Brave Origin', urgency: 2 }, 7, 1000, remapBrave).urgency,
+  1,
+  'notifications remap urgency on an in-place notification update too'
+)
+
+assert(
+  notifications.shouldBypassDnd({ app: 'notify-send', urgency: 2 }, 2),
+  'notifications let a CLI critical alert bypass do-not-disturb'
+)
+
+assert(
+  !notifications.shouldBypassDnd({ app: 'notify-send', urgency: 1 }, 2),
+  'notifications stop bypassing do-not-disturb once a rule maps a sender below critical'
+)
+
+assert(
+  /shouldBypassDnd\(snapshot\)/.test(serviceQml),
+  'notifications service checks do-not-disturb against the mapped snapshot'
+)
+
+assert(
+  /shellConfig\.notifications[\s\S]{0,200}?rules/.test(serviceQml),
+  'notifications service reads its urgency rules from shell.json'
+)
+
+assert(
+  /NotificationLogic\.snapshotOf\(notification, Date\.now\(\), service\.urgencyRules\)/.test(serviceQml),
+  'notifications service hands its urgency rules to every snapshot it takes'
 )
 JS


### PR DESCRIPTION
Senders pick their own urgency and some misdeclare it. A chat app that marks every message critical gets a toast that never expires, because `durationFor()` returns `0` for `NotificationUrgency.Critical`. The message then sits on screen until it is dismissed by hand.

Urgency is not read in one place — popup lifetime, the do-not-disturb bypass, card styling and what lands in history all consult it. So rather than special-casing duration, this corrects urgency once at ingest and lets every downstream decision stay honest.

## What it adds

A top-level `notifications.rules[]` block in `shell.json`:

```json
{
  "notifications": {
    "rules": [
      { "app": "Brave Origin", "urgency": "critical", "set": { "urgency": "normal" } },
      { "app": "Brave Origin", "summary~": "Alex|Sam", "set": { "urgency": "critical" } }
    ]
  }
}
```

A rule filters on the fields it names — `app`, `appIcon`, `summary`, `body`, and the incoming `urgency` — and every field it names has to match. A `~` suffix makes the value a regular expression instead of exact text, following mako’s `summary~` / `body~` convention. What changes goes in `set`. Rules apply in order and the last match wins, so the pair above reads as “everything that browser marks critical is really only normal, except messages from these two people”.

Read straight off `shellConfig`, so the rules hot-reload with the rest of `shell.json`.

## Prior art

dunst has carried this for years: its rules match `appname` / `desktop_entry` / `msg_urgency` and `urgency` is among the attributes they can set. mako matches on a comparable field set with POSIX regex on `summary` / `body`. Both converged on declarative multi-field criteria rather than an expression language, which is what this follows.

## Implementation notes

- The mapping lands in `snapshotOf()`. Every snapshot funnels through it, `replacementSnapshot()` included, so notifications updated in place via `replaces_id` are mapped on the same path.
- `shouldBypassDnd()` now takes the snapshot instead of the live notification, so it reads the mapped urgency. Without this a sender mapped below critical would keep bypassing do-not-disturb and the mapping would only half apply. Its four existing assertions were updated to pass `app` rather than `appName`.
- `isEphemeral()` deliberately still reads the live object: it looks at the `transient` hint and the app name, neither of which the mapping touches.
- A rule whose regular expression does not compile is skipped rather than propagated, so a typo in `shell.json` cannot take a notification down with it.

## Testing

`test/shell.d/notifications-test.sh` covers the pure logic: matching by app and by regex, AND across matchers, later-rule-wins, an unknown urgency name, absent rules, and a malformed pattern. Three further assertions check the `Service.qml` wiring the way that file already checks the rest of the service.

`./test/all` passes except `config-test.sh`, `snapper-test.sh` and `unowned-system-paths-test.sh`, which fail identically on a clean checkout here (they want a sibling `omarchy-pkgs` checkout and a real system layout).

Also verified end to end on a running Omarchy 4.0.2 desktop, with the rules above in `shell.json`: a critical from the browser expired on the normal 8s timer, a matching summary stayed pinned, an unmapped CLI critical stayed pinned, and a `notify-send` critical mapped down to normal correctly stopped bypassing do-not-disturb.

## Relationship to existing work

Related to #9361, which reports that critical notifications never auto-expire. This does not close it: that report is about Omarchy’s own crash toasts, which are genuinely critical, and remapping those would be the wrong fix. A bounded default for critical, as the issue suggests, remains a separate change.

Orthogonal to #9010 and #8980, which both add a visible dismiss control. This touches neither the card nor `durationFor()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLxWtBaFee73f3cnkcA4iu