### PR TITLE
Show useful app details in menu search

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -628,7 +628,7 @@ Item {
         if (!root.isDescendantOf(entry.id, active)) continue
         if (!root.matchesQuery(entry, query)) continue
 
-        var detail = root.parentPathFor(entry.id)
+        var detail = MenuModel.searchDetail(root.items, entry)
         var row = root.displayRow(entry, detail, root.searchScore(entry, query))
         if (entry.parent === active) currentRows.push(row)
         else drilldownRows.push(row)

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -228,6 +228,16 @@ function parentPathFor(items, id) {
   return pathFor(items, entry.parent)
 }
 
+function searchDetail(items, entry) {
+  var description = String((entry && entry.description) || "").trim()
+  var label = String((entry && entry.label) || "").trim()
+
+  if (entry && entry.kind === "app" && description && description.toLowerCase() !== label.toLowerCase())
+    return description
+
+  return parentPathFor(items, entry ? entry.id : "")
+}
+
 function isDescendantOf(items, id, ancestorId) {
   if (ancestorId === "root") return id !== "root"
 
@@ -507,6 +517,7 @@ if (typeof module !== "undefined") {
     depthFor: depthFor,
     pathFor: pathFor,
     parentPathFor: parentPathFor,
+    searchDetail: searchDetail,
     isDescendantOf: isDescendantOf,
     childCount: childCount,
     isVisible: isVisible,

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -61,6 +61,16 @@ assert(merged.items.root, 'menu injects root when merging sources')
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')
 assertEqual(menu.parentPathFor(merged.items, 'style.theme'), 'Style', 'menu builds parent paths')
+const appSearchItems = {
+  apps: { id: 'apps', parent: 'root', kind: 'menu', label: 'Apps' },
+  'apps.contacts': { id: 'apps.contacts', parent: 'apps', kind: 'app', label: 'Google Contacts', description: 'Address Book' },
+  'apps.unnamed': { id: 'apps.unnamed', parent: 'apps', kind: 'app', label: 'Aether', description: '' },
+  'apps.repeated': { id: 'apps.repeated', parent: 'apps', kind: 'app', label: 'Calculator', description: 'Calculator' }
+}
+assertEqual(menu.searchDetail(appSearchItems, appSearchItems['apps.contacts']), 'Address Book', 'app search uses a distinct GenericName as its detail')
+assertEqual(menu.searchDetail(appSearchItems, appSearchItems['apps.unnamed']), 'Apps', 'app search falls back to its parent path without GenericName')
+assertEqual(menu.searchDetail(appSearchItems, appSearchItems['apps.repeated']), 'Apps', 'app search avoids repeating the application name')
+assertEqual(menu.searchDetail(merged.items, merged.items['style.theme']), 'Style', 'non-app search keeps its parent path')
 assert(menu.isDescendantOf(merged.items, 'style.theme', 'style'), 'menu detects descendants')
 assertEqual(menu.childCount(merged.items, merged.itemOrder, 'style'), 1, 'menu counts children')
 assertEqual(menu.labelFor({ id: 'style.theme', label: 'Theme', checked: 'cmd' }, { 'style.theme': true }), 'Theme ✓', 'menu appends checked marker')


### PR DESCRIPTION
## Why

Application search results currently repeat the same `Apps` subtitle even when a desktop entry provides a more useful `GenericName`. Omarchy already reads this standard, localized field and includes it in app search, but replaces it with the parent path when rendering results.

Using the application type helps distinguish similarly named results and makes existing desktop-entry metadata visible without adding configuration or an Omarchy-specific field.

## Fix

Show an application's `GenericName` as its search detail when it is present and differs from `Name`. Keep the existing parent path when the field is missing or redundant, and leave non-application results unchanged.

Checked with `bash test/shell.d/menu-test.sh` and `bash test/shell.d/app-search-test.sh`.