### PR TITLE
Stop the screensaver interrupting video playback

### DIFF
--- a/config/xdg-desktop-portal/hyprland-portals.conf
+++ b/config/xdg-desktop-portal/hyprland-portals.conf
@@ -1,0 +1,13 @@
+# Route portal requests to Hyprland's backend first, GTK for what it doesn't implement.
+#
+# Inhibit is disabled outright. xdg-desktop-portal-gtk is the only installed backend that
+# offers it, and its implementation forwards to org.gnome.SessionManager or
+# org.freedesktop.ScreenSaver -- neither of which exists under Omarchy, so every request
+# fails. Firefox-based browsers commit to the portal whenever the interface is present and
+# only fall back to the Wayland zwp_idle_inhibit_manager_v1 protocol when it is absent, so
+# advertising a broken Inhibit stopped video playback from holding off the screensaver.
+# With the interface gone they use the Wayland protocol, which Hyprland and the shell's
+# idle service (IdleMonitor.respectInhibitors) already honor.
+[preferred]
+default=hyprland;gtk
+org.freedesktop.impl.portal.Inhibit=none

--- a/migrations/1788655505.sh
+++ b/migrations/1788655505.sh
@@ -1,0 +1,17 @@
+echo "Stop the screensaver interrupting video playback"
+
+# xdg-desktop-portal-gtk is the only installed backend offering org.freedesktop.impl.portal.Inhibit,
+# and it forwards to org.gnome.SessionManager or org.freedesktop.ScreenSaver, neither of which exists
+# under Omarchy, so every inhibit request fails. Firefox-based browsers commit to the portal whenever
+# the interface is present and only fall back to the Wayland idle-inhibit protocol when it is absent,
+# so a playing video never held off the screensaver. Ship the config that removes the interface.
+portals_conf=~/.config/xdg-desktop-portal/hyprland-portals.conf
+
+# Omarchy has never shipped this file, so anything already here is the user's own routing; leave it.
+if [[ -f $portals_conf ]]; then
+  echo "Keeping your existing $portals_conf; add 'org.freedesktop.impl.portal.Inhibit=none' under [preferred] to apply the fix."
+else
+  mkdir -p ~/.config/xdg-desktop-portal
+  cp -f "$OMARCHY_PATH/config/xdg-desktop-portal/hyprland-portals.conf" "$portals_conf"
+  systemctl --user try-restart xdg-desktop-portal.service
+fi

--- a/test/shell.d/idle-inhibit-portal-migration-test.sh
+++ b/test/shell.d/idle-inhibit-portal-migration-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1788655505.sh"
+shipped="$ROOT/config/xdg-desktop-portal/hyprland-portals.conf"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+portals_conf="$home/.config/xdg-desktop-portal/hyprland-portals.conf"
+
+# The migration restarts the portal; a test must never reach the real session bus.
+stub_bin="$test_dir/bin"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/systemctl" <<'STUB'
+#!/bin/bash
+echo "$*" >>"${SYSTEMCTL_CALLS:?}"
+STUB
+chmod +x "$stub_bin/systemctl"
+
+systemctl_calls="$test_dir/systemctl-calls"
+
+run_migration() {
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" \
+    SYSTEMCTL_CALLS="$systemctl_calls" bash -euo pipefail "$migration" >/dev/null 2>&1
+}
+
+# The shipped config is what makes browsers fall through to the Wayland
+# idle-inhibit protocol; without this key the whole change is a no-op.
+grep -q "^org.freedesktop.impl.portal.Inhibit=none$" "$shipped" ||
+  fail "shipped config disables the Inhibit portal"
+grep -q "^default=hyprland;gtk$" "$shipped" ||
+  fail "shipped config keeps the stock backend routing"
+pass "shipped config disables the Inhibit portal"
+
+# Fresh install: no file yet, so the shipped default lands and the portal picks it up.
+rm -rf "$home"
+: >"$systemctl_calls"
+run_migration || fail "migration succeeds when no portals.conf exists"
+[[ -f $portals_conf ]] || fail "migration installs the portals config"
+cmp -s "$portals_conf" "$shipped" || fail "migration installs the shipped config verbatim"
+grep -q "try-restart xdg-desktop-portal.service" "$systemctl_calls" ||
+  fail "migration restarts the portal so the change applies without a relogin"
+pass "migration installs the portals config and restarts the portal"
+
+# Omarchy has never shipped this file, so an existing one is hand-written
+# routing. Clobbering it could break the user's screencast or file-chooser
+# backends, so it is left exactly as-is.
+custom=$'[preferred]\ndefault=hyprland\n'
+printf '%s' "$custom" >"$portals_conf"
+: >"$systemctl_calls"
+run_migration || fail "migration succeeds when a custom portals.conf exists"
+[[ $(cat "$portals_conf") == "${custom%$'\n'}" ]] ||
+  fail "migration leaves a user-written portals.conf untouched"
+[[ ! -s $systemctl_calls ]] ||
+  fail "migration does not restart the portal when it changed nothing"
+pass "migration leaves a user-written portals.conf untouched"
+
+# Rerunning after a successful install hits the same guard and changes nothing.
+rm -rf "$home"
+run_migration || fail "migration succeeds on first run"
+installed_hash=$(sha256sum "$portals_conf" | cut -d' ' -f1)
+: >"$systemctl_calls"
+run_migration || fail "migration reruns cleanly"
+[[ $(sha256sum "$portals_conf" | cut -d' ' -f1) == "$installed_hash" ]] ||
+  fail "migration is idempotent"
+pass "migration is idempotent"


