### PR TITLE
Network panel: don't paint NOT CONNECTED when the wifi route is up

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -69,7 +69,17 @@ Panel {
   readonly property var networkDevices: Networking.devices ? Networking.devices.values : []
   readonly property var wifiDevice: findDevice(DeviceType.Wifi)
   readonly property var wifiNetworkObjects: wifiDevice && wifiDevice.networks ? wifiDevice.networks.values : []
-  readonly property var connectedWifiNetwork: findConnectedWifiNetwork()
+  // Rebind nudge: Quickshell's network list can lag the live route during
+  // activation or scan churn -- the poller reports an up interface while no
+  // network object is marked connected yet. Incrementing this counter re-runs
+  // the connected-network lookup without waiting for the list itself to emit
+  // a change signal. The nudge rides the existing omarchy-network-status
+  // poller's cadence, so there is no second poller here.
+  property int wifiRebind: 0
+  readonly property var connectedWifiNetwork: {
+    wifiRebind
+    return findConnectedWifiNetwork()
+  }
   property var wifiNetworks: []
   property bool scanning: false
   property bool wifiStationAvailable: false
@@ -392,6 +402,14 @@ Panel {
 
   onWifiNetworkObjectsChanged: syncWifiNetworks()
 
+  // Rebind when the poller and Quickshell disagree: the route is up but no
+  // network object is marked connected yet. Each status sample nudges the
+  // lookup once; when Quickshell's list catches up the mismatch clears by
+  // itself (onWifiNetworkObjectsChanged fires and the binding re-runs).
+  onInfoChanged: {
+    if (info.iface && info.type === "wifi" && !connectedWifiNetwork) wifiRebind++
+  }
+
   function selectByDelta(delta) {
     if (wifiNetworks.length === 0) { selectedIndex = -1; return }
     if (selectedIndex < 0) selectedIndex = delta > 0 ? 0 : wifiNetworks.length - 1
@@ -441,6 +459,12 @@ Panel {
   readonly property string kind: {
     if (wiredDevice && wiredDevice.connected) return "ethernet"
     if (connectedWifiNetwork) return "wifi"
+    // Trust the omarchy-network-status poller: an up wifi interface means
+    // the link is associated even while Quickshell's network list has not
+    // rebound a connected network object yet. Only wifi is inferred from the
+    // poller -- the default route can be a VPN tunnel, and a tun must never
+    // be reported as ethernet.
+    if (info.iface && info.type === "wifi") return "wifi"
     return "disconnected"
   }
   readonly property int signalStrength: connectedWifiNetwork
@@ -1273,11 +1297,11 @@ Panel {
               if (root.restricted) return "LIMITED INTERNET ACCESS"
               if (root.info.type === "wifi") {
                 if (root.canDisconnect) return root.connectionPhrase.toUpperCase()
-                if (root.kind === "disconnected") return "NOT CONNECTED"
+                if (root.kind === "disconnected" && !root.info.iface) return "NOT CONNECTED"
                 return ""
               }
               if (root.info.type === "ethernet") return root.connectionPhrase.toUpperCase()
-              if (root.kind === "disconnected") return "NOT CONNECTED"
+              if (root.kind === "disconnected" && !root.info.iface) return "NOT CONNECTED"
               return ""
             }
             visible: text !== ""


### PR DESCRIPTION
## Summary
Fixes the split-brain in `shell/plugins/panels/network/Panel.qml` where Quickshell's `connectedWifiNetwork` lags (or never rebinds after a late NetworkManager start) while `omarchy-network-status` already reports an up wifi interface. The panel then painted **NOT CONNECTED** on a live link ([omarchy#7324](https://github.com/basecamp/omarchy/issues/7324)).

When `info.iface` is up and `connectedWifiNetwork` is null:
- Nudge the connected-network lookup on the existing status-poller cadence (no second poller).
- Keep `kind` as wifi instead of disconnected.
- Never paint NOT CONNECTED while the poller reports an up interface.

Ethernet is **not** inferred from the poller (a Tailscale/VPN tun must not become ethernet). No chrome restack. No vendored copy.

Verified on a live Omarchy-Nix box (Quickshell 0.3.0): NM State=70 on `wlp0s20f3`, shell started while NM was down, journal `Network will not work. Could not find an available backend.` `findDevice(Wifi)` was null on the stale instance; a healthy bind lands on the station, not `p2p-dev-*`.

## Test plan
- [ ] After a late NetworkManager start (or restart while the shell is running), the network panel kind is wifi while the status poller reports an up wifi iface — not NOT CONNECTED.
- [ ] Connected wifi still shows the SSID / disconnect affordance as before.
- [ ] A Tailscale/VPN tun default route does not flip the panel to ethernet.
- [ ] Ethernet-only still uses the wired device, not the poller.