### PR TITLE
Delegate bar transparency to the active plugin

### DIFF
--- a/bin/omarchy-bar
+++ b/bin/omarchy-bar
@@ -204,16 +204,26 @@ cmd_position() {
   echo "Bar position set to $position"
 }
 
+try_bar_transparency_ipc() {
+  local result
+  result=$(omarchy-shell shell "$@" 2>/dev/null) || return 1
+  [[ $result == "ok" ]]
+}
+
 cmd_transparent() {
   local transparent="${1:-}"
   [[ -n $transparent ]] || fail "transparent is required"
   (( $# == 1 )) || fail "transparent takes a single value"
   [[ $transparent =~ ^(true|false|toggle)$ ]] || fail "transparent must be true, false, or toggle"
   if [[ $transparent == "toggle" ]]; then
-    commit "$NORMALIZE | .bar.transparent = (.bar.transparent != true)"
+    if ! try_bar_transparency_ipc toggleBarTransparency; then
+      commit "$NORMALIZE | .bar.transparent = (.bar.transparent != true)"
+    fi
     echo "Bar transparency toggled"
   else
-    commit "$NORMALIZE | .bar.transparent = \$transparent" --argjson transparent "$transparent"
+    if ! try_bar_transparency_ipc setBarTransparency "$transparent"; then
+      commit "$NORMALIZE | .bar.transparent = \$transparent" --argjson transparent "$transparent"
+    fi
     echo "Bar transparency set to $transparent"
   fi
 }

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -113,7 +113,8 @@ or `omarchy.power`. There is no `bar` target.
 | `rescanPlugins`                       | re-walk plugin dirs and hot-reload plugin code |
 | `reloadConfig`                        | reload shell.json               |
 | `applyTheme <colorsB64> <shellB64>`   | push theme colors + shell.toml  |
-| `toggleBarTransparency`               | flip the bar background between solid and transparent |
+| `toggleBarTransparency`               | ask the active bar to toggle its transparency mode |
+| `setBarTransparency <"true"\|…>`     | ask the active bar to enter or leave transparent mode |
 | `setPluginEnabled <id> <"true"\|…>`   | flip enabled bit (`ok` / `unknown`) |
 | `enablePlugin <id> <placementJson>`   | enable and place in one mutation |
 | `putBarWidget <id> <placementJson>`   | place a widget only where absent (`omarchy bar put`) |
@@ -123,9 +124,9 @@ or `omarchy.power`. There is no `bar` target.
 | `listShellConfig`                     | effective shell.json as JSON    |
 | `debugBarGeometry`                    | bar geometry dump for debugging |
 
-`setPluginEnabled` takes a string; only literal `"true"` enables. Methods
-answer on stdout with exit 0 — `ok` on success, `unknown` or an error
-string on a miss.
+`setPluginEnabled` takes a string; only literal `"true"` enables. Methods answer on stdout with exit 0 — `ok` on success, `unknown` or an error string on a miss.
+
+Full bar entry points may implement `toggleTransparency()` and `setTransparency(transparent)`. The host delegates the two transparency IPC methods to those hooks on the active bar, allowing custom bars to define their own modes. When a hook is absent, the host falls back to updating the boolean `bar.transparent` setting for compatibility.
 
 ## shell.json
 

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -614,16 +614,20 @@ Item {
     Util.execDetached(command)
   }
 
-  function toggleTransparency() {
-    var nextTransparent = !(root.requestedTransparent === true)
+  function setTransparency(value) {
+    var transparent = value === true
     if (root.shell && typeof root.shell.mutateShellConfig === "function") {
       root.shell.mutateShellConfig(function(config) {
         if (!Util.isPlainObject(config.bar)) config.bar = {}
-        config.bar.transparent = nextTransparent
+        config.bar.transparent = transparent
       })
     } else {
-      root.setRequestedTransparency(nextTransparent)
+      root.setRequestedTransparency(transparent)
     }
+  }
+
+  function toggleTransparency() {
+    root.setTransparency(!(root.requestedTransparent === true))
   }
 
   function rawLayoutSection(config, region) {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -922,9 +922,26 @@ ShellRoot {
     function toggleBarTransparency(): string {
       if (shell.bar && typeof shell.bar.toggleTransparency === "function") {
         shell.bar.toggleTransparency()
-        return "ok"
+      } else {
+        shell.mutateShellConfig(function(config) {
+          if (!Util.isPlainObject(config.bar)) config.bar = {}
+          config.bar.transparent = config.bar.transparent !== true
+        })
       }
-      return "no-bar"
+      return "ok"
+    }
+
+    function setBarTransparency(value: string): string {
+      var transparent = value === "true"
+      if (shell.bar && typeof shell.bar.setTransparency === "function") {
+        shell.bar.setTransparency(transparent)
+      } else {
+        shell.mutateShellConfig(function(config) {
+          if (!Util.isPlainObject(config.bar)) config.bar = {}
+          config.bar.transparent = transparent
+        })
+      }
+      return "ok"
     }
 
     function setPluginEnabled(id: string, enabled: string): string {

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -36,7 +36,10 @@ const bar = requireFromRoot('shell/plugins/bar/BarModel.js')
 const barSource = fs.readFileSync(root + '/shell/plugins/bar/Bar.qml', 'utf8')
 const shellSource = fs.readFileSync(root + '/shell/shell.qml', 'utf8')
 
-assert(/function toggleBarTransparency\(\): string \{[\s\S]*?shell\.bar\.toggleTransparency\(\)/.test(shellSource), 'shell exposes the bar transparency toggle over IPC')
+assert(/function toggleBarTransparency\(\): string \{[\s\S]*?shell\.bar\.toggleTransparency\(\)/.test(shellSource), 'shell delegates the bar transparency toggle over IPC')
+assert(/function setBarTransparency\(value: string\): string \{[\s\S]*?shell\.bar\.setTransparency\(transparent\)/.test(shellSource), 'shell delegates explicit transparency over IPC')
+assert(/function setTransparency\(value\)[\s\S]*?config\.bar\.transparent = transparent/.test(barSource), 'built-in bar accepts explicit transparency')
+assert(/function toggleTransparency\(\)[\s\S]*?root\.setTransparency\(!\(root\.requestedTransparent === true\)\)/.test(barSource), 'built-in bar toggles through its explicit setter')
 
 // put tolerates a placement target the bar does not carry, so the IPC call
 // must reach the registry's put rather than route back through enable.

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -217,6 +217,7 @@ set -euo pipefail
 
 mkdir -p "$HOME/.local/state/omarchy"
 printf '%s\n' "$*" >>"$HOME/.local/state/omarchy/shell-ipc-calls"
+[[ ${OMARCHY_TEST_SHELL_DOWN:-0} == "1" ]] && exit 1
 printf 'ok\n'
 SH
 chmod +x "$ipc_mock_bin/omarchy-shell"
@@ -287,16 +288,22 @@ jq -e '
 pass "shell config sets bar position"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar transparent true
-jq -e '
-  .bar.transparent == true and
-  .bar.position == "bottom" and
-  .plugins == []
-' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
-pass "shell config sets bar transparency"
+grep -Fqx 'shell setBarTransparency true' \
+  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls"
+pass "bar delegates explicit transparency to the active bar"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar transparent toggle
+grep -Fqx 'shell toggleBarTransparency' \
+  "$TMPDIR/home/.local/state/omarchy/shell-ipc-calls"
+jq -e '.bar.transparent == null and .bar.position == "bottom" and .plugins == []' \
+  "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+pass "bar delegates transparency toggles to the active bar"
+
+HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" OMARCHY_TEST_SHELL_DOWN=1 omarchy-bar transparent true
+jq -e '.bar.transparent == true' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
+HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" OMARCHY_TEST_SHELL_DOWN=1 omarchy-bar transparent toggle
 jq -e '.bar.transparent == false' "$TMPDIR/home/.config/omarchy/shell.json" >/dev/null
-pass "shell config toggles bar transparency"
+pass "bar transparency falls back to shell config without IPC"
 
 HOME="$TMPDIR/home" OMARCHY_PATH="$ROOT" omarchy-bar set omarchy.bluetooth enabled false --json
 grep -Fqx 'shell setBarWidget omarchy.bluetooth enabled false {}' \


### PR DESCRIPTION
## Summary

- route `omarchy bar transparent true|false|toggle` through the active bar over shell IPC
- add an explicit transparency hook while preserving the built-in bar's current boolean behavior
- fall back to editing `shell.json` when the shell is stopped or predates the IPC contract
- document the optional full-bar hooks and cover delegation plus fallback behavior

## Why

Full bar plugins can replace `omarchy.bar`, but the CLI currently writes `bar.transparent` directly. That prevents a custom bar from distinguishing a toggle request from an explicit `true` or `false` request. Delegating those operations lets each active bar define its own transparency modes without changing the existing config schema.

## Testing

- `env -u NO_COLOR ./test/all` — all 226 test files passed