### PR TITLE
Run theme helpers without loading profile scripts

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -35,7 +35,7 @@ run_parallel() {
   local pids=()
 
   for command in "$@"; do
-    bash -lc "$command" &
+    bash --noprofile --norc -c "$command" &
     pids+=("$!")
   done
 


### PR DESCRIPTION
## Summary
- theme-set used `bash -lc`, inheriting profile/bashrc into parallel hooks
- switch to `bash --noprofile --norc -c`

## Test plan
- [ ] theme switch still applies helper commands
