### PR TITLE
Feature: Allow user to create floating bar by adding support for custom margin and bar radius.

### DIFF
--- a/bin/omarchy-bar-text-color
+++ b/bin/omarchy-bar-text-color
@@ -11,6 +11,10 @@ text_color=${3:-}
 background_color=${4:-}
 background_path=""
 screen_size=""
+inset_top=0
+inset_right=0
+inset_bottom=0
+inset_left=0
 
 shift 4 2>/dev/null || true
 while (($# > 0)); do
@@ -21,6 +25,10 @@ while (($# > 0)); do
     ;;
   --screen)
     screen_size=${2:-}
+    shift 2
+    ;;
+  --inset)
+    read -r inset_top inset_right inset_bottom inset_left <<<"${2:-}"
     shift 2
     ;;
   *)
@@ -72,6 +80,9 @@ valid_hex "$text_color" || fallback
 valid_hex "$background_color" || fallback
 [[ $position =~ ^(top|bottom|left|right)$ ]] || fallback
 [[ $bar_size =~ ^[0-9]+$ ]] || fallback
+for inset in "$inset_top" "$inset_right" "$inset_bottom" "$inset_left"; do
+  [[ $inset =~ ^[0-9]+$ ]] || fallback
+done
 omarchy-cmd-present magick || fallback
 
 if [[ -z $background_path ]]; then
@@ -90,22 +101,31 @@ screen_width=${BASH_REMATCH[1]}
 screen_height=${BASH_REMATCH[2]}
 ((screen_width > 0 && screen_height > 0 && bar_size > 0)) || fallback
 
+# A detached bar is inset on every edge it touches, so the strip it actually
+# covers starts that far in on the axes it spans and that far short of the far
+# edge it is anchored to. At all-zero insets this is the flush bar's strip.
 case "$position" in
 top)
-  crop="${screen_width}x${bar_size}+0+0"
+  crop_width=$((screen_width - inset_left - inset_right))
+  ((crop_width > 0)) || fallback
+  crop="${crop_width}x${bar_size}+${inset_left}+${inset_top}"
   ;;
 bottom)
-  crop_y=$((screen_height - bar_size))
-  ((crop_y >= 0)) || fallback
-  crop="${screen_width}x${bar_size}+0+${crop_y}"
+  crop_width=$((screen_width - inset_left - inset_right))
+  crop_y=$((screen_height - bar_size - inset_bottom))
+  ((crop_width > 0 && crop_y >= 0)) || fallback
+  crop="${crop_width}x${bar_size}+${inset_left}+${crop_y}"
   ;;
 left)
-  crop="${bar_size}x${screen_height}+0+0"
+  crop_height=$((screen_height - inset_top - inset_bottom))
+  ((crop_height > 0)) || fallback
+  crop="${bar_size}x${crop_height}+${inset_left}+${inset_top}"
   ;;
 right)
-  crop_x=$((screen_width - bar_size))
-  ((crop_x >= 0)) || fallback
-  crop="${bar_size}x${screen_height}+${crop_x}+0"
+  crop_height=$((screen_height - inset_top - inset_bottom))
+  crop_x=$((screen_width - bar_size - inset_right))
+  ((crop_height > 0 && crop_x >= 0)) || fallback
+  crop="${bar_size}x${crop_height}+${crop_x}+${inset_top}"
   ;;
 esac
 

--- a/default/themed/shell.toml.tpl
+++ b/default/themed/shell.toml.tpl
@@ -15,6 +15,12 @@ active           = "{{ red }}"
 scale-with-font  = true
 size-horizontal  = 26
 size-vertical    = 28
+# Detach the bar from the screen. margin is the gap left on every edge the bar
+# touches, reserved along with the bar so windows still tile clear of it, and
+# radius rounds the bar's corners. Both are 0 by default — flush against the
+# edge, square corners — and both follow scale-with-font.
+margin           = 0
+radius           = 0
 
 [hyprland]
 # Shared Hyprland-derived border tokens. Surface sections reference these so

