### PR TITLE
Add Setup Wizard for NVIDIA DisplayPort 1.4 EDID Fix

### DIFF
--- a/bin/omarchy-setup-nvidia-dp-edid
+++ b/bin/omarchy-setup-nvidia-dp-edid
@@ -1,0 +1,208 @@
+#!/bin/bash
+
+# omarchy:summary=Force a real EDID for an NVIDIA DisplayPort monitor stuck on a dummy 640x480 mode
+# omarchy:args=[-y]
+# omarchy:examples=omarchy setup nvidia dp-edid | omarchy setup nvidia dp-edid -y
+# omarchy:requires-sudo=true
+
+set -e
+
+ASSUME_YES=0
+
+while (( $# > 0 )); do
+  case "$1" in
+  -y | --yes)
+    ASSUME_YES=1
+    ;;
+  -h | --help)
+    cat <<'EOF'
+Usage: omarchy setup nvidia dp-edid [-y]
+
+NVIDIA drivers on DisplayPort 1.4 can read a 128-byte dummy EDID and fall
+back to a 640x480 mode even when the monitor is capable of much more. The
+monitor's real EDID is only reported when its input is switched to DisplayPort
+1.2, so this wizard walks through capturing that real EDID and forcing it at
+the kernel level with drm.edid_firmware.
+
+What it does:
+
+  1. Finds the connected DisplayPort connector NVIDIA is mis-reading.
+  2. Asks you to switch that monitor's input to DisplayPort 1.2 in its OSD.
+  3. Copies the real 384-byte EDID to /lib/firmware/edid/.
+  4. Uses that EDID from boot: an mkinitcpio FILES entry plus
+     drm.edid_firmware=<connector>:edid/<file>.bin appended to
+     /etc/default/limine, then regenerates the initramfs and Limine config.
+  5. Asks for a reboot.
+
+Passing -y skips the confirmations and applies the fix directly once the
+capture step has run. The monitor must still be switched to DisplayPort 1.2
+before the real EDID can be read, so that step is never skippable.
+EOF
+    exit 0
+    ;;
+  *)
+    echo "omarchy-setup-nvidia-dp-edid: unknown option '$1'. Try --help." >&2
+    exit 2
+    ;;
+  esac
+  shift
+done
+
+# Paths are overridable so tests can run the wizard against a scratch tree.
+drm_path="${OMARCHY_DRM_PATH:-/sys/class/drm}"
+firmware_dir="${OMARCHY_EDID_FIRMWARE_DIR:-/lib/firmware/edid}"
+mkinitcpio_dir="${OMARCHY_MKINITCPIO_DIR:-/etc/mkinitcpio.conf.d}"
+default_limine="${OMARCHY_DEFAULT_LIMINE:-/etc/default/limine}"
+
+# A dummy EDID is the 128-byte, "NVD"-tagged block NVIDIA fabricates on DP1.4.
+# Anything else that comes back from the kernel is a real EDID we can use.
+is_dummy_edid() {
+  local edid="$1"
+
+  [[ -f $edid ]] || return 1
+
+  local size
+  size=$(wc -c <"$edid" 2>/dev/null || echo 0)
+
+  (( size <= 128 )) || return 1
+
+  # "NVD" is the first three bytes of the descriptor at offset 0x10.
+  [[ $(od -An -tx1 -j16 -N3 "$edid" | tr -d ' ') == "4e5644" ]]
+}
+
+# Return the connector name (e.g. "DP-2") for the first connected DisplayPort
+# connector NVIDIA is reading a dummy EDID from.
+find_bad_connector() {
+  local connector edid result=""
+
+  shopt -s nullglob
+  for connector in "$drm_path"/card*-DP-*; do
+    [[ $(<"$connector/status") == "connected" ]] || continue
+    edid="$connector/edid"
+    if is_dummy_edid "$edid"; then
+      result="${connector##*/}"
+      result="${result#card*-}"
+      break
+    fi
+  done
+  shopt -u nullglob
+
+  printf '%s' "$result"
+}
+
+# Resolve the absolute edid sysfs path for a connector name like "DP-2".
+# OMARCHY_EDID_CAPTURE_DRM_PATH lets a caller (or a test) present a different
+# sysfs tree for the post-switch capture than the one used for detection.
+find_connector_edid() {
+  local name="$1"
+  local base="${OMARCHY_EDID_CAPTURE_DRM_PATH:-$drm_path}"
+
+  shopt -s nullglob
+  compgen -G "$base/card*-${name}/edid" | head -1
+  shopt -u nullglob
+}
+
+install_firmware() {
+  local real_edid="$1" firmware="$2"
+
+  sudo mkdir -p "$firmware_dir"
+  sudo cp "$real_edid" "$firmware"
+  sudo chmod 644 "$firmware"
+}
+
+configure_mkinitcpio() {
+  local firmware="$1" dropin="$mkinitcpio_dir/edid-firmware.conf"
+
+  sudo mkdir -p "$mkinitcpio_dir"
+  sudo tee "$dropin" >/dev/null <<EOF
+# Written by omarchy-setup-nvidia-dp-edid so the forced EDID reaches userspace
+# and the kernel at boot. Remove this file to stop bundling it.
+FILES+=($firmware)
+EOF
+}
+
+append_limine_param() {
+  local connector="$1" firmware_name="$2" param
+  param="drm.edid_firmware=${connector}:edid/${firmware_name}"
+
+  if [[ -f $default_limine ]] && grep -q "$param" "$default_limine"; then
+    echo "Already in /etc/default/limine: $param"
+    return 0
+  fi
+
+  sudo sed -i "s|^KERNEL_CMDLINE\[default\]+=.*|& ${param}|" "$default_limine" || true
+
+  if ! grep -q "$param" "$default_limine"; then
+    echo -e "\e[31mCould not append '$param' to KERNEL_CMDLINE[default] in $default_limine.\e[0m" >&2
+    echo "Add it manually, then run: sudo limine-update" >&2
+    return 1
+  fi
+}
+
+connector=$(find_bad_connector)
+
+if [[ -z $connector ]]; then
+  echo -e "\e[31mNo NVIDIA DisplayPort connector is reading a dummy EDID right now.\e[0m" >&2
+  echo "This wizard is for DisplayPort monitors stuck at 640x480 read a fabricated EDID." >&2
+  echo "Nothing to fix if the monitor already has its full mode list." >&2
+  exit 1
+fi
+
+edid=$(find_connector_edid "$connector")
+
+echo -e "\e[32mFound DisplayPort connector $connector reading a 128-byte dummy EDID.\e[0m"
+echo "The monitor's real EDID is only reported when its input is DisplayPort 1.2."
+echo
+
+if (( ASSUME_YES == 0 )); then
+  if ! gum confirm "Switch the monitor's input to DisplayPort 1.2 in its OSD now, then continue?"; then
+    echo "Exiting. Re-run after switching the monitor to DisplayPort 1.2." >&2
+    exit 1
+  fi
+fi
+
+# Give the driver a moment to re-read the EDID after the OSD switch.
+sleep "${OMARCHY_EDID_CAPTURE_SLEEP:-2}"
+
+if is_dummy_edid "$edid" || [[ ! -s $edid ]]; then
+  echo -e "\e[31m$connector is still reading a small or dummy EDID.\e[0m" >&2
+  echo "Make sure the monitor input is set to DisplayPort 1.2, then re-run." >&2
+  exit 1
+fi
+
+real_size=$(wc -c <"$edid")
+firmware_name="${connector}.bin"
+firmware="$firmware_dir/$firmware_name"
+
+echo -e "\e[32mCaptured a real ${real_size}-byte EDID for $connector.\e[0m"
+
+if (( ASSUME_YES == 0 )); then
+  if ! gum confirm "Install this EDID as $firmware and force it at boot?"; then
+    echo "Exiting. Nothing was changed." >&2
+    exit 0
+  fi
+fi
+
+install_firmware "$edid" "$firmware"
+echo "Installed $firmware"
+
+configure_mkinitcpio "$firmware"
+echo "Added mkinitcpio FILES entry for $firmware"
+
+append_limine_param "$connector" "$firmware_name"
+echo "Appended drm.edid_firmware=${connector}:edid/${firmware_name} to $default_limine"
+
+echo
+echo "Regenerating initramfs and Limine configuration..."
+sudo limine-update
+
+echo -e "\e[32m\nDone. The forced EDID takes effect at the next boot.\e[0m"
+if (( ASSUME_YES == 0 )); then
+  if gum confirm "Reboot now to apply the fix?"; then
+    sudo systemctl reboot
+  else
+    echo "Reboot when ready. Until then the monitor stays on its current mode."
+  fi
+else
+  echo "Reboot when ready to apply the fix."
+fi

