### PR TITLE
Send universal copy/paste/cut as keycodes so non-Latin layouts work

### DIFF
--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -42,7 +42,18 @@ local function universal_clipboard_shortcut(default_mods, default_key, terminal_
   end
 end
 
-o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "C", "CTRL", "Insert"))
-o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "V", "SHIFT", "Insert"))
-o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", "X"))
+-- Name the letters by keycode, not by keysym. Hyprland resolves a keysym name
+-- against the *active* keymap, so "C" is simply absent while a non-Latin layout
+-- (ru, uk, bg, el, ...) is selected: send_key_state then aborts with
+-- "key not found" and the shortcut only pops a Hyprland error notification.
+-- A keycode is layout-independent and is exactly what a physical press emits,
+-- so clients keep applying their usual Latin-fallback accelerator matching.
+-- Insert stays a name; it is present in every layout.
+local KEY_C = "code:54" -- AB03
+local KEY_V = "code:55" -- AB04
+local KEY_X = "code:53" -- AB02
+
+o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", KEY_C, "CTRL", "Insert"))
+o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", KEY_V, "SHIFT", "Insert"))
+o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", KEY_X))
 o.bind("SUPER + CTRL + V", "Clipboard manager", "omarchy-shell shell toggle omarchy.clipboard")


### PR DESCRIPTION
Super + C / Super + V / Super + X do nothing but raise a Hyprland error notification while a non-Latin keyboard layout is active.

`send_key_state` takes the key by **keysym name**, and Hyprland resolves that name against the *active* keymap. With `kb_layout = us,ru` and the Russian group selected, there is no `c` keysym in the map, so the dispatcher bails out before sending anything:

```
$ hyprctl dispatch 'hl.dsp.send_key_state({ mods = "CTRL", key = "C", state = "down" })'
error: send_key_state: key not found
```

The same call with a keycode succeeds under any layout:

```
$ hyprctl dispatch 'hl.dsp.send_key_state({ mods = "CTRL", key = "code:54", state = "down" })'
ok
```

So this switches the three letter keys to keycodes (`code:54` / `code:55` / `code:53` — AB03 / AB04 / AB02). A keycode is layout-independent and is exactly what a physical key press puts on the wire, so clients keep doing their usual Latin-fallback accelerator matching — the same reason physically pressing Ctrl + C already copies while typing Cyrillic. `Insert` is left as a name: it exists in every layout, which is why the terminal branch of the binding was the only part that still worked.

Affects every non-Latin layout — ru, uk, bg, el, sr, ... `default/hypr/bindings/clipboard.lua` is the only place in the tree calling `send_key_state`, so nothing else needs the same treatment.

Tested on Omarchy 4.0.0.alpha / Hyprland 0.56.2 with `kb_layout = us,ru`: before the change Super + C on a non-terminal window only popped the error notification, after it copies with either group active, and the terminal path (Ctrl/Shift + Insert) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
