### PR TITLE
Switch Claude accounts from the agents panel

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -75,6 +75,10 @@ crush)
   fi
   ;;
 claude)
+  if [[ -x ${OMARCHY_PATH:-}/bin/omarchy-agent-account ]]; then
+    claude_dir=$("$OMARCHY_PATH/bin/omarchy-agent-account" dir claude 2>/dev/null || true)
+    [[ -n $claude_dir ]] && export CLAUDE_CONFIG_DIR=$claude_dir
+  fi
   command=(claude --permission-mode auto)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;

--- a/bin/omarchy-agent-account
+++ b/bin/omarchy-agent-account
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# omarchy:summary=List or switch AI coding-agent accounts
+# omarchy:args=<list|use|add|dir|current> [claude] [id]
+# omarchy:examples=omarchy agent account list | omarchy agent account use claude acct-1 | omarchy agent account add claude
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: omarchy agent account <list|use|add|dir|current> [claude] [id]" >&2
+}
+
+fail() {
+  echo "omarchy-agent-account: $*" >&2
+  exit 1
+}
+
+here=$(cd -- "$(dirname -- "$(realpath -- "$0")")" && pwd)
+
+backend_for() {
+  local provider=$1 backend
+  backend="$here/omarchy-agent-account-$provider"
+  if [[ ! -x $backend && -n ${OMARCHY_PATH:-} ]]; then
+    backend="$OMARCHY_PATH/bin/omarchy-agent-account-$provider"
+  fi
+  [[ -x $backend ]] || fail "no account backend for $provider"
+  printf '%s\n' "$backend"
+}
+
+is_provider() {
+  local name=$1
+  [[ -x $here/omarchy-agent-account-$name ]] && return 0
+  [[ -n ${OMARCHY_PATH:-} && -x $OMARCHY_PATH/bin/omarchy-agent-account-$name ]] && return 0
+  return 1
+}
+
+(( $# > 0 )) || { usage; exit 1; }
+
+action=$1
+shift
+
+case $action in
+list | dir | current | add | use) ;;
+-h | --help)
+  usage
+  exit 0
+  ;;
+*)
+  usage
+  exit 1
+  ;;
+esac
+
+provider=claude
+id=""
+json=()
+
+while (( $# > 0 )); do
+  case $1 in
+  --json)
+    json=(--json)
+    shift
+    ;;
+  *)
+    if is_provider "$1"; then
+      provider=$1
+    elif [[ $action == "use" || $action == "add" ]]; then
+      id=$1
+    else
+      fail "no account backend for $1"
+    fi
+    shift
+    ;;
+  esac
+done
+
+backend=$(backend_for "$provider")
+
+case $action in
+list | dir | current)
+  exec "$backend" "$action" "${json[@]}"
+  ;;
+add)
+  exec "$backend" add "${json[@]}"
+  ;;
+use)
+  [[ -n $id ]] || fail "use needs an account id"
+  exec "$backend" use "$id" "${json[@]}"
+  ;;
+esac

