### PR TITLE
Add Ollama stats bar widget: context window, speeds, and TTFT for the local model

### DIFF
--- a/bin/omarchy-ollama-context-watch
+++ b/bin/omarchy-ollama-context-watch
@@ -1,0 +1,696 @@
+#!/usr/bin/python3
+# omarchy:summary=Watch the local Ollama model and keep live stats for the bar widget
+# omarchy:hidden=true
+"""Tail the ollama systemd journal and keep a live JSON snapshot of context-
+window usage, for the omarchy.ollama-stats bar widget to read.
+
+Written state (atomic replace) at $XDG_STATE_HOME/omarchy/ollama-context-watch/state.json:
+
+  {
+    "updatedAt": ISO8601,
+    "modelLoaded": "qwen3.8:27b" | null,
+    "configuredMax": 196608 | null,
+    "phase": "idle" | "prefill" | "generating",
+    "prefillProgress": {"nTokens": int, "percent": float} | null,
+    "contextPos": int | null,        # absolute position NOW (live while generating)
+    "contextPeak": int | null,       # highest absolute position reached since the model loaded
+    "lastPromptTokens": int | null,  # absolute position at the END of last finished request
+    "lastPercent": float | null,      # lastPromptTokens / configuredMax
+    # contextPos is the live absolute offset in the window; lastPromptTokens
+    # is the same figure at the end of the last finished request. Both are
+    # absolute — they must NOT come from "prompt eval time", which reports
+    # only the NEW delta of a request when a prefix was already cached.
+    # contextPeak is the high-water mark of contextPos since the model was
+    # loaded: it only ever increases, and resets when ollama unloads/reloads
+    # the model. The widget shows the peak so that stray requests on other
+    # conversation lineages (which genuinely shrink the single slot's usage)
+    # don't make the meter bounce around.
+    "lastTokensPerSec": float | null, # average decode speed of the last finished generation
+    "liveTokensPerSec": float | null, # tg_3s from the in-flight generation, ~1 update / 3 s
+    "maxTokensPerSec": float | null,  # fastest decode speed seen since the model loaded
+    "lastPrefillTokensPerSec": float | null, # whole-prefill average from the "prompt eval time" line
+    "livePrefillTokensPerSec": float | null, # ingest speed between two "prompt processing" progress lines
+    "maxPrefillTokensPerSec": float | null,  # fastest ingest speed seen since the model loaded
+    "ttftLastMs": float | null,       # time from request start to first token, latest request
+    "ttftBestMs": float | null,       # fastest TTFT since the model loaded
+    "ttftWorstMs": float | null,      # slowest TTFT since the model loaded
+    "ttftAvgMs": float | null,        # running average TTFT since the model loaded
+    "ttftMedianMs": float | null,     # median TTFT since the model loaded
+    "ttftCount": int,                 # requests measured for the TTFT stats (0 = none yet)
+    "truncated": bool,                # true if the MOST RECENT event was a truncation
+    "truncatedDetail": {"limit": int, "prompt": int, "keep": int, "new": int} | null,
+    "processor": "100% GPU" | null,   # the CPU/GPU split ollama settled on
+    "layers": {"offloaded": int, "total": int} | null,
+    "modelBufferMiB": float | null,   # VRAM the weights themselves occupy
+    "gpu": {"util": int, "memUsed": int, "memTotal": int,
+            "temp": int, "power": float} | null,
+  }
+
+Why this exists: ollama does not enforce its configured context length
+(OLLAMA_CONTEXT_LENGTH) as a hard ceiling. Under VRAM pressure from stale
+prompt-cache entries, it silently truncates a new prompt to whatever it can
+free — sometimes far below the configured max — and only says so in a WARN
+line in its own journal. This watcher surfaces that in real time instead of
+finding out from a garbled response.
+
+The journal tail and the `ollama ps` poll run on separate clocks on purpose.
+Reading the journal blocks until ollama says something, and a model that has
+been loaded but not yet prompted says nothing at all — polling `ollama ps`
+from inside that read loop leaves the widget reporting "no model" for as long
+as the journal stays quiet.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+STATE_DIR = Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local" / "state")) / "omarchy" / "ollama-context-watch"
+STATE_PATH = STATE_DIR / "state.json"
+
+PROGRESS_RE = re.compile(r"prompt processing,\s*n_tokens\s*=\s*(\d+),\s*progress\s*=\s*([\d.]+)")
+# Both of these carry the ABSOLUTE position in the context window. The
+# "prompt eval time" count must NOT be used for that: a cached prefix makes it
+# report only the new delta (one request showed 1012 while the real window in
+# use was 37041 tokens), which is exactly what makes the meter look "tiny"
+# while the session is actually large.
+NEW_PROMPT_RE = re.compile(r"new prompt,\s*n_ctx_slot\s*=\s*\d+,\s*n_keep\s*=\s*\d+,\s*task\.n_tokens\s*=\s*(\d+)")
+# Printed when the request's prefix is already in the KV cache — the same
+# conversation continues where it left off. Its absence after a "new prompt"
+# means a fresh conversation lineage, and the load-session peak must reset
+# then (a stale high-water mark from another lineage freezes the meter).
+RESTORE_RE = re.compile(r"restored context checkpoint \(pos_min = \d+, pos_max = \d+, n_tokens = \d+, n_past = (\d+),")
+STOP_RE = re.compile(r"stop processing:\s*n_tokens\s*=\s*(\d+)")
+# llama.cpp prints one of these ~every second while a generation is in flight;
+# tg_3s is its own rolling average, which is exactly the "current speed".
+LIVE_TGS_RE = re.compile(r"\bn_gen\s*=\s*(\d+),\s*tg\s*=\s*[\d.]+\s*t/s,\s*tg_3s\s*=\s*([\d.]+)\s*t/s")
+# The last "eval time" line of a finished generation carries its average speed.
+# Lookbehind keeps this from matching "prompt eval time", whose speed is the
+# prefill rate — a different figure altogether.
+GEN_AVG_RE = re.compile(r"(?<!prompt )eval time\s*=\s*[\d.]+\s*ms\s*/\s*\d+\s*tokens\s*\(\s*[\d.]+\s*ms per token,\s*([\d.]+)\s*tokens per second\)")
+PROMPT_DONE_RE = re.compile(r"prompt eval time\s*=\s*[\d.]+\s*ms\s*/\s*(\d+)\s*tokens\s*\(\s*[\d.]+\s*ms per token,\s*([\d.]+)\s*tokens per second\)")
+TRUNC_RE = re.compile(r'msg="truncating input prompt"\s*limit=(\d+)\s*prompt=(\d+)\s*keep=(\d+)\s*new=(\d+)')
+LAYERS_RE = re.compile(r"offloaded\s+(\d+)\s*/\s*(\d+)\s+layers to GPU")
+BUFFER_RE = re.compile(r"CUDA0 model buffer size\s*=\s*([\d.]+)\s*MiB")
+
+NOTIFY_COOLDOWN_SECONDS = 120
+PS_INTERVAL_SECONDS = 3
+
+# nvidia-smi's own loop, rather than one process per sample: 2 Hz is fast
+# enough to watch a generation spin the GPU up and cheap enough to leave
+# running forever.
+GPU_QUERY = ["utilization.gpu", "memory.used", "memory.total", "temperature.gpu", "power.draw"]
+GPU_SAMPLE_MS = 500
+
+
+def now_iso() -> str:
+  return datetime.now(timezone.utc).isoformat()
+
+
+def notify(urgency: str, headline: str, description: str) -> None:
+  try:
+    subprocess.run(
+      ["omarchy-notification-send", "-u", urgency, "--app-name", "Ollama Context", headline, description],
+      check=False, timeout=5,
+    )
+  except (OSError, subprocess.TimeoutExpired):
+    pass
+
+
+def ollama_ps() -> tuple[str | None, int | None, str | None] | None:
+  """Returns (model_name, configured_context, processor_split).
+
+  (None, None, None) means ollama answered and has nothing loaded. A bare
+  None means the question could not be answered at all — and the two must
+  not be conflated: `ollama ps` can take seconds while a model is being
+  placed, and reading a timeout as an unload wipes the very numbers the
+  reload is about to make interesting.
+
+  `ollama ps` is a fixed-width table, not whitespace-delimited: SIZE ("18 GB")
+  and PROCESSOR ("30%/70% CPU/GPU") are each two space-separated words, so
+  naively splitting the data row and indexing by the header's word position
+  misaligns every column after SIZE. Slicing at the header's character
+  column instead sidesteps that.
+  """
+  try:
+    result = subprocess.run(["ollama", "ps"], capture_output=True, text=True, timeout=20)
+  except (OSError, subprocess.TimeoutExpired):
+    return None
+  if result.returncode != 0:
+    return None
+  lines = [l for l in result.stdout.splitlines() if l.strip()]
+  if not lines:
+    return None  # Not even a header: ollama is not answering properly.
+  if len(lines) < 2:
+    return None, None, None  # Header only — genuinely nothing loaded.
+  header_line, data_line = lines[0], lines[1]
+  model = data_line.split()[0] if data_line.split() else None
+
+  context = None
+  context_col = header_line.find("CONTEXT")
+  if context_col != -1 and context_col < len(data_line):
+    field = data_line[context_col:].split()
+    if field:
+      try:
+        context = int(field[0])
+      except ValueError:
+        context = None
+
+  # PROCESSOR spans to the start of CONTEXT, so it survives being two words.
+  processor = None
+  processor_col = header_line.find("PROCESSOR")
+  if processor_col != -1 and context_col > processor_col and processor_col < len(data_line):
+    processor = data_line[processor_col:context_col].strip() or None
+
+  return model, context, processor
+
+
+class Watcher:
+  def __init__(self) -> None:
+    self.lock = threading.Lock()
+    self.state = {
+      "modelLoaded": None,
+      "configuredMax": None,
+      "phase": "idle",
+      "prefillProgress": None,
+      "contextPos": None,
+      "contextPeak": None,
+      "lastPromptTokens": None,
+      "lastPercent": None,
+      "lastTokensPerSec": None,
+      "liveTokensPerSec": None,
+      "maxTokensPerSec": None,
+      "lastPrefillTokensPerSec": None,
+      "livePrefillTokensPerSec": None,
+      "maxPrefillTokensPerSec": None,
+      "ttftLastMs": None,
+      "ttftBestMs": None,
+      "ttftWorstMs": None,
+      "ttftAvgMs": None,
+      "ttftMedianMs": None,
+      "ttftCount": 0,
+      "truncated": False,
+      "truncatedDetail": None,
+      "processor": None,
+      "layers": None,
+      "modelBufferMiB": None,
+      "gpu": None,
+    }
+    # A truncated request still logs its own normal "prompt eval time" line
+    # once it finishes — that would otherwise immediately clear the flag the
+    # truncation branch just set. Carry the truncation forward through that
+    # one completion, and only clear it on the *next* request's completion.
+    self.pending_truncation: dict | None = None
+    self.last_notify_at = 0.0
+    # Highest progress n_tokens seen for the in-flight request — the position
+    # at the end of prefill, to which n_gen (decoded tokens) is added for the
+    # live context position during generation. Reset at each "new prompt".
+    self.prefill_baseline: int | None = None
+    # Progress-line bookkeeping for live ingest speed and TTFT. Both are
+    # wall-clock deltas between journal lines, so they live outside state.
+    self.prev_progress: tuple[int, float] | None = None  # (n_tokens, time.time())
+    self.request_started_at: float | None = None         # "new prompt" line arrived
+    # TTFT samples since the model loaded — needed for the median. Reset
+    # alongside the other TTFT stats when the model changes.
+    self.ttft_samples: list[float] = []
+    # True from a "new prompt" line until either the "restored context
+    # checkpoint" line (same conversation → keep the peak) or the first
+    # prefill/progress/stop line (fresh lineage → reset the peak) arrives.
+    self.pending_restore = False
+
+  # ------------------------------------------------------------------ output
+
+  def write_state(self) -> None:
+    """Caller must hold self.lock."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    snapshot = dict(self.state)
+    snapshot["updatedAt"] = now_iso()
+    fd, tmp_path = tempfile.mkstemp(dir=STATE_DIR, prefix=".state-", suffix=".json")
+    try:
+      with os.fdopen(fd, "w") as f:
+        json.dump(snapshot, f, separators=(",", ":"))
+      os.replace(tmp_path, STATE_PATH)
+    except Exception:
+      try:
+        os.unlink(tmp_path)
+      except OSError:
+        pass
+      raise
+
+  def set_percent(self) -> None:
+    """Caller must hold self.lock."""
+    tokens = self.state["contextPeak"] or self.state["contextPos"] or self.state["lastPromptTokens"]
+    configured = self.state["configuredMax"]
+    self.state["lastPercent"] = tokens / configured if tokens is not None and configured else None
+
+  def set_context(self, pos: int) -> None:
+    """Update the live context position and the load-session peak.
+
+    The single slot genuinely shrinks when a request on another conversation
+    lineage lands (cache miss → the window re-fills from scratch). The peak is
+    what the widget shows, so the meter only moves up while the model stays
+    loaded; a smaller stray request no longer drags it down. Caller must hold
+    self.lock."""
+    self.state["contextPos"] = pos
+    peak = self.state["contextPeak"]
+    if peak is None or pos > peak:
+      self.state["contextPeak"] = pos
+
+  def update_speed_max(self, key: str, value: float) -> None:
+    """Raise the load-session speed high-water mark. The widget sizes the
+    live/avg speed meters against this, so bars show the current speed as a
+    fraction of the fastest ever seen while the model stays loaded. Caller
+    must hold self.lock."""
+    maximum = self.state[key]
+    if maximum is None or value > maximum:
+      self.state[key] = value
+
+  # -------------------------------------------------------------- ps polling
+
+  def poll_models(self) -> None:
+    """Track load/unload independently of journal traffic."""
+    while True:
+      result = ollama_ps()
+      if result is None:
+        # Unanswerable, not empty. Leave the last known good state standing.
+        time.sleep(PS_INTERVAL_SECONDS)
+        continue
+      model, configured_max, processor = result
+      with self.lock:
+        was_loaded = self.state["modelLoaded"]
+        changed = (model != was_loaded
+                   or configured_max != self.state["configuredMax"]
+                   or processor != self.state["processor"])
+        if changed:
+          self.state["modelLoaded"] = model
+          self.state["configuredMax"] = configured_max
+          self.state["processor"] = processor
+          if model != was_loaded:
+            # Whichever direction it went, the numbers on screen belong to a
+            # window that no longer exists. An unload is also exactly what
+            # clears the cache pressure behind a truncation, so the stale
+            # warning goes with it rather than waiting for the next request.
+            self.state["phase"] = "idle"
+            self.state["prefillProgress"] = None
+            self.state["contextPos"] = None
+            self.state["contextPeak"] = None
+            self.state["lastPromptTokens"] = None
+            self.state["lastTokensPerSec"] = None
+            self.state["liveTokensPerSec"] = None
+            self.state["maxTokensPerSec"] = None
+            self.state["lastPrefillTokensPerSec"] = None
+            self.state["livePrefillTokensPerSec"] = None
+            self.state["maxPrefillTokensPerSec"] = None
+            self.state["ttftLastMs"] = None
+            self.state["ttftBestMs"] = None
+            self.state["ttftWorstMs"] = None
+            self.state["ttftAvgMs"] = None
+            self.state["ttftMedianMs"] = None
+            self.state["ttftCount"] = 0
+            self.ttft_samples.clear()
+            self.state["truncated"] = False
+            self.state["truncatedDetail"] = None
+            self.pending_truncation = None
+            self.prefill_baseline = None
+            self.prev_progress = None
+            self.request_started_at = None
+            self.pending_restore = False
+            # The offload figures are printed once at load time, so they
+            # describe whichever model is resident now. On an unload they
+            # describe nothing; on a load the new ones arrive via the journal.
+            if model is None:
+              self.state["layers"] = None
+              self.state["modelBufferMiB"] = None
+          self.set_percent()
+          self.write_state()
+      time.sleep(PS_INTERVAL_SECONDS)
+
+  # ------------------------------------------------------------ gpu sampling
+
+  def sample_gpu(self) -> None:
+    while True:
+      try:
+        proc = subprocess.Popen(
+          ["nvidia-smi", "--query-gpu=" + ",".join(GPU_QUERY),
+           "--format=csv,noheader,nounits", "-lms", str(GPU_SAMPLE_MS)],
+          stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, bufsize=1,
+        )
+      except OSError:
+        return  # No nvidia-smi: the GPU section simply stays absent.
+
+      assert proc.stdout is not None
+      for line in proc.stdout:
+        sample = self.parse_gpu_line(line)
+        if sample is None:
+          continue
+        with self.lock:
+          # An idle GPU reports the same numbers forever; only writing on a
+          # change keeps this from churning the state file twice a second.
+          if sample != self.state["gpu"]:
+            self.state["gpu"] = sample
+            self.write_state()
+
+      proc.wait()
+      time.sleep(5)
+
+  @staticmethod
+  def parse_gpu_line(line: str) -> dict | None:
+    fields = [f.strip() for f in line.split(",")]
+    if len(fields) != len(GPU_QUERY):
+      return None
+
+    def number(text, cast):
+      try:
+        return cast(text)
+      except ValueError:
+        return None  # nvidia-smi prints "[N/A]" for unsupported sensors.
+
+    sample = {
+      "util": number(fields[0], int),
+      "memUsed": number(fields[1], int),
+      "memTotal": number(fields[2], int),
+      "temp": number(fields[3], int),
+      "power": number(fields[4], float),
+    }
+    return sample if sample["util"] is not None else None
+
+  # ------------------------------------------------------------ journal tail
+
+  def handle_line(self, line: str) -> None:
+    # Load-time facts: printed once, when llama.cpp places the model.
+    m = LAYERS_RE.search(line)
+    if m:
+      with self.lock:
+        self.state["layers"] = {"offloaded": int(m.group(1)), "total": int(m.group(2))}
+        self.write_state()
+      return
+
+    m = BUFFER_RE.search(line)
+    if m:
+      with self.lock:
+        self.state["modelBufferMiB"] = float(m.group(1))
+        self.write_state()
+      return
+
+    m = TRUNC_RE.search(line)
+    if m:
+      limit, prompt, keep, new = (int(x) for x in m.groups())
+      with self.lock:
+        self.pending_truncation = {"limit": limit, "prompt": prompt, "keep": keep, "new": new}
+        self.state["truncated"] = True
+        self.state["truncatedDetail"] = self.pending_truncation
+        self.state["phase"] = "idle"
+        self.state["prefillProgress"] = None
+        self.state["lastPromptTokens"] = new
+        self.state["contextPos"] = new
+        self.state["contextPeak"] = new  # the window was forcibly cut; start over
+        self.state["lastPercent"] = new / limit if limit else None
+        self.write_state()
+        now = time.time()
+        should_notify = now - self.last_notify_at > NOTIFY_COOLDOWN_SECONDS
+        if should_notify:
+          self.last_notify_at = now
+      if should_notify:
+        notify(
+          "critical",
+          "Ollama truncated a prompt",
+          f"Cache pressure cut the usable window to {new:,} tokens "
+          f"(requested {prompt:,}) — reload the model to clear it.",
+        )
+      return
+
+    # Absolute input position for this request (cached + new). Trust this
+    # over "prompt eval time", which reports only the new delta.
+    m = NEW_PROMPT_RE.search(line)
+    if m:
+      task_tokens = int(m.group(1))
+      with self.lock:
+        # Whether this is the same conversation (a restore line follows) or a
+        # fresh lineage is only known once the next journal lines land.
+        self.pending_restore = True
+        self.state["phase"] = "prefill"
+        self.state["prefillProgress"] = {"nTokens": 0, "percent": 0.0}
+        self.state["livePrefillTokensPerSec"] = None
+        self.set_context(task_tokens)
+        self.prefill_baseline = task_tokens
+        self.prev_progress = None
+        self.request_started_at = time.time()
+        self.write_state()
+      return
+
+    m = RESTORE_RE.search(line)
+    if m:
+      n_past = int(m.group(1))
+      with self.lock:
+        # Same conversation lineage: the cache resumes where it left off, so
+        # the load-session peak stays — this request only extends it.
+        self.pending_restore = False
+        self.set_context(n_past)
+        self.write_state()
+      return
+
+    m = PROGRESS_RE.search(line)
+    if m:
+      n_tokens, progress = int(m.group(1)), float(m.group(2))
+      now = time.time()
+      with self.lock:
+        if self.pending_restore:
+          # No restore line followed the "new prompt": a fresh conversation
+          # lineage re-fills the single slot from scratch. The load-session
+          # peak belongs to a different session and would freeze the meter
+          # on a stale high-water mark — reset it here.
+          self.pending_restore = False
+          self.state["contextPeak"] = None
+        self.state["phase"] = "prefill"
+        self.state["prefillProgress"] = {"nTokens": n_tokens, "percent": progress}
+        self.set_context(n_tokens)
+        # Live ingest speed: the journal streams one progress line per batch,
+        # so the delta between two of them is the current prefill rate.
+        if self.prev_progress is not None:
+          prev_tokens, prev_time = self.prev_progress
+          dt = now - prev_time
+          dn = n_tokens - prev_tokens
+          if dt > 0.05 and dn > 0:
+            self.state["livePrefillTokensPerSec"] = dn / dt
+            self.update_speed_max("maxPrefillTokensPerSec", dn / dt)
+        self.prev_progress = (n_tokens, now)
+        self.write_state()
+      return
+
+    # One of these lands roughly every second while tokens are being decoded.
+    m = LIVE_TGS_RE.search(line)
+    if m:
+      n_gen, live_tps = int(m.group(1)), float(m.group(2))
+      with self.lock:
+        self.state["phase"] = "generating"
+        self.state["liveTokensPerSec"] = live_tps
+        self.state["lastTokensPerSec"] = live_tps
+        self.update_speed_max("maxTokensPerSec", live_tps)
+        if self.prefill_baseline is not None:
+          self.set_context(self.prefill_baseline + n_gen)
+        self.write_state()
+      return
+
+    m = GEN_AVG_RE.search(line)
+    if m:
+      with self.lock:
+        self.state["lastTokensPerSec"] = float(m.group(1))
+        self.state["liveTokensPerSec"] = None
+        self.update_speed_max("maxTokensPerSec", float(m.group(1)))
+        self.state["phase"] = "idle"
+        self.write_state()
+      return
+
+    # Definitive context position at the end of the request.
+    m = STOP_RE.search(line)
+    if m:
+      final_tokens = int(m.group(1))
+      with self.lock:
+        if self.pending_restore:
+          # A request too short to stream progress lines: it still did not
+          # restore a checkpoint, so it is a fresh lineage like any other.
+          self.pending_restore = False
+          self.state["contextPeak"] = None
+        self.set_context(final_tokens)
+        self.state["lastPromptTokens"] = final_tokens
+        self.state["lastPercent"] = final_tokens / self.state["configuredMax"] if self.state["configuredMax"] else None
+        if self.pending_truncation is not None:
+          self.state["truncated"] = True
+          self.state["truncatedDetail"] = self.pending_truncation
+          self.pending_truncation = None
+        self.state["phase"] = "idle"
+        self.prefill_baseline = None
+        self.write_state()
+      return
+
+    m = PROMPT_DONE_RE.search(line)
+    if m:
+      tokens = int(m.group(1))
+      now = time.time()
+      with self.lock:
+        self.state["liveTokensPerSec"] = None
+        if self.pending_restore:
+          # Same safety as PROGRESS/STOP: a prompt so short it produced no
+          # progress line still belongs to a fresh lineage if no restore
+          # checkpoint was printed.
+          self.pending_restore = False
+          self.state["contextPeak"] = None
+        # Whole-prefill average: this is the line that closes prefill out, so
+        # its tokens-per-second is the definitive ingest speed for the request.
+        # (Same paren-group shape as GEN_AVG_RE, but this regex anchors on
+        # "prompt eval time", so there is no overlap between the two.)
+        self.state["lastPrefillTokensPerSec"] = float(m.group(2))
+        self.state["livePrefillTokensPerSec"] = None
+        self.update_speed_max("maxPrefillTokensPerSec", float(m.group(2)))
+        # TTFT: the "new prompt" line marks the request start; the "prompt
+        # eval time" line lands the moment prefill finishes and the first
+        # token is about to be decoded — the closest the journal gets to a
+        # first-token timestamp.
+        if self.request_started_at is not None:
+          ttft_ms = (now - self.request_started_at) * 1000.0
+          self.state["ttftLastMs"] = ttft_ms
+          best, worst, avg, count = (
+            self.state["ttftBestMs"], self.state["ttftWorstMs"],
+            self.state["ttftAvgMs"], self.state["ttftCount"],
+          )
+          count += 1
+          self.state["ttftCount"] = count
+          self.state["ttftBestMs"] = ttft_ms if best is None else min(best, ttft_ms)
+          self.state["ttftWorstMs"] = ttft_ms if worst is None else max(worst, ttft_ms)
+          self.state["ttftAvgMs"] = (avg * (count - 1) + ttft_ms) / count if avg is not None else ttft_ms
+          self.ttft_samples.append(ttft_ms)
+          self.ttft_samples.sort()
+          n = len(self.ttft_samples)
+          midpoint = n // 2
+          self.state["ttftMedianMs"] = (
+            self.ttft_samples[midpoint] if n % 2
+            else (self.ttft_samples[midpoint - 1] + self.ttft_samples[midpoint]) / 2.0
+          )
+        self.request_started_at = None
+        if self.pending_truncation is not None:
+          # This completion is the truncated request finishing — keep the
+          # warning visible, and consume the marker so the *next* clean
+          # request is what finally clears it.
+          self.state["truncated"] = True
+          self.state["truncatedDetail"] = self.pending_truncation
+          self.pending_truncation = None
+        else:
+          self.state["truncated"] = False
+          self.state["truncatedDetail"] = None
+        self.state["phase"] = "generating"
+        self.state["prefillProgress"] = None
+        self.state["lastPromptTokens"] = tokens
+        self.set_percent()
+        self.write_state()
+      return
+
+    if "slot print_timing" in line and "eval time" in line and "prompt eval time" not in line:
+      with self.lock:
+        self.state["phase"] = "idle"
+        self.write_state()
+
+  def tail_journal(self) -> None:
+    while True:
+      try:
+        proc = subprocess.Popen(
+          ["journalctl", "-u", "ollama", "-f", "-n", "0", "-o", "cat"],
+          stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, bufsize=1,
+        )
+      except OSError as error:
+        print(f"omarchy-ollama-context-watch: cannot start journalctl: {error}", file=sys.stderr)
+        time.sleep(10)
+        continue
+
+      assert proc.stdout is not None
+      for line in proc.stdout:
+        self.handle_line(line)
+
+      proc.wait()
+      time.sleep(3)  # journalctl -f exited (service restarted?) — retry
+
+  # ------------------------------------------------------------------ startup
+
+  @staticmethod
+  def last_journal_match(pattern: str) -> str:
+    try:
+      return subprocess.run(
+        ["journalctl", "-u", "ollama", "--no-pager", "-g", pattern, "-n", "1", "-o", "cat"],
+        capture_output=True, text=True, timeout=10,
+      ).stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+      return ""
+
+  def seed_offload(self) -> None:
+    """The offload figures are printed once, when the model loads. A watcher
+    started afterwards would otherwise show nothing until the next reload."""
+    if self.state["modelLoaded"] is None:
+      return
+    m = LAYERS_RE.search(self.last_journal_match("offloaded .* layers to GPU"))
+    if m:
+      self.state["layers"] = {"offloaded": int(m.group(1)), "total": int(m.group(2))}
+    m = BUFFER_RE.search(self.last_journal_match("CUDA0 model buffer size"))
+    if m:
+      self.state["modelBufferMiB"] = float(m.group(1))
+
+  def seed_from_recent_journal(self) -> None:
+    """Best-effort: pull the last completed prefill/truncation event so the
+    display isn't blank right after the watcher (re)starts."""
+    out = self.last_journal_match("prompt eval time|truncating input prompt")
+    if not out:
+      return
+    m = TRUNC_RE.search(out)
+    if m:
+      limit, prompt, keep, new = (int(x) for x in m.groups())
+      self.state["truncated"] = True
+      self.state["truncatedDetail"] = {"limit": limit, "prompt": prompt, "keep": keep, "new": new}
+      self.state["lastPromptTokens"] = new
+      self.state["contextPos"] = new
+      self.state["contextPeak"] = new
+      return
+    m = PROMPT_DONE_RE.search(out)
+    if m:
+      self.state["lastPromptTokens"] = int(m.group(1))
+      self.state["contextPos"] = int(m.group(1))
+      self.state["lastPrefillTokensPerSec"] = float(m.group(2))
+
+    # Definitive end-of-request context position, if one exists.
+    out_stop = self.last_journal_match("stop processing:")
+    m = STOP_RE.search(out_stop)
+    if m:
+      self.state["contextPos"] = int(m.group(1))
+      self.state["contextPeak"] = int(m.group(1))
+
+    # Last finished generation's average decode speed — a different line, so
+    # a separate last-match (the lookbehind keeps the "prompt eval" line out).
+    out2 = self.last_journal_match("eval time =")
+    m = GEN_AVG_RE.search(out2)
+    if m:
+      self.state["lastTokensPerSec"] = float(m.group(1))
+
+  def run(self) -> int:
+    model, configured_max, processor = ollama_ps() or (None, None, None)
+    with self.lock:
+      self.state["modelLoaded"] = model
+      self.state["configuredMax"] = configured_max
+      self.state["processor"] = processor
+      self.seed_offload()
+      self.seed_from_recent_journal()
+      self.set_percent()
+      self.write_state()
+
+    threading.Thread(target=self.poll_models, daemon=True).start()
+    threading.Thread(target=self.sample_gpu, daemon=True).start()
+    self.tail_journal()
+    return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(Watcher().run())

