### PR TITLE
Keep notification toasts on the focused monitor

### DIFF
--- a/bin/omarchy-toggle-notification-popups
+++ b/bin/omarchy-toggle-notification-popups
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# omarchy:summary=Show notification toasts on every display or only the focused one
+# omarchy:group=toggle
+# omarchy:args=[toggle|all|focused|status]
+# omarchy:examples=omarchy toggle notification popups | omarchy toggle notification popups focused
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: omarchy-toggle-notification-popups [toggle|all|focused|status]" >&2
+}
+
+case "${1:-toggle}" in
+  toggle)
+    omarchy-shell notifications togglePopupMonitor
+    ;;
+  all)
+    omarchy-shell notifications setPopupMonitor all
+    ;;
+  focused)
+    omarchy-shell notifications setPopupMonitor focused
+    ;;
+  status)
+    omarchy-shell notifications popupMonitor
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -89,6 +89,7 @@
   "trigger.share.receive": {"icon":"󰥦","label":"Receive","action":"uwsm-app -- localsend"},
   "trigger.toggle.idle-lock": {"icon":"󰅶","label":"Stay Awake","action":"omarchy-toggle-idle"},
   "trigger.toggle.notifications": {"icon":"󰂛","label":"Notifications","action":"omarchy-toggle-notification-silencing"},
+  "trigger.toggle.notification-popups": {"icon":"󰍺","label":"Toasts on every display","checked":"[[ \"$(omarchy-shell notifications popupMonitor 2>/dev/null)\" == \"all\" ]]","action":"omarchy-toggle-notification-popups"},
   "trigger.toggle.crash-capture": {"icon":"󱚡","label":"Crash Capture","action":"omarchy-toggle-crash-capture"},
   "trigger.toggle.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-toggle-screensaver"},
   "trigger.toggle.nightlight": {"icon":"󰔎","label":"Nightlight","action":"omarchy-toggle-nightlight"},

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -12,6 +12,7 @@ From the terminal, the same switches are `omarchy toggle <thing>`. Run `omarchy 
 | ------ | ------ | ------- |
 | Night light | `Super + Ctrl + N` | `omarchy toggle nightlight` |
 | Silence notifications | `Super + Ctrl + ,` | `omarchy toggle notification silencing` |
+| Toasts on every display | — | `omarchy toggle notification popups` |
 | Stay awake (no idle lock) | `Super + Ctrl + I` | `omarchy toggle idle` |
 | Crash capture | — | `omarchy toggle crash-capture` |
 | Screensaver | — | `omarchy toggle screensaver` |
@@ -61,6 +62,8 @@ Then start hyprsunset at login by adding `o.launch_on_start("hyprsunset")` to `~
 Nothing is lost, though. A silenced notification is written straight into your notification history, which is exactly the record you want when you come back and wonder what you missed. Open it with `Super + Shift + Alt + ,`. See [notices](10-notices.md) for the rest of the notification story.
 
 Two kinds of message still get through: Omarchy's own confirmation toasts for something you just did ("Theme changed", "Screenshot saved"), and critical alerts sent from the command line. Chat apps that mark everything critical to force their way in front of you don't qualify.
+
+Toasts appear on every monitor. Uncheck _Trigger > Toggle > Toasts on every display_ to show them only on the focused one.
 
 ### Idle
 

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -252,23 +252,41 @@ function historyEntry(value, normalUrgency) {
   }
 }
 
-// notifications.json holds nothing but the last-set DND preference now that
+// Canonical toast-display mode. "all" is every output (the historical
+// default). "focused" is the monitor Hyprland currently has focused.
+function normalizePopupMonitor(value) {
+  if (value === undefined || value === null || value === "") return null
+  return String(value).toLowerCase() === "focused" ? "focused" : "all"
+}
+
+// Whether a toast overlay on `screenName` should be visible. An empty
+// focused name fail-opens to every output so toasts are not lost before
+// Hyprland has reported a focused monitor.
+function showsOnScreen(mode, screenName, focusedName) {
+  if (normalizePopupMonitor(mode) !== "focused") return true
+  var focused = String(focusedName || "")
+  if (!focused) return true
+  return String(screenName || "") === focused
+}
+
+// notifications.json holds DND and which outputs show toasts, now that
 // history is a directory of files. Older versions kept `pending`/`past`
 // (and, older still, `entries`) arrays in there; their presence is reported
 // so the service can rewrite the file without the dead payload.
 function parseSettings(raw) {
   var text = String(raw || "").trim()
-  if (!text) return { error: false, dnd: null, legacy: false }
+  if (!text) return { error: false, dnd: null, popupMonitor: null, legacy: false }
 
   try {
     var parsed = JSON.parse(text)
     return {
       error: false,
       dnd: parsed && typeof parsed.dnd === "boolean" ? parsed.dnd : null,
+      popupMonitor: parsed ? normalizePopupMonitor(parsed.popupMonitor) : null,
       legacy: !!(parsed && (parsed.pending || parsed.past || parsed.entries))
     }
   } catch (e) {
-    return { error: true, errorMessage: String(e), dnd: null, legacy: false }
+    return { error: true, errorMessage: String(e), dnd: null, popupMonitor: null, legacy: false }
   }
 }
 
