### PR TITLE
Let the session see Flatpak's exported desktop entries

### DIFF
--- a/default/uwsm/env.d/10-omarchy
+++ b/default/uwsm/env.d/10-omarchy
@@ -3,6 +3,14 @@
 # UWSM doesn't source /etc/profile.d, so pull the env bootstrap in directly.
 [ -r /usr/share/omarchy/default/bash/env-bootstrap ] && . /usr/share/omarchy/default/bash/env-bootstrap
 
+# The same gap costs the launcher its Flatpak apps: profile.d/flatpak.sh is what
+# prepends Flatpak's export dirs to XDG_DATA_DIRS, and the app list scans that
+# variable as the shell process sees it. Source Flatpak's own hook rather than
+# hardcoding paths, so extra installations from `flatpak --installations` are
+# covered too; it no-ops when Flatpak is not on PATH.
+# OMARCHY_FLATPAK_PROFILE is a test seam.
+[ -r "${OMARCHY_FLATPAK_PROFILE:-/etc/profile.d/flatpak.sh}" ] && . "${OMARCHY_FLATPAK_PROFILE:-/etc/profile.d/flatpak.sh}"
+
 # Omarchy session defaults. Users can override these in ~/.config/uwsm/default
 # or, preferably, ~/.config/uwsm/env.d/*.
 if [ -f "${OMARCHY_PATH%/}/default/uwsm/default" ]; then

--- a/test/shell.d/flatpak-env-test.sh
+++ b/test/shell.d/flatpak-env-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+uwsm_env="$ROOT/default/uwsm/env.d/10-omarchy"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Stands in for /etc/profile.d/flatpak.sh: prepend the export dirs of every
+# installation, skip dirs already on XDG_DATA_DIRS, and do nothing at all when
+# Flatpak is not on PATH. Same contract as the real hook, without needing
+# Flatpak installed on the machine running the tests.
+cat >"$tmp/flatpak.sh" <<'PROFILE'
+if command -v flatpak >/dev/null; then
+  for share_path in "${XDG_DATA_HOME:-$HOME/.local/share}/flatpak/exports/share" /var/lib/flatpak/exports/share; do
+    case ":$XDG_DATA_DIRS:" in
+    *":$share_path:"*) ;;
+    *) XDG_DATA_DIRS="$share_path:$XDG_DATA_DIRS" ;;
+    esac
+  done
+  export XDG_DATA_DIRS
+fi
+PROFILE
+
+mkdir -p "$tmp/bin" "$tmp/empty"
+printf '#!/bin/sh\nexit 0\n' >"$tmp/bin/flatpak"
+chmod +x "$tmp/bin/flatpak"
+
+session_data_dirs() {
+  local profile="$1" path_dir="$2"
+
+  HOME=/home/test \
+    OMARCHY_PATH="$ROOT" \
+    XDG_DATA_HOME=/home/test/.local/share \
+    XDG_DATA_DIRS=/usr/local/share:/usr/share \
+    OMARCHY_FLATPAK_PROFILE="$profile" \
+    bash -c 'PATH="$2:$ROOT/bin"; source "$1"; printf "%s" "$XDG_DATA_DIRS"' bash "$uwsm_env" "$path_dir"
+}
+
+expected="/var/lib/flatpak/exports/share:/home/test/.local/share/flatpak/exports/share:/usr/local/share:/usr/share"
+
+# The whole point: the session the launcher runs in can see Flatpak's exports.
+actual=$(session_data_dirs "$tmp/flatpak.sh" "$tmp/bin")
+[[ $actual == "$expected" ]] ||
+  fail "session env picks up the Flatpak export dirs" "actual: $actual"
+pass "session env picks up the Flatpak export dirs"
+
+# Sourcing twice must not stack duplicates onto XDG_DATA_DIRS.
+actual=$(HOME=/home/test OMARCHY_PATH="$ROOT" XDG_DATA_HOME=/home/test/.local/share \
+  XDG_DATA_DIRS=/usr/local/share:/usr/share OMARCHY_FLATPAK_PROFILE="$tmp/flatpak.sh" \
+  bash -c 'PATH="$2:$ROOT/bin"; source "$1"; source "$1"; printf "%s" "$XDG_DATA_DIRS"' bash "$uwsm_env" "$tmp/bin")
+[[ $actual == "$expected" ]] ||
+  fail "session env stays idempotent across reloads" "actual: $actual"
+pass "session env stays idempotent across reloads"
+
+# A machine without Flatpak keeps the stock search path.
+actual=$(session_data_dirs "$tmp/flatpak.sh" "$tmp/empty")
+[[ $actual == "/usr/local/share:/usr/share" ]] ||
+  fail "session env is unchanged when Flatpak is not installed" "actual: $actual"
+pass "session env is unchanged when Flatpak is not installed"
+
+# And one without the hook file at all does not fail the session env.
+actual=$(session_data_dirs "$tmp/absent.sh" "$tmp/bin")
+[[ $actual == "/usr/local/share:/usr/share" ]] ||
+  fail "session env is unchanged when the Flatpak hook is absent" "actual: $actual"
+pass "session env is unchanged when the Flatpak hook is absent"


