### PR TITLE
Tag Chromium --app web apps as chromium-based browsers

### DIFF
--- a/default/hypr/apps/browser.lua
+++ b/default/hypr/apps/browser.lua
@@ -1,12 +1,22 @@
 -- Browser tags and styling.
-o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
+-- Hyprland matches class with RE2 FullMatch, so bare browser ids alone miss
+-- Chromium --app webapp classes. The --app class uses a product id prefix, not
+-- the browser window class: chrome- / brave- / msedge- / vivaldi- / opera- /
+-- helium-, then <host>__<path>-<Profile> (see omarchy-launch-webapp).
+-- Suffix is (-.+__.*-.+)? so non-Default profiles still match while extension
+-- popouts like chrome-<extension-id>-Default (no host/__) stay untagged.
+-- [oO]pera also tags Opera's main window class for the first time.
+o.window("((google-)?[cC]hrom(e|ium)|[bB]rave(-browser|-origin)?|[mM]icrosoft-edge|msedge|[vV]ivaldi(-stable)?|[oO]pera|helium)(-.+__.*-.+)?", { tag = "+chromium-based-browser" })
 o.window("([fF]irefox|zen|librewolf)", { tag = "+firefox-based-browser" })
-o.window({ tag = "chromium-based-browser" }, { tag = "-default-opacity", tile = true, opacity = "1.0 0.985" })
-o.window({ tag = "firefox-based-browser" }, { tag = "-default-opacity", opacity = "1.0 0.985" })
 
--- Video apps: remove chromium browser tag so they don't get opacity applied.
+-- Video apps: remove the chromium browser tag so they don't get opacity applied.
+-- This has to precede the rules below, because removing a tag does not undo a
+-- rule that already matched on it.
 o.window("(^.+-youtube\\.com__.*$|^.+-app\\.zoom\\.us__wc_home.*$)", { tag = "-chromium-based-browser" })
 o.window("(^.+-youtube\\.com__.*$|^.+-app\\.zoom\\.us__wc_home.*$)", { tag = "-default-opacity" })
+
+o.window({ tag = "chromium-based-browser" }, { tag = "-default-opacity", tile = true, opacity = "1.0 0.985" })
+o.window({ tag = "firefox-based-browser" }, { tag = "-default-opacity", opacity = "1.0 0.985" })
 
 -- Hide screen sharing notification windows.
 o.window({ title = ".*is sharing.*" }, { workspace = "special silent" })

