### PR TITLE
Add optional Ponte Android remote service commands

### DIFF
--- a/bin/omarchy-install-service-ponte
+++ b/bin/omarchy-install-service-ponte
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# omarchy:summary=Install the optional Ponte phone remote without starting a service.
+# omarchy:requires-sudo=true
+
+set -e
+
+omarchy-pkg-add ponte-remote
+
+cat <<'EOF'
+Ponte is installed. No service has been started.
+
+To configure this computer, connect it to Tailscale and run:
+  ponte setup
+
+To enable Ponte for your graphical session, run:
+  ponte install
+
+Phone setup and experimental release limitations:
+  https://github.com/LucasOl1337/ponte/tree/v0.1.0-alpha.1
+EOF

--- a/bin/omarchy-remove-service-ponte
+++ b/bin/omarchy-remove-service-ponte
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=Stop and remove Ponte while keeping its private configuration and recordings.
+# omarchy:requires-sudo=true
+
+set -e
+
+if omarchy-pkg-present ponte-remote; then
+  ponte uninstall
+  omarchy-pkg-drop ponte-remote
+fi

--- a/manual/35-networking.md
+++ b/manual/35-networking.md
@@ -40,6 +40,14 @@ That gives you a Tailscale panel in the bar, which connects and disconnects the 
 
 Installing it also adds a web app for the Tailscale admin console.
 
