### PR TITLE
Disable ghost internal display connectors

### DIFF
--- a/bin/omarchy-hyprland-monitor-disable-ghosts
+++ b/bin/omarchy-hyprland-monitor-disable-ghosts
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# omarchy:summary=Disable empty duplicate internal display connectors
+# omarchy:hidden=true
+
+# Dual-GPU laptops can expose a second eDP connector that has no identity or
+# modes because the panel is wired to the other GPU. A generic monitor rule can
+# still enable it at 0x0, where it captures workspaces and can never recover on
+# reload. Only disable one while a separate, healthy internal panel is active.
+monitors=$(hyprctl monitors all -j 2>/dev/null) || exit 0
+
+healthy_internal=$(jq 'any(.[];
+  (.name | startswith("eDP-")) and
+  .disabled != true and
+  .description != "" and
+  .width > 0 and
+  .height > 0 and
+  (.availableModes | length) > 0
+)' <<<"$monitors" 2>/dev/null)
+
+[[ $healthy_internal == "true" ]] || exit 0
+
+while read -r output; do
+  [[ -n $output ]] || continue
+  [[ $output =~ ^eDP-[A-Za-z0-9._-]+$ ]] || continue
+  hyprctl eval "hl.monitor({ output = \"$output\", disabled = true })" >/dev/null 2>&1 || true
+done < <(jq -r '.[] |
+  select(
+    (.name | startswith("eDP-")) and
+    .disabled != true and
+    .description == "" and
+    .make == "" and
+    .model == "" and
+    .width == 0 and
+    .height == 0 and
+    (.availableModes | length) == 0
+  ) |
+  .name
+' <<<"$monitors" 2>/dev/null)

--- a/bin/omarchy-hyprland-monitor-watch
+++ b/bin/omarchy-hyprland-monitor-watch
@@ -60,6 +60,14 @@ recover_modeless() {
   ) 9>"$MODELESS_LOCK" &
 }
 
+recover_monitors() {
+  # A duplicate internal connector with no identity or modes is permanent, not
+  # a powered-off display that a reload can recover. Disable it first so it
+  # cannot capture workspaces or keep the modeless recovery loop alive.
+  omarchy-hyprland-monitor-disable-ghosts
+  recover_modeless
+}
+
 poll_clamshell_state() {
   while true; do
     sleep 2
@@ -88,7 +96,7 @@ sync_poll_state() {
 
 sync_clamshell_after_monitor_change
 sync_poll_state
-recover_modeless
+recover_monitors
 
 # Process substitution (not a pipe) keeps this loop in the main shell, so
 # sync_poll_state can start and stop the background poll as monitors come and go.
@@ -97,18 +105,18 @@ while read -r event; do
     monitoradded\>\>*|monitoraddedv2\>\>*)
       sync_clamshell_after_monitor_change
       sync_poll_state
-      recover_modeless
+      recover_monitors
       ;;
     monitorremoved\>\>*|monitorremovedv2\>\>*)
       sync_clamshell_after_monitor_change
       sync_poll_state
-      recover_modeless
+      recover_monitors
       ;;
     # A reload while the monitor is unpowered leaves it at 0x0 with no hotplug
     # to notice, same as at boot. Our own recovery reload lands here too, and is
     # a no-op while its loop still holds the pid.
     configreloaded\>\>*)
-      recover_modeless
+      recover_monitors
       ;;
   esac
 done < <(socat -U - "UNIX-CONNECT:$SOCKET")

--- a/test/shell.d/monitor-modeless-test.sh
+++ b/test/shell.d/monitor-modeless-test.sh
@@ -52,6 +52,7 @@ mkdir -p "$fake_bin"
 
 monitors_file="$test_tmp/monitors.json"
 reload_log="$test_tmp/reload.log"
+eval_log="$test_tmp/eval.log"
 recovered="$test_tmp/recovered.json"
 events="$test_tmp/events"
 modeless_lock="$test_tmp/omarchy-monitor-modeless.lock"
@@ -69,6 +70,16 @@ elif [[ ${1:-} == "reload" ]]; then
   printf 'reload\n' >>"$OMARCHY_TEST_RELOAD_LOG"
   [[ -f $OMARCHY_TEST_RECOVERED_MONITORS ]] &&
     cp "$OMARCHY_TEST_RECOVERED_MONITORS" "$OMARCHY_TEST_MONITORS_FILE"
