### PR TITLE
Add Super+Z shortcut to reopen browser tabs

### DIFF
--- a/default/hypr/bindings/browser.lua
+++ b/default/hypr/bindings/browser.lua
@@ -1,0 +1,7 @@
+local function reopen_closed_browser_tab()
+  if o.active_window_has_tag("chromium-based-browser") or o.active_window_has_tag("firefox-based-browser") then
+    o.send_shortcut_once("CTRL + SHIFT", "T")()
+  end
+end
+
+o.bind("SUPER + Z", "Reopen closed browser tab", reopen_closed_browser_tab)

--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -1,48 +1,14 @@
--- Send with explicit mods to the focused surface by omitting the window target,
--- so universal clipboard shortcuts reach both normal windows and focused
--- layer-shell surfaces such as Omarchy panels. A virtual keyboard (wtype) won't
--- do: the physically held SUPER merges into the injected chord at the seat.
--- The down/up split works around Hyprland send_shortcut sometimes leaving
--- synthetic key state stuck/repeating.
--- https://github.com/hyprwm/Hyprland/discussions/14099
-local function send_shortcut_once(mods, key)
-  return function()
-    hl.dispatch(hl.dsp.send_key_state({ mods = mods, key = key, state = "down" }))
-
-    hl.timer(function()
-      hl.dispatch(hl.dsp.send_key_state({ mods = mods, key = key, state = "up" }))
-    end, { timeout = 50, type = "oneshot" })
-  end
-end
-
--- Lean on the terminal tag from default/hypr/apps/terminals.lua so there's one
--- definition of what counts as a terminal. Dynamic tags carry a trailing "*".
-local function active_window_is_terminal()
-  local window = hl.get_active_window()
-  if not window then
-    return false
-  end
-
-  for _, tag in ipairs(window.tags or {}) do
-    if tag:gsub("%*$", "") == "terminal" then
-      return true
-    end
-  end
-
-  return false
-end
-
 local function universal_clipboard_shortcut(default_mods, default_key, terminal_mods, terminal_key)
   return function()
-    if active_window_is_terminal() then
-      send_shortcut_once(terminal_mods, terminal_key)()
+    if o.active_window_has_tag("terminal") then
+      o.send_shortcut_once(terminal_mods, terminal_key)()
     else
-      send_shortcut_once(default_mods, default_key)()
+      o.send_shortcut_once(default_mods, default_key)()
     end
   end
 end
 
 o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "C", "CTRL", "Insert"))
 o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "V", "SHIFT", "Insert"))
-o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", "X"))
+o.bind("SUPER + X", "Universal cut", o.send_shortcut_once("CTRL", "X"))
 o.bind("SUPER + CTRL + V", "Clipboard manager", "omarchy-shell shell toggle omarchy.clipboard")

--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -53,6 +53,38 @@ function o.cmd_missing(command)
   return not o.cmd_present(command)
 end
 
+-- Send with explicit mods to the focused surface by omitting the window target,
+-- so shortcuts reach both normal windows and focused layer-shell surfaces. A
+-- virtual keyboard (wtype) cannot do this because the physically held SUPER
+-- merges into the injected chord at the seat. The down/up split also avoids
+-- send_shortcut sometimes leaving synthetic key state stuck or repeating.
+-- https://github.com/hyprwm/Hyprland/discussions/14099
+function o.send_shortcut_once(mods, key)
+  return function()
+    hl.dispatch(hl.dsp.send_key_state({ mods = mods, key = key, state = "down" }))
+
+    hl.timer(function()
+      hl.dispatch(hl.dsp.send_key_state({ mods = mods, key = key, state = "up" }))
+    end, { timeout = 50, type = "oneshot" })
+  end
+end
+
+-- App rules assign dynamic tags, which Hyprland reports with a trailing "*".
+function o.active_window_has_tag(expected_tag)
+  local window = hl.get_active_window()
+  if not window then
+    return false
+  end
+
+  for _, tag in ipairs(window.tags or {}) do
+    if tag:gsub("%*$", "") == expected_tag then
+      return true
+    end
+  end
+
+  return false
+end
+
 local function command_from(value, description)
   if type(value) ~= "table" then
     return value

--- a/default/hypr/omarchy.lua
+++ b/default/hypr/omarchy.lua
@@ -8,6 +8,7 @@ require("default.hypr.autostart")
 if _G.omarchy_default_bindings ~= false then
   require("default.hypr.bindings.media")
   require("default.hypr.bindings.clipboard")
+  require("default.hypr.bindings.browser")
   require("default.hypr.bindings.tiling")
   require("default.hypr.bindings.utilities")
   require("default.hypr.bindings.voxtype")

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -137,6 +137,12 @@ Change/add bindings in `~/.config/hypr/bindings.lua`.
 
 Usually on Linux, you need `Ctrl + Shift + C/V` to copy'n'paste in the terminal and `Ctrl + C/V` to do it everywhere else. These Omarchy unified clipboard hotkeys work everywhere.
 
