### PR TITLE
Prefer logind's LidClosed over raw ACPI for lid detection

### DIFF
--- a/bin/omarchy-hw-laptop-closed
+++ b/bin/omarchy-hw-laptop-closed
@@ -3,7 +3,22 @@
 # omarchy:summary=Returns true when the laptop lid is closed
 # omarchy:hidden=true
 
-for state in /proc/acpi/button/lid/*/state; do
+# logind reads the lid switch through evdev with hardware quirk handling, so
+# its answer beats raw ACPI, whose _LID method can report stale state.
+lid_closed=$(busctl get-property org.freedesktop.login1 /org/freedesktop/login1 org.freedesktop.login1.Manager LidClosed 2>/dev/null)
+if [[ -n $lid_closed ]]; then
+  if [[ $lid_closed == "b true" ]]; then
+    exit 0
+  else
+    exit 1
+  fi
+fi
+
+# Fall back to ACPI for contexts without a running logind, such as install
+# chroots.
+lid_path="${OMARCHY_ACPI_LID_PATH:-/proc/acpi/button/lid}"
+
+for state in "$lid_path"/*/state; do
   [[ -r $state ]] || continue
   [[ $(< "$state") == *"closed"* ]] && exit 0
 done

--- a/test/shell.d/hw-laptop-closed-test.sh
+++ b/test/shell.d/hw-laptop-closed-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+laptop_closed="$ROOT/bin/omarchy-hw-laptop-closed"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+lid_path="$tmpdir/lid"
+
+# logind's LidClosed is the contract whenever logind is available, because it
+# reads the lid switch through evdev while raw ACPI can report stale state.
+# Each scenario pins what busctl reports and records the resulting exit.
+setup_busctl() {
+  mock_bin="$tmpdir/$1/bin"
+  mkdir -p "$mock_bin"
+
+  cat >"$mock_bin/busctl" <<SH
+#!/bin/bash
+$2
+SH
+  chmod +x "$mock_bin/busctl"
+}
+
+write_lid_state() {
+  rm -rf "$lid_path"
+  mkdir -p "$lid_path/LID0"
+  printf 'state:      %s\n' "$1" >"$lid_path/LID0/state"
+}
+
+run_laptop_closed() {
+  if OMARCHY_ACPI_LID_PATH="$lid_path" PATH="$mock_bin:$PATH" "$laptop_closed"; then
+    result=0
+  else
+    result=$?
+  fi
+}
+
+setup_busctl closed 'echo "b true"'
+write_lid_state open
+run_laptop_closed
+
+(( result == 0 )) ||
+  fail "a lid logind reports closed is closed" "exit: $result"
+pass "a lid logind reports closed is closed"
+
+# The stale-ACPI case this exists for: firmware says closed, logind knows
+# better from evdev.
+setup_busctl open 'echo "b false"'
+write_lid_state closed
+run_laptop_closed
+
+(( result == 1 )) ||
+  fail "a lid logind reports open is open despite stale ACPI" "exit: $result"
+pass "a lid logind reports open is open despite stale ACPI"
+
+# Without a running logind, as in an install chroot, busctl produces nothing
+# and the ACPI fallback decides.
+setup_busctl absent 'exit 1'
+write_lid_state closed
+run_laptop_closed
+
+(( result == 0 )) ||
+  fail "without logind a closed ACPI lid is closed" "exit: $result"
+pass "without logind a closed ACPI lid is closed"
+
+write_lid_state open
+run_laptop_closed
+
+(( result == 1 )) ||
+  fail "without logind an open ACPI lid is open" "exit: $result"
+pass "without logind an open ACPI lid is open"
+
+rm -rf "$lid_path"
+run_laptop_closed
+
+(( result == 1 )) ||
+  fail "no lid device at all means open" "exit: $result"
+pass "no lid device at all means open"

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -60,7 +60,8 @@ grep -F 'hyprctl monitors all -j' "$ROOT/bin/omarchy-hyprland-monitor-modeless" 
 pass "modeless helper sees mirrors and ignores monitors disabled on purpose"
 
 grep -F 'omarchy-hw-laptop-closed && omarchy-hw-external-monitors' "$hw_clamshell" >/dev/null
-grep -F '/proc/acpi/button/lid/*/state' "$hw_laptop_closed" >/dev/null
+grep -F 'org.freedesktop.login1.Manager LidClosed' "$hw_laptop_closed" >/dev/null
+grep -F ':-/proc/acpi/button/lid}' "$hw_laptop_closed" >/dev/null
 pass "clamshell helper detects closed-lid external monitor state"
 
 # A mirrored external is absent from plain `monitors`, so asking without `all`


### PR DESCRIPTION
Fixes #9753.


`omarchy-hw-laptop-closed` trusted `/proc/acpi/button/lid/*/state` alone. Firmware `_LID` methods can report stale state. On my Razer Blade Stealth 13 (Late 2019), ACPI reported `closed` for over an hour of lid-open use, so every external-monitor hotplug entered clamshell mode and blanked the internal panel, while logind had the correct answer the whole time from the evdev lid switch:

```
$ cat /proc/acpi/button/lid/LID0/state
state:      closed                                # lid physically open

$ busctl get-property org.freedesktop.login1 /org/freedesktop/login1 \
    org.freedesktop.login1.Manager LidClosed
b false                                           # logind, correct
```

This asks logind first and keeps the ACPI loop as the fallback:

- `busctl get-property ... org.freedesktop.login1.Manager LidClosed`, parsed as `b true`/`b false`.
- Empty busctl output (no running logind, e.g. install chroots) falls through to the ACPI read, now behind an `OMARCHY_ACPI_LID_PATH` seam matching the other `hw-` probes (`OMARCHY_DRM_PATH`, `OMARCHY_USB_DEVICES_PATH`, ...).

No new dependencies; busctl ships with systemd.

`test/shell.d/hw-laptop-closed-test.sh` pins five behaviors from fixtures: logind-closed, logind-open despite stale ACPI (the bug), and the three ACPI fallback states (closed, open, no lid device). Against the old script the stale-ACPI scenario fails; against this change all five pass:

```
not ok - a lid logind reports closed is closed          # old script
ok - a lid logind reports closed is closed              # fixed
ok - a lid logind reports open is open despite stale ACPI
ok - without logind a closed ACPI lid is closed
ok - without logind an open ACPI lid is open
ok - no lid device at all means open
```

The source pin in `monitor-recovery-test.sh` is updated to match the new mechanism.

Callers affected beyond clamshell: the PAM fingerprint gate in `/etc/pam.d/sudo` and `/etc/pam.d/polkit-1` runs this as root at auth time (busctl uses the system bus by default; unreachable D-Bus falls back to ACPI as today), and `PolkitAgent.qml` samples it per auth request. The stale-ACPI failure mode mis-answers those consumers too, so they are corrected together.

Verified on the affected hardware: with ACPI stuck on closed and the lid open, the old script reported closed and the clamshell path disabled eDP-1 on hotplug; the new script follows logind and the panel stays up. `./test/cli` passes; `./test/shell` matches the base commit (the four failures on my machine fail identically on a clean checkout of the base and want a live Omarchy runtime).
