### PR TITLE
Register the Chromium native messaging hosts for Brave Origin

### DIFF
--- a/bin/omarchy-install-chromium-copy-url
+++ b/bin/omarchy-install-chromium-copy-url
@@ -16,6 +16,9 @@ browser_dirs=(
   "$HOME/.config/BraveSoftware/Brave-Browser"
   "$HOME/.config/BraveSoftware/Brave-Browser-Beta"
   "$HOME/.config/BraveSoftware/Brave-Browser-Nightly"
+  "$HOME/.config/BraveSoftware/Brave-Origin"
+  "$HOME/.config/BraveSoftware/Brave-Origin-Beta"
+  "$HOME/.config/BraveSoftware/Brave-Origin-Nightly"
   "$HOME/.config/microsoft-edge"
   "$HOME/.config/microsoft-edge-dev"
 )

--- a/bin/omarchy-install-chromium-ytdlp
+++ b/bin/omarchy-install-chromium-ytdlp
@@ -17,6 +17,9 @@ browser_dirs=(
   "$HOME/.config/BraveSoftware/Brave-Browser"
   "$HOME/.config/BraveSoftware/Brave-Browser-Beta"
   "$HOME/.config/BraveSoftware/Brave-Browser-Nightly"
+  "$HOME/.config/BraveSoftware/Brave-Origin"
+  "$HOME/.config/BraveSoftware/Brave-Origin-Beta"
+  "$HOME/.config/BraveSoftware/Brave-Origin-Nightly"
   "$HOME/.config/microsoft-edge"
   "$HOME/.config/microsoft-edge-dev"
 )

--- a/migrations/1788595060.sh
+++ b/migrations/1788595060.sh
@@ -1,0 +1,4 @@
+echo "Register the Chromium extension native messaging hosts for Brave Origin"
+
+omarchy-install-chromium-copy-url
+omarchy-install-chromium-ytdlp

--- a/test/shell.d/chromium-copy-url-test.sh
+++ b/test/shell.d/chromium-copy-url-test.sh
@@ -71,6 +71,10 @@ jq -e --arg path "$ROOT/bin/omarchy-chromium-copy-url-host" '
 ' "$native_manifest" >/dev/null || fail "copy-url native host manifest uses Omarchy host path and extension id"
 pass "copy-url native host installer registers the stable extension id"
 
+[[ -f $test_home/.config/BraveSoftware/Brave-Origin/NativeMessagingHosts/com.omarchy.copy_url.json ]] ||
+  fail "copy-url native host installer covers Brave Origin"
+pass "copy-url native host installer covers Brave Origin"
+
 # Chromium ships in the base packages, so fresh installs do not go through
 # omarchy-install-browser, and they mark every migration as already applied.
 # The user install still has to register the host itself.

--- a/test/shell.d/chromium-ytdlp-test.sh
+++ b/test/shell.d/chromium-ytdlp-test.sh
@@ -33,6 +33,10 @@ jq -e --arg path "$ROOT/bin/omarchy-chromium-ytdlp-host" '
 ' "$manifest_path" >/dev/null
 pass "yt-dlp native host manifest uses Omarchy host path and extension id"
 
+[[ -f $test_home/.config/BraveSoftware/Brave-Origin/NativeMessagingHosts/com.omarchy.ytdlp.json ]] ||
+  fail "yt-dlp native host installer covers Brave Origin"
+pass "yt-dlp native host installer covers Brave Origin"
+
 parse_result=$(bash -c '
   OMARCHY_PATH="$3"
   source "$1"


### PR DESCRIPTION
Brave Origin keeps its profile under `~/.config/BraveSoftware/Brave-Origin` rather than `Brave-Browser`, so `omarchy-install-chromium-copy-url` and `omarchy-install-chromium-ytdlp` never wrote their host manifests there. The Copy URL and Download Video extensions loaded fine, but Alt+Shift+L and Alt+Shift+D silently did nothing because `chrome.runtime.sendNativeMessage` had no host to talk to.

This adds the Brave Origin, Beta, and Nightly profile roots to both installers and reruns them through a migration so existing installs pick up the manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
