### PR TITLE
Give the SDDM greeter the system keyboard layout

### DIFF
--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -1,58 +1,13 @@
 -- https://wiki.hypr.land/Configuring/Basics/Variables/#input
 
-local function read_vconsole()
-  local values = {}
-  local file = io.open("/etc/vconsole.conf", "r")
-  if not file then
-    return values
-  end
-
-  for line in file:lines() do
-    local key, value = line:match("^%s*([%w_]+)%s*=%s*(.-)%s*$")
-    if key and value then
-      value = value:gsub("%s+#.*$", "")
-      value = value:gsub('^"(.*)"$', "%1")
-      value = value:gsub("^'(.*)'$", "%1")
-      values[key] = value
-    end
-  end
-
-  file:close()
-  return values
-end
-
--- Layouts that can't type Latin letters. Keep in sync with the list in
--- etc/mkinitcpio.conf.d/omarchy_hooks.conf.
-local non_latin_layouts =
-  " af am ara bd bg by et ge gr il in iq ir kg kh kz la lk mk mm mn mv np rs ru sy th tj ua "
-
-local vconsole = read_vconsole()
-
-local kb_layout = vconsole.XKBLAYOUT or "us"
-local kb_variant = vconsole.XKBVARIANT or ""
--- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
--- Both Shifts together is the usual home for it, but it's easy to hit by
--- accident while typing. The _cancel variant sets Caps Lock the same way and
--- releases it on the next lone Shift, so a misfire clears itself.
-local kb_options = "compose:caps,shift:both_capslock_cancel"
-
--- Hyprland resolves keybindings against the first entry in kb_layout, not the
--- layout that's currently active, so Omarchy's Latin-keysym bindings (SUPER + W
--- and friends) only fire when a Latin layout leads. Installing with a non-Latin
--- one would otherwise leave the desktop unusable.
-if non_latin_layouts:find(" " .. kb_layout:match("^[^,]*") .. " ", 1, true) then
-  kb_layout = "us," .. kb_layout
-  kb_variant = "," .. kb_variant
-  -- Reach the original layout with Left Alt + Right Alt.
-  kb_options = kb_options .. ",grp:alts_toggle"
-end
+local keyboard = require("default.hypr.keyboard")
 
 hl.config({
   input = {
-    kb_layout = kb_layout,
-    kb_variant = kb_variant,
+    kb_layout = keyboard.layout,
+    kb_variant = keyboard.variant,
     kb_model = "",
-    kb_options = kb_options,
+    kb_options = keyboard.options,
     kb_rules = "",
     follow_mouse = 1,
     sensitivity = 0,

--- a/default/hypr/keyboard.lua
+++ b/default/hypr/keyboard.lua
@@ -1,0 +1,60 @@
+-- Keyboard layout resolved from the system's /etc/vconsole.conf.
+-- Shared by the user session (default/hypr/input.lua) and by the SDDM greeter
+-- (default/sddm/hyprland.lua). They are separate Hyprland instances, but a
+-- password is typed at one and set from the other, so both have to agree on
+-- the layout.
+
+local function read_vconsole()
+  local values = {}
+  local file = io.open("/etc/vconsole.conf", "r")
+  if not file then
+    return values
+  end
+
+  for line in file:lines() do
+    local key, value = line:match("^%s*([%w_]+)%s*=%s*(.-)%s*$")
+    if key and value then
+      value = value:gsub("%s+#.*$", "")
+      value = value:gsub('^"(.*)"$', "%1")
+      value = value:gsub("^'(.*)'$", "%1")
+      values[key] = value
+    end
+  end
+
+  file:close()
+  return values
+end
+
+-- Layouts that can't type Latin letters. Keep in sync with the list in
+-- etc/mkinitcpio.conf.d/omarchy_hooks.conf.
+local non_latin_layouts =
+  " af am ara bd bg by et ge gr il in iq ir kg kh kz la lk mk mm mn mv np rs ru sy th tj ua "
+
+local vconsole = read_vconsole()
+
+local kb_layout = vconsole.XKBLAYOUT or "us"
+local kb_variant = vconsole.XKBVARIANT or ""
+-- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
+-- Both Shifts together is the usual home for it, but it's easy to hit by
+-- accident while typing. The _cancel variant sets Caps Lock the same way and
+-- releases it on the next lone Shift, so a misfire clears itself.
+local kb_options = "compose:caps,shift:both_capslock_cancel"
+
+-- Hyprland resolves keybindings against the first entry in kb_layout, not the
+-- layout that's currently active, so Omarchy's Latin-keysym bindings (SUPER + W
+-- and friends) only fire when a Latin layout leads. Installing with a non-Latin
+-- one would otherwise leave the desktop unusable. The greeter needs the same
+-- fallback for a different reason: passwords are Latin, so a non-Latin-only
+-- layout would leave the correct one untypeable at the login prompt.
+if non_latin_layouts:find(" " .. kb_layout:match("^[^,]*") .. " ", 1, true) then
+  kb_layout = "us," .. kb_layout
+  kb_variant = "," .. kb_variant
+  -- Reach the original layout with Left Alt + Right Alt.
+  kb_options = kb_options .. ",grp:alts_toggle"
+end
+
+return {
+  layout = kb_layout,
+  variant = kb_variant,
+  options = kb_options,
+}

--- a/default/sddm/hyprland.lua
+++ b/default/sddm/hyprland.lua
@@ -1,6 +1,22 @@
 -- Minimal Hyprland config for the SDDM Wayland greeter.
 -- SDDM starts the greeter itself after the compositor is ready.
+
+-- The greeter is its own Hyprland instance, started by sddm-helper instead of
+-- the user session, so it never runs default/hypr/bootstrap.lua. Set up just
+-- enough of the module path to share the session's layout resolution: with no
+-- input block Hyprland falls back to its built-in "us" default, and a password
+-- set under any other layout cannot be typed at the login prompt.
+package.path = (os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/?.lua;" .. package.path
+
+local keyboard = require("default.hypr.keyboard")
+
 hl.config({
+  input = {
+    kb_layout = keyboard.layout,
+    kb_variant = keyboard.variant,
+    kb_options = keyboard.options,
+  },
+
   misc = {
     disable_hyprland_logo = true,
     disable_splash_rendering = true,

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -4,10 +4,10 @@ source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 require_command lua
 
-resolved_input() {
-  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua <<'LUA'
-package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
-
+# The session and the greeter are separate Hyprland instances that must resolve
+# the same layout, so both are driven through the same stubbed vconsole.conf.
+lua_stub() {
+  cat <<'LUA'
 local vconsole = os.getenv("OMARCHY_VCONSOLE")
 local real_open = io.open
 
@@ -34,25 +34,44 @@ hl = {
 }
 
 o = { window = function() end }
-
-require("default.hypr.input")
 LUA
 }
 
-assert_input() {
-  local description="$1"
-  local expected="$2"
+resolved_input() {
+  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua -e "$(lua_stub)" \
+    -e 'package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path' \
+    -e 'require("default.hypr.input")'
+}
+
+# Loaded the way SDDM loads it: by path, with no module path set up for it.
+resolved_greeter() {
+  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua -e "$(lua_stub)" \
+    -e 'dofile(os.getenv("OMARCHY_PATH") .. "/default/sddm/hyprland.lua")'
+}
+
+assert_resolved() {
+  local resolver="$1"
+  local description="$2"
+  local expected="$3"
   local actual
 
-  if (( $# > 2 )); then
-    actual=$(resolved_input "$3")
+  if (( $# > 3 )); then
+    actual=$("$resolver" "$4")
   else
-    actual=$(resolved_input)
+    actual=$("$resolver")
   fi
 
   [[ $actual == "$expected" ]] ||
     fail "$description" "expected: $expected"$'\n'"actual:   $actual"
   pass "$description"
+}
+
+assert_input() {
+  assert_resolved resolved_input "$@"
+}
+
+assert_greeter() {
+  assert_resolved resolved_greeter "$@"
 }
 
 base_options="compose:caps,shift:both_capslock_cancel"
@@ -73,11 +92,22 @@ XKBVARIANT=phonetic
 assert_input "non-latin layout in front gains us even when us trails" "[us,il,us] [,] [$toggle_options]" 'XKBLAYOUT=il,us
 '
 
+# A greeter left on Hyprland's built-in "us" default makes a password set under
+# any other layout untypeable at the login prompt.
+assert_greeter "greeter falls back to us without vconsole.conf" "[us] [] [$base_options]"
+assert_greeter "greeter follows the system layout" "[be] [] [$base_options]" 'XKBLAYOUT=be
+'
+assert_greeter "greeter keeps the variant" "[de] [nodeadkeys] [$base_options]" 'XKBLAYOUT=de
+XKBVARIANT=nodeadkeys
+'
+assert_greeter "greeter keeps a latin layout reachable for passwords" "[us,ru] [,] [$toggle_options]" 'XKBLAYOUT=ru
+'
+
 hooks_conf="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
-input_lua="$ROOT/default/hypr/input.lua"
+keyboard_lua="$ROOT/default/hypr/keyboard.lua"
 
 hooks_layouts=$(awk -F')' '/\) ;;$/ { gsub(/[[:space:]|]+/, "\n", $1); print $1 }' "$hooks_conf" | grep '^[a-z]\+$' | sort)
-lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$input_lua" | grep -o '"[^"]*"' | tr -d '"' | tr ' ' '\n' | grep '^[a-z]\+$' | sort)
+lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$keyboard_lua" | grep -o '"[^"]*"' | tr -d '"' | tr ' ' '\n' | grep '^[a-z]\+$' | sort)
 
 [[ -n $hooks_layouts ]] || fail "non-latin layout list is readable from omarchy_hooks.conf"
 [[ $hooks_layouts == "$lua_layouts" ]] ||


### PR DESCRIPTION
Fixes #6880. Also covers #9421, which reports the same bug independently.

## The bug

The SDDM Wayland greeter runs its own Hyprland instance:

```ini
# etc/sddm.conf.d/10-wayland.conf
CompositorCommand=start-hyprland -- --config /usr/share/sddm/hyprland.lua
```

`default/sddm/hyprland.lua` set only `misc` and `animations` — no `input` block — so Hyprland fell back to its built-in `us` default. A password set under any other layout cannot be typed at the login prompt, while the LUKS prompt (vconsole `KEYMAP`) and the user session (`default/hypr/input.lua`, which reads `XKBLAYOUT`) both get it right.

It is easy to miss because autologin skips the greeter at boot: the first time most users meet it is after an explicit logout, and then they simply cannot log back in.

## The fix

`default/hypr/input.lua` already resolved the layout from `/etc/vconsole.conf`. That block moves to `default/hypr/keyboard.lua`, which returns `{ layout, variant, options }`, and both configs read it — so the session and the greeter cannot drift apart. No behaviour change for the session; the test below pins that.

The greeter is started by sddm-helper rather than the user session, so it never runs `default/hypr/bootstrap.lua`. It sets up just the module path it needs, with the same `os.getenv("OMARCHY_PATH") or "/usr/share/omarchy"` idiom `config/hypr/hyprland.lua` already uses (deliberately not `bootstrap.lua`, which dereferences `$HOME` — not something to rely on in the greeter's environment).

The non-Latin fallback carries over to the greeter, and matters more there than in the session: passwords are Latin, so a non-Latin-only layout would leave the correct password untypeable. Same reasoning as the `vconsole.conf` guard in `etc/mkinitcpio.conf.d/omarchy_hooks.conf`.

`kb_model` and `numlock_by_default` are deliberately left alone — out of scope for this bug.

## Verification

`test/shell.d/hyprland-keyboard-layout-test.sh` gains four greeter assertions alongside the existing session ones, driven through the same stubbed `vconsole.conf`. The greeter is loaded the way SDDM loads it — by path, with no module path prepared for it — so the `package.path` line is exercised rather than assumed. The non-Latin-list sync check now reads `default/hypr/keyboard.lua`.

```
ok - greeter falls back to us without vconsole.conf
ok - greeter follows the system layout
ok - greeter keeps the variant
ok - greeter keeps a latin layout reachable for passwords
```

`./test/all`: 222 of 226 shell test files pass. The 4 failures (`config`, `snapper`, `unowned-system-paths`, `bar-icon-geometry`) fail identically on an unmodified checkout here — the first three want an `omarchy-pkgs` checkout, the last is sub-pixel monitor geometry.

Beyond the stubs, the greeter config was run as a real nested Hyprland instance (headless backend) on a `be` system:

```
$ hyprctl -i <nested> getoption input:kb_layout
str: be
$ hyprctl -i <nested> devices -j | jq '.keyboards[].active_keymap'
"Belgian"
$ hyprctl -i <nested> configerrors
(empty)
```

with `misc.disable_hyprland_logo` and `animations.enabled` still resolving to the values the file already set.

## Note for maintainers

The two open reports carry workarounds that no longer hold: #9421 edits the packaged `/usr/share/sddm/hyprland.lua`, which `omarchy update` silently reverts, and #6880 predates the move to Lua (it uses `source =` against the old `hyprland.conf`) and hardcodes one layout. Worth closing both on this rather than leaving those recipes as the answer.

Reported on Omarchy 4.0.2-1, Hyprland 0.56.2-1, sddm 0.21.0-7, layout `be`.
