### PR TITLE
Show design capacity and battery health in the power panel

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -111,6 +111,17 @@ if [[ $shell_output == "true" ]]; then
 
   [[ -n $cycles ]] && printf 'cycles\t%s\n' "$cycles"
 
+  # What the pack was sold as, and how much of that survives. `capacity` is
+  # UPower's own energy-full / energy-full-design; anchored so it cannot match
+  # `capacity-level:`, which is a word rather than a number. A desktop UPS or a
+  # pack whose firmware omits the design figure reports neither, and callers
+  # are expected to hide the difference rather than invent a 100%.
+  design=$(awk '/energy-full-design:/ { printf "%d", $2; exit }' <<<"$battery_info")
+  health=$(awk '/^[[:space:]]*capacity:/ { gsub(/%/, "", $2); printf "%d", $2; exit }' <<<"$battery_info")
+
+  [[ -n $design ]] && (( design > 0 )) && printf 'design\t%sWh\n' "$design"
+  [[ -n $health ]] && (( health > 0 )) && printf 'health\t%s%%\n' "$health"
+
   if [[ -n $threshold_end ]]; then
     if [[ -n $threshold_start && $threshold_start != $threshold_end ]]; then
       printf 'threshold\t%s-%s%%\n' "$threshold_start" "$threshold_end"

--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -89,6 +89,39 @@ function modeLabel(device, onBattery, states) {
   return "Charging"
 }
 
