### PR TITLE
Add speech-dispatcher so Brave Web Speech has voices

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -30,6 +30,7 @@ evince
 exfatprogs
 expac
 eza
+espeak-ng
 fakeroot
 fastfetch
 fcitx5
@@ -115,6 +116,7 @@ tensaku
 sddm
 slurp
 socat
+speech-dispatcher
 starship
 sushi
 system-config-printer

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -18,4 +18,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  speech-dispatcher.socket

--- a/manual/23-browsers.md
+++ b/manual/23-browsers.md
@@ -28,6 +28,12 @@ Both extensions talk to Omarchy through a small native messaging host, which get
 
 These are Chromium-family only. Firefox and Zen don't get them.
 
+## Listen / text to speech
+
+Sites that use the Web Speech API — Google Translate's Listen button is the usual example — talk to a local speech backend on Linux. Chromium still ships Google cloud voices, so it works without one. Brave does not.
+
+Omarchy therefore installs `speech-dispatcher` and `espeak-ng`, and enables the user socket so those sites have voices in every Chromium-family browser, including Brave. After an update on an existing machine, fully quit and reopen the browser once so it picks the new voices up.
+
 ## Firefox and Zen
 
 Firefox and Zen are a different family, so they get different treatment: Omarchy installs a policies file for sensible defaults and switches them into native Wayland mode, which you want for fractional scaling and smooth trackpad scrolling.

--- a/migrations/1788533192.sh
+++ b/migrations/1788533192.sh
@@ -1,0 +1,16 @@
+echo "Install a local speech backend so Web Speech works in Brave and other browsers"
+
+omarchy-pkg-add speech-dispatcher espeak-ng
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# speech-dispatcher.socket is a distro unit (WantedBy=sockets.target). Enable
+# without assuming a live user manager: an update from a TTY still needs the
+# symlink so the next graphical login has voices. --now starts it immediately
+# when the user manager is up, so an already-open session does not wait.
+if ! systemctl --user enable --now speech-dispatcher.socket >/dev/null 2>&1; then
+  wants_dir="$HOME/.config/systemd/user/sockets.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn /usr/lib/systemd/user/speech-dispatcher.socket \
+    "$wants_dir/speech-dispatcher.socket"
+fi

