### PR TITLE
Keep removed preinstalls removed when refreshing application launchers

### DIFF
--- a/bin/omarchy-install-preinstalls
+++ b/bin/omarchy-install-preinstalls
@@ -7,8 +7,9 @@ if gum confirm "Are you sure you want to restore all preinstalled web apps, TUI 
   echo -e "Restoring preinstalled Omarchy applications...\n"
 
   # Recreates the shipped .desktop launchers (web apps and TUIs) and the mise stubs
-  # that back claude, gh, opencode, and the rest of the agents
-  omarchy-refresh-applications
+  # that back claude, gh, opencode, and the rest of the agents. The opt-out marker
+  # is still in place here, so ask for them by name.
+  omarchy-refresh-applications --with-preinstalls
 
   # Mirrors the list in omarchy-remove-preinstalls; both track omarchy-base.packages
   if ! omarchy-pkg-add \

--- a/bin/omarchy-refresh-applications
+++ b/bin/omarchy-refresh-applications
@@ -1,16 +1,38 @@
 #!/bin/bash
 
 # omarchy:summary=Ensure default application launchers and mise wrappers are installed.
+# omarchy:args=[--with-preinstalls]
+
+# Remove Preinstalls deletes the shipped web app and TUI launchers and the mise
+# wrappers, and records that choice at the marker below. This command lays all
+# of them back down, so it honours the marker: an update that refreshes the
+# launchers must not quietly undo the opt-out. Install Preinstalls is the one
+# caller meant to undo it, and says so with --with-preinstalls.
+marker="$HOME/.local/state/omarchy/preinstalls-removed"
+include_preinstalls=true
+if [[ -f $marker && ${1:-} != "--with-preinstalls" ]]; then
+  include_preinstalls=false
+fi
+
+# The same test omarchy-webapp-remove-all and omarchy-tui-remove-all apply, so
+# what stays away here is exactly what Remove Preinstalls took away.
+is_preinstall_launcher() {
+  grep -q "Exec=omarchy-launch-webapp\|Exec=omarchy-webapp-handler\|Exec=xdg-terminal-exec --app-id=TUI\." "$1"
+}
 
 # Copy .desktop declarations
 mkdir -p ~/.local/share/applications
