### PR TITLE
Re-apply hardware pacman repos after a refresh restore

### DIFF
--- a/bin/omarchy-refresh-pacman
+++ b/bin/omarchy-refresh-pacman
@@ -23,8 +23,13 @@ sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$channel" /etc/pacman.d/mirr
 # Macs) must survive the template restore above; the install path re-applies
 # them from this same file. It is idempotent and no-ops on other hardware,
 # but appends to /etc/pacman.conf, so it has to run as root like the copies.
+# A failure here is exactly the silent-failure class this issue is about:
+# the refresh must stop rather than run the upgrade with hardware repos gone.
 if [[ -f $OMARCHY_PATH/install/hardware/pacman.sh ]]; then
-  sudo bash -c "source '$OMARCHY_PATH/install/hardware/pacman.sh'"
+  if ! sudo bash -c "source '$OMARCHY_PATH/install/hardware/pacman.sh'"; then
+    echo "Failed to re-apply hardware pacman repositories; aborting refresh" >&2
+    exit 1
+  fi
 fi
 
 # Allow user customization of /etc/pacman.conf before the upgrade runs

--- a/bin/omarchy-refresh-pacman
+++ b/bin/omarchy-refresh-pacman
@@ -19,6 +19,14 @@ echo
 sudo cp -f "$OMARCHY_PATH/default/pacman/pacman-$channel.conf" /etc/pacman.conf
 sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$channel" /etc/pacman.d/mirrorlist
 
+# Hardware-specific repository additions (e.g. [arch-mact2] on Apple T2
+# Macs) must survive the template restore above; the install path re-applies
+# them from this same file. It is idempotent and no-ops on other hardware,
+# but appends to /etc/pacman.conf, so it has to run as root like the copies.
+if [[ -f $OMARCHY_PATH/install/hardware/pacman.sh ]]; then
+  sudo bash -c "source '$OMARCHY_PATH/install/hardware/pacman.sh'"
+fi
+
 # Allow user customization of /etc/pacman.conf before the upgrade runs
 omarchy-hook pre-refresh-pacman
 

--- a/test/shell.d/refresh-pacman-test.sh
+++ b/test/shell.d/refresh-pacman-test.sh
@@ -61,7 +61,7 @@ run_refresh() {
     HOOK_LOG="$tmp_dir/hook.log" \
     OMARCHY_PATH="$tmp_dir/omarchy" \
     PATH="$tmp_dir/bin:$PATH" \
-    bash -euo pipefail "$tmp_dir/leaf.sh"
+    bash "$tmp_dir/leaf.sh"
 }
 
 # On Apple T2 hardware (lspci shows 106b:1801) the [arch-mact2] repository must
@@ -90,5 +90,33 @@ run_refresh "0000:01:00.0 VGA compatible controller: NVIDIA Corporation"
 grep -q '^\[arch-mact2\]' "$sandbox_conf" &&
   fail "non-T2 hardware gets no arch-mact2 stanza" "$(cat "$sandbox_conf")"
 pass "non-T2 hardware is untouched"
+
+# If the hardware re-apply itself fails (say a future pacman.sh cannot fetch
+# a signing key), the refresh must stop before the upgrade: continuing and
+# running pacman -Syyuu with the repo missing is the same silent failure
+# #9853 reports. The command has no set -e, so this only holds if the
+# re-apply step is checked explicitly.
+mkdir -p "$tmp_dir/omarchy-broken/install/hardware" \
+  "$tmp_dir/omarchy-broken/default/pacman"
+printf '#%%generated\n' >"$tmp_dir/omarchy-broken/default/pacman/pacman-stable.conf"
+printf 'Server = https://example.org/mirror\n' \
+  >"$tmp_dir/omarchy-broken/default/pacman/mirrorlist-stable"
+printf 'echo "key import failed" >&2\nexit 1\n' \
+  >"$tmp_dir/omarchy-broken/install/hardware/pacman.sh"
+chmod +x "$tmp_dir/omarchy-broken/install/hardware/pacman.sh"
+rm -f "$tmp_dir/pacman.log" "$tmp_dir/hook.log"
+if LSPCI_OUT="" PACMAN_LOG="$tmp_dir/pacman.log" HOOK_LOG="$tmp_dir/hook.log" \
+  SUDO_LOG="$tmp_dir/sudo.log" OMARCHY_PATH="$tmp_dir/omarchy-broken" \
+  PATH="$tmp_dir/bin:$PATH" \
+  bash "$tmp_dir/leaf.sh" >"$tmp_dir/broken.out" 2>&1; then
+  fail "a failed hardware re-apply aborts the refresh" \
+    "$(cat "$tmp_dir/broken.out")"
+fi
+[[ ! -s $tmp_dir/pacman.log ]] ||
+  fail "the upgrade does not run after a failed re-apply" \
+    "$(cat "$tmp_dir/pacman.log")"
+grep -q "Failed to re-apply hardware pacman repos" "$tmp_dir/broken.out" ||
+  fail "the failure is reported before aborting" "$(cat "$tmp_dir/broken.out")"
+pass "a failed hardware re-apply aborts before the upgrade"
 
 pass "refresh pacman re-applies hardware repos and upgrades cleanly"

