### PR TITLE
Show the workspace name in the bar pips' hover tooltip

### DIFF
--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -58,8 +58,17 @@ BarWidget {
         readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
         readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
 
+        readonly property string keyLabel: modelData === 10 ? "0" : String(modelData)
+        // Hyprland names a fresh workspace after its own id; anything else is
+        // a name someone gave it -- via `hyprctl dispatch` or a
+        // workspace-naming plugin -- worth surfacing on hover since the pip
+        // itself only shows the number.
+        readonly property bool named: workspace !== null
+          && workspace.name !== "" && workspace.name !== String(modelData)
+
         bar: root.bar
-        text: focused ? "\uDB85\uDCFB" : (modelData === 10 ? "0" : String(modelData))
+        text: focused ? "\uDB85\uDCFB" : keyLabel
+        tooltipText: named ? keyLabel + ": " + workspace.name : "Workspace " + keyLabel
         opacity: occupied || focused ? 1 : 0.5
         horizontalMargin: 6
         verticalPadding: 6


### PR DESCRIPTION
Hyprland names a fresh workspace after its own id; anything else is a name someone gave it — via `hyprctl dispatch` or a workspace-naming plugin. This surfaces that name when hovering a pip, as `N: name`, since the pip itself only shows the number. Unnamed workspaces read `Workspace N`, so the pips gain a tooltip either way and the named case stands out.

No new state and no coupling: the name is read from the same `Hyprland.workspaces` objects the widget already binds, and `tooltipText` rides the bar's existing tooltip plumbing (`WidgetButton` → `bar.showTooltip`).

Live on the running shell, hovering pip 2 on a machine whose workspaces are named:

![Workspace pip tooltip showing "2: Rig2"](https://raw.githubusercontent.com/gw7523/omarchy/captures/workspace-pip-tooltip.png)

Tests: `test/cli` passes; `test/shell` shows the same 5 pre-existing environment failures on my machine with and without this change (jq parse errors in migration tests, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01121sXsXetn9HztudfV3maz