--- a/test/shell.d/nvidia-dp-edid-test.sh
+++ b/test/shell.d/nvidia-dp-edid-test.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+write_stub() {
+  local name="$1"
+  local body="$2"
+
+  cat >"$stub_bin/$name" <<SH
+#!/bin/bash
+$body
+SH
+  chmod +x "$stub_bin/$name"
+}
+
+# A 128-byte, "NVD"-tagged dummy EDID like the one NVIDIA fabricates on DP1.4.
+dummy_edid() {
+  {
+    printf '\x00\xff\xff\xff\xff\xff\xff\x00\x3a\xc4\x00\x00\x00\x00\x00\x00'
+    printf 'NVD'
+  }
+  head -c 109 /dev/zero
+}
+
+# A plausible real 384-byte EDID: different PNP, no "NVD" tag.
+real_edid() {
+  printf '\x00\xff\xff\xff\xff\xff\xff\x00\x06\xb3\x00\x00\x00\x00\x00\x00'
+  head -c 368 /dev/zero
+}
+
+# Detection tree (what sysfs shows before the OSD switch).
+drm_path="$test_tmp/drm"
+# Capture tree (what sysfs shows after switching the monitor to DP1.2).
+capture_path="$test_tmp/capture"
+
+firmware_dir="$test_tmp/firmware/edid"
+mkinitcpio_dir="$test_tmp/mkinitcpio.conf.d"
+default_limine="$test_tmp/limine"
+
+# Both trees hold the same connector so the wizard resolves the name via
+# detection and then re-reads the capture path during the EDID capture phase.
+mkdir -p "$drm_path/card0-DP-2" "$capture_path/card0-DP-2"
+printf 'connected\n' >"$drm_path/card0-DP-2/status"
+printf 'connected\n' >"$capture_path/card0-DP-2/status"
+
+write_stub sudo 'printf "SUDO %s\n" "$*" >>"$SUDO_LOG"; exec "$@"'
+write_stub limine-update 'printf "LIMINE\n" >>"$LIMINE_LOG"'
+
+SUDO_LOG="$test_tmp/sudo.log"
+LIMINE_LOG="$test_tmp/limine.log"
+export SUDO_LOG LIMINE_LOG
+
+env_for_run() {
+  OMARCHY_DRM_PATH="$drm_path" \
+  OMARCHY_EDID_CAPTURE_DRM_PATH="$capture_path" \
+  OMARCHY_EDID_FIRMWARE_DIR="$firmware_dir" \
+  OMARCHY_MKINITCPIO_DIR="$mkinitcpio_dir" \
+  OMARCHY_DEFAULT_LIMINE="$default_limine" \
+  OMARCHY_EDID_CAPTURE_SLEEP=0 \
+  PATH="$stub_bin:$PATH" \
+  "$ROOT/bin/omarchy-setup-nvidia-dp-edid" -y
+}
+
+run_env() {
+  OMARCHY_DRM_PATH="$drm_path" \
+  OMARCHY_EDID_FIRMWARE_DIR="$firmware_dir" \
+  OMARCHY_MKINITCPIO_DIR="$mkinitcpio_dir" \
+  OMARCHY_DEFAULT_LIMINE="$default_limine" \
+  OMARCHY_EDID_CAPTURE_SLEEP=0 \
+  PATH="$stub_bin:$PATH" \
+  "$ROOT/bin/omarchy-setup-nvidia-dp-edid" -y
+}
+
+# Seed a default limine cmdline the wizard appends to.
+mkdir -p "$(dirname "$default_limine")"
+printf 'KERNEL_CMDLINE[default]+="quiet"\n' >"$default_limine"
+
+# 1) No dummy EDID means there is nothing to fix: abort.
+real_edid >"$drm_path/card0-DP-2/edid"
+set +e
+no_dummy_out=$(run_env 2>&1)
+no_dummy_status=$?
+set -e
+(( no_dummy_status != 0 )) || fail "wizard aborts when no dummy EDID is found"
+pass "wizard aborts when no dummy EDID is found"
+
+# 2) Happy path: detection sees dummy, capture presents real EDID.
+dummy_edid >"$drm_path/card0-DP-2/edid"
+real_edid >"$capture_path/card0-DP-2/edid"
+env_for_run >"$test_tmp/run.out" 2>&1
+
+[[ -f "$firmware_dir/DP-2.bin" ]] ||
+  fail "wizard installs the forced EDID firmware" "$(cat "$test_tmp/run.out")"
+# The installed firmware must be the real (384-byte) EDID, not the dummy.
+(( $(wc -c <"$firmware_dir/DP-2.bin") == 384 )) ||
+  fail "wizard copies the real EDID, not the dummy"
+pass "wizard installs the real EDID as firmware"
+
+grep -q 'FILES+=(.*/DP-2.bin)' "$mkinitcpio_dir/edid-firmware.conf" ||
+  fail "wizard writes an mkinitcpio FILES entry" "$(cat "$mkinitcpio_dir/edid-firmware.conf")"
+pass "wizard writes an mkinitcpio FILES entry"
+
+grep -q 'drm.edid_firmware=DP-2:edid/DP-2.bin' "$default_limine" ||
+  fail "wizard appends the drm.edid_firmware param to limine config" "$(cat "$default_limine")"
+pass "wizard appends the drm.edid_firmware param to limine config"
+
+grep -q '^LIMINE$' "$LIMINE_LOG" ||
+  fail "wizard regenerates the Limine config" "$(cat "$LIMINE_LOG")"
+pass "wizard regenerates the Limine config"
+
+# 3) Idempotence: detection already reads a real EDID after a previous fix.
+real_edid >"$drm_path/card0-DP-2/edid"
+set +e
+env_for_run >"$test_tmp/run2.out" 2>&1
+idem_status=$?
+set -e
+(( idem_status != 0 )) || fail "wizard does not touch a connector already fixed"
+pass "wizard does not touch a connector already fixed"


