### PR TITLE
Make the plugin watcher die with the shell

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -633,8 +633,14 @@ QtObject {
     }
   }
 
+  // The pdeathsig makes the kernel kill the watcher whenever the shell exits,
+  // however it exits. Qt leaves through _exit() when the Wayland connection
+  // drops, so nothing in QML gets to stop the watcher on the path that matters.
   property Process localPluginWatcher: Process {
     command: [
+      "setpriv",
+      "--pdeathsig",
+      "TERM",
       "inotifywait",
       "-m",
       "-r",

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -626,7 +626,44 @@ QtObject {
     }
   }
 
+  // The watcher argv, shared by the process that runs it and by the pattern
+  // that reaps leftover copies of it.
+  readonly property var watcherCommand: [
+    "inotifywait",
+    "-m",
+    "-r",
+    "-q",
+    "-e",
+    "close_write,create,delete,move",
+    "--format",
+    "%w%f",
+    registry.pluginsDir
+  ]
+
+  // pkill -f matches an extended regex against each process's argv joined by
+  // spaces, so every argument is escaped and the pattern is anchored at the
+  // end. That reaps only this exact command, with or without the setpriv
+  // prefix, and leaves any other inotifywait alone.
+  readonly property string watcherPattern: registry.watcherCommand.map(function(arg) {
+    return arg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  }).join(" ") + "$"
+
+  // Creates the plugins dir, then reaps watchers of it that earlier shells
+  // left behind: shells that predate the pdeathsig, and a shell a crash
+  // handler re-execed in place, which kept its PID so the pdeathsig never
+  // fired. Only once that is done does this shell start its own watcher, so
+  // it is never the one being reaped. The reap does not wait on mkdir
+  // succeeding: a leftover watcher is stale whether or not the directory can
+  // be made. pkill exits 1 when there was nothing to reap, so onExited starts
+  // the watcher whatever the status.
   property Process initProcess: Process {
+    command: [
+      "bash",
+      "-c",
+      "mkdir -p \"$0\"; exec pkill -f \"$1\"",
+      registry.pluginsDir,
+      registry.watcherPattern
+    ]
     onExited: {
       localPluginWatcher.running = true
       registry.rescan()
@@ -637,20 +674,7 @@ QtObject {
   // however it exits. Qt leaves through _exit() when the Wayland connection
   // drops, so nothing in QML gets to stop the watcher on the path that matters.
   property Process localPluginWatcher: Process {
-    command: [
-      "setpriv",
-      "--pdeathsig",
-      "TERM",
-      "inotifywait",
-      "-m",
-      "-r",
-      "-q",
-      "-e",
-      "close_write,create,delete,move",
-      "--format",
-      "%w%f",
-      registry.pluginsDir
-    ]
+    command: ["setpriv", "--pdeathsig", "TERM"].concat(registry.watcherCommand)
     stdout: SplitParser {
       onRead: function(path) {
         var pluginId = registry.localPluginIdForPath(path)
@@ -699,11 +723,6 @@ QtObject {
     scanProcess.running = true
   }
 
-  function ensureUserDir() {
-    initProcess.command = ["bash", "-c", "mkdir -p \"$0\"", registry.pluginsDir]
-    initProcess.running = true
-  }
-
   function localPluginIdForPath(filePath) {
     var base = pluginsDir.replace(/\/$/, "") + "/"
     var path = String(filePath || "").trim()
@@ -718,5 +737,5 @@ QtObject {
     return slash === -1 ? relative : relative.slice(0, slash)
   }
 
-  Component.onCompleted: ensureUserDir()
+  Component.onCompleted: initProcess.running = true
 }

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -148,7 +148,7 @@ ShellRoot {
     pluginRegistry.firstPartyDir = shell.firstPartyPluginsDir
     pluginRegistry.shellConfigProvider = function() { return shell.shellConfig }
     pluginRegistry.shellConfigMutator = function(mutate) { shell.mutateShellConfig(mutate) }
-    // PluginRegistry.ensureUserDir() runs in its own Component.onCompleted and
+    // PluginRegistry.initProcess runs from its own Component.onCompleted and
     // chains rescan() once the directory exists. We also kick a scan here in
     // case the user dir already existed at startup.
     pluginRegistry.rescan()

--- a/test/shell.d/fixtures/plugin-watcher/shell.qml
+++ b/test/shell.d/fixtures/plugin-watcher/shell.qml
@@ -1,0 +1,6 @@
+import Quickshell
+import "services"
+
+ShellRoot {
+  PluginRegistry { }
+}

--- a/test/shell.d/plugin-watcher-test.sh
+++ b/test/shell.d/plugin-watcher-test.sh
@@ -6,6 +6,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 TMPDIR=""
 QS_PID=""
+STALE_PID=""
 WATCHER_PID=""
 
 cleanup() {
@@ -13,9 +14,11 @@ cleanup() {
     kill -KILL "$QS_PID" 2>/dev/null || true
     wait "$QS_PID" 2>/dev/null || true
   fi
-  if [[ -n $WATCHER_PID ]] && kill -0 "$WATCHER_PID" 2>/dev/null; then
-    kill "$WATCHER_PID" 2>/dev/null || true
-  fi
+  for pid in "$STALE_PID" "$WATCHER_PID"; do
+    if [[ -n $pid ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
   if [[ -n $TMPDIR && -d $TMPDIR ]]; then
     rm -rf "$TMPDIR"
   fi
@@ -45,12 +48,24 @@ require_command setpriv
 
 TMPDIR=$(mktemp -d)
 log="$TMPDIR/quickshell.log"
+stale_log="$TMPDIR/stale.log"
 config_dir="$TMPDIR/plugin-watcher"
 plugins_dir="$TMPDIR/home/.config/omarchy/plugins"
-mkdir -p "$config_dir" "$TMPDIR/home"
+mkdir -p "$config_dir" "$plugins_dir"
 cp "$SHELL_TEST_DIR/fixtures/plugin-watcher/shell.qml" "$config_dir/shell.qml"
 ln -s "$ROOT/shell/services" "$config_dir/services"
 ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
+
+# A watcher an earlier shell left behind, run with the shell's exact argv
+# because that is all the shell reaps. Its cmdline reads inotifywait only once
+# bash has exec'd it, which is when pkill can see it too.
+inotifywait -m -r -q -e close_write,create,delete,move --format %w%f "$plugins_dir" >/dev/null 2>"$stale_log" &
+STALE_PID=$!
+for _ in {1..50}; do
+  grep -qzxF -- inotifywait "/proc/$STALE_PID/cmdline" 2>/dev/null && break
+  sleep 0.1
+done
+grep -qzxF -- inotifywait "/proc/$STALE_PID/cmdline" 2>/dev/null || fail "stale plugin watcher did not start" "$(<"$stale_log")"
 
 OMARCHY_PATH="$ROOT" \
 HOME="$TMPDIR/home" \
@@ -77,6 +92,17 @@ done
 
 [[ -n $WATCHER_PID ]] || fail "plugin watcher did not start" "$(sed -n '1,180p' "$log")"
 
+# The shell reaps stale watchers of its plugins dir before starting its own,
+# so by now the one we planted must be gone, and gone from the shell's SIGTERM
+# rather than from some failure of its own. Bash reaps a background child on
+# SIGCHLD without a wait and keeps its status, so kill -0 stops seeing the
+# watcher as soon as it dies while wait still reports how.
+process_gone "$STALE_PID" || fail "stale plugin watcher survived shell start"
+stale_status=0
+wait "$STALE_PID" || stale_status=$?
+STALE_PID=""
+[[ $stale_status -eq 143 ]] || fail "stale plugin watcher did not die from the shell's SIGTERM" "exit status $stale_status: $(<"$stale_log")"
+
 # A watcher that fails on its own moments after starting (an exhausted inotify
 # quota, say) must not pass for one that died with the shell.
 sleep 1
@@ -91,4 +117,4 @@ QS_PID=""
 process_gone "$WATCHER_PID" || fail "plugin watcher outlived the shell"
 WATCHER_PID=""
 
-pass "plugin watcher dies with the shell"
+pass "plugin registry reaps stale watchers and its watcher dies with the shell"

--- a/test/shell.d/plugin-watcher-test.sh
+++ b/test/shell.d/plugin-watcher-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+WATCHER_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill -KILL "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $WATCHER_PID ]] && kill -0 "$WATCHER_PID" 2>/dev/null; then
+    kill "$WATCHER_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+process_gone() {
+  local pid=$1
+
+  for _ in {1..50}; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.1
+  done
+
+  return 1
+}
+
+require_compositor "plugin watcher test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping plugin watcher test"
+  exit 0
+fi
+
+require_command inotifywait
+require_command setpriv
+
+TMPDIR=$(mktemp -d)
+log="$TMPDIR/quickshell.log"
+config_dir="$TMPDIR/plugin-watcher"
+plugins_dir="$TMPDIR/home/.config/omarchy/plugins"
+mkdir -p "$config_dir" "$TMPDIR/home"
+cp "$SHELL_TEST_DIR/fixtures/plugin-watcher/shell.qml" "$config_dir/shell.qml"
+ln -s "$ROOT/shell/services" "$config_dir/services"
+ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
+
+OMARCHY_PATH="$ROOT" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..100}; do
+  WATCHER_PID=$(pgrep -P "$QS_PID" -x inotifywait | head -n 1 || true)
+  if [[ -n $WATCHER_PID ]] && grep -qzxF -- "$plugins_dir" "/proc/$WATCHER_PID/cmdline" 2>/dev/null; then
+    break
+  fi
+  WATCHER_PID=""
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail "plugin watcher quickshell exited before starting its watcher" "$(sed -n '1,180p' "$log")"
+  fi
+  sleep 0.1
+done
+
+[[ -n $WATCHER_PID ]] || fail "plugin watcher did not start" "$(sed -n '1,180p' "$log")"
+
+# A watcher that fails on its own moments after starting (an exhausted inotify
+# quota, say) must not pass for one that died with the shell.
+sleep 1
+kill -0 "$WATCHER_PID" 2>/dev/null || fail "plugin watcher exited on its own" "$(sed -n '1,180p' "$log")"
+
+# SIGKILL stands in for the shell leaving without any QML teardown, which is
+# what happens when Qt aborts on a dropped Wayland connection.
+kill -KILL "$QS_PID"
+wait "$QS_PID" 2>/dev/null || true
+QS_PID=""
+
+process_gone "$WATCHER_PID" || fail "plugin watcher outlived the shell"
+WATCHER_PID=""
+
+pass "plugin watcher dies with the shell"


### PR DESCRIPTION
## Problem

`PluginRegistry` runs `inotifywait -m -r … ~/.config/omarchy/plugins` for the life of the shell and restarts it whenever it exits, but nothing ends it when the shell itself goes. Quickshell's `Process` only reaps its child on an orderly QML teardown, and the shell often does not leave that way: when the Wayland connection drops Qt calls `_exit()`, and SIGTERM or SIGKILL are just as abrupt. Each such exit leaves one `inotifywait` reparented to `systemd --user`, immortal because the plugins dir is quiet. Every one holds an inotify instance, so after enough compositor restarts the user hits `fs.inotify.max_user_instances` (1024) and nothing on the desktop can watch a file any more (#7150). The machine this was written on had 978 of them before they were cleared by hand.

#7230 attaches the cleanup to `Component.onDestruction`, but that hook never runs on the exits that cause the leak, which the live measurement in its review bears out. That is why this takes a different route.

## Fix

Spawn the watcher under `setpriv --pdeathsig TERM`, the same kernel-level lifetime binding the clipboard watchers (`Clipboard.qml`, 60e0a2a0) and `omarchy-voxtype-status` already rely on. `PR_SET_PDEATHSIG` fires when the thread that forked the child exits, and Quickshell starts `Process` commands synchronously on the QML thread, so it covers `_exit()`, SIGTERM and SIGKILL alike. `setpriv` is util-linux, so it is on every Omarchy install already.

This also closes #7124: the contract and screenshot tests end their shell with SIGTERM, which now takes the watcher with it.

The second commit deals with what is already there. The pdeathsig only helps shells started after it lands: an install that has been crashing for weeks keeps every watcher those crashes orphaned, and the update that brings the fix restarts the old shell, which orphans one more on its way out. So before the registry starts its own watcher it now runs `pkill -f` against any `inotifywait` still watching its plugins dir, from the same init step that creates the dir, the way `Clipboard.qml` reaps stale `wl-paste` watchers. The match is anchored on the exact plugins dir, so watchers of other dirs (another user's, a test fixture's) are left alone, and the shell's own watcher only starts once the reaper has exited, so it is never the one being reaped. This also covers the one path the pdeathsig leaves half open: Quickshell's crash handler re-`execve`s the same PID in place, the forking thread does not exit there, and the old image's watcher would otherwise keep running beside the new one until the next real exit. The new image reaps it at start.

## Test

`test/shell.d/plugin-watcher-test.sh` plants a watcher of the fixture's plugins dir, then launches a shell that runs only the registry (`fixtures/plugin-watcher/shell.qml`, no windows), waits for the shell's own watcher on that dir, checks the planted one is gone, SIGKILLs the shell and checks that the shell's watcher is gone too. It skips without a compositor, like the other Quickshell tests, and it kills both watchers itself on the way out so a failing run never leaks one.

## Verification

- The new test passes on this branch with a real `inotifywait` under Quickshell 0.3.1. It fails on unfixed `quattro` with `plugin watcher outlived the shell`, and with the pdeathsig but without the reaper with `stale plugin watcher survived shell start`.
- The reaper's match, run as the exact init command against four live watchers: it kills the two on the plugins dir (argv[0] `inotifywait` and `/usr/bin/inotifywait`, the form older shells leave behind) and leaves the ones on a sibling dir and a subdirectory alone. The init step exits 0 when it reaped something and 1 when there was nothing, and the shell starts its watcher either way.
- Running the tests next to a live Omarchy shell leaves that shell's watcher untouched, since the fixtures watch a temp dir.
- SIGTERM to the shell, the way the contract and screenshot tests end it: the watcher survives on `quattro` and dies with this change. The contract test now leaves the `inotifywait` count unchanged.
- Under Quickshell the wrapped watcher keeps one PID for as long as the shell lives, so the death signal is bound to a thread that outlives the QML engine and there is no restart churn.
- Mechanism check outside Quickshell: a plain child survives its parent's `_exit()`, SIGKILL and SIGTERM and lands under `systemd --user`; the same child under `setpriv --pdeathsig TERM` dies in all three cases, and also dies after the parent re-`execve`s itself in place and then exits.
- `setpriv --pdeathsig TERM` execs the target in place: same PID, stdout, environment, uid and capabilities as without it. `inotifywait` neither ignores nor catches SIGTERM.
- `plugin-registry-contract-test.sh` and `qml-text-format-test.sh` still pass.

## Validated on a live shell

On this machine the real Omarchy shell has been exiting through the Wayland `_exit()` path about 350 times a day (an HDMI hotplug storm; 20,000 connector disconnect events since boot), which is how 978 watchers piled up. The fixed shell was run as the real session shell (launched through `omarchy-launch-shell` with `OMARCHY_PATH` pointing at this branch) and killed with SIGKILL twice so the launcher relaunched it:

- Every step of the way the real plugins dir had exactly one `inotifywait`, owned by the live shell: before, after the clean stop, with the fixed shell up, after each relaunch, and after switching back to the packaged shell.
- The killed shell's watcher was gone 86 ms after the kill, well inside the launcher's one-second relaunch delay, so it is the death signal that removes it, not the reaper in the next shell.
- The reaper was exercised separately: a shell running this registry against the real plugins dir removed the twelve stale watchers left by earlier relaunches within two seconds of starting, and left the running shell's watcher and an unrelated `inotifywait` on another dir alone.

Fixes #7150
Fixes #7124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GMSgUsKyhyZMRSSaXkm3F

