### PR TITLE
Deduplicate audio nodes and filter portless ALSA sinks

### DIFF
--- a/bin/omarchy-audio-output-switch
+++ b/bin/omarchy-audio-output-switch
@@ -8,8 +8,8 @@ fronted=$(omarchy-audio-tuning fronted-sink 2>/dev/null || true)
 
 sinks=$(timeout 2 pactl -f json list sinks |
   jq --arg fronted "$fronted" '[.[]
-    | select((.ports | length == 0) or ([.ports[]? | .availability != "not available"] | any))
-    | select($fronted == "" or .name != $fronted)]')
+    | select(if (.name | startswith("alsa_output.")) then ((.ports | length > 0) and ([.ports[]? | .availability != "not available"] | any)) else ((.ports | length == 0) or ([.ports[]? | .availability != "not available"] | any)) end)
+    | select($fronted == "" or .name != $fronted)] | unique_by(.name)')
 sinks_count=$(jq 'length' <<<"$sinks")
 
 if (( sinks_count == 0 )); then

--- a/bin/omarchy-audio-sink-availability
+++ b/bin/omarchy-audio-sink-availability
@@ -12,10 +12,19 @@ pactl list sinks 2>/dev/null | awk -v fronted="$fronted" '
   function emit_sink() {
     if (name == "") return
     if (fronted != "" && name == fronted) {
-      print name "\t0"
-      return
+      avail = 0
+    } else if (name ~ /^alsa_output\./) {
+      avail = (port_count > 0 && available) ? 1 : 0
+    } else {
+      avail = (port_count == 0 || available) ? 1 : 0
     }
-    print name "\t" ((port_count == 0 || available) ? 1 : 0)
+    if (!(name in sink_order)) {
+      order[++count] = name
+      sink_order[name] = 1
+    }
+    if (avail > sink_avail[name]) {
+      sink_avail[name] = avail
+    }
   }
 
   /^Sink #/ {
@@ -50,5 +59,9 @@ pactl list sinks 2>/dev/null | awk -v fronted="$fronted" '
 
   END {
     emit_sink()
+    for (i = 1; i <= count; i++) {
+      n = order[i]
+      print n "\t" sink_avail[n]
+    }
   }
 '

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -233,6 +233,33 @@ function streamRepresentsPlayer(node, player, players, streams) {
   return streamRepresentsMprisPlayer(streamLabel(node, players, streams), playerLabel)
 }
 
+function deduplicateNodes(nodes, preferredNode) {
+  var seen = {}
+  var order = []
+  var list = Array.isArray(nodes) ? nodes : []
+  for (var i = 0; i < list.length; i++) {
+    var n = list[i]
+    if (!n) continue
+    var name = String(n.name || "")
+    if (!name) continue
+    if (!seen[name]) {
+      seen[name] = n
+      order.push(name)
+    } else {
+      if (preferredNode && n === preferredNode) {
+        seen[name] = n
+      } else if (seen[name] !== preferredNode && n.id !== undefined && seen[name].id !== undefined && n.id > seen[name].id) {
+        seen[name] = n
+      }
+    }
+  }
+  var result = []
+  for (var j = 0; j < order.length; j++) {
+    result.push(seen[order[j]])
+  }
+  return result
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     isPlaybackStream: isPlaybackStream,
@@ -257,6 +284,7 @@ if (typeof module !== "undefined") {
     matchingMprisStreamLabel: matchingMprisStreamLabel,
     unmatchedMprisStreamLabel: unmatchedMprisStreamLabel,
     streamLabel: streamLabel,
-    streamRepresentsPlayer: streamRepresentsPlayer
+    streamRepresentsPlayer: streamRepresentsPlayer,
+    deduplicateNodes: deduplicateNodes
   }
 }

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -77,15 +77,16 @@ Panel {
   property var cachedAudioSources: []
 
   readonly property var rawAudioSinks: {
-    var list = []
+    var available = []
     for (var i = 0; i < candidateSinks.length; i++)
-      if (sinkAvailable(candidateSinks[i])) list.push(candidateSinks[i])
+      if (sinkAvailable(candidateSinks[i])) available.push(candidateSinks[i])
+    var list = Model.deduplicateNodes(available, sink)
     if (sink && list.indexOf(sink) < 0) list.unshift(sink)
     return list
   }
 
   readonly property var rawAudioSources: {
-    var list = candidateSources.slice()
+    var list = Model.deduplicateNodes(candidateSources, source)
     if (source && list.indexOf(source) < 0) list.unshift(source)
     return list
   }

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -46,4 +46,10 @@ assertEqual(audio.matchingMprisStreamLabel('Chromium', players), 'Chromium', 'au
 assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spotify', 'audio uses unmatched MPRIS player for generic streams')
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
+
+const node1 = { id: 10, name: 'alsa_output.hdmi' }
+const node2 = { id: 20, name: 'alsa_output.hdmi' }
+const node3 = { id: 30, name: 'alsa_output.speakers' }
+assertDeepEqual(audio.deduplicateNodes([node1, node2, node3]), [node2, node3], 'deduplicateNodes picks highest id by default')
+assertDeepEqual(audio.deduplicateNodes([node1, node2, node3], node1), [node1, node3], 'deduplicateNodes prefers current active node')
 JS


### PR DESCRIPTION
### Problem

When external displays (e.g. Type-C/DisplayPort/HDMI) are connected or the system wakes from sleep, WirePlumber/PipeWire may re-enumerate audio endpoints without promptly unbinding previous nodes, leaving stale or duplicate nodes in the PipeWire graph.

This caused several issues in Omarchy:
1. **Duplicate outputs in the audio panel:**
   `shell/plugins/panels/audio/Panel.qml` gathered all candidate sinks from PipeWire without deduplicating by `node.name`. When duplicate nodes for the same sink name existed, the panel rendered each one as a separate duplicate entry (e.g. multiple identical HDMI entries).
2. **False availability of zombie/unplugged ALSA sinks:**
   `omarchy-audio-sink-availability` used `((port_count == 0 || available) ? 1 : 0)` to check sink availability, intending to treat virtual sinks without ports (like EasyEffects) as available. However, disconnected or orphaned ALSA sinks (`alsa_output.*`) also report 0 ports in `pactl`, causing them to be falsely marked as available (`1`). Furthermore, duplicate entries with the same sink name were emitted repeatedly.
3. **Output switcher cycling onto dead sinks:**
   `omarchy-audio-output-switch` used `((.ports | length == 0) or ([.ports[]? | .availability != "not available"] | any))` and did not deduplicate by name, causing the switcher hotkey to cycle onto dead sinks.

### Solution

- **`shell/plugins/panels/audio/Model.js` & `Panel.qml`:**
  - Added `Model.deduplicateNodes(nodes, preferredNode)` to deduplicate candidate sinks and sources by unique `node.name`, prioritizing the current active default sink/source (or newest ID).
- **`bin/omarchy-audio-sink-availability`:**
  - Differentiated ALSA hardware sinks (`alsa_output.*`) from virtual sinks: ALSA sinks require at least one active port (`port_count > 0 && available`), while virtual sinks without ports remain available (`port_count == 0`).
  - Aggregated availability by sink name so each unique sink is emitted cleanly once.
- **`bin/omarchy-audio-output-switch`:**
  - Applied the ALSA port requirement and piped through `unique_by(.name)`.
- **`test/shell.d/audio-test.sh`:**
  - Added unit tests for `Model.deduplicateNodes`.