### PR DESCRIPTION
Fixes #8650.

## The problem

Flatpak apps never show up in the Omarchy launcher. The app list (`shell/services/AppLibrary.qml` → Quickshell `DesktopEntries`) scans `XDG_DATA_DIRS` as the shell process sees it, and the uwsm-composed session has only the stock pair:

```
$ tr '\0' '\n' </proc/$(pgrep -o quickshell)/environ | grep XDG_DATA_DIRS
XDG_DATA_DIRS=/usr/local/share:/usr/share

$ bash -lc 'echo $XDG_DATA_DIRS'
/home/me/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share
```

The difference is `/etc/profile.d/flatpak.sh`, which the graphical session never sources — the same gap the file already works around one line earlier for `default/bash/env-bootstrap`. So `/var/lib/flatpak/exports/share/applications/*.desktop` and the per-user equivalent are simply never scanned.

## The fix

Source Flatpak's own profile hook from `default/uwsm/env.d/10-omarchy`, right after the env bootstrap that exists for the identical reason.

Sourcing the hook rather than hardcoding the two well-known paths is deliberate: the hook enumerates `flatpak --installations`, so extra installations configured in `/etc/flatpak/installations.d` are covered, and the dir list stays correct if Flatpak ever changes it. It self-skips when `flatpak` is not on `PATH`, and the file itself ships with the `flatpak` package, so a machine without Flatpak reads one `[ -r ... ]` test and moves on.

Cost when Flatpak *is* installed: the hook shells out once, measured at **235 ms** on this machine (`time bash -c '. /etc/profile.d/flatpak.sh'`), paid once at session start by users who chose to install Flatpak. Hardcoding the two paths avoids that subprocess but loses custom installations; happy to switch if you'd rather not pay it.

`OMARCHY_FLATPAK_PROFILE` exists purely as a test seam.

## Scope

This is the session-environment half of #8650 only. It does not add Flatpak to Omarchy, install it, or put anything Flatpak-related in the menu — #870 settled that, and nothing here changes it. It only stops the launcher from hiding apps a user already installed themselves.

The second failure mode reported in #8650 (an entry still missing until `omarchy restart shell`, with the search paths already correct) is a separate live-refresh question and is untouched here.

@lde-alen prototyped this same approach in #8652 and then closed it; this is an independent take with the idempotency case covered and the measurement above.

## Tests

New `test/shell.d/flatpak-env-test.sh`, with a stub in the shape of `/etc/profile.d/flatpak.sh`:

```
ok - session env picks up the Flatpak export dirs
ok - session env stays idempotent across reloads
ok - session env is unchanged when Flatpak is not installed
ok - session env is unchanged when the Flatpak hook is absent
```

Against the real hook on a Flatpak-enabled machine:

```
$ env -i HOME=$HOME PATH=/usr/bin:/usr/share/omarchy/bin OMARCHY_PATH=/usr/share/omarchy \
    XDG_DATA_DIRS=/usr/local/share:/usr/share \
    bash -c '. default/uwsm/env.d/10-omarchy; echo "$XDG_DATA_DIRS"'
/home/alfkonee/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share
```

`./test/cli` — all green. `./test/shell` — the failures left are pre-existing on this machine and reproduce identically on a clean `quattro` worktree: `config-test`, `snapper-test`, `unowned-system-paths-test` (no `omarchy-pkgs` sibling checkout), `launch-about-test`, `screenshot-sanity-test` (live-session/graphical). `bar-widget-contract-test` flaked only while two suites ran concurrently and passes on its own.

Omarchy 4.0.2-1, quickshell 0.3.1-1, Hyprland session via uwsm.
