### PR TITLE
Add browser profile picker to web app setup

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -136,6 +136,55 @@ desktop_exec_arg() {
   printf '"%s"' "$escaped"
 }
 
+browser_profile_state_file() {
+  local browser
+  browser=$(xdg-settings get default-web-browser 2>/dev/null || true)
+
+  # Keep this in step with omarchy-launch-webapp: unsupported default browsers
+  # use Chromium for web apps.
+  case $browser in
+  google-chrome*) printf '%s' "$HOME/.config/google-chrome/Local State" ;;
+  brave-origin*) printf '%s' "$HOME/.config/BraveSoftware/Brave-Origin/Local State" ;;
+  brave*) printf '%s' "$HOME/.config/BraveSoftware/Brave-Browser/Local State" ;;
+  microsoft-edge*) printf '%s' "$HOME/.config/microsoft-edge/Local State" ;;
+  opera*) printf '%s' "$HOME/.config/opera/Local State" ;;
+  vivaldi*) printf '%s' "$HOME/.config/vivaldi/Local State" ;;
+  helium*) printf '%s' "$HOME/.config/net.imput.helium/Local State" ;;
+  *) printf '%s' "$HOME/.config/chromium/Local State" ;;
+  esac
+}
+
+select_browser_profile() {
+  local state_file directory name option selected
+  local -a options=("Automatic")
+  local -A profile_directories=()
+
+  state_file=$(browser_profile_state_file)
+  [[ -r $state_file ]] || return 0
+
+  while IFS=$'\t' read -r directory name; do
+    [[ -n $directory ]] || continue
+    option="$name ($directory)"
+    options+=("$option")
+    profile_directories["$option"]=$directory
+  done < <(jq -r '
+    .profile.info_cache // {}
+    | to_entries
+    | sort_by(.key)
+    | .[]
+    | [.key, (.value.name // .key)]
+    | @tsv
+  ' "$state_file" 2>/dev/null)
+
+  # With zero or one profile, automatic browser selection is unambiguous.
+  (( ${#options[@]} > 2 )) || return 0
+
+  selected=$(gum choose --header "Browser profile" "${options[@]}")
+  if [[ $selected != "Automatic" ]]; then
+    printf '%s' "${profile_directories[$selected]}"
+  fi
+}
+
 if (( $# < 3 )); then
   echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")
@@ -143,6 +192,7 @@ if (( $# < 3 )); then
   APP_URL=$(gum input --prompt "URL> " --placeholder "https://example.com")
   APP_URL=$(normalize_webapp_url "$APP_URL")
   require_http_url "$APP_URL"
+  BROWSER_PROFILE=$(select_browser_profile)
 
   # Try to fetch the site's icon automatically first.
   mkdir -p "$ICON_DIR"
@@ -164,6 +214,7 @@ else
   ICON_REF="$3"
   CUSTOM_EXEC="$4" # Optional custom exec command
   MIME_TYPES="$5"  # Optional mime types
+  BROWSER_PROFILE=""
   INTERACTIVE_MODE=false
 fi
 
@@ -206,6 +257,9 @@ if [[ -n $CUSTOM_EXEC ]]; then
   EXEC_COMMAND=$CUSTOM_EXEC
 else
   EXEC_COMMAND="omarchy-launch-webapp $(desktop_exec_arg "$APP_URL")"
+  if [[ -n $BROWSER_PROFILE ]]; then
+    EXEC_COMMAND+=" --profile-directory=$(desktop_exec_arg "$BROWSER_PROFILE")"
+  fi
 fi
 
 # Create application .desktop file

--- a/test/shell.d/webapp-browser-profile-test.sh
+++ b/test/shell.d/webapp-browser-profile-test.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command gio
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+home="$test_tmp/home"
+applications="$home/.local/share/applications"
+state_file="$home/.config/chromium/Local State"
+mkdir -p "$mock_bin" "$(dirname "$state_file")" "$applications"
+
+cat >"$state_file" <<'JSON'
+{
+  "profile": {
+    "info_cache": {
+      "Default": { "name": "Personal" },
+      "Profile 2": { "name": "Work" }
+    }
+  }
+}
+JSON
+
+cat >"$mock_bin/xdg-settings" <<'SH'
+#!/bin/bash
+printf '%s\n' chromium.desktop
+SH
+
+cat >"$mock_bin/gum" <<'SH'
+#!/bin/bash
+case $1 in
+input)
+  case $3 in
+  "Name> ") printf '%s\n' "Profile App" ;;
+  "URL> ") printf '%s\n' "https://example.com" ;;
+  "Icon URL/name> ") printf '%s\n' "someicon" ;;
+  esac
+  ;;
+choose)
+  printf '%s\n' "$*" >"$GUM_CHOOSE_ARGS"
+  printf '%s\n' "$GUM_PROFILE_SELECTION"
+  ;;
+esac
+SH
+
+cat >"$mock_bin/curl" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$mock_bin/omarchy-launch-webapp" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >"$OMARCHY_TEST_ARGV"
+SH
+
+chmod +x "$mock_bin"/*
+
+export HOME="$home"
+export PATH="$mock_bin:$PATH"
+export GUM_CHOOSE_ARGS="$test_tmp/gum-choose-args"
+export OMARCHY_TEST_ARGV="$test_tmp/argv"
+
+install_webapp() {
+  GUM_PROFILE_SELECTION="$1" "$ROOT/bin/omarchy-webapp-install" >/dev/null
+}
+
+launched_arguments() {
+  local file="$1" attempt
+
+  : >"$OMARCHY_TEST_ARGV"
+  gio launch "$file" >/dev/null 2>&1 || return 1
+  for ((attempt = 0; attempt < 200; attempt++)); do
+    [[ -s $OMARCHY_TEST_ARGV ]] && break
+    sleep 0.01
+  done
+
+  cat "$OMARCHY_TEST_ARGV"
+}
+
+install_webapp "Work (Profile 2)"
+profiled_file="$applications/Profile App.desktop"
+
+grep -Fq 'Automatic' "$GUM_CHOOSE_ARGS" ||
+  fail "webapp profile picker offers automatic selection" "$(cat "$GUM_CHOOSE_ARGS")"
+grep -Fq 'Personal (Default)' "$GUM_CHOOSE_ARGS" ||
+  fail "webapp profile picker shows the default profile" "$(cat "$GUM_CHOOSE_ARGS")"
+grep -Fq 'Work (Profile 2)' "$GUM_CHOOSE_ARGS" ||
+  fail "webapp profile picker shows named profiles" "$(cat "$GUM_CHOOSE_ARGS")"
+pass "webapp profile picker lists Chromium profiles"
+
+mapfile -t argv < <(launched_arguments "$profiled_file")
+(( ${#argv[@]} == 2 )) ||
+  fail "profiled webapp launches with two arguments" "${argv[*]}"
+[[ ${argv[0]} == "https://example.com" ]] ||
+  fail "profiled webapp keeps its URL" "${argv[*]}"
+[[ ${argv[1]} == "--profile-directory=Profile 2" ]] ||
+  fail "profiled webapp passes the selected profile directory" "${argv[*]}"
+pass "webapp profile picker binds the launcher to the selected profile"
+
+install_webapp "Automatic"
+automatic_argv=$(launched_arguments "$profiled_file")
+[[ $automatic_argv == "https://example.com" ]] ||
+  fail "automatic profile choice adds no browser profile flag" "$automatic_argv"
+pass "webapp profile picker preserves automatic browser selection"
+
+cat >"$state_file" <<'JSON'
+{"profile":{"info_cache":{"Default":{"name":"Personal"}}}}
+JSON
+rm -f "$GUM_CHOOSE_ARGS"
+install_webapp "unused"
+[[ ! -e $GUM_CHOOSE_ARGS ]] ||
+  fail "single-profile webapp install does not show a redundant picker" "$(cat "$GUM_CHOOSE_ARGS")"
+pass "webapp profile picker stays hidden with one browser profile"


### PR DESCRIPTION
## Summary

- discover profiles for the effective Chromium-family web app browser
- offer an optional profile picker when the interactive wizard finds multiple profiles
- store the selected `--profile-directory` directly in the generated desktop launcher
- keep `Automatic` as the default, preserving current behavior
- hide the picker when profile selection would be redundant

The direct launcher binding keeps the choice visible and portable, requires no separate runtime profile store, and lets other desktop-entry work inspect the selected profile.

## Browser support

Profile discovery follows the browsers already supported by `omarchy-launch-webapp`: Chromium, Chrome, Brave, Brave Origin, Edge, Opera, Vivaldi, and Helium. Unsupported default browsers continue to use Chromium's profile state because web apps already fall back to Chromium.

## Related work

#6105 proposes a broader profile-aware runtime for the older `dev` branch, including remembered launch-time choices. This is an independent, narrower Quattro implementation: it binds a profile only during web app creation and writes the choice into the launcher itself.

## Testing

- `bash test/shell.d/webapp-browser-profile-test.sh`
- `bash test/shell.d/webapp-install-test.sh`
- `bash test/shell.d/webapp-name-test.sh`
- `bash test/shell.d/webapp-install-escaping-test.sh`
- `./test/cli`
- `./test/shell` — 221 of 226 files passed; the same five unrelated graphical/package-coverage failures reproduce on untouched `origin/quattro`
- exercised against an isolated copy of a real six-profile Chromium `Local State`; generated launcher passed `desktop-file-validate` and preserved `Profile 2` as one argument
