### PR TITLE
Add a refresh-rate picker to the display panel

### DIFF
--- a/bin/omarchy-hyprland-monitor-refresh
+++ b/bin/omarchy-hyprland-monitor-refresh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# omarchy:summary=Show, list, or set the focused Hyprland monitor's refresh rate
+# omarchy:args=[--list|RATE]
+# omarchy:examples=omarchy hyprland monitor refresh | omarchy hyprland monitor refresh --list | omarchy hyprland monitor refresh 120
+
+# Companion to omarchy-hyprland-monitor-scaling, and shaped like it: apply with
+# `hyprctl eval`, then write the choice into monitors.lua. A rate set only at
+# runtime does not last, because the config is authoritative again from the next
+# reload and plugging a monitor in is enough to cause one.
+
+set -uo pipefail
+
+MONITOR_LUA="$HOME/.config/hypr/monitors.lua"
+
+usage() {
+  echo "Usage: omarchy-hyprland-monitor-refresh [--list|RATE]"
+}
+
+focused_monitor() {
+  hyprctl monitors -j | jq -e -c '.[] | select(.focused == true)'
+}
+
+# Hyprland reports rates as 143.979; whole numbers are what spec sheets, mode
+# strings and users say.
+round_rate() {
+  awk '{ printf "%d\n", $0 + 0.5 }'
+}
+
+# The rates this monitor offers at the resolution it is currently running,
+# highest first. Hyprland lists modes as "2560x1440@240.00Hz".
+available_rates() {
+  local monitor_info="$1"
+  local mode_prefix
+
+  mode_prefix=$(jq -r '"\(.width)x\(.height)@"' <<<"$monitor_info")
+
+  jq -r --arg prefix "$mode_prefix" '.availableModes[] | select(startswith($prefix))' <<<"$monitor_info" |
+    sed -E 's/.*@([0-9.]+)Hz$/\1/' |
+    round_rate |
+    sort -rnu
+}
+
+set_rate() {
+  local requested="$1"
+  local monitor_info name width height scale position
+
+  if ! monitor_info=$(focused_monitor); then
+    echo "No focused monitor" >&2
+    exit 1
+  fi
+
+  name=$(jq -r '.name' <<<"$monitor_info")
+  width=$(jq -r '.width' <<<"$monitor_info")
+  height=$(jq -r '.height' <<<"$monitor_info")
+  scale=$(jq -r '.scale' <<<"$monitor_info")
+  position=$(jq -r '"\(.x)x\(.y)"' <<<"$monitor_info")
+
+  # The name is written into the Lua string eval'd below and into the config,
+  # so only a plain connector name may pass; a hostile output name could
+  # execute otherwise.
+  if [[ ! $name =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "Refusing unsafe monitor name" >&2
+    exit 1
+  fi
+
+  if ! available_rates "$monitor_info" | grep -qx -- "$requested"; then
+    echo "$name has no ${requested}Hz mode at ${width}x${height}" >&2
+    echo "Available: $(available_rates "$monitor_info" | paste -sd' ')" >&2
+    exit 1
+  fi
+
+  # Keep the monitor where it is for this change. The resolution is not moving,
+  # so there is nothing for "auto" to re-derive and no reason to make the other
+  # displays jump.
+  local mode="${width}x${height}@${requested}"
+  hyprctl eval "hl.monitor({ output = \"$name\", mode = \"$mode\", position = \"$position\", scale = $scale })" >/dev/null
+
+  persist_rate "$name" "$mode" "$scale"
+}
+
+# An output that already has a rule of its own only gets its mode rewritten, so
+# a hand-written position or transform survives. Otherwise append a rule for it.
+# That rule inherits omarchy_monitor_scale where the file still defines it, so
+# `omarchy hyprland monitor scaling` keeps reaching this output afterwards.
+persist_rate() {
+  local name="$1" mode="$2" scale="$3"
+
+  [[ -f $MONITOR_LUA ]] || return 0
+
+  local rule='^([[:space:]]*hl\.monitor\(\{[^)]*output[[:space:]]*=[[:space:]]*"'"$name"'".*)mode[[:space:]]*=[[:space:]]*"[^"]*"(.*)$'
+  if grep -Eq "$rule" "$MONITOR_LUA"; then
+    sed -i -E "s|$rule|\1mode = \"$mode\"\2|" "$MONITOR_LUA"
+  else
+    local scale_field="$scale"
+    if grep -q '^local omarchy_monitor_scale = ' "$MONITOR_LUA"; then
+      scale_field="omarchy_monitor_scale"
+    fi
+
+    cat >>"$MONITOR_LUA" <<LUA
+
+-- Written by omarchy-hyprland-monitor-refresh
+hl.monitor({ output = "$name", mode = "$mode", position = "auto", scale = $scale_field })
+LUA
+  fi
+}
+
+case "${1:-}" in
+"")
+  focused_monitor | jq -r '.refreshRate' | round_rate
+  ;;
+-h | --help)
+  usage
+  ;;
+--list)
+  available_rates "$(focused_monitor)"
+  ;;
+*)
+  if [[ $1 =~ ^[0-9]+$ ]]; then
+    set_rate "$1"
+  else
+    usage >&2
+    exit 1
+  fi
+  ;;
+esac

--- a/bin/omarchy-monitor-state
+++ b/bin/omarchy-monitor-state
@@ -19,5 +19,7 @@ printf '%s\n' "$monitors_json" | jq -r '
 printf '%s\n' "$focused_monitor"
 omarchy-hyprland-monitor-scaling 2>/dev/null || echo
 
