### PR TITLE
Pin Signal to gnome-libsecret like the browsers

### DIFF
--- a/bin/omarchy-install-service-signal
+++ b/bin/omarchy-install-service-signal
@@ -8,6 +8,21 @@ set -e
 echo "Installing Signal..."
 omarchy-pkg-add signal-desktop
 
+# Signal is Electron and uses Chromium's os_crypt machinery. On Hyprland the
+# xdg-desktop-portal Secret backend has no provider, so an unpinned app falls
+# back to the 'basic' store; a profile whose DB key was stored under
+# gnome-libsecret then cannot be decrypted. Pin the store before the first
+# launch the same way the browser defaults do, since a first start with the
+# wrong backend bakes the key choice into the profile.
+mkdir -p "$HOME/.config"
+flags_file="$HOME/.config/signal-desktop-flags.conf"
+if [[ ! -f $flags_file ]] || ! grep -q -- '--password-store=' "$flags_file"; then
+  if [[ -f $flags_file ]] && [[ -n $(tail -c1 "$flags_file") ]]; then
+    echo >>"$flags_file"
+  fi
+  echo '--password-store=gnome-libsecret' >>"$flags_file"
+fi
+
 echo "Opening Signal..."
 setsid uwsm-app -- /usr/bin/signal-desktop >/dev/null 2>&1 &
 

--- a/migrations/1788562800.sh
+++ b/migrations/1788562800.sh
@@ -1,0 +1,18 @@
+echo "Pin Signal password store to gnome-libsecret (prevents profile key fallback on Hyprland)"
+
+# Signal is an Electron app and uses the same os_crypt machinery as Chromium
+# browsers. On Hyprland the xdg-desktop-portal Secret backend has no provider,
+# so without a pin Signal falls back to the 'basic' store and a profile whose
+# DB key was stored under gnome-libsecret can no longer be decrypted (the
+# profile is unrecoverable without the original keyring secret). Migration
+# 1784508556 pins the browsers; this is the same class for the app Omarchy
+# installs itself. A user-chosen --password-store line wins, as it does for
+# browsers.
+flags_file="$HOME/.config/signal-desktop-flags.conf"
+if grep -q -- '--password-store=' "$flags_file" 2>/dev/null; then
+  exit 0
+fi
+
+mkdir -p "$HOME/.config"
+[[ -n $(tail -c1 "$flags_file" 2>/dev/null) ]] && echo >>"$flags_file"
+echo '--password-store=gnome-libsecret' >>"$flags_file"

--- a/test/shell.d/signal-password-store-test.sh
+++ b/test/shell.d/signal-password-store-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+export HOME="$tmp_dir/home"
+mkdir -p "$HOME"
+
+migration="$ROOT/migrations/1788562800.sh"
+flags="$HOME/.config/signal-desktop-flags.conf"
+
+# The migration pins the store on an existing install, without touching a
+# user-chosen --password-store line.
+bash "$migration"
+grep -qx -- '--password-store=gnome-libsecret' "$flags" ||
+  fail "the migration pins Signal to gnome-libsecret" "$(cat "$flags")"
+lines_before=$(wc -l <"$flags")
+bash "$migration"
+(( $(wc -l <"$flags") == lines_before )) ||
+  fail "the migration is idempotent" "$(cat "$flags")"
+pass "existing installs get the Signal password-store pin once"
+
+printf '%s\n' '--password-store=basic_text' >"$flags"
+bash "$migration"
+grep -qx -- '--password-store=basic_text' "$flags" ||
+  fail "a user-chosen password-store line is respected" "$(cat "$flags")"
+grep -q -- '--password-store=gnome-libsecret' "$flags" &&
+  fail "the migration does not override a user choice" "$(cat "$flags")"
+pass "an explicit password-store choice wins"
+rm -f "$flags"
+
+# The install path writes the same pin before the first launch, so a fresh
+# install never starts with the fallback backend.
+mkdir -p "$tmp_dir/bin"
+cat >"$tmp_dir/bin/omarchy-pkg-add" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$PKG_ADD_LOG"
+EOF
+cat >"$tmp_dir/bin/uwsm-app" <<'EOF'
+#!/bin/bash
+:
+EOF
+cat >"$tmp_dir/bin/setsid" <<'EOF'
+#!/bin/bash
+"$@"
+EOF
+chmod +x "$tmp_dir/bin"/*
+cat >"$tmp_dir/leaf.sh" <<EOF
+#!/bin/bash
+set -e
+PATH="$tmp_dir/bin:\$PATH" PKG_ADD_LOG="$tmp_dir/pkg-add.log" bash "$ROOT/bin/omarchy-install-service-signal"
+EOF
+chmod +x "$tmp_dir/leaf.sh"
+bash "$tmp_dir/leaf.sh" >/dev/null
+grep -qx -- '--password-store=gnome-libsecret' "$flags" ||
+  fail "the install path pins Signal before first launch" "$(cat "$flags" 2>/dev/null || echo missing)"
+grep -qx 'signal-desktop' "$tmp_dir/pkg-add.log" ||
+  fail "Signal is still installed" "$(cat "$tmp_dir/pkg-add.log")"
+rm -f "$flags"
+bash "$tmp_dir/leaf.sh" >/dev/null
+(( $(grep -c -- '--password-store=' "$flags") == 1 )) ||
+  fail "re-installing does not duplicate the pin" "$(cat "$flags")"
+pass "the install path pins Signal once and stays idempotent"
+
+pass "Signal is pinned to gnome-libsecret on both install and migration paths"


### PR DESCRIPTION
Fixes #10005

## What broke

Signal is an Electron app and uses Chromium's `os_crypt`/`safeStorage` machinery. On Hyprland the xdg-desktop-portal Secret backend has no provider, so an unpinned Signal falls back to the `basic` store; a profile whose DB key was stored under gnome-libsecret then cannot decrypt (`Detected change in safeStorage backend`, `hmac check failed`) and is unrecoverable without the original keyring secret. Browsers were already pinned to `--password-store=gnome-libsecret` by `config/chromium-flags.conf`, `copy_chromium_flags` in `omarchy-install-browser`, and migration 1784508556; Signal — which Omarchy installs itself and which explicitly reads `~/.config/signal-desktop-flags.conf` — got nothing.

## Fix

Mirror the browser treatment for Signal:

- `bin/omarchy-install-service-signal` writes the pin before the first launch, so an install never starts with the fallback backend (a first start with the wrong backend bakes the key choice into the profile).
- New `migrations/1788562800.sh` pins existing installs idempotently, and respects a user-chosen `--password-store=` line, exactly as the browser migration does.

I audited the other Electron-ish apps Omarchy ships: 1Password and Spotify do not read a `<app>-flags.conf` os_crypt pin (1Password uses libsecret directly, Spotify has its own keyring path), so they are left alone; Signal was the confirmed case with the source-level evidence in the issue.

## Tests

New `test/shell.d/signal-password-store-test.sh`, run against a sandbox HOME:

- the migration writes the pin once and is idempotent;
- a user-chosen `--password-store=basic_text` line is respected, not overridden;
- the install path writes the pin before launch, is idempotent on re-install, and still installs Signal.

All assertions pass here. Before this change nothing wrote the flag at all, so there is no path by which the file appears without the new code.

## Scope note

No default `config/` file is added: Signal is not installed by default, so the pin belongs on its install path and in the migration, not in a global default.
