### PR TITLE
Support selecting installed Linux kernel in direct boot setup

### DIFF
--- a/bin/omarchy-setup-direct-boot
+++ b/bin/omarchy-setup-direct-boot
@@ -26,36 +26,87 @@ case "${bios_vendor,,}" in
     ;;
 esac
 
+format_kernel_name() {
+  local file="$1"
+  local name="${file%.efi}"
+  name="${name#omarchy_}"
+  name="${name#omarchy-}"
+  name=$(echo "$name" | sed -E 's/^[0-9a-f]{32}[_-]//')
+
+  if [[ $name =~ (.*)[_-]fallback$ ]]; then
+    echo "${BASH_REMATCH[1]} (fallback)"
+  else
+    echo "$name"
+  fi
+}
+
 existing_entry=$(efibootmgr | grep -E "^Boot[0-9A-Fa-f]+\*? Omarchy([[:space:]]|$)" | head -1)
+boot_num=""
 
 if [[ -n $existing_entry ]]; then
   boot_num=$(echo "$existing_entry" | sed -n 's/^Boot\([0-9A-Fa-f]\+\).*/\1/p')
 
-  if gum confirm "Disable direct boot (remove Omarchy EFI entry)?"; then
+  action=$(gum choose "Change kernel" "Disable direct boot" --header "Direct boot is currently enabled (Boot$boot_num)") || exit 0
+
+  if [[ $action == "Disable direct boot" ]]; then
     echo "Removing EFI boot entry $boot_num"
