### PR TITLE
Enable bar widgets for active hybrid plugins

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -500,7 +500,7 @@ QtObject {
         removeDisabled(config, key)
         var entry = { id: key }
         var insertedWithPlacement = false
-        if (!location.found && isBarWidget) {
+        if (isBarWidget && location.kind !== "bar") {
           var sourceLocation = clonedFrom ? findEntryLocation(config, clonedFrom) : { found: false }
           if (sourceLocation.kind === "bar") {
             var sourceEntry = config.bar.layout[sourceLocation.section][sourceLocation.index]

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -84,6 +84,7 @@ ShellRoot {
     scan += block("firstparty", "/first/panels/grouped", manifest("omarchy.grouped-panel", ["panel"], { panel: "Panel.qml" }))
     scan += block("firstparty", "/first/hybrid", manifest("omarchy.hybrid", ["menu", "bar-widget"], { menu: "Menu.qml", barWidget: "Widget.qml" }))
     scan += block("thirdparty", "/third/panel", manifest("third.panel", ["panel"], { panel: "Panel.qml" }))
+    scan += block("thirdparty", "/third/hybrid", manifest("third.hybrid", ["overlay", "bar-widget"], { overlay: "Overlay.qml", barWidget: "Widget.qml" }))
     scan += block("thirdparty", "/third/widget", manifest("third.widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "left" }))
     scan += block("thirdparty", "/third/center-widget", manifest("third.center-widget", ["bar-widget"], { barWidget: "Widget.qml" }))
     scan += block("thirdparty", "/third/right-widget", manifest("third.right-widget", ["bar-widget"], { barWidget: "Widget.qml" }, { defaultSection: "right" }))
@@ -125,6 +126,7 @@ ShellRoot {
       "omarchy.hybrid",
       "third.bar",
       "third.center-widget",
+      "third.hybrid",
       "third.panel",
       "third.right-widget",
       "third.widget"
@@ -167,6 +169,23 @@ ShellRoot {
     root.assertTrue(registry.isEnabled("third.widget"), "enabled bar widgets are found")
     registry.setEnabled("third.widget", false)
     root.assertDeepEqual(root.config.bar.layout.left, [], "disabling bar widgets removes layout entry")
+
+    root.config = {
+      version: 1,
+      bar: { layout: { left: [], center: [], right: [] } },
+      plugins: [{ id: "third.hybrid" }]
+    }
+    registry.setEnabled("third.hybrid", true)
+    root.assertDeepEqual(root.config.bar.layout.center, [{ id: "third.hybrid" }], "enabling an active hybrid plugin adds its widget")
+    root.assertDeepEqual(root.config.plugins, [{ id: "third.hybrid" }], "enabling a hybrid widget preserves its other plugin kinds")
+
+    root.config = {
+      version: 1,
+      bar: { layout: { left: [], center: [], right: [] } },
+      plugins: [{ id: "third.hybrid" }]
+    }
+    root.assertEqual(registry.putBarWidget("third.hybrid", {}), "", "put accepts an active hybrid plugin")
+    root.assertDeepEqual(root.config.bar.layout.center, [{ id: "third.hybrid" }], "put adds the hybrid plugin's widget")
 
     root.config = {
       version: 1,


### PR DESCRIPTION
## Summary

- add a bar widget even when the same plugin is already active through another kind
- preserve the existing plugin entry so overlays, panels, or menus remain enabled
- cover both `setEnabled` and `putBarWidget` with a hybrid-plugin regression case

## Why

`findEntryLocation` searches both the bar layout and `plugins[]`. Treating any match as proof that a bar widget was already placed made enablement a no-op for active hybrid plugins. The bar-specific branch now skips insertion only when the plugin is actually present in the bar.

## Tests

- plugin registry QML contract fixture under headless Arch Linux/Weston (fails before the fix, passes after)
- `bash test/shell.d/plugin-clone-test.sh`
- `bash test/shell.d/plugins-test.sh`
- `bash test/shell.d/plugin-validate-test.sh`
- `bash test/shell.d/bar-test.sh`
- `bash test/shell.d/menu-plugin-test.sh`
- `./test/cli`

Fixes #10264

## Worked on by

- Aris Gysel
