### PR TITLE
Require a real charge threshold before reporting a held charge

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -49,10 +49,20 @@ function batteryFraction(device) {
   return device && device.isPresent ? Math.max(0, Math.min(1, device.percentage)) : 0
 }
 
-function chargeThresholdActive(device, onBattery, states) {
+function chargeThresholdActive(device, onBattery, states, threshold) {
   var d = device || {}
   var s = states || {}
   if (!(d && d.isPresent && !onBattery)) return false
+
+  // A charge can only be held at a threshold the hardware actually has.
+  // omarchy-battery-status gates its own charge_holding block on a non-empty
+  // threshold, and omits the field entirely when the battery exposes no
+  // charge_control_* attribute, so an absent threshold here means the machine
+  // cannot limit charging at all. Without this guard the states below misread
+  // firmware that merely stops topping the pack up: Apple's SMC parks at
+  // FullyCharged around 94% by design, and that read as a limit the machine
+  // has no way to set.
+  if (!threshold) return false
 
   var fraction = batteryFraction(d)
   if (d.state === s.Discharging) return false
@@ -63,27 +73,27 @@ function chargeThresholdActive(device, onBattery, states) {
   return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
 }
 
-function batteryIcon(device, onBattery, states) {
+function batteryIcon(device, onBattery, states, threshold) {
   var d = device || {}
   if (!d.isPresent) return ""
 
   var chargingIcons = ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"]
   var defaultIcons = ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
   var index = Math.max(0, Math.min(9, Math.floor(d.percentage * 10)))
-  var threshold = chargeThresholdActive(d, onBattery, states)
+  var holding = chargeThresholdActive(d, onBattery, states, threshold)
 
-  if (threshold) return defaultIcons[index]
+  if (holding) return defaultIcons[index]
   if (d.state === states.FullyCharged) return "󰂅"
   if (!onBattery) return chargingIcons[index]
   return defaultIcons[index]
 }
 
-function modeLabel(device, onBattery, states) {
+function modeLabel(device, onBattery, states, threshold) {
   var d = device || {}
   if (!d.isPresent) return ""
 
   var percentage = d.isPresent ? d.percentage : 0
-  if (chargeThresholdActive(d, onBattery, states)) return "Threshold"
+  if (chargeThresholdActive(d, onBattery, states, threshold)) return "Threshold"
   if (onBattery) return "On battery"
   if (!onBattery && percentage >= 1) return "Fully charged"
   return "Charging"

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -49,12 +49,12 @@ Panel {
 
   function batteryIcon() {
     var device = UPower.displayDevice
-    return Model.batteryIcon(device, root.discharging, upowerStates())
+    return Model.batteryIcon(device, root.discharging, upowerStates(), root.chargeThreshold)
   }
 
   function modeLabel() {
     var device = UPower.displayDevice
-    return Model.modeLabel(device, root.discharging, upowerStates())
+    return Model.modeLabel(device, root.discharging, upowerStates(), root.chargeThreshold)
   }
 
   function profileIcon(name) {
@@ -69,9 +69,12 @@ Panel {
     var device = UPower.displayDevice
     return !!(device && device.isPresent && UPower.onBattery)
   }
+  // Empty on hardware that exposes no charge_control_* attribute:
+  // omarchy-battery-status only emits the field when a threshold exists.
+  readonly property string chargeThreshold: root.batteryInfo.threshold || ""
   readonly property bool chargeThresholdActive: {
     var device = UPower.displayDevice
-    return Model.chargeThresholdActive(device, root.discharging, upowerStates())
+    return Model.chargeThresholdActive(device, root.discharging, upowerStates(), root.chargeThreshold)
   }
   readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
   readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive
@@ -442,7 +445,7 @@ Panel {
             spacing: Style.spacing.labelGap
             InfoPair {
               label: root.chargeThresholdActive ? "Charge limit" : (root.discharging ? "Time left" : "Time to full")
-              value: root.chargeThresholdActive ? (root.batteryInfo.threshold || "-") : (root.batteryFlowIdle ? "-" : (root.batteryInfo.time || "—"))
+              value: root.chargeThresholdActive ? root.chargeThreshold : (root.batteryFlowIdle ? "-" : (root.batteryInfo.time || "—"))
             }
             InfoPair {
               label: root.chargeThresholdActive ? "Battery state" : (root.discharging ? "Discharging" : "Charging")

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -23,10 +23,20 @@ assertDeepEqual(
 assert(power.profileIcon('performance').length > 0, 'power maps profile icons')
 assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'power clamps battery fraction')
 
-assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power detects threshold by pending charge state')
-assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states), 'power detects threshold by stalled charging')
-assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states), 'power does not flag active charging as threshold')
-assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states, '80%'), 'power detects threshold by pending charge state')
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states, '80%'), 'power detects threshold by stalled charging')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states, '80%'), 'power does not flag active charging as threshold')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states, '80%'), 'power does not flag discharging as threshold')
+
+// Hardware with no charge_control_* attribute reports no threshold at all, and
+// omarchy-battery-status then omits the field. Apple's SMC stops recharging
+// around 94% and UPower reports FullyCharged there, which must not read as a
+// charge limit the machine cannot set.
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.947, state: states.FullyCharged }, false, states, ''), 'power does not invent a threshold without charge control')
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.947, state: states.FullyCharged }, false, states, '95%'), 'power detects threshold when the hardware reports one')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states, ''), 'power does not flag pending charge as threshold without charge control')
+assertEqual(power.modeLabel({ isPresent: true, percentage: 0.947, state: states.FullyCharged }, false, states, ''), 'Charging', 'power does not label a held charge without charge control')
+assertEqual(power.modeLabel({ isPresent: true, percentage: 0.947, state: states.FullyCharged }, false, states, '95%'), 'Threshold', 'power labels a held charge when a threshold exists')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'Charging', 'power treats external power as newer than stale discharging state')
@@ -41,6 +51,9 @@ assertEqual(
   power.batteryIcon({ isPresent: true, percentage: 0.4, state: states.Discharging }, true, states),
   'power shows battery icon when unplugged before battery state refreshes'
 )
