### PR TITLE
Survive an unset OMARCHY_PATH in the update pipeline

### DIFF
--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# Reached from `sudo omarchy update` through omarchy-update-status, where sudo's
+# env_reset has already dropped the session's OMARCHY_PATH.
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+
 updates=()
 
 if [[ $OMARCHY_PATH != "/usr/share/omarchy" ]]; then

--- a/bin/omarchy-update-dev
+++ b/bin/omarchy-update-dev
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# `sudo omarchy update` runs no shell that sources default/bash/env-bootstrap,
+# and sudo's env_reset has already dropped the session's copy.
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+
 [[ $OMARCHY_PATH != "/usr/share/omarchy" ]] || exit 0
 
 if ! git -C "$OMARCHY_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/test/shell.d/update-available-test.sh
+++ b/test/shell.d/update-available-test.sh
@@ -211,3 +211,17 @@ grep -Fx 'omarchy-dev-checkout 1 new commit on origin/quattro' "$stdout" >/dev/n
   fail "update checker reports cached dev commits after a fetch failure" "$(cat "$stdout")"
 [[ ! -s $stderr ]] || fail "update checker keeps dev fetch failures quiet" "$(cat "$stderr")"
 pass "update checker uses cached dev state when fetching is unavailable"
+
+: >"$git_log"
+if TEST_CHECKUPDATES=updates TEST_INSTALLED_PACKAGE=omarchy TEST_GIT_LOG="$git_log" \
+  PATH="$stub_bin:$PATH" env -u OMARCHY_PATH \
+  "$ROOT/bin/omarchy-update-available" >"$stdout" 2>"$stderr"; then
+  status=0
+else
+  status=$?
+fi
+[[ ! -s $stderr ]] || fail "sudo's stripped environment does not break the update checker" "$(cat "$stderr")"
+[[ $status -eq 0 ]] || fail "update checker still reports package updates without OMARCHY_PATH"
+grep -q '^omarchy ' "$stdout" || fail "update checker still reports package updates without OMARCHY_PATH" "$(cat "$stdout")"
+[[ ! -s $git_log ]] || fail "an unset OMARCHY_PATH checks no dev checkout" "$(cat "$git_log")"
+pass "an unset OMARCHY_PATH means the package install"

--- a/test/shell.d/update-dev-test.sh
+++ b/test/shell.d/update-dev-test.sh
@@ -59,6 +59,14 @@ run_dev_update /usr/share/omarchy
 pass "package-backed updates skip the dev checkout step"
 
 : >"$git_log"
+if ! TEST_GIT_LOG="$git_log" PATH="$stub_bin:$PATH" \
+  env -u OMARCHY_PATH "$ROOT/bin/omarchy-update-dev" 2>"$test_tmp/unset.err"; then
+  fail "sudo's stripped environment does not abort the update" "$(cat "$test_tmp/unset.err")"
+fi
+[[ ! -s $git_log ]] || fail "an unset OMARCHY_PATH means the package install" "$(cat "$git_log")"
+pass "an unset OMARCHY_PATH means the package install"
+
+: >"$git_log"
 run_dev_update "$checkout"
 grep -Fx -- "-C $checkout pull --ff-only" "$git_log" >/dev/null ||
   fail "dev checkout update pulls its upstream with fast-forward only" "$(cat "$git_log")"


### PR DESCRIPTION
`sudo omarchy update` aborts right after the system snapshot with `/usr/bin/omarchy-update-dev: line 7: OMARCHY_PATH: unbound variable`, before any package is upgraded.

`OMARCHY_PATH` is established by `default/bash/env-bootstrap`, which runs only from a login shell, an interactive rc, or the uwsm session environment. `sudo` execs the router directly under its default `env_reset`, and `omarchy-update:12` re-execs itself through `script -qefc`, so none of those run and the variable is unset. `omarchy-update-dev:5,7` is `set -euo pipefail` with a bare `$OMARCHY_PATH`, so `set -u` kills it and the ERR trap at `omarchy-update:19` aborts the whole update. `omarchy-update-available:5,9` carries the identical defect and is reached from the same run through `omarchy-update-status`; it is quieter only because its caller puts it in an `if` condition, where the death reads as "no updates".

Both now fall back to `/usr/share/omarchy`, which is the value `env-bootstrap:13-14` itself picks when no dev-link config is present, and which `omarchy-migrate:31` already defaults to one step later in this same pipeline. A dev-linked checkout is not pulled under `sudo`: `omarchy-dev-link` grants sudo a `secure_path` and no `env_keep`, and pulling a user-owned checkout as root would leave root-owned objects behind.

This stops the abort. It does not make a root-run update correct, and it is not meant to: migrations, hooks, AUR and mise updates read root's `$HOME`, `omarchy-restart-shell:9` resolves an empty path, and `omarchy-shell -q` turns the missing variable into quiet success. Whether `sudo omarchy update` should be supported at all, refused with a message, or made to drop back to the invoking user is a separate decision, and this change does not settle it either way.

Fixes #8369
Fixes #9953