### PR TITLE
Keep bluetooth panel visible after user powers it off

### DIFF
--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -55,9 +55,18 @@ Panel {
   readonly property var knownDevices: deviceGroups.known || []
   readonly property var discoveredDevices: deviceGroups.discovered || []
 
+  // Track whether the user explicitly powered off Bluetooth. When the rfkill
+  // soft block drops the adapter, we still want the panel visible with the
+  // "Turned Off" status instead of disappearing with "No adapter" (#9724).
+  property bool poweredOffByUser: false
+
+  onAdapterChanged: {
+    if (adapter) poweredOffByUser = false
+  }
+
   readonly property string icon: {
-    if (!adapter) return ""
-    if (!adapter.enabled) return "󰂲"
+    if (!adapter && !poweredOffByUser) return ""
+    if (poweredOffByUser || (adapter && !adapter.enabled)) return "󰂲"
     if (connectedDevices.length > 0) return "󰂱"
     return "󰂯"
   }
@@ -75,7 +84,7 @@ Panel {
   ]
   readonly property bool rotatingPhrases: adapter && adapter.enabled
   readonly property string heroStatusText: {
-    if (!adapter) return "No adapter"
+    if (!adapter) return poweredOffByUser ? "Turned Off" : "No adapter"
     if (!adapter.enabled) return "Turned Off"
     return activePhrases[phraseIndex % activePhrases.length]
   }
@@ -101,7 +110,7 @@ Panel {
   // sits above the device sections so the adapter can be toggled by keyboard
   // even when it is off and no device rows exist.
   readonly property bool headerHasCursor: cursorActive && focusSection === "header"
-  readonly property string toggleHint: root.adapter && root.adapter.enabled ? "Turn Bluetooth off" : "Turn Bluetooth on"
+  readonly property string toggleHint: (adapter && adapter.enabled) ? "Turn Bluetooth off" : "Turn Bluetooth on"
 
   readonly property color hoverFill: bar
     ? Style.hoverFillFor(bar.foreground, Color.accent)
@@ -497,7 +506,7 @@ Panel {
     if (selectedIndex < 0) selectedIndex = 0
   }
 
-  visible: adapter !== null
+  visible: adapter !== null || poweredOffByUser
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
@@ -633,8 +642,16 @@ Panel {
   // switch only moves once BlueZ catches up, so a second click inside that window
   // would re-read the old state and undo the first.
   function toggleBluetooth() {
-    if (!adapter) return
-    Quickshell.execDetached(["omarchy-bluetooth-power", adapter.enabled ? "off" : "on"])
+    if (adapter && adapter.enabled) {
+      poweredOffByUser = true
+      Quickshell.execDetached(["omarchy-bluetooth-power", "off"])
+    } else if (adapter && !adapter.enabled) {
+      poweredOffByUser = false
+      Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+    } else if (!adapter && poweredOffByUser) {
+      // rfkill blocked the adapter; turn it back on.
+      Quickshell.execDetached(["omarchy-bluetooth-power", "on"])
+    }
   }
 
   IpcHandler {

--- a/test/shell.d/bluetooth-powered-off-test.sh
+++ b/test/shell.d/bluetooth-powered-off-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+qml="$ROOT/shell/plugins/panels/bluetooth/Panel.qml"
+[[ -f $qml ]] || fail "bluetooth panel QML is present"
+
+# poweredOffByUser flag (#9724)
+grep -F 'property bool poweredOffByUser' "$qml" >/dev/null ||
+  fail "bluetooth panel tracks powered-off state"
+grep -F 'onAdapterChanged' "$qml" >/dev/null ||
+  fail "bluetooth panel clears poweredOffByUser when adapter returns"
+
+# Visibility must include powered-off case.
+if grep -q 'visible: adapter !== null$' "$qml"; then
+  fail "bluetooth panel must stay visible when powered off by user"
+fi
+grep -F 'visible: adapter !== null || poweredOffByUser' "$qml" >/dev/null ||
+  fail "bluetooth panel stays visible when powered off by user"
+pass "bluetooth panel stays visible when powered off by user"
+
+# heroStatusText shows "Turned Off" not "No adapter" when powered off.
+python3 - <<'PY' || fail "heroStatusText handles powered-off case"
+from pathlib import Path
+import os, re
+
+qml = Path(os.environ["ROOT"], "shell/plugins/panels/bluetooth/Panel.qml").read_text()
+
+# heroStatusText logic
+m = re.search(r"readonly property string heroStatusText:\s*\{([^}]+)\}", qml)
+assert m, "heroStatusText definition found"
+body = m.group(1)
+assert "poweredOffByUser" in body, "heroStatusText checks poweredOffByUser"
+assert '"No adapter"' in body, "keeps No adapter for genuine absence"
+assert '"Turned Off"' in body, "shows Turned Off when powered off"
+PY
+pass "bluetooth panel shows Turned Off when rfkill blocks the adapter"
+
+# toggleBluetooth logic: set/clear flag, enable resume from poweredOffByUser.
+python3 - <<'PY' || fail "toggleBluetooth handles all states"
+from pathlib import Path
+import os, re
+
+qml = Path(os.environ["ROOT"], "shell/plugins/panels/bluetooth/Panel.qml").read_text()
+m = re.search(r"function toggleBluetooth\(\)\s*\{([\s\S]*?)\n  \}", qml)
+assert m, "toggleBluetooth definition found"
+body = m.group(1)
+
+assert "poweredOffByUser = true" in body, "toggle off sets the flag"
+assert "adapter && adapter.enabled" in body, "toggle detects powered state"
+assert "!adapter && poweredOffByUser" in body, "toggle resumes from rfkill block"
+PY
+pass "bluetooth toggle tracks poweredOffByUser and resumes from rfkill block"
+
+# Existing toggle contract still good.
+grep -F 'execDetached(["omarchy-bluetooth-power"' "$qml" >/dev/null ||
+  fail "bluetooth toggle still dispatches to omarchy-bluetooth-power"
+pass "bluetooth toggle still uses omarchy-bluetooth-power"

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -17,7 +17,8 @@ assert(/IpcHandler[\s\S]*?function toggleBluetooth\(\) \{ root\.toggleBluetooth\
 assert(/manageIpc: false/.test(panelSource), 'bluetooth owns its IPC handler so it can extend the target methods')
 
 // Writing adapter.enabled sets BlueZ Powered, which does not survive a reboot.
-assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
+assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", "off"\]\)/.test(panelSource), 'bluetooth toggles off through the rfkill soft block')
+assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", "on"\]\)/.test(panelSource), 'bluetooth toggles on through the rfkill soft block')
 assert(!/adapter\.enabled = /.test(panelSource), 'bluetooth never writes the adapter power state directly')
 
 // Discovery is a BlueZ session that nothing ends at panel close: it persists


### PR DESCRIPTION
## Summary

`omarchy-bluetooth-power off` uses `rfkill block bluetooth`. This drops the Quickshell `Bluetooth.defaultAdapter` to null, so the panel showed "No adapter", hid the power switch, and offered no way to turn Bluetooth back on.

## Fix

- `poweredOffByUser` flag set when the user toggles BT off, cleared when adapter returns
- `visible: adapter !== null || poweredOffByUser`
- "Turned Off" status and off icon when powered off, "No adapter" only for genuine absence
- `toggleBluetooth` can turn BT back on from the powered-off state

Fixes #9724

## Test plan

- [x] Confirmed panel disappears with adapter-null-only guard on quattro
- [x] `bash test/shell.d/bluetooth-powered-off-test.sh` — flags, visibility, status text, toggle
- [x] `bash test/shell.d/bluetooth-test.sh` — existing tests still pass