### PR TITLE
Redirect mise use output to /dev/null in generated wrappers

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -22,7 +22,7 @@ rm -f "$HOME/.local/bin/$command"
 cat >"$HOME/.local/bin/$command" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
-mise use -g --quiet "$package" || exit 1
+mise use -g --quiet "$package" >/dev/null || exit 1
 exec mise x "$package" -- "$bin" "\$@"
 EOF
 

--- a/test/shell.d/mise-wrapper-quiet-migration-test.sh
+++ b/test/shell.d/mise-wrapper-quiet-migration-test.sh
@@ -65,11 +65,11 @@ chmod +x "$bin_dir/mise-exec-era" "$bin_dir/bare-exec-era"
 
 run_migration
 
-grep -qF 'mise use -g --quiet "claude" || exit 1' "$bin_dir/claude" ||
+grep -qF 'mise use -g --quiet "claude" >/dev/null || exit 1' "$bin_dir/claude" ||
   fail "migration adds --quiet to a stale wrapper"
 pass "migration adds --quiet to a stale wrapper"
 
-grep -qF 'mise use -g --quiet "github:can1357/oh-my-pi" || exit 1' "$bin_dir/omp" ||
+grep -qF 'mise use -g --quiet "github:can1357/oh-my-pi" >/dev/null || exit 1' "$bin_dir/omp" ||
   fail "migration keeps a wrapper's package when the command name differs"
 grep -qF 'exec mise x "github:can1357/oh-my-pi" -- "omp" "$@"' "$bin_dir/omp" ||
   fail "migration keeps a wrapper's bin name when the command name differs"
@@ -79,17 +79,17 @@ grep -qF 'exec mise x "npm:@kitlangton/ghui" -- "ghui" "$@"' "$bin_dir/ghui" ||
   fail "migration preserves a scoped npm package name"
 pass "migration preserves a scoped npm package name"
 
-grep -qF 'mise use -g --quiet "github:someone/custom-tool" || exit 1' "$bin_dir/custom-tool" ||
+grep -qF 'mise use -g --quiet "github:someone/custom-tool" >/dev/null || exit 1' "$bin_dir/custom-tool" ||
   fail "migration rewrites a wrapper on the pre-export template"
 grep -qF 'export MISE_MINIMUM_RELEASE_AGE=0' "$bin_dir/custom-tool" ||
   fail "migration brings a pre-export wrapper up to the current template"
 pass "migration rewrites wrappers on the pre-export template"
 
-grep -qF 'mise use -g --quiet "npm:some/tool" || exit 1' "$bin_dir/mise-exec-era" ||
+grep -qF 'mise use -g --quiet "npm:some/tool" >/dev/null || exit 1' "$bin_dir/mise-exec-era" ||
   fail "migration rewrites a wrapper on the mise-exec template"
 grep -qF 'exec mise x "npm:some/tool" -- "tool-bin" "$@"' "$bin_dir/mise-exec-era" ||
   fail "migration keeps the bin name from a mise-exec wrapper"
-grep -qF 'mise use -g --quiet "aqua:some/other" || exit 1' "$bin_dir/bare-exec-era" ||
+grep -qF 'mise use -g --quiet "aqua:some/other" >/dev/null || exit 1' "$bin_dir/bare-exec-era" ||
   fail "migration rewrites a wrapper on the bare-exec template"
 grep -qF 'exec mise x "aqua:some/other" -- "other-bin" "$@"' "$bin_dir/bare-exec-era" ||
   fail "migration keeps the bin name from a bare-exec wrapper"


### PR DESCRIPTION
## Summary

`omarchy-mise-install` now redirects `mise use -g --quiet` stdout to `/dev/null` in the generated wrapper. This prevents `mise` progress output (e.g. `tools: codex@0.147.0`) from leaking into the wrapper's stdout, which breaks protocol-speaking tools such as `codex app-server`.

Fixes #7376.

## Test plan

- [x] Manually generated a wrapper and confirmed it contains `mise use -g --quiet "<package>" >/dev/null || exit 1`
- [x] Updated `test/shell.d/mise-wrapper-quiet-migration-test.sh` expectations to match the new wrapper form
- [ ] Run `./test/all` on a Linux box (not available in this environment)