### PR TITLE
Fix GTK4 black window and hardware cursor lag on NVIDIA

### DIFF
--- a/default/hypr/nvidia.lua
+++ b/default/hypr/nvidia.lua
@@ -8,6 +8,18 @@ local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without
 -- lspci reads PCI config space, which resumes a runtime-suspended GPU, and on a
 -- hybrid laptop that wake alone outlasts Hyprland's 1.5s config reload budget.
 if o.shell_succeeds(o.shell_quote(nvidia)) then
+  -- Prevent GTK4 / Nautilus from rendering blank black windows under Wayland on NVIDIA
+  hl.env("GSK_RENDERER", "gl")
+
+  -- Hardware cursors on NVIDIA need a CPU buffer. Auto was falling back to software
+  -- cursors, which trail behind the pointer especially on high-refresh external displays.
+  hl.config({
+    cursor = {
+      no_hardware_cursors = 0,
+      use_cpu_buffer = 1,
+    },
+  })
+
   if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
     hl.env("NVD_BACKEND", "direct")
     hl.env("LIBVA_DRIVER_NAME", "nvidia")


### PR DESCRIPTION
### Problem

On machines with NVIDIA GPUs running under Wayland:
1. **GTK4 Blank / Black Windows:** GTK 4.14+ defaults to the Vulkan or NGL renderer. On NVIDIA (especially hybrid laptop setups like Intel/NVIDIA), Nautilus (Files), Loupe, and other GTK4 applications frequently open as blank black windows or crash.
2. **Laggy / Trailing Software Cursor on External Monitors:** Hyprland auto cursor selection on NVIDIA often drops down to a software cursor, which creates a noticeable lag/trail behind the true pointer position on high-refresh external displays (120Hz/240Hz).

### Solution

In `default/hypr/nvidia.lua`, when NVIDIA hardware is detected:
- Set `hl.env("GSK_RENDERER", "gl")` to force GTK4 to use the stable OpenGL renderer, eliminating black windows in Nautilus.
- Configure `cursor = { no_hardware_cursors = 0, use_cpu_buffer = 1 }` so Hyprland utilizes a hardware cursor with a CPU buffer for smooth 1:1 cursor response on NVIDIA.