### PR TITLE
security: add a disk-unlock duress password that factory-resets

### DIFF
--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -740,6 +740,12 @@ create_user() {
   printf '%s:%s\n' "$username" "$password" | chpasswd
   printf '%s:%s\n' root "$password" | chpasswd
 
+  if [[ -f $PROVISIONING_DIR/duress-owner ]]; then
+    install -d -m 755 "/home/$username/.local/state/omarchy"
+    touch "/home/$username/.local/state/omarchy/skip-welcome"
+    chown -R "$username:$username" "/home/$username/.local/state"
+  fi
+
   # deferred-provisioning installs skip archinstall's create_users, which is what normally
   # uncomments %wheel in /etc/sudoers. Always write the drop-in: detecting an
   # existing grant is error-prone (omarchy ships narrow %wheel NOPASSWD rules
@@ -990,7 +996,9 @@ reset_limine_config() {
 cleanup_oem_state() {
   # Keep groups + packages: omarchy-system-factory-reset stages the bundled Node
   # tarball from these live copies when the factory snapshot predates it.
-  rm -f "$PROVISIONING_DIR/pending" "$PROVISIONING_DIR/authorized_keys" "$PROVISIONING_DIR/setup-user"
+  shred -u "$PROVISIONING_DIR/duress-key" 2>/dev/null || rm -f "$PROVISIONING_DIR/duress-key"
+  rm -f "$PROVISIONING_DIR/pending" "$PROVISIONING_DIR/authorized_keys" "$PROVISIONING_DIR/setup-user" \
+    "$PROVISIONING_DIR/duress-owner"
 
   rm -f /etc/systemd/system/multi-user.target.wants/omarchy-provision-owner.service
   systemctl daemon-reload 2>/dev/null || true
@@ -1017,17 +1025,22 @@ run_provisioning() {
     touch "$FINALIZE_WARNING_FLAG"
   fi
 
+  local boot_rebuilt=0
   if [[ -f $PROVISIONING_DIR/luks-key ]]; then
     log_step "re-keying LUKS to the user's password"
     echo rekey >"$STATE_FILE"
     rekey_luks
     log_step "LUKS re-key complete"
+    boot_rebuilt=1
   fi
 
   # After a factory reset on an unencrypted machine nothing above rebuilds the
   # boot entries, so entries keyed to the previous machine identity would
   # linger and go hash-stale on the first UKI rebuild. Refresh them now.
-  if limine_entries_stale; then
+  # A duress wipe that skipped the factory-root UKI rebuild also lands here:
+  # the ESP still has the duress cryptsetup wrapper, and the factory clone has
+  # no zz-omarchy-duress.conf, so limine-update writes a clean UKI.
+  if (( boot_rebuilt == 0 )) && { limine_entries_stale || [[ -f $PROVISIONING_DIR/duress-owner ]]; }; then
     log_step "refreshing boot entries for the new machine identity"
     echo boot >"$STATE_FILE"
     reset_limine_config
@@ -1039,8 +1052,51 @@ run_provisioning() {
   log_step "first-boot setup complete"
 }
 
+load_duress_owner() {
+  local file=$PROVISIONING_DIR/duress-owner
+  local key=$PROVISIONING_DIR/duress-key
+  [[ -f $file && -f $key ]] || return 1
+  username=$(jq -r '.username // empty' "$file")
+  password=$(cat "$key")
+  hostname=$(jq -r '.hostname // empty' "$file")
+  timezone=$(jq -r '.timezone // empty' "$file")
+  keyboard=$(jq -r '.keyboard // empty' "$file")
+  keyboard_label=$(jq -r '.keyboard_label // empty' "$file")
+  full_name=$(jq -r '.full_name // empty' "$file")
+  email_address=$(jq -r '.email_address // empty' "$file")
+  [[ -n $username && -n "$password" ]]
+}
+
 run_setup() {
   local status
+
+  if load_duress_owner; then
+    apply_keyboard "${keyboard:-us}"
+    touch "$LOG_FILE"
+    chmod 600 "$LOG_FILE"
+    rm -f "$FINALIZE_WARNING_FLAG"
+    echo account >"$STATE_FILE"
+    run_provisioning >>"$LOG_FILE" 2>&1 &
+    local worker=$!
+    set_now
+    SETUP_T0=$NOW
+    SETUP_PHASE_T0=$NOW
+    render_setup_static
+    while kill -0 "$worker" 2>/dev/null; do
+      render_setup_dynamic
+      sleep 0.5
+    done
+    status=0
+    wait "$worker" || status=$?
+    if (( status != 0 )); then
+      printf '%s' "$SHOW_CURSOR"
+      return "$status"
+    fi
+    echo done >"$STATE_FILE"
+    render_setup_dynamic
+    sleep 1
+    return 0
+  fi
 
   while true; do
     keyboard_form
@@ -1108,6 +1164,15 @@ run_setup() {
 # screen. Each attempt runs as its own process — bash ignores errexit inside
 # `while !` conditions, but a child process keeps its own set -e — and failure
 # offers a retry; create_user and friends are idempotent, so retrying is safe.
+if [[ ${1:-} == "--silent" ]]; then
+  load_duress_owner || exit 1
+  apply_keyboard "${keyboard:-us}"
+  touch "$LOG_FILE"
+  chmod 600 "$LOG_FILE"
+  run_provisioning
+  exit 0
+fi
+
 if [[ ${1:-} == "--attempt" ]]; then
   run_setup
   exit 0
@@ -1118,7 +1183,11 @@ main() {
   # greeter_screen (which owns that settle) rather than running here on a VT
   # that may still be in a transitional mode this early in first boot.
   set_tokyo_night_colors
-  greeter_screen
+  if [[ -f $PROVISIONING_DIR/duress-owner ]]; then
+    scale_console_font
+  else
+    greeter_screen
+  fi
 
   while ! "$0" --attempt; do
     clear_logo

--- a/bin/omarchy-setup-security-duress
+++ b/bin/omarchy-setup-security-duress
@@ -1,0 +1,434 @@
+#!/bin/bash
+
+# omarchy:summary=Set a disk-unlock duress password that factory-resets the machine
+# omarchy:args=[--remove] [--change]
+# omarchy:examples=omarchy-setup-security-duress | omarchy-setup-security-duress --change | omarchy-setup-security-duress --remove
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+PROVISIONING_DIR=/var/lib/omarchy/provisioning
+OWNER_FILE=$PROVISIONING_DIR/duress-owner
+DROPIN=/etc/mkinitcpio.conf.d/zz-omarchy-duress.conf
+UNIT_SRC="$OMARCHY_PATH/install/provisioning/omarchy-system-duress-wipe.service"
+UNIT_DST=/etc/systemd/system/omarchy-system-duress-wipe.service
+INITCPIO_SRC="$OMARCHY_PATH/default/initcpio"
+REMOVE=0
+CHANGE=0
+REFRESH_BOOT=0
+
+for arg in "$@"; do
+  case $arg in
+    --remove) REMOVE=1 ;;
+    --change) CHANGE=1 ;;
+    --refresh-boot) REFRESH_BOOT=1 ;;
+  esac
+done
+
+as_root() {
+  if (( EUID == 0 )); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+fail() {
+  echo -e "\e[31m$1\e[0m" >&2
+  exit 1
+}
+
+luks_device() {
+  local spec src part
+  spec=$(grep -o 'cryptdevice=[^ :]*' /proc/cmdline | head -1 | cut -d= -f2-)
+  case $spec in
+    UUID=*) echo "/dev/disk/by-uuid/${spec#UUID=}"; return 0 ;;
+    PARTUUID=*) echo "/dev/disk/by-partuuid/${spec#PARTUUID=}"; return 0 ;;
+    LABEL=*) echo "/dev/disk/by-label/${spec#LABEL=}"; return 0 ;;
+    PARTLABEL=*) echo "/dev/disk/by-partlabel/${spec#PARTLABEL=}"; return 0 ;;
+    /dev/*) echo "$spec"; return 0 ;;
+  esac
+
+  src=$(findmnt -no SOURCE / | sed 's/\[.*//')
+  [[ -n $src ]] || return 1
+  part=$(lsblk -nspo NAME,FSTYPE "$src" 2>/dev/null | awk '$2=="crypto_LUKS"{print $1; exit}')
+  [[ -n $part ]] && { echo "$part"; return 0; }
+  return 1
+}
+
+token_slot() {
+  printf '%s' "$1" | sed -n 's/.*"keyslots":\["\([0-9][0-9]*\)"\].*/\1/p'
+}
+
+# Prefer leftover omarchy-duress tokens so change/remove/migrate can strip the
+# custom type. Otherwise the generic luks2 token enroll writes.
+find_duress_token() {
+  local device="$1" id json compact slot
+  local luks2_id="" luks2_slot=""
+  for id in {0..31}; do
+    json=$(cryptsetup token export --token-id "$id" "$device" 2>/dev/null) || continue
+    compact=$(printf '%s' "$json" | tr -d ' \n')
+    slot=$(token_slot "$compact")
+    [[ -n $slot ]] || continue
+    case $compact in
+      *'"type":"omarchy-duress"'*)
+        printf '%s %s' "$id" "$slot"
+        return 0
+        ;;
+      *'"type":"luks2"'*)
+        if [[ -z $luks2_id ]]; then
+          luks2_id=$id
+          luks2_slot=$slot
+        fi
+        ;;
+    esac
+  done
+  if [[ -n $luks2_id ]]; then
+    printf '%s %s' "$luks2_id" "$luks2_slot"
+    return 0
+  fi
+  return 1
+}
+
+assign_duress_token() {
+  cryptsetup token add --key-slot "$1" "$2"
+}
+
+# Header-only: swap leftover omarchy-duress tokens for a generic luks2 token so
+# luksDump no longer names the feature. Safe only once the UKI wrapper already
+# understands luks2 tokens (refresh_boot rebuilds first). Uses as_root because
+# --refresh-boot runs as the user from migrations.
+convert_legacy_duress_tokens() {
+  local device id json compact slot
+  device=$(luks_device) || return 0
+  [[ -e $device ]] || return 0
+
+  for id in {0..31}; do
+    json=$(as_root cryptsetup token export --token-id "$id" "$device" 2>/dev/null) || continue
+    compact=$(printf '%s' "$json" | tr -d ' \n')
+    case $compact in
+      *'"type":"omarchy-duress"'*)
+        slot=$(token_slot "$compact")
+        [[ -n $slot ]] || continue
+        as_root cryptsetup token add --key-slot "$slot" "$device" || continue
+        as_root cryptsetup token remove --token-id "$id" "$device" 2>/dev/null || true
+        ;;
+    esac
+  done
+}
+
+luks_keyslots() {
+  cryptsetup luksDump "$1" 2>/dev/null | sed -n 's/^[[:space:]]*\([0-9][0-9]*\):[[:space:]]*luks2.*/\1/p'
+}
+
+new_luks_slot() {
+  local device="$1"
+  shift
+  local -a before=("$@")
+  local slot found existing
+  for slot in $(luks_keyslots "$device"); do
+    found=0
+    for existing in "${before[@]}"; do
+      [[ $slot == "$existing" ]] && { found=1; break; }
+    done
+    if (( !found )); then
+      printf '%s' "$slot"
+      return 0
+    fi
+  done
+  return 1
+}
+
+require_factory_snapshot() {
+  local src top
+  src=$(findmnt -no SOURCE / | sed 's/\[.*\]//')
+  [[ -n $src ]] || return 1
+  top=$(mktemp -d)
+  if mount -o subvolid=5,ro "$src" "$top" 2>/dev/null; then
+    if [[ -d $top/@factory ]]; then
+      umount "$top"
+      rmdir "$top" 2>/dev/null || true
+      return 0
+    fi
+    umount "$top"
+  fi
+  rmdir "$top" 2>/dev/null || true
+  return 1
+}
+
+install_boot_files() {
+  local src="$INITCPIO_SRC"
+  [[ -f $src/cryptsetup-wrapper && -f $src/hooks/omarchy-duress && -f $src/install/omarchy-duress && -f $src/zz-omarchy-duress.conf ]] ||
+    fail "duress initramfs files are missing from $src"
+
+  as_root install -Dm644 "$src/hooks/omarchy-duress" /usr/lib/initcpio/hooks/omarchy-duress
+  as_root install -Dm644 "$src/install/omarchy-duress" /usr/lib/initcpio/install/omarchy-duress
+  as_root install -Dm755 "$src/cryptsetup-wrapper" /usr/lib/initcpio/omarchy-duress-wrapper
+  as_root install -Dm644 "$src/zz-omarchy-duress.conf" "$DROPIN"
+  as_root install -Dm644 "$UNIT_SRC" "$UNIT_DST"
+  as_root systemctl enable omarchy-system-duress-wipe.service >/dev/null
+  omarchy-pkg-add kexec-tools >/dev/null 2>&1 || true
+}
+
+rebuild_boot() {
+  if omarchy-cmd-present limine-mkinitcpio; then
+    as_root limine-mkinitcpio
+  else
+    as_root mkinitcpio -P
+  fi
+}
+
+prompt_current_passphrase() {
+  local device="$1" current
+  while true; do
+    current=$(gum input --password --placeholder "Current disk encryption passphrase" --prompt "Current> ") || exit 1
+    if [[ -z $current ]]; then
+      gum style --foreground 1 "Passphrase cannot be empty." >&2
+      continue
+    fi
+    if cryptsetup open --test-passphrase --key-file <(printf '%s' "$current") "$device" 2>/dev/null; then
+      printf '%s' "$current"
+      return 0
+    fi
+    gum style --foreground 1 "That passphrase does not unlock $device. Try again." >&2
+  done
+}
+
+prompt_new_duress() {
+  local current="$1" duress confirm
+  while true; do
+    duress=$(gum input --password --placeholder "Duress password (must differ from the real one)" --prompt "Duress> ") || exit 1
+    if [[ -z $duress ]]; then
+      gum style --foreground 1 "Duress password cannot be empty." >&2
+      continue
+    fi
+    if [[ $duress == "$current" ]]; then
+      gum style --foreground 1 "Duress password must be different from the real disk password." >&2
+      continue
+    fi
+    confirm=$(gum input --password --placeholder "Confirm duress password" --prompt "Confirm> ") || exit 1
+    if [[ $duress == "$confirm" ]]; then
+      printf '%s' "$duress"
+      return 0
+    fi
+    gum style --foreground 1 "Passwords do not match. Try again." >&2
+  done
+}
+
+change_duress() {
+  local device token_id slot current duress found
+  device=$(luks_device) || fail "No encrypted drive found."
+  [[ -e $device ]] || fail "LUKS device $device not found"
+
+  found=$(find_duress_token "$device" || true)
+  [[ -n $found ]] || fail "No duress password is enrolled. Set one up from Setup > Security > Duress Password."
+  token_id=${found%% *}
+  slot=${found#* }
+
+  echo
+  gum style --bold "Change the duress password?"
+  echo
+  gum style "The current disk password stays the same. Only the duress phrase is replaced."
+  echo
+
+  current=$(prompt_current_passphrase "$device")
+  duress=$(prompt_new_duress "$current")
+
+  local -a slots_before
+  mapfile -t slots_before < <(luks_keyslots "$device")
+  cryptsetup luksAddKey --key-file <(printf '%s' "$current") --pbkdf argon2id --iter-time 2000 "$device" <(printf '%s' "$duress")
+  local new_slot
+  new_slot=$(new_luks_slot "$device" "${slots_before[@]}") || fail "Could not determine the new LUKS keyslot."
+
+  cryptsetup -q luksKillSlot --key-file <(printf '%s' "$current") "$device" "$slot"
+  cryptsetup token remove --token-id "$token_id" "$device" 2>/dev/null || true
+  assign_duress_token "$new_slot" "$device"
+
+  echo -e "\e[32mDuress password updated. It is active immediately.\e[0m"
+}
+
+remove_duress() {
+  local device token_id slot current found
+  device=$(luks_device) || fail "No encrypted drive found."
+  [[ -e $device ]] || fail "LUKS device $device not found"
+
+  found=$(find_duress_token "$device" || true)
+  [[ -n $found ]] || fail "No duress password is enrolled."
+  token_id=${found%% *}
+  slot=${found#* }
+
+  echo
+  echo "This removes the duress password from $device (LUKS slot $slot)."
+  current=$(prompt_current_passphrase "$device")
+
+  cryptsetup -q luksKillSlot --key-file <(printf '%s' "$current") "$device" "$slot"
+  cryptsetup token remove --token-id "$token_id" "$device" 2>/dev/null || true
+  rm -f "$DROPIN" "$OWNER_FILE"
+
+  echo "Rebuilding boot files..."
+  rebuild_boot
+  echo -e "\e[32mDuress password removed.\e[0m"
+}
+
+enroll_duress() {
+  local device current duress confirm typed slot existing token_id old_slot
+
+  device=$(luks_device) || fail "Duress passwords need full-disk encryption."
+  [[ -e $device ]] || fail "LUKS device $device not found"
+  require_factory_snapshot || fail "This machine has no @factory snapshot to reset to. Reinstall from the Omarchy ISO first."
+
+  existing=$(find_duress_token "$device" || true)
+  if [[ -n $existing ]]; then
+    echo "A duress password is already enrolled."
+    local choice
+    choice=$(gum choose "Replace duress password" "Remove duress password" "Cancel") || exit 1
+    case $choice in
+      "Remove duress password") remove_duress; return ;;
+      Cancel) exit 0 ;;
+    esac
+  fi
+
+  echo
+  gum style --bold --foreground 1 "Set a duress password?"
+  echo
+  gum style "At the disk-unlock screen, this password looks like it works — then the machine factory-resets. There is no confirmation and no way to undo it once typed."
+  echo
+  gum style "The next boot after this setup is when it becomes active."
+  echo
+
+  while true; do
+    typed=$(gum input --placeholder "Type 'wipe' to continue" --prompt "> ") || exit 1
+    [[ $typed == "wipe" ]] && break
+    gum style --foreground 1 "Type 'wipe' to continue."
+  done
+
+  current=$(prompt_current_passphrase "$device")
+  duress=$(prompt_new_duress "$current")
+
+  if [[ -n $existing ]]; then
+    token_id=${existing%% *}
+    old_slot=${existing#* }
+    cryptsetup -q luksKillSlot --key-file <(printf '%s' "$current") "$device" "$old_slot"
+    cryptsetup token remove --token-id "$token_id" "$device" 2>/dev/null || true
+  fi
+
+  local -a slots_before
+  mapfile -t slots_before < <(luks_keyslots "$device")
+  cryptsetup luksAddKey --key-file <(printf '%s' "$current") --pbkdf argon2id --iter-time 2000 "$device" <(printf '%s' "$duress")
+  slot=$(new_luks_slot "$device" "${slots_before[@]}") || fail "Could not determine the new LUKS keyslot."
+  assign_duress_token "$slot" "$device"
+
+  collect_duress_owner
+
+  install_boot_files
+  echo "Rebuilding boot files (this can take a minute)..."
+  rebuild_boot
+  echo
+  echo -e "\e[32mDuress password enrolled. It is active on the next reboot.\e[0m"
+}
+
+write_duress_owner() {
+  install -d -m 700 "$PROVISIONING_DIR"
+  umask 077
+  jq -n \
+    --arg username "$1" \
+    --arg hostname "$2" \
+    --arg timezone "$3" \
+    --arg keyboard "$4" \
+    --arg keyboard_label "$5" \
+    --arg full_name "$6" \
+    --arg email_address "$7" \
+    '{username:$username,hostname:$hostname,timezone:$timezone,keyboard:$keyboard,keyboard_label:$keyboard_label,full_name:$full_name,email_address:$email_address}' \
+    >"$OWNER_FILE"
+  chmod 600 "$OWNER_FILE"
+}
+
+collect_duress_owner() {
+  local username full_name email_address hostname timezone keyboard keyboard_label
+
+  echo
+  gum style --bold "After a duress wipe, the machine boots into a fresh desktop."
+  echo
+  gum style "The duress password becomes the new disk and login password, so it keeps working after reboot. There is no duress password on that system."
+  echo
+
+  if gum confirm --affirmative "Choose account details" --negative "Use defaults" "Customize the post-wipe account?"; then
+    source "$OMARCHY_PATH/install/provisioning/setup-form.sh"
+    notice() { gum style --foreground 1 "$1" >&2; sleep "${2:-0}"; }
+    omarchy_username_taken() { return 1; }
+
+    while true; do
+      omarchy_prompt_keyboard || continue
+      omarchy_prompt_username || continue
+      omarchy_prompt_identity || continue
+      omarchy_prompt_hostname || continue
+      omarchy_prompt_timezone || continue
+      break
+    done
+  else
+    username=omarchy
+    hostname=omarchy
+    timezone=UTC
+    keyboard=us
+    keyboard_label="English (US)"
+    full_name=""
+    email_address=""
+  fi
+
+  write_duress_owner \
+    "$username" \
+    "${hostname:-omarchy}" \
+    "${timezone:-UTC}" \
+    "${keyboard:-us}" \
+    "${keyboard_label:-English (US)}" \
+    "${full_name:-}" \
+    "${email_address:-}"
+}
+
+refresh_boot() {
+  [[ -f $DROPIN ]] || exit 0
+  [[ -f $INITCPIO_SRC/cryptsetup-wrapper ]] || exit 0
+
+  local changed=0
+  if ! cmp -s "$INITCPIO_SRC/cryptsetup-wrapper" /usr/lib/initcpio/omarchy-duress-wrapper 2>/dev/null; then
+    changed=1
+  fi
+
+  install_boot_files
+  if (( changed )); then
+    rebuild_boot
+  fi
+  convert_legacy_duress_tokens
+}
+
+main() {
+  export PATH="$OMARCHY_PATH/bin:$PATH"
+
+  if (( REFRESH_BOOT )); then
+    refresh_boot
+    return
+  fi
+
+  if (( EUID != 0 )); then
+    mapfile -t gum_env < <(env | grep '^GUM_' || true)
+    exec sudo env "${gum_env[@]}" "$0" "$@"
+  fi
+
+  omarchy-cmd-present cryptsetup || fail "cryptsetup is required"
+  omarchy-cmd-present gum || fail "gum is required"
+
+  if (( REMOVE )); then
+    remove_duress
+    return
+  fi
+
+  if (( CHANGE )); then
+    change_duress
+    return
+  fi
+
+  enroll_duress
+}
+
+main "$@"

--- a/bin/omarchy-system-factory-reset
+++ b/bin/omarchy-system-factory-reset
@@ -25,6 +25,10 @@
 #  - LUKS re-keying changes passphrases, not the volume key. Freed extents
 #    remain readable to someone with raw-device access and a valid passphrase.
 #    Use cryptsetup reencrypt or a reinstall if you need certainty.
+#
+# --unattended is the duress path: no confirm, no gum, always reboot. It
+# requires /var/lib/omarchy/provisioning/duress-pending (armed by the
+# initramfs cryptsetup wrapper) and must already be root.
 
 set -euo pipefail
 
@@ -33,11 +37,23 @@ OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
 TOP_MNT=/run/omarchy-system-factory-reset/top
 NEXT_NAME=@omarchy-reset-next
 LOG_FILE=/var/log/omarchy-system-factory-reset.log
+UNATTENDED=0
+
+for arg in "$@"; do
+  case $arg in
+    --unattended) UNATTENDED=1 ;;
+  esac
+done
 
 # Self-elevate so the menu entry (and a bare shell invocation) need no sudo
 # prefix. The caller's gum theme vars are forwarded as `env` arguments rather
 # than via `sudo -E`, so styling survives even under an env_reset sudoers.
