### PR TITLE
Stop the keybindings scanner spinning on hl list accessors

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -186,8 +186,16 @@ end
 
 local noop
 noop = setmetatable({}, {
-  __index = function()
+  __index = function(_, key)
+    -- ipairs walks 1..n until it sees nil. Returning noop for numeric
+    -- keys makes `for _, p in ipairs(hl.get_loaded_plugins())` spin.
+    if type(key) == "number" then
+      return nil
+    end
     return noop
+  end,
+  __len = function()
+    return 0
   end,
   __call = function()
     return noop
@@ -221,7 +229,10 @@ hl = setmetatable({
     return nil
   end,
 }, {
-  __index = function()
+  __index = function(_, key)
+    if type(key) == "number" then
+      return nil
+    end
     return noop
   end,
 })

--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -200,6 +200,41 @@ noop = setmetatable({}, {
   __call = function()
     return noop
   end,
+  -- Stock qconsole.lua does monitor.scale <= 0 then height / scale - reserved.
+  -- Without these, Lua raises and pcall aborts the scan before user bindings.
+  __lt = function()
+    return false
+  end,
+  __le = function()
+    return false
+  end,
+  __eq = function()
+    return false
+  end,
+  __add = function()
+    return 0
+  end,
+  __sub = function()
+    return 0
+  end,
+  __mul = function()
+    return 0
+  end,
+  __div = function()
+    return 0
+  end,
+  __mod = function()
+    return 0
+  end,
+  __pow = function()
+    return 0
+  end,
+  __unm = function()
+    return 0
+  end,
+  __idiv = function()
+    return 0
+  end,
 })
 
 hl = setmetatable({

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -186,16 +186,26 @@ pass "chords with the same label but different actions stay apart"
 # User configs that iterate hl.get_loaded_plugins() must not hang the scanner.
 # Use a standalone hyprland.lua so dofile actually reaches the loop; appending
 # it after the default tree can fail earlier inside qconsole.lua.
+stub_hyprctl <<BINDS
+$(lua_bind 64 "" "Spin probe")
+BINDS
+
 spin_home="$tmpdir/spin-home"
 mkdir -p "$spin_home/.config/hypr"
 cat >"$spin_home/.config/hypr/hyprland.lua" <<'LUA'
 for _, p in ipairs(hl.get_loaded_plugins()) do
 end
+
+hl.bind("SUPER + P", hl.dsp.exec_cmd("true"), { description = "Spin probe" })
 LUA
-timeout 2 env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$spin_home" \
+# Hyprland reports a Lua bind without its key, so a rendered chord is the scan
+# reaching past the loop. Exiting alone would not say that: a stub that raised
+# on a numeric index also terminates, losing every bind declared after it.
+spin_rendered=$(timeout 2 env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$spin_home" \
   XDG_CACHE_HOME="$tmpdir/cache-spin" OMARCHY_PATH="$ROOT" \
-  bash "$ROOT/bin/omarchy-menu-keybindings" --print >/dev/null ||
-  fail "the keybindings scanner terminates when a config iterates hl.get_loaded_plugins()"
+  bash "$ROOT/bin/omarchy-menu-keybindings" --print) &&
+  grep -q 'SUPER + P  *→ Spin probe' <<<"$spin_rendered" ||
+  fail "the keybindings scanner terminates when a config iterates hl.get_loaded_plugins()" "$spin_rendered"
 pass "the keybindings scanner terminates when a config iterates hl.get_loaded_plugins()"
 
 # An unresolved Lua bind reports no dispatcher at all, so nothing says the two

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -183,6 +183,21 @@ rendered=$(keybindings)
   fail "chords with the same label but different actions stay apart" "$rendered"
 pass "chords with the same label but different actions stay apart"
 
+# User configs that iterate hl.get_loaded_plugins() must not hang the scanner.
+# Use a standalone hyprland.lua so dofile actually reaches the loop; appending
+# it after the default tree can fail earlier inside qconsole.lua.
+spin_home="$tmpdir/spin-home"
+mkdir -p "$spin_home/.config/hypr"
+cat >"$spin_home/.config/hypr/hyprland.lua" <<'LUA'
+for _, p in ipairs(hl.get_loaded_plugins()) do
+end
+LUA
+timeout 2 env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$spin_home" \
+  XDG_CACHE_HOME="$tmpdir/cache-spin" OMARCHY_PATH="$ROOT" \
+  bash "$ROOT/bin/omarchy-menu-keybindings" --print >/dev/null ||
+  fail "the keybindings scanner terminates when a config iterates hl.get_loaded_plugins()"
+pass "the keybindings scanner terminates when a config iterates hl.get_loaded_plugins()"
+
 # An unresolved Lua bind reports no dispatcher at all, so nothing says the two
 # chords run the same thing, whatever their label promises.
 stub_hyprctl <<BINDS

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -208,6 +208,27 @@ spin_rendered=$(timeout 2 env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$spin_ho
   fail "the keybindings scanner terminates when a config iterates hl.get_loaded_plugins()" "$spin_rendered"
 pass "the keybindings scanner terminates when a config iterates hl.get_loaded_plugins()"
 
+# Stock ~/.config/hypr loads qconsole before the user's bindings.lua. A stub
+# that cannot compare monitor.scale aborts the scan there, so a bind declared
+# after omarchy.lua never reaches the menu. Hyprland reports the Lua bind
+# without its key, so SUPER + Y can only come from the scan getting past fit().
+stub_hyprctl <<BINDS
+$(lua_bind 64 "" "Probe user bind")
+BINDS
+
+probe_home="$tmpdir/probe-home"
+mkdir -p "$probe_home/.config"
+cp -r "$ROOT/config/hypr" "$probe_home/.config/hypr"
+cat >>"$probe_home/.config/hypr/bindings.lua" <<'LUA'
+o.bind("SUPER + Y", "Probe user bind", "true")
+LUA
+probe_rendered=$(env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$probe_home" \
+  XDG_CACHE_HOME="$tmpdir/cache-probe" OMARCHY_PATH="$ROOT" \
+  bash "$ROOT/bin/omarchy-menu-keybindings" --print)
+grep -q 'SUPER + Y  *→ Probe user bind' <<<"$probe_rendered" ||
+  fail "the keybindings scanner reaches user binds after qconsole" "$probe_rendered"
+pass "the keybindings scanner reaches user binds after qconsole"
+
 # An unresolved Lua bind reports no dispatcher at all, so nothing says the two
 # chords run the same thing, whatever their label promises.
 stub_hyprctl <<BINDS


### PR DESCRIPTION
User configs that `ipairs(hl.get_loaded_plugins())` hang `omarchy-menu-keybindings` at 100% CPU. The Hyprland stub's `__index` returned a table for numeric keys, so `ipairs` never saw nil.

Return nil for numeric keys on the noop/`hl` metatables. Give noop comparison (`__lt`, `__le`, `__eq`) and arithmetic metamethods so stock `qconsole.lua`'s `monitor.scale <= 0` and the following `height / scale - reserved` do not raise; `pcall` no longer aborts the scan before `require("hypr.bindings")`.

The regression tests load a standalone `hyprland.lua` that iterates `hl.get_loaded_plugins()` and binds a chord after the loop, and a stock user config (`require("default.hypr.omarchy")` then `require("hypr.bindings")`) with a probe bind in `~/.config/hypr/bindings.lua` that must render as `SUPER + Y`.

Fixes #10214

Related hang/missing-binds reports that need both of these stub changes: #7025, #8819, #9052, #9395. This does not time-box the lua child, so a config that spins for some other reason can still hang the menu.