### PR TITLE
Bound network speed test runtime

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -10,6 +10,8 @@ direction="${1:-}"
 probe=1.1.1.1
 parallel=8
 url_count=3
+# The panel normally stops each phase after 5s; this bounds orphaned workers.
+max_runtime_seconds=${OMARCHY_NETWORK_SPEEDTEST_MAX_SECONDS:-10}
 
 case "$direction" in
   down | up)
@@ -19,6 +21,11 @@ case "$direction" in
     exit 2
     ;;
 esac
+
+if [[ ! $max_runtime_seconds =~ ^[1-9][0-9]*$ ]]; then
+  echo "OMARCHY_NETWORK_SPEEDTEST_MAX_SECONDS must be a positive integer" >&2
+  exit 2
+fi
 
 format_mbps() {
   awk -v value="$1" 'BEGIN {
@@ -93,6 +100,7 @@ done
 
 rx_before=$(cat "/sys/class/net/$iface/statistics/rx_bytes")
 tx_before=$(cat "/sys/class/net/$iface/statistics/tx_bytes")
+deadline=$((SECONDS + max_runtime_seconds))
 
 any_alive() {
   local pid
@@ -105,7 +113,7 @@ any_alive() {
   return 1
 }
 
-while any_alive; do
+while any_alive && (( SECONDS < deadline )); do
   sleep 1
   rx_after=$(cat "/sys/class/net/$iface/statistics/rx_bytes")
   tx_after=$(cat "/sys/class/net/$iface/statistics/tx_bytes")
@@ -126,5 +134,3 @@ while any_alive; do
   rx_before=$rx_after
   tx_before=$tx_after
 done
-
-wait 2>/dev/null || true

--- a/test/shell.d/network-speedtest-test.sh
+++ b/test/shell.d/network-speedtest-test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+require_command timeout
+
+stage=$(mktemp -d)
+trap 'rm -rf -- "$stage"' EXIT
+
+mkdir -p "$stage/bin"
+
+cat >"$stage/bin/ip" <<'STUB'
+#!/bin/bash
+printf '1.1.1.1 via 192.0.2.1 dev lo src 192.0.2.2\n'
+STUB
+
+cat >"$stage/bin/omarchy-cmd-present" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+
+cat >"$stage/bin/curl" <<'STUB'
+#!/bin/bash
+
+for arg in "$@"; do
+  if [[ $arg == https://api.fast.com/* ]]; then
+    printf '{"targets":[{"url":"https://speed.test/chunk"}]}\n'
+    exit 0
+  fi
+done
+
+printf '%s\n' "$BASHPID" >>"$SPEEDTEST_WORKER_PIDS"
+exec sleep 30
+STUB
+
+chmod +x "$stage/bin/ip" "$stage/bin/omarchy-cmd-present" "$stage/bin/curl"
+
+run_bounded_speedtest() {
+  local direction="$1"
+  local elapsed
+  local status=0
+  local started_at=$SECONDS
+
+  : >"$stage/worker-pids"
+  OMARCHY_NETWORK_SPEEDTEST_MAX_SECONDS=2 \
+    SPEEDTEST_WORKER_PIDS="$stage/worker-pids" \
+    PATH="$stage/bin:$PATH" \
+    timeout 6 "$ROOT/bin/omarchy-network-speedtest" "$direction" >"$stage/speedtest.out" 2>"$stage/speedtest.err" || status=$?
+
+  (( status == 0 )) || fail "$direction speed test reaches its internal deadline" "$(<"$stage/speedtest.err")"
+  elapsed=$((SECONDS - started_at))
+  (( elapsed >= 2 && elapsed < 6 )) || fail "$direction speed test stops near its internal deadline" "elapsed: $elapsed seconds"
+  [[ -s $stage/worker-pids ]] || fail "$direction speed test starts traffic workers"
+
+  while IFS= read -r pid; do
+    if kill -0 "$pid" 2>/dev/null; then
+      fail "$direction speed test reaps traffic workers after its deadline" "worker still alive: $pid"
+    fi
+  done <"$stage/worker-pids"
+}
+
+run_bounded_speedtest down
+run_bounded_speedtest up
+
+if OMARCHY_NETWORK_SPEEDTEST_MAX_SECONDS=0 "$ROOT/bin/omarchy-network-speedtest" down >"$stage/invalid.out" 2>"$stage/invalid.err"; then
+  fail "speed test rejects a disabled internal deadline"
+fi
+grep -Fx 'OMARCHY_NETWORK_SPEEDTEST_MAX_SECONDS must be a positive integer' "$stage/invalid.err" >/dev/null ||
+  fail "speed test explains an invalid internal deadline"
+
+pass "network speed test bounds traffic independently of its UI parent"


### PR DESCRIPTION
## Summary

- stop each network speed-test phase after a hard 10-second deadline
- reuse the existing EXIT trap to terminate and reap all traffic workers
- cover download and upload orphan scenarios without making real network requests

## Why

The Quickshell panel normally stops each phase after five seconds. If that caller disappears before sending SIGTERM, the script and its eight traffic workers can otherwise continue indefinitely.

## Tests

- `bash test/shell.d/network-speedtest-test.sh`
- `bash test/shell.d/bin-style-test.sh`
- `bash test/shell.d/network-captive-portal-test.sh`
- `./test/cli`
- `./bin/omarchy commands --check`

Fixes #10186
