### PR TITLE
Prevent screensaver fullscreen from transferring to other windows

### DIFF
--- a/default/hypr/looknfeel.lua
+++ b/default/hypr/looknfeel.lua
@@ -107,7 +107,8 @@ hl.config({
     disable_scale_notification = true,
     focus_on_activate = true,
     anr_missed_pings = 3,
-    on_focus_under_fullscreen = 1,
+    -- Leave fullscreen when focus moves away, rather than passing it to the next window.
+    on_focus_under_fullscreen = 2,
     initial_workspace_tracking = 0,
     -- Let a fresh shell re-acquire the session lock after the lock client
     -- died, so omarchy-restart-shell can recover the LOCK failsafe.


### PR DESCRIPTION
Returning focus from Omarchy's fullscreen screensaver to an existing tiled application can make that application fullscreen. With `misc.on_focus_under_fullscreen = 1`, Hyprland deliberately transfers the old window's fullscreen mode to the newly focused window.

Set the default to `2`, which exits fullscreen when focus moves to another window. This applies to all ordinary focus changes, including leaving intentionally fullscreen applications; explicit fullscreen shortcuts remain available.

Verified on Omarchy 4.0.1 with Hyprland 0.56.2 and the scrolling layout:

- Start with a normal tiled application, `fullscreen=0`, `fullscreenClient=0`.
- Launch the stock screensaver and confirm its windows are floating and fullscreen.
- Return focus to the original application with `hl.dsp.focus({window=...})` before the screensaver exits.
- With the old setting, the application becomes `fullscreen=2`, `fullscreenClient=2`.
- With the new setting, it remains `fullscreen=0`, `fullscreenClient=0` and retains its original column width.

The installed configuration reloads without errors, `luac -p` passes for this file, and the resulting normal tiled window was visually checked. `test/shell.d/config-test.sh` could not start on the headless controller because `jq` is unavailable there; no full automated suite pass is claimed.
