### PR TITLE
Map toggle bar on/off to visible bar state

### DIFF
--- a/bin/omarchy-toggle-bar
+++ b/bin/omarchy-toggle-bar
@@ -4,7 +4,15 @@
 # omarchy:args=[toggle|on|off]
 # omarchy:examples=omarchy toggle bar | omarchy toggle bar off | omarchy toggle bar on
 
-omarchy-toggle bar-off "${1:-toggle}"
+# bar-off presence hides the bar. Map user-facing on/off to the inverse flag
+# action so `omarchy toggle bar on` shows the bar and `off` hides it.
+action=${1:-toggle}
+case "$action" in
+  on) action=off ;;
+  off) action=on ;;
+esac
+
+omarchy-toggle bar-off "$action"
 
 # The shell's watch on the toggles directory can miss flag changes that land in
 # quick succession, stranding the bar off screen until the shell restarts.

--- a/test/acceptance.d/session-test.sh
+++ b/test/acceptance.d/session-test.sh
@@ -30,16 +30,16 @@ wait_until "background layer is on screen" 30 layer_on_screen "omarchy-backgroun
 # Hiding parks the bar off-screen without unmapping its layer surface, and
 # revealing brings that same surface back on-screen.
 restore_bar_visibility() {
-  omarchy-toggle-bar off >/dev/null 2>&1 || true
+  omarchy-toggle-bar on >/dev/null 2>&1 || true
 }
 trap restore_bar_visibility EXIT
 
-omarchy-toggle-bar on
+omarchy-toggle-bar off
 wait_until "hidden bar layer stays mapped" 15 layer_present "omarchy-bar"
 wait_until "hidden bar layer parks off screen" 15 layer_off_screen "omarchy-bar"
 screenshot "success-bar-hidden"
 
-omarchy-toggle-bar off
+omarchy-toggle-bar on
 wait_until "revealed bar layer returns on screen" 15 layer_on_screen "omarchy-bar"
 screenshot "success-bar-revealed"
 trap - EXIT

--- a/test/shell.d/toggle-test.sh
+++ b/test/shell.d/toggle-test.sh
@@ -40,14 +40,29 @@ HOME="$test_home" omarchy-toggle example toggle
 [[ ! -f $flag ]] || fail "generic toggle flips enabled state off"
 pass "generic toggle flips enabled state off"
 
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on enables bar-off toggle"
-pass "bar on enables bar-off toggle"
-
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on is idempotent"
-pass "bar on is idempotent"
+# Presence of bar-off hides the bar. User-facing on/off must track visibility,
+# not the internal flag polarity (#9925).
+HOME="$test_home" omarchy-toggle-bar off
+[[ -f $bar_flag ]] || fail "bar off hides the bar by creating bar-off"
+pass "bar off hides the bar by creating bar-off"
 
 HOME="$test_home" omarchy-toggle-bar off
-[[ ! -f $bar_flag ]] || fail "bar off disables bar-off toggle"
-pass "bar off disables bar-off toggle"
+[[ -f $bar_flag ]] || fail "bar off is idempotent while the bar stays hidden"
+pass "bar off is idempotent while the bar stays hidden"
+
+HOME="$test_home" omarchy-toggle-bar on
+[[ ! -f $bar_flag ]] || fail "bar on shows the bar by clearing bar-off"
+pass "bar on shows the bar by clearing bar-off"
+
+HOME="$test_home" omarchy-toggle-bar on
+[[ ! -f $bar_flag ]] || fail "bar on is idempotent while the bar stays visible"
+pass "bar on is idempotent while the bar stays visible"
+
+# Plain toggle still flips visibility either way.
+HOME="$test_home" omarchy-toggle-bar
+[[ -f $bar_flag ]] || fail "bar toggle hides a visible bar"
+pass "bar toggle hides a visible bar"
+
+HOME="$test_home" omarchy-toggle-bar toggle
+[[ ! -f $bar_flag ]] || fail "bar toggle shows a hidden bar"
+pass "bar toggle shows a hidden bar"


### PR DESCRIPTION
## Summary

`omarchy toggle bar on` hid the bar and `off` showed it. `omarchy-toggle-bar` forwarded the action unchanged to the negative `bar-off` flag, whose presence means hidden.

## Fix

Invert `on`/`off` before calling `omarchy-toggle bar-off`. Plain `toggle` is unchanged.

Fixes #9925

## Test plan

- [x] `bash test/shell.d/toggle-test.sh` — generic toggle cases plus corrected bar visibility:
  - `bar off` creates `bar-off` (hidden)
  - `bar on` clears `bar-off` (visible)
  - both actions idempotent
  - plain toggle still flips either way
- [x] Before: `on` → flag present; After: `on` → flag absent