### PR TITLE
Allow cloned bar plugins to receive host properties after load

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -12,14 +12,16 @@ Item {
   id: root
 
   // The omarchy-shell host injects omarchyPath from OMARCHY_PATH.
-  required property string omarchyPath
+  property string omarchyPath: ""
   // Injected by the host shell so bar slots can resolve enabled widgets.
-  required property var barWidgetRegistry
+  // Not `required`: a cloned bar is a Loader source, so the host can only
+  // assign these after construction.
+  property var barWidgetRegistry: null
   // Injected by the host shell every time shell.json is reloaded. Holds the
   // `bar:` subtree: position, centerAnchor, layout. The host owns file IO;
   // the bar just renders whatever it's handed. The bar font follows the
   // OS-level fontconfig monospace binding — it is not stored in shell.json.
-  required property var barConfig
+  property var barConfig: null
   // Injected by the host shell. Used for shell-wide actions such as opening
   // settings and persisting inline widget state.
   property var shell: null
@@ -1552,7 +1554,8 @@ Item {
     // plugin enabled/disabled, etc.). Reading the `widgets` property creates
     // the binding dependency — the wrapped function call alone wouldn't.
     readonly property var registryComponent: {
-      var w = root.barWidgetRegistry.widgets
+      var w = root.barWidgetRegistry && root.barWidgetRegistry.widgets
+      if (!w) return null
       if (customType) return null
       var registryName = root.canonicalWidgetId(moduleName)
       return w[registryName] ? w[registryName].component : null

--- a/test/shell.d/bar-clone-required-test.sh
+++ b/test/shell.d/bar-clone-required-test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+bar="$ROOT/shell/plugins/bar/Bar.qml"
+
+if grep -E '^[[:space:]]*required property (string omarchyPath|var barWidgetRegistry|var barConfig)' "$bar"; then
+  fail "cloned bars can assign host properties after construction"
+fi
+grep -Fq 'root.barWidgetRegistry && root.barWidgetRegistry.widgets' "$bar" ||
+  fail "cloned bars tolerate a null widget registry before host assignment"
+pass "cloned bars can assign host properties after construction"


### PR DESCRIPTION
`omarchy plugin clone omarchy.bar` produced a bar that could never load. `Bar.qml` declared `required` host properties, and the plugin `Loader` only assigns them in `onLoaded` — after construction, which `required` rejects.

Drop `required`, default the host properties, and guard `barWidgetRegistry.widgets` while the clone is still unconfigured.

Fixes #10325
