### PR TITLE
Fix keybindings menu hang when user configs iterate hl accessors

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -184,9 +184,17 @@ local function dsp_proxy(path)
   })
 end
 
+-- Unknown hl.* accessors fall back to a noop so simple config calls parse, but
+-- a noop must read as an empty sequence: the scan is reading real user configs
+-- (e.g. ones that call hl.get_loaded_plugins and iterate the result), and a
+-- metatable that yields a fresh value for every numeric index makes ipairs()
+-- and # spin forever. Return nil for numbers so such loops terminate.
 local noop
 noop = setmetatable({}, {
-  __index = function()
+  __index = function(_, key)
+    if type(key) == "number" then
+      return nil
+    end
     return noop
   end,
   __call = function()

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -224,27 +224,40 @@ pass "every action named as having an alternative is bound twice"
 # The menu parses real user configs under a stubbed `hl`. A config that calls a
 # list accessor and walks the result (such as a border-fx style file doing
 # ipairs(hl.get_loaded_plugins())) must leave the scan, not hang on a noop
-# that answers a value for every numeric index.
-spin_home="$tmpdir/spin-home"
-mkdir -p "$spin_home/.config"
-cp -r "$ROOT/config/hypr" "$spin_home/.config/hypr"
+# that answers a value for every numeric index. Hyprland reports the bind below
+# without its key, so a rendered "SUPER + P" is the scan reaching past the loop
+# rather than terminating with nothing left to say.
+stub_hyprctl <<BINDS
+$(lua_bind 64 "" "Spin probe")
+BINDS
 
-cat >"$spin_home/.config/hypr/spin.lua" <<'LUA'
-local function loaded()
-  for _, p in ipairs(hl.get_loaded_plugins()) do
-    if p.name == "hypr-shiny-border" then
+spin_home="$tmpdir/spin-home"
+mkdir -p "$spin_home/.config/hypr"
+
+cat >"$spin_home/.config/hypr/hyprland.lua" <<'LUA'
+local function border_fx_loaded()
+  for _, plugin in ipairs(hl.get_loaded_plugins()) do
+    if plugin.name == "hypr-shiny-border" then
       return true
     end
   end
+
   return false
 end
-loaded()
-LUA
-printf '\npcall(require, "hypr.spin")\n' >>"$spin_home/.config/hypr/hyprland.lua"
 
+border_fx_loaded()
+
+hl.bind("SUPER + P", hl.dsp.exec_cmd("true"), { description = "Spin probe" })
+LUA
+
+# A cache of its own: the records cache is keyed on the stubbed hyprctl alone,
+# so sharing one with an earlier block answers from the cache and never reads
+# the config this is about.
 spin_rendered=$(env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$spin_home" \
-  XDG_CACHE_HOME="$tmpdir/cache" OMARCHY_PATH="$ROOT" \
+  XDG_CACHE_HOME="$tmpdir/spin-cache" OMARCHY_PATH="$ROOT" \
   timeout 20 bash "$ROOT/bin/omarchy-menu-keybindings" --print)
 [[ $? == 0 ]] ||
+  fail "a config iterating a stubbed hl accessor completes the scan" "$spin_rendered"
+grep -q 'SUPER + P  *→ Spin probe' <<<"$spin_rendered" ||
   fail "a config iterating a stubbed hl accessor completes the scan" "$spin_rendered"
 pass "a config iterating a stubbed hl accessor completes the scan"

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -220,3 +220,31 @@ for action in "${expected_alternatives[@]}"; do
     fail "every action named as having an alternative is bound twice" "$action"
 done
 pass "every action named as having an alternative is bound twice"
+
+# The menu parses real user configs under a stubbed `hl`. A config that calls a
+# list accessor and walks the result (such as a border-fx style file doing
+# ipairs(hl.get_loaded_plugins())) must leave the scan, not hang on a noop
+# that answers a value for every numeric index.
+spin_home="$tmpdir/spin-home"
+mkdir -p "$spin_home/.config"
+cp -r "$ROOT/config/hypr" "$spin_home/.config/hypr"
+
+cat >"$spin_home/.config/hypr/spin.lua" <<'LUA'
+local function loaded()
+  for _, p in ipairs(hl.get_loaded_plugins()) do
+    if p.name == "hypr-shiny-border" then
+      return true
+    end
+  end
+  return false
+end
+loaded()
+LUA
+printf '\npcall(require, "hypr.spin")\n' >>"$spin_home/.config/hypr/hyprland.lua"
+
+spin_rendered=$(env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$spin_home" \
+  XDG_CACHE_HOME="$tmpdir/cache" OMARCHY_PATH="$ROOT" \
+  timeout 20 bash "$ROOT/bin/omarchy-menu-keybindings" --print)
+[[ $? == 0 ]] ||
+  fail "a config iterating a stubbed hl accessor completes the scan" "$spin_rendered"
+pass "a config iterating a stubbed hl accessor completes the scan"


### PR DESCRIPTION
## Problem

`omarchy-menu-keybindings` parses the user's `~/.config/hypr/hyprland.lua` under a stubbed `hl` so it can resolve Lua bindings that Hyprland reports as `__lua`. Unknown `hl.*` accessors fall back to a `noop` object whose `__index` returns itself for **every** key — including numeric indices.

Any real user config that calls a list accessor and walks the result spins forever:

```lua
for _, p in ipairs(hl.get_loaded_plugins()) do ... end
```

This is what the border-fx plugin's generated `border-fx.lua` does. Result: `lua` pegs a CPU core, `omarchy menu keybindings` never opens, and `--print` never returns.

## Fix

In the embedded `noop` metatable, return `nil` for numeric keys while still mirroring non-numeric access for method chaining. Stubbed accessors then read as empty sequences, so `ipairs()` and `#` terminate immediately instead of recursing on a metatable that never yields `nil`.

## Test

Added a regression test to `test/shell.d/keybindings-menu-test.sh` that installs a config calling `ipairs(hl.get_loaded_plugins())` and asserts the scan completes (wrapped in `timeout` so a regression fails instead of hanging the suite).

Verified:
- new test passes; full `test/shell.d/keybindings-menu-test.sh` passes
- `./test/cli` passes
- before the fix the reproducer times out (exit 124); after, it exits 0