### PR TITLE
Add Do ordinal token to the clock format

### DIFF
--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -57,7 +57,8 @@ BarWidget {
   }
 
   function formatted(date) {
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
+    var withWeek = activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate()))
+    return Qt.formatDateTime(date, Model.applyOrdinalToken(withWeek, date.getDate()))
   }
 
   // ---- Calendar popup. Shape contract for shell.summon/hide/toggle

--- a/shell/plugins/panels/clock/Model.js
+++ b/shell/plugins/panels/clock/Model.js
@@ -84,6 +84,76 @@ function isoWeekLiteral(year, month, day) {
   return pad2(isoWeek(year, month, day))
 }
 
+// English ordinal suffix for a day of month: 1st, 2nd, 3rd, 4th… with the
+// 11th through 13th taking th regardless of their final digit.
+function ordinalSuffix(day) {
+  var n = Number(day)
+  if (!isFinite(n)) return ""
+  n = Math.abs(Math.round(n))
+  if (n % 100 >= 11 && n % 100 <= 13) return "th"
+  switch (n % 10) {
+    case 1: return "st"
+    case 2: return "nd"
+    case 3: return "rd"
+    default: return "th"
+  }
+}
+
+// Day of month followed by its ordinal suffix: 2 -> "2nd".
+function ordinalLiteral(day) {
+  var n = Number(day)
+  return isFinite(n) ? String(Math.abs(Math.round(n))) + ordinalSuffix(n) : ""
+}
+
+// Whether a format's Do token actually prints the ordinal. Quoted literals go
+// first: a 'Do' quoted by the user is text, and an opening quote with no
+// closing one runs to the end of the format the way Qt reads it. The doubled
+// quote is a literal apostrophe, so it does not start a literal span.
+function clockHasOrdinalToken(format) {
+  var text = String(format === undefined || format === null ? "" : format)
+  var quote = false
+  var escapedQuote = false
+  for (var i = 0; i < text.length - 1; i++) {
+    if (text.charAt(i) === "'") {
+      if (escapedQuote) { escapedQuote = false; continue }
+      if (text.charAt(i + 1) === "'") { escapedQuote = true; continue }
+      quote = !quote
+      continue
+    }
+    escapedQuote = false
+    if (!quote && text.charAt(i) === "D" && text.charAt(i + 1) === "o") return true
+  }
+  return false
+}
+
+// A format's Do token swapped for the day's ordinal literal, leaving quoted
+// literals untouched -- the same pre-substitution the widget does for 'ww'.
+// A literal apostrophe ('') starts no span, per clockHasOrdinalToken.
+function applyOrdinalToken(format, day) {
+  var text = String(format === undefined || format === null ? "" : format)
+  var quote = false
+  var escapedQuote = false
+  var out = ""
+  for (var i = 0; i < text.length; i++) {
+    var c = text.charAt(i)
+    if (c === "'") {
+      if (escapedQuote) { escapedQuote = false }
+      else if (text.charAt(i + 1) === "'") { escapedQuote = true }
+      else { quote = !quote }
+      out += c
+      continue
+    }
+    escapedQuote = false
+    if (!quote && c === "D" && text.charAt(i + 1) === "o") {
+      out += ordinalLiteral(day)
+      i++
+      continue
+    }
+    out += c
+  }
+  return out
+}
+
 function pad2(value) {
   var n = Number(value)
   return (n < 10 ? "0" : "") + n
@@ -301,6 +371,10 @@ if (typeof module !== "undefined") {
     stepMonth: stepMonth,
     clockFormats: clockFormats,
     clockNeedsSeconds: clockNeedsSeconds,
+    ordinalSuffix: ordinalSuffix,
+    ordinalLiteral: ordinalLiteral,
+    clockHasOrdinalToken: clockHasOrdinalToken,
+    applyOrdinalToken: applyOrdinalToken,
     clockFormatRing: clockFormatRing,
     nextClockFormat: nextClockFormat,
     isoWeekLiteral: isoWeekLiteral

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -170,6 +170,39 @@ assertEqual(
 )
 assertEqual(calendar.isoWeekLiteral(2026, 0, 5), '02', 'clock zero-pads the ISO week token')
 
+// ---- ordinal token, substituted before Qt formats it: Qt has no ordinal specifier
+assertEqual(calendar.ordinalSuffix(1), 'st', 'clock gives the 1st its st')
+assertEqual(calendar.ordinalSuffix(2), 'nd', 'clock gives the 2nd its nd')
+assertEqual(calendar.ordinalSuffix(3), 'rd', 'clock gives the 3rd its rd')
+assertEqual(calendar.ordinalSuffix(4), 'th', 'clock gives the 4th its th')
+assertEqual(calendar.ordinalSuffix(11), 'th', 'clock gives the 11th th')
+assertEqual(calendar.ordinalSuffix(12), 'th', 'clock gives the 12th th')
+assertEqual(calendar.ordinalSuffix(13), 'th', 'clock gives the 13th th despite its final digit')
+assertEqual(calendar.ordinalSuffix(21), 'st', 'clock gives the 21st st')
+assertEqual(calendar.ordinalSuffix(22), 'nd', 'clock gives the 22nd nd')
+assertEqual(calendar.ordinalSuffix(23), 'rd', 'clock gives the 23rd rd')
+assertEqual(calendar.ordinalSuffix(31), 'st', 'clock gives the 31st st')
+assertEqual(calendar.ordinalLiteral(2), '2nd', 'clock prints the day before its suffix')
+assertEqual(calendar.ordinalLiteral(31), '31st', 'clock prints two-digit days whole')
+
+assert(calendar.clockHasOrdinalToken('dddd, MMMM Do, HH:mm'), 'clock sees the Do token in a hand-written format')
+assert(calendar.clockHasOrdinalToken('Do'), 'clock sees a bare Do token')
+assert(!calendar.clockHasOrdinalToken("'Do'"), 'clock reads a quoted Do as text')
+assert(!calendar.clockHasOrdinalToken("HH:mm 'Do"), 'clock reads an unterminated literal as text to the end')
+assert(calendar.clockHasOrdinalToken("Do''o"), 'clock still reads Do before an escaped apostrophe')
+assert(calendar.clockHasOrdinalToken("'a' Do"), 'clock sees Do after a closed literal')
+assert(!calendar.clockHasOrdinalToken('d MMMM'), 'clock sees no Do token in plain date formats')
+assert(!calendar.clockHasOrdinalToken(''), 'clock sees no Do token in an empty format')
+assert(!calendar.clockHasOrdinalToken(null), 'clock sees no Do token in a missing format')
+
+assertEqual(calendar.applyOrdinalToken('dddd, MMMM Do, HH:mm', 2), 'dddd, MMMM 2nd, HH:mm', 'clock swaps Do for the ordinal literal')
+assertEqual(calendar.applyOrdinalToken('Do', 13), '13th', 'clock swaps a bare Do')
+assertEqual(calendar.applyOrdinalToken("'Do'", 2), "'Do'", 'clock leaves a quoted Do as text')
+assertEqual(calendar.applyOrdinalToken("Do''o", 2), "2nd''o", 'clock honours the escaped apostrophe after a swap')
+assertEqual(calendar.applyOrdinalToken('d MMMM yyyy', 2), 'd MMMM yyyy', 'clock leaves formats without Do untouched')
+assertEqual(calendar.applyOrdinalToken(null, 2), '', 'clock renders a missing format as an empty label')
+assertEqual(calendar.applyOrdinalToken('', 2), '', 'clock renders an empty format as an empty label')
+
 // ---- seconds detection, which decides how often the widget's clock ticks
 assert(calendar.clockNeedsSeconds('dddd HH:mm:ss'), 'clock sees seconds in the live preset')
 assert(calendar.clockNeedsSeconds('h:mm:ss AP'), 'clock sees seconds in an AM/PM format')
@@ -241,6 +274,7 @@ assert(/entry\[vertical \? "verticalFormat" : "format"\] = next/.test(widgetSour
 assert(!/formatIndex/.test(widgetSource), 'clock keeps no session-only format position')
 assert(/else root\.togglePanel\(\)/.test(widgetSource), 'clock left click reveals the calendar')
 assert(/omarchy-menu-timezone/.test(widgetSource), 'clock keeps the timezone picker on middle click')
+assert(/Model\.applyOrdinalToken\(withWeek, date\.getDate\(\)\)/.test(widgetSource), 'clock substitutes the ordinal token before Qt formats the label')
 
 // The bar identifies a panel by the widget in its slot, so the nested panel
 // has to present the host widget rather than itself.


### PR DESCRIPTION
Add a `Do` format token to the bar clock, rendering the day of month with its English ordinal suffix: `dddd, MMMM Do, HH:mm` now displays as "Wednesday, September 2nd, 03:28".

Qt has no ordinal specifier, so — like the existing `'ww'` ISO-week token — the widget pre-substitutes the computed value into the format string before `Qt.formatDateTime` runs. `Model.applyOrdinalToken()` walks the format string the same way Qt reads it: quoted literals (`'Do'`) are left as text, an unterminated quote runs to the end, and a doubled quote (`''`) is a literal apostrophe rather than a literal span. `D` is otherwise unused in Qt's date-format grammar, so the token collides with nothing.

The substitution happens in `formatted()`, so `Do` works in `format`, `formatAlt`, and `verticalFormat` alike.

Ordinals are always English regardless of locale — suffix conventions differ per language, and `Model.js` is deliberately locale-free. This is a documented limitation, not an omission.

Tests in `test/shell.d/clock-test.sh` cover the suffix rules (including the 11th–13th exception), token detection with quoted and unterminated literals, substitution cases, and the widget wiring. `./test/shell.d/clock-test.sh` passes 185/185.
