### PR TITLE
Let any installed browser be the default, Flatpaks included

### DIFF
--- a/bin/omarchy-cmd-desktop-entry
+++ b/bin/omarchy-cmd-desktop-entry
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# omarchy:summary=Read a desktop entry from any XDG data dir
+# omarchy:args=<dirs|path|name|exec> [desktop-id]
+# omarchy:hidden=true
+
+# Resolves entries the way a launcher does: the user's data dir first, then
+# every XDG data dir. Flatpak exports its entries under its own data dirs and
+# adds them to XDG_DATA_DIRS, so a Flatpak browser resolves here without a
+# special case; they stay listed explicitly for sessions that never sourced
+# Flatpak's profile. The Nix profile is not on XDG_DATA_DIRS either.
+
+applications_dirs() {
+  local data_dirs=("${XDG_DATA_HOME:-$HOME/.local/share}" "$HOME/.nix-profile/share")
+  local system_data_dirs
+  IFS=: read -r -a system_data_dirs <<<"${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+  data_dirs+=("${system_data_dirs[@]}")
+  data_dirs+=(/var/lib/flatpak/exports/share "$HOME/.local/share/flatpak/exports/share")
+
+  local data_dir
+  for data_dir in "${data_dirs[@]}"; do
+    printf '%s/applications\n' "$data_dir"
+  done
+}
+
+desktop_path() {
+  local applications_dir
+  while read -r applications_dir; do
+    if [[ -f $applications_dir/$1 ]]; then
+      printf '%s\n' "$applications_dir/$1"
+      return 0
+    fi
+  done < <(applications_dirs)
+
+  return 1
+}
+
+# The Exec line minus its %u/%U/%f-style field codes, and minus the @@u ... @@
+# markers Flatpak wraps them in, one word per line: the command and its fixed
+# arguments, ready for a caller to append its own.
+desktop_exec() {
+  local exec_line
+  exec_line=$(sed -n 's/^Exec=//p' "$1" | head -1)
+  [[ -n $exec_line ]] || return 1
+
+  local exec_words word
+  read -r -a exec_words <<<"$exec_line"
+  for word in "${exec_words[@]}"; do
+    case $word in
+    %[a-zA-Z] | @@ | @@u) continue ;;
+    esac
+    printf '%s\n' "$word"
+  done
+}
+
+verb=${1:-}
+desktop_id=${2:-}
+
+case $verb in
+dirs)
+  applications_dirs
+  ;;
+path | name | exec)
+  [[ -n $desktop_id ]] || exit 1
+  desktop_file=$(desktop_path "$desktop_id") || exit 1
+  case $verb in
+  path) printf '%s\n' "$desktop_file" ;;
+  name) sed -n 's/^Name=//p' "$desktop_file" | head -1 ;;
+  exec) desktop_exec "$desktop_file" ;;
+  esac
+  ;;
+*)
+  echo "Usage: omarchy-cmd-desktop-entry <dirs|path|name|exec> [desktop-id]" >&2
+  exit 1
+  ;;
+esac

--- a/bin/omarchy-default-browser
+++ b/bin/omarchy-default-browser
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Set the default browser for Omarchy and XDG handlers
-# omarchy:args=[chromium|chrome|brave|brave-origin|edge|firefox|zen]
-# omarchy:examples=omarchy default browser firefox | omarchy default browser brave
+# omarchy:args=[chromium|chrome|brave|brave-origin|edge|firefox|zen|<desktop-id>]
+# omarchy:examples=omarchy default browser firefox | omarchy default browser brave | omarchy default browser net.waterfox.waterfox.desktop
 
 installing=false
 if [[ ${1:-} == "--install" ]]; then
@@ -32,13 +32,25 @@ brave-origin) browser="brave-origin"; command="brave-origin"; desktop_id="brave-
 edge) browser="edge"; command="microsoft-edge-stable"; desktop_id="microsoft-edge.desktop"; name="Edge"; glyph=󰇩 ;;
 firefox) browser="firefox"; command="firefox"; desktop_id="firefox.desktop"; name="Firefox"; glyph=󰈹 ;;
 zen) browser="zen"; command="zen-browser"; desktop_id="zen.desktop"; name="Zen"; glyph=󰖟 ;;