+## Controlling Omarchy from an Android phone
+
+[Ponte](https://github.com/LucasOl1337/ponte/tree/v0.1.0-alpha.1) is an experimental phone remote for Omarchy. It offers a touchpad, keyboard, live screen view, and playback on the computer of voice recordings sent from the phone. Android voice recording is still being verified. It does not stream the computer's audio back to the phone.
+
+Run `omarchy install service ponte` to install the optional package. This does not start a server. Pointer control requires your user to have access to `/dev/uinput`; the package does not change device permissions. Connect the computer and phone to Tailscale, then run `ponte setup` to create this computer's private configuration and `ponte install` to enable its service for your graphical session. Follow the [versioned phone setup instructions](https://github.com/LucasOl1337/ponte/tree/v0.1.0-alpha.1/android) to build the Android client for your installation and pair it. Keep that APK and the pairing token private.
+
+Use `ponte stop` to stop the server, or `omarchy remove service ponte` to disable its services and remove the package. Removal keeps your private configuration and recordings. Installing or removing Ponte does not change your Tailscale configuration.
+
 ## When it stops working
 
 Before rebooting, try restarting the offending piece on its own. _Update > Hardware_ has Wi-Fi, Bluetooth, Audio, and Trackpad, and reloading one of those clears up most "it worked five minutes ago" situations. See [troubleshooting](45-troubleshooting.md).

--- a/test/shell.d/ponte-service-test.sh
+++ b/test/shell.d/ponte-service-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+
+cat >"$tmp_dir/bin/omarchy-pkg-add" <<'SCRIPT'
+#!/bin/bash
+printf 'add:%s\n' "$*" >>"$PONTE_TEST_LOG"
+exit "${PONTE_TEST_ADD_STATUS:-0}"
+SCRIPT
+
+cat >"$tmp_dir/bin/omarchy-pkg-present" <<'SCRIPT'
+#!/bin/bash
+printf 'present:%s\n' "$*" >>"$PONTE_TEST_LOG"
+exit "${PONTE_TEST_PRESENT_STATUS:-0}"
+SCRIPT
+
+cat >"$tmp_dir/bin/omarchy-pkg-drop" <<'SCRIPT'
+#!/bin/bash
+printf 'drop:%s\n' "$*" >>"$PONTE_TEST_LOG"
+exit "${PONTE_TEST_DROP_STATUS:-0}"
+SCRIPT
+
+cat >"$tmp_dir/bin/ponte" <<'SCRIPT'
+#!/bin/bash
+printf 'ponte:%s\n' "$*" >>"$PONTE_TEST_LOG"
+exit "${PONTE_TEST_UNINSTALL_STATUS:-0}"
+SCRIPT
+
+for command in systemctl tailscale sudo curl ydotool ydotoold; do
+  cat >"$tmp_dir/bin/$command" <<'SCRIPT'
+#!/bin/bash
+printf 'unexpected:%s:%s\n' "${0##*/}" "$*" >>"$PONTE_TEST_LOG"
+exit 91
+SCRIPT
+done
+chmod +x "$tmp_dir/bin/"*
+export PONTE_TEST_LOG="$tmp_dir/log"
+export PATH="$tmp_dir/bin:$PATH"
+
+"$ROOT/bin/omarchy-install-service-ponte" >"$tmp_dir/output"
+[[ $(cat "$PONTE_TEST_LOG") == 'add:ponte-remote' ]] || fail "Ponte package install never configures or starts services"
+pass "Ponte package install never configures or starts services"
+grep -q 'ponte setup' "$tmp_dir/output" && grep -q 'ponte install' "$tmp_dir/output" || fail "Ponte setup and activation are explicit next steps"
+pass "Ponte setup and activation are explicit next steps"
+
+: >"$PONTE_TEST_LOG"
+status=0
+PONTE_TEST_ADD_STATUS=17 "$ROOT/bin/omarchy-install-service-ponte" >"$tmp_dir/output" 2>&1 || status=$?
+[[ $status == 17 && ! -s $tmp_dir/output ]] || fail "Ponte package failure propagates without a success message"
+[[ $(cat "$PONTE_TEST_LOG") == 'add:ponte-remote' ]] || fail "Ponte package failure has no follow-up actions"
+pass "Ponte package failure propagates without follow-up actions or success"
+
+: >"$PONTE_TEST_LOG"
+"$ROOT/bin/omarchy-remove-service-ponte"
+[[ $(cat "$PONTE_TEST_LOG") == $'present:ponte-remote\nponte:uninstall\ndrop:ponte-remote' ]] || fail "Ponte stops and removes its user units before dropping the package"
+pass "Ponte stops and removes its user units before dropping the package"
+
+: >"$PONTE_TEST_LOG"
+status=0
+PONTE_TEST_UNINSTALL_STATUS=23 "$ROOT/bin/omarchy-remove-service-ponte" || status=$?
+[[ $status == 23 && $(cat "$PONTE_TEST_LOG") == $'present:ponte-remote\nponte:uninstall' ]] || fail "Ponte teardown failure keeps the package available for recovery"
+pass "Ponte teardown failure keeps the package available for recovery"
+
+: >"$PONTE_TEST_LOG"
+PONTE_TEST_PRESENT_STATUS=1 "$ROOT/bin/omarchy-remove-service-ponte"
+[[ $(cat "$PONTE_TEST_LOG") == 'present:ponte-remote' ]] || fail "Ponte package absence leaves source installs alone"
+pass "Ponte package absence leaves source installs alone"
+
+: >"$PONTE_TEST_LOG"
+status=0
+PONTE_TEST_DROP_STATUS=29 "$ROOT/bin/omarchy-remove-service-ponte" || status=$?
+[[ $status == 29 ]] || fail "Ponte package removal failure propagates"
+pass "Ponte package removal failure propagates"


### PR DESCRIPTION
Ponte lets an Android phone control an Omarchy desktop over Tailscale, with a touchpad, keyboard, window controls and live views of physical monitors. This draft proposes explicit, optional install/remove commands; it does not add Ponte to the default installation.

`omarchy install service ponte` installs the package and shows `ponte setup` / `ponte install` as the next steps. It does not start a service or change Tailscale configuration. Removal tears down Ponte's managed user services before dropping the package and preserves private configuration and recordings.

The companion package proposal is https://github.com/omacom/omarchy-pkgs/pull/316. It pins [Ponte v0.1.0-alpha.1](https://github.com/LucasOl1337/ponte/releases/tag/v0.1.0-alpha.1) and contains no APK, certificate or pairing key. English is the app default, with an optional saved Portuguese preference.

I read [plans/remote.md](https://github.com/omacom/omarchy/blob/quattro/plans/remote.md) and its Sunshine/Moonlight direction. Ponte's scope is phone controls and a limited monitor view; MJPEG tops out at 10 fps and carries no system audio. This draft is for feedback on whether that optional scope belongs here.

The [project page](https://lucasol1337.github.io/ponte/), [presentation](https://lucasol1337.github.io/ponte/presentation.pdf) and [evidence report](https://github.com/LucasOl1337/ponte/blob/v0.1.0-alpha.1/docs/evidence.md) include screenshots and measured results. Live view, fullscreen and saved pairing worked on a Redmi development build. The public portable build passes source and signed-APK fixture tests; a clean physical-device install of that build, an Android recording retest, and cellular/WAN measurements remain open. First-time setup still needs an APK built for the user's PC, a pairing key and existing `/dev/uinput` access.

Validation: seven focused shell cases, CLI metadata/routing suite, safe help output, Bash syntax and diff checks passed. The package was built from the published archive using `makepkg --nodeps` (Node is provided by mise); its file layout and extracted CLI were checked with temporary XDG state and service-command stubs. A clean chroot build is still pending. The running desktop was not changed. Broader clean-session acceptance remains a prerequisite for requesting merge.

@dhh, I'd appreciate your take on the scope before developing the upstream integration further.
