### PR TITLE
Force SPI PIO on MacBook8,1 so the built-in keyboard works

### DIFF
--- a/install/hardware/apple/fix-spi-keyboard.sh
+++ b/install/hardware/apple/fix-spi-keyboard.sh
@@ -8,6 +8,18 @@ if [[ $product_name =~ MacBook[89],1|MacBook1[02],1|MacBookPro13,[123]|MacBookPr
   if [[ $product_name == "MacBook8,1" ]]; then
     echo "MODULES=(applespi spi_pxa2xx_platform spi_pxa2xx_pci)" | \
       sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null
+
+    # The Wildcat Point GSPI controller (00:15.4) does transfers through the
+    # companion DesignWare DMA engine (00:15.0). On this board those DMA
+    # transfers never complete: applespi times out with -110 and IRQ 21 stays
+    # at zero. dw_dmac_pci is builtin, so it cannot be blacklisted as a module.
+    # Blacklisting its initcall forces spi-pxa2xx into PIO, which works.
+    # Deep/S3 sleep then wedges the same SPI device until reboot; s2idle does not.
+    sudo mkdir -p /etc/limine-entry-tool.d
+    sudo tee /etc/limine-entry-tool.d/macbook81-spi-pio.conf >/dev/null <<'EOF'
+# MacBook8,1: DesignWare DMA never completes GSPI transfers.
+KERNEL_CMDLINE[default]+=" initcall_blacklist=dw_pci_driver_init mem_sleep_default=s2idle"
+EOF
   else
     echo "MODULES=(applespi intel_lpss_pci spi_pxa2xx_platform)" | \
       sudo tee /etc/mkinitcpio.conf.d/macbook_spi_modules.conf >/dev/null

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -37,6 +37,8 @@ It is necessary to disable Apple's Secure Boot in order to boot the bootable USB
 
 The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, and an NVMe suspend fix for those same models.
 
+The 12-inch Early 2015 (MacBook8,1) needs a USB keyboard for the installer itself. After the first reboot the built-in keyboard and trackpad work: DMA on that board never completes SPI transfers, so the installer forces the controller into PIO and defaults sleep to s2idle.
+
 ### Known Limitations
 
 Members of the community are constantly working on solutions to these challenges so if these are problematic for you, join #omarchy-on-other in our [Discord](https://discord.gg/tXFUdasqhY) and see if there's any up-to-date methods for resolving these.

--- a/migrations/1788318101.sh
+++ b/migrations/1788318101.sh
@@ -1,0 +1,42 @@
+echo "Force SPI PIO on MacBook8,1 so the built-in keyboard works"
+
+# The install-time leaf already loads applespi for this model, but that is not
+# enough: DesignWare DMA on 00:15.0 never completes GSPI transfers, so the
+# keyboard and trackpad time out until the controller is forced into PIO.
+# See install/hardware/apple/fix-spi-keyboard.sh.
+product="${OMARCHY_MACBOOK81_DMI_PRODUCT:-/sys/class/dmi/id/product_name}"
+limine_conf="${OMARCHY_MACBOOK81_LIMINE_CONF:-/etc/limine-entry-tool.d/macbook81-spi-pio.conf}"
+repair_marker="${OMARCHY_MACBOOK81_REPAIR_MARKER:-/var/lib/omarchy/migrations/1788318101}"
+running_cmdline="${OMARCHY_MACBOOK81_RUNNING_CMDLINE:-/proc/cmdline}"
+
+product_name="$(cat "$product" 2>/dev/null || true)"
+if [[ $product_name != "MacBook8,1" ]]; then
+  exit 0
+fi
+
+needs_limine_rebuild=0
+
+if [[ ! -f $limine_conf ]] || ! grep -q 'initcall_blacklist=dw_pci_driver_init' "$limine_conf"; then
+  sudo mkdir -p "$(dirname "$limine_conf")"
+  sudo tee "$limine_conf" >/dev/null <<'EOF'
+# MacBook8,1: DesignWare DMA never completes GSPI transfers.
+KERNEL_CMDLINE[default]+=" initcall_blacklist=dw_pci_driver_init mem_sleep_default=s2idle"
+EOF
+  needs_limine_rebuild=1
+fi
+
+# The current kernel keeps its old command line until reboot. Record a
+# successful machine-wide rebuild so another user's migration does not repeat
+# it before then, while a missing marker still retries an interrupted rebuild.
+if [[ -f $limine_conf ]] &&
+  [[ ! -e $repair_marker ]] &&
+  grep -q 'initcall_blacklist=dw_pci_driver_init' "$limine_conf" &&
+  { [[ ! -r $running_cmdline ]] ||
+    ! grep -Eq '(^| )initcall_blacklist=dw_pci_driver_init( |$)' "$running_cmdline"; }; then
+  needs_limine_rebuild=1
+fi
+
+if (( needs_limine_rebuild )); then
+  sudo limine-mkinitcpio
+  sudo install -Dm644 /dev/null "$repair_marker"
+fi

--- a/test/shell.d/macbook81-spi-pio-test.sh
+++ b/test/shell.d/macbook81-spi-pio-test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-spi-keyboard.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1788318101.sh"
+
+grep -q 'apple/fix-spi-keyboard.sh' "$all" ||
+  fail "the SPI keyboard leaf runs during hardware setup"
+grep -q 'initcall_blacklist=dw_pci_driver_init' "$leaf" ||
+  fail "MacBook8,1 setup forces SPI PIO"
+grep -q 'mem_sleep_default=s2idle' "$leaf" ||
+  fail "MacBook8,1 setup defaults sleep to s2idle"
+pass "MacBook8,1 SPI PIO is part of hardware setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local product="$1"
+  rm -rf "$test_tmp/etc"
+  mkdir -p "$test_tmp/etc"
+  printf '%s' "$product" >"$test_tmp/dmi/product_name"
+  : >"$calls"
+
+  local script="$test_tmp/leaf.sh"
+  sed -e "s|/sys/class/dmi/id/product_name|$test_tmp/dmi/product_name|g" \
+      -e "s|/etc/mkinitcpio.conf.d|$test_tmp/etc/mkinitcpio.conf.d|g" \
+      -e "s|/etc/limine-entry-tool.d|$test_tmp/etc/limine-entry-tool.d|g" \
+      "$leaf" >"$script"
+
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+run_leaf "MacBook8,1" >/dev/null
+modules="$test_tmp/etc/mkinitcpio.conf.d/macbook_spi_modules.conf"
+pio="$test_tmp/etc/limine-entry-tool.d/macbook81-spi-pio.conf"
+grep -Fq 'MODULES=(applespi spi_pxa2xx_platform spi_pxa2xx_pci)' "$modules" ||
+  fail "MacBook8,1 still gets the SPI initramfs modules" "$(cat "$modules" 2>/dev/null)"
+grep -Fq 'initcall_blacklist=dw_pci_driver_init' "$pio" ||
+  fail "MacBook8,1 gets the PIO kernel parameter" "$(cat "$pio" 2>/dev/null)"
+grep -Fq 'mem_sleep_default=s2idle' "$pio" ||
+  fail "MacBook8,1 gets s2idle" "$(cat "$pio" 2>/dev/null)"
+grep -Fq $'omarchy-pkg-add\tmacbook12-spi-driver-dkms' "$calls" ||
+  fail "MacBook8,1 still installs the SPI DKMS package" "$(cat "$calls")"
+pass "MacBook8,1 setup writes SPI modules and the PIO drop-in"
+
+run_leaf "MacBook10,1" >/dev/null
+[[ -f $modules ]] || fail "MacBook10,1 still gets SPI modules"
+[[ ! -e $pio ]] || fail "later 12-inch MacBooks do not get the 8,1 PIO quirk" "$(cat "$pio")"
+pass "later SPI MacBooks are left on DMA"
+
+run_leaf "MacBookPro14,1" >/dev/null
+[[ ! -e $pio ]] || fail "MacBookPro models do not get the 8,1 PIO quirk"
+pass "MacBookPro SPI models are left on DMA"
+
+run_leaf "ThinkPad X1 Carbon" >/dev/null
+[[ ! -e $modules ]] || fail "non-Apple hardware is left alone"
+[[ ! -e $pio ]] || fail "non-Apple hardware is left alone"
+[[ ! -s $calls ]] || fail "non-Apple hardware escalates nothing" "$(cat "$calls")"
+pass "non-Apple hardware is left alone"
+
+run_migration() {
+  local product="$1"
+  printf '%s' "$product" >"$test_tmp/dmi/product_name"
+  : >"$calls"
+
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_MACBOOK81_DMI_PRODUCT="$test_tmp/dmi/product_name" \
+    OMARCHY_MACBOOK81_LIMINE_CONF="$pio" \
+    OMARCHY_MACBOOK81_REPAIR_MARKER="$test_tmp/repair-complete" \
+    OMARCHY_MACBOOK81_RUNNING_CMDLINE="$test_tmp/cmdline" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -rf "$test_tmp/etc" "$test_tmp/repair-complete"
+mkdir -p "$test_tmp/etc"
+echo 'quiet splash' >"$test_tmp/cmdline"
+run_migration "MacBook8,1"
+grep -Fq 'initcall_blacklist=dw_pci_driver_init' "$pio" ||
+  fail "the migration writes the PIO drop-in" "$(cat "$pio" 2>/dev/null)"
+grep -Fq 'mem_sleep_default=s2idle' "$pio" ||
+  fail "the migration writes s2idle" "$(cat "$pio" 2>/dev/null)"
+grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "the migration rebuilds the boot image" "$(cat "$calls")"
+[[ -f $test_tmp/repair-complete ]] || fail "the migration records the machine-wide repair"
+pass "the migration repairs an existing MacBook8,1"
+
+: >"$calls"
+run_migration "MacBook8,1"
+[[ ! -s $calls ]] || fail "an already repaired MacBook8,1 is left unchanged" "$(cat "$calls")"
+pass "the migration is machine-idempotent before reboot"
+
+rm -f "$test_tmp/repair-complete"
+: >"$calls"
+run_migration "MacBook8,1"
+grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "the migration retries an interrupted boot image rebuild"
+[[ -f $test_tmp/repair-complete ]] || fail "a retried repair records completion"
+! grep -Eq $'^(sudo\t)?tee(\t|$)' "$calls" ||
+  fail "rebuild retry leaves a complete drop-in alone" "$(cat "$calls")"
+pass "the migration retries an interrupted boot image rebuild"
+
+rm -rf "$test_tmp/etc" "$test_tmp/repair-complete"
+mkdir -p "$test_tmp/etc"
+: >"$calls"
+run_migration "MacBook10,1"
+[[ ! -e $pio ]] || fail "the migration skips later 12-inch MacBooks"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on unrelated Macs" "$(cat "$calls")"
+pass "the migration skips unrelated hardware"


### PR DESCRIPTION
## Summary

On MacBook8,1 (12-inch Early 2015) the installer already loads `applespi` and the PXA SPI modules. That is not enough. The GSPI controller (`00:15.4`) does transfers through the companion DesignWare DMA engine (`00:15.0`), and on this board those DMA transfers never complete. `applespi` times out with `-110`, IRQ 21 stays at zero, and the built-in keyboard and trackpad never work. #1954.

Force the controller into PIO and it probes immediately. `dw_dmac_pci` is builtin, so the switch is a kernel parameter:

```
initcall_blacklist=dw_pci_driver_init
```

Deep/S3 then wedges the same SPI device until reboot, so sleep defaults to `s2idle`.

Same shape as the ASUS Panther Lake backlight leaf: detect the machine, write a Limine drop-in. No new package. No vendored C.

## Changes

- `install/hardware/apple/fix-spi-keyboard.sh` — on MacBook8,1 only, write `/etc/limine-entry-tool.d/macbook81-spi-pio.conf`. Other SPI MacBooks are unchanged.
- Migration `1788318101.sh` for existing installs. Idempotent. Rebuilds the UKI. No-ops on anything that is not MacBook8,1.
- `test/shell.d/macbook81-spi-pio-test.sh`
- Manual note: USB keyboard for the installer itself; glass keys after the first reboot.

## Tested

MacBook8,1 (A1534, Early 2015), Core M-5Y31, Omarchy 4.0.2, kernel 7.1.9-arch1-2. Keyboard and trackpad work at LUKS, at the login screen, and after lid close.

The same PIO cmdline is what [matthiasjg](https://gist.github.com/matthiasjg/78aaf7802146f0b89be3da9e4feb111f) documented on #1954; the original reporter and two other MacBook8,1s confirmed it.

Speakers, camera, and Bluetooth stay out of this PR.

Fixes #1954