### PR TITLE
Seed Chromium's first-run preferences with a mode the browser can read

### DIFF
--- a/migrations/1787691200.sh
+++ b/migrations/1787691200.sh
@@ -13,6 +13,9 @@ chromium_prefs="/usr/lib/chromium/initial_preferences"
 chromium_seed='{"distribution":{"require_eula":false},"browser":{"theme":{"color_scheme":0,"color_scheme2":0}}}'
 
 if [[ $(cat "$chromium_prefs" 2>/dev/null) != "$chromium_seed" ]]; then
-  sudo mkdir -p "$(dirname "$chromium_prefs")"
-  echo "$chromium_seed" | sudo tee "$chromium_prefs" >/dev/null
+  # Explicit modes: the migration runs under the caller's umask and sudo keeps
+  # it, so a bare mkdir and tee under `umask 077` leave the seed root-only, and
+  # Chromium, running as the user, lands back on the dialog this exists to skip.
+  sudo install -d -m 755 "$(dirname "$chromium_prefs")"
+  printf '%s\n' "$chromium_seed" | sudo install -m 644 -T /dev/stdin "$chromium_prefs"
 fi

--- a/test/shell.d/chromium-first-run-seed-migration-test.sh
+++ b/test/shell.d/chromium-first-run-seed-migration-test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+migration="$ROOT/migrations/1787691200.sh"
+seed='{"distribution":{"require_eula":false},"browser":{"theme":{"color_scheme":0,"color_scheme2":0}}}'
+stub_bin="$test_dir/bin"
+mkdir -p "$stub_bin"
+
+# The scenarios below retarget the one path assignment in the migration. A
+# second copy of the literal would escape that rewrite and reach the host.
+occurrences=$(grep -Fc '/usr/lib/chromium/initial_preferences' "$migration") || occurrences=0
+(( occurrences == 1 )) ||
+  fail "Chromium seed migration names its destination exactly once" "found $occurrences occurrences"
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"${CALL_LOG:?}"
+exec "$@"
+STUB
+chmod +x "$stub_bin/sudo"
+
+run_migration() {
+  local scenario=$1
+  local prefs="$test_dir/$scenario/usr/lib/chromium/initial_preferences"
+
+  : >"$test_dir/$scenario.calls"
+  # Keep the privileged production destination fixed in the shipped migration.
+  # For this isolated test only, rewrite that one assignment in the input fed to
+  # bash so no scenario can touch the host's /usr/lib. Every scenario runs under
+  # a hardened umask, the case the explicit modes exist for.
+  sed "s|^chromium_prefs=\"/usr/lib/chromium/initial_preferences\"$|chromium_prefs=\"$prefs\"|" "$migration" |
+    (umask 077 && CALL_LOG="$test_dir/$scenario.calls" PATH="$stub_bin:$PATH" bash -euo pipefail) >/dev/null
+}
+
+mode_of() {
+  stat -c '%a' "$1"
+}
+
+# A machine already on Quattro has no seed and no directory yet.
+run_migration fresh
+prefs="$test_dir/fresh/usr/lib/chromium/initial_preferences"
+[[ $(<"$prefs") == "$seed" ]] || fail "Chromium seed migration writes the seed" "$(cat "$prefs")"
+[[ $(mode_of "$prefs") == "644" ]] ||
+  fail "Chromium seed stays readable to the browser user under umask 077" "mode $(mode_of "$prefs")"
+[[ $(mode_of "${prefs%/*}") == "755" ]] ||
+  fail "Chromium seed directory stays traversable under umask 077" "mode $(mode_of "${prefs%/*}")"
+pass "Chromium seed migration writes a seed the browser user can read"
+
+# A second user on the same machine, or a rerun: the seed is readable and
+# current, so nothing is written and nobody is asked for a password.
+run_migration fresh
+[[ ! -s $test_dir/fresh.calls ]] ||
+  fail "a seeded machine must not prompt for privileges" "$(cat "$test_dir/fresh.calls")"
+pass "Chromium seed migration no-ops once the seed is in place"
+
+# What the old mkdir and tee left behind under umask 077: a root-only directory
+# and a seed the user cannot read. The read fails, so the migration rewrites the
+# seed, and it must come back readable rather than root-only again.
+stale_dir="$test_dir/stale/usr/lib/chromium"
+mkdir -p "$stale_dir"
+printf '%s\n' '{"distribution":{"require_eula":false}}' >"$stale_dir/initial_preferences"
+chmod 000 "$stale_dir/initial_preferences"
+chmod 700 "$stale_dir"
+run_migration stale
+[[ $(<"$stale_dir/initial_preferences") == "$seed" ]] ||
+  fail "Chromium seed migration replaces a stale seed" "$(cat "$stale_dir/initial_preferences")"
+[[ $(mode_of "$stale_dir/initial_preferences") == "644" ]] ||
+  fail "a root-only seed comes back readable" "mode $(mode_of "$stale_dir/initial_preferences")"
+[[ $(mode_of "$stale_dir") == "755" ]] ||
+  fail "a root-only seed directory comes back traversable" "mode $(mode_of "$stale_dir")"
+pass "Chromium seed migration repairs a seed the old write left root-only"


### PR DESCRIPTION
## Problem

`migrations/1787691200.sh` (from #8203) writes the Chromium first-run seed with `sudo mkdir -p` and `echo | sudo tee`, with no mode. `omarchy-migrate` runs migrations as the user under the caller's umask, and sudo keeps it: sudoers applies the union of the caller's umask and its own 0022. Under `umask 077` the seed lands as `-rw------- root root` inside a `0700` directory. Chromium, running as the user, cannot read it, the terms-of-service dialog the migration exists to skip comes back, and the migration exits 0 and records itself done. Under `umask 027` the file is `0640`, unreadable to anyone outside group root, which is the same failure. A second user's run cannot repair it either: their `cat` fails, and the rewrite produces the same modes.

The repo already treats this as a house rule. `migrations/1786278735.sh` sets explicit modes for exactly this reason ("so a restrictive user umask cannot leave the root-owned drop-in unreadable to the unprivileged ssh client"), and the FIDO2 migration from #7904 repairs the same `sudo mkdir -p` umask union.

## Change

Create the directory with `install -d -m 755` and the seed with `install -m 644 -T /dev/stdin`, following the keepalive migration and the upgrade command's own `install -d -m 0755` for this directory. The existing content check keeps the migration idempotent, and it now doubles as repair: on a machine the old write already hit, the user's `cat` fails, the seed is rewritten readable, and `install -d` puts the directory back to 755. The 3.x upgrade path writes the same seed with a bare `tee` and then runs `omarchy-migrate`, so this migration repairs that copy as well.

## Verification

- New `test/shell.d/chromium-first-run-seed-migration-test.sh`, in the retargeted-copy style of the sshd hardening and FIDO2 migration tests: a `sudo` stub that logs and execs, the one path literal rewritten to a scratch tree (asserted to occur exactly once), every scenario under `umask 077`. It checks seed content and modes on a fresh machine (644 file, 755 directory), no privilege calls on a rerun, and repair of a root-only 0700/000 leftover. Passes locally, 3 ok.
- The same harness against the migration as shipped on `quattro` produces `700` and `600`, so the test fails without the fix.
- `migrate-wrapper`, `migrate-notify`, `sshd-hardening-migration`, and `security-fido2-migration` tests still pass. The eight `./test/shell` files that fail on this machine fail identically on pristine `quattro` (host assumptions: a sibling `omarchy-pkgs` checkout, `rg`, hardware tools) and are unrelated.

Written with Claude Code; I reviewed the change and ran the tests above locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTqr6ZjXfNthXT719ag7Qc
