### PR TITLE
Speed up Super+Return terminal launch

### DIFF
--- a/bin/omarchy-cmd-terminal-cwd
+++ b/bin/omarchy-cmd-terminal-cwd
@@ -3,20 +3,34 @@
 # omarchy:summary=Print the current working directory of the active terminal window
 # omarchy:hidden=true
 
-terminal_pid=$(hyprctl activewindow | awk '/pid:/ {print $2}')
-kitty_socket="$XDG_RUNTIME_DIR/omarchy-kitty-$terminal_pid"
+# Prefer /proc children over pgrep -P: pgrep can take 50-150ms on slower machines.
+
 cwd=""
+meta=$(hyprctl activewindow -j 2>/dev/null || true)
+class=$(jq -r '.class // empty' <<<"$meta")
+terminal_pid=$(jq -r '.pid // empty' <<<"$meta")
 
-if [[ -S $kitty_socket ]]; then
-  cwd=$(kitten @ --to "unix:$kitty_socket" ls --match "state:focused" 2>/dev/null |
-    jq -r '.[].tabs[].windows[].cwd // empty')
-else
-  shell_pid=$(pgrep -P "$terminal_pid" | tail -n1)
+if [[ -n $terminal_pid && $terminal_pid != "null" ]]; then
+  kitty_socket="$XDG_RUNTIME_DIR/omarchy-kitty-$terminal_pid"
 
-  if [[ -n $shell_pid ]]; then
-    cwd=$(readlink -f "/proc/$shell_pid/cwd" 2>/dev/null)
-    shell=$(readlink -f "/proc/$shell_pid/exe" 2>/dev/null)
-    grep -Fqsx "$shell" /etc/shells || cwd=""
+  if [[ -S $kitty_socket ]]; then
+    cwd=$(kitten @ --to "unix:$kitty_socket" ls --match "state:focused" 2>/dev/null |
+      jq -r '.[].tabs[].windows[].cwd // empty' | head -n1)
+  else
+    case $class in
+    foot | footclient | com.mitchellh.ghostty | org.codeberg.dnkl.foot | Alacritty | kitty | org.omarchy.terminal | org.omarchy.bash | org.omarchy.btop | TUI.float)
+      children=$(cat "/proc/$terminal_pid/task/$terminal_pid/children" 2>/dev/null || true)
+      for shell_pid in $children; do
+        shell=$(readlink -f "/proc/$shell_pid/exe" 2>/dev/null || true)
+        if [[ -n $shell ]] && grep -Fqsx "$shell" /etc/shells; then
+          candidate=$(readlink -f "/proc/$shell_pid/cwd" 2>/dev/null || true)
+          if [[ -d $candidate ]]; then
+            cwd=$candidate
+          fi
+        fi
+      done
+      ;;
+    esac
   fi
 fi
 

--- a/bin/omarchy-launch-terminal
+++ b/bin/omarchy-launch-terminal
@@ -3,4 +3,133 @@
 # omarchy:summary=Launch a terminal in the active terminal's current directory
 # omarchy:args=[command...]
 
