### PR TITLE
Add optional keyboard shortcut for web apps

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Create a desktop launcher for a web app
-# omarchy:args=[name url icon-url-or-name [custom-exec] [mime-types]]
+# omarchy:args=[name url icon-url-or-name [custom-exec] [mime-types] [shortcut]]
 
 set -e
 
@@ -154,6 +154,8 @@ if (( $# < 3 )); then
     ICON_REF=$(gum input --prompt "Icon URL/name> " --placeholder "Could not fetch favicon automatically. Enter PNG icon URL or icon name")
   fi
 
+  WEBAPP_SHORTCUT=$(gum input --prompt "Shortcut> " --placeholder "Optional keyboard shortcut, e.g. SUPER SHIFT G (Enter to skip)")
+
   CUSTOM_EXEC=""
   MIME_TYPES=""
   INTERACTIVE_MODE=true
@@ -162,8 +164,9 @@ else
   APP_URL=$(normalize_webapp_url "$2")
   require_http_url "$APP_URL"
   ICON_REF="$3"
-  CUSTOM_EXEC="$4" # Optional custom exec command
-  MIME_TYPES="$5"  # Optional mime types
+  CUSTOM_EXEC="$4"      # Optional custom exec command
+  MIME_TYPES="$5"       # Optional mime types
+  WEBAPP_SHORTCUT="$6"  # Optional keyboard shortcut, e.g. "SUPER SHIFT G"
   INTERACTIVE_MODE=false
 fi
 
@@ -235,6 +238,11 @@ if [[ -n $MIME_TYPES ]]; then
 fi
 
 chmod +x "$DESKTOP_FILE"
+
+if [[ -n $WEBAPP_SHORTCUT ]] && ! omarchy-webapp-shortcut set "$APP_NAME" "$WEBAPP_SHORTCUT"; then
+  echo "The web app was installed, but the shortcut was not assigned (see above)."
+  echo "Assign one later with: omarchy webapp shortcut set \"$APP_NAME\" \"$WEBAPP_SHORTCUT\""
+fi
 
 if [[ $INTERACTIVE_MODE == "true" ]]; then
   echo -e "You can now find $APP_NAME using the app launcher (SUPER + SPACE)\n"

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -59,3 +59,8 @@ if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
   omarchy-notification-send -g  "Web app removed" "$APP_NAME"
 fi
 update-desktop-database "$DESKTOP_DIR" &>/dev/null
+
+# Drop any keyboard shortcut the removed web app had claimed. Best effort, and
+# silent: this also runs from minimal contexts (the gaming removers) that do not
+# hide stderr.
+omarchy-webapp-shortcut sync >/dev/null 2>&1 || true

--- a/bin/omarchy-webapp-remove-all
+++ b/bin/omarchy-webapp-remove-all
@@ -34,4 +34,7 @@ if omarchy-cmd-present update-desktop-database; then
   update-desktop-database "$APP_DIR" &>/dev/null || true
 fi
 
+# Every web app is gone, so recompile shortcuts down to nothing.
+omarchy-webapp-shortcut sync >/dev/null 2>&1 || true
+
 echo "Web apps removed successfully."

--- a/bin/omarchy-webapp-shortcut
+++ b/bin/omarchy-webapp-shortcut
@@ -1,0 +1,346 @@
+#!/bin/bash
+
+# omarchy:summary=Assign, list, or clear a keyboard shortcut for a web app
+# omarchy:args=<list | sync [--no-reload] | set <app> <keys...> [--match <regex>] [--force] | unset <app>>
+# omarchy:examples=omarchy webapp shortcut set Figma SUPER SHIFT F | omarchy webapp shortcut unset Figma | omarchy webapp shortcut list
+
+# A shortcut is stored on the web app itself, as an X-Omarchy-Shortcut key in its
+# ~/.local/share/applications/<name>.desktop file:
+#
+#   X-Omarchy-Shortcut=SUPER + SHIFT + F
+#   X-Omarchy-Shortcut-Match=figma          (optional; window class/title regex)
+#
+# `sync` compiles every such key into a single Hyprland bindings file that
+# default/hypr/webapp-shortcuts.lua loads. omarchy-webapp-install and
+# omarchy-webapp-remove call `sync` for you, so this command is only needed to
+# add, change, or drop a shortcut on an already-installed web app.
+
+# No pipefail: several helpers below end a pipe with `head -1`, which closes the
+# pipe early and would surface as a SIGPIPE failure in the producer.
+set -eu
+
+APPS_DIR="$HOME/.local/share/applications"
+STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+GENERATED="$STATE_HOME/omarchy/webapp-shortcuts.lua"
+OMARCHY_ROOT="${OMARCHY_PATH:-/usr/share/omarchy}"
+
+usage() {
+  echo "Usage: omarchy webapp shortcut <list | sync | set <app> <keys...> [--match <regex>] [--force] | unset <app>>"
+}
+
+# Normalize a free-form combo ("super shift f", "SUPER+SHIFT+F", "SUPER + SHIFT + F")
+# to Omarchy's canonical "SUPER + SHIFT + F": modifiers in a fixed order followed
+# by the single non-modifier key. Returns 1 when no key is present.
+canonical_combo() {
+  local raw="${1//+/ }" token upper key=""
+  local -A mods=()
+
+  for token in $raw; do
+    upper="${token^^}"
+    case $upper in
+      SUPER | WIN | MOD) mods[SUPER]=1 ;;
+      CTRL | CONTROL) mods[CTRL]=1 ;;
+      ALT | MOD1) mods[ALT]=1 ;;
+      SHIFT) mods[SHIFT]=1 ;;
+      "") ;;
+      *) key="$upper" ;;
+    esac
+  done
+
+  if [[ -z $key ]]; then
+    return 1
+  fi
+
+  local out="" modifier
+  for modifier in SUPER CTRL ALT SHIFT; do
+    if [[ -n ${mods[$modifier]:-} ]]; then
+      out+="$modifier + "
+    fi
+  done
+
+  printf '%s%s\n' "$out" "$key"
+}
+
+# The registrable-domain label of a URL, used as the default focus match:
+# https://www.icloud.com/foo -> icloud, https://sub.example.co.uk/ -> example.
+# A user can override a wrong guess with --match / X-Omarchy-Shortcut-Match.
+default_match_for_url() {
+  local host="${1#*://}"
+  host="${host%%/*}"
+  host="${host%%:*}"
+  host="${host#www.}"
+  awk -F. '
+    {
+      if (NF < 2) { print $0; next }
+      label = $(NF - 1)
+      if (NF >= 3 && label ~ /^(co|com|org|net|gov|edu|ac)$/) {
+        label = $(NF - 2)
+      }
+      print label
+    }
+  ' <<<"$host"
+}
+
+# The http(s) URL an omarchy-launch-webapp Exec line launches.
+url_from_desktop() {
+  local exec_line
+  exec_line=$(sed -n 's/^Exec=//p' "$1" | head -1)
+  grep -oE 'https?://[^ "'"'"']+' <<<"$exec_line" | head -1
+}
+
+is_webapp() {
+  grep -q '^Exec=.*omarchy-launch-webapp' "$1"
+}
+
+# Resolve a user-supplied name to a .desktop path, matching either the Name= field
+# or the file's basename, case-insensitively.
+resolve_desktop() {
+  local want="${1,,}" file base name
+  for file in "$APPS_DIR"/*.desktop; do
+    [[ -f $file ]] || continue
+    base=$(basename "$file" .desktop)
+    name=$(sed -n 's/^Name=//p' "$file" | head -1)
+    if [[ ${base,,} == "$want" || ${name,,} == "$want" ]]; then
+      printf '%s\n' "$file"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Every canonical combo already claimed by Omarchy's shipped bindings, the user's
+# own bindings.lua, or another web app. Source-derived, so no compositor needed.
+# Pass a .desktop path to exclude that web app's own shortcut from the list.
+claimed_combos() {
+  local exclude="${1:-}" file combo value desktop
+
+  for file in "$OMARCHY_ROOT"/default/hypr/bindings/*.lua "$CONFIG_HOME/hypr/bindings.lua"; do
+    [[ -f $file ]] || continue
+    # Anchor to the start of the line (allowing indentation) so a commented-out
+    # `-- o.bind("SUPER + SHIFT + R", ...)` example is not read as a live binding.
+    while IFS= read -r combo; do
+      canonical_combo "$combo" || true
+    done < <(grep -oE '^[[:space:]]*o\.bind\([[:space:]]*"[^"]+"' "$file" | sed -E 's/.*"([^"]+)".*/\1/')
+  done
+
+  for desktop in "$APPS_DIR"/*.desktop; do
+    [[ -f $desktop ]] || continue
+    [[ $desktop == "$exclude" ]] && continue
+    value=$(sed -n 's/^X-Omarchy-Shortcut=//p' "$desktop" | head -1)
+    [[ -n $value ]] || continue
+    canonical_combo "$value" || true
+  done
+}
+
+# Replace (or add) a Key=value line. Delete-then-append rather than sed
+# substitution so a --match value containing sed-significant characters (| & \)
+# cannot corrupt the write.
+set_desktop_key() {
+  local file="$1" key="$2" value="$3"
+  sed -i "/^$key=/d" "$file"
+  printf '%s=%s\n' "$key" "$value" >>"$file"
+}
+
+reload_hyprland() {
+  hyprctl reload >/dev/null 2>&1 || true
+}
+
+# Escape a value for a Lua "..." string literal.
+lua_string() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "$value"
+}
+
+cmd_sync() {
+  local reload=1
+  if [[ ${1:-} == --no-reload ]]; then
+    reload=0
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  {
+    echo "-- Generated by 'omarchy webapp shortcut sync'. Do not edit."
+    echo "-- Source of truth: X-Omarchy-Shortcut in ~/.local/share/applications/*.desktop"
+    echo
+  } >"$tmp"
+
+  local count=0 desktop key name url match combo
+  for desktop in "$APPS_DIR"/*.desktop; do
+    [[ -f $desktop ]] || continue
+
+    key=$(sed -n 's/^X-Omarchy-Shortcut=//p' "$desktop" | head -1)
+    [[ -n $key ]] || continue
+
+    if ! combo=$(canonical_combo "$key"); then
+      echo "omarchy-webapp-shortcut: skipping $(basename "$desktop"): cannot parse '$key'" >&2
+      continue
+    fi
+
+    url=$(url_from_desktop "$desktop")
+    if [[ -z $url ]]; then
+      echo "omarchy-webapp-shortcut: skipping $(basename "$desktop"): no http(s) URL in Exec=" >&2
+      continue
+    fi
+    if [[ $url == *"'"* ]]; then
+      echo "omarchy-webapp-shortcut: skipping $(basename "$desktop"): URL contains a single quote" >&2
+      continue
+    fi
+
+    name=$(sed -n 's/^Name=//p' "$desktop" | head -1)
+    match=$(sed -n 's/^X-Omarchy-Shortcut-Match=//p' "$desktop" | head -1)
+    if [[ -z $match ]]; then
+      match=$(default_match_for_url "$url")
+    fi
+
+    {
+      printf 'o.bind("%s", "%s", {\n' "$(lua_string "$combo")" "$(lua_string "$name")"
+      printf '  launch = %s,\n' "'omarchy-launch-webapp \"$url\"'"
+      printf '  focus = "%s",\n' "$(lua_string "$match")"
+      printf '})\n'
+    } >>"$tmp"
+    count=$((count + 1))
+  done
+
+  mkdir -p "$(dirname "$GENERATED")"
+  mv "$tmp" "$GENERATED"
+
+  if (( reload )); then
+    reload_hyprland
+  fi
+
+  echo "Compiled $count web app shortcut(s)."
+}
+
+cmd_list() {
+  local file name key match found=0
+  for file in "$APPS_DIR"/*.desktop; do
+    [[ -f $file ]] || continue
+    key=$(sed -n 's/^X-Omarchy-Shortcut=//p' "$file" | head -1)
+    [[ -n $key ]] || continue
+    found=1
+    name=$(sed -n 's/^Name=//p' "$file" | head -1)
+    match=$(sed -n 's/^X-Omarchy-Shortcut-Match=//p' "$file" | head -1)
+    printf '%-24s %-20s %s\n' "$name" "$(canonical_combo "$key" || echo "$key")" "${match:+match: $match}"
+  done
+
+  if (( ! found )); then
+    echo "No web app shortcuts are defined."
+  fi
+}
+
+cmd_set() {
+  local app="" match="" force=0
+  local -a keys=()
+
+  while (($#)); do
+    case $1 in
+      --match)
+        shift
+        match="${1:-}"
+        ;;
+      --force)
+        force=1
+        ;;
+      --*)
+        echo "Unknown option: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+      *)
+        if [[ -z $app ]]; then
+          app="$1"
+        else
+          keys+=("$1")
+        fi
+        ;;
+    esac
+    shift
+  done
+
+  if [[ -z $app ]] || (( ${#keys[@]} == 0 )); then
+    usage >&2
+    exit 1
+  fi
+
+  local file
+  if ! file=$(resolve_desktop "$app"); then
+    echo "No web app named '$app' found in $APPS_DIR" >&2
+    exit 1
+  fi
+  if ! is_webapp "$file"; then
+    echo "'$(basename "$file")' is not an Omarchy web app." >&2
+    exit 1
+  fi
+
+  local combo
+  if ! combo=$(canonical_combo "${keys[*]}"); then
+    echo "Could not parse a key combo from: ${keys[*]}" >&2
+    exit 1
+  fi
+
+  local name
+  name=$(sed -n 's/^Name=//p' "$file" | head -1)
+
+  local claimed
+  claimed=$(claimed_combos "$file")
+  if (( ! force )) && grep -Fxq "$combo" <<<"$claimed"; then
+    echo "$combo is already bound. Re-run with --force to take it for \"$name\"." >&2
+    exit 1
+  fi
+
+  set_desktop_key "$file" "X-Omarchy-Shortcut" "$combo"
+  if [[ -n $match ]]; then
+    set_desktop_key "$file" "X-Omarchy-Shortcut-Match" "$match"
+  fi
+
+  echo "$combo -> \"$name\""
+  cmd_sync
+}
+
+cmd_unset() {
+  local app="${1:-}"
+  if [[ -z $app ]]; then
+    usage >&2
+    exit 1
+  fi
+
+  local file
+  if ! file=$(resolve_desktop "$app"); then
+    echo "No web app named '$app' found in $APPS_DIR" >&2
+    exit 1
+  fi
+
+  sed -i '/^X-Omarchy-Shortcut=/d; /^X-Omarchy-Shortcut-Match=/d' "$file"
+  echo "Cleared the shortcut for $(basename "$file" .desktop)."
+  cmd_sync
+}
+
+case "${1:-}" in
+  set)
+    shift
+    cmd_set "$@"
+    ;;
+  unset)
+    shift
+    cmd_unset "$@"
+    ;;
+  list)
+    cmd_list
+    ;;
+  sync)
+    shift
+    cmd_sync "$@"
+    ;;
+  -h | --help | help | "")
+    usage
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/default/hypr/omarchy.lua
+++ b/default/hypr/omarchy.lua
@@ -12,6 +12,7 @@ if _G.omarchy_default_bindings ~= false then
   require("default.hypr.bindings.utilities")
   require("default.hypr.bindings.voxtype")
   require_optional.module("default.hypr.bindings.applications")
+  require("default.hypr.webapp-shortcuts")
 end
 require("default.hypr.envs")
 require("default.hypr.looknfeel")

--- a/default/hypr/webapp-shortcuts.lua
+++ b/default/hypr/webapp-shortcuts.lua
@@ -1,0 +1,16 @@
+-- Keyboard shortcuts for user-installed web apps.
+--
+-- `omarchy webapp shortcut sync` compiles the X-Omarchy-Shortcut keys from
+-- ~/.local/share/applications/*.desktop into the file loaded below;
+-- omarchy-webapp-install and omarchy-webapp-remove run it automatically. This
+-- loads before ~/.config/hypr/bindings.lua, so a hand-written binding there
+-- still overrides a generated one.
+
+local paths = require("default.hypr.paths")
+
+local generated = paths.state_home .. "/omarchy/webapp-shortcuts.lua"
+local file = io.open(generated, "r")
+if file then
+  file:close()
+  dofile(generated)
+end

--- a/manual/25-web-apps.md
+++ b/manual/25-web-apps.md
@@ -1,6 +1,6 @@
 # Web Apps
 
-You can add your own web apps using _Install > Web App_ in the Omarchy menu (`Super + Space`). It'll ask you for the app name, app URL, and the icon URL, if it can't retrieve it via favicon. You can get great PNG icons for many popular web apps on [Dashboard Icons](https://dashboardicons.com).
+You can add your own web apps using _Install > Web App_ in the Omarchy menu (`Super + Space`). It'll ask you for the app name, app URL, the icon URL if it can't retrieve it via favicon, and an optional keyboard shortcut. You can get great PNG icons for many popular web apps on [Dashboard Icons](https://dashboardicons.com).
 
 They'll then be accessible through the app launcher (`Super + Space`), and use the beautiful frameless web-app window.
 
@@ -9,6 +9,8 @@ If you wish to remove a web app, just go to _Remove > Web App_ in the Omarchy me
 It's best if you log into all your accounts using a regular browser before using the web app shortcuts. The thin wrapper frame doesn't work well with 1password, so just easier to be logged in directly first.
 
 All the keyboard hotkeys for these web apps can be changed in `~/.config/hypr/bindings.lua`.
+
+For web apps you added yourself, assign or change a shortcut at any time with `omarchy webapp shortcut set "<app name>" SUPER SHIFT G`, drop one with `omarchy webapp shortcut unset "<app name>"`, and list them with `omarchy webapp shortcut list`. These shortcuts are stored on the web app itself, so they survive reinstalls and are removed with the app.
 
 When you're in a web app, you can copy the current URL to the clipboard using `Shift + Alt + L`.
 

--- a/migrations/1788380505.sh
+++ b/migrations/1788380505.sh
@@ -1,0 +1,8 @@
+echo "Compile keyboard shortcuts for existing web apps"
+
+# omarchy-webapp-shortcut is new in this release. Build the generated bindings
+# file once so an existing web app that gains an X-Omarchy-Shortcut key is picked
+# up without waiting for the next install or removal. Writes an empty stub and
+# no-ops when no web app declares a shortcut, and is safe to run repeatedly.
+# --no-reload: omarchy update reloads Hyprland once after all migrations run.
+omarchy-webapp-shortcut sync --no-reload >/dev/null

--- a/test/shell.d/webapp-name-test.sh
+++ b/test/shell.d/webapp-name-test.sh
@@ -8,7 +8,7 @@ tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 mkdir -p "$tmp_dir/bin" "$tmp_dir/home"
 
-for stub in gtk-update-icon-cache update-desktop-database omarchy-notification-send; do
+for stub in gtk-update-icon-cache update-desktop-database omarchy-notification-send omarchy-webapp-shortcut; do
   printf '#!/bin/bash\n:\n' >"$tmp_dir/bin/$stub"
   chmod +x "$tmp_dir/bin/$stub"
 done

--- a/test/shell.d/webapp-shortcut-test.sh
+++ b/test/shell.d/webapp-shortcut-test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+home="$tmpdir/home"
+apps="$home/.local/share/applications"
+generated="$home/.local/state/omarchy/webapp-shortcuts.lua"
+mkdir -p "$apps"
+
+export HOME="$home"
+export XDG_STATE_HOME="$home/.local/state"
+export XDG_CONFIG_HOME="$home/.config"
+export OMARCHY_PATH="$ROOT"
+export PATH="$ROOT/bin:$PATH"
+
+shortcut() {
+  omarchy-webapp-shortcut "$@"
+}
+
+write_webapp() {
+  local name="$1" url="$2"
+  cat >"$apps/$name.desktop" <<EOF
+[Desktop Entry]
+Version=1.0
+Name=$name
+Comment=$name
+Exec=omarchy-launch-webapp "$url"
+Terminal=false
+Type=Application
+Icon=${name,,}
+StartupNotify=true
+EOF
+}
+
+# --- wiring -----------------------------------------------------------------
+
+grep -Fq 'require("default.hypr.webapp-shortcuts")' "$ROOT/default/hypr/omarchy.lua" ||
+  fail "omarchy.lua loads the compiled web app shortcuts"
+pass "omarchy.lua loads the compiled web app shortcuts"
+
+# --- sync compiles X-Omarchy-Shortcut keys --------------------------------
+
+write_webapp "Figma" "https://www.figma.com/files"
+printf 'X-Omarchy-Shortcut=SUPER + SHIFT + F\n' >>"$apps/Figma.desktop"
+
+shortcut sync --no-reload >/dev/null
+[[ -f $generated ]] || fail "sync writes the generated bindings file"
+grep -Fq 'o.bind("SUPER + SHIFT + F", "Figma", {' "$generated" ||
+  fail "sync emits a bind for a web app shortcut" "$(cat "$generated")"
+grep -Fq 'launch = '\''omarchy-launch-webapp "https://www.figma.com/files"'\''' "$generated" ||
+  fail "sync launches the web app URL" "$(cat "$generated")"
+grep -Fq 'focus = "figma"' "$generated" ||
+  fail "sync derives a focus match from the registrable domain" "$(cat "$generated")"
+pass "sync compiles an X-Omarchy-Shortcut key into a Hyprland bind"
+
+# --- set writes and canonicalizes a shortcut -----------------------------
+
+write_webapp "Linear" "https://linear.app"
+shortcut set Linear super shift l >/dev/null
+grep -Fxq 'X-Omarchy-Shortcut=SUPER + SHIFT + L' "$apps/Linear.desktop" ||
+  fail "set canonicalizes and stores the combo on the desktop file" "$(cat "$apps/Linear.desktop")"
+grep -Fq 'o.bind("SUPER + SHIFT + L", "Linear", {' "$generated" ||
+  fail "set recompiles the bindings file"
+pass "set stores a canonical combo and recompiles"
+
+# --- set --match overrides the derived focus pattern --------------------
+
+shortcut set Linear SUPER SHIFT L --match "Linear" >/dev/null
+grep -Fxq 'X-Omarchy-Shortcut-Match=Linear' "$apps/Linear.desktop" ||
+  fail "set --match stores the focus override"
+grep -Fq 'focus = "Linear"' "$generated" ||
+  fail "set --match feeds the focus override into the bind"
+pass "set --match overrides the focus pattern"
+
+# --- conflicts with a shipped binding are refused ----------------------
+
+if shortcut set Linear SUPER K >"$tmpdir/out" 2>"$tmpdir/err"; then
+  fail "set refuses a combo already bound by Omarchy" "$(cat "$tmpdir/out")"
+fi
+grep -Fq 'already bound' "$tmpdir/err" ||
+  fail "set explains the refusal" "$(cat "$tmpdir/err")"
+grep -Fxq 'X-Omarchy-Shortcut=SUPER + SHIFT + L' "$apps/Linear.desktop" ||
+  fail "a refused set leaves the existing shortcut untouched"
+pass "set refuses a combo already claimed by a shipped binding"
+
+shortcut set Linear SUPER K --force >/dev/null
+grep -Fxq 'X-Omarchy-Shortcut=SUPER + K' "$apps/Linear.desktop" ||
+  fail "set --force takes a claimed combo"
+pass "set --force overrides a conflict"
+
+# --- conflicts also cover the user's own bindings.lua ------------------
+
+mkdir -p "$home/.config/hypr"
+cat >"$home/.config/hypr/bindings.lua" <<'LUA'
+-- o.bind("SUPER + SHIFT + R", "SSH", "alacritty -e ssh your-server")
+o.bind("SUPER + SHIFT + J", "Journal", "obsidian")
+LUA
+write_webapp "Slack" "https://app.slack.com/client"
+
+if shortcut set Slack SUPER SHIFT J >/dev/null 2>&1; then
+  fail "set refuses a combo the user bound in their own bindings.lua"
+fi
+shortcut set Slack SUPER SHIFT R >/dev/null ||
+  fail "set allows a combo that only appears commented out in bindings.lua"
+pass "set reads live bindings from bindings.lua but ignores commented-out ones"
+
+shortcut unset Slack >/dev/null
+rm -f "$home/.config/hypr/bindings.lua"
+
+# --- unset clears the keys and recompiles -----------------------------
+
+shortcut unset Linear >/dev/null
+if grep -q '^X-Omarchy-Shortcut' "$apps/Linear.desktop"; then
+  fail "unset removes every shortcut key from the desktop file"
+fi
+if grep -Fq '"Linear"' "$generated"; then
+  fail "unset drops the bind from the compiled file"
+fi
+pass "unset clears the shortcut and recompiles"
+
+# --- list reports the current mappings ------------------------------
+
+output=$(shortcut list)
+grep -Fq "Figma" <<<"$output" || fail "list shows a web app with a shortcut" "$output"
+grep -Fq "SUPER + SHIFT + F" <<<"$output" || fail "list shows the canonical combo" "$output"
+if grep -Fq "Linear" <<<"$output"; then
+  fail "list omits a web app with no shortcut" "$output"
+fi
+pass "list reports web apps that have a shortcut"
+
+# --- install accepts a shortcut argument ---------------------------
+
+rm -f "$apps"/*.desktop
+omarchy-webapp-install "Notion" "https://www.notion.so" "webapp" "" "" "SUPER SHIFT ALT N" >/dev/null 2>&1
+grep -Fxq 'X-Omarchy-Shortcut=SUPER + ALT + SHIFT + N' "$apps/Notion.desktop" ||
+  fail "webapp install stores the shortcut argument" "$(cat "$apps/Notion.desktop")"
+grep -Fq 'o.bind("SUPER + ALT + SHIFT + N", "Notion", {' "$generated" ||
+  fail "webapp install compiles the shortcut" "$(cat "$generated")"
+pass "webapp install assigns a shortcut passed as an argument"


### PR DESCRIPTION
## What

Lets you give a web app a launch keyboard shortcut when you install it, instead of hand-editing `~/.config/hypr/bindings.lua` afterward.

- **Install flow** – `Install > Web App` (and `omarchy-webapp-install`) now has an optional `Shortcut>` prompt after the icon step. Non-interactive callers can pass it as a 6th argument.
- **New command** – `omarchy webapp shortcut set <app> <keys…> [--match <regex>] [--force]`, plus `unset`, `list`, and `sync`, to add, change, or remove a shortcut on an already-installed web app.

```
omarchy webapp shortcut set Figma SUPER SHIFT F
omarchy webapp shortcut set "Google Contacts" "SUPER + SHIFT + K" --match contacts
omarchy webapp shortcut unset Figma
omarchy webapp shortcut list
```

## How it works

The shortcut lives on the web app's own `.desktop` file as an `X-Omarchy-Shortcut` key (with an optional `X-Omarchy-Shortcut-Match` for the focus regex), so it survives a reinstall and is dropped when the app is removed.

`omarchy webapp shortcut sync` compiles every such key into `~/.local/state/omarchy/webapp-shortcuts.lua`. A new `default/hypr/webapp-shortcuts.lua` loads that file just after the default application bindings and before `~/.config/hypr/bindings.lua`, so a hand-written binding still wins. The whole file is regenerated on every `sync`, so removing a key removes its binding.

`omarchy-webapp-install` and `omarchy-webapp-remove`/`-remove-all` call `sync` themselves; a migration runs it once for existing installs. Each generated bind uses the existing `{ launch = 'omarchy-launch-webapp "<url>"', focus = "<match>" }` form, so a second press focuses the running window instead of opening another.

The default focus match is the registrable-domain label of the URL (`https://www.figma.com/…` → `figma`, with a small allowance for `co.uk`-style suffixes); `--match` / `X-Omarchy-Shortcut-Match` overrides it.

## Conflicts

`set` refuses a combo that is already bound by a shipped `default/hypr/bindings/*.lua` binding or by a live (non-commented) `o.bind` in the user's `bindings.lua`, unless `--force` is passed. Comparison is modifier-order-independent.

## Notes / decisions

- The generated file is loaded inside the `omarchy_default_bindings ~= false` block, so `omarchy_default_bindings = false` disables these too, consistent with it disabling every other Omarchy binding.
- The interactive install gains one extra prompt; it is skippable with Enter.
- Conflict detection is source-derived (greps the Lua), so it needs no running compositor and works in tests.

## Tests

- New `test/shell.d/webapp-shortcut-test.sh` covers `sync` compilation, canonicalization, `--match`, conflict refusal against both shipped bindings and the user's `bindings.lua` (including that commented-out `o.bind` lines are ignored), `--force`, `unset`, `list`, and the install-time argument.
- `test/shell.d/webapp-name-test.sh` gains an `omarchy-webapp-shortcut` stub alongside the other sibling stubs.
- `./test/cli`, `./bin/omarchy commands --check`, and the webapp / hyprland shell tests pass. The 5 unrelated failures in `./test/shell` on this checkout (`bar-icon-geometry`, `config`, `runtime-smoke`, `snapper`, `unowned-system-paths`) are environment prerequisites and also fail on a clean `quattro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
