### PR TITLE
Show Bluetooth pairing codes in the Omarchy panel

### DIFF
--- a/bin/omarchy-bluetooth-agent
+++ b/bin/omarchy-bluetooth-agent
@@ -1,0 +1,369 @@
+#!/usr/bin/python
+
+# omarchy:hidden=true
+# omarchy:summary=Bridge BlueZ pairing prompts to the Bluetooth panel
+
+import json
+import os
+import signal
+import socket
+import sys
+
+from gi.repository import Gio, GLib, GLibUnix
+
+
+AGENT_PATH = "/org/omarchy/BluetoothAgent"
+CAPABILITY = "KeyboardDisplay"
+REQUEST_TIMEOUT = 30
+
+AGENT_XML = """
+<node>
+  <interface name="org.bluez.Agent1">
+    <method name="Release"/>
+    <method name="RequestPinCode">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="pincode" type="s" direction="out"/>
+    </method>
+    <method name="DisplayPinCode">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="pincode" type="s" direction="in"/>
+    </method>
+    <method name="RequestPasskey">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="passkey" type="u" direction="out"/>
+    </method>
+    <method name="DisplayPasskey">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="passkey" type="u" direction="in"/>
+      <arg name="entered" type="q" direction="in"/>
+    </method>
+    <method name="RequestConfirmation">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="passkey" type="u" direction="in"/>
+    </method>
+    <method name="RequestAuthorization">
+      <arg name="device" type="o" direction="in"/>
+    </method>
+    <method name="AuthorizeService">
+      <arg name="device" type="o" direction="in"/>
+      <arg name="uuid" type="s" direction="in"/>
+    </method>
+    <method name="Cancel"/>
+  </interface>
+</node>
+"""
+
+
+class BluetoothAgent:
+    def __init__(self):
+        self.loop = GLib.MainLoop()
+        self.connection = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+        self.interface = Gio.DBusNodeInfo.new_for_xml(AGENT_XML).interfaces[0]
+        self.object_id = self.connection.register_object_with_closures2(
+            AGENT_PATH, self.interface, self._method_call, None, None
+        )
+
+        self.pending = {}
+        self.next_request_id = 1
+        self._register_with_bluez()
+
+        self.clients = {}
+        self.server = self._create_server()
+        self.server_watch = GLibUnix.fd_add_full(
+            GLib.PRIORITY_DEFAULT,
+            self.server.fileno(),
+            GLib.IOCondition.IN,
+            self._accept_client,
+        )
+
+    @property
+    def socket_path(self):
+        return self._socket_path
+
+    def _create_server(self):
+        runtime_dir = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        directory = os.path.join(runtime_dir, "omarchy")
+        os.makedirs(directory, mode=0o700, exist_ok=True)
+        os.chmod(directory, 0o700)
+        self._socket_path = os.path.join(directory, "bluetooth-agent.sock")
+        try:
+            os.unlink(self._socket_path)
+        except FileNotFoundError:
+            pass
+
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(self._socket_path)
+        os.chmod(self._socket_path, 0o600)
+        server.listen(1)
+        server.setblocking(False)
+        return server
+
+    def _register_with_bluez(self):
+        self.connection.call_sync(
+            "org.bluez",
+            "/org/bluez",
+            "org.bluez.AgentManager1",
+            "RegisterAgent",
+            GLib.Variant("(os)", (AGENT_PATH, CAPABILITY)),
+            None,
+            Gio.DBusCallFlags.NONE,
+            -1,
+            None,
+        )
+        self.connection.call_sync(
+            "org.bluez",
+            "/org/bluez",
+            "org.bluez.AgentManager1",
+            "RequestDefaultAgent",
+            GLib.Variant("(o)", (AGENT_PATH,)),
+            None,
+            Gio.DBusCallFlags.NONE,
+            -1,
+            None,
+        )
+
+    @staticmethod
+    def _address(device_path):
+        marker = "/dev_"
+        if marker not in device_path:
+            return ""
+        return device_path.rsplit(marker, 1)[1].replace("_", ":")
+
+    def _event(self, event, device="", **values):
+        payload = {
+            "event": event,
+            "device": device,
+            "address": self._address(device),
+        }
+        payload.update(values)
+        self._send(payload)
+
+    def _send(self, payload):
+        if not self.clients:
+            return False
+        delivered = False
+        try:
+            data = (json.dumps(payload, separators=(",", ":")) + "\n").encode()
+            for client in list(self.clients):
+                try:
+                    client.sendall(data)
+                    delivered = True
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    self._drop_client(client)
+        except OSError:
+            return delivered
+        return delivered
+
+    def _accept_client(self, _fd, condition):
+        if condition & (GLib.IOCondition.ERR | GLib.IOCondition.HUP | GLib.IOCondition.NVAL):
+            return GLib.SOURCE_CONTINUE
+        try:
+            client, _ = self.server.accept()
+        except BlockingIOError:
+            return GLib.SOURCE_CONTINUE
+        client.setblocking(False)
+        self.clients[client] = {"buffer": b"", "watch": 0}
+        self.clients[client]["watch"] = GLibUnix.fd_add_full(
+            GLib.PRIORITY_DEFAULT,
+            client.fileno(),
+            GLib.IOCondition.IN | GLib.IOCondition.HUP | GLib.IOCondition.ERR,
+            self._read_client,
+            client,
+        )
+        return GLib.SOURCE_CONTINUE
+
+    def _read_client(self, _fd, condition, client):
+        if client not in self.clients:
+            return GLib.SOURCE_REMOVE
+        if condition & (GLib.IOCondition.HUP | GLib.IOCondition.ERR | GLib.IOCondition.NVAL):
+            self._drop_client(client)
+            return GLib.SOURCE_REMOVE
+        try:
+            data = client.recv(4096)
+        except BlockingIOError:
+            return GLib.SOURCE_CONTINUE
+        except OSError:
+            self._drop_client(client)
+            return GLib.SOURCE_REMOVE
+        if not data:
+            self._drop_client(client)
+            return GLib.SOURCE_REMOVE
+
+        client_buffer = self.clients[client]["buffer"] + data
+        while b"\n" in client_buffer:
+            line, client_buffer = client_buffer.split(b"\n", 1)
+            try:
+                message = json.loads(line.decode())
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            self._handle_response(message)
+        if client in self.clients:
+            self.clients[client]["buffer"] = client_buffer
+        return GLib.SOURCE_CONTINUE
+
+    def _drop_client(self, client):
+        item = self.clients.pop(client, None)
+        if item is None:
+            return
+        if item["watch"]:
+            GLib.source_remove(item["watch"])
+        try:
+            client.close()
+        except OSError:
+            pass
+        if not self.clients:
+            for request_id in list(self.pending):
+                self._finish(request_id, error="org.bluez.Error.Canceled")
+
+    def _new_request(self, kind, device, invocation, **values):
+        if not self.clients:
+            invocation.return_dbus_error("org.bluez.Error.Rejected", "Bluetooth panel is unavailable")
+            return
+        request_id = str(self.next_request_id)
+        self.next_request_id += 1
+        timer = GLib.timeout_add_seconds(REQUEST_TIMEOUT, self._timeout, request_id)
+        self.pending[request_id] = (kind, invocation, timer)
+        self._event(kind, device, id=request_id, **values)
+
+    def _timeout(self, request_id):
+        if request_id in self.pending:
+            self._event("timeout", id=request_id)
+            self._finish(request_id, error="org.bluez.Error.Rejected")
+        return GLib.SOURCE_REMOVE
+
+    def _handle_response(self, message):
+        request_id = str(message.get("id", ""))
+        if request_id not in self.pending:
+            return
+        response = message.get("response")
+        kind, _invocation, _timer = self.pending[request_id]
+        if kind == "request_passkey":
+            try:
+                value = int(str(response))
+            except (TypeError, ValueError):
+                return
+            if value < 0 or value > 999999:
+                return
+            self._finish(request_id, value=value)
+        elif kind == "request_pin_code":
+            if isinstance(response, str) and 1 <= len(response) <= 16:
+                self._finish(request_id, value=response)
+        elif kind in ("request_confirmation", "request_authorization"):
+            if response in ("yes", "accept", "confirm", True):
+                self._finish(request_id)
+            elif response in ("no", "reject", "cancel", False):
+                self._finish(request_id, error="org.bluez.Error.Rejected")
+
+    def _finish(self, request_id, value=None, error=None):
+        item = self.pending.pop(request_id, None)
+        if item is None:
+            return
+        kind, invocation, timer = item
+        GLib.source_remove(timer)
+        if error:
+            invocation.return_dbus_error(error, "Bluetooth pairing request was rejected")
+            return
+        if kind == "request_passkey":
+            invocation.return_value(GLib.Variant("(u)", (int(value),)))
+        elif kind == "request_pin_code":
+            invocation.return_value(GLib.Variant("(s)", (str(value),)))
+        else:
+            invocation.return_value(GLib.Variant("()", ()))
+
+    def _cancel_pending(self):
+        for request_id in list(self.pending):
+            self._finish(request_id, error="org.bluez.Error.Canceled")
+
+    def _method_call(
+        self, _connection, _sender, _object_path, _interface_name, method_name, parameters, invocation
+    ):
+        values = parameters.unpack()
+        if method_name == "Release":
+            invocation.return_value(GLib.Variant("()", ()))
+        elif method_name == "Cancel":
+            self._cancel_pending()
+            self._event("cancel")
+            invocation.return_value(GLib.Variant("()", ()))
+        elif method_name == "DisplayPasskey":
+            device, passkey, entered = values
+            self._event("display_passkey", device, passkey=f"{passkey:06d}", entered=entered)
+            invocation.return_value(GLib.Variant("()", ()))
+        elif method_name == "DisplayPinCode":
+            device, pincode = values
+            self._event("display_pin_code", device, pincode=pincode)
+            invocation.return_value(GLib.Variant("()", ()))
+        elif method_name == "RequestPasskey":
+            self._new_request("request_passkey", values[0], invocation)
+        elif method_name == "RequestPinCode":
+            self._new_request("request_pin_code", values[0], invocation)
+        elif method_name == "RequestConfirmation":
+            self._new_request(
+                "request_confirmation", values[0], invocation, passkey=f"{values[1]:06d}"
+            )
+        elif method_name == "RequestAuthorization":
+            self._new_request("request_authorization", values[0], invocation)
+        elif method_name == "AuthorizeService":
+            # BlueZ asks this after the user-approved pairing. HID and audio
+            # profiles should not require a second, confusing prompt.
+            invocation.return_value(GLib.Variant("()", ()))
+        else:
+            invocation.return_dbus_error("org.bluez.Error.Rejected", "Unsupported pairing request")
+
+    def run(self):
+        self.loop.run()
+
+    def close(self):
+        self._cancel_pending()
+        for client in list(self.clients):
+            self._drop_client(client)
+        try:
+            self.connection.call_sync(
+                "org.bluez",
+                "/org/bluez",
+                "org.bluez.AgentManager1",
+                "UnregisterAgent",
+                GLib.Variant("(o)", (AGENT_PATH,)),
+                None,
+                Gio.DBusCallFlags.NONE,
+                1000,
+                None,
+            )
+        except GLib.Error:
+            pass
+        if self.object_id:
+            self.connection.unregister_object(self.object_id)
+            self.object_id = 0
+        if self.server_watch:
+            GLib.source_remove(self.server_watch)
+            self.server_watch = 0
+        try:
+            self.server.close()
+        except OSError:
+            pass
+        try:
+            os.unlink(self.socket_path)
+        except FileNotFoundError:
+            pass
+
+
+def main():
+    try:
+        agent = BluetoothAgent()
+    except GLib.Error as error:
+        print(f"omarchy-bluetooth-agent: {error}", file=sys.stderr)
+        return 1
+
+    def stop(_signum, _frame):
+        agent.loop.quit()
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    try:
+        agent.run()
+    finally:
+        agent.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/default/systemd/user/bt-agent.service
+++ b/default/systemd/user/bt-agent.service
@@ -1,21 +1,21 @@
 [Unit]
