### PR TITLE
Fix Wi-Fi dying after suspend on BCM43602 MacBooks

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -39,6 +39,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-suspend.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-brcmfmac-suspend.sh
+++ b/install/hardware/apple/fix-brcmfmac-suspend.sh
@@ -1,0 +1,46 @@
+# BCM43602's brcmfmac firmware occasionally fails to reinitialize its message
+# ring after suspend/resume: every ioctl times out ("brcmf_msgbuf_query_dcmd:
+# Timeout on response for query command", then cascading -5/-12 errors) and
+# Wi-Fi stays dead until a reboot. It isn't every cycle -- the driver
+# sometimes redoes the firmware download cleanly on resume and sometimes
+# doesn't -- which is what makes it read as "Wi-Fi randomly dies after
+# sleep" rather than a hard failure. See kernel.org bugzilla #196019 and
+# #197977, both open since 2017 with no upstream driver fix.
+#
+# Forcing a full module unload/reload around every suspend makes the driver
+# redo the firmware download it already performs successfully on a cold
+# boot, instead of relying on the in-place PCIe resume path that
+# intermittently fails.
+#
+# Same chip family as the four-way-handshake quirk in
+# fix-brcmfmac-supplicant.sh: BCM43602 and its single-band variants in
+# 2015-2017 Macs (14e4:43ba/43bb/43bc). Scoped to just that family for now --
+# the 2018+ chips (BCM4350/4355/4364) and T2-era chips (BCM4377/4378/4387)
+# have their own suspend behavior and are already being tracked separately
+# (see github.com/basecamp/omarchy/discussions/4695).
+if lspci -nn | grep -E "14e4:(43ba|43bb|43bc)" >/dev/null; then
+  echo "Detected BCM43602 Wi-Fi; installing suspend/resume firmware-reload workaround"
+
+  mkdir -p /usr/lib/systemd/system-sleep
+  cat > /usr/lib/systemd/system-sleep/brcmfmac-suspend.sh <<'EOF'
+#!/bin/bash
+
+# Work around a brcmfmac/BCM43602 firmware bug where suspend/resume
+# occasionally leaves the wifi message ring uninitialized. See
+# install/hardware/apple/fix-brcmfmac-suspend.sh for the full explanation.
+
+case "$1" in
+  pre)
+    modprobe -r brcmfmac_wcc 2>/dev/null
+    modprobe -r brcmfmac 2>/dev/null
+    ;;
+  post)
+    modprobe brcmfmac
+    modprobe brcmfmac_wcc 2>/dev/null
+    ;;
+esac
+
+exit 0
+EOF
+  chmod 755 /usr/lib/systemd/system-sleep/brcmfmac-suspend.sh
+fi


### PR DESCRIPTION
## Summary

- `brcmfmac`'s firmware on BCM43602 (2015-2017 MacBooks) occasionally fails to reinitialize its message ring after suspend/resume: every wifi ioctl times out (`brcmf_msgbuf_query_dcmd: Timeout on response for query command`, cascading into `-5`/`-12` errors) and Wi-Fi stays dead until a reboot.
- It's intermittent by nature — the in-place PCIe resume path sometimes succeeds and sometimes doesn't — which is why it reads as "Wi-Fi randomly dies after sleep" rather than a consistent failure. Tracked upstream and unfixed since 2017: [kernel.org bugzilla #196019](https://bugzilla.kernel.org/show_bug.cgi?id=196019), [#197977](https://bugzilla.kernel.org/show_bug.cgi?id=197977).
- Adds `install/hardware/apple/fix-brcmfmac-suspend.sh`, which installs a `systemd-sleep` hook that unloads and reloads the `brcmfmac` module around every suspend, forcing the same clean firmware download a cold boot already performs successfully, instead of relying on the flaky in-place resume path.
- Scoped to the confirmed BCM43602 PCI IDs already used by `fix-brcmfmac-supplicant.sh` (`14e4:43ba/43bb/43bc`), not the broader chip list in that file — the 2018+ and T2-era chips have different suspend behavior and are already being tracked separately in #4695.

## Test plan

- [x] Verified on a MacBookPro12,1 (BCM43602, `14e4:43ba`): observed the actual failure in `journalctl` after a real sleep/wake cycle (firmware timeout cascade, requiring a reboot to recover).
- [x] Confirmed the fix manually: repeated `pre`/`post` invocations of the installed hook complete cleanly, the `wlp3s0` interface reappears, and NetworkManager reconnects within a few seconds each time.
- [ ] Not yet verified on other BCM43602 Mac models (MacBookPro13,x) — PCI ID match should be equivalent, but flagging for anyone who can confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XWKvdTCkjZXrGHPvDySZ4