### PR TITLE
Load personal Hyprland overrides through require_optional.safe

### DIFF
--- a/config/hypr/hyprland.lua
+++ b/config/hypr/hyprland.lua
@@ -16,11 +16,16 @@ require("default.hypr.omarchy")
 -- Put your personal overrides in these files. They're loaded after Omarchy's
 -- defaults so package updates can improve the defaults without rewriting your
 -- ~/.config/hypr files.
-require("hypr.monitors")
-require("hypr.input")
-require("hypr.bindings")
-require("hypr.looknfeel")
-require("hypr.autostart")
+--
+-- Bindings first, each via require_optional.safe: a syntax/runtime error in
+-- monitors or input must not abort evaluation before keybindings load, or the
+-- session starts with no Super shortcuts and no recovery path (#9721).
+local require_optional = require("default.hypr.require_optional")
+require_optional.safe("hypr.bindings")
+require_optional.safe("hypr.monitors")
+require_optional.safe("hypr.input")
+require_optional.safe("hypr.looknfeel")
+require_optional.safe("hypr.autostart")
 
 -- Toggle config flags dynamically.
 require("default.hypr.toggles")

--- a/default/hypr/require_optional.lua
+++ b/default/hypr/require_optional.lua
@@ -1,11 +1,26 @@
 -- Require a module only when it can be found on package.path.
--- Errors inside existing modules still surface normally.
+-- Errors inside existing modules still surface normally from module().
+-- Use safe() for user overrides that must not abort the rest of the config.
 
 local M = {}
 
 function M.module(module)
   if package.searchpath(module, package.path) then
     return require(module)
+  end
+end
+
+-- Load when present; log and continue if the module itself errors. Used by the
+-- user hyprland.lua so a broken monitors/input file cannot strand the session
+-- without keybindings (#9721).
+function M.safe(module)
+  if not package.searchpath(module, package.path) then
+    return
+  end
+
+  local ok, err = pcall(require, module)
+  if not ok then
+    print("[Omarchy Config Error] Failed to load " .. module .. ": " .. tostring(err))
   end
 end
 

--- a/test/shell.d/hyprland-safe-require-test.sh
+++ b/test/shell.d/hyprland-safe-require-test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+
+# #9721: a broken personal monitors/input module must not prevent hypr.bindings
+# from loading. require_optional.safe pcall-wraps user overrides; hyprland.lua
+# loads bindings first.
+
+entry="$ROOT/config/hypr/hyprland.lua"
+grep -F 'require_optional.safe("hypr.bindings")' "$entry" >/dev/null ||
+  fail "hyprland.lua loads personal bindings through require_optional.safe"
+grep -F 'require_optional.safe("hypr.monitors")' "$entry" >/dev/null ||
+  fail "hyprland.lua loads monitors through require_optional.safe"
+grep -F 'require_optional.safe("hypr.input")' "$entry" >/dev/null ||
+  fail "hyprland.lua loads input through require_optional.safe"
+
+# Bindings must appear before monitors so a monitors failure cannot strand the
+# session without Super shortcuts even if safe() were bypassed.
+bindings_line=$(grep -n 'require_optional.safe("hypr.bindings")' "$entry" | head -n1 | cut -d: -f1)
+monitors_line=$(grep -n 'require_optional.safe("hypr.monitors")' "$entry" | head -n1 | cut -d: -f1)
+(( bindings_line < monitors_line )) ||
+  fail "hyprland.lua loads bindings before monitors" "bindings=$bindings_line monitors=$monitors_line"
+pass "hyprland.lua loads personal overrides safely with bindings first"
+
+if grep -E '^\s*require\("hypr\.(monitors|input|bindings|looknfeel|autostart)"\)' "$entry" >/dev/null; then
+  fail "hyprland.lua must not bare-require personal override modules"
+fi
+pass "hyprland.lua does not bare-require personal override modules"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/config/hypr"
+
+# Broken monitors module: syntax/runtime error on load.
+cat >"$test_tmp/config/hypr/monitors.lua" <<'LUA'
+error("broken monitors fixture")
+LUA
+
+# Bindings module records that it ran.
+cat >"$test_tmp/config/hypr/bindings.lua" <<LUA
+local f = assert(io.open("$test_tmp/bindings-loaded", "w"))
+f:write("yes\n")
+f:close()
+LUA
+
+# Empty optional peers so searchpath finds them without erroring.
+: >"$test_tmp/config/hypr/input.lua"
+: >"$test_tmp/config/hypr/looknfeel.lua"
+: >"$test_tmp/config/hypr/autostart.lua"
+
+HOME="$test_tmp" XDG_CONFIG_HOME="$test_tmp/config" OMARCHY_PATH="$ROOT" \
+  lua <<'LUA' >"$test_tmp/lua.out" 2>"$test_tmp/lua.err"
+package.path = os.getenv("XDG_CONFIG_HOME") .. "/?.lua;"
+  .. os.getenv("XDG_CONFIG_HOME") .. "/?/init.lua;"
+  .. os.getenv("OMARCHY_PATH") .. "/?.lua;"
+  .. os.getenv("OMARCHY_PATH") .. "/?/init.lua;"
+  .. package.path
+
+-- Stub the heavy defaults package so we only exercise the personal require path.
+package.preload["default.hypr.omarchy"] = function() end
+package.preload["default.hypr.toggles"] = function() end
+package.preload["default.hypr.bootstrap"] = function() end
+
+-- bootstrap is dofile()'d from the absolute path; provide a no-op file load
+-- by intercepting dofile for the bootstrap path only.
+local real_dofile = dofile
+function dofile(path)
+  if type(path) == "string" and path:find("bootstrap%.lua") then
+    return
+  end
+  return real_dofile(path)
+end
+
+local ok, err = pcall(dofile, os.getenv("OMARCHY_PATH") .. "/config/hypr/hyprland.lua")
+if not ok then
+  io.stderr:write(tostring(err) .. "\n")
+  os.exit(1)
+end
+LUA
+
+[[ -f $test_tmp/bindings-loaded ]] ||
+  fail "bindings still load when monitors.lua errors" "$(cat "$test_tmp/lua.err"; cat "$test_tmp/lua.out")"
+grep -F 'Failed to load hypr.monitors' "$test_tmp/lua.out" >/dev/null ||
+  grep -F 'Failed to load hypr.monitors' "$test_tmp/lua.err" >/dev/null ||
+  fail "safe_require reports the failed monitors module" "$(cat "$test_tmp/lua.out"; cat "$test_tmp/lua.err")"
+pass "broken hypr.monitors does not prevent hypr.bindings from loading"
+
+# require_optional.safe itself: missing module is a no-op; present broken module logs.
+HOME="$test_tmp" OMARCHY_PATH="$ROOT" lua <<'LUA' >"$test_tmp/safe.out" 2>"$test_tmp/safe.err"
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+local require_optional = require("default.hypr.require_optional")
+require_optional.safe("definitely.missing.module")
+package.path = os.getenv("HOME") .. "/config/?.lua;" .. package.path
+require_optional.safe("hypr.monitors")
+LUA
+grep -F 'Failed to load hypr.monitors' "$test_tmp/safe.out" >/dev/null ||
+  grep -F 'Failed to load hypr.monitors' "$test_tmp/safe.err" >/dev/null ||
+  fail "require_optional.safe logs module errors" "$(cat "$test_tmp/safe.out"; cat "$test_tmp/safe.err")"
+pass "require_optional.safe logs errors and ignores missing modules"


### PR DESCRIPTION
## Summary

`config/hypr/hyprland.lua` bare-required personal modules in order `monitors → input → bindings`. A syntax or runtime error in `monitors.lua` / `input.lua` aborted Lua before bindings loaded, so the desktop came up with wallpaper and bar but no Super shortcuts and no recovery path.

## Fix

- Add `require_optional.safe()` — pcall `require`, log failures, continue
- Load personal overrides through `safe()`, with **bindings first**
- Keep package defaults on hard `require`

Fixes #9721

## Test plan

- [x] Reproduced bare `require("hypr.monitors")` before bindings in shipped entrypoint
- [x] `bash test/shell.d/hyprland-safe-require-test.sh`
  - entrypoint uses `safe()` and bindings-before-monitors order
  - no bare personal requires
  - broken `hypr.monitors` still lets `hypr.bindings` load and logs the failure