### PR TITLE
Add notification center bar widget

### DIFF
--- a/shell/plugins/notifications/BarWidget.qml
+++ b/shell/plugins/notifications/BarWidget.qml
@@ -1,0 +1,149 @@
+import QtQuick
+import QtQuick.Controls
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+import "components"
+import "NotificationLogic.js" as NotificationLogic
+
+Panel {
+  id: root
+  moduleName: "omarchy.notifications"
+  ipcTarget: ""
+
+  readonly property var notificationService: bar?.shell?.firstPartyServiceFor("omarchy.notifications")
+  property var entries: []
+
+  visible: true
+  implicitWidth: button.implicitWidth
+  implicitHeight: button.implicitHeight
+
+  function refreshHistory() {
+    if (!readHistory.running) readHistory.running = true
+  }
+
+  onOpenedChanged: if (opened) refreshHistory()
+
+  Connections {
+    target: root.notificationService
+    function onHistoryRevisionChanged() { if (root.opened) root.refreshHistory() }
+  }
+
+  Process {
+    id: readHistory
+    running: false
+    command: ["bash", "-c", "awk 1 \"$1\"/*.json \"$2\"/*.json 2>/dev/null || true", "--",
+      (Quickshell.env("HOME") || "") + "/.local/state/omarchy/notifications/history",
+      (Quickshell.env("HOME") || "") + "/.local/state/omarchy/notifications"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.entries = NotificationLogic.historyRows(text, [], 1, 1000000)
+    }
+  }
+
+  BarIconButton {
+    id: button
+    anchors.fill: parent
+    bar: root.bar
+    text: "󰂚"
+    active: root.entries.length > 0
+    tooltipText: "Notification center"
+    onPressed: root.toggle()
+  }
+
+  KeyboardPanel {
+    anchorItem: button
+    owner: root
+    bar: root.bar
+    open: root.opened
+    contentWidth: fittedContentWidth(Style.space(410))
+    contentHeight: fittedContentHeight(content.implicitHeight, Style.space(650))
+
+    Column {
+      id: content
+      anchors.fill: parent
+      spacing: Style.space(10)
+
+      Item {
+        width: parent.width
+        height: Math.max(title.implicitHeight, clearButton.implicitHeight)
+
+        Text {
+          id: title
+          anchors.left: parent.left
+          anchors.verticalCenter: parent.verticalCenter
+          text: "Notifications"
+          color: root.barForeground
+          font.family: root.bar ? root.bar.fontFamily : Style.font.family
+          font.pixelSize: Style.font.heading
+          font.bold: true
+        }
+
+        Button {
+          id: clearButton
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+          visible: root.entries.length > 0
+          text: "Clear all"
+          foreground: root.barForeground
+          fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
+          onClicked: {
+            if (root.notificationService) root.notificationService.clearHistory()
+            root.entries = []
+          }
+        }
+      }
+
+      Text {
+        visible: root.entries.length === 0
+        width: parent.width
+        topPadding: Style.space(24)
+        text: "No notifications since startup"
+        color: Qt.darker(root.barForeground, 1.5)
+        horizontalAlignment: Text.AlignHCenter
+        font.family: root.bar ? root.bar.fontFamily : Style.font.family
+        font.pixelSize: Style.font.body
+      }
+
+      Flickable {
+        width: parent.width
+        height: Math.min(historyColumn.implicitHeight, Style.space(580))
+        contentWidth: width
+        contentHeight: historyColumn.implicitHeight
+        visible: root.entries.length > 0
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        flickableDirection: Flickable.VerticalFlick
+        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+        Column {
+          id: historyColumn
+          width: parent.width
+          spacing: Style.space(8)
+
+          Repeater {
+            model: root.entries
+
+            NotificationCard {
+              required property var modelData
+              width: historyColumn.width
+              app: String(modelData.app || "")
+              appIcon: String(modelData.appIcon || "")
+              summary: String(modelData.summary || "")
+              body: String(modelData.body || "")
+              image: String(modelData.image || "")
+              glyph: String(modelData.glyph || "")
+              urgency: Number(modelData.urgency || 1)
+              timestamp: Number(modelData.timestamp || 0)
+              cornerRadius: Style.cornerRadius
+              fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
+              dismissible: false
+              onCardClicked: if (root.notificationService) root.notificationService.activateHistoryEntry(modelData)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -90,9 +90,10 @@ Item {
   // to it. QML ids aren't visible to external consumers without the alias.
   property alias popupModel: popupModel
   ListModel { id: popupModel }
+  property int historyRevision: 0
 
-  // How many notifications the history directory keeps, and therefore how
-  // many `showHistory` can replay.
+  // How many archived notifications `showHistory` replays as simultaneous
+  // toasts. The notification-center widget reads the complete boot archive.
   readonly property int historyLimit: 10
 
   readonly property int lowPopupDuration: 5000
@@ -396,6 +397,12 @@ Item {
     dismissPopup(index)
   }
 
+  function activateHistoryEntry(entry) {
+    var argv = NotificationLogic.parseExecArgv(entry ? entry.execArgv : "")
+    if (argv) Util.execArgv(argv)
+    else focusApp(entry)
+  }
+
   // Try to focus an existing Hyprland window matching the notification's
   // sender. The helper handles case-insensitive class matching.
   function focusApp(entry) {
@@ -411,7 +418,14 @@ Item {
 
   Process {
     id: ensureDirsProc
-    command: ["mkdir", "-p", service.stateDir, service.popupStateDir, service.historyDir, service.imagesDir]
+    // History belongs to the current boot. The boot id survives shell
+    // restarts but changes after reboot, when the previous archive is cleared.
+    command: ["bash", "-c",
+      "mkdir -p \"$1\" \"$2\" \"$3\" \"$4\" || exit 0\n" +
+      "boot=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)\n" +
+      "old=$(cat \"$3/.boot-id\" 2>/dev/null)\n" +
+      "if [[ -n $boot && $boot != $old ]]; then rm -f \"$2\"/*.json \"$3\"/*.json \"$4\"/*; printf '%s\\n' \"$boot\" > \"$3/.boot-id\"; fi",
+      "--", service.stateDir, service.popupStateDir, service.historyDir, service.imagesDir]
     running: false
   }
 
@@ -513,7 +527,7 @@ Item {
       NotificationLogic.popupFileName(snapshot)]
     for (var i = 0; i < persistable.copies.length; i++)
       command.push(persistable.copies[i].from, persistable.copies[i].to)
-    enqueuePopupFileJob(command)
+    enqueuePopupFileJob(command, function() { service.historyRevision++ })
   }
 
   function deletePopupFileFor(row) {
@@ -528,28 +542,22 @@ Item {
   // ---------------------------------------------------- history
   //
   // A popup that leaves the screen keeps its file — it just moves one level
-  // down, into historyDir. Trimming happens right there in the same shell
-  // job: the names sort numerically by their leading millisecond timestamp,
-  // so everything but the newest historyLimit files is the tail to drop,
-  // image copies included. Callers set $hist, $limit and $imgs first.
-  readonly property string trimHistoryScript:
-    "ls -1 \"$hist\" 2>/dev/null | sort -n | head -n \"-$limit\" | while IFS= read -r stale; do rm -f \"$hist/$stale\" \"$imgs/${stale%.json}\"-*; done"
+  // down, into historyDir. The archive is cleared when the boot id changes;
+  // showHistory still limits toast replay while the bar panel can show all.
 
   function archivePopupFileFor(row) {
     if (!row) return
     // A history replay or the empty-history placeholder has no file to move;
-    // the failed mv leaves the history untouched, trimming included. Image
+    // the failed mv leaves the history untouched. Image
     // copies stay put — live and archived entries share imagesDir.
     enqueuePopupFileJob(["bash", "-c",
       "mkdir -p \"$1\" || exit 0\n" +
-      "hist=\"$1\" limit=\"$2\" imgs=\"$5\"\n" +
-      "mv -f \"$4/$3\" \"$1/$3\" 2>/dev/null || exit 0\n" +
-      trimHistoryScript, "--",
+      "mv -f \"$4/$3\" \"$1/$3\" 2>/dev/null", "--",
       historyDir,
       String(historyLimit),
       NotificationLogic.popupFileName(row),
       popupStateDir,
-      imagesDir])
+      imagesDir], function() { service.historyRevision++ })
   }
 
   // Record a notification that never made it to the screen (DND silenced it),
@@ -559,7 +567,7 @@ Item {
   // A silenced notification is untracked the moment it arrives, so the server
   // has nothing left for a later replaces_id to replace and hands the sender a
   // fresh id instead. Every update from a chatty thread is therefore its own
-  // notification here, and several can sit in the ten slots together — there
+  // notification here, and several can sit in the archive together — there
   // is no id to recognize them by, and guessing from app and summary would
   // merge genuinely separate messages.
   function writeHistoryFile(entry, done) {
@@ -570,11 +578,10 @@ Item {
     var persistable = NotificationLogic.persistablePopup(entry, imagesDir)
     var command = ["bash", "-c",
       "mkdir -p \"$1\" \"$5\" || exit 0\n" +
-      "hist=\"$1\" limit=\"$2\" name=\"$3\" json=\"$4\" imgs=\"$5\"\n" +
+      "name=\"$3\" json=\"$4\"\n" +
       "shift 5\n" +
       copyImagesScript +
-      "printf '%s\\n' \"$json\" > \"$hist/$name\" || exit 0\n" +
-      trimHistoryScript, "--",
+      "printf '%s\\n' \"$json\" > \"$1/$name\"", "--",
       historyDir,
       String(historyLimit),
       NotificationLogic.popupFileName(entry),
@@ -582,7 +589,10 @@ Item {
       imagesDir]
     for (var i = 0; i < persistable.copies.length; i++)
       command.push(persistable.copies[i].from, persistable.copies[i].to)
-    enqueuePopupFileJob(command, done)
+    enqueuePopupFileJob(command, function() {
+      service.historyRevision++
+      if (done) done()
+    })
   }
 
   function clearHistory() {
@@ -591,7 +601,7 @@ Item {
       "  [[ -e $f ]] || continue\n" +
       "  stale=\"${f##*/}\"\n" +
       "  rm -f \"$f\" \"$2/${stale%.json}\"-*\n" +
-      "done", "--", historyDir, imagesDir])
+      "done", "--", historyDir, imagesDir], function() { service.historyRevision++ })
   }
 
   // A restart can kill a queued job between its cp and its JSON write,

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -26,6 +26,7 @@ BorderSurface {
   property int urgency: 1
   property double timestamp: 0
   property int cornerRadius: 0
+  property bool dismissible: true
 
   // System monospace font injected by the container.
   property string fontFamily: ""
@@ -197,7 +198,7 @@ BorderSurface {
     anchors.rightMargin: root.borderRight + Style.space(3)
     width: Style.space(18)
     height: Style.space(18)
-    visible: opacity > 0
+    visible: root.dismissible && opacity > 0
     opacity: root.hovered ? 1 : 0
 
     Behavior on opacity { NumberAnimation { duration: 100 } }

--- a/shell/plugins/notifications/manifest.json
+++ b/shell/plugins/notifications/manifest.json
@@ -6,10 +6,19 @@
   "author": "Omarchy",
   "description": "Notification daemon, popups, DND, and history",
   "kinds": [
-    "service"
+    "service",
+    "bar-widget"
   ],
   "keepLoaded": true,
   "entryPoints": {
-    "service": "Service.qml"
+    "service": "Service.qml",
+    "barWidget": "BarWidget.qml"
+  },
+  "barWidget": {
+    "displayName": "Notification center",
+    "description": "Bell and scrollable history of notifications received since boot",
+    "category": "Status",
+    "allowMultiple": false,
+    "defaultSection": "right"
   }
 }

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -451,12 +451,12 @@ assert(
   'notifications service archives by moving the popup file into the history dir'
 )
 assert(
-  /head -n \\"-\$limit\\"/.test(serviceQml),
-  'notifications service trims history to the newest entries in the same job'
+  /cat \/proc\/sys\/kernel\/random\/boot_id/.test(serviceQml),
+  'notifications service scopes history to the current boot'
 )
 assert(
-  /\\"\$imgs\/\$\{stale%\.json\}\\"-\*/.test(serviceQml),
-  'notifications service drops a trimmed history entry\'s image copies with it'
+  /\$boot != \$old[\s\S]{0,180}?rm -f/.test(serviceQml),
+  'notifications service clears the previous boot history and images'
 )
 assert(
   /readonly property string imagesDir: popupStateDir \+ "images\/"/.test(serviceQml),
@@ -578,4 +578,12 @@ assert(
   !/pendingModel|pastModel/.test(serviceQml),
   'notifications service keeps no in-memory history models'
 )
+
+const barWidgetQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/BarWidget.qml'), 'utf8')
+const notificationManifest = JSON.parse(fs.readFileSync(path.join(root, 'shell/plugins/notifications/manifest.json'), 'utf8'))
+assert(notificationManifest.kinds.includes('bar-widget'), 'notifications provide a bar widget')
+assert(/Notification center/.test(barWidgetQml), 'notification bar widget opens a notification center')
+assert(/Flickable \{[\s\S]*NotificationCard \{/.test(barWidgetQml), 'notification center renders scrollable notification cards')
+assert(/historyRows\(text, \[\], 1, 1000000\)/.test(barWidgetQml), 'notification center loads the full boot history')
+assert(/clearHistory\(\)/.test(barWidgetQml), 'notification center can clear its history')
 JS


### PR DESCRIPTION
## Summary

- add an optional notification-center bell widget with a scrollable history panel
- retain all notification cards received during the current boot and clear the archive on reboot
- keep the existing shortcut behavior bounded to the ten most recent replayed toasts
- support clear-all and the existing notification click actions

## Testing

- `./test/shell.d/notifications-test.sh`
- `./test/shell` (notification and preceding tests passed; full run later stops at the existing `omarchy-pkgs checkout found for PKGBUILD coverage` environment prerequisite)