### PR TITLE
Reduce notification overlay surface area

### DIFF
--- a/default/hypr/apps/omarchy-shell.lua
+++ b/default/hypr/apps/omarchy-shell.lua
@@ -4,6 +4,9 @@
 -- Keep the bar instant: no layer-shell fade/slide animation.
 hl.layer_rule({ match = { namespace = "omarchy-bar" }, no_anim = true, animation = "none" })
 
+-- Notification strips should appear without animating the transparent surface.
+hl.layer_rule({ match = { namespace = "omarchy-notifications" }, no_anim = true, animation = "none" })
+
 -- Launcher, image selector, emojis, clipboard overlays, and keyboard-driven
 -- panels should pop without compositor layer fades. Panels keep their own
 -- QML opacity transition for normal open/close, and skip it for panel handoff.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -14,6 +14,8 @@ The end-user view (hotkey notices for time, battery, weather) is in
 
 ## Toast lifecycle
 
+Each output uses a fixed-width, full-height transparent strip sized to the card width plus its right clearance, rather than a full-screen surface. Keeping the dimensions independent of the popup count avoids stale-buffer stretching when cards are added or removed. Only the card column accepts input, and the Hyprland layer rule disables compositor animation for the strip.
+
 A toast lives on screen for at least 5s (low), 8s (normal), or forever
 (critical), stretched up to 30s if the sender asked for a longer
 `expire_timeout`. Hovering pauses the countdown, and a content update restarts

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -967,14 +967,14 @@ Item {
       readonly property var popupPlacement: NotificationLogic.popupPlacement(
         service.barPosition, service.barClearance, Style.gapsOut)
 
-      // Full-screen, fixed-size surface (like the OSD overlay). Adding or
-      // removing a toast changes only the content inside; the Wayland surface
-      // never resizes, so the compositor can't briefly scale a stale buffer --
-      // which is what stretched/squished the cards during count changes.
-      anchors { top: true; bottom: true; left: true; right: true }
+      // Keep a fixed-width strip instead of allocating a full-screen
+      // transparent surface on every output. Full height keeps adding and
+      // removing cards from resizing the surface and stretching stale buffers.
+      anchors { top: true; bottom: true; right: true }
+      implicitWidth: Math.ceil(Style.space(380) + popupPlacement.margins.right)
 
       // Keep the surface click-through except over the toast column, so the
-      // rest of the (invisible) full-screen overlay never eats input.
+      // rest of the invisible notification strip never eats input.
       mask: Region { item: popupColumn }
 
       ColumnLayout {

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -571,6 +571,28 @@ assert(!('exec' in legacyRestored), 'a restored legacy popup drops the old exec 
 assertEqual(notifications.parseExecArgv(legacyRestored.execArgv || ''), null, 'a restored legacy popup has no runnable click action')
 
 const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/Service.qml'), 'utf8')
+const popupWindowQml = serviceQml.slice(serviceQml.indexOf('id: popupWindow'))
+assert(
+  /anchors \{ top: true; bottom: true; right: true \}/.test(popupWindowQml),
+  'notification surfaces keep full height without spanning the output width'
+)
+assert(
+  /implicitWidth: Math\.ceil\(Style\.space\(380\) \+ popupPlacement\.margins\.right\)/.test(popupWindowQml),
+  'notification surface width includes the fixed card width and right clearance'
+)
+assert(
+  /implicitWidth: Style\.space\(380\)/.test(cardQml),
+  'notification surface and card widths remain in sync'
+)
+assert(
+  /mask: Region \{ item: popupColumn \}/.test(popupWindowQml),
+  'notification strips remain click-through outside the popup column'
+)
+const shellLayerRules = fs.readFileSync(path.join(root, 'default/hypr/apps/omarchy-shell.lua'), 'utf8')
+assert(
+  /hl\.layer_rule\(\{ match = \{ namespace = "omarchy-notifications" \}, no_anim = true, animation = "none" \}\)/.test(shellLayerRules),
+  'notification surfaces do not animate at compositor level'
+)
 assert(
   /readonly property int historyLimit: 10/.test(serviceQml),
   'notifications service keeps the last ten notifications in history'


### PR DESCRIPTION
# Reduce notification overlay surface area

## Summary

- Use a fixed-width notification strip rather than a full-screen transparent surface on every output.
- Preserve the full-height, fixed-size surface so adding/removing cards does not resize it or reintroduce stale-buffer stretching.
- Preserve the right/top placement, card dimensions, and click-through mask.
- Disable compositor animation for the notification strip, consistent with the bar and other shell overlays.
- Add structural regression tests and document the surface sizing.

## Motivation and observations

On a dual-4K NVIDIA/Hyprland system, unfocused ChatGPT prompt-completion notifications repeatedly coincided with visible stutter and audio underruns. The user reported clean behavior when popups were suppressed. Sound-only playback and simple test notifications did not reliably reproduce the problem.

The previous surface occupied 2400×1350 logical pixels on each output. With this change, the live compositor reported 349×1350 on each output at the current shell scaling, preserving the right edge and reducing the surface area by approximately 85%. Physical monitor mode was 3840×2160 at 29.97 Hz, Hyprland scale 1.6; the shell's card scaling produced the 349-pixel strip.

The user subsequently reported that the combined workaround appeared to fix the problem. This is not a claim that the root cause is proven or that all audio errors disappeared: an earlier post-change observation still recorded audio errors, and the surface-size change was not isolated from disabled layer animation and a shell restart. The deterministic benefit is avoiding unnecessary full-screen notification surfaces. Further hardware coverage and sustained timing validation are needed.

## Validation

- Focused notification tests pass.
- `git diff --check` passes.
- Live compositor geometry verified on both outputs using the user-owned plugin clone; notification IPC remained functional.
- The aggregate suite is run with Wayland/Hyprland environment variables unset to avoid driving the user's active desktop; compositor-dependent checks are skipped in this mode.
- The aggregate run completed with 4 of 226 shell test files failing: `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` require an unavailable companion `omarchy-pkgs` checkout; `launch-about-test.sh` failed with the inherited `NO_COLOR=1`. Rerunning the latter with `NO_COLOR` unset passes. The aggregate suite is therefore not fully green in this environment.
- Before/after screenshots, video, and graphical VM acceptance remain pending. The user reported disruption during live testing, so the old configuration was not re-enabled merely to record it.

## Scope

No PipeWire, USB, GPU-driver, monitor-mode, workspace, or window-gap changes. This proposal should remain a draft pending visual review and broader reproduction.
