### PR TITLE
Drop the Shokz dongle phantom power key with a libinput quirk

### DIFF
--- a/default/libinput/50-omarchy.quirks
+++ b/default/libinput/50-omarchy.quirks
@@ -1,0 +1,22 @@
+# Shokz USB headset dongles declare their vendor control channel as a single
+# Consumer "Power" usage, which the kernel maps to KEY_POWER on every byte of
+# that channel, so headset telemetry arrives as phantom power-key presses. The
+# dongles have no host power button, so only KEY_POWER is dropped.
+
+[Shokz OpenComm2 UC Dongle]
+MatchBus=usb
+MatchVendor=0x3511
+MatchProduct=0x2B1E
+AttrEventCode=-KEY_POWER
+
+[Shokz Loop120 Dongle (2EF2)]
+MatchBus=usb
+MatchVendor=0x3511
+MatchProduct=0x2EF2
+AttrEventCode=-KEY_POWER
+
+[Shokz Loop120 Dongle (2F06)]
+MatchBus=usb
+MatchVendor=0x3511
+MatchProduct=0x2F06
+AttrEventCode=-KEY_POWER

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -121,6 +121,7 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ environment.d/*.conf                               /usr/lib/environment.d/
   ├─ fontconfig/conf.avail/50-omarchy.conf              /usr/share/fontconfig/conf.avail/
   │                                                       + symlink /etc/fonts/conf.d/50-omarchy.conf
+  ├─ libinput/50-omarchy.quirks                         /usr/share/libinput/
   ├─ xdg-terminal-exec/*.list                           /usr/share/xdg-terminal-exec/
   ├─ applications/mimeapps.list                         /usr/share/applications/mimeapps.list
   ├─ systemd/user/*.service                             /usr/lib/systemd/user/

--- a/test/shell.d/libinput-quirks-test.sh
+++ b/test/shell.d/libinput-quirks-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command libinput
+
+quirks="$ROOT/default/libinput/50-omarchy.quirks"
+
+[[ -f $quirks ]] || fail "the shipped libinput quirks file exists"
+pass "the shipped libinput quirks file exists"
+
+# Stage the file alone: libinput validates a whole directory, so the host's own
+# quirks would confound the result.
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+cp "$quirks" "$test_tmp/"
+
+if ! validate_output=$(libinput quirks validate --data-dir "$test_tmp" 2>&1); then
+  fail "the shipped quirks file parses" "$validate_output"
+fi
+pass "the shipped quirks file parses"
+
+# Dropping a PID silently reintroduces the bug for that dongle.
+for product in 0x2B1E 0x2EF2 0x2F06; do
+  grep -q "MatchProduct=$product" "$quirks" ||
+    fail "the quirks cover the known Shokz dongles" "missing $product"
+done
+pass "the quirks cover the known Shokz dongles"
+
+# The volume and media keys are real; only KEY_POWER may be dropped.
+if grep '^AttrEventCode=' "$quirks" | grep -qvx 'AttrEventCode=-KEY_POWER'; then
+  fail "the quirks drop only the phantom power key" "$(grep '^AttrEventCode=' "$quirks")"
+fi
+pass "the quirks drop only the phantom power key"


### PR DESCRIPTION
## What

Ships a libinput quirk that drops the phantom `KEY_POWER` events Shokz USB headset dongles emit, so the system menu stops opening by itself.

Requires the companion PR in omarchy-pkgs: **omacom/omarchy-pkgs#279**. Without it the file ships only under `/usr/share/omarchy/default/` and has no effect.

## Why

Shokz dongles (`3511:2B1E/2EF2/2F06`) declare their proprietary control channel inside the Consumer Control collection using a single Consumer page usage `0x30`, which means "Power". The kernel duplicates that lone usage across every byte position of the three 511-byte and one 128-byte input reports (1661 usages) and `hid-input` maps Consumer `0x30` to `KEY_POWER` unconditionally. Ordinary headset telemetry therefore arrives as power-key presses, a few seconds after plug-in and again on later link or battery state changes.

Omarchy binds `XF86PowerOff` to the system menu (`default/hypr/bindings/utilities.lua`), so each phantom press opens it. The dongles have no host power button, so dropping `KEY_POWER` for them loses nothing; volume and media keys on the same node are untouched.

A hwdb keycode remap cannot fix this: udev issues one `EVIOCSKEYCODE` per entry and `hidinput_setkeycode()` reaches only the first of the 1661 duplicated usages. Filtering the event code in libinput is unaffected by the duplication.

## Placement

`default/libinput/50-omarchy.quirks`, installed package-owned at `/usr/share/libinput/50-omarchy.quirks`, per the quick reference in `docs/file-layout.md` and matching `default/fontconfig/conf.avail/50-omarchy.conf`.

Deliberately not `/etc/libinput/local-overrides.quirks`: that is the single admin override path libinput reads, and a package owning it would conflict with users who already applied the manual workaround.

No migration. Package-owned files reach existing installs through pacman on the next `omarchy update`, which is how every other `default/**` system file ships. It takes effect at the next Hyprland start.

## Device coverage

`0x2F06` (Loop120) is verified by full HID descriptor decode and on-hardware testing. `0x2EF2` (Loop120) and `0x2B1E` (OpenComm2 UC) come from public reports of the same symptom; `0x2B1E` is corroborated by the existing `USB_ID(0x3511, 0x2b1e)` entry in `sound/usb/quirks.c`. The quirk is an exact VID:PID match and inert on anything else.

## Upstream

Reported to libinput as [libinput#1333](https://gitlab.freedesktop.org/libinput/libinput/-/issues/1333) with a `libinput record` capture attached and the same quirk offered as a patch. Once it ships in a libinput release and reaches Arch, this file becomes redundant and can be deleted with no migration.

## Tests

- `./test/cli` — pass
- `./test/shell` — 226 of 227. The single failure is `runtime-smoke-test.sh`, which fails identically on pristine `quattro` on the same machine.
- New `test/shell.d/libinput-quirks-test.sh` — pass. Validates the file through `libinput quirks validate`, pins the three PIDs, and asserts `KEY_POWER` is the only event code touched. Negative-tested against a deliberately broken section.
- Live device: with the dongle attached, `libinput quirks list` against the shipped file prints `AttrEventCode=-KEY_POWER;`. Confirmed behaviorally on 4.0.2 with the same rule installed as a local override: after a Hyprland restart the menu no longer opens on headset power-cycle, and the dongle's volume keys still work.
