### PR TITLE
Load personal hypr.envs from package defaults, not user hyprland.lua

### DIFF
--- a/config/hypr/envs.lua
+++ b/config/hypr/envs.lua
@@ -1,0 +1,5 @@
+-- Personal environment overrides.
+-- Loaded after Omarchy's default.hypr.envs (including nvidia.lua), so these hl.env() calls win.
+--
+-- Example (hybrid laptop, decode on the iGPU):
+-- hl.env("LIBVA_DRIVER_NAME", "iHD")

--- a/config/hypr/hyprland.lua
+++ b/config/hypr/hyprland.lua
@@ -16,6 +16,9 @@ require("default.hypr.omarchy")
 -- Put your personal overrides in these files. They're loaded after Omarchy's
 -- defaults so package updates can improve the defaults without rewriting your
 -- ~/.config/hypr files.
+-- Environment variables: optional ~/.config/hypr/envs.lua, loaded from
+-- default.hypr.envs after nvidia.lua. Do not require it here; a missing file
+-- would abort the rest of this config.
 require("hypr.monitors")
 require("hypr.input")
 require("hypr.bindings")

--- a/default/hypr/envs.lua
+++ b/default/hypr/envs.lua
@@ -47,3 +47,7 @@ hl.config({
     no_update_news = true,
   },
 })
+
+-- Personal environment overrides. After the package defaults (including nvidia.lua)
+-- so user hl.env calls win. Optional: many installs have no ~/.config/hypr/envs.lua.
+require_optional.module("hypr.envs")

