### PR TITLE
Avoid Baffin GPU hangs during screen recording

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -122,6 +122,14 @@ default_resolution() {
   fi
 }
 
+screenrecording_needs_cpu_encoder() {
+  # Radeon Pro 450/455/460 cards can hang their VCE 3.x encode ring and lose
+  # compositor VRAM when the ensuing GPU reset fails (#9555). The recorder's
+  # fallback cannot recover from a GPU that has already hung, so avoid starting
+  # hardware encoding on Baffin altogether.
+  LC_ALL=C lspci -Dn | grep -qE '[[:space:]]1002:67ef([[:space:]]|$)'
+}
+
 # Echoes "monitor:NAME" when the selection matches an entire monitor (prefer
 # -w <monitor> over a region capture — same kms backend, but no scaling math
 # and full native res), otherwise "region:WxH+X+Y". Returns non-zero if the
@@ -176,6 +184,11 @@ start_screenrecording() {
   local filename="$OUTPUT_DIR/screenrecording-$(date +'%Y-%m-%d_%H-%M-%S').mp4"
   local audio_devices=""
   local audio_args=()
+  local encoder_args=()
+
+  if screenrecording_needs_cpu_encoder; then
+    encoder_args=(-encoder cpu)
+  fi
 
   [[ $DESKTOP_AUDIO == "true" ]] && audio_devices+="default_output"
 
@@ -188,7 +201,7 @@ start_screenrecording() {
   [[ -n $audio_devices ]] && audio_args+=(-a "$audio_devices" -ac aac)
 
   echo "===== $(date '+%F %T') args: $* target: $target =====" >>"$LOG_FILE"
-  gpu-screen-recorder "${capture_args[@]}" -k auto -f 60 -fm cfr -fallback-cpu-encoding yes -o "$filename" "${audio_args[@]}" 2>>"$LOG_FILE" &
+  gpu-screen-recorder "${capture_args[@]}" "${encoder_args[@]}" -k auto -f 60 -fm cfr -fallback-cpu-encoding yes -o "$filename" "${audio_args[@]}" 2>>"$LOG_FILE" &
   local pid=$!
 
   while kill -0 $pid 2>/dev/null && [[ ! -f $filename ]]; do

--- a/test/shell.d/screenrecording-encoder-test.sh
+++ b/test/shell.d/screenrecording-encoder-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin" "$tmp_dir/Videos"
+
+cat >"$stub_bin/gpu-screen-recorder" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$@" >"$OMARCHY_TEST_RECORDER_ARGS"
+while (($#)); do
+  if [[ $1 == "-o" ]]; then
+    touch "$2"
+    break
+  fi
+  shift
+done
+SH
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+printf '%s\n' '[{"focused":true,"width":1920,"height":1080}]'
+SH
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$OMARCHY_TEST_PCI_DEVICES"
+SH
+
+for command in omarchy-hyprland-monitor-focused omarchy-shell omarchy-notification-send; do
+  cat >"$stub_bin/$command" <<'SH'
+#!/bin/bash
+
+[[ ${0##*/} == "omarchy-hyprland-monitor-focused" ]] && echo "eDP-1"
+SH
+done
+
+chmod +x "$stub_bin"/*
+
+export HOME="$tmp_dir"
+export PATH="$stub_bin:$PATH"
+export OMARCHY_SCREENRECORD_DIR="$tmp_dir/Videos"
+export OMARCHY_TEST_RECORDER_ARGS="$tmp_dir/recorder-args"
+
+run_recorder() {
+  rm -f "$OMARCHY_TEST_RECORDER_ARGS" "$tmp_dir"/Videos/*
+  OMARCHY_TEST_PCI_DEVICES="$1" "$ROOT/bin/omarchy-capture-screenrecording" --fullscreen
+  [[ -f $OMARCHY_TEST_RECORDER_ARGS ]] || fail "$2 did not start the recorder"
+}
+
+run_recorder $'0000:00:02.0 0300: 8086:191b (rev 06)\n0000:01:00.0 0300: 1002:67ef (rev c0)' "Baffin detection"
+grep -Fx -- "-encoder" "$OMARCHY_TEST_RECORDER_ARGS" >/dev/null &&
+  grep -Fx -- "cpu" "$OMARCHY_TEST_RECORDER_ARGS" >/dev/null ||
+  fail "Baffin forces CPU encoding"
+pass "Baffin forces CPU encoding"
+
+run_recorder "0000:01:00.0 0300: 1002:73df (rev c1)" "unaffected GPU detection"
+if grep -Fx -- "-encoder" "$OMARCHY_TEST_RECORDER_ARGS" >/dev/null; then
+  fail "unaffected GPUs preserve automatic encoder selection"
+fi
+pass "unaffected GPUs preserve automatic encoder selection"


### PR DESCRIPTION
## Problem

Hardware encoding on AMD Baffin (`1002:67ef`, Radeon Pro 450/455/460) can hang the VCE 3.x encode ring. The subsequent GPU reset can lose compositor VRAM, terminate the graphical session, and leave an unusable recording. `-fallback-cpu-encoding yes` cannot recover after the GPU has already hung.

Fixes #9555.

## Fix

Detect the affected PCI device before starting `gpu-screen-recorder` and select its existing CPU encoder. All other GPUs retain the current automatic encoder selection.

## Verification

- Added regression coverage for an Intel + Baffin hybrid system
- Added coverage confirming unaffected GPUs keep automatic selection
- `bash test/shell.d/screenrecording-encoder-test.sh`
- `./test/cli`
- `git diff --check`
- Recorded and visually inspected a 2880x1800, 60 fps H.264 capture on the affected MacBook Pro