--- a/test/acceptance.d/system-test.sh
+++ b/test/acceptance.d/system-test.sh
@@ -67,6 +67,10 @@ verify_services() {
   systemctl --user is-active --quiet pipewire.service pipewire-pulse.service wireplumber.service ||
     fail "user audio services are running"
   pass "user audio services are running"
+
+  systemctl --user is-enabled --quiet speech-dispatcher.socket ||
+    fail "speech dispatcher socket is enabled"
+  pass "speech dispatcher socket is enabled"
 }
 
 verify_runtime_tools() {

--- a/test/shell.d/speech-dispatcher-test.sh
+++ b/test/shell.d/speech-dispatcher-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+packages="$ROOT/install/omarchy-base.packages"
+first_run_units="$ROOT/install/user/first-run/enable-user-units.sh"
+migration=$(grep -rl 'Install a local speech backend so Web Speech works' "$ROOT/migrations" | head -n 1 || true)
+
+grep -qxF espeak-ng "$packages" || fail "espeak-ng is in the base package set"
+grep -qxF speech-dispatcher "$packages" || fail "speech-dispatcher is in the base package set"
+pass "the base install ships a local speech backend"
+
+grep -F 'speech-dispatcher.socket' "$first_run_units" >/dev/null ||
+  fail "first-run does not enable the speech dispatcher socket"
+pass "first-run enables the speech dispatcher socket"
+
+[[ -n $migration ]] || fail "speech backend migration exists"
+pass "speech backend migration exists"
+
+# A user speechd.conf would mask the packaged one, including module auto-detect
+# and Orca dictionaries. The distro default is enough once espeak-ng is present.
+[[ ! -e $ROOT/config/speech-dispatcher/speechd.conf ]] ||
+  fail "Omarchy does not ship a user speechd.conf that masks the packaged default"
+pass "Omarchy does not ship a user speechd.conf"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin" "$test_tmp/home"
+
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'omarchy-pkg-add\t%s\n' "$*" >>"$OMARCHY_SPEECH_TEST_LOG"
+exit "${OMARCHY_SPEECH_PKG_ADD_STATUS:-0}"
+SH
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+printf 'systemctl\t%s\n' "$*" >>"$OMARCHY_SPEECH_TEST_LOG"
+if [[ $1 == "--user" && $2 == "enable" ]]; then
+  exit "${OMARCHY_SPEECH_ENABLE_STATUS:-0}"
+fi
+exit 0
+SH
+chmod +x "$mock_bin"/*
+
+log="$test_tmp/actions.log"
+touch "$log"
+
+run_migration() {
+  : >"$log"
+  HOME="$test_tmp/home" \
+    PATH="$mock_bin:$PATH" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_SPEECH_TEST_LOG="$log" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+if OMARCHY_SPEECH_PKG_ADD_STATUS=1 run_migration 2>/dev/null; then
+  fail "the migration continues when package installation fails"
+fi
+grep -qxF $'omarchy-pkg-add\tspeech-dispatcher espeak-ng' "$log" ||
+  fail "a failed package install still attempted omarchy-pkg-add"
+! grep -q $'systemctl\t' "$log" ||
+  fail "a failed package install still enabled the socket"
+pass "the migration stops when the speech packages cannot be installed"
+
+run_migration
+grep -qxF $'omarchy-pkg-add\tspeech-dispatcher espeak-ng' "$log" ||
+  fail "the migration installs speech-dispatcher and espeak-ng"
+grep -qxF $'systemctl\t--user daemon-reload' "$log" ||
+  fail "the migration reloads user units after installing the package"
+grep -qxF $'systemctl\t--user enable --now speech-dispatcher.socket' "$log" ||
+  fail "the migration enables the speech dispatcher socket"
+[[ ! -e $test_tmp/home/.config/systemd/user/sockets.target.wants/speech-dispatcher.socket ]] ||
+  fail "a live user manager does not also write a fallback symlink"
+pass "the migration installs the packages and enables the socket"
+
+OMARCHY_SPEECH_ENABLE_STATUS=1 run_migration
+[[ -L $test_tmp/home/.config/systemd/user/sockets.target.wants/speech-dispatcher.socket ]] ||
+  fail "a TTY update still enables the socket for the next login"
+[[ $(readlink "$test_tmp/home/.config/systemd/user/sockets.target.wants/speech-dispatcher.socket") == /usr/lib/systemd/user/speech-dispatcher.socket ]] ||
+  fail "the fallback symlink points at the distro socket unit"
+pass "the migration writes the socket wants symlink when systemctl cannot enable"
+
+OMARCHY_SPEECH_ENABLE_STATUS=1 run_migration
+pass "the migration is idempotent when the socket is already linked"


### PR DESCRIPTION
Fixes #10178

## Summary

Brave does not ship Google cloud TTS voices. On a stock Omarchy install `speechSynthesis.getVoices()` is empty, so sites that use the Web Speech API (Google Translate's Listen button is the usual case) animate as if they are playing and produce no audio. Chromium still works on the same machine because it has those cloud voices.

This installs a local backend and turns the user socket on:

- `speech-dispatcher` and `espeak-ng` in `install/omarchy-base.packages`
- `speech-dispatcher.socket` enabled at first-run
- a migration so existing installs get the same packages and socket (including updates from a TTY, which write the `sockets.target.wants` symlink when `systemctl --user enable` cannot run)

The packaged `speechd.conf` already auto-detects espeak-ng. This PR does **not** ship a user `speechd.conf`, which would mask Orca dictionaries and module auto-detect.

## Test plan

- [x] `test/shell.d/speech-dispatcher-test.sh` — package list, first-run enablement, migration install/enable, TTY fallback symlink, failed `omarchy-pkg-add` stays pending
- [ ] Fresh install: `speechSynthesis.getVoices()` is non-empty in Brave; Translate Listen is audible
- [ ] Existing install after `omarchy update`: fully quit Brave, reopen, confirm voices and Listen
- [ ] `spd-say "hello"` produces audio
- [ ] `systemctl --user is-enabled speech-dispatcher.socket`

Related: #5686 added the same packages but also a custom user config and did not enable the socket. This PR is the narrower fix for #10178.