--- a/test/shell.d/refresh-pacman-test.sh
+++ b/test/shell.d/refresh-pacman-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# The command writes to /etc/pacman.conf and /etc/pacman.d/mirrorlist, so a
+# full copy with the absolute paths rewritten into the sandbox is used. The
+# hardware repo script is copied the same way.
+sandbox_conf="$tmp_dir/etc/pacman.conf"
+sandbox_mirror="$tmp_dir/etc/pacman.d/mirrorlist"
+mkdir -p "$tmp_dir/etc/pacman.d" "$tmp_dir/omarchy/default/pacman" \
+  "$tmp_dir/omarchy/install/hardware" "$tmp_dir/bin"
+
+printf '#%%current\n[core]\nServer = https://example.org/core\n' >"$sandbox_conf"
+printf 'Server = https://example.org/mirror\n' >"$sandbox_mirror"
+printf '#%%generated\n[core]\nInclude = /etc/pacman.d/mirrorlist\n' \
+  >"$tmp_dir/omarchy/default/pacman/pacman-stable.conf"
+printf 'Server = https://example.org/mirror\n' \
+  >"$tmp_dir/omarchy/default/pacman/mirrorlist-stable"
+
+# Sandboxed copy of install/hardware/pacman.sh with /etc/pacman.conf rewritten.
+sed -e "s|/etc/pacman.conf|$sandbox_conf|g" \
+  "$ROOT/install/hardware/pacman.sh" >"$tmp_dir/omarchy/install/hardware/pacman.sh"
+
+# Sandboxed copy of the command itself.
+sed -e "s|/etc/pacman.conf|$sandbox_conf|g" \
+  -e "s|/etc/pacman.d/mirrorlist|$sandbox_mirror|g" \
+  "$ROOT/bin/omarchy-refresh-pacman" >"$tmp_dir/leaf.sh"
+
+cat >"$tmp_dir/bin/lspci" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$LSPCI_OUT"
+EOF
+
+cat >"$tmp_dir/bin/sudo" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$SUDO_LOG"
+exec "$@"
+EOF
+
+cat >"$tmp_dir/bin/pacman" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$PACMAN_LOG"
+EOF
+
+cat >"$tmp_dir/bin/omarchy-hook" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HOOK_LOG"
+EOF
+
+chmod +x "$tmp_dir/bin"/*
+
+run_refresh() {
+  LSPCI_OUT="$1" \
+    SUDO_LOG="$tmp_dir/sudo.log" \
+    PACMAN_LOG="$tmp_dir/pacman.log" \
+    HOOK_LOG="$tmp_dir/hook.log" \
+    OMARCHY_PATH="$tmp_dir/omarchy" \
+    PATH="$tmp_dir/bin:$PATH" \
+    bash -euo pipefail "$tmp_dir/leaf.sh"
+}
+
+# On Apple T2 hardware (lspci shows 106b:1801) the [arch-mact2] repository must
+# survive the template restore, otherwise linux-t2 loses its update source.
+run_refresh "0000:00:1c.4 PCI bridge: Apple Inc. 106b:1801"
+grep -q '^\[arch-mact2\]' "$sandbox_conf" ||
+  fail "the arch-mact2 repository survives a refresh on T2 hardware" \
+    "$(cat "$sandbox_conf")"
+grep -q 'NoaHimesaka1873/arch-mact2-mirror' "$sandbox_conf" ||
+  fail "the arch-mact2 mirror server is re-appended" "$(cat "$sandbox_conf")"
+grep -q 'pre-refresh-pacman' "$tmp_dir/hook.log" ||
+  fail "the pre-refresh-pacman hook still runs"
+grep -q -- '-Syyuu' "$tmp_dir/pacman.log" ||
+  fail "pacman -Syyuu still runs after the restore" "$(cat "$tmp_dir/pacman.log")"
+pass "T2 hardware keeps its arch-mact2 repo through a refresh"
+
+# Idempotent: a second refresh must not duplicate the stanza.
+run_refresh "0000:00:1c.4 PCI bridge: Apple Inc. 106b:1801"
+(( $(grep -c '^\[arch-mact2\]' "$sandbox_conf") == 1 )) ||
+  fail "the arch-mact2 repo is appended only once" "$(cat "$sandbox_conf")"
+pass "a second refresh does not duplicate the arch-mact2 stanza"
+
+# Non-T2 hardware: nothing added, nothing broken.
+printf '#%%current\n[core]\nServer = https://example.org/core\n' >"$sandbox_conf"
+run_refresh "0000:01:00.0 VGA compatible controller: NVIDIA Corporation"
+grep -q '^\[arch-mact2\]' "$sandbox_conf" &&
+  fail "non-T2 hardware gets no arch-mact2 stanza" "$(cat "$sandbox_conf")"
+pass "non-T2 hardware is untouched"
+
+pass "refresh pacman re-applies hardware repos and upgrades cleanly"


### PR DESCRIPTION
Fixes #9853

## What broke

`omarchy refresh pacman` overwrites `/etc/pacman.conf` with the channel template and never re-applies hardware-specific repository additions. On Apple T2 Macs that silently drops the `[arch-mact2]` stanza, so `linux-t2` (the running kernel), `t2fanrd`, `apple-t2-audio-config` and `apple-bcm-firmware` lose their update source with no visible symptom.

The install path does this correctly: `install/post-install/pacman.sh` sources `install/hardware/pacman.sh`, which appends the T2 stanza and is idempotent (it guards on `grep -q '^\[arch-mact2\]'`). That same file states the intent in its own comment: the extension "must survive the final pacman.conf restore". The refresh path never copies it.

## Fix

After the template restore, source `$OMARCHY_PATH/install/hardware/pacman.sh` the same way the install path does:

```bash
if [[ -f $OMARCHY_PATH/install/hardware/pacman.sh ]]; then
  sudo bash -c "source '$OMARCHY_PATH/install/hardware/pacman.sh'"
fi
```

Notes on why this shape:

- The issue's suggested `source "$OMARCHY_INSTALL/hardware/pacman.sh"` cannot work in `bin/omarchy-refresh-pacman`: `$OMARCHY_INSTALL` is not defined at runtime (only `omarchy-apply-hardware`/`omarchy-apply-system` set it). At runtime the tree lives at `$OMARCHY_PATH/install/` (docs/file-layout.md maps `install/**` to `/usr/share/omarchy/install/`).
- The file appends to `/etc/pacman.conf`, so it must run as root; the copy steps just above already use `sudo`, so the script runs as the user and elevates.
- Placed before the `pre-refresh-pacman` user hook, matching the issue's ordering, so user hooks see the final repo set.
- The `[[ -f ]]` guard keeps the refresh a no-op on anything where the install tree is absent, and if `install/hardware/pacman.sh` is ever removed the refresh simply skips it.

## Security context

`install/hardware/pacman.sh` is also in the sights of open security PRs #8709 (arms verification on the T2 stanza) and #9461 (draft: remove the unsigned source). This PR deliberately does not take a side: it sources whatever the packaged file contains at runtime, so if #8709 lands the refresh re-applies the armed stanza, and if a removal lands the `-f` guard no-ops. Only the "refresh drops hardware repos" bug is fixed here.

## Tests

New `test/shell.d/refresh-pacman-test.sh` runs the command against a sandboxed `/etc/pacman.conf` (absolute paths rewritten) with stubbed `lspci`/`sudo`/`pacman`/`omarchy-hook`:

- T2 (`lspci` shows `106b:1801`): `[arch-mact2]` with the mirror server is present after the refresh, the user hook still runs, and `pacman -Syyuu` still runs.
- Second run: the stanza is not duplicated.
- Non-T2: nothing is added.

All four assertions pass here, and the test fails against the pre-fix command (RED → GREEN). Honest host note: this is an Apple Silicon macOS machine with no bash 4+ and no Wayland, so the repo's full `./test/shell` cannot complete here (`${var,,}`-style and compositor tests are environment-bound); the new test is bash-3.2 compatible and was run directly, and it never touches the real `/etc/pacman.conf`. Real-T2 end-to-end validation (an actual `omarchy refresh pacman` on a T2 Mac) remains for someone with that hardware.

One scope note: a migration that repairs already-upgraded machines was intentionally left out — I did not want to guess at maintainer preferences on machine-wide repairs, and the refresh fix covers every future refresh. Happy to add one if you want it.
