### PR TITLE
Expose dropdown indicator font

### DIFF
--- a/shell/Ui/Dropdown.qml
+++ b/shell/Ui/Dropdown.qml
@@ -28,6 +28,8 @@ Item {
   property color accent: Color.accent
   readonly property var popupBorderSpec: Border.localOrSurfaceSpec("popups", "border", popupBorder, Color.popups.border, Style.normalBorderWidth)
   property string fontFamily: Style.font.family
+  property string indicatorText: "󰅀"
+  property string indicatorFontFamily: fontFamily
   property int rowHeight: Style.spacing.controlHeight
   property int popupRowHeight: Style.spacing.popupRowHeight
   property bool showLabel: true
@@ -129,9 +131,9 @@ Item {
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
         anchors.rightMargin: trigger.borderRight + Style.spacing.controlGap
-        text: "󰅀"
+        text: root.indicatorText
         color: Qt.darker(root.foreground, 1.2)
-        font.family: root.fontFamily
+        font.family: root.indicatorFontFamily
         font.pixelSize: Style.font.body
       }
 

--- a/test/shell.d/dropdown-indicator-test.sh
+++ b/test/shell.d/dropdown-indicator-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+dropdown_qml=$(<"$ROOT/shell/Ui/Dropdown.qml")
+
+if [[ $dropdown_qml != *'property string indicatorText: "󰅀"'* ]]; then
+  fail "dropdown exposes its indicator text"
+fi
+pass "dropdown exposes its indicator text"
+
+if [[ $dropdown_qml != *'property string indicatorFontFamily: fontFamily'* ]]; then
+  fail "dropdown exposes its indicator font family"
+fi
+pass "dropdown exposes its indicator font family"
+
+if [[ $dropdown_qml != *'text: root.indicatorText'* ]] || [[ $dropdown_qml != *'font.family: root.indicatorFontFamily'* ]]; then
+  fail "dropdown renders the indicator with its dedicated properties"
+fi
+pass "dropdown renders the indicator with its dedicated properties"


### PR DESCRIPTION
Dropdown currently renders its Nerd Font chevron with the same font family as option labels. Consumers that use a separate icon font cannot override the indicator without also breaking label text.

Add indicatorText and indicatorFontFamily properties while preserving the existing glyph and font defaults. This is backward-compatible and lets hosts supply another icon font or glyph.

Test: bash test/shell.d/dropdown-indicator-test.sh