### PR TITLE
feat: cycle battery percentage placement

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -89,6 +89,31 @@ function modeLabel(device, onBattery, states) {
   return "Charging"
 }
 
+function batteryDisplayMode(configured, legacyShowPercentage) {
+  var mode = String(configured || "")
+  if (mode === "icon" || mode === "percentage-before" || mode === "percentage-after") return mode
+  return legacyShowPercentage === true ? "percentage-before" : "icon"
+}
+
+function nextBatteryDisplayMode(mode) {
+  var current = batteryDisplayMode(mode, false)
+  if (current === "icon") return "percentage-before"
+  if (current === "percentage-before") return "percentage-after"
+  return "icon"
+}
+
+function batteryBarText(mode, fraction, icon, vertical) {
+  if (vertical) return icon
+
+  var displayMode = batteryDisplayMode(mode, false)
+  if (displayMode === "icon") return icon
+
+  var percentage = Math.round(Number(fraction) * 100) + "%"
+  return displayMode === "percentage-after"
+    ? icon + " " + percentage
+    : percentage + " " + icon
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampIndex: clampIndex,
@@ -99,6 +124,9 @@ if (typeof module !== "undefined") {
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,
-    modeLabel: modeLabel
+    modeLabel: modeLabel,
+    batteryDisplayMode: batteryDisplayMode,
+    nextBatteryDisplayMode: nextBatteryDisplayMode,
+    batteryBarText: batteryBarText
   }
 }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -19,11 +19,16 @@ Panel {
   property string activeProfile: ""
   property int profileIndex: 0
   property bool cursorActive: false
-  readonly property bool showPercentage: setting("showPercentage", false) === true
+  // Keep the old boolean setting as the compatibility fallback. New cycles
+  // persist the richer mode only after the user reaches the new behavior.
+  readonly property string displayMode: Model.batteryDisplayMode(
+    setting("displayMode", null), setting("showPercentage", false)
+  )
+  readonly property bool percentageShown: displayMode !== "icon"
   // With the percentage shown the button paints a text block wider than an
   // icon, so the open-panel mark takes the painted width instead of the
   // icon-sized fraction of the slot the fallback assumes.
-  readonly property real openPanelIndicatorWidth: showPercentage && !button.vertical ? button.glyphPaintedWidth : 0
+  readonly property real openPanelIndicatorWidth: percentageShown && !button.vertical ? button.glyphPaintedWidth : 0
   readonly property bool batteryPresent: {
     var device = UPower.displayDevice
     return !!(device && device.isPresent)
@@ -170,7 +175,11 @@ Panel {
   }
 
   function togglePercentage() {
-    root.settings = Object.assign({}, root.settings, { showPercentage: !root.showPercentage })
+    // Retain this method name for existing IPC callers; right-click now cycles
+    // through the icon-only and the two percentage placements.
+    root.settings = Object.assign({}, root.settings, {
+      displayMode: Model.nextBatteryDisplayMode(root.displayMode)
+    })
     if (root.bar && root.bar.shell) root.bar.shell.updateEntryInline(root.moduleName, root.settings)
   }
 
@@ -277,10 +286,8 @@ Panel {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.showPercentage && !vertical
-      ? Math.round(root.batteryFraction * 100) + "% " + root.batteryIcon()
-      : root.batteryIcon()
-    slotSize: Style.bar.iconSlot * (root.showPercentage && !vertical ? 2 : 1)
+    text: Model.batteryBarText(root.displayMode, root.batteryFraction, root.batteryIcon(), vertical)
+    slotSize: Style.bar.iconSlot * (root.percentageShown && !vertical ? 2 : 1)
     tooltipText: ""
     onPressed: function(b) {
       if (!root.batteryPresent) return

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -42,10 +42,22 @@ assertEqual(
   'power shows battery icon when unplugged before battery state refreshes'
 )
 
-assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
-assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')
-assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon')
-assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
+assertEqual(power.batteryDisplayMode(undefined, false), 'icon', 'power defaults to the icon-only display')
+assertEqual(power.batteryDisplayMode(undefined, true), 'percentage-before', 'power preserves the legacy percentage setting')
+assertEqual(power.batteryDisplayMode('invalid', true), 'percentage-before', 'power falls back from an invalid display mode')
+assertEqual(power.nextBatteryDisplayMode('icon'), 'percentage-before', 'power cycles from icon to percentage before icon')
+assertEqual(power.nextBatteryDisplayMode('percentage-before'), 'percentage-after', 'power cycles from percentage before icon to percentage after icon')
+assertEqual(power.nextBatteryDisplayMode('percentage-after'), 'icon', 'power cycles from percentage after icon back to icon')
+assertEqual(power.batteryBarText('icon', 0.51, 'BATTERY', false), 'BATTERY', 'power renders the icon-only display')
+assertEqual(power.batteryBarText('percentage-before', 0.51, 'BATTERY', false), '51% BATTERY', 'power renders percentage before the icon')
+assertEqual(power.batteryBarText('percentage-after', 0.51, 'BATTERY', false), 'BATTERY 51%', 'power renders percentage after the icon')
+assertEqual(power.batteryBarText('percentage-after', 0.51, 'BATTERY', true), 'BATTERY', 'power hides percentage in vertical bars')
+
+assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click cycles the bar display')
+assert(/displayMode: Model\.nextBatteryDisplayMode\(root\.displayMode\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the selected display mode')
+assert(/Model\.batteryBarText\(root\.displayMode, root\.batteryFraction, root\.batteryIcon\(\), vertical\)/.test(panelSource), 'power delegates bar text placement to the display model')
+assert(/slotSize: Style\.bar\.iconSlot \* \(root\.percentageShown && !vertical \? 2 : 1\)/.test(panelSource), 'power keeps percentage hidden and icon-sized in vertical bars')
+assert(/openPanelIndicatorWidth:.*percentageShown.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
 JS


### PR DESCRIPTION
Adds icon-only, percentage-before-icon, and percentage-after-icon
    battery display modes. Preserves the legacy setting and keeps vertical bars
    icon-only.