### PR TITLE
fix(notifications): group identical notifications the way mako did

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -37,6 +37,8 @@ from a dead server generation (ids restart from 1 each shell process), so
 they are keyed by timestamp+id and never matched against live objects — a
 fresh notification reusing an old id must not dismiss or replace them.
 
+Exact duplicates are grouped, the way Omarchy 3.8 configured mako (`group-by=app-name,summary,body`). Among the popups on screen, rows with the same app name, summary and body form one group; only the newest member is drawn, with the group size prefixed to its summary (`(3) Task finished`, mako's default grouped format). Every member stays in the model, so each keeps its own server object, countdown, click action, persistence file and history entry, and the delegate only hides the older rows. Click and close act on the visible member, so the next member takes its place with a lower count, matching mako's default bindings. Multi-window Electron apps are the usual source: each window can emit the same completed-task notification under a fresh id, which `replaces_id` handling cannot catch.
+
 ## Silencing
 
 Do-not-disturb is a single boolean, persisted as the `dnd` key in

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -223,6 +223,42 @@ function popupRowChanged(row, updated) {
   return false
 }
 
+// Match mako's grouping contract from Omarchy 3.8: among visible
+// notifications, exact app-name + summary + body matches form one group. The
+// newest row is the leader because popupModel is newest-first. Keep every row
+// in the model so each server notification retains its own lifetime, action,
+// persistence file and history entry; the delegate only hides older members.
+function popupGroup(model, index) {
+  // Reading count and each row's fields here is what makes the QML binding
+  // follow inserts, removals and in-place replaces_id rewrites.
+  var count = Array.isArray(model) ? model.length : (model && Number(model.count)) || 0
+
+  function rowAt(i) {
+    if (Array.isArray(model)) return model[i]
+    return model && typeof model.get === "function" ? model.get(i) : null
+  }
+
+  function sameVisibleContent(a, b) {
+    var left = a || {}
+    var right = b || {}
+    return String(left.app || "") === String(right.app || "")
+      && String(left.summary || "") === String(right.summary || "")
+      && String(left.body || "") === String(right.body || "")
+  }
+
+  var current = rowAt(index)
+  if (!current) return { count: 0, leader: false }
+
+  var matches = 0
+  var leader = true
+  for (var i = 0; i < count; i++) {
+    if (!sameVisibleContent(current, rowAt(i))) continue
+    matches++
+    if (i < index) leader = false
+  }
+  return { count: matches, leader: leader }
+}
+
 // A client updating a notification through replaces_id keeps the identity of
 // the popup it took over: the file name is the timestamp and id the popup was
 // first persisted under, and the restore, replace and archive paths all key
@@ -462,6 +498,7 @@ if (typeof module !== "undefined") {
     snapshotOf: snapshotOf,
     popupRoles: popupRoles,
     popupRowChanged: popupRowChanged,
+    popupGroup: popupGroup,
     replacementSnapshot: replacementSnapshot,
     historyEntry: historyEntry,
     parseSettings: parseSettings,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -1004,6 +1004,13 @@ Item {
             required property double expireTimeout
             required property double timestamp
 
+            // Omarchy's former mako daemon grouped exact app-name + summary +
+            // body matches. Keep every notification alive in the model, but
+            // draw only the newest member and expose the group size in its
+            // summary, matching mako's default grouped format.
+            readonly property var group: NotificationLogic.popupGroup(popupModel, cardSlot.index)
+            visible: cardSlot.group.leader
+
             // Each card sizes itself based on mode (text vs media); the slot
             // tracks the card so the column auto-fits to whichever is widest.
             Layout.preferredWidth: card.implicitWidth
@@ -1043,7 +1050,9 @@ Item {
               anchors.right: parent.right
               app: cardSlot.app
               appIcon: cardSlot.appIcon
-              summary: cardSlot.summary
+              summary: cardSlot.group.count > 1
+                ? "(" + cardSlot.group.count + ") " + cardSlot.summary
+                : cardSlot.summary
               body: cardSlot.body
               image: cardSlot.image
               urgency: cardSlot.urgency

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -360,6 +360,65 @@ assert(
   'notifications ignore identity fields when deciding whether a refresh has work'
 )
 
+// Omarchy 3.8's mako configuration grouped visible notifications by the exact
+// app-name, summary and body tuple. Keep that behavior when different D-Bus ids
+// carry the same visible notification (Electron renderers can each emit one).
+const groupedPopups = [
+  { originalId: 21, app: 'ChatGPT', summary: 'Task finished', body: 'The answer is ready', urgency: 1 },
+  { originalId: 22, app: 'ChatGPT', summary: 'Task finished', body: 'The answer is ready', urgency: 2 },
+  { originalId: 23, app: 'ChatGPT', summary: 'Task finished', body: 'A different answer is ready', urgency: 1 },
+  { originalId: 24, app: 'Mail', summary: 'Task finished', body: 'The answer is ready', urgency: 1 }
+]
+assertDeepEqual(
+  notifications.popupGroup(groupedPopups, 0),
+  { count: 2, leader: true },
+  'notifications make the newest exact content match the visible group leader'
+)
+assertDeepEqual(
+  notifications.popupGroup(groupedPopups, 1),
+  { count: 2, leader: false },
+  'notifications hide older members of an exact content group'
+)
+assertDeepEqual(
+  notifications.popupGroup({ count: groupedPopups.length, get: index => groupedPopups[index] }, 0),
+  { count: 2, leader: true },
+  'notifications group rows read through the QML ListModel contract'
+)
+assertDeepEqual(
+  notifications.popupGroup(groupedPopups.slice(1), 0),
+  { count: 1, leader: true },
+  'notifications promote the next member when the group leader leaves'
+)
+assertDeepEqual(
+  notifications.popupGroup(groupedPopups, 99),
+  { count: 0, leader: false },
+  'notifications treat a missing row as no group'
+)
+assertDeepEqual(
+  notifications.popupGroup(groupedPopups, 2),
+  { count: 1, leader: true },
+  'notifications do not group a different body'
+)
+assertDeepEqual(
+  notifications.popupGroup(groupedPopups, 3),
+  { count: 1, leader: true },
+  'notifications do not group a different app'
+)
+
+const groupingServiceQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/Service.qml'), 'utf8')
+assert(
+  /readonly property var group: NotificationLogic\.popupGroup\(popupModel, cardSlot\.index\)/.test(groupingServiceQml),
+  'the popup delegate derives its visible group from the complete live model'
+)
+assert(
+  /visible: cardSlot\.group\.leader/.test(groupingServiceQml),
+  'only the newest member of an exact notification group is visible'
+)
+assert(
+  /cardSlot\.group\.count > 1[\s\S]*cardSlot\.group\.count/.test(groupingServiceQml),
+  'a grouped notification shows how many exact copies were received'
+)
+
 const settings = notifications.parseSettings(JSON.stringify({ version: 3, dnd: true }))
 assertEqual(settings.dnd, true, 'notifications parse the persisted DND state')
 assertEqual(settings.legacy, false, 'notifications do not flag a current settings file as legacy')


### PR DESCRIPTION
Fixes #10145.

## Summary

- restore the exact `app-name + summary + body` grouping Omarchy 3.8 configured in mako (5c3ca608), lost when the Quickshell daemon replaced mako (c1015912)
- draw only the newest member of each live group and prefix its summary with the group size, mako's default `(%g) %s` format
- keep every underlying row so each notification keeps its own server object, click action, countdown, persistence file and history entry; the delegate only hides the older members, and hidden members take no layout space
- cover the grouping decision and the delegate wiring in `test/shell.d/notifications-test.sh`
- document the behavior in `docs/notifications.md`

## Why

The Quickshell service correctly handles `replaces_id` through `originalId` (020cb537), but that only catches a sender that reuses an id. Multi-window Electron apps emit the same notification once per window under fresh ids. With the ChatGPT desktop app and four windows open, every completed response in a session produced two or three D-Bus notifications with identical app, summary, body, urgency, icon and expiry, 25 to 55 ms apart. That sender bug is reported to OpenAI as openai/codex#42705; this change restores the desktop-side behavior Omarchy already shipped, which covers every such sender.

Related: #7834 (mako replacement hints lost in the same transition), #9671 (asks for the same app + summary + body coalescing on restore; restored rows land in the same model and are grouped by this change), discussion #4285.

There is no time-window heuristic. Grouping uses the same exact fields and the same "currently on screen" scope as the mako configuration, so it never merges a new notification with one the user already dismissed.

## Behavior worth knowing

- Click and close act on the visible member; the next member then shows with a lower count. This matches mako's default bindings (`dismiss`, not `dismiss-group`). Dismissing the whole group on click is a small follow-up in `removePopup` if preferred.
- The group key ignores urgency, as mako's did, so a critical duplicate can outlive the normal one that led the group.
- Duplicates still archive to history individually. `showHistory` replays into the same model, so the replay is grouped too, but each duplicate still takes one of the ten history slots.

## Testing

- `bash test/shell.d/notifications-test.sh` — passes (145 assertions, 9 new)
- the new assertions against the unmodified source fail on the missing `popupGroup` export (red), pass with the change (green)
- `./test/all` on the committed tree — `test/cli` passes; `test/shell` passes except the three files that need a sibling `omarchy-pkgs` checkout, which fail identically on unmodified `quattro` here
- `git diff --check` — clean
- headless QML probe of the delegate binding (`ListModel` + `Repeater`) under Qt 6.11.2: newest member leads, in-place `replaces_id` rewrites regroup, hidden rows reserve no layout height
- live check in the running shell (installed 4.0.2-1 with only the two patched files swapped in, then restored): exact duplicate, different body, different app, three copies then `dismissOne` twice, `invokeLast` with two different `--exec` argv (only the newest member's command ran), `replaces_id` update, `showHistory` replay. Captures below.

## Captures

Before, two identical notifications on current `quattro`:

![before: two identical cards](https://github.com/user-attachments/assets/02c7ab11-ed62-4568-999d-0cab1b3e3a40)


After, the same two notifications:

![after: one card reading (2) Grouping probe](https://github.com/user-attachments/assets/3b78029f-d712-4500-a0d0-9c9e3dd302b3)


Controls stay separate. Different body:

![different body: two cards](https://github.com/user-attachments/assets/4e656890-f90a-4119-9112-6d309b2baefa)

Different app name:

![different app: two cards](https://github.com/user-attachments/assets/e8b925af-d2cb-493e-aa43-066a6cc451d1)

Three copies, then `dismissOne` twice (top to bottom):

![three copies then dismiss twice](https://github.com/user-attachments/assets/29a85c94-a410-4762-b6b1-1fb0767b93a2)

Click on a `(2)` group runs the newest member's action and leaves the older member (top); a `replaces_id` update rewrites in place without a count (bottom):

![click handover and replaces_id](https://github.com/user-attachments/assets/f157ac08-4d6b-4cc9-84c0-809ac99af66c)

History replay groups identical entries too:

![history replay](https://github.com/user-attachments/assets/41f0ce45-54d6-487b-9f97-dd8e9cd8644d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

