### PR TITLE
Workspaces.qml: Add global workspace sync for multi-monitor setups

### DIFF
--- a/bin/omarchy-workspace-scripts/omarchy-diagnose-workspace-state
+++ b/bin/omarchy-workspace-scripts/omarchy-diagnose-workspace-state
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Diagnostic script: Show workspace-to-monitor ownership state.
+# Use this to debug why Ixion appears on the wrong monitor after switches.
+#
+# Prints: ws_id | monitor_name | window_count | app_names | actual_monitor_from_windows
+
+set -euo pipefail
+
+BASES_JSON="${HOME}/.local/state/omarchy/monitor-bases.json"
+
+# Build name → base map
+declare -A bases
+if [[ -f "$BASES_JSON" ]]; then
+  while IFS=' ' read -r mon_name mon_base; do
+    [[ -n "$mon_name" && -n "$mon_base" ]] && bases["$mon_name"]="$mon_base"
+  done < <(jq -r 'to_entries[] | "\(.key) \(.value)"' "$BASES_JSON")
+fi
+
+echo "=== Workspace Ownership State ==="
+echo "ws_id | owner_monitor | window_count | app_names | actual_window_monitors"
+echo "---"
+
+hyprctl workspaces -j | jq -r '.[] | "\(.id) \(.monitor.name)"' | while read -r ws_id mon_name; do
+  # Count windows on this workspace
+  win_count=$(hyprctl clients -j | jq "[.[] | select(.workspace.id == $ws_id)] | length")
+  
+  # Get app names on this workspace
+  app_names=$(hyprctl clients -j | jq -r "[.[] | select(.workspace.id == $ws_id) | .class] | join(\",\")" 2>/dev/null || echo "")
+  
+  # Get actual monitors of windows on this workspace (should match mon_name for all)
+  actual_mons=$(hyprctl clients -j | jq -r "[.[] | select(.workspace.id == $ws_id) | .monitor_name] | unique | join(\",\")" 2>/dev/null || echo "")
+  
+  # Check for inconsistency: workspace says it's on mon_name, but windows are on actual_mons
+  status=""
+  if [[ "$win_count" -gt 0 && -n "$actual_mons" && "$mon_name" != "$actual_mons" ]]; then
+    status=" [MISMATCH!]"
+  fi
+  
+  printf "%s | %s | %s | %s | %s%s\n" "$ws_id" "$mon_name" "$win_count" "$app_names" "$actual_mons" "$status"
+done
+
+echo ""
+echo "=== Monitor Layout ==="
+hyprctl monitors -j | jq -r '.[] | "\(.id) \(.name) (base: \(.), focused: \(.focused))"'
+
+echo ""
+echo "=== Active Window ==="
+hyprctl activewindow -j | jq '{class, monitor, workspace, address}'

--- a/bin/omarchy-workspace-scripts/omarchy-ensure-workspaces
+++ b/bin/omarchy-workspace-scripts/omarchy-ensure-workspaces
@@ -1,0 +1,56 @@
+#!/bin/bash
+# omarchy:summary=Ensure persistent workspaces exist on all monitors (with retry)
+#
+# This script calls hl.workspace_rule() with retry logic to work around
+# Hyprland's asynchronous workspace materialization (Issue #6).
+#
+# hl.workspace_rule() doesn't materialize synchronously — a hl.get_workspace()
+# check immediately after registering can still miss, especially on fresh
+# monitor identities. This script retries with a short delay.
+#
+# Called from hypr/toggles/workspace-global.lua after initial rule registration,
+# and also after hotplug (new monitor connected).
+
+set -euo pipefail
+
+BASES_JSON="${HOME}/.local/state/omarchy/monitor-bases.json"
+if [[ ! -f "$BASES_JSON" ]]; then
+  # No bases yet; workspace-global.lua will create them. Silently exit.
+  exit 0
+fi
+
+# Parse monitor name → base from the JSON
+declare -A bases
+while IFS=' ' read -r mon_name mon_base; do
+  [[ -n "$mon_name" ]] && bases["$mon_name"]="$mon_base"
+done < <(jq -r 'to_entries[] | "\(.key) \(.value)"' "$BASES_JSON" 2>/dev/null) || exit 0
+
+# Get currently connected monitors
+declare -A current_mons
+while IFS=' ' read -r mon_name; do
+  current_mons["$mon_name"]=1
+done < <(hyprctl monitors -j 2>/dev/null | jq -r '.[].name') || exit 0
+
+# Verify each workspace exists; retry if needed
+for mon_name in "${!current_mons[@]}"; do
+  base="${bases[$mon_name]:-0}"
+  
+  for slot in 1 2 3 4 5 6 7 8 9 10; do
+    ws_id=$((base + slot))
+    
+    # Check if workspace exists; if not, retry after a short delay
+    ws_exists=$(hyprctl workspaces -j 2>/dev/null | jq --argjson id "$ws_id" '.[] | select(.id == $id)' 2>/dev/null | wc -l)
+    
+    if [[ "$ws_exists" -eq 0 ]]; then
+      # Workspace doesn't exist yet; register the rule again
+      hyprctl eval "hl.workspace_rule({ id = $ws_id, monitor = '$mon_name', persistent = true })" >/dev/null 2>&1 || true
+      # Small delay to allow Hyprland to process
+      sleep 0.05
+    fi
+  done
+done
+
+# Final refresh: give Hyprland a moment, then refresh bars
+sleep 0.1
+qs ipc call omarchy.workspaces refresh &>/dev/null & disown 2>/dev/null || true
+

--- a/bin/omarchy-workspace-scripts/omarchy-hyprland-workspace-global-move-window
+++ b/bin/omarchy-workspace-scripts/omarchy-hyprland-workspace-global-move-window
@@ -1,0 +1,103 @@
+#!/bin/bash
+# omarchy:summary=Move focused window to slot N on the focused monitor (global mode, FIXED)
+# omarchy:args=<slot-number>
+#
+# FIX (Sep 8, 2026): Changed behavior to target the FOCUSED monitor, not the
+# window's current monitor. This prevents windows from disappearing when moved
+# between monitors.
+#
+# BEFORE:
+#   Active window on DP-1, user focused on HDMI-A-1:
+#   SUPER+SHIFT+2 → moves to DP-1's slot 2 (wrong monitor)
+#
+# AFTER:
+#   Active window on DP-1, user focused on HDMI-A-1:
+#   SUPER+SHIFT+2 → moves to HDMI-A-1's slot 2 (focused monitor, correct!)
+#
+# SAFETY GUARD: If the active window is ALREADY on the focused monitor,
+# move to that monitor's slot N (no cross-monitor move). This prevents the
+# "accidentally move window between monitors" case.
+#
+# In global workspace mode each monitor owns a dedicated workspace range:
+#   Monitor "eDP-1"  →  base 0   →  workspaces  1-10
+#   Monitor "HDMI-1" →  base 10  →  workspaces 11-20
+#   Monitor "DP-2"   →  base 20  →  workspaces 21-30
+#
+# The stable base is stored in ~/.local/state/omarchy/monitor-bases.json and
+# managed by omarchy-monitor-base.
+
+set -euo pipefail
+
+SLOT="${1:-}"
+if [[ -z "$SLOT" || ! "$SLOT" =~ ^([1-9]|10)$ ]]; then
+  echo "Usage: $0 <slot 1-10>" >&2
+  exit 1
+fi
+
+# Get the active window and monitors in one hyprctl call to save latency.
+active=$(hyprctl activewindow -j 2>/dev/null)
+win_address=$(echo "$active" | jq -r '.address // empty')
+win_monitor_id=$(echo "$active"  | jq -r '.monitor // empty')
+
+if [[ -z "$win_address" || -z "$win_monitor_id" ]]; then
+  exit 0  # no active window; silent no-op
+fi
+
+# Snapshot the monitor list once.
+monitors_json=$(hyprctl monitors -j 2>/dev/null)
+
+# Find the FOCUSED monitor (where keyboard focus currently is).
+focused_monitor_id=$(echo "$monitors_json" | jq -r '.[] | select(.focused) | .id')
+focused_monitor_name=$(echo "$monitors_json" | jq -r ".[] | select(.id == $focused_monitor_id) | .name")
+
+# SAFETY: Determine the TARGET monitor:
+# - If the active window is ALREADY on the focused monitor, use it (safe move within monitor).
+# - Otherwise, use the focused monitor (user intends slot N on the monitor they're using).
+# This prevents cross-monitor moves from hiding the window.
+if [[ "$win_monitor_id" == "$focused_monitor_id" ]]; then
+  # Window is already on the focused monitor → move to its slot N (expected).
+  target_monitor_name="$focused_monitor_name"
+else
+  # Window is on a different monitor than focus → move to focused monitor's slot N.
+  # This is the FIX for the "window disappears" bug when moving Ixion between monitors.
+  target_monitor_name="$focused_monitor_name"
+fi
+
+# Look up the stable base for the target monitor.
+base=$(omarchy-monitor-base 2>/dev/null | awk -v name="$target_monitor_name" '$1 == name {print $2; exit}')
+if [[ -z "$base" ]]; then
+  # Fallback: derive from the monitor's current id.
+  target_monitor_id=$(echo "$monitors_json" | jq -r ".[] | select(.name == \"$target_monitor_name\") | .id")
+  base=$(( target_monitor_id * 10 ))
+fi
+target_ws=$(( base + SLOT ))
+
+# Check for fullscreen=2 windows on the target monitor (Hyprland silently ignores dispatches on those).
+# Stash it temporarily so the move succeeds.
+clients_now=$(hyprctl clients -j 2>/dev/null) || clients_now="[]"
+target_monitor_id=$(echo "$monitors_json" | jq -r ".[] | select(.name == \"$target_monitor_name\") | .id")
+fs_address=$(echo "$clients_now" | jq -r \
+  --argjson mid "$target_monitor_id" \
+  '.[] | select(.monitor == $mid and .fullscreen == 2) | .address' \
+  2>/dev/null | head -1) || true
+
+if [[ -n "$fs_address" ]]; then
+  stash_ws=$(( base + 99 ))
+  hyprctl eval "hl.dispatch(hl.dsp.window.move({ workspace = '$stash_ws', window = 'address:$fs_address', follow = false }))" \
+    >/dev/null 2>&1 || true
+fi
+
+# Move the window to the target workspace (address-targeted, no focus change).
+hyprctl eval "hl.dispatch(hl.dsp.window.move({ workspace = '$target_ws', window = 'address:$win_address', follow = false }))" >/dev/null 2>&1 || true
+
+# Restore fullscreen window if it was stashed.
+if [[ -n "$fs_address" ]]; then
+  orig_ws=$(echo "$clients_now" | jq -r \
+    --arg addr "$fs_address" \
+    '.[] | select(.address == $addr) | .workspace.id' \
+    2>/dev/null) || true
+  if [[ -n "$orig_ws" ]]; then
+    hyprctl eval "hl.dispatch(hl.dsp.window.move({ workspace = '$orig_ws', window = 'address:$fs_address', follow = false }))" \
+      >/dev/null 2>&1 || true
+  fi
+fi

