### PR TITLE
Fix removal of nested desktop entries

### DIFF
--- a/bin/omarchy-remove-launcher-entry
+++ b/bin/omarchy-remove-launcher-entry
@@ -40,8 +40,9 @@ fi
 
 desktop_file=""
 for dir in "${desktop_dirs[@]}"; do
-  candidate="$dir/$desktop_file_name"
-  if [[ -f $candidate ]]; then
+  [[ -d $dir ]] || continue
+  candidate="$(find "$dir" -type f -name "$desktop_file_name" -print -quit 2>/dev/null)"
+  if [[ -n $candidate ]]; then
     desktop_file="$candidate"
     break
   fi
@@ -57,7 +58,7 @@ is_user_desktop_file() {
 
   desktop_dir="${desktop_file%/*}"
   for dir in "${user_desktop_dirs[@]}"; do
-    [[ $desktop_dir == $dir ]] && return 0
+    [[ $desktop_dir == "$dir" || $desktop_dir == "$dir"/* ]] && return 0
   done
 
   return 1

--- a/bin/omarchy-remove-launcher-entry
+++ b/bin/omarchy-remove-launcher-entry
@@ -41,11 +41,14 @@ fi
 desktop_file=""
 for dir in "${desktop_dirs[@]}"; do
   [[ -d $dir ]] || continue
-  candidate="$(find "$dir" -type f -name "$desktop_file_name" -print -quit 2>/dev/null)"
-  if [[ -n $candidate ]]; then
-    desktop_file="$candidate"
-    break
-  fi
+  while IFS= read -r -d '' candidate; do
+    relative="${candidate#"$dir"/}"
+    candidate_id="${relative//\//-}"
+    if [[ $candidate_id == "$desktop_file_name" || ${candidate##*/} == "$desktop_file_name" ]]; then
+      desktop_file="$candidate"
+      break 2
+    fi
+  done < <(find "$dir" -type f -name '*.desktop' -print0 2>/dev/null)
 done
 
 if [[ -z $desktop_file ]]; then

--- a/test/shell.d/launcher-remove-test.sh
+++ b/test/shell.d/launcher-remove-test.sh
@@ -83,7 +83,7 @@ export XDG_DATA_DIRS="$tmp_dir/system"
 "$ROOT/bin/omarchy-remove-launcher-entry" Docker.desktop Docker
 "$ROOT/bin/omarchy-remove-launcher-entry" native.desktop Native
 "$ROOT/bin/omarchy-remove-launcher-entry" aliens.desktop Aliens
-"$ROOT/bin/omarchy-remove-launcher-entry" example.desktop "Example App"
+"$ROOT/bin/omarchy-remove-launcher-entry" wine-Programs-Example\ App-example.desktop "Example App"
 
 mapfile -t lines <"$TEST_LOG"
 

--- a/test/shell.d/launcher-remove-test.sh
+++ b/test/shell.d/launcher-remove-test.sh
@@ -7,7 +7,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-mkdir -p "$tmp_dir/data/applications" "$tmp_dir/system/applications" "$tmp_dir/bin"
+mkdir -p "$tmp_dir/data/applications" "$tmp_dir/data/applications/wine/Programs/Example App" "$tmp_dir/system/applications" "$tmp_dir/bin"
 
 write_fake_command() {
   local name="$1"
@@ -68,6 +68,12 @@ Name=Aliens
 Exec=retroarch -L /usr/lib/libretro/fbneo_libretro.so /home/example/Games/roms/fbneo/aliens.zip
 DESKTOP
 
+cat >"$tmp_dir/data/applications/wine/Programs/Example App/example.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Example App
+Exec=wine "C:\\Program Files\\Example App\\example.exe"
+DESKTOP
+
 export TEST_LOG="$tmp_dir/log"
 export PATH="$tmp_dir/bin:$PATH"
 export XDG_DATA_HOME="$tmp_dir/data"
@@ -77,6 +83,7 @@ export XDG_DATA_DIRS="$tmp_dir/system"
 "$ROOT/bin/omarchy-remove-launcher-entry" Docker.desktop Docker
 "$ROOT/bin/omarchy-remove-launcher-entry" native.desktop Native
 "$ROOT/bin/omarchy-remove-launcher-entry" aliens.desktop Aliens
+"$ROOT/bin/omarchy-remove-launcher-entry" example.desktop "Example App"
 
 mapfile -t lines <"$TEST_LOG"
 
@@ -91,6 +98,9 @@ pass "launcher remove opens package uninstall flow"
 
 [[ ! -e $tmp_dir/data/applications/aliens.desktop ]] || fail "launcher remove deletes user-owned desktop files"
 pass "launcher remove deletes user-owned desktop files"
+
+[[ ! -e "$tmp_dir/data/applications/wine/Programs/Example App/example.desktop" ]] || fail "launcher remove deletes nested user-owned desktop files"
+pass "launcher remove deletes nested user-owned desktop files"
 
 (( ${#lines[@]} == 3 )) || fail "launcher remove does not notify for user-owned desktop files" "$(printf '%s\n' "${lines[@]}")"
 pass "launcher remove does not notify for user-owned desktop files"


### PR DESCRIPTION
## Summary
- resolve desktop entries recursively under user and system application directories
- allow removal of nested user-owned entries such as Wine launchers
- add regression coverage for nested desktop files

Fixes the launcher removal failure described in #6975.

## Tests
- bash test/shell.d/launcher-remove-test.sh
- bash test/shell.d/menu-test.sh