### PR TITLE
Add omarchy-install-blesh for opt-in ble.sh autocompletion

### DIFF
--- a/bin/omarchy-install-blesh
+++ b/bin/omarchy-install-blesh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# omarchy:summary=Install ble.sh for enhanced bash autocompletion and line editing
+
+echo "Installing ble.sh..."
+omarchy-pkg-aur-add blesh-git
+
+# Source ble.sh from the user's bashrc so interactive shells get syntax
+# highlighting, autosuggestions, and menu completion. The grep keeps this
+# idempotent across repeated runs.
+if ! grep -q 'share/blesh/ble.sh' ~/.bashrc 2>/dev/null; then
+  cat >>~/.bashrc <<'EOF'
+
+# Added by omarchy-install-blesh (https://github.com/akinomyoga/ble.sh)
+if [[ $- == *i* && -r /usr/share/blesh/ble.sh ]]; then
+  source /usr/share/blesh/ble.sh
+  ble-bind -f 'TAB' 'menu-complete'
+  ble-bind -f 'S-TAB' 'menu-complete backward'
+fi
+EOF
+fi
+
+echo "ble.sh installed. Restart your shell to activate it."


### PR DESCRIPTION
## Summary
- Add `omarchy install blesh` command that installs `blesh-git` from the AUR via `omarchy-pkg-aur-add` and sources ble.sh from the user's bashrc for enhanced autocompletion, syntax highlighting, and autosuggestions.
- Opt-in only: nothing changes for existing users unless they run the command.
- ble.sh replaces readline, so the snippet rebinds TAB / Shift-TAB to `menu-complete` to preserve Omarchy's inputrc TAB behavior.

## Why this shape
- `bash-completion` already ships in `omarchy-base.packages`, but ble.sh is AUR-only and that list is pacstrapped from the ISO's offline mirror with no AUR entries, so an install command using the AUR helper is the fitting route (same pattern as `omarchy-install-editor-emacs`).
- bashrc sourcing follows the idempotent-append precedent of `omarchy-install-editor-helix`.

## Testing
- [x] `./test/cli` — 116/116 pass
- [x] `omarchy install blesh --help` routes and renders correctly
- [x] bashrc-append block run twice against a temp HOME — single append, output passes `bash -n`