### PR TITLE
Show countdown progress on notifications

### DIFF
--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -1051,6 +1051,8 @@ Item {
               cornerRadius: service.cornerRadius
               fontFamily: service.shell && service.shell.bar ? service.shell.bar.fontFamily : ""
               glyph: cardSlot.glyph
+              remainingLifetime: cardSlot.remainingLifetime
+              showCountdown: cardSlot.lifetime > 0
 
               onCloseRequested: service.dismissPopup(cardSlot.index)
               onCardClicked: service.invokePopupDefault(cardSlot.index)

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -26,6 +26,8 @@ BorderSurface {
   property int urgency: 1
   property double timestamp: 0
   property int cornerRadius: 0
+  property real remainingLifetime: 1.0
+  property bool showCountdown: false
 
   // System monospace font injected by the container.
   property string fontFamily: ""
@@ -50,6 +52,7 @@ BorderSurface {
   readonly property color bodyColor: Qt.darker(Color.notifications.text, 1.15)
   readonly property color accentColor: urgency === 2 ? Color.urgent : (urgency === 0 ? dimColor : Color.notifications.countdown)
   readonly property var cardBorderSpec: Border.surfaceSpec("notifications", "border", Color.notifications.border, Math.max(1, Style.space(2)))
+  readonly property real countdownReservedHeight: showCountdown ? Style.space(12) : 0
 
   function sanitizeBody(s) {
     return NotificationLogic.sanitizeBody(s, app, appIcon)
@@ -66,7 +69,7 @@ BorderSurface {
   implicitWidth: Style.space(380)
   // Add vertical border insets so mainColumn (inset by border on top/left/right)
   // doesn't push content under the bottom edge.
-  implicitHeight: mainColumn.implicitHeight + borderTop + borderBottom
+  implicitHeight: mainColumn.implicitHeight + borderTop + borderBottom + countdownReservedHeight
   radius: cornerRadius
   color: Color.notifications.background
   borderSpec: cardBorderSpec
@@ -192,6 +195,29 @@ BorderSurface {
           maximumLineCount: 3
         }
       }
+    }
+  }
+
+  Rectangle {
+    id: countdownTrack
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    anchors.leftMargin: root.borderLeft + Style.space(8)
+    anchors.rightMargin: root.borderRight + Style.space(8)
+    anchors.bottomMargin: root.borderBottom + Style.space(4)
+    height: Style.space(4)
+    visible: root.showCountdown
+    radius: height / 2
+    color: Util.alpha(Color.notifications.countdown, 0.25)
+
+    Rectangle {
+      anchors.left: parent.left
+      anchors.top: parent.top
+      anchors.bottom: parent.bottom
+      width: parent.width * root.remainingLifetime
+      radius: height / 2
+      color: Color.notifications.countdown
     }
   }
 

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -144,6 +144,14 @@ assert(
   !/<br\/>/.test(cardQml),
   'the notification card does not rewrite newlines itself, which would leave tag syntax unchecked'
 )
+assert(
+  /readonly property real countdownReservedHeight: showCountdown \? Style\.space\(12\) : 0/.test(cardQml),
+  'timed notification cards reserve room for a countdown without padding persistent cards'
+)
+assert(
+  /id: countdownTrack[\s\S]{0,700}?visible: root\.showCountdown[\s\S]{0,700}?width: parent\.width \* root\.remainingLifetime/.test(cardQml),
+  'notification cards show a countdown whose fill tracks the remaining lifetime'
+)
 
 assertEqual(
   notifications.sanitizeBody('trailing <img src="http://host/z.png"', 'Slack', ''),
@@ -682,6 +690,10 @@ assert(
 assert(
   /onSummaryChanged: cardSlot\.remainingLifetime = 1\.0/.test(serviceQml),
   'notifications service restarts the countdown when a toast is updated under it'
+)
+assert(
+  /remainingLifetime: cardSlot\.remainingLifetime\s*\n\s*showCountdown: cardSlot\.lifetime > 0/.test(serviceQml),
+  'notifications service exposes timed popup progress to the notification card'
 )
 assert(
   /awk 1 \\"\$1\\"\/\*\.json 2>\/dev\/null \|\| true", "--", historyDir/.test(serviceQml),


### PR DESCRIPTION
## Summary

- show a themed countdown track beneath auto-expiring notification cards
- reuse the popup's existing `remainingLifetime` timer, including its pause-on-hover behavior
- keep persistent notifications unchanged, with no countdown or extra padding

## Why

Notifications currently disappear without showing how long remains to click them. This is especially noticeable for background agent completion alerts: the toast can avoid interrupting the current workspace, but the user has no visible indication of the click window.

The service already computes a normalized remaining lifetime every 50 ms. This change exposes that value to `NotificationCard` and renders it without introducing another timer or changing any expiry policy.

Related to #9361, which also suggested reusing the existing lifetime plumbing for a progress bar. This PR intentionally does not change critical-notification expiry.

## Before

![Notification without countdown](https://raw.githubusercontent.com/aissa-93/omarchy/pr-assets/notification-countdown-bar/before.webp)

## After

Captured two seconds into a five-second notification:

![Notification with countdown at roughly sixty percent](https://raw.githubusercontent.com/aissa-93/omarchy/pr-assets/notification-countdown-bar/after.webp)

## Verification

- `bash test/shell.d/notifications-test.sh`
- `bash test/shell.d/qml-text-format-test.sh`
- `git diff --check`
- live five-second notification: the fill depleted smoothly and was about 60% wide at two seconds
- live persistent critical notification: no bar and no additional bottom padding

`./test/all` was also run on the untouched `quattro` baseline. It has four unrelated local-environment failures: three packaging checks require a separate `omarchy-pkgs` checkout, and `launch-about-test.sh` reports `a roomy window animates` on this machine.
