### PR TITLE
Render usageStatusText in the agents status banner

### DIFF
--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -511,7 +511,7 @@ Panel {
               anchors.verticalCenter: parent.verticalCenter
               anchors.leftMargin: Style.space(12)
               anchors.rightMargin: Style.space(12)
-              text: root.provider ? String(root.provider.authHelpText || "") : ""
+              text: root.provider ? String(root.provider.usageStatusText || root.provider.authHelpText || "") : ""
               color: root.dim
               font.family: root.fontFamily
               font.pixelSize: Style.font.caption


### PR DESCRIPTION
## Summary

The agents panel status banner is visible when `usageStatusText` is non-empty, but the `Text` node rendered `authHelpText`. A collector that sets status without auth help therefore draws an empty urgent-styled box.

This makes the banner text follow the same field as its visibility gate (`usageStatusText`, falling back to `authHelpText`).

Fixes https://github.com/omacom/omarchy/issues/10000

## Test plan

- [ ] Reproduce with the example collector JSON from #10000 (`usageStatusText` set, `authHelpText` empty): empty red box before, status line after.
- [ ] Confirm existing claude/codex/fireworks banners still show when they set `authHelpText` together with status.
- Visual change is one line of status copy in the agents panel; no layout/theme change.