### PR TITLE
Propagate sleep-lock failure from the sleep monitor

### DIFF
--- a/bin/omarchy-system-sleep-monitor
+++ b/bin/omarchy-system-sleep-monitor
@@ -10,8 +10,9 @@ consume_sleep_events() {
 
   while IFS= read -r line; do
     if [[ $line == *"boolean true"* ]]; then
+      # Propagate lock failure so the inhibitor keeps the system awake.
       "$sleep_lock"
-      return 0
+      return $?
     fi
   done
 }


### PR DESCRIPTION
## Summary
- After PrepareForSleep, a failed `omarchy-system-sleep-lock` still returned success.
- Propagate the lock exit status so the inhibitor keeps the system awake when locking fails.

## Test plan
- [ ] Simulate a sleep-lock failure and confirm the monitor exits non-zero
- [ ] Confirm a successful lock still returns success
