### PR TITLE
Bound the Bluetooth panel's discovery retry

### DIFF
--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -417,6 +417,11 @@ Panel {
       else { focusSection = "header" }
       actionFocused = false
       cursorActive = false
+    } else {
+      // Each visit gets its own budget of discovery starts, refilled on the way
+      // out rather than the way in: the retry's guard reads `opened` too, and
+      // nothing orders a binding against a signal handler on the same property.
+      discoveryRetry.attempts = 0
     }
   }
 
@@ -503,14 +508,18 @@ Panel {
 
   // BlueZ rejects StartDiscovery while the adapter is still powering up, and
   // discovery can also time out on its own. While the panel is open, keep
-  // nudging it back on so an enabled adapter is always scanning.
+  // nudging it back on so an enabled adapter is always scanning. Bounded like
+  // the stop below: a controller that takes the call but never confirms the
+  // scan would otherwise draw a start every second for as long as this is open.
   Timer {
     id: discoveryRetry
     interval: 1000
     repeat: true
     triggeredOnStart: true
-    running: root.opened && root.adapter !== null && root.adapter.enabled && !root.adapter.discovering
+    property int attempts: 0
+    running: root.opened && root.adapter !== null && root.adapter.enabled && !root.adapter.discovering && attempts < 3
     onTriggered: {
+      attempts += 1
       root.owesDiscoveryStop = true
       root.adapter.discovering = true
     }
@@ -556,11 +565,14 @@ Panel {
   // The debt is settled the moment BlueZ reports discovery down — whether
   // because the stop above landed or the session ended some other way — so a
   // stale claim never touches a scan another client starts later. While the
-  // panel is open, discoveryRetry re-incurs it as it restarts the scan.
+  // panel is open, discoveryRetry re-incurs it as it restarts the scan. A
+  // confirmed scan also refills the retry's budget: a controller that answered
+  // once has earned another round if the session later ends on its own.
   Connections {
     target: root.adapter
     function onDiscoveringChanged() {
-      if (!root.adapter.discovering) root.owesDiscoveryStop = false
+      if (root.adapter.discovering) discoveryRetry.attempts = 0
+      else root.owesDiscoveryStop = false
     }
   }
 
@@ -634,6 +646,8 @@ Panel {
   // would re-read the old state and undo the first.
   function toggleBluetooth() {
     if (!adapter) return
+    // Asking for the radio back is a fresh start, whatever the retry spent.
+    if (!adapter.enabled) discoveryRetry.attempts = 0
     Quickshell.execDetached(["omarchy-bluetooth-power", adapter.enabled ? "off" : "on"])
   }
 

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -29,6 +29,17 @@ const retryTimer = panelSource.match(/id: discoveryRetry[\s\S]*?onTriggered: \{[
 assert(retryTimer, 'bluetooth has the discovery retry timer')
 assert(/owesDiscoveryStop = true/.test(retryTimer[0]), 'bluetooth takes on the stop it owes when it starts discovery')
 
+// A controller can accept StartDiscovery and never confirm the scan, which
+// leaves the retry's guard armed forever. A panel visit, a confirmed scan and
+// the user asking for the radio back refill the budget; nothing the adapter
+// does on its own does, so one that keeps resetting itself off the bus is not
+// met with a fresh round of starts each time it comes back.
+assert(/attempts \+= 1/.test(retryTimer[0]), 'bluetooth counts its discovery start attempts')
+assert(/running:[^\n]*attempts < 3/.test(retryTimer[0]), 'bluetooth stops starting discovery once its attempts run out')
+assert(/\n {4}\} else \{[\s\S]{0,300}discoveryRetry\.attempts = 0/.test(panelSource), 'bluetooth gives each panel visit a fresh budget of discovery starts')
+assert(/onDiscoveringChanged[\s\S]{0,120}discovering\) discoveryRetry\.attempts = 0/.test(panelSource), 'bluetooth refills the budget when BlueZ confirms the scan')
+assert(/function toggleBluetooth\(\)[\s\S]{0,200}if \(!adapter\.enabled\) discoveryRetry\.attempts = 0/.test(panelSource), 'bluetooth refills the budget when the user asks for the radio back')
+
 // Quickshell only forwards a discovering write that differs from BlueZ's last
 // confirmed state, so a stop written in the same instant as an in-flight
 // StartDiscovery would be swallowed. Binding the stop timer to the confirmed


### PR DESCRIPTION
Opening the Bluetooth panel arms a 1 Hz timer that writes `adapter.discovering = true` until BlueZ confirms the scan. The guard has no cap and no backoff, and a controller that accepts `StartDiscovery` but never completes the underlying scan enable never sends that confirmation — so on a Realtek RTL8761BU the panel issues a start every second for as long as it is open, without being touched.

Those repeats reach the controller. BlueZ replies to a *failed* start with the same `org.bluez.Error.InProgress` / "Operation already in progress" it uses to reject a duplicate call, and `discovery_complete()` drops the client from the adapter's discovery list on the way out, so the next tick is accepted and issues real work again — the identical warning text hides the difference between the two. Re-enumeration reopens the same door from the other side: `adapter` follows `Bluetooth.defaultAdapter`, and a controller the kernel has just reset off the bus comes back as a fresh adapter object with no discovery session to collide with, so it is met with another start a second later. That is the loop behind the `0x200c` timeouts, the repeated `Resetting usb device`, and `start background scanning failed: -110` — which is the kernel failing to resume the passive scan that paired BLE devices reconnect through, and why a BLE mouse stops coming back. The wedge itself is established against the source, BlueZ 5.87 and Quickshell 0.3.1 rather than reproduced: it needs a controller that behaves this way.

The retry is now bounded the way `discoveryStop` beside it already is, and the budget refills only where a person or a working controller says it should: a panel visit, a scan BlueZ confirms, and the user asking for the radio back. It deliberately does not refill on an adapter change, because that is the edge the reset loop rides on; the cost is that a dongle hot-plugged into an already-open panel scans on the next visit rather than immediately.

Two things this deliberately leaves alone. The empty-state text reads "Scanning for devices…" whenever the adapter is enabled, independent of `adapter.discovering`, so it was already saying that throughout the failure and still does — worth deciding on separately. And #7385 rewrites this same guard to protect A2DP audio from discovery; it narrows when the retry runs and leaves it uncapped when no Bluetooth sink is connected, which is this report's case, so the two are complementary and whichever lands second needs a rebase.

Fixes #10142