### PR TITLE
Don't treat pointer motion right after an output change as lock-screen activity

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -42,6 +42,10 @@ Item {
   signal passwordTextEdited(string password)
   signal clearFailureRequested()
   signal wakeRequested()
+  // Pointer motion gets its own signal so the service can tell motion
+  // synthesized by a lock-surface rebuild (an output leaving and returning)
+  // apart from deliberate input. Clicks and keys stay on wakeRequested.
+  signal motionWakeRequested()
 
   // Cache-busts the lock background by appending `?v=`. Adding a query
   // string keeps Image's loader happy while forcing it to reload when the
@@ -116,7 +120,7 @@ Item {
       anchors.fill: parent
       hoverEnabled: true
       onClicked: { root.wakeRequested(); root.forcePasswordFocus() }
-      onPositionChanged: root.wakeRequested()
+      onPositionChanged: root.motionWakeRequested()
     }
 
     BorderSurface {

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -281,6 +281,20 @@ Item {
         onSubmitPassword: function(password) { root.submitPassword(password) }
         onClearFailureRequested: root.failureMessage = ""
         onWakeRequested: root.runWake()
+        // Motion within 10s of an output change is surface-rebuild noise, not
+        // a person: waking on it turns a monitor that drops its link on blank
+        // into an all-night wake/blank loop (and every hotplug re-sends dmabuf
+        // feedback, which is a crash roll for GTK4 apps under gtk4 4.22.x).
+        // Keep the display asleep and re-arm the blank instead, so a returning
+        // monitor that comes back lit goes dark again. Clicks and keys are
+        // deliberate and still wake immediately.
+        onMotionWakeRequested: {
+          if (Date.now() - root.lastScreensChangeAt < 10000) {
+            if (root.lockRequested) root.armBlankTimer()
+          } else {
+            root.runWake()
+          }
+        }
       }
 
     }
@@ -464,9 +478,17 @@ Item {
     }
   }
 
+  // A monitor that drops its link after the blank (deep-sleeping panels
+  // de-assert HPD) comes back as a fresh output; rebuilding the lock surface
+  // for it can deliver synthetic pointer motion to LockView's MouseArea.
+  // Remember when the screens last changed so that motion arriving right
+  // after is not mistaken for someone at the desk.
+  property double lastScreensChangeAt: 0
+
   Connections {
     target: Quickshell
     function onScreensChanged() {
+      root.lastScreensChangeAt = Date.now()
       root.requestSessionLock()
 
       // A monitor still coming up has no workspace, so cannot answer yet.

--- a/test/shell.d/lock-motion-wake-gate-test.sh
+++ b/test/shell.d/lock-motion-wake-gate-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+const lockViewQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/LockView.qml'), 'utf8')
+
+// Rebuilding the lock surface for a returning output can synthesize pointer
+// motion. Motion therefore travels on its own signal, distinct from the
+// deliberate-input wake, so the service can gate it.
+assert(
+  /signal motionWakeRequested\(\)/.test(lockViewQml),
+  'LockView declares a dedicated motion wake signal'
+)
+
+assert(
+  /onPositionChanged: root\.motionWakeRequested\(\)/.test(lockViewQml),
+  'pointer motion emits the motion signal, not the deliberate wake'
+)
+
+assert(
+  /onClicked: \{ root\.wakeRequested\(\); root\.forcePasswordFocus\(\) \}/.test(lockViewQml),
+  'clicks stay on the deliberate wake and still focus the password field'
+)
+
+// The service must stamp screen changes and gate motion on that stamp: motion
+// within the window re-arms the blank (a returning monitor goes dark again)
+// instead of waking the whole desk.
+assert(
+  /property double lastScreensChangeAt: 0/.test(serviceQml),
+  'the service tracks when the screens last changed'
+)
+
+assert(
+  /function onScreensChanged\(\) \{\s*root\.lastScreensChangeAt = Date\.now\(\)/.test(serviceQml),
+  'every screens change refreshes the stamp before anything else reacts'
+)
+
+assert(
+  /onMotionWakeRequested: \{\s*if \(Date\.now\(\) - root\.lastScreensChangeAt < 10000\) \{\s*if \(root\.lockRequested\) root\.armBlankTimer\(\)\s*\} else \{\s*root\.runWake\(\)\s*\}/.test(serviceQml),
+  'motion inside the window re-arms the blank; motion outside it wakes'
+)
+
+// The deliberate wake path is untouched: wakeRequested still wakes directly.
+assert(
+  /onWakeRequested: root\.runWake\(\)/.test(serviceQml),
+  'deliberate input still wakes immediately'
+)
+JS


### PR DESCRIPTION
## What happens

A monitor that deep-sleeps on DPMS-off (many Dell/ViewSonic/BenQ panels) drops its link a few seconds after the lock screen blanks, then re-handshakes and returns. Hyprland re-adds the output lit, the lock surface is rebuilt for it, and the rebuild can deliver synthetic pointer motion to `LockView`'s full-surface `MouseArea`. That motion counted as user activity: `runWake()` lit every display and re-armed the 5s blank, closing a wake/blank loop that runs for as long as the session stays locked.

Measured on an AMD Cezanne APU with dual Dell 4K monitors on HDMI (Omarchy 4.0.2-1, Hyprland 0.56.2): ~10s period, from lock at 21:29 to unlock at 07:11 without a break — 4,182 hotplug cycles in one day. Related reports: #8863, #8689, #8580, #8946.

Beyond the visible light show, every cycle re-sends `zwp_linux_dmabuf_feedback_v1` to all Wayland clients, and gtk4 4.22.x's dmabuf munmap bug (fixed on GTK master in a8a5692c, not backported to gtk-4-22) turns each one into a crash roll — this machine collected 12 ghostty and several nautilus coredumps in a week, symbolized to exactly that GTK frame.

## Why not a time-since-blank debounce

#8896 debounces unforced wakes for 1.5s after the blank, which covers vectors that fire immediately. But the link drop lands at ~2s here, ~11s on a Navi 32 report in #8863, and ~19s in #8580 — a blank-relative window has to be very long to cover the spread, and a long window swallows real users. The output change itself is the reliable anchor: whenever the drop happens, the synthetic motion arrives right after the screens change.

## Fix

- `LockView` gains a dedicated `motionWakeRequested()` signal; pointer motion emits it, while clicks and keys stay on `wakeRequested()`.
- The service stamps `lastScreensChangeAt` on every `Quickshell.onScreensChanged`.
- Motion within 10s of a screens change re-arms the blank timer — so a returning monitor that comes back lit goes dark again — instead of waking the desk. Motion outside the window wakes as before. Clicks and keys always wake immediately, so a real person at the desk is never locked out of waking the display.

This closes the lock-surface wake vector. It deliberately composes with, rather than replaces, the in-flight work on the neighbouring vectors: #9152 (idle service waking a locked session's display) and #8581 (re-arming the blank for returning monitors with backoff). On the hardware above, the journal evidence shows both the lock-surface and idle-service vectors firing; both fixes are needed for a fully quiet night.

## Tests

`test/shell.d/lock-motion-wake-gate-test.sh` asserts the signal split, the stamp, the gate, and that the deliberate-input paths are untouched. Existing lock tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
