### PR TITLE
Keep Quickshell logs from exhausting the user runtime dir

### DIFF
--- a/bin/omarchy-launch-shell
+++ b/bin/omarchy-launch-shell
@@ -3,9 +3,42 @@
 # omarchy:summary=Launch the Omarchy shell with its log kept in the journal
 # omarchy:hidden=true
 
+# Quickshell never collects a dead instance's runtime dir, so every restart or
+# crash relaunch abandons the previous instance there, detailed log included,
+# until the tmpfs fills. Collect the dead instances of this shell's config
+# before launching the replacement. Liveness comes from `quickshell list`,
+# which checks the instance lock properly: it is a POSIX fcntl lock, which
+# flock(1) cannot test. Other configs' instances — a user's own Quickshell,
+# the dev gallery — are left alone.
+reap_dead_shell_instances() {
+  local by_id=${XDG_RUNTIME_DIR:-/run/user/$UID}/quickshell/by-id
+  [[ -d $by_id ]] || return 0
+
+  local all alive dead id
+  all=$(quickshell list --all --show-dead --json 2>/dev/null) || return 0
+  alive=$(quickshell list --all --json 2>/dev/null) || return 0
+
+  dead=$(jq -r --arg config "$OMARCHY_PATH/shell/shell.qml" \
+    '.[] | select(.config_path == $config) | .id' <<<"$all" 2>/dev/null)
+
+  for id in $dead; do
+    [[ $id == */* || $id == .* ]] && continue
+    jq -e --arg id "$id" 'any(.[]; .id == $id)' <<<"$alive" >/dev/null 2>&1 && continue
+    rm -rf "${by_id:?}/$id"
+  done
+}
+
 # Quickshell only logs to its instance runtime dir (tmpfs), so when the shell
 # dies the idle/lock event trail is gone after a reboot. The journal keeps it
 # across sessions, bounded and timestamped, under the omarchy-shell tag.
+#
+# The detailed log Quickshell keeps in that dir besides stdout has no cap or
+# rotation, and log rules deliberately don't apply to quickshell.* categories,
+# so it grows by hundreds of megabytes a day against a runtime dir capped at
+# 10% of RAM; a week of session uptime exhausts the tmpfs, and the compositor
+# dies on the next shm write with SIGBUS. The journal above already keeps the
+# trail, so drop the file with --no-detailed-logs, which also stops the debug
+# messages from being generated at all.
 #
 # Backgrounded because bash defers a trap until a foreground command returns but
 # interrupts wait. systemd-cat execs, so the job is Quickshell itself.
@@ -15,8 +48,10 @@
 # against a half-written tree, and that failed reload leaves a second engine
 # generation behind that turns the next restart's IPC kill into a crash.
 run_shell() {
+  reap_dead_shell_instances
+
   QS_DISABLE_FILE_WATCHER=1 QS_NO_RELOAD_POPUP=1 \
-    systemd-cat -t omarchy-shell -- quickshell -n -p "$OMARCHY_PATH/shell" &
+    systemd-cat -t omarchy-shell -- quickshell -n --no-detailed-logs -p "$OMARCHY_PATH/shell" &
   shell_pid=$!
 
   local status

--- a/test/shell.d/launch-shell-log-hygiene-test.sh
+++ b/test/shell.d/launch-shell-log-hygiene-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+LAUNCHER="$ROOT/bin/omarchy-launch-shell"
+
+# Quickshell's detailed instance log has no cap or rotation and ignores log
+# rules for quickshell.* categories, so a long session fills the runtime dir
+# tmpfs. The launcher must opt out of it; the journal keeps the trail.
+if ! grep -q -- '--no-detailed-logs' "$LAUNCHER"; then
+  fail "launcher passes --no-detailed-logs to quickshell"
+fi
+pass "launcher passes --no-detailed-logs to quickshell"
+
+# The reap must remove dead instances of this shell's config and nothing
+# else: not live instances, not other configs' instances dead or alive.
+# Exercise the real launcher against a mocked quickshell and runtime dir.
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+mkdir -p "$workdir/bin" "$workdir/omarchy/shell" "$workdir/fixtures"
+mkdir -p "$workdir/run/quickshell/by-id"/{deadone,deadtwo,liveother,deadother}
+touch "$workdir/omarchy/shell/shell.qml"
+touch "$workdir/run/quickshell/by-id"/{deadone,deadtwo,liveother,deadother}/log.qslog
+
+ours="$workdir/omarchy/shell/shell.qml"
+
+cat > "$workdir/fixtures/alive.json" <<JSON
+[
+  {"config_path": "/elsewhere/shell.qml", "id": "liveother", "pid": 4242}
+]
+JSON
+
+cat > "$workdir/fixtures/all.json" <<JSON
+[
+  {"config_path": "/elsewhere/shell.qml", "id": "liveother", "pid": 4242},
+  {"config_path": "$ours", "id": "deadone", "pid": 4243},
+  {"config_path": "$ours", "id": "deadtwo", "pid": 4244},
+  {"config_path": "/elsewhere/shell.qml", "id": "deadother", "pid": 4245}
+]
+JSON
+
+cat > "$workdir/bin/quickshell" <<MOCK
+#!/bin/bash
+if [[ \$1 == "list" ]]; then
+  if [[ " \$* " == *" --show-dead "* ]]; then
+    cat "$workdir/fixtures/all.json"
+  else
+    cat "$workdir/fixtures/alive.json"
+  fi
+fi
+exit 0
+MOCK
+
+cat > "$workdir/bin/systemd-cat" <<'MOCK'
+#!/bin/bash
+while [[ $1 != "--" ]]; do shift; done
+shift
+exec "$@"
+MOCK
+
+cat > "$workdir/bin/hyprctl" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+
+chmod +x "$workdir/bin"/{quickshell,systemd-cat,hyprctl}
+
+if ! PATH="$workdir/bin:$PATH" XDG_RUNTIME_DIR="$workdir/run" OMARCHY_PATH="$workdir/omarchy" \
+  timeout 10 bash "$LAUNCHER" >/dev/null 2>&1; then
+  fail "launcher exits cleanly when the mocked shell exits cleanly"
+fi
+pass "launcher exits cleanly when the mocked shell exits cleanly"
+
+by_id="$workdir/run/quickshell/by-id"
+
+[[ ! -d $by_id/deadone && ! -d $by_id/deadtwo ]] ||
+  fail "dead instances of this shell's config are reaped before launch"
+pass "dead instances of this shell's config are reaped before launch"
+
+[[ -d $by_id/liveother ]] || fail "live instances are preserved"
+pass "live instances are preserved"
+
+[[ -d $by_id/deadother ]] || fail "other configs' dead instances are preserved"
+pass "other configs' dead instances are preserved"

--- a/test/shell.d/launch-shell-test.sh
+++ b/test/shell.d/launch-shell-test.sh
@@ -27,6 +27,13 @@ mkdir -p "$fake_bin" "$shell_root/shell"
 cat >"$fake_bin/quickshell" <<'SH'
 #!/bin/bash
 
+# `list` calls come from the launcher's dead-instance reap, not from a
+# launch; answer with no instances and keep them out of the launch count.
+if [[ $1 == "list" ]]; then
+  printf '[]\n'
+  exit 0
+fi
+
 printf '%s\n' "$*" >>"$OMARCHY_TEST_QS_LOG"
 printf 'watcher=%s popup=%s\n' \
   "${QS_DISABLE_FILE_WATCHER:-unset}" "${QS_NO_RELOAD_POPUP:-unset}" >>"$OMARCHY_TEST_QS_ENV_LOG"
@@ -108,7 +115,7 @@ launches() {
 
 launch_shell '0' || fail "a clean launch succeeds"
 [[ $(launches) == 1 ]] || fail "a shell that exits cleanly is not relaunched" "$(<"$qs_log")"
-grep -F -- "-n -p $shell_root/shell" "$qs_log" >/dev/null || fail "the shell launches from OMARCHY_PATH"
+grep -F -- "-n --no-detailed-logs -p $shell_root/shell" "$qs_log" >/dev/null || fail "the shell launches from OMARCHY_PATH"
 pass "a shell that exits cleanly is left alone"
 
 # A misspelled variable would leave Quickshell hot-reloading the tree pacman


### PR DESCRIPTION
Quickshell writes a detailed binary log to `$XDG_RUNTIME_DIR/quickshell/by-id/<instance>/log.qslog` with no cap and no rotation, and its log rules deliberately do not apply to `quickshell.*` categories, so every debug message lands there even though none of them reach the journal. On the desktop where this was diagnosed that is ~350MB/day — mostly `quickshell.dbus.properties` chatter tracking NetworkManager access points. The user runtime dir is a tmpfs capped at 10% of RAM: 2.3GB on a 24GB machine.

Quickshell also never collects a dead instance's runtime dir, and every `omarchy-restart-shell` — updates, font changes, Voxtype setup — abandons the previous instance's log there and starts a fresh one beside it. Restarts add up instead of resetting.

Once the tmpfs fills, everything that lives in the runtime dir starts failing — dconf, uwsm's app daemon — and then the compositor itself: Hyprland dies with SIGBUS on the next screencopy into an shm buffer whose pages cannot be allocated (`Screenshare::CScreenshareFrame::copyShm`), taking the whole session down. Observed on a real machine: boots with 13h and 3.1 days of uptime logged zero ENOSPC, while a 5.8-day session logged 2698 of them and ended in exactly that SIGBUS.

Two changes to `omarchy-launch-shell`:

- **Launch Quickshell with `--no-detailed-logs`.** The launcher already pipes the shell's output to the journal precisely because the runtime dir does not survive a reboot; the text log in the instance dir stays, and nothing in Omarchy reads `log.qslog`. Sparse mode also makes log rules apply for real, so the debug messages stop being generated instead of being formatted and thrown away. Trade-off: Quickshell's crash reporter bundles `log.qslog` into its crash dossier, so those get thinner — the journal keeps covering that ground.

- **Reap dead instances of this shell's config before each launch.** Liveness comes from `quickshell list`, which checks the instance lock correctly — it is a POSIX fcntl lock, which `flock(1)` cannot test. Instances of other configs, dead or alive — a user's own Quickshell, the dev gallery — are left alone.

## Test plan

- `bash test/shell.d/launch-shell-log-hygiene-test.sh` — the launcher passes `--no-detailed-logs`; a run over a mocked `quickshell` reaps this config's dead instance dirs while preserving the live one and other configs'
- `bash test/shell.d/launch-shell-test.sh` — supervision behavior unchanged (the mock now answers `list` without counting it as a launch)
- `bash test/shell` — same results as the quattro baseline on this machine (the four failures predate the change: missing omarchy-pkgs sibling checkout, bar geometry needs the graphical session)
- Live 4.0.2 session with the patched launcher installed: `omarchy-restart-shell` came back in 0.7s with the shell answering ping. The reap collected both dead instances of the session's config — one holding a 21.9MB `log.qslog` from 1.5h of uptime — and preserved all 36 dead instances `test/shell` runs had left behind under other config paths. The new instance's `log.qslog` sat at 929 bytes and stayed there over the following minutes (the unpatched launcher's instance had written 520KB within its first 30 seconds), while the journal kept receiving the shell log