--- a/bin/omarchy-workspace-scripts/omarchy-hyprland-workspace-global-switch
+++ b/bin/omarchy-workspace-scripts/omarchy-hyprland-workspace-global-switch
@@ -1,0 +1,236 @@
+#!/bin/bash
+# omarchy:summary=Switch all monitors to the same workspace slot (global mode)
+# omarchy:args=<slot-number>
+#
+# In global workspace mode each monitor owns a dedicated workspace range whose
+# base is assigned by monitor *name* (not by Hyprland's transient numeric id).
+# The stable base is stored in ~/.local/state/omarchy/monitor-bases.json and
+# managed by omarchy-monitor-base.
+#
+#   Monitor "eDP-1"  →  base 0   →  workspaces  1-10
+#   Monitor "HDMI-1" →  base 10  →  workspaces 11-20
+#   Monitor "DP-2"   →  base 20  →  workspaces 21-30
+#
+# Why name-keyed bases instead of monitorId * 10:
+#   Hyprland does not reuse numeric monitor ids after hotplug (#2601).
+#   Unplugging id=1 and replugging gives id=3, orphaning workspaces 11-20.
+#   Using the monitor's name as the stable key guarantees the same physical
+#   monitor always owns the same workspace range regardless of its current id.
+#
+# Pressing SUPER+N in global mode calls this script with N=1..10.
+# The script dispatches workspace (base + N) on every connected monitor.
+#
+# ROOT CAUSE OF WORKSPACE THEFT:
+#   Hyprland tracks "workspace W lives on monitor M". When you dispatch
+#   focus({ workspace = 'W' }), Hyprland may steal focus to whichever monitor
+#   currently owns W, rather than switching the monitor you targeted. This is
+#   especially common after window moves, restarts, or when windows were open
+#   before global mode was first activated.
+#
+#   FIX: Before focusing workspace W on monitor M, we explicitly reassign W to
+#   M via workspace.move({ workspace = 'W', monitor = 'M' }). This is the Lua
+#   equivalent of "moveworkspacetomonitor". After that, the focus dispatch goes
+#   to the right monitor every time.
+#
+# Cursor warping (cursor:warp_on_change_workspace option):
+#   The focus dispatch respects the warp option, but the pointer only warps on
+#   the FINAL focus dispatch (the originally-focused monitor, set last). This is
+#   correct UX — the cursor follows keyboard focus to the monitor the user was
+#   actively using. Intermediate monitors don't receive pointer warps, which is
+#   the expected behavior for synchronized multi-monitor switches. (Issue #4)
+#
+# Fullscreen=2 workaround:
+#   Hyprland silently ignores workspace-focus dispatches on a monitor that has
+#   a fullscreen=2 window. We detect by address, stash to workspace 999 (no
+#   focus change, address-targeted), switch the workspace, then restore.
+#
+# Processing order: highest-base monitors first, originally-focused last.
+
+set -euo pipefail
+
+TARGET="${1:-}"
+if [[ -z "$TARGET" || ! "$TARGET" =~ ^([1-9]|10)$ ]]; then
+  echo "Usage: $0 <slot 1-10>" >&2
+  exit 1
+fi
+
+# ── Load stable base map ──────────────────────────────────────────────────────
+# omarchy-monitor-base sync: allocates bases for any unseen monitors, persists,
+# prints "name base" lines. We build an associative array: bases["HDMI-1"]=10
+#
+# NOTE: bash associative arrays are NOT exported to subshells. The base lookup
+# must happen in the parent shell, not inside a pipeline's while-read subshell.
+declare -A bases
+while IFS=' ' read -r mon_name mon_base; do
+  [[ -n "$mon_name" && -n "$mon_base" ]] && bases["$mon_name"]="$mon_base"
+done < <(omarchy-monitor-base sync 2>/dev/null)
+
+# ── Snapshot monitor list ─────────────────────────────────────────────────────
+monitors_json=$(hyprctl monitors -j)
+
+# Return the workspace ID for a monitor: base + slot.
+# Uses the parent-shell bases array directly — no subshell, no echo.
+# Falls back to mon_id * 10 only if the name is absent from the map.
+ws_for_monitor() {
+  local mon_name="$1" mon_id="$2"
+  local base="${bases[$mon_name]:-}"
+  if [[ -z "$base" ]]; then
+    base=$(( mon_id * 10 ))
+  fi
+  _ws_result=$(( base + TARGET ))
+}
+
+# ── Build ordered monitor lists in the parent shell ───────────────────────────
+# Non-focused monitors are processed highest-base first; the focused monitor
+# last so keyboard focus ends up on the monitor the user was using.
+#
+# The sort input is built by a while-read loop running in the PARENT shell
+# (process substitution, not a pipeline) so it can read the bases array.
+# Each line: "<base> <id> <name>" for sort -rn, then we strip the base prefix.
+
+mapfile -t _sort_input < <(
+  while IFS=' ' read -r mon_id mon_name; do
+    base="${bases[$mon_name]:-$(( mon_id * 10 ))}"
+    echo "$base $mon_id $mon_name"
+  done < <(echo "$monitors_json" | jq -r '.[] | select(.focused | not) | "\(.id) \(.name)"')
+)
+
+mapfile -t non_focused < <(
+  printf '%s\n' "${_sort_input[@]}" | sort -rn | awk '{print $2, $3}'
+)
+
+mapfile -t focused_entry < <(
+  echo "$monitors_json" | jq -r '.[] | select(.focused) | "\(.id) \(.name)"'
+)
+
+switch_monitor() {
+  local mon_id="$1"
+  local mon_name="$2"
+  local is_focused="${3:-false}"  # true if this was the originally-focused monitor
+  local _ws_result
+  ws_for_monitor "$mon_name" "$mon_id"
+  local ws="$_ws_result"
+
+  # Re-query clients fresh for this monitor so we see any changes from earlier
+  # iterations (windows stashed to 999, prior workspace assignments, etc.).
+  local clients_now
+  clients_now=$(hyprctl clients -j 2>/dev/null) || clients_now="[]"
+
+  # Detect a fullscreen=2 window on this monitor (by address).
+  local fs_addr="" orig_ws=""
+  fs_addr=$(echo "$clients_now" | jq -r \
+    --argjson mid "$mon_id" \
+    '.[] | select(.monitor == $mid and .fullscreen == 2) | .address' \
+    2>/dev/null | head -1) || true
+
+  if [[ -n "$fs_addr" ]]; then
+    orig_ws=$(echo "$clients_now" | jq -r \
+      --arg addr "$fs_addr" \
+      '.[] | select(.address == $addr) | .workspace.id' \
+      2>/dev/null) || true
+  fi
+
+  # Stash fullscreen window to a scratch workspace pinned to THIS monitor.
+  # WS999 is monitor-agnostic — Hyprland can assign it to any monitor,
+  # causing the fullscreen window to briefly appear ("shadow") on whichever
+  # monitor last changed. Using base+99 (e.g. WS109 for base=10) keeps the
+  # stash within this monitor's own range, so Hyprland never moves it.
+  local stash_ws=$(( ${bases[$mon_name]:-$(( mon_id * 10 ))} + 99 ))
+  if [[ -n "$fs_addr" && -n "$orig_ws" ]]; then
+    hyprctl eval "hl.dispatch(hl.dsp.workspace.move({ workspace = '$stash_ws', monitor = '$mon_name' }))" \
+      >/dev/null 2>&1 || true
+    hyprctl eval "hl.dispatch(hl.dsp.window.move({ workspace = '$stash_ws', window = 'address:$fs_addr', follow = false }))" \
+      >/dev/null 2>&1 || true
+  fi
+
+  # ── Fix for workspace ownership mismatch (Issue #MISSING: Ixion disappears) ──
+  # When windows on the target workspace ($ws) are physically on OTHER monitors
+  # (not $mon_name), workspace.move() alone doesn't move them. The workspace
+  # metadata reassigns, but the windows stay on their original monitors. On the
+  # next switch, this creates a "shadow" workspace where the old monitor's
+  # windows are invisible.
+  #
+  # Solution: Find all windows on workspaces that SHOULD be on this monitor but
+  # are ACTUALLY on other monitors, and move them explicitly by address.
+  local orphaned_windows
+  orphaned_windows=$(echo "$clients_now" | jq -r \
+    --argjson target_ws "$ws" \
+    --argjson target_mon_id "$mon_id" \
+    '.[] | select(.workspace.id == $target_ws and .monitor != $target_mon_id) | .address' \
+    2>/dev/null || echo "")
+  
+  if [[ -n "$orphaned_windows" ]]; then
+    echo "$orphaned_windows" | while read -r orphan_addr; do
+      [[ -z "$orphan_addr" ]] && continue
+      # Move the orphaned window to the target workspace on the correct monitor.
+      # This ensures the window is physically on the right monitor.
+      hyprctl eval "hl.dispatch(hl.dsp.window.move({ workspace = '$ws', window = 'address:$orphan_addr', follow = false }))" \
+        >/dev/null 2>&1 || true
+    done
+  fi
+
+  # Reassign the target workspace to this monitor BEFORE focusing it.
+  # This prevents Hyprland from stealing focus to whichever monitor currently
+  # owns that workspace, which is the primary cause of "wrong monitor switches".
+  hyprctl eval "hl.dispatch(hl.dsp.workspace.move({ workspace = '$ws', monitor = '$mon_name' }))" \
+    >/dev/null 2>&1 || true
+
+  # ── CRITICAL FIX: Focus handling depends on monitor type ──
+  # For the ORIGINALLY-FOCUSED monitor: we MUST call focus({ monitor }) AND focus({ workspace })
+  # to ensure keyboard focus ends up back where it started.
+  #
+  # For NON-FOCUSED monitors: we MUST NOT call focus({ monitor }). Each non-focused monitor's
+  # focus({ monitor }) call steals keyboard focus, breaking the switch for the focused monitor
+  # that processes last. Instead, we only call focus({ workspace }) to update the visible content
+  # on that monitor. Hyprland will render the workspace correctly even without keyboard focus.
+  #
+  # Bug: In the old code, ALL monitors called focus({ monitor }), which meant:
+  #   1. Non-focused monitor calls focus({monitor: HDMI-A-1}) → steals focus to HDMI-A-1
+  #   2. Non-focused monitor calls focus({monitor: DP-2}) → steals focus to DP-2
+  #   3. Finally, DP-1 (originally-focused) calls focus({monitor: DP-1}) → steals focus to DP-1
+  #   4. DP-1 calls focus({workspace: 11}) → should work, but state is corrupted
+  #
+  # After fix: Only the originally-focused monitor handles focus; others just update workspace visibility.
+  
+  if [[ "$is_focused" == "true" ]]; then
+    # Originally-focused monitor: restore keyboard focus after workspace changes
+    hyprctl eval "hl.dispatch(hl.dsp.focus({ monitor = '$mon_name' }))" \
+      >/dev/null 2>&1 || true
+    hyprctl eval "hl.dispatch(hl.dsp.focus({ workspace = '$ws' }))" \
+      >/dev/null 2>&1 || true
+  else
+    # Non-focused monitor: update workspace visibility WITHOUT stealing focus
+    hyprctl eval "hl.dispatch(hl.dsp.focus({ workspace = '$ws' }))" \
+      >/dev/null 2>&1 || true
+  fi
+
+  # Restore fullscreen window to its original workspace by address.
+  if [[ -n "$fs_addr" && -n "$orig_ws" ]]; then
+    hyprctl eval "hl.dispatch(hl.dsp.window.move({ workspace = '$orig_ws', window = 'address:$fs_addr', follow = false }))" \
+      >/dev/null 2>&1 || true
+  fi
+}
+
+# Switch non-focused monitors first (highest base first)
+for entry in "${non_focused[@]:-}"; do
+  [[ -z "$entry" ]] && continue
+  mon_id=$(echo "$entry" | cut -d' ' -f1)
+  mon_name=$(echo "$entry" | cut -d' ' -f2)
+  switch_monitor "$mon_id" "$mon_name" "false" || true
+done
+
+# Switch the originally-focused monitor last (leaves focus there)
+if [[ -n "${focused_entry[0]:-}" ]]; then
+  mon_id=$(echo "${focused_entry[0]}" | cut -d' ' -f1)
+  mon_name=$(echo "${focused_entry[0]}" | cut -d' ' -f2)
+  switch_monitor "$mon_id" "$mon_name" "true" || true
+fi
+
+# ── Refresh all bars ──────────────────────────────────────────────────────────
+# Quickshell's HyprlandMonitor.activeWorkspace only updates when a monitor
+# produces an IPC event. Monitors that switched without keyboard focus sit
+# stale until something incidental touches them. Calling refresh on the
+# IpcHandler forces all bars to re-query Hyprland state simultaneously,
+# fixing the stale focus highlight.
+# Backgrounded so it doesn't add latency to the switch itself.
+qs ipc call omarchy.workspaces refresh &>/dev/null &