--- a/test/shell.d/webapp-browser-tags-test.sh
+++ b/test/shell.d/webapp-browser-tags-test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Chromium --app web apps must receive +chromium-based-browser under Hyprland's
+# RE2 FullMatch class matching. Bare browser ids alone never full-match the
+# product-prefixed <id>-<host>__<path>-<Profile> form from omarchy-launch-webapp
+# (chrome-/brave-/msedge-/vivaldi-/opera-/helium-, not the bare window class).
+#
+# Regression guard for omacom/omarchy#9784. Uses Python re.fullmatch so the
+# test matches Hyprland semantics (bash [[ =~ ]] is unanchored and would hide
+# the bug).
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command python3
+
+browser_lua="$ROOT/default/hypr/apps/browser.lua"
+
+chromium_pattern=$(
+  grep -F 'tag = "+chromium-based-browser"' "$browser_lua" | head -n1 |
+    sed -n 's/^o\.window("\([^"]*\)".*$/\1/p'
+)
+[[ -n $chromium_pattern ]] || fail "browser.lua declares a chromium-based-browser class rule"
+
+# Decode Lua string escapes in the extracted pattern so Python sees the same
+# bytes Hyprland's RE2 engine does after the Lua string is parsed.
+chromium_pattern=$(
+  PATTERN=$chromium_pattern python3 - <<'PY'
+import codecs, os
+print(codecs.decode(os.environ["PATTERN"], "unicode_escape"), end="")
+PY
+)
+
+fullmatch() {
+  local value=$1 pattern=$2
+  PATTERN=$pattern VALUE=$value python3 - <<'PY'
+import os, re, sys
+sys.exit(0 if re.fullmatch(os.environ["PATTERN"], os.environ["VALUE"]) else 1)
+PY
+}
+
+# Bare Chromium-family browser windows still match.
+for appid in \
+  chromium chrome Chrome google-chrome \
+  brave-browser Brave-browser brave-origin \
+  microsoft-edge Microsoft-edge Vivaldi-stable helium \
+  opera Opera; do
+  fullmatch "$appid" "$chromium_pattern" ||
+    fail "chromium rule full-matches bare browser class $appid"
+done
+pass "chromium rule full-matches bare Chromium-family browser classes"
+
+# Web apps launched via --app= use product id + host/path + profile suffix.
+# omarchy-launch-webapp never passes --profile-directory, so Chromium puts the
+# last-used profile basename in the class (Default, Profile_1, ...). The host
+# path always contains __; that is what separates web apps from extension ids.
+for appid in \
+  "chrome-example.com__-Default" \
+  "chrome-example.com__path-Default" \
+  "chrome-example.test__-Profile_1" \
+  "chrome-example.com__-Profile_1" \
+  "chrome-youtube.com__-Default" \
+  "brave-outlook.office.com__mail_-Default" \
+  "brave-example.com__-Default" \
+  "brave-example.com__-Profile_1" \
+  "msedge-example.com__-Default" \
+  "msedge-example.com__-Profile_1" \
+  "vivaldi-example.com__-Default" \
+  "opera-example.com__-Default" \
+  "helium-example.com__-Default"; do
+  fullmatch "$appid" "$chromium_pattern" ||
+    fail "chromium rule full-matches webapp class $appid"
+done
+pass "chromium rule full-matches Chromium --app webapp classes"
+
+# Non-Chromium classes, incomplete suffixes, and extension popouts stay untagged.
+# Bitwarden popout is chrome-<extension-id>-Default with no host/__ (bitwarden.lua).
+for appid in \
+  firefox zen librewolf \
+  "firefox-example.com__-Default" \
+  chrome-evil \
+  brave-something \
+  not-a-browser \
+  "chrome-nngceckbapebfimnlniiiahkandclblb-Default" \
+  "chrome-abcdefghijklmnopqrstuvwxyzabcdef-Default"; do
+  fullmatch "$appid" "$chromium_pattern" &&
+    fail "chromium rule leaves non-matching class $appid untagged"
+done
+pass "chromium rule leaves non-Chromium, incomplete, and extension classes untagged"
+
+# Tag removals for YouTube/Zoom must precede the rules that consume the tag.
+# Hyprland does not undo a rule that already matched on a later-removed tag.
+mapfile -t order_lines < <(
+  grep -nE 'tag = "-chromium-based-browser"|tag = "chromium-based-browser"' "$browser_lua" |
+    awk -F: '{print $1, $2}'
+)
+remove_line=
+consume_line=
+for entry in "${order_lines[@]}"; do
+  line=${entry%% *}
+  text=${entry#* }
+  if [[ $text == *'tag = "-chromium-based-browser"'* ]]; then
+    remove_line=${remove_line:-$line}
+  elif [[ $text == *'tag = "chromium-based-browser"'* ]]; then
+    consume_line=${consume_line:-$line}
+  fi
+done
+[[ -n $remove_line && -n $consume_line ]] ||
+  fail "browser.lua declares both chromium tag removal and tag consumer rules"
+(( remove_line < consume_line )) ||
+  fail "YouTube/Zoom chromium tag removal precedes the tile/opacity consumer" \
+    "remove=$remove_line consume=$consume_line"
+pass "chromium video-app tag removals precede the rules that consume the tag"


### PR DESCRIPTION
## Summary

Fixes #9784.

Hyprland matches window-rule `class` with `RE2::FullMatch`. The chromium tag rule in `default/hypr/apps/browser.lua` listed bare browser classes only, so Chromium `--app` web apps never received `+chromium-based-browser`.

Observed classes from the issue:

```
chrome-example.com__-Default
brave-outlook.office.com__mail_-Default
```

Both missed the tag and fell through to `default-opacity` (more translucent when unfocused) instead of the browser tile + opacity pair.

## Change

```lua
o.window("((google-)?[cC]hrom(e|ium)|[bB]rave(-browser|-origin)?|[mM]icrosoft-edge|Vivaldi-stable|helium)(-.+-Default)?", { tag = "+chromium-based-browser" })
```

- Optional `(-.+-Default)` covers the Chromium `--app` class form used by `omarchy-launch-webapp`.
- `brave(-browser|-origin)?` covers bare Brave / Brave Origin windows and their webapp classes (adjacent to #8968 on the same line).
- Existing YouTube/Zoom strip rules already use a browser-agnostic `^.+-youtube.com__.*` form and start working once the tag is applied.

## Test plan

- [x] Added `test/shell.d/webapp-browser-tags-test.sh` using Python `re.fullmatch` (bash `=~` is unanchored and would hide this bug)
- [x] Bare Chromium-family classes still match
- [x] Webapp classes from the issue match (`chrome-example.com__-Default`, `brave-outlook.office.com__mail_-Default`, plus origin/edge/helium variants)
- [x] Firefox and incomplete suffixes stay untagged
- [x] `bash test/shell.d/webapp-browser-tags-test.sh` — all pass
- [x] Confirmed pre-fix FullMatch fails the issue classes; post-fix succeeds

```
ok - chromium rule full-matches bare Chromium-family browser classes
ok - chromium rule full-matches Chromium --app webapp classes
ok - chromium rule leaves non-Chromium and incomplete classes untagged
ok - chromium rule includes the Chromium --app webapp class suffix
```