### PR TITLE
Keep the Plymouth unlock entry field on-screen for large logos

### DIFF
--- a/bin/omarchy-plymouth-preview
+++ b/bin/omarchy-plymouth-preview
@@ -56,6 +56,10 @@ logo_x=$(( (canvas_w - logo_w) / 2 ))
 logo_y=$(( (canvas_h - logo_h) / 2 ))
 entry_x=$(( (canvas_w - entry_w) / 2 ))
 entry_y=$(( logo_y + logo_h + 40 ))
+entry_max_y=$(( canvas_h - entry_h - 40 ))
+if (( entry_y > entry_max_y )); then
+  entry_y=$entry_max_y
+fi
 lock_x=$(( entry_x - lock_w - 15 ))
 lock_y=$(( entry_y + entry_h/2 - lock_h/2 ))
 bullet_y=$(( entry_y + entry_h/2 - 4 ))

--- a/default/plymouth/omarchy.script
+++ b/default/plymouth/omarchy.script
@@ -110,6 +110,8 @@ bullet.image = Image("bullet.png");
 entry.sprite = Sprite(entry.image);
 entry.x = Window.GetWidth() / 2 - entry.image.GetWidth() / 2;
 entry.y = logo.sprite.GetY() + logo.image.GetHeight() + 40;
+entry_max_y = Window.GetHeight() - entry.image.GetHeight() - 40;
+if (entry.y > entry_max_y) entry.y = entry_max_y;
 entry.sprite.SetPosition(entry.x, entry.y, 10001);
 entry.sprite.SetOpacity(0);
 

--- a/migrations/1789203771.sh
+++ b/migrations/1789203771.sh
@@ -1,0 +1,11 @@
+echo "Rebuild the Plymouth theme into the initramfs so the entry-field clamp reaches the boot screen"
+
+# The LUKS prompt is drawn by Plymouth from inside the initramfs, not from the
+# on-disk theme, and no pacman hook rebuilds the image when usr/share/plymouth
+# changes. Without this, existing installs keep the old boot script until an
+# unrelated kernel or cryptsetup update happens to rebuild the image.
+#
+# omarchy-refresh-plymouth also reverts a custom unlock theme to the packaged
+# default (#6864); whether the delivery path should survive that is the
+# maintainer's call.
+omarchy-refresh-plymouth

--- a/test/shell.d/plymouth-entry-test.sh
+++ b/test/shell.d/plymouth-entry-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# The preview renders with ImageMagick and ends by opening the result in imv.
+# Neither is needed to assert the geometry, so skip when magick is absent and
+# stub imv so the command never opens a viewer.
+if ! command -v magick >/dev/null; then
+  pass "no magick; skipping plymouth entry field geometry test"
+  exit 0
+fi
+
+stub=$(mktemp -d)
+scratch=$(mktemp -d)
+printf '#!/bin/bash\nexit 0\n' >"$stub/imv"
+chmod +x "$stub/imv"
+export PATH="$stub:$PATH"
+export OMARCHY_PATH="$ROOT"
+trap 'rm -rf "$stub" "$scratch"' EXIT
+
+preview="$ROOT/bin/omarchy-plymouth-preview"
+
+# Renders a preview for a logo of the given size and prints the top edge (y) of
+# the bright pixels, which track the entry field's top. Prints nothing when there
+# are no bright pixels. Returns non-zero if the preview command itself fails.
+entry_top_y() {
+  local logo_w="$1" logo_h="$2"
+  local logo="$scratch/logo-${logo_w}x${logo_h}.png"
+  local out="$scratch/out-${logo_w}x${logo_h}.png"
+  magick -size "${logo_w}x${logo_h}" xc:black "$logo"
+  if ! "$preview" '#000000' '#ffffff' "$logo" "$out"; then
+    return 1
+  fi
+  local bbox
+  bbox=$(magick "$out" -threshold 50% -format '%[bounding-box]' info: 2>/dev/null) || bbox=""
+  [[ -n $bbox ]] || return 0
+  local top=${bbox#*,}
+  printf '%s\n' "${top%% *}"
+}
+
+assert_entry_top() {
+  local description="$1" logo_w="$2" logo_h="$3" min="$4" max="$5"
+  local y
+  if ! y=$(entry_top_y "$logo_w" "$logo_h"); then
+    fail "$description" "preview command failed for a ${logo_w}x${logo_h} logo"
+  fi
+  if [[ -n $y ]] && (( y >= min && y <= max )); then
+    pass "$description (entry top y=$y)"
+  else
+    fail "$description" "entry top y='${y:-none}', expected $min..$max"
+  fi
+}
+
+# A full-screen logo pushes the field below the window; the clamp keeps it 40px
+# above the bottom edge (1080 - 48 - 40 = 992) instead of off-screen at 1120.
+assert_entry_top "full-screen logo keeps the entry field on-screen" 1920 1080 985 1000
+
+# A small logo leaves the field below the logo, unclamped (440 + 200 + 40 = 680).
+assert_entry_top "small logo leaves the entry field below the logo" 200 200 675 690
+
+# The boot script applies the same clamp so the real unlock screen matches.
+script="$ROOT/default/plymouth/omarchy.script"
+grep -q 'entry_max_y = Window.GetHeight() - entry.image.GetHeight() - 40;' "$script" \
+  || fail "boot script clamps the entry field to the window"
+grep -q 'if (entry.y > entry_max_y) entry.y = entry_max_y;' "$script" \
+  || fail "boot script applies the entry field clamp"
+pass "boot script clamps the entry field to the window"


### PR DESCRIPTION
Fixes #10201

## Summary

The LUKS unlock entry field is positioned 40px below the logo's bottom edge with no clamping to the window bounds. When a full-screen logo (height == window height) is set via `omarchy plymouth set`, the field lands below the visible area, so only a sliver of its top shows and the unlock prompt is unusable.

## Changes

- `default/plymouth/omarchy.script`: clamp `entry.y` to the bottom of the window. This leaves the default (small-logo) layout unchanged and only kicks in for large logos.
- `bin/omarchy-plymouth-preview`: apply the same clamp so the preview matches the boot screen (previously the preview also dropped the field off-canvas for full-screen logos).

## Testing

- `./test/cli` passes.
- Rendered before/after below using a full-screen logo: before, the field is off the bottom of the screen; after, it sits 40px above the bottom edge, fully visible.

## Before / After

(before)
<img width="1920" height="1080" alt="pr-before" src="https://github.com/user-attachments/assets/34d58467-7356-4d2a-973e-477bf9cb688b" />

(after)
<img width="1920" height="1080" alt="pr-after" src="https://github.com/user-attachments/assets/937b3543-7f6b-453a-9e26-edaac7d7fdfd" />