+# scale and position ride along so the panel can put an output back where it
+# was after switching it off; a disabled output no longer reports them dependably.
 printf '%s\n' "$monitors_json" | jq -c \
-  '[.[] | {name, enabled:(.disabled != true), focused:(.focused == true), width, height}]'
+  '[.[] | {name, enabled:(.disabled != true), focused:(.focused == true), width, height, scale, x, y}]'

--- a/bin/omarchy-monitor-state
+++ b/bin/omarchy-monitor-state
@@ -20,6 +20,7 @@ printf '%s\n' "$focused_monitor"
 omarchy-hyprland-monitor-scaling 2>/dev/null || echo
 
 # scale and position ride along so the panel can put an output back where it
-# was after switching it off; a disabled output no longer reports them dependably.
+# was after switching it off; a disabled output no longer reports them
+# dependably. The rate and the mode list feed the panel's refresh picker.
 printf '%s\n' "$monitors_json" | jq -c \
-  '[.[] | {name, enabled:(.disabled != true), focused:(.focused == true), width, height, scale, x, y}]'
+  '[.[] | {name, enabled:(.disabled != true), focused:(.focused == true), width, height, scale, x, y, refreshRate, availableModes}]'

--- a/manual/33-monitors.md
+++ b/manual/33-monitors.md
@@ -30,6 +30,20 @@ omarchy display text size 14
 
 That takes a pixel size between 9 and 20, and moves the Omarchy shell, GTK applications, and your terminal together, so the whole desktop stays in proportion. Run it without an argument to see where you're at, and `omarchy display text size reset` to go back to the default. Foot is the one straggler: it has no way to reload its config, so running terminals keep their old size until you open a new one.
 
+### Refresh rate
+
+A monitor comes up at whatever rate it reports as preferred, and on plenty of panels that is a modest 60Hz even when the hardware can do far better. The Display panel (`Super + Ctrl + D`) lists every rate the focused monitor offers at its current resolution under REFRESH, right below the scaling presets. Picking one applies it immediately.
+
+There is a command for it too:
+
+```
+omarchy hyprland monitor refresh 120
+```
+
+Run it without an argument to see the current rate, and with `--list` to see what is on offer. Both the panel and the command write the choice into `~/.config/hypr/monitors.lua`, so it lasts past a reboot.
+
+This is worth a look even if smoothness is not what you are after. Low refresh rates make some people motion sick — the same queasiness a shaky camera or a VR headset can bring on. If a screen leaves you nauseous or headachy after a while, raising the rate is the first thing to try.
+
 ### Extending and mirroring laptop displays
 
 When you connect an external screen to your laptop, the display is automatically extended. But you can change that to mirroring instead using _Trigger > Hardware_ in the Omarchy menu or `Super + Ctrl + Alt + Delete`. This is especially helpful if that external screen is a projector, and you want to show something while working.

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -111,6 +111,46 @@ function parseDisplays(raw) {
   }
 }
 
+// An output's scale and position can only be read dependably while it is on,
+// and bringing one back with "auto" for both re-places the display and drops a
+// scaled one to 1. Carry the last values seen while an output was on, so
+// switching it back on restores the layout it had.
+function rememberLayouts(previous, displays) {
+  var layouts = {}
+  for (var name in previous) layouts[name] = previous[name]
+  if (!Array.isArray(displays)) return layouts
+
+  for (var i = 0; i < displays.length; i++) {
+    var display = displays[i]
+    if (!display || !display.name || !display.enabled) continue
+
+    var scale = Number(display.scale)
+    var x = Number(display.x)
+    var y = Number(display.y)
+    if (!isFinite(scale) || scale <= 0 || !isFinite(x) || !isFinite(y)) continue
+
+    layouts[display.name] = { scale: scale, position: x + "x" + y }
+  }
+
+  return layouts
+}
+
+// Omarchy configures Hyprland through the Lua parser, which rejects
+// `hyprctl keyword` outright ("keyword can't work with non-legacy parsers. Use
+// eval.") while still exiting 0 — so a keyword-based toggle fails silently.
+// `disabled = false` has to be spelled out as well: restating a mode alone
+// leaves an already-disabled output off.
+function monitorRule(name, disable, layout) {
+  if (disable) return 'hl.monitor({ output = "' + name + '", disabled = true })'
+
+  var position = layout && layout.position ? layout.position : "auto"
+  var scale = layout && layout.scale ? String(layout.scale) : '"auto"'
+
+  return 'hl.monitor({ output = "' + name + '", disabled = false, mode = "preferred"' +
+    ', position = "' + position + '"' +
+    ', scale = ' + scale + ' })'
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampBrightness: clampBrightness,
@@ -119,6 +159,8 @@ if (typeof module !== "undefined") {
     matchingScaleIndex: matchingScaleIndex,
     availableScales: availableScales,
     brightnessName: brightnessName,
-    parseDisplays: parseDisplays
+    parseDisplays: parseDisplays,
+    rememberLayouts: rememberLayouts,
+    monitorRule: monitorRule
   }
 }

--- a/shell/plugins/panels/monitor/Model.js
+++ b/shell/plugins/panels/monitor/Model.js
@@ -151,6 +151,37 @@ function monitorRule(name, disable, layout) {
     ', scale = ' + scale + ' })'
 }
 
