### PR TITLE
Fix WPA3 on MacBookPro16,1

### DIFF
--- a/install/hardware/apple/fix-brcmfmac-supplicant.sh
+++ b/install/hardware/apple/fix-brcmfmac-supplicant.sh
@@ -3,9 +3,9 @@
 # WPA2/WPA3 transition mode: the client associates, the four-way handshake never
 # completes, and NetworkManager reports the password as wrong.
 #
-# feature_disable turns off the firmware supplicant (FWSUP, 0x2000) and firmware
-# authenticator (FWAUTH, 0x80000), handing the handshake back to wpa_supplicant
-# in software.
+# feature_disable turns off the firmware supplicant (FWSUP, 0x2000) and SAE
+# authentication (SAE, 0x80000), handing WPA2 handshakes back to wpa_supplicant
+# in software and preventing WPA3-only authentication.
 #
 # This quirk already shipped for T2 Macs, detected by the T2 PCI ID that every
 # one of them carries. The bug is in the Broadcom firmware, not in the T2 bridge,
@@ -19,17 +19,20 @@
 # from the T2 era on. The BCM4360 in 2013-2015 Macs is deliberately absent: it
 # runs the out-of-tree wl driver, which never reads a brcmfmac option.
 sys_vendor="$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)"
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
 
-if lspci -nn | grep "106b:180[12]" >/dev/null ||
+if [[ $product_name == "MacBookPro16,1" ]]; then
+  echo "Detected a MacBookPro16,1; keeping WPA3 firmware offload enabled"
+elif lspci -nn | grep "106b:180[12]" >/dev/null ||
   { [[ $sys_vendor == Apple* ]] &&
     lspci -nn | grep -E "14e4:(43ba|43bb|43bc|43a3|43dc|4464|4488|4425|4433)" >/dev/null; }; then
   echo "Detected a Mac with Broadcom Wi-Fi; running the WPA handshake in software"
 
   mkdir -p /etc/modprobe.d
   cat > /etc/modprobe.d/brcmfmac.conf <<'EOF'
-# Broadcom's firmware supplicant and authenticator fail the WPA four-way
-# handshake on Apple hardware, which surfaces as a rejected password. Disable
-# both so wpa_supplicant performs the handshake instead.
+# Broadcom's firmware WPA handling fails on affected Apple hardware, which
+# surfaces as a rejected password. Disable firmware supplication and SAE so
+# transition-mode networks use the software WPA2 handshake instead.
 options brcmfmac feature_disable=0x82000
 EOF
 fi

--- a/migrations/1786391100.sh
+++ b/migrations/1786391100.sh
@@ -6,9 +6,13 @@ echo "Run the WPA handshake in software on Macs with Broadcom Wi-Fi"
 # install/hardware/apple/fix-brcmfmac-supplicant.sh for the failure it fixes and
 # for where this list of brcmfmac PCI IDs comes from.
 dmi_vendor="${OMARCHY_BRCMFMAC_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+dmi_product="${OMARCHY_BRCMFMAC_DMI_PRODUCT:-/sys/class/dmi/id/product_name}"
 conf="${OMARCHY_BRCMFMAC_CONF:-/etc/modprobe.d/brcmfmac.conf}"
 
 sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+product_name="$(cat "$dmi_product" 2>/dev/null || true)"
