### PR TITLE
Keep Hyprland exec-rule brackets outside uwsm-app

### DIFF
--- a/default/hypr/helpers.lua
+++ b/default/hypr/helpers.lua
@@ -106,6 +106,14 @@ function o.bind(keys, description, dispatcher, options)
 end
 
 function o.launch(command)
+  -- Hyprland exec rules (`[workspace N silent]`, `[float]`, …) have to stay
+  -- outside uwsm-app: uwsm parses argv itself and otherwise looks up `[workspace`
+  -- as a binary.
+  local prefix, rest = command:match("^(%b[])%s+(.*)$")
+  if prefix and rest ~= "" then
+    return prefix .. " uwsm-app -- " .. rest
+  end
+
   return "uwsm-app -- " .. command
 end
 

--- a/test/shell.d/hyprland-launch-test.sh
+++ b/test/shell.d/hyprland-launch-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+
+launch_output=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+hl = {}
+require("default.hypr.helpers")
+print(o.launch("foot"))
+print(o.launch("[workspace 4 silent] foot"))
+print(o.launch("[float] kitty --class notes"))
+LUA
+) || fail "o.launch can be evaluated"
+
+expected=$'uwsm-app -- foot\n[workspace 4 silent] uwsm-app -- foot\n[float] uwsm-app -- kitty --class notes'
+[[ $launch_output == "$expected" ]] || fail "o.launch keeps Hyprland exec-rule brackets outside uwsm-app" "$launch_output"
+pass "o.launch keeps Hyprland exec-rule brackets outside uwsm-app"


### PR DESCRIPTION
`o.launch("[workspace 4 silent] foot")` became `uwsm-app -- [workspace 4 silent] foot`, so uwsm looked up `[workspace` as a binary and the window never appeared. Keep a leading `[…]` exec-rule prefix outside `uwsm-app --`.

Fixes #10137