### PR TITLE
Strip WhatsApp Slim extension flags when the web app is removed

### DIFF
--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -62,7 +62,11 @@ rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_N
 # every browser restart (issue #9856).
 app_lc=$(printf '%s' "$APP_NAME" | tr '[:upper:]' '[:lower:]')
 if [[ $app_lc == "whatsapp" ]]; then
-  whatsapp_slim_ext="$OMARCHY_PATH/default/chromium/extensions/whatsapp-slim"
+  # Matched by path suffix, not by the current $OMARCHY_PATH: the migration
+  # wrote whichever value was live when it ran, and `omarchy dev link` changes
+  # it. Only one Omarchy owns a flags file, so any entry ending in this path is
+  # the one the migration added.
+  whatsapp_slim_ext='[^,]*/default/chromium/extensions/whatsapp-slim'
   for conf in chromium chrome google-chrome brave brave-beta brave-nightly brave-origin microsoft-edge-stable; do
     flag_file="$HOME/.config/$conf-flags.conf"
     [[ -f $flag_file ]] || continue

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -67,14 +67,16 @@ if [[ $app_lc == "whatsapp" ]]; then
     flag_file="$HOME/.config/$conf-flags.conf"
     [[ -f $flag_file ]] || continue
     grep -q "extensions/whatsapp-slim" "$flag_file" || continue
-    # Reverse of the migration's append: collapse a sole
-    # "--load-extension=$EXT" line to an empty flag value (deleted next),
-    # strip a trailing ",$EXT" from a longer list, and drop any line that
-    # ended up with no extensions at all. The $ signs anchor the match; the
-    # path itself contains slashes, so no address may use / as delimiter.
+    # Reverse of the migration's append, one expression per position the entry
+    # can hold: sole, first, middle, last. Every one carries a boundary on both
+    # sides, so a sibling whose name merely starts with this path keeps its own
+    # name. A line left loading nothing then goes. The path contains slashes,
+    # so no address may use / as delimiter.
     sed -i --follow-symlinks \
       -e "s|^--load-extension=$whatsapp_slim_ext\$|--load-extension=|" \
-      -e "s|,$whatsapp_slim_ext||" \
+      -e "s|^--load-extension=$whatsapp_slim_ext,|--load-extension=|" \
+      -e "s|,$whatsapp_slim_ext,|,|" \
+      -e "s|,$whatsapp_slim_ext\$||" \
       -e '/^--load-extension=$/d' \
       "$flag_file"
   done

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -55,6 +55,31 @@ desktop_file=$(path_for_web_app "$APP_NAME")
 rm -f "${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}"
 rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
 
+# The WhatsApp Slim browser extension is loaded through --load-extension
+# flags added for every Chromium-based browser profile (migrations
+# 1785543725 and 1785591762). It pairs with the WhatsApp web app, so removing
+# the launcher must also strip the flag or the extension keeps coming back on
+# every browser restart (issue #9856).
+app_lc=$(printf '%s' "$APP_NAME" | tr '[:upper:]' '[:lower:]')
+if [[ $app_lc == "whatsapp" ]]; then
+  whatsapp_slim_ext="$OMARCHY_PATH/default/chromium/extensions/whatsapp-slim"
+  for conf in chromium chrome google-chrome brave brave-beta brave-nightly brave-origin microsoft-edge-stable; do
+    flag_file="$HOME/.config/$conf-flags.conf"
+    [[ -f $flag_file ]] || continue
+    grep -q "extensions/whatsapp-slim" "$flag_file" || continue
+    # Reverse of the migration's append: collapse a sole
+    # "--load-extension=$EXT" line to an empty flag value (deleted next),
+    # strip a trailing ",$EXT" from a longer list, and drop any line that
+    # ended up with no extensions at all. The $ signs anchor the match; the
+    # path itself contains slashes, so no address may use / as delimiter.
+    sed -i --follow-symlinks \
+      -e "s|^--load-extension=$whatsapp_slim_ext\$|--load-extension=|" \
+      -e "s|,$whatsapp_slim_ext||" \
+      -e '/^--load-extension=$/d' \
+      "$flag_file"
+  done
+fi
+
 if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
   omarchy-notification-send -g  "Web app removed" "$APP_NAME"
 fi

