### PR TITLE
Switch to a workspace on the focused monitor

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -20,7 +20,7 @@ o.bind("SUPER + DOWN", "Focus on below window", hl.dsp.focus({ direction = "d" }
 
 for workspace = 1, 10 do
   local key = "code:" .. tostring(workspace + 9)
-  o.bind("SUPER + " .. key, "Switch to workspace " .. workspace, hl.dsp.focus({ workspace = tostring(workspace) }))
+  o.bind("SUPER + " .. key, "Switch to workspace " .. workspace, hl.dsp.focus({ workspace = tostring(workspace), on_current_monitor = true }))
   o.bind("SUPER + SHIFT + " .. key, "Move window to workspace " .. workspace, hl.dsp.window.move({ workspace = tostring(workspace) }))
   o.bind("SUPER + SHIFT + ALT + " .. key, "Move window silently to workspace " .. workspace, hl.dsp.window.move({ workspace = tostring(workspace), follow = false }))
 end


### PR DESCRIPTION
Implements the proposal in discussion #5407.

## Problem

`SUPER+[1-9,0]` binds to `hl.dsp.focus({ workspace = N })`, which follows a workspace to whichever monitor already holds it. On a multi-monitor setup, pressing `SUPER+1` while focused on the second screen silently moves focus to the *other* monitor — so the screen you are looking at appears to do nothing. It is a confusing default, particularly for users coming from macOS or from tiling WMs where workspaces are per-monitor.

This has come up repeatedly: #1317, #2200, and discussions #1316, #1351, #3780 — which so far have all settled on the third-party `split-monitor-workspaces` plugin.

## Change

One line in `default/hypr/bindings/tiling.lua` — pass `on_current_monitor = true`:

```lua
o.bind("SUPER + " .. key, "Switch to workspace " .. workspace,
  hl.dsp.focus({ workspace = tostring(workspace), on_current_monitor = true }))
```

This is Hyprland's native `focusworkspaceoncurrentmonitor` dispatcher (available since 0.41.0) — no plugin needed. The target workspace is brought to the focused monitor, and focus stays where it is.

Deliberately scoped to the numbered bindings only. `SUPER+TAB` / `SUPER+SHIFT+TAB` / `SUPER+CTRL+TAB` and the `SUPER+scroll` bindings use relative targets (`e+1`, `e-1`, `previous`) and do not exhibit the jump, so they are untouched.

## Verification

Tested live on a dual-monitor setup (two 1920x1080, DP-1 + DP-2), dispatching from DP-2 at a workspace living on DP-1:

| Dispatcher | Result |
| --- | --- |
| `hl.dsp.focus({ workspace = "3" })` (before) | focus jumps to DP-1; DP-2 reverts to its previous workspace |
| `+ on_current_monitor = true` (after) | workspace 3 moves to DP-2; focus stays on DP-2 |

`./test/all` reports 4 pre-existing failures on my machine, all unrelated to this change and all reproducing on a clean `upstream/quattro` checkout without this commit: `config-test`, `snapper-test` and `unowned-system-paths-test` require an `omarchy-pkgs` checkout that is not present, and `runtime-smoke-test` fails on the duplicate `omarchy.monitor` IPC handler registration (`saw 3 for 2 screen(s)`) on a two-screen setup.

## Note on behavior change

This changes a long-standing default. Single-monitor users see no difference whatsoever — the dispatcher is only distinguishable when a second monitor exists. Multi-monitor users who prefer the old follow-the-workspace behavior can restore it in `~/.config/hypr/bindings.lua` with `hl.unbind` plus a plain `hl.dsp.focus({ workspace = ... })` rebind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ioK67NLii7JC9snL2X3Js