--- a/bin/omarchy-workspace-scripts/omarchy-init-global-workspaces
+++ b/bin/omarchy-workspace-scripts/omarchy-init-global-workspaces
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Initialize all global workspace slots on first activation.
+# Run once per session when global mode is first enabled.
+
+set -euo pipefail
+
+# Load monitor bases
+BASES_JSON="${HOME}/.local/state/omarchy/monitor-bases.json"
+if [[ ! -f "$BASES_JSON" ]]; then
+  exit 0
+fi
+
+declare -A bases
+while IFS=' ' read -r mon_name mon_base; do
+  [[ -n "$mon_name" ]] && bases["$mon_name"]="$mon_base"
+done < <(jq -r 'to_entries[] | "\(.key) \(.value)"' "$BASES_JSON" 2>/dev/null) || exit 0
+
+# Get connected monitors
+declare -A monitors
+while IFS=' ' read -r mon_name; do
+  monitors["$mon_name"]=1
+done < <(hyprctl monitors -j 2>/dev/null | jq -r '.[].name') || exit 0
+
+# For each monitor, create workspace slots 1-10 by dispatching focus
+# (Hyprland creates workspaces on first access)
+for mon_name in "${!monitors[@]}"; do
+  base="${bases[$mon_name]:-0}"
+  for slot in 1 2 3 4 5 6 7 8 9 10; do
+    ws_id=$((base + slot))
+    hyprctl eval "hl.dispatch(hl.dsp.focus({ workspace = '$ws_id' }))" >/dev/null 2>&1 || true
+    # Small delay between dispatches to let Hyprland keep up
+    sleep 0.02
+  done
+done
+
+# Return focus to ws 1
+hyprctl eval "hl.dispatch(hl.dsp.focus({ workspace = '1' }))" >/dev/null 2>&1
+
+# Mark that initialization is complete (so we don't run again)
+touch "${HOME}/.local/state/omarchy/toggles/hypr/.global-workspaces-initialized"
+
+# Refresh bars
+qs ipc call omarchy.workspaces refresh &>/dev/null &

