### PR TITLE
fix: idle-inhibit Steam games matching steam_app_*

### DIFF
--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -1,4 +1,6 @@
 o.window("steam", { float = true, idle_inhibit = "fullscreen" })
+-- Hyprland FullMatch: "steam" is the client only. Games are steam_app_<id>.
+o.window("steam_app_.*", { idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })

--- a/test/shell.d/steam-idle-inhibit-test.sh
+++ b/test/shell.d/steam-idle-inhibit-test.sh
@@ -9,15 +9,15 @@ const fs = require('fs')
 const steam = fs.readFileSync(root + '/default/hypr/apps/steam.lua', 'utf8')
 
 assert(
-  /o\.window\("steam_app_\.\*",\s*\{\s*idle_inhibit\s*=\s*"fullscreen"\s*\}/.test(steam),
+  /^o\.window\("steam_app_\.\*",\s*\{\s*idle_inhibit\s*=\s*"fullscreen"\s*\}/m.test(steam),
   'Steam games (steam_app_<id>) get a fullscreen idle inhibitor'
 )
 assert(
-  /o\.window\("steam",\s*\{[^}]*idle_inhibit\s*=\s*"fullscreen"/.test(steam),
+  /^o\.window\("steam",\s*\{[^}]*idle_inhibit\s*=\s*"fullscreen"/m.test(steam),
   'the Steam client still gets a fullscreen idle inhibitor'
 )
 assert(
-  !/o\.window\("steam_app_\.\*",\s*\{[^}]*float\s*=\s*true/.test(steam),
+  !/^o\.window\("steam_app_\.\*",\s*\{[^}]*float\s*=\s*true/m.test(steam),
   'Steam games are not forced floating by the idle-inhibit rule'
 )
 JS

--- a/test/shell.d/steam-idle-inhibit-test.sh
+++ b/test/shell.d/steam-idle-inhibit-test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const steam = fs.readFileSync(root + '/default/hypr/apps/steam.lua', 'utf8')
+
+assert(
+  /o\.window\("steam_app_\.\*",\s*\{\s*idle_inhibit\s*=\s*"fullscreen"\s*\}/.test(steam),
+  'Steam games (steam_app_<id>) get a fullscreen idle inhibitor'
+)
+assert(
+  /o\.window\("steam",\s*\{[^}]*idle_inhibit\s*=\s*"fullscreen"/.test(steam),
+  'the Steam client still gets a fullscreen idle inhibitor'
+)
+assert(
+  !/o\.window\("steam_app_\.\*",\s*\{[^}]*float\s*=\s*true/.test(steam),
+  'Steam games are not forced floating by the idle-inhibit rule'
+)
+JS


### PR DESCRIPTION
Closes #9636

Hyprland FullMatchs class regexes, so literal `steam` never matches `steam_app_<id>`. Keep the client float+idle_inhibit rule and add `steam_app_.*` idle_inhibit fullscreen without float.

`test/shell.d/steam-idle-inhibit-test.sh` PASS on `346f98a5`.