### PR TITLE
Drive the launch OSD in-process so a lost close cannot strand it

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -12,6 +12,9 @@ Item {
   id: root
 
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+  // The shell that owns this library; launch feedback drives the OSD plugin
+  // through it in-process rather than through a spawned omarchy-shell call.
+  property var shell: null
 
   property var configuredHiddenEntryIds: ({})
   property var desktopHiddenEntryIds: ({})
@@ -171,7 +174,7 @@ Item {
     launchDelay.stop()
     launchTimeout.stop()
     if (root.launchOsdOpen) {
-      Quickshell.execDetached(["omarchy-shell", "osd", "close"])
+      root.shell.hide("omarchy.osd")
       root.launchOsdOpen = false
     }
   }
@@ -242,7 +245,7 @@ Item {
     onTriggered: {
       if (root.toplevelCount() > root.launchToplevelCount || ToplevelManager.activeToplevel !== root.launchActiveToplevel) return
       root.launchOsdOpen = true
-      Quickshell.execDetached(["omarchy-shell", "osd", "show", JSON.stringify({ icon: "󱓞", message: root.launchOsdMessage, duration: 0 })])
+      root.shell.summon("omarchy.osd", JSON.stringify({ icon: "󱓞", message: root.launchOsdMessage, duration: 0 }))
     }
   }
 

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -17,7 +17,7 @@ ShellRoot {
   // own empty copies.
   property PluginRegistry pluginRegistry: PluginRegistry { }
   property BarWidgetRegistry barWidgetRegistry: BarWidgetRegistry { }
-  property AppLibrary appLibrary: AppLibrary { }
+  property AppLibrary appLibrary: AppLibrary { shell: shell }
 
   property string home: Quickshell.env("HOME")
 


### PR DESCRIPTION
The "Launching Slack…" OSD stayed on screen after Slack had opened. Nothing removed it until a shell restart.

The launcher opens this OSD with duration 0. Only an explicit close removes it. It sends both the show and the close by spawning `omarchy-shell`, a bash script that forwards to `qs ipc` with a 2s timeout and no retry. If the close process times out, or runs before the show process, the OSD stays forever. Both cases are easy to hit while the launched app loads the CPU.

The shell already has `summon()` and `hide()`. Other plugins use them for the OSD. This change hands the shell to `AppLibrary` and calls them directly. The calls are in-process and ordered, so a close cannot be lost or overtake a show.

Tested by running the shell from this branch and launching a desktop entry that sleeps 5s, then opens a terminal. The OSD appeared after 2s and closed when the window appeared. `./test/all` passes except `config-test.sh`, which needs an `omarchy-pkgs` checkout.

https://claude.ai/code/session_017J3tUnyMTMmWF6MDp96LZC
