### PR TITLE
Add drop-zone candidates for empty bar sections

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -690,10 +690,12 @@ Item {
     }
 
     var candidates = []
+    var seenRegions = {}
     for (var i = 0; i < moduleSlots.length; i++) {
       var slot = moduleSlots[i]
       if (!slot || slot === sourceSlot || !slot.visible || slot.width <= 0 || slot.height <= 0) continue
       if (sourceWindow && !root.sameWindow(root.slotWindow(slot), sourceWindow)) continue
+      seenRegions[slot.region] = true
 
       var slotPoint = { x: slot.x, y: slot.y }
       try {
@@ -708,6 +710,37 @@ Item {
         width: slot.width,
         height: slot.height
       })
+    }
+
+    // Every section needs a drop-zone, even when empty (#9842).
+    // Add a thin reference candidate at the expected section edge so that
+    // nearestDropTarget can resolve the correct region when no real slots
+    // occupy that area. The candidate is 1 px wide and sits flush with the
+    // section boundary; it only wins when the cursor is inside an empty zone.
+    var barBounds = { x: 0, y: 0, width: 1, height: 1 }
+    try {
+      barBounds = root.mapToItem(null, 0, 0)
+      barBounds.width = root.width
+      barBounds.height = root.height
+    } catch (e) {}
+
+    function addEmptyRegionCandidate(region, edgeX, edgeY) {
+      if (seenRegions[region]) return
+      candidates.push({
+        slot: { region: region, moduleName: "" },
+        x: edgeX, y: edgeY,
+        width: 1, height: 1
+      })
+    }
+
+    if (root.vertical) {
+      addEmptyRegionCandidate("left",   barBounds.x, barBounds.y)
+      addEmptyRegionCandidate("center", barBounds.x, barBounds.y + barBounds.height / 2)
+      addEmptyRegionCandidate("right",  barBounds.x, barBounds.y + barBounds.height - 1)
+    } else {
+      addEmptyRegionCandidate("left",   barBounds.x, barBounds.y)
+      addEmptyRegionCandidate("center", barBounds.x + barBounds.width / 2, barBounds.y)
+      addEmptyRegionCandidate("right",  barBounds.x + barBounds.width - 1, barBounds.y)
     }
 
     return BarModel.nearestDropTarget(candidates, scenePoint, root.vertical)

--- a/test/shell.d/bar-empty-section-drop-test.sh
+++ b/test/shell.d/bar-empty-section-drop-test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+bar_qml="$ROOT/shell/plugins/bar/Bar.qml"
+[[ -f $bar_qml ]] || fail "bar QML is present"
+
+# moduleDropAtScene must create empty-region candidates (#9842).
+grep -F 'addEmptyRegionCandidate' "$bar_qml" >/dev/null ||
+  fail "moduleDropAtScene adds empty region candidates"
+
+grep -F 'seenRegions' "$bar_qml" >/dev/null ||
+  fail "moduleDropAtScene tracks which regions have visible slots"
+
+# Synthetic candidates carry a region string.
+python3 - <<'PY' || fail "empty-region candidate structure is correct"
+from pathlib import Path
+import os, re
+
+bar = Path(os.environ["ROOT"], "shell/plugins/bar/Bar.qml").read_text()
+
+# Find addEmptyRegionCandidate calls and verify they pass region strings.
+calls = re.findall(r'addEmptyRegionCandidate\("([^"]+)"', bar)
+assert "left" in calls, "left empty region has a drop candidate"
+assert "center" in calls, "center empty region has a drop candidate"
+assert "right" in calls, "right empty region has a drop candidate"
+
+# Synthetic slot must have region + moduleName.
+assert 'region: region' in bar
+assert 'moduleName: ""' in bar
+
+# nearestDropTarget must be called after empty-region augmentation.
+func_start = bar.index("function moduleDropAtScene")
+func_end = bar.index("\n  function visibleModuleSlot", func_start)
+body = bar[func_start:func_end]
+candidates_pos = body.index("return BarModel.nearestDropTarget")
+assert "addEmptyRegionCandidate" in body[:candidates_pos], \
+  "empty-region candidates are added before nearestDropTarget"
+print("ok")
+PY
+pass "empty-region candidates are added to moduleDropAtScene"


### PR DESCRIPTION
## Summary

When a bar layout section (left/center/right) was empty, `moduleDropAtScene` had no candidate slots for that region. Drag-and-drop always resolved to a neighbor, so widgets could never be dropped into an empty section. The CLI workaround was the only recovery path.

## Fix

Add a 1px reference candidate per region that has no visible slots. The candidate sits at the expected section boundary (left edge for left, center for center, right edge for right) and carries only `{ region, moduleName: "" }` so `dropBarModule` inserts at index 0 of the empty section.

Fixes #9842

## Test plan

- [x] Confirmed no empty-region logic in quattro `moduleDropAtScene`
- [x] `bash test/shell.d/bar-empty-section-drop-test.sh` — structure check