### PR TITLE
Add dust drift to the Plymouth shutdown logo

### DIFF
--- a/default/plymouth/omarchy.plymouth
+++ b/default/plymouth/omarchy.plymouth
@@ -9,3 +9,7 @@ ScriptFile=/usr/share/plymouth/themes/omarchy/omarchy.script
 ConsoleLogBackgroundColor=0x1a1b26
 MonospaceFont=Cantarell 11
 Font=Cantarell 11
+
+[script-env-vars]
+ShutdownAnimation=dust-drift
+ShutdownDuration=2.4

--- a/default/plymouth/omarchy.script
+++ b/default/plymouth/omarchy.script
@@ -9,6 +9,152 @@ logo.sprite.SetX(Window.GetWidth() / 2 - logo.image.GetWidth() / 2);
 logo.sprite.SetY(Window.GetHeight() / 2 - logo.image.GetHeight() / 2);
 logo.sprite.SetOpacity(1);
 
+#----------------------------------------- Shutdown --------------------------------
+
+# Settings come from [script-env-vars] in omarchy.plymouth. They are strings.
+# An absent/unknown style keeps the static logo, including on older installs.
+global.shutdown.style = ShutdownAnimation;
+global.shutdown.duration = 2.4;
+global.shutdown.frame = 0;
+global.shutdown.active = 0;
+global.shutdown.started = 0;
+global.shutdown.particles = [];
+global.shutdown.count = 0;
+global.shutdown.fps = 30;
+
+fun shutdown_duration(value) {
+  if (!value) return 2.4;
+  text = String(value);
+  if (text.Length() > 5) return 2.4;
+  number = 0;
+  divisor = 0;
+  digits = 0;
+  for (i = 0; i < text.Length(); i++) {
+    character = text.CharAt(i);
+    if (character == "." && divisor == 0) {
+      divisor = 1;
+    } else {
+      digit = 0;
+      while (digit < 10 && character != "" + digit) digit++;
+      if (digit == 10) return 2.4;
+      number = number * 10 + digit;
+      digits++;
+      if (divisor > 0) divisor *= 10;
+    }
+  }
+  if (divisor > 0) number /= divisor;
+  if (digits == 0 || number < 0.8 || number > 5) return 2.4;
+  return number;
+}
+
+fun start_shutdown_animation() {
+  if (Plymouth.GetMode() != "shutdown") return;
+  if (global.shutdown.style != "dust-drift") return;
+
+  width = logo.image.GetWidth();
+  height = logo.image.GetHeight();
+  if (width < 1 || height < 1) return;
+
+  # Bound allocations for custom logos. Cache crops and reduced sizes once;
+  # native Plymouth's software renderer should not transform images per frame.
+  tile = Math.Int(Math.Sqrt(width * height / 600)) + 1;
+  if (tile < 3) tile = 3;
+  while ((Math.Int((width + tile - 1) / tile) * Math.Int((height + tile - 1) / tile)) > 600) tile++;
+  index = 0;
+  for (y = 0; y < height; y += tile) {
+    for (x = 0; x < width; x += tile) {
+      particle = [];
+      particle.x = x;
+      particle.y = y;
+      tile_width = tile;
+      tile_height = tile;
+      if (x + tile_width > width) tile_width = width - x;
+      if (y + tile_height > height) tile_height = height - y;
+      particle.image = logo.image.Crop(x, y, tile_width, tile_height);
+      small_width = Math.Int(tile_width / 2);
+      small_height = Math.Int(tile_height / 2);
+      if (small_width < 1) small_width = 1;
+      if (small_height < 1) small_height = 1;
+      particle.dust = particle.image.Scale(small_width, small_height);
+      particle.offset_x = (tile_width - small_width) / 2;
+      particle.offset_y = (tile_height - small_height) / 2;
+      particle.sprite = Sprite(particle.image);
+      particle.sprite.SetPosition(logo.sprite.GetX() + x, logo.sprite.GetY() + y, 2);
+      particle.sprite.SetOpacity(0);
+      particle.small = 0;
+      particle.finished = 0;
+      particle.release = 0.10 + (1 - x / width) * 0.34 + Math.Random() * 0.065;
+      particle.life = 0.46 * (0.75 + Math.Random() * 0.25);
+      particle.speed = 0.45 + Math.Random() * 0.85;
+      particle.phase = Math.Random() * 6.283185;
+      particle.wobble = 4 + Math.Random() * 22;
+      global.shutdown.particles[index] = particle;
+      index++;
+    }
+  }
+  global.shutdown.count = index;
+  global.shutdown.duration = shutdown_duration(ShutdownDuration);
+  global.shutdown.active = 1;
+  Plymouth.SetRefreshRate(global.shutdown.fps);
+}
+
+fun stop_shutdown_animation(restore_logo) {
+  if (restore_logo) logo.sprite.SetOpacity(1);
+  if (global.shutdown.active == 0) return;
+  for (index = 0; index < global.shutdown.count; index++) {
+    global.shutdown.particles[index].sprite.SetOpacity(0);
+  }
+  global.shutdown.active = 0;
+  global.shutdown.particles = [];
+}
+
+fun refresh_shutdown_animation() {
+  if (global.shutdown.active == 0) return;
+  global.shutdown.frame++;
+  progress = global.shutdown.frame / (global.shutdown.fps * global.shutdown.duration);
+  if (progress >= 1) {
+    stop_shutdown_animation(0);
+    return;
+  }
+  # Keep the original image during the hold; even translucent logos stay exact.
+  if (progress <= 0.10) return;
+  if (global.shutdown.started == 0) {
+    for (index = 0; index < global.shutdown.count; index++) {
+      global.shutdown.particles[index].sprite.SetOpacity(1);
+    }
+    global.shutdown.started = 1;
+    logo.sprite.SetOpacity(0);
+  }
+  origin_x = Window.GetWidth() / 2 - logo.image.GetWidth() / 2;
+  origin_y = Window.GetHeight() / 2 - logo.image.GetHeight() / 2;
+  for (index = 0; index < global.shutdown.count; index++) {
+    particle = global.shutdown.particles[index];
+    if (particle.finished) continue;
+    age = (progress - particle.release) / particle.life;
+    if (age <= 0) {
+      particle.sprite.SetPosition(origin_x + particle.x, origin_y + particle.y, 2);
+      continue;
+    }
+    if (age >= 1) {
+      particle.sprite.SetOpacity(0);
+      particle.finished = 1;
+      continue;
+    }
+    travel = age * age * 0.45 + age * 0.55;
+    flutter = Math.Sin(age * 7 + particle.phase) - Math.Sin(particle.phase);
+    dx = travel * 230 * particle.speed + flutter * particle.wobble * age;
+    dy = -travel * 100 * particle.speed + Math.Sin(age * 6 + particle.phase) * 35 * age;
+    if (age > 0.15 && particle.small == 0) {
+      particle.sprite.SetImage(particle.dust);
+      particle.small = 1;
+    }
+    particle.sprite.SetPosition(origin_x + particle.x + dx + particle.offset_x * particle.small, origin_y + particle.y + dy + particle.offset_y * particle.small, 2);
+    particle.sprite.SetOpacity((1 - age) * (1 - age));
+  }
+}
+
+start_shutdown_animation();
+
 # Use these to adjust the progress bar timing
 global.fake_progress_limit = 0.7;  # Target percentage for fake progress (0.0 to 1.0)
 global.fake_progress_duration = 15.0;  # Duration in seconds to reach limit
