### PR TITLE
Skip the encrypt hook on verified plain roots

### DIFF
--- a/etc/mkinitcpio.conf.d/omarchy_hooks.conf
+++ b/etc/mkinitcpio.conf.d/omarchy_hooks.conf
@@ -1,5 +1,59 @@
 HOOKS=(base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck btrfs-overlayfs)
 
+_omarchy_plain_root=0
+_omarchy_root_cmdline_path="${OMARCHY_ROOT_CMDLINE_PATH:-/proc/cmdline}"
+_omarchy_crypttab_initramfs="${OMARCHY_CRYPTTAB_INITRAMFS:-/etc/crypttab.initramfs}"
+
+if [[ -r $_omarchy_root_cmdline_path ]] &&
+  _omarchy_root_cmdline=$(<"$_omarchy_root_cmdline_path") &&
+  [[ -n $_omarchy_root_cmdline ]] &&
+  _omarchy_root_source=$(findmnt -nro SOURCE --nofsroot / 2>/dev/null) &&
+  [[ -n $_omarchy_root_source && $_omarchy_root_source == /dev/* && $_omarchy_root_source != *[[:space:]]* ]] &&
+  _omarchy_root_fstype=$(findmnt -nro FSTYPE / 2>/dev/null) &&
+  [[ $_omarchy_root_fstype == "ext4" || $_omarchy_root_fstype == "btrfs" ]] &&
+  _omarchy_root_stack=$(lsblk -nrso TYPE "$_omarchy_root_source" 2>/dev/null) &&
+  [[ -n $_omarchy_root_stack ]]; then
+  _omarchy_plain_root=1
+
+  while IFS= read -r _omarchy_root_type; do
+    if [[ $_omarchy_root_type != "disk" && $_omarchy_root_type != "part" ]]; then
+      _omarchy_plain_root=0
+    fi
+  done <<<"$_omarchy_root_stack"
+
+  for _omarchy_param in $_omarchy_root_cmdline; do
+    _omarchy_param_name=${_omarchy_param%%=*}
+    if [[ $_omarchy_param_name == "cryptdevice" || $_omarchy_param_name == "cryptkey" || $_omarchy_param_name == "crypto" ]]; then
+      _omarchy_plain_root=0
+    fi
+  done
+
+  if [[ -e $_omarchy_crypttab_initramfs || -L $_omarchy_crypttab_initramfs ]]; then
+    _omarchy_crypttab_contents=""
+    if [[ -f $_omarchy_crypttab_initramfs && -r $_omarchy_crypttab_initramfs ]] &&
+      _omarchy_crypttab_contents=$(cat -- "$_omarchy_crypttab_initramfs" 2>/dev/null); then
+      while IFS= read -r _omarchy_crypttab_line; do
+        [[ $_omarchy_crypttab_line =~ ^[[:space:]]*(#|$) ]] || _omarchy_plain_root=0
+      done <<<"$_omarchy_crypttab_contents"
+    else
+      _omarchy_plain_root=0
+    fi
+  fi
+fi
+
+if ((_omarchy_plain_root)); then
+  _omarchy_plain_root_hooks=()
+  for _omarchy_hook in "${HOOKS[@]}"; do
+    [[ $_omarchy_hook == "encrypt" ]] || _omarchy_plain_root_hooks+=("$_omarchy_hook")
+  done
+  HOOKS=("${_omarchy_plain_root_hooks[@]}")
+fi
+
+unset _omarchy_plain_root _omarchy_root_cmdline_path _omarchy_crypttab_initramfs
+unset _omarchy_root_cmdline _omarchy_root_source _omarchy_root_fstype _omarchy_root_stack _omarchy_root_type
+unset _omarchy_param _omarchy_param_name _omarchy_crypttab_contents _omarchy_crypttab_line
+unset _omarchy_plain_root_hooks _omarchy_hook
+
 # The proprietary NVIDIA driver does early KMS itself: nvidia.conf (written by
 # install/hardware/nvidia.sh, sourced before this file) early-loads nvidia_drm
 # with modeset=1. Keeping the kms hook on such a system makes autodetect pull

--- a/migrations/1788279117.sh
+++ b/migrations/1788279117.sh
@@ -1,0 +1,28 @@
+echo "Rebuild the boot image for a verified direct plain root"
+
+hooks_conf="${OMARCHY_MKINITCPIO_HOOKS_CONF:-/etc/mkinitcpio.conf.d/omarchy_hooks.conf}"
+rebuild_marker="${OMARCHY_PLAIN_ROOT_REBUILD_MARKER:-/var/lib/omarchy/migrations/1788279117}"
+
+[[ -f $hooks_conf ]] || exit 0
+[[ ! -e $rebuild_marker ]] || exit 0
+
+resolved=$(bash -uc '
+  FILES=()
+  MODULES=()
+  XKBLAYOUT=us
+  source "$1"
+  printf "OMARCHY_HOOKS:%s\n" "${HOOKS[*]}"
+' -- "$hooks_conf") || exit 0
+
+hooks=${resolved##*$'\n'}
+[[ $hooks == OMARCHY_HOOKS:* ]] || exit 0
+hooks=${hooks#OMARCHY_HOOKS:}
+[[ " $hooks " != *" encrypt "* ]] || exit 0
+
+echo "This machine has a direct plain root; rebuilding the boot image without the encrypt hook"
+if omarchy-cmd-present limine-mkinitcpio; then
+  sudo limine-mkinitcpio
+else
+  sudo mkinitcpio -P
+fi
+sudo install -Dm644 /dev/null "$rebuild_marker"

--- a/test/shell.d/plain-root-encrypt-hook-test.sh
+++ b/test/shell.d/plain-root-encrypt-hook-test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hooks_conf="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+cmdline="$test_tmp/cmdline"
+crypttab="$test_tmp/crypttab.initramfs"
+pci_devices="$test_tmp/pci-devices"
+mkdir -p "$stub_bin" "$pci_devices"
+
+cat >"$stub_bin/findmnt" <<'SH'
+#!/bin/bash
+
+(( ${FINDMNT_FAIL:-0} == 0 )) || exit 1
+
+case "$*" in
+  "-nro SOURCE --nofsroot /") printf '%s\n' "${ROOT_SOURCE-/dev/test-root}" ;;
+  "-nro FSTYPE /") printf '%s\n' "${ROOT_FSTYPE:-ext4}" ;;
+  *) exit 1 ;;
+esac
+SH
+
+cat >"$stub_bin/lsblk" <<'SH'
+#!/bin/bash
+
+(( ${LSBLK_FAIL:-0} == 0 )) || exit 1
+(( $# == 3 )) || exit 64
+[[ $1 == "-nrso" && $2 == "TYPE" && $3 == "${ROOT_SOURCE-/dev/test-root}" ]] || exit 64
+printf '%b' "${ROOT_STACK-part\ndisk\n}"
+SH
+
+chmod +x "$stub_bin"/*
+
+resolved_hooks() {
+  local fstype="$1" stack="$2" kernel_cmdline="$3" crypttab_contents="${4:-missing}"
+
+  printf '%s\n' "$kernel_cmdline" >"$cmdline"
+  rm -rf "$crypttab"
+  if [[ $crypttab_contents == "directory" ]]; then
+    mkdir "$crypttab"
+  elif [[ $crypttab_contents == "dangling" ]]; then
+    ln -s "$test_tmp/missing-crypttab-target" "$crypttab"
+  elif [[ $crypttab_contents != "missing" ]]; then
+    printf '%b' "$crypttab_contents" >"$crypttab"
+  fi
+
+  PATH="$stub_bin:$PATH" \
+    ROOT_FSTYPE="$fstype" \
+    ROOT_STACK="$stack" \
+    OMARCHY_ROOT_CMDLINE_PATH="$cmdline" \
+    OMARCHY_CRYPTTAB_INITRAMFS="$crypttab" \
+    OMARCHY_PCI_DEVICES_PATH="$pci_devices" \
+    bash -uc "
+      FILES=()
+      MODULES=()
+      XKBLAYOUT=us
+      source '$hooks_conf'
+      echo \"\${HOOKS[*]}\"
+    "
+}
+
+baseline=$(FINDMNT_FAIL=1 resolved_hooks ext4 $'part\ndisk\n' 'root=UUID=test rw')
+[[ " $baseline " == *" encrypt "* ]] || fail "the fail-closed baseline contains encrypt" "$baseline"
+without_encrypt=${baseline/ encrypt / }
+
+assert_hooks() {
+  local description="$1" expected="$2"
+  shift 2
+
+  local actual
+  actual=$(resolved_hooks "$@")
+  [[ $actual == "$expected" ]] ||
+    fail "$description" "expected: $expected"$'\n'"actual:   $actual"
+  pass "$description"
+}
+
+assert_hooks "a direct ext4 root drops only encrypt" "$without_encrypt" \
+  ext4 $'part\ndisk\n' 'root=UUID=test rw'
+assert_hooks "a direct Btrfs root drops only encrypt" "$without_encrypt" \
+  btrfs $'part\ndisk\n' 'root=UUID=test rw' $'\n  # no initramfs mappings\n'
+
+assert_hooks "dm-crypt ancestry keeps encrypt" "$baseline" \
+  ext4 $'crypt\npart\ndisk\n' 'root=/dev/mapper/root rw'
+assert_hooks "LVM ancestry keeps encrypt" "$baseline" \
+  ext4 $'lvm\npart\ndisk\n' 'root=/dev/mapper/vg-root rw'
+assert_hooks "RAID ancestry keeps encrypt" "$baseline" \
+  ext4 $'raid1\npart\ndisk\n' 'root=/dev/md0 rw'
+
+for selector in \
+  'cryptdevice=UUID=test:root' \
+  'cryptkey=rootfs:/root.key' \
+  'crypto=sha256:aes:256:0:0'; do
+  assert_hooks "$selector keeps encrypt" "$baseline" \
+    ext4 $'part\ndisk\n' "root=UUID=test rw $selector"
+done
+
+assert_hooks "an active initramfs crypttab row keeps encrypt" "$baseline" \
+  ext4 $'part\ndisk\n' 'root=UUID=test rw' $'root UUID=test none luks\n'
+
+FINDMNT_FAIL=1 assert_hooks "failed root discovery keeps encrypt" "$baseline" \
+  ext4 $'part\ndisk\n' 'root=UUID=test rw'
+
+LSBLK_FAIL=1 assert_hooks "failed ancestry discovery keeps encrypt" "$baseline" \
+  ext4 $'part\ndisk\n' 'root=UUID=test rw'
+
+ROOT_SOURCE='' assert_hooks "an empty root source keeps encrypt" "$baseline" \
+  ext4 $'part\ndisk\n' 'root=UUID=test rw'
+
+assert_hooks "an unknown ancestry type keeps encrypt" "$baseline" \
+  ext4 $'part\nunknown\ndisk\n' 'root=UUID=test rw'
+assert_hooks "an empty ancestry result keeps encrypt" "$baseline" \
+  ext4 '' 'root=UUID=test rw'
+assert_hooks "an unsupported root filesystem keeps encrypt" "$baseline" \
+  xfs $'part\ndisk\n' 'root=UUID=test rw'
+
+assert_hooks "an unreadable initramfs crypttab path keeps encrypt" "$baseline" \
+  ext4 $'part\ndisk\n' 'root=UUID=test rw' directory
+assert_hooks "a dangling initramfs crypttab symlink keeps encrypt" "$baseline" \
+  ext4 $'part\ndisk\n' 'root=UUID=test rw' dangling
+
+rm -f "$crypttab"
+rm -f "$cmdline"
+actual=$(
+  PATH="$stub_bin:$PATH" \
+    ROOT_FSTYPE=ext4 \
+    ROOT_STACK=$'part\ndisk\n' \
+    OMARCHY_ROOT_CMDLINE_PATH="$cmdline" \
+    OMARCHY_CRYPTTAB_INITRAMFS="$crypttab" \
+    OMARCHY_PCI_DEVICES_PATH="$pci_devices" \
+    bash -uc "FILES=(); MODULES=(); XKBLAYOUT=us; source '$hooks_conf'; echo \"\${HOOKS[*]}\""
+)
+[[ $actual == "$baseline" ]] || fail "an unreadable kernel command line keeps encrypt"
+pass "an unreadable kernel command line keeps encrypt"

--- a/test/shell.d/plain-root-encrypt-migration-test.sh
+++ b/test/shell.d/plain-root-encrypt-migration-test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1788279117.sh"
+packaged_hooks="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+hooks_conf="$test_tmp/omarchy_hooks.conf"
+cmdline="$test_tmp/cmdline"
+crypttab="$test_tmp/crypttab.initramfs"
+pci_devices="$test_tmp/pci-devices"
+marker="$test_tmp/rebuild-complete"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin" "$pci_devices"
+cp "$packaged_hooks" "$hooks_conf"
+printf '%s\n' 'root=UUID=test rw' >"$cmdline"
+: >"$calls"
+
+cat >"$stub_bin/findmnt" <<'SH'
+#!/bin/bash
+
+case "$*" in
+  "-nro SOURCE --nofsroot /") printf '%s\n' /dev/test-root ;;
+  "-nro FSTYPE /") printf '%s\n' "${ROOT_FSTYPE:-ext4}" ;;
+  *) exit 1 ;;
+esac
+SH
+
+cat >"$stub_bin/lsblk" <<'SH'
+#!/bin/bash
+
+(( $# == 3 )) || exit 64
+[[ $1 == "-nrso" && $2 == "TYPE" && $3 == "/dev/test-root" ]] || exit 64
+printf '%b' "${ROOT_STACK:-part\ndisk\n}"
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+
+[[ $1 == "limine-mkinitcpio" ]] && (( ${LIMINE_MKINITCPIO_INSTALLED:-1} == 1 ))
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+(( ${REBUILD_FAIL:-0} == 0 ))
+SH
+
+cat >"$stub_bin/mkinitcpio" <<'SH'
+#!/bin/bash
+
+printf 'mkinitcpio' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+(( ${REBUILD_FAIL:-0} == 0 ))
+SH
+
+chmod +x "$stub_bin"/*
+
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_MKINITCPIO_HOOKS_CONF="$hooks_conf" \
+    OMARCHY_PLAIN_ROOT_REBUILD_MARKER="$marker" \
+    OMARCHY_ROOT_CMDLINE_PATH="$cmdline" \
+    OMARCHY_CRYPTTAB_INITRAMFS="$crypttab" \
+    OMARCHY_PCI_DEVICES_PATH="$pci_devices" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration
+grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "a verified plain-root Limine install rebuilds its boot image"
+first_sudo=$(grep '^sudo' "$calls" | head -1)
+[[ $first_sudo == $'sudo\tlimine-mkinitcpio' ]] ||
+  fail "hook classification stays unprivileged" "first sudo call: $first_sudo"
+[[ -f $marker ]] || fail "a successful Limine rebuild records machine-wide completion"
+pass "migration classifies without privilege and rebuilds a verified plain-root Limine install"
+
+: >"$calls"
+run_migration
+[[ ! -s $calls ]] || fail "another user's migration run does not repeat the rebuild" "$(cat "$calls")"
+pass "migration is machine-idempotent across users"
+
+rm -f "$marker"
+: >"$calls"
+LIMINE_MKINITCPIO_INSTALLED=0 run_migration
+grep -Fxq $'mkinitcpio\t-P' "$calls" ||
+  fail "a non-Limine install rebuilds all initramfs images" "$(cat "$calls")"
+[[ -f $marker ]] || fail "a successful mkinitcpio rebuild records machine-wide completion"
+pass "migration falls back to mkinitcpio"
+
+rm -f "$marker"
+: >"$calls"
+if REBUILD_FAIL=1 run_migration; then
+  fail "a failed rebuild fails the migration"
+fi
+[[ ! -e $marker ]] || fail "a failed rebuild remains retryable"
+
+: >"$calls"
+run_migration
+grep -Fxq 'limine-mkinitcpio' "$calls" || fail "a failed rebuild is retried"
+[[ -f $marker ]] || fail "the successful retry records machine-wide completion"
+pass "migration retries a failed rebuild"
+
+rm -f "$marker"
+: >"$calls"
+ROOT_STACK=$'crypt\npart\ndisk\n' run_migration
+[[ ! -s $calls ]] || fail "an encrypted root is left alone" "$(cat "$calls")"
+[[ ! -e $marker ]] || fail "an encrypted root is not marked as rebuilt"
+pass "migration skips roots whose installed config retains encrypt"
+
+rm -f "$marker"
+: >"$calls"
+echo 'HOOKS=(base udev block encrypt filesystems fsck)' >"$hooks_conf"
+run_migration
+[[ ! -s $calls ]] || fail "a user-edited hook config that retains encrypt is left alone" "$(cat "$calls")"
+pass "migration skips user-edited hook configuration"
+
+rm -f "$hooks_conf"
+: >"$calls"
+run_migration
+[[ ! -s $calls ]] || fail "a missing installed hook config is left alone" "$(cat "$calls")"
+pass "migration skips installs without the hook configuration"


### PR DESCRIPTION
Omarchy always includes mkinitcpio's classic `encrypt` hook. On a direct unencrypted root with no `cryptdevice=`, the hook tries to treat `root=` as an encrypted mapping and prints an early boot error. The system can still boot, but the message indicates a configuration that does not match the storage layout.

This change keeps the complete current hook list as the safe default. It removes only `encrypt` when `findmnt` and `lsblk` prove that root is a direct ext4 or Btrfs filesystem backed only by a partition or disk. Encrypted, LVM, RAID, unsupported and unknown layouts keep `encrypt`. Explicit classic-encrypt selectors, active `crypttab.initramfs` rows and all discovery failures also keep it.

The migration evaluates the installed hook configuration without privilege. It rebuilds affected existing images with `limine-mkinitcpio`, or `mkinitcpio -P` when Limine is absent. It records completion only after a successful rebuild, so failures remain retryable across users.

Validation:

- 18 focused hook cases cover plain ext4/Btrfs, dm-crypt, LVM, RAID, selectors, crypttab and discovery failures.
- 7 migration cases cover unprivileged classification, Limine, mkinitcpio, repeated users, rebuild retry and no-op paths.
- NVIDIA KMS and keyboard-layout hook regressions pass.
- The same commit applies cleanly to the Apple Silicon fork and preserves its Asahi-specific hook list.
- A real direct ext4 root on an M2 MacBook Air resolves to `part → disk` and omits only `encrypt`.

Related to #6876. This PR handles the verified direct plain-root case and leaves the broader storage-hook redesign to that issue.
