### PR TITLE
Add favorites to clipboard history

### DIFF
--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -12,6 +12,7 @@ Item {
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
   property bool opened: false
   property string filterText: ""
+  property bool favoritesOnly: false
   property int selectedIndex: 0
   property bool cursorActive: false
   property bool clearConfirmOpen: false
@@ -42,6 +43,7 @@ Item {
   function open(payloadJson) {
     root.opened = true
     root.filterText = ""
+    root.favoritesOnly = false
     root.selectedIndex = 0
     root.cursorActive = true
     root.disarmPointer()
@@ -73,7 +75,7 @@ Item {
   }
 
   function saveHistory() {
-    historyFile.setText(JSON.stringify(root.history.slice(0, root.historyLimit), null, 2) + "\n")
+    historyFile.setText(JSON.stringify(ClipboardHistory.capHistory(root.history, root.historyLimit), null, 2) + "\n")
   }
 
   function addClipboardEntry(entry) {
@@ -130,8 +132,23 @@ Item {
     root.rebuildDisplay()
   }
 
+  function toggleFavoriteAt(index) {
+    if (index < 0 || index >= displayModel.count) return
+
+    var row = displayModel.get(index)
+    root.history = ClipboardHistory.toggleFavorite(root.history, row.historyIndex)
+    root.saveHistory()
+    root.rebuildDisplay()
+  }
+
+  function toggleFavoritesOnly() {
+    root.favoritesOnly = !root.favoritesOnly
+    root.selectedIndex = 0
+    root.rebuildDisplay()
+  }
+
   function rebuildDisplay() {
-    var rows = ClipboardHistory.displayRows(root.history, root.filterText, 50)
+    var rows = ClipboardHistory.displayRows(root.history, root.filterText, 50, root.favoritesOnly)
 
     displayModel.clear()
     for (var i = 0; i < rows.length; i++) {
@@ -143,6 +160,7 @@ Item {
         previewImage: row.previewImage ? Util.fileUrl(row.previewImage) : "",
         path: row.path,
         mime: row.mime,
+        favorite: row.favorite,
         historyIndex: row.index
       })
     }
@@ -432,16 +450,36 @@ Item {
           color: "transparent"
 
           Text {
-            textFormat: Text.PlainText
             anchors.left: parent.left
-            anchors.right: parent.right
+            anchors.right: favoritesToggle.left
+            anchors.rightMargin: Style.space(10)
             anchors.verticalCenter: parent.verticalCenter
-            text: root.filterText || "Search clipboard…"
+            text: root.filterText || (root.favoritesOnly ? "Search favorites…" : "Search clipboard…")
+            textFormat: Text.PlainText
             color: root.foreground
             opacity: root.filterText ? 1 : 0.58
             font.family: root.fontFamily
             font.pixelSize: Style.font.heading
             elide: Text.ElideRight
+          }
+
+          Text {
+            id: favoritesToggle
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            text: ""
+            color: root.favoritesOnly ? Color.accent : root.foreground
+            opacity: root.favoritesOnly ? 1 : 0.5
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.heading
+
+            MouseArea {
+              anchors.fill: parent
+              anchors.margins: -Style.space(6)
+              hoverEnabled: true
+              cursorShape: Qt.PointingHandCursor
+              onClicked: root.toggleFavoritesOnly()
+            }
           }
         }
 
@@ -474,8 +512,10 @@ Item {
                   required property string previewText
                   required property string fullText
                   required property string previewImage
+                  required property bool favorite
 
                   readonly property bool hasCursor: root.cursorActive && index === root.selectedIndex
+                  readonly property int starWidth: Style.space(28)
 
                   width: ListView.view.width
                   height: root.rowHeight
@@ -501,10 +541,10 @@ Item {
                     }
 
                     Text {
-                      textFormat: Text.PlainText
-                      width: parent.width - (parent.parent.previewImage.length > 0 ? parent.height + parent.spacing : 0)
+                      width: parent.width - row.starWidth - (parent.parent.previewImage.length > 0 ? parent.height + parent.spacing : 0)
                       height: parent.height
                       text: parent.parent.previewText
+                      textFormat: Text.PlainText
                       color: parent.parent.hasCursor ? root.selectedText : root.foreground
                       font.family: root.fontFamily
                       font.pixelSize: Style.font.title
@@ -528,6 +568,26 @@ Item {
                       root.activateIndex(row.index)
                     }
                   }
+
+                  Text {
+                    id: starIcon
+                    anchors.right: parent.right
+                    anchors.rightMargin: Style.space(12)
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "\uf005"
+                    color: row.favorite ? Color.accent : (row.hasCursor ? root.selectedText : root.foreground)
+                    opacity: row.favorite ? 1 : 0.35
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.title
+
+                    MouseArea {
+                      anchors.fill: parent
+                      anchors.margins: -Style.space(6)
+                      hoverEnabled: true
+                      cursorShape: Qt.PointingHandCursor
+                      onClicked: root.toggleFavoriteAt(row.index)
+                    }
+                  }
                 }
               }
             }
@@ -548,7 +608,6 @@ Item {
               }
 
               Text {
-                textFormat: Text.PlainText
                 visible: parent.activeRow && !parent.activeRow.previewImage
                 anchors.fill: parent
                 anchors.leftMargin: root.contentMargin
@@ -556,6 +615,7 @@ Item {
                 anchors.topMargin: 0
                 anchors.bottomMargin: 0
                 text: parent.activeRow ? parent.activeRow.fullText : ""
+                textFormat: Text.PlainText
                 color: root.foreground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.title
@@ -596,8 +656,12 @@ Item {
             }
 
             Text {
+              text: root.history.length === 0
+                ? "Clipboard is empty"
+                : (root.favoritesOnly && !root.filterText
+                  ? "No favorites yet"
+                  : "No matches for “" + root.filterText + "”")
               textFormat: Text.PlainText
-              text: root.history.length === 0 ? "Clipboard is empty" : "No matches for “" + root.filterText + "”"
               color: root.foreground
               opacity: 0.7
               font.family: root.fontFamily

--- a/shell/plugins/clipboard/ClipboardHistory.js
+++ b/shell/plugins/clipboard/ClipboardHistory.js
@@ -7,7 +7,10 @@ function normalizeEntry(value) {
   var type = String(value.type || value.kind || "")
   if (type === "text") {
     var text = String(value.text || "")
-    return text.trim().length > 0 ? { type: "text", text: text } : null
+    if (text.trim().length === 0) return null
+    var textEntry = { type: "text", text: text }
+    if (value.favorite) textEntry.favorite = true
+    return textEntry
   }
 
   if (type === "image") {
@@ -20,6 +23,7 @@ function normalizeEntry(value) {
     }
     if (value.capturedAt !== undefined && value.capturedAt !== null)
       entry.capturedAt = String(value.capturedAt)
+    if (value.favorite) entry.favorite = true
     return entry
   }
 
@@ -48,24 +52,71 @@ function parseHistory(raw) {
   }
 }
 
-function addEntry(history, entry, limit) {
-  var normalized = normalizeEntry(entry)
-  var max = limit === undefined || limit === null ? 100 : Number(limit)
-  if (isNaN(max)) max = 100
-  max = Math.max(0, max)
-  if (!normalized) return Array.isArray(history) ? history.slice(0, max) : []
-  if (max === 0) return []
-
-  var key = entryKey(normalized)
-  var next = [normalized]
+function capHistory(history, limit) {
   var values = Array.isArray(history) ? history : []
+  var max = limit === undefined || limit === null ? 300 : Number(limit)
+  if (isNaN(max)) max = 300
+  max = Math.max(0, max)
 
-  for (var i = 0; i < values.length && next.length < max; i++) {
-    var existing = normalizeEntry(values[i])
-    if (!existing || entryKey(existing) === key) continue
-    next.push(existing)
+  var favoriteCount = 0
+  for (var i = 0; i < values.length; i++) {
+    var counted = normalizeEntry(values[i])
+    if (counted && counted.favorite) favoriteCount++
   }
 
+  var restBudget = Math.max(0, max - favoriteCount)
+  var kept = []
+  var restKept = 0
+
+  for (var j = 0; j < values.length; j++) {
+    var entry = normalizeEntry(values[j])
+    if (!entry) continue
+    if (entry.favorite) {
+      kept.push(entry)
+    } else if (restKept < restBudget) {
+      kept.push(entry)
+      restKept++
+    }
+  }
+
+  return kept
+}
+
+function addEntry(history, entry, limit) {
+  var normalized = normalizeEntry(entry)
+  var values = Array.isArray(history) ? history : []
+  if (!normalized) return capHistory(values, limit)
+
+  var key = entryKey(normalized)
+  for (var i = 0; i < values.length; i++) {
+    var existing = normalizeEntry(values[i])
+    if (existing && entryKey(existing) === key && existing.favorite) {
+      normalized.favorite = true
+      break
+    }
+  }
+
+  var next = [normalized]
+  for (var j = 0; j < values.length; j++) {
+    var current = normalizeEntry(values[j])
+    if (!current || entryKey(current) === key) continue
+    next.push(current)
+  }
+
+  return capHistory(next, limit)
+}
+
+function toggleFavorite(history, index) {
+  var values = Array.isArray(history) ? history : []
+  var target = Number(index)
+  if (isNaN(target) || target < 0 || target >= values.length) return values.slice()
+
+  var next = values.slice()
+  var entry = normalizeEntry(next[target])
+  if (!entry) return next
+
+  entry.favorite = !entry.favorite
+  next[target] = entry
   return next
 }
 
@@ -171,7 +222,7 @@ function cappedEntry(entry) {
   return { type: "text", text: entry.text.slice(0, cut > 0 ? cut : displayTextLimit) }
 }
 
-function displayRows(history, query, limit) {
+function displayRows(history, query, limit, favoritesOnly) {
   var values = Array.isArray(history) ? history : []
   var needle = String(query || "").trim().toLowerCase()
   var max = limit === undefined || limit === null ? 50 : Number(limit)
@@ -184,6 +235,7 @@ function displayRows(history, query, limit) {
   for (var i = 0; i < values.length; i++) {
     var entry = cappedEntry(normalizeEntry(values[i]))
     if (!entry) continue
+    if (favoritesOnly && !entry.favorite) continue
     if (needle && searchableText(entry).toLowerCase().indexOf(needle) < 0) continue
 
     var paths = filePaths(entry)
@@ -197,6 +249,7 @@ function displayRows(history, query, limit) {
       previewImage: previewPath,
       path: isImage ? String(entry.path || "") : (isFile && paths.length === 1 ? paths[0] : ""),
       mime: isImage ? String(entry.mime || "image/png") : "text/plain",
+      favorite: !!entry.favorite,
       index: i
     })
     if (rows.length >= max) break
@@ -211,6 +264,8 @@ if (typeof module !== "undefined") {
     entryKey: entryKey,
     parseHistory: parseHistory,
     addEntry: addEntry,
+    capHistory: capHistory,
+    toggleFavorite: toggleFavorite,
     removeEntryAt: removeEntryAt,
     clearHistory: clearHistory,
     parseEntryJson: parseEntryJson,

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -106,6 +106,7 @@ assertDeepEqual(
     previewImage: '/home/dhh/Videos/screenrecording-2026-05-29_13-56-43-720p.gif',
     path: '/home/dhh/Videos/screenrecording-2026-05-29_13-56-43-720p.gif',
     mime: 'text/plain',
+    favorite: false,
     index: 0
   },
   'clipboard display rows show file uri entries as files'
@@ -125,6 +126,78 @@ assertDeepEqual(
 
 assertDeepEqual(clipboard.displayRows(history, '', 0), [], 'clipboard display rows supports zero result limit')
 assertDeepEqual(clipboard.addEntry(history, 'next', 0), [], 'clipboard addEntry supports zero history limit')
+
+assertDeepEqual(
+  clipboard.normalizeEntry({ type: 'text', text: 'starred', favorite: true }),
+  { type: 'text', text: 'starred', favorite: true },
+  'clipboard normalizeEntry keeps the favorite flag on text entries'
+)
+
+assertDeepEqual(
+  clipboard.normalizeEntry({ type: 'text', text: 'plain', favorite: false }),
+  { type: 'text', text: 'plain' },
+  'clipboard normalizeEntry omits a false favorite flag'
+)
+
+assertDeepEqual(
+  clipboard.toggleFavorite([{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }], 1),
+  [{ type: 'text', text: 'a' }, { type: 'text', text: 'b', favorite: true }],
+  'clipboard toggleFavorite stars the entry at the given index'
+)
+
+assertDeepEqual(
+  clipboard.toggleFavorite([{ type: 'text', text: 'a', favorite: true }], 0),
+  [{ type: 'text', text: 'a', favorite: false }],
+  'clipboard toggleFavorite unstars an already favorited entry'
+)
+
+assertDeepEqual(
+  clipboard.toggleFavorite([{ type: 'text', text: 'a' }], 5),
+  [{ type: 'text', text: 'a' }],
+  'clipboard toggleFavorite ignores an out-of-range index'
+)
+
+assertDeepEqual(
+  clipboard.addEntry([{ type: 'text', text: 'dup', favorite: true }], 'dup', 100)[0],
+  { type: 'text', text: 'dup', favorite: true },
+  'clipboard addEntry keeps the favorite flag when a favorited entry is copied again'
+)
+
+assertDeepEqual(
+  clipboard.capHistory([
+    { type: 'text', text: 'keep-1', favorite: true },
+    { type: 'text', text: 'keep-2', favorite: true },
+    { type: 'text', text: 'old-1' },
+    { type: 'text', text: 'old-2' }
+  ], 3),
+  [
+    { type: 'text', text: 'keep-1', favorite: true },
+    { type: 'text', text: 'keep-2', favorite: true },
+    { type: 'text', text: 'old-1' }
+  ],
+  'clipboard capHistory exempts favorites from the history limit'
+)
+
+assertDeepEqual(
+  clipboard.displayRows([{ type: 'text', text: 'starred' }, { type: 'text', text: 'plain', favorite: true }], '', 50).map(row => row.favorite),
+  [false, true],
+  'clipboard display rows expose the favorite flag'
+)
+
+assertDeepEqual(
+  clipboard.displayRows([{ type: 'text', text: 'a', favorite: true }, { type: 'text', text: 'b' }], '', 50, true).map(row => row.previewText),
+  ['a'],
+  'clipboard display rows support filtering to favorites only'
+)
+
+assert(
+  /function toggleFavoriteAt\(index\)[\s\S]*ClipboardHistory\.toggleFavorite\(root\.history, row\.historyIndex\)/.test(clipboardQml),
+  'clipboard toggles the favorite flag on the underlying history entry'
+)
+assert(
+  /function toggleFavoritesOnly\(\)[\s\S]*root\.favoritesOnly = !root\.favoritesOnly/.test(clipboardQml),
+  'clipboard supports toggling a favorites-only filter'
+)
 
 assert(
   /function select\(delta\)[\s\S]*root\.disarmPointer\(\)[\s\S]*selectedIndex =/.test(clipboardQml),


### PR DESCRIPTION
## Summary
- Star clipboard entries so they survive the history size cap instead of aging out, with a star toggle on each row and a favorites-only filter in the search bar
- `capHistory()` now exempts favorites from the size limit; non-favorites still get trimmed to fill the remaining budget
- Re-copying an already-favorited entry keeps it starred instead of resetting it

## Test plan
- [x] `test/shell.d/clipboard-test.sh` passes, including new coverage for `toggleFavorite`, `capHistory` favorite exemption, favorite-preserving dedupe, and `displayRows` favorites filtering
- [x] `test/shell.d/qml-text-format-test.sh` passes