-exec setsid uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" "$@"
+# Fast path: skip uwsm-app + xdg-terminal-exec for known terminals. Those wrappers
+# add tens to hundreds of milliseconds before the emulator starts, which is very
+# noticeable on Super+Return. Fall back to the old path for unknown terminals.
+
+default_terminal() {
+  local line desktop
+
+  if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/xdg-terminals.list ]]; then
+    while IFS= read -r line || [[ -n $line ]]; do
+      [[ -z $line || $line == \#* ]] && continue
+      desktop=${line%%:*}
+      case $desktop in
+      Alacritty.desktop)
+        echo alacritty
+        return
+        ;;
+      foot.desktop)
+        echo foot
+        return
+        ;;
+      com.mitchellh.ghostty.desktop)
+        echo ghostty
+        return
+        ;;
+      kitty.desktop)
+        echo kitty
+        return
+        ;;
+      esac
+    done <"${XDG_CONFIG_HOME:-$HOME/.config}/xdg-terminals.list"
+  fi
+
+  omarchy-default-terminal
+}
+
+ghostty_on_bus() {
+  gdbus call --session \
+    --dest com.mitchellh.ghostty \
+    --object-path /com/mitchellh/ghostty \
+    --method org.freedesktop.DBus.Peer.Ping \
+    >/dev/null 2>&1
+}
+
+launch_ghostty() {
+  local cwd=$1
+  shift
+
+  if ghostty_on_bus; then
+    if (($# == 0)) && [[ $cwd == "$HOME" ]]; then
+      gdbus call --session \
+        --dest com.mitchellh.ghostty \
+        --object-path /com/mitchellh/ghostty \
+        --method org.gtk.Actions.Activate \
+        new-window "[]" "{}" >/dev/null
+      return
+    fi
+
+    if (($#)); then
+      local cmd
+      cmd=$(printf '%q ' "$@")
+      exec setsid ghostty +new-window --working-directory="$cwd" --command="$cmd"
+    else
+      exec setsid ghostty +new-window --working-directory="$cwd"
+    fi
+  fi
+
+  if (($#)); then
+    exec setsid ghostty --gtk-single-instance=true --working-directory="$cwd" -e "$@"
+  else
+    exec setsid ghostty --gtk-single-instance=true --working-directory="$cwd"
+  fi
+}
+
+launch_foot() {
+  local cwd=$1
+  shift
+
+  if (($#)); then
+    exec setsid foot --working-directory="$cwd" -e "$@"
+  else
+    exec setsid foot --working-directory="$cwd"
+  fi
+}
+
+launch_kitty() {
+  local cwd=$1
+  shift
+
+  if (($#)); then
+    exec setsid kitty --working-directory="$cwd" "$@"
+  else
+    exec setsid kitty --working-directory="$cwd"
+  fi
+}
+
+launch_alacritty() {
+  local cwd=$1
+  shift
+
+  if (($#)); then
+    exec setsid alacritty --working-directory="$cwd" -e "$@"
+  else
+    exec setsid alacritty --working-directory="$cwd"
+  fi
+}
+
+launch_fallback() {
+  exec setsid uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)" "$@"
+}
+
+cwd=$(omarchy-cmd-terminal-cwd)
+term=$(default_terminal)
+
+case $term in
+ghostty)
+  launch_ghostty "$cwd" "$@"
+  ;;
+foot)
+  launch_foot "$cwd" "$@"
+  ;;
+kitty)
+  launch_kitty "$cwd" "$@"
+  ;;
+alacritty)
+  launch_alacritty "$cwd" "$@"
+  ;;
+*)
+  launch_fallback "$@"
+  ;;
+esac


### PR DESCRIPTION
## Summary

`Super+Return` was going through `uwsm-app` → `systemd-run` → `xdg-terminal-exec` → emulator on every press. On slower machines that wrapper chain alone was tens to hundreds of milliseconds, and Ghostty cold-start made it worse (~500–800ms to first window).

This keeps the same user-facing behavior (default terminal from `xdg-terminals.list`, cwd inheritance, optional command args) but fast-paths known emulators:

- **foot / kitty / alacritty**: `setsid` + direct exec with `--working-directory`
- **ghostty**: D-Bus `new-window` when already running and cwd is `$HOME`; otherwise `ghostty +new-window` IPC (or cold start with `--gtk-single-instance=true`)
- **unknown**: previous `uwsm-app -- xdg-terminal-exec` path

Also speeds up `omarchy-cmd-terminal-cwd` by replacing `pgrep -P` with `/proc/.../children` (pgrep was ~50–150ms here).

### Measurements

**Machine:** Apple MacBookPro15,1 (2018/2019 15″ MacBook Pro, T2) — Intel Core i7-9750H (6C/12T, 2.6–4.5 GHz), 16 GB RAM, Omarchy 4.0.2, Linux 7.1.8 (Watanare T2). Idle clocks often sat around ~20% of max, which stretches cold launches further.

| Path | Time to window |
|------|----------------|
| Stock Ghostty via wrappers | ~800ms |
| Fast Ghostty (D-Bus / IPC) | ~150–300ms |
| Fast Foot | ~50–80ms (≈ bare `foot`) |

## Test plan

- [ ] `Super+Return` opens the configured default terminal
- [ ] From a terminal in a project dir, new window inherits that cwd
- [ ] From a non-terminal window, new terminal opens in `$HOME`
- [ ] `omarchy launch terminal btop` (or similar) still runs a command
- [ ] With each default (`omarchy default terminal foot|ghostty|kitty|alacritty`), launch still works
- [ ] `./test/cli` and `test/shell.d/bin-style-test.sh` pass