### PR TITLE
Preview hex colors in the clipboard picker

### DIFF
--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -141,6 +141,7 @@ Item {
         fullText: row.fullText,
         previewText: row.previewText,
         previewImage: row.previewImage ? Util.fileUrl(row.previewImage) : "",
+        swatchColor: row.swatchColor || "",
         path: row.path,
         mime: row.mime,
         historyIndex: row.index
@@ -474,8 +475,11 @@ Item {
                   required property string previewText
                   required property string fullText
                   required property string previewImage
+                  required property string swatchColor
 
                   readonly property bool hasCursor: root.cursorActive && index === root.selectedIndex
+                  readonly property bool hasSwatch: swatchColor.length > 0
+                  readonly property bool hasThumb: !hasSwatch && previewImage.length > 0
 
                   width: ListView.view.width
                   height: root.rowHeight
@@ -490,8 +494,18 @@ Item {
                     anchors.bottomMargin: Style.space(8)
                     spacing: Style.space(10)
 
+                    Rectangle {
+                      visible: parent.parent.hasSwatch
+                      width: visible ? parent.height : 0
+                      height: parent.height
+                      radius: Math.min(root.cornerRadius, height / 2)
+                      color: parent.parent.swatchColor || "transparent"
+                      border.width: Style.normalBorderWidth
+                      border.color: Util.alpha(parent.parent.hasCursor ? root.selectedText : root.border, 0.4)
+                    }
+
                     Image {
-                      visible: parent.parent.previewImage.length > 0
+                      visible: parent.parent.hasThumb
                       width: visible ? parent.height : 0
                       height: parent.height
                       source: parent.parent.previewImage
@@ -502,7 +516,7 @@ Item {
 
                     Text {
                       textFormat: Text.PlainText
-                      width: parent.width - (parent.parent.previewImage.length > 0 ? parent.height + parent.spacing : 0)
+                      width: parent.width - ((parent.parent.hasSwatch || parent.parent.hasThumb) ? parent.height + parent.spacing : 0)
                       height: parent.height
                       text: parent.parent.previewText
                       color: parent.parent.hasCursor ? root.selectedText : root.foreground
@@ -533,6 +547,7 @@ Item {
             }
 
             Item {
+              id: previewPane
               width: parent.width / 2
               height: parent.height
               clip: true
@@ -549,13 +564,13 @@ Item {
 
               Text {
                 textFormat: Text.PlainText
-                visible: parent.activeRow && !parent.activeRow.previewImage
+                visible: previewPane.activeRow && !previewPane.activeRow.previewImage && !previewPane.activeRow.swatchColor
                 anchors.fill: parent
                 anchors.leftMargin: root.contentMargin
                 anchors.rightMargin: 0
                 anchors.topMargin: 0
                 anchors.bottomMargin: 0
-                text: parent.activeRow ? parent.activeRow.fullText : ""
+                text: previewPane.activeRow ? previewPane.activeRow.fullText : ""
                 color: root.foreground
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.title
@@ -564,14 +579,41 @@ Item {
                 verticalAlignment: Text.AlignTop
               }
 
-              Image {
-                visible: parent.activeRow && parent.activeRow.previewImage
+              Column {
+                visible: previewPane.activeRow && previewPane.activeRow.swatchColor
                 anchors.fill: parent
                 anchors.leftMargin: root.contentMargin
                 anchors.rightMargin: 0
                 anchors.topMargin: 0
                 anchors.bottomMargin: 0
-                source: parent.activeRow ? parent.activeRow.previewImage : ""
+                spacing: Style.spacing.md
+
+                Rectangle {
+                  width: Math.min(parent.width, Style.space(220))
+                  height: width
+                  radius: Math.min(root.cornerRadius, height / 2)
+                  color: previewPane.activeRow ? previewPane.activeRow.swatchColor : "transparent"
+                  border.width: Style.normalBorderWidth
+                  border.color: Util.alpha(root.border, 0.4)
+                }
+
+                Text {
+                  textFormat: Text.PlainText
+                  text: previewPane.activeRow ? previewPane.activeRow.fullText : ""
+                  color: root.foreground
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.title
+                }
+              }
+
+              Image {
+                visible: previewPane.activeRow && previewPane.activeRow.previewImage
+                anchors.fill: parent
+                anchors.leftMargin: root.contentMargin
+                anchors.rightMargin: 0
+                anchors.topMargin: 0
+                anchors.bottomMargin: 0
+                source: previewPane.activeRow ? previewPane.activeRow.previewImage : ""
                 fillMode: Image.PreserveAspectFit
                 verticalAlignment: Image.AlignTop
                 asynchronous: true

--- a/shell/plugins/clipboard/ClipboardHistory.js
+++ b/shell/plugins/clipboard/ClipboardHistory.js
@@ -150,6 +150,13 @@ function previewText(entry) {
   return String(entry.text || "").replace(/\s+/g, " ")
 }
 
+// Whole-entry hex only: #RRGGBB or RRGGBB. Derived at display time so
+// clipboard-history.json stays text/image and stays compatible with older shells.
+function detectColor(text) {
+  var match = String(text || "").trim().match(/^#?([0-9a-fA-F]{6})$/)
+  return match ? "#" + match[1].toUpperCase() : ""
+}
+
 function fullText(entry) {
   if (!entry) return ""
   var paths = filePaths(entry)
@@ -195,6 +202,7 @@ function displayRows(history, query, limit) {
       fullText: isImage ? "" : fullText(entry),
       previewText: previewText(entry),
       previewImage: previewPath,
+      swatchColor: isFile || isImage ? "" : detectColor(entry.text),
       path: isImage ? String(entry.path || "") : (isFile && paths.length === 1 ? paths[0] : ""),
       mime: isImage ? String(entry.mime || "image/png") : "text/plain",
       index: i
@@ -220,6 +228,7 @@ if (typeof module !== "undefined") {
     filePaths: filePaths,
     fileEntryText: fileEntryText,
     fullText: fullText,
+    detectColor: detectColor,
     displayRows: displayRows
   }
 }

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -104,6 +104,7 @@ assertDeepEqual(
     fullText: '/home/dhh/Videos/screenrecording-2026-05-29_13-56-43-720p.gif',
     previewText: 'screenrecording-2026-05-29_13-56-43-720p.gif',
     previewImage: '/home/dhh/Videos/screenrecording-2026-05-29_13-56-43-720p.gif',
+    swatchColor: '',
     path: '/home/dhh/Videos/screenrecording-2026-05-29_13-56-43-720p.gif',
     mime: 'text/plain',
     index: 0
@@ -125,6 +126,40 @@ assertDeepEqual(
 
 assertDeepEqual(clipboard.displayRows(history, '', 0), [], 'clipboard display rows supports zero result limit')
 assertDeepEqual(clipboard.addEntry(history, 'next', 0), [], 'clipboard addEntry supports zero history limit')
+
+assertEqual(clipboard.detectColor('#a954f4'), '#A954F4', 'clipboard detectColor normalizes hashed hex')
+assertEqual(clipboard.detectColor(' 3bd671 '), '#3BD671', 'clipboard detectColor accepts unhashed hex')
+assertEqual(clipboard.detectColor('color #a954f4'), '', 'clipboard detectColor ignores embedded hex')
+assertEqual(clipboard.detectColor('#abcd'), '', 'clipboard detectColor rejects short hex')
+assertEqual(clipboard.detectColor('red'), '', 'clipboard detectColor ignores named colors')
+assertEqual(
+  clipboard.displayRows([{ type: 'text', text: '#a954f4' }], '', 50)[0].swatchColor,
+  '#A954F4',
+  'clipboard display rows expose a swatch for whole-entry hex'
+)
+assertEqual(
+  clipboard.displayRows([{ type: 'text', text: 'hello' }], '', 50)[0].swatchColor,
+  '',
+  'clipboard display rows leave ordinary text without a swatch'
+)
+assertEqual(
+  clipboard.displayRows([{ type: 'image', path: '/tmp/a.png', mime: 'image/png' }], '', 50)[0].swatchColor,
+  '',
+  'clipboard display rows leave images without a swatch'
+)
+assert(
+  /required property string swatchColor/.test(clipboardQml),
+  'clipboard list rows declare a swatch color'
+)
+assert(
+  /visible: parent\.parent\.hasSwatch/.test(clipboardQml),
+  'clipboard list rows render a color swatch'
+)
+assertEqual(
+  (clipboardQml.match(/radius: Math\.min\(root\.cornerRadius, height \/ 2\)/g) || []).length,
+  2,
+  'clipboard swatches follow Hyprland decoration rounding'
+)
 
 assert(
   /function select\(delta\)[\s\S]*root\.disarmPointer\(\)[\s\S]*selectedIndex =/.test(clipboardQml),


### PR DESCRIPTION
## Summary
- Show a color swatch next to clipboard entries that are a whole-entry hex value (`#RRGGBB` or `RRGGBB`), plus a large preview on the right.
- Derive the color at display time so `clipboard-history.json` stays text/image and older shells keep working.
- Round the swatches with `Style.cornerRadius` (Hyprland `decoration:rounding`); `0` stays square.

<img width="893" height="623" alt="image" src="https://github.com/user-attachments/assets/7cbd4292-2823-4b71-95a6-23bed9442c3c" />

Implements the stock-picker half of https://github.com/omacom/omarchy/discussions/8273. Named colors, 3-digit hex, `rgb()`/`hsl()`, and hex embedded in other text are out of scope.

## Test plan
- [ ] `bash test/shell.d/clipboard-test.sh`
- [ ] Copy `#a954f4` and `3bd671`, open the clipboard picker, confirm list chip + large preview
- [ ] Copy ordinary text and an image; confirm no swatch
- [ ] With `decoration:rounding` 0, swatches are square; with a non-zero theme rounding they match window corners
- [ ] Paste/copy a color entry still inserts the original text