### PR TITLE
Confirm destructive power actions in the system menu

### DIFF
--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -15,6 +15,8 @@
   //   title          header text shown when the submenu is open; defaults to label
   //   when           shell condition; hide row when it fails
   //   checked        shell condition; append ✓ when it succeeds
+  //   confirmation   confirmation dialog shown before an action runs; accepts
+  //                  message, cancelText, confirmText, and countdown seconds
   //   disabled       shell condition; when it succeeds the row stays listed but
   //                  goes dim, takes a ✓ and can no longer be selected. Install
   //                  rows use it so software already on the machine reads as
@@ -38,8 +40,8 @@
   "system.suspend": {"icon":"󰒲","label":"Suspend","when":"! omarchy-toggle-enabled suspend-off","action":"systemctl suspend"},
   "system.hibernate": {"icon":"󰤁","label":"Hibernate","when":"omarchy-hibernation-available","action":"systemctl hibernate"},
   "system.logout": {"icon":"󰍃","label":"Logout","action":"omarchy-system-logout"},
-  "system.reboot": {"icon":"󰜉","label":"Reboot","action":"omarchy-system-reboot"},
-  "system.shutdown": {"icon":"󰐥","label":"Shutdown","action":"omarchy-system-shutdown"},
+  "system.reboot": {"icon":"󰜉","label":"Reboot","action":"omarchy-system-reboot","confirmation":{"message":"Reboot this computer?","confirmText":"Reboot","seconds":5}},
+  "system.shutdown": {"icon":"󰐥","label":"Shutdown","action":"omarchy-system-shutdown","confirmation":{"message":"Shut down this computer?","confirmText":"Shut down","seconds":5}},
 
   // Learn
   "learn.keybindings": {"icon":"","label":"Keybindings","action":"omarchy-menu-keybindings"},

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -37,6 +37,7 @@ submenu. The fields:
 | `label` | Visible row title; defaults to the id |
 | `title` | Header text when the submenu is open; defaults to `label`. Lets a row read "Browser" under Defaults while the open menu says "Default Browser" |
 | `action` | Shell command to run, detached, when selected |
+| `confirmation` | Optional confirmation dialog before an action runs. Accepts `message`, `cancelText`, `confirmText`, and `seconds`; a positive `seconds` value counts down and runs the action when it reaches zero |
 | `target` | Existing submenu id to open; makes the row a link |
 | `provider` | Runtime row source for this submenu (see Providers) |
 | `aliases` | Alternate `omarchy menu summon <name>` routes; also searchable |

