### PR TITLE
Record a failed custom bar so the default bar can load

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -253,9 +253,12 @@ ShellRoot {
     onActiveChanged: if (!active) shell.bar = null
     onStatusChanged: {
       if (status === Loader.Error) {
-        var detail = errorString && errorString() ? errorString() : ""
-        console.warn("bar option " + shell.activeBarId + " failed to load, falling back to " + shell.defaultBarId + ":", detail)
-        shell.failedBarId = shell.activeBarId
+        var failedId = shell.activeBarId
+        shell.failedBarId = failedId
+        var detail = ""
+        if (sourceComponent)
+          detail = sourceComponent.errorString()
+        console.warn("bar option " + failedId + " failed to load, falling back to " + shell.defaultBarId + ":", detail)
       }
     }
   }
@@ -639,11 +642,11 @@ ShellRoot {
         }
         onStatusChanged: {
           if (status === Loader.Error) {
-            // Loader.errorString() reflects the source-load failure even when
-            // sourceComponent is null. Surface both so the user sees something
-            // actionable instead of a panel that silently refuses to open.
-            var detail = errorString && errorString() ? errorString() : ""
-            if (!detail && sourceComponent) detail = sourceComponent.errorString()
+            // Bare errorString() is unbound on Loader and aborts this handler
+            // before hide(). Component.errorString is the QML error text.
+            var detail = ""
+            if (sourceComponent)
+              detail = sourceComponent.errorString()
             console.warn("panel plugin " + panelEntry.pluginId + " failed to load:", detail)
             shell.hide(panelEntry.pluginId)
           }

--- a/test/shell.d/bar-load-fallback-test.sh
+++ b/test/shell.d/bar-load-fallback-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+shell="$ROOT/shell/shell.qml"
+handler=$(awk '/id: pluginBarLoader/,/^  }/' "$shell")
+
+grep -q 'shell.failedBarId = failedId' <<<"$handler" ||
+  fail "a failed custom bar still records failedBarId"
+if grep -q 'errorString && errorString()' <<<"$handler"; then
+  fail "bar load errors must not call an unbound errorString identifier"
+fi
+
+failed_line=$(grep -n 'shell.failedBarId = failedId' <<<"$handler" | head -n 1 | cut -d: -f1)
+error_line=$(grep -n 'sourceComponent.errorString()' <<<"$handler" | head -n 1 | cut -d: -f1)
+[[ -n $failed_line && -n $error_line ]] ||
+  fail "bar load errors record failedBarId and read Component.errorString"
+(( failed_line < error_line )) ||
+  fail "failedBarId is recorded before errorString is read"
+pass "a failed custom bar still records failedBarId"


### PR DESCRIPTION
A custom bar that fails to load never fell back to `omarchy.bar`. `pluginBarLoader.onStatusChanged` called an unbound `errorString()` and threw before `failedBarId` was set.

Record `failedBarId` first, then read `sourceComponent.errorString()`. Snapshot the failed id for the warn so fallback is not logged as the default bar failing to load itself.

Fixes #10324
