### PR TITLE
agent-usage-update: discover user-level collectors in $XDG_BIN_HOME or ~/.local/bin

### DIFF
--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -52,10 +52,18 @@ collect() {
 }
 
 pids=()
-for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
+# User-level collectors (e.g. ~/.local/bin/omarchy-agent-usage-hermes) join
+# the packaged set, so agents installed outside Omarchy packages show up in
+# the agents panel too. Packaged collectors win on name collision so a
+# stale user copy can never shadow an upstream-shipped one.
+user_bin="${XDG_BIN_HOME:-$HOME/.local/bin}"
+declare -A seen
+for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-* "$user_bin"/omarchy-agent-usage-*; do
   [[ -x $collector ]] || continue
   agent="${collector##*/omarchy-agent-usage-}"
-  [[ $agent == "update" ]] && continue
+  [[ -n $agent && $agent != "update" ]] || continue
+  [[ -n ${seen[$agent]:-} ]] && continue
+  seen[$agent]=1
   wanted "$agent" || continue
   collect "$collector" "$agent" &
   pids+=($!)


### PR DESCRIPTION
## Summary

`omarchy-agent-usage-update` only discovers collectors in `$OMARCHY_PATH/bin`, so agents installed outside Omarchy packages never reach the agents panel unless their plugin ships a separate systemd timer that writes the usage record itself. This PR adds user-level discovery: collectors in `${XDG_BIN_HOME:-$HOME/.local/bin}/omarchy-agent-usage-*` run alongside the packaged set.

Packaged collectors win on name collision, so a stale user-level copy can never shadow an upstream-shipped collector. This is the user-level mirror of the packaged `omarchy-agent-*` pattern that community agent plugins (Hermes, for one) already follow.

## Testing

- Packaged + user collectors both discovered, packaged wins the collision (verified with stub collectors: `alpha.json` from the package, `beta.json` from user dir).
- An executable named exactly `omarchy-agent-usage-` (empty agent name) no longer triggers a `bad array subscript` error.
- Non-executable paths and the `update` script are skipped as before.