### PR TITLE
Float LibreOffice file dialogs

### DIFF
--- a/default/hypr/apps/system.lua
+++ b/default/hypr/apps/system.lua
@@ -15,7 +15,7 @@ o.window(
 -- whatever the app that asked for it titled it.
 o.window("xdg-desktop-portal-gtk", { tag = "+floating-window" })
 o.window({
-  class = "(sublime_text|DesktopEditors|org.gnome.Nautilus)",
+  class = "(sublime_text|DesktopEditors|org.gnome.Nautilus|soffice|soffice.bin|libreoffice.*)",
   title = "^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)",
 }, { tag = "+floating-window" })
 

--- a/test/shell.d/libreoffice-dialog-rule-test.sh
+++ b/test/shell.d/libreoffice-dialog-rule-test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+rules="$ROOT/default/hypr/apps/system.lua"
+class_rule='class = "(sublime_text|DesktopEditors|org.gnome.Nautilus|soffice|soffice.bin|libreoffice.*)"'
+
+grep -F "$class_rule" "$rules" >/dev/null ||
+  fail "LibreOffice native file dialogs are covered by the floating dialog rule"
+
+grep -A2 -F "$class_rule" "$rules" | grep -F 'tag = "+floating-window"' >/dev/null ||
+  fail "LibreOffice native file dialogs receive the floating-window tag"
+
+pass "LibreOffice native file dialogs use the standard floating dialog treatment"


### PR DESCRIPTION
Summary

Extend Omarchy's existing floating file-dialog rule to cover LibreOffice native/VCL dialog classes ("soffice", "soffice.bin", and "libreoffice.*").

When LibreOffice does not use "xdg-desktop-portal-gtk", its Open/Save dialogs currently miss the "+floating-window" tag and can open at unconstrained height underneath the top bar.

The existing title filter stays in place, so normal Writer/Calc windows are not floated; only matching Open/Save/Choose dialogs receive the standard floating treatment.

Fixes #9393

Verification

- Regression test fails against the current "quattro" rule before the class expansion.
- "test/shell.d/libreoffice-dialog-rule-test.sh" passes with this change.
- "bash -n test/shell.d/libreoffice-dialog-rule-test.sh" passes.

Live LibreOffice/Hyprland UI verification was not available in this environment, so this PR does not claim a manual visual check.