### PR TITLE
bluetooth: surface passkey prompt during device pairing

### DIFF
--- a/bin/omarchy-bluetooth-device
+++ b/bin/omarchy-bluetooth-device
@@ -29,10 +29,24 @@ trust_device() {
   bluetoothctl trust "$address" >/dev/null 2>&1 || true
 }
 
+# Some devices (keyboards in particular) require passkey-entry pairing: BlueZ's
+# default agent prints "[agent] Passkey: NNNNNN" on stdout and waits for the
+# user to type it on the device itself. That line was previously discarded
+# along with the rest of bluetoothctl's noise, so pairing such a device looked
+# like it just hung with no indication a code needed to be entered anywhere.
+notify_passkey() {
+  timeout 20s stdbuf -oL bluetoothctl pair "$address" 2>&1 | while IFS= read -r line; do
+    if [[ $line == *Passkey:* ]]; then
+      passkey=${line##*Passkey: }
+      omarchy-notification-send -u critical -t 20000 "Bluetooth pairing" "Type $passkey on the device, then press Enter"
+    fi
+  done || true
+}
+
 case "$action" in
   pair)
     power_on
-    timeout 20s bluetoothctl pair "$address" >/dev/null 2>&1 || true
+    notify_passkey
     trust_device
     timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 || true
     ;;


### PR DESCRIPTION
## Summary

`omarchy-bluetooth-device pair` runs `bluetoothctl pair "$address" >/dev/null 2>&1`, discarding all output. Some Bluetooth HID devices (e.g. Logitech MX Keys) require passkey-entry pairing: BlueZ's default agent prints `[agent] Passkey: NNNNNN` on stdout and waits for that code to be typed on the device itself before the pairing completes.

Because that output was redirected to `/dev/null`, pairing such a device looks like it just hangs or silently fails, with no indication anywhere that a code needs to be entered on the device. Confirmed this by hand: `bluetoothctl pair` connects, prints the passkey line, and if it's never seen/entered, the connection cycles connect/disconnect until the pairing attempt times out.

## Fix

Stream `bluetoothctl pair`'s output through a small reader instead of discarding it, watch for the `Passkey:` line, and surface it via `omarchy-notification-send` (critical urgency, 20s) so the user knows a code exists and what to type. All other output is still swallowed as before; behavior for devices that don't need passkey entry (Just Works pairing) is unchanged.

## Test plan

- [x] `bash -n` syntax check on the modified script
- [x] Mocked `bluetoothctl`/`omarchy-notification-send` to confirm the passkey line is detected and the notification fires with the right code
- [x] Mocked a Just-Works pairing flow (no `Passkey:` line) to confirm no notification fires and the script still exits cleanly
- [x] Verified against a real MX Keys keyboard pairing session that needed exactly this passkey flow