### PR TITLE
Fix invisible hover and active states in the generated VS Code theme

### DIFF
--- a/default/themed/vscode-theme.json.tpl
+++ b/default/themed/vscode-theme.json.tpl
@@ -61,7 +61,7 @@
         "textPreformat.background": "{{ background }}",
         "textSeparator.foreground": "{{ muted }}",
 
-        "toolbar.hoverBackground": "{{ background }}",
+        "toolbar.hoverBackground": "{{ muted }}60",
         "toolbar.activeBackground": "{{ muted }}",
 
         "button.background": "{{ accent }}",
@@ -69,7 +69,7 @@
         "button.hoverBackground": "{{ blue }}",
         "button.secondaryForeground": "{{ foreground }}",
         "button.secondaryBackground": "{{ muted }}",
-        "button.secondaryHoverBackground": "{{ background }}",
+        "button.secondaryHoverBackground": "{{ muted }}80",
         "button.border": "{{ accent }}20",
         "checkbox.background": "{{ background }}",
         "checkbox.foreground": "{{ foreground }}",
@@ -135,7 +135,7 @@
         "tree.indentGuidesStroke": "{{ muted }}",
         "tree.inactiveIndentGuidesStroke": "{{ muted }}60",
         "tree.tableColumnsBorder": "{{ muted }}",
-        "tree.tableOddRowsBackground": "{{ background }}40",
+        "tree.tableOddRowsBackground": "{{ muted }}20",
 
         "activityBar.background": "{{ background }}",
         "activityBar.dropBorder": "{{ accent }}",
@@ -145,7 +145,7 @@
         "activityBarBadge.background": "{{ accent }}",
         "activityBarBadge.foreground": "{{ background }}",
         "activityBar.activeBorder": "{{ accent }}",
-        "activityBar.activeBackground": "{{ background }}40",
+        "activityBar.activeBackground": "{{ muted }}80",
 
         "sideBar.background": "{{ background }}",
         "sideBar.foreground": "{{ foreground }}",
@@ -526,7 +526,7 @@
         "keybindingLabel.border": "{{ muted }}",
         "keybindingLabel.bottomBorder": "{{ muted }}",
         "keybindingTable.headerBackground": "{{ background }}",
-        "keybindingTable.rowsBackground": "{{ background }}40",
+        "keybindingTable.rowsBackground": "{{ muted }}20",
 
         "terminal.background": "{{ background }}",
         "terminal.foreground": "{{ foreground }}",
@@ -623,7 +623,7 @@
         "settings.checkboxBackground": "{{ background }}",
         "settings.checkboxForeground": "{{ foreground }}",
         "settings.checkboxBorder": "{{ muted }}",
-        "settings.rowHoverBackground": "{{ background }}",
+        "settings.rowHoverBackground": "{{ muted }}60",
         "settings.textInputBackground": "{{ background }}",
         "settings.textInputForeground": "{{ foreground }}",
         "settings.textInputBorder": "{{ muted }}",
@@ -704,12 +704,12 @@
 
         "notebook.editorBackground": "{{ background }}",
         "notebook.cellBorderColor": "{{ muted }}40",
-        "notebook.cellHoverBackground": "{{ background }}40",
+        "notebook.cellHoverBackground": "{{ muted }}40",
         "notebook.cellInsertionIndicator": "{{ accent }}",
         "notebook.cellStatusBarItemHoverBackground": "{{ muted }}",
         "notebook.cellToolbarSeparator": "{{ muted }}",
         "notebook.cellEditorBackground": "{{ background }}",
-        "notebook.focusedCellBackground": "{{ background }}60",
+        "notebook.focusedCellBackground": "{{ muted }}80",
         "notebook.focusedCellBorder": "{{ accent }}",
         "notebook.focusedEditorBorder": "{{ accent }}",
         "notebook.inactiveFocusedCellBorder": "{{ muted }}",


### PR DESCRIPTION
Eight keys in `default/themed/vscode-theme.json.tpl` are painted with the window background, so the state they exist to signal never appears. `{{ background }}40` over a `{{ background }}` surface is just the background again, at any alpha.

