### PR TITLE
Add timed Stay Awake options to the coffee indicator

### DIFF
--- a/bin/omarchy-toggle-idle
+++ b/bin/omarchy-toggle-idle
@@ -10,6 +10,13 @@ set -euo pipefail
 STATE_DIR="$HOME/.local/state/omarchy/indicators"
 STATE_FILE="$STATE_DIR/stay-awake"
 
+# Serialize choices with the shell and update ownership changes.
+lock_state() {
+  mkdir -p -- "$STATE_DIR"
+  exec {idle_lock}>>"$STATE_FILE.lock"
+  flock "$idle_lock"
+}
+
 stay_awake_enabled() {
   [[ -f $STATE_FILE && ! -L $STATE_FILE ]] || return 1
   [[ ! -s $STATE_FILE ]] && return 0
@@ -56,6 +63,7 @@ apply_state() {
 
 case "${1:-toggle}" in
   toggle)
+    lock_state
     if stay_awake_enabled; then
       apply_state allow-idle
     else
@@ -64,10 +72,12 @@ case "${1:-toggle}" in
     print_idle_state
     ;;
   stay-awake|awake|on)
+    lock_state
     apply_state stay-awake
     print_idle_state
     ;;
   allow-idle|idle|off)
+    lock_state
     apply_state allow-idle
     print_idle_state
     ;;

--- a/bin/omarchy-toggle-idle
+++ b/bin/omarchy-toggle-idle
@@ -5,11 +5,23 @@
 # omarchy:args=[toggle|stay-awake|allow-idle|status]
 # omarchy:examples=omarchy toggle idle | omarchy toggle idle stay-awake | omarchy-toggle-idle --status
 