--- a/bin/omarchy-agent-account-claude
+++ b/bin/omarchy-agent-account-claude
@@ -1,0 +1,442 @@
+#!/usr/bin/python3
+# omarchy:summary=Claude Code account snapshots for omarchy agent account
+# omarchy:args=<list|use|add|dir|current> [--json] [id]
+# omarchy:hidden=true
+"""Isolated Claude Code accounts behind a pointer file.
+
+Each extra login gets its own CLAUDE_CONFIG_DIR. Switching writes the active
+id; it does not copy OAuth into ~/.claude. The default ~/.claude directory
+can itself be a registered account so the first login does not move.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+VERSION = 1
+PROVIDER = "claude"
+
+
+def state_dir() -> Path:
+  root = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state"))
+  return root / "omarchy" / "agent-accounts" / "claude"
+
+
+def default_config_dir() -> Path:
+  raw = os.environ.get("CLAUDE_CONFIG_DIR") or str(Path.home() / ".claude")
+  return Path(os.path.expanduser(raw)).resolve()
+
+
+def expand_path(value: str) -> Path:
+  return Path(os.path.expandvars(os.path.expanduser(value))).resolve()
+
+
+def index_path() -> Path:
+  return state_dir() / "index.json"
+
+
+def pending_add_path() -> Path:
+  return state_dir() / "pending-add"
+
+
+def isolated_dir(account_id: str) -> Path:
+  return state_dir() / "accounts" / account_id
+
+
+def die(message: str, code: int = 1) -> None:
+  print(f"omarchy-agent-account-claude: {message}", file=sys.stderr)
+  raise SystemExit(code)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+  if not path.is_file():
+    return {}
+  try:
+    data = json.loads(path.read_text())
+  except (OSError, json.JSONDecodeError):
+    return {}
+  return data if isinstance(data, dict) else {}
+
+
+def atomic_write(path: Path, data: Any, mode: int = 0o600) -> None:
+  path.parent.mkdir(parents=True, exist_ok=True)
+  fd, tmp = tempfile_path(path)
+  try:
+    with os.fdopen(fd, "w") as handle:
+      json.dump(data, handle, indent=2)
+      handle.write("\n")
+    os.chmod(tmp, mode)
+    os.replace(tmp, path)
+  except Exception:
+    try:
+      os.unlink(tmp)
+    except OSError:
+      pass
+    raise
+
+
+def tempfile_path(path: Path) -> tuple[int, str]:
+  fd, tmp = tempfile.mkstemp(prefix="." + path.name + ".", dir=str(path.parent))
+  return fd, tmp
+
+
+def ensure_state() -> None:
+  path = state_dir()
+  path.mkdir(parents=True, exist_ok=True)
+  os.chmod(path, 0o700)
+  (state_dir() / "accounts").mkdir(parents=True, exist_ok=True)
+  os.chmod(state_dir() / "accounts", 0o700)
+
+
+@contextmanager
+def locked():
+  ensure_state()
+  fd = os.open(state_dir() / "lock", os.O_CREAT | os.O_RDWR, 0o600)
+  fcntl.flock(fd, fcntl.LOCK_EX)
+  try:
+    yield
+  finally:
+    fcntl.flock(fd, fcntl.LOCK_UN)
+    os.close(fd)
+
+
+def plan_label(tier: str, subscription: str, org_tier: str = "") -> str:
+  for raw in (org_tier, tier):
+    match = re.search(r"max[_-]?(\d+x)", str(raw or ""), re.IGNORECASE)
+    if match:
+      return "Max " + match.group(1).lower()
+  sub = str(subscription or "").strip().lower()
+  if sub in ("max", "pro", "team"):
+    return sub.capitalize()
+  if sub:
+    return sub
+  return ""
+
+
+def slug_id(email: str, uuid: str) -> str:
+  if uuid:
+    return "acct-" + re.sub(r"[^a-zA-Z0-9]+", "", uuid)[:12].lower()
+  cleaned = re.sub(r"[^a-z0-9]+", "-", email.lower()).strip("-")
+  return cleaned or "account"
+
+
+def identity_in(config_dir: Path) -> dict[str, Any] | None:
+  home = read_json(Path.home() / ".claude.json") if config_dir == (Path.home() / ".claude").resolve() else {}
+  nested = read_json(config_dir / ".claude.json")
+  creds = read_json(config_dir / ".credentials.json")
+  account = nested.get("oauthAccount") if isinstance(nested.get("oauthAccount"), dict) else {}
+  if not account and isinstance(home.get("oauthAccount"), dict):
+    account = home["oauthAccount"]
+  oauth = creds.get("claudeAiOauth") if isinstance(creds.get("claudeAiOauth"), dict) else {}
+  if not account and not oauth:
+    return None
+  email = str(account.get("emailAddress") or "").strip()
+  uuid = str(account.get("accountUuid") or "").strip()
+  if not email and not uuid:
+    return None
+  label = str(account.get("displayName") or "").strip() or email or "Claude"
+  return {
+    "id": slug_id(email, uuid),
+    "email": email,
+    "label": label,
+    "plan": plan_label(
+      str(oauth.get("rateLimitTier") or account.get("userRateLimitTier") or ""),
+      str(oauth.get("subscriptionType") or account.get("organizationType") or ""),
+      str(account.get("organizationRateLimitTier") or ""),
+    ),
+    "organization": str(account.get("organizationName") or "").strip(),
+    "path": str(config_dir),
+  }
+
+
+def load_index() -> dict[str, Any]:
+  data = read_json(index_path())
+  accounts = data.get("accounts") if isinstance(data.get("accounts"), list) else []
+  return {
+    "version": VERSION,
+    "activeId": str(data.get("activeId") or ""),
+    "accounts": [a for a in accounts if isinstance(a, dict) and a.get("id") and a.get("path")],
+  }
+
+
+def write_index(index: dict[str, Any]) -> None:
+  atomic_write(index_path(), {
+    "version": VERSION,
+    "activeId": index.get("activeId") or "",
+    "accounts": index.get("accounts") or [],
+  })
+
+
+def upsert_account(index: dict[str, Any], ident: dict[str, Any], active: bool) -> dict[str, Any]:
+  accounts = [a for a in index["accounts"] if str(a.get("id")) != ident["id"]]
+  accounts.append({
+    "id": ident["id"],
+    "email": ident.get("email") or "",
+    "label": ident.get("label") or ident.get("email") or ident["id"],
+    "plan": ident.get("plan") or "",
+    "organization": ident.get("organization") or "",
+    "path": ident["path"],
+  })
+  accounts.sort(key=lambda row: str(row.get("email") or row.get("id")).lower())
+  index["accounts"] = accounts
+  if active:
+    index["activeId"] = ident["id"]
+  write_index(index)
+  return index
+
+
+def public_index(index: dict[str, Any], live: dict[str, Any] | None) -> dict[str, Any]:
+  active_id = str(index.get("activeId") or "")
+  accounts = []
+  for row in index.get("accounts") or []:
+    item = {
+      "id": str(row.get("id") or ""),
+      "email": str(row.get("email") or ""),
+      "label": str(row.get("email") or row.get("label") or row.get("id") or ""),
+      "plan": str(row.get("plan") or ""),
+      "organization": str(row.get("organization") or ""),
+      "path": str(row.get("path") or ""),
+      "active": str(row.get("id") or "") == active_id,
+    }
+    if item["id"]:
+      accounts.append(item)
+  current = next((a for a in accounts if a["active"]), None)
+  return {
+    "provider": PROVIDER,
+    "activeId": active_id,
+    "current": current,
+    "live": None if live is None else {
+      "id": live["id"],
+      "email": live.get("email") or "",
+      "label": live.get("label") or "",
+      "plan": live.get("plan") or "",
+      "path": live.get("path") or "",
+    },
+    "accounts": accounts,
+  }
+
+
+def active_path(index: dict[str, Any]) -> Path | None:
+  active_id = str(index.get("activeId") or "")
+  for row in index.get("accounts") or []:
+    if str(row.get("id")) == active_id:
+      path = str(row.get("path") or "")
+      if path:
+        return expand_path(path)
+  return None
+
+
+def emit(payload: dict[str, Any], as_json: bool) -> None:
+  if as_json:
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return
+  accounts = payload.get("accounts") or []
+  if not accounts:
+    print("No saved Claude accounts.")
+    return
+  for row in accounts:
+    mark = "*" if row.get("active") else " "
+    plan = f"  {row['plan']}" if row.get("plan") else ""
+    print(f"{mark} {row['email'] or row['label']}{plan}")
+
+
+def cmd_list(as_json: bool) -> int:
+  with locked():
+    index = load_index()
+    if pending_add_path().exists():
+      payload = public_index(index, None)
+    else:
+      live_dir = active_path(index) or default_config_dir()
+      live = identity_in(live_dir)
+      if live is not None:
+        index = upsert_account(index, live, active=True)
+      payload = public_index(index, live)
+  emit(payload, as_json)
+  return 0
+
+
+def cmd_current(as_json: bool) -> int:
+  with locked():
+    index = load_index()
+    payload = public_index(index, identity_in(active_path(index) or default_config_dir()))
+  current = payload.get("current") or payload.get("live")
+  if as_json:
+    json.dump({"current": current, "live": payload.get("live")}, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0 if current else 1
+  if not current:
+    print("No Claude account is active.", file=sys.stderr)
+    return 1
+  print(current.get("id") or "")
+  return 0
+
+
+def cmd_dir() -> int:
+  with locked():
+    index = load_index()
+    path = active_path(index)
+  if path is None:
+    path = default_config_dir()
+  print(path)
+  return 0
+
+
+def cmd_use(account_id: str, as_json: bool) -> int:
+  with locked():
+    index = load_index()
+    match = next((row for row in index["accounts"] if str(row.get("id")) == account_id), None)
+    if match is None:
+      die(f"no saved Claude account '{account_id}'")
+    index["activeId"] = account_id
+    write_index(index)
+    payload = public_index(index, identity_in(expand_path(str(match["path"]))))
+  notify_switched(payload.get("current") or {})
+  refresh_usage()
+  if as_json:
+    emit(payload, True)
+  else:
+    current = payload.get("current") or {}
+    print(f"Switched to {current.get('email') or account_id}")
+    print("New Claude sessions use this account. Already-open windows keep the previous one.")
+  return 0
+
+
+def cmd_add(as_json: bool) -> int:
+  with locked():
+    index = load_index()
+    live = identity_in(default_config_dir())
+    if live is not None:
+      index = upsert_account(index, live, active=True)
+    pending_add_path().write_text("")
+    os.chmod(pending_add_path(), 0o600)
+
+  new_id = "pending"
+  dest = isolated_dir(new_id)
+  if dest.exists():
+    shutil.rmtree(dest)
+  dest.mkdir(parents=True, exist_ok=True)
+  os.chmod(dest, 0o700)
+
+  source = default_config_dir()
+  settings = source / "settings.json"
+  if settings.is_file():
+    shutil.copy2(settings, dest / "settings.json")
+
+  env = os.environ.copy()
+  env["CLAUDE_CONFIG_DIR"] = str(dest)
+  cmd = ["claude", "auth", "login", "--claudeai"]
+  try:
+    completed = subprocess.run(cmd, env=env, check=False)
+  except OSError as exc:
+    shutil.rmtree(dest, ignore_errors=True)
+    pending_add_path().unlink(missing_ok=True)
+    die(f"failed to launch claude auth login: {exc}")
+
+  if completed.returncode != 0:
+    shutil.rmtree(dest, ignore_errors=True)
+    pending_add_path().unlink(missing_ok=True)
+    die("claude auth login did not finish; previous account is unchanged")
+
+  with locked():
+    ident = identity_in(dest)
+    if ident is None:
+      shutil.rmtree(dest, ignore_errors=True)
+      pending_add_path().unlink(missing_ok=True)
+      die("login finished but no Claude session was found in the new config dir")
+    final = isolated_dir(ident["id"])
+    if final != dest:
+      if final.exists():
+        shutil.rmtree(final)
+      dest.rename(final)
+      ident["path"] = str(final)
+    else:
+      ident["path"] = str(dest)
+    index = load_index()
+    index = upsert_account(index, ident, active=True)
+    pending_add_path().unlink(missing_ok=True)
+    payload = public_index(index, ident)
+  refresh_usage()
+  if as_json:
+    emit(payload, True)
+  else:
+    print(f"Saved {ident.get('email') or ident['id']}")
+    print("New Claude sessions use this account. Already-open windows keep the previous one.")
+  return 0
+
+
+def notify_switched(meta: dict[str, Any]) -> None:
+  email = meta.get("email") or meta.get("label") or "Claude"
+  try:
+    subprocess.run(
+      [
+        "omarchy-notification-send",
+        "-g", "󰛄",
+        "--app-name", "Claude",
+        "Switched Claude account",
+        email,
+      ],
+      check=False,
+      stdout=subprocess.DEVNULL,
+      stderr=subprocess.DEVNULL,
+    )
+  except OSError:
+    pass
+
+
+def refresh_usage() -> None:
+  try:
+    subprocess.run(
+      ["omarchy-agent-usage-update", "--force", "claude"],
+      check=False,
+      stdout=subprocess.DEVNULL,
+      stderr=subprocess.DEVNULL,
+    )
+  except OSError:
+    pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(prog="omarchy-agent-account-claude")
+  parser.add_argument("--json", action="store_true")
+  sub = parser.add_subparsers(dest="command", required=True)
+  for name in ("list", "dir", "current", "add"):
+    p = sub.add_parser(name)
+    p.add_argument("--json", action="store_true")
+  use = sub.add_parser("use")
+  use.add_argument("id")
+  use.add_argument("--json", action="store_true")
+  return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+  parser = build_parser()
+  args = parser.parse_args(argv)
+  as_json = bool(getattr(args, "json", False))
+  if args.command == "list":
+    return cmd_list(as_json)
+  if args.command == "dir":
+    return cmd_dir()
+  if args.command == "current":
+    return cmd_current(as_json)
+  if args.command == "use":
+    return cmd_use(args.id, as_json)
+  if args.command == "add":
+    return cmd_add(as_json)
+  parser.print_help()
+  return 2
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/bin/omarchy-agent-account-claude
+++ b/bin/omarchy-agent-account-claude
@@ -5,8 +5,9 @@
 """Isolated Claude Code accounts behind a pointer file.
 
 Each extra login gets its own CLAUDE_CONFIG_DIR. Switching writes the active
-id; it does not copy OAuth into ~/.claude. The default ~/.claude directory
-can itself be a registered account so the first login does not move.
+id and points ~/.claude/.credentials.json at that account's credentials so
+Hermes (which hardcodes that path) follows the chip. The rest of ~/.claude
+stays put.
 """
 
 from __future__ import annotations
@@ -52,6 +53,53 @@ def pending_add_path() -> Path:
 
 def isolated_dir(account_id: str) -> Path:
   return state_dir() / "accounts" / account_id
+
+
+def home_credentials_path() -> Path:
+  return Path.home() / ".claude" / ".credentials.json"
+
+
+def canonical_credentials_path(account_id: str) -> Path:
+  return isolated_dir(account_id) / ".credentials.json"
+
+
+def ensure_canonical_credentials(account_id: str, account_path: Path) -> Path | None:
+  dest = canonical_credentials_path(account_id)
+  dest.parent.mkdir(parents=True, exist_ok=True)
+  os.chmod(dest.parent, 0o700)
+  if dest.is_file() and not dest.is_symlink():
+    return dest
+  src = account_path / ".credentials.json"
+  if src.is_symlink():
+    try:
+      src = src.resolve()
+    except OSError:
+      return dest if dest.is_file() else None
+  if not src.is_file() or src == dest:
+    return dest if dest.is_file() else None
+  shutil.copy2(src, dest)
+  os.chmod(dest, 0o600)
+  return dest
+
+
+def point_home_credentials(account_id: str, account_path: Path) -> None:
+  canonical = ensure_canonical_credentials(account_id, account_path)
+  if canonical is None or not canonical.is_file():
+    return
+  home = home_credentials_path()
+  home.parent.mkdir(parents=True, exist_ok=True)
+  try:
+    if home.is_symlink() and home.resolve() == canonical.resolve():
+      return
+  except OSError:
+    pass
+  tmp = home.parent / ".credentials.json.linktmp"
+  try:
+    tmp.unlink()
+  except FileNotFoundError:
+    pass
+  tmp.symlink_to(canonical)
+  os.replace(tmp, home)
 
 
 def die(message: str, code: int = 1) -> None:
@@ -263,6 +311,11 @@ def cmd_list(as_json: bool) -> int:
       if live is not None:
         index = upsert_account(index, live, active=True)
       payload = public_index(index, live)
+    current = payload.get("current") or {}
+    current_id = str(current.get("id") or "")
+    current_path = str(current.get("path") or "")
+    if current_id and current_path:
+      point_home_credentials(current_id, expand_path(current_path))
   emit(payload, as_json)
   return 0
 
@@ -301,6 +354,7 @@ def cmd_use(account_id: str, as_json: bool) -> int:
       die(f"no saved Claude account '{account_id}'")
     index["activeId"] = account_id
     write_index(index)
+    point_home_credentials(account_id, expand_path(str(match["path"])))
     payload = public_index(index, identity_in(expand_path(str(match["path"]))))
   notify_switched(payload.get("current") or {})
   refresh_usage()
@@ -365,6 +419,7 @@ def cmd_add(as_json: bool) -> int:
       ident["path"] = str(dest)
     index = load_index()
     index = upsert_account(index, ident, active=True)
+    point_home_credentials(ident["id"], expand_path(ident["path"]))
     pending_add_path().unlink(missing_ok=True)
     payload = public_index(index, ident)
   refresh_usage()
@@ -396,10 +451,17 @@ def notify_switched(meta: dict[str, Any]) -> None:
 
 
 def refresh_usage() -> None:
+  env = os.environ.copy()
+  path = active_path(load_index())
+  if path is not None:
+    env["CLAUDE_CONFIG_DIR"] = str(path)
+  updater = Path(os.environ.get("OMARCHY_PATH") or "/usr/share/omarchy") / "bin" / "omarchy-agent-usage-update"
+  command = [str(updater) if updater.is_file() else "omarchy-agent-usage-update", "--force", "claude"]
   try:
     subprocess.run(
-      ["omarchy-agent-usage-update", "--force", "claude"],
+      command,
       check=False,
+      env=env,
       stdout=subprocess.DEVNULL,
       stderr=subprocess.DEVNULL,
     )

--- a/bin/omarchy-agent-account-claude
+++ b/bin/omarchy-agent-account-claude
@@ -5,9 +5,10 @@
 """Isolated Claude Code accounts behind a pointer file.
 
 Each extra login gets its own CLAUDE_CONFIG_DIR. Switching writes the active
