### PR TITLE
Report Custom DNS when public resolvers are only secondary

### DIFF
--- a/bin/omarchy-dns
+++ b/bin/omarchy-dns
@@ -97,26 +97,85 @@ resolved_dns() {
   ' /etc/systemd/resolved.conf 2>/dev/null || true
 }
 
+# Classify a raw DNS server list (from NetworkManager or resolved) as a provider
+# name. Stock Cloudflare/Google are recognized only when every entry belongs to
+# that provider — a Custom list that merely includes 1.1.1.1 or 8.8.8.8 as a
+# secondary must report Custom, not the stock preset (see #10245).
+classify_dns_servers() {
+  local dns="$1"
+  local compact="" tok bare host
+  local all_cloudflare=1 all_google=1
+  local is_cloudflare is_google
+
+  compact=$(printf '%s' "$dns" | tr -d '[:space:],')
+  if [[ -z $compact ]]; then
+    echo "DHCP"
+    return
+  fi
+
+  for tok in ${dns//,/ }; do
+    [[ -n $tok ]] || continue
+
+    bare=${tok#dns+tls://}
+    bare=${bare#dns+udp://}
+    host=""
+    if [[ $bare == *#* ]]; then
+      host=${bare#*#}
+      bare=${bare%%#*}
+    fi
+    bare=${bare#[}
+    bare=${bare%]}
+
+    is_cloudflare=0
+    case "$bare" in
+    1.1.1.1 | 1.0.0.1 | 2606:4700:4700::1111 | 2606:4700:4700::1001)
+      is_cloudflare=1
+      ;;
+    esac
+    case "$host" in
+    cloudflare-dns.com)
+      is_cloudflare=1
+      ;;
+    esac
+
+    is_google=0
+    case "$bare" in
+    8.8.8.8 | 8.8.4.4 | 2001:4860:4860::8888 | 2001:4860:4860::8844)
+      is_google=1
+      ;;
+    esac
+    case "$host" in
+    dns.google)
+      is_google=1
+      ;;
+    esac
+
+    if (( !is_cloudflare )); then
+      all_cloudflare=0
+    fi
+    if (( !is_google )); then
+      all_google=0
+    fi
+  done
+
+  if (( all_cloudflare )); then
+    echo "Cloudflare"
+  elif (( all_google )); then
+    echo "Google"
+  else
+    echo "Custom"
+  fi
+}
+
 current_dns_provider() {
   local dns=""
-  local compact=""
 
   dns=$(networkmanager_global_dns)
   if [[ -z $(printf '%s' "$dns" | tr -d '[:space:],') ]]; then
     dns=$(resolved_dns)
   fi
 
-  compact=$(printf '%s' "$dns" | tr -d '[:space:],')
-
-  if [[ -z $compact ]]; then
-    echo "DHCP"
-  elif [[ $dns == *"cloudflare-dns.com"* || $dns == *"1.1.1.1"* || $dns == *"2606:4700:4700::1111"* ]]; then
-    echo "Cloudflare"
-  elif [[ $dns == *"dns.google"* || $dns == *"8.8.8.8"* || $dns == *"2001:4860:4860::8888"* ]]; then
-    echo "Google"
-  else
-    echo "Custom"
-  fi
+  classify_dns_servers "$dns"
 }
 
 normalize_servers() {

--- a/test/shell.d/dns-provider-classify-test.sh
+++ b/test/shell.d/dns-provider-classify-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Exercises classify_dns_servers / current_dns_provider without rewriting the
+# host NetworkManager or resolved configuration. The classifier is extracted
+# into a throwaway script so the production omarchy-dns binary is not sourced
+# (it is a full command, not a library).
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+dns_bin="$ROOT/bin/omarchy-dns"
+
+# Pull the classifier body from the real command so the test tracks the
+# production definition rather than a duplicated copy that can drift.
+classifier_src=$(mktemp)
+trap 'rm -f "$classifier_src"' EXIT
+
+awk '
+  /^classify_dns_servers\(\)/ { printing = 1 }
+  printing { print }
+  printing && /^}$/ { exit }
+' "$dns_bin" >"$classifier_src"
+
+grep -q 'classify_dns_servers()' "$classifier_src" ||
+  fail "omarchy-dns defines classify_dns_servers for stock-provider matching"
+
+# shellcheck disable=SC1090
+source "$classifier_src"
+
+expect_class() {
+  local input="$1"
+  local want="$2"
+  local got
+
+  got=$(classify_dns_servers "$input")
+  [[ $got == "$want" ]] ||
+    fail "classify_dns_servers reports $want for: $input" "got: $got"
+}
+
+# Empty / whitespace-only is DHCP (no global override).
+expect_class "" "DHCP"
+expect_class "   " "DHCP"
+expect_class "," "DHCP"
+pass "empty DNS list classifies as DHCP"
+
+# Exact stock Cloudflare presets written by omarchy-dns Cloudflare.
+expect_class "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001" "Cloudflare"
+expect_class "1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com" "Cloudflare"
+expect_class "dns+tls://1.1.1.1#cloudflare-dns.com" "Cloudflare"
+pass "stock Cloudflare server lists classify as Cloudflare"
+
+# Exact stock Google presets.
+expect_class "8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844" "Google"
+expect_class "8.8.8.8#dns.google 8.8.4.4#dns.google" "Google"
+pass "stock Google server lists classify as Google"
+
+# Custom list that merely contains a public resolver as secondary (#10245).
+expect_class "20.20.20.3 1.1.1.1" "Custom"
+expect_class "20.20.20.3,1.1.1.1" "Custom"
+expect_class "192.168.1.1,1.1.1.1" "Custom"
+expect_class "10.0.0.1 8.8.8.8" "Custom"
+expect_class "9.9.9.9,1.1.1.1,8.8.8.8" "Custom"
+expect_class "1.1.1.1,8.8.8.8" "Custom"
+pass "custom lists that include public resolvers classify as Custom"
+
+# Pure custom without any stock addresses.
+expect_class "192.168.1.1,10.0.0.1" "Custom"
+expect_class "9.9.9.9#dns.quad9.net" "Custom"
+pass "pure custom server lists classify as Custom"


### PR DESCRIPTION
## Summary

`omarchy dns` (no args) mislabels a Custom DNS configuration as Cloudflare or Google whenever the custom server list merely contains `1.1.1.1` / `8.8.8.8` as a secondary. That comes from substring matching in `current_dns_provider()`.

This changes classification so a stock provider is reported only when **every** server entry belongs to that provider. A mixed list such as `20.20.20.3 1.1.1.1` reports `Custom`. Exact stock Cloudflare and Google presets still report correctly.

Fixes #10245

## Test plan

- [x] Added `test/shell.d/dns-provider-classify-test.sh`
- [x] Ran `bash test/shell.d/dns-provider-classify-test.sh` (all ok)
- [x] Covers: empty/DHCP, stock Cloudflare, stock Google, custom-with-public-secondary, pure custom
