### PR TITLE
Use software volume for Audient USB audio interfaces

### DIFF
--- a/config/wireplumber/wireplumber.conf.d/audient-soft-mixer.conf
+++ b/config/wireplumber/wireplumber.conf.d/audient-soft-mixer.conf
@@ -1,0 +1,33 @@
+## Audient USB interfaces: attenuate in software, not through the device mixer.
+##
+## Their USB playback path declares no controls at all. On an iD14 that path is
+## InputTerminal 2 -> ExtensionUnit 51 -> FeatureUnit 10 -> OutputTerminal 20
+## "Speaker", and every bmaControls entry of FeatureUnit 10 is 0x00000000. The one
+## playback volume element the driver can expose, "Speaker Playback Volume", is
+## FeatureUnit 12, fed by MixerUnit 60 -- the interface's internal monitor mixer,
+## not the stream coming from the host. ACP binds it as the sink's hardware volume
+## anyway, so the output slider moves only part of the analog output: on an iD14
+## with balanced monitors it changes the right speaker and leaves the left alone.
+##
+## Matching the vendor keeps this narrow, and the rule is inert on a machine with
+## no Audient interface attached. That is what separates it from
+## default/wireplumber/wireplumber.conf.d/alsa-soft-mixer.conf, which matches every
+## card and stays opt-in because soft mixing is not right for all hardware.
+##
+## soft-mixer has to sit on the device rather than the node: with api.alsa.use-acp
+## enabled ACP owns the mixer and never reads the node-level property.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        device.vendor.id = "0x2708"
+      }
+    ]
+    actions = {
+      update-props = {
+        api.alsa.soft-mixer = true
+      }
+    }
+  }
+]

--- a/migrations/1788513270.sh
+++ b/migrations/1788513270.sh
@@ -1,0 +1,28 @@
+echo "Use software volume for Audient USB audio interfaces"
+
+alsa_procfs="${OMARCHY_ALSA_PROCFS:-/proc/asound}"
+audient_cards=()
+
+for usbid in "$alsa_procfs"/card*/usbid; do
+  [[ -r $usbid ]] || continue
+  [[ $(<$usbid) == 2708:* ]] || continue
+  [[ $usbid =~ /card([0-9]+)/ ]] && audient_cards+=("${BASH_REMATCH[1]}")
+done
+
+# Seed the rule whether or not an interface is attached: it is inert without one,
+# and it has to already be in place for an interface plugged in later.
+destination=~/.config/wireplumber/wireplumber.conf.d/audient-soft-mixer.conf
+[[ -f $destination ]] || omarchy-refresh-config wireplumber/wireplumber.conf.d/audient-soft-mixer.conf
+
+if (( ${#audient_cards[@]} > 0 )); then
+  # Restart before touching the mixer: while the old binding is still live,
+  # WirePlumber writes its stored volume straight back into the element below.
+  omarchy-restart-audio
+
+  # ACP drove "Speaker Playback Volume" as the sink's hardware volume, so an
+  # interface last left mid-attenuation would keep that attenuation now that
+  # WirePlumber no longer moves the element. Put it back to 0 dB.
+  for card in "${audient_cards[@]}"; do
+    amixer -c "$card" sset Speaker 100% >/dev/null 2>&1 || true
+  done
+fi

--- a/test/shell.d/audient-soft-mixer-migration-test.sh
+++ b/test/shell.d/audient-soft-mixer-migration-test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1788513270.sh"
+shipped="$ROOT/config/wireplumber/wireplumber.conf.d/audient-soft-mixer.conf"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/omarchy-restart-audio" <<'SH'
+#!/bin/bash
+
+echo 'omarchy-restart-audio' >>"$CALLS"
+SH
+
+cat >"$stub_bin/amixer" <<'SH'
+#!/bin/bash
+
+printf 'amixer %s\n' "$*" >>"$CALLS"
+SH
+
+chmod +x "$stub_bin"/*
+
+export CALLS="$test_tmp/calls"
+
+reset_machine() {
+  test_home="$test_tmp/home"
+  asound="$test_tmp/asound"
+
+  rm -rf "$test_home" "$asound"
+  mkdir -p "$test_home" "$asound"
+}
+
+add_card() {
+  mkdir -p "$asound/card$1"
+  printf '%s\n' "$2" >"$asound/card$1/usbid"
+}
+
+seeded_rule() {
+  printf '%s/.config/wireplumber/wireplumber.conf.d/audient-soft-mixer.conf' "$test_home"
+}
+
+run_migration() {
+  : >"$CALLS"
+
+  HOME="$test_home" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_ALSA_PROCFS="$asound" \
+    PATH="$stub_bin:$ROOT/bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+# An attached interface gets the rule, a restart to pick it up, and its mixer
+# element put back where WirePlumber will no longer move it.
+reset_machine
+add_card 0 "8086:2668"
+add_card 2 "2708:0002"
+run_migration
+
+cmp -s "$(seeded_rule)" "$shipped" ||
+  fail "migration seeds the shipped rule"
+pass "migration seeds the shipped rule"
+
+grep -qx 'omarchy-restart-audio' "$CALLS" ||
+  fail "migration restarts audio so the rule takes effect" "$(cat "$CALLS")"
+pass "migration restarts audio so the rule takes effect"
+
+grep -qx 'amixer -c 2 sset Speaker 100%' "$CALLS" ||
+  fail "migration puts the interface mixer back to 0 dB" "$(cat "$CALLS")"
+pass "migration puts the interface mixer back to 0 dB"
+
+if grep -q 'amixer -c 0' "$CALLS"; then
+  fail "migration leaves cards from other vendors alone" "$(cat "$CALLS")"
+fi
+pass "migration leaves cards from other vendors alone"
+
+# The rule is inert without the hardware, so it is seeded anyway and nothing
+# else on the machine gets disturbed for it.
+reset_machine
+add_card 0 "8086:2668"
+run_migration
+
+cmp -s "$(seeded_rule)" "$shipped" ||
+  fail "migration seeds the rule with no interface attached"
+pass "migration seeds the rule with no interface attached"
+
+[[ ! -s $CALLS ]] ||
+  fail "migration touches no audio state with no interface attached" "$(cat "$CALLS")"
+pass "migration touches no audio state with no interface attached"
+
+# Someone who already wrote this rule by hand keeps their version.
+reset_machine
+add_card 2 "2708:0002"
+mkdir -p "$(dirname "$(seeded_rule)")"
+printf '# hand written\n' >"$(seeded_rule)"
+run_migration
+
+grep -qx '# hand written' "$(seeded_rule)" ||
+  fail "migration keeps a hand-written rule" "$(cat "$(seeded_rule)")"
+pass "migration keeps a hand-written rule"


### PR DESCRIPTION
On an Audient iD14 the output slider moves only the right speaker. These interfaces expose no volume control on the USB playback path at all, so ACP falls back to `Speaker Playback Volume` — an element that belongs to the interface's internal monitor mixer, not to the stream coming from the host. Turning it does something, just not what the slider promises.

This puts Audient devices on the software mixer instead. It matches the vendor id, so it stays inert on a machine with no Audient interface attached — not the global `~alsa_card.*` soft mixer that 21514dc5 made opt-in. It also can't ride along with the Asus ROG fix in `install/user/hardware/`, since a USB interface gets plugged in long after install.

The migration restarts audio before resetting the mixer element, because the old binding writes its stored volume straight back otherwise. Without that reset, anyone whose volume was turned down keeps the attenuation forever, now that WirePlumber no longer moves the element.

Verified on an iD14; extended to the vendor because the iD and EVO range shares this firmware.