### PR TITLE
Let screenshots skip the file and go clipboard-only

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -9,14 +9,24 @@
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
 OUTPUT_DIR="${OMARCHY_SCREENSHOT_DIR:-${XDG_PICTURES_DIR:-$HOME/Pictures}}"
 
-if [[ ! -d $OUTPUT_DIR ]]; then
-  mkdir -p "$OUTPUT_DIR"
-  omarchy-notification-send "Created screenshot directory: $OUTPUT_DIR" -t 2000
-fi
+# The directory is only created when a shot is actually written there, so
+# turning saving off doesn't leave an empty pictures directory behind.
+ensure_output_dir() {
+  if [[ ! -d $OUTPUT_DIR ]]; then
+    mkdir -p "$OUTPUT_DIR"
+    omarchy-notification-send "Created screenshot directory: $OUTPUT_DIR" -t 2000
+  fi
+}
 
 pkill slurp && exit 0
 
 SCREENSHOT_EDITOR="${OMARCHY_SCREENSHOT_EDITOR:-tensaku-edit}"
+
+# The default flow keeps a file alongside the clipboard copy. Only an explicit
+# "false" turns the file off, so a typo can't silently discard screenshots.
+# The positional copy/save arguments still say what they mean either way.
+SAVE_FILE=true
+[[ ${OMARCHY_SCREENSHOT_SAVE_FILE:-true} == "false" ]] && SAVE_FILE=false
 
 # Parse --editor flag from any position
 ARGS=()
@@ -62,20 +72,29 @@ FILEPATH="$OUTPUT_DIR/$FILENAME"
 
 case "$PROCESSING" in
   slurp)
-    grim -g "$SELECTION" "$FILEPATH" || exit 1
-    echo "$FILEPATH"
-    wl-copy --type image/png <"$FILEPATH"
+    if [[ $SAVE_FILE == true ]]; then
+      ensure_output_dir
+      grim -g "$SELECTION" "$FILEPATH" || exit 1
+      echo "$FILEPATH"
+      wl-copy --type image/png <"$FILEPATH"
 
-    # Best-effort: the screenshot is already saved and on the clipboard, so a
-    # notification outage must not report the capture itself as failed.
-    omarchy-notification-send "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" \
-      --image "$FILEPATH" \
-      --exec "$SCREENSHOT_EDITOR" "$FILEPATH" || true
+      # Best-effort: the screenshot is already saved and on the clipboard, so a
+      # notification outage must not report the capture itself as failed.
+      omarchy-notification-send "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" \
+        --image "$FILEPATH" \
+        --exec "$SCREENSHOT_EDITOR" "$FILEPATH" || true
+    else
+      grim -g "$SELECTION" - | wl-copy --type image/png || exit 1
+
+      # Nothing was written, so the notification can't offer the editor.
+      omarchy-notification-send "Screenshot copied to clipboard" -t 2000 || true
+    fi
     ;;
   copy)
     grim -g "$SELECTION" - | wl-copy --type image/png
     ;;
   save)
+    ensure_output_dir
     grim -g "$SELECTION" "$FILEPATH" || exit 1
     echo "$FILEPATH"
     ;;

--- a/default/agents/skills/omarchy/capture.md
+++ b/default/agents/skills/omarchy/capture.md
@@ -15,7 +15,9 @@ omarchy capture screenshot fullscreen save    # Full screen, straight to disk (n
 The first argument picks the mode (`smart|region|windows|fullscreen`), the
 second what happens with it (`slurp|copy|save`). `save` skips the annotation
 editor and prints the saved path. Screenshots land in the configured Pictures
-directory (override with `OMARCHY_SCREENSHOT_DIR`).
+directory (override with `OMARCHY_SCREENSHOT_DIR`). Set
+`OMARCHY_SCREENSHOT_SAVE_FILE=false` to make the default flow clipboard-only;
+explicit `copy` and `save` are unaffected.
 
 ## Screen Recording
 

--- a/default/uwsm/default
+++ b/default/uwsm/default
@@ -13,5 +13,8 @@ export EDITOR="omarchy-launch-editor --inline"
 # Use a custom directory for screenshots (remember to make the directory!)
 # export OMARCHY_SCREENSHOT_DIR="$HOME/Pictures/Screenshots"
 
+# Keep screenshots on the clipboard only, without writing a file
+# export OMARCHY_SCREENSHOT_SAVE_FILE=false
+
 # Use a custom directory for screenrecordings (remember to make the directory!)
 # export OMARCHY_SCREENRECORD_DIR="$HOME/Videos/Screencasts"

