### PR TITLE
Fix keyboard backlight restore after screensaver dismiss

### DIFF
--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -25,11 +25,31 @@ if [[ -z $device ]]; then
   exit 1
 fi
 
+# Marker tracks whether this command actually turned the backlight off, so a
+# later restore without a preceding off (e.g. screensaver dismiss, which wakes
+# via omarchy-system-wake without ever blanking the keyboard) is a no-op
+# instead of restoring a stale brightnessctl save.
+state_marker="${XDG_RUNTIME_DIR:-/tmp}/omarchy-keyboard-backlight-off"
+
 if [[ $direction == "off" ]]; then
-  brightnessctl -sd "$device" set 0 >/dev/null
+  current_brightness="$(brightnessctl -d "$device" get 2>/dev/null || echo 0)"
+  if (( current_brightness == 0 )); then
+    brightnessctl -d "$device" set 0 >/dev/null
+  else
+    brightnessctl -sd "$device" set 0 >/dev/null
+    touch "$state_marker"
+  fi
   exit 0
 elif [[ $direction == "restore" ]]; then
-  brightnessctl -rd "$device" >/dev/null
+  if [[ ! -f $state_marker ]]; then
+    exit 0
+  fi
+  rm -f "$state_marker"
+  current_brightness="$(brightnessctl -d "$device" get 2>/dev/null || echo 0)"
+  if (( current_brightness != 0 )); then
+    exit 0
+  fi
+  brightnessctl -rd "$device" >/dev/null || true
   exit 0
 fi
 

--- a/test/shell.d/keyboard-backlight-test.sh
+++ b/test/shell.d/keyboard-backlight-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+keyboard="$ROOT/bin/omarchy-brightness-keyboard"
+wake="$ROOT/bin/omarchy-system-wake"
+
+# The bug: screensaver dismiss runs omarchy-system-wake (keyboard restore)
+# without any preceding keyboard off, so restore must not apply a stale
+# brightnessctl save. The marker pairs off/restore.
+grep -F 'state_marker="${XDG_RUNTIME_DIR:-/tmp}/omarchy-keyboard-backlight-off"' "$keyboard" >/dev/null || \
+  fail "keyboard backlight tracks whether off actually blanked the keyboard"
+pass "keyboard backlight tracks whether off actually blanked the keyboard"
+
+# A repeated off while already at zero must not re-save (which would clobber
+# the saved brightness with 0 and make the later restore a no-op).
+grep -F 'if (( current_brightness == 0 )); then' "$keyboard" >/dev/null || \
+  fail "keyboard off avoids re-saving when already off"
+grep -F 'brightnessctl -d "$device" set 0' "$keyboard" >/dev/null || \
+  fail "repeated keyboard off turns off without saving"
+grep -F 'brightnessctl -sd "$device" set 0' "$keyboard" >/dev/null || \
+  fail "keyboard off saves state when turning off a lit keyboard"
+pass "keyboard off only saves when turning off a lit keyboard"
+
+# Restore without a preceding off (screensaver dismiss) stays put.
+grep -F 'if [[ ! -f $state_marker ]]; then' "$keyboard" >/dev/null || \
+  fail "keyboard restore without a preceding off is a no-op"
+pass "keyboard restore without a preceding off is a no-op"
+
+# Restore is one-shot and never clobbers a keyboard that is already lit
+# (e.g. user adjusted it while locked).
+grep -F 'rm -f "$state_marker"' "$keyboard" >/dev/null || \
+  fail "keyboard restore clears its marker"
+grep -F 'if (( current_brightness != 0 )); then' "$keyboard" >/dev/null || \
+  fail "keyboard restore leaves an already-lit keyboard alone"
+grep -F 'brightnessctl -rd "$device"' "$keyboard" >/dev/null || \
+  fail "keyboard restore still restores a blanked keyboard"
+pass "keyboard restore is one-shot and leaves a lit keyboard alone"
+
+# The wake path itself is unchanged: display on, keyboard restore, clamshell.
+grep -F 'omarchy-brightness-keyboard restore' "$wake" >/dev/null || \
+  fail "system wake still restores keyboard brightness"
+pass "system wake still restores keyboard brightness"


### PR DESCRIPTION
## Problem

After the screensaver shows and is dismissed (before the lock deadline), the keyboard backlight stays dark instead of keeping its previous brightness.

## Root cause

- Lock blanking (`shell/plugins/lock/Service.qml` blankProcess) runs `omarchy-brightness-keyboard off` = `brightnessctl -s set 0` (save + off).
- Wake (`bin/omarchy-system-wake`) runs `omarchy-brightness-keyboard restore` = `brightnessctl -r`.
- But screensaver dismiss (`shell/plugins/services/idle/Service.qml` `cancelIdleCycle`) also runs `omarchy-system-wake` **without any preceding `off`**, so `restore` applied a stale save (often `0` from an earlier cycle) and clobbered the still-lit keyboard. A repeated `off` while already at zero had the same clobbering effect on the save file.

Reproduced live on a MacBook (`kbd_backlight`, max 255): stray `restore` with no preceding `off` reset a lit keyboard to the stale saved value.

## Fix

`bin/omarchy-brightness-keyboard` now pairs `off`/`restore` with a marker file (`${XDG_RUNTIME_DIR:-/tmp}/omarchy-keyboard-backlight-off`):

- `off` only saves (`-s`) when the keyboard is actually lit; a repeated `off` at zero is a plain `set 0` that leaves the save intact.
- `restore` is a no-op without the marker (screensaver dismiss), one-shot (clears the marker), and leaves an already-lit keyboard alone.

No caller changes needed; `omarchy-system-wake` keeps calling `restore`.

## Verification

- New `test/shell.d/keyboard-backlight-test.sh` passes; `idle-test.sh` passes (`bin-style-test.sh` failure is pre-existing on clean checkout, unrelated `omarchy-remove-ai-openclaw`).
- Live check: `25 -> off -> 0 (marker) -> restore -> 25 (marker cleared)`; stray `restore` on a lit keyboard is a no-op.