### PR TITLE
Let a free agent report savings where limits would go

### DIFF
--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -269,6 +269,14 @@ Item {
       hasLocalStats: synced ? (stats.hasLocalStats !== false) : (record.hasLocalStats !== false),
       hasPromptStats: synced ? (stats.hasPromptStats !== false) : (record.hasPromptStats !== false),
 
+      // An agent that costs nothing to run has no allowance to meter, so its
+      // collector may report what the traffic would have cost instead. Passed
+      // through untouched; a record without these fields draws as before.
+      savings: record.savings || null,
+      savingsByDay: Array.isArray(record.savingsByDay) ? record.savingsByDay : [],
+      savingsCurrency: String(record.savingsCurrency || "USD"),
+      savingsBaselineName: String(record.savingsBaselineName || ""),
+
       syncEnabled: synced,
       syncDeviceCount: deviceCount,
       syncUpdatedAt: aggregateData && aggregateData.updatedAt ? aggregateData.updatedAt : ""

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -46,6 +46,25 @@ Panel {
     && balance.remaining / balance.funded <= 0.1
   readonly property bool alarming: (!!headline && headline.percent >= 0.9) || balanceAlarming
 
+  // ---------------------------------------------------------------- savings
+  //
+  // A model you host yourself fills no window and sends no invoice, which
+  // leaves the limits and balance sections with nothing to say. Such a
+  // collector reports savings instead: what the same traffic would have cost
+  // rented from a provider, against what it actually did.
+  readonly property var savings: provider ? (provider.savings || null) : null
+  readonly property var savingsByDay: provider ? (provider.savingsByDay || []) : []
+  readonly property string savingsCurrency: provider ? String(provider.savingsCurrency || "USD") : "USD"
+  readonly property string savingsBaseline: provider ? String(provider.savingsBaselineName || "") : ""
+
+  function savedFor(date) {
+    var key = String(date || "")
+    for (var i = 0; i < savingsByDay.length; i++) {
+      if (String(savingsByDay[i].date || "") === key) return Number(savingsByDay[i].saved || 0)
+    }
+    return -1
+  }
+
   function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)) }
   function alpha(c, a) { return Qt.rgba(c.r, c.g, c.b, a) }
 
@@ -611,6 +630,81 @@ Panel {
             }
           }
 
