### PR TITLE
Stop previewing received Taildrop images

### DIFF
--- a/bin/omarchy-tailscale-receive
+++ b/bin/omarchy-tailscale-receive
@@ -59,16 +59,8 @@ claim_path() {
 announce() {
   local path="$1"
   local name="${path##*/}"
-  local args=("Received $name" "Saved to ${dir/#$HOME/~}" -u critical)
-
-  case "${name,,}" in
-  *.png | *.jpg | *.jpeg | *.gif | *.webp | *.avif | *.bmp | *.tif | *.tiff)
-    args+=(--image "$path")
-    ;;
-  *)
-    args+=(-g 󰒊)
-    ;;
-  esac
+  # Keep received files passive until the user chooses to open them.
+  local args=("Received $name" "Saved to ${dir/#$HOME/~}" -u critical -g 󰒊)
 
   # Announcing is best-effort: the file is already delivered, and under `set -e`
   # a notification outage would otherwise kill the long-running receiver.

--- a/test/shell.d/tailscale-receive-test.sh
+++ b/test/shell.d/tailscale-receive-test.sh
@@ -52,9 +52,9 @@ notifications=$(<"$WORKDIR/notifications")
   fail "taildrop receive saves incoming files" "$(ls "$downloads")"
 pass "taildrop receive saves incoming files"
 
-grep -qF -- "Received photo.png Saved to $downloads -u critical --image $downloads/photo.png" <<<"$notifications" ||
-  fail "taildrop receive previews received images" "$notifications"
-pass "taildrop receive previews received images"
+grep -q -- "--image" <<<"$notifications" &&
+  fail "taildrop receive does not decode received images" "$notifications"
+pass "taildrop receive does not decode received images"
 
 while IFS= read -r line; do
   [[ $line == *"-u critical"* ]] || fail "taildrop receive announcements wait to be answered" "$line"


### PR DESCRIPTION
## Problem

The Taildrop receiver passes received image files directly to the notification service with `--image`.

This causes Quickshell to decode received image contents automatically, before the recipient interacts with the notification. Some Qt image decoders can allocate memory proportional to the encoded file size even when a small `sourceSize` is requested, allowing a sufficiently large received image to exhaust Quickshell’s available memory.

## Fix

Use the existing generic file glyph for every received Taildrop file instead of attaching image files as notification previews.

The existing behavior is otherwise preserved:

- files are still saved to the downloads directory
- notifications remain persistent
- clicking a notification still opens the received file

## Tests

- `bash test/shell.d/tailscale-receive-test.sh`
- `bash -n bin/omarchy-tailscale-receive test/shell.d/tailscale-receive-test.sh`
- `git diff --check`

The regression test now verifies that received images are not passed to the notification service through `--image`.