### PR TITLE
Drop destroyed PipeWire nodes before they reach the audio panel's repeaters

### DIFF
--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -18,8 +18,34 @@ function isAudioSource(node) {
     || mediaClass.indexOf("Source") !== -1
 }
 
-function listSnapshot(list) {
-  return list && list.slice ? list.slice() : []
+// PipeWire can destroy a PwNode while the panel still holds a reference to it:
+// during a service restart, or on any graph churn that re-enumerates devices.
+// A destroyed node left in a Repeater's model is dereferenced as a null
+// QObject* while the delegate is incubated -- qtdeclarative's
+// qqmldmlistaccessordata_p.h:222 calls row->value<QObject *>()->metaObject()
+// with no null guard -- and the shell segfaults.
+//
+// Keeping only the nodes PipeWire still lists drops those references before
+// they can reach a Repeater. Membership is an identity comparison, so it is
+// safe to test on a node that is already gone.
+function liveNodeSnapshot(list, liveNodes) {
+  if (!list || !list.length) return []
+  if (!liveNodes || !liveNodes.length) return []
+
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var node = list[i]
+    if (!node) continue
+    // Indexed access only: the live list arrives as a QML sequence type, which
+    // is not guaranteed to carry Array.prototype methods such as indexOf.
+    for (var j = 0; j < liveNodes.length; j++) {
+      if (liveNodes[j] === node) {
+        out.push(node)
+        break
+      }
+    }
+  }
+  return out
 }
 
 function outputVolumeName(volume, muted) {
@@ -237,7 +263,7 @@ if (typeof module !== "undefined") {
   module.exports = {
     isPlaybackStream: isPlaybackStream,
     isAudioSource: isAudioSource,
-    listSnapshot: listSnapshot,
+    liveNodeSnapshot: liveNodeSnapshot,
     outputVolumeName: outputVolumeName,
     parseSinkAvailability: parseSinkAvailability,
     friendlyDeviceLabel: friendlyDeviceLabel,

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -324,8 +324,12 @@ Panel {
   onAudioSourcesChanged: scheduleDisplayAudioModelRefresh()
   onAudioStreamsChanged: scheduleDisplayAudioModelRefresh()
 
+  // Snapshots are taken against the live PipeWire node list so that a node
+  // destroyed since the list was built -- most often one still held by
+  // cachedAudioSinks/cachedAudioSources after a PipeWire restart -- never
+  // reaches a Repeater delegate. See Model.liveNodeSnapshot.
   function listSnapshot(list) {
-    return Model.listSnapshot(list)
+    return Model.liveNodeSnapshot(list, nodes)
   }
 
   function refreshDisplayAudioModels() {

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -46,4 +46,18 @@ assertEqual(audio.matchingMprisStreamLabel('Chromium', players), 'Chromium', 'au
 assertEqual(audio.unmatchedMprisStreamLabel('audio-src', players, streams), 'Spotify', 'audio uses unmatched MPRIS player for generic streams')
 assertEqual(audio.streamLabel(streams[1], players, streams), 'Spotify', 'audio labels generic streams from MPRIS')
 assert(audio.streamRepresentsPlayer(streams[1], players[0], players, streams), 'audio links generic streams to active player')
+
+// A PwNode destroyed by PipeWire must never survive into a Repeater's model:
+// Qt dereferences it as a null QObject* during delegate incubation and the
+// shell segfaults (basecamp/omarchy#9914, #9647, #9256).
+const speakers = { name: 'alsa_output' }
+const headset = { name: 'bluez_output' }
+const destroyed = { name: 'raop_sink' }
+
+assertDeepEqual(audio.liveNodeSnapshot([speakers, headset], [speakers, headset]), [speakers, headset], 'audio keeps nodes PipeWire still lists')
+assertDeepEqual(audio.liveNodeSnapshot([speakers, destroyed], [speakers, headset]), [speakers], 'audio drops nodes PipeWire has destroyed')
+assertDeepEqual(audio.liveNodeSnapshot([speakers, destroyed], []), [], 'audio empties the snapshot when PipeWire drops every node')
+assertDeepEqual(audio.liveNodeSnapshot([null, speakers], [speakers]), [speakers], 'audio drops null entries')
+assertDeepEqual(audio.liveNodeSnapshot(null, [speakers]), [], 'audio tolerates a missing list')
+assertDeepEqual(audio.liveNodeSnapshot([speakers], null), [], 'audio tolerates a missing live node list')
 JS


### PR DESCRIPTION
Fixes the SIGSEGV reported in #6952, #9914, #9647 and #9256 — four open issues that are the same crash seen from four different triggers (a USB DAC timing out, a PipeWire restart, an ALSA capture device going busy, and plain graph churn).

## The crash

When PipeWire restarts, or any graph churn re-enumerates devices, Quickshell destroys the `PwNode` objects backing the audio panel. `rawAudioSinks` goes empty, `audioSinks` falls back to `cachedAudioSinks`, and that cache still references the destroyed nodes. `listSnapshot()` was a bare `list.slice()`, so those dangling references were copied straight into `displayAudioSinks` and handed to a `Repeater`. Regenerating it dereferences them as a null `QObject*` during delegate incubation:

```
VDMListDelegateDataType::createMissingProperties
  qtdeclarative/src/qmlmodels/qqmldmlistaccessordata_p.h:222

  const QMetaObject *metaObject = row->value<QObject *>()->metaObject();
```

That line has no null guard, so the shell segfaults. Upstream could harden it, but the dangling reference is ours.

The 75 ms snapshot timer debounces the *list* mutation, which is what the comment at `Panel.qml:103` is about — but it never detached the *elements*. That is the gap this closes.

## The fix

Snapshots are taken against the live PipeWire node list, so a node that is already gone cannot reach a delegate. Membership is an identity comparison and never dereferences the candidate, which is what makes it safe to test on a node that may already be destroyed.

## Behaviour change

The cached fallback no longer serves nodes PipeWire has dropped, so on a full restart the device list is briefly empty rather than showing stale entries. It repopulates on the next refresh. Showing devices that no longer exist is what crashed, so I think empty is the correct trade — but it is a visible change and worth a maintainer's opinion.

## Testing

**Crash reproduced, and confirmed fixed.** On Omarchy 4.0.1-1 / Quickshell 0.3.1 / Qt 6.11.2, in an isolated shell config that mirrors the panel's shape — a `Repeater` over a plain array of `PwNode`s whose delegate declares `required property var modelData` — with `systemctl --user restart pipewire wireplumber` as the trigger:

| | before restart | after restart | assigning stale cache | result |
|---|---|---|---|---|
| `listSnapshot()` (old) | 9 nodes cached | 11 new live nodes | — | **SIGSEGV**, execution never reaches the next statement |
| `liveNodeSnapshot()` (new) | 11 nodes cached | 11 new live nodes | 0 rows survive the filter | clean exit, no crash |

The old run logged `Quickshell has crashed under pid …`; the new run logged `assigned_rows: 0` and exited 0.

<details>
<summary>Harness used (drop in a directory as <code>shell.qml</code> alongside <code>Model.js</code>, run <code>quickshell -n -p &lt;dir&gt;</code>)</summary>

```qml
import QtQuick
import Quickshell
import Quickshell.Services.Pipewire
import "Model.js" as Model

ShellRoot {
  id: root
  property var cache: []
  property var displayList: []

  PwObjectTracker { objects: Pipewire.nodes ? Pipewire.nodes.values : [] }

  Item {
    Repeater {
      model: root.displayList
      delegate: Item { required property var modelData }
    }
  }

  Timer { interval: 3000; running: true; onTriggered: {
    root.cache = Pipewire.nodes.values.slice()
    console.log("PWTEST cached_nodes:", root.cache.length)
  } }

  Timer { interval: 4000; running: true; onTriggered: {
    Quickshell.execDetached(["systemctl", "--user", "restart", "pipewire", "wireplumber"])
  } }

  Timer { interval: 9000; running: true; onTriggered: {
    console.log("PWTEST live_nodes_now:", Pipewire.nodes.values.length)
    root.displayList = Model.liveNodeSnapshot(root.cache, Pipewire.nodes.values)
    console.log("PWTEST assigned_rows:", root.displayList.length)
  } }

  Timer { interval: 11000; running: true; onTriggered: { console.log("PWTEST SURVIVED"); Qt.callLater(Qt.quit) } }
}
```

Swap the assignment for `Model.listSnapshot(root.cache)` against the pre-patch `Model.js` to reproduce the crash.
</details>

**Unit tests.** `test/shell.d/audio-test.sh` gains six cases: live nodes, destroyed nodes, a fully emptied graph, null entries, and both missing-argument paths. Whole file passes.

**Suite.** `test/shell` — 223/226 files pass. The three failures (`config`, `snapper`, `unowned-system-paths`) fail identically on a clean checkout here, so they are pre-existing and environment-sensitive.

**Also verified** that `Pipewire.nodes.values` returns identical JS wrappers for the same `PwNode` across separate accesses, and rejects foreign objects — the assumption the membership test rests on.

**Not done:** verification inside the running shell via `omarchy dev link`, which needs a reboot. The harness above exercises the same code path, delegate shape and trigger.

## Origin

Diagnosed from a `systemd-coredump` core after `pipewire`, `wireplumber` and `pipewire-pulse` were restarted with the audio panel open — the exact reproduction in #9914. Symbolized stack matches #9647 and #6952 frame for frame.

## Related PRs

#7783 targets the same defect from the other direction — primitive `{id, name}` rows resolved through a `nodeFor()` lookup, the pattern `plugins/bluetooth/Model.js` already uses. That is immune by construction rather than by call-path analysis, at the cost of a much larger diff. Which shape the repo wants is a maintainer's call; I am not touching that PR.

#9808 deduplicates `rawAudioSinks`/`rawAudioSources` by name. It is upstream of this snapshot rather than in competition with it, but it will conflict textually in `Model.js`'s exports block and at the end of `audio-test.sh`. Happy to rebase behind it if it lands first.

> Authored by Claude Opus 5 via Claude Code.
