### PR TITLE
Give foot its own touchpad scroll factor

### DIFF
--- a/config/hypr/input.lua
+++ b/config/hypr/input.lua
@@ -45,7 +45,8 @@
 -- })
 
 -- App-specific touchpad scroll speeds.
--- o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
+-- o.window("(Alacritty|kitty)", { scroll_touchpad = 1.5 })
+-- o.window("foot", { scroll_touchpad = 2.0 })
 -- o.window("com.mitchellh.ghostty", { scroll_touchpad = 0.2 })
 
 -- Enable touchpad gestures for changing workspaces.

--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -75,5 +75,7 @@ hl.config({
 })
 
 -- Scroll nicely in the terminal.
-o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
+o.window("(Alacritty|kitty)", { scroll_touchpad = 1.5 })
+-- foot only applies its scrollback multiplier to wheel clicks, not precise touchpad scrolling.
+o.window("foot", { scroll_touchpad = 2.0 })
 o.window("com.mitchellh.ghostty", { scroll_touchpad = 0.2 })


### PR DESCRIPTION
Touchpad scrolling in foot crawls compared to the other terminals, and cranking `scrollback.multiplier` in foot.ini doesn't help: foot only applies that multiplier to discrete wheel clicks ([input.c](https://codeberg.org/dnkl/foot/src/branch/master/input.c)), so pixel-precise touchpad scrolling ignores it entirely and is left with the global 0.4 factor times the terminal group's 1.5.

This splits foot out of the shared terminal rule with a 2.0 touchpad factor, which brings it in line with how Alacritty and kitty feel on a trackpad (tuned on an XPS 14). The commented example in the user-facing template is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)