### PR TITLE
Cap how long the network speed test can run

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -72,16 +72,20 @@ traffic_worker() {
   local urls=("$@")
   local url_count=${#urls[@]}
   local idx=$RANDOM
+  # Bound each worker on its own clock. Losing the parent to a SIGKILL leaves
+  # these subshells reparented to init with no one left to signal them, so a
+  # ceiling that only lives in the sampling loop would never reach them.
+  local deadline=$((SECONDS + max_seconds))
   if [[ $direction == "down" ]]; then
-    while true; do
+    while (( SECONDS < deadline )); do
       url=${urls[$((idx % url_count))]}
-      curl -fsS -o /dev/null "$url" 2>/dev/null || return
+      curl -fsS -o /dev/null --max-time "$max_seconds" "$url" 2>/dev/null || return
       idx=$((idx + 1))
     done
   else
-    while true; do
+    while (( SECONDS < deadline )); do
       url=${urls[$((idx % url_count))]}
-      dd if=/dev/zero bs=1M count=64 2>/dev/null | curl -fsS -o /dev/null -X POST --data-binary @- "$url" 2>/dev/null || return
+      dd if=/dev/zero bs=1M count=64 2>/dev/null | curl -fsS -o /dev/null --max-time "$max_seconds" -X POST --data-binary @- "$url" 2>/dev/null || return
       idx=$((idx + 1))
     done
   fi

--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -10,6 +10,7 @@ direction="${1:-}"
 probe=1.1.1.1
 parallel=8
 url_count=3
+max_seconds=15
 
 case "$direction" in
   down | up)
@@ -105,8 +106,15 @@ any_alive() {
   return 1
 }
 
-while any_alive; do
+# The traffic workers loop until they're killed, so never depend on the caller
+# to stop them. A summoner that dies without signalling us would otherwise
+# leave the workers saturating the link -- and burning metered data -- for as
+# long as the machine stays online. The UI stops us well before this ceiling.
+elapsed=0
+
+while any_alive && (( elapsed < max_seconds )); do
   sleep 1
+  elapsed=$((elapsed + 1))
   rx_after=$(cat "/sys/class/net/$iface/statistics/rx_bytes")
   tx_after=$(cat "/sys/class/net/$iface/statistics/tx_bytes")
 
@@ -127,4 +135,6 @@ while any_alive; do
   tx_before=$tx_after
 done
 
-wait 2>/dev/null || true
+# Reaching the ceiling leaves the workers running, so let the EXIT trap stop
+# and reap them. Waiting on them here would block until they finished, which
+# is exactly what the ceiling exists to prevent.


### PR DESCRIPTION
Refs #8515, #6989.

## The problem

The traffic workers loop until something kills them:

```bash
parallel=8
traffic_worker() {
  while true; do
    curl -fsS -o /dev/null "$url" ...          # download: uncapped, repeats
    # upload: dd if=/dev/zero bs=1M count=64 | curl -X POST   → 64 MB per iteration, per worker
  done
}
while any_alive; do ... done                   # workers only exit if curl *fails*
```

Nothing in the script stops itself. The only thing that does is the panel's 5-second `phaseTimer` sending SIGTERM, and that path works correctly — a clean SIGTERM runs the EXIT trap and tears down all 17 descendants with zero orphans.

Everything else leaks, in one of two shapes:

1. **The script outlives its caller.** The shell restarts or crashes, the script is reparented, and nothing is left to signal it. It keeps sampling and keeps its workers fetching.
2. **The script dies outright.** Its eight worker subshells are reparented to init, where nothing can signal them either and `traffic_worker`'s loop simply never ends. This is the signature in #8515 — note that a forked bash subshell shares its parent's command line, so those "7 instances" in `ps` are workers, not separate runs.

Either way there's no overlay on screen to show for it, and on a metered connection it quietly drains the data plan.

## The fix

Two ceilings, because one doesn't reach both shapes:

- A cap on the sampling loop, for shape 1.
- A per-worker deadline plus `--max-time`, for shape 2 — a worker has to be able to stop itself without anyone to tell it to.

The UI still stops the test after a few seconds; these only bound the worst case.

The trailing `wait` goes too. It was redundant with the EXIT trap, and on the ceiling path the workers are still alive, so waiting there would block until they finished — exactly what the ceiling exists to prevent.

`elapsed=$((elapsed + 1))` rather than `(( elapsed++ ))` on purpose: under `set -e` the post-increment returns exit status 1 on the first iteration, since it yields the old value of `0`.

## Testing

Against a local endpoint rather than fast.com, so the repro costs no bandwidth — one line changed, `fast_urls` pointed at `http://127.0.0.1:8731/`.

Before, with the script SIGKILLed at 4s: 8 curls still running at +19s, and still going at 54s in a longer run.

After:

| Scenario | Result |
| --- | --- |
| SIGTERM at 4s (normal panel path) | exit 143, 0 workers, 3 samples |
| Script orphaned but alive | self-terminates at the cap, 0 workers, 15 samples |
| Script SIGKILLed, workers orphaned | 0 workers by +19s |
| `up` direction, SIGTERM at 4s | 0 workers, 3 samples |

`./test/all` shows the same 3 pre-existing failures as an untouched `quattro` checkout (`config`, `snapper`, `unowned-system-paths` — all environment-dependent), and no new ones.

Scope note: the unbounded traffic and both orphan shapes are reproduced directly, as above. I did not drive the real panel end-to-end, so I'm not claiming a specific QML teardown path as the trigger — these ceilings are a backstop that holds regardless of which one drops the signal, and they don't preclude fixing that race separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1jMTn5VHDD3gypSFJfYcD
