### PR TITLE
feat(network): add wired NIC DHCP/static IPv4 settings to the panel

### DIFF
--- a/bin/omarchy-network-eth-config
+++ b/bin/omarchy-network-eth-config
@@ -1,0 +1,264 @@
+#!/bin/bash
+
+# omarchy:summary=Show or configure IPv4 settings for managed wired NICs
+# omarchy:group=network
+# omarchy:args=[list | set <device> <dhcp|manual> [ip] [prefix] [gateway] [dns]]
+# omarchy:examples=omarchy network eth-config list | omarchy network eth-config set enp1s0 dhcp | omarchy network eth-config set enp1s0 manual 192.168.1.10 24 192.168.1.1 1.1.1.1
+
+set -euo pipefail
+export LC_ALL=C
+
+# nmcli -e no keeps ':' and '\' verbatim in values; -g asks for one field at a
+# time so values can never be confused with separators.
+nm_get() {
+  local field=$1
+  shift
+  nmcli -e no -g "$field" "$@" 2>/dev/null || true
+}
+
+device_state() {
+  local dev=$1
+  nmcli -e no -t -f DEVICE,TYPE,STATE device status 2>/dev/null | awk -F: -v want="$dev" '
+    $1 == want { print $3; exit }
+  '
+}
+
+device_carrier() {
+  local dev=$1
+  if [[ -r /sys/class/net/$dev/carrier ]]; then
+    cat "/sys/class/net/$dev/carrier" 2>/dev/null || echo 0
+  else
+    echo 0
+  fi
+}
+
+# The profile currently bound to the device: active connection first, then the
+# first saved 802-3-ethernet profile that names this interface (or MAC), with
+# autoconnect profiles preferred so the panel edits what will actually be used.
+profile_for_device() {
+  local dev=$1
+  local active profile
+  local devmac uuid type iface mac name auto found=""
+
+  active=$(nm_get GENERAL.CONNECTION device show "$dev")
+  if [[ -n $active && $active != "--" ]]; then
+    echo "$active"
+    return 0
+  fi
+
+  devmac=$(cat "/sys/class/net/$dev/address" 2>/dev/null || true)
+
+  while IFS=: read -r uuid type; do
+    [[ -n $uuid && $type == 802-3-ethernet ]] || continue
+
+    iface=$(nm_get connection.interface-name connection show uuid "$uuid")
+    mac=$(nm_get 802-3-ethernet.mac-address connection show uuid "$uuid")
+    [[ $iface == "$dev" ]] || { [[ -n $devmac && -n $mac && $mac == "$devmac" ]]; } || continue
+
+    name=$(nm_get connection.id connection show uuid "$uuid")
+    [[ -n $name ]] || continue
+    auto=$(nm_get connection.autoconnect connection show uuid "$uuid")
+    if [[ -z $found ]]; then
+      found=$name
+    fi
+    if [[ $auto == yes ]]; then
+      echo "$name"
+      return 0
+    fi
+  done < <(nmcli -e no -g UUID,TYPE connection show)
+
+  [[ -z $found ]] || echo "$found"
+}
+
+first_line() {
+  head -n 1
+}
+
+clean_dns() {
+  tr '\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//'
+}
+
+list_devices() {
+  local line dev type state carrier profile method addrs addr prefix gateway dns live_ip live_gw
+
+  while IFS=: read -r dev type state; do
+    [[ $type == ethernet ]] || continue
+    [[ $state != unmanaged ]] || continue
+
+    carrier=$(device_carrier "$dev")
+    state=${state%% *}
+
+    profile=$(profile_for_device "$dev")
+    method=auto
+    addr=""
+    prefix=""
+    gateway=""
+    dns=""
+
+    if [[ -n $profile ]]; then
+      method=$(nm_get ipv4.method connection show "$profile")
+      [[ -n $method ]] || method=auto
+
+      if [[ $method == manual ]]; then
+        addrs=$(nm_get ipv4.addresses connection show "$profile" | first_line)
+        if [[ -n $addrs ]]; then
+          if [[ $addrs == */* ]]; then
+            addr=${addrs%/*}
+            prefix=${addrs##*/}
+          else
+            addr=$addrs
+          fi
+        fi
+        gateway=$(nm_get ipv4.gateway connection show "$profile" | first_line)
+        dns=$(nm_get ipv4.dns connection show "$profile" | clean_dns)
+      fi
+    fi
+
+    live_ip=$(nm_get IP4.ADDRESS device show "$dev" | first_line)
+    live_gw=$(nm_get IP4.GATEWAY device show "$dev" | first_line)
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$dev" "$carrier" "$state" "$profile" "$method" \
+      "$addr" "$prefix" "$gateway" "$dns" "$live_ip" "$live_gw"
+  done < <(nmcli -e no -t -f DEVICE,TYPE,STATE device status)
+}
+
+# Make sure there is an editable NetworkManager profile for this interface.
+# NM would normally auto-create one on `device connect`; when we are setting a
+# static IP before any DHCP server answers we need the profile to exist first.
+ensure_profile() {
+  local dev=$1 profile con_name
+
+  profile=$(profile_for_device "$dev")
+  if [[ -n $profile ]]; then
+    echo "$profile"
+    return 0
+  fi
+
+  con_name="Wired $dev"
+  nmcli connection add \
+    type ethernet \
+    con-name "$con_name" \
+    ifname "$dev" \
+    connection.autoconnect yes \
+    >/dev/null
+  echo "$con_name"
+}
+
+apply_connection() {
+  local dev=$1 profile=$2 state carrier
+
+  state=$(device_state "$dev")
+  carrier=$(device_carrier "$dev")
+
+  if [[ $state == connected* ]]; then
+    nmcli device reapply "$dev" >/dev/null 2>&1 \
+      || nmcli --wait 10 connection up "$profile" >/dev/null 2>&1 \
+      || true
+  elif [[ $carrier == 1 ]]; then
+    nmcli --wait 10 device connect "$dev" >/dev/null 2>&1 \
+      || nmcli --wait 10 connection up "$profile" >/dev/null 2>&1 \
+      || true
+  fi
+}
+
+set_command() {
+  local dev=$1 mode=$2
+  local profile ip prefix gateway dns
+
+  if (($# < 2)); then
+    echo "Usage: omarchy-network-eth-config set <device> <dhcp|manual> [ip] [prefix] [gateway] [dns]" >&2
+    exit 2
+  fi
+
+  profile=$(ensure_profile "$dev")
+  if [[ -z $profile ]]; then
+    echo "Error: could not find or create a NetworkManager profile for $dev." >&2
+    exit 1
+  fi
+
+  case $mode in
+    dhcp|auto)
+      nmcli connection modify "$profile" \
+        connection.autoconnect yes \
+        ipv4.method auto \
+        ipv4.addresses "" \
+        ipv4.gateway "" \
+        ipv4.dns "" \
+        ipv4.dns-search "" \
+        ipv4.ignore-auto-dns no \
+        >/dev/null
+      ;;
+
+    manual)
+      if (($# < 4)); then
+        echo "Usage: omarchy-network-eth-config set <device> manual <ip> [prefix] [gateway] [dns]" >&2
+        exit 2
+      fi
+
+      ip=$3
+      prefix=${4:-24}
+      gateway=${5:-}
+      dns=${6:-}
+
+      if [[ -z $ip ]]; then
+        echo "Error: an IP address is required for manual configuration." >&2
+        exit 1
+      fi
+
+      if [[ -n $dns ]]; then
+        nmcli connection modify "$profile" \
+          connection.autoconnect yes \
+          ipv4.method manual \
+          ipv4.addresses "$ip/$prefix" \
+          ipv4.gateway "$gateway" \
+          ipv4.dns "$dns" \
+          ipv4.dns-search "" \
+          ipv4.ignore-auto-dns yes \
+          >/dev/null
+      else
+        nmcli connection modify "$profile" \
+          connection.autoconnect yes \
+          ipv4.method manual \
+          ipv4.addresses "$ip/$prefix" \
+          ipv4.gateway "$gateway" \
+          ipv4.dns "" \
+          ipv4.dns-search "" \
+          ipv4.ignore-auto-dns no \
+          >/dev/null
+      fi
+      ;;
+
+    *)
+      echo "Error: unknown mode '$mode' (expected dhcp or manual)." >&2
+      exit 2
+      ;;
+  esac
+
+  apply_connection "$dev" "$profile"
+}
+
+usage() {
+  echo "Usage: omarchy-network-eth-config list" >&2
+  echo "       omarchy-network-eth-config set <device> dhcp" >&2
+  echo "       omarchy-network-eth-config set <device> manual <ip> [prefix] [gateway] [dns]" >&2
+}
+
+if (($# == 0)); then
+  usage
+  exit 2
+fi
+
+case $1 in
+  list)
+    list_devices
+    ;;
+  set)
+    shift
+    set_command "$@"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -277,6 +277,19 @@ function formatPingLatency(ms, hasSamples) {
   return value.toFixed(value > 0 && value < 10 ? 1 : 0) + " ms"
 }
 
+// The wired NIC's mode switch stages a change: nothing is written to the
+// profile until the Apply beside it runs, which matters most on a NIC with no
+// cable, where there is nothing to activate and the profile is only saved. The
+// header therefore states what the profile says *now* and names the requested
+// mode separately while the two differ -- "MANUAL → AUTO DHCP" -- so a flip can
+// never read as a mode already in force. Once they agree it is just the mode.
+function ipv4ModeLabel(manualMode, manualSaved) {
+  var staged = manualMode ? "MANUAL" : "AUTO DHCP"
+  var saved = manualSaved ? "MANUAL" : "AUTO DHCP"
+
+  return staged === saved ? saved : saved + " → " + staged
+}
+
 function wifiRow(network) {
   if (!network) return null
   // Primitives only: rows become list-model data, so a WifiNetwork here puts a
@@ -386,6 +399,7 @@ if (typeof module !== "undefined") {
     formatBytes: formatBytes,
     formatRate: formatRate,
     formatPingLatency: formatPingLatency,
+    ipv4ModeLabel: ipv4ModeLabel,
     wifiRow: wifiRow,
     sortWifiRows: sortWifiRows,
     wifiSectionTitle: wifiSectionTitle,

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -16,6 +16,17 @@ Panel {
   // permits — needed for the toggleNetwork method below.
   manageIpc: false
 
+  // Helper for the inline wired-NIC IPv4 settings (DHCP / static IP).
+  readonly property string ethConfigScript: "omarchy-network-eth-config"
+
+  // Plain-object rows returned by ethConfigScript list:
+  // { device, carrier, state, profile, method, address, prefix, gateway, dns,
+  //   liveIp, liveGateway }
+  property var wiredDevices: []
+  // Set while a wired TextField has focus so the poller does not rebuild rows
+  // under the user's cursor.
+  property string editingWiredDevice: ""
+
   // Centralized close so callers can't forget to drop the passphrase prompt.
   function close() {
     root.controller.hide()
@@ -345,6 +356,7 @@ Panel {
       routerPingLatency = -1
       internetPingLatency = -1
       internetPingPacketLoss = 0
+      editingWiredDevice = ""
       setScannerEnabled(false)
     }
   }
@@ -526,6 +538,10 @@ Panel {
     checkConnectivity()
     if (scanWifi === undefined) scanWifi = false
     if (!detailsProc.running) detailsProc.running = true
+    if (!ethListProc.running) {
+      ethListProc.command = [root.ethConfigScript, "list"]
+      ethListProc.running = true
+    }
     if (!dnsProc.running) {
       dnsProc.command = ["bash", "-c", root.dnsCommand("")]
       dnsProc.running = true
@@ -546,6 +562,38 @@ Panel {
       }
     }
     syncWifiNetworks()
+  }
+
+  function refreshWiredDevices() {
+    if (!ethListProc.running) {
+      ethListProc.command = [root.ethConfigScript, "list"]
+      ethListProc.running = true
+    }
+  }
+
+  function updateWiredDevices(raw) {
+    var lines = String(raw || "").split("\n")
+    var rows = []
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i].replace(/\r$/, "")
+      if (!line) continue
+      var p = line.split("\t")
+      if (p.length < 11) continue
+      rows.push({
+        device: p[0],
+        carrier: p[1] === "1",
+        state: p[2],
+        profile: p[3],
+        method: p[4] || "auto",
+        address: p[5],
+        prefix: p[6],
+        gateway: p[7],
+        dns: p[8],
+        liveIp: p[9],
+        liveGateway: p[10]
+      })
+    }
+    wiredDevices = rows
   }
 
   function formatHeaderSpeed(mbps) {
@@ -868,6 +916,30 @@ Panel {
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.updateDetails(text)
+    }
+  }
+
+  // Pulls the list of NetworkManager-managed wired NICs and their IPv4 mode.
+  Process {
+    id: ethListProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateWiredDevices(text)
+    }
+  }
+
+  Timer {
+    id: ethPoll
+    interval: 3000
+    repeat: true
+    running: root.opened
+    onTriggered: {
+      // Don't replace rows while a TextField has focus; the row keeps the
+      // user's draft and the next manual refresh/open catches status changes.
+      if (root.editingWiredDevice !== "") return
+      if (ethListProc.running) return
+      ethListProc.command = [root.ethConfigScript, "list"]
+      ethListProc.running = true
     }
   }
 
@@ -1377,6 +1449,45 @@ Panel {
             text: root.info.gateway || "--"
             copyable: !!root.info.gateway
             tooltipText: "Copy gateway"
+          }
+        }
+      }
+
+      // Wired NIC settings. Every NetworkManager-managed wired adapter gets a
+      // row here, even when no cable is plugged in or no DHCP server has
+      // answered, so an external NIC can be switched to a static IP from the
+      // panel before it ever gets an address.
+      PanelSeparator {
+        visible: root.wiredDevices.length > 0
+        foreground: root.bar.foreground
+      }
+
+      Column {
+        visible: root.wiredDevices.length > 0
+        width: parent.width
+        spacing: Style.space(10)
+
+        PanelSectionHeader {
+          text: root.wiredDevices.length === 1 ? "WIRED NIC" : "WIRED NICS"
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+        }
+
+        Repeater {
+          model: root.wiredDevices
+
+          delegate: Item {
+            required property var modelData
+            required property int index
+            width: parent.width
+            height: wiredNic.implicitHeight
+
+            WiredNicRow {
+              id: wiredNic
+              width: parent.width
+              info: modelData
+              rowIndex: index
+            }
           }
         }
       }
