### PR TITLE
Remove dead Qt.clearComponentCache guard from plugin reload

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -777,7 +777,10 @@ ShellRoot {
       shell.pluginReloadPending = true
       return
     }
-    if (typeof Qt.clearComponentCache === "function") Qt.clearComponentCache()
+    // Qt.clearComponentCache has never been a QML API; the guard was always
+    // false. The engine's component/directory-resolve caches are not cleared
+    // on reload, so a plugin that adds new files while the shell is running
+    // may need a shell restart (#9772).
     shell.pluginRegistry.rescan()
   }
 

--- a/test/shell.d/plugin-reload-cache-test.sh
+++ b/test/shell.d/plugin-reload-cache-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+sq="$ROOT/shell/shell.qml"
+[[ -f $sq ]] || fail "shell.qml is present"
+
+# finishPluginReload must not call the dead Qt.clearComponentCache (#9772).
+if grep -F 'typeof Qt.clearComponentCache' "$sq" >/dev/null; then
+  fail "shell.qml must not reference the non-existent Qt.clearComponentCache QML API"
+fi
+
+grep -F 'Qt.clearComponentCache has never been a QML API' "$sq" >/dev/null ||
+  fail "shell.qml documents that the QML engine cache is not cleared on reload"
+grep -F '#9772' "$sq" >/dev/null ||
+  fail "shell.qml references the issue"
+grep -F 'pluginRegistry.rescan()' "$sq" >/dev/null ||
+  fail "shell.qml still calls rescan after reload"
+
+# finishPluginReload still exists and guards correctly.
+grep -F 'function finishPluginReload()' "$sq" >/dev/null ||
+  fail "finishPluginReload function is still present"
+grep -F '!shell.pluginReloading' "$sq" >/dev/null ||
+  fail "finishPluginReload guards on pluginReloading"
+pass "finishPluginReload removes dead clearComponentCache call"


### PR DESCRIPTION
## Summary

`finishPluginReload()` guarded a call to `Qt.clearComponentCache()` behind `typeof Qt.clearComponentCache === "function"`. That API is C++ only (`QQmlEngine::clearComponentCache()`) and has never been exported to QML, so the call never ran.

The engine caches component types, script imports, and directory listings. When a plugin adds new files while the shell is running, those stale caches can cause `File name case mismatch` errors for files that exist at the correct path.

## Fix

Remove the dead guard and document that the QML engine caches are not cleared on reload. A plugin that adds new files after the shell starts may require a restart.

Fixes #9772

## Test plan

- [x] Confirmed `typeof Qt.clearComponentCache` guard present on quattro
- [x] `bash test/shell.d/plugin-reload-cache-test.sh`