### PR TITLE
Clear setgid before setting the Windows VM mount modes

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -109,6 +109,16 @@ priv() {
 
 dc() { docker-compose -f "$COMPOSE_FILE" "$@"; }
 
+# chmod preserves a directory's set-user-ID and set-group-ID bits when it is
+# given an octal mode, so `chmod 0700 dir` leaves a setgid directory at 2700 and
+# the exact-mode check before Docker starts then rejects every bring-up. Clear
+# the special bits explicitly so the requested mode is the mode that lands.
+chmod_exact() {
+  local mode="$1"
+  shift
+  chmod u-s,g-s,o-t -- "$@" && chmod "$mode" -- "$@"
+}
+
 with_vm_lock() {
   local fd rc=0
   if ((EUID == 0)); then
@@ -264,7 +274,7 @@ prepare_boundary_component() {
       install -d -m "$mode" -- "$path" || return 1
     fi
   fi
-  chmod "$mode" -- "$path" || return 1
+  chmod_exact "$mode" "$path" || return 1
   if ((EUID == 0)); then chown root:root -- "$path" || return 1; fi
   assert_boundary_dir "$path" "$owner"
 }
@@ -580,7 +590,7 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  chmod_exact 0700 "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
@@ -1015,7 +1025,7 @@ prepare_user_mount_sources() {
     echo "omarchy-windows-vm: storage and shared must be different directories" >&2
     return 1
   }
-  chmod 0700 -- "$storage" "$shared"
+  chmod_exact 0700 "$storage" "$shared"
 }
 
 storage_space_path() {
@@ -1058,7 +1068,7 @@ write_credentials() {
   local username="$1" password="$2" old_umask dir tmp
   dir=$(dirname -- "$CREDENTIALS_FILE")
   mkdir -p "$dir" || return 1
-  chmod 0700 "$dir" || return 1
+  chmod_exact 0700 "$dir" || return 1
   old_umask=$(umask)
   umask 077
   tmp=$(mktemp "$dir/.credentials.XXXXXX") || { umask "$old_umask"; return 1; }

--- a/test/shell.d/windows-vm-compose-test.sh
+++ b/test/shell.d/windows-vm-compose-test.sh
@@ -491,3 +491,14 @@ df() {
 unset -f df
 [[ $(cat "$df_log") == "$external_storage" ]] || fail "free-space used home filesystem"
 pass "disk-space checks follow the storage symlink target"
+
+# An install whose sources picked up a setgid bit must be normalized, not left
+# at 2700: the privileged bring-up compares the mode against 700 exactly, so a
+# source chmod that silently keeps the bit locks the VM out for good.
+reset_case
+mkdir -p "$HOME/.windows" "$HOME/Windows"
+chmod 2755 "$HOME/.windows" "$HOME/Windows"
+prepare_user_mount_sources || fail "setgid sources were rejected instead of hardened"
+[[ $(stat -Lc '%a' "$HOME/.windows") == 700 && $(stat -Lc '%a' "$HOME/Windows") == 700 ]] ||
+  fail "setgid sources were not hardened to an exact 0700"
+pass "setgid mount sources are hardened to an exact 0700"

--- a/test/shell.d/windows-vm-mount-boundary-test.sh
+++ b/test/shell.d/windows-vm-mount-boundary-test.sh
@@ -89,9 +89,13 @@ pass "root dispatch rejects missing/invalid uid, passwd, owner, symlink, and wri
 
 # Put each familiar source on its own filesystem. Both start with legacy 0755
 # permissions and world-readable payloads to prove migration hardens the leaves.
+# The setgid bit is part of that legacy state: chmod keeps a directory's
+# set-group-ID bit when it is handed an octal mode, so a source left at 2755
+# stays at 2700 and the exact-mode check below rejects every bring-up.
 mkdir /home/storage-target /home/shared-target
 mount -t tmpfs -o uid=1000,gid=1000,mode=0755,size=3g storage-test /home/storage-target
 mount -t tmpfs -o uid=1000,gid=1000,mode=0755,size=64m shared-test /home/shared-target
+chmod g+s /home/storage-target /home/shared-target
 ln -s /home/storage-target /home/alice/.windows
 ln -s /home/shared-target /home/alice/Windows
 chown -h 1000:1000 /home/alice/.windows /home/alice/Windows


### PR DESCRIPTION
`omarchy-windows-vm launch` works exactly once. After the first successful run every later launch fails silently and permanently: no output, no notification, no Docker contact - the daemon is never even started.

## Cause

`chmod` preserves a directory's set-user-ID and set-group-ID bits when it is handed an octal mode. `chmod 0700 dir` on a `2777` directory leaves it at `2700`:

```
$ mkdir t && chmod 2777 t && chmod 0700 t && stat -c %a t
2700
```

`prepare_caller_mounts` hardens both pinned sources and then requires the result to be exactly `700`:

```bash
chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || { ... }
storage_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$storage_fd" 2>/dev/null) || storage_mode=""
...
if [[ $storage_mode != 700 || $shared_mode != 700 ]]; then ... return 1
```

The chmod succeeds, `stat` returns `2700`, the check fails, and `__priv_up_wait` returns 1 before `dc up -d`. The desktop entry appears to do nothing.

Nothing in the tool can recover from it: the unprivileged `prepare_user_mount_sources` normalizes the same sources with the same octal `chmod 0700`, so the bit can never be cleared.

## What sets the bit

The `dockurr/windows` image does, on every single run. Its Samba setup probes the share and then chmods it to `2777`. Caught with an `inotifywait` on both sources across a full launch:

```
22:17:18 ATTRIB,ISDIR  ~/.windows/                        <- prepare_caller_mounts hardens both sources
22:17:18 ATTRIB,ISDIR  ~/Windows/
22:17:22 ATTRIB        ~/.windows/data.img                <- container starts
22:17:23 CREATE        ~/Windows/.samba-write-test.u8fzeK
22:17:23 DELETE        ~/Windows/.samba-write-test.u8fzeK
22:17:23 ATTRIB,ISDIR  ~/Windows/                         <- 0700 -> 2777
```

`~/Windows` is the bind source for `/shared`, so the container's chmod lands on the same inode the next bring-up checks. Verified on a real install: `~/Windows` measured `0700` before the launch and `2777` after it, while `~/.windows` stayed `700` throughout. The next launch then failed with no output at all.

There is a privacy consequence too. The `0700` hardening never actually holds: between runs the share sits world-writable at `2777`, and the hardening chmod cannot bring it back because it cannot clear the setgid bit. With this fix the source really is `0700` at each bring-up.

## Fix

Route every exact-mode `chmod` through a helper that clears the special bits first:

```bash
chmod_exact() {
  local mode="$1"
  shift
  chmod u-s,g-s,o-t -- "$@" && chmod "$mode" -- "$@"
}
```

Applied to the four sites that set a mode a later check compares against, or that are meant to normalize an inherited one: `prepare_caller_mounts`, `prepare_user_mount_sources`, `prepare_boundary_component`, and `write_credentials`. The `chmod 0640/0600 "$tmp"` calls are untouched: those are fresh `mktemp` regular files that cannot carry special bits.

Affected installs recover on their next launch, so no migration is needed.

## Tests

A regression in each of the two existing harnesses:

- `windows-vm-mount-boundary-test.sh` seeds `g+s` on both tmpfs sources before the root bind. Without the fix: `not ok - root could not create verified production bind anchors`.
- `windows-vm-compose-test.sh` covers the unprivileged path - setgid sources must leave `prepare_user_mount_sources` at exactly `0700`. Without the fix: `not ok - setgid sources were not hardened to an exact 0700`.

Both verified failing on stock `quattro` and passing with the fix. `./test/shell` is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4RgepEpHPpP5i8Qcccpi8