--- a/default/systemd/user/omarchy-ollama-context-watch.service
+++ b/default/systemd/user/omarchy-ollama-context-watch.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Live Ollama context-window stats for the bar widget
+# Ollama is optional; the widget's numbers all come from this watcher, but a
+# machine without ollama has nothing to watch.
+ConditionPathExists=/usr/bin/ollama
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-ollama-context-watch
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -52,6 +52,10 @@ Hermes Desktop is the one to know about, because there is only ever one Hermes o
 
 Omarchy recommends two ways of running local LLM models: LM Studio and Ollama. LM Studio provides a GUI interface for finding open-weight models, installing them, and running them. It's a great way to get going easily. Ollama offers a CLI for doing so similarly. But if you're new to local models, I'd start with LM Studio. You can install either under _Install > AI_ in the Omarchy Menu.
 
+### Ollama stats
+
+With Ollama running locally, the **Ollama stats** bar widget (`omarchy bar put omarchy.ollama-stats`) shows how much of the model's context window is in use, the current decode and prompt-ingest speeds, and time-to-first-token history for the session. Ollama does not enforce its configured context length as a hard ceiling — under VRAM pressure it silently truncates a prompt — so the widget also flags truncations and offers a one-click model reload to clear the cache pressure behind them. It is backed by the `omarchy-ollama-context-watch` service, which tails ollama's journal and is enabled automatically when ollama is present.
+
 ### The Omarchy Skill
 
 Agent skills help AI use specific tools in a specific way, and Omarchy ships with a default skill for tailoring the system. Like tweaking your Hyprland config, adjusting the bar, or even creating a new theme from scratch. It's symlinked into the skill directories for Claude Code (`~/.claude/skills`), Codex (`~/.codex/skills`), Pi (`~/.pi/agent/skills`), Antigravity (`~/.gemini/config/skills`), Hermes (`~/.hermes/skills` and each `~/.hermes/profiles/*/skills`), and the generic `~/.agents/skills` location, so most harnesses pick it up automatically.