+set -euo pipefail
+
 STATE_DIR="$HOME/.local/state/omarchy/indicators"
 STATE_FILE="$STATE_DIR/stay-awake"
 
 stay_awake_enabled() {
-  [[ -f $STATE_FILE ]]
+  [[ -f $STATE_FILE && ! -L $STATE_FILE ]] || return 1
+  [[ ! -s $STATE_FILE ]] && return 0
+
+  local deadline now size
+  size=$(stat -c %s -- "$STATE_FILE") || return 1
+  (( size <= 28 )) || return 1
+  deadline=$(head -c 64 -- "$STATE_FILE") || return 1
+  [[ $deadline =~ ^[0-9]{1,10}:[0-9]{1,5}:[0-9]{1,5}$ ]] && return 0
+  [[ $deadline =~ ^[0-9]{1,16}$ ]] || return 1
+  now=$(date +%s%3N)
+  (( 10#$deadline > now && 10#$deadline <= now + 86400000 ))
 }
 
 print_status() {
@@ -31,8 +43,10 @@ print_idle_state() {
 apply_state() {
   case "$1" in
     stay-awake)
-      mkdir -p "$STATE_DIR"
-      : > "$STATE_FILE"
+      mkdir -p -- "$STATE_DIR"
+      temporary=$(mktemp "$STATE_DIR/.stay-awake.XXXXXX")
+      trap 'rm -f -- "$temporary"' EXIT
+      mv -fT -- "$temporary" "$STATE_FILE"
       ;;
     allow-idle)
       rm -f "$STATE_FILE"

--- a/bin/omarchy-toggle-idle
+++ b/bin/omarchy-toggle-idle
@@ -32,7 +32,7 @@ apply_state() {
   case "$1" in
     stay-awake)
       mkdir -p "$STATE_DIR"
-      touch "$STATE_FILE"
+      : > "$STATE_FILE"
       ;;
     allow-idle)
       rm -f "$STATE_FILE"

--- a/bin/omarchy-update-stay-awake
+++ b/bin/omarchy-update-stay-awake
@@ -47,14 +47,13 @@ process_state() {
   printf '%s\n' "${process_stat%% *}"
 }
 
-stop() {
-  local inhibit_pid=""
-  local recorded_start_time=""
-  local current_start_time=""
-  local idle_owner=""
-  local current_idle_owner=""
-  local restore_failed=0
-
+# Share the writers' lock across ownership checks and restoration. Keep it out
+# of the long-lived sleep inhibitor and avoid re-entering the locking CLI.
+restore_idle_state() (
+  local idle_owner="" current_idle_owner=""
+  mkdir -p "${stay_awake_state%/*}" || return
+  exec 9>>"$stay_awake_state.lock" || return
+  flock 9 || return
   if [[ -s $idle_owner_file ]]; then
     idle_owner=$(<"$idle_owner_file")
     if [[ -f $stay_awake_state ]]; then
@@ -64,15 +63,24 @@ stop() {
       if [[ -f $idle_previous_file ]]; then
         if ! write_idle_state "$(<"$idle_previous_file")"; then
           echo "Failed to restore the previous Stay Awake deadline." >&2
-          restore_failed=1
+          return 1
         fi
       else
-        omarchy-toggle-idle allow-idle >/dev/null 2>&1 || true
+        rm -f -- "$stay_awake_state" || return
       fi
     fi
-    if (( restore_failed == 0 )); then
-      rm -f "$idle_owner_file" "$idle_previous_file"
-    fi
+    rm -f "$idle_owner_file" "$idle_previous_file"
+  fi
+)
+
+stop() {
+  local inhibit_pid=""
+  local recorded_start_time=""
+  local current_start_time=""
+  local restore_failed=0
+
+  if ! restore_idle_state; then
+    restore_failed=1
   fi
 
   if [[ -s $inhibit_pid_file ]]; then
@@ -148,6 +156,9 @@ start() {
   # A timed choice may expire before the update finishes. Hold our own marker,
   # then restore that same deadline only if the user has not replaced our choice.
   local previous=""
+  mkdir -p "${stay_awake_state%/*}"
+  exec {idle_lock}>>"$stay_awake_state.lock"
+  flock "$idle_lock"
   if [[ -f $stay_awake_state && ! -L $stay_awake_state ]]; then
     [[ -s $stay_awake_state ]] || return 0
     previous=$(head -c 64 -- "$stay_awake_state")

--- a/bin/omarchy-update-stay-awake
+++ b/bin/omarchy-update-stay-awake
@@ -8,8 +8,21 @@ set -e
 
 state_dir="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}/omarchy-update-stay-awake"
 idle_owner_file="$state_dir/idle-owner"
+idle_previous_file="$state_dir/idle-previous"
 inhibit_pid_file="$state_dir/inhibit-pid"
 stay_awake_state="$HOME/.local/state/omarchy/indicators/stay-awake"
+
+# Publish ownership and restored deadlines without exposing a partial state.
+write_idle_state() {
+  local temporary
+  mkdir -p "${stay_awake_state%/*}" || return
+  temporary=$(mktemp "${stay_awake_state%/*}/.stay-awake.XXXXXX") || return
+  if printf '%s' "$1" > "$temporary" && mv -fT -- "$temporary" "$stay_awake_state"; then
+    return 0
+  fi
+  rm -f -- "$temporary"
+  return 1
+}
 
 process_start_time() {
   local process_pid="$1"
@@ -40,6 +53,7 @@ stop() {
   local current_start_time=""
   local idle_owner=""
   local current_idle_owner=""
+  local restore_failed=0
 
   if [[ -s $idle_owner_file ]]; then
     idle_owner=$(<"$idle_owner_file")
@@ -47,9 +61,18 @@ stop() {
       current_idle_owner=$(<"$stay_awake_state")
     fi
     if [[ -n $idle_owner && $current_idle_owner == "$idle_owner" ]]; then
-      omarchy-toggle-idle allow-idle >/dev/null 2>&1 || true
+      if [[ -f $idle_previous_file ]]; then
+        if ! write_idle_state "$(<"$idle_previous_file")"; then
+          echo "Failed to restore the previous Stay Awake deadline." >&2
+          restore_failed=1
+        fi
+      else
+        omarchy-toggle-idle allow-idle >/dev/null 2>&1 || true
+      fi
     fi
-    rm -f "$idle_owner_file"
+    if (( restore_failed == 0 )); then
+      rm -f "$idle_owner_file" "$idle_previous_file"
+    fi
   fi
 
   if [[ -s $inhibit_pid_file ]]; then
@@ -78,6 +101,7 @@ stop() {
   fi
 
   rmdir "$state_dir" 2>/dev/null || true
+  (( restore_failed == 0 ))
 }
 
 start() {
@@ -121,14 +145,21 @@ start() {
     fi
   fi
 
-  if [[ ! -f $stay_awake_state ]]; then
-    printf '%s\n' "$idle_owner" >"$idle_owner_file"
-    mkdir -p "$(dirname "$stay_awake_state")"
-    if omarchy-toggle-idle stay-awake >/dev/null 2>&1; then
-      printf '%s\n' "$idle_owner" >"$stay_awake_state"
-    else
-      rm -f "$idle_owner_file"
-    fi
+  # A timed choice may expire before the update finishes. Hold our own marker,
+  # then restore that same deadline only if the user has not replaced our choice.
+  local previous=""
+  if [[ -f $stay_awake_state && ! -L $stay_awake_state ]]; then
+    [[ -s $stay_awake_state ]] || return 0
+    previous=$(head -c 64 -- "$stay_awake_state")
+    [[ $previous =~ ^[0-9]{1,10}:[0-9]{1,5}:[0-9]{1,5}$ ]] && return 0
+  fi
+  if [[ $previous =~ ^[0-9]{1,16}$ ]]; then
+    printf '%s' "$previous" > "$idle_previous_file"
+  fi
+  printf '%s' "$idle_owner" > "$idle_owner_file"
+  if ! write_idle_state "$idle_owner"; then
+    rm -f "$idle_owner_file" "$idle_previous_file"
+    return 1
   fi
 }
 

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -82,6 +82,8 @@ If you dismiss the screensaver before the lock deadline, that counts as activity
 
 To stop locking on idle entirely, `Super + Ctrl + I` — or `omarchy toggle idle` — flips stay awake on, and the coffee cup indicator appears in the bar. That's the one to hit before a long presentation or a build you want to watch. Hit it again to go back to normal. `omarchy toggle idle status` prints the current state as JSON if you need it from a script.
 
+Right-click the coffee cup to keep awake for 30 minutes, 1 hour, 3 hours, or 8 hours. You can also choose **Indefinitely** or **Turn off**. Hover near the clock to reveal the coffee cup when stay awake is off. Timed sessions return to normal idle behavior when the time is up, even if the shell has restarted in between; hover the active cup to see the end time.
+
 This is about locking and the screensaver, not power. Suspend and hibernation have their own setup in [system sleep](36-system-sleep.md).
 
 ### The screensaver

--- a/shell/plugins/bar/indicators/StayAwake.qml
+++ b/shell/plugins/bar/indicators/StayAwake.qml
@@ -34,9 +34,10 @@ BarIndicator {
     anchorItem: root
     owner: root
     bar: root.bar
-    focusTarget: choices.itemAt(0)
+    focusTarget: options
     contentWidth: fittedContentWidth(Style.space(232))
     contentHeight: fittedContentHeight(options.implicitHeight)
+    onOpenChanged: if (open) Qt.callLater(function() { options.focusChoice(0) })
 
     Column {
       id: options

--- a/shell/plugins/bar/indicators/StayAwake.qml
+++ b/shell/plugins/bar/indicators/StayAwake.qml
@@ -86,11 +86,11 @@ BarIndicator {
           focusable: true
           onActiveFocusChanged: if (activeFocus) options.focusedIndex = index
           onClicked: {
+            root.close()
             if (root.idleService) {
               if (modelData.seconds > 0) root.idleService.stayAwakeFor(modelData.seconds)
               else root.idleService.setIdleEnabled(false)
             }
-            root.close()
           }
         }
       }
@@ -106,8 +106,8 @@ BarIndicator {
         focusable: true
         onActiveFocusChanged: if (activeFocus) options.focusedIndex = choices.count
         onClicked: {
-          if (root.idleService) root.idleService.setIdleEnabled(true)
           root.close()
+          if (root.idleService) root.idleService.setIdleEnabled(true)
         }
       }
     }

--- a/shell/plugins/bar/indicators/StayAwake.qml
+++ b/shell/plugins/bar/indicators/StayAwake.qml
@@ -1,6 +1,6 @@
 import QtQuick
-import qs.Ui
 import qs.Commons
+import qs.Ui
 
 BarIndicator {
   id: root
@@ -11,9 +11,9 @@ BarIndicator {
   activeText: "󰅶"
   inactiveText: "󰅶"
   activeTooltipText: idleService && idleService.stayAwakeUntil > 0
-    ? "Stay Awake until " + Qt.formatTime(new Date(idleService.stayAwakeUntil), "hh:mm") + " · Right-click for options"
-    : "Allow Idle Lock & Screensaver · Right-click for options"
-  inactiveTooltipText: "Stay Awake · Right-click for options"
+    ? "Stay Awake until " + Qt.formatTime(new Date(idleService.stayAwakeUntil), "hh:mm") + "\nRight-click for duration"
+    : "Allow Idle Lock & Screensaver\nRight-click for duration"
+  inactiveTooltipText: "Stay Awake\nRight-click for duration"
 
   function toggle() {
     if (root.idleService) root.idleService.setIdleEnabled(root.active)
@@ -29,52 +29,84 @@ BarIndicator {
     }
   }
 
-  PopupCard {
+  KeyboardPanel {
     id: durationPopup
     anchorItem: root
     owner: root
     bar: root.bar
-    contentWidth: fittedContentWidth(Style.space(260))
+    focusTarget: choices.itemAt(0)
+    contentWidth: fittedContentWidth(Style.space(232))
     contentHeight: fittedContentHeight(options.implicitHeight)
 
     Column {
       id: options
       width: parent.width
-      spacing: Style.space(4)
-      focus: durationPopup.open
+      spacing: Style.spacing.labelGap
+      property int focusedIndex: 0
+
+      function focusChoice(index) {
+        focusedIndex = (index + choices.count + 1) % (choices.count + 1)
+        var button = focusedIndex === choices.count ? turnOff : choices.itemAt(focusedIndex)
+        if (button) button.forceActiveFocus()
+      }
+
+      Keys.onDownPressed: focusChoice(focusedIndex + 1)
+      Keys.onUpPressed: focusChoice(focusedIndex - 1)
       Keys.onEscapePressed: root.close()
 
       Text {
-        text: "Keep awake"
-        color: Color.foreground
+        text: "Stay awake"
+        textFormat: Text.PlainText
+        color: Color.popups.text
         font.family: root.fontFamily
         font.pixelSize: Style.font.body
+        font.bold: true
+        leftPadding: Style.spacing.controlPaddingX
         height: implicitHeight + Style.space(8)
       }
 
       Repeater {
+        id: choices
         model: [
-          { label: "For 30 minutes", seconds: 1800 },
-          { label: "For 1 hour", seconds: 3600 },
-          { label: "For 3 hours", seconds: 10800 },
-          { label: "For 8 hours", seconds: 28800 },
-          { label: "Indefinitely", seconds: 0 },
-          { label: "Turn off", seconds: -1 }
+          { label: "30 minutes", seconds: 1800 },
+          { label: "1 hour", seconds: 3600 },
+          { label: "3 hours", seconds: 10800 },
+          { label: "8 hours", seconds: 28800 },
+          { label: "Indefinitely", seconds: 0 }
         ]
 
         Button {
           required property var modelData
+          required property int index
           width: options.width
           text: modelData.label
+          foreground: Color.popups.text
           leftAlign: true
           focusable: true
+          onActiveFocusChanged: if (activeFocus) options.focusedIndex = index
           onClicked: {
             if (root.idleService) {
               if (modelData.seconds > 0) root.idleService.stayAwakeFor(modelData.seconds)
-              else root.idleService.setIdleEnabled(modelData.seconds < 0)
+              else root.idleService.setIdleEnabled(false)
             }
             root.close()
           }
+        }
+      }
+
+      PanelSeparator { foreground: Color.popups.text }
+
+      Button {
+        id: turnOff
+        width: options.width
+        text: "Turn off"
+        foreground: Color.popups.text
+        leftAlign: true
+        focusable: true
+        onActiveFocusChanged: if (activeFocus) options.focusedIndex = choices.count
+        onClicked: {
+          if (root.idleService) root.idleService.setIdleEnabled(true)
+          root.close()
         }
       }
     }

--- a/shell/plugins/bar/indicators/StayAwake.qml
+++ b/shell/plugins/bar/indicators/StayAwake.qml
@@ -34,80 +34,87 @@ BarIndicator {
     anchorItem: root
     owner: root
     bar: root.bar
-    focusTarget: options
+    focusTarget: keys
     contentWidth: fittedContentWidth(Style.space(232))
     contentHeight: fittedContentHeight(options.implicitHeight)
-    onOpenChanged: if (open) Qt.callLater(function() { options.focusChoice(0) })
+    onOpenChanged: if (open) keys.currentIndex = 0
 
-    Column {
-      id: options
-      width: parent.width
-      spacing: Style.spacing.labelGap
-      property int focusedIndex: 0
+    PanelKeyCatcher {
+      id: keys
+      anchors.fill: parent
+      property int currentIndex: 0
 
-      function focusChoice(index) {
-        focusedIndex = (index + choices.count + 1) % (choices.count + 1)
-        var button = focusedIndex === choices.count ? turnOff : choices.itemAt(focusedIndex)
-        if (button) button.forceActiveFocus()
+      function moveChoice(direction) {
+        currentIndex = (currentIndex + direction + choices.count + 1) % (choices.count + 1)
       }
 
-      Keys.onDownPressed: focusChoice(focusedIndex + 1)
-      Keys.onUpPressed: focusChoice(focusedIndex - 1)
-      Keys.onEscapePressed: root.close()
-
-      Text {
-        text: "Stay awake"
-        textFormat: Text.PlainText
-        color: Color.popups.text
-        font.family: root.fontFamily
-        font.pixelSize: Style.font.body
-        font.bold: true
-        leftPadding: Style.spacing.controlPaddingX
-        height: implicitHeight + Style.space(8)
+      onMoveRequested: function(dx, dy) { if (dy) moveChoice(dy) }
+      onTabRequested: function(direction) { moveChoice(direction) }
+      onActivateRequested: {
+        var button = currentIndex === choices.count ? turnOff : choices.itemAt(currentIndex)
+        if (button) button.clicked()
       }
+      onCloseRequested: root.close()
 
-      Repeater {
-        id: choices
-        model: [
-          { label: "30 minutes", seconds: 1800 },
-          { label: "1 hour", seconds: 3600 },
-          { label: "3 hours", seconds: 10800 },
-          { label: "8 hours", seconds: 28800 },
-          { label: "Indefinitely", seconds: 0 }
-        ]
+      Column {
+        id: options
+        width: parent.width
+        spacing: Style.spacing.labelGap
 
-        Button {
-          required property var modelData
-          required property int index
-          width: options.width
-          text: modelData.label
-          foreground: Color.popups.text
-          leftAlign: true
-          focusable: true
-          onActiveFocusChanged: if (activeFocus) options.focusedIndex = index
-          onClicked: {
-            root.close()
-            if (root.idleService) {
-              if (modelData.seconds > 0) root.idleService.stayAwakeFor(modelData.seconds)
-              else root.idleService.setIdleEnabled(false)
+        Text {
+          text: "Stay awake"
+          textFormat: Text.PlainText
+          color: Color.popups.text
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          font.bold: true
+          leftPadding: Style.spacing.controlPaddingX
+          height: implicitHeight + Style.space(8)
+        }
+
+        Repeater {
+          id: choices
+          model: [
+            { label: "30 minutes", seconds: 1800 },
+            { label: "1 hour", seconds: 3600 },
+            { label: "3 hours", seconds: 10800 },
+            { label: "8 hours", seconds: 28800 },
+            { label: "Indefinitely", seconds: 0 }
+          ]
+
+          Button {
+            required property var modelData
+            required property int index
+            width: options.width
+            text: modelData.label
+            foreground: Color.popups.text
+            leftAlign: true
+            hasCursor: keys.currentIndex === index
+            onHovered: function(hovered) { if (hovered) keys.currentIndex = index }
+            onClicked: {
+              root.close()
+              if (root.idleService) {
+                if (modelData.seconds > 0) root.idleService.stayAwakeFor(modelData.seconds)
+                else root.idleService.setIdleEnabled(false)
+              }
             }
           }
         }
-      }
 
-      PanelSeparator { foreground: Color.popups.text }
+        PanelSeparator { foreground: Color.popups.text }
 
-      Button {
-        id: turnOff
-        width: options.width
-        text: "Turn off"
-        foreground: Color.popups.text
-        leftAlign: true
-        focusable: true
-        onActiveFocusChanged: if (activeFocus) options.focusedIndex = choices.count
-        onClicked: {
-          root.close()
-          if (root.idleService) root.idleService.setIdleEnabled(true)
+        Button {
+          id: turnOff
+          width: options.width
+          text: "Turn off"
+          foreground: Color.popups.text
+          leftAlign: true
+          hasCursor: keys.currentIndex === choices.count
+          onHovered: function(hovered) { if (hovered) keys.currentIndex = choices.count }
+          onClicked: {
+            root.close()
+            if (root.idleService) root.idleService.setIdleEnabled(true)
+          }
         }
       }
     }

--- a/shell/plugins/bar/indicators/StayAwake.qml
+++ b/shell/plugins/bar/indicators/StayAwake.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.Ui
+import qs.Commons
 
 BarIndicator {
   id: root
@@ -9,12 +10,73 @@ BarIndicator {
   active: idleService ? idleService.stayAwake : false
   activeText: "󰅶"
   inactiveText: "󰅶"
-  activeTooltipText: "Allow Idle Lock & Screensaver"
-  inactiveTooltipText: "Stay Awake"
+  activeTooltipText: idleService && idleService.stayAwakeUntil > 0
+    ? "Stay Awake until " + Qt.formatTime(new Date(idleService.stayAwakeUntil), "hh:mm") + " · Right-click for options"
+    : "Allow Idle Lock & Screensaver · Right-click for options"
+  inactiveTooltipText: "Stay Awake · Right-click for options"
 
   function toggle() {
     if (root.idleService) root.idleService.setIdleEnabled(root.active)
   }
 
-  onPressed: function() { root.toggle() }
+  function close() { durationPopup.open = false }
+
+  onPressed: function(button) {
+    if (button === Qt.RightButton) durationPopup.open = !durationPopup.open
+    else if (button === Qt.LeftButton) {
+      root.close()
+      root.toggle()
+    }
+  }
+
+  PopupCard {
+    id: durationPopup
+    anchorItem: root
+    owner: root
+    bar: root.bar
+    contentWidth: fittedContentWidth(Style.space(260))
+    contentHeight: fittedContentHeight(options.implicitHeight)
+
+    Column {
+      id: options
+      width: parent.width
+      spacing: Style.space(4)
+      focus: durationPopup.open
+      Keys.onEscapePressed: root.close()
+
+      Text {
+        text: "Keep awake"
+        color: Color.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        height: implicitHeight + Style.space(8)
+      }
+
+      Repeater {
+        model: [
+          { label: "For 30 minutes", seconds: 1800 },
+          { label: "For 1 hour", seconds: 3600 },
+          { label: "For 3 hours", seconds: 10800 },
+          { label: "For 8 hours", seconds: 28800 },
+          { label: "Indefinitely", seconds: 0 },
+          { label: "Turn off", seconds: -1 }
+        ]
+
+        Button {
+          required property var modelData
+          width: options.width
+          text: modelData.label
+          leftAlign: true
+          focusable: true
+          onClicked: {
+            if (root.idleService) {
+              if (modelData.seconds > 0) root.idleService.stayAwakeFor(modelData.seconds)
+              else root.idleService.setIdleEnabled(modelData.seconds < 0)
+            }
+            root.close()
+          }
+        }
+      }
+    }
+  }
 }

--- a/shell/plugins/bar/widgets/Indicators.qml
+++ b/shell/plugins/bar/widgets/Indicators.qml
@@ -15,7 +15,9 @@ BarWidget {
   property bool indicatorAreaHovered: false
   property bool indicatorItemHovered: false
   readonly property bool alwaysShowIndicators: setting("alwaysShow", false) === true
-  readonly property bool revealInactiveIndicators: alwaysShowIndicators || indicatorAreaHovered || indicatorItemHovered || (bar && bar.centerSectionRevealHeld === true && bar.centerHoverRevealSuppressed !== true)
+  // A popup owns the pointer while open; keep its indicator and anchor in place.
+  readonly property bool indicatorPopupOpen: bar?.activePopout?.indicatorHost === root
+  readonly property bool revealInactiveIndicators: alwaysShowIndicators || indicatorPopupOpen || indicatorAreaHovered || indicatorItemHovered || (bar && bar.centerSectionRevealHeld === true && bar.centerHoverRevealSuppressed !== true)
 
   signal refreshRequested()
 

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,3 +1,13 @@
+// Empty legacy state files mean indefinitely; timed files contain a Unix deadline in milliseconds.
+function stayAwakeState(line, now) {
+  if (line.indexOf("yes:") !== 0) return { enabled: false, until: 0, expired: false }
+  var value = line.slice(4)
+  var until = Number(value)
+  if (value === "") return { enabled: true, until: 0, expired: false }
+  if (!isFinite(until) || until <= now) return { enabled: false, until: 0, expired: true }
+  return { enabled: true, until: until, expired: false }
+}
+
 function secondsFromConfig(value, fallback) {
   var n = Number(value)
   if (!isFinite(n) || n < 0) return fallback
@@ -45,6 +55,7 @@ function screensaverWindowsAfter(windows, address, visible) {
 
 if (typeof module !== "undefined") {
   module.exports = {
+    stayAwakeState: stayAwakeState,
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,11 +1,23 @@
-// Empty legacy state files mean indefinitely; timed files contain a Unix deadline in milliseconds.
-function stayAwakeState(line, now) {
-  if (line.indexOf("yes:") !== 0) return { enabled: false, until: 0, expired: false }
-  var value = line.slice(4)
+// Empty legacy files mean indefinitely. A timed file contains its deadline in milliseconds.
+var maxStayAwakeSeconds = 24 * 60 * 60
+
+function stayAwakeDeadline(seconds, now) {
+  var duration = Number(seconds)
+  if (!Number.isInteger(duration) || duration <= 0 || duration > maxStayAwakeSeconds) return 0
+  return now + duration * 1000
+}
+
+function stayAwakeState(raw, now) {
+  var disabled = { enabled: false, until: 0 }
+  if (raw === "yes:") return { enabled: true, until: 0 }
+  if (raw.indexOf("yes:") !== 0 || raw.length > 32) return disabled
+
+  var value = raw.slice(4).replace(/\n+$/, "")
+  if (/^[0-9]{1,10}:[0-9]{1,5}:[0-9]{1,5}$/.test(value)) return { enabled: true, until: 0 }
   var until = Number(value)
-  if (value === "") return { enabled: true, until: 0, expired: false }
-  if (!isFinite(until) || until <= now) return { enabled: false, until: 0, expired: true }
-  return { enabled: true, until: until, expired: false }
+  if (!/^[0-9]{1,16}$/.test(value) || !Number.isSafeInteger(until)) return disabled
+  if (until <= now || until > now + maxStayAwakeSeconds * 1000) return disabled
+  return { enabled: true, until: until }
 }
 
 function secondsFromConfig(value, fallback) {
@@ -56,6 +68,7 @@ function screensaverWindowsAfter(windows, address, visible) {
 if (typeof module !== "undefined") {
   module.exports = {
     stayAwakeState: stayAwakeState,
+    stayAwakeDeadline: stayAwakeDeadline,
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -261,6 +261,7 @@ Item {
     return applyStayAwake(true, true, "timed", Date.now() + Math.ceil(duration * 1000))
   }
 
+  // Check the saved wall-clock deadline so suspend does not extend the session.
   Timer {
     interval: 1000
     repeat: true
@@ -328,6 +329,7 @@ Item {
     command: ["bash", "-c", "mkdir -p \"$HOME/.local/state/omarchy/indicators\"; if [[ -f $HOME/.local/state/omarchy/indicators/stay-awake ]]; then printf 'yes:'; cat \"$HOME/.local/state/omarchy/indicators/stay-awake\"; echo; else echo no; fi"]
     stdout: SplitParser {
       onRead: function(line) {
+        // A probe started before a newer choice must not replace it.
         if (stayAwakeStateProbe.revision !== root.stayAwakeRevision || stayAwakeStateWriter.running || root.hasPendingStayAwakePersist) return
         var state = IdleModel.stayAwakeState(String(line).trim(), Date.now())
         root.applyStayAwake(state.enabled, state.expired, "state-file", state.until)

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -28,10 +28,10 @@ Item {
 
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
-  property bool hasPendingStayAwakePersist: false
   property var pendingStayAwakePersist: null
   property double stayAwakeUntil: 0
   property int stayAwakeRevision: 0
+  property bool stayAwakeProbePending: false
   property bool idledThisCycle: false
   property bool screensaverStartedThisCycle: false
   property string lastEvent: "starting"
@@ -211,22 +211,31 @@ Item {
   }
 
   function persistStayAwake(value, until) {
-    var command = value
-      ? "mkdir -p \"$HOME/.local/state/omarchy/indicators\" && printf '%s' '" + (until > 0 ? String(until) : "") + "' > \"$HOME/.local/state/omarchy/indicators/stay-awake\""
-      : "rm -f \"$HOME/.local/state/omarchy/indicators/stay-awake\""
-
     if (stayAwakeStateWriter.running) {
-      root.pendingStayAwakePersist = { value: !!value, until: until }
-      root.hasPendingStayAwakePersist = true
+      root.pendingStayAwakePersist = { value: value, until: until }
       return
     }
 
-    stayAwakeStateWriter.command = ["bash", "-lc", command]
+    // Rename a complete file into place. Readers must never see a timed write as
+    // an empty (indefinite) file, and a symlink must not redirect a truncation.
+    stayAwakeStateWriter.command = value ? ["bash", "-c", `
+      set -euo pipefail
+      mkdir -p -- "$1"
+      temporary=$(mktemp "$1/.stay-awake.XXXXXX")
+      trap 'rm -f -- "$temporary"' EXIT
+      printf '%s' "$2" > "$temporary"
+      mv -fT -- "$temporary" "$1/stay-awake"
+    `, "--", root.stayAwakeStateDir, until > 0 ? String(until) : ""]
+      : ["rm", "-f", "--", root.stayAwakeStatePath]
     stayAwakeStateWriter.running = true
   }
 
   function refreshStayAwakeState() {
-    if (!stayAwakeStateWriter.running && !stayAwakeStateProbe.running) stayAwakeStateProbe.running = true
+    root.stayAwakeProbePending = true
+    if (stayAwakeStateWriter.running || stayAwakeStateProbe.running) return
+    root.stayAwakeProbePending = false
+    stayAwakeStateProbe.revision = root.stayAwakeRevision
+    stayAwakeStateProbe.running = true
   }
 
   function applyStayAwake(value, persist, reason, until) {
@@ -256,9 +265,9 @@ Item {
   }
 
   function stayAwakeFor(seconds) {
-    var duration = Number(seconds)
-    if (!isFinite(duration) || duration <= 0) return "invalid duration"
-    return applyStayAwake(true, true, "timed", Date.now() + Math.ceil(duration * 1000))
+    var until = IdleModel.stayAwakeDeadline(seconds, Date.now())
+    if (!until) return "invalid duration"
+    return applyStayAwake(true, true, "timed", until)
   }
 
   // Check the saved wall-clock deadline so suspend does not extend the session.
@@ -267,7 +276,7 @@ Item {
     repeat: true
     running: root.stayAwake && root.stayAwakeUntil > 0
     onTriggered: {
-      if (Date.now() >= root.stayAwakeUntil) root.setIdleEnabled(true)
+      if (Date.now() >= root.stayAwakeUntil) root.applyStayAwake(false, false, "expired")
     }
   }
 
@@ -325,48 +334,51 @@ Item {
   Process {
     id: stayAwakeStateProbe
     property int revision: 0
-    onRunningChanged: if (running) revision = root.stayAwakeRevision
-    command: ["bash", "-c", "mkdir -p \"$HOME/.local/state/omarchy/indicators\"; if [[ -f $HOME/.local/state/omarchy/indicators/stay-awake ]]; then printf 'yes:'; cat \"$HOME/.local/state/omarchy/indicators/stay-awake\"; echo; else echo no; fi"]
-    stdout: SplitParser {
-      onRead: function(line) {
-        // A probe started before a newer choice must not replace it.
-        if (stayAwakeStateProbe.revision !== root.stayAwakeRevision || stayAwakeStateWriter.running || root.hasPendingStayAwakePersist) return
-        var state = IdleModel.stayAwakeState(String(line).trim(), Date.now())
-        root.applyStayAwake(state.enabled, state.expired, "state-file", state.until)
+    command: ["bash", "-c", `
+      mkdir -p -- "$1" || exit
+      if [[ ! -e $1/stay-awake && ! -L $1/stay-awake ]]; then
+        printf no
+      elif [[ -f $1/stay-awake && ! -L $1/stay-awake ]]; then
+        printf 'yes:'
+        head -c 64 -- "$1/stay-awake"
+      else
+        exit 1
+      fi
+    `, "--", root.stayAwakeStateDir]
+    stdout: StdioCollector { id: stayAwakeStateOutput; waitForEnd: true }
+    onExited: function(exitCode) {
+      // A probe started before a newer choice must not replace it.
+      if (revision === root.stayAwakeRevision && !stayAwakeStateWriter.running && !root.pendingStayAwakePersist) {
+        var state = IdleModel.stayAwakeState(exitCode === 0 ? stayAwakeStateOutput.text : "no", Date.now())
+        root.applyStayAwake(state.enabled, false, "state-file", state.until)
+        if (exitCode !== 0) root.logEvent("state-read-failed", exitCode)
       }
-    }
-    onExited: function() {
-      stayAwakeStateDirWatcher.reload()
       stayAwakeStateWatcher.reload()
-      if (revision !== root.stayAwakeRevision) root.refreshStayAwakeState()
+      if (root.stayAwakeProbePending || revision !== root.stayAwakeRevision) root.refreshStayAwakeState()
     }
   }
 
   Process {
     id: stayAwakeStateWriter
-    onExited: function() {
-      if (root.hasPendingStayAwakePersist) {
+    onExited: function(exitCode) {
+      if (root.pendingStayAwakePersist) {
         var pending = root.pendingStayAwakePersist
-        root.hasPendingStayAwakePersist = false
+        root.pendingStayAwakePersist = null
         root.persistStayAwake(pending.value, pending.until)
-        return
+      } else {
+        if (exitCode !== 0) {
+          root.logEvent("state-write-failed", exitCode)
+          Quickshell.execDetached(["omarchy-notification-send", "Stay Awake could not be saved", "Your change was not saved. Please try again."])
+        }
+        root.refreshStayAwakeState()
       }
-
-      root.refreshStayAwakeState()
     }
-  }
-
-  FileView {
-    id: stayAwakeStateDirWatcher
-    path: root.stayAwakeStateDir
-    watchChanges: true
-    printErrors: false
-    onFileChanged: root.refreshStayAwakeState()
   }
 
   FileView {
     id: stayAwakeStateWatcher
     path: root.stayAwakeStatePath
+    preload: false
     watchChanges: true
     printErrors: false
     onFileChanged: root.refreshStayAwakeState()

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -218,15 +218,20 @@ Item {
 
     // Rename a complete file into place. Readers must never see a timed write as
     // an empty (indefinite) file, and a symlink must not redirect a truncation.
-    stayAwakeStateWriter.command = value ? ["bash", "-c", `
+    stayAwakeStateWriter.command = ["bash", "-c", `
       set -euo pipefail
       mkdir -p -- "$1"
-      temporary=$(mktemp "$1/.stay-awake.XXXXXX")
-      trap 'rm -f -- "$temporary"' EXIT
-      printf '%s' "$2" > "$temporary"
-      mv -fT -- "$temporary" "$1/stay-awake"
-    `, "--", root.stayAwakeStateDir, until > 0 ? String(until) : ""]
-      : ["rm", "-f", "--", root.stayAwakeStatePath]
+      exec 9>>"$1/stay-awake.lock"
+      flock 9
+      if [[ $2 == "true" ]]; then
+        temporary=$(mktemp "$1/.stay-awake.XXXXXX")
+        trap 'rm -f -- "$temporary"' EXIT
+        printf '%s' "$3" > "$temporary"
+        mv -fT -- "$temporary" "$1/stay-awake"
+      else
+        rm -f -- "$1/stay-awake"
+      fi
+    `, "--", root.stayAwakeStateDir, String(value), until > 0 ? String(until) : ""]
     stayAwakeStateWriter.running = true
   }
 

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -29,7 +29,9 @@ Item {
   property bool stayAwake: false
   property bool stayAwakeStateLoaded: false
   property bool hasPendingStayAwakePersist: false
-  property bool pendingStayAwakePersist: false
+  property var pendingStayAwakePersist: null
+  property double stayAwakeUntil: 0
+  property int stayAwakeRevision: 0
   property bool idledThisCycle: false
   property bool screensaverStartedThisCycle: false
   property string lastEvent: "starting"
@@ -182,6 +184,7 @@ Item {
     return JSON.stringify({
       enabled: root.idleEnabled,
       stayAwake: root.stayAwake,
+      stayAwakeUntil: root.stayAwakeUntil,
       stayAwakeStateLoaded: root.stayAwakeStateLoaded,
       stayAwakeStatePath: root.stayAwakeStatePath,
       idle: idleMonitor.isIdle,
@@ -207,13 +210,13 @@ Item {
     })
   }
 
-  function persistStayAwake(value) {
+  function persistStayAwake(value, until) {
     var command = value
-      ? "mkdir -p \"$HOME/.local/state/omarchy/indicators\" && touch \"$HOME/.local/state/omarchy/indicators/stay-awake\""
+      ? "mkdir -p \"$HOME/.local/state/omarchy/indicators\" && printf '%s' '" + (until > 0 ? String(until) : "") + "' > \"$HOME/.local/state/omarchy/indicators/stay-awake\""
       : "rm -f \"$HOME/.local/state/omarchy/indicators/stay-awake\""
 
     if (stayAwakeStateWriter.running) {
-      root.pendingStayAwakePersist = !!value
+      root.pendingStayAwakePersist = { value: !!value, until: until }
       root.hasPendingStayAwakePersist = true
       return
     }
@@ -223,14 +226,18 @@ Item {
   }
 
   function refreshStayAwakeState() {
-    if (!stayAwakeStateProbe.running) stayAwakeStateProbe.running = true
+    if (!stayAwakeStateWriter.running && !stayAwakeStateProbe.running) stayAwakeStateProbe.running = true
   }
 
-  function applyStayAwake(value, persist, reason) {
+  function applyStayAwake(value, persist, reason, until) {
     var enabled = !!value
     var changed = !root.stayAwakeStateLoaded || root.stayAwake !== enabled
 
-    if (persist) persistStayAwake(enabled)
+    root.stayAwakeUntil = enabled ? Number(until || 0) : 0
+    if (persist) {
+      root.stayAwakeRevision++
+      persistStayAwake(enabled, root.stayAwakeUntil)
+    }
 
     root.stayAwake = enabled
     root.stayAwakeStateLoaded = true
@@ -246,6 +253,21 @@ Item {
 
   function setIdleEnabled(value) {
     return applyStayAwake(!value, true, "ipc")
+  }
+
+  function stayAwakeFor(seconds) {
+    var duration = Number(seconds)
+    if (!isFinite(duration) || duration <= 0) return "invalid duration"
+    return applyStayAwake(true, true, "timed", Date.now() + Math.ceil(duration * 1000))
+  }
+
+  Timer {
+    interval: 1000
+    repeat: true
+    running: root.stayAwake && root.stayAwakeUntil > 0
+    onTriggered: {
+      if (Date.now() >= root.stayAwakeUntil) root.setIdleEnabled(true)
+    }
   }
 
   IdleMonitor {
@@ -301,11 +323,21 @@ Item {
 
   Process {
     id: stayAwakeStateProbe
-    command: ["bash", "-c", "mkdir -p \"$HOME/.local/state/omarchy/indicators\"; if [[ -f $HOME/.local/state/omarchy/indicators/stay-awake ]]; then echo yes; else echo no; fi"]
+    property int revision: 0
+    onRunningChanged: if (running) revision = root.stayAwakeRevision
+    command: ["bash", "-c", "mkdir -p \"$HOME/.local/state/omarchy/indicators\"; if [[ -f $HOME/.local/state/omarchy/indicators/stay-awake ]]; then printf 'yes:'; cat \"$HOME/.local/state/omarchy/indicators/stay-awake\"; echo; else echo no; fi"]
     stdout: SplitParser {
-      onRead: function(line) { root.applyStayAwake(String(line).trim() === "yes", false, "state-file") }
+      onRead: function(line) {
+        if (stayAwakeStateProbe.revision !== root.stayAwakeRevision || stayAwakeStateWriter.running || root.hasPendingStayAwakePersist) return
+        var state = IdleModel.stayAwakeState(String(line).trim(), Date.now())
+        root.applyStayAwake(state.enabled, state.expired, "state-file", state.until)
+      }
     }
-    onExited: function() { stayAwakeStateDirWatcher.reload() }
+    onExited: function() {
+      stayAwakeStateDirWatcher.reload()
+      stayAwakeStateWatcher.reload()
+      if (revision !== root.stayAwakeRevision) root.refreshStayAwakeState()
+    }
   }
 
   Process {
@@ -314,7 +346,7 @@ Item {
       if (root.hasPendingStayAwakePersist) {
         var pending = root.pendingStayAwakePersist
         root.hasPendingStayAwakePersist = false
-        root.persistStayAwake(pending)
+        root.persistStayAwake(pending.value, pending.until)
         return
       }
 
@@ -325,6 +357,14 @@ Item {
   FileView {
     id: stayAwakeStateDirWatcher
     path: root.stayAwakeStateDir
+    watchChanges: true
+    printErrors: false
+    onFileChanged: root.refreshStayAwakeState()
+  }
+
+  FileView {
+    id: stayAwakeStateWatcher
+    path: root.stayAwakeStatePath
     watchChanges: true
     printErrors: false
     onFileChanged: root.refreshStayAwakeState()
@@ -352,6 +392,10 @@ Item {
 
     function disable(): string {
       return root.setIdleEnabled(false)
+    }
+
+    function stayAwakeFor(seconds: int): string {
+      return root.stayAwakeFor(seconds)
     }
 
     function toggle(): string {

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -27,6 +27,7 @@ ShellRoot {
   QtObject {
     id: idleService
     property bool stayAwake: false
+    property double stayAwakeUntil: 0
     readonly property bool idleEnabled: !stayAwake
     function setIdleEnabled(value) {
       stayAwake = !value
@@ -54,6 +55,7 @@ ShellRoot {
   QtObject {
     id: mockBar
     property bool vertical: false
+    property string position: "top"
     property int barSize: 26
     property string fontFamily: "monospace"
     property color barForeground: "white"
@@ -62,6 +64,7 @@ ShellRoot {
     property bool centerSectionRevealHeld: false
     property bool centerHoverRevealSuppressed: false
     property var shell: mockShell
+    property var activePopout: null
     function run(command) {
       root.commands.push(String(command))
     }
@@ -74,6 +77,11 @@ ShellRoot {
   QtObject {
     id: indicatorHost
     property bool revealInactiveIndicators: true
+  }
+
+  QtObject {
+    id: popupOwner
+    property var indicatorHost: null
   }
 
   function createIndicator(name) {
@@ -148,12 +156,32 @@ ShellRoot {
 
       Qt.callLater(function() {
         root.assertTrue(tray.implicitWidth > 0, "inactive indicator tray expands on center hover")
+        var revealedWidth = tray.implicitWidth
+        popupOwner.indicatorHost = tray
+        mockBar.activePopout = popupOwner
         mockBar.centerSectionRevealHeld = false
 
         Qt.callLater(function() {
-          root.assertTrue(tray.implicitWidth === 0, "inactive indicator tray collapses after hover")
-          tray.destroy()
-          root.writeResult()
+          root.assertTrue(tray.implicitWidth === revealedWidth, "indicator popup holds the revealed bar layout after hover leaves")
+          mockBar.vertical = true
+
+          Qt.callLater(function() {
+            root.assertTrue(tray.vertical && tray.revealInactiveIndicators, "indicator popup also holds a vertical bar open")
+            mockBar.activePopout = null
+
+            Qt.callLater(function() {
+              root.assertTrue(tray.implicitHeight === 0, "indicator tray collapses when its popup closes")
+              popupOwner.indicatorHost = indicatorHost
+              mockBar.activePopout = popupOwner
+
+              Qt.callLater(function() {
+                root.assertTrue(tray.implicitHeight === 0, "an unrelated popup does not reveal indicators")
+                mockBar.activePopout = null
+                tray.destroy()
+                root.writeResult()
+              })
+            })
+          })
         })
       })
     })

--- a/test/shell.d/idle-state-test.sh
+++ b/test/shell.d/idle-state-test.sh
@@ -160,3 +160,68 @@ await_state '.enabled == true'
 [[ -s $test_home/notifications ]] || fail "Failed writes notify the user"
 rm "$test_home/fail-write"
 pass "failed saves preserve the prior setting and notify the user"
+
+# Pause update publication after its ownership read, then make a newer choice.
+# Only filesystem state is exercised: never acquire a real sleep inhibitor.
+cat > "$test_tmp/bin/omarchy-cmd-present" <<'BASH'
+#!/bin/bash
+exit 1
+BASH
+cat > "$test_tmp/bin/mv" <<'BASH'
+#!/bin/bash
+if [[ -e $HOME/pause-rename ]]; then
+  rm "$HOME/pause-rename"
+  touch "$HOME/rename-ready"
+  for _ in {1..200}; do
+    [[ ! -e $HOME/rename-ready ]] && break
+    sleep 0.02
+  done
+fi
+exec /usr/bin/mv "$@"
+BASH
+chmod +x "$test_tmp/bin/omarchy-cmd-present" "$test_tmp/bin/mv"
+update_idle() {
+  HOME="$test_home" XDG_RUNTIME_DIR="$test_tmp/runtime" PATH="$test_tmp/bin:$ROOT/bin:$PATH" \
+    "$ROOT/bin/omarchy-update-stay-awake" "$@"
+}
+for phase in start stop; do
+  for choice in timed indefinite off cli-on cli-off cli-toggle; do
+    original=$(( $(date +%s%3N) + 60000 ))
+    printf '%s' "$original" > "$state_file"
+    await_state ".stayAwakeUntil == $original"
+    if [[ $phase == "stop" ]]; then update_idle start; fi
+    touch "$test_home/pause-rename"
+    update_idle "$phase" &
+    update_pid=$!
+    for _ in {1..100}; do [[ -e $test_home/rename-ready ]] && break; sleep 0.02; done
+    [[ -e $test_home/rename-ready ]] || fail "Update reaches paused $phase"
+    choice_pid=""
+    case "$choice" in
+      timed) call stayAwakeFor 10800 >/dev/null ;;
+      indefinite) call disable >/dev/null ;;
+      off) call enable >/dev/null ;;
+      cli-*)
+        HOME="$test_home" "$ROOT/bin/omarchy-toggle-idle" "${choice#cli-}" >/dev/null &
+        choice_pid=$!
+        ;;
+    esac
+    sleep 0.3
+    rm "$test_home/rename-ready"
+    wait "$update_pid"
+    if [[ -n $choice_pid ]]; then wait "$choice_pid"; fi
+    sleep 0.3
+    if [[ $phase == "start" ]]; then update_idle stop; fi
+    case "$choice" in
+      timed) await_state '.stayAwakeUntil > (now * 1000 + 10700000)' ;;
+      indefinite|cli-on)
+        await_state '.stayAwake == true and .stayAwakeUntil == 0'
+        [[ -f $state_file && ! -s $state_file ]] || fail "Indefinite choice survives update $phase"
+        ;;
+      off|cli-off|cli-toggle)
+        await_state '.enabled == true'
+        [[ ! -e $state_file ]] || fail "Turn off survives update $phase"
+        ;;
+    esac
+    pass "a newer $choice choice survives overlapping update $phase"
+  done
+done

--- a/test/shell.d/idle-state-test.sh
+++ b/test/shell.d/idle-state-test.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+require_compositor "idle state persistence test"
+require_command quickshell
+require_command jq
+
+test_tmp=$(mktemp -d)
+test_home="$test_tmp/home with spaces"
+fixture="$test_tmp/idle"
+qs_pid=""
+cleanup() {
+  if [[ -n $qs_pid ]]; then
+    kill "$qs_pid" 2>/dev/null || true
+    wait "$qs_pid" 2>/dev/null || true
+  fi
+  rm -rf "$test_tmp"
+}
+trap cleanup EXIT
+mkdir -p "$test_home" "$fixture" "$test_tmp/bin"
+cat > "$fixture/shell.qml" <<'QML'
+import QtQuick
+import Quickshell
+ShellRoot {
+  Loader {
+    source: "file://" + Quickshell.env("OMARCHY_PATH") + "/shell/plugins/services/idle/Service.qml"
+    onLoaded: item.shell = { shellConfig: { idle: { screensaver: 86400, lock: 86400 } } }
+  }
+}
+QML
+cat > "$test_tmp/bin/bash" <<'BASH'
+#!/bin/bash
+if [[ ${1:-} == "-c" && ${2:-} == *'head -c'* ]]; then
+  if [[ -e $HOME/fail-read ]]; then printf 'yes:'; exit 1; fi
+  if [[ -e $HOME/delay-read ]]; then
+    /bin/bash "$@"
+    touch "$HOME/read-finished"
+    sleep 0.4
+    exit 0
+  fi
+fi
+if [[ ${1:-} == "-c" && ${2:-} == *mktemp* ]]; then
+  [[ ! -e $HOME/fail-write ]] || exit 1
+  [[ ! -e $HOME/delay-write ]] || sleep 0.3
+fi
+exec /bin/bash "$@"
+BASH
+cat > "$test_tmp/bin/omarchy-notification-send" <<'BASH'
+#!/bin/bash
+printf '%s\n' "$*" >> "$HOME/notifications"
+BASH
+chmod +x "$test_tmp/bin/"*
+call() { quickshell ipc -p "$fixture" call idle "$@"; }
+await_state() {
+  local predicate="$1"
+  for _ in {1..60}; do
+    if call status 2>/dev/null | jq -e "$predicate" >/dev/null 2>&1; then return 0; fi
+    sleep 0.05
+  done
+  cat "$test_tmp/shell.log" >&2
+  fail "idle state reaches $predicate"
+}
+start_shell() {
+  HOME="$test_home" XDG_CONFIG_HOME="$test_home/.config" XDG_STATE_HOME="$test_home/.local/state" \
+    OMARCHY_PATH="$ROOT" PATH="$test_tmp/bin:$PATH" \
+    quickshell -p "$fixture" --no-color > "$test_tmp/shell.log" 2>&1 &
+  qs_pid=$!
+  await_state '.stayAwakeStateLoaded == true'
+}
+stop_shell() {
+  quickshell kill -p "$fixture" >/dev/null
+  wait "$qs_pid" || true
+  qs_pid=""
+}
+state_file="$test_home/.local/state/omarchy/indicators/stay-awake"
+start_shell
+await_state '.enabled == true'
+call stayAwakeFor 60 >/dev/null
+await_state '.stayAwakeUntil > 0'
+for _ in {1..50}; do [[ -s $state_file ]] && break; sleep 0.05; done
+deadline=$(cat "$state_file")
+stop_shell
+start_shell
+await_state ".stayAwakeUntil == $deadline"
+pass "timed state survives a shell restart without extending its deadline"
+
+for invalid in 0 -1 86401; do
+  [[ $(call stayAwakeFor "$invalid") == "invalid duration" ]] || fail "Invalid duration is refused"
+  await_state ".stayAwakeUntil == $deadline"
+done
+pass "invalid requests do not change the running timer"
+
+call stayAwakeFor 1 >/dev/null
+await_state '.stayAwakeUntil > 0'
+sleep 1.2
+await_state '.enabled == true'
+[[ -s $state_file ]] || fail "Expiry does not need to delete the deadline"
+HOME="$test_home" "$ROOT/bin/omarchy-toggle-idle" status | jq -e '.enabled == false' >/dev/null
+stop_shell
+start_shell
+await_state '.enabled == true'
+pass "expiry restores idle even across restart, without a cleanup write"
+
+for raw in '1e300' 'Infinity' 'not a deadline' $'\n' $'2000\nno'; do
+  call disable >/dev/null
+  await_state '.stayAwake == true'
+  sleep 0.15
+  printf '%s' "$raw" > "$state_file"
+  sleep 0.1
+  await_state '.enabled == true'
+done
+pass "malformed state does not disable idle"
+
+printf 'preserve this' > "$test_home/victim"
+rm "$state_file"
+ln -s "$test_home/victim" "$state_file"
+call stayAwakeFor 60 >/dev/null
+await_state '.stayAwakeUntil > 0'
+for _ in {1..50}; do [[ ! -L $state_file ]] && break; sleep 0.05; done
+[[ $(cat "$test_home/victim") == "preserve this" && ! -L $state_file ]] || fail "Atomic writer must preserve symlink targets"
+pass "the shell replaces state symlinks without truncating their targets"
+
+# Force overlapping asynchronous saves. Only the newest request should remain.
+touch "$test_home/delay-write"
+call stayAwakeFor 60 >/dev/null
+call enable >/dev/null
+call disable >/dev/null
+call stayAwakeFor 1800 >/dev/null
+sleep 1
+await_state '.stayAwakeUntil > (now * 1000 + 1700000)'
+rm "$test_home/delay-write"
+pass "overlapping choices preserve the latest requested duration"
+
+# Hold a completed old read open while an external command changes the file.
+call enable >/dev/null
+await_state '.enabled == true'
+sleep 0.2
+touch "$test_home/delay-read"
+: > "$state_file"
+for _ in {1..50}; do [[ -e $test_home/read-finished ]] && break; sleep 0.02; done
+[[ -e $test_home/read-finished ]] || fail "Delayed read starts"
+rm "$state_file" "$test_home/delay-read"
+sleep 0.7
+await_state '.enabled == true'
+pass "a file change during an in-flight probe is not lost"
+
+# Failed reads must not turn a partial 'yes:' response into indefinite mode.
+touch "$test_home/fail-read"
+: > "$state_file"
+sleep 0.3
+await_state '.enabled == true'
+rm "$test_home/fail-read" "$state_file"
+pass "read errors cannot become an indefinite stay-awake session"
+
+touch "$test_home/fail-write"
+call stayAwakeFor 60 >/dev/null
+sleep 0.3
+await_state '.enabled == true'
+[[ ! -e $state_file ]] || fail "Failed writes leave prior state intact"
+[[ -s $test_home/notifications ]] || fail "Failed writes notify the user"
+rm "$test_home/fail-write"
+pass "failed saves preserve the prior setting and notify the user"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -7,12 +7,23 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
 
-assertDeepEqual(idle.stayAwakeState('no', 1000), { enabled: false, until: 0, expired: false }, 'missing state allows idle')
-assertDeepEqual(idle.stayAwakeState('yes:', 1000), { enabled: true, until: 0, expired: false }, 'legacy empty state stays awake indefinitely')
-assertDeepEqual(idle.stayAwakeState('yes:2000', 1000), { enabled: true, until: 2000, expired: false }, 'future deadline survives reload')
-assertDeepEqual(idle.stayAwakeState('yes:1000', 1000), { enabled: false, until: 0, expired: true }, 'deadline expires at boundary')
-assertDeepEqual(idle.stayAwakeState('yes:999', 1000), { enabled: false, until: 0, expired: true }, 'past deadline allows idle')
-assertDeepEqual(idle.stayAwakeState('yes:invalid', 1000), { enabled: false, until: 0, expired: true }, 'invalid deadline allows idle')
+assertDeepEqual(idle.stayAwakeState('no', 1000), { enabled: false, until: 0 }, 'missing state allows idle')
+assertDeepEqual(idle.stayAwakeState('yes:', 1000), { enabled: true, until: 0 }, 'legacy empty state stays awake indefinitely')
+assertDeepEqual(idle.stayAwakeState('yes:2000', 1000), { enabled: true, until: 2000 }, 'future deadline survives reload')
+assertDeepEqual(idle.stayAwakeState('yes:1000', 1000), { enabled: false, until: 0 }, 'deadline expires at boundary')
+assertDeepEqual(idle.stayAwakeState('yes:999', 1000), { enabled: false, until: 0 }, 'past deadline allows idle')
+assertDeepEqual(idle.stayAwakeState('yes:invalid', 1000), { enabled: false, until: 0 }, 'invalid deadline allows idle')
+
+for (const raw of ['yes:1e300', 'yes:Infinity', 'yes:0x1000', 'yes:2000.5', 'yes: 2000 ', 'yes:\n', 'yes:2000\nno', 'yes:2000' + '\n'.repeat(70), 'yes:86401001']) {
+  assertDeepEqual(idle.stayAwakeState(raw, 1000), { enabled: false, until: 0 }, 'malformed or excessive deadline allows idle: ' + JSON.stringify(raw))
+}
+assertDeepEqual(idle.stayAwakeState('yes:2000\n', 1000), { enabled: true, until: 2000 }, 'a trailing newline is allowed')
+assertDeepEqual(idle.stayAwakeState('yes:12345:6789:1234\n', 1000), { enabled: true, until: 0 }, 'update ownership tokens still inhibit idle')
+assertEqual(idle.stayAwakeDeadline(3600, 1000), 3601000, 'one hour produces an absolute deadline')
+assertEqual(idle.stayAwakeDeadline(86400, 1000), 86401000, 'one day is the maximum duration')
+for (const seconds of [0, -1, 1.5, 86401, Infinity, NaN, 1e300, '$(touch /tmp/should-not-exist)']) {
+  assertEqual(idle.stayAwakeDeadline(seconds, 1000), 0, 'invalid duration is rejected: ' + String(seconds))
+}
 
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
@@ -62,4 +73,25 @@ if rg -q 'omarchy-shell' "$ROOT/bin/omarchy-toggle-idle"; then
   fail "Stay Awake toggle avoids reentrant shell IPC"
 fi
 
-pass "Stay Awake toggle persists state without reentrant shell IPC"
+# Expired deadlines need no cleanup process: both the CLI and the shell ignore them.
+printf '1' > "$test_home/.local/state/omarchy/indicators/stay-awake"
+HOME="$test_home" "$ROOT/bin/omarchy-toggle-idle" status | jq -e '.enabled == false' >/dev/null || fail "Expired state allows idle in the CLI"
+HOME="$test_home" "$ROOT/bin/omarchy-toggle-idle" >/dev/null
+[[ ! -s $test_home/.local/state/omarchy/indicators/stay-awake ]] || fail "Toggle from expired state enables indefinitely"
+
+state_file="$test_home/.local/state/omarchy/indicators/stay-awake"
+victim="$test_tmp/preserve-me"
+printf 'unchanged' > "$victim"
+rm "$state_file"
+ln -s "$victim" "$state_file"
+HOME="$test_home" "$ROOT/bin/omarchy-toggle-idle" stay-awake >/dev/null
+[[ $(cat "$victim") == "unchanged" && ! -L $state_file ]] || fail "State writes replace symlinks without truncating targets"
+
+rm "$state_file"
+mkdir "$state_file"
+if HOME="$test_home" "$ROOT/bin/omarchy-toggle-idle" stay-awake >/dev/null 2>&1; then
+  fail "A failed state write must return failure"
+fi
+[[ -z $(find "${state_file%/*}" -name '.stay-awake.*' -print) ]] || fail "Failed writes clean up temporary files"
+
+pass "Stay Awake toggle persists state atomically without reentrant shell IPC"

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -7,6 +7,13 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
 
+assertDeepEqual(idle.stayAwakeState('no', 1000), { enabled: false, until: 0, expired: false }, 'missing state allows idle')
+assertDeepEqual(idle.stayAwakeState('yes:', 1000), { enabled: true, until: 0, expired: false }, 'legacy empty state stays awake indefinitely')
+assertDeepEqual(idle.stayAwakeState('yes:2000', 1000), { enabled: true, until: 2000, expired: false }, 'future deadline survives reload')
+assertDeepEqual(idle.stayAwakeState('yes:1000', 1000), { enabled: false, until: 0, expired: true }, 'deadline expires at boundary')
+assertDeepEqual(idle.stayAwakeState('yes:999', 1000), { enabled: false, until: 0, expired: true }, 'past deadline allows idle')
+assertDeepEqual(idle.stayAwakeState('yes:invalid', 1000), { enabled: false, until: 0, expired: true }, 'invalid deadline allows idle')
+
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
@@ -43,6 +50,10 @@ mkdir -p "$test_home"
 
 HOME="$test_home" "$ROOT/bin/omarchy-toggle-idle" stay-awake >/dev/null
 [[ -f $test_home/.local/state/omarchy/indicators/stay-awake ]] || fail "Stay Awake toggle persists enabled state"
+
+printf '9999999999999' > "$test_home/.local/state/omarchy/indicators/stay-awake"
+HOME="$test_home" "$ROOT/bin/omarchy-toggle-idle" stay-awake >/dev/null
+[[ ! -s $test_home/.local/state/omarchy/indicators/stay-awake ]] || fail "Indefinite Stay Awake clears deadline"
 
 HOME="$test_home" "$ROOT/bin/omarchy-toggle-idle" allow-idle >/dev/null
 [[ ! -f $test_home/.local/state/omarchy/indicators/stay-awake ]] || fail "Stay Awake toggle persists disabled state"

--- a/test/shell.d/update-lock-test.sh
+++ b/test/shell.d/update-lock-test.sh
@@ -206,6 +206,7 @@ deadline=$(( $(date +%s%3N) + 60000 ))
 printf '%s' "$deadline" > "$stay_awake_state"
 run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" start
 [[ $(<"$stay_awake_state") =~ ^[0-9]+:[0-9]+:[0-9]+$ ]] || fail "Update temporarily owns a timed stay-awake session"
+flock -n "$stay_awake_state.lock" true || fail "The sleep inhibitor must not inherit the idle state lock"
 run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
 [[ $(<"$stay_awake_state") == "$deadline" ]] || fail "Update restores the original deadline without extending it"
 

--- a/test/shell.d/update-lock-test.sh
+++ b/test/shell.d/update-lock-test.sh
@@ -199,6 +199,42 @@ run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
   fail "stale update ownership does not remove a newer Stay Awake choice"
 pass "stale update ownership preserves a newer Stay Awake choice"
 
+# A timer must not expire underneath a running update, and finishing the update
+# must not extend the timer or overwrite a choice made while the update ran.
+rm -f "$stay_awake_state"
+deadline=$(( $(date +%s%3N) + 60000 ))
+printf '%s' "$deadline" > "$stay_awake_state"
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" start
+[[ $(<"$stay_awake_state") =~ ^[0-9]+:[0-9]+:[0-9]+$ ]] || fail "Update temporarily owns a timed stay-awake session"
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
+[[ $(<"$stay_awake_state") == "$deadline" ]] || fail "Update restores the original deadline without extending it"
+
+printf '1' > "$stay_awake_state"
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" start
+[[ $(<"$stay_awake_state") =~ ^[0-9]+:[0-9]+:[0-9]+$ ]] || fail "Expired state must not prevent update inhibition"
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
+[[ $(<"$stay_awake_state") == "1" ]] || fail "Update restores an expired deadline as expired"
+
+printf '%s' "$deadline" > "$stay_awake_state"
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" start
+printf '%s' "$((deadline + 1000))" > "$stay_awake_state"
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
+[[ $(<"$stay_awake_state") == "$((deadline + 1000))" ]] || fail "Update cleanup preserves a newer timed choice"
+pass "updates hold timed sessions safely and restore only their own changes"
+
+printf '%s' "$deadline" > "$stay_awake_state"
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" start
+write_stub mv 'exit 1'
+if run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop 2>/dev/null; then
+  fail "Failed deadline restoration must report failure"
+fi
+[[ ! -e $stay_awake_helper_state/inhibit-pid ]] || fail "Failed restoration must still release the sleep inhibitor"
+[[ -e $stay_awake_helper_state/idle-previous ]] || fail "Failed restoration retains the deadline for retry"
+write_stub mv 'exec /usr/bin/mv "$@"'
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
+[[ $(<"$stay_awake_state") == "$deadline" ]] || fail "Deadline restoration can be retried"
+pass "failed restoration releases sleep inhibition and can be retried"
+
 # A stale PID is safe even if it has been reused by another process.
 sleep 30 &
 unrelated_pid=$!


### PR DESCRIPTION
Right-click the coffee indicator to stay awake for 30 minutes, 1 hour, 3 hours, or 8 hours. Indefinitely and Turn off are also available. Left-click keeps the existing toggle behavior.

### Why

Let an agent keep working while you step away, without leaving Stay Awake on all night. When the duration ends, normal idle behavior resumes. The deadline survives shell restarts.

Before:

![Original coffee indicator](https://raw.githubusercontent.com/0x4A756E65/omarchy/d5c14b62ac5478ce4e9b82baf5fcdf30d9ebaa89/keep-awake-original.png)

After:

![Coffee indicator with duration choices](https://raw.githubusercontent.com/0x4A756E65/omarchy/d5c14b62ac5478ce4e9b82baf5fcdf30d9ebaa89/keep-awake-after.png)

Tested locally with mouse and keyboard. CLI tests and 226/227 shell test files pass; the remaining About animation failure also reproduces on the unchanged base.