+# Unattended is systemd-only: a sudo prompt would be a duress giveaway.
 if (( EUID != 0 )); then
+  if (( UNATTENDED )); then
+    echo "Error: unattended factory reset must run as root" >&2
+    exit 1
+  fi
   mapfile -t gum_env < <(env | grep '^GUM_' || true)
   exec sudo env "${gum_env[@]}" "$0" "$@"
 fi
@@ -46,11 +62,19 @@ export PATH="$OMARCHY_PATH/bin:$PATH"
 
 log() {
   echo "$1" | tee -a "$LOG_FILE" >/dev/null
-  gum style --foreground 8 "  $1"
+  if (( UNATTENDED )); then
+    echo "factory-reset: $1"
+  else
+    gum style --foreground 8 "  $1"
+  fi
 }
 
 fail() {
-  gum style --foreground 1 "Error: $1"
+  if (( UNATTENDED )); then
+    echo "Error: $1" >&2
+  else
+    gum style --foreground 1 "Error: $1"
+  fi
   exit 1
 }
 
@@ -110,6 +134,11 @@ cleanup() {
 trap cleanup EXIT
 
 confirm_reset() {
+  if (( UNATTENDED )); then
+    [[ -f $PROVISIONING_DIR/duress-pending ]] || fail "unattended reset requires a duress pending marker"
+    return 0
+  fi
+
   echo
   gum style --bold --foreground 1 "Reset this computer to factory state?"
   echo
@@ -127,6 +156,19 @@ confirm_reset() {
   [[ $typed == "reset" ]] || fail "Reset not confirmed."
 }
 
+luks_keyslots() {
+  cryptsetup luksDump "$1" 2>/dev/null | sed -n 's/^[[:space:]]*\([0-9][0-9]*\):[[:space:]]*luks2.*/\1/p'
+}
+
+kill_luks_slots_except() {
+  local device="$1" keep_slot="$2" auth="$3" slot
+  [[ -n $keep_slot ]] || return 0
+  for slot in $(luks_keyslots "$device"); do
+    [[ $slot == "$keep_slot" ]] && continue
+    cryptsetup -q luksKillSlot --key-file <(printf '%s' "$auth") "$device" "$slot" >/dev/null 2>&1 || true
+  done
+}
+
 # Re-key to a throwaway passphrase whose keyfile auto-unlocks boot during the
 # provisioning window. $1 is the root of the staged factory system.
 stage_luks_rekey() {
@@ -135,19 +177,46 @@ stage_luks_rekey() {
   device=$(luks_device) || fail "encrypted install, but no usable cryptdevice= in /proc/cmdline"
   [[ -e $device ]] || fail "LUKS device $device not found"
 
-  echo
-  gum style "Confirm your disk encryption passphrase to authorize the re-key."
   local current
-  while true; do
-    current=$(gum input --password --placeholder "Current disk encryption passphrase" --prompt "Passphrase> ") || exit 1
-    if cryptsetup open --test-passphrase --key-file <(printf '%s' "$current") "$device" 2>/dev/null; then
-      break
-    fi
-    gum style --foreground 1 "That passphrase does not unlock $device. Try again."
-  done
+  if (( UNATTENDED )); then
+    [[ -f $PROVISIONING_DIR/duress-key ]] || fail "unattended reset is missing the duress keyfile"
+    current=$(cat "$PROVISIONING_DIR/duress-key")
+    cryptsetup open --test-passphrase --key-file <(printf '%s' "$current") "$device" 2>/dev/null ||
+      fail "duress keyfile does not unlock $device"
+  else
+    echo
+    gum style "Confirm your disk encryption passphrase to authorize the re-key."
+    while true; do
+      current=$(gum input --password --placeholder "Current disk encryption passphrase" --prompt "Passphrase> ") || exit 1
+      if cryptsetup open --test-passphrase --key-file <(printf '%s' "$current") "$device" 2>/dev/null; then
+        break
+      fi
+      gum style --foreground 1 "That passphrase does not unlock $device. Try again."
+    done
+  fi
+
+  local -a slots_before slots_after
+  local new_slot slot found existing
+  mapfile -t slots_before < <(luks_keyslots "$device")
 
   passphrase=$(generate_passphrase)
   cryptsetup luksAddKey --key-file <(printf '%s' "$current") "$device" <(printf '%s' "$passphrase")
+
+  if (( UNATTENDED )); then
+    mapfile -t slots_after < <(luks_keyslots "$device")
+    new_slot=""
+    for slot in "${slots_after[@]}"; do
+      found=0
+      for existing in "${slots_before[@]}"; do
+        [[ $slot == "$existing" ]] && { found=1; break; }
+      done
+      if (( !found )); then
+        new_slot=$slot
+        break
+      fi
+    done
+    kill_luks_slots_except "$device" "$new_slot" "$passphrase"
+  fi
 
   install -d -m 755 "$next$PROVISIONING_DIR"
   printf '%s' "$passphrase" >"$next$PROVISIONING_DIR/luks-key"
@@ -169,6 +238,8 @@ install_provisioning_units() {
 
   install -Dm644 "$unit_src/omarchy-provision-owner.service" \
     "$next/etc/systemd/system/omarchy-provision-owner.service"
+  install -Dm644 "$unit_src/omarchy-provision-duress.service" \
+    "$next/etc/systemd/system/omarchy-provision-duress.service"
   install -Dm644 "$unit_src/omarchy-system-factory-reset-finish.service" \
     "$next/etc/systemd/system/omarchy-system-factory-reset-finish.service"
 
@@ -176,6 +247,8 @@ install_provisioning_units() {
     "$next/etc/systemd/system/sysinit.target.wants"
   ln -sf /etc/systemd/system/omarchy-provision-owner.service \
     "$next/etc/systemd/system/multi-user.target.wants/omarchy-provision-owner.service"
+  ln -sf /etc/systemd/system/omarchy-provision-duress.service \
+    "$next/etc/systemd/system/multi-user.target.wants/omarchy-provision-duress.service"
   ln -sf /etc/systemd/system/omarchy-system-factory-reset-finish.service \
     "$next/etc/systemd/system/sysinit.target.wants/omarchy-system-factory-reset-finish.service"
 }
@@ -204,6 +277,11 @@ reset_limine_config() {
     fi
   done
   [[ -n $found ]] || fail "no limine.conf template in $root/usr/share/omarchy"
+
+  if (( UNATTENDED )); then
+    sed -i 's/^#timeout:.*/timeout: 0/' "$root$esp/limine.conf"
+    grep -q '^timeout:' "$root$esp/limine.conf" || echo 'timeout: 0' >>"$root$esp/limine.conf"
+  fi
 
   local machine_id old_id
   machine_id=$(cat "$root/etc/machine-id" 2>/dev/null || true)
@@ -365,20 +443,38 @@ stage_full_reset() {
 
   install -d -m 755 "$next$PROVISIONING_DIR"
   touch "$next$PROVISIONING_DIR/pending" "$next$PROVISIONING_DIR/wipe-pending"
+  if (( UNATTENDED )); then
+    if [[ -f $PROVISIONING_DIR/duress-owner ]]; then
+      install -Dm600 "$PROVISIONING_DIR/duress-owner" "$next$PROVISIONING_DIR/duress-owner"
+    fi
+    if [[ -f $PROVISIONING_DIR/duress-key ]]; then
+      install -Dm600 "$PROVISIONING_DIR/duress-key" "$next$PROVISIONING_DIR/duress-key"
+    fi
+  fi
 
   install_provisioning_units "$next" "$unit_src"
 
-  if encrypted_install; then
+  local skip_boot_rebuild=0
+  if (( UNATTENDED )) && [[ -d $next/usr/lib/modules/$(uname -r) ]]; then
+    skip_boot_rebuild=1
+  fi
+
+  if encrypted_install && (( skip_boot_rebuild == 0 )); then
     stage_luks_rekey "$next"
   fi
 
-  rebuild_next_boot "$next"
+  if (( skip_boot_rebuild == 0 )); then
+    rebuild_next_boot "$next"
+  fi
 
   log "Activating the factory system"
   local old="@omarchy-old-$(date +%s)"
   mv "$top/@" "$top/$old"
   mv "$next" "$top/@"
   swap_done=1
+  if (( UNATTENDED )); then
+    shred -u "$PROVISIONING_DIR/duress-key" 2>/dev/null || rm -f "$PROVISIONING_DIR/duress-key"
+  fi
   sync
 }
 
@@ -386,6 +482,10 @@ stage_full_reset() {
 # return to. Only the Quattro installer takes that snapshot.
 require_factory_snapshot() {
   [[ -d $TOP_MNT/@factory ]] && return 0
+
+  if (( UNATTENDED )); then
+    fail "This machine has no factory snapshot to reset to."
+  fi
 
   echo
   gum style --bold --foreground 3 "This machine has no factory snapshot to reset to."
@@ -399,11 +499,42 @@ require_factory_snapshot() {
   exit 1
 }
 
+jump_to_factory_system() {
+  local uki dir device
+  device=$(root_device)
+  if [[ -n $device ]]; then
+    mkdir -p /run/nextroot
+    if mount -o subvol=@ "$device" /run/nextroot 2>/dev/null &&
+      [[ -x /run/nextroot/usr/lib/systemd/systemd ]]; then
+      log "Switching userspace to the factory system"
+      systemctl soft-reboot && return
+      umount /run/nextroot 2>/dev/null || true
+    fi
+  fi
+
+  if omarchy-cmd-present kexec; then
+    for dir in /boot/EFI/Linux /efi/EFI/Linux /boot/efi/EFI/Linux; do
+      [[ -d $dir ]] || continue
+      uki=$(find "$dir" -maxdepth 1 -name '*.efi' -print -quit)
+      [[ -n $uki ]] && break
+    done
+    if [[ -n $uki ]] && kexec -l --reuse-cmdline "$uki" 2>/dev/null; then
+      log "Jumping into $uki"
+      systemctl kexec && return
+      kexec -u 2>/dev/null || true
+    fi
+  fi
+  systemctl reboot
+}
+
 main() {
   omarchy-cmd-present btrfs || { echo "Error: btrfs-progs is required" >&2; exit 1; }
 
   root_is_btrfs_at || fail "reset requires the standard Omarchy Btrfs layout (subvol=@)"
 
+  if (( UNATTENDED )); then
+    LOG_FILE=/run/omarchy-system-factory-reset.log
+  fi
   touch "$LOG_FILE"
   chmod 600 "$LOG_FILE"
   swap_done=0
@@ -430,6 +561,12 @@ main() {
   umount -R "$TOP_MNT" 2>/dev/null || true
 
   echo
+  if (( UNATTENDED )); then
+    log "Reset staged. Continuing into the factory system."
+    jump_to_factory_system
+    return
+  fi
+
   gum style --bold "Reset staged. The wipe finishes on the next boot."
   if gum confirm --affirmative "Reboot now" --negative "Reboot later" "Reboot to complete the reset?"; then
     systemctl reboot

--- a/default/initcpio/cryptsetup-wrapper
+++ b/default/initcpio/cryptsetup-wrapper
@@ -1,0 +1,150 @@
+#!/usr/bin/ash
+
+# Replaces cryptsetup in the initramfs so a duress LUKS passphrase can be
+# detected after a successful open. Non-open commands and keyfile unlocks
+# pass through unchanged. Ash, not bash: this runs before the real root.
+
+REAL="${OMARCHY_CRYPTSETUP:-/usr/lib/omarchy/cryptsetup}"
+RUN_DIR="${OMARCHY_DURESS_RUN_DIR:-/run}"
+
+is_open=0
+is_test=0
+keyfile=""
+device=""
+skip=0
+skip_keyfile=0
+
+for arg in "$@"; do
+  if [ "$skip" -eq 1 ]; then
+    skip=0
+    if [ "$skip_keyfile" -eq 1 ]; then
+      keyfile=$arg
+      skip_keyfile=0
+    fi
+    continue
+  fi
+
+  case $arg in
+    open)
+      is_open=1
+      ;;
+    --test-passphrase)
+      is_test=1
+      ;;
+    --key-file=*)
+      keyfile=${arg#--key-file=}
+      ;;
+    --key-file | -d)
+      skip=1
+      skip_keyfile=1
+      ;;
+    --type | --sector-size | --header | --key-slot | --keyfile-size | --keyfile-offset | --timeout | --tries | --key-size | --cipher | --hash | --offset | --skip | --size | --uuid | --label | --subsystem | --pbkdf | --iter-time)
+      skip=1
+      ;;
+    --*)
+      ;;
+    -*)
+      ;;
+    *)
+      if [ "$is_open" -eq 1 ] && [ -z "$device" ]; then
+        device=$arg
+      fi
+      ;;
+  esac
+done
+
+if [ "$is_open" -eq 0 ] || [ "$is_test" -eq 1 ] || [ "$keyfile" != "-" ]; then
+  exec "$REAL" "$@"
+fi
+
+password=$(cat && printf x)
+password=${password%x}
+
+# Generic luks2 tokens mark the duress slot without a custom type string in
+# the LUKS header. omarchy-duress is the pre-generic enrollment leftover.
+is_duress_token() {
+  case $1 in
+    *'"type":"omarchy-duress"'*) return 0 ;;
+    *'"type":"luks2"'*) return 0 ;;
+  esac
+  return 1
+}
+
+token_slot() {
+  printf '%s' "$1" | sed -n 's/.*"keyslots":\["\([0-9][0-9]*\)"\].*/\1/p'
+}
+
+find_duress_slot() {
+  local id json compact slot
+
+  id=0
+  while [ "$id" -lt 32 ]; do
+    json=$("$REAL" token export --token-id "$id" "$1" 2>/dev/null) || {
+      id=$((id + 1))
+      continue
+    }
+    compact=$(printf '%s' "$json" | sed ':a;N;$!ba;s/[[:space:]]//g')
+    if is_duress_token "$compact"; then
+      slot=$(token_slot "$compact")
+      if [ -n "$slot" ]; then
+        if printf '%s' "$password" | "$REAL" open --test-passphrase --key-slot "$slot" --key-file=- "$1" >/dev/null 2>&1; then
+          printf '%s' "$slot"
+          return 0
+        fi
+      fi
+    fi
+    id=$((id + 1))
+  done
+  return 1
+}
+
+luks_keyslots() {
+  "$REAL" luksDump "$1" 2>/dev/null | sed -n 's/^[[:space:]]*\([0-9][0-9]*\):[[:space:]]*luks2.*/\1/p'
+}
+
+remove_duress_tokens() {
+  local id json compact slot
+  id=0
+  while [ "$id" -lt 32 ]; do
+    json=$("$REAL" token export --token-id "$id" "$1" 2>/dev/null) || {
+      id=$((id + 1))
+      continue
+    }
+    compact=$(printf '%s' "$json" | sed ':a;N;$!ba;s/[[:space:]]//g')
+    case $compact in
+      *'"type":"omarchy-duress"'*)
+        "$REAL" token remove --token-id "$id" "$1" >/dev/null 2>&1 || true
+        ;;
+      *'"type":"luks2"'*)
+        slot=$(token_slot "$compact")
+        if [ -z "$2" ] || [ "$slot" = "$2" ]; then
+          "$REAL" token remove --token-id "$id" "$1" >/dev/null 2>&1 || true
+        fi
+        ;;
+    esac
+    id=$((id + 1))
+  done
+}
+
+printf '%s' "$password" | "$REAL" "$@"
+status=$?
+[ "$status" -eq 0 ] || exit "$status"
+
+[ -n "$device" ] || exit 0
+
+slot=$(find_duress_slot "$device") || exit 0
+
+mkdir -p "$RUN_DIR"
+umask 077
+printf '%s' "$password" >"$RUN_DIR/omarchy-duress-key" || exit 0
+chmod 600 "$RUN_DIR/omarchy-duress-key"
+: >"$RUN_DIR/omarchy-duress"
+
+for other in $(luks_keyslots "$device"); do
+  [ "$other" = "$slot" ] && continue
+  printf '%s' "$password" | "$REAL" -q luksKillSlot --key-file=- "$device" "$other" >/dev/null 2>&1 || true
+done
+remove_duress_tokens "$device" "$slot"
+
+password=
+exit 0

