### PR TITLE
Add a dedicated pi agent usage collector

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -871,10 +871,6 @@ def main() -> int:
       if today_prompts or today_sessions:
         stats = dict(stats, todayPrompts=today_prompts, todaySessions=today_sessions)
 
-  pi_usage = scan_pi_usage(scan_age)
-  if pi_usage is not None:
-    stats = merge_stats(stats, pi_usage)
-
   opencode = scan_opencode_usage(scan_age)
   if opencode is not None:
     stats = merge_stats(stats, opencode)

--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -6,7 +6,7 @@
 
 Everything the agents panel shows for Claude comes from this one
 command: local transcript stats from ~/.claude/projects, the stats-cache and
-history fallbacks for machines without transcripts, pi/omp and opencode
+history fallbacks for machines without transcripts, opencode
 sessions that ran on an Anthropic provider, and the authoritative rate
 limits from Anthropic's OAuth usage endpoint. The panel itself only ever
 reads the JSON this prints; it never talks to disk formats or endpoints.

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -433,7 +433,6 @@ def local_stats():
 
 
 def run_local_scans():
-  scan_pi_sessions()
   scan_native_codex_sessions()
   complete = scan_opencode_sessions()
   return local_stats(), complete

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -4,10 +4,10 @@
 # omarchy:hidden=true
 """Collect Codex usage into one display-ready JSON record.
 
-Local stats come from native Codex CLI session files, pi/omp sessions that
-ran through openai-codex, and opencode sessions that ran on an OpenAI
-provider; rate limits and the plan come from the Codex app-server RPC. The agents
-panel only ever reads the JSON this prints.
+Local stats come from native Codex CLI session files and opencode sessions
+that ran on an OpenAI provider; rate limits and the plan come from the Codex
+app-server RPC. Pi/OMP local stats belong to the dedicated Pi collector.
+The agents panel only ever reads the JSON this prints.
 """
 
 import argparse
@@ -346,9 +346,9 @@ def cache_root():
 def scan_cache_paths():
   codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
   db = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")) / "opencode" / "opencode.db"
-  # The digest covers every data path the scan reads: the codex session
-  # roots, the opencode DB, and (via Path.home()) the pi/omp session roots.
-  digest = hashlib.sha1((str(Path.home()) + "\n" + str(codex_home) + "\n" + str(db)).encode("utf-8")).hexdigest()[:16]
+  # The digest covers the codex session roots and the opencode DB; its
+  # namespace excludes caches from before Pi/OMP moved to their own collector.
+  digest = hashlib.sha1(("native-opencode\n" + str(Path.home()) + "\n" + str(codex_home) + "\n" + str(db)).encode("utf-8")).hexdigest()[:16]
   root = cache_root()
   return root / f"codex-scan-{digest}.json", root / f"codex-scan-{digest}.lock"
 

--- a/bin/omarchy-agent-usage-pi
+++ b/bin/omarchy-agent-usage-pi
@@ -1,0 +1,270 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the Pi/Oh My Pi usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect Pi and Oh My Pi usage into one display-ready JSON record.
+
+Scans ~/.pi/agent/sessions and ~/.omp/agent/sessions for any provider that
+writes provider, model, and token usage on assistant messages. This deliberately
+does not filter by backend, so OpenRouter, Anthropic, OpenAI, and any other
+configured provider all contribute to a single 'pi' record.
+"""
+
+import datetime as dt
+import fcntl
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+AGENT_ID = "pi"
+AGENT_NAME = "Pi"
+SCAN_REUSE_SECONDS = 20
+LIMITS_ONLY_REUSE_SECONDS = 900
+
+
+def cache_root() -> Path:
+  root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root.mkdir(parents=True, exist_ok=True)
+  return root
+
+
+def date_string(value: dt.date) -> str:
+  return value.strftime("%Y-%m-%d")
+
+
+def recent_date_strings() -> list[str]:
+  today = dt.datetime.now().date()
+  return [date_string(today - dt.timedelta(days=offset)) for offset in range(6, -1, -1)]
+
+
+def local_date_string() -> str:
+  return date_string(dt.datetime.now().date())
+
+
+def local_date_from_timestamp(value: Any) -> str:
+  if value is None:
+    return local_date_string()
+
+  if isinstance(value, (int, float)):
+    try:
+      seconds = float(value) / 1000.0 if float(value) > 10_000_000_000 else float(value)
+      return date_string(dt.datetime.fromtimestamp(seconds).date())
+    except Exception:
+      return local_date_string()
+
+  raw = str(value).strip()
+  if not raw:
+    return local_date_string()
+
+  try:
+    parsed = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if parsed.tzinfo is not None:
+      parsed = parsed.astimezone()
+    return date_string(parsed.date())
+  except Exception:
+    return local_date_string()
+
+
+def usage_token(usage: dict[str, Any], snake_key: str, camel_key: str) -> int:
+  value = usage.get(snake_key, usage.get(camel_key, 0))
+  try:
+    return round(float(value or 0))
+  except Exception:
+    return 0
+
+
+def number(value: Any) -> int:
+  try:
+    n = float(value or 0)
+    return round(n) if n == n else 0
+  except Exception:
+    return 0
+
+
+def empty_bucket() -> dict[str, int]:
+  return {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadInputTokens": 0,
+    "cacheCreationInputTokens": 0,
+  }
+
+
+def read_fresh_json(path: Path, max_age_seconds: float) -> dict[str, Any] | None:
+  if max_age_seconds <= 0 or not path.exists():
+    return None
+  try:
+    if time.time() - path.stat().st_mtime <= max_age_seconds:
+      return json.loads(path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  return None
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+  handle_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+  tmp = Path(tmp_name)
+  try:
+    with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+      handle.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n")
+    tmp.chmod(0o644)
+    tmp.replace(path)
+  except BaseException:
+    tmp.unlink(missing_ok=True)
+    raise
+
+
+def scan_sessions() -> dict[str, Any] | None:
+  roots = [
+    Path.home() / ".pi" / "agent" / "sessions",
+    Path.home() / ".omp" / "agent" / "sessions",
+  ]
+  cache_file = cache_root() / "pi-sessions.json"
+
+  today = local_date_string()
+  recent_dates = recent_date_strings()
+  recent = {day: {"date": day, "messageCount": 0} for day in recent_dates}
+  sessions: set[str] = set()
+  active_days: set[str] = set()
+  today_sessions: set[str] = set()
+  today_tokens: dict[str, int] = {}
+  usage_by_model: dict[str, dict[str, int]] = {}
+  seen: set[str] = set()
+  prompts = 0
+  today_prompt_count = 0
+  today_token_total = 0
+
+  for root in roots:
+    files = root.rglob("*.jsonl") if root.is_dir() else []
+    for path in files:
+      try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+          for line_number, line in enumerate(handle, 1):
+            if '"usage"' not in line or '"assistant"' not in line:
+              continue
+            try:
+              entry = json.loads(line)
+            except Exception:
+              continue
+
+            message = entry.get("message") if isinstance(entry.get("message"), dict) else {}
+            if entry.get("type") != "message" or message.get("role") != "assistant":
+              continue
+
+            usage = message.get("usage") or {}
+            if not isinstance(usage, dict):
+              continue
+
+            unique_key = f"{path}:{entry.get('id') or line_number}"
+            if unique_key in seen:
+              continue
+            seen.add(unique_key)
+
+            input_tokens = usage_token(usage, "input", "inputTokens")
+            output_tokens = usage_token(usage, "output", "outputTokens")
+            cache_read = usage_token(usage, "cacheRead", "cacheReadInputTokens")
+            cache_write = usage_token(usage, "cacheWrite", "cacheCreationInputTokens")
+            total = input_tokens + output_tokens + cache_read + cache_write
+            if total <= 0:
+              total = number(usage.get("totalTokens"))
+              input_tokens = total
+            if total <= 0:
+              continue
+
+            model = str(message.get("model") or "pi")
+            day = local_date_from_timestamp(entry.get("timestamp") or message.get("timestamp"))
+            session_key = str(path)
+            sessions.add(session_key)
+            active_days.add(day)
+            prompts += 1
+
+            bucket = usage_by_model.setdefault(model, empty_bucket())
+            bucket["inputTokens"] += input_tokens
+            bucket["outputTokens"] += output_tokens
+            bucket["cacheReadInputTokens"] += cache_read
+            bucket["cacheCreationInputTokens"] += cache_write
+
+            if day in recent:
+              recent[day]["messageCount"] += total
+            if day == today:
+              today_prompt_count += 1
+              today_sessions.add(session_key)
+              today_token_total += total
+              today_tokens[model] = today_tokens.get(model, 0) + total
+      except OSError:
+        continue
+
+  if prompts <= 0:
+    return None
+
+  return {
+    "todayPrompts": today_prompt_count,
+    "todaySessions": len(today_sessions),
+    "todayTotalTokens": today_token_total,
+    "todayTokensByModel": today_tokens,
+    "recentDays": [recent[day] for day in recent_dates],
+    "modelUsage": usage_by_model,
+    "totalPrompts": prompts,
+    "totalSessions": len(sessions),
+    "activeDays": len(active_days),
+    "activeDates": sorted(active_days),
+  }
+
+
+def cached_scan(max_age_seconds: float) -> dict[str, Any] | None:
+  cache_file = cache_root() / "pi-sessions.json"
+
+  cached = read_fresh_json(cache_file, max_age_seconds)
+  if cached is not None:
+    return cached.get("stats")
+
+  stats = scan_sessions()
+  if stats is not None:
+    write_json(cache_file, {"stats": stats})
+  return stats
+
+
+def main() -> int:
+  import argparse
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--force", action="store_true")
+  parser.add_argument("--limits-only", action="store_true")
+  parser.add_argument("--cache-seconds", type=float, default=20)
+  args = parser.parse_args()
+
+  max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else args.cache_seconds)
+  stats = cached_scan(max_age)
+
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "ready": True,
+    "hasLocalStats": True,
+  }
+  if stats is not None:
+    record.update(stats)
+  else:
+    record.update({
+      "todayPrompts": 0,
+      "todaySessions": 0,
+      "todayTotalTokens": 0,
+      "todayTokensByModel": {},
+      "recentDays": [{"date": day, "messageCount": 0} for day in recent_date_strings()],
+      "modelUsage": {},
+      "totalPrompts": 0,
+      "totalSessions": 0,
+      "activeDays": 0,
+      "activeDates": [],
+    })
+
+  print(json.dumps(record, separators=(",", ":"), sort_keys=True))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/bin/omarchy-agent-usage-pi
+++ b/bin/omarchy-agent-usage-pi
@@ -4,18 +4,22 @@
 # omarchy:hidden=true
 """Collect Pi and Oh My Pi usage into one display-ready JSON record.
 
