### PR TITLE
Runtime i18n: self-translating Ui kit with system gettext catalogs as the default source

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,115 @@
+# i18n
+
+Omarchy translates itself at runtime. No build step, no file rewriting: the
+Ui kit wraps its internal label bindings in `I18n.tr()`, and the I18n
+singleton resolves them against two translation sources.
+
+## Where translations come from
+
+1. **System gettext catalogs — the default.** Omarchy reads the catalogs the
+   Linux distribution already ships in
+   `/usr/share/locale/<lang>/LC_MESSAGES/` for the well-known desktop domains
+   (gtk30, gtk40, glib20, gdk-pixbuf, gnome-desktop-3.0). The vocabulary
+   every desktop UI shares — "Save", "Open", "Close", "Rename", "Delete",
+   "Search", "Settings", "Cancel"… — is translated here for every language
+   the distro packages, with no Omarchy-specific work at all. GTK accelerator
+   mnemonics are normalized: the catalog entry `_Save` serves lookups for
+   both `_Save` and `Save` (the latter returning the mnemonic-free
+   "Guardar"). This source is registered with precedence 200.
+2. **Plugin `i18n.json` — for the gaps.** A plugin may ship an `i18n.json`
+   next to its `manifest.json` with translations for strings the system
+   catalogs do not cover. It is registered with precedence 100, so it wins
+   over the system source — but only for the msgids it actually defines.
+
+There are no language packs and no per-language plugins: common UI strings
+are already translated by the system.
+
+## The `i18n.json` format
+
+One gettext-style catalog per locale, keyed by locale name. Regional
+variants fall back: shipping `es` covers a user running `es_CL`, `es_MX`, …
+
+```json
+{
+  "es": {
+    "": { "language": "es", "plural-forms": "nplurals=2; plural=(n != 1);" },
+    "Workspace profiles": "Perfiles de espacios de trabajo",
+    "Clear workspace": "Limpiar espacio de trabajo",
+    "%1 workspace": { "msgid_plural": "%1 workspaces", "msgstr": ["%1 espacio de trabajo", "%1 espacios de trabajo"] }
+  },
+  "de": {
+    "": { "language": "de", "plural-forms": "nplurals=2; plural=(n != 1);" },
+    "Workspace profiles": "Arbeitsflächenprofile",
+    "Clear workspace": "Arbeitsfläche leeren"
+  }
+}
+```
+
+Rules:
+
+- **Keys are the exact English source strings** your plugin renders — the
+  same string you would pass to `I18n.tr()`. Match them exactly, including
+  capitalization and punctuation.
+- **The `""` key is the catalog header** and carries the locale name and the
+  CLDR plural rule. It is required when the catalog contains plural entries;
+  the plural rule is evaluated by a small parser (never `eval`).
+- **Plurals** use the gettext shape shown above; `%1` interpolates the
+  number.
+- **UTF-8, no BOM.** Non-ASCII is fine (see the Russian examples in the
+  test fixture plugin).
+
+## How to fill an `i18n.json` — including for AI agents
+
+Before adding any translation, check whether the system catalogs already
+cover the string. Never duplicate a system translation in `i18n.json`:
+
+```bash
+# Does "Save" exist in the system catalogs for Spanish?
+for d in gtk30 gtk40 glib20 gdk-pixbuf gnome-desktop-3.0; do
+  msgunfmt /usr/share/locale/es/LC_MESSAGES/$d.mo 2>/dev/null \
+    | grep -q '^msgid "Save"$' && echo "found in $d"
+done
+```
+
+- If the msgid is found in any domain, **do not add it** — Omarchy resolves
+  it from the system source already. Duplicating it only creates drift.
+- If it is not found, **add the direct translation** of the exact string
+  under each locale you can translate. Check every domain, not just gtk30.
+
+Notes on what "not found" means:
+
+- **Fuzzy entries never reach the `.mo` files.** If upstream gettext marks
+  a translation fuzzy, `msgunfmt` output will not contain it even though the
+  distro ships the language. That is the normal case for a string that
+  appears missing — and exactly what `i18n.json` is for. ("Test" is fuzzy
+  in gtk30, for example: panels with a Test button ship their own.)
+- Test against the `.mo` files themselves, not the upstream PO sources —
+  only compiled entries are loaded at runtime.
+- Match the msgid exactly. `Test` and `test` are different keys.
+
+## Which strings belong in an `i18n.json`
+
+Only strings your plugin renders that the system catalogs do not cover:
+
+- Strings rendered through **raw bindings** (`Text { text: ... }`, direct
+  `placeholderText:`, `PanelSectionHeader`) — these are not intercepted by
+  the Ui kit. Prefer wrapping them in `I18n.tr()` (available via
+  `import qs.Commons`); then the same `i18n.json` entries apply.
+- **App-specific vocabulary** that desktop catalogs don't carry ("workspace
+  profile", "launch order", domain nouns of your feature).
+
+Generic UI strings ("Save", "Cancel", "Delete"…) must not be duplicated
+here — they come from the system catalogs.
+
+## Precedence summary
+
+| Source | Precedence | Wins over |
+|---|---|---|
+| Plugin `i18n.json` | 100 | system catalogs |
+| System gettext (`omarchy.system`) | 200 | English fallback |
+| English source string | — | — |
+
+On a locale change or plugin enable/disable the interface updates
+immediately and stays translated across restarts: the merged catalogs are
+persisted to the startup snapshot (`$XDG_CACHE_HOME/omarchy/i18n/<locale>.json`),
+which is read synchronously before the first frame.

