### PR TITLE
Drop a Bluetooth power change that lands mid-transition

### DIFF
--- a/bin/omarchy-bluetooth-power
+++ b/bin/omarchy-bluetooth-power
@@ -18,6 +18,10 @@
 
 POWER_WAIT_SECONDS=${OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS:-2}
 
+# How long the adapter is left undisturbed after this call brought it up. See
+# take_lock for what lands in that window otherwise.
+POWER_SETTLE_SECONDS=${OMARCHY_BLUETOOTH_POWER_SETTLE_SECONDS:-5}
+
 controllers() {
   timeout 2s bluetoothctl list 2>/dev/null | awk '{print $2}'
 }
@@ -48,31 +52,74 @@ wait_powered() {
   done
 }
 
+# Serialize the calls that move the block. A block landing while bluetoothd is
+# still bringing the adapter up takes the USB transport down mid-setup, and the
+# commands still in flight fail against a controller that is no longer there:
+#
+#   Bluetooth: hci0: Device setup in 2012942 usecs
+#   Bluetooth: hci0: Opcode 0x0c1a failed: -71
+#   Bluetooth: hci0: Error when powering off device on rfkill (-71)
+#
+# Nothing retries them, and the adapter comes back Powered: yes and reads as
+# healthy either way, so nothing surfaces the radio having been left
+# half-configured. Two quick clicks on the bar toggle are enough to land in it.
+#
+# Dropped rather than queued, like the brightness keys: a click the user never
+# saw land is not worth replaying seconds later against a radio whose state has
+# moved on since. is-on must not take the lock — it answers through its exit
+# status, and a dropped call exiting 0 would report a blocked radio as powered.
+# Failing open on a lock file that cannot be opened at all: the interlock makes
+# the common path safer, but it is not a precondition for honouring what the
+# user asked for. Swallowing the request there would leave a toggle that reports
+# success and does nothing.
+take_lock() {
+  # Grouped so the shell's own redirection error is silenced too: on the
+  # command itself the failing redirection is processed before the 2>/dev/null
+  # that was meant to cover it.
+  { exec {lock_fd}>"${XDG_RUNTIME_DIR:-/tmp}/omarchy-bluetooth-power.lock"; } 2>/dev/null || return 0
+  flock -n "$lock_fd" || exit 0
+}
+
 power_on() {
+  local was_powered=0
+
+  powered && was_powered=1
+
   rfkill unblock bluetooth
 
   # Usually all it takes: with AutoEnable at its default, bluetoothd powers the
   # adapter up on its own once the block is gone. It will not do that for an
   # adapter powered down without a block, so ask directly before giving up.
-  wait_powered && return 0
+  if ! wait_powered; then
+    timeout 5s bluetoothctl power on >/dev/null 2>&1
 
-  timeout 5s bluetoothctl power on >/dev/null 2>&1
-  wait_powered && return 0
+    if ! wait_powered; then
+      echo "omarchy-bluetooth-power: adapter did not come up" >&2
+      return 1
+    fi
+  fi
 
-  echo "omarchy-bluetooth-power: adapter did not come up" >&2
-  return 1
+  # Hold the lock past Powered: yes when this call is what brought the adapter
+  # up. Powered flips as soon as the controller answers, while bluetoothd is
+  # still restoring the LE state behind it, and that gap is the whole window
+  # take_lock exists to cover. An adapter that was already on has no setup
+  # running and nothing to wait for.
+  ((was_powered)) || sleep "$POWER_SETTLE_SECONDS"
 }
 
 case "${1:-}" in
   on)
+    take_lock
     power_on
     ;;
   off)
+    take_lock
     # No bluetoothctl power off to go with this: the block already drops the
     # adapter to Powered: no, and it is the half that survives the reboot.
     rfkill block bluetooth
     ;;
   toggle)
+    take_lock
     if powered; then
       rfkill block bluetooth
     else

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -190,7 +190,7 @@ bluetooth_run() {
   echo "$powered" >"$POWERED_FILE"
   : >"$device_tmp/log"
   PATH="$mock_bin:$ROOT/bin:$PATH" BLUETOOTHCTL_LOG="$device_tmp/log" \
-    OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=0 "$@" ||
+    OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=0 OMARCHY_BLUETOOTH_POWER_SETTLE_SECONDS=0 "$@" ||
     fail "$* exits cleanly with Powered: $powered"
   printf '%s' "$device_tmp/log"
 }
@@ -280,3 +280,69 @@ pass "bluetooth counts a secondary controller as on"
 grep -q 'AutoEnable=false' "$ROOT/install/hardware/bluetooth.sh" &&
   fail "bluetooth install leaves AutoEnable at its default"
 pass "bluetooth install leaves AutoEnable at its default"
