### PR TITLE
Wrap polkit justification text instead of middle-eliding it

### DIFF
--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -364,9 +364,18 @@ Item {
       }
     }
 
+    // Justification chip sits above the card so the user can verify what they
+    // are authorizing. Long pkexec argv must wrap (not middle-elide); width is
+    // capped to a readable column rather than the full panel.
     Rectangle {
-      width: Math.min(justificationText.implicitWidth + Style.space(24), panel.width - Style.gapsOut * 2)
-      height: Style.space(28)
+      id: justificationBox
+      // Readable column (card-width range up to 480); never full monitor width.
+      readonly property int maxTextWidth: Math.min(
+        Style.space(480),
+        Math.max(1, panel.width - Style.gapsOut * 2 - Style.space(24))
+      )
+      width: justificationText.width + Style.space(24)
+      height: Math.max(Style.space(28), justificationText.height + Style.space(12))
       anchors.horizontalCenter: card.horizontalCenter
       anchors.bottom: card.top
       anchors.bottomMargin: Style.space(10)
@@ -376,16 +385,20 @@ Item {
       Text {
         id: justificationText
         textFormat: Text.PlainText
-        anchors.fill: parent
-        anchors.leftMargin: Style.space(12)
-        anchors.rightMargin: Style.space(12)
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        // Shrink-wrap short labels; wrap long ones inside the readable cap.
+        width: Math.min(implicitWidth, justificationBox.maxTextWidth)
         text: root.authorizationLabel(root.currentMessage)
         color: root.foreground
         font.family: root.fontFamily
         font.pixelSize: Style.font.bodySmall
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideMiddle
+        wrapMode: Text.Wrap
+        // Cap pathological input so the chip cannot grow page-tall.
+        maximumLineCount: 4
+        elide: Text.ElideRight
       }
     }
   }

--- a/test/shell.d/polkit-test.sh
+++ b/test/shell.d/polkit-test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
+const fs = require('fs')
 const polkit = requireFromRoot('shell/plugins/polkit/PolkitModel.js')
 
 assert(polkit.promptLooksFingerprint('Swipe your finger'), 'polkit detects fingerprint prompts')
@@ -45,5 +46,60 @@ auth include system-auth
 auth required pam_unix.so
 `),
   'polkit reports no fingerprint when pam_fprintd is absent'
+)
+
+// Justification chip structure (#9872): long pkexec argv must wrap inside a
+// readable width cap instead of middle-eliding inside a fixed single-line height.
+const agentQml = fs.readFileSync(path.join(root, 'shell/plugins/polkit/PolkitAgent.qml'), 'utf8')
+
+const justificationStart = agentQml.indexOf('id: justificationText')
+assert(justificationStart !== -1, 'polkit agent declares justificationText')
+const justificationBlock = agentQml.slice(justificationStart, justificationStart + 900)
+
+assert(
+  /wrapMode:\s*Text\.Wrap\b/.test(justificationBlock),
+  'polkit justification wraps long authorization text'
+)
+assert(
+  /maximumLineCount:\s*\d+/.test(justificationBlock),
+  'polkit justification caps line count so pathological input cannot grow page-tall'
+)
+assert(
+  /textFormat:\s*Text\.PlainText/.test(justificationBlock),
+  'polkit justification stays plain text'
+)
+assert(
+  !/elide:\s*Text\.ElideMiddle/.test(justificationBlock),
+  'polkit justification does not middle-elide (hides the important middle of a command)'
+)
+// ElideRight is only acceptable as the overflow policy past maximumLineCount.
+assert(
+  /elide:\s*Text\.ElideRight/.test(justificationBlock),
+  'polkit justification elides at the end only after the line cap'
+)
+
+const boxStart = agentQml.indexOf('id: justificationBox')
+assert(boxStart !== -1, 'polkit agent declares justificationBox')
+const boxBlock = agentQml.slice(boxStart, justificationStart + 900)
+
+assert(
+  /maxTextWidth:/.test(boxBlock),
+  'polkit justification bounds width to a readable column'
+)
+assert(
+  /Style\.space\(480\)/.test(boxBlock),
+  'polkit justification width cap stays well below full-panel width'
+)
+assert(
+  !/height:\s*Style\.space\(28\)\s*$/m.test(boxBlock.split('Text {')[0]),
+  'polkit justification box height is not fixed at a single Style.space(28) line'
+)
+assert(
+  /Math\.max\(\s*Style\.space\(28\),\s*justificationText\.(height|implicitHeight)/.test(boxBlock),
+  'polkit justification box height follows wrapped text with a single-line floor'
+)
+assert(
+  /fingerprintMode/.test(agentQml) && /OpticalGlyph/.test(agentQml),
+  'polkit keeps the fingerprint-mode card path intact'
 )
 JS


### PR DESCRIPTION
## Summary

The polkit justification chip used a fixed `Style.space(28)` height and `Text.ElideMiddle`, so long `pkexec` commands lost most of their argv — often the informative middle — while only the ends stayed visible.

## Fix

- `wrapMode: Text.Wrap` inside a readable width cap (`Style.space(480)`, not full panel)
- Box height follows wrapped text with a single-line floor
- `maximumLineCount: 4` with `ElideRight` only past the cap
- Keep `textFormat: Text.PlainText` and the fingerprint card path

Fixes #9872

## Test plan

- [x] Reproduced prior structure: fixed height + `ElideMiddle`
- [x] `bash test/shell.d/polkit-test.sh` — existing PolkitModel cases plus justification structure asserts (wrap, no middle elide, width cap, height follows text, fingerprint path intact)