### PR TITLE
Install Intel VA-API drivers by device, not by marketing name

### DIFF
--- a/install/hardware/intel/video-acceleration.sh
+++ b/install/hardware/intel/video-acceleration.sh
@@ -1,11 +1,18 @@
 # This installs hardware video acceleration for Intel GPUs
 
-if INTEL_GPU=$(lspci | grep -iE 'vga|3d|display' | grep -i 'intel'); then
-  # HD Graphics / Iris / Xe / Arc / Non-Arc Panther Lake use intel-media-driver + VPL
-  if [[ ${INTEL_GPU,,} =~ (hd\ graphics|uhd\ graphics|xe|iris|arc|panther\ lake) ]]; then
-    omarchy-pkg-add intel-media-driver libvpl vpl-gpu-rt
-  elif [[ ${INTEL_GPU,,} =~ "gma" ]]; then
+# Select on the presence of an Intel display device rather than on the marketing
+# name lspci reports. Intel ships recent parts -- Raptor Lake, Meteor Lake,
+# Arrow Lake, Lunar Lake, Battlemage -- as a bare "[Intel Graphics]" with no
+# Iris, UHD or Arc branding, so an allowlist of names installs nothing at all on
+# them and has to be widened for every new family; "panther lake" was added for
+# exactly that reason. Inverting the test leaves only the pre-Broadwell parts
+# needing a name, and that set stopped growing in 2014.
+if INTEL_GPU=$(lspci -d '8086::0300') && [[ -n $INTEL_GPU ]]; then
+  if [[ ${INTEL_GPU,,} =~ gma ]]; then
     # Older generations from 2008 to ~2014-2017 use libva-intel-driver
     omarchy-pkg-add libva-intel-driver
+  else
+    # Broadwell and newer use intel-media-driver + VPL
+    omarchy-pkg-add intel-media-driver libvpl vpl-gpu-rt
   fi
 fi

