### PR TITLE
Install ffmpeg 4.4 with Spotify so Local Files can play

### DIFF
--- a/bin/omarchy-install-service-spotify
+++ b/bin/omarchy-install-service-spotify
@@ -6,7 +6,7 @@
 set -e
 
 echo "Installing Spotify..."
-omarchy-pkg-add spotify
+omarchy-pkg-add spotify ffmpeg4.4 zenity
 
 echo "Opening Spotify..."
 setsid uwsm-app -- /usr/bin/spotify >/dev/null 2>&1 &

--- a/manual/24-commercial-apps-services.md
+++ b/manual/24-commercial-apps-services.md
@@ -18,6 +18,8 @@ You start 1Password with `Super + Shift + /`. If it isn't installed yet, that ho
 
 You start Spotify using `Super + Shift + M`. Like 1Password, the hotkey kicks off the installation first if Spotify isn't installed yet (or use _Install > Service > Spotify_ from the Omarchy menu).
 
+Local Files work too. Add a folder under Settings > Local Files. The Linux client still needs the older FFmpeg 4.4 libraries to decode those tracks, so the installer also pulls in `ffmpeg4.4` and `zenity` for the folder picker. Without them, a file starts for a second then Spotify says it cannot play the content — even when the file is already on disk.
+
 ## Dropbox
 
 [Dropbox](https://www.dropbox.com/) is a great way to sync files between machines while keeping a backup in the cloud. To set it up, select _Install > Service > Dropbox_ from the Omarchy menu. Once it's running, hover the tray in the top right of the bar and right-click the Dropbox icon to finish the setup.

--- a/migrations/1788642930.sh
+++ b/migrations/1788642930.sh
@@ -1,0 +1,5 @@
+echo "Install ffmpeg 4.4 so Spotify can play Local Files"
+
+if omarchy-pkg-present spotify; then
+  omarchy-pkg-add ffmpeg4.4 zenity
+fi

--- a/migrations/1788642930.sh
+++ b/migrations/1788642930.sh
@@ -1,4 +1,4 @@
-echo "Install ffmpeg 4.4 so Spotify can play Local Files"
+echo "Install ffmpeg 4.4 and zenity so Spotify can play Local Files"
 
 if omarchy-pkg-present spotify; then
   omarchy-pkg-add ffmpeg4.4 zenity


### PR DESCRIPTION
## Summary

Linux Spotify still `dlopen`s FFmpeg **4.4** sonames (`libavcodec.so.58`, `libavformat.so.58`, `libavutil.so.56`). Arch's current `ffmpeg` is 9 (`libavcodec.so.63` only), so Local Files look imported and even start, then die after about a second with *Spotify can't play this content* / *If you have the file on your computer, you can import it.*

The files are fine. The decoder libraries are gone. [ArchWiki](https://wiki.archlinux.org/title/Spotify) already documents this: Local Files need `ffmpeg4.4` plus `zenity` for the folder picker.

- New installs via _Install > Service > Spotify_ pull in `ffmpeg4.4` and `zenity` next to `spotify`
- Existing Spotify installs get the same packages on the next `omarchy update`
- Manual notes why a "import this file" toast is usually a missing 4.4 decoder, not a bad file

## Test plan

- [ ] Fresh _Install > Service > Spotify_ installs `ffmpeg4.4` and `zenity`
- [ ] On a machine that already has Spotify, the migration installs them; machines without Spotify skip it
- [ ] Add a Local Files folder, play an MP3: it continues past the first second instead of toasting
- [ ] `ldconfig -p | grep libavcodec.so.58` finds the 4.4 library after install


Made with [Cursor](https://cursor.com)