--- a/default/themed/shell.toml.tpl
+++ b/default/themed/shell.toml.tpl
@@ -15,10 +15,8 @@ active           = "{{ red }}"
 scale-with-font  = true
 size-horizontal  = 26
 size-vertical    = 28
-# Detach the bar from the screen. margin is the gap left on every edge the bar
-# touches, reserved along with the bar so windows still tile clear of it, and
-# radius rounds the bar's corners. Both are 0 by default — flush against the
-# edge, square corners — and both follow scale-with-font.
+# Gap between the bar and the edge. Takes one CSS-style scalar/list:
+# N, "Y X", "T X B", or "T R B L".
 margin           = 0
 radius           = 0
 

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -368,6 +368,18 @@ size-vertical   = 28   # left/right bar width at base-size 12
 
 Set `scale-with-font = false` to keep those bar sizes as fixed pixels.
 
+### Detached bar
+
+`[bar] margin` and `radius` lift the bar off its screen edge. `margin` is the gap left on every edge the bar touches — the one it is anchored to and the two it spans — and `radius` rounds the corners of the bar surface:
+
+```toml
+[bar]
+margin = 10   # gap between the bar and the screen edges; 0 = flush
+radius = 12   # corner rounding of the bar surface; 0 = square
+```
+
+Both default to `0`, a bar sitting flush against its edge with square corners, and both follow `scale-with-font` like the sizes above. The gap is reserved along with the bar itself, so maximized and tiled windows stop clear of it instead of sliding underneath. Auto-hide still parks the bar fully off screen, clearing the margin as well as the bar.
+
 ## Custom bar modules
 
 If a full plugin is overkill, declare a one-off module inline in

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -368,14 +368,23 @@ size-vertical   = 28   # left/right bar width at base-size 12
 
 Set `scale-with-font = false` to keep those bar sizes as fixed pixels.
 
-### Detached bar
+### Floating bar
 
-`[bar] margin` and `radius` lift the bar off its screen edge. `margin` is the gap left on every edge the bar touches — the one it is anchored to and the two it spans — and `radius` rounds the corners of the bar surface:
+`[bar] margin` lift the bar off its screen edge. `margin` is the gap between the bar and every edge the bar touches — the one it is anchored to and the two it spans
+
+[bar] `radius` rounds the corners of the bar surface
 
 ```toml
 [bar]
 margin = 10   # gap between the bar and the screen edges; 0 = flush
 radius = 12   # corner rounding of the bar surface; 0 = square
+```
+
+`margin` accepts the same CSS-style list as the border widths — `N`, `"Y X"`, `"T X B"`, or `"T R B L"` — so the gap can differ per edge. A bar set further off the sides than off the edge it hangs from:
+
+```toml
+[bar]
+margin = "4 8"   # 4 from the anchored edge, 8 at the two it spans
 ```
 
 Both default to `0`, a bar sitting flush against its edge with square corners, and both follow `scale-with-font` like the sizes above. The gap is reserved along with the bar itself, so maximized and tiled windows stop clear of it instead of sliding underneath. Auto-hide still parks the bar fully off screen, clearing the margin as well as the bar.

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -301,6 +301,17 @@ QtObject {
     return Math.max(1, Math.round(base))
   }
 
