### PR TITLE
Keep wttr coordinate fallbacks intact in weather location

### DIFF
--- a/bin/omarchy-weather-location
+++ b/bin/omarchy-weather-location
@@ -21,7 +21,12 @@ case "${1:-}" in
   [[ -f $LOC_FILE ]] && name=$(jq -r '.name // "" | if type == "string" then . else "" end' "$LOC_FILE" 2>/dev/null)
   if [[ -z $name ]]; then
     name=$(curl -fsS --max-time 4 "https://wttr.in/?format=%l" 2>/dev/null)
-    name=${name%%,*}
+    # wttr %l is usually "City, Country". When it cannot resolve a city it
+    # returns raw "lat,lon" instead — stripping at the first comma then leaves
+    # a bare latitude (#9706). Keep coordinate pairs intact.
+    if [[ -n $name && ! $name =~ $COORDS_PATTERN ]]; then
+      name=${name%%,*}
+    fi
   fi
   [[ -n $name ]] && echo "$name"
   ;;

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -182,3 +182,34 @@ pass "weather location rejects malformed coordinates"
 weather_location --clear
 [[ ! -e "$test_tmp/.local/state/omarchy/settings/weather.json" ]] || fail "weather location clear removes the state file"
 pass "weather location clear removes the state file"
+
+# Auto-detect path: stub curl so we do not hit the network. When wttr falls
+# back to raw coordinates, the label must keep the full pair (#9706).
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/curl" <<'SH'
+#!/bin/bash
+printf '%s\n' "${TEST_WTTR_LOCATION:-}"
+SH
+chmod +x "$stub_bin/curl"
+
+run_auto_location() {
+  HOME="$test_tmp" PATH="$stub_bin:$PATH" \
+    TEST_WTTR_LOCATION="$1" \
+    "$ROOT/bin/omarchy-weather-location"
+}
+
+[[ $(run_auto_location '37.751000,-97.822000') == '37.751000,-97.822000' ]] ||
+  fail "weather location keeps full coordinate fallback from wttr" "$(run_auto_location '37.751000,-97.822000')"
+pass "weather location keeps full coordinate fallback from wttr"
+
+[[ $(run_auto_location 'Malibu, United States') == 'Malibu' ]] ||
+  fail "weather location still strips country from a city label" "$(run_auto_location 'Malibu, United States')"
+pass "weather location still strips country from a city label"
+
+[[ $(run_auto_location 'Tokyo') == 'Tokyo' ]] ||
+  fail "weather location returns a bare city name" "$(run_auto_location 'Tokyo')"
+pass "weather location returns a bare city name"
+
+[[ -z $(run_auto_location '') ]] || fail "weather location stays quiet when wttr returns nothing"
+pass "weather location stays quiet when wttr returns nothing"


### PR DESCRIPTION
## Summary

`omarchy weather location` (no args) auto-detects via `wttr.in/?format=%l` and stripped at the first comma for `City, Country`. When wttr cannot resolve a city it returns `lat,lon`; the same strip left a bare latitude (e.g. `37.751000`).

## Fix

If the response matches the existing `COORDS_PATTERN`, keep the full pair. Otherwise still strip the country suffix.

Fixes #9706

## Test plan

- [x] Reproduced: `37.751000,-97.822000` → `${name%%,*}` → `37.751000`
- [x] `bash test/shell.d/weather-test.sh` — prior cases plus stubbed curl:
  - coordinate fallback kept whole
  - `City, Country` still becomes city
  - bare city and empty responses unchanged