+
+# Two quick clicks on the bar toggle used to put a block on the wire while
+# bluetoothd was still bringing the adapter up, failing the commands still in
+# flight against a controller that had gone away. The second call has to drop
+# instead of landing in that window.
+locked_run() {
+  local status=0
+
+  : >"$device_tmp/log"
+  (
+    exec {held_fd}>"${XDG_RUNTIME_DIR:-/tmp}/omarchy-bluetooth-power.lock"
+    flock "$held_fd"
+    PATH="$mock_bin:$ROOT/bin:$PATH" BLUETOOTHCTL_LOG="$device_tmp/log" \
+      OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=0 OMARCHY_BLUETOOTH_POWER_SETTLE_SECONDS=0 \
+      "$ROOT/bin/omarchy-bluetooth-power" "$1"
+  ) || status=$?
+
+  printf '%s' "$status"
+}
+
+echo yes >"$POWERED_FILE"
+locked_run off >/dev/null
+grep -q rfkill "$device_tmp/log" &&
+  fail "bluetooth drops an off that lands while another call is still in flight" "$(cat "$device_tmp/log")"
+pass "bluetooth drops an off that lands while another call is still in flight"
+
+echo no >"$POWERED_FILE"
+locked_run on >/dev/null
+grep -q rfkill "$device_tmp/log" &&
+  fail "bluetooth drops an on that lands while another call is still in flight" "$(cat "$device_tmp/log")"
+pass "bluetooth drops an on that lands while another call is still in flight"
+
+# is-on answers through its exit status, so it must never be gated on the lock:
+# a dropped call exiting 0 would report a blocked radio as powered.
+echo no >"$POWERED_FILE"
+[[ $(locked_run is-on) == "1" ]] ||
+  fail "bluetooth still reports the radio off while another call holds the lock"
+pass "bluetooth still reports the radio off while another call holds the lock"
+
+# The settle only covers a power-up this call performed. An adapter that was
+# already on has no setup running, so nothing waits on it.
+echo yes >"$POWERED_FILE"
+: >"$device_tmp/log"
+start=$SECONDS
+PATH="$mock_bin:$ROOT/bin:$PATH" BLUETOOTHCTL_LOG="$device_tmp/log" \
+  OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=0 OMARCHY_BLUETOOTH_POWER_SETTLE_SECONDS=30 \
+  "$ROOT/bin/omarchy-bluetooth-power" on ||
+  fail "bluetooth turns on cleanly when the adapter is already powered"
+((SECONDS - start < 5)) ||
+  fail "bluetooth does not sit out the settle when the adapter was already on"
+pass "bluetooth does not sit out the settle when the adapter was already on"
+
+# A lock file that cannot be opened at all must not swallow the request. The
+# interlock makes the common path safer; it is not a precondition for moving the
+# block, and failing closed here would leave a toggle that reports success and
+# does nothing.
+echo yes >"$POWERED_FILE"
+: >"$device_tmp/log"
+PATH="$mock_bin:$ROOT/bin:$PATH" BLUETOOTHCTL_LOG="$device_tmp/log" \
+  OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=0 OMARCHY_BLUETOOTH_POWER_SETTLE_SECONDS=0 \
+  XDG_RUNTIME_DIR="$device_tmp/does-not-exist" \
+  "$ROOT/bin/omarchy-bluetooth-power" off ||
+  fail "bluetooth exits cleanly when the lock file cannot be created"
+grep -qx "rfkill block bluetooth" "$device_tmp/log" ||
+  fail "bluetooth still turns off when the lock file cannot be created" "$(cat "$device_tmp/log")"
+pass "bluetooth still turns off when the lock file cannot be created"


### PR DESCRIPTION
## The problem

`omarchy-bluetooth-power` has no interlock, so a second call can land while the first is still bringing the adapter up. The block that arrives in that window is not a wasted click — it takes the USB transport down mid-setup, and HCI commands fail against a controller that is no longer there.

Reproduced here by driving the helper the way two quick clicks on the bar toggle would:

```
omarchy-bluetooth-power off
sleep 3
omarchy-bluetooth-power on     # returns at Powered: yes, setup still running
omarchy-bluetooth-power off    # lands mid-setup
```

```
Bluetooth: hci0: Device setup in 2012942 usecs
Bluetooth: hci0: Opcode 0x0c1a failed: -71
Bluetooth: hci0: Error when powering off device on rfkill (-71)
```

Nothing retries the failed commands. The adapter comes back `Powered: yes` and reads as healthy afterwards, so there is no sign in the UI that anything went wrong.

Bonded LE devices take noticeably longer to find their way back after a cycle that hit this than after a clean one, though I only have single runs of each and touching an LE peripheral speeds its reconnect up, so I am claiming nothing firm beyond the failed commands themselves.

## The fix

Serialize the verbs that move the block behind a non-blocking `flock`, following the pattern `omarchy-brightness-display` already uses to drop overlapping key events, and hold the lock past `Powered: yes` when the call is what brought the adapter up.

- Dropped rather than queued: a click the user never saw land is not worth replaying seconds later against a radio whose state has moved on since.
- `is-on` deliberately stays outside the lock. It answers through its exit status, so a dropped call exiting 0 would report a blocked radio as powered.
- An adapter that was already on has no setup running and does not wait, so `omarchy-bluetooth-power on` stays as responsive as it is today in the common case.

The interlock lives in the helper rather than in the bar widget so that every caller is covered — the panel toggle, the `omarchy.bluetooth` IPC method, and the CLI alike.

## Trade-off worth a second opinion

The settle is a fixed wait (`OMARCHY_BLUETOOTH_POWER_SETTLE_SECONDS`, default 5) because I could not find a cheap unprivileged signal for "the adapter is done coming up" — `Powered` flips well before setup finishes. The cost is that a real power-up from the CLI takes about five seconds longer to return. Happy to shorten it, or drop it in favour of the lock alone, if you would rather not carry a sleep here.

## Testing

`./test/shell` and `./test/cli` pass. Four cases added to `test/shell.d/bluetooth-test.sh` on the existing mocked `rfkill`/`bluetoothctl` harness: a second `off` and a second `on` arriving under a held lock touch nothing, `is-on` still answers correctly under one, and an already-powered adapter does not sit out the settle.

Verified on Omarchy 4.0.2, ThinkPad with a MediaTek 0e8d:e111 controller.
