### PR TITLE
Ignore quickshell surfaces when matching launch windows

### DIFF
--- a/bin/omarchy-launch-or-focus
+++ b/bin/omarchy-launch-or-focus
@@ -10,7 +10,14 @@ fi
 
 WINDOW_PATTERN="$1"
 LAUNCH_COMMAND="${2:-"uwsm-app -- $WINDOW_PATTERN"}"
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '.[]|select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))|.address' | head -n1)
+# Quickshell layer/plugin windows often put the app name in the title; they are
+# not focusable app windows and must not satisfy launch-or-focus (#9901).
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r --arg p "$WINDOW_PATTERN" '
+  .[]
+  | select(.class != "org.quickshell")
+  | select((.class|test("\\b" + $p + "\\b";"i")) or (.title|test("\\b" + $p + "\\b";"i")))
+  | .address
+' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"

--- a/bin/omarchy-launch-signal
+++ b/bin/omarchy-launch-signal
@@ -4,7 +4,12 @@
 
 set -e
 
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[]|select((.class|test("\\bsignal\\b";"i")) or (.title|test("\\bsignal\\b";"i")))|.address' | head -n1)
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '
+  .[]
+  | select(.class != "org.quickshell")
+  | select((.class|test("\\bsignal\\b";"i")) or (.title|test("\\bsignal\\b";"i")))
+  | .address
+' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"

--- a/bin/omarchy-launch-spotify
+++ b/bin/omarchy-launch-spotify
@@ -4,7 +4,14 @@
 
 set -e
 
-WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '.[]|select((.class|test("\\bspotify\\b";"i")) or (.title|test("\\bspotify\\b";"i")))|.address' | head -n1)
+# Skip org.quickshell surfaces: the quickshell.spotify plugin titles itself
+# "Omarchy Spotify" and would steal focus/match before the real client (#9901).
+WINDOW_ADDRESS=$(hyprctl clients -j | jq -r '
+  .[]
+  | select(.class != "org.quickshell")
+  | select((.class|test("\\bspotify\\b";"i")) or (.title|test("\\bspotify\\b";"i")))
+  | .address
+' | head -n1)
 
 if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"

--- a/test/shell.d/launch-spotify-test.sh
+++ b/test/shell.d/launch-spotify-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+clients_json="$test_tmp/clients.json"
+dispatch_log="$test_tmp/dispatch.log"
+spotify_bin="$stub_bin/spotify"
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ ${1:-} == clients && ${2:-} == -j ]]; then
+  cat "$TEST_CLIENTS_JSON"
+  exit 0
+fi
+if [[ ${1:-} == dispatch ]]; then
+  printf '%s\n' "$*" >>"$TEST_DISPATCH_LOG"
+  exit 0
+fi
+exit 0
+SH
+
+cat >"$spotify_bin" <<'SH'
+#!/bin/bash
+printf 'spotify-launched\n' >>"$TEST_SPOTIFY_LOG"
+exit 0
+SH
+
+# setsid/uwsm-app: run the remaining argv so the stub spotify is reached.
+cat >"$stub_bin/setsid" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+cat >"$stub_bin/uwsm-app" <<'SH'
+#!/bin/bash
+# omarchy-launch-spotify uses: setsid uwsm-app -- /usr/bin/spotify
+while [[ $# -gt 0 && $1 != "--" ]]; do shift; done
+[[ ${1:-} == "--" ]] && shift
+exec "$@"
+SH
+
+chmod +x "$stub_bin"/*
+
+export PATH="$stub_bin:$PATH"
+export TEST_CLIENTS_JSON="$clients_json"
+export TEST_DISPATCH_LOG="$dispatch_log"
+export TEST_SPOTIFY_LOG="$test_tmp/spotify.log"
+
+# Point the launcher at our stub binary path by placing it as /usr/bin/spotify
+# is hardcoded — override via a wrapper script that we inject by rewriting PATH
+# won't work for absolute /usr/bin/spotify. Patch a copy of the launcher.
+launcher="$test_tmp/omarchy-launch-spotify"
+sed 's|/usr/bin/spotify|'"$spotify_bin"'|g' "$ROOT/bin/omarchy-launch-spotify" >"$launcher"
+chmod +x "$launcher"
+
+: >"$dispatch_log"
+: >"$TEST_SPOTIFY_LOG"
+
+# Only Quickshell "Omarchy Spotify" — must launch the real client (#9901).
+cat >"$clients_json" <<'JSON'
+[
+  {"class":"org.quickshell","title":"Omarchy Spotify","address":"0xqs"}
+]
+JSON
+
+"$launcher" >/dev/null 2>&1 || true
+[[ -s $TEST_SPOTIFY_LOG ]] || fail "spotify launches when only quickshell title matches" "$(cat "$dispatch_log")"
+if grep -F '0xqs' "$dispatch_log" >/dev/null; then
+  fail "must not focus the quickshell surface" "$(cat "$dispatch_log")"
+fi
+pass "spotify launches when only quickshell title matches"
+
+# Real Spotify present — focus it, do not relaunch.
+: >"$dispatch_log"
+: >"$TEST_SPOTIFY_LOG"
+cat >"$clients_json" <<'JSON'
+[
+  {"class":"org.quickshell","title":"Omarchy Spotify","address":"0xqs"},
+  {"class":"Spotify","title":"Spotify Premium","address":"0xreal"}
+]
+JSON
+"$launcher" >/dev/null 2>&1 || true
+grep -F '0xreal' "$dispatch_log" >/dev/null ||
+  fail "focuses the real Spotify client when both exist" "$(cat "$dispatch_log")"
+[[ ! -s $TEST_SPOTIFY_LOG ]] || fail "does not relaunch when real Spotify is open"
+pass "focuses real Spotify and ignores quickshell peer"
+
+# Source guard on shared helpers.
+for script in omarchy-launch-spotify omarchy-launch-or-focus omarchy-launch-signal; do
+  grep -F 'org.quickshell' "$ROOT/bin/$script" >/dev/null ||
+    fail "$script excludes org.quickshell from window match"
+done
+pass "launch helpers exclude org.quickshell from class/title match"


### PR DESCRIPTION
## Summary

`omarchy-launch-spotify` matched windows by class **or** title. The `quickshell.spotify` plugin window is `class=org.quickshell`, `title="Omarchy Spotify"`, so Super+Shift+M focused a non-focusable layer and never started `/usr/bin/spotify`.

## Fix

Exclude `class == "org.quickshell"` from the match in:

- `omarchy-launch-spotify`
- `omarchy-launch-or-focus` (same heuristic)
- `omarchy-launch-signal` (same pattern)

Fixes #9901

## Test plan

- [x] Reproduced: only QS title → buggy match `0xqs`; fixed → launch
- [x] `bash test/shell.d/launch-spotify-test.sh` — QS-only launches client; QS+real focuses real; helpers exclude quickshell