### PR TITLE
Disable MacBook10,1 BCM4350 wakeup through S3

### DIFF
--- a/bin/omarchy-hw-macbook10-sleep-drain
+++ b/bin/omarchy-hw-macbook10-sleep-drain
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# omarchy:summary=Disable MacBook10,1 Wi-Fi wakeup so S3 does not keep the radio powered
+# omarchy:args=[status]
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+WIFI_VENDOR=0x14e4
+WIFI_DEVICE=0x43a3
+
+sysfs_root=${OMARCHY_SYSFS_ROOT:-}
+acpi_wakeup=${OMARCHY_ACPI_WAKEUP:-/proc/acpi/wakeup}
+
+sysfs() {
+  printf '%s%s' "$sysfs_root" "$1"
+}
+
+product_name() {
+  cat "$(sysfs /sys/class/dmi/id/product_name)" 2>/dev/null || true
+}
+
+wifi_pci_dirs() {
+  local vendor_file dir
+
+  shopt -s nullglob
+  for vendor_file in "$(sysfs /sys/bus/pci/devices)"/*/vendor; do
+    dir=$(dirname "$vendor_file")
+    [[ $(<"$vendor_file") == "$WIFI_VENDOR" ]] || continue
+    [[ -f $dir/device && $(<"$dir/device") == "$WIFI_DEVICE" ]] || continue
+    printf '%s\n' "$dir"
+  done
+  shopt -u nullglob
+}
+
+acpi_arpt_state() {
+  local line
+
+  [[ -f $acpi_wakeup ]] || {
+    echo missing
+    return 0
+  }
+
+  line=$(grep -E '^ARPT[[:space:]]' "$acpi_wakeup" || true)
+  [[ -n $line ]] || {
+    echo missing
+    return 0
+  }
+
+  if [[ $line == *'*enabled'* ]]; then
+    echo enabled
+  else
+    echo disabled
+  fi
+}
+
+print_status() {
+  local dir wakeup
+
+  printf 'product=%s\n' "$(product_name)"
+  printf 'acpi_arpt=%s\n' "$(acpi_arpt_state)"
+
+  wakeup=missing
+  while IFS= read -r dir; do
+    [[ -n $dir ]] || continue
+    wakeup=$(cat "$dir/power/wakeup" 2>/dev/null || echo missing)
+    printf 'pci=%s wakeup=%s\n' "$(basename "$dir")" "$wakeup"
+  done < <(wifi_pci_dirs)
+
+  if [[ $wakeup == missing ]]; then
+    printf 'pci=missing wakeup=missing\n'
+  fi
+}
+
+disable_acpi_arpt() {
+  [[ -f $acpi_wakeup ]] || return 0
+  [[ $(acpi_arpt_state) == enabled ]] || return 0
+  printf 'ARPT\n' >"$acpi_wakeup"
+}
+
+apply_drain() {
+  local dir
+
+  if [[ $(product_name) != "MacBook10,1" ]]; then
+    return 0
+  fi
+
+  if [[ -z $sysfs_root ]] && ((EUID != 0)); then
+    echo "omarchy-hw-macbook10-sleep-drain must run as root" >&2
+    exit 1
+  fi
+
+  while IFS= read -r dir; do
+    [[ -n $dir && -f $dir/power/wakeup ]] || continue
+    printf 'disabled\n' >"$dir/power/wakeup"
+  done < <(wifi_pci_dirs)
+
+  disable_acpi_arpt
+}
+
+case "${1:-apply}" in
+  status)
+    print_status
+    ;;
+  apply | "")
+    apply_drain
+    ;;
+  *)
+    echo "Usage: omarchy-hw-macbook10-sleep-drain [status]" >&2
+    exit 1
+    ;;
+esac

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -37,6 +37,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-macbook10-sleep-drain.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 

--- a/install/hardware/apple/fix-macbook10-sleep-drain.sh
+++ b/install/hardware/apple/fix-macbook10-sleep-drain.sh
@@ -1,0 +1,49 @@
+# The 2017 12-inch MacBook (MacBook10,1) leaks around a third of a watt in S3.
+# ACPI leaves Airport (ARPT / BCM4350) armed as a wake source, which keeps the
+# radio powered for the whole sleep. Disable that wakeup.
+#
+# Do not switch the lid to suspend-then-hibernate. On this chassis hibernate
+# never reached S4: the session lock came up and applespi stopped delivering
+# keyboard and trackpad events, so the only recovery was a force reboot.
+
+if omarchy-hw-match "MacBook10,1"; then
+  echo "Detected MacBook10,1; disabling Wi-Fi wakeup for S3"
+
+  udev_rules=${OMARCHY_MACBOOK10_SLEEP_UDEV:-/etc/udev/rules.d/99-omarchy-macbook10-wifi-wakeup.rules}
+  unit_path=${OMARCHY_MACBOOK10_SLEEP_UNIT:-/etc/systemd/system/omarchy-macbook10-sleep-drain.service}
+  sleep_hook=${OMARCHY_MACBOOK10_SLEEP_HOOK:-/usr/lib/systemd/system-sleep/omarchy-macbook10-sleep-drain}
+  drain_bin=${OMARCHY_MACBOOK10_SLEEP_BIN:-${OMARCHY_PATH:-/usr/share/omarchy}/bin/omarchy-hw-macbook10-sleep-drain}
+  logind_dropin=${OMARCHY_MACBOOK10_SLEEP_LOGIND:-/etc/systemd/logind.conf.d/30-macbook10-suspend-then-hibernate.conf}
+  sleep_dropin=${OMARCHY_MACBOOK10_SLEEP_CONF:-/etc/systemd/sleep.conf.d/30-macbook10-hibernate-delay.conf}
+
+  sudo mkdir -p "$(dirname "$udev_rules")" "$(dirname "$unit_path")" "$(dirname "$sleep_hook")"
+
+  sudo tee "$udev_rules" >/dev/null <<'EOF'
+# BCM4350 on MacBook10,1. Wake-on-WLAN keeps the radio powered through S3.
+ACTION=="add|change", SUBSYSTEM=="pci", ATTR{vendor}=="0x14e4", ATTR{device}=="0x43a3", TEST=="power/wakeup", ATTR{power/wakeup}="disabled"
+EOF
+
+  sudo tee "$unit_path" >/dev/null <<EOF
+[Unit]
+Description=Omarchy MacBook10,1 Wi-Fi wakeup disable for S3
+
+[Service]
+Type=oneshot
+ExecStart=$drain_bin
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  sudo tee "$sleep_hook" >/dev/null <<EOF
+#!/bin/bash
+exec "$drain_bin"
+EOF
+  sudo chmod 755 "$sleep_hook"
+
+  sudo rm -f "$logind_dropin" "$sleep_dropin"
+  sudo systemctl reload systemd-logind >/dev/null 2>&1 || true
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now omarchy-macbook10-sleep-drain.service
+fi

--- a/migrations/1788600200.sh
+++ b/migrations/1788600200.sh
@@ -1,0 +1,3 @@
+echo "Cut MacBook10,1 S3 drain by disabling Wi-Fi wakeup; do not hibernate on lid close"
+
+source "$OMARCHY_PATH/install/hardware/apple/fix-macbook10-sleep-drain.sh"

--- a/test/shell.d/macbook10-sleep-drain-test.sh
+++ b/test/shell.d/macbook10-sleep-drain-test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+apply="$ROOT/bin/omarchy-hw-macbook10-sleep-drain"
+leaf="$ROOT/install/hardware/apple/fix-macbook10-sleep-drain.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1788600200.sh"
+
+grep -q 'apple/fix-macbook10-sleep-drain.sh' "$all" ||
+  fail "the MacBook10,1 sleep-drain fix runs during hardware setup"
+pass "the MacBook10,1 sleep-drain fix runs during hardware setup"
+
+grep -q 'fix-macbook10-sleep-drain.sh' "$migration" ||
+  fail "a migration applies the sleep-drain fix on existing installs"
+pass "a migration applies the sleep-drain fix on existing installs"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+: >"$calls"
+
+cat >"$stub_bin/omarchy-hw-match" <<'SH'
+#!/bin/bash
+[[ ${TEST_PRODUCT_NAME:-} == *"$1"* ]]
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+fake_sysfs() {
+  local root=$1 product=${2:-MacBook10,1} wakeup=${3:-enabled}
+  mkdir -p "$root/sys/class/dmi/id" \
+    "$root/sys/bus/pci/devices/0000:02:00.0/power"
+  printf '%s\n' "$product" >"$root/sys/class/dmi/id/product_name"
+  printf '0x14e4\n' >"$root/sys/bus/pci/devices/0000:02:00.0/vendor"
+  printf '0x43a3\n' >"$root/sys/bus/pci/devices/0000:02:00.0/device"
+  printf '%s\n' "$wakeup" >"$root/sys/bus/pci/devices/0000:02:00.0/power/wakeup"
+}
+
+sys="$test_tmp/sysfs"
+acpi="$test_tmp/acpi-wakeup"
+fake_sysfs "$sys"
+cat >"$acpi" <<'EOF'
+Device	S-state	  Status   Sysfs node
+ARPT	  S4	*enabled   pci:0000:02:00.0
+LID0	  S4	*enabled   platform:PNP0C0D:00
+EOF
+
+OMARCHY_SYSFS_ROOT="$sys" OMARCHY_ACPI_WAKEUP="$acpi" bash "$apply"
+[[ $(cat "$sys/sys/bus/pci/devices/0000:02:00.0/power/wakeup") == disabled ]] ||
+  fail "apply disables BCM4350 PCI wakeup"
+[[ $(cat "$acpi") == ARPT ]] || fail "apply toggles ACPI ARPT when it was enabled" "$(cat "$acpi")"
+pass "apply disables Wi-Fi PCI and ACPI wakeup"
+
+fake_sysfs "$sys"
+cat >"$acpi" <<'EOF'
+Device	S-state	  Status   Sysfs node
+ARPT	  S4	*disabled  pci:0000:02:00.0
+EOF
+before=$(cat "$acpi")
+OMARCHY_SYSFS_ROOT="$sys" OMARCHY_ACPI_WAKEUP="$acpi" bash "$apply"
+[[ $(cat "$acpi") == "$before" ]] || fail "apply leaves ARPT alone when it is already disabled"
+pass "apply is idempotent when ARPT is already disabled"
+
+other="$test_tmp/other"
+fake_sysfs "$other" "MacBookPro14,1"
+printf 'enabled\n' >"$other/sys/bus/pci/devices/0000:02:00.0/power/wakeup"
+OMARCHY_SYSFS_ROOT="$other" OMARCHY_ACPI_WAKEUP="$acpi" bash "$apply"
+[[ $(cat "$other/sys/bus/pci/devices/0000:02:00.0/power/wakeup") == enabled ]] ||
+  fail "apply leaves unrelated hardware wakeup unchanged"
+pass "apply is a no-op off MacBook10,1"
+
+status=$(OMARCHY_SYSFS_ROOT="$sys" OMARCHY_ACPI_WAKEUP="$acpi" bash "$apply" status)
+[[ $status == *wakeup=disabled* ]] || fail "status reports disabled PCI wakeup" "$status"
+[[ $status == *acpi_arpt=disabled* ]] || fail "status reports disabled ARPT" "$status"
+pass "status reports the applied wakeup disable"
+
+udev="$test_tmp/99-omarchy-macbook10-wifi-wakeup.rules"
+unit="$test_tmp/omarchy-macbook10-sleep-drain.service"
+hook="$test_tmp/sleep-hook"
+logind="$test_tmp/30-macbook10-suspend-then-hibernate.conf"
+sleep_conf="$test_tmp/30-macbook10-hibernate-delay.conf"
+resume="$test_tmp/omarchy_resume.conf"
+drain_copy="$test_tmp/omarchy-hw-macbook10-sleep-drain"
+cp "$apply" "$drain_copy"
+chmod +x "$drain_copy"
+
+run_leaf() {
+  : >"$calls"
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+    TEST_PRODUCT_NAME="$1" \
+    TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_MACBOOK10_SLEEP_UDEV="$udev" \
+    OMARCHY_MACBOOK10_SLEEP_UNIT="$unit" \
+    OMARCHY_MACBOOK10_SLEEP_HOOK="$hook" \
+    OMARCHY_MACBOOK10_SLEEP_BIN="$drain_copy" \
+    OMARCHY_MACBOOK10_SLEEP_LOGIND="$logind" \
+    OMARCHY_MACBOOK10_SLEEP_CONF="$sleep_conf" \
+    OMARCHY_MACBOOK10_RESUME_CONF="$2" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$leaf"
+}
+
+rm -f "$udev" "$unit" "$hook" "$logind" "$sleep_conf"
+run_leaf "MacBookPro14,1" "$resume"
+[[ ! -f $udev ]] || fail "setup skips unrelated hardware"
+[[ ! -s $calls ]] || fail "setup escalates nothing on unrelated hardware" "$(cat "$calls")"
+pass "setup skips unrelated hardware"
+
+run_leaf "MacBook10,1" "$test_tmp/missing-resume.conf"
+[[ -f $udev ]] || fail "setup writes the udev rule"
+grep -Fq 'ATTR{device}=="0x43a3"' "$udev" || fail "the udev rule matches BCM4350" "$(cat "$udev")"
+[[ -f $unit ]] || fail "setup writes the systemd unit"
+grep -Fq "ExecStart=$drain_copy" "$unit" ||
+  fail "the unit runs the sleep-drain command" "$(cat "$unit")"
+[[ -x $hook ]] || fail "setup installs an executable sleep hook"
+grep -Fq "exec \"$drain_copy\"" "$hook" ||
+  fail "the sleep hook re-applies the wakeup disable" "$(cat "$hook")"
+[[ ! -f $logind ]] || fail "setup does not change the lid action"
+grep -Fq $'systemctl\tenable\t--now\tomarchy-macbook10-sleep-drain.service' "$calls" ||
+  fail "setup enables the sleep-drain service" "$(cat "$calls")"
+pass "setup installs wakeup disable and leaves lid-close as S3"
+
+printf 'HandleLidSwitch=suspend-then-hibernate\n' >"$logind"
+printf 'HibernateDelaySec=30min\n' >"$sleep_conf"
+run_leaf "MacBook10,1" "$resume"
+[[ ! -f $logind ]] || fail "setup removes a previous hibernate-on-lid drop-in"
+[[ ! -f $sleep_conf ]] || fail "setup removes a previous hibernate delay drop-in"
+grep -Fq $'systemctl\treload\tsystemd-logind' "$calls" ||
+  fail "setup reloads logind after removing hibernate-on-lid" "$(cat "$calls")"
+pass "setup removes a previous hibernate-on-lid policy"
+
+: >"$calls"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_PRODUCT_NAME="MacBook10,1" \
+  TEST_LOG="$calls" \
+  OMARCHY_PATH="$ROOT" \
+  OMARCHY_MACBOOK10_SLEEP_UDEV="$udev" \
+  OMARCHY_MACBOOK10_SLEEP_UNIT="$unit" \
+  OMARCHY_MACBOOK10_SLEEP_HOOK="$hook" \
+  OMARCHY_MACBOOK10_SLEEP_BIN="$drain_copy" \
+  OMARCHY_MACBOOK10_SLEEP_LOGIND="$logind" \
+  OMARCHY_MACBOOK10_SLEEP_CONF="$sleep_conf" \
+  OMARCHY_MACBOOK10_RESUME_CONF="$resume" \
+  bash -euo pipefail "$migration"
+grep -Fq $'systemctl\tenable\t--now\tomarchy-macbook10-sleep-drain.service' "$calls" ||
+  fail "the migration runs hardware setup" "$(cat "$calls")"
+pass "the migration runs hardware setup"


### PR DESCRIPTION
## Summary
- Guarded on DMI `MacBook10,1` and PCI `14e4:43a3` (BCM4350). ACPI leaves Airport (`ARPT`) armed as a wake source, which keeps the radio powered for the whole S3 sleep.
- Disable PCI `power/wakeup` on that device (udev + a boot/resume oneshot that also toggles `ARPT` if it is still enabled). Existing installs pick this up through a migration.
- Does **not** change lid-close to hibernate. Hibernate on this chassis never reached S4: the lock screen came up and applespi stopped delivering keyboard and trackpad events. Lid stays `suspend`. The leaf removes a leftover hibernate-on-lid drop-in if one is present.

## Test plan
- [x] `bash test/shell.d/macbook10-sleep-drain-test.sh` (pass)
- [x] Live on MacBook10,1: `acpi_arpt=disabled`, `0000:02:00.0 power/wakeup=disabled`, `ARPT *disabled` after apply and after reboot
- [x] `HandleLidSwitch` remains `suspend`
- [ ] Confirm the leaf is a no-op off MacBook10,1 (guard)
- [ ] `omarchy update` on an existing MacBook10,1 runs the migration and enables the oneshot