### PR TITLE
fix(power): handle PendingDischarge state and sanitize rate metrics for battery charge limits

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -56,11 +56,22 @@ function chargeThresholdActive(device, onBattery, states) {
 
   var fraction = batteryFraction(d)
   if (d.state === s.Discharging) return false
-  if (d.state === s.PendingCharge) return true
+  // Firmware and UPower do not agree on one state for a charge-limit hold:
+  // both pending states have been observed while connected to AC.
+  if (d.state === s.PendingCharge || d.state === s.PendingDischarge) return true
   if (d.state === s.FullyCharged && fraction < 0.99) return true
-  if (d.state !== s.Charging || fraction >= 0.99) return false
+  if (fraction >= 0.99) return false
 
-  return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
+  // An AC-connected battery in a non-charging, non-discharging state is
+  // holding its level even when the driver reports it as Unknown.
+  if (d.state !== s.Charging) return true
+
+  // Only use measurements that the driver actually supplied. Treating a
+  // missing rate as zero caused state detection to depend on firmware quirks.
+  var rate = Number(d.changeRate)
+  var timeToFull = Number(d.timeToFull)
+  return (isFinite(rate) && rate <= 0.2) ||
+    (isFinite(timeToFull) && timeToFull >= 8 * 60 * 60)
 }
 
 function batteryIcon(device, onBattery, states) {
@@ -72,7 +83,10 @@ function batteryIcon(device, onBattery, states) {
   var index = Math.max(0, Math.min(9, Math.floor(d.percentage * 10)))
   var threshold = chargeThresholdActive(d, onBattery, states)
 
-  if (threshold) return defaultIcons[index]
+  // battery-plus-variant keeps the plus inside the battery body. The regular
+  // battery-plus glyph places it at the lower-right edge, where it vanishes
+  // at the compact size used by the top bar.
+  if (threshold) return "󱟦"
   if (d.state === states.FullyCharged) return "󰂅"
   if (!onBattery) return chargingIcons[index]
   return defaultIcons[index]

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -78,16 +78,18 @@ function batteryIcon(device, onBattery, states) {
   var d = device || {}
   if (!d.isPresent) return ""
 
+  // battery_charging_10..100 — the MDI charging series; its codepoints are
+  // scattered across the font, so the literals below are the ordered set.
   var chargingIcons = ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"]
   var defaultIcons = ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
   var index = Math.max(0, Math.min(9, Math.floor(d.percentage * 10)))
   var threshold = chargeThresholdActive(d, onBattery, states)
 
-  // battery-plus-variant keeps the plus inside the battery body. The regular
-  // battery-plus glyph places it at the lower-right edge, where it vanishes
-  // at the compact size used by the top bar.
+  // battery-plus (U+F17E6) marks a charge-limit hold: a full battery with a
+  // plus, reading as "limit" next to the bolt used while actively charging.
   if (threshold) return "󱟦"
-  if (d.state === states.FullyCharged) return "󰂅"
+  // battery-check (U+F17E2): charged and holding, not actively charging.
+  if (d.state === states.FullyCharged) return "󱟢"
   if (!onBattery) return chargingIcons[index]
   return defaultIcons[index]
 }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -34,7 +34,10 @@ Panel {
       Charging: UPowerDeviceState.Charging,
       Discharging: UPowerDeviceState.Discharging,
       FullyCharged: UPowerDeviceState.FullyCharged,
-      PendingCharge: UPowerDeviceState.PendingCharge
+      PendingCharge: UPowerDeviceState.PendingCharge,
+      // Some firmware reports a charge limit as PendingDischarge rather than
+      // PendingCharge while the laptop is connected to AC.
+      PendingDischarge: UPowerDeviceState.PendingDischarge
     }
   }
 

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -8,7 +8,7 @@ run_node_test <<'JS'
 const fs = require('fs')
 const power = requireFromRoot('shell/plugins/panels/power/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/power/Panel.qml', 'utf8')
-const states = { Charging: 1, Discharging: 2, FullyCharged: 3, PendingCharge: 4 }
+const states = { Charging: 1, Discharging: 2, FullyCharged: 3, PendingCharge: 4, PendingDischarge: 5 }
 
 assertEqual(power.selectProfileIndex(0, 1, ['balanced', 'performance']), 1, 'power advances profile selection')
 assertEqual(power.selectProfileIndex(1, 1, ['balanced', 'performance']), 1, 'power clamps profile selection')
@@ -24,13 +24,17 @@ assert(power.profileIcon('performance').length > 0, 'power maps profile icons')
 assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'power clamps battery fraction')
 
 assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power detects threshold by pending charge state')
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingDischarge }, false, states), 'power detects threshold by pending discharge state on AC')
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: 0 }, false, states), 'power detects threshold by non-charging state on AC')
 assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states), 'power detects threshold by stalled charging')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, timeToFull: 120 }, false, states), 'power does not treat missing rate as stalled charge threshold')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states), 'power does not flag active charging as threshold')
 assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'Charging', 'power treats external power as newer than stale discharging state')
 assert(power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging }, false, states).length > 0, 'power maps battery icons')