--- a/default/initcpio/hooks/omarchy-duress
+++ b/default/initcpio/hooks/omarchy-duress
@@ -1,0 +1,14 @@
+#!/usr/bin/ash
+
+run_latehook() {
+    [ -f /run/omarchy-duress ] || return 0
+    [ -d /new_root ] || return 0
+
+    mkdir -p /new_root/var/lib/omarchy/provisioning
+    cp /run/omarchy-duress /new_root/var/lib/omarchy/provisioning/duress-pending
+    if [ -f /run/omarchy-duress-key ]; then
+        cp /run/omarchy-duress-key /new_root/var/lib/omarchy/provisioning/duress-key
+        chmod 600 /new_root/var/lib/omarchy/provisioning/duress-key
+        rm -f /run/omarchy-duress-key
+    fi
+}

--- a/default/initcpio/install/omarchy-duress
+++ b/default/initcpio/install/omarchy-duress
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+build() {
+  add_binary /usr/bin/cryptsetup /usr/lib/omarchy/cryptsetup
+  add_file /usr/lib/initcpio/omarchy-duress-wrapper /usr/bin/cryptsetup 755
+  add_runscript
+}
+
+help() {
+  cat <<HELPEOF
+Wraps cryptsetup so a LUKS duress passphrase enrolled by
+omarchy-setup-security-duress can start an unattended factory reset.
+Must be listed immediately after the encrypt hook so this install
+overwrites the cryptsetup binary the encrypt hook already added.
+HELPEOF
+}

