### PR TITLE
Keep the idle cycle armed across lock so unlock wakes the display

### DIFF
--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -73,7 +73,11 @@ Item {
     screensaverTimer.stop()
     lockTimer.stop()
     screensaverLaunchGraceTimer.stop()
-    root.idledThisCycle = false
+    // idledThisCycle stays true across the lock: the lock plugin blanks the
+    // display a few seconds after this point on its own timer, independent
+    // of this cycle. Clearing it here would make the next activity signal's
+    // handleActiveSignal() bail out before cancelIdleCycle() can run the
+    // wake process, leaving the display dark after a real unlock.
     root.screensaverStartedThisCycle = false
     resetScreensaverWindows()
     runProcess(lockProcess, "lock", "omarchy-system-lock")


### PR DESCRIPTION
## Problem

After the idle lock fires, unlocking leaves the display dark. The session is unlocked and responsive underneath, but nothing turns the panel back on — you have to blindly trigger something else to get an image back.

## Cause

`lockSystem()` cleared `root.idledThisCycle`, but that flag is exactly what gates the wake path:

- `handleActiveSignal()` returns early unless it is set (`shell/plugins/services/idle/Service.qml:162`)
- `cancelIdleCycle()` only dispatches `omarchy-system-wake` when it is set (`:110`)

The lock plugin blanks the display on its own timer a few seconds *after* `lockSystem()` returns. So by the time the screen actually went dark, the idle cycle had already been disarmed. The next input then hit the early return in `handleActiveSignal()`, `omarchy-system-wake` never ran, and the display stayed off.

In the journal the failure looks like an `idle-monitor: active` line with nothing following it:

```
idle-monitor: active
<nothing>
```

## Fix

Leave `idledThisCycle` set through the lock. `cancelIdleCycle()` still clears it once the wake process has been dispatched, so the cycle ends in the same state as before — just one step later. `screensaverStartedThisCycle` is still reset at lock time, since the screensaver genuinely is finished at that point.

## Verification

Ran on hardware across several idle/lock/unlock cycles. The wake now completes on a wake following a real lock:

```
13:18:27  process-exit: lock exitCode=0
14:57:32  idle-monitor: active
14:57:32  idle-cycle-cancel: activity
14:57:32  process-start: wake omarchy-system-wake
14:57:32  process-exit: wake exitCode=0
```

`test/shell.d/idle-test.sh` passes. Note that the existing idle tests cover the seconds parsing, screensaver window tracking, and the Stay Awake toggle — the `Service.qml` lock/wake state machine has no coverage, so this change is verified by hand rather than by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYjy8bib6bsGwRz5XPDHCq