--- a/manual/12-screenshots-recording.md
+++ b/manual/12-screenshots-recording.md
@@ -19,6 +19,8 @@ The result goes two places at once: a PNG in your pictures directory, and the cl
 
 Files land in `~/Pictures` by default, named `screenshot-2026-08-13_14-22-05.png`. If you'd rather keep them in their own folder, set `OMARCHY_SCREENSHOT_DIR` — see [the FAQ](46-faq.md) for where to put session environment variables. Omarchy creates the directory for you if it isn't there. You can swap the editor too with `OMARCHY_SCREENSHOT_EDITOR`.
 
+If you only ever paste your screenshots and don't want the pile of files, set `OMARCHY_SCREENSHOT_SAVE_FILE=false`. `Print Screen` then puts the shot on the clipboard and nothing else: no file, and a plain notification instead of the clickable thumbnail, since there's nothing on disk for the editor to open. The explicit `omarchy capture screenshot ... save` still writes a file when you ask for one.
+
 From the terminal, `omarchy screenshot` takes the same shot, and you can be explicit about it: `omarchy capture screenshot region` for freeform only, `windows` to snap to window and monitor rectangles, or `fullscreen` to skip the picker entirely and grab the focused monitor. A second argument of `copy` puts the shot only on the clipboard, and `save` only on disk.
 
 ### Driving the picker from the keyboard

--- a/manual/46-faq.md
+++ b/manual/46-faq.md
@@ -64,6 +64,16 @@ You can do the same for screenrecordings using `OMARCHY_SCREENRECORD_DIR`.
 
 Just remember to create the directoy you want to save to and restart Omarchy for this to take effect.
 
+### How do I stop screenshots from being saved as files?
+
+If you only paste screenshots and never want them cluttering up a directory, put this in the same place:
+
+```
+export OMARCHY_SCREENSHOT_SAVE_FILE=false
+```
+
+`Print Screen` then copies the shot to the clipboard without writing anything to disk. Since there's no file, the notification is a plain one rather than a thumbnail you can click into the editor.
+
 ### How do I get the speakers + webcam working on my Apple Studio Display?
 
 You'd think that it should all work just plugging in USB C, but unfortunately that isn't the case. The solution I've found to make it work reliably is using [the WJESOG DisplayPort + USB-A => USB-C cable](https://www.amazon.com/WJESOG-DisplayPort-Adapter-Converter-Thunderbolt/dp/B0BNX7MS6N/). Then speakers and webcam work like a charm.

