### PR TITLE
Query Dropbox API for real usage and quota

### DIFF
--- a/shell/plugins/panels/dropbox/manifest.json
+++ b/shell/plugins/panels/dropbox/manifest.json
@@ -14,7 +14,7 @@
   },
   "barWidget": {
     "displayName": "Dropbox",
-    "description": "Log in to Dropbox, view storage usage, and open recent synced files.",
+    "description": "Log in to Dropbox, view storage usage, and open recent synced files. Set the DROPBOX_API_TOKEN environment variable for the shell to report real server-side usage and quota (plan-based quotas are used otherwise).",
     "category": "Files",
     "allowMultiple": false,
     "defaultSection": "right",

--- a/shell/plugins/panels/dropbox/status.py
+++ b/shell/plugins/panels/dropbox/status.py
@@ -3,6 +3,8 @@ import os
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 import heapq
 from pathlib import Path
 
@@ -14,6 +16,37 @@ PLAN_QUOTAS = {
   "professional": 3_000_000_000_000,
   "essentials": 3_000_000_000_000,
 }
+
+
+def read_api_token():
+  # The Dropbox API token is read from the environment only, so no secret is
+  # stored in the panel config or this repository.
+  token = os.environ.get("DROPBOX_API_TOKEN", "").strip()
+  return token or None
+
+
+def fetch_api_usage(token):
+  if token is None:
+    return None
+  request = urllib.request.Request(
+    "https://api.dropboxapi.com/2/users/get_space_usage",
+    method="POST",
+    headers={"Authorization": "Bearer " + token},
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=5) as response:
+      body = json.loads(response.read().decode("utf-8"))
+  except (OSError, ValueError, urllib.error.URLError):
+    return None
+  allocation = body.get("allocation", {})
+  try:
+    allocated = int(allocation.get("allocated", 0))
+    used = int(body.get("used", 0))
+  except (TypeError, ValueError):
+    return None
+  if allocated <= 0 or used < 0:
+    return None
+  return used, allocated
 
 
 def read_info():
@@ -93,7 +126,6 @@ def main():
   account = dropbox_account(info)
   account_path = account.get("path") if isinstance(account.get("path"), str) else ""
   plan = account.get("subscription_type") if isinstance(account.get("subscription_type"), str) else ""
-  quota = PLAN_QUOTAS.get(plan.lower(), 0)
   authenticated = account_path != "" and Path(account_path).exists()
 
   running = False
@@ -106,6 +138,16 @@ def main():
     running = status_exit == 0 and status_output != "" and not stopped
 
   used, files = scan_dropbox(account_path, limit) if authenticated else (0, [])
+
+  # Prefer server-reported usage and quota when an API token is configured:
+  # plan-based quotas ignore bonus/referral space, so e.g. a Basic account
+  # can hold more than the base 2 GB and used can exceed quota locally.
+  api_usage = fetch_api_usage(read_api_token())
+  if api_usage is not None:
+    used, quota = api_usage
+  else:
+    quota = PLAN_QUOTAS.get(plan.lower(), 0)
+
   usage_percent = (used / quota * 100) if quota > 0 else 0
 
   print(json.dumps({

--- a/test/shell.d/dropbox-test.sh
+++ b/test/shell.d/dropbox-test.sh
@@ -32,3 +32,62 @@ assertEqual(
   'dropbox file metadata includes relative time and folder'
 )
 JS
+
+require_command jq
+require_command python3
+
+# The status helper prefers the Dropbox API (DROPBOX_API_TOKEN) over the
+# hardcoded plan quotas, since plans ignore bonus/referral space.
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+mkdir -p "$TEST_HOME/.dropbox" "$TEST_HOME/Dropbox"
+printf 'x' >"$TEST_HOME/Dropbox/file.txt"
+cat >"$TEST_HOME/.dropbox/info.json" <<EOF
+{"personal": {"path": "$TEST_HOME/Dropbox", "host": 1, "is_team": false, "subscription_type": "Basic"}}
+EOF
+
+run_status() {
+  env -i HOME="$TEST_HOME" PATH="$PATH" DROPBOX_API_TOKEN="${1:-}" \
+    python3 "$ROOT/shell/plugins/panels/dropbox/status.py"
+}
+
+# Without a token, quota falls back to the hardcoded plan quota.
+result=$(run_status "")
+[[ $(jq -r '.quotaBytes' <<<"$result") == "2000000000" ]] ||
+  fail "dropbox status falls back to plan quota without a token" "$result"
+pass "dropbox status falls back to plan quota without a token"
+
+# With a token but no reachable API, it still falls back instead of failing.
+result=$(run_status "invalid-token")
+[[ $(jq -r '.quotaBytes' <<<"$result") == "2000000000" ]] ||
+  fail "dropbox status falls back to plan quota when the API is unreachable" "$result"
+pass "dropbox status falls back to plan quota when the API is unreachable"
+
+# With a working API, server-reported usage and quota win over the plan table.
+MOCK_BIN=$(mktemp -d)
+cat >"$MOCK_BIN/python3" <<'EOF'
+#!/bin/bash
+exec /usr/bin/python3 - "$@" <<'PYEOF'
+import json, sys, urllib.request
+
+class FakeResponse:
+  def __enter__(self): return self
+  def __exit__(self, *args): return False
+  def read(self): return json.dumps({"used": 3_500_000_000, "allocation": {"allocated": 8_000_000_000}}).encode()
+
+urllib.request.urlopen = lambda request, timeout=5: FakeResponse()
+
+script = sys.argv[1]
+sys.argv = [script] + sys.argv[2:]
+with open(script) as handle:
+  exec(compile(handle.read(), script, "exec"), {"__name__": "__main__"})
+PYEOF
+EOF
+chmod +x "$MOCK_BIN/python3"
+
+result=$(env -i HOME="$TEST_HOME" PATH="$MOCK_BIN:$PATH" DROPBOX_API_TOKEN="valid-token" \
+  "$MOCK_BIN/python3" "$ROOT/shell/plugins/panels/dropbox/status.py")
+[[ $(jq -r '.usedBytes' <<<"$result") == "3500000000" && $(jq -r '.quotaBytes' <<<"$result") == "8000000000" ]] ||
+  fail "dropbox status uses API usage and quota when a token is configured" "$result"
+pass "dropbox status uses API usage and quota when a token is configured"


### PR DESCRIPTION
## Problem

The Dropbox bar panel displays **incorrect storage information**. It reports usage as `<local folder size> of <hardcoded plan quota>`, neither of which reflects the account's real server-side numbers.

`shell/plugins/panels/dropbox/status.py` derives the quota from a fixed table keyed on the plan name read out of `~/.dropbox/info.json`:

```python
PLAN_QUOTAS = {
  "basic": 2_000_000_000,
  ...
}
```

This ignores **bonus/referral space**, so a Basic account can legitimately have well over 2 GB of quota. Combined with `used` being a raw local disk scan of `~/Dropbox`, the panel routinely shows nonsensical values like **"3.11 GB of 2 GB"** (used > quota), highlighted in red as if the user were over quota — when in reality the account is fine and syncing is "Up to date".

<img width="445" height="141" alt="screenshot-2026-09-05_21-04-33" src="https://github.com/user-attachments/assets/ad7d29ce-d95a-4ce7-810c-2b1be4ae31a0" />


## Fix

Query the Dropbox API for the authoritative `used` and `allocated` values when a token is available, and fall back to the existing plan-based table when it is not:

- New `read_api_token()` / `fetch_api_usage()` in `status.py`. When `DROPBOX_API_TOKEN` is set, it `POST`s to `https://api.dropboxapi.com/2/users/get_space_usage` (5s timeout) and uses `used` + `allocation.allocated`, which include bonus/referral space.
- If the token is unset, the request fails, or the response is malformed, it falls back to the current `PLAN_QUOTAS` behavior. No change for anyone who hasn't configured a token.
- The token is read from the **environment only** — no secret is stored in the panel config or the repo, keeping the zero-setup default intact.

## Notes

- The env var is documented in the panel's `manifest.json` description.
- Reading real usage requires a Dropbox API token with the `account_info.read` scope, generated once from the Dropbox developer console and exported into the shell's environment.

## Tests

Extended `test/shell.d/dropbox-test.sh` with three cases:

1. Falls back to the plan quota when no token is set.
2. Falls back to the plan quota when the API is unreachable (invalid token).
3. Uses API `used`/`quota` when a working token is configured (mocked `urlopen`).

All pass:

```
ok - dropbox status falls back to plan quota without a token
ok - dropbox status falls back to plan quota when the API is unreachable
ok - dropbox status uses API usage and quota when a token is configured
```
