### PR TITLE
Exit non-zero when drive password change is cancelled

### DIFF
--- a/bin/omarchy-drive-password
+++ b/bin/omarchy-drive-password
@@ -25,6 +25,7 @@ if [[ -n $encrypted_drives ]]; then
     printf "%s" "$new_password" | sudo bash -c 'exec cryptsetup luksChangeKey --pbkdf argon2id --iter-time 2000 "$1" <(cat) </dev/tty' bash "$drive_to_change"
   else
     echo "No drive selected."
+    exit 1
   fi
 else
   echo "No encrypted drives available."


### PR DESCRIPTION
## Summary
- Cancelling the drive picker printed a message but still exited 0.
- Return 1 so scripts can tell a cancelled run from success.

## Test plan
- [ ] Cancel the drive picker and confirm exit status 1
- [ ] Complete a password change and confirm exit status 0
