### PR TITLE
fix(hardware): prevent ~130s sleep wake stall on MacBook Pro 2016-2017

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -37,6 +37,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-thunderbolt.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 

--- a/install/hardware/apple/fix-suspend-thunderbolt.sh
+++ b/install/hardware/apple/fix-suspend-thunderbolt.sh
@@ -1,0 +1,49 @@
+# Fix Thunderbolt/xHCI sleep stall on MacBook Pro models (2016-2017)
+# In ACPI S3 sleep, Apple firmware cuts power to the Alpine Ridge controller (8086:15d2/15d4).
+# Removing the unpowered xHCI controller before sleep prevents xhci_hcd from freezing for ~130s on wake.
+macbook_model=$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)
+
+if [[ $macbook_model =~ MacBookPro13,[123]|MacBookPro14,[123] ]]; then
+  echo "Detected MacBook Pro with Alpine Ridge Thunderbolt ($macbook_model)"
+  echo "Applying Thunderbolt and display sleep fixes..."
+
+  sudo mkdir -p /etc/systemd/system-sleep
+  sudo tee /etc/systemd/system-sleep/omarchy-macbook-sleep.sh >/dev/null <<'EOF'
+#!/bin/bash
+case "$1/$2" in
+  pre/*)
+    for dev in /sys/bus/pci/devices/*; do
+      if [[ -f "$dev/vendor" && -f "$dev/device" ]]; then
+        if [[ $(cat "$dev/vendor" 2>/dev/null) == "0x8086" && $(cat "$dev/device" 2>/dev/null) == "0x15d4" ]]; then
+          echo 1 > "$dev/remove" 2>/dev/null || true
+        fi
+      fi
+    done
+    [[ -d /sys/bus/pci/devices/0000:07:00.0 ]] && echo 1 > /sys/bus/pci/devices/0000:07:00.0/remove 2>/dev/null || true
+
+    [[ -d /sys/module/thunderbolt ]] && modprobe -r thunderbolt 2>/dev/null || true
+    [[ -d /sys/module/facetimehd ]] && modprobe -r facetimehd 2>/dev/null || true
+    ;;
+
+  post/*)
+    for user_dir in /run/user/*; do
+      if [[ -d "$user_dir/hypr" ]]; then
+        uid=$(basename "$user_dir")
+        uname=$(id -nu "$uid" 2>/dev/null)
+        sig=$(ls -td "$user_dir/hypr/"* 2>/dev/null | head -1 | xargs basename 2>/dev/null)
+        if [[ -n "$uname" && -n "$sig" ]]; then
+          ( runuser -u "$uname" -- env XDG_RUNTIME_DIR="$user_dir" HYPRLAND_INSTANCE_SIGNATURE="$sig" hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })' >/dev/null 2>&1 || true ) &
+        fi
+      fi
+    done
+
+    [[ -d /sys/bus/pci/devices/0000:00:1c.4 ]] && ( sleep 2 && echo 1 > /sys/bus/pci/devices/0000:00:1c.4/rescan ) >/dev/null 2>&1 &
+    ;;
+esac
+EOF
+
+  sudo chmod 755 /etc/systemd/system-sleep/omarchy-macbook-sleep.sh
+
+  sudo mkdir -p /etc/modprobe.d
+  echo "blacklist thunderbolt" | sudo tee /etc/modprobe.d/disable-thunderbolt.conf >/dev/null
+fi

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -35,7 +35,7 @@ It is necessary to disable Apple's Secure Boot in order to boot the bootable USB
 3. Select the orange EFI Boot device
 4. Proceed with the [install as normal](02-getting-started.md)
 
-The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, and an NVMe suspend fix for those same models.
+The installer detects Mac hardware and applies the needed fixes automatically: Broadcom Wi-Fi drivers and firmware, the SPI keyboard driver on the MacBook models that need it, an NVMe suspend fix, and an Alpine Ridge Thunderbolt sleep hook to prevent wake stalls.
 
 ### Known Limitations
 


### PR DESCRIPTION
### Summary

Fixes a ~130-second system freeze on wake from ACPI S3 (`deep`) sleep on MacBook Pro 2016–2017 models (MacBookPro13,x and MacBookPro14,x).

### Root Cause
On MacBook Pro 2016–2017 models equipped with Intel Alpine Ridge Thunderbolt 3 controllers (`8086:15d2` NHI / `8086:15d4` integrated xHCI), Apple firmware cuts power to the controller during S3 sleep. On wake, `xhci_hcd` polls the unpowered PCIe device (`0000:07:00.0`), hitting exponential backoff timeouts (`1023ms` -> `2047ms` -> ... -> `65535ms`) totalling ~130 seconds before `pciehp` drops the dead device.

### Solution
1. Adds `install/hardware/apple/fix-suspend-thunderbolt.sh` to remove unpowered `8086:15d4` PCIe devices prior to S3 sleep.
2. Unloads `thunderbolt` and `facetimehd` before sleep to prevent kernel call traces and unneeded sensor power-on.
3. Automatically dispatches `hl.dsp.dpms({ action = "enable" })` upon resume across active Hyprland user sessions so the display backlight lights up immediately.
4. Rescans the Thunderbolt root port (`0000:00:1c.4`) after resume.
5. Updates `manual/44-mac-support.md` with documentation.