### PR TITLE
Add secure declarative Neovim theming

### DIFF
--- a/bin/omarchy-theme-neovim
+++ b/bin/omarchy-theme-neovim
@@ -1,0 +1,388 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Render a theme's declarative Neovim appearance
+# omarchy:hidden=true
+
+import argparse
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+
+MAX_INPUT_SIZE = 1024 * 1024
+MAX_HIGHLIGHTS = 512
+NAME_PATTERN = re.compile(r"[A-Za-z0-9_@.:-]{1,128}\Z")
+HEX_COLOR_PATTERN = re.compile(r"#[0-9A-Fa-f]{6}\Z")
+
+OPTION_KEYS = {
+    "transparent",
+    "terminal_colors",
+    "dim_inactive",
+    "lualine_bold",
+}
+STYLE_GROUPS = {"comments", "keywords", "functions", "variables"}
+STYLE_ATTRIBUTES = {"bold", "italic", "underline", "undercurl", "strikethrough"}
+STYLE_VARIANTS = {"dark", "transparent", "normal"}
+PALETTE_KEYS = {
+    "accent",
+    "cursor",
+    "foreground",
+    "background",
+    "selection_foreground",
+    "selection_background",
+    "bg",
+    "lighter_bg",
+    "selection",
+    "muted",
+    "dark_fg",
+    "fg",
+    "light_fg",
+    "bright_fg",
+    "red",
+    "yellow",
+    "orange",
+    "green",
+    "cyan",
+    "blue",
+    "purple",
+    "magenta",
+    "brown",
+    "dark_bg",
+    "darker_bg",
+    "bright_red",
+    "bright_yellow",
+    "bright_green",
+    "bright_cyan",
+    "bright_blue",
+    "bright_purple",
+    "bright_magenta",
+}
+HIGHLIGHT_ATTRIBUTES = {
+    "fg",
+    "bg",
+    "sp",
+    "bold",
+    "italic",
+    "underline",
+    "undercurl",
+    "strikethrough",
+    "blend",
+}
+BOOLEAN_HIGHLIGHT_ATTRIBUTES = STYLE_ATTRIBUTES
+
+BASE_PALETTE = (
+    ("bg", "background"),
+    ("dark_bg", "dark_background"),
+    ("darker_bg", "darker_background"),
+    ("lighter_bg", "lighter_background"),
+    ("fg", "foreground"),
+    ("dark_fg", "dark_foreground"),
+    ("light_fg", "light_foreground"),
+    ("bright_fg", "bright_foreground"),
+    ("muted", "muted"),
+    ("red", "red"),
+    ("yellow", "yellow"),
+    ("orange", "orange"),
+    ("green", "green"),
+    ("cyan", "cyan"),
+    ("blue", "blue"),
+    ("magenta", "magenta"),
+    ("brown", "brown"),
+    ("bright_red", "bright_red"),
+    ("bright_yellow", "bright_yellow"),
+    ("bright_green", "bright_green"),
+    ("bright_cyan", "bright_cyan"),
+    ("bright_blue", "bright_blue"),
+    ("bright_magenta", "bright_magenta"),
+    ("accent", "accent"),
+    ("cursor", "bright_foreground"),
+    ("foreground", "foreground"),
+    ("background", "background"),
+    ("selection", "selection"),
+    ("selection_foreground", "selection_foreground"),
+    ("selection_background", "selection_background"),
+)
+
+
+class DeclarationError(Exception):
+    pass
+
+
+def fail(message):
+    print(f"omarchy-theme-neovim: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def expect_table(value, path):
+    if not isinstance(value, dict):
+        raise DeclarationError(f"{path} must be a table")
+    return value
+
+
+def reject_unknown(table, allowed, path):
+    unknown = sorted(set(table) - allowed)
+    if unknown:
+        raise DeclarationError(f"{path} does not support '{unknown[0]}'")
+
+
+def expect_boolean(value, path):
+    if not isinstance(value, bool):
+        raise DeclarationError(f"{path} must be true or false")
+
+
+def validate_name(value, path):
+    if not isinstance(value, str) or not NAME_PATTERN.fullmatch(value):
+        raise DeclarationError(f"{path} must match [A-Za-z0-9_@.:-]+ and be at most 128 characters")
+
+
+def validate_color(value, path, allow_none=False):
+    if not isinstance(value, str):
+        raise DeclarationError(f"{path} must be a palette name or #RRGGBB")
+    if value in PALETTE_KEYS or HEX_COLOR_PATTERN.fullmatch(value):
+        return
+    if allow_none and value == "NONE":
+        return
+    raise DeclarationError(f"{path} must be a known palette name or #RRGGBB")
+
+
+def validate_declaration(data):
+    reject_unknown(data, {"schema", "options", "styles", "colors", "highlights"}, "neovim.toml")
+
+    schema = data.get("schema")
+    if not isinstance(schema, int) or isinstance(schema, bool) or schema != 1:
+        raise DeclarationError("schema must be the integer 1")
+
+    options = expect_table(data.get("options", {}), "[options]")
+    reject_unknown(options, OPTION_KEYS, "[options]")
+    for key, value in options.items():
+        expect_boolean(value, f"options.{key}")
+
+    styles = expect_table(data.get("styles", {}), "[styles]")
+    reject_unknown(styles, STYLE_GROUPS | {"sidebars", "floats"}, "[styles]")
+    for key in ("sidebars", "floats"):
+        if key in styles and (not isinstance(styles[key], str) or styles[key] not in STYLE_VARIANTS):
+            raise DeclarationError(f"styles.{key} must be dark, transparent, or normal")
+    for group in STYLE_GROUPS:
+        if group not in styles:
+            continue
+        attributes = expect_table(styles[group], f"[styles.{group}]")
+        reject_unknown(attributes, STYLE_ATTRIBUTES, f"[styles.{group}]")
+        for key, value in attributes.items():
+            expect_boolean(value, f"styles.{group}.{key}")
+
+    colors = expect_table(data.get("colors", {}), "[colors]")
+    reject_unknown(colors, PALETTE_KEYS, "[colors]")
+    for key, value in colors.items():
+        if not isinstance(value, str) or not HEX_COLOR_PATTERN.fullmatch(value):
+            raise DeclarationError(f"colors.{key} must be #RRGGBB")
+    for canonical, alias in (("purple", "magenta"), ("bright_purple", "bright_magenta")):
+        if canonical in colors and alias in colors and colors[canonical].lower() != colors[alias].lower():
+            raise DeclarationError(f"colors.{canonical} and colors.{alias} must match when both are set")
+
+    highlights = expect_table(data.get("highlights", {}), "[highlights]")
+    if len(highlights) > MAX_HIGHLIGHTS:
+        raise DeclarationError(f"[highlights] may contain at most {MAX_HIGHLIGHTS} groups")
+    for group, value in highlights.items():
+        validate_name(group, f"highlight group {group!r}")
+        attributes = expect_table(value, f"[highlights.{group!r}]")
+        if not attributes:
+            raise DeclarationError(f"[highlights.{group!r}] must not be empty")
+        if "link" in attributes:
+            if set(attributes) != {"link"}:
+                raise DeclarationError(f"highlights.{group}.link cannot be combined with other fields")
+            validate_name(attributes["link"], f"highlights.{group}.link")
+            continue
+        reject_unknown(attributes, HIGHLIGHT_ATTRIBUTES, f"[highlights.{group!r}]")
+        for key, item in attributes.items():
+            if key in {"fg", "bg", "sp"}:
+                validate_color(item, f"highlights.{group}.{key}", allow_none=key == "bg")
+            elif key in BOOLEAN_HIGHLIGHT_ATTRIBUTES:
+                expect_boolean(item, f"highlights.{group}.{key}")
+            elif key == "blend":
+                if not isinstance(item, int) or isinstance(item, bool) or not 0 <= item <= 100:
+                    raise DeclarationError(f"highlights.{group}.blend must be an integer from 0 to 100")
+
+    return options, styles, colors, highlights
+
+
+def resolve_theme_colors(colors_path):
+    omarchy_path = os.environ.get("OMARCHY_PATH")
+    if not omarchy_path:
+        raise DeclarationError("OMARCHY_PATH is not set")
+
+    command = Path(omarchy_path) / "bin" / "omarchy-theme-color"
+    try:
+        result = subprocess.run(
+            [str(command), "--file", str(colors_path), "--all"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail = error.stderr.strip() if isinstance(error, subprocess.CalledProcessError) else str(error)
+        raise DeclarationError(f"could not resolve colors.toml: {detail}") from error
+
+    resolved = {}
+    for line in result.stdout.splitlines():
+        key, separator, value = line.partition("\t")
+        if separator:
+            resolved[key] = value
+
+    palette = {}
+    for output_key, source_key in BASE_PALETTE:
+        value = resolved.get(source_key, "")
+        if not HEX_COLOR_PATTERN.fullmatch(value):
+            raise DeclarationError(f"colors.toml did not resolve {source_key} to #RRGGBB")
+        palette[output_key] = value
+    return palette
+
+
+def lua_string(value):
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def lua_value(value):
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    return lua_string(value)
+
+
+def render_lua(options, styles, palette, color_overrides, highlights):
+    palette.update(color_overrides)
+    lines = [
+        "-- Generated by Omarchy from colors.toml and neovim.toml.",
+        "-- Aether and LazyVim are selected by Omarchy; theme declarations only control appearance.",
+        "",
+        "return {",
+        "  {",
+        '    "bjarneo/aether.nvim",',
+        '    branch = "v3",',
+        '    name = "aether",',
+        "    priority = 1000,",
+        "    opts = {",
+    ]
+
+    for key in ("transparent", "terminal_colors", "dim_inactive", "lualine_bold"):
+        if key in options:
+            lines.append(f"      {key} = {lua_value(options[key])},")
+
+    if styles:
+        lines.append("      styles = {")
+        for key in ("sidebars", "floats"):
+            if key in styles:
+                lines.append(f"        {key} = {lua_value(styles[key])},")
+        for group in ("comments", "keywords", "functions", "variables"):
+            if group not in styles:
+                continue
+            lines.append(f"        {group} = {{")
+            for key in ("bold", "italic", "underline", "undercurl", "strikethrough"):
+                if key in styles[group]:
+                    lines.append(f"          {key} = {lua_value(styles[group][key])},")
+            lines.append("        },")
+        lines.append("      },")
+
+    lines.append("      colors = {")
+    emitted = set()
+    for key, _ in BASE_PALETTE:
+        lines.append(f"        {key} = {lua_string(palette[key])},")
+        emitted.add(key)
+    for key in sorted(set(color_overrides) - emitted):
+        lines.append(f"        {key} = {lua_string(palette[key])},")
+    lines.append("      },")
+
+    if highlights:
+        lines.append("      on_highlights = function(highlight, colors)")
+        for group in sorted(highlights):
+            attributes = highlights[group]
+            if "link" in attributes:
+                value = lua_string(attributes["link"])
+            else:
+                fields = []
+                for key in ("fg", "bg", "sp", "bold", "italic", "underline", "undercurl", "strikethrough", "blend"):
+                    if key not in attributes:
+                        continue
+                    item = attributes[key]
+                    if key in {"fg", "bg", "sp"} and item in PALETTE_KEYS:
+                        fields.append(f"{key} = colors[{lua_string(item)}]")
+                    else:
+                        fields.append(f"{key} = {lua_value(item)}")
+                value = "{ " + ", ".join(fields) + " }"
+            lines.append(f"        highlight[{lua_string(group)}] = {value}")
+        lines.append("      end,")
+
+    lines.extend(
+        [
+            "    },",
+            "  },",
+            "  {",
+            '    "LazyVim/LazyVim",',
+            "    opts = {",
+            '      colorscheme = "aether",',
+            "    },",
+            "  },",
+            "}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_atomic(output_path, rendered):
+    output_path = output_path.absolute()
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output_path.parent,
+            prefix=".neovim.lua.",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, output_path)
+    except OSError as error:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        raise DeclarationError(f"could not write {output_path}: {error}") from error
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render declarative Neovim theme appearance")
+    parser.add_argument("--file", required=True, type=Path)
+    parser.add_argument("--colors", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+
+    try:
+        with args.file.open("rb") as handle:
+            contents = handle.read(MAX_INPUT_SIZE + 1)
+        if len(contents) > MAX_INPUT_SIZE:
+            raise DeclarationError("neovim.toml must not exceed 1 MiB")
+        data = tomllib.loads(contents.decode("utf-8"))
+        options, styles, colors, highlights = validate_declaration(data)
+        palette = resolve_theme_colors(args.colors)
+        rendered = render_lua(options, styles, palette, colors, highlights)
+        write_atomic(args.out, rendered)
+    except FileNotFoundError as error:
+        fail(f"no such file: {error.filename}")
+    except OSError as error:
+        fail(f"could not read neovim.toml: {error}")
+    except UnicodeDecodeError:
+        fail("neovim.toml must be valid UTF-8")
+    except tomllib.TOMLDecodeError as error:
+        fail(f"invalid TOML: {error}")
+    except DeclarationError as error:
+        fail(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -265,14 +265,22 @@ flock 9
 rm -rf "$NEXT_THEME_PATH"
 mkdir -p "$NEXT_THEME_PATH"
 
-# Copy official theme first, then overlay the user's theme on top
+# Copy official theme first, then overlay the user's theme on top. Remember
+# whether neovim.lua came from the user before both sources share one staging
+# directory: trusted local Lua wins over neovim.toml, repository Lua never does.
+USER_THEME_PATH="$USER_THEMES_PATH/$THEME_NAME"
+KEEP_TRUSTED_NEOVIM_LUA=0
+if ! theme_came_from_a_repo "$USER_THEME_PATH" && [[ -f $USER_THEME_PATH/neovim.lua ]]; then
+  KEEP_TRUSTED_NEOVIM_LUA=1
+fi
+
 cp -r "$OMARCHY_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
 
-if theme_came_from_a_repo "$USER_THEMES_PATH/$THEME_NAME"; then
-  stage_installed_theme "$USER_THEMES_PATH/$THEME_NAME"
+if theme_came_from_a_repo "$USER_THEME_PATH"; then
+  stage_installed_theme "$USER_THEME_PATH"
   report_ignored_theme_files
 else
-  cp -r "$USER_THEMES_PATH/$THEME_NAME/"* "$NEXT_THEME_PATH/" 2>/dev/null
+  cp -r "$USER_THEME_PATH/"* "$NEXT_THEME_PATH/" 2>/dev/null
 fi
 
 # Generate colors.toml from alacritty.toml if theme is missing colors.toml
@@ -281,7 +289,7 @@ if [[ ! -f $NEXT_THEME_PATH/colors.toml && -f $NEXT_THEME_PATH/alacritty.toml ]]
 fi
 
 # Generate dynamic configs
-omarchy-theme-set-templates
+OMARCHY_THEME_KEEP_NEOVIM_LUA=$KEEP_TRUSTED_NEOVIM_LUA omarchy-theme-set-templates
 
 OLD_BACKGROUND_SNAPSHOT=""
 if [[ $THEME_HEADLESS != "1" && $OMARCHY_THEME_SKIP_BACKGROUND != "1" ]]; then

--- a/bin/omarchy-theme-set-templates
+++ b/bin/omarchy-theme-set-templates
@@ -367,6 +367,18 @@ apply_shell_section_overrides() {
   done
 }
 
+apply_neovim_declaration() {
+  [[ -f $NEXT_THEME_DIR/neovim.toml ]] || return
+  [[ ${OMARCHY_THEME_KEEP_NEOVIM_LUA:-0} != "1" ]] || return
+
+  if ! omarchy-theme-neovim \
+    --file "$NEXT_THEME_DIR/neovim.toml" \
+    --colors "$COLORS_FILE" \
+    --out "$NEXT_THEME_DIR/neovim.lua"; then
+    echo "omarchy-theme-set-templates: keeping the existing neovim.lua" >&2
+  fi
+}
+
 # Only generate dynamic templates for themes with a colors.toml definition
 if [[ -f $COLORS_FILE ]]; then
   sed_script=$(mktemp)
@@ -401,4 +413,5 @@ if [[ -f $COLORS_FILE ]]; then
   rm "$sed_script"
 fi
 
+apply_neovim_declaration
 apply_shell_section_overrides

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -23,15 +23,12 @@ A theme installed from a git repo is held to a much shorter list; see [What an i
 1. Copy the first-party theme from `themes/<name>/`.
 2. Overlay `~/.config/omarchy/themes/<name>/`, in full when the user wrote it and filtered when it came from a git repo, naming anything it dropped on stderr.
 3. If needed, generate `colors.toml` from `alacritty.toml`.
-4. Run `omarchy-theme-set-templates` to render templates into the staging
-   theme.
+4. Run `omarchy-theme-set-templates` to render templates into the staging theme and materialize any valid `neovim.toml` declaration.
 5. Move the staging theme into `~/.local/state/omarchy/current/theme`, write
    `~/.local/state/omarchy/current/theme.name`, and notify the running shell.
 
 Template rendering only happens when the staged theme has `colors.toml`.
-Existing files are never overwritten by a template, so a hand-written
-`themes/<name>/shell.toml` or `hyprland.lua` wins over
-`default/themed/shell.toml.tpl` or `hyprland.lua.tpl`.
+Existing files are never overwritten by a template, so a hand-written `themes/<name>/shell.toml` or `hyprland.lua` wins over `default/themed/shell.toml.tpl` or `hyprland.lua.tpl`. A valid `neovim.toml` is the narrow exception: it replaces bundled or generated `neovim.lua`, while a trusted `neovim.lua` from a local user theme remains authoritative.
 
 User templates in `~/.config/omarchy/themed/*.tpl` are processed before the
 built-in templates. If a user template has the same output filename as a
@@ -55,7 +52,7 @@ instead of racing.
 - `alacritty.toml`, `foot.ini`, `ghostty.conf`, `kitty.conf` — each names the program the terminal launches
 - `vscode.json` — names the extension `omarchy-theme-set-vscode` installs, and a VS Code extension is arbitrary JavaScript
 
-Symlinks are dropped with them, at any depth; in a cloned theme they point wherever the theme author chose. Everything a cloned theme ships that is colour is kept, including files Omarchy would otherwise have generated — `btop.theme`, `chromium.theme`, `helix.toml`, `shell.toml`, `icons.theme`, `keyboard.rgb` and the rest — so a theme can still say exactly how it wants each app to look. What is dropped gets generated from `default/themed/*.tpl` instead, and is named on stderr.
+Symlinks are dropped with them, at any depth; in a cloned theme they point wherever the theme author chose. Everything a cloned theme ships that is colour is kept, including files Omarchy would otherwise have generated — `btop.theme`, `chromium.theme`, `helix.toml`, `shell.toml`, `icons.theme`, `keyboard.rgb` and the rest — so a theme can still say exactly how it wants each app to look. A cloned theme may also ship the validated appearance-only `neovim.toml` described below. What is dropped gets generated from `default/themed/*.tpl` instead, and is named on stderr.
 
 A denylist is only right while it is maintained. Adding a template for another terminal, or for another editor that loads Lua, means adding it to `INSTALLED_THEME_DENIED` in `bin/omarchy-theme-set`; `test/shell.d/theme-staging-test.sh` fails on any `default/themed/*.tpl` whose output is recorded as neither code nor colour, so a new template cannot be added without that decision being made.
 
@@ -127,6 +124,47 @@ in that ramp; Omarchy derives `selection_background = selection` and
 `selection_foreground = bright_foreground`. Use
 `omarchy dev theme-preview [theme]` to inspect that ramp, including
 `dark_background`, `darker_background`, and a selected-text sample.
+
+## `neovim.toml`
+
+A theme may add `neovim.toml` for Neovim-specific appearance without shipping executable Lua. Omarchy validates this file and generates the complete `neovim.lua` integration itself. The plugin remains `bjarneo/aether.nvim` on branch `v3`, and LazyVim remains configured to use the `aether` colorscheme; the declaration cannot select a plugin, repository, branch, build command, callback, dependency, import, path, or other executable behavior.
+
+A declaration starts with `schema = 1`. Every section is optional after that:
+
+```toml
+schema = 1
+
+[options]
+transparent = true
+dim_inactive = false
+
+[styles]
+sidebars = "transparent"
+floats = "dark"
+
+[styles.comments]
+italic = true
+
+[colors]
+bright_magenta = "#c1d7e3"
+
+[highlights.Keyword]
+fg = "bright_magenta"
+bold = true
+
+[highlights."@keyword.function"]
+link = "Function"
+```
+
+`[options]` accepts `transparent`, `terminal_colors`, `dim_inactive`, and `lualine_bold` booleans. `[styles]` accepts `sidebars` and `floats` as `dark`, `transparent`, or `normal`; its `comments`, `keywords`, `functions`, and `variables` tables accept the boolean attributes `bold`, `italic`, `underline`, `undercurl`, and `strikethrough`.
+
+`[colors]` is an optional Neovim-only override of the Aether v3 base palette. Its values must be `#RRGGBB`; omitted colors continue to come from `colors.toml`. The supported palette names are `accent`, `cursor`, `foreground`, `background`, `selection_foreground`, `selection_background`, `bg`, `lighter_bg`, `selection`, `muted`, `dark_fg`, `fg`, `light_fg`, `bright_fg`, `red`, `yellow`, `orange`, `green`, `cyan`, `blue`, `purple`, `magenta`, `brown`, `dark_bg`, `darker_bg`, and the `bright_` variants of `red`, `yellow`, `green`, `cyan`, `blue`, `purple`, and `magenta`. Aether treats `magenta` as an alias for `purple` (and likewise for their bright variants), so both names may only be set together when their values match.
+
+A highlight may set `fg`, `bg`, or `sp` to one of those palette names or `#RRGGBB`, plus the same boolean style attributes and an integer `blend` from 0 to 100. `bg = "NONE"` is also accepted. A highlight with `link` cannot contain any other field. Highlight group and link names must contain only ASCII letters, digits, `_`, `@`, `.`, `:`, or `-`, with a maximum length of 128 characters.
+
+The file is limited to 1 MiB and 512 non-empty highlight groups. Unknown fields, malformed TOML, invalid values, and unsupported schema versions are rejected. Rejection is reported on stderr and leaves the normal bundled or `colors.toml`-generated Neovim theme in place.
+
+A trusted local user theme may still ship handwritten `neovim.lua`; that file wins when both files exist. Repository-installed `neovim.lua` remains forbidden, so a valid repository `neovim.toml` replaces only Omarchy's bundled or generated Lua.
 
 ## Template placeholders
 

--- a/test/shell.d/theme-neovim-test.sh
+++ b/test/shell.d/theme-neovim-test.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# neovim.toml restores editor-specific appearance for repository themes without
+# allowing them to choose plugins or ship Lua. Omarchy validates the declaration
+# and generates the fixed Aether v3 integration itself.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+state="$home/.local/state/omarchy/current"
+themes="$home/.config/omarchy/themes"
+mkdir -p "$state" "$themes"
+
+marker="omarchy-neovim-marker"
+
+write_colors() {
+  cat >"$1" <<'TOML'
+mode = "dark"
+accent = "#7aa2f7"
+selection = "#292e42"
+muted = "#414868"
+background = "#1a1b26"
+dark_background = "#13141c"
+darker_background = "#0e0e14"
+lighter_background = "#24283b"
+foreground = "#a9b1d6"
+dark_foreground = "#565f89"
+light_foreground = "#b4bee6"
+bright_foreground = "#c0caf5"
+red = "#f7768e"
+green = "#9ece6a"
+yellow = "#e0af68"
+blue = "#7aa2f7"
+magenta = "#bb9af7"
+cyan = "#7dcfff"
+TOML
+}
+
+write_declaration() {
+  cat >"$1" <<'TOML'
+schema = 1
+
+[options]
+transparent = true
+terminal_colors = false
+dim_inactive = true
+lualine_bold = true
+
+[styles]
+sidebars = "transparent"
+floats = "normal"
+
+[styles.comments]
+italic = false
+
+[styles.keywords]
+bold = true
+italic = true
+
+[colors]
+bright_magenta = "#c1d7e3"
+purple = "#9bb0c2"
+
+[highlights.Keyword]
+fg = "bright_magenta"
+bold = true
+italic = true
+
+[highlights.Visual]
+bg = "NONE"
+blend = 20
+
+[highlights."@keyword.function"]
+link = "Function"
+TOML
+}
+
+set_theme() {
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+    OMARCHY_THEME_HEADLESS=1 OMARCHY_THEME_SKIP_BACKGROUND=1 \
+    XDG_RUNTIME_DIR="$test_tmp" \
+    bash "$ROOT/bin/omarchy-theme-set" "$1" 2>"$test_tmp/stderr"
+}
+
+staged() {
+  printf '%s' "$state/theme/$1"
+}
+
+render() {
+  OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+    "$ROOT/bin/omarchy-theme-neovim" \
+    --file "$1" --colors "$2" --out "$3"
+}
+
+# An installed overlay on a bundled theme may replace Omarchy's bundled
+# neovim.lua through validated appearance data, while its own Lua is denied.
+installed="$themes/tokyo-night"
+mkdir -p "$installed/.git"
+write_colors "$installed/colors.toml"
+write_declaration "$installed/neovim.toml"
+printf 'vim.cmd("%s")\n' "$marker" >"$installed/neovim.lua"
+
+set_theme tokyo-night || fail "theme set accepts a valid installed neovim.toml"
+
+lua_file=$(staged neovim.lua)
+[[ -f $(staged neovim.toml) ]] || fail "installed neovim.toml is staged as appearance data"
+[[ -f $lua_file ]] || fail "valid neovim.toml generates neovim.lua"
+! grep -q "$marker" "$lua_file" || fail "repository neovim.lua remains denied"
+(( $(grep -cF '"bjarneo/aether.nvim"' "$lua_file") == 1 )) || fail "generated Lua fixes the Aether plugin identity"
+(( $(grep -cF 'branch = "v3"' "$lua_file") == 1 )) || fail "generated Lua fixes the Aether branch"
+(( $(grep -cF '"LazyVim/LazyVim"' "$lua_file") == 1 )) || fail "generated Lua fixes the LazyVim identity"
+grep -Fq 'colorscheme = "aether"' "$lua_file" || fail "generated Lua fixes the colorscheme"
+grep -Fq 'transparent = true' "$lua_file" || fail "Neovim boolean options are rendered"
+grep -Fq 'sidebars = "transparent"' "$lua_file" || fail "Neovim style variants are rendered"
+grep -Fq 'bright_magenta = "#c1d7e3"' "$lua_file" || fail "Neovim palette overrides are rendered"
+grep -Fq 'highlight["Keyword"] = { fg = colors["bright_magenta"], bold = true, italic = true }' "$lua_file" || fail "Neovim visual highlights are rendered"
+grep -Fq 'highlight["Visual"] = { bg = "NONE", blend = 20 }' "$lua_file" || fail "Neovim transparent highlight backgrounds are rendered"
+grep -Fq 'highlight["@keyword.function"] = "Function"' "$lua_file" || fail "Neovim highlight links are rendered"
+! grep -Eq '(^|[[:space:]])(spec|build|config|init|dependencies|import)[[:space:]]*=' "$lua_file" || fail "generated Lua exposes no plugin-shaped declaration fields"
+
+pass "installed neovim.toml generates only the fixed trusted Neovim integration"
+
+if command -v luac >/dev/null; then
+  luac -p "$lua_file" || fail "generated neovim.lua parses with luac"
+  pass "generated neovim.lua parses with luac"
+fi
+
+if command -v nvim >/dev/null; then
+  callback_check="$test_tmp/check-neovim.lua"
+  cat >"$callback_check" <<LUA
+local specs = assert(loadfile([[$lua_file]]))()
+local highlights = {}
+specs[1].opts.on_highlights(highlights, { bright_magenta = "#c1d7e3" })
+assert(highlights.Keyword.fg == "#c1d7e3")
+assert(highlights.Keyword.bold == true)
+assert(highlights.Visual.bg == "NONE")
+assert(highlights["@keyword.function"] == "Function")
+LUA
+  nvim --headless -u NONE "+lua dofile([[$callback_check]])" +qa >/dev/null 2>&1 || fail "generated neovim.lua loads and applies highlights in headless Neovim"
+  pass "generated neovim.lua loads and applies highlights in headless Neovim without installing plugins"
+fi
+
+# Without a declaration, the ordinary colors.toml template remains unchanged.
+plain="$themes/plain"
+mkdir -p "$plain/.git"
+write_colors "$plain/colors.toml"
+set_theme plain || fail "theme set accepts a theme without neovim.toml"
+grep -Fq 'bg = "#1a1b26"' "$(staged neovim.lua)" || fail "colors.toml still generates the normal Neovim palette"
+! grep -Fq 'Generated by Omarchy from colors.toml and neovim.toml' "$(staged neovim.lua)" || fail "absent neovim.toml leaves the ordinary template output"
+
+pass "absent neovim.toml preserves normal template generation"
+
+# A malformed declaration fails closed after the normal template was generated.
+invalid="$themes/invalid"
+mkdir -p "$invalid/.git"
+write_colors "$invalid/colors.toml"
+printf 'schema = 1\nplugins = [{ spec = "evil/plugin.nvim" }]\n' >"$invalid/neovim.toml"
+set_theme invalid || fail "an invalid neovim.toml falls back without aborting theme set"
+grep -Fq '"bjarneo/aether.nvim"' "$(staged neovim.lua)" || fail "invalid neovim.toml retains the generated Aether fallback"
+! grep -Fq 'evil/plugin.nvim' "$(staged neovim.lua)" || fail "plugin selection cannot reach generated Lua"
+grep -Fq 'keeping the existing neovim.lua' "$test_tmp/stderr" || fail "invalid neovim.toml reports its fallback"
+
+pass "invalid neovim.toml keeps the normal generated fallback"
+
+# A handwritten local neovim.lua is trusted user code and remains authoritative.
+local_theme="$themes/local"
+mkdir -p "$local_theme"
+write_colors "$local_theme/colors.toml"
+write_declaration "$local_theme/neovim.toml"
+printf 'return { "%s" }\n' "$marker" >"$local_theme/neovim.lua"
+set_theme local || fail "theme set accepts a trusted local Neovim override"
+grep -Fq "$marker" "$(staged neovim.lua)" || fail "trusted local neovim.lua wins over neovim.toml"
+
+pass "trusted local neovim.lua retains precedence"
+
+# The renderer rejects each schema escape without replacing an existing output.
+render_dir="$test_tmp/render"
+mkdir -p "$render_dir"
+write_colors "$render_dir/colors.toml"
+
+assert_rejected() {
+  local name="$1"
+  local declaration="$2"
+  local output="$render_dir/$name.lua"
+  local stderr="$render_dir/$name.stderr"
+
+  printf '%s\n' "$marker" >"$output"
+  if render "$declaration" "$render_dir/colors.toml" "$output" 2>"$stderr"; then
+    fail "$name declaration is rejected"
+  fi
+  [[ $(cat "$output") == "$marker" ]] || fail "$name rejection leaves the existing output untouched"
+}
+
+cat >"$render_dir/plugin.toml" <<'TOML'
+schema = 1
+[[plugins]]
+spec = "evil/plugin.nvim"
+build = "touch /tmp/owned"
+config = true
+TOML
+assert_rejected "plugin-shaped" "$render_dir/plugin.toml"
+
+printf 'schema = [\n' >"$render_dir/malformed.toml"
+assert_rejected "malformed" "$render_dir/malformed.toml"
+
+printf 'schema = true\n' >"$render_dir/schema.toml"
+assert_rejected "wrong-schema" "$render_dir/schema.toml"
+
+cat >"$render_dir/types.toml" <<'TOML'
+schema = 1
+[options]
+transparent = "yes"
+TOML
+assert_rejected "wrong-type" "$render_dir/types.toml"
+
+cat >"$render_dir/color.toml" <<'TOML'
+schema = 1
+[colors]
+accent = "red; os.execute('owned')"
+TOML
+assert_rejected "unsafe-color" "$render_dir/color.toml"
+
+cat >"$render_dir/unknown.toml" <<'TOML'
+schema = 1
+[styles]
+plugin = "evil"
+TOML
+assert_rejected "unknown-field" "$render_dir/unknown.toml"
+
+cat >"$render_dir/conflicting-aliases.toml" <<'TOML'
+schema = 1
+[colors]
+purple = "#112233"
+magenta = "#445566"
+TOML
+assert_rejected "conflicting-aliases" "$render_dir/conflicting-aliases.toml"
+
+cat >"$render_dir/hostile.toml" <<'TOML'
+schema = 1
+[highlights.'Keyword"]; vim.cmd("owned"); --']
+fg = "red"
+TOML
+assert_rejected "hostile-name" "$render_dir/hostile.toml"
+
+cat >"$render_dir/mixed-link.toml" <<'TOML'
+schema = 1
+[highlights.Keyword]
+link = "Statement"
+bold = true
+TOML
+assert_rejected "mixed-link" "$render_dir/mixed-link.toml"
+
+printf 'schema = 1\n' >"$render_dir/oversized.toml"
+truncate -s $((1024 * 1024 + 1)) "$render_dir/oversized.toml"
+assert_rejected "oversized" "$render_dir/oversized.toml"
+
+printf 'schema = 1\n' >"$render_dir/too-many.toml"
+for index in $(seq 0 512); do
+  printf '\n[highlights.Group%s]\nfg = "red"\n' "$index" >>"$render_dir/too-many.toml"
+done
+assert_rejected "too-many-highlights" "$render_dir/too-many.toml"
+
+pass "renderer rejects plugin selection, malformed data, unsafe values, and schema limits atomically"


### PR DESCRIPTION
## Summary

- Add optional `neovim.toml` support for theme-specific Neovim appearance.
- Validate a fixed, appearance-only schema before generating trusted Lua.
- Keep the Aether v3 and LazyVim plugin identities hard-coded by Omarchy.
- Preserve trusted local `neovim.lua` precedence while continuing to reject Lua from Git-installed themes.
- Fall back atomically to the normal `colors.toml`-generated Neovim configuration when a declaration is invalid.

## Why

Git-installed themes currently lose `neovim.lua` because it can select and execute arbitrary plugins. That security boundary is correct, but it prevents repository themes from expressing Neovim-specific presentation.

`neovim.toml` restores that visual control without restoring executable behavior. A theme can customize safe options, style flags, palette values, and highlight groups, while Omarchy remains responsible for the complete plugin specification and generated Lua.

## Related work

This follows the strict declarative theme-extension pattern introduced in [#8720](https://github.com/omacom/omarchy/pull/8720), which adds `hyprland.toml` and safe terminal appearance settings. This PR applies the same trust model to Neovim while keeping executable Lua restricted.

## Security model

The declaration cannot select a plugin, repository, branch, dependency, build command, callback, import, path, command, or arbitrary Lua.

Omarchy always generates the fixed integration:

```lua
{
  "bjarneo/aether.nvim",
  branch = "v3",
  name = "aether",
  priority = 1000,
}

{
  "LazyVim/LazyVim",
  opts = { colorscheme = "aether" },
}
```

Validation is strict and whole-file:

- `schema` must be the integer `1`.
- Unknown fields and unsupported values are rejected.
- Colors must be allowlisted palette names or `#RRGGBB` values.
- Highlight names and links use a constrained character set and length.
- Highlight links cannot be mixed with other fields.
- Input size and highlight count are bounded.
- Output replacement is atomic; rejection preserves the existing fallback.

## Precedence

- A trusted local user theme may still provide handwritten `neovim.lua`; it wins over `neovim.toml`.
- A Git-installed theme’s `neovim.lua` remains forbidden.
- A valid `neovim.toml` from a Git-installed theme may replace only Omarchy’s bundled or generated Neovim configuration.
- An invalid declaration reports the error and leaves the normal generated configuration in place.

## Example

```toml
schema = 1

[options]
transparent = false
terminal_colors = true
dim_inactive = true
lualine_bold = true

[styles]
sidebars = "dark"
floats = "dark"

[styles.comments]
italic = true

[colors]
accent = "#BFA75D"
bright_red = "#D35F5F"
bright_yellow = "#F6F1DD"
bright_magenta = "#BFA75D"

[highlights.Keyword]
fg = "bright_red"
bold = true

[highlights.Function]
fg = "bright_yellow"
bold = true

[highlights.String]
fg = "bright_magenta"
```

## Visual validation

Validated in the Omarchy Quattro QEMU test VM across all three relevant provenance paths: a first-party base theme, a trusted complete user theme, and an untrusted Git-installed theme.

### First-party compatibility: Tokyo Night

Tokyo Night has no `neovim.toml`; its bundled `folke/tokyonight.nvim` integration remains authoritative and continues to load normally. This verifies that the new declaration path does not disturb existing base themes.

<p align="center">
  <img width="900" src="https://raw.githubusercontent.com/OldJobobo/omarchy/6e14dacb8942b2e7b5bbf9b6b14054a774a64ad0/tokyo-night-base-theme-regression.png" alt="Tokyo Night base theme running without neovim.toml" />
  <br />
  <sub><strong>Tokyo Night:</strong> first-party bundled integration preserved; no declaration required.</sub>
</p>

<details>
<summary>Tokyo Night runtime proof</summary>

```text
theme=tokyo-night
declaration=absent
plugin=folke/tokyonight.nvim
colorscheme=tokyonight-night
```

</details>

### Trusted complete theme: Watchmen

Watchmen exercises the trusted-local precedence path. In the disposable VM, its complete theme was applied normally, then its handwritten Neovim integration was temporarily replaced with `neovim.toml` and reapplied through `omarchy theme set watchmen`.

<table>
  <tr>
    <td width="50%" align="center">
      <img src="https://raw.githubusercontent.com/OldJobobo/omarchy/6e14dacb8942b2e7b5bbf9b6b14054a774a64ad0/01-watchmen-full-theme-before.png" alt="Watchmen before adding neovim.toml" />
      <br />
      <sub><strong>Before:</strong> Watchmen’s complete authored integration.</sub>
    </td>
    <td width="50%" align="center">
      <img src="https://raw.githubusercontent.com/OldJobobo/omarchy/6e14dacb8942b2e7b5bbf9b6b14054a774a64ad0/02-watchmen-full-theme-after-neovim-toml.png" alt="Watchmen after adding neovim.toml" />
      <br />
      <sub><strong>After:</strong> The same full theme rendered from validated appearance data.</sub>
    </td>
  </tr>
</table>

<details>
<summary>Watchmen generated configuration</summary>

<p align="center">
  <img width="900" src="https://raw.githubusercontent.com/OldJobobo/omarchy/6e14dacb8942b2e7b5bbf9b6b14054a774a64ad0/03-watchmen-full-theme-generated-neovim.png" alt="Watchmen generated Neovim configuration" />
  <br />
  <sub>Generated Aether v3 configuration beside the themed source.</sub>
</p>

</details>

### Untrusted Git install: Black Gold

Black Gold was installed through Omarchy’s normal untrusted-theme path:

```bash
omarchy theme install \
  https://github.com/HANCORE-linux/omarchy-blackgold-theme.git
```

The repository’s `hyprland.lua`, `neovim.lua`, and `vscode.json` were filtered as expected. A new `neovim.toml` was then added to the installed clone and the complete theme was reapplied with `omarchy theme set blackgold`.

<table>
  <tr>
    <td width="50%" align="center">
      <img src="https://raw.githubusercontent.com/OldJobobo/omarchy/6e14dacb8942b2e7b5bbf9b6b14054a774a64ad0/01-blackgold-before-neovim-toml.png" alt="Black Gold before adding neovim.toml" />
      <br />
      <sub><strong>Before:</strong> repository Lua filtered; standard safe fallback retained.</sub>
    </td>
    <td width="50%" align="center">
      <img src="https://raw.githubusercontent.com/OldJobobo/omarchy/6e14dacb8942b2e7b5bbf9b6b14054a774a64ad0/02-blackgold-after-neovim-toml.png" alt="Black Gold after adding neovim.toml" />
      <br />
      <sub><strong>After:</strong> the same Git-installed theme using its declarative Black Gold palette.</sub>
    </td>
  </tr>
</table>

<details>
<summary>Black Gold generated configuration and runtime proof</summary>

<p align="center">
  <img width="900" src="https://raw.githubusercontent.com/OldJobobo/omarchy/6e14dacb8942b2e7b5bbf9b6b14054a774a64ad0/03-blackgold-generated-from-git-neovim-toml.png" alt="Generated trusted Neovim configuration from a Git-installed theme" />
  <br />
  <sub>Generated configuration beside the themed source.</sub>
</p>

```text
origin=https://github.com/HANCORE-linux/omarchy-blackgold-theme.git
git-status=?? neovim.toml
declaration=staged
generated=1
repo-lua-marker=0
colorscheme=aether
Keyword=#d35f5f
Function=#f6f1dd
String=#bfa75d
Type=#bfa75d
```

</details>

## Tests

- Focused `neovim.toml` renderer and pipeline tests
- Git-installed theme filtering and declaration precedence
- Trusted local `neovim.lua` precedence
- Malformed TOML and unknown-field rejection
- Plugin-shaped and hostile-input rejection
- Type, color, name, link, size, and count validation
- Atomic fallback preservation
- Generated Lua parsing with `luac`
- Headless Neovim callback execution
- Theme staging tests
- `./test/cli`
- Bash and Python syntax checks
- Shellcheck, excluding the pre-existing `SC2053`
- `git diff --check`
- Full runtime application through LazyVim and Aether v3 in the Quattro VM

The full shell suite’s feature tests pass. Remaining failures are unrelated environment-dependent checks involving a missing `omarchy-pkgs` checkout, an existing manifest cleanup race, and duplicate runtime IPC registration in the active desktop session.
