### PR TITLE
Add live-screen fallback for capture tools

### DIFF
--- a/bin/omarchy-capture-qr
+++ b/bin/omarchy-capture-qr
@@ -2,19 +2,19 @@
 
 # omarchy:summary=Decode a QR code from a screenshot region
 # omarchy:group=capture
-# omarchy:examples=omarchy capture qr
+# omarchy:args=[--no-freeze]
+# omarchy:examples=omarchy capture qr --no-freeze
 
 # Keep hyprpicker alive until after grim captures so the screenshot sees the
 # frozen overlay rather than live content shifting during teardown.
 cleanup_freeze() {
-  [[ -n $PID ]] && kill $PID 2>/dev/null
+  [[ -n $FREEZE_PID ]] && kill $FREEZE_PID 2>/dev/null
 }
 trap cleanup_freeze EXIT
 
-hyprpicker -r -z >/dev/null 2>&1 &
-PID=$!
-sleep .1
-SELECTION=$(slurp 2>/dev/null)
+REGION_ARGS=(region --keep-freeze)
+[[ ${1:-} == "--no-freeze" ]] && REGION_ARGS+=(--no-freeze)
+{ read -r FREEZE_PID; read -r SELECTION; } < <(omarchy-capture-region "${REGION_ARGS[@]}")
 
 [[ -z $SELECTION ]] && exit 0
 

--- a/bin/omarchy-capture-region
+++ b/bin/omarchy-capture-region
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# omarchy:summary=Pick a screen region over frozen screen content
-# omarchy:args=[region|windows|smart|fullscreen] [--keep-freeze] [--match-monitor] | --take-fullscreen | --take-window | --select-window <next|prev|left|right|up|down>
+# omarchy:summary=Pick a screen region
+# omarchy:args=[region|windows|smart|fullscreen] [--keep-freeze] [--no-freeze] [--match-monitor] | --take-fullscreen | --take-window | --select-window <next|prev|left|right|up|down>
 # omarchy:hidden=true
 
 # Prints the picked geometry in slurp's "X,Y WxH" format, or exits 1 when the
@@ -17,6 +17,8 @@
 #   --keep-freeze   leave the hyprpicker screen freeze running and print its
 #                   PID as the first output line (empty when no freeze was
 #                   started); the caller owns killing it
+#   --no-freeze     select live screen content without starting hyprpicker;
+#                   also available globally with OMARCHY_CAPTURE_FREEZE=false
 #   --match-monitor print "monitor:NAME" instead when the picked geometry
 #                   exactly matches a monitor
 
@@ -274,10 +276,16 @@ fi
 MODE=smart
 KEEP_FREEZE=false
 MATCH_MONITOR=false
+USE_FREEZE=true
+
+case ${OMARCHY_CAPTURE_FREEZE:-true} in
+0 | false | no | off) USE_FREEZE=false ;;
+esac
 
 for arg in "$@"; do
   case $arg in
   --keep-freeze) KEEP_FREEZE=true ;;
+  --no-freeze) USE_FREEZE=false ;;
   --match-monitor) MATCH_MONITOR=true ;;
   *) MODE=$arg ;;
   esac
