### PR TITLE
fix(omarchy-channel-set): re-setting the current channel is a no-op (idempotence guard)

### DIFF
--- a/bin/omarchy-channel-set
+++ b/bin/omarchy-channel-set
@@ -72,6 +72,34 @@ case "$channel" in
     ;;
 esac
 
+# Idempotence guard — re-setting the CURRENT channel is a no-op (round-trip).
+# The active channel is read from /etc/pacman.d/mirrorlist, which
+# omarchy-refresh-pacman writes verbatim per channel (user customization targets
+# pacman.conf, not the mirrorlist).
+detect_active_channel() {
+  local m
+  m=$(grep -oE 'https?://[^/]*mirror\.omarchy\.org' /etc/pacman.d/mirrorlist 2>/dev/null | head -1)
+  case "$m" in
+    *stable-mirror*) echo stable ;;
+    *rc-mirror*)     echo rc ;;
+    *mirror*)        echo edge ;;
+    *)               echo "" ;;
+  esac
+}
+
+if [[ -n $dev_checkout && $OMARCHY_PATH == "$dev_checkout" ]]; then
+  echo "Already on the dev channel (linked checkout in $dev_checkout)."
+  exit 0
+fi
+
+if [[ -z $dev_checkout ]]; then
+  active=$(detect_active_channel)
+  if [[ -n $active && $active == "$channel" ]]; then
+    echo "Already on the $channel channel."
+    exit 0
+  fi
+fi
+
 if [[ -z $dev_checkout && $OMARCHY_PATH != "/usr/share/omarchy" ]]; then
   leaving_dev=1
 fi


### PR DESCRIPTION
## Summary

`omarchy-channel-set` unconditionally re-pointed pacman and reinstalled the channel packages on every invocation — including when the requested channel is the one already active. On a fresh ISO base this resolves a system-wide DOWNGRADE to the active channel snapshot's older versions, because the base ships packages newer than the frozen snapshot. The documented round-trip contract ("re-set is a no-op", used by the opencharly omarchy eval suite) is broken.

**Observed failure chain** (opencharly eval rc-twin bed, fresh base, repeated runs):
1. Killed at the runner's 2-minute bound — the command legitimately runs longer because it performs a real (downgrade) transaction.
2. With a raised bound: `warning: frei0r-plugins: downgrading from version 3.5.0-1 to version 3.4.3-1` and the transaction fails non-interactively (exit 1).
3. With piped answers: the full downgrade churn exhausts the 8G guest and is SIGKILLed (exit 137).

## Change

Add an idempotence guard that short-circuits when the requested channel is already active:
- Detect the active channel from `/etc/pacman.d/mirrorlist` (stable/rc/edge each write a uniquely-named mirror server; `omarchy-refresh-pacman` copies the mirrorlist verbatim, while user customization targets pacman.conf per the documented hook behavior).
- dev-channel re-set is a no-op when the source checkout is already linked.

The guard runs after argument validation and before any pacman mutation — no behavioral change for actual channel switches.

## How tested

- `bash -n` syntax check passes.
- Shell-logic review against the existing `omarchy-refresh-pacman` mirrorlist naming (stable → stable-mirror.omarchy.org, rc → rc-mirror.omarchy.org, edge → mirror.omarchy.org).
- The opencharly eval round-trip check (which asserted "re-set is a no-op" and exposed this defect) is expected to pass on this fix — verification on an actual RC VM runs on the eval bed once merged.

## Notes

- No metadata changes (command-metadata.md respected; summary/args/requires-sudo untouched).
- This is the implementation-level fix for the defect the opencharly eval suite surfaced; the eval-side workaround was intentionally not shipped (auto-confirming the downgrade would mask the bug).
