### PR TITLE
Show Claude and Codex input cache hit rates

### DIFF
--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -30,7 +30,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 ### The agents panel
 
-The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
+The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), token usage by day and by model, and the percentage of Claude or Codex input served from cache. Claude Code, Codex, and Fireworks are covered out of the box.
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -38,6 +38,7 @@ Panel {
 
   readonly property var limits: limitWindows(provider)
   readonly property var models: modelRows(provider)
+  readonly property var cacheStats: inputCacheStats(provider)
   readonly property var headline: bindingWindow(provider)
   readonly property var balance: provider ? (provider.balance || null) : null
   // A prepaid account runs low the way a subscription window fills up: the
@@ -229,6 +230,46 @@ Panel {
     return peak
   }
 
+  // Cache efficiency is an input-side ratio. Both collectors normalize their
+  // records so inputTokens excludes cache reads and writes; adding the three
+  // therefore reconstructs all input without counting any category twice.
+  // Output is deliberately excluded because it can never be served by the
+  // prompt cache.
+  function inputCachePercent(input, cacheRead, cacheWrite) {
+    var totalInput = input + cacheRead + cacheWrite
+    return totalInput > 0 ? Math.max(0, Math.min(1, cacheRead / totalInput)) : -1
+  }
+
+  function inputCacheStats(p) {
+    if (!p || (p.providerId !== "claude" && p.providerId !== "codex")) return null
+    var usageByModel = p.modelUsage || {}
+    var input = 0
+    var cacheRead = 0
+    var cacheWrite = 0
+    for (var id in usageByModel) {
+      var bucket = usageByModel[id] || {}
+      input += Math.max(0, Number(bucket.inputTokens || 0))
+      cacheRead += Math.max(0, Number(bucket.cacheReadInputTokens || 0))
+      cacheWrite += Math.max(0, Number(bucket.cacheCreationInputTokens || 0))
+    }
+    var totalInput = input + cacheRead + cacheWrite
+    if (!(totalInput > 0)) return null
+    return {
+      percent: inputCachePercent(input, cacheRead, cacheWrite),
+      input: input,
+      cacheRead: cacheRead,
+      cacheWrite: cacheWrite,
+      totalInput: totalInput
+    }
+  }
+
+  function cacheDetailText(stats) {
+    if (!stats) return ""
+    return usage.formatTokenCount(stats.cacheRead) + " reused · "
+      + usage.formatTokenCount(stats.cacheWrite) + " written · "
+      + usage.formatTokenCount(stats.input) + " uncached"
+  }
+
   function modelRows(p) {
     var usageByModel = p ? (p.modelUsage || {}) : {}
     var rows = []
@@ -244,7 +285,8 @@ Panel {
         input: input,
         output: output,
         cacheRead: cacheRead,
-        cacheWrite: cacheWrite
+        cacheWrite: cacheWrite,
+        cachePercent: inputCachePercent(input, cacheRead, cacheWrite)
       })
     }
     rows.sort(function(a, b) { return b.total - a.total })
@@ -253,10 +295,13 @@ Panel {
 
   function modelTooltip(row) {
     if (!row) return ""
-    return "In " + usage.formatTokenCount(row.input)
+    var text = "In " + usage.formatTokenCount(row.input)
       + " · out " + usage.formatTokenCount(row.output)
       + " · cache read " + usage.formatTokenCount(row.cacheRead)
       + " · cache write " + usage.formatTokenCount(row.cacheWrite)
+    if (row.cachePercent >= 0)
+      text += " · " + Math.round(row.cachePercent * 100) + "% of input cached"
+    return text
   }
 
   // Only speaks up when the numbers cover more than this machine.
@@ -608,6 +653,68 @@ Panel {
                 width: limitsSection.width
                 window: modelData
               }
+            }
+          }
+
+          // ---------- Input cache ----------
+          PanelSeparator {
+            visible: cacheSection.visible
+            foreground: root.foreground
+          }
+
+          Column {
+            id: cacheSection
+            visible: !!root.cacheStats
+            width: parent.width
+            spacing: Style.space(10)
+
+            PanelSectionHeader {
+              width: parent.width
+              text: "INPUT CACHE"
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+            }
+
+            Item {
+              width: parent.width
+              implicitHeight: Math.max(cacheLabel.implicitHeight, cacheValue.implicitHeight)
+
+              Text {
+                id: cacheLabel
+                text: "Hit rate"
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+              }
+
+              Text {
+                id: cacheValue
+                textFormat: Text.PlainText
+                text: root.cacheStats ? Math.round(root.cacheStats.percent * 100) + "%" : ""
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                font.bold: true
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+              }
+            }
+
+            Meter {
+              width: parent.width
+              value: root.cacheStats ? root.cacheStats.percent : -1
+            }
+
+            Text {
+              textFormat: Text.PlainText
+              width: parent.width
+              text: root.cacheDetailText(root.cacheStats)
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              elide: Text.ElideRight
             }
           }
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -15,6 +15,8 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
   It appears only when more than one agent is enabled.
 - **Limits** — the percentage of each allowance used, a matching meter, and
   the time until the session or weekly window resets.
