### PR TITLE
Document that bar-widget plugins need a shell restart

### DIFF
--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -194,7 +194,7 @@ cp ~/.config/hypr/bindings.lua ~/.config/hypr/bindings.lua.bak.$(date +%s)
 
 # 4. Apply changes
 # - Hyprland: auto-reloads on save, but MUST validate with `hyprctl reload` and `hyprctl configerrors`
-# - Omarchy shell: shell.json and user plugin code under ~/.config/omarchy/plugins/ hot-reload on save
+# - Omarchy shell: shell.json hot-reloads on save; bar-widget plugin instances need `omarchy restart shell`
 # - Menus/launcher: ~/.config/omarchy/extensions/omarchy-menu.jsonc hot-reloads on save
 # - Terminals: apply with `omarchy restart terminal` (reloads running terminals; foot picks changes up in new windows)
 ```

--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -35,15 +35,16 @@ Clone it into the user plugin directory instead:
 
 ```bash
 omarchy plugin clone omarchy.workspaces
-# Edit ~/.config/omarchy/plugins/<username>.workspaces/; saved changes reload automatically.
+# Edit ~/.config/omarchy/plugins/<username>.workspaces/
 ```
 
 Cloning switches the bar to the cloned copy (e.g. `<username>.workspaces`),
 which is yours to edit and survives updates.
 
-Saving a file anywhere under `~/.config/omarchy/plugins/` reloads plugin code
-automatically. If a change somehow fails to apply, force a reload with
-`omarchy-shell shell rescanPlugins`.
+Saving a file under `~/.config/omarchy/plugins/` reloads plugin *definitions*.
+Panels and overlays instantiate from that definition the next time they open.
+A live bar-widget instance is not rebuilt on save, so new properties, processes, timers, or UI added to a bar-widget need `omarchy restart shell`.
+`omarchy-shell shell rescanPlugins` re-reads manifests; it does not replace a live bar-widget instance.
 
 ## Idle and Lock
 

--- a/test/shell.d/plugins-skill-test.sh
+++ b/test/shell.d/plugins-skill-test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+skill="$ROOT/default/agents/skills/omarchy/plugins.md"
+parent="$ROOT/default/agents/skills/omarchy/SKILL.md"
+
+if grep -Eq 'reloads plugin code|saved changes reload automatically|plugin code under ~/.config/omarchy/plugins/ hot-reload' "$skill" "$parent"; then
+  fail "shipped agent skills do not claim every plugin kind hot-reloads on save"
+fi
+pass "shipped agent skills do not claim every plugin kind hot-reloads on save"
+
+grep -Fq 'the next time they open' "$skill" ||
+  fail "plugins.md says panels and overlays instantiate the next time they open"
+grep -Fq 'need `omarchy restart shell`' "$skill" ||
+  fail "plugins.md tells agents to restart the shell for bar-widget instance changes"
+pass "plugins.md tells agents to restart the shell for bar-widget instance changes"


### PR DESCRIPTION
The shipped plugin skill said saving under `~/.config/omarchy/plugins/` reloads plugin code. That is true for definitions and for panels that instantiate on open, not for a live bar-widget instance. Call out `omarchy restart shell` for bar-widget wiring changes.

Fixes #10126