### PR TITLE
Clear set-ID bits on Windows VM directories

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,7 +580,7 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  chmod a-s,u=rwx,go= -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1

--- a/test/shell.d/windows-vm-mount-boundary-test.sh
+++ b/test/shell.d/windows-vm-mount-boundary-test.sh
@@ -92,6 +92,9 @@ pass "root dispatch rejects missing/invalid uid, passwd, owner, symlink, and wri
 mkdir /home/storage-target /home/shared-target
 mount -t tmpfs -o uid=1000,gid=1000,mode=0755,size=3g storage-test /home/storage-target
 mount -t tmpfs -o uid=1000,gid=1000,mode=0755,size=64m shared-test /home/shared-target
+# dockur/windows can leave the shared directory setgid. Numeric chmod preserves
+# directory set-ID bits, so exercise the mode the next launch must normalize.
+chmod 2755 /home/shared-target
 ln -s /home/storage-target /home/alice/.windows
 ln -s /home/shared-target /home/alice/Windows
 chown -h 1000:1000 /home/alice/.windows /home/alice/Windows


### PR DESCRIPTION
Fixes #9374.\n\nGNU chmod preserves set-ID bits on directories when applying a numeric mode, so a shared directory left at mode 2700 remained 2700 after chmod 0700. The following exact-mode check then rejected it and prevented the Windows VM from launching.\n\nUse an explicit symbolic mode that clears special bits while setting private 0700 permissions. Add a mount-boundary regression case starting with a setgid shared directory.\n\nTests:\n- bash test/shell.d/windows-vm-mount-boundary-test.sh (passes in an isolated privileged namespace)\n- ./test/all (Windows VM tests pass; five unrelated environment-dependent files fail because omarchy-pkgs is not checked out and the live desktop differs from test expectations)