### PR TITLE
Render notification action buttons

### DIFF
--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -180,6 +180,46 @@ function shouldRenderCompactGlyph(glyph, iconSource, singleLineToast) {
   return String(glyph || "").length > 0 && String(iconSource || "").length === 0 && !!singleLineToast
 }
 
+// The freedesktop "default" action is the whole-card click (see
+// invokePopupDefault in Service.qml); every other action is a labelled button
+// the sender wants drawn. The server advertises the "actions" capability, so
+// senders send these whether or not anything renders them.
+//
+// Serialized to JSON: ListModel roles hold plain values, and the popup files
+// round-trip through JSON anyway.
+function actionsJson(notification) {
+  var n = notification || {}
+  var out = []
+  try {
+    var list = n.actions || []
+    for (var i = 0; i < list.length; i++) {
+      var action = list[i]
+      if (!action) continue
+      var identifier = String(action.identifier === undefined ? "" : action.identifier)
+      var label = String(action.text === undefined ? "" : action.text)
+      // A label-less action has nothing to draw, and "default" is already the
+      // card click.
+      if (identifier === "default" || identifier.length === 0 || label.length === 0) continue
+      out.push({ id: identifier, text: label })
+    }
+  } catch (e) {
+    // Object torn down by the server mid-read — no buttons is the safe answer.
+    return "[]"
+  }
+  return JSON.stringify(out)
+}
+
+function parseActions(json) {
+  var value = String(json || "")
+  if (value.length === 0) return []
+  try {
+    var parsed = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed : []
+  } catch (e) {
+    return []
+  }
+}
+
 function snapshotOf(notification, timestamp) {
   var n = notification || {}
   var id = n.id || 0
@@ -195,6 +235,7 @@ function snapshotOf(notification, timestamp) {
     image: n.image || "",
     glyph: glyphFromHints(n.hints),
     execArgv: execArgvFromHints(n.hints),
+    actions: actionsJson(n),
     urgency: n.urgency,
     expireTimeout: expireTimeout,
     timestamp: timestamp === undefined ? Date.now() : timestamp
@@ -203,7 +244,7 @@ function snapshotOf(notification, timestamp) {
 
 // Everything the popup card draws, and therefore everything an in-place
 // update has to write through to the row and its file.
-var POPUP_ROLES = ["app", "appIcon", "summary", "body", "image", "glyph", "execArgv", "urgency", "expireTimeout"]
+var POPUP_ROLES = ["app", "appIcon", "summary", "body", "image", "glyph", "execArgv", "actions", "urgency", "expireTimeout"]
 
 function popupRoles() {
   return POPUP_ROLES
@@ -460,6 +501,8 @@ if (typeof module !== "undefined") {
     parseExecArgv: parseExecArgv,
     shouldRenderCompactGlyph: shouldRenderCompactGlyph,
     snapshotOf: snapshotOf,
+    actionsJson: actionsJson,
+    parseActions: parseActions,
     popupRoles: popupRoles,
     popupRowChanged: popupRowChanged,
     replacementSnapshot: replacementSnapshot,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -396,6 +396,35 @@ Item {
     dismissPopup(index)
   }
 
+  // Invoke one of the notification's named actions (the buttons on the card)
+  // and dismiss, which is what a click on an action button means everywhere
+  // else that renders them.
+  //
+  // Only live rows can do this: a restored row's sender died with the previous
+  // server generation, and its originalId may since have been handed to an
+  // unrelated notification — invoking through it would fire the wrong action.
+  // Restored rows carry no actions at all, so this is belt-and-braces.
+  function invokePopupAction(index, identifier) {
+    if (index < 0 || index >= popupModel.count) return
+    var entry = popupModel.get(index)
+    var ref = entry && !isRestoredRow(entry) ? liveRefs[entry.originalId] : null
+    try {
+      if (ref && ref.actions) {
+        for (var i = 0; i < ref.actions.length; i++) {
+          var action = ref.actions[i]
+          if (action && String(action.identifier) === String(identifier)) {
+            action.invoke()
+            break
+          }
+        }
+      }
+    } catch (e) {
+      // Already torn down by the server — the row is stale either way.
+      console.warn("invoke action failed:", e)
+    }
+    dismissPopup(index)
+  }
+
   // Try to focus an existing Hyprland window matching the notification's
   // sender. The helper handles case-insensitive class matching.
   function focusApp(entry) {
@@ -691,6 +720,7 @@ Item {
         image: "",
         glyph: "󰂚",
         execArgv: "",
+        actions: "",
         urgency: NotificationUrgency.Low,
         expireTimeout: 0,
         timestamp: Date.now()
@@ -705,6 +735,8 @@ Item {
       // sender long ago, so they must never resolve to a live server object
       // that has since been handed their old id.
       service.restoredPopups[NotificationLogic.popupFileName(rows[i])] = true
+      // Buttons need a live sender to invoke against, and this one is gone.
+      rows[i].actions = ""
       popupModel.append(rows[i])
     }
   }
@@ -771,6 +803,7 @@ Item {
         // popups have no liveRefs entry — the server object died with the
         // old shell — so dismissal and action fallbacks degrade gracefully.
         service.restoredPopups[NotificationLogic.popupFileName(restored)] = true
+        restored.actions = ""
         popupModel.append(restored)
       }
     })
@@ -1000,6 +1033,7 @@ Item {
             required property string body
             required property string image
             required property string glyph
+            required property string actions
             required property int urgency
             required property double expireTimeout
             required property double timestamp
@@ -1051,9 +1085,13 @@ Item {
               cornerRadius: service.cornerRadius
               fontFamily: service.shell && service.shell.bar ? service.shell.bar.fontFamily : ""
               glyph: cardSlot.glyph
+              actionsJson: cardSlot.actions
 
               onCloseRequested: service.dismissPopup(cardSlot.index)
               onCardClicked: service.invokePopupDefault(cardSlot.index)
+              onActionInvoked: function(identifier) {
+                service.invokePopupAction(cardSlot.index, identifier)
+              }
             }
           }
         }

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -32,8 +32,15 @@ BorderSurface {
 
   readonly property bool hovered: hoverTracker.hovered
 
+  // Freedesktop actions other than "default" (which is the whole-card click),
+  // as JSON from NotificationLogic.actionsJson. Empty for history rows and
+  // restored toasts, whose sender is gone — so they render no buttons.
+  property string actionsJson: ""
+  readonly property var actionList: NotificationLogic.parseActions(actionsJson)
+
   signal closeRequested()
   signal cardClicked()
+  signal actionInvoked(string identifier)
   // Prefer per-notification media/avatar data, then fall back to the app icon.
   // The `check` flag avoids Qt's missing-texture placeholder for unknown names.
   readonly property string smallIconSource: image.length > 0 ? image : iconSource(appIcon)
@@ -190,6 +197,36 @@ BorderSurface {
           wrapMode: Text.WordWrap
           elide: Text.ElideRight
           maximumLineCount: 3
+        }
+      }
+    }
+
+    // Action buttons. Inside mainColumn but declared after the card-wide
+    // MouseArea, so a button takes its own click instead of falling through
+    // to the default action.
+    RowLayout {
+      Layout.fillWidth: true
+      Layout.leftMargin: Style.space(12)
+      Layout.rightMargin: Style.space(12)
+      Layout.bottomMargin: Style.space(10)
+      spacing: Style.space(8)
+      visible: root.actionList.length > 0
+
+      Item { Layout.fillWidth: true }
+
+      Repeater {
+        model: root.actionList
+
+        delegate: Button {
+          required property var modelData
+          text: modelData.text
+          bordered: true
+          focusable: false
+          fontFamily: "Liberation Sans"
+          fontSize: Style.font.body
+          foreground: Color.notifications.text
+          accent: root.accentColor
+          onClicked: root.actionInvoked(modelData.id)
         }
       }
     }

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -723,4 +723,74 @@ assert(
   !/pendingModel|pastModel/.test(serviceQml),
   'notifications service keeps no in-memory history models'
 )
+
+// ---- action buttons -------------------------------------------------------
+// The server advertises the freedesktop "actions" capability, so senders send
+// labelled actions; these keep them reaching the card.
+
+assertEqual(
+  notifications.actionsJson({ actions: [
+    { identifier: 'default', text: 'Activate' },
+    { identifier: '0', text: 'Delete' },
+    { identifier: '1', text: 'Mark as read' }
+  ] }),
+  '[{"id":"0","text":"Delete"},{"id":"1","text":"Mark as read"}]',
+  'notifications keep labelled actions and drop the default one'
+)
+
+assertEqual(
+  notifications.actionsJson({ actions: [{ identifier: '0', text: '' }] }),
+  '[]',
+  'notifications drop actions with no label to draw'
+)
+
+assertEqual(
+  notifications.actionsJson({}),
+  '[]',
+  'notifications treat a sender with no actions as no buttons'
+)
+
+assertDeepEqual(
+  notifications.parseActions(notifications.actionsJson({ actions: [{ identifier: 'read', text: 'Mark as read' }] })),
+  [{ id: 'read', text: 'Mark as read' }],
+  'notifications round-trip actions through the model role'
+)
+
+assertDeepEqual(
+  notifications.parseActions('not json'),
+  [],
+  'notifications treat an unreadable actions role as no buttons'
+)
+
+assertDeepEqual(
+  notifications.parseActions(''),
+  [],
+  'notifications treat an empty actions role as no buttons'
+)
+
+assert(
+  notifications.popupRoles().indexOf('actions') !== -1,
+  'notifications carry actions as a popup role so in-place updates write through'
+)
+
+assert(
+  /function invokePopupAction\(index, identifier\)/.test(serviceQml),
+  'notifications service can invoke a named action'
+)
+
+assert(
+  /rows\[i\]\.actions = ""/.test(serviceQml) && /restored\.actions = ""/.test(serviceQml),
+  'notifications service clears actions on restored rows, whose sender is gone'
+)
+
+
+assert(
+  /Repeater\s*\{[\s\S]{0,120}?model: root\.actionList/.test(cardQml),
+  'notification card draws a button per action'
+)
+
+assert(
+  /onClicked: root\.actionInvoked\(modelData\.id\)/.test(cardQml),
+  'notification card reports the clicked action by identifier'
+)
 JS


### PR DESCRIPTION
Closes #9715.

The notification server advertises the freedesktop `actions` capability, so
senders send labelled actions — but nothing rendered them. Only `default` (the
whole-card click) was reachable, and every other action was silently dropped.
Gmail's "Delete" / "Mark as read", Facebook's "Settings", and any
`notify-send -A` action all arrived over D-Bus and went nowhere.

## Change

- `NotificationLogic.js` — `actionsJson()` serializes the sender's actions,
  skipping `default` (already the card click) and label-less entries, into a
  new `actions` popup role; `parseActions()` reads it back. The role is in
  `POPUP_ROLES`, so an in-place update through `replaces_id` writes through.
- `Service.qml` — `invokePopupAction(index, identifier)` resolves the row
  through `liveRefs`, calls `action.invoke()`, and dismisses.
- `components/NotificationCard.qml` — a right-aligned `Repeater` of `Button`s,
  inside `mainColumn` but declared after the card-wide `MouseArea` so a button
  takes its own click rather than falling through to the default action.

The live `Notification` objects were already retained in `liveRefs`, so this is
a UI layer over existing plumbing — no change to the D-Bus surface.

Restored and replayed rows clear the role before append: their sender died with
the previous server generation and their `originalId` may since have been handed
to an unrelated notification, so a button there would invoke nothing or the
wrong action. History rows never set the property, so the panel is unchanged.
Senders that register no actions (Slack, Discord, and most chat apps) draw no
buttons and keep the existing `focusApp` click behaviour.

## Tests

Added to `test/shell.d/notifications-test.sh`: `default` and label-less actions
are dropped, labelled ones survive the model round-trip, malformed and empty
roles degrade to no buttons, `actions` is in `POPUP_ROLES`, the service exposes
the invoke path and clears the role on restored rows, and the card draws one
button per action and reports the clicked identifier.

`./test/shell` passes apart from four failures that also fail on a clean
`quattro` checkout here and are unrelated to this change:
`bar-icon-geometry`, `config`, `snapper`, `unowned-system-paths`.

## Visual verification

Verified in the running UI on the card as it stands on `quattro`, i.e.
alongside the hover-revealed close button: buttons sit bottom-right, the close
glyph top-right, no overlap or clipping.

End-to-end invocation confirmed two ways:

- `notify-send -u critical -A "delete=Delete" -A "read=Mark as read" ...`
  printed `delete` when the button was clicked.
- A live Facebook web notification in Chromium: its "Settings" button opened
  Chromium's per-site notification settings, i.e. the action reached the
  sender.

Screenshots (before / after / on the `quattro` card) are attached below.
<img width="410" height="120" alt="issue-before" src="https://github.com/user-attachments/assets/803052a2-ec87-4585-a8b7-17a03011ca26" />
<img width="410" height="120" alt="issue-after" src="https://github.com/user-attachments/assets/71387039-3933-4890-a3e5-6710f8a282da" />
<img width="415" height="130" alt="issue-upstream" src="https://github.com/user-attachments/assets/15ef2bf0-2671-4907-9217-f2c2a5efc885" />
