### PR TITLE
Fix explicit bar toggle states

### DIFF
--- a/bin/omarchy-toggle-bar
+++ b/bin/omarchy-toggle-bar
@@ -4,10 +4,28 @@
 # omarchy:args=[toggle|on|off]
 # omarchy:examples=omarchy toggle bar | omarchy toggle bar off | omarchy toggle bar on
 
-omarchy-toggle bar-off "${1:-toggle}"
+case "${1:-toggle}" in
+on)
+  flag_action=off
+  ;;
+off)
+  flag_action=on
+  ;;
+toggle)
+  flag_action=toggle
+  ;;
+*)
+  echo "Usage: omarchy-toggle-bar [toggle|on|off]" >&2
+  exit 1
+  ;;
+esac
 
 # The shell's watch on the toggles directory can miss flag changes that land in
 # quick succession, stranding the bar off screen until the shell restarts.
 # Nudge the bar to re-read the flag; quiet best-effort so the toggle still
 # works when the shell is not up.
-omarchy-shell -q omarchy.bar syncHidden
+if omarchy-toggle bar-off "$flag_action"; then
+  omarchy-shell -q omarchy.bar syncHidden
+else
+  exit 1
+fi

--- a/test/acceptance.d/session-test.sh
+++ b/test/acceptance.d/session-test.sh
@@ -30,16 +30,16 @@ wait_until "background layer is on screen" 30 layer_on_screen "omarchy-backgroun
 # Hiding parks the bar off-screen without unmapping its layer surface, and
 # revealing brings that same surface back on-screen.
 restore_bar_visibility() {
-  omarchy-toggle-bar off >/dev/null 2>&1 || true
+  omarchy-toggle-bar on >/dev/null 2>&1 || true
 }
 trap restore_bar_visibility EXIT
 
-omarchy-toggle-bar on
+omarchy-toggle-bar off
 wait_until "hidden bar layer stays mapped" 15 layer_present "omarchy-bar"
 wait_until "hidden bar layer parks off screen" 15 layer_off_screen "omarchy-bar"
 screenshot "success-bar-hidden"
 
-omarchy-toggle-bar off
+omarchy-toggle-bar on
 wait_until "revealed bar layer returns on screen" 15 layer_on_screen "omarchy-bar"
 screenshot "success-bar-revealed"
 trap - EXIT

--- a/test/shell.d/toggle-test.sh
+++ b/test/shell.d/toggle-test.sh
@@ -19,6 +19,18 @@ TMPDIR=$(mktemp -d)
 test_home="$TMPDIR/home"
 flag="$test_home/.local/state/omarchy/toggles/example"
 bar_flag="$test_home/.local/state/omarchy/toggles/bar-off"
+stub_bin="$TMPDIR/bin"
+ipc_log="$TMPDIR/ipc.log"
+
+mkdir -p "$stub_bin"
+cat >"$stub_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$IPC_LOG"
+SH
+chmod +x "$stub_bin/omarchy-shell"
+export IPC_LOG="$ipc_log"
+export PATH="$stub_bin:$PATH"
 
 HOME="$test_home" omarchy-toggle example on
 [[ -f $flag ]] || fail "generic toggle enables explicit on state"
@@ -40,14 +52,55 @@ HOME="$test_home" omarchy-toggle example toggle
 [[ ! -f $flag ]] || fail "generic toggle flips enabled state off"
 pass "generic toggle flips enabled state off"
 
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on enables bar-off toggle"
-pass "bar on enables bar-off toggle"
-
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on is idempotent"
-pass "bar on is idempotent"
+HOME="$test_home" omarchy-toggle-bar off
+[[ -f $bar_flag ]] || fail "bar off enables bar-off toggle"
+pass "bar off enables bar-off toggle"
 
 HOME="$test_home" omarchy-toggle-bar off
