### PR TITLE
Read battery aggregate from UPower DisplayDevice

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -32,8 +32,12 @@ else
   aggregate_info=$(upower -i "${batteries[0]}")
 fi
 
-# Per-battery details (native-path, charge thresholds) are not on DisplayDevice.
+# Per-battery details (native-path, charge thresholds, design capacity) are not
+# on DisplayDevice. Keep battery_info as an alias of the primary pack so other
+# work that still reads that name (design/health keys) does not silently no-op
+# when composed onto this change.
 primary_info=$(upower -i "${batteries[0]}")
+battery_info=$primary_info
 
 percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$aggregate_info")
 capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$aggregate_info")
@@ -56,6 +60,20 @@ time_remaining=$(awk '/time to (empty|full)/ {
 power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$aggregate_info")
 state=$(awk '/state/ { print $2; exit }' <<<"$aggregate_info")
 
+# Resolve a pack's sysfs node. native-path is usually bare (BAT0); some drivers
+# emit a full path under /sys/devices/.../power_supply/BAT1. Always join the
+# basename onto power_supply_path so OMARCHY_POWER_SUPPLY_PATH stubs and the
+# class symlink both resolve.
+battery_sysfs_path() {
+  local native_path=$1
+  local name
+
+  [[ -n $native_path ]] || return 1
+  name=$(basename -- "$native_path")
+  [[ -n $name && $name != "/" && $name != "." ]] || return 1
+  printf '%s\n' "$power_supply_path/$name"
+}
+
 # UPower's energy-rate can lag the kernel telemetry by tens of seconds. Sum the
 # instantaneous sysfs reading across every BAT so dual-battery packs stay live
 # and match the aggregate percentage above.
@@ -64,20 +82,19 @@ sysfs_rate_count=0
 for battery in "${batteries[@]}"; do
   battery_detail=$(upower -i "$battery")
   native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_detail")
-  [[ -n $native_path ]] || continue
-  battery_path="$power_supply_path/$native_path"
+  battery_path=$(battery_sysfs_path "$native_path") || continue
 
   if [[ -r $battery_path/power_now ]]; then
     part=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
     sysfs_rate_sum=$(awk -v a="$sysfs_rate_sum" -v b="$part" 'BEGIN { print a + b }')
-    ((sysfs_rate_count++))
+    ((sysfs_rate_count++)) || true
   elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
     part=$(awk \
       -v microamps="$(<"$battery_path/current_now")" \
       -v microvolts="$(<"$battery_path/voltage_now")" \
       'BEGIN { print microamps * microvolts / 1000000000000 }')
     sysfs_rate_sum=$(awk -v a="$sysfs_rate_sum" -v b="$part" 'BEGIN { print a + b }')
-    ((sysfs_rate_count++))
+    ((sysfs_rate_count++)) || true
   fi
 done
 

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -60,7 +60,7 @@ state=$(awk '/state/ { print $2; exit }' <<<"$aggregate_info")
 # instantaneous sysfs reading across every BAT so dual-battery packs stay live
 # and match the aggregate percentage above.
 sysfs_rate_sum=0
-sysfs_rate_found=false
+sysfs_rate_count=0
 for battery in "${batteries[@]}"; do
   battery_detail=$(upower -i "$battery")
   native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_detail")
@@ -70,18 +70,20 @@ for battery in "${batteries[@]}"; do
   if [[ -r $battery_path/power_now ]]; then
     part=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
     sysfs_rate_sum=$(awk -v a="$sysfs_rate_sum" -v b="$part" 'BEGIN { print a + b }')
-    sysfs_rate_found=true
+    ((sysfs_rate_count++))
   elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
     part=$(awk \
       -v microamps="$(<"$battery_path/current_now")" \
       -v microvolts="$(<"$battery_path/voltage_now")" \
       'BEGIN { print microamps * microvolts / 1000000000000 }')
     sysfs_rate_sum=$(awk -v a="$sysfs_rate_sum" -v b="$part" 'BEGIN { print a + b }')
-    sysfs_rate_found=true
+    ((sysfs_rate_count++))
   fi
 done
 
-if [[ $sysfs_rate_found == "true" ]]; then
+# A subtotal is worse than a lagging total: a pack whose native-path does not
+# resolve drops out of the sum, and a low enough result reads as idle below.
+if ((sysfs_rate_count == ${#batteries[@]})); then
   power_rate_raw=$sysfs_rate_sum
 fi
 

--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -18,13 +18,25 @@ case "${1:-}" in
     ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
-[[ -z $battery ]] && exit 0
+# Physical batteries. DisplayDevice is the aggregate UPower synthesises over
+# them and is what the bar icon already reads; percentage/state/time/size must
+# come from there on dual-battery machines or the panel contradicts the icon.
+mapfile -t batteries < <(upower -e 2>/dev/null | grep BAT || true)
+((${#batteries[@]} == 0)) && exit 0
 
-battery_info=$(upower -i "$battery")
+display_device=$(upower -e 2>/dev/null | grep DisplayDevice | head -n 1)
+if [[ -n $display_device ]]; then
+  aggregate_info=$(upower -i "$display_device")
+else
+  # Older or stubbed UPower with no DisplayDevice: fall back to the first BAT.
+  aggregate_info=$(upower -i "${batteries[0]}")
+fi
 
-percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$battery_info")
-capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$battery_info")
+# Per-battery details (native-path, charge thresholds) are not on DisplayDevice.
+primary_info=$(upower -i "${batteries[0]}")
+
+percentage=$(awk '/percentage/ { print int($2); exit }' <<<"$aggregate_info")
+capacity=$(awk '/energy-full:/ { printf "%d", $2; exit }' <<<"$aggregate_info")
 time_remaining=$(awk '/time to (empty|full)/ {
   value = $4
   unit = $5
@@ -40,20 +52,37 @@ time_remaining=$(awk '/time to (empty|full)/ {
     }
   }
   exit
-}' <<<"$battery_info")
-power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
-native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
-battery_path="$power_supply_path/$native_path"
+}' <<<"$aggregate_info")
+power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$aggregate_info")
+state=$(awk '/state/ { print $2; exit }' <<<"$aggregate_info")
 
-# UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
-# the instantaneous sysfs reading when available so the open panel stays live.
-if [[ -r $battery_path/power_now ]]; then
-  power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
-elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
-  power_rate_raw=$(awk \
-    -v microamps="$(<"$battery_path/current_now")" \
-    -v microvolts="$(<"$battery_path/voltage_now")" \
-    'BEGIN { print microamps * microvolts / 1000000000000 }')
+# UPower's energy-rate can lag the kernel telemetry by tens of seconds. Sum the
+# instantaneous sysfs reading across every BAT so dual-battery packs stay live
+# and match the aggregate percentage above.
+sysfs_rate_sum=0
+sysfs_rate_found=false
+for battery in "${batteries[@]}"; do
+  battery_detail=$(upower -i "$battery")
+  native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_detail")
+  [[ -n $native_path ]] || continue
+  battery_path="$power_supply_path/$native_path"
+
+  if [[ -r $battery_path/power_now ]]; then
+    part=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
+    sysfs_rate_sum=$(awk -v a="$sysfs_rate_sum" -v b="$part" 'BEGIN { print a + b }')
+    sysfs_rate_found=true
+  elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
+    part=$(awk \
+      -v microamps="$(<"$battery_path/current_now")" \
+      -v microvolts="$(<"$battery_path/voltage_now")" \
+      'BEGIN { print microamps * microvolts / 1000000000000 }')
+    sysfs_rate_sum=$(awk -v a="$sysfs_rate_sum" -v b="$part" 'BEGIN { print a + b }')
+    sysfs_rate_found=true
+  fi
+done
+
+if [[ $sysfs_rate_found == "true" ]]; then
+  power_rate_raw=$sysfs_rate_sum
 fi
 
 power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
@@ -61,9 +90,9 @@ power_rate=$(awk -v rate="${power_rate_raw:-0}" 'BEGIN {
   sub(/\.0$/, "", rounded)
   print rounded
 }')
-state=$(awk '/state/ { print $2; exit }' <<<"$battery_info")
-threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
-threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$battery_info")
+
+threshold_start=$(awk '/charge-start-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$primary_info")
+threshold_end=$(awk '/charge-end-threshold:/ { gsub(/%/, "", $2); print int($2); exit }' <<<"$primary_info")
 
 [[ -z $threshold_end ]] && threshold_end=$(cat "$power_supply_path"/BAT*/charge_control_end_threshold 2>/dev/null | head -1)
 [[ -z $threshold_start ]] && threshold_start=$(cat "$power_supply_path"/BAT*/charge_control_start_threshold 2>/dev/null | head -1)

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -16,10 +16,146 @@ cat >"$tmp_dir/bin/upower" <<'STUB'
 
 if [[ $1 == "-e" ]]; then
   echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/DisplayDevice"
   exit 0
 fi
 
 if [[ $1 == "-i" ]]; then
+  case "$2" in
+    *DisplayDevice)
+      cat <<'INFO'
+  state:                discharging
+  energy:               28.3 Wh
+  energy-full:          56.7 Wh
+  energy-rate:          7.3 W
+  time to empty:        2.5 hours
+  percentage:           51%
+INFO
+      ;;
+    *BAT0)
+      cat <<'INFO'
+  native-path:          BAT0
+  state:                discharging
+  energy:               28.3 Wh
+  energy-full:          56.7 Wh
+  energy-rate:          7.3 W
+  time to empty:        2.5 hours
+  percentage:           51%
+INFO
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'percentage\t51%' <<<"$shell_output" >/dev/null || fail "battery status reports percentage"
+grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "battery status reports state"
+grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status reports live sysfs power rate"
+grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
+grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
+
+pass "battery status reports single-battery aggregate from DisplayDevice"
+
+# Dual-battery: BAT0 full/idle, BAT1 draining. DisplayDevice holds the combined
+# figures the bar icon already shows; the panel must match it, not BAT0 alone.
+mkdir -p "$tmp_dir/power/BAT1"
+printf '0\n' >"$tmp_dir/power/BAT0/current_now"
+printf '12000000\n' >"$tmp_dir/power/BAT0/voltage_now"
+printf '1500000\n' >"$tmp_dir/power/BAT1/current_now"
+printf '11000000\n' >"$tmp_dir/power/BAT1/voltage_now"
+printf '100\n' >"$tmp_dir/power/BAT0/cycle_count"
+printf '200\n' >"$tmp_dir/power/BAT1/cycle_count"
+
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  echo "/org/freedesktop/UPower/devices/line_power_ADP1"
+  echo "/org/freedesktop/UPower/devices/DisplayDevice"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  case "$2" in
+    *DisplayDevice)
+      cat <<'INFO'
+  state:                discharging
+  energy:               30.15 Wh
+  energy-full:          71.5 Wh
+  energy-rate:          12.0 W
+  time to empty:        2.5 hours
+  percentage:           42.1678%
+INFO
+      ;;
+    *BAT0)
+      cat <<'INFO'
+  native-path:          BAT0
+  state:                fully-charged
+  energy:               23.5 Wh
+  energy-full:          24.0 Wh
+  energy-rate:          0.0 W
+  percentage:           98%
+INFO
+      ;;
+    *BAT1)
+      cat <<'INFO'
+  native-path:          BAT1
+  state:                discharging
+  energy:               6.65 Wh
+  energy-full:          47.5 Wh
+  energy-rate:          12.0 W
+  time to empty:        0.55 hours
+  percentage:           14%
+INFO
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+dual_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'percentage\t42%' <<<"$dual_output" >/dev/null || fail "dual-battery status uses DisplayDevice percentage" "$dual_output"
+grep -Fx $'state\tdischarging' <<<"$dual_output" >/dev/null || fail "dual-battery status uses DisplayDevice state" "$dual_output"
+grep -Fx $'size\t71Wh' <<<"$dual_output" >/dev/null || fail "dual-battery status uses DisplayDevice capacity" "$dual_output"
+grep -Fx $'time\t2h 30m' <<<"$dual_output" >/dev/null || fail "dual-battery status uses DisplayDevice remaining time" "$dual_output"
+# BAT0 contributes 0W, BAT1 1.5A * 11V = 16.5W
+grep -Fx $'rate\t16.5W' <<<"$dual_output" >/dev/null || fail "dual-battery status sums live sysfs power across BATs" "$dual_output"
+grep -Fx $'cycles\t100' <<<"$dual_output" >/dev/null || fail "dual-battery status still reports a cycle count" "$dual_output"
+
+# Guard against regressing to BAT0-only selection.
+if grep -Fx $'percentage\t98%' <<<"$dual_output" >/dev/null; then
+  fail "dual-battery status must not report BAT0-only percentage" "$dual_output"
+fi
+
+pass "dual-battery status matches DisplayDevice aggregate"
+
+# No DisplayDevice (stubbed/old UPower): still report the first BAT.
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  exit 0
+fi
+
+if [[ $1 == "-i" && $2 == *BAT0 ]]; then
   cat <<'INFO'
   native-path:          BAT0
   state:                discharging
@@ -35,14 +171,18 @@ fi
 exit 1
 STUB
 chmod +x "$tmp_dir/bin/upower"
+# Restore BAT0 current for the single-battery sysfs rate path.
+printf '900000\n' >"$tmp_dir/power/BAT0/current_now"
+printf '12000000\n' >"$tmp_dir/power/BAT0/voltage_now"
+# BAT1 still present on disk would sum into rate; remove it for this case.
+rm -rf "$tmp_dir/power/BAT1"
 
-shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+fallback_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
 
-grep -Fx $'percentage\t51%' <<<"$shell_output" >/dev/null || fail "battery status reports percentage"
-grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "battery status reports state"
-grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status reports live sysfs power rate"
-grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
-grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
+grep -Fx $'percentage\t51%' <<<"$fallback_output" >/dev/null || fail "battery status falls back to first BAT without DisplayDevice" "$fallback_output"
+grep -Fx $'rate\t10.8W' <<<"$fallback_output" >/dev/null || fail "fallback still reports live sysfs power rate" "$fallback_output"
+
+pass "battery status falls back when DisplayDevice is absent"
 
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -184,13 +184,80 @@ grep -Fx $'rate\t10.8W' <<<"$fallback_output" >/dev/null || fail "fallback still
 
 pass "battery status falls back when DisplayDevice is absent"
 
-# One pack reporting a full sysfs native-path leaves nothing to read under
-# /sys/class/power_supply, so summing only the packs that resolved would report
-# a fraction of the real draw -- and a low enough rate reads as a held charge.
+# Drivers that report native-path as a full /sys/devices/... path still resolve
+# through the power_supply class basename, so live wattage stays available.
+mkdir -p "$tmp_dir/power/BAT1"
+printf '0\n' >"$tmp_dir/power/BAT0/power_now"
+printf '45000000\n' >"$tmp_dir/power/BAT1/power_now"
+rm -f "$tmp_dir/power/BAT0/current_now" "$tmp_dir/power/BAT0/voltage_now"
+rm -f "$tmp_dir/power/BAT1/current_now" "$tmp_dir/power/BAT1/voltage_now"
+
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  echo "/org/freedesktop/UPower/devices/DisplayDevice"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  case "$2" in
+    *DisplayDevice)
+      cat <<'INFO'
+  state:                charging
+  energy:               56.1 Wh
+  energy-full:          66.0 Wh
+  energy-rate:          5.0 W
+  time to full:         0.3 hours
+  percentage:           85%
+INFO
+      ;;
+    *BAT0)
+      cat <<'INFO'
+  native-path:          BAT0
+  state:                fully-charged
+  energy-full:          24.0 Wh
+  energy-rate:          0.0 W
+  percentage:           98%
+INFO
+      ;;
+    *BAT1)
+      cat <<'INFO'
+  native-path:          /sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0A:01/power_supply/BAT1
+  state:                charging
+  energy-full:          42.0 Wh
+  energy-rate:          5.0 W
+  percentage:           79%
+INFO
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+abs_path_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+# BAT0 0W + BAT1 45W via basename of the absolute native-path; not the stale 5W.
+grep -Fx $'rate\t45W' <<<"$abs_path_output" >/dev/null || fail "absolute native-path still sums live sysfs power" "$abs_path_output"
+grep -Fx $'state\tcharging' <<<"$abs_path_output" >/dev/null || fail "absolute native-path path keeps DisplayDevice state" "$abs_path_output"
+
+pass "battery status resolves absolute native-path via basename"
+
+# A pack with no readable sysfs node at all must not replace the DisplayDevice
+# rate with a subtotal: a low enough result reads as a held charge.
 mkdir -p "$tmp_dir/power/AC"
 printf 'Mains\n' >"$tmp_dir/power/AC/type"
 printf '1\n' >"$tmp_dir/power/AC/online"
 printf '0\n' >"$tmp_dir/power/BAT0/power_now"
