### PR TITLE
Publish Xft.dpi to XWayland so fcitx5's candidate window scales

### DIFF
--- a/bin/omarchy-hyprland-xwayland-dpi
+++ b/bin/omarchy-hyprland-xwayland-dpi
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# omarchy:summary=Publish the desktop scale to XWayland clients as Xft.dpi
+# omarchy:hidden=true
+
+set -euo pipefail
+
+# Omarchy runs XWayland with force_zero_scaling, so X11 windows draw at 1x and
+# every client has to scale itself. GTK and Qt apps read GDK_SCALE and their
+# own variables for that, but plain X11 clients read Xft.dpi from the root
+# window's RESOURCE_MANAGER property, and nothing in the session set it. The
+# client every CJK user meets is fcitx5's candidate window, which it draws as
+# an X11 window whenever the focused app is XWayland: at 96 dpi it came up at
+# half size on a 2x display. Publish 96 * GDK_SCALE, the factor the rest of the
+# desktop already applies to X11 windows.
+
+[[ -n ${DISPLAY:-} ]] || exit 0
+
+scale=${GDK_SCALE:-1}
+if [[ ! $scale =~ ^[0-9]+$ ]]; then
+  scale=1
+fi
+dpi=$((96 * scale))
+
+marker="! Xft.dpi is managed by omarchy-hyprland-xwayland-dpi"
+
+# xprop prints the property as a C string literal; turn it back into text so
+# other resources a user loaded with xrdb survive the rewrite.
+current=$(xprop -root -notype RESOURCE_MANAGER 2>/dev/null | sed -n 's/^RESOURCE_MANAGER = "\(.*\)"$/\1/p')
+current=${current//\\\"/\"}
+current=$(printf '%b' "$current")
+
+# A user who set Xft.dpi themselves, through xrdb or a dotfile, knows better
+# than the GDK_SCALE guess. Only replace a value this command wrote.
+if grep -q '^Xft\.dpi:' <<<"$current" && ! grep -qF "$marker" <<<"$current"; then
+  exit 0
+fi
+
+kept=$(grep -v '^Xft\.dpi:' <<<"$current" | grep -vFx "$marker" || true)
+resources="$marker"$'\n'"Xft.dpi:"$'\t'"$dpi"$'\n'
+if [[ -n $kept ]]; then
+  resources="$kept"$'\n'"$resources"
+fi
+
+xprop -root -f RESOURCE_MANAGER 8s -set RESOURCE_MANAGER "$resources"

--- a/default/systemd/user/omarchy-fcitx5.service
+++ b/default/systemd/user/omarchy-fcitx5.service
@@ -20,6 +20,10 @@ ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 Type=simple
+# fcitx5 draws its candidate window as an X11 window for XWayland apps and
+# sizes the font from Xft.dpi, which nothing else in the session publishes.
+# The leading - keeps a failed xprop from taking the input method down with it.
+ExecStartPre=-/usr/bin/omarchy-hyprland-xwayland-dpi
 # notificationitem duplicates the tray entry omarchy already renders itself.
 ExecStart=/usr/bin/fcitx5 --disable notificationitem
 # always, not on-failure: fcitx5 exits 0 when it detects another instance owning

--- a/migrations/1788320383.sh
+++ b/migrations/1788320383.sh
@@ -1,0 +1,9 @@
+echo "Scale fcitx5's candidate window for XWayland apps on HiDPI displays"
+
+# The fcitx5 unit now publishes Xft.dpi to XWayland before it starts. Reload so
+# the next login runs the new ExecStartPre, and repair the running session
+# directly: fcitx5 re-reads the property the moment it changes, so no restart.
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+if [[ -n ${DISPLAY:-} ]]; then
+  omarchy-hyprland-xwayland-dpi >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/xwayland-dpi-test.sh
+++ b/test/shell.d/xwayland-dpi-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+stub_bin="$test_dir/bin"
+mkdir -p "$stub_bin"
+property="$test_dir/property"
+set_log="$test_dir/set"
+
+# Answers the read with a canned C-string literal, the way xprop prints it, and
+# records what a -set call would have written.
+cat >"$stub_bin/xprop" <<STUB
+#!/bin/bash
+if [[ " \$* " == *" -set "* ]]; then
+  printf '%s' "\${@: -1}" >"$set_log"
+  exit 0
+fi
+if [[ -s "$property" ]]; then
+  printf 'RESOURCE_MANAGER = "%s"\n' "\$(cat "$property")"
+fi
+STUB
+chmod +x "$stub_bin/xprop"
+
+run() {
+  rm -f "$set_log"
+  env -i PATH="$stub_bin:/usr/bin" "$@" "$ROOT/bin/omarchy-hyprland-xwayland-dpi"
+}
+
+marker='! Xft.dpi is managed by omarchy-hyprland-xwayland-dpi'
+
+: >"$property"
+run DISPLAY=:0 GDK_SCALE=2
+[[ -f $set_log ]] || fail "no property written on an empty RESOURCE_MANAGER"
+[[ $(cat "$set_log") == "$marker"$'\nXft.dpi:\t192' ]] ||
+  fail "unexpected resources for GDK_SCALE=2" "$(cat "$set_log")"
+pass "publishes Xft.dpi as 96 times GDK_SCALE"
+
+run DISPLAY=:0
+[[ $(cat "$set_log") == *$'Xft.dpi:\t96' ]] || fail "GDK_SCALE unset should mean 96 dpi" "$(cat "$set_log")"
+pass "falls back to 96 dpi without GDK_SCALE"
+
+run GDK_SCALE=2
+[[ ! -f $set_log ]] || fail "wrote a property with no X display"
+pass "does nothing without DISPLAY"
+
+printf 'Xcursor.size:\\t48\\n' >"$property"
+run DISPLAY=:0 GDK_SCALE=2
+[[ $(cat "$set_log") == $'Xcursor.size:\t48\n'"$marker"$'\nXft.dpi:\t192' ]] ||
+  fail "other resources were not kept" "$(cat "$set_log")"
+pass "keeps resources a user loaded with xrdb"
+
+printf 'Xft.dpi:\\t144\\n' >"$property"
+run DISPLAY=:0 GDK_SCALE=2
+[[ ! -f $set_log ]] || fail "overwrote a user-set Xft.dpi" "$(cat "$set_log")"
+pass "leaves a user-set Xft.dpi alone"
+
+printf 'Xcursor.size:\\t48\\n%s\\nXft.dpi:\\t192\\n' "$marker" >"$property"
+run DISPLAY=:0 GDK_SCALE=3
+[[ $(cat "$set_log") == $'Xcursor.size:\t48\n'"$marker"$'\nXft.dpi:\t288' ]] ||
+  fail "did not replace its own earlier value" "$(cat "$set_log")"
+pass "replaces the value it wrote when the scale changes"
+
+service="$ROOT/default/systemd/user/omarchy-fcitx5.service"
+grep -Fx 'ExecStartPre=-/usr/bin/omarchy-hyprland-xwayland-dpi' "$service" >/dev/null ||
+  fail "fcitx5 unit does not publish Xft.dpi before starting"
+pass "fcitx5 unit publishes Xft.dpi before fcitx5 starts"


### PR DESCRIPTION
## Problem

On a HiDPI laptop (2x scale), typing Chinese with fcitx5 into an XWayland app such as Feishu shows the candidate window at half size. The same input into a Wayland-native app (terminal, Chromium) is fine.

## Cause

Omarchy runs XWayland with `force_zero_scaling`, so X11 windows draw at 1x and each client has to scale itself. GTK and Qt apps do that from `GDK_SCALE` and their own variables. Plain X11 clients read `Xft.dpi` from the root window's `RESOURCE_MANAGER` property, and nothing in the session sets it: Omarchy ships no `.Xresources`, does not install xrdb, and the property is empty on a fresh install.

fcitx5 draws its candidate window as an X11 window whenever the focused app is XWayland and sizes the font from `Xft.dpi` ([xcbui.cpp](https://github.com/fcitx/fcitx5/blob/master/src/ui/classic/xcbui.cpp), `forcedDpi`). With the property empty it assumes 96 dpi on a 192 dpi screen. Since Omarchy ships fcitx5 in every session and the manual points CJK users at it, every one of them with a 2x display hits this the first time they type into Feishu, WeChat, or any Electron app that fell back to X11.

## Fix

- `bin/omarchy-hyprland-xwayland-dpi` (hidden) writes `Xft.dpi = 96 * GDK_SCALE` into `RESOURCE_MANAGER` with xprop, which gtk3 already pulls in through at-spi2-core. It keeps other resources a user loaded with xrdb, leaves a user-set `Xft.dpi` alone, and replaces only the value it wrote itself (marked with a comment line), so a changed `omarchy_gdk_scale` takes effect on the next login.
- `omarchy-fcitx5.service` runs it as `ExecStartPre=-` so the value is published before the first candidate window. The unit already has `GDK_SCALE` and `DISPLAY` from the imported session environment. The leading `-` keeps a failed xprop from taking the input method down.
- A migration reloads the user manager and runs the command once. fcitx5 re-reads `RESOURCE_MANAGER` on `PropertyNotify`, so the running session is repaired without restarting fcitx5.

The 1x-monitor trade-off is the same one Omarchy already accepts for `GDK_SCALE` on X11 windows.

## Verification

- `test/shell.d/xwayland-dpi-test.sh` covers the scale math, the no-DISPLAY no-op, keeping foreign resources, respecting a user-set value, replacing its own, and the unit wiring.
- Ran on Omarchy 4.0.2 with fcitx5 5.1.21 and a 2880x1800 display at scale 2: after the unit change the property reads `Xft.dpi: 192` and running the command twice is idempotent.
- `./test/all` passes apart from `bar-icon-geometry-test.sh`, which fails on this machine before the change too because it launches Quickshell inside a live session.


Back to draft: with `GDK_SCALE=2`, GTK3 reads `Xft.dpi` as an unscaled value and multiplies it by the scale, so GTK X11 apps and Electron apps (via Chromium's GTK backend, `resolution * scale / 96`) render at 4x. Feishu doubled in size. Needs a different mechanism.
