### PR TITLE
Float Omawrite's file dialogs

### DIFF
--- a/default/hypr/apps/system.lua
+++ b/default/hypr/apps/system.lua
@@ -15,7 +15,7 @@ o.window(
 -- whatever the app that asked for it titled it.
 o.window("xdg-desktop-portal-gtk", { tag = "+floating-window" })
 o.window({
-  class = "(sublime_text|DesktopEditors|org.gnome.Nautilus)",
+  class = "(sublime_text|DesktopEditors|org.gnome.Nautilus|omawrite)",
   title = "^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)",
 }, { tag = "+floating-window" })
 


### PR DESCRIPTION
## Problem

Saving a file in Omawrite on a 1440x900 (2x) laptop screen shows the file chooser filling the whole screen with the header bar cut off, so the Save and Cancel buttons are unreachable.

## Cause

Omawrite is a Qt app. Omarchy sets `QT_QPA_PLATFORMTHEME=gtk3`, so Qt builds the Open and Save dialogs with an in-process GTK3 file chooser instead of going through the portal. That dialog has the `omawrite` class, not `xdg-desktop-portal-gtk`, so the existing portal float rule never matches. The chooser opens at 1454x1116 logical pixels, larger than the screen, and Hyprland centers it on its parent without clamping, which pushes the top of the dialog off-screen.

Measured with `hyprctl clients` on Omarchy 4.0.2, omawrite 0.5.0:

| Platform theme | Dialog class | Dialog size |
|---|---|---|
| gtk3 (Omarchy default) | omawrite | 1454x1116 |
| gtk3 with GDK_SCALE unset, or Qt high-DPI off | omawrite | 1454x1116 |
| xdgdesktopportal | xdg-desktop-portal-gtk | 875x600 |

Resetting `org.gtk.Settings.FileChooser window-size` does not change the result.

## Fix

Add `omawrite` to the class list of the editor file-dialog rule next to Sublime, OnlyOffice and Nautilus. Its dialogs are titled `Open File` and `Save File`, which the existing title pattern already covers.

## Verification

With the rule loaded, both dialogs open floating, centered, at 875x600 with the `floating-window` tag:

```
title=Save File size=[875,600] at=[283,164] float=true tags=["default-opacity*","floating-window*"]
title=Open File size=[875,600] at=[283,164] float=true tags=["default-opacity*","floating-window*"]
```

`./test/all` passes apart from `bar-icon-geometry-test.sh`, which fails on this machine before the change too because it launches Quickshell inside a live session.