+elif [[ ${1:-} == "eval" ]]; then
+  printf '%s\n' "${2:-}" >>"$OMARCHY_TEST_EVAL_LOG"
+
+  output=$(sed -n 's/.*output = "\([^"]*\)".*/\1/p' <<<"${2:-}")
+  if [[ -n $output ]]; then
+    jq --arg output "$output" \
+      'map(if .name == $output then .disabled = true else . end)' \
+      "$OMARCHY_TEST_MONITORS_FILE" >"$OMARCHY_TEST_MONITORS_FILE.next"
+    mv "$OMARCHY_TEST_MONITORS_FILE.next" "$OMARCHY_TEST_MONITORS_FILE"
+  fi
 fi
 SH
 
@@ -99,6 +110,8 @@ SH
 
 chmod +x "$fake_bin"/*
 ln -s "$ROOT/bin/omarchy-hyprland-monitor-modeless" "$fake_bin/omarchy-hyprland-monitor-modeless"
+ln -s "$ROOT/bin/omarchy-hyprland-monitor-disable-ghosts" \
+  "$fake_bin/omarchy-hyprland-monitor-disable-ghosts"
 
 MODELESS=0
 WORKING=1
@@ -144,6 +157,47 @@ assert_state $WORKING '[{"name":"DP-1","width":0,"height":0,"disabled":true}]' \
 
 assert_state $WORKING '[]' "a session with no monitors is not reported as modeless"
 
+assert_ghosts_disabled() {
+  local expected="$1" monitors="$2" actual
+
+  : >"$eval_log"
+  printf '%s' "$monitors" >"$monitors_file"
+  PATH="$fake_bin:$PATH" OMARCHY_TEST_MONITORS_FILE="$monitors_file" \
+  OMARCHY_TEST_HYPRCTL_FAIL_FLAG="$hyprctl_fail" \
+  OMARCHY_TEST_EVAL_LOG="$eval_log" \
+    "$ROOT/bin/omarchy-hyprland-monitor-disable-ghosts"
+  actual=$(<"$eval_log")
+
+  [[ $actual == "$expected" ]] || fail "$3" "expected '$expected', got '$actual'"
+  pass "$3"
+}
+
+healthy_edp='{"name":"eDP-1","description":"Apple panel","make":"Apple","model":"Color LCD","width":3072,"height":1920,"disabled":false,"availableModes":["3072x1920@60"]}'
+ghost_edp='{"name":"eDP-2","description":"","make":"","model":"","width":0,"height":0,"disabled":false,"availableModes":[]}'
+
+assert_ghosts_disabled 'hl.monitor({ output = "eDP-2", disabled = true })' \
+  "[$healthy_edp,$ghost_edp]" \
+  "an empty duplicate internal connector is disabled"
+
+assert_ghosts_disabled '' \
+  "[$healthy_edp,{\"name\":\"DP-1\",\"description\":\"Dell\",\"make\":\"Dell\",\"model\":\"U2720Q\",\"width\":0,\"height\":0,\"disabled\":false,\"availableModes\":[]}]" \
+  "a modeless external monitor remains eligible for recovery"
+
+assert_ghosts_disabled '' "[$ghost_edp]" \
+  "the only internal connector is never disabled"
+
+assert_ghosts_disabled '' \
+  "[$healthy_edp,{\"name\":\"eDP-2\",\"description\":\"\",\"make\":\"\",\"model\":\"\",\"width\":0,\"height\":0,\"disabled\":true,\"availableModes\":[]}]" \
+  "an already disabled duplicate internal connector is left alone"
+
+assert_ghosts_disabled 'hl.monitor({ output = "eDP-1", disabled = true })' \
+  "[{\"name\":\"eDP-2\",\"description\":\"Apple panel\",\"make\":\"Apple\",\"model\":\"Color LCD\",\"width\":3072,\"height\":1920,\"disabled\":false,\"availableModes\":[\"3072x1920@60\"]},{\"name\":\"eDP-1\",\"description\":\"\",\"make\":\"\",\"model\":\"\",\"width\":0,\"height\":0,\"disabled\":false,\"availableModes\":[]}]" \
+  "the empty connector is detected independently of eDP numbering"
+
+assert_ghosts_disabled '' \
+  "[$healthy_edp,{\"name\":\"eDP-2\\\" })os.execute(\\\"calc\\\")--\",\"description\":\"\",\"make\":\"\",\"model\":\"\",\"width\":0,\"height\":0,\"disabled\":false,\"availableModes\":[]}]" \
+  "an unsafe connector name is never evaluated as Lua"
+
 # Nothing fires an event for this state, so taking an unanswered query for a
 # healthy monitor would leave the screen black for good.
 assert_state $UNDETERMINED 'not json' "an unreadable monitor payload cannot say"
@@ -169,6 +223,7 @@ start_watcher() {
   OMARCHY_TEST_EVENTS="$events" \
   OMARCHY_TEST_MONITORS_FILE="$monitors_file" \
   OMARCHY_TEST_RELOAD_LOG="$reload_log" \
+  OMARCHY_TEST_EVAL_LOG="$eval_log" \
   OMARCHY_TEST_RECOVERED_MONITORS="$recovered" \
   OMARCHY_TEST_GUARD_PAUSED="${1:-0}" \
   OMARCHY_TEST_HYPRCTL_FAIL_FLAG="$hyprctl_fail" \
@@ -176,6 +231,18 @@ start_watcher() {
   watch_pid=$!
 
   exec {events_fd}>"$events"
+}
+
+await_evals() {
+  local waited lines
+
+  for (( waited = 0; waited < 100; waited++ )); do
+    lines=$(wc -l <"$eval_log" | tr -d ' ')
+    (( lines >= $1 )) && return 0
+    sleep 0.05
+  done
+
+  return 1
 }
 
 await_reloads() {
@@ -188,6 +255,21 @@ await_reloads() {
 
   return 1
 }
+
+# A dual-GPU laptop can expose an empty duplicate eDP connector permanently.
+# Disable it before modeless recovery, otherwise every reload re-enables it and
+# starts another reload cycle while the ghost output captures workspaces.
+: >"$eval_log"
+printf '%s' "[$healthy_edp,$ghost_edp]" >"$monitors_file"
+rm -f "$recovered"
+start_watcher
+
+await_evals 1 || fail "a ghost internal connector is disabled at startup"
+sleep 1
+[[ ! -s $reload_log ]] || fail "a ghost internal connector does not start recovery" "$(<"$reload_log")"
+pass "a ghost internal connector is disabled without a reload loop"
+
+stop_watcher
 
 # The watcher reloads until the monitor reports a mode, then stops. It has to
 # stop on its own: powering the monitor on fires no event to stop it.


### PR DESCRIPTION
## Summary

- disable an empty duplicate internal `eDP-*` connector before modeless monitor recovery runs
- run that reconciliation on watcher startup, monitor hotplug/removal, and every Hyprland config reload
- retain the existing reload recovery for real modeless monitors, including external displays

## Problem

The modeless monitor recovery added in #6701 assumes that an enabled `0x0` output is a temporarily unavailable display whose modes may return after `hyprctl reload`.

On some dual-GPU laptops, the GPU that is not wired to the built-in panel exposes a second permanent eDP connector. Hyprland reports the real panel as a healthy `eDP-1`, while the unused connector can appear as an enabled `eDP-2` with:

- no description, make, or model
- no available modes
- a permanent `0x0` geometry

The generic monitor rule enables this output again after each configuration reload. Hyprland may then assign workspaces to the invisible output. The monitor watcher sees it as modeless and keeps reloading, but that connector can never acquire a mode. The result is an inaccessible workspace/window and an endless recovery cycle.

## Solution

Add a small hidden helper that disables an eDP connector only when all of these conditions hold:

1. another enabled `eDP-*` output has an identity, at least one mode, and non-zero geometry;
2. the candidate is enabled, has no identity, exposes no modes, and remains at `0x0`;
3. its connector name is safe to interpolate into Hyprland's Lua IPC expression.

The watcher invokes this helper synchronously before starting its existing modeless recovery loop. Once the permanent ghost is disabled, the modeless check no longer treats it as recoverable, so no reload loop starts. Running this after every config reload also makes the behavior survive package and system updates that reapply the generic monitor rule.

The conservative predicate intentionally does not disable:

- an external display that is temporarily modeless;
- the only internal connector;
- a deliberately disabled connector;
- an eDP connector with identity or advertised modes.

The logic does not depend on whether the real panel is numbered `eDP-1` or `eDP-2`.

## Verification

- `test/shell.d/monitor-modeless-test.sh` — passes, including new positive, negative, connector-numbering, Lua-safety, and watcher integration cases
- `bash -n` on both monitor helpers and the updated test — passes
- `git diff --check` — passes
- `./test/cli` — passes
- `./test/all` — the changed monitor tests pass; the local run ends with six unrelated environment-dependent failures (missing sibling `omarchy-pkgs` checkout, unavailable graphical runtime behavior, and sandboxed privilege/runtime paths). The two affected QR/disk-space tests pass when invoked directly with Bash.

`shellcheck` was not available on the test machine.
