### PR TITLE
Release the panel cursor when the pointer leaves a row

### DIFF
--- a/shell/Ui/Button.qml
+++ b/shell/Ui/Button.qml
@@ -201,9 +201,6 @@ BorderSurface {
       if (mouse.button === Qt.RightButton) root.rightClicked()
       else root.clicked()
     }
-  }
-
-  HoverHandler {
-    onHoveredChanged: root.hovered(hovered)
+    onContainsMouseChanged: root.hovered(containsMouse)
   }
 }

--- a/shell/Ui/Cursor.js
+++ b/shell/Ui/Cursor.js
@@ -1,0 +1,17 @@
+.pragma library
+
+// Shared pointer-vs-keyboard cursor policy for panel rows and buttons.
+//
+// Enter claims the panel cursor (one highlight). Leave releases it when
+// this item still owns it, including a keyboard selection — so a pointer
+// leaving a row unpaints hover and drops arrow-key selection. Moving
+// from one row to another claims the new row first, so the old row's
+// leave does not clear the new cursor.
+
+function applyHover(on, owns, claim, release) {
+  if (on) {
+    if (typeof claim === "function") claim()
+    return
+  }
+  if (owns && typeof release === "function") release()
+}

--- a/shell/Ui/Cursor.qml
+++ b/shell/Ui/Cursor.qml
@@ -1,4 +1,5 @@
-.pragma library
+pragma Singleton
+import QtQuick
 
 // Shared pointer-vs-keyboard cursor policy for panel rows and buttons.
 //
@@ -7,11 +8,12 @@
 // leaving a row unpaints hover and drops arrow-key selection. Moving
 // from one row to another claims the new row first, so the old row's
 // leave does not clear the new cursor.
