### PR TITLE
fix(launcher): remove plugin when desktop belongs to a shell plugin

### DIFF
--- a/bin/omarchy-remove-launcher-entry
+++ b/bin/omarchy-remove-launcher-entry
@@ -77,6 +77,60 @@ if [[ $exec_line =~ (^|[[:space:]])(\$TERMINAL|xdg-terminal-exec)[[:space:]].*-e
   exit 0
 fi
 
+# Shell plugins often install a .desktop under the user applications dir
+# (scheme handlers, MIME claims). Deleting only that file leaves the plugin
+# enabled and running — route those through plugin remove instead.
+plugin_owner_for_desktop() {
+  local plugins_dir candidate resolved exec_paths path plugin_id
+  plugins_dir="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/plugins"
+
+  [[ -d $plugins_dir ]] || return 1
+
+  # Desktop id matches an installed plugin directory name (omamail.desktop → omamail).
+  if [[ -e $plugins_dir/$desktop_name || -L $plugins_dir/$desktop_name ]]; then
+    printf '%s\n' "$desktop_name"
+    return 0
+  fi
+
+  # Exec/Icon paths that resolve inside a plugin tree.
+  exec_paths=$(sed -n 's/^\(Exec\|Icon\|TryExec\|Path\)=//p' "$desktop_file")
+  while IFS= read -r candidate; do
+    [[ -z $candidate ]] && continue
+    # Strip field codes and take first token for Exec=
+    candidate=${candidate%% \%*}
+    candidate=${candidate%%\$*}
+    candidate=$(awk '{print $1}' <<<"$candidate")
+    [[ -z $candidate || $candidate == /* ]] || continue
+    resolved=$(readlink -f "$candidate" 2>/dev/null || true)
+    [[ -n $resolved ]] || continue
+    case "$resolved" in
+    "$plugins_dir"/*)
+      path=${resolved#"$plugins_dir"/}
+      plugin_id=${path%%/*}
+      if [[ -n $plugin_id && ( -e $plugins_dir/$plugin_id || -L $plugins_dir/$plugin_id ) ]]; then
+        printf '%s\n' "$plugin_id"
+        return 0
+      fi
+      ;;
+    esac
+  done <<<"$exec_paths"
+
+  return 1
+}
+
+if plugin_id="$(plugin_owner_for_desktop)"; then
+  # Non-interactive: menu Remove already confirmed. --yes skips gum.
+  if command -v omarchy-plugin-remove >/dev/null 2>&1; then
+    exec omarchy-plugin-remove --yes "$plugin_id"
+  elif [[ -x ${OMARCHY_PATH:-}/bin/omarchy-plugin-remove ]]; then
+    exec "${OMARCHY_PATH}/bin/omarchy-plugin-remove" --yes "$plugin_id"
+  else
+    # Same directory as this script when invoked via absolute path from AppLibrary.
+    self_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+    exec "$self_dir/omarchy-plugin-remove" --yes "$plugin_id"
+  fi
+fi
+
 if is_user_desktop_file; then
   display_name="${entry_name:-$desktop_name}"
   rm -f "$desktop_file"

--- a/bin/omarchy-remove-launcher-entry
+++ b/bin/omarchy-remove-launcher-entry
@@ -92,8 +92,9 @@ plugin_owner_for_desktop() {
     return 0
   fi
 
-  # Exec/Icon paths that resolve inside a plugin tree.
-  exec_paths=$(sed -n 's/^\(Exec\|Icon\|TryExec\|Path\)=//p' "$desktop_file")
+  # Exec/TryExec/Path that resolve inside a plugin tree (not Icon= —
+  # an unrelated .desktop may borrow a plugin icon without owning it).
+  exec_paths=$(sed -n 's/^\(Exec\|TryExec\|Path\)=//p' "$desktop_file")
   while IFS= read -r candidate; do
     [[ -z $candidate ]] && continue
     # Strip field codes and take first token for Exec=

--- a/test/shell.d/launcher-remove-test.sh
+++ b/test/shell.d/launcher-remove-test.sh
@@ -68,15 +68,30 @@ Name=Aliens
 Exec=retroarch -L /usr/lib/libretro/fbneo_libretro.so /home/example/Games/roms/fbneo/aliens.zip
 DESKTOP
 
+# Plugin-owned launcher: basename matches ~/.config/omarchy/plugins/<id>
+mkdir -p "$tmp_dir/config/omarchy/plugins/omamail"
+cat >"$tmp_dir/data/applications/omamail.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Omamail
+Exec=true
+MimeType=x-scheme-handler/mailto;
+DESKTOP
+
+write_fake_command omarchy-plugin-remove plugin
+
 export TEST_LOG="$tmp_dir/log"
 export PATH="$tmp_dir/bin:$PATH"
 export XDG_DATA_HOME="$tmp_dir/data"
 export XDG_DATA_DIRS="$tmp_dir/system"
+export XDG_CONFIG_HOME="$tmp_dir/config"
+export HOME="$tmp_dir/home"
+mkdir -p "$HOME"
 
 "$ROOT/bin/omarchy-remove-launcher-entry" Basecamp.desktop Basecamp
 "$ROOT/bin/omarchy-remove-launcher-entry" Docker.desktop Docker
 "$ROOT/bin/omarchy-remove-launcher-entry" native.desktop Native
 "$ROOT/bin/omarchy-remove-launcher-entry" aliens.desktop Aliens
+"$ROOT/bin/omarchy-remove-launcher-entry" omamail.desktop Omamail
 
 mapfile -t lines <"$TEST_LOG"
 
@@ -92,5 +107,12 @@ pass "launcher remove opens package uninstall flow"
 [[ ! -e $tmp_dir/data/applications/aliens.desktop ]] || fail "launcher remove deletes user-owned desktop files"
 pass "launcher remove deletes user-owned desktop files"
 
-(( ${#lines[@]} == 3 )) || fail "launcher remove does not notify for user-owned desktop files" "$(printf '%s\n' "${lines[@]}")"
+(( ${#lines[@]} == 4 )) || fail "launcher remove does not notify for user-owned desktop files" "$(printf '%s\n' "${lines[@]}")"
 pass "launcher remove does not notify for user-owned desktop files"
+
+[[ ${lines[3]} == "plugin:false:--yes omamail" || ${lines[3]} == "plugin::--yes omamail" ]] ||   fail "launcher remove routes plugin desktops through plugin remove" "${lines[3]}"
+pass "launcher remove routes plugin desktops through plugin remove"
+
+[[ -e $tmp_dir/data/applications/omamail.desktop ]] || fail "plugin remove owns the desktop file lifecycle"
+# Fake plugin-remove does not delete desktop; real one does via plugin tree. Presence of call is the contract.
+pass "plugin remove is invoked for plugin-owned launchers"

--- a/test/shell.d/launcher-remove-test.sh
+++ b/test/shell.d/launcher-remove-test.sh
@@ -69,12 +69,21 @@ Exec=retroarch -L /usr/lib/libretro/fbneo_libretro.so /home/example/Games/roms/f
 DESKTOP
 
 # Plugin-owned launcher: basename matches ~/.config/omarchy/plugins/<id>
-mkdir -p "$tmp_dir/config/omarchy/plugins/omamail"
+mkdir -p "$tmp_dir/config/omarchy/plugins/omamail/icons"
+touch "$tmp_dir/config/omarchy/plugins/omamail/icons/app.png"
 cat >"$tmp_dir/data/applications/omamail.desktop" <<'DESKTOP'
 [Desktop Entry]
 Name=Omamail
 Exec=true
 MimeType=x-scheme-handler/mailto;
+DESKTOP
+
+# False positive: Icon= under a plugin tree must NOT imply ownership.
+cat >"$tmp_dir/data/applications/borrowed-icon.desktop" <<DESKTOP
+[Desktop Entry]
+Name=Borrowed Icon
+Exec=true
+Icon=$tmp_dir/config/omarchy/plugins/omamail/icons/app.png
 DESKTOP
 
 write_fake_command omarchy-plugin-remove plugin
@@ -92,6 +101,7 @@ mkdir -p "$HOME"
 "$ROOT/bin/omarchy-remove-launcher-entry" native.desktop Native
 "$ROOT/bin/omarchy-remove-launcher-entry" aliens.desktop Aliens
 "$ROOT/bin/omarchy-remove-launcher-entry" omamail.desktop Omamail
+"$ROOT/bin/omarchy-remove-launcher-entry" borrowed-icon.desktop "Borrowed Icon"
 
 mapfile -t lines <"$TEST_LOG"
 
@@ -116,3 +126,11 @@ pass "launcher remove routes plugin desktops through plugin remove"
 [[ -e $tmp_dir/data/applications/omamail.desktop ]] || fail "plugin remove owns the desktop file lifecycle"
 # Fake plugin-remove does not delete desktop; real one does via plugin tree. Presence of call is the contract.
 pass "plugin remove is invoked for plugin-owned launchers"
+
+[[ ! -e $tmp_dir/data/applications/borrowed-icon.desktop ]] || fail "Icon-only reference deletes desktop without plugin remove"
+pass "Icon-only reference deletes desktop without plugin remove"
+
+# Still exactly one plugin remove (omamail); borrowed-icon must not trigger another.
+plugin_calls=$(grep -c '^plugin:' "$TEST_LOG" || true)
+(( plugin_calls == 1 )) || fail "Icon= under plugin tree is not ownership" "plugin_calls=$plugin_calls lines=$(printf '%s\n' "${lines[@]}")"
+pass "Icon= under plugin tree is not ownership"


### PR DESCRIPTION
## Summary
- detect plugin-owned user .desktop (id match or Exec/Icon under plugins dir)
- route through `omarchy-plugin-remove --yes` instead of bare rm

Fixes #10073.

## Verification
- `bash test/shell.d/launcher-remove-test.sh` (7 ok)