### PR TITLE
Report unreadable Claude transcripts once per scan

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -132,6 +132,8 @@ def scan_projects(projects_path: Path) -> dict[str, Any]:
   prompts = 0
   today_prompt_count = 0
   today_token_total = 0
+  unreadable = 0
+  first_unreadable = ""
 
   files = projects_path.rglob("*.jsonl") if projects_path.is_dir() else []
   for path in files:
@@ -194,7 +196,21 @@ def scan_projects(projects_path: Path) -> dict[str, Any]:
             today_token_total += total
             today_tokens[model] = today_tokens.get(model, 0) + total
     except Exception as exc:
-      print(f"Ignoring unreadable Claude project file {path}: {exc}", file=sys.stderr)
+      # A transcript the user cannot read is a normal condition: Claude Code
+      # run as root with the home mounted leaves thousands behind. The shell
+      # keeps this collector's stderr in its tmpfs log, and a line per file per
+      # refresh filled $XDG_RUNTIME_DIR until the compositor died. Count them
+      # and say so once per scan.
+      unreadable += 1
+      if not first_unreadable:
+        first_unreadable = f"{path}: {exc}"
+
+  if unreadable:
+    noun = "file" if unreadable == 1 else "files"
+    print(
+      f"Ignoring {unreadable} unreadable Claude project {noun} under {projects_path}; first: {first_unreadable}",
+      file=sys.stderr,
+    )
 
   return {
     "todayPrompts": today_prompt_count,

--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -132,8 +132,8 @@ def scan_projects(projects_path: Path) -> dict[str, Any]:
   prompts = 0
   today_prompt_count = 0
   today_token_total = 0
-  unreadable = 0
-  first_unreadable = ""
+  skipped: dict[str, int] = {}
+  skipped_examples: dict[str, str] = {}
 
   files = projects_path.rglob("*.jsonl") if projects_path.is_dir() else []
   for path in files:
@@ -200,17 +200,17 @@ def scan_projects(projects_path: Path) -> dict[str, Any]:
       # run as root with the home mounted leaves thousands behind. The shell
       # keeps this collector's stderr in its tmpfs log, and a line per file per
       # refresh filled $XDG_RUNTIME_DIR until the compositor died. Count them
-      # and say so once per scan.
-      unreadable += 1
-      if not first_unreadable:
-        first_unreadable = f"{path}: {exc}"
+      # by error and say so once per scan, so ninety thousand permission
+      # errors cannot hide the one failure that is a bug.
+      kind = type(exc).__name__
+      skipped[kind] = skipped.get(kind, 0) + 1
+      skipped_examples.setdefault(kind, f"{path}: {exc}")
 
-  if unreadable:
-    noun = "file" if unreadable == 1 else "files"
-    print(
-      f"Ignoring {unreadable} unreadable Claude project {noun} under {projects_path}; first: {first_unreadable}",
-      file=sys.stderr,
-    )
+  skipped_total = sum(skipped.values())
+  if skipped_total:
+    noun = "file" if skipped_total == 1 else "files"
+    detail = ", ".join(f"{kind} {count} (first {skipped_examples[kind]})" for kind, count in sorted(skipped.items()))
+    print(f"Skipped {skipped_total} Claude project {noun} under {projects_path}: {detail}", file=sys.stderr)
 
   return {
     "todayPrompts": today_prompt_count,
@@ -226,6 +226,10 @@ def scan_projects(projects_path: Path) -> dict[str, Any]:
     # union, which a count alone cannot give.
     "activeDays": len(active_days),
     "activeDates": sorted(active_days),
+    # Transcripts the scan could not read, by error, so the panel can say the
+    # numbers above are missing something rather than present them as whole.
+    "skippedFiles": skipped_total,
+    "skippedFilesByError": dict(sorted(skipped.items())),
   }
 
 
@@ -879,7 +883,10 @@ def main() -> int:
   if number(stats.get("totalPrompts")) <= 0:
     fallback = stats_cache_fallback(claude_dir)
     if fallback is not None:
-      stats = fallback
+      # The aggregate cache knows nothing about files the scan could not read,
+      # and a scan that read nothing is the case where that matters most.
+      skipped = {key: stats[key] for key in ("skippedFiles", "skippedFilesByError") if key in stats}
+      stats = dict(fallback, **skipped)
     else:
       # No transcripts and no aggregate cache, but history.jsonl alone can
       # still put numbers on today.

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -33,6 +33,33 @@ pass "Claude collector keeps mutually exclusive token categories"
   fail "Claude collector identifies itself and reports missing auth" "$result"
 pass "Claude collector identifies itself and reports missing auth"
 
+# Transcripts the user cannot read are a normal condition, and the shell keeps
+# this collector's stderr in its tmpfs log: the report must be one line per
+# scan, not one per file, and the readable transcripts must still count.
+# Root reads a mode-000 file anyway, so give a root test run something it
+# cannot open either: a directory wearing the transcript suffix.
+for index in 1 2 3; do
+  unreadable="$projects/unreadable-$index.jsonl"
+  if (( EUID == 0 )); then
+    mkdir "$unreadable"
+  else
+    : >"$unreadable"
+    chmod 000 "$unreadable"
+  fi
+done
+
+stderr_file="$TEST_HOME/collector.stderr"
+result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force 2>"$stderr_file")
+
+[[ $(wc -l <"$stderr_file") == 1 ]] ||
+  fail "Claude collector reports unreadable transcripts once per scan" "$(cat "$stderr_file")"
+grep -q '^Ignoring 3 unreadable Claude project files under ' "$stderr_file" ||
+  fail "Claude collector counts the unreadable transcripts it skipped" "$(cat "$stderr_file")"
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "58793" ]] ||
+  fail "Claude collector still counts the readable transcripts" "$result"
+pass "Claude collector reports unreadable transcripts once per scan"
+
 # A machine with no transcripts and no stats-cache still gets today's counts
 # from history.jsonl alone.
 HISTORY_HOME=$(mktemp -d)

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -38,14 +38,22 @@ pass "Claude collector identifies itself and reports missing auth"
 # scan, not one per file, and the readable transcripts must still count.
 # Root reads a mode-000 file anyway, so give a root test run something it
 # cannot open either: a directory wearing the transcript suffix.
