### PR TITLE
fix(update): detect aarch64 kernels without vmlinuz

### DIFF
--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -11,14 +11,14 @@ confirm_reboot() {
 running_kernel=$(uname -r)
 kernel_updated=true
 
-for kernel in /usr/lib/modules/*/vmlinuz; do
-  if [[ -f $kernel ]] && pacman -Qo "$kernel" &>/dev/null; then
-    installed_kernel=$(basename "$(dirname "$kernel")")
+for modules_dir in /usr/lib/modules/*/; do
+  [[ -d $modules_dir ]] || continue
+  pacman -Qo "$modules_dir" &>/dev/null || continue
+  installed_kernel=$(basename "$modules_dir")
 
-    if [[ $installed_kernel == $running_kernel ]]; then
-      kernel_updated=false
-      break
-    fi
+  if [[ $installed_kernel == "$running_kernel" ]]; then
+    kernel_updated=false
+    break
   fi
 done
 


### PR DESCRIPTION
## Summary
- match running kernel against pacman-owned `/usr/lib/modules/*/` dirs
- stop requiring `vmlinuz` so linux-aarch64 (Image) no longer always prompts reboot

Fixes #10048.

## Verification
- `bash -n bin/omarchy-update-restart`
- running modules dir → kernel_updated=false without vmlinuz