### PR TITLE
Re-arm the lock screen's blank timer from any input while locked

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -36,6 +36,8 @@ Item {
 
   readonly property bool locked: lockRequested || sessionLock.locked || sessionLock.secure
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
+  readonly property bool blankArmed: idleBlankTimer.running
+  readonly property alias activityMonitor: activityMonitor
 
   function realScreenCount() {
     var screens = Quickshell.screens || []
@@ -171,6 +173,19 @@ Item {
 
   function runBlank() {
     if (!blankProcess.running) blankProcess.running = true
+  }
+
+  // Input the lock surface never sees still lights the display: Hyprland wakes
+  // DPMS itself on a single pointer count or key press, and no `wakeRequested`
+  // follows, so the spent one-shot blank timer stays spent and the panel is
+  // left on until someone touches the machine. The idle protocol reports every
+  // input, so re-arm from it while locked.
+  function handleActivityResumed() {
+    if (!lockRequested || authenticatingPassword) return
+    // Input the lock surface saw has re-armed the timer already; only the
+    // input it never saw is worth a line in the journal.
+    if (!idleBlankTimer.running) logEvent("blank-rearmed: activity")
+    armBlankTimer()
   }
 
   function submitPassword(value) {
@@ -360,6 +375,20 @@ Item {
     onTriggered: root.startFingerprint()
   }
 
+  IdleMonitor {
+    id: activityMonitor
+    enabled: root.lockRequested
+    // Shorter than the blank countdown, so the monitor is already idle by the
+    // time the display goes dark and the next input is a transition it reports.
+    timeout: 1
+    // A monitor that respects inhibitors is paused while one is held, so it
+    // never reaches idle and never sees the next input as a transition -- and
+    // an inhibitor appearing counts as a resume in its own right. Only real
+    // input belongs here.
+    respectInhibitors: false
+    onIsIdleChanged: if (!isIdle) root.handleActivityResumed()
+  }
+
   Process {
     id: readlinkProc
     command: ["readlink", "-f", root.currentBackgroundLink]
@@ -409,6 +438,7 @@ Item {
   Process {
     id: blankProcess
     command: ["bash", "-c", "omarchy-brightness-keyboard off; omarchy-brightness-display off"]
+    onStarted: root.logEvent("blank-started")
   }
 
   Timer {
@@ -531,6 +561,8 @@ Item {
         passwordPam: root.passwordPamConfigured,
         fingerprint: root.fingerprintConfigured,
         authenticating: root.authenticating,
+        blankArmed: root.blankArmed,
+        activityIdle: root.activityMonitor.isIdle,
         lastEvent: root.lastEvent,
         lastEventAt: root.lastEventAt
       })

--- a/test/shell.d/fixtures/lock-activity-reblank/shell.qml
+++ b/test/shell.d/fixtures/lock-activity-reblank/shell.qml
@@ -1,0 +1,148 @@
+import QtQuick
+import Quickshell
+import qs.Commons
+
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  readonly property string rootPath: Quickshell.env("OMARCHY_PATH")
+  property var failures: []
+
+  function fail(message) {
+    failures.push(String(message))
+  }
+
+  function assertTrue(condition, message) {
+    if (!condition) fail(message)
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    var payload = JSON.stringify({
+      ok: failures.length === 0,
+      failures: failures
+    })
+
+    if (resultPath) {
+      Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+    }
+  }
+
+  Item { id: host }
+
+  property var lock: null
+  property string lastLoggedBeforeGate: ""
+  property int blankPolls: 0
+
+  Timer {
+    interval: 1
+    running: true
+    repeat: false
+    onTriggered: {
+      try {
+        // Load the real lock service. shell: null is fine here -- the parts of
+        // Service.qml this fixture exercises (activity re-arm, blank timer,
+        // status) never reach into shell.
+        var component = Qt.createComponent("file://" + root.rootPath + "/shell/plugins/lock/Service.qml", Component.PreferSynchronous)
+        if (component.status !== Component.Ready) {
+          root.fail("lock service failed to load: " + component.errorString())
+          root.writeResult()
+          return
+        }
+
+        var lock = component.createObject(host, { shell: null, omarchyPath: root.rootPath })
+        if (!lock) {
+          root.fail("lock service failed to instantiate: " + component.errorString())
+          root.writeResult()
+          return
+        }
+        root.lock = lock
+
+        // 1. Freshly instantiated and unlocked: the activity monitor is off and
+        // nothing has armed the blank timer.
+        root.assertTrue(lock.activityMonitor.enabled === false, "activity monitor is disabled before any lock is requested")
+        root.assertTrue(lock.blankArmed === false, "blank timer is not armed before any lock is requested")
+        root.assertTrue(lock.activityMonitor.respectInhibitors === false,
+          "inhibitors are not activity: a background video taking one is what lit the panel in #9152")
+        root.assertTrue(lock.activityMonitor.timeout < 5,
+          "activity monitor's idle timeout is shorter than the blank countdown, got " + lock.activityMonitor.timeout)
+
+        // 2. beginLock() would take a real session lock, which this fixture must
+        // never do. Set lockRequested directly instead -- it is exactly the state
+        // beginLock() leaves behind, without the WlSessionLock side effect. Doing
+        // it this way also proves the bug this test guards: lockRequested alone
+        // does not arm the timer, only beginLock() does, so a lock that reaches
+        // this state through a real session lock and then goes idle is "lit and
+        // spent" until something re-arms it.
+        lock.lockRequested = true
+        root.assertTrue(lock.activityMonitor.enabled === true, "activity monitor turns on once a lock is requested")
+        root.assertTrue(lock.blankArmed === false, "setting lockRequested directly does not arm the blank timer")
+
+        // 3. Raw input activity (an IdleMonitor transition) re-arms it and logs
+        // the re-arm.
+        lock.handleActivityResumed()
+        root.assertTrue(lock.lastEvent === "blank-rearmed: activity",
+          "activity re-arm is logged, got " + lock.lastEvent)
+        root.assertTrue(lock.blankArmed === true, "activity re-arm arms the blank timer")
+
+        // 4. A password check in flight must never be interrupted by a re-arm.
+        lock.authenticatingPassword = true
+        root.assertTrue(lock.blankArmed === false, "starting a password check stops the blank timer")
+        root.lastLoggedBeforeGate = lock.lastEvent
+
+        lock.handleActivityResumed()
+        root.assertTrue(lock.blankArmed === false, "activity during a password check does not re-arm the blank timer")
+        root.assertTrue(lock.lastEvent === root.lastLoggedBeforeGate,
+          "activity during a password check is not logged as a re-arm, got " + lock.lastEvent)
+
+        lock.authenticatingPassword = false
+        root.assertTrue(lock.blankArmed === true, "clearing the password check re-arms the blank timer")
+
+        // 5. Let the re-armed 5000 ms timer run out for real and spawn the blank.
+        // This races real input in the live session: any mouse motion or key
+        // press re-arms the timer again (silently this time, since it is
+        // already running), which is correct behaviour but can keep pushing
+        // the deadline out, so give this a generous budget.
+        blankPollTimer.start()
+      } catch (error) {
+        root.fail("lock activity reblank fixture threw: " + error)
+        root.writeResult()
+      }
+    }
+  }
+
+  Timer {
+    id: blankPollTimer
+    interval: 50
+    repeat: true
+    onTriggered: {
+      root.blankPolls++
+      var lock = root.lock
+
+      if (lock.lastEvent !== "blank-started" && root.blankPolls < 400) return
+
+      stop()
+
+      root.assertTrue(lock.lastEvent === "blank-started",
+        "the re-armed timer spawns the blank within 20s, got " + lock.lastEvent)
+      root.assertTrue(lock.blankArmed === false, "the blank timer is spent once it has fired")
+
+      // 6. Unlocking turns the monitor back off, and activity after that point
+      // must never re-arm anything.
+      lock.lockRequested = false
+      root.assertTrue(lock.activityMonitor.enabled === false, "activity monitor turns back off once the lock is released")
+
+      lock.handleActivityResumed()
+      root.assertTrue(lock.blankArmed === false, "activity while unlocked never arms the blank timer")
+      root.assertTrue(lock.lastEvent === "blank-started",
+        "activity while unlocked is not logged as a re-arm, got " + lock.lastEvent)
+
+      lock.destroy()
+      root.writeResult()
+    }
+  }
+}

--- a/test/shell.d/lock-activity-reblank-test.sh
+++ b/test/shell.d/lock-activity-reblank-test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+
+// The compositor part of this file is skipped on headless machines, so pin
+// the activity monitor's wiring here too: enabled only while locked, real
+// input only (inhibitors do not count as idle), and every resume re-arms
+// the blank.
+assert(
+  /IdleMonitor \{[\s\S]*?id: activityMonitor[\s\S]*?enabled: root\.lockRequested[\s\S]*?respectInhibitors: false[\s\S]*?onIsIdleChanged: if \(!isIdle\) root\.handleActivityResumed\(\)/.test(serviceQml),
+  'the activity monitor is enabled while locked, ignores inhibitors, and re-arms the blank on every resume'
+)
+
+assert(
+  /Process \{\s*id: blankProcess[\s\S]*?onStarted: root\.logEvent\("blank-started"\)/.test(serviceQml),
+  'the blank process logs its own start'
+)
+JS
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "lock activity reblank test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping lock activity reblank test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+blank_marker="$TMPDIR/blank-called"
+config_dir="$TMPDIR/lock-activity-reblank"
+fake_bin="$TMPDIR/bin"
+mkdir -p "$config_dir" "$TMPDIR/home" "$fake_bin"
+cp "$SHELL_TEST_DIR/fixtures/lock-activity-reblank/shell.qml" "$config_dir/shell.qml"
+ln -s "$ROOT/shell/Ui" "$config_dir/Ui"
+ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
+
+# The fixture drives the real lock service, so a fired blank timer spawns the
+# real brightness commands. Shadow them: the test wants to know the spawn
+# reached the command, not to actually blank the developer's display.
+cat >"$fake_bin/omarchy-brightness-display" <<SH
+#!/bin/bash
+printf '%s\n' "\$*" >> "$blank_marker"
+SH
+chmod +x "$fake_bin/omarchy-brightness-display"
+
+cat >"$fake_bin/omarchy-brightness-keyboard" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$fake_bin/omarchy-brightness-keyboard"
+
+cat >"$fake_bin/omarchy-system-wake" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$fake_bin/omarchy-system-wake"
+
+# The fixture never locks a real session (it sets lockRequested directly
+# instead of calling beginLock()/queueSessionLock()), so this only needs to
+# answer "not locked" to keep the stranded-lock check from trying to recover
+# anything.
+cat >"$fake_bin/omarchy-hyprland-session-locked" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$fake_bin/omarchy-hyprland-session-locked"
+
+# lock/Service.qml spawns every Process through "bash", "-c" (not a login
+# shell), so a shell.rc PATH override cannot reach it -- but a machine
+# dev-linked to another checkout can still shadow the fake bin earlier in
+# $PATH itself. Refuse to run the real blank against the developer's display
+# unless the same lookup a plain "bash -c" would do resolves to the fake.
+resolved=$(HOME="$TMPDIR/home" PATH="$fake_bin:$ROOT/bin:$PATH" bash -c 'command -v omarchy-brightness-display' 2>/dev/null || true)
+if [[ $resolved != "$fake_bin/omarchy-brightness-display" ]]; then
+  pass "PATH resolves omarchy-brightness-display to ${resolved:-nothing}; skipping lock activity reblank test"
+  exit 0
+fi
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+PATH="$fake_bin:$ROOT/bin:$PATH" \
+  timeout 40 quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+# The fixture's own poll for the re-armed blank firing runs up to ~20s (real
+# input in a live session can keep re-arming the countdown), so give this
+# outer wait enough room past that plus load/startup time.
+for _ in {1..350}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "lock activity reblank quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "lock activity reblank test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Lock activity reblank result:\n' >&2
+  jq . "$result" >&2
+  printf 'Lock activity reblank log:\n' >&2
+  sed -n '1,220p' "$log" >&2
+  fail "lock screen re-arms its blank from raw input while locked"
+fi
+
+# The re-armed timer is the only one allowed to reach the blank command in
+# this run; the marker proves the spawn went all the way through.
+for _ in {1..30}; do
+  [[ -e $blank_marker ]] && break
+  sleep 0.1
+done
+[[ -e $blank_marker ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "the re-armed blank timer runs omarchy-brightness-display"
+}
+
+pass "lock screen re-arms its blank from raw input while locked"


### PR DESCRIPTION
## Summary

The lock screen blanks the display with a one-shot five-second timer that is re-armed only by input reaching the lock surface or by a password check finishing. Hyprland lights DPMS on its own for any pointer motion or key press (`mouse_move_enables_dpms`, `key_press_enables_dpms`, both on in `default/hypr/input.lua`), and when that input produces no event on the lock surface - one stray sensor count at 03:29, in the captured case - the spent timer stays spent and the panel is on until someone touches the machine. On an OLED that is the lock screen lit for 4 h 49 min, reported as "same defect, opposite symptom" on #7749. The idle service did get the ext-idle `resumed` for that motion, but it has no display-off command of its own; the only blank in the tree is the lock's timer.

Caught with an evdev + DPMS witness (Hyprland 0.56.2, Omarchy 4.0.2, LG UltraGear OLED on DP-1):

```
23:00:06  dpms=DP-1=off locked=true      (locked 22:59:00, blanked 5 s later)
03:20:06  dpms=DP-1=off locked=true      (quiet all night)
03:29:11  input event2 'Razer Basilisk V3' EV_REL REL_Y value=1
03:29:11  input event18 'HDA NVidia HDMI/DP' SW_VIDEOOUT_INSERT value=1   (DP link back up)
03:30:01  dpms=DP-1=on locked=true       ... unchanged until 08:18
```

This listens to ext-idle-notify while a lock is requested, the protocol the idle service already uses, and re-arms the blank on every resume unless a password check is in flight. The idle service's own monitor cannot serve here: it respects inhibitors and its timeout is the user's screensaver setting.

- `respectInhibitors: false` is load-bearing. A monitor that respects inhibitors is paused while one is held, so it never reaches idle and never sees the next input as a transition, and an inhibitor appearing counts as a resume in its own right. Ignoring them costs nothing: the lock blanks five seconds after locking no matter what inhibitors are held, so this monitor darkens nothing the lock was not already darkening.
- The monitor's timeout is shorter than the blank countdown, so it is already idle by the time the display goes dark and the next input is a transition it reports.
- The re-arm is journaled (`blank-rearmed: activity`) only when the timer was actually spent; input the surface already saw and re-armed on earns no line.
- The blank command logs `blank-started` when it spawns, and `omarchy-shell lock status` gains `blankArmed` and `activityIdle`. Nothing in the shell logged display state at the lock screen before; the line #8581 proposes is the same idea.

In #9152 I argued that re-blanking is the wrong fix for a wake the shell itself causes: the flash still happens, so the wake should not fire. That still holds, and the two are complementary rather than the same fix twice. #9152 is for a wake the idle service causes and can skip; this is for lights the shell did not cause and cannot prevent.

Scope, stated up front: this covers the raw-input trigger of the never-blanks state. It never calls `runWake()` and never shortens anything, so a panel that is slow today is no slower; the blanks it adds happen only in the state where the panel would otherwise stay lit indefinitely. The five-second budget itself (#7749) and the output re-add after an HPD drop (#8580) are separate defects and untouched, and a device that jitters more often than every five seconds keeps the panel lit, same as today, since Hyprland relights on every count regardless. `armBlankTimer`, `runWake`, `runBlank` and the interval literal are not modified, so the open PRs that change them (#7643, #7673, #7386, #8581, #8561, #12245) still apply; #7643, #7673 and #12245 touch adjacent lines and will need a one-hunk resolution whichever lands second. #12245 makes `armBlankTimer` take an interval and gives deliberate wakes 30 s; the re-arm here passes no interval, so it keeps the 5 s default and the two compose without either changing the other's behaviour.

Since this was opened, #6792 (video wallpaper) landed with a note in `Service.qml` about "a panel woken behind the lock's back (a resume that kept the same outputs)". That is this state. #6792 handles it only for a video wallpaper, by polling `hyprctl monitors` so the video resumes instead of freezing; the display stays lit. This PR is the fix for the state itself, video or not. Rebased onto quattro after that merge; the two add lines at the same spots and nothing else touches.

No separate issue: the report is the comment on #7749 linked above, and #8580 already describes the same end state from a different trigger.

Refs #7749, #8580.

## Test

`test/shell.d/lock-activity-reblank-test.sh` pins the monitor wiring by source-text assertion first, so it is covered on headless machines where the compositor part skips, then loads the real lock service in a sandboxed quickshell with the brightness, wake and session-locked helpers shadowed, and asserts:

- the activity monitor is off before any lock and on with one, ignores inhibitors, and times out faster than the blank countdown;
- setting `lockRequested` alone does not arm the timer (the state a locked, idle machine sits in until something re-arms it);
- raw activity re-arms and is logged while locked;
- activity during a password check neither re-arms nor logs, and clearing the check re-arms;
- the re-armed timer spawns the (faked) blank command for real and logs `blank-started`;
- activity while unlocked never arms anything.

The fixture never takes a session lock, and the stubs plus a PATH guard keep it from ever blanking the developer's display. The fire wait allows twenty seconds because real input in the developer's session re-arms the monitor under test. Against the unpatched service the test fails. The existing lock tests, including the source-text-asserting `lock-blank-fingerprint-test.sh`, pass unchanged; `./test/shell` shows the same five pre-existing environmental failures with and without this change.

