### PR TITLE
Tag Waterfox as a Firefox-based browser

### DIFF
--- a/default/hypr/apps/browser.lua
+++ b/default/hypr/apps/browser.lua
@@ -1,6 +1,6 @@
 -- Browser tags and styling.
 o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
-o.window("([fF]irefox|zen|librewolf)", { tag = "+firefox-based-browser" })
+o.window("([fF]irefox|zen|librewolf|[wW]aterfox)", { tag = "+firefox-based-browser" })
 o.window({ tag = "chromium-based-browser" }, { tag = "-default-opacity", tile = true, opacity = "1.0 0.985" })
 o.window({ tag = "firefox-based-browser" }, { tag = "-default-opacity", opacity = "1.0 0.985" })
 


### PR DESCRIPTION
## Problem

Waterfox is a Firefox fork, but its window class (`waterfox`) isn't matched by the `firefox-based-browser` regex in `default/hypr/apps/browser.lua`:

```lua
o.window("([fF]irefox|zen|librewolf)", { tag = "+firefox-based-browser" })
```

`waterfox` doesn't contain the substring `firefox`, so it never picks up the tag. It therefore keeps the blanket `default-opacity` tag from `default/hypr/windows.lua` and ends up at `0.985 0.96` — visibly translucent — while Firefox, Zen and LibreWolf get `1.0 0.985` and stay opaque when focused.

## Fix

One line — add Waterfox to the same alternation, following the existing `[fF]irefox` capitalisation style:

```lua
o.window("([fF]irefox|zen|librewolf|[wW]aterfox)", { tag = "+firefox-based-browser" })
```

This is the only hardcoded list of Firefox forks in the tree (`grep -rn librewolf` returns just this line), so no other site needs updating.

## Verification

Confirmed on Omarchy 4.0.2-1. Before, with Waterfox running:

```
class = waterfox
tags  = ['default-opacity*']
```

After applying the equivalent rule and reloading:

```
class = waterfox
tags  = ['firefox-based-browser*']
```

Waterfox now renders opaque when focused, matching the other Firefox forks.

`./test/all`: the 4 browser-related suites (`launch-browser`, `browser-policy-sudoers`, `browser-policy-dir`, `webapp-install`) pass. 5 suites fail — `agent-usage-claude-scanner`, `agent-usage-codex-scanner`, `config`, `snapper`, `unowned-system-paths` — but all 5 fail identically on an unmodified `quattro` checkout on this host, so they're pre-existing and unrelated.