### PR TITLE
Refuse to run the shell suite as root

### DIFF
--- a/test/shell
+++ b/test/shell
@@ -5,6 +5,15 @@ set -euo pipefail
 ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 TEST_DIR="$ROOT/test/shell.d"
 
+# Some tests mount, unmount and delete for real inside an unprivileged user
+# namespace, where the kernel keeps them to files the caller owns. As root
+# nothing does, and one wrong default deletes real system trees. Refuse
+# unless the caller says this is a throwaway machine or container.
+if (( EUID == 0 )) && [[ ${OMARCHY_TEST_ALLOW_ROOT:-0} != 1 ]]; then
+  echo "test/shell: refusing to run as root; run as a normal user, or set OMARCHY_TEST_ALLOW_ROOT=1 on a throwaway system" >&2
+  exit 1
+fi
+
 shopt -s nullglob
 tests=()
 for test in "$TEST_DIR"/*-test.sh; do

--- a/test/shell.d/windows-vm-compose-test.sh
+++ b/test/shell.d/windows-vm-compose-test.sh
@@ -4,6 +4,17 @@
 set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+# This test performs real bind mounts, unmounts and recursive deletions
+# against the paths it sets up. Inside an unprivileged user namespace the
+# kernel confines all of that to files the caller already owns; as real root
+# there is no such confinement, and a mismatch between the script's privileged
+# defaults and the test's fake HOME/OMARCHY_WINDOWS_DIR deletes real trees.
+# Refuse to run as root rather than rely on every path being right.
+if (( EUID == 0 )); then
+  pass "windows VM mount runtime tests must not run as root; skipping (run the suite as a normal user)"
+  exit 0
+fi
+
 # Bind mounts need CAP_SYS_ADMIN in a private mount namespace. Keep the
 # caller's uid so the non-root development path is exercised.
 if [[ ${OMARCHY_WINDOWS_TEST_NAMESPACE:-0} != 1 ]]; then


### PR DESCRIPTION
## Summary

`test/shell.d/windows-vm-compose-test.sh` performs real bind mounts, unmounts and recursive deletions against the paths it sets up. Inside an unprivileged user namespace the kernel confines all of that to files the caller already owns, which is the case the test is written for. As real root there is no such confinement, and a mismatch between the script's privileged defaults and the test's fake `HOME` and `OMARCHY_WINDOWS_DIR` deleted `/home`, `/var/lib`, `/var/log` and `/run` on a test machine yesterday, while I was validating an unrelated branch with `sudo bash test/shell`.

Two guards:

- the compose test skips itself when `EUID` is 0, with a message saying to run the suite as a normal user;
- `test/shell` refuses to run as root unless `OMARCHY_TEST_ALLOW_ROOT=1` says the machine is disposable, so a root shell cannot start the suite by accident.

Nothing changes for the intended, unprivileged run.