+*.desktop)
+  # Any other installed browser, by desktop id: Flatpaks, AUR builds, and
+  # hand-written entries alike. It has to already exist, there is nothing to
+  # install on its behalf.
+  desktop_id=$1
+  glyph=󰖟
+  if ! name=$(omarchy-cmd-desktop-entry name "$desktop_id"); then
+    echo "omarchy-default-browser: no desktop entry named $desktop_id" >&2
+    exit 1
+  fi
+  [[ -n $name ]] || name=${desktop_id%.desktop}
+  ;;
 *)
-  echo "Usage: omarchy-default-browser <chromium|chrome|brave|brave-origin|edge|firefox|zen>"
+  echo "Usage: omarchy-default-browser <chromium|chrome|brave|brave-origin|edge|firefox|zen|desktop-id>"
   exit 1
   ;;
 esac
 
-if omarchy-cmd-missing "$command"; then
+if [[ -n ${command:-} ]] && omarchy-cmd-missing "$command"; then
   if [[ $installing == "false" ]]; then
     exec omarchy-launch-floating-terminal-with-presentation omarchy-default-browser --install "$browser"
   else

--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -7,11 +7,12 @@ default_browser=$(env -u BROWSER xdg-settings get default-web-browser)
 if [[ -z $default_browser ]]; then
   default_browser=$(xdg-mime query default x-scheme-handler/https)
 fi
-browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1)
+mapfile -t browser_command < <(omarchy-cmd-desktop-entry exec "$default_browser")
+(( ${#browser_command[@]} > 0 )) || exit 1
 
-if $browser_exec --help 2>/dev/null | grep -q MOZ_LOG; then
+if "${browser_command[@]}" --help 2>/dev/null | grep -q MOZ_LOG; then
   private_flag="--private-window"
-elif [[ $browser_exec =~ edge ]]; then
+elif [[ ${browser_command[*],,} =~ edge ]]; then
   private_flag="--inprivate"
 else
   private_flag="--incognito"
@@ -19,7 +20,7 @@ fi
 
 systemd-run --user --quiet --collect --unit="omarchy-browser-$(date +%s%N)" \
   --property=StandardOutput=null --property=StandardError=null \
-  uwsm-app -- "$browser_exec" "${@/--private/$private_flag}"
+  uwsm-app -- "${browser_command[@]}" "${@/--private/$private_flag}"
 
 url=""
 for argument in "$@"; do
@@ -30,5 +31,18 @@ for argument in "$@"; do
 done
 
 if [[ -n $url && -n ${HYPRLAND_INSTANCE_SIGNATURE:-} ]]; then
-  omarchy-hyprland-focus-app "^$(basename "$browser_exec" -stable).*$" || true
+  # A Flatpak window carries the app id (or the sandboxed command) as its
+  # class, not "flatpak"; a native one is named after its binary.
+  if [[ $(basename "${browser_command[0]}") == "flatpak" ]]; then
+    app_id=${browser_command[-1]}
+    app_command=$app_id
+    for word in "${browser_command[@]}"; do
+      if [[ $word == --command=* ]]; then
+        app_command=$(basename "${word#--command=}")
+      fi
+    done
+    omarchy-hyprland-focus-app "^($app_id|$app_command).*$" || true
+  else
+    omarchy-hyprland-focus-app "^$(basename "${browser_command[0]}" -stable).*$" || true
+  fi
 fi

--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -7,7 +7,11 @@ browser=$(xdg-settings get default-web-browser)
 
 case $browser in
 google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+org.chromium.* | com.google.Chrome* | com.brave.* | com.microsoft.Edge* | com.opera.* | com.vivaldi.*) ;;
 *) browser="chromium.desktop" ;;
 esac
 
-exec setsid uwsm-app -- $(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$browser 2>/dev/null | head -1) --app="$1" "${@:2}"
+mapfile -t browser_command < <(omarchy-cmd-desktop-entry exec "$browser")
+(( ${#browser_command[@]} > 0 )) || exit 1
+
+exec setsid uwsm-app -- "${browser_command[@]}" --app="$1" "${@:2}"

--- a/bin/omarchy-menu-default-browser
+++ b/bin/omarchy-menu-default-browser
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# omarchy:summary=Pick the default browser from every installed browser
+# omarchy:group=menu
+# omarchy:name=default-browser
+
+# Lists every desktop entry that handles web links, wherever it was installed
+# from: pacman, the AUR, Flatpak, or a hand-written entry under ~/.local.
+# Selecting one hands its desktop id to omarchy-default-browser.
+
+set -e
+
+current=$(env -u BROWSER xdg-settings get default-web-browser)
+
+declare -A seen
+options=()
+while read -r applications_dir; do
+  for desktop_file in "$applications_dir"/*.desktop; do
+    [[ -f $desktop_file ]] || continue
+    desktop_id=$(basename "$desktop_file")
+    [[ -z ${seen[$desktop_id]:-} ]] || continue
+    seen[$desktop_id]=1
+
+    grep -q '^MimeType=.*x-scheme-handler/https' "$desktop_file" || continue
+    if grep -q '^NoDisplay=true' "$desktop_file"; then
+      continue
+    fi
+
+    name=$(sed -n 's/^Name=//p' "$desktop_file" | head -1)
+    [[ -n $name ]] || name=${desktop_id%.desktop}
+    if [[ $desktop_id == "$current" ]]; then
+      name="$name ✓"
+    fi
+    options+=("$(printf '󰖟\t%s\t%s' "$name" "$desktop_id")")
+  done
+done < <(omarchy-cmd-desktop-entry dirs)
+
+if (( ${#options[@]} == 0 )); then
+  omarchy-notification-send "No installed browser handles web links"
+  exit 1
+fi
+
+selection=$(printf '%s\n' "${options[@]}" | omarchy-menu-select "Default browser" -- --width 520) || exit 1
+desktop_id=${selection##*$'\t'}
+
+omarchy-default-browser "$desktop_id"

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -155,6 +155,7 @@
   "setup.default.browser.edge": {"icon":"󰇩","label":"Edge","checked":"[[ \"$(omarchy-default-browser)\" == \"edge\" ]]","action":"omarchy-default-browser edge"},
   "setup.default.browser.firefox": {"icon":"","label":"Firefox","checked":"[[ \"$(omarchy-default-browser)\" == \"firefox\" ]]","action":"omarchy-default-browser firefox"},
   "setup.default.browser.zen": {"icon":"󰖟","label":"Zen","checked":"[[ \"$(omarchy-default-browser)\" == \"zen\" ]]","action":"omarchy-default-browser zen"},
+  "setup.default.browser.other": {"icon":"󰖟","label":"Other","description":"Any installed browser, including Flatpaks","checked":"[[ \"$(omarchy-default-browser)\" == *.desktop ]]","action":"omarchy-menu-default-browser"},
   "setup.default.terminal": {"icon":"","label":"Terminal","title":"Default Terminal"},
   "setup.default.terminal.alacritty": {"icon":"","label":"Alacritty","checked":"[[ \"$(omarchy-default-terminal)\" == \"alacritty\" ]]","action":"omarchy-default-terminal alacritty"},
   "setup.default.terminal.foot": {"icon":"","label":"Foot","checked":"[[ \"$(omarchy-default-terminal)\" == \"foot\" ]]","action":"omarchy-default-terminal foot"},

--- a/manual/23-browsers.md
+++ b/manual/23-browsers.md
@@ -6,12 +6,20 @@ If Chromium isn't your taste, you're not stuck with it. Under _Install > Browser
 
 ## Making one the default
 
-Installing a browser doesn't promote it. Once it's on the machine, go to _Setup > Defaults > Browser_ and pick it — the menu only lists browsers you actually have installed, and marks the current default with a check.
+Installing a browser doesn't promote it. Once it's on the machine, go to _Setup > Defaults > Browser_ and pick it — the menu marks the current default with a check, and picking a browser you don't have yet installs it first.
+
+Browsers Omarchy doesn't install for you can be the default too. _Other_ at the bottom of that list shows every browser on the machine that handles web links, whether it came from pacman, the AUR, or Flatpak, so a Flatpak Waterfox or LibreWolf is a couple of keystrokes away from being what `Super + Shift + Return` opens.
 
 From the terminal it's:
 
 ```bash
 omarchy default browser firefox
+```
+
+or, for anything outside the built-in list, its desktop entry id:
+
+```bash
+omarchy default browser net.waterfox.waterfox.desktop
 ```
 
 Run it with no argument and it tells you the current default. This sets the XDG handler, so it's not just Omarchy's hotkeys that follow along — anything that opens a link, from a chat app to a terminal command, goes to the browser you picked.

--- a/test/shell.d/default-browser-any-test.sh
+++ b/test/shell.d/default-browser-any-test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+flatpak_share="$test_tmp/flatpak/exports/share"
+system_share="$test_tmp/usr/share"
+browser_file="$test_tmp/browser"
+terminal_log="$test_tmp/terminal-log"
+notification_log="$test_tmp/notification-log"
+select_log="$test_tmp/select-log"
+mkdir -p "$mock_bin" "$test_home/.local/share/applications" "$flatpak_share/applications" "$system_share/applications"
+
+cat >"$mock_bin/xdg-settings" <<'SH'
+#!/bin/bash
+case $1 in
+get) [[ -f $OMARCHY_TEST_BROWSER_FILE ]] && cat "$OMARCHY_TEST_BROWSER_FILE" ;;
+set) printf '%s\n' "$3" >"$OMARCHY_TEST_BROWSER_FILE" ;;
+esac
+SH
+cat >"$mock_bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf '%s\0' "$@" >"$OMARCHY_TEST_TERMINAL_LOG"
+SH
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_NOTIFICATION_LOG"
+SH
+cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+exit 0
+SH
+# Records the rows it was offered and answers with the row whose subtext
+# matches OMARCHY_TEST_SELECT, the way the real picker returns "label<TAB>subtext".
+cat >"$mock_bin/omarchy-menu-select" <<'SH'
+#!/bin/bash
+cat >"$OMARCHY_TEST_SELECT_LOG"
+grep -P "\t${OMARCHY_TEST_SELECT}\$" "$OMARCHY_TEST_SELECT_LOG" | head -1 | cut -f2-
+SH
+chmod +x "$mock_bin"/*
+
+cat >"$flatpak_share/applications/net.waterfox.waterfox.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Waterfox
+Exec=/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=waterfox --file-forwarding net.waterfox.waterfox @@u %u @@
+MimeType=text/html;x-scheme-handler/http;x-scheme-handler/https;
+DESKTOP
+cat >"$system_share/applications/chromium.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Chromium
+Exec=/usr/bin/chromium %U
+MimeType=text/html;x-scheme-handler/http;x-scheme-handler/https;
+DESKTOP
+cat >"$system_share/applications/hidden-browser.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Hidden
+NoDisplay=true
+Exec=/usr/bin/hidden %U
+MimeType=x-scheme-handler/https;
+DESKTOP
+cat >"$system_share/applications/org.gnome.Calculator.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Calculator
+Exec=gnome-calculator
+MimeType=x-scheme-handler/calculator;
+DESKTOP
+# The user's own copy of an entry shadows the system one, so it is listed once.
+cat >"$test_home/.local/share/applications/chromium.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Chromium (mine)
+Exec=/usr/bin/chromium --flag %U
+MimeType=x-scheme-handler/https;
+DESKTOP
+
+export HOME="$test_home"
+export XDG_DATA_HOME="$test_home/.local/share"
+export PATH="$mock_bin:$ROOT/bin:$PATH"
+export XDG_DATA_DIRS="$flatpak_share:$system_share"
+export OMARCHY_TEST_BROWSER_FILE="$browser_file"
+export OMARCHY_TEST_TERMINAL_LOG="$terminal_log"
+export OMARCHY_TEST_NOTIFICATION_LOG="$notification_log"
+export OMARCHY_TEST_SELECT_LOG="$select_log"
+
+[[ $(omarchy-cmd-desktop-entry path net.waterfox.waterfox.desktop) == "$flatpak_share/applications/net.waterfox.waterfox.desktop" ]] ||
+  fail "desktop entry helper resolves an entry from a Flatpak export dir on XDG_DATA_DIRS"
+[[ $(omarchy-cmd-desktop-entry path chromium.desktop) == "$test_home/.local/share/applications/chromium.desktop" ]] ||
+  fail "desktop entry helper prefers the user's data dir"
+[[ $(omarchy-cmd-desktop-entry name net.waterfox.waterfox.desktop) == "Waterfox" ]] ||
+  fail "desktop entry helper reads the entry's name"
+expected_exec=$'/usr/bin/flatpak\nrun\n--branch=stable\n--arch=x86_64\n--command=waterfox\n--file-forwarding\nnet.waterfox.waterfox'
+[[ $(omarchy-cmd-desktop-entry exec net.waterfox.waterfox.desktop) == "$expected_exec" ]] ||
+  fail "desktop entry helper keeps the whole flatpak command and drops the field codes" "$(omarchy-cmd-desktop-entry exec net.waterfox.waterfox.desktop)"
+[[ $(omarchy-cmd-desktop-entry exec chromium.desktop) == $'/usr/bin/chromium\n--flag' ]] ||
+  fail "desktop entry helper keeps fixed arguments and drops %U"
+if omarchy-cmd-desktop-entry path missing.desktop >/dev/null; then
+  fail "desktop entry helper fails on an unknown entry"
+fi
+pass "desktop entry helper resolves entries across XDG data dirs"
+
+: >"$notification_log"
+rm -f "$terminal_log"
+omarchy-default-browser net.waterfox.waterfox.desktop
+[[ $(<"$browser_file") == "net.waterfox.waterfox.desktop" ]] || fail "a desktop id becomes the default browser"
+[[ $(omarchy-default-browser) == "net.waterfox.waterfox.desktop" ]] || fail "the default browser reports an unlisted browser by desktop id"
+[[ ! -e $terminal_log ]] || fail "a desktop id never opens an installer"
+grep -q 'Waterfox is now the default browser' "$notification_log" || fail "the notification names the browser from its desktop entry" "$(cat "$notification_log")"
+pass "any installed browser can be made the default by desktop id"
+
+printf 'chromium.desktop\n' >"$browser_file"
+if omarchy-default-browser missing.desktop 2>/dev/null; then
+  fail "an unknown desktop id is refused"
+fi
+[[ $(<"$browser_file") == "chromium.desktop" ]] || fail "an unknown desktop id leaves the default alone"
+pass "a desktop id that resolves to nothing is refused"
+
+OMARCHY_TEST_SELECT=net.waterfox.waterfox.desktop omarchy-menu-default-browser
+[[ $(<"$browser_file") == "net.waterfox.waterfox.desktop" ]] || fail "the picker hands the chosen desktop id to omarchy-default-browser"
+grep -q $'\tWaterfox\tnet.waterfox.waterfox.desktop$' "$select_log" || fail "the picker lists a Flatpak browser" "$(cat "$select_log")"
+grep -q $'\tChromium (mine) ✓\tchromium.desktop$' "$select_log" || fail "the picker marks the current default and prefers the user's entry" "$(cat "$select_log")"
+[[ $(grep -c 'chromium.desktop' "$select_log") == 1 ]] || fail "the picker lists a shadowed entry once" "$(cat "$select_log")"
+if grep -q 'hidden-browser\|Calculator' "$select_log"; then
+  fail "the picker skips hidden entries and non-browsers" "$(cat "$select_log")"
+fi
+pass "the browser picker offers every installed browser that handles web links"

--- a/test/shell.d/launch-browser-test.sh
+++ b/test/shell.d/launch-browser-test.sh
@@ -19,7 +19,7 @@ EOF
 cat >"$mock_bin/xdg-settings" <<'SH'
 #!/bin/bash
 [[ -z ${BROWSER:-} ]] || printf '%s\n' "$BROWSER" >"$OMARCHY_TEST_XDG_SETTINGS_BROWSER"
-[[ ${OMARCHY_TEST_XDG_SETTINGS_EMPTY:-0} == "1" ]] || echo chromium.desktop
+[[ ${OMARCHY_TEST_XDG_SETTINGS_EMPTY:-0} == "1" ]] || echo "${OMARCHY_TEST_XDG_SETTINGS_DEFAULT:-chromium.desktop}"
 SH
 cat >"$mock_bin/xdg-mime" <<'SH'
 #!/bin/bash
@@ -44,19 +44,19 @@ chmod +x "$mock_bin"/*
 launch_log="$test_tmp/launch"
 focus_log="$test_tmp/focus"
 xdg_settings_browser="$test_tmp/xdg-settings-browser"
-HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
+HOME="$test_home" PATH="$mock_bin:$ROOT/bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
   OMARCHY_TEST_BROWSER_LAUNCH="$launch_log" OMARCHY_TEST_BROWSER_FOCUS="$focus_log" \
   bash "$ROOT/bin/omarchy-launch-browser"
 
 [[ ! -e $focus_log ]] || fail "browser launcher leaves a new window on the current workspace"
 
-HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
+HOME="$test_home" PATH="$mock_bin:$ROOT/bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
   OMARCHY_TEST_BROWSER_LAUNCH="$launch_log" OMARCHY_TEST_BROWSER_FOCUS="$focus_log" \
   bash "$ROOT/bin/omarchy-launch-browser" --private
 
 [[ ! -e $focus_log ]] || fail "private browser launcher leaves a new window on the current workspace"
 
-HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
+HOME="$test_home" PATH="$mock_bin:$ROOT/bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
   OMARCHY_TEST_BROWSER_LAUNCH="$launch_log" OMARCHY_TEST_BROWSER_FOCUS="$focus_log" \
   bash "$ROOT/bin/omarchy-launch-browser" "https://example.test/authorize"
 
@@ -65,7 +65,7 @@ grep -Fx '^chromium.*$' "$focus_log" >/dev/null || fail "browser launcher focuse
 
 rm -f "$focus_log" "$xdg_settings_browser"
 
-HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
+HOME="$test_home" PATH="$mock_bin:$ROOT/bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
   BROWSER=omarchy-launch-browser OMARCHY_TEST_XDG_SETTINGS_EMPTY=1 \
   OMARCHY_TEST_BROWSER_LAUNCH="$launch_log" OMARCHY_TEST_BROWSER_FOCUS="$focus_log" \
   OMARCHY_TEST_XDG_SETTINGS_BROWSER="$xdg_settings_browser" \
@@ -79,3 +79,36 @@ grep -Fx '^chromium.*$' "$focus_log" >/dev/null ||
   fail "browser launcher focuses the browser resolved from the HTTPS handler"
 
 pass "browser launcher follows opened links to the browser workspace"
+
+# A Flatpak browser lives under Flatpak's exported data dir, not /usr, and its
+# Exec is the whole `flatpak run ...` line with the URL slot wrapped in @@u/@@.
+flatpak_share="$test_tmp/flatpak/exports/share"
+mkdir -p "$flatpak_share/applications"
+cat >"$flatpak_share/applications/net.waterfox.waterfox.desktop" <<'EOF'
+[Desktop Entry]
+Name=Waterfox
+Exec=/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=waterfox --file-forwarding net.waterfox.waterfox @@u %u @@
+EOF
+cat >"$mock_bin/flatpak" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$mock_bin/flatpak"
+
+rm -f "$focus_log"
+HOME="$test_home" PATH="$mock_bin:$ROOT/bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE=test \
+  XDG_DATA_DIRS="$flatpak_share:/usr/share" \
+  OMARCHY_TEST_XDG_SETTINGS_DEFAULT=net.waterfox.waterfox.desktop \
+  OMARCHY_TEST_BROWSER_LAUNCH="$launch_log" OMARCHY_TEST_BROWSER_FOCUS="$focus_log" \
+  bash "$ROOT/bin/omarchy-launch-browser" "https://example.test/flatpak"
+
+grep -F -- '--collect' "$launch_log" >/dev/null || fail "flatpak browser launcher still detaches the browser"
+grep -F -- 'uwsm-app -- /usr/bin/flatpak run --branch=stable --arch=x86_64 --command=waterfox --file-forwarding net.waterfox.waterfox https://example.test/flatpak' "$launch_log" >/dev/null ||
+  fail "browser launcher runs a Flatpak browser through its full flatpak command" "$(cat "$launch_log")"
+if grep -F -- '@@' "$launch_log" >/dev/null; then
+  fail "browser launcher strips Flatpak's file-forwarding markers" "$(cat "$launch_log")"
+fi
+grep -Fx '^(net.waterfox.waterfox|waterfox).*$' "$focus_log" >/dev/null ||
+  fail "browser launcher focuses a Flatpak browser by its app id or command" "$(cat "$focus_log")"
+
+pass "browser launcher runs and focuses a Flatpak browser"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -250,7 +250,7 @@ assertDeepEqual(
   'menu sorts coding agents alphabetically'
 )
 const expectedDefaults = {
-  browser: ['Chromium', 'Chrome', 'Brave', 'Brave Origin', 'Edge', 'Firefox', 'Zen'],
+  browser: ['Chromium', 'Chrome', 'Brave', 'Brave Origin', 'Edge', 'Firefox', 'Zen', 'Other'],
   terminal: ['Alacritty', 'Foot', 'Ghostty', 'Kitty'],
   editor: ['Neovim', 'VSCode', 'Cursor', 'Zed', 'Sublime Text', 'Helix', 'Vim', 'Emacs']
 }


### PR DESCRIPTION
## Problem

_Setup > Defaults > Browser_ is a fixed list of seven browsers. A browser installed any other way (Flatpak, AUR, a hand-written desktop entry) shows up in the app launcher but has no route to becoming the default, and `omarchy default browser` only accepts the seven names.

Flatpak browsers fail a second way: `omarchy-launch-browser` and `omarchy-launch-webapp` only look for the desktop entry under `~/.local`, the Nix profile and `/usr`, and take the first word of `Exec` as the command. A Flatpak entry lives under Flatpak's exported data dir and its `Exec` is a whole `flatpak run --command=... app.id @@u %u @@` line, so even after setting it with `xdg-settings` by hand, `Super + Shift + Return` does nothing.

## Change

- **Other** row at the bottom of Defaults > Browser. It opens a picker listing every installed desktop entry that handles `x-scheme-handler/https`, wherever it came from, marks the current default, and hands the chosen desktop id to `omarchy-default-browser`. The row shows ✓ whenever the default is something outside the built-in seven.
- `omarchy default browser <desktop-id>` sets any existing entry as the default (nothing to install on its behalf, so an unknown id is refused rather than opening an installer). The seven named browsers behave exactly as before.
- New hidden helper `omarchy-cmd-desktop-entry` resolves an entry through `XDG_DATA_HOME` / `XDG_DATA_DIRS` (plus the Nix profile and Flatpak export dirs) and returns its `Exec` with field codes and Flatpak's `@@u`/`@@` markers stripped. The browser launcher and web-app launcher use it, so Flatpak browsers launch, get the right private-window flag, and are focused by app id rather than by "flatpak".
- Web apps recognise the Flatpak ids of the Chromium-family browsers (`org.chromium.Chromium`, `com.brave.Browser`, ...) instead of falling back to native Chromium.
- Manual page for browsers updated.

## Tests

- New `default-browser-any-test.sh`: entry resolution across data dirs (user dir wins, Flatpak export dir found), field-code stripping, setting a default by desktop id, refusing an unknown id, and the picker's listing (Flatpak entry present, shadowed entry listed once, `NoDisplay` and non-browser handlers skipped).
- `launch-browser-test.sh` gains a Flatpak browser case: full `flatpak run` command passed through, markers stripped, window focused by app id.
- `menu-test.sh` expects the new Other row.

`test/shell` passes apart from failures already present on `quattro` that this change does not touch (`bin-style` on `omarchy-remove-ai-openclaw`, `bar-icon-geometry`, and the three tests that need an `omarchy-pkgs` sibling checkout).