--- a/shell/Ui/ConfirmDialog.qml
+++ b/shell/Ui/ConfirmDialog.qml
@@ -8,6 +8,9 @@ Item {
   property string message: ""
   property string cancelText: "Cancel"
   property string confirmText: "Confirm"
+  property int countdownSeconds: 0
+  property int remainingSeconds: 0
+  readonly property string effectiveConfirmText: remainingSeconds > 0 ? confirmText + " (" + remainingSeconds + ")" : confirmText
   property int selectedIndex: 1
   property color background: Color.background
   property color foreground: Color.foreground
@@ -19,6 +22,21 @@ Item {
 
   signal canceled()
   signal confirmed()
+
+  onOpenedChanged: {
+    if (opened) remainingSeconds = Math.max(0, countdownSeconds)
+    else remainingSeconds = 0
+  }
+
+  Timer {
+    interval: 1000
+    repeat: true
+    running: root.opened && root.remainingSeconds > 0
+    onTriggered: {
+      root.remainingSeconds -= 1
+      if (root.remainingSeconds === 0) root.confirmed()
+    }
+  }
 
   function handleKey(event) {
     if (!root.opened) return false
@@ -86,7 +104,7 @@ Item {
           spacing: Style.space(10)
 
           Repeater {
-            model: [root.cancelText, root.confirmText]
+            model: [root.cancelText, root.effectiveConfirmText]
 
             BorderSurface {
               required property int index

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -80,7 +80,14 @@ Item {
   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
   property bool deleteConfirmOpen: false
   property var deleteTarget: null
-  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null }
+  property bool actionConfirmOpen: false
+  property var actionConfirmTarget: null
+  onOpenedChanged: if (!opened) {
+    deleteConfirmOpen = false
+    deleteTarget = null
+    actionConfirmOpen = false
+    actionConfirmTarget = null
+  }
   // Bound to the central [menu] section in shell.toml via Color.qml.
   // Each color already includes its alpha companion (composed in the
   // singleton), so consumers can drop them straight into a Rectangle.
@@ -585,6 +592,7 @@ Item {
         path: "",
         childCount: 0,
         action: "",
+        confirmation: null,
         provider: "",
         score: i,
         section: ""
@@ -757,7 +765,7 @@ Item {
   }
 
   function activateIndex(index, fromPointer) {
-    if (root.deleteConfirmOpen) return
+    if (root.deleteConfirmOpen || root.actionConfirmOpen) return
     if (root.dmenuActive) {
       if (root.mode === "input") {
         root.applyDmenuSelection(root.filterText)
@@ -782,8 +790,40 @@ Item {
       filterText = ""
       if (root.appLibrary) root.appLibrary.launch(appId, label)
     } else {
-      root.applySelected(row.itemId, row.action)
+      root.requestAction(row)
     }
+  }
+
+  function requestAction(row) {
+    if (!row || !row.itemId) return
+    if (!row.confirmation) {
+      root.applySelected(row.itemId, row.action)
+      return
+    }
+
+    root.actionConfirmTarget = {
+      itemId: row.itemId,
+      action: row.action,
+      confirmation: row.confirmation
+    }
+    actionConfirm.selectedIndex = 0
+    root.actionConfirmOpen = true
+  }
+
+  function cancelAction() {
+    root.actionConfirmOpen = false
+    root.actionConfirmTarget = null
+    actionConfirm.selectedIndex = 0
+    root.disarmPointer()
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function confirmAction() {
+    var target = root.actionConfirmTarget
+    root.actionConfirmOpen = false
+    root.actionConfirmTarget = null
+    if (!target) return
+    root.applySelected(target.itemId, target.action)
   }
 
   function requestDeleteSelected() {
@@ -899,8 +939,13 @@ Item {
     // a leaf, e.g. `omarchy menu summon screenrecord-stop`), run it directly
     // instead of opening an action with no children.
     if (entry && entry.kind === "action" && entry.action) {
-      root.cancel()
-      root.runAction(entry.action)
+      if (entry.confirmation) {
+        root.openExistingMenu(entry.parent || "root")
+        root.requestAction(root.displayRow(entry, entry.description, entry.order))
+      } else {
+        root.cancel()
+        root.runAction(entry.action)
+      }
       return "ok"
     }
     // If it's a link (a redirect to another menu), follow the link.
@@ -1116,13 +1161,17 @@ Item {
       Item {
         id: keyCatcher
         anchors.fill: parent
-        z: root.deleteConfirmOpen ? 20 : 0
+        z: root.deleteConfirmOpen || root.actionConfirmOpen ? 20 : 0
         focus: true
 
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
           if (root.deleteConfirmOpen) {
             if (deleteConfirm.handleKey(event)) event.accepted = true
+            return
+          }
+          if (root.actionConfirmOpen) {
+            if (actionConfirm.handleKey(event)) event.accepted = true
             return
           }
 
@@ -1181,6 +1230,27 @@ Item {
           cornerRadius: root.cornerRadius
           onCanceled: root.cancelDelete()
           onConfirmed: root.confirmDelete()
+        }
+
+        ConfirmDialog {
+          id: actionConfirm
+
+          anchors.fill: parent
+          opened: root.actionConfirmOpen
+          z: 10
+          message: (root.actionConfirmTarget && root.actionConfirmTarget.confirmation && root.actionConfirmTarget.confirmation.message) || "Are you sure?"
+          cancelText: (root.actionConfirmTarget && root.actionConfirmTarget.confirmation && root.actionConfirmTarget.confirmation.cancelText) || "Cancel"
+          confirmText: (root.actionConfirmTarget && root.actionConfirmTarget.confirmation && root.actionConfirmTarget.confirmation.confirmText) || "Confirm"
+          countdownSeconds: (root.actionConfirmTarget && root.actionConfirmTarget.confirmation && root.actionConfirmTarget.confirmation.seconds) || 0
+          background: root.background
+          foreground: root.foreground
+          scrim: root.scrim
+          selectedBackground: root.selectedBackground
+          selectedText: root.selectedText
+          fontFamily: root.fontFamily
+          cornerRadius: root.cornerRadius
+          onCanceled: root.cancelAction()
+          onConfirmed: root.confirmAction()
         }
       }
 
@@ -1259,6 +1329,7 @@ Item {
               required property string detail
               required property string path
               required property string action
+              required property var confirmation
               required property int childCount
               required property bool disabled
 

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -31,6 +31,7 @@ function normalizeItem(id, raw) {
     target: value.target || "",
     description: value.description || "",
     action: value.action || "",
+    confirmation: value.confirmation || null,
     provider: value.provider || "",
     aliases: aliases,
     when: value.when || "",
@@ -84,7 +85,7 @@ function mergeMenuSources(defaultItems, userItems) {
   }
 
   if (!nextItems.root) {
-    nextItems.root = { id: "root", parent: "", kind: "menu", icon: "", iconFont: "", label: "Go", title: "", target: "", description: "", aliases: [], when: "", checked: "", disabled: "", action: "", provider: "" }
+    nextItems.root = { id: "root", parent: "", kind: "menu", icon: "", iconFont: "", label: "Go", title: "", target: "", description: "", aliases: [], when: "", checked: "", disabled: "", action: "", confirmation: null, provider: "" }
     nextOrder.unshift("root")
   }
   for (var k3 = 0; k3 < nextOrder.length; k3++) nextItems[nextOrder[k3]].order = k3
@@ -378,6 +379,7 @@ function displayRow(items, itemOrder, checkedResults, disabledResults, entry, de
     path: pathFor(items, entry.id),
     childCount: (entry.kind === "menu" || entry.kind === "link") ? childCount(items, itemOrder, target) : 0,
     action: entry.action || "",
+    confirmation: entry.confirmation || null,
     provider: entry.provider || "",
     score: score || 0,
     section: section || ""

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -20,7 +20,12 @@ const parsed = menu.parseMenuJsonc(`
       "label": "Themes",
       "aliases": "theme",
       "description": "appearance colors",
-      "action": "omarchy-theme-set"
+      "action": "omarchy-theme-set",
+      "confirmation": {
+        "message": "Apply this theme?",
+        "confirmText": "Apply",
+        "seconds": 3
+      }
     },
   },
 }
@@ -40,6 +45,11 @@ assertDeepEqual(
     target: '',
     description: 'appearance colors',
     action: 'omarchy-theme-set',
+    confirmation: {
+      message: 'Apply this theme?',
+      confirmText: 'Apply',
+      seconds: 3
+    },
     provider: '',
     aliases: ['theme'],
     when: '',
@@ -120,6 +130,7 @@ assertDeepEqual(
     path: 'Style › Theme picker',
     childCount: 0,
     action: 'custom-theme',
+    confirmation: null,
     provider: '',
     score: 12,
     section: 'search'
@@ -129,6 +140,20 @@ assertDeepEqual(
 
 const defaultItems = menu.parseMenuJsonc(defaultMenuJsonc)
 const defaultById = Object.fromEntries(defaultItems.map(item => [item.id, item]))
+assertDeepEqual(
+  defaultById['system.reboot'].confirmation,
+  { message: 'Reboot this computer?', confirmText: 'Reboot', seconds: 5 },
+  'menu requires a five-second confirmation before reboot'
+)
+assertDeepEqual(
+  defaultById['system.shutdown'].confirmation,
+  { message: 'Shut down this computer?', confirmText: 'Shut down', seconds: 5 },
+  'menu requires a five-second confirmation before shutdown'
+)
+assert(
+  /property int countdownSeconds: 0/.test(fs.readFileSync(path.join(root, 'shell/Ui/ConfirmDialog.qml'), 'utf8')),
+  'confirmation dialog supports an optional countdown'
+)
 
 // Needs the real menu: app rows sort after all menu items, and only at that
 // item count does the order tiebreak alone bury an installed app.


### PR DESCRIPTION
## Summary

- add optional per-action confirmations to the Omarchy menu schema
- confirm Reboot and Shutdown with a native five-second countdown
- keep Cancel selected by default and preserve keyboard navigation
- leave direct CLI and internal power actions unchanged
- document the new menu field and cover it in the menu test suite

## Motivation

Reboot and Shutdown currently execute immediately from the System menu. A stray click or Enter can therefore interrupt work with no recovery window. The confirmation is deliberately attached to the interactive menu entries rather than the underlying commands, so developer scripts and terminal workflows retain their existing behavior.

## Related work

- #4620 explored graceful shutdown and handling applications that were still open. It was closed after feedback that a full-size terminal was too obtrusive and that the interaction should be a much lighter touch. This PR addresses a different moment in the flow—accidental activation before shutdown begins—and uses the shell's native confirmation dialog instead of launching a terminal.
- Discussion #5128 proposes configurable shutdown grace periods so applications have more time to save state.
- #7085 reports incomplete application-session restoration because the shutdown flow does not wait long enough for windows to close.

Those proposals concern application shutdown and state preservation. This PR is limited to confirmation of destructive actions initiated from the interactive menu; it does not change the underlying shutdown sequence or direct CLI behavior.

## Verification

- `bash test/shell.d/menu-test.sh`
- `./test/all` (the changed menu suite passes; six unrelated host/baseline tests fail: `config-test.sh`, `launch-about-test.sh`, `network-qr-test.sh`, `plugin-add-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`)

Closes #9837
