### PR TITLE
Restore the presentation terminal after a shell restart

### DIFF
--- a/bin/omarchy-hyprland-window-restore-presentation
+++ b/bin/omarchy-hyprland-window-restore-presentation
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# omarchy:summary=Re-float and center Omarchy presentation terminals
+# omarchy:hidden=true
+
+# Menu actions launch `xdg-terminal-exec --app-id=org.omarchy.terminal` as a
+# floating 875x600 window (tag floating-window in default/hypr/apps/system.lua).
+# Those size/center rules are map-time only. Restarting the shell tears down
+# the bar's exclusive zone and can leave the still-open terminal 0-size,
+# off-screen, or on monitor -1: present in overviews, invisible on the desktop.
+# Re-apply the float treatment after the new shell is up.
+
+hypr_dispatch() {
+  local lua="$1"
+  shift
+  hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null 2>&1 || true
+}
+
+width=875
+height=600
+
+hyprctl clients -j 2>/dev/null |
+  jq -r '.[] | select((.class // "") == "org.omarchy.terminal" or (.initialClass // "") == "org.omarchy.terminal") | .address // empty' |
+  while read -r addr; do
+    [[ -n $addr ]] || continue
+    window="address:$addr"
+    hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"on\" })" setfloating on "$window"
+    hypr_dispatch "hl.dsp.window.resize({ window = \"$window\", x = $width, y = $height })" resizeactive exact "$width" "$height" "$window"
+    hypr_dispatch "hl.dsp.window.center({ window = \"$window\" })" centerwindow "$window"
+    hypr_dispatch "hl.dsp.focus({ window = \"$window\" })" focuswindow "$window"
+  done

--- a/bin/omarchy-restart-shell
+++ b/bin/omarchy-restart-shell
@@ -84,6 +84,11 @@ for (( attempt = 0; attempt < 20; attempt++ )); do
     # reappears on the new shell. Answered invitations have already exited
     # and been collected, so the glob no longer matches them.
     systemctl --user try-restart 'omarchy-*-invitation.service' 2>/dev/null || true
+
+    # Menu Update keeps a presentation terminal open across this restart.
+    # Re-apply float/size/center after exclusive zones return. Best-effort:
+    # no such window, or hyprctl unavailable over SSH, is not a failure.
+    omarchy-hyprland-window-restore-presentation >/dev/null 2>&1 || true
     exit 0
   fi
   sleep 0.1

--- a/test/shell.d/hyprland-window-restore-presentation-test.sh
+++ b/test/shell.d/hyprland-window-restore-presentation-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+hyprctl_log="$test_tmp/hyprctl.log"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "clients" ]]; then
+  printf '%s\n' "$OMARCHY_TEST_CLIENTS_JSON"
+else
+  printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+fi
+SH
+chmod +x "$mock_bin/hyprctl"
+
+run_restore() {
+  : >"$hyprctl_log"
+  PATH="$mock_bin:$PATH" HYPRCTL_LOG="$hyprctl_log" \
+    OMARCHY_TEST_CLIENTS_JSON="$1" \
+    bash "$ROOT/bin/omarchy-hyprland-window-restore-presentation"
+}
+
+run_restore '[]'
+[[ ! -s $hyprctl_log ]] || fail "restore is a no-op when no presentation terminal exists" "$(cat "$hyprctl_log")"
+pass "restore is a no-op when no presentation terminal exists"
+
+run_restore '[{"address":"0xabc","class":"org.omarchy.terminal","initialClass":"org.omarchy.terminal"}]'
+expected="$test_tmp/expected.log"
+cat >"$expected" <<'EOF'
+dispatch hl.dsp.window.float({ window = "address:0xabc", action = "on" })
+dispatch hl.dsp.window.resize({ window = "address:0xabc", x = 875, y = 600 })
+dispatch hl.dsp.window.center({ window = "address:0xabc" })
+dispatch hl.dsp.focus({ window = "address:0xabc" })
+EOF
+diff -u "$expected" "$hyprctl_log" || fail "restore re-applies float, size, center, and focus" "$(diff -u "$expected" "$hyprctl_log")"
+pass "restore re-applies float, size, center, and focus"
+
+run_restore '[{"address":"0xdef","class":"foot","initialClass":"org.omarchy.terminal"}]'
+grep -F 'window = "address:0xdef"' "$hyprctl_log" >/dev/null || fail "restore matches initialClass"
+pass "restore matches presentation terminals by initialClass"
+
+run_restore '[{"address":"0xfoot","class":"foot","initialClass":"foot"}]'
+[[ ! -s $hyprctl_log ]] || fail "restore ignores ordinary terminals" "$(cat "$hyprctl_log")"
+pass "restore ignores ordinary terminals"


### PR DESCRIPTION
Fixes #10128.

Menu Update (and other presentation-terminal actions) keep `org.omarchy.terminal` open across `omarchy-restart-shell`. Killing the bar drops its exclusive zone, and the map-time `float` / `size` / `center` rules on tag `floating-window` do not re-run. The window can go 0-size or off-screen: still listed in overviews, invisible on the desktop, so `Done! Press any key` is never seen.

This re-applies float, 875×600, center, and focus to any `org.omarchy.terminal` client once the new shell answers ping.

## Test plan

- [x] `bash test/shell.d/hyprland-window-restore-presentation-test.sh`
- [x] `bash test/shell.d/restart-shell-test.sh`
- [x] Live: launch `foot --app-id=org.omarchy.terminal --title=Omarchy`, move it to `(-4000, 0)`, run `omarchy-hyprland-window-restore-presentation` — window returned to a centered 875×600 float