### PR TITLE
Keep floating and pop window states consistent

### DIFF
--- a/bin/omarchy-hyprland-window-float-toggle
+++ b/bin/omarchy-hyprland-window-float-toggle
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle floating for the focused window without breaking pop mode
+
+set -euo pipefail
+
+active=$(hyprctl activewindow -j)
+addr=$(jq -r '.address // empty' <<<"$active")
+[[ -n $addr ]] || exit 0
+window="address:$addr"
+
+# Pop is a separate mode, not another floating state. Leave it before
+# applying the normal floating toggle.
+is_pop=$(jq -r 'any(.tags[]?; sub("\\*$"; "") == "pop")' <<<"$active")
+
+if [[ $is_pop == "true" ]]; then
+  omarchy-hyprland-window-pop
+else
+  hyprctl dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" >/dev/null 2>&1 || \
+    hyprctl dispatch togglefloating "$window" >/dev/null
+fi

--- a/bin/omarchy-hyprland-window-pop
+++ b/bin/omarchy-hyprland-window-pop
@@ -3,15 +3,24 @@
 # omarchy:summary=Toggle to pop-out a tile to stay fixed on a display basis.
 # omarchy:args=[width height x y]
 
+set -euo pipefail
+
 width=${1:-1300}
 height=${2:-900}
 x=${3:-}
 y=${4:-}
 
 active=$(hyprctl activewindow -j)
-pinned=$(echo "$active" | jq ".pinned")
-addr=$(echo "$active" | jq -r ".address")
+addr=$(jq -r '.address // empty' <<<"$active")
+[[ -n $addr ]] || exit 0
 window="address:$addr"