+- **Input cache** — Claude and Codex show the percentage of recorded input
+  served from cache, with reused, newly written, and uncached token counts.
 - **Balance** — prepaid agents report a credit ledger instead of limits:
   remaining credit, a fuel-gauge meter that drains toward empty, and
   funded-versus-spent detail.
@@ -23,7 +25,7 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
 - **Tokens by model** — tokens per model with the bar behind each row scaled
   to the heaviest model,
   the same way the weekly chart scales to its busiest day. Hover for the
-  input / output / cache split.
+  input / output / cache split and that model's cache-hit percentage.
 
 A subscription appears only when it is enabled in settings and has actually
 recorded usage — on this machine or on a synced one. With one such agent

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -14,4 +14,50 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+
+const cacheStart = panelSource.indexOf('function inputCacheStats')
+const cacheEnd = panelSource.indexOf('function cacheDetailText')
+const cachePercentStart = panelSource.indexOf('function inputCachePercent')
+assert(cachePercentStart > 0 && cacheStart > cachePercentStart && cacheEnd > cacheStart, 'agents panel exposes its input-cache helpers')
+eval(panelSource.slice(cachePercentStart, cacheEnd))
+
+assertDeepEqual(
+  inputCacheStats({
+    providerId: 'claude',
+    modelUsage: {
+      opus: { inputTokens: 10, outputTokens: 500, cacheReadInputTokens: 80, cacheCreationInputTokens: 10 },
+      haiku: { inputTokens: 5, outputTokens: 500, cacheReadInputTokens: 95, cacheCreationInputTokens: 0 }
+    }
+  }),
+  { percent: 0.875, input: 15, cacheRead: 175, cacheWrite: 10, totalInput: 200 },
+  'agents panel calculates Claude cache hits from input tokens without counting output'
+)
+
+assertDeepEqual(
+  inputCacheStats({
+    providerId: 'codex',
+    modelUsage: {
+      'gpt-5': { inputTokens: 20, outputTokens: 40, cacheReadInputTokens: 80, cacheCreationInputTokens: 0 }
+    }
+  }),
+  { percent: 0.8, input: 20, cacheRead: 80, cacheWrite: 0, totalInput: 100 },
+  'agents panel calculates Codex cache hits from its normalized token split'
+)
+
+assertEqual(inputCacheStats({ providerId: 'claude', modelUsage: {} }), null, 'agents panel hides cache metrics without input data')
+assertEqual(inputCacheStats({
+  providerId: 'fireworks',
+  modelUsage: { kimi: { inputTokens: 20, cacheReadInputTokens: 80 } }
+}), null, 'agents panel limits the cache metric to Claude and Codex')
+
+const modelStart = panelSource.indexOf('function modelRows')
+const modelEnd = panelSource.indexOf('// Only speaks up')
+assert(modelStart > 0 && modelEnd > modelStart, 'agents panel exposes its model helpers')
+const usage = { friendlyModelName: value => value, formatTokenCount: value => String(value) }
+eval(panelSource.slice(modelStart, modelEnd))
+const model = modelRows({ modelUsage: {
+  'gpt-test': { inputTokens: 20, outputTokens: 40, cacheReadInputTokens: 80, cacheCreationInputTokens: 0 }
+} })[0]
+assertEqual(model.cachePercent, 0.8, 'agents panel gives each model its cache-hit percentage')
+assert(/80% of input cached/.test(modelTooltip(model)), 'agents model tooltip shows its cache-hit percentage')
 JS


### PR DESCRIPTION
## What changed

- calculate cache hit rate from normalized input, cache-read, and cache-write token totals
- show the aggregate percentage, meter, and underlying token counts in the agents panel
- add the per-model cache percentage to model tooltips
- document the new metric in the plugin README and AI manual

## Why

The Claude and Codex collectors already preserve mutually exclusive cache token counts, but the panel only exposed the raw split on hover. This makes cache effectiveness visible at a glance without changing the collector contract.

## Verification

- PASS: bash test/shell.d/agents-panel-test.sh
- PASS: live panel screenshot inspected at 1920x1080; the new section has no clipping or overlap
- PARTIAL: ./test/shell ran all 226 test files; the changed agents-panel test passed. Five unrelated baseline/environment failures remained: bar-icon-geometry-test.sh, config-test.sh and unowned-system-paths-test.sh due missing omarchy-pkgs checkout, launch-about-test.sh, and snapper-test.sh.