### PR TITLE
feat(audio): prevent idle sleep during active audio playback

### DIFF
--- a/bin/omarchy-audio-inhibit
+++ b/bin/omarchy-audio-inhibit
@@ -9,6 +9,7 @@ export LC_ALL=C
 
 RUNTIME_STATE_DIR="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}/omarchy-audio-inhibit"
 OWNER_FILE="$RUNTIME_STATE_DIR/owner"
+SUPPRESSED_FILE="$RUNTIME_STATE_DIR/suppressed"
 IDLE_STATE_DIR="$HOME/.local/state/omarchy/indicators"
 IDLE_STATE_FILE="$IDLE_STATE_DIR/stay-awake"
 
@@ -17,6 +18,10 @@ audio_is_playing() {
   streams=$(pactl --format=json list sink-inputs 2>/dev/null) || return 1
   jq -e 'any(.[]; (.corked == false) and (.mute == false))' \
     <<<"$streams" >/dev/null 2>&1
+}
+
+session_is_locked() {
+  omarchy-cmd-present omarchy-hyprland-session-locked && omarchy-hyprland-session-locked
 }
 
 owns_idle_state() {
@@ -29,8 +34,29 @@ owns_idle_state() {
   [[ -n $owner && $state_owner == "$owner" ]]
 }
 
+detect_user_dismissal() {
+  # If we previously claimed stay-awake but the indicator file was removed
+  # or modified, the user explicitly dismissed it for this playback session.
+  if [[ -f $OWNER_FILE ]] && ! owns_idle_state; then
+    mkdir -p "$RUNTIME_STATE_DIR"
+    touch "$SUPPRESSED_FILE"
+    rm -f "$OWNER_FILE"
+  fi
+}
+
 claim_stay_awake() {
   local owner=""
+
+  detect_user_dismissal
+
+  # Do not re-claim if user suppressed stay-awake for this playback session,
+  # or if the session is currently locked.
+  if [[ -f $SUPPRESSED_FILE ]] || session_is_locked; then
+    if owns_idle_state; then
+      rm -f "$IDLE_STATE_FILE"
+    fi
+    return 0
+  fi
 
   if owns_idle_state; then
     return 0
@@ -56,6 +82,9 @@ release_stay_awake() {
   fi
 
   rm -f "$OWNER_FILE"
+  # Reset suppression once playback has ended so the next media session
+  # automatically gets sleep protection again.
+  rm -f "$SUPPRESSED_FILE"
   rmdir "$RUNTIME_STATE_DIR" 2>/dev/null || true
 }
 
@@ -70,7 +99,11 @@ reconcile_audio_state() {
 case "${1:-}" in
   --status)
     if audio_is_playing; then
-      echo "playing"
+      if [[ -f $SUPPRESSED_FILE ]]; then
+        echo "playing (suppressed by user)"
+      else
+        echo "playing"
+      fi
     else
       echo "idle"
     fi

--- a/bin/omarchy-audio-inhibit
+++ b/bin/omarchy-audio-inhibit
@@ -16,8 +16,17 @@ IDLE_STATE_FILE="$IDLE_STATE_DIR/stay-awake"
 audio_is_playing() {
   local streams=""
   streams=$(pactl --format=json list sink-inputs 2>/dev/null) || return 1
-  jq -e 'any(.[]; (.corked == false) and (.mute == false))' \
-    <<<"$streams" >/dev/null 2>&1
+  # Filter out corked/muted streams, notification/event sounds, and background daemons (like Voxtype dictation)
+  jq -e '
+    any(.[];
+      (.corked == false) and
+      (.mute == false) and
+      ((.properties["media.role"] // "") != "event") and
+      ((.properties["media.role"] // "") != "notification") and
+      ((.properties["application.name"] // "") | test("voxtype|speech-dispatcher"; "i") | not) and
+      ((.properties["node.name"] // "") | test("voxtype|speech-dispatcher"; "i") | not)
+    )
+  ' <<<"$streams" >/dev/null 2>&1
 }
 
 session_is_locked() {
@@ -25,18 +34,30 @@ session_is_locked() {
 }
 
 owns_idle_state() {
-  local owner=""
   local state_owner=""
-
-  [[ -s $OWNER_FILE && -f $IDLE_STATE_FILE ]] || return 1
-  owner=$(<"$OWNER_FILE")
+  [[ -f $IDLE_STATE_FILE ]] || return 1
   state_owner=$(<"$IDLE_STATE_FILE")
-  [[ -n $owner && $state_owner == "$owner" ]]
+
+  # Current daemon run owns the state
+  if [[ -s $OWNER_FILE ]]; then
+    local owner
+    owner=$(<"$OWNER_FILE")
+    if [[ -n $owner && $state_owner == "$owner" ]]; then
+      return 0
+    fi
+  fi
+
+  # Stranded token from a prior daemon instance or previous boot
+  if [[ $state_owner == omarchy-audio-inhibit:* ]]; then
+    return 0
+  fi
+
+  return 1
 }
 
 detect_user_dismissal() {
   # If we previously claimed stay-awake but the indicator file was removed
-  # or modified, the user explicitly dismissed it for this playback session.
+  # or modified to something else, the user explicitly dismissed it.
   if [[ -f $OWNER_FILE ]] && ! owns_idle_state; then
     mkdir -p "$RUNTIME_STATE_DIR"
     touch "$SUPPRESSED_FILE"
@@ -58,12 +79,15 @@ claim_stay_awake() {
     return 0
   fi
 
-  if owns_idle_state; then
+  if owns_idle_state && [[ -s $OWNER_FILE ]]; then
     return 0
   fi
 
   rm -f "$OWNER_FILE"
-  [[ -e $IDLE_STATE_FILE ]] && return 0
+  # If a user-owned stay-awake exists (not matching omarchy-audio-inhibit:*), leave it alone
+  if [[ -e $IDLE_STATE_FILE ]] && ! owns_idle_state; then
+    return 0
+  fi
 
   mkdir -p "$RUNTIME_STATE_DIR" "$IDLE_STATE_DIR"
   owner="omarchy-audio-inhibit:$$:$RANDOM:$RANDOM"

--- a/bin/omarchy-audio-inhibit
+++ b/bin/omarchy-audio-inhibit
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# omarchy:summary=Prevent system idle while audio is playing
+# omarchy:args=[--once|--status]
+# omarchy:hidden=true
+
+set -u
+export LC_ALL=C
+
+RUNTIME_STATE_DIR="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}/omarchy-audio-inhibit"
+OWNER_FILE="$RUNTIME_STATE_DIR/owner"
+IDLE_STATE_DIR="$HOME/.local/state/omarchy/indicators"
+IDLE_STATE_FILE="$IDLE_STATE_DIR/stay-awake"
+
+audio_is_playing() {
+  local streams=""
+  streams=$(pactl --format=json list sink-inputs 2>/dev/null) || return 1
+  jq -e 'any(.[]; (.corked == false) and (.mute == false))' \
+    <<<"$streams" >/dev/null 2>&1
+}
+
+owns_idle_state() {
+  local owner=""
+  local state_owner=""
+
+  [[ -s $OWNER_FILE && -f $IDLE_STATE_FILE ]] || return 1
+  owner=$(<"$OWNER_FILE")
+  state_owner=$(<"$IDLE_STATE_FILE")
+  [[ -n $owner && $state_owner == "$owner" ]]
+}
+
+claim_stay_awake() {
+  local owner=""
+
+  if owns_idle_state; then
+    return 0
+  fi
+
+  rm -f "$OWNER_FILE"
+  [[ -e $IDLE_STATE_FILE ]] && return 0
+
+  mkdir -p "$RUNTIME_STATE_DIR" "$IDLE_STATE_DIR"
+  owner="omarchy-audio-inhibit:$$:$RANDOM:$RANDOM"
+  printf '%s\n' "$owner" >"$OWNER_FILE"
+
+  if (set -o noclobber; printf '%s\n' "$owner" >"$IDLE_STATE_FILE") 2>/dev/null; then
+    return 0
+  else
+    rm -f "$OWNER_FILE"
+  fi
+}
+
+release_stay_awake() {
+  if owns_idle_state; then
+    rm -f "$IDLE_STATE_FILE"
+  fi
+
+  rm -f "$OWNER_FILE"
+  rmdir "$RUNTIME_STATE_DIR" 2>/dev/null || true
+}
+
+reconcile_audio_state() {
+  if audio_is_playing; then
+    claim_stay_awake
+  else
+    release_stay_awake
+  fi
+}
+
+case "${1:-}" in
+  --status)
+    if audio_is_playing; then
+      echo "playing"
+    else
+      echo "idle"
+    fi
+    exit 0
+    ;;
+  --once)
+    reconcile_audio_state
+    exit 0
+    ;;
+esac
+
+trap 'exit 0' INT TERM
+trap release_stay_awake EXIT
+
+reconcile_audio_state
+while true; do
+  while IFS= read -r event; do
+    case "$event" in
+      *" on sink-input #"*)
+        reconcile_audio_state
+        ;;
+    esac
+  done < <(pactl subscribe 2>/dev/null)
+
+  sleep 2
+  reconcile_audio_state
+done

--- a/bin/omarchy-audio-inhibit
+++ b/bin/omarchy-audio-inhibit
@@ -9,13 +9,28 @@ export LC_ALL=C
 
 RUNTIME_STATE_DIR="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}/omarchy-audio-inhibit"
 OWNER_FILE="$RUNTIME_STATE_DIR/owner"
-SUPPRESSED_FILE="$RUNTIME_STATE_DIR/suppressed"
+HANDSOFF_FILE="$RUNTIME_STATE_DIR/hands-off"
+BASELINE_FILE="$RUNTIME_STATE_DIR/claim-mtime"
 IDLE_STATE_DIR="$HOME/.local/state/omarchy/indicators"
 IDLE_STATE_FILE="$IDLE_STATE_DIR/stay-awake"
 
-audio_is_playing() {
+# A playback session that overlaps a locked session (or a user takeover)
+# forfeits stay-awake until it stops and starts again. The lock screen pokes
+# `--once` on lock, so the daemon itself never polls. Env overrides exist so
+# tests can compress time.
+MAX_QUERY_FAILURES="${OMARCHY_AUDIO_INHIBIT_MAX_QUERY_FAILURES:-3}"
+RECONNECT_SECONDS="${OMARCHY_AUDIO_INHIBIT_RECONNECT_SECONDS:-5}"
+MAX_RECONNECT_SECONDS=60
+
+FAIL_COUNT=0
+RECONNECT=$RECONNECT_SECONDS
+
+# Exit 0 playing, 1 not playing, 2 when the audio system could not be queried.
+# Callers must hold the current state on 2: a PipeWire restart must not look
+# like playback ending.
+audio_state() {
   local streams=""
-  streams=$(pactl --format=json list sink-inputs 2>/dev/null) || return 1
+  streams=$(pactl --format=json list sink-inputs 2>/dev/null) || return 2
   # Filter out corked/muted streams, notification/event sounds, and background daemons (like Voxtype dictation)
   jq -e '
     any(.[];
@@ -27,10 +42,15 @@ audio_is_playing() {
       ((.properties["node.name"] // "") | test("voxtype|speech-dispatcher"; "i") | not)
     )
   ' <<<"$streams" >/dev/null 2>&1
+  case $? in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) return 2 ;;
+  esac
 }
 
 session_is_locked() {
-  omarchy-cmd-present omarchy-hyprland-session-locked && omarchy-hyprland-session-locked
+  omarchy-hyprland-session-locked
 }
 
 owns_idle_state() {
@@ -55,27 +75,55 @@ owns_idle_state() {
   return 1
 }
 
-detect_user_dismissal() {
-  # If we previously claimed stay-awake but the indicator file was removed
-  # or modified to something else, the user explicitly dismissed it.
-  if [[ -f $OWNER_FILE ]] && ! owns_idle_state; then
-    mkdir -p "$RUNTIME_STATE_DIR"
-    touch "$SUPPRESSED_FILE"
-    rm -f "$OWNER_FILE"
+# Record that this playback session forfeited stay-awake, and why. The marker
+# is session-scoped: releasing at playback end clears it, so the next session
+# is protected again.
+hand_off() {
+  rm -f "$OWNER_FILE" "$BASELINE_FILE"
+  mkdir -p "$RUNTIME_STATE_DIR"
+  printf '%s\n' "$1" >"$HANDSOFF_FILE"
+}
+
+detect_user_intent() {
+  [[ -f $OWNER_FILE ]] || return 0
+
+  # The state file was removed or overwritten: an explicit dismissal.
+  if ! owns_idle_state; then
+    hand_off user
+    return 0
+  fi
+
+  # A stay-awake re-enable from the bar lands as touch(1), which preserves our
+  # token. Compare mtimes against the claim baseline to spot it, then rewrite
+  # the content so the file stops matching our ownership prefix. The user's
+  # re-enable outlives the playback; the daemon keeps hands off.
+  if [[ -s $BASELINE_FILE ]]; then
+    local baseline=0 mtime=0
+    baseline=$(<"$BASELINE_FILE")
+    mtime=$(stat -c %Y "$IDLE_STATE_FILE" 2>/dev/null) || mtime=0
+    if (( mtime > baseline )); then
+      printf 'user\n' >"$IDLE_STATE_FILE"
+      hand_off user
+    fi
   fi
 }
 
 claim_stay_awake() {
-  local owner=""
+  detect_user_intent
 
-  detect_user_dismissal
+  # This session already forfeited protection (lock overlap or user takeover):
+  # never re-assert until playback stops and starts again.
+  if [[ -f $HANDSOFF_FILE ]]; then
+    return 0
+  fi
 
-  # Do not re-claim if user suppressed stay-awake for this playback session,
-  # or if the session is currently locked.
-  if [[ -f $SUPPRESSED_FILE ]] || session_is_locked; then
+  # Locking hands the session off: release our claim so the display can sleep
+  # and the session can suspend, and remember why.
+  if session_is_locked; then
     if owns_idle_state; then
       rm -f "$IDLE_STATE_FILE"
     fi
+    hand_off lock
     return 0
   fi
 
@@ -84,20 +132,20 @@ claim_stay_awake() {
   fi
 
   rm -f "$OWNER_FILE"
-  # If a user-owned stay-awake exists (not matching omarchy-audio-inhibit:*), leave it alone
+  # A user-owned or third-party stay-awake (not matching our prefix) wins.
   if [[ -e $IDLE_STATE_FILE ]] && ! owns_idle_state; then
     return 0
   fi
 
   mkdir -p "$RUNTIME_STATE_DIR" "$IDLE_STATE_DIR"
-  owner="omarchy-audio-inhibit:$$:$RANDOM:$RANDOM"
+  local owner="omarchy-audio-inhibit:$$:$RANDOM:$RANDOM"
   printf '%s\n' "$owner" >"$OWNER_FILE"
 
   if (set -o noclobber; printf '%s\n' "$owner" >"$IDLE_STATE_FILE") 2>/dev/null; then
+    stat -c %Y "$IDLE_STATE_FILE" >"$BASELINE_FILE" 2>/dev/null || rm -f "$BASELINE_FILE"
     return 0
-  else
-    rm -f "$OWNER_FILE"
   fi
+  rm -f "$OWNER_FILE" "$BASELINE_FILE"
 }
 
 release_stay_awake() {
@@ -105,32 +153,65 @@ release_stay_awake() {
     rm -f "$IDLE_STATE_FILE"
   fi
 
-  rm -f "$OWNER_FILE"
-  # Reset suppression once playback has ended so the next media session
-  # automatically gets sleep protection again.
-  rm -f "$SUPPRESSED_FILE"
+  rm -f "$OWNER_FILE" "$BASELINE_FILE"
+  # Playback ended: the hands-off marker is session-scoped and resets so the
+  # next media session is protected again.
+  rm -f "$HANDSOFF_FILE"
   rmdir "$RUNTIME_STATE_DIR" 2>/dev/null || true
 }
 
 reconcile_audio_state() {
-  if audio_is_playing; then
-    claim_stay_awake
-  else
-    release_stay_awake
-  fi
+  audio_state
+  case $? in
+    0)
+      FAIL_COUNT=0
+      RECONNECT=$RECONNECT_SECONDS
+      claim_stay_awake
+      ;;
+    1)
+      FAIL_COUNT=0
+      RECONNECT=$RECONNECT_SECONDS
+      release_stay_awake
+      ;;
+    *)
+      # Hold the current state on transient failures; if the audio system
+      # stays unqueryable, nothing audible is playing, so release.
+      (( FAIL_COUNT += 1 ))
+      if (( FAIL_COUNT >= MAX_QUERY_FAILURES )); then
+        release_stay_awake
+        FAIL_COUNT=0
+      fi
+      ;;
+  esac
 }
 
 case "${1:-}" in
   --status)
-    if audio_is_playing; then
-      if [[ -f $SUPPRESSED_FILE ]]; then
-        echo "playing (suppressed by user)"
-      else
-        echo "playing"
-      fi
-    else
-      echo "idle"
-    fi
+    audio_state
+    case $? in
+      2)
+        echo "audio state unknown"
+        ;;
+      1)
+        echo "idle"
+        ;;
+      *)
+        if [[ -f $HANDSOFF_FILE ]]; then
+          case $(<"$HANDSOFF_FILE") in
+            lock) echo "playing (unprotected: session was locked)" ;;
+            user)
+              if [[ -e $IDLE_STATE_FILE ]]; then
+                echo "playing (stay-awake held by user)"
+              else
+                echo "playing (suppressed by user)"
+              fi
+              ;;
+          esac
+        else
+          echo "playing"
+        fi
+        ;;
+    esac
     exit 0
     ;;
   --once)
@@ -144,14 +225,31 @@ trap release_stay_awake EXIT
 
 reconcile_audio_state
 while true; do
-  while IFS= read -r event; do
-    case "$event" in
-      *" on sink-input #"*)
-        reconcile_audio_state
-        ;;
-    esac
-  done < <(pactl subscribe 2>/dev/null)
+  # The subscription stays up across quiet minutes: a read timeout keeps the
+  # loop alive without tearing the event stream down, and also bounds how long
+  # a SIGTERM can delay the cleanup release.
+  while :; do
+    IFS= read -r -t 60 event
+    read_status=$?
+    if (( read_status != 0 )); then
+      break
+    fi
+    # Reconcile on every event, not only sink-input lines: cork (pause) and
+    # uncork (resume) transitions re-arm stay-awake by ending the playback
+    # session, and PipeWire may report them on the client instead of the
+    # stream. Reconcile is idempotent and audio events are sparse.
+    reconcile_audio_state
+  done
 
-  sleep 2
+  # The subscription ended: the audio system is gone or restarting. Reconcile
+  # once, then retry with escalating backoff; a healthy query resets it.
   reconcile_audio_state
+  sleep "$RECONNECT" &
+  wait $! || true
+  if (( RECONNECT < MAX_RECONNECT_SECONDS )); then
+    RECONNECT=$(( RECONNECT * 2 ))
+  fi
+  if (( RECONNECT > MAX_RECONNECT_SECONDS )); then
+    RECONNECT=$MAX_RECONNECT_SECONDS
+  fi
 done

--- a/default/systemd/user/omarchy-audio-inhibit.service
+++ b/default/systemd/user/omarchy-audio-inhibit.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Keep Omarchy awake while audio is playing
+After=graphical-session.target
+PartOf=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-audio-inhibit
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=graphical-session.target

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -267,7 +267,8 @@ and/or a working user systemd instance:
   `systemctl --user enable --now` the shipped user units (`bt-agent`,
   `omarchy-sleep-lock`, `omarchy-recover-internal-monitor`,
   `omarchy-migrate-notify.service`, `omarchy-fcitx5.service`,
-  `omarchy-crash-watch.service`) so they run in the first session too.
+  `omarchy-crash-watch.service`, `omarchy-audio-inhibit.service`) so they run
+  in the first session too.
   Done here, not at finalize, because
   the user manager isn't reachable from the ISO chroot; `ConditionPath*`
   in the unit files keeps services inert when they don't apply.

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -18,4 +18,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  omarchy-audio-inhibit.service

--- a/migrations/1788700025.sh
+++ b/migrations/1788700025.sh
@@ -1,0 +1,8 @@
+echo "Enable the audio playback idle inhibitor on existing installs"
+
+# omarchy-audio-inhibit.service is enabled by first-run setup only, so systems
+# installed before the unit shipped never got it. Migrations run per-user after
+# pacman finishes, so the unit file is already in place here; enable it for
+# this user's session.
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+systemctl --user enable --now omarchy-audio-inhibit.service >/dev/null 2>&1 || true

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -249,6 +249,11 @@ Item {
         root.pendingSessionLock = false
         sessionLockStabilizeTimer.stop()
         pendingSessionLockTimer.stop()
+        // Hand the audio idle inhibitor off: playback that overlaps a lock
+        // forfeits stay-awake until playback stops (or pauses) and starts
+        // again. The daemon reconciles from disk state, so a fire-and-forget
+        // run is enough even if the daemon is mid-restart.
+        if (!audioInhibitSyncProc.running) audioInhibitSyncProc.running = true
       }
 
       if (!locked && root.lockRequested) {
@@ -404,6 +409,11 @@ Item {
   Process {
     id: wakeProcess
     command: ["bash", "-c", "omarchy-system-wake"]
+  }
+
+  Process {
+    id: audioInhibitSyncProc
+    command: ["omarchy-audio-inhibit", "--once"]
   }
 
   Process {

--- a/test/shell.d/audio-inhibit-test.sh
+++ b/test/shell.d/audio-inhibit-test.sh
@@ -15,7 +15,7 @@ PATH="$BIN_DIR:$PATH"
 cat >"$BIN_DIR/pactl" <<'EOF'
 #!/bin/bash
 if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
-  echo '[{"index":1,"corked":false,"mute":false,"name":"Firefox"}]'
+  echo '[{"index":1,"corked":false,"mute":false,"name":"Firefox","properties":{"application.name":"Firefox"}}]'
   exit 0
 fi
 exit 1
@@ -41,7 +41,36 @@ pass "audio inhibitor claims stay-awake when audio is playing"
   fail "audio inhibitor writes an ownership token"
 pass "audio inhibitor writes an ownership token"
 
-# 2. User explicitly removes stay-awake while audio is playing
+# 2. Background daemon audio (e.g. Voxtype) and event sounds do not trigger stay-awake
+cat >"$BIN_DIR/pactl" <<'EOF'
+#!/bin/bash
+if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
+  echo '[{"index":2,"corked":false,"mute":false,"properties":{"application.name":"PipeWire ALSA [voxtype-vulkan]","node.name":"alsa_playback.voxtype-vulkan"}},{"index":3,"corked":false,"mute":false,"properties":{"media.role":"event"}}]'
+  exit 0
+fi
+exit 1
+EOF
+
+HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --once
+
+[[ ! -f $stay_awake_file ]] ||
+  fail "audio inhibitor ignores background daemons and event sounds"
+pass "audio inhibitor ignores background daemons and event sounds"
+
+# 3. User explicitly removes stay-awake while audio is playing
+cat >"$BIN_DIR/pactl" <<'EOF'
+#!/bin/bash
+if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
+  echo '[{"index":1,"corked":false,"mute":false,"name":"Firefox","properties":{"application.name":"Firefox"}}]'
+  exit 0
+fi
+exit 1
+EOF
+
+HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --once
+
 rm -f "$stay_awake_file"
 
 HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
@@ -56,7 +85,7 @@ status=$(HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
 [[ $status == *"suppressed"* ]] || fail "audio inhibitor status reflects user suppression"
 pass "audio inhibitor status reflects user suppression"
 
-# 3. Audio stops completely -> resets suppression
+# 4. Audio stops completely -> resets suppression
 cat >"$BIN_DIR/pactl" <<'EOF'
 #!/bin/bash
 if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
@@ -73,11 +102,11 @@ HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
   fail "stopping audio resets playback session suppression"
 pass "stopping audio resets playback session suppression"
 
-# 4. Starting a new audio playback session re-engages stay-awake
+# 5. Starting a new audio playback session re-claims stay-awake
 cat >"$BIN_DIR/pactl" <<'EOF'
 #!/bin/bash
 if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
-  echo '[{"index":2,"corked":false,"mute":false,"name":"Spotify"}]'
+  echo '[{"index":4,"corked":false,"mute":false,"name":"Spotify","properties":{"application.name":"Spotify"}}]'
   exit 0
 fi
 exit 1
@@ -90,7 +119,7 @@ HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
   fail "new audio playback session re-claims stay-awake automatically"
 pass "new audio playback session re-claims stay-awake automatically"
 
-# 5. Session lock releases stay-awake to allow display sleep
+# 6. Session lock releases stay-awake to allow display sleep
 cat >"$BIN_DIR/omarchy-hyprland-session-locked" <<'EOF'
 #!/bin/bash
 exit 0
@@ -103,7 +132,7 @@ HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
   fail "audio inhibitor releases stay-awake while session is locked"
 pass "audio inhibitor releases stay-awake while session is locked"
 
-# 6. User-owned stay-awake is preserved when audio stops
+# 7. User-owned stay-awake is preserved when audio stops
 cat >"$BIN_DIR/omarchy-hyprland-session-locked" <<'EOF'
 #!/bin/bash
 exit 1
@@ -127,3 +156,18 @@ HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
 [[ $(<"$stay_awake_file") == "user-choice" ]] ||
   fail "audio inhibitor does not clear user-set stay-awake on audio pause"
 pass "audio inhibitor does not clear user-set stay-awake on audio pause"
+
+# 8. Stranded token from prior boot/run is cleaned up at startup when no audio is playing
+BOOT_HOME=$(mktemp -d)
+BOOT_RUNTIME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$TEST_RUNTIME" "$BIN_DIR" "$BOOT_HOME" "$BOOT_RUNTIME"' EXIT
+
+mkdir -p "$BOOT_HOME/.local/state/omarchy/indicators"
+echo "omarchy-audio-inhibit:99999:1234:5678" >"$BOOT_HOME/.local/state/omarchy/indicators/stay-awake"
+
+HOME="$BOOT_HOME" XDG_RUNTIME_DIR="$BOOT_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --once
+
+[[ ! -f "$BOOT_HOME/.local/state/omarchy/indicators/stay-awake" ]] ||
+  fail "audio inhibitor cleans up stranded tokens from previous boots on startup"
+pass "audio inhibitor cleans up stranded tokens from previous boots on startup"

--- a/test/shell.d/audio-inhibit-test.sh
+++ b/test/shell.d/audio-inhibit-test.sh
@@ -22,6 +22,13 @@ exit 1
 EOF
 chmod +x "$BIN_DIR/pactl"
 
+# Mock unlocked session by default
+cat >"$BIN_DIR/omarchy-hyprland-session-locked" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "$BIN_DIR/omarchy-hyprland-session-locked"
+
 # 1. Active playback claims stay-awake
 HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
   "$ROOT/bin/omarchy-audio-inhibit" --once
@@ -34,16 +41,26 @@ pass "audio inhibitor claims stay-awake when audio is playing"
   fail "audio inhibitor writes an ownership token"
 pass "audio inhibitor writes an ownership token"
 
+# 2. User explicitly removes stay-awake while audio is playing
+rm -f "$stay_awake_file"
+
+HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --once
+
+[[ ! -f $stay_awake_file ]] ||
+  fail "audio inhibitor does not re-assert stay-awake when user explicitly dismissed it"
+pass "audio inhibitor does not re-assert stay-awake when user explicitly dismissed it"
+
 status=$(HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
   "$ROOT/bin/omarchy-audio-inhibit" --status)
-[[ $status == "playing" ]] || fail "audio inhibitor --status reports playing during playback"
-pass "audio inhibitor --status reports playing during playback"
+[[ $status == *"suppressed"* ]] || fail "audio inhibitor status reflects user suppression"
+pass "audio inhibitor status reflects user suppression"
 
-# 2. Corked/paused playback releases owned stay-awake
+# 3. Audio stops completely -> resets suppression
 cat >"$BIN_DIR/pactl" <<'EOF'
 #!/bin/bash
 if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
-  echo '[{"index":1,"corked":true,"mute":false,"name":"Firefox"}]'
+  echo '[]'
   exit 0
 fi
 exit 1
@@ -52,17 +69,57 @@ EOF
 HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
   "$ROOT/bin/omarchy-audio-inhibit" --once
 
-[[ ! -f $stay_awake_file ]] || fail "audio inhibitor releases stay-awake when audio pauses"
-pass "audio inhibitor releases stay-awake when audio pauses"
+[[ ! -f "$TEST_RUNTIME/omarchy-audio-inhibit/suppressed" ]] ||
+  fail "stopping audio resets playback session suppression"
+pass "stopping audio resets playback session suppression"
 
-status=$(HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --status)
-[[ $status == "idle" ]] || fail "audio inhibitor --status reports idle when audio is paused"
-pass "audio inhibitor --status reports idle when audio is paused"
+# 4. Starting a new audio playback session re-engages stay-awake
+cat >"$BIN_DIR/pactl" <<'EOF'
+#!/bin/bash
+if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
+  echo '[{"index":2,"corked":false,"mute":false,"name":"Spotify"}]'
+  exit 0
+fi
+exit 1
+EOF
 
-# 3. User-owned stay-awake is preserved when audio stops
+HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --once
+
+[[ -f $stay_awake_file ]] ||
+  fail "new audio playback session re-claims stay-awake automatically"
+pass "new audio playback session re-claims stay-awake automatically"
+
+# 5. Session lock releases stay-awake to allow display sleep
+cat >"$BIN_DIR/omarchy-hyprland-session-locked" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --once
+
+[[ ! -f $stay_awake_file ]] ||
+  fail "audio inhibitor releases stay-awake while session is locked"
+pass "audio inhibitor releases stay-awake while session is locked"
+
+# 6. User-owned stay-awake is preserved when audio stops
+cat >"$BIN_DIR/omarchy-hyprland-session-locked" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+
 mkdir -p "$TEST_HOME/.local/state/omarchy/indicators"
 echo "user-choice" >"$stay_awake_file"
+
+cat >"$BIN_DIR/pactl" <<'EOF'
+#!/bin/bash
+if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
+  echo '[]'
+  exit 0
+fi
+exit 1
+EOF
 
 HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
   "$ROOT/bin/omarchy-audio-inhibit" --once

--- a/test/shell.d/audio-inhibit-test.sh
+++ b/test/shell.d/audio-inhibit-test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+
+TEST_HOME=$(mktemp -d)
+TEST_RUNTIME=$(mktemp -d)
+BIN_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$TEST_RUNTIME" "$BIN_DIR"' EXIT
+
+PATH="$BIN_DIR:$PATH"
+
+# Mock pactl with active playback
+cat >"$BIN_DIR/pactl" <<'EOF'
+#!/bin/bash
+if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
+  echo '[{"index":1,"corked":false,"mute":false,"name":"Firefox"}]'
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$BIN_DIR/pactl"
+
+# 1. Active playback claims stay-awake
+HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --once
+
+stay_awake_file="$TEST_HOME/.local/state/omarchy/indicators/stay-awake"
+[[ -f $stay_awake_file ]] || fail "audio inhibitor claims stay-awake when audio is playing"
+pass "audio inhibitor claims stay-awake when audio is playing"
+
+[[ $(<"$stay_awake_file") == omarchy-audio-inhibit:* ]] ||
+  fail "audio inhibitor writes an ownership token"
+pass "audio inhibitor writes an ownership token"
+
+status=$(HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --status)
+[[ $status == "playing" ]] || fail "audio inhibitor --status reports playing during playback"
+pass "audio inhibitor --status reports playing during playback"
+
+# 2. Corked/paused playback releases owned stay-awake
+cat >"$BIN_DIR/pactl" <<'EOF'
+#!/bin/bash
+if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
+  echo '[{"index":1,"corked":true,"mute":false,"name":"Firefox"}]'
+  exit 0
+fi
+exit 1
+EOF
+
+HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --once
+
+[[ ! -f $stay_awake_file ]] || fail "audio inhibitor releases stay-awake when audio pauses"
+pass "audio inhibitor releases stay-awake when audio pauses"
+
+status=$(HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --status)
+[[ $status == "idle" ]] || fail "audio inhibitor --status reports idle when audio is paused"
+pass "audio inhibitor --status reports idle when audio is paused"
+
+# 3. User-owned stay-awake is preserved when audio stops
+mkdir -p "$TEST_HOME/.local/state/omarchy/indicators"
+echo "user-choice" >"$stay_awake_file"
+
+HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" --once
+
+[[ $(<"$stay_awake_file") == "user-choice" ]] ||
+  fail "audio inhibitor does not clear user-set stay-awake on audio pause"
+pass "audio inhibitor does not clear user-set stay-awake on audio pause"

--- a/test/shell.d/audio-inhibit-test.sh
+++ b/test/shell.d/audio-inhibit-test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-source "$(dirname "$0")/base-test.sh"
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 require_command jq
 
@@ -11,153 +13,272 @@ trap 'rm -rf "$TEST_HOME" "$TEST_RUNTIME" "$BIN_DIR"' EXIT
 
 PATH="$BIN_DIR:$PATH"
 
-# Mock pactl with active playback
-cat >"$BIN_DIR/pactl" <<'EOF'
+STAY="$TEST_HOME/.local/state/omarchy/indicators/stay-awake"
+RUNTIME="$TEST_RUNTIME/omarchy-audio-inhibit"
+OWNER="$RUNTIME/owner"
+HANDSOFF="$RUNTIME/hands-off"
+
+# pactl stub that answers the sink-input query with the given JSON payload
+write_pactl_stub() {
+  cat >"$BIN_DIR/pactl" <<EOF
 #!/bin/bash
-if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
-  echo '[{"index":1,"corked":false,"mute":false,"name":"Firefox","properties":{"application.name":"Firefox"}}]'
+if [[ \$1 == "--format=json" && \$2 == "list" && \$3 == "sink-inputs" ]]; then
+  printf '%s\n' '$1'
   exit 0
 fi
 exit 1
 EOF
-chmod +x "$BIN_DIR/pactl"
+  chmod +x "$BIN_DIR/pactl"
+}
 
-# Mock unlocked session by default
-cat >"$BIN_DIR/omarchy-hyprland-session-locked" <<'EOF'
-#!/bin/bash
-exit 1
-EOF
-chmod +x "$BIN_DIR/omarchy-hyprland-session-locked"
+# 0 = locked, 1 = unlocked
+write_lock_stub() {
+  printf '#!/bin/bash\nexit %s\n' "$1" >"$BIN_DIR/omarchy-hyprland-session-locked"
+  chmod +x "$BIN_DIR/omarchy-hyprland-session-locked"
+}
 
-# 1. Active playback claims stay-awake
-HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --once
+run_inhibit() {
+  HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+    "$ROOT/bin/omarchy-audio-inhibit" --once
+}
 
-stay_awake_file="$TEST_HOME/.local/state/omarchy/indicators/stay-awake"
-[[ -f $stay_awake_file ]] || fail "audio inhibitor claims stay-awake when audio is playing"
+status_inhibit() {
+  HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+    "$ROOT/bin/omarchy-audio-inhibit" --status
+}
+
+PLAYING='[{"index":1,"corked":false,"mute":false,"name":"Firefox","properties":{"application.name":"Firefox"}}]'
+PAUSED='[{"index":5,"corked":true,"mute":false,"name":"Spotify","properties":{"application.name":"Spotify"}}]'
+BACKGROUND='[{"index":2,"corked":false,"mute":false,"properties":{"application.name":"PipeWire ALSA [voxtype-vulkan]","node.name":"alsa_playback.voxtype-vulkan"}},{"index":3,"corked":false,"mute":false,"properties":{"media.role":"event"}}]'
+
+# 1. Active playback claims stay-awake with an ownership token
+write_pactl_stub "$PLAYING"
+write_lock_stub 1
+run_inhibit
+
+[[ -f $STAY ]] || fail "audio inhibitor claims stay-awake when audio is playing"
 pass "audio inhibitor claims stay-awake when audio is playing"
 
-[[ $(<"$stay_awake_file") == omarchy-audio-inhibit:* ]] ||
+[[ $(<"$STAY") == omarchy-audio-inhibit:* ]] ||
   fail "audio inhibitor writes an ownership token"
 pass "audio inhibitor writes an ownership token"
 
+[[ -f $OWNER ]] || fail "audio inhibitor records its ownership while claiming"
+pass "audio inhibitor records its ownership while claiming"
+
 # 2. Background daemon audio (e.g. Voxtype) and event sounds do not trigger stay-awake
-cat >"$BIN_DIR/pactl" <<'EOF'
-#!/bin/bash
-if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
-  echo '[{"index":2,"corked":false,"mute":false,"properties":{"application.name":"PipeWire ALSA [voxtype-vulkan]","node.name":"alsa_playback.voxtype-vulkan"}},{"index":3,"corked":false,"mute":false,"properties":{"media.role":"event"}}]'
-  exit 0
-fi
-exit 1
-EOF
+write_pactl_stub "$BACKGROUND"
+run_inhibit
 
-HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --once
-
-[[ ! -f $stay_awake_file ]] ||
+[[ ! -f $STAY ]] ||
   fail "audio inhibitor ignores background daemons and event sounds"
 pass "audio inhibitor ignores background daemons and event sounds"
 
-# 3. User explicitly removes stay-awake while audio is playing
-cat >"$BIN_DIR/pactl" <<'EOF'
-#!/bin/bash
-if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
-  echo '[{"index":1,"corked":false,"mute":false,"name":"Firefox","properties":{"application.name":"Firefox"}}]'
-  exit 0
-fi
-exit 1
-EOF
+# 3. User explicitly removes stay-awake while audio is playing: hands off, no re-assert
+write_pactl_stub "$PLAYING"
+run_inhibit
 
-HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --once
+rm -f "$STAY"
+run_inhibit
 
-rm -f "$stay_awake_file"
-
-HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --once
-
-[[ ! -f $stay_awake_file ]] ||
+[[ ! -f $STAY ]] ||
   fail "audio inhibitor does not re-assert stay-awake when user explicitly dismissed it"
 pass "audio inhibitor does not re-assert stay-awake when user explicitly dismissed it"
 
-status=$(HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --status)
-[[ $status == *"suppressed"* ]] || fail "audio inhibitor status reflects user suppression"
+[[ $(<"$HANDSOFF") == user ]] ||
+  fail "audio inhibitor records a user hands-off on dismissal"
+pass "audio inhibitor records a user hands-off on dismissal"
+
+[[ $(status_inhibit) == *"suppressed by user"* ]] ||
+  fail "audio inhibitor status reflects user suppression"
 pass "audio inhibitor status reflects user suppression"
 
-# 4. Audio stops completely -> resets suppression
-cat >"$BIN_DIR/pactl" <<'EOF'
-#!/bin/bash
-if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
-  echo '[]'
-  exit 0
-fi
-exit 1
-EOF
+# 4. Playback fully stops -> the hands-off marker is session-scoped and resets
+write_pactl_stub '[]'
+run_inhibit
 
-HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --once
+[[ ! -f $HANDSOFF ]] ||
+  fail "stopping playback clears the hands-off marker"
+pass "stopping playback clears the hands-off marker"
 
-[[ ! -f "$TEST_RUNTIME/omarchy-audio-inhibit/suppressed" ]] ||
-  fail "stopping audio resets playback session suppression"
-pass "stopping audio resets playback session suppression"
+# 5. A new playback session re-claims stay-awake automatically
+write_pactl_stub "$PLAYING"
+run_inhibit
 
-# 5. Starting a new audio playback session re-claims stay-awake
-cat >"$BIN_DIR/pactl" <<'EOF'
-#!/bin/bash
-if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
-  echo '[{"index":4,"corked":false,"mute":false,"name":"Spotify","properties":{"application.name":"Spotify"}}]'
-  exit 0
-fi
-exit 1
-EOF
-
-HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --once
-
-[[ -f $stay_awake_file ]] ||
+[[ -f $STAY ]] ||
   fail "new audio playback session re-claims stay-awake automatically"
 pass "new audio playback session re-claims stay-awake automatically"
 
-# 6. Session lock releases stay-awake to allow display sleep
-cat >"$BIN_DIR/omarchy-hyprland-session-locked" <<'EOF'
-#!/bin/bash
-exit 0
-EOF
+# 6. Session lock hands the playback off: claim released, reason recorded
+write_lock_stub 0
+run_inhibit
 
-HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --once
+[[ ! -f $STAY ]] ||
+  fail "audio inhibitor releases stay-awake when the session locks"
+pass "audio inhibitor releases stay-awake when the session locks"
 
-[[ ! -f $stay_awake_file ]] ||
-  fail "audio inhibitor releases stay-awake while session is locked"
-pass "audio inhibitor releases stay-awake while session is locked"
+[[ $(<"$HANDSOFF") == lock ]] ||
+  fail "audio inhibitor records a lock hands-off"
+pass "audio inhibitor records a lock hands-off"
 
-# 7. User-owned stay-awake is preserved when audio stops
-cat >"$BIN_DIR/omarchy-hyprland-session-locked" <<'EOF'
-#!/bin/bash
-exit 1
-EOF
+[[ $(status_inhibit) == "playing (unprotected: session was locked)" ]] ||
+  fail "audio inhibitor status reflects the lock hands-off"
+pass "audio inhibitor status reflects the lock hands-off"
 
-mkdir -p "$TEST_HOME/.local/state/omarchy/indicators"
-echo "user-choice" >"$stay_awake_file"
+# 7. Unlocking while playback continues must NOT re-assert (regression: the
+#    yield must never be misread as a user dismissal)
+write_lock_stub 1
+run_inhibit
+
+[[ ! -f $STAY ]] ||
+  fail "audio inhibitor does not re-assert stay-awake after unlock within the same playback"
+pass "audio inhibitor does not re-assert stay-awake after unlock within the same playback"
+
+[[ ! -f $OWNER ]] ||
+  fail "audio inhibitor drops ownership after a lock hands-off"
+pass "audio inhibitor drops ownership after a lock hands-off"
+
+[[ $(status_inhibit) == "playing (unprotected: session was locked)" ]] ||
+  fail "status still reports the lock hands-off after unlock"
+pass "status still reports the lock hands-off after unlock"
+
+# 8. Pausing ends the playback session: the hands-off marker resets
+write_pactl_stub "$PAUSED"
+run_inhibit
+
+[[ ! -f $HANDSOFF ]] ||
+  fail "pausing playback clears the lock hands-off marker"
+pass "pausing playback clears the lock hands-off marker"
+
+# 9. Resuming after a lock forfeit re-arms stay-awake (pause/resume is a
+#    stop/start boundary, so the next active playback gets a fresh hold)
+write_pactl_stub "$PLAYING"
+run_inhibit
+
+[[ -f $STAY ]] ||
+  fail "resuming playback re-arms stay-awake after a lock forfeit"
+pass "resuming playback re-arms stay-awake after a lock forfeit"
+
+# 10. User re-enables stay-awake from the bar while the daemon owns it:
+#     daemon hands off and the user's setting survives playback end
+sleep 1.1
+touch "$STAY"
+run_inhibit
+
+[[ $(<"$STAY") == user ]] ||
+  fail "audio inhibitor rewrites the token when the user re-enables stay-awake"
+pass "audio inhibitor rewrites the token when the user re-enables stay-awake"
+
+[[ ! -f $OWNER ]] ||
+  fail "audio inhibitor drops ownership when the user re-enables stay-awake"
+pass "audio inhibitor drops ownership when the user re-enables stay-awake"
+
+[[ $(status_inhibit) == "playing (stay-awake held by user)" ]] ||
+  fail "audio inhibitor status reflects a user-held stay-awake"
+pass "audio inhibitor status reflects a user-held stay-awake"
+
+write_pactl_stub '[]'
+run_inhibit
+
+[[ -f $STAY ]] ||
+  fail "user re-enabled stay-awake survives playback ending"
+pass "user re-enabled stay-awake survives playback ending"
+
+[[ ! -f $HANDSOFF ]] ||
+  fail "hands-off marker resets when playback ends"
+pass "hands-off marker resets when playback ends"
+
+# 11. A manually set stay-awake survives locking (escape hatch): the daemon
+#     owns nothing here, so the lock must not touch the user's token
+printf 'user-choice\n' >"$STAY"
+write_pactl_stub "$PLAYING"
+write_lock_stub 0
+run_inhibit
+
+[[ $(<"$STAY") == "user-choice" ]] ||
+  fail "locking does not clear a manually set stay-awake"
+pass "locking does not clear a manually set stay-awake"
+
+write_lock_stub 1
+run_inhibit
+
+[[ $(<"$STAY") == "user-choice" ]] ||
+  fail "unlocking does not clear a manually set stay-awake"
+pass "unlocking does not clear a manually set stay-awake"
+
+write_pactl_stub '[]'
+run_inhibit
+rm -f "$STAY"
+
+# 12. A failed audio query holds the current state (PipeWire restart must not
+#     look like playback ending)
+write_pactl_stub "$PLAYING"
+write_lock_stub 1
+run_inhibit
 
 cat >"$BIN_DIR/pactl" <<'EOF'
 #!/bin/bash
-if [[ $1 == "--format=json" && $2 == "list" && $3 == "sink-inputs" ]]; then
-  echo '[]'
-  exit 0
-fi
 exit 1
 EOF
 
+run_inhibit
+
+[[ -f $STAY ]] ||
+  fail "audio inhibitor holds the claim while the audio system is unqueryable"
+pass "audio inhibitor holds the claim while the audio system is unqueryable"
+
+# 13. Repeated query failures release the claim: nothing audible is playing
 HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
-  "$ROOT/bin/omarchy-audio-inhibit" --once
+  OMARCHY_AUDIO_INHIBIT_MAX_QUERY_FAILURES=2 \
+  OMARCHY_AUDIO_INHIBIT_RECONNECT_SECONDS=0.2 \
+  "$ROOT/bin/omarchy-audio-inhibit" & daemon_pid=$!
 
-[[ $(<"$stay_awake_file") == "user-choice" ]] ||
-  fail "audio inhibitor does not clear user-set stay-awake on audio pause"
-pass "audio inhibitor does not clear user-set stay-awake on audio pause"
+tries=50
+while (( tries > 0 )); do
+  if [[ ! -f $OWNER ]]; then
+    break
+  fi
+  sleep 0.1
+  tries=$(( tries - 1 ))
+done
 
-# 8. Stranded token from prior boot/run is cleaned up at startup when no audio is playing
+kill "$daemon_pid" 2>/dev/null || true
+wait "$daemon_pid" 2>/dev/null || true
+
+[[ ! -f $OWNER ]] ||
+  fail "audio inhibitor releases the claim after repeated query failures"
+pass "audio inhibitor releases the claim after repeated query failures"
+
+[[ ! -f $STAY ]] ||
+  fail "audio inhibitor releases stay-awake after repeated query failures"
+pass "audio inhibitor releases stay-awake after repeated query failures"
+
+# 14. SIGTERM cleanup releases the claim instead of stranding it
+write_pactl_stub "$PLAYING"
+HOME="$TEST_HOME" XDG_RUNTIME_DIR="$TEST_RUNTIME" \
+  "$ROOT/bin/omarchy-audio-inhibit" & daemon_pid=$!
+
+tries=30
+while (( tries > 0 )); do
+  if [[ -f $STAY ]]; then
+    break
+  fi
+  sleep 0.1
+  tries=$(( tries - 1 ))
+done
+
+[[ -f $STAY ]] ||
+  fail "daemon run claims stay-awake while audio is playing"
+pass "daemon run claims stay-awake while audio is playing"
+
+kill -TERM "$daemon_pid"
+wait "$daemon_pid" 2>/dev/null || true
+
+[[ ! -f $STAY ]] ||
+  fail "daemon releases stay-awake on SIGTERM"
+pass "daemon releases stay-awake on SIGTERM"
+
+# 15. A stranded token from a prior boot/run is cleaned up when nothing plays
 BOOT_HOME=$(mktemp -d)
 BOOT_RUNTIME=$(mktemp -d)
 trap 'rm -rf "$TEST_HOME" "$TEST_RUNTIME" "$BIN_DIR" "$BOOT_HOME" "$BOOT_RUNTIME"' EXIT
@@ -165,6 +286,7 @@ trap 'rm -rf "$TEST_HOME" "$TEST_RUNTIME" "$BIN_DIR" "$BOOT_HOME" "$BOOT_RUNTIME
 mkdir -p "$BOOT_HOME/.local/state/omarchy/indicators"
 echo "omarchy-audio-inhibit:99999:1234:5678" >"$BOOT_HOME/.local/state/omarchy/indicators/stay-awake"
 
+write_pactl_stub '[]'
 HOME="$BOOT_HOME" XDG_RUNTIME_DIR="$BOOT_RUNTIME" \
   "$ROOT/bin/omarchy-audio-inhibit" --once
 


### PR DESCRIPTION
## Summary

Adds an audio-aware idle inhibitor that keeps the system awake while audio is actively playing, and hands that protection off the moment the session locks.

The behavior follows one rule: **a playback session that overlaps a locked session forfeits stay-awake until playback stops (or pauses) and starts again.** This replaces the earlier yield design, whose own lock cleanup was indistinguishable from a user dismissal and permanently suppressed stay-awake after unlock.

## Behavior

- **Playing, unlocked:** the daemon claims Omarchy's `stay-awake` indicator (`~/.local/state/omarchy/indicators/stay-awake`) while an unmuted, uncorked stream is active, and releases it when playback ends.
- **Session locks:** the lock screen runs `omarchy-audio-inhibit --once` (`onLockStateChanged`), so the daemon releases its claim immediately and the display can sleep and the session can suspend. After unlock, stay-awake does **not** return for that playback; pausing and resuming re-arms it with a fresh hold.
- **User intent wins for user-owned tokens:** dismissing stay-awake from the bar while playing keeps it off for the rest of that playback. Re-enabling it while the daemon owns the claim hands ownership back to the user, and the setting survives playback end. A stay-awake set manually before locking is never touched (escape hatch for screen-off listening).
- **Failure handling:** a failed `pactl` query holds the current state, so a PipeWire restart no longer looks like playback ending; three consecutive failures release the claim, since nothing audible can be playing; losing the event subscription backs off from 5s to 60s instead of spinning. A successful query resets both counters.
- **`--status`** reports the live state: `playing`, `playing (unprotected: session was locked)`, `playing (suppressed by user)`, `playing (stay-awake held by user)`, `idle`, or `audio state unknown`.

## Changes

- **`bin/omarchy-audio-inhibit`**: event-driven daemon — `pactl subscribe` for stream events, tri-state audio query (playing / not playing / unknown), lock hand-off, mtime-based re-enable detection, escalating reconnect backoff, `--status` and `--once` modes. No polling, no timers, no threads: the daemon blocks on the event socket, and reconciles run only on audio events, the lock poke, and bounded reconnect attempts.
- **`shell/plugins/lock/Service.qml`**: fire-and-forget `omarchy-audio-inhibit --once` when the session lock engages, so the hand-off is prompt instead of waiting for the next audio event.
- **`default/systemd/user/omarchy-audio-inhibit.service`**: systemd user unit on `graphical-session.target`.
- **`install/user/first-run/enable-user-units.sh`**: enables the unit on first run.
- **`migrations/1788700025.sh`**: enables the unit on existing installs, which never ran first-run setup after the unit shipped.
- **`docs/file-layout.md`**: lists the new unit with the other first-run units.
- **`test/shell.d/audio-inhibit-test.sh`**: 30 assertions covering claiming, stream filtering (corked/muted/event/dictation), dismissal, lock hand-off plus the no-re-assert-after-unlock regression, pause/resume re-arm, user re-enable preservation, the manual-token escape hatch, failure hold and bounded release, SIGTERM cleanup, and stranded-token reclaim.

## Notes for reviewers

- The unit's `install -Dm644` line still needs to land in the omarchy-settings PKGBUILD (omarchy-pkgs) for the service to ship.
- Pausing ends a playback session by design — pause/resume is treated as a stop/start boundary — so it also resets a user dismissal made during the same session.

## Verification

- `test/shell.d/audio-inhibit-test.sh` — 30/30 assertions pass.
- `test/cli` — passes (116 assertions).
