### PR TITLE
Strip password keyring auth from sddm-autologin too

### DIFF
--- a/install/login/sddm.sh
+++ b/install/login/sddm.sh
@@ -5,3 +5,7 @@ if [[ -f /etc/pam.d/sddm ]]; then
   sed -i '/-auth.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
   sed -i '/-password.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
 fi
+if [[ -f /etc/pam.d/sddm-autologin ]]; then
+  sed -i '/-auth.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm-autologin
+  sed -i '/-password.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm-autologin
+fi

--- a/migrations/1788600002.sh
+++ b/migrations/1788600002.sh
@@ -1,0 +1,21 @@
+echo "Strip password keyring auth from the SDDM autologin PAM stack"
+
+# Autologin uses /etc/pam.d/sddm-autologin, not sddm. Existing installs that
+# already ran install/login/sddm.sh still have gnome-keyring auth/password
+# modules on the autologin stack, which create an encrypted login keyring
+# against Omarchy's passwordless default.
+
+pam=/etc/pam.d/sddm-autologin
+[[ -f $pam ]] || exit 0
+
+if ! grep -qE -- '-auth.*pam_gnome_keyring\.so|-password.*pam_gnome_keyring\.so' "$pam"; then
+  exit 0
+fi
+
+if (( EUID == 0 )); then
+  sed -i '/-auth.*pam_gnome_keyring\.so/d' "$pam"
+  sed -i '/-password.*pam_gnome_keyring\.so/d' "$pam"
+else
+  sudo sed -i '/-auth.*pam_gnome_keyring\.so/d' "$pam"
+  sudo sed -i '/-password.*pam_gnome_keyring\.so/d' "$pam"
+fi

--- a/test/shell.d/sddm-keyring-test.sh
+++ b/test/shell.d/sddm-keyring-test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+script="$ROOT/install/login/sddm.sh"
+shipped_migration="$ROOT/migrations/1788600002.sh"
+
+grep -q 'sddm-autologin' "$script" ||
+  fail "SDDM keyring strip covers the autologin PAM stack"
+grep -q "/etc/pam.d/sddm-autologin" "$script" ||
+  fail "SDDM keyring strip names the autologin PAM file"
+[[ -f $shipped_migration ]] || fail "existing installs get an autologin keyring migration"
+[[ $(head -n 1 "$shipped_migration") == echo* ]] ||
+  fail "autologin keyring migration starts with an echo"
+! grep -q '^#!' "$shipped_migration" || fail "autologin keyring migration has no shebang"
+grep -Fxq 'pam=/etc/pam.d/sddm-autologin' "$shipped_migration" ||
+  fail "the production autologin PAM path is a fixed literal"
+if grep -q 'OMARCHY_.*PAM' "$shipped_migration"; then
+  fail "the migration does not accept caller-controlled privileged paths"
+fi
+pass "SDDM keyring strip covers password and autologin stacks"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+mkdir -p "$test_dir/bin"
+pam="$test_dir/sddm-autologin"
+calls="$test_dir/calls"
+
+cat >"$test_dir/bin/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"${CALLS:?}"
+exec "$@"
+STUB
+chmod +x "$test_dir/bin/sudo"
+
+sed "s|^pam=/etc/pam.d/sddm-autologin$|pam=$pam|" "$shipped_migration" >"$test_dir/migration.sh"
+
+cat >"$pam" <<'PAM'
+#%PAM-1.0
+auth        required    pam_permit.so
+-auth       optional    pam_gnome_keyring.so
+account     include     system-local-login
+password    include     system-local-login
+-password   optional    pam_gnome_keyring.so use_authtok
+-session    optional    pam_gnome_keyring.so auto_start
+session     include     system-local-login
+PAM
+
+: >"$calls"
+CALLS="$calls" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$test_dir/migration.sh" >/dev/null
+
+grep -q 'pam_permit.so' "$pam" || fail "keyring strip keeps required autologin auth"
+grep -q 'pam_gnome_keyring.so auto_start' "$pam" ||
+  fail "keyring strip keeps session keyring auto_start"
+if grep -qE -- '-auth.*pam_gnome_keyring\.so|-password.*pam_gnome_keyring\.so' "$pam"; then
+  fail "keyring strip removes autologin auth and password gnome-keyring modules"
+fi
+grep -q '^sudo sed' "$calls" || fail "non-root migration elevates with sudo"
+pass "keyring strip removes autologin auth and password gnome-keyring modules"
+
+: >"$calls"
+CALLS="$calls" PATH="$test_dir/bin:$PATH" bash -euo pipefail "$test_dir/migration.sh" >/dev/null
+[[ ! -s $calls ]] || fail "an already-stripped autologin stack is a no-op" "$(<"$calls")"
+pass "an already-stripped autologin stack is a no-op"


### PR DESCRIPTION
`install/login/sddm.sh` stripped gnome-keyring auth/password from `/etc/pam.d/sddm`. Autologin uses `/etc/pam.d/sddm-autologin`, so passwordless machines still created an encrypted login keyring.

Strip the same `-auth`/`-password` modules from the autologin stack, leave `-session auto_start`, and migrate existing installs.

Fixes #10243
