### PR TITLE
Run executable hooks directly instead of forcing bash

### DIFF
--- a/bin/omarchy-hook
+++ b/bin/omarchy-hook
@@ -16,13 +16,21 @@ HOOK_DIR="$HOOK_PATH.d"
 shift
 
 if [[ -f $HOOK_PATH ]]; then
-  bash "$HOOK_PATH" "$@" || echo "Hook failed: $HOOK_PATH"
+  if [[ -x $HOOK_PATH ]]; then
+    "$HOOK_PATH" "$@" || echo "Hook failed: $HOOK_PATH"
+  else
+    bash "$HOOK_PATH" "$@" || echo "Hook failed: $HOOK_PATH"
+  fi
 fi
 
 if [[ -d $HOOK_DIR ]]; then
   for hook in "$HOOK_DIR"/*; do
     [[ -f $hook ]] || continue
     [[ $hook == *.sample ]] && continue
-    bash "$hook" "$@" || echo "Hook failed: $hook"
+    if [[ -x $hook ]]; then
+      "$hook" "$@" || echo "Hook failed: $hook"
+    else
+      bash "$hook" "$@" || echo "Hook failed: $hook"
+    fi
   done
 fi


### PR DESCRIPTION
## Summary

`bin/omarchy-hook` always ran hooks with `bash "$hook"`, so an executable hook with a non-bash shebang (e.g. a Python script) failed because bash tried to parse it as shell. `default/agents/skills/omarchy/hooks.md` already documents that hooks are meant to just run.

This makes the runner invoke executable hooks directly (`"$hook" "$@"`, respecting the shebang) and only fall back to `bash "$hook" "$@"` for non-executable files. `.sample` files are still skipped, and a nonzero exit still prints `Hook failed: ...`.

Fixes #9845

## Test plan

- Manually created a `post-boot.d/` with an executable Python-shebang hook, a non-executable bash hook, a `.sample` file, and a failing executable hook, then ran `omarchy-hook post-boot`:
  - Python hook ran via its own shebang
  - non-executable bash hook still ran via `bash`
  - `.sample` file was skipped
  - failing hook still printed `Hook failed: ...`

Made with [Cursor](https://cursor.com)