@@ -2046,6 +2157,394 @@ Panel {
     }
   }
 
+
+  // One NetworkManager-managed wired NIC row. The header always shows the
+  // adapter; the mode switch toggles between automatic DHCP and a manual
+  // static IPv4 form that is applied straight through nmcli.
+  component WiredNicRow: Item {
+    id: wiredRow
+    required property var info
+    required property int rowIndex
+
+    readonly property bool connected: info.state === "connected"
+    readonly property bool connecting: info.state === "connecting"
+    readonly property bool hasCarrier: info.carrier
+    readonly property bool manualSaved: info.method === "manual"
+    readonly property string liveAddressText: {
+      var raw = String(info.liveIp || "")
+      var idx = raw.indexOf("/")
+      return idx < 0 ? raw : raw.substring(0, idx)
+    }
+    readonly property string livePrefixText: {
+      var raw = String(info.liveIp || "")
+      var idx = raw.indexOf("/")
+      return idx < 0 ? "" : raw.substring(idx + 1)
+    }
+    readonly property string stateText: {
+      if (info.state === "connected") return "Connected"
+      if (info.state === "connecting") return "Connecting"
+      if (info.state === "unavailable") return "No cable"
+      if (info.state === "disconnected") return hasCarrier ? "Cable present" : "Disconnected"
+      if (info.state) return info.state.charAt(0).toUpperCase() + info.state.slice(1)
+      return "Unknown"
+    }
+    readonly property string summaryText: {
+      var parts = []
+      parts.push(stateText)
+      if (liveAddressText !== "") parts.push(liveAddressText + (livePrefixText !== "" ? "/" + livePrefixText : ""))
+      if (info.profile) parts.push(info.profile)
+      if (statusText !== "") parts.push(statusText)
+      return parts.join(" · ")
+    }
+
+    property bool manualMode: manualSaved
+    property string draftAddress: info.address || ""
+    property string draftPrefix: info.prefix || ""
+    property string draftGateway: info.gateway || ""
+    property string draftDns: info.dns || ""
+    property bool busy: false
+    property string statusText: ""
+    property bool failed: false
+    property string initializedDevice: ""
+
+    function initFromInfo() {
+      if (initializedDevice === info.device) return
+      initializedDevice = info.device
+      manualMode = info.method === "manual"
+      draftAddress = info.address || ""
+      draftPrefix = info.prefix || ""
+      draftGateway = info.gateway || ""
+      draftDns = info.dns || ""
+      busy = false
+      statusText = ""
+      failed = false
+    }
+
+    function setMode(nextManual) {
+      if (busy) return
+      manualMode = nextManual
+      statusText = ""
+      failed = false
+
+      if (manualMode) {
+        if (draftAddress === "") {
+          if (liveAddressText !== "") {
+            draftAddress = liveAddressText
+            if (livePrefixText !== "") draftPrefix = livePrefixText
+          }
+        }
+        if (draftPrefix === "") draftPrefix = "24"
+      }
+    }
+
+    function validIpv4(value) {
+      var text = String(value || "").trim()
+      if (!text) return false
+      var parts = text.split(".")
+      if (parts.length !== 4) return false
+      for (var i = 0; i < parts.length; i++) {
+        var part = parts[i]
+        if (!/^\d{1,3}$/.test(part)) return false
+        var n = parseInt(part, 10)
+        if (n < 0 || n > 255) return false
+      }
+      return true
+    }
+
+    function validPrefix(value) {
+      var text = String(value || "").trim()
+      if (!/^\d{1,2}$/.test(text)) return false
+      var n = parseInt(text, 10)
+      return n >= 0 && n <= 32
+    }
+
+    function validDns(value) {
+      var text = String(value || "").trim()
+      if (text === "") return true
+      var tokens = text.split(/[\s,]+/)
+      for (var i = 0; i < tokens.length; i++) {
+        if (!validIpv4(tokens[i])) return false
+      }
+      return true
+    }
+
+    function applyConfig() {
+      if (busy || !info.device) return
+      statusText = ""
+      failed = false
+
+      if (manualMode) {
+        if (!validIpv4(draftAddress)) {
+          statusText = "Invalid IP address"
+          failed = true
+          return
+        }
+        if (!validPrefix(draftPrefix)) {
+          statusText = "Invalid prefix (0-32)"
+          failed = true
+          return
+        }
+        if (String(draftGateway || "").trim() !== "" && !validIpv4(draftGateway)) {
+          statusText = "Invalid gateway"
+          failed = true
+          return
+        }
+        if (!validDns(draftDns)) {
+          statusText = "Invalid DNS server"
+          failed = true
+          return
+        }
+      }
+
+      busy = true
+      statusText = connected
+        ? "Applying…"
+        : (hasCarrier ? "Applying and connecting…" : "Saving…")
+
+      var args = [root.ethConfigScript, "set", info.device]
+      if (!manualMode) {
+        args.push("dhcp")
+      } else {
+        var prefix = String(draftPrefix || "").trim() || "24"
+        args.push("manual")
+        args.push(String(draftAddress || "").trim())
+        args.push(prefix)
+        args.push(String(draftGateway || "").trim())
+        args.push(String(draftDns || "").trim())
+      }
+      ethApplyProc.command = args
+      ethApplyProc.running = true
+    }
+
+    onInfoChanged: initFromInfo()
+    Component.onCompleted: initFromInfo()
+
+    implicitHeight: contentColumn.implicitHeight
+
+    Column {
+      id: contentColumn
+      width: parent.width
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      spacing: Style.space(6)
+
+      // Header: interface + state on the left, DHCP/manual switch on the right.
+      Item {
+        width: parent.width
+        implicitHeight: Math.max(headerLabels.implicitHeight, modeSwitchGroup.implicitHeight)
+
+        Row {
+          id: modeSwitchGroup
+          spacing: Style.space(6)
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+
+          Text {
+            textFormat: Text.PlainText
+            text: wiredRow.manualMode ? "MANUAL" : "AUTO DHCP"
+            color: Qt.darker(root.bar.foreground, 1.4)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
+            font.letterSpacing: 1.0
+            anchors.verticalCenter: parent.verticalCenter
+          }
+
+          ToggleSwitch {
+            checked: !wiredRow.manualMode
+            foreground: root.bar.foreground
+            onToggled: wiredRow.setMode(!wiredRow.manualMode)
+            onHovered: function(hovered) {
+              if (hovered) root.cursorActive = false
+            }
+          }
+        }
+
+        Column {
+          id: headerLabels
+          anchors.left: parent.left
+          anchors.right: modeSwitchGroup.left
+          anchors.rightMargin: Style.space(12)
+          anchors.verticalCenter: parent.verticalCenter
+          spacing: Style.space(1)
+
+          Text {
+            textFormat: Text.PlainText
+            width: parent.width
+            text: wiredRow.info.device
+            color: (wiredRow.connected || wiredRow.hasCarrier)
+              ? root.bar.foreground
+              : Qt.darker(root.bar.foreground, 1.4)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.body
+            font.bold: wiredRow.connected || wiredRow.hasCarrier
+            elide: Text.ElideRight
+          }
+
+          Text {
+            textFormat: Text.PlainText
+            width: parent.width
+            text: wiredRow.summaryText
+            color: wiredRow.failed
+              ? root.bar.urgent
+              : Qt.darker(root.bar.foreground, 1.4)
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.caption
+            elide: Text.ElideRight
+          }
+        }
+      }
+
+      // Auto DHCP is the default; no form is needed.
+      Text {
+        textFormat: Text.PlainText
+        visible: !wiredRow.manualMode
+        width: parent.width
+        text: "DHCP — obtain IP, gateway and DNS automatically."
+        color: Qt.darker(root.bar.foreground, 1.6)
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+
+      // Static IPv4 form.
+      Column {
+        visible: wiredRow.manualMode
+        width: parent.width
+        spacing: Style.space(6)
+
+        RowLayout {
+          width: parent.width
+          spacing: Style.space(6)
+
+          TextField {
+            id: ipField
+            Layout.fillWidth: true
+            placeholderText: "IP address"
+            font.family: Style.font.family
+            font.pixelSize: Style.font.body
+            foreground: root.bar.foreground
+            horizontalPadding: Style.spacing.controlGap
+            verticalPadding: Style.spacing.controlPaddingY
+            enabled: !wiredRow.busy
+            text: wiredRow.draftAddress
+            onTextChanged: if (text !== wiredRow.draftAddress) wiredRow.draftAddress = text
+            onActiveFocusChanged: {
+              if (activeFocus) root.editingWiredDevice = wiredRow.info.device
+              else if (root.editingWiredDevice === wiredRow.info.device) root.editingWiredDevice = ""
+            }
+            onAccepted: prefixField.forceActiveFocus()
+          }
+
+          TextField {
+            id: prefixField
+            Layout.preferredWidth: Style.space(72)
+            placeholderText: "/24"
+            font.family: Style.font.family
+            font.pixelSize: Style.font.body
+            foreground: root.bar.foreground
+            horizontalPadding: Style.spacing.controlGap
+            verticalPadding: Style.spacing.controlPaddingY
+            enabled: !wiredRow.busy
+            text: wiredRow.draftPrefix
+            onTextChanged: if (text !== wiredRow.draftPrefix) wiredRow.draftPrefix = text
+            onActiveFocusChanged: {
+              if (activeFocus) root.editingWiredDevice = wiredRow.info.device
+              else if (root.editingWiredDevice === wiredRow.info.device) root.editingWiredDevice = ""
+            }
+            onAccepted: gatewayField.forceActiveFocus()
+          }
+        }
+
+        TextField {
+          id: gatewayField
+          width: parent.width
+          placeholderText: "Gateway (optional)"
+          font.family: Style.font.family
+          font.pixelSize: Style.font.body
+          foreground: root.bar.foreground
+          horizontalPadding: Style.spacing.controlGap
+          verticalPadding: Style.spacing.controlPaddingY
+          enabled: !wiredRow.busy
+          text: wiredRow.draftGateway
+          onTextChanged: if (text !== wiredRow.draftGateway) wiredRow.draftGateway = text
+          onActiveFocusChanged: {
+            if (activeFocus) root.editingWiredDevice = wiredRow.info.device
+            else if (root.editingWiredDevice === wiredRow.info.device) root.editingWiredDevice = ""
+          }
+          onAccepted: dnsField.forceActiveFocus()
+        }
+
+        TextField {
+          id: dnsField
+          width: parent.width
+          placeholderText: "DNS servers (optional, comma or space separated)"
+          font.family: Style.font.family
+          font.pixelSize: Style.font.body
+          foreground: root.bar.foreground
+          horizontalPadding: Style.spacing.controlGap
+          verticalPadding: Style.spacing.controlPaddingY
+          enabled: !wiredRow.busy
+          text: wiredRow.draftDns
+          onTextChanged: if (text !== wiredRow.draftDns) wiredRow.draftDns = text
+          onActiveFocusChanged: {
+            if (activeFocus) root.editingWiredDevice = wiredRow.info.device
+            else if (root.editingWiredDevice === wiredRow.info.device) root.editingWiredDevice = ""
+          }
+          onAccepted: wiredRow.applyConfig()
+        }
+
+        Row {
+          spacing: Style.space(6)
+
+          Button {
+            text: wiredRow.busy
+              ? "Applying…"
+              : ((wiredRow.connected || wiredRow.hasCarrier) ? "Apply & connect" : "Save")
+            enabled: !wiredRow.busy
+            fontSize: Style.font.body
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            horizontalPadding: Style.spacing.controlPaddingX
+            verticalPadding: Style.spacing.controlPaddingY
+            onClicked: wiredRow.applyConfig()
+          }
+
+          Button {
+            text: "Reset"
+            visible: !wiredRow.busy
+            fontSize: Style.font.body
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            horizontalPadding: Style.spacing.controlPaddingX
+            verticalPadding: Style.spacing.controlPaddingY
+            onClicked: wiredRow.initFromInfo()
+          }
+        }
+      }
+    }
+
+    Process {
+      id: ethApplyProc
+      stdout: StdioCollector { id: ethApplyOut; waitForEnd: true }
+      stderr: StdioCollector { id: ethApplyErr; waitForEnd: true }
+      onExited: function(exitCode) {
+        wiredRow.busy = false
+        if (exitCode === 0) {
+          wiredRow.failed = false
+          wiredRow.statusText = wiredRow.hasCarrier ? "Applied" : "Saved"
+          root.refreshWiredDevices()
+          root.refresh()
+        } else {
+          wiredRow.failed = true
+          var firstLine = String(ethApplyErr.text || "").trim().split("\n")[0]
+          wiredRow.statusText = firstLine !== "" ? "Failed: " + firstLine : "Apply failed"
+        }
+        if (root.editingWiredDevice === wiredRow.info.device) root.editingWiredDevice = ""
+      }
+    }
+  }
 
   component DetailValue: InfoValue {
     property bool copyable: false

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -2198,6 +2198,23 @@ Panel {
     }
 
     property bool manualMode: manualSaved
+    // The switch stages a change: nothing is written to the profile until the
+    // Apply beside it runs, so the row has to say which mode is in force rather
+    // than let a flip speak for itself. modeDirty is the switch disagreeing with
+    // the saved profile; modeEdited remembers that the user moved it, so a
+    // background reload of info.method cannot make a staged apply vanish before
+    // it is committed.
+    readonly property bool modeDirty: manualMode !== manualSaved
+    property bool modeEdited: false
+    // The header states the saved mode and names the requested one beside it
+    // while they differ -- "MANUAL → AUTO DHCP" -- so an unapplied flip can never
+    // read as a mode already in force. See Model.ipv4ModeLabel.
+    readonly property string modeLabel: Model.ipv4ModeLabel(manualMode, manualSaved)
+    // A staged switch to automatic gets its own button, so the DHCP side is
+    // committable instead of only being a switch that moves.
+    readonly property string dhcpButtonText: (connected || hasCarrier)
+      ? "Apply DHCP & connect"
+      : "Save DHCP"
     property string draftAddress: info.address || ""
     property string draftPrefix: info.prefix || ""
     property string draftGateway: info.gateway || ""
@@ -2211,6 +2228,7 @@ Panel {
       if (initializedDevice === info.device) return
       initializedDevice = info.device
       manualMode = info.method === "manual"
+      modeEdited = false
       draftAddress = info.address || ""
       draftPrefix = info.prefix || ""
       draftGateway = info.gateway || ""
@@ -2235,6 +2253,16 @@ Panel {
         }
         if (draftPrefix === "") draftPrefix = "24"
       }
+
+      modeEdited = manualMode !== manualSaved
+    }
+
+    // Reset/Cancel: restore every draft from the saved profile. initFromInfo()
+    // returns early for a device it has already loaded, so Reset needs its own
+    // entry point or it would be a no-op.
+    function resetToInfo() {
+      initializedDevice = ""
+      initFromInfo()
     }
 
     function validIpv4(value) {
@@ -2342,7 +2370,7 @@ Panel {
 
           Text {
             textFormat: Text.PlainText
-            text: wiredRow.manualMode ? "MANUAL" : "AUTO DHCP"
+            text: wiredRow.modeLabel
             color: Qt.darker(root.bar.foreground, 1.4)
             font.family: root.bar.fontFamily
             font.pixelSize: Style.font.caption
@@ -2396,16 +2424,52 @@ Panel {
         }
       }
 
-      // Auto DHCP is the default; no form is needed.
-      Text {
-        textFormat: Text.PlainText
+      // Auto DHCP is the default; no form is needed. Switching into it is still
+      // a staged change, though, so the automatic side needs the same Apply and
+      // Reset the form has: without them the only Apply in the row disappears
+      // with the form, leaving the header claiming a mode that was never applied
+      // and no way to apply it from here.
+      Column {
         visible: !wiredRow.manualMode
         width: parent.width
-        text: "DHCP — obtain IP, gateway and DNS automatically."
-        color: Qt.darker(root.bar.foreground, 1.6)
-        font.family: root.bar.fontFamily
-        font.pixelSize: Style.font.caption
-        wrapMode: Text.WordWrap
+        spacing: Style.space(6)
+
+        Text {
+          textFormat: Text.PlainText
+          width: parent.width
+          text: "DHCP — obtain IP, gateway and DNS automatically."
+          color: Qt.darker(root.bar.foreground, 1.6)
+          font.family: root.bar.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.WordWrap
+        }
+
+        Row {
+          visible: wiredRow.modeDirty || wiredRow.modeEdited
+          spacing: Style.space(6)
+
+          Button {
+            text: wiredRow.busy ? "Applying…" : wiredRow.dhcpButtonText
+            enabled: !wiredRow.busy
+            fontSize: Style.font.body
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            horizontalPadding: Style.spacing.controlPaddingX
+            verticalPadding: Style.spacing.controlPaddingY
+            onClicked: wiredRow.applyConfig()
+          }
+
+          Button {
+            text: "Reset"
+            visible: !wiredRow.busy
+            fontSize: Style.font.body
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+            horizontalPadding: Style.spacing.controlPaddingX
+            verticalPadding: Style.spacing.controlPaddingY
+            onClicked: wiredRow.resetToInfo()
+          }
+        }
       }
 
       // Static IPv4 form.
@@ -2519,7 +2583,7 @@ Panel {
             fontFamily: root.bar.fontFamily
             horizontalPadding: Style.spacing.controlPaddingX
             verticalPadding: Style.spacing.controlPaddingY
-            onClicked: wiredRow.initFromInfo()
+            onClicked: wiredRow.resetToInfo()
           }
         }
       }

--- a/shell/plugins/panels/network/manifest.json
+++ b/shell/plugins/panels/network/manifest.json
@@ -4,7 +4,7 @@
   "name": "Network",
   "version": "1.0.0",
   "author": "Omarchy",
-  "description": "Wi-Fi list and connection state",
+  "description": "Network status, Wi-Fi list and wired NIC settings",
   "kinds": [
     "bar-widget"
   ],
@@ -13,7 +13,7 @@
   },
   "barWidget": {
     "displayName": "Network",
-    "description": "Wi-Fi list and connection state",
+    "description": "Network status, Wi-Fi list and wired NIC settings",
     "category": "Network",
     "allowMultiple": false
   }

--- a/test/shell.d/network-eth-config-test.sh
+++ b/test/shell.d/network-eth-config-test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+cat >"$tmp/bin/nmcli" <<'EOF'
+#!/bin/bash
+args=("$@")
+log="$NM_LOG"
+joined="${args[*]}"
+
+if [[ $joined == *"connection modify"* || $joined == *"connection add"* ]]; then
+  printf '%s\n' "${args[@]}" >>"$log"
+  printf -- '---\n' >>"$log"
+  exit 0
+fi
+
+if [[ $joined == *"device reapply"* || $joined == *"device connect"* || $joined == *"connection up"* ]]; then
+  printf '%s\n' "${args[@]}" >>"$log"
+  printf -- '---\n' >>"$log"
+  exit 0
+fi
+
+if [[ $joined == *"DEVICE,TYPE,STATE"* && $joined == *"device status"* ]]; then
+  printf 'eth0:ethernet:connected\nwlan0:wifi:connected\nunm0:ethernet:unmanaged\n'
+  exit 0
+fi
+
+if [[ $joined == *"UUID,TYPE"* && $joined == *"connection show"* ]]; then
+  printf '11111111-1111-1111-1111-111111111111:802-3-ethernet\n'
+  exit 0
+fi
+
+if [[ $joined == *"GENERAL.CONNECTION"* ]]; then
+  printf '%s\n' "${NM_ACTIVE_CONNECTION:-Wired eth0}"
+  exit 0
+fi
+
+if [[ $joined == *"connection.interface-name"* ]]; then
+  echo eth0
+  exit 0
+fi
+
+if [[ $joined == *"connection.autoconnect"* ]]; then
+  echo yes
+  exit 0
+fi
+
+if [[ $joined == *"connection.id"* ]]; then
+  echo "Wired eth0"
+  exit 0
+fi
+
+if [[ $joined == *"802-3-ethernet.mac-address"* ]]; then
+  exit 0
+fi
+
+if [[ $joined == *"ipv4.method"* ]]; then
+  printf '%s\n' "${NM_METHOD:-auto}"
+  exit 0
+fi
+
+if [[ $joined == *"ipv4.addresses"* ]]; then
+  [[ ${NM_METHOD:-auto} == manual ]] && echo '192.168.1.10/24'
+  exit 0
+fi
+
+if [[ $joined == *"ipv4.gateway"* ]]; then
+  [[ ${NM_METHOD:-auto} == manual ]] && echo '192.168.1.1'
+  exit 0
+fi
+
+if [[ $joined == *"ipv4.dns"* ]]; then
+  [[ ${NM_METHOD:-auto} == manual ]] && echo '1.1.1.1'
+  exit 0
+fi
+
+if [[ $joined == *"IP4.ADDRESS"* ]]; then
+  [[ ${NM_STATE:-connected} == connected ]] && echo '192.168.1.10/24'
+  exit 0
+fi
+
+if [[ $joined == *"IP4.GATEWAY"* ]]; then
+  [[ ${NM_STATE:-connected} == connected ]] && echo '192.168.1.1'
+  exit 0
+fi
+
+exit 0
+EOF
+chmod +x "$tmp/bin/nmcli"
+
+export NM_LOG="$tmp/nmcli.log"
+export NM_STATE=connected
+export NM_METHOD=manual
+export NM_ACTIVE_CONNECTION="Wired eth0"
+
+output=$(PATH="$tmp/bin:$PATH" "$ROOT/bin/omarchy-network-eth-config" list)
+[[ $output == *$'eth0\t'* ]] || fail "network eth-config lists managed ethernet devices" "missing eth0: $output"
+[[ $output != *wlan0* ]] || fail "network eth-config skips Wi-Fi devices" "wlan0 leaked: $output"
+[[ $output != *unm0* ]] || fail "network eth-config skips unmanaged ethernet devices" "unm0 leaked: $output"
+[[ $output == *$'manual\t192.168.1.10\t24\t192.168.1.1\t1.1.1.1'* ]] || fail "network eth-config reports manual IPv4 profile" "missing manual fields: $output"
+pass "network eth-config lists managed wired NICs and their IPv4 mode"
+
+: >"$NM_LOG"
+PATH="$tmp/bin:$PATH" "$ROOT/bin/omarchy-network-eth-config" set eth0 dhcp >/dev/null
+modify=$(<"$NM_LOG")
+method=$(awk '/^ipv4.method$/ { getline; print; exit }' <<<"$modify")
+addresses=$(awk '/^ipv4.addresses$/ { getline; print; exit }' <<<"$modify")
+[[ $method == auto ]] || fail "network eth-config switches a NIC to DHCP" "method: $method"
+[[ -z $addresses ]] || fail "network eth-config clears manual addresses on DHCP" "addresses: $addresses"
+pass "network eth-config set dhcp switches a NIC to automatic DHCP"
+
+: >"$NM_LOG"
+PATH="$tmp/bin:$PATH" "$ROOT/bin/omarchy-network-eth-config" set eth0 manual 10.0.0.5 24 10.0.0.1 >/dev/null
+modify=$(<"$NM_LOG")
+method=$(awk '/^ipv4.method$/ { getline; print; exit }' <<<"$modify")
+addresses=$(awk '/^ipv4.addresses$/ { getline; print; exit }' <<<"$modify")
+gateway=$(awk '/^ipv4.gateway$/ { getline; print; exit }' <<<"$modify")
+[[ $method == manual ]] || fail "network eth-config switches a NIC to manual" "method: $method"
+[[ $addresses == 10.0.0.5/24 ]] || fail "network eth-config writes the static address" "addresses: $addresses"
+[[ $gateway == 10.0.0.1 ]] || fail "network eth-config writes the gateway" "gateway: $gateway"
+pass "network eth-config set manual writes static IPv4 settings"

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -293,4 +293,33 @@ assertDeepEqual(
 
 assertEqual(network.headerDetail({ type: 'wifi', freq: '5745' }), '', 'network keeps wifi band state out of the hero')
 assertEqual(network.headerDetail({ type: 'ethernet', speed: '100' }), '100mbit', 'network keeps ethernet speed in the hero')
+
+assertEqual(network.ipv4ModeLabel(false, false), 'AUTO DHCP', 'network labels an unchanged automatic mode')
+assertEqual(network.ipv4ModeLabel(true, true), 'MANUAL', 'network labels an unchanged manual mode')
+assertEqual(network.ipv4ModeLabel(false, true), 'MANUAL → AUTO DHCP', 'network states the mode in force before a staged flip to DHCP')
+assertEqual(network.ipv4ModeLabel(true, false), 'AUTO DHCP → MANUAL', 'network states the mode in force before a staged flip to MANUAL')
+
+// The switch only stages a change, so it may not read as a mode already in
+// force -- and the automatic side has to keep a way to commit it. In the first
+// revision of this branch the only Apply lived inside the manual branch, so
+// switching to automatic collapsed the form and the button with it, and the
+// mode could never be applied from the panel at all.
+const wiredRowSource = panelSource.match(/component WiredNicRow: Item \{[\s\S]*?\n {2}\}/)
+assert(wiredRowSource, 'network has a wired NIC row')
+assert(/readonly property string modeLabel: Model\.ipv4ModeLabel\(manualMode, manualSaved\)/.test(wiredRowSource[0]),
+  'network states the saved mode in the wired row header, not a staged flip')
+assert(/readonly property bool modeDirty: manualMode !== manualSaved/.test(wiredRowSource[0]),
+  'network treats the wired row mode as staged until it is applied')
+assert(/text: wiredRow\.modeLabel/.test(panelSource),
+  'network renders the wired row mode label from the saved mode')
+assert(/visible: wiredRow\.modeDirty \|\| wiredRow\.modeEdited/.test(panelSource),
+  'network offers the staged apply only while a mode change is pending')
+assert(/text: wiredRow\.busy \? "Applying…" : wiredRow\.dhcpButtonText/.test(panelSource),
+  'network gives the automatic side its own apply button')
+assert(/readonly property string dhcpButtonText: \(connected \|\| hasCarrier\)/.test(wiredRowSource[0]),
+  'network words the automatic apply button for the carrier the NIC has or lacks')
+assert(/function resetToInfo\(\) \{/.test(wiredRowSource[0]),
+  'network can restore a draft after initFromInfo has already loaded the device')
+assert(!/onClicked: wiredRow\.initFromInfo\(\)/.test(panelSource),
+  'network reset goes through the forced reload rather than the guarded initializer')
 JS


### PR DESCRIPTION
## Summary

Add an inline wired-NIC configuration section to the `omarchy.network` panel so users can switch any NetworkManager-managed wired adapter between:

- **AUTO DHCP** (default) — the profile obtains IP, gateway and DNS automatically.
- **MANUAL** — an inline form for static IPv4 address, prefix, optional gateway, and optional DNS servers.

This is particularly useful for external USB NICs or direct device-to-device links where no DHCP server answers before a static profile exists.

## What changes

- `shell/plugins/panels/network/Panel.qml`
  - Lists every NetworkManager-managed wired NIC in a new `WIRED NIC` / `WIRED NICS` section above the existing Wi-Fi content.
  - Shows carrier/link state, current profile, and current/live IPv4 information.
  - Provides a DHCP/manual switch and, in manual mode, IP/prefix/gateway/DNS fields with an Apply/Save action.
  - Polls the wired NIC list while the panel is open and pauses polling while a text field has focus.
- `bin/omarchy-network-eth-config`
  - New Omarchy CLI helper: `omarchy network eth-config list | set <device> dhcp | set <device> manual <ip> [prefix] [gateway] [dns]`.
  - Enumerates NM-managed ethernet devices only, resolves the active/bound NetworkManager profile, modifies IPv4 settings through `nmcli`, and reconnects/reapplies when a cable is present.
- `test/shell.d/network-eth-config-test.sh`
  - Stubs `nmcli` and covers list filtering (ethernet vs Wi-Fi vs unmanaged), DHCP mode, and manual static IPv4 mode.

## Scope

This PR intentionally only adds the wired static-IP feature. It preserves upstream features that already exist on `quattro`, including captive portal handling, DNS provider selection, Wi-Fi band selection, and the Wi-Fi network list. It does **not** include local personal customizations such as removing the DNS provider section.

## Verification

- `qmllint shell/plugins/panels/network/Panel.qml` passes.
- `./test/cli` passes, including metadata checks for the new `bin/omarchy-network-eth-config`.
- Network-related shell tests pass:
  - `test/shell.d/network-eth-config-test.sh`
  - `test/shell.d/network-test.sh`
  - `test/shell.d/network-qr-test.sh`
  - `test/shell.d/network-password-test.sh`
  - `test/shell.d/network-captive-portal-test.sh`
- `./test/shell` reports 4 pre-existing environment failures unrelated to this change (`bar-icon-geometry`, `config`, `snapper`, `unowned-system-paths`); these also fail on the clean `quattro` baseline without this branch.
- Visual verification was performed against the equivalent user-cloned widget on the same Omarchy desktop: the WIRED NIC section renders above Wi-Fi, and the DHCP/manual toggle reveals the static IP form.