--- a/migrations/1788595667.sh
+++ b/migrations/1788595667.sh
@@ -1,0 +1,9 @@
+echo "Enable the Ollama stats watcher"
+
+if omarchy-cmd-present ollama; then
+  systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+  if ! error=$(systemctl --user enable --now omarchy-ollama-context-watch.service 2>&1); then
+    echo "Could not enable omarchy-ollama-context-watch.service: $error"
+  fi
+fi

--- a/shell/plugins/README.md
+++ b/shell/plugins/README.md
@@ -29,6 +29,7 @@ User-installed plugins live alongside these conceptually but on disk under
 | Tailscale     | `omarchy.tailscale`       | `bar-widget`            | `panels/tailscale/Panel.qml`          |
 | Agents   | `omarchy.agents`     | `bar-widget`            | `agents/Panel.qml`               |
 | Weather       | `omarchy.weather`         | `bar-widget`            | `panels/weather/BarWidget.qml`        |
+| Ollama stats  | `omarchy.ollama-stats`    | `bar-widget`            | `panels/ollama/Panel.qml`             |
 | Media         | `omarchy.media`           | `service`, `bar-widget` | `services/media/Service.qml`, `services/media/BarWidget.qml` |
 | Battery       | `omarchy.battery`         | `service`               | `services/battery/Service.qml`        |
 | Idle          | `omarchy.idle`            | `service`               | `services/idle/Service.qml`           |

