### PR TITLE
Say why the console is empty, and let it run something other than an agent

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -40,10 +40,33 @@ agent=$(omarchy-default-agent)
 # Omarchy ships without a default, so there is nothing to launch until one is
 # picked. --pick offers the choice instead of the error, which is what the
 # keybinding wants: a keypress that opens nothing explains nothing.
+#
+# Saying so on stderr only reaches a caller that has a terminal to read it in.
+# The Quake console does not: it seeds itself by spawning this from Hyprland, so
+# the message goes nowhere and Super + S dims the screen over an empty console.
+# The device node is there whether or not a terminal is behind it, so opening it
+# is the only test that means anything — the same one omarchy-show-done makes.
 if [[ -z $agent ]]; then
-  [[ $pick == "true" ]] && exec omarchy-menu summon setup.default.agent
-  echo "Choose default agent with: omarchy default agent <name>" >&2
-  exit 1
+  if [[ $pick == "true" ]]; then
+    exec omarchy-menu summon setup.default.agent
+  elif : 2>/dev/null <>/dev/tty; then
+    echo "Choose default agent with: omarchy default agent <name>" >&2
+    exit 1
+  else
+    notice=$(
+      cat <<'NOTICE'
+No default coding agent set, so there is nothing to run here yet.
+
+  Pick one from the menu:  SUPER + SHIFT + CTRL + A
+  Or from a terminal:      omarchy default agent <name>
+NOTICE
+    )
+
+    # Launched the way an agent would be, so the notice lands where the agent
+    # was meant to: pinned into the console by the exec rule that seeded it.
+    exec omarchy-launch-tui --app-id=org.omarchy.agent \
+      bash -c 'omarchy-show-logo; printf "%s\n" "$1"; omarchy-show-done' omarchy-agent "$notice"
+  fi
 fi
 
 if omarchy-cmd-missing "$agent"; then

--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -59,6 +59,10 @@ No default coding agent set, so there is nothing to run here yet.
 
   Pick one from the menu:  SUPER + SHIFT + CTRL + A
   Or from a terminal:      omarchy default agent <name>
+
+The console can run something else instead:
+
+  omarchy default console terminal
 NOTICE
     )
 

--- a/bin/omarchy-default-console
+++ b/bin/omarchy-default-console
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# omarchy:summary=Set what the Quake console runs
+# omarchy:args=[agent|terminal|<command>...]
+# omarchy:examples=omarchy default console | omarchy default console terminal | omarchy default console omarchy-launch-tui btop
+
+console_file="$HOME/.config/omarchy/defaults/console"
+
+if (($# == 0)); then
+  if [[ -f $console_file ]]; then
+    read -r console <"$console_file"
+  fi
+
+  # Silent when unset, the way the default agent is: nothing has been chosen
+  # over the agent the console falls back to, so there is nothing to report.
+  [[ -n ${console:-} ]] && echo "$console"
+  exit 0
+fi
+
+# Two shorthands for what the console is usually pointed at, and anything else
+# is taken as the command to run. A TUI needs a terminal around it to be seen —
+# `omarchy default console omarchy-launch-tui btop` — while a graphical app is
+# its own window and can be named on its own.
+case "$*" in
+agent) console="omarchy-agent"; name="the coding agent" ;;
+terminal) console="omarchy-launch-terminal"; name="a terminal" ;;
+*) console="$*"; name="$*" ;;
+esac
+
+mkdir -p "$(dirname "$console_file")"
+printf '%s\n' "$console" >"$console_file"
+
+omarchy-notification-send "The console now runs $name"

--- a/bin/omarchy-launch-console
+++ b/bin/omarchy-launch-console
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# omarchy:summary=Run what the Quake console is set to
+# omarchy:hidden=true
+
+# The console seeds itself with this from default/hypr/qconsole.lua. It is a
+# workspace like any other, so what drops into it is a preference: an agent is
+# only where Omarchy starts. See `omarchy default console`.
+console=$(omarchy-default-console)
+
+if [[ -z $console ]]; then
+  exec omarchy-agent
+else
+  # A stored command line, so let the shell split it the way omarchy-launch-or-focus
+  # does with the one it is handed.
+  eval exec setsid $console
+fi

--- a/default/hypr/qconsole.lua
+++ b/default/hypr/qconsole.lua
@@ -9,9 +9,9 @@ local share = 0.5
 -- at boot, so nothing is running until it is wanted. The exec rule has to pin
 -- the workspace itself: Hyprland only tags a spawn with the workspace it came
 -- from while misc.initial_workspace_tracking is on, and looknfeel turns it off.
