### PR TITLE
Document how to tile the Steam window

### DIFF
--- a/manual/42-common-tweaks.md
+++ b/manual/42-common-tweaks.md
@@ -35,3 +35,13 @@ hl.config({
   },
 })
 ```
+
+### Tile the Steam window
+
+Omarchy floats every Steam window by default, so the client opens as a centered window instead of joining the tiling layout. If you'd rather the main window tile like any other app, add this to the bottom of `~/.config/hypr/hyprland.lua`:
+
+```
+o.window({ class = "steam", title = "Steam" }, { tile = true })
+```
+
+Window rules are applied top to bottom and the last match wins, so this re-tiles only the main client. Steam's login prompt, Friends List, Settings, and popup menus all keep floating.


### PR DESCRIPTION
Omarchy floats every window with the `steam` class, which also catches the main client. That's a deliberate default (`3c07b541`, "Good window defaults for gaming"), so this doesn't change it — it just documents the override for people who'd rather have the client tile.

The snippet is scoped to the main window only. Because rules are applied top to bottom with the last match winning, the login prompt, Friends List, Settings and Steam's popup menus all keep floating under the existing class-wide rule.

Verified on Omarchy 4.0.2, Hyprland 0.56.2, by restarting Steam under the rule and logging every window it opened:

| Window | Result |
| --- | --- |
| `Steam` (main) | tiles, 2024x1102 |
| `Sign in to Steam` | floats, 560x352 |
| `Friends List` | floats, 460x800 |
| `Steam Settings` | floats, 680x578 |

`hyprctl configerrors` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1jMTn5VHDD3gypSFJfYcD
