### PR TITLE
Cover the lid switch in the update sleep inhibitor

### DIFF
--- a/bin/omarchy-update-stay-awake
+++ b/bin/omarchy-update-stay-awake
@@ -101,14 +101,14 @@ start() {
 
     if [[ -n ${OMARCHY_UPDATE_LOCK_FD:-} ]]; then
       "${inhibit_runner[@]}" systemd-inhibit \
-        --what=sleep:idle \
+        --what=sleep:idle:handle-lid-switch \
         --who=omarchy-update \
         --why="Omarchy update in progress" \
         --mode=block \
         sleep infinity >/dev/null 2>&1 {OMARCHY_UPDATE_LOCK_FD}>&- &
     else
       "${inhibit_runner[@]}" systemd-inhibit \
-        --what=sleep:idle \
+        --what=sleep:idle:handle-lid-switch \
         --who=omarchy-update \
         --why="Omarchy update in progress" \
         --mode=block \

--- a/test/shell.d/update-lock-test.sh
+++ b/test/shell.d/update-lock-test.sh
@@ -151,6 +151,14 @@ SH
   [[ ! -e $pkexec_marker ]] || fail "terminal sleep inhibition does not use pkexec"
   run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
   pass "terminal updates use sudo instead of Polkit for sleep inhibition"
+
+  # The sudo stub logs the whole systemd-inhibit argv, which is the only place
+  # the inhibitor's --what mask is observable. sleep and idle are high-level
+  # locks that logind ignores for the lid switch by default, so without
+  # handle-lid-switch closing the lid suspends the machine mid-update.
+  grep -q -- '--what=sleep:idle:handle-lid-switch' "$sudo_log" ||
+    fail "update sleep inhibition covers the lid switch"
+  pass "update sleep inhibition covers the lid switch"
 fi
 
 # Update-owned Stay Awake state must be cleared before the restart helper can


### PR DESCRIPTION

`omarchy-update-stay-awake` blocks sleep for the length of an update, but the inhibitor asks for `--what=sleep:idle`. Both of those are high-level inhibitor locks, and `logind.conf(5)` says the lid switch ignores high-level locks by default:

> Controls whether actions that systemd-logind takes when the power, reboot and sleep keys and the lid switch are triggered are subject to high-level inhibitor locks ("shutdown", "reboot", "sleep", "idle"). Low level inhibitor locks ("handle-power-key", "handle-suspend-key", "handle-hibernate-key", "handle-lid-switch", "handle-reboot-key"), are always honored, irrespective of this setting.
>
> [...] `LidSwitchIgnoreInhibited=` defaults to "yes". This means [...] the lid switch does not respect suspend blockers by default.

The two drop-ins in `etc/systemd/logind.conf.d/` don't set `LidSwitchIgnoreInhibited`, so the default applies and closing the laptop during `omarchy update` suspends the machine regardless of the block inhibitor. In the worst case that happens in the middle of a pacman transaction.

Adding `handle-lid-switch` to the mask fixes it at the call site, since low-level locks are honored whatever `LidSwitchIgnoreInhibited` is set to. I preferred that over shipping a drop-in with `LidSwitchIgnoreInhibited=no`, which would change lid behavior for every application on the system instead of just this inhibitor.

Nothing pinned the mask, so I added an assertion to `update-lock-test.sh`. The sudo stub there already logs the whole `systemd-inhibit` argv, which is the only place the mask is visible from a test. Reverting the one-word change makes the assertion fail.

`./test/all` gives 3156 passing. The four failures are unrelated and reproduce on a clean checkout of `quattro`: three want an `omarchy-pkgs` checkout I don't have locally, and one is `runtime-smoke-test.sh` counting IPC handlers on a two-screen setup.

#9467 rewrites this file and edits these exact `systemd-inhibit` invocations, but carries `--what=sleep:idle` through unchanged, so the same fix applies on that branch.

Closes #10203