### PR TITLE
Resolve mise wrappers to @latest on each run

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -27,17 +27,33 @@ esac
 
 mkdir -p "$HOME/.local/bin"
 
+# Append @latest only when the spec has no version. npm:@scope/name uses @
+# for the scope, so that form still needs @latest; tool@1.2.3 does not.
+# Backend specs with [options] or http: already carry their own version
+# source; @latest would mangle them.
+if [[ $package == *@latest || $package == npm:@*/*@* ]]; then
+  spec=$package
+elif [[ $package == npm:@*/* ]]; then
+  spec="$package@latest"
+elif [[ $package == *@* ]]; then
+  spec=$package
+elif [[ $package == *'['* || $package == http:* ]]; then
+  spec=$package
+else
+  spec="$package@latest"
+fi
+
 # The heredoc below is unquoted, so whatever these hold is written into the
 # wrapper as shell source. Quote them the way omarchy-install-and-launch does, so
 # a package name carrying shell characters stays one argument instead of running.
-printf -v package_arg '%q' "$package"
+printf -v package_arg '%q' "$spec"
 printf -v bin_arg '%q' "$bin"
 
 # Keep values that are inert inside double quotes in the form existing migrations
 # recognize, including mise backend options that %q would unnecessarily escape.
-case "$package" in
+case "$spec" in
   *'$'* | *'`'* | *'"'* | *'\'* | *'!'* | *[[:cntrl:]]*) ;;
-  *) package_arg="\"$package\"" ;;
+  *) package_arg="\"$spec\"" ;;
 esac
 case "$bin" in
   *'$'* | *'`'* | *'"'* | *'\'* | *'!'* | *[[:cntrl:]]*) ;;

--- a/bin/omarchy-remove-preinstalls
+++ b/bin/omarchy-remove-preinstalls
@@ -20,7 +20,7 @@ if gum confirm "Are you sure you want to remove all preinstalled web apps, TUI w
   # Cursor's own installer links ~/.local/bin/cursor-agent as well, so only
   # the mise wrapper omarchy-mise-install wrote is a preinstall.
   if [[ -f ~/.local/bin/cursor-agent && ! -L ~/.local/bin/cursor-agent ]] &&
-    grep -Eq '^mise use -g .*"cursor-agent"' ~/.local/bin/cursor-agent; then
+    grep -Eq '^mise use -g .*"cursor-agent(@latest)?"' ~/.local/bin/cursor-agent; then
     rm -f ~/.local/bin/cursor-agent
   fi
 

--- a/migrations/1785846769.sh
+++ b/migrations/1785846769.sh
@@ -4,6 +4,6 @@ if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
   omarchy-mise-install github:can1357/oh-my-pi omp
   omarchy-mise-install npm:@xai-official/grok grok
   omarchy-mise-install crush
-elif [[ -f $HOME/.local/bin/omp ]] && grep -Eq 'mise use -g .*"oh-my-pi"' "$HOME/.local/bin/omp"; then
+elif [[ -f $HOME/.local/bin/omp ]] && grep -Eq 'mise use -g .*"oh-my-pi(@latest)?"' "$HOME/.local/bin/omp"; then
   rm -f "$HOME/.local/bin/omp"
 fi

--- a/migrations/1786719479.sh
+++ b/migrations/1786719479.sh
@@ -27,7 +27,7 @@ fi
 # Remove Preinstalls no longer lists gemini, so Omarchy's own wrapper would
 # linger with nothing left to clean it up. Anchored to the line the installer
 # writes, so a hand-written wrapper that merely mentions it is left alone.
-if [[ -f $HOME/.local/bin/gemini ]] && grep -Eq '^mise use -g .*"gemini"' "$HOME/.local/bin/gemini"; then
+if [[ -f $HOME/.local/bin/gemini ]] && grep -Eq '^mise use -g .*"gemini(@latest)?"' "$HOME/.local/bin/gemini"; then
   rm -f "$HOME/.local/bin/gemini"
 fi
 

