### PR TITLE
Preserve keyboard backlight across repeated blanks

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -25,11 +25,24 @@ if [[ -z $device ]]; then
   exit 1
 fi
 
+state_file="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}/omarchy-keyboard-backlight-$device"
+
 if [[ $direction == "off" ]]; then
-  brightnessctl -sd "$device" set 0 >/dev/null
+  if [[ ! -f $state_file ]]; then
+    current_brightness="$(brightnessctl -d "$device" get)" || exit 1
+    mkdir -p "$(dirname "$state_file")" || exit 1
+    printf '%s\n' "$current_brightness" >"$state_file" || {
+      rm -f "$state_file"
+      exit 1
+    }
+  fi
+  brightnessctl -d "$device" set 0 >/dev/null || exit 1
   exit 0
 elif [[ $direction == "restore" ]]; then
-  brightnessctl -rd "$device" >/dev/null
+  if [[ -f $state_file ]]; then
+    brightnessctl -d "$device" set "$(<"$state_file")" >/dev/null || exit 1
+    rm -f "$state_file" || exit 1
+  fi
   exit 0
 fi
 
@@ -54,5 +67,6 @@ else
 fi
 
 # Set the new brightness.
-brightnessctl -d "$device" set "$new_brightness" >/dev/null
+brightnessctl -d "$device" set "$new_brightness" >/dev/null || exit 1
+rm -f "$state_file" || exit 1
 (( no_osd )) || omarchy-osd -i keyboard -p "$(( new_brightness * 100 / max_brightness ))"

--- a/test/shell.d/keyboard-brightness-test.sh
+++ b/test/shell.d/keyboard-brightness-test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+runtime_dir="$test_tmp/runtime"
+brightness_file="$test_tmp/brightness"
+mock_leds="$test_tmp/sys/class/leds"
+command="$test_tmp/omarchy-brightness-keyboard"
+state_file="$runtime_dir/omarchy-keyboard-backlight-mock_kbd_backlight"
+mkdir -p "$mock_bin" "$runtime_dir" "$mock_leds/mock_kbd_backlight"
+
+sed "s|/sys/class/leds/\\*kbd_backlight\\*|$mock_leds/*kbd_backlight*|" \
+  "$ROOT/bin/omarchy-brightness-keyboard" >"$command"
+chmod +x "$command"
+
+cat >"$mock_bin/brightnessctl" <<'SH'
+#!/bin/bash
+device=""
+operation=""
+value=""
+
+while (( $# > 0 )); do
+  case "$1" in
+    -d)
+      device="$2"
+      shift 2
+      ;;
+    get|max)
+      operation="$1"
+      shift
+      ;;
+    set)
+      operation="$1"
+      value="$2"
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+
+[[ $device == "mock_kbd_backlight" ]] || exit 1
+
+case "$operation" in
+  get) cat "$BRIGHTNESS_FILE" ;;
+  max) printf '2\n' ;;
+  set)
+    [[ ${FAIL_SET:-0} == 1 ]] && exit 1
+    printf '%s\n' "$value" >"$BRIGHTNESS_FILE"
+    ;;
+  *) exit 1 ;;
+esac
+SH
+
+cat >"$mock_bin/omarchy-osd" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$mock_bin"/*
+
+run_brightness() {
+  BRIGHTNESS_FILE="$brightness_file" FAIL_SET="${FAIL_SET:-0}" XDG_RUNTIME_DIR="$runtime_dir" PATH="$mock_bin:$PATH" \
+    "$command" --no-osd "$@"
+}
+
+assert_brightness() {
+  local expected="$1"
+  local description="$2"
+  local actual
+  actual=$(<"$brightness_file")
+  [[ $actual == "$expected" ]] || fail "$description" "expected: $expected, actual: $actual"
+  pass "$description"
+}
+
+printf '2\n' >"$brightness_file"
+run_brightness off
+run_brightness off
+run_brightness restore
+assert_brightness 2 "a keyboard that starts on is restored to its previous level"
+[[ ! -e $state_file ]] || fail "restoring clears the saved keyboard brightness"
+pass "restoring clears the saved keyboard brightness"
+
+printf '0\n' >"$brightness_file"
+run_brightness off
+run_brightness off
+[[ $(<"$state_file") == 0 ]] || fail "blanking saves an initial brightness of zero"
+pass "blanking saves an initial brightness of zero"
+run_brightness restore
+assert_brightness 0 "a keyboard that starts off remains off"
+[[ ! -e $state_file ]] || fail "restoring an off keyboard clears its saved brightness"
+pass "restoring an off keyboard clears its saved brightness"
+
+printf '1\n' >"$brightness_file"
+printf '2\n' >"$state_file"
+run_brightness down
+assert_brightness 0 "manually turning the keyboard off leaves it off"
+[[ ! -e $state_file ]] || fail "manual brightness changes clear the saved level"
+pass "manual brightness changes clear the saved level"
+
+run_brightness off
+run_brightness restore
+assert_brightness 0 "a manually disabled keyboard remains off after blank and restore"
+
+printf '1\n' >"$brightness_file"
+printf '2\n' >"$state_file"
+if FAIL_SET=1 run_brightness down; then
+  fail "a failed manual brightness change is reported"
+fi
+assert_brightness 1 "a failed manual brightness change leaves the keyboard unchanged"
+[[ $(<"$state_file") == 2 ]] || fail "a failed manual brightness change preserves the saved level"
+pass "a failed manual brightness change preserves the saved level"
+
+rm -f "$state_file"
+rm -rf "$runtime_dir"
+printf 'not a directory\n' >"$runtime_dir"
+if run_brightness off >/dev/null 2>&1; then
+  fail "a failed state save is reported"
+fi
+assert_brightness 1 "a failed state save does not turn the keyboard off"


### PR DESCRIPTION
My keyboard backlight turns off when Omarchy blanks the screen, which is expected. It was not turning back on when I woke the screen.

Omarchy used `brightnessctl -s` to save the current level before turning the backlight off. The blank command can run more than once, so a second call saved `0` over the original level. `restore` then brought the keyboard back to `0`.

This change treats a runtime file as the snapshot for one blank and restore cycle. The first blank saves the current level, including `0`. Later blank calls leave that snapshot alone. Restore applies it once and deletes it. Successful manual brightness changes also delete it, so they remain in effect.

If the snapshot cannot be saved, the keyboard is not turned off. A failed manual brightness change also leaves the snapshot intact.

The behavioral test covers:
- starts on, blanks more than once, restores to the previous level
- starts off, blanks more than once, remains off
- manually turns off, then remains off after blank and restore
- failed state saves and failed manual brightness changes

I also ran Bash syntax checks for the command and test.

Fixes #7650
Fixes #10105

Related to #6667