+assertEqual(power.batteryIcon({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), '󱟦', 'power returns battery-plus-variant icon at threshold')
 assertEqual(
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Discharging }, false, states),
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states),
@@ -48,4 +52,5 @@ assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
+assert(/PendingDischarge: UPowerDeviceState\.PendingDischarge/.test(panelSource), 'power maps PendingDischarge UPower state')
 JS

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -34,7 +34,8 @@ assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.Full
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'Charging', 'power treats external power as newer than stale discharging state')
 assert(power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging }, false, states).length > 0, 'power maps battery icons')
-assertEqual(power.batteryIcon({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), '󱟦', 'power returns battery-plus-variant icon at threshold')
+assertEqual(power.batteryIcon({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), '󱟦', 'power returns the battery-plus glyph at threshold')
+assertEqual(power.batteryIcon({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), '󱟢', 'power returns the battery-check glyph when fully charged')
 assertEqual(
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Discharging }, false, states),
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states),


### PR DESCRIPTION
## Summary

When a laptop has a battery charge threshold/limit configured (such as an 80% maximum charge cap common on ASUS, Lenovo, Dell, Framework, and other modern laptops), UPower and device firmware frequently report `PendingDischarge` or non-charging states while connected to AC power.

Additionally:
1. Treating missing `changeRate` or `timeToFull` values as `0` caused charge threshold detection to falsely trigger or misbehave depending on whether the hardware driver exposed rate metrics.
2. The charge-holding marker is deliberately the `battery-plus` glyph (`󱟦`) — a full battery with a plus — kept visually distinct from the bolt used while charging.

## Changes

- **`shell/plugins/panels/power/Model.js`**:
  - Accept `PendingDischarge` as a threshold state when on AC power (`d.state === s.PendingCharge || d.state === s.PendingDischarge`).
  - Add fallback for AC-connected batteries in non-charging, non-discharging states holding their charge level.
  - Guard `changeRate` and `timeToFull` calculations with `isFinite()` checks so missing measurements are not coerced to zero.
  - Switch the threshold glyph to `battery-plus` (`󱟦`) — a full battery with a plus marking the limit hold, complementing the bolt used while charging — and the fully-charged glyph to `battery-check` (`󱟢`). The charging series (`battery_charging_10`–`100`) already complements both and is unchanged.
- **`shell/plugins/panels/power/Panel.qml`**:
  - Map `UPowerDeviceState.PendingDischarge` in `upowerStates()`.
- **`test/shell.d/power-test.sh`**:
  - Add test coverage for `PendingDischarge` on AC, non-charging AC threshold holds, sanitized missing rate metrics, and `battery-plus`/`battery-check` icon mapping.

## Verification

- Automated tests in `test/shell.d/power-test.sh` pass (28 assertions).
- Automated CLI tests in `./test/cli` pass (107 assertions).
