### PR TITLE
Apply USB autosuspend policy through the kernel command line

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1213,7 +1213,6 @@ run_final_system_package_upgrade() {
     --overwrite '/etc/gnupg/dirmngr.conf' \
     --overwrite '/etc/mkinitcpio.conf.d/omarchy_hooks.conf' \
     --overwrite '/etc/mkinitcpio.conf.d/thunderbolt_module.conf' \
-    --overwrite '/etc/modprobe.d/omarchy-usb-autosuspend.conf' \
     --overwrite '/etc/sddm.conf.d/10-theme.conf' \
     --overwrite '/etc/sddm.conf.d/10-wayland.conf' \
     --overwrite '/etc/sudoers.d/omarchy-asdcontrol' \

--- a/etc/limine-entry-tool.d/omarchy-defaults.conf
+++ b/etc/limine-entry-tool.d/omarchy-defaults.conf
@@ -2,6 +2,10 @@ TARGET_OS_NAME="Omarchy"
 
 KERNEL_CMDLINE[default]+=" quiet splash loglevel=0 systemd.show_status=false rd.udev.log_level=0 vt.global_cursor_default=0"
 
+# Keep USB devices awake by default. usbcore is built into the Arch kernel, so
+# this must be a kernel parameter rather than a modprobe.d option.
+KERNEL_CMDLINE[default]+=" usbcore.autosuspend=-1"
+
 # Kernel 7.1 unpacks the initramfs asynchronously, which races /init: the
 # early /proc, /sys, /dev, and /run mounts fail while unpacking settles, so
 # plymouthd exits when it can't read /proc/cmdline and encrypted boots fall

--- a/etc/modprobe.d/omarchy-usb-autosuspend.conf
+++ b/etc/modprobe.d/omarchy-usb-autosuspend.conf
@@ -1,1 +1,0 @@
-options usbcore autosuspend=-1

--- a/migrations/1788507775.sh
+++ b/migrations/1788507775.sh
@@ -1,0 +1,27 @@
+echo "Apply Omarchy's USB autosuspend policy through the kernel command line"
+
+defaults_conf="${OMARCHY_USB_AUTOSUSPEND_DEFAULTS_CONF:-/etc/limine-entry-tool.d/omarchy-defaults.conf}"
+legacy_conf="${OMARCHY_USB_AUTOSUSPEND_LEGACY_CONF:-/etc/modprobe.d/omarchy-usb-autosuspend.conf}"
+running_cmdline="${OMARCHY_USB_AUTOSUSPEND_RUNNING_CMDLINE:-/proc/cmdline}"
+rebuild_marker="${OMARCHY_USB_AUTOSUSPEND_REBUILD_MARKER:-/var/lib/omarchy/migrations/1788507775}"
+
+# Remove only the exact file Omarchy used to ship. Preserve administrator
+# changes, even though usbcore is built in and modprobe cannot apply them.
+if [[ -f $legacy_conf ]] &&
+  [[ $(<"$legacy_conf") == "options usbcore autosuspend=-1" ]]; then
+  sudo rm "$legacy_conf"
+fi
+
+omarchy-cmd-present limine-mkinitcpio || exit 0
+[[ -f $defaults_conf && -r $running_cmdline ]] || exit 0
+grep -Fq 'usbcore.autosuspend=-1' "$defaults_conf" || exit 0
+
+# The running command line cannot change until reboot. Record a successful
+# rebuild so this machine-wide repair is not repeated for each Omarchy user.
+[[ ! -e $rebuild_marker ]] || exit 0
+
+if [[ " $(<"$running_cmdline") " != *" usbcore.autosuspend=-1 "* ]]; then
+  sudo limine-mkinitcpio
+  sudo install -Dm644 /dev/null "$rebuild_marker"
+  omarchy-state set reboot-required
+fi

--- a/test/shell.d/usb-autosuspend-test.sh
+++ b/test/shell.d/usb-autosuspend-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+defaults_conf="$ROOT/etc/limine-entry-tool.d/omarchy-defaults.conf"
+migration="$ROOT/migrations/1788507775.sh"
+
+grep -Fqx 'KERNEL_CMDLINE[default]+=" usbcore.autosuspend=-1"' "$defaults_conf" ||
+  fail "USB autosuspend is disabled through the kernel command line"
+[[ ! -e $ROOT/etc/modprobe.d/omarchy-usb-autosuspend.conf ]] ||
+  fail "the ineffective usbcore modprobe option is removed"
+pass "USB autosuspend policy is expressed as a working kernel parameter"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+legacy_conf="$test_tmp/omarchy-usb-autosuspend.conf"
+running_cmdline="$test_tmp/cmdline"
+rebuild_marker="$test_tmp/rebuild-complete"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+(( ${LIMINE_MKINITCPIO_INSTALLED:-1} == 1 ))
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_USB_AUTOSUSPEND_DEFAULTS_CONF="$defaults_conf" \
+    OMARCHY_USB_AUTOSUSPEND_LEGACY_CONF="$legacy_conf" \
+    OMARCHY_USB_AUTOSUSPEND_RUNNING_CMDLINE="$running_cmdline" \
+    OMARCHY_USB_AUTOSUSPEND_REBUILD_MARKER="$rebuild_marker" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+echo 'options usbcore autosuspend=-1' >"$legacy_conf"
+echo 'quiet splash' >"$running_cmdline"
+run_migration
+
+[[ ! -e $legacy_conf ]] || fail "migration removes the exact obsolete config"
+grep -Fxq 'limine-mkinitcpio' "$calls" || fail "migration rebuilds the boot image"
+grep -Fxq $'omarchy-state\tset\treboot-required' "$calls" || fail "migration requests a reboot"
+[[ -f $rebuild_marker ]] || fail "migration records the machine-wide rebuild"
+pass "migration replaces the obsolete setting and rebuilds once"
+
+: >"$calls"
+run_migration
+[[ ! -s $calls ]] || fail "migration does not repeat a recorded rebuild" "$(cat "$calls")"
+pass "migration is machine-idempotent before reboot"
+
+printf '%s\n' '# administrator note' 'options usbcore autosuspend=-1' >"$legacy_conf"
+echo 'quiet splash usbcore.autosuspend=-1' >"$running_cmdline"
+rm -f "$rebuild_marker"
+: >"$calls"
+run_migration
+
+[[ -e $legacy_conf ]] || fail "migration preserves an administrator-modified config"
+[[ ! -s $calls ]] || fail "a booted kernel with the parameter needs no rebuild" "$(cat "$calls")"
+pass "migration preserves custom files and skips an active parameter"


### PR DESCRIPTION
Fixes #8097.

## What changed

- move `usbcore.autosuspend=-1` from `modprobe.d` to the Limine kernel command line
- remove the ineffective modprobe configuration and its Quattro upgrade overwrite
- migrate existing installs by rebuilding their boot image once and marking reboot required
- preserve administrator-modified legacy files
- add focused migration and policy coverage

## Why

Arch builds `usbcore` into the kernel, so `/etc/modprobe.d/omarchy-usb-autosuspend.conf` is never read for it. Omarchy therefore currently expresses a global no-autosuspend policy without applying it: `/sys/module/usbcore/parameters/autosuspend` remains the kernel default of `2`.

I reproduced this on a 2016 MacBook Pro 15-inch (`MacBookPro13,3`) with two Intel JHL6540 Alpine Ridge USB controllers (`8086:15d4`). The installed Omarchy configuration contains `options usbcore autosuspend=-1`, while the live parameter remains `2` and both controllers use runtime power management.

This draft deliberately preserves the policy already stated by Omarchy. The maintainer decision is whether global disabling remains desirable given its idle-power cost; if not, removing the dead setting without activating it would be the alternative.

## Testing

- `test/shell.d/usb-autosuspend-test.sh`
- `test/shell.d/upgrade-to-quattro-test.sh`
- `bash -n migrations/1788507775.sh test/shell.d/usb-autosuspend-test.sh`
- `git diff --check`

`./test/all` ran all 227 shell test files. The new test and related upgrade tests passed. Six unrelated environment/baseline tests failed: missing `omarchy-pkgs` checkout coverage, live graphical geometry checks, and an existing Windows VM concurrency race. No suspend, reboot, module reload, GPU recording, or other disruptive hardware test was performed on the MacBook.