+rm -rf "$tmp_dir/power/BAT1"
 
 cat >"$tmp_dir/bin/upower" <<'STUB'
 #!/bin/bash
@@ -227,7 +294,7 @@ INFO
       ;;
     *BAT1)
       cat <<'INFO'
-  native-path:          /sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0A:01/power_supply/BAT1
+  native-path:          BAT1
   state:                charging
   energy-full:          42.0 Wh
   energy-rate:          45.0 W
@@ -251,6 +318,91 @@ grep -Fx $'rate\t45W' <<<"$partial_output" >/dev/null || fail "unresolvable pack
 grep -Fx $'state\tcharging' <<<"$partial_output" >/dev/null || fail "a charging pack is not reported as holding" "$partial_output"
 
 pass "battery status keeps the aggregate rate when a pack has no readable sysfs"
+
+# battery_info remains an alias of the primary pack so concurrent design/health
+# work that still reads that name does not silently drop those keys. Patch a
+# temporary copy the same way #10377 would compose onto this branch.
+tmp_script=$(mktemp)
+trap 'rm -rf "$tmp_dir"; rm -f "$tmp_script"' EXIT
+cp "$ROOT/bin/omarchy-battery-status" "$tmp_script"
+chmod +x "$tmp_script"
+
+python3 - "$tmp_script" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+needle = "  cycles=$(cat \"$power_supply_path\"/BAT*/cycle_count 2>/dev/null | head -1)\n"
+insert = (
+    "  # Composed design/health keys still read battery_info.\n"
+    "  design=$(awk '/energy-full-design:/ { printf \"%d\", $2; exit }' <<<\"$battery_info\")\n"
+    "  health=$(awk '/^[[:space:]]*capacity:/ { gsub(/%/, \"\", $2); printf \"%d\", $2; exit }' <<<\"$battery_info\")\n"
+    "  [[ -n $design ]] && (( design > 0 )) && printf 'design\\t%sWh\\n' \"$design\"\n"
+    "  [[ -n $health ]] && (( health > 0 )) && printf 'health\\t%s%%\\n' \"$health\"\n\n"
+)
+if needle not in text:
+    raise SystemExit("cycles line not found for composition stub")
+path.write_text(text.replace(needle, insert + needle, 1))
+PY
+
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/DisplayDevice"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  case "$2" in
+    *DisplayDevice)
+      cat <<'INFO'
+  state:                discharging
+  energy:               28.3 Wh
+  energy-full:          56.7 Wh
+  energy-rate:          7.3 W
+  time to empty:        2.5 hours
+  percentage:           51%
+INFO
+      ;;
+    *BAT0)
+      cat <<'INFO'
+  native-path:          BAT0
+  state:                discharging
+  energy:               28.3 Wh
+  energy-full:          56.7 Wh
+  energy-full-design:   78.9 Wh
+  energy-rate:          7.3 W
+  time to empty:        2.5 hours
+  percentage:           51%
+  capacity:             71.8%
+  capacity-level:       Normal
+INFO
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+printf '900000\n' >"$tmp_dir/power/BAT0/current_now"
+printf '12000000\n' >"$tmp_dir/power/BAT0/voltage_now"
+rm -f "$tmp_dir/power/BAT0/power_now"
+rm -rf "$tmp_dir/power/AC" "$tmp_dir/power/BAT1"
+
+composed_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$tmp_script" --shell)
+
+grep -Fx $'design\t78Wh' <<<"$composed_output" >/dev/null || fail "battery_info alias still supplies design capacity for composed keys" "$composed_output"
+grep -Fx $'health\t71%' <<<"$composed_output" >/dev/null || fail "battery_info alias still supplies pack health for composed keys" "$composed_output"
+grep -Fx $'health\t0%' <<<"$composed_output" >/dev/null && fail "composed health must not read capacity-level" "$composed_output"
+
+pass "battery_info alias keeps composed design/health keys working"
 
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -184,6 +184,74 @@ grep -Fx $'rate\t10.8W' <<<"$fallback_output" >/dev/null || fail "fallback still
 
 pass "battery status falls back when DisplayDevice is absent"
 
