### PR TITLE
Report git-managed plugins that are behind their origin

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -51,6 +51,14 @@ if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
   omarchy-update-mise
   omarchy-update-orphan-pkgs
 
+  # Third-party plugin code is only ever fast-forwarded with its diff on
+  # screen and an answer from the user, so an unattended run leaves plugins
+  # alone rather than pulling code nobody has read. A plugin whose remote is
+  # unreachable must not take the system update down with it.
+  if [[ -z ${OMARCHY_UPDATE_UNATTENDED:-} ]]; then
+    omarchy-plugin-update || true
+  fi
+
   omarchy-update-analyze-logs
   omarchy-update-status
 

--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -35,6 +35,43 @@ if [[ -n ${update:-} ]]; then
   updates+=("$update")
 fi
 
+# Git-managed plugins. Nothing else checks these, so a plugin can sit years
+# behind with nothing saying so.
+#
+# Read-only on purpose: ls-remote asks the remote for its HEAD without writing
+# an object or moving a ref in the user's checkout. Fetching belongs to
+# `omarchy plugin update`, which shows the diff before it pulls anything.
+plugins_dir="$HOME/.config/omarchy/plugins"
+
+if [[ -d $plugins_dir ]]; then
+  for dir in "$plugins_dir"/*/; do
+    [[ -d $dir/.git ]] || continue
+
+    plugin=$(basename "$dir")
+    remote=$(GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}" \
+      timeout 5 git -C "$dir" ls-remote --quiet origin HEAD 2>/dev/null |
+      awk 'NR == 1 { print $1 }' || true)
+    [[ -n $remote ]] || continue
+
+    head=$(git -C "$dir" rev-parse HEAD 2>/dev/null || true)
+    [[ -n $head && $head != "$remote" ]] || continue
+
+    # Counting the commits needs the remote one locally, which we have
+    # whenever the user has looked at an update and not taken it: `omarchy
+    # plugin update` fetches before it shows its diff. Without the object we
+    # still know the remote moved somewhere this checkout has never seen.
+    behind=$(git -C "$dir" rev-list --count "HEAD..$remote" 2>/dev/null || true)
+
+    if [[ -z $behind ]]; then
+      updates+=("plugin $plugin has an update")
+    elif (( behind > 0 )); then
+      commit_label=commits
+      (( behind == 1 )) && commit_label=commit
+      updates+=("plugin $plugin $behind new $commit_label")
+    fi
+  done
+fi
+
 if (( ${#updates[@]} > 0 )); then
   printf '%s\n' "${updates[@]}"
   exit 0

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -230,18 +230,31 @@ omarchy-update-available
 - new upstream commits for the active dev-linked checkout
 - `omarchy-dev`, when installed
 - otherwise `omarchy`, when installed
+- git-managed plugins under `~/.config/omarchy/plugins` that are behind their origin
 
 The dev check fetches the checkout's configured upstream before comparing it
 with `HEAD`. A failed fetch is quiet and falls back to the existing remote-
 tracking state.
 
+The plugin check is read-only: `git ls-remote` asks each origin for its `HEAD`
+without writing an object or moving a ref in the user's checkout, because
+fetching belongs to `omarchy plugin update`, which shows the diff before it
+pulls. A plugin is only reported when origin holds a commit the checkout does
+not, so a plugin carrying local commits is left alone. The commit count is
+printed when the remote commit is already present locally — which it is
+whenever the user has looked at an update and declined it — and omitted when
+it is not. Each plugin gets five seconds, and an unreachable origin is quiet.
+
 Exit codes:
 
-- `0` — Omarchy updates are available; stdout is the update list.
-- non-zero — no Omarchy updates are available; stdout says Omarchy is up to date.
+- `0` — updates are available; stdout is the update list.
+- non-zero — nothing is available; stdout says Omarchy is up to date.
 
 The widget runs this check on shell startup and every six hours. Clicking the
-update icon launches `omarchy-update` in a floating terminal.
+update icon launches `omarchy-update` in a floating terminal, which offers
+each behind plugin's diff for confirmation after the system packages are done.
+Unattended runs (`omarchy update -y`) skip plugins rather than fast-forward
+third-party code nobody has read.
 
 ## Channels and versions
 
@@ -280,7 +293,7 @@ scripts.
 | `omarchy-update-pacman-guard` | ALPM pre-transaction guard that aborts direct `pacman -Syu` style upgrades unless Omarchy set `OMARCHY_UPDATE_PACMAN=1` or the user explicitly set `OMARCHY_ALLOW_DIRECT_PACMAN=1`. | **Keep internal/hidden.** This is what nudges users back to `omarchy update`. |
 | `omarchy-migrate-notify` | Internal login-time notification helper. Uses `omarchy-migrate --pending` and shows a notification only when this user has pending migrations. | **Keep internal/hidden.** Clear name now that the public command is `omarchy-migrate`. |
 | `omarchy-update-user-notify` | Hidden compatibility wrapper for `omarchy-migrate-notify`. | **Temporary.** Keep only for old callers. |
-| `omarchy-update-available` | Update checker for shell widget and post-update refresh. | **Keep.** Could eventually be renamed `omarchy-update-check`, but current name matches widget semantics. |
+| `omarchy-update-available` | Update checker for shell widget and post-update refresh. Covers the dev checkout, the Omarchy package, and git-managed plugins that are behind their origin. | **Keep.** Could eventually be renamed `omarchy-update-check`, but current name matches widget semantics. |
 | `omarchy-update-aur-pkgs` | Updates AUR packages with `yay -Sua` if foreign packages exist and AUR is reachable. | **Question.** Omarchy is package-backed now, but users may still install AUR packages. Keep for now. |
 | `omarchy-update-mise` | Runs `MISE_MINIMUM_RELEASE_AGE=0 mise up` for mise-managed tools — the override of mise's release-age cooldown is the point. | **Keep.** Mise-managed tools are intentionally part of the blessed update path. |
 | `omarchy-update-orphan-pkgs` | Lists orphans and prompts before removal; noninteractive mode never removes. | **Keep for now.** Safe because it is prompt-only. |

--- a/test/shell.d/update-available-test.sh
+++ b/test/shell.d/update-available-test.sh
@@ -11,6 +11,10 @@ stub_bin="$test_tmp/bin"
 git_log="$test_tmp/git.log"
 mkdir -p "$stub_bin"
 
+# Captured before the stub shadows it: the plugin checkouts below are real
+# repositories, so the stub hands their calls to the real thing.
+real_git=$(command -v git)
+
 cat >"$stub_bin/checkupdates" <<'SH'
 #!/bin/bash
 case "${TEST_CHECKUPDATES:-updates}" in
@@ -59,7 +63,14 @@ cat >"$stub_bin/git" <<'SH'
 printf '%s\n' "$*" >>"$TEST_GIT_LOG"
 
 [[ $1 == "-C" ]] || exit 1
+dir="$2"
 shift 2
+
+# Only the dev checkout is mocked. Plugin checkouts are real repositories in
+# the test's temp dir, so their ancestry answers come from git itself.
+if [[ $dir != "$OMARCHY_PATH" ]]; then
+  exec "$TEST_REAL_GIT" -C "$dir" "$@"
+fi
 
 case "$1" in
   fetch)
@@ -91,8 +102,13 @@ SH
 chmod +x "$stub_bin/git"
 
 run_checker() {
+  # HOME is always pointed somewhere controlled: the plugin scan reads
+  # ~/.config/omarchy/plugins, and the developer's own plugins must never
+  # decide the result of a test.
   OMARCHY_PATH="${TEST_OMARCHY_PATH:-/usr/share/omarchy}" \
+    HOME="${TEST_HOME:-$test_tmp/home}" \
     TEST_GIT_LOG="$git_log" \
+    TEST_REAL_GIT="$real_git" \
     PATH="$stub_bin:$PATH" \
     "$ROOT/bin/omarchy-update-available"
 }
@@ -211,3 +227,104 @@ grep -Fx 'omarchy-dev-checkout 1 new commit on origin/quattro' "$stdout" >/dev/n
   fail "update checker reports cached dev commits after a fetch failure" "$(cat "$stdout")"
 [[ ! -s $stderr ]] || fail "update checker keeps dev fetch failures quiet" "$(cat "$stderr")"
 pass "update checker uses cached dev state when fetching is unavailable"
+
+# ---- git-managed plugins -----------------------------------------------------
+#
+# Real repositories rather than a mock, so what is asserted is the ancestry
+# logic itself: a plugin is only behind when the remote holds a commit this
+# checkout does not, whether or not that commit has already been fetched.
+
+plugin_home="$test_tmp/plugin-home"
+plugins_dir="$plugin_home/.config/omarchy/plugins"
+mkdir -p "$plugins_dir"
+
+git_quiet() {
+  "$real_git" -c init.defaultBranch=main -c user.email=test@example.com \
+    -c user.name=Test -c commit.gpgsign=false "$@" >/dev/null 2>&1
+}
+
+commit_into() {
+  local repo="$1" message="$2"
+  echo "$message" >>"$repo/log.txt"
+  git_quiet -C "$repo" add log.txt
+  git_quiet -C "$repo" commit -m "$message"
+}
+
+new_plugin() {
+  local id="$1"
+  local origin="$test_tmp/origins/$id.git"
+  local seed="$test_tmp/seeds/$id"
+
+  mkdir -p "$origin" "$seed"
+  git_quiet init --bare "$origin"
+  git_quiet init "$seed"
+  commit_into "$seed" "first"
+  git_quiet -C "$seed" remote add origin "$origin"
+  git_quiet -C "$seed" push origin main
+  git_quiet clone "$origin" "$plugins_dir/$id"
+}
+
+# Origin has moved and the new commit has already been fetched — the state a
+# user is left in by looking at `omarchy plugin update` and declining it.
+new_plugin fetched-behind
+commit_into "$test_tmp/seeds/fetched-behind" "second"
+git_quiet -C "$test_tmp/seeds/fetched-behind" push origin main
+git_quiet -C "$plugins_dir/fetched-behind" fetch origin
+
+# Origin has moved and this checkout has never seen the commit.
+new_plugin never-fetched
+commit_into "$test_tmp/seeds/never-fetched" "second"
+git_quiet -C "$test_tmp/seeds/never-fetched" push origin main
+
+# Current, and one carrying local commits origin does not have.
+new_plugin current
+new_plugin ahead
+commit_into "$plugins_dir/ahead" "local work"
+
+# Neither of these can be behind anything: no checkout, and no remote.
+mkdir -p "$plugins_dir/not-a-checkout"
+git_quiet init "$plugins_dir/no-remote"
+commit_into "$plugins_dir/no-remote" "first"
+
+if capture_checker "$stdout" "$stderr" \
+  TEST_CHECKUPDATES=none \
+  TEST_INSTALLED_PACKAGE=none \
+  TEST_HOME="$plugin_home"; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 0 ]] || fail "update checker exits successfully when a plugin is behind" "$(cat "$stdout")"
+grep -Fx 'plugin fetched-behind 1 new commit' "$stdout" >/dev/null ||
+  fail "update checker counts commits for a plugin that already holds them" "$(cat "$stdout")"
+grep -Fx 'plugin never-fetched has an update' "$stdout" >/dev/null ||
+  fail "update checker reports a plugin whose new commit is not local yet" "$(cat "$stdout")"
+! grep -q '^plugin current ' "$stdout" || fail "update checker reports a current plugin"
+! grep -q '^plugin ahead ' "$stdout" || fail "update checker reports a plugin that is ahead of origin"
+! grep -q 'not-a-checkout' "$stdout" || fail "update checker inspects a plugin that is not a checkout"
+! grep -q 'no-remote' "$stdout" || fail "update checker reports a plugin with no remote"
+[[ ! -s $stderr ]] || fail "update checker is quiet while scanning plugins" "$(cat "$stderr")"
+pass "update checker detects git-managed plugins that are behind"
+
+if capture_checker "$stdout" "$stderr" \
+  TEST_CHECKUPDATES=none \
+  TEST_INSTALLED_PACKAGE=none; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 1 ]] || fail "update checker exits non-zero with no plugins installed"
+grep -q '^Omarchy is up to date$' "$stdout" || fail "update checker reports up to date with no plugins"
+pass "update checker ignores systems with no plugins installed"
+
+# A plugin update alone must not be silent: the widget only sees the exit code.
+if capture_checker "$stdout" "$stderr" \
+  TEST_CHECKUPDATES=none \
+  TEST_INSTALLED_PACKAGE=omarchy \
+  TEST_HOME="$plugin_home"; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 0 ]] || fail "update checker signals an update when only a plugin is behind"
+pass "update checker signals the shell widget for plugin-only updates"


### PR DESCRIPTION
Nothing checks plugins for updates. `omarchy-update-available` covers the dev checkout and the Omarchy package, and `omarchy-update` reloads plugins without ever pulling them, so a git-managed plugin can sit indefinitely behind its origin with nothing saying so. On my own machine this change immediately found two:

```
plugin io.github.pablo-merino.altswitch 5 new commits
plugin mirador has an update
```

## The check is read-only

`git ls-remote` asks each origin for its `HEAD` without writing an object or moving a ref in the user's checkout. Fetching belongs to `omarchy plugin update`, which shows the diff before it pulls, and a background check that runs every six hours should not be mutating repositories on the side.

A plugin is reported only when origin holds a commit the checkout does not, so a plugin carrying local commits is left alone rather than nagged. The commit count is printed when the remote commit is already present locally — which it is whenever someone has looked at an update and declined it, since that path fetches before showing its diff — and omitted when it is not, because "the remote has moved somewhere this checkout has never seen" is all that can honestly be said then.

Each plugin gets five seconds, and an unreachable or authenticating origin is quiet: `GIT_TERMINAL_PROMPT=0` and `ssh -oBatchMode=yes` keep a private remote from hanging on a prompt.

## Why this also touches `omarchy-update`

The widget only sees the exit code, and its button launches `omarchy-update`. Letting a plugin flip that exit code on its own would light the icon and hand the user a button that does nothing about what was reported. So `omarchy-update` now offers each behind plugin's diff for confirmation, after the packages and migrations are done and before the restart that reloads them.

Two constraints kept: unattended runs (`omarchy update -y`) skip plugins rather than fast-forward third-party code nobody has read, and a plugin whose remote is unreachable cannot take the system update down with it.

If you would rather keep the update pipeline untouched, I am happy to reshape this — but the two halves have to agree about whether a plugin update is something the user is told about.

## Tests

`test/shell.d/update-available-test.sh` gains three cases. The plugin checkouts in them are real repositories with a real local origin rather than a mock, so what is asserted is the ancestry logic itself, and the git stub now hands anything that is not the dev checkout to real git. Covered: behind with the commit already fetched (exact count), behind without it (no count), current, ahead of origin, a directory that is not a checkout, a checkout with no remote, no plugins installed at all, and a plugin-only update still signalling the widget.

The suite's `run_checker` now always points `HOME` at a controlled directory, so the developer's own plugins cannot decide the result of a test.

`./test/cli` passes. `./test/shell` reports 223 of 226 files passing; the three failures (`config-test`, `snapper-test`, `unowned-system-paths-test`) fail identically on a clean checkout of this machine and are unrelated.
