### PR TITLE
Redact MAC and IP addresses in omarchy-debug

### DIFF
--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -28,16 +28,26 @@ done
 
 LOG_FILE="/tmp/omarchy-debug.log"
 
+redact_network() {
+  sed -E \
+    -e 's/\b([0-9a-f]{2}:){5}[0-9a-f]{2}\b/<mac>/gi' \
+    -e 's/\b[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\b/<ip>/g'
+}
+
 if [[ $NO_SUDO = "true" ]]; then
   DMESG_OUTPUT="(skipped - --no-sudo flag used)"
 else
-  DMESG_OUTPUT="$(sudo dmesg)"
+  DMESG_OUTPUT="$(sudo dmesg | grep -v '\[UFW BLOCK\]' | redact_network)"
 fi
 
 cat > "$LOG_FILE" <<EOF
 Date: $(date)
 Hostname: $(hostname)
 Omarchy Package: $(pacman -Q omarchy-dev 2>/dev/null || pacman -Q omarchy 2>/dev/null || echo "unknown")
+
+Note: [UFW BLOCK] lines, MAC addresses, and IPv4 addresses in the logs below
+have been redacted. The hostname, package list, and other system details may
+still identify this machine; review this file before sharing it publicly.
 
 =========================================
 SYSTEM INFORMATION
@@ -52,7 +62,7 @@ $DMESG_OUTPUT
 =========================================
 JOURNALCTL (CURRENT BOOT, WARNINGS+ERRORS)
 =========================================
-$(journalctl -b -p 4..1)
+$(journalctl -b -p 4..1 | redact_network)
 
 =========================================
 INSTALLED PACKAGES


### PR DESCRIPTION
## Summary

Fixes #10255.

The bug report template asks users to attach `omarchy-debug` output, but that output currently includes unredacted LAN MAC addresses and IPv4 addresses from UFW BLOCK `dmesg` lines.

## Changes

- Add `redact_network()` to `bin/omarchy-debug` to mask MAC addresses and IPv4 addresses.
- Drop `[UFW BLOCK]` lines from `dmesg` (they are netfilter noise and are rarely relevant).
- Apply the same redaction to the `journalctl` warnings/errors section.
- Add a header note warning that hostname and package list may still identify the machine, so the reporter should review before sharing.

## Test plan

- [x] `bash -n bin/omarchy-debug` passes
- [ ] Full run with `omarchy-debug --print` on a Linux box (not available here)