### PR TITLE
Make Super + J flip the axis on scrolling workspaces

### DIFF
--- a/bin/omarchy-hyprland-window-split-toggle
+++ b/bin/omarchy-hyprland-window-split-toggle
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle the split direction on the current active workspace
+
+ACTIVE_WORKSPACE_JSON=$(hyprctl activeworkspace -j)
+WORKSPACE=$(jq -r '.id' <<<"$ACTIVE_WORKSPACE_JSON")
+[[ $WORKSPACE =~ ^-?[0-9]+$ ]] || exit 1
+
+LAYOUT=$(jq -r '.tiledLayout // "dwindle"' <<<"$ACTIVE_WORKSPACE_JSON")
+
+LAYOUTS_DIR="$HOME/.local/state/omarchy/workspace-layouts"
+LAYOUT_FILE="$LAYOUTS_DIR/$WORKSPACE.lua"
+
+# Hyprland has no IPC query for the axis, so the saved rule is the only record;
+# take the first match, or a two-rule file reads as both and stops flipping.
+saved_direction() {
+  [[ -f $LAYOUT_FILE ]] || return 0
+
+  sed -n 's/.*direction = "\([a-z]*\)".*/\1/p' "$LAYOUT_FILE" | head -1
+}
+
+case "$LAYOUT" in
+  scrolling)
+    # Scrolling has no togglesplit; flipping its axis is the same intent.
+    if [[ $(saved_direction) == "down" ]]; then
+      NEW_DIRECTION=right
+      HEADLINE="Scrolling horizontally"
+    else
+      NEW_DIRECTION=down
+      HEADLINE="Scrolling vertically"
+    fi
+
+    RULE="hl.workspace_rule({ workspace = \"$WORKSPACE\", layout = \"scrolling\", layout_opts = { direction = \"$NEW_DIRECTION\" } })"
+    mkdir -p "$LAYOUTS_DIR"
+    printf '%s\n' "$RULE" >"$LAYOUT_FILE"
+
+    hyprctl eval "$RULE" >/dev/null 2>&1 ||
+      hyprctl keyword workspace "$WORKSPACE, layout:scrolling, layoutopt:direction:$NEW_DIRECTION"
+
+    omarchy-notification-send -g 󱂬 "$HEADLINE"
+    ;;
+  dwindle)
+    hyprctl dispatch 'hl.dsp.layout("togglesplit")' >/dev/null
+    ;;
+  *)
+    omarchy-notification-send -g 󱂬 "No split to toggle" "The $LAYOUT layout has no split direction"
+    ;;
+esac

--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -16,6 +16,19 @@ esac
 mkdir -p "$LAYOUTS_DIR"
 printf 'hl.workspace_rule({ workspace = "%s", layout = "%s" })\n' "$ACTIVE_WORKSPACE" "$NEW_LAYOUT" >"$LAYOUT_FILE"
 
-hyprctl eval "hl.workspace_rule({ workspace = \"$ACTIVE_WORKSPACE\", layout = \"$NEW_LAYOUT\" })" >/dev/null 2>&1 || \
-  hyprctl keyword workspace "$ACTIVE_WORKSPACE, layout:$NEW_LAYOUT"
+# hl.workspace_rule merges rather than replaces, so a direction set earlier
+# lingers until the next reload; re-apply the configured default to reset now.
+DEFAULT_DIRECTION=$(hyprctl getoption scrolling:direction -j | jq -r '.str')
+case "$DEFAULT_DIRECTION" in
+  right | left | up | down)
+    RULE="hl.workspace_rule({ workspace = \"$ACTIVE_WORKSPACE\", layout = \"$NEW_LAYOUT\", layout_opts = { direction = \"$DEFAULT_DIRECTION\" } })"
+    KEYWORD="$ACTIVE_WORKSPACE, layout:$NEW_LAYOUT, layoutopt:direction:$DEFAULT_DIRECTION"
+    ;;
+  *)
+    RULE="hl.workspace_rule({ workspace = \"$ACTIVE_WORKSPACE\", layout = \"$NEW_LAYOUT\" })"
+    KEYWORD="$ACTIVE_WORKSPACE, layout:$NEW_LAYOUT"
+    ;;
+esac
+
+hyprctl eval "$RULE" >/dev/null 2>&1 || hyprctl keyword workspace "$KEYWORD"
 omarchy-notification-send -g 󱂬 "Workspace layout set to $NEW_LAYOUT"

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -2,7 +2,7 @@ o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+o.bind("SUPER + J", "Toggle split direction", "omarchy-hyprland-window-split-toggle")
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -36,6 +36,8 @@ But you can also choose to turn a workspace into the scrolling layout where wind
 
  ![navigation-scrolling-layout](images/navigation-scrolling-layout.webp)
 
