### PR TITLE
fix: pull Broadcom Wi-Fi from broadcom-wl-dkms

### DIFF
--- a/install/hardware/fix-bcm43xx.sh
+++ b/install/hardware/fix-bcm43xx.sh
@@ -6,5 +6,5 @@ pci_info=$(lspci -nn)
 
 if (echo "$pci_info" | grep -q "14e4:43a0" || echo "$pci_info" | grep -q "14e4:4331"); then
   echo "BCM4360 / BCM4331 detected"
-  omarchy-pkg-add broadcom-wl dkms linux-headers
+  omarchy-pkg-add broadcom-wl-dkms dkms linux-headers
 fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -5,7 +5,7 @@ autoconf-archive
 asusctl
 base
 base-devel
-broadcom-wl
+broadcom-wl-dkms
 btrfs-progs
 dkms
 egl-wayland


### PR DESCRIPTION
Hello!

Arch dropped broadcom-wl from extra, which broke ISO offline package download. The DKMS package is the replacement, including for BCM4360/BCM4331 setups.

Thanks!