### PR TITLE
Fix workspace indicator after monitor move

### DIFF
--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -8,6 +8,16 @@ BarWidget {
   id: root
   moduleName: "omarchy.workspaces"
 
+  Connections {
+    target: Hyprland
+    function onRawEvent(event) {
+      // Quickshell 0.3.1 updates a moved workspace's monitor but leaves each
+      // monitor's activeWorkspace stale. focusedWorkspace is derived from it,
+      // so refresh the monitor model after Hyprland completes the move.
+      if (event.name === "moveworkspacev2") Hyprland.refreshMonitors()
+    }
+  }
+
   function workspaceById(id) {
     var values = Hyprland.workspaces.values
     for (var i = 0; i < values.length; i++) {


### PR DESCRIPTION
## Summary

- Refresh Quickshell's Hyprland monitor model after `moveworkspacev2` events.

## Why

With Quickshell 0.3.1, moving the active workspace to another monitor updates the workspace's monitor association but can leave `monitor.activeWorkspace` stale. Because `focusedWorkspace` is derived from that monitor state, the bar can indicate the wrong workspace until another workspace switch forces it to catch up.

This is a narrow Omarchy workaround: re-query monitor state after Hyprland completes the move. It avoids inferring focus or changing UI state locally. A proposed Quickshell-side fix is available for reference at https://github.com/dzanaga/quickshell/tree/fix/hyprland-workspace-monitor-state.

This complements #8997: that PR makes each bar read its own monitor's `activeWorkspace`, while this PR ensures Quickshell refreshes that value after a workspace moves between monitors. The behavior is independent, but both patches insert code after `moduleName`, so whichever merges second may need a trivial placement-conflict resolution.

Fixes #10187.

## Verification

- Reproduced on two monitors with Quickshell 0.3.1.
- Verified moves in both directions now settle on the correct indicator. A brief flicker can remain while the asynchronous monitor refresh completes.
- Combined current `quattro`, #8997, and this change on [`test/workspaces-pr-8997-integration`](https://github.com/dzanaga/omarchy/tree/test/workspaces-pr-8997-integration). The combined widget keeps #8997's per-monitor binding and adds this PR's refresh hook.
- Published the exact combined widget as an installable [workspace indicator fix](https://github.com/dzanaga/omarchy-workspaces-indicator-fix) for normal-use testing while both PRs are reviewed.
- Combined-branch `bar-test.sh` and `plugins-test.sh` pass; `git diff --check` passes.
- `./test/shell`: 222/227 test files pass. The five failures are existing/environment-specific: `config-test.sh`, `launch-about-test.sh`, `network-qr-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`.