+// The rates a display offers at the resolution it is running, highest first.
+// Hyprland lists modes as "2560x1440@240.00Hz", and a mode list can hold the
+// same rate twice at different timings.
+function availableRates(display) {
+  if (!display) return []
+
+  var prefix = display.width + "x" + display.height + "@"
+  var modes = display.availableModes || []
+  var rates = []
+
+  for (var i = 0; i < modes.length; i++) {
+    var mode = String(modes[i])
+    if (mode.indexOf(prefix) !== 0) continue
+
+    var rate = Math.round(parseFloat(mode.slice(prefix.length)))
+    if (!isFinite(rate) || rate <= 0) continue
+    if (rates.indexOf(rate) < 0) rates.push(rate)
+  }
+
+  rates.sort(function (a, b) { return b - a })
+  return rates
+}
+
+// Hyprland reports 143.979 where the mode string says 144.
+function activeRate(display) {
+  if (!display) return 0
+
+  var rate = Math.round(Number(display.refreshRate))
+  return isFinite(rate) && rate > 0 ? rate : 0
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampBrightness: clampBrightness,
@@ -161,6 +192,8 @@ if (typeof module !== "undefined") {
     brightnessName: brightnessName,
     parseDisplays: parseDisplays,
     rememberLayouts: rememberLayouts,
-    monitorRule: monitorRule
+    monitorRule: monitorRule,
+    availableRates: availableRates,
+    activeRate: activeRate
   }
 }

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -26,6 +26,8 @@ Panel {
   property string monitorScale: ""
   property var displays: []
   property int enabledDisplayCount: 0
+  // name -> { scale, position } last seen while that output was on
+  property var displayLayouts: ({})
 
   // Carry sub-notch touchpad deltas between wheel events.
   property real wheelAccumulator: 0
@@ -294,13 +296,14 @@ Panel {
     var parsed = Model.parseDisplays(displaysJson)
     root.displays = parsed.displays
     root.enabledDisplayCount = parsed.enabledDisplayCount
+    root.displayLayouts = Model.rememberLayouts(root.displayLayouts, parsed.displays)
   }
 
   function toggleDisplay(name, enabled) {
     if (!name) return
     if (enabled && root.enabledDisplayCount <= 1) return
 
-    actionProc.command = ["hyprctl", "keyword", "monitor", name + (enabled ? ",disable" : ",preferred,auto,auto")]
+    actionProc.command = ["hyprctl", "eval", Model.monitorRule(name, enabled, root.displayLayouts[name])]
     if (!actionProc.running) actionProc.running = true
   }
 

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -39,6 +39,8 @@ Panel {
   //   "scale"      - 6 Button scale presets; treated as a single
   //                  horizontal row from j/k's perspective. h/l moves
   //                  between presets, identical to bluetooth's header.
+  //   "refresh"    - refresh rate presets, laid out like "scale"; only
+  //                  present when the focused display offers more than one.
   //   "monitors"   - vertical display row list for enabling/disabling displays;
   //                  j/k walks each row.
   // Mouse hover on a target updates root state via the components' `hovered`
@@ -51,6 +53,16 @@ Panel {
         return Model.availableScales(scalePresets, display.width, display.height)
     }
     return scalePresets
+  }
+  // Rates the focused display offers at its current resolution, mirroring
+  // scaleValues above.
+  readonly property var refreshValues: {
+    for (var i = 0; i < displays.length; i++) {
+      var display = displays[i]
+      if (display && display.focused)
+        return Model.availableRates(display)
+    }
+    return []
   }
   property string focusSection: "scale"
   property int selectedIndex: 0
@@ -79,6 +91,8 @@ Panel {
     if (brightnessAvailable) list.push("brightness")
     list.push("textsize")
     list.push("scale")
+    // A display with a single rate has nothing to pick between.
+    if (refreshValues.length > 1) list.push("refresh")
     if (displays.length > 1) list.push("monitors")
     return list
   }
@@ -87,13 +101,15 @@ Panel {
     if (section === "brightness") return 0  // only the slider sentinel at -1
     if (section === "textsize") return 0    // slider sentinel at -1, like brightness
     if (section === "scale") return scaleValues.length
+    if (section === "refresh") return refreshValues.length
     if (section === "monitors") return displays.length
     return 0
   }
 
   function sectionIsSingleRow(section) {
-    // brightness and text size are lone sliders; scale presets sit horizontally.
-    return section === "brightness" || section === "textsize" || section === "scale"
+    // brightness and text size are lone sliders; scale and refresh presets sit
+    // horizontally.
+    return section === "brightness" || section === "textsize" || section === "scale" || section === "refresh"
   }
 
   function sectionFirstIndex(section) {
@@ -131,14 +147,15 @@ Panel {
     }
   }
 
-  // h/l: in scale section, walks the preset row; everywhere else, no-op
-  // because adjustBrightness handles horizontal motion on the brightness
-  // slider.
+  // h/l: in the scale and refresh sections, walks that preset row; everywhere
+  // else, no-op because adjustBrightness handles horizontal motion on the
+  // brightness slider.
   function moveCursorH(delta) {
-    if (focusSection !== "scale") return
+    if (focusSection !== "scale" && focusSection !== "refresh") return
+    var row = focusSection === "scale" ? scaleValues : refreshValues
     var next = selectedIndex + delta
     if (next < 0) next = 0
-    if (next > scaleValues.length - 1) next = scaleValues.length - 1
+    if (next > row.length - 1) next = row.length - 1
     selectedIndex = next
   }
 
@@ -151,6 +168,10 @@ Panel {
   function activateCursor() {
     if (focusSection === "scale" && selectedIndex >= 0 && selectedIndex < scaleValues.length) {
       setScale(scaleValues[selectedIndex])
+      return
+    }
+    if (focusSection === "refresh" && selectedIndex >= 0 && selectedIndex < refreshValues.length) {
+      setRefresh(refreshValues[selectedIndex])
       return
     }
     if (focusSection === "monitors" && selectedIndex >= 0 && selectedIndex < displays.length) {
@@ -276,6 +297,15 @@ Panel {
     return -1
   }
 
+  function activeRefreshIndex() {
+    for (var i = 0; i < displays.length; i++) {
+      var display = displays[i]
+      if (display && display.focused)
+        return refreshValues.indexOf(Model.activeRate(display))
+    }
+    return -1
+  }
+
   function effectiveScale(scale) {
     for (var i = 0; i < displays.length; i++) {
       var display = displays[i]
@@ -309,6 +339,14 @@ Panel {
 
   function setScale(scale) {
     actionProc.command = ["bash", "-c", "omarchy-hyprland-monitor-scaling " + scale]
+    if (!actionProc.running) actionProc.running = true
+  }
+
+  // Applying and persisting a rate belongs in the CLI, the way setScale defers
+  // to omarchy-hyprland-monitor-scaling: a rate set only at runtime is undone
+  // by the next config reload.
+  function setRefresh(rate) {
+    actionProc.command = ["omarchy-hyprland-monitor-refresh", String(rate)]
     if (!actionProc.running) actionProc.running = true
   }
 
@@ -793,6 +831,73 @@ Panel {
             }
           }
 
+          // ---------- Refresh rate ----------
+          PanelSeparator {
+            visible: root.refreshValues.length > 1
+            foreground: root.bar.foreground
+          }
+
+          Column {
+            width: parent.width
+            spacing: Style.space(10)
+            visible: root.refreshValues.length > 1
+
+            Item {
+              width: parent.width
+              implicitHeight: Math.max(refreshHeader.implicitHeight, refreshMonitor.implicitHeight)
+
+              PanelSectionHeader {
+                id: refreshHeader
+                text: "REFRESH"
+                foreground: root.bar.foreground
+                fontFamily: root.bar.fontFamily
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+              }
+
+              // Like SCALE, this only applies to the focused monitor.
+              Text {
+                id: refreshMonitor
+                textFormat: Text.PlainText
+                text: root.focusedMonitor
+                visible: root.focusedMonitor !== "" && root.enabledDisplayCount > 1
+                color: Qt.darker(root.bar.foreground, 1.4)
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.caption
+                font.bold: true
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(6)
+                anchors.verticalCenter: parent.verticalCenter
+              }
+            }
+
+            Grid {
+              id: refreshRow
+              width: parent.width
+              // scaleValues always has entries; refreshValues can be empty, and
+              // a Grid needs at least one column even while it is hidden.
+              columns: Math.max(1, root.refreshValues.length)
+              spacing: Style.spacing.xs
+
+              readonly property real cellWidth: root.refreshValues.length > 0
+                ? (width - spacing * (columns - 1)) / columns
+                : 0
+
+              Repeater {
+                model: root.refreshValues
+
+                RatePill {
+                  required property int modelData
+                  required property int index
+
+                  rateValue: modelData
+                  rateIndex: index
+                  width: refreshRow.cellWidth
+                }
+              }
+            }
+          }
+
           // ---------- Monitors ----------
           PanelSeparator {
             visible: root.displays.length > 1
@@ -855,6 +960,31 @@ Panel {
       root.cursorActive = true
       root.focusSection = "scale"
       root.selectedIndex = pill.scaleIndex
+    }
+  }
+
+  component RatePill: Button {
+    id: ratePill
+    required property int rateValue
+    required property int rateIndex
+
+    text: rateValue + " Hz"
+    fontSize: Style.font.caption
+    foreground: root.bar.foreground
+    fontFamily: root.bar.fontFamily
+    horizontalPadding: Style.spacing.sm
+    verticalPadding: Style.spacing.controlPaddingY
+    bordered: true
+
+    active: root.activeRefreshIndex() === rateIndex
+    hasCursor: root.cursorActive && root.focusSection === "refresh" && root.selectedIndex === rateIndex
+
+    onClicked: root.setRefresh(rateValue)
+    onHovered: function(isHovered) {
+      if (!isHovered || root.reflowingText) return
+      root.cursorActive = true
+      root.focusSection = "refresh"
+      root.selectedIndex = ratePill.rateIndex
     }
   }
 

--- a/test/shell.d/monitor-refresh-test.sh
+++ b/test/shell.d/monitor-refresh-test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+eval_out="$test_tmp/hyprctl-eval"
+home_dir="$test_tmp/home"
+monitor_lua="$home_dir/.config/hypr/monitors.lua"
+
+mkdir -p "$stub_bin" "$home_dir/.config/hypr"
+
+# 5120x1440 offers four rates; the 3840x1080 modes belong to another
+# resolution and must not show up in the list.
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "monitors" && $2 == "-j" ]]; then
+  cat <<'JSON'
+[
+  {
+    "name": "DP-1",
+    "focused": true,
+    "scale": 1.25,
+    "x": 0,
+    "y": 0,
+    "width": 5120,
+    "height": 1440,
+    "refreshRate": 143.979,
+    "availableModes": [
+      "5120x1440@143.98Hz",
+      "5120x1440@85.00Hz",
+      "3840x1080@119.97Hz",
+      "5120x1440@100.00Hz",
+      "5120x1440@71.98Hz"
+    ]
+  }
+]
+JSON
+elif [[ $1 == "eval" ]]; then
+  printf '%s\n' "$2" >"$OMARCHY_TEST_HYPRCTL_EVAL_OUT"
+else
+  exit 1
+fi
+SH
+chmod +x "$stub_bin/hyprctl"
+
+write_default_config() {
+  cat >"$monitor_lua" <<'LUA'
+local omarchy_monitor_scale = "auto"
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+
+-- Configure a specific monitor.
+-- hl.monitor({ output = "DP-2", mode = "2560x1440@144", position = "0x0", scale = 1 })
+LUA
+}
+
+write_explicit_config() {
+  cat >"$monitor_lua" <<'LUA'
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = 1.25 })
+hl.monitor({ output = "DP-1", mode = "5120x1440@72", position = "0x0", scale = 1.25, transform = 0 })
+LUA
+}
+
+run_refresh() {
+  HOME="$home_dir" \
+    PATH="$stub_bin:$PATH" \
+    OMARCHY_TEST_HYPRCTL_EVAL_OUT="$eval_out" \
+    "$ROOT/bin/omarchy-hyprland-monitor-refresh" "$@"
+}
+
+rate=$(run_refresh)
+[[ $rate == "144" ]] || fail "monitor refresh reports the rate the mode names" "actual: $rate"
+pass "monitor refresh rounds the reported rate to the one the mode names"
+
+rates=$(run_refresh --list | paste -sd' ')
+[[ $rates == "144 100 85 72" ]] || fail "monitor refresh lists the rates of the current resolution" "actual: $rates"
+pass "monitor refresh lists the rates of the current resolution, highest first"
+
+# A rate belonging to another resolution is not on offer here.
+write_default_config
+if run_refresh 120 2>/dev/null; then
+  fail "monitor refresh refuses a rate the current resolution has no mode for"
+fi
+if grep -F '120' "$monitor_lua" >/dev/null; then
+  fail "monitor refresh leaves the config alone when it refuses a rate"
+fi
+pass "monitor refresh refuses a rate the current resolution has no mode for"
+
+# The eval keeps the monitor where it is: the resolution is not changing, so
+# there is nothing for "auto" to re-derive.
+write_default_config
+run_refresh 100
+grep -Fx 'hl.monitor({ output = "DP-1", mode = "5120x1440@100", position = "0x0", scale = 1.25 })' "$eval_out" >/dev/null ||
+  fail "monitor refresh applies the rate in place" "actual: $(cat "$eval_out")"
+pass "monitor refresh applies the rate without moving the monitor"
+
+# With only the catch-all in the file, the output gets a rule of its own. It
+# inherits omarchy_monitor_scale so monitor scaling keeps reaching this output.
+grep -Fx 'hl.monitor({ output = "DP-1", mode = "5120x1440@100", position = "auto", scale = omarchy_monitor_scale })' "$monitor_lua" >/dev/null ||
+  fail "monitor refresh persists a rule for the output" "actual:"$'\n'"$(cat "$monitor_lua")"
+grep -Fx 'hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })' "$monitor_lua" >/dev/null ||
+  fail "monitor refresh leaves the catch-all in place"
+pass "monitor refresh persists a rule that still follows the catch-all's scale"
+
+# Setting a second rate rewrites that rule rather than stacking another one.
+run_refresh 85
+(( $(grep -c '^hl\.monitor({ output = "DP-1"' "$monitor_lua") == 1 )) ||
+  fail "monitor refresh keeps one rule per output" "actual:"$'\n'"$(cat "$monitor_lua")"
+grep -F 'mode = "5120x1440@85"' "$monitor_lua" >/dev/null || fail "monitor refresh rewrites the rate it already wrote"
+pass "monitor refresh rewrites its own rule instead of stacking another"
+
+# The commented example in the shipped config is not a rule to rewrite.
+grep -Fx -e '-- hl.monitor({ output = "DP-2", mode = "2560x1440@144", position = "0x0", scale = 1 })' "$monitor_lua" >/dev/null ||
+  fail "monitor refresh leaves commented examples alone"
+pass "monitor refresh leaves commented examples alone"
+
+# A rule the user wrote keeps its position, scale and transform.
+write_explicit_config
+run_refresh 144
+grep -Fx 'hl.monitor({ output = "DP-1", mode = "5120x1440@144", position = "0x0", scale = 1.25, transform = 0 })' "$monitor_lua" >/dev/null ||
+  fail "monitor refresh rewrites only the mode of an existing rule" "actual:"$'\n'"$(cat "$monitor_lua")"
+pass "monitor refresh rewrites only the mode of a rule the user wrote"

--- a/test/shell.d/monitor-state-test.sh
+++ b/test/shell.d/monitor-state-test.sh
@@ -57,26 +57,26 @@ assert_line_count() {
 }
 
 extended='[
-  { "name": "eDP-1", "mirrorOf": "none", "disabled": false, "focused": false, "width": 1920, "height": 1080 },
-  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440 }
+  { "name": "eDP-1", "mirrorOf": "none", "disabled": false, "focused": false, "width": 1920, "height": 1080, "scale": 2, "x": 0, "y": 0 },
+  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "scale": 1.5, "x": 960, "y": 0 }
 ]'
 
 # Omarchy mirrors by pointing the external at the internal, so `mirrorOf` lands
 # on the external and the internal keeps saying "none".
 mirrored='[