-for index in 1 2 3; do
-  unreadable="$projects/unreadable-$index.jsonl"
+make_unreadable() {
   if (( EUID == 0 )); then
-    mkdir "$unreadable"
+    mkdir "$1"
   else
-    : >"$unreadable"
-    chmod 000 "$unreadable"
+    : >"$1"
+    chmod 000 "$1"
   fi
+}
+if (( EUID == 0 )); then
+  unreadable_kind=IsADirectoryError
+else
+  unreadable_kind=PermissionError
+fi
+
+for index in 1 2 3; do
+  make_unreadable "$projects/unreadable-$index.jsonl"
 done
 
 stderr_file="$TEST_HOME/collector.stderr"
@@ -53,12 +61,47 @@ result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TE
   "$ROOT/bin/omarchy-agent-usage-claude" --force 2>"$stderr_file")
 
 [[ $(wc -l <"$stderr_file") == 1 ]] ||
-  fail "Claude collector reports unreadable transcripts once per scan" "$(cat "$stderr_file")"
-grep -q '^Ignoring 3 unreadable Claude project files under ' "$stderr_file" ||
-  fail "Claude collector counts the unreadable transcripts it skipped" "$(cat "$stderr_file")"
+  fail "Claude collector reports skipped transcripts once per scan" "$(cat "$stderr_file")"
+grep -q "^Skipped 3 Claude project files under .*: $unreadable_kind 3 (first " "$stderr_file" ||
+  fail "Claude collector counts the skipped transcripts by error" "$(cat "$stderr_file")"
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "58793" ]] ||
   fail "Claude collector still counts the readable transcripts" "$result"
