### PR TITLE
Add update notification bar with per-app update menu and update-all

### DIFF
--- a/bin/omarchy-update-all
+++ b/bin/omarchy-update-all
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# omarchy:summary=Update everything: Omarchy, system, AUR, mise, Hermes, npm, and uv tools
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+# 1. Omarchy / system / AUR / mise tools
+omarchy-update
+
+# 2. Hermes agent (git-installed)
+if omarchy-cmd-present hermes; then
+  echo -e "\e[32m\nUpdate Hermes agent\e[0m"
+  hermes update
+fi
+
+# 3. npm global packages
+if omarchy-cmd-present npm; then
+  echo -e "\e[32m\nUpdate npm global packages\e[0m"
+  npm update -g
+fi
+
+# 4. uv tools (Python CLI tools)
+if omarchy-cmd-present uv; then
+  echo -e "\e[32m\nUpdate uv tools\e[0m"
+  uv tool upgrade --all
+fi

--- a/bin/omarchy-update-menu
+++ b/bin/omarchy-update-menu
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# omarchy:summary=Show an interactive menu of available updates
+# omarchy:hidden=true
+
+set -euo pipefail
+
+# Each entry: NAME | DETAIL | COMMAND
+declare -a ENTRIES=()
+
+# System packages (pacman) — grouped, since updating one package alone can
+# break dependencies. The detail lists the package names.
+sys_names=()
+while IFS= read -r line; do
+  [[ -z $line ]] && continue
+  sys_names+=("$(printf '%s' "$line" | awk '{print $1}')")
+done < <(timeout 60 checkupdates 2>/dev/null || true)
+if (( ${#sys_names[@]} > 0 )); then
+  ENTRIES+=("System packages (${#sys_names[@]})|${sys_names[*]}|omarchy-update")
+fi
+
+# AUR packages (yay)
+aur_names=()
+while IFS= read -r line; do
+  [[ -z $line ]] && continue
+  aur_names+=("$(printf '%s' "$line" | awk '{print $1}')")
+done < <(timeout 60 yay -Qua 2>/dev/null || true)
+if (( ${#aur_names[@]} > 0 )); then
+  ENTRIES+=("AUR packages (${#aur_names[@]})|${aur_names[*]}|yay -Sua --noconfirm")
+fi
+
+# mise tools (AI + dev tools)
+mise_out=$(timeout 60 mise outdated 2>/dev/null || true)
+if [[ -n $mise_out && $mise_out != *"up to date"* ]]; then
+  while IFS= read -r line; do
+    [[ -z $line ]] && continue
+    tool=$(printf '%s' "$line" | awk '{print $1}')
+    [[ -z $tool ]] && continue
+    ENTRIES+=("mise: $tool|$line|mise up $tool")
+  done <<< "$mise_out"
+fi
+
+# Hermes agent (git repo)
+if [[ -d $HOME/.hermes/hermes-agent/.git ]]; then
+  if GIT_TERMINAL_PROMPT=0 timeout 20 git -C "$HOME/.hermes/hermes-agent" fetch --quiet origin 2>/dev/null; then
+    behind=$(git -C "$HOME/.hermes/hermes-agent" rev-list --count "HEAD..origin/main" 2>/dev/null || echo 0)
+    if (( behind > 0 )); then
+      ENTRIES+=("hermes agent|$behind commit(s) behind|hermes update")
+    fi
+  fi
+fi
+
+# npm global packages
+npm_out=$(timeout 60 npm outdated -g 2>/dev/null || true)
+if [[ -n $npm_out ]]; then
+  while IFS= read -r line; do
+    [[ $line == Package* ]] && continue
+    [[ -z $line ]] && continue
+    pkg=$(printf '%s' "$line" | awk '{print $1}')
+    cur=$(printf '%s' "$line" | awk '{print $2}')
+    latest=$(printf '%s' "$line" | awk '{print $4}')
+    [[ -z $pkg ]] && continue
+    ENTRIES+=("npm: $pkg|$cur -> $latest|npm install -g $pkg@latest")
+  done <<< "$npm_out"
+fi
+
+# uv tools (Python CLI tools)
+uv_out=$(timeout 60 uv tool list --outdated 2>/dev/null || true)
+if [[ -n $uv_out ]]; then
+  while IFS= read -r line; do
+    [[ -z $line ]] && continue
+    tool=$(printf '%s' "$line" | awk '{print $1}')
+    [[ -z $tool ]] && continue
+    ENTRIES+=("uv: $tool|$line|uv tool upgrade $tool")
+  done <<< "$uv_out"
+fi
+
+if (( ${#ENTRIES[@]} == 0 )); then
+  echo "Everything is up to date."
+  read -rp "Press Enter to close..."
+  exit 0
+fi
+
+# --- Render menu -----------------------------------------------------------
+clear
+echo -e "\e[1m=== Available Updates ===\e[0m"
+echo ""
+for i in "${!ENTRIES[@]}"; do
+  IFS='|' read -r name detail cmd <<< "${ENTRIES[$i]}"
+  printf '  \e[1;36m%2d)\e[0m \e[1m%-28s\e[0m %s\n' "$((i+1))" "$name" "$detail"
+done
+echo ""
+echo -e "  \e[1;32m a)\e[0m \e[1mUpdate ALL\e[0m"
+echo -e "  \e[1;31m q)\e[0m Quit"
+echo ""
+read -rp "Select: " choice
+
+case "$choice" in
+  q|Q) exit 0 ;;
+  a|A)
+    echo ""
+    echo -e "\e[1m=== Updating everything ===\e[0m"
+    omarchy-update-all
+    ;;
+  *)
+    if [[ $choice =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= ${#ENTRIES[@]} )); then
+      IFS='|' read -r name detail cmd <<< "${ENTRIES[$((choice-1))]}"
+      echo ""
+      echo -e "\e[1m=== Updating: $name ===\e[0m"
+      echo -e "\e[2m$cmd\e[0m"
+      echo ""
+      eval "$cmd"
+    else
+      echo "Invalid selection."
+    fi
+    ;;
+esac
+
+echo ""
+read -rp "Press Enter to close..."

--- a/bin/omarchy-update-notify
+++ b/bin/omarchy-update-notify
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# omarchy:summary=Notify when updates are available for installed apps and tools
+# omarchy:hidden=true
+
+set -euo pipefail
+
+declare -a lines=()
+
+# System packages (pacman)
+if omarchy-cmd-present checkupdates; then
+  n=$(timeout 60 checkupdates 2>/dev/null | wc -l || true)
+  if (( n > 0 )); then
+    lines+=("$n system package(s)")
+  fi
+fi
+
+# AUR packages
+if omarchy-cmd-present yay; then
+  n=$(timeout 60 yay -Qua 2>/dev/null | wc -l || true)
+  if (( n > 0 )); then
+    lines+=("$n AUR package(s)")
+  fi
+fi
+
+# mise-managed tools (AI + dev tools)
+if omarchy-cmd-present mise; then
+  out=$(timeout 60 mise outdated 2>/dev/null || true)
+  if [[ -n $out && $out != *"up to date"* ]]; then
+    n=$(printf '%s\n' "$out" | grep -v '^[[:space:]]*$' | wc -l || true)
+    if (( n > 0 )); then
+      lines+=("$n mise tool(s)")
+    fi
+  fi
+fi
+
+# Hermes agent (git-installed)
+if [[ -d $HOME/.hermes/hermes-agent/.git ]]; then
+  if GIT_TERMINAL_PROMPT=0 timeout 20 git -C "$HOME/.hermes/hermes-agent" fetch --quiet origin 2>/dev/null; then
+    behind=$(git -C "$HOME/.hermes/hermes-agent" rev-list --count "HEAD..origin/main" 2>/dev/null || echo 0)
+    if (( behind > 0 )); then
+      lines+=("hermes agent ($behind commit(s) behind)")
+    fi
+  fi
+fi
+
+# npm global packages
+if omarchy-cmd-present npm; then
+  n=$(timeout 60 npm outdated -g 2>/dev/null | tail -n +2 | grep -c . || true)
+  if (( n > 0 )); then
+    lines+=("$n npm global package(s)")
+  fi
+fi
+
+# uv tools (Python CLI tools)
+if omarchy-cmd-present uv; then
+  n=$(timeout 60 uv tool list --outdated 2>/dev/null | grep -c . || true)
+  if (( n > 0 )); then
+    lines+=("$n uv tool(s)")
+  fi
+fi
+
+# Nothing to update -> stay quiet.
+if (( ${#lines[@]} == 0 )); then
+  exit 0
+fi
+
+summary="Updates available"
+body=$(printf '%s\n' "${lines[@]}")
+
+# Clicking the toast opens the interactive update menu (per-app or update all).
+omarchy-notification-send \
+  -u normal \
+  -g $'\uf021' \
+  "$summary" \
+  "$body" \
+  --exec omarchy-launch-floating-terminal-with-presentation omarchy-update-menu

--- a/default/systemd/user/omarchy-update-notify.service
+++ b/default/systemd/user/omarchy-update-notify.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check for available updates and notify
+# Needs the session bus to notify, and uwsm-app to open the update menu
+# terminal. Both are up only after graphical-session.target.
+After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/omarchy-update-notify

--- a/default/systemd/user/omarchy-update-notify.timer
+++ b/default/systemd/user/omarchy-update-notify.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic update check (notify when updates are available)
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -18,4 +18,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  omarchy-update-notify.timer

--- a/migrations/1788529761.sh
+++ b/migrations/1788529761.sh
@@ -1,0 +1,21 @@
+echo "Notify when updates are available for installed apps and tools"
+
+# The timer is enabled at first-run in install/user/first-run/enable-user-units.sh,
+# which only runs once, so existing installs need it enabled here.
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# `systemctl enable` needs a live user manager, which an update from a TTY does
+# not have, so fall back to writing the symlink it would have written.
+if ! systemctl --user enable omarchy-update-notify.timer >/dev/null 2>&1; then
+  wants_dir="$HOME/.config/systemd/user/timers.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn /usr/lib/systemd/user/omarchy-update-notify.timer \
+    "$wants_dir/omarchy-update-notify.timer"
+fi
+
+# Nothing to start into over SSH; the next graphical login handles it. A failed
+# start only delays the first update toast, so it stays quiet.
+if systemctl --user is-active --quiet graphical-session.target; then
+  systemctl --user start omarchy-update-notify.timer >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -141,6 +141,8 @@ package_defaults = [
   ("default/systemd/user/omarchy-tailscale-receive.service", "/usr/lib/systemd/user/omarchy-tailscale-receive.service", "systemd/user/omarchy-tailscale-receive.service"),
   ("default/systemd/user/omarchy-fcitx5.service", "/usr/lib/systemd/user/omarchy-fcitx5.service", "systemd/user/omarchy-fcitx5.service"),
   ("default/systemd/user/omarchy-crash-watch.service", "/usr/lib/systemd/user/omarchy-crash-watch.service", "systemd/user/omarchy-crash-watch.service"),
+  ("default/systemd/user/omarchy-update-notify.service", "/usr/lib/systemd/user/omarchy-update-notify.service", "systemd/user/omarchy-update-notify.service"),
+  ("default/systemd/user/omarchy-update-notify.timer", "/usr/lib/systemd/user/omarchy-update-notify.timer", "systemd/user/omarchy-update-notify.timer"),
   ("default/systemd/zram-generator.conf.d/90-omarchy.conf", "/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf", "systemd/zram-generator.conf.d/90-omarchy.conf"),
   ("default/fonts/omarchy/omarchy.ttf", "/usr/share/fonts/omarchy/omarchy.ttf", "omarchy.ttf"),
   ("default/snapper/root", "/etc/snapper/config-templates/omarchy", "snapper/root"),

--- a/test/shell.d/update-notify-test.sh
+++ b/test/shell.d/update-notify-test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+notify_log="$test_tmp/notify.log"
+mkdir -p "$stub_bin" "$test_tmp/home/.hermes/hermes-agent/.git"
+
+cat >"$stub_bin/checkupdates" <<'SH'
+#!/bin/bash
+case "${TEST_CHECKUPDATES:-none}" in
+  updates)
+    printf 'linux 6.1-1 -> 6.1-2\nfirefox 120-1 -> 120-2\n'
+    exit 0
+    ;;
+  none)
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$stub_bin/checkupdates"
+
+cat >"$stub_bin/yay" <<'SH'
+#!/bin/bash
+case "${TEST_AUR:-none}" in
+  updates)
+    printf 'spotify 1.0-1 -> 1.1-1\n'
+    exit 0
+    ;;
+  none)
+    exit 0
+    ;;
+esac
+SH
+chmod +x "$stub_bin/yay"
+
+cat >"$stub_bin/mise" <<'SH'
+#!/bin/bash
+case "${TEST_MISE:-uptodate}" in
+  updates)
+    printf 'claude 2.1.260 -> 2.1.300\n'
+    exit 0
+    ;;
+  uptodate)
+    printf 'mise All tools are up to date\n'
+    exit 0
+    ;;
+esac
+SH
+chmod +x "$stub_bin/mise"
+
+cat >"$stub_bin/npm" <<'SH'
+#!/bin/bash
+case "${TEST_NPM:-none}" in
+  updates)
+    printf 'Package  Current   Wanted   Latest  Location              Depended by\nvercel    54.7.1   59.11.2  59.11.2  node_modules/vercel   global\n'
+    exit 0
+    ;;
+  none)
+    exit 0
+    ;;
+esac
+SH
+chmod +x "$stub_bin/npm"
+
+cat >"$stub_bin/uv" <<'SH'
+#!/bin/bash
+case "${TEST_UV:-none}" in
+  updates)
+    printf 'litellm v1.99.0 -> v1.100.0\n'
+    exit 0
+    ;;
+  none)
+    exit 0
+    ;;
+esac
+SH
+chmod +x "$stub_bin/uv"
+
+cat >"$stub_bin/git" <<'SH'
+#!/bin/bash
+[[ $1 == "-C" ]] || exit 1
+shift 2
+case "$1" in
+  fetch) exit 0 ;;
+  rev-list) printf '%s\n' "${TEST_HERMES_BEHIND:-0}" ;;
+esac
+SH
+chmod +x "$stub_bin/git"
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$stub_bin/omarchy-cmd-present"
+
+cat >"$stub_bin/omarchy-notification-send" <<SH
+#!/bin/bash
+printf '%s\n' "\$@" >>"$notify_log"
+SH
+chmod +x "$stub_bin/omarchy-notification-send"
+
+export PATH="$stub_bin:$PATH"
+export HOME="$test_tmp/home"
+
+# Everything up to date -> no notification.
+: >"$notify_log"
+TEST_CHECKUPDATES=none TEST_AUR=none TEST_MISE=uptodate TEST_NPM=none TEST_UV=none TEST_HERMES_BEHIND=0 \
+  "$ROOT/bin/omarchy-update-notify" || fail "notify exits successfully when up to date"
+[[ ! -s $notify_log ]] || fail "notify stays quiet when up to date" "$(cat "$notify_log")"
+pass "notify stays quiet when everything is up to date"
+
+# Updates available -> sends a notification covering every source.
+: >"$notify_log"
+TEST_CHECKUPDATES=updates TEST_AUR=updates TEST_MISE=updates TEST_NPM=updates TEST_UV=updates TEST_HERMES_BEHIND=3 \
+  "$ROOT/bin/omarchy-update-notify" || fail "notify exits successfully when updates are available"
+grep -q 'Updates available' "$notify_log" || fail "notify sends an Updates available notification" "$(cat "$notify_log")"
+grep -q 'system package' "$notify_log" || fail "notify reports system packages" "$(cat "$notify_log")"
+grep -q 'AUR package' "$notify_log" || fail "notify reports AUR packages" "$(cat "$notify_log")"
+grep -q 'mise tool' "$notify_log" || fail "notify reports mise tools" "$(cat "$notify_log")"
+grep -q 'hermes agent' "$notify_log" || fail "notify reports hermes" "$(cat "$notify_log")"
+grep -q 'npm global' "$notify_log" || fail "notify reports npm packages" "$(cat "$notify_log")"
+grep -q 'uv tool' "$notify_log" || fail "notify reports uv tools" "$(cat "$notify_log")"
+grep -q 'omarchy-update-menu' "$notify_log" || fail "notify click opens the update menu" "$(cat "$notify_log")"
+pass "notify reports every update source and opens the menu on click"


### PR DESCRIPTION
## Summary

Adds a systemd timer that periodically checks every update source in omarchy (pacman, AUR, hermes, agents) and raises a bar notification when updates are available. Clicking the notification opens a menu listing each app with an available update, letting the user update apps individually or run **update-all** at once.

## What's included

- **`bin/omarchy-update-notify`** — checks all update sources and raises a bar notification when updates are available. Clicking it opens the update menu.
- **`bin/omarchy-update-menu`** — interactive menu listing each app with an available update; user can update apps one-by-one or run update-all.
- **`bin/omarchy-update-all`** — updates every source (pacman, AUR, hermes, agents) in one go.
- **`default/systemd/user/omarchy-update-notify.{service,timer}`** — periodic background check.
- **`migrations/1788529761.sh`** — enables the timer on upgrade.
- **`install/user/first-run/enable-user-units.sh`** — enables the timer on first run.
- **`test/shell.d/update-notify-test.sh`** — tests for the notify/menu/all scripts.

## Behavior

- Stays quiet when everything is up to date.
- Reports every update source and opens the menu on click.
- Handles a failing collector gracefully (reports it, doesn't abort).
- Update-all runs every step in order and keeps the update lock.

## Testing

All new tests pass. The only failing tests in the suite are pre-existing and require an external `omarchy-pkgs` checkout (PKGBUILD coverage / package ownership), unrelated to this change.