### PR TITLE
Add Super + Shift + J for dwindle swapsplit

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -3,6 +3,7 @@ o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
 o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+o.bind("SUPER + SHIFT + J", "Swap window split sides", hl.dsp.layout("swapsplit"))
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -14,6 +14,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Ctrl + Alt + Del` | Close all windows |
 | `Super + T`               | Toggle window between tiling/floating             |
 | `Super + J` | Toggle window position (horizontal/vertical) |
+| `Super + Shift + J` | Swap which side of the split the window sits on |
 | `Super + O`               | Toggle popping window into sticky'n'floating |
 | `Super + L`               | Toggle between dwindle and scrolling layout |
 | `Super + P`               | Toggle pseudo window style (natural v stretch) |


### PR DESCRIPTION
Adds `Super + Shift + J` for dwindle's `swapsplit`, alongside the existing `Super + J` for `togglesplit`.

## Why

Once three or more windows exist, the default bindings cannot produce every dwindle arrangement. `Super + Shift + Arrow` (`swapwindow`) exchanges two windows' contents but never changes the shape of the tree. `Super + J` (`togglesplit`) flips a split between side-by-side and stacked, but cannot move the focused window to the other side of its split.

The common case where this bites: you want one tall window on the left with two stacked on the right, but the tall window is currently on the right. No combination of swap and toggle gets you there, because swapping only trades leaves and toggling only rotates a split. `swapsplit` is the missing verb.

Concrete reproduction on a fresh workspace: open A, B, C in order and you get `A | [B / C]`. Wanting `[B / C] | A` is unreachable. Swapping A with B or C only trades leaves (`B | [A / C]`), and `togglesplit` on A turns the root split into top/bottom instead. `swapsplit` on A does it in one keypress.

## Why a new chord rather than changing swap

#2961 proposed replacing `swapwindow` with `movewindow` and was closed because `movewindow` collapses columns in a 2 / 1 / 2 layout. This change leaves swap alone. `Super + Shift + J` is currently unbound, and pairing it with `Super + J` keeps the two split operations on one key.

## Changes

- `default/hypr/bindings/tiling.lua`: one `o.bind` line
- `manual/07-hotkeys.md`: one row in the hotkey table

Tested on Omarchy 4.0.2 / Hyprland 0.56.2 with `hyprctl reload` and `hyprctl configerrors` clean. `test/shell.d/hyprland-default-config-test.sh` passes.
