### PR TITLE
Keep empty JSON text empty on custom bar command modules

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -1786,6 +1786,7 @@ Item {
     property string outputText: ""
     property string outputTooltip: ""
     property bool outputActive: false
+    property bool jsonProvidedText: false
 
     function setting(name, fallback) {
       var value = settings ? settings[name] : undefined
@@ -1796,13 +1797,22 @@ Item {
       var data = Util.parseModuleJson(raw)
       var klass = data.class || data.alt || ""
 
-      outputText = data.text || String(raw || "").trim()
+      if (data && typeof data === "object" && data.text !== undefined && data.text !== null) {
+        outputText = String(data.text)
+        jsonProvidedText = true
+      } else if (data && typeof data === "object") {
+        outputText = ""
+        jsonProvidedText = false
+      } else {
+        outputText = String(raw || "").trim()
+        jsonProvidedText = false
+      }
       outputTooltip = data.tooltip || String(setting("tooltip", ""))
       outputActive = klass === "active" || (Array.isArray(klass) && klass.indexOf("active") !== -1)
     }
 
     bar: root
-    text: outputText || String(setting("text", ""))
+    text: jsonProvidedText ? outputText : (outputText || String(setting("text", "")))
     tooltipText: outputTooltip || String(setting("tooltip", ""))
     active: outputActive
     keepSpace: setting("keepSpace", false) === true

--- a/test/shell.d/bar-command-module-test.sh
+++ b/test/shell.d/bar-command-module-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+bar="$ROOT/shell/plugins/bar/Bar.qml"
+
+if grep -q 'outputText = data.text ||' "$bar"; then
+  fail "command modules do not treat empty JSON text as missing"
+fi
+grep -Fq 'data.text !== undefined && data.text !== null' "$bar" ||
+  fail "command modules treat an explicit JSON text field as provided"
+grep -Fq 'jsonProvidedText = true' "$bar" ||
+  fail "command modules remember when JSON supplied a text field"
+grep -Fq 'text: jsonProvidedText ? outputText : (outputText || String(setting("text", "")))' "$bar" ||
+  fail "command modules keep empty JSON text empty instead of falling back to setting text"
+pass "command modules keep empty JSON text empty"


### PR DESCRIPTION
A custom command module that printed `{"text":""}` still rendered the raw JSON. `data.text || raw` treated an empty string as missing, so hide-when-empty widgets were impossible.

Remember when JSON supplied a `text` field (including empty) and only fall back to `setting("text")` when it did not.

Fixes #10319