+  // Bar tokens whose resting value is zero: a bar flush against its edge with
+  // square corners. barToken() floors at 1 and reads 0 as "unset", so margin
+  // and radius need a reader that keeps a deliberate 0.
+  function barInsetToken(key, fallback) {
+    var v = barOverrides[key]
+    var n = Number(v)
+    var base = (isFinite(n) && n >= 0) ? n : fallback
+    if (barScaleWithFont) base *= fontScale
+    return Math.max(0, Math.round(base))
+  }
+
   function boolToken(value, fallback) {
     if (value === undefined || value === null) return fallback
     var s = String(value).replace(/^\s+|\s+$/g, "").toLowerCase()
@@ -341,6 +352,11 @@ QtObject {
   readonly property QtObject bar: QtObject {
     readonly property int sizeHorizontal: root.barToken("size-horizontal", 26)
     readonly property int sizeVertical:   root.barToken("size-vertical",   28)
+    // Gap between the bar and the screen edges it would otherwise sit flush
+    // against, and the corner rounding of the bar surface. Both default to 0,
+    // which is the flush, square bar.
+    readonly property int margin:         root.barInsetToken("margin",     0)
+    readonly property int radius:         root.barInsetToken("radius",     0)
     readonly property int iconSlot:       root.barToken("icon-slot",       27)
     readonly property int iconCanvas:     root.barToken("icon-canvas",     16)
     readonly property int iconFont:       root.barToken("icon-font",       13)
@@ -405,7 +421,8 @@ QtObject {
       } else if (section === "bar") {
         if (key === "scale-with-font") {
           nextBarScaleWithFont = boolToken(raw, nextBarScaleWithFont)
-        } else if (key === "size-horizontal" || key === "size-vertical") {
+        } else if (key === "size-horizontal" || key === "size-vertical"
+          || key === "margin" || key === "radius") {
           var b = parseInt(raw, 10)
           if (isFinite(b)) barOut[key] = b
         }

--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -2,6 +2,7 @@ pragma Singleton
 import QtQuick
 import Quickshell
 import Quickshell.Io
+import "BorderGeometry.js" as Geometry
 
 // Shared structural style tokens for the shell. Color is the palette
 // singleton; Style holds everything else themes can influence — corner
@@ -312,6 +313,20 @@ QtObject {
     return Math.max(0, Math.round(base))
   }
 
+  // margin takes the same CSS-style list as the border widths — N, "Y X",
+  // "T X B", or "T R B L" — because a bar is usually set further off the edges
+  // it spans than off the one it hangs from.
+  function barMarginToken() {
+    var widths = Geometry.parseWidthSpec(barOverrides["margin"], 0)
+    var scale = barScaleWithFont ? fontScale : 1
+    return {
+      top: Math.max(0, Math.round(widths.top * scale)),
+      right: Math.max(0, Math.round(widths.right * scale)),
+      bottom: Math.max(0, Math.round(widths.bottom * scale)),
+      left: Math.max(0, Math.round(widths.left * scale))
+    }
+  }
+
   function boolToken(value, fallback) {
     if (value === undefined || value === null) return fallback
     var s = String(value).replace(/^\s+|\s+$/g, "").toLowerCase()
@@ -352,10 +367,7 @@ QtObject {
   readonly property QtObject bar: QtObject {
     readonly property int sizeHorizontal: root.barToken("size-horizontal", 26)
     readonly property int sizeVertical:   root.barToken("size-vertical",   28)
-    // Gap between the bar and the screen edges it would otherwise sit flush
-    // against, and the corner rounding of the bar surface. Both default to 0,
-    // which is the flush, square bar.
-    readonly property int margin:         root.barInsetToken("margin",     0)
+    readonly property var margins:        root.barMarginToken()
     readonly property int radius:         root.barInsetToken("radius",     0)
     readonly property int iconSlot:       root.barToken("icon-slot",       27)
     readonly property int iconCanvas:     root.barToken("icon-canvas",     16)
@@ -421,8 +433,11 @@ QtObject {
       } else if (section === "bar") {
         if (key === "scale-with-font") {
           nextBarScaleWithFont = boolToken(raw, nextBarScaleWithFont)
+        } else if (key === "margin") {
+          // Kept verbatim: the width spec is a list as often as a number.
+          barOut[key] = raw
         } else if (key === "size-horizontal" || key === "size-vertical"
-          || key === "margin" || key === "radius") {
+          || key === "radius") {
           var b = parseInt(raw, 10)
           if (isFinite(b)) barOut[key] = b
         }

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -554,6 +554,11 @@ Item {
 
   readonly property bool vertical: position === "left" || position === "right"
   readonly property int barSize: vertical ? Style.bar.sizeVertical : Style.bar.sizeHorizontal
+  // A detached bar floats barMargin away from every screen edge it touches and
+  // rounds its corners by barRadius. Both are 0 by default, which anchors the
+  // bar flush against its edge with square corners.
+  readonly property int barMargin: Style.bar.margin
+  readonly property int barRadius: Style.bar.radius
 
   function normalizePosition(value) {
     return BarModel.normalizePosition(value)
@@ -1247,11 +1252,16 @@ Item {
       window: barWindow
     }
 
+    // Parking a detached bar has to clear its margin as well as its own size,
+    // or the gap leaves a sliver of it on screen.
+    readonly property int parkedMargin: -(root.barSize + root.barMargin)
+    readonly property int edgeMargin: root.barHidden ? parkedMargin : root.barMargin
+
     margins {
-      top: root.barHidden && root.position === "top" ? -root.barSize : 0
-      bottom: root.barHidden && root.position === "bottom" ? -root.barSize : 0
-      left: root.barHidden && root.position === "left" ? -root.barSize : 0
-      right: root.barHidden && root.position === "right" ? -root.barSize : 0
+      top: root.position === "top" ? edgeMargin : (root.vertical ? root.barMargin : 0)
+      bottom: root.position === "bottom" ? edgeMargin : (root.vertical ? root.barMargin : 0)
+      left: root.position === "left" ? edgeMargin : (root.vertical ? 0 : root.barMargin)
+      right: root.position === "right" ? edgeMargin : (root.vertical ? 0 : root.barMargin)
     }
 
     anchors {
@@ -1263,10 +1273,21 @@ Item {
 
     implicitWidth: root.vertical ? root.barSize : 0
     implicitHeight: root.vertical ? 0 : root.barSize
-    color: root.transparent ? "transparent" : root.background
+    // The surface itself stays transparent so the rounded background below can
+    // paint the corners; a window color would square them off again.
+    color: "transparent"
     surfaceFormat.opaque: false
     WlrLayershell.namespace: "omarchy-bar"
     WlrLayershell.layer: WlrLayer.Top
+
+    // Declared before the loader so it paints behind the widgets. Carries the
+    // bar's background instead of the window, which is what lets barRadius
+    // round the corners.
+    Rectangle {
+      anchors.fill: parent
+      color: root.transparent ? "transparent" : root.background
+      radius: root.barRadius
+    }
 
     Loader {
       anchors.fill: parent

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -430,10 +430,17 @@ Item {
     var y = scenePoint ? scenePoint.y : 0
     if (!window || !window.screen) return { x: x, y: y }
 
-    if (root.position === "bottom")
-      y += Math.max(0, window.screen.height - window.height)
-    else if (root.position === "right")
-      x += Math.max(0, window.screen.width - window.width)
+    // A detached bar sits inside every edge it touches, so its origin is the
+    // gap itself on the axes it spans, and the far edge less its own size and
+    // gap on the one it is anchored to. At margin 0 this is the flush bar's
+    // plain screen-corner offset.
+    var margins = root.barMargins
+    x += root.position === "right"
+      ? Math.max(0, window.screen.width - window.width - margins.right)
+      : margins.left
+    y += root.position === "bottom"
+      ? Math.max(0, window.screen.height - window.height - margins.bottom)
+      : margins.top
 
     return { x: x, y: y }
   }
@@ -554,10 +561,11 @@ Item {
 
   readonly property bool vertical: position === "left" || position === "right"
   readonly property int barSize: vertical ? Style.bar.sizeVertical : Style.bar.sizeHorizontal
-  // A detached bar floats barMargin away from every screen edge it touches and
-  // rounds its corners by barRadius. Both are 0 by default, which anchors the
-  // bar flush against its edge with square corners.
-  readonly property int barMargin: Style.bar.margin
+  // A detached bar floats barMargins away from every screen edge it touches
+  // and rounds its corners by barRadius. Every side is 0 by default, which
+  // anchors the bar flush against its edge with square corners. The keys are
+  // the position names, so barMargins[position] is the anchored edge's gap.
+  readonly property var barMargins: Style.bar.margins
   readonly property int barRadius: Style.bar.radius
 
   function normalizePosition(value) {
@@ -1070,13 +1078,20 @@ Item {
       root.position,
       String(root.barSize),
       colorHex(root.themeForeground),
-      colorHex(root.themeContrastForeground)
+      colorHex(root.themeContrastForeground),
+      // A detached bar no longer covers the strip at the screen edge, so the
+      // sample has to move in with it or the contrast is picked against pixels
+      // the bar does not sit on.
+      "--inset",
+      [root.barMargins.top, root.barMargins.right,
+       root.barMargins.bottom, root.barMargins.left].join(" ")
     ]
     transparentForegroundProc.running = true
   }
 
   onRequestedTransparentChanged: scheduleTransparentForegroundRefresh()
   onPositionChanged: scheduleTransparentForegroundRefresh()
+  onBarMarginsChanged: scheduleTransparentForegroundRefresh()
   onThemeForegroundChanged: scheduleTransparentForegroundRefresh()
   onThemeContrastForegroundChanged: scheduleTransparentForegroundRefresh()
 
@@ -1254,14 +1269,18 @@ Item {
 
     // Parking a detached bar has to clear its margin as well as its own size,
     // or the gap leaves a sliver of it on screen.
-    readonly property int parkedMargin: -(root.barSize + root.barMargin)
-    readonly property int edgeMargin: root.barHidden ? parkedMargin : root.barMargin
+    readonly property int anchoredMargin: root.barMargins[root.position]
+    readonly property int parkedMargin: -(root.barSize + anchoredMargin)
+    readonly property int edgeMargin: root.barHidden ? parkedMargin : anchoredMargin
 
+    // Only the edges the bar actually touches take a gap: the one it is
+    // anchored to, and the two it spans. The remaining side is the bar's own
+    // far face, which no margin applies to.
     margins {
-      top: root.position === "top" ? edgeMargin : (root.vertical ? root.barMargin : 0)
-      bottom: root.position === "bottom" ? edgeMargin : (root.vertical ? root.barMargin : 0)
-      left: root.position === "left" ? edgeMargin : (root.vertical ? 0 : root.barMargin)
-      right: root.position === "right" ? edgeMargin : (root.vertical ? 0 : root.barMargin)
+      top: root.position === "top" ? edgeMargin : (root.vertical ? root.barMargins.top : 0)
+      bottom: root.position === "bottom" ? edgeMargin : (root.vertical ? root.barMargins.bottom : 0)
+      left: root.position === "left" ? edgeMargin : (root.vertical ? 0 : root.barMargins.left)
+      right: root.position === "right" ? edgeMargin : (root.vertical ? 0 : root.barMargins.right)
     }
 
     anchors {

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -56,9 +56,19 @@ assert(
   /exclusionMode: root\.barHidden \? ExclusionMode\.Ignore : ExclusionMode\.Auto/.test(barSource),
   'a hidden bar reserves no space for itself'
 )
+// A detached bar sits barMargin off its edge, so parking has to clear the gap
+// as well as the bar or the margin leaves a sliver of it on screen.
+assert(
+  /readonly property int parkedMargin: -\(root\.barSize \+ root\.barMargin\)/.test(barSource),
+  'parking a hidden bar clears its margin as well as its own size'
+)
+assert(
+  /readonly property int edgeMargin: root\.barHidden \? parkedMargin : root\.barMargin/.test(barSource),
+  'the anchored edge parks when hidden and carries the margin when shown'
+)
 for (const edge of ['top', 'bottom', 'left', 'right']) {
   assert(
-    new RegExp(`${edge}: root\\.barHidden && root\\.position === "${edge}" \\? -root\\.barSize : 0`).test(barSource),
+    new RegExp(`${edge}: root\\.position === "${edge}" \\? edgeMargin :`).test(barSource),
     `a hidden bar parks past the ${edge} edge`
   )
 }

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -59,11 +59,11 @@ assert(
 // A detached bar sits barMargin off its edge, so parking has to clear the gap
 // as well as the bar or the margin leaves a sliver of it on screen.
 assert(
-  /readonly property int parkedMargin: -\(root\.barSize \+ root\.barMargin\)/.test(barSource),
+  /readonly property int parkedMargin: -\(root\.barSize \+ anchoredMargin\)/.test(barSource),
   'parking a hidden bar clears its margin as well as its own size'
 )
 assert(
-  /readonly property int edgeMargin: root\.barHidden \? parkedMargin : root\.barMargin/.test(barSource),
+  /readonly property int edgeMargin: root\.barHidden \? parkedMargin : anchoredMargin/.test(barSource),
   'the anchored edge parks when hidden and carries the margin when shown'
 )
 for (const edge of ['top', 'bottom', 'left', 'right']) {
@@ -72,6 +72,61 @@ for (const edge of ['top', 'bottom', 'left', 'right']) {
     `a hidden bar parks past the ${edge} edge`
   )
 }
+
+// The gap is a width spec, not a scalar, so a bar can sit further off the edges
+// it spans than off the one it hangs from. The anchored edge reads out of the
+// same object by position name.
+const styleSource = fs.readFileSync(root + '/shell/Commons/Style.qml', 'utf8')
+assert(
+  /Geometry\.parseWidthSpec\(barOverrides\["margin"\], 0\)/.test(styleSource),
+  'the bar margin is parsed as a per-edge width spec'
+)
+assert(
+  /barOut\[key\] = raw/.test(styleSource),
+  'the bar margin reaches the parser unparsed, so a list survives'
+)
+assert(
+  /readonly property int anchoredMargin: root\.barMargins\[root\.position\]/.test(barSource),
+  'the anchored edge takes its own side of the margin'
+)
+// The drag overlays are full-screen, so a bar-local point becomes a screen point
+// by adding the bar window's origin. A detached bar's origin is the gap itself on the
+// axes it spans, and the far edge less its own size and gap on the one it is
+// anchored to; without that the drop marker and the drag ghost sit a margin away
+// from the cursor.
+const windowScreenPoint = barSource.slice(
+  barSource.indexOf('function windowScreenPoint'),
+  barSource.indexOf('function barDragScreenPoint')
+)
+assert(
+  /var margins = root\.barMargins/.test(windowScreenPoint),
+  'mapping a bar point to the screen accounts for a detached bar'
+)
+assert(
+  /window\.screen\.height - window\.height - margins\.bottom/.test(windowScreenPoint),
+  'a detached bottom bar maps from its own top edge, not the screen edge'
+)
+assert(
+  /window\.screen\.width - window\.width - margins\.right/.test(windowScreenPoint),
+  'a detached right bar maps from its own left edge, not the screen edge'
+)
+
+// omarchy-bar-text-color samples the wallpaper under the bar to pick a legible
+// transparent-mode foreground. It crops from the screen edge unless told
+// otherwise, so a detached bar has to hand it the gap or the contrast is
+// decided against pixels the bar does not cover.
+const transparentForeground = barSource.slice(
+  barSource.indexOf('function refreshTransparentForeground'),
+  barSource.indexOf('onRequestedTransparentChanged')
+)
+assert(
+  /"--inset",\s*\n\s*\[root\.barMargins\.top/.test(transparentForeground),
+  'transparent bar text samples the strip a detached bar covers'
+)
+assert(
+  /onBarMarginsChanged: scheduleTransparentForegroundRefresh\(\)/.test(barSource),
+  'changing the bar margin re-samples the transparent bar text color'
+)
 
 // The center section declares two arrangements and shows one; the hidden one
 // must not build its modules or every center widget exists twice.

--- a/test/shell.d/bar-text-color-test.sh
+++ b/test/shell.d/bar-text-color-test.sh
@@ -14,9 +14,12 @@ export PATH="$ROOT/bin:$PATH"
 
 light_top="$TMPDIR/light-top.png"
 dark_top="$TMPDIR/dark-top.png"
+dark_band="$TMPDIR/dark-band.png"
 
 magick -size 100x100 xc:'#202020' -fill '#f5f5f5' -draw 'rectangle 0,0 99,19' "$light_top"
 magick -size 100x100 xc:'#f5f5f5' -fill '#202020' -draw 'rectangle 0,0 99,19' "$dark_top"
+# Light everywhere but the band a bottom bar covers once it is inset by 20.
+magick -size 100x100 xc:'#f5f5f5' -fill '#202020' -draw 'rectangle 0,60 99,79' "$dark_band"
 
 result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$light_top" --screen 100x100)
 [[ $result == "#101010" ]] || fail "transparent bar text switches to background color on light wallpaper" "expected #101010, got $result"
@@ -41,3 +44,31 @@ ffmpeg -y -f lavfi -i "testsrc=size=640x360:rate=10:duration=2" \
 result=$(HOME="$TMPDIR" omarchy-bar-text-color top 40 '#ffffff' '#101010' --background "$light_top_video" --screen 640x360)
 [[ $result == "#101010" ]] || fail "transparent bar text samples one frame of a video wallpaper" "expected #101010, got $result"
 pass "transparent bar text samples one frame of a video wallpaper"
+
+# A detached bar covers a strip the screen edge does not. Same wallpaper, same
+# bar size: only the offset moves the sample off the light top band and onto the
+# dark one below it, which has to flip the answer.
+result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$light_top" --screen 100x100 --inset "20 0 0 0")
+[[ $result == "#ffffff" ]] || fail "a detached top bar samples the strip it covers" "expected #ffffff, got $result"
+pass "a detached top bar samples the strip it covers"
+
+result=$(HOME="$TMPDIR" omarchy-bar-text-color bottom 20 '#ffffff' '#101010' --background "$dark_band" --screen 100x100)
+[[ $result == "#101010" ]] || fail "a flush bottom bar samples the screen edge" "expected #101010, got $result"
+pass "a flush bottom bar samples the screen edge"
+
+result=$(HOME="$TMPDIR" omarchy-bar-text-color bottom 20 '#ffffff' '#101010' --background "$dark_band" --screen 100x100 --inset "0 0 20 0")
+[[ $result == "#ffffff" ]] || fail "a detached bottom bar samples back from its own edge" "expected #ffffff, got $result"
+pass "a detached bottom bar samples back from its own edge"
+
+# The gap on the axis the bar spans moves the sample sideways, which is the half
+# of a per-edge inset the vertical cases above cannot show.
+split="$TMPDIR/split.png"
+magick -size 100x100 xc:'#f5f5f5' -fill '#202020' -draw 'rectangle 0,0 49,99' "$split"
+
+result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$split" --screen 100x100 --inset "0 0 0 50")
+[[ $result == "#101010" ]] || fail "a bar inset from the left samples past the dark half" "expected #101010, got $result"
+pass "a bar inset from the left samples past the dark half"
+
+result=$(HOME="$TMPDIR" omarchy-bar-text-color top 20 '#ffffff' '#101010' --background "$split" --screen 100x100 --inset "0 50 0 0")
+[[ $result == "#ffffff" ]] || fail "a bar inset from the right stops before the light half" "expected #ffffff, got $result"
+pass "a bar inset from the right stops before the light half"


### PR DESCRIPTION
Allow user to customize the emplacement of the bar without having to fork it. This PR is an iteration over #8975 

## What you get

`[bar] margin` and `radius` in `shell.toml`. `margin` takes the same CSS-style list the border widths already take.

```toml
[bar]
margin = "4 8"   # 4 from the anchored edge, 8 at the two it spans
radius = 16
```

Both default to `0` to replicate current state.

## What changed

- **`Style.qml`** — adds the `margin` and `radius` tokens; `margin` is read through `Geometry.parseWidthSpec`, the width spec the border widths already use, so there is no new vocabulary.
- **`Bar.qml`** — the surface carries the gap on each edge it touches and paints its background in a rounded `Rectangle` rather than the window clear colour, which is what lets a radius round it. Hiding parks by the bar's size *plus* the anchored edge's gap, so no sliver is left on screen.
- **`windowScreenPoint()`** — maps drag points from the bar's own origin. It assumed that origin was the screen corner, which left the drop marker and drag ghost a margin away from the cursor and handed `nearestScreenEdge()` a skewed point.
- **`omarchy-bar-text-color`** — takes an `--inset`. It crops the wallpaper at the screen edge to choose a legible transparent-mode foreground, and that is a strip a detached bar no longer covers.

Result:
<img width="1920" height="1080" alt="screenshot-2026-09-01_21-39-59" src="https://github.com/user-attachments/assets/34ed7c88-1186-464c-b06d-d213e37fab35" />