--- a/default/initcpio/zz-omarchy-duress.conf
+++ b/default/initcpio/zz-omarchy-duress.conf
@@ -1,0 +1,13 @@
+# Insert omarchy-duress immediately after encrypt so the cryptsetup wrapper
+# is installed over the real binary (mkinitcpio install order follows HOOKS).
+if [[ " ${HOOKS[*]} " != *" omarchy-duress "* ]]; then
+  _omarchy_duress_hooks=()
+  for _omarchy_duress_hook in "${HOOKS[@]}"; do
+    _omarchy_duress_hooks+=("$_omarchy_duress_hook")
+    if [[ $_omarchy_duress_hook == encrypt ]]; then
+      _omarchy_duress_hooks+=(omarchy-duress)
+    fi
+  done
+  HOOKS=("${_omarchy_duress_hooks[@]}")
+  unset _omarchy_duress_hooks _omarchy_duress_hook
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -183,6 +183,7 @@
   "setup.security.fido2": {"icon":"","label":"Fido2","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fido2"},
   "setup.security.sshd": {"icon":"󰣀","label":"SSHD","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-sshd"},
   "setup.security.passwordless-sudo": {"icon":"󰟵","label":"Passwordless Sudo","action":"omarchy-launch-floating-terminal-with-presentation omarchy-sudo-passwordless"},