--- a/migrations/1789093830.sh
+++ b/migrations/1789093830.sh
@@ -1,0 +1,29 @@
+echo "Refresh mise wrappers so they resolve @latest on each run"
+
+# omarchy-mise-install now writes `mise use -g --quiet "<tool>@latest"` so a
+# wrapper cannot stay pinned on a stale installed version. Wrappers already on
+# disk still call the bare tool name (e.g. claude@latest is the target form).
+# Rewrite the exact --quiet template through omarchy-mise-install.
+
+stale_quiet_template() {
+  printf '#!/bin/bash\nexport MISE_MINIMUM_RELEASE_AGE=0\nmise use -g --quiet "%s" || exit 1\nexec mise x "%s" -- "%s" "$@"' "$1" "$1" "$2"
+}
+
+bin_dir="$HOME/.local/bin"
+
+[[ -d $bin_dir ]] || exit 0
+
+for wrapper in "$bin_dir"/*; do
+  [[ -f $wrapper && ! -L $wrapper && -r $wrapper ]] || continue
+  (($(stat -c%s "$wrapper") <= 1024)) || continue
+
+  contents=$(<"$wrapper")
+  package=$(sed -n 's/^mise use -g --quiet "\(.*\)" || exit 1$/\1/p' <<<"$contents")
+  bin=$(sed -n 's/^exec mise x ".*" -- "\(.*\)" "\$@"$/\1/p' <<<"$contents")
+
+  [[ -n $package && -n $bin ]] || continue
+  [[ $package == *@latest ]] && continue
+  [[ $contents == "$(stale_quiet_template "$package" "$bin")" ]] || continue
+
+  omarchy-mise-install "$package" "${wrapper##*/}" "$bin"
+done

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -122,22 +122,23 @@ muse_package="http:muse[url=https://api.meta.ai/muse-launcher.sh,bin=muse,versio
 assert_lazy_stub() {
   local package=$1
   local command=$2
+  local spec=${3:-$package}
 
   : >"$mise_history"
   "$ROOT/bin/omarchy-mise-install" "$package" "$command"
   "$test_home/.local/bin/$command" --version
   mapfile -t mise_calls <"$mise_history"
 
-  [[ ${mise_calls[0]} == "use -g --quiet $package" && ${mise_calls[1]} == "x $package -- $command --version" ]] ||
+  [[ ${mise_calls[0]} == "use -g --quiet $spec" && ${mise_calls[1]} == "x $spec -- $command --version" ]] ||
     fail "$command lazy stub preserves its mise package"
 }
 
-assert_lazy_stub "$grok_package" grok
-assert_lazy_stub "$omp_package" omp
-assert_lazy_stub "$crush_package" crush
-assert_lazy_stub "$ori_package" ori
-assert_lazy_stub "$cursor_agent_package" cursor-agent
-assert_lazy_stub "$muse_package" muse
+assert_lazy_stub "$grok_package" grok "${grok_package}@latest"
+assert_lazy_stub "$omp_package" omp "${omp_package}@latest"
+assert_lazy_stub "$crush_package" crush "${crush_package}@latest"
+assert_lazy_stub "$ori_package" ori "${ori_package}@latest"
+assert_lazy_stub "$cursor_agent_package" cursor-agent "${cursor_agent_package}@latest"
+assert_lazy_stub "$muse_package" muse "$muse_package"
 pass "custom agent lazy stubs preserve their mise packages"
 
 OMARCHY_TEST_MISSING_COMMAND=cursor-agent source "$ROOT/install/user/mise.sh"

--- a/test/shell.d/mise-install-test.sh
+++ b/test/shell.d/mise-install-test.sh
@@ -37,7 +37,7 @@ install_wrapper npm:playwright playwright >/dev/null
 log="$tmpdir/normal.log"
 : >"$log"
 OMARCHY_MISE_TEST_LOG="$log" PATH="$stub_bin:$PATH" "$home/.local/bin/playwright" >/dev/null
-grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:playwright' "$log" ||
+grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:playwright@latest' "$log" ||
   fail "the wrapper asks mise for the package it was given" "$(cat "$log")"
 
 pass "a normal install writes a wrapper that names its package"
@@ -54,7 +54,7 @@ OMARCHY_MISE_TEST_LOG="$log" PATH="$stub_bin:$PATH" "$home/.local/bin/hostile" >
   fail "a package name with shell characters does not run when the wrapper does" \
     "wrapper: $(cat "$home/.local/bin/hostile")"
 
-grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:pkg$(touch '"$tmpdir"'/PWNED)end' "$log" ||
+grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:pkg$(touch '"$tmpdir"'/PWNED)end@latest' "$log" ||
   fail "the package reaches mise whole" "$(cat "$log")"
 
 pass "a package name with shell characters reaches mise as one argument"

--- a/test/shell.d/mise-wrapper-latest-test.sh
+++ b/test/shell.d/mise-wrapper-latest-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+mkdir -p "$home/.local/bin"
+
+HOME="$home" PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-mise-install" claude
+wrapper="$home/.local/bin/claude"
+
+grep -qF 'mise use -g --quiet "claude@latest" || exit 1' "$wrapper" ||
+  fail "mise wrapper pins the tool at @latest" "$(cat "$wrapper")"
+grep -qF 'exec mise x "claude@latest" -- "claude" "$@"' "$wrapper" ||
+  fail "mise wrapper executes the @latest spec" "$(cat "$wrapper")"
+pass "mise wrapper refreshes to @latest on each run"
+
+HOME="$home" PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-mise-install" "npm:@kitlangton/ghui" ghui
+grep -qF 'mise use -g --quiet "npm:@kitlangton/ghui@latest" || exit 1' "$home/.local/bin/ghui" ||
+  fail "mise wrapper appends @latest after a scoped npm package" "$(cat "$home/.local/bin/ghui")"
+pass "mise wrapper appends @latest after a scoped npm package"
+
+HOME="$home" PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-mise-install" "claude@1.2.3" claude-pinned
+grep -qF 'mise use -g --quiet "claude@1.2.3" || exit 1' "$home/.local/bin/claude-pinned" ||
+  fail "mise wrapper leaves an already-versioned spec alone" "$(cat "$home/.local/bin/claude-pinned")"
+if grep -q 'claude@1.2.3@latest' "$home/.local/bin/claude-pinned"; then
+  fail "mise wrapper does not append @latest onto a pinned version"
+fi
+pass "mise wrapper leaves an already-versioned spec alone"
+
+HOME="$home" PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-mise-install" "claude@latest" claude-latest
+grep -qF 'mise use -g --quiet "claude@latest" || exit 1' "$home/.local/bin/claude-latest" ||
+  fail "mise wrapper does not double @latest" "$(cat "$home/.local/bin/claude-latest")"
+pass "mise wrapper does not double @latest"
+
+HOME="$home" PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-mise-install" \
+  "http:muse[url=https://example.test/muse.sh,bin=muse]" muse
+grep -qF 'mise use -g --quiet "http:muse[url=https://example.test/muse.sh,bin=muse]" || exit 1' "$home/.local/bin/muse" ||
+  fail "mise wrapper leaves an http backend spec with options alone" "$(cat "$home/.local/bin/muse")"
+if grep -q '@latest' "$home/.local/bin/muse"; then
+  fail "mise wrapper does not append @latest onto an http backend spec"
+fi
+pass "mise wrapper leaves an http backend spec with options alone"
+
+migration="$ROOT/migrations/1789093830.sh"
+[[ -f $migration ]] || fail "a migration rewrites existing mise wrappers onto @latest"
+pass "a migration rewrites existing mise wrappers onto @latest"
+
+bin_dir="$home/.local/bin"
+cat >"$bin_dir/codex" <<'EOF'
+#!/bin/bash
+export MISE_MINIMUM_RELEASE_AGE=0
+mise use -g --quiet "codex" || exit 1
+exec mise x "codex" -- "codex" "$@"
+EOF
+chmod +x "$bin_dir/codex"
+
+HOME="$home" PATH="$ROOT/bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+
+grep -qF 'mise use -g --quiet "codex@latest" || exit 1' "$bin_dir/codex" ||
+  fail "migration rewrites a quiet wrapper onto @latest" "$(cat "$bin_dir/codex")"
+pass "migration rewrites a quiet wrapper onto @latest"
+
+before=$(cat "$bin_dir/codex")
+HOME="$home" PATH="$ROOT/bin:$PATH" bash -euo pipefail "$migration" >/dev/null
+[[ $(cat "$bin_dir/codex") == "$before" ]] || fail "latest-wrapper migration is idempotent"
+pass "latest-wrapper migration is idempotent"

--- a/test/shell.d/mise-wrapper-quiet-migration-test.sh
+++ b/test/shell.d/mise-wrapper-quiet-migration-test.sh
@@ -65,33 +65,33 @@ chmod +x "$bin_dir/mise-exec-era" "$bin_dir/bare-exec-era"
 
 run_migration
 
-grep -qF 'mise use -g --quiet "claude" || exit 1' "$bin_dir/claude" ||
+grep -qF 'mise use -g --quiet "claude@latest" || exit 1' "$bin_dir/claude" ||
   fail "migration adds --quiet to a stale wrapper"
 pass "migration adds --quiet to a stale wrapper"
 
-grep -qF 'mise use -g --quiet "github:can1357/oh-my-pi" || exit 1' "$bin_dir/omp" ||
+grep -qF 'mise use -g --quiet "github:can1357/oh-my-pi@latest" || exit 1' "$bin_dir/omp" ||
   fail "migration keeps a wrapper's package when the command name differs"
-grep -qF 'exec mise x "github:can1357/oh-my-pi" -- "omp" "$@"' "$bin_dir/omp" ||
+grep -qF 'exec mise x "github:can1357/oh-my-pi@latest" -- "omp" "$@"' "$bin_dir/omp" ||
   fail "migration keeps a wrapper's bin name when the command name differs"
 pass "migration preserves package and bin names"
 
-grep -qF 'exec mise x "npm:@kitlangton/ghui" -- "ghui" "$@"' "$bin_dir/ghui" ||
+grep -qF 'exec mise x "npm:@kitlangton/ghui@latest" -- "ghui" "$@"' "$bin_dir/ghui" ||
   fail "migration preserves a scoped npm package name"
 pass "migration preserves a scoped npm package name"
 
-grep -qF 'mise use -g --quiet "github:someone/custom-tool" || exit 1' "$bin_dir/custom-tool" ||
+grep -qF 'mise use -g --quiet "github:someone/custom-tool@latest" || exit 1' "$bin_dir/custom-tool" ||
   fail "migration rewrites a wrapper on the pre-export template"
 grep -qF 'export MISE_MINIMUM_RELEASE_AGE=0' "$bin_dir/custom-tool" ||
   fail "migration brings a pre-export wrapper up to the current template"
 pass "migration rewrites wrappers on the pre-export template"
 
-grep -qF 'mise use -g --quiet "npm:some/tool" || exit 1' "$bin_dir/mise-exec-era" ||
+grep -qF 'mise use -g --quiet "npm:some/tool@latest" || exit 1' "$bin_dir/mise-exec-era" ||
   fail "migration rewrites a wrapper on the mise-exec template"
-grep -qF 'exec mise x "npm:some/tool" -- "tool-bin" "$@"' "$bin_dir/mise-exec-era" ||
+grep -qF 'exec mise x "npm:some/tool@latest" -- "tool-bin" "$@"' "$bin_dir/mise-exec-era" ||
   fail "migration keeps the bin name from a mise-exec wrapper"
-grep -qF 'mise use -g --quiet "aqua:some/other" || exit 1' "$bin_dir/bare-exec-era" ||
+grep -qF 'mise use -g --quiet "aqua:some/other@latest" || exit 1' "$bin_dir/bare-exec-era" ||
   fail "migration rewrites a wrapper on the bare-exec template"
-grep -qF 'exec mise x "aqua:some/other" -- "other-bin" "$@"' "$bin_dir/bare-exec-era" ||
+grep -qF 'exec mise x "aqua:some/other@latest" -- "other-bin" "$@"' "$bin_dir/bare-exec-era" ||
   fail "migration keeps the bin name from a bare-exec wrapper"
 pass "migration rewrites every generated form that predates --quiet"
 


### PR DESCRIPTION
`mise use -g <tool>` reaffirms the installed pin, so wrappers generated by `omarchy-mise-install` could stay on a stale version even with `MISE_MINIMUM_RELEASE_AGE=0`. Use `<tool>@latest` (including scoped npm packages), leave already-versioned specs alone, and rewrite existing quiet wrappers.

Fixes #10112