### PR TITLE
Move resolved DNS to drop-in with DHCP fallback

### DIFF
--- a/bin/omarchy-dns
+++ b/bin/omarchy-dns
@@ -19,6 +19,7 @@ if (( EUID == 0 )); then
 fi
 
 NM_DNS_CONF=/etc/NetworkManager/conf.d/20-omarchy-dns.conf
+RESOLVED_DNS_CONF=/etc/systemd/resolved.conf.d/20-omarchy-dns.conf
 
 provider_from_arg() {
   case "${1:-}" in
@@ -94,7 +95,7 @@ resolved_dns() {
       print value
       exit
     }
-  ' /etc/systemd/resolved.conf 2>/dev/null || true
+  ' "$RESOLVED_DNS_CONF" /etc/systemd/resolved.conf 2>/dev/null || true
 }
 
 current_dns_provider() {
@@ -163,6 +164,25 @@ EOF
 
 clear_networkmanager_dns() {
   rm -f "$NM_DNS_CONF"
+}
+
+write_resolved_dns() {
+  local dns="${1:-}"
+  local dot="${2:-opportunistic}"
+
+  install -d -m 0755 "$(dirname "$RESOLVED_DNS_CONF")"
+  # omarchy:heredoc-expands paths=none -- $dns and $dot are DNS settings written as data, not paths or commands; nothing user-writable is resolved or executed from the root-owned drop-in.
+  cat >"$RESOLVED_DNS_CONF" <<EOF
+# Managed by omarchy-dns. Remove this file or run omarchy dns DHCP to use DHCP DNS again.
+[Resolve]
+DNS=$dns
+FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
+DNSOverTLS=$dot
+EOF
+}
+
+clear_resolved_dns() {
+  rm -f "$RESOLVED_DNS_CONF"
 }
 
 networkmanager_dns_connection() {
@@ -262,32 +282,19 @@ case "$provider" in
 Cloudflare)
   write_networkmanager_dns "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001"
   set_connection_dns "1.1.1.1 1.0.0.1" "2606:4700:4700::1111 2606:4700:4700::1001"
-  tee /etc/systemd/resolved.conf >/dev/null <<'EOF'
-[Resolve]
-DNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com
-FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
-DNSOverTLS=opportunistic
-EOF
+  write_resolved_dns "1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com" "opportunistic"
   ;;
 
 Google)
   write_networkmanager_dns "8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844"
   set_connection_dns "8.8.8.8 8.8.4.4" "2001:4860:4860::8888 2001:4860:4860::8844"
-  tee /etc/systemd/resolved.conf >/dev/null <<'EOF'
-[Resolve]
-DNS=8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google
-FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
-DNSOverTLS=opportunistic
-EOF
+  write_resolved_dns "8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google" "opportunistic"
   ;;
 
 DHCP)
   clear_networkmanager_dns
   clear_connection_dns
-  tee /etc/systemd/resolved.conf >/dev/null <<'EOF'
-[Resolve]
-DNSOverTLS=no
-EOF
+  write_resolved_dns "" "no"
   ;;
 
 Custom)
@@ -305,14 +312,7 @@ Custom)
   split_dns_servers "$dns_servers"
   write_networkmanager_dns "$dns_servers"
   set_connection_dns "$ipv4_dns" "$ipv6_dns"
-  # omarchy:heredoc-expands paths=none -- $dns_servers is a normalized,
-  # single-line DNS server list; the //,/ turns its comma separators into the
-  # spaces resolved.conf wants. It is written as data, not a path or command.
-  tee /etc/systemd/resolved.conf >/dev/null <<EOF
-[Resolve]
-DNS=${dns_servers//,/ }
-FallbackDNS=9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
-EOF
+  write_resolved_dns "${dns_servers//,/ }"
   ;;
 esac
 


### PR DESCRIPTION
### Motivation

Currently, `omarchy-dns` manages NetworkManager cleanly via a drop-in (`/etc/NetworkManager/conf.d/20-omarchy-dns.conf`), but overwrites `/etc/systemd/resolved.conf` directly using `tee`.

This presents two issues:
1. **Package conflicts and setting destruction:**
`/etc/systemd/resolved.conf` is tracked by Arch's `systemd` package. Direct overwrites trigger `.pacnew` churn during system updates and clobber any base host settings (e.g. `Cache=`, `DNSSEC=`, `MulticastDNS=`).

2. **Missing fallback in DHCP mode:**
While `Cloudflare`, `Google`, and `Custom` configure Quad9 as `FallbackDNS`, the `DHCP` case writes only `[Resolve]\nDNSOverTLS=no`. If DHCP-assigned upstream resolvers fail, return SERVFAIL, or hang, `systemd-resolved` is left without an upstream fallback.

---

### Changes

- **Drop-in Parity:**
Manage systemd-resolved settings through `/etc/systemd/resolved.conf.d/20-omarchy-dns.conf`, matching the pattern used by `/etc/NetworkManager/conf.d/20-omarchy-dns.conf` and `20-docker-dns.conf`.

- **FallbackDNS in DHCP:**
Retain Quad9 `FallbackDNS` in the drop-in when reverting to DHCP (`write_resolved_dns "" "no"`), while leaving `DNS=` unset so DHCP nameservers take priority.

- **Deduplication:**
Consolidate the four duplicated `tee` heredoc blocks into a unified `write_resolved_dns` helper annotated with `paths=none`.

- **Reading Logic:**
Update `resolved_dns()` to check `$RESOLVED_DNS_CONF` first, falling back t `/etc/systemd/resolved.conf` if absent.

---

### Verification

- **Environment:**
Omarchy Quattro `4.0.2-1` (systemd `261.2-1-arch`, Linux `7.1.9-arch1-2`)

Ran the test suite locally:
- `test/shell.d/dns-sudoers-test.sh`: **PASS**
- `test/shell.d/privileged-heredoc-test.sh`: **PASS**
- `test/shell.d/network-manager-transition-test.sh`: **PASS**
- `test/shell.d/menu-guards-test.sh`: **PASS**

Verified live switching between `Cloudflare`, `Google`, and `DHCP`:
- Verified drop-in file generation under `/etc/systemd/resolved.conf.d/20-omarchy-dns.conf`.
- Verified `resolvectl status` reflects active per-link DHCP and global fallback settings.
- Verified menu/panel state detection (`omarchy-dns`) returns expected provider names.