### PR TITLE
Resolve notification image-path through iconSource

### DIFF
--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -35,8 +35,10 @@ BorderSurface {
   signal closeRequested()
   signal cardClicked()
   // Prefer per-notification media/avatar data, then fall back to the app icon.
-  // The `check` flag avoids Qt's missing-texture placeholder for unknown names.
-  readonly property string smallIconSource: image.length > 0 ? image : iconSource(appIcon)
+  // image-path may be a URI *or* a themed icon name (notify-send -i); both must
+  // go through iconSource so missing names become "" instead of Qt's pink
+  // placeholder (#9920).
+  readonly property string smallIconSource: image.length > 0 ? iconSource(image) : iconSource(appIcon)
   readonly property bool hasGlyph: glyph.length > 0
   readonly property bool compactGlyph: NotificationLogic.shouldRenderCompactGlyph(glyph, smallIconSource, singleLineToast)
   readonly property bool hasSmallIcon: smallIconSource.length > 0

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -723,4 +723,20 @@ assert(
   !/pendingModel|pastModel/.test(serviceQml),
   'notifications service keeps no in-memory history models'
 )
+
+// image-path may be a themed icon name (notify-send -i). Routing the raw string
+// into Image.source paints Qt's missing-texture placeholder; iconSource() must
+// resolve both image and appIcon (#9920). cardQml is loaded earlier in this file.
+assert(
+  /smallIconSource:\s*image\.length\s*>\s*0\s*\?\s*iconSource\(image\)\s*:\s*iconSource\(appIcon\)/.test(cardQml),
+  'notifications card resolves image-path through iconSource like appIcon'
+)
+assert(
+  !/smallIconSource:\s*image\.length\s*>\s*0\s*\?\s*image\s*:/.test(cardQml),
+  'notifications card does not feed bare image-path strings to Image.source'
+)
+assert(
+  /function iconSource\(icon\)/.test(cardQml) && /Quickshell\.iconPath\(value,\s*true\)/.test(cardQml),
+  'notifications card iconSource checks themed names before painting'
+)
 JS


### PR DESCRIPTION
## Summary

`NotificationCard` preferred `image` over `appIcon` but only ran `appIcon` through `iconSource()`. Spec `image-path` may be a themed icon name (`notify-send -i`); a bare name was treated as a relative URL and Qt painted the magenta missing-texture placeholder.

## Fix

```qml
readonly property string smallIconSource: image.length > 0 ? iconSource(image) : iconSource(appIcon)
```

Missing themed names become `""` and the existing slot visibility guard hides the icon.

Fixes #9920

## Test plan

- [x] Reproduced bare `image` ternary on quattro
- [x] `bash test/shell.d/notifications-test.sh` — prior cases plus image-path routed through `iconSource`