### PR TITLE
Redact network identifiers from debug output

### DIFF
--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -28,10 +28,19 @@ done
 
 LOG_FILE="/tmp/omarchy-debug.log"
 
+# Strip identifiers before this output is attached to a public issue: ufw's
+# packet log carries the addresses of every device on the reporter's network,
+# and the kernel's wifi association lines carry the access point BSSID, which is
+# geolocatable. ufw logs at kernel warning level, so both dmesg and the journal
+# carry them.
+scrub_network_identifiers() {
+  grep -v '\[UFW BLOCK\]' | sed -E 's/([0-9a-f]{2}:){5}[0-9a-f]{2}/<mac>/g'
+}
+
 if [[ $NO_SUDO = "true" ]]; then
   DMESG_OUTPUT="(skipped - --no-sudo flag used)"
 else
-  DMESG_OUTPUT="$(sudo dmesg)"
+  DMESG_OUTPUT="$(sudo dmesg | scrub_network_identifiers)"
 fi
 
 cat > "$LOG_FILE" <<EOF
@@ -52,7 +61,7 @@ $DMESG_OUTPUT
 =========================================
 JOURNALCTL (CURRENT BOOT, WARNINGS+ERRORS)
 =========================================
-$(journalctl -b -p 4..1)
+$(journalctl -b -p 4..1 | scrub_network_identifiers)
 
 =========================================
 INSTALLED PACKAGES

--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -30,11 +30,20 @@ LOG_FILE="/tmp/omarchy-debug.log"
 
 # Strip identifiers before this output is attached to a public issue: ufw's
 # packet log carries the addresses of every device on the reporter's network,
-# and the kernel's wifi association lines carry the access point BSSID, which is
-# geolocatable. ufw logs at kernel warning level, so both dmesg and the journal
-# carry them.
+# the kernel's wifi association lines carry the access point BSSID, which is
+# geolocatable, and bluetoothd logs the addresses of paired devices. ufw logs at
+# kernel warning level, so both dmesg and the journal carry them.
+#
+# Hex is matched case-insensitively: the kernel prints MACs lowercase but BlueZ
+# prints them uppercase. MACs are substituted before the IPv6 rules so that a
+# MAC is never mistaken for an address.
 scrub_network_identifiers() {
-  grep -v '\[UFW BLOCK\]' | sed -E 's/([0-9a-f]{2}:){5}[0-9a-f]{2}/<mac>/g'
+  grep -v '\[UFW BLOCK\]' |
+    sed -E \
+      -e 's/([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}/<mac>/g' \
+      -e 's/\b([0-9]{1,3}\.){3}[0-9]{1,3}\b/<ip>/g' \
+      -e 's/\b([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b/<ipv6>/g' \
+      -e 's/\b[0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,6}::([0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,6})?/<ipv6>/g'
 }
 
 if [[ $NO_SUDO = "true" ]]; then

--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -28,28 +28,57 @@ done
 
 LOG_FILE="/tmp/omarchy-debug.log"
 
-# Strip identifiers before this output is attached to a public issue: ufw's
+# Strip identifiers before this output is attached to a public issue. ufw's
 # packet log carries the addresses of every device on the reporter's network,
 # the kernel's wifi association lines carry the access point BSSID, which is
-# geolocatable, and bluetoothd logs the addresses of paired devices. ufw logs at
-# kernel warning level, so both dmesg and the journal carry them.
+# geolocatable, and bluetoothd logs the addresses of paired devices, both as
+# colon-separated hex and in the underscore form its D-Bus object paths use.
+# ufw logs at kernel warning level, so both dmesg and the journal carry them.
 #
-# Hex is matched case-insensitively: the kernel prints MACs lowercase but BlueZ
-# prints them uppercase. MACs are substituted before the address rules so a MAC
-# is never rewritten as an address.
+# Ordering matters. IPv6 is substituted before MAC: a MAC rule with no left
+# boundary would otherwise consume six two-hex groups out of the middle of an
+# address and leave the prefix behind (2001:db8:00:11:22:33:44:55). The MAC and
+# IPv6 rules therefore refuse to start after a colon, which also leaves
+# colon-hex fingerprints (MD5:aa:bb:...) alone.
 #