--- Omarchy ships without a default agent, and omarchy-agent exits without
--- opening anything when none is set, so until one is picked this just opens an
--- empty console.
+-- Omarchy ships without a default agent, and omarchy-agent has no terminal to
+-- report that in when Hyprland spawns it, so until one is picked it fills the
+-- console with a notice on how to choose one rather than leaving it empty.
 local seed = "[workspace special:scratchpad silent] omarchy-agent"
 
 -- Dimming only applies while a special workspace is open, so the console gets

--- a/default/hypr/qconsole.lua
+++ b/default/hypr/qconsole.lua
@@ -5,14 +5,14 @@
 -- How much of the usable screen the console covers, measured from the top.
 local share = 0.5
 
--- Seed the console with the default agent the first time it opens, rather than
--- at boot, so nothing is running until it is wanted. The exec rule has to pin
--- the workspace itself: Hyprland only tags a spawn with the workspace it came
--- from while misc.initial_workspace_tracking is on, and looknfeel turns it off.
--- Omarchy ships without a default agent, and omarchy-agent has no terminal to
--- report that in when Hyprland spawns it, so until one is picked it fills the
--- console with a notice on how to choose one rather than leaving it empty.
-local seed = "[workspace special:scratchpad silent] omarchy-agent"
+-- Seed the console the first time it opens, rather than at boot, so nothing is
+-- running until it is wanted. The exec rule has to pin the workspace itself:
+-- Hyprland only tags a spawn with the workspace it came from while
+-- misc.initial_workspace_tracking is on, and looknfeel turns it off. What drops
+-- in is `omarchy default console` — the coding agent unless it is pointed at a
+-- terminal or anything else — and with no agent picked yet that is a notice on
+-- how to choose one, rather than an empty console.
+local seed = "[workspace special:scratchpad silent] omarchy-launch-console"
 
 -- Dimming only applies while a special workspace is open, so the console gets
 -- its separation from the workspace underneath without costing anything the

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -66,6 +66,8 @@ Finally, there's a special scratchpad workspace that drops down over whatever wo
 
 It works especially well for a terminal running an agent, or for controls you want to interact with quickly without leaving the current workspace. To move a window off the scratchpad, send it directly to another workspace with something like `Super + Shift + 1`.
 
+The first time you open it, Omarchy drops your default coding agent into it. Run `omarchy default console terminal` for a plain terminal there instead, or name any command of your own — `omarchy default console omarchy-launch-tui btop` for a TUI, wrapper and all — and `omarchy default console agent` hands it back to the agent.
+
 ### It takes some getting used to!
 
 It takes a little while to get used to navigating your desktop like this, but once you do, it'll be hard to go back to a traditional mouse-driven desktop experience!