-  { "name": "eDP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 1920, "height": 1080 },
-  { "name": "DP-1", "mirrorOf": "eDP-1", "disabled": false, "focused": false, "width": 1920, "height": 1080 }
+  { "name": "eDP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 1920, "height": 1080, "scale": 2, "x": 0, "y": 0 },
+  { "name": "DP-1", "mirrorOf": "eDP-1", "disabled": false, "focused": false, "width": 1920, "height": 1080, "scale": 2, "x": 0, "y": 0 }
 ]'
 
 # A monitors.lua of the user's own can mirror the other way instead.
 reverse_mirrored='[
-  { "name": "eDP-1", "mirrorOf": "DP-1", "disabled": false, "focused": false, "width": 2560, "height": 1440 },
-  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440 }
+  { "name": "eDP-1", "mirrorOf": "DP-1", "disabled": false, "focused": false, "width": 2560, "height": 1440, "scale": 1.5, "x": 0, "y": 0 },
+  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "scale": 1.5, "x": 0, "y": 0 }
 ]'
 
 clamshell='[
-  { "name": "eDP-1", "mirrorOf": "none", "disabled": true, "focused": false, "width": 0, "height": 0 },
-  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440 }
+  { "name": "eDP-1", "mirrorOf": "none", "disabled": true, "focused": false, "width": 0, "height": 0, "scale": 1, "x": 0, "y": 0 },
+  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "scale": 1.5, "x": 0, "y": 0 }
 ]'
 
 monitor_state "$extended"