-Description=Bluetooth pairing agent (auto-accept)
-Documentation=man:bt-agent(1)
+Description=Bluetooth pairing agent for the Omarchy panel
+Documentation=man:bluetoothd(8)
 ConditionPathIsDirectory=/sys/class/bluetooth
 # bluez must be reachable on the system bus before we can register.
-After=dbus.socket
+After=dbus.socket bluetooth.service
 Requires=dbus.socket
 
 [Service]
 Type=simple
+UMask=0077
+# bluez-tools' bt-agent can wait forever on its stdin during replacement.
+# Bound the handoff so the new Agent1 is registered promptly on upgrade.
+TimeoutStopSec=5s
 # If bluetoothd is unavailable (for example in VMs or machines without a
 # usable adapter), skip cleanly instead of entering a restart loop.
 ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service
-# NoInputNoOutput auto-accepts pair requests. Safe because the adapter
-# is only `pairable: true` when the user explicitly opens the omarchy
-# bluetoothPanel and starts scanning; outside that window bluez refuses
-# inbound pair attempts at a lower layer.
-ExecStart=/usr/bin/bt-agent -c NoInputNoOutput
+ExecStart=/usr/bin/omarchy-bluetooth-agent
 Restart=on-failure
 RestartSec=2
 

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -8,7 +8,6 @@ avahi
 bash-completion
 bat
 bluez