-# Each address rule captures the character before the match and puts it back,
-# rather than relying on a word-boundary escape. That keeps the compressed-IPv6
-# rule from eating C++ scope resolution in log lines, where "e::" would
-# otherwise look like the start of an address:
-#   QSqlDatabasePrivate::removeDatabase
+# Each rule captures the characters bounding the match and puts them back
+# instead of using a word-boundary escape, and each runs twice so two addresses
+# separated by a single character are both caught. The right-hand boundary is
+# what stops the compressed-IPv6 rule eating C++ scope resolution in log lines,
+# where caf::actor_system and cc::Build otherwise parse as an address.
+#
+# Loopback, link-local and the unspecified address are protected first, by
+# standing their dots aside, because they identify nobody and losing them
+# destroys the diagnosis: 169.254.x.x is how a failed DHCP lease presents, and
+# 127.0.0.53 says a query went to the resolved stub. The octet range check
+# spares firmware versions such as "10.1.467.2", where 467 is not an octet.
 scrub_network_identifiers() {
+  local h='[0-9a-fA-F]' o='(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])'
+  local p='(^|[^0-9A-Za-z])' pc='(^|[^0-9A-Za-z:])' d=$'\001'
+  # A trailing colon or dot ends the match only when what follows is not more
+  # of the same, so "addr: message" is redacted while MD5:aa:bb:... and
+  # 1.2.3.4.5 are left whole.
+  local tc="(\$|[^0-9A-Za-z:]|:(\$|[^0-9a-fA-F]))"
+  local td="(\$|[^0-9A-Za-z.]|\.(\$|[^0-9]))"
+  local v6="${pc}(${h}{1,4}:){7}${h}{1,4}${tc}"
+  local v6c="${pc}${h}{1,4}(:${h}{1,4}){0,6}::(${h}{1,4}(:${h}{1,4}){0,6})?${tc}"
+  local mac="${pc}(${h}{2}:){5}${h}{2}${tc}"
+  local und="${p}(${h}{2}_){5}${h}{2}([^0-9A-Za-z_]|\$)"
+  local ip4="${p}${o}(\.${o}){3}${td}"
+
   grep -v '\[UFW BLOCK\]' |
     sed -E \
-      -e 's/([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}/<mac>/g' \
-      -e 's/(^|[^0-9A-Za-z.])([0-9]{1,3}\.){3}[0-9]{1,3}/\1<ip>/g' \
-      -e 's/(^|[^0-9A-Za-z:])([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}/\1<ipv6>/g' \
-      -e 's/(^|[^0-9A-Za-z:])[0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,6}::([0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,6})?/\1<ipv6>/g'
+      -e "s/${p}127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/\1127${d}\2${d}\3${d}\4/g" \
+      -e "s/${p}169\.254\.([0-9]{1,3})\.([0-9]{1,3})/\1169${d}254${d}\2${d}\3/g" \
+      -e "s/${p}0\.0\.0\.0/\10${d}0${d}0${d}0/g" \
+      -e "s/${p}255\.255\.255\.255/\1255${d}255${d}255${d}255/g" \
+      -e "s/${v6}/\1<ipv6>\3/g"  -e "s/${v6}/\1<ipv6>\3/g" \
+      -e "s/${v6c}/\1<ipv6>\5/g" -e "s/${v6c}/\1<ipv6>\5/g" \
+      -e "s/${mac}/\1<mac>\3/g"  -e "s/${mac}/\1<mac>\3/g" \
+      -e "s/${und}/\1<mac>\3/g"  -e "s/${und}/\1<mac>\3/g" \
+      -e "s/(wlx|enx)${h}{12}/\1<mac>/g" \
+      -e "s/${ip4}/\1<ip>\5/g"   -e "s/${ip4}/\1<ip>\5/g" \
+      -e "s/${d}/./g"
 }
 
 if [[ $NO_SUDO = "true" ]]; then

--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -35,15 +35,21 @@ LOG_FILE="/tmp/omarchy-debug.log"
 # kernel warning level, so both dmesg and the journal carry them.
 #
 # Hex is matched case-insensitively: the kernel prints MACs lowercase but BlueZ
-# prints them uppercase. MACs are substituted before the IPv6 rules so that a
-# MAC is never mistaken for an address.
+# prints them uppercase. MACs are substituted before the address rules so a MAC
+# is never rewritten as an address.
+#
+# Each address rule captures the character before the match and puts it back,
+# rather than relying on a word-boundary escape. That keeps the compressed-IPv6
+# rule from eating C++ scope resolution in log lines, where "e::" would
+# otherwise look like the start of an address:
+#   QSqlDatabasePrivate::removeDatabase
 scrub_network_identifiers() {
   grep -v '\[UFW BLOCK\]' |
     sed -E \
       -e 's/([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}/<mac>/g' \
-      -e 's/\b([0-9]{1,3}\.){3}[0-9]{1,3}\b/<ip>/g' \
-      -e 's/\b([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b/<ipv6>/g' \
-      -e 's/\b[0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,6}::([0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,6})?/<ipv6>/g'
+      -e 's/(^|[^0-9A-Za-z.])([0-9]{1,3}\.){3}[0-9]{1,3}/\1<ip>/g' \
+      -e 's/(^|[^0-9A-Za-z:])([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}/\1<ipv6>/g' \
+      -e 's/(^|[^0-9A-Za-z:])[0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,6}::([0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,6})?/\1<ipv6>/g'
 }
 
 if [[ $NO_SUDO = "true" ]]; then


