### PR TITLE
Stop the Apple Studio Display flickering at 5K on T2 Macs

### DIFF
--- a/bin/omarchy-hw-apple-display-link
+++ b/bin/omarchy-hw-apple-display-link
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# omarchy:summary=Pin an Apple Studio Display's DisplayPort link to HBR3 so 5K runs without DSC
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# The Studio Display advertises an HBR2 link through its Thunderbolt tunnel.
+# 5120x2880@60 does not fit HBR2 uncompressed, so amdgpu turns on DSC, and that
+# path flickers and blacks out on the Radeon Pro in T2 MacBooks. The panel
+# trains fine at HBR3, where 5K needs no compression, so prefer that rate on
+# every connector carrying a Studio Display.
+#
+# The preferred rate sticks to the connector until reboot, across replugs and
+# suspend, so one pass per connector is enough. Writing it retrains the link at
+# once; when the compositor had already lit the panel over the compressed link,
+# a simulated replug makes it set the mode again over the new one.
+#
+# Runs as root from omarchy-apple-display-link.service, at boot and on every
+# DRM hotplug via udev. Without a Studio Display it does nothing.
+
+drm_path="${OMARCHY_DRM_PATH:-/sys/class/drm}"
+debug_path="${OMARCHY_DRI_DEBUG_PATH:-/sys/kernel/debug/dri}"
+settle="${OMARCHY_APPLE_DISPLAY_SETTLE:-2}"
+
+# debugfs is root-only; a test pointing at its own tree needs no privileges.
+if (( EUID != 0 )) && [[ -z ${OMARCHY_DRI_DEBUG_PATH:-} ]]; then
+  exec sudo "$0" "$@"
+fi
+
+shopt -s nullglob
+
+for edid in "$drm_path"/card*-DP-*/edid; do
+  connector=${edid%/edid}
+  [[ $(<"$connector/status") == connected ]] || continue
+  grep -aq StudioDisplay "$edid" || continue
+
+  name=${connector##*/}
+  card=${name%%-*}
+  debug="$debug_path/${card#card}/${name#"$card"-}"
+  [[ -w $debug/link_settings ]] || continue
+
+  preferred=$(tr -d '\0' <"$debug/link_settings" |
+    sed -nE 's/.*Preferred:[[:space:]]+[0-9]+[[:space:]]+(0x[0-9a-fA-F]+).*/\1/p')
+  [[ $preferred == 0x1e ]] && continue
+
+  echo "4 0x1e" >"$debug/link_settings"
+  echo "$name: DisplayPort link pinned to HBR3"
+
+  # Give a modeset that raced this write time to finish before judging it.
+  sleep "$settle"
+  [[ $(tr -d '\0' <"$debug/dsc_clock_en") == 1 ]] || continue
+  echo "$name: stream still compressed, replugging for a fresh modeset"
+  echo 0 >"$debug/trigger_hotplug"
+  sleep 1
+  echo 1 >"$debug/trigger_hotplug"
+done
+
+exit 0

--- a/default/systemd/system/omarchy-apple-display-link.service
+++ b/default/systemd/system/omarchy-apple-display-link.service
@@ -3,6 +3,9 @@ Description=Pin the Apple Studio Display DisplayPort link to HBR3
 # Runs once at boot for a display already attached and again from udev on every
 # DRM hotplug. Does nothing when no Studio Display is connected.
 RequiresMountsFor=/sys/kernel/debug
+# udev fires several DRM change events within milliseconds when the display
+# comes back through Thunderbolt; the run that sees the connector is a late one.
+StartLimitIntervalSec=0
 
 [Service]
 Type=oneshot

--- a/default/systemd/system/omarchy-apple-display-link.service
+++ b/default/systemd/system/omarchy-apple-display-link.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Pin the Apple Studio Display DisplayPort link to HBR3
+# Runs once at boot for a display already attached and again from udev on every
+# DRM hotplug. Does nothing when no Studio Display is connected.
+RequiresMountsFor=/sys/kernel/debug
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/omarchy-hw-apple-display-link
+
+[Install]
+WantedBy=multi-user.target

--- a/default/udev/apple-display-link.rules
+++ b/default/udev/apple-display-link.rules
@@ -1,0 +1,3 @@
+# Apple Studio Display: on every DRM hotplug, pin its DisplayPort link to HBR3 so
+# 5K runs without DSC, which flickers on amdgpu. See omarchy-hw-apple-display-link.
+ACTION=="change", SUBSYSTEM=="drm", ENV{DEVTYPE}=="drm_minor", RUN+="/usr/bin/systemctl --no-block start omarchy-apple-display-link.service"

--- a/install/hardware/apple/fix-t2.sh
+++ b/install/hardware/apple/fix-t2.sh
@@ -47,4 +47,12 @@ high_temp=75
 speed_curve=linear
 always_full_speed=false
 EOF
+
+  # The Studio Display flickers at 5K over the HBR2+DSC link amdgpu picks by
+  # default; the service pins the link to HBR3, where 5K needs no compression.
+  install -Dm644 "$OMARCHY_PATH/default/udev/apple-display-link.rules" \
+    /etc/udev/rules.d/90-omarchy-apple-display-link.rules
+  install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-apple-display-link.service" \
+    /etc/systemd/system/omarchy-apple-display-link.service
+  systemctl enable omarchy-apple-display-link.service
 fi

--- a/migrations/1788346426.sh
+++ b/migrations/1788346426.sh
@@ -1,0 +1,22 @@
+echo "Stop the Apple Studio Display flickering at 5K on T2 Macs"
+
+if ! lspci -nn | grep "106b:180[12]" >/dev/null; then
+  exit 0
+fi
+
+unit="${OMARCHY_APPLE_DISPLAY_UNIT:-/etc/systemd/system/omarchy-apple-display-link.service}"
+rule="${OMARCHY_APPLE_DISPLAY_RULE:-/etc/udev/rules.d/90-omarchy-apple-display-link.rules}"
+
+# Both files present is the machine-wide completion state another user's run leaves.
+if [[ -f $unit && -f $rule ]]; then
+  exit 0
+fi
+
+# The Studio Display advertises an HBR2 link, 5K@60 only fits HBR2 with DSC, and
+# that path flickers on amdgpu. The service pins the link to HBR3 at boot and on
+# every DRM hotplug; see omarchy-hw-apple-display-link.
+sudo install -Dm644 "$OMARCHY_PATH/default/udev/apple-display-link.rules" "$rule"
+sudo install -Dm644 "$OMARCHY_PATH/default/systemd/system/omarchy-apple-display-link.service" "$unit"
+sudo systemctl daemon-reload
+sudo udevadm control --reload
+sudo systemctl enable --now omarchy-apple-display-link.service

--- a/test/shell.d/apple-display-link-test.sh
+++ b/test/shell.d/apple-display-link-test.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+helper="$ROOT/bin/omarchy-hw-apple-display-link"
+unit="$ROOT/default/systemd/system/omarchy-apple-display-link.service"
+rule="$ROOT/default/udev/apple-display-link.rules"
+fix_t2="$ROOT/install/hardware/apple/fix-t2.sh"
+migration="$ROOT/migrations/1788346426.sh"
+
+[[ -x $helper ]] || fail "the Apple display link helper is tracked executable"
+grep -Fq 'ExecStart=/usr/bin/omarchy-hw-apple-display-link' "$unit" ||
+  fail "the service runs the packaged helper"
+grep -Fq 'ACTION=="change", SUBSYSTEM=="drm"' "$rule" ||
+  fail "the udev rule fires on DRM hotplug"
+grep -Fq 'systemctl --no-block start omarchy-apple-display-link.service' "$rule" ||
+  fail "the udev rule starts the service without blocking udev"
+grep -Fq 'default/udev/apple-display-link.rules' "$fix_t2" ||
+  fail "T2 setup installs the udev rule"
+grep -Fq 'default/systemd/system/omarchy-apple-display-link.service' "$fix_t2" ||
+  fail "T2 setup installs the service"
+grep -Fq 'systemctl enable omarchy-apple-display-link.service' "$fix_t2" ||
+  fail "T2 setup enables the service"
+pass "T2 setup ships the Apple display link service"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+drm="$test_tmp/drm"
+dri="$test_tmp/dri"
+
+debug_dir() {
+  local name="$1" card=${1%%-*}
+  printf '%s\n' "$dri/${card#card}/${name#"$card"-}"
+}
+
+# A fake connector with the amdgpu debugfs files the helper reads and writes.
+# debugfs pads its reads with NUL bytes, so the fixtures do too.
+add_connector() {
+  local name="$1" status="$2" product="$3" preferred="$4" dsc="$5"
+  local debug
+  debug=$(debug_dir "$name")
+  mkdir -p "$drm/$name" "$debug"
+  echo "$status" >"$drm/$name/status"
+  printf 'edid %s\0' "$product" >"$drm/$name/edid"
+  printf 'Current:  4  0x14  0  Verified:  4  0x14  16  Reported:  4  0x14  16  Preferred:  %s\n\0' "$preferred" \
+    >"$debug/link_settings"
+  printf '%s\n\0' "$dsc" >"$debug/dsc_clock_en"
+  echo untouched >"$debug/trigger_hotplug"
+}
+
+run_helper() {
+  OMARCHY_DRM_PATH="$drm" OMARCHY_DRI_DEBUG_PATH="$dri" OMARCHY_APPLE_DISPLAY_SETTLE=0 bash "$helper"
+}
+
+link_settings() {
+  tr -d '\0' <"$(debug_dir "$1")/link_settings"
+}
+
+trigger_hotplug() {
+  tr -d '\0' <"$(debug_dir "$1")/trigger_hotplug"
+}
+
+add_connector card2-DP-6 connected StudioDisplay "0  0x0  0" 1
+add_connector card2-DP-7 connected StudioDisplay "4  0x1e  0" 0
+add_connector card2-DP-4 connected "DELL U2723QE" "0  0x0  0" 1
+add_connector card2-DP-5 disconnected StudioDisplay "0  0x0  0" 0
+add_connector card2-eDP-1 connected StudioDisplay "0  0x0  0" 0
+
+output=$(run_helper)
+
+[[ $(link_settings card2-DP-6) == "4 0x1e" ]] ||
+  fail "a connected Studio Display on an HBR2 link gets HBR3 preferred" "$output"
+[[ $(trigger_hotplug card2-DP-6) == 1 ]] ||
+  fail "a stream still compressed after the retrain gets a simulated replug" "$output"
+grep -Fq 'card2-DP-6: DisplayPort link pinned to HBR3' <<<"$output" ||
+  fail "the helper names the connector it pinned" "$output"
+[[ $(link_settings card2-DP-7) == Current:* ]] ||
+  fail "a link already preferring HBR3 is left alone"
+[[ $(trigger_hotplug card2-DP-7) == untouched ]] ||
+  fail "a link already preferring HBR3 is not replugged"
+[[ $(link_settings card2-DP-4) == Current:* ]] ||
+  fail "other monitors keep their link settings"
+[[ $(link_settings card2-DP-5) == Current:* ]] ||
+  fail "a disconnected Studio Display is left alone"
+[[ $(link_settings card2-eDP-1) == Current:* ]] ||
+  fail "internal panels are never touched"
+pass "the helper pins HBR3 on connected Studio Displays only"
+
+rm -rf "$drm" "$dri"
+add_connector card2-DP-6 connected StudioDisplay "0  0x0  0" 0
+
+run_helper >/dev/null
+
+[[ $(link_settings card2-DP-6) == "4 0x1e" ]] ||
+  fail "the helper still pins HBR3 when the retrain alone drops DSC"
+[[ $(trigger_hotplug card2-DP-6) == untouched ]] ||
+  fail "an uncompressed stream after the retrain is not replugged"
+pass "the helper only replugs a stream that stayed compressed"
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the T2
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no T2 hardware" (#6608).
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+for tool in systemctl udevadm; do
+  cat >"$stub_bin/$tool" <<SH
+#!/bin/bash
+
+printf '$tool' >>"\$TEST_LOG"
+printf '\\t%s' "\$@" >>"\$TEST_LOG"
+printf '\\n' >>"\$TEST_LOG"
+SH
+done
+
+chmod +x "$stub_bin"/*
+
+unit_target="$test_tmp/etc/systemd/system/omarchy-apple-display-link.service"
+rule_target="$test_tmp/etc/udev/rules.d/90-omarchy-apple-display-link.rules"
+
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    T2_HARDWARE="$1" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_APPLE_DISPLAY_UNIT="$unit_target" \
+    OMARCHY_APPLE_DISPLAY_RULE="$rule_target" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration 1
+
+cmp -s "$unit" "$unit_target" || fail "the migration installs the shipped service"
+cmp -s "$rule" "$rule_target" || fail "the migration installs the shipped udev rule"
+grep -Fq $'systemctl\tdaemon-reload' "$calls" || fail "the migration reloads systemd" "$(cat "$calls")"
+grep -Fq $'udevadm\tcontrol\t--reload' "$calls" || fail "the migration reloads udev" "$(cat "$calls")"
+grep -Fq $'systemctl\tenable\t--now\tomarchy-apple-display-link.service' "$calls" ||
+  fail "the migration enables and starts the service" "$(cat "$calls")"
+pass "the migration installs the Apple display link service on existing T2 installs"
+
+: >"$calls"
+run_migration 1
+[[ ! -s $calls ]] || fail "an already repaired T2 install is left unchanged" "$(cat "$calls")"
+pass "the migration is idempotent"
+
+rm -rf "$test_tmp/etc"
+: >"$calls"
+run_migration 0
+[[ ! -e $unit_target && ! -e $rule_target ]] || fail "non-T2 systems get no Apple display link service"
+[[ ! -s $calls ]] || fail "non-T2 systems skip the repair" "$(cat "$calls")"
+pass "the migration skips unrelated hardware"


### PR DESCRIPTION
## Problem

Plug an Apple Studio Display into a T2 MacBook Pro with the Radeon Pro (a MacBookPro16,1 here) and it comes up at 5120x2880@60, then flickers, glitches and periodically blacks out. 3840x2160 is stable.

The display advertises an HBR2 DisplayPort link through its Thunderbolt tunnel (`Reported: 4 0x14` in amdgpu's debugfs). 5K@60 does not fit HBR2 uncompressed, so amdgpu enables DSC, and that HBR2+DSC path is what glitches: `dsc_clock_en` is 1 while it flickers. The panel trains fine at HBR3, where 5K needs no compression. Someone hit the same thing on the same machine and worked it out first: https://discuss.cachyos.org/t/29495

## Fix

`omarchy-hw-apple-display-link` looks for connected connectors whose EDID names a StudioDisplay and writes `4 0x1e` to that connector's `link_settings` in debugfs, which retrains the link at HBR3 right away. If the compositor had already set the 5K mode over the compressed link, it simulates a replug through `trigger_hotplug` so the mode gets set again over the new link. The preferred rate sticks to the connector until reboot, so it survives replugs and suspend.

A oneshot service runs the helper at boot and a udev rule starts it on every DRM hotplug. `fix-t2.sh` installs both on new T2 installs and a migration installs them on existing ones. The helper does nothing without a Studio Display and skips connectors that have no amdgpu debugfs files, so it is inert on other GPUs and other displays.

## Verified

On the MacBookPro16,1: `Current: 4 0x1e`, `dsc_clock_en` 0, 5120x2880@60 with no flicker since. Putting the link back to HBR2 with DSC on and firing a real hotplug through `trigger_hotplug` had udev start the service and land the display on HBR3 without DSC. Simulated unplug/replug and a suspend cycle kept the preference. Camera, speakers, microphone and brightness through `omarchy brightness display` keep working.

`test/shell.d/apple-display-link-test.sh` runs the helper against a fake sysfs and debugfs tree (pins only connected Studio Displays, leaves other monitors and internal panels alone, replugs only a stream that stayed compressed) and the migration with stubbed `lspci`, `sudo`, `systemctl` and `udevadm` (installs, idempotent, skips non-T2). `./test/cli` and `test/shell.d/t2-hardware-test.sh` pass.