@@ -465,6 +483,8 @@ if (typeof module !== "undefined") {
     replacementSnapshot: replacementSnapshot,
     historyEntry: historyEntry,
     parseSettings: parseSettings,
+    normalizePopupMonitor: normalizePopupMonitor,
+    showsOnScreen: showsOnScreen,
     historyRows: historyRows,
     popupEntry: popupEntry,
     popupFileName: popupFileName,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -3,6 +3,7 @@
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
+import Quickshell.Hyprland
 import Quickshell.Io
 import Quickshell.Wayland
 import Quickshell.Services.Notifications
@@ -59,28 +60,38 @@ Item {
   property var liveRefs: ({})
 
   // PersistentProperties handles in-process QML reloads. The on-disk
-  // notifications.json file is the cross-restart backstop — its `dnd` key
-  // is hydrated into persisted.doNotDisturb on startup and written back via
-  // a debounced save timer.
+  // notifications.json file is the cross-restart backstop — `dnd` and
+  // `popupMonitor` hydrate on startup and write back via a debounced save.
   PersistentProperties {
     id: persisted
     reloadableId: "omarchy-notifications"
     property bool doNotDisturb: false
+    property string popupMonitor: "all"
     onDoNotDisturbChanged: {
       // Suppress the write that load-time hydration would otherwise trigger.
       if (service._hydrating) return
       service.scheduleSettingsSave()
     }
+    onPopupMonitorChanged: {
+      if (service._hydrating) return
+      service.scheduleSettingsSave()
+    }
   }
 
-  // Guards onDoNotDisturbChanged while we're hydrating from disk so the
+  // Guards property-changed handlers while we're hydrating from disk so the
   // hydration assignment doesn't immediately schedule a write-back.
   property bool _hydrating: false
 
   readonly property alias doNotDisturb: persisted.doNotDisturb
+  readonly property alias popupMonitor: persisted.popupMonitor
+  readonly property string focusedMonitorName: Hyprland.focusedMonitor ? String(Hyprland.focusedMonitor.name || "") : ""
 
   function setDoNotDisturb(value) {
     persisted.doNotDisturb = !!value
+  }
+
+  function setPopupMonitor(value) {
+    persisted.popupMonitor = NotificationLogic.normalizePopupMonitor(value) || "all"
   }
 
   // popupModel feeds the on-screen toast stack — the only model the service
@@ -821,6 +832,12 @@ Item {
       service._hydrating = false
     }
 
+    if (parsed.popupMonitor !== null) {
+      service._hydrating = true
+      persisted.popupMonitor = parsed.popupMonitor
+      service._hydrating = false
+    }
+
     service.settingsLoaded = true
     // Versions before the history moved into its own directory kept every
     // notification in here. Rewrite once so that dead payload doesn't sit in
@@ -829,7 +846,7 @@ Item {
   }
 
   function flushSettings() {
-    settingsFile.setText(JSON.stringify({ version: 3, dnd: persisted.doNotDisturb }, null, 2) + "\n")
+    settingsFile.setText(JSON.stringify({ version: 4, dnd: persisted.doNotDisturb, popupMonitor: persisted.popupMonitor }, null, 2) + "\n")
   }
 
   Component.onCompleted: {
@@ -875,6 +892,20 @@ Item {
 
     function isDnd(): string {
       return dndState()
+    }
+
+    function popupMonitor(): string {
+      return service.popupMonitor
+    }
+
+    function setPopupMonitor(value: string): string {
+      service.setPopupMonitor(value)
+      return service.popupMonitor
+    }
+
+    function togglePopupMonitor(): string {
+      service.setPopupMonitor(service.popupMonitor === "focused" ? "all" : "focused")
+      return service.popupMonitor
     }
 
     // Replay the notifications that have been moved into the history dir.
@@ -947,7 +978,8 @@ Item {
   // One PanelWindow per output (Variants on Quickshell.screens) holding the
   // stacked toast cards. Layer is Overlay, exclusionMode Ignore, no
   // keyboard focus — popups are passive surfaces and must never steal input
-  // from the focused application.
+  // from the focused application. popupMonitor "focused" hides the overlay
+  // on every output except the one Hyprland currently has focused.
 
   Variants {
     model: Quickshell.screens
@@ -956,7 +988,8 @@ Item {
       id: popupWindow
       required property var modelData
       screen: modelData
-      visible: popupModel.count > 0
+      visible: popupModel.count > 0 && NotificationLogic.showsOnScreen(
+        service.popupMonitor, String(modelData.name || ""), service.focusedMonitorName)
 
       WlrLayershell.namespace: "omarchy-notifications"
       WlrLayershell.layer: WlrLayer.Overlay

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -364,6 +364,43 @@ const settings = notifications.parseSettings(JSON.stringify({ version: 3, dnd: t
 assertEqual(settings.dnd, true, 'notifications parse the persisted DND state')
 assertEqual(settings.legacy, false, 'notifications do not flag a current settings file as legacy')
 assertEqual(notifications.parseSettings('').dnd, null, 'notifications leave DND unset without a settings file')
+assertEqual(notifications.parseSettings('').popupMonitor, null, 'notifications leave popupMonitor unset without a settings file')
+assertEqual(
+  notifications.parseSettings(JSON.stringify({ version: 3, dnd: false })).popupMonitor,
+  null,
+  'notifications leave popupMonitor unset on a pre-v4 settings file'
+)
+assertEqual(
+  notifications.parseSettings(JSON.stringify({ popupMonitor: 'focused' })).popupMonitor,
+  'focused',
+  'notifications parse focused toast display'
+)
+assertEqual(
+  notifications.parseSettings(JSON.stringify({ popupMonitor: 'nope' })).popupMonitor,
+  'all',
+  'notifications fall unknown popupMonitor values back to all'
+)
+assertEqual(
+  notifications.normalizePopupMonitor(''),
+  null,
+  'notifications treat a blank popupMonitor as unset'
+)
+assert(
+  notifications.showsOnScreen('all', 'HDMI-A-1', 'DP-1'),
+  'notifications show toasts on every output in all mode'
+)
+assert(
+  notifications.showsOnScreen('focused', 'DP-1', 'DP-1'),
+  'notifications show toasts on the focused output'
+)
+assert(
+  !notifications.showsOnScreen('focused', 'HDMI-A-1', 'DP-1'),
+  'notifications hide toasts on unfocused outputs'
+)
+assert(
+  notifications.showsOnScreen('focused', 'HDMI-A-1', ''),
+  'notifications fail-open to every output before Hyprland reports a focused monitor'
+)
 assertEqual(
   notifications.parseSettings(JSON.stringify({ dnd: false, pending: [], past: [] })).legacy,
   true,
@@ -722,5 +759,13 @@ assert(
 assert(
   !/pendingModel|pastModel/.test(serviceQml),
   'notifications service keeps no in-memory history models'
+)
+assert(
+  /visible: popupModel\.count > 0 && NotificationLogic\.showsOnScreen\(/.test(serviceQml),
+  'notifications service gates toast overlays with the popupMonitor setting'
+)
+assert(
+  /function togglePopupMonitor\(\): string \{/.test(serviceQml),
+  'notifications IPC can switch toast overlays between every display and the focused one'
 )
 JS


### PR DESCRIPTION
## Summary

Notification toasts are one overlay per output, so every monitor shows the same ping. Default stays that way.

`popupMonitor` (`all` | `focused`) is stored with DND in `notifications.json`. `focused` shows the overlay only on Hyprland's focused monitor.

Trigger > Toggle > Toasts on every display, or `omarchy toggle notification popups`.

## Test plan

- `./test/shell.d/notifications-test.sh`
- `omarchy toggle notification popups focused`, then `omarchy notification send "test"` — toast only on the focused output
- `omarchy toggle notification popups all` — toast on every output
- Restart the shell and confirm the setting persisted