### PR TITLE
Add pre-update hook point to the update flow

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -38,6 +38,7 @@ if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
 
   omarchy-update-stay-awake start
 
+  omarchy-hook pre-update
   omarchy-update-dev
   omarchy-update-keyring
 


### PR DESCRIPTION
Runs omarchy-hook pre-update before the dev checkout pull, symmetric with the existing post-update hook. Enables pre-pull automation such as stashing local changes so pull --ff-only succeeds.