+          // ---------- Savings ----------
+          PanelSeparator {
+            visible: savingsSection.visible
+            foreground: root.foreground
+          }
+
+          Column {
+            id: savingsSection
+            visible: !!root.savings
+            width: parent.width
+            spacing: Style.space(10)
+
+            PanelSectionHeader {
+              width: parent.width
+              text: "SAVINGS"
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+            }
+
+            Repeater {
+              model: root.savings ? [
+                { label: "Today", value: Number(root.savings.today || 0), strong: true },
+                { label: "All time vs " + (root.savingsBaseline || "cloud"),
+                  value: Number(root.savings.savedVsBaseline || 0), strong: false },
+                { label: "All time vs same model in cloud",
+                  value: Number(root.savings.savedVsEquivalent || 0), strong: false },
+                { label: "Actually paid",
+                  value: Number(root.savings.spent || 0), strong: false }
+              ] : []
+
+              Item {
+                required property var modelData
+                width: savingsSection.width
+                implicitHeight: Math.max(savingsLabel.implicitHeight, savingsValue.implicitHeight)
+
+                Text {
+                  id: savingsLabel
+                  textFormat: Text.PlainText
+                  text: modelData.label
+                  color: modelData.strong ? root.foreground : root.dim
+                  font.family: root.fontFamily
+                  font.pixelSize: modelData.strong ? Style.font.body : Style.font.caption
+                  anchors.left: parent.left
+                  anchors.verticalCenter: parent.verticalCenter
+                  elide: Text.ElideRight
+                  width: parent.width - savingsValue.width - Style.space(8)
+                }
+
+                Text {
+                  id: savingsValue
+                  textFormat: Text.PlainText
+                  text: root.formatMoney(modelData.value, root.savingsCurrency)
+                  color: modelData.strong ? root.foreground : root.dim
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.caption
+                  font.bold: modelData.strong
+                  anchors.right: parent.right
+                  anchors.verticalCenter: parent.verticalCenter
+                }
+              }
+            }
+
+            Text {
+              textFormat: Text.PlainText
+              visible: !!root.savings && Number(root.savings.monthlyPace || 0) > 0
+              width: parent.width
+              text: root.savings
+                ? root.formatMoney(root.savings.monthlyPace, root.savingsCurrency) + " / month at this pace"
+                : ""
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+            }
+          }
+
           // ---------- Usage ----------
           PanelSeparator {
             visible: usageSection.visible
@@ -628,7 +722,7 @@ Panel {
 
             PanelSectionHeader {
               width: parent.width
-              text: "TOKENS BY DAY"
+              text: root.savingsByDay.length > 0 ? "TOKENS & SAVINGS BY DAY" : "TOKENS BY DAY"
               foreground: root.foreground
               fontFamily: root.fontFamily
             }
@@ -642,6 +736,7 @@ Panel {
 
                 width: usageSection.width
                 day: modelData
+                saved: root.savedFor(modelData.date)
                 ratio: Number(modelData.messageCount || 0) / usageSection.peak
                 // By date, not by position: the Claude stats-cache fallback can
                 // hand us a window that stops short of today.
@@ -801,6 +896,9 @@ Panel {
     property var day: null
     property real ratio: 0
     property bool today: false
+    // Below zero when the agent reports no savings, which hides the column
+    // rather than filling the row with zeroes.
+    property real saved: -1
 
     implicitHeight: Math.max(dayLabel.implicitHeight, dayValue.implicitHeight) + Style.spacing.sm
 
@@ -820,7 +918,7 @@ Panel {
     Rectangle {
       id: dayTrack
       anchors.left: dayLabel.right
-      anchors.right: dayValue.left
+      anchors.right: daySaved.visible ? daySaved.left : dayValue.left
       anchors.leftMargin: Style.space(8)
       anchors.rightMargin: Style.space(10)
       anchors.verticalCenter: parent.verticalCenter
@@ -840,6 +938,22 @@ Panel {
           NumberAnimation { duration: 160; easing.type: Easing.OutCubic }
         }
       }
+    }
+
+    Text {
+      id: daySaved
+      textFormat: Text.PlainText
+      visible: dayRow.saved >= 0
+      text: visible ? root.formatMoney(dayRow.saved, root.savingsCurrency) : ""
+      color: dayRow.today ? root.foreground : root.dim
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      font.bold: dayRow.today
+      horizontalAlignment: Text.AlignRight
+      anchors.right: dayValue.left
+      anchors.rightMargin: visible ? Style.space(10) : 0
+      anchors.verticalCenter: parent.verticalCenter
+      width: visible ? Style.space(48) : 0
     }
 
     Text {

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -18,8 +18,13 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
 - **Balance** — prepaid agents report a credit ledger instead of limits:
   remaining credit, a fuel-gauge meter that drains toward empty, and
   funded-versus-spent detail.
+- **Savings**: for an agent that costs nothing to run, the section that
+  replaces limits. Saved today, saved all time against a reference price, saved
+  against renting the same models, and what was actually paid, with the monthly
+  pace underneath. Only a record that reports savings draws it.
 - **Tokens by day** — one row per day for the last week: day, bar, tokens, with today
-  bolded at the bottom. Hover today for its prompt and session count.
+  bolded at the bottom. A record with per-day savings puts the amount saved
+  between the bar and the token count. Hover today for its prompt and session count.
 - **Tokens by model** — tokens per model with the bar behind each row scaled
   to the heaviest model,
   the same way the weekly chart scales to its busiest day. Hover for the
@@ -46,7 +51,31 @@ record that lands in the directory regardless of who wrote it.
 
 Adding an agent therefore never touches this plugin: ship a collector that
 prints the record contract (see the `claude` and `codex` collectors in
-`bin/`), and the panel gains a tab. An `assets/<id>.svg` mark is optional —
+`bin/`), and the panel gains a tab.
+
+A locally hosted agent has no allowance to meter and no invoice to read, so
+`limits` and `balance` leave it with nothing to report. Such a collector can
+send `savings` instead, and the panel swaps the limits section for it:
+
+```json
+{
+  "savingsCurrency": "USD",
+  "savingsBaselineName": "the reference the comparison is quoted against",
+  "savings": {
+    "spent": 0.0,
+    "savedVsBaseline": 28.7,
+    "savedVsEquivalent": 1.57,
+    "today": 16.93,
+    "monthlyPace": 174.35
+  },
+  "savingsByDay": [{ "date": "2026-09-03", "saved": 16.93 }]
+}
+```
+
+Every field is optional and every amount is the collector's own estimate; the
+panel formats and lays them out, and says nothing when they are absent. Dates
+in `savingsByDay` are matched against `recentDays`, so a day the collector
+skips simply has no amount beside its bar. An `assets/<id>.svg` mark is optional —
 with an `assets/<id>-light.svg` twin if the mark needs a dark variant for
 light surfaces — and the bar glyph stands in when there is none.
 


### PR DESCRIPTION
The agents panel is built around allowances. Percent of the window used, time
until it resets, credits left. An agent that runs on hardware you already own
has none of that: it fills no window and sends no invoice, so `limits` and
`balance` come back empty and the tab reads as though the agent were idle, even
on a day it did most of the work.

This lets such a collector report what its traffic *would* have cost instead.

- `savings` draws where limits would go: saved today, saved all time against a
  reference price, saved against renting the same models from a provider, and
  what was actually paid, with the monthly pace underneath.
- `savingsByDay` puts the amount saved between the bar and the token count in
  the weekly chart, and retitles it to `TOKENS & SAVINGS BY DAY`.

Every field is optional. A record without them is passed through and drawn
exactly as before, so claude, codex and fireworks are untouched. The record
contract is documented in `shell/plugins/agents/README.md` alongside the rest.

Nothing here computes a price. The panel formats what a collector sends and
says nothing when it sends nothing, which keeps the estimate, and the blame for
it, with the collector that made it.

<img src="https://raw.githubusercontent.com/lkzwieder/omarchy-opencode-savings/main/docs/panel.png" width="380">

The screenshot is an opencode collector reading two local llama.cpp servers,
published separately as a third-party plugin so this PR stays generic:
https://github.com/lkzwieder/omarchy-opencode-savings

`./test/all` is green on the branch, all 226 test files, with
`OMARCHY_PKGS_PATH` and `OMARCHY_ISO_PATH` pointed at sibling checkouts.
