### PR TITLE
Add Omarchy spelling correction to Voxtype

### DIFF
--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -13,6 +13,7 @@ if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
   # Setup voxtype
   mkdir -p ~/.config/voxtype
   cp "$OMARCHY_PATH/default/voxtype/config.toml" ~/.config/voxtype/
+  voxtype config set text.replacements.omachi Omarchy
 
   voxtype setup --download --no-post-install
   if omarchy-hw-vulkan; then


### PR DESCRIPTION
Voxtype likes to say "omachi".
Update that in config on install so that it knows to replace that with "Omarchy"