### PR TITLE
Fix iMac20,2 AMDGPU startup race

### DIFF
--- a/bin/omarchy-amdgpu-uclk-enable
+++ b/bin/omarchy-amdgpu-uclk-enable
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# omarchy:summary=Re-enable memory-clock features after an affected iMac GPU has initialized.
+# omarchy:requires-sudo=true
+# omarchy:hidden=true
+
+set -euo pipefail
+
+readonly boot_mask="amdgpu.ppfeaturemask=0xfff7bffd"
+readonly memory_clock_features=$((0x308))
+cmdline_file="${OMARCHY_KERNEL_CMDLINE:-/proc/cmdline}"
+wait_attempts="${OMARCHY_AMDGPU_WAIT_ATTEMPTS:-30}"
+
+if (( EUID != 0 )) && [[ ${OMARCHY_ALLOW_NON_ROOT_TEST:-0} != 1 ]]; then
+  echo "Error: omarchy-amdgpu-uclk-enable must run as root" >&2
+  exit 1
+fi
+
+[[ -r $cmdline_file ]] || {
+  echo "Error: cannot read kernel command line at $cmdline_file" >&2
+  exit 1
+}
+
+cmdline=" $(<"$cmdline_file") "
+if [[ $cmdline != *" $boot_mask "* ]]; then
+  echo "Error: refusing to change AMDGPU features without $boot_mask" >&2
+  exit 1
+fi
+
+gpu_path="$(omarchy-hw-imac20-amdgpu-uclk)" || {
+  echo "Error: the affected iMac20,2 Radeon Pro 5700 XT was not found" >&2
+  exit 1
+}
+features_file="$gpu_path/pp_features"
+
+for (( attempt = 1; attempt <= wait_attempts; attempt++ )); do
+  [[ -r $features_file && -w $features_file ]] && break
+  (( attempt < wait_attempts )) && sleep 1
+done
+
+if [[ ! -r $features_file || ! -w $features_file ]]; then
+  echo "Error: AMDGPU feature control did not appear at $features_file" >&2
+  exit 1
+fi
+
+read_features() {
+  local label="$1"
+  awk -v label="$label" '$1 == "features" && $2 == label ":" { print $3 }' "$features_file"
+}
+
+features_high="$(read_features high)"
+features_low="$(read_features low)"
+if [[ ! $features_high =~ ^0x[[:xdigit:]]+$ || ! $features_low =~ ^0x[[:xdigit:]]+$ ]]; then
+  echo "Error: cannot parse AMDGPU features from $features_file" >&2
+  exit 1
+fi
+
+(( features_low |= memory_clock_features ))
+features_mask="$(printf '0x%08x%08x' "$features_high" "$features_low")"
+if [[ -n ${OMARCHY_AMDGPU_FEATURES_WRITER:-} ]]; then
+  "$OMARCHY_AMDGPU_FEATURES_WRITER" "$features_mask" "$features_file"
+else
+  printf '%s\n' "$features_mask" >"$features_file"
+fi
+
+verified_low="$(read_features low)"
+if [[ ! $verified_low =~ ^0x[[:xdigit:]]+$ ]] ||
+  (( (verified_low & memory_clock_features) != memory_clock_features )); then
+  echo "Error: AMDGPU rejected the runtime memory-clock features" >&2
+  exit 1
+fi
+
+printf 'AMDGPU runtime memory-clock features enabled: %s\n' "$features_mask"

