### PR TITLE
Let a bar layout entry lock its widget against dragging

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -542,6 +542,10 @@ Item {
     return BarModel.entryId(entry)
   }
 
+  function entryLocked(entry) {
+    return BarModel.entryLocked(entry)
+  }
+
   function moduleString(entry, key, fallback) {
     return BarModel.moduleString(entry, key, fallback)
   }
@@ -1566,6 +1570,7 @@ Item {
       return componentLoader.item
     }
     readonly property bool hovered: moduleHover.hovered
+    readonly property bool locked: root.entryLocked(entry)
     readonly property bool dragSource: root.barDragSource === slot
     readonly property bool panelOpen: root.activePopout === slot.activeItem
     // Modules bigger than the mark they want (a text label in a padded slot,
@@ -1673,7 +1678,7 @@ Item {
       property bool suppressClick: false
       property real pressedX: 0
       property real pressedY: 0
-      readonly property bool canReorder: root.shell && typeof root.shell.mutateShellConfig === "function"
+      readonly property bool canReorder: root.shell && typeof root.shell.mutateShellConfig === "function" && !slot.locked
       readonly property real dragThreshold: Style.space(4)
 
       anchors.fill: parent

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -11,7 +11,7 @@ function entrySettings(entry) {
   if (!isPlainObject(entry)) return {}
   var copy = {}
   for (var key in entry) {
-    if (key === "id") continue
+    if (key === "id" || key === "locked") continue
     copy[key] = entry[key]
   }
   return copy
@@ -24,6 +24,10 @@ function entryId(entry) {
     if (id !== undefined && id !== null && String(id) !== "") return String(id)
   }
   return ""
+}
+
+function entryLocked(entry) {
+  return isPlainObject(entry) && entry["locked"] === true
 }
 
 function pinTrayToInner(entries, section) {
@@ -217,6 +221,7 @@ if (typeof module !== "undefined") {
     normalizePosition: normalizePosition,
     entrySettings: entrySettings,
     entryId: entryId,
+    entryLocked: entryLocked,
     pinTrayToInner: pinTrayToInner,
     moduleString: moduleString,
     entryIndex: entryIndex,

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -31,7 +31,7 @@ Example `shell.json` (bar subtree only shown):
       "left": [
         { "id": "omarchy.menu" },
         { "id": "omarchy.spacer", "size": 12 },
-        { "id": "omarchy.workspaces" }
+        { "id": "omarchy.workspaces", "locked": true }
       ],
       "center": [
         { "id": "omarchy.media" },
@@ -47,6 +47,8 @@ Example `shell.json` (bar subtree only shown):
 ```
 
 `centerAnchor` pins one center module to the exact horizontal/vertical center and flanks others around it. Set to an empty string to disable anchoring (the center list is centered as a group).
+
+`"locked": true` on a layout entry stops that widget being dragged. It still reorders through `omarchy bar move`, so the lock guards against a stray pointer rather than sealing the position against every route.
 
 ## Module catalogue
 

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -30,6 +30,11 @@ if ! perl -0ne 'exit(/onPressAndHold:\s*function[^{]*\{[^}]*?\bpressed\b[^}]*?\b
 fi
 pass "bar move ignores a press-and-hold propagated from a widget above"
 
+if ! rg -q 'canReorder:.*!slot\.locked' "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "bar reorder gate must refuse a locked slot"
+fi
+pass "bar reorder gate refuses a locked slot"
+
 run_node_test <<'JS'
 const fs = require('fs')
 const bar = requireFromRoot('shell/plugins/bar/BarModel.js')
@@ -289,6 +294,12 @@ assertEqual(bar.normalizePosition('sideways'), 'top', 'bar defaults invalid posi
 assertDeepEqual(bar.entrySettings({ id: 'omarchy.clock', format: 'HH:mm' }), { format: 'HH:mm' }, 'bar extracts entry settings')
 assertEqual(bar.entryId({ id: 'omarchy.clock' }), 'omarchy.clock', 'bar extracts object entry ids')
 assertEqual(bar.entryId('omarchy.clock'), 'omarchy.clock', 'bar extracts string entry ids')
+
+assertDeepEqual(bar.entrySettings({ id: 'omarchy.workspaces', locked: true }), {}, 'bar keeps the lock flag out of widget settings')
+assertEqual(bar.entryLocked({ id: 'omarchy.workspaces', locked: true }), true, 'bar reads a locked entry')
+assertEqual(bar.entryLocked({ id: 'omarchy.workspaces' }), false, 'bar treats an entry with no flag as movable')
+assertEqual(bar.entryLocked({ id: 'omarchy.workspaces', locked: 'yes' }), false, 'bar ignores a lock flag that is not literally true')
+assertEqual(bar.entryLocked('omarchy.workspaces'), false, 'bar treats a bare string entry as movable')
 
 const entries = [{ id: 'a' }, { id: 'omarchy.tray' }, { id: 'b' }]
 assertDeepEqual(bar.pinTrayToInner(entries, 'left').map(bar.entryId), ['a', 'b', 'omarchy.tray'], 'bar pins tray to left inner edge')


### PR DESCRIPTION
**TLDR:** An opt-in `locked` flag on a bar layout entry, so a widget cannot be dragged out of place by accident. Nothing changes for anyone who does not set it.

---

A bar layout entry takes a new key `locked`:

```json
{ "id": "omarchy.workspaces", "locked": true }
```

The widget then ignores drags. The gate in [`Bar.qml`](https://github.com/omacom/omarchy/blob/493067741e081c3b09082da6bfd51e99ec24ef00/shell/plugins/bar/Bar.qml#L1676) gains one term:

```qml
readonly property bool canReorder: root.shell && typeof root.shell.mutateShellConfig === "function" && !slot.locked
```

I kept accidentally dragging the workspace indicator out of place while trying to click a workspace. That widget is a click target by design, so it gets clicked constantly, and the bar reorders on a very small drag threshold with no modifier and no edit mode. A click that drifts a few pixels moves the widget instead of switching workspace.

It is also not self-correcting. The workspace indicator is the only widget in my left section, so once it has been dragged away the section is empty and there is no drop target left to aim at. Putting it back means `omarchy bar move` or editing shell.json by hand (this might justify a separate patch later on... ).

There is currently no way to say a widget should stay where it is, so rather than keep the patch to myself I would rather anyone who hits the same thing be able to lock a widget down.

Requested independently in [discussion 8222](https://github.com/omacom/omarchy/discussions/8222), which describes the same trigger: an imprecise click on a workspace number nudging the widget into another section. That thread floats a bar-wide `bar.locked` instead. I went per-entry because it leaves the rest of the bar draggable while you are still arranging it, and a bar-wide flag can layer on top later without changing this key.

## What it does not do

- `omarchy bar move` still relocates a locked widget. An explicit command should not be second-guessed, but it does mean "locked" overstates it.
- A locked widget is still a drop target, so a neighbor dropped onto it shifts its index within the section. It cannot be dragged out of the section, but it is not pinned to an absolute slot.
- Nothing renders differently, so a refused drag is indistinguishable from a missed grab. That probably wants a cursor or opacity change, which I left to you rather than guessing at the visual language.
- No command sets the flag, it is a shell.json edit. An `omarchy bar lock <id>` would be the obvious follow-up.

## Tests

`test/shell` is unchanged by this, with coverage added to `bar-test.sh` for the flag. 
The failures it reports here also reproduce on a clean checkout of the base commit: the bar icon geometry check, the per-screen IPC handler count, and two `omarchy-pkgs` checks wanting a sibling repository I do not have. No CI runs on fork PRs, so those are worth re-running wherever you normally do.

