### PR TITLE
[PoC] Load Qt translations from an external QML module

### DIFF
--- a/poc/qtranslator-adapter/.gitignore
+++ b/poc/qtranslator-adapter/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/build-*/

--- a/poc/qtranslator-adapter/CMakeLists.txt
+++ b/poc/qtranslator-adapter/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(omarchy-i18n-poc LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Qml)
+qt_standard_project_setup(REQUIRES 6.6)
+
+qt_add_qml_module(omarchy-i18n
+    URI Omarchy.I18n
+    VERSION 1.0
+    OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/qml/Omarchy/I18n"
+    SOURCES
+        src/translator.cpp
+        src/translator.hpp
+)
+
+target_link_libraries(omarchy-i18n PRIVATE Qt6::Core Qt6::Qml)
+target_include_directories(omarchy-i18n PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/poc/qtranslator-adapter/README.md
+++ b/poc/qtranslator-adapter/README.md
@@ -1,0 +1,58 @@
+# QTranslator adapter proof of concept
+
+This proof of concept checks whether Omarchy can add Qt's standard translation runtime to an unmodified Quickshell process by shipping an external C++ QML module.
+
+It exposes one QML singleton:
+
+```qml
+import Omarchy.I18n
+
+Component.onCompleted: Translator.load("/path/to/omarchy_ja.qm")
+```
+
+QML strings continue to use Qt's standard translation APIs:
+
+```qml
+Text { text: qsTr("Settings") }
+```
+
+## What this proves
+
+The test launches the installed `quickshell` binary without patching or rebuilding it. It imports the external module, loads a real Japanese `.qm` catalog with `QTranslator`, and checks that an existing `qsTr()` binding changes from `&Close` to its Japanese translation.
+
+Installing a `QTranslator` is not sufficient to update bindings that already exist. The adapter must also call `QQmlEngine::retranslate()` after installing the catalog.
+
+## Run
+
+Requirements:
+
+- CMake and a C++ compiler
+- Qt 6 Core and QML development files
+- Quickshell
+- `/usr/share/locale/ja/LC_MESSAGES/kconfig6_qt.qm` from KDE Frameworks, used only as an available real-world test catalog
+
+```bash
+cmake -S . -B build
+cmake --build build
+./tests/run.sh
+```
+
+Expected output includes:
+
+```text
+TEST_PASS: &Close -> 閉じる(&C)
+```
+
+The test uses Qt's offscreen platform and does not alter or restart the user's running Omarchy shell.
+
+## Why this is not proposed as the preferred production design
+
+The clean solution is for Quickshell to expose first-class support for loading and replacing `QTranslator` catalogs. This adapter demonstrates a fallback if upstream support is unavailable, but it would make Omarchy responsible for a native Qt binary and introduce costs that a QML-only implementation does not have:
+
+- rebuilding and publishing the module for supported architectures;
+- coordinating rebuilds with Qt ABI updates in Arch Linux;
+- making shell startup resilient to a missing or incompatible native module;
+- maintaining a CMake, CI, and package pipeline for a very small runtime feature;
+- requiring C++ and Qt knowledge from future maintainers.
+
+This is therefore discussion material rather than merge-ready integration. A production implementation would still need packaging, safe optional loading, TS/QM extraction and compilation, locale fallback, catalog replacement failure handling, and shell reload tests.

--- a/poc/qtranslator-adapter/src/translator.cpp
+++ b/poc/qtranslator-adapter/src/translator.cpp
@@ -1,0 +1,17 @@
+#include "translator.hpp"
+
+#include <QCoreApplication>
+#include <QQmlEngine>
+
+Translator::Translator(QObject* parent): QObject(parent) {}
+
+bool Translator::load(const QString& catalogPath) {
+    QCoreApplication::removeTranslator(&m_translator);
+
+    if (!m_translator.load(catalogPath)) return false;
+    if (!QCoreApplication::installTranslator(&m_translator)) return false;
+
+    if (auto* engine = qmlEngine(this)) engine->retranslate();
+
+    return true;
+}

--- a/poc/qtranslator-adapter/src/translator.hpp
+++ b/poc/qtranslator-adapter/src/translator.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QTranslator>
+
+class Translator final : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    explicit Translator(QObject* parent = nullptr);
+
+    Q_INVOKABLE bool load(const QString& catalogPath);
+
+private:
+    QTranslator m_translator;
+};

--- a/poc/qtranslator-adapter/tests/run.sh
+++ b/poc/qtranslator-adapter/tests/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+CATALOG=/usr/share/locale/ja/LC_MESSAGES/kconfig6_qt.qm
+BUILD_DIR="${BUILD_DIR:-$ROOT/build}"
+
+if [[ ! -f $CATALOG ]]; then
+  echo "Japanese Qt test catalog is unavailable: $CATALOG" >&2
+  exit 77
+fi
+
+output="$(QT_QPA_PLATFORM=offscreen \
+  QML_IMPORT_PATH="$BUILD_DIR/qml${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+  quickshell -p "$ROOT/tests/translation-test.qml" 2>&1)" || {
+    status=$?
+    printf '%s\n' "$output" >&2
+    exit "$status"
+  }
+
+printf '%s\n' "$output"
+[[ $output == *"TEST_PASS:"* ]]

