### PR TITLE
Unload BCM4377 Wi-Fi around sleep on T2 Macs

### DIFF
--- a/bin/omarchy-hw-t2-bcm4377
+++ b/bin/omarchy-hw-t2-bcm4377
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# omarchy:summary=Detect a T2 Mac with BCM4377b Wi-Fi
+# omarchy:hidden=true
+
+# BCM4377b (14e4:4488) times out entering PCI D3 and aborts suspend.
+# BCM4364 (14e4:4464) is the opposite: brcmfmac must stay bound.
+# Drain lspci fully; grep -q would SIGPIPE and look like "no such hardware" (#6608).
+pci=$(lspci -nn 2>/dev/null || true)
+
+if [[ $pci != *106b:1801* && $pci != *106b:1802* ]]; then
+  exit 1
+fi
+
+if [[ $pci == *14e4:4464* ]]; then
+  exit 1
+fi
+
+[[ $pci == *14e4:4488* ]]

--- a/bin/omarchy-t2-bcm4377-sleep
+++ b/bin/omarchy-t2-bcm4377-sleep
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+# omarchy:summary=Unload BCM4377 Wi-Fi around sleep on T2 Macs
+# omarchy:args=pre|post
+# omarchy:group=hw
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# brcmfmac times out entering PCI D3 (pci_pm_suspend returns -5 / EIO).
+# The kernel then aborts both deep (S3) and s2idle, systemd-suspend fails,
+# and logind retries about every 20 seconds with the lid closed.
+#
+# Invoked by omarchy-t2-bcm4377-sleep.service as: omarchy-t2-bcm4377-sleep pre|post
+# Do not use set -e: a failing nmcli on resume must not abort the rest of post.
+
+set -u
+
+export PATH="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
+
+STATE=/run/omarchy-t2-bcm4377-sleep.state
+TAG=omarchy-t2-bcm4377-sleep
+
+log() {
+  logger -t "$TAG" "$*" 2>/dev/null || true
+  printf '%s\n' "$*"
+}
+
+wifi_iface() {
+  local d driver
+  for d in /sys/class/net/*; do
+    [[ -e $d/device/driver ]] || continue
+    driver=$(basename "$(readlink -f "$d/device/driver")")
+    if [[ $driver == brcmfmac ]]; then
+      basename "$d"
+      return 0
+    fi
+  done
+  return 1
+}
+
+module_loaded() {
+  grep -q "^$1 " /proc/modules
+}
+
+release_fan() {
+  systemctl stop t2fanrd.service 2>/dev/null || true
+  local f
+  while IFS= read -r -d '' f; do
+    echo 0 >"$f" 2>/dev/null || true
+  done < <(find /sys/devices -name 'fan*_manual' -print0 2>/dev/null)
+}
+
+restore_fan() {
+  if systemctl list-unit-files t2fanrd.service >/dev/null 2>&1; then
+    systemctl restart t2fanrd.service 2>/dev/null ||
+      systemctl start t2fanrd.service 2>/dev/null || true
+  fi
+}
+
+unload_brcmfmac() {
+  local i
+  for ((i = 1; i <= 5; i++)); do
+    if ! module_loaded brcmfmac; then
+      log "brcmfmac already unloaded"
+      return 0
+    fi
+    # wcc is a plugin that holds brcmfmac; it is not present on every kernel.
+    if module_loaded brcmfmac_wcc; then
+      modprobe -r brcmfmac_wcc 2>/dev/null || true
+    fi
+    if modprobe -r brcmfmac 2>/dev/null; then
+      log "unloaded brcmfmac"
+      return 0
+    fi
+    log "unload attempt $i failed, retrying"
+    sleep 1
+  done
+  log "failed to unload brcmfmac"
+  return 1
+}
+
+unload() {
+  local iface="" conn=""
+  rm -f "$STATE"
+  release_fan
+
+  iface=$(wifi_iface || true)
+  if [[ -n ${iface:-} ]] && command -v nmcli >/dev/null 2>&1; then
+    conn=$(nmcli -t -f NAME,DEVICE connection show --active 2>/dev/null |
+      awk -F: -v i="$iface" '$2 == i { print $1; exit }')
+    {
+      printf 'iface=%q\n' "$iface"
+      printf 'conn=%q\n' "$conn"
+    } >"$STATE"
+    if [[ -n ${conn:-} ]]; then
+      nmcli device disconnect "$iface" >/dev/null 2>&1 || true
+      log "disconnected $iface (conn=$conn)"
+    else
+      log "wifi iface $iface has no active connection"
+    fi
+  fi
+
+  # Let firmware finish the disconnect before the driver is yanked.
+  sleep 1
+  unload_brcmfmac
+}
+
+reload() {
+  restore_fan
+
+  if ! modprobe brcmfmac; then
+    log "failed to load brcmfmac"
+    return 1
+  fi
+  modprobe brcmfmac_wcc 2>/dev/null || true
+  log "loaded brcmfmac"
+
+  local iface="" conn=""
+  if [[ -f $STATE ]]; then
+    # shellcheck disable=SC1090
+    source "$STATE"
+    rm -f "$STATE"
+  fi
+
+  local i
+  for ((i = 1; i <= 20; i++)); do
+    iface=${iface:-$(wifi_iface || true)}
+    [[ -n ${iface:-} ]] && break
+    sleep 0.5
+  done
+
+  if [[ -n ${iface:-} ]] && command -v nmcli >/dev/null 2>&1; then
+    if [[ -n ${conn:-} ]] && nmcli connection up "$conn" >/dev/null 2>&1; then
+      log "restored connection $conn"
+    elif nmcli device connect "$iface" >/dev/null 2>&1; then
+      log "connected $iface"
+    else
+      log "NetworkManager will autoconnect $iface"
+    fi
+  fi
+}
+
+case "${1:-}" in
+  pre | post) ;;
+  *)
+    echo "usage: $0 pre|post" >&2
+    exit 2
+    ;;
+esac
+
+if ! omarchy-hw-t2-bcm4377; then
+  exit 0
+fi
+
+case "$1" in
+  pre) unload ;;
+  post) reload ;;
+esac

--- a/bin/omarchy-t2-bcm4377-sleep
+++ b/bin/omarchy-t2-bcm4377-sleep
@@ -6,153 +6,277 @@
 # omarchy:hidden=true
 # omarchy:requires-sudo=true
 
-# brcmfmac times out entering PCI D3 (pci_pm_suspend returns -5 / EIO).
-# The kernel then aborts both deep (S3) and s2idle, systemd-suspend fails,
-# and logind retries about every 20 seconds with the lid closed.
-#
-# Invoked by omarchy-t2-bcm4377-sleep.service as: omarchy-t2-bcm4377-sleep pre|post
-# Do not use set -e: a failing nmcli on resume must not abort the rest of post.
+# BCM4377b firmware does not acknowledge the PCI D3 request on current T2
+# kernels. Keep this helper reversible: a failed preparation must restore the
+# state it changed, and resume must restore only what preparation removed.
 
 set -u
 
 export PATH="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
 
-STATE=/run/omarchy-t2-bcm4377-sleep.state
-TAG=omarchy-t2-bcm4377-sleep
+STATE="${OMARCHY_T2_BCM4377_STATE:-/run/omarchy-t2-bcm4377-sleep.state}"
+PROC_MODULES="${OMARCHY_T2_BCM4377_PROC_MODULES:-/proc/modules}"
+SYS_CLASS_NET="${OMARCHY_T2_BCM4377_SYS_CLASS_NET:-/sys/class/net}"
+T2BCE_MODULE="${OMARCHY_T2_BCM4377_T2BCE_MODULE:-/sys/module/t2bce_core}"
+PM_ASYNC="${OMARCHY_T2_BCM4377_PM_ASYNC:-/sys/power/pm_async}"
+
+prepared=0
+brcmfmac_was_loaded=0
+wcc_was_loaded=0
+wifi_disconnected=0
+wifi_iface_before=""
+wifi_uuid=""
+
+reset_state_vars() {
+  prepared=0
+  brcmfmac_was_loaded=0
+  wcc_was_loaded=0
+  wifi_disconnected=0
+  wifi_iface_before=""
+  wifi_uuid=""
+}
 
 log() {
-  logger -t "$TAG" "$*" 2>/dev/null || true
   printf '%s\n' "$*"
+}
+
+module_loaded() {
+  grep -q "^$1 " "$PROC_MODULES"
 }
 
 wifi_iface() {
   local d driver
-  for d in /sys/class/net/*; do
+
+  for d in "$SYS_CLASS_NET"/*; do
     [[ -e $d/device/driver ]] || continue
     driver=$(basename "$(readlink -f "$d/device/driver")")
-    if [[ $driver == brcmfmac ]]; then
+    if [[ $driver == "brcmfmac" ]]; then
       basename "$d"
       return 0
     fi
   done
+
   return 1
 }
 
-module_loaded() {
-  grep -q "^$1 " /proc/modules
+runtime_supports_deep_sleep() {
+  [[ -d $T2BCE_MODULE ]] || return 1
+  [[ -r $PM_ASYNC ]] || return 1
+  [[ $(<"$PM_ASYNC") == "0" ]]
 }
 
-release_fan() {
-  systemctl stop t2fanrd.service 2>/dev/null || true
-  local f
-  while IFS= read -r -d '' f; do
-    echo 0 >"$f" 2>/dev/null || true
-  done < <(find /sys/devices -name 'fan*_manual' -print0 2>/dev/null)
-}
+save_state() {
+  local state_tmp="${STATE}.$$"
 
-restore_fan() {
-  if systemctl list-unit-files t2fanrd.service >/dev/null 2>&1; then
-    systemctl restart t2fanrd.service 2>/dev/null ||
-      systemctl start t2fanrd.service 2>/dev/null || true
+  umask 077
+  if ! {
+    printf '%s\n' "$prepared"
+    printf '%s\n' "$brcmfmac_was_loaded"
+    printf '%s\n' "$wcc_was_loaded"
+    printf '%s\n' "$wifi_disconnected"
+    printf '%s\n' "$wifi_iface_before"
+    printf '%s\n' "$wifi_uuid"
+  } >"$state_tmp"; then
+    rm -f "$state_tmp"
+    return 1
   fi
+
+  if ! mv "$state_tmp" "$STATE"; then
+    rm -f "$state_tmp"
+    return 1
+  fi
+}
+
+load_state() {
+  local extra=""
+
+  [[ -f $STATE ]] || return 1
+
+  {
+    IFS= read -r prepared &&
+      IFS= read -r brcmfmac_was_loaded &&
+      IFS= read -r wcc_was_loaded &&
+      IFS= read -r wifi_disconnected &&
+      IFS= read -r wifi_iface_before &&
+      IFS= read -r wifi_uuid &&
+      ! IFS= read -r extra
+  } <"$STATE" || return 1
+
+  [[ $prepared == "1" ]] || return 1
+  [[ $brcmfmac_was_loaded == "0" || $brcmfmac_was_loaded == "1" ]] || return 1
+  [[ $wcc_was_loaded == "0" || $wcc_was_loaded == "1" ]] || return 1
+  [[ $wifi_disconnected == "0" || $wifi_disconnected == "1" ]] || return 1
+}
+
+wait_for_wifi_iface() {
+  local i iface=""
+
+  for ((i = 1; i <= 20; i++)); do
+    iface=$(wifi_iface || true)
+    if [[ -n $iface ]]; then
+      printf '%s\n' "$iface"
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  return 1
+}
+
+restore() {
+  local iface="" status=0
+
+  if ! load_state; then
+    log "no prepared BCM4377 state to restore"
+    return 0
+  fi
+
+  if (( brcmfmac_was_loaded )) && ! module_loaded brcmfmac; then
+    if modprobe brcmfmac; then
+      log "loaded brcmfmac"
+    else
+      log "failed to load brcmfmac"
+      status=1
+    fi
+  fi
+
+  if (( wcc_was_loaded )) && module_loaded brcmfmac && ! module_loaded brcmfmac_wcc; then
+    if modprobe brcmfmac_wcc; then
+      log "loaded brcmfmac_wcc"
+    else
+      log "failed to load brcmfmac_wcc"
+      status=1
+    fi
+  fi
+
+  if (( brcmfmac_was_loaded )) && module_loaded brcmfmac; then
+    iface=$(wait_for_wifi_iface || true)
+    if [[ -z $iface ]]; then
+      log "brcmfmac loaded but its network interface did not appear"
+      status=1
+    fi
+  fi
+
+  if (( wifi_disconnected )) &&
+    [[ -n $wifi_uuid && -n $iface ]] &&
+    omarchy-cmd-present nmcli; then
+    if nmcli --wait 0 connection up uuid "$wifi_uuid" ifname "$iface" >/dev/null 2>&1; then
+      log "requested NetworkManager connection $wifi_uuid on $iface"
+    else
+      log "NetworkManager could not queue connection $wifi_uuid; autoconnect may retry"
+    fi
+  fi
+
+  if (( status == 0 )); then
+    rm -f "$STATE"
+  fi
+
+  return $status
+}
+
+rollback() {
+  log "rolling back incomplete BCM4377 sleep preparation"
+  restore || true
 }
 
 unload_brcmfmac() {
   local i
+
+  if (( wcc_was_loaded )) && module_loaded brcmfmac_wcc; then
+    if ! modprobe -r brcmfmac_wcc; then
+      log "failed to unload brcmfmac_wcc"
+      return 1
+    fi
+  fi
+
   for ((i = 1; i <= 5; i++)); do
     if ! module_loaded brcmfmac; then
-      log "brcmfmac already unloaded"
-      return 0
-    fi
-    # wcc is a plugin that holds brcmfmac; it is not present on every kernel.
-    if module_loaded brcmfmac_wcc; then
-      modprobe -r brcmfmac_wcc 2>/dev/null || true
-    fi
-    if modprobe -r brcmfmac 2>/dev/null; then
       log "unloaded brcmfmac"
       return 0
     fi
-    log "unload attempt $i failed, retrying"
-    sleep 1
+    if modprobe -r brcmfmac; then
+      log "unloaded brcmfmac"
+      return 0
+    fi
+    if (( i < 5 )); then
+      log "unload attempt $i failed, retrying"
+      sleep 1
+    fi
   done
+
   log "failed to unload brcmfmac"
   return 1
 }
 
-unload() {
-  local iface="" conn=""
-  rm -f "$STATE"
-  release_fan
+prepare() {
+  local active=""
 
-  iface=$(wifi_iface || true)
-  if [[ -n ${iface:-} ]] && command -v nmcli >/dev/null 2>&1; then
-    conn=$(nmcli -t -f NAME,DEVICE connection show --active 2>/dev/null |
-      awk -F: -v i="$iface" '$2 == i { print $1; exit }')
-    {
-      printf 'iface=%q\n' "$iface"
-      printf 'conn=%q\n' "$conn"
-    } >"$STATE"
-    if [[ -n ${conn:-} ]]; then
-      nmcli device disconnect "$iface" >/dev/null 2>&1 || true
-      log "disconnected $iface (conn=$conn)"
-    else
-      log "wifi iface $iface has no active connection"
-    fi
+  if [[ -e $STATE ]]; then
+    log "restoring stale BCM4377 state before a new sleep attempt"
+    restore || return 1
+  fi
+  reset_state_vars
+
+  if ! runtime_supports_deep_sleep; then
+    log "skipping BCM4377 unload: requires t2bce_core with pm_async=0"
+    return 0
   fi
 
-  # Let firmware finish the disconnect before the driver is yanked.
-  sleep 1
-  unload_brcmfmac
-}
+  if module_loaded brcmfmac; then
+    brcmfmac_was_loaded=1
+  else
+    log "brcmfmac was already unloaded"
+    return 0
+  fi
+  module_loaded brcmfmac_wcc && wcc_was_loaded=1
 
-reload() {
-  restore_fan
+  wifi_iface_before=$(wifi_iface || true)
+  if [[ -n $wifi_iface_before ]] && omarchy-cmd-present nmcli; then
+    active=$(nmcli -t -f UUID,DEVICE connection show --active 2>/dev/null || true)
+    wifi_uuid=$(awk -F: -v iface="$wifi_iface_before" '$2 == iface { print $1; exit }' <<<"$active")
+  fi
 
-  if ! modprobe brcmfmac; then
-    log "failed to load brcmfmac"
+  prepared=1
+  if ! save_state; then
+    log "failed to save BCM4377 sleep state"
     return 1
   fi
-  modprobe brcmfmac_wcc 2>/dev/null || true
-  log "loaded brcmfmac"
 
-  local iface="" conn=""
-  if [[ -f $STATE ]]; then
-    # shellcheck disable=SC1090
-    source "$STATE"
-    rm -f "$STATE"
+  if [[ -n $wifi_uuid ]]; then
+    if nmcli --wait 5 device disconnect "$wifi_iface_before" >/dev/null 2>&1; then
+      wifi_disconnected=1
+      if ! save_state; then
+        log "failed to record disconnected Wi-Fi state"
+        nmcli --wait 0 connection up uuid "$wifi_uuid" \
+          ifname "$wifi_iface_before" >/dev/null 2>&1 || true
+        rm -f "$STATE"
+        return 1
+      fi
+      log "disconnected $wifi_iface_before (uuid=$wifi_uuid)"
+    fi
   fi
 
-  local i
-  for ((i = 1; i <= 20; i++)); do
-    iface=${iface:-$(wifi_iface || true)}
-    [[ -n ${iface:-} ]] && break
-    sleep 0.5
-  done
+  # Give firmware a bounded interval to finish NetworkManager's disconnect or
+  # its own PrepareForSleep transition before removing the driver.
+  sleep 1
 
-  if [[ -n ${iface:-} ]] && command -v nmcli >/dev/null 2>&1; then
-    if [[ -n ${conn:-} ]] && nmcli connection up "$conn" >/dev/null 2>&1; then
-      log "restored connection $conn"
-    elif nmcli device connect "$iface" >/dev/null 2>&1; then
-      log "connected $iface"
-    else
-      log "NetworkManager will autoconnect $iface"
-    fi
+  if ! unload_brcmfmac; then
+    rollback
+    return 1
   fi
 }
 
 case "${1:-}" in
-  pre | post) ;;
+  pre)
+    if omarchy-hw-t2-bcm4377; then
+      prepare
+    fi
+    ;;
+  post)
+    restore
+    ;;
   *)
     echo "usage: $0 pre|post" >&2
     exit 2
     ;;
-esac
-
-if ! omarchy-hw-t2-bcm4377; then
-  exit 0
-fi
-
-case "$1" in
-  pre) unload ;;
-  post) reload ;;
 esac

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -38,6 +38,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-bcm4377.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"

--- a/install/hardware/apple/fix-suspend-bcm4377.sh
+++ b/install/hardware/apple/fix-suspend-bcm4377.sh
@@ -1,0 +1,32 @@
+# Unload BCM4377b Wi-Fi around sleep so T2 Macs actually reach S3.
+#
+# brcmfmac times out entering PCI D3 (-EIO). The kernel aborts suspend,
+# logind retries, and a lid-closed machine stays awake (~10 W).
+#
+# Only BCM4377b (14e4:4488). BCM4364 (14e4:4464) must keep brcmfmac bound.
+# Do not change mem_sleep_default; t2bce + pm_async=off reaches real S3
+# once this chip is out of the way. Do not enable --now: that would drop
+# Wi-Fi until the next resume.
+#
+# Keep /etc/modprobe.d/brcmfmac.conf owned by fix-brcmfmac-supplicant.sh.
+
+if omarchy-hw-t2-bcm4377; then
+  echo "Detected T2 Mac with BCM4377b. Unloading Wi-Fi around sleep."
+
+  unit="${OMARCHY_T2_BCM4377_UNIT:-/etc/systemd/system/omarchy-t2-bcm4377-sleep.service}"
+  src="${OMARCHY_INSTALL:-$OMARCHY_PATH/install}/hardware/apple/omarchy-t2-bcm4377-sleep.service"
+  install -Dm644 "$src" "$unit"
+  systemctl daemon-reload
+  systemctl enable omarchy-t2-bcm4377-sleep.service
+
+  # Replace a hand-installed t2-bcm4377-sleep.service if one is still present.
+  legacy_unit="${OMARCHY_T2_BCM4377_LEGACY_UNIT:-/etc/systemd/system/t2-bcm4377-sleep.service}"
+  legacy_script="${OMARCHY_T2_BCM4377_LEGACY_SCRIPT:-/usr/local/sbin/t2-bcm4377-sleep.sh}"
+  legacy_fan_lib="${OMARCHY_T2_BCM4377_LEGACY_FAN_LIB:-/usr/lib/systemd/system-sleep/t2-fan.sh}"
+  legacy_fan_etc="${OMARCHY_T2_BCM4377_LEGACY_FAN_ETC:-/etc/systemd/system-sleep/t2-fan.sh}"
+  if [[ -f $legacy_unit ]]; then
+    systemctl disable t2-bcm4377-sleep.service 2>/dev/null || true
+    rm -f "$legacy_unit" "$legacy_script" "$legacy_fan_lib" "$legacy_fan_etc"
+    systemctl daemon-reload
+  fi
+fi

--- a/install/hardware/apple/fix-suspend-bcm4377.sh
+++ b/install/hardware/apple/fix-suspend-bcm4377.sh
@@ -15,18 +15,20 @@ if omarchy-hw-t2-bcm4377; then
 
   unit="${OMARCHY_T2_BCM4377_UNIT:-/etc/systemd/system/omarchy-t2-bcm4377-sleep.service}"
   src="${OMARCHY_INSTALL:-$OMARCHY_PATH/install}/hardware/apple/omarchy-t2-bcm4377-sleep.service"
+  legacy_unit="${OMARCHY_T2_BCM4377_LEGACY_UNIT:-/etc/systemd/system/t2-bcm4377-sleep.service}"
+
   install -Dm644 "$src" "$unit"
   systemctl daemon-reload
-  systemctl enable omarchy-t2-bcm4377-sleep.service
 
-  # Replace a hand-installed t2-bcm4377-sleep.service if one is still present.
-  legacy_unit="${OMARCHY_T2_BCM4377_LEGACY_UNIT:-/etc/systemd/system/t2-bcm4377-sleep.service}"
-  legacy_script="${OMARCHY_T2_BCM4377_LEGACY_SCRIPT:-/usr/local/sbin/t2-bcm4377-sleep.sh}"
-  legacy_fan_lib="${OMARCHY_T2_BCM4377_LEGACY_FAN_LIB:-/usr/lib/systemd/system-sleep/t2-fan.sh}"
-  legacy_fan_etc="${OMARCHY_T2_BCM4377_LEGACY_FAN_ETC:-/etc/systemd/system-sleep/t2-fan.sh}"
-  if [[ -f $legacy_unit ]]; then
-    systemctl disable t2-bcm4377-sleep.service 2>/dev/null || true
-    rm -f "$legacy_unit" "$legacy_script" "$legacy_fan_lib" "$legacy_fan_etc"
-    systemctl daemon-reload
+  # Avoid running the known standalone Wi-Fi workaround alongside Omarchy's
+  # service. Preserve its administrator-owned unit, helper, and any independent
+  # fan hook so this installer never deletes local policy.
+  if [[ -f $legacy_unit ]] &&
+    grep -Fqx 'ExecStart=/usr/local/sbin/t2-bcm4377-sleep.sh pre' "$legacy_unit" &&
+    grep -Fqx 'ExecStop=/usr/local/sbin/t2-bcm4377-sleep.sh post' "$legacy_unit"; then
+    systemctl disable t2-bcm4377-sleep.service
+    echo "Disabled the superseded t2-bcm4377-sleep.service; its files were preserved."
   fi
+
+  systemctl enable omarchy-t2-bcm4377-sleep.service
 fi

--- a/install/hardware/apple/omarchy-t2-bcm4377-sleep.service
+++ b/install/hardware/apple/omarchy-t2-bcm4377-sleep.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Unload BCM4377 Wi-Fi around sleep (T2 Mac)
 Documentation=https://github.com/omacom/omarchy/discussions/4695
+DefaultDependencies=no
 Before=sleep.target
 StopWhenUnneeded=yes
 
@@ -11,7 +12,9 @@ TimeoutStartSec=30
 TimeoutStopSec=30
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart=/usr/bin/omarchy-t2-bcm4377-sleep pre
-ExecStop=/usr/bin/omarchy-t2-bcm4377-sleep post
+# ExecStopPost also runs after a failed or timed-out ExecStart, so partial
+# preparation is rolled back before systemd completes the failed start job.
+ExecStopPost=/usr/bin/omarchy-t2-bcm4377-sleep post
 
 [Install]
-WantedBy=sleep.target
+RequiredBy=sleep.target

--- a/install/hardware/apple/omarchy-t2-bcm4377-sleep.service
+++ b/install/hardware/apple/omarchy-t2-bcm4377-sleep.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Unload BCM4377 Wi-Fi around sleep (T2 Mac)
+Documentation=https://github.com/omacom/omarchy/discussions/4695
+Before=sleep.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutStartSec=30
+TimeoutStopSec=30
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/usr/bin/omarchy-t2-bcm4377-sleep pre
+ExecStop=/usr/bin/omarchy-t2-bcm4377-sleep post
+
+[Install]
+WantedBy=sleep.target

--- a/migrations/1788544020.sh
+++ b/migrations/1788544020.sh
@@ -1,0 +1,29 @@
+echo "Unload BCM4377 Wi-Fi around sleep on T2 Macs"
+
+# Existing Quattro installs already have mem_sleep_default=deep and t2bce.
+# BCM4377b still aborts that S3 attempt. Install the sleep oneshot only when
+# the chip is present; leave BCM4364 and non-T2 machines alone. Do not move
+# t2bce machines onto s2idle.
+
+if ! omarchy-hw-t2-bcm4377; then
+  exit 0
+fi
+
+unit="${OMARCHY_T2_BCM4377_UNIT:-/etc/systemd/system/omarchy-t2-bcm4377-sleep.service}"
+src="${OMARCHY_PATH}/install/hardware/apple/omarchy-t2-bcm4377-sleep.service"
+legacy_unit="${OMARCHY_T2_BCM4377_LEGACY_UNIT:-/etc/systemd/system/t2-bcm4377-sleep.service}"
+legacy_script="${OMARCHY_T2_BCM4377_LEGACY_SCRIPT:-/usr/local/sbin/t2-bcm4377-sleep.sh}"
+legacy_fan_lib="${OMARCHY_T2_BCM4377_LEGACY_FAN_LIB:-/usr/lib/systemd/system-sleep/t2-fan.sh}"
+legacy_fan_etc="${OMARCHY_T2_BCM4377_LEGACY_FAN_ETC:-/etc/systemd/system-sleep/t2-fan.sh}"
+
+if [[ ! -f $unit ]]; then
+  sudo install -Dm644 "$src" "$unit"
+  sudo systemctl daemon-reload
+  sudo systemctl enable omarchy-t2-bcm4377-sleep.service
+fi
+
+if [[ -f $legacy_unit ]]; then
+  sudo systemctl disable t2-bcm4377-sleep.service 2>/dev/null || true
+  sudo rm -f "$legacy_unit" "$legacy_script" "$legacy_fan_lib" "$legacy_fan_etc"
+  sudo systemctl daemon-reload
+fi

--- a/migrations/1788544020.sh
+++ b/migrations/1788544020.sh
@@ -5,6 +5,10 @@ echo "Unload BCM4377 Wi-Fi around sleep on T2 Macs"
 # the chip is present; leave BCM4364 and non-T2 machines alone. Do not move
 # t2bce machines onto s2idle.
 
+machine_marker="${OMARCHY_T2_BCM4377_MARKER:-/var/lib/omarchy/migrations/1788544020}"
+
+[[ ! -e $machine_marker ]] || exit 0
+
 if ! omarchy-hw-t2-bcm4377; then
   exit 0
 fi
@@ -12,18 +16,18 @@ fi
 unit="${OMARCHY_T2_BCM4377_UNIT:-/etc/systemd/system/omarchy-t2-bcm4377-sleep.service}"
 src="${OMARCHY_PATH}/install/hardware/apple/omarchy-t2-bcm4377-sleep.service"
 legacy_unit="${OMARCHY_T2_BCM4377_LEGACY_UNIT:-/etc/systemd/system/t2-bcm4377-sleep.service}"
-legacy_script="${OMARCHY_T2_BCM4377_LEGACY_SCRIPT:-/usr/local/sbin/t2-bcm4377-sleep.sh}"
-legacy_fan_lib="${OMARCHY_T2_BCM4377_LEGACY_FAN_LIB:-/usr/lib/systemd/system-sleep/t2-fan.sh}"
-legacy_fan_etc="${OMARCHY_T2_BCM4377_LEGACY_FAN_ETC:-/etc/systemd/system-sleep/t2-fan.sh}"
 
-if [[ ! -f $unit ]]; then
-  sudo install -Dm644 "$src" "$unit"
-  sudo systemctl daemon-reload
-  sudo systemctl enable omarchy-t2-bcm4377-sleep.service
+sudo install -Dm644 "$src" "$unit"
+sudo systemctl daemon-reload
+
+if [[ -f $legacy_unit ]] &&
+  grep -Fqx 'ExecStart=/usr/local/sbin/t2-bcm4377-sleep.sh pre' "$legacy_unit" &&
+  grep -Fqx 'ExecStop=/usr/local/sbin/t2-bcm4377-sleep.sh post' "$legacy_unit"; then
+  sudo systemctl disable t2-bcm4377-sleep.service
 fi
 
-if [[ -f $legacy_unit ]]; then
-  sudo systemctl disable t2-bcm4377-sleep.service 2>/dev/null || true
-  sudo rm -f "$legacy_unit" "$legacy_script" "$legacy_fan_lib" "$legacy_fan_etc"
-  sudo systemctl daemon-reload
-fi
+sudo systemctl enable omarchy-t2-bcm4377-sleep.service
+
+# Migrations are tracked per user, but this repair is machine-wide. Write the
+# root-owned marker last so interrupted installs retry and other users skip it.
+sudo install -Dm644 /dev/null "$machine_marker"

--- a/test/shell.d/t2-bcm4377-sleep-test.sh
+++ b/test/shell.d/t2-bcm4377-sleep-test.sh
@@ -36,13 +36,19 @@ grep -Fq 'systemctl enable omarchy-t2-bcm4377-sleep.service' "$leaf" ||
   fail "T2 BCM4377 setup enables the sleep service"
 ! grep -Eq 'systemctl enable --now' "$leaf" "$migration" ||
   fail "the sleep service is not started at install time"
+grep -Fq 'DefaultDependencies=no' "$unit_src" ||
+  fail "the sleep unit avoids the normal shutdown dependency graph"
 grep -Fq 'ExecStart=/usr/bin/omarchy-t2-bcm4377-sleep pre' "$unit_src" ||
   fail "the sleep unit unloads Wi-Fi before sleep.target"
-grep -Fq 'WantedBy=sleep.target' "$unit_src" ||
-  fail "the sleep unit is pulled in by every systemd sleep"
+grep -Fq 'ExecStopPost=/usr/bin/omarchy-t2-bcm4377-sleep post' "$unit_src" ||
+  fail "the sleep unit rolls back failed preparation and restores after sleep"
+grep -Fq 'RequiredBy=sleep.target' "$unit_src" ||
+  fail "failed Wi-Fi preparation prevents a broken sleep attempt"
 grep -Fq 'RemainAfterExit=yes' "$unit_src" ||
   fail "the sleep unit keeps Wi-Fi unloaded through suspend-then-hibernate"
-pass "BCM4377 sleep files keep deep S3 and only unload this chipset"
+! grep -Eqi 't2fan|fan._manual|release_fan|restore_fan' "$helper" ||
+  fail "the Wi-Fi workaround does not alter independent fan policy"
+pass "BCM4377 sleep files keep deep S3 and isolate the Wi-Fi workaround"
 
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
@@ -84,6 +90,12 @@ cat >"$stub_bin/systemctl" <<'SH'
 printf 'systemctl' >>"$TEST_LOG"
 printf '\t%s' "$@" >>"$TEST_LOG"
 printf '\n' >>"$TEST_LOG"
+
+if [[ ${1:-} == "enable" && ${2:-} == "omarchy-t2-bcm4377-sleep.service" ]] &&
+  [[ -n ${FAIL_ENABLE_ONCE_MARKER:-} && ! -e $FAIL_ENABLE_ONCE_MARKER ]]; then
+  touch "$FAIL_ENABLE_ONCE_MARKER"
+  exit 1
+fi
 SH
 
 cat >"$stub_bin/install" <<'SH'
@@ -102,6 +114,95 @@ dest=${2:-}
 if [[ -n $src && -n $dest ]]; then
   mkdir -p "$(dirname "$dest")"
   cp "$src" "$dest"
+fi
+SH
+
+cat >"$stub_bin/sleep" <<'SH'
+#!/bin/bash
+
+printf 'sleep' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+
+for cmd in "$@"; do
+  type -P "$cmd" >/dev/null || exit 1
+done
+SH
+
+cat >"$stub_bin/nmcli" <<'SH'
+#!/bin/bash
+
+printf 'nmcli' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+
+if [[ $* == "-t -f UUID,DEVICE connection show --active" ]]; then
+  if (( ${WIFI_ACTIVE:-1} )); then
+    printf '%s:%s\n' "${WIFI_UUID:-test-wifi-uuid}" "${WIFI_IFACE_BEFORE:-wlp2s0}"
+  fi
+elif [[ $* == "--wait 5 device disconnect ${WIFI_IFACE_BEFORE:-wlp2s0}" ]]; then
+  (( ! ${FAIL_NM_DISCONNECT:-0} ))
+elif [[ $* == "--wait 0 connection up uuid ${WIFI_UUID:-test-wifi-uuid}"* ]]; then
+  (( ! ${FAIL_NM_UP:-0} ))
+fi
+SH
+
+cat >"$stub_bin/modprobe" <<'SH'
+#!/bin/bash
+
+printf 'modprobe' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+
+module_add() {
+  grep -q "^$1 " "$TEST_MODULES" || printf '%s 0 0 - Live 0x0\n' "$1" >>"$TEST_MODULES"
+}
+
+module_remove() {
+  awk -v module="$1" '$1 != module' "$TEST_MODULES" >"$TEST_MODULES.tmp"
+  mv "$TEST_MODULES.tmp" "$TEST_MODULES"
+}
+
+remove_wifi_iface() {
+  local d driver
+  for d in "$TEST_SYS_CLASS_NET"/*; do
+    [[ -e $d/device/driver ]] || continue
+    driver=$(basename "$(readlink -f "$d/device/driver")")
+    [[ $driver == "brcmfmac" ]] || continue
+    rm -f "$d/device/driver"
+    rmdir "$d/device" "$d"
+  done
+}
+
+if [[ ${1:-} == "-r" ]]; then
+  case "${2:-}" in
+    brcmfmac_wcc)
+      (( ! ${FAIL_WCC_UNLOAD:-0} )) || exit 1
+      module_remove brcmfmac_wcc
+      ;;
+    brcmfmac)
+      (( ! ${FAIL_BRCM_UNLOAD:-0} )) || exit 1
+      module_remove brcmfmac
+      remove_wifi_iface
+      ;;
+  esac
+else
+  case "${1:-}" in
+    brcmfmac)
+      (( ! ${FAIL_BRCM_LOAD:-0} )) || exit 1
+      module_add brcmfmac
+      mkdir -p "$TEST_SYS_CLASS_NET/${WIFI_IFACE_AFTER:-wlan0}/device"
+      ln -sfn "$TEST_BRCM_DRIVER" "$TEST_SYS_CLASS_NET/${WIFI_IFACE_AFTER:-wlan0}/device/driver"
+      ;;
+    brcmfmac_wcc)
+      (( ! ${FAIL_WCC_LOAD:-0} )) || exit 1
+      module_add brcmfmac_wcc
+      ;;
+  esac
 fi
 SH
 
@@ -144,11 +245,122 @@ pass "sleep helper requires pre or post"
 PATH="$stub_bin:$PATH" T2_BCM4377=0 "$helper" pre >/dev/null
 pass "sleep helper no-ops on machines without BCM4377b"
 
+helper_root="$test_tmp/helper"
+state="$helper_root/run/omarchy-t2-bcm4377-sleep.state"
+modules="$helper_root/proc/modules"
+sys_class_net="$helper_root/sys/class/net"
+t2bce_module="$helper_root/sys/module/t2bce_core"
+pm_async="$helper_root/sys/power/pm_async"
+brcm_driver="$helper_root/drivers/brcmfmac"
+
+reset_helper_fixture() {
+  rm -rf "$helper_root"
+  mkdir -p "$helper_root/run" "$(dirname "$modules")" "$sys_class_net/wlp2s0/device" \
+    "$t2bce_module" "$(dirname "$pm_async")" "$brcm_driver"
+  printf 'brcmfmac 0 0 - Live 0x0\nbrcmfmac_wcc 0 0 - Live 0x0\n' >"$modules"
+  printf '0\n' >"$pm_async"
+  ln -s "$brcm_driver" "$sys_class_net/wlp2s0/device/driver"
+  : >"$calls"
+}
+
+run_helper() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    TEST_MODULES="$modules" \
+    TEST_SYS_CLASS_NET="$sys_class_net" \
+    TEST_BRCM_DRIVER="$brcm_driver" \
+    T2_BCM4377="${T2_BCM4377:-1}" \
+    WIFI_ACTIVE="${WIFI_ACTIVE:-1}" \
+    WIFI_IFACE_BEFORE="${WIFI_IFACE_BEFORE:-wlp2s0}" \
+    WIFI_IFACE_AFTER="${WIFI_IFACE_AFTER:-wlan0}" \
+    WIFI_UUID="${WIFI_UUID:-test-wifi-uuid}" \
+    FAIL_NM_DISCONNECT="${FAIL_NM_DISCONNECT:-0}" \
+    FAIL_NM_UP="${FAIL_NM_UP:-0}" \
+    FAIL_WCC_UNLOAD="${FAIL_WCC_UNLOAD:-0}" \
+    FAIL_BRCM_UNLOAD="${FAIL_BRCM_UNLOAD:-0}" \
+    FAIL_BRCM_LOAD="${FAIL_BRCM_LOAD:-0}" \
+    FAIL_WCC_LOAD="${FAIL_WCC_LOAD:-0}" \
+    OMARCHY_T2_BCM4377_STATE="$state" \
+    OMARCHY_T2_BCM4377_PROC_MODULES="$modules" \
+    OMARCHY_T2_BCM4377_SYS_CLASS_NET="$sys_class_net" \
+    OMARCHY_T2_BCM4377_T2BCE_MODULE="$t2bce_module" \
+    OMARCHY_T2_BCM4377_PM_ASYNC="$pm_async" \
+    "$helper" "$@"
+}
+
+reset_helper_fixture
+run_helper pre >/dev/null
+[[ -f $state ]] || fail "pre records exactly what it changed"
+[[ $(stat -c %a "$state") == "600" ]] || fail "sleep state is root-private"
+! grep -q '^brcmfmac ' "$modules" || fail "pre unloads brcmfmac"
+! grep -q '^brcmfmac_wcc ' "$modules" || fail "pre unloads the brcmfmac_wcc holder"
+grep -Fqx $'nmcli\t--wait\t5\tdevice\tdisconnect\twlp2s0' "$calls" ||
+  fail "pre bounds NetworkManager disconnect time"
+grep -Fqx $'modprobe\t-r\tbrcmfmac_wcc' "$calls" || fail "pre unloads wcc first"
+grep -Fqx $'modprobe\t-r\tbrcmfmac' "$calls" || fail "pre unloads the core driver"
+
+run_helper post >/dev/null
+grep -q '^brcmfmac ' "$modules" || fail "post restores brcmfmac"
+grep -q '^brcmfmac_wcc ' "$modules" || fail "post restores brcmfmac_wcc"
+grep -Fqx $'nmcli\t--wait\t0\tconnection\tup\tuuid\ttest-wifi-uuid\tifname\twlan0' "$calls" ||
+  fail "post queues the saved connection on the newly discovered interface"
+[[ ! -e $state ]] || fail "post clears successfully restored state"
+pass "sleep helper unloads and transactionally restores BCM4377 Wi-Fi"
+
+reset_helper_fixture
+printf '1\n' >"$pm_async"
+run_helper pre >/dev/null
+[[ ! -e $state ]] || fail "legacy asynchronous PCI PM does not create sleep state"
+! grep -q '^modprobe' "$calls" || fail "legacy asynchronous PCI PM does not unload Wi-Fi"
+pass "sleep helper waits for the t2bce pm_async=off stack"
+
+reset_helper_fixture
+rm -rf "$t2bce_module"
+run_helper pre >/dev/null
+[[ ! -e $state ]] || fail "the legacy apple_bce stack does not create sleep state"
+! grep -q '^modprobe' "$calls" || fail "the legacy apple_bce stack does not unload Wi-Fi"
+pass "sleep helper does not race an update before the t2bce reboot"
+
+reset_helper_fixture
+: >"$modules"
+run_helper pre >/dev/null
+[[ ! -e $state ]] || fail "an originally unloaded driver needs no restore state"
+! grep -q '^modprobe' "$calls" || fail "an originally unloaded driver remains untouched"
+run_helper post >/dev/null
+! grep -q '^modprobe' "$calls" || fail "post does not load a driver pre did not unload"
+pass "sleep helper preserves an originally unloaded driver"
+
+reset_helper_fixture
+if FAIL_BRCM_UNLOAD=1 run_helper pre >/dev/null; then
+  fail "pre reports a core driver unload failure"
+fi
+[[ $(grep -Fxc $'modprobe\t-r\tbrcmfmac' "$calls") == "5" ]] ||
+  fail "pre retries a transient core unload"
+grep -q '^brcmfmac ' "$modules" || fail "rollback leaves the core driver loaded"
+grep -q '^brcmfmac_wcc ' "$modules" || fail "rollback restores the unloaded wcc holder"
+grep -Fqx $'nmcli\t--wait\t0\tconnection\tup\tuuid\ttest-wifi-uuid\tifname\twlp2s0' "$calls" ||
+  fail "rollback queues the connection it disconnected"
+[[ ! -e $state ]] || fail "successful rollback clears transaction state"
+pass "failed sleep preparation rolls back before systemd aborts sleep"
+
+reset_helper_fixture
+run_helper pre >/dev/null
+if FAIL_BRCM_LOAD=1 run_helper post >/dev/null; then
+  fail "post reports a core driver reload failure"
+fi
+[[ -e $state ]] || fail "failed resume keeps state for an explicit retry"
+run_helper post >/dev/null
+[[ ! -e $state ]] || fail "a successful resume retry clears state"
+grep -q '^brcmfmac_wcc ' "$modules" || fail "a resume retry restores the plugin"
+pass "failed resume remains safely retryable"
+
 unit="$test_tmp/system/omarchy-t2-bcm4377-sleep.service"
 legacy="$test_tmp/system/t2-bcm4377-sleep.service"
 legacy_script="$test_tmp/sbin/t2-bcm4377-sleep.sh"
 legacy_fan_lib="$test_tmp/lib/t2-fan.sh"
 legacy_fan_etc="$test_tmp/etc-sleep/t2-fan.sh"
+machine_marker="$test_tmp/var/lib/omarchy/migrations/1788544020"
+enable_failure_marker="$test_tmp/enable-failed-once"
 
 run_migration() {
   PATH="$stub_bin:$PATH" \
@@ -157,50 +369,10 @@ run_migration() {
     OMARCHY_PATH="$ROOT" \
     OMARCHY_T2_BCM4377_UNIT="$unit" \
     OMARCHY_T2_BCM4377_LEGACY_UNIT="$legacy" \
-    OMARCHY_T2_BCM4377_LEGACY_SCRIPT="$legacy_script" \
-    OMARCHY_T2_BCM4377_LEGACY_FAN_LIB="$legacy_fan_lib" \
-    OMARCHY_T2_BCM4377_LEGACY_FAN_ETC="$legacy_fan_etc" \
+    OMARCHY_T2_BCM4377_MARKER="$machine_marker" \
+    FAIL_ENABLE_ONCE_MARKER="${FAIL_ENABLE_ONCE_MARKER:-}" \
     bash -euo pipefail "$migration" >/dev/null
 }
-
-: >"$calls"
-run_migration 1
-
-[[ -f $unit ]] || fail "migration installs the sleep unit"
-grep -Fq 'ExecStart=/usr/bin/omarchy-t2-bcm4377-sleep pre' "$unit" ||
-  fail "migration copies the packaged sleep unit"
-grep -Fq $'systemctl\tenable\tomarchy-t2-bcm4377-sleep.service' "$calls" ||
-  fail "migration enables the sleep service"
-! grep -q 'enable --now' "$calls" || fail "migration does not start the sleep service"
-pass "migration installs and enables the sleep service on BCM4377b"
-
-: >"$calls"
-run_migration 1
-[[ ! -s $calls ]] || fail "an already repaired BCM4377 install is left unchanged" "$(cat "$calls")"
-pass "migration is machine-idempotent"
-
-mkdir -p "$(dirname "$legacy")" "$(dirname "$legacy_script")" \
-  "$(dirname "$legacy_fan_lib")" "$(dirname "$legacy_fan_etc")"
-: >"$legacy"
-: >"$legacy_script"
-: >"$legacy_fan_lib"
-: >"$legacy_fan_etc"
-: >"$calls"
-rm -f "$unit"
-run_migration 1
-grep -Fq $'systemctl\tdisable\tt2-bcm4377-sleep.service' "$calls" ||
-  fail "migration disables the standalone Scripts/ unit"
-[[ ! -e $legacy ]] || fail "migration removes the standalone Scripts/ unit"
-[[ ! -e $legacy_script && ! -e $legacy_fan_lib && ! -e $legacy_fan_etc ]] ||
-  fail "migration removes the standalone Scripts/ helper and fan hooks"
-pass "migration replaces the standalone Scripts/ unit"
-
-rm -f "$unit" "$legacy"
-: >"$calls"
-run_migration 0
-[[ ! -e $unit ]] || fail "non-BCM4377 systems get no sleep unit"
-[[ ! -s $calls ]] || fail "non-BCM4377 systems skip the sleep repair" "$(cat "$calls")"
-pass "migration skips unrelated hardware"
 
 run_leaf() {
   PATH="$stub_bin:$PATH" \
@@ -210,21 +382,92 @@ run_leaf() {
     OMARCHY_INSTALL="$ROOT/install" \
     OMARCHY_T2_BCM4377_UNIT="$unit" \
     OMARCHY_T2_BCM4377_LEGACY_UNIT="$legacy" \
-    OMARCHY_T2_BCM4377_LEGACY_SCRIPT="$legacy_script" \
-    OMARCHY_T2_BCM4377_LEGACY_FAN_LIB="$legacy_fan_lib" \
-    OMARCHY_T2_BCM4377_LEGACY_FAN_ETC="$legacy_fan_etc" \
     bash -euo pipefail "$leaf" >/dev/null
 }
 
-rm -f "$unit" "$legacy"
+write_known_legacy_unit() {
+  mkdir -p "$(dirname "$legacy")"
+  cat >"$legacy" <<'UNIT'
+[Service]
+ExecStart=/usr/local/sbin/t2-bcm4377-sleep.sh pre
+ExecStop=/usr/local/sbin/t2-bcm4377-sleep.sh post
+UNIT
+}
+
+rm -f "$unit" "$legacy" "$machine_marker"
+: >"$calls"
+run_migration 1
+[[ -f $unit ]] || fail "migration installs the sleep unit"
+grep -Fq 'ExecStart=/usr/bin/omarchy-t2-bcm4377-sleep pre' "$unit" ||
+  fail "migration copies the packaged sleep unit"
+grep -Fq $'systemctl\tenable\tomarchy-t2-bcm4377-sleep.service' "$calls" ||
+  fail "migration enables the sleep service"
+! grep -q 'enable --now' "$calls" || fail "migration does not start the sleep service"
+[[ -f $machine_marker ]] || fail "migration records machine-wide completion last"
+pass "migration installs and enables the sleep service on BCM4377b"
+
+: >"$calls"
+run_migration 1
+[[ ! -s $calls ]] || fail "an already repaired machine is left unchanged" "$(cat "$calls")"
+pass "migration is machine-idempotent across users"
+
+rm -f "$unit" "$machine_marker" "$enable_failure_marker"
+: >"$calls"
+if FAIL_ENABLE_ONCE_MARKER="$enable_failure_marker" run_migration 1; then
+  fail "migration propagates a failed service enable"
+fi
+[[ ! -e $machine_marker ]] || fail "an interrupted migration remains pending"
+: >"$calls"
+FAIL_ENABLE_ONCE_MARKER="$enable_failure_marker" run_migration 1
+grep -Fq $'install\t-Dm644' "$calls" || fail "migration reinstalls after partial completion"
+[[ -f $machine_marker ]] || fail "a successful retry records completion"
+pass "migration retries cleanly after partial installation"
+
+mkdir -p "$(dirname "$legacy_script")" "$(dirname "$legacy_fan_lib")" \
+  "$(dirname "$legacy_fan_etc")"
+write_known_legacy_unit
+: >"$legacy_script"
+: >"$legacy_fan_lib"
+: >"$legacy_fan_etc"
+rm -f "$unit" "$machine_marker"
+: >"$calls"
+run_migration 1
+grep -Fq $'systemctl\tdisable\tt2-bcm4377-sleep.service' "$calls" ||
+  fail "migration disables the known overlapping standalone unit"
+[[ -f $legacy && -f $legacy_script && -f $legacy_fan_lib && -f $legacy_fan_etc ]] ||
+  fail "migration preserves administrator-owned legacy files and fan policy"
+pass "migration disables only the overlap and preserves local files"
+
+printf '[Service]\nExecStart=/usr/local/sbin/custom-sleep pre\n' >"$legacy"
+rm -f "$unit" "$machine_marker"
+: >"$calls"
+run_migration 1
+! grep -Fq $'systemctl\tdisable\tt2-bcm4377-sleep.service' "$calls" ||
+  fail "migration does not disable an unrecognized administrator unit"
+[[ -f $legacy ]] || fail "migration preserves an unrecognized administrator unit"
+pass "migration leaves unrelated administrator policy alone"
+
+rm -f "$unit" "$legacy" "$machine_marker"
+: >"$calls"
+run_migration 0
+[[ ! -e $unit ]] || fail "non-BCM4377 systems get no sleep unit"
+[[ ! -e $machine_marker ]] || fail "unrelated hardware is not marked repaired"
+[[ ! -s $calls ]] || fail "non-BCM4377 systems skip the sleep repair" "$(cat "$calls")"
+pass "migration skips unrelated hardware"
+
+write_known_legacy_unit
+rm -f "$unit"
 : >"$calls"
 run_leaf 1
 [[ -f $unit ]] || fail "installer leaf installs the sleep unit"
+grep -Fq $'systemctl\tdisable\tt2-bcm4377-sleep.service' "$calls" ||
+  fail "installer leaf disables the known overlapping unit"
 grep -Fq $'systemctl\tenable\tomarchy-t2-bcm4377-sleep.service' "$calls" ||
   fail "installer leaf enables the sleep service"
-pass "installer leaf installs the sleep service on BCM4377b"
+[[ -f $legacy ]] || fail "installer leaf preserves the legacy unit file"
+pass "installer leaf installs one active BCM4377 sleep implementation"
 
-rm -f "$unit"
+rm -f "$unit" "$legacy"
 : >"$calls"
 run_leaf 0
 [[ ! -e $unit ]] || fail "installer leaf skips machines without BCM4377b"

--- a/test/shell.d/t2-bcm4377-sleep-test.sh
+++ b/test/shell.d/t2-bcm4377-sleep-test.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+fix_t2="$ROOT/install/hardware/apple/fix-t2.sh"
+leaf="$ROOT/install/hardware/apple/fix-suspend-bcm4377.sh"
+unit_src="$ROOT/install/hardware/apple/omarchy-t2-bcm4377-sleep.service"
+helper="$ROOT/bin/omarchy-t2-bcm4377-sleep"
+detector="$ROOT/bin/omarchy-hw-t2-bcm4377"
+hardware_all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1788544020.sh"
+
+grep -Fq 'KERNEL_CMDLINE[default]+=" intel_iommu=on iommu=pt pm_async=off mem_sleep_default=deep"' "$fix_t2" ||
+  fail "T2 setup still selects deep sleep"
+! grep -Eq 'mem_sleep_default=s2idle|SuspendState=freeze' "$leaf" "$unit_src" "$migration" ||
+  fail "BCM4377 sleep setup does not force s2idle"
+if [[ -f $hardware_all ]]; then
+  grep -q 'apple/fix-suspend-bcm4377.sh' "$hardware_all" ||
+    fail "the BCM4377 sleep leaf runs during hardware setup"
+  awk '
+    /fix-t2\.sh/ { t2=NR }
+    /fix-suspend-bcm4377\.sh/ { bcm=NR }
+    /fix-brcmfmac-supplicant\.sh/ { brcm=NR }
+    END {
+      if (!(t2 && bcm && brcm) || !(t2 < bcm && bcm < brcm))
+        exit 1
+    }
+  ' "$hardware_all" ||
+    fail "the BCM4377 sleep leaf sits between T2 setup and the brcmfmac quirk"
+fi
+! grep -Eq '(tee|cat >).*/etc/modprobe.d/brcmfmac.conf|options brcmfmac' "$leaf" ||
+  fail "only fix-brcmfmac-supplicant.sh writes /etc/modprobe.d/brcmfmac.conf"
+grep -Fq 'systemctl enable omarchy-t2-bcm4377-sleep.service' "$leaf" ||
+  fail "T2 BCM4377 setup enables the sleep service"
+! grep -Eq 'systemctl enable --now' "$leaf" "$migration" ||
+  fail "the sleep service is not started at install time"
+grep -Fq 'ExecStart=/usr/bin/omarchy-t2-bcm4377-sleep pre' "$unit_src" ||
+  fail "the sleep unit unloads Wi-Fi before sleep.target"
+grep -Fq 'WantedBy=sleep.target' "$unit_src" ||
+  fail "the sleep unit is pulled in by every systemd sleep"
+grep -Fq 'RemainAfterExit=yes' "$unit_src" ||
+  fail "the sleep unit keeps Wi-Fi unloaded through suspend-then-hibernate"
+pass "BCM4377 sleep files keep deep S3 and only unload this chipset"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no such hardware" (#6608).
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '74:00.1 Non-VGA unclassified device [0000]: Apple Inc. T2 Bridge Controller [106b:1801] (rev 01)'
+fi
+if [[ -n ${WIFI_ID:-} ]]; then
+  echo "73:00.0 Network controller [0280]: Broadcom Inc. Wireless [14e4:$WIFI_ID]"
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/install" <<'SH'
+#!/bin/bash
+
+printf 'install' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+
+while [[ ${1:-} == -* ]]; do
+  shift
+done
+
+src=${1:-}
+dest=${2:-}
+if [[ -n $src && -n $dest ]]; then
+  mkdir -p "$(dirname "$dest")"
+  cp "$src" "$dest"
+fi
+SH
+
+chmod +x "$stub_bin"/*
+
+run_detector() {
+  PATH="$stub_bin:$PATH" T2_HARDWARE="$1" WIFI_ID="${2:-}" "$detector"
+}
+
+run_detector 1 4488
+pass "detector matches T2 + BCM4377b"
+
+if run_detector 1 4464; then
+  fail "detector refuses BCM4364"
+fi
+pass "detector refuses BCM4364"
+
+if run_detector 1 ""; then
+  fail "detector ignores T2 machines without BCM4377b"
+fi
+pass "detector ignores T2 machines without BCM4377b"
+
+if run_detector 0 4488; then
+  fail "detector ignores BCM4377b on non-T2 hardware"
+fi
+pass "detector ignores BCM4377b on non-T2 hardware"
+
+cat >"$stub_bin/omarchy-hw-t2-bcm4377" <<'SH'
+#!/bin/bash
+
+(( ${T2_BCM4377:-0} == 1 ))
+SH
+chmod +x "$stub_bin/omarchy-hw-t2-bcm4377"
+
+if PATH="$stub_bin:$PATH" "$helper" >/dev/null 2>&1; then
+  fail "sleep helper requires pre or post"
+fi
+pass "sleep helper requires pre or post"
+
+PATH="$stub_bin:$PATH" T2_BCM4377=0 "$helper" pre >/dev/null
+pass "sleep helper no-ops on machines without BCM4377b"
+
+unit="$test_tmp/system/omarchy-t2-bcm4377-sleep.service"
+legacy="$test_tmp/system/t2-bcm4377-sleep.service"
+legacy_script="$test_tmp/sbin/t2-bcm4377-sleep.sh"
+legacy_fan_lib="$test_tmp/lib/t2-fan.sh"
+legacy_fan_etc="$test_tmp/etc-sleep/t2-fan.sh"
+
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    T2_BCM4377="${1:-1}" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_T2_BCM4377_UNIT="$unit" \
+    OMARCHY_T2_BCM4377_LEGACY_UNIT="$legacy" \
+    OMARCHY_T2_BCM4377_LEGACY_SCRIPT="$legacy_script" \
+    OMARCHY_T2_BCM4377_LEGACY_FAN_LIB="$legacy_fan_lib" \
+    OMARCHY_T2_BCM4377_LEGACY_FAN_ETC="$legacy_fan_etc" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+: >"$calls"
+run_migration 1
+
+[[ -f $unit ]] || fail "migration installs the sleep unit"
+grep -Fq 'ExecStart=/usr/bin/omarchy-t2-bcm4377-sleep pre' "$unit" ||
+  fail "migration copies the packaged sleep unit"
+grep -Fq $'systemctl\tenable\tomarchy-t2-bcm4377-sleep.service' "$calls" ||
+  fail "migration enables the sleep service"
+! grep -q 'enable --now' "$calls" || fail "migration does not start the sleep service"
+pass "migration installs and enables the sleep service on BCM4377b"
+
+: >"$calls"
+run_migration 1
+[[ ! -s $calls ]] || fail "an already repaired BCM4377 install is left unchanged" "$(cat "$calls")"
+pass "migration is machine-idempotent"
+
+mkdir -p "$(dirname "$legacy")" "$(dirname "$legacy_script")" \
+  "$(dirname "$legacy_fan_lib")" "$(dirname "$legacy_fan_etc")"
+: >"$legacy"
+: >"$legacy_script"
+: >"$legacy_fan_lib"
+: >"$legacy_fan_etc"
+: >"$calls"
+rm -f "$unit"
+run_migration 1
+grep -Fq $'systemctl\tdisable\tt2-bcm4377-sleep.service' "$calls" ||
+  fail "migration disables the standalone Scripts/ unit"
+[[ ! -e $legacy ]] || fail "migration removes the standalone Scripts/ unit"
+[[ ! -e $legacy_script && ! -e $legacy_fan_lib && ! -e $legacy_fan_etc ]] ||
+  fail "migration removes the standalone Scripts/ helper and fan hooks"
+pass "migration replaces the standalone Scripts/ unit"
+
+rm -f "$unit" "$legacy"
+: >"$calls"
+run_migration 0
+[[ ! -e $unit ]] || fail "non-BCM4377 systems get no sleep unit"
+[[ ! -s $calls ]] || fail "non-BCM4377 systems skip the sleep repair" "$(cat "$calls")"
+pass "migration skips unrelated hardware"
+
+run_leaf() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    T2_BCM4377="${1:-1}" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_INSTALL="$ROOT/install" \
+    OMARCHY_T2_BCM4377_UNIT="$unit" \
+    OMARCHY_T2_BCM4377_LEGACY_UNIT="$legacy" \
+    OMARCHY_T2_BCM4377_LEGACY_SCRIPT="$legacy_script" \
+    OMARCHY_T2_BCM4377_LEGACY_FAN_LIB="$legacy_fan_lib" \
+    OMARCHY_T2_BCM4377_LEGACY_FAN_ETC="$legacy_fan_etc" \
+    bash -euo pipefail "$leaf" >/dev/null
+}
+
+rm -f "$unit" "$legacy"
+: >"$calls"
+run_leaf 1
+[[ -f $unit ]] || fail "installer leaf installs the sleep unit"
+grep -Fq $'systemctl\tenable\tomarchy-t2-bcm4377-sleep.service' "$calls" ||
+  fail "installer leaf enables the sleep service"
+pass "installer leaf installs the sleep service on BCM4377b"
+
+rm -f "$unit"
+: >"$calls"
+run_leaf 0
+[[ ! -e $unit ]] || fail "installer leaf skips machines without BCM4377b"
+[[ ! -s $calls ]] || fail "installer leaf is silent on unrelated hardware" "$(cat "$calls")"
+pass "installer leaf skips unrelated hardware"


### PR DESCRIPTION
## Summary

On T2 Macs with BCM4377b (`14e4:4488`), `brcmfmac` times out entering PCI D3 (`brcmf_pcie_pm_enter_D3` returns `-EIO`). The kernel aborts both `deep` and the s2idle fallback, systemd-suspend fails, and logind retries about every 20 seconds. The lock screen still appears, so lid close *looks* like sleep while the machine stays fully awake.

This installs a `Before=sleep.target` oneshot that unloads `brcmfmac` / `brcmfmac_wcc` on `pre` and reloads them on `post`. `RemainAfterExit` keeps the driver out for the hibernate half of suspend-then-hibernate.

It is gated on T2 **and** BCM4377b. BCM4364 (`14e4:4464`) is refused — that chip needs `brcmfmac` left bound.

**`mem_sleep_default=deep` is left alone.** On current `t2bce` + `pm_async=off`, S3 resumes once Wi-Fi is out of the way. Forcing `s2idle` / `SuspendState=freeze` would take a working S3 path (fan actually powers off) and put it on the high-drain idle path.

## Why not #9830

#9830 unloads `brcmfmac` (right) then forces s2idle because unload + `deep` hard-reset on `linux-t2` 6.17.7 / `apple-bce`. That caveat asked for confirmation on 7.1.4+ `t2bce`.

This is that confirmation, on the same model (MacBookAir9,1):

| | |
|---|---|
| Omarchy | 4.0.2-1 |
| Kernel | `7.1.8-arch1-Watanare-T2-3-t2` (`t2bce`, not `apple-bce`) |
| Wi-Fi | BCM4377b `14e4:4488` |
| `/sys/power/mem_sleep` | `s2idle [deep]` |
| `/sys/power/pm_async` | `0` |
| This boot | `suspend_stats success=7 fail=0` |
| `brcmf_pcie_pm_enter_D3` | 0 |
| NVMe `D3hot → D0` failures | 0 |
| Longest sleep | ~4h 37m overnight |

Every cycle: `PM: suspend entry (deep)` → `ACPI: PM: Waking up from system sleep state S3`. Keyboard/trackpad come back on `t2bce_vhci`. Fan off with the lid closed.

Suggested split, if #9830 still needs s2idle for legacy `apple-bce`:

| Stack | Sleep state | Wi-Fi |
|---|---|---|
| `t2bce` + `pm_async=off` (current Quattro) | keep `deep` | unload `brcmfmac` only if `14e4:4488` |
| legacy `apple-bce` | s2idle may still be required | same Wi-Fi rule |

Same Wi-Fi-only `t2bce` result was reported on a MacBookPro15,4 in https://github.com/omacom/omarchy/discussions/4695.

## Test plan

- [x] `bash test/shell.d/t2-bcm4377-sleep-test.sh` — detector, leaf, migration (BCM4377 / BCM4364 / non-T2 / idempotent / replaces a hand-installed unit)
- [x] `bash test/shell.d/t2-hardware-test.sh` — `mem_sleep_default=deep` unchanged
- [x] `omarchy commands --check`
- [x] Overnight lid-close on MacBookAir9,1 / linux-t2 7.1.8 `t2bce`

After merge, `omarchy update` runs the migration on existing T2+BCM4377 installs. New installs get it from `fix-suspend-bcm4377.sh`. The service is enabled, not started (`enable --now` would drop Wi-Fi until the next resume).