-Scans ~/.pi/agent/sessions and ~/.omp/agent/sessions for any provider that
-writes provider, model, and token usage on assistant messages. This deliberately
+Scans default and configured Pi/OMP session directories, including profiles,
+for provider, model, and token usage on assistant messages. This deliberately
 does not filter by backend, so OpenRouter, Anthropic, OpenAI, and any other
-configured provider all contribute to a single 'pi' record.
+configured provider all contribute to a single local-only 'pi' record.
 """
 
 import datetime as dt
 import fcntl
+import hashlib
 import json
+import math
 import os
+import sys
 import tempfile
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -26,7 +30,7 @@ LIMITS_ONLY_REUSE_SECONDS = 900
 
 
 def cache_root() -> Path:
-  root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  root = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache") / "omarchy" / "agent-usage"
   root.mkdir(parents=True, exist_ok=True)
   return root
 
@@ -44,44 +48,33 @@ def local_date_string() -> str:
   return date_string(dt.datetime.now().date())
 
 
-def local_date_from_timestamp(value: Any) -> str:
-  if value is None:
-    return local_date_string()
-
-  if isinstance(value, (int, float)):
-    try:
-      seconds = float(value) / 1000.0 if float(value) > 10_000_000_000 else float(value)
+def local_date_from_timestamp(value: Any) -> str | None:
+  try:
+    if type(value) in (int, float):
+      if not math.isfinite(value) or value < 0:
+        return None
+      seconds = value / 1000.0 if value > 10_000_000_000 else value
       return date_string(dt.datetime.fromtimestamp(seconds).date())
-    except Exception:
-      return local_date_string()
-
-  raw = str(value).strip()
-  if not raw:
-    return local_date_string()
-
-  try:
-    parsed = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    if parsed.tzinfo is not None:
-      parsed = parsed.astimezone()
-    return date_string(parsed.date())
-  except Exception:
-    return local_date_string()
-
-
-def usage_token(usage: dict[str, Any], snake_key: str, camel_key: str) -> int:
-  value = usage.get(snake_key, usage.get(camel_key, 0))
-  try:
-    return round(float(value or 0))
-  except Exception:
-    return 0
+    if isinstance(value, str) and value.strip():
+      parsed = dt.datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+      if parsed.tzinfo is not None:
+        parsed = parsed.astimezone()
+      return date_string(parsed.date())
+  except (ValueError, OverflowError, OSError):
+    pass
+  return None
 
 
 def number(value: Any) -> int:
-  try:
-    n = float(value or 0)
-    return round(n) if n == n else 0
-  except Exception:
-    return 0
+  if type(value) not in (int, float) or value < 0:
+    raise ValueError("invalid token count")
+  if isinstance(value, float) and (not math.isfinite(value) or not value.is_integer()):
+    raise ValueError("invalid token count")
+  return int(value)
+
+
+def usage_token(usage: dict[str, Any], snake_key: str, camel_key: str) -> int:
+  return number(usage.get(snake_key, usage.get(camel_key, 0)))
 
 
 def empty_bucket() -> dict[str, int]:
@@ -93,15 +86,65 @@ def empty_bucket() -> dict[str, int]:
   }
 
 
+def empty_stats() -> dict[str, Any]:
+  return {
+    "todayPrompts": 0,
+    "todaySessions": 0,
+    "todayTotalTokens": 0,
+    "todayTokensByModel": {},
+    "recentDays": [{"date": day, "messageCount": 0} for day in recent_date_strings()],
+    "modelUsage": {},
+    "totalPrompts": 0,
+    "totalSessions": 0,
+    "activeDays": 0,
+    "activeDates": [],
+  }
+
+
 def read_fresh_json(path: Path, max_age_seconds: float) -> dict[str, Any] | None:
-  if max_age_seconds <= 0 or not path.exists():
+  if max_age_seconds <= 0:
     return None
   try:
-    if time.time() - path.stat().st_mtime <= max_age_seconds:
-      return json.loads(path.read_text(encoding="utf-8"))
-  except Exception:
-    return None
+    age = time.time() - path.stat().st_mtime
+    if 0 <= age <= max_age_seconds:
+      payload = json.loads(path.read_text(encoding="utf-8"))
+      if isinstance(payload, dict):
+        return payload
+  except (OSError, ValueError):
+    pass
   return None
+
+
+def read_cached_stats(path: Path, max_age_seconds: float, roots: list[Path]) -> dict[str, Any] | None:
+  cached = read_fresh_json(path, max_age_seconds)
+  if not cached or cached.get("schemaVersion") != 1 or cached.get("scanDate") != local_date_string():
+    return None
+  if cached.get("roots") != [str(root) for root in roots]:
+    return None
+  stats = cached.get("stats")
+  template = empty_stats()
+  if not isinstance(stats, dict) or any(type(stats.get(key)) is not type(value) for key, value in template.items()):
+    return None
+  try:
+    for key, value in template.items():
+      if isinstance(value, int):
+        number(stats[key])
+    for value in stats["todayTokensByModel"].values():
+      number(value)
+    for bucket in stats["modelUsage"].values():
+      if not isinstance(bucket, dict) or set(bucket) != set(empty_bucket()):
+        return None
+      for value in bucket.values():
+        number(value)
+    if [day.get("date") for day in stats["recentDays"]] != recent_date_strings():
+      return None
+    for day in stats["recentDays"]:
+      number(day["messageCount"])
+    if any(not isinstance(day, str) or dt.date.fromisoformat(day).isoformat() != day for day in stats["activeDates"]):
+      return None
+  except (ValueError, TypeError, KeyError, AttributeError):
+    return None
+  return {key: stats[key] for key in template}
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -117,114 +160,196 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     raise
 
 
-def scan_sessions() -> dict[str, Any] | None:
-  roots = [
-    Path.home() / ".pi" / "agent" / "sessions",
-    Path.home() / ".omp" / "agent" / "sessions",
-  ]
-  cache_file = cache_root() / "pi-sessions.json"
+def session_roots() -> list[Path]:
+  bases = {Path.home() / ".pi", Path.home() / ".omp"}
+  if os.environ.get("PI_CONFIG_DIR"):
+    bases.add(Path.home() / os.path.expanduser(os.environ["PI_CONFIG_DIR"]))
+  roots = [base / "agent" / "sessions" for base in bases]
+  if os.environ.get("PI_CODING_AGENT_DIR"):
+    roots.append(Path(os.path.expandvars(os.path.expanduser(os.environ["PI_CODING_AGENT_DIR"]))) / "sessions")
+  if os.environ.get("PI_CODING_AGENT_SESSION_DIR"):
+    roots.append(Path(os.path.expanduser(os.environ["PI_CODING_AGENT_SESSION_DIR"])))
+  for base in bases:
+    roots.extend(base.glob("profiles/*/agent/sessions"))
+  if os.environ.get("XDG_DATA_HOME"):
+    omp_data = Path(os.environ["XDG_DATA_HOME"]) / "omp"
+    roots.append(omp_data / "sessions")
+    roots.extend(omp_data.glob("profiles/*/sessions"))
+  return sorted({root.resolve() for root in roots})
 
+
+def session_lineage(path: Path, parents: dict[Path, Path | uuid.UUID]) -> tuple[Path | uuid.UUID, int]:
+  visited: set[Path] = set()
+  current: Path | uuid.UUID = path
+  while isinstance(current, Path) and current in parents:
+    if current in visited:
+      return path, 0
+    visited.add(current)
+    current = parents[current]
+  return current, len(visited)
+
+
+def scan_sessions(roots: list[Path]) -> tuple[dict[str, Any], bool]:
   today = local_date_string()
-  recent_dates = recent_date_strings()
-  recent = {day: {"date": day, "messageCount": 0} for day in recent_dates}
-  sessions: set[str] = set()
-  active_days: set[str] = set()
-  today_sessions: set[str] = set()
-  today_tokens: dict[str, int] = {}
-  usage_by_model: dict[str, dict[str, int]] = {}
-  seen: set[str] = set()
-  prompts = 0
-  today_prompt_count = 0
-  today_token_total = 0
+  stats = empty_stats()
+  recent = {day["date"]: day for day in stats["recentDays"]}
+  records: dict[Path, list] = {}
+  headers: dict[Path, dict] = {}
+  aliases: dict[Path, Path] = {}
+  physical_files: dict[tuple[int, int], Path] = {}
+  complete = True
 
   for root in roots:
-    files = root.rglob("*.jsonl") if root.is_dir() else []
-    for path in files:
+    try:
+      candidates = sorted(root.rglob("*.jsonl"))
+    except OSError as exc:
+      print(f"omarchy-agent-usage-pi: incomplete scan of {root} ({exc})", file=sys.stderr)
+      complete = False
+      continue
+    for candidate in candidates:
       try:
+        path = candidate.resolve()
+        file_stat = path.stat()
+        physical_key = (file_stat.st_dev, file_stat.st_ino)
+        aliases[path] = physical_files.setdefault(physical_key, path)
+        if aliases[path] != path or path in records:
+          continue
+        records[path] = []
         with path.open("r", encoding="utf-8", errors="replace") as handle:
           for line_number, line in enumerate(handle, 1):
-            if '"usage"' not in line or '"assistant"' not in line:
+            if '"session"' not in line and '"assistant"' not in line:
               continue
             try:
               entry = json.loads(line)
-            except Exception:
+            except ValueError:
               continue
-
-            message = entry.get("message") if isinstance(entry.get("message"), dict) else {}
-            if entry.get("type") != "message" or message.get("role") != "assistant":
+            if not isinstance(entry, dict):
               continue
-
-            usage = message.get("usage") or {}
+            if entry.get("type") == "session":
+              headers.setdefault(path, entry)
+              continue
+            message = entry.get("message")
+            if entry.get("type") != "message" or not isinstance(message, dict) or message.get("role") != "assistant":
+              continue
+            usage = message.get("usage")
             if not isinstance(usage, dict):
               continue
-
-            unique_key = f"{path}:{entry.get('id') or line_number}"
-            if unique_key in seen:
+            try:
+              bucket = {
+                "inputTokens": usage_token(usage, "input", "inputTokens"),
+                "outputTokens": usage_token(usage, "output", "outputTokens"),
+                "cacheReadInputTokens": usage_token(usage, "cacheRead", "cacheReadInputTokens"),
+                "cacheCreationInputTokens": usage_token(usage, "cacheWrite", "cacheCreationInputTokens"),
+              }
+              total = sum(bucket.values())
+              if total == 0:
+                total = number(usage.get("totalTokens", 0))
+                bucket["inputTokens"] = total
+            except ValueError:
               continue
-            seen.add(unique_key)
-
-            input_tokens = usage_token(usage, "input", "inputTokens")
-            output_tokens = usage_token(usage, "output", "outputTokens")
-            cache_read = usage_token(usage, "cacheRead", "cacheReadInputTokens")
-            cache_write = usage_token(usage, "cacheWrite", "cacheCreationInputTokens")
-            total = input_tokens + output_tokens + cache_read + cache_write
-            if total <= 0:
-              total = number(usage.get("totalTokens"))
-              input_tokens = total
-            if total <= 0:
+            if total == 0:
               continue
+            model = message.get("model") or "pi"
+            day = local_date_from_timestamp(entry.get("timestamp")) or local_date_from_timestamp(message.get("timestamp"))
+            if not isinstance(model, str) or not day or day > today:
+              continue
+            entry_id = entry.get("id")
+            if not isinstance(entry_id, str) or not entry_id:
+              entry_id = f"{path}:{line_number}"
+            identity = [entry.get("timestamp"), message.get("timestamp"), message.get("provider"),
+                        model, message.get("content"), bucket]
+            fingerprint = hashlib.sha256(json.dumps(identity, sort_keys=True).encode()).digest()
+            records[path].append((entry_id, fingerprint, model, day, bucket, total))
+      except OSError as exc:
+        print(f"omarchy-agent-usage-pi: incomplete scan of {candidate} ({exc})", file=sys.stderr)
+        complete = False
 
-            model = str(message.get("model") or "pi")
-            day = local_date_from_timestamp(entry.get("timestamp") or message.get("timestamp"))
-            session_key = str(path)
-            sessions.add(session_key)
-            active_days.add(day)
-            prompts += 1
-
-            bucket = usage_by_model.setdefault(model, empty_bucket())
-            bucket["inputTokens"] += input_tokens
-            bucket["outputTokens"] += output_tokens
-            bucket["cacheReadInputTokens"] += cache_read
-            bucket["cacheCreationInputTokens"] += cache_write
-
-            if day in recent:
-              recent[day]["messageCount"] += total
-            if day == today:
-              today_prompt_count += 1
-              today_sessions.add(session_key)
-              today_token_total += total
-              today_tokens[model] = today_tokens.get(model, 0) + total
-      except OSError:
+  paths_by_id: dict[str, list[Path]] = {}
+  for path, header in headers.items():
+    session_id = header.get("id")
+    if isinstance(session_id, str) and session_id:
+      paths_by_id.setdefault(session_id, []).append(path)
+  parents: dict[Path, Path | uuid.UUID] = {}
+  for path, header in headers.items():
+    parent = header.get("parentSession")
+    if not isinstance(parent, str) or not parent:
+      continue
+    matches = paths_by_id.get(parent, [])
+    if len(matches) == 1:
+      parents[path] = matches[0]
+    elif parent.endswith(".jsonl") or Path(parent).is_absolute():
+      try:
+        parent_path = (path.parent / parent).resolve()
+        parents[path] = aliases.get(parent_path, parent_path)
+      except (OSError, ValueError, RuntimeError):
+        continue
+    elif not matches:
+      try:
+        parent_id = uuid.UUID(parent)
+        if str(parent_id) == parent:
+          parents[path] = parent_id
+      except ValueError:
         continue
 
-  if prompts <= 0:
-    return None
+  lineages = {path: session_lineage(path, parents) for path in records}
+  seen: set[tuple] = set()
+  sessions: set[Path] = set()
+  today_sessions: set[Path] = set()
+  active_days: set[str] = set()
+  for path in sorted(records, key=lambda path: (lineages[path][1], str(path))):
+    for entry_id, fingerprint, model, day, tokens, total in records[path]:
+      unique_key = (lineages[path][0], entry_id, fingerprint)
+      if unique_key in seen:
+        continue
+      seen.add(unique_key)
+      sessions.add(path)
+      active_days.add(day)
+      stats["totalPrompts"] += 1
+      bucket = stats["modelUsage"].setdefault(model, empty_bucket())
+      for key, value in tokens.items():
+        bucket[key] += value
+      if day in recent:
+        recent[day]["messageCount"] += total
+      if day == today:
+        today_sessions.add(path)
+        stats["todayPrompts"] += 1
+        stats["todayTotalTokens"] += total
+        today_tokens = stats["todayTokensByModel"]
+        today_tokens[model] = today_tokens.get(model, 0) + total
+  stats["todaySessions"] = len(today_sessions)
+  stats["totalSessions"] = len(sessions)
+  stats["activeDays"] = len(active_days)
+  stats["activeDates"] = sorted(active_days)
+  return stats, complete
 
-  return {
-    "todayPrompts": today_prompt_count,
-    "todaySessions": len(today_sessions),
-    "todayTotalTokens": today_token_total,
-    "todayTokensByModel": today_tokens,
-    "recentDays": [recent[day] for day in recent_dates],
-    "modelUsage": usage_by_model,
-    "totalPrompts": prompts,
-    "totalSessions": len(sessions),
-    "activeDays": len(active_days),
-    "activeDates": sorted(active_days),
-  }
 
-
-def cached_scan(max_age_seconds: float) -> dict[str, Any] | None:
-  cache_file = cache_root() / "pi-sessions.json"
-
-  cached = read_fresh_json(cache_file, max_age_seconds)
-  if cached is not None:
-    return cached.get("stats")
-
-  stats = scan_sessions()
-  if stats is not None:
-    write_json(cache_file, {"stats": stats})
-  return stats
+def cached_scan(max_age_seconds: float) -> dict[str, Any]:
+  roots = session_roots()
+  try:
+    cache_file = cache_root() / "pi-sessions.json"
+    with cache_file.with_suffix(".lock").open("a") as lock:
+      fcntl.flock(lock, fcntl.LOCK_EX)
+      cached = read_cached_stats(cache_file, max_age_seconds, roots)
+      if cached is not None:
+        return cached
+      scan_date = local_date_string()
+      stats, complete = scan_sessions(roots)
+      try:
+        if complete:
+          write_json(cache_file, {"schemaVersion": 1, "scanDate": scan_date,
+                                 "roots": [str(root) for root in roots], "stats": stats})
+        else:
+          cache_file.unlink(missing_ok=True)
+      except OSError as exc:
+        print(f"omarchy-agent-usage-pi: could not write usage cache ({exc})", file=sys.stderr)
+        try:
+          cache_file.unlink(missing_ok=True)
+        except OSError:
+          pass
+      return stats
+  except OSError as exc:
+    print(f"omarchy-agent-usage-pi: cache unavailable ({exc}); scanning directly", file=sys.stderr)
+    return scan_sessions(roots)[0]
 
 
 def main() -> int:
@@ -232,7 +357,7 @@ def main() -> int:
   parser = argparse.ArgumentParser()
   parser.add_argument("--force", action="store_true")
   parser.add_argument("--limits-only", action="store_true")
-  parser.add_argument("--cache-seconds", type=float, default=20)
+  parser.add_argument("--cache-seconds", type=float, default=SCAN_REUSE_SECONDS)
   args = parser.parse_args()
 
   max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else args.cache_seconds)
@@ -245,23 +370,9 @@ def main() -> int:
     "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
     "ready": True,
     "hasLocalStats": True,
+    "tierLabel": "Local usage",
   }
-  if stats is not None:
-    record.update(stats)
-  else:
-    record.update({
-      "todayPrompts": 0,
-      "todaySessions": 0,
-      "todayTotalTokens": 0,
-      "todayTokensByModel": {},
-      "recentDays": [{"date": day, "messageCount": 0} for day in recent_date_strings()],
-      "modelUsage": {},
-      "totalPrompts": 0,
-      "totalSessions": 0,
-      "activeDays": 0,
-      "activeDates": [],
-    })
-
+  record.update(stats)
   print(json.dumps(record, separators=(",", ":"), sort_keys=True))
   return 0
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -1,6 +1,6 @@
 # Agents
 
-One bar icon and one panel for every AI coding subscription on the machine.
+One bar icon and one panel for AI coding subscriptions and local Pi/OMP usage on the machine.
 The panel is strictly a display: it watches the usage records that
 `omarchy-agent-usage-update` writes to `~/.local/state/omarchy/agents/usage/`
 and draws whatever appears there. `Panel.qml` owns the bar button and the
@@ -53,8 +53,9 @@ light surfaces — and the bar glyph stands in when there is none.
 | Collector | Limits | Local stats |
 |---|---|---|
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
-| `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
+| `codex` | The Codex app-server RPC | native Codex CLI session files and opencode sessions on an OpenAI provider |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `pi` | None; labeled Local usage | Pi and Oh My Pi assistant messages from every backend, with inherited fork responses counted once |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -63,6 +64,10 @@ falls back to local stats only. A non-default Claude directory is honored via
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there.
+
+Pi scans `~/.pi/agent/sessions`, `~/.omp/agent/sessions`, existing `~/.pi/profiles/*/agent/sessions` and `~/.omp/profiles/*/agent/sessions`, and `PI_CODING_AGENT_DIR/sessions` and the explicit `PI_CODING_AGENT_SESSION_DIR` directory when configured. OMP's `PI_CONFIG_DIR` root and existing `$XDG_DATA_HOME/omp/sessions` and `$XDG_DATA_HOME/omp/profiles/*/sessions` are also included. Physical file aliases are counted once. Forks are deduplicated within their `parentSession` lineage using entry IDs and message fingerprints, not globally by Pi's short entry IDs; independent sessions remain separate.
+
+The Pi tab is local usage, not a subscription meter: it does not infer quota resets or costs from tokens. Today and the seven daily rows use local calendar dates; model totals cover all valid assistant usage still on disk. Prompt counts represent assistant responses, including tool-use turns. Invalid dates and negative, non-finite, or fractional token counters are skipped. Recent scans are cached for 20 seconds, or 15 minutes for `--limits-only`; `--force`, a different local date, or changed session roots triggers a fresh scan. The cache is optional and an empty forced scan clears old usage.
 
 ### Fireworks balance
 
@@ -146,5 +151,5 @@ the same account synced from two machines is not counted twice.
 
 One caveat on "all-time": the Codex collector only reads native session files
 touched in the last 30 days, and Fireworks requests the last 30 days from its
-billing API, so their totals and day counts cover that window. Claude's cover
+billing API, so their totals and day counts cover that window. Claude and Pi cover
 every transcript still on disk.

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, Fireworks, and Pi/OMP usage in a native Omarchy bar panel, with limits or balance when available.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -13,7 +13,7 @@
   },
   "barWidget": {
     "displayName": "Agents",
-    "description": "One bar icon and one panel: rate-limit meters with pace, today, the last week, and the all-time model breakdown for every subscription.",
+    "description": "One bar icon and one panel: today, the last week, and the all-time model breakdown for every agent, with rate-limit meters when available.",
     "category": "AI",
     "aliases": ["agents", "model-usage"],
     "allowMultiple": false,

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -121,11 +121,11 @@ EOF
 result=$(HOME="$PI_HOME" XDG_CACHE_HOME="$PI_HOME/.cache" XDG_DATA_HOME="$PI_HOME/.local/share" \
   "$ROOT/bin/omarchy-agent-usage-claude" --force)
 
-[[ $(jq -r '.todayTotalTokens' <<<"$result") == "49" ]] ||
-  fail "Claude collector counts usage from pi and omp sessions" "$result"
-[[ $(jq -c '.modelUsage' <<<"$result") == '{"claude-omp":{"cacheCreationInputTokens":1,"cacheReadInputTokens":4,"inputTokens":20,"outputTokens":5},"claude-pi":{"cacheCreationInputTokens":2,"cacheReadInputTokens":3,"inputTokens":10,"outputTokens":4}}' ]] ||
-  fail "Claude collector filters pi and omp sessions to Anthropic providers" "$result"
-pass "Claude collector counts pi and omp subscription usage"
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "0" ]] ||
+  fail "Claude collector no longer counts pi and omp sessions" "$result"
+[[ $(jq -c '.modelUsage' <<<"$result") == '{}' ]] ||
+  fail "Claude collector keeps pi and omp usage in the dedicated pi collector" "$result"
+pass "Claude collector leaves pi and omp sessions to the pi collector"
 
 # Collectors overlap in practice: the update command backgrounds one per agent
 # while the panel refreshes on its own. Two writers aiming at one cache file

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -85,11 +85,11 @@ EOF
 result=$(HOME="$PI_HOME" CODEX_HOME="$PI_HOME/.codex" XDG_DATA_HOME="$PI_HOME/.local/share" \
   PATH="$PI_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
 
-[[ $(jq -r '.todayTotalTokens' <<<"$result") == "49" ]] ||
-  fail "Codex collector counts usage from pi and omp sessions" "$result"
-[[ $(jq -c '.modelUsage' <<<"$result") == '{"gpt-pi":{"inputTokens":10,"outputTokens":4,"cacheReadInputTokens":3,"cacheCreationInputTokens":2},"gpt-omp":{"inputTokens":20,"outputTokens":5,"cacheReadInputTokens":4,"cacheCreationInputTokens":1}}' ]] ||
-  fail "Codex collector filters pi and omp sessions to Codex providers" "$result"
-pass "Codex collector counts pi and omp subscription usage"
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "0" ]] ||
+  fail "Codex collector no longer counts pi and omp sessions" "$result"
+[[ $(jq -c '.modelUsage' <<<"$result") == '{}' ]] ||
+  fail "Codex collector keeps pi and omp usage in the dedicated pi collector" "$result"
+pass "Codex collector leaves pi and omp sessions to the pi collector"
 
 # A subscription burned entirely through opencode has no native session files;
 # usage must come from opencode's message database, filtered to OpenAI.

--- a/test/shell.d/agent-usage-pi-scanner-test.sh
+++ b/test/shell.d/agent-usage-pi-scanner-test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$TEST_HOME/.pi/agent/sessions/project" "$TEST_HOME/.omp/agent/sessions/project"
+
+timestamp="$(date +%Y-%m-%d)T12:00:00Z"
+
+cat >"$TEST_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF
+{"type":"message","id":"pi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"anthropic","api":"anthropic-messages","model":"claude-pi","usage":{"input":10,"output":4,"cacheRead":3,"cacheWrite":2,"totalTokens":19}}}
+{"type":"message","id":"codex-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"openai-codex","model":"gpt-test","usage":{"input":999,"output":999}}}
+{"type":"message","id":"kimi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"kimi-coding","api":"anthropic-messages","model":"k3","usage":{"input":999,"output":999}}}
+EOF
+cat >"$TEST_HOME/.omp/agent/sessions/project/omp.jsonl" <<EOF
+{ "type": "message", "id": "omp-1", "timestamp": "$timestamp", "message": { "role": "assistant", "provider": "anthropic", "model": "claude-omp", "usage": { "input": 20, "output": 5, "cacheRead": 4, "cacheWrite": 1, "totalTokens": 30 } } }
+EOF
+
+result=$(HOME="$TEST_HOME" XDG_CACHE_HOME="$TEST_HOME/.cache" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-pi" --force)
+
+[[ $(jq -r '.id' <<<"$result") == "pi" ]] ||
+  fail "Pi collector identifies itself" "$result"
+pass "Pi collector identifies itself"
+
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "4045" ]] ||
+  fail "Pi collector counts usage from every configured backend" "$result"
+pass "Pi collector counts usage from every configured backend"
+
+[[ $(jq -c '.todayTokensByModel' <<<"$result") == '{"claude-omp":30,"claude-pi":19,"gpt-test":1998,"k3":1998}' ]] ||
+  fail "Pi collector keeps today tokens per model" "$result"
+pass "Pi collector keeps today tokens per model"
+
+[[ $(jq -c '.modelUsage' <<<"$result") == '{"claude-omp":{"cacheCreationInputTokens":1,"cacheReadInputTokens":4,"inputTokens":20,"outputTokens":5},"claude-pi":{"cacheCreationInputTokens":2,"cacheReadInputTokens":3,"inputTokens":10,"outputTokens":4},"gpt-test":{"cacheCreationInputTokens":0,"cacheReadInputTokens":0,"inputTokens":999,"outputTokens":999},"k3":{"cacheCreationInputTokens":0,"cacheReadInputTokens":0,"inputTokens":999,"outputTokens":999}}' ]] ||
+  fail "Pi collector aggregates tokens by model for all providers" "$result"
+pass "Pi collector aggregates tokens by model for all providers"

--- a/test/shell.d/agent-usage-pi-scanner-test.sh
+++ b/test/shell.d/agent-usage-pi-scanner-test.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+set -euo pipefail
+
 source "$(dirname "$0")/base-test.sh"
+
+unset PI_CODING_AGENT_DIR PI_CODING_AGENT_SESSION_DIR PI_CONFIG_DIR
 
 require_command jq
 require_command python3
@@ -10,7 +14,7 @@ trap 'rm -rf "$TEST_HOME"' EXIT
 
 mkdir -p "$TEST_HOME/.pi/agent/sessions/project" "$TEST_HOME/.omp/agent/sessions/project"
 
-timestamp="$(date +%Y-%m-%d)T12:00:00Z"
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 cat >"$TEST_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF
 {"type":"message","id":"pi-1","timestamp":"$timestamp","message":{"role":"assistant","provider":"anthropic","api":"anthropic-messages","model":"claude-pi","usage":{"input":10,"output":4,"cacheRead":3,"cacheWrite":2,"totalTokens":19}}}
@@ -39,3 +43,377 @@ pass "Pi collector keeps today tokens per model"
 [[ $(jq -c '.modelUsage' <<<"$result") == '{"claude-omp":{"cacheCreationInputTokens":1,"cacheReadInputTokens":4,"inputTokens":20,"outputTokens":5},"claude-pi":{"cacheCreationInputTokens":2,"cacheReadInputTokens":3,"inputTokens":10,"outputTokens":4},"gpt-test":{"cacheCreationInputTokens":0,"cacheReadInputTokens":0,"inputTokens":999,"outputTokens":999},"k3":{"cacheCreationInputTokens":0,"cacheReadInputTokens":0,"inputTokens":999,"outputTokens":999}}' ]] ||
   fail "Pi collector aggregates tokens by model for all providers" "$result"
 pass "Pi collector aggregates tokens by model for all providers"
+
+python3 - "$ROOT/bin/omarchy-agent-usage-pi" <<'PY'
+import copy
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import Mock, patch
+
+collector = Path(sys.argv.pop())
+source = collector.read_text()
+
+
+class PiScannerTests(unittest.TestCase):
+  def setUp(self):
+    self.directory = tempfile.TemporaryDirectory()
+    self.addCleanup(self.directory.cleanup)
+    self.home = Path(self.directory.name)
+    self.env = dict(os.environ, HOME=str(self.home), XDG_CACHE_HOME=str(self.home / '.cache'),
+                    XDG_DATA_HOME=str(self.home / '.data'), TZ='UTC')
+    for key in ('PI_CODING_AGENT_DIR', 'PI_CODING_AGENT_SESSION_DIR', 'PI_CONFIG_DIR'):
+      self.env.pop(key, None)
+    self.path = self.home / '.pi/agent/sessions/project/parent.jsonl'
+    self.cache = self.home / '.cache/omarchy/agent-usage/pi-sessions.json'
+    self.timestamp = dt.datetime.now(dt.timezone.utc).isoformat()
+
+  def message(self, id='abcd1234', tokens=19, timestamp=None):
+    return {'type': 'message', 'id': id, 'parentId': None, 'timestamp': timestamp or self.timestamp,
+            'message': {'role': 'assistant', 'api': 'openai-completions', 'provider': 'openrouter',
+                        'model': 'test', 'timestamp': int(time.time() * 1000), 'stopReason': 'stop',
+                        'content': [{'type': 'text', 'text': id}],
+                        'usage': {'input': tokens, 'output': 0, 'cacheRead': 0, 'cacheWrite': 0,
+                                  'totalTokens': tokens, 'cost': {'input': .01, 'output': 0,
+                                  'cacheRead': 0, 'cacheWrite': 0, 'total': .01}}}}
+
+  def put(self, path, entries):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(''.join((e if isinstance(e, str) else json.dumps(e)) + '\n' for e in entries))
+
+  def run_collector(self, *args):
+    result = subprocess.run([sys.executable, str(collector), *args], env=self.env, capture_output=True, text=True)
+    self.assertEqual(result.returncode, 0, result.stderr)
+    record = json.loads(result.stdout)
+    self.assertEqual(record['id'], 'pi')
+    self.assertEqual(record['schemaVersion'], 1)
+    return record
+
+  def header(self, id, parent=None):
+    header = {'type': 'session', 'version': 3, 'id': id, 'timestamp': self.timestamp, 'cwd': '/project'}
+    if parent is not None:
+      header['parentSession'] = str(parent)
+    return header
+
+  def test_empty_force_replaces_nonempty_cache(self):
+    self.put(self.path, [self.message()])
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 19)
+    self.path.unlink()
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 0)
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 0)
+    self.assertEqual(json.loads(self.cache.read_text())['stats']['totalPrompts'], 0)
+
+  def test_failed_cache_write_invalidates_previous_usage(self):
+    self.put(self.path, [self.message()])
+    self.run_collector('--force')
+    self.path.unlink()
+    namespace = {'__name__': 'test_collector'}
+    exec(compile(source, str(collector), 'exec'), namespace)
+    with patch.dict(os.environ, self.env), patch.dict(namespace, write_json=Mock(side_effect=OSError('disk full'))):
+      self.assertEqual(namespace['cached_scan'](0)['todayTotalTokens'], 0)
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 0)
+
+  def test_failed_cache_invalidation_is_best_effort(self):
+    self.put(self.path, [self.message()])
+    self.run_collector('--force')
+    self.path.unlink()
+    namespace = {'__name__': 'test_collector'}
+    exec(compile(source, str(collector), 'exec'), namespace)
+    with patch.dict(os.environ, self.env), patch.dict(namespace, write_json=Mock(side_effect=OSError('read only'))), \
+         patch.object(Path, 'unlink', side_effect=PermissionError('read only')):
+      self.assertEqual(namespace['cached_scan'](0)['todayTotalTokens'], 0)
+
+  def test_cache_reuse_force_and_expiry(self):
+    self.put(self.path, [self.message()])
+    self.run_collector('--force')
+    self.put(self.path, [self.message(tokens=33)])
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 19)
+    self.assertEqual(self.run_collector('--force', '--limits-only')['todayTotalTokens'], 33)
+    self.put(self.path, [self.message(tokens=45)])
+    os.utime(self.cache, (time.time() - 1000,) * 2)
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 45)
+
+  def test_cache_envelope_and_shapes(self):
+    self.put(self.path, [self.message()])
+    self.run_collector('--force')
+    envelope = json.loads(self.cache.read_text())
+    self.assertEqual(envelope.get('schemaVersion'), 1)
+    self.assertEqual(envelope.get('scanDate'), self.timestamp[:10])
+    self.assertEqual(self.cache.stat().st_mode & 0o777, 0o644)
+    for bad in ([], {'stats': {}}, dict(envelope, stats=[]), dict(envelope, stats={}),
+                dict(envelope, stats=dict(envelope['stats'], recentDays='wrong')),
+                dict(envelope, stats=dict(envelope['stats'], modelUsage={'test': []}))):
+      with self.subTest(cache=bad):
+        self.cache.write_text(json.dumps(bad))
+        self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 19)
+    self.cache.write_text('{')
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 19)
+
+  def test_other_date_and_future_mtime_are_cache_misses(self):
+    self.put(self.path, [self.message()])
+    self.run_collector('--force')
+    cached = json.loads(self.cache.read_text())
+    cached['scanDate'] = '2000-01-01'
+    self.cache.write_text(json.dumps(cached))
+    self.put(self.path, [self.message(tokens=33)])
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 33)
+    os.utime(self.cache, (time.time() + 3600,) * 2)
+    self.put(self.path, [self.message(tokens=45)])
+    self.assertEqual(self.run_collector()['todayTotalTokens'], 45)
+
+  def test_cache_unavailable_still_emits_record(self):
+    self.put(self.path, [self.message()])
+    blocked = self.home / 'blocked'
+    blocked.write_text('not a directory')
+    self.env['XDG_CACHE_HOME'] = str(blocked)
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 19)
+
+  def test_bad_rows_do_not_abort_or_hide_valid_rows(self):
+    self.put(self.path, [self.message(), '["usage", "assistant"]', '{"usage":',
+                        {'type': 'message', 'message': ['assistant', 'usage']},
+                        {'type': 'message', 'message': {'role': 'assistant', 'usage': []}},
+                        self.message('second', 7)])
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 26)
+
+  def test_fork_lineage_and_short_id_collisions(self):
+    inherited = self.message()
+    child = self.path.parent / 'a-child.jsonl'
+    sibling = self.path.parent / 'b-sibling.jsonl'
+    unrelated = self.path.parent / 'unrelated.jsonl'
+    self.put(self.path, [self.header('parent-session'), inherited, inherited])
+    self.put(child, [self.header('child-session', self.path), inherited, self.message('child-new', 7)])
+    collision = self.message(tokens=5)
+    collision['message']['content'] = [{'type': 'text', 'text': 'independent response with colliding short id'}]
+    self.put(sibling, [self.header('sibling-session', 'parent-session'), inherited, collision])
+    self.put(unrelated, [self.header('unrelated-session'), inherited])
+    record = self.run_collector('--force')
+    self.assertEqual(record['todayTotalTokens'], 50)
+    self.assertEqual(record['totalPrompts'], 4)
+    self.assertEqual(record['totalSessions'], 4)
+    self.put(child, [self.header('child-session', self.path), inherited])
+    sibling.unlink()
+    unrelated.unlink()
+    self.assertEqual(self.run_collector('--force')['totalSessions'], 1)
+    self.path.unlink()
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 19)
+
+  def test_cost_reset_forks_keep_stable_response_identity(self):
+    original = self.message()
+    original['message']['usage'].update(credits=2, premiumRequests=1)
+    inherited = copy.deepcopy(original)
+    inherited['message']['usage']['cost'] = dict.fromkeys(original['message']['usage']['cost'], 0)
+    del inherited['message']['usage']['credits']
+    del inherited['message']['usage']['premiumRequests']
+    child = self.path.parent / 'child.jsonl'
+    self.put(self.path, [self.header('parent-session'), original])
+    self.put(child, [self.header('child-session', self.path), inherited])
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 19)
+    for key, value in (('provider', 'another-provider'), ('model', 'another-model'),
+                       ('timestamp', original['message']['timestamp'] + 1),
+                       ('content', [{'type': 'text', 'text': 'different response'}]),
+                       ('usage', dict(original['message']['usage'], input=7, totalTokens=7))):
+      with self.subTest(field=key):
+        collision = copy.deepcopy(original)
+        collision['message'][key] = value
+        self.put(child, [self.header('child-session', self.path), inherited, collision])
+        expected = 26 if key == 'usage' else 38
+        self.assertEqual(self.run_collector('--force')['todayTotalTokens'], expected)
+    collision = copy.deepcopy(original)
+    collision['timestamp'] = (dt.datetime.fromisoformat(self.timestamp) - dt.timedelta(seconds=1)).isoformat()
+    self.put(child, [self.header('child-session', self.path), inherited, collision])
+    self.assertEqual(self.run_collector('--force')['totalPrompts'], 2)
+
+  def test_missing_uuid_parent_keeps_sibling_forks_linked(self):
+    parent_id = '01995131-8e80-7000-8000-000000000001'
+    inherited = self.message()
+    sibling = self.path.parent / 'sibling.jsonl'
+    self.put(self.path, [self.header('child-session', parent_id), inherited])
+    self.put(sibling, [self.header('sibling-session', parent_id), inherited, self.message('new', 7)])
+    record = self.run_collector('--force')
+    self.assertEqual(record['todayTotalTokens'], 26)
+    self.assertEqual(record['totalPrompts'], 2)
+
+  def test_ambiguous_and_non_uuid_parent_ids_remain_independent(self):
+    inherited = self.message()
+    sibling = self.path.parent / 'sibling.jsonl'
+    parent_id = '01995131-8e80-7000-8000-000000000001'
+    for parent in ('abcd1234', '{' + parent_id + '}', parent_id):
+      with self.subTest(parent=parent):
+        if parent == parent_id:
+          for name in ('original-a', 'original-b'):
+            self.put(self.path.parent / (name + '.jsonl'), [self.header(parent)])
+        self.put(self.path, [self.header('child-session', parent), inherited])
+        self.put(sibling, [self.header('sibling-session', parent), inherited])
+        self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 38)
+
+  def test_malformed_parent_paths_do_not_hide_usage(self):
+    self.put(self.path.parent / 'later.jsonl', [self.message('later', 7)])
+    loop = self.path.parent / 'loop'
+    loop.symlink_to(loop)
+    for parent in ('bad\x00.jsonl', '/bad\x00/parent', str(loop)):
+      with self.subTest(parent=parent):
+        self.put(self.path, [self.header('session', parent), self.message()])
+        self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 26)
+
+  def test_physical_aliases_count_once(self):
+    self.put(self.path, [self.message()])
+    alias = self.home / '.omp/agent/sessions'
+    alias.parent.mkdir(parents=True)
+    alias.symlink_to(self.home / '.pi/agent/sessions', target_is_directory=True)
+    os.link(self.path, self.path.parent / 'hardlink.jsonl')
+    self.env['PI_CODING_AGENT_DIR'] = str(self.home / '.pi/agent')
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 19)
+
+  def test_configured_roots_profiles_and_cache_identity(self):
+    configured = self.home / 'configured agent'
+    self.env['PI_CODING_AGENT_DIR'] = str(configured)
+    self.put(configured / 'sessions/project/custom.jsonl', [self.message('custom', 11)])
+    self.put(self.home / '.omp/profiles/work/agent/sessions/project/profile.jsonl', [self.message('profile', 7)])
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 18)
+    self.env['PI_CODING_AGENT_DIR'] = str(self.home / 'other agent')
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 7)
+    self.put(self.home / '.omp/profiles/new/agent/sessions/project/new.jsonl', [self.message('new', 3)])
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 10)
+
+  def test_explicit_session_directory_and_cache_identity(self):
+    self.put(self.path, [self.message()])
+    self.put(self.home / 'custom sessions/project/a.jsonl', [self.message('custom', 11)])
+    self.env['PI_CODING_AGENT_SESSION_DIR'] = '~/custom sessions'
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 30)
+    other = self.home / 'other sessions'
+    self.put(other / 'project/b.jsonl', [self.message('other', 7)])
+    self.env['PI_CODING_AGENT_SESSION_DIR'] = str(other)
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 26)
+    self.env['PI_CODING_AGENT_SESSION_DIR'] = str(self.home / '.pi/agent/sessions')
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 19)
+
+  def test_omp_xdg_and_custom_config_roots(self):
+    self.env['PI_CONFIG_DIR'] = '.custom-omp'
+    self.put(self.home / '.custom-omp/agent/sessions/project/a.jsonl', [self.message('custom', 11)])
+    self.put(self.home / '.data/omp/sessions/project/b.jsonl', [self.message('xdg', 7)])
+    self.put(self.home / '.data/omp/profiles/work/sessions/project/c.jsonl', [self.message('profile', 3)])
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 21)
+
+  def test_invalid_counters_are_not_replaced_by_total_tokens(self):
+    rows = [self.message()]
+    for index, value in enumerate((-1, float('nan'), float('inf'), True, 'bad', {}, 1.5)):
+      bad = self.message(str(index))
+      bad['message']['usage']['input'] = value
+      rows.append(bad)
+    self.put(self.path, rows)
+    self.assertEqual(self.run_collector('--force')['todayTotalTokens'], 19)
+
+  def test_token_categories_are_exclusive_and_per_response(self):
+    row = self.message()
+    row['message']['usage'] = {'input': 10, 'output': 4, 'cacheRead': 3, 'cacheWrite': 2,
+                               'reasoning': 2, 'cacheWrite1h': 1, 'totalTokens': 19, 'cost': {'total': 99}}
+    fallback = self.message('fallback')
+    fallback['message']['usage'] = {'totalTokens': 5}
+    self.put(self.path, [row, fallback, self.message('next', 2)])
+    record = self.run_collector('--force')
+    self.assertEqual(record['todayTotalTokens'], 26)
+    self.assertEqual(sum(record['modelUsage']['test'].values()), 26)
+    self.assertNotIn('cost', record)
+
+  def test_invalid_dates_do_not_become_today(self):
+    rows = [self.message()]
+    for index, timestamp in enumerate((None, '', 'invalid', True, [], -1, float('nan'))):
+      bad = self.message(str(index))
+      bad['timestamp'] = timestamp
+      bad['message']['timestamp'] = timestamp
+      rows.append(bad)
+    old = self.message('old', 7)
+    old['timestamp'] = 'invalid'
+    old['message']['timestamp'] = 1577836800000
+    future = self.message('future', 9, '2999-01-01T00:00:00Z')
+    self.put(self.path, [*rows, old, future])
+    record = self.run_collector('--force')
+    self.assertEqual(record['todayTotalTokens'], 19)
+    self.assertEqual(record['activeDates'], ['2020-01-01', self.timestamp[:10]])
+    self.assertEqual(record['modelUsage']['test']['inputTokens'], 26)
+
+  def test_local_calendar_and_timestamp_units(self):
+    namespace = {'__name__': 'test_collector'}
+    exec(compile(source, str(collector), 'exec'), namespace)
+    with patch.dict(os.environ, TZ='America/Los_Angeles'):
+      time.tzset()
+      try:
+        instant = dt.datetime(2026, 9, 5, 1, tzinfo=dt.timezone.utc).timestamp()
+        for timestamp in ('2026-09-05T01:00:00Z', '2026-09-05T03:00:00+02:00', instant, instant * 1000):
+          self.assertEqual(namespace['local_date_from_timestamp'](timestamp), '2026-09-04')
+      finally:
+        time.tzset()
+    time.tzset()
+    today = dt.datetime.now(dt.timezone.utc).date()
+    rows = [self.message(str(offset), 1, (today - dt.timedelta(days=offset)).isoformat() + 'T12:00:00Z')
+            for offset in range(9)]
+    self.put(self.path, rows)
+    record = self.run_collector('--force')
+    self.assertEqual(len(record['recentDays']), 7)
+    self.assertEqual(sum(day['messageCount'] for day in record['recentDays']), 7)
+    self.assertEqual(record['modelUsage']['test']['inputTokens'], 9)
+
+  def test_local_only_record_is_not_a_subscription(self):
+    self.put(self.path, [self.message()])
+    record = self.run_collector('--force')
+    self.assertEqual(record.get('tierLabel'), 'Local usage')
+    self.assertEqual(record.get('usageStatusText', ''), '')
+    self.assertEqual(record.get('limits', []), [])
+
+  def test_codex_cache_from_before_pi_split_is_ignored(self):
+    namespace = {'__name__': 'test_codex'}
+    codex_source = collector.with_name('omarchy-agent-usage-codex').read_text()
+    with patch.dict(os.environ, dict(self.env, CODEX_HOME=str(self.home / '.codex'))):
+      exec(compile(codex_source, 'omarchy-agent-usage-codex', 'exec'), namespace)
+      stats = namespace['local_stats']()
+      stats['todayTotalTokens'] = 99
+      stats['totalPrompts'] = 1
+      db = self.home / '.data/opencode/opencode.db'
+      identity = str(self.home) + '\n' + str(self.home / '.codex') + '\n' + str(db)
+      old_cache = self.cache.parent / ('codex-scan-' + hashlib.sha1(identity.encode()).hexdigest()[:16] + '.json')
+      old_cache.parent.mkdir(parents=True, exist_ok=True)
+      old_cache.write_text(json.dumps({'schemaVersion': 1, 'scanDate': namespace['today'], 'stats': stats}))
+      self.assertEqual(namespace['cached_local_stats'](900)['todayTotalTokens'], 0)
+
+  def test_unreadable_file_does_not_hide_later_files_or_get_cached(self):
+    self.put(self.path, [self.message()])
+    unreadable = self.path.parent / 'a-unreadable.jsonl'
+    self.put(unreadable, [self.message('unreadable', 7)])
+    namespace = {'__name__': 'test_collector'}
+    exec(compile(source, str(collector), 'exec'), namespace)
+    original_open = Path.open
+    def open_file(path, *args, **kwargs):
+      if path == unreadable:
+        raise PermissionError('fixture permission denied')
+      return original_open(path, *args, **kwargs)
+    with patch.dict(os.environ, self.env), patch.object(Path, 'open', open_file):
+      stats = namespace['cached_scan'](0)
+    self.assertEqual(stats['todayTotalTokens'], 19)
+    self.assertFalse(self.cache.exists())
+    self.assertEqual(self.run_collector('--limits-only')['todayTotalTokens'], 26)
+
+  def test_midnight_changes_today_even_with_fresh_cache(self):
+    namespace = {'__name__': 'test_collector'}
+    exec(compile(source, str(collector), 'exec'), namespace)
+    real_datetime = dt.datetime
+    class Clock(real_datetime):
+      current = real_datetime(2026, 9, 5, 23, 59, 59, tzinfo=dt.timezone.utc)
+      @classmethod
+      def now(cls, tz=None):
+        return cls.current.astimezone(tz) if tz else cls.current.replace(tzinfo=None)
+    self.put(self.path, [self.message(timestamp='2026-09-05T12:00:00Z')])
+    with patch.dict(os.environ, self.env), patch.object(dt, 'datetime', Clock):
+      self.assertEqual(namespace['cached_scan'](0)['todayTotalTokens'], 19)
+      Clock.current = real_datetime(2026, 9, 6, 0, 0, 1, tzinfo=dt.timezone.utc)
+      self.assertEqual(namespace['cached_scan'](900)['todayTotalTokens'], 0)
+
+
+unittest.main(verbosity=2)
+PY


### PR DESCRIPTION
## Summary

Fixes #8270.

Add a dedicated local Pi/Oh My Pi usage record for every backend, including OpenRouter. Claude and Codex no longer aggregate Pi/OMP transcripts; native and opencode collection remains intact.

## Changes

- Discover default/configured session directories, Pi/OMP profiles, the explicit Pi session-directory override, and OMP XDG locations.
- Count physical aliases and inherited fork responses once using lineage-scoped response identity, not globally unique short IDs. Cover OMP cost-reset forks and missing UUID parents.
- Preserve exclusive per-response token categories and local-calendar windows; skip malformed records, counters, dates and parent paths.
- Make caching optional, serialized, date/root-aware, and safe after empty forced scans or failed writes. Invalidation is best effort if the filesystem refuses both replacement and deletion.
- Invalidate Codex caches from before the Pi split to prevent transitional double counting.
- Label the record Local usage, not Subscription, and update existing documentation.

## Validation

- 25 Pi regressions plus the original four scanner assertions pass in UTC and Pacific/Kiritimati (UTC+14).
- Claude, Codex, Claude limits, Fireworks, updater, agents-panel, plugin validation and first-party manifest schema suites pass in isolated Bash 5/Linux tests.
- Full test/cli, metadata validation, Python compilation and git diff --check pass. Minimal-container CLI runs emit existing missing-theme-directory warnings. No full test/all pass is claimed.
- Real updater integration discovers and writes pi.json; extracted panel functions select Local usage and make a nonempty record visible.
- No live Quickshell/graphical acceptance run is claimed.

## Coordination

Related active work: #8602 (fork deduplication), #9546 (profiles), #8345 (roots/cache identity), and #8649 (OMP collector). After this split, Pi fixes must target the dedicated collector rather than unused Claude/Codex Pi scanners. Agree on OMP ownership before adding another record.

Generated with [Devin](https://devin.ai)