--- a/shell/plugins/panels/ollama/Panel.qml
+++ b/shell/plugins/panels/ollama/Panel.qml
@@ -1,0 +1,763 @@
+import QtQuick
+import QtQuick.Controls
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+
+// Live Ollama stats: context-window usage, decode and ingest speeds, and
+// time-to-first-token for the locally loaded Ollama model.
+//
+// All numbers come from omarchy-ollama-context-watch, a user service that
+// tails ollama's journal and keeps a small JSON snapshot current. Ollama does
+// not enforce OLLAMA_CONTEXT_LENGTH as a hard ceiling: under VRAM pressure it
+// silently truncates a prompt to whatever it can free and says so only in a
+// WARN line, so the truncation state here is the whole reason this exists.
+Panel {
+  id: root
+  moduleName: "omarchy.ollama-stats"
+  ipcTarget: "omarchy.ollama-stats"
+  manageIpc: false
+
+  readonly property color foreground: bar ? bar.foreground : Color.foreground
+  readonly property color urgent: bar ? bar.urgent : Color.urgent
+  readonly property color dim: Qt.darker(foreground, 1.55)
+  readonly property color track: Style.selectedFillFor(foreground, Color.accent)
+  readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
+
+  readonly property string home: Quickshell.env("HOME") || ""
+  readonly property string statePath: (Quickshell.env("XDG_STATE_HOME") || (root.home + "/.local/state"))
+    + "/omarchy/ollama-context-watch/state.json"
+
+  // NOT `data`: every Item already has a default property by that name — the
+  // list its children are assigned into. Shadowing it parses fine and logs
+  // nothing, and the widget's own button silently never becomes a child.
+  property var snapshot: null
+  property bool cursorActive: false
+  property double nowMs: Date.now()
+
+  readonly property bool hasState: snapshot !== null
+  readonly property string model: hasState ? String(snapshot.modelLoaded || "") : ""
+  readonly property bool hasModel: model !== ""
+  readonly property int configuredMax: hasState ? Number(snapshot.configuredMax || 0) : 0
+  readonly property string phase: hasState ? String(snapshot.phase || "idle") : "idle"
+  readonly property bool truncated: hasState && snapshot.truncated === true
+  readonly property var truncatedDetail: hasState ? (snapshot.truncatedDetail || null) : null
+
+  // While a prompt is being ingested the journal reports progress token by
+  // token, so the bar counts up live instead of jumping at the end. Once
+  // settled, show the session PEAK: the single slot genuinely shrinks when a
+  // request on another conversation lineage lands, and re-painting that would
+  // make the meter bounce around — the peak only moves up while the model
+  // stays loaded. The peak also stays on screen during prefill: a fresh
+  // request starts its progress at 0, which would otherwise make the meter
+  // briefly collapse from the session peak.
+  readonly property int tokens: {
+    if (!hasState) return -1
+    var peak = snapshot.contextPeak
+    if (phase === "prefill" && snapshot.prefillProgress) {
+      var progress = Number(snapshot.prefillProgress.nTokens || 0)
+      if (peak != null && peak !== undefined && progress < peak) return Number(peak)
+      return progress
+    }
+    if (peak != null && peak !== undefined) return Number(peak)
+    var last = (snapshot.contextPos != null ? snapshot.contextPos : snapshot.lastPromptTokens)
+    return last === null || last === undefined ? -1 : Number(last)
+  }
+
+  readonly property real percent: tokens >= 0 && configuredMax > 0 ? tokens / configuredMax : -1
+  readonly property bool alarming: truncated || percent >= 0.9
+
+  // Decode speed: the in-flight tg_3s while a generation is running, and the
+  // previous run's whole-run average once it has finished.
+  readonly property real liveTokSec: hasState && snapshot.liveTokensPerSec !== null && snapshot.liveTokensPerSec !== undefined
+    ? Number(snapshot.liveTokensPerSec) : -1
+  readonly property real lastTokSec: hasState && snapshot.lastTokensPerSec !== null && snapshot.lastTokensPerSec !== undefined
+    ? Number(snapshot.lastTokensPerSec) : -1
+  readonly property real maxTokSec: hasState && snapshot.maxTokensPerSec !== null && snapshot.maxTokensPerSec !== undefined
+    ? Number(snapshot.maxTokensPerSec) : -1
+  readonly property bool decoding: liveTokSec >= 0
+
+  // Ingest (prefill) speed: live while the prompt is being read (journal
+  // progress-line deltas), the whole-prefill average once it has finished.
+  readonly property real livePrefillTokSec: hasState && snapshot.livePrefillTokensPerSec !== null && snapshot.livePrefillTokensPerSec !== undefined
+    ? Number(snapshot.livePrefillTokensPerSec) : -1
+  readonly property real lastPrefillTokSec: hasState && snapshot.lastPrefillTokensPerSec !== null && snapshot.lastPrefillTokensPerSec !== undefined
+    ? Number(snapshot.lastPrefillTokensPerSec) : -1
+  readonly property real maxPrefillTokSec: hasState && snapshot.maxPrefillTokensPerSec !== null && snapshot.maxPrefillTokensPerSec !== undefined
+    ? Number(snapshot.maxPrefillTokensPerSec) : -1
+  readonly property bool prefilling: phase === "prefill"
+  readonly property real prefillSpeed: prefilling
+    ? (livePrefillTokSec >= 0 ? livePrefillTokSec : lastPrefillTokSec) : -1
+
+  // Time to first token: the prompt-eval line closes prefill out, so the
+  // wall-clock gap between the request start and that line is the TTFT.
+  readonly property real ttftLastMs: hasState && snapshot.ttftLastMs !== null && snapshot.ttftLastMs !== undefined
+    ? Number(snapshot.ttftLastMs) : -1
+  readonly property real ttftBestMs: hasState && snapshot.ttftBestMs !== null && snapshot.ttftBestMs !== undefined
+    ? Number(snapshot.ttftBestMs) : -1
+  readonly property real ttftWorstMs: hasState && snapshot.ttftWorstMs !== null && snapshot.ttftWorstMs !== undefined
+    ? Number(snapshot.ttftWorstMs) : -1
+  readonly property real ttftAvgMs: hasState && snapshot.ttftAvgMs !== null && snapshot.ttftAvgMs !== undefined
+    ? Number(snapshot.ttftAvgMs) : -1
+  readonly property real ttftMedianMs: hasState && snapshot.ttftMedianMs !== null && snapshot.ttftMedianMs !== undefined
+    ? Number(snapshot.ttftMedianMs) : -1
+  readonly property bool hasTtft: ttftLastMs >= 0
+
+  // ---- GPU placement (load-time facts) and utilisation (sampled at 2 Hz) ----
+  readonly property var layers: hasState ? (snapshot.layers || null) : null
+  readonly property string processor: hasState ? String(snapshot.processor || "") : ""
+  readonly property real modelBufferMiB: hasState ? Number(snapshot.modelBufferMiB || 0) : 0
+  readonly property var gpu: hasState ? (snapshot.gpu || null) : null
+  readonly property bool hasGpu: gpu !== null
+
+  readonly property real gpuUtil: hasGpu && gpu.util !== null ? Number(gpu.util) / 100 : -1
+  readonly property real vramUsed: hasGpu ? Number(gpu.memUsed || 0) : 0
+  readonly property real vramTotal: hasGpu ? Number(gpu.memTotal || 0) : 0
+  readonly property real vramPercent: vramTotal > 0 ? vramUsed / vramTotal : -1
+  // A model that did not fit lands partly on the CPU, and that costs far more
+  // than a full context does — worth the same alarm colour.
+  readonly property bool partialOffload: layers !== null && Number(layers.offloaded) < Number(layers.total)
+
+  function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)) }
+  function alpha(c, a) { return Qt.rgba(c.r, c.g, c.b, a) }
+
+  function fmt(n) {
+    var value = Number(n)
+    if (!isFinite(value)) return "—"
+    return value.toLocaleString(Qt.locale(), "f", 0)
+  }
+
+  // One decimal below 10% so a prompt being ingested visibly climbs instead of
+  // sitting on "0%" for the first twenty thousand tokens.
+  function percentText(p) {
+    if (!(p >= 0)) return "—"
+    var pct = p * 100
+    return (pct < 10 ? pct.toFixed(1) : Math.round(pct)) + "%"
+  }
+
+  function phaseText() {
+    if (truncated) return "Truncated"
+    if (!hasModel) return "No model loaded"
+    if (phase === "prefill") return "Reading prompt"
+    if (phase === "generating") return "Generating"
+    return "Idle"
+  }
+
+  function gib(mib) {
+    var value = Number(mib)
+    if (!isFinite(value) || value <= 0) return "—"
+    return (value / 1024).toFixed(1) + " GiB"
+  }
+
+  function layersText() {
+    if (!layers) return "—"
+    return layers.offloaded + " / " + layers.total
+  }
+
+  function tokSecText(v) { return Math.round(v) + " tok/s" }
+
+  // Prefill runs at hundreds–thousands of tokens/second, a completely
+  // different regime from decode — label it explicitly so the number isn't
+  // mistaken for decode speed.
+  function prefillSpeedText(v) { return "prefill " + Math.round(v) + " t/s" }
+
+  function prefillValueText(v) { return Math.round(v) + " t/s" }
+
+  // TTFT is always shown as seconds with one decimal — 2560 ms reads "2.6 s",
+  // 256 ms reads "0.3 s" — so the readout stays comparable across requests.
+  function secText(v) {
+    var value = Number(v)
+    if (!isFinite(value) || value < 0) return "—"
+    return (value / 1000).toFixed(1) + " s"
+  }
+
+  function barText() {
+    var context = truncated ? "󰓅 !" : "󰓅 " + percentText(percent)
+    if (prefilling) {
+      // While a prompt is being ingested the GPU is pinned anyway, and the
+      // ingest rate is the interesting number — same trade-off as decoding.
+      if (prefillSpeed >= 0) return context + "  󰢮 " + prefillSpeedText(prefillSpeed)
+      return context
+    }
+    if (decoding) {
+      // While a generation is in flight the speed is the interesting number —
+      // the GPU is pinned at 100% anyway — and it updates more often.
+      return context + "  󰢮 " + tokSecText(liveTokSec)
+    }
+    if (gpuUtil < 0) return context
+    // Right-padded to a constant width: this redraws twice a second, and an
+    // 9%→10% width change would shove every widget beside it in the bar.
+    var util = Math.round(gpuUtil * 100) + "%"
+    return context + "  󰢮 " + ("   " + util).slice(-4)
+  }
+
+  function tooltipText() {
+    if (!hasState) return "Ollama context watcher is not running"
+    var lines = []
+    if (truncated && truncatedDetail)
+      lines.push("Prompt truncated to " + fmt(truncatedDetail.new) + " of "
+        + fmt(truncatedDetail.prompt) + " tokens — reload the model")
+    else if (!hasModel)
+      lines.push("No model loaded")
+    else
+      lines.push(model + " · " + fmt(tokens) + " / " + fmt(configuredMax)
+        + " tokens (" + percentText(percent) + ") · " + phaseText()
+        + " · session peak")
+    if (decoding) lines.push("Decoding at " + tokSecText(liveTokSec))
+    else if (lastTokSec >= 0) lines.push("Last generation " + tokSecText(lastTokSec) + " average")
+    if (prefilling && prefillSpeed >= 0) lines.push("Ingesting " + prefillSpeedText(prefillSpeed))
+    else if (lastPrefillTokSec >= 0) lines.push("Last prefill " + prefillValueText(lastPrefillTokSec) + " average")
+    if (hasTtft) lines.push("TTFT " + secText(ttftLastMs) + " · best " + secText(ttftBestMs)
+      + " · worst " + secText(ttftWorstMs) + " · avg " + secText(ttftAvgMs)
+      + " · med " + secText(ttftMedianMs))
+    if (layers) lines.push("Layers on GPU " + layersText() + (processor !== "" ? " · " + processor : ""))
+    if (hasGpu) lines.push("GPU " + Math.round(gpuUtil * 100) + "% · VRAM "
+      + gib(vramUsed) + " / " + gib(vramTotal))
+    return lines.join("\n")
+  }
+
+  function updatedText() {
+    if (!hasState || !snapshot.updatedAt) return ""
+    var ms = new Date(String(snapshot.updatedAt)).getTime()
+    if (!isFinite(ms)) return ""
+    var seconds = Math.max(0, Math.round((root.nowMs - ms) / 1000))
+    if (seconds < 5) return "Updated just now"
+    if (seconds < 90) return "Updated " + seconds + "s ago"
+    if (seconds < 5400) return "Updated " + Math.round(seconds / 60) + "m ago"
+    return "Updated " + Math.round(seconds / 3600) + "h ago"
+  }
+
+  // Unloading is what actually clears the stale prompt-cache entries behind a
+  // truncation; the next request reloads the model with a clean window.
+  function reloadModel() {
+    if (!hasModel || reloadProc.running) return
+    reloadProc.command = ["ollama", "stop", root.model]
+    reloadProc.running = true
+  }
+
+  function parseState(text) {
+    try {
+      root.snapshot = JSON.parse(text)
+    } catch (error) {
+      root.snapshot = null
+    }
+  }
+
+  implicitWidth: button.implicitWidth
+  implicitHeight: button.implicitHeight
+
+  onOpenedChanged: if (opened) {
+    cursorActive = false
+    nowMs = Date.now()
+    stateFile.reload()
+  }
+
+  FileView {
+    id: stateFile
+    path: root.statePath
+    watchChanges: true
+    printErrors: false
+    onFileChanged: reload()
+    onLoaded: root.parseState(text())
+    onLoadFailed: root.snapshot = null
+  }
+
+  // The watcher replaces the file rather than rewriting it in place, which can
+  // cost the inotify watch its target. A short poll on top of watchChanges is
+  // what makes the count actually climb in real time.
+  Timer {
+    interval: root.opened ? 200 : 500
+    running: true
+    repeat: true
+    onTriggered: stateFile.reload()
+  }
+
+  Timer {
+    interval: 1000
+    running: root.opened
+    repeat: true
+    onTriggered: root.nowMs = Date.now()
+  }
+
+  Process {
+    id: reloadProc
+    onExited: stateFile.reload()
+  }
+
+  IpcHandler {
+    target: root.ipcTarget
+    function open(): void { root.open() }
+    function close(): void { root.close() }
+    function show(): void { root.open() }
+    function hide(): void { root.close() }
+    function toggle(): void { root.toggle() }
+    function reload(): string { root.reloadModel(); return root.hasModel ? "stopping " + root.model : "no model loaded" }
+    function usage(): string { return root.tooltipText() }
+  }
+
+  WidgetButton {
+    id: button
+    anchors.fill: parent
+    bar: root.bar
+    text: root.barText()
+    active: root.alarming
+    tooltipText: root.tooltipText()
+    onPressed: function(buttonCode) {
+      if (buttonCode === Qt.MiddleButton) root.reloadModel()
+      else root.toggle()
+    }
+  }
+
+  KeyboardPanel {
+    id: panel
+    anchorItem: button
+    owner: root
+    bar: root.bar
+    open: root.opened
+    focusTarget: keyCatcher
+    contentWidth: panel.fittedContentWidth(Style.space(340))
+    contentHeight: panel.fittedContentHeight(column.implicitHeight, Style.space(520))
+
+    PanelKeyCatcher {
+      id: keyCatcher
+      anchors.fill: parent
+
+      onActivateRequested: root.reloadModel()
+      onCloseRequested: root.close()
+      onTabRequested: function(direction) { root.switchPanel(direction) }
+      onTextKey: function(t) { if (t === "r" || t === "R") root.reloadModel() }
+
+      Column {
+        id: column
+        anchors.left: parent.left
+        anchors.right: parent.right
+        spacing: Style.space(12)
+
+        PanelHero {
+          width: parent.width
+          title: root.hasModel ? root.model : "Ollama"
+          meta: root.phaseText()
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+
+          iconComponent: Component {
+            Text {
+              textFormat: Text.PlainText
+              text: "󰓅"
+              color: root.alarming ? root.urgent : root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.display
+            }
+          }
+        }
+
+        // ---------- Truncation warning ----------
+        BorderSurface {
+          visible: root.truncated
+          width: parent.width
+          implicitHeight: truncText.implicitHeight + Style.spacing.xl * 2
+          color: root.alpha(root.urgent, 0.10)
+          borderSpec: Border.flat(root.alpha(root.urgent, 0.35), 1)
+          radius: Style.cornerRadius
+
+          Text {
+            id: truncText
+            textFormat: Text.PlainText
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.leftMargin: Style.space(12)
+            anchors.rightMargin: Style.space(12)
+            text: root.truncatedDetail
+              ? "Cache pressure cut the usable window to " + root.fmt(root.truncatedDetail.new)
+                + " tokens — the last prompt asked for " + root.fmt(root.truncatedDetail.prompt)
+                + ". Reload the model to clear it."
+              : "The last prompt was silently truncated."
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
+          }
+        }
+
+        // ---------- Context window ----------
+        PanelSeparator { foreground: root.foreground }
+
+        Column {
+          width: parent.width
+          spacing: Style.space(10)
+
+          PanelSectionHeader {
+            width: parent.width
+            text: "CONTEXT WINDOW"
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+          }
+
+          Item {
+            width: parent.width
+            implicitHeight: Math.max(usedLabel.implicitHeight, usedValue.implicitHeight)
+
+            Text {
+              id: usedLabel
+              textFormat: Text.PlainText
+              text: root.phase === "prefill" ? "Reading" : "Peak used"
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.body
+              anchors.left: parent.left
+              anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Text {
+              id: usedValue
+              textFormat: Text.PlainText
+              text: root.percentText(root.percent)
+              color: root.alarming ? root.urgent : root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+            }
+          }
+
+          Meter {
+            width: parent.width
+            value: root.percent
+            alarming: root.alarming
+          }
+
+          Text {
+            textFormat: Text.PlainText
+            width: parent.width
+            text: root.configuredMax > 0
+              ? root.fmt(root.tokens) + " of " + root.fmt(root.configuredMax) + " tokens"
+              : "No model loaded — the window is reported by the running model."
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
+          }
+        }
+
+        // ---------- Latency ----------
+        PanelSeparator {
+          visible: ttftSection.visible
+          foreground: root.foreground
+        }
+
+        Column {
+          id: ttftSection
+          visible: root.hasTtft
+          width: parent.width
+          spacing: Style.space(10)
+
+          PanelSectionHeader {
+            width: parent.width
+            text: "TIME TO FIRST TOKEN"
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+          }
+
+          Column {
+            width: parent.width
+            spacing: Style.space(4)
+
+            Row {
+              width: parent.width
+
+              Text {
+                text: "Last"
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                width: parent.width / 5
+              }
+              Text {
+                text: "Best"
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                width: parent.width / 5
+              }
+              Text {
+                text: "Worst"
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                width: parent.width / 5
+              }
+              Text {
+                text: "Avg"
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                width: parent.width / 5
+              }
+              Text {
+                text: "Med"
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                width: parent.width / 5
+              }
+            }
+
+            Row {
+              width: parent.width
+
+              Text {
+                text: root.secText(root.ttftLastMs)
+                textFormat: Text.PlainText
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                width: parent.width / 5
+              }
+              Text {
+                text: root.secText(root.ttftBestMs)
+                textFormat: Text.PlainText
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                width: parent.width / 5
+              }
+              Text {
+                text: root.secText(root.ttftWorstMs)
+                textFormat: Text.PlainText
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                width: parent.width / 5
+              }
+              Text {
+                text: root.secText(root.ttftAvgMs)
+                textFormat: Text.PlainText
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                width: parent.width / 5
+              }
+              Text {
+                text: root.secText(root.ttftMedianMs)
+                textFormat: Text.PlainText
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                width: parent.width / 5
+              }
+            }
+          }
+        }
+
+        // ---------- GPU ----------
+        PanelSeparator {
+          visible: gpuSection.visible
+          foreground: root.foreground
+        }
+
+        Column {
+          id: gpuSection
+          visible: root.hasGpu || root.layers !== null
+          width: parent.width
+          spacing: Style.space(10)
+
+          PanelSectionHeader {
+            width: parent.width
+            text: "GPU"
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+          }
+
+           StatRow {
+             visible: root.gpuUtil >= 0 || root.prefilling
+             width: parent.width
+             label: root.decoding ? "Decode (live)"
+               : root.prefilling ? "Ingest (live)" : "Utilisation"
+             value: root.decoding ? root.tokSecText(root.liveTokSec)
+               : root.prefilling ? (root.livePrefillTokSec >= 0 ? root.prefillValueText(root.livePrefillTokSec) : "—")
+               : Math.round(root.gpuUtil * 100) + "%"
+             ratio: root.decoding
+               ? (root.maxTokSec > 0 ? root.liveTokSec / root.maxTokSec : -1)
+               : root.prefilling
+                 ? (root.maxPrefillTokSec > 0 && root.livePrefillTokSec > 0 ? root.livePrefillTokSec / root.maxPrefillTokSec : -1)
+                 : root.gpuUtil
+           }
+
+           StatRow {
+             visible: root.lastPrefillTokSec >= 0
+             width: parent.width
+             label: "Last prefill"
+             value: root.prefillValueText(root.lastPrefillTokSec) + " average"
+             // Bar sized against the fastest ingest speed seen this load.
+             ratio: root.maxPrefillTokSec > 0 ? root.lastPrefillTokSec / root.maxPrefillTokSec : -1
+           }
+
+           StatRow {
+             visible: !root.decoding && root.lastTokSec >= 0
+             width: parent.width
+             label: "Last generation"
+             value: root.tokSecText(root.lastTokSec) + " average"
+             ratio: root.maxTokSec > 0 ? root.lastTokSec / root.maxTokSec : -1
+           }
+
+          Text {
+            textFormat: Text.PlainText
+            visible: text !== ""
+            width: parent.width
+            text: {
+              var parts = []
+              if (root.vramPercent >= 0)
+                parts.push("VRAM " + root.gib(root.vramUsed) + " / " + root.gib(root.vramTotal))
+              if (root.layers !== null)
+                parts.push("layers " + root.layersText() + " on GPU")
+              return parts.join(" · ")
+            }
+            // Full VRAM or a partial offload means truncation / slow decode —
+            // the same alarm colours the meter rows used to carry.
+            color: (root.partialOffload || root.vramPercent >= 0.95) ? root.urgent : root.dim
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
+          }
+
+          Text {
+            textFormat: Text.PlainText
+            visible: text !== ""
+            width: parent.width
+            text: {
+              var parts = []
+              if (root.processor !== "") parts.push(root.processor)
+              if (root.modelBufferMiB > 0) parts.push("weights " + root.gib(root.modelBufferMiB))
+              if (root.hasGpu && root.gpu.temp !== null) parts.push(root.gpu.temp + " °C")
+              if (root.hasGpu && root.gpu.power !== null) parts.push(Math.round(root.gpu.power) + " W")
+              return parts.join(" · ")
+            }
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
+          }
+
+          Text {
+            textFormat: Text.PlainText
+            visible: root.partialOffload
+            width: parent.width
+            text: "Part of this model is running on the CPU — expect it to be several times slower."
+            color: root.urgent
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
+          }
+        }
+
+        // ---------- Reload ----------
+        PanelSeparator { foreground: root.foreground }
+
+        Button {
+          width: parent.width
+          text: reloadProc.running ? "Reloading…" : "Reload model"
+          bordered: true
+          opacity: root.hasModel && !reloadProc.running ? 1 : 0.45
+          hasCursor: root.cursorActive
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+          fontSize: Style.font.bodySmall
+          verticalPadding: Style.spacing.controlPaddingY
+          onClicked: root.reloadModel()
+          onHovered: function(isHovered) { if (isHovered) root.cursorActive = true }
+        }
+
+        Text {
+          textFormat: Text.PlainText
+          visible: text !== ""
+          width: parent.width
+          text: root.hasState ? root.updatedText() : "Watcher not running: omarchy-ollama-context-watch.service"
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          horizontalAlignment: Text.AlignHCenter
+          wrapMode: Text.WordWrap
+        }
+      }
+    }
+  }
+
+  // Label, value, and a meter underneath — the shape every GPU figure takes.
+  component StatRow: Column {
+    id: statRow
+    property string label: ""
+    property string value: ""
+    property real ratio: -1
+    property bool alarming: false
+
+    spacing: Style.space(6)
+
+    Item {
+      width: parent.width
+      implicitHeight: Math.max(statLabel.implicitHeight, statValue.implicitHeight)
+
+      Text {
+        id: statLabel
+        textFormat: Text.PlainText
+        text: statRow.label
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        elide: Text.ElideRight
+        anchors.left: parent.left
+        anchors.right: statValue.left
+        anchors.rightMargin: Style.spacing.sm
+        anchors.verticalCenter: parent.verticalCenter
+      }
+
+      Text {
+        id: statValue
+        textFormat: Text.PlainText
+        text: statRow.value
+        color: statRow.alarming ? root.urgent : root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+      }
+    }
+
+    Meter {
+      width: parent.width
+      value: statRow.ratio
+      alarming: statRow.alarming
+    }
+  }
+
+  // Rounded track showing how much of the window the current prompt fills.
+  component Meter: Item {
+    id: meter
+    property real value: -1
+    property bool alarming: false
+    property real thickness: Math.max(Style.space(4), Math.round(Style.spacing.controlHeight * 0.14))
+
+    implicitHeight: thickness
+
+    Rectangle {
+      id: meterTrack
+      anchors.fill: parent
+      radius: height / 2
+      color: root.track
+    }
+
+    Rectangle {
+      anchors.left: meterTrack.left
+      anchors.verticalCenter: meterTrack.verticalCenter
+      height: meterTrack.height
+      radius: meterTrack.radius
+      width: meterTrack.width * root.clamp(meter.value, 0, 1)
+      color: meter.alarming ? root.urgent : root.foreground
+
+      Behavior on width {
+        NumberAnimation { duration: 160; easing.type: Easing.OutCubic }
+      }
+    }
+  }
+}