-id and points ~/.claude/.credentials.json at that account's credentials so
-Hermes (which hardcodes that path) follows the chip. The rest of ~/.claude
-stays put.
+id and copies that account's credentials onto ~/.claude/.credentials.json so
+Hermes (which hardcodes that path) follows the chip. Live credentials are a
+regular file, not a symlink onto the saved copy. The rest of ~/.claude stays
+put.
 """
 
 from __future__ import annotations
@@ -63,43 +64,8 @@ def canonical_credentials_path(account_id: str) -> Path:
   return isolated_dir(account_id) / ".credentials.json"
 
 
-def ensure_canonical_credentials(account_id: str, account_path: Path) -> Path | None:
-  dest = canonical_credentials_path(account_id)
-  dest.parent.mkdir(parents=True, exist_ok=True)
-  os.chmod(dest.parent, 0o700)
-  if dest.is_file() and not dest.is_symlink():
-    return dest
-  src = account_path / ".credentials.json"
-  if src.is_symlink():
-    try:
-      src = src.resolve()
-    except OSError:
-      return dest if dest.is_file() else None
-  if not src.is_file() or src == dest:
-    return dest if dest.is_file() else None
-  shutil.copy2(src, dest)
-  os.chmod(dest, 0o600)
-  return dest
-
-
-def point_home_credentials(account_id: str, account_path: Path) -> None:
-  canonical = ensure_canonical_credentials(account_id, account_path)
-  if canonical is None or not canonical.is_file():
-    return
-  home = home_credentials_path()
-  home.parent.mkdir(parents=True, exist_ok=True)
-  try:
-    if home.is_symlink() and home.resolve() == canonical.resolve():
-      return
-  except OSError:
-    pass
-  tmp = home.parent / ".credentials.json.linktmp"
-  try:
-    tmp.unlink()
-  except FileNotFoundError:
-    pass
-  tmp.symlink_to(canonical)
-  os.replace(tmp, home)
+def last_good_credentials_path(account_id: str) -> Path:
+  return isolated_dir(account_id) / ".credentials.last-good.json"
 
 
 def die(message: str, code: int = 1) -> None:
@@ -137,6 +103,100 @@ def atomic_write(path: Path, data: Any, mode: int = 0o600) -> None:
 def tempfile_path(path: Path) -> tuple[int, str]:
   fd, tmp = tempfile.mkstemp(prefix="." + path.name + ".", dir=str(path.parent))
   return fd, tmp
+
+
+def oauth_tokens_present(data: dict[str, Any]) -> bool:
+  oauth = data.get("claudeAiOauth")
+  if not isinstance(oauth, dict):
+    return False
+  return bool(str(oauth.get("accessToken") or "").strip() and str(oauth.get("refreshToken") or "").strip())
+
+
+def remember_good_credentials(account_id: str, data: dict[str, Any]) -> None:
+  # Do not save empty OAuth over last-good.
+  if not oauth_tokens_present(data):
+    return
+  atomic_write(last_good_credentials_path(account_id), data, 0o600)
+
+
+def restore_canonical_if_blank(account_id: str) -> Path | None:
+  dest = canonical_credentials_path(account_id)
+  dest.parent.mkdir(parents=True, exist_ok=True)
+  os.chmod(dest.parent, 0o700)
+  current = read_json(dest)
+  if oauth_tokens_present(current):
+    remember_good_credentials(account_id, current)
+    return dest
+  good = read_json(last_good_credentials_path(account_id))
+  if oauth_tokens_present(good):
+    atomic_write(dest, good, 0o600)
+    return dest
+  return dest if dest.is_file() else None
+
+
+def harvest_home_into_owner(index: dict[str, Any] | None = None) -> None:
+  home = home_credentials_path()
+  data = read_json(home)
+  if not oauth_tokens_present(data):
+    return
+  owner_id = ""
+  rows = (index or load_index()).get("accounts") or []
+  if home.is_symlink():
+    try:
+      target = home.resolve()
+    except OSError:
+      target = None
+    if target is not None:
+      for row in rows:
+        account_id = str(row.get("id") or "")
+        if account_id and canonical_credentials_path(account_id).resolve() == target:
+          owner_id = account_id
+          break
+  else:
+    owner_id = str((index or load_index()).get("activeId") or "")
+  if not owner_id:
+    return
+  remember_good_credentials(owner_id, data)
+  dest = canonical_credentials_path(owner_id)
+  if not oauth_tokens_present(read_json(dest)):
+    atomic_write(dest, data, 0o600)
+
+
+def ensure_canonical_credentials(account_id: str, account_path: Path) -> Path | None:
+  dest = restore_canonical_if_blank(account_id) or canonical_credentials_path(account_id)
+  dest.parent.mkdir(parents=True, exist_ok=True)
+  os.chmod(dest.parent, 0o700)
+  if oauth_tokens_present(read_json(dest)):
+    return dest
+  src = account_path / ".credentials.json"
+  if src.is_symlink():
+    try:
+      src = src.resolve()
+    except OSError:
+      return dest
+  if not src.is_file() or src == dest:
+    return dest
+  data = read_json(src)
+  if not oauth_tokens_present(data):
+    return dest
+  shutil.copy2(src, dest)
+  os.chmod(dest, 0o600)
+  remember_good_credentials(account_id, data)
+  return dest
+
+
+def point_home_credentials(account_id: str, account_path: Path, index: dict[str, Any] | None = None) -> None:
+  harvest_home_into_owner(index)
+  canonical = ensure_canonical_credentials(account_id, account_path)
+  if canonical is None or not canonical.is_file():
+    return
+  data = read_json(canonical)
+  home = home_credentials_path()
+  home.parent.mkdir(parents=True, exist_ok=True)
+  # Do not symlink live credentials onto canonical.
+  if home.is_symlink():
+    home.unlink()
+  atomic_write(home, data, 0o600)
 
 
 def ensure_state() -> None:
@@ -315,7 +375,7 @@ def cmd_list(as_json: bool) -> int:
     current_id = str(current.get("id") or "")
     current_path = str(current.get("path") or "")
     if current_id and current_path:
-      point_home_credentials(current_id, expand_path(current_path))
+      point_home_credentials(current_id, expand_path(current_path), index)
   emit(payload, as_json)
   return 0
 
@@ -352,9 +412,10 @@ def cmd_use(account_id: str, as_json: bool) -> int:
     match = next((row for row in index["accounts"] if str(row.get("id")) == account_id), None)
     if match is None:
       die(f"no saved Claude account '{account_id}'")
+    harvest_home_into_owner(index)
     index["activeId"] = account_id
     write_index(index)
-    point_home_credentials(account_id, expand_path(str(match["path"])))
+    point_home_credentials(account_id, expand_path(str(match["path"])), index)
     payload = public_index(index, identity_in(expand_path(str(match["path"]))))
   notify_switched(payload.get("current") or {})
   refresh_usage()

--- a/bin/omarchy-agent-account-claude
+++ b/bin/omarchy-agent-account-claude
@@ -185,8 +185,7 @@ def ensure_canonical_credentials(account_id: str, account_path: Path) -> Path | 
   return dest
 
 
-def point_home_credentials(account_id: str, account_path: Path, index: dict[str, Any] | None = None) -> None:
-  harvest_home_into_owner(index)
+def install_home_credentials(account_id: str, account_path: Path) -> None:
   canonical = ensure_canonical_credentials(account_id, account_path)
   if canonical is None or not canonical.is_file():
     return
@@ -197,6 +196,11 @@ def point_home_credentials(account_id: str, account_path: Path, index: dict[str,
   if home.is_symlink():
     home.unlink()
   atomic_write(home, data, 0o600)
+
+
+def point_home_credentials(account_id: str, account_path: Path, index: dict[str, Any] | None = None) -> None:
+  harvest_home_into_owner(index)
+  install_home_credentials(account_id, account_path)
 
 
 def ensure_state() -> None:
@@ -287,6 +291,10 @@ def write_index(index: dict[str, Any]) -> None:
 
 
 def upsert_account(index: dict[str, Any], ident: dict[str, Any], active: bool) -> dict[str, Any]:
+  existing = next((a for a in index["accounts"] if str(a.get("id")) == ident["id"]), None)
+  path = ident["path"]
+  if existing and existing.get("path"):
+    path = str(existing["path"])
   accounts = [a for a in index["accounts"] if str(a.get("id")) != ident["id"]]
   accounts.append({
     "id": ident["id"],
@@ -294,7 +302,7 @@ def upsert_account(index: dict[str, Any], ident: dict[str, Any], active: bool) -
     "label": ident.get("label") or ident.get("email") or ident["id"],
     "plan": ident.get("plan") or "",
     "organization": ident.get("organization") or "",
-    "path": ident["path"],
+    "path": path,
   })
   accounts.sort(key=lambda row: str(row.get("email") or row.get("id")).lower())
   index["accounts"] = accounts
@@ -369,7 +377,8 @@ def cmd_list(as_json: bool) -> int:
       live_dir = active_path(index) or default_config_dir()
       live = identity_in(live_dir)
       if live is not None:
-        index = upsert_account(index, live, active=True)
+        known = any(str(a.get("id")) == live["id"] for a in index["accounts"])
+        index = upsert_account(index, live, active=not known and not index.get("activeId"))
       payload = public_index(index, live)
     current = payload.get("current") or {}
     current_id = str(current.get("id") or "")
@@ -415,7 +424,7 @@ def cmd_use(account_id: str, as_json: bool) -> int:
     harvest_home_into_owner(index)
     index["activeId"] = account_id
     write_index(index)
-    point_home_credentials(account_id, expand_path(str(match["path"])), index)
+    install_home_credentials(account_id, expand_path(str(match["path"])))
     payload = public_index(index, identity_in(expand_path(str(match["path"]))))
   notify_switched(payload.get("current") or {})
   refresh_usage()

--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -37,8 +37,34 @@ USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage"
 PROBE_MIN_INTERVAL_SECONDS = 15
 
 
+def account_pointer_dir() -> Path | None:
+  root = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state"))
+  index_path = root / "omarchy" / "agent-accounts" / "claude" / "index.json"
+  if not index_path.is_file():
+    return None
+  try:
+    data = json.loads(index_path.read_text())
+  except (OSError, json.JSONDecodeError):
+    return None
+  if not isinstance(data, dict):
+    return None
+  active_id = str(data.get("activeId") or "")
+  for row in data.get("accounts") or []:
+    if isinstance(row, dict) and str(row.get("id") or "") == active_id:
+      path = str(row.get("path") or "")
+      if path:
+        return expand_path(path)
+  return None
+
+
 def config_dir() -> Path:
-  return expand_path(os.environ.get("CLAUDE_CONFIG_DIR") or "~/.claude")
+  pointed = os.environ.get("CLAUDE_CONFIG_DIR")
+  if pointed:
+    return expand_path(pointed)
+  active = account_pointer_dir()
+  if active is not None:
+    return active
+  return expand_path("~/.claude")
 
 
 def expand_path(value: str) -> Path:

--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -22,6 +22,7 @@ import json
 import os
 import re
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import time
@@ -817,13 +818,14 @@ def usable_cached_limits(cached: dict[str, Any]) -> list[dict[str, Any]]:
   return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
 
 
-def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[str, Any]:
+def collect_limits(access_token: str, expires_at_ms: int, force: bool, claude_dir: Path) -> dict[str, Any]:
   result = {"limits": [], "usageStatusText": "", "authHelpText": AUTH_HELP}
 
   # A panel that is opened and shut repeatedly must not turn into a request
   # per flick, so recent probe results are reused for a short window — and
   # kept as the answer of record when a later probe fails.
-  probe_cache = cache_root() / "claude-limits.json"
+  digest = hashlib.sha1(str(claude_dir).encode("utf-8")).hexdigest()[:16]
+  probe_cache = cache_root() / f"claude-limits-{digest}.json"
   cached = read_fresh_json(probe_cache, float("inf")) or {}
   fallback = usable_cached_limits(cached)
 
@@ -875,6 +877,88 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
 # -------------------------------------------------------------------- record
 
 
+def notify_state_path() -> Path:
+  root = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")) / "omarchy" / "agents"
+  root.mkdir(parents=True, exist_ok=True)
+  return root / "limit-notified.json"
+
+
+def other_claude_logins() -> list[str]:
+  helper = Path(os.environ.get("OMARCHY_PATH") or "/usr/share/omarchy") / "bin" / "omarchy-agent-account"
+  cmd = [str(helper) if helper.is_file() else "omarchy-agent-account", "list", "--json"]
+  try:
+    raw = subprocess.check_output(cmd, text=True, timeout=8)
+    data = json.loads(raw)
+  except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+    return []
+  if not isinstance(data, dict):
+    return []
+  active = str(data.get("activeId") or "")
+  emails = []
+  for row in data.get("accounts") or []:
+    if not isinstance(row, dict):
+      continue
+    account_id = str(row.get("id") or "")
+    if not account_id or account_id == active:
+      continue
+    emails.append(str(row.get("email") or row.get("label") or account_id))
+  return emails
+
+
+def notify_exhausted(plan: str, limits: list[Any]) -> None:
+  if os.environ.get("OMARCHY_AGENT_USAGE_NOTIFY") == "0":
+    return
+  spent = []
+  for entry in limits:
+    if not isinstance(entry, dict):
+      continue
+    if number(entry.get("percent")) < 1:
+      continue
+    label = str(entry.get("title") or entry.get("label") or "limit")
+    spent.append((label, str(entry.get("resetsAt") or "")))
+  if not spent:
+    return
+  path = notify_state_path()
+  previous = read_fresh_json(path, float("inf")) or {}
+  last = previous.get("claude") if isinstance(previous.get("claude"), dict) else {}
+  fresh = []
+  remembered = dict(last)
+  for label, resets_at in spent:
+    if last.get(label) == resets_at and resets_at != "":
+      continue
+    fresh.append(label)
+    remembered[label] = resets_at
+  if not fresh:
+    return
+  others = other_claude_logins()
+  who = plan.strip() or "Claude"
+  windows = ", ".join(fresh)
+  headline = f"{who} {windows} used up"
+  if others:
+    body = "Another Claude login is saved. Switch from the agents icon."
+  else:
+    body = "No other Claude login is saved on this machine."
+  try:
+    subprocess.run(
+      [
+        "omarchy-notification-send",
+        "--app-name", "Claude",
+        "-g", "󰀦",
+        "-u", "normal",
+        headline,
+        body,
+        "--exec", "omarchy-shell", "-q", "omarchy.agents", "open",
+      ],
+      check=False,
+      stdout=subprocess.DEVNULL,
+      stderr=subprocess.DEVNULL,
+      timeout=8,
+    )
+  except (OSError, subprocess.TimeoutExpired):
+    return
+  write_json(path, {"claude": remembered})
+
+
 def main() -> int:
   parser = argparse.ArgumentParser()
   parser.add_argument("--force", action="store_true", help="rescan transcripts and re-probe limits, ignoring caches")
@@ -906,7 +990,7 @@ def main() -> int:
     stats = merge_stats(stats, opencode)
 
   access_token, expires_at_ms, plan = oauth_login(claude_dir)
-  limits = collect_limits(access_token, expires_at_ms, args.force)
+  limits = collect_limits(access_token, expires_at_ms, args.force, claude_dir)
 
   record = {
     "schemaVersion": 1,
@@ -923,6 +1007,10 @@ def main() -> int:
   if limits.get("retryAdvised"):
     record["retryAdvised"] = True
   record.update(stats)
+  try:
+    notify_exhausted(str(plan or ""), limits["limits"])
+  except Exception:
+    pass
   print(json.dumps(record, separators=(",", ":"), sort_keys=True))
   return 0
 

--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -755,7 +755,7 @@ def probe_limits(access_token: str) -> dict[str, Any]:
       ) + ". Local Claude Code stats are still shown."
     else:
       help_text = f"Anthropic's usage endpoint returned status {error.code}. Local Claude Code stats are still shown."
-    return {"ok": False, "helpText": help_text}
+    return {"ok": False, "http": error.code, "helpText": help_text}
   except Exception:
     # A transport failure reached no server at all — no route, no DNS. Any
     # real answer, including an error status, is a server we should stop
@@ -818,7 +818,7 @@ def usable_cached_limits(cached: dict[str, Any]) -> list[dict[str, Any]]:
   return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
 
 
-def collect_limits(access_token: str, expires_at_ms: int, force: bool, claude_dir: Path) -> dict[str, Any]:
+def collect_limits(access_token: str, _expires_at_ms: int, force: bool, claude_dir: Path) -> dict[str, Any]:
   result = {"limits": [], "usageStatusText": "", "authHelpText": AUTH_HELP}
 
   # A panel that is opened and shut repeatedly must not turn into a request
@@ -829,23 +829,10 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool, claude_di
   cached = read_fresh_json(probe_cache, float("inf")) or {}
   fallback = usable_cached_limits(cached)
 
-  # Probing needs a live token and only the Claude Code CLI can mint one: it
-  # refreshes the credential file when it runs, so a machine left alone long
-  # enough finds the saved token lapsed. Say so — an empty limits list with
-  # nothing else set hides the whole section and explains nothing — and keep
-  # showing the last numbers whose window has not since reset.
+  # An empty token is a missing login. A past expiresAt is not.
   if access_token == "":
     result["limits"] = fallback
     result["usageStatusText"] = "Waiting for auth"
-    return result
-  if expires_at_ms > 0 and expires_at_ms <= time.time() * 1000:
-    result["limits"] = fallback
-    result["usageStatusText"] = "Sign-in expired"
-    result["authHelpText"] = (
-      "Claude Code's saved sign-in expired"
-      + (" — showing the last known limits." if fallback else ".")
-      + " Start Claude Code, or run `claude auth login`, to refresh it."
-    )
     return result
 
   # --force is a person asking for fresh numbers, so it skips the reuse window
@@ -860,6 +847,16 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool, claude_di
   if probe["ok"]:
     result["limits"] = probe["limits"]
     write_json(probe_cache, {"fetchedAtMs": round(time.time() * 1000), "limits": probe["limits"]})
+    return result
+
+  if probe.get("http") in (401, 403):
+    result["limits"] = fallback
+    result["usageStatusText"] = "Sign-in expired"
+    result["authHelpText"] = (
+      "Claude Code's saved sign-in expired"
+      + (" — showing the last known limits." if fallback else ".")
+      + " Start Claude Code, or run `claude auth login`, to refresh it."
+    )
     return result
 
   # The first probe after login often fires before DHCP has handed out a

--- a/shell/plugins/agents/Accounts.qml
+++ b/shell/plugins/agents/Accounts.qml
@@ -1,0 +1,116 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+Item {
+  id: root
+  visible: false
+
+  property var accounts: []
+  property var current: null
+  property var live: null
+  property string errorText: ""
+  property bool switching: false
+  property bool ready: false
+
+  readonly property string home: Quickshell.env("HOME") || ""
+  readonly property string indexPath: (Quickshell.env("XDG_STATE_HOME") || home + "/.local/state")
+    + "/omarchy/agent-accounts/claude/index.json"
+  readonly property string currentId: current && current.id ? String(current.id) : ""
+  readonly property string currentEmail: current && current.email ? String(current.email) : ""
+  readonly property string liveId: live && live.id ? String(live.id) : ""
+
+  signal switched()
+
+  FileView {
+    path: root.indexPath
+    watchChanges: true
+    printErrors: false
+    onFileChanged: reload()
+    onLoaded: root.applyIndex(text())
+    onLoadFailed: if (!root.ready) root.sync()
+  }
+
+  Process {
+    id: listProcess
+    running: false
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.applyIndex(text)
+    }
+    stderr: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: if (text.trim() !== "") root.errorText = text.trim()
+    }
+  }
+
+  Process {
+    id: useProcess
+    running: false
+    onExited: {
+      root.switching = false
+      root.sync()
+      root.switched()
+    }
+    stderr: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: if (text.trim() !== "") root.errorText = text.trim()
+    }
+  }
+
+  function applyIndex(raw) {
+    var parsed
+    try { parsed = JSON.parse(String(raw || "")) } catch (e) { parsed = null }
+    if (!parsed || typeof parsed !== "object") return
+    var rows = Array.isArray(parsed.accounts) ? parsed.accounts : []
+    var activeId = String(parsed.activeId || (parsed.current && parsed.current.id) || "")
+    var out = []
+    var seen = {}
+    for (var i = 0; i < rows.length; i++) {
+      var row = rows[i] || {}
+      var id = String(row.id || "")
+      if (id === "" || seen[id]) continue
+      seen[id] = true
+      var active = row.active === true || (activeId !== "" && id === activeId)
+      out.push({
+        id: id,
+        email: String(row.email || row.label || id),
+        label: String(row.email || row.label || id),
+        plan: String(row.plan || ""),
+        organization: String(row.organization || ""),
+        active: active
+      })
+    }
+    root.accounts = out
+    var selected = out.filter(function(item) { return item.active })[0] || null
+    root.current = selected
+    root.live = parsed.live && typeof parsed.live === "object" ? parsed.live : null
+    root.ready = true
+    root.errorText = ""
+  }
+
+  function sync() {
+    if (listProcess.running) return
+    listProcess.command = ["omarchy-agent-account", "list", "--json"]
+    listProcess.running = true
+  }
+
+  function use(id) {
+    var accountId = String(id || "")
+    if (accountId === "" || root.switching) return
+    if (root.currentId === accountId && root.liveId === accountId) return
+    root.switching = true
+    root.errorText = ""
+    useProcess.command = ["omarchy-agent-account", "use", "claude", accountId]
+    useProcess.running = true
+  }
+
+  function addAccount() {
+    Quickshell.execDetached([
+      "bash", "-lc",
+      "omarchy-shell -q omarchy.agents close; sleep 0.2; exec omarchy-launch-tui --app-id=TUI.float omarchy-agent-account add claude"
+    ])
+  }
+
+  Component.onCompleted: sync()
+}

--- a/shell/plugins/agents/Agent.qml
+++ b/shell/plugins/agents/Agent.qml
@@ -14,12 +14,17 @@ Item {
   property var record: null
 
   FileView {
+    id: view
     path: root.path
     watchChanges: true
     printErrors: false
     onFileChanged: reload()
     onLoaded: root.parse(text())
     onLoadFailed: root.record = null
+  }
+
+  function reloadFromDisk() {
+    view.reload()
   }
 
   function parse(content) {

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -74,6 +74,14 @@ Item {
     recordsChanged()
   }
 
+  function reloadAgentRecords() {
+    for (var i = 0; i < agentInstantiator.count; i++) {
+      var agent = agentInstantiator.objectAt(i)
+      if (agent && agent.reloadFromDisk) agent.reloadFromDisk()
+    }
+    recordsChanged()
+  }
+
   function recordsChanged() {
     dataRevision++
     scheduleLimitsRetry()
@@ -130,6 +138,7 @@ Item {
     running: false
     onExited: {
       root.rescanAgents()
+      root.reloadAgentRecords()
       if (root.pendingUpdateKind !== "") {
         var kind = root.pendingUpdateKind
         root.pendingUpdateKind = ""
@@ -217,6 +226,7 @@ Item {
   // All-time keeps a quiet day from hiding an agent; today's counts admit a
   // machine whose only source is history.jsonl, which knows nothing older.
   function providerHasData(p) {
+    if (String(p.providerId) === "claude") return true
     return numberValue(p.totalPrompts) > 0 || numberValue(p.totalSessions) > 0
       || numberValue(p.activeDays) > 0 || numberValue(p.todayPrompts) > 0
       || numberValue(p.todaySessions) > 0 || (p.limits && p.limits.length > 0)

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -64,6 +64,29 @@ Panel {
     root.close()
   }
 
+  readonly property string activeProviderId: selectedProviderId !== ""
+    ? selectedProviderId
+    : (provider ? String(provider.providerId) : "")
+
+  function accountChipLabel(account) {
+    if (!account) return ""
+    return String(account.email || account.label || account.id || "")
+  }
+
+  function accountChipTooltip(account) {
+    if (!account) return ""
+    var parts = []
+    if (account.plan) parts.push(account.plan)
+    if (account.organization && account.organization !== account.email)
+      parts.push(account.organization)
+    return parts.join(" · ")
+  }
+
+  function addClaudeAccount() {
+    root.close()
+    claudeAccounts.addAccount()
+  }
+
   // ---------------------------------------------------------------- limits
   //
   // Both providers report the same two shapes: a short rolling session window
@@ -307,12 +330,18 @@ Panel {
     nowMs = Date.now()
     if (panelFlick) panelFlick.contentY = 0
     usage.refreshLimits()
+    claudeAccounts.sync()
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
 
   Main {
     id: usage
     settings: root.settings
+  }
+
+  Accounts {
+    id: claudeAccounts
+    onSwitched: root.refreshNow()
   }
 
   // Cheap enough to keep running: it only re-evaluates text bindings, and a
@@ -491,6 +520,72 @@ Panel {
                 }
                 onHovered: function(isHovered) { if (isHovered) root.cursorActive = true }
               }
+            }
+          }
+
+          Column {
+            id: accountSection
+            visible: root.activeProviderId === "claude"
+            width: parent.width
+            spacing: Style.space(4)
+
+            Item {
+              width: parent.width
+              implicitHeight: Math.max(accountFlow.implicitHeight, addAccountBtn.implicitHeight)
+              opacity: claudeAccounts.switching ? 0.55 : 1.0
+
+              Flow {
+                id: accountFlow
+                anchors.left: parent.left
+                anchors.right: addAccountBtn.left
+                anchors.rightMargin: Style.space(8)
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Style.spacing.sm
+
+                Repeater {
+                  model: claudeAccounts.accounts
+
+                  Button {
+                    required property var modelData
+
+                    text: root.accountChipLabel(modelData)
+                    tooltipText: root.accountChipTooltip(modelData)
+                    selected: modelData.active === true
+                    hasCursor: false
+                    bordered: true
+                    enabled: !claudeAccounts.switching
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                    fontSize: Style.font.caption
+                    verticalPadding: Style.space(4)
+                    horizontalPadding: Style.space(8)
+                    onClicked: claudeAccounts.use(modelData.id)
+                  }
+                }
+              }
+
+              PanelActionButton {
+                id: addAccountBtn
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                iconText: "+"
+                tooltipText: "Add another Claude account"
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                enabled: !claudeAccounts.switching
+                onClicked: root.addClaudeAccount()
+              }
+            }
+
+            Text {
+              visible: claudeAccounts.errorText !== ""
+              width: parent.width
+              textFormat: Text.PlainText
+              text: claudeAccounts.errorText
+              color: root.urgent
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              wrapMode: Text.WordWrap
             }
           }
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -13,6 +13,9 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
   Auth and endpoint problems replace the plan line and repeat in a card.
 - **Subscription switch** — one chip per enabled agent (`h`/`l` or click).
   It appears only when more than one agent is enabled.
+- **Claude accounts** — on the Claude tab, email chips from
+  `omarchy agent account`. Switching writes a `CLAUDE_CONFIG_DIR` pointer;
+  it does not copy OAuth into `~/.claude`. `+` adds another isolated login.
 - **Limits** — the percentage of each allowance used, a matching meter, and
   the time until the session or weekly window resets.
 - **Balance** — prepaid agents report a credit ledger instead of limits:

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -15,10 +15,11 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
   It appears only when more than one agent is enabled.
 - **Claude accounts** — on the Claude tab, email chips from
   `omarchy agent account`. Switching writes a `CLAUDE_CONFIG_DIR` pointer and
-  points `~/.claude/.credentials.json` at that login so tools that hardcode
-  that path (Hermes) follow. The rest of `~/.claude` stays put. `+` adds
-  another isolated login. When a limit window hits 100%, a notification says
-  whether another login is saved.
+  copies the selected login onto `~/.claude/.credentials.json` as a regular
+  file so tools that hardcode that path follow. The saved copy is a different
+  file, so a live Claude blank does not destroy it. The rest of `~/.claude`
+  stays put. `+` adds another isolated login. When a limit window hits 100%, a
+  notification says whether another login is saved.
 - **Limits** — the percentage of each allowance used, a matching meter, and
   the time until the session or weekly window resets.
 - **Balance** — prepaid agents report a credit ledger instead of limits:

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -14,8 +14,11 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
 - **Subscription switch** — one chip per enabled agent (`h`/`l` or click).
   It appears only when more than one agent is enabled.
 - **Claude accounts** — on the Claude tab, email chips from
-  `omarchy agent account`. Switching writes a `CLAUDE_CONFIG_DIR` pointer;
-  it does not copy OAuth into `~/.claude`. `+` adds another isolated login.
+  `omarchy agent account`. Switching writes a `CLAUDE_CONFIG_DIR` pointer and
+  points `~/.claude/.credentials.json` at that login so tools that hardcode
+  that path (Hermes) follow. The rest of `~/.claude` stays put. `+` adds
+  another isolated login. When a limit window hits 100%, a notification says
+  whether another login is saved.
 - **Limits** — the percentage of each allowance used, a matching meter, and
   the time until the session or weekly window resets.
 - **Balance** — prepaid agents report a credit ledger instead of limits:

--- a/test/shell.d/agent-account-claude-test.sh
+++ b/test/shell.d/agent-account-claude-test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command python3
+require_command jq
+
+TEST_HOME=$(mktemp -d)
+mock_bin="$TEST_HOME/mock-bin"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$mock_bin" "$TEST_HOME/.claude"
+
+cat >"$mock_bin/omarchy-agent-usage-update" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat >"$mock_bin/omarchy-notification-send" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat >"$mock_bin/claude" <<'EOF'
+#!/bin/bash
+if [[ $1 == auth && $2 == login ]]; then
+  mkdir -p "$CLAUDE_CONFIG_DIR"
+  cat >"$CLAUDE_CONFIG_DIR/.claude.json" <<'JSON'
+{"oauthAccount":{"emailAddress":"work@example.com","accountUuid":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","displayName":"Work","organizationName":"Work Org","organizationType":"max","organizationRateLimitTier":"default_claude_max_5x"}}
+JSON
+  cat >"$CLAUDE_CONFIG_DIR/.credentials.json" <<'JSON'
+{"claudeAiOauth":{"accessToken":"work-token","refreshToken":"work-refresh","subscriptionType":"max","rateLimitTier":"default_claude_max_5x"}}
+JSON
+  exit 0
+fi
+exit 1
+EOF
+
+chmod +x "$mock_bin"/*
+
+export HOME="$TEST_HOME"
+export XDG_STATE_HOME="$TEST_HOME/.local/state"
+export OMARCHY_PATH="$ROOT"
+export PATH="$mock_bin:$ROOT/bin:$PATH"
+
+cat >"$HOME/.claude/.claude.json" <<'JSON'
+{"oauthAccount":{"emailAddress":"personal@example.com","accountUuid":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","displayName":"Personal","organizationName":"Personal Org","organizationType":"max","organizationRateLimitTier":"default_claude_max_20x"}}
+JSON
+cat >"$HOME/.claude/.credentials.json" <<'JSON'
+{"claudeAiOauth":{"accessToken":"personal-token","refreshToken":"personal-refresh","subscriptionType":"max","rateLimitTier":"default_claude_max_20x"}}
+JSON
+chmod 600 "$HOME/.claude/.credentials.json"
+
+listed=$(omarchy-agent-account list claude --json)
+[[ $(jq -r '.provider' <<<"$listed") == "claude" ]] || fail "list names the claude provider" "$listed"
+[[ $(jq -r '.accounts | length' <<<"$listed") == "1" ]] || fail "list registers the live ~/.claude login" "$listed"
+[[ $(jq -r '.accounts[0].email' <<<"$listed") == "personal@example.com" ]] || fail "list reports the live email" "$listed"
+[[ $(jq -r '.accounts[0].active' <<<"$listed") == "true" ]] || fail "the live login is the active account" "$listed"
+pass "list registers the live Claude login"
+
+personal_id=$(jq -r '.accounts[0].id' <<<"$listed")
+[[ $(omarchy-agent-account dir claude) == "$(python3 -c "from pathlib import Path; print(Path('$HOME/.claude').resolve())")" ]] ||
+  fail "dir points at ~/.claude for the first account"
+pass "dir points at ~/.claude for the first account"
+
+omarchy-agent-account add claude >/dev/null
+
+listed=$(omarchy-agent-account list --json)
+[[ $(jq -r '.accounts | length' <<<"$listed") == "2" ]] || fail "add registers a second isolated account" "$listed"
+[[ $(jq -r '.current.email' <<<"$listed") == "work@example.com" ]] || fail "add switches the pointer to the new account" "$listed"
+work_path=$(jq -r '.current.path' <<<"$listed")
+[[ $work_path == "$XDG_STATE_HOME/omarchy/agent-accounts/claude/accounts/"* ]] ||
+  fail "the new account lives under the state directory" "$work_path"
+[[ $(omarchy-agent-account dir claude) == "$work_path" ]] || fail "dir follows the pointer after add"
+pass "add creates an isolated Claude config dir and points at it"
+
+[[ -f $HOME/.claude/.credentials.json ]] || fail "add does not remove the original ~/.claude credentials"
+original_token=$(jq -r '.claudeAiOauth.accessToken' "$HOME/.claude/.credentials.json")
+[[ $original_token == "personal-token" ]] || fail "add does not copy over the original OAuth" "$original_token"
+pass "add leaves the original ~/.claude session in place"
+
+work_id=$(jq -r '.current.id' <<<"$listed")
+omarchy-agent-account use claude "$personal_id" >/dev/null
+[[ $(jq -r '.current.email' <<<"$(omarchy-agent-account list --json)") == "personal@example.com" ]] ||
+  fail "use switches the pointer back to the original account"
+[[ $(omarchy-agent-account dir claude) == "$(python3 -c "from pathlib import Path; print(Path('$HOME/.claude').resolve())")" ]] ||
+  fail "dir follows the pointer after use"
+[[ $(jq -r '.claudeAiOauth.accessToken' "$work_path/.credentials.json") == "work-token" ]] ||
+  fail "use does not rewrite the unused account's credentials"
+pass "use switches the pointer without copying OAuth"
+
+if omarchy-agent-account list codex >/dev/null 2>&1; then
+  fail "list refuses providers with no backend"
+fi
+pass "list refuses providers with no backend"
+
+omarchy-agent-account use "$work_id" >/dev/null
+[[ $(jq -r '.current.email' <<<"$(omarchy-agent-account list --json)") == "work@example.com" ]] ||
+  fail "use claude is implied when the provider is omitted"
+pass "use claude is implied when the provider is omitted"
+
+collector_dir=$(HOME="$TEST_HOME" XDG_STATE_HOME="$XDG_STATE_HOME" python3 - <<'PY'
+import importlib.machinery, importlib.util, os
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["OMARCHY_PATH"] + "/bin/omarchy-agent-usage-claude")
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+print(collector.config_dir())
+PY
+)
+[[ $collector_dir == "$work_path" ]] || fail "usage collector follows the account pointer" "$collector_dir"
+pass "usage collector follows the account pointer"

--- a/test/shell.d/agent-account-claude-test.sh
+++ b/test/shell.d/agent-account-claude-test.sh
@@ -90,6 +90,9 @@ pass "add leaves the original session saved and copies active credentials to ~/.
 
 work_id=$(jq -r '.current.id' <<<"$listed")
 omarchy-agent-account use claude "$personal_id" >/dev/null
+personal_good="$XDG_STATE_HOME/omarchy/agent-accounts/claude/accounts/$personal_id/.credentials.last-good.json"
+[[ $(jq -r '.claudeAiOauth.accessToken' "$personal_good") == "personal-token" ]] ||
+  fail "switching away does not harvest the old live tokens into the new account"
 [[ $(jq -r '.current.email' <<<"$(omarchy-agent-account list --json)") == "personal@example.com" ]] ||
   fail "use switches the pointer back to the original account"
 [[ $(omarchy-agent-account dir claude) == "$(python3 -c "from pathlib import Path; print(Path('$HOME/.claude').resolve())")" ]] ||
@@ -99,6 +102,11 @@ omarchy-agent-account use claude "$personal_id" >/dev/null
 [[ $(jq -r '.claudeAiOauth.accessToken' "$HOME/.claude/.credentials.json") == "personal-token" ]] ||
   fail "use copies the selected account onto ~/.claude"
 [[ ! -L $HOME/.claude/.credentials.json ]] || fail "use does not reintroduce a credentials symlink"
+work_listed=$(omarchy-agent-account list --json)
+[[ $(jq -r --arg id "$personal_id" '.accounts[] | select(.id==$id) | .path' <<<"$work_listed") == "$(python3 -c "from pathlib import Path; print(Path('$HOME/.claude').resolve())")" ]] ||
+  fail "list does not move the original account onto the isolated dir"
+[[ $(jq -r --arg id "$work_id" '.accounts[] | select(.id==$id) | .path' <<<"$work_listed") == "$work_path" ]] ||
+  fail "list keeps the isolated account on its own dir"
 pass "use switches the pointer without copying OAuth"
 
 if omarchy-agent-account list codex >/dev/null 2>&1; then
@@ -147,3 +155,15 @@ omarchy-agent-account use claude "$work_id" >/dev/null
 [[ $(jq -r '.claudeAiOauth.accessToken' "$HOME/.claude/.credentials.json") == "work-token" ]] ||
   fail "restored tokens are what live credentials follow"
 pass "use restores a blanked login without touching the other account"
+
+omarchy-agent-account use claude "$personal_id" >/dev/null
+rm -f "$XDG_STATE_HOME/omarchy/agent-accounts/claude/accounts/$work_id/.credentials.last-good.json"
+cat >"$work_path/.credentials.json" <<'JSON'
+{"claudeAiOauth":{"accessToken":"","refreshToken":"","expiresAt":0,"refreshTokenExpiresAt":1,"subscriptionType":"max","rateLimitTier":"default_claude_max_5x"}}
+JSON
+omarchy-agent-account use claude "$work_id" >/dev/null
+[[ $(jq -r '.claudeAiOauth.accessToken' "$work_path/.credentials.json") == "" ]] ||
+  fail "switching onto an empty saved login does not copy the previous live tokens into it"
+[[ $(jq -r '.claudeAiOauth.accessToken' "$personal_canon") == "personal-token" ]] ||
+  fail "an empty target does not steal the other account's saved tokens"
+pass "switching onto an empty saved login does not inherit the previous live tokens"

--- a/test/shell.d/agent-account-claude-test.sh
+++ b/test/shell.d/agent-account-claude-test.sh
@@ -81,10 +81,12 @@ personal_canon="$XDG_STATE_HOME/omarchy/agent-accounts/claude/accounts/$personal
 [[ -f $personal_canon ]] || fail "the original login keeps a canonical credentials file" "$personal_canon"
 original_token=$(jq -r '.claudeAiOauth.accessToken' "$personal_canon")
 [[ $original_token == "personal-token" ]] || fail "add does not copy over the original OAuth" "$original_token"
-[[ -L $HOME/.claude/.credentials.json ]] || fail "home credentials become a symlink to the active account"
-[[ $(readlink -f "$HOME/.claude/.credentials.json") == "$work_path/.credentials.json" ]] ||
-  fail "home credentials point at the new account after add"
-pass "add leaves the original session saved and points ~/.claude credentials at the active login"
+[[ ! -L $HOME/.claude/.credentials.json ]] || fail "home credentials are a regular file, not a symlink"
+[[ $(jq -r '.claudeAiOauth.accessToken' "$HOME/.claude/.credentials.json") == "work-token" ]] ||
+  fail "home credentials are a copy of the active account"
+[[ $(stat -c %i "$HOME/.claude/.credentials.json") != $(stat -c %i "$work_path/.credentials.json") ]] ||
+  fail "home credentials are not the same inode as the saved copy"
+pass "add leaves the original session saved and copies active credentials to ~/.claude"
 
 work_id=$(jq -r '.current.id' <<<"$listed")
 omarchy-agent-account use claude "$personal_id" >/dev/null
@@ -94,8 +96,9 @@ omarchy-agent-account use claude "$personal_id" >/dev/null
   fail "dir follows the pointer after use"
 [[ $(jq -r '.claudeAiOauth.accessToken' "$work_path/.credentials.json") == "work-token" ]] ||
   fail "use does not rewrite the unused account's credentials"
-[[ $(readlink -f "$HOME/.claude/.credentials.json") == "$personal_canon" ]] ||
-  fail "use points ~/.claude credentials at the selected account"
+[[ $(jq -r '.claudeAiOauth.accessToken' "$HOME/.claude/.credentials.json") == "personal-token" ]] ||
+  fail "use copies the selected account onto ~/.claude"
+[[ ! -L $HOME/.claude/.credentials.json ]] || fail "use does not reintroduce a credentials symlink"
 pass "use switches the pointer without copying OAuth"
 
 if omarchy-agent-account list codex >/dev/null 2>&1; then
@@ -119,3 +122,28 @@ PY
 )
 [[ $collector_dir == "$work_path" ]] || fail "usage collector follows the account pointer" "$collector_dir"
 pass "usage collector follows the account pointer"
+
+cat >"$HOME/.claude/.credentials.json" <<'JSON'
+{"claudeAiOauth":{"accessToken":"","refreshToken":"","expiresAt":0,"refreshTokenExpiresAt":1,"subscriptionType":"max","rateLimitTier":"default_claude_max_5x"}}
+JSON
+omarchy-agent-account list claude >/dev/null
+[[ $(jq -r '.claudeAiOauth.accessToken' "$work_path/.credentials.json") == "work-token" ]] ||
+  fail "blanking the live ~/.claude credentials does not wipe the saved copy"
+[[ $(jq -r '.claudeAiOauth.accessToken' "$HOME/.claude/.credentials.json") == "work-token" ]] ||
+  fail "list restores live credentials from the saved copy"
+pass "blanking live credentials does not destroy the saved login"
+
+cat >"$work_path/.credentials.json" <<'JSON'
+{"claudeAiOauth":{"accessToken":"","refreshToken":"","expiresAt":0,"refreshTokenExpiresAt":1,"subscriptionType":"max","rateLimitTier":"default_claude_max_5x"}}
+JSON
+omarchy-agent-account use claude "$personal_id" >/dev/null
+[[ $(jq -r '.claudeAiOauth.accessToken' "$personal_canon") == "personal-token" ]] ||
+  fail "blanking the active login does not overwrite the other account"
+[[ $(jq -r '.claudeAiOauth.accessToken' "$HOME/.claude/.credentials.json") == "personal-token" ]] ||
+  fail "use still points home at the account that still has tokens"
+omarchy-agent-account use claude "$work_id" >/dev/null
+[[ $(jq -r '.claudeAiOauth.accessToken' "$work_path/.credentials.json") == "work-token" ]] ||
+  fail "use restores a blanked login from last-good"
+[[ $(jq -r '.claudeAiOauth.accessToken' "$HOME/.claude/.credentials.json") == "work-token" ]] ||
+  fail "restored tokens are what live credentials follow"
+pass "use restores a blanked login without touching the other account"

--- a/test/shell.d/agent-account-claude-test.sh
+++ b/test/shell.d/agent-account-claude-test.sh
@@ -77,9 +77,14 @@ work_path=$(jq -r '.current.path' <<<"$listed")
 pass "add creates an isolated Claude config dir and points at it"
 
 [[ -f $HOME/.claude/.credentials.json ]] || fail "add does not remove the original ~/.claude credentials"
-original_token=$(jq -r '.claudeAiOauth.accessToken' "$HOME/.claude/.credentials.json")
+personal_canon="$XDG_STATE_HOME/omarchy/agent-accounts/claude/accounts/$personal_id/.credentials.json"
+[[ -f $personal_canon ]] || fail "the original login keeps a canonical credentials file" "$personal_canon"
+original_token=$(jq -r '.claudeAiOauth.accessToken' "$personal_canon")
 [[ $original_token == "personal-token" ]] || fail "add does not copy over the original OAuth" "$original_token"
-pass "add leaves the original ~/.claude session in place"
+[[ -L $HOME/.claude/.credentials.json ]] || fail "home credentials become a symlink to the active account"
+[[ $(readlink -f "$HOME/.claude/.credentials.json") == "$work_path/.credentials.json" ]] ||
+  fail "home credentials point at the new account after add"
+pass "add leaves the original session saved and points ~/.claude credentials at the active login"
 
 work_id=$(jq -r '.current.id' <<<"$listed")
 omarchy-agent-account use claude "$personal_id" >/dev/null
@@ -89,6 +94,8 @@ omarchy-agent-account use claude "$personal_id" >/dev/null
   fail "dir follows the pointer after use"
 [[ $(jq -r '.claudeAiOauth.accessToken' "$work_path/.credentials.json") == "work-token" ]] ||
   fail "use does not rewrite the unused account's credentials"
+[[ $(readlink -f "$HOME/.claude/.credentials.json") == "$personal_canon" ]] ||
+  fail "use points ~/.claude credentials at the selected account"
 pass "use switches the pointer without copying OAuth"
 
 if omarchy-agent-account list codex >/dev/null 2>&1; then

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -10,7 +10,7 @@ require_command python3
 # stands in for the response.
 read_limits() {
   COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" PAYLOAD="$1" python3 - <<'PY'
-import importlib.machinery, importlib.util, io, json, os
+import importlib.machinery, importlib.util, io, json, os, pathlib
 
 loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -89,7 +89,7 @@ spec = importlib.util.spec_from_loader(loader.name, loader)
 collector = importlib.util.module_from_spec(spec)
 loader.exec_module(collector)
 
-cache = collector.cache_root() / "claude-limits.json"
+cache = collector.cache_root() / ("claude-limits-" + collector.hashlib.sha1(b"/unused-claude").hexdigest()[:16] + ".json")
 cached = os.environ["CACHED"]
 if cached:
   cache.write_text(cached, encoding="utf-8")
@@ -100,7 +100,7 @@ def unreachable(request, timeout=None):
   raise OSError("no route to host")
 
 collector.urllib.request.urlopen = unreachable
-print(json.dumps(collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False)))
+print(json.dumps(collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False, pathlib.Path("/unused-claude"))))
 PY
 }
 
@@ -160,14 +160,14 @@ pass "Claude collector falls back to cache when the probe cannot connect"
 probe_with_cache() {
   COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" FORCE="$1" CACHED="$2" PAYLOAD="$3" \
     XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
-import importlib.machinery, importlib.util, io, json, os
+import importlib.machinery, importlib.util, io, json, os, pathlib
 
 loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
 spec = importlib.util.spec_from_loader(loader.name, loader)
 collector = importlib.util.module_from_spec(spec)
 loader.exec_module(collector)
 
-cache = collector.cache_root() / "claude-limits.json"
+cache = collector.cache_root() / ("claude-limits-" + collector.hashlib.sha1(b"/unused-claude").hexdigest()[:16] + ".json")
 cache.write_text(os.environ["CACHED"], encoding="utf-8")
 
 probes = []
@@ -177,7 +177,7 @@ def urlopen(request, timeout=None):
   return io.BytesIO(os.environ["PAYLOAD"].encode())
 
 collector.urllib.request.urlopen = urlopen
-result = collector.collect_limits("token", 0, os.environ["FORCE"] == "true")
+result = collector.collect_limits("token", 0, os.environ["FORCE"] == "true", pathlib.Path("/unused-claude"))
 print(json.dumps({
   "result": result,
   "probes": len(probes),

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -116,27 +116,22 @@ cache=$(jq -nc --arg open "$open_at" --arg past "$past_at" '{
   ]
 }')
 
-# An expired token used to return an empty limits list and no status at all,
-# which hides the panel's whole limits section without saying why.
-expired=$(collect_limits "token" 1000 "$cache")
-[[ $(jq -r '.usageStatusText' <<<"$expired") == "Sign-in expired" ]] ||
-  fail "Claude collector reports an expired sign-in" "$expired"
-[[ $(jq -r '.authHelpText' <<<"$expired") == *"claude auth login"* ]] ||
-  fail "Claude collector says how to refresh an expired sign-in" "$expired"
-pass "Claude collector reports an expired sign-in instead of hiding the section"
+# A lapsed expiresAt is not a missing login: still probe. An unreachable
+# endpoint then falls back the same way a live token does.
+lapsed=$(collect_limits "token" 1000 "$cache")
+[[ $(jq -r '.usageStatusText' <<<"$lapsed") == "" ]] ||
+  fail "Claude collector does not treat a lapsed expiresAt as a signed-out login" "$lapsed"
+[[ $(jq -c '[.limits[].label]' <<<"$lapsed") == '["Weekly (7-day)"]' ]] ||
+  fail "Claude collector keeps only cached windows that have not reset" "$lapsed"
+[[ $(jq -r '.retryAdvised' <<<"$lapsed") == "true" ]] ||
+  fail "Claude collector advises a retry after a transport failure on a lapsed token" "$lapsed"
+pass "Claude collector still probes when the saved token's expiresAt has lapsed"
 
-# The window that has not reset is still true; the one that has is not.
-[[ $(jq -c '[.limits[].label]' <<<"$expired") == '["Weekly (7-day)"]' ]] ||
-  fail "Claude collector keeps only cached windows that have not reset" "$expired"
-pass "Claude collector keeps only cached windows that have not reset"
-
-# Nothing worth showing: the status still explains the silence.
+# Nothing worth showing and no route: transport failure, not a fake logout.
 stale=$(collect_limits "token" 1000 "$(jq -c '.limits |= [.[0]]' <<<"$cache")")
-[[ $(jq -c '.limits' <<<"$stale") == "[]" && $(jq -r '.usageStatusText' <<<"$stale") == "Sign-in expired" ]] ||
-  fail "Claude collector drops a wholly reset cache but keeps explaining itself" "$stale"
-[[ $(jq -r '.authHelpText' <<<"$stale") != *"last known"* ]] ||
-  fail "Claude collector promises no last-known limits when it has none" "$stale"
-pass "Claude collector drops a wholly reset cache but keeps explaining itself"
+[[ $(jq -c '.limits' <<<"$stale") == "[]" && $(jq -r '.usageStatusText' <<<"$stale") == "Claude limits unavailable" ]] ||
+  fail "Claude collector drops a wholly reset cache without calling it a logout" "$stale"
+pass "Claude collector drops a wholly reset cache without calling it a logout"
 
 # A signed-out machine says so, and still shows what it last knew.
 signed_out=$(collect_limits "" 0 "$cache")
@@ -145,6 +140,46 @@ signed_out=$(collect_limits "" 0 "$cache")
 [[ $(jq -c '[.limits[].label]' <<<"$signed_out") == '["Weekly (7-day)"]' ]] ||
   fail "Claude collector serves open cached windows without a token" "$signed_out"
 pass "Claude collector serves open cached windows without a token"
+
+collect_limits_http() {
+  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="token" EXPIRES_AT="1000" HTTP="$1" CACHED="$2" \
+    XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
+import importlib.machinery, importlib.util, io, json, os, pathlib, urllib.error
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+cache = collector.cache_root() / ("claude-limits-" + collector.hashlib.sha1(b"/unused-claude").hexdigest()[:16] + ".json")
+cached = os.environ["CACHED"]
+if cached:
+  cache.write_text(cached, encoding="utf-8")
+elif cache.exists():
+  cache.unlink()
+
+def unauthorized(request, timeout=None):
+  raise urllib.error.HTTPError(
+    "https://api.anthropic.com/api/oauth/usage",
+    int(os.environ["HTTP"]),
+    "Unauthorized",
+    None,
+    io.BytesIO(b""),
+  )
+
+collector.urllib.request.urlopen = unauthorized
+print(json.dumps(collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False, pathlib.Path("/unused-claude"))))
+PY
+}
+
+unauthorized=$(collect_limits_http 401 "$cache")
+[[ $(jq -r '.usageStatusText' <<<"$unauthorized") == "Sign-in expired" ]] ||
+  fail "Claude collector reports expired only after HTTP 401" "$unauthorized"
+[[ $(jq -r '.authHelpText' <<<"$unauthorized") == *"claude auth login"* ]] ||
+  fail "Claude collector says how to refresh after HTTP 401" "$unauthorized"
+[[ $(jq -c '[.limits[].label]' <<<"$unauthorized") == '["Weekly (7-day)"]' ]] ||
+  fail "Claude collector keeps open cached windows after HTTP 401" "$unauthorized"
+pass "Claude collector reports an expired sign-in after HTTP 401"
 
 # A live token that cannot reach the endpoint keeps the old contract: the open
 # window stands in, and the shell is asked to retry sooner than its interval.

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -18,7 +18,8 @@ cat >"$projects/session.jsonl" <<EOF
 {"timestamp":"$timestamp","type":"assistant","sessionId":"session-1","uuid":"event-3","message":{"id":"message-2","role":"assistant","model":"claude-test","usage":{"input_tokens":2,"cache_creation_input_tokens":454,"cache_read_input_tokens":28857,"output_tokens":390}}}
 EOF
 
-result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+result=$(HOME="$TEST_HOME" XDG_STATE_HOME="$TEST_HOME/.local/state" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  CLAUDE_CONFIG_DIR= OMARCHY_AGENT_USAGE_NOTIFY=0 \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "58793" ]] ||
@@ -46,7 +47,8 @@ cat >"$HISTORY_HOME/.claude/history.jsonl" <<EOF
 {"timestamp":$now_ms,"sessionId":"s2","display":"two"}
 EOF
 
-result=$(HOME="$HISTORY_HOME" XDG_CACHE_HOME="$HISTORY_HOME/.cache" XDG_DATA_HOME="$HISTORY_HOME/.local/share" \
+result=$(HOME="$HISTORY_HOME" XDG_STATE_HOME="$HISTORY_HOME/.local/state" XDG_CACHE_HOME="$HISTORY_HOME/.cache" XDG_DATA_HOME="$HISTORY_HOME/.local/share" \
+  CLAUDE_CONFIG_DIR= OMARCHY_AGENT_USAGE_NOTIFY=0 \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
 [[ $(jq -r '(.todayPrompts|tostring) + "/" + (.todaySessions|tostring)' <<<"$result") == "2/2" ]] ||
@@ -92,7 +94,8 @@ conn.commit()
 conn.close()
 PY
 
-result=$(HOME="$OPENCODE_HOME" XDG_CACHE_HOME="$OPENCODE_HOME/.cache" XDG_DATA_HOME="$OPENCODE_HOME/.local/share" \
+result=$(HOME="$OPENCODE_HOME" XDG_STATE_HOME="$OPENCODE_HOME/.local/state" XDG_CACHE_HOME="$OPENCODE_HOME/.cache" XDG_DATA_HOME="$OPENCODE_HOME/.local/share" \
+  CLAUDE_CONFIG_DIR= OMARCHY_AGENT_USAGE_NOTIFY=0 \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
 [[ $(jq -r '(.ready|tostring) + "/" + (.todayTotalTokens|tostring)' <<<"$result") == "true/192" ]] ||
@@ -118,7 +121,8 @@ cat >"$PI_HOME/.omp/agent/sessions/project/omp.jsonl" <<EOF
 { "type": "message", "id": "omp-1", "timestamp": "$timestamp", "message": { "role": "assistant", "provider": "anthropic", "model": "claude-omp", "usage": { "input": 20, "output": 5, "cacheRead": 4, "cacheWrite": 1, "totalTokens": 30 } } }
 EOF
 
-result=$(HOME="$PI_HOME" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
+result=$(HOME="$PI_HOME" XDG_STATE_HOME="$PI_HOME/.local/state" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
+  CLAUDE_CONFIG_DIR= OMARCHY_AGENT_USAGE_NOTIFY=0 \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "49" ]] ||

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -14,4 +14,6 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+assert(/activeProviderId === "claude"/.test(panelSource), 'claude account chips are scoped to the Claude tab')
+assert(/omarchy-agent-account/.test(fs.readFileSync(root + '/shell/plugins/agents/Accounts.qml', 'utf8')), 'account chips call omarchy-agent-account')
 JS

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -16,4 +16,6 @@ assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggl
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
 assert(/activeProviderId === "claude"/.test(panelSource), 'claude account chips are scoped to the Claude tab')
 assert(/omarchy-agent-account/.test(fs.readFileSync(root + '/shell/plugins/agents/Accounts.qml', 'utf8')), 'account chips call omarchy-agent-account')
+assert(/reloadFromDisk/.test(fs.readFileSync(root + '/shell/plugins/agents/Agent.qml', 'utf8')), 'usage records can be reloaded after a switch')
+assert(fs.readFileSync(root + '/shell/plugins/agents/Main.qml', 'utf8').includes('providerId) === "claude"'), 'empty Claude accounts stay on the bar')
 JS


### PR DESCRIPTION
The agents widget already switches providers. It still has one Claude login at a time, so personal and work means swapping `CLAUDE_CONFIG_DIR` by hand. See https://github.com/omacom/omarchy/discussions/9821.

`omarchy agent account` registers the live `~/.claude` session, adds further logins as isolated config dirs, and writes a pointer. Switching copies the selected login onto `~/.claude/.credentials.json` as a regular file so tools that hardcode that path follow. The saved copy is a different file; a live Claude blank does not destroy it, empty writes are not harvested back, and last-good restores a blanked saved file. `omarchy agent` and the Claude usage collector follow the pointer. The Claude tab of the agents panel shows email chips and a `+` to add another account.

The usage collector still probes when the saved token's `expiresAt` has lapsed. Only an empty token or HTTP 401/403 is treated as signed out.

Codex is out of this change. A later `omarchy-agent-account-codex` collector would light the same chips.

## Test plan

- `bash test/shell.d/agent-account-claude-test.sh` — list/add/use against a fake `$HOME`, original credentials left in place, live file is not a symlink onto the saved copy, blanking live does not wipe the saved login, usage collector follows the pointer, unknown providers fail
- `bash test/shell.d/agent-usage-claude-limits-test.sh` — lapsed `expiresAt` still probes; 401 is signed out
- `bash test/shell.d/agents-panel-test.sh` — right-click still launches the agent; chips are Claude-tab only
- `./test/cli` — metadata for the new binaries

Visual: adding a second account uses `omarchy-launch-tui` and leaves the original `~/.claude` login intact. New `omarchy agent` windows follow the pointer. Already-open Claude windows do not.