### PR TITLE
Add Code of Conduct prohibiting AI-generated CSAM

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+1. Purpose
+Omarchy is committed to maintaining a safe, ethical, and legally compliant open‑source ecosystem. This Code of Conduct establishes clear rules prohibiting the creation, distribution, or inclusion of AI‑generated child sexual abuse material (CSAM) within the project and its community.
+
+AI‑generated CSAM is harmful, illegal in many jurisdictions, and incompatible with the values of the Omarchy project. This policy ensures that contributors, users, and organisations engaging with Omarchy uphold the highest standards of child safety and digital responsibility.
+
+2. Prohibited Content
+The following activities are strictly forbidden within the Omarchy project:
+
+AI‑generated CSAM must not be added to the project in any form, including but not limited to wallpapers, themes, artwork, assets, documentation, or user‑submitted contributions.
+
+No code, tools, or systems designed to create, distribute, or facilitate AI‑generated CSAM may be included in the project or its ecosystem.
+
+Any attempt to introduce such content will result in immediate removal and further action as outlined in Section 5.
+
+3. Prohibited Use of the Operating System
+Omarchy must not be used by individuals or organisations who engage in the creation, distribution, or facilitation of AI‑generated CSAM. This includes:
+
+Companies developing systems that generate AI‑based CSAM.
+
+Individuals using Omarchy for activities involving AI‑generated CSAM.
+
+Any entity knowingly supporting or enabling the production of such material.
+
+Omarchy reserves the right to deny support, participation, or community access to users or organisations violating this policy.
+
+4. Rationale
+The global legal landscape surrounding AI‑generated CSAM is inconsistent and, in some regions, insufficient. As discussions around Omarchy Kids and user‑generated content continue, it is essential to establish clear boundaries to protect the project, its contributors, and its users.
+
+This policy reflects a non‑controversial, widely supported position within the technology community: AI‑generated CSAM has no place in open‑source software or digital ecosystems.
+
+5. Enforcement
+Violations of this policy may result in:
+
+Removal of offending content
+
+Revocation of contributor privileges
+
+Suspension or banning from project communication channels
+
+Reporting of illegal activity to relevant authorities where required
+
+Project maintainers will review incidents on a case‑by‑case basis and take appropriate action.
+
+6. Reporting Concerns
+If you encounter content or behaviour that violates this policy, please report it immediately via:
+
+GitHub Issues (with appropriate tagging)
+
+Direct contact with project maintainers
+
+Email to the Omarchy governance team (if applicable)
+
+Reports will be handled confidentially and with urgency.
+
+7. Commitment to Safety
+By contributing to or using Omarchy, you agree to uphold this Code of Conduct and support a safe, responsible, and ethical open‑source community.


### PR DESCRIPTION
This Code of Conduct establishes rules against AI-generated child sexual abuse material (CSAM) within the Omarchy project, outlining prohibited content and usage, enforcement measures, and reporting procedures.

This aims to address https://github.com/omacom/omarchy/discussions/10349