### PR TITLE
Cap MacBook10,1 RAPL at 4.5W/7W and CPU turbo at 3GHz

### DIFF
--- a/bin/omarchy-hw-macbook10
+++ b/bin/omarchy-hw-macbook10
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# omarchy:summary=Detect the 2017 12-inch MacBook (MacBook10,1).
+
+omarchy-hw-match "MacBook10,1"

--- a/bin/omarchy-hw-macbook10-power-envelope
+++ b/bin/omarchy-hw-macbook10-power-envelope
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# omarchy:summary=Apply the MacBook10,1 RAPL and 3GHz CPU envelope
+# omarchy:args=[status]
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+PL1_UW=4500000
+PL2_UW=7000000
+PL1_WINDOW_US=28000000
+PL2_WINDOW_US=2000000
+CPU_MAX_KHZ=3000000
+
+sysfs_root=${OMARCHY_SYSFS_ROOT:-}
+
+sysfs() {
+  printf '%s%s' "$sysfs_root" "$1"
+}
+
+product_name() {
+  cat "$(sysfs /sys/class/dmi/id/product_name)" 2>/dev/null || true
+}
+
+write_sysfs() {
+  local path=$1
+  local value=$2
+
+  [[ -f $path ]] || return 0
+  printf '%s\n' "$value" >"$path"
+}
+
+print_status() {
+  local rapl cpu0_max cpu0_cur pct temp
+
+  rapl=$(sysfs /sys/class/powercap/intel-rapl:0)
+  cpu0_max=$(sysfs /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq)
+  cpu0_cur=$(sysfs /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)
+  pct=$(sysfs /sys/devices/system/cpu/intel_pstate/max_perf_pct)
+  temp=$(sysfs /sys/class/thermal/thermal_zone0/temp)
+
+  printf 'product=%s\n' "$(product_name)"
+  printf 'target_pl1_uw=%s\n' "$PL1_UW"
+  printf 'target_pl2_uw=%s\n' "$PL2_UW"
+  printf 'target_cpu_max_khz=%s\n' "$CPU_MAX_KHZ"
+  printf 'pl1_uw=%s\n' "$(cat "$rapl/constraint_0_power_limit_uw" 2>/dev/null || echo missing)"
+  printf 'pl2_uw=%s\n' "$(cat "$rapl/constraint_1_power_limit_uw" 2>/dev/null || echo missing)"
+  printf 'pl1_window_us=%s\n' "$(cat "$rapl/constraint_0_time_window_us" 2>/dev/null || echo missing)"
+  printf 'pl2_window_us=%s\n' "$(cat "$rapl/constraint_1_time_window_us" 2>/dev/null || echo missing)"
+  printf 'cpu0_scaling_max_khz=%s\n' "$(cat "$cpu0_max" 2>/dev/null || echo missing)"
+  printf 'cpu0_scaling_cur_khz=%s\n' "$(cat "$cpu0_cur" 2>/dev/null || echo missing)"
+  printf 'max_perf_pct=%s\n' "$(cat "$pct" 2>/dev/null || echo missing)"
+  printf 'pkg_temp_mc=%s\n' "$(cat "$temp" 2>/dev/null || echo missing)"
+}
+
+apply_envelope() {
+  local rapl cpuinfo_max want pct scaling_max_files path
+
+  if [[ $(product_name) != "MacBook10,1" ]]; then
+    return 0
+  fi
+
+  if [[ -z $sysfs_root ]] && ((EUID != 0)); then
+    echo "omarchy-hw-macbook10-power-envelope must run as root" >&2
+    exit 1
+  fi
+
+  rapl=$(sysfs /sys/class/powercap/intel-rapl:0)
+  if [[ ! -d $rapl ]]; then
+    echo "intel-rapl sysfs is missing" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$PL1_UW" >"$rapl/constraint_0_power_limit_uw"
+  printf '%s\n' "$PL2_UW" >"$rapl/constraint_1_power_limit_uw"
+  write_sysfs "$rapl/constraint_0_time_window_us" "$PL1_WINDOW_US"
+  write_sysfs "$rapl/constraint_1_time_window_us" "$PL2_WINDOW_US"
+  write_sysfs "$rapl/enabled" "1"
+
+  cpuinfo_max=$(cat "$(sysfs /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq)")
+  want=$CPU_MAX_KHZ
+  if ((want > cpuinfo_max)); then
+    want=$cpuinfo_max
+  fi
+
+  shopt -s nullglob
+  scaling_max_files=("$(sysfs /sys/devices/system/cpu)"/cpu*/cpufreq/scaling_max_freq)
+  shopt -u nullglob
+  ((${#scaling_max_files[@]} > 0)) || {
+    echo "cpufreq scaling_max_freq is missing" >&2
+    exit 1
+  }
+
+  for path in "${scaling_max_files[@]}"; do
+    printf '%s\n' "$want" >"$path"
+  done
+
+  if ((cpuinfo_max > 0)); then
+    pct=$((want * 100 / cpuinfo_max))
+    write_sysfs "$(sysfs /sys/devices/system/cpu/intel_pstate/max_perf_pct)" "$pct"
+  fi
+}
+
+case "${1:-apply}" in
+  status)
+    print_status
+    ;;
+  apply | "")
+    apply_envelope
+    ;;
+  *)
+    echo "Usage: omarchy-hw-macbook10-power-envelope [status]" >&2
+    exit 1
+    ;;
+esac

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -37,6 +37,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-macbook10-power-envelope.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 

