### PR TITLE
Add omarchy font cjk commands for locale-aware CJK fallback

### DIFF
--- a/bin/omarchy-font-cjk-current
+++ b/bin/omarchy-font-cjk-current
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# omarchy:summary=Show current CJK font variant preference
+# omarchy:examples=omarchy font cjk current
+
+# The CJK variant marker lives in fonts.conf (the only per-user fontconfig
+# file this system loads), managed by `omarchy font cjk set`.
+cjk_file="$HOME/.config/fontconfig/fonts.conf"
+
+if [[ ! -f "$cjk_file" ]]; then
+  echo "unset"
+  exit 0
+fi
+
+# The variant marker is written by cjk-set as "<!-- omarchy-cjk-variant: <name> -->".
+current=$(sed -n 's/.*omarchy-cjk-variant: \([a-z]*\).*/\1/p' "$cjk_file" | tail -n1)
+
+if [[ -z "$current" ]]; then
+  echo "unset"
+else
+  echo "$current"
+fi

--- a/bin/omarchy-font-cjk-list
+++ b/bin/omarchy-font-cjk-list
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# omarchy:summary=List available CJK font variants
+# omarchy:examples=omarchy font cjk list
+
+# Each variant is a Noto CJK sub-family installed by noto-fonts-cjk.
+# We check for the sans-serif variant as a proxy — if it is present,
+# the serif and mono siblings are too.
+variants=("jp" "kr" "sc" "tc" "hk")
+
+for v in "${variants[@]}"; do
+  upper=$(echo "$v" | tr '[:lower:]' '[:upper:]')
+  if fc-list | grep -Fqi "Noto Sans CJK $upper"; then
+    echo "$v"
+  fi
+done

--- a/bin/omarchy-font-cjk-set
+++ b/bin/omarchy-font-cjk-set
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+# omarchy:summary=Set the preferred CJK font variant
+# omarchy:args=<variant>
+# omarchy:examples=omarchy font cjk set jp | omarchy font cjk set auto
+
+usage() {
+  cat <<'EOF'
+Usage: omarchy font cjk set <variant>
+
+Variants:
+  jp    Japanese (Noto Sans CJK JP)
+  kr    Korean (Noto Sans CJK KR)
+  sc    Simplified Chinese (Noto Sans CJK SC)
+  tc    Traditional Chinese (Noto Sans CJK TC)
+  hk    Hong Kong Chinese (Noto Sans CJK HK)
+  auto  Detect from LANG environment variable (prompts if LANG is en_*)
+EOF
+}
+
+variant="${1:-}"
+
+case "$variant" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  "")
+    usage >&2
+    exit 1
+    ;;
+esac
+
+# --- Resolve variant name ---
+
+resolve_auto() {
+  local lang="${LANG:-en_US.UTF-8}"
+  local base="${lang%%.*}"
+  base="${base%%@*}"
+  local territory="${base##*_}"
+  local language="${base%%_*}"
+
+  case "$language" in
+    ja)
+      echo "jp"
+      ;;
+    ko)
+      echo "kr"
+      ;;
+    zh)
+      case "$territory" in
+        CN|SG) echo "sc" ;;
+        TW|HK) echo "tc" ;;  # zh_HK defaults to TC per design decision
+        *)     echo "sc" ;;
+      esac
+      ;;
+    *)
+      # en_* or unknown — prompt the user
+      echo ""
+      ;;
+  esac
+}
+
+case "$variant" in
+  auto)
+    resolved=$(resolve_auto)
+    if [[ -z "$resolved" ]]; then
+      echo "LANG=$LANG does not map to a CJK variant."
+      echo ""
+      echo "Select CJK variant:"
+      echo "  1) jp  — Japanese (Noto Sans CJK JP)"
+      echo "  2) kr  — Korean (Noto Sans CJK KR)"
+      echo "  3) sc  — Simplified Chinese (Noto Sans CJK SC)"
+      echo "  4) tc  — Traditional Chinese (Noto Sans CJK TC)"
+      echo "  5) hk  — Hong Kong Chinese (Noto Sans CJK HK)"
+      echo ""
+      read -rp "Number [1-5]: " choice
+      case "$choice" in
+        1) resolved="jp" ;;
+        2) resolved="kr" ;;
+        3) resolved="sc" ;;
+        4) resolved="tc" ;;
+        5) resolved="hk" ;;
+        *)
+          echo "Invalid choice." >&2
+          exit 1
+          ;;
+      esac
+    fi
+    variant="$resolved"
+    ;;
+  jp|kr|sc|tc|hk)
+    ;;
+  *)
+    echo "Unknown variant: $variant" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+# --- Map variant to font family names ---
+
+upper=$(echo "$variant" | tr '[:lower:]' '[:upper:]')
+sans_family="Noto Sans CJK $upper"
+serif_family="Noto Serif CJK $upper"
+mono_family="Noto Sans Mono CJK $upper"
+
+# For the lang match, map variant back to BCP 47 language tag.
+case "$variant" in
+  jp) lang_tag="ja" ;;
+  kr) lang_tag="ko" ;;
+  sc) lang_tag="zh-cn" ;;
+  tc) lang_tag="zh-tw" ;;
+  hk) lang_tag="zh-hk" ;;
+esac
+
+# --- Check that the font is installed ---
+
+if ! fc-list | grep -Fqi -- "$sans_family"; then
+  echo "Font '$sans_family' not found. Install noto-fonts-cjk first." >&2
+  exit 1
+fi
+
+# --- Write the CJK section into fonts.conf ---
+#
+# fonts.conf is the only per-user fontconfig file this system loads, so the
+# CJK rules live here in a marker-delimited section. The monospace section
+# managed by `omarchy font set` is preserved.
+
+section_file=$(mktemp)
+cat >"$section_file" <<XML
+  <!-- omarchy:begin-cjk -->
+  <!-- omarchy-cjk-variant: $variant -->
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>sans-serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>$sans_family</string>
+    </edit>
+  </match>
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>$serif_family</string>
+    </edit>
+  </match>
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>$mono_family</string>
+    </edit>
+  </match>
+  <!-- Backup for Chromium/Electron: they resolve glyphs one character at a
+       time without lang on the pattern, so the rules above never fire.
+       The lang-targeted rule covers that path. -->
+  <match target="pattern">
+    <test name="lang" compare="contains">
+      <string>$lang_tag</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>$sans_family</string>
+    </edit>
+  </match>
+  <!-- omarchy:end-cjk -->
+XML
+
+omarchy-fontconfig-replace-section cjk "$section_file"
+rm -f -- "$section_file"
+
+echo "CJK variant set to: $variant ($sans_family)"
+
+omarchy-restart-shell 2>/dev/null || true
+
+if pgrep -x foot; then
+  omarchy-notification-send -g "You must restart Foot to see CJK font change" 2>/dev/null || true
+fi
+
+if pgrep -x ghostty; then
+  omarchy-notification-send -g "You must restart Ghostty to see CJK font change" 2>/dev/null || true
+fi
+
+omarchy-hook font-set "cjk-$variant" 2>/dev/null || true