+# One pack reporting a full sysfs native-path leaves nothing to read under
+# /sys/class/power_supply, so summing only the packs that resolved would report
+# a fraction of the real draw -- and a low enough rate reads as a held charge.
+mkdir -p "$tmp_dir/power/AC"
+printf 'Mains\n' >"$tmp_dir/power/AC/type"
+printf '1\n' >"$tmp_dir/power/AC/online"
+printf '0\n' >"$tmp_dir/power/BAT0/power_now"
+
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  echo "/org/freedesktop/UPower/devices/DisplayDevice"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  case "$2" in
+    *DisplayDevice)
+      cat <<'INFO'
+  state:                charging
+  energy:               56.1 Wh
+  energy-full:          66.0 Wh
+  energy-rate:          45.0 W
+  time to full:         0.3 hours
+  percentage:           85%
+INFO
+      ;;
+    *BAT0)
+      cat <<'INFO'
+  native-path:          BAT0
+  state:                fully-charged
+  energy-full:          24.0 Wh
+  energy-rate:          0.0 W
+  percentage:           98%
+  charge-start-threshold: 75%
+  charge-end-threshold:   80%
+INFO
+      ;;
+    *BAT1)
+      cat <<'INFO'
+  native-path:          /sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0A:01/power_supply/BAT1
+  state:                charging
+  energy-full:          42.0 Wh
+  energy-rate:          45.0 W
+  percentage:           79%
+INFO
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+partial_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+
+grep -Fx $'rate\t45W' <<<"$partial_output" >/dev/null || fail "unresolvable pack keeps the DisplayDevice rate instead of a subtotal" "$partial_output"
+grep -Fx $'state\tcharging' <<<"$partial_output" >/dev/null || fail "a charging pack is not reported as holding" "$partial_output"
+
+pass "battery status keeps the aggregate rate when a pack has no readable sysfs"
+
 if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/bin" "$ROOT/test" "$ROOT/shell" "$ROOT/docs"); then
   fail "battery status owns capacity and remaining calculations" "$matches"
 fi


### PR DESCRIPTION
## Summary

Fixes #10244.

`omarchy-battery-status` selected the first `BAT*` device from `upower -e`. On dual-battery laptops that is usually a full, idle internal pack while the removable pack drains, so the power panel percentage disagreed with the bar icon (which already reads UPower's combined `DisplayDevice`).

The script now prefers `DisplayDevice` for percentage, state, remaining time, and capacity, sums live sysfs power across every BAT, and still reads charge thresholds / cycle count from the first physical battery. If `DisplayDevice` is missing it falls back to the first BAT.

## Test plan

- [x] `bash test/shell.d/battery-status-test.sh`
  - single-battery DisplayDevice path (existing rate/time assertions)
  - dual-battery BAT0-full / BAT1-draining stub: percentage/state/size/time from DisplayDevice, rate sum across BATs, rejects BAT0-only 98%
  - no-DisplayDevice fallback to first BAT
- [x] Live single-battery machine: script percentage matches `upower -i .../DisplayDevice`
- [x] Pre-fix dual-battery stub reproduction: reported `percentage 98%` / `fully-charged` from BAT0

## Notes

Charge-threshold detection still uses the primary BAT's UPower/sysfs threshold fields; those are not published on DisplayDevice.