### PR TITLE
Refresh Claude usage after the clock moves backwards

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -219,12 +219,22 @@ def scan_cache_paths(projects_path: Path) -> tuple[Path, Path]:
   return root / f"claude-scan-{digest}.json", root / f"claude-scan-{digest}.lock"
 
 
+def read_json(path: Path) -> dict[str, Any] | None:
+  try:
+    return json.loads(path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+
+
 def read_fresh_json(path: Path, max_age_seconds: float) -> dict[str, Any] | None:
   if max_age_seconds <= 0 or not path.exists():
     return None
   try:
-    if time.time() - path.stat().st_mtime <= max_age_seconds:
-      return json.loads(path.read_text(encoding="utf-8"))
+    # A negative age means the mtime is in the future: the clock moved
+    # backwards since the write, so the cache's freshness cannot be trusted.
+    age = time.time() - path.stat().st_mtime
+    if 0 <= age <= max_age_seconds:
+      return read_json(path)
   except Exception:
     return None
   return None
@@ -798,7 +808,7 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
   # per flick, so recent probe results are reused for a short window — and
   # kept as the answer of record when a later probe fails.
   probe_cache = cache_root() / "claude-limits.json"
-  cached = read_fresh_json(probe_cache, float("inf")) or {}
+  cached = read_json(probe_cache) or {}
   fallback = usable_cached_limits(cached)
 
   # Probing needs a live token and only the Claude Code CLI can mint one: it
@@ -824,7 +834,8 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
   # entirely; the interval is there to absorb repeated panel opens, not to
   # overrule someone who pressed refresh.
   fetched_at = number(cached.get("fetchedAtMs")) / 1000
-  if fallback and not force and time.time() - fetched_at < PROBE_MIN_INTERVAL_SECONDS:
+  fetched_age = time.time() - fetched_at
+  if fallback and not force and 0 <= fetched_age < PROBE_MIN_INTERVAL_SECONDS:
     result["limits"] = fallback
     return result
 

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -81,8 +81,8 @@ trap 'rm -rf "$CACHE_HOME"' EXIT
 
 collect_limits() {
   COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="$1" EXPIRES_AT="$2" CACHED="$3" \
-    XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
-import importlib.machinery, importlib.util, json, os, pathlib
+    CACHE_MTIME_OFFSET="${4:-0}" XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
+import importlib.machinery, importlib.util, json, os, pathlib, time
 
 loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -93,6 +93,10 @@ cache = collector.cache_root() / "claude-limits.json"
 cached = os.environ["CACHED"]
 if cached:
   cache.write_text(cached, encoding="utf-8")
+  offset = float(os.environ["CACHE_MTIME_OFFSET"])
+  if offset:
+    timestamp = time.time() + offset
+    os.utime(cache, (timestamp, timestamp))
 elif cache.exists():
   cache.unlink()
 
@@ -146,6 +150,14 @@ signed_out=$(collect_limits "" 0 "$cache")
   fail "Claude collector serves open cached windows without a token" "$signed_out"
 pass "Claude collector serves open cached windows without a token"
 
+# The limits cache is a last-known fallback governed by each window's reset
+# time, not by the file's age. A backwards clock correction must not discard
+# an otherwise open fallback when no token is available to replace it.
+future_fallback=$(collect_limits "" 0 "$cache" 3600)
+[[ $(jq -c '[.limits[].label]' <<<"$future_fallback") == '["Weekly (7-day)"]' ]] ||
+  fail "Claude collector keeps open fallback limits after a backwards clock correction" "$future_fallback"
+pass "Claude collector keeps open fallback limits after a backwards clock correction"
+
 # A live token that cannot reach the endpoint keeps the old contract: the open
 # window stands in, and the shell is asked to retry sooner than its interval.
 unreachable=$(collect_limits "token" 0 "$cache")
@@ -158,9 +170,9 @@ pass "Claude collector falls back to cache when the probe cannot connect"
 # Reuse and --force are decided against a cache that is fresh by the clock, so
 # the probe is answered rather than refused: what matters is whether it ran.
 probe_with_cache() {
-  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" FORCE="$1" CACHED="$2" PAYLOAD="$3" \
+  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" FORCE="$1" CACHED="$2" PAYLOAD="$3" CACHE_MTIME_OFFSET="${4:-0}" \
     XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
-import importlib.machinery, importlib.util, io, json, os
+import importlib.machinery, importlib.util, io, json, os, time
 
 loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -169,6 +181,10 @@ loader.exec_module(collector)
 
 cache = collector.cache_root() / "claude-limits.json"
 cache.write_text(os.environ["CACHED"], encoding="utf-8")
+offset = float(os.environ["CACHE_MTIME_OFFSET"])
+if offset:
+  timestamp = time.time() + offset
+  os.utime(cache, (timestamp, timestamp))
 
 probes = []
 
@@ -197,6 +213,27 @@ reused=$(probe_with_cache false "$fresh" "$payload")
 [[ $(jq -r '.probes' <<<"$reused") == "0" && $(jq -c '[.result.limits[].percent]' <<<"$reused") == "[0.11]" ]] ||
   fail "Claude collector reuses a cache younger than the probe interval" "$reused"
 pass "Claude collector reuses a cache younger than the probe interval"
+
+# An early boot probe can be stamped ahead of corrected wall time when NTP
+# moves the clock backwards. That cache must not suppress live probes until
+# the clock catches up.
+future=$(jq -nc --arg open "$open_at" --argjson future "$(python3 -c 'import time; print(round((time.time() + 3600) * 1000))')" '{
+  fetchedAtMs: $future,
+  limits: [{ label: "Weekly (7-day)", percent: 0.11, resetsAt: $open }]
+}')
+
+# If the clock correction makes a probe necessary but that probe cannot
+# connect, the cache remains the last-known answer. Its reset time, rather than
+# its future mtime, decides whether the fallback is still usable.
+future_unreachable=$(collect_limits "token" 0 "$future" 3600)
+[[ $(jq -c '[.limits[].percent]' <<<"$future_unreachable") == "[0.11]" && $(jq -r '.retryAdvised' <<<"$future_unreachable") == "true" ]] ||
+  fail "Claude collector keeps future-dated fallback when the re-probe fails" "$future_unreachable"
+pass "Claude collector keeps future-dated fallback when the re-probe fails"
+
+corrected=$(probe_with_cache false "$future" "$payload" 3600)
+[[ $(jq -r '.probes' <<<"$corrected") == "1" && $(jq -c '[.result.limits[].percent]' <<<"$corrected") == "[0.44]" ]] ||
+  fail "Claude collector re-probes after a backwards clock correction" "$corrected"
+pass "Claude collector re-probes after a backwards clock correction"
 
 # --force is someone pressing refresh, and its help text promises the caches are
 # ignored — so the reuse window must not outrank it.

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -33,6 +33,22 @@ pass "Claude collector keeps mutually exclusive token categories"
   fail "Claude collector identifies itself and reports missing auth" "$result"
 pass "Claude collector identifies itself and reports missing auth"
 
+# A cache stamped in the future can happen when NTP moves the clock backwards
+# after an early boot scan. Its age is not trustworthy, so it must be a miss
+# rather than freezing the usage snapshot until wall time catches up.
+cat >>"$projects/session.jsonl" <<EOF
+{"timestamp":"$timestamp","type":"assistant","sessionId":"session-1","uuid":"event-4","message":{"id":"message-3","role":"assistant","model":"claude-test","usage":{"input_tokens":7,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":3}}}
+EOF
+cache_file=$(find "$TEST_HOME/.cache/omarchy/agent-usage" -name 'claude-scan-*.json' -print -quit)
+touch -d "@$(( $(date +%s) + 3600 ))" "$cache_file"
+
+result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude")
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "58803" ]] ||
+  fail "Claude collector treats a future-dated scan cache as a miss" "$result"
+pass "Claude collector treats a future-dated scan cache as a miss"
+
 # A machine with no transcripts and no stats-cache still gets today's counts
 # from history.jsonl alone.
 HISTORY_HOME=$(mktemp -d)


### PR DESCRIPTION
Fixes #9955.

After a reboot the Agents panel showed Claude at Session 0% for two hours, with the local Claude Code stats frozen as well. The automatic refreshes ran the whole time. Only `--force` got fresh numbers, and the panel recovered by itself once wall time caught up.

The machine boots with its clock two hours ahead (the CMOS clock holds local time, a dual-boot side effect) and systemd-timesyncd steps it back about 75 seconds in. The shell starts at 52 seconds and the agents plugin collects on start, so the first `omarchy-agent-usage-claude` run stamps every cache two hours into the future. Both readers then accept a negative age:

```python
if time.time() - path.stat().st_mtime <= max_age_seconds:
```

```python
if fallback and not force and time.time() - fetched_at < PROBE_MIN_INTERVAL_SECONDS:
```

A negative number is below every positive bound. The scan cache is fresh until its future mtime plus the TTL, and the limits throttle skips the probe until the future `fetchedAtMs` plus 15 seconds. #6780 closed the same hole in the Codex scan cache.

Claude needs a slightly different fix, because `claude-limits.json` does two jobs. It is the 15-second probe throttle, and since #6795 it is the last-known fallback that keeps still-open windows visible when the token is missing, expired, or the endpoint is unreachable. A blanket future-mtime rejection would fix the throttle and lose the fallback. So the two policies are now separate:

- `read_fresh_json` requires `0 <= age <= max_age`, the same guard and comment as the Codex collector. This covers the transcript, pi/omp, and opencode scan caches.
- The limits cache is read with no age check at all (`read_json`). Its windows retire on their own `resetsAt`, as before.
- The probe throttle applies only when `0 <= now - fetchedAt < 15 s`.
- `--force` is unchanged.

The RTC setup that exposed this is deliberately not part of the change. Any backwards correction hits the same comparisons.

## Verification

Four new assertions, all against temp homes with `urlopen` stubbed:

- append a transcript record, future-date the scan cache: the new record is counted (58,793 becomes 58,803)
- future-date the limits cache and `fetchedAtMs` with a live token: one probe, the probe's numbers returned
- same cache, endpoint unreachable: the cached window is returned and `retryAdvised` is set, which proves the probe ran
- future-dated limits cache, no token: the open window is still served. This is the case an mtime-only guard would break.

On the unpatched collector the scanner suite fails at the first case and the limits suite at the unreachable case. With the patch: scanner 9/9, limits 17/17, codex 21/21. `./test/all` runs all 226 files; the only three failures need the separate `omarchy-pkgs` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
