### PR TITLE
Agents panel: every signed-in Claude account, and an opt-in Columns layout

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -10,6 +10,12 @@ history fallbacks for machines without transcripts, pi/omp and opencode
 sessions that ran on an Anthropic provider, and the authoritative rate
 limits from Anthropic's OAuth usage endpoint. The panel itself only ever
 reads the JSON this prints; it never talks to disk formats or endpoints.
+
+A machine signed in to more than one Claude account keeps each in its own
+config directory (`CLAUDE_CONFIG_DIR=~/.claude-work claude`). Every
+`~/.claude-<name>` directory holding a sign-in is collected as well and
+nested under `accounts` in the record, one record each; the updater writes
+them out as `claude-<name>.json` so the panel gains a tab per account.
 """
 
 from __future__ import annotations
@@ -39,6 +45,62 @@ PROBE_MIN_INTERVAL_SECONDS = 15
 
 def config_dir() -> Path:
   return expand_path(os.environ.get("CLAUDE_CONFIG_DIR") or "~/.claude")
+
+
+# ------------------------------------------------------------------ accounts
+#
+# The CLI keeps one sign-in per config directory, so a second account is a
+# second directory: `~/.claude-work`, selected with CLAUDE_CONFIG_DIR. The
+# suffix names the account in the panel, and the directory's own
+# `.claude.json` says which account it is — the default directory's lives at
+# `~/.claude.json` instead — so two directories signed in to the same account
+# are shown once.
+
+def account_suffix(claude_dir: Path) -> str:
+  name = claude_dir.name
+  return name[len(".claude-"):] if name.startswith(".claude-") else ""
+
+
+def account_record_id(suffix: str) -> str:
+  cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", suffix).strip("-.")
+  return AGENT_ID + "-" + cleaned if cleaned else ""
+
+
+def account_identity(claude_dir: Path, default: bool) -> str:
+  candidates = [claude_dir / ".claude.json"]
+  if default:
+    candidates.append(Path.home() / ".claude.json")
+  for path in candidates:
+    try:
+      account = json.loads(path.read_text(encoding="utf-8")).get("oauthAccount")
+    except Exception:
+      continue
+    if not isinstance(account, dict):
+      continue
+    identity = str(account.get("accountUuid") or account.get("emailAddress") or "").strip()
+    if identity:
+      return identity
+  return ""
+
+
+def extra_account_dirs(default_dir: Path) -> list[tuple[str, Path]]:
+  seen = {account_identity(default_dir, True)}
+  out: list[tuple[str, Path]] = []
+  for candidate in sorted(Path.home().glob(".claude-*")):
+    if not candidate.is_dir() or not (candidate / ".credentials.json").is_file():
+      continue
+    claude_dir = candidate.resolve()
+    if claude_dir == default_dir:
+      continue
+    record_id = account_record_id(account_suffix(candidate))
+    if record_id == "" or any(record_id == existing for existing, _ in out):
+      continue
+    identity = account_identity(claude_dir, False)
+    if identity and identity in seen:
+      continue
+    seen.add(identity)
+    out.append((record_id, claude_dir))
+  return out
 
 
 def expand_path(value: str) -> Path:
@@ -791,13 +853,14 @@ def usable_cached_limits(cached: dict[str, Any]) -> list[dict[str, Any]]:
   return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
 
 
-def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[str, Any]:
+def collect_limits(access_token: str, expires_at_ms: int, force: bool, cache_key: str = "") -> dict[str, Any]:
   result = {"limits": [], "usageStatusText": "", "authHelpText": AUTH_HELP}
 
   # A panel that is opened and shut repeatedly must not turn into a request
   # per flick, so recent probe results are reused for a short window — and
-  # kept as the answer of record when a later probe fails.
-  probe_cache = cache_root() / "claude-limits.json"
+  # kept as the answer of record when a later probe fails. Every account
+  # keeps its own cache: one sign-in's numbers must never answer for another.
+  probe_cache = cache_root() / ("claude-limits" + ("-" + cache_key if cache_key else "") + ".json")
   cached = read_fresh_json(probe_cache, float("inf")) or {}
   fallback = usable_cached_limits(cached)
 
@@ -849,15 +912,7 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
 # -------------------------------------------------------------------- record
 
 
-def main() -> int:
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--force", action="store_true", help="rescan transcripts and re-probe limits, ignoring caches")
-  parser.add_argument("--limits-only", action="store_true", help="reuse any recent transcript scan; only the limits probe must be fresh")
-  parser.add_argument("--cache-seconds", type=float, default=20)
-  args = parser.parse_args()
-
-  claude_dir = config_dir()
-  scan_age = 0 if args.force else (900 if args.limits_only else args.cache_seconds)
+def collect_record(claude_dir: Path, scan_age: float, force: bool, record_id: str, name: str, shared: bool) -> dict[str, Any]:
   stats = cached_scan(claude_dir / "projects", scan_age)
 
   if number(stats.get("totalPrompts")) <= 0:
@@ -871,21 +926,24 @@ def main() -> int:
       if today_prompts or today_sessions:
         stats = dict(stats, todayPrompts=today_prompts, todaySessions=today_sessions)
 
-  pi_usage = scan_pi_usage(scan_age)
-  if pi_usage is not None:
-    stats = merge_stats(stats, pi_usage)
+  # Pi, omp, and opencode keep no per-account split, so their sessions
+  # count once, toward the default account, never toward every account.
+  if shared:
+    pi_usage = scan_pi_usage(scan_age)
+    if pi_usage is not None:
+      stats = merge_stats(stats, pi_usage)
 
-  opencode = scan_opencode_usage(scan_age)
-  if opencode is not None:
-    stats = merge_stats(stats, opencode)
+    opencode = scan_opencode_usage(scan_age)
+    if opencode is not None:
+      stats = merge_stats(stats, opencode)
 
   access_token, expires_at_ms, plan = oauth_login(claude_dir)
-  limits = collect_limits(access_token, expires_at_ms, args.force)
+  limits = collect_limits(access_token, expires_at_ms, force, "" if shared else record_id)
 
   record = {
     "schemaVersion": 1,
-    "id": AGENT_ID,
-    "name": AGENT_NAME,
+    "id": record_id,
+    "name": name,
     "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
     "ready": number(stats.get("totalPrompts")) > 0 or len(limits["limits"]) > 0,
     "hasLocalStats": True,
@@ -897,6 +955,27 @@ def main() -> int:
   if limits.get("retryAdvised"):
     record["retryAdvised"] = True
   record.update(stats)
+  return record
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--force", action="store_true", help="rescan transcripts and re-probe limits, ignoring caches")
+  parser.add_argument("--limits-only", action="store_true", help="reuse any recent transcript scan; only the limits probe must be fresh")
+  parser.add_argument("--cache-seconds", type=float, default=20)
+  args = parser.parse_args()
+
+  claude_dir = config_dir()
+  scan_age = 0 if args.force else (900 if args.limits_only else args.cache_seconds)
+  record = collect_record(claude_dir, scan_age, args.force, AGENT_ID, AGENT_NAME, True)
+
+  accounts = [
+    collect_record(account_dir, scan_age, args.force, record_id, "Claude · " + account_suffix(account_dir), False)
+    for record_id, account_dir in extra_account_dirs(claude_dir)
+  ]
+  if accounts:
+    record["accounts"] = accounts
+
   print(json.dumps(record, separators=(",", ":"), sort_keys=True))
   return 0
 

--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -8,6 +8,11 @@
 # record; this writes them to ~/.local/state/omarchy/agents/usage/ where the
 # agents panel watches them. Adding an agent is adding a collector — the
 # panel picks up any record that appears here.
+#
+# A collector signed in to several accounts nests the others under
+# `accounts`, one full record each with an id under its own namespace
+# (`claude-work`). Those land as their own files, and a namespaced file the
+# collector no longer reports is removed, so a sign-out clears its tab.
 
 USAGE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/usage"
 mkdir -p "$USAGE_DIR"
@@ -39,16 +44,44 @@ wanted() {
   return 1
 }
 
+write_record() {
+  local id="$1" record="$2"
+  local tmp
+  tmp=$(mktemp "$USAGE_DIR/.$id.XXXXXX")
+  printf '%s\n' "$record" >"$tmp"
+  mv "$tmp" "$USAGE_DIR/$id.json"
+}
+
 collect() {
   local collector="$1" agent="$2"
-  local record tmp
+  local record id
+  local -A kept
   if ! record=$("$collector" "${flags[@]}") || [[ -z $record ]] || ! jq -e . >/dev/null 2>&1 <<<"$record"; then
     echo "omarchy-agent-usage-update: $agent collector failed" >&2
     return 1
   fi
-  tmp=$(mktemp "$USAGE_DIR/.$agent.XXXXXX")
-  printf '%s\n' "$record" >"$tmp"
-  mv "$tmp" "$USAGE_DIR/$agent.json"
+
+  while IFS= read -r id; do
+    if [[ $id != "$agent-"?* || $id =~ [^A-Za-z0-9_.-] ]]; then
+      echo "omarchy-agent-usage-update: $agent collector nested a record outside its namespace: $id" >&2
+      continue
+    fi
+    write_record "$id" "$(jq -c --arg id "$id" '.accounts[] | select(.id == $id)' <<<"$record")"
+    kept[$id]=1
+  done < <(jq -r '(.accounts // [])[] | .id // empty' <<<"$record")
+
+  if jq -e 'has("accounts")' >/dev/null <<<"$record"; then
+    record=$(jq -c 'del(.accounts)' <<<"$record")
+  fi
+  write_record "$agent" "$record"
+
+  local stale name
+  for stale in "$USAGE_DIR/$agent-"*.json; do
+    [[ -e $stale ]] || continue
+    name=${stale##*/}
+    name=${name%.json}
+    [[ -n ${kept[$name]} ]] || rm -f "$stale"
+  done
 }
 
 pids=()

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -30,7 +30,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 ### The agents panel
 
-The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
+The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box. Signed in to more than one Claude account? Every `~/.claude-<name>` directory you've logged into with `CLAUDE_CONFIG_DIR` gets a tab of its own, and `omarchy bar set omarchy.agents layout Columns` lays all of them out side by side instead.
 
 Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -32,6 +32,14 @@ Panel {
 
   property bool cursorActive: false
 
+  // "Tabs" shows one subscription at a time behind a switch row; "Columns"
+  // lays every one out side by side, which suits a wide screen and several
+  // accounts. Nothing is picked in Columns, so the switch, `h`/`l`, and the
+  // middle-click cycle all stand down.
+  readonly property bool columns: !!settings && String(settings.layout || "").toLowerCase() === "columns"
+  readonly property real columnWidth: Style.space(340)
+  readonly property real columnGap: Style.space(28)
+
   // Countdowns and "updated" read this instead of Date.now() so the
   // panel keeps telling the truth while it sits open.
   property double nowMs: Date.now()
@@ -44,13 +52,27 @@ Panel {
   // last 10% of the funded credits lights the same alarm.
   readonly property bool balanceAlarming: !!balance && balance.funded > 0
     && balance.remaining / balance.funded <= 0.1
-  readonly property bool alarming: (!!headline && headline.percent >= 0.9) || balanceAlarming
+  // In Columns every subscription is in view, so the bar icon lights up for
+  // whichever is closest to its cap.
+  readonly property bool alarming: {
+    if (!columns) return (!!headline && headline.percent >= 0.9) || balanceAlarming
+    for (var i = 0; i < providers.length; i++)
+      if (providerAlarming(providers[i])) return true
+    return false
+  }
+
+  function providerAlarming(p) {
+    var window = bindingWindow(p)
+    if (window && window.percent >= 0.9) return true
+    var b = p ? (p.balance || null) : null
+    return !!b && b.funded > 0 && b.remaining / b.funded <= 0.1
+  }
 
   function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)) }
   function alpha(c, a) { return Qt.rgba(c.r, c.g, c.b, a) }
 
   function selectProvider(index) {
-    if (providers.length === 0) return
+    if (columns || providers.length === 0) return
     var wrapped = ((index % providers.length) + providers.length) % providers.length
     selectedProviderId = providers[wrapped].providerId
   }
@@ -206,7 +228,7 @@ Panel {
     return dayName(date)
   }
 
-  function dayTooltip(day, today) {
+  function dayTooltip(day, today, p) {
     if (!day) return ""
     var parsed = new Date(String(day.date) + "T00:00:00")
     var label = isNaN(parsed.getTime())
@@ -216,9 +238,9 @@ Panel {
     // Prompt and session counts only exist for today, so they ride along here
     // instead of taking a section of their own. Billing-API agents never
     // count prompts, and "0 prompts" would read as a quiet day, not a gap.
-    if (today && provider && provider.hasPromptStats !== false)
-      text += " · " + Number(provider.todayPrompts || 0) + " prompts · "
-        + Number(provider.todaySessions || 0) + " sessions"
+    if (today && p && p.hasPromptStats !== false)
+      text += " · " + Number(p.todayPrompts || 0) + " prompts · "
+        + Number(p.todaySessions || 0) + " sessions"
     return text
   }
 
@@ -260,10 +282,10 @@ Panel {
   }
 
   // Only speaks up when the numbers cover more than this machine.
-  function footerText() {
+  function footerText(p) {
     if (usage.syncStatusText !== "") return usage.syncStatusText
-    if (provider && provider.syncEnabled && provider.syncDeviceCount > 0)
-      return "Merged from " + provider.syncDeviceCount + " device" + (provider.syncDeviceCount === 1 ? "" : "s")
+    if (p && p.syncEnabled && p.syncDeviceCount > 0)
+      return "Merged from " + p.syncDeviceCount + " device" + (p.syncDeviceCount === 1 ? "" : "s")
     return ""
   }
 
@@ -284,13 +306,19 @@ Panel {
 
   // Marks resolve by convention, so a new agent's data file needs nothing
   // from this panel: assets/<id>.svg if it ships one, the module's bar glyph
-  // if it doesn't.
+  // if it doesn't. A record filed under a collector's namespace
+  // (`claude-work`) borrows the collector's mark when it has none of its own.
   function iconCandidatesForProvider(p, surfaceColor) {
     if (!p) return []
+    var ids = [String(p.providerId)]
+    var dash = ids[0].indexOf("-")
+    if (dash > 0) ids.push(ids[0].slice(0, dash))
+    var light = colorLuminance(surfaceColor || Color.background) >= 0.5
     var candidates = []
-    if (colorLuminance(surfaceColor || Color.background) >= 0.5)
-      candidates.push(Qt.resolvedUrl("assets/" + p.providerId + "-light.svg"))
-    candidates.push(Qt.resolvedUrl("assets/" + p.providerId + ".svg"))
+    for (var i = 0; i < ids.length; i++) {
+      if (light) candidates.push(Qt.resolvedUrl("assets/" + ids[i] + "-light.svg"))
+      candidates.push(Qt.resolvedUrl("assets/" + ids[i] + ".svg"))
+    }
     return candidates
   }
 
@@ -355,7 +383,9 @@ Panel {
     bar: root.bar
     open: root.opened
     focusTarget: keyCatcher
-    contentWidth: panel.fittedContentWidth(Style.space(380))
+    contentWidth: panel.fittedContentWidth(root.columns
+      ? root.columnWidth * Math.max(1, root.providers.length) + root.columnGap * Math.max(0, root.providers.length - 1)
+      : Style.space(380))
     // Taller than the control panels on purpose: this one is a dashboard, and
     // the whole point is reading limits and history without scrolling.
     contentHeight: panel.fittedContentHeight(column.implicitHeight, Style.space(640))
@@ -365,7 +395,7 @@ Panel {
       anchors.fill: parent
 
       onMoveRequested: function(dx, dy) {
-        if (dx !== 0) {
+        if (dx !== 0 && !root.columns) {
           root.cursorActive = true
           root.selectProvider(root.providerIndex + dx)
         }
@@ -397,7 +427,7 @@ Panel {
           // ---------- Hero: provider mark · name · plan ----------
           PanelHero {
             id: hero
-            visible: !!root.provider
+            visible: !root.columns && !!root.provider
             width: parent.width
             title: root.provider ? root.provider.providerName : ""
             meta: root.heroMeta(root.provider)
@@ -461,7 +491,7 @@ Panel {
           // ---------- Provider switch ----------
           Row {
             id: providerSwitch
-            visible: root.providers.length > 1
+            visible: !root.columns && root.providers.length > 1
             width: parent.width
             spacing: Style.spacing.md
 
@@ -494,208 +524,326 @@ Panel {
             }
           }
 
-          // ---------- Status ----------
-          BorderSurface {
-            visible: !!root.provider && String(root.provider.usageStatusText || "") !== ""
+          // ---------- Tabs: the selected subscription ----------
+          ProviderColumn {
+            visible: !root.columns && !!root.provider
             width: parent.width
-            implicitHeight: statusText.implicitHeight + Style.spacing.xl * 2
-            color: root.alpha(root.urgent, 0.10)
-            borderSpec: Border.flat(root.alpha(root.urgent, 0.35), 1)
-            radius: Style.cornerRadius
-
-            Text {
-              id: statusText
-              textFormat: Text.PlainText
-              anchors.left: parent.left
-              anchors.right: parent.right
-              anchors.verticalCenter: parent.verticalCenter
-              anchors.leftMargin: Style.space(12)
-              anchors.rightMargin: Style.space(12)
-              text: root.provider ? String(root.provider.authHelpText || "") : ""
-              color: root.dim
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
-              wrapMode: Text.WordWrap
-            }
+            provider: root.columns ? null : root.provider
           }
 
-          // ---------- Balance / limits ----------
-          PanelSeparator {
-            visible: balanceSection.visible || limitsSection.visible
-            foreground: root.foreground
-          }
-
-          Column {
-            id: balanceSection
-            visible: !!root.balance
+          // ---------- Columns: every subscription, side by side ----------
+          Row {
+            id: providerRow
+            visible: root.columns
             width: parent.width
-            spacing: Style.space(10)
+            spacing: root.columnGap
 
-            // The meter shows what is left, not what is used: a prepaid
-            // account drains toward empty rather than filling toward a cap.
-            readonly property real ratio: root.balance && root.balance.funded > 0
-              ? root.clamp(root.balance.remaining / root.balance.funded, 0, 1)
-              : -1
-
-            PanelSectionHeader {
-              width: parent.width
-              text: "BALANCE"
-              foreground: root.foreground
-              fontFamily: root.fontFamily
-            }
-
-            Item {
-              width: parent.width
-              implicitHeight: Math.max(balanceLabel.implicitHeight, balanceValue.implicitHeight)
-
-              Text {
-                id: balanceLabel
-                text: "Prepaid credits"
-                color: root.foreground
-                font.family: root.fontFamily
-                font.pixelSize: Style.font.body
-                anchors.left: parent.left
-                anchors.verticalCenter: parent.verticalCenter
-              }
-
-              Text {
-                id: balanceValue
-                textFormat: Text.PlainText
-                text: root.balance ? root.formatMoney(root.balance.remaining, root.balance.currency) : ""
-                color: root.balanceAlarming ? root.urgent : root.foreground
-                font.family: root.fontFamily
-                font.pixelSize: Style.font.caption
-                anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
-              }
-            }
-
-            Meter {
-              visible: balanceSection.ratio >= 0
-              width: parent.width
-              value: balanceSection.ratio
-              alarming: root.balanceAlarming
-            }
-
-            Text {
-              textFormat: Text.PlainText
-              visible: text !== ""
-              width: parent.width
-              text: root.balanceDetailText(root.balance)
-              color: root.dim
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
-            }
-          }
-
-          Column {
-            id: limitsSection
-            visible: root.limits.length > 0
-            width: parent.width
-            spacing: Style.space(10)
-
-            PanelSectionHeader {
-              text: "LIMITS"
-              foreground: root.foreground
-              fontFamily: root.fontFamily
-            }
+            readonly property real cellWidth: root.providers.length > 0
+              ? (width - spacing * (root.providers.length - 1)) / root.providers.length
+              : width
 
             Repeater {
-              model: root.limits
+              model: root.columns ? root.providers : []
 
-              LimitRow {
-                required property var modelData
-                width: limitsSection.width
-                window: modelData
-              }
-            }
-          }
-
-          // ---------- Usage ----------
-          PanelSeparator {
-            visible: usageSection.visible
-            foreground: root.foreground
-          }
-
-          Column {
-            id: usageSection
-            visible: !!root.provider && root.provider.recentDays && root.provider.recentDays.length > 0
-            width: parent.width
-            spacing: Style.spacing.md
-
-            readonly property var days: root.provider ? (root.provider.recentDays || []) : []
-            readonly property real peak: Math.max(1, root.weekPeak(root.provider))
-
-            PanelSectionHeader {
-              width: parent.width
-              text: "TOKENS BY DAY"
-              foreground: root.foreground
-              fontFamily: root.fontFamily
-            }
-
-            Repeater {
-              model: usageSection.days
-
-              DayRow {
+              ProviderColumn {
                 required property var modelData
                 required property int index
 
-                width: usageSection.width
-                day: modelData
-                ratio: Number(modelData.messageCount || 0) / usageSection.peak
-                // By date, not by position: the Claude stats-cache fallback can
-                // hand us a window that stops short of today.
-                today: String(modelData.date || "") === root.todayDate()
+                width: providerRow.cellWidth
+                provider: modelData
+                showHero: true
+                first: index === 0
               }
             }
           }
+        }
+      }
+    }
+  }
 
-          // ---------- Models ----------
-          PanelSeparator {
-            visible: modelSection.visible
-            foreground: root.foreground
+  // One subscription's dashboard: the sections under the hero, and the hero
+  // itself when the column stands alone. Tabs shows one of these for the
+  // selected subscription; Columns shows one per subscription in a row.
+  component ProviderColumn: Item {
+    id: providerColumn
+    property var provider: null
+    property bool showHero: false
+    property bool first: true
+
+    readonly property var limits: root.limitWindows(provider)
+    readonly property var models: root.modelRows(provider)
+    readonly property var balance: provider ? (provider.balance || null) : null
+    readonly property bool balanceAlarming: !!balance && balance.funded > 0
+      && balance.remaining / balance.funded <= 0.1
+
+    implicitHeight: body.implicitHeight
+
+    Rectangle {
+      visible: !providerColumn.first
+      x: -Math.round(root.columnGap / 2)
+      width: 1
+      height: providerRow.implicitHeight
+      color: root.alpha(root.foreground, 0.15)
+    }
+
+    Column {
+      id: body
+      anchors.left: parent.left
+      anchors.right: parent.right
+      spacing: Style.space(12)
+
+      // ---------- Hero: provider mark · name · plan ----------
+      PanelHero {
+        visible: providerColumn.showHero && !!providerColumn.provider
+        width: parent.width
+        title: providerColumn.provider ? providerColumn.provider.providerName : ""
+        meta: root.heroMeta(providerColumn.provider)
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+
+        iconComponent: Component {
+          Item {
+            id: heroMark
+            property var candidates: root.iconCandidatesForProvider(providerColumn.provider, root.surface)
+            // Provider objects are rebuilt on every refresh, which churns the
+            // array's identity without changing its content. Restart the fallback
+            // walk only when the URLs change: re-pointing source at a URL whose
+            // load already failed emits no statusChanged, so an identity-only
+            // reset would strand the walker on a missing -light twin.
+            property string candidatesKey: candidates.join("\n")
+            property int candidateIndex: 0
+            onCandidatesKeyChanged: candidateIndex = 0
+
+            width: Style.font.display
+            height: Style.font.display
+
+            Image {
+              id: heroMarkImage
+              anchors.fill: parent
+              source: heroMark.candidateIndex < heroMark.candidates.length ? heroMark.candidates[heroMark.candidateIndex] : ""
+              sourceSize.width: Style.font.display * 2
+              sourceSize.height: Style.font.display * 2
+              fillMode: Image.PreserveAspectFit
+              // Advancing source from inside its own status change trips the
+              // binding-loop detector; defer the step one tick.
+              onStatusChanged: if (status === Image.Error && heroMark.candidateIndex < heroMark.candidates.length)
+                Qt.callLater(function() { heroMark.candidateIndex++ })
+            }
+
+            Text {
+              textFormat: Text.PlainText
+              anchors.centerIn: parent
+              visible: heroMarkImage.status !== Image.Ready
+              text: button.text
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.display
+            }
           }
+        }
+      }
 
-          Column {
-            id: modelSection
-            visible: root.models.length > 0
-            width: parent.width
-            spacing: Style.spacing.md
+      // ---------- Status ----------
+      BorderSurface {
+        visible: !!providerColumn.provider && String(providerColumn.provider.usageStatusText || "") !== ""
+        width: parent.width
+        implicitHeight: statusText.implicitHeight + Style.spacing.xl * 2
+        color: root.alpha(root.urgent, 0.10)
+        borderSpec: Border.flat(root.alpha(root.urgent, 0.35), 1)
+        radius: Style.cornerRadius
 
-            PanelSectionHeader {
-              width: parent.width
-              text: "TOKENS BY MODEL"
-              foreground: root.foreground
-              fontFamily: root.fontFamily
-            }
+        Text {
+          id: statusText
+          textFormat: Text.PlainText
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+          anchors.leftMargin: Style.space(12)
+          anchors.rightMargin: Style.space(12)
+          text: providerColumn.provider ? String(providerColumn.provider.authHelpText || "") : ""
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.WordWrap
+        }
+      }
 
-            Repeater {
-              model: root.models
+      // ---------- Balance / limits ----------
+      PanelSeparator {
+        visible: balanceSection.visible || limitsSection.visible
+        foreground: root.foreground
+      }
 
-              ModelRow {
-                required property var modelData
-                width: modelSection.width
-                row: modelData
-                // Scaled to the heaviest model, so the top row is always full —
-                // the same scale-to-peak the weekly chart uses for its busiest day.
-                share: modelData.total / Math.max(1, root.models[0].total)
-              }
-            }
+      Column {
+        id: balanceSection
+        visible: !!providerColumn.balance
+        width: parent.width
+        spacing: Style.space(10)
+
+        // The meter shows what is left, not what is used: a prepaid
+        // account drains toward empty rather than filling toward a cap.
+        readonly property real ratio: providerColumn.balance && providerColumn.balance.funded > 0
+          ? root.clamp(providerColumn.balance.remaining / providerColumn.balance.funded, 0, 1)
+          : -1
+
+        PanelSectionHeader {
+          width: parent.width
+          text: "BALANCE"
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+        }
+
+        Item {
+          width: parent.width
+          implicitHeight: Math.max(balanceLabel.implicitHeight, balanceValue.implicitHeight)
+
+          Text {
+            id: balanceLabel
+            text: "Prepaid credits"
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.body
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
           }
 
           Text {
+            id: balanceValue
             textFormat: Text.PlainText
-            visible: text !== ""
-            width: parent.width
-            topPadding: Style.space(2)
-            text: root.footerText()
-            color: root.dim
+            text: providerColumn.balance ? root.formatMoney(providerColumn.balance.remaining, providerColumn.balance.currency) : ""
+            color: providerColumn.balanceAlarming ? root.urgent : root.foreground
             font.family: root.fontFamily
             font.pixelSize: Style.font.caption
-            horizontalAlignment: Text.AlignHCenter
-            elide: Text.ElideRight
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
           }
         }
+
+        Meter {
+          visible: balanceSection.ratio >= 0
+          width: parent.width
+          value: balanceSection.ratio
+          alarming: providerColumn.balanceAlarming
+        }
+
+        Text {
+          textFormat: Text.PlainText
+          visible: text !== ""
+          width: parent.width
+          text: root.balanceDetailText(providerColumn.balance)
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+        }
+      }
+
+      Column {
+        id: limitsSection
+        visible: providerColumn.limits.length > 0
+        width: parent.width
+        spacing: Style.space(10)
+
+        PanelSectionHeader {
+          text: "LIMITS"
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+        }
+
+        Repeater {
+          model: providerColumn.limits
+
+          LimitRow {
+            required property var modelData
+            width: limitsSection.width
+            window: modelData
+          }
+        }
+      }
+
+      // ---------- Usage ----------
+      PanelSeparator {
+        visible: usageSection.visible
+        foreground: root.foreground
+      }
+
+      Column {
+        id: usageSection
+        visible: !!providerColumn.provider && providerColumn.provider.recentDays && providerColumn.provider.recentDays.length > 0
+        width: parent.width
+        spacing: Style.spacing.md
+
+        readonly property var days: providerColumn.provider ? (providerColumn.provider.recentDays || []) : []
+        readonly property real peak: Math.max(1, root.weekPeak(providerColumn.provider))
+
+        PanelSectionHeader {
+          width: parent.width
+          text: "TOKENS BY DAY"
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+        }
+
+        Repeater {
+          model: usageSection.days
+
+          DayRow {
+            required property var modelData
+            required property int index
+
+            width: usageSection.width
+            day: modelData
+            provider: providerColumn.provider
+            ratio: Number(modelData.messageCount || 0) / usageSection.peak
+            // By date, not by position: the Claude stats-cache fallback can
+            // hand us a window that stops short of today.
+            today: String(modelData.date || "") === root.todayDate()
+          }
+        }
+      }
+
+      // ---------- Models ----------
+      PanelSeparator {
+        visible: modelSection.visible
+        foreground: root.foreground
+      }
+
+      Column {
+        id: modelSection
+        visible: providerColumn.models.length > 0
+        width: parent.width
+        spacing: Style.spacing.md
+
+        PanelSectionHeader {
+          width: parent.width
+          text: "TOKENS BY MODEL"
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+        }
+
+        Repeater {
+          model: providerColumn.models
+
+          ModelRow {
+            required property var modelData
+            width: modelSection.width
+            row: modelData
+            // Scaled to the heaviest model, so the top row is always full —
+            // the same scale-to-peak the weekly chart uses for its busiest day.
+            share: modelData.total / Math.max(1, providerColumn.models[0].total)
+          }
+        }
+      }
+
+      Text {
+        textFormat: Text.PlainText
+        visible: text !== ""
+        width: parent.width
+        topPadding: Style.space(2)
+        text: root.footerText(providerColumn.provider)
+        color: root.dim
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        horizontalAlignment: Text.AlignHCenter
+        elide: Text.ElideRight
       }
     }
   }
@@ -801,6 +949,7 @@ Panel {
     property var day: null
     property real ratio: 0
     property bool today: false
+    property var provider: null
 
     implicitHeight: Math.max(dayLabel.implicitHeight, dayValue.implicitHeight) + Style.spacing.sm
 
@@ -865,7 +1014,7 @@ Panel {
 
     PanelToolTip {
       visible: dayHover.containsMouse
-      text: root.dayTooltip(dayRow.day, dayRow.today)
+      text: root.dayTooltip(dayRow.day, dayRow.today, dayRow.provider)
       fontFamily: root.fontFamily
     }
   }

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -12,7 +12,9 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
 - **Hero** — the mark, the tool, and the plan it runs on ("Max 20x", "Pro").
   Auth and endpoint problems replace the plan line and repeat in a card.
 - **Subscription switch** — one chip per enabled agent (`h`/`l` or click).
-  It appears only when more than one agent is enabled.
+  It appears only when more than one agent is enabled. With `layout` set to
+  `"Columns"` there is no switch: every subscription is laid out side by
+  side, one column each, which suits a wide screen and several accounts.
 - **Limits** — the percentage of each allowance used, a matching meter, and
   the time until the session or weekly window resets.
 - **Balance** — prepaid agents report a credit ledger instead of limits:
@@ -50,9 +52,16 @@ prints the record contract (see the `claude` and `codex` collectors in
 with an `assets/<id>-light.svg` twin if the mark needs a dark variant for
 light surfaces — and the bar glyph stands in when there is none.
 
+A collector signed in to more than one account nests the others under
+`accounts` in its record, one full record each, with ids under its own
+namespace (`claude-work`). The updater files each as its own `<id>.json`,
+drops a namespaced file the collector stops reporting, and the panel treats
+them as agents in their own right — `providers` enablement by id included.
+A namespaced record without a mark of its own borrows its collector's.
+
 | Collector | Limits | Local stats |
 |---|---|---|
-| `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
+| `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly), per account | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback; every `~/.claude-<name>` with a sign-in becomes its own tab |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
 
@@ -63,6 +72,16 @@ falls back to local stats only. A non-default Claude directory is honored via
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there.
+
+### Several Claude accounts
+
+A second Claude account is a second config directory: sign in with
+`CLAUDE_CONFIG_DIR=~/.claude-work claude`, and every `~/.claude-<name>`
+directory holding a sign-in becomes its own tab, `Claude · <name>`, with its
+own limits, plan, and transcripts. Two directories signed in to the same
+account are shown once, and pi, omp, and opencode sessions count toward the
+default account only, since they keep no account of their own. Hide one
+with `providers`, by its record id: `"claude-work": { "enabled": false }`.
 
 ### Fireworks balance
 
@@ -94,9 +113,10 @@ only adds the meter and the spent-of-funded line under the real figure.
 
 ## Interactions
 
-- Bar icon: left = panel, right = launch agent, middle = next subscription.
-- Panel: `h`/`l` switch subscription, `j`/`k` scroll, `r` or Enter refresh,
-  Tab moves to the neighboring bar panel, Esc closes.
+- Bar icon: left = panel, right = launch agent, middle = next subscription
+  (Tabs layout).
+- Panel: `h`/`l` switch subscription (Tabs layout), `j`/`k` scroll, `r` or
+  Enter refresh, Tab moves to the neighboring bar panel, Esc closes.
 - IPC: `omarchy-shell omarchy.agents <open|close|toggle|refresh|next>`.
 
 ## Settings
@@ -108,6 +128,7 @@ top-level keys can be set with
 | Key | Default | What it does |
 |---|---|---|
 | `refreshIntervalSec` | `900` | How often the usage records regenerate |
+| `layout` | `"Tabs"` | `"Columns"` lays every subscription out side by side instead of behind a switch row |
 | `syncMode` | `"Off"` | `"On"` writes this machine's snapshot and merges the others |
 | `syncDir` | `""` | A folder synced by Syncthing, Dropbox, rsync, … |
 | `syncFileName` | `<hostname>.json` | This machine's snapshot file |
@@ -117,6 +138,7 @@ Numbers need `--json`, or they land in `shell.json` as strings:
 
 ```bash
 omarchy bar set omarchy.agents refreshIntervalSec 300 --json
+omarchy bar set omarchy.agents layout Columns
 omarchy bar set omarchy.agents syncDir '~/Sync/agent-usage'
 ```
 

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -24,6 +24,7 @@
         "fireworks": { "enabled": true }
       },
       "refreshIntervalSec": 900,
+      "layout": "Tabs",
       "syncMode": "Off",
       "syncDir": "",
       "syncFileName": "",
@@ -31,6 +32,7 @@
     },
     "schema": [
       { "key": "refreshIntervalSec", "type": "integer", "label": "Refresh interval (seconds)", "min": 30, "max": 3600, "step": 30, "defaultValue": 900 },
+      { "key": "layout", "type": "enum", "label": "Panel layout", "options": ["Tabs", "Columns"], "defaultValue": "Tabs", "description": "Tabs shows one subscription at a time behind a switch row. Columns lays every subscription out side by side." },
       { "key": "syncMode", "type": "enum", "label": "Synced aggregation", "options": ["Off", "On"], "defaultValue": "Off", "description": "When On, write this machine's local usage snapshot and merge snapshots from other machines." },
       { "key": "syncDir", "type": "path", "label": "Sync folder", "defaultValue": "", "description": "A folder synced by Syncthing, Dropbox, rsync, etc." },
       { "key": "syncFileName", "type": "string", "label": "Snapshot file name", "defaultValue": "", "description": "Optional. Defaults to <hostname>.json. Use a different file name on each machine, such as laptop.json or desktop.json." },

--- a/test/shell.d/agent-usage-claude-accounts-test.sh
+++ b/test/shell.d/agent-usage-claude-accounts-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+# A second Claude account lives in its own config directory, and the
+# collector reports every one it finds beside the default. Everything here
+# is planted under a scratch HOME, and the sign-ins are lapsed so no probe
+# ever leaves the machine.
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+timestamp="$(date +%Y-%m-%d)T12:00:00Z"
+
+plant_transcript() {
+  local dir="$1" model="$2" output="$3"
+  mkdir -p "$dir/projects/example"
+  cat >"$dir/projects/example/session.jsonl" <<JSONL
+{"timestamp":"$timestamp","type":"assistant","sessionId":"session-1","uuid":"event-1","message":{"id":"message-1","role":"assistant","model":"$model","usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":$output}}}
+JSONL
+}
+
+plant_login() {
+  local dir="$1" account="$2"
+  mkdir -p "$dir"
+  echo '{"claudeAiOauth":{"accessToken":"token","expiresAt":1000,"subscriptionType":"max","rateLimitTier":"default_claude_max_5x"}}' >"$dir/.credentials.json"
+  echo "{\"oauthAccount\":{\"accountUuid\":\"$account\",\"emailAddress\":\"$account@example.com\"}}" >"$dir/.claude.json"
+}
+
+plant_transcript "$TEST_HOME/.claude" claude-home 100
+plant_login "$TEST_HOME/.claude" personal
+# The default directory's identity file lives beside it, not inside it.
+mv "$TEST_HOME/.claude/.claude.json" "$TEST_HOME/.claude.json"
+
+plant_transcript "$TEST_HOME/.claude-work" claude-work 7
+plant_login "$TEST_HOME/.claude-work" work
+
+# Signed in to the account the default directory already covers.
+plant_transcript "$TEST_HOME/.claude-dupe" claude-dupe 999
+plant_login "$TEST_HOME/.claude-dupe" personal
+
+# A directory with transcripts but no sign-in is a leftover, not an account.
+plant_transcript "$TEST_HOME/.claude-stale" claude-stale 999
+
+# Pi sessions have no account of their own and count toward the default only.
+mkdir -p "$TEST_HOME/.pi/agent/sessions/project"
+cat >"$TEST_HOME/.pi/agent/sessions/project/pi.jsonl" <<JSONL
+{"type":"message","id":"pi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"anthropic","model":"claude-pi","usage":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0,"totalTokens":3}}}
+JSONL
+
+result=$(env -u CLAUDE_CONFIG_DIR HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force)
+
+[[ $(jq -c '[.accounts[].id]' <<<"$result") == '["claude-work"]' ]] ||
+  fail "Claude collector nests one record per additional signed-in account" "$result"
+pass "Claude collector nests one record per additional signed-in account"
+
+[[ $(jq -r '.accounts[0].name + "/" + .accounts[0].tierLabel + "/" + .accounts[0].usageStatusText' <<<"$result") == "Claude · work/Max 5x/Sign-in expired" ]] ||
+  fail "Claude collector names and labels an additional account from its own directory" "$result"
+pass "Claude collector names and labels an additional account from its own directory"
+
+[[ $(jq -c '[.todayTotalTokens, .accounts[0].todayTotalTokens]' <<<"$result") == "[113,17]" ]] ||
+  fail "Claude collector keeps each account's transcripts apart and counts pi sessions once" "$result"
+pass "Claude collector keeps each account's transcripts apart and counts pi sessions once"
+
+[[ $(jq -c '[.modelUsage | keys[]], [.accounts[0].modelUsage | keys[]]' <<<"$result" | tr -d '\n') == '["claude-home","claude-pi"]["claude-work"]' ]] ||
+  fail "Claude collector attributes models to the account that ran them" "$result"
+pass "Claude collector attributes models to the account that ran them"
+
+# With nothing beside the default directory, the record is what it always was.
+mkdir -p "$TEST_HOME/solo"
+mv "$TEST_HOME/.claude" "$TEST_HOME/solo/.claude"
+solo=$(env -u CLAUDE_CONFIG_DIR HOME="$TEST_HOME/solo" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force)
+
+[[ $(jq -r 'has("accounts")' <<<"$solo") == "false" ]] ||
+  fail "Claude collector nests nothing when only the default account is signed in" "$solo"
+pass "Claude collector nests nothing when only the default account is signed in"
+
+# Naming: a directory suffix becomes a record id the updater can file, and
+# one that cannot be filed is skipped rather than written somewhere odd.
+mapfile -t ids < <(python3 - "$ROOT/bin/omarchy-agent-usage-claude" <<'PY'
+import importlib.util, sys
+from importlib.machinery import SourceFileLoader
+loader = SourceFileLoader("collector", sys.argv[1])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+for suffix in ["work", "Acme Corp", "team/2", "...", ""]:
+  print(collector.account_record_id(suffix) or "(none)")
+PY
+)
+[[ "${ids[*]}" == "claude-work claude-Acme-Corp claude-team-2 (none) (none)" ]] ||
+  fail "Claude collector derives a filing-safe record id from the directory suffix" "${ids[*]}"
+pass "Claude collector derives a filing-safe record id from the directory suffix"

--- a/test/shell.d/agent-usage-update-test.sh
+++ b/test/shell.d/agent-usage-update-test.sh
@@ -63,3 +63,34 @@ pass "update succeeds when the requested collectors all pass"
 [[ -e $usage_dir/skipped.json && ! -e $usage_dir/noisy.json ]] ||
   fail "update with agent arguments only runs the named collectors"
 pass "update with agent arguments only runs the named collectors"
+
+# A collector signed in to several accounts nests the others under
+# `accounts`. Each lands as its own file inside the collector's namespace,
+# nothing else does, and a namespaced file it stops reporting goes away.
+cat >"$FAKE_OMARCHY/bin/omarchy-agent-usage-multi" <<'EOF2'
+#!/bin/bash
+echo '{"id":"multi","name":"Multi","accounts":[{"id":"multi-work","name":"Multi · work"},{"id":"other-work","name":"Escapee"},{"id":"multi-bad/../x","name":"Traversal"}]}'
+EOF2
+chmod +x "$FAKE_OMARCHY/bin/omarchy-agent-usage-multi"
+echo '{"id":"multi-old"}' >"$usage_dir/multi-old.json"
+
+HOME="$TEST_HOME" OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" \
+  "$ROOT/bin/omarchy-agent-usage-update" multi 2>/dev/null ||
+  fail "update succeeds for a collector that nests account records"
+pass "update succeeds for a collector that nests account records"
+
+[[ $(jq -r '.name' "$usage_dir/multi-work.json") == "Multi · work" ]] ||
+  fail "update writes each nested account record as its own file"
+pass "update writes each nested account record as its own file"
+
+[[ $(jq -r 'has("accounts")' "$usage_dir/multi.json") == "false" ]] ||
+  fail "update strips the nested records from the collector's own file"
+pass "update strips the nested records from the collector's own file"
+
+[[ ! -e $usage_dir/other-work.json && -z $(find "$usage_dir" -name '*bad*') ]] ||
+  fail "update refuses nested records outside the collector's namespace"
+pass "update refuses nested records outside the collector's namespace"
+
+[[ ! -e $usage_dir/multi-old.json ]] ||
+  fail "update removes namespaced records the collector no longer reports"
+pass "update removes namespaced records the collector no longer reports"


### PR DESCRIPTION

## What

Two additions to the agents bar widget, for people who juggle more than one Claude Code subscription (say, a personal Max plan and a work team plan):

1. **Every signed-in Claude account gets its own tab.** Claude Code keeps one sign-in per config directory, selected with `CLAUDE_CONFIG_DIR`. The collector now also reads every `~/.claude-<name>` directory that holds a sign-in and nests one full record per account under `accounts`. The updater files those as `claude-<name>.json`, so the panel shows `Claude · work` beside `Claude Code`, each with its own limits, plan, and transcripts. Nothing changes for a machine with a single account: the record is byte-for-byte what it was.
2. **An opt-in `layout` setting.** `"Tabs"` is the default and renders exactly as before. `"Columns"` lays every subscription out side by side, one column each, which is what you want on a wide screen with several accounts:

   ```
   omarchy bar set omarchy.agents layout Columns
   ```

<img width="1165" alt="The agents panel in Columns layout: four Claude accounts side by side" src="https://github.com/user-attachments/assets/87cb17b1-2c20-4144-99fc-9bf34aa09c82" />

## Details

- Directories signed in to the same account (identified through `.claude.json`) are shown once.
- Each account keeps its own limits probe cache, so one sign-in's numbers never answer for another.
- pi, omp, and opencode sessions carry no account of their own, so they count toward the default account only rather than toward every account.
- The updater only accepts nested ids inside the collector's namespace (`claude-*`), and removes a namespaced file the collector stops reporting, so signing out of an account clears its tab.
- Per-account enablement works through the existing `providers` map by record id (`"claude-work": { "enabled": false }`).
- In Columns the switch row, `h`/`l`, and the middle-click cycle stand down, and the bar icon alarms for whichever subscription is closest to its cap. A namespaced record borrows its collector's mark, so the extra accounts get the Claude logo.
- The per-subscription body moved into a `ProviderColumn` component that both layouts share, so Tabs is unchanged.
- Docs: the plugin README and the manual's agents panel section.

## Testing

- New `test/shell.d/agent-usage-claude-accounts-test.sh`: nesting, naming, deduplication of a directory signed in to the same account, a directory without a sign-in being skipped, transcript attribution per account, pi sessions counted once, and the single-account record staying free of `accounts`.
- `agent-usage-update-test.sh` gained coverage for filing nested records, stripping them from the collector's own file, refusing ids outside the namespace, and removing stale namespaced files.
- `./test/all` passes apart from three tests that need an `omarchy-pkgs` checkout on disk (`config-test`, `snapper-test`, `unowned-system-paths-test`), which fail the same way on `master` here.
- Verified visually on a running 4.0.2 shell in both layouts with four Claude accounts, including the account deduplication and the logo fallback.

https://claude.ai/code/session_01LrSjN4v13RrMXai5j95jGJ