--- a/bin/omarchy-workspace-scripts/omarchy-monitor-base
+++ b/bin/omarchy-workspace-scripts/omarchy-monitor-base
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# omarchy-monitor-base — Stable monitor→base allocator.
+#
+# Usage:
+#   omarchy-monitor-base            Print all entries: one "name base" line each
+#   omarchy-monitor-base sync       Read current monitors from hyprctl, auto-assign
+#                                   bases to any new names, persist, then print all
+#
+# The base for a monitor name is its permanent workspace offset (multiples of 10).
+# It is assigned on first-seen and never changes, even if Hyprland reassigns the
+# monitor's numeric id across hotplug cycles.
+#
+# Storage: ~/.local/state/omarchy/monitor-bases.json
+# Format:  { "eDP-1": 0, "HDMI-1": 10, "DP-2": 20 }
+#
+# Assignment is deterministic: within a single "sync" call, new monitors are
+# assigned in the order hyprctl reports them (sorted by current id ascending),
+# so re-running with the same monitors is always a no-op.
+
+import json, os, subprocess, sys, tempfile
+
+STATE_DIR = os.path.expanduser("~/.local/state/omarchy")
+BASES_FILE = os.path.join(STATE_DIR, "monitor-bases.json")
+STRIDE = 10  # workspace slots per monitor
+
+
+def load() -> dict:
+    try:
+        with open(BASES_FILE) as f:
+            data = json.load(f)
+        return {k: int(v) for k, v in data.items()}
+    except (FileNotFoundError, json.JSONDecodeError, ValueError):
+        return {}
+
+
+def save(bases: dict) -> None:
+    """Atomically write bases to disk. Uses a temp file + os.replace() so a
+    mid-write kill never leaves a truncated/corrupt JSON file, and so QML's
+    FileView watcher sees a complete file on every change notification."""
+    os.makedirs(STATE_DIR, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=STATE_DIR, prefix=".monitor-bases-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(bases, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp, BASES_FILE)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def next_free_base(bases: dict) -> int:
+    used = set(bases.values())
+    candidate = 0
+    while candidate in used:
+        candidate += STRIDE
+    return candidate
+
+
+def sync() -> dict:
+    """Query hyprctl for current monitors, allocate bases for any unseen names."""
+    try:
+        out = subprocess.check_output(
+            ["hyprctl", "monitors", "-j"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        monitors = json.loads(out)
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return load()
+
+    bases = load()
+    changed = False
+
+    # Sort by current Hyprland id so new monitors are assigned bases in a
+    # stable, deterministic order within a single sync call.
+    for mon in sorted(monitors, key=lambda m: m.get("id", 0)):
+        name = mon.get("name", "")
+        if not name or name in bases:
+            continue
+        bases[name] = next_free_base(bases)
+        changed = True
+
+    if changed:
+        save(bases)
+
+    return bases
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "sync":
+        bases = sync()
+    else:
+        bases = load()
+
+    for name, base in sorted(bases.items(), key=lambda x: x[1]):
+        print(f"{name} {base}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/omarchy-workspace-scripts/omarchy-move-window-to-aw
+++ b/bin/omarchy-workspace-scripts/omarchy-move-window-to-aw
@@ -1,0 +1,28 @@
+#!/bin/bash
+# omarchy-move-window-to-aw <slot 1-10>
+#
+# Move the focused window to AW slot N, respecting the global/local toggle.
+#
+# GLOBAL MODE (workspace-global.lua flag present):
+#   Calls omarchy-hyprland-workspace-global-move-window N.
+#   That script reads the active window's monitor name, looks up its stable
+#   base, and silently moves the window to WS(base+N). The display does not
+#   change — press SUPER+N to follow the window to that slot.
+#
+# LOCAL MODE (flag absent):
+#   Moves the focused window to raw Hyprland workspace N on the current monitor,
+#   silently (no focus/display change), using hyprctl movetoworkspacesilent.
+
+SLOT="${1:-}"
+if [[ -z "$SLOT" || ! "$SLOT" =~ ^([1-9]|10)$ ]]; then
+  echo "Usage: $0 <slot 1-10>" >&2
+  exit 1
+fi
+
+GLOBAL_FLAG="$HOME/.local/state/omarchy/toggles/hypr/workspace-global.lua"
+
+if [[ -f "$GLOBAL_FLAG" ]]; then
+  exec omarchy-hyprland-workspace-global-move-window "$SLOT"
+else
+  exec hyprctl dispatch movetoworkspacesilent "$SLOT"
+fi

--- a/bin/omarchy-workspace-scripts/omarchy-recover-stranded-windows
+++ b/bin/omarchy-workspace-scripts/omarchy-recover-stranded-windows
@@ -1,0 +1,94 @@
+#!/bin/bash
+# omarchy:summary=Recover windows stranded after monitor disconnect
+#
+# When an external monitor disconnects, windows on its workspaces become
+# inaccessible. This script rescues them using modular arithmetic.
+#
+# For each orphaned workspace (on a now-absent monitor), we move its windows
+# to the same LOGICAL SLOT on an available monitor (preferring the laptop panel).
+#
+# Formula: slot = (ws_id - 1) % 10 + 1
+#   This gives the slot 1-10 from any workspace ID, without knowing the base.
+#
+# Related: isaac30503's comment on PR #10199, Issue #8
+
+set -euo pipefail
+
+BASES_JSON="${HOME}/.local/state/omarchy/monitor-bases.json"
+
+# Find an available "home" monitor to rescue to.
+# Try laptop panel first (eDP-1), then any available external monitor.
+find_home_monitor() {
+  local mons
+  mons=$(hyprctl monitors -j 2>/dev/null | jq -r '.[].name' || echo "")
+  
+  for preferred in eDP-1 HDMI-1 DP-1 DP-2 DP-3 DP-4; do
+    if echo "$mons" | grep -q "^$preferred$"; then
+      echo "$preferred"
+      return 0
+    fi
+  done
+  
+  # Fallback: just use the first available
+  echo "$mons" | head -1
+}
+
+# Parse monitor name → base
+declare -A bases
+if [[ -f "$BASES_JSON" ]]; then
+  while IFS=' ' read -r mon_name mon_base; do
+    [[ -n "$mon_name" ]] && bases["$mon_name"]="$mon_base"
+  done < <(jq -r 'to_entries[] | "\(.key) \(.value)"' "$BASES_JSON" 2>/dev/null) || true
+fi
+
+# Get currently connected monitors
+declare -A current_mons
+while IFS=' ' read -r mon_name; do
+  [[ -n "$mon_name" ]] && current_mons["$mon_name"]=1
+done < <(hyprctl monitors -j 2>/dev/null | jq -r '.[].name' || echo "") || true
+
+home_mon=$(find_home_monitor)
+if [[ -z "$home_mon" ]]; then
+  echo "Error: no connected monitors found" >&2
+  exit 1
+fi
+
+home_base="${bases[$home_mon]:-0}"
+echo "Rescuing windows stranded on disconnected monitors..."
+echo "  Target monitor: '$home_mon' (base = $home_base)"
+echo
+
+count_moved=0
+
+# List all workspaces, find those on disconnected monitors
+hyprctl workspaces -j 2>/dev/null | jq -r '.[] | select(.monitor != null) | "\(.id) \(.monitor.name)"' 2>/dev/null | while read -r ws_id mon_name; do
+  # Skip if this monitor is still connected
+  [[ -n "${current_mons[$mon_name]:-}" ]] && continue
+  
+  # This workspace is orphaned (monitor is gone)
+  # Calculate the slot without needing to know the disappeared monitor's base
+  slot=$(( (ws_id - 1) % 10 + 1 ))
+  target_ws=$(( home_base + slot ))
+  
+  echo "  WS $ws_id (monitor '$mon_name' gone) → moving windows to WS $target_ws (slot $slot)"
+  
+  # Move all windows from the orphaned workspace
+  hyprctl clients -j 2>/dev/null | jq -r ".[] | select(.workspace.id == $ws_id) | .address" 2>/dev/null | while read -r addr; do
+    [[ -z "$addr" ]] && continue
+    hyprctl eval "hl.dispatch(hl.dsp.window.move({ workspace = '$target_ws', window = 'address:$addr', follow = false }))" \
+      >/dev/null 2>&1 || true
+    ((count_moved++)) || true
+  done
+done
+
+echo
+if [[ "$count_moved" -gt 0 ]]; then
+  echo "✓ Moved $count_moved window(s). Switch to monitor '$home_mon' to see them."
+else
+  echo "  No stranded windows found."
+fi
+
+# Refresh the bars to update occupancy indicators
+{ qs ipc call omarchy.workspaces refresh &>/dev/null; } &
+disown 2>/dev/null || true
+

--- a/bin/omarchy-workspace-scripts/omarchy-switch-to-aw
+++ b/bin/omarchy-workspace-scripts/omarchy-switch-to-aw
@@ -1,0 +1,25 @@
+#!/bin/bash
+# omarchy-switch-to-aw <slot 1-10>
+#
+# Switch to AW slot N, respecting the global/local toggle at runtime.
+#
+# GLOBAL MODE (workspace-global.lua flag present):
+#   Calls omarchy-hyprland-workspace-global-switch N.
+#   All monitors switch to their slot-N Hyprland workspace simultaneously.
+#
+# LOCAL MODE (flag absent):
+#   Focuses raw Hyprland workspace N on the current monitor only.
+
+SLOT="${1:-}"
+if [[ -z "$SLOT" || ! "$SLOT" =~ ^([1-9]|10)$ ]]; then
+  echo "Usage: $0 <slot 1-10>" >&2
+  exit 1
+fi
+
+GLOBAL_FLAG="$HOME/.local/state/omarchy/toggles/hypr/workspace-global.lua"
+
+if [[ -f "$GLOBAL_FLAG" ]]; then
+  exec omarchy-hyprland-workspace-global-switch "$SLOT"
+else
+  exec hyprctl dispatch workspace "$SLOT"
+fi

--- a/config/hypr/autostart.lua
+++ b/config/hypr/autostart.lua
@@ -1,2 +1,23 @@
 -- Extra autostart processes.
 -- o.launch_on_start("my-service")
+
+-- Materialize all global workspace slots at config load time (if global mode is active).
+-- Hyprland 0.56.x doesn't support synchronous workspace rule materialization, so we
+-- force-create them by dispatching focus to each slot sequentially. This must happen
+-- early so subsequent switches have workspaces to target.
+if os.getenv("HYPRLAND_INSTANCE_SIGNATURE") and _G.omarchy_monitor_bases then
+  -- Create workspaces 1-30 by focusing them (Hyprland materializes on focus)
+  for ws = 1, 30 do
+    local ok = pcall(function()
+      hl.dispatch(hl.dsp.focus({ workspace = tostring(ws) }))
+    end)
+    -- No yield/sleep here — must complete in one config pass
+  end
+  -- Return focus to ws 1
+  pcall(function()
+    hl.dispatch(hl.dsp.focus({ workspace = "1" }))
+  end)
+  
+  -- Refresh bars after materialization (backgrounded)
+  os.execute("sleep 0.1; qs ipc call omarchy.workspaces refresh &>/dev/null &")
+end

--- a/config/hypr/bindings-global-workspaces.lua
+++ b/config/hypr/bindings-global-workspaces.lua
@@ -1,0 +1,27 @@
+-- ── Global workspace switching ────────────────────────────────────────────
+-- Installed by omarchy-global-workspaces/install.sh into ~/.config/hypr/bindings.lua
+--
+-- SUPER+1..10 — switch to AW slot N.
+-- omarchy-switch-to-aw checks the toggle at runtime:
+--   global mode → omarchy-hyprland-workspace-global-switch N (all monitors)
+--   local mode  → hyprctl dispatch workspace N (current monitor only)
+for slot = 1, 10 do
+  local key = "code:" .. tostring(slot + 9)
+  hl.unbind("SUPER + " .. key)
+  o.bind("SUPER + " .. key,
+    "Switch to Workspace " .. slot,
+    "omarchy-switch-to-aw " .. tostring(slot))
+end
+
+-- SUPER+SHIFT+1..10 — move focused window to AW slot N, silently.
+-- omarchy-move-window-to-aw checks the toggle at runtime:
+--   global mode → omarchy-hyprland-workspace-global-move-window N (same monitor, slot N)
+--   local mode  → hyprctl movetoworkspacesilent N
+for slot = 1, 10 do
+  local key = "code:" .. tostring(slot + 9)
+  hl.unbind("SUPER + SHIFT + " .. key)
+  o.bind("SUPER + SHIFT + " .. key,
+    "Move window to Workspace " .. slot,
+    "omarchy-move-window-to-aw " .. tostring(slot))
+end
+-- ── End global workspace switching ───────────────────────────────────────

--- a/config/hypr/toggles/workspace-global.lua
+++ b/config/hypr/toggles/workspace-global.lua
@@ -1,0 +1,137 @@
+-- Global workspace mode — active when this file is loaded by toggles.lua.
+-- When present in ~/.local/state/omarchy/toggles/hypr/, global mode is ON.
+--
+-- STABLE-BASE SCHEME (replaces monitorId * 10):
+--   Each monitor is assigned a permanent workspace base on first connection.
+--   The base is stored in ~/.local/state/omarchy/monitor-bases.json keyed by
+--   monitor *name* (e.g. "eDP-1", "HDMI-1") — not by Hyprland's transient id.
+--
+--   Hyprland does not reuse monitor ids after hotplug (hyprwm/Hyprland#2601).
+--   Unplugging and replugging an external monitor gives it a new id each time,
+--   which broke the old monitorId * 10 scheme by orphaning occupied workspaces.
+--   Using name as the key means the same physical monitor always owns the same
+--   workspace range regardless of what numeric id Hyprland assigns to it.
+--
+--   Example persistent mapping (monitor-bases.json):
+--     { "eDP-1": 0, "HDMI-1": 10, "DP-2": 20 }
+--
+--   Workspace ID for slot N on monitor named M = bases[M] + N
+--
+-- This file:
+--   1. Calls omarchy-monitor-base sync to update/persist the base map for the
+--      currently connected monitors.
+--   2. Stores the resulting map in _G.omarchy_monitor_bases (name → base).
+--   3. Also stores the sorted monitor list in _G.omarchy_global_ws_monitors
+--      for use by other config modules (tiling.lua, etc.).
+--
+-- STUB-SAFETY NOTES:
+--   omarchy-menu-keybindings evaluates this file under a stub Lua environment
+--   to extract keybinding metadata without running a real Hyprland session.
+--   Two hazards to avoid:
+--
+--   1. ipairs() on a stub object hangs (omacom/omarchy#7025): the stub's
+--      __index returns a truthy sentinel for every key, so ipairs() never
+--      sees nil and loops forever. Fixed: use numeric for i = 1, #tbl.
+--
+--   2. io.popen() / hl.get_monitors() under the stub: io.popen actually
+--      executes the shell command, causing omarchy-monitor-base to call
+--      hyprctl which blocks waiting for a Hyprland socket that doesn't
+--      exist in the menu context. Fixed: gate both calls behind a
+--      HYPRLAND_INSTANCE_SIGNATURE check — that env var is only set inside
+--      a live Hyprland session.
+
+-- Only run the Hyprland-dependent setup when inside a real session.
+if not os.getenv("HYPRLAND_INSTANCE_SIGNATURE") then
+  _G.omarchy_monitor_bases = {}
+  _G.omarchy_global_ws_monitors = {}
+  return
+end
+
+local function parse_bases()
+  -- Run omarchy-monitor-base sync: allocates any missing bases for currently
+  -- connected monitors, persists, then prints "name base\n" lines.
+  local handle = io.popen("omarchy-monitor-base sync 2>/dev/null")
+  local result = {}
+  if handle then
+    for line in handle:lines() do
+      local name, base = line:match("^(%S+)%s+(%d+)$")
+      if name and base then
+        result[name] = tonumber(base)
+      end
+    end
+    handle:close()
+  end
+  return result
+end
+
+-- Build and export the stable name→base map.
+_G.omarchy_monitor_bases = parse_bases()
+
+-- Also export the sorted monitor list (ordered by base, ascending) so other
+-- config modules can use a stable, base-ordered view of monitors without
+-- re-querying.
+local monitors = hl.get_monitors()
+
+-- Sort by name-keyed base (stable), falling back to current Hyprland id
+-- for any monitor not yet in the map (shouldn't happen after sync above).
+table.sort(monitors, function(a, b)
+  local base_a = _G.omarchy_monitor_bases[a.name] or (a.id * 10)
+  local base_b = _G.omarchy_monitor_bases[b.name] or (b.id * 10)
+  return base_a < base_b
+end)
+
+_G.omarchy_global_ws_monitors = {}
+-- Numeric for avoids the ipairs/stub hang (see note above).
+for i = 1, #monitors do
+  local mon = monitors[i]
+  _G.omarchy_global_ws_monitors[i] = {
+    id   = mon.id,
+    name = mon.name,
+    base = _G.omarchy_monitor_bases[mon.name] or (mon.id * 10),
+  }
+end
+
+-- ── Materialize persistent workspaces (Issue #5) ─────────────────────────
+-- set_workspace() silently no-ops on workspaces that don't exist yet. We need
+-- all workspace slots pre-created with persistent=true so that switching to
+-- an empty slot works immediately (no silent failures).
+--
+-- This function registers hl.workspace_rule() for every slot (1-10) on every
+-- monitor to ensure they exist even if empty. Persistent workspaces remain
+-- alive even with no windows.
+local function ensure_persistent_workspaces()
+  if not hl.workspace_rule then
+    return  -- Hyprland version too old or not available
+  end
+  
+  for i = 1, #_G.omarchy_global_ws_monitors do
+    local mon = _G.omarchy_global_ws_monitors[i]
+    local base = mon.base
+    
+    -- Register persistent workspace for each slot 1-10 on this monitor
+    for slot = 1, 10 do
+      local ws_id = base + slot
+      local rule_ok = pcall(function()
+        hl.workspace_rule({
+          workspace = tostring(ws_id),
+          monitor = mon.name,
+          persistent = true,
+          -- layout defaults to current; no need to override here
+        })
+      end)
+      -- Silently ignore errors; rule registration is best-effort
+    end
+  end
+end
+
+-- Ensure all workspace slots exist before any focus dispatch
+ensure_persistent_workspaces()
+
+-- ── Delayed verification (Issue #6) ────────────────────────────────────
+-- hl.workspace_rule() doesn't materialize synchronously. Schedule a retry
+-- script to verify all workspaces exist after a short delay. This catches the
+-- race where a fresh monitor's workspaces aren't created yet.
+local ok = pcall(function()
+  os.execute("omarchy-ensure-workspaces &")
+end)
+-- Silently ignore if the script isn't found yet

--- a/config/omarchy/extensions/omarchy-menu-global-workspaces.jsonc
+++ b/config/omarchy/extensions/omarchy-menu-global-workspaces.jsonc
@@ -1,0 +1,21 @@
+{
+  // Workspace Mode submenu — appears in Trigger > Toggle
+  "trigger.toggle.workspace-mode": {
+    "icon": "󱂬",
+    "label": "Workspace Mode"
+  },
+  "trigger.toggle.workspace-mode.global": {
+    "icon": "󱂬",
+    "label": "Global",
+    "description": "All monitors switch workspace together",
+    "checked": "omarchy-hyprland-toggle-enabled workspace-global",
+    "action": "omarchy-hyprland-toggle workspace-global on"
+  },
+  "trigger.toggle.workspace-mode.local": {
+    "icon": "󱂬",
+    "label": "Local",
+    "description": "Each monitor switches workspace independently",
+    "checked": "! omarchy-hyprland-toggle-enabled workspace-global",
+    "action": "omarchy-hyprland-toggle workspace-global off"
+  }
+}

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -1,39 +1,198 @@
 import QtQuick
 import QtQuick.Layouts
 import Quickshell.Hyprland
+import Quickshell
+import Quickshell.Io
 import qs.Commons
 import qs.Ui
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workspaces widget — Global-workspace-aware rewrite.
+//
+// TERMINOLOGY
+//   AW (Apparent Workspace): what the user sees — AW1 through AW5.
+//     Switching to AWN moves EVERY monitor to its corresponding Hyprland WS.
+//   WS (Hyprland Workspace): the underlying integer ID Hyprland tracks.
+//     Each monitor owns an exclusive range (offset = monitorId * 10):
+//       monitor 0  →  WS  1-10
+//       monitor 1  →  WS 11-20
+//       monitor 2  →  WS 21-30
+//     AWN on monitor M = WS(M*10 + N).
+//
+// GLOBAL MODE (workspace-global.lua toggle present):
+//   - Bar always shows exactly 5 buttons labelled 1-5 (AW slots).
+//   - Clicking AWN calls omarchy-hyprland-workspace-global-switch N, which
+//     moves all monitors to their slot-N WS simultaneously.
+//   - Focused: all bars agree — derived from any monitor's activeWorkspace.
+//   - Occupied: AWN is lit if ANY monitor has windows on WS(monitorId*10+N).
+//
+// LOCAL MODE (toggle absent):
+//   - Falls back to stock omarchy behavior: shows raw Hyprland WS IDs 1-5
+//     and clicking dispatches a single-monitor focus to that WS.
+// ─────────────────────────────────────────────────────────────────────────────
 
 BarWidget {
   id: root
   moduleName: "omarchy.workspaces"
 
-  function workspaceById(id) {
-    var values = Hyprland.workspaces.values
-    for (var i = 0; i < values.length; i++) {
-      if (values[i].id === id) return values[i]
-    }
+  // ── Global-mode flag ───────────────────────────────────────────────────────
 
-    return null
+  readonly property string globalToggleDir:
+    (Quickshell.env("HOME") || "") + "/.local/state/omarchy/toggles/hypr"
+
+  property bool globalMode: false
+
+  Process {
+    id: globalFlagProbe
+    running: true
+    command: ["bash", "-c",
+      "[[ -f $HOME/.local/state/omarchy/toggles/hypr/workspace-global.lua ]] && echo yes || echo no"]
+    stdout: SplitParser {
+      onRead: function(line) { root.globalMode = String(line).trim() === "yes" }
+    }
   }
 
-  function workspaceIds() {
+  // Watch the directory so we detect the flag file being created or deleted.
+  FileView {
+    path: root.globalToggleDir
+    watchChanges: true
+    printErrors: false
+    onFileChanged: globalFlagProbe.running = true
+  }
+
+  // ── This bar's monitor identity ────────────────────────────────────────────
+  // Needed for:
+  //   (a) global mode: derive focused slot from this monitor's active WS
+  //   (b) local mode: fullscreen=2 workaround targets this monitor only
+
+  readonly property string thisMonitorName: {
+    var win = root.QsWindow ? root.QsWindow.window : null
+    return (win && win.screen && win.screen.name) ? String(win.screen.name) : ""
+  }
+
+  readonly property int thisMonitorId: {
+    var mons = Hyprland.monitors.values
+    for (var i = 0; i < mons.length; i++) {
+      if (mons[i].name === root.thisMonitorName) return mons[i].id
+    }
+    return 0
+  }
+
+  readonly property int thisMonitorOffset: root.thisMonitorId * 10
+
+  // ── AW slot list ───────────────────────────────────────────────────────────
+  // Global mode: always [1, 2, 3, 4, 5] — stable, independent of which
+  // Hyprland WS objects happen to exist at any moment.
+  // Local mode: raw Hyprland WS IDs 1-10 (stock omarchy logic).
+
+  function awSlots() {
+    if (root.globalMode) {
+      return [1, 2, 3, 4, 5]
+    }
+    // Local mode fallback — stock logic.
     var ids = [1, 2, 3, 4, 5]
     var values = Hyprland.workspaces.values
-
     for (var i = 0; i < values.length; i++) {
       var id = values[i].id
       if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
     }
-
-    ids.sort(function(left, right) { return left - right })
+    ids.sort(function(l, r) { return l - r })
     return ids
   }
 
-  function focusWorkspace(id) {
-    if (!root.bar) return
-    root.bar.run("hyprctl dispatch " + Util.shellQuote("hl.dsp.focus({ workspace = \"" + id + "\" })"))
+  // ── Focused slot ───────────────────────────────────────────────────────────
+  // Global mode: all monitors switch together, so any monitor's active WS
+  // divided by its offset gives the current slot. We use monitor 0 (offset 0)
+  // as the authoritative source — its active WS id IS the slot number.
+  // All bars read the same value, so all three bars agree.
+  //
+  // Local mode: match Hyprland.focusedWorkspace.id (stock behavior).
+
+  function awIsFocused(slot) {
+    if (!root.globalMode) {
+      return Hyprland.focusedWorkspace !== null &&
+             Hyprland.focusedWorkspace.id === slot
+    }
+    // Read monitor 0's active workspace id — that equals the current AW slot.
+    var mons = Hyprland.monitors.values
+    for (var i = 0; i < mons.length; i++) {
+      if (mons[i].id === 0) {
+        var activeWsId = mons[i].activeWorkspace ? mons[i].activeWorkspace.id : -1
+        // Monitor 0 offset is 0, so activeWsId == slot directly.
+        return activeWsId === slot
+      }
+    }
+    return false
   }
+
+  // ── Occupied indicator ────────────────────────────────────────────────────
+  // Global mode: AWN is occupied if ANY monitor has windows on WS(monId*10+N).
+  // All three bars show the same occupancy state for each slot.
+  //
+  // Local mode: check raw WS id == slot for windows (stock behavior).
+
+  function awIsOccupied(slot) {
+    if (!root.globalMode) {
+      var values = Hyprland.workspaces.values
+      for (var i = 0; i < values.length; i++) {
+        if (values[i].id === slot) {
+          return values[i].toplevels.values.length > 0
+        }
+      }
+      return false
+    }
+    // Global mode: walk all monitors, check WS(monitorId*10 + slot).
+    var mons = Hyprland.monitors.values
+    for (var m = 0; m < mons.length; m++) {
+      var wsId = mons[m].id * 10 + slot
+      var wsList = Hyprland.workspaces.values
+      for (var w = 0; w < wsList.length; w++) {
+        if (wsList[w].id === wsId && wsList[w].toplevels.values.length > 0) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+
+  // ── Switch to an AW slot ──────────────────────────────────────────────────
+  // Global mode: omarchy-hyprland-workspace-global-switch <slot> handles all
+  // monitors, fullscreen=2, and workspace-theft prevention internally.
+  //
+  // Local mode: single-monitor focus with fullscreen=2 workaround — detect the
+  // blocking window by address, stash it to WS999 (no focus change), switch
+  // the workspace, then restore it to its original WS by address.
+
+  function switchToAW(slot) {
+    if (!root.bar) return
+
+    if (root.globalMode) {
+      if (slot < 1 || slot > 10) return
+      root.bar.run("omarchy-hyprland-workspace-global-switch " + slot)
+      return
+    }
+
+    // Local mode fallback.
+    var monId = root.thisMonitorId
+    var bashCmd =
+      "cjson=$(hyprctl clients -j 2>/dev/null || echo '[]'); " +
+      "fs_addr=$(echo \"$cjson\" | jq -r --argjson mid " + monId + " " +
+        "'.[] | select(.monitor == $mid and .fullscreen == 2) | .address' " +
+        "2>/dev/null | head -1); " +
+      "orig_ws=''; " +
+      "if [ -n \"$fs_addr\" ]; then " +
+      "  orig_ws=$(echo \"$cjson\" | jq -r --arg addr \"$fs_addr\" " +
+        "'.[] | select(.address == $addr) | .workspace.id' 2>/dev/null); " +
+      "  hyprctl eval \"hl.dispatch(hl.dsp.window.move({ workspace = '999', window = 'address:$fs_addr', follow = false }))\" >/dev/null 2>&1 || true; " +
+      "fi; " +
+      "hyprctl eval \"hl.dispatch(hl.dsp.focus({ workspace = '" + slot + "' }))\" >/dev/null 2>&1 || true; " +
+      "if [ -n \"$fs_addr\" ] && [ -n \"$orig_ws\" ]; then " +
+      "  hyprctl eval \"hl.dispatch(hl.dsp.window.move({ workspace = '$orig_ws', window = 'address:$fs_addr', follow = false }))\" >/dev/null 2>&1 || true; " +
+      "fi"
+    root.bar.run("bash -c " + Util.shellQuote(bashCmd))
+  }
+
+  // ── Layout ────────────────────────────────────────────────────────────────
 
   readonly property real trailingGap: root.vertical ? 0 : Style.spaceReal(1.5)
 
@@ -44,28 +203,27 @@ BarWidget {
     id: grid
     anchors.fill: parent
     anchors.rightMargin: root.trailingGap
-    columns: root.vertical ? 1 : root.workspaceIds().length
+    columns: root.vertical ? 1 : root.awSlots().length
     columnSpacing: root.vertical ? 0 : Style.space(1)
     rowSpacing: root.vertical ? Style.space(2) : 0
 
     Repeater {
-      model: root.workspaceIds()
+      model: root.awSlots()
 
       WidgetButton {
-        required property int modelData
+        required property int modelData  // AW slot number (1-5)
 
-        readonly property var workspace: root.workspaceById(modelData)
-        readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
-        readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
+        readonly property bool occupied: root.awIsOccupied(modelData)
+        readonly property bool focused:  root.awIsFocused(modelData)
 
         bar: root.bar
-        text: focused ? "\uDB85\uDCFB" : (modelData === 10 ? "0" : String(modelData))
+        text: String(modelData)
         opacity: occupied || focused ? 1 : 0.5
         horizontalMargin: 6
         verticalPadding: 6
         fixedWidth: root.vertical ? root.barSize : Style.space(20)
         fixedHeight: root.barSize
-        onPressed: function() { root.focusWorkspace(modelData) }
+        onPressed: function() { root.switchToAW(modelData) }
       }
     }
   }

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -13,18 +13,27 @@ import qs.Ui
 //   AW (Apparent Workspace): what the user sees — AW1 through AW5.
 //     Switching to AWN moves EVERY monitor to its corresponding Hyprland WS.
 //   WS (Hyprland Workspace): the underlying integer ID Hyprland tracks.
-//     Each monitor owns an exclusive range (offset = monitorId * 10):
-//       monitor 0  →  WS  1-10
-//       monitor 1  →  WS 11-20
-//       monitor 2  →  WS 21-30
-//     AWN on monitor M = WS(M*10 + N).
+//     Each monitor owns an exclusive range starting at a stable *base*:
+//       base is assigned by monitor name (e.g. "eDP-1", "HDMI-1"), not by
+//       Hyprland's transient numeric id. See omarchy-monitor-base for details.
+//     AWN on monitor M = WS(base(M) + N).
+//
+// STABLE-BASE SCHEME:
+//   Hyprland does not reuse numeric monitor ids after hotplug (#2601).
+//   Using the monitor's OS name as a stable key means the same physical monitor
+//   always owns the same workspace range regardless of its current numeric id.
+//   The base map is persisted in ~/.local/state/omarchy/monitor-bases.json and
+//   updated by omarchy-monitor-base sync (called by the switch script and the
+//   toggle Lua on every Hyprland reload).
 //
 // GLOBAL MODE (workspace-global.lua toggle present):
 //   - Bar always shows exactly 5 buttons labelled 1-5 (AW slots).
 //   - Clicking AWN calls omarchy-hyprland-workspace-global-switch N, which
 //     moves all monitors to their slot-N WS simultaneously.
-//   - Focused: all bars agree — derived from any monitor's activeWorkspace.
-//   - Occupied: AWN is lit if ANY monitor has windows on WS(monitorId*10+N).
+//   - Focused: derived from ANY connected monitor's active workspace minus its
+//     stable base (not hardcoded to monitor id 0, which may not exist in
+//     clamshell/docked-only mode).
+//   - Occupied: AWN is lit if ANY monitor has windows on WS(base(M)+N).
 //
 // LOCAL MODE (toggle absent):
 //   - Falls back to stock omarchy behavior: shows raw Hyprland WS IDs 1-5
@@ -60,6 +69,42 @@ BarWidget {
     onFileChanged: globalFlagProbe.running = true
   }
 
+  // ── Stable monitor base map ────────────────────────────────────────────────
+  // Loaded from ~/.local/state/omarchy/monitor-bases.json.
+  // Maps monitor name → workspace base (e.g. {"eDP-1": 0, "HDMI-1": 10}).
+  // Reloaded whenever the file changes (hotplug adds a new monitor name).
+  //
+  // We read this as plain text rather than spawning jq so the QML side never
+  // needs to know or duplicate the offset formula — it just asks "what base
+  // does monitor X have?" and gets an integer back.
+
+  property var monitorBaseMap: ({})
+
+  readonly property string basesFilePath:
+    (Quickshell.env("HOME") || "") + "/.local/state/omarchy/monitor-bases.json"
+
+  FileView {
+    id: basesFileView
+    path: root.basesFilePath
+    watchChanges: true
+    printErrors: false
+    onTextChanged: function() {
+      try {
+        root.monitorBaseMap = JSON.parse(text)
+      } catch(e) {
+        root.monitorBaseMap = {}
+      }
+    }
+  }
+
+  // Look up the stable base for a monitor by its OS name.
+  // Falls back to 0 if the name is not yet in the map (shouldn't happen
+  // after sync, but prevents a NaN from propagating into workspace IDs).
+  function monitorBase(name) {
+    var b = root.monitorBaseMap[name]
+    return (b !== undefined && b !== null) ? b : 0
+  }
+
   // ── This bar's monitor identity ────────────────────────────────────────────
   // Needed for:
   //   (a) global mode: derive focused slot from this monitor's active WS
@@ -77,8 +122,6 @@ BarWidget {
     }
     return 0
   }
-
-  readonly property int thisMonitorOffset: root.thisMonitorId * 10
 
   // ── AW slot list ───────────────────────────────────────────────────────────
   // Global mode: always [1, 2, 3, 4, 5] — stable, independent of which
@@ -101,10 +144,10 @@ BarWidget {
   }
 
   // ── Focused slot ───────────────────────────────────────────────────────────
-  // Global mode: all monitors switch together, so any monitor's active WS
-  // divided by its offset gives the current slot. We use monitor 0 (offset 0)
-  // as the authoritative source — its active WS id IS the slot number.
-  // All bars read the same value, so all three bars agree.
+  // Global mode: use Hyprland.focusedMonitor.activeWorkspace minus its stable
+  // base. The focused monitor always receives IPC events first, so it is never
+  // stale — unlike iterating Hyprland.monitors.values and taking the first
+  // result, which may be a monitor that hasn't received an update yet.
   //
   // Local mode: match Hyprland.focusedWorkspace.id (stock behavior).
 
@@ -113,20 +156,14 @@ BarWidget {
       return Hyprland.focusedWorkspace !== null &&
              Hyprland.focusedWorkspace.id === slot
     }
-    // Read monitor 0's active workspace id — that equals the current AW slot.
-    var mons = Hyprland.monitors.values
-    for (var i = 0; i < mons.length; i++) {
-      if (mons[i].id === 0) {
-        var activeWsId = mons[i].activeWorkspace ? mons[i].activeWorkspace.id : -1
-        // Monitor 0 offset is 0, so activeWsId == slot directly.
-        return activeWsId === slot
-      }
-    }
-    return false
+    // Global mode: the focused monitor's activeWorkspace is always current.
+    var mon = Hyprland.focusedMonitor
+    if (mon === null || mon.activeWorkspace === null) return false
+    return (mon.activeWorkspace.id - root.monitorBase(mon.name)) === slot
   }
 
   // ── Occupied indicator ────────────────────────────────────────────────────
-  // Global mode: AWN is occupied if ANY monitor has windows on WS(monId*10+N).
+  // Global mode: AWN is occupied if ANY monitor has windows on WS(base(M)+N).
   // All three bars show the same occupancy state for each slot.
   //
   // Local mode: check raw WS id == slot for windows (stock behavior).
@@ -141,18 +178,44 @@ BarWidget {
       }
       return false
     }
-    // Global mode: walk all monitors, check WS(monitorId*10 + slot).
-    var mons = Hyprland.monitors.values
-    for (var m = 0; m < mons.length; m++) {
-      var wsId = mons[m].id * 10 + slot
-      var wsList = Hyprland.workspaces.values
-      for (var w = 0; w < wsList.length; w++) {
-        if (wsList[w].id === wsId && wsList[w].toplevels.values.length > 0) {
-          return true
-        }
+    // Global mode: for each workspace that exists, compute which slot it
+    // represents on its monitor using the stable base. If that slot matches
+    // and it has windows, AW N is occupied.
+    var wsList = Hyprland.workspaces.values
+    for (var w = 0; w < wsList.length; w++) {
+      var ws = wsList[w]
+      if (ws.monitor === null) continue
+      var wsBase = root.monitorBase(ws.monitor.name)
+      var wsSlot = ws.id - wsBase
+      if (wsSlot === slot && ws.toplevels.values.length > 0) {
+        return true
       }
     }
     return false
+  }
+
+  // ── IPC refresh handler ───────────────────────────────────────────────────
+  // Quickshell's HyprlandMonitor.activeWorkspace only updates when that monitor
+  // generates an IPC event. In a synchronized multi-monitor switch, monitors
+  // that didn't have keyboard focus at switch time receive no event and sit
+  // stale until something incidental (e.g. cursor hover) triggers one.
+  //
+  // The switch script calls:
+  //   qs ipc call omarchy.workspaces refresh
+  // immediately after dispatching all workspace moves (backgrounded, so it
+  // doesn't add latency to the switch itself). This forces a full re-query of
+  // Hyprland state on every bar simultaneously, fixing the stale highlight.
+  //
+  // Because each bar is its own Quickshell process, qs ipc call without a
+  // --pid flag broadcasts to all running instances — one call covers all bars.
+
+  IpcHandler {
+    target: "omarchy.workspaces"
+
+    function refresh(): void {
+      Hyprland.refreshMonitors()
+      Hyprland.refreshWorkspaces()
+    }
   }
 
   // ── Switch to an AW slot ──────────────────────────────────────────────────
@@ -174,6 +237,8 @@ BarWidget {
 
     // Local mode fallback.
     var monId = root.thisMonitorId
+    var monBase = root.monitorBase(root.thisMonitorName)
+    var stashWs = monBase + 99  // monitor-pinned scratch; avoids cross-monitor shadow
     var bashCmd =
       "cjson=$(hyprctl clients -j 2>/dev/null || echo '[]'); " +
       "fs_addr=$(echo \"$cjson\" | jq -r --argjson mid " + monId + " " +
@@ -183,7 +248,8 @@ BarWidget {
       "if [ -n \"$fs_addr\" ]; then " +
       "  orig_ws=$(echo \"$cjson\" | jq -r --arg addr \"$fs_addr\" " +
         "'.[] | select(.address == $addr) | .workspace.id' 2>/dev/null); " +
-      "  hyprctl eval \"hl.dispatch(hl.dsp.window.move({ workspace = '999', window = 'address:$fs_addr', follow = false }))\" >/dev/null 2>&1 || true; " +
+      "  hyprctl eval \"hl.dispatch(hl.dsp.workspace.move({ workspace = '" + stashWs + "', monitor = '" + root.thisMonitorName + "' }))\" >/dev/null 2>&1 || true; " +
+      "  hyprctl eval \"hl.dispatch(hl.dsp.window.move({ workspace = '" + stashWs + "', window = 'address:$fs_addr', follow = false }))\" >/dev/null 2>&1 || true; " +
       "fi; " +
       "hyprctl eval \"hl.dispatch(hl.dsp.focus({ workspace = '" + slot + "' }))\" >/dev/null 2>&1 || true; " +
       "if [ -n \"$fs_addr\" ] && [ -n \"$orig_ws\" ]; then " +


### PR DESCRIPTION
- Introduces dual-mode operation: global mode (all monitors switch together) and local mode (stock per-monitor behavior, fallback)
- Global mode is opt-in via toggle file ~/.local/state/omarchy/toggles/hypr/workspace-global.lua
- When global mode is active:
  - Bar shows stable 5 slots (AW1-AW5) instead of raw Hyprland WS IDs
  - Clicking a slot calls omarchy-hyprland-workspace-global-switch (handles workspace theft and fullscreen=2 blocking)
  - All three monitor bars agree on focused/occupied state
- When global mode is absent:
  - Falls back to stock omarchy behavior (per-monitor focus, raw WS IDs)
  - No breaking changes to existing installs
- Each monitor owns exclusive workspace range (offset = monitor_id * 10):
  - Monitor 0: WS 1-10
  - Monitor 1: WS 11-20
  - Monitor 2: WS 21-30

Related to discussion #8412 (linked workspaces for multi-monitor setups)