### PR TITLE
Fix theme switcher listing a theme twice when a user override has no preview

### DIFF
--- a/bin/omarchy-theme-switcher
+++ b/bin/omarchy-theme-switcher
@@ -43,7 +43,16 @@ add_theme_preview() {
   extension="${extension,,}"
 
   [[ -n $preview ]] || return
-  [[ -e $preview_dir/$theme_name.$extension ]] && return
+
+  # A theme can be found under the user directory and again under the Omarchy
+  # directory, and the two previews need not share an extension: an override
+  # that only adds backgrounds/ resolves to a .jpg, while the stock theme ships
+  # preview.png. Compare on the theme name alone so the user entry wins and the
+  # theme is listed once.
+  local existing
+  for existing in "$preview_dir/$theme_name".*; do
+    [[ -e $existing ]] && return
+  done
 
   ln -s "$preview" "$preview_dir/$theme_name.$extension"
 }


### PR DESCRIPTION
Fixes #10209

### Problem

`omarchy-theme-switcher` enumerates user themes and then Omarchy themes with no
de-duplication between the two loops; `add_theme_preview` is what stops a theme
being added twice. Its guard compares **name + extension**:

```bash
[[ -e $preview_dir/$theme_name.$extension ]] && return
```

A user override at `~/.config/omarchy/themes/<slug>/` containing only
`backgrounds/` — the shape `docs/theming.md` recommends — has no `preview.*`, so
`find_preview` falls back to the first background image, typically `.jpg`. The
stock pass then finds `preview.png`. The extensions differ, the guard misses, and
the theme is listed twice: once previewed by a wallpaper, once by its screenshot.

Every stock theme ships `preview.png` and most backgrounds are `.jpg`, so this
affects effectively any override that includes backgrounds.

### Change

Compare on the theme name alone. The user directory is still enumerated first, so
a user preview continues to take precedence; only the duplicate is suppressed.

### Verification

On omarchy 4.0.2-1 with a `white` override containing one `.jpg` background,
running both versions against isolated `XDG_CACHE_HOME` directories:

| | preview entries | `white` entries |
|---|---|---|
| before | 26 | `white.jpg`, `white.png` |
| after | 25 | `white.jpg` |

The set of themes is unchanged — only the duplicate is removed — and a theme with
its own `preview.png` in the override still uses it.
