### PR TITLE
Allow configuring workspace count in the workspaces bar widget

### DIFF
--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -8,6 +8,11 @@ BarWidget {
   id: root
   moduleName: "omarchy.workspaces"
 
+  readonly property int count: {
+    var raw = Number(setting("count", 5))
+    return isNaN(raw) ? 5 : Math.max(1, Math.min(10, Math.floor(raw)))
+  }
+
   function workspaceById(id) {
     var values = Hyprland.workspaces.values
     for (var i = 0; i < values.length; i++) {
@@ -18,7 +23,9 @@ BarWidget {
   }
 
   function workspaceIds() {
-    var ids = [1, 2, 3, 4, 5]
+    var ids = []
+    for (var n = 1; n <= root.count; n++) ids.push(n)
+
     var values = Hyprland.workspaces.values
 
     for (var i = 0; i < values.length; i++) {


### PR DESCRIPTION
## Context

The `omarchy.workspaces` bar widget statically displays workspaces `[1, 2, 3, 4, 5]`. Workspaces 6 through 10 are only shown dynamically when occupied by an active window.

Users with multi-workspace workflows (e.g., workspaces 1–9 mapped to keybindings) had to clone the widget to custom user plugins just to change the persistent range.

## Solution

Support an optional `count` setting in `Workspaces.qml` via `setting("count", 5)`:
- Clamps the configured count between 1 and 10 (`Math.max(1, Math.min(10, ...))`).
- Retains the default of `5` when unset or invalid, ensuring 100% backwards compatibility with existing setups.
- Dynamically populates the base workspace range up to the configured count, while still including any higher-numbered occupied workspaces.

## Example

In `~/.config/omarchy/shell.json`:
```json
{
  "id": "omarchy.workspaces",
  "count": 9
}
```

Or via CLI:
```bash
omarchy bar set omarchy.workspaces count 9
```

## Test Plan

- `test/shell.d/bar-widget-contract-test.sh` — passes bar widget contract checks.
- `test/shell.d/plugin-validate-test.sh` — passes plugin entry points and kind validation.
- `./test/cli` — passes CLI routing and command metadata tests.
- Visual verification in running shell with `"count": 9` and `"count": 5`.
