### PR TITLE
Report combined battery percentage from UPower DisplayDevice

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -18,7 +18,18 @@ case "${1:-}" in
     ;;
 esac
 
-battery=$(upower -e 2>/dev/null | grep BAT | head -n 1)
+upower_devices=$(upower -e 2>/dev/null)
+pack_count=$(grep -c BAT <<<"$upower_devices" || true)
+# DisplayDevice is the combined view. Use it only when more than one pack
+# exists; a single pack must stay on BAT* so sysfs power_now still applies.
+if (( pack_count > 1 )); then
+  battery=$(grep DisplayDevice <<<"$upower_devices" | head -n 1)
+else
+  battery=""
+fi
+if [[ -z $battery ]]; then
+  battery=$(grep BAT <<<"$upower_devices" | head -n 1)
+fi
 [[ -z $battery ]] && exit 0
 
 battery_info=$(upower -i "$battery")
@@ -44,12 +55,14 @@ time_remaining=$(awk '/time to (empty|full)/ {
 power_rate_raw=$(awk '/energy-rate/ { print $2; exit }' <<<"$battery_info")
 native_path=$(awk '/native-path/ { print $2; exit }' <<<"$battery_info")
 battery_path="$power_supply_path/$native_path"
+# DisplayDevice's native-path is not a sysfs battery node.
+[[ -d $battery_path && -r $battery_path/type ]] || battery_path=""
 
 # UPower's energy-rate can lag the kernel telemetry by tens of seconds. Use
 # the instantaneous sysfs reading when available so the open panel stays live.
-if [[ -r $battery_path/power_now ]]; then
+if [[ -n $battery_path && -r $battery_path/power_now ]]; then
   power_rate_raw=$(awk -v microwatts="$(<"$battery_path/power_now")" 'BEGIN { print microwatts / 1000000 }')
-elif [[ -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
+elif [[ -n $battery_path && -r $battery_path/current_now && -r $battery_path/voltage_now ]]; then
   power_rate_raw=$(awk \
     -v microamps="$(<"$battery_path/current_now")" \
     -v microvolts="$(<"$battery_path/voltage_now")" \

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 mkdir -p "$tmp_dir/bin"
 mkdir -p "$tmp_dir/power/BAT0"
+printf 'Battery\n' >"$tmp_dir/power/BAT0/type"
 printf '900000\n' >"$tmp_dir/power/BAT0/current_now"
 printf '12000000\n' >"$tmp_dir/power/BAT0/voltage_now"
 cat >"$tmp_dir/bin/upower" <<'STUB'
@@ -49,3 +50,123 @@ if matches=$(rg -n 'omarchy-battery-(capacity|remaining|remaining-time)' "$ROOT/
 fi
 
 pass "battery status owns capacity and remaining calculations"
+
+# Ordinary laptops still enumerate DisplayDevice. Combined capacity is only
+# for multiple packs; one BAT* must keep the sysfs live rate.
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/DisplayDevice"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  if [[ $* == *DisplayDevice* ]]; then
+    cat <<'INFO'
+  native-path:          DisplayDevice
+  state:                discharging
+  energy-full:          56.7 Wh
+  energy-rate:          7.3 W
+  time to empty:        2.5 hours
+  percentage:           12%
+INFO
+  else
+    cat <<'INFO'
+  native-path:          BAT0
+  state:                discharging
+  energy-full:          56.7 Wh
+  energy-rate:          7.3 W
+  time to empty:        2.5 hours
+  percentage:           51%
+INFO
+  fi
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+grep -Fx $'percentage\t51%' <<<"$shell_output" >/dev/null ||
+  fail "single-pack status stays on BAT0 when DisplayDevice is also listed" "$shell_output"
+grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null ||
+  fail "single-pack status keeps the live sysfs power rate" "$shell_output"
+pass "single-pack status stays on BAT0 when DisplayDevice is also listed"
+
+# Dual-battery machines report a combined DisplayDevice; reading only BAT0
+# leaves the power panel stuck on the idle internal pack.
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/battery_BAT0"
+  echo "/org/freedesktop/UPower/devices/battery_BAT1"
+  echo "/org/freedesktop/UPower/devices/DisplayDevice"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  if [[ $* == *DisplayDevice* ]]; then
+    cat <<'INFO'
+  native-path:          DisplayDevice
+  state:                discharging
+  energy:               24.76 Wh
+  energy-full:          66.01 Wh
+  energy-rate:          12.0 W
+  time to empty:        2.0 hours
+  percentage:           37%
+INFO
+  else
+    cat <<'INFO'
+  native-path:          BAT0
+  state:                fully-charged
+  energy:               23.5 Wh
+  energy-full:          24.0 Wh
+  energy-rate:          0.0 W
+  percentage:           98%
+INFO
+  fi
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+grep -Fx $'percentage\t37%' <<<"$shell_output" >/dev/null ||
+  fail "battery status uses UPower DisplayDevice on dual-battery systems" "$shell_output"
+grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null ||
+  fail "battery status uses DisplayDevice state, not BAT0" "$shell_output"
+pass "battery status uses UPower DisplayDevice on dual-battery systems"
+
+# DisplayDevice exists on desktops with no pack. Combined-capacity display is
+# only meaningful when a BAT* device is also enumerated.
+cat >"$tmp_dir/bin/upower" <<'STUB'
+#!/bin/bash
+
+if [[ $1 == "-e" ]]; then
+  echo "/org/freedesktop/UPower/devices/DisplayDevice"
+  exit 0
+fi
+
+if [[ $1 == "-i" ]]; then
+  cat <<'INFO'
+  native-path:          DisplayDevice
+  state:                unknown
+  percentage:           0%
+INFO
+  exit 0
+fi
+
+exit 1
+STUB
+chmod +x "$tmp_dir/bin/upower"
+
+shell_output=$(OMARCHY_POWER_SUPPLY_PATH="$tmp_dir/power" PATH="$tmp_dir/bin:$PATH" "$ROOT/bin/omarchy-battery-status" --shell)
+[[ -z $shell_output ]] ||
+  fail "battery status ignores DisplayDevice when no BAT pack exists" "$shell_output"
+pass "battery status ignores DisplayDevice when no BAT pack exists"


### PR DESCRIPTION
`omarchy-battery-status` always read the first `BAT*` pack. Dual-battery laptops then showed the idle internal pack instead of the combined percentage.

Use UPower's DisplayDevice only when more than one pack is enumerated. A single pack stays on that `BAT*` device so the live sysfs wattage path still runs. DisplayDevice's native-path is not a sysfs battery node.

Fixes #10244
