### PR TITLE
Clamp idle timeouts to QTimer-safe seconds

### DIFF
--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,7 +1,12 @@
+// QTimer/QQmlTimer intervals are milliseconds in a signed 32-bit int.
+// Values above floor(INT32_MAX / 1000) wrap negative, Qt clamps them to 1ms,
+// and the idle service floods the journal until shmem is exhausted.
+var MAX_TIMER_SECONDS = 2147483
+
 function secondsFromConfig(value, fallback) {
   var n = Number(value)
   if (!isFinite(n) || n < 0) return fallback
-  return Math.floor(n)
+  return Math.min(Math.floor(n), MAX_TIMER_SECONDS)
 }
 
 function eventParts(event, count) {
@@ -45,6 +50,7 @@ function screensaverWindowsAfter(windows, address, visible) {
 
 if (typeof module !== "undefined") {
   module.exports = {
+    MAX_TIMER_SECONDS: MAX_TIMER_SECONDS,
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -10,6 +10,27 @@ const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
+assertEqual(idle.secondsFromConfig(0, 10), 0, 'idle accepts a zero timeout')
+assertEqual(
+  idle.secondsFromConfig(idle.MAX_TIMER_SECONDS, 10),
+  idle.MAX_TIMER_SECONDS,
+  'idle keeps the largest QTimer-safe timeout'
+)
+assertEqual(
+  idle.secondsFromConfig(idle.MAX_TIMER_SECONDS + 1, 10),
+  idle.MAX_TIMER_SECONDS,
+  'idle clamps just past the QTimer-safe ceiling'
+)
+// 30 days is a common "never lock" approximation and overflows INT32 ms.
+assertEqual(
+  idle.secondsFromConfig(2592000, 10),
+  idle.MAX_TIMER_SECONDS,
+  'idle clamps multi-week lock timeouts that would wrap QTimer intervals negative'
+)
+assert(
+  idle.secondsFromConfig(2592000, 10) * 1000 <= 2147483647,
+  'clamped idle timeouts stay within a signed 32-bit millisecond interval'
+)
 
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(


### PR DESCRIPTION
## Summary

Fixes #9832.

`idle.lock` / `idle.screensaver` values above ~24.8 days overflow the idle service's QTimer interval. Qt stores timer intervals as a signed 32-bit millisecond int, so a 30-day "never lock" config (`2592000`) wraps negative, is clamped to 1ms, and floods ~400 `QBasicTimer::start: negative intervals aren't allowed` warnings per second until shmem/tmpfs is exhausted and the session dies.

## Change

`secondsFromConfig` in `shell/plugins/services/idle/IdleModel.js` already rejected non-finite and negative values. Clamp the high end to `floor(INT32_MAX / 1000)` (`2147483`) so both `lockTimer` and `screensaverTimer` intervals stay representable:

```js
var MAX_TIMER_SECONDS = 2147483

function secondsFromConfig(value, fallback) {
  var n = Number(value)
  if (!isFinite(n) || n < 0) return fallback
  return Math.min(Math.floor(n), MAX_TIMER_SECONDS)
}
```

Both timers bind `interval: *DelaySeconds * 1000` after this helper, so one clamp covers lock and screensaver.

## Test plan

- [x] Extended `test/shell.d/idle-test.sh` with ceiling, ceiling+1, and the 30-day overflow case from the issue
- [x] `bash test/shell.d/idle-test.sh` — all assertions pass, including `clamped idle timeouts stay within a signed 32-bit millisecond interval`
- [x] `bash -n test/shell.d/idle-test.sh` — clean
- [x] Confirmed pre-fix math: `2591850 * 1000` wraps to a negative int32; post-fix clamp yields `2147483000 <= INT32_MAX`

```
ok - idle floors configured seconds
ok - idle rejects negative seconds
ok - idle rejects invalid seconds
ok - idle accepts a zero timeout
ok - idle keeps the largest QTimer-safe timeout
ok - idle clamps just past the QTimer-safe ceiling
ok - idle clamps multi-week lock timeouts that would wrap QTimer intervals negative
ok - clamped idle timeouts stay within a signed 32-bit millisecond interval
```