### PR TITLE
Add original vi as a standard terminal editor

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -27,6 +27,7 @@ dosfstools
 dotnet-runtime
 dua-cli
 evince
+ex-vi-compat
 exfatprogs
 expac
 eza

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -27,7 +27,6 @@ dosfstools
 dotnet-runtime
 dua-cli
 evince
-ex-vi-compat
 exfatprogs
 expac
 eza
@@ -134,6 +133,7 @@ ufw-docker
 unzip
 usage
 uwsm
+vi
 whois
 wireless-regdb
 wireplumber

--- a/manual/18-development-tools.md
+++ b/manual/18-development-tools.md
@@ -4,7 +4,7 @@
 
 Omarchy ships with [Neovim](https://neovim.io/) by default, but if you'd like something a bit more mainstream and familiar, you can run the Omarchy Menu (`Super + Space`) and see the options under _Install > Editor_. We have VSCode, Cursor, Zed, Sublime Text, Helix, Vim, and Emacs listed there. If you don't find what you're looking for, checkout _Install > Package_, and see if it isn't in an Arch package (and if not, try _Install > AUR_ to check the AUR).
 
-The `vi` command is also available out of the box through Vim's compatibility mode. Run `vi filename` to edit a file in the terminal.
+The original `vi` editor is also available out of the box. Run `vi filename` to edit a file in the terminal.
 
 Theme matching is offered for `VSCode`, `Cursor`, `VSCodium`, and `Helix`.
 

--- a/manual/18-development-tools.md
+++ b/manual/18-development-tools.md
@@ -4,6 +4,8 @@
 
 Omarchy ships with [Neovim](https://neovim.io/) by default, but if you'd like something a bit more mainstream and familiar, you can run the Omarchy Menu (`Super + Space`) and see the options under _Install > Editor_. We have VSCode, Cursor, Zed, Sublime Text, Helix, Vim, and Emacs listed there. If you don't find what you're looking for, checkout _Install > Package_, and see if it isn't in an Arch package (and if not, try _Install > AUR_ to check the AUR).
 
+The `vi` command is also available out of the box through Vim's compatibility mode. Run `vi filename` to edit a file in the terminal.
+
 Theme matching is offered for `VSCode`, `Cursor`, `VSCodium`, and `Helix`.
 
 You can set the system-wide default editor under `Setup > Defaults > Editor`.

--- a/migrations/1788596255.sh
+++ b/migrations/1788596255.sh
@@ -1,0 +1,3 @@
+echo "Add vi as a standard terminal editor"
+
+omarchy-pkg-add ex-vi-compat

--- a/migrations/1788596255.sh
+++ b/migrations/1788596255.sh
@@ -1,3 +1,3 @@
 echo "Add vi as a standard terminal editor"
 
-omarchy-pkg-add ex-vi-compat
+omarchy-pkg-add vi


### PR DESCRIPTION
Give the original `vi` editor a home in Omarchy. This adds `vi` to the standard package list for fresh installs, installs it through a migration for existing users, and documents `vi filename` in the development tools manual.

Bill Joy began developing vi at Berkeley around 1976. Fifty years later, its editing language still lives in our fingers: motions, operators, and a few well-chosen keystrokes that compose into something remarkably powerful. The [traditional vi project](https://ex-vi.sourceforge.net/) preserves the original editor's style and feature set while making it usable on modern Unix systems, including support for UTF-8.

We should honor our elders. Computing history deserves to remain something you can run, learn from, and use every day. Shipping the original vi keeps a little of that history alive and puts the work of the people who built our foundations within reach of anyone curious enough to type `vi`.

And a tiny vi is simply great. The tested x86_64 package takes just **313 KiB installed**, with a **174 KiB download**, and depends only on ncurses. That's a wonderfully small price for a capable editor that can open a file, make a quick change, and get out of the way.

For everything more ambitious, Omarchy already ships a great, full-featured Neovim environment with LazyVim: plugins, completion, navigation, and all the comforts of a modern development setup. There is room for both the original and its richly equipped descendant. A tiny `vi` for the simple jobs, our complete `nvim` setup when you want the works.

The package comes from https://github.com/omacom/omarchy-pkgs/pull/314 and must be published to the target channel before this change ships.

Validation: built the package with source checksum and PGP verification and exercised insert, substitution, and save commands. Checked migration syntax, exercised the migration with a stubbed package helper, and ran `git diff --check`.
