### PR TITLE
Dismiss low battery notification when charging

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -20,6 +20,7 @@ if [[ -n $BATTERY_LEVEL && $BATTERY_LEVEL =~ ^[0-9]+$ ]]; then
       touch $NOTIFICATION_FLAG
     fi
   else
+    omarchy-notification-dismiss "Time to recharge!"
     rm -f $NOTIFICATION_FLAG
   fi
 fi


### PR DESCRIPTION
## Summary

Dismiss the persistent low-battery notification when the battery monitor detects that the device is no longer low and discharging.

The notification is critical, so Mako intentionally keeps it visible past the `notify-send` timeout. Reusing `omarchy-notification-dismiss` closes only the matching recharge notification while preserving the existing notification flag behavior.

## Testing

- `bash -n bin/omarchy-battery-monitor`
- `bash test/omarchy-cli-test.sh`
- Simulated UPower `charging` state and verified dismissal plus flag cleanup
- Simulated UPower `discharging` state at 10% and verified the warning is sent without dismissal