--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -45,15 +45,12 @@ if [[ -f ~/.config/foot/foot.ini ]]; then
 fi
 
 # fontconfig is the canonical source of truth — the omarchy shell, Qt apps,
-# and anything resolving "monospace" all read from here. This file is loaded
-# after the package-owned default, and prepend_first puts the chosen family at
-# the head of the list so it wins over the family that default prefers.
-fontconfig_file="$HOME/.config/fontconfig/fonts.conf"
-mkdir -p "$(dirname "$fontconfig_file")"
-cat >"$fontconfig_file" <<XML
-<?xml version="1.0"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
-<fontconfig>
+# and anything resolving "monospace" all read from here. The monospace choice
+# lives in a marker-delimited section of fonts.conf so the CJK section managed
+# by `omarchy font cjk set` survives a font change (and vice versa).
+section_file=$(mktemp)
+cat >"$section_file" <<XML
+  <!-- omarchy:begin-mono -->
   <match target="pattern">
     <test name="family" qual="any">
       <string>monospace</string>
@@ -62,8 +59,11 @@ cat >"$fontconfig_file" <<XML
       <string>$font_name</string>
     </edit>
   </match>
-</fontconfig>
+  <!-- omarchy:end-mono -->
 XML
+
+omarchy-fontconfig-replace-section mono "$section_file"
+rm -f -- "$section_file"
 
 omarchy-restart-shell
 

