### PR TITLE
Close three ways past the installed-theme denylist

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -138,11 +138,15 @@ set_theme_background() {
 is_denied_installed_file() {
   local name="$1"
   local denied
+  # Match without regard to case: the loaders ask for the lowercase name, but a
+  # casefold or case-insensitive filesystem would answer a request for
+  # hyprland.lua with a staged hyprland.LUA.
+  local lower=${name,,}
 
-  [[ $name == *.lua ]] && return 0
+  [[ $lower == *.lua ]] && return 0
 
   for denied in "${INSTALLED_THEME_DENIED[@]}"; do
-    [[ $name == "$denied" ]] && return 0
+    [[ $lower == "${denied,,}" ]] && return 0
   done
 
   return 1
@@ -180,16 +184,27 @@ stage_installed_colors_from_alacritty() {
 stage_installed_dir() {
   local source="$1"
   local dest="$2"
-  local entry name
+  local prefix="${3:-}"
+  local entry name display
 
   mkdir -p "$dest"
 
   for entry in "$source"/*; do
     [[ -e $entry && ! -L $entry ]] || continue
     name=${entry##*/}
+    display="$prefix$name"
+
+    # The denylist is the whole guarantee, so it has to hold at every depth.
+    # Without this a theme ships sub/hyprland.lua and it stages verbatim: no
+    # shipped consumer reads code from a subdirectory today, but the promise
+    # this function exists to keep would already be broken.
+    if is_denied_installed_file "$name"; then
+      IGNORED_THEME_FILES+=("$display")
+      continue
+    fi
 
     if [[ -d $entry ]]; then
-      stage_installed_dir "$entry" "$dest/$name"
+      stage_installed_dir "$entry" "$dest/$name" "$display/"
     else
       cp "$entry" "$dest/$name"
     fi
@@ -204,7 +219,11 @@ stage_installed_dir() {
 theme_came_from_a_repo() {
   local source="$1"
 
-  [[ ! -L $source && -d $source/.git ]]
+  # Any .git entry, not just a directory. `git clone` writes a directory, but a
+  # linked worktree or a submodule writes a .git *file* holding "gitdir: ...".
+  # Testing for a directory alone makes that case fall through to the unfiltered
+  # branch below, so a stranger's theme would stage its Lua verbatim.
+  [[ ! -L $source && -e $source/.git ]]
 }
 
 stage_installed_theme() {

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -141,6 +141,11 @@ is_denied_installed_file() {
   # Match without regard to case: the loaders ask for the lowercase name, but a
   # casefold or case-insensitive filesystem would answer a request for
   # hyprland.lua with a staged hyprland.LUA.
+  #
+  # Fold under a fixed C locale, not the caller's: bash's ${x,,} follows
+  # LC_CTYPE, and in a Turkish or Azeri locale "I" folds to a dotless "ı", so
+  # KITTY.CONF becomes "kıtty.conf" and never matches "kitty.conf".
+  local LC_ALL=C
   local lower=${name,,}
 
   [[ $lower == *.lua ]] && return 0

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -49,13 +49,13 @@ instead of racing.
 
 `themes/<name>/` in this repo is Omarchy's own code and is trusted. So is a theme the user wrote by hand in `~/.config/omarchy/themes/<name>/`: it is their machine and their file, and both stage in full.
 
-`omarchy theme install <url>` is different. It clones a stranger's git repo straight into that same directory, so the contents are whatever the theme author pushed. `omarchy-theme-set` tells the two apart the way `omarchy-theme-extras` already does — a `.git` directory means it was cloned, while a plain directory or a symlink to a working copy is the user's own — and from a cloned one it drops only what can run code:
+`omarchy theme install <url>` is different. It clones a stranger's git repo straight into that same directory, so the contents are whatever the theme author pushed. `omarchy-theme-set` tells the two apart the way `omarchy-theme-extras` already does — a `.git` entry (the directory a plain clone leaves, or the file a linked worktree or submodule leaves) means it was cloned, while a plain directory or a symlink to a working copy is the user's own — and from a cloned one it drops only what can run code:
 
 - any `*.lua` — Hyprland `require`s a theme's `hyprland.lua` and `gum_env.lua` at login, and Neovim loads its `neovim.lua` at startup
 - `alacritty.toml`, `foot.ini`, `ghostty.conf`, `kitty.conf` — each names the program the terminal launches
 - `vscode.json` — names the extension `omarchy-theme-set-vscode` installs, and a VS Code extension is arbitrary JavaScript
 
-Symlinks are dropped with them, at any depth; in a cloned theme they point wherever the theme author chose. Everything a cloned theme ships that is colour is kept, including files Omarchy would otherwise have generated — `btop.theme`, `chromium.theme`, `helix.toml`, `shell.toml`, `icons.theme`, `keyboard.rgb` and the rest — so a theme can still say exactly how it wants each app to look. What is dropped gets generated from `default/themed/*.tpl` instead, and is named on stderr.
+The list applies at any depth and matches names without regard to case, and symlinks are dropped with it; in a cloned theme a symlink points wherever the theme author chose. Everything a cloned theme ships that is colour is kept, including files Omarchy would otherwise have generated — `btop.theme`, `chromium.theme`, `helix.toml`, `shell.toml`, `icons.theme`, `keyboard.rgb` and the rest — so a theme can still say exactly how it wants each app to look. What is dropped gets generated from `default/themed/*.tpl` instead, and is named on stderr.
 
 A denylist is only right while it is maintained. Adding a template for another terminal, or for another editor that loads Lua, means adding it to `INSTALLED_THEME_DENIED` in `bin/omarchy-theme-set`; `test/shell.d/theme-staging-test.sh` fails on any `default/themed/*.tpl` whose output is recorded as neither code nor colour, so a new template cannot be added without that decision being made.
 

--- a/test/shell.d/theme-staging-test.sh
+++ b/test/shell.d/theme-staging-test.sh
@@ -203,6 +203,51 @@ done
 
 pass "a theme name cannot climb out of the theme directories"
 
+# `git clone` writes .git as a directory, but a linked worktree or a submodule
+# writes it as a file holding "gitdir: ...". Both mean the contents came from a
+# repo, so both have to be filtered: testing only for a directory sends a
+# worktree down the unfiltered branch.
+worktree="$themes/worktree"
+mkdir -p "$worktree"
+write_colors "$worktree/colors.toml"
+printf 'gitdir: /somewhere/else\n' >"$worktree/.git"
+printf 'os.execute("%s")\n' "$marker" >"$worktree/hyprland.lua"
+
+set_theme worktree || fail "omarchy-theme-set applies a theme whose .git is a file"
+assert_no_marker hyprland.lua "a theme whose .git is a file is still an installed theme"
+
+pass "a .git file is treated as an installed theme, not one the user wrote"
+
+# The denylist has to hold at every depth. Nothing shipped reads code from a
+# theme subdirectory today, but staging it verbatim breaks the guarantee.
+nested="$themes/nested"
+mkdir -p "$nested/.git" "$nested/sub"
+write_colors "$nested/colors.toml"
+printf 'os.execute("%s")\n' "$marker" >"$nested/sub/hyprland.lua"
+printf '[terminal.shell]\nprogram = "%s"\n' "$marker" >"$nested/sub/alacritty.toml"
+printf 'png\n' >"$nested/sub/art.png"
+
+set_theme nested || fail "omarchy-theme-set applies a theme with a subdirectory"
+assert_not_staged sub/hyprland.lua "a subdirectory cannot smuggle Lua past the denylist"
+assert_not_staged sub/alacritty.toml "a subdirectory cannot smuggle a terminal config past the denylist"
+assert_staged sub/art.png "colour and images in a subdirectory are still staged"
+
+pass "the denylist applies inside subdirectories"
+
+# The loaders ask for the lowercase name, but a casefold filesystem would answer
+# a request for hyprland.lua with a staged hyprland.LUA.
+uppercase="$themes/uppercase"
+mkdir -p "$uppercase/.git"
+write_colors "$uppercase/colors.toml"
+printf 'os.execute("%s")\n' "$marker" >"$uppercase/HYPRLAND.LUA"
+printf '[terminal.shell]\nprogram = "%s"\n' "$marker" >"$uppercase/Alacritty.TOML"
+
+set_theme uppercase || fail "omarchy-theme-set applies a theme with uppercase filenames"
+assert_not_staged HYPRLAND.LUA "the .lua match is case-insensitive"
+assert_not_staged Alacritty.TOML "the denied names are matched case-insensitively"
+
+pass "denied files are matched without regard to case"
+
 # A denylist is only correct while someone adding a template classifies what it
 # generates. Every generated theme file is either denied to an installed theme or
 # recorded here as carrying colour, so a new template fails until it is placed.

--- a/test/shell.d/theme-staging-test.sh
+++ b/test/shell.d/theme-staging-test.sh
@@ -248,6 +248,38 @@ assert_not_staged Alacritty.TOML "the denied names are matched case-insensitivel
 
 pass "denied files are matched without regard to case"
 
+# bash's ${x,,} folds by the caller's LC_CTYPE. In a Turkish or Azeri locale
+# "I" folds to a dotless "ı", so KITTY.CONF becomes "kıtty.conf" and no longer
+# equals "kitty.conf": the uppercase file stages, and on a casefold filesystem a
+# later open of kitty.conf finds it. The denylist has to fold the same way
+# whoever runs omarchy-theme-set.
+turkish_locale=$(locale -a 2>/dev/null | grep -iE '^(tr_TR|az_AZ)\.utf-?8$' | head -1 || true)
+
+if [[ -n $turkish_locale ]]; then
+  # Positive control: confirm this locale really does the dotless fold, so that
+  # a pass below means the denylist withstood it, not that nothing folded.
+  probe=$(LC_ALL="$turkish_locale" bash -c 'x=KITTY.CONF; printf "%s" "${x,,}"')
+  [[ $probe == "kıtty.conf" ]] ||
+    fail "the $turkish_locale probe folds I to a dotless i" "got: $probe"
+
+  dotless="$themes/dotless"
+  mkdir -p "$dotless/.git"
+  write_colors "$dotless/colors.toml"
+  printf 'os.execute("%s")\n' "$marker" >"$dotless/KITTY.CONF"
+  printf '[terminal.shell]\nprogram = "%s"\n' "$marker" >"$dotless/FOOT.INI"
+  printf 'png\n' >"$dotless/ART.PNG"
+
+  LC_ALL="$turkish_locale" set_theme dotless ||
+    fail "omarchy-theme-set applies a theme under $turkish_locale"
+  assert_not_staged KITTY.CONF "a terminal config is denied when the locale folds I to a dotless i"
+  assert_not_staged FOOT.INI "foot.ini is denied when the locale folds I to a dotless i"
+  assert_staged ART.PNG "colour is still staged under $turkish_locale"
+
+  pass "the denylist folds case under a fixed locale, not the caller's"
+else
+  pass "no Turkish or Azeri locale installed; skipping the case-fold locale check"
+fi
+
 # A denylist is only correct while someone adding a template classifies what it
 # generates. Every generated theme file is either denied to an installed theme or
 # recorded here as carrying colour, so a new template fails until it is placed.


### PR DESCRIPTION
Following up on the report I sent to security@omarchy.org, which Erik suggested would be better as PRs than as security tickets. Agreed, and this is the first of them.

`omarchy-theme-set` tells the user that "A theme installed from a git repo cannot supply Lua, a terminal config, or vscode.json." Three separate things let files through anyway. Each is a line or two, and each gets a regression test.

**`theme_came_from_a_repo` only recognised a `.git` directory.** `git clone` writes one, but a linked worktree or a submodule writes a `.git` *file* holding `gitdir: ...`. Both mean the contents came from a repo, but only the directory case reached `stage_installed_theme`; the file case fell through to the unfiltered `cp -r`, so a top-level `hyprland.lua` staged verbatim and Hyprland `require()`d it at the next reload. Now any `.git` entry counts.

**`stage_installed_dir` applied no denylist at all.** It copied every non-symlink file it found, so a theme shipping `sub/hyprland.lua` staged it as-is. Nothing shipped reads code from a theme subdirectory today, so this was latent, but the denylist is meant to be structural and `theme-staging-test.sh` only asserted it at the top level, so a later consumer or a refactor that globs the tree would have reopened it silently. The check now runs at every depth, and dropped files are reported with their path so the "Ignored in ..." message stays useful.

**The `*.lua` match was case-sensitive**, so `evil.LUA` passed. Latent on a case-sensitive filesystem because the loaders ask for the lowercase name, not latent on a casefold one, where a `require` for `hyprland.lua` would find a staged `hyprland.LUA`. Denied names are now matched without regard to case, which also covers `Alacritty.TOML` and friends.

Testing: `test/shell.d/theme-staging-test.sh` passes, including the existing cases. Reverting any one of the three fixes fails that fix's own test and leaves the other two passing, so none of the new tests is decorative.

Happy to split this into three PRs if you would rather review them separately.

For transparency, as in the original report: this came out of AI-assisted work. An agent did much of the reading through `omarchy-theme-set` and drafted the tests; I directed it, checked the result against the source, and confirmed each fix is load-bearing by reverting it and watching its own test fail.