+
+assert(/readonly property string chargeThreshold: root\.batteryInfo\.threshold \|\| ""/.test(panelSource), 'power panel derives the charge threshold from battery status output')
+assert(!/Model\.(chargeThresholdActive|batteryIcon|modeLabel)\([^)]*upowerStates\(\)\)/.test(panelSource), 'power panel passes the charge threshold to every threshold-aware model call')
 
 assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')


### PR DESCRIPTION
Fixes #10193.

## The problem

`Model.chargeThresholdActive()` mirrors the three states `omarchy-battery-status` uses to decide a charge is being held, but not its outer guard. The script requires a threshold to actually exist:

```bash
if [[ $ac_online == "true" && -n $threshold_end ]]; then
```

and omits the `threshold` field entirely when the battery exposes no `charge_control_*` attribute. `Model.js` only checked that we are on AC, so `state === FullyCharged && fraction < 0.99` was enough to claim a limit.

Firmware that merely stops topping the pack up then reads as a charge limit the machine has no way to set. Apple's SMC does exactly this — it will not recharge until the pack falls to roughly 93–95%, the behaviour macOS surfaces as "Battery is charged". On a MacBookPro12,1 with no `charge_control_*` sysfs at all, the panel claimed a limit while the CLI correctly reported `fully-charged`.

## The change

Thread the threshold through `chargeThresholdActive()`, `batteryIcon()` and `modeLabel()`, and bail out when it is empty — the same condition the shell script already applies. `Panel.qml` derives it from `batteryInfo.threshold`, which is exactly the field the script omits when there is no threshold, so the two implementations now agree by construction.

The charge-limit row's `|| "-"` fallback goes away with it: `chargeThresholdActive` now implies a non-empty threshold, so the row can no longer render a label with no value.

Machines that genuinely have a threshold are unaffected — they report one, so the guard passes.

## Verified

Automated:

- `test/shell.d/power-test.sh` extended with the no-charge-control case, its positive counterpart, and `modeLabel` coverage for both. Existing threshold assertions now pass a threshold, which is what the hardware they model would report.
- Two assertions against `Panel.qml` source pin the wiring: the `chargeThreshold` property must exist, and no threshold-aware `Model.*` call may end at `upowerStates()`. Both fail against the pre-fix file, so the guard cannot be silently orphaned again.
- `./test/all`: the shell and CLI suites pass. Three files fail identically before and after this change on a clean checkout (`config-test`, `snapper-test`, `unowned-system-paths-test`) — all three need a sibling `omarchy-pkgs` checkout that isn't present here.
- `qmllint` on `Panel.qml`: no syntax errors, and no warnings beyond the import-resolution noise the unmodified file already produces.

Visually, on the MacBookPro12,1 that reproduces this, with the patched files overlaid on the package install and the shell restarted:

| | Before | After |
|---|---|---|
| Hero label | `THRESHOLD` | `FULLY CHARGED` |
| Left row | `Charge limit` / `-` | `Time to full` / `-` |
| Right row | `Battery state` / `Holding` | `Charging` / `-` |
| Icon | plain battery | charged battery |

Layout, spacing and the power-profile row are unchanged. A before/after capture is attached below.

<img width="794" height="1092" alt="omarchy-pr-charge-threshold" src="https://github.com/user-attachments/assets/b6bfa416-9b34-403d-af0a-f57215a74638" />