@@ -109,9 +109,9 @@ assert_line 4 "" "monitor state reports no mirror while clamshelled"
 pass "monitor state separates a disabled internal monitor from a missing one"
 
 monitor_state "$extended"
-[[ ${state_lines[7]-} == '[{"name":"eDP-1","enabled":true,"focused":false,"width":1920,"height":1080},{"name":"DP-1","enabled":true,"focused":true,"width":2560,"height":1440}]' ]] ||
+[[ ${state_lines[7]-} == '[{"name":"eDP-1","enabled":true,"focused":false,"width":1920,"height":1080,"scale":2,"x":0,"y":0},{"name":"DP-1","enabled":true,"focused":true,"width":2560,"height":1440,"scale":1.5,"x":960,"y":0}]' ]] ||
   fail "monitor state lists every display for the panel" "actual: ${state_lines[7]-<missing>}"
 monitor_state "$clamshell"
-[[ ${state_lines[7]-} == '[{"name":"eDP-1","enabled":false,"focused":false,"width":0,"height":0},{"name":"DP-1","enabled":true,"focused":true,"width":2560,"height":1440}]' ]] ||
+[[ ${state_lines[7]-} == '[{"name":"eDP-1","enabled":false,"focused":false,"width":0,"height":0,"scale":1,"x":0,"y":0},{"name":"DP-1","enabled":true,"focused":true,"width":2560,"height":1440,"scale":1.5,"x":0,"y":0}]' ]] ||
   fail "monitor state lists every display for the panel" "actual: ${state_lines[7]-<missing>}"
