### PR TITLE
Prefer the live device name when labeling Bluetooth devices

### DIFF
--- a/shell/plugins/panels/bluetooth/Model.js
+++ b/shell/plugins/panels/bluetooth/Model.js
@@ -1,6 +1,6 @@
 function deviceLabel(device) {
   if (!device) return ""
-  return String(device.deviceName || device.name || "").trim()
+  return String(device.name || device.deviceName || "").trim()
 }
 
 function toArray(values) {

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -98,9 +98,14 @@ assertDeepEqual(
   'bluetooth projects device rows with primitives only'
 )
 assertEqual(
-  bluetooth.deviceLabel(bluetooth.deviceRow({ name: 'Generic', deviceName: 'MX Master 3S', address: '2', connected: true })),
+  bluetooth.deviceLabel(bluetooth.deviceRow({ name: 'My Headphones', deviceName: 'MX Master 3S', address: '2', connected: true })),
+  'My Headphones',
+  'bluetooth prefers name (BlueZ Alias) over deviceName (BlueZ Name) so a rename reaches the label'
+)
+assertEqual(
+  bluetooth.deviceLabel(bluetooth.deviceRow({ name: '', deviceName: 'MX Master 3S', address: '2', connected: true })),
   'MX Master 3S',
-  'bluetooth keeps deviceName in row projections so labels survive QObject-free rows'
+  'bluetooth keeps deviceName in row projections as a fallback label when name is unset'
 )
 
 assertDeepEqual(


### PR DESCRIPTION
## Summary
- Renaming a Bluetooth device never showed up in the panel — not
  after restarting the bar or shell, not after rebooting.
- `deviceLabel` favored `device.deviceName` over `device.name`.
  `deviceName` mirrors BlueZ's `Name` property, which is set once
  from the device's advertisement and persisted to BlueZ's own
  on-disk device record — it never changes. `device.name` mirrors
  BlueZ's `Alias`, the property a rename actually writes.
- Swaps the priority so the label follows the Alias, with
  `deviceName` kept as a fallback for the (rare) case where `name`
  is unset.

## Test plan
- Updated `test/shell.d/bluetooth-test.sh`, which previously asserted
  the old priority, to cover both the rename-wins and the
  deviceName-fallback cases.
- `bash test/shell.d/bluetooth-test.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)