### PR TITLE
Allow symlinking hooks with omarchy hook install --symlink

### DIFF
--- a/bin/omarchy-hook-install
+++ b/bin/omarchy-hook-install
@@ -3,29 +3,64 @@
 # omarchy:summary=Install a hook into ~/.config/omarchy/hooks/<type>.d/
 # omarchy:group=hook
 # omarchy:name=install
-# omarchy:args=<type> <file>
-# omarchy:examples=omarchy hook install post-update ~/my-hook
+# omarchy:args=[--symlink] <type> <file>
+# omarchy:examples=omarchy hook install post-update ~/my-hook | omarchy hook install --symlink post-boot ~/my-hook
 
 set -e
 
-if (( $# != 2 )); then
-  echo "Usage: omarchy-hook-install <type> <file>"
+use_symlink=0
+positional=()
+
+while (($#)); do
+  case "$1" in
+    -s|--symlink)
+      use_symlink=1
+      shift
+      ;;
+    --)
+      shift
+      while (($#)); do
+        positional+=("$1")
+        shift
+      done
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      positional+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 2 )); then
+  echo "Usage: omarchy-hook-install [--symlink|-s] <type> <file>" >&2
   exit 1
 fi
 
-HOOK_TYPE=$1
-HOOK_FILE=$2
+HOOK_TYPE="${positional[0]}"
+HOOK_FILE="${positional[1]}"
 HOOK_DIR="$HOME/.config/omarchy/hooks/$HOOK_TYPE.d"
 HOOK_NAME=$(basename "$HOOK_FILE")
 HOOK_PATH="$HOOK_DIR/$HOOK_NAME"
 
 if [[ ! -f $HOOK_FILE ]]; then
-  echo "Hook file not found: $HOOK_FILE"
+  echo "Hook file not found: $HOOK_FILE" >&2
   exit 1
 fi
 
 mkdir -p "$HOOK_DIR"
-cp "$HOOK_FILE" "$HOOK_PATH"
-chmod 755 "$HOOK_PATH"
 
-echo "Installed $HOOK_TYPE hook: $HOOK_PATH"
+if (( use_symlink )); then
+  HOOK_TARGET=$(realpath "$HOOK_FILE")
+  ln -sfn "$HOOK_TARGET" "$HOOK_PATH"
+  chmod +x "$HOOK_PATH"
+  echo "Symlinked $HOOK_TYPE hook: $HOOK_PATH -> $HOOK_TARGET"
+else
+  cp "$HOOK_FILE" "$HOOK_PATH"
+  chmod 755 "$HOOK_PATH"
+  echo "Installed $HOOK_TYPE hook: $HOOK_PATH"
+fi

--- a/test/shell.d/hook-install-test.sh
+++ b/test/shell.d/hook-install-test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+test_home="$test_tmp/home"
+mkdir -p "$test_home"
+
+install_hook() {
+  HOME="$test_home" PATH="$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-hook-install" "$@" >"$test_tmp/out" 2>&1 || return $?
+}
+
+run_hook() {
+  HOME="$test_home" PATH="$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-hook" "$@" >"$test_tmp/out" 2>&1 || return $?
+}
+
+source_hook="$test_tmp/my-hook.sh"
+cat >"$source_hook" <<'SH'
+#!/usr/bin/env bash
+echo "hook executed: $1" >> "$HOOK_LOG"
+SH
+chmod +x "$source_hook"
+
+installed_path="$test_home/.config/omarchy/hooks/post-boot.d/my-hook.sh"
+
+# ---------------------------------------------------------------- default copy
+install_hook post-boot "$source_hook" || fail "hook install succeeds with default copy"
+[[ -f "$installed_path" ]] || fail "installed hook exists at target destination"
+[[ ! -L "$installed_path" ]] || fail "default install copies rather than symlinks"
+[[ -x "$installed_path" ]] || fail "installed hook is executable"
+pass "omarchy hook install copies the file by default"
+
+# ---------------------------------------------------------------- --symlink & -s
+rm -f "$installed_path"
+
+install_hook --symlink post-boot "$source_hook" || fail "hook install succeeds with --symlink"
+[[ -L "$installed_path" ]] || fail "target is a symbolic link with --symlink"
+[[ $(readlink -f "$installed_path") == $(readlink -f "$source_hook") ]] || \
+  fail "symlink points to the canonical source file"
+pass "omarchy hook install --symlink creates a valid symbolic link"
+
+# Re-run with short flag -s (idempotency check)
+install_hook -s post-boot "$source_hook" || fail "hook install -s succeeds and overwrites existing symlink"
+[[ -L "$installed_path" ]] || fail "target remains a symbolic link with -s"
+pass "omarchy hook install -s supports short flag and is idempotent"
+
+# Verify edits to source reflect through symlink
+printf '\necho "updated"\n' >> "$source_hook"
+grep -Fq "updated" "$installed_path" || fail "modifications to source file reflect through symlink"
+pass "symlinked hook dynamically reflects changes to source"
+
+# ---------------------------------------------------------------- runner executes symlink
+hook_log="$test_tmp/hook.log"
+HOOK_LOG="$hook_log" run_hook post-boot || fail "omarchy-hook runner executes successfully"
+grep -Fq "hook executed:" "$hook_log" || fail "omarchy-hook executed the symlinked hook script"
+pass "omarchy-hook runner successfully executes symlinked hooks"
+
+# ---------------------------------------------------------------- error handling
+if install_hook post-boot "$test_tmp/does-not-exist.sh"; then
+  fail "hook install rejects non-existent source file"
+fi
+pass "hook install rejects non-existent source file"
+
+if install_hook --invalid-flag post-boot "$source_hook"; then
+  fail "hook install rejects unknown options"
+fi
+pass "hook install rejects unknown options"
+
+if install_hook post-boot; then
+  fail "hook install rejects missing arguments"
+fi
+pass "hook install rejects missing arguments"


### PR DESCRIPTION
## Summary
Adds an optional `--symlink` / `-s` flag to `omarchy hook install` so users can symlink hook scripts (e.g. from version-controlled dotfiles) into `~/.config/omarchy/hooks/<type>.d/` rather than copying them.

## Changes
- **`bin/omarchy-hook-install`**:
  - Adds support for `--symlink` and `-s`.
  - Resolves the target via `realpath` so relative paths link correctly into `~/.config/omarchy/hooks/<type>.d/`.
  - Ensures the installed symlink target is marked executable (`chmod +x`).
  - Supports flags passed before or after positional arguments.
  - Updates command metadata frontmatter and examples.
- **`test/shell.d/hook-install-test.sh`**:
  - Adds dedicated test coverage for `omarchy-hook-install`.
  - Verifies default copy behavior, `--symlink`, `-s`, idempotency, and live execution via `omarchy-hook`.
  - Verifies error handling on missing arguments, non-existent files, and invalid options.

## Test plan
- Run `test/shell.d/hook-install-test.sh` -> All 8 assertions pass.
- Run `omarchy commands --check` -> Metadata checks pass.
- Run `test/cli` -> All CLI entrypoint assertions pass.