### PR TITLE
Preserve foot font size when changing the monospace family

### DIFF
--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -40,8 +40,14 @@ if [[ -f ~/.config/ghostty/config ]]; then
   pkill -SIGUSR2 ghostty
 fi
 
+# Only swap the family. Size is owned by omarchy-display-text-size; rewriting
+# `:size=9` here desyncs foot from the other terminals after a text-size set.
 if [[ -f ~/.config/foot/foot.ini ]]; then
-  sed -i "s/^font=.*/font=$font_name:size=9/g" ~/.config/foot/foot.ini
+  if grep -qE '^font=.*:size=' ~/.config/foot/foot.ini; then
+    sed -i -E "s/^font=.*(:size=[0-9.]+)/font=$font_name\1/" ~/.config/foot/foot.ini
+  else
+    sed -i -E "s/^font=.*/font=$font_name/" ~/.config/foot/foot.ini
+  fi
 fi
 
 # fontconfig is the canonical source of truth — the omarchy shell, Qt apps,

--- a/test/shell.d/font-set-test.sh
+++ b/test/shell.d/font-set-test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+stub_bin="$test_tmp/bin"
+mkdir -p "$test_home/.config/"{foot,alacritty,kitty,ghostty,fontconfig} "$stub_bin"
+
+# fc-list must report the family as installed; other side effects are stubbed.
+cat >"$stub_bin/fc-list" <<'SH'
+#!/bin/bash
+printf 'CaskaydiaMono Nerd Font:style=Regular\nJetBrainsMono Nerd Font:style=Regular\n'
+SH
+
+cat >"$stub_bin/omarchy-restart-shell" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-hook" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/pgrep" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$stub_bin/pkill" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$stub_bin"/*
+
+printf '%s\n' \
+  '[main]' \
+  'font=JetBrainsMono Nerd Font:size=12' \
+  'pad=14x14' >"$test_home/.config/foot/foot.ini"
+
+printf '%s\n' \
+  '[font.normal]' \
+  'family = "JetBrainsMono Nerd Font"' \
+  'size = 12' >"$test_home/.config/alacritty/alacritty.toml"
+
+printf '%s\n' \
+  'font_family JetBrainsMono Nerd Font' \
+  'font_size 12.0' >"$test_home/.config/kitty/kitty.conf"
+
+printf '%s\n' \
+  'font-family = "JetBrainsMono Nerd Font"' \
+  'font-size = 12' >"$test_home/.config/ghostty/config"
+
+run_font_set() {
+  HOME="$test_home" PATH="$stub_bin:$ROOT/bin:$PATH" \
+    "$ROOT/bin/omarchy-font-set" "$@"
+}
+
+run_font_set "CaskaydiaMono Nerd Font"
+
+foot_font=$(grep -E '^font=' "$test_home/.config/foot/foot.ini")
+[[ $foot_font == "font=CaskaydiaMono Nerd Font:size=12" ]] ||
+  fail "font-set preserves foot point size while changing family" "$foot_font"
+pass "font-set preserves foot point size while changing family"
+
+grep -F 'family = "CaskaydiaMono Nerd Font"' "$test_home/.config/alacritty/alacritty.toml" >/dev/null ||
+  fail "font-set updates alacritty family"
+grep -E '^size = 12$' "$test_home/.config/alacritty/alacritty.toml" >/dev/null ||
+  fail "font-set leaves alacritty size alone"
+pass "font-set updates alacritty family without touching size"
+
+grep -E '^font_family CaskaydiaMono Nerd Font$' "$test_home/.config/kitty/kitty.conf" >/dev/null ||
+  fail "font-set updates kitty family"
+grep -E '^font_size 12.0$' "$test_home/.config/kitty/kitty.conf" >/dev/null ||
+  fail "font-set leaves kitty size alone"
+pass "font-set updates kitty family without touching size"
+
+grep -F 'font-family = "CaskaydiaMono Nerd Font"' "$test_home/.config/ghostty/config" >/dev/null ||
+  fail "font-set updates ghostty family"
+grep -E '^font-size = 12$' "$test_home/.config/ghostty/config" >/dev/null ||
+  fail "font-set leaves ghostty size alone"
+pass "font-set updates ghostty family without touching size"
+
+# Foot line without an explicit size must still take the new family.
+printf '%s\n' 'font=Old Family' >"$test_home/.config/foot/foot.ini"
+run_font_set "CaskaydiaMono Nerd Font"
+foot_font=$(grep -E '^font=' "$test_home/.config/foot/foot.ini")
+[[ $foot_font == "font=CaskaydiaMono Nerd Font" ]] ||
+  fail "font-set rewrites a size-less foot font line" "$foot_font"
+pass "font-set rewrites a size-less foot font line"
+
+# Fractional sizes from display-text-size must survive too.
+printf '%s\n' 'font=JetBrainsMono Nerd Font:size=11.5' >"$test_home/.config/foot/foot.ini"
+run_font_set "CaskaydiaMono Nerd Font"
+foot_font=$(grep -E '^font=' "$test_home/.config/foot/foot.ini")
+[[ $foot_font == "font=CaskaydiaMono Nerd Font:size=11.5" ]] ||
+  fail "font-set preserves fractional foot sizes" "$foot_font"
+pass "font-set preserves fractional foot sizes"


### PR DESCRIPTION
## Summary

`omarchy font set` rewrote `~/.config/foot/foot.ini` as `font=<family>:size=9`, wiping whatever point size `omarchy display text size` had set. Alacritty, kitty, and ghostty only change family; foot did not.

## Fix

Replace only the family on the foot `font=` line and keep any existing `:size=…` (including fractional sizes). A size-less line still gets the new family alone.

Fixes #9954

## Test plan

- [x] `bash test/shell.d/font-set-test.sh`
  - foot keeps `:size=12` across family change
  - alacritty / kitty / ghostty family updated, size untouched
  - size-less foot line rewritten without inventing a size
  - fractional `:size=11.5` preserved
- [x] Before: `size=12` → `size=9`; After: `size=12` stays