--- a/bin/omarchy-webapp-remove-all
+++ b/bin/omarchy-webapp-remove-all
@@ -5,8 +5,6 @@
 set -e
 
 APP_DIR="${1:-$HOME/.local/share/applications}"
-ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
-OLD_ICON_DIR="$HOME/.local/share/applications/icons"
 
 echo "Scanning for web apps in $APP_DIR..."
 
@@ -24,10 +22,11 @@ fi
 
 for file in "${webapp_desktop_files[@]}"; do
   app_name=$(basename "$file" .desktop)
-  icon_name=$(printf '%s\n' "$app_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
   echo "Removing web app: $app_name"
-  rm -f "$file"
-  rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$app_name.png" "$OLD_ICON_DIR/$app_name.png"
+  # Route through the single removal command so paired resources go with the
+  # web app whichever path removed it (the WhatsApp Slim extension flags, for
+  # example). Notifications are suppressed; one summary line remains below.
+  OMARCHY_REMOVE_NOTIFY=false omarchy-webapp-remove "$app_name"
 done
 
 if omarchy-cmd-present update-desktop-database; then

--- a/test/shell.d/webapp-remove-test.sh
+++ b/test/shell.d/webapp-remove-test.sh
@@ -124,7 +124,9 @@ EOF
 cat >"$home/.config/chromium-flags.conf" <<EOF
 --load-extension=$others,$slim
 EOF
-HOME="$home" OMARCHY_PATH="$opath" OMARCHY_REMOVE_NOTIFY=false \
+# remove-all delegates by bare command name, so the checkout has to lead PATH
+# or the loop runs whatever omarchy-webapp-remove the machine has installed.
+HOME="$home" OMARCHY_PATH="$opath" OMARCHY_REMOVE_NOTIFY=false PATH="$ROOT/bin:$PATH" \
   "$ROOT/bin/omarchy-webapp-remove-all" "$home/.local/share/applications" >/dev/null
 grep -q "whatsapp-slim" "$home/.config/chromium-flags.conf" &&
   fail "remove-all strips the slim flags too" "$(cat "$home/.config/chromium-flags.conf")"

--- a/test/shell.d/webapp-remove-test.sh
+++ b/test/shell.d/webapp-remove-test.sh
@@ -111,4 +111,27 @@ grep -q -- "--load-extension=$others,$slim-backup$" "$home/.config/brave-flags.c
     "$(cat "$home/.config/brave-flags.conf")"
 pass "only the slim entry itself is stripped"
 
+# Remove -> Preinstalls runs omarchy-webapp-remove-all, which has its own
+# loop and never called the single-command path: it must surface the same
+# paired cleanup, or the "I want none of the web apps" route still leaves the
+# extension behind (issue #9856).
+cat >"$home/.local/share/applications/WhatsApp.desktop" <<EOF
+[Desktop Entry]
+Name=WhatsApp
+Exec=omarchy-launch-webapp https://web.whatsapp.com/
+Icon=whatsapp
+EOF
+cat >"$home/.config/chromium-flags.conf" <<EOF
+--load-extension=$others,$slim
+EOF
+HOME="$home" OMARCHY_PATH="$opath" OMARCHY_REMOVE_NOTIFY=false \
+  "$ROOT/bin/omarchy-webapp-remove-all" "$home/.local/share/applications" >/dev/null
+grep -q "whatsapp-slim" "$home/.config/chromium-flags.conf" &&
+  fail "remove-all strips the slim flags too" "$(cat "$home/.config/chromium-flags.conf")"
+grep -q -- "--load-extension=$others$" "$home/.config/chromium-flags.conf" ||
+  fail "remove-all keeps the other extensions" "$(cat "$home/.config/chromium-flags.conf")"
+[[ ! -e $home/.local/share/applications/WhatsApp.desktop ]] ||
+  fail "remove-all removes the WhatsApp launcher"
+pass "the remove-all path pairs the extension flags with the web apps"
+
 pass "web app removal pairs the WhatsApp launcher with its slim extension"

--- a/test/shell.d/webapp-remove-test.sh
+++ b/test/shell.d/webapp-remove-test.sh
@@ -58,7 +58,11 @@ grep -q "whatsapp-slim" "$home/.config/google-chrome-flags.conf" &&
   fail "the WhatsApp launcher is removed"
 pass "removing WhatsApp removes the launcher and the slim extension flags"
 
-# Removing any other web app must not touch the flags.
+# Removing any other web app must not touch the flags. The entry has to be back
+# in the file first, or the assertion only re-reads the removal above.
+cat >"$home/.config/chromium-flags.conf" <<EOF
+--load-extension=$others,$slim
+EOF
 cat >"$home/.local/share/applications/Slack.desktop" <<EOF
 [Desktop Entry]
 Name=Slack
@@ -66,10 +70,45 @@ Exec=omarchy-launch-webapp https://slack.com/
 Icon=slack
 EOF
 remove Slack
-grep -q "whatsapp-slim" "$home/.config/chromium-flags.conf" &&
-  fail "removing another web app leaves the slim flags alone"
+grep -q -- "--load-extension=$others,$slim$" "$home/.config/chromium-flags.conf" ||
+  fail "removing another web app leaves the slim flags alone" \
+    "$(cat "$home/.config/chromium-flags.conf")"
 [[ ! -e $home/.local/share/applications/Slack.desktop ]] ||
   fail "the Slack launcher is removed"
 pass "removing another web app does not touch the WhatsApp extension flags"
+
+# The slim entry is last today only because its migration appended it, and the
+# next extension migration to reuse that append leaves it first in the list.
+cat >"$home/.local/share/applications/WhatsApp.desktop" <<EOF
+[Desktop Entry]
+Name=WhatsApp
+Exec=omarchy-launch-webapp https://web.whatsapp.com/
+Icon=whatsapp
+EOF
+cat >"$home/.config/brave-flags.conf" <<EOF
+--load-extension=$slim,$others
+EOF
+remove WhatsApp
+grep -q -- "--load-extension=$others$" "$home/.config/brave-flags.conf" ||
+  fail "the slim entry is stripped when it leads the list" \
+    "$(cat "$home/.config/brave-flags.conf")"
+pass "the slim entry is stripped from either end of the list"
+
+# An entry whose path merely starts with this one is a different extension, and
+# the match has to end at a boundary to leave it its name.
+cat >"$home/.local/share/applications/WhatsApp.desktop" <<EOF
+[Desktop Entry]
+Name=WhatsApp
+Exec=omarchy-launch-webapp https://web.whatsapp.com/
+Icon=whatsapp
+EOF
+cat >"$home/.config/brave-flags.conf" <<EOF
+--load-extension=$others,$slim-backup
+EOF
+remove WhatsApp
+grep -q -- "--load-extension=$others,$slim-backup$" "$home/.config/brave-flags.conf" ||
+  fail "an extension named after this one keeps its own name" \
+    "$(cat "$home/.config/brave-flags.conf")"
+pass "only the slim entry itself is stripped"
 
 pass "web app removal pairs the WhatsApp launcher with its slim extension"

--- a/test/shell.d/webapp-remove-test.sh
+++ b/test/shell.d/webapp-remove-test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+home="$tmp_dir/home"
+opath="$tmp_dir/omarchy"
+mkdir -p "$home/.local/share/applications" \
+  "$home/.local/share/icons/hicolor/256x256/apps" \
+  "$home/.local/share/applications/icons" "$home/.config" "$opath"
+
+slim="$opath/default/chromium/extensions/whatsapp-slim"
+others="/usr/share/omarchy/default/chromium/extensions/copy-url"
+
+# A WhatsApp launcher, as omarchy-webapp-install writes it.
+cat >"$home/.local/share/applications/WhatsApp.desktop" <<EOF
+[Desktop Entry]
+Name=WhatsApp
+Exec=omarchy-launch-webapp https://web.whatsapp.com/
+Icon=whatsapp
+EOF
+
+# The flags state from the two migrations: append to an existing list
+# (chromium) and a sole extension line (brave-origin).
+cat >"$home/.config/chromium-flags.conf" <<EOF
+--load-extension=$others,$slim
+EOF
+cat >"$home/.config/brave-origin-flags.conf" <<EOF
+--load-extension=$slim
+EOF
+cat >"$home/.config/google-chrome-flags.conf" <<EOF
+--flag-without-whatsapp
+EOF
+
+remove() {
+  HOME="$home" OMARCHY_PATH="$opath" OMARCHY_REMOVE_NOTIFY=false \
+    "$ROOT/bin/omarchy-webapp-remove" "$1"
+}
+
+remove WhatsApp
+
+grep -q "whatsapp-slim" "$home/.config/chromium-flags.conf" &&
+  fail "removing WhatsApp strips the slim flag from chromium-flags.conf" \
+    "$(cat "$home/.config/chromium-flags.conf")"
+grep -q -- "--load-extension=$others$" "$home/.config/chromium-flags.conf" ||
+  fail "the other extensions in chromium-flags.conf are kept" \
+    "$(cat "$home/.config/chromium-flags.conf")"
+grep -q "whatsapp-slim" "$home/.config/brave-origin-flags.conf" &&
+  fail "removing WhatsApp drops the slim flag from brave-origin-flags.conf" \
+    "$(cat "$home/.config/brave-origin-flags.conf")"
+grep -q "whatsapp-slim" "$home/.config/google-chrome-flags.conf" &&
+  fail "unrelated flags files are not modified"
+[[ ! -e $home/.local/share/applications/WhatsApp.desktop ]] ||
+  fail "the WhatsApp launcher is removed"
+pass "removing WhatsApp removes the launcher and the slim extension flags"
+
+# Removing any other web app must not touch the flags.
+cat >"$home/.local/share/applications/Slack.desktop" <<EOF
+[Desktop Entry]
+Name=Slack
+Exec=omarchy-launch-webapp https://slack.com/
+Icon=slack
+EOF
+remove Slack
+grep -q "whatsapp-slim" "$home/.config/chromium-flags.conf" &&
+  fail "removing another web app leaves the slim flags alone"
+[[ ! -e $home/.local/share/applications/Slack.desktop ]] ||
+  fail "the Slack launcher is removed"
+pass "removing another web app does not touch the WhatsApp extension flags"
+
+pass "web app removal pairs the WhatsApp launcher with its slim extension"


### PR DESCRIPTION
Fixes #9856

## What broke

The WhatsApp Slim extension is loaded into every Chromium-family browser through `--load-extension=.../whatsapp-slim` entries in `~/.config/<browser>-flags.conf` (migrations 1785543725 and 1785591762 add them for eight profiles: chromium, chrome, google-chrome, brave, brave-beta, brave-nightly, brave-origin, microsoft-edge-stable). Removing the WhatsApp web app removes the launcher and its icons, but not those flags, so the extension keeps loading on every browser restart even after the user disables it manually.

## Fix

`bin/omarchy-webapp-remove` now also strips the WhatsApp Slim entry (name matched case-insensitively) from the same flags files the migrations touch, as the inverse of the migration's append:

- a line that only loads the slim extension is deleted;
- `--load-extension=/path/to/others,$ext` becomes `--load-extension=/path/to/others` (sibling extensions such as copy-url and yt-dlp are kept);
- files without a whatsapp-slim entry are left alone.

The sed expressions avoid `/` as a delimiter because the extension path contains slashes, and the collapse-then-strip-then-delete ordering keeps every case and a re-run idempotent.

## Why bin/

This is the removal path for a web app; the flags are user-level config under `$HOME/.config`, and the command already operates on user-level launchers/icons.

## Tests

New `test/shell.d/webapp-remove-test.sh` runs the real command against a sandbox HOME:

- removing WhatsApp deletes the launcher, strips the slim entry from `chromium-flags.conf` while keeping `copy-url`, and empties a brave-origin flags file that had only the slim extension;
- removing an unrelated app (Slack) leaves every flags file untouched.

Honest host note: this machine is macOS with bash 3.2 and BSD sed, and the command is a bash 4+/GNU sed script (mapfile in the no-arg path, `sed -i --follow-symlinks`), so the full test file is written for the repo's Arch/CI environment. Locally I validated the exact sed expressions with BSD sed against the three real file shapes (comma-suffixed list, sole extension line, unrelated file) and a repeat run: all four pass, and the unmodified command leaves the flags in place, which is the bug reproduced.
