### PR TITLE
Bound colour alias resolution in shell.toml

### DIFF
--- a/shell/Commons/Color.qml
+++ b/shell/Commons/Color.qml
@@ -22,6 +22,12 @@ QtObject {
   property color urgent: "#a55555"
   property color muted: "#707880"
 
+  // A shell.toml role may name another role instead of a colour. Chains are
+  // short in practice, so bound the walk rather than trusting the file: a
+  // theme ships shell.toml verbatim, and two roles naming each other would
+  // otherwise recurse until the shell process dies.
+  readonly property int maxAliasDepth: 8
+
   // Flat dictionary of "section.key" -> raw string from shell.toml.
   // Reassigning this whole property is what makes surface bindings below
   // re-evaluate when the theme swaps; mutating it in place would not.
@@ -48,10 +54,17 @@ QtObject {
     return value
   }
 
-  function flatColor(value, fallback) {
+  function flatColor(value, fallback, depth) {
+    var level = depth || 0
     var token = firstColorToken(value)
     var role = String(token || "").replace(/^\s+|\s+$/g, "").toLowerCase()
-    if (root.shellValues[role] && root.shellValues[role] !== token) return flatColor(root.shellValues[role], fallback)
+    if (root.shellValues[role] && root.shellValues[role] !== token) {
+      // The !== above only catches a role naming itself. A cycle of two or more
+      // needs the depth bound; an exhausted chain resolves to the fallback, the
+      // same answer an unresolvable token gets below.
+      if (level >= root.maxAliasDepth) return fallback
+      return flatColor(root.shellValues[role], fallback, level + 1)
+    }
     if (role === "foreground" || role === "text") return root.foreground
     if (role === "accent") return root.accent
     if (role === "urgent") return root.urgent

--- a/test/shell.d/color-alias-test.sh
+++ b/test/shell.d/color-alias-test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# A shell.toml role may name another role instead of a colour, and Color.qml
+# resolves that by recursing. A theme ships shell.toml verbatim, so the chain
+# has to be bounded: two roles naming each other is enough to exhaust the stack
+# of the process that draws the desktop.
+#
+# flatColor is plain JavaScript inside the QML block, so lift it out and run it
+# against a stubbed root rather than asserting on the source text.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const source = fs.readFileSync(root + '/shell/Commons/Color.qml', 'utf8')
+
+function lift(name) {
+  const match = source.match(new RegExp('\\n  function ' + name + '\\([\\s\\S]*?\\n  \\}\\n'))
+  if (!match) fail('Color.qml still defines ' + name + '()')
+  return match[0]
+}
+
+const depthMatch = source.match(/readonly property int maxAliasDepth:\s*(\d+)/)
+assert(!!depthMatch, 'Color.qml declares a maximum alias depth')
+const maxAliasDepth = Number(depthMatch[1])
+
+// Stand-ins for the QML scope flatColor closes over.
+const rootStub = {
+  foreground: '#cacccc',
+  background: '#101315',
+  accent: '#cacccc',
+  urgent: '#a55555',
+  muted: '#707880',
+  maxAliasDepth: maxAliasDepth,
+  shellValues: {}
+}
+const Qt = { rgba: (r, g, b, a) => 'rgba(' + [r, g, b, a].join(',') + ')' }
+const Geometry = { canonicalColor: (token) => token }
+
+const build = new Function('root', 'Qt', 'Geometry', `
+  ${lift('firstColorToken')}
+  ${lift('flatColor')}
+  return { firstColorToken: firstColorToken, flatColor: flatColor }
+`)
+const color = build(rootStub, Qt, Geometry)
+
+const FALLBACK = '#fallback'
+
+// A role naming a real colour resolves.
+rootStub.shellValues = { 'bar.background': '#123456' }
+assertEqual(color.flatColor('bar.background', FALLBACK), '#123456', 'a role pointing at a colour resolves to it')
+
+// A short chain of aliases still resolves, so the bound is not too tight.
+rootStub.shellValues = { 'a.one': 'a.two', 'a.two': 'a.three', 'a.three': '#abcdef' }
+assertEqual(color.flatColor('a.one', FALLBACK), '#abcdef', 'a chain of aliases shorter than the bound still resolves')
+
+// A role naming itself was already handled by the !== check, which stops the
+// recursion and lets the value fall through as an unresolvable colour name.
+rootStub.shellValues = { 'bar.background': 'bar.background' }
+assertEqual(color.flatColor('bar.background', FALLBACK), FALLBACK, 'a role naming itself resolves to the fallback')
+
+// Two roles naming each other is the case the !== check misses. Before the
+// depth bound this recursed until the stack gave out.
+rootStub.shellValues = { 'bar.background': 'bar.text', 'bar.text': 'bar.background' }
+let cycled
+try {
+  cycled = color.flatColor('bar.background', FALLBACK)
+} catch (e) {
+  fail('a two-role cycle in shell.toml resolves instead of exhausting the stack', String(e))
+}
+assertEqual(cycled, FALLBACK, 'a two-role cycle in shell.toml resolves to the fallback')
+
+// A longer ring, in case someone raises the bound without rechecking.
+const ring = {}
+for (let i = 0; i < maxAliasDepth + 4; i++) ring['r.' + i] = 'r.' + ((i + 1) % (maxAliasDepth + 4))
+rootStub.shellValues = ring
+let ringed
+try {
+  ringed = color.flatColor('r.0', FALLBACK)
+} catch (e) {
+  fail('a long alias ring resolves instead of exhausting the stack', String(e))
+}
+assertEqual(ringed, FALLBACK, 'a longer alias ring also resolves to the fallback')
+
+pass('shell.toml colour aliases cannot recurse without bound')
+JS


### PR DESCRIPTION
Second of the PRs from the report Erik suggested I open rather than send to the security team. Unrelated to the theme-staging one, so it is separate.

A `shell.toml` role may name another role instead of a colour, and `flatColor()` resolves that by recursing. The only guard is that the looked-up value differs from the token, which catches a role naming itself but not two roles naming each other:

```toml
[bar]
background = bar.text
text = bar.background
```

That recurses until the stack gives out. It matters because a theme ships `shell.toml` verbatim, so the file is not necessarily one the user wrote, and the process it takes down is the one drawing the desktop.

The fix bounds the walk at `maxAliasDepth` and resolves an exhausted chain to the fallback, which is the same answer an unresolvable token already gets. Eight is well clear of anything real; the generated `shell.toml.tpl` uses one level, and the test checks a three-link chain still resolves so the bound is not too tight.

The test lifts `firstColorToken()` and `flatColor()` out of the QML and runs them against a stubbed `root`, so it exercises the behaviour rather than asserting on the source text. Against the current code the two-role case raises `RangeError: Maximum call stack size exceeded`.

Writing the test also corrected something I had assumed: a role naming *itself* does not fall through to the palette, it resolves to the fallback, because its role string is `bar.background` rather than `background`. The test records that as-is.

For transparency, as in the other PR: this came out of AI-assisted work. An agent did much of the reading and drafted the test; I directed it and verified the behaviour both ways.
