### PR TITLE
Keep agent usage caches owner-readable

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -240,8 +240,8 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
   try:
     with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
       handle.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n")
-    # mkstemp opens at 0600; these caches were world-readable before.
-    tmp.chmod(0o644)
+    # mkstemp opens at 0600 — keep caches owner-only (usage may include
+    # model/plan details from the local agent config).
     tmp.replace(path)
   except BaseException:
     tmp.unlink(missing_ok=True)

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -379,8 +379,7 @@ def write_json(path, payload):
       handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
     # mkstemp opens at 0600; nothing in the cache is sensitive, so open it
     # up to the usual 0644.
-    tmp.chmod(0o644)
-    tmp.replace(path)
+        tmp.replace(path)
   except BaseException:
     tmp.unlink(missing_ok=True)
     raise


### PR DESCRIPTION
## Summary
- usage collectors chmod'd mkstemp caches to 0644
- leave 0600 so local agent plan/usage details stay private

## Test plan
- [ ] regenerated cache mode is 0600
