### PR TITLE
Open tray menus on left-click when a menu is exposed

### DIFF
--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -834,7 +834,9 @@ BarWidget {
           mouse.accepted = true
         } else if (mouse.button === Qt.MiddleButton) {
           trayItemRoot.modelData.secondaryActivate()
-        } else if (trayItemRoot.modelData.onlyMenu) {
+        } else if (TrayModel.leftClickOpensMenu(trayItemRoot.modelData)) {
+          // onlyMenu covers ItemIsMenu; hasMenu/menu covers AppIndicator
+          // applets that ship a menu but never set ItemIsMenu (#10339).
           trayItemRoot.displayMenu(mouse)
         } else {
           trayItemRoot.modelData.activate()

--- a/shell/plugins/bar/widgets/TrayModel.js
+++ b/shell/plugins/bar/widgets/TrayModel.js
@@ -38,11 +38,25 @@ function ownedByOmarchy(item, layout) {
     || (layoutHasWidget(layout, "omarchy.dropbox") && itemNamed(item, "dropbox"))
 }
 
+// Left-click action for an SNI tray item. Menu-only items (ItemIsMenu) always
+// open the menu. libayatana-appindicator never sets ItemIsMenu and implements
+// Activate as a silent no-op, so any item that exposes a menu must open it on
+// left-click too — otherwise those icons look dead. Items with no menu still
+// take Activate.
+function leftClickOpensMenu(item) {
+  if (!item) return false
+  if (item.onlyMenu) return true
+  if (item.hasMenu) return true
+  if (item.menu) return true
+  return false
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     itemNamed: itemNamed,
     entryId: entryId,
     layoutHasWidget: layoutHasWidget,
-    ownedByOmarchy: ownedByOmarchy
+    ownedByOmarchy: ownedByOmarchy,
+    leftClickOpensMenu: leftClickOpensMenu
   }
 }

--- a/test/shell.d/tray-test.sh
+++ b/test/shell.d/tray-test.sh
@@ -23,4 +23,12 @@ assert(tray.ownedByOmarchy({ id: 'dropbox' }, layout), 'tray suppresses dropbox 
 assert(!tray.ownedByOmarchy({ id: 'dropbox' }, { left: [], center: [], right: [] }), 'tray keeps dropbox when dedicated widget is absent')
 assert(tray.ownedByOmarchy({ id: 'qlBCprNUqU', title: 'localsend' }, { left: [], center: [], right: [] }), 'tray suppresses localsend regardless of layout')
 assert(!tray.ownedByOmarchy({ id: 'nextcloud' }, layout), 'tray keeps unrelated tray items')
+
+// Left-click: menu-only and AppIndicator items with a menu open the menu;
+// items that only implement Activate still activate.
+assert(tray.leftClickOpensMenu({ onlyMenu: true, hasMenu: false, menu: null }), 'tray opens menu when ItemIsMenu is set')
+assert(tray.leftClickOpensMenu({ onlyMenu: false, hasMenu: true, menu: {} }), 'tray opens menu when hasMenu is set without ItemIsMenu')
+assert(tray.leftClickOpensMenu({ onlyMenu: false, hasMenu: false, menu: { path: '/Menu' } }), 'tray opens menu when a menu handle is present')
+assert(!tray.leftClickOpensMenu({ onlyMenu: false, hasMenu: false, menu: null }), 'tray activates when no menu is exposed')
+assert(!tray.leftClickOpensMenu(null), 'tray treats a missing item as activate')
 JS


### PR DESCRIPTION
## Summary

Fixes #10339.

Left-click on menu-bearing tray icons only opened the menu when SNI `ItemIsMenu` was set. libayatana-appindicator never sets that property and implements `Activate` as a silent no-op, so left-click on those icons did nothing even though a working menu was on the bus.

`TrayModel.leftClickOpensMenu` now opens the menu when `onlyMenu`, `hasMenu`, or a menu handle is present. Items with no menu still call `activate()`.

## Test plan

- [x] `bash test/shell.d/tray-test.sh` — covers ItemIsMenu, hasMenu-without-ItemIsMenu, menu handle, activate-only, and null item
- [x] Before/after decision matrix against the issue's AppIndicator probe shape (`onlyMenu=false`, `hasMenu=true`): old path returns false, new path returns true
- [x] Activate-only items still take the activate path

## Notes

Right-click and middle-click are unchanged. Omarchy's own bar widgets are not SNI items and never reach this branch.