### PR TITLE
Keep the power-profile keyboard cursor off pointer hover

### DIFF
--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -493,12 +493,10 @@ Panel {
                 active: root.activeProfile === modelData
                 hasCursor: root.cursorActive && root.profileIndex === index
                 onClicked: root.setProfile(modelData)
-                onHovered: function(h) {
-                  if (h) {
-                    root.cursorActive = true
-                    root.profileIndex = index
-                  }
-                }
+                // Pointer hover already paints via Button.containsMouse and
+                // clears on leave. Copying it into cursorActive made the
+                // highlight stick, because the overlay does not emit hover
+                // leave while the panel is still open.
               }
             }
           }

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -48,4 +48,5 @@ assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
+assert(!/onHovered:/.test(panelSource), 'power does not copy pointer hover into the keyboard cursor')
 JS


### PR DESCRIPTION
## What

Hovering a power profile that is not selected paints it as the keyboard cursor, and that highlight stays after the pointer leaves.

Pointer hover already paints via `Button.containsMouse` and clears on leave. The extra `onHovered` handler copied that into `cursorActive`, which does not get a leave event while the panel overlay is still open.

Keyboard interaction is unchanged: first arrow claims the cursor, arrows move it, Enter applies.

## Test plan

- [x] `bash test/shell.d/power-test.sh`
- Open the power panel (Super+Ctrl+P), hover a non-selected profile, move off it — only the active profile should stay filled
- Arrow keys still highlight and Enter still applies

Split from #10063; this is not a battery-status change.