-cp "$OMARCHY_PATH"/applications/*.desktop ~/.local/share/applications/
+for launcher in "$OMARCHY_PATH"/applications/*.desktop; do
+  if [[ $include_preinstalls == true ]] || ! is_preinstall_launcher "$launcher"; then
+    cp "$launcher" ~/.local/share/applications/
+  fi
+done
 
 if omarchy-cmd-present alacritty; then
   cp "$OMARCHY_PATH/default/alacritty/Alacritty.desktop" ~/.local/share/applications/
 fi
 
-if [[ -f "$OMARCHY_PATH/install/user/mise.sh" ]]; then
+if [[ $include_preinstalls == true && -f $OMARCHY_PATH/install/user/mise.sh ]]; then
   bash "$OMARCHY_PATH/install/user/mise.sh"
 fi
 

--- a/test/shell.d/preinstalls-test.sh
+++ b/test/shell.d/preinstalls-test.sh
@@ -11,11 +11,17 @@ mock_bin="$test_tmp/bin"
 test_home="$test_tmp/home"
 marker="$test_home/.local/state/omarchy/preinstalls-removed"
 pkg_log="$test_tmp/packages"
+refresh_log="$test_tmp/refresh"
 mkdir -p "$mock_bin" "$test_home/.local/state/omarchy"
 
-for command in omarchy-webapp-remove-all omarchy-tui-remove-all omarchy-refresh-applications hyprctl; do
+for command in omarchy-webapp-remove-all omarchy-tui-remove-all hyprctl; do
   printf '#!/bin/bash\nexit 0\n' >"$mock_bin/$command"
 done
+
+cat >"$mock_bin/omarchy-refresh-applications" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_REFRESH_LOG"
+SH
 
 cat >"$mock_bin/gum" <<'SH'
 #!/bin/bash
@@ -42,6 +48,7 @@ chmod +x "$mock_bin"/*
 export PATH="$mock_bin:$ROOT/bin:$PATH"
 export HOME="$test_home"
 export OMARCHY_TEST_PKG_LOG="$pkg_log"
+export OMARCHY_TEST_REFRESH_LOG="$refresh_log"
 
 # Both scripts restore and remove the same set, and every package in it has to be
 # one Omarchy actually ships, or Remove Preinstalls takes out an app the user
@@ -83,6 +90,12 @@ pass "restore keeps the opt-out marker when packages fail to install"
 "$ROOT/bin/omarchy-install-preinstalls" >/dev/null
 [[ ! -e $marker ]] || fail "restore clears the opt-out marker once the packages are back"
 pass "restore clears the opt-out marker once the packages are back"
+
+# The refresh holds the preinstalls back while the marker exists, and the marker
+# is still there when restore calls it, so restore has to ask for them by name.
+[[ $(<"$refresh_log") == "--with-preinstalls" ]] ||
+  fail "restore asks the refresh for the preinstalls the marker holds back" "$(cat "$refresh_log")"
+pass "restore asks the refresh for the preinstalls the marker holds back"
 
 rm -f "$marker"
 OMARCHY_TEST_CONFIRM=1 "$ROOT/bin/omarchy-remove-preinstalls" >/dev/null

--- a/test/shell.d/refresh-applications-test.sh
+++ b/test/shell.d/refresh-applications-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+call_log="$test_tmp/calls"
+mkdir -p "$mock_bin"
+
+# The refresh copies the real shipped launchers; only what would reach the host
+# is mocked, and every mock records its call.
+for command in omarchy-mise-install omarchy-install-hermes-cli update-desktop-database; do
+  cat >"$mock_bin/$command" <<SH
+#!/bin/bash
+printf '%s %s\n' "$command" "\$*" >>"\$OMARCHY_TEST_CALL_LOG"
+SH
+done
+printf '#!/bin/bash\nexit 0\n' >"$mock_bin/omarchy-cmd-present"
+chmod +x "$mock_bin"/*
+
+export PATH="$mock_bin:$ROOT/bin:$PATH"
+export OMARCHY_PATH="$ROOT"
+export OMARCHY_TEST_CALL_LOG="$call_log"
+
+run_refresh() {
+  local scenario=$1
+  shift
+
+  : >"$call_log"
+  HOME="$test_tmp/$scenario" "$ROOT/bin/omarchy-refresh-applications" "$@" >/dev/null
+}
+
+launchers_in() {
+  (cd "$test_tmp/$1/.local/share/applications" && ls -- *.desktop | sort)
+}
+
+wrapper_calls() {
+  grep -c '^omarchy-mise-install \|^omarchy-install-hermes-cli' "$call_log" || true
+}
+
+# No opt-out on record: every shipped launcher, Alacritty's, and every wrapper.
+mkdir -p "$test_tmp/fresh"
+run_refresh fresh
+shipped=$(cd "$ROOT/applications" && ls -- *.desktop | wc -l)
+(( $(launchers_in fresh | wc -l) == shipped + 1 )) ||
+  fail "refresh lays down every shipped launcher" "$(launchers_in fresh)"
+(( $(wrapper_calls) > 0 )) || fail "refresh installs the wrappers" "$(cat "$call_log")"
+pass "refresh restores every launcher and wrapper while preinstalls are in place"
+
+# What Remove Preinstalls takes away from a full set is the reference for what
+# the refresh must hold back once the opt-out is recorded.
+reference="$test_tmp/reference"
+mkdir -p "$reference"
+cp "$test_tmp"/fresh/.local/share/applications/*.desktop "$reference/"
+HOME="$test_tmp/fresh" omarchy-webapp-remove-all "$reference" >/dev/null
+HOME="$test_tmp/fresh" omarchy-tui-remove-all "$reference" >/dev/null
+expected=$(cd "$reference" && ls -- *.desktop | sort)
+
+mkdir -p "$test_tmp/removed/.local/state/omarchy"
+touch "$test_tmp/removed/.local/state/omarchy/preinstalls-removed"
+run_refresh removed
+[[ $(launchers_in removed) == "$expected" ]] ||
+  fail "refresh holds back exactly the launchers Remove Preinstalls deletes" \
+    "expected:
+$expected
+got:
+$(launchers_in removed)"
+for launcher in foot.desktop imv.desktop mpv.desktop Alacritty.desktop; do
+  [[ -f $test_tmp/removed/.local/share/applications/$launcher ]] ||
+    fail "refresh keeps the launchers Remove Preinstalls leaves alone" "$launcher missing"
+done
+(( $(wrapper_calls) == 0 )) || fail "refresh holds back the wrappers Remove Preinstalls deletes" "$(cat "$call_log")"
+[[ -f $test_tmp/removed/.local/state/omarchy/preinstalls-removed ]] ||
+  fail "refresh leaves the opt-out marker in place"
+pass "refresh honours the preinstalls opt-out"
+
+# Install Preinstalls runs the refresh while the marker still exists; asking by
+# name brings everything back.
+mkdir -p "$test_tmp/restore/.local/state/omarchy"
+touch "$test_tmp/restore/.local/state/omarchy/preinstalls-removed"
+run_refresh restore --with-preinstalls
+[[ $(launchers_in restore) == "$(launchers_in fresh)" ]] ||
+  fail "refresh --with-preinstalls restores every launcher" "$(launchers_in restore)"
+(( $(wrapper_calls) > 0 )) || fail "refresh --with-preinstalls restores the wrappers" "$(cat "$call_log")"
+pass "refresh restores the preinstalls when asked by name"


### PR DESCRIPTION
Fixes #7107

## Problem

`omarchy-remove-preinstalls` deletes the shipped web app and TUI launchers and the mise wrappers, and records the choice at `~/.local/state/omarchy/preinstalls-removed`. `omarchy-refresh-applications` lays every one of them back down, and two update paths call it without looking at the marker: migration `1786183928.sh`, and `omarchy-upgrade-to-quattro`, which sets the marker for 3.x users who had removed the preinstalls and then calls the refresh two steps later, before the post-upgrade migrations run. The result is what the report describes: Discord, WhatsApp, X, YouTube, Zoom, HEY and Basecamp back in the menu, the mise stubs back in `~/.local/bin`, the marker still present so the keybindings stay off and the menu still offers Restore, and the Docker launcher pointing at a `lazydocker` that stays uninstalled.

## Change

The refresh honours the marker. With it present, the command still copies the launchers Remove Preinstalls never touches (foot, imv, mpv, Alacritty) and skips the web app and TUI launchers and `install/user/mise.sh`. Which launchers count is decided by the same `Exec=` test `omarchy-webapp-remove-all` and `omarchy-tui-remove-all` apply, so what stays away is exactly what they took away.

`omarchy-install-preinstalls` runs the refresh while the marker is still in place (it clears it last, deliberately, so a failed package transaction leaves the opt-out intact), so it is the one caller that asks for the preinstalls by name with `--with-preinstalls`. The migration and the upgrader are untouched: both now do the right thing through the command, and the upgrade test's guard on that call keeps holding.

## Verification

- New `test/shell.d/refresh-applications-test.sh` runs the real command against the shipped `applications/` with the wrappers mocked. It checks the full set without a marker, then builds the reference by running the real `omarchy-webapp-remove-all` and `omarchy-tui-remove-all` on a full copy and asserts a marker run yields exactly that leftover set with zero wrapper calls and the marker intact, then that `--with-preinstalls` brings everything back. 3 ok.
- `preinstalls-test.sh` now asserts restore passes `--with-preinstalls`, and still passes end to end.
- Before and after on `quattro` HEAD with the marker present: the shipped command copied 16 launchers and made 16 wrapper calls; this one copies 3 (foot, imv, mpv) and makes none.
- `upgrade-to-quattro`, `default-agent`, `hermes-cli-migration`, `bin-style` and `./test/cli` (which validates the new args metadata) pass. `hyprland-default-config-test.sh` needs `lua` and fails identically on pristine `quattro` on this machine.

Written with Claude Code; I reviewed the change and ran the tests above locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTqr6ZjXfNthXT719ag7Qc
