### PR TITLE
Strip gnome-keyring session auto_start from SDDM PAM

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1452,6 +1452,7 @@ EOF
   if [[ -f /etc/pam.d/sddm ]]; then
     as_root sed -i '/-auth.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
     as_root sed -i '/-password.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
+    as_root sed -i '/-session.*pam_gnome_keyring\.so.*auto_start/d' /etc/pam.d/sddm
   fi
 
   if [[ -f /etc/pam.d/system-auth ]]; then
@@ -1459,6 +1460,9 @@ EOF
     as_root sed -i 's|^\(auth\s\+\[default=die\]\s\+pam_faillock.so\)\s\+authfail.*$|\1 authfail deny=10 unlock_time=120|' /etc/pam.d/system-auth
   fi
   if [[ -f /etc/pam.d/sddm-autologin ]]; then
+    as_root sed -i '/-auth.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm-autologin
+    as_root sed -i '/-password.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm-autologin
+    as_root sed -i '/-session.*pam_gnome_keyring\.so.*auto_start/d' /etc/pam.d/sddm-autologin
     as_root sed -i '/pam_faillock\.so preauth/d' /etc/pam.d/sddm-autologin
     as_root sed -i '/pam_faillock\.so authsucc/d' /etc/pam.d/sddm-autologin
     as_root sed -i '/auth.*pam_permit\.so/a auth        required    pam_faillock.so authsucc' /etc/pam.d/sddm-autologin

--- a/install/login/sddm.sh
+++ b/install/login/sddm.sh
@@ -1,7 +1,16 @@
 # Prevent password-based SDDM logins from creating an encrypted login keyring
 # that conflicts with Omarchy's passwordless default keyring behavior. The ISO
 # owns autologin/session state because it knows whether the target is encrypted.
+# Strip auth/password *and* session auto_start — leaving session alone still
+# unlocks/creates a login keyring (omacom/omarchy#9235).
 if [[ -f /etc/pam.d/sddm ]]; then
   sed -i '/-auth.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
   sed -i '/-password.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
+  sed -i '/-session.*pam_gnome_keyring\.so.*auto_start/d' /etc/pam.d/sddm
+fi
+
+if [[ -f /etc/pam.d/sddm-autologin ]]; then
+  sed -i '/-auth.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm-autologin
+  sed -i '/-password.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm-autologin
+  sed -i '/-session.*pam_gnome_keyring\.so.*auto_start/d' /etc/pam.d/sddm-autologin
 fi


### PR DESCRIPTION
## Summary
- install/upgrade removed gnome-keyring auth/password lines but left `session ... auto_start`
- that still creates/unlocks an encrypted login keyring that fights Omarchy's default keyring
- also strip the session line on `sddm` and `sddm-autologin`

## Test plan
- [ ] inspect `/etc/pam.d/sddm` after install/upgrade: no gnome-keyring auto_start
