### PR TITLE
Add draggable screenshot notifications

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -70,6 +70,7 @@ case "$PROCESSING" in
     # notification outage must not report the capture itself as failed.
     omarchy-notification-send "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" \
       --image "$FILEPATH" \
+      --drag-file "$FILEPATH" \
       --exec "$SCREENSHOT_EDITOR" "$FILEPATH" || true
     ;;
   copy)

--- a/bin/omarchy-notification-send
+++ b/bin/omarchy-notification-send
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Send an Omarchy desktop notification
-# omarchy:args=[--app-name <app-name>] [-g <glyph>] [-u <low|normal|critical>] [-i <icon>] [-t <ms>] [-r <id>] [-p] [--image <path-or-uri>] <headline> [description] [--exec <program> [args...]]
+# omarchy:args=[--app-name <app-name>] [-g <glyph>] [-u <low|normal|critical>] [-i <icon>] [-t <ms>] [-r <id>] [-p] [--image <path-or-uri>] [--drag-file <path>] <headline> [description] [--exec <program> [args...]]
 # omarchy:examples=omarchy notification send "Reminder" "5 minutes are up" -g 󰢌
 
 set -euo pipefail
@@ -13,6 +13,7 @@ urgency="low"
 app_name="omarchy-action"
 app_icon=""
 image=
+drag_file=
 expire_timeout=-1
 replaces_id=0
 print_id=0
@@ -21,7 +22,7 @@ exec_present=0
 parsed_option_args=0
 
 usage() {
-  echo "Usage: omarchy-notification-send [--app-name <app-name>] [-g <glyph>] [-u <low|normal|critical>] [-i <icon>] [-t <ms>] [-r <id>] [-p] [--image <path-or-uri>] <headline> [description] [--exec <program> [args...]]" >&2
+  echo "Usage: omarchy-notification-send [--app-name <app-name>] [-g <glyph>] [-u <low|normal|critical>] [-i <icon>] [-t <ms>] [-r <id>] [-p] [--image <path-or-uri>] [--drag-file <path>] <headline> [description] [--exec <program> [args...]]" >&2
 }
 
 # Recognize a known option, in both `--flag value` and `--flag=value` forms.
@@ -47,7 +48,7 @@ parse_omarchy_option() {
   fi
 
   case $opt in
-  -g | --glyph | -u | --urgency | --app-name | -i | --icon | --image | -r | --replace-id | -t | --expire-time) ;;
+  -g | --glyph | -u | --urgency | --app-name | -i | --icon | --image | --drag-file | -r | --replace-id | -t | --expire-time) ;;
   *) return 1 ;;
   esac
 
@@ -62,6 +63,7 @@ parse_omarchy_option() {
   --app-name) app_name=$val ;;
   -i | --icon) app_icon=$val ;;
   --image) image=$val ;;
+  --drag-file) drag_file=$val ;;
   -r | --replace-id)
     [[ $val =~ ^[0-9]+$ ]] || {
       echo "Invalid $opt value (numeric id expected): $val" >&2
@@ -103,8 +105,8 @@ shift
 # Only a recognized option flag or --exec in that slot is not the description.
 known_flag() {
   case $1 in
-  -g | --glyph | -u | --urgency | --app-name | -i | --icon | -t | --expire-time | --image | -r | --replace-id | -p | --print-id | --exec) return 0 ;;
-  --glyph=* | --urgency=* | --app-name=* | --icon=* | --expire-time=* | --image=* | --replace-id=*) return 0 ;;
+  -g | --glyph | -u | --urgency | --app-name | -i | --icon | -t | --expire-time | --image | --drag-file | -r | --replace-id | -p | --print-id | --exec) return 0 ;;
+  --glyph=* | --urgency=* | --app-name=* | --icon=* | --expire-time=* | --image=* | --drag-file=* | --replace-id=*) return 0 ;;
   esac
   return 1
 }
@@ -157,6 +159,10 @@ fi
 
 if [[ -n $image ]]; then
   hints+=(image-path s "$image")
+fi
+
+if [[ -n $drag_file ]]; then
+  hints+=(omarchy-drag-file s "$drag_file")
 fi
 
 if ((exec_present)); then

