### PR TITLE
Make notification corner configurable

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -5,7 +5,7 @@ hosts a Quickshell `NotificationServer` that claims `org.freedesktop.Notificatio
 on the session bus. There is no dunst or mako — anything that speaks the
 freedesktop notification protocol (notify-send, libnotify apps, Chromium web
 apps) lands in the shell, which renders it as a toast card stacked in the
-top-right corner. The pure decision logic lives in `NotificationLogic.js`,
+top-right corner by default. The plugin entry's `position` setting selects any of the four corners; see `manual/10-notices.md`. The pure decision logic lives in `NotificationLogic.js`,
 which is also loadable from Node so `test/shell.d/` can exercise it without
 a compositor.
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -5,7 +5,9 @@ hosts a Quickshell `NotificationServer` that claims `org.freedesktop.Notificatio
 on the session bus. There is no dunst or mako — anything that speaks the
 freedesktop notification protocol (notify-send, libnotify apps, Chromium web
 apps) lands in the shell, which renders it as a toast card stacked in the
-top-right corner by default. The plugin entry's `position` setting selects any of the four corners; see `manual/10-notices.md`. The pure decision logic lives in `NotificationLogic.js`,
+top-right corner by default. The plugin entry's `position` setting selects
+any of the four corners; see `manual/10-notices.md`. The pure decision logic
+lives in `NotificationLogic.js`,
 which is also loadable from Node so `test/shell.d/` can exercise it without
 a compositor.
 

--- a/manual/10-notices.md
+++ b/manual/10-notices.md
@@ -2,6 +2,16 @@
 
 You can quickly access the date and time, battery status, and current weather using the hotkey notices.
 
+### Notification position
+
+Notifications appear in the top-right corner by default. To move them, add an entry to the `plugins` array in `~/.config/omarchy/shell.json`:
+
+```json
+{ "id": "omarchy.notifications", "position": "bottom-right" }
+```
+
+Supported positions are `top-left`, `top-right`, `bottom-left`, and `bottom-right`. Changes apply on save. Missing or invalid positions use `top-right`.
+
 ### Date & Time
 
 `Super + Ctrl + Alt + T`

--- a/manual/10-notices.md
+++ b/manual/10-notices.md
@@ -12,6 +12,8 @@ Notifications appear in the top-right corner by default. To move them, add an en
 
 Supported positions are `top-left`, `top-right`, `bottom-left`, and `bottom-right`. Changes apply on save. Missing or invalid positions use `top-right`.
 
+New notifications appear below the stack at the top of the screen, or above it at the bottom.
+
 ### Date & Time
 
 `Super + Ctrl + Alt + T`

--- a/manual/10-notices.md
+++ b/manual/10-notices.md
@@ -4,15 +4,19 @@ You can quickly access the date and time, battery status, and current weather us
 
 ### Notification position
 
-Notifications appear in the top-right corner by default. To move them, add an entry to the `plugins` array in `~/.config/omarchy/shell.json`:
+Notifications appear in the top-right corner by default. To move them, add an
+entry to the `plugins` array in `~/.config/omarchy/shell.json`:
 
 ```json
 { "id": "omarchy.notifications", "position": "bottom-right" }
 ```
 
-Supported positions are `top-left`, `top-right`, `bottom-left`, and `bottom-right`. Changes apply on save. Missing or invalid positions use `top-right`.
+Supported positions are `top-left`, `top-right`, `bottom-left`, and
+`bottom-right`. Changes apply on save. Missing or invalid positions use
+`top-right`.
 
-New notifications appear below the stack at the top of the screen, or above it at the bottom.
+New notifications appear below the stack at the top of the screen, or above
+it at the bottom.
 
 ### Date & Time
 

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -395,20 +395,22 @@ function popupExpired(entry, duration, now) {
   return (Number(now) - Number((entry || {}).timestamp || 0)) >= lifetime
 }
 
