### PR TITLE
Stage debug reports in a private temp directory

### DIFF
--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -26,7 +26,10 @@ while (( $# > 0 )); do
   esac
 done
 
-LOG_FILE="/tmp/omarchy-debug.log"
+DEBUG_TMP_DIR=$(mktemp -d "${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/omarchy-debug.XXXXXX")
+chmod 700 "$DEBUG_TMP_DIR"
+LOG_FILE="$DEBUG_TMP_DIR/omarchy-debug.log"
+trap 'rm -rf -- "$DEBUG_TMP_DIR"' EXIT
 
 if [[ $NO_SUDO = "true" ]]; then
   DMESG_OUTPUT="(skipped - --no-sudo flag used)"


### PR DESCRIPTION
## Summary
- `omarchy-debug` wrote dmesg and package lists to `/tmp/omarchy-debug.log`.
- Stage the report under a private mktemp directory and remove it on exit.

## Test plan
- [ ] Run `omarchy-debug` and confirm the report still opens/uploads
- [ ] Confirm `/tmp/omarchy-debug.log` is no longer used
