### PR TITLE
Note that service-plugin constants need a shell restart

### DIFF
--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -43,7 +43,10 @@ which is yours to edit and survives updates.
 
 Saving a file anywhere under `~/.config/omarchy/plugins/` reloads plugin code
 automatically. If a change somehow fails to apply, force a reload with
-`omarchy-shell shell rescanPlugins`.
+`omarchy-shell shell rescanPlugins`. Service plugins keep their `readonly
+property` values from construction, so constant changes in a service (popup
+durations, timeouts) need `omarchy restart shell`; a rescan reports the plugin
+as active while the old values stay live.
 
 ## Idle and Lock
 


### PR DESCRIPTION
Fixes #9999

## What was wrong

`default/agents/skills/omarchy/plugins.md` told readers that any save under `~/.config/omarchy/plugins/` reloads plugin code, and that `omarchy-shell shell rescanPlugins` force-applies a change that did not take. For service plugins that is not true: a service keeps its `readonly property` values from construction, so changing a constant (popup durations, timeouts) and running `rescanPlugins` leaves the old behaviour running with no error, while `omarchy plugin list` still shows the plugin enabled. `omarchy restart shell` is what applies it (measured in the issue: 8.04s popup after rescan, 2.99s after restart).

## Fix

Amend the paragraph in the packaged agent skill to state the distinction: widget code hot-reloads; service-plugin constants need `omarchy restart shell`. No code change; the report itself measured and isolated the behaviour.

The shell docs (`docs/omarchy-shell.md`) describe `rescanPlugins` for plugin enablement, which still works, so they are left as they are.

## Tests

Docs-only change, no test applies. Verification: the sentence is the only edit (git diff), and the wording matches the measured behaviour quoted from the issue.