--- a/test/shell.d/console-test.sh
+++ b/test/shell.d/console-test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+console_file="$test_home/.config/omarchy/defaults/console"
+run_log="$test_tmp/run"
+notification_history="$test_tmp/notification-history"
+mkdir -p "$mock_bin" "$test_home"
+
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\0' "$@" >>"$OMARCHY_TEST_NOTIFICATION_HISTORY"
+SH
+
+# Whatever the console is pointed at reports itself rather than opening a window.
+for command in omarchy-agent omarchy-launch-terminal omarchy-launch-tui; do
+  cat >"$mock_bin/$command" <<SH
+#!/bin/bash
+printf '%s\0' $command "\$@" >"\$OMARCHY_TEST_CONSOLE_RUN_LOG"
+SH
+done
+
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+chmod +x "$mock_bin"/*
+
+export HOME="$test_home"
+export PATH="$mock_bin:$ROOT/bin:$PATH"
+export OMARCHY_TEST_NOTIFICATION_HISTORY="$notification_history"
+export OMARCHY_TEST_CONSOLE_RUN_LOG="$run_log"
+
+ran() {
+  mapfile -d '' -t run_args <"$run_log"
+  printf '%s' "${run_args[*]}"
+}
+
+[[ -z $(omarchy-default-console) ]] || fail "the console is unset until it is pointed somewhere"
+pass "the console is unset until it is pointed somewhere"
+
+# Omarchy ships the console as the agent's home, so an unset console is still
+# one: the setting is what to run *instead*.
+: >"$run_log"
+omarchy-launch-console
+[[ $(ran) == "omarchy-agent" ]] || fail "an unset console runs the coding agent" "$(ran)"
+[[ ! -s $notification_history ]] || fail "an unset console reports nothing"
+pass "an unset console runs the coding agent"
+
+omarchy-default-console terminal
+[[ $(omarchy-default-console) == "omarchy-launch-terminal" ]] ||
+  fail "terminal is shorthand for the terminal launcher" "$(omarchy-default-console)"
+: >"$run_log"
+omarchy-launch-console
+[[ $(ran) == "omarchy-launch-terminal" ]] || fail "a console set to a terminal runs one" "$(ran)"
+pass "a console set to a terminal runs one"
+
+mapfile -d '' -t notified <"$notification_history"
+[[ ${notified[*]} == *"a terminal"* ]] || fail "choosing what the console runs says so" "${notified[*]}"
+pass "choosing what the console runs says so"
+
+# Anything else is the command, arguments and all — a TUI needs the terminal
+# wrapper named around it to be seen, and that is the caller's to pass.
+omarchy-default-console omarchy-launch-tui btop
+[[ $(omarchy-default-console) == "omarchy-launch-tui btop" ]] ||
+  fail "the console takes any command" "$(omarchy-default-console)"
+: >"$run_log"
+omarchy-launch-console
+[[ $(ran) == "omarchy-launch-tui btop" ]] || fail "the console runs the command it was given" "$(ran)"
+pass "the console runs the command it was given"
+
+omarchy-default-console agent
+[[ $(omarchy-default-console) == "omarchy-agent" ]] ||
+  fail "agent is shorthand for the coding agent" "$(omarchy-default-console)"
+: >"$run_log"
+omarchy-launch-console
+[[ $(ran) == "omarchy-agent" ]] || fail "a console handed back to the agent runs it" "$(ran)"
+pass "a console handed back to the agent runs it"
+
+[[ -f $console_file ]] || fail "the console selection lives in Omarchy user config"
+pass "the console selection lives in Omarchy user config"
+
+grep -Fq "omarchy-launch-console" "$ROOT/default/hypr/qconsole.lua" ||
+  fail "the Quake console seeds itself with the launcher"
+pass "the Quake console seeds itself with the launcher"

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -250,14 +250,37 @@ pass "Remove Preinstalls deletes every optional agent lazy stub"
 [[ -z $(omarchy-default-agent) ]] || fail "default agent is unset until one is chosen"
 pass "default agent is unset until one is chosen"
 
-: >"$launch_log"
-if omarchy-agent >"$test_tmp/no-agent-output" 2>&1; then
-  fail "agent launcher refuses to launch without a default"
+# Whether a terminal is there to read stderr in decides how the missing default
+# gets reported. A pty is the only way to test the terminal case from a suite
+# that may itself be running without one, the same guard plugin-add-test makes.
+if script -qec true /dev/null >/dev/null 2>&1; then
+  : >"$launch_log"
+  status=0
+  script -qec omarchy-agent /dev/null >"$test_tmp/no-agent-output" 2>&1 || status=$?
+  ((status != 0)) || fail "agent launcher refuses to launch without a default"
+  grep -Fq "Choose default agent with" "$test_tmp/no-agent-output" ||
+    fail "agent launcher explains that no default is set"
+  [[ ! -s $launch_log ]] || fail "agent launcher starts nothing without a default"
+  pass "agent launcher refuses to launch without a default"
+else
+  pass "script -qec unavailable; skipping the terminal case for a missing default"
 fi
-grep -Fq "Choose default agent with" "$test_tmp/no-agent-output" ||
-  fail "agent launcher explains that no default is set"
-[[ ! -s $launch_log ]] || fail "agent launcher starts nothing without a default"
-pass "agent launcher refuses to launch without a default"
+
+# The Quake console seeds itself by spawning the launcher from Hyprland, where
+# nothing reads stderr and an exit leaves a dimmed, empty console. setsid drops
+# the controlling terminal the way that spawn does, so the notice has to be a
+# window instead. It opens the way an agent would, to land where one would have.
+: >"$launch_log"
+setsid --wait omarchy-agent >"$test_tmp/no-terminal-output" 2>&1 ||
+  fail "agent launcher opens a notice when no terminal can read the error"
+mapfile -d '' -t notice_args <"$launch_log"
+[[ ${notice_args[0]} == "--app-id=org.omarchy.agent" ]] ||
+  fail "agent launcher opens the notice as the agent window"
+[[ ${notice_args[*]} == *"No default coding agent set"* ]] ||
+  fail "agent launcher notice says that no default is set"
+[[ ${notice_args[*]} == *"omarchy default agent <name>"* ]] ||
+  fail "agent launcher notice says how to choose one"
+pass "agent launcher opens a notice when no terminal can read the error"
 
 # The keybinding uses --pick, where an error on stderr nobody sees would make
 # the keypress look broken. It offers the choice instead.

--- a/test/shell.d/hyprland-qconsole-test.sh
+++ b/test/shell.d/hyprland-qconsole-test.sh
@@ -32,7 +32,7 @@ end
 -- Config loads before the outputs are up, so the first pass has no monitor to
 -- read. It still has to leave a rule behind, or the console would open unseeded.
 assert(#rules > 0, "console is ruled even before a monitor can be read")
-assert(current().on_created_empty:find("omarchy%-agent"), "console is seeded with the default agent")
+assert(current().on_created_empty:find("omarchy%-launch%-console"), "console is seeded with whatever it is set to run")
 assert(current().on_created_empty:find("^%[workspace special:scratchpad silent%]"),
   "the seed is pinned to the console rather than trusting the spawn to inherit it")
 assert(current().workspace == "special:scratchpad")
@@ -57,7 +57,7 @@ assert(rescale(1440, 1, 0) == 720, "a monitor with nothing reserved")
 local final = current()
 assert(final.gaps_out.top == 0 and final.gaps_out.left == 0 and final.gaps_out.right == 0,
   "the console is flush to the top and sides")
-assert(final.on_created_empty:find("omarchy%-agent"), "refitting keeps the console seeded")
+assert(final.on_created_empty:find("omarchy%-launch%-console"), "refitting keeps the console seeded")
 assert(final.no_border == true, "the console drops the active window border")
 
 -- A monitor that cannot be read must not wipe the last good rule.


### PR DESCRIPTION
Pressing `Super + S` on a fresh install dims the screen and shows nothing.

The Quake console seeds itself with `on_created_empty` → `omarchy-agent`, and Omarchy ships without a default agent, so the launcher writes `Choose default agent with: omarchy default agent <name>` to a stderr that Hyprland spawned it with no terminal to read. The console opens empty, `dim_special` dims everything behind it, and nothing says why — the same "a keypress that opens nothing explains nothing" the `--pick` comment already names, one path over.

Two commits, and the second is what the first one's notice points at.

### Say why the console is empty

`--pick` does not fix this on its own: summoning the menu from `on_created_empty` does open it, but the special workspace taking focus dismisses it immediately. A window is what survives, so the missing default gets reported in one.

Which report to give depends on who can read it. A terminal gets the stderr line it always got; a spawn with no terminal gets a window instead, opened as `org.omarchy.agent` through `omarchy-launch-tui` so the seed's exec rule pins it into the console the way it would an agent:

```
No default coding agent set, so there is nothing to run here yet.

  Pick one from the menu:  SUPER + SHIFT + CTRL + A
  Or from a terminal:      omarchy default agent <name>

The console can run something else instead:

  omarchy default console terminal
```

The terminal test is the one `omarchy-show-done` already makes: the `/dev/tty` node is there whether or not a terminal is behind it, so opening it is the only test that means anything.

`omarchy-agent-crash` reaches the launcher the same way and gets the same window instead of failing silently.

### Let the console run something other than an agent

The console is a workspace like any other, but its seed named the agent, so putting a terminal there meant editing an Omarchy default that the next update takes back. It now seeds `omarchy-launch-console`, which runs whatever `omarchy default console` holds:

```bash
omarchy default console                          # what it runs now
omarchy default console terminal                 # a plain terminal
omarchy default console omarchy-launch-tui btop  # any command, wrapper and all
omarchy default console agent                    # back to the coding agent
```

Unset keeps today's behaviour exactly: the console runs the default agent, and the notice above is what an unset agent looks like. The stored value is a command line, split by the shell the way `omarchy-launch-or-focus` splits the one it is handed — a TUI names its terminal wrapper, a graphical app stands on its own.

`manual/04-navigation.md` documents it beside the scratchpad section.

### Verification

`./test/all` — no new failures (10 pre-existing ones in this environment are unrelated: browser policy dirs, snapper, plymouth, unowned system paths, and friends).

`default-agent-test.sh` covers both reports: the terminal case on a pty via `script -qec`, guarded with the same availability skip `plugin-add-test.sh` uses, and the no-terminal case under `setsid --wait`, asserting the notice opens as the agent window and says how to choose. A new `console-test.sh` covers the setting, both shorthands, an arbitrary command with arguments, and the unset fallback to the agent. `hyprland-qconsole-test.sh` follows the seed.

Verified end to end on a fresh 4.0.2 install in a VM, dev-linked to this branch: with nothing set, `Super + S` fills the console with the notice instead of opening it empty; `omarchy default console terminal` drops a shell in there instead. Before/after captures attached below.

<img width="1280" height="800" alt="01-before-empty-console" src="https://github.com/user-attachments/assets/85d6251a-ffea-48b9-9d83-ccc0907f930c" />
<img width="1280" height="800" alt="02-after-notice" src="https://github.com/user-attachments/assets/9ea21014-bd99-4c6f-9131-6c468021d2cb" />
<img width="1280" height="800" alt="03-notice-with-console-option" src="https://github.com/user-attachments/assets/4155d985-206f-4385-9605-15d7bb7eca56" />
<img width="1280" height="800" alt="04-console-as-terminal" src="https://github.com/user-attachments/assets/a3572483-f8ab-4c8e-b8eb-e90018eaff20" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