(I found these while building an [Omarchy Tokyo Night Storm theme](https://github.com/ivanskodje/omarchy-tokyo-night-storm-theme), which renders this file rather than pointing VS Code at a third-party extension.)

Every new value below is one this file already uses somewhere else, so nothing new is introduced.

## Toolbar icons

**Before**

<img width="500" height="183" alt="Before" src="https://github.com/user-attachments/assets/9ca417ca-cf18-4aba-aa3b-1c30db4a6ec3" />

**After**

<img width="500" height="245" alt="After" src="https://github.com/user-attachments/assets/d73cde9d-6f75-482e-9596-bbbeae97ab44" />

```diff
-"toolbar.hoverBackground": "{{ background }}",
+"toolbar.hoverBackground": "{{ muted }}60",
```

## Settings rows

**Before**

<img width="800" height="603" alt="Before" src="https://github.com/user-attachments/assets/5d811c51-432d-4f3c-9a42-2ced43e2a7a0" />

**After**

<img width="800" height="603" alt="After" src="https://github.com/user-attachments/assets/340ba413-c22f-468c-947b-16334cc85491" />

```diff
-"settings.rowHoverBackground": "{{ background }}",
+"settings.rowHoverBackground": "{{ muted }}60",
```

## Activity bar

**Before**

<img width="362" height="488" alt="Before" src="https://github.com/user-attachments/assets/932cd24e-5473-45c0-8952-1ae7984c2f39" />

**After**

<img width="354" height="494" alt="After" src="https://github.com/user-attachments/assets/508d5c74-b5fb-45a3-892d-2f46c17dde33" />

```diff
-"activityBar.activeBackground": "{{ background }}40",
+"activityBar.activeBackground": "{{ muted }}80",
```

## Keyboard shortcuts table

**Before**

<img width="800" height="495" alt="Before" src="https://github.com/user-attachments/assets/c1785c79-c399-4920-96f1-1dede55171de" />

**After**

<img width="800" height="494" alt="After" src="https://github.com/user-attachments/assets/45ddbcb4-d630-4240-9dad-7582e657dc73" />

```diff
-"keybindingTable.rowsBackground": "{{ background }}40",
+"keybindingTable.rowsBackground": "{{ muted }}20",
```

## Dialog buttons

**Before**

<img width="610" height="196" alt="Before" src="https://github.com/user-attachments/assets/a4a59756-f607-4578-bee5-99e205684187" />

**After**

<img width="606" height="194" alt="After" src="https://github.com/user-attachments/assets/c2c284cc-2376-4b4a-86b5-3f8c5e675981" />

```diff
-"button.secondaryHoverBackground": "{{ background }}",
+"button.secondaryHoverBackground": "{{ muted }}80",
```

## Three more, not filmed

Same defect, but awkward to show, so here is what each one does.

`tree.tableOddRowsBackground` is the alternating row shading for VS Code's generic table widget, the same striping as the Keyboard Shortcuts table above and with the same dead value, so those tables render as a flat block. Fixed for consistency rather than because I can point at a view that renders it.

`notebook.cellHoverBackground` is the highlight under the pointer as you move down a notebook, so today a notebook gives no feedback about which cell you are about to click.

`notebook.focusedCellBackground` is the fill marking which cell has focus. The accent border still draws, so the cell is not completely unmarked, but the fill that should reinforce it is missing.

```diff
-"tree.tableOddRowsBackground": "{{ background }}40",
+"tree.tableOddRowsBackground": "{{ muted }}20",
-"notebook.cellHoverBackground": "{{ background }}40",
+"notebook.cellHoverBackground": "{{ muted }}40",
-"notebook.focusedCellBackground": "{{ background }}60",
+"notebook.focusedCellBackground": "{{ muted }}80",
```

## Notes

`{{ muted }}60` is what `statusBarItem.hoverBackground` uses, `{{ muted }}80` is what `extensionButton.hoverBackground` uses, `{{ muted }}40` is what `tab.hoverBackground` uses, and `{{ muted }}20` is what `minimapSlider.background` uses. Each hover value stays weaker than the active or focused state it pairs with.

`list.hoverBackground` has the same defect and is left out, since #7240 already fixes it.

Only themes without a `vscode.json` render this file, so `ethereal`, `lupine`, `miasma`, `ristretto`, `vantablack`, `white`, and anything installed from a git repo.

`./test/cli` and `./test/shell` are unchanged, and the few failures `./test/shell` reports also fail on a clean checkout.

To try it, copy `default/themed/vscode-theme.json.tpl` into `~/.config/omarchy/themed/`, run `omarchy-theme-refresh`, then fully restart VS Code, which caches the parsed theme.

--

#9964 touches the same file but different lines. Those two and #7240 are the only open PRs that modify this file, and neither of them touches any of these eight keys.

