### PR TITLE
Let users disable the bar transparency double-click gesture

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -7,6 +7,7 @@
   "bar": {
     "position": "top",
     "transparent": false,
+    "transparencyToggle": true,
     "centerAnchor": "omarchy.clock",
     "layout": {
       "left": [

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -140,6 +140,7 @@ string on a miss.
     "id": "omarchy.bar",
     "position": "top",
     "transparent": false,
+    "transparencyToggle": true,
     "centerAnchor": "omarchy.clock",
     "layout": {
       "left":   [ { "id": "omarchy.menu" } ],

--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -80,7 +80,7 @@ If you'd rather they were always visible, set `alwaysShow` to `true` on the widg
 
 The bar configures itself. You don't have to open a config file to move things.
 
-Grab an empty patch of the bar around the center and drag it toward another screen edge, and the bar moves there — left, right, top, or bottom all work, and every widget adapts (vertical bars fall back to compact icon-only forms). A click-and-hold starts the same drag. Double-left-click that same empty space to toggle transparency. And drag any widget to reorder it or throw it into another section.
+Grab an empty patch of the bar around the center and drag it toward another screen edge, and the bar moves there — left, right, top, or bottom all work, and every widget adapts (vertical bars fall back to compact icon-only forms). A click-and-hold starts the same drag. Double-left-click that same empty space to toggle transparency. And drag any widget to reorder it or throw it into another section. If you never want the gesture, set `transparencyToggle` to `false` under `bar:` in `~/.config/omarchy/shell.json`.
 
 If you'd rather pick from a menu, **Style → Menu Bar** has both position and transparency.
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -242,6 +242,7 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
     "id": "omarchy.bar",
     "position": "top",
     "transparent": false,
+    "transparencyToggle": true,
     "centerAnchor": "omarchy.clock",
     "layout": {
       "left":   [ { "id": "omarchy.menu" }, { "id": "omarchy.workspaces" } ],

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -36,12 +36,14 @@ Item {
   property var fallbackBarConfig: ({
     position: "top",
     transparent: false,
+    transparencyToggle: true,
     centerAnchor: "omarchy.clock",
     layout: { left: [], center: [], right: [] }
   })
   property var layoutConfig: fallbackBarConfig.layout
   property string centerAnchor: ""
   property bool requestedTransparent: false
+  property bool transparencyToggle: true
   property bool useTransparentForeground: false
   property bool transparent: false
   property bool centerSectionHovered: false
@@ -357,6 +359,7 @@ Item {
 
     position = normalizePosition(config.position)
     setRequestedTransparency(config.transparent === true)
+    transparencyToggle = config.transparencyToggle !== false
     centerAnchor = Util.canonicalWidgetId(config.centerAnchor || "")
 
     // layoutEntries feeds plain JS arrays to the module Repeaters, and QML
@@ -1479,7 +1482,7 @@ Item {
         suppressClick = false
         return
       }
-      if (mouse.button === Qt.LeftButton) {
+      if (root.transparencyToggle && mouse.button === Qt.LeftButton) {
         root.toggleTransparency()
         mouse.accepted = true
       }

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -16,7 +16,7 @@ the shell for its whole session.
 
 The bar config lives under the `bar:` key of [`~/.config/omarchy/shell.json`](../../README.md#shelljson-shape). Out of the box the shell uses [`config/omarchy/shell.json`](../../../config/omarchy/shell.json). Once you customize anything via the bar gestures, `omarchy bar ...`, or by editing shell.json directly, your file is canonical — there is no deep-merge.
 
-The bar is configured directly on the bar itself: drag empty bar space (or click-and-hold) to move the bar to another screen edge, double-left-click empty center-bar space to toggle transparency, and drag widgets to reorder them. The `omarchy bar position`, `omarchy bar transparent`, `omarchy bar move`, and `omarchy bar set` commands do the same from scripts. Enable or disable widgets with `omarchy plugin enable` and `omarchy plugin disable` (widget ids come from `omarchy plugin list`).
+The bar is configured directly on the bar itself: drag empty bar space (or click-and-hold) to move the bar to another screen edge, double-left-click empty center-bar space to toggle transparency, and drag widgets to reorder them. Set `transparencyToggle` to `false` in the bar config to disable the double-click gesture. The `omarchy bar position`, `omarchy bar transparent`, `omarchy bar move`, and `omarchy bar set` commands do the same from scripts. Enable or disable widgets with `omarchy plugin enable` and `omarchy plugin disable` (widget ids come from `omarchy plugin list`).
 
 Example `shell.json` (bar subtree only shown):
 

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -338,6 +338,20 @@ assert(
   'bar consults the inline settings delta before rebuilding the layout'
 )
 
+// Double-clicking empty bar space toggles transparency, but only when the
+// gesture is enabled: transparencyToggle false keeps the bar as configured
+// for users who always want it opaque.
+const gestureArea = barSource.slice(barSource.indexOf('component CenterGestureArea'))
+const gestureBody = gestureArea.slice(0, gestureArea.indexOf('\n  }\n'))
+assert(
+  /if \(root\.transparencyToggle && mouse\.button === Qt\.LeftButton\)/.test(gestureBody),
+  'double-click toggles transparency only when the gesture is enabled'
+)
+assert(
+  /transparencyToggle = config\.transparencyToggle !== false/.test(barSource),
+  'the transparency gesture stays on unless the config turns it off'
+)
+
 assertEqual(bar.moduleString({ id: 'custom', label: 42 }, 'label', 'fallback'), '42', 'bar stringifies module settings')
 assertEqual(bar.entryIndex(entries, 'b'), 2, 'bar finds entry indexes')
 assertDeepEqual(bar.entriesBefore(entries, 'b').map(bar.entryId), ['a', 'omarchy.tray'], 'bar returns entries before target')


### PR DESCRIPTION
Follows up on #9932.

Double-left-clicking empty bar space toggles transparency with no way to opt out, and it's easy to trigger accidentally. This adds a `transparencyToggle` bar option (default `true`) so `{"bar": {"transparencyToggle": false}}` leaves the bar as configured.

- shell/plugins/bar/Bar.qml: new property, read in applyBarConfig via `config.transparencyToggle !== false` (no deep-merge, so the default lives in code), honored by the CenterGestureArea double-click handler
- config/omarchy/shell.json, shell/README.md, docs/omarchy-shell.md: documented in the bar config shape
- shell/plugins/bar/README.md, manual/05-the-top-bar.md: gesture docs mention the opt-out
- test/shell.d/bar-test.sh: asserts the gesture is gated and defaults on

Tests: bar-test.sh fully green, including the two new assertions. ./test/all shows only the 5 failures that also fail on untouched quattro (agent-usage collectors x2, plus 3 needing an omarchy-pkgs checkout). Not visually verified in a running shell beyond config-level checks; the change is one boolean guard on an existing gesture.