### PR TITLE
Add OpenClaw as an AI agent option

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -104,6 +104,10 @@ ori)
   command=(ori code)
   [[ -n ${prompt:-} ]] && command+=(--interactive --prompt "$prompt")
   ;;
+openclaw)
+  command=(openclaw tui)
+  [[ -n ${prompt:-} ]] && command+=(--message "$prompt")
+  ;;
 pi)
   command=(pi)
   [[ -n ${prompt:-} ]] && command+=("$prompt")

--- a/bin/omarchy-agent-usage-openclaw
+++ b/bin/omarchy-agent-usage-openclaw
@@ -1,0 +1,178 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the OpenClaw Agent usage record as JSON
+# omarchy:args=[--write]
+"""Collect OpenClaw Gateway usage into one display-ready JSON record.
+
+Everything the agents panel shows for OpenClaw comes from this one command:
+session stats (sessions, per-model input/output tokens) from
+`openclaw sessions --json --all-agents` and run counts from the gateway audit
+log (`openclaw audit`, agent.run.started events). It prints the same record
+contract as the packaged claude/codex collectors; with --write it updates the
+record file atomically.
+
+Chat sessions that arrived over messaging gateways count too: the gateway
+treats them as first-class sessions and so does this record.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+USAGE_DIR = Path(os.environ.get("XDG_STATE_HOME") or Path.home() / ".local/state") / "omarchy/agents/usage"
+RECENT_DAYS = 7
+AUDIT_MAX_PAGES = 50
+
+
+def day_bounds(day) -> tuple[float, float]:
+    start = datetime(day.year, day.month, day.day).astimezone()
+    return start.timestamp(), start.timestamp() + 86400
+
+
+def cli_json(args: list[str]) -> dict:
+    out = subprocess.run(["openclaw"] + args, capture_output=True, text=True, timeout=60)
+    if out.returncode != 0:
+        raise RuntimeError((out.stderr or out.stdout).strip().splitlines()[-1] if (out.stderr or out.stdout) else "cli failed")
+    return json.loads(out.stdout)
+
+
+def collect_run_events() -> tuple[int, int, dict[str, int]]:
+    """Return (totalPrompts, todayPrompts, perDayCounts for the recent window)."""
+    now = datetime.now().astimezone()
+    today_start, _ = day_bounds(now.date())
+    week_start, _ = day_bounds(now.date() - timedelta(days=RECENT_DAYS - 1))
+
+    total = 0
+    today = 0
+    per_day: dict[str, int] = {}
+    cursor = None
+    for _ in range(AUDIT_MAX_PAGES):
+        args = ["audit", "--json"]
+        if cursor:
+            args += ["--cursor", str(cursor)]
+        data = cli_json(args)
+        events = data.get("events") or []
+        for ev in events:
+            if ev.get("action") != "agent.run.started":
+                continue
+            ts = ev.get("occurredAt")
+            if not ts:
+                continue
+            total += 1
+            if ts >= today_start * 1000:
+                today += 1
+            if ts >= week_start * 1000:
+                day = datetime.fromtimestamp(ts / 1000).astimezone().date().isoformat()
+                per_day[day] = per_day.get(day, 0) + 1
+        cursor = data.get("nextCursor") or data.get("cursor")
+        if not cursor or not events:
+            break
+    return total, today, per_day
+
+
+def collect() -> dict:
+    now = datetime.now().astimezone()
+    record = {
+        "schemaVersion": 1,
+        "id": "openclaw",
+        "name": "OpenClaw",
+        "updatedAt": now.isoformat(),
+        "ready": shutil.which("openclaw") is not None,
+        "hasLocalStats": False,
+        "todayPrompts": 0,
+        "todaySessions": 0,
+        "todayTotalTokens": 0,
+        "todayTokensByModel": {},
+        "recentDays": [],
+        "totalPrompts": 0,
+        "totalSessions": 0,
+        "activeDays": 0,
+        "activeDates": [],
+        "modelUsage": {},
+        "limits": [],
+        "tierLabel": "",
+        "usageStatusText": "" if shutil.which("openclaw") else "OpenClaw CLI not found",
+        "authHelpText": "",
+    }
+    if not record["ready"]:
+        return record
+
+    today_start, _ = day_bounds(now.date())
+
+    try:
+        sessions = cli_json(["sessions", "--json", "--all-agents", "--limit", "all"]).get("sessions") or []
+        total_prompts, today_prompts, run_days = collect_run_events()
+    except (RuntimeError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        record["usageStatusText"] = f"OpenClaw CLI error: {exc}"
+        return record
+
+    record["hasLocalStats"] = True
+    record["totalPrompts"] = total_prompts
+    record["todayPrompts"] = today_prompts
+    record["totalSessions"] = len(sessions)
+
+    started_dates = []
+    for s in sessions:
+        started = s.get("sessionStartedAt")
+        if started:
+            started_dates.append(datetime.fromtimestamp(started / 1000).astimezone().date().isoformat())
+        if s.get("updatedAt", 0) >= today_start * 1000:
+            record["todaySessions"] += 1
+            model = s.get("model") or "unknown"
+            provider = s.get("modelProvider")
+            ref = f"{provider}/{model}" if provider else model
+            tokens = int(s.get("totalTokens") or 0)
+            if tokens:
+                record["todayTokensByModel"][ref] = record["todayTokensByModel"].get(ref, 0) + tokens
+        mu = record["modelUsage"].setdefault(
+            f"{s.get('modelProvider')}/{s.get('model')}" if s.get("modelProvider") else s.get("model") or "unknown",
+            {"inputTokens": 0, "outputTokens": 0, "cacheReadInputTokens": 0, "cacheCreationInputTokens": 0},
+        )
+        mu["inputTokens"] += int(s.get("inputTokens") or 0)
+        mu["outputTokens"] += int(s.get("outputTokens") or 0)
+
+    record["todayTotalTokens"] = sum(record["todayTokensByModel"].values())
+    record["recentDays"] = [
+        {
+            "date": (now.date() - timedelta(days=offset)).isoformat(),
+            "messageCount": int(run_days.get((now.date() - timedelta(days=offset)).isoformat(), 0)),
+        }
+        for offset in range(RECENT_DAYS - 1, -1, -1)
+    ]
+    active_dates = sorted(set(started_dates))
+    record["activeDays"] = len(active_dates)
+    record["activeDates"] = active_dates[-400:]
+    return record
+
+
+def main() -> int:
+    record = collect()
+    payload = json.dumps(record, separators=(",", ":"))
+
+    if "--write" not in sys.argv[1:]:
+        print(payload)
+        return 0
+
+    USAGE_DIR.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".openclaw.", dir=USAGE_DIR)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(payload + "\n")
+        os.replace(tmp, USAGE_DIR / "openclaw.json")
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set and launch the default coding agent
-# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|agy|hermes|copilot|crush]
+# omarchy:args=[pi|omp|opencode|ori|openclaw|claude|codex|grok|agy|hermes|copilot|crush]
 # omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent claude
 
 installing=false
@@ -26,6 +26,7 @@ fi
 case "$1" in
 pi) agent="pi"; name="Pi" ;;
 omp | oh-my-pi) agent="omp"; name="Oh My Pi"; agent_package="github:can1357/oh-my-pi" ;;
+openclaw | open-claw) agent="openclaw"; name="OpenClaw"; agent_package="npm:openclaw" ;;
 opencode | open-code) agent="opencode"; name="OpenCode" ;;
 ori | openrouter) agent="ori"; name="Ori"; agent_package="github:OpenRouterLabs/ori-releases" ;;
 claude | claude-code) agent="claude"; name="Claude Code" ;;
@@ -36,7 +37,7 @@ agy | antigravity | antigravity-cli | gemini | gemini-cli) agent="agy"; name="An
 hermes) agent="hermes"; name="Hermes"; agent_installer="omarchy-install-hermes-cli" ;;
 copilot | github-copilot) agent="copilot"; name="GitHub Copilot" ;;
 *)
-  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|agy|hermes|copilot|crush>"
+  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|openclaw|claude|codex|grok|agy|hermes|copilot|crush>"
   exit 1
   ;;
 esac

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -143,6 +143,7 @@
   "setup.default.agent.grok": {"icon":"","iconFont":"omarchy","label":"Grok","checked":"[[ \"$(omarchy-default-agent)\" == \"grok\" ]]","action":"omarchy-default-agent grok"},
   "setup.default.agent.hermes": {"icon":"","iconFont":"omarchy","label":"Hermes","checked":"[[ \"$(omarchy-default-agent)\" == \"hermes\" ]]","action":"omarchy-default-agent hermes"},
   "setup.default.agent.omp": {"icon":"","iconFont":"omarchy","label":"omp","checked":"[[ \"$(omarchy-default-agent)\" == \"omp\" ]]","action":"omarchy-default-agent omp"},
+  "setup.default.agent.openclaw": {"icon":"󰚩","iconFont":"omarchy","label":"OpenClaw","checked":"[[ \"$(omarchy-default-agent)\" == \"openclaw\" ]]","action":"omarchy-default-agent openclaw"},
   "setup.default.agent.opencode": {"icon":"","iconFont":"omarchy","label":"OpenCode","checked":"[[ \"$(omarchy-default-agent)\" == \"opencode\" ]]","action":"omarchy-default-agent opencode"},
   "setup.default.agent.ori": {"icon":"","iconFont":"omarchy","label":"Ori","checked":"[[ \"$(omarchy-default-agent)\" == \"ori\" ]]","action":"omarchy-default-agent ori"},
   "setup.default.agent.pi": {"icon":"","iconFont":"omarchy","label":"Pi","checked":"[[ \"$(omarchy-default-agent)\" == \"pi\" ]]","action":"omarchy-default-agent pi"},


### PR DESCRIPTION
# Add OpenClaw as an AI agent option

## Summary

Adds [OpenClaw](https://openclaw.ai/) (formerly Clawdbot/Moltbot) to the AI
coding-agent roster on `quattro`, following the exact conventions of the
existing agents:

- lazy-loaded launcher via mise (`agent_package="npm:openclaw"`)
- a row in **Setup > Defaults > Agent** with the standard checkmark guard
- an unattended launch mapping in `omarchy-agent` (`openclaw tui`, prompt
  seeded via `--message`)
- an agents-panel usage collector matching the packaged collector record
  contract (`schemaVersion: 1`), writing `openclaw.json` next to
  `claude.json` and `codex.json`

## Why

OpenClaw is one of the most widely used agent harnesses, and its terminal UI
(`openclaw tui`) is a full agent surface with tool approvals. Users who run it
alongside Claude Code / Codex / OpenCode currently get no agents-panel usage
tracking and no default-agent option. This patch closes both gaps the same way
every other agent is wired.

## Changes

1. `bin/omarchy-default-agent` — `openclaw` / `open-claw` case, usage strings
2. `bin/omarchy-agent` — launch case: `openclaw tui` (gateway-connected TUI),
   `--message "$prompt"` for prompt seeding
3. `default/omarchy/omarchy-menu.jsonc` — `setup.default.agent.openclaw` row
4. `bin/omarchy-agent-usage-openclaw` — new usage collector (same record
   contract as the packaged collectors; discovers sessions via
   `openclaw sessions --json --all-agents` and prompt counts from gateway
   audit events)

## Notes for review

- OpenClaw is a gateway-first tool; `openclaw tui` talks to the local Gateway
  (loopback) and works headless, so the launch mapping needs no special flags.
- The usage collector shells out to the `openclaw` CLI rather than reading its
  state SQLite directly (the store uses the `sqlite-vec` extension), which
  also keeps it stable across OpenClaw schema changes.
- The collector only reports metadata (counts, model names, token totals) —
  no message content, credentials, or provider keys are read or written.

## Testing

- `bash -n` on both modified scripts; JSONC parse on the modified menu
- `openclaw tui` launches against a running gateway and accepts `--message`
- collector verified against a live gateway: correct today/session/token
  aggregates, atomic write to `~/.local/state/omarchy/agents/usage/openclaw.json`
