### PR TITLE
Show Done in the presentation terminal only on success

### DIFF
--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -8,6 +8,6 @@
 source omarchy-restart-gum
 
 cmd="$*"
-presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
+presentation_script="omarchy-show-logo; $cmd; status=\$?; if (( status == 0 )); then omarchy-show-done; elif (( status != 130 )); then printf '\\nPress any key to close...' >/dev/tty; read -rsn 1 </dev/tty; fi"
 
 exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"

--- a/test/shell.d/floating-terminal-test.sh
+++ b/test/shell.d/floating-terminal-test.sh
@@ -21,3 +21,13 @@ export PATH="$tmp_dir:$ROOT/bin:$PATH"
 launch=$(<"$TEST_LOG")
 [[ $launch == *"xdg-terminal-exec --app-id=org.omarchy.terminal"* ]] || fail "floating terminal launches Omarchy terminal" "$launch"
 pass "floating terminal launches Omarchy terminal"
+
+# Ctrl-C is 130; every other non-zero used to be presented as success.
+[[ $launch == *'if (( status == 0 )); then omarchy-show-done;'* ]] ||
+  fail "presentation wrapper shows Done only after a successful command" "$launch"
+[[ $launch == *'elif (( status != 130 )); then'* ]] ||
+  fail "presentation wrapper waits on failure instead of closing immediately" "$launch"
+if [[ $launch == *'$? != 130'* ]]; then
+  fail "presentation wrapper does not treat a non-zero exit as success" "$launch"
+fi
+pass "presentation wrapper shows Done only after a successful command"


### PR DESCRIPTION
`omarchy-launch-floating-terminal-with-presentation` showed Done for every exit except 130, so a rejected web-app name still got the success prompt. Show Done only on 0; wait for a key on other failures so the error stays readable; close immediately on Ctrl-C.

Fixes #10104