### PR TITLE
Add Ctrl+R application renaming to the menu

### DIFF
--- a/bin/omarchy-remove-launcher-entry
+++ b/bin/omarchy-remove-launcher-entry
@@ -39,9 +39,14 @@ else
 fi
 
 desktop_file=""
+rename_override=""
 for dir in "${desktop_dirs[@]}"; do
   candidate="$dir/$desktop_file_name"
   if [[ -f $candidate ]]; then
+    if [[ $dir == "${user_desktop_dirs[0]}" ]] && grep -Fxq 'X-Omarchy-Renamed=true' "$candidate"; then
+      rename_override="$candidate"
+      continue
+    fi
     desktop_file="$candidate"
     break
   fi
@@ -88,13 +93,25 @@ if package_name="$(pacman -Qqo "$desktop_file" 2>/dev/null | head -1)" && [[ -n 
   display_name="${entry_name:-$desktop_name}"
   quoted_package="$(printf '%q' "$package_name")"
   quoted_display="$(printf '%q' "$display_name")"
-  exec omarchy-launch-floating-terminal-with-presentation "echo Uninstalling $quoted_display...; sudo pacman -Rns $quoted_package"
+  command="echo Uninstalling $quoted_display...; sudo pacman -Rns $quoted_package"
+  if [[ -n $rename_override ]]; then
+    quoted_override="$(printf '%q' "$rename_override")"
+    quoted_applications_dir="$(printf '%q' "${rename_override%/*}")"
+    command+=" && rm -f -- $quoted_override && update-desktop-database $quoted_applications_dir"
+  fi
+  exec omarchy-launch-floating-terminal-with-presentation "$command"
 fi
 
 if omarchy-cmd-present flatpak && flatpak info "${desktop_file_name%.desktop}" >/dev/null 2>&1; then
   flatpak_id="${desktop_file_name%.desktop}"
   quoted_flatpak="$(printf '%q' "$flatpak_id")"
-  exec omarchy-launch-floating-terminal-with-presentation "flatpak uninstall $quoted_flatpak"
+  command="flatpak uninstall $quoted_flatpak"
+  if [[ -n $rename_override ]]; then
+    quoted_override="$(printf '%q' "$rename_override")"
+    quoted_applications_dir="$(printf '%q' "${rename_override%/*}")"
+    command+=" && rm -f -- $quoted_override && update-desktop-database $quoted_applications_dir"
+  fi
+  exec omarchy-launch-floating-terminal-with-presentation "$command"
 fi
 
 echo "Don't know how to uninstall $desktop_file_name" >&2

--- a/bin/omarchy-rename-launcher-entry
+++ b/bin/omarchy-rename-launcher-entry
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# omarchy:summary=Rename an application in the launcher
+# omarchy:args=<desktop-id> <name>
+# omarchy:hidden=true
+
+set -euo pipefail
+
+desktop_id="${1-}"
+new_name="${2-}"
+
+if [[ -z $desktop_id || -z $new_name ]]; then
+  echo "Usage: omarchy-rename-launcher-entry <desktop-id> <name>" >&2
+  exit 1
+fi
+
+# Desktop IDs are basenames here. Reject path syntax before using the value in
+# a path so direct callers cannot escape an XDG applications directory.
+if [[ $desktop_id == "." || $desktop_id == ".." || $desktop_id == */* || $desktop_id == *\\* || $desktop_id =~ [[:cntrl:]] ]]; then
+  echo "Invalid launcher entry id: $desktop_id" >&2
+  exit 1
+fi
+
+# A Desktop Entry string is line-oriented. Newlines and other separators would
+# turn a display name into additional keys, so refuse them rather than trying
+# to interpret surprising input from a direct command invocation.
+if [[ $new_name =~ [[:cntrl:]] ]]; then
+  echo "Application names cannot contain control characters" >&2
+  exit 1
+fi
+
+if [[ $new_name == [[:space:]]* || $new_name == *[[:space:]] ]]; then
+  echo "Application names cannot begin or end with whitespace" >&2
+  exit 1
+fi
+
+desktop_file_name="$desktop_id"
+if [[ $desktop_file_name != *.desktop ]]; then
+  desktop_file_name="$desktop_file_name.desktop"
+fi
+
+if [[ -n ${XDG_DATA_HOME-} ]]; then
+  user_applications_dir="$XDG_DATA_HOME/applications"
+else
+  user_applications_dir="$HOME/.local/share/applications"
+fi
+
+desktop_dirs=("$user_applications_dir")
+if [[ -n ${XDG_DATA_DIRS-} ]]; then
+  IFS=: read -ra data_dirs <<<"$XDG_DATA_DIRS"
+  for data_dir in "${data_dirs[@]}"; do
+    [[ -n $data_dir ]] && desktop_dirs+=("$data_dir/applications")
+  done
+else
+  desktop_dirs+=("/usr/local/share/applications" "/usr/share/applications")
+fi
+
+source_file=""
+for dir in "${desktop_dirs[@]}"; do
+  candidate="$dir/$desktop_file_name"
+  if [[ -f $candidate ]]; then
+    source_file="$candidate"
+    break
+  fi
+done
+
+if [[ -z $source_file ]]; then
+  echo "Could not find launcher entry: $desktop_file_name" >&2
+  exit 1
+fi
+
+mkdir -p "$user_applications_dir"
+target_file="$user_applications_dir/$desktop_file_name"
+if [[ -L $target_file ]]; then
+  echo "Refusing to replace symlinked launcher entry: $target_file" >&2
+  exit 1
+fi
+
+managed_override=false
+if [[ $source_file != "$target_file" ]]; then
+  managed_override=true
+fi
+
+temp_file="$(mktemp --tmpdir="$user_applications_dir" ".${desktop_file_name}.XXXXXX")"
+trap 'rm -f -- "$temp_file"' EXIT
+
+# Backslashes are escaped for the Desktop Entry string value. The QML field is
+# single-line, while the validation above keeps direct callers single-line too.
+escaped_name="${new_name//\\/\\\\}"
+in_desktop_entry=false
+desktop_entry_found=false
+name_written=false
+
+while IFS= read -r line || [[ -n $line ]]; do
+  if [[ $line == "[Desktop Entry]" && $desktop_entry_found == false ]]; then
+    in_desktop_entry=true
+    desktop_entry_found=true
+    printf '%s\n' "$line"
+    if [[ $managed_override == true ]]; then
+      printf 'X-Omarchy-Renamed=true\n'
+    fi
+  elif [[ $in_desktop_entry == true && $line == \[* ]]; then
+    if [[ $name_written == false ]]; then
+      printf 'Name=%s\n' "$escaped_name"
+      name_written=true
+    fi
+    in_desktop_entry=false
+    printf '%s\n' "$line"
+  elif [[ $in_desktop_entry == true && $line =~ ^Name(\[[^]]+\])?= ]]; then
+    if [[ $name_written == false ]]; then
+      printf 'Name=%s\n' "$escaped_name"
+      name_written=true
+    fi
+  elif [[ $managed_override == true && $in_desktop_entry == true && $line == "X-Omarchy-Renamed="* ]]; then
+    # Replace any source marker with the one written directly after the group.
+    continue
+  else
+    printf '%s\n' "$line"
+  fi
+done <"$source_file" >"$temp_file"
+
+if [[ $desktop_entry_found == false ]]; then
+  echo "Invalid launcher entry (missing [Desktop Entry]): $desktop_file_name" >&2
+  exit 1
+fi
+
+if [[ $in_desktop_entry == true && $name_written == false ]]; then
+  printf 'Name=%s\n' "$escaped_name" >>"$temp_file"
+fi
+
+chmod 0644 "$temp_file"
+mv -f -- "$temp_file" "$target_file"
+trap - EXIT
+update-desktop-database "$user_applications_dir" &>/dev/null || true

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -104,10 +104,12 @@ JSONC. The names are defined by the shell, not the menu file — an extension
 can point a submenu at an existing provider but cannot declare a new one:
 
 - `apps` is QML-native: rows come from the shared AppLibrary (desktop
-  entries), carrying image icons, launch feedback, and uninstall support like
-  the launcher. App rows are searchable by their desktop Keywords but never
-  routable, so an installed app cannot capture a menu route (htop ships
-  `Keywords=system;...`, and SUPER+ESCAPE must still open the system menu).
+  entries), carrying image icons, launch feedback, and entry management.
+  With an app highlighted, `Ctrl+R` opens its rename dialog and
+  `Delete` opens its uninstall confirmation. App rows are searchable by their
+  desktop Keywords but never routable, so an installed app cannot capture a
+  menu route (htop ships `Keywords=system;...`, and SUPER+ESCAPE must still
+  open the system menu).
 - `fonts` and `power-profiles` are bash one-liners in the `providers` map in
   `Menu.qml`. The contract is one tab-delimited line per row:
   `label\tvalue\tcurrent`. The row whose value equals `current` gets the ✓

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -76,11 +76,20 @@ Item {
   property int providerRevision: 0
 
   // Shared application engine (entries, hidden filters, icons, launch,
-  // removal), owned by the shell and also used by the standalone launcher.
+  // removal and renaming), owned by the shell.
   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
   property bool deleteConfirmOpen: false
   property var deleteTarget: null
-  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null }
+  property bool renameDialogOpen: false
+  property var renameTarget: null
+  property string renameName: ""
+  onOpenedChanged: if (!opened) {
+    deleteConfirmOpen = false
+    deleteTarget = null
+    renameDialogOpen = false
+    renameTarget = null
+    renameName = ""
+  }
   // Bound to the central [menu] section in shell.toml via Color.qml.
   // Each color already includes its alpha companion (composed in the
   // singleton), so consumers can drop them straight into a Rectangle.