### PR DESCRIPTION
Fixes #10407.

A playing video does not hold off the screensaver, so it appears mid-video after 2.5 minutes and the lock screen follows at 5.

The shell's idle service is not at fault — it already sets `IdleMonitor { respectInhibitors: true }`, so a Wayland idle inhibitor suppresses it correctly. The browser just never creates one:

- `xdg-desktop-portal-gtk` (installed by `install/omarchy-base.packages`) is the only backend advertising `org.freedesktop.impl.portal.Inhibit`; `hyprland.portal` does not list it.
- Omarchy ships no `portals.conf`, so `Inhibit` falls through to the GTK backend as a last resort.
- That backend forwards to `org.gnome.SessionManager`, then `org.freedesktop.ScreenSaver`. Neither exists under Omarchy, so every request fails.

Firefox-based browsers commit to the portal whenever the interface is **present** and only fall back to the Wayland `zwp_idle_inhibit_manager_v1` protocol when it is **absent** — not when the call fails ([Mozilla bug 1877022](https://bugzilla.mozilla.org/show_bug.cgi?id=1877022)). Advertising a broken `Inhibit` therefore shadows the path that works.

Same class of bug as `migrations/1784508556.sh` ("on Hyprland the xdg-desktop-portal Secret backend has no provider and fails").

## Changes

- `config/xdg-desktop-portal/hyprland-portals.conf` — mirrors the stock routing and adds `org.freedesktop.impl.portal.Inhibit=none`.
- `migrations/1788655505.sh` — installs it for existing users and `try-restart`s the portal so it applies without a relogin.
- `test/shell.d/idle-inhibit-portal-migration-test.sh` — covers the shipped key, the fresh-install path, the untouched-custom-config path, and idempotency. `systemctl` is stubbed.

## Notes for review

**The migration skips users who already have a `hyprland-portals.conf`**, printing what to add rather than editing it. Omarchy has never shipped that file, so anything present is hand-written routing that may be load-bearing for their screencast or file-chooser backends, and appending a key to an INI file risks landing it under the wrong section. Those users stay broken until they act — happy to change this if you would rather it edit in place.

**Nothing regresses.** The portal `Inhibit` path failed 100% of calls before this change; both of its backends are structurally absent on Omarchy.

**`org.freedesktop.ScreenSaver` being unowned is a separate, wider gap** — apps that call it directly rather than through the portal (Steam, LibreOffice presentation mode, various Electron apps) are silently dropped too. Having `omarchy-shell` own it and map `Inhibit`/`UnInhibit` onto stay-awake would fix that class, but it is a shell change with a much wider blast radius, so I kept it out of this commit. Written up in the issue.

## Verification

On a 4.0.2-1 install with Zen 1.21.16b, Hyprland 0.56.2. Before, the journal showed these at exactly the moments the screensaver fired:

```
xdg-desktop-portal: A backend call failed: Inhibiting other than idle not supported
xdg-desktop-portal-gtk: Backend call failed: Cannot invoke method; proxy is for the
  well-known name org.freedesktop.ScreenSaver without an owner
```

After applying it and restarting the browser:

```
$ busctl --user call org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop \
    org.freedesktop.portal.Inhibit Inhibit "sua{sv}" "" 8 0
Call failed: No such interface "org.freedesktop.portal.Inhibit"
```

and video playback now suppresses the screensaver.

`./test/all`: the new test passes. 4 of 222 files fail (`config`, `unowned-system-paths`, `snapper`, `bin-style`) — all four fail identically on a clean `quattro` checkout without this change; three want a sibling `omarchy-pkgs` checkout and `bin-style` hits `bin/omarchy-remove-ai-openclaw`.
