### PR TITLE
Keep notification dismiss buttons visible and clear of text

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -18,7 +18,8 @@ A toast lives on screen for at least 5s (low), 8s (normal), or forever
 (critical), stretched up to 30s if the sender asked for a longer
 `expire_timeout`. Hovering pauses the countdown, and a content update restarts
 it — new text deserves a full look. Left-click invokes the default action,
-right-click or the hover-revealed close button dismisses.
+right-click or the always-visible close button dismisses without invoking an action.
+The close button occupies its own space beside the text, including on compact single-line toasts, so long summaries cannot paint underneath it.
 
 Every on-screen popup is mirrored to its own file under
 `~/.local/state/omarchy/notifications/` (one JSON line per file, named

--- a/manual/10-notices.md
+++ b/manual/10-notices.md
@@ -2,6 +2,10 @@
 
 You can quickly access the date and time, battery status, and current weather using the hotkey notices.
 
+### Dismissing Notifications
+
+Click the **✕** button on a notification to dismiss it without opening the app or running its action. You can also right-click anywhere on the notification to dismiss it. Left-clicking the notification text keeps its usual action.
+
 ### Date & Time
 
 `Super + Ctrl + Alt + T`

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -192,36 +192,22 @@ BorderSurface {
           maximumLineCount: 3
         }
       }
-    }
-  }
 
-  // Hover-revealed close. Stacked after mainColumn so its MouseArea sits
-  // above the full-card one and the click never reaches cardClicked.
-  Item {
-    anchors.top: parent.top
-    anchors.right: parent.right
-    anchors.topMargin: root.borderTop + Style.space(3)
-    anchors.rightMargin: root.borderRight + Style.space(3)
-    width: Style.space(18)
-    height: Style.space(18)
-    visible: opacity > 0
-    opacity: root.hovered ? 1 : 0
-
-    Behavior on opacity { NumberAnimation { duration: 100 } }
-
-    Text {
-      anchors.centerIn: parent
-      text: "✕"
-      color: closeArea.containsMouse ? Color.notifications.text : root.dimColor
-      font.pixelSize: Math.round(Style.font.caption * 1.44)
-    }
-
-    MouseArea {
-      id: closeArea
-      anchors.fill: parent
-      hoverEnabled: true
-      cursorShape: Qt.PointingHandCursor
-      onClicked: root.closeRequested()
+      // Keep dismissal discoverable and reserve its space beside the text.
+      // This button consumes the click before the full-card action MouseArea.
+      PanelActionButton {
+        Layout.alignment: root.singleLineToast ? Qt.AlignVCenter : Qt.AlignTop
+        Layout.leftMargin: root.collapseRedundantIcon ? Style.space(8) : 0
+        size: Style.space(24)
+        iconText: "✕"
+        fontFamily: "Liberation Sans"
+        fontSize: Style.font.title
+        foreground: Color.notifications.text
+        tooltipText: "Dismiss notification"
+        Accessible.role: Accessible.Button
+        Accessible.name: tooltipText
+        onClicked: root.closeRequested()
+      }
     }
   }
 


### PR DESCRIPTION
A notification with a default action needs a discoverable way to dismiss it without opening the app or running that action. The current close control appears only on hover and floats over the card's text area.

This makes the close control always visible using the shared `PanelActionButton`, with a 24px scaled hit target, notification text color, and a “Dismiss notification” tooltip and accessible name. The button sits in the content layout, so long summaries and bodies reserve space for it. Compact toasts vertically center it; multiline cards align it to the top. Clicking it emits only `closeRequested`; card clicks and right-click dismissal retain their existing behavior. The notification reference and user manual describe the control.

Related proposals: #8980 and #9010. This overlaps their visibility goal and also reserves layout space for the control so it cannot overlap the notification text.

### Visual verification

Installed and exercised as a cloned user notification plugin on Omarchy 4.0.2-1, using the same changed `NotificationCard.qml`. Inspected compact, multiline, and long-title notifications with an icon for clipping and overlap.

Before on the installed 4.0.2-1 notification card (which has no close button):

![Before](https://raw.githubusercontent.com/rookepoole/omarchy/notification-dismiss-previews-20260905/notification-before.png)

After, with the pointer away from the card:

![After](https://raw.githubusercontent.com/rookepoole/omarchy/notification-dismiss-previews-20260905/notification-after.png)

### Validation

- Passed `test/shell.d/notifications-test.sh`, `test/shell.d/notification-send-test.sh`, `test/shell.d/qml-text-format-test.sh`, and `git diff --check`.
- Live pointer test: clicking the close button removed and archived an actionable test notification without creating its action's marker file.
- Live pointer test: clicking the card text still created its action marker; right-click dismissed the card; the close button also dismissed a compact toast without invoking its action.
- Ran `./test/all`: CLI passed; 221 of 226 shell test files passed. All five failing test files also failed on an untouched archive of upstream commit `e8e92c5`: `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` require an `omarchy-pkgs` checkout; `launch-about-test.sh` fails “a roomy window animates”; `network-qr-test.sh` exits after its initial two passing cases in this environment.