--- a/install/hardware/apple/fix-macbook10-power-envelope.sh
+++ b/install/hardware/apple/fix-macbook10-power-envelope.sh
@@ -1,0 +1,37 @@
+# The 2017 12-inch MacBook (MacBook10,1) is fanless. Apple leaves RAPL unlocked,
+# so Linux programs a 49W package cap on a 4.5W Y-series part and the i7-7Y75
+# turbos to 3.6GHz until the 100°C trip. Cap PL1/PL2 to Intel's TDP / cTDP-up
+# and CPU turbo to the m3-7Y32's 3.0GHz so the chassis stays in the envelope
+# both SKUs were rated for.
+
+if omarchy-hw-macbook10; then
+  echo "Detected MacBook10,1; capping RAPL at 4.5W/7W and CPU turbo at 3GHz"
+
+  unit_path=${OMARCHY_MACBOOK10_ENVELOPE_UNIT:-/etc/systemd/system/omarchy-macbook10-power-envelope.service}
+  sleep_hook=${OMARCHY_MACBOOK10_ENVELOPE_SLEEP_HOOK:-/usr/lib/systemd/system-sleep/omarchy-macbook10-power-envelope}
+  envelope_bin=${OMARCHY_MACBOOK10_ENVELOPE_BIN:-${OMARCHY_PATH:-/usr/share/omarchy}/bin/omarchy-hw-macbook10-power-envelope}
+
+  sudo mkdir -p "$(dirname "$unit_path")" "$(dirname "$sleep_hook")"
+
+  sudo tee "$unit_path" >/dev/null <<EOF
+[Unit]
+Description=Omarchy MacBook10,1 RAPL and CPU frequency envelope
+
+[Service]
+Type=oneshot
+ExecStart=$envelope_bin
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  sudo tee "$sleep_hook" >/dev/null <<EOF
+#!/bin/bash
+[[ \$1 == post ]] || exit 0
+exec "$envelope_bin"
+EOF
+  sudo chmod 755 "$sleep_hook"
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now omarchy-macbook10-power-envelope.service
+fi

--- a/migrations/1788380505.sh
+++ b/migrations/1788380505.sh
@@ -1,0 +1,3 @@
+echo "Cap MacBook10,1 package power at 4.5W/7W and CPU turbo at 3GHz"
+
+source "$OMARCHY_PATH/install/hardware/apple/fix-macbook10-power-envelope.sh"

