### PR TITLE
Expose image picker cursor control over IPC

### DIFF
--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # omarchy:summary=Open a generic image selector menu
-# omarchy:args=[--selected <image>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>...
+# omarchy:args=[--selected <image>] [--context <name>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>...
 
 selected_image=""
+context=""
 print_name=false
 show_labels=false
 filterable=false
@@ -14,7 +15,7 @@ cache_only=false
 image_dirs=()
 
 usage() {
-  echo "Usage: omarchy-menu-images [--selected <image>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>..."
+  echo "Usage: omarchy-menu-images [--selected <image>] [--context <name>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>..."
 }
 
 while (( $# > 0 )); do
@@ -26,6 +27,15 @@ while (( $# > 0 )); do
       fi
 
       selected_image="$2"
+      shift 2
+      ;;
+    --context)
+      if (( $# < 2 )); then
+        usage >&2
+        exit 1
+      fi
+
+      context="$2"
       shift 2
       ;;
     --print-name)
@@ -277,18 +287,30 @@ fi
 rows_b64=$(printf '%s' "$rows" | base64 -w 0)
 
 if [[ $preload == true ]]; then
-  omarchy-shell image-selector preload "$rows_b64" "$selected_list_image" "$show_labels" "$filterable" >/dev/null || true
+  if [[ -n $context ]]; then
+    omarchy-shell image-selector preloadWithContext "$rows_b64" "$selected_list_image" "$show_labels" "$filterable" "$context" >/dev/null || true
+  else
+    omarchy-shell image-selector preload "$rows_b64" "$selected_list_image" "$show_labels" "$filterable" >/dev/null || true
+  fi
   exit 0
 fi
 
-if ! open_result=$(omarchy-shell image-selector open \
-     "" \
-     "$rows_b64" \
-     "$selected_list_image" \
-     "$selection_file" \
-     "$done_file" \
-     "$show_labels" \
-     "$filterable"); then
+open_method="open"
+open_args=(
+  ""
+  "$rows_b64"
+  "$selected_list_image"
+  "$selection_file"
+  "$done_file"
+  "$show_labels"
+  "$filterable"
+)
+if [[ -n $context ]]; then
+  open_method="openWithContext"
+  open_args+=("$context")
+fi
+
+if ! open_result=$(omarchy-shell image-selector "$open_method" "${open_args[@]}"); then
   echo "Image selector failed to accept request" >&2
   exit 1
 fi

--- a/bin/omarchy-theme-bg-switcher
+++ b/bin/omarchy-theme-bg-switcher
@@ -9,6 +9,7 @@ theme_name=$(cat "$HOME/.local/state/omarchy/current/theme.name" 2>/dev/null)
 current_background=$(readlink -f "$HOME/.local/state/omarchy/current/background" 2>/dev/null)
 
 omarchy-menu-images \
+  --context background \
   --selected "$current_background" \
   "$HOME/.local/state/omarchy/current/theme/backgrounds" \
   "$HOME/.config/omarchy/backgrounds/$theme_name"

--- a/bin/omarchy-theme-switcher
+++ b/bin/omarchy-theme-switcher
@@ -111,6 +111,7 @@ for extension in png jpg jpeg webp gif bmp; do
   fi
 done
 menu_args=(
+  --context theme
   --print-name
   --show-labels
   --filterable

--- a/shell/plugins/README.md
+++ b/shell/plugins/README.md
@@ -67,6 +67,18 @@ Two ways to drive it:
   uses. Colors come from the central shell theme singleton; there is no
   per-call override surface.
 
+`omarchy-menu-images --context <name> ...` gives a picker request a semantic context without exposing its image-directory layout. The theme and background switchers use `theme` and `background`; other callers may supply their own value. Direct IPC consumers that already have encoded rows can use `openWithContext`, which accepts the normal `open` arguments followed by the context. The original `open` method remains unchanged for compatibility.
+
+While the picker is open, external controllers and local automation can inspect and move its cursor without introducing another selection model:
+
+```bash
+omarchy-shell image-selector state
+omarchy-shell image-selector setCursor <path-or-name>
+omarchy-shell image-selector apply
+```
+
+`state` returns JSON containing `opened`, `context`, `cursorPath`, and `cursorName`. `setCursor` matches an exact loaded path, file name, or extension-free name; it moves the cursor without applying or closing the picker. `apply` uses the normal file-based selection flow. Control calls return `closed` while no picker is visible, and an unknown cursor returns `unknown` without changing the selection.
+
 The selection round-trip remains file-based: callers create a
 `selection_file` and `done_file` (both `mktemp`), pass the paths, and
 poll `done_file` for existence. The plugin writes the chosen path into

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -18,6 +18,7 @@ Item {
   property string loadedImageRows: ""
   property string selectionFile: Quickshell.env("OMARCHY_IMAGE_SELECTOR_SELECTION_FILE") || Quickshell.env("OMARCHY_BACKGROUND_SELECTION_FILE")
   property string selectedImage: Quickshell.env("OMARCHY_IMAGE_SELECTOR_SELECTED")
+  property string pickerContext: ""
   property int selectedIndex: 0
   property bool imagesLoaded: false
   property bool opened: false
@@ -84,6 +85,36 @@ Item {
     if (!path) return filterText ? "No matches" : ""
 
     return labelForPath(path)
+  }
+
+  function cursorState() {
+    var path = opened ? currentPath() : ""
+    return JSON.stringify({
+      opened: opened,
+      context: opened ? pickerContext : "",
+      cursorPath: path,
+      cursorName: path ? nameForPath(path) : ""
+    })
+  }
+
+  function setCursor(cursor) {
+    if (!opened) return "closed"
+
+    var index = ImagePickerModel.indexForCursor(imageArray, cursor)
+    if (index < 0) return "unknown"
+
+    if (filterText) updateFilter("")
+    select(index, true)
+    focusPicker()
+    return "ok"
+  }
+
+  function applyCursor() {
+    if (!opened) return "closed"
+    if (!currentPath() || !selectionFile) return "unknown"
+
+    applySelected()
+    return "ok"
   }
 
   function itemMatches(index) {
@@ -207,7 +238,7 @@ Item {
     }
   }
 
-  function openSelector(nextImageDirs, nextImageRows, nextSelectedImage, nextSelectionFile, nextDoneFile, nextShowLabels, nextFilterable) {
+  function openSelector(nextImageDirs, nextImageRows, nextSelectedImage, nextSelectionFile, nextDoneFile, nextShowLabels, nextFilterable, nextContext) {
     if (requestActive && doneFile && doneFile !== nextDoneFile)
       finishDoneFile(doneFile)
 
@@ -221,6 +252,7 @@ Item {
     requestActive = !!doneFile
     showLabels = nextShowLabels === true || nextShowLabels === "true"
     filterable = nextFilterable === true || nextFilterable === "true"
+    pickerContext = String(nextContext || "")
     filterText = ""
     layoutSettled = false
 
@@ -316,14 +348,14 @@ Item {
     var doneF = String(args.doneFile || "")
     var labels = args.showLabels === true || args.showLabels === "true"
     var filter = args.filterable === true || args.filterable === "true"
-    openSelector(dirs, rows, sel, selFile, doneF, labels, filter)
+    openSelector(dirs, rows, sel, selFile, doneF, labels, filter, args.context)
   }
 
   function close() {
     cancel()
   }
 
-  function preloadRows(nextImageRows, nextSelectedImage, nextShowLabels, nextFilterable) {
+  function preloadRows(nextImageRows, nextSelectedImage, nextShowLabels, nextFilterable, nextContext) {
     // Theme/background set hooks can warm selector rows after a picker was
     // dismissed. Ignore those preloads while a user-visible request is open;
     // otherwise the preload resets layoutSettled without revealing again,
@@ -335,6 +367,7 @@ Item {
     selectedImage = nextSelectedImage
     showLabels = nextShowLabels === true || nextShowLabels === "true"
     filterable = nextFilterable === true || nextFilterable === "true"
+    pickerContext = String(nextContext || "")
     filterText = ""
     layoutSettled = false
 

--- a/shell/plugins/image-picker/ImagePickerModel.js
+++ b/shell/plugins/image-picker/ImagePickerModel.js
@@ -77,6 +77,26 @@ function indexForSelectedImage(images, selectedImage) {
   return 0
 }
 
+function indexForCursor(images, cursor) {
+  var values = Array.isArray(images) ? images : []
+  var needle = String(cursor || "")
+  if (!needle) return -1
+
+  for (var i = 0; i < values.length; i++) {
+    if (values[i].filePath === needle) return i
+  }
+
+  for (var j = 0; j < values.length; j++) {
+    if (values[j].fileName === needle) return j
+  }
+
+  for (var k = 0; k < values.length; k++) {
+    if (nameForPath(values[k].filePath) === needle) return k
+  }
+
+  return -1
+}
+
 function nextSelectedIndexForFilter(images, selectedIndex, filterText) {
   if (itemMatches(images, selectedIndex, filterText)) return selectedIndex
   return firstMatchingIndex(images, filterText)
@@ -92,6 +112,7 @@ if (typeof module !== "undefined") {
     filteredPosition: filteredPosition,
     selectedFilteredPosition: selectedFilteredPosition,
     indexForSelectedImage: indexForSelectedImage,
+    indexForCursor: indexForCursor,
     nextSelectedIndexForFilter: nextSelectedIndexForFilter
   }
 }

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -840,6 +840,27 @@ ShellRoot {
       return shell.summon("omarchy.image-picker", payload) ? "ok" : "unknown"
     }
 
+    function openWithContext(imageDirs: string,
+                             imageRowsB64: string,
+                             selectedImage: string,
+                             selectionFile: string,
+                             doneFile: string,
+                             showLabels: string,
+                             filterable: string,
+                             context: string): string {
+      var payload = JSON.stringify({
+        imageDirs: imageDirs,
+        imageRows: Util.decodeBase64(imageRowsB64),
+        selectedImage: selectedImage,
+        selectionFile: selectionFile,
+        doneFile: doneFile,
+        showLabels: showLabels,
+        filterable: filterable,
+        context: context
+      })
+      return shell.summon("omarchy.image-picker", payload) ? "ok" : "unknown"
+    }
+
     function preload(imageRowsB64: string,
                      selectedImage: string,
                      showLabels: string,
@@ -852,6 +873,19 @@ ShellRoot {
       return "ok"
     }
 
+    function preloadWithContext(imageRowsB64: string,
+                                selectedImage: string,
+                                showLabels: string,
+                                filterable: string,
+                                context: string): string {
+      var picker = shell.imagePickerItem()
+      if (picker && typeof picker.preloadRows === "function") {
+        picker.preloadRows(Util.decodeBase64(imageRowsB64), selectedImage,
+                           showLabels, filterable, context)
+      }
+      return "ok"
+    }
+
     function cancel(doneFile: string): string {
       var picker = shell.imagePickerItem()
       if (picker && typeof picker.closeSelector === "function") {
@@ -860,6 +894,27 @@ ShellRoot {
         shell.hide("omarchy.image-picker")
       }
       return "ok"
+    }
+
+    function state(): string {
+      var picker = shell.imagePickerItem()
+      return picker && typeof picker.cursorState === "function"
+        ? picker.cursorState()
+        : JSON.stringify({ opened: false, context: "", cursorPath: "", cursorName: "" })
+    }
+
+    function setCursor(cursor: string): string {
+      var picker = shell.imagePickerItem()
+      return picker && typeof picker.setCursor === "function"
+        ? picker.setCursor(cursor)
+        : "closed"
+    }
+
+    function apply(): string {
+      var picker = shell.imagePickerItem()
+      return picker && typeof picker.applyCursor === "function"
+        ? picker.applyCursor()
+        : "closed"
     }
 
     function ping(): string {

--- a/test/shell.d/image-picker-test.sh
+++ b/test/shell.d/image-picker-test.sh
@@ -37,6 +37,11 @@ assert(!picker.itemMatches(images, 2, 'river'), 'image picker rejects non-matchi
 assertEqual(picker.firstMatchingIndex(images, 'plain'), 2, 'image picker finds first matching index')
 assertEqual(picker.indexForSelectedImage(images, '/themes/a/gruvbox-dark.jpeg'), 1, 'image picker finds selected image')
 assertEqual(picker.indexForSelectedImage(images, '/missing.png'), 0, 'image picker defaults selected image to first row')
+assertEqual(picker.indexForCursor(images, '/themes/a/gruvbox-dark.jpeg'), 1, 'image picker finds a remote cursor by path')
+assertEqual(picker.indexForCursor(images, 'gruvbox-dark.jpeg'), 1, 'image picker finds a remote cursor by file name')
+assertEqual(picker.indexForCursor(images, 'gruvbox-dark'), 1, 'image picker finds a remote cursor by name')
+assertEqual(picker.indexForCursor(images, 'Gruvbox Dark'), -1, 'image picker cursor matching stays exact')
+assertEqual(picker.indexForCursor(images, 'missing'), -1, 'image picker rejects an unknown remote cursor')
 
 assertEqual(picker.filteredPosition(images, 2, 'dark'), 1, 'image picker computes filtered position')
 assertEqual(picker.selectedFilteredPosition(images, 2, 'dark'), 0, 'image picker selected filtered position falls back when selected is hidden')
@@ -51,4 +56,27 @@ assert(
   /source: item\.sourceActivated && item\.thumbnailPath \? Util\.fileUrl\(item\.thumbnailPath\) : ""[\s\S]*asynchronous: false/.test(imagePickerQml),
   'image picker loads activated thumbnails synchronously to avoid carousel flicker'
 )
+assert(
+  /function cursorState\(\)[\s\S]*opened: opened[\s\S]*cursorPath: path[\s\S]*cursorName: path \? nameForPath\(path\) : ""/.test(imagePickerQml),
+  'image picker exposes live cursor state'
+)
+assert(
+  /function setCursor\(cursor\)[\s\S]*if \(!opened\) return "closed"[\s\S]*indexForCursor\(imageArray, cursor\)[\s\S]*select\(index, true\)/.test(imagePickerQml),
+  'image picker moves a remote cursor without applying it'
+)
+assert(
+  /function applyCursor\(\)[\s\S]*if \(!opened\) return "closed"[\s\S]*applySelected\(\)/.test(imagePickerQml),
+  'image picker remote apply reuses the existing selection flow'
+)
+
+const shellQml = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+assert(
+  /target: "image-selector"[\s\S]*function state\(\): string[\s\S]*function setCursor\(cursor: string\): string[\s\S]*function apply\(\): string/.test(shellQml),
+  'image selector IPC exposes state, setCursor, and apply'
+)
+
+const themeSwitcher = fs.readFileSync(path.join(root, 'bin/omarchy-theme-switcher'), 'utf8')
+const backgroundSwitcher = fs.readFileSync(path.join(root, 'bin/omarchy-theme-bg-switcher'), 'utf8')
+assert(/menu_args=\([\s\S]*--context theme/.test(themeSwitcher), 'theme picker declares its semantic context')
+assert(/omarchy-menu-images[\s\S]*--context background/.test(backgroundSwitcher), 'background picker declares its semantic context')
 JS

--- a/test/shell.d/menu-images-test.sh
+++ b/test/shell.d/menu-images-test.sh
@@ -38,6 +38,13 @@ printf 'thumbnail' >"$output"
 EOF
 chmod +x "$stub_bin/vipsthumbnail"
 
+cat >"$stub_bin/omarchy-shell" <<'EOF'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$OMARCHY_TEST_IPC_LOG"
+EOF
+chmod +x "$stub_bin/omarchy-shell"
+
 for name in one two three; do
   printf 'image-%s' "$name" >"$images/$name.png"
 done
@@ -139,3 +146,11 @@ PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" VIPSTHUMBNAIL_CALLS_FILE="$t
 
 (( $(wc -l <"$tmp/calls") == 6 )) || fail "image menu releases thumbnail locks after generation"
 pass "image menu owns locks for exactly one generator lifetime"
+
+ipc_log="$tmp/ipc.log"
+PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" OMARCHY_TEST_IPC_LOG="$ipc_log" \
+  "$ROOT/bin/omarchy-menu-images" --preload --context theme "$images"
+
+[[ $(awk '{ print $1, $2, $NF }' "$ipc_log") == "image-selector preloadWithContext theme" ]] ||
+  fail "image menu forwards semantic context over IPC"
+pass "image menu forwards semantic context over IPC"

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -189,19 +189,25 @@ jq -e '.hasPlayer | type == "boolean"' <<<"$(shell_ipc media status)" >/dev/null
 jq -e '.enabled | type == "boolean"' <<<"$(shell_ipc idle status)" >/dev/null || fail_with_log "idle IPC returns status JSON"
 jq -e '.locked | type == "boolean"' <<<"$(shell_ipc lock status)" >/dev/null || fail_with_log "lock IPC returns status JSON"
 [[ $(shell_ipc image-selector ping) == "ok" ]] || fail_with_log "image selector IPC responds"
+jq -e '.opened == false and .context == "" and .cursorPath == "" and .cursorName == ""' \
+  <<<"$(shell_ipc image-selector state)" >/dev/null || fail_with_log "closed image selector reports empty cursor state"
+[[ $(shell_ipc image-selector setCursor missing) == "closed" ]] || fail_with_log "closed image selector rejects remote cursor changes"
+[[ $(shell_ipc image-selector apply) == "closed" ]] || fail_with_log "closed image selector rejects remote apply"
 [[ $(shell_ipc osd ping) == "ok" ]] || fail_with_log "OSD IPC responds"
 [[ $(shell_ipc osd show '{"message":"Runtime smoke","duration":0}') == "ok" ]] || fail_with_log "OSD IPC opens"
 [[ $(shell_ipc osd close) == "ok" ]] || fail_with_log "OSD IPC closes"
 pass "plugin IPC contracts respond"
 
 shell_ipc_quiet shell rescanPlugins >/dev/null
-selector_rows_b64=$(printf '%s\t%s' "$TMPDIR/selector.png" "$TMPDIR/selector.png" | base64 -w 0)
+selector_one="$TMPDIR/selector-one.png"
+selector_two="$TMPDIR/selector-two.png"
+selector_rows_b64=$(printf '%s\t%s\n%s\t%s' "$selector_one" "$selector_one" "$selector_two" "$selector_two" | base64 -w 0)
 selector_selection_file=$(mktemp "$TMPDIR/selector-selection.XXXXXX")
 selector_done_file=$(mktemp "$TMPDIR/selector-done.XXXXXX")
 rm -f "$selector_done_file"
 selector_open=""
 for _ in {1..80}; do
-  selector_open=$(shell_ipc image-selector open "" "$selector_rows_b64" "" "$selector_selection_file" "$selector_done_file" false false 2>/dev/null || true)
+  selector_open=$(shell_ipc image-selector openWithContext "" "$selector_rows_b64" "" "$selector_selection_file" "$selector_done_file" false false theme 2>/dev/null || true)
   if [[ $selector_open == "ok" ]]; then
     break
   fi
@@ -211,9 +217,36 @@ for _ in {1..80}; do
   sleep 0.1
 done
 [[ $selector_open == "ok" ]] || fail_with_log "image selector IPC survives plugin rescan"
-shell_ipc_quiet image-selector cancel "$selector_done_file" >/dev/null
+
+selector_state=""
+for _ in {1..80}; do
+  selector_state=$(shell_ipc image-selector state 2>/dev/null || true)
+  jq -e --arg path "$selector_one" '.opened == true and .context == "theme" and .cursorPath == $path and .cursorName == "selector-one"' \
+    <<<"$selector_state" >/dev/null 2>&1 && break
+  sleep 0.1
+done
+jq -e --arg path "$selector_one" '.opened == true and .context == "theme" and .cursorPath == $path and .cursorName == "selector-one"' \
+  <<<"$selector_state" >/dev/null || fail_with_log "image selector reports live cursor state and context"
+
+[[ $(shell_ipc image-selector setCursor selector-two) == "ok" ]] || fail_with_log "image selector accepts a remote cursor name"
+selector_state=$(shell_ipc image-selector state)
+jq -e --arg path "$selector_two" '.opened == true and .cursorPath == $path and .cursorName == "selector-two"' \
+  <<<"$selector_state" >/dev/null || fail_with_log "image selector reports a remotely moved cursor"
+[[ $(shell_ipc image-selector setCursor missing) == "unknown" ]] || fail_with_log "image selector rejects an unknown cursor"
+jq -e --arg path "$selector_two" '.cursorPath == $path' <<<"$(shell_ipc image-selector state)" >/dev/null ||
+  fail_with_log "unknown remote cursor leaves the selection unchanged"
+
+[[ $(shell_ipc image-selector apply) == "ok" ]] || fail_with_log "image selector applies the remote cursor"
+for _ in {1..80}; do
+  [[ -e $selector_done_file ]] && break
+  sleep 0.1
+done
+[[ -e $selector_done_file ]] || fail_with_log "image selector remote apply finishes the request"
+[[ $(<"$selector_selection_file") == "$selector_two" ]] || fail_with_log "image selector remote apply writes the selected path"
+jq -e '.opened == false and .cursorPath == "" and .cursorName == ""' \
+  <<<"$(shell_ipc image-selector state)" >/dev/null || fail_with_log "image selector remote apply closes the picker"
 rm -f "$selector_selection_file" "$selector_done_file"
-pass "image selector IPC survives plugin rescan"
+pass "image selector remote-control IPC survives plugin rescan"
 
 shell_ipc_quiet omarchy.system-update refresh >/dev/null 2>&1 || true
 sleep 0.8


### PR DESCRIPTION
## Summary

- expose live Image Picker state and remote cursor control through the existing `image-selector` IPC target
- add optional semantic picker contexts while preserving the existing `open` and `preload` methods
- mark the theme and background pickers with `theme` and `background` contexts, and document the public contract

The new control surface is:

```bash
omarchy-shell image-selector state
omarchy-shell image-selector setCursor <path-or-name>
omarchy-shell image-selector apply
```

`setCursor` performs an exact match against the loaded path, file name, or extension-free name. It only moves the picker cursor. `apply` reuses the existing file-based selection flow. Calls made while the picker is closed return `closed`, and unknown cursor values return `unknown` without changing the current selection.

This first version intentionally uses polling through `state`. It does not add a runtime state file, event mechanism, or any Touch Bar-specific code.

## Testing

- `bash test/shell.d/image-picker-test.sh`
- `bash test/shell.d/menu-images-test.sh`
- `bash test/shell.d/runtime-smoke-test.sh` (real Wayland/Quickshell IPC)
- `./test/cli`
- `./test/shell` — affected tests pass; the full local run still reports unrelated environment failures from the missing `omarchy-pkgs` checkout and the About animation assertion. A transient Network QR failure passed on immediate rerun.

Related discussion: #9536
