### PR TITLE
Dedupe sound menu output and input entries

### DIFF
--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -69,6 +69,48 @@ function nodeLabel(node) {
   return friendlyDeviceLabel(node.description || p["node.description"] || node.name || "Unknown")
 }
 
+// PipeWire can expose one physical device as several nodes (ALSA vs Pulse
+// names, profile variants, or a default handle distinct from the catalog
+// entry). Collapse those before the menu renders so output/input rows stay
+// unique by node.name and by the friendly label the row would show.
+function dedupeAudioNodes(list) {
+  var out = []
+  var seenName = {}
+  var seenLabel = {}
+  var values = Array.isArray(list) ? list : []
+
+  for (var i = 0; i < values.length; i++) {
+    var n = values[i]
+    if (!n) continue
+
+    var name = String(n.name || "")
+    if (name !== "" && seenName[name]) continue
+
+    var label = String(nodeLabel(n) || "").trim().toLowerCase()
+    if (label !== "" && seenLabel[label]) continue
+
+    if (name !== "") seenName[name] = true
+    if (label !== "") seenLabel[label] = true
+    out.push(n)
+  }
+
+  return out
+}
+
+// Sink monitors are capture nodes that mirror an output; they are not
+// selectable inputs and must not appear beside the real microphone entries.
+function isMonitorSource(node) {
+  if (!node) return false
+  var name = String(node.name || "")
+  if (/\.monitor$/i.test(name)) return true
+
+  var p = nodeProps(node)
+  var mediaClass = String(node.type || p["media.class"] || "")
+  if (mediaClass.indexOf("Monitor") !== -1) return true
+  var description = String(node.description || p["node.description"] || "")
+  return /\bmonitor\b/i.test(description)
+}
+
 function isHeadphones(node) {
   if (!node) return false
   var p = nodeProps(node)
@@ -243,6 +285,8 @@ if (typeof module !== "undefined") {
     friendlyDeviceLabel: friendlyDeviceLabel,
     nodeProps: nodeProps,
     nodeLabel: nodeLabel,
+    dedupeAudioNodes: dedupeAudioNodes,
+    isMonitorSource: isMonitorSource,
     isHeadphones: isHeadphones,
     sinkGlyph: sinkGlyph,
     sourceGlyph: sourceGlyph,

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -36,6 +36,8 @@ Panel {
       if (n && !n.isSink && !n.isStream && isAudioSource(n)) {
         var name = n.name || ""
         if (name === "quickshell") continue
+        // Sink monitors mirror outputs; they are not real input devices.
+        if (isMonitorSource(n)) continue
         list.push(n)
       }
     }
@@ -77,17 +79,21 @@ Panel {
   property var cachedAudioSources: []
 
   readonly property var rawAudioSinks: {
+    // Prefers the default sink (unshifted first) when PipeWire also lists it
+    // under another object identity or label-equivalent node.
     var list = []
+    if (sink) list.push(sink)
     for (var i = 0; i < candidateSinks.length; i++)
       if (sinkAvailable(candidateSinks[i])) list.push(candidateSinks[i])
-    if (sink && list.indexOf(sink) < 0) list.unshift(sink)
-    return list
+    return dedupeAudioNodes(list)
   }
 
   readonly property var rawAudioSources: {
-    var list = candidateSources.slice()
-    if (source && list.indexOf(source) < 0) list.unshift(source)
-    return list
+    var list = []
+    if (source) list.push(source)
+    for (var i = 0; i < candidateSources.length; i++)
+      list.push(candidateSources[i])
+    return dedupeAudioNodes(list)
   }
 
   readonly property var audioSinks: rawAudioSinks.length > 0 ? rawAudioSinks : cachedAudioSinks
@@ -501,6 +507,14 @@ Panel {
 
   function nodeLabel(node) {
     return Model.nodeLabel(node)
+  }
+
+  function dedupeAudioNodes(list) {
+    return Model.dedupeAudioNodes(list)
+  }
+
+  function isMonitorSource(node) {
+    return Model.isMonitorSource(node)
   }
 
   function nodeProps(node) {

--- a/test/shell.d/audio-dedup-test.sh
+++ b/test/shell.d/audio-dedup-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Static contract: Panel.qml must collapse duplicate PipeWire nodes before
+# feeding the sound menu Repeaters (issue #9887).
+panel="$ROOT/shell/plugins/panels/audio/Panel.qml"
+model="$ROOT/shell/plugins/panels/audio/Model.js"
+
+[[ -f $panel ]] || fail "audio Panel.qml exists"
+[[ -f $model ]] || fail "audio Model.js exists"
+
+grep -q 'dedupeAudioNodes' "$panel" || fail "Panel.qml calls dedupeAudioNodes"
+grep -q 'function dedupeAudioNodes' "$model" || fail "Model.js defines dedupeAudioNodes"
+grep -q 'rawAudioSinks' "$panel" || fail "Panel.qml still builds rawAudioSinks"
+grep -q 'rawAudioSources' "$panel" || fail "Panel.qml still builds rawAudioSources"
+grep -q 'isMonitorSource' "$panel" || fail "Panel.qml filters monitor sources"
+grep -q 'function isMonitorSource' "$model" || fail "Model.js defines isMonitorSource"
+
+# rawAudioSinks/Sources must run through dedupe rather than identity indexOf.
+awk '
+  /readonly property var rawAudioSinks:/ { in_sinks = 1 }
+  in_sinks && /return dedupeAudioNodes\(list\)/ { sinks_deduped = 1 }
+  in_sinks && /^  readonly property var / && !/rawAudioSinks:/ { in_sinks = 0 }
+  /readonly property var rawAudioSources:/ { in_sources = 1 }
+  in_sources && /return dedupeAudioNodes\(list\)/ { sources_deduped = 1 }
+  in_sources && /^  readonly property var / && !/rawAudioSources:/ { in_sources = 0 }
+  END {
+    if (!sinks_deduped) { print "rawAudioSinks missing dedupeAudioNodes return" > "/dev/stderr"; exit 1 }
+    if (!sources_deduped) { print "rawAudioSources missing dedupeAudioNodes return" > "/dev/stderr"; exit 1 }
+  }
+' "$panel" || fail "rawAudio lists return dedupeAudioNodes(list)"
+pass "Panel.qml dedupes rawAudioSinks and rawAudioSources"
+
+run_node_test <<'JS'
+const audio = requireFromRoot('shell/plugins/panels/audio/Model.js')
+
+function node(partial) {
+  return Object.assign({ ready: true, properties: {} }, partial)
+}
+
+// Same PipeWire name twice (default handle + catalog entry).
+const sameName = audio.dedupeAudioNodes([
+  node({ name: 'alsa_output.pci-speakers', description: 'Built-in Audio Speakers Output' }),
+  node({ name: 'alsa_output.pci-speakers', description: 'Built-in Audio Speakers Output', id: 99 })
+])
+assertEqual(sameName.length, 1, 'dedupe collapses identical node.name')
+assertEqual(sameName[0].name, 'alsa_output.pci-speakers', 'dedupe keeps first node.name match')
+
+// Distinct names, identical friendly label (ALSA vs pulse path to same hardware).
+const sameLabel = audio.dedupeAudioNodes([
+  node({
+    name: 'alsa_output.pci-0000_00_1f.3.analog-stereo',
+    properties: { 'node.nick': 'Speakers' }
+  }),
+  node({
+    name: 'alsa_output.pci-0000_00_1f.3.HiFi__hw_sofhdadsp_0__sink',
+    properties: { 'node.nick': 'Built-in Audio Speakers Output' }
+  })
+])
+assertEqual(sameLabel.length, 1, 'dedupe collapses matching friendlyDeviceLabel')
+assertEqual(audio.nodeLabel(sameLabel[0]), 'Speakers', 'dedupe keeps first friendly label')
+
+// Truly distinct devices stay listed.
+const distinct = audio.dedupeAudioNodes([
+  node({ name: 'alsa_output.pci-speakers', properties: { 'node.nick': 'Speakers' } }),
+  node({ name: 'bluez_output.airpods', properties: { 'device.product.name': 'AirPods Headphones' } }),
+  node({ name: 'alsa_output.pci-hdmi', properties: { 'node.nick': 'HDMI' } })
+])
+assertEqual(distinct.length, 3, 'dedupe keeps distinct sinks')
+
+// Default-first ordering: preferred node wins when a later candidate matches.
+const preferred = node({ name: 'preferred_sink', properties: { 'node.nick': 'Speakers' }, id: 1 })
+const duplicate = node({ name: 'other_path_sink', properties: { 'node.nick': 'Speakers' }, id: 2 })
+const ordered = audio.dedupeAudioNodes([preferred, duplicate])
+assertEqual(ordered.length, 1, 'dedupe prefers earlier (default) entry')
+assertEqual(ordered[0].id, 1, 'dedupe keeps default sink object')
+
+// Sources: same microphone under two node paths.
+const mics = audio.dedupeAudioNodes([
+  node({ name: 'alsa_input.pci-analog', properties: { 'node.nick': 'Built-in Audio Microphones Input' } }),
+  node({ name: 'alsa_input.pci-hifi', description: 'Built-in Audio Microphones Input' })
+])
+assertEqual(mics.length, 1, 'dedupe collapses duplicate input labels')
+assertEqual(audio.nodeLabel(mics[0]), 'Microphone', 'dedupe keeps friendly mic label')
+
+assert(audio.isMonitorSource(node({ name: 'alsa_output.pci-speakers.monitor' })), 'monitor suffix detected')
+assert(audio.isMonitorSource(node({ name: 'virtual', type: 'Stream/Input/Audio/Monitor' })), 'monitor media class detected')
+assert(!audio.isMonitorSource(node({ name: 'alsa_input.pci-mic', description: 'Microphone' })), 'real mic is not a monitor')
+
+// Empty / sparse inputs are safe.
+assertDeepEqual(audio.dedupeAudioNodes([]), [], 'dedupe handles empty list')
+assertDeepEqual(audio.dedupeAudioNodes([null, undefined]), [], 'dedupe skips nullish entries')
+assertEqual(audio.dedupeAudioNodes([node({ name: 'only' })]).length, 1, 'dedupe keeps singleton')
+JS


### PR DESCRIPTION
## Summary
- Collapse PipeWire sink/source nodes that share a `node.name` or the same friendly device label before the sound menu Repeaters render, so one physical device no longer appears twice.
- Prefer the current default sink/source when a later catalog entry matches, and omit sink-monitor capture nodes from the input candidate list.
- Add `test/shell.d/audio-dedup-test.sh` covering Model dedupe behavior and the Panel contract that `rawAudioSinks` / `rawAudioSources` return through `dedupeAudioNodes`.

Fixes #9887

## Test plan
- [x] `bash test/shell.d/audio-dedup-test.sh`
- [x] `bash test/shell.d/audio-test.sh`
- [ ] Open the sound menu and confirm output/input rows list each device once
- [ ] Switch default output/input and confirm the selected row stays unique and correct