### PR TITLE
Add visual plugin marketplace browser

### DIFF
--- a/bin/omarchy-plugin-browse
+++ b/bin/omarchy-plugin-browse
@@ -7,6 +7,7 @@ set -euo pipefail
 
 catalog_url="https://plugins.omarchy.org/catalog.json"
 plugin_url="https://plugins.omarchy.org/plugin.html"
+preview_base_url="https://plugins.omarchy.org/"
 
 catalog=$(curl -fsSL --max-time 10 "$catalog_url" 2>/dev/null) || {
   omarchy-notification-send "Could not load the Omarchy plugin marketplace"
@@ -21,21 +22,60 @@ jq -e '.plugins | type == "array"' <<<"$catalog" >/dev/null || {
 installed=$(omarchy-plugin-list --json 2>/dev/null || printf '[]')
 jq -e 'type == "array"' <<<"$installed" >/dev/null || installed='[]'
 
-rows=$(jq -r --argjson installed "$installed" '
-  .plugins[]
-  | select((.sourceType // "community") == "community")
-  | select((.id // "") != "")
-  | . as $plugin
-  | "󰐱\t" + (.name // .id) + (if $installed | any(.id == $plugin.id) then " (installed)" else "" end) + "\t" + .id
+plugins=$(jq -c --argjson installed "$installed" --arg preview_base_url "$preview_base_url" '
+  def preview_url:
+    if . == "" then ""
+    elif startswith("http://") or startswith("https://") then .
+    else $preview_base_url + .
+    end;
+
+  [.plugins[]
+   | select((.sourceType // "community") == "community")
+   | select((.id // "") != "")
+   | . as $plugin
+   | . + {
+       installed: ($installed | any(.id == $plugin.id)),
+       previewPath: ((.previewImage // .previewThumbnail // "") | preview_url),
+       previewImages: (
+         ([.previewImage // empty]
+          + ((.previewImages // .previews // .screenshots // [])
+             | map(if type == "string" then . else (.url // .src // .path // "") end)))
+         | map(select(type == "string" and length > 0) | preview_url)
+         | unique
+       )
+     }]
 ' <<<"$catalog")
 
-if [[ -z $rows ]]; then
+if [[ $(jq 'length' <<<"$plugins") == "0" ]]; then
   omarchy-notification-send "No community plugins are currently listed"
   exit 0
 fi
 
-selection=$(omarchy-menu-select "Browse plugins" <<<"$rows") || exit 0
-id=$(cut -f2 <<<"$selection")
+selection_file=$(mktemp)
+done_file=$(mktemp)
+catalog_file=$(mktemp)
+printf '%s' "$plugins" >"$catalog_file"
+rm -f "$done_file"
+trap 'rm -f "$selection_file" "$done_file" "$catalog_file"' EXIT
+
+payload=$(jq -cn --arg catalog_file "$catalog_file" --arg selection_file "$selection_file" --arg done_file "$done_file" '{catalogFile: $catalog_file, selectionFile: $selection_file, doneFile: $done_file}')
+omarchy-shell shell summon omarchy.plugin-marketplace "$payload" >/dev/null || {
+  omarchy-notification-send "Could not open the Omarchy plugin marketplace"
+  exit 1
+}
+
+while [[ ! -e $done_file ]]; do
+  sleep 0.05
+done
+
+[[ -s $selection_file ]] || exit 0
+selection=$(<"$selection_file")
+action=${selection%%$'\t'*}
+id=${selection#*$'\t'}
+if [[ $action == "$selection" ]]; then
+  action="view"
+  id=$selection
+fi
 [[ -n $id ]] || exit 1
 
 plugin=$(jq -cer --arg id "$id" '.plugins[] | select(.id == $id)' <<<"$catalog") || {
@@ -51,7 +91,9 @@ else
   installed_plugin=false
 fi
 
-if [[ $installed_plugin == "true" ]]; then
+if [[ $action == "remove" && $installed_plugin == "true" ]]; then
+  omarchy-launch-floating-terminal-with-presentation "omarchy-plugin-remove $(printf '%q' "$id")"
+elif [[ $installed_plugin == "true" ]]; then
   omarchy-launch-webapp "$plugin_url?id=$(jq -rn --arg id "$id" '$id | @uri')"
 elif [[ $install_available == "true" && -n $repo ]]; then
   omarchy-launch-floating-terminal-with-presentation "omarchy-plugin-add $(printf '%q' "$repo")"

--- a/bin/omarchy-plugin-browse
+++ b/bin/omarchy-plugin-browse
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# omarchy:summary=Browse and install community shell plugins
+# omarchy:group=plugin
+
+set -euo pipefail
+
+catalog_url="https://plugins.omarchy.org/catalog.json"
+plugin_url="https://plugins.omarchy.org/plugin.html"
+
+catalog=$(curl -fsSL --max-time 10 "$catalog_url" 2>/dev/null) || {
+  omarchy-notification-send "Could not load the Omarchy plugin marketplace"
+  exit 1
+}
+
+jq -e '.plugins | type == "array"' <<<"$catalog" >/dev/null || {
+  omarchy-notification-send "The Omarchy plugin marketplace returned invalid data"
+  exit 1
+}
+
+installed=$(omarchy-plugin-list --json 2>/dev/null || printf '[]')
+jq -e 'type == "array"' <<<"$installed" >/dev/null || installed='[]'
+
+rows=$(jq -r --argjson installed "$installed" '
+  .plugins[]
+  | select((.sourceType // "community") == "community")
+  | select((.id // "") != "")
+  | . as $plugin
+  | "󰐱\t" + (.name // .id) + (if $installed | any(.id == $plugin.id) then " (installed)" else "" end) + "\t" + .id
+' <<<"$catalog")
+
+if [[ -z $rows ]]; then
+  omarchy-notification-send "No community plugins are currently listed"
+  exit 0
+fi
+
+selection=$(omarchy-menu-select "Browse plugins" <<<"$rows") || exit 0
+id=$(cut -f2 <<<"$selection")
+[[ -n $id ]] || exit 1
+
+plugin=$(jq -cer --arg id "$id" '.plugins[] | select(.id == $id)' <<<"$catalog") || {
+  omarchy-notification-send "That plugin is no longer in the marketplace"
+  exit 1
+}
+
+repo=$(jq -r '.repo // empty' <<<"$plugin")
+install_available=$(jq -r '.installAvailable // false' <<<"$plugin")
+if jq -e --arg id "$id" 'any(.[]; .id == $id)' <<<"$installed" >/dev/null; then
+  installed_plugin=true
+else
+  installed_plugin=false
+fi
+
+if [[ $installed_plugin == "true" ]]; then
+  omarchy-launch-webapp "$plugin_url?id=$(jq -rn --arg id "$id" '$id | @uri')"
+elif [[ $install_available == "true" && -n $repo ]]; then
+  omarchy-launch-floating-terminal-with-presentation "omarchy-plugin-add $(printf '%q' "$repo")"
+else
+  omarchy-launch-webapp "$plugin_url?id=$(jq -rn --arg id "$id" '$id | @uri')"
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -172,6 +172,7 @@
   "setup.default.editor.vim": {"icon":"","label":"Vim","checked":"[[ \"$(omarchy-default-editor)\" == \"vim\" ]]","action":"omarchy-default-editor vim"},
   "setup.default.editor.emacs": {"icon":"","label":"Emacs","checked":"[[ \"$(omarchy-default-editor)\" == \"emacs\" ]]","action":"omarchy-default-editor emacs"},
   "setup.plugin": {"icon":"󰐱","label":"Plugins","aliases":["plugin","plugins"]},
+  "setup.plugin.browse": {"icon":"󰈈","label":"Browse Marketplace","action":"omarchy-plugin-browse"},
   "setup.plugin.enable": {"icon":"󰄬","label":"Enable Plugin","action":"omarchy-menu-plugin enable"},
   "setup.plugin.disable": {"icon":"󰅖","label":"Disable Plugin","action":"omarchy-menu-plugin disable"},
   "setup.plugin.add": {"icon":"󰖟","label":"Add Plugin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-plugin-add'"},

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -172,7 +172,7 @@
   "setup.default.editor.vim": {"icon":"","label":"Vim","checked":"[[ \"$(omarchy-default-editor)\" == \"vim\" ]]","action":"omarchy-default-editor vim"},
   "setup.default.editor.emacs": {"icon":"","label":"Emacs","checked":"[[ \"$(omarchy-default-editor)\" == \"emacs\" ]]","action":"omarchy-default-editor emacs"},
   "setup.plugin": {"icon":"󰐱","label":"Plugins","aliases":["plugin","plugins"]},
-  "setup.plugin.browse": {"icon":"󰈈","label":"Browse Marketplace","action":"omarchy-plugin-browse"},
+  "setup.plugin.browse": {"icon":"󰏗","label":"Plugin Marketplace","action":"omarchy-plugin-browse"},
   "setup.plugin.enable": {"icon":"󰄬","label":"Enable Plugin","action":"omarchy-menu-plugin enable"},
   "setup.plugin.disable": {"icon":"󰅖","label":"Disable Plugin","action":"omarchy-menu-plugin disable"},
   "setup.plugin.add": {"icon":"󰖟","label":"Add Plugin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-plugin-add'"},

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -29,6 +29,16 @@ Enabled state is stored in `~/.config/omarchy/shell.json`, and the rule differs 
 
 A full bar plugin has no off state at all. There's always exactly one bar, so you replace it by enabling another one. Bar widget placement is covered in [the top bar](05-the-top-bar.md).
 
+## Finding community plugins
+
+Browse the community marketplace from Omarchy:
+
+```
+omarchy plugin browse
+```
+
+The native picker marks plugins you already have. Selecting an installable plugin opens the normal add flow, including the trust warning and confirmation; listings that need manual setup open their marketplace page instead. The full catalog is also available at [omarchyplugins.com](https://omarchyplugins.com).
+
 ## Adding a plugin from git
 
 A third-party plugin is just a git repo with a `manifest.json` at its root.

--- a/shell/plugins/plugin-marketplace/MarketplaceModel.js
+++ b/shell/plugins/plugin-marketplace/MarketplaceModel.js
@@ -1,0 +1,88 @@
+function cleaned(value) {
+  return String(value || "").replace(/^\s+|\s+$/g, "")
+}
+
+function textFor(plugin) {
+  return [plugin.name, plugin.id, plugin.description, plugin.author, plugin.category, plugin.kind]
+    .concat(Array.isArray(plugin.tags) ? plugin.tags : [])
+    .join(" ").toLowerCase()
+}
+
+function normalize(catalog, installedIds) {
+  var plugins = catalog && Array.isArray(catalog.plugins) ? catalog.plugins : []
+  var installed = {}
+  var ids = Array.isArray(installedIds) ? installedIds : []
+  for (var i = 0; i < ids.length; i++) installed[String(ids[i])] = true
+
+  var rows = []
+  for (var j = 0; j < plugins.length; j++) {
+    var source = plugins[j] || {}
+    if (String(source.sourceType || "community") !== "community" || !cleaned(source.id)) continue
+    rows.push({
+      id: cleaned(source.id), name: cleaned(source.name) || cleaned(source.id),
+      description: cleaned(source.description), author: cleaned(source.author),
+      version: cleaned(source.version), category: cleaned(source.category) || "Other",
+      kind: cleaned(source.kind) || "Plugin", tags: Array.isArray(source.tags) ? source.tags : [],
+      stars: Number(source.stars || 0), addedAt: cleaned(source.addedAt || source.listedAt),
+      installAvailable: source.installAvailable === true, installed: source.installed === true || !!installed[String(source.id)],
+      verified: String(source.verificationStatus || "") === "verified",
+      status: cleaned(source.status), license: cleaned(source.license), installNote: cleaned(source.installNote),
+      repo: cleaned(source.repo), previewPath: cleaned(source.previewPath),
+      previewImages: Array.isArray(source.previewImages) ? source.previewImages.map(cleaned).filter(function(path) { return path !== "" }) : [],
+      previewThumbnail: cleaned(source.previewThumbnail)
+    })
+  }
+  return rows
+}
+
+function options(plugins, key) {
+  var found = {}
+  for (var i = 0; i < plugins.length; i++) found[String(plugins[i][key] || "")] = true
+  return Object.keys(found).filter(function(value) { return value !== "" }).sort()
+}
+
+function score(plugin, query) {
+  var needle = cleaned(query).toLowerCase()
+  if (!needle) return 0
+  var name = plugin.name.toLowerCase()
+  var id = plugin.id.toLowerCase()
+  if (name === needle || id === needle) return 100
+  if (name.indexOf(needle) !== -1) return 60
+  if (id.indexOf(needle) !== -1) return 50
+  return textFor(plugin).indexOf(needle) !== -1 ? 10 : -1
+}
+
+function filtered(plugins, filters) {
+  var state = filters || {}
+  var result = []
+  for (var i = 0; i < plugins.length; i++) {
+    var plugin = plugins[i]
+    if (state.category && plugin.category !== state.category) continue
+    if (state.kind && plugin.kind !== state.kind) continue
+    if (state.installable && !plugin.installAvailable) continue
+    if (state.verified && !plugin.verified) continue
+    if (state.installed === "installed" && !plugin.installed) continue
+    if (state.installed === "available" && plugin.installed) continue
+    var relevance = score(plugin, state.query)
+    if (relevance < 0) continue
+    result.push({ plugin: plugin, relevance: relevance })
+  }
+  var sort = state.sort || "relevance"
+  result.sort(function(a, b) {
+    if (sort === "stars") return b.plugin.stars - a.plugin.stars || a.plugin.name.localeCompare(b.plugin.name)
+    if (sort === "newest") return String(b.plugin.addedAt).localeCompare(String(a.plugin.addedAt)) || a.plugin.name.localeCompare(b.plugin.name)
+    return b.relevance - a.relevance || a.plugin.name.localeCompare(b.plugin.name)
+  })
+  return result.map(function(row) { return row.plugin })
+}
+
+function badges(plugin) {
+  var values = []
+  if (plugin.installed) values.push("Installed")
+  else if (plugin.installAvailable) values.push("Installable")
+  else values.push("Manual setup")
+  if (plugin.verified) values.push("Verified")
+  return values
+}
+
+if (typeof module !== "undefined") module.exports = { normalize: normalize, options: options, filtered: filtered, badges: badges }

--- a/shell/plugins/plugin-marketplace/PluginMarketplace.qml
+++ b/shell/plugins/plugin-marketplace/PluginMarketplace.qml
@@ -1,0 +1,333 @@
+import Quickshell
+import Quickshell.Io
+import Quickshell.Wayland
+import QtQuick
+import QtQuick.Controls
+import qs.Commons
+import qs.Ui
+import "MarketplaceModel.js" as MarketplaceModel
+
+Item {
+  id: root
+
+  property bool opened: false
+  property string selectionFile: ""
+  property string doneFile: ""
+  property var plugins: []
+  property string query: ""
+  property string category: ""
+  property string kind: ""
+  property bool installable: false
+  property bool verified: false
+  property string installed: ""
+  property string sort: "relevance"
+  property int selectedIndex: 0
+  property int previewIndex: 0
+  property bool previewExpanded: false
+  property color background: Color.menu.background
+  property color foreground: Color.menu.text
+  property color border: Color.menu.border
+  property color scrim: Color.menu.scrim
+  property color accent: Color.accent
+
+  readonly property var visiblePlugins: MarketplaceModel.filtered(plugins, {
+    query: query, category: category, kind: kind, installable: installable,
+    verified: verified, installed: installed, sort: sort
+  })
+  readonly property var categoryOptions: MarketplaceModel.options(plugins, "category")
+  readonly property var kindOptions: MarketplaceModel.options(plugins, "kind")
+  readonly property var selectedPlugin: selectedIndex >= 0 && selectedIndex < visiblePlugins.length ? visiblePlugins[selectedIndex] : null
+  readonly property var selectedPreviewImages: selectedPlugin ? selectedPlugin.previewImages : []
+  readonly property string selectedPreview: selectedPreviewImages.length > 0 ? selectedPreviewImages[Math.max(0, Math.min(previewIndex, selectedPreviewImages.length - 1))] : (selectedPlugin ? selectedPlugin.previewPath : "")
+
+  function loadPlugins(value) {
+    var rows = Array.isArray(value) ? value : []
+    plugins = MarketplaceModel.normalize({ plugins: rows }, [])
+  }
+  function optionRows(values, allLabel) {
+    var rows = [{ value: "", label: allLabel }]
+    for (var index = 0; index < values.length; index++) {
+      rows.push({ value: values[index], label: values[index] })
+    }
+    return rows
+  }
+
+  FileView {
+    id: catalogFile
+    watchChanges: false
+    printErrors: false
+    onLoaded: {
+      try { root.loadPlugins(JSON.parse(text())) } catch (e) { root.loadPlugins([]) }
+    }
+  }
+  function open(payloadJson) {
+    var payload = {}
+    try { payload = JSON.parse(payloadJson || "{}") } catch (e) { payload = {} }
+    var catalogPath = String(payload.catalogFile || "")
+    if (catalogPath) {
+      catalogFile.path = catalogPath
+      catalogFile.reload()
+    } else {
+      root.loadPlugins(payload.plugins)
+    }
+    selectionFile = String(payload.selectionFile || "")
+    doneFile = String(payload.doneFile || "")
+    query = ""; category = ""; kind = ""; installable = false; verified = false; installed = ""; sort = "relevance"; selectedIndex = 0
+    opened = true
+    Qt.callLater(function() { search.forceActiveFocus() })
+  }
+
+  function close() { cancel() }
+  function cancel() {
+    var done = doneFile
+    selectionFile = ""; doneFile = ""; opened = false
+    if (done) result.command = ["bash", "-c", ": > " + Util.shellQuote(done)], result.running = true
+  }
+  function choose(action) {
+    if (!selectedPlugin || !selectionFile || !doneFile) return
+    var selected = selectedPlugin.id
+    var operation = String(action || "")
+    var file = selectionFile
+    var done = doneFile
+    selectionFile = ""; doneFile = ""; opened = false
+    result.command = ["bash", "-c", "printf '%s\\t%s\\n' " + Util.shellQuote(operation) + " " + Util.shellQuote(selected) + " > " + Util.shellQuote(file) + "; : > " + Util.shellQuote(done)]
+    result.running = true
+  }
+  function move(delta) {
+    if (visiblePlugins.length === 0) { selectedIndex = 0; return }
+    selectedIndex = Math.max(0, Math.min(visiblePlugins.length - 1, selectedIndex + delta))
+  }
+  function resetSelection() { selectedIndex = 0 }
+  function resetPreview() { previewIndex = 0; previewExpanded = false }
+  function previousPreview() {
+    if (selectedPreviewImages.length > 1) previewIndex = (previewIndex + selectedPreviewImages.length - 1) % selectedPreviewImages.length
+  }
+  function nextPreview() {
+    if (selectedPreviewImages.length > 1) previewIndex = (previewIndex + 1) % selectedPreviewImages.length
+  }
+
+  onQueryChanged: resetSelection()
+  onCategoryChanged: resetSelection()
+  onKindChanged: resetSelection()
+  onInstallableChanged: resetSelection()
+  onVerifiedChanged: resetSelection()
+  onInstalledChanged: resetSelection()
+  onSelectedIndexChanged: {
+    resetPreview()
+    list.currentIndex = selectedIndex
+  }
+
+  Process { id: result }
+
+  PanelWindow {
+    visible: root.opened
+    anchors { top: true; bottom: true; left: true; right: true }
+    color: "transparent"
+    WlrLayershell.namespace: "omarchy-plugin-marketplace"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+    exclusionMode: ExclusionMode.Ignore
+
+    Rectangle { anchors.fill: parent; color: root.scrim }
+    MouseArea { anchors.fill: parent; onClicked: root.cancel() }
+
+    BorderSurface {
+      id: card
+      anchors.centerIn: parent
+      width: Math.min(parent.width, Style.space(780))
+      height: Math.min(parent.height - Style.gapsOut * 2, Style.space(560))
+      color: root.background
+      borderSpec: Border.surfaceSpec("menu", "border", root.border, Math.max(1, Style.space(2)))
+      radius: Style.cornerRadius
+      padding: Style.spacing.panelPadding
+      MouseArea { anchors.fill: parent; onClicked: {} }
+
+      Keys.priority: Keys.BeforeItem
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Escape) { if (root.query) root.query = ""; else root.cancel(); event.accepted = true }
+        else if (event.key === Qt.Key_Down) { root.move(1); event.accepted = true }
+        else if (event.key === Qt.Key_Up) { root.move(-1); event.accepted = true }
+        else if (event.key === Qt.Key_Left) { root.previousPreview(); event.accepted = true }
+        else if (event.key === Qt.Key_Right) { root.nextPreview(); event.accepted = true }
+        else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { root.choose(); event.accepted = true }
+      }
+
+      Column {
+        anchors.fill: parent
+        anchors.topMargin: card.contentTopInset
+        anchors.rightMargin: card.contentRightInset
+        anchors.bottomMargin: card.contentBottomInset
+        anchors.leftMargin: card.contentLeftInset
+        spacing: Style.spacing.md
+        Text { text: "Plugin Marketplace"; color: root.foreground; font.family: Style.font.family; font.pixelSize: Style.font.title; font.bold: true }
+        TextField {
+          id: search
+          width: parent.width
+          placeholderText: "Search plugins, authors, categories, and tags"
+          text: root.query
+          onTextEdited: root.query = text
+          onAccepted: root.choose()
+        }
+        Row {
+          spacing: Style.spacing.sm
+          Dropdown { width: Style.space(150); showLabel: false; value: root.category; options: root.optionRows(root.categoryOptions, "All categories"); onChanged: function(value) { root.category = value } }
+          Dropdown { width: Style.space(140); showLabel: false; value: root.kind; options: root.optionRows(root.kindOptions, "All kinds"); onChanged: function(value) { root.kind = value } }
+          Button { text: "Installable"; selected: root.installable; onClicked: root.installable = !root.installable }
+          Button { text: "Verified"; selected: root.verified; onClicked: root.verified = !root.verified }
+          Dropdown { width: Style.space(130); showLabel: false; value: root.installed; options: [{value:"",label:"All plugins"},{value:"available",label:"Not installed"},{value:"installed",label:"Installed"}]; onChanged: function(value) { root.installed = value } }
+          Dropdown { width: Style.space(120); showLabel: false; value: root.sort; options: [{value:"relevance",label:"Relevance"},{value:"stars",label:"Most stars"},{value:"newest",label:"Newest"}]; onChanged: function(value) { root.sort = value } }
+        }
+        Row {
+          width: parent.width
+          height: parent.height - y
+          spacing: Style.spacing.md
+          ListView {
+            id: list
+            width: Math.round(parent.width * 0.45)
+            height: parent.height
+            model: root.visiblePlugins
+            clip: true
+            spacing: Style.spacing.xs
+            currentIndex: root.selectedIndex
+            onCurrentIndexChanged: if (currentIndex >= 0 && currentIndex !== root.selectedIndex) root.selectedIndex = currentIndex
+            delegate: Item {
+              required property var modelData
+              required property int index
+              width: list.width
+              height: Style.space(72)
+              id: pluginRow
+              property int rowIndex: index
+              Rectangle {
+                anchors.fill: parent
+                color: root.selectedIndex == pluginRow.rowIndex ? Util.alpha(root.accent, 0.50) : "transparent"
+                border.width: root.selectedIndex == pluginRow.rowIndex ? Math.max(1, Style.space(1)) : 0
+                border.color: root.accent
+                radius: Style.cornerRadius
+              }
+              Rectangle {
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                width: root.selectedIndex == pluginRow.rowIndex ? Style.space(5) : 0
+                color: root.accent
+                radius: Style.cornerRadius
+              }
+              Text {
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.rightMargin: Style.spacing.controlPaddingX
+                anchors.topMargin: Style.spacing.xs
+                visible: root.selectedIndex == pluginRow.rowIndex
+                text: "SELECTED"
+                color: root.accent
+                font.family: Style.font.family
+                font.pixelSize: Style.font.caption
+                font.bold: true
+              }
+              Text {
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.rightMargin: Style.spacing.controlPaddingX
+                anchors.bottomMargin: Style.spacing.xs
+                visible: modelData.installed
+                text: "INSTALLED"
+                color: root.accent
+                font.family: Style.font.family
+                font.pixelSize: Style.font.caption
+                font.bold: true
+              }
+              Column {
+                anchors.left: parent.left; anchors.right: parent.right; anchors.leftMargin: Style.spacing.controlPaddingX + (root.selectedIndex == pluginRow.rowIndex ? Style.space(5) : 0); anchors.rightMargin: modelData.installed ? Style.space(80) : Style.spacing.controlPaddingX; anchors.verticalCenter: parent.verticalCenter
+                Text { width: parent.width; text: modelData.name; textFormat: Text.PlainText; color: root.foreground; font.family: Style.font.family; font.pixelSize: Style.font.body; font.bold: true; elide: Text.ElideRight }
+                Text { width: parent.width; text: modelData.description || (modelData.kind + " · " + modelData.category); textFormat: Text.PlainText; color: Qt.darker(root.foreground, 1.35); font.family: Style.font.family; font.pixelSize: Style.font.caption; elide: Text.ElideRight }
+              }
+              MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                  var alreadySelected = root.selectedIndex == pluginRow.rowIndex
+                  root.selectedIndex = pluginRow.rowIndex
+                  if (alreadySelected) root.choose()
+                }
+              }
+            }
+          }
+          Rectangle { width: 1; height: parent.height; color: Util.alpha(root.border, 0.55) }
+          Item {
+            width: parent.width - list.width - Style.spacing.md * 2 - 1
+            height: parent.height
+            visible: !!root.selectedPlugin
+            Column {
+              anchors.fill: parent
+              spacing: Style.spacing.sm
+              Text { width: parent.width; text: root.selectedPlugin ? root.selectedPlugin.name : ""; textFormat: Text.PlainText; color: root.foreground; font.family: Style.font.family; font.pixelSize: Style.font.title; font.bold: true; elide: Text.ElideRight }
+              Item {
+                id: previewArea
+                width: parent.width
+                height: Style.space(240)
+                Image {
+                  id: preview
+                  anchors.fill: parent
+                  source: root.selectedPreview
+                  fillMode: Image.PreserveAspectFit
+                  visible: status === Image.Ready
+                }
+                Rectangle {
+                  anchors.fill: parent
+                  visible: !preview.visible
+                  color: Util.alpha(root.foreground, 0.06)
+                  Text { anchors.centerIn: parent; text: "No preview available"; color: Qt.darker(root.foreground, 1.4); font.family: Style.font.family }
+                }
+                MouseArea { anchors.fill: parent; enabled: preview.visible; cursorShape: Qt.PointingHandCursor; onClicked: root.previewExpanded = true }
+                Button { anchors.left: parent.left; anchors.verticalCenter: parent.verticalCenter; visible: root.selectedPreviewImages.length > 1; text: "‹"; onClicked: root.previousPreview() }
+                Button { anchors.right: parent.right; anchors.verticalCenter: parent.verticalCenter; visible: root.selectedPreviewImages.length > 1; text: "›"; onClicked: root.nextPreview() }
+                Text {
+                  anchors.horizontalCenter: parent.horizontalCenter; anchors.bottom: parent.bottom; anchors.bottomMargin: Style.spacing.xs
+                  visible: root.selectedPreviewImages.length > 1
+                  text: (root.previewIndex + 1) + " / " + root.selectedPreviewImages.length
+                  textFormat: Text.PlainText; color: root.foreground; font.family: Style.font.family; font.pixelSize: Style.font.caption
+                }
+              }
+              Text { width: parent.width; text: root.selectedPlugin ? root.selectedPlugin.description : ""; textFormat: Text.PlainText; color: root.foreground; font.family: Style.font.family; font.pixelSize: Style.font.body; wrapMode: Text.Wrap; maximumLineCount: 3; elide: Text.ElideRight }
+              Text { width: parent.width; text: root.selectedPlugin ? [root.selectedPlugin.kind, root.selectedPlugin.category, root.selectedPlugin.author && "by " + root.selectedPlugin.author, root.selectedPlugin.version && "v" + root.selectedPlugin.version, root.selectedPlugin.stars + " stars"].filter(Boolean).join(" · ") : ""; textFormat: Text.PlainText; color: Qt.darker(root.foreground, 1.35); font.family: Style.font.family; font.pixelSize: Style.font.caption; wrapMode: Text.Wrap }
+              Text { width: parent.width; text: root.selectedPlugin ? MarketplaceModel.badges(root.selectedPlugin).join(" · ") : ""; textFormat: Text.PlainText; color: root.accent; font.family: Style.font.family; font.pixelSize: Style.font.body; font.bold: true }
+              Button { text: root.selectedPlugin && root.selectedPlugin.installed ? "View details" : (root.selectedPlugin && root.selectedPlugin.installAvailable ? "Install plugin" : "View setup instructions"); bordered: true; onClicked: root.choose() }
+              Button { visible: root.selectedPlugin && root.selectedPlugin.installed; text: "Uninstall plugin"; onClicked: root.choose("remove") }
+            }
+          }
+        }
+      }
+    }
+    Rectangle {
+      anchors.fill: parent
+      visible: root.previewExpanded
+      color: root.scrim
+      z: 1
+      MouseArea { anchors.fill: parent; onClicked: root.previewExpanded = false }
+      BorderSurface {
+        anchors.centerIn: parent
+        width: Math.min(parent.width - Style.gapsOut * 2, Style.space(1120))
+        height: Math.min(parent.height - Style.gapsOut * 2, Style.space(760))
+        color: root.background
+        borderSpec: Border.surfaceSpec("menu", "border", root.border, Math.max(1, Style.space(2)))
+        radius: Style.cornerRadius
+        padding: Style.spacing.panelPadding
+        MouseArea { anchors.fill: parent; onClicked: {} }
+        Image {
+          id: expandedPreview
+          anchors.fill: parent
+          source: root.selectedPreview
+          fillMode: Image.PreserveAspectFit
+        }
+        Button { anchors.top: parent.top; anchors.right: parent.right; text: "Close"; onClicked: root.previewExpanded = false }
+        Button { anchors.left: parent.left; anchors.verticalCenter: parent.verticalCenter; visible: root.selectedPreviewImages.length > 1; text: "‹"; onClicked: root.previousPreview() }
+        Button { anchors.right: parent.right; anchors.verticalCenter: parent.verticalCenter; visible: root.selectedPreviewImages.length > 1; text: "›"; onClicked: root.nextPreview() }
+        Text {
+          anchors.horizontalCenter: parent.horizontalCenter; anchors.bottom: parent.bottom; anchors.bottomMargin: Style.spacing.sm
+          visible: root.selectedPreviewImages.length > 1
+          text: (root.previewIndex + 1) + " / " + root.selectedPreviewImages.length
+          textFormat: Text.PlainText; color: root.foreground; font.family: Style.font.family; font.pixelSize: Style.font.caption
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/plugin-marketplace/manifest.json
+++ b/shell/plugins/plugin-marketplace/manifest.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.plugin-marketplace",
+  "name": "Plugin marketplace",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Searchable community plugin marketplace with previews and metadata",
+  "kinds": ["overlay"],
+  "keepLoaded": true,
+  "entryPoints": {
+    "overlay": "PluginMarketplace.qml"
+  }
+}

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -343,8 +343,13 @@ assertEqual(
 )
 assertDeepEqual(
   defaultItems.filter(item => item.parent === 'setup.plugin').map(item => item.label),
-  ['Enable Plugin', 'Disable Plugin', 'Add Plugin', 'Clone Plugin', 'Remove Plugin'],
-  'menu manages plugins from Setup > Plugins'
+  ['Browse Marketplace', 'Enable Plugin', 'Disable Plugin', 'Add Plugin', 'Clone Plugin', 'Remove Plugin'],
+  'menu manages and browses plugins from Setup > Plugins'
+)
+assertEqual(
+  defaultById['setup.plugin.browse'].action,
+  'omarchy-plugin-browse',
+  'menu opens the native plugin marketplace browser'
 )
 assert(
   ['enable', 'disable', 'clone', 'remove'].every(

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -343,7 +343,7 @@ assertEqual(
 )
 assertDeepEqual(
   defaultItems.filter(item => item.parent === 'setup.plugin').map(item => item.label),
-  ['Browse Marketplace', 'Enable Plugin', 'Disable Plugin', 'Add Plugin', 'Clone Plugin', 'Remove Plugin'],
+  ['Plugin Marketplace', 'Enable Plugin', 'Disable Plugin', 'Add Plugin', 'Clone Plugin', 'Remove Plugin'],
   'menu manages and browses plugins from Setup > Plugins'
 )
 assertEqual(

--- a/test/shell.d/plugin-browse-test.sh
+++ b/test/shell.d/plugin-browse-test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+catalog_file="$test_tmp/catalog.json"
+selection_file="$test_tmp/selection"
+action_log="$test_tmp/actions"
+notification_log="$test_tmp/notifications"
+installed_file="$test_tmp/installed.json"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/curl" <<'SH'
+#!/bin/bash
+[[ ${OMARCHY_TEST_CURL_FAIL:-false} == "true" ]] && exit 1
+cat "$OMARCHY_TEST_CATALOG"
+SH
+
+cat >"$mock_bin/omarchy-menu-select" <<'SH'
+#!/bin/bash
+cat >"$OMARCHY_TEST_ROWS"
+cat "$OMARCHY_TEST_SELECTION"
+SH
+
+cat >"$mock_bin/omarchy-plugin-list" <<'SH'
+#!/bin/bash
+cat "$OMARCHY_TEST_INSTALLED"
+SH
+
+cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf 'terminal\0%s\0' "$@" >"$OMARCHY_TEST_ACTIONS"
+SH
+
+cat >"$mock_bin/omarchy-launch-webapp" <<'SH'
+#!/bin/bash
+printf 'webapp\0%s\0' "$@" >"$OMARCHY_TEST_ACTIONS"
+SH
+
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_NOTIFICATIONS"
+SH
+
+chmod +x "$mock_bin"/*
+export PATH="$mock_bin:$ROOT/bin:$PATH"
+export OMARCHY_TEST_CATALOG="$catalog_file"
+export OMARCHY_TEST_SELECTION="$selection_file"
+export OMARCHY_TEST_ROWS="$test_tmp/rows"
+export OMARCHY_TEST_ACTIONS="$action_log"
+export OMARCHY_TEST_NOTIFICATIONS="$notification_log"
+export OMARCHY_TEST_INSTALLED="$installed_file"
+printf '[]\n' >"$installed_file"
+
+cat >"$catalog_file" <<'JSON'
+{
+  "plugins": [
+    {
+      "id": "acme.clock",
+      "name": "Clock",
+      "repo": "https://github.com/acme/clock.git",
+      "sourceType": "community",
+      "installAvailable": true
+    },
+    {
+      "id": "acme.suite",
+      "name": "Desktop Suite",
+      "repo": "https://github.com/acme/suite.git",
+      "sourceType": "community",
+      "installAvailable": false
+    }
+  ]
+}
+JSON
+
+printf 'Clock\tacme.clock\n' >"$selection_file"
+omarchy-plugin-browse
+mapfile -d '' -t action <"$action_log"
+[[ ${action[0]} == "terminal" && ${action[1]} == "omarchy-plugin-add https://github.com/acme/clock.git" ]] ||
+  fail "plugin marketplace routes installable repositories through the guarded installer" "${action[*]}"
+grep -Fq $'󰐱\tClock\tacme.clock' "$test_tmp/rows" || fail "plugin marketplace lists community plugins in the native picker"
+pass "plugin marketplace browses and installs a community plugin"
+
+printf 'Desktop Suite\tacme.suite\n' >"$selection_file"
+omarchy-plugin-browse
+mapfile -d '' -t action <"$action_log"
+[[ ${action[0]} == "webapp" && ${action[1]} == "https://plugins.omarchy.org/plugin.html?id=acme.suite" ]] ||
+  fail "manual marketplace entries open their detail page" "${action[*]}"
+pass "manual marketplace entries open their detail page"
+
+printf '[{"id":"acme.clock"}]\n' >"$installed_file"
+printf 'Clock (installed)\tacme.clock\n' >"$selection_file"
+omarchy-plugin-browse
+mapfile -d '' -t action <"$action_log"
+[[ ${action[0]} == "webapp" && ${action[1]} == "https://plugins.omarchy.org/plugin.html?id=acme.clock" ]] ||
+  fail "installed marketplace entries open their detail page instead of reinstalling" "${action[*]}"
+grep -Fq $'󰐱\tClock (installed)\tacme.clock' "$test_tmp/rows" || fail "installed marketplace entries are marked in the picker"
+pass "installed marketplace entries are marked and not reinstalled"
+
+export OMARCHY_TEST_CURL_FAIL=true
+if omarchy-plugin-browse; then
+  fail "plugin marketplace reports a failed catalog request"
+fi
+grep -Fq "Could not load the Omarchy plugin marketplace" "$notification_log" || fail "plugin marketplace notifies on a failed catalog request"
+unset OMARCHY_TEST_CURL_FAIL
+
+printf '{"plugins":"broken"}\n' >"$catalog_file"
+if omarchy-plugin-browse; then
+  fail "plugin marketplace rejects malformed catalog data"
+fi
+grep -Fq "returned invalid data" "$notification_log" || fail "plugin marketplace notifies on malformed catalog data"
+pass "plugin marketplace handles catalog failures"

--- a/test/shell.d/plugin-browse-test.sh
+++ b/test/shell.d/plugin-browse-test.sh
@@ -9,27 +9,59 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 mock_bin="$test_tmp/bin"
 catalog_file="$test_tmp/catalog.json"
-selection_file="$test_tmp/selection"
 action_log="$test_tmp/actions"
 notification_log="$test_tmp/notifications"
 installed_file="$test_tmp/installed.json"
+payload_file="$test_tmp/marketplace-payload.json"
+catalog_payload_file="$test_tmp/marketplace-catalog.json"
+summon_log="$test_tmp/summon"
+curl_log="$test_tmp/curl"
+cache_dir="$test_tmp/cache"
 mkdir -p "$mock_bin"
 
 cat >"$mock_bin/curl" <<'SH'
 #!/bin/bash
-[[ ${OMARCHY_TEST_CURL_FAIL:-false} == "true" ]] && exit 1
-cat "$OMARCHY_TEST_CATALOG"
-SH
 
-cat >"$mock_bin/omarchy-menu-select" <<'SH'
-#!/bin/bash
-cat >"$OMARCHY_TEST_ROWS"
-cat "$OMARCHY_TEST_SELECTION"
+set -euo pipefail
+
+url="${!#}"
+if [[ $url == "https://plugins.omarchy.org/catalog.json" ]]; then
+  [[ ${OMARCHY_TEST_CURL_FAIL:-false} == "true" ]] && exit 1
+  cat "$OMARCHY_TEST_CATALOG"
+  exit 0
+fi
+
+printf '%s\n' "$url" >>"$OMARCHY_TEST_CURL_LOG"
+output=""
+for (( index = 1; index <= $#; index++ )); do
+  if [[ ${!index} == "-o" ]]; then
+    (( index++ ))
+    output=${!index}
+    break
+  fi
+done
+
+[[ -n $output ]] || exit 1
+mkdir -p "$(dirname -- "$output")"
+printf 'thumbnail for %s\n' "$url" >"$output"
 SH
 
 cat >"$mock_bin/omarchy-plugin-list" <<'SH'
 #!/bin/bash
 cat "$OMARCHY_TEST_INSTALLED"
+SH
+
+cat >"$mock_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+
+set -euo pipefail
+
+[[ $1 == "shell" && $2 == "summon" && $3 == "omarchy.plugin-marketplace" ]] || exit 1
+printf '%s\0' "$@" >"$OMARCHY_TEST_SUMMON"
+printf '%s' "$4" >"$OMARCHY_TEST_PAYLOAD"
+cat "$(jq -r '.catalogFile' <<<"$4")" >"$OMARCHY_TEST_CATALOG_PAYLOAD"
+printf '%s\t%s\n' "${OMARCHY_TEST_ACTION:-}" "$OMARCHY_TEST_SELECTED_ID" >"$(jq -r '.selectionFile' <<<"$4")"
+touch "$(jq -r '.doneFile' <<<"$4")"
 SH
 
 cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
@@ -49,9 +81,14 @@ SH
 
 chmod +x "$mock_bin"/*
 export PATH="$mock_bin:$ROOT/bin:$PATH"
+export XDG_CACHE_HOME="$cache_dir"
 export OMARCHY_TEST_CATALOG="$catalog_file"
-export OMARCHY_TEST_SELECTION="$selection_file"
-export OMARCHY_TEST_ROWS="$test_tmp/rows"
+export OMARCHY_TEST_SELECTED_ID="acme.clock"
+export OMARCHY_TEST_ACTION=""
+export OMARCHY_TEST_PAYLOAD="$payload_file"
+export OMARCHY_TEST_CATALOG_PAYLOAD="$catalog_payload_file"
+export OMARCHY_TEST_SUMMON="$summon_log"
+export OMARCHY_TEST_CURL_LOG="$curl_log"
 export OMARCHY_TEST_ACTIONS="$action_log"
 export OMARCHY_TEST_NOTIFICATIONS="$notification_log"
 export OMARCHY_TEST_INSTALLED="$installed_file"
@@ -65,7 +102,9 @@ cat >"$catalog_file" <<'JSON'
       "name": "Clock",
       "repo": "https://github.com/acme/clock.git",
       "sourceType": "community",
-      "installAvailable": true
+      "installAvailable": true,
+      "previewImage": "https://plugins.omarchy.org/previews/clock-detail.png",
+      "previewThumbnail": "https://plugins.omarchy.org/previews/clock.png"
     },
     {
       "id": "acme.suite",
@@ -73,34 +112,68 @@ cat >"$catalog_file" <<'JSON'
       "repo": "https://github.com/acme/suite.git",
       "sourceType": "community",
       "installAvailable": false
+    },
+    {
+      "id": "omarchy.builtin",
+      "name": "Built-in",
+      "sourceType": "builtin"
     }
   ]
 }
 JSON
 
-printf 'Clock\tacme.clock\n' >"$selection_file"
 omarchy-plugin-browse
 mapfile -d '' -t action <"$action_log"
 [[ ${action[0]} == "terminal" && ${action[1]} == "omarchy-plugin-add https://github.com/acme/clock.git" ]] ||
   fail "plugin marketplace routes installable repositories through the guarded installer" "${action[*]}"
-grep -Fq $'󰐱\tClock\tacme.clock' "$test_tmp/rows" || fail "plugin marketplace lists community plugins in the native picker"
-pass "plugin marketplace browses and installs a community plugin"
+mapfile -d '' -t summon <"$summon_log"
+[[ ${summon[0]} == "shell" && ${summon[1]} == "summon" && ${summon[2]} == "omarchy.plugin-marketplace" ]] ||
+  fail "plugin marketplace summons the native browser" "${summon[*]}"
 
-printf 'Desktop Suite\tacme.suite\n' >"$selection_file"
+jq -e --arg cache "$cache_dir" '
+  (.catalogFile | type == "string" and length > 0)
+  and (.selectionFile | type == "string" and length > 0)
+  and (.doneFile | type == "string" and length > 0)
+' "$payload_file" >/dev/null || fail "plugin marketplace receives catalog and IPC files"
+
+jq -e '
+  (length == 2)
+  and (map(.id) == ["acme.clock", "acme.suite"])
+  and (map(select(.id == "acme.clock")) | .[0].installed == false)
+  and (map(select(.id == "acme.suite")) | .[0].installed == false)
+  and (.[] | select(.id == "acme.clock") | .previewPath == "https://plugins.omarchy.org/previews/clock-detail.png")
+  and (.[] | select(.id == "acme.clock") | .previewImages == ["https://plugins.omarchy.org/previews/clock-detail.png"])
+  and (.[] | select(.id == "acme.suite") | .previewPath == "")
+  and (.[] | select(.id == "acme.suite") | .previewImages == [])
+' "$catalog_payload_file" >/dev/null || fail "plugin marketplace receives community catalog entries with installed state"
+
+pass "plugin marketplace summons the native browser with community catalog data"
+
+printf '[{"id":"acme.clock"}]\n' >"$installed_file"
+export OMARCHY_TEST_SELECTED_ID="acme.clock"
+omarchy-plugin-browse
+mapfile -d '' -t action <"$action_log"
+[[ ${action[0]} == "webapp" && ${action[1]} == "https://plugins.omarchy.org/plugin.html?id=acme.clock" ]] ||
+  fail "installed marketplace entries open their detail page instead of reinstalling" "${action[*]}"
+jq -e '.[] | select(.id == "acme.clock") | .installed == true' "$catalog_payload_file" >/dev/null ||
+  fail "plugin marketplace marks installed community plugins in its payload"
+pass "installed marketplace entries open their detail page"
+
+export OMARCHY_TEST_ACTION="remove"
+omarchy-plugin-browse
+mapfile -d '' -t action <"$action_log"
+[[ ${action[0]} == "terminal" && ${action[1]} == "omarchy-plugin-remove acme.clock" ]] ||
+  fail "installed marketplace entries route uninstalls through the guarded remover" "${action[*]}"
+pass "installed marketplace entries can be removed"
+export OMARCHY_TEST_ACTION=""
+
+printf '[]\n' >"$installed_file"
+export OMARCHY_TEST_SELECTED_ID="acme.suite"
 omarchy-plugin-browse
 mapfile -d '' -t action <"$action_log"
 [[ ${action[0]} == "webapp" && ${action[1]} == "https://plugins.omarchy.org/plugin.html?id=acme.suite" ]] ||
   fail "manual marketplace entries open their detail page" "${action[*]}"
 pass "manual marketplace entries open their detail page"
-
-printf '[{"id":"acme.clock"}]\n' >"$installed_file"
-printf 'Clock (installed)\tacme.clock\n' >"$selection_file"
-omarchy-plugin-browse
-mapfile -d '' -t action <"$action_log"
-[[ ${action[0]} == "webapp" && ${action[1]} == "https://plugins.omarchy.org/plugin.html?id=acme.clock" ]] ||
-  fail "installed marketplace entries open their detail page instead of reinstalling" "${action[*]}"
-grep -Fq $'󰐱\tClock (installed)\tacme.clock' "$test_tmp/rows" || fail "installed marketplace entries are marked in the picker"
-pass "installed marketplace entries are marked and not reinstalled"
 
 export OMARCHY_TEST_CURL_FAIL=true
 if omarchy-plugin-browse; then

--- a/test/shell.d/plugin-marketplace-model-test.sh
+++ b/test/shell.d/plugin-marketplace-model-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const marketplace = requireFromRoot('shell/plugins/plugin-marketplace/MarketplaceModel.js')
+
+const plugins = marketplace.normalize({ plugins: [
+  {
+    id: 'acme.clock', name: 'Clock', description: 'A focused desktop clock', author: 'Acme', category: 'Widgets', kind: 'Bar widget', tags: ['bar', 'time'], stars: 9, addedAt: '2026-02-01', installAvailable: true, verificationStatus: 'verified',
+    previewImages: ['https://plugins.omarchy.org/previews/clock-detail.png', 'https://plugins.omarchy.org/previews/clock-second.png']
+  },
+  { id: 'acme.menu', name: 'Quick Menu', description: 'Search programs', author: 'Acme', category: 'Menus', kind: 'Overlay', tags: ['launcher'], stars: 2, addedAt: '2026-03-01', installAvailable: false }
+]}, ['acme.clock'])
+
+assertEqual(plugins.length, 2, 'marketplace model keeps valid community plugins')
+assert(plugins[0].installed && plugins[0].verified, 'marketplace model combines installed and verified state')
+assertDeepEqual(plugins[0].previewImages, ['https://plugins.omarchy.org/previews/clock-detail.png', 'https://plugins.omarchy.org/previews/clock-second.png'], 'marketplace model preserves all preview images')
+assertDeepEqual(marketplace.options(plugins, 'category'), ['Menus', 'Widgets'], 'marketplace model exposes category filters')
+assertEqual(marketplace.filtered(plugins, { query: 'focused desktop', sort: 'relevance' })[0].id, 'acme.clock', 'marketplace model searches descriptions')
+assertEqual(marketplace.filtered(plugins, { category: 'Menus' })[0].id, 'acme.menu', 'marketplace model filters category')
+assertEqual(marketplace.filtered(plugins, { installable: true })[0].id, 'acme.clock', 'marketplace model filters installable plugins')
+assertEqual(marketplace.filtered(plugins, { installed: 'available' })[0].id, 'acme.menu', 'marketplace model filters installed state')
+assertEqual(marketplace.filtered(plugins, { sort: 'stars' })[0].id, 'acme.clock', 'marketplace model sorts by stars')
+assertDeepEqual(marketplace.badges(plugins[0]), ['Installed', 'Verified'], 'marketplace model labels installed verified plugins')
+JS


### PR DESCRIPTION
## Summary
- add a native Quickshell plugin marketplace overlay with search, filters, previews, and metadata
- route installing, viewing installed entries, and uninstalling through the existing plugin commands
- cover marketplace payloads, model behavior, and menu integration with shell tests

## Verification
- `bash -n bin/omarchy-plugin-browse test/shell.d/plugin-browse-test.sh test/shell.d/plugin-marketplace-model-test.sh`
- `node --check shell/plugins/plugin-marketplace/MarketplaceModel.js`
- `./test/shell.d/plugin-browse-test.sh`
- `./test/shell.d/plugin-marketplace-model-test.sh`
- `./test/shell.d/qml-text-format-test.sh`
- `bash test/shell.d/menu-test.sh`
- `./test/shell` *(fails on pre-existing/environment failures: bar icon geometry, config test, and missing `omarchy-pkgs` checkout checks)*

Generated with AFK