--- a/shell/plugins/panels/ollama/manifest.json
+++ b/shell/plugins/panels/ollama/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.ollama-stats",
+  "name": "Ollama stats",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Live context-window usage, speeds, and latency for the local Ollama model",
+  "kinds": [
+    "bar-widget"
+  ],
+  "entryPoints": {
+    "barWidget": "Panel.qml"
+  },
+  "barWidget": {
+    "displayName": "Ollama stats",
+    "description": "Live context-window usage for the locally loaded Ollama model, sourced from omarchy-ollama-context-watch.",
+    "category": "AI",
+    "allowMultiple": false
+  }
+}

--- a/test/shell.d/ollama-context-watch-test.sh
+++ b/test/shell.d/ollama-context-watch-test.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command python3
+
+# Drive the watcher's journal-line parser with realistic llama.cpp lines and
+# check the state it keeps. write_state is stubbed so no file is written and
+# the wall-clock TTFT delta stays deterministic.
+ROOT="$ROOT" python3 - <<'PY'
+import importlib.machinery
+import importlib.util
+import os
+from pathlib import Path
+
+loader = importlib.machinery.SourceFileLoader(
+  "watcher", os.environ["ROOT"] + "/bin/omarchy-ollama-context-watch")
+spec = importlib.util.spec_from_loader(loader.name, loader)
+watcher = importlib.util.module_from_spec(spec)
+loader.exec_module(watcher)
+
+class FakeWatch(watcher.Watcher):
+  def __init__(self):
+    super().__init__()
+    self.state["configuredMax"] = 196608
+    self.state["modelLoaded"] = "qwen3.8:27b"
+    self.written = 0
+  def write_state(self):
+    self.written += 1
+
+w = FakeWatch()
+w.request_started_at = 1000.0  # deterministic TTFT start
+
+def phase():
+  return w.state["phase"]
+
+# Load-time facts are captured once.
+w.handle_line("llama_model_load: - type  f32:  360 tensors")
+w.handle_line("load_tensors: offloaded 66/66 layers to GPU")
+w.handle_line("load_tensors:        CUDA0 model buffer size = 15339.44 MiB")
+assert w.state["layers"] == {"offloaded": 66, "total": 66}, w.state["layers"]
+assert w.state["modelBufferMiB"] == 15339.44, w.state["modelBufferMiB"]
+
+# A request starts: the new prompt sets the absolute input position.
+w.handle_line("slot   operator(): id  0 | task 108186 | new prompt, n_ctx_slot = 196608, n_keep = 4, task.n_tokens = 49469")
+assert phase() == "prefill", phase()
+assert w.state["contextPos"] == 49469, w.state["contextPos"]
+assert w.state["contextPeak"] == 49469, w.state["contextPeak"]
+
+# Prefill progress lines climb and feed the live ingest speed.
+w.handle_line("slot   operator(): id  0 | task 108186 | prompt processing, n_tokens = 49057, progress = 0.92")
+assert phase() == "prefill", phase()
+assert w.state["prefillProgress"] == {"nTokens": 49057, "percent": 0.92}, w.state["prefillProgress"]
+w.prev_progress = (w.state["prefillProgress"]["nTokens"], 1001.0)
+w.handle_line("slot   operator(): id  0 | task 108186 | prompt processing, n_tokens = 49469, progress = 1.00")
+assert w.state["livePrefillTokensPerSec"] > 0, w.state["livePrefillTokensPerSec"]
+
+# Prompt eval done: whole-prefill average recorded, TTFT measured, and the
+# truncated flag consumed from a pending truncation marker.
+w.pending_truncation = {"limit": 196608, "prompt": 49469, "keep": 4, "new": 32000}
+w.handle_line("slot print_timing: id  0 | task 108186 | prompt eval time =     256.56 ms /   408 tokens (    0.63 ms per token,  1590.30 tokens per second)")
+assert phase() == "generating", phase()
+assert w.state["lastPrefillTokensPerSec"] == 1590.30, w.state["lastPrefillTokensPerSec"]
+assert w.state["ttftCount"] == 1 and w.state["ttftLastMs"] > 0, w.state["ttftCount"]
+assert w.state["truncated"] is True, w.state["truncated"]
+
+# Generation print_timing lines carry live decode speed and the growing
+# absolute position (baseline + n_gen).
+w.handle_line("slot print_timing: id  0 | task 108186 | n_gen =    169, tg =  55.25 t/s, tg_3s =  55.57 t/s")
+assert phase() == "generating", phase()
+assert w.state["liveTokensPerSec"] == 55.57, w.state["liveTokensPerSec"]
+assert w.state["contextPos"] == 49469 + 169, w.state["contextPos"]
+assert w.state["maxTokensPerSec"] == 55.57, w.state["maxTokensPerSec"]
+w.handle_line("slot print_timing: id  0 | task 108186 | n_gen =    502, tg =  55.30 t/s, tg_3s =  52.22 t/s")
+assert w.state["contextPos"] == 49469 + 502, w.state["contextPos"]
+
+# The closing eval-time line keeps the whole-run average and drops the live one.
+w.handle_line("slot print_timing: id  0 | task 108186 |        eval time =    5368.72 ms /   547 tokens (    9.83 ms per token,   101.70 tokens per second)")
+assert phase() == "idle", phase()
+assert w.state["lastTokensPerSec"] == 101.70, w.state["lastTokensPerSec"]
+assert w.state["liveTokensPerSec"] is None, w.state["liveTokensPerSec"]
+
+# Stop processing settles the definitive position and clears the request
+# baseline. A smaller stray request on another lineage must not lower the peak.
+w.handle_line("slot      release: id  0 | task 108186 | stop processing: n_tokens = 49971, truncated = 0")
+assert w.state["contextPos"] == 49971, w.state["contextPos"]
+assert w.state["contextPeak"] == 49971, w.state["contextPeak"]
+w.handle_line("slot   operator(): id  0 | task 108423 | new prompt, n_ctx_slot = 196608, n_keep = 4, task.n_tokens = 3000")
+assert w.state["contextPos"] == 3000, w.state["contextPos"]
+assert w.state["contextPeak"] == 49971, w.state["contextPeak"]
+
+# A truncation is the one event that resets both the position and the peak.
+w.handle_line('llama.cpp: msg="truncating input prompt" limit=196608 prompt=49971 keep=4 new=29000')
+assert w.state["truncated"] is True, w.state["truncated"]
+assert w.state["contextPos"] == 29000 and w.state["contextPeak"] == 29000, (w.state["contextPos"], w.state["contextPeak"])
+
+print("ok - watcher parses journal lines into context, speed, and TTFT state")
+PY


