### PR TITLE
Match Google Meet PiP titles that use an en dash

### DIFF
--- a/default/hypr/apps/pip.lua
+++ b/default/hypr/apps/pip.lua
@@ -12,10 +12,12 @@ o.window({ tag = "pip" }, {
 })
 
 -- Google Meet PiP uses the meeting title instead of "Picture-in-Picture".
-o.window({ tag = "chromium-based-browser", title = "^Meet - .+" }, {
+-- Chromium titles the overlay with an en dash (U+2013); keep ASCII and em dash too.
+o.window({ tag = "chromium-based-browser", title = "^Meet (-|–|—) .+" }, {
   tag = "-default-opacity",
   float = true,
   pin = true,
+  group = "deny",
   size = { 600, 338 },
   keep_aspect_ratio = true,
   border_size = 0,

--- a/test/shell.d/hyprland-pip-test.sh
+++ b/test/shell.d/hyprland-pip-test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command python3
+
+ROOT="$ROOT" python3 <<'PY' || fail "Meet PiP title regex matches ASCII hyphen, en dash, and em dash"
+import os
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(os.environ["ROOT"], "default/hypr/apps/pip.lua").read_text()
+match = re.search(r'title = "(\^Meet[^"]+)"', text)
+if match is None:
+    print("pip.lua has no Meet title rule", file=sys.stderr)
+    sys.exit(1)
+
+pattern = match.group(1)
+cases = {
+    "Meet - Team standup": True,
+    "Meet – Team standup": True,
+    "Meet — Team standup": True,
+    "Meet": False,
+    "Meeting notes": False,
+    "Chrome - Meet": False,
+}
+
+for title, should_match in cases.items():
+    matched = re.search(pattern, title) is not None
+    if matched != should_match:
+        print(f"{title!r} vs {pattern!r}: matched={matched} expected={should_match}", file=sys.stderr)
+        sys.exit(1)
+PY
+pass "Meet PiP title regex matches ASCII hyphen, en dash, and em dash"


### PR DESCRIPTION
Chromium titles the Meet PiP overlay with an en dash, so `pip.lua`'s ASCII hyphen rule never matched and the overlay stayed tiled (and grouped). Accept hyphen, en dash, and em dash, and deny grouping.

Fixes #10152