--- a/test/shell.d/macbook10-power-envelope-test.sh
+++ b/test/shell.d/macbook10-power-envelope-test.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+detector="$ROOT/bin/omarchy-hw-macbook10"
+apply="$ROOT/bin/omarchy-hw-macbook10-power-envelope"
+leaf="$ROOT/install/hardware/apple/fix-macbook10-power-envelope.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1788380505.sh"
+
+grep -q 'apple/fix-macbook10-power-envelope.sh' "$all" ||
+  fail "the MacBook10,1 power envelope runs during hardware setup"
+pass "the MacBook10,1 power envelope runs during hardware setup"
+
+grep -q 'fix-macbook10-power-envelope.sh' "$migration" ||
+  fail "a migration applies the envelope on existing installs"
+pass "a migration applies the envelope on existing installs"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-hw-match" <<'SH'
+#!/bin/bash
+[[ ${TEST_PRODUCT_NAME:-} == *"$1"* ]]
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_detector() {
+  PATH="$stub_bin:$PATH" TEST_PRODUCT_NAME="$1" bash "$detector"
+}
+
+run_detector "MacBook10,1" || fail "the detector matches MacBook10,1"
+pass "the detector matches MacBook10,1"
+
+run_detector "MacBookPro14,1" && fail "the detector rejects a MacBook Pro"
+pass "the detector rejects a MacBook Pro"
+
+run_detector "MacBook9,1" && fail "the detector rejects the 2016 12-inch"
+pass "the detector rejects the 2016 12-inch"
+
+fake_sysfs() {
+  local root=$1 product=${2:-MacBook10,1}
+  mkdir -p "$root/sys/class/dmi/id" \
+    "$root/sys/class/powercap/intel-rapl:0" \
+    "$root/sys/devices/system/cpu/cpu0/cpufreq" \
+    "$root/sys/devices/system/cpu/cpu1/cpufreq" \
+    "$root/sys/devices/system/cpu/intel_pstate" \
+    "$root/sys/class/thermal/thermal_zone0"
+  printf '%s\n' "$product" >"$root/sys/class/dmi/id/product_name"
+  printf '49000000\n' >"$root/sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw"
+  printf '49000000\n' >"$root/sys/class/powercap/intel-rapl:0/constraint_1_power_limit_uw"
+  printf '27983872\n' >"$root/sys/class/powercap/intel-rapl:0/constraint_0_time_window_us"
+  printf '2440\n' >"$root/sys/class/powercap/intel-rapl:0/constraint_1_time_window_us"
+  printf '1\n' >"$root/sys/class/powercap/intel-rapl:0/enabled"
+  printf '3600000\n' >"$root/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"
+  printf '3600000\n' >"$root/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq"
+  printf '1300000\n' >"$root/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"
+  printf '3600000\n' >"$root/sys/devices/system/cpu/cpu1/cpufreq/cpuinfo_max_freq"
+  printf '3600000\n' >"$root/sys/devices/system/cpu/cpu1/cpufreq/scaling_max_freq"
+  printf '100\n' >"$root/sys/devices/system/cpu/intel_pstate/max_perf_pct"
+  printf '63000\n' >"$root/sys/class/thermal/thermal_zone0/temp"
+}
+
+sys="$test_tmp/sysfs"
+fake_sysfs "$sys"
+
+OMARCHY_SYSFS_ROOT="$sys" bash "$apply"
+[[ $(cat "$sys/sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw") == 4500000 ]] ||
+  fail "apply writes PL1 4.5W"
+[[ $(cat "$sys/sys/class/powercap/intel-rapl:0/constraint_1_power_limit_uw") == 7000000 ]] ||
+  fail "apply writes PL2 7W"
+[[ $(cat "$sys/sys/class/powercap/intel-rapl:0/constraint_1_time_window_us") == 2000000 ]] ||
+  fail "apply sets a multi-second PL2 window"
+[[ $(cat "$sys/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq") == 3000000 ]] ||
+  fail "apply caps CPU0 at 3GHz"
+[[ $(cat "$sys/sys/devices/system/cpu/cpu1/cpufreq/scaling_max_freq") == 3000000 ]] ||
+  fail "apply caps CPU1 at 3GHz"
+[[ $(cat "$sys/sys/devices/system/cpu/intel_pstate/max_perf_pct") == 83 ]] ||
+  fail "apply sets max_perf_pct to 83"
+pass "apply writes the 4.5W/7W RAPL cap and 3GHz CPU ceiling"
+
+other="$test_tmp/other"
+fake_sysfs "$other" "MacBookPro14,1"
+OMARCHY_SYSFS_ROOT="$other" bash "$apply"
+[[ $(cat "$other/sys/class/powercap/intel-rapl:0/constraint_0_power_limit_uw") == 49000000 ]] ||
+  fail "apply leaves unrelated hardware RAPL unchanged"
+[[ $(cat "$other/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq") == 3600000 ]] ||
+  fail "apply leaves unrelated hardware frequency unchanged"
+pass "apply is a no-op off MacBook10,1"
+
+status=$(OMARCHY_SYSFS_ROOT="$sys" bash "$apply" status)
+[[ $status == *pl1_uw=4500000* ]] || fail "status reports the applied PL1" "$status"
+[[ $status == *cpu0_scaling_max_khz=3000000* ]] || fail "status reports the applied CPU cap" "$status"
+pass "status reports the applied envelope"
+
+unit="$test_tmp/omarchy-macbook10-power-envelope.service"
+hook="$test_tmp/sleep-hook"
+envelope_copy="$test_tmp/omarchy-hw-macbook10-power-envelope"
+cp "$apply" "$envelope_copy"
+chmod +x "$envelope_copy"
+
+run_leaf() {
+  : >"$calls"
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+    TEST_PRODUCT_NAME="$1" \
+    TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_MACBOOK10_ENVELOPE_UNIT="$unit" \
+    OMARCHY_MACBOOK10_ENVELOPE_SLEEP_HOOK="$hook" \
+    OMARCHY_MACBOOK10_ENVELOPE_BIN="$envelope_copy" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$leaf"
+}
+
+rm -f "$unit" "$hook"
+run_leaf "MacBookPro14,1"
+[[ ! -f $unit ]] || fail "setup skips unrelated hardware"
+[[ ! -s $calls ]] || fail "setup escalates nothing on unrelated hardware" "$(cat "$calls")"
+pass "setup skips unrelated hardware"
+
+run_leaf "MacBook10,1"
+[[ -f $unit ]] || fail "setup writes the systemd unit"
+grep -Fq "ExecStart=$envelope_copy" "$unit" ||
+  fail "the unit runs the envelope command" "$(cat "$unit")"
+[[ -x $hook ]] || fail "setup installs an executable resume hook"
+grep -Fq "exec \"$envelope_copy\"" "$hook" ||
+  fail "the resume hook re-applies the envelope" "$(cat "$hook")"
+grep -Fq $'systemctl\tenable\t--now\tomarchy-macbook10-power-envelope.service' "$calls" ||
+  fail "setup enables the envelope service" "$(cat "$calls")"
+pass "setup installs the boot unit and resume hook"
+
+: >"$calls"
+run_leaf "MacBook10,1"
+grep -Fq $'systemctl\tenable\t--now\tomarchy-macbook10-power-envelope.service' "$calls" ||
+  fail "setup remains idempotent" "$(cat "$calls")"
+pass "setup remains idempotent"
+
+: >"$calls"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_PRODUCT_NAME="MacBook10,1" \
+  TEST_LOG="$calls" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_MACBOOK10_ENVELOPE_UNIT="$unit" \
+  OMARCHY_MACBOOK10_ENVELOPE_SLEEP_HOOK="$hook" \
+  OMARCHY_MACBOOK10_ENVELOPE_BIN="$envelope_copy" \
+  bash -euo pipefail "$migration"
+grep -Fq $'systemctl\tenable\t--now\tomarchy-macbook10-power-envelope.service' "$calls" ||
+  fail "the migration runs hardware setup" "$(cat "$calls")"
+pass "the migration runs hardware setup"


### PR DESCRIPTION
## Summary
- Guarded on DMI `MacBook10,1` (2017 12-inch, fanless). Apple leaves RAPL unlocked, so Linux programs a 49W package cap on a 4.5W Y-series part and the i7-7Y75 turbos to 3.6GHz until the 100°C trip.
- Cap PL1 at Intel's 4.5W TDP, PL2 at 7W (cTDP-up), and `scaling_max_freq` at 3.0GHz (the m3-7Y32 turbo both SKUs share). Re-apply after S3 via a system-sleep hook.
- Existing installs pick this up through a migration. No-op on every other machine.

## Test plan
- [x] `bash test/shell.d/macbook10-power-envelope-test.sh` (pass)
- [x] Live on MacBook10,1 i7-7Y75: after apply, `constraint_0_power_limit_uw=4500000`, `constraint_1_power_limit_uw=7000000`, `cpu0 scaling_max_freq=3000000`
- [x] Envelope still held after a later force reboot
- [ ] Confirm the leaf is a no-op on a non-MacBook10,1 (guard)
- [ ] `omarchy update` on an existing MacBook10,1 runs the migration and enables the oneshot