### PR TITLE
Avoid focusing Quickshell plugin windows

### DIFF
--- a/bin/omarchy-launch-or-focus
+++ b/bin/omarchy-launch-or-focus
@@ -10,7 +10,7 @@ fi
 
 WINDOW_PATTERN="$1"
 LAUNCH_COMMAND="${2:-"uwsm-app -- $WINDOW_PATTERN"}"
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[] | select(((.class // "") | ascii_downcase) != "org.quickshell") | select(((.class // "") | test("\\b" + $p + "\\b"; "i")) or ((.title // "") | test("\\b" + $p + "\\b"; "i"))) | .address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"

--- a/bin/omarchy-launch-signal
+++ b/bin/omarchy-launch-signal
@@ -4,7 +4,7 @@
 
 set -e
 
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[]|select((.class|test("\\bsignal\\b";"i")) or (.title|test("\\bsignal\\b";"i")))|.address' | head -n1)
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[] | select((.class // "") | test("\\bsignal\\b"; "i")) | .address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"

--- a/bin/omarchy-launch-spotify
+++ b/bin/omarchy-launch-spotify
@@ -4,7 +4,7 @@
 
 set -e
 
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[]|select((.class|test("\\bspotify\\b";"i")) or (.title|test("\\bspotify\\b";"i")))|.address' | head -n1)
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[] | select((.class // "") | test("\\bspotify\\b"; "i")) | .address' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"

--- a/test/shell.d/launch-or-focus-test.sh
+++ b/test/shell.d/launch-or-focus-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ $1 == "clients" ]]; then
+  printf '%s\n' "$OMARCHY_TEST_CLIENTS_JSON"
+elif [[ $1 == "dispatch" ]]; then
+  printf '%s\n' "$2" >"$OMARCHY_TEST_FOCUS_DISPATCH"
+fi
+SH
+cat >"$mock_bin/setsid" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_LAUNCH"
+SH
+cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_LAUNCH"
+SH
+chmod +x "$mock_bin"/*
+
+dispatch_log="$test_tmp/dispatch"
+launch_log="$test_tmp/launch"
+
+run_launcher() {
+  local launcher="$1"
+  local clients_json="$2"
+  shift 2
+  rm -f "$dispatch_log" "$launch_log"
+  PATH="$mock_bin:$PATH" OMARCHY_TEST_CLIENTS_JSON="$clients_json" \
+    OMARCHY_TEST_FOCUS_DISPATCH="$dispatch_log" OMARCHY_TEST_LAUNCH="$launch_log" \
+    bash "$ROOT/bin/$launcher" "$@"
+}
+
+clients_json='[
+  {"address":"0xplugin","class":"org.quickshell","title":"Spotify"},
+  {"address":"0xspotify","class":"Spotify","title":"Liked Songs"}
+]'
+run_launcher omarchy-launch-spotify "$clients_json"
+grep -F 'address:0xspotify' "$dispatch_log" >/dev/null || fail "Spotify launcher skips the Quickshell plugin window"
+pass "Spotify launcher focuses the official client behind a plugin window"
+
+clients_json='[
+  {"address":"0xplugin","class":"org.quickshell","title":"Spotify"},
+  {"address":"0xbrowser","class":"chromium","title":"Spotify - Chromium"},
+  {"address":"0xterminal","title":"Spotify"},
+  {"address":"0xmissing","class":null,"title":"Spotify"}
+]'
+run_launcher omarchy-launch-spotify "$clients_json"
+[[ ! -e $dispatch_log ]] || fail "Spotify launcher ignores title-only and missing-class matches"
+[[ -e $launch_log ]] || fail "Spotify launcher starts Spotify or its installer when no client exists"
+pass "Spotify launcher safely ignores non-client Spotify titles"
+
+clients_json='[
+  {"address":"0xsignal","class":"signal","title":"Alice"},
+  {"address":"0xother","class":"signal-desktop","title":"Bob"}
+]'
+run_launcher omarchy-launch-signal "$clients_json"
+grep -F 'address:0xsignal' "$dispatch_log" >/dev/null || fail "Signal launcher identifies a client whose conversation title omits Signal"
+pass "Signal launcher identifies the signal class"
+
+clients_json='[{"address":"0xsignal-desktop","class":"signal-desktop","title":"Alice"}]'
+run_launcher omarchy-launch-signal "$clients_json"
+grep -F 'address:0xsignal-desktop' "$dispatch_log" >/dev/null || fail "Signal launcher identifies the signal-desktop class"
+pass "Signal launcher supports the signal-desktop class"
+
+clients_json='[
+  {"address":"0xplugin","class":"ORG.QUICKSHELL","title":"Signal"},
+  {"address":"0xbrowser","class":"chromium","title":"Signal"}
+]'
+run_launcher omarchy-launch-signal "$clients_json"
+[[ ! -e $dispatch_log ]] || fail "Signal launcher ignores title-only matches"
+[[ -e $launch_log ]] || fail "Signal launcher starts Signal or its installer when no client exists"
+pass "Signal launcher ignores Quickshell and other application titles"
+
+clients_json='[
+  {"address":"0xplugin","class":"org.quickshell","title":"Calendar"},
+  {"address":"0xwebapp","class":"chromium","title":"Calendar"}
+]'
+run_launcher omarchy-launch-or-focus "$clients_json" Calendar 'calendar-launch-command'
+grep -F 'address:0xwebapp' "$dispatch_log" >/dev/null || fail "generic launcher skips Quickshell before matching a web app title"
+pass "generic launcher preserves title matching for Chromium web apps"
+
+clients_json='[{"address":"0xplugin","class":"Org.Quickshell","title":"Calendar"}]'
+run_launcher omarchy-launch-or-focus "$clients_json" Calendar 'calendar-launch-command'
+[[ ! -e $dispatch_log ]] || fail "generic launcher ignores a case-insensitive Quickshell class"
+grep -F 'calendar-launch-command' "$launch_log" >/dev/null || fail "generic launcher starts the command when only a Quickshell match exists"
+pass "generic launcher excludes org.quickshell windows case-insensitively"


### PR DESCRIPTION
## Summary

Quickshell plugin windows can use application names such as Spotify in their titles. The launch-or-focus commands could then mistake the plugin surface for the application and focus it instead of launching or focusing the real client.

- Ignore `org.quickshell` windows in the shared launch-or-focus helper while preserving class-or-title matching for web apps and TUIs
- Identify Spotify and Signal clients by class only, with safe handling for missing or null classes
- Keep support for class variants such as `signal-desktop`
- Add focused coverage for plugin-first ordering, title-only false positives, missing classes, and Chromium web app title matching

The shared helper change also covers its existing TUI, Obsidian, WhatsApp, Google Messages, Google Photos, and Google Maps callers.

## Testing

- `test/shell.d/launch-or-focus-test.sh`
- `./test/cli`
- Manually verified through `omarchy dev link`:
  - Spotify and Signal both launch and focus their official clients while application-named plugin or unrelated windows are present
  - Existing Spotify and Signal windows are focused without opening duplicate windows
  - Several Chromium web apps still launch and refocus correctly without opening duplicate windows