### PR TITLE
feat(menu): inline calculator in search

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -645,7 +645,29 @@ Item {
       if (root.searchDivider) {
         for (var d = 0; d < drilldownRows.length; d++) drilldownRows[d].section = "drilldown"
       }
+      var calcResult = MenuModel.calcResultForQuery(query)
       rows = currentRows.concat(drilldownRows)
+      if (calcResult) {
+        var calcText = calcResult.text
+        rows.unshift({
+          itemId: "calc",
+          disabled: false,
+          kind: "action",
+          icon: "",
+          iconFont: "",
+          appIcon: "",
+          appId: "",
+          label: calcText,
+          target: "calc",
+          detail: "",
+          path: "",
+          childCount: 0,
+          action: "printf '%s' " + Util.shellQuote(calcText) + " | wl-copy",
+          provider: "",
+          score: 0,
+          section: ""
+        })
+      }
     } else {
       for (var j = 0; j < root.itemOrder.length; j++) {
         var child = root.item(root.itemOrder[j])
@@ -1265,6 +1287,7 @@ Item {
               readonly property bool hasCursor: root.cursorActive && row.index === root.selectedIndex
               readonly property bool isApp: row.kind === "app"
               readonly property bool hasIcon: row.icon.length > 0 || row.isApp
+              readonly property bool isCalc: row.itemId === "calc"
 
               width: ListView.view.width
               height: root.rowHeightForDetail(row.detail)
@@ -1333,6 +1356,7 @@ Item {
                   textFormat: Text.PlainText
                   width: parent.width
                   text: row.label
+                  horizontalAlignment: row.isCalc ? Text.AlignHCenter : Text.AlignLeft
                   color: row.hasCursor ? root.selectedText : root.foreground
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.heading
@@ -1357,7 +1381,7 @@ Item {
                 id: trail
                 width: Style.space(14)
                 anchors.right: parent.right
-                anchors.rightMargin: root.rowReservedBorderRight + Style.space(8)
+                anchors.rightMargin: root.rowReservedBorderRight + Style.space(8) + (row.isCalc ? Style.space(8) : 0)
                 y: contentColumn.y + labelText.y + (labelText.height - height) / 2
                 spacing: 0
 
@@ -1374,9 +1398,9 @@ Item {
 
                 Text {
                   textFormat: Text.PlainText
-                  text: row.kind === "menu" || row.kind === "link" ? "›" : ""
+                  text: row.kind === "menu" || row.kind === "link" ? "›" : (row.isCalc ? "\uf0c5" : "")
                   color: row.hasCursor ? root.selectedText : root.foreground
-                  opacity: row.kind === "menu" || row.kind === "link" ? 0.36 : 0
+                  opacity: row.kind === "menu" || row.kind === "link" ? 0.36 : (row.isCalc ? 0.55 : 0)
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.heading
                   font.weight: Font.Normal

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -384,6 +384,172 @@ function displayRow(items, itemOrder, checkedResults, disabledResults, entry, de
   }
 }
 
+// Inline calculator for menu search. The tokenizer and the recursive-descent
+// parser below are written from scratch for the menu: `+ - * /`, `x`/`X` and
+// the multiplication/division glyphs (\u00d7 \u00f7), parentheses, unary signs,
+// decimals with `.` only (`,` invalidates all), juxtaposition (`2(3)`), and
+// postfix `%` (`50%` -> 0.5, `5%200` -> 10).
+
+function calcTokenize(text) {
+  var tokens = []
+  var i = 0
+  while (i < text.length) {
+    var c = text.charAt(i)
+    if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+      i += 1
+      continue
+    }
+    if (c === "(" || c === ")" || c === "+" || c === "-" || c === "*" || c === "/" || c === "x" || c === "X" || c === "\u00d7" || c === "\u00f7" || c === "%") {
+      tokens.push(c === "x" || c === "X" ? "*" : c)
+      i += 1
+      continue
+    }
+    var match = text.slice(i).match(/^(?:\d+(?:\.\d*)?|\.\d+)/)
+    if (match) {
+      tokens.push({ value: parseFloat(match[0]) })
+      i += match[0].length
+      continue
+    }
+    return null
+  }
+  return tokens
+}
+
+function calcParse(tokens) {
+  var pos = 0
+  var hasOp = false
+
+  function peek() {
+    return pos < tokens.length ? tokens[pos] : null
+  }
+
+  function next() {
+    var token = tokens[pos]
+    pos += 1
+    return token
+  }
+
+  function parseExpr() {
+    var value = parseTerm()
+    if (value === null) return null
+    for (;;) {
+      var op = peek()
+      if (op !== "+" && op !== "-") return value
+      next()
+      var rhs = parseTerm()
+      if (rhs === null) return null
+      hasOp = true
+      value = op === "+" ? value + rhs : value - rhs
+    }
+  }
+
+  function parseTerm() {
+    var value = parseFactor()
+    if (value === null) return null
+    for (;;) {
+      var op = peek()
+      // Juxtaposition multiplies, like phone calculators: 5%200 is 10.
+      // Never number-on-number, so 1.2.3 stays invalid.
+      var prev = pos > 0 ? tokens[pos - 1] : null
+      var opNum = op !== null && typeof op === "object"
+      var prevNum = prev !== null && typeof prev === "object"
+      var implicit = (opNum || op === "(")
+        && (prevNum || prev === ")" || prev === "%")
+        && !(opNum && prevNum)
+      if (!implicit && op !== "*" && op !== "/" && op !== "\u00d7" && op !== "\u00f7") return value
+      if (!implicit) next()
+      var rhs = parseFactor()
+      if (rhs === null) return null
+      hasOp = true
+      if (implicit || op === "*" || op === "\u00d7") value = value * rhs
+      else value = value / rhs
+    }
+  }
+
+  function parseFactor() {
+    var op = peek()
+    if (op === "+" || op === "-") {
+      next()
+      var value = parseFactor()
+      if (value === null) return null
+      return op === "-" ? -value : value
+    }
+    return parsePrimary()
+  }
+
+  function parsePrimary() {
+    var token = peek()
+    var value = null
+    if (token !== null && typeof token === "object") {
+      next()
+      value = token.value
+    } else if (token === "(") {
+      next()
+      value = parseExpr()
+      if (value === null || peek() !== ")") return null
+      next()
+    } else {
+      return null
+    }
+    while (peek() === "%") {
+      next()
+      value = value / 100
+      hasOp = true
+    }
+    return value
+  }
+
+  var value = parseExpr()
+  if (value === null) return null
+  if (pos !== tokens.length) return null
+  if (!hasOp) return null
+  if (typeof value !== "number" || !isFinite(value)) return null
+  return value
+}
+
+// Evaluates an arithmetic expression to a finite Number. Returns null for
+// anything that is not a complete calculation: empty input, a lone number
+// with no operator, unknown characters, trailing garbage, unbalanced
+// parentheses, or a non-finite result such as division by zero.
+function calcEvaluate(text) {
+  var input = String(text === null || text === undefined ? "" : text)
+  if (!input.trim()) return null
+  if (input.indexOf(",") >= 0) return null
+  var tokens = calcTokenize(input)
+  if (!tokens) return null
+  try {
+    return calcParse(tokens)
+  } catch (e) {
+    return null
+  }
+}
+
+// Formats a result for display: integers below 1e15 print as themselves,
+// else gets 15 significant digits (all a double can be trusted with), padding
+// zeros stripped: 0.1 + 0.2 reads "0.3" instead of "0.30000000000000004".
+function calcFormat(value) {
+  if (typeof value !== "number" || !isFinite(value)) return ""
+  if (Math.abs(value) < 1e15 && Math.floor(value) === value) return String(value)
+  var parts = value.toPrecision(15).split("e")
+  var mantissa = parts[0]
+  if (mantissa.indexOf(".") >= 0) mantissa = mantissa.replace(/0+$/, "").replace(/\.$/, "")
+  if (mantissa === "-0") mantissa = "0"
+  return parts.length > 1 ? mantissa + "e" + parts[1] : mantissa
+}
+
+// Resolves a menu search query to a calculator result row payload, or null
+// when the query is not a calculation: empty, a lone number, or anything
+// with commas or trailing garbage. Letters other than `x` die in the
+// tokenizer, so "firefox" stays a plain search.
+function calcResultForQuery(query) {
+  var text = String(query === null || query === undefined ? "" : query).trim()
+  if (!text) return null
+  if (text.indexOf(",") >= 0) return null
+  var value = calcEvaluate(text)
+  if (value === null) return null
+  return { text: calcFormat(value) }
+}
+
 // Commands a `checked:` expression reads a value out of. Every sibling row
 // asks the same one -- Defaults > Browser has seven rows all comparing
 // against `omarchy-default-browser` -- so the batch runs it once and the rows
@@ -519,6 +685,9 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
-    displayRow: displayRow
+    displayRow: displayRow,
+    calcEvaluate: calcEvaluate,
+    calcFormat: calcFormat,
+    calcResultForQuery: calcResultForQuery
   }
 }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -384,12 +384,6 @@ function displayRow(items, itemOrder, checkedResults, disabledResults, entry, de
   }
 }
 
-// Inline calculator for menu search. The tokenizer and the recursive-descent
-// parser below are written from scratch for the menu: `+ - * /`, `x`/`X` and
-// the multiplication/division glyphs (\u00d7 \u00f7), parentheses, unary signs,
-// decimals with `.` only (`,` invalidates all), juxtaposition (`2(3)`), and
-// postfix `%` (`50%` -> 0.5, `5%200` -> 10).
-
 function calcTokenize(text) {
   var tokens = []
   var i = 0
@@ -448,8 +442,6 @@ function calcParse(tokens) {
     if (value === null) return null
     for (;;) {
       var op = peek()
-      // Juxtaposition multiplies, like phone calculators: 5%200 is 10.
-      // Never number-on-number, so 1.2.3 stays invalid.
       var prev = pos > 0 ? tokens[pos - 1] : null
       var opNum = op !== null && typeof op === "object"
       var prevNum = prev !== null && typeof prev === "object"
@@ -507,10 +499,6 @@ function calcParse(tokens) {
   return value
 }
 
-// Evaluates an arithmetic expression to a finite Number. Returns null for
-// anything that is not a complete calculation: empty input, a lone number
-// with no operator, unknown characters, trailing garbage, unbalanced
-// parentheses, or a non-finite result such as division by zero.
 function calcEvaluate(text) {
   var input = String(text === null || text === undefined ? "" : text)
   if (!input.trim()) return null
@@ -524,9 +512,6 @@ function calcEvaluate(text) {
   }
 }
 
-// Formats a result for display: integers below 1e15 print as themselves,
-// else gets 15 significant digits (all a double can be trusted with), padding
-// zeros stripped: 0.1 + 0.2 reads "0.3" instead of "0.30000000000000004".
 function calcFormat(value) {
   if (typeof value !== "number" || !isFinite(value)) return ""
   if (Math.abs(value) < 1e15 && Math.floor(value) === value) return String(value)
@@ -537,10 +522,6 @@ function calcFormat(value) {
   return parts.length > 1 ? mantissa + "e" + parts[1] : mantissa
 }
 
-// Resolves a menu search query to a calculator result row payload, or null
-// when the query is not a calculation: empty, a lone number, or anything
-// with commas or trailing garbage. Letters other than `x` die in the
-// tokenizer, so "firefox" stays a plain search.
 function calcResultForQuery(query) {
   var text = String(query === null || query === undefined ? "" : query).trim()
   if (!text) return null

--- a/test/shell.d/menu-calc-test.sh
+++ b/test/shell.d/menu-calc-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+
+const calcText = query => {
+  const result = menu.calcResultForQuery(query)
+  return result && result.text
+}
+
+assertEqual(calcText('2+3'), '5', 'menu calculates addition')
+assertEqual(calcText('10-4'), '6', 'menu calculates subtraction')
+assertEqual(calcText('6*7'), '42', 'menu calculates multiplication')
+assertEqual(calcText('54000*2'), '108000', 'menu calculates a large multiplication')
+assertEqual(calcText('8/2'), '4', 'menu calculates division')
+assertEqual(calcText('2+3*4'), '14', 'menu respects operator precedence')
+assertEqual(calcText('(2+3)*4'), '20', 'menu evaluates parentheses')
+assertEqual(calcText('-5+3'), '-2', 'menu applies a leading unary sign')
+assertEqual(calcText('3\u00d74'), '12', 'menu multiplies with the × glyph')
+assertEqual(calcText('8\u00f72'), '4', 'menu divides with the ÷ glyph')
+assertEqual(calcText('2.5*2'), '5', 'menu calculates decimals')
+assertEqual(calcText('0.1+0.2'), '0.3', 'menu formats 0.1+0.2 without float noise')
+    assertEqual(calcText('6x6'), '36', 'menu multiplies with x')
+    assertEqual(calcText('50%'), '0.5', 'menu reads a lone percent as a fraction')
+    assertEqual(calcText('5%200'), '10', 'menu reads juxtaposed percent as percent-of')
+    assertEqual(calcText('2(3+4)'), '14', 'menu multiplies a juxtaposed parenthesis')
+    assertEqual(calcText('1.2.3'), null, 'menu rejects number-on-number juxtaposition')
+    assertEqual(calcText('5 5'), null, 'menu rejects two numbers side by side')
+
+assertEqual(menu.calcResultForQuery('3,5*2'), null, 'menu rejects a comma decimal separator')
+assertEqual(menu.calcResultForQuery('1500abc'), null, 'menu rejects trailing garbage')
+assertEqual(menu.calcResultForQuery('42'), null, 'menu rejects a lone number with no operator')
+assertEqual(menu.calcResultForQuery(''), null, 'menu rejects an empty query')
+assertEqual(menu.calcResultForQuery('1/0'), null, 'menu rejects division by zero')
+assertEqual(menu.calcResultForQuery('(2+3'), null, 'menu rejects unbalanced parentheses')
+assertEqual(menu.calcResultForQuery('firefox'), null, 'menu leaves a plain word search alone')
+
+assert(
+  /var calcResult = MenuModel\.calcResultForQuery\(query\)\s*\n\s*rows = currentRows\.concat\(drilldownRows\)\s*\n\s*if \(calcResult\) \{/.test(menuQml),
+  'menu evaluates the calculator after sorting search rows and before showing them'
+)
+assert(
+  /rows\.unshift\(\{\s*\n\s*itemId: "calc",\s*\n\s*disabled: false,\s*\n\s*kind: "action",\s*\n\s*icon: "",/.test(menuQml),
+  'menu prepends the calculator row without a leading icon'
+)
+assert(
+  /label: calcText,/.test(menuQml)
+    && /detail: "",/.test(menuQml)
+    && /action: "printf '%s' " \+ Util\.shellQuote\(calcText\) \+ " \| wl-copy",/.test(menuQml),
+  'menu labels the calculator row with its result and copies it through wl-copy'
+)
+assert(
+  /horizontalAlignment: row\.isCalc \? Text\.AlignHCenter : Text\.AlignLeft/.test(menuQml)
+    && /row\.isCalc \? "\\uf0c5" : ""\)/.test(menuQml),
+  'menu centers the calculator result and keeps a copy glyph on the right'
+    )
+    assert(
+      /rowReservedBorderRight \+ Style\.space\(8\) \+ \(row\.isCalc \? Style\.space\(8\) : 0\)/.test(menuQml),
+      'menu gives the calculator copy glyph extra right margin'
+    )
+JS


### PR DESCRIPTION
Spotlight-style calculator in the menu search: type an arithmetic expression and the result comes first, so the quick-sums case never needs a calculator app. `3000*36` gives `108000`; Enter copies the bare result through wl-copy and closes the menu. Anything that is not a calculation searches exactly like before.
Supports `+ - * /`, `x`/`X`/`×`, `÷`, parentheses, unary signs, `.` decimals, juxtaposition (`2(3)`), and postfix `%` (`50%` gives `0.5`, `5%200` gives `10`). Commas, lone numbers, letters, trailing garbage, unbalanced parentheses, and division by zero stay plain searches.
Why in core instead of a plugin: the menu has no per-keystroke extension point (search never re-runs providers, and the provider table is hardcoded), so a plugin can only do this by forking Menu.qml whole, freezing the menu at that version and losing upstream updates. A small core addition keeps working across updates.
Related: #8537 explores the same need as a general query-plugin framework; this is the minimal alternative scoped to the calculator, with no framework, no config files, no subprocess per keystroke, and no new dependencies (wl-clipboard already ships in the base set).
| File | Change |
|------|--------|
| `shell/plugins/menu/MenuModel.js` | Calculator tokenizer, parser, formatter, and query resolver (pure, Node-tested) |
| `shell/plugins/menu/Menu.qml` | Prepend the centered calc row with trailing copy glyph in rebuildDisplay |
| `test/shell.d/menu-calc-test.sh` | 30 asserts: operations, precedence, rejections, row shape |
Test plan: new suite 30/30 plus the existing menu suites green; `./test/shell` shows only the three pre-existing environmental failures that need a sibling omarchy-pkgs checkout; verified live in the running shell (result first and centered, Enter copies and closes).


[![Calculator demo: type 12x12, result first and centered](https://github.com/aragi-dev/omarchy/releases/download/pr-10294-evidence/pr-menu-calc.png)](https://github.com/aragi-dev/omarchy/releases/download/pr-10294-evidence/pr-menu-calc-demo.mp4)
Demo video (26s, click the image above): open the menu, type `12x12`, the centered `144` row comes first, Enter copies it and closes.

https://github.com/user-attachments/assets/e1ed3d0e-0b7c-4115-8f2d-a2c467d915fb