+    sudo efibootmgr --bootnum "$boot_num" --delete-bootnum >/dev/null
+    exit 0
+  fi
+fi
+
+mapfile -t uki_files < <(sudo find /boot/EFI/Linux/ -maxdepth 1 -name "omarchy*.efi" -printf "%f\n" 2>/dev/null | sort)
+if (( ${#uki_files[@]} == 0 )); then
+  mapfile -t uki_files < <(sudo find /boot/EFI/Linux/ -maxdepth 1 -name "*.efi" -printf "%f\n" 2>/dev/null | sort)
+fi
+
+if (( ${#uki_files[@]} == 0 )); then
+  echo "Error: No Omarchy UKI found in /boot/EFI/Linux/" >&2
+  exit 1
+fi
+
+if (( ${#uki_files[@]} == 1 )); then
+  selected_uki="${uki_files[0]}"
+  kernel_display=$(format_kernel_name "$selected_uki")
+else
+  options=()
+  default_choice=""
+  for file in "${uki_files[@]}"; do
+    kname=$(format_kernel_name "$file")
+    opt="$kname ($file)"
+    options+=("$opt")
+    if [[ -z $default_choice && $kname == "linux" ]]; then
+      default_choice="$opt"
+    fi
+  done
+
+  if [[ -z $default_choice ]]; then
+    default_choice="${options[0]}"
+  fi
+
+  choice=$(printf "%s\n" "${options[@]}" | gum choose --header "Select Linux kernel for direct boot:" --selected "$default_choice") || exit 0
+  selected_uki=$(echo "$choice" | sed -n 's/.*(\([^()]*\))$/\1/p')
+  if [[ -z $selected_uki ]]; then
+    selected_uki="$choice"
+  fi
+  kernel_display=$(format_kernel_name "$selected_uki")
+fi
+
+boot_source=$(findmnt -n -o SOURCE /boot)
+disk=$(echo "$boot_source" | sed 's/p\?[0-9]*$//')
+part=$(echo "$boot_source" | grep -o 'p\?[0-9]*$' | sed 's/^p//')
+
+if gum confirm "Setup direct boot with $kernel_display (so snapshot booting must be done via bios)?"; then
+  if [[ -n $boot_num ]]; then
+    echo "Removing existing EFI boot entry $boot_num"
     sudo efibootmgr --bootnum "$boot_num" --delete-bootnum >/dev/null
   fi
 
-  exit 0
-else
-  uki_file=$(sudo find /boot/EFI/Linux/ -name "omarchy*.efi" -printf "%f\n" 2>/dev/null | head -1)
+  echo "Creating EFI boot entry for $selected_uki"
 
-  if [[ -z $uki_file ]]; then
-    echo "Error: No Omarchy UKI found in /boot/EFI/Linux/" >&2
-    exit 1
-  fi
-
-  boot_source=$(findmnt -n -o SOURCE /boot)
-  disk=$(echo "$boot_source" | sed 's/p\?[0-9]*$//')
-  part=$(echo "$boot_source" | grep -o 'p\?[0-9]*$' | sed 's/^p//')
-
-  if gum confirm "Setup direct boot (so snapshot booting must be done via bios)?"; then
-    echo "Creating EFI boot entry for $uki_file"
-
-    sudo efibootmgr --create \
-      --disk "$disk" \
-      --part "$part" \
-      --label "Omarchy" \
-      --loader "\\EFI\\Linux\\$uki_file"
-  fi
+  sudo efibootmgr --create \
+    --disk "$disk" \
+    --part "$part" \
+    --label "Omarchy" \
+    --loader "\\EFI\\Linux\\$selected_uki"
 fi

--- a/bin/omarchy-setup-direct-boot
+++ b/bin/omarchy-setup-direct-boot
@@ -56,9 +56,6 @@ if [[ -n $existing_entry ]]; then
 fi
 
 mapfile -t uki_files < <(sudo find /boot/EFI/Linux/ -maxdepth 1 -name "omarchy*.efi" -printf "%f\n" 2>/dev/null | sort)
-if (( ${#uki_files[@]} == 0 )); then
-  mapfile -t uki_files < <(sudo find /boot/EFI/Linux/ -maxdepth 1 -name "*.efi" -printf "%f\n" 2>/dev/null | sort)
-fi
 
 if (( ${#uki_files[@]} == 0 )); then
   echo "Error: No Omarchy UKI found in /boot/EFI/Linux/" >&2

--- a/test/shell.d/setup-direct-boot-test.sh
+++ b/test/shell.d/setup-direct-boot-test.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+stub_bin="$test_dir/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+case "$1" in
+  choose)
+    if [[ -n ${STUB_GUM_CHOOSE:-} ]]; then
+      echo "$STUB_GUM_CHOOSE"
+      exit 0
+    fi
+    shift
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --header*|--selected*)
+          shift 2 2>/dev/null || shift 1
+          ;;
+        --*)
+          shift
+          ;;
+        *)
+          echo "$1"
+          exit 0
+          ;;
+      esac
+    done
+    head -n 1
+    ;;
+  confirm)
+    [[ ${STUB_GUM_CONFIRM:-1} == 1 ]]
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+STUB
+
+cat >"$stub_bin/efibootmgr" <<'STUB'
+#!/bin/bash
+printf 'efibootmgr %s\n' "$*" >>"${CALL_LOG:?}"
+if [[ -n ${STUB_EFIBOOTMGR_ENTRIES:-} ]]; then
+  printf '%s\n' "$STUB_EFIBOOTMGR_ENTRIES"
+else
+  printf 'BootCurrent: 0000\nBootOrder: 0000\nBoot0000* EFI Hard Drive\n'
+fi
+STUB
+
+cat >"$stub_bin/findmnt" <<'STUB'
+#!/bin/bash
+echo "/dev/nvme0n1p1"
+STUB
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"${CALL_LOG:?}"
+case "$1" in
+  find)
+    shift
+    if [[ -d "${FAKE_BOOT_DIR:-}" ]]; then
+      /usr/bin/find "$FAKE_BOOT_DIR" "${@:2}"
+    else
+      exit 0
+    fi
+    ;;
+  efibootmgr)
+    shift
+    efibootmgr "$@"
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac
+STUB
+
+chmod +x "$stub_bin"/*
+
+fake_boot="$test_dir/boot/EFI/Linux"
+mkdir -p "$fake_boot"
+
+run_direct_boot() {
+  local scenario="$1"
+  : >"$test_dir/$scenario.calls"
+
+  CALL_LOG="$test_dir/$scenario.calls" \
+    FAKE_BOOT_DIR="$fake_boot" \
+    TEST_DIR="$test_dir" \
+    STUB_GUM_CHOOSE="${STUB_GUM_CHOOSE:-}" \
+    STUB_GUM_CONFIRM="${STUB_GUM_CONFIRM:-1}" \
+    STUB_EFIBOOTMGR_ENTRIES="${STUB_EFIBOOTMGR_ENTRIES:-}" \
+    PATH="$stub_bin:$PATH" \
+    bash "$ROOT/bin/omarchy-setup-direct-boot"
+}
+
+# Test 1: Error when no UKIs found
+if run_direct_boot no_uki >"$test_dir/no_uki.out" 2>&1; then
+  fail "direct boot setup must fail when no UKI files are found"
+fi
+grep -q "No Omarchy UKI found" "$test_dir/no_uki.out" || fail "reports missing UKI error"
+pass "direct boot setup errors when no UKIs exist"
+
+# Test 2: Single kernel UKI auto-selected and created
+touch "$fake_boot/omarchy_linux.efi"
+output=$(run_direct_boot single_kernel)
+grep -q "Creating EFI boot entry for omarchy_linux.efi" <<<"$output" || fail "creates EFI boot entry for single kernel"
+grep -q "efibootmgr --create --disk /dev/nvme0n1 --part 1 --label Omarchy --loader \\\\EFI\\\\Linux\\\\omarchy_linux.efi" "$test_dir/single_kernel.calls" || fail "calls efibootmgr create correctly"
+pass "direct boot setup configures entry for single kernel"
+
+# Test 3: Multiple kernels available, user selects cachyos kernel
+touch "$fake_boot/omarchy_linux-cachyos-bore.efi"
+touch "$fake_boot/omarchy_linux-lts.efi"
+
+STUB_GUM_CHOOSE="linux-cachyos-bore (omarchy_linux-cachyos-bore.efi)" output=$(run_direct_boot multi_kernel)
+grep -q "Creating EFI boot entry for omarchy_linux-cachyos-bore.efi" <<<"$output" || fail "creates EFI boot entry for chosen cachyos kernel"
+grep -q "efibootmgr --create --disk /dev/nvme0n1 --part 1 --label Omarchy --loader \\\\EFI\\\\Linux\\\\omarchy_linux-cachyos-bore.efi" "$test_dir/multi_kernel.calls" || fail "calls efibootmgr create with selected kernel UKI"
+pass "direct boot setup allows choosing specific kernel among multiple installed kernels"
+
+# Test 4: Existing entry - Disable direct boot
+STUB_EFIBOOTMGR_ENTRIES="Boot0005* Omarchy HD(1,GPT,...)" STUB_GUM_CHOOSE="Disable direct boot" output=$(run_direct_boot disable_existing)
+grep -q "Removing EFI boot entry 0005" <<<"$output" || fail "removes EFI boot entry when disabling"
+grep -q "efibootmgr --bootnum 0005 --delete-bootnum" "$test_dir/disable_existing.calls" || fail "calls efibootmgr delete-bootnum"
+pass "direct boot setup disables existing direct boot entry"
+
+# Test 5: Existing entry - Change kernel
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+case "$1" in
+  choose)
+    state_file="${TEST_DIR:-/tmp}/gum_choose_state"
+    if [[ ! -f $state_file ]]; then
+      echo 1 >"$state_file"
+      echo "Change kernel"
+    else
+      echo "linux-lts (omarchy_linux-lts.efi)"
+    fi
+    ;;
+  confirm)
+    [[ ${STUB_GUM_CONFIRM:-1} == 1 ]]
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+STUB
+chmod +x "$stub_bin/gum"
+
+STUB_EFIBOOTMGR_ENTRIES="Boot0005* Omarchy HD(1,GPT,...)" output=$(run_direct_boot change_kernel)
+grep -q "Removing existing EFI boot entry 0005" <<<"$output" || fail "removes old entry when changing kernel"
+grep -q "Creating EFI boot entry for omarchy_linux-lts.efi" <<<"$output" || fail "creates new entry for changed kernel"
+grep -q "efibootmgr --bootnum 0005 --delete-bootnum" "$test_dir/change_kernel.calls" || fail "deletes old bootnum"
+grep -q "efibootmgr --create --disk /dev/nvme0n1 --part 1 --label Omarchy --loader \\\\EFI\\\\Linux\\\\omarchy_linux-lts.efi" "$test_dir/change_kernel.calls" || fail "creates new entry"
+pass "direct boot setup supports changing kernel on existing direct boot configuration"

--- a/test/shell.d/setup-direct-boot-test.sh
+++ b/test/shell.d/setup-direct-boot-test.sh
@@ -107,6 +107,15 @@ fi
 grep -q "No Omarchy UKI found" "$test_dir/no_uki.out" || fail "reports missing UKI error"
 pass "direct boot setup errors when no UKIs exist"
 
+# Test 1b: Error when only non-Omarchy EFI files exist
+touch "$fake_boot/custom_loader.efi"
+if run_direct_boot non_omarchy_efi >"$test_dir/non_omarchy_efi.out" 2>&1; then
+  fail "direct boot setup must fail when only non-Omarchy EFI files exist"
+fi
+grep -q "No Omarchy UKI found" "$test_dir/non_omarchy_efi.out" || fail "reports missing UKI error for non-Omarchy EFI"
+rm -f "$fake_boot/custom_loader.efi"
+pass "direct boot setup ignores non-Omarchy EFI files"
+
 # Test 2: Single kernel UKI auto-selected and created
 touch "$fake_boot/omarchy_linux.efi"
 output=$(run_direct_boot single_kernel)


### PR DESCRIPTION
Previously, `omarchy-setup-direct-boot` picked the first UKI it found matching `omarchy*.efi` (`head -1`), always configuring the standard `linux` kernel even when alternative kernels (such as `linux-cachyos-bore`, `linux-lts`, `linux-zen`, etc.) were installed on the system.

This update allows users to choose which installed Linux kernel UKI to boot directly:
- Discovers all available UKIs in `/boot/EFI/Linux/` and presents them via `gum choose` with clean, human-friendly kernel labels.
- Preselects the default `linux` kernel when present.
- Smoothly handles existing direct boot configurations: offers to change kernel or disable direct boot, cleanly replacing the old EFI boot entry.
- Safely aborts without modifying the system if cancelled.
- Adds comprehensive automated tests in `test/shell.d/setup-direct-boot-test.sh`.

## Screenshots

| Before (Hardcoded First UKI) | After (Kernel Selection) | After (Managing Existing Direct Boot) |
|---|---|---|
| ![Before](https://raw.githubusercontent.com/melihemik/omarchy/screenshots/old.png) | ![After - Kernel Selection](https://raw.githubusercontent.com/melihemik/omarchy/screenshots/new.png) | ![After - Reconfigure](https://raw.githubusercontent.com/melihemik/omarchy/screenshots/new2.png) |

## Test plan

- `bash test/shell.d/setup-direct-boot-test.sh` — verified no-UKI error handling, single kernel auto-detection, multiple kernel selection, disabling direct boot, and updating existing EFI boot entry.
- `bash test/cli` — verified all CLI tests, routing, and metadata pass.
- Verified on a live UEFI system by creating and verifying the direct boot EFI entry with `efibootmgr`.