@@ -304,6 +312,7 @@ pick() {
 
 FREEZE_PID=""
 freeze_screen() {
+  [[ $USE_FREEZE == true ]] || return
   hyprpicker -r -z >/dev/null 2>&1 &
   FREEZE_PID=$!
   sleep .1

--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -2,8 +2,8 @@
 
 # omarchy:summary=Take a screenshot
 # omarchy:group=capture
-# omarchy:args=[smart|region|windows|fullscreen] [slurp|copy|save] [--editor=<name>]
-# omarchy:examples=omarchy screenshot | omarchy capture screenshot region
+# omarchy:args=[smart|region|windows|fullscreen] [slurp|copy|save] [--editor=<name>] [--no-freeze]
+# omarchy:examples=omarchy screenshot | omarchy capture screenshot region | omarchy capture screenshot region --no-freeze
 # omarchy:aliases=omarchy screenshot
 
 [[ -f ~/.config/user-dirs.dirs ]] && source ~/.config/user-dirs.dirs
@@ -17,11 +17,18 @@ fi
 pkill slurp && exit 0
 
 SCREENSHOT_EDITOR="${OMARCHY_SCREENSHOT_EDITOR:-tensaku-edit}"
+USE_FREEZE=true
 
-# Parse --editor flag from any position
+case ${OMARCHY_CAPTURE_FREEZE:-true} in
+0 | false | no | off) USE_FREEZE=false ;;
+esac
+
+# Parse capture options from any position.
 ARGS=()
 for arg in "$@"; do
-  if [[ $arg == --editor=* ]]; then
+  if [[ $arg == "--no-freeze" ]]; then
+    USE_FREEZE=false
+  elif [[ $arg == --editor=* ]]; then
     SCREENSHOT_EDITOR="${arg#--editor=}"
   else
     ARGS+=("$arg")
@@ -39,7 +46,8 @@ PROCESSING="${2:-slurp}"
 # Software-composited cursors (Hyprland's fallback on GPUs without working
 # hardware cursors) are baked into the frames grim captures, so force
 # hardware cursors until after grim runs and restore the setting on exit.
-NO_HW_CURSORS=$(hyprctl getoption cursor:no_hardware_cursors -j | jq '.int')
+NO_HW_CURSORS=""
+CURSOR_SETTING_CHANGED=false
 
 set_no_hw_cursors() {
   hyprctl eval "hl.config({ cursor = { no_hardware_cursors = $1 } })" &>/dev/null ||
@@ -48,12 +56,19 @@ set_no_hw_cursors() {
 
 cleanup() {
   [[ -n $FREEZE_PID ]] && kill $FREEZE_PID 2>/dev/null
-  set_no_hw_cursors "$NO_HW_CURSORS"
+  [[ $CURSOR_SETTING_CHANGED == true ]] && set_no_hw_cursors "$NO_HW_CURSORS"
 }
 trap cleanup EXIT
 
-set_no_hw_cursors 0
-{ read -r FREEZE_PID; read -r SELECTION; } < <(omarchy-capture-region "$MODE" --keep-freeze)
+if [[ $USE_FREEZE == true ]]; then
+  NO_HW_CURSORS=$(hyprctl getoption cursor:no_hardware_cursors -j | jq '.int')
+  set_no_hw_cursors 0
+  CURSOR_SETTING_CHANGED=true
+fi
+
+REGION_ARGS=("$MODE" --keep-freeze)
+[[ $USE_FREEZE == false ]] && REGION_ARGS+=(--no-freeze)
+{ read -r FREEZE_PID; read -r SELECTION; } < <(omarchy-capture-region "${REGION_ARGS[@]}")
 
 [[ -z $SELECTION ]] && exit 0
 

--- a/bin/omarchy-capture-text
+++ b/bin/omarchy-capture-text
@@ -2,19 +2,19 @@
 
 # omarchy:summary=Extract text from a screenshot region with OCR
 # omarchy:group=capture
-# omarchy:examples=omarchy capture text
+# omarchy:args=[--no-freeze]
+# omarchy:examples=omarchy capture text --no-freeze
 
 # Keep hyprpicker alive until after grim captures so the screenshot sees the
 # frozen overlay rather than live content shifting during teardown.
 cleanup_freeze() {
-  [[ -n $PID ]] && kill $PID 2>/dev/null
+  [[ -n $FREEZE_PID ]] && kill $FREEZE_PID 2>/dev/null
 }
 trap cleanup_freeze EXIT
 
-hyprpicker -r -z >/dev/null 2>&1 &
-PID=$!
-sleep .1
-SELECTION=$(slurp 2>/dev/null)
+REGION_ARGS=(region --keep-freeze)
+[[ ${1:-} == "--no-freeze" ]] && REGION_ARGS+=(--no-freeze)
+{ read -r FREEZE_PID; read -r SELECTION; } < <(omarchy-capture-region "${REGION_ARGS[@]}")
 
 [[ -z $SELECTION ]] && exit 0
 

--- a/default/agents/skills/omarchy/capture.md
+++ b/default/agents/skills/omarchy/capture.md
@@ -10,12 +10,15 @@ omarchy screenshot                            # Interactive smart-region flow
 omarchy capture screenshot region             # Select a region
 omarchy capture screenshot windows            # Pick a window
 omarchy capture screenshot fullscreen save    # Full screen, straight to disk (no editor)
+omarchy capture screenshot region --no-freeze # Live picker for systems where screen freezing is unstable
 ```
 
 The first argument picks the mode (`smart|region|windows|fullscreen`), the
 second what happens with it (`slurp|copy|save`). `save` skips the annotation
 editor and prints the saved path. Screenshots land in the configured Pictures
 directory (override with `OMARCHY_SCREENSHOT_DIR`).
+
+Interactive captures freeze the screen with Hyprpicker by default. Pass `--no-freeze` to screenshot, text, or QR capture to select live content instead. Set `OMARCHY_CAPTURE_FREEZE=false` in the UWSM environment to make live capture the default when the frozen overlay is unstable with a GPU or compositor.
 
 ## Screen Recording
 

--- a/default/uwsm/default
+++ b/default/uwsm/default
@@ -13,5 +13,8 @@ export EDITOR="omarchy-launch-editor --inline"
 # Use a custom directory for screenshots (remember to make the directory!)
 # export OMARCHY_SCREENSHOT_DIR="$HOME/Pictures/Screenshots"
 
+# Use live content for screenshot, OCR, and QR selection if Hyprpicker screen freezing is unstable
+# export OMARCHY_CAPTURE_FREEZE=false
+
 # Use a custom directory for screenrecordings (remember to make the directory!)
 # export OMARCHY_SCREENRECORD_DIR="$HOME/Videos/Screencasts"

--- a/test/shell.d/capture-no-freeze-test.sh
+++ b/test/shell.d/capture-no-freeze-test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+picker_bin="$work/picker-bin"
+client_bin="$work/client-bin"
+mkdir -p "$picker_bin" "$client_bin" "$work/shots"
+
+cat > "$picker_bin/slurp" <<'SH'
+#!/bin/bash
+printf '1,2 30x40\n'
+SH
+
+cat > "$picker_bin/hyprpicker" <<'SH'
+#!/bin/bash
+printf 'hyprpicker\n' >> "$CAPTURE_CALLS"
+exec sleep 30
+SH
+
+chmod +x "$picker_bin/slurp" "$picker_bin/hyprpicker"
+
+CAPTURE_CALLS="$work/picker.calls" PATH="$picker_bin:$PATH" \
+  "$ROOT/bin/omarchy-capture-region" region > "$work/default.out"
+grep -qx '1,2 30x40' "$work/default.out" || fail "default capture returns the selection"
+grep -qx 'hyprpicker' "$work/picker.calls" || fail "default capture starts the frozen overlay"
+
+: > "$work/picker.calls"
+CAPTURE_CALLS="$work/picker.calls" PATH="$picker_bin:$PATH" \
+  "$ROOT/bin/omarchy-capture-region" region --no-freeze > "$work/flag.out"
+grep -qx '1,2 30x40' "$work/flag.out" || fail "no-freeze capture returns the selection"
+[[ ! -s $work/picker.calls ]] || fail "--no-freeze skips the frozen overlay"
+
+CAPTURE_CALLS="$work/picker.calls" OMARCHY_CAPTURE_FREEZE=false PATH="$picker_bin:$PATH" \
+  "$ROOT/bin/omarchy-capture-region" region > "$work/env.out"
+grep -qx '1,2 30x40' "$work/env.out" || fail "environment-safe capture returns the selection"
+[[ ! -s $work/picker.calls ]] || fail "OMARCHY_CAPTURE_FREEZE=false skips the frozen overlay"
+
+CAPTURE_CALLS="$work/picker.calls" PATH="$picker_bin:$PATH" \
+  "$ROOT/bin/omarchy-capture-region" region --keep-freeze --no-freeze > "$work/protocol.out"
+[[ $(sed -n '1p' "$work/protocol.out") == "" ]] || fail "safe keep-freeze protocol emits an empty PID"
+[[ $(sed -n '2p' "$work/protocol.out") == "1,2 30x40" ]] || fail "safe keep-freeze protocol preserves the selection"
+
+cat > "$client_bin/omarchy-capture-region" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >> "$CAPTURE_CALLS"
+printf '\n1,2 30x40\n'
+SH
+
+cat > "$client_bin/hyprctl" <<'SH'
+#!/bin/bash
+printf 'hyprctl %s\n' "$*" >> "$CAPTURE_CALLS"
+exit 1
+SH
+
+cat > "$client_bin/pkill" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat > "$client_bin/grim" <<'SH'
+#!/bin/bash
+printf 'image'
+SH
+
+cat > "$client_bin/tesseract" <<'SH'
+#!/bin/bash
+cat >/dev/null
+printf 'captured text\n'
+SH
+
+cat > "$client_bin/zbarimg" <<'SH'
+#!/bin/bash
+cat >/dev/null
+printf 'https://example.test\n'
+SH
+
+cat > "$client_bin/wl-copy" <<'SH'
+#!/bin/bash
+cat >/dev/null
+SH
+
+cat > "$client_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$client_bin"/*
+
+: > "$work/client.calls"
+CAPTURE_CALLS="$work/client.calls" OMARCHY_SCREENSHOT_DIR="$work/shots" PATH="$client_bin:$PATH" \
+  "$ROOT/bin/omarchy-capture-screenshot" region save --no-freeze >/dev/null
+grep -qx 'region --keep-freeze --no-freeze' "$work/client.calls" || fail "screenshot forwards --no-freeze"
+! grep -q '^hyprctl ' "$work/client.calls" || fail "safe screenshot does not change cursor rendering"
+
+: > "$work/client.calls"
+CAPTURE_CALLS="$work/client.calls" PATH="$client_bin:$PATH" \
+  "$ROOT/bin/omarchy-capture-text" --no-freeze
+grep -qx 'region --keep-freeze --no-freeze' "$work/client.calls" || fail "OCR forwards --no-freeze"
+
+: > "$work/client.calls"
+CAPTURE_CALLS="$work/client.calls" PATH="$client_bin:$PATH" \
+  "$ROOT/bin/omarchy-capture-qr" --no-freeze
+grep -qx 'region --keep-freeze --no-freeze' "$work/client.calls" || fail "QR capture forwards --no-freeze"
+
+pass "capture commands provide a live-screen fallback without changing defaults"


### PR DESCRIPTION
## What was wrong

Hyprpicker's frozen overlay (`-r -z`) can be unstable on some GPU/compositor combinations. On an RTX 4050 system, region capture repeatedly took Hyprland down in the Mesa GL texture path. Screenshot, OCR, and QR capture all unconditionally started the same overlay, so there was no supported recovery path.

Removing the freeze globally would regress stable region selection for systems where it works well.

## Fix

- add `--no-freeze` to screenshot, OCR, QR, and the shared region helper
- add `OMARCHY_CAPTURE_FREEZE=false` as a persistent opt-out
- preserve the frozen default and the region helper's two-line `--keep-freeze` protocol
- avoid temporary cursor-rendering mutations in screenshot safe mode
- route OCR and QR selection through the shared region helper
- document the setting in the capture skill and default UWSM environment

## Verification

- [x] `test/shell.d/capture-no-freeze-test.sh`
- [x] `./test/cli`
- [x] `bash -n` on all changed shell scripts and the new test
- [x] `git diff --check`
- [x] live fullscreen save through the new `--no-freeze` path; rendered output inspected
- [x] `./test/all` exercised the new test; unrelated baseline/environment failures remain in `config-test`, `launch-about-test`, `network-qr-test`, `snapper-test`, and `unowned-system-paths-test` (three require the separate `omarchy-pkgs` checkout; `network-qr-test` passes when invoked with Bash but is not executable; the roomy-window animation assertion fails in this live environment)

Related: #5506, #8797
