### PR TITLE
Add Update Plugin to Setup > Plugins menu

### DIFF
--- a/bin/omarchy-plugin-update
+++ b/bin/omarchy-plugin-update
@@ -36,6 +36,26 @@ valid_plugin_id() {
   [[ $1 =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ && $1 != *..* ]]
 }
 
+show_diff() {
+  local id="$1" dir="$2"
+  echo "Changes for $id:"
+  if omarchy-cmd-present delta; then
+    git -C "$dir" diff HEAD FETCH_HEAD | delta --paging=never
+  else
+    git -C "$dir" diff HEAD FETCH_HEAD
+  fi
+  echo
+}
+
+review_update() {
+  local id="$1" dir="$2"
+  local choice
+  choice=$(gum choose --header="Update $id — review the diff first?" \
+    "Show diff" "Update without diff") || return 1
+  if [[ $choice == "Show diff" ]]; then show_diff "$id" "$dir"; fi
+  return 0
+}
+
 update_one() {
   local id="$1"
   local dir="$PLUGINS_DIR/$id"
@@ -51,13 +71,11 @@ update_one() {
   fi
 
   if (( ! ASSUME_YES )); then
-    echo "Changes for $id:"
-    if omarchy-cmd-present delta; then
-      git -C "$dir" diff HEAD FETCH_HEAD | delta --paging=never
-    else
-      git -C "$dir" diff HEAD FETCH_HEAD
-    fi
-    echo
+    interactive || fail "refusing to continue without confirmation; pass --yes"
+    review_update "$id" "$dir" || {
+      echo "Skipped $id."
+      return 0
+    }
     confirm "Update $id?" || {
       echo "Skipped $id."
       return 0

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -177,6 +177,7 @@
   "setup.plugin.add": {"icon":"󰖟","label":"Add Plugin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-plugin-add'"},
   "setup.plugin.clone": {"icon":"󰆏","label":"Clone Plugin","action":"omarchy-menu-plugin clone"},
   "setup.plugin.remove": {"icon":"󰭌","label":"Remove Plugin","when":"compgen -G \"$HOME/.config/omarchy/plugins/*/manifest.json\"","action":"omarchy-menu-plugin remove"},
+  "setup.plugin.update": {"icon":"󰑪","label":"Update Plugin","when":"compgen -G \"$HOME/.config/omarchy/plugins/*/.git\"","provider":"plugin-updates"},
   "setup.security": {"icon":"","label":"Security"},
   "setup.config": {"icon":"","label":"Config"},
   "setup.security.fingerprint": {"icon":"󰈷","label":"Fingerprint","when":"omarchy-hw-fingerprint","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint"},

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -113,7 +113,9 @@ can point a submenu at an existing provider but cannot declare a new one:
   `label\tvalue\tcurrent`. The row whose value equals `current` gets the ✓
   icon, and selection runs the spec's `actionFor(value)`. Row ids are
   `<menuId>.<slugify(value)>`, with a `-` appended on collision so two values
-  that slugify alike cannot silently drop a row.
+  that slugify alike cannot silently drop a row. A provider can set
+  `placeholder` to show a disabled row while it runs and `emptyLabel` to show a
+  disabled provider-specific message when it returns no rows.
 
 A provider marked `volatile` re-runs every time its submenu is entered — a
 font installed since the shell started shows up without a restart — but not
@@ -127,8 +129,8 @@ writing into a map held by a QML `var` property occasionally loses the write,
 which used to duplicate launcher rows. Never mutate `root.items` in place.
 
 Adding a provider means adding an entry to the `providers` map in `Menu.qml`
-(script, icon, `actionFor`, optionally `volatile`) and pointing a submenu at
-it with `provider:`.
+(script, icon, `actionFor`, optionally `volatile`, `placeholder`, and
+`emptyLabel`) and pointing a submenu at it with `provider:`.
 
 ## Driving the menu from the CLI
 

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -23,7 +23,7 @@ omarchy plugin enable omarchy.tailscale
 omarchy plugin disable omarchy.weather
 ```
 
-Or use the menu: _Setup > Plugins_ has Enable, Disable, Add, Clone, and Remove, each with a picker that only offers the plugins that make sense for that action.
+Or use the menu: _Setup > Plugins > Update Plugin_ lists the git-managed plugins with changes available — fetching fresh from git as it opens — and picking one opens a floating terminal where you can choose whether to review the diff before confirming the update.
 
 Enabled state is stored in `~/.config/omarchy/shell.json`, and the rule differs slightly for the two kinds of plugin. A third-party plugin is enabled exactly when its id appears somewhere in that file — as a bar layout entry, as an entry in `plugins[]`, or as `bar.id`. First-party plugins that aren't bar widgets are the other way around: they're on by default and only turn off by being listed in `disabledPlugins[]`.
 
@@ -50,7 +50,7 @@ omarchy plugin update acme.weather
 omarchy plugin update
 ```
 
-With no id it updates every git-managed plugin you have. It shows you the diff before applying it, refuses to update if you've got local changes it can't fast-forward past, and rolls back if the new revision fails validation.
+With no id it updates every git-managed plugin you have. Interactively, you can review each diff or skip straight to confirmation; `--yes` applies updates unattended without showing diffs. The command refuses updates it can't fast-forward and rolls back a new revision that fails validation.
 
 ```
 omarchy plugin remove acme.weather

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -277,6 +277,14 @@ Item {
       script: "current=$(powerprofilesctl get 2>/dev/null); omarchy-powerprofiles-list 2>/dev/null | while read -r p; do [[ -z $p ]] && continue; printf '%s\\t%s\\t%s\\n' \"$p\" \"$p\" \"$current\"; done",
       icon: "\udb81\udc0b",
       actionFor: function(value) { return "omarchy-powerprofiles-set autodetect " + Util.shellQuote(value) }
+    },
+    "plugin-updates": {
+      script: "for d in \"$HOME\"/.config/omarchy/plugins/*/; do [[ -d $d/.git ]] || continue; id=$(basename \"$d\"); name=$(jq -r '.name // .id' \"$d/manifest.json\" 2>/dev/null); git -C \"$d\" fetch --quiet origin HEAD 2>/dev/null || continue; head_sha=$(git -C \"$d\" rev-parse --short HEAD); new_sha=$(git -C \"$d\" rev-parse --short FETCH_HEAD); [[ $(git -C \"$d\" rev-parse HEAD) != $(git -C \"$d\" rev-parse FETCH_HEAD) ]] || continue; printf '%s\\t%s\\t%s\\n' \"$name  $head_sha → $new_sha\" \"$id\" \"\"; done",
+      icon: "\udb80\udc72",
+      placeholder: "Fetching updates from git…",
+      emptyLabel: "All plugins are up to date",
+      volatile: true,
+      actionFor: function(value) { return "omarchy-launch-floating-terminal-with-presentation " + Util.shellQuote("omarchy-plugin-update " + value) }
     }
   })
 
@@ -339,6 +347,29 @@ Item {
     var spec = root.providers[entry.provider]
     if (!spec) return
 
+    if (spec.placeholder) {
+      var merged = MenuModel.swapProviderRows(root.items, root.itemOrder, id, [{
+        id: id + ".placeholder",
+        parent: id,
+        kind: "action",
+        icon: spec.placeholderIcon || "",
+        label: spec.placeholder,
+        title: "",
+        target: "",
+        description: "",
+        action: "",
+        provider: "",
+        aliases: [],
+        when: "",
+        checked: "",
+        disabled: "true",
+        order: 0
+      }])
+      root.items = merged.items
+      root.itemOrder = merged.itemOrder
+      if (root.opened) root.rebuildDisplay()
+    }
+
     root.providersLoaded[id] = true
     providerProc.menuId = id
     providerProc.providerKey = entry.provider
@@ -384,6 +415,25 @@ Item {
         when: "",
         checked: "",
         disabled: "",
+        order: 0
+      })
+    }
+    if (providerRows.length === 0 && spec.emptyLabel) {
+      providerRows.push({
+        id: menuId + ".empty",
+        parent: menuId,
+        kind: "action",
+        icon: "",
+        label: spec.emptyLabel,
+        title: "",
+        target: "",
+        description: "",
+        action: "",
+        provider: "",
+        aliases: [],
+        when: "",
+        checked: "",
+        disabled: "true",
         order: 0
       })
     }

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -343,7 +343,7 @@ assertEqual(
 )
 assertDeepEqual(
   defaultItems.filter(item => item.parent === 'setup.plugin').map(item => item.label),
-  ['Enable Plugin', 'Disable Plugin', 'Add Plugin', 'Clone Plugin', 'Remove Plugin'],
+  ['Enable Plugin', 'Disable Plugin', 'Add Plugin', 'Clone Plugin', 'Remove Plugin', 'Update Plugin'],
   'menu manages plugins from Setup > Plugins'
 )
 assert(
@@ -413,6 +413,47 @@ assert(
 
 // A font installed since the shell started should show up without a restart.
 const providerBlock = menuQml.match(/readonly property var providers: \(\{[\s\S]*?\n  \}\)/)[0]
+assertEqual(
+  defaultById['setup.plugin.update'].provider,
+  'plugin-updates',
+  'menu loads plugin updates through the provider-backed submenu'
+)
+assert(
+  defaultById['setup.plugin.update'].when.includes('plugins/*/.git'),
+  'menu hides Update until a git-managed plugin is installed'
+)
+const pluginUpdateProvider = providerBlock.match(/"plugin-updates": \{[\s\S]*?\n    \}/)[0]
+assert(
+  /placeholder: "Fetching updates from git…"/.test(pluginUpdateProvider)
+    && /emptyLabel: "All plugins are up to date"/.test(pluginUpdateProvider)
+    && /volatile: true/.test(pluginUpdateProvider),
+  'plugin update provider shows loading and empty states and fetches again on every open'
+)
+assert(
+  /actionFor: function\(value\) \{ return "omarchy-launch-floating-terminal-with-presentation " \+ Util\.shellQuote\("omarchy-plugin-update " \+ value\) \}/.test(pluginUpdateProvider),
+  'plugin update provider quotes the complete floating-terminal command'
+)
+assert(
+  /function startProviderForMenu\([\s\S]*?if \(spec\.placeholder\)[\s\S]*?label: spec\.placeholder[\s\S]*?disabled: "true"/.test(menuQml),
+  'menu swaps in a disabled placeholder while a provider loads'
+)
+assert(
+  /function mergeProviderRows\([\s\S]*?providerRows\.length === 0 && spec\.emptyLabel[\s\S]*?label: spec\.emptyLabel[\s\S]*?disabled: "true"/.test(menuQml),
+  'menu swaps in a disabled provider-specific empty state when no rows return'
+)
+const providerBaseItems = { root: { id: 'root', kind: 'menu', label: 'Go' } }
+const providerBaseOrder = ['root']
+const pluginLoading = menu.swapProviderRows(providerBaseItems, providerBaseOrder, 'setup.plugin.update', [
+  { id: 'setup.plugin.update.placeholder', kind: 'action', parent: 'setup.plugin.update', label: 'Fetching updates from git…', disabled: true }
+])
+const pluginEmpty = menu.swapProviderRows(pluginLoading.items, pluginLoading.itemOrder, 'setup.plugin.update', [
+  { id: 'setup.plugin.update.empty', kind: 'action', parent: 'setup.plugin.update', label: 'All plugins are up to date', disabled: true }
+])
+assert(
+  !pluginEmpty.items['setup.plugin.update.placeholder']
+    && pluginEmpty.items['setup.plugin.update.empty'].disabled,
+  'plugin update provider replaces its loading row with its empty state'
+)
 assert(
   /"fonts": \{[\s\S]*?volatile: true/.test(providerBlock),
   'menu re-enumerates the font list every time it is opened'

--- a/test/shell.d/plugin-update-test.sh
+++ b/test/shell.d/plugin-update-test.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+HOME_DIR="$TMPDIR/home"
+PLUGIN_DIR="$HOME_DIR/.config/omarchy/plugins/acme.weather"
+STUB_DIR="$TMPDIR/stubs"
+mkdir -p "$PLUGIN_DIR/.git" "$STUB_DIR"
+printf '%s\n' '{"id":"acme.weather","name":"Weather"}' >"$PLUGIN_DIR/manifest.json"
+
+cat >"$STUB_DIR/git" <<'STUB'
+#!/bin/bash
+printf 'git %s\n' "$*" >>"$CALLS"
+case "$3" in
+fetch) exit 0 ;;
+rev-parse)
+  ref=${!#}
+  if [[ $ref == "HEAD" ]]; then printf 'old\n'; else printf 'new\n'; fi
+  ;;
+diff)
+  printf '%s\n' '-old setting' '+new setting'
+  ;;
+*) exit 0 ;;
+esac
+STUB
+
+cat >"$STUB_DIR/gum" <<'STUB'
+#!/bin/bash
+printf 'gum %s\n' "$*" >>"$CALLS"
+touch "$GUM_CALLED"
+if [[ $1 == "choose" ]]; then printf '%s\n' "${GUM_CHOICE:-Show diff}"; fi
+STUB
+
+cat >"$STUB_DIR/omarchy-cmd-present" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+
+for command in omarchy-plugin-validate omarchy-shell; do
+  cat >"$STUB_DIR/$command" <<'STUB'
+#!/bin/bash
+printf '%s %s\n' "${0##*/}" "$*" >>"$CALLS"
+STUB
+done
+
+chmod +x "$STUB_DIR"/*
+
+export CALLS="$TMPDIR/calls"
+: >"$CALLS"
+
+provider_script=$(node - "$ROOT/shell/plugins/menu/Menu.qml" <<'JS'
+const fs = require('fs')
+const qml = fs.readFileSync(process.argv[2], 'utf8')
+const match = qml.match(/"plugin-updates": \{\s*script: ("(?:\\.|[^"\\])*")/)
+if (!match) process.exit(1)
+process.stdout.write(JSON.parse(match[1]))
+JS
+) || fail "plugin update provider script can be extracted from the menu"
+provider_output=$(HOME="$HOME_DIR" PATH="$STUB_DIR:$PATH" bash -c "$provider_script")
+expected_provider_output=$(printf 'Weather  old → new\tacme.weather\t')
+[[ $provider_output == "$expected_provider_output" ]] ||
+  fail "plugin update provider emits the available update row" "$provider_output"
+pass "plugin update provider executes and emits the available update row"
+
+status=0
+output=$(HOME="$HOME_DIR" PATH="$STUB_DIR:$ROOT/bin:$PATH" GUM_CALLED="$TMPDIR/gum-called" \
+  "$ROOT/bin/omarchy-plugin-update" acme.weather </dev/null 2>&1) || status=$?
+
+(( status != 0 )) || fail "plugin update refuses noninteractive updates without --yes" "$output"
+[[ $output == *"refusing to continue without confirmation; pass --yes"* ]] ||
+  fail "plugin update explains how to confirm a noninteractive update" "$output"
+[[ ! -e $TMPDIR/gum-called ]] || fail "plugin update opens gum without an interactive terminal"
+pass "plugin update refuses noninteractive updates before opening gum"
+
+: >"$CALLS"
+rm -f "$TMPDIR/gum-called"
+output=$(HOME="$HOME_DIR" PATH="$STUB_DIR:$ROOT/bin:$PATH" GUM_CALLED="$TMPDIR/gum-called" \
+  "$ROOT/bin/omarchy-plugin-update" acme.weather --yes 2>&1) ||
+  fail "plugin update rejects an explicitly confirmed noninteractive update" "$output"
+[[ ! -e $TMPDIR/gum-called ]] || fail "plugin update opens gum when --yes was passed"
+[[ $(<"$CALLS") == *"git -C $PLUGIN_DIR merge --ff-only FETCH_HEAD"* ]] ||
+  fail "plugin update does not fast-forward after --yes" "$(<"$CALLS")"
+[[ $(<"$CALLS") == *"omarchy-plugin-validate $PLUGIN_DIR"* ]] ||
+  fail "plugin update does not validate after --yes" "$(<"$CALLS")"
+[[ $(<"$CALLS") == *"omarchy-shell shell rescanPlugins"* ]] ||
+  fail "plugin update does not rescan plugins after --yes" "$(<"$CALLS")"
+pass "plugin update honors --yes without opening gum"
+
+if script -qec true /dev/null >/dev/null 2>&1; then
+  : >"$CALLS"
+  rm -f "$TMPDIR/gum-called"
+  status=0
+  raw=$(HOME="$HOME_DIR" PATH="$STUB_DIR:$ROOT/bin:$PATH" CALLS="$CALLS" \
+    GUM_CALLED="$TMPDIR/gum-called" GUM_CHOICE="Show diff" \
+    script -qec "'$ROOT/bin/omarchy-plugin-update' acme.weather" /dev/null) || status=$?
+  output=$(tr -d '\r' <<<"$raw")
+
+  (( status == 0 )) || fail "interactive plugin update completes" "$output"
+  [[ $output == *"Changes for acme.weather:"* && $output == *"+new setting"* ]] ||
+    fail "interactive plugin update shows the requested diff" "$output"
+  calls=$(<"$CALLS")
+  [[ $calls == *"gum choose"*"review the diff first?"* ]] ||
+    fail "interactive plugin update asks whether to review the diff" "$calls"
+  [[ $calls == *"git -C $PLUGIN_DIR diff HEAD FETCH_HEAD"* ]] ||
+    fail "interactive plugin update does not request the diff" "$calls"
+  [[ $calls == *"gum confirm Update acme.weather?"* ]] ||
+    fail "interactive plugin update does not ask for final confirmation" "$calls"
+  [[ $calls == *"git -C $PLUGIN_DIR merge --ff-only FETCH_HEAD"* ]] ||
+    fail "interactive plugin update does not fast-forward after confirmation" "$calls"
+  pass "plugin update reviews and confirms an interactive update"
+
+  : >"$CALLS"
+  rm -f "$TMPDIR/gum-called"
+  status=0
+  raw=$(HOME="$HOME_DIR" PATH="$STUB_DIR:$ROOT/bin:$PATH" CALLS="$CALLS" \
+    GUM_CALLED="$TMPDIR/gum-called" GUM_CHOICE="Update without diff" \
+    script -qec "'$ROOT/bin/omarchy-plugin-update' acme.weather" /dev/null) || status=$?
+  output=$(tr -d '\r' <<<"$raw")
+
+  (( status == 0 )) || fail "interactive plugin update completes without a diff" "$output"
+  calls=$(<"$CALLS")
+  [[ $calls != *" diff HEAD FETCH_HEAD"* && $output != *"Changes for acme.weather:"* ]] ||
+    fail "interactive plugin update shows a diff after it was declined" "$output"
+  [[ $calls == *"gum confirm Update acme.weather?"*
+    && $calls == *"git -C $PLUGIN_DIR merge --ff-only FETCH_HEAD"* ]] ||
+    fail "interactive plugin update does not confirm and apply after skipping the diff" "$calls"
+  pass "plugin update can skip the diff and still require confirmation"
+else
+  pass "script -qec unavailable; skipping the interactive plugin update case"
+fi


### PR DESCRIPTION
## What

`omarchy plugin update` exists in the CLI but has no menu surface — `Setup > Plugins` only offers Enable, Disable, Add, Clone, and Remove. This adds **Update Plugin**, a provider-backed submenu that lists git-managed plugins with changes available:

- Entering the submenu shows a dimmed “Fetching updates from git…” placeholder while each plugin is fetched
- The placeholder is replaced in place with one row per available update, including the `old → new` short SHAs
- When everything is current, the submenu shows “All plugins are up to date”
- Picking a row opens the existing floating-terminal update flow, where the user can optionally review the diff before confirming

The entry is hidden when no git-managed plugins are installed.

## Implementation

- `shell/plugins/menu/Menu.qml`: adds the `plugin-updates` volatile provider and generic `placeholder`/`emptyLabel` provider states
- `default/omarchy/omarchy-menu.jsonc`: adds `Setup > Plugins > Update Plugin`
- `bin/omarchy-plugin-update`: offers optional diff review while preserving the noninteractive `--yes` requirement, fast-forward-only updates, validation, and rollback
- `docs/menu.md` and `manual/32-shell-plugins.md`: document provider states and the interactive/unattended update behavior
- `test/shell.d/menu-test.sh` and `test/shell.d/plugin-update-test.sh`: cover provider execution, loading and empty states, command quoting, noninteractive refusal, `--yes`, and both interactive review choices

## Verification

- `bash test/shell.d/plugin-update-test.sh`
- `bash test/shell.d/menu-test.sh`
- `./test/cli`
- `bash -n` on the changed shell scripts
- `git diff --check`

The full shell suite was also run. Its four remaining failures are pre-existing/environmental: the existing bar-icon geometry check, `config-test.sh`, and two checks requiring a separate `omarchy-pkgs` checkout.
