### PR TITLE
Swallow the keystroke that wakes a blanked lock screen

### DIFF
--- a/bin/omarchy-system-sleep-lock
+++ b/bin/omarchy-system-sleep-lock
@@ -113,7 +113,13 @@ sync_clamshell
 # inside the reserve derive_budget_ms already held back for logind.
 while (( $(remaining_ms) > 0 )); do
   case $(lock_state) in
-    secure) exit 0 ;;
+    secure)
+      # Lid-close suspend often wins the race against the lock's five-second
+      # blank timer. Mark the panel blanked before the machine goes down so
+      # the first key after resume wakes the display instead of typing.
+      lock_ipc "$status_timeout_ms" lock blank >/dev/null || true
+      exit 0
+      ;;
     locking) ;;
     *) request_lock ;;
   esac

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -13,6 +13,8 @@ Item {
   property string failureMessage: ""
   property int failedAttempts: 0
   property bool inputEnabled: true
+  property bool displayBlanked: false
+  property bool swallowingWakeKey: false
   property bool loadBackground: true
   property string passwordText: ""
   property bool syncingPasswordText: false
@@ -175,11 +177,27 @@ Item {
         }
 
         Keys.onPressed: function(event) {
-          root.wakeRequested()
           if (event.key === Qt.Key_Escape || (event.modifiers & Qt.ControlModifier && event.key === Qt.Key_U)) {
             root.passwordTextEdited("")
             event.accepted = true
+            return
           }
+
+          // A key at a dark panel is there to wake it, not to type. Sample
+          // before wakeRequested() clears the flag, and keep swallowing
+          // auto-repeats until that key is released.
+          var waking = root.displayBlanked || root.swallowingWakeKey
+          root.wakeRequested()
+          if (waking) {
+            root.swallowingWakeKey = true
+            event.accepted = true
+          }
+        }
+
+        Keys.onReleased: function(event) {
+          if (!root.swallowingWakeKey) return
+          root.swallowingWakeKey = false
+          event.accepted = true
         }
       }
 

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -17,6 +17,9 @@ Item {
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
 
   property bool lockRequested: false
+  // True from runBlank() until runWake(), so a key at a dark panel wakes it
+  // instead of becoming the first character of the password.
+  property bool displayBlanked: false
   property bool pendingSessionLock: false
   property bool authenticatingPassword: false
   property bool fingerprintAuthenticating: false
@@ -165,11 +168,13 @@ Item {
   }
 
   function runWake() {
+    displayBlanked = false
     if (!wakeProcess.running) wakeProcess.running = true
     if (lockRequested) armBlankTimer()
   }
 
   function runBlank() {
+    displayBlanked = true
     if (!blankProcess.running) blankProcess.running = true
   }
 
@@ -275,6 +280,7 @@ Item {
         failureMessage: root.failureMessage
         failedAttempts: root.failedAttempts
         inputEnabled: root.lockRequested
+        displayBlanked: root.displayBlanked
         loadBackground: root.locked
         passwordText: root.enteredPassword
         onPasswordTextEdited: function(password) { root.enteredPassword = password }
@@ -513,6 +519,12 @@ Item {
     function lock(): string {
       if (!root.passwordPamConfigured) return "missing-pam"
       if (!root.locked && !root.beginLock()) return "failed"
+      return "ok"
+    }
+
+    function blank(): string {
+      if (!root.lockRequested) return "not-locked"
+      root.runBlank()
       return "ok"
     }
 

--- a/test/shell.d/lock-wake-keystroke-test.sh
+++ b/test/shell.d/lock-wake-keystroke-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+const lockViewQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/LockView.qml'), 'utf8')
+const sleepLock = fs.readFileSync(path.join(root, 'bin/omarchy-system-sleep-lock'), 'utf8')
+
+// The blank state has to be tracked where the display is actually turned on
+// and off, or the view cannot tell a wake keystroke from a typed character.
+assert(
+  /property bool displayBlanked: false/.test(serviceQml),
+  'the lock tracks whether it blanked the display'
+)
+
+assert(
+  /function runBlank\(\) \{\s*displayBlanked = true/.test(serviceQml),
+  'blanking the display records that it is blanked'
+)
+
+assert(
+  /function runWake\(\) \{\s*displayBlanked = false/.test(serviceQml),
+  'waking the display clears the blanked state'
+)
+
+assert(
+  /displayBlanked: root\.displayBlanked/.test(serviceQml),
+  'the lock surface view is told whether the display is blanked'
+)
+
+assert(
+  /property bool displayBlanked: false/.test(lockViewQml),
+  'the view declares the blanked state it is handed'
+)
+
+// wakeRequested() clears the flag, so the handler has to sample it first.
+assert(
+  /var waking = root\.displayBlanked \|\| root\.swallowingWakeKey\s*\n\s*root\.wakeRequested\(\)/.test(lockViewQml),
+  'the blanked state is sampled before waking clears it'
+)
+
+// The keystroke that wakes a blanked display means "wake up", not "here is the
+// first character of my password".
+assert(
+  /if \(waking\) \{\s*root\.swallowingWakeKey = true\s*event\.accepted = true/.test(lockViewQml),
+  'the keystroke that wakes the display is swallowed'
+)
+
+// Holding the wake key would otherwise fill the field with auto-repeats once
+// runWake() has already cleared displayBlanked.
+assert(
+  /Keys\.onReleased: function\(event\) \{\s*if \(!root\.swallowingWakeKey\) return\s*root\.swallowingWakeKey = false/.test(lockViewQml),
+  'auto-repeats of the wake key are swallowed until that key is released'
+)
+
+// Escape and Ctrl+U still clear the field rather than falling through to the
+// swallow.
+assert(
+  /root\.passwordTextEdited\(""\)\s*\n\s*event\.accepted = true\s*\n\s*return/.test(lockViewQml),
+  'clearing the field returns before the wake-keystroke swallow'
+)
+
+// Lid-close suspend often wins the race against the lock's five-second blank
+// timer, so the sleep path has to mark the panel blanked before the machine
+// goes down. Frozen QML state then still says "blanked" on the first key
+// after resume.
+assert(
+  /function blank\(\): string \{\s*if \(!root\.lockRequested\) return "not-locked"\s*root\.runBlank\(\)\s*return "ok"/.test(serviceQml),
+  'the lock can be told to blank over IPC'
+)
+
+assert(
+  /secure\)[\s\S]*?lock blank/.test(sleepLock),
+  'sleep lock blanks the display once the session is secure'
+)
+JS

--- a/test/shell.d/sleep-lock-test.sh
+++ b/test/shell.d/sleep-lock-test.sh
@@ -99,6 +99,10 @@ pass "sleep lock requests the session lock first"
   fail "sleep lock checks security after clamshell reconciliation"
 pass "sleep lock checks security after clamshell reconciliation"
 
+[[ ${calls[3]} == "shell lock blank" ]] ||
+  fail "sleep lock blanks the display once the session is secure" "calls: ${calls[*]}"
+pass "sleep lock blanks the display once the session is secure"
+
 (( elapsed_us < 1500000 )) ||
   fail "sleep lock bounds a stalled clamshell sync" "elapsed: ${elapsed_us}us"
 pass "sleep lock bounds a stalled clamshell sync"
@@ -144,6 +148,10 @@ done
 (( polls > 1 )) ||
   fail "sleep lock keeps polling until the deadline" "polls: $polls"
 pass "sleep lock keeps polling until the deadline"
+
+[[ ${calls[*]} != *"lock blank"* ]] ||
+  fail "sleep lock does not blank a session that never secured" "calls: ${calls[*]}"
+pass "sleep lock does not blank a session that never secured"
 
 # A lock request that times out may never have landed, so the wait retries it
 # instead of suspending an unlocked session over one slow IPC call.


### PR DESCRIPTION
## Bug Description

When the lock screen has blanked the display (idle blank, or after sleep), the first key that wakes it is inserted into the password field. Space is the obvious case — a lone dot before you have typed anything — but every character does it. Unlock then fails, or you backspace first.

Holding that key also auto-repeats into the field once the display is considered awake.

Lid-close suspend often wins the race against the lock's five-second blank timer, so the same first-key-is-password bug happens after resume even when Omarchy never blanked the panel itself.

## Root Cause

`LockView`'s `Keys.onPressed` always calls `wakeRequested()` and then lets the event fall through to the `TextInput`. Nothing records that the panel is dark, so a wake keystroke is indistinguishable from the first character of the password.

## Fix

- The lock tracks `displayBlanked` in `runBlank()` / `runWake()` and hands it to the view.
- The view samples that flag *before* `wakeRequested()` clears it, accepts the event, and keeps swallowing auto-repeats until that key is released.
- Escape and Ctrl+U still clear the field and return before the swallow.
- `omarchy-system-sleep-lock` blanks the panel once the session is secure, so the frozen QML state still says "blanked" on the first key after resume.

Mouse wake is unchanged. Typing after the display is on is unchanged.

Related: #7805. Adjacent open PRs #9157 (dirty fork) and #9211 (does not mark blanked on suspend, and does not swallow auto-repeats).

## How to Verify

1. Lock (`Super+Escape`), wait for the display to blank (~5s), press Space. The field should stay empty; the next character should be the first password dot.
2. Lock, wait for blank, hold a letter. The field should stay empty until you release and type again.
3. Close the lid (or suspend), open it, press a key. That key should wake the panel and not appear in the field.

## Test Plan

- [x] Added `test/shell.d/lock-wake-keystroke-test.sh` and sleep-lock coverage for the blank IPC
- [x] `./test/cli` passes
- [x] Focused lock/sleep tests pass (`lock-wake-keystroke`, `sleep-lock`, `lock-blank-fingerprint`)
- [ ] Manual verification of the fix on hardware (please try a lock-blank and a lid-close cycle)

## Risk Assessment

Low — only the lock password field and the pre-suspend blank. A key pressed while the panel is lit still types. A failed `lock blank` IPC is ignored so suspend is not blocked.