### PR TITLE
Ci/GitHub actions tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           - cli
           - shell
     steps:
+      - name: Install Git before checkout
+        run: pacman -Syu --noconfirm --needed git
+
       - name: Check out Omarchy
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -52,8 +55,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pacman -Syu --noconfirm --needed \
-            git \
+          pacman -S --noconfirm --needed \
             glib2 \
             imagemagick \
             jq \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - quattro
+  push:
+    branches:
+      - quattro
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: ${{ matrix.suite }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    container:
+      image: archlinux:base-devel
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - cli
+          - shell
+    steps:
+      - name: Check out Omarchy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: omarchy
+          persist-credentials: false
+
+      - name: Check out package definitions
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: omacom/omarchy-pkgs
+          path: omarchy-pkgs
+          persist-credentials: false
+
+      - name: Check out ISO tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: omacom/omarchy-iso
+          path: omarchy-iso
+          persist-credentials: false
+
+      - name: Install test dependencies
+        run: |
+          pacman -Syu --noconfirm --needed \
+            git \
+            glib2 \
+            imagemagick \
+            jq \
+            libxkbcommon \
+            lua \
+            nodejs \
+            python \
+            ripgrep \
+            sudo
+
+      - name: Configure unprivileged test user
+        run: |
+          useradd --create-home --shell /bin/bash ci
+          printf 'ci ALL=(ALL:ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/ci
+          chmod 0440 /etc/sudoers.d/ci
+          chown -R ci:ci "$GITHUB_WORKSPACE"
+
+      - name: Report tested revisions
+        run: |
+          sudo --user=ci -- git -C "$GITHUB_WORKSPACE/omarchy" rev-parse HEAD
+          sudo --user=ci -- git -C "$GITHUB_WORKSPACE/omarchy-pkgs" rev-parse HEAD
+          sudo --user=ci -- git -C "$GITHUB_WORKSPACE/omarchy-iso" rev-parse HEAD
+
+      - name: Run ${{ matrix.suite }} tests
+        working-directory: omarchy
+        run: |
+          sudo --user=ci -- env \
+            HOME="/home/ci" \
+            LANG="C.UTF-8" \
+            LC_ALL="C.UTF-8" \
+            OMARCHY_PATH="$GITHUB_WORKSPACE/omarchy" \
+            OMARCHY_PKGS_PATH="$GITHUB_WORKSPACE/omarchy-pkgs" \
+            OMARCHY_ISO_PATH="$GITHUB_WORKSPACE/omarchy-iso" \
+            PATH="$GITHUB_WORKSPACE/omarchy/bin:$PATH" \
+            TERM="xterm-256color" \
+            "./test/${{ matrix.suite }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,14 @@ jobs:
       - name: Install test dependencies
         run: |
           pacman -S --noconfirm --needed \
+            desktop-file-utils \
             glib2 \
             imagemagick \
             jq \
             libxkbcommon \
             lua \
             nodejs \
+            openssh \
             python \
             ripgrep \
             sudo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 20
     container:
       image: archlinux:base-devel
+      options: --init
     strategy:
       fail-fast: false
       matrix:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,21 @@ machine — including headless CI sandboxes with no compositor. The graphical
 acceptance suite is a separate thing that drives a live session in a disposable
 VM; see [`agents/skills/acceptance-tests.md`](../agents/skills/acceptance-tests.md).
 
+## GitHub Actions CI
+
+The `CI` workflow runs on pull requests and pushes to `quattro`. It exposes separate `cli` and `shell` checks so a failure in one suite does not hide the result of the other.
+
+Both checks run inside the rolling `archlinux:base-devel` container as an unprivileged user. The workflow checks out `omarchy-pkgs` and `omarchy-iso` beside this repository and exports `OMARCHY_PKGS_PATH` and `OMARCHY_ISO_PATH`, because shell tests validate contracts owned by those sibling repositories.
+
+Run the same suite entry points locally from the repository root:
+
+```bash
+./test/cli
+./test/shell
+```
+
+For the complete shell coverage, keep current `omacom/omarchy-pkgs` and `omacom/omarchy-iso` checkouts beside this repository or point `OMARCHY_PKGS_PATH` and `OMARCHY_ISO_PATH` at them explicitly. A non-Arch host can run the entry points, but it does not exactly reproduce the workflow's package and filesystem environment.
+
 ## Suite map
 
 `./test/all` runs both suites below and keeps going when one fails, so a single


### PR DESCRIPTION
## Summary

This PR adds GitHub Actions CI for Omarchy’s existing test suites.

The workflow:

- runs on pull requests and pushes targeting `quattro`
- executes the existing `test/cli` and `test/shell` suites as separate matrix jobs
- uses an Arch Linux `base-devel` container on an Ubuntu 24.04 runner
- checks out `omarchy-pkgs` and `omarchy-iso` alongside Omarchy
- runs tests as an unprivileged user
- pins `actions/checkout` to a full commit SHA
- uses read-only repository permissions
- cancels outdated runs for the same branch
- supports manual execution through `workflow_dispatch`

## Architecture

The initial CI intentionally focuses on fast, deterministic validation:

- **CLI suite:** command metadata and CLI behavior
- **Shell suite:** shell scripts, installers, migrations, and desktop behavior
- **Separate matrix jobs:** failures are isolated and both suites remain visible
- **Arch container:** matches Omarchy’s target distribution more closely than the runner host
- **Sibling repositories:** preserves the directory layout expected by the current tests

Full ISO builds and QEMU installation tests are intentionally excluded from pull-request CI. They are better suited to a separate scheduled or manually triggered acceptance workflow because they require more time and compute.

## Security

- workflow permissions are limited to `contents: read`
- checkout credentials are not persisted
- third-party actions are pinned to immutable commit SHAs
- repository tests run as an unprivileged `ci` user

## Documentation

Adds `docs/testing.md` covering:

- local test execution
- required sibling repository layout
- GitHub Actions behavior
- the boundary between fast CI and future ISO/QEMU acceptance testing

## Verification

Validated on the fork with both matrix jobs passing:

- `cli` ✅
- `shell` ✅

CI run: https://github.com/Mina-Sayed/omarchy/actions/runs/33875551298