+
+floating=$(jq -r '.floating == true' <<<"$active")
+pinned=$(jq -r '.pinned == true' <<<"$active")
+# `pop` is the mode bit: pop windows are floating and pinned, and leaving
+# the mode always returns them to the tiled state.
+# Dynamic tags are reported with a trailing '*', while static tags are not.
+is_pop=$(jq -r 'any(.tags[]?; sub("\\*$"; "") == "pop")' <<<"$active")
 
 hypr_dispatch() {
   local lua="$1"
@@ -20,12 +29,24 @@ hypr_dispatch() {
   hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null
 }
 
-if [[ $pinned == "true" ]]; then
-  hypr_dispatch "hl.dsp.window.pin({ window = \"$window\" })" pin "$window"
-  hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+if [[ $is_pop == "true" ]]; then
+  # Target state: tiled, unpinned, and without the pop tag.
+  if [[ $pinned == "true" ]]; then
+    hypr_dispatch "hl.dsp.window.pin({ window = \"$window\" })" pin "$window"
+  fi
+  if [[ $floating == "true" ]]; then
+    hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+  fi
   hypr_dispatch "hl.dsp.window.tag({ window = \"$window\", tag = \"-pop\" })" tagwindow -pop "$window"
-elif [[ -n $addr ]]; then
-  hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+else
+  # Target state: floating, pinned, and tagged as pop.
+  if [[ $floating != "true" ]]; then
+    hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+  fi
+  if [[ $pinned != "true" ]]; then
+    hypr_dispatch "hl.dsp.window.pin({ window = \"$window\" })" pin "$window"
+  fi
+
   hypr_dispatch "hl.dsp.window.resize({ window = \"$window\", x = $width, y = $height })" resizeactive exact "$width" "$height" "$window"
 
   if [[ -n $x && -n $y ]]; then
@@ -34,7 +55,6 @@ elif [[ -n $addr ]]; then
     hypr_dispatch "hl.dsp.window.center({ window = \"$window\" })" centerwindow "$window"
   fi
 
-  hypr_dispatch "hl.dsp.window.pin({ window = \"$window\" })" pin "$window"
   hypr_dispatch "hl.dsp.window.alter_zorder({ window = \"$window\", mode = \"top\" })" alterzorder top "$window"
   hypr_dispatch "hl.dsp.window.tag({ window = \"$window\", tag = \"+pop\" })" tagwindow +pop "$window"
 fi

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -4,7 +4,8 @@ o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-clos
 
 o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
-o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
+-- Keep SUPER + T from leaving a popped window pinned but tiled.
+o.bind("SUPER + T", "Toggle window floating/tiling", "omarchy-hyprland-window-float-toggle")
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))
 o.bind("SUPER + CTRL + F", "Tiled full screen", "omarchy-hyprland-window-tiled-fullscreen-toggle")
 o.bind("SUPER + ALT + F", "Full width", hl.dsp.window.fullscreen({ mode = "maximized" }))

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -12,7 +12,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Ctrl + L` | Lock computer |
 | `Super + W` or `Super + Q` | Close window             |
 | `Ctrl + Alt + Del` | Close all windows |
-| `Super + T`               | Toggle window between tiling/floating             |
+| `Super + T`               | Toggle window between tiling/floating; close a popped window             |
 | `Super + J` | Toggle window position (horizontal/vertical) |
 | `Super + O`               | Toggle popping window into sticky'n'floating |
 | `Super + L`               | Toggle between dwindle and scrolling layout |

--- a/test/shell.d/hyprland-window-pop-test.sh
+++ b/test/shell.d/hyprland-window-pop-test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat >"$tmpdir/hyprctl" <<'BASH'
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $1 == "activewindow" && $2 == "-j" ]]; then
+  cat "$HYPR_STATE"
+  exit 0
+fi
+
+if [[ $1 == "dispatch" ]]; then
+  command="$*"
+  printf '%s\n' "$command" >>"$HYPRCTL_LOG"
+
+  update_state() {
+    local filter="$1"
+    local next_state="$HYPR_STATE.next"
+
+    jq "$filter" "$HYPR_STATE" >"$next_state"
+    mv "$next_state" "$HYPR_STATE"
+  }
+
+  case "$command" in
+    *'hl.dsp.window.float('*|*' togglefloating '*)
+      update_state '.floating = (.floating | not)'
+      ;;
+    *'hl.dsp.window.pin('*|*' pin '*)
+      update_state '.pinned = (.pinned | not)'
+      ;;
+    *'tag = "+pop"'*|*' +pop '*)
+      update_state '.tags = (((.tags // []) + ["pop*"]) | unique)'
+      ;;
+    *'tag = "-pop"'*|*' -pop '*)
+      update_state '.tags = [(.tags // [])[] | select(sub("\\*$"; "") != "pop")]'
+      ;;
+  esac
+
+  exit 0
+fi
+
+exit 1
+BASH
+chmod +x "$tmpdir/hyprctl"
+
+state="$tmpdir/state.json"
+log="$tmpdir/hyprctl.log"
+cat >"$state" <<'JSON'
+{
+  "address": "0x1",
+  "floating": false,
+  "pinned": false,
+  "tags": []
+}
+JSON
+
+run_pop() {
+  PATH="$tmpdir:$ROOT/bin:$PATH" HYPR_STATE="$state" HYPRCTL_LOG="$log" \
+    "$ROOT/bin/omarchy-hyprland-window-pop"
+}
+
+run_float_toggle() {
+  PATH="$tmpdir:$ROOT/bin:$PATH" HYPR_STATE="$state" HYPRCTL_LOG="$log" \
+    "$ROOT/bin/omarchy-hyprland-window-float-toggle"
+}
+
+assert_state() {
+  local filter="$1"
+  local description="$2"
+
+  jq -e "$filter" "$state" >/dev/null || fail "$description" "$(cat "$state")"
+  pass "$description"
+}
+
+run_pop
+assert_state '.floating == true and .pinned == true and any(.tags[]; sub("\\*$"; "") == "pop")' \
+  "pop changes a tiled window into the pop state"
+
+run_float_toggle
+assert_state '.floating == false and .pinned == false and ([.tags[] | sub("\\*$"; "")] | index("pop")) == null' \
+  "floating toggle exits pop mode as a tiled window"
+
+run_float_toggle
+assert_state '.floating == true and .pinned == false and ([.tags[] | sub("\\*$"; "")] | index("pop")) == null' \
+  "floating toggle changes a normal window to floating"
+
+run_pop
+assert_state '.floating == true and .pinned == true and any(.tags[]; sub("\\*$"; "") == "pop")' \
+  "pop keeps a floating window floating while entering pop mode"
+
+run_float_toggle
+assert_state '.floating == false and .pinned == false and ([.tags[] | sub("\\*$"; "")] | index("pop")) == null' \
+  "floating toggle exits pop mode as a tiled window regardless of entry state"
+
+run_pop
+run_pop
+assert_state '.floating == false and .pinned == false and ([.tags[] | sub("\\*$"; "")] | index("pop")) == null' \
+  "pop toggles cleanly between the tiled and pop states"
+
+grep -Fq 'o.bind("SUPER + T", "Toggle window floating/tiling", "omarchy-hyprland-window-float-toggle")' \
+  "$ROOT/default/hypr/bindings/tiling.lua" || fail "SUPER + T uses the pop-aware floating toggle"
+pass "SUPER + T uses the pop-aware floating toggle"


### PR DESCRIPTION
`SUPER+T` only toggles the window’s floating state, while `SUPER+O` manages floating, pinning, and the `pop` tag together. Using them interchangeably could leave a window pinned and rounded while it was tiled.

This PR defines three states and explicit transitions:

- A normal tiled window and a normal floating window switch between each other with `SUPER+T`.
- Either normal state enters pop-out mode with `SUPER+O`, becoming floating, pinned, and tagged `pop`.
- A popped window returns to the normal tiled state when `SUPER+O` or `SUPER+T` is pressed.
