### PR TITLE
Support browser flags in web app bindings

### DIFF
--- a/bin/omarchy-launch-or-focus-webapp
+++ b/bin/omarchy-launch-or-focus-webapp
@@ -10,6 +10,6 @@ fi
 
 WINDOW_PATTERN="$1"
 shift
-LAUNCH_COMMAND="omarchy-launch-webapp $@"
+printf -v LAUNCH_COMMAND '%q ' omarchy-launch-webapp "$@"
 
 exec omarchy-launch-or-focus "$WINDOW_PATTERN" "$LAUNCH_COMMAND"

--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -8,6 +8,21 @@ end
 
 o.shell_quote = shell_quote
 
+local function append_shell_args(command, args)
+  if args == nil then
+    return command
+  end
+
+  assert(type(args) == "table", "webapp flags must be a list")
+
+  for _, arg in ipairs(args) do
+    assert(type(arg) == "string", "webapp flags must contain only strings")
+    command = command .. " " .. shell_quote(arg)
+  end
+
+  return command
+end
+
 local function file_exists(path)
   local file = io.open(path, "r")
   if file then
@@ -66,9 +81,9 @@ local function command_from(value, description)
     return o.launch(value.launch)
   elseif value.webapp then
     if value.focus then
-      return o.launch_webapp_sole(description, value.webapp)
+      return o.launch_webapp_sole(description, value.webapp, value.flags)
     else
-      return o.launch_webapp(value.webapp)
+      return o.launch_webapp(value.webapp, value.flags)
     end
   elseif value.tui then
     if value.focus then
@@ -119,12 +134,12 @@ function o.launch_on_start(command)
   o.exec_on_start(o.launch(command))
 end
 
-function o.launch_webapp(url)
-  return "omarchy-launch-webapp " .. shell_quote(url)
+function o.launch_webapp(url, flags)
+  return append_shell_args("omarchy-launch-webapp " .. shell_quote(url), flags)
 end
 
-function o.launch_webapp_sole(name, url)
-  return "omarchy-launch-or-focus-webapp " .. shell_quote(name) .. " " .. shell_quote(url)
+function o.launch_webapp_sole(name, url, flags)
+  return append_shell_args("omarchy-launch-or-focus-webapp " .. shell_quote(name) .. " " .. shell_quote(url), flags)
 end
 
 function o.launch_sole(match, command)

--- a/manual/31-dotfiles.md
+++ b/manual/31-dotfiles.md
@@ -71,6 +71,15 @@ hl.unbind("SUPER + SHIFT + O")
 o.bind("SUPER + SHIFT + O", "Joplin", "joplin-desktop")
 ```
 
+Web app bindings can pass additional arguments to the Chromium-family browser as a list. For example, to open YouTube Music with an existing browser profile:
+
+```lua
+o.bind("SUPER + SHIFT + M", "YouTube Music", {
+  webapp = "https://music.youtube.com",
+  flags = { "--profile-directory=Profile 1" },
+})
+```
+
 If you insist on hacking on the internal Omarchy files, switch to the dev channel via _Update > Channel > Dev_. That links Omarchy to a git checkout of the source code in `~/omarchy`, which you're free to change to your heart's content. Ain't nobody here to tell you what to do!
 
 ### Resetting any changes

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -105,6 +105,46 @@ grep -Fq $'SUPER + RETURN	Terminal' <<<"$fresh_output" || fail "default applicat
 grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
 pass "default application bindings load from package defaults"
 
+HOME="$fresh_home" OMARCHY_PATH="$ROOT" lua <<'LUA' || fail "web app bindings forward browser flags safely"
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local command
+hl = {
+  dsp = {
+    exec_cmd = function(value)
+      return { arg = value }
+    end,
+  },
+  bind = function(_, dispatcher)
+    command = dispatcher.arg
+  end,
+}
+
+require("default.hypr.helpers")
+
+o.bind("SUPER + M", "Music", { webapp = "https://music.youtube.com" })
+assert(command == "omarchy-launch-webapp 'https://music.youtube.com'")
+
+o.bind("SUPER + M", "Music", {
+  webapp = "https://music.youtube.com",
+  flags = { "--profile-directory=Profile 1", "--user-agent=$(touch /tmp/not-run)" },
+})
+assert(command == "omarchy-launch-webapp 'https://music.youtube.com' '--profile-directory=Profile 1' '--user-agent=$(touch /tmp/not-run)'")
+
+o.bind("SUPER + M", "Music", {
+  webapp = "https://music.youtube.com",
+  flags = { "--profile-directory=Profile 1" },
+  focus = true,
+})
+assert(command == "omarchy-launch-or-focus-webapp 'Music' 'https://music.youtube.com' '--profile-directory=Profile 1'")
+
+local ok, error_message = pcall(function()
+  o.bind("SUPER + M", "Music", { webapp = "https://music.youtube.com", flags = "--start-maximized" })
+end)
+assert(not ok and error_message:find("webapp flags must be a list", 1, true))
+LUA
+pass "web app bindings forward browser flags safely"
+
 grep -F 'hl.dsp.send_key_state({ mods = mods, key = key, state = "down" })' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null ||
   fail "universal clipboard shortcuts send explicit mods to the focused surface"
 pass "universal clipboard shortcuts send explicit mods to the focused surface"

--- a/test/shell.d/webapp-launch-or-focus-test.sh
+++ b/test/shell.d/webapp-launch-or-focus-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p "$tmpdir/bin"
+
+cat >"$tmpdir/bin/omarchy-launch-or-focus" <<'SH'
+#!/bin/bash
+eval "$2"
+SH
+
+cat >"$tmpdir/bin/omarchy-launch-webapp" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >"$CALLS"
+SH
+
+chmod +x "$tmpdir/bin/omarchy-launch-or-focus" "$tmpdir/bin/omarchy-launch-webapp"
+
+marker="$tmpdir/not-run"
+literal_flag="--user-agent=\$(touch $marker)"
+CALLS="$tmpdir/calls" PATH="$tmpdir/bin:$PATH" "$ROOT/bin/omarchy-launch-or-focus-webapp" \
+  "YouTube Music" "https://music.youtube.com" "--profile-directory=Profile 1" "$literal_flag"
+
+mapfile -t calls <"$tmpdir/calls"
+[[ ${calls[0]} == "https://music.youtube.com" ]] || fail "focused web app keeps its URL argument"
+[[ ${calls[1]} == "--profile-directory=Profile 1" ]] || fail "focused web app keeps spaces in browser flags"
+[[ ${calls[2]} == "$literal_flag" ]] || fail "focused web app keeps browser flags literal"
+[[ ! -e $marker ]] || fail "focused web app does not execute browser flag contents"
+pass "focused web apps preserve browser flag arguments"


### PR DESCRIPTION
## Summary
- allow web app bindings to pass browser flags as an argument list
- preserve argument boundaries for focused web app launches
- document selecting a Chromium browser profile

## Tests
- not run after final changes (requested)