--- a/manual/12-screenshots-recording.md
+++ b/manual/12-screenshots-recording.md
@@ -15,7 +15,7 @@ Everything you can grab off the screen hangs off the Print Screen key. One key o
 
 Hit `Print Screen` and the screen freezes so nothing shifts under you while you aim. Drag a box for a freeform region, or just click once and the shot snaps to whatever rectangle you clicked in — a window if you landed on one, the whole monitor if you landed on the bar or in a gap. Changed your mind? Hit `Print Screen` again to dismiss the picker.
 
-The result goes two places at once: a PNG in your pictures directory, and the clipboard, so you can paste it straight into a chat window with `Super + V`. A notification pops up with a thumbnail. Click it (or hit `Super + Alt + ,` to invoke the last notification) and the shot opens in Tensaku, the annotation editor, where you can draw arrows and boxes on it before you send it.
+The result goes two places at once: a PNG in your pictures directory, and the clipboard, so you can paste it straight into a chat window with `Super + V`. A notification pops up with a thumbnail. Drag the notification into a folder in Files to move the PNG there, into a terminal to insert the file path, or into a browser, chat, or other file-aware app to attach it. Click it instead (or hit `Super + Alt + ,` to invoke the last notification) and the shot opens in Tensaku, the annotation editor, where you can draw arrows and boxes on it before you send it.
 
 Files land in `~/Pictures` by default, named `screenshot-2026-08-13_14-22-05.png`. If you'd rather keep them in their own folder, set `OMARCHY_SCREENSHOT_DIR` — see [the FAQ](46-faq.md) for where to put session environment variables. Omarchy creates the directory for you if it isn't there. You can swap the editor too with `OMARCHY_SCREENSHOT_EDITOR`.
 

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -150,6 +150,10 @@ function execArgvFromHints(hints) {
   return stringHint(hints, "omarchy-exec-argv")
 }
 
+function dragFileFromHints(hints) {
+  return stringHint(hints, "omarchy-drag-file")
+}
+
 // Validate a persisted omarchy-exec-argv into a runnable argv, or null. This is
 // a STRUCTURAL check only: it fails closed on a malformed hint (non-array, a
 // non-string or empty program, or a leading-dash program that argv would read as
