### PR TITLE
Fix Obsidian Electron flags and float Mullvad VPN

### DIFF
--- a/config/obsidian/user-flags.conf
+++ b/config/obsidian/user-flags.conf
@@ -1,3 +1,4 @@
 # Obsidian reads this file through the Arch package wrapper.
--disable-gpu
+--disable-gpu
+--ozone-platform-hint=auto
 --enable-wayland-ime

--- a/default/hypr/apps/mullvad.lua
+++ b/default/hypr/apps/mullvad.lua
@@ -1,0 +1,6 @@
+-- Mullvad VPN is a fixed-aspect companion popup; tiling stretches the map.
+o.window("^(Mullvad VPN|mullvad-vpn|Mullvad)$", {
+  float = true,
+  center = true,
+  size = { 380, 640 },
+})

--- a/test/shell.d/obsidian-mullvad-test.sh
+++ b/test/shell.d/obsidian-mullvad-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+flags="$ROOT/config/obsidian/user-flags.conf"
+[[ -f $flags ]] || fail "obsidian user-flags.conf is shipped"
+
+# Single-dash -disable-gpu is not a valid Electron flag (#9781).
+if grep -E '^-disable-gpu' "$flags" >/dev/null; then
+  fail "obsidian flags must not use a single-dash -disable-gpu"
+fi
+grep -Fx -- '--disable-gpu' "$flags" >/dev/null ||
+  fail "obsidian flags include --disable-gpu"
+grep -E '^--ozone-platform-hint=' "$flags" >/dev/null ||
+  fail "obsidian flags include an ozone platform hint for Wayland"
+grep -Fx -- '--enable-wayland-ime' "$flags" >/dev/null ||
+  fail "obsidian flags keep wayland IME support"
+pass "obsidian user-flags.conf uses valid Electron flags"
+
+mullvad="$ROOT/default/hypr/apps/mullvad.lua"
+[[ -f $mullvad ]] || fail "mullvad app rule is shipped"
+grep -E 'float\s*=\s*true' "$mullvad" >/dev/null || fail "mullvad rule floats the window"
+grep -E 'center\s*=\s*true' "$mullvad" >/dev/null || fail "mullvad rule centers the window"
+grep -E 'Mullvad VPN|mullvad-vpn' "$mullvad" >/dev/null ||
+  fail "mullvad rule matches Mullvad VPN window class/title"
+pass "mullvad app rule floats and centers the VPN window"
+
+# default.hypr.apps require_all loads every .lua under default/hypr/apps.
+apps_loader="$ROOT/default/hypr/apps.lua"
+grep -F 'default/hypr/apps' "$apps_loader" >/dev/null ||
+  fail "apps.lua loads the apps directory"
+pass "mullvad.lua is picked up by default.hypr.apps require_all"


### PR DESCRIPTION
## Summary

1. **Obsidian** `config/obsidian/user-flags.conf` used `-disable-gpu` (single dash; invalid Electron flag) and lacked a Wayland ozone hint.
2. **Mullvad VPN** had no Hyprland app rule, so the fixed-aspect GUI was tiled and stretched.

## Fix

- `--disable-gpu` and `--ozone-platform-hint=auto` (keep `--enable-wayland-ime`)
- `default/hypr/apps/mullvad.lua`: float, center, size `{ 380, 640 }`

Fixes #9781

## Test plan

- [x] Reproduced prior `-disable-gpu` line on quattro
- [x] `bash test/shell.d/obsidian-mullvad-test.sh` — flag validity, mullvad rule shape, apps loader pickup