### PR TITLE
Show active network adapter when ambiguous

### DIFF
--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -315,6 +315,21 @@ function wifiSectionTitle(wifiNetworks, index) {
   return ""
 }
 
+function shouldShowAdapter(devices, connectionType, wifiType, wiredType) {
+  var targetType
+  if (connectionType === "wifi") targetType = wifiType
+  else if (connectionType === "ethernet") targetType = wiredType
+  else return false
+
+  var values = Array.isArray(devices) ? devices : []
+  var count = 0
+  for (var i = 0; i < values.length; i++) {
+    if (values[i] && values[i].type === targetType) count++
+  }
+
+  return count > 1
+}
+
 // OWE (Enhanced Open) encrypts traffic without authenticating the user, so it
 // has no credentials to collect. The panel's lock is a credentials-required
 // affordance, so OWE should neither show it nor open its attached prompt.
@@ -389,6 +404,7 @@ if (typeof module !== "undefined") {
     wifiRow: wifiRow,
     sortWifiRows: sortWifiRows,
     wifiSectionTitle: wifiSectionTitle,
+    shouldShowAdapter: shouldShowAdapter,
     requiresCredentials: requiresCredentials,
     canForgetNetwork: canForgetNetwork,
     enterpriseConnectScript: enterpriseConnectScript,

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -70,6 +70,8 @@ Panel {
   readonly property var wifiDevice: findDevice(DeviceType.Wifi)
   readonly property var wifiNetworkObjects: wifiDevice && wifiDevice.networks ? wifiDevice.networks.values : []
   readonly property var connectedWifiNetwork: findConnectedWifiNetwork()
+  readonly property bool showAdapter: Model.shouldShowAdapter(
+    networkDevices, info.type, DeviceType.Wifi, DeviceType.Wired)
   property var wifiNetworks: []
   property bool scanning: false
   property bool wifiStationAvailable: false
@@ -1377,6 +1379,15 @@ Panel {
             text: root.info.gateway || "--"
             copyable: !!root.info.gateway
             tooltipText: "Copy gateway"
+          }
+
+          InfoLabel {
+            text: "Adapter"
+            visible: root.showAdapter
+          }
+          DetailValue {
+            text: root.info.iface || "--"
+            visible: root.showAdapter
           }
         }
       }

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -177,6 +177,40 @@ assertDeepEqual(rows.map(row => row.ssid), ['Connected', 'Known', 'Open'], 'netw
 assertEqual(network.wifiSectionTitle(rows, 0), 'KNOWN NETWORKS', 'network labels known wifi section')
 assertEqual(network.wifiSectionTitle(rows, 2), 'OTHER NETWORKS', 'network labels other wifi section')
 
+const wifiType = 2
+const wiredType = 1
+assertEqual(network.shouldShowAdapter([], 'wifi', wifiType, wiredType), false, 'network hides the adapter for no Wi-Fi devices')
+assertEqual(network.shouldShowAdapter([{ type: wifiType }], 'wifi', wifiType, wiredType), false, 'network hides the adapter for one Wi-Fi device')
+assertEqual(
+  network.shouldShowAdapter([{ type: wifiType }, { type: wifiType }], 'wifi', wifiType, wiredType),
+  true,
+  'network shows the adapter for multiple Wi-Fi devices'
+)
+assertEqual(
+  network.shouldShowAdapter([{ type: wifiType }, { type: wiredType }], 'wifi', wifiType, wiredType),
+  false,
+  'network ignores wired devices when deciding whether Wi-Fi is ambiguous'
+)
+assertEqual(
+  network.shouldShowAdapter([{ type: wiredType }, { type: wiredType }], 'ethernet', wifiType, wiredType),
+  true,
+  'network shows the adapter for multiple wired devices'
+)
+assertEqual(
+  network.shouldShowAdapter([{ type: wifiType }, { type: wifiType }], 'ethernet', wifiType, wiredType),
+  false,
+  'network ignores Wi-Fi devices when deciding whether Ethernet is ambiguous'
+)
+assertEqual(
+  network.shouldShowAdapter([{ type: wifiType }, { type: wiredType }], 'disconnected', wifiType, wiredType),
+  false,
+  'network hides adapter detail when disconnected'
+)
+assert(
+  /showAdapter: Model\.shouldShowAdapter\(\s*networkDevices, info\.type, DeviceType\.Wifi, DeviceType\.Wired\)/.test(panelSource),
+  'network wires adapter visibility to the tested model helper'
+)
+
 const wifiRow = network.wifiRow({ connected: true, known: true, name: 'Home', signalStrength: 0.8, security: 1 })
 assertDeepEqual(
   wifiRow,


### PR DESCRIPTION
## Summary

- Add an Adapter row to the network panel when the system has multiple adapters matching the active connection type.
- Show the interface reported by the active connection, such as `wlan0` or `enp5s0`.
- Support both Wi-Fi and Ethernet while keeping the row hidden when there is only one adapter of that type.

## Why

On systems with multiple Wi-Fi radios or multiple Ethernet adapters, the network panel does not currently identify which interface is carrying the active connection. Showing the interface only when the choice is ambiguous provides that information without adding noise for the common single-adapter case. A system with one Wi-Fi and one Ethernet adapter does not trigger the row because the panel already identifies the connection type.

## Testing

- `bash test/shell.d/network-test.sh`
- `qmllint shell/plugins/panels/network/Panel.qml`
- Manually verified with the user plugin override on a system with two Wi-Fi adapters
