### PR TITLE
Keep panel sliders from losing the pointer grab inside a ScrollView

### DIFF
--- a/shell/Ui/PanelSlider.qml
+++ b/shell/Ui/PanelSlider.qml
@@ -107,12 +107,22 @@ Item {
     hoverEnabled: true
     cursorShape: Qt.PointingHandCursor
     acceptedButtons: Qt.LeftButton | Qt.RightButton
+    // Keep the grab inside a ScrollView; otherwise a vertical move off the
+    // track lets the Flickable steal it and onReleased never fires.
+    preventStealing: true
 
     function valueFromX(x) {
       var clamped = Math.max(0, Math.min(track.width, x))
       var raw = root.minimum + (clamped / track.width) * root.range
       if (root.integer) raw = Math.round(raw)
       return Math.max(root.minimum, Math.min(root.maximum, raw))
+    }
+
+    function endDrag() {
+      if (!root.dragging) return
+      root.dragging = false
+      root.released(root.liveValue)
+      root.liveValue = root.value
     }
 
     onPressed: function(mouse) {
@@ -126,17 +136,16 @@ Item {
       if (mouse.button === Qt.RightButton) root.rightClicked()
     }
     onPositionChanged: function(mouse) {
-      if (!root.dragging) return
+      if (!pressed || !root.dragging) return
       var next = valueFromX(mouse.x)
       root.liveValue = next
       root.moved(next)
     }
     onReleased: function(mouse) {
       if (mouse.button !== Qt.LeftButton) return
-      root.dragging = false
-      root.released(root.liveValue)
-      root.liveValue = root.value
+      endDrag()
     }
+    onCanceled: endDrag()
     onWheel: function(wheel) {
       var delta = wheel.angleDelta.y > 0 ? root.step : -root.step
       var next = Math.max(root.minimum, Math.min(root.maximum, root.liveValue + delta))

--- a/test/shell.d/panel-slider-test.sh
+++ b/test/shell.d/panel-slider-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# PanelSlider sits in ScrollViews. preventStealing keeps the pointer grab;
+# onCanceled clears dragging if that grab is still lost.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const sliderQml = fs.readFileSync(path.join(root, 'shell/Ui/PanelSlider.qml'), 'utf8')
+
+assert(
+  /preventStealing:\s*true/.test(sliderQml),
+  'panel slider keeps the pointer grab so a ScrollView Flickable cannot steal it'
+)
+assert(
+  /onCanceled:\s*endDrag\(\)/.test(sliderQml),
+  'panel slider ends the drag when the pointer grab is canceled'
+)
+JS


### PR DESCRIPTION
## The issue
When the audio panel in the top bar got big enough to scroll, the volume slider would stop working when trying to keep a drag active while the slider is not hovered.

## Root cause
`PanelSlider` sits in `ScrollView`s (audio, brightness, gallery). When content exceeds the panel height the inner `Flickable` becomes interactive; a vertical move off the track lets it steal the pointer grab. `onReleased` never fires, so `dragging` stays true: re-entering teleports the knob, and hover keeps moving it after the button is up.

## Solution
`preventStealing: true` keeps the grab. `onCanceled` ends the drag if it is still lost. `onPositionChanged` requires `pressed`.

## Test plan
- Audio panel tall enough to scroll: drag the volume slider off the track, return, release
- `test/shell.d/panel-slider-test.sh`

## Video

Before:
<img width="406" height="608" alt="volume_slider_not_working" src="https://github.com/user-attachments/assets/cf23603d-67f1-4207-9917-c731df2af326" />

After:
<img width="392" height="578" alt="volume_slider_working" src="https://github.com/user-attachments/assets/1ce9f885-8e9a-4d42-8b6d-3269967c8d8c" />