--- a/test/shell.d/screenshot-save-file-test.sh
+++ b/test/shell.d/screenshot-save-file-test.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+
+cleanup() {
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+test_home="$TMPDIR/home"
+stub_bin="$TMPDIR/bin"
+mkdir -p "$test_home" "$stub_bin"
+
+# The capture itself needs a compositor, a picker and a clipboard, none of which
+# a headless test run has. Stub the surface the command talks to so the file
+# handling stays observable on its own.
+cat >"$stub_bin/pkill" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+[[ $* == *"getoption cursor:no_hardware_cursors"* ]] && echo '{"int": 0}'
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-capture-region" <<'SH'
+#!/bin/bash
+# The command kills the freeze process it is handed, so hand it a real one.
+sleep 30 &
+echo "$!"
+echo "0,0 100x100"
+SH
+
+cat >"$stub_bin/grim" <<'SH'
+#!/bin/bash
+target="${*: -1}"
+if [[ $target == "-" ]]; then
+  printf 'png-bytes'
+else
+  printf 'png-bytes' >"$target"
+fi
+SH
+
+cat >"$stub_bin/wl-copy" <<'SH'
+#!/bin/bash
+cat >>"$STUB_LOG_DIR/wl-copy"
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$STUB_LOG_DIR/notifications"
+SH
+
+chmod +x "$stub_bin"/*
+
+# screenshot <case name> [VAR=value ...] [-- <command arguments>]
+screenshot() {
+  local case_dir="$TMPDIR/$1"
+  shift
+
+  local env_vars=()
+  while (( $# )) && [[ $1 != "--" ]]; do
+    env_vars+=("$1")
+    shift
+  done
+  [[ ${1:-} == "--" ]] && shift
+
+  local output_dir="$case_dir/pictures"
+  local log_dir="$case_dir/log"
+  mkdir -p "$log_dir"
+
+  env -i \
+    PATH="$stub_bin:$ROOT/bin:$PATH" \
+    HOME="$test_home" \
+    OMARCHY_PATH="$ROOT" \
+    STUB_LOG_DIR="$log_dir" \
+    OMARCHY_SCREENSHOT_DIR="$output_dir" \
+    "${env_vars[@]}" \
+    "$ROOT/bin/omarchy-capture-screenshot" "$@" >/dev/null
+}
+
+saved_count() {
+  local dir="$1"
+
+  if [[ -d $dir ]]; then
+    find "$dir" -name 'screenshot-*.png' | wc -l
+  else
+    echo 0
+  fi
+}
+
+screenshot default
+(( $(saved_count "$TMPDIR/default/pictures") == 1 )) ||
+  fail "the default flow writes a screenshot file"
+pass "the default flow writes a screenshot file"
+
+grep -q "saved to clipboard and file" "$TMPDIR/default/log/notifications" ||
+  fail "the default flow reports the saved file" "$(cat "$TMPDIR/default/log/notifications")"
+pass "the default flow reports the saved file"
+
+screenshot clipboard-only OMARCHY_SCREENSHOT_SAVE_FILE=false
+(( $(saved_count "$TMPDIR/clipboard-only/pictures") == 0 )) ||
+  fail "OMARCHY_SCREENSHOT_SAVE_FILE=false writes no screenshot file"
+pass "OMARCHY_SCREENSHOT_SAVE_FILE=false writes no screenshot file"
+
+[[ ! -d $TMPDIR/clipboard-only/pictures ]] ||
+  fail "OMARCHY_SCREENSHOT_SAVE_FILE=false leaves the screenshot directory uncreated"
+pass "OMARCHY_SCREENSHOT_SAVE_FILE=false leaves the screenshot directory uncreated"
+
+[[ -s $TMPDIR/clipboard-only/log/wl-copy ]] ||
+  fail "OMARCHY_SCREENSHOT_SAVE_FILE=false still copies to the clipboard"
+pass "OMARCHY_SCREENSHOT_SAVE_FILE=false still copies to the clipboard"
+
+grep -q "Screenshot copied to clipboard" "$TMPDIR/clipboard-only/log/notifications" ||
+  fail "the clipboard-only flow notifies without offering the editor" \
+    "$(cat "$TMPDIR/clipboard-only/log/notifications")"
+pass "the clipboard-only flow notifies without offering the editor"
+
+screenshot explicit-save OMARCHY_SCREENSHOT_SAVE_FILE=false -- smart save
+(( $(saved_count "$TMPDIR/explicit-save/pictures") == 1 )) ||
+  fail "an explicit save argument writes a file even with saving turned off"
+pass "an explicit save argument writes a file even with saving turned off"
+
+screenshot unrecognized-value OMARCHY_SCREENSHOT_SAVE_FILE=nope
+(( $(saved_count "$TMPDIR/unrecognized-value/pictures") == 1 )) ||
+  fail "only an explicit false turns off saving"
+pass "only an explicit false turns off saving"


### PR DESCRIPTION
## What

`Print Screen` always writes a PNG next to the clipboard copy. For people who only ever paste their screenshots, that's a pictures directory that fills up with files nobody opens, and today the only way out is to rebind the key to `omarchy capture screenshot smart copy` — which also loses the notification.

This adds `OMARCHY_SCREENSHOT_SAVE_FILE`. Set it to `false` and the default flow copies to the clipboard without writing anything:

```bash
export OMARCHY_SCREENSHOT_SAVE_FILE=false
```

## Details

- Only a literal `false` turns saving off, so a typo can't silently discard screenshots.
- The positional `copy` / `save` arguments are untouched — `omarchy capture screenshot fullscreen save` still writes a file with saving turned off.
- With no file, the notification drops the thumbnail and the editor action and just says the shot is on the clipboard; there'd be nothing on disk for the editor to open.
- Creating the screenshot directory moved out of the top of the script into the branches that actually write there, so turning saving off doesn't leave an empty `~/Pictures` behind.
- Documented in the manual (screenshots page + a FAQ entry), the capture skill, and the commented `default/uwsm/default` example next to `OMARCHY_SCREENSHOT_DIR`.

## Testing

- New `test/shell.d/screenshot-save-file-test.sh` stubs the compositor, picker, clipboard and notifier and covers: default still saves, `false` writes no file and creates no directory, `false` still copies to the clipboard, an explicit `save` argument overrides it, and an unrecognized value keeps saving on.
- `./test/cli` clean; `./test/shell` has the same 4 failures on this branch as on `quattro` (`config`, `runtime-smoke`, `snapper`, `unowned-system-paths` — all environment-related and unrelated to this change).
- Verified live on a running session: with `OMARCHY_SCREENSHOT_SAVE_FILE=false` the shot landed on the clipboard as `image/png` with no file and no directory created, and the "Screenshot copied to clipboard" notification rendered; the default run wrote the file as before.

## Notes

- No prior issue or discussion asked for this. Related but distinct: #322 (merged) added `OMARCHY_SCREENSHOT_DIR` for *where*, discussion #5366 asks for more clipboard behavior after editing.
- #9446 (Use Omasnap for screenshots) touches the same dispatch. Happy to rebase this on top of it, or fold the flag into that flow, whichever the maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)