### PR TITLE
Raise browser windows that open behind the presentation float

### DIFF
--- a/bin/omarchy-hyprland-browser-watch
+++ b/bin/omarchy-hyprland-browser-watch
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# omarchy:summary=Bring browser windows to the front when they open behind the Omarchy presentation float
+
+SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
+
+# The browser classes default/hypr/apps/browser.lua tags; chromium-based ones
+# are forced to tile there, and the rest tile by layout anyway.
+BROWSERS='^((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium|[fF]irefox|zen|librewolf)'
+
+# The presentation terminal omarchy-launch-floating-terminal-with-presentation
+# opens: floated, centered and 875x600 by default/hypr/apps/system.lua.
+PRESENTATION='^org\.omarchy\.terminal$'
+
+hypr_dispatch() {
+  local lua="$1"
+  shift
+
+  hyprctl dispatch "$lua" >/dev/null 2>&1 || hyprctl dispatch "$@" >/dev/null 2>&1
+}
+
+# Hyprland draws every floating window above every tiled one, so a tiled browser
+# under the presentation float cannot be raised: a click or an alt-tab gives it
+# the keyboard and leaves it behind the float, with nothing on screen to say a
+# login page is waiting. Floating the browser moves it into the only layer that
+# can cover the terminal that asked for it.
+raise_over_presentation() {
+  local address=$1 window="address:$1"
+
+  hyprctl clients -j 2>/dev/null |
+    jq -e --arg address "$address" --arg presentation "$PRESENTATION" '
+      (first(.[] | select(.address == $address)) // empty) as $browser
+      | $browser.floating == false
+        and any(
+          .[];
+          .floating
+            and .address != $address
+            and .workspace.id == $browser.workspace.id
+            and ((.class // "") | test($presentation))
+        )
+    ' >/dev/null || return 0
+
+  hypr_dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" togglefloating "$window"
+  hypr_dispatch "hl.dsp.window.alter_zorder({ window = \"$window\", mode = \"top\" })" alterzorder top "$window"
+  hypr_dispatch "hl.dsp.focus({ window = \"$window\" })" focuswindow "$window"
+}
+
+while IFS= read -r event; do
+  case "$event" in
+    openwindow\>\>*)
+      # openwindow>>address,workspace,class,title -- a title can hold commas, so
+      # let it take the rest of the line rather than shifting the fields. The
+      # event address comes without the 0x that hyprctl reports and expects.
+      IFS=, read -r address _ class _ <<<"${event#openwindow>>}"
+      if [[ $class =~ $BROWSERS ]]; then
+        raise_over_presentation "0x${address#0x}"
+      fi
+      ;;
+  esac
+done < <(socat -U - "UNIX-CONNECT:$SOCKET")

--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -7,6 +7,7 @@ hl.on("hyprland.start", function()
   hl.exec_cmd("omarchy-provision-first-run")
   hl.exec_cmd("omarchy-powerprofiles-init")
   hl.exec_cmd(o.launch("omarchy-hyprland-monitor-watch"))
+  hl.exec_cmd(o.launch("omarchy-hyprland-browser-watch"))
   hl.exec_cmd(o.launch("udiskie --automount --no-notify --no-tray"))
 
   -- Run post-boot hooks after startup config has loaded.

--- a/test/shell.d/browser-watch-test.sh
+++ b/test/shell.d/browser-watch-test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+browser_watch="$ROOT/bin/omarchy-hyprland-browser-watch"
+autostart="$ROOT/default/hypr/autostart.lua"
+browser_rules="$ROOT/default/hypr/apps/browser.lua"
+
+test_tmp=$(mktemp -d)
+watch_pid=""
+events_fd=""
+
+stop_watcher() {
+  if [[ -n $watch_pid ]]; then
+    kill -KILL "$watch_pid" 2>/dev/null || true
+    wait "$watch_pid" 2>/dev/null || true
+    watch_pid=""
+  fi
+
+  if [[ -n $events_fd ]]; then
+    exec {events_fd}>&-
+    events_fd=""
+  fi
+
+  return 0
+}
+
+cleanup() {
+  stop_watcher
+  rm -rf "$test_tmp"
+}
+trap cleanup EXIT
+
+fake_bin="$test_tmp/bin"
+mkdir -p "$fake_bin"
+
+clients_file="$test_tmp/clients.json"
+dispatch_log="$test_tmp/dispatch.log"
+events="$test_tmp/events"
+
+cat >"$fake_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ ${1:-} == "clients" && ${2:-} == "-j" ]]; then
+  cat "$OMARCHY_TEST_CLIENTS_FILE"
+elif [[ ${1:-} == "dispatch" ]]; then
+  shift
+  printf '%s\n' "$*" >>"$OMARCHY_TEST_DISPATCH_LOG"
+fi
+SH
+
+cat >"$fake_bin/socat" <<'SH'
+#!/bin/bash
+
+exec cat "$OMARCHY_TEST_EVENTS"
+SH
+
+chmod +x "$fake_bin"/*
+
+# One workspace 1 holding the presentation float, one workspace 3 holding
+# another, and a workspace 2 with none.
+cat >"$clients_file" <<'JSON'
+[
+  {"address":"0x1a01","class":"org.omarchy.terminal","floating":true,"workspace":{"id":1}},
+  {"address":"0x1a03","class":"org.omarchy.terminal","floating":true,"workspace":{"id":3}},
+  {"address":"0x2b01","class":"chromium","floating":false,"workspace":{"id":1}},
+  {"address":"0x2b02","class":"chromium","floating":false,"workspace":{"id":2}},
+  {"address":"0x2b03","class":"chromium","floating":true,"workspace":{"id":1}},
+  {"address":"0x2c03","class":"firefox","floating":false,"workspace":{"id":3}},
+  {"address":"0x2d01","class":"org.codeberg.dnkl.foot","floating":false,"workspace":{"id":1}}
+]
+JSON
+
+: >"$dispatch_log"
+mkfifo "$events"
+
+PATH="$fake_bin:$PATH" \
+XDG_RUNTIME_DIR="$test_tmp" \
+HYPRLAND_INSTANCE_SIGNATURE=test \
+OMARCHY_TEST_EVENTS="$events" \
+OMARCHY_TEST_CLIENTS_FILE="$clients_file" \
+OMARCHY_TEST_DISPATCH_LOG="$dispatch_log" \
+  "$browser_watch" &
+watch_pid=$!
+
+exec {events_fd}>"$events"
+
+dispatches() {
+  wc -l <"$dispatch_log" | tr -d ' '
+}
+
+await_dispatches() {
+  local waited
+
+  for (( waited = 0; waited < 100; waited++ )); do
+    (( $(dispatches) >= $1 )) && return 0
+    sleep 0.05
+  done
+
+  return 1
+}
+
+# Events are handled in order, so the cases that must do nothing can be sent
+# first and judged by what the log holds once the later ones have landed. No
+# sleeping on the absence of an action.
+# Hyprland writes the address without the 0x that hyprctl reports and expects,
+# so the events here carry the bare form the compositor sends.
+printf 'openwindow>>2b02,2,chromium,Sign in\n' >&"$events_fd"
+printf 'openwindow>>2b03,1,chromium,Sign in\n' >&"$events_fd"
+printf 'openwindow>>2d01,1,org.codeberg.dnkl.foot,Omarchy\n' >&"$events_fd"
+
+# A page title can hold commas; the class must still be read from field three.
+printf 'openwindow>>2b01,1,chromium,Sign in to Claude, then return here\n' >&"$events_fd"
+printf 'openwindow>>2c03,3,firefox,Mozilla Firefox\n' >&"$events_fd"
+
+await_dispatches 6 || fail "a browser opening under the presentation float is raised" "$(<"$dispatch_log")"
+
+for address in 0x2b01 0x2c03; do
+  grep -qF "hl.dsp.window.float({ window = \"address:$address\", action = \"toggle\" })" "$dispatch_log" ||
+    fail "the browser is floated out of the tiled layer" "$address: $(<"$dispatch_log")"
+  grep -qF "hl.dsp.window.alter_zorder({ window = \"address:$address\", mode = \"top\" })" "$dispatch_log" ||
+    fail "the browser is raised above the float that covered it" "$address: $(<"$dispatch_log")"
+  grep -qF "hl.dsp.focus({ window = \"address:$address\" })" "$dispatch_log" ||
+    fail "the browser takes focus once it is visible" "$address: $(<"$dispatch_log")"
+done
+pass "a browser opening under the presentation float is floated, raised and focused"
+
+(( $(dispatches) == 6 )) || fail "only covered browsers are touched" "$(<"$dispatch_log")"
+for address in 0x2b02 0x2b03 0x2d01; do
+  ! grep -qF "address:$address" "$dispatch_log" ||
+    fail "an uncovered window is left alone" "$address: $(<"$dispatch_log")"
+done
+pass "browsers on a workspace with no presentation float, already-floating browsers and non-browsers are left alone"
+
+stop_watcher
+
+grep -F 'o.launch("omarchy-hyprland-browser-watch")' "$autostart" >/dev/null ||
+  fail "the browser watcher starts with the session"
+pass "the browser watcher starts with the session"
+
+# The fix exists because browsers are pinned to the tiled layer, where nothing
+# can lift them over a float. If that ever changes, this is the thread to pull.
+grep -F 'o.window({ tag = "chromium-based-browser" }, { tag = "-default-opacity", tile = true' "$browser_rules" >/dev/null ||
+  fail "browsers are still forced to tile, which is what strands them under the float"
+pass "browsers are still forced to tile, which is what strands them under the float"


### PR DESCRIPTION
Fixes #7174

## The problem

Hyprland draws every floating window above every tiled one, and `default/hypr/apps/browser.lua:4` pins chromium-based browsers to `tile = true`. A browser that opens while the presentation float is up is therefore **unreachable**: `Alt+Tab` or a click gives it the keyboard, and it stays behind the float. There is no dispatcher that lifts a tiled window over a floating one.

First login walks straight into it. "Set your default agent" runs `omarchy-default-agent --install <agent>` in the 875×600 centered float, that `exec`s `omarchy-agent --inline`, the agent opens its OAuth page, and the login window lands under the window that asked for it — with nothing on screen to say a browser opened at all. #7174 has it with Grok; I reproduced it with Claude Code, where auth took 6m35s (setup terminal at `21:02:14`, `~/.claude/.credentials.json` at `21:08:49`) against seconds once the window is visible.

On an unscaled 1366×768 panel the float leaves ~245px of margin, so the browser is *partly visible* and clicking it appears to do nothing. That reads as a hung install rather than a hidden window.

## The fix

`bin/omarchy-hyprland-browser-watch` watches `openwindow` and, when a browser opens tiled on a workspace where the presentation float is up, moves it into the floating layer — the only layer that can cover the terminal that opened it — then raises and focuses it. Started from `default/hypr/autostart.lua` alongside `omarchy-hyprland-monitor-watch`.

It is deliberately narrow. Nothing happens unless the new window is a browser class from `browser.lua`, it opened tiled, and an `org.omarchy.terminal` float is on the same workspace. Ordinary browsing is untouched.

Fixing it in window management rather than in the launch path is what makes it hold for every agent: Grok opens `uwsm-app -- /usr/bin/chromium <url>` directly, so nothing routed through `$BROWSER` or `omarchy-launch-browser` would have caught it.

## Relationship to #8961 / #9040

They are separate defects in the same flow and both need fixing. #9040 restores `BROWSER` in the presentation terminal so the browser stops being a child of a terminal that is about to exit — that fixes the SIGTRAP in #8961. It does not change stacking: `omarchy-launch-browser` ends in `omarchy-hyprland-focus-app`, and focusing a tiled window cannot raise it above a float. This PR touches neither file, so the two do not conflict.

## Testing

- `bash test/shell.d/browser-watch-test.sh` — new. Drives the watcher over a fifo with a fake `hyprctl`, covering the covered-browser case, a browser on a workspace with no float, an already-floating browser, a non-browser window, and a page title containing commas. Negative cases are sent before positive ones and judged by the dispatch log once the later ones land, so nothing sleeps on the absence of an action.
- `./test/shell` — 219 of 223 files pass. The 4 failures (`bin-style`, `config`, `snapper`, `unowned-system-paths`) fail identically on a clean `quattro` checkout here: `bin/omarchy-remove-ai-openclaw` uses a raw `command -v`, and the other three want an `omarchy-pkgs` checkout this machine does not have.
- `./test/cli` — passes.
- Verified in the running session on the affected machine (Omarchy 4.0.2, Hyprland 0.56.2, Chromium 151.0.7922.173): with the presentation float up at 875×600 on workspace 1, a Chromium window launched the way an agent launches it went from `floating=false`, invisible under the float, to `floating=true`, focused and drawn over it. Confirmed on a screenshot, not just in `hyprctl clients`.

One implementation note worth flagging for review: Hyprland's `openwindow` event carries the window address **without** the `0x` prefix that `hyprctl` reports and expects. The first cut of this dropped every event silently for that reason; the test covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMpAZJem9C7UMa3LLbBjKB