--- a/shell/Commons/I18n.qml
+++ b/shell/Commons/I18n.qml
@@ -1,0 +1,249 @@
+pragma Singleton
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "I18nModel.js" as Model
+import "I18nSystem.js" as System
+
+// qs.Commons.I18n — the shell's translation primitive.
+//
+// This file owns everything that touches Qt: the environment, the cache file,
+// system gettext loading, and reactivity. All lookup logic lives in
+// I18nModel.js so it can be tested under node.
+//
+// Translation sources, lowest to highest precedence:
+//   1. Startup snapshot (the persisted merge from the previous session)
+//   2. System gettext catalogs — /usr/share/locale/<locale>/LC_MESSAGES/*.mo
+//      (gtk30, gtk40, glib20, …) read via msgunfmt. This is the default
+//      source: Linux already ships translations for the common UI
+//      vocabulary, no packs or plugins required.
+//   3. A plugin's own i18n.json — for strings the system catalogs do not
+//      cover. Registered by shell.qml from manifest.__i18n.
+//
+// Call sites
+//   I18n.tr("Connect")                          unbound: global merge
+//   readonly property var _: I18n.domain("dev.foo.weather")
+//   _.tr("Connect")  _.trc("verb", "Open")  _.ntr(n, "%1 city", "%1 cities", [n])
+//
+// With nothing registered every call returns its source string, so a stock
+// install is unaffected. Catalogs arrive late — the msgunfmt process and the
+// plugin registry finish after startup — so lookups read `revision` and any
+// binding that called tr() re-evaluates when a catalog registers. To avoid
+// a flash of English on every login, the merged catalogs are persisted to
+// $XDG_CACHE_HOME/omarchy/i18n/<language>.json and loaded synchronously here,
+// before the first frame. The Bash helper in default/bash/i18n reads the
+// same file.
+
+QtObject {
+  id: root
+
+  // ---------------------------------------------------------------------
+  // Locale
+
+  readonly property var candidates: Model.localeCandidates({
+    LANGUAGE: Quickshell.env("LANGUAGE"),
+    LC_ALL: Quickshell.env("LC_ALL"),
+    LC_MESSAGES: Quickshell.env("LC_MESSAGES"),
+    LANG: Quickshell.env("LANG")
+  })
+
+  // Primary language code ("ca" for ca_ES, or the first LANGUAGE entry).
+  // Empty means English / C: nothing to translate and no cache to keep.
+  readonly property string language: candidates.length > 0 ? candidates[0].split("_")[0] : ""
+
+  // Where a pack's locale sits in the user's preference order, for use as
+  // its registration precedence. -1 means the pack does not apply.
+  function precedenceFor(locale) {
+    var normalized = Model.normalizeLocale(locale)
+    if (!normalized) return -1
+    var index = candidates.indexOf(normalized)
+    if (index === -1) index = candidates.indexOf(normalized.split("_")[0])
+    return index
+  }
+
+  // ---------------------------------------------------------------------
+  // Lookup
+
+  // Bumped on every registry change. Read inside every lookup so QML
+  // bindings that call tr() depend on it and repaint when catalogs change.
+  property int revision: 0
+  property var _registry: Model.createRegistry()
+
+  function _lookup(source, options) {
+    void root.revision
+    return root._registry.translate(source, options)
+  }
+
+  function _lookupPlural(count, singular, plural, options) {
+    void root.revision
+    return root._registry.translatePlural(count, singular, plural, options)
+  }
+
+  function tr(source, args) {
+    return _lookup(source, { args: args })
+  }
+
+  function trc(context, source, args) {
+    return _lookup(source, { context: context, args: args })
+  }
+
+  function ntr(count, singular, plural, args) {
+    return _lookupPlural(count, singular, plural, { args: args })
+  }
+
+  // Marks a string for extraction without translating it, for strings
+  // defined away from where they are shown (a model returning a status).
+  function noop(source) {
+    return source
+  }
+
+  // A translator bound to one domain: lookups walk the domain, its
+  // clonedFrom parents, then the global merge.
+  function domain(id) {
+    var d = String(id === undefined || id === null ? "" : id)
+    return {
+      id: d,
+      tr: function(source, args) {
+        return root._lookup(source, { domain: d, args: args })
+      },
+      trc: function(context, source, args) {
+        return root._lookup(source, { domain: d, context: context, args: args })
+      },
+      ntr: function(count, singular, plural, args) {
+        return root._lookupPlural(count, singular, plural, { domain: d, args: args })
+      },
+      noop: function(source) { return source }
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Registration
+
+  // Replace an owner's whole contribution atomically.
+  //   catalogs  { domain: catalog }   one po2json-shaped object per domain
+  //   options   { links: { childDomain: parentDomain }, precedence: int }
+  function setCatalogs(ownerId, catalogs, options) {
+    var result = root._registry.setCatalogs(String(ownerId), catalogs, options)
+    root._changed()
+    return result
+  }
+
+  function clearCatalogs(ownerId) {
+    var removed = root._registry.clearOwner(String(ownerId))
+    if (removed) root._changed()
+    return removed
+  }
+
+  function _changed() {
+    root.revision = root._registry.revision()
+    root.cacheWriteTimer.restart()
+  }
+
+  // ---------------------------------------------------------------------
+  // System gettext catalogs
+  //
+  // Runs once at startup: for the first candidate locale that has any of
+  // the well-known desktop domains, msgunfmt concatenates them into PO
+  // text, which I18nSystem.js folds into one catalog. Registered below the
+  // plugin i18n.json source so an author can still override a string.
+  // The merge is persisted into the startup snapshot, so subsequent logins
+  // render translated on the first frame and this process only refreshes.
+
+  readonly property var systemDomains: ["gtk30", "gtk40", "glib20", "gdk-pixbuf", "gnome-desktop-3.0"]
+
+  function _systemCatalogCommand() {
+    var candidates = []
+    for (var i = 0; i < root.candidates.length; i++) {
+      // /usr/share/locale directories never carry an encoding suffix.
+      var bare = String(root.candidates[i]).replace(/\..*$/, "")
+      if (bare && candidates.indexOf(bare) === -1) candidates.push(bare)
+    }
+    if (candidates.length === 0) return []
+
+    var script = ""
+      + "DOMAINS=\"" + root.systemDomains.join(" ") + "\"\n"
+      + "for loc in " + candidates.join(" ") + "; do\n"
+      + "  files=\"\"\n"
+      + "  for d in $DOMAINS; do\n"
+      + "    f=\"/usr/share/locale/$loc/LC_MESSAGES/$d.mo\"\n"
+      + "    [ -f \"$f\" ] && files=\"$files '$f'\"\n"
+      + "  done\n"
+      + "  if [ -n \"$files\" ]; then\n"
+      + "    echo \"X-OMARCHY-SYSTEM-LOCALE: $loc\"\n"
+      + "    eval msgunfmt --no-wrap $files\n"
+      + "    exit 0\n"
+      + "  fi\n"
+      + "done\n"
+      + "exit 1\n"
+    return ["bash", "-c", script]
+  }
+
+  property Process systemCatalogProcess: Process {
+    command: root._systemCatalogCommand()
+    running: true
+    onExited: function(exitCode) {
+      if (exitCode !== 0) return
+      var output = systemCatalogStdout.text || ""
+      var marker = output.indexOf("\n")
+      if (marker === -1) return
+      var catalog = System.buildCatalog([output.slice(marker + 1)])
+      var keys = Object.keys(catalog).length
+      if (keys > 0) {
+        console.log("I18n: system gettext catalog for " + root.candidates.join(", ")
+          + " (" + (keys - (catalog[""] ? 1 : 0)) + " entries)")
+        root.setCatalogs("system:gettext", ({ "omarchy.system": catalog }), { precedence: 200 })
+      }
+    }
+    stdout: StdioCollector {
+      id: systemCatalogStdout
+      waitForEnd: true
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Startup cache
+
+  readonly property string cacheDir: {
+    var xdg = Quickshell.env("XDG_CACHE_HOME")
+    var base = xdg ? String(xdg) : String(Quickshell.env("HOME")) + "/.cache"
+    return base.replace(/\/$/, "") + "/omarchy/i18n"
+  }
+  readonly property string cachePath: language ? cacheDir + "/" + language + ".json" : ""
+
+  property FileView cacheFile: FileView {
+    path: root.cachePath
+    // Synchronous on purpose: the whole point is having catalogs before the
+    // bar's first frame. The file is small and local.
+    blockLoading: true
+    atomicWrites: true
+    printErrors: false
+    onLoaded: root._loadCache(text())
+    // No cache yet, or unreadable: English until a pack registers.
+    onLoadFailed: function(error) { }
+  }
+
+  function _loadCache(raw) {
+    var text = String(raw || "").trim()
+    if (!text) return
+    try {
+      var parsed = JSON.parse(text)
+      if (root._registry.loadSnapshot(parsed)) root.revision = root._registry.revision()
+    } catch (error) {
+      console.warn("I18n: ignoring unreadable cache at " + root.cachePath + ": " + error)
+    }
+  }
+
+  // Registrations arrive in bursts (one pack per locale, a rescan); coalesce
+  // them into one write.
+  property Timer cacheWriteTimer: Timer {
+    interval: 250
+    repeat: false
+    onTriggered: root._writeCache()
+  }
+
+  function _writeCache() {
+    if (!root.cachePath) return
+    var snapshot = root._registry.snapshot()
+    root.cacheFile.setText(JSON.stringify(snapshot) + "\n")
+  }
+}

--- a/shell/Commons/I18nModel.js
+++ b/shell/Commons/I18nModel.js
@@ -1,0 +1,455 @@
+// I18nModel.js — the pure-JS core of qs.Commons.I18n.
+//
+// No Qt or QML dependencies, so it runs under node for tests and QML loads it
+// with `import "I18nModel.js" as Model`. Keep it that way: everything that
+// touches FileView, Quickshell.env, or the plugin registry lives in I18n.qml.
+//
+// Vocabulary
+//   domain    a namespace for keys, normally a plugin id ("omarchy.menu");
+//             "omarchy.shell" and "omarchy.cli" are reserved for code with no id
+//   owner     whoever registered a set of catalogs, normally a language pack;
+//             owners are replaced atomically and can be cleared
+//   catalog   one JSON object per domain, po2json/Jed shape: a "" header entry
+//             plus msgid -> msgstr, or msgid -> [forms] for plurals
+//   link      child domain -> parent domain, from a clone's omarchy.clonedFrom
+
+var CONTEXT_SEPARATOR = "\u0004"
+
+// ---------------------------------------------------------------------------
+// Locale selection
+
+function normalizeLocale(value) {
+  var locale = String(value || "").trim()
+  if (!locale) return ""
+  locale = locale.split(".")[0].split("@")[0].replace(/-/g, "_")
+  if (locale === "C" || locale === "POSIX") return ""
+  var parts = locale.split("_")
+  var language = parts[0].toLowerCase()
+  if (!language) return ""
+  // Region ISO 3166 (2 letras) o numérica UN M.49 (3 dígitos, p. ej. es_419).
+  // El script BCP-47 (zh_Hans_CN) no existe en nombres de locale glibc/gettext:
+  // se omite y se conserva la región, que es lo que los catálogos usan.
+  var region = ""
+  for (var i = 1; i < parts.length; i++) {
+    if (/^[A-Za-z]{2}$/.test(parts[i]) || /^\d{3}$/.test(parts[i])) {
+      region = parts[i].toUpperCase()
+      break
+    }
+  }
+  return region ? language + "_" + region : language
+}
+
+// Ordered preference list from the gettext environment variables. LANGUAGE is
+// a colon-separated list and wins outright; the others are single values.
+// Each entry expands to [regional, language] so "ca_ES" also tries "ca".
+// "en" is the source language: nothing after it can apply, so the list stops.
+function localeCandidates(environment) {
+  var env = environment || {}
+  var raw = env.LANGUAGE || env.LC_ALL || env.LC_MESSAGES || env.LANG || ""
+  var requested = env.LANGUAGE ? String(raw).split(":") : [raw]
+  var candidates = []
+  for (var i = 0; i < requested.length; i++) {
+    var normalized = normalizeLocale(requested[i])
+    if (!normalized) continue
+    var language = normalized.split("_")[0]
+    if (candidates.indexOf(normalized) === -1) candidates.push(normalized)
+    if (candidates.indexOf(language) === -1) candidates.push(language)
+    if (language === "en") break
+  }
+  return candidates
+}
+
+// ---------------------------------------------------------------------------
+// Interpolation: %1, %2 ... Single pass, so an argument that itself contains
+// "%2" is inserted verbatim and never re-expanded. Unknown indices stay as-is.
+
+function interpolate(value, args) {
+  var output = String(value === undefined || value === null ? "" : value)
+  var values = Array.isArray(args) ? args : []
+  return output.replace(/%([1-9][0-9]*)/g, function(match, rawIndex) {
+    var index = Number(rawIndex) - 1
+    return index < values.length ? String(values[index]) : match
+  })
+}
+
+function contextKey(context, source) {
+  var ctx = String(context === undefined || context === null ? "" : context)
+  var key = String(source === undefined || source === null ? "" : source)
+  return ctx ? ctx + CONTEXT_SEPARATOR + key : key
+}
+
+// ---------------------------------------------------------------------------
+// Plural rules. The catalog header carries a gettext Plural-Forms line:
+//   "nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);"
+// The expression is a C integer expression over n. It is evaluated by a small
+// recursive-descent parser rather than eval/Function, so a hostile catalog
+// cannot run code and a malformed one is rejected rather than half-applied.
+
+var ENGLISH_PLURAL = { nplurals: 2, plural: function(n) { return n !== 1 ? 1 : 0 } }
+
+function tokenizePlural(text) {
+  var tokens = []
+  var i = 0
+  while (i < text.length) {
+    var c = text.charAt(i)
+    if (c === " " || c === "\t" || c === "\n") { i++; continue }
+    if (c >= "0" && c <= "9") {
+      var j = i
+      while (j < text.length && text.charAt(j) >= "0" && text.charAt(j) <= "9") j++
+      tokens.push({ type: "num", value: Number(text.slice(i, j)) })
+      i = j
+      continue
+    }
+    if (c === "n") { tokens.push({ type: "n" }); i++; continue }
+    var two = text.substr(i, 2)
+    if (["||", "&&", "==", "!=", "<=", ">="].indexOf(two) !== -1) {
+      tokens.push({ type: "op", value: two }); i += 2; continue
+    }
+    if ("?:()<>+-*/%!".indexOf(c) !== -1) { tokens.push({ type: "op", value: c }); i++; continue }
+    throw new Error("unexpected character in plural expression: " + c)
+  }
+  return tokens
+}
+
+function parsePluralExpression(text) {
+  var tokens = tokenizePlural(text)
+  var pos = 0
+
+  function peek() { return tokens[pos] }
+  function take(value) {
+    var t = tokens[pos]
+    if (!t || (value !== undefined && (t.type !== "op" || t.value !== value))) {
+      throw new Error("plural expression: expected " + (value || "token") + " at " + pos)
+    }
+    pos++
+    return t
+  }
+  function isOp(value) { var t = peek(); return t && t.type === "op" && t.value === value }
+
+  function primary() {
+    var t = peek()
+    if (!t) throw new Error("plural expression: unexpected end")
+    if (t.type === "num") { pos++; var v = t.value; return function() { return v } }
+    if (t.type === "n") { pos++; return function(n) { return n } }
+    if (isOp("(")) { take("("); var e = ternary(); take(")"); return e }
+    throw new Error("plural expression: unexpected " + t.value)
+  }
+  function unary() {
+    if (isOp("!")) { take("!"); var e = unary(); return function(n) { return e(n) ? 0 : 1 } }
+    return primary()
+  }
+  function binary(next, ops, apply) {
+    return function parse() {
+      var left = next()
+      while (peek() && peek().type === "op" && ops.indexOf(peek().value) !== -1) {
+        var op = take().value
+        var right = next()
+        left = (function(l, r, o) { return function(n) { return apply(o, l(n), r(n)) } })(left, right, op)
+      }
+      return left
+    }
+  }
+  var mul = binary(unary, ["*", "/", "%"], function(o, a, b) {
+    if (o === "*") return a * b
+    if (b === 0) return 0
+    return o === "/" ? Math.floor(a / b) : a % b
+  })
+  var add = binary(mul, ["+", "-"], function(o, a, b) { return o === "+" ? a + b : a - b })
+  var rel = binary(add, ["<", ">", "<=", ">="], function(o, a, b) {
+    if (o === "<") return a < b ? 1 : 0
+    if (o === ">") return a > b ? 1 : 0
+    if (o === "<=") return a <= b ? 1 : 0
+    return a >= b ? 1 : 0
+  })
+  var eq = binary(rel, ["==", "!="], function(o, a, b) { return (o === "==" ? a === b : a !== b) ? 1 : 0 })
+  var and = binary(eq, ["&&"], function(o, a, b) { return a && b ? 1 : 0 })
+  var or = binary(and, ["||"], function(o, a, b) { return a || b ? 1 : 0 })
+  function ternary() {
+    var cond = or()
+    if (!isOp("?")) return cond
+    take("?")
+    var yes = ternary()
+    take(":")
+    var no = ternary()
+    return function(n) { return cond(n) ? yes(n) : no(n) }
+  }
+
+  var fn = ternary()
+  if (pos !== tokens.length) throw new Error("plural expression: trailing tokens")
+  return fn
+}
+
+// Returns { nplurals, plural(n) } or null when the header is absent/invalid.
+function parsePluralForms(header) {
+  var text = String(header || "")
+  var countMatch = text.match(/nplurals\s*=\s*(\d+)/)
+  var exprMatch = text.match(/plural\s*=\s*([^;]+)/)
+  if (!countMatch || !exprMatch) return null
+  var nplurals = Number(countMatch[1])
+  if (!(nplurals >= 1)) return null
+  var expr
+  try { expr = parsePluralExpression(exprMatch[1]) } catch (e) { return null }
+  return {
+    nplurals: nplurals,
+    plural: function(n) {
+      var count = Math.abs(Math.floor(Number(n) || 0))
+      var index = Number(expr(count))
+      if (!(index >= 0)) index = 0
+      if (index >= nplurals) index = nplurals - 1
+      return index
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Catalog validation. A catalog is a plain object; the "" entry is a header
+// object; every other value is a string or an array of strings. Anything else
+// is dropped entry-by-entry so one bad line does not lose the whole file.
+
+function sanitizeCatalog(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
+  var out = {}
+  for (var key in raw) {
+    if (!Object.prototype.hasOwnProperty.call(raw, key)) continue
+    var value = raw[key]
+    if (key === "") {
+      if (value && typeof value === "object" && !Array.isArray(value)) out[""] = value
+      continue
+    }
+    if (typeof value === "string") { out[key] = value; continue }
+    if (Array.isArray(value) && value.length > 0) {
+      var ok = true
+      for (var i = 0; i < value.length; i++) if (typeof value[i] !== "string") { ok = false; break }
+      if (ok) out[key] = value.slice()
+    }
+  }
+  return out
+}
+
+function headerPluralForms(catalog) {
+  var header = catalog && catalog[""]
+  if (!header) return null
+  return parsePluralForms(header["plural-forms"] || header["Plural-Forms"])
+}
+
+// ---------------------------------------------------------------------------
+// Registry. Holds every owner's catalogs and links, and derives:
+//   merged[domain]  one catalog per domain, owners folded by precedence
+//   global          every domain folded into one map, parents before children
+//   parents         child domain -> parent domain
+// Derived state is rebuilt on every change; catalogs are small and changes
+// are rare (login, plugin toggles), so simplicity wins over incrementality.
+
+function createRegistry() {
+  var owners = {}          // ownerId -> { catalogs, links, precedence, order }
+  var nextOrder = 0
+  var state = { revision: 0, merged: {}, global: {}, parents: {}, plurals: {} }
+
+  // The startup cache is registered as an ordinary owner at the lowest
+  // precedence so it can answer lookups for the frames before the real packs
+  // register. It is only ever a stand-in: once a live pack has registered,
+  // the cache copy is dropped and no longer reloadable, so disabling that
+  // pack actually reverts the interface instead of falling back to a stale
+  // duplicate of the strings it just removed.
+  var CACHE_OWNER = "cache"
+  var liveOwnerSeen = false
+
+  // Fold a list of owners into { merged, parents, plurals, global }.
+  function computeState(list) {
+    // Lower precedence number wins. Among equals, the later registration
+    // wins, which is what lets a pack refresh itself by re-registering.
+    list = list.slice().sort(function(a, b) {
+      return a.precedence !== b.precedence ? b.precedence - a.precedence : a.order - b.order
+    })
+
+    var merged = {}
+    var parents = {}
+    var domainOrder = []
+    for (var i = 0; i < list.length; i++) {
+      var owner = list[i]
+      for (var domain in owner.catalogs) {
+        if (!merged[domain]) { merged[domain] = {}; domainOrder.push(domain) }
+        var cat = owner.catalogs[domain]
+        for (var key in cat) merged[domain][key] = cat[key]
+      }
+      for (var child in owner.links) parents[child] = owner.links[child]
+    }
+
+    var plurals = {}
+    for (var d = 0; d < domainOrder.length; d++) {
+      plurals[domainOrder[d]] = headerPluralForms(merged[domainOrder[d]])
+    }
+
+    // Global merge: a domain's ancestors are folded before it, so a clone's
+    // translation shadows the original's for unbound callers.
+    var global = {}
+    var folded = {}
+    function fold(domain, depth) {
+      if (folded[domain] || depth > 16) return
+      folded[domain] = true
+      if (parents[domain] && merged[parents[domain]]) fold(parents[domain], depth + 1)
+      var cat = merged[domain]
+      for (var key in cat) if (key !== "") global[key] = { value: cat[key], domain: domain }
+    }
+    for (var o = 0; o < domainOrder.length; o++) fold(domainOrder[o], 0)
+
+    return { merged: merged, global: global, parents: parents, plurals: plurals }
+  }
+
+  function ownerList(excludeId) {
+    var list = []
+    for (var id in owners) if (id !== excludeId) list.push(owners[id])
+    return list
+  }
+
+  function rebuild() {
+    var next = computeState(ownerList())
+    state.merged = next.merged
+    state.global = next.global
+    state.parents = next.parents
+    state.plurals = next.plurals
+    state.revision++
+  }
+
+  // Domain chain for a bound caller: the domain, then its parents.
+  function chain(domain) {
+    var out = []
+    var seen = {}
+    var current = domain ? String(domain) : ""
+    while (current && !seen[current] && out.length < 16) {
+      seen[current] = true
+      out.push(current)
+      current = state.parents[current]
+    }
+    return out
+  }
+
+  // Per-key lookup. Returns { value, domain } or null.
+  function lookup(key, domain) {
+    var domains = chain(domain)
+    for (var i = 0; i < domains.length; i++) {
+      var cat = state.merged[domains[i]]
+      if (cat && Object.prototype.hasOwnProperty.call(cat, key) && key !== "") {
+        return { value: cat[key], domain: domains[i] }
+      }
+    }
+    return Object.prototype.hasOwnProperty.call(state.global, key) ? state.global[key] : null
+  }
+
+  function translate(source, options) {
+    var opts = options || {}
+    var fallback = String(source === undefined || source === null ? "" : source)
+    var key = contextKey(opts.context, fallback)
+    var hit = lookup(key, opts.domain)
+    var value = hit ? hit.value : fallback
+    if (Array.isArray(value)) value = value[0]
+    return interpolate(value, opts.args)
+  }
+
+  function translatePlural(count, singular, plural, options) {
+    var opts = options || {}
+    var n = Number(count) || 0
+    var key = contextKey(opts.context, String(singular === undefined || singular === null ? "" : singular))
+    var hit = lookup(key, opts.domain)
+    var text
+    if (hit && Array.isArray(hit.value)) {
+      var rule = state.plurals[hit.domain] || ENGLISH_PLURAL
+      var index = rule.plural(n)
+      text = hit.value[index] !== undefined ? hit.value[index] : hit.value[hit.value.length - 1]
+    } else if (hit && typeof hit.value === "string") {
+      text = hit.value
+    } else {
+      text = ENGLISH_PLURAL.plural(n) === 0 ? singular : plural
+    }
+    return interpolate(text, opts.args)
+  }
+
+  // Replace an owner's whole contribution atomically.
+  //   catalogs   { domain: catalog }
+  //   options    { links: { child: parent }, precedence: number }
+  function setCatalogs(ownerId, catalogs, options) {
+    var opts = options || {}
+    var clean = {}
+    var raw = catalogs && typeof catalogs === "object" ? catalogs : {}
+    for (var domain in raw) {
+      var cat = sanitizeCatalog(raw[domain])
+      if (cat) clean[String(domain)] = cat
+    }
+    var links = {}
+    var rawLinks = opts.links && typeof opts.links === "object" ? opts.links : {}
+    for (var child in rawLinks) {
+      if (typeof rawLinks[child] === "string" && rawLinks[child] && rawLinks[child] !== child) {
+        links[String(child)] = rawLinks[child]
+      }
+    }
+    var existing = owners[ownerId]
+    owners[ownerId] = {
+      catalogs: clean,
+      links: links,
+      precedence: typeof opts.precedence === "number" ? opts.precedence : 0,
+      order: nextOrder++
+    }
+    if (ownerId !== CACHE_OWNER) {
+      liveOwnerSeen = true
+      delete owners[CACHE_OWNER]
+    }
+    rebuild()
+    return existing ? "replaced" : "added"
+  }
+
+  function clearOwner(ownerId) {
+    if (!owners[ownerId]) return false
+    delete owners[ownerId]
+    rebuild()
+    return true
+  }
+
+  // Serializable view of the merged state, for the startup cache. The
+  // snapshot excludes the cache owner: otherwise disabling every pack would
+  // write the old cache back out and the translations would return at the
+  // next login.
+  function snapshot(options) {
+    var exclude = options && options.exclude !== undefined ? options.exclude : CACHE_OWNER
+    var view = computeState(ownerList(exclude))
+    var catalogs = {}
+    for (var domain in view.merged) catalogs[domain] = view.merged[domain]
+    var links = {}
+    for (var child in view.parents) links[child] = view.parents[child]
+    return { version: 1, catalogs: catalogs, links: links }
+  }
+
+  function loadSnapshot(snap, ownerId) {
+    if (!snap || typeof snap !== "object" || snap.version !== 1) return false
+    // Writing the cache re-triggers the FileView that loads it. Without this
+    // a pack's own registration would come straight back in as a cache owner
+    // that outlives it.
+    if (liveOwnerSeen && (ownerId || CACHE_OWNER) === CACHE_OWNER) return false
+    setCatalogs(ownerId || CACHE_OWNER, snap.catalogs, { links: snap.links, precedence: 1000 })
+    return true
+  }
+
+  return {
+    setCatalogs: setCatalogs,
+    clearOwner: clearOwner,
+    lookup: lookup,
+    chain: chain,
+    translate: translate,
+    translatePlural: translatePlural,
+    snapshot: snapshot,
+    loadSnapshot: loadSnapshot,
+    domains: function() { var out = []; for (var d in state.merged) out.push(d); return out },
+    owners: function() { var out = []; for (var o in owners) out.push(o); return out },
+    revision: function() { return state.revision }
+  }
+}
+
+if (typeof module !== "undefined") module.exports = {
+  CONTEXT_SEPARATOR: CONTEXT_SEPARATOR,
+  normalizeLocale: normalizeLocale,
+  localeCandidates: localeCandidates,
+  interpolate: interpolate,
+  contextKey: contextKey,
+  parsePluralForms: parsePluralForms,
+  sanitizeCatalog: sanitizeCatalog,
+  createRegistry: createRegistry
+}

--- a/shell/Commons/I18nSystem.js
+++ b/shell/Commons/I18nSystem.js
@@ -1,0 +1,181 @@
+// I18nSystem.js — system gettext catalogs as an Omarchy translation source.
+//
+// Linux distributions already ship translations for the common UI vocabulary
+// ("Save", "Open", "Close", …) in /usr/share/locale/<locale>/LC_MESSAGES/*.mo.
+// This module turns the PO text produced by `msgunfmt` into the po2json-shaped
+// catalog the I18n registry understands, so the shell uses those translations
+// by default. Plugin authors only ship an i18n.json for strings the system
+// catalogs do not cover.
+//
+// No Qt or QML dependencies: QML loads it with `import "I18nSystem.js" as
+// System`, tests require it under node. The Qt-side Process that runs
+// msgunfmt lives in I18n.qml.
+//
+// Catalog build rules:
+//   - fuzzy and untranslated entries are dropped
+//   - GTK/Qt accelerator markers are normalized: "_Save" and "&Save" also
+//     register under "Save" (plain keys win when both exist)
+//   - the first domain wins on conflicts; later domains only fill gaps
+//   - the gettext header (plural rules) of the first domain is kept
+
+"use strict"
+
+// ---------------------------------------------------------------------------
+// Minimal PO reader (msgunfmt output): msgctxt, msgid, msgid_plural,
+// msgstr[n], multi-line strings, flags.
+
+function parsePoEntries(text) {
+  var entries = []
+  var cur = null
+  var target = null // "msgid" | "msgid_plural" | "msgctxt" | "msgstr" | "msgstr[n]"
+
+  function flush() {
+    if (cur && (cur.msgid !== "" || cur.msgctxt !== null || cur.msgstr.length > 0)) {
+      if (!cur.obsolete) entries.push(cur)
+    }
+    cur = null
+  }
+
+  function unescape(s) {
+    return s.replace(/\\(n|t|r|"|\\)/g, function(_, c) {
+      return { n: "\n", t: "\t", r: "\r", '"': '"', "\\": "\\" }[c]
+    })
+  }
+
+  var lines = String(text || "").replace(/\r\n/g, "\n").split("\n")
+  var pendingFlags = []
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i]
+
+    if (line.indexOf("#~") === 0) { if (cur) cur.obsolete = true; continue }
+    if (line.indexOf("#") === 0) {
+      // Comments (incl. flags) always precede the entry they describe:
+      // finish any pending entry so flags never leak into the previous one.
+      flush()
+      if (line.indexOf("#,") === 0) {
+        var flagParts = line.slice(2).trim().split(/\s*,\s*/)
+        for (var fp = 0; fp < flagParts.length; fp++) {
+          if (flagParts[fp]) pendingFlags.push(flagParts[fp])
+        }
+      }
+      continue
+    }
+
+    function makeEntry() {
+      var e = { msgctxt: null, msgid: "", msgid_plural: null, msgstr: [], flags: [], obsolete: false }
+      for (var pf = 0; pf < pendingFlags.length; pf++) e.flags.push(pendingFlags[pf])
+      pendingFlags = []
+      return e
+    }
+
+    var m
+    if ((m = line.match(/^msgctxt\s+"(.*)"\s*$/))) {
+      flush()
+      cur = makeEntry()
+      cur.msgctxt = unescape(m[1])
+      target = "msgctxt"
+    } else if ((m = line.match(/^msgid\s+"(.*)"\s*$/))) {
+      if (!cur || cur.msgid !== "" || cur.msgctxt === null) {
+        flush()
+        cur = makeEntry()
+        cur.msgid = unescape(m[1])
+      } else {
+        cur.msgid = unescape(m[1])
+      }
+      target = "msgid"
+    } else if ((m = line.match(/^msgid_plural\s+"(.*)"\s*$/))) {
+      if (cur) { cur.msgid_plural = unescape(m[1]); target = "msgid_plural" }
+    } else if ((m = line.match(/^msgstr\[(\d+)\]\s+"(.*)"\s*$/))) {
+      if (cur) { cur.msgstr[Number(m[1])] = unescape(m[2]); target = "msgstr[" + m[1] + "]" }
+    } else if ((m = line.match(/^msgstr\s+"(.*)"\s*$/))) {
+      if (cur) { cur.msgstr[0] = unescape(m[1]); target = "msgstr[0]" }
+    } else if ((m = line.match(/^"(.*)"\s*$/))) {
+      if (cur && target) {
+        var value = unescape(m[1])
+        if (target === "msgid") cur.msgid += value
+        else if (target === "msgid_plural") cur.msgid_plural += value
+        else if (target === "msgctxt") cur.msgctxt += value
+        else if (target.slice(0, 6) === "msgstr") cur.msgstr[Number(target.slice(7, -1))] += value
+      }
+    }
+  }
+  flush()
+  return entries
+}
+
+// ---------------------------------------------------------------------------
+// Accelerator normalization. GTK marks mnemonics with an underscore anywhere
+// in the string ("_Save", "Sa_ve"); Qt/KDE prefix an ampersand ("&Save").
+// The translated string keeps its own marker — only the lookup key changes.
+
+function stripAccelerators(msgid) {
+  var s = String(msgid)
+  if (s.charAt(0) === "&") s = s.slice(1)
+  return s.split("_").join("")
+}
+
+// ---------------------------------------------------------------------------
+// Catalog builder. texts is an array of PO document strings (one per system
+// domain, most preferred first). Returns the po2json-shaped catalog.
+
+function buildCatalog(texts) {
+  var catalog = {}
+  var headerDone = false
+
+  for (var t = 0; t < texts.length; t++) {
+    var entries = parsePoEntries(texts[t])
+    for (var i = 0; i < entries.length; i++) {
+      var e = entries[i]
+      if (e.msgctxt) continue // contextual entries are not reachable via tr()
+      if (e.flags.indexOf("fuzzy") !== -1) continue
+      if (e.msgid === "") {
+        // Gettext header: keep the first one (plural rules, language).
+        if (!headerDone && e.msgstr[0]) {
+          var header = {}
+          e.msgstr[0].split("\n").forEach(function(row) {
+            var idx = row.indexOf(": ")
+            if (idx > 0) header[row.slice(0, idx)] = row.slice(idx + 2)
+          })
+          if (header["Content-Type"]) delete header["Content-Type"]
+          catalog[""] = header
+          headerDone = true
+        }
+        continue
+      }
+      var untranslated = !e.msgstr[0]
+      if (untranslated && !e.msgid_plural) continue
+
+      if (e.msgid_plural) {
+        if (catalog[e.msgid] === undefined) {
+          catalog[e.msgid] = { msgid_plural: e.msgid_plural, msgstr: e.msgstr.slice() }
+        }
+        // Plain variant without accelerators, on both msgid and msgstr:
+        // "Pane" must yield "Panel"/"Paneles", not accelerator-marked text.
+        var plainP = stripAccelerators(e.msgid)
+        if (plainP !== e.msgid && plainP && catalog[plainP] === undefined) {
+          catalog[plainP] = {
+            msgid_plural: stripAccelerators(e.msgid_plural),
+            msgstr: e.msgstr.map(function(s) { return stripAccelerators(s) })
+          }
+        }
+      } else {
+        var value = e.msgstr[0]
+        if (catalog[e.msgid] === undefined) catalog[e.msgid] = value
+        // Plain variant: "Save" must yield "Guardar", not "_Guardar" — the
+        // mnemonic marker lives in both the msgid and the msgstr.
+        var plain = stripAccelerators(e.msgid)
+        if (plain !== e.msgid && plain && catalog[plain] === undefined) {
+          var plainValue = stripAccelerators(value)
+          if (plainValue) catalog[plain] = plainValue
+        }
+      }
+    }
+  }
+
+  if (!headerDone) delete catalog[""]
+  return catalog
+}
+
+var api = { parsePoEntries: parsePoEntries, stripAccelerators: stripAccelerators, buildCatalog: buildCatalog }
+
+if (typeof module !== "undefined" && module.exports) module.exports = api

--- a/shell/Commons/qmldir
+++ b/shell/Commons/qmldir
@@ -1,5 +1,6 @@
 module qs.Commons
 singleton Border 1.0 Border.qml
 singleton Color 1.0 Color.qml
+singleton I18n 1.0 I18n.qml
 singleton Style 1.0 Style.qml
 singleton Util 1.0 Util.qml

--- a/shell/Ui/Button.qml
+++ b/shell/Ui/Button.qml
@@ -129,7 +129,7 @@ BorderSurface {
 
   ToolTip {
     visible: root.tooltipText !== "" && mouseArea.containsMouse
-    text: root.tooltipText
+    text: root.tooltipText !== "" ? I18n.tr(root.tooltipText) : ""
     delay: 400
     padding: 0
     background: BorderSurface {
@@ -139,7 +139,7 @@ BorderSurface {
     }
     contentItem: Text {
       textFormat: Text.PlainText
-      text: root.tooltipText
+      text: root.tooltipText !== "" ? I18n.tr(root.tooltipText) : ""
       color: root.tooltipForeground
       font.family: root.fontFamily
       font.pixelSize: Style.font.bodySmall
@@ -181,7 +181,7 @@ BorderSurface {
     Text {
       textFormat: Text.PlainText
       visible: root.text !== ""
-      text: root.text
+      text: root.text !== "" ? I18n.tr(root.text) : ""
       color: root.selected ? root._selectedColor : root.foreground
       font.family: root.fontFamily
       font.pixelSize: root.fontSize

--- a/shell/Ui/PanelActionButton.qml
+++ b/shell/Ui/PanelActionButton.qml
@@ -94,7 +94,7 @@ BorderSurface {
 
   PanelToolTip {
     visible: root.tooltipText !== "" && mouse.containsMouse
-    text: root.tooltipText
+    text: root.tooltipText !== "" ? I18n.tr(root.tooltipText) : ""
     fontFamily: root.fontFamily
   }
 }

--- a/shell/Ui/PanelHero.qml
+++ b/shell/Ui/PanelHero.qml
@@ -50,7 +50,7 @@ Item {
       Text {
         textFormat: Text.PlainText
         visible: root.title !== ""
-        text: root.title
+        text: root.title !== "" ? I18n.tr(root.title) : ""
         width: Math.min(implicitWidth, Math.max(0, parent.width - (detailPill.visible ? detailPill.implicitWidth + Style.space(8) : 0)))
         color: root.foreground
         font.family: root.fontFamily
@@ -78,7 +78,7 @@ Item {
           id: detailText
           textFormat: Text.PlainText
           anchors.centerIn: parent
-          text: root.detail
+          text: root.detail !== "" ? I18n.tr(root.detail) : ""
           color: root.dim
           font.family: root.fontFamily
           font.pixelSize: Style.font.body

--- a/shell/Ui/PanelToolTip.qml
+++ b/shell/Ui/PanelToolTip.qml
@@ -37,7 +37,7 @@ ToolTip {
 
   contentItem: Text {
     textFormat: Text.PlainText
-    text: root.text
+    text: root.text !== "" ? I18n.tr(root.text) : ""
     color: root.panelForeground
     font.family: root.fontFamily
     font.pixelSize: root.fontSize

--- a/shell/Ui/Toggle.qml
+++ b/shell/Ui/Toggle.qml
@@ -70,7 +70,7 @@ BorderSurface {
 
       Text {
         textFormat: Text.PlainText
-        text: root.label
+        text: root.label !== "" ? I18n.tr(root.label) : ""
         color: root.foreground
         font.family: root.fontFamily
         font.pixelSize: root.titleSize
@@ -82,7 +82,7 @@ BorderSurface {
       Text {
         textFormat: Text.PlainText
         visible: root.description !== ""
-        text: root.description
+        text: root.description !== "" ? I18n.tr(root.description) : ""
         color: Qt.darker(root.foreground, 1.5)
         font.family: root.fontFamily
         font.pixelSize: root.descriptionSize

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -546,6 +546,8 @@ QtObject {
   // Output format produced by the rescan script:
   //   ===<kind>::<absolute-source-dir>===
   //   ... raw manifest.json content ...
+  //   === I18N ===            (only when the plugin ships i18n.json)
+  //   ... raw i18n.json content ...
   //   === EOM ===
   // (repeating for every manifest found)
   function parseScanOutput(text) {
@@ -555,6 +557,7 @@ QtObject {
     var currentSource = null
     var currentKind = null
     var currentJson = []
+    var currentI18n = null
 
     function flush() {
       if (!currentSource) return
@@ -563,6 +566,13 @@ QtObject {
         var manifest = JSON.parse(raw)
         manifest.__sourceDir = currentSource
         manifest.__isFirstParty = (currentKind === "firstparty")
+        if (currentI18n) {
+          try {
+            manifest.__i18n = JSON.parse(currentI18n.join("\n"))
+          } catch (e) {
+            console.warn("PluginRegistry: bad i18n.json at " + currentSource + ": " + e)
+          }
+        }
         var validated = validateManifest(manifest, currentSource + "/manifest.json")
         if (validated) {
           if (currentKind === "firstparty") firstParty[validated.id] = validated
@@ -584,13 +594,19 @@ QtObject {
         currentKind = startMatch[1]
         currentSource = startMatch[2].replace(/\/$/, "")
         currentJson = []
+        currentI18n = null
+        continue
+      }
+      if (line === "=== I18N ===") {
+        currentI18n = []
         continue
       }
       if (line === "=== EOM ===") {
         flush()
         continue
       }
-      if (currentSource) currentJson.push(line)
+      if (currentI18n) currentI18n.push(line)
+      else if (currentSource) currentJson.push(line)
     }
     flush()
 
@@ -674,6 +690,7 @@ QtObject {
       + "  if [[ ${manifest##*/} == \"manifest.json\" ]]; then sub=\"${manifest%/manifest.json}\"; else sub=\"$(dirname -- \"$manifest\")\"; fi; "
       + "  printf '===%s::%s===\\n' \"$kind\" \"$sub\"; "
       + "  cat \"$manifest\"; "
+      + "  if [[ -f \"$sub/i18n.json\" ]]; then printf '\\n=== I18N ===\\n'; cat \"$sub/i18n.json\"; fi; "
       + "  printf '\\n=== EOM ===\\n'; "
       + "}; "
       + "scan_firstparty() { local dir=\"$1\"; "

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -153,6 +153,50 @@ ShellRoot {
     // case the user dir already existed at startup.
     pluginRegistry.rescan()
     shell._syncServices()
+    shell.refreshBundledI18n()
+  }
+
+  // Plugins may ship their own translations in i18n.json next to
+  // manifest.json: { "<locale>": { "": {language, plural-forms}, "msgid":
+  // "msgstr" } }. The scan stamps it on the manifest as __i18n; here it is
+  // registered under the plugin's own domain so plain I18n.tr() calls in the
+  // plugin resolve through the global merge. Intended for strings the system
+  // gettext catalogs do not cover — those stay the default source.
+  // Precedence 100 (lower number wins): a plugin override beats the system
+  // gettext merge (200); language packs would sit below and the startup
+  // snapshot at 1000.
+  property var _bundledI18nOwners: []
+
+  function refreshBundledI18n() {
+    var active = {}
+    var plugins = pluginRegistry.installedPlugins
+    for (var id in plugins) {
+      var manifest = plugins[id]
+      var bundled = manifest ? manifest.__i18n : null
+      if (!bundled || !pluginRegistry.isEnabled(id)) continue
+      for (var i = 0; i < I18n.candidates.length; i++) {
+        var catalog = bundled[I18n.candidates[i]]
+        if (!catalog) catalog = bundled[I18n.candidates[i].split("_")[0]]
+        if (!catalog) continue
+        var domains = {}
+        domains[id] = catalog
+        I18n.setCatalogs(id + ":i18n", domains, { precedence: 100 })
+        active[id + ":i18n"] = true
+        break
+      }
+    }
+    for (var j = 0; j < _bundledI18nOwners.length; j++) {
+      var owner = _bundledI18nOwners[j]
+      if (!active[owner]) I18n.clearCatalogs(owner)
+    }
+    var owners = []
+    for (var k in active) owners.push(k)
+    _bundledI18nOwners = owners
+  }
+
+  Connections {
+    target: pluginRegistry
+    function onPluginsChanged() { shell.refreshBundledI18n() }
   }
 
   function mutateShellConfig(mutator) {


### PR DESCRIPTION
## Summary

Runtime i18n that translates the shell **and every plugin built on the Omarchy Ui kit, with zero changes to any plugin source** — no codemod, no overlay, no per-plugin conversion PRs, and no language packs.

Four commits:

1. `Add runtime i18n: I18n singleton + self-translating Ui kit` — a `qs.Commons.I18n` singleton (gettext semantics: `LANGUAGE` > `LC_ALL` > `LC_MESSAGES` > `LANG`, regional fallback, CLDR plurals evaluated by a parser, never `eval`) plus the five Ui components that render plugin-authored labels wrapping their *internal* bindings in `I18n.tr()`: `Button` (label + tooltip), `Toggle` (label + description), `PanelToolTip`, `PanelHero` (title + detail), `PanelActionButton` (tooltip). A third-party plugin using `qs.Ui` translates automatically; the author writes nothing.
2. `Load per-plugin i18n.json translations at scan time` — a plugin may ship an `i18n.json` next to `manifest.json` (one gettext-in-JSON catalog per locale). The plugin scan stamps it on the manifest and the shell registers it with precedence 100.
3. `Load system gettext catalogs (gtk/glib) as the default translation source` — at startup the shell runs `msgunfmt` over the distro's own `/usr/share/locale/<lang>/LC_MESSAGES/{gtk30,gtk40,glib20,gdk-pixbuf,gnome-desktop-3.0}.mo` and registers the result as `omarchy.system` (precedence 200, below the plugin source). GTK accelerator mnemonics are normalized (`_Save` serves both `_Save` and `Save`, the latter yielding the mnemonic-free "Guardar"). Fuzzy/obsolete/untranslated entries are skipped. The merged catalogs persist into a startup snapshot read synchronously, so restarts render translated on the first frame.
4. `Add i18n documentation` — `docs/i18n.md`: the two-source model, the `i18n.json` format, and the fill rules (below).

## Why this shape

**Why the Ui kit translates itself:** Qt can only translate strings that pass through a translation call, so `text: "Save"` in author code can never be intercepted from outside. Wrapping the label bindings *inside* the shared components is the only runtime-only choke point — and it is where Omarchy convention already funnels plugin UI.

**Why system gettext is the default source:** the translations for the shared desktop vocabulary already exist on every install — the distro ships them. "Save", "Open", "Close", "Rename", "Delete", "Search", "Settings", "Cancel" are covered for every packaged language with nothing to download, review, or keep in sync. Measured on this machine: 2951 (es), 2952 (fr), 2946 (de), 2952 (ru) entries.

**Why `i18n.json` exists at all:** system catalogs don't carry app-specific vocabulary, and fuzzy entries are never compiled into `.mo` files at all — so a string can be genuinely missing (concrete case: "Test" is fuzzy in gtk30 and absent from every compiled catalog; a panel with a Test button ships `"Test": "Probar"` in its `i18n.json`). That is the only file an author ever writes, and only for strings the system doesn't cover.

## The `i18n.json` fill rule (for humans and AI agents)

Before adding a translation, check whether the system catalogs already cover the string — and never duplicate one:

```bash
for d in gtk30 gtk40 glib20 gdk-pixbuf gnome-desktop-3.0; do
  msgunfmt /usr/share/locale/es/LC_MESSAGES/$d.mo 2>/dev/null \
    | grep -q '^msgid "Save"$' && echo "found in $d"
done
```

Found → do not add it. Not found → add the direct translation of the exact string under each locale you can translate. Test against the `.mo` files, not upstream PO sources — only compiled entries load at runtime. Full spec and examples in `docs/i18n.md`.

## Live evidence

Real session, second Quickshell instance, third-party plugin `io.github.imryiuk.workspace-profiles` **with its source untouched**: its Buttons render "Renombrar / Probar / Guardar" (es), "Renommer / Tester / Enregistrer" (fr), "Umbenennen / Testen / Speichern" (de), "Переименовать / Тест / Сохранить" (ru); "Probar"/"Tester"/"Testen"/"Тест" come from the plugin's `i18n.json` — the gap-fill path. Strings rendered through raw bindings (`placeholderText:`, bare `Text`) stay in English unless the author opts in with `I18n.tr()` — the one documented limitation, by construction rather than oversight.

## Relationship to the other proposals

- **#8765** (xavivars' primitive + language packs as plugins) and its PoC deserve the credit for the gettext-in-JSON catalog model and plural-rule parser this builds on. This PR answers its two questions differently: with the Ui kit self-translating, there are no per-plugin call-site conversion PRs to land; and with system catalogs as the source, common strings need no packs at all — packs reduce to an optional community layer for app-specific vocabulary, which `i18n.json` already covers per plugin.
- **#10051** (QTranslator PoC) explores delegating to Qt's runtime. Not mutually exclusive with the source question this PR settles: whatever runtime wins, the translations still have to come from somewhere, and the distro's gettext is the zero-maintenance answer for shared vocabulary.
- Related: #7434, #7284, #6360.

## Testing

- 38 unit tests (`node --test`): PO parsing, mnemonic normalization in both msgid and msgstr, fuzzy/obsolete skipping, first-domain-wins merge, plural evaluation, locale chain, end-to-end resolution against real compiled catalogs.
- `./test/shell`: 3 of 226 files fail — identical failures on a pristine `quattro` checkout (config, snapper, unowned-system-paths), so pre-existing and unrelated.
- Cold-boot snapshot verified: the merged system + plugin catalogs are served from the cache on restart with no re-fetch flicker.

## Precedence

| Source | Precedence |
|---|---|
| Plugin `i18n.json` | 100 (wins over system) |
| System gettext (`omarchy.system`) | 200 |
| English source string | fallback |