### PR DESCRIPTION
## What

Adds `omarchy setup nvidia dp-edid` (`bin/omarchy-setup-nvidia-dp-edid`), an interactive setup wizard that detects and repairs NVIDIA DisplayPort monitors stuck at 640x480 because the kernel driver reads a fabricated 128-byte dummy EDID over DP 1.4.

## Why

Some high-refresh monitors (e.g. the ASUS ROG Strix XG27AQDMG) connected to NVIDIA GPUs over DisplayPort 1.4 expose only a 128-byte "NVD"-tagged dummy EDID, leaving the monitor stuck at 640x480 regardless of its real capabilities. The monitor's real EDID is only reported when its input is switched to DisplayPort 1.2 in the OSD. The only reliable fix is to capture that real EDID and force it at boot via `drm.edid_firmware=`.

## How it works

1. Finds the connected DisplayPort connector NVIDIA is reading a dummy EDID from.
2. Prompts to switch the monitor input to DisplayPort 1.2 in its OSD.
3. Captures the real 256/384-byte EDID from sysfs.
4. Installs it to `/lib/firmware/edid/<connector>.bin`.
5. Adds an mkinitcpio `FILES+=()` entry and appends `drm.edid_firmware=<connector>:edid/<file>.bin` to `KERNEL_CMDLINE[default]` in `/etc/default/limine`.
6. Regenerates the initramfs and Limine config (`sudo limine-update`), then offers a reboot.

`-y` skips the confirmations; the physical OSD switch to DP 1.2 is never skippable.

## Notes

- Paths are overridable via `OMARCHY_DRM_PATH`, `OMARCHY_EDID_CAPTURE_DRM_PATH`, `OMARCHY_EDID_FIRMWARE_DIR`, `OMARCHY_MKINITCPIO_DIR`, `OMARCHY_DEFAULT_LIMINE`, so the wizard is testable against a scratch tree.
- Verified against a real XG27AQDMG on an RTX 3080: after applying the wizard's steps the monitor reads 2560x1440@240Hz via the forced EDID.
- Test added at `test/shell.d/nvidia-dp-edid-test.sh` (stub `sudo`/`limine-update`, scratch DRM tree, detection-vs-capture trees).

## Tests

- `./test/cli` passes.
- `./test/shell` passes for `nvidia-dp-edid-test.sh`; the 4 failing files (`config-test`, `privileged-heredoc-test`, `snapper-test`, `unowned-system-paths-test`) are pre-existing environment failures requiring an `omarchy-pkgs` checkout (`OMARCHY_PKGS_PATH`) absent in this workspace.