-function popupPlacement(barPosition, barClearance, gapsOut) {
+function popupPlacement(barPosition, barClearance, gapsOut, corner) {
   var position = String(barPosition || "top")
   var clearance = Number(barClearance)
   var gap = Number(gapsOut)
   if (!isFinite(clearance)) clearance = 0
   if (!isFinite(gap)) gap = 0
+  var bottom = corner === "bottom-left" || corner === "bottom-right"
+  var left = corner === "top-left" || corner === "bottom-left"
 
   return {
-    anchors: { top: true, bottom: false, left: false, right: true },
+    anchors: { top: !bottom, bottom: bottom, left: left, right: !left },
     margins: {
-      top: position === "top" ? clearance : gap,
-      bottom: gap,
-      left: gap,
-      right: position === "right" ? clearance : gap
+      top: !bottom && position === "top" ? clearance : gap,
+      bottom: bottom && position === "bottom" ? clearance : gap,
+      left: left && position === "left" ? clearance : gap,
+      right: !left && position === "right" ? clearance : gap
     }
   }
 }

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -16,6 +16,16 @@ Item {
 
   // Injected by omarchy-shell (the first-party service loader).
   property var shell: null
+  property var manifest: null
+
+  readonly property string position: {
+    var entries = shell && shell.shellConfig ? shell.shellConfig.plugins || [] : []
+    var id = manifest ? manifest.id : "omarchy.notifications"
+    for (var i = 0; i < entries.length; i++) {
+      if (entries[i].id === id) return String(entries[i].position || "top-right")
+    }
+    return "top-right"
+  }
 
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
   readonly property string home: Quickshell.env("HOME")
@@ -40,9 +50,7 @@ Item {
   // Corner radius is shared with the menu and shell panels.
   // It mirrors Hyprland's current decoration:rounding value.
   readonly property int cornerRadius: Style.cornerRadius
-  // Toasts are fixed to the top-right corner. They only clear the omarchy bar
-  // when the bar occupies the top or right edge, so left/bottom bars do not
-  // pull notification popups away from the expected top-right location.
+  // Toasts clear the omarchy bar when it touches their configured corner.
   // Falls back to the bar's default size (26 horizontal / 28 vertical) when
   // shell.bar isn't reachable so the popup never lands on top of the bar.
   readonly property string barPosition: shell && shell.barConfig ? String(shell.barConfig.position || "top") : "top"
@@ -965,7 +973,7 @@ Item {
       color: "transparent"
 
       readonly property var popupPlacement: NotificationLogic.popupPlacement(
-        service.barPosition, service.barClearance, Style.gapsOut)
+        service.barPosition, service.barClearance, Style.gapsOut, service.position)
 
       // Full-screen, fixed-size surface (like the OSD overlay). Adding or
       // removing a toast changes only the content inside; the Wayland surface
@@ -979,10 +987,12 @@ Item {
 
       ColumnLayout {
         id: popupColumn
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.topMargin: popupWindow.popupPlacement.margins.top
-        anchors.rightMargin: popupWindow.popupPlacement.margins.right
+        x: popupWindow.popupPlacement.anchors.left
+          ? popupWindow.popupPlacement.margins.left
+          : parent.width - width - popupWindow.popupPlacement.margins.right
+        y: popupWindow.popupPlacement.anchors.top
+          ? popupWindow.popupPlacement.margins.top
+          : parent.height - height - popupWindow.popupPlacement.margins.bottom
         spacing: Style.space(8)
 
         Repeater {
@@ -1007,7 +1017,7 @@ Item {
             // Each card sizes itself based on mode (text vs media); the slot
             // tracks the card so the column auto-fits to whichever is widest.
             Layout.preferredWidth: card.implicitWidth
-            Layout.alignment: Qt.AlignRight
+            Layout.alignment: popupWindow.popupPlacement.anchors.left ? Qt.AlignLeft : Qt.AlignRight
             implicitHeight: card.implicitHeight
 
             readonly property real lifetime: service.durationFor(cardSlot.urgency, cardSlot.expireTimeout)

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -985,15 +985,16 @@ Item {
       // rest of the (invisible) full-screen overlay never eats input.
       mask: Region { item: popupColumn }
 
-      ColumnLayout {
+      GridLayout {
         id: popupColumn
+        columns: 1
         x: popupWindow.popupPlacement.anchors.left
           ? popupWindow.popupPlacement.margins.left
           : parent.width - width - popupWindow.popupPlacement.margins.right
         y: popupWindow.popupPlacement.anchors.top
           ? popupWindow.popupPlacement.margins.top
           : parent.height - height - popupWindow.popupPlacement.margins.bottom
-        spacing: Style.space(8)
+        rowSpacing: Style.space(8)
 
         Repeater {
           model: popupModel
@@ -1017,6 +1018,10 @@ Item {
             // Each card sizes itself based on mode (text vs media); the slot
             // tracks the card so the column auto-fits to whichever is widest.
             Layout.preferredWidth: card.implicitWidth
+            // The model stays newest-first for notification actions. Visually,
+            // new toasts extend the stack away from the configured screen edge.
+            Layout.row: popupWindow.popupPlacement.anchors.bottom ? index : popupModel.count - 1 - index
+            Layout.column: 0
             Layout.alignment: popupWindow.popupPlacement.anchors.left ? Qt.AlignLeft : Qt.AlignRight
             implicitHeight: card.implicitHeight
 

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -1020,7 +1020,8 @@ Item {
             Layout.preferredWidth: card.implicitWidth
             // The model stays newest-first for notification actions. Visually,
             // new toasts extend the stack away from the configured screen edge.
-            Layout.row: popupWindow.popupPlacement.anchors.bottom ? index : popupModel.count - 1 - index
+            Layout.row: popupWindow.popupPlacement.anchors.bottom
+              ? index : popupModel.count - 1 - index
             Layout.column: 0
             Layout.alignment: popupWindow.popupPlacement.anchors.left ? Qt.AlignLeft : Qt.AlignRight
             implicitHeight: card.implicitHeight

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -259,6 +259,27 @@ assertDeepEqual(
   'notifications ignore a left bar for popup placement'
 )
 
+for (const corner of ['top-left', 'top-right', 'bottom-left', 'bottom-right']) {
+  const edges = corner.split('-')
+  for (const bar of ['top', 'bottom', 'left', 'right']) {
+    const placement = notifications.popupPlacement(bar, 32, 6, corner)
+    assertDeepEqual(
+      Object.keys(placement.anchors).filter(edge => placement.anchors[edge]).sort(),
+      edges.slice().sort(),
+      `${corner} anchors to its two edges with a ${bar} bar`
+    )
+    for (const edge of ['top', 'bottom', 'left', 'right']) {
+      assertEqual(placement.margins[edge], edges.includes(edge) && edge === bar ? 32 : 6,
+        `${corner} only clears a ${bar} bar on an anchored edge`)
+    }
+  }
+}
+for (const invalid of [undefined, null, '', 'bottom', 'center', 'BOTTOM-LEFT']) {
+  assertDeepEqual(notifications.popupPlacement('top', 32, 6, invalid),
+    notifications.popupPlacement('top', 32, 6, 'top-right'),
+    `invalid position ${invalid} preserves the default`)
+}
+
 const notification = {
   id: 12,
   appName: 'Mail',


### PR DESCRIPTION
Allow choosing a notification corner without cloning the built-in plugin and missing subsequent upstream fixes.

Add a `position` option to the notification entry in `~/.config/omarchy/shell.json`:

```json
{ "id": "omarchy.notifications", "position": "bottom-right" }
```

Supports `top-left`, `top-right`, `bottom-left`, and `bottom-right`. Missing or invalid values preserve the `top-right` position. Changes apply on save, including to visible notifications. The stack clears the bar only on the edges it touches, and cards align to the selected side. The fullscreen surface and click-through mask stay in place.

New notifications extend the stack away from its screen edge: below existing notifications at the top, above them at the bottom. With notifications arriving as 1, 2, 3, the visual order from top to bottom is 1, 2, 3 in a top corner and 3, 2, 1 in a bottom corner. This also updates when moving a visible stack. The underlying model remains newest-first, preserving action and dismissal shortcuts.

The change is limited to the notification plugin, its existing tests, and documentation. No new settings UI or shell-wide configuration changes.

Validation:

- `bash test/shell.d/notifications-test.sh` passes, including all 16 corner/bar combinations and invalid-position fallback.
- Verified all four corners in the running shell, live configuration changes, and three sequential notifications. Confirmed that moving the visible stack between top and bottom reverses its visual order.
- `git diff --check` passes.
- Ran `./test/all`: CLI passes; 222 of 226 shell test files pass. Reproduced all four failures on unmodified upstream commit `4930677`: `config`, `snapper`, and `unowned-system-paths` require a separate `omarchy-pkgs` checkout; `launch-about` fails its "a roomy window animates" assertion in this environment.