@@ -195,6 +199,7 @@ function snapshotOf(notification, timestamp) {
     image: n.image || "",
     glyph: glyphFromHints(n.hints),
     execArgv: execArgvFromHints(n.hints),
+    dragFile: dragFileFromHints(n.hints),
     urgency: n.urgency,
     expireTimeout: expireTimeout,
     timestamp: timestamp === undefined ? Date.now() : timestamp
@@ -203,7 +208,7 @@ function snapshotOf(notification, timestamp) {
 
 // Everything the popup card draws, and therefore everything an in-place
 // update has to write through to the row and its file.
-var POPUP_ROLES = ["app", "appIcon", "summary", "body", "image", "glyph", "execArgv", "urgency", "expireTimeout"]
+var POPUP_ROLES = ["app", "appIcon", "summary", "body", "image", "glyph", "execArgv", "dragFile", "urgency", "expireTimeout"]
 
 function popupRoles() {
   return POPUP_ROLES
@@ -246,6 +251,7 @@ function historyEntry(value, normalUrgency) {
     image: e.image || "",
     glyph: e.glyph || "",
     execArgv: e.execArgv || "",
+    dragFile: e.dragFile || "",
     urgency: typeof e.urgency === "number" ? e.urgency : normalUrgency,
     expireTimeout: 0,
     timestamp: e.timestamp || 0
@@ -457,6 +463,7 @@ if (typeof module !== "undefined") {
     stringHint: stringHint,
     glyphFromHints: glyphFromHints,
     execArgvFromHints: execArgvFromHints,
+    dragFileFromHints: dragFileFromHints,
     parseExecArgv: parseExecArgv,
     shouldRenderCompactGlyph: shouldRenderCompactGlyph,
     snapshotOf: snapshotOf,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -667,6 +667,7 @@ Item {
         image: row.image,
         glyph: row.glyph || "",
         execArgv: row.execArgv || "",
+        dragFile: row.dragFile || "",
         urgency: row.urgency,
         timestamp: row.timestamp
       }, imagesDir).entry)
@@ -691,6 +692,7 @@ Item {
         image: "",
         glyph: "󰂚",
         execArgv: "",
+        dragFile: "",
         urgency: NotificationUrgency.Low,
         expireTimeout: 0,
         timestamp: Date.now()
@@ -1000,6 +1002,7 @@ Item {
             required property string body
             required property string image
             required property string glyph
+            required property string dragFile
             required property int urgency
             required property double expireTimeout
             required property double timestamp
@@ -1046,6 +1049,7 @@ Item {
               summary: cardSlot.summary
               body: cardSlot.body
               image: cardSlot.image
+              dragFile: cardSlot.dragFile
               urgency: cardSlot.urgency
               timestamp: cardSlot.timestamp
               cornerRadius: service.cornerRadius
@@ -1054,6 +1058,7 @@ Item {
 
               onCloseRequested: service.dismissPopup(cardSlot.index)
               onCardClicked: service.invokePopupDefault(cardSlot.index)
+              onFileDragFinished: service.dismissPopup(cardSlot.index)
             }
           }
         }

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -17,6 +17,10 @@ BorderSurface {
   property string summary: ""
   property string body: ""
   property string image: ""
+  // A local file explicitly offered by the sender for native drag-and-drop.
+  // Kept separate from `image`: notification images can be avatars, album art,
+  // or transient image:// resources that are not user-shareable files.
+  property string dragFile: ""
   // Nerd Font glyph rendered in the icon slot when no real icon is set.
   // Used by omarchy-notification-send so user-action toasts (`Silenced
   // notifications` etc.) show their bell/lock/etc. glyph without leaking
@@ -34,6 +38,7 @@ BorderSurface {
 
   signal closeRequested()
   signal cardClicked()
+  signal fileDragFinished()
   // Prefer per-notification media/avatar data, then fall back to the app icon.
   // The `check` flag avoids Qt's missing-texture placeholder for unknown names.
   readonly property string smallIconSource: image.length > 0 ? image : iconSource(appIcon)
@@ -45,6 +50,7 @@ BorderSurface {
   readonly property bool collapseRedundantIcon: singleLineToast && !hasGlyph && summaryStartsWithGlyph
   readonly property string sanitizedBody: sanitizeBody(body)
   readonly property string styledBody: NotificationLogic.styledBody(body, app, appIcon)
+  readonly property string dragFileUrl: Util.fileUrl(dragFile)
 
   readonly property color dimColor: Qt.darker(Color.notifications.text, 1.4)
   readonly property color bodyColor: Qt.darker(Color.notifications.text, 1.15)
@@ -72,11 +78,33 @@ BorderSurface {
   borderSpec: cardBorderSpec
   clip: true
 
+  Drag.active: fileDrag.active
+  Drag.dragType: Drag.Automatic
+  Drag.supportedActions: Qt.CopyAction | Qt.MoveAction
+  Drag.proposedAction: Qt.MoveAction
+  Drag.mimeData: ({
+    "text/uri-list": root.dragFileUrl + "\r\n",
+    "text/plain": root.dragFile
+  })
+  Drag.imageSource: root.image.length > 0 ? root.iconSource(root.image) : ""
+  Drag.imageSourceSize: Qt.size(Style.space(160), Style.space(90))
+  // Some Wayland targets consume the URI while reporting IgnoreAction back to
+  // Qt, so completion itself is the reliable signal that the user is done
+  // with this transient share affordance.
+  Drag.onDragFinished: root.fileDragFinished()
+
   HoverHandler { id: hoverTracker }
+
+  DragHandler {
+    id: fileDrag
+    enabled: root.dragFile.length > 0
+    target: null
+    acceptedButtons: Qt.LeftButton
+  }
 
   MouseArea {
     anchors.fill: parent
-    cursorShape: Qt.PointingHandCursor
+    cursorShape: fileDrag.active ? Qt.ClosedHandCursor : (root.dragFile.length > 0 ? Qt.OpenHandCursor : Qt.PointingHandCursor)
     acceptedButtons: Qt.LeftButton | Qt.RightButton
     onClicked: function(mouse) {
       if (mouse.button === Qt.RightButton) {

--- a/test/shell.d/notification-send-test.sh
+++ b/test/shell.d/notification-send-test.sh
@@ -49,7 +49,7 @@ hint_value() { # key -> variant value
 
 # ---------------------------------------------------------------- happy path
 send --app-name custom-app -g K -u critical -i battery-caution -t 5000 \
-  "Download complete" "A body" --exec mpv -- "/tmp/a b.mp4"
+  "Download complete" "A body" --drag-file "/tmp/a b.mp4" --exec mpv -- "/tmp/a b.mp4"
 load
 
 [[ ${args[2]} == "call" ]] || fail "notification wrapper calls a bus method"
@@ -63,7 +63,8 @@ load
 [[ $(hint_value urgency) == "2" ]] || fail "notification wrapper maps critical urgency to 2"
 [[ $(hint_value omarchy-glyph) == "K" ]] || fail "notification wrapper sets the glyph hint"
 [[ $(hint_value omarchy-exec-argv) == '["mpv","--","/tmp/a b.mp4"]' ]] || fail "notification wrapper builds the click argv hint" "$(hint_value omarchy-exec-argv)"
-pass "notification wrapper issues a Notify call with app, icon, urgency, glyph, and click argv"
+[[ $(hint_value omarchy-drag-file) == "/tmp/a b.mp4" ]] || fail "notification wrapper sets the drag file hint" "$(hint_value omarchy-drag-file)"
+pass "notification wrapper issues a Notify call with app, icon, urgency, glyph, drag file, and click argv"
 
 [[ -f $tripwire ]] && fail "notification wrapper must never invoke notify-send"
 pass "notification wrapper never invokes notify-send"
@@ -106,8 +107,9 @@ pass "notification wrapper accepts the --flag=value form"
 send "Plain" >/dev/null
 load
 has_hint omarchy-exec-argv && fail "notification wrapper adds no click hint without --exec"
+has_hint omarchy-drag-file && fail "notification wrapper adds no drag hint without --drag-file"
 [[ ${args[11]} == "Plain" ]] || fail "notification wrapper still sends a plain toast"
-pass "notification wrapper omits the click hint when no command is given"
+pass "notification wrapper omits click and drag hints when neither is requested"
 
 # ------------------------------------------------ rest-of-line --exec is literal
 : >"$args_file"

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -218,13 +218,17 @@ const execSnapshot = notifications.snapshotOf({
   id: 3,
   appName: 'omarchy-action',
   summary: 'Download complete',
-  hints: { 'omarchy-exec-argv': '["mpv","--","/tmp/clip.mp4"]' }
+  hints: {
+    'omarchy-exec-argv': '["mpv","--","/tmp/clip.mp4"]',
+    'omarchy-drag-file': '/tmp/clip.mp4'
+  }
 }, 1)
 assertEqual(
   execSnapshot.execArgv,
   '["mpv","--","/tmp/clip.mp4"]',
   'notifications carry the exec argv hint onto the snapshot'
 )
+assertEqual(execSnapshot.dragFile, '/tmp/clip.mp4', 'notifications carry the drag file hint onto the snapshot')
 
 assertDeepEqual(
   notifications.popupPlacement('top', 32, 6),
@@ -266,7 +270,7 @@ const notification = {
   summary: 42,
   body: 'Body',
   image: 'file:///tmp/mail.png',
-  hints: { 'omarchy-glyph': '!' },
+  hints: { 'omarchy-glyph': '!', 'omarchy-drag-file': '/tmp/mail.png' },
   urgency: 1,
   expireTimeout: 1.5
 }
@@ -281,6 +285,7 @@ assertDeepEqual(
     body: snapshot.body,
     image: snapshot.image,
     glyph: snapshot.glyph,
+    dragFile: snapshot.dragFile,
     urgency: snapshot.urgency,
     expireTimeout: snapshot.expireTimeout,
     timestamp: snapshot.timestamp
@@ -294,6 +299,7 @@ assertDeepEqual(
     body: 'Body',
     image: 'file:///tmp/mail.png',
     glyph: '!',
+    dragFile: '/tmp/mail.png',
     urgency: 1,
     expireTimeout: 1.5,
     timestamp: 12345
@@ -556,6 +562,14 @@ assertEqual(
   '["xdg-open","/tmp/received"]',
   'notifications keep the click argv on history rows'
 )
+assertEqual(
+  notifications.popupEntry(
+    JSON.parse(notifications.serializePopup({ id: 1, originalId: 1, timestamp: 5, dragFile: '/tmp/a b.png' }, 1)),
+    1
+  ).dragFile,
+  '/tmp/a b.png',
+  'notifications round-trip the drag file through popup files'
+)
 
 // Upgrade fail-closed: a popup persisted by a pre-upgrade shell carried its
 // click action as an `exec` shell string. After the update-triggered shell
@@ -714,6 +728,26 @@ assert(
 assert(
   /parseExecArgv\(entry \? entry\.execArgv : ""\)[\s\S]{0,200}?Util\.execArgv\(argv\)/.test(serviceQml),
   'notifications service runs the popup click argv itself instead of a libnotify action'
+)
+assert(
+  /required property string dragFile[\s\S]*?dragFile: cardSlot\.dragFile/.test(serviceQml),
+  'notifications service passes the drag file to popup cards'
+)
+assert(
+  /onFileDragFinished: service\.dismissPopup\(cardSlot\.index\)/.test(serviceQml),
+  'notifications dismiss a popup after its file drag finishes'
+)
+assert(
+  /Drag\.dragType: Drag\.Automatic[\s\S]*?"text\/uri-list"[\s\S]*?DragHandler/.test(cardQml),
+  'notification cards expose marked files through native drag-and-drop'
+)
+assert(
+  /Drag\.supportedActions: Qt\.CopyAction \| Qt\.MoveAction[\s\S]{0,100}?Drag\.proposedAction: Qt\.MoveAction/.test(cardQml),
+  'notification cards prefer moving files while allowing copy-only targets'
+)
+assert(
+  /Drag\.onDragFinished: root\.fileDragFinished\(\)/.test(cardQml),
+  'notification cards report completed drags even when a Wayland target returns IgnoreAction'
 )
 assert(
   /function clear\(\): string \{\s*service\.clearHistory\(\)/.test(serviceQml),

--- a/test/shell.d/screenshot-test.sh
+++ b/test/shell.d/screenshot-test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mock_bin="$tmpdir/bin"
+notification_args="$tmpdir/notification-args"
+mkdir -p "$mock_bin" "$tmpdir/home"
+
+cat >"$mock_bin/pkill" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+
+cat >"$mock_bin/hyprctl" <<'EOF'
+#!/bin/bash
+if [[ ${1:-} == "getoption" ]]; then
+  printf '{"int":0}\n'
+fi
+EOF
+
+cat >"$mock_bin/omarchy-capture-region" <<'EOF'
+#!/bin/bash
+printf '\n0,0 10x10\n'
+EOF
+
+cat >"$mock_bin/grim" <<'EOF'
+#!/bin/bash
+output=${@: -1}
+printf 'fake png' >"$output"
+EOF
+
+cat >"$mock_bin/wl-copy" <<'EOF'
+#!/bin/bash
+cat >/dev/null
+EOF
+
+cat >"$mock_bin/omarchy-notification-send" <<'EOF'
+#!/bin/bash
+printf '%s\0' "$@" >"$OMARCHY_TEST_NOTIFICATION_ARGS"
+EOF
+
+chmod +x "$mock_bin"/*
+
+output=$(HOME="$tmpdir/home" OMARCHY_TEST_NOTIFICATION_ARGS="$notification_args" \
+  PATH="$mock_bin:$ROOT/bin:/usr/bin" OMARCHY_SCREENSHOT_EDITOR=test-editor \
+  "$ROOT/bin/omarchy-capture-screenshot")
+
+[[ -f $output ]] || fail "screenshot creates the file announced on stdout" "$output"
+mapfile -d '' -t args <"$notification_args"
+
+image_path=
+drag_path=
+editor=
+editor_path=
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case ${args[i]} in
+  --image) image_path=${args[i + 1]:-} ;;
+  --drag-file) drag_path=${args[i + 1]:-} ;;
+  --exec)
+    editor=${args[i + 1]:-}
+    editor_path=${args[i + 2]:-}
+    ;;
+  esac
+done
+
+[[ $image_path == "$output" ]] || fail "screenshot uses the saved file as the notification image" "$image_path"
+[[ $drag_path == "$output" ]] || fail "screenshot offers the saved file for notification dragging" "$drag_path"
+[[ $editor == "test-editor" && $editor_path == "$output" ]] || fail "screenshot keeps click-to-edit alongside dragging"
+pass "screenshots notify with one file for the thumbnail, drag payload, and editor action"


### PR DESCRIPTION
## Summary

- add a `--drag-file` notification option carried through the `omarchy-drag-file` D-Bus hint
- expose marked notification files through native Wayland drag-and-drop with move/copy negotiation
- make screenshot notifications draggable and dismiss them when dragging finishes
- document the screenshot drag workflow

## Testing

- `./test/cli`
- `bash test/shell.d/notification-send-test.sh`
- `bash test/shell.d/notifications-test.sh`
- `bash test/shell.d/screenshot-test.sh`
- manually verified drops into Ghostty, Chromium, and Files on the running desktop