### PR TITLE
Keep low-battery latch across AC online flaps

### DIFF
--- a/shell/plugins/services/battery/BatteryModel.js
+++ b/shell/plugins/services/battery/BatteryModel.js
@@ -9,13 +9,22 @@ function isDischarging(device, onBattery, dischargingState) {
 
 function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified) {
   var level = batteryPercentage(device)
-  if (level < 0) return { level: level, notify: false, notifiedLowBattery: false }
+  if (level < 0) {
+    return { level: level, notify: false, notifiedLowBattery: !!alreadyNotified }
+  }
 
+  // True only while discharging at/under the threshold. AC-online flaps must not
+  // clear the latch: onBattery false makes low false, and the old latch reset on
+  // that alone re-fired a critical toast on every flap (~3s) until the machine died.
   var low = isDischarging(device, onBattery, dischargingState) && level <= threshold
+  // Clear only after a real recovery above the threshold, not on transient AC state.
+  var recovered = level > threshold
+  var notifiedLowBattery = recovered ? false : !!(alreadyNotified || low)
+
   return {
     level: level,
     notify: low && !alreadyNotified,
-    notifiedLowBattery: low
+    notifiedLowBattery: notifiedLowBattery
   }
 }
 

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -46,6 +46,13 @@ assertDeepEqual(
   { level: 8, notify: false, notifiedLowBattery: false },
   'battery does not latch from AC-only low readings without a discharge warning'
 )
+// A missing reading is another blip the latch has to survive, or a dropped
+// UPower device re-arms the same storm the AC flap used to.
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: false, percentage: 0.08, state: discharging }, true, discharging, 10, true),
+  { level: -1, notify: false, notifiedLowBattery: true },
+  'battery keeps the low latch while the device reading is missing'
+)
 
 // Simulate the issue #9670 flap loop: one warning, then many AC toggles.
 ;(function () {

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -28,4 +28,36 @@ assertDeepEqual(
   { level: 40, notify: false, notifiedLowBattery: false },
   'battery clears notified state after recovery'
 )
+
+// AC online status can flap while still critically low (UCSI/PD). The latch must
+// survive onBattery false so onOnBatteryChanged cannot re-arm a toast storm.
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, false, discharging, 10, true),
+  { level: 8, notify: false, notifiedLowBattery: true },
+  'battery keeps the low latch across an AC-online flap'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, true),
+  { level: 8, notify: false, notifiedLowBattery: true },
+  'battery does not re-notify after an AC flap while still low'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, false, discharging, 10, false),
+  { level: 8, notify: false, notifiedLowBattery: false },
+  'battery does not latch from AC-only low readings without a discharge warning'
+)
+
+// Simulate the issue #9670 flap loop: one warning, then many AC toggles.
+;(function () {
+  const device = { isPresent: true, percentage: 0.08, state: discharging }
+  let notified = false
+  let warnings = 0
+  for (let i = 0; i < 20; i++) {
+    const onBattery = i === 0 || i % 2 === 1
+    const state = battery.shouldWarnLowBattery(device, onBattery, discharging, 10, notified)
+    if (state.notify) warnings++
+    notified = state.notifiedLowBattery
+  }
+  assertEqual(warnings, 1, 'battery emits a single warning across repeated AC flaps while low')
+})()
 JS


### PR DESCRIPTION
## Summary

Fixes #9670.

The battery service latched `notifiedLowBattery` to "currently low and discharging". `Service.qml` re-runs `checkBattery()` on every `onOnBatteryChanged`. When AC online status flaps (UCSI/PD trouble at critical charge), each "on AC" check cleared the latch and the next "on battery" check immediately re-fired a critical **Time to recharge!** toast — ~one every 3s for 14 minutes in the report (~260 never-expiring critical popups).

## Change

In `shell/plugins/services/battery/BatteryModel.js`, keep the latch set through transient `onBattery == false` while still at/under the threshold, and clear it only after the level recovers above the threshold:

```js
var low = isDischarging(...) && level <= threshold
var recovered = level > threshold
var notifiedLowBattery = recovered ? false : !!(alreadyNotified || low)
```

`notify` is still `low && !alreadyNotified` — one warning per low episode.

## Test plan

- [x] Extended `test/shell.d/battery-test.sh` with AC-flap latch cases and a 20-step flap loop
- [x] `bash test/shell.d/battery-test.sh` — all pass, including single warning across repeated flaps
- [x] Existing once-under-threshold / keep-notified / clear-after-recovery cases still pass

```
ok - battery warns once under threshold
ok - battery keeps low-battery notified state
ok - battery clears notified state after recovery
ok - battery keeps the low latch across an AC-online flap
ok - battery does not re-notify after an AC flap while still low
ok - battery does not latch from AC-only low readings without a discharge warning
ok - battery emits a single warning across repeated AC flaps while low
```