### PR TITLE
Probe sudo non-interactively so unattended updates cannot hang

### DIFF
--- a/bin/omarchy-update-stay-awake
+++ b/bin/omarchy-update-stay-awake
@@ -91,8 +91,11 @@ start() {
 
   if omarchy-cmd-present systemd-inhibit; then
     if (( EUID != 0 )); then
-      if [[ -t 0 ]]; then
-        sudo -v
+      # sudo -v hangs scripted updates: it demands a password even under
+      # NOPASSWD, and the update always runs under a pty, so a tty check
+      # cannot tell a human from a script. Probe instead and fall back to
+      # pkexec when sudo would need an interactive password.
+      if sudo -n true 2>/dev/null; then
         inhibit_runner=(sudo)
       else
         inhibit_runner=(pkexec)

--- a/test/shell.d/update-lock-test.sh
+++ b/test/shell.d/update-lock-test.sh
@@ -50,6 +50,7 @@ for command in \
   write_stub "$command" 'exit 0'
 done
 write_stub omarchy-update-available 'exit 1'
+write_stub sudo '[[ $1 != "-n" ]] || shift; exec "$@"'
 write_stub pkexec 'exec "$@"'
 
 # omarchy-update should hold the lock before snapshotting, so a second update
@@ -123,9 +124,7 @@ if (( EUID != 0 )); then
   terminal_inhibit_pid_file="$test_tmp/terminal-inhibit-pid"
   write_stub sudo '
 printf "%s\n" "$*" >>"$SUDO_LOG"
-if [[ $1 == "-v" ]]; then
-  exit 0
-fi
+[[ $1 != "-n" ]] || shift
 exec "$@"'
   write_stub pkexec 'touch "$PKEXEC_MARKER"; exec "$@"'
 
@@ -146,7 +145,7 @@ SH
   SUDO_LOG="$sudo_log" PKEXEC_MARKER="$pkexec_marker" INHIBIT_PID_FILE="$terminal_inhibit_pid_file" \
     run_with_lock_env script -qefc "$terminal_driver" /dev/null >/dev/null
 
-  grep -qx -- '-v' "$sudo_log" || fail "terminal sleep inhibition validates sudo in the foreground"
+  grep -qx -- '-n true' "$sudo_log" || fail "terminal sleep inhibition probes sudo without prompting"
   grep -q '^systemd-inhibit ' "$sudo_log" || fail "terminal sleep inhibition runs through sudo"
   [[ ! -e $pkexec_marker ]] || fail "terminal sleep inhibition does not use pkexec"
   run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop


### PR DESCRIPTION
## Problem

`omarchy update` run non-interactively (scripts, cron, AI agents — a workflow the manual explicitly supports) hangs for exactly 5 minutes and then aborts with "Something went wrong during the update!". By that point the pre-update snapshot has already been created, so the user is left with a confusing failure and no update.

## Root cause

Three pieces conspire:

1. `omarchy-update` re-executes itself under `script -qefc ... /tmp/omarchy-update.log` for logging, so **every** step runs with a PTY on stdin.
2. `omarchy-update-stay-awake start()` picks its privilege runner with `[[ -t 0 ]]` — which is therefore **always** true under the logging PTY — and runs `sudo -v`.
3. `sudo -v` cannot complete without typed input: on current Arch sudo it prompts even when `NOPASSWD: ALL` is granted, waits `passwd_timeout` (default 300 s), then fails. `set -e` plus the ERR trap abort the whole update.

Journal evidence from a real machine: three failed update attempts at 00:27–00:28, and one that hung from 01:01:58 to exactly 01:07:01 (≈ `passwd_timeout`) before aborting right after the snapshot step.

Reproducer on an affected system (returns nothing until killed, 300 s unattended):

```bash
timeout 12 script -qefc 'omarchy-update-stay-awake start' /dev/null
```

## Fix

Replace the tty guess with a capability probe:

```bash
if sudo -n true 2>/dev/null; then
  inhibit_runner=(sudo)
else
  inhibit_runner=(pkexec)
fi
```

- Non-interactive by construction — it can never wait on input.
- Interactive users with valid tickets or NOPASSWD keep the sudo path.
- Everyone else gets the pkexec dialog: the branch that already existed for non-tty callers but could never trigger during an update, because the logging PTY always defeated the `[[ -t 0 ]]` check.

## Tests

`test/shell.d/update-lock-test.sh` updated: the sudo stub handles the `-n true` probe, and the terminal-section assertion now verifies the non-interactive probe instead of `sudo -v`. All 7 assertions pass.

## Related (not in this PR)

`omarchy-sudo-keepalive` (sourced by `omarchy-pkg-install` / `omarchy-pkg-aur-install`) opens with a bare `sudo -v` and can hang menu-driven package installs the same way while passwordless sudo is enabled. Happy to file or fix that separately.
