### PR TITLE
Point the UI font families at Adwaita Sans

### DIFF
--- a/default/fontconfig/conf.avail/50-omarchy.conf
+++ b/default/fontconfig/conf.avail/50-omarchy.conf
@@ -66,12 +66,25 @@
     </edit>
   </match>
 
-  <alias>
-    <family>system-ui</family>
-    <prefer>
-      <family>Liberation Sans</family>
-    </prefer>
-  </alias>
+  <!-- The interface font. These are the families CSS and Electron apps name
+       when they want "whatever font this desktop's UI uses", and every
+       platform points them at its own UI face. fontconfig's own 45-latin.conf
+       already classifies Adwaita Sans, Cantarell, Noto Sans UI and Segoe UI
+       under the system-ui generic; Liberation Sans is an Arial metric clone
+       and is classified sans-serif.
+
+       These must be assigned with a strong binding rather than preferred:
+       49-sansserif.conf appends sans-serif to any pattern that carries no
+       generic, the sans-serif rule above then rewrites that into a strongly
+       bound Liberation Sans, and a weakly bound <prefer> loses to it. -->
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>system-ui</string>
+    </test>
+    <edit name="family" mode="assign" binding="strong">
+      <string>Adwaita Sans</string>
+    </edit>
+  </match>
 
   <alias>
     <family>ui-monospace</family>
@@ -80,19 +93,32 @@
     </default>
   </alias>
 
-  <alias>
-    <family>-apple-system</family>
-    <prefer>
-      <family>Liberation Sans</family>
-    </prefer>
-  </alias>
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>-apple-system</string>
+    </test>
+    <edit name="family" mode="assign" binding="strong">
+      <string>Adwaita Sans</string>
+    </edit>
+  </match>
 
-  <alias>
-    <family>BlinkMacSystemFont</family>
-    <prefer>
-      <family>Liberation Sans</family>
-    </prefer>
-  </alias>
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>BlinkMacSystemFont</string>
+    </test>
+    <edit name="family" mode="assign" binding="strong">
+      <string>Adwaita Sans</string>
+    </edit>
+  </match>
+
+  <match target="pattern">
+    <test name="family" qual="any">
+      <string>Segoe UI</string>
+    </test>
+    <edit name="family" mode="assign" binding="strong">
+      <string>Adwaita Sans</string>
+    </edit>
+  </match>
 
   <alias>
     <family>Liberation Sans</family>


### PR DESCRIPTION
## The problem

`50-omarchy.conf` points the interface-font families at Liberation Sans:

```xml
<alias><family>system-ui</family><prefer><family>Liberation Sans</family></prefer></alias>
<alias><family>-apple-system</family><prefer><family>Liberation Sans</family></prefer></alias>
<alias><family>BlinkMacSystemFont</family><prefer><family>Liberation Sans</family></prefer></alias>
```

Those are the families CSS and Electron apps name when they want "whatever font this desktop's UI uses" — every platform points them at its own UI face (Segoe UI on Windows, SF on macOS). Liberation Sans is an Arial metric clone; fontconfig's own `45-latin.conf` classifies it as `sans-serif`, and classifies Adwaita Sans, Cantarell, Noto Sans UI and Segoe UI under the `system-ui` generic.

The result is that GTK and Qt chrome renders in Adwaita Sans (the GNOME `font-name` default), while everything inside a Chromium or Electron window — web pages, Slack, VS Code, Discord — renders its UI in Liberation Sans. Two different typefaces in the same window.

## Why `assign` and not `prefer`

`<prefer>` produces a **weak** binding, which loses here. `49-sansserif.conf` appends `sans-serif` to any pattern that carries no generic, so an `-apple-system` request arrives at this file as `["-apple-system", "sans-serif"]`. The `sans-serif` rule at the top of this file then rewrites that into a **strongly** bound `Liberation Sans`, which outranks the weakly preferred family. Changing only the `<prefer>` target has no effect — verified.

The generic rules are untouched. Their `mode="assign"` is load-bearing: switching `sans-serif` to `<prefer>` leaves `sans-serif` in the family list, `60-latin.conf` then prepends its own list, and the trailing catch-all Naskh rule wins — `fc-match sans-serif` returns `Noto Naskh Arabic`. Also verified.

`Segoe UI` is included because it reaches Chromium as a plain family name and, being uninstalled, currently falls through to Chromium's default `standard` family — a serif. A site whose stack names only `"Segoe UI"` renders in Liberation Serif today.

## Verification

`fc-match` before → after, on Omarchy 4.0.2. Exactly four lines change:

```
 system-ui           Liberation Sans   ->  Adwaita Sans
 -apple-system       Liberation Sans   ->  Adwaita Sans
 BlinkMacSystemFont  Liberation Sans   ->  Adwaita Sans
 Segoe UI            Liberation Sans   ->  Adwaita Sans
```

Unchanged: `sans-serif`, `serif`, `monospace`, `Arial`, `Times New Roman`, `Georgia`, `Courier New`, `Verdana`, `Helvetica`, `Liberation Sans`, `emoji`, and `:lang=` for `ar`, `ur`, `zh`, `ja`, `he`, `ko`. Arial metric compatibility in LibreOffice and PDFs is unaffected.

End to end in Chromium, measuring rendered text width against known font metrics:

| CSS stack | before | after |
|---|---|---|
| `-apple-system` | Liberation Sans | **Adwaita Sans** |
| `BlinkMacSystemFont` | Liberation Sans | **Adwaita Sans** |
| `"Segoe UI"` | Liberation **Serif** | **Adwaita Sans** |
| `-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif` | Liberation Sans | **Adwaita Sans** |
| `sans-serif` | Liberation Sans | Liberation Sans |
| `Arial` | Liberation Sans | Liberation Sans |
| `monospace` | JetBrainsMono | JetBrainsMono |

Note on `system-ui`: Blink treats it as a CSS generic keyword and resolves it from the desktop UI font rather than through fontconfig, so it reads Adwaita Sans in a real session either way. The rule still matters for toolkits that do resolve the name through fontconfig, and it is what makes the `Segoe UI` case work, since `45-latin.conf` files Segoe UI under the `system-ui` generic.

`adwaita-fonts` needs no packaging change: it is a hard dependency of `gtk3`, `gtk4` and `gsettings-desktop-schemas`.

`./test/all` is unchanged by this commit: the same 3 of 226 test files fail before and after (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`), and they fail on a clean `quattro` checkout in this environment too.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QHVnWswgsLi42o3bEb7ap
