### PR TITLE
Pick the matching Noto CJK variant for language-tagged text

### DIFF
--- a/default/fontconfig/conf.avail/50-omarchy.conf
+++ b/default/fontconfig/conf.avail/50-omarchy.conf
@@ -1,6 +1,313 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
+  <!-- CJK: give language-tagged text the Noto CJK variant that matches its
+       language. noto-fonts-cjk ships all five, Han glyph shapes differ between
+       them, and the generic assigns below would otherwise hand tagged CJK text
+       to families with no Han coverage, leaving the variant to a charset-scan
+       lottery. Chinese arrives under many tags (W3C recommends the zh-Hans and
+       zh-Hant script forms), so the tags are first folded onto one tag per
+       variant. Order is load-bearing: a bare zh and a bare zh-hant satisfy
+       the contains test of every one of their extensions, so both are pinned
+       by exact matches before the extension folds run. Cantonese under its
+       own primary tag folds to Hong Kong forms, except explicitly
+       Simplified Cantonese, which folds to SC. -->
+
+  <match target="pattern">
+    <test name="lang" compare="eq">
+      <string>zh</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-cn</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="eq">
+      <string>zh-hant</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-tw</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-hant-hk</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-hk</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-hant-mo</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-hk</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-hant</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-tw</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-hans</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-cn</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-sg</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-cn</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-mo</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-hk</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="eq">
+      <string>yue</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-hk</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>yue-hans</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-cn</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>yue-cn</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-cn</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>yue</string>
+    </test>
+    <edit name="lang" mode="assign">
+      <string>zh-hk</string>
+    </edit>
+  </match>
+
+
+  <!-- Each variant is then prepended for its tag, ahead of the assigns below
+       because these test the generic names those assigns replace. Unlike the
+       Arabic rule further down, these carry a family test, so the prepend
+       lands just ahead of the matched generic and a concrete family the app
+       asked for stays in front of the variant. -->
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-cn</string>
+    </test>
+    <test name="family">
+      <string>sans-serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans CJK SC</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-cn</string>
+    </test>
+    <test name="family">
+      <string>serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Serif CJK SC</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-cn</string>
+    </test>
+    <test name="family">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans Mono CJK SC</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-hk</string>
+    </test>
+    <test name="family">
+      <string>sans-serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans CJK HK</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-hk</string>
+    </test>
+    <test name="family">
+      <string>serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Serif CJK HK</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-hk</string>
+    </test>
+    <test name="family">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans Mono CJK HK</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-tw</string>
+    </test>
+    <test name="family">
+      <string>sans-serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans CJK TC</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-tw</string>
+    </test>
+    <test name="family">
+      <string>serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Serif CJK TC</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>zh-tw</string>
+    </test>
+    <test name="family">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans Mono CJK TC</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>ja</string>
+    </test>
+    <test name="family">
+      <string>sans-serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans CJK JP</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>ja</string>
+    </test>
+    <test name="family">
+      <string>serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Serif CJK JP</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>ja</string>
+    </test>
+    <test name="family">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans Mono CJK JP</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>ko</string>
+    </test>
+    <test name="family">
+      <string>sans-serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans CJK KR</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>ko</string>
+    </test>
+    <test name="family">
+      <string>serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Serif CJK KR</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>ko</string>
+    </test>
+    <test name="family">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans Mono CJK KR</string>
+    </edit>
+  </match>
+
   <match target="pattern">
     <test name="family" qual="any">
       <string>sans-serif</string>


### PR DESCRIPTION
## Summary

The generic-family assigns replace `sans-serif`, `serif` and `monospace` with families that have no Han, Kana or Hangul coverage. Tagged CJK text then falls through to a raw charset scan, and which of the five Noto CJK variants it lands on is luck — in practice Chinese renders with Japanese glyph forms (骨, 直, 门 and friends look wrong). `noto-fonts-cjk` ships in `omarchy-base.packages`, so every install has the right fonts and never picks them. The whole bug is visible in one query:

```
$ fc-match "sans-serif:lang=zh-cn"    # before
LiberationSans-Regular.ttf: "Liberation Sans"

$ fc-match "sans-serif:lang=zh-cn"    # after
NotoSansCJK-Regular.ttc: "Noto Sans CJK SC"
```

Chinese arrives under many tags — the `zh-Hans`/`zh-Hant` script forms the W3C recommends, `yue` for Cantonese, `yue-CN` from `Intl.Locale.minimize()`, small territories like `zh-SG` — so the tags are first folded onto one tag per variant, then each variant is prepended for its tag ahead of the assigns. Rule order is load-bearing and the comments say why: a bare `zh` satisfies the contains test of every one of its extensions, so exact matches pin `zh`, `zh-hant` and `yue` before the extension folds run. The prepends carry a family test, so unlike the Arabic rule the variant lands just behind any concrete family the app asked for.

Like #6322 did for the `lang`-gated Arabic path, this fixes only tagged text. Chromium's untagged per-glyph fallback is a separate problem: any single last-resort variant is zero-sum between zh, ja and ko users, so it deserves its own discussion.

## Test plan

Verified in a clean Arch container with the patched file linked into the real `/etc/fonts/conf.d/` chain, fonts from the default package set.

- [x] 26 tag forms × sans-serif/serif/monospace all resolve to the matching variant: `zh`, `zh-cn`, `zh-sg`, `zh-hans`(+`-cn`/`-sg`/`-hk`) → SC; `zh-tw`, `zh-hant`(+`-tw`) → TC; `zh-hk`, `zh-mo`, `zh-hant-hk`, `zh-hant-mo` → HK; `yue`(+`-hk`/`-hant`/`-hant-hk`/`-hant-cn`) → HK; `yue-hans`(+`-cn`/`-hk`), `yue-cn` → SC; `ja`(+`-jp`) → JP; `ko`(+`-kr`) → KR
- [x] Before/after differential over non-CJK queries is byte-identical: `lang=ar` → Naskh, `lang=ur`, untagged Han charset, plain `sans-serif`/`serif`/`monospace`, emoji
- [x] A concrete requested family stays in front: `Arial,sans-serif:lang=ja` keeps the resolved Arial substitute first, JP variant next in the fallback list
- [x] Zero fontconfig warnings loading the file; `fc-cache -f` clean


