### PR TITLE
Report the highest-band link and MLO state in network band and status

### DIFF
--- a/bin/omarchy-network-band
+++ b/bin/omarchy-network-band
@@ -67,13 +67,16 @@ selected_band() {
   band_from_nm "$(nm_get 802-11-wireless.band connection show "$1")"
 }
 
-# Sets $ssid and $freq from one `iw dev <device> link`. iw prints the SSID as
-# the rest of its line, so an SSID containing ':' needs no special handling.
+# Sets $ssid, $freq, and $mlo from one `iw dev <device> link`. iw prints the
+# SSID as the rest of its line, so an SSID containing ':' needs no special
+# handling. Under Wi-Fi 7 MLO, iw lists one freq per radio link (2.4+5, 5+6,
+# ...) instead of a single one: the max is the fast data path and matches what
+# NetworkManager reports as the in-use BSSID, and more than one link is MLO.
 read_link() {
   local link
   link=$(iw dev "$1" link 2>/dev/null)
   ssid=$(awk '/SSID:/ { sub(/.*SSID: /, ""); print; exit }' <<<"$link")
-  freq=$(awk '/freq:/ { print $2; exit }' <<<"$link")
+  read -r freq mlo <<<"$(awk '/freq:/ { v = $2 + 0; if (v > max) max = v; links++ } END { print max, (links > 1 ? 1 : 0) }' <<<"$link")"
 }
 
 # Every band the SSID is reachable on, low to high, always including the one