-pass "monitor state lists every display with its enabled and focused state"
+pass "monitor state lists every display with its enabled state, focus, scale and position"

--- a/test/shell.d/monitor-state-test.sh
+++ b/test/shell.d/monitor-state-test.sh
@@ -57,26 +57,26 @@ assert_line_count() {
 }
 
 extended='[
-  { "name": "eDP-1", "mirrorOf": "none", "disabled": false, "focused": false, "width": 1920, "height": 1080, "scale": 2, "x": 0, "y": 0 },
-  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "scale": 1.5, "x": 960, "y": 0 }
+  { "name": "eDP-1", "mirrorOf": "none", "disabled": false, "focused": false, "width": 1920, "height": 1080, "scale": 2, "x": 0, "y": 0, "refreshRate": 60.001, "availableModes": ["1920x1080@60.00Hz"] },
+  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "scale": 1.5, "x": 960, "y": 0, "refreshRate": 143.979, "availableModes": ["2560x1440@143.98Hz", "2560x1440@60.00Hz"] }
 ]'
 
 # Omarchy mirrors by pointing the external at the internal, so `mirrorOf` lands
 # on the external and the internal keeps saying "none".
 mirrored='[
-  { "name": "eDP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 1920, "height": 1080, "scale": 2, "x": 0, "y": 0 },
-  { "name": "DP-1", "mirrorOf": "eDP-1", "disabled": false, "focused": false, "width": 1920, "height": 1080, "scale": 2, "x": 0, "y": 0 }
+  { "name": "eDP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 1920, "height": 1080, "scale": 2, "x": 0, "y": 0, "refreshRate": 60.001, "availableModes": ["1920x1080@60.00Hz"] },
+  { "name": "DP-1", "mirrorOf": "eDP-1", "disabled": false, "focused": false, "width": 1920, "height": 1080, "scale": 2, "x": 0, "y": 0, "refreshRate": 60.001, "availableModes": ["1920x1080@60.00Hz"] }
 ]'
 
 # A monitors.lua of the user's own can mirror the other way instead.
 reverse_mirrored='[
-  { "name": "eDP-1", "mirrorOf": "DP-1", "disabled": false, "focused": false, "width": 2560, "height": 1440, "scale": 1.5, "x": 0, "y": 0 },
-  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "scale": 1.5, "x": 0, "y": 0 }
+  { "name": "eDP-1", "mirrorOf": "DP-1", "disabled": false, "focused": false, "width": 2560, "height": 1440, "scale": 1.5, "x": 0, "y": 0, "refreshRate": 60.001, "availableModes": ["2560x1440@60.00Hz"] },
+  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "scale": 1.5, "x": 0, "y": 0, "refreshRate": 143.979, "availableModes": ["2560x1440@143.98Hz", "2560x1440@60.00Hz"] }
 ]'
 
 clamshell='[
