### PR TITLE
Mark T2 Mac trackpads as internal for DWT

### DIFF
--- a/bin/omarchy-hw-t2
+++ b/bin/omarchy-hw-t2
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Detect an Intel Mac with an Apple T2 coprocessor
+# omarchy:hidden=true
+
+# T2 PCI IDs: 106b:1801 or 106b:1802. The built-in keyboard/trackpad
+# hangs off t2bce_vhci and udev labels that USB pad external.
+# Drain lspci fully; grep -q would SIGPIPE and look like "no such hardware" (#6608).
+pci=$(lspci -nn 2>/dev/null || true)
+
+[[ $pci == *106b:1801* || $pci == *106b:1802* ]]

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -38,6 +38,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"

--- a/install/hardware/apple/99-omarchy-t2-touchpad.rules
+++ b/install/hardware/apple/99-omarchy-t2-touchpad.rules
@@ -1,0 +1,3 @@
+# T2 virtual USB reports the built-in keyboard/trackpad as removable=unknown,
+# so udev marks it external and libinput leaves disable-while-typing off.
+ACTION=="add|change", KERNEL=="event*", ENV{ID_INPUT_TOUCHPAD}=="1", ATTRS{name}=="Apple Inc. Apple Internal Keyboard / Trackpad", ENV{ID_INPUT_TOUCHPAD_INTEGRATION}="internal", ENV{ID_INTEGRATION}="internal"

--- a/install/hardware/apple/fix-t2-touchpad.sh
+++ b/install/hardware/apple/fix-t2-touchpad.sh
@@ -1,0 +1,19 @@
+# Fix disable-while-typing on T2 Mac built-in trackpads.
+#
+# t2bce_vhci presents the keyboard/trackpad as USB with
+# ATTR{removable}=="unknown", so udev marks the pad external. libinput
+# then leaves disable-while-typing off. Thumbs resting on the clickpad
+# jump the cursor while typing; Hyprland follow_mouse steals focus.
+#
+# Upstream libinput (50-system-apple.quirks) already marks the keyboard
+# internal. Touchpad integration is a udev property, not a libinput
+# quirk — same pattern as fix-z13-touchpad.sh.
+
+if omarchy-hw-t2; then
+  echo "Detected T2 Mac. Marking the built-in trackpad as internal."
+
+  src="$OMARCHY_INSTALL/hardware/apple"
+  rule_dst="${OMARCHY_T2_TOUCHPAD_RULE:-/etc/udev/rules.d/99-omarchy-t2-touchpad.rules}"
+
+  install -Dm644 "$src/99-omarchy-t2-touchpad.rules" "$rule_dst"
+fi

--- a/migrations/1788537572.sh
+++ b/migrations/1788537572.sh
@@ -1,0 +1,17 @@
+echo "Mark T2 Mac built-in trackpads as internal so disable-while-typing works"
+
+# t2bce_vhci USB pads are udev-external. Existing T2 installs already have
+# linux-t2 and the keyboard quirk; they still need this udev rule.
+
+if ! omarchy-hw-t2; then
+  exit 0
+fi
+
+src="${OMARCHY_PATH}/install/hardware/apple"
+rule_dst="${OMARCHY_T2_TOUCHPAD_RULE:-/etc/udev/rules.d/99-omarchy-t2-touchpad.rules}"
+
+if [[ ! -f $rule_dst ]]; then
+  sudo install -Dm644 "$src/99-omarchy-t2-touchpad.rules" "$rule_dst"
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --subsystem-match=input --action=change
+fi

