### PR TITLE
Clear setgid when hardening Windows VM mount modes

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,14 +580,18 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
+  # dockurr/windows sets ~/Windows to 2777; GNU chmod 0700 keeps setgid (2700),
+  # so clear g-s explicitly or the literal 700 check fails forever (#9943).
   chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
   }
+  chmod g-s,o-t -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" 2>/dev/null || true
   storage_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$storage_fd" 2>/dev/null) || storage_mode=""
   shared_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$shared_fd" 2>/dev/null) || shared_mode=""
   if [[ $storage_mode != 700 || $shared_mode != 700 ]]; then
+    echo "omarchy-windows-vm: refusing VM mount source with unexpected mode (storage=$storage_mode shared=$shared_mode; want 700)" >&2
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
@@ -1015,7 +1019,9 @@ prepare_user_mount_sources() {
     echo "omarchy-windows-vm: storage and shared must be different directories" >&2
     return 1
   }
-  chmod 0700 -- "$storage" "$shared"
+  chmod 0700 -- "$storage" "$shared" || return 1
+  # Clear setgid/sticky the container may have left on ~/Windows (#9943).
+  chmod g-s,o-t -- "$storage" "$shared" 2>/dev/null || true
 }
 
 storage_space_path() {

--- a/test/shell.d/windows-vm-setgid-test.sh
+++ b/test/shell.d/windows-vm-setgid-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+vm="$ROOT/bin/omarchy-windows-vm"
+[[ -f $vm ]] || fail "omarchy-windows-vm is present"
+
+# Source must clear setgid after chmod 0700 (#9943).
+grep -F 'chmod g-s' "$vm" >/dev/null ||
+  fail "windows-vm clears setgid after normalizing mount modes"
+grep -F 'unexpected mode' "$vm" >/dev/null ||
+  fail "windows-vm reports unexpected mount modes instead of silent return"
+pass "windows-vm clears setgid and reports mode failures"
+
+# Reproduce GNU chmod retaining setgid, then the fix sequence.
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+dir="$test_tmp/Windows"
+mkdir -p "$dir"
+chmod 2777 "$dir"
+[[ $(stat -c '%a' "$dir") == 2777 ]] || fail "fixture starts setgid+world"
+chmod 0700 "$dir"
+[[ $(stat -c '%a' "$dir") == 2700 ]] ||
+  fail "GNU chmod 0700 retains setgid as 2700" "$(stat -c '%a' "$dir")"
+pass "reproduced: chmod 0700 leaves setgid as 2700"
+
+chmod g-s,o-t -- "$dir"
+[[ $(stat -c '%a' "$dir") == 700 ]] ||
+  fail "chmod g-s,o-t clears setgid to 700" "$(stat -c '%a' "$dir")"
+pass "chmod g-s,o-t normalizes container 2777 down to 700"
+
+# Extract and run the prepare_user_mount_sources chmod pair against a fixture.
+# Full prepare_caller_mounts needs root/bind mounts; the user-path sequence is
+# the same fix and is what every launch hits on ~/Windows.
+mkdir -p "$test_tmp/home/.windows" "$test_tmp/home/Windows"
+chmod 2777 "$test_tmp/home/Windows"
+chmod 2777 "$test_tmp/home/.windows"
+HOME="$test_tmp/home" bash -c '
+  storage="$HOME/.windows"
+  shared="$HOME/Windows"
+  chmod 0700 -- "$storage" "$shared" || exit 1
+  chmod g-s,o-t -- "$storage" "$shared" 2>/dev/null || true
+  s=$(stat -c "%a" "$storage")
+  w=$(stat -c "%a" "$shared")
+  [[ $s == 700 && $w == 700 ]]
+' || fail "user mount normalize reaches mode 700 from 2777"
+pass "user mount normalize reaches mode 700 from 2777"


### PR DESCRIPTION
## Summary

`prepare_caller_mounts` ran `chmod 0700` then required `stat -c %a` to equal `700`. The Windows container sets `~/Windows` to `2777`; GNU chmod keeps directory setgid, leaving `2700`, so launch failed with only `Failed to start Windows VM!` while status still said RUNNING. The failure self-renewed on every container start.

## Fix

- After `chmod 0700`, run `chmod g-s,o-t` on storage/shared FDs and user mount sources
- Print unexpected modes on refusal instead of a silent `return 1`

Fixes #9943

## Test plan

- [x] Reproduced: `2777` → `chmod 0700` → `2700`; `g-s,o-t` → `700`
- [x] `bash test/shell.d/windows-vm-setgid-test.sh`