### PR TITLE
Manual: name the GRUB error Secure Boot causes, and the BIOS clock pitfall

### DIFF
--- a/manual/02-getting-started.md
+++ b/manual/02-getting-started.md
@@ -6,6 +6,10 @@ Omarchy is installed using an ISO. You can choose between a full-disk install, w
 
 _You must turn off Secure Boot and/or TPM in the BIOS. You have to turn these off to be able to install Omarchy. They're Microsoft security schemes meant for Windows and Microsoft-affiliated Linux distributions._
 
+If the boot menu flashes `error: loader/efi/linux.c:grub_arch_efi_linux_boot_image:227: cannot load image.` and `Failed to boot both default and fallback entries.` for a couple of seconds and then drops you straight back to the menu, Secure Boot is still on. It looks like a broken graphics card or a bad USB stick, but it isn't either: go back into the BIOS, set Secure Boot to Disabled, save, and boot the stick again.
+
+While you're in the BIOS, check the date on its home screen. New machines sometimes sit in a box long enough for the clock to arrive years out of date, and a wrong date trips up live installers. Set it to today before you install.
+
 Then answer the configuration questions, and confirm them like this:
 
  ![install-config](images/install-config.webp)

--- a/manual/02-getting-started.md
+++ b/manual/02-getting-started.md
@@ -6,7 +6,7 @@ Omarchy is installed using an ISO. You can choose between a full-disk install, w
 
 _You must turn off Secure Boot and/or TPM in the BIOS. You have to turn these off to be able to install Omarchy. They're Microsoft security schemes meant for Windows and Microsoft-affiliated Linux distributions._
 
-If the boot menu flashes `error: loader/efi/linux.c:grub_arch_efi_linux_boot_image:227: cannot load image.` and `Failed to boot both default and fallback entries.` for a couple of seconds and then drops you straight back to the menu, Secure Boot is still on. It looks like a broken graphics card or a bad USB stick, but it isn't either: go back into the BIOS, set Secure Boot to Disabled, save, and boot the stick again.
+If the boot menu flashes `error: ... cannot load image.` and `Failed to boot both default and fallback entries.` for a couple of seconds and then drops you straight back to the menu, Secure Boot is still on. It looks like a broken graphics card or a bad USB stick, but it isn't either: go back into the BIOS, set Secure Boot to Disabled, save, and boot the stick again.
 
 While you're in the BIOS, check the date on its home screen. New machines sometimes sit in a box long enough for the clock to arrive years out of date, and a wrong date trips up live installers. Set it to today before you install.
 


### PR DESCRIPTION
`manual/02-getting-started.md` already tells people to turn Secure Boot off. It doesn't tell them what it looks like when they didn't.

On an MSI B550M PRO-VDH WiFi (Ryzen 7 5700X, GTX 1050 Ti) booting the Omarchy 4.0.2 ISO with Secure Boot enabled, the GRUB entry prints this for about two seconds and then drops back to the menu:

```
error: loader/efi/linux.c:grub_arch_efi_linux_boot_image:227: cannot load image.
Failed to boot both default and fallback entries.
Press any key to continue...
```

Nobody reads that as "Secure Boot" — it reads as a graphics card GRUB can't drive, or a USB stick that didn't write cleanly. By the time you see it you've stopped reading the manual, so the error text has to be *in* the manual to be findable: searching the exact string is what a stuck person does next.

The same board also arrived with its BIOS clock set to 2020-01-01, which had already broken Ubuntu's live installer. Common enough on new boards to be worth one sentence while the reader is in the BIOS anyway.

## What changed

Two paragraphs right after the existing italicised Secure Boot / TPM warning:

- One quoting the GRUB error, saying plainly that it means Secure Boot is still on and that it's neither the graphics card nor the USB stick, with the fix (BIOS → Secure Boot → Disabled → save → boot again).
- One line to check the date on the BIOS home screen while you're there.

The `:227:` line number is GRUB-build-specific, so the quoted string in the manual is trimmed to the stable part (`cannot load image.` / `Failed to boot both default and fallback entries.`) rather than the full verbatim line.

End-user voice, no internals, full lines with no hard wrapping, per `AGENTS.md`.

## Verification

Documentation only, no code. Reviewed as markdown source against the surrounding prose and the repo's style rules; not rendered on omarchy.org.