--- a/bin/omarchy-hw-imac20-amdgpu-uclk
+++ b/bin/omarchy-hw-imac20-amdgpu-uclk
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# omarchy:summary=Locate the affected iMac20,2 Radeon Pro 5700 XT GPU.
+# omarchy:hidden=true
+
+set -euo pipefail
+
+product_name_file="${OMARCHY_DMI_PRODUCT_NAME:-/sys/class/dmi/id/product_name}"
+pci_devices_path="${OMARCHY_PCI_DEVICES_PATH:-/sys/bus/pci/devices}"
+
+[[ -r $product_name_file ]] || exit 1
+[[ $(<"$product_name_file") == "iMac20,2" ]] || exit 1
+
+shopt -s nullglob
+
+for device_path in "$pci_devices_path"/*; do
+  [[ -r $device_path/vendor ]] || continue
+  [[ -r $device_path/device ]] || continue
+  [[ -r $device_path/subsystem_vendor ]] || continue
+  [[ -r $device_path/subsystem_device ]] || continue
+
+  [[ $(<"$device_path/vendor") == "0x1002" ]] || continue
+  [[ $(<"$device_path/device") == "0x7319" ]] || continue
+  [[ $(<"$device_path/subsystem_vendor") == "0x106b" ]] || continue
+  [[ $(<"$device_path/subsystem_device") == "0x021b" ]] || continue
+
+  printf '%s\n' "$device_path"
+  exit 0
+done
+
+exit 1

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -38,6 +38,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-imac20-amdgpu-uclk.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"

--- a/install/hardware/apple/fix-imac20-amdgpu-uclk.sh
+++ b/install/hardware/apple/fix-imac20-amdgpu-uclk.sh
@@ -1,0 +1,32 @@
+if omarchy-hw-imac20-amdgpu-uclk >/dev/null; then
+  echo "Detected iMac20,2 with Radeon Pro 5700 XT. Applying AMDGPU startup workaround..."
+
+  limine_conf="${OMARCHY_IMAC20_AMDGPU_LIMINE_CONF:-/etc/limine-entry-tool.d/imac20-amdgpu-uclk.conf}"
+  systemd_unit="${OMARCHY_IMAC20_AMDGPU_SYSTEMD_UNIT:-/etc/systemd/system/omarchy-imac20-amdgpu-uclk.service}"
+
+  mkdir -p "$(dirname "$limine_conf")" "$(dirname "$systemd_unit")"
+
+  cat >"$limine_conf" <<'EOF'
+# Work around SMU initialization failures on the iMac20,2 Radeon Pro 5700 XT.
+# Memory-clock features are restored after the display manager starts.
+KERNEL_CMDLINE[default]+=" amdgpu.ppfeaturemask=0xfff7bffd"
+EOF
+
+  cat >"$systemd_unit" <<'EOF'
+[Unit]
+Description=Restore AMDGPU memory-clock features on iMac20,2
+After=display-manager.service
+ConditionKernelCommandLine=amdgpu.ppfeaturemask=0xfff7bffd
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/omarchy-amdgpu-uclk-enable
+RemainAfterExit=yes
+
+[Install]
+WantedBy=graphical.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable omarchy-imac20-amdgpu-uclk.service
+fi

--- a/migrations/1788524636.sh
+++ b/migrations/1788524636.sh
@@ -1,0 +1,16 @@
+echo "Stabilize AMDGPU startup on iMac20,2 with Radeon Pro 5700 XT"
+
+detector="$OMARCHY_PATH/bin/omarchy-hw-imac20-amdgpu-uclk"
+marker="${OMARCHY_IMAC20_AMDGPU_MARKER:-/var/lib/omarchy/migrations/1788524636}"
+system_path="${OMARCHY_IMAC20_AMDGPU_SYSTEM_PATH:-$OMARCHY_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/bin}"
+
+[[ -e $marker ]] && exit 0
+"$detector" >/dev/null || exit 0
+
+sudo env \
+  PATH="$system_path" \
+  OMARCHY_IMAC20_AMDGPU_LIMINE_CONF="${OMARCHY_IMAC20_AMDGPU_LIMINE_CONF:-/etc/limine-entry-tool.d/imac20-amdgpu-uclk.conf}" \
+  OMARCHY_IMAC20_AMDGPU_SYSTEMD_UNIT="${OMARCHY_IMAC20_AMDGPU_SYSTEMD_UNIT:-/etc/systemd/system/omarchy-imac20-amdgpu-uclk.service}" \
+  bash "$OMARCHY_PATH/install/hardware/apple/fix-imac20-amdgpu-uclk.sh"
+sudo limine-mkinitcpio
+sudo install -Dm644 /dev/null "$marker"

--- a/test/shell.d/imac20-amdgpu-uclk-test.sh
+++ b/test/shell.d/imac20-amdgpu-uclk-test.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+detector="$ROOT/bin/omarchy-hw-imac20-amdgpu-uclk"
+enabler="$ROOT/bin/omarchy-amdgpu-uclk-enable"
+installer="$ROOT/install/hardware/apple/fix-imac20-amdgpu-uclk.sh"
+migration="$ROOT/migrations/1788524636.sh"
+
+grep -Fq 'apple/fix-imac20-amdgpu-uclk.sh' "$ROOT/install/hardware/all.sh" ||
+  fail "the iMac AMDGPU workaround runs during hardware setup"
+pass "the iMac AMDGPU workaround runs during hardware setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+dmi_file="$test_tmp/product_name"
+pci_devices="$test_tmp/pci"
+gpu_path="$pci_devices/0000:03:00.0"
+mkdir -p "$gpu_path"
+
+write_hardware() {
+  printf '%s\n' "${1:-iMac20,2}" >"$dmi_file"
+  printf '%s\n' "${2:-0x1002}" >"$gpu_path/vendor"
+  printf '%s\n' "${3:-0x7319}" >"$gpu_path/device"
+  printf '%s\n' "${4:-0x106b}" >"$gpu_path/subsystem_vendor"
+  printf '%s\n' "${5:-0x021b}" >"$gpu_path/subsystem_device"
+}
+
+detect_gpu() {
+  OMARCHY_DMI_PRODUCT_NAME="$dmi_file" \
+    OMARCHY_PCI_DEVICES_PATH="$pci_devices" \
+    "$detector"
+}
+
+write_hardware
+[[ $(detect_gpu) == "$gpu_path" ]] || fail "the affected iMac GPU is detected"
+pass "the affected iMac GPU is detected"
+
+write_hardware "iMac20,1"
+! detect_gpu >/dev/null || fail "a different iMac model is rejected"
+write_hardware "iMac20,2" "0x1002" "0x7319" "0x106b" "0x0219"
+! detect_gpu >/dev/null || fail "a different Apple Radeon subsystem is rejected"
+pass "nearby Apple Radeon hardware is not matched"
+
+write_hardware
+cmdline_file="$test_tmp/cmdline"
+features_file="$gpu_path/pp_features"
+printf '%s\n' 'quiet amdgpu.ppfeaturemask=0xfff7bffd splash' >"$cmdline_file"
+printf '%s\n%s\n' 'features high: 0x00000662' 'features low: 0xa3d9acb3' >"$features_file"
+features_writer="$test_tmp/write-features"
+cat >"$features_writer" <<'SH'
+#!/bin/bash
+[[ $1 == "0x00000662a3d9afbb" ]] || exit 1
+printf '%s\n%s\n' 'features high: 0x00000662' 'features low: 0xa3d9afbb' >"$2"
+SH
+chmod +x "$features_writer"
+
+PATH="$ROOT/bin:$PATH" \
+  OMARCHY_ALLOW_NON_ROOT_TEST=1 \
+  OMARCHY_AMDGPU_FEATURES_WRITER="$features_writer" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi_file" \
+  OMARCHY_PCI_DEVICES_PATH="$pci_devices" \
+  OMARCHY_KERNEL_CMDLINE="$cmdline_file" \
+  "$enabler" >/dev/null
+
+grep -Fxq 'features low: 0xa3d9afbb' "$features_file" ||
+  fail "the runtime helper restores UCLK and its voltage-scaling features" "$(cat "$features_file")"
+pass "the runtime helper restores UCLK and its voltage-scaling features"
+
+printf '%s\n' 'quiet splash' >"$cmdline_file"
+printf '%s\n%s\n' 'features high: 0x00000662' 'features low: 0xa3d9acb3' >"$features_file"
+! PATH="$ROOT/bin:$PATH" \
+  OMARCHY_ALLOW_NON_ROOT_TEST=1 \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi_file" \
+  OMARCHY_PCI_DEVICES_PATH="$pci_devices" \
+  OMARCHY_KERNEL_CMDLINE="$cmdline_file" \
+  "$enabler" >/dev/null 2>&1 || fail "the runtime helper requires the safe boot mask"
+grep -Fq 'features low: 0xa3d9acb3' "$features_file" || fail "a rejected runtime update leaves features unchanged"
+pass "the runtime helper refuses to run without the safe boot mask"
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+limine_conf="$test_tmp/etc/limine-entry-tool.d/imac20-amdgpu-uclk.conf"
+systemd_unit="$test_tmp/etc/systemd/system/omarchy-imac20-amdgpu-uclk.service"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+chmod +x "$stub_bin/systemctl"
+
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi_file" \
+  OMARCHY_PCI_DEVICES_PATH="$pci_devices" \
+  OMARCHY_IMAC20_AMDGPU_LIMINE_CONF="$limine_conf" \
+  OMARCHY_IMAC20_AMDGPU_SYSTEMD_UNIT="$systemd_unit" \
+  bash -euo pipefail "$installer" >/dev/null
+
+grep -Fq 'amdgpu.ppfeaturemask=0xfff7bffd' "$limine_conf" || fail "the installer adds the safe boot mask"
+grep -Fq 'After=display-manager.service' "$systemd_unit" || fail "the service waits for the display manager"
+grep -Fq 'ExecStart=/usr/bin/omarchy-amdgpu-uclk-enable' "$systemd_unit" || fail "the service runs the packaged helper"
+grep -Fxq $'systemctl\tdaemon-reload' "$calls" || fail "the installer reloads systemd"
+grep -Fxq $'systemctl\tenable\tomarchy-imac20-amdgpu-uclk.service' "$calls" || fail "the installer enables the workaround"
+pass "fresh installs configure both stages of the workaround"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin/sudo" "$stub_bin/limine-mkinitcpio"
+marker="$test_tmp/migration-complete"
+: >"$calls"
+
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi_file" \
+  OMARCHY_PCI_DEVICES_PATH="$pci_devices" \
+  OMARCHY_IMAC20_AMDGPU_LIMINE_CONF="$limine_conf" \
+  OMARCHY_IMAC20_AMDGPU_SYSTEMD_UNIT="$systemd_unit" \
+  OMARCHY_IMAC20_AMDGPU_MARKER="$marker" \
+  OMARCHY_IMAC20_AMDGPU_SYSTEM_PATH="$stub_bin:$ROOT/bin:/usr/bin" \
+  bash -euo pipefail "$migration" >/dev/null
+
+grep -Fq $'sudo\tlimine-mkinitcpio' "$calls" || fail "the migration rebuilds the boot image"
+[[ -f $marker ]] || fail "the migration records machine-wide completion"
+pass "existing affected installs receive the workaround"
+
+: >"$calls"
+PATH="$stub_bin:$PATH" \
+  TEST_LOG="$calls" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_DMI_PRODUCT_NAME="$dmi_file" \
+  OMARCHY_PCI_DEVICES_PATH="$pci_devices" \
+  OMARCHY_IMAC20_AMDGPU_LIMINE_CONF="$limine_conf" \
+  OMARCHY_IMAC20_AMDGPU_SYSTEMD_UNIT="$systemd_unit" \
+  OMARCHY_IMAC20_AMDGPU_MARKER="$marker" \
+  OMARCHY_IMAC20_AMDGPU_SYSTEM_PATH="$stub_bin:$ROOT/bin:/usr/bin" \
+  bash -euo pipefail "$migration" >/dev/null
+
+[[ ! -s $calls ]] || fail "the migration is machine-idempotent" "$(cat "$calls")"
+pass "the migration is machine-idempotent"


### PR DESCRIPTION
> [!NOTE] 90% AI
> It was particularly painful to do all the manual reboots and testing :)

## Summary

- Detect only the affected `iMac20,2` with AMD/Apple PCI IDs
  `1002:7319 / 106b:021b`.
- Add `amdgpu.ppfeaturemask=0xfff7bffd` to the generated Limine command line so
  the memory-clock feature group is not enabled during the fragile SMU probe.
- Restore DPM_UCLK, MEM_VDDCI_SCALING, and MEM_MVDD_SCALING after the display
  manager starts, with guards for the boot parameter and exact hardware IDs.
- Cover fresh installs and existing systems with an idempotent migration.

## Problem

On this 2020 27-inch iMac, AMDGPU initialization fails intermittently before
the display manager starts. A failed boot consistently contains:

```text
apple_gmux: Found gmux version 5.0.0 [T2]
amdgpu 0000:03:00.0: SMU: No response msg_reg: 6 resp_reg: 0
amdgpu 0000:03:00.0: Failed to enable requested dpm features!
amdgpu 0000:03:00.0: Failed to setup smc hw!
amdgpu 0000:03:00.0: hw_init of IP block <smu> failed -62
amdgpu 0000:03:00.0: Fatal error during GPU init
```

This happens during the kernel probe, so delaying SDDM did not address it.
Loading AMDGPU early from the initramfs also did not address it.

## Why this workaround

The default AMDGPU feature mask on the tested kernel is `0xfff7bfff`.
Clearing `PP_MCLK_DPM_MASK` (`0x2`) gives `0xfff7bffd`. On Navi10 that keeps
the following features out of the initial SMU allowed-feature set:

- DPM_UCLK, bit 3
- MEM_VDDCI_SCALING, bit 8
- MEM_MVDD_SCALING, bit 9

With that boot mask, the GPU initializes reliably. Once userspace reaches the
display manager, writing the original three bits back through `pp_features`
restores memory-clock scaling without a kernel error. The helper preserves all
other feature bits and verifies that the three requested bits were accepted.

The workaround fails closed unless both the exact kernel parameter and all four
PCI IDs match. It discovers the PCI address through sysfs rather than assuming
`03:00.0`.

## Hardware and software tested

```text
Model:              Apple iMac20,2 (Mac-AF89B6D9451A490B)
CPU:                Intel Core i7-10700K
GPU:                Radeon Pro 5700 XT / Navi10
PCI IDs:            1002:7319, subsystem 106b:021b
Omarchy:            4.0.2-1
Kernel:             7.1.8-arch1-Watanare-T2-3-t2
```

## Validation

- A captured unmasked boot reproduced all six SMU/GPU initialization errors
  above and failed the AMDGPU probe with `-62`.
- `amdgpu.dpm=0` was tested as a negative control. It failed differently with
  firmware loading/probe error `-95` and is not used here.
- An SDDM readiness gate was tested as a negative control. It could not help
  because the GPU failure precedes SDDM.
- Four consecutive boots with `amdgpu.ppfeaturemask=0xfff7bffd` completed with
  no `Failed to setup smc hw`, SMU block-init, or fatal GPU-init messages.
- The automatic late restore completed with:

  ```text
  AMDGPU runtime memory-clock features enabled: 0x00000662a3d9afbb
  ```

- DPM_UCLK, MEM_VDDCI_SCALING, and MEM_MVDD_SCALING all read back enabled, and
  MCLK returned from the boot-time `0 MHz` state to `98 MHz` idle.
- `brcmfmac` remained loaded during the successful boots, so Wi-Fi driver
  removal was not responsible for the result.

Related T2 reports:

- https://github.com/t2linux/wiki/issues/646
- https://github.com/t2linux/wiki/issues/743

The second report independently isolates early DPM_UCLK enablement on the
iMac20,1 Radeon Pro 5300 and demonstrates a kernel-level late-enable approach.
The Omarchy change is intentionally a hardware-scoped userspace workaround
until the T2 kernel carries an equivalent fix for `1002:7319 / 106b:021b`.

## Tests

```text
bash test/shell.d/imac20-amdgpu-uclk-test.sh
test/cli
git diff --check
```

The new focused test covers hardware matching, nearby-device rejection, feature
restoration, boot-mask enforcement, fresh setup, migration, and migration
idempotence. It passes both directly and as part of `./test/all`.

`./test/all` was also run. It completed with five unrelated failures that
reproduce unchanged on the clean upstream checkout:

- `bar-icon-geometry-test.sh` (live Quickshell geometry)
- `launch-about-test.sh` (live animation check)
- `config-test.sh` (missing sibling `omarchy-pkgs` checkout)
- `snapper-test.sh` (missing sibling `omarchy-pkgs` checkout)
- `unowned-system-paths-test.sh` (missing sibling `omarchy-pkgs` checkout)