@@ -812,6 +821,36 @@ Item {
     if (root.appLibrary) root.appLibrary.remove(target.appId, target.label)
   }
 
+  function requestRenameSelected() {
+    if (!root.cursorActive || root.selectedIndex < 0 || root.selectedIndex >= displayModel.count) return false
+    var row = displayModel.get(root.selectedIndex)
+    if (!row || row.kind !== "app") return false
+    root.renameTarget = { appId: row.appId, label: row.label }
+    root.renameName = row.label
+    root.renameDialogOpen = true
+    Qt.callLater(function() {
+      renameField.forceActiveFocus()
+      renameField.selectAll()
+    })
+    return true
+  }
+
+  function cancelRename() {
+    root.renameDialogOpen = false
+    root.renameTarget = null
+    root.renameName = ""
+    root.disarmPointer()
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function confirmRename() {
+    var target = root.renameTarget
+    var nextName = root.renameName.trim()
+    if (!target || !nextName) return
+    root.cancelRename()
+    if (root.appLibrary) root.appLibrary.rename(target.appId, nextName)
+  }
+
   function applyDmenuSelection(value) {
     applySerial = requestSerial
     opened = false
@@ -1116,7 +1155,7 @@ Item {
       Item {
         id: keyCatcher
         anchors.fill: parent
-        z: root.deleteConfirmOpen ? 20 : 0
+        z: root.deleteConfirmOpen || root.renameDialogOpen ? 20 : 0
         focus: true
 
         Keys.priority: Keys.BeforeItem
@@ -1126,8 +1165,14 @@ Item {
             return
           }
 
+          if (root.renameDialogOpen) return
+
           if (event.key === Qt.Key_Delete) {
             root.requestDeleteSelected()
+            event.accepted = true
+          } else if (event.key === Qt.Key_R
+                     && (event.modifiers & Qt.ControlModifier)
+                     && root.requestRenameSelected()) {
             event.accepted = true
           } else if (event.key === Qt.Key_Escape) {
             if (root.filterText) root.setFilter("")
@@ -1181,6 +1226,96 @@ Item {
           cornerRadius: root.cornerRadius
           onCanceled: root.cancelDelete()
           onConfirmed: root.confirmDelete()
+        }
+
+        Rectangle {
+          anchors.fill: parent
+          visible: root.renameDialogOpen
+          z: 10
+          color: root.scrim
+
+          MouseArea { anchors.fill: parent; onClicked: root.cancelRename() }
+
+          BorderSurface {
+            id: renameCard
+            width: Math.min(parent.width - Style.space(32), Style.space(370))
+            height: renameCard.contentTopInset + renameCard.contentBottomInset + renameContent.implicitHeight
+            anchors.centerIn: parent
+            color: root.background
+            borderSpec: Border.flat(root.selectedText, Style.normalBorderWidth)
+            padding: Style.space(18)
+            radius: root.cornerRadius
+
+            MouseArea { anchors.fill: parent; onClicked: {} }
+
+            Column {
+              id: renameContent
+              anchors.left: parent.left
+              anchors.right: parent.right
+              anchors.top: parent.top
+              anchors.leftMargin: parent.contentLeftInset
+              anchors.rightMargin: parent.contentRightInset
+              anchors.topMargin: parent.contentTopInset
+              spacing: Style.space(14)
+
+              Text {
+                textFormat: Text.PlainText
+                width: parent.width
+                text: "Rename " + ((root.renameTarget && root.renameTarget.label) || "application")
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.title
+                wrapMode: Text.WordWrap
+              }
+
+              TextField {
+                id: renameField
+                width: parent.width
+                text: root.renameName
+                placeholderText: "Application name"
+                foreground: root.foreground
+                accent: root.selectedText
+                onTextChanged: if (root.renameDialogOpen && text !== root.renameName) root.renameName = text
+                // Consume submit keys here. Otherwise the same Enter event
+                // reaches the menu key catcher after the dialog closes and
+                // launches the selected application.
+                Keys.onReturnPressed: function(event) {
+                  root.confirmRename()
+                  event.accepted = true
+                }
+                Keys.onEnterPressed: function(event) {
+                  root.confirmRename()
+                  event.accepted = true
+                }
+                Keys.onEscapePressed: function(event) {
+                  root.cancelRename()
+                  event.accepted = true
+                }
+              }
+
+              Row {
+                anchors.right: parent.right
+                spacing: Style.space(10)
+
+                Button {
+                  text: "Cancel"
+                  bordered: true
+                  foreground: root.foreground
+                  accent: root.selectedText
+                  onClicked: root.cancelRename()
+                }
+
+                Button {
+                  text: "Rename"
+                  bordered: true
+                  enabled: root.renameName.trim().length > 0
+                  foreground: root.foreground
+                  accent: root.selectedText
+                  onClicked: root.confirmRename()
+                }
+              }
+            }
+          }
         }
       }
 

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -6,7 +6,7 @@ import qs.Commons
 import "AppSearch.js" as AppSearch
 
 // Shared desktop-application library: the sorted entry list with hidden-entry
-// filtering, the icon fallback index, launch feedback, and entry removal.
+// filtering, the icon fallback index, launch feedback, and entry management.
 // Injected as shell.appLibrary; the menu's Apps submenu is the consumer.
 Item {
   id: root
@@ -89,6 +89,13 @@ Item {
     var id = String(desktopId || "")
     if (!id) return
     Util.execDetached(Util.shellQuote(root.omarchyPath + "/bin/omarchy-remove-launcher-entry") + " " + Util.shellQuote(id) + " " + Util.shellQuote(String(name || id)))
+  }
+
+  function rename(desktopId, name) {
+    var id = String(desktopId || "")
+    var nextName = String(name || "").trim()
+    if (!id || !nextName) return
+    Util.execDetached(Util.shellQuote(root.omarchyPath + "/bin/omarchy-rename-launcher-entry") + " " + Util.shellQuote(id) + " " + Util.shellQuote(nextName))
   }
 
   function normalizeDesktopId(id) {

--- a/test/shell.d/launcher-remove-test.sh
+++ b/test/shell.d/launcher-remove-test.sh
@@ -38,8 +38,11 @@ chmod +x "$tmp_dir/bin/update-desktop-database"
 
 cat >"$tmp_dir/bin/pacman" <<'SCRIPT'
 #!/bin/bash
-if [[ $1 == "-Qqo" && $2 == */native.desktop ]]; then
-  printf 'native-pkg\n'
+if [[ $1 == "-Qqo" ]]; then
+  case "$2" in
+    */native.desktop) printf 'native-pkg\n' ;;
+    */renamed.desktop) printf 'renamed-pkg\n' ;;
+  esac
 fi
 SCRIPT
 chmod +x "$tmp_dir/bin/pacman"
@@ -62,6 +65,19 @@ Name=Native
 Exec=native
 DESKTOP
 
+cat >"$tmp_dir/system/applications/renamed.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Original
+Exec=renamed
+DESKTOP
+
+cat >"$tmp_dir/data/applications/renamed.desktop" <<'DESKTOP'
+[Desktop Entry]
+X-Omarchy-Renamed=true
+Name=Custom Name
+Exec=renamed
+DESKTOP
+
 cat >"$tmp_dir/data/applications/aliens.desktop" <<'DESKTOP'
 [Desktop Entry]
 Name=Aliens
@@ -77,6 +93,7 @@ export XDG_DATA_DIRS="$tmp_dir/system"
 "$ROOT/bin/omarchy-remove-launcher-entry" Docker.desktop Docker
 "$ROOT/bin/omarchy-remove-launcher-entry" native.desktop Native
 "$ROOT/bin/omarchy-remove-launcher-entry" aliens.desktop Aliens
+"$ROOT/bin/omarchy-remove-launcher-entry" renamed.desktop 'Custom Name'
 
 mapfile -t lines <"$TEST_LOG"
 
@@ -92,5 +109,8 @@ pass "launcher remove opens package uninstall flow"
 [[ ! -e $tmp_dir/data/applications/aliens.desktop ]] || fail "launcher remove deletes user-owned desktop files"
 pass "launcher remove deletes user-owned desktop files"
 
-(( ${#lines[@]} == 3 )) || fail "launcher remove does not notify for user-owned desktop files" "$(printf '%s\n' "${lines[@]}")"
+[[ ${lines[3]} == "terminal::echo Uninstalling Custom\\ Name...; sudo pacman -Rns renamed-pkg && rm -f -- $tmp_dir/data/applications/renamed.desktop && update-desktop-database $tmp_dir/data/applications" ]] || fail "launcher remove uninstalls through a managed rename override" "${lines[3]}"
+pass "launcher remove uninstalls through a managed rename override"
+
+(( ${#lines[@]} == 4 )) || fail "launcher remove does not notify for user-owned desktop files" "$(printf '%s\n' "${lines[@]}")"
 pass "launcher remove does not notify for user-owned desktop files"

--- a/test/shell.d/launcher-rename-test.sh
+++ b/test/shell.d/launcher-rename-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/data/applications" "$tmp_dir/system/applications" "$tmp_dir/bin"
+
+cat >"$tmp_dir/bin/update-desktop-database" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' "$1" >>"$TEST_LOG"
+SCRIPT
+chmod +x "$tmp_dir/bin/update-desktop-database"
+
+cat >"$tmp_dir/system/applications/org.example.Editor.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Editor
+Name[fr]=Éditeur
+Comment=Edit files
+Exec=editor --open %F
+Type=Application
+
+[Desktop Action New]
+Name=New document
+Exec=editor --new
+DESKTOP
+
+export TEST_LOG="$tmp_dir/log"
+export PATH="$tmp_dir/bin:$PATH"
+export XDG_DATA_HOME="$tmp_dir/data"
+export XDG_DATA_DIRS="$tmp_dir/system"
+
+"$ROOT/bin/omarchy-rename-launcher-entry" org.example.Editor 'Work\Editor = Primary'
+
+renamed="$tmp_dir/data/applications/org.example.Editor.desktop"
+[[ -f $renamed ]] || fail "launcher rename creates a user desktop override"
+pass "launcher rename creates a user desktop override"
+
+grep -Fx 'Name=Work\\Editor = Primary' "$renamed" >/dev/null || fail "launcher rename escapes the replacement display name"
+pass "launcher rename escapes the replacement display name"
+
+grep -Fx 'X-Omarchy-Renamed=true' "$renamed" >/dev/null || fail "launcher rename marks an override of a system entry"
+pass "launcher rename marks system overrides for the uninstall path"
+
+[[ $(grep -c '^Name=' "$renamed") == 2 ]] || fail "launcher rename changes only the main desktop-entry name" "$(grep '^Name' "$renamed")"
+grep -Fx 'Name=New document' "$renamed" >/dev/null || fail "launcher rename preserves desktop action names"
+! grep -q '^Name\[' "$renamed" || fail "launcher rename removes localized names that would override the chosen name"
+grep -Fx 'Exec=editor --open %F' "$renamed" >/dev/null || fail "launcher rename preserves launch commands"
+pass "launcher rename changes only the application display name"
+
+grep -Fx 'Name=Editor' "$tmp_dir/system/applications/org.example.Editor.desktop" >/dev/null || fail "launcher rename leaves package-owned desktop files untouched"
+pass "launcher rename leaves package-owned desktop files untouched"
+
+[[ $(stat -c '%a' "$renamed") == 644 ]] || fail "launcher rename writes a non-executable desktop override"
+[[ $(cat "$TEST_LOG") == "$tmp_dir/data/applications" ]] || fail "launcher rename refreshes the user desktop database"
+pass "launcher rename installs the override safely"
+
+cp "$renamed" "$tmp_dir/data/applications/no-name.desktop"
+sed -i '/^X-Omarchy-Renamed=/d' "$tmp_dir/data/applications/no-name.desktop"
+sed -i '/^Name=/d' "$tmp_dir/data/applications/no-name.desktop"
+"$ROOT/bin/omarchy-rename-launcher-entry" no-name.desktop 'Added Name'
+grep -Fx 'Name=Added Name' "$tmp_dir/data/applications/no-name.desktop" >/dev/null || fail "launcher rename adds a missing main name"
+! grep -q '^X-Omarchy-Renamed=' "$tmp_dir/data/applications/no-name.desktop" || fail "launcher rename does not mark an in-place user entry"
+pass "launcher rename adds a missing main name"
+
+outside="$tmp_dir/outside.desktop"
+printf 'keep\n' >"$outside"
+ln -s "$outside" "$tmp_dir/data/applications/symlink.desktop"
+if "$ROOT/bin/omarchy-rename-launcher-entry" symlink Changed 2>/dev/null; then
+  fail "launcher rename rejects a symlink destination"
+fi
+[[ $(cat "$outside") == "keep" ]] || fail "launcher rename does not follow a destination symlink"
+pass "launcher rename refuses destination symlinks"
+
+if "$ROOT/bin/omarchy-rename-launcher-entry" '../outside' Changed 2>/dev/null; then
+  fail "launcher rename rejects path traversal ids"
+fi
+[[ $(cat "$outside") == "keep" ]] || fail "launcher rename path validation protects files outside the applications directory"
+pass "launcher rename rejects path traversal ids"
+
+if "$ROOT/bin/omarchy-rename-launcher-entry" org.example.Editor $'Injected\nExec=bad' 2>/dev/null; then
+  fail "launcher rename rejects multiline names"
+fi
+! grep -q '^Exec=bad$' "$renamed" || fail "launcher rename does not inject desktop-entry keys"
+pass "launcher rename rejects desktop-entry injection"
+
+menu_qml="$ROOT/shell/plugins/menu/Menu.qml"
+app_library_qml="$ROOT/shell/services/AppLibrary.qml"
+grep -F 'event.key === Qt.Key_R' "$menu_qml" >/dev/null || fail "menu handles the R key for rename"
+grep -F '(event.modifiers & Qt.ControlModifier)' "$menu_qml" >/dev/null || fail "menu requires Ctrl for rename"
+grep -F 'root.requestRenameSelected()' "$menu_qml" >/dev/null || fail "menu invokes rename for the selected application"
+grep -F 'if (!row || row.kind !== "app") return false' "$menu_qml" >/dev/null || fail "menu limits rename to application rows"
+grep -F 'root.appLibrary.rename(target.appId, nextName)' "$menu_qml" >/dev/null || fail "menu delegates application renames to AppLibrary"
+grep -F 'Keys.onReturnPressed' "$menu_qml" >/dev/null || fail "rename field consumes Return"
+grep -F 'Keys.onEnterPressed' "$menu_qml" >/dev/null || fail "rename field consumes Enter"
+grep -F 'event.accepted = true' "$menu_qml" >/dev/null || fail "rename field consumes submit events"
+grep -F '/bin/omarchy-rename-launcher-entry' "$app_library_qml" >/dev/null || fail "AppLibrary invokes the rename helper"
+pass "menu exposes the guarded application rename flow"


### PR DESCRIPTION
## Summary
- Add a Ctrl+R rename dialog for application entries in the Omarchy menu.
- Store renames as safe per-user desktop-entry overrides, preserving package-owned files.
- Keep uninstall behavior intact and remove managed overrides when the underlying package is removed.
- Consume rename-dialog Enter/Escape events so Enter does not launch the app immediately.

## Testing
- `qmllint -I shell shell/services/AppLibrary.qml shell/plugins/menu/Menu.qml`
- `bash test/shell.d/launcher-rename-test.sh`
- `bash test/shell.d/launcher-remove-test.sh`
- `bash test/shell.d/app-search-test.sh`
- `./test/cli`

`./test/all` also ran; unrelated environment-dependent failures remain in tests requiring a separate `omarchy-pkgs` checkout, compositor access, or package permissions.