### PR TITLE
Persist apple-gmux panel brightness across reboots

### DIFF
--- a/bin/omarchy-hw-apple-gmux
+++ b/bin/omarchy-hw-apple-gmux
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# omarchy:summary=Detect the old IO-port apple-gmux panel backlight
+# omarchy:hidden=true
+
+# Pre-T2 dual-GPU Macs register gmux_backlight on PNP APP000b. T2 Macs also
+# expose that HID, but apple-gmux does not bind there (no IORESOURCE_IO) and
+# never creates this class device — so the sysfs node is the discriminator,
+# not the PNP id. Observed on MacBookPro14,3.
+[[ -e ${OMARCHY_GMUX_BACKLIGHT:-/sys/class/backlight/gmux_backlight} ]]

--- a/default/udev/apple-gmux-backlight.rules
+++ b/default/udev/apple-gmux-backlight.rules
@@ -1,0 +1,8 @@
+# apple-gmux registers gmux_backlight on the PNP bus (APP000b). systemd's
+# 99-systemd.rules imports path_id on the same line as SYSTEMD_WANTS, and
+# that builtin fails for PNP, so the whole rule is skipped.
+# Keyboard backlight on PCI/SPI is unaffected. systemd-backlight already
+# falls back to backlight:<name> when ID_PATH is missing — it just never
+# gets asked to.
+ACTION=="add", SUBSYSTEM=="backlight", KERNEL=="gmux_backlight", \
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="systemd-backlight@backlight:gmux_backlight.service"

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -39,6 +39,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-gmux-backlight.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-gmux-backlight.sh
+++ b/install/hardware/apple/fix-gmux-backlight.sh
@@ -1,0 +1,16 @@
+# Persist panel brightness on Macs whose backlight is apple-gmux.
+#
+# systemd-backlight never attaches to gmux_backlight: udev path_id cannot
+# name the PNP bus, so 99-systemd.rules skips SYSTEMD_WANTS. Drop a rule
+# that does not import path_id. Keyboard backlight is on PCI/SPI and is
+# already persisted by stock systemd.
+
+if omarchy-hw-apple-gmux; then
+  echo "Detected apple-gmux panel backlight"
+
+  # shellcheck source=gmux-backlight.sh
+  source "$OMARCHY_INSTALL/hardware/apple/gmux-backlight.sh"
+
+  gmux_install_rule
+  gmux_activate
+fi

