### PR TITLE
Show per-window occupancy squares on the workspace indicator

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -6,7 +6,7 @@ It's also the one piece of the desktop that's always on screen, so it's worth kn
 
 ## What's on it by default
 
-The bar has three sections. On the left sits the Omarchy logo (the menu launcher) and the workspace indicators. In the center you get the status indicators, the clock, the keyboard layout, the weather, and an Omarchy update badge. On the right: the system tray, agents, bluetooth, network, audio, display, and power.
+The bar has three sections. On the left sits the Omarchy logo (the menu launcher) and the workspace indicators. Each workspace shows a number, or a filled square for the one you're on, with a row of smaller squares underneath — one per open window, hollow unless that window is focused. In the center you get the status indicators, the clock, the keyboard layout, the weather, and an Omarchy update badge. On the right: the system tray, agents, bluetooth, network, audio, display, and power.
 
 A few of those only show up when they have something to say. The keyboard layout appears only if you've configured more than one layout. The update badge appears only when there's an Omarchy update waiting. And the agents icon appears the first time Omarchy finds AI coding usage on the machine (see [AI](17-ai.md)).
 

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -55,7 +55,7 @@ Example `shell.json` (bar subtree only shown):
 | Name | What it does | Interactions |
 |---|---|---|
 | `omarchy.menu` | Omarchy menu launcher | left = menu · right = terminal |
-| `omarchy.workspaces` | Hyprland workspace switcher | left = focus workspace |
+| `omarchy.workspaces` | Hyprland workspace switcher; small squares under each workspace show open windows (hollow = idle, filled = focused) | left = focus workspace |
 | `omarchy.clock` | Date/time label + popup with a month grid, ISO week numbers, and month stepping | left = popup · right = cycle label format · middle = timezone selector |
 | `omarchy.media` | MPRIS now-playing — scrolling track + artist, cover-art popup | left = play/pause · middle = next · scroll = prev/next · right = popup |
 | `omarchy.indicators` | Manual state indicators | left = indicator action |

--- a/shell/plugins/bar/widgets/Workspaces.manifest.json
+++ b/shell/plugins/bar/widgets/Workspaces.manifest.json
@@ -4,7 +4,7 @@
   "name": "Workspaces",
   "version": "1.0.0",
   "author": "Omarchy",
-  "description": "Workspace number indicators",
+  "description": "Workspace indicators with per-window occupancy squares",
   "kinds": [
     "bar-widget"
   ],
@@ -13,8 +13,16 @@
   },
   "barWidget": {
     "displayName": "Workspaces",
-    "description": "Workspace number indicators",
+    "description": "Workspace indicators with per-window occupancy squares",
     "category": "Compositor",
     "allowMultiple": false
+  },
+  "omarchy": {
+    "clonePaths": [
+      {
+        "source": "WorkspacesModel.js",
+        "target": "WorkspacesModel.js"
+      }
+    ]
   }
 }

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -3,31 +3,18 @@ import QtQuick.Layouts
 import Quickshell.Hyprland
 import qs.Commons
 import qs.Ui
