### PR TITLE
Handle package groups in omarchy pkg add

### DIFF
--- a/bin/omarchy-pkg-add
+++ b/bin/omarchy-pkg-add
@@ -15,7 +15,7 @@ fi
 
 for pkg in "$@"; do
   # Secondary check to handle states where pacman doesn't actually register an error
-  if ! pacman -Q "$pkg" &>/dev/null; then
+  if omarchy-pkg-missing "$pkg"; then
     echo -e "\033[31mError: Package '$pkg' did not install\033[0m" >&2
     exit 1
   fi

--- a/bin/omarchy-pkg-missing
+++ b/bin/omarchy-pkg-missing
@@ -1,10 +1,23 @@
 #!/bin/bash
 
-# omarchy:summary=Returns true if any of the named packages are missing from the system (or false if they're all there).
+# omarchy:summary=Returns true if any of the named packages or groups are missing from the system (or false if they're all there).
 # omarchy:args=<packages...>
 
 for pkg in "$@"; do
-  if ! pacman -Q "$pkg" &>/dev/null; then
+  if pacman -Q "$pkg" &>/dev/null; then
+    continue
+  fi
+
+  # `pacman -Q` only recognizes package records; groups need a sync query.
+  group_packages=$(pacman -Sgq "$pkg" 2>/dev/null)
+  if [[ -n $group_packages ]]; then
+    # Treat a group as present only when every member is installed.
+    while read -r group_pkg; do
+      if ! pacman -Q "$group_pkg" &>/dev/null; then
+        exit 0
+      fi
+    done <<< "$group_packages"
+  else
     exit 0
   fi
 done

--- a/test/shell.d/pkg-add-test.sh
+++ b/test/shell.d/pkg-add-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_path="$test_tmp/bin"
+mkdir -p "$mock_path"
+
+cat >"$mock_path/pacman" <<'EOF'
+#!/bin/bash
+case "$1" in
+  -Q)
+    case "$2" in
+      group-package-1)
+        [[ -f $TEST_TMP/group-installed || -f $TEST_TMP/group-package-1-installed ]]
+        ;;
+      group-package-2)
+        [[ -f $TEST_TMP/group-installed && -z ${INCOMPLETE_GROUP:-} ]]
+        ;;
+      regular-package)
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  -Sgq)
+    if [[ $2 != example-group && $2 != incomplete-group ]]; then
+      exit 1
+    fi
+    printf '%s\n' group-package-1 group-package-2
+    ;;
+  -S)
+    printf '%s\n' "$*" >"$TEST_TMP/install-command"
+    if [[ -n ${INCOMPLETE_GROUP:-} ]]; then
+      touch "$TEST_TMP/group-package-1-installed"
+    else
+      touch "$TEST_TMP/group-installed"
+    fi
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+
+cat >"$mock_path/omarchy-pkg-missing" <<'EOF'
+#!/bin/bash
+exec "$ROOT/bin/omarchy-pkg-missing" "$@"
+EOF
+
+cat >"$mock_path/sudo" <<'EOF'
+#!/bin/bash
+if [[ $1 != pacman ]]; then
+  exit 1
+fi
+shift
+exec pacman "$@"
+EOF
+
+chmod +x "$mock_path/pacman" "$mock_path/omarchy-pkg-missing" "$mock_path/sudo"
+
+PATH="$mock_path:$ROOT/bin:$PATH" TEST_TMP="$test_tmp" \
+  "$ROOT/bin/omarchy-pkg-add" example-group
+
+[[ $(<"$test_tmp/install-command") == "-S --noconfirm --needed example-group" ]] ||
+  fail "package group is passed to pacman for installation"
+pass "pkg add accepts a group whose member packages are installed"
+
+rm -f "$test_tmp/install-command"
+PATH="$mock_path:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-pkg-add" regular-package
+
+[[ ! -e "$test_tmp/install-command" ]] ||
+  fail "pkg add does not reinstall an already-installed package"
+pass "pkg add does not reinstall an already-installed package"
+
+rm -f "$test_tmp/group-installed" "$test_tmp/group-package-1-installed"
+if INCOMPLETE_GROUP=1 PATH="$mock_path:$ROOT/bin:$PATH" TEST_TMP="$test_tmp" \
+  "$ROOT/bin/omarchy-pkg-add" incomplete-group; then
+  fail "pkg add reports a group with a missing member"
+fi
+pass "pkg add reports a group with a missing member"


### PR DESCRIPTION
## Summary

- recognize Arch package groups when checking whether requested packages are missing
- consider a group present only when all of its member packages are installed
- reuse the group-aware check after installation so successful group installs are not reported as failures

## Problem

Commands such as:

```bash
omarchy pkg add lv2-plugins
```

successfully install the packages in the Arch group, but the final verification checks the group name with `pacman -Q`. Groups are not package records, so the command exits with:

```text
Error: Package 'lv2-plugins' did not install
```

The same applies to groups such as `vst-plugins` and `ladspa-plugins`.

## Fix

When a name is not an installed package or provider, query the sync databases for a matching group and check each concrete group member. The existing error is retained when any member is still missing after installation.

## Testing

- `bash test/shell.d/pkg-add-test.sh`
- `./test/all` (the new package-group test and CLI suite pass; this environment reported unrelated shell-test failures in `launch-about-test.sh`, `network-qr-test.sh`, and `snapper-test.sh`)
