### PR TITLE
Let a critical toast's sender name its own window

### DIFF
--- a/bin/omarchy-system-sleep-lock
+++ b/bin/omarchy-system-sleep-lock
@@ -92,14 +92,18 @@ sync_clamshell() {
 
 # logind suspends whether or not this wait succeeded, so a failure here means
 # the machine slept with the session exposed. The notification is the only way
-# anyone finds out, and it lands on the screen they unlock into.
+# anyone finds out, and it lands on the screen they unlock into. It names the
+# longest window a toast can have rather than taking the never-expires an
+# untimed critical alert defaults to: there is nothing to act on by the time it
+# arrives, and a notice about a lock that already failed should not have to be
+# clicked away. It moves into the notification history either way.
 report_unsecured() {
   printf 'omarchy-system-sleep-lock: suspending without a secure lock (%s)\n' \
     "$1" >&2
 
   omarchy-notification-send -u critical -g 󰌾 \
     "Screen did not lock before suspend" \
-    "The session was left unlocked ($1)." >/dev/null 2>&1 || true
+    "The session was left unlocked ($1)." -t 30000 >/dev/null 2>&1 || true
 
   exit 1
 }

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -14,11 +14,7 @@ The end-user view (hotkey notices for time, battery, weather) is in
 
 ## Toast lifecycle
 
-A toast lives on screen for at least 5s (low), 8s (normal), or forever
-(critical), stretched up to 30s if the sender asked for a longer
-`expire_timeout`. Hovering pauses the countdown, and a content update restarts
-it — new text deserves a full look. Left-click invokes the default action,
-right-click or the hover-revealed close button dismisses.
+A toast lives on screen for at least 5s (low), 8s (normal), or forever (critical). Those are floors a sender's own `expire_timeout` is measured against, capped at 30s: it stretches a low or normal toast, and it decides a critical one outright, since a floor of forever is the one that cannot be stretched and overruling the request instead would pin a self-clearing alert to the screen. So `omarchy-battery-low`'s `-t 30000` leaves after 30s, while an untimed critical toast — a crash, a pending migration — stays until it is dismissed. Hovering pauses the countdown, and a content update restarts it — new text deserves a full look. Left-click invokes the default action, right-click or the hover-revealed close button dismisses.
 
 Every on-screen popup is mirrored to its own file under
 `~/.local/state/omarchy/notifications/` (one JSON line per file, named

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -381,6 +381,28 @@ function parsePopupFiles(raw, normalUrgency) {
   return entries
 }
 
+// Urgency sets the floor a toast stays up for, and a floor of 0 means it never
+// leaves on its own. expire_timeout is the sender saying how long it wants,
+// so it decides against that floor rather than only stretching it: a critical
+// toast that asked for 30s is asking to leave after 30s, and overruling it is
+// what left `omarchy-battery-low -t 30000` pinned to the screen until clicked.
+// The spec spends -1 on "server decides" and 0 on "never expire", so only a
+// positive request counts as the sender having named a window at all — which
+// keeps the untimed critical alerts (a crash, a pending migration) sticky.
+function popupDuration(floor, expireTimeout, cap) {
+  var minimum = Number(floor || 0)
+  if (!isFinite(minimum) || minimum <= 0) minimum = 0
+
+  // Quickshell reports expireTimeout in milliseconds, as the spec does.
+  var requested = Number(expireTimeout || 0)
+  if (!isFinite(requested) || requested <= 0) return minimum
+
+  var wanted = Math.max(minimum, Math.round(requested))
+  var limit = Number(cap || 0)
+  if (!isFinite(limit) || limit <= 0) return wanted
+  return Math.min(limit, wanted)
+}
+
 // A persisted popup whose lifetime already ran out would have expired on
 // screen had the shell kept running, so it is not restored. duration 0 means
 // the popup never expires (critical urgency) and always survives restarts.
@@ -473,6 +495,7 @@ if (typeof module !== "undefined") {
     persistablePopup: persistablePopup,
     serializePopup: serializePopup,
     parsePopupFiles: parsePopupFiles,
+    popupDuration: popupDuration,
     popupExpired: popupExpired,
     popupPlacement: popupPlacement
   }

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -100,22 +100,22 @@ Item {
   readonly property int maxPopupDuration: 30000
 
   function durationFor(urgency, expireTimeout) {
+    return NotificationLogic.popupDuration(floorDurationFor(urgency), expireTimeout, maxPopupDuration)
+  }
+
+  // 0 keeps the toast up until it is dismissed. Critical gets that by default
+  // because an alert nobody saw is worse than one they have to click away, but
+  // it is the floor the sender's own expire_timeout is measured against, not a
+  // veto on it.
+  function floorDurationFor(urgency) {
     switch (urgency) {
     case NotificationUrgency.Critical:
       return 0
     case NotificationUrgency.Low:
-      return Math.min(maxPopupDuration, Math.max(lowPopupDuration, requestedDuration(expireTimeout)))
+      return lowPopupDuration
     default:
-      return Math.min(maxPopupDuration, Math.max(normalPopupDuration, requestedDuration(expireTimeout)))
+      return normalPopupDuration
     }
-  }
-
-  function requestedDuration(expireTimeout) {
-    // FreeDesktop notification spec (and Quickshell) report expireTimeout in
-    // milliseconds, so pass it through directly.
-    var ms = Number(expireTimeout || 0)
-    if (!isFinite(ms) || ms <= 0) return 0
-    return Math.round(ms)
   }
 
   // DND bypass: only let through notifications we trust to be intentional

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -508,6 +508,19 @@ assertDeepEqual(
   'notifications restore nothing from an empty popup dir'
 )
 
+// Floors are the urgency defaults the service passes in: 0 (critical, never
+// expires), 5000 (low), 8000 (normal), capped at 30000. A floor of forever is
+// the one a request has to be able to override rather than merely stretch,
+// which is the whole reason `omarchy-battery-low -t 30000` reaches the screen
+// as a toast that leaves on its own.
+assertEqual(notifications.popupDuration(0, 0, 30000), 0, 'critical toasts stay up when the sender names no window')
+assertEqual(notifications.popupDuration(0, -1, 30000), 0, 'a server-decides expire timeout leaves critical toasts sticky')
+assertEqual(notifications.popupDuration(0, 3000, 30000), 3000, 'a critical toast leaves after the window its sender asked for')
+assertEqual(notifications.popupDuration(0, 60000, 30000), 30000, 'a critical toast cannot outstay the cap')
+assertEqual(notifications.popupDuration(8000, 3000, 30000), 8000, 'a request under the urgency floor does not cut a toast short')
+assertEqual(notifications.popupDuration(5000, 12000, 30000), 12000, 'a request over the urgency floor stretches the toast')
+assertEqual(notifications.popupDuration(5000, 0, 30000), 5000, 'an untimed toast lives exactly its urgency floor')
+
 assert(!notifications.popupExpired({ timestamp: 0 }, 0, 999999), 'critical popups never expire on restore')
 assert(!notifications.popupExpired({ timestamp: 1000 }, 8000, 5000), 'popups within their lifetime are restored')
 assert(notifications.popupExpired({ timestamp: 1000 }, 8000, 9000), 'popups past their lifetime are not restored')


### PR DESCRIPTION
**Description**

Critical toasts discarded the sender's `expire_timeout`, so a sender that named its own window was overruled and pinned to the screen until clicked. Urgency now sets the floor and a positive `expire_timeout` decides against it, capped at 30s as before; with no timeout, critical stays sticky.

**Motivation**

Four call sites already pass a timeout alongside `-u critical` and are silently ignored — `omarchy-battery-low -t 30000` and three screen-recording errors at `-t 3000`/`-t 5000`. The sleep-lock warning gets the same treatment: it reports a lock that already failed, so there is nothing to act on by the time it arrives, and it takes a 30s window rather than waiting to be clicked away.