--- a/test/shell.d/intel-video-acceleration-test.sh
+++ b/test/shell.d/intel-video-acceleration-test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/intel/video-acceleration.sh"
+all="$ROOT/install/hardware/all.sh"
+
+grep -q 'run_logged .*hardware/intel/video-acceleration.sh' "$all" ||
+  fail "video acceleration is installed during hardware setup"
+pass "video acceleration is installed during hardware setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+
+# lspci is only ever called with a device selector here, so the stub can ignore
+# it and replay whatever the case under test puts in TEST_LSPCI.
+cat >"$test_tmp/bin/lspci" <<'SH'
+#!/bin/bash
+printf '%s' "${TEST_LSPCI:-}"
+SH
+
+cat >"$test_tmp/bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg-add %s\n' "$*" >>"$CALL_LOG"
+SH
+
+chmod +x "$test_tmp/bin"/*
+
+call_log="$test_tmp/calls.log"
+
+# Sourced the way run_logged runs it.
+run_leaf() {
+  : >"$call_log"
+  PATH="$test_tmp/bin:$PATH" \
+    CALL_LOG="$call_log" \
+    TEST_LSPCI="$1" \
+    bash -c 'source "$1"' bash "$leaf"
+}
+
+assert_installs() {
+  local description="$1" lspci_output="$2" expected="$3"
+
+  run_leaf "$lspci_output" || fail "$description" "the leaf exited non-zero"
+
+  local actual
+  actual=$(cat "$call_log")
+  [[ $actual == "$expected" ]] ||
+    fail "$description" "expected: $expected"$'\n'"actual:   $actual"
+
+  pass "$description"
+}
+
+modern='pkg-add intel-media-driver libvpl vpl-gpu-rt'
+
+# The regression this replaces: Intel dropped Iris/UHD/Arc branding for these
+# parts, so a name allowlist matched none of them and installed nothing.
+assert_installs "Raptor Lake reports no marketing name and still gets a driver" \
+  '00:02.0 VGA compatible controller: Intel Corporation Raptor Lake-P [Intel Graphics] (rev 04)' \
+  "$modern"
+
+assert_installs "Meteor Lake gets a driver" \
+  '00:02.0 VGA compatible controller: Intel Corporation Meteor Lake-P [Intel Graphics] (rev 08)' \
+  "$modern"
+
+assert_installs "Arrow Lake gets a driver" \
+  '00:02.0 VGA compatible controller: Intel Corporation Arrow Lake-U [Intel Graphics]' \
+  "$modern"
+
+assert_installs "Lunar Lake gets a driver" \
+  '00:02.0 VGA compatible controller: Intel Corporation Lunar Lake [Intel Graphics]' \
+  "$modern"
+
+assert_installs "Alder Lake-N gets a driver" \
+  '00:02.0 VGA compatible controller: Intel Corporation Alder Lake-N [Intel Graphics]' \
+  "$modern"
+
+# Discrete Arc, which the old "arc" token missed because pci.ids does not
+# spell out the brand for these boards.
+assert_installs "discrete Battlemage gets a driver" \
+  '03:00.0 VGA compatible controller: Intel Corporation Battlemage G21 [Intel Graphics]' \
+  "$modern"
+
+# The names the previous allowlist did match must keep working.
+assert_installs "branded Iris Xe still gets a driver" \
+  '00:02.0 VGA compatible controller: Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics] (rev 01)' \
+  "$modern"
+
+assert_installs "branded UHD Graphics still gets a driver" \
+  '00:02.0 VGA compatible controller: Intel Corporation CometLake-U GT2 [UHD Graphics] (rev 02)' \
+  "$modern"
+
+assert_installs "Panther Lake still gets a driver" \
+  '00:02.0 VGA compatible controller: Intel Corporation Panther Lake [Intel Graphics]' \
+  "$modern"
+
+# Pre-Broadwell parts predate intel-media-driver.
+assert_installs "GMA falls back to the legacy driver" \
+  '00:02.0 VGA compatible controller: Intel Corporation Mobile 4 Series Chipset Integrated Graphics Controller (GMA 4500MHD)' \
+  'pkg-add libva-intel-driver'
+
+assert_installs "a machine with no Intel GPU installs nothing" '' ''


### PR DESCRIPTION
## Problem

`install/hardware/intel/video-acceleration.sh` decides which VA-API driver to install by matching the `lspci` line against an allowlist of marketing names:

```bash
if [[ ${INTEL_GPU,,} =~ (hd\ graphics|uhd\ graphics|xe|iris|arc|panther\ lake) ]]; then
```

Intel ships many recent parts as a bare `[Intel Graphics]` with no Iris/UHD/Arc branding, so the allowlist matches nothing and the leaf silently installs no VA-API driver at all.

**25 device IDs across 13 families miss**, per `pci.ids`:

| Family | Examples |
|---|---|
| Raptor Lake-P/U | `8086:a7aa` `a7ab` `a7ac` `a7ad` |
| Meteor Lake-M/P | `7d40` `7d45` `7d60` `7dd5` |
| Arrow Lake-U/S/P/H | `7d41` `7d67` `7dd1` `b640` |
| Lunar Lake | `6420` `64b0` |
| Alder Lake-N | `46d3` `46d4` |
| Wildcat Lake | `fd80` `fd81` |
| Battlemage G21/G31 | `e202` `e20d` `e210` `e215` `e216` `e220` `e221` |

Battlemage is discrete Arc and misses despite the `arc` token, because `pci.ids` does not spell out the brand for those boards.

`panther lake` is in that allowlist because this same failure was already hit on one family and patched there rather than at the root — so it regressed again for every other family.

## Evidence from an affected machine

Intel Raptor Lake-P `[8086:a7ab]`, Omarchy 4.0.2. After a normal install:

- `vpl-gpu-rt` — **not installed** (3rd package on that `omarchy-pkg-add` line, so the line never ran)
- `libvpl` — installed, but as an `ffmpeg` dependency
- `intel-media-driver` — **not installed**
- `vulkan-intel` — installed

That last one is the contrast. `install/hardware/vulkan.sh` runs in the same install and matches on *vendor* (`(VGA|Display).*Intel`); it worked. This leaf matches on model names; it did not.

The practical result was no `iHD_drv_video.so` on disk at all, so the only VA-API driver present was NVIDIA's — which on a hybrid laptop means video decodes on the dGPU and every frame crosses the PRIME boundary. That surfaced as flicker while scrolling video (see #9812, which is the other half of this and independent of it).

## Fix

Invert the test. Any Intel display device gets `intel-media-driver`; only the pre-Broadwell parts still need a name, and that set stopped growing in 2014. New hardware now works by default instead of waiting for another token to be added.

Also select the device with `lspci -d 8086::0300`. The old `grep -iE 'vga|3d|display'` matched unrelated lines whose hex device ID contains `3d` — on the reporting machine it pulled in a PCI bridge, `Device a73d`, alongside the GPU.

## Tradeoff

Pre-Broadwell parts that are not named GMA — Ivy Bridge, Haswell — now get `intel-media-driver`, which cannot drive them, leaving decode in software. That is exactly what they already got from matching no token at all, so this is not a regression, but it is not a fix for them either. Handling them properly needs generation detection rather than name matching, which felt like a separate change.

## Tests

`test/shell.d/intel-video-acceleration-test.sh` stubs `lspci` and `omarchy-pkg-add` and covers each missed family, discrete Battlemage, the GMA fallback, no-Intel-GPU, and the previously-matching names (Iris Xe, UHD, Panther Lake) as regression cases.

Against the current script it fails exactly as reported:

```
expected: pkg-add intel-media-driver libvpl vpl-gpu-rt
actual:
not ok - Raptor Lake reports no marketing name and still gets a driver
```

`test/cli` passes. `test/shell` has 3 failures (`config-test`, `snapper-test`, `unowned-system-paths-test`) that reproduce identically on unmodified `quattro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT3H7mj63CxzHWKLd4apWk