@@ -107,7 +110,7 @@ available_bands() {
 }
 
 print_status() {
-  local device profile band available
+  local device profile band available mlo
 
   device=$(wifi_device)
   [[ -n $device ]] || return 0
@@ -120,6 +123,7 @@ print_status() {
   profile=$(wifi_profile "$device")
 
   printf 'band\t%s\n' "$band"
+  printf 'mlo\t%s\n' "${mlo:-0}"
   printf 'available\t%s\n' "$available"
   if [[ -n $profile ]]; then printf 'selected\t%s\n' "$(selected_band "$profile")"; fi
 }

--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -19,6 +19,12 @@ case "${1:-}" in
     ;;
 esac
 
+# Under Wi-Fi 7 MLO, iw prints one freq per link; the max is the fast path and
+# matches what NetworkManager reports as the in-use BSSID.
+max_link_freq() {
+  awk '/freq:/ { v = $2 + 0; if (v > max) max = v } END { print max }'
+}
+
 print_status() {
   local device nm state ssid signal freq
 
@@ -38,7 +44,7 @@ print_status() {
   state=$(awk -F: '$1 == "GENERAL.STATE" { print $2; exit }' <<<"$nm")
   ssid=$(awk -F: '$1 == "GENERAL.CONNECTION" { print $2; exit }' <<<"$nm")
   signal=$(nmcli -t -f IN-USE,SIGNAL dev wifi list ifname "$device" --rescan no 2>/dev/null | awk -F: '$1 == "*" { print $2; exit }')
-  freq=$(iw dev "$device" link 2>/dev/null | awk '/freq:/ { print $2; exit }')
+  freq=$(iw dev "$device" link 2>/dev/null | max_link_freq)
 
   if [[ $state != 100* ]]; then
     printf 'disconnected\t\t\t\n'
@@ -117,7 +123,7 @@ print_verbose() {
       if [[ -n $link ]]; then
         printf 'ssid\t%s\n' "$(awk '/SSID:/ { sub(/.*SSID: /, ""); print; exit }' <<<"$link")"
         printf 'signal_dbm\t%s\n' "$(awk '/signal:/ { print $2; exit }' <<<"$link")"
-        printf 'freq\t%s\n' "$(awk '/freq:/ { print $2; exit }' <<<"$link")"
+        printf 'freq\t%s\n' "$(max_link_freq <<<"$link")"
         printf 'bitrate\t%s %s\n' "$(awk '/tx bitrate:/ { print $3; exit }' <<<"$link")" "$(awk '/tx bitrate:/ { print $4; exit }' <<<"$link")"
       fi
     fi

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -73,13 +73,15 @@ function bandLabel(band) {
 // Under Automatic the pills are hidden, so the header carries the live band
 // instead -- "WI-FI BAND: 2.4GHZ". Once a band is pinned the pills are on
 // screen and say it themselves, so the header drops back to a plain label.
-function bandSectionTitle(selected, current) {
+// When the radio is on a Wi-Fi 7 Multi-Link Device, the live band is followed
+// by "· MLO" so the split-link state is visible at a glance.
+function bandSectionTitle(selected, current, mlo) {
   if (selected !== "auto") return "WI-FI BAND"
 
   var label = bandLabel(current)
   if (label === "") return "WI-FI BAND"
 
-  return "WI-FI BAND: " + label.toUpperCase()
+  return "WI-FI BAND: " + label.toUpperCase() + (mlo ? " · MLO" : "")
 }
 
 function bandTooltip(band) {
@@ -100,7 +102,8 @@ function parseBandStatus(raw) {
   return {
     band: next.band || "",
     selected: next.selected || "auto",
-    available: available
+    available: available,
+    mlo: next.mlo === "1"
   }
 }
 

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -78,8 +78,10 @@ Panel {
   // Wi-Fi band state from `omarchy-network-band`. `bandCurrent` is the band
   // the radio is actually on; `bandSelected` is the pinned choice ("auto" when
   // nothing is pinned), and the two differ whenever Auto is in effect.
+  // `bandMlo` is true when the radio is on a Wi-Fi 7 Multi-Link Device.
   property string bandCurrent: ""
   property string bandSelected: "auto"
+  property bool bandMlo: false
   property var bandAvailable: []
   property string pendingBand: ""
 
@@ -159,7 +161,7 @@ Panel {
   // Under Automatic there is nothing to pick, so the pills collapse away and
   // the header states the live band instead.
   readonly property bool bandPillsVisible: canSelectBand && bandPinned
-  readonly property string bandSectionTitle: Model.bandSectionTitle(bandEffective, bandCurrent)
+  readonly property string bandSectionTitle: Model.bandSectionTitle(bandEffective, bandCurrent, bandMlo)
   readonly property bool bandBusy: pendingBand !== ""
   // The speed test needs an interface to test, so its hero action only
   // appears once there is one.
@@ -686,6 +688,7 @@ Panel {
 
     bandCurrent = status.band
     bandSelected = status.selected
+    bandMlo = status.mlo
     bandAvailable = status.available
   }
 

--- a/test/shell.d/network-band-test.sh
+++ b/test/shell.d/network-band-test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+stage=$(mktemp -d)
+trap 'rm -rf -- "$stage"' EXIT
+mkdir -p "$stage/bin"
+
+# Synthetic network used by every fixture below; nothing here is read from,
+# or reflects, the machine running the test.
+ssid="HomeNet"
+
+# ── stub iw ──────────────────────────────────────────────────────────────────
+# The iw stub cats a fixture file whose path is exported before each run.
+printf '#!/bin/bash\ncat "$IW_FIXTURE"\n' > "$stage/bin/iw"
+chmod +x "$stage/bin/iw"
+
+# ── stub nmcli ───────────────────────────────────────────────────────────────
+# Dispatches on the full argument list the real nm_get/nmcli calls produce.
+cat > "$stage/bin/nmcli" <<STUB
+#!/bin/bash
+args="\$*"
+
+case "\$args" in
+  *-e\ no\ -g\ DEVICE,TYPE,STATE\ device\ status)
+    printf 'wlo1:wifi:connected\n'
+    ;;
+  *-e\ no\ -g\ GENERAL.CONNECTION\ device\ show\ wlo1)
+    printf '%s\n' "$ssid"
+    ;;
+  *-e\ no\ -g\ 802-11-wireless.band\ connection\ show\ "$ssid")
+    printf '\n'
+    ;;
+  *-e\ no\ -g\ FREQ,SSID\ dev\ wifi\ list\ ifname\ wlo1\ --rescan\ no)
+    printf '2412:%s\n5745:%s\n' "$ssid" "$ssid"
+    ;;
+  *)
+    printf 'stub-nmcli: unexpected call: %s\n' "\$args" >&2
+    exit 99
+    ;;
+esac
+STUB
+chmod +x "$stage/bin/nmcli"
+
+# ── helper ───────────────────────────────────────────────────────────────────
+run_band() {
+  HOME="$stage" PATH="$stage/bin:$PATH" "$ROOT/bin/omarchy-network-band" 2>/dev/null
+}
+
+assert_band() {
+  local label="$1" iw_text="$2" expect_band="$3" expect_available="$4" expect_mlo="${5:-0}"
+
+  printf '%s\n' "$iw_text" > "$stage/iw-fixture"
+  export IW_FIXTURE="$stage/iw-fixture"
+
+  local output
+  output=$(run_band) || fail "$label: omarchy-network-band exits 0" "$output"
+
+  local got_band
+  got_band=$(printf '%s' "$output" | awk -F'\t' '$1 == "band" { print $2 }')
+  [[ $got_band == "$expect_band" ]] || fail "$label: reports correct band" "got=$got_band expected=$expect_band"
+
+  local got_available
+  got_available=$(printf '%s' "$output" | awk -F'\t' '$1 == "available" { print $2 }')
+  [[ $got_available == "$expect_available" ]] || fail "$label: lists available bands" "got=$got_available expected=$expect_available"
+
+  local got_selected
+  got_selected=$(printf '%s' "$output" | awk -F'\t' '$1 == "selected" { print $2 }')
+  [[ $got_selected == "auto" ]] || fail "$label: selected is auto" "got=$got_selected"
+
+  local got_mlo
+  got_mlo=$(printf '%s' "$output" | awk -F'\t' '$1 == "mlo" { print $2 }')
+  [[ ${got_mlo:-0} == "$expect_mlo" ]] || fail "$label: reports MLO flag" "got=$got_mlo expected=$expect_mlo"
+
+  pass "$label"
+}
+
+# ── MLO: two links (2.4 + 5 GHz) — should report the highest band ──────────
+iw_mlo='Connected to 02:11:22:33:44:66 (on wlo1)
+	SSID: HomeNet
+	Link 0 BSSID 02:11:22:33:44:67
+		freq: 2412.0
+	Link 1 BSSID 02:11:22:33:44:68
+		freq: 5745.0
+MLD 02:11:22:33:44:66 stats:
+	RX: 182119686 bytes (143468 packets)
+	TX: 4658073 bytes (24069 packets)
+	signal: -26 dBm
+	tx bitrate: 1200.9 MBit/s 80MHz EHT-MCS 11 EHT-NSS 2 EHT-GI 0
+	bss flags:
+	dtim period: 1
+	beacon int: 100'
+
+assert_band "MLO reports 5 GHz (the highest-band link)" "$iw_mlo" "5" "2.4 5" "1"
+
+# ── single 5 GHz link ────────────────────────────────────────────────────────
+iw_single_5='Connected to 02:11:22:33:44:68 (on wlo1)
+	SSID: HomeNet
+	freq: 5745.0
+	signal: -50 dBm
+	rx bitrate: 1200.9 MBit/s 80MHz EHT-MCS 11 EHT-NSS 2 EHT-GI 0
+	tx bitrate: 1200.9 MBit/s 80MHz EHT-MCS 11 EHT-NSS 2 EHT-GI 0'
+
+assert_band "single 5 GHz link reports band 5" "$iw_single_5" "5" "2.4 5" "0"
+
+# ── single 2.4 GHz link ─────────────────────────────────────────────────────
+iw_single_24='Connected to 02:11:22:33:44:67 (on wlo1)
+	SSID: HomeNet
+	freq: 2412.0
+	signal: -40 dBm
+	tx bitrate: 286.8 MBit/s 40MHz VHT-MCS 7 VHT-NSS 2 VHT-GI 0.8'
+
+assert_band "single 2.4 GHz link reports band 2.4" "$iw_single_24" "2.4" "2.4 5" "0"
+
+# ── MLO: 5 + 6 GHz — should report 6 ───────────────────────────────────────
+iw_mlo_56='Connected to 02:11:22:33:44:66 (on wlo1)
+	SSID: HomeNet
+	Link 0 BSSID 02:11:22:33:44:67
+		freq: 5745.0
+	Link 1 BSSID 02:11:22:33:44:68
+		freq: 6115.0
+MLD 02:11:22:33:44:66 stats:
+	signal: -45 dBm
+	tx bitrate: 2402.7 MBit/s 160MHz EHT-MCS 13 EHT-NSS 2 EHT-GI 0.8'
+
+assert_band "MLO 5+6 GHz reports 6" "$iw_mlo_56" "6" "2.4 5 6" "1"

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -274,18 +274,26 @@ assertEqual(network.bandLabel('6'), '6ghz', 'network labels the 6GHz band')
 assertEqual(network.bandLabel('auto'), 'Auto', 'network labels the automatic band choice')
 
 assertEqual(network.bandSectionTitle('auto', '2.4'), 'WI-FI BAND: 2.4GHZ', 'network names the live band in the header under automatic')
+assertEqual(network.bandSectionTitle('auto', '5', true), 'WI-FI BAND: 5GHZ · MLO', 'network flags MLO beside the live band')
+assertEqual(network.bandSectionTitle('auto', '2.4', false), 'WI-FI BAND: 2.4GHZ', 'network leaves the header plain without MLO')
 assertEqual(network.bandSectionTitle('auto', ''), 'WI-FI BAND', 'network omits an unknown band from the header')
 assertEqual(network.bandSectionTitle('5', '5'), 'WI-FI BAND', 'network drops the header band once the pills are showing')
+assertEqual(network.bandSectionTitle('5', '5', true), 'WI-FI BAND', 'network keeps the header plain while MLO is pinned')
 assertEqual(network.bandSectionTitle('5', '2.4'), 'WI-FI BAND', 'network keeps a plain header while a pin is settling')
 
 assertDeepEqual(
   network.parseBandStatus('band\t5\navailable\t2.4 5 6\nselected\tauto\n'),
-  { band: '5', selected: 'auto', available: ['2.4', '5', '6'] },
-  'network parses band status'
+  { band: '5', selected: 'auto', available: ['2.4', '5', '6'], mlo: false },
+  'network parses band status without MLO'
+)
+assertDeepEqual(
+  network.parseBandStatus('band\t5\nmlo\t1\navailable\t2.4 5\nselected\tauto\n'),
+  { band: '5', selected: 'auto', available: ['2.4', '5'], mlo: true },
+  'network parses band status with MLO'
 )
 assertDeepEqual(
   network.parseBandStatus(''),
-  { band: '', selected: 'auto', available: [] },
+  { band: '', selected: 'auto', available: [], mlo: false },
   'network parses empty band status without a wifi connection'
 )
 


### PR DESCRIPTION
## Problem

On a Wi-Fi 7 MLO (Multi-Link Operation) connection, the AP exposes one radio link per band under a single SSID, and `iw dev <dev> link` prints each link with its own `freq:` line — Link 0 (typically 2.4 GHz) first:

```
Link 0 BSSID … 
    freq: 2412.0
Link 1 BSSID …
    freq: 5745.0
MLD … stats:
    tx bitrate: 1200.9 MBit/s 80MHz EHT-MCS 11 …
```

`omarchy-network-band` and `omarchy-network-status` extracted the **first** `freq:` line, so a 2.4+5 GHz association was always reported as **2.4GHZ** in the network panel, even though the 5 GHz link carries the traffic and is the BSSID NetworkManager reports as in-use. Pinning the band "worked" only because it forced a single-band association.

## Fix

- **`bin/omarchy-network-band` / `bin/omarchy-network-status`** — select the highest-band link's frequency instead of the first. Non-MLO output is unchanged (a single `freq:` yields the same value).
- **`bin/omarchy-network-band`** — emit a new `mlo\t0|1` line, detected by counting `freq:` links, so the shell can tell split-link associations apart.
- **`shell/plugins/panels/network/Model.js`** — `parseBandStatus` reads the flag; `bandSectionTitle` appends ` · MLO` beside the live band.
- **`shell/plugins/panels/network/Panel.qml`** — new `bandMlo` property wired into the band header.

The panel's band header now reads:

```
WI-FI BAND: 5GHZ · MLO
```

<img width="465" height="166" alt="image" src="https://github.com/user-attachments/assets/2f2fee26-cafb-48ab-a69c-123551605c78" />


and stays plain (`WI-FI BAND: 5GHZ`, `WI-FI BAND: 2.4GHZ`) for single-link connections.

## Tests

- New `test/shell.d/network-band-test.sh` (stubbed `iw`/`nmcli`):
  - MLO 2.4+5 → `band 5`, `mlo 1`
  - MLO 5+6 → `band 6`, `mlo 1`
  - single 5 GHz / 2.4 GHz links → unchanged bands, `mlo 0`
- `test/shell.d/network-test.sh` — coverage for the MLO header variants (live, plain, pinned) and the `mlo` field in `parseBandStatus`.
- `./test/all` passes apart from the 3 pre-existing `omarchy-pkgs` checkout failures on this machine (environment-related, unrelated to this change).

The `· MLO` suffix intentionally only appears under **Automatic** (when the header carries the live band); once a band is pinned the pills show instead and the header stays plain — matching the existing design.