+import "WorkspacesModel.js" as WorkspacesModel
 
 BarWidget {
   id: root
   moduleName: "omarchy.workspaces"
 
   function workspaceById(id) {
-    var values = Hyprland.workspaces.values
-    for (var i = 0; i < values.length; i++) {
-      if (values[i].id === id) return values[i]
-    }
-
-    return null
+    return WorkspacesModel.workspaceById(Hyprland.workspaces.values, id)
   }
 
   function workspaceIds() {
-    var ids = [1, 2, 3, 4, 5]
-    var values = Hyprland.workspaces.values
-
-    for (var i = 0; i < values.length; i++) {
-      var id = values[i].id
-      if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
-    }
-
-    ids.sort(function(left, right) { return left - right })
-    return ids
+    return WorkspacesModel.workspaceIds(Hyprland.workspaces.values)
   }
 
   function focusWorkspace(id) {
@@ -36,6 +23,9 @@ BarWidget {
   }
 
   readonly property real trailingGap: root.vertical ? 0 : Style.spaceReal(1.5)
+  readonly property int windowSquare: Style.space(5)
+  readonly property int windowGap: Style.space(2)
+  readonly property int windowSlotMargin: Style.space(2)
 
   implicitWidth: grid.implicitWidth + trailingGap
   implicitHeight: grid.implicitHeight
@@ -52,20 +42,70 @@ BarWidget {
       model: root.workspaceIds()
 
       WidgetButton {
+        id: button
         required property int modelData
 
         readonly property var workspace: root.workspaceById(modelData)
-        readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
+        readonly property bool occupied: WorkspacesModel.isOccupied(workspace)
         readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
+        readonly property int windowCount: WorkspacesModel.toplevelCount(workspace)
+        readonly property int windowRowWidth: WorkspacesModel.windowRowLength(windowCount, root.windowSquare, root.windowGap)
 
         bar: root.bar
-        text: focused ? "\uDB85\uDCFB" : (modelData === 10 ? "0" : String(modelData))
+        text: WorkspacesModel.workspaceLabel(modelData, focused)
+        labelVisible: false
         opacity: occupied || focused ? 1 : 0.5
         horizontalMargin: 6
         verticalPadding: 6
-        fixedWidth: root.vertical ? root.barSize : Style.space(20)
+        fixedWidth: root.vertical ? root.barSize : Math.max(Style.space(20), windowRowWidth + Style.space(6))
         fixedHeight: root.barSize
         onPressed: function() { root.focusWorkspace(modelData) }
+
+        Text {
+          id: workspaceLabel
+          textFormat: Text.PlainText
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.top: parent.top
+          anchors.bottom: windowSlot.top
+          text: button.text
+          color: button.foreground
+          font.family: button.fontFamily
+          font.pixelSize: button.fontSize
+          renderType: Text.NativeRendering
+          horizontalAlignment: Text.AlignHCenter
+          verticalAlignment: Text.AlignVCenter
+        }
+
+        Item {
+          id: windowSlot
+          anchors.horizontalCenter: parent.horizontalCenter
+          anchors.bottom: parent.bottom
+          anchors.bottomMargin: root.windowSlotMargin
+          height: root.windowSquare
+          width: Math.max(root.windowSquare, button.windowRowWidth)
+
+          Row {
+            id: windowRow
+            anchors.centerIn: parent
+            spacing: root.windowGap
+
+            Repeater {
+              model: button.workspace ? button.workspace.toplevels : 0
+
+              Rectangle {
+                required property var modelData
+
+                width: root.windowSquare
+                height: root.windowSquare
+                color: WorkspacesModel.isWindowFocused(modelData) ? button.foreground : "transparent"
+                border.width: Style.spacing.hairline
+                border.color: button.foreground
+                antialiasing: false
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/shell/plugins/bar/widgets/WorkspacesModel.js
+++ b/shell/plugins/bar/widgets/WorkspacesModel.js
@@ -1,0 +1,74 @@
+// Workspace list and window-occupancy math for the workspaces widget,
+// kept Qt-free so it can be unit tested under node (test/shell.d/workspaces-test.sh).
+
+function workspaceIds(workspaces) {
+  var ids = [1, 2, 3, 4, 5]
+  var values = workspaces || []
+
+  for (var i = 0; i < values.length; i++) {
+    var id = values[i].id
+    if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
+  }
+
+  ids.sort(function (left, right) { return left - right })
+  return ids
+}
+
+function workspaceById(workspaces, id) {
+  var values = workspaces || []
+  for (var i = 0; i < values.length; i++) {
+    if (values[i].id === id) return values[i]
+  }
+  return null
+}
+
+// Focused workspace is the filled-square nerd glyph; workspace 10 is labelled 0
+// to match the Super+0 binding.
+function workspaceLabel(id, focused) {
+  if (focused) return "\uDB85\uDCFB"
+  if (id === 10) return "0"
+  return String(id)
+}
+
+function toplevelList(workspace) {
+  if (!workspace || !workspace.toplevels) return []
+  var values = workspace.toplevels.values
+  if (values && typeof values.length === "number") return values
+  if (typeof workspace.toplevels.length === "number") return workspace.toplevels
+  return []
+}
+
+function toplevelCount(workspace) {
+  return toplevelList(workspace).length
+}
+
+function isOccupied(workspace) {
+  return toplevelCount(workspace) > 0
+}
+
+function isWindowFocused(toplevel) {
+  return !!(toplevel && toplevel.activated)
+}
+
+function windowRowLength(count, square, gap) {
+  var n = Number(count)
+  if (!isFinite(n) || n <= 0) return 0
+  var size = Number(square)
+  var spacing = Number(gap)
+  if (!isFinite(size) || size < 0) size = 0
+  if (!isFinite(spacing) || spacing < 0) spacing = 0
+  return n * size + (n - 1) * spacing
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    workspaceIds: workspaceIds,
+    workspaceById: workspaceById,
+    workspaceLabel: workspaceLabel,
+    toplevelList: toplevelList,
+    toplevelCount: toplevelCount,
+    isOccupied: isOccupied,
+    isWindowFocused: isWindowFocused,
+    windowRowLength: windowRowLength
+  }
+}

--- a/test/shell.d/workspaces-test.sh
+++ b/test/shell.d/workspaces-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const model = requireFromRoot('shell/plugins/bar/widgets/WorkspacesModel.js')
+const widgetSource = fs.readFileSync(root + '/shell/plugins/bar/widgets/Workspaces.qml', 'utf8')
+  .replace(/^\s*\/\/.*$/gm, '')
+
+assertDeepEqual(model.workspaceIds([]), [1, 2, 3, 4, 5], 'workspaces always include 1-5')
+assertDeepEqual(
+  model.workspaceIds([{ id: 2 }, { id: 7 }, { id: -99 }, { id: 11 }]),
+  [1, 2, 3, 4, 5, 7],
+  'workspaces append extra ids in 1-10 and ignore the rest'
+)
+assertDeepEqual(
+  model.workspaceIds([{ id: 10 }, { id: 6 }]),
+  [1, 2, 3, 4, 5, 6, 10],
+  'workspaces sort extra ids numerically'
+)
+
+const listed = [{ id: 2, name: '2' }, { id: 4, name: '4' }]
+assertEqual(model.workspaceById(listed, 4).name, '4', 'workspaces find a workspace by id')
+assertEqual(model.workspaceById(listed, 9), null, 'workspaces miss an unknown id')
+
+assertEqual(model.workspaceLabel(3, false), '3', 'workspaces label an inactive workspace with its number')
+assertEqual(model.workspaceLabel(10, false), '0', 'workspaces label workspace 10 as 0')
+assertEqual(model.workspaceLabel(2, true), '\uDB85\uDCFB', 'workspaces label the focused workspace with the filled-square glyph')
+
+const empty = { toplevels: { values: [] } }
+const occupied = { toplevels: { values: [{ activated: false }, { activated: true }] } }
+assertEqual(model.toplevelCount(null), 0, 'workspaces count no windows without a workspace')
+assertEqual(model.toplevelCount(empty), 0, 'workspaces count no windows on an empty workspace')
+assertEqual(model.toplevelCount(occupied), 2, 'workspaces count toplevels on a workspace')
+assertEqual(model.isOccupied(empty), false, 'workspaces treat an empty workspace as unoccupied')
+assertEqual(model.isOccupied(occupied), true, 'workspaces treat a workspace with toplevels as occupied')
+assertEqual(model.isWindowFocused({ activated: true }), true, 'workspaces treat an activated toplevel as focused')
+assertEqual(model.isWindowFocused({ activated: false }), false, 'workspaces treat an inactive toplevel as unfocused')
+
+assertEqual(model.windowRowLength(0, 5, 2), 0, 'workspaces give an empty window row no width')
+assertEqual(model.windowRowLength(1, 5, 2), 5, 'workspaces size a single window square')
+assertEqual(model.windowRowLength(3, 5, 2), 19, 'workspaces size three window squares with gaps')
+
+assert(/import "WorkspacesModel.js" as WorkspacesModel/.test(widgetSource), 'workspaces widget uses the model module')
+assert(/labelVisible: false/.test(widgetSource), 'workspaces widget draws its own stacked label so window squares can sit underneath')
+assert(/id: windowSlot/.test(widgetSource), 'workspaces widget reserves a slot under every workspace label')
+assert(/button\.workspace\.toplevels/.test(widgetSource), 'workspaces widget repeats one square per workspace toplevel')
+assert(/WorkspacesModel\.isWindowFocused\(modelData\)/.test(widgetSource), 'workspaces widget fills the square for the focused window')
+assert(/anchors\.horizontalCenter: parent\.horizontalCenter/.test(widgetSource), 'workspaces widget centers window squares under the workspace glyph')
+JS


### PR DESCRIPTION
The workspace indicator currently shows which workspace you're on. This adds a centered row of small squares under each workspace, one per open window:

- hollow square = window on that workspace
- filled square = the focused window

Empty workspaces keep the same reserved slot so the numbers stay aligned. A workspace cell grows horizontally when it has more windows than the default width. Clicking a workspace still focuses it, and the filled-square glyph for the active workspace is unchanged.

## Test plan

- `bash test/shell.d/workspaces-test.sh`
- `bash test/shell.d/bar-widget-contract-test.sh`
- `bash test/shell.d/qml-text-format-test.sh`
- `bash test/shell.d/plugin-clone-test.sh`
- Switch workspaces and confirm the filled workspace glyph moves, idle workspaces show only hollow window squares, and cycling windows on the current workspace moves the filled window square