### PR TITLE
Exclude the internal Apple T2 Ethernet link from automatic wired profiles

### DIFF
--- a/default/networkmanager/t2-ncm.conf
+++ b/default/networkmanager/t2-ncm.conf
@@ -1,0 +1,5 @@
+# The Apple T2 internal USB Ethernet link is not a LAN connection.
+# Its fixed address is documented by https://wiki.t2linux.org/guides/postinstall/
+# Append rather than replace other no-auto-default exclusions.
+[main]
+no-auto-default+=mac:ac:de:48:00:11:22

--- a/install/hardware/apple/fix-t2.sh
+++ b/install/hardware/apple/fix-t2.sh
@@ -13,6 +13,13 @@ if lspci -nn | grep "106b:180[12]" >/dev/null; then
   # Enable T2 fan control
   systemctl enable t2fanrd.service
 
+  # Do not create a DHCP connection for the internal T2 USB Ethernet link.
+  # Keep USB Ethernet adapters and manually configured connections available.
+  if [[ ! -e /etc/NetworkManager/conf.d/90-omarchy-t2-ncm.conf ]]; then
+    install -Dm644 "$OMARCHY_PATH/default/networkmanager/t2-ncm.conf" \
+      /etc/NetworkManager/conf.d/90-omarchy-t2-ncm.conf
+  fi
+
   mkdir -p /etc/modules-load.d
   {
     echo "t2bce_vhci"

--- a/migrations/1788548210.sh
+++ b/migrations/1788548210.sh
@@ -1,0 +1,15 @@
+echo "Prevent automatic wired connections to the internal Apple T2 interface"
+
+# Do not let grep exit early: with pipefail, a chatty lspci can get SIGPIPE.
+if lspci -nn | grep '106b:180[12]' >/dev/null; then
+  t2_ncm_conf=${OMARCHY_T2_NCM_CONF:-/etc/NetworkManager/conf.d/90-omarchy-t2-ncm.conf}
+  if [[ ! -e $t2_ncm_conf ]]; then
+    sudo install -Dm644 "$OMARCHY_PATH/default/networkmanager/t2-ncm.conf" "$t2_ncm_conf"
+  elif ! cmp -s "$OMARCHY_PATH/default/networkmanager/t2-ncm.conf" "$t2_ncm_conf"; then
+    echo "Preserving customized $t2_ncm_conf; review the T2 no-auto-default exclusion."
+  fi
+  # Avoid interrupting networking during an update. At reboot, NetworkManager
+  # drops its temporary generated profile and loads this exclusion. Persistent
+  # profiles are deliberately untouched, even if named 'Wired connection 1'.
+  echo "T2 network exclusion applies on reboot; existing saved profiles are unchanged."
+fi

--- a/test/shell.d/t2-ncm-test.sh
+++ b/test/shell.d/t2-ncm-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+cat > "$test_tmp/bin/lspci" <<'EOF'
+#!/bin/bash
+if [[ ${TEST_T2:-0} == 1 ]]; then
+  echo 'Bridge: Apple T2 [106b:1801]'
+fi
+for _ in {1..4096}; do echo 'Unrelated device [ffff:0000]'; done
+EOF
+cat > "$test_tmp/bin/sudo" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$TEST_CALLS"
+"$@"
+EOF
+chmod +x "$test_tmp/bin/"*
+export PATH="$test_tmp/bin:$PATH" TEST_CALLS="$test_tmp/calls"
+export OMARCHY_PATH="$ROOT" OMARCHY_T2_NCM_CONF="$test_tmp/conf/t2.conf"
+migration="$ROOT/migrations/1788548210.sh"
+
+TEST_T2=0 bash -euo pipefail "$migration"
+[[ ! -e $OMARCHY_T2_NCM_CONF && ! -e $TEST_CALLS ]] || fail "non-T2 host changed"
+pass "non-T2 hosts are untouched"
+
+TEST_T2=1 bash -euo pipefail "$migration"
+cmp "$ROOT/default/networkmanager/t2-ncm.conf" "$OMARCHY_T2_NCM_CONF"
+[[ $(stat -c %a "$OMARCHY_T2_NCM_CONF") == 644 ]] || fail "wrong config mode"
+[[ $(wc -l < "$TEST_CALLS") == 1 ]] || fail "unexpected privileged operations"
+TEST_T2=1 bash -euo pipefail "$migration"
+[[ $(wc -l < "$TEST_CALLS") == 1 ]] || fail "second invocation changed system"
+pass "T2 migration installs once, without restarting networking"
+
+printf '[main]\nno-auto-default=*\n' > "$OMARCHY_T2_NCM_CONF"
+TEST_T2=1 bash -euo pipefail "$migration"
+grep -Fxq 'no-auto-default=*' "$OMARCHY_T2_NCM_CONF" || fail "custom config overwritten"
+[[ $(wc -l < "$TEST_CALLS") == 1 ]] || fail "custom config modified"
+pass "customized configuration and saved connection profiles are preserved"
+
+grep -Fxq 'no-auto-default+=mac:ac:de:48:00:11:22' "$ROOT/default/networkmanager/t2-ncm.conf" || fail "exclusion must append only the T2 address"
+grep -Fq '"$OMARCHY_PATH/default/networkmanager/t2-ncm.conf"' "$ROOT/install/hardware/apple/fix-t2.sh" || fail "fresh installs missing exclusion"
+pass "fresh installs share the narrowly scoped exclusion"


### PR DESCRIPTION
## Problem

On an Intel T2 MacBookPro16,1 with linux-t2 7.1.8, NetworkManager creates a temporary wired DHCP connection for the internal Apple T2 USB Ethernet link (cdc_ncm, USB 05ac:8233). This link is not an external LAN adapter. Repeated activation attempts fail; the same device also logged repeated transmit watchdog timeouts after resume. We do not claim this configuration change fixes every possible cdc_ncm kernel timeout.

T2 Linux documents excluding this internal connection: https://wiki.t2linux.org/guides/postinstall/

## Change

- Fresh T2 setup installs a NetworkManager `no-auto-default` snippet for the documented fixed internal MAC address.
- Append to existing exclusions rather than replacing them.
- A hardware-gated migration installs the same snippet for existing T2 systems.
- Preserve customized snippets and all saved connection profiles.
- No interface renaming, driver blacklisting, NetworkManager restart, or changes to USB Ethernet/tethering.

## Migration behavior

The setting prevents generation of a default profile; it does not disable saved profiles. At reboot, temporary generated profiles disappear and the exclusion takes effect. A user who previously saved such a profile must review its autoconnect setting separately. The migration intentionally does not delete connections based on a localized name such as Wired connection 1.

On the test machine the active configuration was verified with `NetworkManager --print-config`, loaded without restarting NetworkManager, and the already-existing profile's autoconnect was disabled separately. Wi-Fi remained connected. This local profile edit is not an automated destructive migration.

## Tests

New executable migration tests cover non-T2 hosts, chatty lspci with pipefail, first install, repeat invocation, customized configuration preservation, and absence of service restarts. The fresh-install path uses the same snippet. `git diff --check` passes.

Reboot/resume and physical USB Ethernet/tethering validation remain outstanding; those are explicitly not claimed as tested.

Full suite: `env -u NO_COLOR ./test/all` completed; CLI passes, 226/227 shell test files pass. The remaining existing network-qr test invokes `ip route get` without a stub and exits under sandbox routing restrictions. Initial missing omarchy-pkgs/omarchy-iso checkout failures were resolved by fetching those test dependencies. No unrelated test or product behavior was changed to force a green result.

The remaining `network-qr-test.sh` passes all seven cases when rerun outside the sandbox with routing access. Thus every test file has passed, though the sandboxed aggregate run itself remains nonzero.