--- a/test/shell.d/t2-touchpad-test.sh
+++ b/test/shell.d/t2-touchpad-test.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-t2-touchpad.sh"
+rule_src="$ROOT/install/hardware/apple/99-omarchy-t2-touchpad.rules"
+detector="$ROOT/bin/omarchy-hw-t2"
+hardware_all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1788537572.sh"
+
+grep -Fq 'ID_INPUT_TOUCHPAD_INTEGRATION' "$rule_src" ||
+  fail "udev rule sets touchpad integration"
+grep -Fq 'Apple Inc. Apple Internal Keyboard / Trackpad' "$rule_src" ||
+  fail "udev rule matches the T2 HID name"
+! grep -Fq '/etc/libinput' "$leaf" "$migration" ||
+  fail "the workaround leaves administrator libinput overrides alone"
+grep -Fq 'omarchy-hw-t2' "$leaf" ||
+  fail "leaf gates on the T2 detector"
+grep -Fq 'omarchy-hw-t2' "$migration" ||
+  fail "migration gates on the T2 detector"
+if [[ -f $hardware_all ]]; then
+  grep -q 'apple/fix-t2-touchpad.sh' "$hardware_all" ||
+    fail "the T2 touchpad leaf runs during hardware setup"
+  awk '
+    /fix-t2\.sh/ { t2=NR }
+    /fix-t2-touchpad\.sh/ { pad=NR }
+    END {
+      if (!(t2 && pad) || !(t2 < pad))
+        exit 1
+    }
+  ' "$hardware_all" ||
+    fail "the T2 touchpad leaf runs after T2 setup"
+fi
+pass "T2 touchpad files mark the pad internal without local libinput quirks"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no such hardware" (#6608).
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '74:00.1 Non-VGA unclassified device [0000]: Apple Inc. T2 Bridge Controller [106b:1801] (rev 01)'
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/install" <<'SH'
+#!/bin/bash
+
+printf 'install' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+
+while [[ ${1:-} == -* ]]; do
+  shift
+done
+
+src=${1:-}
+dest=${2:-}
+if [[ -n $src && -n $dest ]]; then
+  mkdir -p "$(dirname "$dest")"
+  cp "$src" "$dest"
+fi
+SH
+
+cat >"$stub_bin/udevadm" <<'SH'
+#!/bin/bash
+
+printf 'udevadm' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_detector() {
+  PATH="$stub_bin:$PATH" T2_HARDWARE="$1" "$detector"
+}
+
+run_detector 1
+pass "detector matches T2"
+
+if run_detector 0; then
+  fail "detector ignores non-T2 hardware"
+fi
+pass "detector ignores non-T2 hardware"
+
+cat >"$stub_bin/omarchy-hw-t2" <<'SH'
+#!/bin/bash
+
+(( ${T2_HARDWARE:-0} == 1 ))
+SH
+chmod +x "$stub_bin/omarchy-hw-t2"
+
+rule="$test_tmp/udev/99-omarchy-t2-touchpad.rules"
+
+run_migration() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    T2_HARDWARE="${1:-1}" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_T2_TOUCHPAD_RULE="$rule" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+: >"$calls"
+run_migration 1
+[[ -f $rule ]] || fail "migration installs the udev rule"
+grep -Fq 'ID_INPUT_TOUCHPAD_INTEGRATION' "$rule" ||
+  fail "migration copies the packaged udev rule"
+grep -Fq $'sudo\tudevadm\tcontrol\t--reload-rules' "$calls" ||
+  fail "migration reloads udev rules after install"
+grep -Fq $'sudo\tudevadm\ttrigger\t--subsystem-match=input\t--action=change' "$calls" ||
+  fail "migration reapplies input rules after install"
+pass "migration installs and activates the udev rule on T2"
+
+: >"$calls"
+run_migration 1
+[[ ! -s $calls ]] || fail "an already repaired T2 install is left unchanged" "$(cat "$calls")"
+pass "migration is machine-idempotent"
+
+rm -f "$rule"
+: >"$calls"
+run_migration 0
+[[ ! -e $rule ]] || fail "non-T2 systems get no trackpad rule"
+[[ ! -s $calls ]] || fail "non-T2 systems skip the trackpad repair" "$(cat "$calls")"
+pass "migration skips unrelated hardware"
+
+run_leaf() {
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    T2_HARDWARE="${1:-1}" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_INSTALL="$ROOT/install" \
+    OMARCHY_T2_TOUCHPAD_RULE="$rule" \
+    bash -euo pipefail "$leaf" >/dev/null
+}
+
+rm -f "$rule"
+: >"$calls"
+run_leaf 1
+[[ -f $rule ]] || fail "installer leaf installs the udev rule"
+pass "installer leaf installs the udev rule on T2"
+
+rm -f "$rule"
+: >"$calls"
+run_leaf 0
+[[ ! -e $rule ]] || fail "installer leaf skips machines without T2"
+[[ ! -s $calls ]] || fail "installer leaf is silent on unrelated hardware" "$(cat "$calls")"
+pass "installer leaf skips unrelated hardware"


### PR DESCRIPTION
## Summary

- detect Intel Macs with an Apple T2 coprocessor
- mark the built-in T2 USB touchpad internal so libinput enables
  disable-while-typing
- apply the rule during fresh hardware setup and through an idempotent
  migration for existing installs
- reload and retrigger udev from the migration so the corrected
  property is available without waiting for a reboot

## Why

`t2bce_vhci` exposes the built-in keyboard/trackpad as USB with
`removable=unknown`. `65-integration.rules` consequently labels the
touchpad external, and libinput skips DWT even though Hyprland enables
the option.

This follows the existing `fix-z13-touchpad.sh` approach. The match is
limited to touchpad event nodes with the exact internal Apple HID name,
so external Magic Trackpads are unaffected.

No libinput override is installed. Stock `50-system-apple.quirks`
already marks the keyboard internal and recognizes Apple USB
touchpads.

## Reference hardware

- MacBookAir9,1
- T2 PCI `106b:1801` / `106b:1802`
- touchpad USB `05ac:0280`
- `linux-t2` 7.1.8, `t2bce_vhci`, `hid-magicmouse`
- Omarchy 4 / Hyprland 0.56.2 / libinput 1.31.3

After applying the rule:

```text
ID_INPUT_TOUCHPAD=1
ID_INPUT_TOUCHPAD_INTEGRATION=internal
ID_INTEGRATION=internal
```

Typing with thumbs resting on the clickpad no longer moves the pointer
or changes focus under `follow_mouse = 1`.

An existing graphical session may need to restart so its libinput
context reopens the device with the corrected property.

## Tests

```bash
udevadm verify install/hardware/apple/99-omarchy-t2-touchpad.rules
./test/shell.d/t2-touchpad-test.sh
./test/cli commands --check
```

The shell test covers T2/non-T2 detection, installation, migration
idempotence, and migration-time udev activation.

Related: discussion #1273.
