### PR TITLE
Document readiness-aware health check hooks

### DIFF
--- a/manual/31-dotfiles.md
+++ b/manual/31-dotfiles.md
@@ -45,6 +45,51 @@ Omarchy fires hooks at a handful of moments, and you can hang your own scripts o
 
 Each of those directories already holds a `.sample` file showing the shape of a hook — drop the `.sample` from the name to put it to work. To install a script you've written elsewhere, use `omarchy hook install post-boot ~/my-hook`, which copies it in and makes it executable.
 
+#### Checking services without startup alerts
+
+`post-boot` means the desktop has started, not that every application or user service is ready. A health check can otherwise report a failure while the service it checks is still starting. Wait for the readiness condition you actually need, with a bounded retry, before notifying.
+
+For example, save this as `~/check-my-service`, replace `my-service.service` with your user service, and install it with `omarchy hook install post-boot ~/check-my-service`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+umask 077
+
+state="$HOME/.local/state/check-my-service"
+mkdir -p "$state"
+exec 9>"$state/lock"
+flock -n 9 || exit 0
+
+report=$(mktemp "$state/.report-XXXXXX")
+trap 'rm -f -- "$report"' EXIT
+status="FAIL"
+for attempt in {1..12}; do
+  if timeout 2s systemctl --user is-active --quiet my-service.service; then
+    status="OK"
+    break
+  fi
+  if (( attempt < 12 )); then
+    sleep 5
+  fi
+done
+
+printf 'Status: %s\nChecked: %s\nAttempts: %s\n' \
+  "$status" "$(date --iso-8601=seconds)" "$attempt" > "$report"
+mv -f -- "$report" "$state/health.txt"
+
+if [[ $status == "OK" ]]; then
+  omarchy notification dismiss "My service health check failed"
+else
+  omarchy notification send -u critical "My service health check failed" "Report: $state/health.txt"
+  exit 1
+fi
+```
+
+This keeps a private, dated report, publishes it atomically, and clears only the matching old notification after a successful check. Use a distinct notification title and state directory for each check. `systemctl is-active` checks the unit's active state; if you need application readiness, replace it with a read-only probe for that application's ready state. Keep a timeout on the probe so a stalled check cannot wait indefinitely.
+
+You can install the same script as a `post-update` hook; the lock avoids overlapping runs. Hooks run sequentially, so retries delay the remaining hooks. Keep the wait short, or use a separate user service/timer for longer-running monitoring. Recovery is checked the next time the hook runs, not continuously. Retry only read-only checks: rerunning an installation, migration, or other state-changing hook may repeat its side effects. This example does not change how Omarchy runs other hooks.
+
 ### Adding your own menu entries
 
 The Omarchy menu (`Super + Space`) can be extended with your own rows by editing `~/.config/omarchy/extensions/omarchy-menu.jsonc`. Entries are keyed by a dotted id, and the id is what places them in the tree, so `personal` shows up on the root menu and `personal.notes` shows up inside it:


### PR DESCRIPTION
## Summary

Add a small, opt-in health-check recipe to the existing dotfiles/hooks manual. No runtime code, defaults, migrations, or hook-runner behavior changes.

## Motivation

A custom post-boot health check can run before an independently starting user service or application is ready. In a local setup, a check reported a failure several seconds before session restoration completed; a later check passed. This was a race in the custom check, not evidence that Omarchy had overwritten configuration or that all post-boot hooks should be retried.

## Recipe

- Retry only a read-only readiness probe, with bounded attempts and a per-probe timeout.
- Serialize overlapping invocations with flock.
- Publish a private, timestamped OK/FAIL report atomically.
- Notify on persistent failure and dismiss only the check's distinct obsolete notification after success.
- Explain that unit active state is not necessarily application readiness, that sequential hooks are delayed by retries, and that longer monitoring belongs in a user service/timer.
- Explicitly warn against retrying state-changing hooks.

## Validation

- Extracted the exact Bash example from Markdown and passed `bash -n`.
- Executed it in temporary HOME directories with stubbed service/sleep/notification commands: immediate success, recovery after two failures, and persistent failure through all 12 attempts. Verified exit status, attempt count, notification action, report contents, mode 0600, and temporary-file cleanup.
- `git diff --check` passed.
- `./test/all` ran to completion: the CLI suite passed; 2 of 226 shell test files failed: `launch-about-test.sh` and `network-qr-test.sh`. The About failure (`a roomy window animates`) comes from this environment exporting `NO_COLOR`; rerunning with `env -u NO_COLOR bash test/shell.d/launch-about-test.sh` passed all assertions. The network QR test also exits 1 when run individually, after its first two passing assertions; its cause has not been diagnosed here. Both tests and their implementations are unchanged from the base branch. The full suite is therefore not reported as green.

No screenshots: this changes documentation only and does not alter the running desktop. No machine-specific configurations, session identifiers, or logs are included.
