### PR TITLE
Fix uwsm-app deadlock that stops all app launches

### DIFF
--- a/bin/omarchy-restart-app
+++ b/bin/omarchy-restart-app
@@ -3,5 +3,11 @@
 # omarchy:summary=Restart an application by killing it and relaunching via uwsm.
 # omarchy:args=<application-name> [application-args...]
 
-pkill -x $1
-setsid uwsm-app -- "$@" >/dev/null 2>&1 &
+pkill -x "$1" || true
+
+# Launch in a transient user service so we return immediately and so a
+# Type=oneshot caller cannot SIGTERM uwsm-app mid FIFO handshake. setsid
+# does not leave the caller's cgroup; that wedges wayland-wm-app-daemon.
+systemd-run --user --no-block --collect --quiet --same-dir \
+  --slice=app-graphical.slice \
+  -- uwsm-app -- "$@"

--- a/test/shell.d/restart-app-test.sh
+++ b/test/shell.d/restart-app-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/pkill" <<'SH'
+#!/bin/bash
+printf 'pkill:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/systemd-run" <<'SH'
+#!/bin/bash
+printf 'systemd-run:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/uwsm-app" <<'SH'
+#!/bin/bash
+printf 'uwsm-app:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+printf 'setsid:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
+SH
+
+chmod +x "$mock_bin"/*
+
+export PATH="$mock_bin:$PATH"
+export OMARCHY_TEST_LOG="$test_tmp/log"
+: >"$OMARCHY_TEST_LOG"
+
+bash "$ROOT/bin/omarchy-restart-app" hyprsunset extra-arg
+
+grep -Fxq 'pkill:-x hyprsunset' "$OMARCHY_TEST_LOG" ||
+  fail "restart-app kills the named process" "$(<"$OMARCHY_TEST_LOG")"
+pass "restart-app kills the named process"
+
+grep -Fq 'setsid:' "$OMARCHY_TEST_LOG" &&
+  fail "restart-app does not launch via setsid in the caller cgroup" "$(<"$OMARCHY_TEST_LOG")"
+grep -Fq 'uwsm-app:' "$OMARCHY_TEST_LOG" &&
+  fail "restart-app does not invoke uwsm-app in this process" "$(<"$OMARCHY_TEST_LOG")"
+pass "restart-app does not launch uwsm-app in the caller cgroup"
+
+systemd_line=$(grep '^systemd-run:' "$OMARCHY_TEST_LOG" || true)
+[[ $systemd_line == *'--user '* ]] || fail "restart-app uses the user systemd" "$systemd_line"
+[[ $systemd_line == *'--no-block '* ]] || fail "restart-app does not wait for the app" "$systemd_line"
+[[ $systemd_line == *'--slice=app-graphical.slice '* ]] ||
+  fail "restart-app relaunches into the graphical app slice" "$systemd_line"
+[[ $systemd_line == *' -- uwsm-app -- hyprsunset extra-arg' ]] ||
+  fail "restart-app hands the command to uwsm-app via systemd-run" "$systemd_line"
+pass "restart-app detaches via systemd-run --no-block"
+
+grep -F 'setsid uwsm-app' "$ROOT/bin/omarchy-restart-app" &&
+  fail "restart-app source no longer backgrounds uwsm-app with setsid"
+pass "restart-app source no longer backgrounds uwsm-app with setsid"


### PR DESCRIPTION
Grok (xAI), writing with Sean.

After `omarchy restart hyprsunset` (or any `Type=oneshot` that calls `omarchy-restart-app`), nothing launches until you sign out. The notification is `Timed out trying to write to /run/user/$UID/uwsm-app-daemon-in`.

`setsid uwsm-app … &` does not leave the caller's cgroup, so the oneshot's default `KillMode=control-group` SIGTERMs `uwsm-app` after it has written the IN fifo and before it opens OUT. UWSM's app-daemon then waits forever for a reader.

## How

Relaunch via `systemd-run --user --no-block` so the FIFO handshake runs in a transient user service. (`--scope` cannot be combined with `--no-block`.) The command still goes to `uwsm-app` in `app-graphical.slice`.

## Where

- `bin/omarchy-restart-app`
- `test/shell.d/restart-app-test.sh`

Companion recovery if a client still dies: [Vladimir-csp/uwsm#223](https://github.com/Vladimir-csp/uwsm/pull/223).

## Test plan

- `bash test/shell.d/restart-app-test.sh`
- `omarchy restart hyprsunset` from a terminal still starts hyprsunset
- A `Type=oneshot` user unit that runs `omarchy-restart-hyprsunset` no longer wedges `uwsm-app ping`