### PR TITLE
Add reverse keybinding inspector with safe chord capture

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -8,6 +8,9 @@
 declare -A LUA_BIND_KEY_MAP
 declare -A LUA_BIND_DISPATCHER_MAP
 declare -A LUA_BIND_ARG_MAP
+declare -A LUA_BIND_INSPECTABLE_MAP
+declare -A LUA_BIND_INSPECTION_REASON_MAP
+declare -A LUA_BIND_GLOBAL_BYPASS_MAP
 
 # Hyprland reports XKB keycodes for code: bindings. Resolve them to symbols
 # via the compiled keymap, with a small fallback for common keys so the menu
@@ -68,18 +71,33 @@ parse_keycodes() {
 
 # Supplement `hyprctl binds` for Lua-only binds that Hyprland currently
 # reports as dispatcher __lua and without their original key for code: binds.
+# Inspectability is decided here from Lua opts and again in dynamic_bindings
+# from hyprctl flags; both must agree, and hyprctl-only flags still override.
 build_lua_bind_cache() {
-  local modmask description key dispatcher arg cache_key
+  local modmask description key dispatcher arg inspectable inspection_reason global_bypass cache_key
 
   omarchy-cmd-present lua || return 0
 
-  while IFS=$'\t' read -r modmask description key dispatcher arg; do
+  # Unit separator, not tab: bash collapses consecutive IFS whitespace, and Lua
+  # function binds emit empty kind+arg, which would shift inspectable onto the
+  # wrong fields (Universal copy / zoom looked non-inspectable with no reason).
+  while IFS=$'\x1f' read -r modmask description key dispatcher arg inspectable inspection_reason global_bypass; do
     [[ -z $modmask || -z $description || -z $key ]] && continue
 
     LUA_BIND_KEY_MAP["$modmask,$description"]="$key"
     cache_key="$modmask,$description,$key"
     LUA_BIND_DISPATCHER_MAP["$cache_key"]="$dispatcher"
     LUA_BIND_ARG_MAP["$cache_key"]="$arg"
+    if [[ -v LUA_BIND_INSPECTABLE_MAP["$cache_key"] ]] &&
+      [[ ${LUA_BIND_INSPECTABLE_MAP["$cache_key"]},${LUA_BIND_INSPECTION_REASON_MAP["$cache_key"]},${LUA_BIND_GLOBAL_BYPASS_MAP["$cache_key"]} != "$inspectable,$inspection_reason,$global_bypass" ]]; then
+      LUA_BIND_INSPECTABLE_MAP["$cache_key"]=0
+      LUA_BIND_INSPECTION_REASON_MAP["$cache_key"]="ambiguous binding safety metadata"
+      LUA_BIND_GLOBAL_BYPASS_MAP["$cache_key"]=1
+    else
+      LUA_BIND_INSPECTABLE_MAP["$cache_key"]="$inspectable"
+      LUA_BIND_INSPECTION_REASON_MAP["$cache_key"]="$inspection_reason"
+      LUA_BIND_GLOBAL_BYPASS_MAP["$cache_key"]="$global_bypass"
+    fi
   done < <(
     lua <<'LUA'
 local modifiers = { SHIFT = 1, CTRL = 4, CONTROL = 4, ALT = 8, SUPER = 64 }
@@ -87,19 +105,23 @@ local modifiers = { SHIFT = 1, CTRL = 4, CONTROL = 4, ALT = 8, SUPER = 64 }
 local function split_keys(keys)
   local modmask = 0
   local key = ""
+  local key_count = 0
+  local modifiers_ended = false
 
   for part in string.gmatch(tostring(keys or ""), "[^+]+") do
     local value = part:gsub("^%s+", ""):gsub("%s+$", "")
     local modifier = modifiers[string.upper(value)]
 
-    if modifier then
+    if modifier and not modifiers_ended then
       modmask = modmask + modifier
     else
+      modifiers_ended = true
       key = value
+      key_count = key_count + 1
     end
   end
 
-  return modmask, key
+  return modmask, key, key_count > 1
 end
 
 local function lua_literal(value)
@@ -198,11 +220,15 @@ hl = setmetatable({
   dsp = dsp_proxy("hl.dsp"),
   bind = function(keys, bind_dispatcher, opts)
     opts = opts or {}
+    local description = opts.description or opts.desc
 
-    if opts.description and opts.description ~= "" then
-      local modmask, key = split_keys(keys)
+    if description and description ~= "" then
+      local modmask, key, multi_key = split_keys(keys)
       local kind = ""
       local arg = ""
+      local inspectable = "1"
+      local inspection_reason = "-"
+      local global_bypass = "0"
 
       if type(bind_dispatcher) == "table" and bind_dispatcher.__omarchy_dispatcher then
         kind = bind_dispatcher.kind or ""
@@ -212,7 +238,25 @@ hl = setmetatable({
         arg = bind_dispatcher
       end
 
-      print(table.concat({ tostring(modmask), opts.description, key, kind, arg }, "\t"))
+      if opts.dont_inhibit then
+        inspectable = "0"
+        inspection_reason = "bypasses shortcut inhibition"
+        global_bypass = "1"
+      elseif opts.allow_input_capture then
+        inspectable = "0"
+        inspection_reason = "allowed during input capture"
+      elseif opts.ignore_mods then
+        inspectable = "0"
+        inspection_reason = "ignores modifiers"
+      elseif opts.device then
+        inspectable = "0"
+        inspection_reason = "device-specific binding"
+      elseif multi_key or tostring(keys):find("&", 1, true) then
+        inspectable = "0"
+        inspection_reason = "multi-key binding"
+      end
+
+      print(table.concat({ tostring(modmask), description, key, kind, arg, inspectable, inspection_reason, global_bypass }, "\x1f"))
     end
 
     return noop
@@ -270,7 +314,8 @@ modmask_to_text() {
 # - Map numeric modifier key mask to a textual rendition
 # - Output comma-separated values that the parser can understand
 dynamic_bindings() {
-  local modmask key keycode description dispatcher arg modifiers cache_key
+  local header flags named_flags modmask submap key keycode catchall description dispatcher arg device
+  local modifiers cache_key inspectable inspection_reason global_bypass
 
   # Parse the plain `hyprctl binds` output rather than `hyprctl -j binds`:
   # Hyprland 0.56.0 emits invalid JSON for binds (misaligned fields in
@@ -279,13 +324,14 @@ dynamic_bindings() {
     function emit() {
       if (!seen) return
       seen = 0
-      printf "%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\n", f["modmask"], f["key"], f["keycode"], f["description"], f["dispatcher"], f["arg"]
+      printf "%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\n", header, f["flags"], f["modmask"], f["submap"], f["key"], f["keycode"], f["catchall"], f["description"], f["dispatcher"], f["arg"], f["device"]
     }
-    /^bind/ { emit(); seen = 1; delete f; next }
+    /^bind/ { emit(); seen = 1; delete f; header = $0; next }
     seen && match($0, /^\t[a-z]+: /) { f[substr($0, 2, RLENGTH - 3)] = substr($0, RLENGTH + 1) }
     END { emit() }
   ' |
-    while IFS=$'\x1f' read -r modmask key keycode description dispatcher arg; do
+    while IFS=$'\x1f' read -r header named_flags modmask submap key keycode catchall description dispatcher arg device; do
+      flags="${header#bind}"
       # Lua binds report their full display key ("SUPER + code:20"); the
       # modifiers are already carried separately in modmask.
       key="${key##* + }"
@@ -309,6 +355,25 @@ dynamic_bindings() {
       # The Copilot key just duplicates an existing binding, so keep it hidden
       [[ $key == "code:201" ]] && continue
 
+      cache_key="$modmask,$description,$key"
+      # Prefer Lua-scan inspectability when the row ties back to source; then
+      # apply hyprctl-visible flags below so both paths stay aligned.
+      if [[ -v LUA_BIND_INSPECTABLE_MAP["$cache_key"] ]]; then
+        inspectable="${LUA_BIND_INSPECTABLE_MAP["$cache_key"]}"
+        inspection_reason="${LUA_BIND_INSPECTION_REASON_MAP["$cache_key"]}"
+        [[ $inspection_reason == "-" ]] && inspection_reason=""
+        global_bypass="${LUA_BIND_GLOBAL_BYPASS_MAP["$cache_key"]}"
+      else
+        # Current Hyprland plain output exposes allow_input_capture as `x`, but
+        # omits dont_inhibit, ignore_mods, multi-key, and device metadata. An
+        # active row we cannot tie back to Lua source could therefore bypass
+        # the inhibitor; one such row disables physical capture for the whole
+        # request instead of making a safety claim from incomplete data.
+        inspectable=0
+        inspection_reason="binding safety metadata unavailable"
+        global_bypass=1
+      fi
+
       case "$key" in
         comma) key="COMMA" ;;
         grave) key="~" ;;
@@ -318,17 +383,50 @@ dynamic_bindings() {
         slash) key="SLASH" ;;
       esac
 
+      if [[ ,${named_flags// /}, == *",dont_inhibit,"* || $flags == *p* ]]; then
+        inspectable=0
+        inspection_reason="bypasses shortcut inhibition"
+        global_bypass=1
+      elif [[ ,${named_flags// /}, == *",ignore_mods,"* || $flags == *i* ]]; then
+        inspectable=0
+        inspection_reason="ignores modifiers"
+      elif [[ ,${named_flags// /}, == *",allow_input_capture,"* || $flags == *x* ]]; then
+        inspectable=0
+        inspection_reason="allowed during input capture"
+      elif [[ ,${named_flags// /}, == *",device_inclusive,"* ]]; then
+        inspectable=0
+        inspection_reason="device-specific binding"
+      elif [[ -n $submap ]]; then
+        inspectable=0
+        inspection_reason="non-default submap"
+      elif [[ -n $device ]]; then
+        inspectable=0
+        inspection_reason="device-specific binding"
+      elif [[ $catchall == "true" ]]; then
+        inspectable=0
+        inspection_reason="catch-all binding"
+      elif [[ $key == *" & "* ]]; then
+        inspectable=0
+        inspection_reason="multi-key binding"
+      elif [[ $key == mouse:* || $key == switch:* || $key == *"MOUSE BUTTON"* ]]; then
+        inspectable=0
+        inspection_reason="non-keyboard binding"
+      elif [[ ${key^^} == XF86* ]]; then
+        inspectable=0
+        inspection_reason="media or device key"
+      fi
+
       modifiers=$(modmask_to_text "$modmask")
       arg="${arg//~\/.local\/share\/omarchy\/bin\//}"
 
-      printf '%s,%s,%s,%s,%s\n' "$modifiers" "$key" "$description" "$dispatcher" "$arg"
+      printf '%s,%s,%s,%s,%s,%s,%s,%s\n' "$modifiers" "$key" "$description" "$dispatcher" "$inspectable" "$inspection_reason" "$global_bypass" "$arg"
     done
 }
 
 # Hardcoded bindings, like the copy-url extension and such
 static_bindings() {
-  echo "SHIFT ALT,L,Copy URL from Web App,sendshortcut,SHIFT ALT,L,"
-  echo "SHIFT ALT,D,Download Video from Web App,sendshortcut,SHIFT ALT,D,"
+  echo "SHIFT ALT,L,Copy URL from Web App,sendshortcut,0,static binding context unavailable,0,SHIFT ALT,L,"
+  echo "SHIFT ALT,D,Download Video from Web App,sendshortcut,0,static binding context unavailable,0,SHIFT ALT,D,"
 }
 
 # Actions Omarchy binds to a second chord meant as an alternative, named one at
@@ -355,6 +453,28 @@ ACTIONS
 # - Prints display text and dispatch metadata as tab-separated fields.
 parse_binding_records() {
   awk -F, -v alternatives="$(alternative_chord_actions)" '
+function canonical_chord(modifiers, key,    count, values, result, i) {
+    gsub(/^[ \t]+|[ \t]+$/, "", modifiers);
+    gsub(/^[ \t]+|[ \t]+$/, "", key);
+    key = toupper(key);
+    result = "";
+    count = split(modifiers, values, /[ \t]+/);
+    for (i = 1; i <= count; i++) {
+        if (values[i] == "") continue;
+        result = result (result == "" ? "" : "+") toupper(values[i]);
+    }
+    return result (result == "" ? "" : "+") key;
+}
+# Must stay aligned with MenuModel chord naming / stand-alone keys
+# (test/shell.d/keybinding-inspector-test.sh allowlist parity).
+function supported_key(key, upper) {
+    upper = toupper(key);
+    return upper ~ /^[A-Z]$/ ||
+        upper ~ /^[0-9]$/ ||
+        upper ~ /^(SPACE|COMMA|MINUS|PERIOD|SLASH|SEMICOLON|EQUAL|BRACKETLEFT|BACKSLASH|BRACKETRIGHT|~|APOSTROPHE)$/ ||
+        upper ~ /^(TAB|BACKTAB|BACKSPACE|RETURN|INSERT|DELETE|HOME|END|LEFT|UP|RIGHT|DOWN|PRIOR|NEXT|PRINT|ESCAPE)$/ ||
+        upper ~ /^F([1-9]|1[0-2])$/;
+}
 BEGIN {
     # The column every row pads its chords to. Nothing is allowed past it: the
     # menu renders in monospace, and a row that overruns pushes its arrow out
@@ -377,17 +497,28 @@ BEGIN {
     # Use description, if set
     action = $3;
     dispatcher = $4;
+    inspectable = $5;
+    inspection_reason = $6;
+    global_bypass = $7;
+    canonical = canonical_chord($1, $2);
+
+    if (inspectable == "1" && !supported_key($2)) {
+        inspectable = "0";
+        inspection_reason = "unsupported keyboard key";
+    }
 
     # Reconstruct the dispatcher arg from the remaining fields
     arg = "";
-    for (i = 5; i <= NF; i++) {
+    for (i = 8; i <= NF; i++) {
         arg = arg $i (i < NF ? "," : "");
     }
 
     if (action == "") {
-        # Reconstruct the command from the remaining fields
-        for (i = 4; i <= NF; i++) {
-            action = action $i (i < NF ? "," : "");
+        # Reconstruct the command from the dispatcher and its argument. The
+        # structured inspection columns between them are metadata, not action.
+        action = dispatcher;
+        for (i = 8; i <= NF; i++) {
+            action = action (action == "" ? "" : ",") $i;
         }
 
         # Clean up trailing commas, remove leading "exec, ", and trim
@@ -406,12 +537,16 @@ BEGIN {
         action_key = action SUBSEP dispatcher SUBSEP arg;
         together = "";
 
-        if (action in shares_a_row && dispatcher != "" && action_key in leads) {
+        if (action in shares_a_row && dispatcher != "" && action_key in leads &&
+            inspectables[leads[action_key]] == inspectable &&
+            reasons[leads[action_key]] == inspection_reason &&
+            bypasses[leads[action_key]] == global_bypass) {
             together = chords[leads[action_key]] " / " key_combo;
         }
 
         if (together != "" && length(together) <= column) {
             chords[leads[action_key]] = together;
+            canonicals[leads[action_key]] = canonicals[leads[action_key]] "|" canonical;
         } else {
             # Also the path a pair too wide for the column takes: two rows in
             # line beat one that juts out of it.
@@ -420,13 +555,17 @@ BEGIN {
             actions[entries] = action;
             dispatchers[entries] = dispatcher;
             args[entries] = arg;
+            canonicals[entries] = canonical;
+            inspectables[entries] = inspectable;
+            reasons[entries] = inspection_reason;
+            bypasses[entries] = global_bypass;
             leads[action_key] = entries;
         }
     }
 }
 END {
     for (entry = 1; entry <= entries; entry++) {
-        printf "%-*s → %s\t%s\t%s\n", column, chords[entry], actions[entry], dispatchers[entry], args[entry];
+        printf "%-*s → %s\t%s\t%s\t%s\t%s\t%s\t%s\n", column, chords[entry], actions[entry], canonicals[entry], inspectables[entry], reasons[entry], bypasses[entry], dispatchers[entry], args[entry];
     }
 }'
 }
@@ -530,7 +669,8 @@ output_binding_records_uncached() {
 
 keybindings_cache_key() {
   {
-    printf 'v13\n'
+    printf 'v15\n'
+    sha256sum "$0" 2>/dev/null
     hyprctl devices 2>/dev/null | grep -F 'active keymap:'
     hyprctl binds 2>/dev/null
   } | sha256sum | awk '{ print $1 }'
@@ -571,6 +711,10 @@ output_binding_records() {
 
 output_keybindings() {
   output_binding_records | cut -f1
+}
+
+output_inspection_records() {
+  output_binding_records | cut -f1-5
 }
 
 trim() {
@@ -654,15 +798,17 @@ dispatch_binding() {
 
 if [[ $1 == "--print" || $1 == "-p" ]]; then
   output_keybindings
+elif [[ $1 == "--print-inspection" ]]; then
+  output_inspection_records
 else
   records=$(output_binding_records)
-  selection=$(cut -f1 <<<"$records" |
-    omarchy-menu-select 'Keybindings' -- --width 800 --height 500)
+  selection=$(cut -f1-5 <<<"$records" |
+    omarchy-menu-select 'Keybindings' -- --width 800 --height 500 --inspect-keybindings)
 
   if [[ -n $selection ]]; then
     record=$(awk -F '\t' -v selection="$selection" '$1 == selection { print; exit }' <<<"$records")
-    dispatcher=$(cut -f2 <<<"$record")
-    arg=$(cut -f3- <<<"$record")
+    dispatcher=$(cut -f6 <<<"$record")
+    arg=$(cut -f7- <<<"$record")
 
     dispatch_binding "$dispatcher" "$arg"
   fi

--- a/bin/omarchy-menu-select
+++ b/bin/omarchy-menu-select
@@ -6,6 +6,11 @@
 # omarchy:args=prompt [option...] [-- menu args...]
 # omarchy:examples=omarchy menu select Format jpg png|omarchy-menu-select Resolution 4k 1080p 720p -- --width 400
 
+# --inspect-keybindings asks the menu to read chords as well as words: a
+# shortcut pressed physically is looked up instead of reaching the compositor.
+# It is off by default because this is the system's dmenu, and a picker asking
+# for a timezone has no business swallowing shortcuts.
+#
 # An option may lead with an icon, as "<glyph><TAB><label>", and may trail a
 # subtext shown under the label, as "<glyph><TAB><label><TAB><subtext>". The
 # menu shows the glyph but never returns it. A plain option returns the label
@@ -25,6 +30,7 @@ shift
 options=()
 menu_width=""
 menu_maxheight=""
+inspect_keybindings=""
 
 while (( $# > 0 )); do
   if [[ $1 == "--" ]]; then
@@ -47,6 +53,9 @@ while (( $# > 0 )); do
             exit 1
           fi
           menu_maxheight="$1"
+          ;;
+        --inspect-keybindings)
+          inspect_keybindings=1
           ;;
       esac
       shift
@@ -74,22 +83,56 @@ trap 'rm -f "$selection_file" "$done_file"' EXIT
 
 options_json=$(perl -MEncode=decode -MJSON::PP=encode_json -e 'print encode_json([map { decode("UTF-8", $_) } @ARGV])' "${options[@]}")
 payload=$(perl -MEncode=decode -MJSON::PP=encode_json,decode_json -e '
+  my $inspect = length($ARGV[6] // "") > 0;
+  my $raw_options = decode_json($ARGV[1]);
+  my @options = @$raw_options;
+  my @inspection_options;
+  my $blocked_reason = "";
+  my $has_inspectable = 0;
+
+  if ($inspect) {
+    @options = ();
+    for my $raw (@$raw_options) {
+      my ($label, $chords, $inspectable, $reason, $bypass) = split(/\t/, $raw, 5);
+      my $safe = ($inspectable // "") eq "1";
+      push @options, $label // "";
+      push @inspection_options, {
+        chords => [grep { length($_) } split(/\|/, $chords // "")],
+        inspectable => $safe ? JSON::PP::true : JSON::PP::false,
+        reason => $reason // ""
+      };
+      $has_inspectable ||= $safe;
+      $blocked_reason = $reason // "unsafe binding" if !$blocked_reason && ($bypass // "") eq "1";
+    }
+    $blocked_reason = "No supported keyboard bindings are available" if !$blocked_reason && !$has_inspectable;
+  }
+
   my $payload = {
     mode => "select",
     prompt => decode("UTF-8", $ARGV[0]),
-    options => decode_json($ARGV[1]),
+    options => \@options,
     selectionFile => decode("UTF-8", $ARGV[2]),
     doneFile => decode("UTF-8", $ARGV[3])
   };
   $payload->{width} = int($ARGV[4]) if length($ARGV[4] // "");
   $payload->{maxHeight} = int($ARGV[5]) if length($ARGV[5] // "");
+  if ($inspect) {
+    $payload->{inspectKeybindings} = JSON::PP::true;
+    $payload->{inspectionOptions} = \@inspection_options;
+    $payload->{inspectionBlockedReason} = $blocked_reason if $blocked_reason;
+  }
   print encode_json($payload)
-' "$prompt" "$options_json" "$selection_file" "$done_file" "$menu_width" "$menu_maxheight")
+' "$prompt" "$options_json" "$selection_file" "$done_file" "$menu_width" "$menu_maxheight" "$inspect_keybindings")
 
 omarchy-shell shell summon omarchy.menu "$payload" >/dev/null
 
+poll_count=0
 while [[ ! -e $done_file ]]; do
   sleep 0.05
+  (( poll_count += 1 ))
+  if (( poll_count % 20 == 0 )) && ! omarchy-shell shell ping >/dev/null 2>&1; then
+    exit 1
+  fi
 done
 
 if [[ -s $selection_file ]]; then

--- a/plans/keybinding-inspector.md
+++ b/plans/keybinding-inspector.md
@@ -1,0 +1,424 @@
+# Omarchy bidirectional keybinding guide — development pre-study
+
+Status: proposal / implementation brief  
+Prepared: 2026-09-05  
+Target project: [omacom/omarchy](https://github.com/omacom/omarchy)
+
+## Executive summary
+
+Extend the existing `Super + K` keybinding guide so it supports two inputs in the same interface, with no explicit mode switch:
+
+- Type ordinary words and receive matching shortcuts.
+- Physically press a shortcut chord and receive its description.
+
+Example:
+
+- Type `file manager` → `SUPER + SHIFT + F → File manager`.
+- Physically press `Super + Shift + F` → `SUPER + SHIFT + F → File manager`, without opening the file manager.
+
+This should be implemented in Omarchy, not Hyprland. Hyprland already supports the standard Wayland keyboard-shortcuts inhibitor protocol, and Quickshell exposes it through `Quickshell.Wayland.ShortcutInhibitor`. The existing Omarchy menu already requests keyboard focus and receives key events. The required work is therefore an Omarchy shell/menu enhancement plus a small change to the keybinding-record interface.
+
+Do not use synthetic key injection or keep a fake modifier logically pressed. That approach is unnecessarily fragile and can leak modifier state, interact with keyboard layouts, or fail for bindings that ignore modifiers.
+
+## Product contract
+
+There is exactly one entry point and one interface:
+
+1. The user presses `Super + K`.
+2. The existing Keybindings guide opens.
+3. If the user types ordinary unmodified printable text, the guide performs its current description search.
+4. If the user physically presses a chord, the guide looks up that chord and shows its description.
+5. The inspected shortcut must not execute.
+
+There is no second `Super + K`, capture button, capture mode, prompt, or manually typed shortcut syntax.
+
+### Input classification
+
+The guide should classify input automatically:
+
+- Unmodified printable keys: text search.
+- `Shift` plus a printable key where Shift is being used to type text: text search. Uppercase letters must remain usable in search.
+- A non-modifier key pressed while `Super`, `Ctrl`, or `Alt` is held: chord lookup.
+- Non-text keys such as `Print`, function keys, arrows, navigation keys, and media keys: chord lookup, with or without modifiers.
+- Modifier press/release by itself: update transient modifier state but do not search until a non-modifier key arrives.
+- `Escape`: preserve the existing clear/close behavior; it must not become a chord query.
+- `Enter`, arrows, Tab, Delete, and other existing menu-navigation controls: preserve current behavior unless held with a modifier that forms a known shortcut.
+
+The result should be resolved on the non-modifier key press. Waiting for all modifiers to be released would make the interface feel laggy.
+
+## Why it belongs in Omarchy
+
+Omarchy owns all relevant product concepts:
+
+- `Super + K` and its “Keybindings” meaning.
+- Collection and normalization of configured Hyprland bindings.
+- Human-readable binding descriptions.
+- The searchable guide UI.
+- The desired interaction and visual presentation.
+
+Hyprland owns the compositor primitive required to suppress global shortcuts, and that primitive already exists. A Hyprland PR is only warranted if a minimal reproduction demonstrates that its implementation of `keyboard-shortcuts-inhibit-unstable-v1` does not suppress a normal binding for a focused layer-shell surface.
+
+## Existing implementation
+
+The installed Omarchy source currently contains:
+
+- `default/hypr/bindings/utilities.lua`
+  - Registers `SUPER + K`, description `Keybindings`, action `omarchy-menu-keybindings`.
+- `bin/omarchy-menu-keybindings`
+  - Reads dynamic bindings from `hyprctl binds`.
+  - Supplements Lua-only bindings by scanning the user configuration.
+  - Normalizes modifier masks, keycodes, mouse buttons, and descriptions.
+  - Produces records with display text and dispatch metadata.
+  - Sends display rows to `omarchy-menu-select`.
+  - Dispatches the selected binding when a row is selected.
+- `shell/plugins/menu/Menu.qml`
+  - Implements the native Quickshell menu.
+  - Uses a full-screen `PanelWindow`.
+  - Sets `WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive`.
+  - Has a `keyCatcher` with `Keys.priority: Keys.BeforeItem` and an existing `Keys.onPressed` handler.
+
+This means Omarchy already possesses the reverse index data. The current display row has this conceptual shape:
+
+```text
+SUPER SHIFT + F → File manager
+```
+
+The missing pieces are:
+
+1. Prevent Hyprland from executing the chord while this particular menu is focused.
+2. Observe and normalize the physical chord in QML.
+3. Match it against the keybinding records.
+4. Show the matching row without dispatching it.
+
+## Recommended architecture
+
+### 1. Identify the menu request as a keybinding-inspection request
+
+Avoid enabling shortcut inhibition for every Omarchy menu. The generic menu is also used to execute commands and should retain its current behavior.
+
+Extend the `omarchy-menu-select` request with semantic metadata, for example:
+
+```bash
+omarchy-menu-select 'Keybindings' --inspect-keybindings -- --width 800 --height 500
+```
+
+The exact flag should follow the existing IPC/request conventions in the repository. A generic alternative would be `--capture-shortcuts`, but the behavior is currently specific to the keybinding guide.
+
+The corresponding menu request/model property might be:
+
+```qml
+property bool inspectKeybindings: false
+```
+
+### 2. Activate a Quickshell shortcut inhibitor
+
+Attach a `ShortcutInhibitor` to the menu's focused `PanelWindow` only while the keybinding guide is open:
+
+```qml
+import Quickshell.Wayland
+
+ShortcutInhibitor {
+  id: shortcutInhibitor
+  window: panel
+  enabled: root.opened && root.inspectKeybindings
+}
+```
+
+The actual `window` value may need to be the Quickshell window object expected by the installed Quickshell version rather than the QML wrapper. Follow existing Quickshell patterns and verify `active` before relying on suppression.
+
+Important behavior:
+
+- If the inhibitor is not active, do not silently pretend inspection is safe.
+- Either keep ordinary text search but decline modified-chord inspection, or close the guide and report that capture could not be activated.
+- Handle the inhibitor's `cancelled` signal by disabling chord inspection immediately.
+- The inhibitor must be disabled as soon as the menu closes or loses the relevant focus.
+
+Hyprland bindings marked to bypass inhibitors (currently represented by flags such as `dont_inhibit` / `allow_input_capture`, depending on the mechanism and version) need explicit testing. The inspector must not claim that a chord is harmless if Hyprland will still process it.
+
+### 3. Preserve structured binding records
+
+Do not reverse-parse the formatted display string if it can be avoided. Pass structured fields to the menu:
+
+```text
+display label | normalized chord | description | dispatcher | argument
+```
+
+The transport could remain tab-separated if that is the established contract, but the menu needs direct access to at least:
+
+- normalized chord;
+- human description;
+- display label;
+- optionally flags indicating whether the chord bypasses inhibition.
+
+Normalization must be shared between record production and QML chord capture. If the shell cannot reuse the Bash normalization logic directly, define a small, explicit canonical representation and test both sides against the same fixture table.
+
+Suggested canonical form:
+
+```text
+SUPER+SHIFT+F
+CTRL+ALT+DELETE
+PRINT
+SUPER+mouse:272
+```
+
+Suggested modifier order:
+
+```text
+SUPER, SHIFT, CTRL, ALT
+```
+
+Display formatting can remain `SUPER SHIFT + F` to preserve the current UI.
+
+### 4. Capture before the text field
+
+Use the existing `keyCatcher` and `Keys.priority: Keys.BeforeItem` path. In pseudocode:
+
+```qml
+Keys.onPressed: function(event) {
+  if (handleExistingMenuControls(event)) {
+    event.accepted = true
+    return
+  }
+
+  if (root.inspectKeybindings && shortcutInhibitor.active && isChordInput(event)) {
+    const chord = normalizeChord(event.key, event.modifiers)
+    root.showBindingForChord(chord)
+    event.accepted = true
+    return
+  }
+
+  // Preserve the existing text-search path.
+}
+```
+
+`isChordInput` must not treat `Shift + letter` as a chord, because users need capitalization. It should treat `Super`, `Ctrl`, or `Alt` plus a non-modifier key as a chord. It should also treat recognized non-printable keys as chords.
+
+Qt modifier auto-repeat and native scan-code behavior should be checked. Use Qt's key enum and modifier mask for the first implementation; only use native scan codes when required to distinguish a configured `code:` binding.
+
+### 5. Display the lookup result without dispatching
+
+Chord lookup must never follow the existing selection path that calls `dispatch_binding`.
+
+Recommended result behavior:
+
+- Replace/filter the rows to the exact chord match.
+- Keep the search field unchanged or temporarily display the chord as a non-editable chip/status line.
+- If several bindings share a chord, display all of them and their relevant context/submap.
+- If no record matches, show `No binding found for SUPER + ...`.
+- The next normal character should return naturally to textual search; no explicit mode-reset action should be required.
+
+The user may still deliberately execute a selected row using the guide's existing behavior. Inspection itself must not trigger selection or execution.
+
+## Opening-event race
+
+`Super + K` opens the guide, so its key release events may arrive after the surface and inhibitor become active.
+
+Do not solve this with a visible delay. Internally gate chord recognition until all keys from the opening gesture have been released. Options:
+
+- Ignore release events entirely and only resolve chords on non-modifier press; if the opening `K` press occurred before the surface gained focus, this may already be sufficient.
+- Record an `armed` flag after the first zero-modifier state or a short event-loop turn after focus acquisition.
+- Explicitly ignore the initial `Super + K` sequence associated with the summon request.
+
+Choose the smallest solution that passes an automated or integration test. Avoid arbitrary long timers.
+
+## Safety and escape behavior
+
+Shortcut inhibition creates a temporary keyboard grab-like experience, so failure recovery matters:
+
+- `Escape` must always clear/close through the client.
+- Clicking outside must still close the guide.
+- Focus loss must deactivate the inhibitor.
+- Closing/unmapping the window must deactivate it automatically.
+- Handle `ShortcutInhibitor.cancelled`.
+- Do not enable inhibition globally or for unrelated menu requests.
+- Verify that switching TTY remains compositor/kernel controlled and is not affected.
+- Test a shell reload/crash while the guide is open; Wayland resource destruction should release inhibition.
+- Do not add a synthetic-key fallback.
+
+## Keyboard-layout considerations
+
+The existing script already resolves `code:` bindings through `xkbcli` and the active keymap. The inspector introduces the reverse direction and therefore needs tests for:
+
+- US QWERTY.
+- A non-US layout used by a contributor or CI fixture.
+- A configured binding expressed as a keysym.
+- A configured binding expressed as `code:<number>`.
+- Shifted symbols such as `/`, `?`, `-`, `_`, number-row symbols, and locale-specific symbols.
+- Left/right variants of Ctrl, Alt, Shift, and Super; these should normally normalize to the same logical modifier.
+- AltGr, which may appear as Ctrl+Alt on some stacks and must not be misreported casually.
+
+For an MVP, it is acceptable to support the same logical representation already shown by `omarchy-menu-keybindings` and report no match for ambiguous raw-keycode cases. Do not silently map an uncertain chord to the wrong action.
+
+## Interaction with binding flags and submaps
+
+The existing list may include bindings that:
+
+- ignore extra modifiers;
+- fire on release;
+- repeat while held;
+- remain active under shortcut inhibition;
+- exist only in a Hyprland submap;
+- are device-specific;
+- use mouse buttons or switches.
+
+MVP scope should be ordinary keyboard bindings in the default submap. Suggested behavior outside that scope:
+
+- Release bindings: identify on key press but label normally; do not wait to execute, because nothing executes.
+- Repeating bindings: identify once.
+- `ignore_mods`: exact chord lookup first; optionally show an “also matches because modifiers are ignored” result later.
+- Inhibitor-bypassing bindings: exclude from safe capture or label as unsafe until a robust policy is implemented.
+- Other submaps: show only if record metadata reliably exposes the submap; otherwise defer.
+- Mouse/switch bindings: retain text discoverability; physical capture can be a later extension.
+
+## Test plan
+
+Follow the repository's `AGENTS.md` and run the full required suite, including `./test/all` before submission.
+
+### Unit tests
+
+- Normalize every supported Qt modifier combination into the canonical order.
+- Normalize key aliases consistently with `bin/omarchy-menu-keybindings`.
+- `Shift + f` remains text input.
+- `Super + Shift + F` becomes a chord query.
+- `Ctrl + K` becomes a chord query, not the letter `k` in search.
+- `Print`, `F9`, media keys, arrows with modifiers, and Delete with modifiers classify correctly.
+- Modifier-only events do not produce a result.
+- Duplicate chords return all matching descriptions.
+- An unknown chord returns an explicit no-match state.
+
+### Integration tests
+
+- Open with `Super + K`; the menu appears and the original action does not repeat.
+- Type `browser`; normal search still works.
+- Physically press a safe test chord; its description appears and its dispatcher is not called.
+- Physically press a normally destructive chord such as close-window in a disposable test environment; the window is not closed.
+- Press Escape; the guide closes and normal Hyprland shortcuts work immediately afterward.
+- Click outside; same restoration behavior.
+- Cancel the inhibitor; chord capture stops safely.
+- Change keyboard layout and repeat lookup.
+- Reload/terminate the shell while inhibited; normal shortcuts recover.
+
+### Manual UX checks
+
+- No visible capture mode or additional activation step appears.
+- Modified chords feel instantaneous.
+- Typing normal prose never unexpectedly switches to chord lookup.
+- The result communicates both the physical chord and the description clearly.
+- Unknown chords do not look like errors or execute anything.
+
+## Acceptance criteria
+
+- `Super + K` remains the sole entry point.
+- Existing word search behaves unchanged.
+- A physical chord entered while the guide is open resolves to its human description.
+- The inspected ordinary Hyprland binding does not execute.
+- No extra mode switch, prompt, button, or second invocation is required.
+- Escape/outside-click/focus-loss restore normal keybindings immediately.
+- Failure to obtain shortcut inhibition fails safely.
+- The implementation does not inject synthetic input.
+- Automated tests cover classification, normalization, non-execution, and cleanup.
+- Documentation briefly describes the bidirectional behavior.
+
+## Scope recommendation
+
+### MVP
+
+- Default-submap keyboard chords.
+- `Super`, `Ctrl`, and `Alt` combinations.
+- Common non-printable keys.
+- Exact-match lookup.
+- Safe failure when inhibition is unavailable.
+
+### Follow-ups
+
+- Mouse bindings.
+- Device-specific bindings.
+- Submap-aware results.
+- `ignore_mods` fuzzy matching.
+- Displaying binding source file and line.
+- Showing conflicts or several actions bound to one chord.
+
+Do not expand the first PR into a general keybinding editor.
+
+## Likely files to change
+
+Confirm paths against the development branch before editing:
+
+- `bin/omarchy-menu-keybindings`
+  - Emit structured normalized-chord data and request inspection semantics.
+- The `omarchy-menu-select` request/CLI implementation
+  - Carry an inspector/capture flag into the shell menu request.
+- `shell/plugins/menu/Menu.qml`
+  - Add the conditional `ShortcutInhibitor`, key classification, normalization, and chord-result behavior.
+- Menu model/helper JS used by `Menu.qml`
+  - Prefer placing pure normalization and matching functions here for unit testing.
+- Existing keybindings-menu and shell/menu tests
+  - Add fixtures and regression coverage.
+- `manual/07-hotkeys.md` or the current guide documentation
+  - Add one concise explanation.
+
+## Relationship to current Omarchy PRs
+
+- [PR #7722 — Display keybindings in menu on demand via `?`](https://github.com/omacom/omarchy/pull/7722)
+  - Closest functional overlap. It adds shortcut-aware menu data and textual searching by shortcut tokens. Coordinate with it to avoid conflicting changes to menu models and keybinding parsing.
+- [PR #8569 — Show hotkey chips on menu rows](https://github.com/omacom/omarchy/pull/8569)
+  - Related discoverability work, but not physical chord inspection.
+- [PR #7165 — Make hotkeys discoverable](https://github.com/omacom/omarchy/pull/7165)
+  - Introduces a structured relationship between actions/menu rows and bindings. Its data-model approach may reduce duplicated parsing if accepted.
+
+Before coding, check the current state of these PRs and the target branch. The repository is moving quickly and overlapping work may have landed or changed shape.
+
+## Upstream references
+
+- [Quickshell `ShortcutInhibitor`](https://quickshell.org/docs/v0.3.1/types/Quickshell.Wayland/ShortcutInhibitor/)
+  - Prevents the compositor from processing shortcuts for a focused surface so the application receives the key events.
+- [Hyprland bind documentation](https://wiki.hypr.land/Configuring/Basics/Binds/)
+  - Current binding model, flags, keycodes, global bindings, and submaps.
+- [Hyprland bind flags](https://wiki.hypr.land/configuring/core/binds/flags/)
+  - Includes flags related to inhibition/input capture and identifies bindings that may remain active.
+
+## Suggested development sequence for Cursor
+
+1. Clone/fork the repository; never develop in `/usr/share/omarchy`.
+2. Read the repository's current `AGENTS.md` completely.
+3. Re-check PRs #7722, #8569, and #7165 for overlap or merge status.
+4. Trace `omarchy-menu-keybindings` → `omarchy-menu-select` → shell IPC → `Menu.qml` and document the exact request data flow.
+5. Build a minimal spike that enables `ShortcutInhibitor` only for the Keybindings request and logs received modified key events without performing lookup.
+6. Verify experimentally that `Super + W` or another disposable test binding is received by QML and not executed.
+7. If that succeeds, add structured chord data, normalization, lookup, UI behavior, and tests.
+8. If it fails, produce a minimal standalone Quickshell reproduction before considering an upstream Quickshell or Hyprland report.
+9. Run focused tests, then `./test/all`.
+10. Open an atomic Omarchy PR with a short screen recording showing word search and physical chord inspection in the same guide.
+
+## Suggested PR description
+
+### What
+
+Make the `Super + K` keybinding guide bidirectional. Typing words continues to search descriptions; physically pressing a shortcut now shows what it does without executing it.
+
+### Why
+
+The guide currently answers “which shortcut performs this action?” but not “what will this shortcut do?” Users exploring an unfamiliar keyboard-driven system need both directions.
+
+### Interaction
+
+- `Super + K`
+- Type `file manager` → see its shortcut.
+- Or physically press `Super + Shift + F` → see `File manager`.
+- No second invocation or capture mode is required.
+
+### Safety
+
+The focused guide uses Quickshell's Wayland shortcut inhibitor, so normal compositor bindings are not executed during inspection. Inhibition is scoped to the keybinding guide and released on close or focus loss.
+
+## Open questions to resolve during the spike
+
+1. Does the Omarchy-packaged Quickshell version expose `ShortcutInhibitor` with the documented API?
+2. What exact window object must be assigned to its `window` property for `PanelWindow`?
+3. Does Hyprland grant inhibition to Omarchy's overlay layer-shell surface consistently?
+4. Which current Omarchy bindings bypass shortcut inhibition?
+5. Can the existing menu request transport structured hidden fields cleanly, or should keybinding inspection get a dedicated request/model path?
+6. How should `Shift + printable key` be classified for layouts where Shift changes the symbol substantially?
+7. What is the safest behavior when the inhibitor reports inactive or cancelled?
+
+These are spike questions, not reasons to redesign Hyprland up front.

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -60,6 +60,30 @@ Item {
   property string doneFile: ""
   property int dmenuWidth: 300
   property int dmenuMaxHeight: 0
+  // The keybindings guide reads both directions: typed words find a shortcut,
+  // and a shortcut pressed physically finds its description. Only that request
+  // asks for it -- this plugin is also the system's dmenu, and a picker asking
+  // for a timezone must keep letting shortcuts through to the compositor.
+  property bool inspectKeybindings: false
+  property var inspectionOptions: []
+  property string inspectionBlockedReason: ""
+  // inactive: generic menu; arming: inhibition requested; ready: safe lookup;
+  // text-only: the request is visible but physical lookup is unavailable.
+  property string chordCaptureState: "inactive"
+  // The chord last pressed, canonical, or "" while the guide is reading words.
+  property string chordQuery: ""
+  // Qt key that established chordQuery. Extra non-modifier presses while it is
+  // held must not replace the lookup (Super+Tab then an arrow was showing the
+  // arrow chord and ignoring Tab).
+  property int chordHoldKey: 0
+  // Physical key identity for Shift+digit: press may be Key_Dollar while release
+  // is Key_4; scan code stays stable and must settle the chord.
+  property int chordHoldScan: 0
+  // First inspectionOptions index matched on press; release selects it in the
+  // full list without looking the chord up again.
+  property int chordMatchIndex: -1
+  readonly property bool chordCaptureReady: root.chordCaptureState === "ready"
+    && shortcutInhibitor.active
   property bool requestActive: false
   property bool rowsLoaded: false
   property string activeMenu: "root"
@@ -132,6 +156,31 @@ Item {
       resultProc.command = ["bash", "-c", "printf '%s\\n' " + Util.shellQuote(selection) + " > " + Util.shellQuote(activeSelectionFile) + "; : > " + Util.shellQuote(activeDoneFile)]
     }
     resultProc.running = true
+  }
+
+  // IPC may replace a dmenu request while its caller is still waiting. Finish
+  // that caller before installing the new files; otherwise a healthy shell can
+  // leave the old omarchy-menu-select blocked forever.
+  function finishReplacedRequest() {
+    if (!root.requestActive || !root.doneFile) return
+
+    var replacedDoneFile = root.doneFile
+    root.requestActive = false
+    root.selectionFile = ""
+    root.doneFile = ""
+    Util.execDetached(": > " + Util.shellQuote(replacedDoneFile))
+  }
+
+  function prepareForReplacement() {
+    root.finishReplacedRequest()
+    // Drop the old surface gate before assigning the new request files. An
+    // active inhibitor may deactivate synchronously here; opened=false keeps
+    // that expected transition from canceling the replacement request.
+    root.opened = false
+    shortcutInhibitor.enabled = false
+    captureArmTimer.stop()
+    root.chordCaptureState = "inactive"
+    root.inspectKeybindings = false
   }
 
   function runAction(action) {
@@ -559,8 +608,20 @@ Item {
       return
     }
 
+    // A chord asks for the rows it is bound to and nothing else, so it selects
+    // rows outright instead of narrowing them by text. More than one row can
+    // answer when two actions share a chord; all of them are shown rather than
+    // one being picked.
+    var chordRows = null
+    if (root.chordQuery) {
+      chordRows = ({})
+      var matched = MenuModel.findRowsForChord(root.inspectionOptions, root.chordQuery).matches
+      for (var c = 0; c < matched.length; c++) chordRows[matched[c]] = true
+    }
+
     var query = root.filterText.trim().toLowerCase()
     for (var i = 0; i < root.dmenuOptions.length; i++) {
+      if (chordRows && !chordRows[i]) continue
       // An option is "<label>", "<glyph>\t<label>", or
       // "<glyph>\t<label>\t<subtext>". The glyph never comes back with the
       // selection; the subtext renders under the label, filters alongside it,
@@ -719,10 +780,91 @@ Item {
   function setFilter(nextFilter) {
     panel.freezeCardTop()
     root.filterText = nextFilter
+    // Typing is the other direction of the same guide, so the next ordinary
+    // character drops the chord and searches words again. No reset to press.
+    root.resetChordState()
     root.selectedIndex = 0
     root.cursorActive = root.mode !== "input"
     root.disarmPointer()
     if (!root.dmenuActive && root.filterText.trim()) root.loadProvidersForSearch()
+    root.rebuildDisplay()
+  }
+
+  // Held chord is a read-only answer. Release settles onto the match in the
+  // full list; Enter / click then dispatch like any other selection. Misses
+  // and unnamed keys stay silent so typed filter text is left alone.
+  function sameChordHoldKey(left, right) {
+    if (left === right) return true
+    // Shift+Tab arrives as Backtab; treat it as the same physical Tab hold.
+    var tab = 0x01000001
+    var backtab = 0x01000002
+    return (left === tab || left === backtab) && (right === tab || right === backtab)
+  }
+
+  // Prefer scan code: Shift+digit press/release often disagree on keysym.
+  function sameChordHold(event) {
+    var scan = Number(event.nativeScanCode) || 0
+    if (root.chordHoldScan > 0 && scan === root.chordHoldScan) return true
+    return root.sameChordHoldKey(event.key, root.chordHoldKey)
+  }
+
+  function resetChordState() {
+    root.chordQuery = ""
+    root.chordHoldKey = 0
+    root.chordHoldScan = 0
+    root.chordMatchIndex = -1
+  }
+
+  function showChord(key, modifiers, nativeScanCode) {
+    var chord = MenuModel.normalizeChordFromEvent(key, modifiers, nativeScanCode)
+    if (!chord) return
+
+    var lookup = MenuModel.findRowsForChord(root.inspectionOptions, chord)
+    if (lookup.matches.length === 0) return
+
+    panel.freezeCardTop()
+    root.filterText = ""
+    root.selectedIndex = 0
+    root.disarmPointer()
+    root.chordQuery = chord
+    root.chordHoldKey = key
+    root.chordHoldScan = Number(nativeScanCode) || 0
+    root.chordMatchIndex = lookup.matches[0]
+    root.cursorActive = true
+    root.rebuildDisplay()
+  }
+
+  function clearChord() {
+    root.resetChordState()
+    root.selectedIndex = 0
+    root.rebuildDisplay()
+  }
+
+  // Release ends the filtered lookup and returns to the full list with the
+  // matched row selected, so Enter / click run it like any other choice.
+  function settleChordSelection() {
+    var matchIndex = root.chordMatchIndex
+    root.resetChordState()
+    root.rebuildDisplay()
+
+    if (matchIndex < 0) return
+
+    var targetId = "dmenu." + matchIndex
+    for (var i = 0; i < displayModel.count; i++) {
+      if (displayModel.get(i).itemId === targetId) {
+        root.selectedIndex = i
+        root.cursorActive = true
+        Qt.callLater(function() { root.revealCursor() })
+        return
+      }
+    }
+  }
+
+  function fallBackToTextOnly(reason) {
+    root.chordCaptureState = "text-only"
+    root.inspectionBlockedReason = String(reason || "Shortcut capture is unavailable")
+    root.resetChordState()
+    shortcutInhibitor.enabled = false
     root.rebuildDisplay()
   }
 
@@ -759,6 +901,9 @@ Item {
   function activateIndex(index, fromPointer) {
     if (root.deleteConfirmOpen) return
     if (root.dmenuActive) {
+      // While a chord is held the list is a read-only answer. Release settles
+      // onto the match in the full list; Enter / Right / click then dispatch.
+      if (root.chordQuery) return
       if (root.mode === "input") {
         root.applyDmenuSelection(root.filterText)
         return
@@ -815,6 +960,8 @@ Item {
   function applyDmenuSelection(value) {
     applySerial = requestSerial
     opened = false
+    chordCaptureState = "inactive"
+    shortcutInhibitor.enabled = false
     filterText = ""
     root.finishRequest(value)
   }
@@ -829,12 +976,20 @@ Item {
   }
 
   function cancel() {
-    if (root.dmenuActive) root.finishRequest(null)
+    var finishDmenu = root.dmenuActive
     opened = false
+    chordCaptureState = "inactive"
+    shortcutInhibitor.enabled = false
+    if (finishDmenu) root.finishRequest(null)
     filterText = ""
+    root.resetChordState()
+    inspectKeybindings = false
+    inspectionOptions = []
+    inspectionBlockedReason = ""
   }
 
   function openExistingMenu(initialMenu) {
+    root.prepareForReplacement()
     requestSerial += 1
     mode = "menu"
     requestActive = false
@@ -843,6 +998,11 @@ Item {
     activeMenu = root.item(initialMenu) ? initialMenu : "root"
     navStack = []
     filterText = ""
+    root.resetChordState()
+    inspectKeybindings = false
+    inspectionOptions = []
+    inspectionBlockedReason = ""
+    chordCaptureState = "inactive"
     selectedIndex = 0
     cursorActive = true
     root.disarmPointer()
@@ -859,6 +1019,7 @@ Item {
   }
 
   function openDmenu(payload) {
+    root.prepareForReplacement()
     requestSerial += 1
     mode = payload.mode === "input" ? "input" : "select"
     dmenuPrompt = String(payload.prompt || (mode === "input" ? "Input" : "Select"))
@@ -868,15 +1029,29 @@ Item {
     requestActive = !!doneFile
     dmenuWidth = Math.max(1, Number(payload.width || 300))
     dmenuMaxHeight = Math.max(0, Number(payload.maxHeight || 0))
+    inspectKeybindings = mode === "select" && payload.inspectKeybindings === true
+    inspectionOptions = Array.isArray(payload.inspectionOptions) ? payload.inspectionOptions : []
+    inspectionBlockedReason = String(payload.inspectionBlockedReason || "")
     activeMenu = "root"
     navStack = []
     filterText = ""
+    root.resetChordState()
+    chordCaptureState = inspectKeybindings
+      ? (inspectionBlockedReason ? "text-only" : "arming")
+      : "inactive"
     selectedIndex = 0
     cursorActive = mode !== "input"
     root.disarmPointer()
     opened = true
     rebuildDisplay()
 
+    if (chordCaptureState === "arming") {
+      // Cancellation sets enabled=false inside ShortcutInhibitor. Re-enable it
+      // for each new request so a later inspector can recover.
+      shortcutInhibitor.enabled = true
+      if (shortcutInhibitor.active) chordCaptureState = "ready"
+      else captureArmTimer.restart()
+    }
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
   ListModel { id: displayModel }
@@ -936,6 +1111,16 @@ Item {
         if (root.filterText.trim()) root.loadProvidersForSearch()
       }
       root.startNextProvider()
+    }
+  }
+
+  Timer {
+    id: captureArmTimer
+    interval: 1200
+    repeat: false
+    onTriggered: {
+      if (root.opened && root.chordCaptureState === "arming")
+        root.fallBackToTextOnly("Shortcut capture could not be activated")
     }
   }
 
@@ -1064,13 +1249,38 @@ Item {
   }
   PanelWindow {
     id: panel
-    visible: root.opened && root.rowsLoaded
+    visible: root.opened && (root.dmenuActive || root.rowsLoaded)
     anchors { top: true; bottom: true; left: true; right: true }
     color: "transparent"
     WlrLayershell.namespace: "omarchy-menu"
     WlrLayershell.layer: WlrLayer.Overlay
     WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
     exclusionMode: ExclusionMode.Ignore
+
+    // Exclusive keyboard focus decides where a key event goes; it does not stop
+    // Hyprland from acting on its own binds first. Without this, a chord
+    // pressed over the guide runs its action and never reaches QML at all.
+    // Scoped to the keybindings request and released with the surface.
+    ShortcutInhibitor {
+      id: shortcutInhibitor
+      window: panel
+      enabled: false
+      // The compositor can hand inhibition back at any time. Close this
+      // request immediately; a later request starts a fresh enable cycle.
+      onCancelled: {
+        if (root.opened && root.inspectKeybindings) root.cancel()
+      }
+      onActiveChanged: {
+        if (active && root.opened && root.chordCaptureState === "arming") {
+          captureArmTimer.stop()
+          root.chordCaptureState = "ready"
+        } else if (!active && root.opened && root.chordCaptureState === "ready") {
+          // Once readiness was promised, losing it closes the request before
+          // another chord can be mistaken for a harmless lookup.
+          root.cancel()
+        }
+      }
+    }
 
     // The card opens centered exactly as always. The first search keystroke
     // or submenu move freezes the top line where it currently sits — from
@@ -1118,6 +1328,14 @@ Item {
         anchors.fill: parent
         z: root.deleteConfirmOpen ? 20 : 0
         focus: true
+        onActiveFocusChanged: {
+          if (!activeFocus && root.opened && root.chordCaptureState === "ready") {
+            Qt.callLater(function() {
+              if (root.opened && !keyCatcher.activeFocus && root.chordCaptureState === "ready")
+                root.cancel()
+            })
+          }
+        }
 
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
@@ -1126,11 +1344,55 @@ Item {
             return
           }
 
+          // A chord is a question about a shortcut, not a menu control, so it
+          // is read before the controls that share its keys: CTRL+ALT+DELETE
+          // would otherwise be taken for the uninstall shortcut and SUPER+LEFT
+          // for a step back. Bare Escape still exits; modified Escape is a chord.
+          if (root.chordCaptureReady) {
+            var keyKind = MenuModel.classifyKeyEvent(
+              event.key, event.modifiers, event.text, event.isAutoRepeat, event.nativeScanCode)
+
+            if (keyKind === "repeat") {
+              event.accepted = true
+              return
+            }
+            if (keyKind === "chord") {
+              // A second non-modifier while the first is still held is not a
+              // real Hyprland chord. Drop back to text search instead of
+              // replacing Tab with the new key or silently ignoring it.
+              if (root.chordQuery && root.chordHoldKey
+                  && !root.sameChordHold(event)) {
+                root.clearChord()
+                event.accepted = true
+                return
+              }
+              root.showChord(event.key, event.modifiers, event.nativeScanCode)
+              event.accepted = true
+              return
+            }
+            if (keyKind === "unsupported") {
+              // Swallow so Hyprland does not fire, but leave the search UI alone.
+              event.accepted = true
+              return
+            }
+            if (keyKind === "text"
+                && event.text
+                && (event.modifiers & (Qt.ControlModifier | Qt.AltModifier | Qt.GroupSwitchModifier))) {
+              root.setFilter(root.filterText + event.text)
+              event.accepted = true
+              return
+            }
+          }
+
           if (event.key === Qt.Key_Delete) {
             root.requestDeleteSelected()
             event.accepted = true
-          } else if (event.key === Qt.Key_Escape) {
-            if (root.filterText) root.setFilter("")
+          } else if (event.key === Qt.Key_Escape
+              && !(event.modifiers & (Qt.MetaModifier | Qt.ControlModifier | Qt.AltModifier))) {
+            // Peel one layer at a time, and always leave through the client:
+            // this is the way out of an inhibited keyboard.
+            if (root.chordQuery) root.clearChord()
+            else if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
@@ -1160,6 +1422,22 @@ Item {
             event.accepted = true
           } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
             root.setFilter(root.filterText + event.text)
+            event.accepted = true
+          }
+        }
+
+        Keys.onReleased: function(event) {
+          if (root.deleteConfirmOpen) return
+          // Auto-repeat is synthesized as release+press pairs. Clearing on those
+          // would drop the chord UI while the key is still held.
+          if (event.isAutoRepeat) {
+            event.accepted = true
+            return
+          }
+          // Only the key that established the chord ends a still-active lookup.
+          // Settle onto the match in the full list; Escape still uses clearChord.
+          if (root.chordQuery && root.sameChordHold(event)) {
+            root.settleChordSelection()
             event.accepted = true
           }
         }
@@ -1203,9 +1481,18 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            text: root.filterText || (root.dmenuActive ? (root.dmenuPrompt + "…") : ((root.item(root.activeMenu) ? (root.item(root.activeMenu).title || root.item(root.activeMenu).label) : "Go") + "…"))
+            // A chord reads as the shortcut that was pressed, printed the way
+            // the rows print theirs, so the answer names the question.
+            text: root.chordQuery
+              ? MenuModel.formatChord(root.chordQuery)
+              : (root.filterText
+                || (root.inspectKeybindings && root.chordCaptureState === "arming"
+                  ? "Preparing shortcut capture…"
+                  : (root.inspectKeybindings && root.chordCaptureState === "text-only"
+                    ? "Text search only — " + root.inspectionBlockedReason
+                    : (root.dmenuActive ? (root.dmenuPrompt + "…") : ((root.item(root.activeMenu) ? (root.item(root.activeMenu).title || root.item(root.activeMenu).label) : "Go") + "…")))))
             color: root.foreground
-            opacity: root.filterText ? 1 : 0.58
+            opacity: (root.filterText || root.chordQuery) ? 1 : 0.58
             font.family: root.fontFamily
             font.pixelSize: Style.font.heading
             elide: Text.ElideRight

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -384,6 +384,281 @@ function displayRow(items, itemOrder, checkedResults, disabledResults, entry, de
   }
 }
 
+// ------------------------------------------------------- keybinding chords
+//
+// The keybindings guide reads both directions: typed words find a shortcut,
+// and a shortcut pressed physically finds its description. Both sides have to
+// agree on one spelling of a chord, so everything below reduces to the same
+// canonical string -- modifiers in the order `omarchy-menu-keybindings` prints
+// them, then the key:
+//
+//   SUPER+SHIFT+F
+//   CTRL+ALT+DELETE
+//   PRINT
+//
+// Qt's enum values are written out rather than read off the `Qt` namespace:
+// this file is plain JavaScript that Node loads directly in the shell tests,
+// where no Qt exists.
+var CHORD_MOD_SHIFT = 0x02000000
+var CHORD_MOD_CONTROL = 0x04000000
+var CHORD_MOD_ALT = 0x08000000
+var CHORD_MOD_META = 0x10000000
+var CHORD_MOD_KEYPAD = 0x20000000
+var CHORD_MOD_GROUP_SWITCH = 0x40000000
+var CHORD_KNOWN_MODIFIERS = CHORD_MOD_SHIFT | CHORD_MOD_CONTROL | CHORD_MOD_ALT
+  | CHORD_MOD_META | CHORD_MOD_KEYPAD | CHORD_MOD_GROUP_SWITCH
+
+// The order `modmask_to_text` in `bin/omarchy-menu-keybindings` emits, so a
+// captured chord and a rendered row sort their modifiers alike.
+var CHORD_MOD_ORDER = ["SUPER", "SHIFT", "CTRL", "ALT"]
+
+// A modifier held down is not a chord on its own. AltGr arrives as its own
+// keysym on some stacks and as Ctrl+Alt on others, so it never names a key.
+var CHORD_MODIFIER_KEYS = {
+  0x01000020: true, // Shift
+  0x01000021: true, // Control
+  0x01000022: true, // Meta
+  0x01000023: true, // Alt
+  0x01000024: true, // CapsLock
+  0x01000025: true, // NumLock
+  0x01000026: true, // ScrollLock
+  0x01001103: true  // AltGr
+}
+
+// Keys whose Omarchy spelling is not simply the character they type. The
+// names on the right are what `hyprctl binds` reports and the guide renders,
+// including `~` for the key Hyprland calls grave.
+var CHORD_KEY_NAMES = {
+  0x20: "SPACE",
+  0x2c: "COMMA",
+  0x2d: "MINUS",
+  0x2e: "PERIOD",
+  0x2f: "SLASH",
+  0x3b: "SEMICOLON",
+  0x3d: "EQUAL",
+  0x5b: "BRACKETLEFT",
+  0x5c: "BACKSLASH",
+  0x5d: "BRACKETRIGHT",
+  0x60: "~",
+  0x27: "APOSTROPHE",
+  0x01000000: "ESCAPE",
+  0x01000001: "TAB",
+  0x01000002: "TAB",
+  0x01000003: "BACKSPACE",
+  0x01000004: "RETURN",
+  0x01000005: "RETURN",
+  0x01000006: "INSERT",
+  0x01000007: "DELETE",
+  0x01000009: "PRINT",
+  0x01000010: "HOME",
+  0x01000011: "END",
+  0x01000012: "LEFT",
+  0x01000013: "UP",
+  0x01000014: "RIGHT",
+  0x01000015: "DOWN",
+  0x01000016: "PRIOR",
+  0x01000017: "NEXT"
+}
+
+// XKB keycodes Hyprland uses for `code:N` binds and that Qt reports as
+// `nativeScanCode`. When Shift is held Qt often emits Key_Exclam instead of
+// Key_1; the scan code is what still names the physical key.
+var CHORD_SCAN_KEY_NAMES = {
+  10: "1", 11: "2", 12: "3", 13: "4", 14: "5",
+  15: "6", 16: "7", 17: "8", 18: "9", 19: "0",
+  20: "MINUS", 21: "EQUAL",
+  24: "Q", 25: "W", 26: "E", 27: "R", 28: "T",
+  29: "Y", 30: "U", 31: "I", 32: "O", 33: "P",
+  67: "F1", 68: "F2", 69: "F3", 70: "F4", 71: "F5", 72: "F6",
+  73: "F7", 74: "F8", 75: "F9", 76: "F10", 77: "F11", 78: "F12"
+}
+
+// Keys that mean a chord with no modifier at all, because they carry no text
+// and the guide has nothing else to do with them. Deliberately an allowlist:
+// arrows, Enter, Tab, Backspace, Delete and the paging keys steer the menu and
+// must keep doing that.
+function chordStandsAlone(key) {
+  if (key === 0x01000009) return true                    // Print
+  if (key >= 0x01000030 && key <= 0x0100003b) return true // F1..F12
+  return false
+}
+
+function chordStandsAloneScan(nativeScanCode) {
+  var scan = Number(nativeScanCode) || 0
+  return scan >= 67 && scan <= 78
+}
+
+// The name the guide would print for a Qt key, or "" when this file cannot
+// say. An unknown key reports no match rather than being mapped to a
+// neighbouring row: naming the wrong action is worse than naming none.
+function chordKeyName(key) {
+  var code = Number(key)
+
+  if (CHORD_MODIFIER_KEYS[code]) return ""
+  if (CHORD_KEY_NAMES[code]) return CHORD_KEY_NAMES[code]
+  if (code >= 0x30 && code <= 0x39) return String.fromCharCode(code) // 0..9
+  if (code >= 0x41 && code <= 0x5a) return String.fromCharCode(code) // A..Z
+  if (code >= 0x01000030 && code <= 0x0100003b) return "F" + (code - 0x01000030 + 1)
+
+  return ""
+}
+
+function chordKeyNameFromScan(nativeScanCode) {
+  var scan = Number(nativeScanCode) || 0
+  return CHORD_SCAN_KEY_NAMES[scan] || ""
+}
+
+// Canonical spelling for a modifier list plus a key, whatever order the
+// modifiers arrived in.
+function normalizeChord(modifiers, key) {
+  var held = {}
+  var list = Array.isArray(modifiers) ? modifiers : []
+
+  for (var i = 0; i < list.length; i++) {
+    var name = String(list[i] || "").trim().toUpperCase()
+    if (name === "CONTROL") name = "CTRL"
+    if (name === "WIN" || name === "META" || name === "MOD") name = "SUPER"
+    if (CHORD_MOD_ORDER.indexOf(name) < 0) return ""
+    held[name] = true
+  }
+
+  var parts = []
+  for (var m = 0; m < CHORD_MOD_ORDER.length; m++) {
+    if (held[CHORD_MOD_ORDER[m]]) parts.push(CHORD_MOD_ORDER[m])
+  }
+
+  var keyName = String(key || "").trim().toUpperCase()
+  if (!keyName) return ""
+  parts.push(keyName)
+
+  return parts.join("+")
+}
+
+// Canonical spelling for a physical key press. Returns "" when the key is a
+// modifier on its own or one this file cannot name. Prefer the scan code when
+// Super/Ctrl/Alt is held (or for bare F-keys) so Shift+digit and Fn-layer
+// F-keys still match Hyprland's code:N / Fn rows.
+function normalizeChordFromEvent(key, modifiers, nativeScanCode) {
+  var mask = Number(modifiers) || 0
+  if (mask & ~CHORD_KNOWN_MODIFIERS) return ""
+  if (mask & (CHORD_MOD_KEYPAD | CHORD_MOD_GROUP_SWITCH)) return ""
+
+  var keyName = chordKeyName(key)
+  var scanName = chordKeyNameFromScan(nativeScanCode)
+  var useScan = !!(mask & (CHORD_MOD_META | CHORD_MOD_CONTROL | CHORD_MOD_ALT))
+    || chordStandsAlone(Number(key))
+    || chordStandsAloneScan(nativeScanCode)
+  if (useScan && scanName) keyName = scanName
+  if (!keyName) return ""
+
+  var held = []
+  if (mask & CHORD_MOD_META) held.push("SUPER")
+  if (mask & CHORD_MOD_SHIFT) held.push("SHIFT")
+  if (mask & CHORD_MOD_CONTROL) held.push("CTRL")
+  if (mask & CHORD_MOD_ALT) held.push("ALT")
+
+  return normalizeChord(held, keyName)
+}
+
+// Whether a key press is asking "what does this shortcut do?" rather than
+// typing into the filter.
+//
+// Shift plus a printable key is text, or capitals could not be searched for.
+// Bare Escape is never a chord: it is the way out of an inhibited keyboard.
+// SUPER+ESCAPE (and other modified Escapes) remain inspectable chords.
+function printableEventText(text) {
+  var value = String(text || "")
+  return value.length === 1 && value.charCodeAt(0) >= 32 && value.charCodeAt(0) !== 127
+}
+
+function isMenuControlKey(key) {
+  return key === 0x01000000 || // Escape
+    key === 0x01000001 ||      // Tab
+    key === 0x01000003 ||      // Backspace
+    key === 0x01000004 ||      // Return
+    key === 0x01000005 ||      // Enter
+    key === 0x01000007 ||      // Delete
+    (key >= 0x01000010 && key <= 0x01000017) // Home..PageDown
+}
+
+// Classify before QML decides which path may consume the event. Unsupported
+// means the press is swallowed without updating the chord UI; QML treats it as
+// a silent no-op rather than a sticky banner. Bare Escape stays the way out of
+// an inhibited keyboard; Escape with Super/Ctrl/Alt is a chord (e.g. SUPER+ESCAPE).
+function classifyKeyEvent(key, modifiers, text, autoRepeat, nativeScanCode) {
+  var code = Number(key)
+  var mask = Number(modifiers) || 0
+  if (autoRepeat) return "repeat"
+  if (CHORD_MODIFIER_KEYS[code]) return "modifier"
+  if (code === 0x01000000
+      && !(mask & (CHORD_MOD_META | CHORD_MOD_CONTROL | CHORD_MOD_ALT)))
+    return "control"
+  if (mask & ~CHORD_KNOWN_MODIFIERS) return "unsupported"
+
+  // Shift-only printable input is search text. Group-switch/AltGr is text too;
+  // Qt stacks that expose AltGr only as Ctrl+Alt still provide translated text.
+  if (printableEventText(text)
+      && (!(mask & (CHORD_MOD_META | CHORD_MOD_CONTROL | CHORD_MOD_ALT))
+          || (!(mask & CHORD_MOD_META) && (mask & CHORD_MOD_GROUP_SWITCH))
+          || (!(mask & CHORD_MOD_META)
+            && (mask & (CHORD_MOD_CONTROL | CHORD_MOD_ALT)) === (CHORD_MOD_CONTROL | CHORD_MOD_ALT))))
+    return "text"
+
+  if (mask & (CHORD_MOD_KEYPAD | CHORD_MOD_GROUP_SWITCH)) return "unsupported"
+
+  var asksForChord = !!(mask & (CHORD_MOD_META | CHORD_MOD_CONTROL | CHORD_MOD_ALT))
+    || ((mask & CHORD_MOD_SHIFT) && code === 0x01000002)
+    || chordStandsAlone(code)
+    || chordStandsAloneScan(nativeScanCode)
+  if (!asksForChord)
+    return isMenuControlKey(code) ? "control" : (code >= 0x01000000 ? "unsupported" : "control")
+
+  return normalizeChordFromEvent(code, mask, nativeScanCode) ? "chord" : "unsupported"
+}
+
+function isChordEvent(key, modifiers, text, nativeScanCode) {
+  return classifyKeyEvent(key, modifiers, text, false, nativeScanCode) === "chord"
+}
+
+// Structured records travel beside display strings. Formatting can now change
+// without changing lookup semantics, and excluded rows remain text-searchable.
+function findRowsForChord(options, chord) {
+  var wanted = String(chord || "")
+  var matches = []
+  var unsupported = false
+  var reasons = []
+  if (!wanted) return { matches: matches, unsupported: false, reasons: reasons }
+
+  var list = Array.isArray(options) ? options : []
+  for (var i = 0; i < list.length; i++) {
+    var option = list[i] || {}
+    var chords = Array.isArray(option.chords) ? option.chords : []
+    for (var c = 0; c < chords.length; c++) {
+      if (String(chords[c]) !== wanted) continue
+      if (option.inspectable === true) {
+        matches.push(i)
+      } else {
+        unsupported = true
+        var reason = String(option.reason || "")
+        if (reason && reasons.indexOf(reason) < 0) reasons.push(reason)
+      }
+      break
+    }
+  }
+
+  return { matches: matches, unsupported: unsupported, reasons: reasons }
+}
+
+// A canonical chord written the way the guide prints it, for the header line
+// that reports what was pressed.
+function formatChord(chord) {
+  var parts = String(chord || "").split("+")
+  if (parts.length < 2) return parts[0] || ""
+
+  var key = parts[parts.length - 1]
+  return parts.slice(0, parts.length - 1).join(" ") + " + " + key
+}
+
 // Commands a `checked:` expression reads a value out of. Every sibling row
 // asks the same one -- Defaults > Browser has seven rows all comparing
 // against `omarchy-default-browser` -- so the batch runs it once and the rows
@@ -519,6 +794,13 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
     searchScore: searchScore,
-    displayRow: displayRow
+    displayRow: displayRow,
+    normalizeChord: normalizeChord,
+    normalizeChordFromEvent: normalizeChordFromEvent,
+    chordKeyNameFromScan: chordKeyNameFromScan,
+    classifyKeyEvent: classifyKeyEvent,
+    isChordEvent: isChordEvent,
+    findRowsForChord: findRowsForChord,
+    formatChord: formatChord
   }
 }

--- a/test/shell.d/keybinding-inspector-test.sh
+++ b/test/shell.d/keybinding-inspector-test.sh
@@ -1,0 +1,529 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+
+// Qt enum values, spelled out here for the same reason MenuModel.js spells
+// them out: Node has no Qt namespace to read them from.
+const SHIFT = 0x02000000
+const CTRL = 0x04000000
+const ALT = 0x08000000
+const SUPER = 0x10000000
+
+const Key_0 = 0x30
+const Key_1 = 0x31
+const Key_A = 0x41
+const Key_F = 0x46
+const Key_K = 0x4b
+const Key_Q = 0x51
+const Key_W = 0x57
+const Key_Space = 0x20
+const Key_Exclam = 0x21
+const Key_At = 0x40
+const Key_Grave = 0x60
+const Key_Escape = 0x01000000
+const Key_Tab = 0x01000001
+const Key_Backtab = 0x01000002
+const Key_Backspace = 0x01000003
+const Key_Return = 0x01000004
+const Key_Delete = 0x01000007
+const Key_Print = 0x01000009
+const Key_Home = 0x01000010
+const Key_Left = 0x01000012
+const Key_PageUp = 0x01000016
+const Key_Shift = 0x01000020
+const Key_Control = 0x01000021
+const Key_Meta = 0x01000022
+const Key_Alt = 0x01000023
+const Key_F5 = 0x01000034
+const Key_F9 = 0x01000038
+const Key_F13 = 0x0100003c
+const Key_VolumeMute = 0x01000071
+const Key_Question = 0x3f
+const KEYPAD = 0x20000000
+const GROUP_SWITCH = 0x40000000
+
+// ------------------------------------------------------------- normalization
+
+assertEqual(menu.normalizeChordFromEvent(Key_F, SUPER | SHIFT), 'SUPER+SHIFT+F',
+  'a captured chord spells its modifiers in the guide order')
+assertEqual(menu.normalizeChordFromEvent(Key_F, SHIFT | SUPER), 'SUPER+SHIFT+F',
+  'the order modifiers arrive in does not change the chord')
+assertEqual(menu.normalizeChordFromEvent(Key_Delete, CTRL | ALT), 'CTRL+ALT+DELETE',
+  'a named key normalizes to the name the guide prints')
+assertEqual(menu.normalizeChordFromEvent(Key_W, SUPER | SHIFT | CTRL | ALT), 'SUPER+SHIFT+CTRL+ALT+W',
+  'every modifier at once still sorts into one order')
+assertEqual(menu.normalizeChordFromEvent(Key_Print, 0), 'PRINT',
+  'a chord with no modifier is just its key')
+assertEqual(menu.normalizeChordFromEvent(Key_F9, 0), 'F9',
+  'function keys resolve to their printed name')
+assertEqual(menu.normalizeChordFromEvent(Key_Space, SUPER), 'SUPER+SPACE',
+  'space normalizes to the word Hyprland reports')
+assertEqual(menu.normalizeChordFromEvent(Key_0, SUPER | SHIFT | ALT), 'SUPER+SHIFT+ALT+0',
+  'digits carry through as themselves')
+assertEqual(menu.normalizeChordFromEvent(Key_1, SUPER), 'SUPER+1',
+  'a bare digit key with Super still names without needing a scan code')
+assertEqual(menu.normalizeChordFromEvent(Key_Question, SUPER | SHIFT), '',
+  'layout-dependent shifted punctuation fails closed')
+assertEqual(menu.normalizeChordFromEvent(Key_Backtab, SHIFT), 'SHIFT+TAB',
+  'Backtab resolves to the shifted Tab chord Hyprland reports')
+assertEqual(menu.normalizeChordFromEvent(Key_Tab, SUPER), 'SUPER+TAB',
+  'Tab with Super names the workspace chord')
+assertEqual(menu.normalizeChordFromEvent(Key_Backtab, SUPER | SHIFT), 'SUPER+SHIFT+TAB',
+  'Backtab with Super and Shift names the reverse workspace chord')
+
+// Shifted number-row keysyms lie; XKB scan codes 10–19 name the physical keys
+assertEqual(menu.normalizeChordFromEvent(Key_Exclam, SUPER | SHIFT, 10), 'SUPER+SHIFT+1',
+  'Shift+1 via Key_Exclam still names digit 1 from scan code 10')
+assertEqual(menu.normalizeChordFromEvent(Key_At, SUPER | SHIFT, 11), 'SUPER+SHIFT+2',
+  'Shift+2 via Key_At still names digit 2 from scan code 11')
+assertEqual(menu.normalizeChordFromEvent(0x23, SUPER | SHIFT, 12), 'SUPER+SHIFT+3',
+  'Shift+3 via Key_NumberSign still names digit 3 from scan code 12')
+assertEqual(menu.normalizeChordFromEvent(0x24, SUPER | SHIFT, 13), 'SUPER+SHIFT+4',
+  'Shift+4 via Key_Dollar still names digit 4 from scan code 13')
+assertEqual(menu.normalizeChordFromEvent(0x25, SUPER | SHIFT, 14), 'SUPER+SHIFT+5',
+  'Shift+5 via Key_Percent still names digit 5 from scan code 14')
+assertEqual(menu.normalizeChordFromEvent(0x5e, SUPER | SHIFT, 15), 'SUPER+SHIFT+6',
+  'Shift+6 via Key_AsciiCircum still names digit 6 from scan code 15')
+assertEqual(menu.normalizeChordFromEvent(0x26, SUPER | SHIFT, 16), 'SUPER+SHIFT+7',
+  'Shift+7 via Key_Ampersand still names digit 7 from scan code 16')
+assertEqual(menu.normalizeChordFromEvent(0x2a, SUPER | SHIFT, 17), 'SUPER+SHIFT+8',
+  'Shift+8 via Key_Asterisk still names digit 8 from scan code 17')
+assertEqual(menu.normalizeChordFromEvent(0x28, SUPER | SHIFT, 18), 'SUPER+SHIFT+9',
+  'Shift+9 via Key_ParenLeft still names digit 9 from scan code 18')
+assertEqual(menu.normalizeChordFromEvent(0x29, SUPER | SHIFT, 19), 'SUPER+SHIFT+0',
+  'Shift+0 via Key_ParenRight still names digit 0 from scan code 19')
+assertEqual(menu.chordKeyNameFromScan(20), 'MINUS',
+  'scan code 20 names MINUS')
+assertEqual(menu.chordKeyNameFromScan(21), 'EQUAL',
+  'scan code 21 names EQUAL')
+
+assertEqual(menu.normalizeChordFromEvent(Key_VolumeMute, 0, 71), 'F5',
+  'an odd Fn-layer keysym still names F5 from scan code 71 when stands-alone')
+assertEqual(menu.normalizeChordFromEvent(Key_VolumeMute, SUPER, 71), 'SUPER+F5',
+  'scan-named F5 works with Super held')
+assertEqual(menu.classifyKeyEvent(Key_VolumeMute, 0, '', false, 71), 'chord',
+  'scan code 71 asks for a chord even when the keysym is a media key')
+
+// Hyprland calls the key left of 1 "grave" and the guide renders the symbol
+// printed on it, so a capture has to arrive at the same spelling.
+assertEqual(menu.normalizeChordFromEvent(Key_Grave, SUPER), 'SUPER+~',
+  'the grave key normalizes to the symbol printed on it')
+
+// A modifier held on its own names no chord, so nothing is looked up until a
+// real key arrives.
+for (const [key, name] of [[Key_Shift, 'shift'], [Key_Control, 'ctrl'], [Key_Meta, 'super'], [Key_Alt, 'alt']]) {
+  assertEqual(menu.normalizeChordFromEvent(key, SUPER), '',
+    `a held ${name} key names no chord by itself`)
+}
+
+// Naming the wrong action is worse than naming none.
+assertEqual(menu.normalizeChordFromEvent(0x0100ffff, SUPER), '',
+  'a key this side cannot name resolves to no chord at all')
+
+assertEqual(menu.normalizeChord(['ctrl', 'Control', 'WIN'], 'k'), 'SUPER+CTRL+K',
+  'modifier spellings collapse onto the canonical names')
+assertEqual(menu.normalizeChord(['SUPER', 'HYPER'], 'k'), '',
+  'unknown modifier names are rejected instead of silently discarded')
+assertEqual(menu.normalizeChordFromEvent(Key_W, SUPER | 0x1), '',
+  'unknown Qt modifier bits are rejected instead of creating a false match')
+
+// ----------------------------------------------------------- classification
+
+assertEqual(menu.classifyKeyEvent(Key_K, CTRL, '', false), 'chord',
+  'Ctrl and a letter asks what the shortcut does')
+assertEqual(menu.classifyKeyEvent(Key_F, SUPER | SHIFT, 'F', false), 'chord',
+  'Super with Shift and a letter is a chord')
+assertEqual(menu.classifyKeyEvent(Key_Left, SUPER, '', false), 'chord',
+  'an arrow held with a modifier is a chord')
+assertEqual(menu.classifyKeyEvent(Key_Delete, CTRL | ALT, '', false), 'chord',
+  'Delete held with modifiers is a chord')
+assertEqual(menu.classifyKeyEvent(Key_Print, 0, '', false), 'chord',
+  'Print alone is a chord')
+assertEqual(menu.classifyKeyEvent(Key_F9, 0, '', false), 'chord',
+  'a function key alone is a chord')
+assertEqual(menu.classifyKeyEvent(Key_Backtab, SHIFT, '', false), 'chord',
+  'Backtab is inspected as Shift Tab')
+assertEqual(menu.classifyKeyEvent(Key_Tab, SUPER, '', false), 'chord',
+  'Tab with Super is captured as a chord, not menu control')
+assertEqual(menu.classifyKeyEvent(Key_Exclam, SUPER | SHIFT, '!', false, 10), 'chord',
+  'Shift+digit via a shifted keysym still classifies as a chord with its scan code')
+assertEqual(menu.classifyKeyEvent(Key_VolumeMute, 0, '', false), 'unsupported',
+  'media keys fail closed outside physical inspection')
+assertEqual(menu.classifyKeyEvent(Key_F13, 0, '', false), 'unsupported',
+  'function keys beyond F12 fail closed outside the strict MVP')
+
+// Typing has to keep working, capitals included.
+assertEqual(menu.classifyKeyEvent(Key_F, 0, 'f', false), 'text',
+  'a bare letter is text, not a chord')
+assertEqual(menu.classifyKeyEvent(Key_F, SHIFT, 'F', false), 'text',
+  'Shift and a letter stays text so capitals can be searched for')
+assertEqual(menu.classifyKeyEvent(Key_Q, CTRL | ALT, '@', false), 'text',
+  'AltGr exposed as Ctrl Alt remains translated text')
+assertEqual(menu.classifyKeyEvent(Key_Q, SUPER | CTRL | ALT, '@', false), 'chord',
+  'Super prevents a real Ctrl Alt chord from being mistaken for AltGr text')
+assertEqual(menu.classifyKeyEvent(Key_Q, GROUP_SWITCH, '@', false), 'text',
+  'an explicit group-switch modifier remains text')
+assertEqual(menu.classifyKeyEvent(Key_Q, SUPER | CTRL | ALT | GROUP_SWITCH, '@', false), 'unsupported',
+  'Super plus group-switch fails closed instead of becoming AltGr text')
+assertEqual(menu.classifyKeyEvent(Key_Question, SUPER | SHIFT, '?', false), 'unsupported',
+  'translated shifted punctuation cannot false-match a non-US base key')
+assertEqual(menu.classifyKeyEvent(Key_Q, SUPER | 0x1, '', false), 'unsupported',
+  'unknown modifiers fail closed')
+assertEqual(menu.classifyKeyEvent(Key_0, SUPER | KEYPAD, '', false), 'unsupported',
+  'keypad context is not collapsed onto the main keyboard')
+assertEqual(menu.classifyKeyEvent(Key_W, SUPER, '', true), 'repeat',
+  'auto-repeat never initiates a lookup')
+
+// Keys that steer the menu keep steering it when nothing is held.
+for (const [key, name] of [[Key_Left, 'an arrow'], [Key_Return, 'Enter'], [Key_Tab, 'Tab'],
+                           [Key_Backspace, 'Backspace'], [Key_Delete, 'Delete'],
+                           [Key_PageUp, 'PageUp'], [Key_Home, 'Home']]) {
+  assertEqual(menu.classifyKeyEvent(key, 0, '', false), 'control',
+    `${name} on its own still drives the menu`)
+}
+
+// Bare Escape is the way out of an inhibited keyboard. Modified Escape is a
+// real binding (SUPER+ESCAPE) and must inspect like any other chord.
+assertEqual(menu.classifyKeyEvent(Key_Escape, 0, '', false), 'control',
+  'bare Escape is never a chord')
+assertEqual(menu.classifyKeyEvent(Key_Escape, SUPER, '', false), 'chord',
+  'Super+Escape is inspected as a chord')
+assertEqual(menu.normalizeChordFromEvent(Key_Escape, SUPER), 'SUPER+ESCAPE',
+  'Super+Escape normalizes to the guide chord')
+assertEqual(menu.classifyKeyEvent(Key_Escape, CTRL | ALT, '', false), 'chord',
+  'Ctrl+Alt+Escape is inspected as a chord')
+
+// A modifier press updates the held state but asks nothing.
+for (const [key, name] of [[Key_Shift, 'shift'], [Key_Control, 'ctrl'], [Key_Meta, 'super'], [Key_Alt, 'alt']]) {
+  assertEqual(menu.classifyKeyEvent(key, SUPER, '', false), 'modifier',
+    `a ${name} press on its own asks nothing`)
+}
+
+// ------------------------------------------------------- structured records
+
+const rows = [
+  { chords: ['SUPER+K'], inspectable: true, reason: '' },
+  { chords: ['SUPER+SHIFT+F'], inspectable: true, reason: '' },
+  { chords: ['SUPER+W', 'SUPER+Q'], inspectable: true, reason: '' },
+  { chords: ['CTRL+ALT+DELETE'], inspectable: true, reason: '' },
+  { chords: ['PRINT'], inspectable: true, reason: '' },
+  { chords: ['SUPER+LEFT MOUSE BUTTON'], inspectable: false, reason: 'non-keyboard binding' },
+  { chords: ['SUPER+SHIFT+1'], inspectable: true, reason: '' },
+  { chords: ['SUPER+TAB'], inspectable: true, reason: '' }
+]
+
+// -------------------------------------------------------------- looking up
+
+assertDeepEqual(menu.findRowsForChord(rows, 'SUPER+SHIFT+F').matches, [1],
+  'a chord finds the row that describes it')
+assertDeepEqual(menu.findRowsForChord(rows, 'SUPER+W').matches, [2],
+  'the chord leading a shared row finds it')
+assertDeepEqual(menu.findRowsForChord(rows, 'SUPER+Q').matches, [2],
+  'the alternative chord finds the same row')
+assertDeepEqual(menu.findRowsForChord(rows, 'SUPER+SHIFT+CTRL+ALT+Y').matches, [],
+  'a chord nothing is bound to finds nothing')
+assertDeepEqual(menu.findRowsForChord(rows, '').matches, [],
+  'an unnamed chord looks nothing up')
+assertDeepEqual(
+  menu.findRowsForChord(rows, menu.normalizeChordFromEvent(Key_Exclam, SUPER | SHIFT, 10)).matches,
+  [6],
+  'a Shift+digit capture via scan code finds the workspace row')
+assertDeepEqual(
+  menu.findRowsForChord(rows, menu.normalizeChordFromEvent(Key_Tab, SUPER)).matches,
+  [7],
+  'a Super+Tab capture finds the workspace row')
+
+// Two actions can answer to one chord; the guide has to show both rather than
+// pick one.
+const duplicated = [
+  { chords: ['SUPER+Y'], inspectable: true },
+  { chords: ['SUPER+Y'], inspectable: true }
+]
+assertDeepEqual(menu.findRowsForChord(duplicated, 'SUPER+Y').matches, [0, 1],
+  'a chord bound twice reports both rows')
+
+// A capture and a rendered row have to meet: what the event normalizes to is
+// what the row is found by.
+assertDeepEqual(menu.findRowsForChord(rows, menu.normalizeChordFromEvent(Key_Delete, CTRL | ALT)).matches, [3],
+  'a captured chord finds the row rendered for it')
+assertDeepEqual(menu.findRowsForChord(rows, menu.normalizeChordFromEvent(Key_Q, SUPER)).matches, [2],
+  'a captured alternative chord finds its shared row')
+assert(menu.findRowsForChord(rows, 'SUPER+LEFT MOUSE BUTTON').unsupported,
+  'an excluded binding is reported as unsupported, not silently absent')
+
+// Labels are deliberately absent: presentation text is no longer an input to
+// reverse lookup.
+assertDeepEqual(menu.findRowsForChord([{ chords: ['SUPER+W'], inspectable: true }], 'SUPER+W').matches, [0],
+  'lookup semantics do not depend on the rendered label')
+
+// ------------------------------------------------------------- reporting it
+
+assertEqual(menu.formatChord('SUPER+SHIFT+F'), 'SUPER SHIFT + F',
+  'a chord reports itself the way the guide prints chords')
+assertEqual(menu.formatChord('PRINT'), 'PRINT',
+  'a bare key reports itself without a separator')
+assertEqual(menu.formatChord(''), '',
+  'no chord reports nothing')
+JS
+
+# ---------------------------------------------------------- request transport
+
+tmpdir=$(mktemp -d) && [[ -n $tmpdir && -d $tmpdir ]] ||
+  fail "the transport test gets a temporary directory"
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_bin="$tmpdir/bin"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "shell" && $2 == "summon" ]]; then
+  printf '%s' "$4" >"$CAPTURE_PAYLOAD"
+  if [[ ${NO_DONE_FILE:-0} != "1" ]]; then
+    perl -MJSON::PP=decode_json -e '
+      my $payload = decode_json($ARGV[0]);
+      open(my $done, ">", $payload->{doneFile}) or die $!;
+      close($done);
+    ' "$4"
+  fi
+elif [[ $1 == "shell" && $2 == "ping" ]]; then
+  exit 1
+fi
+SH
+chmod +x "$stub_bin/omarchy-shell"
+
+capture="$tmpdir/inspect.json"
+record_safe=$'SUPER + W                           → Close window\tSUPER+W\t1\t\t0'
+record_unsafe=$'SUPER + LEFT MOUSE BUTTON           → Move window\tnone\t0\tnon-keyboard binding\t0'
+record_bypass=$'SUPER + P                           → Bypass inhibition\tSUPER+P\t0\tbypasses shortcut inhibition\t1'
+
+status=0
+printf '%s\n%s\n%s\n' "$record_safe" "$record_unsafe" "$record_bypass" |
+  env PATH="$stub_bin:$PATH" CAPTURE_PAYLOAD="$capture" \
+    "$ROOT/bin/omarchy-menu-select" Keybindings -- --inspect-keybindings ||
+  status=$?
+(( status == 1 )) || fail "an empty inspector selection exits as canceled"
+
+CAPTURE_PAYLOAD="$capture" run_node_test <<'JS'
+const fs = require('fs')
+const payload = JSON.parse(fs.readFileSync(process.env.CAPTURE_PAYLOAD, 'utf8'))
+
+assert(payload.inspectKeybindings === true,
+  'the keybinding request explicitly enables inspection')
+assertDeepEqual(payload.options, [
+  'SUPER + W                           → Close window',
+  'SUPER + LEFT MOUSE BUTTON           → Move window',
+  'SUPER + P                           → Bypass inhibition'
+], 'structured metadata is removed from display labels')
+assertDeepEqual(payload.inspectionOptions[0].chords, ['SUPER+W'],
+  'canonical chords travel beside the display option')
+assert(payload.inspectionOptions[0].inspectable === true,
+  'an ordinary keyboard row stays physically inspectable')
+assert(payload.inspectionOptions[1].inspectable === false,
+  'an excluded row remains text-searchable but not physically inspectable')
+assertEqual(payload.inspectionBlockedReason, 'bypasses shortcut inhibition',
+  'one bypassing binding disables physical capture for the whole request')
+JS
+
+capture="$tmpdir/generic.json"
+status=0
+env PATH="$stub_bin:$PATH" CAPTURE_PAYLOAD="$capture" \
+  "$ROOT/bin/omarchy-menu-select" Format jpg png ||
+  status=$?
+(( status == 1 )) || fail "an empty generic selection exits as canceled"
+
+CAPTURE_PAYLOAD="$capture" run_node_test <<'JS'
+const fs = require('fs')
+const payload = JSON.parse(fs.readFileSync(process.env.CAPTURE_PAYLOAD, 'utf8'))
+
+assert(payload.inspectKeybindings === undefined,
+  'generic selectors never inherit shortcut capture')
+assert(payload.inspectionOptions === undefined,
+  'generic selectors carry no inspection metadata')
+JS
+
+capture="$tmpdir/dead-shell.json"
+status=0
+printf '%s\n' "$record_safe" |
+  env PATH="$stub_bin:$PATH" CAPTURE_PAYLOAD="$capture" NO_DONE_FILE=1 \
+    timeout 3 "$ROOT/bin/omarchy-menu-select" Keybindings -- --inspect-keybindings ||
+  status=$?
+(( status == 1 )) || fail "the selector exits when the shell dies instead of waiting forever"
+pass "a dead shell cannot strand the selector request"
+
+grep -q 'if (root.chordQuery) return' "$ROOT/shell/plugins/menu/Menu.qml" ||
+  fail "held chord results are guarded from dmenu activation"
+pass "held chord results stay display-only until release settles selection"
+
+grep -q 'root.chordCaptureState = "ready"' "$ROOT/shell/plugins/menu/Menu.qml" &&
+  grep -q 'root.fallBackToTextOnly("Shortcut capture could not be activated")' "$ROOT/shell/plugins/menu/Menu.qml" &&
+  grep -q 'if (root.opened && root.inspectKeybindings) root.cancel()' "$ROOT/shell/plugins/menu/Menu.qml" &&
+  grep -q 'else if (!active && root.opened && root.chordCaptureState === "ready")' "$ROOT/shell/plugins/menu/Menu.qml" ||
+  fail "the QML lifecycle does not fail closed around inhibitor readiness"
+pass "inhibitor denial, cancellation, and active loss fail closed"
+
+grep -q 'if (keyKind === "repeat")' "$ROOT/shell/plugins/menu/Menu.qml" ||
+  fail "the QML input path does not drop auto-repeat"
+pass "the QML input path drops auto-repeat before lookup"
+
+grep -q 'enabled: false' "$ROOT/shell/plugins/menu/Menu.qml" &&
+  grep -q 'shortcutInhibitor.enabled = true' "$ROOT/shell/plugins/menu/Menu.qml" ||
+  fail "each inspector request does not explicitly reacquire inhibition"
+pass "later inspector requests can reacquire inhibition after cancellation"
+
+(( $(grep -c 'root.prepareForReplacement()' "$ROOT/shell/plugins/menu/Menu.qml") == 2 )) &&
+  grep -q 'root.opened = false' "$ROOT/shell/plugins/menu/Menu.qml" &&
+  grep -q 'if (shortcutInhibitor.active) chordCaptureState = "ready"' "$ROOT/shell/plugins/menu/Menu.qml" ||
+  fail "reentrant requests do not finish the old caller and inherit active capture safely"
+pass "reentrant menu requests finish the old caller and preserve capture readiness"
+
+# ------------------------------------------------------- silent / release UX
+
+qml="$ROOT/shell/plugins/menu/Menu.qml"
+! grep -q 'chordStatus' "$qml" ||
+  fail "Menu.qml still references removed chordStatus"
+grep -q 'function resetChordState' "$qml" ||
+  fail "resetChordState is not defined"
+grep -q 'chordMatchIndex' "$qml" ||
+  fail "chordMatchIndex is not tracked for release settle"
+grep -q 'Keys.onReleased' "$qml" ||
+  fail "key release does not settle the chord selection"
+grep -q 'if (event.isAutoRepeat)' "$qml" ||
+  fail "auto-repeat releases are not ignored before settleChordSelection"
+grep -q 'chordHoldScan' "$qml" ||
+  fail "chord hold scan is not tracked for Shift+digit press/release keysym mismatch"
+grep -q 'function sameChordHold' "$qml" ||
+  fail "sameChordHold is not defined for scan-stable hold matching"
+grep -q 'chordHoldKey' "$qml" ||
+  fail "chord hold key is not tracked to prevent replacement while held"
+grep -q 'function settleChordSelection' "$qml" ||
+  fail "settleChordSelection is not defined"
+grep -q 'root.settleChordSelection()' "$qml" ||
+  fail "release does not settle onto the matched row"
+grep -q 'root.clearChord' "$qml" ||
+  fail "clearChord is not wired for Escape / third-key abort"
+! grep -q 'Unsupported shortcut' "$qml" ||
+  fail "Menu.qml still sets a sticky Unsupported shortcut banner"
+! grep -q 'No binding for ' "$qml" ||
+  fail "Menu.qml still sets a sticky No binding banner"
+grep -q 'event.nativeScanCode' "$qml" ||
+  fail "nativeScanCode is not passed into model calls"
+grep -q 'if (lookup.matches.length === 0)' "$qml" ||
+  fail "showChord does not stay silent when nothing matches"
+grep -q 'if (root.chordQuery) root.clearChord()' "$qml" ||
+  fail "Escape does not clear an active chord lookup"
+grep -q 'if (keyKind === "unsupported")' "$qml" ||
+  fail "unsupported presses are not accepted as silent no-ops"
+grep -q 'dmenu.' "$qml" && grep -q 'settleChordSelection' "$qml" ||
+  fail "settleChordSelection does not reselect the matched dmenu row"
+pass "silent miss, scan-code wiring, and release-to-select contracts hold in Menu.qml"
+
+# ------------------------------------------------------- allowlist parity
+
+# Names bash supported_key accepts (families, not every letter/digit). Must stay
+# produceable by MenuModel; Backtab is listed in bash but captures as TAB+Shift.
+bash_key_names=(
+  A 0
+  SPACE COMMA MINUS PERIOD SLASH SEMICOLON EQUAL BRACKETLEFT BACKSLASH BRACKETRIGHT '~' APOSTROPHE
+  TAB BACKTAB BACKSPACE RETURN INSERT DELETE HOME END LEFT UP RIGHT DOWN PRIOR NEXT PRINT ESCAPE
+  F1 F9 F12
+)
+
+supported_fn=$(sed -n '/^function supported_key/,/^}/p' "$ROOT/bin/omarchy-menu-keybindings")
+[[ -n $supported_fn ]] || fail "supported_key is missing from omarchy-menu-keybindings"
+
+for name in "${bash_key_names[@]}"; do
+  awk -v key="$name" "$supported_fn"'
+BEGIN { exit supported_key(key) ? 0 : 1 }
+' || fail "bash supported_key rejects $name (MenuModel parity list is out of date)"
+done
+pass "bash supported_key accepts the shared core key-name set"
+
+run_node_test <<'JS'
+const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+const SUPER = 0x10000000
+const SHIFT = 0x02000000
+const CTRL = 0x04000000
+
+const Key_0 = 0x30
+const Key_A = 0x41
+const Key_Space = 0x20
+const Key_Comma = 0x2c
+const Key_Minus = 0x2d
+const Key_Period = 0x2e
+const Key_Slash = 0x2f
+const Key_Semicolon = 0x3b
+const Key_Equal = 0x3d
+const Key_BracketLeft = 0x5b
+const Key_Backslash = 0x5c
+const Key_BracketRight = 0x5d
+const Key_Apostrophe = 0x27
+const Key_Grave = 0x60
+const Key_Escape = 0x01000000
+const Key_Tab = 0x01000001
+const Key_Backtab = 0x01000002
+const Key_Backspace = 0x01000003
+const Key_Return = 0x01000004
+const Key_Insert = 0x01000006
+const Key_Delete = 0x01000007
+const Key_Print = 0x01000009
+const Key_Home = 0x01000010
+const Key_End = 0x01000011
+const Key_Left = 0x01000012
+const Key_Up = 0x01000013
+const Key_Right = 0x01000014
+const Key_Down = 0x01000015
+const Key_PageUp = 0x01000016
+const Key_PageDown = 0x01000017
+const Key_F1 = 0x01000030
+const Key_F9 = 0x01000038
+const Key_F12 = 0x0100003b
+
+const cases = [
+  ['A', menu.normalizeChordFromEvent(Key_A, SUPER), 'SUPER+A'],
+  ['0', menu.normalizeChordFromEvent(Key_0, SUPER), 'SUPER+0'],
+  ['SPACE', menu.normalizeChordFromEvent(Key_Space, SUPER), 'SUPER+SPACE'],
+  ['COMMA', menu.normalizeChordFromEvent(Key_Comma, SUPER), 'SUPER+COMMA'],
+  ['MINUS', menu.normalizeChordFromEvent(Key_Minus, SUPER, 20), 'SUPER+MINUS'],
+  ['PERIOD', menu.normalizeChordFromEvent(Key_Period, SUPER), 'SUPER+PERIOD'],
+  ['SLASH', menu.normalizeChordFromEvent(Key_Slash, SUPER), 'SUPER+SLASH'],
+  ['SEMICOLON', menu.normalizeChordFromEvent(Key_Semicolon, SUPER), 'SUPER+SEMICOLON'],
+  ['EQUAL', menu.normalizeChordFromEvent(Key_Equal, SUPER, 21), 'SUPER+EQUAL'],
+  ['BRACKETLEFT', menu.normalizeChordFromEvent(Key_BracketLeft, SUPER), 'SUPER+BRACKETLEFT'],
+  ['BACKSLASH', menu.normalizeChordFromEvent(Key_Backslash, SUPER), 'SUPER+BACKSLASH'],
+  ['BRACKETRIGHT', menu.normalizeChordFromEvent(Key_BracketRight, SUPER), 'SUPER+BRACKETRIGHT'],
+  ['~', menu.normalizeChordFromEvent(Key_Grave, SUPER), 'SUPER+~'],
+  ['APOSTROPHE', menu.normalizeChordFromEvent(Key_Apostrophe, SUPER), 'SUPER+APOSTROPHE'],
+  ['TAB', menu.normalizeChordFromEvent(Key_Tab, SUPER), 'SUPER+TAB'],
+  // Bash lists BACKTAB; capture spells Shift+Tab as SUPER+SHIFT+TAB (same key family).
+  ['BACKTAB', menu.normalizeChordFromEvent(Key_Backtab, SUPER | SHIFT), 'SUPER+SHIFT+TAB'],
+  ['BACKSPACE', menu.normalizeChordFromEvent(Key_Backspace, SUPER), 'SUPER+BACKSPACE'],
+  ['RETURN', menu.normalizeChordFromEvent(Key_Return, SUPER), 'SUPER+RETURN'],
+  ['INSERT', menu.normalizeChordFromEvent(Key_Insert, SUPER), 'SUPER+INSERT'],
+  ['DELETE', menu.normalizeChordFromEvent(Key_Delete, CTRL | 0x08000000), 'CTRL+ALT+DELETE'],
+  ['HOME', menu.normalizeChordFromEvent(Key_Home, SUPER), 'SUPER+HOME'],
+  ['END', menu.normalizeChordFromEvent(Key_End, SUPER), 'SUPER+END'],
+  ['LEFT', menu.normalizeChordFromEvent(Key_Left, SUPER), 'SUPER+LEFT'],
+  ['UP', menu.normalizeChordFromEvent(Key_Up, SUPER), 'SUPER+UP'],
+  ['RIGHT', menu.normalizeChordFromEvent(Key_Right, SUPER), 'SUPER+RIGHT'],
+  ['DOWN', menu.normalizeChordFromEvent(Key_Down, SUPER), 'SUPER+DOWN'],
+  ['PRIOR', menu.normalizeChordFromEvent(Key_PageUp, SUPER), 'SUPER+PRIOR'],
+  ['NEXT', menu.normalizeChordFromEvent(Key_PageDown, SUPER), 'SUPER+NEXT'],
+  ['PRINT', menu.normalizeChordFromEvent(Key_Print, 0), 'PRINT'],
+  ['ESCAPE', menu.normalizeChordFromEvent(Key_Escape, SUPER), 'SUPER+ESCAPE'],
+  ['F1', menu.normalizeChordFromEvent(Key_F1, 0), 'F1'],
+  ['F9', menu.normalizeChordFromEvent(Key_F9, 0), 'F9'],
+  ['F12', menu.normalizeChordFromEvent(Key_F12, 0), 'F12']
+]
+
+for (const [name, actual, expected] of cases) {
+  assertEqual(actual, expected,
+    `MenuModel produces bash-supported key family ${name}`)
+}
+JS
+pass "MenuModel produces chords for every bash supported_key family"

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -46,6 +46,12 @@ keybindings() {
     bash "$ROOT/bin/omarchy-menu-keybindings" --print
 }
 
+inspection_records() {
+  env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$home" \
+    XDG_CACHE_HOME="$tmpdir/cache-inspection" OMARCHY_PATH="$ROOT" \
+    bash "$ROOT/bin/omarchy-menu-keybindings" --print-inspection
+}
+
 # Closing a window and toggling the scratchpad are two of the actions Omarchy
 # binds twice on purpose. The last bind carries the longest description Omarchy
 # ships, which is what puts a row closest to the width the menu allows.
@@ -97,9 +103,10 @@ pass "every entry pads its chords to the same column"
   fail "no entry outgrows the width the menu gives it" "$rendered"
 pass "no entry outgrows the width the menu gives it"
 
-# Priority ordering reads the row, and the chord sharing it must not reclassify
-# the entry: XF86Calculator alone belongs in the tail the menu keeps for media
-# keys, while the calculator itself sits in the body of the list.
+# Priority ordering reads the row. XF86Calculator is outside physical
+# inspection, so it no longer shares metadata with the ordinary Super chord;
+# the ordinary calculator stays in the body and the media key stays in the
+# tail.
 stub_hyprctl <<BINDS
 $(exec_bind 68 "SUPER CTRL + Q" "Calculator" "omacalc")
 $(exec_bind 0 "XF86Calculator" "Calculator" "omacalc")
@@ -107,17 +114,19 @@ $(exec_bind 8 "ALT + TAB" "Reveal active window on top" "true")
 BINDS
 
 rendered=$(keybindings)
-(( $(grep -n '→ Calculator$' <<<"$rendered" | cut -d: -f1) <
+(( $(grep -n 'SUPER CTRL.*→ Calculator$' <<<"$rendered" | cut -d: -f1) <
    $(grep -n '→ Reveal active window on top$' <<<"$rendered" | cut -d: -f1) )) ||
-  fail "a shared chord does not change where its entry ranks" "$rendered"
-pass "a shared chord does not change where its entry ranks"
+  fail "an excluded alternative does not change where the safe entry ranks" "$rendered"
+(( $(grep -c '→ Calculator$' <<<"$rendered") == 2 )) ||
+  fail "safe and excluded alternatives keep separate metadata rows" "$rendered"
+pass "safe and excluded alternatives keep separate rows"
 
 # The same key written as a keycode arrives by the other road: Hyprland reports
 # the code and the keymap resolves it, after the rename above has run.
 stub_hyprctl <<'BINDS'
 bind
 	modmask: 64
-	submap: 
+	submap:
 	key: 
 	keycode: 49
 	catchall: false
@@ -220,3 +229,152 @@ for action in "${expected_alternatives[@]}"; do
     fail "every action named as having an alternative is bound twice" "$action"
 done
 pass "every action named as having an alternative is bound twice"
+
+# Physical lookup reads these fields, not the padded display label. Unsafe and
+# unsupported rows stay present for ordinary text search.
+cat >"$home/.config/hypr/hyprland.lua" <<'LUA'
+hl.bind("SUPER + W", hl.dsp.exec_cmd("true"), { description = "Close window" })
+hl.bind("SUPER + I", hl.dsp.exec_cmd("true"), { description = "Ignore modifiers", ignore_mods = true })
+hl.bind("SUPER + P", hl.dsp.exec_cmd("true"), { description = "Bypass inhibition", dont_inhibit = true })
+hl.bind("SUPER + A", hl.dsp.exec_cmd("true"), { desc = "Allow input capture", allow_input_capture = true })
+hl.bind("SUPER + M + N", hl.dsp.exec_cmd("true"), { description = "Multi key" })
+hl.bind("SUPER + R", hl.dsp.exec_cmd("true"), { description = "Resize submap" })
+hl.bind("XF86AudioMute", hl.dsp.exec_cmd("true"), { description = "Mute" })
+-- Empty kind+arg (Lua function) must not collapse TSV fields and demote this.
+hl.bind("SUPER + C", function() end, { description = "Universal copy" })
+LUA
+
+stub_hyprctl <<'BINDS'
+bindd
+	modmask: 64
+	submap:
+	key: W
+	keycode: 0
+	catchall: false
+	description: Close window
+	dispatcher: exec
+	arg: true
+
+bindd
+	modmask: 64
+	submap:
+	key: I
+	keycode: 0
+	catchall: false
+	description: Ignore modifiers
+	dispatcher: exec
+	arg: true
+
+bindd
+	modmask: 64
+	submap:
+	key: P
+	keycode: 0
+	catchall: false
+	description: Bypass inhibition
+	dispatcher: exec
+	arg: true
+
+bindxd
+	modmask: 64
+	submap:
+	key: A
+	keycode: 0
+	catchall: false
+	description: Allow input capture
+	dispatcher: exec
+	arg: true
+
+bindd
+	modmask: 64
+	submap:
+	key: N
+	keycode: 0
+	catchall: false
+	description: Multi key
+	dispatcher: exec
+	arg: true
+
+bindd
+	modmask: 64
+	submap: resize
+	key: R
+	keycode: 0
+	catchall: false
+	description: Resize submap
+	dispatcher: exec
+	arg: true
+
+bindd
+	modmask: 0
+	submap:
+	key: XF86AudioMute
+	keycode: 0
+	catchall: false
+	description: Mute
+	dispatcher: exec
+	arg: true
+
+bind
+	modmask: 64
+	submap:
+	key: C
+	keycode: 0
+	catchall: false
+	description: Universal copy
+	dispatcher: __lua
+	arg: 
+BINDS
+
+metadata=$(inspection_records)
+awk -F '\t' '$1 ~ /Close window$/ && $2 == "SUPER+W" && $3 == "1" { found = 1 } END { exit !found }' <<<"$metadata" ||
+  fail "an ordinary default-submap keyboard binding is inspectable" "$metadata"
+awk -F '\t' '$1 ~ /Ignore modifiers$/ && $3 == "0" && $4 == "ignores modifiers" { found = 1 } END { exit !found }' <<<"$metadata" ||
+  fail "ignore-modifier bindings remain searchable but are not inspectable" "$metadata"
+awk -F '\t' '$1 ~ /Bypass inhibition$/ && $3 == "0" && $5 == "1" { found = 1 } END { exit !found }' <<<"$metadata" ||
+  fail "inhibitor-bypassing bindings block physical capture for the request" "$metadata"
+awk -F '\t' '$1 ~ /Allow input capture$/ && $3 == "0" && $4 == "allowed during input capture" && $5 == "0" { found = 1 } END { exit !found }' <<<"$metadata" ||
+  fail "input-capture bindings are excluded without being mistaken for shortcut-inhibitor bypasses" "$metadata"
+awk -F '\t' '$1 ~ /Multi key$/ && $3 == "0" && $4 == "multi-key binding" { found = 1 } END { exit !found }' <<<"$metadata" ||
+  fail "multi-key Lua bindings retain unsupported context omitted by hyprctl" "$metadata"
+awk -F '\t' '$1 ~ /Resize submap$/ && $3 == "0" && $4 == "non-default submap" { found = 1 } END { exit !found }' <<<"$metadata" ||
+  fail "non-default-submap bindings retain their context" "$metadata"
+awk -F '\t' '$1 ~ /Mute$/ && $3 == "0" && $4 == "media or device key" { found = 1 } END { exit !found }' <<<"$metadata" ||
+  fail "media bindings remain text-searchable but outside physical inspection" "$metadata"
+awk -F '\t' '$1 ~ /Universal copy$/ && $2 == "SUPER+C" && $3 == "1" && $4 == "" { found = 1 } END { exit !found }' <<<"$metadata" ||
+  fail "Lua function binds stay inspectable when kind and arg are empty" "$metadata"
+pass "structured inspection metadata preserves binding safety and context"
+
+# A Lua workspace bind is declared as code:10; the guide resolves that to digit
+# 1. Capture of Shift+1 arrives as Key_Exclam + scan 10 and must spell the same
+# chord the inspection record carries.
+stub_hyprctl <<BINDS
+$(lua_bind 65 "SUPER SHIFT + code:10" "Move window to workspace 1")
+BINDS
+
+workspace_meta=$(inspection_records)
+awk -F '\t' '$1 ~ /Move window to workspace 1$/ && $2 == "SUPER+SHIFT+1" { found = 1 } END { exit !found }' <<<"$workspace_meta" ||
+  fail "SUPER+SHIFT+code:10 resolves to inspection chord SUPER+SHIFT+1" "$workspace_meta"
+
+run_node_test <<'JS'
+const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+const SUPER = 0x10000000
+const SHIFT = 0x02000000
+const Key_Exclam = 0x21
+assertEqual(menu.normalizeChordFromEvent(Key_Exclam, SUPER | SHIFT, 10), 'SUPER+SHIFT+1',
+  'scan-code capture matches the SUPER+SHIFT+code:10 inspection chord')
+JS
+pass "SUPER+SHIFT+code:10 record chord matches scan-code normalize"
+
+# Escape is a named chord key in the inspector model; without it in the
+# keybindings allowlist SUPER+ESCAPE was demoted to unsupported and silent.
+stub_hyprctl <<BINDS
+$(lua_bind 64 "SUPER + ESCAPE" "System menu")
+BINDS
+
+escape_meta=$(inspection_records)
+awk -F '\t' '$2 == "SUPER+ESCAPE" && $4 == "unsupported keyboard key" { bad = 1 } END { exit bad }' <<<"$escape_meta" ||
+  fail "SUPER+ESCAPE was demoted as an unsupported keyboard key" "$escape_meta"
+awk -F '\t' '$1 ~ /System menu$/ && $2 == "SUPER+ESCAPE" { found = 1 } END { exit !found }' <<<"$escape_meta" ||
+  fail "SUPER+ESCAPE resolves to an inspection chord" "$escape_meta"
+pass "SUPER+ESCAPE remains a supported inspection key"


### PR DESCRIPTION
## Problem

The keybindings guide is great for browsing by name, but not for answering “what does *this* chord do?” without firing the binding. Typing to search still works; reverse lookup did not.

## Behavior

Open the keybindings guide (`Super + K` / `omarchy-menu-keybindings`). With shortcut capture armed:

1. **Press** a keyboard shortcut → the matching row(s) are shown. The physical chord does **not** execute (Wayland `ShortcutInhibitor`).
2. **Release** → back to the full list with that row selected.
3. **Enter** (or click) → run it like any other menu selection.

Misses stay silent (no sticky “unsupported” banners). Bare Escape exits; `Super + Escape` is inspected as a chord. Shift+digit chords (e.g. move window to workspace) match via **scan code**, because Qt often reports `Key_Exclam` on press and `Key_4` on release.

Typing still filters by text; a chord lookup is the other direction of the same guide.

## Safety

- Capture is only requested for this guide (`--inspect-keybindings`), not for every dmenu.
- While a chord is held, Enter / click do not dispatch.
- Bindings that bypass inhibition, ignore modifiers, are device/media/mouse, multi-key, or otherwise unsafe for capture stay **text-searchable** but are not physically inspectable.
- Bash `supported_key` and MenuModel naming are kept in sync via a parity test.

## Limitations

- **Media / XF86 / mouse** chords are intentionally out of physical capture (MVP keyboard-only).
- **Lua function binds** such as Universal copy/paste/cut and zoom are inspectable after metadata fixes, but menu Enter may still not reconstruct a dispatcher for pure Lua functions (same as selecting those rows by name today).
- Web-app static chords (`Shift+Alt+L/D`) remain “static binding context unavailable.”

## Tests

- `./test/shell.d/keybinding-inspector-test.sh` — normalize/classify, silent/release contracts, Shift+digit scan hold, allowlist parity
- `./test/shell.d/keybindings-menu-test.sh` — inspection metadata, `SUPER+SHIFT+code:10` round-trip, function-bind inspectability

## Test plan

- [ ] Run the two shell tests above
- [ ] Open the guide: `Super + W` → release → row selected → Enter closes the window
- [ ] `Super + Shift + digit` settles on the workspace row (not stuck filtered)
- [ ] `Super + Escape` inspects; bare Escape exits
- [ ] Volume/brightness media keys remain findable by typing, not by pressing

---

I used this a lot while building it and had fun putting it together. Happy to iterate if anything’s off.