### PR TITLE
Keep reminder message files out of shared /tmp

### DIFF
--- a/bin/omarchy-reminder
+++ b/bin/omarchy-reminder
@@ -44,7 +44,7 @@ open_interactive() {
 
 show_reminders() {
   local timer next remaining reminder reminder_minutes body=""
-  local reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
+  local reminder_dir="${XDG_RUNTIME_DIR:-$HOME/.local/state}/omarchy-reminders"
   local reminder_message=""
   local now=$(date +%s)
 
@@ -72,7 +72,7 @@ show_reminders() {
 
 show_json() {
   local timer next remaining reminder reminder_minutes unit reminder_message label item_json reminders_json="[]"
-  local reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
+  local reminder_dir="${XDG_RUNTIME_DIR:-$HOME/.local/state}/omarchy-reminders"
   local now=$(date +%s)
   local count=0
   local tooltip="Set Reminder"
@@ -119,7 +119,7 @@ show_json() {
 
 clear_reminders() {
   local units
-  local reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
+  local reminder_dir="${XDG_RUNTIME_DIR:-$HOME/.local/state}/omarchy-reminders"
 
   units=$(systemctl --user list-timers --all --no-legend --no-pager "omarchy-reminder-*.timer" 2>/dev/null | awk '{ print $(NF - 1), $NF }')
 
@@ -182,12 +182,13 @@ fi
 set_at=$(date +%s)
 remind_at=$(date -d "+${minutes} minutes" +%H:%M)
 unit="omarchy-reminder-${minutes}m-$set_at"
-reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
+reminder_dir="${XDG_RUNTIME_DIR:-$HOME/.local/state}/omarchy-reminders"
 message_file="$reminder_dir/$unit.message"
 confirmation="You'll be reminded at $remind_at"
 confirmation_title="Reminder set for ${minutes} minutes"
 
 mkdir -p "$reminder_dir"
+chmod 700 "$reminder_dir"
 
 if [[ -n $custom_message ]]; then
   printf "%s" "$custom_message" >"$message_file"


### PR DESCRIPTION
## Summary
- reminder messages fell back to `/tmp/omarchy-reminders`
- prefer `XDG_RUNTIME_DIR`, else `~/.local/state`, and `chmod 0700`

## Test plan
- [ ] `omarchy reminder 1 test` writes under runtime/state, not `/tmp`