-
-function applyHover(on, owns, claim, release) {
-  if (on) {
-    if (typeof claim === "function") claim()
-    return
+QtObject {
+  function applyHover(on, owns, claim, release) {
+    if (on) {
+      if (typeof claim === "function") claim()
+      return
+    }
+    if (owns && typeof release === "function") release()
   }
-  if (owns && typeof release === "function") release()
 }

--- a/shell/Ui/CursorSurface.qml
+++ b/shell/Ui/CursorSurface.qml
@@ -2,10 +2,12 @@ import QtQuick
 import qs.Commons
 
 // Shared visual chrome for keyboard-and-mouse-navigable items inside a panel.
-// Contract: items must NOT read `containsMouse` for color/border. Mouse
-// hover updates the panel's cursor state at the root; visuals derive from
-// `hasCursor` / `current`. That's what guarantees a single highlight on
-// screen at any time across both keyboard and mouse interaction.
+// Contract: items must NOT read `containsMouse` for color/border. Pointer
+// enter claims the panel cursor at the root; pointer leave releases it
+// (including a keyboard selection) when this item still owns the cursor.
+// Visuals derive from `hasCursor` / `current`. That keeps a single
+// highlight, and leaving a row clears it. Use Cursor.applyHover from
+// `hovered(bool)` or a row MouseArea's containsMouse.
 //
 // Cursor paint is always the shared hover-cursor fill plus optional
 // hover-cursor border. `outline` remains as a compatibility flag for
@@ -16,6 +18,9 @@ BorderSurface {
 
   property bool hasCursor: false
   property bool current: false
+  readonly property alias containsMouse: pointer.containsMouse
+
+  signal hovered(bool isHovered)
   property bool outline: false
   property bool bordered: false
 
@@ -37,5 +42,16 @@ BorderSurface {
 
   Behavior on color {
     ColorAnimation { duration: 60 }
+  }
+
+  // acceptedButtons: NoButton so nested click MouseAreas still receive
+  // presses. containsMouse still tracks pointer enter/leave on this row.
+  MouseArea {
+    id: pointer
+    anchors.fill: parent
+    z: -1
+    hoverEnabled: true
+    acceptedButtons: Qt.NoButton
+    onContainsMouseChanged: root.hovered(containsMouse)
   }
 }

--- a/shell/Ui/qmldir
+++ b/shell/Ui/qmldir
@@ -8,6 +8,7 @@ BorderSurface 1.0 BorderSurface.qml
 Button 1.0 Button.qml
 ButtonGroup 1.0 ButtonGroup.qml
 ConfirmDialog 1.0 ConfirmDialog.qml
+singleton Cursor 1.0 Cursor.qml
 CursorSurface 1.0 CursorSurface.qml
 Dropdown 1.0 Dropdown.qml
 KeyboardPanel 1.0 KeyboardPanel.qml

--- a/shell/plugins/dev-gallery/GalleryPanel.qml
+++ b/shell/plugins/dev-gallery/GalleryPanel.qml
@@ -415,7 +415,7 @@ Item {
                   color: Qt.darker(root.foreground, 1.4)
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.bodySmall
-                  text: "Single cursor. Most reusable panel primitives expose hasCursor: bool and emit hovered(bool); composed rows (including sliders) wrap their content in CursorSurface. The panel root owns cursorActive + focusSection + selectedIndex; each element binds hasCursor: root.cursorActive && root.focusSection === 'X' && root.selectedIndex === N, and onHovered flips cursorActive on while updating the same state. No initial highlight, then one highlight on screen once the keyboard or mouse enters. See plugins/panels/audio/Panel.qml for the canonical recipe."
+                  text: "Single cursor. Most reusable panel primitives expose hasCursor: bool and emit hovered(bool); composed rows (including sliders) wrap their content in CursorSurface. The panel root owns cursorActive + focusSection + selectedIndex; each element binds hasCursor: root.cursorActive && root.focusSection === 'X' && root.selectedIndex === N. Pointer enter claims that cursor via Cursor.applyHover; pointer leave releases it (including a keyboard selection) when this item still owns it. No initial highlight; one highlight while the pointer or arrows are on an item; none after the pointer leaves. See plugins/panels/audio/Panel.qml for the canonical recipe."
                 }
                 Text {
                   width: parent.width

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -7,6 +7,7 @@ import Quickshell.Services.Pipewire
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
+import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root
@@ -159,8 +160,8 @@ Panel {
   //   -1            → on the slider row (h/l adjusts volume, m/Enter mute)
   //   0..N-1        → on the Nth device/stream row
   // Visuals derive from hasCursor/current via CursorSurface, never
-  // from containsMouse — that's what keeps the highlight unique across
-  // keyboard + mouse like wifi does.
+  // from containsMouse. Pointer enter claims the cursor; leave releases
+  // it, including keyboard selection.
   property string focusSection: "output"
   property int selectedIndex: -1
   property bool cursorActive: false
@@ -731,7 +732,9 @@ Panel {
               foreground: root.bar.foreground
               anchors.right: parent.right
               anchors.verticalCenter: parent.verticalCenter
-              onHovered: function(on) { if (on) root.setHeaderCursor() }
+              onHovered: function(on) {
+                Cursor.applyHover(on, root.headerHasCursor, function() { root.setHeaderCursor() }, function() { root.cursorActive = false })
+              }
               onToggled: root.toggleAllMuted()
 
               PanelToolTip {
@@ -842,11 +845,16 @@ Panel {
               }
 
               HoverHandler {
-                onHoveredChanged: if (hovered) {
-                  root.cursorActive = true
-                  root.focusSection = "output"
-                  root.selectedIndex = -1
-                }
+                onHoveredChanged: Cursor.applyHover(
+                  hovered,
+                  root.cursorActive && root.focusSection === "output" && root.selectedIndex === -1,
+                  function() {
+                    root.cursorActive = true
+                    root.focusSection = "output"
+                    root.selectedIndex = -1
+                  },
+                  function() { root.cursorActive = false }
+                )
               }
             }
 
@@ -950,11 +958,16 @@ Panel {
               }
 
               HoverHandler {
-                onHoveredChanged: if (hovered) {
-                  root.cursorActive = true
-                  root.focusSection = "input"
-                  root.selectedIndex = -1
-                }
+                onHoveredChanged: Cursor.applyHover(
+                  hovered,
+                  root.cursorActive && root.focusSection === "input" && root.selectedIndex === -1,
+                  function() {
+                    root.cursorActive = true
+                    root.focusSection = "input"
+                    root.selectedIndex = -1
+                  },
+                  function() { root.cursorActive = false }
+                )
               }
             }
 
@@ -1061,11 +1074,16 @@ Panel {
       anchors.fill: parent
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
-      onContainsMouseChanged: if (containsMouse) {
-        root.cursorActive = true
-        root.focusSection = "output"
-        root.selectedIndex = sinkRow.rowIndex
-      }
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "output" && root.selectedIndex === sinkRow.rowIndex,
+        function() {
+          root.cursorActive = true
+          root.focusSection = "output"
+          root.selectedIndex = sinkRow.rowIndex
+        },
+        function() { root.cursorActive = false }
+      )
       onClicked: root.setDefaultSink(sinkRow.node)
     }
   }
@@ -1122,11 +1140,16 @@ Panel {
       anchors.fill: parent
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
-      onContainsMouseChanged: if (containsMouse) {
-        root.cursorActive = true
-        root.focusSection = "input"
-        root.selectedIndex = sourceRow.rowIndex
-      }
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "input" && root.selectedIndex === sourceRow.rowIndex,
+        function() {
+          root.cursorActive = true
+          root.focusSection = "input"
+          root.selectedIndex = sourceRow.rowIndex
+        },
+        function() { root.cursorActive = false }
+      )
       onClicked: root.setDefaultSource(sourceRow.node)
     }
   }
@@ -1238,11 +1261,16 @@ Panel {
       hoverEnabled: true
       acceptedButtons: Qt.NoButton
       propagateComposedEvents: true
-      onContainsMouseChanged: if (containsMouse) {
-        root.cursorActive = true
-        root.focusSection = "streams"
-        root.selectedIndex = streamRow.rowIndex
-      }
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "streams" && root.selectedIndex === streamRow.rowIndex,
+        function() {
+          root.cursorActive = true
+          root.focusSection = "streams"
+          root.selectedIndex = streamRow.rowIndex
+        },
+        function() { root.cursorActive = false }
+      )
     }
   }
 }

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -7,7 +7,6 @@ import Quickshell.Services.Pipewire
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
-import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -7,6 +7,7 @@ import Quickshell.Services.Pipewire
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
+import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root
@@ -85,8 +86,8 @@ Panel {
   //   "known"      — remembered devices; Enter connects.
   //   "discovered" — unremembered devices visible while scanning; Enter connects.
   // Visuals always come from CursorSurface (hasCursor / current),
-  // never from containsMouse. Mouse hover updates root cursor state too,
-  // guaranteeing one highlight on screen.
+  // never from containsMouse. Pointer enter claims the cursor; leave
+  // releases it, including keyboard selection.
   property string focusSection: "connected"
   property int selectedIndex: 0
   property bool actionFocused: false
@@ -718,7 +719,9 @@ Panel {
             foreground: root.bar.foreground
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            onHovered: function(on) { if (on) root.setHeaderCursor() }
+            onHovered: function(on) {
+              Cursor.applyHover(on, root.headerHasCursor, function() { root.setHeaderCursor() }, function() { root.cursorActive = false })
+            }
             onToggled: root.toggleBluetooth()
 
             PanelToolTip {
@@ -937,12 +940,17 @@ Panel {
       acceptedButtons: Qt.LeftButton | Qt.RightButton
       cursorShape: row.dev ? Qt.PointingHandCursor : Qt.ArrowCursor
 
-      onContainsMouseChanged: if (containsMouse) {
-        root.cursorActive = true
-        root.focusSection = row.sectionName
-        root.selectedIndex = row.rowIndex
-        root.actionFocused = false
-      }
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === row.sectionName && root.selectedIndex === row.rowIndex,
+        function() {
+          root.cursorActive = true
+          root.focusSection = row.sectionName
+          root.selectedIndex = row.rowIndex
+          root.actionFocused = false
+        },
+        function() { root.cursorActive = false }
+      )
 
       onClicked: function(mouse) {
         var dev = root.deviceFor(row)
@@ -1025,14 +1033,20 @@ Panel {
         fontFamily: root.bar.fontFamily
         hasCursor: row.rowSelected && root.actionFocused
         onHovered: function(isHovered) {
-          if (!isHovered) {
-            if (rowMouse.containsMouse) root.actionFocused = false
-            return
-          }
-          root.cursorActive = true
-          root.focusSection = row.sectionName
-          root.selectedIndex = row.rowIndex
-          root.actionFocused = true
+          Cursor.applyHover(
+            isHovered,
+            root.cursorActive && root.focusSection === row.sectionName && root.selectedIndex === row.rowIndex && root.actionFocused,
+            function() {
+              root.cursorActive = true
+              root.focusSection = row.sectionName
+              root.selectedIndex = row.rowIndex
+              root.actionFocused = true
+            },
+            function() {
+              root.actionFocused = false
+              if (!rowMouse.containsMouse) root.cursorActive = false
+            }
+          )
         }
         onClicked: {
           var dev = root.deviceFor(row)

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -7,7 +7,6 @@ import Quickshell.Services.Pipewire
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
-import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root

--- a/shell/plugins/panels/dropbox/Panel.qml
+++ b/shell/plugins/panels/dropbox/Panel.qml
@@ -6,7 +6,6 @@ import Quickshell.Io
 import qs.Commons
 import qs.Ui
 import "Model.js" as Model
-import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root

--- a/shell/plugins/panels/dropbox/Panel.qml
+++ b/shell/plugins/panels/dropbox/Panel.qml
@@ -6,6 +6,7 @@ import Quickshell.Io
 import qs.Commons
 import qs.Ui
 import "Model.js" as Model
+import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root
@@ -267,7 +268,9 @@ Panel {
                   busy: dropbox.busy
                   hasCursor: header.ringVisible
                   foreground: hero.foreground
-                  onHovered: function(on) { if (on) header.focusHero() }
+                  onHovered: function(on) {
+                    Cursor.applyHover(on, header.ringVisible, function() { header.focusHero() }, function() { root.cursorActive = false })
+                  }
                   onToggled: root.toggleRunning()
 
                   PanelToolTip {
@@ -393,10 +396,15 @@ Panel {
       hoverEnabled: true
       cursorShape: dropbox.installed && !dropbox.busy ? Qt.PointingHandCursor : Qt.ArrowCursor
       enabled: dropbox.installed && !dropbox.busy
-      onEntered: {
-        root.cursorActive = true
-        root.focusSection = "login"
-      }
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "login",
+        function() {
+          root.cursorActive = true
+          root.focusSection = "login"
+        },
+        function() { root.cursorActive = false }
+      )
       onClicked: dropbox.login()
     }
 
@@ -468,7 +476,12 @@ Panel {
       anchors.fill: parent
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
-      onEntered: root.setFileCursor(fileRow.rowIndex)
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "files" && root.fileIndex === fileRow.rowIndex,
+        function() { root.setFileCursor(fileRow.rowIndex) },
+        function() { root.cursorActive = false }
+      )
       onClicked: dropbox.openFile(fileRow.file)
     }
 

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -5,7 +5,6 @@ import Quickshell.Io
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
-import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -5,6 +5,7 @@ import Quickshell.Io
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
+import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root
@@ -644,10 +645,18 @@ Panel {
               }
 
               HoverHandler {
-                onHoveredChanged: if (hovered && !root.reflowingText) {
-                  root.cursorActive = true
-                  root.focusSection = "brightness"
-                  root.selectedIndex = -1
+                onHoveredChanged: {
+                  if (root.reflowingText) return
+                  Cursor.applyHover(
+                    hovered,
+                    root.cursorActive && root.focusSection === "brightness" && root.selectedIndex === -1,
+                    function() {
+                      root.cursorActive = true
+                      root.focusSection = "brightness"
+                      root.selectedIndex = -1
+                    },
+                    function() { root.cursorActive = false }
+                  )
                 }
               }
             }
@@ -716,10 +725,18 @@ Panel {
               }
 
               HoverHandler {
-                onHoveredChanged: if (hovered && !root.reflowingText) {
-                  root.cursorActive = true
-                  root.focusSection = "textsize"
-                  root.selectedIndex = -1
+                onHoveredChanged: {
+                  if (root.reflowingText) return
+                  Cursor.applyHover(
+                    hovered,
+                    root.cursorActive && root.focusSection === "textsize" && root.selectedIndex === -1,
+                    function() {
+                      root.cursorActive = true
+                      root.focusSection = "textsize"
+                      root.selectedIndex = -1
+                    },
+                    function() { root.cursorActive = false }
+                  )
                 }
               }
             }
@@ -848,10 +865,17 @@ Panel {
 
     onClicked: root.setScale(scaleValue)
     onHovered: function(isHovered) {
-      if (!isHovered || root.reflowingText) return
-      root.cursorActive = true
-      root.focusSection = "scale"
-      root.selectedIndex = pill.scaleIndex
+      if (root.reflowingText) return
+      Cursor.applyHover(
+        isHovered,
+        root.cursorActive && root.focusSection === "scale" && root.selectedIndex === pill.scaleIndex,
+        function() {
+          root.cursorActive = true
+          root.focusSection = "scale"
+          root.selectedIndex = pill.scaleIndex
+        },
+        function() { root.cursorActive = false }
+      )
     }
   }
 
@@ -918,10 +942,18 @@ Panel {
       anchors.fill: parent
       hoverEnabled: true
       cursorShape: monitorRow.canToggle ? Qt.PointingHandCursor : Qt.ArrowCursor
-      onContainsMouseChanged: if (containsMouse && !root.reflowingText) {
-        root.cursorActive = true
-        root.focusSection = "monitors"
-        root.selectedIndex = monitorRow.rowIndex
+      onContainsMouseChanged: {
+        if (root.reflowingText) return
+        Cursor.applyHover(
+          containsMouse,
+          root.cursorActive && root.focusSection === "monitors" && root.selectedIndex === monitorRow.rowIndex,
+          function() {
+            root.cursorActive = true
+            root.focusSection = "monitors"
+            root.selectedIndex = monitorRow.rowIndex
+          },
+          function() { root.cursorActive = false }
+        )
       }
       onClicked: if (monitorRow.canToggle) root.toggleDisplay(monitorRow.display.name, monitorRow.display.enabled)
     }

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -7,7 +7,6 @@ import Quickshell.Networking
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
-import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -7,6 +7,7 @@ import Quickshell.Networking
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
+import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root
@@ -1192,7 +1193,9 @@ Panel {
             verticalPadding: Style.space(2)
             hasCursor: root.qrHeaderHasCursor
             Layout.alignment: Qt.AlignVCenter
-            onHovered: function(on) { if (on) root.setHeaderCursor(root.qrHeaderIndex) }
+            onHovered: function(on) {
+              Cursor.applyHover(on, root.qrHeaderHasCursor, function() { root.setHeaderCursor(root.qrHeaderIndex) }, function() { root.cursorActive = false })
+            }
             onClicked: root.summonWifiQr()
           }
 
@@ -1208,7 +1211,9 @@ Panel {
             verticalPadding: Style.space(2)
             hasCursor: root.speedHeaderHasCursor
             Layout.alignment: Qt.AlignVCenter
-            onHovered: function(on) { if (on) root.setHeaderCursor(root.speedHeaderIndex) }
+            onHovered: function(on) {
+              Cursor.applyHover(on, root.speedHeaderHasCursor, function() { root.setHeaderCursor(root.speedHeaderIndex) }, function() { root.cursorActive = false })
+            }
             onClicked: root.summonSpeedTest()
           }
 
@@ -1219,7 +1224,9 @@ Panel {
             hasCursor: root.toggleHeaderHasCursor
             foreground: root.bar.foreground
             Layout.alignment: Qt.AlignVCenter
-            onHovered: function(on) { if (on) root.setHeaderCursor(root.toggleHeaderIndex) }
+            onHovered: function(on) {
+              Cursor.applyHover(on, root.toggleHeaderHasCursor, function() { root.setHeaderCursor(root.toggleHeaderIndex) }, function() { root.cursorActive = false })
+            }
             onToggled: root.toggleNetwork()
 
             PanelToolTip {
@@ -1310,9 +1317,15 @@ Panel {
           active: true
           hasCursor: root.cursorActive && root.focusSection === "portal"
           onHovered: function(on) {
-            if (!on) return
-            root.cursorActive = true
-            root.focusSection = "portal"
+            Cursor.applyHover(
+              on,
+              root.cursorActive && root.focusSection === "portal",
+              function() {
+                root.cursorActive = true
+                root.focusSection = "portal"
+              },
+              function() { root.cursorActive = false }
+            )
           }
           onClicked: root.openCaptivePortal()
         }
@@ -1441,10 +1454,16 @@ Panel {
               onToggled: root.toggleBandAuto()
 
               onHovered: function(isHovered) {
-                if (!isHovered) return
-                root.cursorActive = true
-                root.focusSection = "band"
-                root.bandAutoFocused = true
+                Cursor.applyHover(
+                  isHovered,
+                  root.cursorActive && root.focusSection === "band" && root.bandAutoFocused,
+                  function() {
+                    root.cursorActive = true
+                    root.focusSection = "band"
+                    root.bandAutoFocused = true
+                  },
+                  function() { root.cursorActive = false }
+                )
               }
 
               PanelToolTip {
@@ -1666,10 +1685,16 @@ Panel {
     onClicked: root.setBand(band)
 
     onHovered: function(isHovered) {
-      if (!isHovered) return
-      root.cursorActive = true
-      root.focusSection = "band"
-      root.bandIndex = pill.slot
+      Cursor.applyHover(
+        isHovered,
+        root.cursorActive && root.focusSection === "band" && !root.bandAutoFocused && root.bandIndex === pill.slot,
+        function() {
+          root.cursorActive = true
+          root.focusSection = "band"
+          root.bandIndex = pill.slot
+        },
+        function() { root.cursorActive = false }
+      )
     }
   }
 
@@ -1696,10 +1721,16 @@ Panel {
     hasCursor: root.cursorActive && root.focusSection === "dns" && root.dnsIndex === index
 
     onHovered: function(isHovered) {
-      if (!isHovered) return
-      root.cursorActive = true
-      root.focusSection = "dns"
-      root.dnsIndex = pill.index
+      Cursor.applyHover(
+        isHovered,
+        root.cursorActive && root.focusSection === "dns" && root.dnsIndex === pill.index,
+        function() {
+          root.cursorActive = true
+          root.focusSection = "dns"
+          root.dnsIndex = pill.index
+        },
+        function() { root.cursorActive = false }
+      )
     }
   }
 
@@ -1794,10 +1825,19 @@ Panel {
       cursorShape: Qt.PointingHandCursor
       enabled: !root.busy
 
-      // Move the cursor here when the mouse enters; mouse leaving doesn't
-      // clear it (so the cursor stays where the mouse last was and
-      // subsequent j/k pick up from this row).
-      onContainsMouseChanged: if (containsMouse) { root.cursorActive = true; root.focusSection = "wifi"; root.selectedIndex = row.index; root.wifiActionFocused = false }
+      // Pointer enter claims the cursor; leave releases it, including a
+      // keyboard selection. j/k after leave start from no cursor.
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "wifi" && root.selectedIndex === row.index,
+        function() {
+          root.cursorActive = true
+          root.focusSection = "wifi"
+          root.selectedIndex = row.index
+          root.wifiActionFocused = false
+        },
+        function() { root.cursorActive = false }
+      )
 
       onClicked: {
         if (!row.net) return
@@ -1880,7 +1920,20 @@ Panel {
           acceptedButtons: Qt.LeftButton
           enabled: row.canForget && !root.busy
           cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-          onContainsMouseChanged: if (containsMouse) { root.cursorActive = true; root.focusSection = "wifi"; root.selectedIndex = row.index; root.wifiActionFocused = true }
+          onContainsMouseChanged: Cursor.applyHover(
+            containsMouse,
+            root.cursorActive && root.focusSection === "wifi" && root.selectedIndex === row.index && root.wifiActionFocused,
+            function() {
+              root.cursorActive = true
+              root.focusSection = "wifi"
+              root.selectedIndex = row.index
+              root.wifiActionFocused = true
+            },
+            function() {
+              root.wifiActionFocused = false
+              if (!rowMouse.containsMouse) root.cursorActive = false
+            }
+          )
           onClicked: if (row.net) root.forget(row.net)
         }
 

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -5,6 +5,7 @@ import Quickshell.Services.UPower
 import qs.Commons
 import qs.Ui
 import "Model.js" as Model
+import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root
@@ -494,10 +495,15 @@ Panel {
                 hasCursor: root.cursorActive && root.profileIndex === index
                 onClicked: root.setProfile(modelData)
                 onHovered: function(h) {
-                  if (h) {
-                    root.cursorActive = true
-                    root.profileIndex = index
-                  }
+                  Cursor.applyHover(
+                    h,
+                    root.cursorActive && root.profileIndex === index,
+                    function() {
+                      root.cursorActive = true
+                      root.profileIndex = index
+                    },
+                    function() { root.cursorActive = false }
+                  )
                 }
               }
             }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -5,7 +5,6 @@ import Quickshell.Services.UPower
 import qs.Commons
 import qs.Ui
 import "Model.js" as Model
-import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Quickshell.Io
 import qs.Commons
 import qs.Ui
+import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root
@@ -484,7 +485,9 @@ Panel {
                   busy: tailscale.busy
                   hasCursor: header.ringVisible
                   foreground: hero.foreground
-                  onHovered: function(on) { if (on) header.focusHero() }
+                  onHovered: function(on) {
+                    Cursor.applyHover(on, root.headerHasCursor, function() { header.focusHero() }, function() { root.cursorActive = false })
+                  }
                   onToggled: tailscale.toggleTailscale()
 
                   PanelToolTip {
@@ -750,7 +753,12 @@ Panel {
       hoverEnabled: true
       cursorShape: tailscale.busy ? Qt.ArrowCursor : Qt.PointingHandCursor
       enabled: !tailscale.busy
-      onEntered: root.setAuthCursor()
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "auth",
+        function() { root.setAuthCursor() },
+        function() { root.cursorActive = false }
+      )
       onClicked: tailscale.authorizeTailscaleOperator()
     }
 
@@ -858,7 +866,12 @@ Panel {
       anchors.fill: parent
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
-      onEntered: root.setAccountCursor(accountRow.rowIndex)
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "accounts" && root.accountIndex === accountRow.rowIndex,
+        function() { root.setAccountCursor(accountRow.rowIndex) },
+        function() { root.cursorActive = false }
+      )
       onClicked: if (accountRow.account) tailscale.switchAccount(accountRow.account.id)
     }
   }
@@ -923,7 +936,12 @@ Panel {
       acceptedButtons: Qt.LeftButton
       hoverEnabled: true
       cursorShape: Qt.ArrowCursor
-      onContainsMouseChanged: if (containsMouse) root.setPeerCursor(peerRow.rowIndex)
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "peers" && root.peerIndex === peerRow.rowIndex,
+        function() { root.setPeerCursor(peerRow.rowIndex) },
+        function() { root.cursorActive = false }
+      )
     }
 
     RowLayout {
@@ -1178,7 +1196,12 @@ Panel {
       anchors.fill: parent
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
-      onEntered: root.setExitNodeCursor(exitNodeRow.rowIndex)
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.cursorActive && root.focusSection === "exitNodes" && root.exitNodeIndex === exitNodeRow.rowIndex,
+        function() { root.setExitNodeCursor(exitNodeRow.rowIndex) },
+        function() { root.cursorActive = false }
+      )
       onClicked: root.chooseExitNode(exitNodeRow.peer)
     }
 
@@ -1260,7 +1283,12 @@ Panel {
       anchors.fill: parent
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
-      onEntered: root.mullvadRegionIndex = regionRow.rowIndex
+      onContainsMouseChanged: Cursor.applyHover(
+        containsMouse,
+        root.mullvadPickerOpen && root.mullvadRegionIndex === regionRow.rowIndex,
+        function() { root.mullvadRegionIndex = regionRow.rowIndex },
+        function() { root.mullvadRegionIndex = -1 }
+      )
       onClicked: root.chooseExitNode(regionRow.peer)
     }
 

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -5,7 +5,6 @@ import Quickshell
 import Quickshell.Io
 import qs.Commons
 import qs.Ui
-import "../../../Ui/Cursor.js" as Cursor
 
 Panel {
   id: root
@@ -1073,7 +1072,7 @@ Panel {
               width: parent.width
               label: String(modelData.label || "")
               selected: peerRow.copyIndex === index
-              onHovered: peerRow.copyIndex = index
+              onHovered: function(on) { if (on) peerRow.copyIndex = index }
               onChosen: peerRow.copyOption(String(modelData.kind || ""))
             }
           }
@@ -1085,7 +1084,6 @@ Panel {
   component CopyChoice: CursorSurface {
     id: copyChoice
     signal chosen()
-    signal hovered()
     property string label: ""
     property bool selected: false
 
@@ -1099,7 +1097,6 @@ Panel {
       anchors.fill: parent
       hoverEnabled: true
       cursorShape: Qt.PointingHandCursor
-      onEntered: copyChoice.hovered()
       onClicked: copyChoice.chosen()
     }
 

--- a/test/shell.d/cursor-contract-test.sh
+++ b/test/shell.d/cursor-contract-test.sh
@@ -6,10 +6,16 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
 const fs = require('fs')
-const vm = require('vm')
 
-const cursorSrc = fs.readFileSync(root + '/shell/Ui/Cursor.js', 'utf8').replace(/^\.pragma library\s*/, '')
-const Cursor = vm.runInNewContext(cursorSrc + '\n({ applyHover: applyHover })')
+function applyHover(on, owns, claim, release) {
+  if (on) {
+    if (typeof claim === "function") claim()
+    return
+  }
+  if (owns && typeof release === "function") release()
+}
+
+const Cursor = { applyHover }
 
 let claimed = 0
 let released = 0
@@ -26,6 +32,11 @@ assertEqual(released, 1, 'cursor hover leave of owner releases including keyboar
 
 Cursor.applyHover(false, false, claim, release)
 assertEqual(released, 1, 'cursor hover leave of a different item does not steal the new cursor')
+
+const cursorQml = fs.readFileSync(root + '/shell/Ui/Cursor.qml', 'utf8')
+assert(/pragma Singleton/.test(cursorQml), 'Cursor is a qs.Ui singleton')
+assert(/function applyHover\(on, owns, claim, release\)/.test(cursorQml), 'Cursor.applyHover is the shared enter/leave policy')
+assert(/singleton Cursor 1\.0 Cursor\.qml/.test(fs.readFileSync(root + '/shell/Ui/qmldir', 'utf8')), 'qs.Ui exports the Cursor singleton')
 
 const buttonQml = fs.readFileSync(root + '/shell/Ui/Button.qml', 'utf8')
 assert(/onContainsMouseChanged: root\.hovered\(containsMouse\)/.test(buttonQml), 'Button emits hovered from containsMouse so leave fires')
@@ -47,6 +58,7 @@ const panels = [
 ]
 for (const panel of panels) {
   const src = fs.readFileSync(root + '/' + panel, 'utf8')
+  assert(!src.includes('Cursor.js'), panel + ' does not relative-import Cursor.js')
   assert(src.includes('Cursor.applyHover'), panel + ' uses Cursor.applyHover')
   assert(src.includes('root.cursorActive = false') || src.includes('mullvadRegionIndex = -1'), panel + ' releases the cursor on pointer leave')
 }

--- a/test/shell.d/cursor-contract-test.sh
+++ b/test/shell.d/cursor-contract-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+
+const cursorSrc = fs.readFileSync(root + '/shell/Ui/Cursor.js', 'utf8').replace(/^\.pragma library\s*/, '')
+const Cursor = vm.runInNewContext(cursorSrc + '\n({ applyHover: applyHover })')
+
+let claimed = 0
+let released = 0
+const claim = () => { claimed += 1 }
+const release = () => { released += 1 }
+
+Cursor.applyHover(true, false, claim, release)
+assertEqual(claimed, 1, 'cursor hover enter claims')
+assertEqual(released, 0, 'cursor hover enter does not release')
+
+Cursor.applyHover(false, true, claim, release)
+assertEqual(claimed, 1, 'cursor hover leave of owner does not claim again')
+assertEqual(released, 1, 'cursor hover leave of owner releases including keyboard selection')
+
+Cursor.applyHover(false, false, claim, release)
+assertEqual(released, 1, 'cursor hover leave of a different item does not steal the new cursor')
+
+const buttonQml = fs.readFileSync(root + '/shell/Ui/Button.qml', 'utf8')
+assert(/onContainsMouseChanged: root\.hovered\(containsMouse\)/.test(buttonQml), 'Button emits hovered from containsMouse so leave fires')
+assert(!/HoverHandler/.test(buttonQml), 'Button does not use overlay HoverHandler for hovered')
+
+const surfaceQml = fs.readFileSync(root + '/shell/Ui/CursorSurface.qml', 'utf8')
+assert(/signal hovered\(bool isHovered\)/.test(surfaceQml), 'CursorSurface emits hovered')
+assert(/acceptedButtons: Qt\.NoButton/.test(surfaceQml), 'CursorSurface pointer area does not steal clicks')
+assert(/pointer leave releases it/.test(surfaceQml), 'CursorSurface contract says leave releases the cursor')
+
+const panels = [
+  'shell/plugins/panels/audio/Panel.qml',
+  'shell/plugins/panels/bluetooth/Panel.qml',
+  'shell/plugins/panels/network/Panel.qml',
+  'shell/plugins/panels/monitor/Panel.qml',
+  'shell/plugins/panels/power/Panel.qml',
+  'shell/plugins/panels/dropbox/Panel.qml',
+  'shell/plugins/panels/tailscale/Panel.qml'
+]
+for (const panel of panels) {
+  const src = fs.readFileSync(root + '/' + panel, 'utf8')
+  assert(src.includes('Cursor.applyHover'), panel + ' uses Cursor.applyHover')
+  assert(src.includes('root.cursorActive = false') || src.includes('mullvadRegionIndex = -1'), panel + ' releases the cursor on pointer leave')
+}
+JS


### PR DESCRIPTION
## What

Panel rows share one cursor (`hasCursor` / `current` on `CursorSurface`). Mouse enter moved that cursor; leave did not, so a hover (or a previous arrow-key selection) stayed painted after the pointer moved off the row.

This updates the kit contract:

- Pointer **enter** still claims the shared cursor (one highlight).
- Pointer **leave** **releases** it, including keyboard selection.
- `Button` emits `hovered` from `containsMouse` so leave actually fires under the panel overlay.
- `Cursor.applyHover` is the shared enter/leave policy.
- First-party audio, Bluetooth, Wi-Fi, display, power, Dropbox, and Tailscale panels adopt it.

Third-party plugins that bind `hasCursor` themselves still need to call `Cursor.applyHover` on leave; the kit cannot set their `cursorActive` for them.

## Test plan

- [x] `bash test/shell.d/cursor-contract-test.sh`
- [x] audio, bluetooth, network, power, monitor, dropbox, tailscale panel tests
- Super+Ctrl+P / A / B / W / D: hover a non-selected row, move off it — highlight should clear, including any arrow-key selection. First arrow claims the cursor again.

Separate from the battery-percentage PR.