### PR TITLE
Make VS Code-family editors reload the Omarchy theme when it changes

### DIFF
--- a/bin/omarchy-theme-set-vscode
+++ b/bin/omarchy-theme-set-vscode
@@ -68,8 +68,17 @@ install_generated_extension() {
     ui_theme="vs-dark"
   fi
 
+  # VS Code caches loaded color themes in memory and only rebuilds a registry
+  # entry when the providing extension changes, so derive the version from the
+  # theme content: identical palettes keep the cache, new palettes invalidate it.
+  GENERATED_EXTENSION_VERSION="1.0.$(cksum "$GENERATED_THEME" | cut -d' ' -f1)"
+
   mkdir -p "$ext_dir/themes"
-  ln -sfn "$GENERATED_THEME" "$ext_dir/themes/omarchy-color-theme.json"
+  # A real file rather than a symlink into current/theme: the _watch watcher
+  # below needs a same-inode rewrite to fire, and a symlink would dangle while
+  # omarchy-theme-set swaps current/theme via rm + mv.
+  rm -f "$ext_dir/themes/omarchy-color-theme.json"
+  cat "$GENERATED_THEME" >"$ext_dir/themes/omarchy-color-theme.json"
 
   cat > "$ext_dir/package.json" <<EOF
 {
@@ -84,7 +93,8 @@ install_generated_extension() {
         "themes": [{
             "label": "Omarchy",
             "uiTheme": "$ui_theme",
-            "path": "./themes/omarchy-color-theme.json"
+            "path": "./themes/omarchy-color-theme.json",
+            "_watch": true
         }]
     }
 }


### PR DESCRIPTION
Fixes #9336

## Problem

`omarchy-theme-set-vscode` rewrites the generated "Omarchy" theme extension with byte-identical content on every `omarchy theme set`. VS Code-family editors load a color theme **once**: `ColorThemeData.ensureLoaded()` is a no-op after first load, and a reload only happens via a file watcher (requires `_watch: true` on the contribution), a theme-registry delta, or re-selecting a theme whose registry entry has changed. None of these trigger today, so:

- with "Omarchy" selected, `omarchy theme set` never updates the editor palette;
- after selecting another theme (e.g. Dracula), re-selecting "Omarchy" serves the stale palette cached at first load.

Same path affects VS Code, Code-Insiders, VSCodium and Cursor.

## Fix

Three small changes in `install_generated_extension`:

1. **Content-derived version.** `GENERATED_EXTENSION_VERSION` becomes `1.0.<crc32 of the theme file>`, so `package.json`/`extensions.json` genuinely change only when the palette changes → extension-scan delta → registry rebuild → a fresh load on the next selection. Identical palettes keep the version and the editor's cache untouched.
2. **`"_watch": true`** on the theme contribution. VS Code reads this private field from any extension's manifest (`themeData.watch = theme._watch === true` in `colorThemeData.ts`) and attaches `ThemeFileWatcher` to the active theme, calling `reload()` on change — i.e. live propagation while Omarchy is the selected theme.
3. **Real file instead of a symlink.** The theme file is written into the extension dir (`rm -f` + `cat >`) rather than symlinked into `current/theme/`, which `omarchy-theme-set` swaps via `rm -rf; mv`. A same-inode rewrite gives the watcher a reliable UPDATED event, and the extension can no longer point at a dangling path mid-swap or on first scan.

## Behavior after the fix

- While "Omarchy" is the selected theme: palette changes apply live (no restart, no re-select).
- After selecting a third-party theme and re-selecting "Omarchy": the current palette is shown (registry entry rebuilt because the extension version changed).

## Testing

- [x] `bash -n` clean; version output is valid semver (`1.0.470365826`-style)
- [x] Upgrade path: a pre-existing symlink from older versions is removed before the first copy
- [ ] `omarchy theme set A` → `B` with the editor open and "Omarchy" selected → live palette switch
- [ ] Select Dracula, `omarchy theme set B`, re-select "Omarchy" → current palette
- [ ] Re-run with the same theme twice → stable version, no extension churn/update popups
- [ ] Light ↔ dark theme toggle → `uiTheme` flips and the watcher still fires

Checked boxes reflect what is verifiable without a running editor session; the remaining items are the manual matrix to confirm on real VS Code/Cursor before merge.