### PR DESCRIPTION
Addresses the MAC, BSSID and LAN-address half of #10255. The hostname half is deliberately not
in scope — see the end.

The bug template asks reporters to attach `omarchy-debug` output. On a stock install that output
identifies the reporter's network, and nothing warns them before they paste it into a public
issue.

`install/config/firewall.sh` enables ufw, and ufw ships `LOGLEVEL=low`, so every blocked packet
lands in the kernel log with the addresses of devices on the LAN. Two sharper cases sit outside
those lines: the kernel's wifi association lines carry the access point BSSID, which resolves to
a street address through public wardriving databases, and `bluetoothd` logs the address of every
paired device — in colon form and in the underscore form its D-Bus object paths use.

### What this does

Drops `[UFW BLOCK]` lines, then substitutes MAC addresses in all three renderings
(`aa:bb:…`, `dev_AA_BB_…`, `wlxaabbccddeeff`), IPv4 and IPv6 — applied to **both** the `dmesg`
and `journalctl -b -p 4..1` sections, since ufw logs at kernel warning level and the journal
carries the same packet log. One shared function so the two cannot drift.

Details that took a few passes to get right:

- Hex is matched case-insensitively. The kernel prints MACs lowercase; BlueZ prints them
  uppercase.
- IPv6 is substituted before MAC, and neither may start after a colon, so the MAC rule cannot
  consume six groups out of the middle of an address and leave the prefix, and colon-hex
  fingerprints (`MD5:aa:bb:…`) are left whole.
- A trailing colon or dot ends a match only when what follows is not more of the same. That
  catches `connect to <mac>: Host is down` and a sentence-final address while leaving
  fingerprints and `1.2.3.4.5` intact.
- Boundaries are captured and restored rather than using `\b`, and each rule runs twice so two
  addresses separated by one character are both caught.
- Loopback, link-local and the unspecified address are stood aside first. They identify nobody
  and losing them destroys the diagnosis: `169.254.x.x` is a failed DHCP lease, `127.0.0.53` a
  query to the resolved stub, `0.0.0.0` a wildcard bind.
- An octet range check spares firmware versions such as `10.1.467.2`, where `467` is not an
  octet.

### Why the scrub is scoped to two sections

Only `dmesg` and the journal are touched — never the `inxi` report or the package list. `inxi`
is already invoked as `inxi -Farz`, and `-z` is its own privacy filter; this brings the two
larger sections in line with the intent already applied to the smallest.

### Verified

Over the 709 lines of `dmesg` and journal the scrub touches:

| | result |
|---|---|
| MACs, all three renderings | 0 |
| routable IPv4 | 0 |
| IPv6 | 0 |
| `[UFW BLOCK]` lines | 0 |
| substitutions made | 45 `<mac>`, 8 `<ip>`, 8 `<ipv6>` |

237 kernel lines, the package list and the inxi report are unchanged. `./test/cli` passes.

### Not in scope, on purpose

- **The hostname.** Still present, both from `Hostname: $(hostname)` and the journal's default
  `short` prefix. Whether Omarchy's debug reports carry a hostname is a product decision for
  @dhh, and it is a visible change to every future report, so it belongs in its own change.
  #10255 should not be closed on this PR alone.
- **Version strings whose parts are all valid octets**, such as `Firmware version 0.29.29.5`.
  Not separable from an address by shape.
- **Substituting ufw lines rather than dropping them.** The substituted form is demonstrably
  clean and "the firewall is dropping this" is sometimes the answer, but that is a
  volume-versus-diagnosis judgement.

### Review history

@Chessing234 found that the first version was lowercase-only on hex and dropped ufw lines
without substituting anything else; both were real leaks here. @omarchybot then found the
underscore and `wlx` MAC renderings, the MAC rule eating an IPv6 middle, the `hex::` over-match
corrupting `caf::actor_system`, and the unranged IPv4 rule destroying firmware versions and
special-purpose addresses. All fixed.

Worth recording, since it recurred: my first verification used the same lowercase pattern the
code used, so it reported "11 → 0" when the truth was 11 → 1; and a later check looked for
survivors rather than corruption, so it could not have caught the `hex::` false positives. The
numbers above are measured with deliberately wider patterns than the code uses.
