### PR TITLE
Hold fingerprint checks on the lock screen until resume

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -22,6 +22,8 @@ Item {
   property bool fingerprintAuthenticating: false
   property bool passwordPamConfigured: false
   property bool fingerprintConfigured: false
+  property bool suspending: false
+  property bool fingerprintCheckDeferred: false
   property bool previewVisible: false
   property string enteredPassword: ""
   property string pendingPassword: ""
@@ -104,7 +106,45 @@ Item {
   }
 
   function refreshFingerprintStatus() {
+    // The check D-Bus-activates fprintd. Hold it back while suspending; resume
+    // runs it.
+    if (suspending) {
+      fingerprintCheckDeferred = true
+      return
+    }
     if (!fingerprintCheckProc.running) fingerprintCheckProc.running = true
+  }
+
+  // logind announces suspend with PrepareForSleep(true) and resume with
+  // PrepareForSleep(false). A lid-close lock lands a few hundred milliseconds
+  // before the machine sleeps, and an fprintd call in that window activates
+  // the daemon mid-transition: it resets the reader as the USB bus goes down,
+  // and a Synaptics reader comes back "unsupported firmware version" for the
+  // rest of that daemon's life. The availability check then reads no reader
+  // and the lock stays password-only until the next lock. Hold new fprintd
+  // calls until resume.
+  //
+  // A scan already in flight is left alone. fprintd suspends and resumes the
+  // reader itself, and while a scan runs, libfprint lets the kernel
+  // re-enumerate the reader after sleep. Aborting the scan here makes fprintd
+  // close the reader during the transition instead: the close blocks until
+  // resume, the reader wakes with stale firmware state, and every scan fails
+  // until the daemon exits. A scan that rides through sleep either continues
+  // or fails on resume, and the retry starts a fresh one on the new device.
+  function prepareForSleep(sleeping) {
+    if (suspending === sleeping) return
+
+    suspending = sleeping
+    logEvent(sleeping ? "suspending" : "resumed")
+
+    if (sleeping) {
+      fingerprintRetryTimer.stop()
+    } else if (fingerprintCheckDeferred) {
+      fingerprintCheckDeferred = false
+      refreshFingerprintStatus()
+    } else if (lockRequested) {
+      startFingerprint()
+    }
   }
 
   function logEvent(event) {
@@ -207,7 +247,7 @@ Item {
   }
 
   function startFingerprint() {
-    if (!lockRequested || !sessionLock.secure || !fingerprintConfigured) return
+    if (!lockRequested || !sessionLock.secure || !fingerprintConfigured || suspending) return
     if (fingerprintPam.active || fingerprintAuthenticating) return
 
     fingerprintAuthenticating = true
@@ -386,6 +426,36 @@ Item {
     }
   }
 
+  // One subscription for the shell's whole life, so PrepareForSleep(false) is
+  // never missed: omarchy-system-sleep-monitor exits to release its delay
+  // inhibitor and is restarted after the machine is already awake.
+  Process {
+    id: sleepMonitorProc
+    command: ["dbus-monitor", "--system",
+      "type='signal',sender='org.freedesktop.login1',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'"]
+    running: true
+    stdout: SplitParser {
+      onRead: function(line) {
+        var text = String(line)
+        if (text.indexOf("boolean true") !== -1) root.prepareForSleep(true)
+        else if (text.indexOf("boolean false") !== -1) root.prepareForSleep(false)
+      }
+    }
+    onExited: function(exitCode) {
+      // A dead monitor cannot report resume, so never leave the lock stuck
+      // suspending.
+      root.prepareForSleep(false)
+      sleepMonitorRestartTimer.restart()
+    }
+  }
+
+  Timer {
+    id: sleepMonitorRestartTimer
+    interval: 5000
+    repeat: false
+    onTriggered: sleepMonitorProc.running = true
+  }
+
   Process {
     id: strandedLockCheckProc
     command: ["bash", "-c", "omarchy-hyprland-session-locked"]
@@ -530,6 +600,7 @@ Item {
         realScreens: root.realScreenCount(),
         passwordPam: root.passwordPamConfigured,
         fingerprint: root.fingerprintConfigured,
+        suspending: root.suspending,
         authenticating: root.authenticating,
         lastEvent: root.lastEvent,
         lastEventAt: root.lastEventAt

--- a/test/shell.d/lock-fingerprint-suspend-test.sh
+++ b/test/shell.d/lock-fingerprint-suspend-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+// A lid-close lock lands a few hundred milliseconds before suspend. Any fprintd
+// call in that window activates the daemon mid-transition, and the reader it
+// resets while the USB bus drops comes back unusable for that daemon's life.
+assert(
+  /command: \["dbus-monitor", "--system",\s*"type='signal',sender='org\.freedesktop\.login1',interface='org\.freedesktop\.login1\.Manager',member='PrepareForSleep'"\]/.test(serviceQml),
+  'the lock follows logind PrepareForSleep for the life of the shell'
+)
+
+assert(
+  /if \(text\.indexOf\("boolean true"\) !== -1\) root\.prepareForSleep\(true\)\s*else if \(text\.indexOf\("boolean false"\) !== -1\) root\.prepareForSleep\(false\)/.test(serviceQml),
+  'suspend and resume both reach the lock'
+)
+
+assert(
+  /function startFingerprint\(\) \{\s*if \([^)]*\|\| suspending\) return/.test(serviceQml),
+  'no fingerprint scan starts while suspending'
+)
+
+assert(
+  /function refreshFingerprintStatus\(\) \{[\s\S]*?if \(suspending\) \{[\s\S]*?return[\s\S]*?fingerprintCheckProc\.running = true/.test(serviceQml),
+  'the fingerprint availability check waits for resume'
+)
+
+assert(
+  /function refreshFingerprintStatus\(\) \{[\s\S]*?if \(suspending\) \{\s*fingerprintCheckDeferred = true\s*return\s*\}/.test(serviceQml),
+  'a check held back by suspend is remembered for resume'
+)
+
+// fprintd suspends and resumes the reader itself, and libfprint only lets the
+// kernel re-enumerate the reader after sleep while a scan is running. Aborting
+// that scan at suspend makes fprintd close the reader mid-transition instead,
+// and it wakes with stale firmware state that fails every scan until the
+// daemon exits.
+const prepareForSleep = serviceQml.match(/function prepareForSleep\(sleeping\) \{[\s\S]*?\n  \}/)[0]
+assert(!/abort\(\)/.test(prepareForSleep), 'suspend leaves a running scan alone')
+
+assert(
+  /if \(sleeping\) \{\s*fingerprintRetryTimer\.stop\(\)\s*\} else if \(fingerprintCheckDeferred\) \{\s*fingerprintCheckDeferred = false\s*refreshFingerprintStatus\(\)\s*\} else if \(lockRequested\) \{\s*startFingerprint\(\)\s*\}/.test(prepareForSleep),
+  'suspend stops retries; resume runs the held-back check or restarts the scan'
+)
+
+// A monitor that died cannot deliver resume, so its exit must not leave the
+// lock stuck in password-only mode.
+assert(
+  /onExited: function\(exitCode\) \{[\s\S]*?root\.prepareForSleep\(false\)\s*sleepMonitorRestartTimer\.restart\(\)/.test(serviceQml),
+  'a dead sleep monitor clears the suspending state and is restarted'
+)
+JS


### PR DESCRIPTION
## Problem

On a ThinkPad X1 Carbon (Synaptics reader `06cb:019f`), closing the lid and reopening it later often leaves the lock screen with no fingerprint option. Only the password works until the next lock.

The journal shows what happens:

```
07:50:53.163 systemd-logind: Lid closed.
07:50:53.263 omarchy-shell: omarchy lock ... lock-requested
07:50:53.840 omarchy-shell: Starting pam session ... "omarchy-lock-fingerprint"
07:50:53.933 kernel: PM: suspend entry (s2idle)
07:50:57.832 fprintd: Ignoring device due to initialization error: unsupported firmware version
```

1. The lid-close lock starts a fingerprint check right away. `fprintd-list` and `pam_fprintd` both D-Bus-activate fprintd, which resets the reader.
2. The machine suspends about 100 ms later, in the middle of that reset. fprintd cannot delay the sleep: it is starting inside the transition, so its own inhibitor fails with `OperationInProgress`.
3. After resume the reader answers "unsupported firmware version". That fprintd instance ignores it for the rest of its life.
4. The lock plugin checks fingerprint availability once, at lock time. That check ran against the broken fprintd, saw no reader, and put the lock in password-only mode. It never re-checks, so the state survives until the next lock.

A scan that is already running when the machine sleeps is a different case, and it already works. fprintd suspends and resumes the reader itself, and while a scan is running libfprint turns off USB `persist` for the reader, so the kernel re-enumerates it after a long sleep. The old device object reports `device was disconnected`, the PAM verify fails, and the retry timer starts a fresh scan on the new device. Two long sleeps on the same laptop yesterday both unlocked by fingerprint within two seconds of resume through that path.

## Fix

The lock plugin now follows logind's `PrepareForSleep` itself, through a `dbus-monitor` process that lives as long as the shell. `omarchy-system-sleep-monitor` cannot deliver the resume half: it exits to release its delay inhibitor and is restarted after the machine is already awake.

- `PrepareForSleep(true)`: stop the retry timer and refuse to start a scan or an availability check until resume. A scan already in flight is left alone.
- `PrepareForSleep(false)`: run the availability check if one was held back, otherwise restart the scan. A check that failed before sleep no longer decides the whole lock.
- If the monitor process dies, the lock clears the suspending state and restarts the monitor after 5 s, so it can never get stuck in password-only mode.

`omarchy-shell lock status` reports the new `suspending` flag.

An earlier revision of this branch also aborted the in-flight PAM at suspend. That made things worse after a long sleep. Killing the PAM helper makes fprintd cancel the verify and close the reader synchronously, in the same instant it is suspending the reader for logind. The close blocked until resume, the reader had kept `persist=1` because no scan was running at suspend time, and it woke with stale firmware state:

```
10:18:19 fprintd[4108]: Corrupted message received
10:18:19 fprintd[4108]: Error closing device after disconnect: The driver encountered a protocol error with the device.
10:19:18 systemd[1]: fprintd.service: Deactivated successfully.
```

Every scan failed until that daemon hit its idle timeout a minute later. The current revision leaves the scan running, so libfprint's own suspend path handles the reader.

## Testing

- `test/shell.d/lock-fingerprint-suspend-test.sh` (new) pins the monitor, the two gates, the held-back check, and that suspend does not abort a running scan.
- `./test/all` passes apart from `bar icons share slot and baseline geometry`, which fails the same way on a clean `quattro` checkout on this machine. `runtime-smoke-test.sh` timed out once under the full run and passed four times on its own, before and after the change.
- Verified the `dbus-monitor` process starts, streams lines through `SplitParser`, and is reaped under a Quickshell `Process`.
- On the linked checkout, the earlier revision passed a 7 s lid close and failed a 27 min one, which is what led to the change above. The current revision unlocks by fingerprint after a long lid close on the same laptop.

