### PR TITLE
No-op dwindle-only tiling binds on scrolling workspaces

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -2,8 +2,21 @@ o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
-o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
+-- togglesplit / pseudo are dwindle-only. On scrolling workspaces the bare
+-- layoutmsg raises "no such layoutmsg for scrolling" (#9726).
+o.bind("SUPER + J", "Toggle window split", function()
+  local workspace = hl.get_active_workspace()
+  if workspace and workspace.tiled_layout == "dwindle" then
+    hl.dispatch(hl.dsp.layout("togglesplit"))
+  end
+end)
+
+o.bind("SUPER + P", "Pseudo window", function()
+  local workspace = hl.get_active_workspace()
+  if workspace and workspace.tiled_layout == "dwindle" then
+    hl.dispatch(hl.dsp.window.pseudo())
+  end
+end)
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))
 o.bind("SUPER + CTRL + F", "Tiled full screen", "omarchy-hyprland-window-tiled-fullscreen-toggle")

--- a/test/shell.d/tiling-togglesplit-test.sh
+++ b/test/shell.d/tiling-togglesplit-test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tiling="$ROOT/default/hypr/bindings/tiling.lua"
+[[ -f $tiling ]] || fail "tiling bindings are present"
+
+# Must not bare-bind togglesplit — that errors on scrolling layouts (#9726).
+if grep -E 'o\.bind\("SUPER \+ J".*hl\.dsp\.layout\("togglesplit"\)' "$tiling" >/dev/null; then
+  fail "SUPER+J must not bare-dispatch togglesplit"
+fi
+
+grep -F 'get_active_workspace' "$tiling" >/dev/null ||
+  fail "tiling guards dwindle-only binds on active workspace layout"
+grep -F 'tiled_layout == "dwindle"' "$tiling" >/dev/null ||
+  fail "tiling only dispatches togglesplit on dwindle"
+grep -F 'layout("togglesplit")' "$tiling" >/dev/null ||
+  fail "tiling still offers togglesplit on dwindle"
+pass "SUPER+J togglesplit is guarded for dwindle-only layouts"
+
+if grep -E 'o\.bind\("SUPER \+ P".*hl\.dsp\.window\.pseudo\(\)' "$tiling" >/dev/null; then
+  fail "SUPER+P must not bare-dispatch window.pseudo"
+fi
+grep -F 'window.pseudo()' "$tiling" >/dev/null ||
+  fail "tiling still offers pseudo on dwindle"
+pass "SUPER+P pseudo is guarded for dwindle-only layouts"
+
+require_command lua
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+HOME="$test_tmp" OMARCHY_PATH="$ROOT" lua <<'LUA' >"$test_tmp/out" 2>"$test_tmp/err"
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+local function proxy()
+  return setmetatable({}, {
+    __index = function(self, key)
+      local value = proxy()
+      rawset(self, key, value)
+      return value
+    end,
+    __call = function()
+      return {}
+    end,
+  })
+end
+
+local dispatched = { dwindle = 0, scrolling = 0 }
+local current = "scrolling"
+local guards = {}
+
+hl = {
+  bind = function(keys, dispatcher, opts)
+    if keys == "SUPER + J" or keys == "SUPER + P" then
+      guards[keys] = dispatcher
+    end
+  end,
+  get_active_workspace = function()
+    return { tiled_layout = current }
+  end,
+  dispatch = function(msg)
+    dispatched[current] = (dispatched[current] or 0) + 1
+  end,
+  dsp = proxy(),
+}
+
+require("default.hypr.helpers")
+dofile(os.getenv("OMARCHY_PATH") .. "/default/hypr/bindings/tiling.lua")
+
+assert(type(guards["SUPER + J"]) == "function", "SUPER + J binds a function")
+assert(type(guards["SUPER + P"]) == "function", "SUPER + P binds a function")
+
+for _, keys in ipairs({ "SUPER + J", "SUPER + P" }) do
+  current = "scrolling"
+  local before_s = dispatched.scrolling
+  guards[keys]()
+  assert(dispatched.scrolling == before_s, keys .. " must no-op on scrolling")
+
+  current = "dwindle"
+  local before_d = dispatched.dwindle
+  guards[keys]()
+  assert(dispatched.dwindle == before_d + 1, keys .. " must dispatch on dwindle")
+end
+
+print("ok")
+LUA
+
+grep -Fx ok "$test_tmp/out" >/dev/null ||
+  fail "tiling guards no-op on scrolling and dispatch on dwindle" "$(cat "$test_tmp/err"; cat "$test_tmp/out")"
+pass "tiling guards no-op on scrolling and dispatch on dwindle"


### PR DESCRIPTION
## Summary

`SUPER + J` (`togglesplit`) and `SUPER + P` (`pseudo`) are dwindle-only layout messages. On workspaces using scrolling (via `SUPER + L`), they raised `no such layoutmsg for scrolling`.

## Fix

Bind both as functions that dispatch only when `hl.get_active_workspace().tiled_layout == "dwindle"`.

Fixes #9726

## Test plan

- [x] Confirmed bare `hl.dsp.layout("togglesplit")` on SUPER+J in quattro
- [x] `bash test/shell.d/tiling-togglesplit-test.sh` — source guards + lua no-op/dispatch