-[[ ! -f $bar_flag ]] || fail "bar off disables bar-off toggle"
-pass "bar off disables bar-off toggle"
+[[ -f $bar_flag ]] || fail "bar off is idempotent"
+pass "bar off is idempotent"
+
+HOME="$test_home" omarchy-toggle-bar on
+[[ ! -f $bar_flag ]] || fail "bar on disables bar-off toggle"
+pass "bar on disables bar-off toggle"
+
+HOME="$test_home" omarchy-toggle-bar on
+[[ ! -f $bar_flag ]] || fail "bar on is idempotent"
+pass "bar on is idempotent"
+
+HOME="$test_home" omarchy-toggle-bar
+[[ -f $bar_flag ]] || fail "bar default action hides a visible bar"
+pass "bar default action hides a visible bar"
+
+HOME="$test_home" omarchy-toggle-bar toggle
+[[ ! -f $bar_flag ]] || fail "bar explicit toggle reveals a hidden bar"
+pass "bar explicit toggle reveals a hidden bar"
+
+invalid_output="$TMPDIR/invalid.out"
+if HOME="$test_home" omarchy-toggle-bar invalid >"$invalid_output" 2>&1; then
+  fail "bar rejects an invalid action"
+fi
+grep -Fx 'Usage: omarchy-toggle-bar [toggle|on|off]' "$invalid_output" >/dev/null ||
+  fail "bar invalid action prints usage" "$(cat "$invalid_output")"
+[[ ! -f $bar_flag ]] || fail "bar invalid action preserves state"
+pass "bar rejects an invalid action without changing state"
+
+ipc_calls=$(wc -l <"$ipc_log")
+(( ipc_calls == 6 )) || fail "bar syncs hidden state after each successful action" "IPC calls: $ipc_calls"
+if grep -Fvx -- '-q omarchy.bar syncHidden' "$ipc_log" >/dev/null; then
+  fail "bar sends the expected hidden-state IPC call" "$(cat "$ipc_log")"
+fi
+pass "bar syncs hidden state after each successful action"
+
+cat >"$stub_bin/omarchy-toggle" <<'SH'
+#!/bin/bash
+
+exit 1
+SH
+chmod +x "$stub_bin/omarchy-toggle"
+if HOME="$test_home" omarchy-toggle-bar off >/dev/null 2>&1; then
+  fail "bar propagates a failed state change"
+fi
+ipc_calls=$(wc -l <"$ipc_log")
+(( ipc_calls == 6 )) || fail "bar skips hidden-state sync after a failed state change" "IPC calls: $ipc_calls"
+pass "bar propagates a failed state change without syncing"


### PR DESCRIPTION
`omarchy-toggle-bar` passed its user-facing `on` and `off` actions directly to `omarchy-toggle bar-off`.

That flag has inverted semantics: its presence means the bar is hidden. As a result, `omarchy toggle bar on` created `bar-off` and hid the bar, while `omarchy toggle bar off` removed it and revealed the bar.

Translate the public visibility actions before delegating:

- `on` disables `bar-off`
- `off` enables `bar-off`
- `toggle` continues to flip the flag normally

The wrapper now also rejects invalid actions before sending the shell IPC call and propagates a failed flag update instead of allowing the quiet IPC call to mask it.

The shell and graphical acceptance tests previously encoded the inverted behavior, so they now assert the public visibility contract.

## Manual verification

This was manually tested on the running desktop with the branch activated through `omarchy dev link`, exercising the real command router, persisted toggle state, Quickshell IPC, and Hyprland layer behavior.

Verified that:

- `omarchy toggle bar on` shows the bar and removes `bar-off`
- `omarchy toggle bar off` hides the bar and creates `bar-off`
- repeated `on` and `off` calls are idempotent
- default and explicit `toggle` work in both directions
- `Super + Shift + Space` continues to toggle the bar
- the hidden bar remains mapped off-screen and releases its reserved space
- revealing the bar returns it on-screen and restores its reserved space
- invalid input fails without changing the current visibility
- the original bar state was restored and the dev link was removed

No issues were observed during manual testing.

## Automated tests

- `bash test/shell.d/toggle-test.sh` — passed
- `./test/cli` — passed
- `bash -n test/acceptance.d/session-test.sh` — passed
- `./test/shell` — the updated toggle tests passed; the suite has one unrelated, independently reproducible failure in `launch-about-test.sh` (`a roomy window animates`)
- VM graphical acceptance was not run

Fixes #10044