### PR TITLE
Add an embedded dev-env for ESP32 and Arduino boards

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -2,12 +2,12 @@
 
 # omarchy:summary=Install a supported development environment
 # omarchy:name=dev-env
-# omarchy:args=<ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>
+# omarchy:args=<ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala|embedded>
 # omarchy:examples=omarchy install dev-env ruby | omarchy install dev-env node
 # omarchy:requires-sudo=true
 
 if [[ -z $1 ]]; then
-  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala>" >&2
+  echo "Usage: omarchy-install-dev-env <ruby|node|bun|deno|go|laravel|symfony|php|python|elixir|phoenix|rust|java|zig|ocaml|dotnet|clojure|scala|embedded>" >&2
   exit 1
 fi
 
@@ -48,6 +48,46 @@ install_php() {
 install_node() {
   echo -e "Installing Node.js...\n"
   mise use --global node
+}
+
+install_embedded() {
+  echo -e "Installing embedded toolchain...\n"
+  omarchy-pkg-add arduino-cli platformio-core esptool avrdude picocom
+
+  # Serial devices belong to uucp on Arch, so without membership every upload
+  # and every serial monitor needs sudo. The group only takes effect on a new
+  # login, which is why this reports rather than silently succeeding.
+  if id -nG "$USER" | grep -qw uucp; then
+    echo "Already in the uucp group."
+  else
+    sudo usermod -aG uucp "$USER"
+    echo "Added $USER to the uucp group — log out and back in for it to apply."
+  fi
+
+  # ModemManager probes new serial devices on plug-in and holds them open long
+  # enough to break the first upload. Development boards are never modems, so
+  # they are marked to be left alone.
+  sudo tee /etc/udev/rules.d/70-omarchy-embedded.rules >/dev/null <<'RULES'
+# Development boards: readable by uucp, and never probed by ModemManager.
+# CH340/CH341 — the USB-serial chip on most low-cost ESP32 and Arduino clones
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", GROUP="uucp", MODE="0660", ENV{ID_MM_DEVICE_IGNORE}="1"
+# CP210x — Silicon Labs, used by most ESP32 DevKit boards
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", GROUP="uucp", MODE="0660", ENV{ID_MM_DEVICE_IGNORE}="1"
+# FTDI — official Arduino and many debug probes
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", GROUP="uucp", MODE="0660", ENV{ID_MM_DEVICE_IGNORE}="1"
+# Espressif and Arduino native USB (ESP32-S2/S3/C3, Leonardo, Micro)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="303a", GROUP="uucp", MODE="0660", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", GROUP="uucp", MODE="0660", ENV{ID_MM_DEVICE_IGNORE}="1"
+RULES
+
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --subsystem-match=tty
+
+  arduino-cli config init --overwrite >/dev/null 2>&1
+  arduino-cli core update-index >/dev/null 2>&1
+
+  echo ""
+  echo "Boards appear as /dev/ttyUSB* or /dev/ttyACM*; 'arduino-cli board list' names them."
 }
 
 case "$1" in
@@ -151,5 +191,8 @@ scala)
   mise use --global java@latest
   mise use --global scala@latest
   mise use --global scala-cli@latest
+  ;;
+embedded)
+  install_embedded
   ;;
 esac

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -268,6 +268,7 @@
   "install.development.ocaml": {"icon":"","label":"OCaml","disabled":"[[ -d $HOME/.opam ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env ocaml'"},
   "install.development.clojure": {"icon":"","label":"Clojure","disabled":"[[ -d $HOME/.local/share/mise/installs/clojure ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env clojure'"},
   "install.development.scala": {"icon":"","label":"Scala","disabled":"[[ -d $HOME/.local/share/mise/installs/scala ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env scala'"},
+  "install.development.embedded": {"icon":"","label":"Embedded (ESP32/Arduino)","disabled":"omarchy-pkg-present arduino-cli","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env embedded'"},
   "install.development.javascript.node": {"icon":"","label":"Node.js","disabled":"[[ -d $HOME/.local/share/mise/installs/node ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env node'"},
   "install.development.javascript.bun": {"icon":"","label":"Bun","disabled":"[[ -d $HOME/.local/share/mise/installs/bun ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env bun'"},
   "install.development.javascript.deno": {"icon":"","label":"Deno","disabled":"[[ -d $HOME/.local/share/mise/installs/deno ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env deno'"},

--- a/manual/18-development-tools.md
+++ b/manual/18-development-tools.md
@@ -10,7 +10,7 @@ You can set the system-wide default editor under `Setup > Defaults > Editor`.
 
 ## Environment
 
-Omarchy supports setting up a whole host of development environments through the _Install > Development_ section of the Omarchy Menu (`Super + Space`). You'll of course find _Ruby on Rails_, but also all three major runtimes for JavaScript (Node.js, Bun, Deno), as well as popular PHP frameworks like Laravel and Symfony. Oh, and there's Go, Rust, Python, Java, Elixir (with Phoenix), .NET, OCaml, Zig, Clojure, and Scala too. It's a very broad selection!
+Omarchy supports setting up a whole host of development environments through the _Install > Development_ section of the Omarchy Menu (`Super + Space`). You'll of course find _Ruby on Rails_, but also all three major runtimes for JavaScript (Node.js, Bun, Deno), as well as popular PHP frameworks like Laravel and Symfony. Oh, and there's Go, Rust, Python, Java, Elixir (with Phoenix), .NET, OCaml, Zig, Clojure, and Scala too. It's a very broad selection! There's an _Embedded_ environment as well, for ESP32 and Arduino boards: it installs arduino-cli, PlatformIO, esptool, avrdude, and picocom, and sets up the serial access a freshly plugged board needs.
 
 The majority of these environments are managed by [Mise](https://mise.jdx.dev/). It's a tool that lets you install and run multiple versions of a programming language on the same machine. It's like rbenv or rvm for Ruby or virtualenv for Python, but it works for a bunch of different environments.
 


### PR DESCRIPTION
`omarchy install dev-env embedded` installs `arduino-cli`, `platformio-core`, `esptool`, `avrdude`, and `picocom`, then clears the two things that otherwise stand between a freshly plugged board and a working upload.

## Why

The 18 existing dev-envs each absorb their own environment papercuts — Composer on PATH, PHP extensions enabled, opam initialised. Hardware has none, and it has two that bite everyone on the first board:

**Serial devices belong to `uucp` on Arch.** Without group membership, every upload and every serial monitor needs sudo. Almost all advice online names `dialout`, which does not exist on Arch, so the search usually costs more time than the fix.

**ModemManager probes new serial devices on plug-in** and holds them open long enough to break the first upload. The symptom is a failed flash that succeeds on the second try, which reads as flaky hardware rather than a fixable cause.

A udev rule marks the common development-board vendors so ModemManager leaves them alone and the node lands in `uucp`:

| Vendor ID | Chip | Found on |
|---|---|---|
| `1a86` | CH340/CH341 | most low-cost ESP32 and Arduino clones |
| `10c4` | CP210x | ESP32 DevKit |
| `0403` | FTDI | official Arduino, many debug probes |
| `303a` | Espressif native USB | ESP32-S2/S3/C3 |
| `2341` | Arduino native USB | Leonardo, Micro |

## Notes

- Every package comes from the official repositories; no AUR.
- Group membership only applies on a new login, so the script reports that rather than appearing to have failed.
- Follows the group-membership pattern already used by `omarchy-install-gaming-xbox-controllers`.
- `test/cli` passes (116 tests).

Tested on Arch with the toolchain install and udev reload; I did not have a board on hand to confirm the end-to-end upload, so a second pair of eyes on the vendor list would be welcome.