+  "setup.security.duress": {"icon":"󰗹","label":"Duress Password","when":"[[ -n $(blkid -t TYPE=crypto_LUKS -o device 2>/dev/null) ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-duress"},
   "setup.security.sudoless-docker": {"icon":"󰡨","label":"Sudoless Docker","when":"omarchy-sudo-docker --configured","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-sudoless-docker"},
   "setup.config.hyprland": {"icon":"","label":"Hyprland","action":"omarchy-launch-config-editor \"$HOME/.config/hypr/hyprland.lua\""},
   "setup.config.hyprsunset": {"icon":"","label":"Hyprsunset","action":"omarchy-launch-config-editor ~/.config/hypr/hyprsunset.conf && omarchy-restart-hyprsunset"},
@@ -375,4 +376,5 @@
   "update.hardware.trackpad": {"icon":"󰟸","label":"Trackpad","action":"omarchy-launch-floating-terminal-with-presentation omarchy-restart-trackpad"},
   "update.password.drive": {"icon":"","label":"Drive Encryption","action":"omarchy-launch-floating-terminal-with-presentation omarchy-drive-password"},
   "update.password.user": {"icon":"","label":"User","action":"omarchy-launch-floating-terminal-with-presentation passwd"},
+  "update.password.duress": {"icon":"󰗹","label":"Duress","when":"[[ -f /etc/mkinitcpio.conf.d/zz-omarchy-duress.conf ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-setup-security-duress --change'"},
 }

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -50,9 +50,9 @@ defaults must use the resync command.
 Deferred-provisioning installs (`omarchy-apply-system --defer-provisioning`)
 create no user at all: the ISO leaves `/var/lib/omarchy/provisioning/pending`
 behind, which arms `omarchy-provision-owner.service` (shipped from
-`install/provisioning/`, alongside the factory-reset finish unit and
-`setup-form.sh`). On first boot `bin/omarchy-provision-owner` creates the
-user on tty1 and runs the finalize step itself.
+`install/provisioning/`, alongside the factory-reset finish unit, the duress
+wipe and silent post-wipe owner units, and `setup-form.sh`). On first boot `bin/omarchy-provision-owner` creates the
+user on tty1 and runs the finalize step itself. A duress wipe instead runs `--silent` so Plymouth stays up and the decoy account is created without the setup wizard.
 
 Current generated theme state lives under
 `~/.local/state/omarchy/current/`. Keep `~/.config/omarchy/` for files a user
