### PR TITLE
Refresh monitor brightness state every second

### DIFF
--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -376,8 +376,10 @@ Panel {
   // Only poll while the panel is open; the bar glyph tracks monitor count via
   // Quickshell.screens, and open-time refresh + Component.onCompleted cover the
   // rest. External brightness changes are reflected whenever the panel is open.
+  // Keep this to one second so brightness keys update the open slider promptly
+  // without turning the full monitor-state command into a hot poll.
   Timer {
-    interval: 5000
+    interval: 1000
     running: root.opened
     repeat: true
     onTriggered: root.refresh()


### PR DESCRIPTION
## Summary
- Changing the monitor brightness via keyboard while the monitor panel is open showed a delay in the brightness slider being updated.
- refresh the open monitor panel state every second instead of every five seconds
- keep external brightness changes from leaving the slider stale
- avoid a 250ms hot poll because the refresh reads all monitor state and launches multiple helpers

## Review
Reviewed recurring refresh timers across the default plugins. This is the only interval that was both user-visible and unnecessarily stale. Other intervals are event-driven, action-specific, network-backed, or already responsive, so they remain unchanged.

Related existing work checked:
- #7293 stale battery charge state
- #6897 event-driven mute state
- #8087 stale Wi-Fi icon recovery

## Validation
- `bash test/shell.d/monitor-test.sh`
- `bash test/shell.d/monitor-state-test.sh`
- local command-cost sampling for `omarchy-monitor-state`