### PR TITLE
Detect touchpads by controller name, not only touchpad|trackpad

### DIFF
--- a/bin/omarchy-hw-touchpad
+++ b/bin/omarchy-hw-touchpad
@@ -2,5 +2,19 @@
 
 # omarchy:summary=Print the detected Hyprland touchpad or trackpad device name
 
-device=$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad"; "i"))] | first // empty')
-[[ -n $device ]] && echo "$device"
+# Prefer an explicit touchpad/trackpad name, then common controller/vendor
+# names that never include those words (synaptics-tm3096-006, elan-*, …).
+# Do not use .touch[] — that is the touchscreen/tablet path (#9805).
+device=$(hyprctl devices -j | jq -r '
+  def name: (.name // "");
+  def explicit: name | test("touchpad|trackpad"; "i");
+  def vendor: name | test(
+    "synaptics|elan|elantech|alps|focaltech|bcm5974|apple-internal-keyboard-trackpad|pixcir|goodix.*pad|dll[0-9a-f]+";
+    "i"
+  );
+  ([.mice[]? | select(explicit) | .name] + [.mice[]? | select(vendor and (explicit | not)) | .name])
+  | first // empty
+')
+if [[ -n $device ]]; then
+  echo "$device"
+fi

--- a/test/shell.d/hw-touchpad-test.sh
+++ b/test/shell.d/hw-touchpad-test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ ${1:-} == devices && ${2:-} == -j ]]; then
+  cat "$TEST_DEVICES_JSON"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$stub_bin/hyprctl"
+
+run_detect() {
+  PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-hw-touchpad"
+}
+
+export TEST_DEVICES_JSON="$test_tmp/devices.json"
+
+# Classic name still works.
+cat >"$TEST_DEVICES_JSON" <<'JSON'
+{"mice":[{"name":"elan-touchpad"},{"name":"logitech-usb-mouse"}],"touch":[]}
+JSON
+[[ $(run_detect) == "elan-touchpad" ]] || fail "detects *touchpad* names" "$(run_detect)"
+pass "detects *touchpad* names"
+
+# Vendor/controller name with no touchpad substring (#9805).
+cat >"$TEST_DEVICES_JSON" <<'JSON'
+{"mice":[{"name":"synaptics-tm3096-006"},{"name":"logitech-g502"}],"touch":[]}
+JSON
+[[ $(run_detect) == "synaptics-tm3096-006" ]] ||
+  fail "detects synaptics controller touchpads" "$(run_detect)"
+pass "detects synaptics controller touchpads"
+
+cat >"$TEST_DEVICES_JSON" <<'JSON'
+{"mice":[{"name":"alps-1013"},{"name":"usb-mouse"}],"touch":[]}
+JSON
+[[ $(run_detect) == "alps-1013" ]] || fail "detects alps touchpads" "$(run_detect)"
+pass "detects alps touchpads"
+
+# Prefer touchpad-named device over a later vendor match.
+cat >"$TEST_DEVICES_JSON" <<'JSON'
+{"mice":[{"name":"synaptics-other"},{"name":"asup1205:00-1043:18a3-touchpad"}],"touch":[]}
+JSON
+[[ $(run_detect) == "asup1205:00-1043:18a3-touchpad" ]] ||
+  fail "prefers an explicit touchpad name when present" "$(run_detect)"
+pass "prefers an explicit touchpad name when present"
+
+# No false positive on plain USB mice only.
+cat >"$TEST_DEVICES_JSON" <<'JSON'
+{"mice":[{"name":"logitech-usb-receiver"},{"name":"razer-deathadder"}],"touch":[{"name":"wacom-touchscreen"}]}
+JSON
+out=$(run_detect)
+[[ -z $out ]] || fail "ignores plain mice and touchscreens" "got: $out"
+pass "ignores plain mice and touchscreens"
+
+# Empty devices.
+cat >"$TEST_DEVICES_JSON" <<'JSON'
+{"mice":[],"touch":[]}
+JSON
+[[ -z $(run_detect) ]] || fail "empty device list yields no name"
+pass "empty device list yields no name"


### PR DESCRIPTION
## Summary

`omarchy-hw-touchpad` only matched mouse names containing `touchpad` or `trackpad`. Controllers that enumerate as `synaptics-tm3096-006` (and similar) produced no device, so `omarchy toggle touchpad` did nothing.

## Fix

- Prefer explicit `touchpad|trackpad` names under `.mice`
- Then match common vendor/controller patterns (synaptics, elan, alps, …)
- Do not use `.touch[]` (touchscreens)

Fixes #9805

## Test plan

- [x] Reproduced: name filter missed `synaptics-tm3096-006`
- [x] `bash test/shell.d/hw-touchpad-test.sh` — classic names, vendor names, preference order, no false positives