### PR TITLE
Fix Obsidian SUPER+SHIFT+O to focus existing window

### DIFF
--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -15,7 +15,7 @@ if o.preinstalled_bindings_enabled() then
   o.bind("SUPER + SHIFT + ALT + M", "Music TUI", { tui = "cliamp", focus = true })
   o.bind("SUPER + SHIFT + D", "Docker", { tui = "omarchy-launch-docker-tui" })
   o.bind("SUPER + SHIFT + G", "Signal", { omarchy = "signal" })
-  o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "^obsidian$" })
+  o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "obsidian" })
   o.bind("SUPER + SHIFT + W", "Omawrite", { launch = "omawrite" })
   o.bind("SUPER + SHIFT + SLASH", "Passwords", { omarchy = "1password" })
 


### PR DESCRIPTION
## Problem

Pressing `SUPER+SHIFT+O` always opens the Obsidian vault selector dialog, even when Obsidian is already running. The binding should focus the existing window on the second press.

## Root cause

Obsidian's `WM_CLASS` is `md.obsidian.Obsidian` (set in its `.desktop` file via `StartupWMClass`), but the focus pattern in the binding was `^obsidian$` — an anchored regex that requires an exact match. Since `md.obsidian.Obsidian` ≠ `obsidian`, `omarchy-launch-or-focus` never finds the existing window and always launches a new instance.

## Fix

Change the focus pattern from `"^obsidian$"` to `"obsidian"`. This produces jq regex `\bobsidian\b`, which matches the word "obsidian" within `md.obsidian.Obsidian` (dots are word boundaries).

```lua
-- before
o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "^obsidian$" })
-- after
o.bind("SUPER + SHIFT + O", "Obsidian", { launch = "obsidian", focus = "obsidian" })
```

## Verified

- `hyprctl clients` confirms the running window class is `md.obsidian.Obsidian`
- jq `test("\\bobsidian\\b"; "i")` returns `true` for that class
- jq `test("\\b^obsidian$\\b"; "i")` returns `false` for that class
- All tests pass (pre-existing flaky `bar-icon-geometry-test` excluded)