### PR TITLE
Render bar tooltips as StyledText for rich plugin markup

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -1105,7 +1105,9 @@ Item {
 
         Text {
           id: tooltipLabel
-          textFormat: Text.PlainText
+          // StyledText: deliberate rich tooltips (custom plugins) without the
+          // AutoText→RichText path that fetches remote <img> URLs (#9940).
+          textFormat: Text.StyledText
           anchors.centerIn: parent
           text: root.tooltipText
           color: Color.tooltip.text

--- a/test/shell.d/bar-tooltip-format-test.sh
+++ b/test/shell.d/bar-tooltip-format-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+bar_qml="$ROOT/shell/plugins/bar/Bar.qml"
+[[ -f $bar_qml ]] || fail "bar QML is present"
+
+# Extract a short window after tooltipLabel for format assertions (#9940).
+block=$(awk '
+  /id: tooltipLabel/ { grab = 1 }
+  grab { print; n++ }
+  grab && n >= 12 { exit }
+' "$bar_qml")
+
+[[ -n $block ]] || fail "tooltipLabel block is present in Bar.qml"
+[[ $block == *'textFormat:'* ]] || fail "tooltipLabel declares textFormat" "$block"
+
+if [[ $block == *'textFormat: Text.PlainText'* ]]; then
+  fail "tooltipLabel must not force PlainText (breaks rich HTML tooltips)" "$block"
+fi
+
+[[ $block == *'textFormat: Text.StyledText'* ]] ||
+  fail "tooltipLabel uses StyledText for deliberate rich tooltips" "$block"
+pass "bar tooltipLabel uses StyledText for rich tooltips"
+
+# Must still satisfy the dynamic-text security scan (explicit textFormat).
+require_command python3
+if printf '%s\n' "$(python3 "$ROOT/test/shell.d/qml-text-format-scan.py" "$ROOT" 2>/dev/null || true)" |
+  grep -F 'Bar.qml' | grep -F 'tooltip' >/dev/null; then
+  fail "tooltipLabel must not appear as a textFormat scan violation"
+fi
+pass "tooltipLabel keeps an explicit textFormat for the security scan"


### PR DESCRIPTION
## Summary

`Bar.qml` `tooltipLabel` used `textFormat: Text.PlainText`, so rich HTML tooltips from custom bar plugins rendered as raw markup on one line (regression vs 4.0.1 AutoText).

## Fix

Use `Text.StyledText` — deliberate markup without AutoText’s remote `<img>` fetch path (keeps the qml-text-format security contract of an explicit `textFormat`).

Fixes #9940

## Test plan

- [x] Confirmed PlainText on quattro `tooltipLabel`
- [x] `bash test/shell.d/bar-tooltip-format-test.sh` — StyledText present, not PlainText, scan clean