-pass "Claude collector reports unreadable transcripts once per scan"
+[[ $(jq -c ".skippedFiles, .skippedFilesByError" <<<"$result") == "3
+{\"$unreadable_kind\":3}" ]] ||
+  fail "Claude collector reports the skipped transcripts in its record" "$result"
+pass "Claude collector reports skipped transcripts once per scan"
+
+# One skipped transcript and nothing readable: the line reads as one file, and
+# the count still reaches the record even though the scan found no usage.
+SKIP_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$SKIP_HOME"' EXIT
+mkdir -p "$SKIP_HOME/.claude/projects/example"
+make_unreadable "$SKIP_HOME/.claude/projects/example/only.jsonl"
+
+result=$(HOME="$SKIP_HOME" XDG_CACHE_HOME="$SKIP_HOME/.cache" XDG_DATA_HOME="$SKIP_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force 2>"$SKIP_HOME/collector.stderr")
+
+grep -q "^Skipped 1 Claude project file under .*: $unreadable_kind 1 (first " "$SKIP_HOME/collector.stderr" ||
+  fail "Claude collector reports a single skipped transcript as one file" "$(cat "$SKIP_HOME/collector.stderr")"
+[[ $(jq -r '.skippedFiles' <<<"$result") == "1" ]] ||
+  fail "Claude collector keeps the skipped count when nothing was readable" "$result"
+pass "Claude collector reports a single skipped transcript as one file"
+
+# Different failures stay distinguishable in the one line: a directory wearing
+# the suffix and a file the user cannot read are two errors, not one count.
+# Root can read the mode-000 file, so only an unprivileged run can stage both.
+if (( EUID == 0 )); then
+  pass "running as root; skipping the mixed-error scenario"
+else
+  mkdir "$SKIP_HOME/.claude/projects/example/dir.jsonl"
+  result=$(HOME="$SKIP_HOME" XDG_CACHE_HOME="$SKIP_HOME/.cache" XDG_DATA_HOME="$SKIP_HOME/.local/share" \
+    "$ROOT/bin/omarchy-agent-usage-claude" --force 2>"$SKIP_HOME/collector.stderr")
+  grep -q '^Skipped 2 Claude project files under .*: IsADirectoryError 1 (first .*), PermissionError 1 (first ' "$SKIP_HOME/collector.stderr" ||
+    fail "Claude collector keeps skipped transcripts apart by error" "$(cat "$SKIP_HOME/collector.stderr")"
+  [[ $(jq -c '.skippedFilesByError' <<<"$result") == '{"IsADirectoryError":1,"PermissionError":1}' ]] ||
+    fail "Claude collector records skipped transcripts by error" "$result"
+  pass "Claude collector keeps skipped transcripts apart by error"
+fi
 
 # A machine with no transcripts and no stats-cache still gets today's counts
 # from history.jsonl alone.


### PR DESCRIPTION
Fixes #9674

## Problem

`omarchy-agent-usage-claude` prints one stderr line for every `~/.claude/projects/**/*.jsonl` it cannot open. The agents widget runs the collector on every `refreshIntervalSec` tick (900 s by default, plus on start), `omarchy-agent-usage-update` captures only its stdout, and Quickshell keeps the collector's stderr in its instance log under `$XDG_RUNTIME_DIR`. A directory of root-owned transcripts (90,105 in the report, left by Claude Code running as root with the home mounted) writes 90,105 lines per refresh. The log filled the tmpfs in about 13 hours, and the next shm screencopy killed Hyprland with SIGBUS.

The sibling scanners already treat an unreadable file as unremarkable: `scan_pi_usage` in the same file and the Codex collector both skip it silently. This loop was the odd one out.

## Change

Count unreadable transcripts during the scan and report them once per scan, keeping the first path and error in the line so the culprit is still findable. Readable transcripts are counted exactly as before, and a scan with nothing unreadable prints nothing.

## Verification

- `test/shell.d/agent-usage-claude-scanner-test.sh` gains a case with three unreadable transcripts beside a readable one: exactly one stderr line, the count in it, and `todayTotalTokens` unchanged. It uses mode-000 files, or directories wearing the transcript suffix when the tests run as root. Passes locally, 9 ok.
- Reporter's shape, before and after: 25 unreadable entries under a scratch `HOME` produced 25 stderr lines at quattro HEAD and one line with this change. A projects tree with no unreadable entries prints nothing.
- `agent-usage-update-test.sh`, `agent-usage-claude-limits-test.sh`, and `agents-panel-test.sh` still pass.

The uncapped Quickshell instance log (#7506) is a separate change and is left alone here.

Written with Claude Code; I reviewed the change and ran the tests above locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTqr6ZjXfNthXT719ag7Qc
