### PR TITLE
Fix Super+J in scrolling layouts

### DIFF
--- a/bin/omarchy-hyprland-window-split-toggle
+++ b/bin/omarchy-hyprland-window-split-toggle
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle the focused window split or scrolling column stack
+
+set -euo pipefail
+
+layout=$(hyprctl activeworkspace -j | jq -r '.tiledLayout // empty')
+
+case "$layout" in
+  dwindle) layout_message="togglesplit" ;;
+  scrolling) layout_message="consume_or_expel prev" ;;
+  *) exit 0 ;;
+esac
+
+hyprctl dispatch "hl.dsp.layout(\"$layout_message\")" >/dev/null

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -2,7 +2,7 @@ o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+o.bind("SUPER + J", "Toggle window split", "omarchy-hyprland-window-split-toggle")
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -38,6 +38,8 @@ But you can also choose to turn a workspace into the scrolling layout where wind
 
 The choice is per workspace, and it sticks. So you can keep workspace 1 on dwindle for browsing and workspace 2 on scrolling for code, and they'll come back that way after a restart. (The same toggle is under _Trigger > Toggle > Workspace Layout_ in the Omarchy menu).
 
+In the scrolling layout, `Super + J` toggles the focused window between its own column and a stack with the previous column.
+
 If you wish to use the scrolling layout as the default, you can set that in `~/.config/hypr/looknfeel.lua`:
 
 ```lua

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -13,7 +13,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + W` or `Super + Q` | Close window             |
 | `Ctrl + Alt + Del` | Close all windows |
 | `Super + T`               | Toggle window between tiling/floating             |
-| `Super + J` | Toggle window position (horizontal/vertical) |
+| `Super + J` | Toggle window position (horizontal/vertical in dwindle, stacked/unstacked in scrolling) |
 | `Super + O`               | Toggle popping window into sticky'n'floating |
 | `Super + L`               | Toggle between dwindle and scrolling layout |
 | `Super + P`               | Toggle pseudo window style (natural v stretch) |

--- a/test/shell.d/hyprland-window-test.sh
+++ b/test/shell.d/hyprland-window-test.sh
@@ -13,6 +13,11 @@ if [[ $1 == "activewindow" && $2 == "-j" ]]; then
   exit 0
 fi
 
+if [[ $1 == "activeworkspace" && $2 == "-j" ]]; then
+  printf '{"tiledLayout":"%s"}\n' "${HYPR_LAYOUT:-dwindle}"
+  exit 0
+fi
+
 if [[ $1 == "dispatch" ]]; then
   printf '%s\n' "$*" >>"$HYPRCTL_LOG"
   exit 0
@@ -37,3 +42,30 @@ PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_FULLSCREEN_CLIENT=2 \
 grep -Fq 'hl.dsp.window.fullscreen_state({ internal = 0, client = 0 })' "$log" || \
   fail "tiled fullscreen disables client fullscreen"
 pass "tiled fullscreen disables client fullscreen"
+
+>"$log"
+PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_LAYOUT=dwindle \
+  "$ROOT/bin/omarchy-hyprland-window-split-toggle"
+
+grep -Fxq 'dispatch hl.dsp.layout("togglesplit")' "$log" || \
+  fail "window split toggle dispatches the dwindle layout message"
+pass "window split toggle supports the dwindle layout"
+
+>"$log"
+PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_LAYOUT=scrolling \
+  "$ROOT/bin/omarchy-hyprland-window-split-toggle"
+
+grep -Fxq 'dispatch hl.dsp.layout("consume_or_expel prev")' "$log" || \
+  fail "window split toggle dispatches the scrolling layout message"
+pass "window split toggle supports the scrolling layout"
+
+>"$log"
+PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_LAYOUT=master \
+  "$ROOT/bin/omarchy-hyprland-window-split-toggle"
+
+[[ ! -s $log ]] || fail "window split toggle dispatches into an unsupported layout"
+pass "window split toggle ignores unsupported layouts"
+
+grep -Fq 'o.bind("SUPER + J", "Toggle window split", "omarchy-hyprland-window-split-toggle")' \
+  "$ROOT/default/hypr/bindings/tiling.lua" || fail "SUPER + J bypasses the layout-aware window split toggle"
+pass "SUPER + J uses the layout-aware window split toggle"


### PR DESCRIPTION
## Summary

- Route `Super + J` through a layout-aware command.
- Keep `togglesplit` for dwindle workspaces.
- Use `consume_or_expel prev` to stack or unstack the focused scrolling column.
- Document and test both layout paths.

## Reproduction

1. Start a fresh Omarchy 4.0 VM with Hyprland 0.56.2.
2. Switch a workspace to the scrolling layout.
3. Open two tiled windows and press `Super + J`.

The stock binding dispatches `togglesplit` and Hyprland reports `no such layoutmsg for scrolling`.

## Verification

- `bash test/shell.d/hyprland-window-test.sh`
- `./test/cli`
- Fresh QEMU VM: reproduced the stock runtime error, then verified stack/unstack in scrolling and horizontal/vertical toggling in dwindle after applying this change.