### PR DESCRIPTION
## What

Adds an **Ollama stats** bar widget (`omarchy.ollama-stats`) showing live metrics for the locally running Ollama model:

- Context-window usage as a session peak (monotonic per model load, so stray requests on other conversation lineages don't make the meter bounce)
- Live decode speed (`tg_3s` from llama.cpp's `slot print_timing` lines) and prompt-ingest speed (progress-line deltas + the `prompt eval time` whole-run average)
- TTFT history (last / best / worst / avg / median) measured between the `new prompt` and `prompt eval time` journal lines
- Truncation warnings — the reason this exists: ollama silently truncates prompts under cache pressure, and the widget offers a one-click `ollama stop` reload to clear it

## How it's built

- `shell/plugins/panels/ollama/` — the panel (bar-widget, category AI), following the existing `panels/*` first-party plugin shape
- `bin/omarchy-ollama-context-watch` — hidden Python command that tails the ollama journal and writes an atomic JSON snapshot to `$XDG_STATE_HOME/omarchy/ollama-context-watch/state.json`
- `default/systemd/user/omarchy-ollama-context-watch.service` — guarded by `ConditionPathExists=/usr/bin/ollama` (same pattern as `omarchy-tailscale-receive.service`)
- `migrations/1788595667.sh` — enables the service on existing installs that have ollama
- `test/shell.d/ollama-context-watch-test.sh` — drives the journal parser with real llama.cpp lines and asserts the state transitions

## Notes

- The widget is not placed on the default bar; users add it with `omarchy bar put omarchy.ollama-stats`.
- `docs/file-layout.md` says new `default/` files need an `install -Dm644` line in the `omarchy-pkgs` PKGBUILD (`omarchy-settings`) — that lives in the separate `omarchy-pkgs` repo and is out of scope here.
- `./test/all` passes with the same 4 pre-existing environmental failures as the pristine tree (they require the external `omarchy-pkgs` checkout and a single-monitor assumption in `runtime-smoke-test.sh`); the new test and the manifest-entrypoint/qml-text-format scans pass.

## Verification

- `./test/cli`: 116 ok, 0 not ok
- `./test/shell`: new `ollama-context-watch-test.sh` passes; manifest-entrypoints load passes with the widget; no new failures vs pristine
- The widget has been running live on a 4090 + qwen3.8:27b (196k window) through development, including live tok/s and prefill t/s readouts