### PR TITLE
Pin Helium password store to libsecret

### DIFF
--- a/config/helium-browser-flags.conf
+++ b/config/helium-browser-flags.conf
@@ -1,0 +1,1 @@
+--password-store=gnome-libsecret

--- a/migrations/1788439900.sh
+++ b/migrations/1788439900.sh
@@ -1,0 +1,25 @@
+echo "Pin Helium's password store to gnome-libsecret (prevents cookie/login loss on Hyprland)"
+
+# Migration 1784508556 pinned the os_crypt backend for the Chromium-based browsers Omarchy knew
+# about then, but Helium was not among them, so a Helium install still auto-detects its backend:
+# the xdg-desktop-portal Secret backend has no provider on Hyprland and fails, and the browser can
+# fall back to the 'basic' (v10) store. That makes every cookie and saved password sealed with the
+# gnome-libsecret (v11) key undecryptable, so the browser drops them and the user is logged out of
+# everything. omarchy-launch-webapp already treats helium as a supported Chromium-based browser.
+#
+# Helium's launcher reads ~/.config/helium-browser-flags.conf, named for the helium-browser command
+# rather than the profile directory, and 1784508556 only amended flags files that already existed.
+# Fresh installs receive the default from config/, while this migration seeds every existing user
+# so installing Helium after the migration ran cannot leave the browser unpinned.
+
+helium_flags_file="$HOME/.config/helium-browser-flags.conf"
+
+if [[ ! -f $helium_flags_file ]] || ! grep -Eq '^[[:space:]]*--password-store=' "$helium_flags_file"; then
+  mkdir -p "${helium_flags_file%/*}"
+
+  if [[ -f $helium_flags_file && -n $(tail -c1 "$helium_flags_file") ]]; then
+    echo >>"$helium_flags_file"
+  fi
+
+  echo '--password-store=gnome-libsecret' >>"$helium_flags_file"
+fi

--- a/test/shell.d/helium-password-store-migration-test.sh
+++ b/test/shell.d/helium-password-store-migration-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1788439900.sh"
+[[ -f $migration ]] || fail "Helium password-store migration exists"
+
+default_flags="$ROOT/config/helium-browser-flags.conf"
+[[ -f $default_flags ]] || fail "fresh installs pin Helium's password store"
+[[ $(<"$default_flags") == "--password-store=gnome-libsecret" ]] ||
+  fail "fresh installs pin Helium's password store"
+pass "fresh installs pin Helium's password store"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+run_migration() {
+  local home=$1
+
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+home="$test_dir/commented-option"
+mkdir -p "$home/.config"
+printf '%s\n' '# --password-store=basic' >"$home/.config/helium-browser-flags.conf"
+
+run_migration "$home"
+
+[[ $(<"$home/.config/helium-browser-flags.conf") == $'# --password-store=basic\n--password-store=gnome-libsecret' ]] ||
+  fail "migration ignores a commented password-store option"
+pass "migration ignores a commented password-store option"
+
+home="$test_dir/existing-user"
+mkdir -p "$home"
+
+run_migration "$home" || fail "migration prepares existing users for a future Helium install"
+
+grep -qxF -- '--password-store=gnome-libsecret' "$home/.config/helium-browser-flags.conf" ||
+  fail "migration prepares existing users for a future Helium install"
+pass "migration prepares existing users for a future Helium install"
+
+home="$test_dir/custom-option"
+mkdir -p "$home/.config"
+printf '%s\n' '--password-store=basic' >"$home/.config/helium-browser-flags.conf"
+
+run_migration "$home"
+
+[[ $(<"$home/.config/helium-browser-flags.conf") == "--password-store=basic" ]] ||
+  fail "migration preserves an active password-store choice"
+pass "migration preserves an active password-store choice"
+
+home="$test_dir/missing-newline"
+mkdir -p "$home/.config"
+printf %s '--ozone-platform=wayland' >"$home/.config/helium-browser-flags.conf"
+
+run_migration "$home"
+
+[[ $(<"$home/.config/helium-browser-flags.conf") == $'--ozone-platform=wayland\n--password-store=gnome-libsecret' ]] ||
+  fail "migration appends the pin on its own line"
+pass "migration appends the pin on its own line"
+
+before=$(sha256sum "$home/.config/helium-browser-flags.conf")
+run_migration "$home"
+after=$(sha256sum "$home/.config/helium-browser-flags.conf")
+
+[[ $before == "$after" ]] || fail "Helium password-store migration is idempotent"
+pass "Helium password-store migration is idempotent"


### PR DESCRIPTION
## Summary

- ship Helium's Arch launcher flags file with the gnome-libsecret password-store backend
- migrate existing users without overriding an active password-store choice
- cover fresh installs, existing configs, newline handling, and idempotence

## Testing

- bash test/shell.d/helium-password-store-migration-test.sh
- bash -n migrations/1788439900.sh test/shell.d/helium-password-store-migration-test.sh
- shellcheck migrations/1788439900.sh test/shell.d/helium-password-store-migration-test.sh
- shfmt -d migrations/1788439900.sh test/shell.d/helium-password-store-migration-test.sh
- ./test/all (Helium coverage passes; unrelated environment-dependent failures remain in config, launch-about, network-qr, snapper, unowned-system-paths, and update-disk-space tests)