### PR TITLE
Keep dictation indicator active while transcribing

### DIFF
--- a/shell/plugins/bar/indicators/Dictation.qml
+++ b/shell/plugins/bar/indicators/Dictation.qml
@@ -8,7 +8,9 @@ BarIndicator {
   property string state: "idle"
   property string icon: ""
 
-  active: state === "recording"
+  // Keep the indicator in the always-visible active block while voxtype is
+  // either recording or still transcribing (#9675).
+  active: state === "recording" || state === "transcribing"
   activeText: icon
   inactiveText: "󰍬"
   activeTooltipText: state

--- a/test/shell.d/dictation-indicator-test.sh
+++ b/test/shell.d/dictation-indicator-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+qml="$ROOT/shell/plugins/bar/indicators/Dictation.qml"
+[[ -f $qml ]] || fail "Dictation indicator QML is present"
+
+# active must include both non-idle voxtype states (#9675).
+grep -E 'active:\s*state\s*===\s*"recording"\s*\|\|\s*state\s*===\s*"transcribing"' "$qml" >/dev/null ||
+  fail "Dictation active covers recording and transcribing" "$(grep -n 'active:' "$qml")"
+
+if grep -E 'active:\s*state\s*===\s*"recording"\s*$' "$qml" >/dev/null; then
+  fail "Dictation must not treat only recording as active"
+fi
+
+grep -F 'state === "transcribing"' "$qml" >/dev/null ||
+  fail "Dictation still maps the transcribing icon"
+grep -F '󰔟' "$qml" >/dev/null || fail "Dictation keeps the transcribing spinner glyph"
+pass "Dictation indicator stays active while recording or transcribing"


### PR DESCRIPTION
## Summary

`Dictation.qml` set `active` only for `recording`. After release, voxtype enters `transcribing` and the widget already picks the spinner icon, but `active: false` hid it in the inactive block.

## Fix

```qml
active: state === "recording" || state === "transcribing"
```

Fixes #9675

## Test plan

- [x] Confirmed `active: state === "recording"` only on quattro
- [x] `bash test/shell.d/dictation-indicator-test.sh`