### PR TITLE
Fix nonfunctional brightness sliders on some DDC monitors

### DIFF
--- a/bin/omarchy-brightness-display-ddc
+++ b/bin/omarchy-brightness-display-ddc
@@ -12,14 +12,12 @@ step="${2:-}"
 cache_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-brightness-display-ddc"
 cache_name="${monitor//[^[:alnum:]_.-]/_}"
 cache_file="$cache_dir/$cache_name.bus"
-full_checks_cache_file="$cache_dir/$cache_name.full-checks"
 unavailable_cache_seconds=60
 range_cache_seconds=10
 
 cache_unavailable() {
   mkdir -p "$cache_dir" 2>/dev/null || true
   printf 'unavailable %s\n' "$(date +%s)" >"$cache_file" 2>/dev/null || true
-  rm -f "$full_checks_cache_file"
 }
 
 detect_bus() {
@@ -103,28 +101,11 @@ read_brightness() {
   printf '%s %s\n' "$bus" "$values"
 }
 
+# Some displays ignore a write on the fast path but accept it once the initial
+# DDC checks run, so retry with full checks before reporting a rejected write.
 write_vcp() {
-  local bus="$1"
-  local raw_target="$2"
-  local full_checks_bus=""
-
-  if [[ -r $full_checks_cache_file ]]; then
-    read -r full_checks_bus <"$full_checks_cache_file" || true
-  fi
-
-  if [[ $full_checks_bus == "$bus" ]]; then
-    if ddcutil --bus "$bus" --verify setvcp 10 "$raw_target" >/dev/null 2>&1; then
-      return 0
-    fi
-  elif ddcutil --bus "$bus" --skip-ddc-checks --verify setvcp 10 "$raw_target" >/dev/null 2>&1; then
-    return 0
-  elif ddcutil --bus "$bus" --verify setvcp 10 "$raw_target" >/dev/null 2>&1; then
-    printf '%s\n' "$bus" >"$full_checks_cache_file" 2>/dev/null || true
-    return 0
-  fi
-
-  cache_unavailable
-  return 1
+  ddcutil --bus "$1" --skip-ddc-checks --verify setvcp 10 "$2" >/dev/null 2>&1 ||
+    ddcutil --bus "$1" --verify setvcp 10 "$2" >/dev/null 2>&1
 }
 
 bus=""

--- a/bin/omarchy-brightness-display-ddc
+++ b/bin/omarchy-brightness-display-ddc
@@ -12,12 +12,14 @@ step="${2:-}"
 cache_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-brightness-display-ddc"
 cache_name="${monitor//[^[:alnum:]_.-]/_}"
 cache_file="$cache_dir/$cache_name.bus"
+full_checks_cache_file="$cache_dir/$cache_name.full-checks"
 unavailable_cache_seconds=60
 range_cache_seconds=10
 
 cache_unavailable() {
   mkdir -p "$cache_dir" 2>/dev/null || true
   printf 'unavailable %s\n' "$(date +%s)" >"$cache_file" 2>/dev/null || true
+  rm -f "$full_checks_cache_file"
 }
 
 detect_bus() {
@@ -101,6 +103,30 @@ read_brightness() {
   printf '%s %s\n' "$bus" "$values"
 }
 
+write_vcp() {
+  local bus="$1"
+  local raw_target="$2"
+  local full_checks_bus=""
+
+  if [[ -r $full_checks_cache_file ]]; then
+    read -r full_checks_bus <"$full_checks_cache_file" || true
+  fi
+
+  if [[ $full_checks_bus == "$bus" ]]; then
+    if ddcutil --bus "$bus" --verify setvcp 10 "$raw_target" >/dev/null 2>&1; then
+      return 0
+    fi
+  elif ddcutil --bus "$bus" --skip-ddc-checks --verify setvcp 10 "$raw_target" >/dev/null 2>&1; then
+    return 0
+  elif ddcutil --bus "$bus" --verify setvcp 10 "$raw_target" >/dev/null 2>&1; then
+    printf '%s\n' "$bus" >"$full_checks_cache_file" 2>/dev/null || true
+    return 0
+  fi
+
+  cache_unavailable
+  return 1
+}
+
 bus=""
 current=""
 maximum=""
@@ -160,9 +186,5 @@ fi
 (( target > 100 )) && target=100
 (( raw_target = (target * maximum + 50) / 100 ))
 
-if ! ddcutil --bus "$bus" --skip-ddc-checks --noverify setvcp 10 "$raw_target" >/dev/null 2>&1; then
-  rm -f "$cache_file"
-  exit 1
-fi
-
+write_vcp "$bus" "$raw_target" || exit 1
 printf '%s\n' "$target"

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -17,6 +17,7 @@ Panel {
   property int brightnessPercent: 0
   property int pendingBrightnessPercent: 0
   property bool brightnessSetQueued: false
+  property bool brightnessOsdPending: false
   property bool brightnessAvailable: false
   property string internalMonitor: ""
   property string externalMonitor: ""
@@ -414,17 +415,30 @@ Panel {
   Process {
     id: setBrightnessProc
     stdout: StdioCollector { waitForEnd: true }
-    // Do NOT call refresh() after a brightness set completes. The local
+    // Do NOT call refresh() after a brightness set succeeds. The local
     // brightnessPercent we just wrote is authoritative; re-reading via
     // `omarchy-brightness-display` races the hardware/driver and can
     // return an empty string, which the parser then coerces to 0 —
     // visible as a "bounce to zero" after h/l keypresses. External
     // brightness changes are still picked up by the 5s periodic refresh,
     // the open-time refresh, and Component.onCompleted.
-    onRunningChanged: {
-      if (running) return
+    //
+    // A failed set is verified wrong, so drop the queue and refresh to snap
+    // the slider back. The OSD is only shown once a write is verified.
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        root.brightnessSetQueued = false
+        root.brightnessOsdPending = false
+        root.refresh()
+        return
+      }
       if (root.brightnessSetQueued) {
         root.setBrightness(root.pendingBrightnessPercent)
+        return
+      }
+      if (root.brightnessOsdPending) {
+        root.brightnessOsdPending = false
+        root.showBrightnessOsd(root.brightnessPercent)
       }
     }
   }
@@ -476,8 +490,8 @@ Panel {
       var wheel = Util.wheelSteps(root.wheelAccumulator, delta)
       root.wheelAccumulator = wheel.remainder
       if (wheel.steps === 0) return
+      root.brightnessOsdPending = true
       root.setBrightness(root.brightnessPercent + wheel.steps * 5)
-      root.showBrightnessOsd(root.brightnessPercent)
     }
   }
 

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -14,9 +14,15 @@ Panel {
 
   // manageIpc: false so this panel can own the single IpcHandler the target
   // permits — needed for the brightness + state methods below.
+
+  // Brightness is written optimistically: the slider moves first and
+  // `omarchy-brightness-display` verifies afterwards. brightnessPercent is both
+  // what the slider shows and the value the hardware still owes us,
+  // sentBrightnessPercent is what the write in flight is verifying, and
+  // confirmedBrightnessPercent is the last percentage the hardware accepted.
   property int brightnessPercent: 0
-  property int pendingBrightnessPercent: 0
-  property bool brightnessSetQueued: false
+  property int sentBrightnessPercent: 0
+  property int confirmedBrightnessPercent: 0
   property bool brightnessOsdPending: false
   property bool brightnessAvailable: false
   property string internalMonitor: ""
@@ -205,7 +211,7 @@ Panel {
   function brightnessIpc(percent) {
     var value = Number(percent)
     root.setBrightness(value)
-    return "got " + root.pendingBrightnessPercent
+    return "got " + root.brightnessPercent
   }
 
   function stateIpc() {
@@ -237,14 +243,14 @@ Panel {
   function setBrightness(value) {
     var percent = Model.clampBrightness(value)
     root.brightnessPercent = percent
-    root.pendingBrightnessPercent = percent
 
-    if (setBrightnessProc.running) {
-      root.brightnessSetQueued = true
-      return
-    }
+    // A write is already in flight. brightnessPercent now differs from the
+    // percentage that write is verifying, which is how onExited knows to send
+    // this one after it finishes -- so a drag coalesces into a single trailing
+    // write instead of one write per step.
+    if (setBrightnessProc.running) return
 
-    root.brightnessSetQueued = false
+    root.sentBrightnessPercent = percent
     setBrightnessProc.command = ["omarchy-brightness-display", "--no-osd", "--monitor", root.focusedMonitor, percent + "%"]
     setBrightnessProc.running = true
   }
@@ -393,7 +399,12 @@ Panel {
         var lines = String(text || "").split("\n")
         var brightness = String(lines[0] || "").trim()
         root.brightnessAvailable = brightness !== "unavailable" && brightness !== ""
-        root.brightnessPercent = root.brightnessAvailable ? Math.max(0, Math.min(100, parseInt(brightness, 10))) : 0
+        var read = root.brightnessAvailable ? Math.max(0, Math.min(100, parseInt(brightness, 10))) : 0
+        if (root.brightnessAvailable) root.confirmedBrightnessPercent = read
+        // A poll that lands mid-write read the hardware before the write got
+        // there, so it is already stale. brightnessPercent is the value we are
+        // still writing; let the write settle it rather than fighting the slider.
+        if (!setBrightnessProc.running) root.brightnessPercent = read
         root.internalMonitor = String(lines[1] || "").trim()
         root.externalMonitor = String(lines[2] || "").trim()
         root.internalEnabled = String(lines[3] || "").trim() !== ""
@@ -423,19 +434,27 @@ Panel {
     // brightness changes are still picked up by the 5s periodic refresh,
     // the open-time refresh, and Component.onCompleted.
     //
-    // A failed set is verified wrong, so drop the queue and refresh to snap
-    // the slider back. The OSD is only shown once a write is verified.
+    // A failed set is verified wrong, so snap the slider back to the last
+    // percentage the hardware confirmed. That revert is local
+    // for the same reason: refresh() here would race the read path and an empty
+    // result clears brightnessAvailable, which hides the slider until the next
+    // poll. The OSD is only shown once a write is verified.
     onExited: function(exitCode) {
       if (exitCode !== 0) {
-        root.brightnessSetQueued = false
         root.brightnessOsdPending = false
-        root.refresh()
+        root.brightnessPercent = root.confirmedBrightnessPercent
         return
       }
-      if (root.brightnessSetQueued) {
-        root.setBrightness(root.pendingBrightnessPercent)
+
+      root.confirmedBrightnessPercent = root.sentBrightnessPercent
+
+      // The slider moved on while this write was in flight, so send what the
+      // hardware still owes us and let that write finish the burst.
+      if (root.brightnessPercent !== root.sentBrightnessPercent) {
+        root.setBrightness(root.brightnessPercent)
         return
       }
+
       if (root.brightnessOsdPending) {
         root.brightnessOsdPending = false
         root.showBrightnessOsd(root.brightnessPercent)

--- a/test/shell.d/brightness-display-test.sh
+++ b/test/shell.d/brightness-display-test.sh
@@ -84,40 +84,33 @@ grep -F 'ddcutil --bus 7 --skip-ddc-checks --verify setvcp 10 24' "$call_log" >/
   fail "external brightness verifies every write"
 pass "absolute external brightness reuses its range and verifies its write"
 
-printf '6\n' >"$runtime_dir/omarchy-brightness-display-ddc/DP-1.full-checks"
 set_count=$(grep -c ' setvcp 10 ' "$call_log")
-run_brightness --no-osd --monitor DP-1 32%
-(( $(grep -c ' setvcp 10 ' "$call_log") == set_count + 1 )) || \
-  fail "a full-checks marker for another bus is ignored"
-grep -F 'ddcutil --bus 7 --skip-ddc-checks --verify setvcp 10 26' "$call_log" >/dev/null || \
-  fail "a remapped DDC bus probes the fast path"
-pass "full DDC checks are cached for one connector and bus"
-
-DDC_FAST_WRITE_FAIL=1 run_brightness --no-osd --monitor DP-1 35%
+DDC_FAST_WRITE_FAIL=1 run_brightness --no-osd --monitor DP-1 35% || \
+  fail "a rejected fast DDC write is retried with full checks"
+(( $(grep -c ' setvcp 10 ' "$call_log") == set_count + 2 )) || \
+  fail "external brightness retries a rejected fast DDC write once"
 grep -F 'ddcutil --bus 7 --skip-ddc-checks --verify setvcp 10 28' "$call_log" >/dev/null || \
   fail "external brightness probes the fast DDC path"
 grep -F 'ddcutil --bus 7 --verify setvcp 10 28' "$call_log" >/dev/null || \
   fail "external brightness retries with full DDC checks"
-set_count=$(grep -c ' setvcp 10 ' "$call_log")
-DDC_FAST_WRITE_FAIL=1 run_brightness --no-osd --monitor DP-1 40%
-(( $(grep -c ' setvcp 10 ' "$call_log") == set_count + 1 )) || \
-  fail "external brightness skips a known broken fast DDC path"
-grep -F 'ddcutil --bus 7 --verify setvcp 10 32' "$call_log" >/dev/null || \
-  fail "external brightness remembers that full DDC checks are required"
 pass "external brightness falls back to full DDC checks"
 
-rm -f "$runtime_dir/omarchy-brightness-display-ddc/DP-1.full-checks"
 set_count=$(grep -c ' setvcp 10 ' "$call_log")
+detect_count=$(grep -c ' detect --brief' "$call_log")
 if DDC_WRITE_FAIL=1 run_brightness --no-osd --monitor DP-1 45% >/dev/null 2>&1; then
   fail "rejected external brightness write is reported"
 fi
-if DDC_WRITE_FAIL=1 run_brightness --no-osd --monitor DP-1 45% >/dev/null 2>&1; then
-  fail "cached rejected external brightness write is reported"
-fi
 (( $(grep -c ' setvcp 10 ' "$call_log") == set_count + 2 )) || \
-  fail "rejected external brightness writes are temporarily cached"
-pass "rejected external brightness writes are temporarily cached"
-rm -f "$runtime_dir/omarchy-brightness-display-ddc/DP-1.bus" "$runtime_dir/omarchy-brightness-display-ddc/DP-1.full-checks"
+  fail "a rejected write tries both DDC paths"
+get_count=$(grep -c ' getvcp 10 ' "$call_log")
+brightness=$(run_brightness --monitor DP-1) || fail "external brightness stays readable after a rejected write"
+[[ $brightness == "50" ]] || fail "external brightness stays readable after a rejected write" "actual: $brightness"
+(( $(grep -c ' getvcp 10 ' "$call_log") == get_count + 1 )) || \
+  fail "external brightness is re-read after a rejected write"
+(( $(grep -c ' detect --brief' "$call_log") == detect_count )) || \
+  fail "a rejected write keeps the cached DDC bus"
+pass "rejected external brightness writes leave the display readable"
+rm -f "$runtime_dir/omarchy-brightness-display-ddc/DP-1.bus"
 
 brightness=$(run_brightness --monitor eDP-1)
 [[ $brightness == "40" ]] || fail "internal monitor uses the kernel backlight" "actual: $brightness"

--- a/test/shell.d/brightness-display-test.sh
+++ b/test/shell.d/brightness-display-test.sh
@@ -48,6 +48,10 @@ EOF
 elif [[ $* == *" getvcp 10 "* ]]; then
   [[ ${DDC_READ_FAIL:-0} == "1" ]] && exit 1
   printf 'VCP 10 C %s %s\n' "${DDC_CURRENT:-40}" "${DDC_MAXIMUM:-80}"
+elif [[ $* == *" setvcp 10 "* ]]; then
+  if [[ ${DDC_WRITE_FAIL:-0} == "1" || ( ${DDC_FAST_WRITE_FAIL:-0} == "1" && $* == *" --skip-ddc-checks "* ) ]]; then
+    [[ $* == *" --noverify "* ]] || exit 1
+  fi
 fi
 SH
 
@@ -68,17 +72,52 @@ run_brightness --monitor DP-1 >/dev/null
 pass "DDC bus mapping is cached"
 
 run_brightness --no-osd --monitor DP-1 25%
-grep -F 'ddcutil --bus 7 --skip-ddc-checks --noverify setvcp 10 20' "$call_log" >/dev/null || \
-  fail "external percentage is converted to the monitor VCP range"
-pass "external percentage is converted to the monitor VCP range"
+grep -F 'ddcutil --bus 7 --skip-ddc-checks --verify setvcp 10 20' "$call_log" >/dev/null || \
+  fail "the first external write verifies the fast DDC path"
+pass "the first external write verifies the fast DDC path"
 
 get_count=$(grep -c ' getvcp 10 ' "$call_log")
 run_brightness --no-osd --monitor DP-1 30%
 (( $(grep -c ' getvcp 10 ' "$call_log") == get_count )) || \
   fail "absolute external brightness reuses the cached VCP range"
-grep -F 'ddcutil --bus 7 --skip-ddc-checks --noverify setvcp 10 24' "$call_log" >/dev/null || \
-  fail "absolute external brightness skips write verification"
-pass "absolute external brightness reuses the cached VCP range"
+grep -F 'ddcutil --bus 7 --skip-ddc-checks --verify setvcp 10 24' "$call_log" >/dev/null || \
+  fail "external brightness verifies every write"
+pass "absolute external brightness reuses its range and verifies its write"
+
+printf '6\n' >"$runtime_dir/omarchy-brightness-display-ddc/DP-1.full-checks"
+set_count=$(grep -c ' setvcp 10 ' "$call_log")
+run_brightness --no-osd --monitor DP-1 32%
+(( $(grep -c ' setvcp 10 ' "$call_log") == set_count + 1 )) || \
+  fail "a full-checks marker for another bus is ignored"
+grep -F 'ddcutil --bus 7 --skip-ddc-checks --verify setvcp 10 26' "$call_log" >/dev/null || \
+  fail "a remapped DDC bus probes the fast path"
+pass "full DDC checks are cached for one connector and bus"
+
+DDC_FAST_WRITE_FAIL=1 run_brightness --no-osd --monitor DP-1 35%
+grep -F 'ddcutil --bus 7 --skip-ddc-checks --verify setvcp 10 28' "$call_log" >/dev/null || \
+  fail "external brightness probes the fast DDC path"
+grep -F 'ddcutil --bus 7 --verify setvcp 10 28' "$call_log" >/dev/null || \
+  fail "external brightness retries with full DDC checks"
+set_count=$(grep -c ' setvcp 10 ' "$call_log")
+DDC_FAST_WRITE_FAIL=1 run_brightness --no-osd --monitor DP-1 40%
+(( $(grep -c ' setvcp 10 ' "$call_log") == set_count + 1 )) || \
+  fail "external brightness skips a known broken fast DDC path"
+grep -F 'ddcutil --bus 7 --verify setvcp 10 32' "$call_log" >/dev/null || \
+  fail "external brightness remembers that full DDC checks are required"
+pass "external brightness falls back to full DDC checks"
+
+rm -f "$runtime_dir/omarchy-brightness-display-ddc/DP-1.full-checks"
+set_count=$(grep -c ' setvcp 10 ' "$call_log")
+if DDC_WRITE_FAIL=1 run_brightness --no-osd --monitor DP-1 45% >/dev/null 2>&1; then
+  fail "rejected external brightness write is reported"
+fi
+if DDC_WRITE_FAIL=1 run_brightness --no-osd --monitor DP-1 45% >/dev/null 2>&1; then
+  fail "cached rejected external brightness write is reported"
+fi
+(( $(grep -c ' setvcp 10 ' "$call_log") == set_count + 2 )) || \
+  fail "rejected external brightness writes are temporarily cached"
+pass "rejected external brightness writes are temporarily cached"
+rm -f "$runtime_dir/omarchy-brightness-display-ddc/DP-1.bus" "$runtime_dir/omarchy-brightness-display-ddc/DP-1.full-checks"
 
 brightness=$(run_brightness --monitor eDP-1)
 [[ $brightness == "40" ]] || fail "internal monitor uses the kernel backlight" "actual: $brightness"
@@ -119,13 +158,13 @@ get_count=$(grep -c ' getvcp 10 ' "$call_log")
 DDC_MAXIMUM=100 run_brightness --no-osd --monitor DP-1 50%
 (( $(grep -c ' getvcp 10 ' "$call_log") == get_count + 1 )) || \
   fail "expired external brightness range is refreshed"
-grep -F 'ddcutil --bus 7 --skip-ddc-checks --noverify setvcp 10 50' "$call_log" >/dev/null || \
+grep -F 'ddcutil --bus 7 --skip-ddc-checks --verify setvcp 10 50' "$call_log" >/dev/null || \
   fail "expired external brightness range uses the refreshed maximum"
 pass "expired external brightness range is refreshed"
 
 rm -f "$runtime_dir/omarchy-brightness-display-ddc/DP-1.bus"
 DDC_CURRENT=4 DDC_MAXIMUM=100 run_brightness --no-osd --monitor DP-1 +5%
-grep -F 'ddcutil --bus 7 --skip-ddc-checks --noverify setvcp 10 5' "$call_log" >/dev/null || \
+grep -F 'ddcutil --bus 7 --skip-ddc-checks --verify setvcp 10 5' "$call_log" >/dev/null || \
   fail "external low brightness writes the one-percent target"
 pass "external low brightness uses a one-percent step"
 

--- a/test/shell.d/brightness-panel-test.sh
+++ b/test/shell.d/brightness-panel-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const panelSource = fs.readFileSync(root + '/shell/plugins/panels/monitor/Panel.qml', 'utf8')
+
+const exited = panelSource.slice(panelSource.indexOf('onExited: function(exitCode)'))
+const exitedBody = exited.slice(0, exited.indexOf('\n    }'))
+const wheel = panelSource.slice(panelSource.indexOf('onWheelMoved: function(delta)'))
+const wheelBody = wheel.slice(0, wheel.indexOf('\n    }'))
+
+// External brightness writes are verified, so a rejected one has to reach the
+// panel. It snaps the slider back locally: refreshing here races the read path,
+// and an empty read clears brightnessAvailable and hides the slider.
+assert(/root\.brightnessPercent = root\.confirmedBrightnessPercent/.test(exitedBody), 'a rejected brightness write snaps the slider back')
+assert(!/refresh\(/.test(exitedBody), 'a finished brightness write never re-reads state')
+
+// The OSD is a claim that the brightness changed, so it waits for the write to
+// verify rather than appearing on the keypress.
+assert(!/showBrightnessOsd/.test(wheelBody), 'the wheel does not show the OSD before the write is verified')
+assert(/root\.brightnessOsdPending = false[\s\S]*root\.showBrightnessOsd/.test(exitedBody), 'a verified brightness write shows the pending OSD')
+JS


### PR DESCRIPTION
Fixes #8931

Upstream investigation: https://github.com/rockowitz/ddcutil/issues/626

> [!Note] 
> The AI reviews in the comments evaluated the earlier two-process fallback, which this version supersedes now that an upstream fix happened

## Summary

1. Verify external DDC brightness writes before reporting success.
2. Retry one rejected set-and-verify cycle in the same ddcutil process with `--max-setvcp-and-verify-tries 2`.
3. Keep rejected displays readable, snap the slider back to the last confirmed value, and suppress the OSD when a write fails.

The affected LG ignores the first fast write. Its verification read primes the display, so the second write succeeds when it reuses the same display handle. The public retry option shipped in ddcutil 3.0.0 as the replacement for the hidden `--i5` option; Omarchy targets ddcutil 3.0.1+, now packaged in Arch Extra.

A display that rejects every write still returns a failure without hiding its brightness slider. The helper remains stateless and uses one ddcutil process per write.

## Out of scope

No ddcutil call has a timeout, so a blocked ddcutil holds the brightness key lock for as long as it blocks. That predates this change and is left for a follow-up.

## Testing

1. `./test/shell.d/brightness-display-test.sh`
2. `./test/shell.d/brightness-panel-test.sh`
3. `bash test/shell.d/bin-style-test.sh`
4. `bash test/shell.d/manifest-entrypoints-test.sh`
5. `./test/cli`
6. Verified the equivalent same-process retry (`--i5 2`) on the affected LG with ddcutil 2.2.7 before upstream published the named option.

