### PR TITLE
Subscribe to PrepareForSleep without system-bus BecomeMonitor

### DIFF
--- a/bin/omarchy-system-sleep-monitor
+++ b/bin/omarchy-system-sleep-monitor
@@ -9,7 +9,7 @@ consume_sleep_events() {
   sleep_lock="$OMARCHY_PATH/bin/omarchy-system-sleep-lock"
 
   while IFS= read -r line; do
-    if [[ $line == *"boolean true"* ]]; then
+    if [[ $line == *"PrepareForSleep (true"* ]]; then
       "$sleep_lock"
       return 0
     fi
@@ -20,8 +20,10 @@ monitor_sleep_events() {
   local monitor_fd monitor_pid status
 
   coproc SLEEP_EVENTS {
-    exec dbus-monitor --system \
-      "type='signal',sender='org.freedesktop.login1',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'"
+    # BecomeMonitor on the system bus is root-only, so a user session of the
+    # old monitor tool fell back to deprecated eavesdropping. gdbus uses
+    # AddMatch, which a session is allowed to do for login1 signals.
+    exec gdbus monitor --system --dest org.freedesktop.login1 --object-path /org/freedesktop/login1
   }
   monitor_fd=${SLEEP_EVENTS[0]}
   monitor_pid=$SLEEP_EVENTS_PID

--- a/test/shell.d/sleep-monitor-test.sh
+++ b/test/shell.d/sleep-monitor-test.sh
@@ -5,6 +5,17 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 sleep_monitor="$ROOT/bin/omarchy-system-sleep-monitor"
+
+if grep -q 'exec dbus-monitor' "$sleep_monitor"; then
+  fail "sleep monitor does not use dbus-monitor BecomeMonitor on the system bus"
+fi
+grep -q 'gdbus monitor --system' "$sleep_monitor" ||
+  fail "sleep monitor subscribes to login1 with gdbus"
+if grep -q 'boolean true' "$sleep_monitor"; then
+  fail "sleep monitor does not treat dbus-monitor boolean true as a sleep event"
+fi
+pass "sleep monitor subscribes to login1 with gdbus"
+
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -24,11 +35,11 @@ done
 exec "$@"
 SH
 
-cat >"$mock_bin/dbus-monitor" <<'SH'
+cat >"$mock_bin/gdbus" <<'SH'
 #!/bin/bash
 
 echo "$$" >"$PRODUCER_PID_FILE"
-printf '   boolean true\n'
+printf '/org/freedesktop/login1: org.freedesktop.login1.Manager.PrepareForSleep (true,)\n'
 exec sleep 30
 SH
 
@@ -40,7 +51,7 @@ SH
 
 chmod +x \
   "$mock_bin/systemd-inhibit" \
-  "$mock_bin/dbus-monitor" \
+  "$mock_bin/gdbus" \
   "$mock_omarchy/bin/omarchy-system-sleep-lock"
 ln -s "$sleep_monitor" "$mock_omarchy/bin/omarchy-system-sleep-monitor"
 
@@ -68,14 +79,14 @@ pass "sleep monitor reaps its event producer"
 
 # Terminating the monitor must also clean up the producer instead of orphaning
 # it under the user systemd instance.
-cat >"$mock_bin/dbus-monitor" <<'SH'
+cat >"$mock_bin/gdbus" <<'SH'
 #!/bin/bash
 
 sleep 0.1
 echo "$$" >"$PRODUCER_PID_FILE"
 exec sleep 30
 SH
-chmod +x "$mock_bin/dbus-monitor"
+chmod +x "$mock_bin/gdbus"
 rm -f "$producer_pid_file"
 
 OMARCHY_PATH="$mock_omarchy" \
@@ -104,3 +115,22 @@ if kill -0 "$producer_pid" 2>/dev/null; then
   fail "sleep monitor cleans up its producer when terminated" "producer still running: $producer_pid"
 fi
 pass "sleep monitor cleans up its producer when terminated"
+
+# gdbus monitor dumps every signal on the login1 object, including property
+# changes whose payload contains true. Only PrepareForSleep (true is sleep.
+: >"$lock_log"
+OMARCHY_PATH="$mock_omarchy" LOCK_LOG="$lock_log" "$sleep_monitor" --consume <<'EOF'
+   boolean true
+/org/freedesktop/login1: org.freedesktop.DBus.Properties.PropertiesChanged ('org.freedesktop.login1.Manager', {'IdleHint': <true>}, @as [])
+/org/freedesktop/login1: org.freedesktop.login1.Manager.PrepareForSleep (false,)
+EOF
+[[ ! -s $lock_log ]] ||
+  fail "sleep monitor ignores non-sleep gdbus lines" "$(<"$lock_log")"
+pass "sleep monitor ignores non-sleep gdbus lines"
+
+OMARCHY_PATH="$mock_omarchy" LOCK_LOG="$lock_log" "$sleep_monitor" --consume <<'EOF'
+/org/freedesktop/login1: org.freedesktop.login1.Manager.PrepareForSleep (true,)
+EOF
+[[ $(<"$lock_log") == "locked" ]] ||
+  fail "sleep monitor locks on gdbus PrepareForSleep true" "$(<"$lock_log")"
+pass "sleep monitor locks on gdbus PrepareForSleep true"


### PR DESCRIPTION
`dbus-monitor --system` uses BecomeMonitor, which a user session is denied, so every start fell back to deprecated eavesdropping.

Subscribe with `gdbus monitor` (AddMatch) and treat only `PrepareForSleep (true` as sleep. Other signals on the login1 object must not lock the session.

Fixes #10317
