### PR TITLE
List hybrid plugins as enabled when they live in plugins[]

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -166,6 +166,28 @@ QtObject {
     return findEntryLocation(config, id).kind === "bar"
   }
 
+  function inPlugins(id) {
+    var config = shellConfigProvider ? shellConfigProvider() : null
+    return findEntryLocation(config, id).kind === "plugin"
+  }
+
+  // What `omarchy plugin list` reports. A bar-only widget's on/off switch is
+  // its place in bar.layout. A plugin that is also an overlay, service, panel,
+  // or menu can be on via plugins[] without a layout slot — its glyph may sit
+  // inside another widget — so inBar alone would list a running overlay as
+  // disabled. First-party hybrids stay loadable off the bar (isEnabled) but
+  // still list from the widget slot, matching enable/disable.
+  function listedEnabled(id) {
+    var key = String(id)
+    var manifest = installedPlugins[key]
+    if (!manifest) return false
+    var kinds = manifest.kinds || []
+    if (Array.isArray(kinds) && kinds.indexOf("bar") !== -1) return isEnabled(key)
+    if (Array.isArray(kinds) && kinds.indexOf("bar-widget") !== -1)
+      return inBar(key) || inPlugins(key)
+    return isEnabled(key)
+  }
+
   function defaultBarWidgetSection(manifest) {
     var metadata = manifest && Util.isPlainObject(manifest.barWidget) ? manifest.barWidget : null
     var section = metadata ? String(metadata.defaultSection || "") : ""

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -955,7 +955,6 @@ ShellRoot {
       for (var id in plugins) {
         var kinds = plugins[id].kinds || []
         var isBarOption = Array.isArray(kinds) && kinds.indexOf("bar") !== -1
-        var isBarWidget = Array.isArray(kinds) && kinds.indexOf("bar-widget") !== -1
         var active = isBarOption && shell.isActiveBarOption(id)
         var metadata = plugins[id].omarchy
         var clonedFrom = Util.isPlainObject(metadata) ? String(metadata.clonedFrom || "") : ""
@@ -963,10 +962,11 @@ ShellRoot {
           id: id,
           name: plugins[id].name,
           kinds: kinds,
-          // What `omarchy plugin enable/disable` toggles: for a widget that is
-          // its place in the bar, not whether its component is loadable.
-          enabled: isBarOption ? active
-            : (isBarWidget ? shell.pluginRegistry.inBar(id) : shell.pluginRegistry.isEnabled(id)),
+          // What `omarchy plugin enable/disable` toggles. A bar-only widget's
+          // place is the layout. A plugin that is also an overlay/service can
+          // be on via plugins[] without sitting in bar.layout; inBar alone
+          // would list it disabled while it is still loaded.
+          enabled: isBarOption ? active : shell.pluginRegistry.listedEnabled(id),
           active: active,
           // A bar has no off, only a successor: you leave one by enabling
           // another, so there is nothing for disable to do to it. Said here so

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -87,6 +87,7 @@ ShellRoot {
     scan += block("thirdparty", "/third/widget", manifest("third.widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "left" }))
     scan += block("thirdparty", "/third/center-widget", manifest("third.center-widget", ["bar-widget"], { barWidget: "Widget.qml" }))
     scan += block("thirdparty", "/third/right-widget", manifest("third.right-widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "right" }))
+    scan += block("thirdparty", "/third/hybrid", manifest("third.hybrid", ["overlay", "bar-widget"], { overlay: "Overlay.qml", barWidget: "Widget.qml" }))
     var localWidget = manifest("local.first-widget", ["bar-widget"], { barWidget: "Widget.qml" })
     localWidget.omarchy = { clonedFrom: "omarchy.first-widget" }
     scan += block("thirdparty", "/third/local-widget", localWidget)
@@ -125,6 +126,7 @@ ShellRoot {
       "omarchy.hybrid",
       "third.bar",
       "third.center-widget",
+      "third.hybrid",
       "third.panel",
       "third.right-widget",
       "third.widget"
@@ -435,6 +437,39 @@ ShellRoot {
     root.assertDeepEqual(root.config.bar.layout.left, [], "disabling a multi-kind built-in removes its widget")
     root.assertTrue(root.config.disabledPlugins === undefined, "disabling a multi-kind widget records nothing else")
     root.assertTrue(registry.isEnabled("omarchy.hybrid"), "a multi-kind built-in remains loadable without its widget")
+    root.assertTrue(!registry.inBar("omarchy.hybrid"), "a multi-kind built-in off the bar is not inBar")
+    root.assertTrue(!registry.inPlugins("omarchy.hybrid"), "a multi-kind built-in is not recorded in plugins[]")
+    root.assertTrue(!registry.listedEnabled("omarchy.hybrid"), "listPlugins still follows the widget slot for a built-in hybrid")
+
+    // A third-party overlay that is also a bar-widget can be on via plugins[]
+    // without a layout slot — its glyph may live inside another widget instead
+    // of sitting in bar.layout. inBar is then false, but the overlay is loaded.
+    root.config = {
+      version: 1,
+      bar: { layout: { left: [], center: [], right: [] } },
+      plugins: [{ id: "third.hybrid" }]
+    }
+    root.assertTrue(!registry.inBar("third.hybrid"), "a plugins[] hybrid is not in the bar layout")
+    root.assertTrue(registry.inPlugins("third.hybrid"), "inPlugins sees a plugins[] entry")
+    root.assertTrue(registry.isEnabled("third.hybrid"), "a plugins[] hybrid is loaded")
+    root.assertTrue(registry.listedEnabled("third.hybrid"), "listPlugins treats a plugins[] hybrid as enabled")
+
+    root.config = {
+      version: 1,
+      bar: { layout: { left: [], center: [], right: [] } },
+      plugins: []
+    }
+    root.assertTrue(!registry.inPlugins("third.hybrid"), "inPlugins is false without a plugins[] entry")
+    root.assertTrue(!registry.listedEnabled("third.hybrid"), "an unreferenced third-party hybrid lists as disabled")
+
+    root.config = {
+      version: 1,
+      bar: { layout: { left: [], center: [{ id: "third.widget" }], right: [] } },
+      plugins: []
+    }
+    root.assertTrue(registry.listedEnabled("third.widget"), "a bar-only widget on the bar still lists as enabled")
+    registry.setEnabled("third.widget", false)
+    root.assertTrue(!registry.listedEnabled("third.widget"), "a bar-only widget off the bar still lists as disabled")
 
     var cloneBase = registry.pluginsDir + "/dhh.clock"
     root.assertEqual(registry.localPluginIdForPath(cloneBase + "/BarWidget.qml"), "dhh.clock", "personal clone changes are watched")


### PR DESCRIPTION
`omarchy plugin list` treated any plugin with `bar-widget` in its kinds as enabled only if the id sat in `bar.layout`. That is the right switch for a bar-only widget. It is the wrong switch for a plugin that is also an overlay or service.

Those hybrids can be on via `plugins[]` without a top-level layout slot. The glyph may live inside another widget (a tray host, for example) instead of in `left`/`center`/`right`. The overlay is loaded, `isEnabled` is true, and the list still said disabled.

This showed up with `perfektnacht.controller-launcher` (`service`, `overlay`, `bar-widget`): it was in `plugins[]` and hosted inside a tray, the wheel summoned fine, and `omarchy plugin list` reported disabled. `omarchy plugin enable` returned ok and changed nothing.

`listedEnabled` now treats a `plugins[]` entry as on for bar-widgets. First-party hybrids are unchanged: taking `omarchy.menu` off the bar still lists it disabled, while `isEnabled` keeps the menu loadable.

## Test plan
- [x] `bash test/shell.d/plugin-registry-contract-test.sh`
- [x] plugin enable/clone/add/validate and menu-plugin tests