### PR TITLE
Enable Sunshine by its real systemd user unit name

### DIFF
--- a/bin/omarchy-install-service-sunshine
+++ b/bin/omarchy-install-service-sunshine
@@ -13,9 +13,11 @@ SUNSHINE_ADMIN_APP="Sunshine Admin"
 SUNSHINE_ADMIN_URL="https://localhost:47990"
 SUNSHINE_ADMIN_EXEC="omarchy-launch-webapp $SUNSHINE_ADMIN_URL --ignore-certificate-errors"
 SUNSHINE_ICON_SOURCE="/usr/share/sunshine/web/images/logo-sunshine-45.png"
+# Package unit name. Alias=sunshine.service only appears after enable, so the
+# first enable must use this name rather than the alias (#9775 / #9710).
+SUNSHINE_UNIT="app-dev.lizardbyte.app.Sunshine.service"
 HYPR_AUTOSTART_FILE="$HOME/.config/hypr/autostart.lua"
 HYPR_AUTOSTART_ENTRY='o.launch_on_start("sunshine")'
-
 open_ufw_port_for_private_lans() {
   local proto="$1"
   local port="$2"
@@ -71,8 +73,7 @@ enable_hyprland_autostart() {
 
 echo "Installing Sunshine..."
 omarchy-pkg-add sunshine
-systemctl --user enable --now sunshine
-
+systemctl --user enable --now "$SUNSHINE_UNIT"
 echo "Opening Sunshine firewall ports..."
 open_ufw_ports
 

--- a/bin/omarchy-remove-service-sunshine
+++ b/bin/omarchy-remove-service-sunshine
@@ -59,9 +59,10 @@ disable_hyprland_autostart() {
   fi
 }
 
+# Prefer the real unit; also clear the alias name if only that remains.
+systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service 2>/dev/null || true
 systemctl --user disable --now sunshine 2>/dev/null || true
-omarchy-pkg-drop sunshine
-omarchy-webapp-remove "$SUNSHINE_ADMIN_APP" 2>/dev/null || true
+omarchy-pkg-drop sunshineomarchy-webapp-remove "$SUNSHINE_ADMIN_APP" 2>/dev/null || true
 disable_hyprland_autostart
 close_ufw_ports
 

--- a/test/shell.d/sunshine-service-test.sh
+++ b/test/shell.d/sunshine-service-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+home="$test_tmp/home"
+log="$test_tmp/systemctl.log"
+mkdir -p "$stub_bin" "$home/.config/hypr"
+
+# Fresh install: sunshine.service alias does not exist until the real unit is
+# enabled. Enabling by the alias must fail; enabling by the package unit works.
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TEST_SYSTEMCTL_LOG"
+if [[ ${1:-} == "--user" && ${2:-} == "enable" && ${3:-} == "--now" ]]; then
+  unit=${4:-}
+  case "$unit" in
+    app-dev.lizardbyte.app.Sunshine.service)
+      exit 0
+      ;;
+    sunshine|sunshine.service)
+      echo "Failed to enable unit: Unit sunshine.service does not exist" >&2
+      exit 1
+      ;;
+    *)
+      echo "unexpected unit: $unit" >&2
+      exit 1
+      ;;
+  esac
+fi
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-pkg-drop" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+# Report ufw missing so install skips firewall work in this fixture.
+[[ $1 == ufw ]]
+SH
+
+cat >"$stub_bin/omarchy-webapp-install" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-launch-webapp" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$stub_bin"/*
+
+: >"$log"
+HOME="$home" PATH="$stub_bin:$PATH" TEST_SYSTEMCTL_LOG="$log" \
+  bash "$ROOT/bin/omarchy-install-service-sunshine" >"$test_tmp/out" 2>"$test_tmp/err" ||
+  fail "sunshine install succeeds when enabling the real unit" "$(cat "$test_tmp/err"; cat "$test_tmp/out")"
+
+grep -F 'enable --now app-dev.lizardbyte.app.Sunshine.service' "$log" >/dev/null ||
+  fail "sunshine install enables the package unit name" "$(cat "$log")"
+if grep -E 'enable --now sunshine(\.service)?$' "$log" >/dev/null; then
+  fail "sunshine install must not enable by the unrealized alias" "$(cat "$log")"
+fi
+pass "sunshine install enables app-dev.lizardbyte.app.Sunshine.service"
+
+grep -F 'o.launch_on_start("sunshine")' "$home/.config/hypr/autostart.lua" >/dev/null ||
+  fail "sunshine install adds hyprland autostart" "$(cat "$home/.config/hypr/autostart.lua" 2>/dev/null)"
+pass "sunshine install completes past enable into autostart"
+
+# Source-level guard: install script documents and uses the real unit constant.
+grep -F 'SUNSHINE_UNIT="app-dev.lizardbyte.app.Sunshine.service"' \
+  "$ROOT/bin/omarchy-install-service-sunshine" >/dev/null ||
+  fail "install script defines SUNSHINE_UNIT"
+grep -F 'enable --now "$SUNSHINE_UNIT"' "$ROOT/bin/omarchy-install-service-sunshine" >/dev/null ||
+  fail "install script enables via SUNSHINE_UNIT"
+pass "install script sources the real Sunshine unit name"


### PR DESCRIPTION
## Summary

`omarchy install service sunshine` ran `systemctl --user enable --now sunshine`. The package only ships `app-dev.lizardbyte.app.Sunshine.service` with `Alias=sunshine.service` in `[Install]`. That alias is created on enable, so enabling by the alias on a fresh install fails with `Unit sunshine.service does not exist` and `set -e` aborts before firewall, webapp, and autostart.

## Fix

Enable/disable the real unit name. Remove still falls back to the alias if present.

Fixes #9775  
Fixes #9710

## Test plan

- [x] Reproduced: enable by `sunshine` fails; enable by package unit succeeds
- [x] `bash test/shell.d/sunshine-service-test.sh` — install stubs enable real unit, does not use alias, completes autostart