--- a/poc/qtranslator-adapter/tests/translation-test.qml
+++ b/poc/qtranslator-adapter/tests/translation-test.qml
@@ -1,0 +1,48 @@
+pragma Translator: "KStandardActions"
+
+import QtQuick
+import Quickshell
+import Omarchy.I18n
+
+ShellRoot {
+    readonly property string catalogPath: "/usr/share/locale/ja/LC_MESSAGES/kconfig6_qt.qm"
+    readonly property string translatedText: qsTr("&Close")
+    property int exitCode: 0
+    property string sourceText
+
+    Timer {
+        id: verifyTimer
+        interval: 1
+        onTriggered: {
+            if (translatedText === sourceText) {
+                console.error(`TEST_FAIL: bound translation unchanged: ${translatedText}`)
+                exitCode = 1
+            } else {
+                console.log(`TEST_PASS: ${sourceText} -> ${translatedText}`)
+            }
+
+            exitTimer.start()
+        }
+    }
+
+    Timer {
+        id: exitTimer
+        interval: 1
+        onTriggered: Qt.exit(exitCode)
+    }
+
+    Component.onCompleted: {
+        Qt.uiLanguage = "en"
+        sourceText = translatedText
+
+        if (!Translator.load(catalogPath)) {
+            console.error("TEST_FAIL: catalog did not load")
+            exitCode = 1
+            exitTimer.start()
+            return
+        }
+
+        Qt.uiLanguage = "ja"
+        verifyTimer.start()
+    }
+}


### PR DESCRIPTION
## Purpose

This draft demonstrates a fallback way to use Qt's standard i18n stack in Omarchy without changing Quickshell itself.

The external C++ QML module installs a real `.qm` catalog through `QTranslator` and calls `QQmlEngine::retranslate()`. Omarchy QML can therefore use the standard `qsTr()` API instead of maintaining a custom translation runtime.

This is related to #8765, but it deliberately explores a different runtime design.

## Difference from #8765

#8765 does valuable work toward making Omarchy translatable, including catalog tooling and coverage across QML and shell code. The concern explored here is narrower: its QML path also makes Omarchy responsible for its own runtime translation behavior, including catalog lookup, locale fallback, interpolation, and plural selection.

Those details accumulate language-specific edge cases over time. This PoC tests whether Omarchy can avoid maintaining a parallel i18n engine by keeping QML strings on Qt's standard `qsTr()` API and delegating contexts, disambiguation, plural rules, and retranslation to Qt. The native adapter is only a bridge for the capability Quickshell does not currently expose; it is not another translation engine.

This distinction does not make the rest of #8765's work unnecessary. Translation ownership, extraction, Bash/gettext integration, contributor workflow, and release policy would still need to be designed on the Omarchy side.

## Verified

The included integration test:

- builds the external `Omarchy.I18n` QML module;
- launches the system Quickshell binary without patching or rebuilding it;
- loads an existing Japanese `.qm` catalog;
- verifies that an already-bound `qsTr()` string changes from `&Close` to `閉じる(&C)`.

## Why this is a draft

This is not the preferred production architecture. First-class `QTranslator` support in Quickshell would be substantially cleaner. An Omarchy-owned native module would otherwise introduce significant costs:

- architecture-specific builds and packaging;
- rebuild coordination with Qt ABI updates on Arch Linux;
- a possible shell-startup failure point when the module is missing or incompatible;
- CMake, CI, and native-code maintenance for a small runtime feature;
- a higher contributor knowledge requirement than QML and Bash alone.

The proof of concept is intentionally isolated under `poc/` and is not wired into the Omarchy shell or package. Before this could become mergeable, it would need safe optional loading, packaging, TS/QM tooling, locale fallback, catalog replacement failure handling, and reload coverage.

## Upstream update

I have opened [quickshell-mirror/quickshell#1081](https://github.com/quickshell-mirror/quickshell/pull/1081) to add translation catalog loading directly to Quickshell using `QTranslator`. It supports the standard `qsTr()` workflow and language switching through `Qt.uiLanguage`, without requiring an external C++ QML module.

The upstream PR is still open and discloses AI assistance. If accepted, it would remove the need for the adapter explored here. This Omarchy PR remains a fallback PoC, not the preferred production approach.

The goal of opening this draft is to give the broader i18n discussion executable evidence: the fallback works, but its operational disadvantages are large enough that upstream Quickshell support should be preferred.

## Test

```bash
cd poc/qtranslator-adapter
cmake -S . -B build
cmake --build build
./tests/run.sh
```

The test currently uses `/usr/share/locale/ja/LC_MESSAGES/kconfig6_qt.qm` as an available real-world Qt catalog.