+// Battery health arrives as a display string ("72%"), hence parseInt.
+//
+// 80% is the load-bearing threshold: the line most vendors treat as a pack
+// still being serviceable, and where capacity warranties usually stop. It
+// separates "nothing to think about" from "start budgeting".
+//
+// 70% separates planning a replacement from needing one. A round third of the
+// pack is gone by then, and it sits in the band where lithium-ion fade tends
+// to accelerate rather than continue linearly. 90% is wording alone; nothing
+// rides on it.
+function healthLevel(health) {
+  var n = parseInt(health, 10)
+  return isFinite(n) && n > 0 ? n : 0
+}
+
+function healthVerdict(health) {
+  var n = healthLevel(health)
+  if (n === 0) return ""
+  if (n >= 90) return "Great"
+  if (n >= 80) return "Normal"
+  if (n >= 70) return "Worn"
+  return "Bad"
+}
+
+function healthHint(health) {
+  var n = healthLevel(health)
+  if (n === 0) return ""
+  if (n >= 90) return "Practically new"
+  if (n >= 80) return "Normal wear for its age"
+  if (n >= 70) return "Worth planning a replacement"
+  return "Time to replace it"
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     clampIndex: clampIndex,
@@ -99,6 +132,9 @@ if (typeof module !== "undefined") {
     batteryFraction: batteryFraction,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,
-    modeLabel: modeLabel
+    modeLabel: modeLabel,
+    healthLevel: healthLevel,
+    healthVerdict: healthVerdict,
+    healthHint: healthHint
   }
 }

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -24,6 +24,17 @@ Panel {
   // icon, so the open-panel mark takes the painted width instead of the
   // icon-sized fraction of the slot the fallback assumes.
   readonly property real openPanelIndicatorWidth: showPercentage && !button.vertical ? button.glyphPaintedWidth : 0
+  // Design capacity and health arrive together or not at all — a pack whose
+  // firmware omits the design figure yields neither. Gating every derived row
+  // on the pair keeps the two stat columns the same height and keeps the
+  // health section from rendering with nothing behind it.
+  readonly property bool hasHealthInfo: !!(batteryInfo.design && batteryInfo.health)
+  readonly property int healthLevel: Model.healthLevel(batteryInfo.health)
+  // A pack fresh off the line can charge past its own design capacity, so
+  // the bar clamps rather than overrunning its track.
+  readonly property real healthFraction: Math.max(0, Math.min(1, healthLevel / 100))
+  readonly property string healthVerdict: Model.healthVerdict(batteryInfo.health)
+  readonly property string healthHint: Model.healthHint(batteryInfo.health)
   readonly property bool batteryPresent: {
     var device = UPower.displayDevice
     return !!(device && device.isPresent)
@@ -433,8 +444,25 @@ Panel {
           Column {
             width: (parent.width - parent.spacing) / 2
             spacing: Style.spacing.labelGap
-            InfoPair { label: "Battery size"; value: root.batteryInfo.size || "" }
-            InfoPair { label: "Charge cycles"; value: root.batteryInfo.cycles || "—" }
+            InfoPair {
+              // The nameplate figure when the design capacity is known. Falls
+              // back to what the pack holds today when it is not, which is the
+              // only number available in that case.
+              label: "Battery size"
+              value: (root.hasHealthInfo ? root.batteryInfo.design : root.batteryInfo.size) || ""
+            }
+            InfoPair {
+              label: "Current capacity"
+              value: root.batteryInfo.size || ""
+              visible: root.hasHealthInfo
+            }
+            // Cycles live in the health section when there is one. This is the
+            // fallback home for packs that report no design capacity.
+            InfoPair {
+              label: "Charge cycles"
+              value: root.batteryInfo.cycles || "—"
+              visible: !root.hasHealthInfo
+            }
           }
 
           Column {
@@ -449,6 +477,108 @@ Panel {
               value: root.chargeThresholdActive ? "Holding" : (root.batteryFull ? "-" : (root.batteryInfo.rate || ""))
             }
           }
+        }
+
+        // ---------- Battery health ----------
+        // A worn pack charges to well under its nameplate capacity, and the
+        // stats above say so without saying what it means. Hidden wholesale
+        // when the design figure is unavailable.
+        PanelSeparator {
+          visible: root.hasHealthInfo
+          foreground: root.bar.foreground
+        }
+
+        Column {
+          visible: root.hasHealthInfo
+          width: parent.width
+          spacing: Style.space(10)
+
+          PanelSectionHeader {
+            text: "BATTERY HEALTH"
+            foreground: root.bar.foreground
+            fontFamily: root.bar.fontFamily
+          }
+
+          // The hero's shape — verdict, caption, right-aligned number — one
+          // type size down, so it reads as the panel's second story rather
+          // than competing with the charge level above it.
+          Item {
+            width: parent.width
+            implicitHeight: Math.max(healthLabels.implicitHeight, healthValue.implicitHeight)
+
+            Column {
+              id: healthLabels
+              anchors.left: parent.left
+              anchors.right: healthValue.left
+              anchors.rightMargin: Style.space(10)
+              anchors.verticalCenter: parent.verticalCenter
+              spacing: Style.space(2)
+
+              Text {
+                textFormat: Text.PlainText
+                text: root.healthVerdict
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.title
+                font.bold: true
+                elide: Text.ElideRight
+                width: parent.width
+              }
+
+              Text {
+                textFormat: Text.PlainText
+                text: root.healthHint.toUpperCase()
+                color: Qt.darker(root.bar.foreground, 1.4)
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.caption
+                font.bold: true
+                font.letterSpacing: 1.2
+                elide: Text.ElideRight
+                width: parent.width
+              }
+            }
+
+            Text {
+              id: healthValue
+              textFormat: Text.PlainText
+              text: root.batteryInfo.health || ""
+              color: root.bar.foreground
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.display
+              font.bold: true
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+            }
+          }
+
+          // The charge bar's vocabulary at two thirds the height, so the two
+          // bars read as "right now" and "over the pack's life" rather than as
+          // the same measurement twice.
+          Item {
+            width: parent.width
+            implicitHeight: Style.space(6)
+
+            Rectangle {
+              id: healthTrack
+              anchors.fill: parent
+              radius: height / 2
+              color: Qt.rgba(root.bar.foreground.r, root.bar.foreground.g, root.bar.foreground.b, 0.12)
+            }
+
+            Rectangle {
+              anchors.left: healthTrack.left
+              anchors.verticalCenter: healthTrack.verticalCenter
+              height: healthTrack.height
+              radius: healthTrack.radius
+              color: root.bar.foreground
+              opacity: 0.75
+              width: Math.max(healthTrack.height, healthTrack.width * root.healthFraction)
+
+              Behavior on width { NumberAnimation { duration: 320; easing.type: Easing.OutCubic } }
+            }
+          }
+
+          InfoPair { label: "Charge cycles"; value: root.batteryInfo.cycles || "—" }
         }
 
         // ---------- Power profile picker ----------

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -25,9 +25,12 @@ if [[ $1 == "-i" ]]; then
   state:                discharging
   energy:               28.3 Wh
   energy-full:          56.7 Wh
+  energy-full-design:   78.9 Wh
   energy-rate:          7.3 W
   time to empty:        2.5 hours
   percentage:           51%
+  capacity:             71.8%
+  capacity-level:       Normal
 INFO
   exit 0
 fi
@@ -43,6 +46,45 @@ grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "battery st
 grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status reports live sysfs power rate"
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
 grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
+grep -Fx $'design\t78Wh' <<<"$shell_output" >/dev/null || fail "battery status reports design capacity"
+grep -Fx $'health\t71%' <<<"$shell_output" >/dev/null || fail "battery status reports pack health"
+
+# capacity-level is a word ("Normal"), so an unanchored /capacity:/ match would
+# report a health of 0% and the panel would hide the section it belongs to.
+grep -Fx $'health\t0%' <<<"$shell_output" >/dev/null && fail "battery status does not read health from capacity-level"
+
+# A pack whose firmware omits the design figure must yield neither key rather
+# than a fabricated 100%: the panel keys its whole health section off them.
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  cat <<'INFO'
+  native-path:          BAT0
+  state:                discharging
+  energy:               28.3 Wh
+  energy-full:          56.7 Wh
+  energy-rate:          7.3 W
+  time to empty:        2.5 hours
+  percentage:           51%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+designless_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -q $'^design\t' <<<"$designless_output" && fail "battery status omits design capacity when the firmware has none"
+grep -q $'^health\t' <<<"$designless_output" && fail "battery status omits health when there is no design capacity to measure against"
+grep -Fx $'size\t56Wh' <<<"$designless_output" >/dev/null || fail "battery status still reports full capacity without a design figure"
 
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -42,10 +42,32 @@ assertEqual(
   'power shows battery icon when unplugged before battery state refreshes'
 )
 
+assertEqual(power.healthLevel('72%'), 72, 'power reads the health percentage out of its display string')
+assertEqual(power.healthLevel(undefined), 0, 'power treats missing health as unknown rather than zero percent')
+assertEqual(power.healthVerdict('95%'), 'Great', 'power calls a near-new pack great')
+assertEqual(power.healthVerdict('103%'), 'Great', 'power handles a pack charging past its design capacity')
+assertEqual(power.healthVerdict('90%'), 'Great', 'power keeps the practically-new boundary on the great side')
+assertEqual(power.healthVerdict('89%'), 'Normal', 'power calls a lightly worn pack normal')
+assertEqual(power.healthVerdict('80%'), 'Normal', 'power keeps the vendor service threshold on the normal side')
+assertEqual(power.healthVerdict('79%'), 'Worn', 'power calls a pack below the service threshold worn')
+assertEqual(power.healthVerdict('70%'), 'Worn', 'power keeps a third of the pack gone on the worn side')
+assertEqual(power.healthVerdict('69%'), 'Bad', 'power calls a pack past a third of its capacity bad')
+assertEqual(power.healthVerdict('41%'), 'Bad', 'power calls a badly degraded pack bad')
+assertEqual(power.healthVerdict(undefined), '', 'power gives no verdict without a health figure')
+assertEqual(power.healthHint('75%'), 'Worth planning a replacement', 'power tells a worn pack owner to plan ahead')
+assertEqual(power.healthHint('50%'), 'Time to replace it', 'power tells a spent pack owner to act')
+assertEqual(power.healthHint(undefined), '', 'power gives no hint without a health figure')
+
 assert(/if \(b === Qt\.RightButton\) root\.togglePercentage\(\)/.test(panelSource), 'power right click toggles the bar percentage')
 assert(/Object\.assign\([^\n]+showPercentage: !root\.showPercentage[^\n]+\)[\s\S]*updateEntryInline/.test(panelSource), 'power persists the bar percentage setting')
 assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon\(\)/.test(panelSource), 'power places the percentage before the battery icon')
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
+
+assert(/hasHealthInfo: !!\(batteryInfo\.design && batteryInfo\.health\)/.test(panelSource), 'power shows health rows only when both figures are present')
+assert(/label: "Battery size"[\s\S]{0,200}root\.hasHealthInfo \? root\.batteryInfo\.design : root\.batteryInfo\.size/.test(panelSource), 'power labels the nameplate capacity as the battery size, falling back to what it holds')
+assert(/label: "Current capacity"[\s\S]{0,120}root\.batteryInfo\.size/.test(panelSource), 'power shows what the pack charges to today beside its nameplate size')
+assert(/text: "BATTERY HEALTH"/.test(panelSource), 'power gives battery health its own section')
+assert(/label: "Charge cycles"[\s\S]{0,120}visible: !root\.hasHealthInfo/.test(panelSource), 'power keeps the cycle count in the stats grid when there is no health section to hold it')
 JS


### PR DESCRIPTION
## Problem

The power panel shows one capacity row, labelled "Battery size", filled with UPower's `energy-full`. That is what the pack charges to today, not what it was sold as. On a worn battery the two are nowhere near each other and nothing on the panel explains the gap.

My machine reports 90Wh on the label and 64Wh in the panel. Omarchy is right, but it reads like it is wrong, and the number I would actually act on (how much of the battery is left) is not shown at all.

## Change

`omarchy-battery-status --shell` gains two keys, both already in `upower -i` output:

```
design  90Wh    # energy-full-design
health  72%     # capacity, i.e. energy-full / energy-full-design
```

The panel then shows:

* "Battery size" as the nameplate figure
* "Current capacity" as what it charges to now
* a "BATTERY HEALTH" section with the percentage, a bar, the cycle count, and a verdict

| Health | Verdict | Hint |
|---|---|---|
| 90% and up | Great | Practically new |
| 80 to 89% | Normal | Normal wear for its age |
| 70 to 79% | Worn | Worth planning a replacement |
| under 70% | Bad | Time to replace it |

80% is the threshold that matters. It is the line most vendors treat as a pack still being serviceable, and where capacity warranties usually stop.

70% is a rounder judgement call than 80% is, so I'm just pointing that out rather
than defending it too hard. A third of the pack is gone by that point, and it sits in
the band where lithium-ion fade tends to accelerate. Happy to drop it back to three
tiers if you would rather but I think the extra tier earns its place, since a pack at
72% is worn rather than spent and the three-tier version can hide that
unintentionally.

The extra tier splits the bottom of the range rather than the top. With three tiers, "Bad" covers 79% down to 40%, so a pack that just crossed the service line reads the same as one that barely holds a charge. Nobody behaves differently at 95% than at 91%, so the top needs no resolution.

The cycle count moves into the health section, since it is a wear figure rather than a live one.

## Before and after

**Before**

<img width="390" height="210" alt="1-before" src="https://github.com/user-attachments/assets/926ae4e1-b1be-4752-a6df-a053e46f5934" />

**After**

<img width="390" height="330" alt="2-after" src="https://github.com/user-attachments/assets/34ac2fbc-f861-4414-b9a8-257741f67527" />

## When there is no design figure

Some firmware does not report `energy-full-design`, and neither does a desktop UPS. In that case the script prints neither key, `hasHealthInfo` is false, and the panel falls back to exactly what it renders today: "Battery size" showing `energy-full`, cycle count back in the stats grid, no health section. Tested against a stubbed device.

<img width="390" height="210" alt="3-no-design-figure" src="https://github.com/user-attachments/assets/1306c99c-1441-4dc9-b7f3-a8fb903fbe30" />

Both keys are gated together rather than individually, so a device that reports one but not the other cannot leave the two stat columns a row out of step.

## Notes

* Quickshell's `UPower.displayDevice` cannot supply this. It is a composite device and UPower populates neither `energy-full-design` nor `capacity` on it, so the figures have to come from `upower -i` on the real `BAT*` device, which `omarchy-battery-status` already parses.
* Both new figures come off the same call and the same device as `size`, `percentage`
and `time`, so they inherit whatever device selection and number formatting those
already use. `cycles` is the odd one out, read from a `BAT*` glob rather than the
enumerated device. I didn't mess with that one since it doesn't align with this PR.
* The `capacity:` match is anchored. Unanchored it also matches `capacity-level:`, whose value is a word rather than a number, which would report 0% health and silently hide the section. There is a test for that.
* A new pack can report over 100%. The verdict handles it and the bar clamps.

## Tests

* `test/shell.d/battery-status-test.sh` covers both new keys, the `capacity-level` trap, and a device with no design figure emitting neither key while still reporting `size`.
* `test/shell.d/power-test.sh` covers every verdict boundary, unknown health, over 100%, and the panel wiring.
* `./test/all` is green apart from four files that also fail on a clean checkout of `quattro` (`bin-style`, `config`, `snapper`, `unowned-system-paths`).
* Verified in a running session on both paths, and at a 40% larger font scale to check the longer "Current capacity" label does not collide.