### PR TITLE
feat(menu): add in-order fuzzy search scoring to application launcher

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -40,7 +40,7 @@ submenu. The fields:
 | `target` | Existing submenu id to open; makes the row a link |
 | `provider` | Runtime row source for this submenu (see Providers) |
 | `aliases` | Alternate `omarchy menu summon <name>` routes; also searchable |
-| `description` | Subtitle shown while searching, and extra search text matched by whole word |
+| `description` | Subtitle shown while searching, and extra search text matched by whole word or in-order fuzzy match |
 | `when` / `checked` / `disabled` | Shell conditions (see Guards) |
 
 Do not add `aliases` to new entries. They are reserved for established

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -320,6 +320,44 @@ function descriptionTextMatches(query, text) {
   return true
 }
 
+// Return a lower-is-better score when every character in `term` appears in
+// order in `text`. This makes "stm" match both "System" and "Steam", while
+// keeping contiguous and word-start matches ahead of scattered ones.
+function fuzzyTextScore(term, text) {
+  var needle = String(term || "").toLowerCase()
+  var haystack = String(text || "").toLowerCase()
+  if (!needle) return 0
+
+  var position = -1
+  var previous = -1
+  var score = 0
+  for (var i = 0; i < needle.length; i++) {
+    position = haystack.indexOf(needle.charAt(i), position + 1)
+    if (position < 0) return -1
+
+    // Earlier matches, word starts, and consecutive characters rank first.
+    score += position === 0 || /[\s._:/\\-]/.test(haystack.charAt(position - 1)) ? -4 : 0
+    if (previous >= 0) score += Math.max(0, position - previous - 1) * 2
+    previous = position
+  }
+
+  // Keep -1 reserved for no match; word-start bonuses may otherwise make a
+  // successful short match negative.
+  return 10 + score + Math.max(0, position - needle.length + 1)
+}
+
+function fuzzyQueryScore(query, text) {
+  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
+  var score = 0
+  for (var i = 0; i < terms.length; i++) {
+    if (!terms[i]) continue
+    var termScore = fuzzyTextScore(terms[i], text)
+    if (termScore < 0) return -1
+    score += termScore
+  }
+  return score
+}
+
 function matchesQuery(entry, query, visible) {
   if (!entry || entry.id === "root") return false
   if (!visible) return false
@@ -330,8 +368,9 @@ function matchesQuery(entry, query, visible) {
 
   for (var i = 0; i < terms.length; i++) {
     if (!terms[i]) continue
-    if (nameText.indexOf(terms[i]) >= 0) continue
+    if (fuzzyTextScore(terms[i], nameText) >= 0) continue
     if (termInSearchWords(terms[i], descriptionText)) continue
+    if (fuzzyTextScore(terms[i], descriptionText) >= 0) continue
     return false
   }
 
@@ -353,7 +392,12 @@ function searchScore(items, entry, query) {
   else if (label.indexOf(needle) >= 0) score = 30
   else if (nameText.indexOf(needle) >= 0) score = 40
   else if (descriptionTextMatches(needle, descriptionText)) score = 60
-
+  else {
+    var nameFuzzyScore = fuzzyQueryScore(needle, nameText)
+    var descriptionFuzzyScore = fuzzyQueryScore(needle, descriptionText)
+    if (nameFuzzyScore >= 0) score = 70 + nameFuzzyScore
+    else if (descriptionFuzzyScore >= 0) score = 100 + descriptionFuzzyScore
+  }
   if (entry.kind === "menu" || entry.kind === "link") score -= 2
   // App rows sort after all menu items, so they lose the tiebreak below to an
   // equal match. Outrank those, but stay inside the tier so better ones win.
@@ -517,6 +561,8 @@ if (typeof module !== "undefined") {
     nameSearchText: nameSearchText,
     termInSearchWords: termInSearchWords,
     descriptionTextMatches: descriptionTextMatches,
+    fuzzyTextScore: fuzzyTextScore,
+    fuzzyQueryScore: fuzzyQueryScore,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
     displayRow: displayRow

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -313,7 +313,7 @@ function termInSearchWords(term, text) {
 }
 
 function descriptionTextMatches(query, text) {
-  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
+  var terms = queryTerms(query)
   for (var i = 0; i < terms.length; i++) {
     if (terms[i] && !termInSearchWords(terms[i], text)) return false
   }
@@ -335,19 +335,25 @@ function fuzzyTextScore(term, text) {
     position = haystack.indexOf(needle.charAt(i), position + 1)
     if (position < 0) return -1
 
-    // Earlier matches, word starts, and consecutive characters rank first.
+    // Earlier matches, word starts (whitespace and . _ : / \ - delimiters),
+    // and consecutive characters rank first.
     score += position === 0 || /[\s._:/\\-]/.test(haystack.charAt(position - 1)) ? -4 : 0
     if (previous >= 0) score += Math.max(0, position - previous - 1) * 2
     previous = position
   }
 
-  // Keep -1 reserved for no match; word-start bonuses may otherwise make a
-  // successful short match negative.
-  return 10 + score + Math.max(0, position - needle.length + 1)
+  // Keep -1 reserved for no match, and floor successful matches at 1:
+  // word-start bonuses can otherwise drive a verbatim substring ("a.b.c"
+  // matching itself) negative, hiding rows the exact search used to find.
+  return Math.max(1, 10 + score + Math.max(0, position - needle.length + 1))
+}
+
+function queryTerms(query) {
+  return String(query || "").toLowerCase().trim().split(/\s+/)
 }
 
 function fuzzyQueryScore(query, text) {
-  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
+  var terms = queryTerms(query)
   var score = 0
   for (var i = 0; i < terms.length; i++) {
     if (!terms[i]) continue
@@ -364,7 +370,7 @@ function matchesQuery(entry, query, visible) {
 
   var nameText = nameSearchText(entry)
   var descriptionText = String(entry.description || "").toLowerCase()
-  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
+  var terms = queryTerms(query)
 
   for (var i = 0; i < terms.length; i++) {
     if (!terms[i]) continue
@@ -393,9 +399,13 @@ function searchScore(items, entry, query) {
   else if (nameText.indexOf(needle) >= 0) score = 40
   else if (descriptionTextMatches(needle, descriptionText)) score = 60
   else {
+    // Fuzzy tiers rank behind every exact tier (0-60); the 80 default never
+    // competes because matchesQuery gates the list first. Name matches cap
+    // below the description tier so a scattered multi-term name match cannot
+    // invert name-over-description ordering.
     var nameFuzzyScore = fuzzyQueryScore(needle, nameText)
     var descriptionFuzzyScore = fuzzyQueryScore(needle, descriptionText)
-    if (nameFuzzyScore >= 0) score = 70 + nameFuzzyScore
+    if (nameFuzzyScore >= 0) score = Math.min(99, 70 + nameFuzzyScore)
     else if (descriptionFuzzyScore >= 0) score = 100 + descriptionFuzzyScore
   }
   if (entry.kind === "menu" || entry.kind === "link") score -= 2

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -104,6 +104,17 @@ assert(!menu.matchesQuery(entry, 'missing', true), 'menu rejects missing terms')
 assert(!menu.matchesQuery(entry, 'theme', false), 'menu hides invisible matches')
 assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'appearance'), 'menu scores name matches above description matches')
 
+assertEqual(menu.fuzzyTextScore('', 'Anything'), 0, 'empty fuzzy search term matches with zero score')
+assertEqual(menu.fuzzyTextScore('xyz', 'abc'), -1, 'non-matching fuzzy search term returns -1')
+assert(menu.fuzzyTextScore('stm', 'System') >= 0, 'fuzzy text score matches in-order characters')
+assert(menu.fuzzyTextScore('stm', 'Steam') >= 0, 'fuzzy text score matches word-start and consecutive characters')
+assert(menu.fuzzyTextScore('sys', 'System') < menu.fuzzyTextScore('stm', 'System'), 'contiguous prefix matches rank higher than scattered characters')
+assert(menu.fuzzyQueryScore('thm pick', 'Theme picker') >= 0, 'fuzzy query score matches multiple terms')
+assertEqual(menu.fuzzyQueryScore('thm zzz', 'Theme picker'), -1, 'fuzzy query score rejects queries with missing terms')
+assert(menu.matchesQuery(entry, 'thm', true), 'menu matches fuzzy queries')
+assert(menu.matchesQuery(entry, 'thm pck', true), 'menu matches multi-term fuzzy queries')
+assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'thm'), 'exact matches score higher than fuzzy matches')
+
 assertDeepEqual(
   menu.displayRow(merged.items, merged.itemOrder, {}, {}, entry, 'Style', 12, 'search'),
   {

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -114,6 +114,11 @@ assertEqual(menu.fuzzyQueryScore('thm zzz', 'Theme picker'), -1, 'fuzzy query sc
 assert(menu.matchesQuery(entry, 'thm', true), 'menu matches fuzzy queries')
 assert(menu.matchesQuery(entry, 'thm pck', true), 'menu matches multi-term fuzzy queries')
 assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'thm'), 'exact matches score higher than fuzzy matches')
+assert(menu.fuzzyTextScore('a.b.c', 'a.b.c') >= 1, 'verbatim delimiter self-matches floor above no-match so exact rows stay visible')
+assert(menu.fuzzyTextScore('....', '....') >= 1, 'delimiter-only verbatim matches floor above no-match')
+assert(menu.matchesQuery({ id: 'test.row', label: 'a.b.c' }, 'a.b.c', true), 'menu keeps rows findable by their exact delimiter text')
+const cappedEntry = { id: 'test.cap', label: 'a b c d e f g h', order: 0 }
+assert(menu.searchScore([cappedEntry], cappedEntry, 'a b c d f g') < 100 * 1000, 'fuzzy name matches cap below the description tier')
 
 assertDeepEqual(
   menu.displayRow(merged.items, merged.itemOrder, {}, {}, entry, 'Style', 12, 'search'),


### PR DESCRIPTION
## Summary

The Omarchy menu / application launcher currently relies strictly on exact substring matching (`indexOf >= 0`). Typing `stm` fails to find `System` or `Steam`, and typing `thm pck` fails to find `Theme picker`.

This PR introduces in-order fuzzy search scoring (`fuzzyTextScore` and `fuzzyQueryScore`) into `MenuModel.js`.

## Features

- **In-order character matching**: Matches when all characters of a term appear in order in the target text.
- **Weighted scoring**:
  - Word-start boundaries and delimiter boundaries (`.`, `_`, `:`, `-`, `/`, whitespace) receive significant scoring bonuses.
  - Consecutive character matches rank ahead of scattered characters.
  - Earlier matches in the string rank ahead of later matches.
- **Multi-term query support**: Each term in a query is scored independently and aggregated across name and description fields.
- **Tier preservation**: Exact label matches and exact substring matches remain in top priority tiers, ensuring existing exact search behavior is unchanged while enabling fuzzy discovery — successful fuzzy scores floor above the no-match sentinel (verbatim delimiter text like `a.b.c` stays findable) and name matches cap below the description tier so scattered multi-term matches cannot invert name-over-description ordering.

## Changes

- **`shell/plugins/menu/MenuModel.js`**:
  - Implemented `fuzzyTextScore(term, text)` and `fuzzyQueryScore(query, text)`.
  - Updated `matchesQuery()` to evaluate fuzzy search against `nameSearchText` and `description`.
  - Updated `searchScore()` to compute weighted ranking for fuzzy name matches (tier 70+, capped below the description tier) and description matches (tier 100+).
  - Exported `fuzzyTextScore` and `fuzzyQueryScore`.
- **`docs/menu.md`**: documents that descriptions are also matched fuzzily.
- **`test/shell.d/menu-test.sh`**:
  - Added unit test coverage for fuzzy scoring, word-start bonuses, multi-term queries, and ranking relative to exact matches.

## Verification

- Automated menu tests in `test/shell.d/menu-test.sh` pass (135 assertions).
- Automated CLI tests in `./test/cli` pass (107 assertions).