--- a/install/hardware/apple/gmux-backlight.sh
+++ b/install/hardware/apple/gmux-backlight.sh
@@ -1,0 +1,30 @@
+# Shared apple-gmux backlight helpers. Sourced; no shebang, no work on source.
+
+gmux_udev_src() {
+  printf '%s\n' "${OMARCHY_GMUX_UDEV_SRC:-$OMARCHY_PATH/default/udev/apple-gmux-backlight.rules}"
+}
+
+gmux_udev_dest() {
+  printf '%s\n' "${OMARCHY_GMUX_UDEV_DEST:-/etc/udev/rules.d/90-apple-gmux-backlight.rules}"
+}
+
+gmux_install_rule() {
+  local src dest
+  src=$(gmux_udev_src)
+  dest=$(gmux_udev_dest)
+  mkdir -p "$(dirname "$dest")"
+  /usr/bin/install -Dm644 "$src" "$dest"
+}
+
+# Attach systemd-backlight and snapshot the current level so the next boot
+# has something to restore. Tests retarget dest away from /etc and skip this.
+gmux_activate() {
+  local dest
+  dest=$(gmux_udev_dest)
+  [[ $dest == /etc/udev/rules.d/* ]] || return 0
+
+  /usr/bin/udevadm control --reload
+  /usr/bin/udevadm trigger --action=add --subsystem-match=backlight --sysname-match=gmux_backlight
+  systemctl start systemd-backlight@backlight:gmux_backlight.service
+  /usr/lib/systemd/systemd-backlight save backlight:gmux_backlight
+}

--- a/migrations/1788392890.sh
+++ b/migrations/1788392890.sh
@@ -1,0 +1,21 @@
+echo "Persist apple-gmux panel brightness across reboots"
+
+# systemd-backlight never attaches to gmux_backlight (PNP path_id failure).
+# See install/hardware/apple/gmux-backlight.sh. Idempotent: install -Dm644
+# rewrites the same static rule, and a second user finds it already in place.
+if ! omarchy-hw-apple-gmux; then
+  exit 0
+fi
+
+# shellcheck source=../install/hardware/apple/gmux-backlight.sh
+source "$OMARCHY_PATH/install/hardware/apple/gmux-backlight.sh"
+
+# Real dest lives under /etc. Tests override OMARCHY_GMUX_UDEV_DEST to a
+# writable tmp tree and skip the privilege hop.
+if (( $(id -u) != 0 )) && [[ $(gmux_udev_dest) == /etc/* ]]; then
+  exec sudo --preserve-env=OMARCHY_PATH,OMARCHY_GMUX_UDEV_DEST,OMARCHY_GMUX_UDEV_SRC,OMARCHY_GMUX_BACKLIGHT \
+    /bin/bash -euo pipefail "$BASH_SOURCE"
+fi
+
+gmux_install_rule
+gmux_activate

--- a/test/shell.d/gmux-backlight-test.sh
+++ b/test/shell.d/gmux-backlight-test.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hw="$ROOT/bin/omarchy-hw-apple-gmux"
+helpers="$ROOT/install/hardware/apple/gmux-backlight.sh"
+fix="$ROOT/install/hardware/apple/fix-gmux-backlight.sh"
+udev_src="$ROOT/default/udev/apple-gmux-backlight.rules"
+migration="$ROOT/migrations/1788392890.sh"
+
+assert_hw() {
+  local path=$1 expect=$2 description=$3
+  if OMARCHY_GMUX_BACKLIGHT="$path" "$hw"; then
+    [[ $expect == yes ]] || fail "$description"
+  else
+    [[ $expect == no ]] || fail "$description"
+  fi
+  pass "$description"
+}
+
+missing=$(mktemp -u)
+assert_hw "$missing" no "missing gmux_backlight is not apple-gmux"
+present=$(mktemp)
+assert_hw "$present" yes "present gmux_backlight is apple-gmux"
+rm -f "$present"
+
+grep -Fq 'IMPORT{builtin}="path_id"' "$udev_src" && fail "udev rule must not import path_id"
+grep -Fq 'systemd-backlight@backlight:gmux_backlight.service' "$udev_src" ||
+  fail "udev rule attaches systemd-backlight to gmux_backlight"
+grep -Fq 'TAG+="systemd"' "$udev_src" || fail "udev rule tags the device for systemd"
+pass "udev rule attaches systemd-backlight without path_id"
+
+grep -Fq 'fix-gmux-backlight.sh' "$ROOT/install/hardware/all.sh" ||
+  fail "hardware install runs the gmux backlight hook with the other Apple hooks"
+pass "gmux backlight install hook is wired"
+
+# shellcheck source=../../install/hardware/apple/gmux-backlight.sh
+OMARCHY_PATH="$ROOT" source "$helpers"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+etc="$test_tmp/etc"
+mkdir -p "$etc/udev/rules.d"
+OMARCHY_PATH="$ROOT"
+OMARCHY_GMUX_UDEV_SRC="$udev_src"
+OMARCHY_GMUX_UDEV_DEST="$etc/udev/rules.d/90-apple-gmux-backlight.rules"
+
+gmux_install_rule
+cmp -s "$udev_src" "$OMARCHY_GMUX_UDEV_DEST" || fail "install copies the packaged udev rule"
+pass "helper installs the packaged udev rule"
+
+gmux_activate
+pass "activate is a no-op when dest is not under /etc/udev/rules.d"
+
+dmi_missing="$test_tmp/no-gmux"
+PATH="$ROOT/bin:$PATH" \
+  OMARCHY_GMUX_BACKLIGHT="$dmi_missing" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_INSTALL="$ROOT/install" \
+  OMARCHY_GMUX_UDEV_DEST="$test_tmp/should-not-exist.rules" \
+  bash -c 'source "$1"' _ "$fix"
+[[ ! -e $test_tmp/should-not-exist.rules ]] || fail "non-gmux install hook wrote a udev rule"
+pass "install hook no-ops without gmux_backlight"
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/omarchy-hw-apple-gmux" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$stub_bin"/*
+
+install_etc="$test_tmp/install-etc"
+mkdir -p "$install_etc/udev/rules.d"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_INSTALL="$ROOT/install" \
+  OMARCHY_GMUX_UDEV_SRC="$udev_src" \
+  OMARCHY_GMUX_UDEV_DEST="$install_etc/udev/rules.d/90-apple-gmux-backlight.rules" \
+  bash -c 'source "$1"' _ "$fix"
+cmp -s "$udev_src" "$install_etc/udev/rules.d/90-apple-gmux-backlight.rules" ||
+  fail "install hook writes the udev rule on gmux hardware"
+pass "install hook writes the udev rule on gmux hardware"
+
+cat >"$stub_bin/omarchy-hw-apple-gmux" <<'SH'
+#!/bin/bash
+exit 1
+SH
+calls="$test_tmp/calls.log"
+: >"$calls"
+PATH="$stub_bin:$PATH" \
+  OMARCHY_PATH="$ROOT" \
+  bash -euo pipefail "$migration"
+[[ ! -s $calls ]] || fail "non-gmux migration is a no-op" "$(cat "$calls")"
+pass "migration skips unrelated hardware"
+
+cat >"$stub_bin/omarchy-hw-apple-gmux" <<'SH'
+#!/bin/bash
+exit 0
+SH
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$CALLS"
+exec "$@"
+SH
+chmod +x "$stub_bin/sudo"
+
+migrate_etc="$test_tmp/migrate-etc"
+mkdir -p "$migrate_etc/udev/rules.d"
+: >"$calls"
+PATH="$stub_bin:$PATH" \
+  CALLS="$calls" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_GMUX_UDEV_SRC="$udev_src" \
+  OMARCHY_GMUX_UDEV_DEST="$migrate_etc/udev/rules.d/90-apple-gmux-backlight.rules" \
+  bash -euo pipefail "$migration"
+cmp -s "$udev_src" "$migrate_etc/udev/rules.d/90-apple-gmux-backlight.rules" ||
+  fail "migration writes the udev rule on gmux hardware"
+[[ ! -s $calls ]] || fail "migration does not sudo when dest is not under /etc" "$(cat "$calls")"
+pass "migration installs the udev rule without a privilege hop in tests"
+
+# Second run is a no-op copy of the same bytes.
+PATH="$stub_bin:$PATH" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_GMUX_UDEV_SRC="$udev_src" \
+  OMARCHY_GMUX_UDEV_DEST="$migrate_etc/udev/rules.d/90-apple-gmux-backlight.rules" \
+  bash -euo pipefail "$migration"
+cmp -s "$udev_src" "$migrate_etc/udev/rules.d/90-apple-gmux-backlight.rules" ||
+  fail "migration changes an already installed rule"
+pass "migration is idempotent"


### PR DESCRIPTION
## Why

Panel brightness on pre-T2 dual-GPU Macs (`gmux_backlight`) resets on reboot. Keyboard backlight on the same machine persists.

Stock systemd udev (`/usr/lib/udev/rules.d/99-systemd.rules`) attaches `systemd-backlight@` with `IMPORT{builtin}="path_id"` on the same line as `SYSTEMD_WANTS`. `apple-gmux` lives on PNP `APP000b`; `path_id` fails (`No such file or directory`), so the rest of the rule is skipped. No unit, no file under `/var/lib/systemd/backlight/`, nothing to restore.

The keyboard LED is on PCI/SPI, so `path_id` works and `systemd-backlight@leds:spi::kbd_backlight` already saves/loads.

`systemd-backlight` itself can persist without `ID_PATH` (it names the state file `backlight:gmux_backlight`). It is never asked.

Verified on MacBookPro14,3. Detector is the sysfs node, not a DMI list — T2 Macs expose PNP `APP000b` but never create `gmux_backlight`. Independent of Touch Bar, CS8409, and the 15" lid/idle work.

## What

- `omarchy-hw-apple-gmux` matches `/sys/class/backlight/gmux_backlight`.
- Packaged udev rule tags that device for systemd **without** importing `path_id`.
- Install hook + migration copy the rule, reload udev, start the unit, and snapshot the current level so the next boot has something to restore.

## Test plan

- [x] `test/shell.d/gmux-backlight-test.sh`
- [x] `./test/cli` metadata for the new hidden detector
- [x] MacBookPro14,3: after installing the rule, `systemd-backlight@backlight:gmux_backlight` is active and `/var/lib/systemd/backlight/backlight:gmux_backlight` matches live sysfs (471). Reboot still needed to confirm load-on-boot.

---

Diagnosed with Compound Engineering `/ce-debug`.
