### PR TITLE
Toggle full width when Super+workspace is pressed again

### DIFF
--- a/bin/omarchy-hyprland-workspace-focus
+++ b/bin/omarchy-hyprland-workspace-focus
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# omarchy:summary=Focus a workspace, or toggle full width when already there
+# omarchy:args=<workspace>
+# omarchy:examples=omarchy hyprland workspace focus 2
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: omarchy-hyprland-workspace-focus <workspace>" >&2
+}
+
+if (($# != 1)) || [[ ! $1 =~ ^[1-9]$|^10$ ]]; then
+  usage
+  exit 1
+fi
+
+workspace="$1"
+
+# When the preference is off, Super+N always just switches workspaces.
+if omarchy-toggle-enabled workspace-fullwidth-repress-off; then
+  hyprctl dispatch "hl.dsp.focus({ workspace = \"$workspace\" })" >/dev/null 2>&1 ||
+    hyprctl dispatch workspace "$workspace" >/dev/null
+  exit 0
+fi
+
+active_workspace=$(hyprctl activeworkspace -j | jq -r '.id')
+[[ $active_workspace =~ ^-?[0-9]+$ ]] || exit 1
+
+if [[ $active_workspace != "$workspace" ]]; then
+  hyprctl dispatch "hl.dsp.focus({ workspace = \"$workspace\" })" >/dev/null 2>&1 ||
+    hyprctl dispatch workspace "$workspace" >/dev/null
+  exit 0
+fi
+
+# Already on this workspace: toggle full width (maximized) on the focused window.
+active=$(hyprctl activewindow -j)
+address=$(jq -r '.address // empty' <<<"$active")
+[[ -n $address && $address != "0x0" ]] || exit 0
+
+fullscreen=$(jq -r '.fullscreen // 0' <<<"$active")
+
+if [[ $fullscreen == "1" ]]; then
+  hyprctl dispatch 'hl.dsp.window.fullscreen_state({ internal = 0, client = 0 })' >/dev/null 2>&1 ||
+    hyprctl dispatch fullscreenstate 0 0 >/dev/null
+else
+  hyprctl dispatch 'hl.dsp.window.fullscreen_state({ internal = 1, client = 1 })' >/dev/null 2>&1 ||
+    hyprctl dispatch fullscreenstate 1 1 >/dev/null
+fi

--- a/bin/omarchy-toggle-workspace-fullwidth-repress
+++ b/bin/omarchy-toggle-workspace-fullwidth-repress
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle whether Super+workspace on the current workspace toggles full width
+# omarchy:args=[toggle|on|off]
+# omarchy:examples=omarchy toggle workspace fullwidth repress | omarchy toggle workspace fullwidth repress off
+
+set -euo pipefail
+
+FLAG=workspace-fullwidth-repress-off
+ACTION="${1:-toggle}"
+
+case "$ACTION" in
+  toggle|"")
+    if omarchy-toggle-enabled "$FLAG"; then
+      omarchy-toggle "$FLAG" off
+    else
+      omarchy-toggle "$FLAG" on
+    fi
+    ;;
+  on|enable)
+    # Feature on means the off-flag is absent.
+    omarchy-toggle "$FLAG" off
+    ;;
+  off|disable)
+    omarchy-toggle "$FLAG" on
+    ;;
+  *)
+    echo "Usage: omarchy-toggle-workspace-fullwidth-repress [toggle|on|off]" >&2
+    exit 1
+    ;;
+esac
+
+if omarchy-toggle-enabled "$FLAG"; then
+  omarchy-notification-send -g 󰖯 "Workspace repress full width disabled"
+else
+  omarchy-notification-send -g 󰖯 "Workspace repress full width enabled"
+fi

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -20,7 +20,9 @@ o.bind("SUPER + DOWN", "Focus on below window", hl.dsp.focus({ direction = "d" }
 
 for workspace = 1, 10 do
   local key = "code:" .. tostring(workspace + 9)
-  o.bind("SUPER + " .. key, "Switch to workspace " .. workspace, hl.dsp.focus({ workspace = tostring(workspace) }))
+  -- Super+N switches workspaces; pressing it again on the current workspace
+  -- toggles full width unless that preference is turned off in the menu.
+  o.bind("SUPER + " .. key, "Switch to workspace " .. workspace, "omarchy-hyprland-workspace-focus " .. workspace)
   o.bind("SUPER + SHIFT + " .. key, "Move window to workspace " .. workspace, hl.dsp.window.move({ workspace = tostring(workspace) }))
   o.bind("SUPER + SHIFT + ALT + " .. key, "Move window silently to workspace " .. workspace, hl.dsp.window.move({ workspace = tostring(workspace), follow = false }))
 end

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -95,6 +95,7 @@
   "trigger.toggle.top-bar": {"icon":"󰍜","label":"Menu Bar","action":"omarchy-toggle-bar"},
   "trigger.toggle.battery-percentage": {"icon":"󰁹","label":"Battery Percentage","when":"omarchy-hw-laptop","action":"omarchy-shell omarchy.power togglePercentage"},
   "trigger.toggle.workspace-layout": {"icon":"󱂬","label":"Workspace Layout","action":"omarchy-hyprland-workspace-layout-toggle"},
+  "trigger.toggle.workspace-fullwidth-repress": {"icon":"󰖯","label":"Workspace Full Width","checked":"! omarchy-toggle-enabled workspace-fullwidth-repress-off","action":"omarchy-toggle-workspace-fullwidth-repress"},
   "trigger.toggle.window-gaps": {"icon":"","label":"Window Gaps","action":"omarchy-hyprland-window-gaps-toggle"},
   "trigger.toggle.one-window-ratio": {"icon":"","label":"1-Window Ratio","action":"omarchy-hyprland-window-single-square-aspect-toggle"},
   "trigger.tests.network-speedtest": {"icon":"󰓅","label":"Network Speed Test","action":"omarchy-shell shell summon omarchy.speedtest"},

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -26,6 +26,8 @@ You close a window on `Super + W` or `Super + Q` (and close all windows on `Ctrl
 
 You can also go full screen with `Super + F` or even just full-width (keeping the top bar) with `Super + Alt + F` or full-screen within a window with `Super + Ctrl + F` (good for YouTube!).
 
+Pressing a workspace key a second time does the same full-width toggle: if you're already on workspace 2, `Super + 2` again flips the focused window between full width and tiled. Turn that off under _Trigger > Toggle > Workspace Full Width_ (or `omarchy toggle workspace fullwidth repress`) if you'd rather the key only switch workspaces.
+
 ### Dwindle vs scrolling layout
 
 Omarchy's default layout is called dwindle. It keeps all the windows you open on a single workspace visible at all time, even if it has to shrink them down.

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -20,7 +20,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + F`                 | Go full screen              |
 | `Super + Alt + F`                 | Go full width              |
 | `Super + Ctrl + F`                 | Go full screen inside window              |
-| `Super + 1/2/3/4`         | Jump to specific workspace     |
+| `Super + 1/2/3/4`         | Jump to specific workspace (press again to toggle full width)     |
 | `Super + Tab` | Jump to next workspace |
 | `Super + Shift + Tab` | Jump to previous workspace |
 | `Super + Ctrl + Tab` | Jump to former workspace |

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -20,10 +20,11 @@ From the terminal, the same switches are `omarchy toggle <thing>`. Run `omarchy 
 | Touchscreen | — | `omarchy toggle touchscreen` |
 | Suspend | — | `omarchy toggle suspend` |
 | Hybrid GPU | — | `omarchy toggle hybrid gpu` |
+| Workspace full width on repress | — | `omarchy toggle workspace fullwidth repress` |
 
 The touchpad, touchscreen, and hybrid GPU switches live under _Trigger > Hardware_ (`Super + Ctrl + H`) rather than under Toggle, since they only show up when you actually have that hardware. The touchpad and touchscreen ones survive a Hyprland reload — the disabled device's name is saved to a small state file that Hyprland reads on startup to disable it again.
 
-The Toggle menu also carries a few things that aren't `omarchy toggle` commands but behave the same: battery percentage in the bar, workspace layout (`Super + L`), window gaps (`Super + Shift + Backspace`), and the 1-window square aspect (`Super + Ctrl + Backspace`).
+The Toggle menu also carries a few things that aren't `omarchy toggle` commands but behave the same: battery percentage in the bar, workspace layout (`Super + L`), window gaps (`Super + Shift + Backspace`), and the 1-window square aspect (`Super + Ctrl + Backspace`). Workspace Full Width is the preference for whether `Super + N` on the workspace you're already on toggles full width (same as `Super + Alt + F`); it's on by default.
 
 Most of these are just a flag file under `~/.local/state/omarchy/toggles/`. If you want to branch on one in a script, `omarchy-toggle-enabled` gives you an exit code instead of making you go looking:
 

--- a/test/shell.d/hyprland-workspace-focus-test.sh
+++ b/test/shell.d/hyprland-workspace-focus-test.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_dir="$tmpdir/bin"
+home_dir="$tmpdir/home"
+log_file="$tmpdir/hyprctl.log"
+mkdir -p "$stub_dir" "$home_dir/.local/state/omarchy/toggles"
+
+cat >"$stub_dir/hyprctl" <<'EOF'
+#!/bin/bash
+
+if [[ $1 == "activeworkspace" && $2 == "-j" ]]; then
+  if [[ -n $HYPRCTL_BROKEN ]]; then
+    printf '{}\n'
+  else
+    printf '{"id":%s}\n' "${HYPR_ACTIVE_WORKSPACE:-2}"
+  fi
+  exit 0
+fi
+
+if [[ $1 == "activewindow" && $2 == "-j" ]]; then
+  printf '{"address":"%s","fullscreen":%s,"fullscreenClient":%s}\n' \
+    "${HYPR_ADDRESS:-0x1}" \
+    "${HYPR_FULLSCREEN:-0}" \
+    "${HYPR_FULLSCREEN_CLIENT:-0}"
+  exit 0
+fi
+
+if [[ $1 == "dispatch" ]]; then
+  printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+  exit 0
+fi
+
+exit 1
+EOF
+chmod +x "$stub_dir/hyprctl"
+
+cat >"$stub_dir/omarchy-toggle-enabled" <<'EOF'
+#!/bin/bash
+[[ -f "$HOME/.local/state/omarchy/toggles/$1" ]]
+EOF
+chmod +x "$stub_dir/omarchy-toggle-enabled"
+
+run_focus() {
+  HOME="$home_dir" HYPRCTL_LOG="$log_file" PATH="$stub_dir:$PATH" \
+    HYPR_ACTIVE_WORKSPACE="${HYPR_ACTIVE_WORKSPACE:-2}" \
+    HYPR_FULLSCREEN="${HYPR_FULLSCREEN:-0}" \
+    "$ROOT/bin/omarchy-hyprland-workspace-focus" "$@"
+}
+
+>"$log_file"
+HYPR_ACTIVE_WORKSPACE=1 run_focus 2
+grep -Fq 'hl.dsp.focus({ workspace = "2" })' "$log_file" ||
+  fail "workspace focus switches when not already there"
+pass "workspace focus switches when not already there"
+
+>"$log_file"
+HYPR_ACTIVE_WORKSPACE=2 HYPR_FULLSCREEN=0 run_focus 2
+grep -Fq 'hl.dsp.window.fullscreen_state({ internal = 1, client = 1 })' "$log_file" ||
+  fail "workspace repress enables full width when already there"
+! grep -Fq 'workspace = "2"' "$log_file" ||
+  fail "workspace repress does not re-dispatch workspace focus"
+pass "workspace repress enables full width when already there"
+
+>"$log_file"
+HYPR_ACTIVE_WORKSPACE=2 HYPR_FULLSCREEN=1 run_focus 2
+grep -Fq 'hl.dsp.window.fullscreen_state({ internal = 0, client = 0 })' "$log_file" ||
+  fail "workspace repress restores tiled when already full width"
+pass "workspace repress restores tiled when already full width"
+
+>"$log_file"
+HYPR_ACTIVE_WORKSPACE=2 HYPR_FULLSCREEN=0 HYPR_ADDRESS=0x0 run_focus 2
+! grep -Fq 'fullscreen_state' "$log_file" ||
+  fail "workspace repress no-ops without a focused window"
+! grep -Fq 'workspace = "2"' "$log_file" ||
+  fail "workspace repress does not re-focus when already there with no window"
+pass "workspace repress no-ops without a focused window"
+
+touch "$home_dir/.local/state/omarchy/toggles/workspace-fullwidth-repress-off"
+>"$log_file"
+HYPR_ACTIVE_WORKSPACE=2 HYPR_FULLSCREEN=0 run_focus 2
+grep -Fq 'hl.dsp.focus({ workspace = "2" })' "$log_file" ||
+  fail "disabled repress always focuses the workspace"
+! grep -Fq 'fullscreen_state' "$log_file" ||
+  fail "disabled repress does not toggle full width"
+pass "disabled repress always focuses the workspace"
+
+if HOME="$home_dir" PATH="$stub_dir:$PATH" \
+  "$ROOT/bin/omarchy-hyprland-workspace-focus" 11 2>/dev/null; then
+  fail "workspace focus rejects workspaces outside 1-10"
+fi
+pass "workspace focus rejects workspaces outside 1-10"
+
+rm -f "$home_dir/.local/state/omarchy/toggles/workspace-fullwidth-repress-off"
+if HOME="$home_dir" PATH="$stub_dir:$PATH" HYPRCTL_LOG="$log_file" \
+  HYPRCTL_BROKEN=1 \
+  "$ROOT/bin/omarchy-hyprland-workspace-focus" 2 2>/dev/null; then
+  fail "workspace focus exits nonzero without a workspace id"
+fi
+pass "workspace focus exits nonzero without a workspace id"
+
+cat >"$stub_dir/omarchy-toggle" <<'EOF'
+#!/bin/bash
+flag="$HOME/.local/state/omarchy/toggles/$1"
+action="${2:-toggle}"
+printf '%s\n' "$*" >>"$TOGGLE_LOG"
+mkdir -p "$(dirname "$flag")"
+case "$action" in
+  on) touch "$flag" ;;
+  off) rm -f "$flag" ;;
+  toggle|"")
+    if [[ -f $flag ]]; then
+      rm -f "$flag"
+    else
+      touch "$flag"
+    fi
+    ;;
+esac
+EOF
+chmod +x "$stub_dir/omarchy-toggle"
+
+cat >"$stub_dir/omarchy-notification-send" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFY_LOG"
+EOF
+chmod +x "$stub_dir/omarchy-notification-send"
+
+toggle_log="$tmpdir/toggle.log"
+notify_log="$tmpdir/notify.log"
+>"$toggle_log"
+>"$notify_log"
+# Feature off writes the off-flag (omarchy-toggle <flag> on).
+HOME="$home_dir" TOGGLE_LOG="$toggle_log" NOTIFY_LOG="$notify_log" PATH="$stub_dir:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-toggle-workspace-fullwidth-repress" off
+grep -Fq 'workspace-fullwidth-repress-off on' "$toggle_log" ||
+  fail "preference off sets the off-flag"
+grep -Fq 'Workspace repress full width disabled' "$notify_log" ||
+  fail "preference toggle announces when disabled"
+pass "preference off sets the off-flag"
+
+>"$toggle_log"
+>"$notify_log"
+# Feature on clears the off-flag.
+HOME="$home_dir" TOGGLE_LOG="$toggle_log" NOTIFY_LOG="$notify_log" PATH="$stub_dir:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-toggle-workspace-fullwidth-repress" on
+grep -Fq 'workspace-fullwidth-repress-off off' "$toggle_log" ||
+  fail "preference on clears the off-flag"
+grep -Fq 'Workspace repress full width enabled' "$notify_log" ||
+  fail "preference toggle announces when enabled"
+pass "preference on clears the off-flag"
+
+grep -Fq 'omarchy-hyprland-workspace-focus' "$ROOT/default/hypr/bindings/tiling.lua" ||
+  fail "tiling bindings route Super+workspace through workspace focus"
+pass "tiling bindings route Super+workspace through workspace focus"
+
+grep -Fq 'omarchy-toggle-workspace-fullwidth-repress' "$ROOT/default/omarchy/omarchy-menu.jsonc" ||
+  fail "toggle menu exposes workspace full width preference"
+pass "toggle menu exposes workspace full width preference"


### PR DESCRIPTION
## Summary
- Pressing `Super + N` while already on workspace N toggles the focused window between full width (same as `Super + Alt + F`) and tiled.
- Preference lives under **Trigger > Toggle > Workspace Full Width** (on by default); `omarchy toggle workspace fullwidth repress [on|off]` flips the same switch.
- Docs updated in navigation, hotkeys, and toggles manuals; shell tests cover switch / repress / preference-off / empty-window cases.

## Why Trigger > Toggle (not Setup)
Setup already covers monitors, keybindings, input, defaults, plugins, and security — there isn't a general “behavior preferences” section there. Window/workspace behavior switches already live under **Trigger > Toggle** (workspace layout, gaps, 1-window ratio), so this preference joins that list with a ✓ when enabled.

## Behavior
| Action | Result |
| --- | --- |
| `Super + 2` on workspace 1 | Switch to workspace 2 |
| `Super + 2` again on workspace 2 | Toggle focused window full width ↔ tiled |
| Preference off | `Super + N` only switches workspaces |

## Test plan
- [x] `./test/shell.d/hyprland-workspace-focus-test.sh`
- [x] Live: `omarchy-hyprland-workspace-focus` on current workspace toggles fullscreen `0 ↔ 1` and restores; preference-off leaves state unchanged; switching away and back does not toggle
- [ ] After install / `omarchy-dev-link` + reload: `Super + 2` twice on workspace 2 toggles full width in the running session
- [ ] Menu: **Trigger > Toggle > Workspace Full Width** shows ✓ when on; selecting it disables repress and notifies
- [ ] `omarchy toggle workspace fullwidth repress off` then `Super + N` on current workspace no longer toggles


Made with [Cursor](https://cursor.com)