### PR TITLE
Use DKMS for Broadcom wl across kernel updates

### DIFF
--- a/install/hardware/fix-bcm43xx.sh
+++ b/install/hardware/fix-bcm43xx.sh
@@ -6,5 +6,5 @@ pci_info=$(lspci -nn)
 
 if (echo "$pci_info" | grep -q "14e4:43a0" || echo "$pci_info" | grep -q "14e4:4331"); then
   echo "BCM4360 / BCM4331 detected"
-  omarchy-pkg-add broadcom-wl dkms linux-headers
+  omarchy-pkg-add broadcom-wl-dkms dkms linux-headers
 fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -5,7 +5,7 @@ autoconf-archive
 asusctl
 base
 base-devel
-broadcom-wl
+broadcom-wl-dkms
 btrfs-progs
 dkms
 egl-wayland


### PR DESCRIPTION
Fixes #9386

## Summary

- replace the kernel-specific `broadcom-wl` package in the offline package set with `broadcom-wl-dkms`
- install the DKMS variant for detected BCM4360 and BCM4331 hardware

`fix-bcm43xx.sh` already installs `dkms` and `linux-headers`, so the module can rebuild when the kernel changes instead of remaining tied to one kernel package.

## Testing

- `bash -n install/hardware/fix-bcm43xx.sh`
- verified both package-selection sites use `broadcom-wl-dkms`
- `git diff --check`