-bluez-tools
 bluez-utils
 bolt
 brightnessctl

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -21,6 +21,36 @@ Panel {
   // this map only keeps the panel responsive while BlueZ catches up.
   property var pendingActions: ({})
 
+  // The user agent owns BlueZ's interactive pairing methods. The panel talks
+  // to it over a per-user socket so passkeys never have to be scraped from a
+  // detached bluetoothctl process.
+  readonly property string agentSocketPath: (Quickshell.env("XDG_RUNTIME_DIR") || ("/run/user/" + (Quickshell.env("UID") || ""))) + "/omarchy/bluetooth-agent.sock"
+  property var authRequest: null
+  property string authInput: ""
+
+  Socket {
+    id: agentSocket
+    path: root.agentSocketPath
+    connected: true
+    parser: SplitParser {
+      splitMarker: "\n"
+      onRead: function(data) { root.handleAgentMessage(data) }
+    }
+    onConnectionStateChanged: if (!connected) agentReconnect.restart()
+    onError: function(error) { agentReconnect.restart() }
+  }
+
+  Timer {
+    id: agentReconnect
+    interval: 2000
+    repeat: true
+    running: !agentSocket.connected
+    onTriggered: {
+      agentSocket.connected = false
+      agentSocket.connected = true
+    }
+  }
+
   readonly property var adapter: Bluetooth.defaultAdapter
 
   // True while this instance owes BlueZ a StopDiscovery: set when it starts
@@ -265,6 +295,86 @@ Panel {
 
   function deviceCommand(action, address) {
     return ["omarchy-bluetooth-device", action, address]
+  }
+
+  function authDeviceLabel(request) {
+    var address = request && request.address ? request.address : ""
+    for (var i = 0; i < devices.length; i++) {
+      var device = devices[i]
+      if (device && device.address === address) return deviceLabel(device)
+    }
+    return address || "Bluetooth device"
+  }
+
+  function authMessage(request) {
+    if (!request) return ""
+    var label = authDeviceLabel(request)
+    if (request.event === "display_passkey") {
+      return label + "\n\nEnter this code on the device:\n\n" + request.passkey
+    }
+    if (request.event === "display_pin_code") {
+      return label + "\n\nEnter this code on the device:\n\n" + request.pincode
+    }
+    if (request.event === "request_confirmation") {
+      return label + "\n\nConfirm this passkey:\n\n" + request.passkey
+    }
+    if (request.event === "request_passkey") {
+      return label + "\n\nEnter the passkey, then choose Send:\n\n" + (authInput || "_")
+    }
+    if (request.event === "request_pin_code") {
+      return label + "\n\nEnter the PIN, then choose Send:\n\n" + (authInput || "_")
+    }
+    if (request.event === "request_authorization") return "Allow pairing with " + label + "?"
+    return ""
+  }
+
+  function authNeedsResponse() {
+    return authRequest && (authRequest.event === "request_confirmation"
+      || authRequest.event === "request_passkey"
+      || authRequest.event === "request_pin_code"
+      || authRequest.event === "request_authorization")
+  }
+
+  function clearAuthRequest() {
+    authRequest = null
+    authInput = ""
+  }
+
+  function authInputValid(response) {
+    if (!authRequest) return false
+    if (authRequest.event === "request_passkey") return /^\d{6}$/.test(String(response))
+    if (authRequest.event === "request_pin_code") return String(response).length > 0 && String(response).length <= 16
+    return true
+  }
+
+  function respondToAuth(response) {
+    if (!authRequest) return
+    if (!authInputValid(response)) return
+    if (authNeedsResponse() && authRequest.id !== undefined && agentSocket.connected) {
+      agentSocket.write(JSON.stringify({ id: String(authRequest.id), response: response }) + "\n")
+      agentSocket.flush()
+    }
+    clearAuthRequest()
+  }
+
+  function handleAgentMessage(data) {
+    var message
+    try {
+      message = JSON.parse(String(data))
+    } catch (error) {
+      return
+    }
+    if (!message || !message.event) return
+    if (message.event === "cancel" || message.event === "timeout") {
+      clearAuthRequest()
+      return
+    }
+    if (["display_passkey", "display_pin_code", "request_confirmation", "request_passkey", "request_pin_code", "request_authorization"].indexOf(message.event) < 0)
+      return
+    authRequest = message
+    authInput = ""
+    root.open()
+    Qt.callLater(function() { authDialog.forceActiveFocus() })
   }
 
   function runDeviceAction(device, action, pending) {
@@ -672,6 +782,7 @@ Panel {
     PanelKeyCatcher {
       id: keyCatcher
       anchors.fill: parent
+      blocked: root.authRequest !== null
       onMoveRequested: function(dx, dy) {
         if (!root.cursorActive) { root.cursorActive = true; return }
         if (dy !== 0) root.moveCursor(dy)
@@ -875,6 +986,47 @@ Panel {
           font.pixelSize: Style.font.bodySmall
           wrapMode: Text.WordWrap
           width: parent.width
+        }
+      }
+
+      ConfirmDialog {
+        id: authDialog
+        anchors.fill: parent
+        z: 10
+        opened: root.authRequest !== null
+        focus: opened
+        message: root.authMessage(root.authRequest)
+        cancelText: "Cancel"
+        confirmText: root.authRequest && root.authRequest.event.indexOf("display_") === 0 ? "Done"
+            : root.authRequest && root.authRequest.event.indexOf("request_") === 0 ? "Send" : "Allow"
+        selectedIndex: 1
+        onOpenedChanged: if (opened) forceActiveFocus()
+        onCanceled: {
+          if (root.authNeedsResponse()) root.respondToAuth("cancel")
+          else root.clearAuthRequest()
+        }
+        onConfirmed: {
+          if (root.authRequest && root.authRequest.event === "request_passkey") root.respondToAuth(root.authInput)
+          else if (root.authRequest && root.authRequest.event === "request_pin_code") root.respondToAuth(root.authInput)
+          else if (root.authRequest && root.authRequest.event === "request_confirmation") root.respondToAuth("yes")
+          else if (root.authRequest && root.authRequest.event === "request_authorization") root.respondToAuth("yes")
+          else root.clearAuthRequest()
+        }
+        Keys.onPressed: function(event) {
+          if (!root.authRequest) return
+          if ((root.authRequest.event === "request_passkey" || root.authRequest.event === "request_pin_code")
+              && event.text && event.text.length === 1 && event.text !== "\n") {
+            root.authInput += event.text
+            event.accepted = true
+            return
+          }
+          if ((root.authRequest.event === "request_passkey" || root.authRequest.event === "request_pin_code")
+              && event.key === Qt.Key_Backspace) {
+            root.authInput = root.authInput.slice(0, -1)
+            event.accepted = true
+            return
+          }
+          if (!authDialog.handleKey(event)) event.accepted = true
         }
       }
     }

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -12,9 +12,22 @@ run_node_test <<'JS'
 const fs = require('fs')
 const bluetooth = requireFromRoot('shell/plugins/panels/bluetooth/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/bluetooth/Panel.qml', 'utf8')
+const agentSource = fs.readFileSync(root + '/bin/omarchy-bluetooth-agent', 'utf8')
+const agentUnit = fs.readFileSync(root + '/default/systemd/user/bt-agent.service', 'utf8')
+const packages = fs.readFileSync(root + '/install/omarchy-base.packages', 'utf8')
 
 assert(/IpcHandler[\s\S]*?function toggleBluetooth\(\) \{ root\.toggleBluetooth\(\) \}/.test(panelSource), 'bluetooth exposes the radio toggle over IPC')
 assert(/manageIpc: false/.test(panelSource), 'bluetooth owns its IPC handler so it can extend the target methods')
+
+assert(/Socket \{[\s\S]*?path: root\.agentSocketPath[\s\S]*?SplitParser/.test(panelSource), 'bluetooth listens for pairing events from the user agent')
+assert(/display_passkey/.test(panelSource) && /request_confirmation/.test(panelSource), 'bluetooth panel renders passkeys and confirmation requests')
+assert(/JSON\.stringify\(\{ id: String\(authRequest\.id\), response: response \}\)/.test(panelSource), 'bluetooth panel answers interactive pairing requests')
+assert(/authInputValid\(response\)/.test(panelSource) && /timeout/.test(panelSource), 'bluetooth panel keeps invalid input open and clears timed out requests')
+assert(/org\.bluez\.Agent1/.test(agentSource) && /DisplayPasskey/.test(agentSource), 'bluetooth agent implements BlueZ passkey callbacks')
+assert(/CAPABILITY = "KeyboardDisplay"/.test(agentSource), 'bluetooth agent advertises keyboard and display capability')
+assert(/ExecStart=\/usr\/bin\/omarchy-bluetooth-agent/.test(agentUnit), 'bt-agent service starts the panel bridge')
+assert(!/bt-agent -c NoInputNoOutput/.test(agentUnit), 'bt-agent service does not discard pairing prompts')
+assert(!/^bluez-tools$/m.test(packages), 'bluetooth no longer installs the obsolete bt-agent provider')
 
 // Writing adapter.enabled sets BlueZ Powered, which does not survive a reboot.
 assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
@@ -141,6 +154,52 @@ assert(
   'bluetooth ignores non-sink nodes when matching audio outputs'
 )
 JS
+
+python - "$ROOT/bin/omarchy-bluetooth-agent" <<'PY'
+import importlib.machinery
+import importlib.util
+import sys
+
+from gi.repository import GLib
+
+loader = importlib.machinery.SourceFileLoader("bluetooth_agent", sys.argv[1])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+agent_module = importlib.util.module_from_spec(spec)
+loader.exec_module(agent_module)
+
+
+class Invocation:
+    def __init__(self):
+        self.reply = None
+
+    def return_value(self, value):
+        self.reply = ("value", value.unpack())
+
+    def return_dbus_error(self, name, message):
+        self.reply = ("error", name, message)
+
+
+agent = object.__new__(agent_module.BluetoothAgent)
+agent.pending = {}
+agent.next_request_id = 1
+agent.clients = {object(): {}}
+events = []
+agent._event = lambda event, device="", **values: events.append((event, device, values))
+device = "/org/bluez/hci0/dev_E8_9F_04_5C_DC_03"
+
+display = Invocation()
+agent._method_call(None, "", "", "org.bluez.Agent1", "DisplayPasskey", GLib.Variant("(ouq)", (device, 47462, 0)), display)
+assert display.reply == ("value", ())
+assert events[-1][2]["passkey"] == "047462"
+
+confirmation = Invocation()
+agent._method_call(None, "", "", "org.bluez.Agent1", "RequestConfirmation", GLib.Variant("(ou)", (device, 641084)), confirmation)
+request_id = next(iter(agent.pending))
+assert events[-1][2]["passkey"] == "641084"
+agent._handle_response({"id": request_id, "response": "yes"})
+assert confirmation.reply == ("value", ())
+print("ok - bluetooth agent formats passkeys and resolves confirmation requests")
+PY
 
 # Turning Bluetooth off is an rfkill soft block, not a bluetoothctl power off,
 # because only the block survives a reboot. These mocks stand in for that pair:


### PR DESCRIPTION
## Summary

- replace the unmaintained `bt-agent` process with a BlueZ `org.bluez.Agent1` service using the existing `python-gobject` base dependency
- bridge passkey, PIN, confirmation, authorization, cancel, and timeout events to the Quickshell Bluetooth panel over a per-user Unix socket
- display zero-padded six-digit passkeys and provide keyboard/mouse controls for confirmation and input requests
- remove the obsolete `bluez-tools` package dependency

Fixes #8485
Related to #9676

## Testing

- `bash test/shell`
- Python Agent1 callback and socket protocol smoke tests
- QML lint with the repository Bluetooth panel dependencies