--- a/bin/omarchy-fontconfig-replace-section
+++ b/bin/omarchy-fontconfig-replace-section
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# omarchy:hidden=true
+# omarchy:summary=Replace a marker-delimited section in fonts.conf (internal helper)
+
+# Usage: omarchy-fontconfig-replace-section <name> <section-file>
+#
+# <name> is "mono" or "cjk". <section-file> holds the complete replacement
+# block, INCLUDING its begin/end marker lines:
+#   <!-- omarchy:begin-<name> --> ... <!-- omarchy:end-<name> -->
+# The other section (if any) is preserved byte-for-byte.
+#
+# fonts.conf is the only per-user fontconfig file this system loads
+# (~/.config/fontconfig/conf.d/ is not read), so both `font set` and
+# `font cjk set` cooperate through marker sections in this one file.
+#
+# A fonts.conf with no omarchy markers is treated as legacy (hand-written):
+# it is backed up once and replaced.
+
+if (( $# != 2 )); then
+  echo "Usage: omarchy-fontconfig-replace-section <name> <section-file>" >&2
+  exit 1
+fi
+
+name="$1"
+section_file="$2"
+fonts_conf="$HOME/.config/fontconfig/fonts.conf"
+begin="<!-- omarchy:begin-$name -->"
+end="<!-- omarchy:end-$name -->"
+
+if [[ ! -f $section_file ]]; then
+  echo "Section file '$section_file' not found." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$fonts_conf")"
+
+write_skeleton() {
+  {
+    echo '<?xml version="1.0"?>'
+    echo '<!DOCTYPE fontconfig SYSTEM "fonts.dtd">'
+    echo '<fontconfig>'
+    cat -- "$section_file"
+    echo '</fontconfig>'
+  } >"$fonts_conf"
+}
+
+if [[ ! -f $fonts_conf ]]; then
+  write_skeleton
+  exit 0
+fi
+
+if ! grep -q "omarchy:begin-" "$fonts_conf"; then
+  backup="$fonts_conf.bak-$(date +%Y%m%d%H%M%S)"
+  cp -- "$fonts_conf" "$backup"
+  echo "Backed up legacy fonts.conf to $backup"
+  write_skeleton
+  exit 0
+fi
+
+tmp=$(mktemp "$(dirname "$fonts_conf")/.fonts.conf.XXXXXX")
+# Marker lines may carry leading indentation; compare stripped.
+if grep -qF -- "$begin" "$fonts_conf"; then
+  awk -v begin="$begin" -v end="$end" -v section="$section_file" '
+    { stripped = $0; sub(/^[ \t]+/, "", stripped) }
+    stripped == begin { while ((getline line < section) > 0) print line; skip = 1; next }
+    stripped == end { skip = 0; next }
+    !skip { print }
+  ' "$fonts_conf" >"$tmp" && mv -- "$tmp" "$fonts_conf"
+else
+  if ! grep -q "</fontconfig>" "$fonts_conf"; then
+    echo "fonts.conf is malformed (no </fontconfig>); aborting." >&2
+    rm -f -- "$tmp"
+    exit 1
+  fi
+  awk -v section="$section_file" '
+    { stripped = $0; sub(/^[ \t]+/, "", stripped) }
+    stripped == "</fontconfig>" { while ((getline line < section) > 0) print line }
+    { print }
+  ' "$fonts_conf" >"$tmp" && mv -- "$tmp" "$fonts_conf"
+fi

--- a/default/agents/skills/omarchy/theming.md
+++ b/default/agents/skills/omarchy/theming.md
@@ -76,4 +76,7 @@ omarchy theme set catppuccin-custom
 omarchy font list               # Available fonts
 omarchy font current            # Current font
 omarchy font set <name>         # Change font
+omarchy font cjk list           # Available CJK variants
+omarchy font cjk current        # Current CJK variant
+omarchy font cjk set <variant>  # Change CJK variant (jp|kr|sc|tc|hk|auto)
 ```

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -105,6 +105,7 @@
   "style.background": {"icon":"","label":"Background","aliases":["background","wallpaper"],"action":"background=$(omarchy-theme-bg-switcher); [[ -n $background ]] && omarchy-theme-bg-set \"$background\""},
   "style.unlock": {"icon":"󰟵","label":"Unlock","aliases":["unlock"],"action":"unlock=$(omarchy-plymouth-switcher); if [[ $unlock == default ]]; then omarchy-launch-floating-terminal-with-presentation omarchy-plymouth-reset; elif [[ -n $unlock ]]; then omarchy-launch-floating-terminal-with-presentation \"omarchy-plymouth-set-by-theme $(printf %q \"$unlock\")\"; fi"},
   "style.font": {"icon":"","label":"Font","provider":"fonts"},
+  "style.font.cjk": {"icon":"","label":"CJK Variant","provider":"cjk-variants"},
   "style.bar": {"icon":"󰍜","label":"Menu Bar"},
   "style.bar.position": {"icon":"","label":"Position"},
   "style.bar.transparency": {"icon":"󰂵","label":"Transparency","action":"omarchy-bar transparent toggle"},

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -277,6 +277,12 @@ Item {
       script: "current=$(powerprofilesctl get 2>/dev/null); omarchy-powerprofiles-list 2>/dev/null | while read -r p; do [[ -z $p ]] && continue; printf '%s\\t%s\\t%s\\n' \"$p\" \"$p\" \"$current\"; done",
       icon: "\udb81\udc0b",
       actionFor: function(value) { return "omarchy-powerprofiles-set autodetect " + Util.shellQuote(value) }
+    },
+    "cjk-variants": {
+      script: "current=$(omarchy-font-cjk-current 2>/dev/null); omarchy-font-cjk-list 2>/dev/null | while read -r v; do [[ -z $v ]] && continue; label=$(echo \"$v\" | tr '[:lower:]' '[:upper:]'); printf '%s\\t%s\\t%s\\n' \"$label\" \"$v\" \"$current\"; done",
+      icon: "",
+      volatile: true,
+      actionFor: function(value) { return "omarchy-font-cjk-set " + Util.shellQuote(value) }
     }
   })
 


### PR DESCRIPTION
Fixes #9580.

CJK characters always resolve to the Korean variant (Noto Sans CJK KR) regardless of the user's locale, because the sans-serif chain in the system `65-nonlatin.conf` only lists KR and Omarchy has no locale-aware selection.

## What this adds (post-install only)

- `omarchy font cjk list` — installed CJK variants (jp/kr/sc/tc/hk)
- `omarchy font cjk set <variant|auto>` — writes `~/.config/fontconfig/conf.d/50-omarchy-cjk.conf`, owned outright by this command; the user's `fonts.conf` is left alone by construction
- `omarchy font cjk current` — shows the active variant (`unset` when the file is absent)
- `omarchy font cjk unset` — removes the file (`rm -f`)
- `auto` maps LANG (ja→jp, ko→kr, zh_CN/SG→sc, zh_TW/HK/MO→tc); `en_*` and unknown locales prompt instead of guessing. `zh_HK` maps to `tc` by design, so `hk` is reachable only by naming it explicitly. A stock install only generates `C.UTF-8` and `en_US.UTF-8`, so `auto` always prompts there until additional locales exist
- `omarchy font set` is untouched by this PR (no shared file, no cooperation needed)
- Style > Font > CJK Variant menu backed by a `cjk-variants` provider
- The `prepend` rules cover sans-serif/serif/monospace plus a `lang` rule for the Chromium per-character path that ignores `lang`. The `lang` rule uses `mode="append"` so a monospace query never gets a proportional CJK face at the head of its chain; charset matching still outranks family matching, so the bare-charset path keeps working

## Design notes

- Explicit stored preference wins over implicit locale tracking: `auto` only proposes from LANG on first run; later LANG changes do not move the selection.
- `ko` mapping keeps KR (status quo), so Korean users see no behavior change.
- `conf.d` loads before `fonts.conf`, so the `prepend_first` monospace rule `omarchy font set` writes keeps winning the head of the chain.

## Verification (author)

| Check | Result |
|---|---|
| `cjk-set jp/kr` flips `fc-match -s` CJK order | Pass |
| `cjk-current` / `cjk-list` | Pass (`jp`, all 5 variants) |
| `auto` on `LANG=en_US.UTF-8` prompts | Pass |
| `menu-test`, `menu-guards-test`, `./test/cli` | Pass |
| Foot/Chromium rendering | Verified JA locale only |

Revision `a71d175` (review feedback, sandbox `HOME` + `fc-list` stub):

| Check | Result |
|---|---|
| `set tc` → `current tc`, `lang` rule `mode="append"`, XML parses | Pass |
| `unset` → file removed, `current unset` | Pass |
| `auto` on `zh_MO` → `tc`, `zh_HK` → `tc`, `bogus` → exit 1 | Pass |
| `fonts.conf` never created or modified | Pass |
| `./test/cli` | 116 ok / 0 fail |

## Not verified by author

ko, zh_CN, zh_TW rendering — requesting native speakers to test. ko mapping is unchanged from status quo, so Korean users see no behavior change. (zh_TW verified by reviewer `linyiru`; re-verification of the `append` revision requested.)

## Out of scope

- Install-time locale prompt (needs a fresh implementation in the current ISO/Quattro flows; follow-up, see #10949)
- Changes to the Arch `fontconfig` package (`65-nonlatin.conf` is intentionally locale-agnostic upstream)
- XDG directory renaming

## User-config side effects

- Only `~/.config/fontconfig/conf.d/50-omarchy-cjk.conf` is written.
- `~/.config/fontconfig/fonts.conf` is untouched by `cjk-set`.
- Terminal configs (`foot.ini` etc.) are untouched by `cjk-set`.

- Per-application tuning (e.g. Foot's fallback font sizes in `foot.ini`)