-  { "name": "eDP-1", "mirrorOf": "none", "disabled": true, "focused": false, "width": 0, "height": 0, "scale": 1, "x": 0, "y": 0 },
-  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "scale": 1.5, "x": 0, "y": 0 }
+  { "name": "eDP-1", "mirrorOf": "none", "disabled": true, "focused": false, "width": 0, "height": 0, "scale": 1, "x": 0, "y": 0, "refreshRate": 0, "availableModes": [] },
+  { "name": "DP-1", "mirrorOf": "none", "disabled": false, "focused": true, "width": 2560, "height": 1440, "scale": 1.5, "x": 0, "y": 0, "refreshRate": 143.979, "availableModes": ["2560x1440@143.98Hz", "2560x1440@60.00Hz"] }
 ]'
 
 monitor_state "$extended"
@@ -109,9 +109,9 @@ assert_line 4 "" "monitor state reports no mirror while clamshelled"
 pass "monitor state separates a disabled internal monitor from a missing one"
 
 monitor_state "$extended"
-[[ ${state_lines[7]-} == '[{"name":"eDP-1","enabled":true,"focused":false,"width":1920,"height":1080,"scale":2,"x":0,"y":0},{"name":"DP-1","enabled":true,"focused":true,"width":2560,"height":1440,"scale":1.5,"x":960,"y":0}]' ]] ||
+[[ ${state_lines[7]-} == '[{"name":"eDP-1","enabled":true,"focused":false,"width":1920,"height":1080,"scale":2,"x":0,"y":0,"refreshRate":60.001,"availableModes":["1920x1080@60.00Hz"]},{"name":"DP-1","enabled":true,"focused":true,"width":2560,"height":1440,"scale":1.5,"x":960,"y":0,"refreshRate":143.979,"availableModes":["2560x1440@143.98Hz","2560x1440@60.00Hz"]}]' ]] ||
   fail "monitor state lists every display for the panel" "actual: ${state_lines[7]-<missing>}"
 monitor_state "$clamshell"
-[[ ${state_lines[7]-} == '[{"name":"eDP-1","enabled":false,"focused":false,"width":0,"height":0,"scale":1,"x":0,"y":0},{"name":"DP-1","enabled":true,"focused":true,"width":2560,"height":1440,"scale":1.5,"x":0,"y":0}]' ]] ||
+[[ ${state_lines[7]-} == '[{"name":"eDP-1","enabled":false,"focused":false,"width":0,"height":0,"scale":1,"x":0,"y":0,"refreshRate":0,"availableModes":[]},{"name":"DP-1","enabled":true,"focused":true,"width":2560,"height":1440,"scale":1.5,"x":0,"y":0,"refreshRate":143.979,"availableModes":["2560x1440@143.98Hz","2560x1440@60.00Hz"]}]' ]] ||
   fail "monitor state lists every display for the panel" "actual: ${state_lines[7]-<missing>}"
-pass "monitor state lists every display with its enabled state, focus, scale and position"
+pass "monitor state lists every display with the state, geometry and modes the panel needs"

--- a/test/shell.d/monitor-test.sh
+++ b/test/shell.d/monitor-test.sh
@@ -120,4 +120,40 @@ assertEqual(
   'hl.monitor({ output = "DP-1", disabled = false, mode = "preferred", position = "auto", scale = "auto" })',
   'monitor falls back to auto placement for an output it never saw enabled'
 )
+
+const ultrawide = {
+  width: 5120,
+  height: 1440,
+  refreshRate: 143.979,
+  availableModes: [
+    '5120x1440@143.98Hz',
+    '5120x1440@85.00Hz',
+    '3840x1080@119.97Hz',
+    '5120x1440@100.00Hz',
+    '5120x1440@71.98Hz',
+    '1920x1080@60.00Hz'
+  ]
+}
+
+assertDeepEqual(
+  monitor.availableRates(ultrawide),
+  [144, 100, 85, 72],
+  'monitor lists the rates of the current resolution, highest first'
+)
+
+assertDeepEqual(
+  monitor.availableRates({
+    width: 1920,
+    height: 1080,
+    availableModes: ['1920x1080@60.00Hz', '1920x1080@59.94Hz']
+  }),
+  [60],
+  'monitor collapses modes that round to the same rate'
+)
+
+assertDeepEqual(monitor.availableRates({ width: 1920, height: 1080 }), [], 'monitor handles a display with no mode list')
+assertDeepEqual(monitor.availableRates(undefined), [], 'monitor handles a missing display')
+
+assertEqual(monitor.activeRate(ultrawide), 144, 'monitor rounds the reported rate to the one the mode names')
+assertEqual(monitor.activeRate({ refreshRate: 0 }), 0, 'monitor rejects an unusable rate')
 JS

--- a/test/shell.d/monitor-test.sh
+++ b/test/shell.d/monitor-test.sh
@@ -75,4 +75,49 @@ assertDeepEqual(
 )
 
 assertDeepEqual(monitor.parseDisplays('{'), { displays: [], enabledDisplayCount: 0 }, 'monitor handles invalid display JSON')