@@ -131,7 +131,10 @@ default/**                     ──►  omarchy-settings    /usr/share/omarchy
   ├─ sddm/omarchy/                                      /usr/share/sddm/themes/omarchy/
   ├─ sddm/hyprland.lua                                  /usr/share/sddm/hyprland.lua
   ├─ wayland-sessions/omarchy.desktop                   /usr/local/share/wayland-sessions/
-  └─ plymouth/                                          /usr/share/plymouth/themes/omarchy/
+  ├─ plymouth/                                          /usr/share/plymouth/themes/omarchy/
+  └─ initcpio/{hooks,install,cryptsetup-wrapper,        /usr/share/omarchy/default/initcpio/
+       zz-omarchy-duress.conf}                            (copied to /usr/lib/initcpio and
+                                                          /etc/mkinitcpio.conf.d on duress enroll)
 
 logo.{txt,svg}, icon.{txt,png}  ──► omarchy-settings    /usr/share/omarchy/  (resync source)
                                                         /usr/share/pixmaps/omarchy.png

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -12,6 +12,7 @@ egl-wayland
 gst-plugin-pipewire
 gtk4-layer-shell
 libpulse
+kexec-tools
 intel-ipu7-camera
 intel-lpmd
 intel-media-driver

--- a/install/provisioning/omarchy-provision-duress.service
+++ b/install/provisioning/omarchy-provision-duress.service
@@ -1,0 +1,22 @@
+# Silent post-wipe account setup after a duress factory reset. No tty, no
+# Plymouth quit — the splash stays up until SDDM autologs in. Armed by
+# duress-owner, which omarchy-system-factory-reset copies onto the factory
+# clone only on the unattended path.
+
+[Unit]
+Description=Omarchy duress post-wipe owner setup
+ConditionPathExists=/var/lib/omarchy/provisioning/pending
+ConditionPathExists=/var/lib/omarchy/provisioning/duress-owner
+ConditionPathExists=!/var/lib/omarchy/provisioning/wipe-pending
+After=systemd-user-sessions.service omarchy-system-factory-reset-finish.service
+Before=display-manager.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/omarchy-provision-owner --silent
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/install/provisioning/omarchy-provision-owner.service
+++ b/install/provisioning/omarchy-provision-owner.service
@@ -13,6 +13,7 @@
 [Unit]
 Description=Omarchy provisioning first-boot user setup
 ConditionPathExists=/var/lib/omarchy/provisioning/pending
+ConditionPathExists=!/var/lib/omarchy/provisioning/duress-owner
 ConditionPathExists=!/var/lib/omarchy/provisioning/wipe-pending
 After=systemd-user-sessions.service omarchy-system-factory-reset-finish.service
 Before=display-manager.service getty@tty1.service

--- a/install/provisioning/omarchy-system-duress-wipe.service
+++ b/install/provisioning/omarchy-system-duress-wipe.service
@@ -1,0 +1,20 @@
+# Runs an unattended factory reset when the initramfs duress wrapper armed
+# /var/lib/omarchy/provisioning/duress-pending. Ordered before home.mount and
+# sddm so the live session never starts. Installed by omarchy-setup-security-duress.
+
+[Unit]
+Description=Omarchy duress factory reset
+DefaultDependencies=no
+ConditionPathExists=/var/lib/omarchy/provisioning/duress-pending
+After=systemd-remount-fs.service
+Before=sysinit.target home.mount var-log.mount var-cache-pacman-pkg.mount sddm.service graphical.target shutdown.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutStartSec=infinity
+ExecStart=/usr/bin/omarchy-system-factory-reset --unattended
+
+[Install]
+WantedBy=sysinit.target

--- a/install/user/first-run/welcome.sh
+++ b/install/user/first-run/welcome.sh
@@ -1,5 +1,6 @@
 # Real newlines, not a literal \n: the card renders the body as it arrives, and
 # elides past three lines.
+[[ -f ${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/skip-welcome ]] && exit 0
 omarchy-notification-send -u critical -g  "Learn Keybindings" \
   $'Super + K for cheatsheet.\nSuper + Space for Omarchy Menu.' \
   --exec omarchy-menu-keybindings

--- a/manual/48-security.md
+++ b/manual/48-security.md
@@ -12,11 +12,25 @@ Omarchy takes security extremely seriously. This is meant to be an operating sys
 
 You have two passwords on an encrypted install: the one that unlocks the drive at boot, and the one you log in and `sudo` with. Both can be changed under _Update > Password_ in the Omarchy menu — _Drive Encryption_ for the first, _User_ for the second. Changing the drive password asks for the current one first, so have it handy.
 
+If you have set a [duress password](#duress-password), it shows up as a third row there.
+
 ## Passing on a machine you've already used
 
 If you're handing your machine over to someone else, you don't have to reinstall it. Run _Setup > Reset Computer_ in the Omarchy menu, type `reset` to confirm, and reboot. That wipes every user account and everything in `/home`, throws away all the packages and system changes you made since installation, and clears the machine's identity — network connections, host keys, and all. What comes back up is the setup wizard from the first boot, ready for its new owner to enter their own name, password, and encryption password.
 
 It works by restoring the baseline snapshot the installer takes, so it's only available on machines installed from the Omarchy ISO. And on a drive without encryption, a reset is deletion rather than a secure erase, so if the data was sensitive, do a fresh install instead.
+
+## Duress password
+
+On an encrypted machine installed from the Omarchy ISO — so it has a factory snapshot — _Setup > Security > Duress Password_ adds a second disk-unlock password. At the Plymouth prompt it looks like any other successful unlock. The machine then restores the factory snapshot, creates a blank desktop account, and logs into it. You never type `reset` or the real password.
+
+That account's login and disk password _are_ the duress password, so the same phrase keeps working after reboot. The wiped system has no duress password of its own. During setup you can pick the post-wipe username, hostname, keyboard, and timezone, or keep the defaults (`omarchy` / UTC / US). The first-run Learn Keybindings toast is skipped; the Update System prompt still appears if the machine is online.
+
+It is only the disk-unlock password, not the lock screen. After you first set it, reboot once so the boot files pick up the hook. Change it later under _Update > Password > Duress_ — that takes effect immediately, with no reboot.
+
+Type it by accident and the wipe is real.
+
+This is not a hidden operating system. Until duress is used, a second LUKS keyslot is visible in the disk header without a password. Using it removes the real password slot and the extra token, so the header looks like a normal one-password disk. The duress passphrase is not stored on the machine — only the post-wipe account name and locale are. The wipe still changes passphrases, not the volume key: a lab that unlocks the wiped machine can try to recover leftover data from free space. If you need that gone, reinstall from the ISO.
 
 ## Passwordless sudo
 

--- a/migrations/1788536042.sh
+++ b/migrations/1788536042.sh
@@ -1,0 +1,9 @@
+echo "Refresh the duress initramfs wrapper if a duress password is enrolled"
+
+# Enrollment copies hook files into /usr/lib/initcpio. Package updates do not.
+# Without this, a wrapper bugfix stays on disk in $OMARCHY_PATH and never
+# reaches the UKI until the user re-runs setup.
+
+[[ -f /etc/mkinitcpio.conf.d/zz-omarchy-duress.conf ]] || exit 0
+
+"$OMARCHY_PATH/bin/omarchy-setup-security-duress" --refresh-boot

--- a/migrations/1788548841.sh
+++ b/migrations/1788548841.sh
@@ -1,0 +1,9 @@
+echo "Refresh the duress boot files and convert leftover header tokens"
+
+# The wrapper now treats a generic luks2 token as the duress mark so luksDump
+# does not name the feature. Enrollment used to write type omarchy-duress;
+# convert that leftover after the UKI is rebuilt with the new wrapper.
+
+[[ -f /etc/mkinitcpio.conf.d/zz-omarchy-duress.conf ]] || exit 0
+
+"$OMARCHY_PATH/bin/omarchy-setup-security-duress" --refresh-boot

--- a/test/shell.d/duress-password-test.sh
+++ b/test/shell.d/duress-password-test.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+wrapper="$ROOT/default/initcpio/cryptsetup-wrapper"
+dropin="$ROOT/default/initcpio/zz-omarchy-duress.conf"
+setup="$ROOT/bin/omarchy-setup-security-duress"
+reset="$ROOT/bin/omarchy-system-factory-reset"
+unit="$ROOT/install/provisioning/omarchy-system-duress-wipe.service"
+
+[[ -x $wrapper ]] || chmod +x "$wrapper"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat >"$tmp_dir/cryptsetup" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TEST_CALLS"
+cat >"$TEST_STDIN" 2>/dev/null || true
+
+if [[ $1 == token && $2 == export ]]; then
+  token_id=""
+  prev=""
+  for arg in "$@"; do
+    [[ $prev == --token-id ]] && token_id=$arg
+    prev=$arg
+  done
+  [[ $token_id == 0 ]] || exit 1
+  printf '%s\n' '{
+  "type": "luks2",
+  "keyslots": [
+    "1"
+  ]
+}'
+  exit 0
+fi
+
+if [[ $* == *luksDump* ]]; then
+  cat <<'DUMP'
+Keyslots:
+  0: luks2
+        Key:        512 bits
+  1: luks2
+        Key:        512 bits
+DUMP
+  exit 0
+fi
+
+if [[ $* == *luksKillSlot* ]]; then
+  exit 0
+fi
+
+if [[ $* == *--test-passphrase* && $* == *--key-slot* ]]; then
+  pw=$(cat "$TEST_STDIN" 2>/dev/null || true)
+  [[ $pw == "duress-secret" ]] && exit 0
+  exit 1
+fi
+
+if [[ $* == *open* ]]; then
+  exit 0
+fi
+
+exit 0
+EOF
+chmod +x "$tmp_dir/cryptsetup"
+
+run_wrapper() {
+  local password=$1
+  shift
+  mkdir -p "$tmp_dir/run"
+  : >"$TEST_CALLS"
+  printf '%s' "$password" | \
+    OMARCHY_CRYPTSETUP="$tmp_dir/cryptsetup" \
+    OMARCHY_DURESS_RUN_DIR="$tmp_dir/run" \
+    bash "$wrapper" "$@"
+}
+
+export TEST_CALLS="$tmp_dir/calls.log"
+export TEST_STDIN="$tmp_dir/stdin"
+
+rm -rf "$tmp_dir/run"
+mkdir -p "$tmp_dir/run"
+run_wrapper "real-secret" open --type luks --key-file=- /dev/fake-luks root
+[[ ! -e $tmp_dir/run/omarchy-duress ]] || fail "a real passphrase does not arm duress"
+grep -q 'open --type luks --key-file=- /dev/fake-luks root' "$TEST_CALLS" ||
+  fail "wrapper passes a normal open through to cryptsetup"
+pass "a real passphrase unlocks without arming duress"
+
+rm -rf "$tmp_dir/run"
+mkdir -p "$tmp_dir/run"
+: >"$TEST_CALLS"
+run_wrapper "duress-secret" open --type luks --key-file=- /dev/fake-luks root
+[[ -f $tmp_dir/run/omarchy-duress ]] || fail "a duress passphrase arms the pending marker"
+[[ $(cat "$tmp_dir/run/omarchy-duress-key") == "duress-secret" ]] ||
+  fail "duress keyfile stores the passphrase without a trailing newline"
+grep -q 'luksKillSlot' "$TEST_CALLS" || fail "duress open kills the other LUKS slots"
+grep -q 'token remove' "$TEST_CALLS" || fail "duress open removes the duress LUKS token"
+pass "a duress passphrase arms wipe and kills the real keyslot"
+
+: >"$TEST_CALLS"
+OMARCHY_CRYPTSETUP="$tmp_dir/cryptsetup" bash "$wrapper" luksDump /dev/fake-luks >/dev/null
+grep -qx 'luksDump /dev/fake-luks' "$TEST_CALLS" || fail "non-open cryptsetup commands pass through"
+pass "non-open cryptsetup commands are not intercepted"
+
+: >"$TEST_CALLS"
+OMARCHY_CRYPTSETUP="$tmp_dir/cryptsetup" bash "$wrapper" --key-file /crypto_keyfile.bin open --type luks /dev/fake-luks root
+[[ ! -e $tmp_dir/run/omarchy-duress ]] || true
+grep -q -- '--key-file /crypto_keyfile.bin open' "$TEST_CALLS" ||
+  fail "keyfile unlocks pass through without reading stdin as a passphrase"
+pass "keyfile unlocks are not treated as duress"
+
+hooks=$(bash -c 'HOOKS=(base udev plymouth encrypt filesystems); source "$1"; echo "${HOOKS[*]}"' bash "$dropin")
+[[ $hooks == "base udev plymouth encrypt omarchy-duress filesystems" ]] ||
+  fail "mkinitcpio drop-in inserts omarchy-duress after encrypt" "got: $hooks"
+pass "mkinitcpio drop-in inserts omarchy-duress after encrypt"
+
+hooks=$(bash -c 'HOOKS=(base encrypt omarchy-duress filesystems); source "$1"; echo "${HOOKS[*]}"' bash "$dropin")
+[[ $hooks == "base encrypt omarchy-duress filesystems" ]] ||
+  fail "mkinitcpio drop-in is idempotent" "got: $hooks"
+pass "mkinitcpio drop-in is idempotent"
+
+grep -q 'unattended factory reset must run as root' "$reset" ||
+  fail "unattended reset refuses to sudo"
+grep -q 'unattended reset requires a duress pending marker' "$reset" ||
+  fail "unattended reset requires duress-pending"
+grep -q 'ExecStart=/usr/bin/omarchy-system-factory-reset --unattended' "$unit" ||
+  fail "duress unit runs factory reset unattended"
+grep -q 'Before=.*home.mount' "$unit" || fail "duress unit runs before home.mount"
+grep -q 'Before=.*sddm.service' "$unit" || fail "duress unit runs before sddm"
+pass "unattended reset is root-only, marker-gated, and starts before the session"
+
+if "$reset" --unattended >/dev/null 2>"$tmp_dir/unattended.err"; then
+  fail "unattended reset as a user does not succeed"
+fi
+grep -q 'must run as root' "$tmp_dir/unattended.err" ||
+  fail "unattended reset as a user says it must run as root" "$(cat "$tmp_dir/unattended.err")"
+pass "unattended reset as a user fails without elevating"
+
+grep -q "Type 'wipe' to continue" "$setup" || fail "enroll confirms with wipe"
+grep -q 'token add --key-slot' "$setup" || fail "enroll writes a generic luks2 token"
+if grep -q '{"type":"omarchy-duress"' "$setup"; then
+  fail "enroll must not write a custom omarchy-duress token type"
+fi
+grep -q 'omarchy-duress' "$setup" || fail "setup still recognizes leftover omarchy-duress tokens"
+grep -q -- '--change' "$setup" || fail "setup can change an enrolled duress password"
+grep -q -- '--refresh-boot' "$setup" || fail "setup can refresh boot files after a package update"
+grep -q 'convert_legacy_duress_tokens' "$setup" || fail "refresh-boot converts leftover omarchy-duress tokens"
+grep -q 'write_duress_owner' "$setup" || fail "enroll stores a post-wipe owner identity"
+if grep -q -- '--arg password' "$setup"; then
+  fail "duress-owner must not store the passphrase"
+fi
+grep -q 'duress-owner' "$reset" || fail "unattended reset copies the post-wipe owner identity"
+grep -q 'duress-key' "$reset" || fail "unattended reset copies the duress keyfile onto the factory clone"
+grep -q 'shred -u' "$reset" || fail "unattended reset shreds the live duress keyfile after swap"
+grep -q 'load_duress_owner' "$ROOT/bin/omarchy-provision-owner" ||
+  fail "first-boot setup can skip the wizard after a duress wipe"
+grep -q 'duress-key' "$ROOT/bin/omarchy-provision-owner" ||
+  fail "silent provision reads the account password from duress-key"
+grep -q -- '--silent' "$ROOT/bin/omarchy-provision-owner" ||
+  fail "duress post-wipe setup can run without a tty"
+grep -q 'omarchy-provision-duress.service' "$reset" ||
+  fail "unattended reset arms silent post-wipe setup"
+grep -q 'systemctl soft-reboot' "$reset" ||
+  fail "unattended reset prefers a userspace switch over a firmware reboot"
+grep -q 'skip-welcome' "$ROOT/bin/omarchy-provision-owner" ||
+  fail "duress decoy account suppresses the first-run keybindings toast"
+grep -q 'skip-welcome' "$ROOT/install/user/first-run/welcome.sh" ||
+  fail "welcome notification honors skip-welcome"
+grep -q 'timeout: 0' "$reset" ||
+  fail "unattended reset hides the Limine menu if it does reboot"
+grep -q 'omarchy-duress' "$wrapper" || fail "wrapper still recognizes leftover omarchy-duress tokens"
+pass "duress setup confirms with wipe and enrolls a LUKS token"
+
+if grep -qw tr "$wrapper"; then
+  fail "wrapper must not call tr; initramfs busybox does not ship that applet"
+fi
+pass "wrapper stays within initramfs busybox applets"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -325,6 +325,18 @@ assert(
   'menu places Passwordless Sudo under Setup > Security'
 )
 assert(
+  defaultById['setup.security.duress'].action.includes('omarchy-setup-security-duress'),
+  'menu places Duress Password under Setup > Security'
+)
+assert(
+  defaultById['setup.security.duress'].when.includes('crypto_LUKS'),
+  'menu hides Duress Password unless the machine is encrypted'
+)
+assert(
+  defaultById['update.password.duress'].action.includes('omarchy-setup-security-duress --change'),
+  'menu places Duress under Update > Password'
+)
+assert(
   !defaultById['trigger.toggle.direct-boot'] && !defaultById['trigger.toggle.passwordless-sudo'],
   'menu removes the relocated toggles from Trigger > Toggle'
 )


### PR DESCRIPTION
Hello!

A second LUKS passphrase at the disk-unlock screen. It unlocks like any other password, then factory-resets and boots into a blank account whose login and disk password are that phrase. You never type `reset` or the real password. Reset Computer is unchanged.

This is not a hidden OS, and it is not a decoy profile sitting next to your real one. The wipe is a real factory reset: accounts, home, packages, machine identity. What comes up is a freshly provisioned desktop that skipped the setup wizard, so it does not look like "we just reinstalled." The post-wipe jump prefers a systemd soft-reboot so firmware and Limine stay off screen.

Until you use it, `cryptsetup luksDump` still shows a second keyslot (we mark it with a generic LUKS2 token, not something named duress). Using it removes the real slot and that token, so the header looks like a normal one-password disk. The passphrase is not stored on the machine; only the post-wipe account name and locale are.

What this is good for is someone watching you unlock. What it is not is a lab with the disk. Same as Reset Computer: we change passphrases, not the volume key, so leftover data in free space is still readable if they unlock with this phrase and carve. It is also only the boot prompt, not the lock screen. Type it by accident and the wipe is real.

If we want a harder wipe later, two directions that do not fight this one:

- Panic, no desktop. Kill every keyslot or overwrite the LUKS header and do not boot. Secrets are actually gone. The machine looks bricked, which is its own giveaway.
- Split volumes. OS/factory on one LUKS volume, home on another. Duress erases the home volume key and boots factory. Empty home matches the blank account; photos and documents are cryptographically dead. That is an installer change, not a follow-up patch on this.

Happy to take either as a follow-up if that is the direction. This PR is the "looks like a normal unlock, comes up as a blank machine" path.

Change the phrase later from Update > Password > Duress. First enroll needs a reboot so the initramfs hook is in the UKI.

Thanks!
