### PR TITLE
Add indicator for outdated mise tools

### DIFF
--- a/bin/omarchy-mise-outdated
+++ b/bin/omarchy-mise-outdated
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=List mise-managed tools with a newer version available
+
+set -euo pipefail
+
+if ! omarchy-cmd-present mise; then
+  exit 1
+fi
+
+# A transient failure (offline, registry hiccup) should read as "nothing to
+# report" rather than crash a caller that runs this unattended, mirroring how
+# omarchy-update-available treats a failed checkupdates.
+outdated=$(mise outdated --json 2>/dev/null) || exit 1
+
+if [[ -z $outdated || $outdated == "{}" ]]; then
+  exit 1
+fi
+
+jq -r 'to_entries[] | "\(.key) \(.value.current) -> \(.value.latest)"' <<<"$outdated"

--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -35,6 +35,9 @@
         },
         {
           "id": "omarchy.system-update"
+        },
+        {
+          "id": "omarchy.mise-outdated"
         }
       ],
       "right": [

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -60,6 +60,7 @@ Example `shell.json` (bar subtree only shown):
 | `omarchy.media` | MPRIS now-playing — scrolling track + artist, cover-art popup | left = play/pause · middle = next · scroll = prev/next · right = popup |
 | `omarchy.indicators` | Manual state indicators | left = indicator action |
 | `omarchy.system-update` | Available update indicator | left = update |
+| `omarchy.mise-outdated` | Outdated mise-managed tool indicator | left = update |
 | `omarchy.tray` | System tray | hover = reveal drawer · right on chevron = manage |
 | `omarchy.weather` | Weather icon + popup with forecast | left = popup · right = full notification |
 | `omarchy.microphone` | Mic icon + scroll volume | left = mute toggle · middle = audio panel · scroll = source volume |

--- a/shell/plugins/bar/widgets/MiseOutdated.manifest.json
+++ b/shell/plugins/bar/widgets/MiseOutdated.manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.mise-outdated",
+  "name": "Mise tool updates",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Indicates outdated mise-managed tools",
+  "kinds": [
+    "bar-widget"
+  ],
+  "entryPoints": {
+    "barWidget": "MiseOutdated.qml"
+  },
+  "barWidget": {
+    "displayName": "Mise tool updates",
+    "description": "Indicates outdated mise-managed tools",
+    "category": "System",
+    "allowMultiple": false
+  }
+}

--- a/shell/plugins/bar/widgets/MiseOutdated.qml
+++ b/shell/plugins/bar/widgets/MiseOutdated.qml
@@ -1,0 +1,65 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+
+BarWidget {
+  id: root
+  moduleName: "omarchy.mise-outdated"
+
+  property bool outdated: false
+
+  function refresh() {
+    if (!outdatedProc.running) outdatedProc.running = true
+  }
+
+  function clear() { outdated = false }
+
+  function runUpdate() {
+    if (root.bar) root.bar.run("omarchy-launch-floating-terminal-with-presentation omarchy-update-mise")
+  }
+
+  visible: outdated
+  implicitWidth: button.implicitWidth
+  implicitHeight: button.implicitHeight
+
+  IpcHandler {
+    target: "omarchy.mise-outdated"
+
+    function refresh(): void {
+      root.broadcast("refresh")
+    }
+
+    function clear(): void {
+      root.broadcast("clear")
+    }
+  }
+
+  Process {
+    id: outdatedProc
+    command: ["omarchy-mise-outdated"]
+    onExited: function(exitCode) {
+      root.outdated = exitCode === 0
+    }
+  }
+
+  Timer {
+    interval: 21600000
+    running: true
+    repeat: true
+    triggeredOnStart: true
+    onTriggered: root.refresh()
+  }
+
+  BarIconButton {
+    id: button
+    anchors.fill: parent
+    bar: root.bar
+    text: "󰭼"
+    slotSize: Style.bar.statusSlot
+    fontSize: Style.font.caption
+    tooltipText: "Pending Mise Tool Updates"
+    onPressed: root.runUpdate()
+  }
+}

--- a/test/shell.d/mise-outdated-test.sh
+++ b/test/shell.d/mise-outdated-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/mise" <<'SH'
+#!/bin/bash
+[[ $1 == "outdated" ]] || exit 1
+
+case "${TEST_MISE_OUTDATED:-clean}" in
+  clean)
+    echo '{}'
+    ;;
+  stale)
+    cat <<'JSON'
+{"claude":{"current":"2.1.258","latest":"2.1.259"},"codex":{"current":"0.152.0","latest":"0.153.0"}}
+JSON
+    ;;
+  fail)
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$stub_bin/mise"
+
+run_checker() {
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+    TEST_MISE_OUTDATED="${1:-clean}" \
+    "$ROOT/bin/omarchy-mise-outdated"
+}
+
+stdout="$test_tmp/stdout"
+stderr="$test_tmp/stderr"
+
+if run_checker clean >"$stdout" 2>"$stderr"; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 1 ]] || fail "outdated checker exits non-zero when no mise tools are outdated"
+[[ ! -s $stdout ]] || fail "outdated checker is quiet on stdout when up to date" "$(cat "$stdout")"
+pass "outdated checker reports no output when mise tools are current"
+
+if run_checker stale >"$stdout" 2>"$stderr"; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 0 ]] || fail "outdated checker exits successfully when mise tools are outdated"
+grep -Fx 'claude 2.1.258 -> 2.1.259' "$stdout" >/dev/null || fail "outdated checker reports the outdated claude version" "$(cat "$stdout")"
+grep -Fx 'codex 0.152.0 -> 0.153.0' "$stdout" >/dev/null || fail "outdated checker reports the outdated codex version" "$(cat "$stdout")"
+pass "outdated checker lists each outdated mise tool with its current and latest version"
+
+if run_checker fail >"$stdout" 2>"$stderr"; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 1 ]] || fail "outdated checker exits non-zero when mise outdated fails"
+[[ ! -s $stdout ]] || fail "outdated checker stays quiet on stdout when mise outdated fails" "$(cat "$stdout")"
+pass "outdated checker treats a failed mise outdated call as nothing to report"
+
+# No stub_bin and no system dirs on PATH, so this proves the checker backs off
+# cleanly rather than happening to find a real mise on the test machine.
+if PATH="$ROOT/bin" "$ROOT/bin/omarchy-mise-outdated" >"$stdout" 2>"$stderr"; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 1 ]] || fail "outdated checker exits non-zero when mise is not installed"
+[[ ! -s $stdout ]] || fail "outdated checker stays quiet on stdout when mise is not installed" "$(cat "$stdout")"
+pass "outdated checker ignores systems without mise installed"


### PR DESCRIPTION
Closes #10179

Adds a persistent bar indicator when `mise outdated` reports updates. Clicking it opens `omarchy-update-mise`.

Tests: `bash test/shell.d/mise-outdated-test.sh`