### PR TITLE
Remove stock linux even when linux-headers is absent

### DIFF
--- a/install/hardware/intel/ptl-kernel.sh
+++ b/install/hardware/intel/ptl-kernel.sh
@@ -5,7 +5,12 @@ if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
   echo "Detected Dell XPS Panther Lake, installing PTL kernel..."
 
   omarchy-pkg-add linux-ptl linux-ptl-headers
-  pacman -Rdd --noconfirm linux linux-headers || true
+  # pacman -R aborts the whole transaction when any target is missing, so a
+  # machine without linux-headers would keep stock linux too.
+  for pkg in linux linux-headers; do
+    pacman -Qq "$pkg" &>/dev/null || continue
+    pacman -Rdd --noconfirm "$pkg" || echo "WARNING: could not remove $pkg"
+  done
 
   # linux-ptl doesn't provide=linux, so anything depending on linux drags the
   # stock kernel back in and the boot menu grows a second, slower entry.

--- a/test/shell.d/ptl-kernel-test.sh
+++ b/test/shell.d/ptl-kernel-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+script="$ROOT/install/hardware/intel/ptl-kernel.sh"
+
+if grep -E 'pacman[[:space:]]+-Rdd.*linux-headers.*[[:space:]]linux([[:space:]]|$)|pacman[[:space:]]+-Rdd.*[[:space:]]linux[[:space:]].*linux-headers' "$script" >/dev/null; then
+  fail "PTL kernel swap must not abort the whole removal when linux-headers is missing"
+fi
+pass "PTL kernel swap does not remove linux and linux-headers in one transaction"
+
+grep -q 'for pkg in linux linux-headers' "$script" ||
+  fail "PTL kernel swap removes each stock kernel package on its own"
+grep -Fq 'pacman -Rdd --noconfirm "$pkg" ||' "$script" ||
+  fail "PTL kernel swap keeps a failed package removal from aborting the boot-order drop-in"
+pass "PTL kernel swap removes each stock kernel package on its own"


### PR DESCRIPTION
`pacman -Rdd linux linux-headers` aborts the whole transaction when `linux-headers` is not installed, so XPS Panther Lake installs kept stock `linux`. Remove each package on its own, and keep a failed removal from skipping the BOOT_ORDER drop-in.

Fixes #10154