### PR TITLE
Don't pin VA-API to NVIDIA on hybrid GPU systems

### DIFF
--- a/bin/omarchy-hw-nvidia-only
+++ b/bin/omarchy-hw-nvidia-only
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether NVIDIA is the only GPU in the computer.
+
+# Read the cached sysfs IDs rather than lspci, which reads PCI config space and
+# resumes runtime-suspended GPUs.
+pci_devices_path="${OMARCHY_PCI_DEVICES_PATH:-/sys/bus/pci/devices}"
+
+shopt -s nullglob
+
+nvidia_found=false
+
+for device in "$pci_devices_path"/*; do
+  [[ $(< "$device/class") == 0x03* ]] || continue
+
+  if [[ $(< "$device/vendor") == "0x10de" ]]; then
+    nvidia_found=true
+  else
+    exit 1
+  fi
+done
+
+[[ $nvidia_found == true ]]

--- a/default/hypr/nvidia.lua
+++ b/default/hypr/nvidia.lua
@@ -3,6 +3,7 @@ local paths = require("default.hypr.paths")
 local nvidia = paths.omarchy_path .. "/bin/omarchy-hw-nvidia"
 local nvidia_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-gsp"
 local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without-gsp"
+local nvidia_only = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-only"
 
 -- These detectors read cached sysfs IDs rather than shelling out to lspci.
 -- lspci reads PCI config space, which resumes a runtime-suspended GPU, and on a
@@ -10,7 +11,17 @@ local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without
 if o.shell_succeeds(o.shell_quote(nvidia)) then
   if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
     hl.env("NVD_BACKEND", "direct")
-    hl.env("LIBVA_DRIVER_NAME", "nvidia")
+
+    -- Pinning VA-API to the NVIDIA driver is only correct when NVIDIA is the
+    -- only GPU. On a hybrid laptop the iGPU normally drives the panel, so
+    -- forcing the whole session to decode on the dGPU sends every video frame
+    -- across the PRIME boundary to reach an iGPU-composited display, which
+    -- flickers while scrolling. Left unset, libva picks the driver matching
+    -- whichever GPU each app actually renders on.
+    if o.shell_succeeds(o.shell_quote(nvidia_only)) then
+      hl.env("LIBVA_DRIVER_NAME", "nvidia")
+    end
+
     hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
   elseif o.shell_succeeds(o.shell_quote(nvidia_without_gsp)) then
     hl.env("NVD_BACKEND", "egl")

--- a/test/shell.d/hw-nvidia-test.sh
+++ b/test/shell.d/hw-nvidia-test.sh
@@ -30,15 +30,16 @@ hw_nvidia() {
 }
 
 assert_detects() {
-  local description="$1" nvidia="$2" gsp="$3" without_gsp="$4"
+  local description="$1" nvidia="$2" gsp="$3" without_gsp="$4" only="$5"
 
   local command
-  for command in nvidia gsp without-gsp; do
+  for command in nvidia gsp without-gsp only; do
     local expected
     case $command in
       nvidia) expected=$nvidia ;;
       gsp) expected=$gsp ;;
       without-gsp) expected=$without_gsp ;;
+      only) expected=$only ;;
     esac
 
     local detector=nvidia
@@ -56,44 +57,49 @@ assert_detects() {
 
 # AMD Cezanne integrated graphics.
 write_pci_devices 0x1002:0x15e7:0x030000
-assert_detects "a machine without an NVIDIA GPU detects nothing" no no no
+assert_detects "a machine without an NVIDIA GPU detects nothing" no no no no
 
 # NVIDIA GA106M [RTX 3060 Mobile] alongside AMD Cezanne, the pair from issue #6660.
 write_pci_devices 0x1002:0x15e7:0x030000 0x10de:0x2560:0x030200
-assert_detects "a hybrid Ampere laptop detects a GSP GPU" yes yes no
+assert_detects "a hybrid Ampere laptop detects a GSP GPU" yes yes no no
+
+# NVIDIA GA107BM [RTX 3050 Mobile] alongside Intel Raptor Lake-P. The iGPU
+# drives the panel here, so VA-API must not be pinned to the NVIDIA driver.
+write_pci_devices 0x8086:0xa7ab:0x030000 0x10de:0x25ac:0x030000
+assert_detects "an Intel hybrid laptop is not NVIDIA-only" yes yes no no
 
 # NVIDIA TU117M [GTX 1650 Mobile], the first generation with GSP firmware.
 write_pci_devices 0x10de:0x1f91:0x030000
-assert_detects "Turing is the oldest generation with GSP firmware" yes yes no
+assert_detects "Turing is the oldest generation with GSP firmware" yes yes no yes
 
 # NVIDIA GV100 [TITAN V], the newest generation without GSP firmware.
 write_pci_devices 0x10de:0x1d81:0x030000
-assert_detects "Volta is the newest generation without GSP firmware" yes no yes
+assert_detects "Volta is the newest generation without GSP firmware" yes no yes yes
 
 # NVIDIA GP104 [GTX 1080].
 write_pci_devices 0x10de:0x1b80:0x030000
-assert_detects "Pascal detects a GPU without GSP firmware" yes no yes
+assert_detects "Pascal detects a GPU without GSP firmware" yes no yes yes
 
 # NVIDIA GM108M [GeForce 830M], the oldest part the 580xx driver supports.
 write_pci_devices 0x10de:0x1340:0x030000
-assert_detects "Maxwell detects a GPU without GSP firmware" yes no yes
+assert_detects "Maxwell detects a GPU without GSP firmware" yes no yes yes
 
 # NVIDIA GK110 [GTX 780]. Kepler predates GSP but also predates 580xx, so
 # claiming it here would install a driver that cannot drive it.
 write_pci_devices 0x10de:0x1004:0x030000
-assert_detects "Kepler is too old for either driver" yes no no
+assert_detects "Kepler is too old for either driver" yes no no yes
 
 # NVIDIA GF100 [GTX 470], older still.
 write_pci_devices 0x10de:0x06cd:0x030000
-assert_detects "Fermi is too old for either driver" yes no no
+assert_detects "Fermi is too old for either driver" yes no no yes
 
 # NVIDIA GB203 [RTX 5080], newer than every other device ID here.
 write_pci_devices 0x10de:0x2c02:0x030000
-assert_detects "Blackwell detects a GSP GPU" yes yes no
+assert_detects "Blackwell detects a GSP GPU" yes yes no yes
 
 # The GA106 audio function carries the NVIDIA vendor ID but is not a GPU.
 write_pci_devices 0x10de:0x228e:0x040300
-assert_detects "a non-display NVIDIA function is not a GPU" no no no
+assert_detects "a non-display NVIDIA function is not a GPU" no no no no
 
 write_pci_devices
-assert_detects "a machine with no PCI devices detects nothing" no no no
+assert_detects "a machine with no PCI devices detects nothing" no no no no


### PR DESCRIPTION
## Problem

On a hybrid GPU laptop, video flickers while scrolling — reproducible on Twitter/X, where videos scroll in and out of the viewport continuously.

## Root cause

`default/hypr/nvidia.lua` exports `LIBVA_DRIVER_NAME=nvidia` for the whole session whenever it finds an NVIDIA GPU with GSP firmware. The systemd user manager inherits it, so desktop launches get it too.

That is correct on an NVIDIA-only machine. On a hybrid laptop the iGPU normally drives the panel, so pinning VA-API to the NVIDIA driver makes every app decode video on the dGPU, and each decoded frame then crosses the PRIME boundary to reach an iGPU-composited display.

Measured on the affected machine before the fix — Edge's GPU process:

```
/usr/lib/dri/nvidia_drv_video.so
/usr/lib/libEGL_nvidia.so.610.57.04
23 fds on /dev/nvidia0
```

while the panel is on the Intel iGPU (`card2-eDP-2`, `i915`).

## Fix

Gate the pin on a new `omarchy-hw-nvidia-only` detector. Left unset, libva picks the driver matching whichever GPU an app actually renders on — the per-device answer a hybrid system needs. `NVD_BACKEND` and `__GLX_VENDOR_LIBRARY_NAME` are left alone.

The detector reads sysfs rather than reusing `omarchy-hw-hybrid-gpu`, which shells out to `lspci`. `nvidia.lua` already documents why that matters: lspci reads PCI config space, resuming a runtime-suspended GPU, and the wake alone outlasts Hyprland's 1.5s config reload budget.

## Verification

Hardware: Intel Raptor Lake-P `[8086:a7ab]` + NVIDIA GA107BM RTX 3050 Laptop `[10de:25ac]`, panel on the iGPU, Omarchy 4.0.2, `nvidia-open-dkms` 610.57.04, Hyprland/Wayland.

Applying the change (via an equivalent per-app override) and restarting the browser:

| | Before | After |
|---|---|---|
| Video decode | `nvidia_drv_video.so` | `iHD_drv_video.so` |
| EGL | `libEGL_nvidia.so` | `libEGL_mesa.so` |
| `/dev/nvidia0` fds | 23 | 0 |

Flicker is gone. Hardware decode is retained, now on the iGPU:

```
$ env -u LIBVA_DRIVER_NAME vainfo
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 26.2.4
```

Worth noting that unsetting the variable was sufficient on its own — EGL moved to Mesa as a consequence, without needing `__EGL_VENDOR_LIBRARY_FILENAMES`. That is why this PR changes only the one export.

Note this requires an iGPU VA-API driver to be present (`intel-media-driver` here). Without one, decode falls back to software instead of decoding on the wrong GPU — which is the safer failure, and no worse than the current behaviour on machines where the NVIDIA VA-API driver is absent.

## Tests

`test/shell.d/hw-nvidia-test.sh` covers the new detector across every existing fixture, plus a new Intel + NVIDIA hybrid case. `test/cli` passes. `test/shell` has 3 failures (`config-test`, `snapper-test`, `unowned-system-paths-test`) that reproduce identically on unmodified `quattro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT3H7mj63CxzHWKLd4apWk
