### PR TITLE
Fit popped windows within the monitor work area

### DIFF
--- a/bin/omarchy-hyprland-window-pop
+++ b/bin/omarchy-hyprland-window-pop
@@ -25,9 +25,10 @@ fit_defaults_to_work_area() {
 
   read -r work_width work_height < <(jq -r '
     . as $monitor
+    # Hyprland reports reserved as [left, top, right, bottom], in logical pixels.
     | ($monitor.reserved // [0, 0, 0, 0]) as $reserved
-    | (if ($monitor.transform % 2) == 1 then $monitor.height else $monitor.width end) / $monitor.scale - $reserved[2] - $reserved[3] as $width
-    | (if ($monitor.transform % 2) == 1 then $monitor.width else $monitor.height end) / $monitor.scale - $reserved[0] - $reserved[1] as $height
+    | (if ($monitor.transform % 2) == 1 then $monitor.height else $monitor.width end) / $monitor.scale - $reserved[0] - $reserved[2] as $width
+    | (if ($monitor.transform % 2) == 1 then $monitor.width else $monitor.height end) / $monitor.scale - $reserved[1] - $reserved[3] as $height
     | "\($width | floor) \($height | floor)"
   ' <<<"$monitor" 2>/dev/null)
 

--- a/bin/omarchy-hyprland-window-pop
+++ b/bin/omarchy-hyprland-window-pop
@@ -16,7 +16,9 @@ addr=$(echo "$active" | jq -r ".address")
 window="address:$addr"
 
 fit_defaults_to_work_area() {
-  local monitor_id monitor work_width work_height
+  local monitor_id monitor work_width work_height gaps_css border_size
+  local gap_top=0 gap_right=0 gap_bottom=0 gap_left=0
+  local -a gaps
 
   monitor_id=$(jq -er '.monitor | numbers' <<<"$active" 2>/dev/null) || return
   monitor=$(hyprctl monitors -j 2>/dev/null | jq -cer --argjson id "$monitor_id" 'first(.[] | select(.id == $id)) // empty' 2>/dev/null) || return
@@ -30,6 +32,22 @@ fit_defaults_to_work_area() {
   ' <<<"$monitor" 2>/dev/null)
 
   [[ $work_width =~ ^[0-9]+$ && $work_height =~ ^[0-9]+$ ]] || return
+  (( work_width > 0 && work_height > 0 )) || return
+
+  gaps_css=$(hyprctl -j getoption general:gaps_out 2>/dev/null | jq -er '.css' 2>/dev/null) || gaps_css=0
+  read -ra gaps <<<"$gaps_css"
+  if [[ ${gaps[*]} =~ ^-?[0-9]+(\ +-?[0-9]+){0,3}$ ]]; then
+    case ${#gaps[@]} in
+      1) gap_top=${gaps[0]}; gap_right=${gaps[0]}; gap_bottom=${gaps[0]}; gap_left=${gaps[0]} ;;
+      2) gap_top=${gaps[0]}; gap_right=${gaps[1]}; gap_bottom=${gaps[0]}; gap_left=${gaps[1]} ;;
+      3) gap_top=${gaps[0]}; gap_right=${gaps[1]}; gap_bottom=${gaps[2]}; gap_left=${gaps[1]} ;;
+      4) gap_top=${gaps[0]}; gap_right=${gaps[1]}; gap_bottom=${gaps[2]}; gap_left=${gaps[3]} ;;
+    esac
+  fi
+
+  border_size=$(hyprctl -j getoption general:border_size 2>/dev/null | jq -er '.int | numbers' 2>/dev/null) || border_size=0
+  work_width=$((work_width - gap_left - gap_right - border_size * 2))
+  work_height=$((work_height - gap_top - gap_bottom - border_size * 2))
   (( work_width > 0 && work_height > 0 )) || return
 
   if [[ -z ${1:-} ]] && (( width > work_width )); then

--- a/bin/omarchy-hyprland-window-pop
+++ b/bin/omarchy-hyprland-window-pop
@@ -3,8 +3,10 @@
 # omarchy:summary=Toggle to pop-out a tile to stay fixed on a display basis.
 # omarchy:args=[width height x y]
 
-width=${1:-1300}
-height=${2:-900}
+default_width=1300
+default_height=900
+width=${1:-$default_width}
+height=${2:-$default_height}
 x=${3:-}
 y=${4:-}
 
@@ -12,6 +14,32 @@ active=$(hyprctl activewindow -j)
 pinned=$(echo "$active" | jq ".pinned")
 addr=$(echo "$active" | jq -r ".address")
 window="address:$addr"
+
+fit_defaults_to_work_area() {
+  local monitor_id monitor work_width work_height
+
+  monitor_id=$(jq -er '.monitor | numbers' <<<"$active" 2>/dev/null) || return
+  monitor=$(hyprctl monitors -j 2>/dev/null | jq -cer --argjson id "$monitor_id" 'first(.[] | select(.id == $id)) // empty' 2>/dev/null) || return
+
+  read -r work_width work_height < <(jq -r '
+    . as $monitor
+    | ($monitor.reserved // [0, 0, 0, 0]) as $reserved
+    | (if ($monitor.transform % 2) == 1 then $monitor.height else $monitor.width end) / $monitor.scale - $reserved[2] - $reserved[3] as $width
+    | (if ($monitor.transform % 2) == 1 then $monitor.width else $monitor.height end) / $monitor.scale - $reserved[0] - $reserved[1] as $height
+    | "\($width | floor) \($height | floor)"
+  ' <<<"$monitor" 2>/dev/null)
+
+  [[ $work_width =~ ^[0-9]+$ && $work_height =~ ^[0-9]+$ ]] || return
+  (( work_width > 0 && work_height > 0 )) || return
+
+  if [[ -z ${1:-} ]] && (( width > work_width )); then
+    width=$work_width
+  fi
+
+  if [[ -z ${2:-} ]] && (( height > work_height )); then
+    height=$work_height
+  fi
+}
 
 hypr_dispatch() {
   local lua="$1"
@@ -25,6 +53,7 @@ if [[ $pinned == "true" ]]; then
   hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
   hypr_dispatch "hl.dsp.window.tag({ window = \"$window\", tag = \"-pop\" })" tagwindow -pop "$window"
 elif [[ -n $addr ]]; then
+  fit_defaults_to_work_area "$@"
   hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
   hypr_dispatch "hl.dsp.window.resize({ window = \"$window\", x = $width, y = $height })" resizeactive exact "$width" "$height" "$window"
 

--- a/test/shell.d/hyprland-window-pop-test.sh
+++ b/test/shell.d/hyprland-window-pop-test.sh
@@ -18,6 +18,16 @@ if [[ $1 == "monitors" && $2 == "-j" ]]; then
   exit 0
 fi
 
+if [[ $1 == "-j" && $2 == "getoption" && $3 == "general:gaps_out" ]]; then
+  printf '{"css":"10 10 10 10"}\n'
+  exit 0
+fi
+
+if [[ $1 == "-j" && $2 == "getoption" && $3 == "general:border_size" ]]; then
+  printf '{"int":2}\n'
+  exit 0
+fi
+
 if [[ $1 == "dispatch" ]]; then
   printf '%s\n' "$*" >>"$HYPRCTL_LOG"
   exit 0
@@ -42,19 +52,19 @@ assert_resize() {
 }
 
 run_pop '[{"id":0,"width":2880,"height":1800,"scale":2,"transform":0,"reserved":[0,26,0,0]}]'
-assert_resize 1300 874 "pop height fits the active monitor work area"
+assert_resize 1300 850 "pop height fits inside the work area gaps and borders"
 
 run_pop '[{"id":0,"width":3840,"height":2160,"scale":2,"transform":0,"reserved":[0,26,0,0]}]'
 assert_resize 1300 900 "pop keeps its preferred size when the work area is large enough"
 
 run_pop '[{"id":0,"width":2560,"height":1440,"scale":1.6,"transform":3,"reserved":[0,35,0,0]}]'
-assert_resize 900 900 "pop accounts for monitor scale and rotation"
+assert_resize 876 900 "pop accounts for monitor scale, rotation, gaps, and borders"
 
 run_pop '[{"id":0,"width":2880,"height":1800,"scale":2,"transform":0,"reserved":[0,26,0,0]}]' 1500 1000
 assert_resize 1500 1000 "pop preserves explicitly requested dimensions"
 
 run_pop '[{"id":0,"width":2880,"height":1800,"scale":2,"transform":0,"reserved":[0,26,0,0]}]' 1200
-assert_resize 1200 874 "pop fits an omitted height while preserving an explicit width"
+assert_resize 1200 850 "pop fits an omitted height while preserving an explicit width"
 
 run_pop '[]'
 assert_resize 1300 900 "pop retains its defaults when monitor information is unavailable"

--- a/test/shell.d/hyprland-window-pop-test.sh
+++ b/test/shell.d/hyprland-window-pop-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat >"$tmpdir/hyprctl" <<'BASH'
+#!/bin/bash
+
+if [[ $1 == "activewindow" && $2 == "-j" ]]; then
+  printf '%s\n' "$HYPR_ACTIVE_WINDOW"
+  exit 0
+fi
+
+if [[ $1 == "monitors" && $2 == "-j" ]]; then
+  printf '%s\n' "$HYPR_MONITORS"
+  exit 0
+fi
+
+if [[ $1 == "dispatch" ]]; then
+  printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+  exit 0
+fi
+
+exit 1
+BASH
+chmod +x "$tmpdir/hyprctl"
+
+log="$tmpdir/hyprctl.log"
+active='{"address":"abc123","monitor":0,"pinned":false}'
+
+run_pop() {
+  >"$log"
+  PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_ACTIVE_WINDOW="$active" HYPR_MONITORS="$1" \
+    "$ROOT/bin/omarchy-hyprland-window-pop" "${@:2}"
+}
+
+assert_resize() {
+  grep -Fq "x = $1, y = $2" "$log" || fail "$3" "$(cat "$log")"
+  pass "$3"
+}
+
+run_pop '[{"id":0,"width":2880,"height":1800,"scale":2,"transform":0,"reserved":[0,26,0,0]}]'
+assert_resize 1300 874 "pop height fits the active monitor work area"
+
+run_pop '[{"id":0,"width":3840,"height":2160,"scale":2,"transform":0,"reserved":[0,26,0,0]}]'
+assert_resize 1300 900 "pop keeps its preferred size when the work area is large enough"
+
+run_pop '[{"id":0,"width":2560,"height":1440,"scale":1.6,"transform":3,"reserved":[0,35,0,0]}]'
+assert_resize 900 900 "pop accounts for monitor scale and rotation"
+
+run_pop '[{"id":0,"width":2880,"height":1800,"scale":2,"transform":0,"reserved":[0,26,0,0]}]' 1500 1000
+assert_resize 1500 1000 "pop preserves explicitly requested dimensions"
+
+run_pop '[{"id":0,"width":2880,"height":1800,"scale":2,"transform":0,"reserved":[0,26,0,0]}]' 1200
+assert_resize 1200 874 "pop fits an omitted height while preserving an explicit width"
+
+run_pop '[]'
+assert_resize 1300 900 "pop retains its defaults when monitor information is unavailable"
+
+run_pop '[{"id":0,"width":2880,"height":1800,"scale":0,"transform":0,"reserved":[0,26,0,0]}]'
+assert_resize 1300 900 "pop retains its defaults when monitor geometry is invalid"

--- a/test/shell.d/hyprland-window-pop-test.sh
+++ b/test/shell.d/hyprland-window-pop-test.sh
@@ -60,6 +60,12 @@ assert_resize 1300 900 "pop keeps its preferred size when the work area is large
 run_pop '[{"id":0,"width":2560,"height":1440,"scale":1.6,"transform":3,"reserved":[0,35,0,0]}]'
 assert_resize 876 900 "pop accounts for monitor scale, rotation, gaps, and borders"
 
+run_pop '[{"id":0,"width":2880,"height":1800,"scale":2,"transform":0,"reserved":[0,0,0,26]}]'
+assert_resize 1300 850 "pop subtracts a bottom reserved edge from the height"
+
+run_pop '[{"id":0,"width":2880,"height":1800,"scale":2,"transform":0,"reserved":[200,0,0,0]}]'
+assert_resize 1216 876 "pop subtracts a left reserved edge from the width"
+
 run_pop '[{"id":0,"width":2880,"height":1800,"scale":2,"transform":0,"reserved":[0,26,0,0]}]' 1500 1000
 assert_resize 1500 1000 "pop preserves explicitly requested dimensions"
 


### PR DESCRIPTION
## Summary

- keep the existing 1300x900 preferred pop-out size when it fits
- cap omitted/default dimensions to the active window monitor's usable window bounds
- account for monitor scale, rotation, reserved edges, outer gaps, and borders while preserving explicit dimensions
- fall back to the current defaults when monitor geometry is unavailable or invalid

Fixes #9731.

## Testing

- `test/shell.d/hyprland-window-pop-test.sh`
- `bash -n bin/omarchy-hyprland-window-pop test/shell.d/hyprland-window-pop-test.sh`
- live-tested on a 2880x1800 display at 2x scale with a 26px reserved top edge, 10px outer gaps, and 2px borders; the popped window was fully visible at 1300x850 with 12px top and bottom insets, then restored cleanly to tiled mode
- `test/all` exercised all 226 shell test files; the new test passed, with five unrelated existing/environment-dependent failures (three require an `omarchy-pkgs` checkout, `launch-about-test.sh` expects a different animation state, and `network-qr-test.sh` is not executable in the checkout)


<sub>This PR was prepared with OpenAI GPT-5.6 Sol.</sub>