+
+[[ $product_name != "MacBookPro16,1" ]] || exit 0
 
 if ! lspci -nn | grep "106b:180[12]" >/dev/null &&
   ! { [[ $sys_vendor == Apple* ]] &&
@@ -31,9 +35,9 @@ sudo mkdir -p "$(dirname "$conf")"
 # feature_disable. The leading newline also covers a file that ends without one.
 sudo tee -a "$conf" >/dev/null <<'EOF'
 
-# Broadcom's firmware supplicant and authenticator fail the WPA four-way
-# handshake on Apple hardware, which surfaces as a rejected password. Disable
-# both so wpa_supplicant performs the handshake instead.
+# Broadcom's firmware WPA handling fails on affected Apple hardware, which
+# surfaces as a rejected password. Disable firmware supplication and SAE so
+# transition-mode networks use the software WPA2 handshake instead.
 options brcmfmac feature_disable=0x82000
 EOF
 

--- a/migrations/1788320383.sh
+++ b/migrations/1788320383.sh
@@ -1,0 +1,50 @@
+echo "Restore WPA3 support on MacBookPro16,1"
+
+# MacBookPro16,1 carries BCM4364B3 firmware that requires firmware SAE offload
+# for WPA3-only networks. Omarchy's 0x82000 quirk disables SAE (bit 19), so
+# remove only the exact blocks written by the old T2 installer and the current
+# Broadcom setup. Administrator-authored variants remain untouched.
+dmi_product="${OMARCHY_BRCMFMAC_DMI_PRODUCT:-/sys/class/dmi/id/product_name}"
+conf="${OMARCHY_BRCMFMAC_CONF:-/etc/modprobe.d/brcmfmac.conf}"
+
+product_name="$(cat "$dmi_product" 2>/dev/null || true)"
+
+[[ $product_name == "MacBookPro16,1" ]] || exit 0
+[[ -f $conf ]] || exit 0
+
+# Read through sudo so a root-only file fails the migration and gets retried
+# rather than reading as empty and burning the per-user migration marker.
+content="$(sudo cat "$conf")"
+
+legacy_block='# Fix for T2 MacBook WiFi connectivity issues
+options brcmfmac feature_disable=0x82000'
+
+current_block="# Broadcom's firmware supplicant and authenticator fail the WPA four-way
+# handshake on Apple hardware, which surfaces as a rejected password. Disable
+# both so wpa_supplicant performs the handshake instead.
+options brcmfmac feature_disable=0x82000"
+
+if [[ $content == "$legacy_block" ]]; then
+  matched_block="$legacy_block"
+elif [[ $content == "$current_block" || $content == *$'\n'"$current_block" ]]; then
+  matched_block="$current_block"
+else
+  exit 0
+fi
+
+# Request the reboot before editing because brcmfmac reads module options only
+# when it loads. Do not reload it during an update carried over Wi-Fi.
+omarchy-state set reboot-required
+
+rest=${content%"$matched_block"}
+while [[ $rest == *$'\n' ]]; do rest=${rest%$'\n'}; done
+
+if [[ -z $rest ]]; then
+  if [[ -L $conf ]]; then
+    : | sudo tee "$conf" >/dev/null
+  else
+    sudo rm -f "$conf"
+  fi
+else
+  printf '%s\n' "$rest" | sudo tee "$conf" >/dev/null
+fi

--- a/test/shell.d/brcmfmac-supplicant-test.sh
+++ b/test/shell.d/brcmfmac-supplicant-test.sh
@@ -67,14 +67,16 @@ chmod +x "$stub_bin"/*
 # running with a fake root on PATH-independent state. pipefail is on, so a
 # grep -q gate would go silent here the way #6608 did.
 run_leaf() {
-  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}"
+  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}" product="${4:-Unknown}"
   rm -rf "$test_tmp/etc"
   mkdir -p "$test_tmp/etc"
   printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  printf '%s' "$product" >"$test_tmp/dmi/product_name"
 
   # Redirect both absolute paths the leaf touches into the sandbox.
   local script="$test_tmp/leaf.sh"
   sed -e "s|/sys/class/dmi/id/sys_vendor|$test_tmp/dmi/sys_vendor|g" \
+      -e "s|/sys/class/dmi/id/product_name|$test_tmp/dmi/product_name|g" \
       -e "s|/etc/modprobe.d|$test_tmp/etc/modprobe.d|g" \
       "$leaf" >"$script"
 
@@ -88,6 +90,13 @@ run_leaf "Apple Inc." 4488 1 >/dev/null
 grep -q 'feature_disable=0x82000' "$conf" 2>/dev/null ||
   fail "a T2 Mac still gets the quirk" "$(ls -R "$test_tmp/etc" 2>&1)"
 pass "a T2 Mac still gets the quirk"
+
+# BCM4364 firmware on the 2019 16-inch Intel Mac needs its firmware SAE
+# offload to join WPA3-only networks. 0x82000 disables SAE (bit 19), leaving
+# wpa_supplicant with no SAE path on firmware that does not advertise SAE_EXT.
+run_leaf "Apple Inc." 4464 1 "MacBookPro16,1" >/dev/null
+[[ ! -f $conf ]] || fail "a MacBookPro16,1 keeps WPA3 firmware offload"
+pass "a MacBookPro16,1 keeps WPA3 firmware offload"
 
 # Every Broadcom part brcmfmac drives, on a Mac with no T2 to detect: BCM43602
 # and its single-band variants, BCM4350, BCM4355, BCM4364, BCM4378, BCM4387.
@@ -120,12 +129,14 @@ pass "a Mac with no wireless device is left alone"
 # Installs that predate the quirk never ran the leaf, so the migration has to
 # reach them. It runs as the user under pipefail, the context #6608 was about.
 run_migration() {
-  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}"
+  local vendor="$1" wifi_id="${2:-}" t2="${3:-0}" product="${4:-Unknown}"
   printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  printf '%s' "$product" >"$test_tmp/dmi/product_name"
   : >"$calls"
 
   WIFI_ID="$wifi_id" T2_HARDWARE="$t2" PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
     OMARCHY_BRCMFMAC_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    OMARCHY_BRCMFMAC_DMI_PRODUCT="$test_tmp/dmi/product_name" \
     OMARCHY_BRCMFMAC_CONF="$conf" \
     bash -euo pipefail "$migration" >/dev/null
 }
@@ -147,6 +158,12 @@ run_migration "Apple Inc." 4488 1
   fail "the migration is idempotent" "$(cat "$conf")"
 [[ ! -s $calls ]] || fail "a repaired install is left untouched" "$(cat "$calls")"
 pass "the migration is idempotent"
+
+rm -rf "$test_tmp/etc"
+run_migration "Apple Inc." 4464 1 "MacBookPro16,1"
+[[ ! -e $conf ]] || fail "the migration leaves MacBookPro16,1 WPA3 support enabled" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on MacBookPro16,1" "$(cat "$calls")"
+pass "the migration leaves MacBookPro16,1 WPA3 support enabled"
 
 # The machine this was written for, with no T2 to fall back on.
 rm -rf "$test_tmp/etc"

--- a/test/shell.d/brcmfmac-wpa3-cleanup-test.sh
+++ b/test/shell.d/brcmfmac-wpa3-cleanup-test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1788320383.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+conf="$test_tmp/etc/modprobe.d/brcmfmac.conf"
+mkdir -p "$stub_bin" "$(dirname "$conf")" "$test_tmp/dmi"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_cleanup() {
+  local product="$1"
+  printf '%s' "$product" >"$test_tmp/dmi/product_name"
+  : >"$calls"
+
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_BRCMFMAC_DMI_PRODUCT="$test_tmp/dmi/product_name" \
+    OMARCHY_BRCMFMAC_CONF="$conf" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+legacy_block='# Fix for T2 MacBook WiFi connectivity issues
+options brcmfmac feature_disable=0x82000'
+
+current_block="# Broadcom's firmware supplicant and authenticator fail the WPA four-way
+# handshake on Apple hardware, which surfaces as a rejected password. Disable
+# both so wpa_supplicant performs the handshake instead.
+options brcmfmac feature_disable=0x82000"
+
+printf '%s\n' "$legacy_block" >"$conf"
+run_cleanup "MacBookPro16,1"
+[[ ! -e $conf ]] || fail "the cleanup removes the legacy T2-owned quirk"
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the legacy cleanup requests the reboot that applies it" "$(cat "$calls")"
+state_line=$(grep -Fn $'omarchy-state\tset\treboot-required' "$calls" | cut -d: -f1 | head -1)
+edit_line=$(grep -En $'^sudo\t(rm|tee)' "$calls" | cut -d: -f1 | head -1)
+(( state_line < edit_line )) ||
+  fail "the reboot request lands before the config edit" "$(cat "$calls")"
+pass "the cleanup removes the legacy T2-owned quirk"
+
+printf '%s\n' "$current_block" >"$conf"
+run_cleanup "MacBookPro16,1"
+[[ ! -e $conf ]] || fail "the cleanup removes the current Omarchy-owned quirk"
+pass "the cleanup removes the current Omarchy-owned quirk"
+
+printf 'options brcmfmac roamoff=1\n\n%s\n' "$current_block" >"$conf"
+run_cleanup "MacBookPro16,1"
+grep -qx 'options brcmfmac roamoff=1' "$conf" ||
+  fail "the cleanup preserves unrelated brcmfmac options" "$(cat "$conf")"
+! grep -q 'feature_disable=0x82000' "$conf" ||
+  fail "the cleanup removes only its owned block" "$(cat "$conf")"
+pass "the cleanup preserves unrelated brcmfmac options"
+
+rm -rf "$test_tmp/etc"
+mkdir -p "$(dirname "$conf")" "$test_tmp/real"
+printf '%s\n' "$legacy_block" >"$test_tmp/real/brcmfmac.conf"
+ln -s "$test_tmp/real/brcmfmac.conf" "$conf"
+run_cleanup "MacBookPro16,1"
+[[ -L $conf ]] || fail "the cleanup preserves a symlinked config"
+[[ ! -s $test_tmp/real/brcmfmac.conf ]] ||
+  fail "the cleanup empties a symlink through its target" "$(cat "$test_tmp/real/brcmfmac.conf")"
+pass "the cleanup writes through a symlinked config"
+
+rm -f "$conf"
+
+printf '# Local override\noptions brcmfmac feature_disable=0x82000 roamoff=1\n' >"$conf"
+run_cleanup "MacBookPro16,1"
+grep -qx 'options brcmfmac feature_disable=0x82000 roamoff=1' "$conf" ||
+  fail "the cleanup leaves an administrator-customized option alone" "$(cat "$conf")"
+! grep -Eq $'^(sudo\t(rm|tee)|omarchy-state\t)' "$calls" ||
+  fail "the customized config triggers no privileged write" "$(cat "$calls")"
+pass "the cleanup leaves administrator-customized options alone"
+
+printf '%s\n' "$legacy_block" >"$conf"
+run_cleanup "MacBookPro15,1"
+grep -qx 'options brcmfmac feature_disable=0x82000' "$conf" ||
+  fail "the cleanup leaves other T2 models alone" "$(cat "$conf")"
+[[ ! -s $calls ]] || fail "another model triggers no privileged write" "$(cat "$calls")"
+pass "the cleanup leaves other T2 models alone"
+
+run_cleanup "MacBookPro16,1"
+run_cleanup "MacBookPro16,1"
+[[ ! -e $conf ]] || fail "the cleanup remains idempotent"
+pass "the cleanup remains idempotent"


### PR DESCRIPTION
## Summary

- keep brcmfmac firmware SAE offload enabled on `MacBookPro16,1`
- correct the `feature_disable` documentation: `0x80000` is SAE, not FWAUTH
- remove the exact Omarchy-owned `0x82000` block from existing `MacBookPro16,1` installs and request a reboot
- leave other Mac models and administrator-customized configurations unchanged

Fixes #9802.

Related: #7439, #7577, #6652.

## Why

The BCM4364B3 firmware on a tested 2019 16-inch Intel Mac needs its advertised SAE offload path to join WPA3-only networks. Omarchy's `feature_disable=0x82000` transition-mode workaround disables bit 19 (`BRCMF_FEAT_SAE`) as well as firmware supplication, so WPA3-SAE authentication is unavailable on this model.

`feature_disable=0x82000` never disabled FWAUTH: it disabled FWSUP and SAE. FWAUTH is bit 20 (`0x100000`) and was enabled both before and after this fix. The behavioral change on `MacBookPro16,1` is restoring FWSUP and SAE, which were verified against WPA2, transition-mode, and WPA3 networks. There is no evidence that disabling FWAUTH is needed for this client-mode issue.

With the quirk enabled, a WPA3-only connection timed out. Reloading the same driver and firmware with `feature_disable=0` exposed `SAE_OFFLOAD`; the same NetworkManager profile then associated, obtained DHCP, and passed gateway and internet ping checks. The persistent configuration was verified after a second reload.

The model exemption is intentionally narrow. The workaround remains useful for older Broadcom firmware with broken WPA2/WPA3 transition-mode handling, and only `MacBookPro16,1` has been verified here.

## Test plan

- `bash test/shell.d/brcmfmac-supplicant-test.sh`
- `bash test/shell.d/brcmfmac-wpa3-cleanup-test.sh`
- `bash -n` on all changed shell files
- `git diff --check`
- live WPA3-SAE/PMF-required association, DHCP, gateway ping, and internet ping on BCM4364B3
- live WPA2/WPA3 transition AP through both WPA-PSK and SAE/PMF-required profiles, including DHCP and 0%-loss gateway/internet pings
- disconnect/reconnect cycle on the transition AP's WPA-PSK profile

`./test/all` was also run. The changed Wi-Fi tests passed; five unrelated environment/baseline tests failed. Three require a separate `omarchy-pkgs` checkout, while `launch-about-test.sh` and `network-qr-test.sh` fail in this non-Wayland test environment. No failure references a changed file.

A separate WPA2-only AP was not available. The WPA2 authentication path itself was verified by pinning the transition AP profile to WPA-PSK; NetworkManager logged `WPA-PSK WPA-PSK-SHA256 FT-PSK`, and the connection passed association, DHCP, reconnect, and traffic tests.
