### PR TITLE
Add an Ethernet toggle to the network panel

### DIFF
--- a/bin/omarchy-network-wired
+++ b/bin/omarchy-network-wired
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# omarchy:summary=Show or set persistent autoconnect for a wired interface
+# omarchy:group=network
+# omarchy:args=<interface> [on|off]
+# omarchy:examples=omarchy network wired enp59s0u1u4i5 | omarchy network wired enp59s0u1u4i5 off
+
+set -euo pipefail
+
+# Duplicated verbatim from omarchy-network-band's identical helper rather
+# than factored into a shared file -- there is no established shared-helper
+# convention for bin/ scripts in this repo, and introducing one would mean
+# touching that unrelated, already-shipped script for a 3-line function.
+# Happy to factor it out if a reviewer would rather have that.
+nm_get() {
+  LC_ALL=C nmcli -e no -g "$@" 2>/dev/null
+}
+
+# NetworkManager's auto-created ethernet profiles bind to a specific
+# interface by name, so the profile for a given NIC can be found
+# deterministically even while it is disconnected -- nmcli's device-to-
+# connection mapping (GENERAL.CONNECTION) only covers the active connection.
+#
+# This is one nmcli call per saved connection profile (Wi-Fi, VPN, everything
+# -- nmcli's bulk `connection show` listing only exposes a fixed compact
+# field set that does not include connection.interface-name, so finding the
+# wired one means asking each profile individually). Deliberately left this
+# way rather than collapsing to a combined bulk query: doing so only works by
+# parsing colon-joined multi-field nmcli output, which mis-parses a
+# connection name that itself contains a colon. For the handful of profiles
+# a typical machine has, the added cost here is not perceptible; happy to
+# revisit if a reviewer wants it optimized.
+wired_profile() {
+  local iface=$1 name
+
+  while IFS= read -r name; do
+    [[ $(nm_get connection.interface-name connection show "$name") == $iface ]] && { echo "$name"; return; }
+  done < <(nm_get NAME connection show)
+
+  # No profile for this interface is a normal outcome (a freshly linked
+  # device NetworkManager has not created one for yet), not a failure --
+  # callers branch on an empty result. Without this, the while loop's own
+  # exit status (1, from the final failed read/match) becomes this
+  # function's return value, and set -e would abort the whole script on
+  # `profile=$(wired_profile ...)` before either caller's empty check runs.
+  return 0
+}
+
+print_status() {
+  local iface=$1 profile
+
+  profile=$(wired_profile "$iface")
+  if [[ -z $profile ]]; then
+    echo "no"
+    return
+  fi
+
+  nm_get connection.autoconnect connection show "$profile"
+}
+
+# Toggling off must persist past a reboot, so this modifies the connection
+# profile's own autoconnect flag rather than the device's runtime-only
+# autoconnect state (nmcli device set --autoconnect), which resets on reboot
+# or replug and would silently let the connection come back.
+set_autoconnect() {
+  local iface=$1 desired=$2 profile
+
+  profile=$(wired_profile "$iface")
+  if [[ -n $profile ]]; then
+    nmcli connection modify "$profile" connection.autoconnect "$desired" >/dev/null
+  elif [[ $desired == "no" ]]; then
+    # No profile exists yet to carry the "off" choice (e.g. a device just
+    # linked for the first time). NetworkManager auto-creates a fresh,
+    # autoconnect-enabled profile the next time this device gets a link if
+    # none exists, which would silently undo "off" on the next boot/replug --
+    # create an explicitly disabled one now instead of leaving nothing
+    # behind for the disconnect below to mean anything past this session.
+    nmcli connection add type ethernet ifname "$iface" con-name "$iface" autoconnect no >/dev/null 2>&1 || true
+  fi
+
+  if [[ $desired == "yes" ]]; then
+    nmcli device connect "$iface" >/dev/null 2>&1 || true
+  else
+    nmcli device disconnect "$iface" >/dev/null 2>&1 || true
+  fi
+}
+
+usage() {
+  echo "Usage: omarchy-network-wired <interface> [on|off]" >&2
+}
+
+iface=${1:-}
+[[ -n $iface ]] || { usage; exit 1; }
+
+case "${2:-}" in
+  "")
+    print_status "$iface"
+    ;;
+  on)
+    set_autoconnect "$iface" yes
+    ;;
+  off)
+    set_autoconnect "$iface" no
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -130,14 +130,42 @@ Panel {
   // radio to switch. On a wired box it would otherwise sit there reading
   // "off" beside a perfectly live Ethernet connection.
   readonly property bool canToggleWifi: networkManagerAvailable && wifiStationAvailable
+  // Ethernet has no radio to switch, so this toggles the wired connection
+  // profile's own autoconnect instead — the closest per-connection
+  // equivalent. Only shown when a wired device actually exists, same
+  // reasoning as canToggleWifi.
+  readonly property bool canToggleWired: networkManagerAvailable && !!linkedWiredDevice
+  // Mirrors the *connection profile's* persisted autoconnect (queried via
+  // omarchy-network-wired), not WiredDevice.autoconnect -- that QML property
+  // is NetworkManager's device-level Autoconnect flag, which is runtime-only
+  // and resets on reboot/replug, so it cannot be what "off" means here.
+  property bool wiredAutoconnect: false
+  // Set while a killed process's stdout-finished is still expected to
+  // arrive -- see the comment on wiredProc for why toggleWired() cannot
+  // just restart it in the same tick. queryWiredAutoconnect() must not
+  // start a fresh query into that same window either, so it checks
+  // wiredTogglePending too.
+  property bool wiredExpectedStop: false
+  property bool wiredTogglePending: false
+  // True only for the user-initiated on/off action, like bandBusy -- not for
+  // the background status query, which reuses the same process but runs far
+  // more often (every refresh()) and should not make the switch ignore
+  // clicks for its own brief round trip.
+  readonly property bool wiredBusy: wiredTogglePending || (wiredProc.running && wiredProc.mode === "toggle")
   readonly property int qrHeaderIndex: canShareWifi ? 0 : -1
   readonly property int speedHeaderIndex: canRunSpeedTest ? (canShareWifi ? 1 : 0) : -1
   readonly property int toggleHeaderIndex: canToggleWifi ? (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) : -1
-  readonly property int headerActionCount: (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) + (canToggleWifi ? 1 : 0)
+  readonly property int wiredHeaderIndex: canToggleWired
+    ? (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) + (canToggleWifi ? 1 : 0)
+    : -1
+  readonly property int headerActionCount: (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0)
+    + (canToggleWifi ? 1 : 0) + (canToggleWired ? 1 : 0)
   readonly property bool qrHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === qrHeaderIndex
   readonly property bool speedHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === speedHeaderIndex
   readonly property bool toggleHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === toggleHeaderIndex
+  readonly property bool wiredHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === wiredHeaderIndex
   readonly property string toggleHint: Networking.wifiEnabled ? "Turn Wi-Fi off" : "Turn Wi-Fi on"
+  readonly property string toggleWiredHint: wiredAutoconnect ? "Turn Ethernet off" : "Turn Ethernet on"
   readonly property var dnsProviders: ["DHCP", "Cloudflare", "Google", "Custom"]
   property int dnsIndex: 0
   // ["2.4", "5", ...], or empty when there is nothing to choose between.
@@ -207,6 +235,55 @@ Panel {
     Qt.callLater(function() { root.refresh(true) })
   }
 
+  // Ethernet has no radio-wide enable flag, so "off" is persisted on the
+  // connection profile itself: autoconnect=false plus an explicit
+  // disconnect, so a dock plugged into a captive-portal or unwanted wired
+  // network stays off until switched back on, the same way
+  // Networking.wifiEnabled stays off across reboots rather than silently
+  // reconnecting. Shells out to omarchy-network-wired because
+  // Quickshell.Networking's WiredDevice.autoconnect is NetworkManager's
+  // device-level flag, not the connection profile's -- see wiredAutoconnect.
+  function toggleWired() {
+    if (!networkManagerAvailable || !linkedWiredDevice) return
+    if (wiredProc.running) {
+      // An in-flight toggle keeps running -- this is just a repeat click.
+      if (wiredProc.mode === "toggle") return
+      // An in-flight status query loses to user intent rather than silently
+      // swallowing the click. It cannot simply be restarted with the new
+      // command in this same tick, though: killing a process and its
+      // stream-finished signal have no guaranteed order (see wiredProc's
+      // comment, and wifiqr/Panel.qml's qrProc for the same shape), so the
+      // old query's output could still land after wiredProc.mode has
+      // already flipped to "toggle" and get misread as the toggle's own
+      // result. Queue it for onExited instead.
+      wiredExpectedStop = true
+      wiredTogglePending = true
+      wiredProc.running = false
+      return
+    }
+    startWiredToggle()
+  }
+
+  function startWiredToggle() {
+    if (!linkedWiredDevice) return
+    wiredProc.mode = "toggle"
+    wiredProc.command = ["omarchy-network-wired", linkedWiredDevice.name, wiredAutoconnect ? "off" : "on"]
+    wiredProc.running = true
+  }
+
+  function queryWiredAutoconnect() {
+    if (!linkedWiredDevice) {
+      wiredAutoconnect = false
+      return
+    }
+    // A toggle queued behind a killed status query (see toggleWired()) must
+    // not be raced by a fresh query starting in the same now-idle window.
+    if (wiredProc.running || wiredTogglePending) return
+    wiredProc.mode = "status"
+    wiredProc.command = ["omarchy-network-wired", linkedWiredDevice.name]
+    wiredProc.running = true
+  }
+
   IpcHandler {
     target: "omarchy.network"
 
@@ -216,6 +293,7 @@ Panel {
     function hide() { root.close() }
     function toggle() { root.toggle() }
     function toggleNetwork() { root.toggleNetwork() }
+    function toggleWired() { root.toggleWired() }
     // Compat routes for configs that summon the centered cards through the
     // network target; both cards are their own plugins now.
     function showQr() { root.summonWifiQr(true) }
@@ -228,6 +306,7 @@ Panel {
     if (headerIndex === qrHeaderIndex) summonWifiQr()
     else if (headerIndex === speedHeaderIndex) summonSpeedTest()
     else if (headerIndex === toggleHeaderIndex) toggleNetwork()
+    else if (headerIndex === wiredHeaderIndex) toggleWired()
   }
 
   function setHeaderCursor(index) {
@@ -438,6 +517,13 @@ Panel {
   // icon reflects connection changes without polling. Wired is preferred
   // when both are up, matching the default-route device.
   readonly property var wiredDevice: findDevice(DeviceType.Wired)
+  // wiredDevice falls back to any known wired device once none is connected,
+  // which on hardware with an onboard NIC that has no exposed jack (or any
+  // idle port) would otherwise show the wired toggle for a device that can
+  // never carry a cable. Gate the toggle on hasLink instead, so it only
+  // appears once something is actually plugged in.
+  readonly property var linkedWiredDevice: findLinkedWiredDevice()
+  onLinkedWiredDeviceChanged: queryWiredAutoconnect()
   readonly property string kind: {
     if (wiredDevice && wiredDevice.connected) return "ethernet"
     if (connectedWifiNetwork) return "wifi"
@@ -534,6 +620,7 @@ Panel {
       bandProc.command = ["omarchy-network-band"]
       bandProc.running = true
     }
+    queryWiredAutoconnect()
     // A closed panel has no nearby-network list to fill, and bare refresh()
     // reaches here from action completion, timeouts and construction.
     if (opened && wifiDevice) {
@@ -626,17 +713,33 @@ Panel {
 
   // Prefer a connected device: a machine can expose several NICs of the
   // same type (e.g. an idle onboard port alongside the active adapter),
-  // and the first-enumerated one may be carrierless.
-  function findDevice(type) {
+  // and the first-enumerated one may be carrierless. `extraFilter`, when
+  // given, narrows candidates further (see findLinkedWiredDevice()).
+  //
+  // Known limitation: this exposes exactly one device of a given type. With
+  // two candidates equally eligible at once (e.g. two wired NICs both
+  // linked, neither connected yet), whichever enumerates first wins with no
+  // way to reach the other. Accepted for now as consistent with the rest of
+  // the panel treating each connection kind as a single hero connection
+  // rather than a multi-NIC manager; revisit if that stops being true.
+  function findDevice(type, extraFilter) {
     var devices = networkDevices || []
     var fallback = null
     for (var i = 0; i < devices.length; i++) {
       var device = devices[i]
       if (!device || device.type !== type) continue
+      if (extraFilter && !extraFilter(device)) continue
       if (device.connected) return device
       if (!fallback) fallback = device
     }
     return fallback
+  }
+
+  // Restricted to wired devices that currently detect a physical link — a
+  // device with no cable plugged in is never a toggle target, however many
+  // wired NICs the system happens to have.
+  function findLinkedWiredDevice() {
+    return findDevice(DeviceType.Wired, function(device) { return device.hasLink })
   }
 
   function findConnectedWifiNetwork() {
@@ -906,6 +1009,38 @@ Panel {
     }
   }
 
+  // Drives both the wired-autoconnect readout and the on/off action, since
+  // omarchy-network-wired covers both and the two only overlap when a click
+  // preempts an in-flight status query (see toggleWired()) -- wiredExpectedStop
+  // covers exactly that window, the same way wifiqr/Panel.qml's qrProc uses
+  // its own expectedStop: killing a process and its stream-finished signal
+  // firing have no guaranteed order, so output from the query that was just
+  // killed could otherwise arrive after mode has already moved on to
+  // "toggle" and get misread as that toggle's result.
+  Process {
+    id: wiredProc
+    property string mode: "status"
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        if (root.wiredExpectedStop) return
+        if (wiredProc.mode === "status") {
+          root.wiredAutoconnect = text.trim() === "yes"
+        } else {
+          // refresh() itself calls queryWiredAutoconnect(), so this alone
+          // re-syncs status after the toggle -- no separate call needed.
+          Qt.callLater(function() { root.refresh(true) })
+        }
+      }
+    }
+    onExited: {
+      if (!root.wiredTogglePending) return
+      root.wiredTogglePending = false
+      root.wiredExpectedStop = false
+      root.startWiredToggle()
+    }
+  }
+
   // Slower than detailsPoll on purpose: this shells out to nmcli several times,
   // and band availability only moves when a scan turns up a new BSSID.
   Timer {
@@ -1145,6 +1280,7 @@ Panel {
       onTextKey: function(t) {
         if (t === "r" || t === "R") root.refresh()
         else if (t === "w" || t === "W") root.toggleNetwork()
+        else if (t === "e" || t === "E") root.toggleWired()
       }
 
     Column {
@@ -1212,20 +1348,69 @@ Panel {
             onClicked: root.summonSpeedTest()
           }
 
-          ToggleSwitch {
-            id: powerSwitch
+          // Two bare switches read as identical controls side by side, so each
+          // gets its own caption -- otherwise telling Wi-Fi and Ethernet apart
+          // requires hovering for the tooltip.
+          Column {
             visible: root.canToggleWifi
-            checked: Networking.wifiEnabled
-            hasCursor: root.toggleHeaderHasCursor
-            foreground: root.bar.foreground
+            spacing: 0
             Layout.alignment: Qt.AlignVCenter
-            onHovered: function(on) { if (on) root.setHeaderCursor(root.toggleHeaderIndex) }
-            onToggled: root.toggleNetwork()
 
-            PanelToolTip {
-              visible: powerSwitch.containsMouse
-              text: root.toggleHint
-              fontFamily: root.bar.fontFamily
+            Text {
+              textFormat: Text.PlainText
+              text: "Wi-Fi"
+              color: Qt.darker(root.bar.foreground, 1.4)
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.caption
+              anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            ToggleSwitch {
+              id: powerSwitch
+              checked: Networking.wifiEnabled
+              anchors.horizontalCenter: parent.horizontalCenter
+              hasCursor: root.toggleHeaderHasCursor
+              foreground: root.bar.foreground
+              onHovered: function(on) { if (on) root.setHeaderCursor(root.toggleHeaderIndex) }
+              onToggled: root.toggleNetwork()
+
+              PanelToolTip {
+                visible: powerSwitch.containsMouse
+                text: root.toggleHint
+                fontFamily: root.bar.fontFamily
+              }
+            }
+          }
+
+          Column {
+            visible: root.canToggleWired
+            spacing: 0
+            Layout.alignment: Qt.AlignVCenter
+
+            Text {
+              textFormat: Text.PlainText
+              text: "Ethernet"
+              color: Qt.darker(root.bar.foreground, 1.4)
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.caption
+              anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            ToggleSwitch {
+              id: wiredSwitch
+              checked: root.wiredAutoconnect
+              busy: root.wiredBusy
+              anchors.horizontalCenter: parent.horizontalCenter
+              hasCursor: root.wiredHeaderHasCursor
+              foreground: root.bar.foreground
+              onHovered: function(on) { if (on) root.setHeaderCursor(root.wiredHeaderIndex) }
+              onToggled: root.toggleWired()
+
+              PanelToolTip {
+                visible: wiredSwitch.containsMouse
+                text: root.toggleWiredHint
+                fontFamily: root.bar.fontFamily
+              }
             }
           }
         }

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -10,7 +10,101 @@ const network = requireFromRoot('shell/plugins/panels/network/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
 
 assert(/IpcHandler[\s\S]*?function toggleNetwork\(\) \{ root\.toggleNetwork\(\) \}/.test(panelSource), 'network exposes the Wi-Fi radio toggle over IPC')
+assert(/IpcHandler[\s\S]*?function toggleWired\(\) \{ root\.toggleWired\(\) \}/.test(panelSource), 'network exposes the wired toggle over IPC')
 assert(/manageIpc: false/.test(panelSource), 'network owns its IPC handler so it can extend the target methods')
+
+// The wired toggle is a header action alongside the Wi-Fi radio toggle, QR
+// share, and speed test, and must be independent of canToggleWifi so both
+// switches can show together when Wi-Fi and Ethernet are both live.
+assert(/readonly property bool canToggleWired: networkManagerAvailable && !!linkedWiredDevice/.test(panelSource), 'network shows the wired toggle whenever a wired device exists, independent of Wi-Fi state')
+assert(/readonly property int wiredHeaderIndex: canToggleWired/.test(panelSource), 'network gives the wired toggle its own header index')
+
+// A wired device with no cable plugged in (e.g. an onboard NIC with no
+// exposed jack) must never offer a toggle for a connection it can't carry.
+assert(/function findLinkedWiredDevice\(\)[\s\S]*?\n {2}\}/.test(panelSource), 'network has a link-gated wired device lookup')
+const findLinkedFn = panelSource.match(/function findLinkedWiredDevice\(\)[\s\S]*?\n {2}\}/)
+assert(findLinkedFn && /device\.hasLink/.test(findLinkedFn[0]), 'the wired toggle target is gated on hasLink, not just device existence')
+assert(/else if \(headerIndex === wiredHeaderIndex\) toggleWired\(\)/.test(panelSource), 'activateHeader() dispatches to the wired toggle')
+assert(/else if \(t === "e" \|\| t === "E"\) root\.toggleWired\(\)/.test(panelSource), 'network has an e/E keyboard shortcut for the wired toggle')
+
+// Turning wired off must persist (connection.autoconnect=no + disconnect),
+// not just disconnect for the session, matching how the Wi-Fi radio toggle
+// stays off across reboots rather than silently reconnecting.
+// WiredDevice.autoconnect (Quickshell.Networking) is NetworkManager's
+// device-level Autoconnect flag, which is runtime-only and resets on
+// reboot/replug -- only the connection profile's own autoconnect persists,
+// so the toggle shells out to omarchy-network-wired for that instead of
+// writing device.autoconnect.
+const toggleWiredFn = panelSource.match(/function toggleWired\(\)[\s\S]*?\n {2}\}/)
+assert(toggleWiredFn, 'network has a toggleWired() function')
+assert(!/device\.autoconnect/.test(toggleWiredFn[0]), 'toggleWired() does not write the non-persistent device-level autoconnect flag')
+assert(/!networkManagerAvailable \|\| !linkedWiredDevice/.test(toggleWiredFn[0]), 'toggleWired() only acts on the link-gated device')
+
+// The actual command dispatch lives in startWiredToggle(), which
+// toggleWired() defers to once it is safe to start (see the preemption
+// tests below) -- it is the one that must shell out to omarchy-network-wired
+// rather than writing device.autoconnect, and flip based on the queried
+// connection-profile autoconnect state.
+const startWiredToggleFn = panelSource.match(/function startWiredToggle\(\)[\s\S]*?\n {2}\}/)
+assert(startWiredToggleFn, 'network has a startWiredToggle() function')
+assert(!/device\.autoconnect/.test(startWiredToggleFn[0]), 'startWiredToggle() does not write the non-persistent device-level autoconnect flag')
+assert(/omarchy-network-wired/.test(startWiredToggleFn[0]), 'startWiredToggle() shells out to omarchy-network-wired for persisted connection-profile autoconnect')
+assert(/wiredAutoconnect \? "off" : "on"/.test(startWiredToggleFn[0]), 'startWiredToggle() flips based on the queried connection-profile autoconnect state')
+assert(/toggleWired\(\)[\s\S]*?startWiredToggle\(\)/.test(panelSource), 'toggleWired() defers the actual command to startWiredToggle()')
+
+// A background status query (queryWiredAutoconnect, run from every refresh())
+// shares wiredProc with the toggle action. A click arriving mid-query must
+// not be silently dropped -- it would look identical to a click that landed,
+// since wiredBusy only reflects an in-flight *toggle*, not a query. Nor can
+// it just restart wiredProc in the same tick: killing a process and its
+// stream-finished signal firing have no guaranteed order (mirrors
+// wifiqr/Panel.qml's qrProc expectedStop handling), so the killed query's
+// output could land after mode has already moved to "toggle" and be
+// misread as that toggle's result -- it must be queued for onExited instead.
+assert(/if \(wiredProc\.mode === "toggle"\) return/.test(toggleWiredFn[0]), 'toggleWired() lets an in-flight toggle keep running rather than restarting it')
+assert(/wiredExpectedStop = true/.test(toggleWiredFn[0]), 'toggleWired() marks a preempted query so its output is ignored on arrival')
+assert(/wiredTogglePending = true/.test(toggleWiredFn[0]), 'toggleWired() queues the toggle rather than starting it in the same tick as the kill')
+assert(/wiredProc\.running = false/.test(toggleWiredFn[0]), 'toggleWired() preempts an in-flight status query rather than silently dropping the click')
+
+const wiredProcBlock = panelSource.match(/Process \{\s*id: wiredProc[\s\S]*?\n {2}\}/)
+assert(wiredProcBlock, 'network has the wiredProc process')
+assert(/if \(root\.wiredExpectedStop\) return/.test(wiredProcBlock[0]), 'wiredProc drops output from a query it was told to expect a kill from')
+assert(/onExited: \{[\s\S]*?wiredTogglePending[\s\S]*?startWiredToggle\(\)/.test(wiredProcBlock[0]), 'wiredProc starts the queued toggle only once the killed query process has actually exited')
+assert(/if \(!root\.wiredTogglePending\) return/.test(wiredProcBlock[0]), 'wiredProc.onExited does nothing when no toggle was queued behind a kill')
+
+// queryWiredAutoconnect() must not race a toggle queued behind a kill it
+// just issued -- a fresh query starting in that same now-idle window would
+// contend with the queued toggle for wiredProc.
+const queryWiredFnForRace = panelSource.match(/function queryWiredAutoconnect\(\)[\s\S]*?\n {2}\}/)
+assert(queryWiredFnForRace && /wiredProc\.running \|\| wiredTogglePending/.test(queryWiredFnForRace[0]), 'queryWiredAutoconnect() will not start into a window a queued toggle is waiting for')
+
+// The switch's on/off state and hint must reflect the persisted
+// connection-profile autoconnect (wiredAutoconnect), not the device-level
+// WiredDevice.autoconnect that caused the original bug.
+assert(/property bool wiredAutoconnect: false/.test(panelSource), 'network tracks the queried connection-profile autoconnect separately from the device')
+assert(/checked: root\.wiredAutoconnect/.test(panelSource), 'the wired switch reflects the queried connection-profile autoconnect')
+assert(/readonly property string toggleWiredHint: wiredAutoconnect/.test(panelSource), 'the wired hint reflects the queried connection-profile autoconnect')
+
+// The wired switch must ignore clicks only while its own toggle action is in
+// flight, matching the bandAutoSwitch/Tailscale busy convention elsewhere in
+// this file -- not while the far more frequent background status query
+// (queried on every refresh()) happens to be running.
+assert(/readonly property bool wiredBusy: wiredTogglePending \|\| \(wiredProc\.running && wiredProc\.mode === "toggle"\)/.test(panelSource), 'network scopes wiredBusy to the toggle action (including a toggle queued behind a preempted query), not the status query')
+assert(/id: wiredSwitch[\s\S]*?busy: root\.wiredBusy/.test(panelSource), 'the wired switch surfaces wiredBusy the same way bandAutoSwitch surfaces bandBusy')
+
+// A Column positioner leaves a child's x alone unless the child anchors
+// itself, so a bare ToggleSwitch under a wider caption would sit at the
+// column's left edge instead of centered beneath the label.
+const wiredColumn = panelSource.match(/Column \{\s*visible: root\.canToggleWired[\s\S]*?\n {10}\}\n {8}\}/)
+assert(wiredColumn, 'network has a labeled wired-toggle column')
+assert(/id: wiredSwitch[\s\S]*?anchors\.horizontalCenter: parent\.horizontalCenter/.test(wiredColumn[0]), 'the wired switch is centered under its caption, not left-aligned by the column default')
+
+// The status query and the toggle both drive through the same process, keyed
+// off the physically linked device's interface name.
+const queryWiredFn = panelSource.match(/function queryWiredAutoconnect\(\)[\s\S]*?\n {2}\}/)
+assert(queryWiredFn, 'network has a queryWiredAutoconnect() function')
+assert(/omarchy-network-wired", linkedWiredDevice\.name\]/.test(queryWiredFn[0]), 'queryWiredAutoconnect() reads status for the linked device by interface name')
+assert(/onLinkedWiredDeviceChanged: queryWiredAutoconnect\(\)/.test(panelSource), 'network re-queries autoconnect as soon as the linked device changes, e.g. on plug/unplug')
 
 // Opening from the bar must call open() and nothing else. open() runs
 // refresh(true), which defers the PHY scan; a second bare refresh() defaults


### PR DESCRIPTION
## Summary

Adds an Ethernet on/off toggle to the network panel, mirroring the existing Wi-Fi radio toggle.

- A header switch appears next to the Wi-Fi one once a wired device actually detects a link (`hasLink`) — never just because a wired NIC exists in the system, so a dead onboard port with no exposed jack never shows a toggle for a connection it can't carry.
- "Off" persists the wired connection profile's own `connection.autoconnect` (via a new `omarchy-network-wired` helper) and disconnects, so a dock's Ethernet — e.g. one gated behind a captive portal you don't want to authenticate a personal device to — stays off across reboots, the same way the Wi-Fi radio toggle does. NetworkManager's device-level `Autoconnect` flag (what `Quickshell.Networking`'s `WiredDevice.autoconnect` exposes) is runtime-only and would not survive a reboot or replug, so this shells out instead of writing that property directly.
- Keyboard shortcut `e`/`E`, alongside the existing `w`/`W` for Wi-Fi.
- Both toggles are independently visible when both connections are live, and each now carries a small "Wi-Fi"/"Ethernet" caption so they're distinguishable without hovering for the tooltip.

<img width="430" height="605" alt="Network panel with both the Wi-Fi and Ethernet toggles visible" src="https://github.com/user-attachments/assets/d9ba0dd4-1e51-48ad-84cb-1705ed81065e" />

## Known limitations / deliberate trade-offs

- **Only one wired device is ever exposed to the toggle at a time** (whichever is connected, or — if none are connected yet — whichever enumerates first). With two cables linked simultaneously, there's no way to reach the second one from this panel. This mirrors the same fallback the panel already uses elsewhere for picking "the" wired connection (not a new gap introduced here), and is accepted for now since the panel treats wired as a single hero connection rather than a multi-NIC manager.
- **`wired_profile()` (in `omarchy-network-wired`) makes one `nmcli` call per saved connection profile** (Wi-Fi, VPN, everything) to find the wired one, since nmcli's bulk `connection show` listing only exposes a fixed compact field set that doesn't include `connection.interface-name`. A combined bulk query is possible but only by parsing colon-joined multi-field nmcli output, which would mis-parse a connection name that itself contains a colon. Left as-is deliberately — the cost is imperceptible for the handful of profiles a typical machine has — but happy to optimize if that's a real concern for reviewers.
- **`nm_get()` is duplicated verbatim from `omarchy-network-band`'s identical helper** rather than factored into a shared file. There's no existing shared-helpers convention for `bin/` scripts in this repo, and introducing one would mean touching that unrelated, already-shipped script. Happy to factor it out if reviewers would rather have that.

## Test plan

- [x] `test/shell.d/network-test.sh` — grew from 128 to 138 assertions during review (covering the fixes below), all passing
- [x] `./test/all` — no new failures (4 pre-existing failures unrelated to this change, confirmed present on a clean `upstream/quattro` checkout too)
- [x] Manual verification in the running shell: toggle appears/disappears live on plug/unplug with no flicker; both toggles show independently when Wi-Fi + Ethernet are both live; toggling wired on/off actually connects/disconnects and persists `connection.autoconnect`; keyboard nav (`e`/`E`, arrows) reaches the new switch

— Claude, on behalf of e2jk
