### PR TITLE
Do not let a migration inherit its path overrides from the caller

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -82,8 +82,33 @@ wait_for_pacman_transaction() {
 
 wait_for_pacman_transaction
 
+# Migrations take the paths they touch from OMARCHY_* overrides so the test
+# suite can point them at a scratch tree, and several of those paths are handed
+# straight to `sudo` -- 1788025225.sh alone reads OMARCHY_SUDOERS_DIR,
+# OMARCHY_SYSTEMD_SYSTEM_DIR and OMARCHY_RETIRED_INSTALLER_ARTIFACTS_MARKER and
+# passes all three to `as_root install`/`rm`. Nothing on a real machine should be
+# able to choose those through whatever environment omarchy-migrate happened to
+# inherit, so clear the namespace before the queue runs.
+#
+# The suite is unaffected: it invokes each migration directly rather than through
+# here. Only the few names that are genuinely passed *to* omarchy-migrate are
+# kept -- OMARCHY_PATH, the state directory, the flag
+# omarchy-upgrade-to-quattro sets, and the documented direct-pacman escape.
+clear_migration_overrides() {
+  local var
+
+  for var in $(compgen -v OMARCHY_ 2>/dev/null); do
+    case "$var" in
+    OMARCHY_PATH | OMARCHY_MIGRATION_STATE | OMARCHY_UPGRADE_TO_QUATTRO_LIVE | OMARCHY_ALLOW_DIRECT_PACMAN) ;;
+    *) unset "$var" ;;
+    esac
+  done
+}
+
 mkdir -p "$STATE_DIR"
 [[ -d $MIGRATIONS_DIR ]] || exit 0
+
+clear_migration_overrides
 
 while IFS=$'\t' read -r name file marker <&3; do
   [[ -n $name ]] || continue

--- a/test/shell.d/migrate-scope-test.sh
+++ b/test/shell.d/migrate-scope-test.sh
@@ -103,3 +103,44 @@ grep -q '^after-reader$' "$stdin_calls" ||
   -f $stdin_home/.local/state/omarchy/migrations/200-after.sh ]] ||
   fail "migration runner marks both stdin-isolated migrations complete"
 pass "migration queue uses a private file descriptor instead of migration stdin"
+
+# Migrations read the paths they touch from OMARCHY_* overrides so the suite can
+# point them at a scratch tree, and several hand those paths to sudo. They must
+# not be settable through the environment omarchy-migrate inherited on a real
+# machine. The handful genuinely passed to omarchy-migrate still have to survive.
+scrub_root="$test_tmp/scrub-omarchy"
+scrub_home="$test_tmp/scrub-home"
+scrub_calls="$test_tmp/scrub-calls"
+mkdir -p "$scrub_root/migrations" "$scrub_home"
+
+cat >"$scrub_root/migrations/100-env.sh" <<'SH'
+{
+  printf 'sudoers:%s\n' "${OMARCHY_SUDOERS_DIR-<unset>}"
+  printf 'marker:%s\n' "${OMARCHY_RETIRED_INSTALLER_ARTIFACTS_MARKER-<unset>}"
+  printf 'zram:%s\n' "${OMARCHY_ZRAM_CONF-<unset>}"
+  printf 'omarchy_path:%s\n' "${OMARCHY_PATH-<unset>}"
+  printf 'quattro_live:%s\n' "${OMARCHY_UPGRADE_TO_QUATTRO_LIVE-<unset>}"
+} >>"$TEST_CALLS"
+SH
+
+HOME="$scrub_home" \
+OMARCHY_PATH="$scrub_root" \
+OMARCHY_SUDOERS_DIR="/tmp/attacker-sudoers" \
+OMARCHY_RETIRED_INSTALLER_ARTIFACTS_MARKER="/tmp/attacker-marker" \
+OMARCHY_ZRAM_CONF="/tmp/attacker-zram" \
+OMARCHY_UPGRADE_TO_QUATTRO_LIVE=1 \
+TEST_CALLS="$scrub_calls" \
+  "$ROOT/bin/omarchy-migrate" >"$test_tmp/scrub.out"
+
+grep -qx 'sudoers:<unset>' "$scrub_calls" ||
+  fail "an inherited OMARCHY_SUDOERS_DIR does not reach a migration" "$(cat "$scrub_calls")"
+grep -qx 'marker:<unset>' "$scrub_calls" ||
+  fail "an inherited marker override does not reach a migration" "$(cat "$scrub_calls")"
+grep -qx 'zram:<unset>' "$scrub_calls" ||
+  fail "the scrub covers the whole OMARCHY_ override namespace, not a denylist" "$(cat "$scrub_calls")"
+grep -qx "omarchy_path:$scrub_root" "$scrub_calls" ||
+  fail "OMARCHY_PATH still reaches a migration" "$(cat "$scrub_calls")"
+grep -qx 'quattro_live:1' "$scrub_calls" ||
+  fail "the Quattro upgrade flag still reaches a migration" "$(cat "$scrub_calls")"
+
+pass "migration path overrides cannot be inherited from the caller's environment"


### PR DESCRIPTION
Third and last of the PRs from the report Erik suggested I open rather than send to the security team. Framing it correctly this time: **this is hardening, not a vulnerability.** I could not turn it into privilege escalation, and I do not think anyone else could either. It is here because it is cheap and because the rest of the codebase already holds this line.

Migrations read the paths they touch from `OMARCHY_*` overrides so the test suite can point them at a scratch tree. That is a good pattern and this PR does not change it. The wrinkle is that several of those paths go straight to `sudo`. `migrations/1788025225.sh` reads `OMARCHY_SUDOERS_DIR`, `OMARCHY_SYSTEMD_SYSTEM_DIR` and `OMARCHY_RETIRED_INSTALLER_ARTIFACTS_MARKER`, and hands all three to `as_root install -Dm644` and `as_root rm -f`. `1787815267.sh` and `1788009111.sh` do the same with their markers.

`omarchy-migrate` passes its whole environment through, so on a real machine those paths can come from whatever the caller exported rather than from the literals in the script. This clears the `OMARCHY_` namespace before the queue runs and keeps only the names genuinely passed *to* `omarchy-migrate`: `OMARCHY_PATH`, `OMARCHY_MIGRATION_STATE`, the `OMARCHY_UPGRADE_TO_QUATTRO_LIVE` flag that `omarchy-upgrade-to-quattro` sets, and the documented `OMARCHY_ALLOW_DIRECT_PACMAN` escape.

Clearing the namespace rather than listing individual variables means a migration added later is covered without anyone having to remember. There are already around 25 of these overrides across `migrations/`.

On why this is not the `env -i` I originally floated: migrations run on every machine during an update, and an allowlist that misses something breaks them there, which is a much bigger problem than the one being fixed. Clearing one namespace is the smallest change that closes it.

Testing: the suite invokes each migration directly rather than through `omarchy-migrate`, so it is unaffected. `retired-installer-artifacts-migration-test`, `cups-hardening-test` and `zram-migration-test` all still pass, and those are the three that actually exercise the overrides. The new case in `migrate-scope-test.sh` fails without the change.

For transparency, as in the other two PRs: this came out of AI-assisted work, directed and verified by me.
