### PR TITLE
Option to hide empty workspaces

### DIFF
--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -72,6 +72,8 @@ Example `shell.json` (bar subtree only shown):
 | `omarchy.bluetooth` | Bluetooth icon + popup with device list, connect/disconnect, battery | left = popup · right = toggle radio |
 | `omarchy.monitor` | Brightness and laptop display controls | left = popup |
 
+The `omarchy.workspaces` widget shows workspaces 1-5 plus any higher numbered one that exists, dimming the empty ones. Set `hideEmptyWorkspaces` to `true` to drop empty workspaces from the bar entirely; the focused workspace stays visible even when it is empty.
+
 The `omarchy.indicators` widget loads individual bar indicators from `indicators/`. Omit `items` (or set it to an empty array) to show all indicators in the default order, or set `items` to a subset such as `["Dnd", "Reminder", "NightLight"]`. Set `alwaysShow` to `true` to keep inactive indicators visible instead of revealing them only on hover. Multiple `omarchy.indicators` instances are allowed, so different sections can show different subsets.
 
 ## Orientation

--- a/shell/plugins/bar/widgets/Workspaces.manifest.json
+++ b/shell/plugins/bar/widgets/Workspaces.manifest.json
@@ -15,6 +15,15 @@
     "displayName": "Workspaces",
     "description": "Workspace number indicators",
     "category": "Compositor",
-    "allowMultiple": false
+    "allowMultiple": false,
+    "schema": [
+      {
+        "key": "hideEmptyWorkspaces",
+        "type": "boolean",
+        "label": "Hide empty workspaces",
+        "description": "Show only workspaces that have windows, plus the focused one.",
+        "defaultValue": false
+      }
+    ]
   }
 }

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -8,6 +8,8 @@ BarWidget {
   id: root
   moduleName: "omarchy.workspaces"
 
+  readonly property bool hideEmptyWorkspaces: setting("hideEmptyWorkspaces", false) === true
+
   function workspaceById(id) {
     var values = Hyprland.workspaces.values
     for (var i = 0; i < values.length; i++) {
@@ -17,13 +19,25 @@ BarWidget {
     return null
   }
 
+  function workspaceOccupied(workspace) {
+    return workspace !== null && workspace.toplevels.values.length > 0
+  }
+
   function workspaceIds() {
-    var ids = [1, 2, 3, 4, 5]
+    var ids = root.hideEmptyWorkspaces ? [] : [1, 2, 3, 4, 5]
     var values = Hyprland.workspaces.values
+    var focusedId = Hyprland.focusedWorkspace !== null ? Hyprland.focusedWorkspace.id : 0
 
     for (var i = 0; i < values.length; i++) {
-      var id = values[i].id
-      if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
+      var workspace = values[i]
+      var id = workspace.id
+
+      if (id < 1 || id > 10 || ids.indexOf(id) !== -1) continue
+      // The focused workspace survives the filter even when empty: hiding it
+      // would leave nothing on the bar saying where you are.
+      if (root.hideEmptyWorkspaces && id !== focusedId && !root.workspaceOccupied(workspace)) continue
+
+      ids.push(id)
     }
 
     ids.sort(function(left, right) { return left - right })
@@ -55,7 +69,7 @@ BarWidget {
         required property int modelData
 
         readonly property var workspace: root.workspaceById(modelData)
-        readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
+        readonly property bool occupied: root.workspaceOccupied(workspace)
         readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
 
         bar: root.bar


### PR DESCRIPTION
Allows users to hide the empty workspaces in the `omarchy.workspaces` plugin, defaults to `false`. This was possible to do pre-quattro and it's something I miss being able to do.
