### PR TITLE
Pin Electron password store to gnome-libsecret

### DIFF
--- a/config/electron-flags.conf
+++ b/config/electron-flags.conf
@@ -1,0 +1,1 @@
+--password-store=gnome-libsecret

--- a/migrations/1788631245.sh
+++ b/migrations/1788631245.sh
@@ -1,0 +1,35 @@
+echo "Pin Electron password store to gnome-libsecret (prevents keyring errors on Hyprland)"
+
+# Migration 1784508556 pinned the os_crypt backend for Chromium-based browsers.
+# Distro Electron apps (Element and anything else launched through Arch's
+# electronN wrapper) still auto-detect: Hyprland is not GNOME/KDE, so the
+# xdg-desktop-portal Secret backend has no matching provider and Electron
+# reports an unsupported keyring or falls back to basic_text. A profile sealed
+# with the wrong backend then cannot be opened.
+#
+# The wrapper reads ~/.config/electronN-flags.conf if present, otherwise
+# ~/.config/electron-flags.conf. Fresh installs receive the default from
+# config/; this migration seeds existing users and pins any versioned flags
+# files that would otherwise shadow the fallback. An explicit
+# --password-store= line is left alone.
+
+pin_electron_flags() {
+  local flags_file=$1
+
+  if [[ ! -f $flags_file ]] || ! grep -Eq '^[[:space:]]*--password-store=' "$flags_file"; then
+    mkdir -p "${flags_file%/*}"
+
+    if [[ -f $flags_file && -n $(tail -c1 "$flags_file") ]]; then
+      echo >>"$flags_file"
+    fi
+
+    echo '--password-store=gnome-libsecret' >>"$flags_file"
+  fi
+}
+
+pin_electron_flags "$HOME/.config/electron-flags.conf"
+
+shopt -s nullglob
+for flags_file in "$HOME"/.config/electron[0-9]*-flags.conf; do
+  pin_electron_flags "$flags_file"
+done

--- a/test/shell.d/electron-password-store-migration-test.sh
+++ b/test/shell.d/electron-password-store-migration-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1788631245.sh"
+[[ -f $migration ]] || fail "Electron password-store migration exists"
+
+default_flags="$ROOT/config/electron-flags.conf"
+[[ -f $default_flags ]] || fail "fresh installs pin Electron's password store"
+[[ $(<"$default_flags") == "--password-store=gnome-libsecret" ]] ||
+  fail "fresh installs pin Electron's password store"
+pass "fresh installs pin Electron's password store"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+run_migration() {
+  local home=$1
+
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+home="$test_dir/commented-option"
+mkdir -p "$home/.config"
+printf '%s\n' '# --password-store=basic' >"$home/.config/electron-flags.conf"
+
+run_migration "$home"
+
+[[ $(<"$home/.config/electron-flags.conf") == $'# --password-store=basic\n--password-store=gnome-libsecret' ]] ||
+  fail "migration ignores a commented password-store option"
+pass "migration ignores a commented password-store option"
+
+home="$test_dir/existing-user"
+mkdir -p "$home"
+
+run_migration "$home" || fail "migration prepares existing users for a future Electron app"
+
+grep -qxF -- '--password-store=gnome-libsecret' "$home/.config/electron-flags.conf" ||
+  fail "migration prepares existing users for a future Electron app"
+pass "migration prepares existing users for a future Electron app"
+
+home="$test_dir/custom-option"
+mkdir -p "$home/.config"
+printf '%s\n' '--password-store=basic' >"$home/.config/electron-flags.conf"
+
+run_migration "$home"
+
+[[ $(<"$home/.config/electron-flags.conf") == "--password-store=basic" ]] ||
+  fail "migration preserves an active password-store choice"
+pass "migration preserves an active password-store choice"
+
+home="$test_dir/missing-newline"
+mkdir -p "$home/.config"
+printf %s '--enable-features=WaylandLinuxDrmSyncobj' >"$home/.config/electron-flags.conf"
+
+run_migration "$home"
+
+[[ $(<"$home/.config/electron-flags.conf") == $'--enable-features=WaylandLinuxDrmSyncobj\n--password-store=gnome-libsecret' ]] ||
+  fail "migration appends the pin on its own line"
+pass "migration appends the pin on its own line"
+
+before=$(sha256sum "$home/.config/electron-flags.conf")
+run_migration "$home"
+after=$(sha256sum "$home/.config/electron-flags.conf")
+
+[[ $before == "$after" ]] || fail "Electron password-store migration is idempotent"
+pass "Electron password-store migration is idempotent"
+
+home="$test_dir/versioned-flags"
+mkdir -p "$home/.config"
+printf '%s\n' '--enable-features=WaylandLinuxDrmSyncobj' >"$home/.config/electron43-flags.conf"
+
+run_migration "$home"
+
+grep -qxF -- '--password-store=gnome-libsecret' "$home/.config/electron-flags.conf" ||
+  fail "migration still seeds the fallback flags file"
+grep -qxF -- '--password-store=gnome-libsecret' "$home/.config/electron43-flags.conf" ||
+  fail "migration pins a versioned Electron flags file"
+pass "migration pins versioned Electron flags files that shadow the fallback"
+
+home="$test_dir/versioned-custom"
+mkdir -p "$home/.config"
+printf '%s\n' '--password-store=basic_text' >"$home/.config/electron43-flags.conf"
+
+run_migration "$home"
+
+[[ $(<"$home/.config/electron43-flags.conf") == "--password-store=basic_text" ]] ||
+  fail "migration preserves a versioned password-store choice"
+pass "migration preserves a versioned password-store choice"


### PR DESCRIPTION
## Summary

- Ship `config/electron-flags.conf` so new users pin distro Electron (Element and anything else launched through Arch's `electronN` wrapper) to `gnome-libsecret`
- Migrate existing `electron-flags.conf` and versioned `electronN-flags.conf` files without overriding an explicit `--password-store=` choice
- Same Hyprland detection gap already handled for Chromium, and the same approach as the Helium/Signal pins

## Test plan

- [x] `bash test/shell.d/electron-password-store-migration-test.sh`


Made with [Cursor](https://cursor.com)