### PR TITLE
feat(agents): add Google Gemini and Antigravity usage provider

### DIFF
--- a/bin/omarchy-agent-usage-gemini
+++ b/bin/omarchy-agent-usage-gemini
@@ -1,0 +1,609 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Gemini / Antigravity usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Gemini / Antigravity usage into one display-ready JSON record.
+
+Combines local stats from pi/omp sessions, Antigravity CLI history, and opencode
+with authoritative rate limits and plan tiers from Google Cloud Code (Antigravity) API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+AGENT_ID = "gemini"
+AGENT_NAME = "Gemini"
+AUTH_HELP = "Run `antigravity` to authenticate."
+PROBE_MIN_INTERVAL_SECONDS = 15
+OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+CLOUDCODE_BASE_URL = "https://daily-cloudcode-pa.googleapis.com"
+LOAD_CODE_ASSIST_URL = f"{CLOUDCODE_BASE_URL}/v1internal:loadCodeAssist"
+RETRIEVE_USER_QUOTA_SUMMARY_URL = f"{CLOUDCODE_BASE_URL}/v1internal:retrieveUserQuotaSummary"
+
+
+def cache_root() -> Path:
+  root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root.mkdir(parents=True, exist_ok=True)
+  return root
+
+
+def local_date_string() -> str:
+  return dt.datetime.now().date().strftime("%Y-%m-%d")
+
+
+def recent_date_strings() -> list[str]:
+  today = dt.datetime.now().date()
+  return [(today - dt.timedelta(days=offset)).strftime("%Y-%m-%d") for offset in range(6, -1, -1)]
+
+
+def date_string(value: dt.date) -> str:
+  return value.strftime("%Y-%m-%d")
+
+
+def local_date_from_timestamp(value: Any) -> str:
+  if value is None:
+    return local_date_string()
+  if isinstance(value, (int, float)):
+    try:
+      seconds = float(value) / 1000.0 if float(value) > 10_000_000_000 else float(value)
+      return date_string(dt.datetime.fromtimestamp(seconds).date())
+    except Exception:
+      return local_date_string()
+  raw = str(value).strip()
+  if not raw:
+    return local_date_string()
+  try:
+    parsed = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if parsed.tzinfo is not None:
+      parsed = parsed.astimezone()
+    return date_string(parsed.date())
+  except Exception:
+    return local_date_string()
+
+
+def empty_bucket() -> dict[str, int]:
+  return {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  }
+
+
+def number(value: Any) -> int:
+  try:
+    n = float(value or 0)
+    return round(n) if n == n else 0
+  except Exception:
+    return 0
+
+
+def read_fresh_json(path: Path, max_age_seconds: float) -> dict[str, Any] | None:
+  if max_age_seconds <= 0 or not path.exists():
+    return None
+  try:
+    if time.time() - path.stat().st_mtime <= max_age_seconds:
+      return json.loads(path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  return None
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+  handle_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+  tmp = Path(tmp_name)
+  try:
+    with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+      handle.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n")
+    tmp.chmod(0o644)
+    tmp.replace(path)
+  except BaseException:
+    tmp.unlink(missing_ok=True)
+    raise
+
+
+# ---------------------------------------------------------------- OAuth Token
+
+
+def get_auth_token() -> tuple[str, int, str]:
+  """Returns (access_token, expires_at_ms, refresh_token)."""
+  try:
+    raw = subprocess.check_output(
+      ["secret-tool", "lookup", "service", "gemini", "username", "antigravity"],
+      stderr=subprocess.DEVNULL,
+      timeout=3,
+    ).decode("utf-8").strip()
+    if raw:
+      data = json.loads(raw)
+      token_obj = data.get("token") or {}
+      access_token = str(token_obj.get("access_token") or "").strip()
+      refresh_token = str(token_obj.get("refresh_token") or "").strip()
+      expiry_str = str(token_obj.get("expiry") or "").strip()
+      expires_at_ms = 0
+      if expiry_str:
+        try:
+          exp_dt = dt.datetime.fromisoformat(expiry_str.replace("Z", "+00:00"))
+          expires_at_ms = round(exp_dt.timestamp() * 1000)
+        except Exception:
+          pass
+
+      now_ms = round(time.time() * 1000)
+      client_id = os.environ.get("ANTIGRAVITY_OAUTH_CLIENT_ID", "")
+      client_secret = os.environ.get("ANTIGRAVITY_OAUTH_CLIENT_SECRET", "")
+      if (not access_token or expires_at_ms <= now_ms + 60000) and refresh_token and client_id and client_secret:
+        refreshed_access, new_exp_ms = refresh_google_token(refresh_token, client_id, client_secret)
+        if refreshed_access:
+          access_token = refreshed_access
+          expires_at_ms = new_exp_ms
+          try:
+            token_obj["access_token"] = access_token
+            if new_exp_ms > 0:
+              token_obj["expiry"] = dt.datetime.fromtimestamp(new_exp_ms / 1000, tz=dt.timezone.utc).isoformat()
+            data["token"] = token_obj
+            subprocess.run(
+              [
+                "secret-tool",
+                "store",
+                "--label=Password for 'antigravity' on 'gemini'",
+                "service",
+                "gemini",
+                "username",
+                "antigravity",
+              ],
+              input=json.dumps(data).encode("utf-8"),
+              stderr=subprocess.DEVNULL,
+              timeout=3,
+            )
+          except Exception:
+            pass
+      return access_token, expires_at_ms, refresh_token
+  except Exception:
+    pass
+  return "", 0, ""
+
+
+def refresh_google_token(refresh_token: str, client_id: str, client_secret: str) -> tuple[str, int]:
+  try:
+    payload = urllib.parse.urlencode({
+      "client_id": client_id,
+      "client_secret": client_secret,
+      "refresh_token": refresh_token,
+      "grant_type": "refresh_token",
+    }).encode("utf-8")
+    req = urllib.request.Request(
+      OAUTH_TOKEN_URL,
+      data=payload,
+      headers={"Content-Type": "application/x-www-form-urlencoded"},
+      method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+      data = json.loads(resp.read().decode("utf-8"))
+      access_token = data.get("access_token", "")
+      expires_in = number(data.get("expires_in", 3600))
+      expires_at_ms = round((time.time() + expires_in) * 1000)
+      return access_token, expires_at_ms
+  except Exception:
+    return "", 0
+
+
+# ------------------------------------------------------------- Limits & Tier
+
+
+def probe_limits(access_token: str) -> dict[str, Any]:
+  headers = {
+    "Authorization": f"Bearer {access_token}",
+    "Content-Type": "application/json",
+    "User-Agent": "antigravity/1.1.22",
+  }
+  tier_label = ""
+  limits = []
+
+  try:
+    req = urllib.request.Request(
+      LOAD_CODE_ASSIST_URL,
+      data=json.dumps({"cloudaicompanion_project": "default-cli-project"}).encode("utf-8"),
+      headers=headers,
+      method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+      data = json.loads(resp.read().decode("utf-8"))
+      current_tier = data.get("currentTier") or {}
+      paid_tier = data.get("paidTier") or {}
+      tier_name = current_tier.get("name") or paid_tier.get("name") or current_tier.get("id") or ""
+      if current_tier.get("id") == "free-tier":
+        tier_label = "Free"
+      elif tier_name:
+        tier_label = tier_name
+  except Exception:
+    pass
+
+  try:
+    req = urllib.request.Request(
+      RETRIEVE_USER_QUOTA_SUMMARY_URL,
+      data=json.dumps({"project": "default-cli-project"}).encode("utf-8"),
+      headers=headers,
+      method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+      data = json.loads(resp.read().decode("utf-8"))
+      groups = data.get("groups") or []
+      for group in groups:
+        group_name = group.get("displayName") or ""
+        is_gemini_group = "gemini" in group_name.lower()
+        for bucket in group.get("buckets") or []:
+          bucket_id = str(bucket.get("bucketId") or "").lower()
+          window = str(bucket.get("window") or "").lower()
+          display_name = str(bucket.get("displayName") or "")
+          rem_frac = float(bucket.get("remainingFraction", 1.0))
+          used_percent = max(0.0, min(1.0, 1.0 - rem_frac))
+          reset_time = str(bucket.get("resetTime") or "")
+
+          if "5h" in window or "5h" in bucket_id or "five hour" in display_name.lower():
+            title = "Session"
+            label = "Session (5-hour)"
+          elif "week" in window or "week" in bucket_id or "weekly" in display_name.lower():
+            title = "Weekly"
+            label = "Weekly (7-day)"
+          else:
+            title = display_name or "Limit"
+            label = display_name or "Limit"
+
+          if not is_gemini_group:
+            short_group = "Claude & GPT" if "claude" in group_name.lower() else group_name
+            title = f"{short_group} {title}"
+            label = f"{short_group} {label}"
+          limits.append({
+            "label": label,
+            "title": title,
+            "percent": used_percent,
+            "resetsAt": reset_time,
+          })
+  except urllib.error.HTTPError as error:
+    retry_after = error.headers.get("retry-after", "") if error.headers else ""
+    if error.code == 429:
+      help_text = "Google Cloud Code usage endpoint is rate limiting checks" + (
+        f" (retry after {retry_after}s)" if retry_after else ""
+      ) + ". Local Gemini stats are still shown."
+    else:
+      help_text = f"Google Cloud Code endpoint returned status {error.code}. Local Gemini stats are still shown."
+    return {"ok": False, "helpText": help_text, "tierLabel": tier_label}
+  except Exception:
+    return {
+      "ok": False,
+      "transport": True,
+      "helpText": "Couldn't reach Google Cloud Code usage endpoint. Local Gemini stats are still shown.",
+      "tierLabel": tier_label,
+    }
+
+  return {"ok": True, "limits": limits, "tierLabel": tier_label}
+
+
+def limit_window_open(entry: dict[str, Any], now: dt.datetime) -> bool:
+  raw = str(entry.get("resetsAt") or "")
+  if raw == "":
+    return True
+  try:
+    resets_at = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+  except Exception:
+    return True
+  if resets_at.tzinfo is None:
+    resets_at = resets_at.replace(tzinfo=dt.timezone.utc)
+  return resets_at > now
+
+
+def usable_cached_limits(cached: dict[str, Any]) -> list[dict[str, Any]]:
+  entries = cached.get("limits")
+  if not isinstance(entries, list):
+    return []
+  now = dt.datetime.now(dt.timezone.utc)
+  return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
+
+
+def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[str, Any]:
+  result = {"limits": [], "tierLabel": "", "usageStatusText": "", "authHelpText": AUTH_HELP}
+
+  probe_cache = cache_root() / "gemini-limits.json"
+  cached = read_fresh_json(probe_cache, float("inf")) or {}
+  fallback = usable_cached_limits(cached)
+  cached_tier = str(cached.get("tierLabel") or "")
+
+  if access_token == "":
+    result["limits"] = fallback
+    result["tierLabel"] = cached_tier
+    result["usageStatusText"] = "Waiting for auth"
+    return result
+
+  if expires_at_ms > 0 and expires_at_ms <= time.time() * 1000:
+    result["limits"] = fallback
+    result["tierLabel"] = cached_tier
+    result["usageStatusText"] = "Sign-in expired"
+    result["authHelpText"] = "Antigravity CLI sign-in expired. Run `antigravity` to refresh it."
+    return result
+
+  fetched_at = number(cached.get("fetchedAtMs")) / 1000
+  if fallback and not force and time.time() - fetched_at < PROBE_MIN_INTERVAL_SECONDS:
+    result["limits"] = fallback
+    result["tierLabel"] = cached_tier
+    return result
+
+  probe = probe_limits(access_token)
+  if probe["ok"]:
+    result["limits"] = probe["limits"]
+    result["tierLabel"] = probe.get("tierLabel") or cached_tier
+    write_json(
+      probe_cache,
+      {
+        "fetchedAtMs": round(time.time() * 1000),
+        "limits": probe["limits"],
+        "tierLabel": result["tierLabel"],
+      },
+    )
+    return result
+
+  if probe.get("transport"):
+    result["retryAdvised"] = True
+  if fallback:
+    result["limits"] = fallback
+    result["tierLabel"] = probe.get("tierLabel") or cached_tier
+  else:
+    result["tierLabel"] = probe.get("tierLabel") or cached_tier
+    result["usageStatusText"] = "Gemini limits unavailable"
+    result["authHelpText"] = probe.get("helpText") or AUTH_HELP
+  return result
+
+
+# ------------------------------------------------------------- Local Scan
+
+
+def scan_local_usage() -> dict[str, Any]:
+  today = local_date_string()
+  recent_dates = recent_date_strings()
+  recent = {day: {"date": day, "messageCount": 0} for day in recent_dates}
+
+  seen: set[str] = set()
+  sessions: set[str] = set()
+  active_days: set[str] = set()
+  today_sessions: set[str] = set()
+  today_tokens: dict[str, int] = {}
+  usage_by_model: dict[str, dict[str, int]] = {}
+  prompts = 0
+  today_prompt_count = 0
+  today_token_total = 0
+
+  # 1. Scan Pi & Omp sessions
+  pi_roots = [
+    Path.home() / ".pi" / "agent" / "sessions",
+    Path.home() / ".omp" / "agent" / "sessions",
+  ]
+  for root in pi_roots:
+    if not root.is_dir():
+      continue
+    for path in root.rglob("*.jsonl"):
+      try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+          for line_number, line in enumerate(handle, 1):
+            if '"usage"' not in line or '"assistant"' not in line:
+              continue
+            try:
+              entry = json.loads(line)
+              message = entry.get("message") if isinstance(entry.get("message"), dict) else {}
+              if entry.get("type") != "message" or message.get("role") != "assistant":
+                continue
+              provider = str(message.get("provider") or entry.get("provider") or "").lower()
+              model_raw = str(message.get("model") or entry.get("model") or "").lower()
+              if (
+                "google" not in provider
+                and "gemini" not in provider
+                and "antigravity" not in provider
+                and "gemini" not in model_raw
+              ):
+                continue
+
+              unique_key = f"{path}:{entry.get('id') or line_number}"
+              if unique_key in seen:
+                continue
+              seen.add(unique_key)
+
+              usage = message.get("usage") or {}
+              input_tokens = number(usage.get("input", usage.get("inputTokens", 0)))
+              output_tokens = number(usage.get("output", usage.get("outputTokens", 0)))
+              cache_read = number(
+                usage.get("cacheRead", usage.get("cache_read_input_tokens", usage.get("cacheReadInputTokens", 0)))
+              )
+              cache_write = number(
+                usage.get(
+                  "cacheWrite",
+                  usage.get("cache_creation_input_tokens", usage.get("cacheCreationInputTokens", 0)),
+                )
+              )
+              total = input_tokens + output_tokens + cache_read + cache_write
+              if total <= 0:
+                total = number(usage.get("totalTokens", 0))
+                input_tokens = total
+              if total <= 0:
+                continue
+
+              model = str(message.get("model") or entry.get("model") or "gemini")
+              if model.startswith("google-antigravity/"):
+                model = model[len("google-antigravity/") :]
+              elif model.startswith("google/"):
+                model = model[len("google/") :]
+
+              day = local_date_from_timestamp(entry.get("timestamp") or message.get("timestamp"))
+              session_key = str(path)
+
+              sessions.add(session_key)
+              active_days.add(day)
+              prompts += 1
+
+              bucket = usage_by_model.setdefault(model, empty_bucket())
+              bucket["inputTokens"] += input_tokens
+              bucket["outputTokens"] += output_tokens
+              bucket["cacheReadInputTokens"] += cache_read
+              bucket["cacheCreationInputTokens"] += cache_write
+
+              if day in recent:
+                recent[day]["messageCount"] += total
+              if day == today:
+                today_prompt_count += 1
+                today_sessions.add(session_key)
+                today_token_total += total
+                today_tokens[model] = today_tokens.get(model, 0) + total
+            except Exception:
+              continue
+      except OSError:
+        continue
+
+  # 2. Scan Antigravity CLI history
+  history_file = Path.home() / ".gemini" / "antigravity-cli" / "history.jsonl"
+  if history_file.is_file():
+    try:
+      with history_file.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+          try:
+            entry = json.loads(line)
+            ts = entry.get("timestamp")
+            day = local_date_from_timestamp(ts)
+            active_days.add(day)
+            prompts += 1
+            if day == today:
+              today_prompt_count += 1
+          except Exception:
+            pass
+    except OSError:
+      pass
+
+  # 3. Check Opencode if present
+  opencode_db = Path.home() / ".local" / "share" / "opencode" / "opencode.db"
+  if opencode_db.is_file():
+    try:
+      conn = sqlite3.connect(opencode_db.resolve().as_uri() + "?mode=ro", uri=True, timeout=2)
+      for session_id, raw in conn.execute("SELECT session_id, data FROM message"):
+        try:
+          entry = json.loads(raw)
+          if not isinstance(entry, dict) or entry.get("role") != "assistant":
+            continue
+          provider_id = str(entry.get("providerID") or "").lower()
+          if "google" not in provider_id and "gemini" not in provider_id and "antigravity" not in provider_id:
+            continue
+          tokens = entry.get("tokens") or {}
+          cache = tokens.get("cache") or {}
+          input_tokens = number(tokens.get("input"))
+          output_tokens = number(tokens.get("output")) + number(tokens.get("reasoning"))
+          cache_read = number(cache.get("read"))
+          cache_write = number(cache.get("write"))
+          total = input_tokens + output_tokens + cache_read + cache_write
+          if total <= 0:
+            continue
+          model_id = str(entry.get("modelID") or "gemini")
+          day = local_date_from_timestamp(entry.get("time") or entry.get("timestamp"))
+          session_key = str(session_id)
+          sessions.add(session_key)
+          active_days.add(day)
+          prompts += 1
+          bucket = usage_by_model.setdefault(model_id, empty_bucket())
+          bucket["inputTokens"] += input_tokens
+          bucket["outputTokens"] += output_tokens
+          bucket["cacheReadInputTokens"] += cache_read
+          bucket["cacheCreationInputTokens"] += cache_write
+          if day in recent:
+            recent[day]["messageCount"] += total
+          if day == today:
+            today_prompt_count += 1
+            today_sessions.add(session_key)
+            today_token_total += total
+            today_tokens[model_id] = today_tokens.get(model_id, 0) + total
+        except Exception:
+          continue
+      conn.close()
+    except Exception:
+      pass
+
+  return {
+    "todayPrompts": today_prompt_count,
+    "todaySessions": len(today_sessions),
+    "todayTotalTokens": today_token_total,
+    "todayTokensByModel": today_tokens,
+    "recentDays": [recent[day] for day in recent_dates],
+    "modelUsage": usage_by_model,
+    "totalPrompts": prompts,
+    "totalSessions": len(sessions),
+    "activeDays": len(active_days),
+    "activeDates": sorted(active_days),
+  }
+
+
+def cached_scan(max_age_seconds: float) -> dict[str, Any]:
+  cache_file = cache_root() / "gemini-scan.json"
+  lock_file = cache_root() / "gemini-scan.lock"
+
+  cached = read_fresh_json(cache_file, max_age_seconds)
+  if cached is not None:
+    return cached
+
+  with lock_file.open("w") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    cached = read_fresh_json(cache_file, max_age_seconds)
+    if cached is not None:
+      return cached
+    summary = scan_local_usage()
+    write_json(cache_file, summary)
+    return summary
+
+
+# -------------------------------------------------------------------- Main
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Collect Gemini / Antigravity usage record")
+  parser.add_argument("--force", action="store_true", help="rescan and re-probe limits")
+  parser.add_argument("--limits-only", action="store_true", help="reuse scan cache; probe fresh limits")
+  parser.add_argument("--cache-seconds", type=float, default=20)
+  args = parser.parse_args()
+
+  scan_age = 0 if args.force else (900 if args.limits_only else args.cache_seconds)
+  stats = cached_scan(scan_age)
+
+  access_token, expires_at_ms, _ = get_auth_token()
+  limits = collect_limits(access_token, expires_at_ms, args.force)
+
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "ready": number(stats.get("totalPrompts")) > 0 or len(limits["limits"]) > 0 or bool(access_token),
+    "hasLocalStats": True,
+    "tierLabel": limits.get("tierLabel", ""),
+    "usageStatusText": limits.get("usageStatusText", ""),
+    "authHelpText": limits.get("authHelpText", ""),
+    "limits": limits.get("limits", []),
+  }
+  if limits.get("retryAdvised"):
+    record["retryAdvised"] = True
+
+  record.update(stats)
+  print(json.dumps(record, separators=(",", ":"), sort_keys=True))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/bin/omarchy-agent-usage-gemini
+++ b/bin/omarchy-agent-usage-gemini
@@ -34,9 +34,10 @@ AGENT_NAME = "Gemini"
 AUTH_HELP = "Run `antigravity` to authenticate."
 PROBE_MIN_INTERVAL_SECONDS = 15
 OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
-CLOUDCODE_BASE_URL = "https://daily-cloudcode-pa.googleapis.com"
-LOAD_CODE_ASSIST_URL = f"{CLOUDCODE_BASE_URL}/v1internal:loadCodeAssist"
-RETRIEVE_USER_QUOTA_SUMMARY_URL = f"{CLOUDCODE_BASE_URL}/v1internal:retrieveUserQuotaSummary"
+CLOUDCODE_BASE_URLS = [
+  "https://daily-cloudcode-pa.googleapis.com",
+  "https://cloudcode-pa.googleapis.com",
+]
 
 
 def cache_root() -> Path:
@@ -113,7 +114,7 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
   try:
     with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
       handle.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n")
-    tmp.chmod(0o644)
+    tmp.chmod(0o600)
     tmp.replace(path)
   except BaseException:
     tmp.unlink(missing_ok=True)
@@ -123,8 +124,12 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
 # ---------------------------------------------------------------- OAuth Token
 
 
-def get_auth_token() -> tuple[str, int, str]:
-  """Returns (access_token, expires_at_ms, refresh_token)."""
+def get_auth_token() -> tuple[str, int]:
+  """Returns (access_token, expires_at_ms).
+
+  Reads the active Antigravity CLI Bearer token from Secret Service.
+  Does not store or mutate credentials in the system keyring.
+  """
   try:
     raw = subprocess.check_output(
       ["secret-tool", "lookup", "service", "gemini", "username", "antigravity"],
@@ -135,8 +140,8 @@ def get_auth_token() -> tuple[str, int, str]:
       data = json.loads(raw)
       token_obj = data.get("token") or {}
       access_token = str(token_obj.get("access_token") or "").strip()
-      refresh_token = str(token_obj.get("refresh_token") or "").strip()
       expiry_str = str(token_obj.get("expiry") or "").strip()
+      del data, raw
       expires_at_ms = 0
       if expiry_str:
         try:
@@ -144,64 +149,11 @@ def get_auth_token() -> tuple[str, int, str]:
           expires_at_ms = round(exp_dt.timestamp() * 1000)
         except Exception:
           pass
-
-      now_ms = round(time.time() * 1000)
-      client_id = os.environ.get("ANTIGRAVITY_OAUTH_CLIENT_ID", "")
-      client_secret = os.environ.get("ANTIGRAVITY_OAUTH_CLIENT_SECRET", "")
-      if (not access_token or expires_at_ms <= now_ms + 60000) and refresh_token and client_id and client_secret:
-        refreshed_access, new_exp_ms = refresh_google_token(refresh_token, client_id, client_secret)
-        if refreshed_access:
-          access_token = refreshed_access
-          expires_at_ms = new_exp_ms
-          try:
-            token_obj["access_token"] = access_token
-            if new_exp_ms > 0:
-              token_obj["expiry"] = dt.datetime.fromtimestamp(new_exp_ms / 1000, tz=dt.timezone.utc).isoformat()
-            data["token"] = token_obj
-            subprocess.run(
-              [
-                "secret-tool",
-                "store",
-                "--label=Password for 'antigravity' on 'gemini'",
-                "service",
-                "gemini",
-                "username",
-                "antigravity",
-              ],
-              input=json.dumps(data).encode("utf-8"),
-              stderr=subprocess.DEVNULL,
-              timeout=3,
-            )
-          except Exception:
-            pass
-      return access_token, expires_at_ms, refresh_token
-  except Exception:
-    pass
-  return "", 0, ""
-
-
-def refresh_google_token(refresh_token: str, client_id: str, client_secret: str) -> tuple[str, int]:
-  try:
-    payload = urllib.parse.urlencode({
-      "client_id": client_id,
-      "client_secret": client_secret,
-      "refresh_token": refresh_token,
-      "grant_type": "refresh_token",
-    }).encode("utf-8")
-    req = urllib.request.Request(
-      OAUTH_TOKEN_URL,
-      data=payload,
-      headers={"Content-Type": "application/x-www-form-urlencoded"},
-      method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=10) as resp:
-      data = json.loads(resp.read().decode("utf-8"))
-      access_token = data.get("access_token", "")
-      expires_in = number(data.get("expires_in", 3600))
-      expires_at_ms = round((time.time() + expires_in) * 1000)
       return access_token, expires_at_ms
   except Exception:
-    return "", 0
+    pass
+  return "", 0
+
 
 
 # ------------------------------------------------------------- Limits & Tier
@@ -245,71 +197,85 @@ def probe_limits(access_token: str) -> dict[str, Any]:
   }
   tier_label = ""
   limits = []
+  last_error: Exception | None = None
 
-  try:
-    req = urllib.request.Request(
-      LOAD_CODE_ASSIST_URL,
-      data=json.dumps({"cloudaicompanion_project": "default-cli-project"}).encode("utf-8"),
-      headers=headers,
-      method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=10) as resp:
-      data = json.loads(resp.read().decode("utf-8"))
-      tier_label = plan_label(data)
-  except Exception:
-    pass
+  for base_url in CLOUDCODE_BASE_URLS:
+    try:
+      req = urllib.request.Request(
+        f"{base_url}/v1internal:loadCodeAssist",
+        data=json.dumps({"cloudaicompanion_project": "default-cli-project"}).encode("utf-8"),
+        headers=headers,
+        method="POST",
+      )
+      with urllib.request.urlopen(req, timeout=10) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+        tier_label = plan_label(data)
+        break
+    except Exception:
+      pass
 
-  try:
-    req = urllib.request.Request(
-      RETRIEVE_USER_QUOTA_SUMMARY_URL,
-      data=json.dumps({"project": "default-cli-project"}).encode("utf-8"),
-      headers=headers,
-      method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=10) as resp:
-      data = json.loads(resp.read().decode("utf-8"))
-      groups = data.get("groups") or []
-      for group in groups:
-        group_name = group.get("displayName") or ""
-        is_gemini_group = "gemini" in group_name.lower()
-        for bucket in group.get("buckets") or []:
-          bucket_id = str(bucket.get("bucketId") or "").lower()
-          window = str(bucket.get("window") or "").lower()
-          display_name = str(bucket.get("displayName") or "")
-          rem_frac = float(bucket.get("remainingFraction", 1.0))
-          used_percent = max(0.0, min(1.0, 1.0 - rem_frac))
-          reset_time = str(bucket.get("resetTime") or "")
+  for base_url in CLOUDCODE_BASE_URLS:
+    try:
+      req = urllib.request.Request(
+        f"{base_url}/v1internal:retrieveUserQuotaSummary",
+        data=json.dumps({"project": "default-cli-project"}).encode("utf-8"),
+        headers=headers,
+        method="POST",
+      )
+      with urllib.request.urlopen(req, timeout=10) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+        groups = data.get("groups") or []
+        for group in groups:
+          group_name = group.get("displayName") or ""
+          is_gemini_group = "gemini" in group_name.lower()
+          for bucket in group.get("buckets") or []:
+            bucket_id = str(bucket.get("bucketId") or "").lower()
+            window = str(bucket.get("window") or "").lower()
+            display_name = str(bucket.get("displayName") or "")
+            rem_frac = float(bucket.get("remainingFraction", 1.0))
+            used_percent = max(0.0, min(1.0, 1.0 - rem_frac))
+            reset_time = str(bucket.get("resetTime") or "")
 
-          if "5h" in window or "5h" in bucket_id or "five hour" in display_name.lower():
-            title = "Session"
-            label = "Session (5-hour)"
-          elif "week" in window or "week" in bucket_id or "weekly" in display_name.lower():
-            title = "Weekly"
-            label = "Weekly (7-day)"
-          else:
-            title = display_name or "Limit"
-            label = display_name or "Limit"
+            if "5h" in window or "5h" in bucket_id or "five hour" in display_name.lower():
+              title = "Session"
+              label = "Session (5-hour)"
+            elif "week" in window or "week" in bucket_id or "weekly" in display_name.lower():
+              title = "Weekly"
+              label = "Weekly (7-day)"
+            else:
+              title = display_name or "Limit"
+              label = display_name or "Limit"
 
-          if not is_gemini_group:
-            short_group = "Claude & GPT" if "claude" in group_name.lower() else group_name
-            title = f"{short_group} {title}"
-            label = f"{short_group} {label}"
-          limits.append({
-            "label": label,
-            "title": title,
-            "percent": used_percent,
-            "resetsAt": reset_time,
-          })
-  except urllib.error.HTTPError as error:
-    retry_after = error.headers.get("retry-after", "") if error.headers else ""
-    if error.code == 429:
-      help_text = "Google Cloud Code usage endpoint is rate limiting checks" + (
-        f" (retry after {retry_after}s)" if retry_after else ""
-      ) + ". Local Gemini stats are still shown."
-    else:
-      help_text = f"Google Cloud Code endpoint returned status {error.code}. Local Gemini stats are still shown."
-    return {"ok": False, "helpText": help_text, "tierLabel": tier_label}
-  except Exception:
+            if not is_gemini_group:
+              short_group = "Claude & GPT" if "claude" in group_name.lower() else group_name
+              title = f"{short_group} {title}"
+              label = f"{short_group} {label}"
+            limits.append({
+              "label": label,
+              "title": title,
+              "percent": used_percent,
+              "resetsAt": reset_time,
+            })
+        last_error = None
+        break
+    except urllib.error.HTTPError as error:
+      last_error = error
+      if error.code in (401, 403):
+        break
+    except Exception as error:
+      last_error = error
+      continue
+
+  if last_error is not None and not limits:
+    if isinstance(last_error, urllib.error.HTTPError):
+      retry_after = last_error.headers.get("retry-after", "") if last_error.headers else ""
+      if last_error.code == 429:
+        help_text = "Google Cloud Code usage endpoint is rate limiting checks" + (
+          f" (retry after {retry_after}s)" if retry_after else ""
+        ) + ". Local Gemini stats are still shown."
+      else:
+        help_text = f"Google Cloud Code endpoint returned status {last_error.code}. Local Gemini stats are still shown."
+      return {"ok": False, "helpText": help_text, "tierLabel": tier_label}
     return {
       "ok": False,
       "transport": True,
@@ -318,6 +284,7 @@ def probe_limits(access_token: str) -> dict[str, Any]:
     }
 
   return {"ok": True, "limits": limits, "tierLabel": tier_label}
+
 
 
 def limit_window_open(entry: dict[str, Any], now: dt.datetime) -> bool:
@@ -583,7 +550,7 @@ def cached_scan(max_age_seconds: float) -> dict[str, Any]:
   if cached is not None:
     return cached
 
-  with lock_file.open("w") as lock:
+  with lock_file.open("a") as lock:
     fcntl.flock(lock, fcntl.LOCK_EX)
     cached = read_fresh_json(cache_file, max_age_seconds)
     if cached is not None:
@@ -606,7 +573,7 @@ def main() -> int:
   scan_age = 0 if args.force else (900 if args.limits_only else args.cache_seconds)
   stats = cached_scan(scan_age)
 
-  access_token, expires_at_ms, _ = get_auth_token()
+  access_token, expires_at_ms = get_auth_token()
   limits = collect_limits(access_token, expires_at_ms, args.force)
 
   record = {

--- a/bin/omarchy-agent-usage-gemini
+++ b/bin/omarchy-agent-usage-gemini
@@ -207,6 +207,36 @@ def refresh_google_token(refresh_token: str, client_id: str, client_secret: str)
 # ------------------------------------------------------------- Limits & Tier
 
 
+def plan_label(data: dict[str, Any]) -> str:
+  paid_tier = data.get("paidTier") or {}
+  paid_id = str(paid_tier.get("id") or "").lower()
+  paid_name = str(paid_tier.get("name") or "")
+
+  if "ultra" in paid_id or "ultra" in paid_name.lower():
+    return "Ultra"
+  if "pro" in paid_id or "pro" in paid_name.lower():
+    return "Pro"
+  if paid_name:
+    return paid_name.replace("Google AI ", "").replace("Antigravity ", "")
+
+  current_tier = data.get("currentTier") or {}
+  current_id = str(current_tier.get("id") or "").lower()
+  current_name = str(current_tier.get("name") or "")
+
+  if "ultra" in current_id or "ultra" in current_name.lower():
+    return "Ultra"
+  if "pro" in current_id or "pro" in current_name.lower():
+    return "Pro"
+  if "standard" in current_id:
+    return "Standard"
+  if current_id == "free-tier" or "free" in current_id:
+    return "Free"
+  if current_name and current_name != "Antigravity":
+    return current_name.replace("Google AI ", "").replace("Antigravity ", "")
+
+  return "Free"
+
+
 def probe_limits(access_token: str) -> dict[str, Any]:
   headers = {
     "Authorization": f"Bearer {access_token}",
@@ -225,13 +255,7 @@ def probe_limits(access_token: str) -> dict[str, Any]:
     )
     with urllib.request.urlopen(req, timeout=10) as resp:
       data = json.loads(resp.read().decode("utf-8"))
-      current_tier = data.get("currentTier") or {}
-      paid_tier = data.get("paidTier") or {}
-      tier_name = current_tier.get("name") or paid_tier.get("name") or current_tier.get("id") or ""
-      if current_tier.get("id") == "free-tier":
-        tier_label = "Free"
-      elif tier_name:
-        tier_label = tier_name
+      tier_label = plan_label(data)
   except Exception:
     pass
 

--- a/bin/omarchy-agent-usage-gemini
+++ b/bin/omarchy-agent-usage-gemini
@@ -13,18 +13,13 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import fcntl
-import hashlib
 import json
 import os
-import re
-import shutil
 import sqlite3
 import subprocess
-import sys
 import tempfile
 import time
 import urllib.error
-import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -33,7 +28,7 @@ AGENT_ID = "gemini"
 AGENT_NAME = "Gemini"
 AUTH_HELP = "Run `antigravity` to authenticate."
 PROBE_MIN_INTERVAL_SECONDS = 15
-OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+OPEN_ENDED_CACHE_MAX_AGE_SECONDS = 24 * 60 * 60
 CLOUDCODE_BASE_URLS = [
   "https://daily-cloudcode-pa.googleapis.com",
   "https://cloudcode-pa.googleapis.com",
@@ -232,8 +227,16 @@ def probe_limits(access_token: str) -> dict[str, Any]:
             bucket_id = str(bucket.get("bucketId") or "").lower()
             window = str(bucket.get("window") or "").lower()
             display_name = str(bucket.get("displayName") or "")
-            rem_frac = float(bucket.get("remainingFraction", 1.0))
-            used_percent = max(0.0, min(1.0, 1.0 - rem_frac))
+            try:
+              rem_frac = float(bucket.get("remainingFraction", 1.0))
+            except (TypeError, ValueError):
+              # One malformed bucket must not discard every limit the
+              # endpoint returned; skip it and keep the rest.
+              continue
+            if rem_frac != rem_frac:  # NaN would poison the JSON output
+              continue
+            rem_frac = max(0.0, min(1.0, rem_frac))
+            used_percent = 1.0 - rem_frac
             reset_time = str(bucket.get("resetTime") or "")
 
             if "5h" in window or "5h" in bucket_id or "five hour" in display_name.lower():
@@ -305,7 +308,20 @@ def usable_cached_limits(cached: dict[str, Any]) -> list[dict[str, Any]]:
   if not isinstance(entries, list):
     return []
   now = dt.datetime.now(dt.timezone.utc)
-  return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
+  fetched_at = number(cached.get("fetchedAtMs")) / 1000.0
+  # Entries without a reset time never expire on their own; cap how long the
+  # cache may keep serving them once probing stops succeeding.
+  keep_open_ended = time.time() - fetched_at <= OPEN_ENDED_CACHE_MAX_AGE_SECONDS
+  kept: list[dict[str, Any]] = []
+  for entry in entries:
+    if not isinstance(entry, dict):
+      continue
+    if entry.get("resetsAt"):
+      if limit_window_open(entry, now):
+        kept.append(entry)
+    elif keep_open_ended:
+      kept.append(entry)
+  return kept
 
 
 def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[str, Any]:
@@ -336,7 +352,7 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
     return result
 
   probe = probe_limits(access_token)
-  if probe["ok"]:
+  if probe["ok"] and probe["limits"]:
     result["limits"] = probe["limits"]
     result["tierLabel"] = probe.get("tierLabel") or cached_tier
     write_json(
@@ -349,11 +365,15 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
     )
     return result
 
+  # The probe answered without quota buckets (an error-shaped 200 or an API
+  # change) or failed outright: keep serving cached limits instead of wiping
+  # them with an empty list, and trust the cached tier over one derived from
+  # an error body.
   if probe.get("transport"):
     result["retryAdvised"] = True
   if fallback:
     result["limits"] = fallback
-    result["tierLabel"] = probe.get("tierLabel") or cached_tier
+    result["tierLabel"] = cached_tier or probe.get("tierLabel")
   else:
     result["tierLabel"] = probe.get("tierLabel") or cached_tier
     result["usageStatusText"] = "Gemini limits unavailable"
@@ -471,6 +491,11 @@ def scan_local_usage() -> dict[str, Any]:
         for line in handle:
           try:
             entry = json.loads(line)
+            # Count prompts only: skip assistant/model/response rows when the
+            # history carries roles, so replies do not double-count.
+            kind = str(entry.get("role") or entry.get("type") or "").lower()
+            if kind in ("assistant", "model", "response"):
+              continue
             ts = entry.get("timestamp")
             day = local_date_from_timestamp(ts)
             active_days.add(day)
@@ -581,7 +606,7 @@ def main() -> int:
     "id": AGENT_ID,
     "name": AGENT_NAME,
     "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
-    "ready": number(stats.get("totalPrompts")) > 0 or len(limits["limits"]) > 0 or bool(access_token),
+    "ready": number(stats.get("totalPrompts")) > 0 or len(limits["limits"]) > 0,
     "hasLocalStats": True,
     "tierLabel": limits.get("tierLabel", ""),
     "usageStatusText": limits.get("usageStatusText", ""),

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -715,7 +715,7 @@ Item {
   }
 
   function modelWordCase(word) {
-    if (word === "gpt") return "GPT"
+    if (word === "gpt" || word === "oss" || word === "api") return word.toUpperCase()
     if (word === "deepseek") return "DeepSeek"
     return word.charAt(0).toUpperCase() + word.slice(1)
   }
@@ -725,7 +725,7 @@ Item {
   // version and title-case the words around it.
   function friendlyModelName(id) {
     if (!id) return "Unknown"
-    var name = String(id).replace(/^claude-/, "").replace(/-\d{8}$/, "")
+    var name = String(id).replace(/^(google-antigravity|google|anthropic|openai)\//, "").replace(/^claude-/, "").replace(/-\d{8}$/, "")
     var parts = name.split("-")
     var words = []
     var version = []

--- a/shell/plugins/agents/assets/gemini.svg
+++ b/shell/plugins/agents/assets/gemini.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="gemini-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1E88E5"/>
+      <stop offset="50%" stop-color="#7B1FA2"/>
+      <stop offset="100%" stop-color="#E91E63"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#gemini-grad)" d="M24 12.02A11.93 11.93 0 0 1 12.02 24h-.04A11.93 11.93 0 0 1 0 12.02v-.04A11.93 11.93 0 0 1 11.98 0h.04A11.93 11.93 0 0 1 24 11.98z"/>
+</svg>

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, Gemini, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -21,7 +21,8 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
-        "fireworks": { "enabled": true }
+        "fireworks": { "enabled": true },
+        "gemini": { "enabled": true }
       },
       "refreshIntervalSec": 900,
       "syncMode": "Off",

--- a/test/shell.d/agent-usage-gemini-scanner-test.sh
+++ b/test/shell.d/agent-usage-gemini-scanner-test.sh
@@ -112,3 +112,17 @@ result=$(HOME="$OPENCODE_HOME" XDG_CACHE_HOME="$OPENCODE_HOME/.cache" XDG_DATA_H
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "520" ]] ||
   fail "Gemini collector reuses cached scan data on --limits-only" "$result"
 pass "Gemini collector reuses cached scan data on --limits-only"
+
+# 5. Plan tier detection
+python3 - "$ROOT/bin/omarchy-agent-usage-gemini" <<'PY' || fail "Gemini plan tier parser maps subscription tiers accurately"
+import sys
+from importlib.machinery import SourceFileLoader
+
+mod = SourceFileLoader("gemini_usage", sys.argv[1]).load_module()
+assert mod.plan_label({"paidTier": {"id": "g1-pro-tier", "name": "Google AI Pro"}}) == "Pro"
+assert mod.plan_label({"paidTier": {"id": "g1-ultra-tier", "name": "Google AI Ultra"}}) == "Ultra"
+assert mod.plan_label({"currentTier": {"id": "standard-tier", "name": "Antigravity"}}) == "Standard"
+assert mod.plan_label({"currentTier": {"id": "free-tier", "name": "Antigravity"}}) == "Free"
+assert mod.plan_label({}) == "Free"
+PY
+pass "Gemini plan tier parser maps subscription tiers accurately"

--- a/test/shell.d/agent-usage-gemini-scanner-test.sh
+++ b/test/shell.d/agent-usage-gemini-scanner-test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+timestamp="$(date +%Y-%m-%d)T12:00:00Z"
+
+# 1. Pi and omp session transcripts for Gemini/Antigravity providers
+mkdir -p "$TEST_HOME/.pi/agent/sessions/project" "$TEST_HOME/.omp/agent/sessions/project"
+
+cat >"$TEST_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF
+{"type":"message","id":"pi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"google","model":"google-antigravity/gemini-2.5-pro","usage":{"input":100,"output":50,"cacheRead":25,"cacheWrite":10,"totalTokens":185}}}
+EOF
+
+cat >"$TEST_HOME/.omp/agent/sessions/project/omp.jsonl" <<EOF
+{"type":"message","id":"omp-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"google-antigravity","model":"gemini-2.5-flash","usage":{"input":200,"output":80,"cacheRead":40,"cacheWrite":20,"totalTokens":340}}}
+{"type":"message","id":"other-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"anthropic","model":"claude-3-5-sonnet","usage":{"input":999,"output":999}}}
+EOF
+
+result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_STATE_HOME="$TEST_HOME/.local/state" \
+  "$ROOT/bin/omarchy-agent-usage-gemini")
+
+[[ $(jq -r '.id' <<<"$result") == "gemini" ]] ||
+  fail "Gemini collector identifies itself with id gemini" "$result"
+pass "Gemini collector identifies itself with id gemini"
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "525" ]] ||
+[[ $(jq -r '.modelUsage["gemini-2.5-pro"].inputTokens' <<<"$result") == "100" && \
+   $(jq -r '.modelUsage["gemini-2.5-pro"].outputTokens' <<<"$result") == "50" && \
+   $(jq -r '.modelUsage["gemini-2.5-pro"].cacheReadInputTokens' <<<"$result") == "25" && \
+   $(jq -r '.modelUsage["gemini-2.5-pro"].cacheCreationInputTokens' <<<"$result") == "10" ]] ||
+  fail "Gemini collector strips provider prefixes and records per-model token buckets" "$result"
+pass "Gemini collector strips provider prefixes and records per-model token buckets"
+
+# 2. Antigravity CLI history scanning
+mkdir -p "$TEST_HOME/.gemini/antigravity-cli"
+cat >"$TEST_HOME/.gemini/antigravity-cli/history.jsonl" <<EOF
+{"timestamp":"$timestamp","query":"explain quickshell"}
+EOF
+
+result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_STATE_HOME="$TEST_HOME/.local/state" \
+  "$ROOT/bin/omarchy-agent-usage-gemini" --force)
+
+[[ $(jq -r '.totalPrompts' <<<"$result") == "3" ]] ||
+  fail "Gemini collector counts prompts from antigravity CLI history" "$result"
+pass "Gemini collector counts prompts from antigravity CLI history"
+
+# 3. Opencode SQLite database scanning
+OPENCODE_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$OPENCODE_HOME"' EXIT
+mkdir -p "$OPENCODE_HOME/.local/share/opencode"
+
+python3 - "$OPENCODE_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+
+conn = sqlite3.connect(sys.argv[1])
+conn.execute("CREATE TABLE message (session_id TEXT, data TEXT)")
+
+conn.execute(
+  "INSERT INTO message VALUES (?, ?)",
+  (
+    "sess-1",
+    json.dumps({
+      "role": "assistant",
+      "providerID": "google",
+      "modelID": "gemini-2.5-flash",
+      "tokens": {
+        "input": 300,
+        "output": 120,
+        "reasoning": 30,
+        "cache": {"read": 50, "write": 20},
+      },
+    }),
+  ),
+)
+
+conn.execute(
+  "INSERT INTO message VALUES (?, ?)",
+  (
+    "sess-2",
+    json.dumps({
+      "role": "assistant",
+      "providerID": "anthropic",
+      "modelID": "claude-3-7-sonnet",
+      "tokens": {"input": 500, "output": 200},
+    }),
+  ),
+)
+
+conn.commit()
+conn.close()
+PY
+
+result=$(HOME="$OPENCODE_HOME" XDG_CACHE_HOME="$OPENCODE_HOME/.cache" XDG_DATA_HOME="$OPENCODE_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-gemini" --force)
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "520" ]] ||
+  fail "Gemini collector counts tokens from opencode database including reasoning" "$result"
+pass "Gemini collector counts tokens from opencode database including reasoning"
+
+# 4. Cache behavior with --limits-only and --force
+result=$(HOME="$OPENCODE_HOME" XDG_CACHE_HOME="$OPENCODE_HOME/.cache" XDG_DATA_HOME="$OPENCODE_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-gemini" --limits-only)
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "520" ]] ||
+  fail "Gemini collector reuses cached scan data on --limits-only" "$result"
+pass "Gemini collector reuses cached scan data on --limits-only"

--- a/test/shell.d/agent-usage-gemini-scanner-test.sh
+++ b/test/shell.d/agent-usage-gemini-scanner-test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-source "$(dirname "$0")/base-test.sh"
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 require_command jq
 require_command python3
@@ -30,6 +32,9 @@ result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_STATE_HOME="$T
 pass "Gemini collector identifies itself with id gemini"
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "525" ]] ||
+  fail "Gemini collector totals today's tokens across pi and omp sessions" "$result"
+pass "Gemini collector totals today's tokens across pi and omp sessions"
+
 [[ $(jq -r '.modelUsage["gemini-2.5-pro"].inputTokens' <<<"$result") == "100" && \
    $(jq -r '.modelUsage["gemini-2.5-pro"].outputTokens' <<<"$result") == "50" && \
    $(jq -r '.modelUsage["gemini-2.5-pro"].cacheReadInputTokens' <<<"$result") == "25" && \
@@ -41,14 +46,15 @@ pass "Gemini collector strips provider prefixes and records per-model token buck
 mkdir -p "$TEST_HOME/.gemini/antigravity-cli"
 cat >"$TEST_HOME/.gemini/antigravity-cli/history.jsonl" <<EOF
 {"timestamp":"$timestamp","query":"explain quickshell"}
+{"timestamp":"$timestamp","role":"assistant","query":"assistant rows must not count as prompts"}
 EOF
 
 result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_STATE_HOME="$TEST_HOME/.local/state" \
   "$ROOT/bin/omarchy-agent-usage-gemini" --force)
 
 [[ $(jq -r '.totalPrompts' <<<"$result") == "3" ]] ||
-  fail "Gemini collector counts prompts from antigravity CLI history" "$result"
-pass "Gemini collector counts prompts from antigravity CLI history"
+  fail "Gemini collector counts prompts from antigravity CLI history, skipping response rows" "$result"
+pass "Gemini collector counts prompts from antigravity CLI history, skipping response rows"
 
 # 3. Opencode SQLite database scanning
 OPENCODE_HOME=$(mktemp -d)
@@ -126,3 +132,106 @@ assert mod.plan_label({"currentTier": {"id": "free-tier", "name": "Antigravity"}
 assert mod.plan_label({}) == "Free"
 PY
 pass "Gemini plan tier parser maps subscription tiers accurately"
+
+# 6. Quota parsing survives malformed buckets and falls back across endpoints
+python3 - "$ROOT/bin/omarchy-agent-usage-gemini" <<'PY' || fail "Gemini quota parser skips malformed buckets and falls back across endpoints"
+import json
+import sys
+import urllib.error
+from importlib.machinery import SourceFileLoader
+
+mod = SourceFileLoader("gemini_usage", sys.argv[1]).load_module()
+
+class FakeResponse:
+  def __init__(self, payload):
+    self._payload = json.dumps(payload).encode("utf-8")
+  def read(self):
+    return self._payload
+  def __enter__(self):
+    return self
+  def __exit__(self, *args):
+    return False
+
+body = {"groups": [{
+  "displayName": "Gemini",
+  "buckets": [
+    {"bucketId": "b-null", "window": "5h", "remainingFraction": None},
+    {"bucketId": "b-nan", "window": "5h", "remainingFraction": float("nan")},
+    {"bucketId": "b-text", "window": "5h", "remainingFraction": "abc"},
+    {"bucketId": "b-week", "window": "week", "remainingFraction": 0.5, "resetTime": "2030-01-01T00:00:00Z"},
+  ],
+}]}
+
+calls = []
+def fake_urlopen(req, timeout=0):
+  calls.append(req.full_url)
+  return FakeResponse(body)
+mod.urllib.request.urlopen = fake_urlopen
+
+result = mod.probe_limits("token")
+assert result["ok"] is True, result
+assert len(result["limits"]) == 1, result
+assert result["limits"][0]["title"] == "Weekly", result
+assert abs(result["limits"][0]["percent"] - 0.5) < 1e-9, result
+# The canary endpoint is consulted first and succeeds, so production is never hit.
+assert calls and all("daily-cloudcode-pa" in url for url in calls), calls
+
+# A transport failure on the canary endpoint falls through to production.
+def failing_urlopen(req, timeout=0):
+  if "daily-cloudcode-pa" in req.full_url:
+    raise urllib.error.URLError("canary down")
+  return FakeResponse(body)
+mod.urllib.request.urlopen = failing_urlopen
+
+result = mod.probe_limits("token")
+assert result["ok"] is True and len(result["limits"]) == 1, result
+PY
+pass "Gemini quota parser skips malformed buckets and falls back across endpoints"
+
+# 7. Cache preservation, open-ended expiry, and owner-only permissions
+python3 - "$ROOT/bin/omarchy-agent-usage-gemini" <<'PY' || fail "Gemini collector preserves cached limits and writes owner-only cache files"
+import json
+import os
+import stat
+import sys
+import tempfile
+import time
+from importlib.machinery import SourceFileLoader
+
+mod = SourceFileLoader("gemini_usage", sys.argv[1]).load_module()
+
+os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp()
+good_limits = [{"label": "Session (5-hour)", "title": "Session", "percent": 0.4, "resetsAt": "2030-01-01T00:00:00Z"}]
+
+cache_file = mod.cache_root() / "gemini-limits.json"
+mod.write_json(cache_file, {"fetchedAtMs": 1000, "limits": good_limits, "tierLabel": "Pro"})
+
+# write_json must leave the cache owner-only.
+assert stat.S_IMODE(cache_file.stat().st_mode) == 0o600, oct(cache_file.stat().st_mode)
+
+# An ok probe with no buckets (error-shaped 200) must not wipe cached limits.
+mod.probe_limits = lambda token: {"ok": True, "limits": [], "tierLabel": ""}
+result = mod.collect_limits("token", 0, False)
+assert result["limits"] == good_limits, result
+assert result["tierLabel"] == "Pro", result
+assert json.loads(cache_file.read_text())["limits"] == good_limits
+
+# Open-ended entries (no reset time) expire once the cache ages out.
+open_ended = {"label": "Open", "title": "Open", "percent": 0.1, "resetsAt": ""}
+mod.write_json(cache_file, {"fetchedAtMs": round(time.time() * 1000), "limits": [open_ended], "tierLabel": "Pro"})
+assert len(mod.usable_cached_limits(json.loads(cache_file.read_text()))) == 1
+stale = {"fetchedAtMs": round((time.time() - 25 * 3600) * 1000), "limits": [open_ended], "tierLabel": "Pro"}
+assert mod.usable_cached_limits(stale) == []
+PY
+pass "Gemini collector preserves cached limits and writes owner-only cache files"
+
+# 8. Security contract: strictly read-only keyring access and a non-truncating lock
+if grep -q '"store"' "$ROOT/bin/omarchy-agent-usage-gemini"; then
+  fail "collector must never mutate the keyring (secret-tool lookup only)"
+fi
+pass "collector must never mutate the keyring (secret-tool lookup only)"
+
+if ! grep -q 'open("a") as lock' "$ROOT/bin/omarchy-agent-usage-gemini"; then
+  fail "scan lock file must open in append mode so active flock handles survive"
+fi
+pass "scan lock file must open in append mode so active flock handles survive"


### PR DESCRIPTION
## Summary

Expands the built-in `omarchy.agents` bar widget and collector ecosystem with official support for **Google Gemini / Antigravity**.

Previously, the agents panel supported Claude Code, Codex, and Fireworks. This PR adds Gemini rate-limit monitoring, plan tier detection, session token tracking, and per-model breakdowns.

## Changes

- **`bin/omarchy-agent-usage-gemini`**: New usage collector adhering to the sibling collector contract (`--force`, `--limits-only`, versioned JSON). Probes the Google Cloud Code (Antigravity) API for 5-hour and weekly quota windows and reset timestamps; parses session files from `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/` for google/gemini/antigravity providers; scans `~/.gemini/antigravity-cli/history.jsonl` for prompt counts (assistant/response rows skipped); queries local `opencode.db` read-only for assistant token metrics including reasoning and cache reads/writes.
- **`shell/plugins/agents/manifest.json`**: Added `gemini` provider default.
- **`shell/plugins/agents/Main.qml`**: Model name prefix handling and token counting support (`google-antigravity/gemini-2.5-pro` → `Gemini 2.5 Pro`).
- **`shell/plugins/agents/assets/gemini.svg`**: Branded vector asset.
- **`test/shell.d/agent-usage-gemini-scanner-test.sh`**: Scanner, cache, security-contract, and quota-parser tests.

## Security

Carries the review hardening from @Klebiano, now pinned by tests: cache files written owner-only (0600, atomic replace), the keyring is strictly read-only (`secret-tool lookup`, never `store`), the quota endpoint falls back from the canary host to production, and the scan lock opens in append mode so active flock handles survive.

## Robustness

- One malformed or NaN quota bucket no longer discards every limit an endpoint returned — the bucket is skipped and valid ones render.
- An ok probe with no quota buckets (error-shaped 200, API change) no longer wipes cached limits with an empty list; cached limits keep serving and the cached tier wins over one derived from an error body.
- Open-ended cached limits (no reset time) expire after 24 hours instead of rendering indefinitely when probing stops succeeding.
- `ready` matches the sibling collectors' contract (local stats or limits), and dead code from the security hardening was removed.

## Notes for reviewers

- `write_json`/`read_fresh_json` are duplicated across the sibling collectors; a shared helper module is a sensible follow-up across all of them.
- `opencode.db` resolution ignores `XDG_DATA_HOME` — same as the claude sibling; worth fixing cross-cutting later.

## Verification

- `test/shell.d/agent-usage-gemini-scanner-test.sh` — 11/11 assertions pass (including quota-parser unit tests with a stubbed endpoint and cache-permission checks).
- `test/shell.d/agent-usage-update-test.sh`, `test/shell.d/agents-panel-test.sh`, `test/shell.d/agent-usage-claude-scanner-test.sh` — pass.
- `test/cli` — passes (116 assertions).
