### PR TITLE
Hide relocated debug commands from the Omarchy router

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -41,7 +41,6 @@ GROUP_DESCRIPTIONS[clipboard]="Clipboard helpers"
 GROUP_DESCRIPTIONS[cmd]="Command and shortcut helpers"
 GROUP_DESCRIPTIONS[config]="System configuration helpers"
 GROUP_DESCRIPTIONS[crash]="Crash notification controls"
-GROUP_DESCRIPTIONS[debug]="Diagnostics and support logs"
 GROUP_DESCRIPTIONS[finalize]="Finalize user setup"
 GROUP_DESCRIPTIONS[default]="Default application selection"
 GROUP_DESCRIPTIONS[dev]="Omarchy development tools"
@@ -530,7 +529,6 @@ Common commands:
   omarchy theme set <name>    Apply a theme
   omarchy font list           List available fonts
   omarchy screenshot          Take a screenshot
-  omarchy debug               Print debugging information
 
 Groups:
 EOF

--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -2,7 +2,7 @@
 
 # omarchy:summary=Print debugging information
 # omarchy:args=[--no-sudo] [--print]
-# omarchy:examples=omarchy debug --print --no-sudo
+# omarchy:hidden=true
 # omarchy:requires-sudo=true
 
 NO_SUDO=false

--- a/bin/omarchy-debug-idle
+++ b/bin/omarchy-debug-idle
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Show idle, screensaver, and lock diagnostics
-# omarchy:group=debug
 # omarchy:args=[log-lines]
-# omarchy:examples=omarchy debug idle | omarchy-debug-idle 400
+# omarchy:hidden=true
 
 lines=${1:-200}
 if [[ ! $lines =~ ^[0-9]+$ ]]; then

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -23,9 +23,9 @@ description with steps to reproduce, and diagnostics. Gather them:
 omarchy version
 
 # Generate the diagnostic log (also written to /tmp/omarchy-debug.log)
-omarchy debug --no-sudo --print
+omarchy-debug --no-sudo --print
 
-# Interactive variant: `omarchy debug` offers to upload the log to
+# Interactive variant: `omarchy-debug` offers to upload the log to
 # logs.omarchy.org (expires after 24h) and prints a shareable URL to
 # include in the issue.
 ```


### PR DESCRIPTION
## Summary

`omarchy-debug` and `omarchy-debug-idle` are installed to `/usr/bin` by the `omarchy-settings` package, while the `omarchy` dispatcher only searches its own directory. This means the `omarchy debug` and `omarchy debug idle` routes the help system advertises always exit 127.

Stop advertising those unreachable routes by marking both scripts `omarchy:hidden=true` and removing their `omarchy:examples` annotations. Also remove the `debug` group from the top-level help since it has no reachable commands, and correct `contributing.md` to use the working hyphenated `omarchy-debug` form.

The `SKILL.md` references are left as-is because they are currently being rewritten in #6718; that PR should apply the same correction.

Addresses #7185.

## Test plan

- [x] Verified the changed files no longer advertise `omarchy debug` / `omarchy debug idle` routes
- [x] Confirmed `.github/ISSUE_TEMPLATE/bug.yml` already uses the hyphenated `omarchy-debug` form
- [ ] Run `./test/all` on a Linux box (not available in this environment)