### PR TITLE
bluetooth: register pairing agent and discover before pair/connect; fix usbcore autosuspend cmdline

### DIFF
--- a/bin/omarchy-bluetooth-device
+++ b/bin/omarchy-bluetooth-device
@@ -29,15 +29,40 @@ trust_device() {
   bluetoothctl trust "$address" >/dev/null 2>&1 || true
 }
 
+discover() {
+  # bluetoothctl refuses to touch an address it has never seen: pair and
+  # connect both fail with "Device not available" while the adapter has no
+  # cached record of the device. A short discovery pass fills the cache, so
+  # run one whenever the address is not already known.
+  if [[ $(timeout 2s bluetoothctl devices 2>/dev/null) != *"$address"* ]]; then
+    timeout 8s bluetoothctl --timeout 8 scan on >/dev/null 2>&1 || true
+  fi
+}
+
+pair_with_agent() {
+  # A bare `bluetoothctl pair` dies with AuthenticationCanceled as soon as the
+  # remote asks BlueZ to confirm the pairing: the request is published and
+  # nothing on the bus answers it unless some other client registered an agent
+  # first. Register one in the same invocation that issues the pair so this
+  # helper stays self-contained. Auto-confirming is correct for HID
+  # peripherals, whose pairing is Just Works with both sides generating the
+  # same passkey; no user interaction is needed.
+  discover
+  {
+    printf 'agent on\ndefault-agent\npair %s\nquit\n' "$address"
+  } | timeout 25s bluetoothctl >/dev/null 2>&1 || true
+}
+
 case "$action" in
   pair)
     power_on
-    timeout 20s bluetoothctl pair "$address" >/dev/null 2>&1 || true
+    pair_with_agent
     trust_device
     timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 || true
     ;;
   connect)
     power_on
+    discover
     trust_device
     timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 || true
     ;;

--- a/etc/limine-entry-tool.d/omarchy-defaults.conf
+++ b/etc/limine-entry-tool.d/omarchy-defaults.conf
@@ -2,6 +2,15 @@ TARGET_OS_NAME="Omarchy"
 
 KERNEL_CMDLINE[default]+=" quiet splash loglevel=0 systemd.show_status=false rd.udev.log_level=0 vt.global_cursor_default=0"
 
+# usbcore is built into the kernel image rather than shipped as a module, so
+# the `options usbcore autosuspend=-1` in etc/modprobe.d is never read on
+# these kernels (modprobe.d only feeds modprobe, and modprobe never handles a
+# built-in driver). Parameters for built-ins only take effect on the command
+# line, so carry the same autosuspend disable here; without it USB Bluetooth
+# dongles and other latency-sensitive devices fall asleep after a few seconds
+# of idle and drop their links mid-session.
+KERNEL_CMDLINE[default]+=" usbcore.autosuspend=-1"
+
 # Kernel 7.1 unpacks the initramfs asynchronously, which races /init: the
 # early /proc, /sys, /dev, and /run mounts fail while unpacking settles, so
 # plymouthd exits when it can't read /proc/cmdline and encrypted boots fall

--- a/etc/modprobe.d/omarchy-usb-autosuspend.conf
+++ b/etc/modprobe.d/omarchy-usb-autosuspend.conf
@@ -1,1 +1,5 @@
+# Omarchy's own kernels build usbcore into the image, where modprobe.d options
+# are never read; for those the kernel command line carries
+# usbcore.autosuspend=-1 via etc/limine-entry-tool.d/omarchy-defaults.conf.
+# This file covers custom kernels that build usbcore as a module instead.
 options usbcore autosuspend=-1


### PR DESCRIPTION
## Problem

Pairing Bluetooth HID peripherals (Apple Magic Mouse, Logitech MX Keys) from Omarchy always fails, and devices that previously worked start dropping.

Two separate bugs in the default pairing path:

### 1. `omarchy bluetooth device pair` fails with `AuthenticationCanceled`

`bin/omarchy-bluetooth-device` ran a bare `bluetoothctl pair` with **no agent registered** on the D-Bus session. HID peripherals use Just Works pairing: BlueZ publishes a confirmation request, and with no client having registered an agent, nothing answers — the pair fails with `org.bluez.Error.AuthenticationCanceled`. Reproduced repeatedly on a fresh Omarchy 4.0.2 install:

```
Failed to pair: org.bluez.Error.AuthenticationCanceled
```

Additionally, `pair` and `connect` failed with `Device ... not available` whenever the address was not already in the adapter's cache — `bluetoothctl` refuses to touch an address it has never seen, and nothing ran a discovery pass first.

### 2. `usbcore autosuspend=-1` in modprobe.d is a no-op on Omarchy kernels

`etc/modprobe.d/omarchy-usb-autosuspend.conf` ships `options usbcore autosuspend=-1`, but on Omarchy's kernels `usbcore` is **built into the kernel image** (`modinfo usbcore` → `filename: (builtin)`), so no modprobe invocation ever reads that option. The effective value stays the default `2` (seconds), and USB Bluetooth dongles fall asleep during idle and drop live links (observed: BT HID reconnect storm after ~2s idle, link death mid-session).

## Fix

- `bin/omarchy-bluetooth-device` — register and default an auto-confirming agent in the *same* `bluetoothctl` invocation that issues the pair (self-contained, no dependency on another client holding an agent), and run a short discovery pass before `pair`/`connect` when the address is not yet in the adapter cache.
- `etc/limine-entry-tool.d/omarchy-defaults.conf` — carry `usbcore.autosuspend=-1` on the default kernel command line, which is the only channel that works for built-in drivers. The modprobe.d file is kept (with a comment) for custom kernels that build `usbcore` as a module.

## Verification

- `./test/cli`: 116/116 pass, no regressions.
- Pairing flow reproduced on hardware before the fix (`AuthenticationCanceled`, `Device not available`), and the agent+discovery sequence verified against the live stack.

## Notes

The CLI metadata contract (`omarchy:group`, `omarchy:args`) and file layout are untouched.
