### PR TITLE
Resync the clock when the wall clock is stepped

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -94,6 +94,26 @@ bar from the CLI — `use | reset | defaults | position | transparent | put |
 move | set`, with placement flags such as `--section` and `--index`.
 The lower-level IPC methods remain available through `omarchy-shell shell ...`.
 
+## Wall-clock jumps
+
+`SystemClock` waits out a delay measured on a clock that stops while the machine is suspended, so it wakes still reporting the time it had before — for up to one full precision period, a whole minute at `SystemClock.Minutes`. An NTP correction after a long time offline steps the clock the same way. A plugin that displays a time should resync when `Wallclock` reports the step:
+
+```qml
+import qs.Commons
+
+SystemClock {
+  id: clock
+  precision: SystemClock.Minutes
+}
+
+Connections {
+  target: Wallclock
+  function onJumped() { Wallclock.resync(clock) }
+}
+```
+
+`Wallclock.resync(clock)` makes the clock re-read the wall clock and reschedule from now.
+
 ## IPC
 
 The shell exposes a `shell` target (the host also registers

--- a/shell/Commons/Wallclock.qml
+++ b/shell/Commons/Wallclock.qml
@@ -1,0 +1,71 @@
+pragma Singleton
+import QtQuick
+import "WallclockMath.js" as Detect
+
+// Notices when wall-clock time is stepped rather than advanced, so anything
+// displaying a clock can re-read it.
+//
+// Timers are scheduled as a delay measured on CLOCK_MONOTONIC, which stops
+// while the machine is suspended. Quickshell's SystemClock schedules its next
+// tick as the delay to the top of the next minute, so a clock that had four
+// seconds left to run when the lid closed still has four seconds left when it
+// opens — and reports the pre-suspend time until they elapse. The length of
+// the sleep does not matter: an eight-hour suspend and a ten-second one leave
+// the same remainder to burn down. Most of that minute passes behind the lock
+// screen; what is left of it lands on the bar the user unlocks into.
+//
+// An NTP correction after a long time offline steps the clock the same way
+// and leaves the same gap. A timezone change does not — it moves the offset,
+// not the epoch, and omarchy-menu-timezone already refreshes the clock over
+// IPC when it changes one.
+//
+// Checking the wall clock when a timer fires is the cheaper move, and it is
+// the one the lock service makes before blanking a freshly woken screen: a
+// countdown that spanned a suspend is discarded and re-armed, at the cost of
+// no extra wakeups at all. SystemClock already does the same thing — setTime
+// and schedule both fall back to the current time when the tick they were
+// waiting for turns out to be more than 500ms stale — and that is precisely
+// why the clock rights itself a minute after waking rather than staying
+// wrong. It cannot do better, because the check only runs when the late tick
+// finally arrives, and waiting for that tick is the whole bug.
+//
+// So the check has to run on a schedule of its own. Nothing else will raise
+// it: logind announces a resume on the system bus, but the shell has no
+// D-Bus of its own, and a clock stepped by NTP announces nothing anywhere.
+QtObject {
+  id: root
+
+  readonly property int interval: 1000
+
+  // A tick can run late under load without the clock having moved, so the
+  // threshold clears ordinary scheduling jitter by a wide margin while
+  // staying far below the shortest step worth reacting to.
+  readonly property int threshold: 3000
+
+  signal jumped(real deltaMs)
+
+  property real lastTick: Date.now()
+
+  // Re-reads the wall clock and reschedules the next tick from now. Toggling
+  // `enabled` is what forces it: SystemClock recomputes both the time it
+  // reports and the delay it waits on when it is re-enabled, and exposes no
+  // other way to ask for either.
+  function resync(clock) {
+    clock.enabled = false
+    clock.enabled = true
+  }
+
+  property Timer watchdog: Timer {
+    interval: root.interval
+    running: true
+    repeat: true
+
+    onTriggered: {
+      var now = Date.now()
+      var elapsed = now - root.lastTick
+      root.lastTick = now
+
+      if (Detect.isDiscontinuity(elapsed, root.interval, root.threshold)) root.jumped(elapsed)
+    }
+  }
+}

--- a/shell/Commons/WallclockMath.js
+++ b/shell/Commons/WallclockMath.js
@@ -1,0 +1,17 @@
+// Whether a tick that waited `interval` came back to a wall clock that had
+// moved by something else entirely. Qt-free so it can be unit tested under
+// node (test/shell.d/clock-test.sh).
+//
+// The comparison is against the deviation from the interval, not against the
+// elapsed time itself: a tick is expected to find `interval` milliseconds
+// gone, and only the surplus — or the shortfall, when the clock is stepped
+// backwards — says the clock was moved rather than advanced.
+function isDiscontinuity(elapsedMs, interval, threshold) {
+  return Math.abs(Number(elapsedMs) - Number(interval)) >= Number(threshold)
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    isDiscontinuity: isDiscontinuity
+  }
+}

