### PR TITLE
Add power source change hook

### DIFF
--- a/config/omarchy/hooks/power-source-change.d/show-power-source-notification.sample
+++ b/config/omarchy/hooks/power-source-change.d/show-power-source-notification.sample
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This hook is called with "ac" or "battery" when the power source changes.
+# To put it into use, remove .sample from this file name.
+
+# Example: Show the newly active power source.
+# omarchy-notification-send -u low "Power source" "Now using $1 power"

--- a/default/agents/skills/omarchy/hooks.md
+++ b/default/agents/skills/omarchy/hooks.md
@@ -16,6 +16,7 @@ file first, if one exists.
 ├── post-boot.d/            # After the desktop starts
 ├── post-update.d/          # During `omarchy update`, after system packages and migrations
 ├── pre-refresh-pacman.d/   # Before `omarchy refresh pacman` re-syncs packages
+├── power-source-change.d/  # After switching power source (`ac` or `battery` in $1)
 └── theme-set.d/            # After theme change (theme slug in $1)
 ```
 

--- a/manual/31-dotfiles.md
+++ b/manual/31-dotfiles.md
@@ -46,6 +46,8 @@ Omarchy fires hooks at a handful of moments, and you can hang your own scripts o
 
 Each of those directories already holds a `.sample` file showing the shape of a hook — drop the `.sample` from the name to put it to work. To install a script you've written elsewhere, use `omarchy hook install post-boot ~/my-hook`, which copies it in and makes it executable.
 
+The `power-source-change` hook starts watching after the power service initializes, so logging in does not run it. Hooks run one at a time; if the source changes several times while a hook is running, the latest source is delivered when it finishes.
+
 ### Adding your own menu entries
 
 The Omarchy menu (`Super + Space`) can be extended with your own rows by editing `~/.config/omarchy/extensions/omarchy-menu.jsonc`. Entries are keyed by a dotted id, and the id is what places them in the tree, so `personal` shows up on the root menu and `personal.notes` shows up inside it:

--- a/manual/31-dotfiles.md
+++ b/manual/31-dotfiles.md
@@ -42,6 +42,7 @@ Omarchy fires hooks at a handful of moments, and you can hang your own scripts o
 | `theme-set` | After a theme change (theme name in `$1`) |
 | `font-set` | After a font change (font name in `$1`) |
 | `battery-low` | When the battery gets low (percentage in `$1`) |
+| `power-source-change` | When switching between AC and battery power (`ac` or `battery` in `$1`) |
 
 Each of those directories already holds a `.sample` file showing the shape of a hook — drop the `.sample` from the name to put it to work. To install a script you've written elsewhere, use `omarchy hook install post-boot ~/my-hook`, which copies it in and makes it executable.
 

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -12,6 +12,7 @@ Item {
 
   readonly property int batteryThreshold: 10
   property string pendingPowerSource: ""
+  property string pendingPowerSourceHook: ""
 
   PersistentProperties {
     id: persisted
@@ -53,11 +54,27 @@ Item {
     powerProfileProcess.running = true
   }
 
+  function dispatchPowerSourceHook() {
+    pendingPowerSourceHook = UPower.onBattery ? "battery" : "ac"
+    if (!powerSourceHookProcess.running) runPendingPowerSourceHook()
+  }
+
+  function runPendingPowerSourceHook() {
+    powerSourceHookProcess.command = ["omarchy-hook", "power-source-change", pendingPowerSourceHook]
+    pendingPowerSourceHook = ""
+    powerSourceHookProcess.running = true
+  }
+
   Process { id: warningProcess }
 
   Process {
     id: powerProfileProcess
     onExited: if (root.pendingPowerSource !== "") root.runPendingPowerProfile()
+  }
+
+  Process {
+    id: powerSourceHookProcess
+    onExited: if (root.pendingPowerSourceHook !== "") root.runPendingPowerSourceHook()
   }
 
   Timer {
@@ -73,6 +90,7 @@ Item {
     function onOnBatteryChanged() {
       root.checkBattery()
       root.applyPowerProfile()
+      root.dispatchPowerSourceHook()
     }
   }
 }

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -13,6 +13,16 @@ Item {
   readonly property int batteryThreshold: 10
   property string pendingPowerSource: ""
   property string pendingPowerSourceHook: ""
+  property string lastPowerSource: ""
+
+  // UPower hydrates OnBattery before the display device becomes ready. Seed
+  // the baseline then, including when this service loads into an existing shell.
+  Component.onCompleted: initializePowerSource()
+
+  function initializePowerSource() {
+    if (UPower.displayDevice.ready && lastPowerSource === "")
+      lastPowerSource = UPower.onBattery ? "battery" : "ac"
+  }
 
   PersistentProperties {
     id: persisted
@@ -55,7 +65,11 @@ Item {
   }
 
   function dispatchPowerSourceHook() {
-    pendingPowerSourceHook = UPower.onBattery ? "battery" : "ac"
+    if (lastPowerSource === "") return
+    var source = UPower.onBattery ? "battery" : "ac"
+    if (source === lastPowerSource) return
+    lastPowerSource = source
+    pendingPowerSourceHook = source
     if (!powerSourceHookProcess.running) runPendingPowerSourceHook()
   }
 
@@ -83,6 +97,11 @@ Item {
     repeat: true
     triggeredOnStart: true
     onTriggered: root.checkBattery()
+  }
+
+  Connections {
+    target: UPower.displayDevice
+    function onReadyChanged() { root.initializePowerSource() }
   }
 
   Connections {

--- a/test/shell.d/power-source-hook-test.sh
+++ b/test/shell.d/power-source-hook-test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+const qml = fs.readFileSync(path.join(root, 'shell/plugins/services/battery/Service.qml'), 'utf8')
+assert(qml.includes('Component.onCompleted: initializePowerSource()'), 'component completion seeds an already-ready service')
+assert(/target: UPower\.displayDevice\s+function onReadyChanged\(\) \{ root\.initializePowerSource\(\) \}/.test(qml), 'display device readiness seeds the startup baseline')
+// Execute the actual service methods with controlled UPower and Process state.
+const methods = ['initializePowerSource', 'dispatchPowerSourceHook', 'runPendingPowerSourceHook']
+const code = methods.map(name => qml.match(new RegExp('  function ' + name + '\\(\\) \\{[\\s\\S]*?\\n  \\}'))[0]).join('\n')
+function service(onBattery, ready = false) {
+  const state = {
+    UPower: { onBattery, displayDevice: { ready } },
+    lastPowerSource: '', pendingPowerSourceHook: '',
+    powerSourceHookProcess: { running: false, command: [] }
+  }
+  vm.createContext(state)
+  vm.runInContext(code, state)
+  state.initializePowerSource()
+  return state
+}
+for (const onBattery of [false, true]) {
+  const s = service(false)
+  s.UPower.onBattery = onBattery
+  s.dispatchPowerSourceHook()
+  assert(!s.powerSourceHookProcess.running, 'initial hydration is silent on ' + (onBattery ? 'battery' : 'AC'))
+  s.UPower.displayDevice.ready = true
+  s.initializePowerSource()
+  assert(!s.powerSourceHookProcess.running, 'readiness establishes a silent baseline')
+  s.dispatchPowerSourceHook()
+  assert(!s.powerSourceHookProcess.running, 'unchanged source does not dispatch a hook')
+  s.UPower.onBattery = !onBattery
+  s.dispatchPowerSourceHook()
+  assertDeepEqual(s.powerSourceHookProcess.command, ['omarchy-hook', 'power-source-change', onBattery ? 'ac' : 'battery'], 'first real transition is delivered')
+}
+const s = service(true, true)
+s.dispatchPowerSourceHook()
+assert(!s.powerSourceHookProcess.running, 'loading into an initialized shell is silent')
+s.UPower.onBattery = false
+s.dispatchPowerSourceHook()
+s.initializePowerSource()
+assertEqual(s.lastPowerSource, 'ac', 'initialization does not reset an established baseline')
+s.UPower.onBattery = true
+s.dispatchPowerSourceHook()
+s.UPower.onBattery = false
+s.dispatchPowerSourceHook()
+assertEqual(s.pendingPowerSourceHook, 'ac', 'busy hook retains the latest source')
+assertDeepEqual(s.powerSourceHookProcess.command, ['omarchy-hook', 'power-source-change', 'ac'], 'busy process command is not replaced')
+s.powerSourceHookProcess.running = false
+s.runPendingPowerSourceHook()
+assertEqual(s.pendingPowerSourceHook, '', 'queued source is consumed')
+JS

--- a/test/shell.d/powerprofiles-set-test.sh
+++ b/test/shell.d/powerprofiles-set-test.sh
@@ -77,6 +77,20 @@ rg -F '["omarchy-powerprofiles-set", pendingPowerSource]' "$ROOT/shell/plugins/s
   fail "battery service applies profiles through Omarchy command"
 pass "battery service applies profiles through Omarchy command"
 
+rg -F '["omarchy-hook", "power-source-change", pendingPowerSourceHook]' "$ROOT/shell/plugins/services/battery/Service.qml" >/dev/null ||
+  fail "battery service dispatches the power source hook with the active source"
+rg -F 'onExited: if (root.pendingPowerSourceHook !== "") root.runPendingPowerSourceHook()' "$ROOT/shell/plugins/services/battery/Service.qml" >/dev/null ||
+  fail "battery service serializes power source hook runs"
+rg -F 'root.dispatchPowerSourceHook()' "$ROOT/shell/plugins/services/battery/Service.qml" >/dev/null ||
+  fail "battery service dispatches the hook when UPower reports a source change"
+pass "battery service dispatches serialized power source change hooks"
+
+[[ -f $ROOT/config/omarchy/hooks/power-source-change.d/show-power-source-notification.sample ]] ||
+  fail "power source hook ships an example"
+rg -F '| `power-source-change` | When switching between AC and battery power (`ac` or `battery` in `$1`) |' "$ROOT/manual/31-dotfiles.md" >/dev/null ||
+  fail "manual documents the power source hook argument"
+pass "power source hook ships an example and documentation"
+
 rg -F 'omarchy-powerprofiles-set autodetect' "$ROOT/shell/plugins/menu/Menu.qml" >/dev/null ||
   fail "power profile menu persists selections through Omarchy command"
 pass "power profile menu persists selections through Omarchy command"


### PR DESCRIPTION
Basically I wanted omarchy to make a chime when I plug my machine in. My agent was able to write a couple scripts to do it on my machine, but I figured others may want to do things based on changing from battery to AC. So I had my agent write this hook.

lmk if this is the right approach, if not, happy to regenerate with better context.