### PR TITLE
Fix Chromium browser policy color scheme

### DIFF
--- a/bin/omarchy-theme-set-browser-policy
+++ b/bin/omarchy-theme-set-browser-policy
@@ -96,7 +96,7 @@ for policy_dir in "${POLICY_DIRS[@]}"; do
     failed=1
     continue
   }
-  printf '{"BrowserThemeColor": "#%s", "BrowserColorScheme": "device"}\n' "$color" >"$staged"
+  printf '{"BrowserThemeColor": "#%s", "BrowserColorScheme": "system"}\n' "$color" >"$staged"
 
   if [[ -L $dest || -d $dest ]]; then
     if ! rm -rf -- "$dest"; then

--- a/install/helpers/browser-policy.sh
+++ b/install/helpers/browser-policy.sh
@@ -110,7 +110,7 @@ browser_policy_install_color() {
   [[ $hex =~ ^#[0-9a-f]{6}$ ]] || return 1
 
   tmp=$(mktemp) || return 1
-  printf '{"BrowserThemeColor": "%s", "BrowserColorScheme": "device"}\n' "$hex" >"$tmp"
+  printf '{"BrowserThemeColor": "%s", "BrowserColorScheme": "system"}\n' "$hex" >"$tmp"
 
   if [[ -L $dest || -d $dest ]]; then
     if ! rm -rf -- "$dest" 2>/dev/null; then

--- a/migrations/1788441039.sh
+++ b/migrations/1788441039.sh
@@ -1,0 +1,16 @@
+echo "Update Chromium browser policies to follow the system color scheme"
+
+policy_files=(
+  /etc/chromium/policies/managed/color.json
+  /etc/opt/chrome/policies/managed/color.json
+  /etc/opt/edge/policies/managed/color.json
+  /etc/brave/policies/managed/color.json
+)
+
+for policy_file in "${policy_files[@]}"; do
+  [[ -f $policy_file ]] || continue
+  if grep -Fq '"BrowserColorScheme": "device"' "$policy_file"; then
+    omarchy-theme-set-browser || true
+    break
+  fi
+done

--- a/test/shell.d/browser-policy-dir-test.sh
+++ b/test/shell.d/browser-policy-dir-test.sh
@@ -41,9 +41,11 @@ browser_policy_install_color "$write_dir" "#aabbcc" ||
   fail "theme colour writes into a writable policy directory"
 grep -F '"BrowserThemeColor": "#aabbcc"' "$write_dir/color.json" >/dev/null ||
   fail "theme colour writes BrowserThemeColor"
+grep -F '"BrowserColorScheme": "system"' "$write_dir/color.json" >/dev/null ||
+  fail "theme colour follows the system color scheme"
 mode=$(stat -c '%a' "$write_dir/color.json")
 [[ $mode == "644" ]] || fail "theme colour creates a root-mode policy file" "mode=$mode"
-pass "theme colour writes a 0644 color.json"
+pass "theme colour writes a 0644 color.json with the system color scheme"
 
 if (( EUID == 0 )); then
   pass "running as root; skipping the mktemp-failure check"
@@ -308,11 +310,18 @@ policy_files=(
   "$ROOT/install/config/browser-policy.sh"
   "$ROOT/install/helpers/browser-policy.sh"
   "$ROOT/migrations/1787515927.sh"
+  "$ROOT/migrations/1788441039.sh"
 )
 if grep -nE 'chmod a\+rwx\b|chmod a\+rw\b|chmod a\+w\b|chmod o\+w|chmod ugo\+w|chmod 2775\b|chmod 2777\b|chmod 0777\b|chmod 777\b|install -d -m 0?[27]?777|omarchy-browser-policy' "${policy_files[@]}" >/dev/null; then
   fail "browser policy setup is not world-writable and does not use omarchy-browser-policy"
 fi
 pass "browser policy setup is not world-writable"
+
+grep -F '"BrowserColorScheme": "device"' "$ROOT/migrations/1788441039.sh" >/dev/null ||
+  fail "the color-scheme migration detects the retired device value"
+grep -F 'omarchy-theme-set-browser || true' "$ROOT/migrations/1788441039.sh" >/dev/null ||
+  fail "the color-scheme migration refreshes existing browser policies"
+pass "a migration refreshes browser policies with the retired color-scheme value"
 
 mapfile -t migrations < <(rg -l 'Stop world-writable Chromium and Firefox policy directories' "$ROOT/migrations")
 (( ${#migrations[@]} == 1 )) || fail "exactly one migration locks existing policy directories" "${migrations[*]}"


### PR DESCRIPTION
Fixes #10054.

Replaces the invalid `BrowserColorScheme: "device"` policy value with `system` in both writers, and adds a one-time migration to refresh existing policies.