### PR TITLE
Default OMARCHY_PATH in update-dev for sudo env_reset

### DIFF
--- a/bin/omarchy-update-dev
+++ b/bin/omarchy-update-dev
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# sudo env_reset drops session exports. Treat a missing path as the packaged
+# install so this step is a no-op there instead of aborting under `set -u`.
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+
 [[ $OMARCHY_PATH != "/usr/share/omarchy" ]] || exit 0
 
 if ! git -C "$OMARCHY_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/test/shell.d/update-dev-test.sh
+++ b/test/shell.d/update-dev-test.sh
@@ -53,10 +53,36 @@ run_dev_update() {
     "$ROOT/bin/omarchy-update-dev"
 }
 
+# sudo env_reset (and similar clean environments) leave OMARCHY_PATH unset.
+# The stock path must still be treated as a no-op so `sudo omarchy update` can
+# continue past this step instead of dying under `set -u`.
+run_dev_update_without_path() {
+  env -u OMARCHY_PATH \
+    TEST_GIT_LOG="$git_log" \
+    PATH="$stub_bin:$PATH" \
+    "$ROOT/bin/omarchy-update-dev"
+}
+
 : >"$git_log"
 run_dev_update /usr/share/omarchy
 [[ ! -s $git_log ]] || fail "package-backed updates do not invoke git" "$(cat "$git_log")"
 pass "package-backed updates skip the dev checkout step"
+
+: >"$git_log"
+run_dev_update_without_path >"$test_tmp/unset.out" 2>"$test_tmp/unset.err" ||
+  fail "unset OMARCHY_PATH must not abort under set -u" "$(cat "$test_tmp/unset.err")"
+[[ ! -s $git_log ]] || fail "unset OMARCHY_PATH is treated as the stock install" "$(cat "$git_log")"
+if grep -q 'unbound variable' "$test_tmp/unset.err"; then
+  fail "unset OMARCHY_PATH must not raise an unbound-variable error" "$(cat "$test_tmp/unset.err")"
+fi
+pass "unset OMARCHY_PATH (sudo env_reset) skips the dev checkout step"
+
+: >"$git_log"
+OMARCHY_PATH= TEST_GIT_LOG="$git_log" PATH="$stub_bin:$PATH" \
+  "$ROOT/bin/omarchy-update-dev" >"$test_tmp/empty.out" 2>"$test_tmp/empty.err" ||
+  fail "empty OMARCHY_PATH must not abort under set -u" "$(cat "$test_tmp/empty.err")"
+[[ ! -s $git_log ]] || fail "empty OMARCHY_PATH is treated as the stock install" "$(cat "$git_log")"
+pass "empty OMARCHY_PATH skips the dev checkout step"
 
 : >"$git_log"
 run_dev_update "$checkout"


### PR DESCRIPTION
## Summary

`sudo omarchy update` aborts right after the system snapshot with:

```
/usr/bin/omarchy-update-dev: line 7: OMARCHY_PATH: unbound variable
Something went wrong during the update!
```

`omarchy-update-dev` runs under `set -euo pipefail` and dereferences `OMARCHY_PATH` before anything else. `sudo` resets the environment, so the variable is unset on stock installs and the step kills the whole update before packages are upgraded.

## Fix

Default a missing path to the packaged install, matching `omarchy-migrate`, `omarchy-version`, and the other privileged helpers:

```bash
OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
```

Stock installs still exit 0 immediately. Dev checkouts keep pulling when the path is set.

Fixes #9953

## Test plan

- [x] `bash test/shell.d/update-dev-test.sh` — all cases pass, including new ones:
  - unset `OMARCHY_PATH` (sudo `env_reset`) skips without unbound-variable error
  - empty `OMARCHY_PATH` skips as stock
  - stock path still skips git
  - custom checkout still `pull --ff-only`
  - invalid checkout still fails with a useful error
  - no-upstream checkout still skips safely
- [x] `bash test/shell.d/update-sequence-test.sh` — update step order unchanged
- [x] Manual repro:
  - **Before:** `env -u OMARCHY_PATH bin/omarchy-update-dev` → `OMARCHY_PATH: unbound variable` (exit 1)
  - **After:** same command exits 0 with no git activity
  - Custom `OMARCHY_PATH` still runs `git -C … pull --ff-only`