+Windows scroll off to the side by default, but `Super + J` flips the workspace to scroll vertically instead, so windows stack down the screen and off the bottom edge. That axis sticks for as long as the workspace stays on scrolling; send it back to dwindle and return, and it starts over from whichever direction scrolling is configured to use. (On a dwindle workspace, `Super + J` flips whether the focused window and its neighbour sit side by side or stacked.)
+
 The choice is per workspace, and it sticks. So you can keep workspace 1 on dwindle for browsing and workspace 2 on scrolling for code, and they'll come back that way after a restart. (The same toggle is under _Trigger > Toggle > Workspace Layout_ in the Omarchy menu).
 
 If you wish to use the scrolling layout as the default, you can set that in `~/.config/hypr/looknfeel.lua`:

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -13,7 +13,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + W` or `Super + Q` | Close window             |
 | `Ctrl + Alt + Del` | Close all windows |
 | `Super + T`               | Toggle window between tiling/floating             |
-| `Super + J` | Toggle window position (horizontal/vertical) |
+| `Super + J` | Toggle split direction (horizontal/vertical) |
 | `Super + O`               | Toggle popping window into sticky'n'floating |
 | `Super + L`               | Toggle between dwindle and scrolling layout |
 | `Super + P`               | Toggle pseudo window style (natural v stretch) |

--- a/test/shell.d/hyprland-workspace-layout-test.sh
+++ b/test/shell.d/hyprland-workspace-layout-test.sh
@@ -10,6 +10,7 @@ trap 'rm -rf "$tmpdir"' EXIT
 stub_dir="$tmpdir/bin"
 home_dir="$tmpdir/home"
 log_file="$tmpdir/hyprctl.log"
+notification_log="$tmpdir/notification.log"
 mkdir -p "$stub_dir" "$home_dir"
 
 cat >"$stub_dir/hyprctl" <<'EOF'
@@ -17,8 +18,15 @@ cat >"$stub_dir/hyprctl" <<'EOF'
 
 if [[ $1 == "activeworkspace" && -n $HYPRCTL_BROKEN ]]; then
   printf '{}\n'
+elif [[ $1 == "getoption" ]]; then
+  printf '{"option":"scrolling:direction","str":"%s","set":false}\n' "${FAKE_DEFAULT_DIRECTION:-right}"
+elif [[ $1 == "activeworkspace" && $FAKE_LAYOUT == "absent" ]]; then
+  printf '{"id":3}\n'
 elif [[ $1 == "activeworkspace" ]]; then
-  printf '{"id":3,"tiledLayout":"dwindle"}\n'
+  printf '{"id":3,"tiledLayout":"%s"}\n' "${FAKE_LAYOUT:-dwindle}"
+elif [[ $1 == "eval" && -n $HYPRCTL_EVAL_FAILS ]]; then
+  printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+  exit 7
 else
   printf '%s\n' "$*" >>"$HYPRCTL_LOG"
 fi
@@ -27,30 +35,95 @@ chmod +x "$stub_dir/hyprctl"
 
 cat >"$stub_dir/omarchy-notification-send" <<'EOF'
 #!/bin/bash
-:
+printf '%s\n' "$*" >>"$NOTIFICATION_LOG"
 EOF
 chmod +x "$stub_dir/omarchy-notification-send"
 
-HOME="$home_dir" HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" \
-  "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle"
-
 layout_file="$home_dir/.local/state/omarchy/workspace-layouts/3.lua"
+
+# bootstrap.lua builds package.path from $HOME, so XDG_STATE_HOME has to match
+# the sandbox or the developer's own state directory leaks into the run.
+run_command() {
+  local command=$1
+  shift
+  env HOME="$home_dir" XDG_STATE_HOME="$home_dir/.local/state" OMARCHY_PATH="$ROOT" \
+    HYPRCTL_LOG="$log_file" NOTIFICATION_LOG="$notification_log" \
+    PATH="$stub_dir:$PATH" "$@" "$ROOT/bin/$command"
+}
+
+run_command omarchy-hyprland-workspace-layout-toggle
+
 [[ -f $layout_file ]] || fail "workspace layout toggle saves a workspace rule"
 grep -Fx 'hl.workspace_rule({ workspace = "3", layout = "scrolling" })' "$layout_file" >/dev/null ||
   fail "workspace layout toggle saves the selected layout"
-grep -Fx 'eval hl.workspace_rule({ workspace = "3", layout = "scrolling" })' "$log_file" >/dev/null ||
+grep -Fx 'eval hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "right" } })' "$log_file" >/dev/null ||
   fail "workspace layout toggle applies the selected layout immediately"
 pass "workspace layout toggle persists and applies the selected layout"
 
-if HOME="$home_dir" HYPRCTL_LOG="$log_file" HYPRCTL_BROKEN=1 PATH="$stub_dir:$PATH" \
-  "$ROOT/bin/omarchy-hyprland-workspace-layout-toggle" 2>/dev/null; then
+if run_command omarchy-hyprland-workspace-layout-toggle HYPRCTL_BROKEN=1 2>/dev/null; then
   fail "workspace layout toggle exits nonzero without a workspace id"
 fi
 [[ -f "$home_dir/.local/state/omarchy/workspace-layouts/null.lua" ]] &&
   fail "workspace layout toggle does not persist a rule without a workspace id"
 pass "workspace layout toggle ignores broken hyprctl output"
 
-HOME="$home_dir" OMARCHY_PATH="$ROOT" lua <<'LUA'
+: >"$log_file"
+before=$(cat "$layout_file")
+run_command omarchy-hyprland-window-split-toggle
+grep -Fx 'dispatch hl.dsp.layout("togglesplit")' "$log_file" >/dev/null ||
+  fail "split toggle uses togglesplit on dwindle"
+[[ $(cat "$layout_file") == "$before" ]] ||
+  fail "split toggle leaves the saved rule alone on dwindle"
+pass "split toggle uses togglesplit on dwindle"
+
+: >"$log_file"
+run_command omarchy-hyprland-window-split-toggle FAKE_LAYOUT=scrolling
+grep -Fx 'hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "down" } })' "$layout_file" >/dev/null ||
+  fail "split toggle saves a vertical scrolling direction"
+grep -Fx 'eval hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "down" } })' "$log_file" >/dev/null ||
+  fail "split toggle applies a vertical scrolling direction immediately"
+pass "split toggle turns scrolling vertical"
+
+: >"$log_file"
+run_command omarchy-hyprland-window-split-toggle FAKE_LAYOUT=scrolling
+grep -Fx 'hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "right" } })' "$layout_file" >/dev/null ||
+  fail "split toggle flips a vertical scrolling direction back to horizontal"
+pass "split toggle flips scrolling back to horizontal"
+
+# Two assertions, not one: hl.workspace_rule merges, so dropping the direction
+# from the file leaves it applied until a reload unless the reset is sent live.
+: >"$log_file"
+run_command omarchy-hyprland-window-split-toggle FAKE_LAYOUT=scrolling
+run_command omarchy-hyprland-workspace-layout-toggle FAKE_LAYOUT=scrolling
+grep -Fx 'hl.workspace_rule({ workspace = "3", layout = "dwindle" })' "$layout_file" >/dev/null ||
+  fail "a layout change drops the saved axis"
+grep -Fx 'eval hl.workspace_rule({ workspace = "3", layout = "dwindle", layout_opts = { direction = "right" } })' "$log_file" >/dev/null ||
+  fail "a layout change resets the live axis rather than leaving it merged on"
+pass "a layout change forgets the axis"
+
+: >"$log_file"
+run_command omarchy-hyprland-workspace-layout-toggle FAKE_LAYOUT=dwindle FAKE_DEFAULT_DIRECTION=up
+grep -Fx 'eval hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "up" } })' "$log_file" >/dev/null ||
+  fail "the reset honours a configured scrolling direction"
+pass "the reset honours a configured scrolling direction"
+
+: >"$log_file"
+run_command omarchy-hyprland-workspace-layout-toggle FAKE_LAYOUT=scrolling FAKE_DEFAULT_DIRECTION=sideways
+grep -Fx 'eval hl.workspace_rule({ workspace = "3", layout = "dwindle" })' "$log_file" >/dev/null ||
+  fail "an unusable default direction is left out of the rule"
+pass "an unusable default direction is left out of the rule"
+
+: >"$log_file"
+: >"$notification_log"
+run_command omarchy-hyprland-window-split-toggle FAKE_LAYOUT=master
+[[ -s $log_file ]] && fail "split toggle does not dispatch on an unsupported layout"
+grep -F 'The master layout has no split direction' "$notification_log" >/dev/null ||
+  fail "split toggle explains an unsupported layout"
+pass "split toggle explains an unsupported layout"
+
+# Replay what the split toggle writes, not whatever the tests above left.
+run_command omarchy-hyprland-window-split-toggle FAKE_LAYOUT=scrolling
+HOME="$home_dir" XDG_STATE_HOME="$home_dir/.local/state" OMARCHY_PATH="$ROOT" lua - <<'LUA'
 local rules = {}
 
 hl = {
@@ -65,5 +138,53 @@ require("default.hypr.workspace-layouts")
 assert(#rules == 1)
 assert(rules[1].workspace == "3")
 assert(rules[1].layout == "scrolling")
+assert(rules[1].layout_opts.direction == "down")
 LUA
+(( $? == 0 )) || fail "saved workspace layouts load into Hyprland configuration"
 pass "saved workspace layouts load into Hyprland configuration"
+
+# Two directions folded into one Lua string would break every reload: these are
+# replayed with a bare require().
+printf '%s\n%s\n' \
+  'hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "down" } })' \
+  'hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "right" } })' \
+  >"$layout_file"
+run_command omarchy-hyprland-window-split-toggle FAKE_LAYOUT=scrolling
+# Whole-file, not a grep: the seeded second line is byte-identical to what a
+# correct run writes, so a script that wrote nothing would pass a match.
+[[ $(cat "$layout_file") == 'hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "right" } })' ]] ||
+  fail "a duplicated rule reads as its first direction"
+pass "a duplicated rule reads as its first direction"
+
+printf 'hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "sideways" } })\n' >"$layout_file"
+run_command omarchy-hyprland-window-split-toggle FAKE_LAYOUT=scrolling
+grep -Fx 'hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "down" } })' "$layout_file" >/dev/null ||
+  fail "an unrecognized direction is ignored"
+pass "an unrecognized direction is ignored"
+
+: >"$log_file"
+printf 'hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "down" } })\n' >"$layout_file"
+run_command omarchy-hyprland-window-split-toggle FAKE_LAYOUT=scrolling HYPRCTL_EVAL_FAILS=1
+grep -Fx 'keyword workspace 3, layout:scrolling, layoutopt:direction:right' "$log_file" >/dev/null ||
+  fail "the keyword fallback carries the direction"
+pass "the keyword fallback carries the direction"
+
+: >"$log_file"
+: >"$notification_log"
+run_command omarchy-hyprland-window-split-toggle FAKE_LAYOUT=absent
+grep -Fx 'dispatch hl.dsp.layout("togglesplit")' "$log_file" >/dev/null ||
+  fail "a Hyprland without tiledLayout keeps togglesplit"
+[[ -s $notification_log ]] && fail "a Hyprland without tiledLayout sends no notification"
+pass "a Hyprland without tiledLayout keeps togglesplit"
+
+fresh_home="$tmpdir/fresh"
+mkdir -p "$fresh_home"
+fresh_errors="$tmpdir/fresh.err"
+env HOME="$fresh_home" XDG_STATE_HOME="$fresh_home/.local/state" OMARCHY_PATH="$ROOT" \
+  HYPRCTL_LOG="$log_file" NOTIFICATION_LOG="$notification_log" PATH="$stub_dir:$PATH" \
+  FAKE_LAYOUT=scrolling "$ROOT/bin/omarchy-hyprland-window-split-toggle" 2>"$fresh_errors"
+[[ $(cat "$fresh_home/.local/state/omarchy/workspace-layouts/3.lua" 2>/dev/null) == 'hl.workspace_rule({ workspace = "3", layout = "scrolling", layout_opts = { direction = "down" } })' ]] ||
+  fail "the first press creates the state directory and rule"
+# A keybinding has no terminal, so a missing rule file must not spill to stderr.
+[[ -s $fresh_errors ]] && fail "the first press reads no missing file" "$(cat "$fresh_errors")"
+pass "the first press creates the state directory and rule"


### PR DESCRIPTION
Closes #7556.

## The choice this makes

`Super + J` dispatched the dwindle-only `togglesplit` layout message, so on a scrolling workspace the key did nothing except raise Hyprland's own error popup, Lua chunk info and all:

```
Runtime error in lua: =[C]:-1: no such layoutmsg for scrolling
```

The Lua binding layer reports before the result reaches `CKeybindManager::handleKeybinds`: `Internal::reportError` logs unconditionally and, at ERROR level, calls `CConfigManager::addError`, which pops the notification overlay. This is what #7556 and #8220 describe.

This is deliberately not just error suppression. The scrolling layout has a native axis, so `Super + J` can mean the same thing in both modes:

| layout | what `Super + J` flips |
|---|---|
| dwindle | whether the focused window and its neighbour sit **side by side** or **stacked** |
| scrolling | whether the workspace runs **rightward** or **downward** — where new windows land, and which way it scrolls |

One key, one meaning in both layouts: flip this arrangement between horizontal and vertical. The scope differs — dwindle flips one pair, scrolling flips the whole workspace — but the question the key asks is the same.

## How

`scrolling:direction` takes `right`/`left`/`up`/`down`, and `CScrollingAlgorithm::getDynamicDirection()` resolves it **per workspace** off the workspace rule before falling back to the global option — the same mechanism `master:orientation` uses through `getDynamicOrientation()`. There is no `layoutmsg` for it and no IPC to query it, so a workspace rule is the only way to flip the axis at all.

The binding routes through `omarchy-hyprland-window-split-toggle`:

- **dwindle** — keeps `togglesplit`, unchanged
- **scrolling** — flips the axis between `right` and `down`, with a notification
- **anything else** — an Omarchy notification instead of Hyprland's runtime-error popup
- **a Hyprland not reporting `tiledLayout`** — keeps the `togglesplit` this binding always sent

### Where the axis lives, and how long

While a workspace stays on scrolling, its axis sticks — across reloads and restarts — exactly like the layout choice it is an attribute of, which the manual already promises "sticks... after a restart".

**Changing layout forgets it**, matching dwindle, whose splits are destroyed on a mode change: `updateWorkspaceLayouts()` replaces the algorithm instance outright, so every `SDwindleNodeData::splitTop` goes with it. Scrolling's own runtime state (`SScrollingData` — columns, widths, tape offset) is discarded the same way, for free.

`Super + L` therefore saves no direction, and additionally re-applies the configured default **live**: `hl.workspace_rule` merges into an existing rule rather than replacing it, so a direction set earlier would otherwise linger until the next reload, making behaviour differ before and after one. The reset value is read from `scrolling:direction` at toggle time rather than hardcoded, so a default set in `looknfeel.lua` stays what a workspace falls back to, and nothing stale is ever written to disk.

Exact parity is not available: Hyprland offers config-backed values (survive everything) or eval-backed ones (die on *every* reload — theme changes, monitor hotplug). Dwindle's "survives a reload, dies on a mode change" is a third lifetime that does not exist for a config-typed value. Persisting both in parallel is left as the follow-up this makes room for.

## Building on the earlier attempts

This is the sixth attempt at this bug, and it reuses a lot of what came before. Credit where it is due:

- **#6924** (@seshna) — first to report and fix it, back on 15 Aug. Established that the dispatch has to be guarded by the active layout.
- **#7171** (@fayimora) — made the argument this PR is built on: that `Super + J` should *do* something layout-appropriate on scrolling rather than no-op, and that the manual needs updating alongside. Picked `consume_or_expel prev`. The reasoning here is an extension of that, not a departure from it.
- **#8548** (@gianmegantara) — introduced the `bin/omarchy-hyprland-window-split-toggle` helper shape dispatched from `tiling.lua`. This PR arrived at the same structure independently and keeps it, including the filename.
- **#8939** (@heyssh) — the layout check plus a notification for unsupported layouts, which is exactly what this PR does for the non-dwindle, non-scrolling case.
- **#9165** (@harshithnadig) — same helper path, with the `jq` fallback for a missing `tiledLayout`.

Also useful along the way: @SamSyntax's and @rsd's local workarounds in #8220 and #7556, @rookepoole's triage linking the duplicate reports to #8939, and @bierlingm's consolidation on #7556 which is what made the shape of the deadlock visible.

The one thing none of them had is the axis, and that is the only reason this PR exists rather than a +1 on one of theirs. Everything else here is their design.

#7556 is the original report and the thread @bierlingm consolidated on, so this closes that one. #8220, #8993 and #9146 are duplicates of it rather than separate bugs — flagging them rather than listing them as closed too, since that call is yours. Discussion and the parser evidence are on #7556.

**#8548 and #9165 create the same `bin/omarchy-hyprland-window-split-toggle` path**, so these conflict by construction — whichever lands first, I am happy to rebase onto it, fold the axis handling into that PR instead, or close this if a smaller fix is preferred. The error wants fixing regardless of which answer wins.

## Testing

`test/shell.d/hyprland-workspace-layout-test.sh`, fifteen assertions, one row each:

| assertion | what it holds down |
|---|---|
| the layout toggle persists and applies the chosen layout | `Super + L` still does its original job |
| it ignores broken `hyprctl` output | no workspace id means no rule file written |
| `togglesplit` on dwindle, saved rule untouched | the dwindle arm must not rewrite state on its way past |
| scrolling turns vertical | the axis is written **and** applied |
| then flips back to horizontal | it toggles, rather than only ever setting one value |
| a layout change forgets the axis | dropped from the rule **and** reset live, so a reload cannot change the answer |
| the reset honours a configured `scrolling:direction` | a default set in `looknfeel.lua` is what a workspace falls back to |
| an unusable default is left out of the rule | never send an answer `hyprctl` could not give to the compositor |
| an unsupported layout is explained | an Omarchy notification instead of Hyprland's runtime-error popup |
| the saved rules still load as Hyprland config | the file is replayed, not merely written |
| a duplicated rule reads as its first direction | a hand-edited file must not stop the axis flipping |
| an unrecognized direction is ignored | garbage in the file never propagates back out |
| the `keyword` fallback carries the direction | the string it builds is correct — but see the note below |
| a Hyprland not reporting `tiledLayout` keeps `togglesplit` | pre-Lua compositors keep the behaviour they had |
| the first press creates the state directory and rule | `Super + J` before `Super + L` ever ran, and without spilling to stderr |

Every assertion was checked to fail when the code it covers is deliberately broken. Two things came out of that pass rather than going in. A whitelist on the parsed direction proved observationally inert — the value is only ever compared against `down` and never written back — so it is gone; the equivalent whitelist on `Super + L` guards a value that comes from `hyprctl` rather than from this code, so it stays and now has a test. And the duplicated-rule assertion originally used `grep -F` against a seeded file whose second line was byte-identical to correct output, so a script that wrote *nothing* would have passed it; it now compares the whole file.

### A note on that `keyword` fallback

`hyprctl eval || hyprctl keyword` is inherited from `quattro`, and this change extends it to carry the direction. On 0.56.2 the two halves cannot combine: a Lua-config Hyprland prefixes a failed `eval` with `error:` so the fallback does fire, but `keyword` then refuses outright — *"keyword can't work with non-legacy parsers. Use eval."* — while a legacy-config Hyprland exits 0 from `eval`, so the fallback never runs at all. The test therefore proves the string this constructs is right, not that the path functions.

I have left it because it is the existing idiom here and removing it is a separate decision, but I am happy to drop it from both scripts if you would rather not carry dead code.

`./test/cli` passes. `./test/shell` fails the same four files on this branch and on a pristine `quattro` — three want an `omarchy-pkgs` checkout, one is a live-session shell smoke test — so there is no regression.

Verified in the running UI on Hyprland 0.56.2: both axes with real windows, the notifications, and that the compositor accepts the rules this writes.

One unrelated fix rides along, noted in the commit body: those Lua assertions never actually ran, because a block run as `lua <<'LUA'` exits 0 even when an `assert` inside it fails and nothing checked the status afterwards.