+
+assertDeepEqual(
+  monitor.rememberLayouts({}, [
+    { name: 'eDP-1', enabled: true, scale: 2, x: 0, y: 0 },
+    { name: 'DP-1', enabled: true, scale: 1.5, x: 960, y: 0 }
+  ]),
+  {
+    'eDP-1': { scale: 2, position: '0x0' },
+    'DP-1': { scale: 1.5, position: '960x0' }
+  },
+  'monitor remembers the layout of every enabled display'
+)
+
+assertDeepEqual(
+  monitor.rememberLayouts(
+    { 'DP-1': { scale: 1.5, position: '960x0' } },
+    [
+      { name: 'eDP-1', enabled: true, scale: 2, x: 0, y: 0 },
+      { name: 'DP-1', enabled: false, scale: 1, x: 0, y: 0 }
+    ]
+  ),
+  {
+    'DP-1': { scale: 1.5, position: '960x0' },
+    'eDP-1': { scale: 2, position: '0x0' }
+  },
+  'monitor keeps the last known layout of a display that went off'
+)
+
+assertEqual(
+  monitor.monitorRule('DP-1', true, { scale: 1.5, position: '960x0' }),
+  'hl.monitor({ output = "DP-1", disabled = true })',
+  'monitor disables an output through the Lua parser'
+)
+
+assertEqual(
+  monitor.monitorRule('DP-1', false, { scale: 1.5, position: '960x0' }),
+  'hl.monitor({ output = "DP-1", disabled = false, mode = "preferred", position = "960x0", scale = 1.5 })',
+  'monitor restores the remembered scale and position when an output comes back'
+)
+
+assertEqual(
+  monitor.monitorRule('DP-1', false, undefined),
+  'hl.monitor({ output = "DP-1", disabled = false, mode = "preferred", position = "auto", scale = "auto" })',
+  'monitor falls back to auto placement for an output it never saw enabled'
+)
 JS


### PR DESCRIPTION
Builds on #10194 — that branch is the base, so the diff here is only the refresh work once #10194 lands.

## Why

Low refresh rates are not only a smoothness preference. For people who get cyber sickness or simulator sickness, a panel running at 60Hz when the hardware can do 144 or 240 means nausea and headaches within minutes of use. It is the same mechanism that makes a VR headset or a shaky camera unpleasant, and it does not go away by getting used to it.

A monitor comes up at whatever rate it reports as preferred, and on plenty of high-refresh panels that is 60Hz. Raising it today means opening `~/.config/hypr/monitors.lua`, knowing that `mode` takes a `WIDTHxHEIGHT@RATE` string, and knowing which rates the monitor actually offers. That is a barrier in front of exactly the people who most need the setting.

So this puts the rate one click away, next to the scale control that already lives there.

The panel with the new REFRESH row — this laptop's built-in display supports 240 Hz and was running at 60.

<img width="542" height="747" alt="omarchy-display-panel-refresh" src="https://github.com/user-attachments/assets/c16f3a47-e499-450b-8c0b-0729b94781b3" />


## What it adds

A **REFRESH** section in the display panel, below SCALE and built the same way: the rates the focused monitor offers at its current resolution, highest first, with the active one marked. It appears only when there is more than one rate to choose from, so single-rate displays see no change. Keyboard navigation matches SCALE — `h`/`l` walks the row, Enter applies.

**`omarchy hyprland monitor refresh`**, a companion to `omarchy-hyprland-monitor-scaling` and shaped like it:

```
omarchy hyprland monitor refresh          # 144
omarchy hyprland monitor refresh --list   # 144 100 85 72
omarchy hyprland monitor refresh 100
```

The panel defers to the CLI the way `setScale` already defers to the scaling command, so applying and persisting live in one place.

## Notes on the details

- **Rates are filtered by the current resolution.** A 5120x1440 ultrawide also lists 3840x1080 and 1920x1080 modes; offering their rates would silently change resolution.
- **Rounded to whole numbers.** Hyprland reports `143.979` where the mode string says `144`; the spec sheet and the user both say 144.
- **The apply keeps the monitor in place.** The resolution is not changing, so there is nothing for `position = "auto"` to re-derive and no reason to make the other displays jump.
- **Persistence does not take the config away from the user.** An output that already has a rule of its own only gets its `mode` rewritten, so a hand-written position or transform survives. An output with no rule gets one appended that inherits `omarchy_monitor_scale` where the file still defines it — otherwise a later `omarchy hyprland monitor scaling` would stop reaching that output. Setting a second rate rewrites that rule instead of stacking another one, and commented example lines are left alone.
- **State plumbing.** `omarchy-monitor-state` carries `refreshRate` and `availableModes` per display, so the panel needs no second `hyprctl` process. Filtering and rounding are pure functions in `Model.js`.

## Tests

- `test/shell.d/monitor-refresh-test.sh` (new, modelled on `monitor-scaling-test.sh`) — reporting, listing, refusing a rate the resolution has no mode for, applying in place, appending a rule, rewriting it instead of stacking, leaving commented examples alone, and preserving a user-written rule's other fields.
- `test/shell.d/monitor-test.sh` — `availableRates` and `activeRate`, including duplicate rates that round to the same number and a display with no mode list.
- `test/shell.d/monitor-state-test.sh` — fixtures and expectations extended.
- Full `test/shell`: the only failures are the ones that fail identically on an unmodified checkout on this host (`bar-icon-geometry`, `config`, `snapper`, `unowned-system-paths`, and `runtime-smoke` whenever two displays are attached).

## Verified on hardware

Alienware m15 R7 with an external 5120x1440 ultrawide on DP-1 at scale 1.25, Hyprland 0.56.2:

```
before   DP-1 5120x1440@143.979 scale 1.25 at 0x0
set 100  DP-1 5120x1440@99.996  scale 1.25 at 0x0
set 144  DP-1 5120x1440@143.979 scale 1.25 at 0x0
```

Scale and position survive the change, `hyprctl configerrors` stays empty, and the persisted rule was rewritten rather than duplicated on the second call. In the panel the four pills (144 / 100 / 85 / 72) fit the section width without clipping, and the active one is marked.

## Also

`manual/33-monitors.md` gains a short "Refresh rate" section, including the motion-sickness note — it is the part users are least likely to guess on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
