### PR TITLE
Hold a cooldown before repeating the low battery warning

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -166,7 +166,11 @@ variants map to the IPC methods `dismissOne`, `dismissAll`, `invokeLast`,
 Everything goes through the same sender contract, so the pieces are small:
 
 - **Low battery** — `omarchy-battery-low` sends a critical toast and runs the
-  `battery-low` hook.
+  `battery-low` hook. The shell's battery service decides when to call it: it
+  latches so a steady drain warns once, and holds a one-minute cooldown on top
+  so a charger too weak to climb past the threshold — flipping between
+  charging and discharging, clearing the latch each time — cannot restart the
+  toast.
 - **Crash capture** — `omarchy-crash-watch` follows the systemd-coredump
   journal stream and announces each crashed program (deduped per minute) as a
   critical toast whose click runs `omarchy-agent-crash` (via `--exec`, so a

--- a/shell/plugins/services/battery/BatteryModel.js
+++ b/shell/plugins/services/battery/BatteryModel.js
@@ -7,15 +7,22 @@ function isDischarging(device, onBattery, dischargingState) {
   return !!(device && device.isPresent && onBattery && device.state === dischargingState)
 }
 
-function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified) {
+// A weak charger can leave the battery hovering on the threshold, flipping
+// between charging and discharging every few seconds. The latch alone clears
+// on every flip, so the warning also needs a cooldown before it may fire again.
+function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified, lastNotifiedAt, now, cooldown) {
   var level = batteryPercentage(device)
-  if (level < 0) return { level: level, notify: false, notifiedLowBattery: false }
+  if (level < 0) return { level: level, notify: false, notifiedLowBattery: false, lastNotifiedAt: lastNotifiedAt }
 
   var low = isDischarging(device, onBattery, dischargingState) && level <= threshold
+  var cooledDown = !lastNotifiedAt || now - lastNotifiedAt >= cooldown
+  var notify = low && !alreadyNotified && cooledDown
+
   return {
     level: level,
-    notify: low && !alreadyNotified,
-    notifiedLowBattery: low
+    notify: notify,
+    notifiedLowBattery: low,
+    lastNotifiedAt: notify ? now : lastNotifiedAt
   }
 }
 

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -11,12 +11,14 @@ Item {
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
 
   readonly property int batteryThreshold: 10
+  readonly property int lowBatteryCooldown: 60000
   property string pendingPowerSource: ""
 
   PersistentProperties {
     id: persisted
     reloadableId: "omarchy-battery"
     property bool notifiedLowBattery: false
+    property double lowBatteryNotifiedAt: 0
   }
 
   function batteryPercentage() {
@@ -28,8 +30,9 @@ Item {
   }
 
   function checkBattery() {
-    var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery)
+    var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery, persisted.lowBatteryNotifiedAt, Date.now(), lowBatteryCooldown)
     persisted.notifiedLowBattery = state.notifiedLowBattery
+    persisted.lowBatteryNotifiedAt = state.lastNotifiedAt
     if (state.notify) sendLowBatteryWarning(state.level)
   }
 

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -7,25 +7,47 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const battery = requireFromRoot('shell/plugins/services/battery/BatteryModel.js')
 const discharging = 1
+const cooldown = 60000
 
 assertEqual(battery.batteryPercentage({ isPresent: true, percentage: 0.126 }), 13, 'battery rounds display percentage')
 assertEqual(battery.batteryPercentage({ isPresent: false, percentage: 0.5 }), -1, 'battery reports missing battery')
 assert(battery.isDischarging({ isPresent: true, state: discharging }, true, discharging), 'battery detects discharging state')
 assert(!battery.isDischarging({ isPresent: true, state: discharging }, false, discharging), 'battery requires on-battery state')
 
+const low = { isPresent: true, percentage: 0.08, state: discharging }
+const healthy = { isPresent: true, percentage: 0.4, state: discharging }
+
 assertDeepEqual(
-  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, false),
-  { level: 8, notify: true, notifiedLowBattery: true },
+  battery.shouldWarnLowBattery(low, true, discharging, 10, false, 0, 1000, cooldown),
+  { level: 8, notify: true, notifiedLowBattery: true, lastNotifiedAt: 1000 },
   'battery warns once under threshold'
 )
 assertDeepEqual(
-  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, true),
-  { level: 8, notify: false, notifiedLowBattery: true },
+  battery.shouldWarnLowBattery(low, true, discharging, 10, true, 1000, 2000, cooldown),
+  { level: 8, notify: false, notifiedLowBattery: true, lastNotifiedAt: 1000 },
   'battery keeps low-battery notified state'
 )
 assertDeepEqual(
-  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, true),
-  { level: 40, notify: false, notifiedLowBattery: false },
+  battery.shouldWarnLowBattery(healthy, true, discharging, 10, true, 1000, 2000, cooldown),
+  { level: 40, notify: false, notifiedLowBattery: false, lastNotifiedAt: 1000 },
   'battery clears notified state after recovery'
+)
+
+// A weak charger flips the battery in and out of discharging on the threshold,
+// clearing the latch each time; the cooldown is what stops the toast storm.
+assertDeepEqual(
+  battery.shouldWarnLowBattery(low, true, discharging, 10, false, 1000, 31000, cooldown),
+  { level: 8, notify: false, notifiedLowBattery: true, lastNotifiedAt: 1000 },
+  'battery holds the warning inside the cooldown'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery(low, true, discharging, 10, false, 1000, 61000, cooldown),
+  { level: 8, notify: true, notifiedLowBattery: true, lastNotifiedAt: 61000 },
+  'battery warns again once the cooldown expires'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: false }, true, discharging, 10, false, 1000, 61000, cooldown),
+  { level: -1, notify: false, notifiedLowBattery: false, lastNotifiedAt: 1000 },
+  'battery keeps the last warning time when no battery is present'
 )
 JS


### PR DESCRIPTION
## Problem

The low battery warning is guarded only by a `notifiedLowBattery` latch in `shell/plugins/services/battery/Service.qml`, and that latch clears the moment the battery stops discharging.

With a charger too weak to climb past the 10% threshold, the battery flips between charging and discharging every few seconds. Each flip clears the latch, so the next 30-second poll fires a fresh toast — the warning repeats indefinitely while the battery hovers on the threshold. Reported on a laptop whose charger cannot outpace draw at 10%.

## Fix

Gate the warning on a one-minute cooldown in addition to the latch. `shouldWarnLowBattery` now takes `lastNotifiedAt`, `now`, and `cooldown`, and returns the updated timestamp; the service persists it in `PersistentProperties` alongside the existing latch, so it survives a shell reload.

The latch is kept, so a normal steady drain still warns exactly once — the cooldown only matters when the latch keeps getting reset.

## Tests

- `test/shell.d/battery-test.sh` — three new cases: the warning is held inside the cooldown, fires again once it expires, and the timestamp is preserved when no battery is present. All pass; the new cases fail against the unfixed model.
- Full `./test/shell`: only pre-existing environmental failures (missing `omarchy-pkgs` checkout for `config-test.sh` and `unowned-system-paths-test.sh`; `snapper-test.sh` not executable).

Behaviour was also checked in an isolated Quickshell harness loading the real service with only `UPower` stubbed, reproducing the reported scenario — 8% battery flipping in and out of discharging once a second:

- **Before:** 11 toasts in 21s of flapping.
- **After:** 2 toasts in 75s of flapping, exactly 60s apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ThTCkRCbS5EHykvTgfUSW