--- a/shell/Commons/qmldir
+++ b/shell/Commons/qmldir
@@ -3,3 +3,4 @@ singleton Border 1.0 Border.qml
 singleton Color 1.0 Color.qml
 singleton Style 1.0 Style.qml
 singleton Util 1.0 Util.qml
+singleton Wallclock 1.0 Wallclock.qml

--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -119,6 +119,14 @@ BarWidget {
     onDateChanged: root.displayDate = date
   }
 
+  // Suspend freezes the deadline the clock is waiting on, so it wakes still
+  // reporting the time the lid closed at — see Wallclock. Resyncing is all
+  // this takes: the handler above puts the recovered time on the label.
+  Connections {
+    target: Wallclock
+    function onJumped() { Wallclock.resync(clock) }
+  }
+
   Loader {
     id: panelLoader
     active: true

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -233,6 +233,16 @@ Panel {
     }
   }
 
+  // Only reachable for a calendar left open across a suspend that crossed
+  // midnight — open() refreshes, so a panel opened after waking is already
+  // right. Resyncing rather than refreshing is the point: refresh() calls
+  // goToToday(), and waking the machine is no reason to drag a calendar left
+  // open on another month back to this one.
+  Connections {
+    target: Wallclock
+    function onJumped() { Wallclock.resync(clock) }
+  }
+
   KeyboardPanel {
     id: panel
     anchorItem: root.anchorItem

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -258,6 +258,38 @@ assert(/readonly property real labelWidth:/.test(fs.readFileSync(root + '/shell/
 // A horizontal wheel reports angleDelta.y === 0; without the guard every one
 // of them would read as a forward step.
 assert(/if \(event\.angleDelta\.y === 0\) return/.test(panelSource), 'calendar ignores wheel events with no vertical delta')
+
+// ---- Resync after a wall-clock step. SystemClock waits out a delay measured
+//      on a clock that stops during suspend, so without a nudge the bar wakes
+//      still reporting the time the lid closed at. Comments stripped so a
+//      commented-out wiring cannot satisfy the assertions.
+const wallclock = requireFromRoot('shell/Commons/WallclockMath.js')
+const wallclockCode = fs.readFileSync(root + '/shell/Commons/Wallclock.qml', 'utf8').replace(/^\s*\/\/.*$/gm, '')
+const panelCode = panelSource.replace(/^\s*\/\/.*$/gm, '')
+
+// A tick is expected to find `interval` gone; only the deviation from that
+// says the clock was stepped rather than advanced. Testing the elapsed time
+// against the threshold instead would fire on every ordinary tick.
+assert(!wallclock.isDiscontinuity(1000, 1000, 3000), 'an on-time tick is not a step')
+assert(!wallclock.isDiscontinuity(1400, 1000, 3000), 'a tick running late under load is not a step')
+assert(!wallclock.isDiscontinuity(3999, 1000, 3000), 'a gap just under the threshold is not a step')
+assert(wallclock.isDiscontinuity(4000, 1000, 3000), 'a gap at the threshold is a step')
+assert(wallclock.isDiscontinuity(8 * 60 * 60 * 1000, 1000, 3000), 'waking from an eight-hour suspend is a step')
+assert(wallclock.isDiscontinuity(-5000, 1000, 3000), 'a clock stepped backwards is a step')
+
+assert(/singleton Wallclock 1\.0 Wallclock\.qml/.test(fs.readFileSync(root + '/shell/Commons/qmldir', 'utf8')), 'Wallclock is registered as a Commons singleton')
+assert(/isDiscontinuity\(elapsed, root\.interval, root\.threshold\)/.test(wallclockCode), 'Wallclock reports a step using the tested predicate')
+assert(/clock\.enabled = false\s*\n\s*clock\.enabled = true/.test(wallclockCode), 'Wallclock.resync toggles SystemClock off and back on to force a re-read')
+
+assert(/target: Wallclock\s*\n\s*function onJumped\(\) \{ Wallclock\.resync\(clock\) \}/.test(widgetSource), 'clock widget resyncs when the wall clock steps')
+assert(/target: Wallclock\s*\n\s*function onJumped\(\) \{ Wallclock\.resync\(clock\) \}/.test(panelCode), 'calendar panel resyncs when the wall clock steps')
+
+// Resyncing reports the new time through each clock's own onDateChanged, so
+// neither handler needs refresh() — and the panel must not call it, because
+// refresh() calls goToToday() and would drag a calendar left open on another
+// month back to today every time the machine wakes.
+const panelJumpBody = /function onJumped\(\) \{([^}]*)\}/.exec(panelCode)[1]
+assert(!/refresh\(\)/.test(panelJumpBody), 'calendar panel does not force itself back to today on a step', panelJumpBody.trim())
 JS
 
 shell_json=$(cd "$ROOT" && jq -r '[.bar.layout.center[].id] | join(",")' config/omarchy/shell.json)


### PR DESCRIPTION
Close a laptop lid and open it again, and the bar clock still reads the time the lid closed at. `date` in a terminal is correct the whole time.

It does correct itself — but not for up to a full minute, and most of that minute passes behind the lock screen, so what you actually see is a stale clock on the bar you unlock into.

## Cause

`SystemClock` computes the delay to the top of the next minute from wall-clock time and arms a `QTimer` with that *relative* delay ([`schedule()`](https://github.com/quickshell-mirror/quickshell/blob/master/src/core/clock.cpp)). Relative Qt timers are measured on `CLOCK_MONOTONIC`, which does not advance while the machine is suspended.

So a clock with four seconds left to run when the lid closes still has four seconds left when it opens. How long the machine slept makes no difference — an eight-hour suspend and a ten-second one leave the same remainder to burn down. On the machine this was found on, `CLOCK_BOOTTIME - CLOCK_MONOTONIC` had reached 36.4 hours over a single boot: that is how much scheduling time every timer in the shell had lost.

An NTP correction after a long time offline steps the clock the same way and leaves the same gap. (A timezone change does not — it moves the offset, not the epoch — and `omarchy-menu-timezone` already refreshes the clock over IPC when it changes one.)

Quickshell has not fixed this upstream: [#559](https://github.com/quickshell-mirror/quickshell/issues/559) is this exact report, closed as user error, and [#107](https://github.com/quickshell-mirror/quickshell/issues/107) is open and stale. So the shell has to notice for itself.

## Fix

`Wallclock`, a new `qs.Commons` singleton, watches for the step and reports it. `Wallclock.resync(clock)` makes a `SystemClock` re-read the wall clock and reschedule from now — toggling `enabled` is the only lever the type exposes for that.

Checking the wall clock when a timer fires is the cheaper move, and it is the one `plugins/lock/Service.qml` already makes before blanking a freshly woken screen: a countdown that spanned a suspend is discarded and re-armed, for no extra wakeups at all. That pattern does not transfer here, and the reason is worth stating plainly — `SystemClock` already implements it. `setTime` and `schedule` both fall back to the current time when the tick they were waiting for turns out to be more than 500ms stale, and that is exactly why the clock rights itself a minute after waking rather than staying wrong forever. It cannot do better, because the check only runs when the late tick finally arrives, and waiting for that tick is the whole bug.

So the check has to run on a schedule of its own. Nothing else will raise it: logind announces a resume on the system bus, but the shell has no D-Bus of its own, and a clock stepped by NTP announces nothing anywhere. The cost is one 1 Hz timer doing two subtractions and a compare — and one, not one per widget: each bar instantiates its own clock widget and calendar panel, which is what the singleton is for. It is also symmetric, unlike the lock service's one-sided check, so a clock stepped backwards is caught too.

Resyncing on unlock instead would be free and would cover the lid-close case, since the lock surface covers the bar for most of the stale minute. It was rejected because it cannot help a clock drawn on the lock screen itself — third-party lock clocks exist — and it misses both suspends that never locked and steps that happen while the session is in use.

The calendar panel resyncs too, though only a panel left open across a suspend that crossed midnight can reach it — `open()` already refreshes. It resyncs rather than refreshing because `refresh()` calls `goToToday()`, and waking the machine is no reason to drag a calendar left open on another month back to this one.

Third-party plugins that display a time have the same problem and can hook the same signal; `docs/omarchy-shell.md` says how.

## Testing

- `./test/shell` passes. `test/shell.d/clock-test.sh` gains six Node assertions covering the detection predicate itself (on-time tick, tick running late under load, either side of the threshold, an eight-hour gap, a clock stepped backwards) plus wiring assertions, including one that pins the panel to resyncing rather than refreshing.
- Verified in a live Quickshell instance running the same wiring shape as the bar widget: a stalled `SystemClock` keeps painting the pre-suspend time, no step is reported while time passes normally, a step is reported exactly once, and the label lands on the real wall-clock time.
