### PR TITLE
Add a Grok (xAI) collector to the agents bar widget

### DIFF
--- a/bin/omarchy-agent-usage-grok
+++ b/bin/omarchy-agent-usage-grok
@@ -1,0 +1,449 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Grok (xAI) usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect xAI/Grok usage into one display-ready JSON record for the
+omarchy.agents bar widget.
+
+Primary source: the Grok CLI's own local log, ~/.grok/logs/unified.jsonl.
+Every `grok` run logs a "billing: fetched credits config" line carrying the
+same numbers the CLI itself displays — the SuperGrok weekly allowance and
+prepaid balance. This is deliberately not sourced from xAI's Management
+API: that API only sees team pay-as-you-go billing, a different pool of
+money from a personal SuperGrok subscription, with no visibility into the
+weekly allowance at all. Reading the CLI's log needs no credentials and
+reflects reality as of the last `grok` invocation.
+
+Fallback source, only used when no matching log line exists yet (e.g.
+right after install, before ever running `grok`): xAI's Management API
+(https://management-api.x.ai). Getting a working key for this takes three
+non-obvious steps: the Grok CLI's own OAuth token is inference-scoped only
+and 403s here, so a separate management key from console.x.ai -> Settings
+-> Management Keys is required; that key is scoped to one team, which need
+not be the CLI's default team; and the key's ACL must explicitly include
+billing read access. Configure it via XAI_MANAGEMENT_KEY or
+~/.config/omarchy/agents/grok.json: {"managementKey": "...", "teamId": "..."}.
+
+This otherwise follows the same display-ready JSON contract as the other
+collectors in this directory: schemaVersion, id, name, updatedAt, ready,
+hasLocalStats, scope, hasPromptStats, tierLabel, usageStatusText,
+authHelpText, limits, plus the stats block (todayPrompts, todaySessions,
+todayTotalTokens, todayTokensByModel, recentDays, totalPrompts,
+totalSessions, activeDays, activeDates, modelUsage).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+AGENT_ID = "grok"
+AGENT_NAME = "Grok"
+MANAGEMENT_BASE_URL = "https://management-api.x.ai"
+CONSOLE_HELP = "Create a management key at console.x.ai and set XAI_MANAGEMENT_KEY, or configure it in ~/.config/omarchy/agents/grok.json."
+GROK_AUTH_PATH = Path.home() / ".grok" / "auth.json"
+GROK_LOG_PATH = Path.home() / ".grok" / "logs" / "unified.jsonl"
+CREDITS_LOG_MSG = "billing: fetched credits config"
+
+
+class GrokError(Exception):
+  pass
+
+
+def number(value: Any) -> int:
+  try:
+    return max(0, round(float(value or 0)))
+  except (TypeError, ValueError):
+    return 0
+
+
+def empty_stats() -> dict[str, Any]:
+  return {
+    "todayPrompts": 0,
+    "todaySessions": 0,
+    "todayTotalTokens": 0,
+    "todayTokensByModel": {},
+    "recentDays": [],
+    "totalPrompts": 0,
+    "totalSessions": 0,
+    "activeDays": 0,
+    "activeDates": [],
+    "modelUsage": {},
+  }
+
+
+def base_record(**overrides: Any) -> dict[str, Any]:
+  record: dict[str, Any] = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": datetime.now(timezone.utc).isoformat(),
+    "ready": False,
+    "hasLocalStats": False,
+    # Billing-API numbers are account/team-global, not machine-local.
+    "scope": "account",
+    "hasPromptStats": False,
+    "tierLabel": "Prepaid",
+    "usageStatusText": "",
+    "authHelpText": "",
+    "limits": [],
+  }
+  record.update(empty_stats())
+  record.update(overrides)
+  return record
+
+
+# --- Local CLI log (primary source) -------------------------------------
+
+def money_val(value: Any) -> float:
+  if isinstance(value, dict):
+    try:
+      return float(value.get("val") or 0)
+    except (TypeError, ValueError):
+      return 0.0
+  return 0.0
+
+
+def normalize_reset_at(value: Any) -> str:
+  raw = str(value or "").strip()
+  if not raw:
+    return ""
+  try:
+    parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+  except ValueError:
+    return raw
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=timezone.utc)
+  return parsed.isoformat()
+
+
+def period_label(period_type: str) -> str:
+  text = (period_type or "").lower()
+  if "month" in text:
+    return "Monthly"
+  if "week" in text:
+    return "Weekly"
+  if "day" in text:
+    return "Daily"
+  return "Plan"
+
+
+def latest_credits_config() -> tuple[str, dict[str, Any]] | None:
+  """Scan the Grok CLI's own log for its freshest billing snapshot.
+
+  Returns (timestamp, ctx) for the most recent "billing: fetched credits
+  config" line, or None if the log doesn't exist or has no such line yet
+  (e.g. `grok` has never been run). Typically well under 100KB, so a full
+  scan per refresh is cheap; no need to tail or index it.
+  """
+  try:
+    lines = GROK_LOG_PATH.read_text().splitlines()
+  except OSError:
+    return None
+  latest_ts = ""
+  latest_ctx: dict[str, Any] | None = None
+  for line in lines:
+    if CREDITS_LOG_MSG not in line:
+      continue
+    try:
+      obj = json.loads(line)
+    except json.JSONDecodeError:
+      continue
+    if obj.get("msg") != CREDITS_LOG_MSG:
+      continue
+    ts = str(obj.get("ts") or "")
+    ctx = obj.get("ctx")
+    if not isinstance(ctx, dict) or (latest_ts and ts <= latest_ts):
+      continue
+    latest_ts, latest_ctx = ts, ctx
+  if latest_ctx is None:
+    return None
+  return latest_ts, latest_ctx
+
+
+def record_from_local_billing(ts: str, ctx: dict[str, Any]) -> dict[str, Any]:
+  config = ctx.get("config") if isinstance(ctx.get("config"), dict) else {}
+  tier = str(ctx.get("subscriptionTier") or "").strip() or "Prepaid"
+
+  limits: list[dict[str, Any]] = []
+  period = config.get("currentPeriod") if isinstance(config.get("currentPeriod"), dict) else None
+  percent = config.get("creditUsagePercent")
+  if period is not None and isinstance(percent, (int, float)):
+    # percent is a 0.0-1.0 fraction in the display-ready record contract,
+    # not 0-100 — creditUsagePercent from the log is 0-100, so this divides.
+    limits.append({
+      "label": period_label(str(period.get("type") or "")),
+      "percent": max(0.0, min(1.0, float(percent) / 100.0)),
+      "resetsAt": normalize_reset_at(period.get("end")),
+    })
+
+  on_demand_cap = money_val(config.get("onDemandCap"))
+  on_demand_used = money_val(config.get("onDemandUsed"))
+  if on_demand_cap > 0:
+    limits.append({
+      "label": "On-demand",
+      "percent": max(0.0, min(1.0, on_demand_used / on_demand_cap)),
+      "resetsAt": normalize_reset_at(period.get("end")) if period is not None else "",
+    })
+
+  status = ""
+  if is_stale(ts):
+    status = "Showing the last synced reading — run `grok` to refresh."
+
+  record = base_record(ready=True, tierLabel=tier, limits=limits, usageStatusText=status)
+  # prepaidBalance.val is USD cents, not dollars (a live account showed 638
+  # against an actual $6.38 balance).
+  record["balance"] = {
+    "remaining": money_val(config.get("prepaidBalance")) / 100.0,
+    "funded": 0.0,
+    "spent": 0.0,
+    "currency": "USD",
+    "estimated": False,
+  }
+  return record
+
+
+def is_stale(ts: str, max_age_hours: int = 48) -> bool:
+  try:
+    parsed = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+  except ValueError:
+    return False
+  if parsed.tzinfo is None:
+    parsed = parsed.replace(tzinfo=timezone.utc)
+  return (datetime.now(timezone.utc) - parsed) > timedelta(hours=max_age_hours)
+
+
+# --- Auth (Management API fallback) --------------------------------------
+
+def cli_session() -> dict[str, Any] | None:
+  """Read the Grok CLI's own OAuth session, the same file `grok` uses."""
+  try:
+    parsed = json.loads(GROK_AUTH_PATH.read_text())
+  except (OSError, json.JSONDecodeError):
+    return None
+  if not isinstance(parsed, dict):
+    return None
+  for key, value in parsed.items():
+    if isinstance(value, dict) and key.startswith("https://auth.x.ai::"):
+      return value
+  return None
+
+
+def cli_session_expired(session: dict[str, Any]) -> bool:
+  raw = str(session.get("expires_at") or "")
+  if not raw:
+    return False
+  try:
+    expires_at = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+  except ValueError:
+    return False
+  if expires_at.tzinfo is None:
+    expires_at = expires_at.replace(tzinfo=timezone.utc)
+  return expires_at <= datetime.now(timezone.utc)
+
+
+def config_path() -> Path:
+  config_home = Path(os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config"))
+  return config_home / "omarchy" / "agents" / "grok.json"
+
+
+def read_config() -> dict[str, Any]:
+  try:
+    parsed = json.loads(config_path().read_text())
+    return parsed if isinstance(parsed, dict) else {}
+  except (OSError, json.JSONDecodeError):
+    return {}
+
+
+def credentials() -> tuple[str, str, bool]:
+  """Returns (bearer_token, team_id, from_cli_session).
+
+  A configured management key wins when present — the CLI's own OAuth token
+  403s against the Management API, so it is only ever a fallback. Either
+  source can supply team_id; the CLI session is a convenient default even
+  when the token itself comes from config, since the console management key
+  and the CLI session normally belong to the same team.
+  """
+  config = read_config()
+  session = cli_session()
+  session_team_id = str(session.get("team_id") or "").strip() if session else ""
+
+  configured_token = str(os.environ.get("XAI_MANAGEMENT_KEY", "")).strip() or str(config.get("managementKey") or "").strip()
+  if configured_token:
+    team_id = str(config.get("teamId") or "").strip() or session_team_id
+    return configured_token, team_id, False
+
+  if session and not cli_session_expired(session):
+    token = str(session.get("key") or "").strip()
+    if token and session_team_id:
+      return token, session_team_id, True
+
+  return "", str(config.get("teamId") or "").strip() or session_team_id, False
+
+
+# --- Management API -------------------------------------------------------
+
+class GrokClient:
+  def __init__(self, token: str):
+    self.token = token
+
+  def request(self, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+    url = MANAGEMENT_BASE_URL + path
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+      url,
+      data=data,
+      method="POST" if body is not None else "GET",
+      headers={
+        "Authorization": "Bearer " + self.token,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    )
+    try:
+      with urllib.request.urlopen(request, timeout=15) as response:
+        decoded = json.load(response)
+        return decoded if isinstance(decoded, dict) else {}
+    except urllib.error.HTTPError as error:
+      if error.code == 401:
+        raise GrokError("xAI rejected the management token")
+      if error.code == 403:
+        raise GrokError("This key cannot read billing data for the team")
+      if error.code == 404:
+        raise GrokError("xAI team not found")
+      raise GrokError(f"xAI Management API returned HTTP {error.code}")
+    except urllib.error.URLError as error:
+      raise GrokError("Could not reach the xAI Management API") from error
+    except (json.JSONDecodeError, TimeoutError) as error:
+      raise GrokError("xAI returned an invalid billing response") from error
+
+  def prepaid_balance(self, team_id: str) -> dict[str, Any]:
+    return self.request(f"/v1/billing/teams/{team_id}/prepaid/balance")
+
+  def cost_usage(self, team_id: str, start: datetime, end: datetime) -> dict[str, Any]:
+    # The analytics query must be wrapped in analyticsRequest, timestamps
+    # are space-separated "YYYY-MM-DD HH:MM:SS" (an ISO8601 T/Z 400s),
+    # timeUnit takes the full TIME_UNIT_* enum name, and filters: [] is
+    # required even when empty. values[].name only accepts "usd"
+    # (AGGREGATION_SUM) grouped by "description" — every token/model field
+    # name tried (tokens, model, model_name, endpoint, api_key, …) was
+    # rejected, so this looks like a cost/line-item analytics endpoint with
+    # no per-model token breakdown available at all.
+    body = {
+      "analyticsRequest": {
+        "timeRange": {
+          "startTime": start.strftime("%Y-%m-%d %H:%M:%S"),
+          "endTime": end.strftime("%Y-%m-%d %H:%M:%S"),
+          "timezone": "Etc/GMT",
+        },
+        "timeUnit": "TIME_UNIT_DAY",
+        "values": [{"name": "usd", "aggregation": "AGGREGATION_SUM"}],
+        "groupBy": ["description"],
+        "filters": [],
+      }
+    }
+    return self.request(f"/v1/billing/teams/{team_id}/usage", body=body)
+
+
+def summarize_balance(payload: dict[str, Any]) -> dict[str, Any] | None:
+  total = payload.get("total") if isinstance(payload.get("total"), dict) else None
+  if total is None:
+    return None
+  # total.val is a plain decimal string (e.g. "0"), not a Fireworks-style
+  # {units, nanos} object.
+  remaining = number(total.get("val"))
+  return {
+    "remaining": float(remaining),
+    "funded": 0.0,
+    "spent": 0.0,
+    "currency": "USD",
+    "estimated": False,
+  }
+
+
+def total_spend_usd(payload: dict[str, Any]) -> float:
+  series = payload.get("timeSeries")
+  if not isinstance(series, list):
+    return 0.0
+  total = 0.0
+  for entry in series:
+    if not isinstance(entry, dict):
+      continue
+    points = entry.get("dataPoints")
+    if not isinstance(points, list):
+      continue
+    for point in points:
+      if not isinstance(point, dict):
+        continue
+      values = point.get("values")
+      if isinstance(values, list) and values:
+        try:
+          total += float(values[0])
+        except (TypeError, ValueError):
+          pass
+  return total
+
+
+def scan() -> dict[str, Any]:
+  local = latest_credits_config()
+  if local is not None:
+    return record_from_local_billing(*local)
+
+  # No local log yet (fresh install, never ran `grok`) — fall back to the
+  # Management API. This path shows team pay-as-you-go billing only; it
+  # cannot see a personal SuperGrok plan's weekly allowance at all.
+  token, team_id, from_cli = credentials()
+  if not token or not team_id:
+    return base_record(
+      usageStatusText="Grok unavailable",
+      authHelpText="Run `grok` once to sync local billing data, or configure the Management API fallback: " + CONSOLE_HELP,
+    )
+
+  client = GrokClient(token)
+  # hasLocalStats/hasPromptStats stay False: there is no confirmed way to
+  # get per-model token counts from the Management API (see cost_usage()
+  # above), so the panel's daily/model-breakdown tabs have nothing to draw.
+  record = base_record(ready=True)
+
+  try:
+    balance = summarize_balance(client.prepaid_balance(team_id))
+    if balance:
+      today = datetime.now(timezone.utc)
+      cost = client.cost_usage(team_id, today - timedelta(days=30), today)
+      balance["spent"] = total_spend_usd(cost)
+      record["balance"] = balance
+  except GrokError as error:
+    hint = "" if not from_cli else " (the CLI's session token may not be scoped for billing — try a console-issued management key instead)"
+    record["usageStatusText"] = "Balance unavailable"
+    record["authHelpText"] = str(error) + hint
+
+  return record
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Print the Grok (xAI) usage record as JSON")
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  parser.parse_args()
+
+  try:
+    record = scan()
+  except GrokError as error:
+    record = base_record(usageStatusText="Grok unavailable", authHelpText=str(error))
+  except Exception as error:
+    record = base_record(usageStatusText="Grok unavailable", authHelpText="Grok usage scan failed")
+    print(f"omarchy-agent-usage-grok: {type(error).__name__}", file=sys.stderr)
+
+  print(json.dumps(record, separators=(",", ":")))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -55,6 +55,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `grok` | The Grok CLI's own local billing log (weekly SuperGrok allowance + prepaid balance), falling back to xAI's Management API (team pay-as-you-go balance only) | none — see "Grok limits" below |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -91,6 +92,34 @@ period. `accountId` only matters when one API key can access several
 accounts. Without a configured `fundedAmount` the tab still shows token
 usage, just no balance. With a live ledger, `fundedAmount` is optional and
 only adds the meter and the spent-of-funded line under the real figure.
+
+### Grok limits
+
+The Grok CLI writes a "billing: fetched credits config" line to
+`~/.grok/logs/unified.jsonl` on every run, carrying the SuperGrok weekly
+allowance and prepaid balance — no credentials needed, just a local read of
+whatever the CLI last saw. This is the only source for the weekly
+allowance: xAI's Management API sees team pay-as-you-go billing, a
+different pool of money from a personal SuperGrok subscription.
+
+Before `grok` has ever been run locally, the collector falls back to that
+Management API (`https://management-api.x.ai`). Getting a working key
+takes three non-obvious steps: the Grok CLI's own OAuth token is
+inference-scoped only and 403s here, so a separate **management key** is
+needed from console.x.ai → Settings → Management Keys (not the regular API
+Keys page, which only offers model/endpoint scoping); that key is scoped
+to one team, which need not be the CLI's default team; and the key's ACL
+must explicitly include billing read access. Configure it via
+`XAI_MANAGEMENT_KEY` or `~/.config/omarchy/agents/grok.json`:
+
+```json
+{ "managementKey": "xai-...", "teamId": "<team-id-from-console>" }
+```
+
+That fallback path has no per-model token breakdown available — xAI's
+usage-analytics endpoint only accepts a cost/line-item query, not a
+token-count one — so it populates `balance` only, with local stats left
+empty.
 
 ## Interactions
 

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, Fireworks, and Grok usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -21,7 +21,8 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
-        "fireworks": { "enabled": true }
+        "fireworks": { "enabled": true },
+        "grok": { "enabled": true }
       },
       "refreshIntervalSec": 900,
       "syncMode": "Off",

--- a/test/shell.d/agent-usage-grok-scanner-test.sh
+++ b/test/shell.d/agent-usage-grok-scanner-test.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$TEST_HOME/.grok/logs" "$TEST_HOME/.config/omarchy/agents"
+
+# Without a local log and without a management key, the collector must still
+# print a full, hidden-by-default record rather than nothing at all.
+no_data=$(HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" XAI_MANAGEMENT_KEY="" \
+  "$ROOT/bin/omarchy-agent-usage-grok")
+
+[[ $(jq -r '.id + ":" + (.ready | tostring)' <<<"$no_data") == "grok:false" ]] ||
+  fail "Grok collector prints a valid record without a log or a key" "$no_data"
+pass "Grok collector prints a valid record without a log or a key"
+
+result=$(HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" python3 - "$ROOT/bin/omarchy-agent-usage-grok" "$TEST_HOME" <<'PY'
+import importlib.machinery
+import importlib.util
+import io
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+collector_path = str(Path(sys.argv[1]))
+home = Path(sys.argv[2])
+
+loader = importlib.machinery.SourceFileLoader("grok_collector", collector_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+summary = {}
+
+# A live account showed prepaidBalance.val: 638 against an actual $6.38
+# balance, and creditUsagePercent: 100.0 for a fully used weekly allowance —
+# the fixture below reproduces both real numbers, plus an on-demand pool and
+# an older, superseded snapshot the scanner must skip in favor of the newest.
+log_path = home / ".grok" / "logs" / "unified.jsonl"
+older = {
+  "ts": "2026-08-30T04:50:46.895Z",
+  "msg": "billing: fetched credits config",
+  "ctx": {
+    "config": {
+      "creditUsagePercent": 31.0,
+      "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY", "start": "2026-08-28T06:16:57+00:00", "end": "2026-09-04T06:16:57+00:00"},
+      "onDemandCap": {"val": 0},
+      "onDemandUsed": {"val": 0},
+      "prepaidBalance": {"val": 0},
+    },
+    "subscriptionTier": "SuperGrok",
+  },
+}
+newest_ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+newest = {
+  "ts": newest_ts,
+  "msg": "billing: fetched credits config",
+  "ctx": {
+    "config": {
+      "creditUsagePercent": 100.0,
+      "currentPeriod": {"type": "USAGE_PERIOD_TYPE_WEEKLY", "start": "2026-08-28T06:16:57+00:00", "end": "2026-09-04T06:16:57+00:00"},
+      "onDemandCap": {"val": 5},
+      "onDemandUsed": {"val": 2},
+      "prepaidBalance": {"val": 638},
+    },
+    "subscriptionTier": "SuperGrok",
+  },
+}
+log_path.write_text(json.dumps(older) + "\n" + json.dumps(newest) + "\n")
+
+record = collector.scan()
+summary["record"] = {
+  "id": record["id"],
+  "ready": record["ready"],
+  "tierLabel": record["tierLabel"],
+  "limits": record["limits"],
+  "balance": record["balance"],
+  "usageStatusText": record["usageStatusText"],
+}
+
+# latest_credits_config() must pick the newest line by timestamp, not the
+# last one physically in the file, and must skip a line whose ctx isn't a
+# dict rather than crash on it.
+log_path.write_text(
+  json.dumps(newest) + "\n" +
+  json.dumps(older) + "\n" +
+  json.dumps({"ts": "2099-01-01T00:00:00Z", "msg": "billing: fetched credits config", "ctx": "not a dict"}) + "\n"
+)
+picked_ts, picked_ctx = collector.latest_credits_config()
+summary["pickedNewestRegardlessOfFileOrder"] = picked_ts == newest_ts and picked_ctx["config"]["creditUsagePercent"] == 100.0
+
+# A stale snapshot (older than 48h) gets a visible note; a fresh one doesn't.
+stale = dict(newest)
+stale["ts"] = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat().replace("+00:00", "Z")
+stale_record = collector.record_from_local_billing(stale["ts"], stale["ctx"])
+summary["staleNoted"] = "run `grok` to refresh" in stale_record["usageStatusText"]
+
+fresh_record = collector.record_from_local_billing(newest["ts"], newest["ctx"])
+summary["freshNotNoted"] = fresh_record["usageStatusText"] == ""
+
+# credentials(): a configured management key wins over the CLI session, and
+# still borrows the CLI session's team_id when the config doesn't set one.
+auth_path = home / ".grok" / "auth.json"
+auth_path.write_text(json.dumps({
+  "https://auth.x.ai::agent": {
+    "key": "cli_token",
+    "team_id": "cli-team",
+    "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+  }
+}))
+config_path = home / ".config" / "omarchy" / "agents" / "grok.json"
+config_path.write_text(json.dumps({"managementKey": "mgmt_token"}))
+token, team_id, from_cli = collector.credentials()
+summary["configuredKeyWinsWithCliTeamId"] = (token, team_id, from_cli) == ("mgmt_token", "cli-team", False)
+
+log_path.unlink()
+
+# The Management API fallback: summarize_balance's plain-decimal-string
+# parse, total_spend_usd's series sum, and the 403 error path's CLI-token
+# hint (the collector's own confirmed finding: the Grok CLI's OAuth token is
+# inference-scoped only, so a 403 there gets an extra hint the fallback from
+# a configured key does not).
+config_path.write_text(json.dumps({"managementKey": "", "teamId": ""}))
+
+balance = collector.summarize_balance({"total": {"val": "6.38"}, "changes": []})
+summary["balanceParsesPlainDecimalString"] = balance == {
+  "remaining": 6.0,
+  "funded": 0.0,
+  "spent": 0.0,
+  "currency": "USD",
+  "estimated": False,
+}
+
+cost_payload = {"timeSeries": [
+  {"dataPoints": [{"values": [1.5]}, {"values": [2.25]}]},
+  {"dataPoints": [{"values": ["not-a-number"]}]},
+]}
+summary["totalSpendSumsSeries"] = collector.total_spend_usd(cost_payload) == 3.75
+
+class ForbiddenClient:
+  def __init__(self, token):
+    pass
+
+  def prepaid_balance(self, team_id):
+    raise collector.GrokError("This key cannot read billing data for the team")
+
+collector.GrokClient = ForbiddenClient
+fallback_record = collector.scan()
+summary["forbiddenHintsCliToken"] = "session token may not be scoped" in fallback_record["authHelpText"]
+
+print(json.dumps(summary, separators=(",", ":")))
+PY
+)
+
+[[ $(jq -c '.record' <<<"$result") == '{"id":"grok","ready":true,"tierLabel":"SuperGrok","limits":[{"label":"Weekly","percent":1.0,"resetsAt":"2026-09-04T06:16:57+00:00"},{"label":"On-demand","percent":0.4,"resetsAt":"2026-09-04T06:16:57+00:00"}],"balance":{"remaining":6.38,"funded":0.0,"spent":0.0,"currency":"USD","estimated":false},"usageStatusText":""}' ]] ||
+  fail "Grok collector builds the display-ready record from the local billing log" "$result"
+pass "Grok collector builds the display-ready record from the local billing log"
+
+[[ $(jq -r '.pickedNewestRegardlessOfFileOrder' <<<"$result") == "true" ]] ||
+  fail "Grok collector reads the newest credits-config line by timestamp, not file order" "$result"
+pass "Grok collector reads the newest credits-config line by timestamp, not file order"
+
+[[ $(jq -r '.staleNoted' <<<"$result") == "true" && $(jq -r '.freshNotNoted' <<<"$result") == "true" ]] ||
+  fail "Grok collector notes a stale local snapshot but not a fresh one" "$result"
+pass "Grok collector notes a stale local snapshot but not a fresh one"
+
+[[ $(jq -r '.configuredKeyWinsWithCliTeamId' <<<"$result") == "true" ]] ||
+  fail "Grok collector prefers a configured management key, borrowing the CLI session's team_id" "$result"
+pass "Grok collector prefers a configured management key, borrowing the CLI session's team_id"
+
+[[ $(jq -r '.balanceParsesPlainDecimalString' <<<"$result") == "true" ]] ||
+  fail "Grok collector parses the Management API's plain-decimal-string balance" "$result"
+pass "Grok collector parses the Management API's plain-decimal-string balance"
+
+[[ $(jq -r '.totalSpendSumsSeries' <<<"$result") == "true" ]] ||
+  fail "Grok collector sums the cost-analytics series, skipping unparseable values" "$result"
+pass "Grok collector sums the cost-analytics series, skipping unparseable values"
+
+[[ $(jq -r '.forbiddenHintsCliToken' <<<"$result") == "true" ]] ||
+  fail "Grok collector hints that a CLI-session token may lack billing scope on 403" "$result"
+pass "Grok collector hints that a CLI-session token may lack billing scope on 403"


### PR DESCRIPTION
## Summary

- Adds `bin/omarchy-agent-usage-grok`, a collector for the `omarchy.agents` bar widget covering Grok/xAI, following the same display-ready JSON contract as `claude`/`codex`/`fireworks`.
- Primary data source is the Grok CLI's own local log (`~/.grok/logs/unified.jsonl`), which already carries the SuperGrok weekly allowance and prepaid balance on every `grok` run — no credentials needed. This is the *only* source for the weekly allowance: xAI's Management API only sees team pay-as-you-go billing, a different pool of money from a personal SuperGrok subscription.
- Falls back to that Management API before `grok` has ever been run locally. Getting a working key for it took three non-obvious steps (documented in `shell/plugins/agents/README.md`): a separate **management key** is required since the CLI's own OAuth token is inference-scoped only, that key is scoped to one team which need not be the CLI's default team, and its ACL must explicitly include billing read access. That fallback path has no per-model token breakdown available — the usage-analytics endpoint only accepts a cost/line-item query, not a token-count one — so it populates a balance only.
- Adds `grok` to the widget's `manifest.json` provider defaults and description, and documents both paths in the plugin's `README.md`.
- Adds `test/shell.d/agent-usage-grok-scanner-test.sh`, covering: a valid record with neither a log nor a key, building the record from a fixture log (percent-fraction scaling, cents-to-dollars balance, on-demand limit, reset time), picking the newest log line by timestamp regardless of file order, a staleness note on an old snapshot vs. none on a fresh one, the configured-key-wins-with-CLI-team_id credential precedence, the Management API's plain-decimal-string balance parse, the cost-series summation, and the CLI-token hint on a 403.

All findings above came from testing against a real xAI team and a real Grok CLI session, not from the docs alone (the docs don't mention the management-key/team-scoping/ACL requirements, and the usage-analytics endpoint's accepted field names aren't documented either — both were found by testing against the real API).

## Test plan

- [x] `./test/all` — passing except 3 pre-existing failures unrelated to this change (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh` all fail the same way on a clean checkout of this branch's base, needing an `OMARCHY_PKGS_PATH` checkout not present in this environment)
- [x] `bash test/shell.d/agent-usage-grok-scanner-test.sh` — all 8 assertions pass
- [x] Ran the collector standalone against a real Grok CLI session and a real xAI Management API team; installed it locally (`$OMARCHY_PATH/bin/`) and confirmed it renders correctly in the live bar panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Webm6BX1U8ZBfzuwQhEyyS