--- a/manual/46-faq.md
+++ b/manual/46-faq.md
@@ -16,6 +16,16 @@ hl.config({
 
 The bar will automatically show your current keyboard layout once you have multiple layouts configured (and you can click it to switch too).
 
+### How do I override environment variables Omarchy sets for Hyprland?
+
+Files under `~/.config/uwsm/env.d/` are exported before Hyprland starts, so they cannot override values Omarchy later sets with `hl.env` — including `LIBVA_DRIVER_NAME` on NVIDIA. Put those in `~/.config/hypr/envs.lua`:
+
+```
+hl.env("LIBVA_DRIVER_NAME", "iHD")
+```
+
+The file is optional and is loaded after Omarchy's hardware defaults. Start a new session after changing it; `hyprctl reload` does not rewrite the environment of processes that are already running.
+
 ### How do I change the clock format to 12-hour?
 
 Right-click the clock in the bar to cycle through the common formats, including the 12-hour ones. You can also set the format directly:

--- a/test/shell.d/hypr-envs-load-test.sh
+++ b/test/shell.d/hypr-envs-load-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+
+defaults="$ROOT/default/hypr/envs.lua"
+entry="$ROOT/config/hypr/hyprland.lua"
+
+grep -F 'require_optional.module("hypr.envs")' "$defaults" >/dev/null ||
+  fail "default.hypr.envs loads personal hypr.envs"
+pass "default.hypr.envs loads personal hypr.envs"
+
+nvidia_line=$(grep -n 'require("default.hypr.nvidia")' "$defaults" | head -n1 | cut -d: -f1)
+envs_line=$(grep -n 'require_optional.module("hypr.envs")' "$defaults" | head -n1 | cut -d: -f1)
+(( nvidia_line < envs_line )) ||
+  fail "personal hypr.envs loads after nvidia.lua" "nvidia=$nvidia_line envs=$envs_line"
+pass "personal hypr.envs loads after nvidia.lua"
+
+grep -F 'require("hypr.envs")' "$entry" >/dev/null &&
+  fail "hyprland.lua must not bare-require hypr.envs (missing file aborts the config)"
+pass "hyprland.lua does not bare-require hypr.envs"
+
+[[ -f $ROOT/config/hypr/envs.lua ]] || fail "shipped template includes config/hypr/envs.lua"
+pass "shipped template includes config/hypr/envs.lua"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/config/hypr" "$test_tmp/omarchy/default/hypr"
+
+cp "$ROOT/default/hypr/require_optional.lua" "$test_tmp/omarchy/default/hypr/require_optional.lua"
+cp "$ROOT/default/hypr/envs.lua" "$test_tmp/omarchy/default/hypr/envs.lua"
+
+cat >"$test_tmp/omarchy/default/hypr/paths.lua" <<'LUA'
+return { home = "/tmp", omarchy_path = "/tmp/omarchy" }
+LUA
+
+cat >"$test_tmp/omarchy/default/hypr/nvidia.lua" <<'LUA'
+_G.OMARCHY_TEST_NVIDIA_LOADED = true
+hl.env("LIBVA_DRIVER_NAME", "nvidia")
+LUA
+
+run_envs() {
+  local config_home=$1
+  HOME="$test_tmp" XDG_CONFIG_HOME="$config_home" OMARCHY_PATH="$test_tmp/omarchy" \
+    lua <<'LUA' >"$test_tmp/out" 2>"$test_tmp/err"
+package.path = os.getenv("XDG_CONFIG_HOME") .. "/?.lua;"
+  .. os.getenv("OMARCHY_PATH") .. "/?.lua;"
+  .. package.path
+
+local envs = {}
+hl = {
+  env = function(k, v) envs[k] = v end,
+  config = function() end,
+}
+
+local ok, err = pcall(require, "default.hypr.envs")
+if not ok then
+  io.stderr:write(tostring(err) .. "\n")
+  os.exit(1)
+end
+
+print("nvidia=" .. tostring(_G.OMARCHY_TEST_NVIDIA_LOADED))
+print("personal=" .. tostring(_G.OMARCHY_TEST_ENVS_LOADED))
+print("libva=" .. tostring(envs.LIBVA_DRIVER_NAME))
+LUA
+}
+
+# Absent personal file: package defaults still load.
+mkdir -p "$test_tmp/empty-config"
+run_envs "$test_tmp/empty-config"
+grep -Fx 'nvidia=true' "$test_tmp/out" >/dev/null ||
+  fail "absent hypr.envs still loads nvidia.lua" "$(cat "$test_tmp/err"; cat "$test_tmp/out")"
+grep -Fx 'personal=nil' "$test_tmp/out" >/dev/null ||
+  fail "absent hypr.envs is skipped" "$(cat "$test_tmp/err"; cat "$test_tmp/out")"
+grep -Fx 'libva=nvidia' "$test_tmp/out" >/dev/null ||
+  fail "absent hypr.envs leaves package LIBVA" "$(cat "$test_tmp/err"; cat "$test_tmp/out")"
+pass "absent hypr.envs does not abort default.hypr.envs"
+
+cat >"$test_tmp/config/hypr/envs.lua" <<'LUA'
+_G.OMARCHY_TEST_ENVS_LOADED = true
+hl.env("LIBVA_DRIVER_NAME", "iHD")
+LUA
+
+run_envs "$test_tmp/config"
+grep -Fx 'nvidia=true' "$test_tmp/out" >/dev/null ||
+  fail "present hypr.envs still loads nvidia.lua" "$(cat "$test_tmp/err"; cat "$test_tmp/out")"
+grep -Fx 'personal=true' "$test_tmp/out" >/dev/null ||
+  fail "present hypr.envs module ran" "$(cat "$test_tmp/err"; cat "$test_tmp/out")"
+grep -Fx 'libva=iHD' "$test_tmp/out" >/dev/null ||
+  fail "present hypr.envs overrides LIBVA" "$(cat "$test_tmp/err"; cat "$test_tmp/out")"
+pass "present hypr.envs overrides package hl.env"


### PR DESCRIPTION
## Why this instead of #9978

#9978 puts `require_optional.module("hypr.envs")` in **user** `config/hypr/hyprland.lua` and ships a migration that rewrites existing `~/.config/hypr/hyprland.lua`. Updates deliberately do not rewrite that file, which is why the migration exists — and why it is the wrong layer.

This PR loads the same optional module from **package** `default/hypr/envs.lua`, after `nvidia.lua`. A package update is enough. Existing installs are unchanged until the user creates `~/.config/hypr/envs.lua`. A missing file is a no-op (`require_optional`); a present one wins over `hl.env` from `nvidia.lua`.

`config/hypr/hyprland.lua` does **not** bare-`require("hypr.envs")`. omarchybot reproduced that a missing file aborts the rest of the entrypoint (`hyprctl configerrors`, requires below never run).

## Why uwsm/env.d is not the channel

`~/.config/uwsm/env.d/*` is exported before Hyprland starts. Omarchy then sets `LIBVA_DRIVER_NAME` / `NVD_BACKEND` / `__GLX_VENDOR_LIBRARY_NAME` with `hl.env` inside the compositor. uwsm cannot override those. That is the escape hatch the hybrid-GPU reports (#8328, #8215, #8989, #4901) all reach for.

638e35fc dropped `envs.conf` because Hyprland env was superseded by uwsm. This file is not that: it is the `hl.env` override uwsm cannot do.

## Changes

- `default/hypr/envs.lua`: `require_optional.module("hypr.envs")` after the hardware defaults
- `config/hypr/envs.lua`: shipped comment-only template
- `config/hypr/hyprland.lua`: comment pointing at the file; no require
- `manual/46-faq.md`: how to override `hl.env` values
- `test/shell.d/hypr-envs-load-test.sh`: load order, absent file does not abort, present file overrides `LIBVA_DRIVER_NAME`

Fixes #9902

## Test plan

- [x] `bash test/shell.d/hypr-envs-load-test.sh` (6/6)
- [x] `bash test/shell.d/hyprland-default-config-test.sh`
- [ ] New session after creating `~/.config/hypr/envs.lua` with `hl.env("LIBVA_DRIVER_NAME", "iHD")` — confirm `systemctl --user show-environment` (or a child spawned after login) sees it. `hyprctl reload` will not rewrite already-running clients.