+## Browser tabs
+
+| Hotkey | Function |
+| ------- | -------- |
+| `Super + Z` | Reopen last closed browser tab |
+
 ## Capture
 
 | Hotkey              | Function                       |

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -105,19 +105,69 @@ grep -Fq $'SUPER + RETURN	Terminal' <<<"$fresh_output" || fail "default applicat
 grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
 pass "default application bindings load from package defaults"
 
-grep -F 'hl.dsp.send_key_state({ mods = mods, key = key, state = "down" })' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null ||
+grep -F 'hl.dsp.send_key_state({ mods = mods, key = key, state = "down" })' "$ROOT/default/hypr/helpers.lua" >/dev/null ||
   fail "universal clipboard shortcuts send explicit mods to the focused surface"
 pass "universal clipboard shortcuts send explicit mods to the focused surface"
 
-if grep -E 'send_key_state\(\{[^}]*window' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null; then
+if grep -E 'send_key_state\(\{[^}]*window' "$ROOT/default/hypr/helpers.lua" >/dev/null; then
   fail "universal clipboard shortcuts do not target only normal windows"
 fi
 pass "universal clipboard shortcuts do not exclude layer-shell fields"
 
-if grep -F 'wtype -M' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null; then
+if grep -F 'wtype -M' "$ROOT/default/hypr/helpers.lua" >/dev/null; then
   fail "universal clipboard shortcuts avoid the virtual keyboard so held SUPER cannot merge in"
 fi
 pass "universal clipboard shortcuts avoid virtual keyboard modifier merging"
+
+browser_shortcut_output=$(HOME="$fresh_home" XDG_CONFIG_HOME="$fresh_home/.config" XDG_STATE_HOME="$fresh_home/.local/state" OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local active_window
+local bindings = {}
+local dispatched = {}
+
+hl = {
+  dsp = {
+    exec_cmd = function(command) return command end,
+    send_key_state = function(shortcut) return shortcut end,
+  },
+  bind = function(keys, dispatcher) bindings[keys] = dispatcher end,
+  dispatch = function(shortcut)
+    table.insert(dispatched, shortcut.mods .. "+" .. shortcut.key .. ":" .. shortcut.state)
+  end,
+  timer = function(callback) callback() end,
+  get_active_window = function() return active_window end,
+}
+
+require("default.hypr.helpers")
+require("default.hypr.bindings.browser")
+
+local function exercise(label, window)
+  active_window = window
+  dispatched = {}
+  bindings["SUPER + Z"]()
+  print(label .. "=" .. table.concat(dispatched, ","))
+end
+
+exercise("chromium", { tags = { "chromium-based-browser" } })
+exercise("firefox", { tags = { "firefox-based-browser*" } })
+exercise("other", { tags = { "terminal*" } })
+exercise("untagged", { tags = nil })
+exercise("no-window", nil)
+LUA
+)
+
+grep -Fqx 'chromium=CTRL + SHIFT+T:down,CTRL + SHIFT+T:up' <<<"$browser_shortcut_output" ||
+  fail "browser tab recovery sends Ctrl+Shift+T to Chromium browsers" "$browser_shortcut_output"
+grep -Fqx 'firefox=CTRL + SHIFT+T:down,CTRL + SHIFT+T:up' <<<"$browser_shortcut_output" ||
+  fail "browser tab recovery accepts dynamic Firefox browser tags" "$browser_shortcut_output"
+grep -Fqx 'other=' <<<"$browser_shortcut_output" ||
+  fail "browser tab recovery leaves other applications alone" "$browser_shortcut_output"
+grep -Fqx 'untagged=' <<<"$browser_shortcut_output" ||
+  fail "browser tab recovery ignores untagged windows" "$browser_shortcut_output"
+grep -Fqx 'no-window=' <<<"$browser_shortcut_output" ||
+  fail "browser tab recovery tolerates an absent active window" "$browser_shortcut_output"
+pass "browser tab recovery is limited to recognized browser windows"
 
 removed_home="$tmpdir/removed-home"
 mkdir -p "$removed_home/.local/state/omarchy"


### PR DESCRIPTION
## Summary

- add `Super+Z` to reopen the last closed tab in recognized Chromium- and Firefox-based browsers
- reuse application tags so the shortcut does nothing outside supported browser windows
- extract reusable Hyprland helpers for tag detection and safe synthetic shortcuts
- document the shortcut in the manual

## Testing

- `bash test/shell.d/hyprland-default-config-test.sh`
- `bash test/shell.d/hyprland-binding-conflicts-test.sh`
- `bash test/shell.d/keybindings-menu-test.sh`
- `./test/all` (221/226 files passed locally; the persistent environment-dependent failures also reproduce on a clean `origin/quattro` worktree, while the transient network QR test passes when rerun)