### PR TITLE
Preserve built-in fields in partial menu overrides

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -240,6 +240,10 @@ Item {
     return MenuModel.parseMenuJsonc(raw)
   }
 
+  function parseMenuOverridesJsonc(raw) {
+    return MenuModel.parseMenuOverridesJsonc(raw)
+  }
+
   // Merge defaults + user extension. Later entries override earlier ones
   // on a per-key basis (so the user can tweak label/icon/action without
   // re-declaring the whole row).
@@ -976,7 +980,7 @@ Item {
     path: root.userMenuPath
     watchChanges: true
     printErrors: false
-    onLoaded: { root.userMenuItems = root.parseMenuJsonc(text()); root.rebuildItemsFromSources() }
+    onLoaded: { root.userMenuItems = root.parseMenuOverridesJsonc(text()); root.rebuildItemsFromSources() }
     onLoadFailed: { root.userMenuItems = []; root.rebuildItemsFromSources() }
     onFileChanged: reload()
   }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -39,7 +39,7 @@ function normalizeItem(id, raw) {
   }
 }
 
-function parseMenuJsonc(raw) {
+function parseMenuSource(raw, preserveMissingFields) {
   var stripped = stripJsonc(raw)
   if (!stripped.trim()) return []
 
@@ -58,9 +58,24 @@ function parseMenuJsonc(raw) {
   for (var id in source) {
     var entry = source[id]
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue
-    out.push(normalizeItem(id, entry))
+    if (preserveMissingFields) {
+      var override = {}
+      for (var key in entry) override[key] = entry[key]
+      override.id = id
+      out.push(override)
+    } else {
+      out.push(normalizeItem(id, entry))
+    }
   }
   return out
+}
+
+function parseMenuJsonc(raw) {
+  return parseMenuSource(raw, false)
+}
+
+function parseMenuOverridesJsonc(raw) {
+  return parseMenuSource(raw, true)
 }
 
 function mergeMenuSources(defaultItems, userItems) {
@@ -84,10 +99,14 @@ function mergeMenuSources(defaultItems, userItems) {
   }
 
   if (!nextItems.root) {
-    nextItems.root = { id: "root", parent: "", kind: "menu", icon: "", iconFont: "", label: "Go", title: "", target: "", description: "", aliases: [], when: "", checked: "", disabled: "", action: "", provider: "" }
+    nextItems.root = { id: "root", label: "Go" }
     nextOrder.unshift("root")
   }
-  for (var k3 = 0; k3 < nextOrder.length; k3++) nextItems[nextOrder[k3]].order = k3
+  for (var k3 = 0; k3 < nextOrder.length; k3++) {
+    var id = nextOrder[k3]
+    nextItems[id] = normalizeItem(id, nextItems[id])
+    nextItems[id].order = k3
+  }
 
   return {
     items: nextItems,
@@ -498,6 +517,7 @@ if (typeof module !== "undefined") {
     normalizeAliases: normalizeAliases,
     normalizeItem: normalizeItem,
     parseMenuJsonc: parseMenuJsonc,
+    parseMenuOverridesJsonc: parseMenuOverridesJsonc,
     mergeMenuSources: mergeMenuSources,
     mergeAppRows: mergeAppRows,
     swapProviderRows: swapProviderRows,

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -58,6 +58,21 @@ assertEqual(merged.items['style.theme'].label, 'Theme picker', 'menu user entrie
 assertEqual(merged.items['style.theme'].order, 2, 'menu preserves original order on override')
 assert(merged.items.root, 'menu injects root when merging sources')
 
+const partialUser = menu.parseMenuOverridesJsonc(`
+{
+  "style.theme": { "description": "appearance colors" }
+}
+`)
+const partiallyMerged = menu.mergeMenuSources(parsed, partialUser)
+assertEqual(partiallyMerged.items['style.theme'].label, 'Themes', 'menu partial user override preserves default label')
+assertEqual(partiallyMerged.items['style.theme'].action, 'omarchy-theme-set', 'menu partial user override preserves default action')
+assertDeepEqual(partiallyMerged.items['style.theme'].aliases, ['theme'], 'menu partial user override preserves default aliases')
+assertEqual(partiallyMerged.items['style.theme'].description, 'appearance colors', 'menu partial user override replaces declared field')
+assert(
+  /root\.userMenuItems = root\.parseMenuOverridesJsonc\(text\(\)\)/.test(menuQml),
+  'menu parses the user extension without filling its omitted fields'
+)
+
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')
 assertEqual(menu.parentPathFor(merged.items, 'style.theme'), 'Style', 'menu builds parent paths')


### PR DESCRIPTION
## Problem

Users can customize a built-in Omarchy menu item by reusing its ID in `~/.config/omarchy/extensions/omarchy-menu.jsonc`. The documented behavior is that only the fields in the personal override should change.

For example, a user may add search text to the built-in Reboot action:

```jsonc
{
  "system.reboot": { "description": "Restart the computer" }
}
```

The expected result is still the built-in **Reboot** item—with its original icon and reboot command—plus the new description.

Instead, Omarchy currently fills every omitted field with a default value before applying the override. Those generated values replace the built-in fields, so the item loses its label, icon, and action. Reboot becomes a broken submenu named `system.reboot`.

## Fix

Keep personal overrides incomplete while loading them, merge only the fields the user supplied into the built-in item, and normalize the completed item afterward.

The example above now changes only `description`; the original label, icon, action, and aliases remain intact. The same fix applies to any partial menu override.

## Scope

This PR does not add synonym search, add keyword fields, or change search matching. It only fixes the existing partial-override behavior. Separate search improvements can build on this without bundling that larger feature into this bug fix.

## Verification

The regression test adds only a description to an existing action and confirms that its original label, action, and aliases are preserved.

- `bash test/shell.d/menu-test.sh` passes.
- `./test/all` passes 225 of 226 test files. The unrelated `test/shell.d/launch-about-test.sh` fails at `a roomy window animates`; the same test also fails on the untouched `quattro` base branch.