@@ -23,6 +169,7 @@ global.password_shown = 0;  # Track if password dialog has been shown
 global.max_progress = 0.0;  # Track the maximum progress reached to prevent backwards movement
 
 fun refresh_callback() {
+  refresh_shutdown_animation();
   global.animation_frame++;
 
   # Animate fake progress to limit over time with easing
@@ -143,6 +290,8 @@ fun display_normal_callback() {
 }
 
 fun display_password_callback(prompt, bullets) {
+  # A prompt must remain readable even if shutdown unexpectedly asks for input.
+  stop_shutdown_animation(1);
   global.password_shown = 1;  # Mark that password dialog has been shown
 
   # Stop fake progress when password dialog appears

--- a/test/shell.d/fixtures/plymouth-render.c
+++ b/test/shell.d/fixtures/plymouth-render.c
@@ -1,0 +1,184 @@
+/* Exercise the installed Plymouth script plugin, image loader, and compositor.
+ * Only display I/O and the timer are replaced; no daemon, VT, or root is used.
+ * The driver uses the public plugin ABI, not Plymouth's private script structs.
+ */
+#include <dlfcn.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <png.h>
+#include <ply-boot-splash-plugin.h>
+#include <ply-pixel-buffer.h>
+
+struct _ply_pixel_display {
+  unsigned long width, height;
+  ply_pixel_buffer_t *buffer;
+  ply_pixel_display_draw_handler_t draw;
+  void *draw_data;
+  bool dirty;
+  int paused;
+};
+
+static ply_event_loop_timeout_handler_t timer;
+static void *timer_data;
+
+unsigned long ply_pixel_display_get_width(ply_pixel_display_t *display) { return display->width; }
+unsigned long ply_pixel_display_get_height(ply_pixel_display_t *display) { return display->height; }
+int ply_pixel_display_get_device_scale(ply_pixel_display_t *display) { (void) display; return 1; }
+bool ply_console_viewer_preferred(void) { return false; }
+/* The fake display has no console viewer. Console/VT output is outside
+ * this offscreen graphics test. */
+void ply_console_viewer_hide(void *viewer) { (void) viewer; }
+
+void ply_pixel_display_set_draw_handler(ply_pixel_display_t *display, ply_pixel_display_draw_handler_t handler, void *data) {
+  display->draw = handler;
+  display->draw_data = data;
+}
+
+static void flush_display(ply_pixel_display_t *display) {
+  if (display->dirty && !display->paused && display->draw) {
+    display->draw(display->draw_data, display->buffer, 0, 0, display->width, display->height, display);
+    display->dirty = false;
+  }
+}
+
+void ply_pixel_display_draw_area(ply_pixel_display_t *display, int x, int y, int width, int height) {
+  (void) x; (void) y; (void) width; (void) height;
+  display->dirty = true;
+  flush_display(display);
+}
+
+void ply_pixel_display_pause_updates(ply_pixel_display_t *display) { display->paused++; }
+void ply_pixel_display_unpause_updates(ply_pixel_display_t *display) {
+  display->paused--;
+  flush_display(display);
+}
+
+void ply_event_loop_watch_for_timeout(ply_event_loop_t *loop, double seconds, ply_event_loop_timeout_handler_t handler, void *data) {
+  (void) loop; (void) seconds;
+  timer = handler;
+  timer_data = data;
+}
+
+void ply_event_loop_stop_watching_for_timeout(ply_event_loop_t *loop, ply_event_loop_timeout_handler_t handler, void *data) {
+  (void) loop;
+  if (handler == timer && data == timer_data) timer = NULL;
+}
+
+static void require(bool condition, const char *message) {
+  if (!condition) { fprintf(stderr, "%s\n", message); exit(1); }
+}
+
+static double now(void) {
+  struct timespec value;
+  clock_gettime(CLOCK_MONOTONIC, &value);
+  return value.tv_sec + value.tv_nsec / 1e9;
+}
+
+static void snapshot(ply_pixel_display_t *display, const char *output, int frame) {
+  uint32_t *pixels = ply_pixel_buffer_get_argb32_data(display->buffer);
+  uint64_t hash = UINT64_C(14695981039346656037);
+  unsigned long foreground = 0;
+  for (unsigned long i = 0; i < display->width * display->height; i++) {
+    hash = (hash ^ pixels[i]) * UINT64_C(1099511628211);
+    if (pixels[i] != pixels[0]) foreground++;
+  }
+  printf("%d,%lu,%" PRIu64 "\n", frame, foreground, hash);
+  if (strcmp(output, "-") == 0) return;
+  char filename[4096];
+  require(snprintf(filename, sizeof(filename), "%s/frame-%04d.png", output, frame) < (int) sizeof(filename), "Output path too long");
+  /* Convert explicitly so this also works on hosts with a different byte order. */
+  png_image image = { .version = PNG_IMAGE_VERSION, .width = display->width, .height = display->height, .format = PNG_FORMAT_RGBA };
+  unsigned char *rgba = malloc(display->width * display->height * 4);
+  require(rgba != NULL, "Unable to allocate PNG buffer");
+  for (unsigned long i = 0; i < display->width * display->height; i++) {
+    rgba[i * 4] = pixels[i] >> 16;
+    rgba[i * 4 + 1] = pixels[i] >> 8;
+    rgba[i * 4 + 2] = pixels[i];
+    rgba[i * 4 + 3] = pixels[i] >> 24;
+  }
+  require(png_image_write_to_file(&image, filename, 0, rgba, 0, NULL), image.message);
+  png_image_free(&image);
+  free(rgba);
+}
+
+int main(int argc, char **argv) {
+  require(argc == 6 || argc == 7 || argc == 9, "Usage: plymouth-render <plugin.so> <theme.plymouth> <mode> <frames> <output-dir|-> [normal|password|interrupt|late-password|progress|message] [width height]");
+  int frames = atoi(argv[4]);
+  require(frames > 0 && frames <= 1000, "Frames must be between 1 and 1000");
+  int width = argc == 9 ? atoi(argv[7]) : 1280;
+  int height = argc == 9 ? atoi(argv[8]) : 720;
+  require(width > 0 && height > 0 && width <= 4096 && height <= 4096, "Invalid display dimensions");
+  const char *scenario = argc >= 7 ? argv[6] : "normal";
+  require(!strcmp(scenario, "normal") || !strcmp(scenario, "password") || !strcmp(scenario, "interrupt") || !strcmp(scenario, "late-password") || !strcmp(scenario, "progress") || !strcmp(scenario, "message"), "Unknown scenario");
+  ply_boot_splash_mode_t mode = PLY_BOOT_SPLASH_MODE_INVALID;
+  if (!strcmp(argv[3], "boot")) mode = PLY_BOOT_SPLASH_MODE_BOOT_UP;
+  if (!strcmp(argv[3], "shutdown")) mode = PLY_BOOT_SPLASH_MODE_SHUTDOWN;
+  if (!strcmp(argv[3], "reboot")) mode = PLY_BOOT_SPLASH_MODE_REBOOT;
+  if (!strcmp(argv[3], "updates")) mode = PLY_BOOT_SPLASH_MODE_UPDATES;
+  require(mode != PLY_BOOT_SPLASH_MODE_INVALID, "Unknown mode");
+
+  void *module = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+  require(module != NULL, dlerror());
+  ply_boot_splash_plugin_interface_t *(*get_interface)(void) = dlsym(module, "ply_boot_splash_plugin_get_interface");
+  void *(*parse_file)(const char *) = dlsym(module, "script_parse_file");
+  void (*free_op)(void *) = dlsym(module, "script_parse_op_free");
+  require(get_interface && parse_file && free_op, "Missing Plymouth plugin/parser API");
+  ply_key_file_t *key_file = ply_key_file_new(argv[2]);
+  require(ply_key_file_load(key_file), "Cannot load theme descriptor");
+  char *script_path = ply_key_file_get_value(key_file, "script", "ScriptFile");
+  require(script_path != NULL, "Theme has no ScriptFile");
+  void *op = parse_file(script_path);
+  require(op != NULL, "Plymouth script failed to parse");
+  free_op(op);
+  free(script_path);
+
+  ply_boot_splash_plugin_interface_t *api = get_interface();
+  ply_boot_splash_plugin_t *plugin = api->create_plugin(key_file);
+  ply_event_loop_t *loop = ply_event_loop_new();
+  ply_pixel_display_t display = { .width = width, .height = height };
+  display.buffer = ply_pixel_buffer_new(width, height);
+  api->add_pixel_display(plugin, &display);
+  double started = now();
+  require(api->show_splash_screen(plugin, loop, NULL, mode), "Cannot show the native theme");
+  double initialization = now() - started;
+  api->display_normal(plugin);
+  if (!strcmp(scenario, "password")) api->display_password(plugin, "Unlock test volume", 4);
+  printf("frame,foreground,hash\n");
+  snapshot(&display, argv[5], 0);
+  double elapsed = 0;
+  double slowest = 0;
+  for (int frame = 1; frame <= frames; frame++) {
+    if (!strcmp(scenario, "interrupt") && frame == 25) api->display_password(plugin, "Unlock test volume", 4);
+    if (!strcmp(scenario, "interrupt") && frame == 50) api->display_normal(plugin);
+    if (!strcmp(scenario, "message") && frame == 100) api->display_message(plugin, "Test shutdown message");
+    if (!strcmp(scenario, "message") && frame == 140) api->hide_message(plugin, "Test shutdown message");
+    if (!strcmp(scenario, "password") && frame == 25) api->display_normal(plugin);
+    if (!strcmp(scenario, "late-password") && frame == 85) api->display_password(plugin, "Unlock test volume", 4);
+    if (!strcmp(scenario, "progress") && frame == 1) api->display_password(plugin, "Unlock test volume", 4);
+    if (!strcmp(scenario, "progress") && frame == 25) api->display_normal(plugin);
+    if (!strcmp(scenario, "progress") && frame == 30) api->on_boot_progress(plugin, 1, 0.4);
+    if (!strcmp(scenario, "progress") && frame == 31) api->on_boot_progress(plugin, 2, 0.4);
+    if (!strcmp(scenario, "progress") && frame == 60) api->on_boot_progress(plugin, 3, 0.2);
+    if (!strcmp(scenario, "progress") && frame == 90) api->on_boot_progress(plugin, 4, 0.8);
+    started = now();
+    require(timer != NULL, "Plymouth stopped refreshing unexpectedly");
+    timer(timer_data, loop);
+    double frame_time = now() - started;
+    elapsed += frame_time;
+    if (frame_time > slowest) slowest = frame_time;
+    snapshot(&display, argv[5], frame);
+  }
+  fprintf(stderr, "native: init=%.1fms average-frame=%.2fms slowest-frame=%.2fms\n", initialization * 1000, elapsed / frames * 1000, slowest * 1000);
+  api->hide_splash_screen(plugin, loop);
+  api->remove_pixel_display(plugin, &display);
+  api->destroy_plugin(plugin);
+  ply_pixel_buffer_free(display.buffer);
+  ply_event_loop_free(loop);
+  ply_key_file_free(key_file);
+  dlclose(module);
+  return 0;
+}

--- a/test/shell.d/plymouth-animation-test.sh
+++ b/test/shell.d/plymouth-animation-test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# The script plugin is an optional native test dependency on headless CI.
+if ! command -v cc >/dev/null || ! command -v pkg-config >/dev/null || ! pkg-config --exists ply-splash-core libpng || [[ ! -f ${PLYMOUTH_SCRIPT_PLUGIN:-/usr/lib/plymouth/script.so} ]]; then
+  pass "SKIP native Plymouth animation: install Plymouth headers, script plugin, C compiler, and libpng"
+  exit 0
+fi
+
+ulimit -c 0
+
+run_node_test <<'JS'
+const fs = require('node:fs')
+const os = require('node:os')
+const { execFileSync } = require('node:child_process')
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'omarchy-plymouth-test-'))
+const plugin = process.env.PLYMOUTH_SCRIPT_PLUGIN || '/usr/lib/plymouth/script.so'
+const assets = path.join(root, 'default/plymouth')
+const executable = path.join(scratch, 'render')
+let serial = 0
+
+function run(options = {}) {
+  const { style = 'dust-drift', duration = '2.4', mode = 'shutdown', frames = 100, scenario = 'normal', imageDir = assets, width = 1280, height = 720 } = options
+  const descriptor = path.join(scratch, `theme-${serial++}.plymouth`)
+  fs.writeFileSync(descriptor, `[Plymouth Theme]\nName=Test\nModuleName=script\n[script]\nImageDir=${imageDir}\nScriptFile=${assets}/omarchy.script\n[script-env-vars]\n${style === null ? '' : `ShutdownAnimation=${style}\n`}${duration === null ? '' : `ShutdownDuration=${duration}\n`}`)
+  const output = execFileSync(executable, [plugin, descriptor, mode, String(frames), '-', scenario, String(width), String(height)], { encoding: 'utf8', timeout: 30000, stdio: ['ignore', 'pipe', 'pipe'] })
+  return output.trim().split('\n').slice(1).map(line => {
+    const [frame, foreground, hash] = line.split(',')
+    return { frame: Number(frame), foreground: Number(foreground), hash }
+  })
+}
+
+function staysStatic(rows) { return rows.every(row => row.hash === rows[0].hash && row.foreground > 0) }
+function endsBlank(rows) { return rows.slice(-10).every(row => row.foreground === 0) }
+function blankFrame(rows) { return rows.find(row => row.foreground === 0)?.frame }
+
+try {
+  const flags = execFileSync('pkg-config', ['--cflags', '--libs', 'ply-splash-core', 'libpng'], { encoding: 'utf8' }).trim().split(/\s+/)
+  execFileSync('cc', ['-Wall', '-Wextra', '-Werror', '-O2', '-Wl,--export-dynamic', path.join(root, 'test/shell.d/fixtures/plymouth-render.c'), '-o', executable, ...flags, '-ldl'], { stdio: 'inherit' })
+  pass('native renderer compiles with warnings treated as errors')
+
+  const descriptor = fs.readFileSync(path.join(assets, 'omarchy.plymouth'), 'utf8')
+  assert(descriptor.includes('[script-env-vars]\nShutdownAnimation=dust-drift\nShutdownDuration=2.4'), 'packaged theme selects Dust drift at 2.4 seconds')
+  const reference = run({ style: 'none' })
+  assert(staysStatic(reference), 'none preserves the static shutdown logo')
+
+  const dust = run()
+  assertEqual(dust[0].hash, reference[0].hash, 'initial hold exactly matches the original logo')
+  assert(dust[30].foreground > 0 && dust[30].hash !== dust[0].hash, 'native frames visibly change during breakup')
+  assert(endsBlank(dust), 'animation completes and never loops')
+
+  for (const style of [null, 'unknown']) assert(staysStatic(run({ style })), 'missing/unknown style falls back to static')
+  for (const mode of ['boot', 'reboot', 'updates']) {
+    const rows = run({ mode })
+    assert(staysStatic(rows), `${mode}: animation does not run`)
+    assertEqual(rows[0].hash, reference[0].hash, `${mode}: unchanged centered logo`)
+  }
+
+  const fast = run({ duration: '.8' })
+  const slow = run({ duration: '5', frames: 170 })
+  assert(blankFrame(fast) <= 24 && blankFrame(dust) > 24, 'short duration accelerates completion')
+  assert(blankFrame(slow) > 72 && endsBlank(slow), 'long duration extends motion and still completes')
+  for (const duration of [null, '', 'oops', '0', '0.7', '5.1', '-2', '1..2', '999999']) {
+    const rows = run({ duration })
+    assert(blankFrame(rows) > 24 && blankFrame(rows) <= 72 && endsBlank(rows), `invalid/missing duration ${JSON.stringify(duration)} safely uses 2.4 seconds`)
+  }
+
+  const bootPrompt = run({ mode: 'boot', scenario: 'password' })
+  assert(bootPrompt[1].foreground > reference[0].foreground, 'boot password UI is visible')
+  assert(bootPrompt[50].foreground > reference[0].foreground, 'boot progress UI appears after the password clears')
+  assertDeepEqual(bootPrompt, run({ mode: 'boot', scenario: 'password', style: 'none' }), 'boot password/progress frames are independent of animation setting')
+  const progress = run({ mode: 'boot', scenario: 'progress' })
+  assert(progress[90].hash !== progress[60].hash, 'real boot progress advances after disk unlock')
+  assertEqual(progress[60].hash, progress[59].hash, 'a lower boot progress update never moves the bar backward')
+
+  const interrupted = run({ scenario: 'interrupt' })
+  assert(interrupted[26].foreground > reference[0].foreground, 'a shutdown password prompt restores the logo and displays controls')
+  assertEqual(interrupted[50].hash, reference[0].hash, 'clearing a shutdown prompt restores the static screen')
+  assertEqual(interrupted[100].hash, reference[0].hash, 'cancelled particles never restart after input')
+  const late = run({ scenario: 'late-password' })
+  assert(late[80].foreground === 0 && late[86].foreground > reference[0].foreground, 'a prompt after animation completion also restores the logo')
+  const messages = run({ scenario: 'message', frames: 150 })
+  assert(messages[105].foreground > 0 && messages[145].foreground === 0, 'shutdown messages remain visible and can be hidden after animation')
+
+  // Custom logos retain their own color/alpha, including partial edge tiles.
+  try {
+    execFileSync('magick', ['-version'], { stdio: 'ignore' })
+    const custom = path.join(scratch, 'custom')
+    fs.mkdirSync(custom)
+    for (const file of fs.readdirSync(assets).filter(file => file.endsWith('.png') && file !== 'logo.png')) fs.symlinkSync(path.join(assets, file), path.join(custom, file))
+    for (const size of ['137x33!', '1x513!']) {
+      execFileSync('magick', [path.join(assets, 'logo.png'), '-resize', size, '-fill', '#e85e99', '-colorize', '100', path.join(custom, 'logo.png')])
+      const rows = run({ imageDir: custom, width: 1024, height: 768 })
+      assertEqual(rows[0].hash, run({ imageDir: custom, style: 'none', width: 1024, height: 768 })[0].hash, `${size}: custom logo starts intact`)
+      assert(endsBlank(rows), `${size}: custom logo finishes without edge-tile errors`)
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') pass('SKIP custom-logo generation: ImageMagick not installed')
+    else throw error
+  }
+} finally {
+  // Only this test's unique scratch directory is removed.
+  fs.rmSync(scratch, { recursive: true, force: true })
+}
+JS


### PR DESCRIPTION
I wanted the shutdown logo to break apart and drift away. This adds a dust-drift effect to the Plymouth theme using the existing logo and colors.

The logo crumbles from right to left, drifts upward, and fades to the background. The effect runs only during shutdown. Boot, reboot, and update modes keep the static logo. A password prompt cancels the animation and restores the logo.

Dust drift is enabled by default, with a target duration of 2.4 seconds at 30 fps. It uses at most 600 particles and prepares image crops and smaller images once. There are no new runtime dependencies or added shutdown waits. A fast poweroff can cut the animation short.

`ShutdownAnimation=none` keeps the static logo. `ShutdownDuration` accepts 0.8–5 seconds and falls back to 2.4 for invalid values.

## Testing

- `bash test/shell.d/plymouth-animation-test.sh` passes against the native Plymouth script plugin, covering completion, disabled and invalid settings, duration limits, password prompts, boot progress, messages, and custom logos.
- `bash test/shell.d/plymouth-set-test.sh` passes.
- `./test/all`: CLI tests pass; 228 of 229 shell-test files pass. The remaining `bin-style-test.sh` failure flags `omarchy-remove-ai-openclaw` and also reproduces on unmodified upstream `eb56446`.
