### PR TITLE
Disable broken Inhibit portal so video holds off the screensaver

### DIFF
--- a/etc/xdg-desktop-portal/hyprland-portals.conf
+++ b/etc/xdg-desktop-portal/hyprland-portals.conf
@@ -1,0 +1,19 @@
+# Disable the Inhibit portal on Hyprland.
+#
+# xdg-desktop-portal-hyprland does not implement org.freedesktop.impl.portal.Inhibit,
+# so without this override the request falls through to xdg-desktop-portal-gtk, whose
+# Inhibit backend forwards to org.gnome.SessionManager / org.freedesktop.ScreenSaver.
+# Neither exists on Omarchy, so every inhibit request fails ("Inhibiting other than
+# idle not supported") and the screensaver/lock fires mid-video.
+#
+# Firefox only falls back to the Wayland zwp_idle_inhibit_manager_v1 protocol when the
+# portal interface is absent, not when the call fails, so advertising this broken
+# Inhibit shadows the path that actually works. Setting it to `none` removes the
+# interface so browsers use Wayland idle-inhibit, which Hyprland honors and the shell
+# idle service already respects (respectInhibitors: true).
+#
+# Shipped as hyprland-portals.conf (XDG_CURRENT_DESKTOP=Hyprland) so it takes
+# precedence over /usr/share/xdg-desktop-portal/hyprland-portals.conf. See portals.conf(5).
+[preferred]
+default=hyprland;gtk
+org.freedesktop.impl.portal.Inhibit=none

--- a/test/shell.d/portal-inhibit-test.sh
+++ b/test/shell.d/portal-inhibit-test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+conf="$ROOT/etc/xdg-desktop-portal/hyprland-portals.conf"
+
+[[ -f $conf ]] || fail "Hyprland portal override is shipped"
+
+grep -qxF 'org.freedesktop.impl.portal.Inhibit=none' "$conf" ||
+  fail "Inhibit portal is disabled so browsers fall back to Wayland idle-inhibit"
+
+grep -qxF 'default=hyprland;gtk' "$conf" ||
+  fail "portal default keeps hyprland before gtk"
+
+pass "Inhibit portal override lets video playback hold off the screensaver"


### PR DESCRIPTION
## Problem

Playing video in a Firefox-based browser does not hold off idle — the screensaver fires after `idle.screensaver` and the lock follows. The shell is not at fault (`respectInhibitors: true` is already set); the browser never creates an inhibitor.

Root cause, verified on a live Omarchy host:

- `xdg-desktop-portal-hyprland` does not implement `org.freedesktop.impl.portal.Inhibit` (its `.portal` lists only Screenshot/ScreenCast/GlobalShortcuts/InputCapture), so the request falls through to `xdg-desktop-portal-gtk`, the only backend claiming Inhibit.
- The GTK backend forwards Inhibit to `org.gnome.SessionManager` / `org.freedesktop.ScreenSaver` — confirmed via `busctl` that nothing owns either name on Omarchy, so every request fails.
- Firefox only falls back to Wayland `zwp_idle_inhibit_manager_v1` (which Hyprland supports — confirmed in the journal: `Got interface: zwp_idle_inhibit_manager_v1`) when the portal interface is **absent**, not when the call **fails**. Advertising the broken Inhibit therefore shadows the working path.

## Change

New `etc/xdg-desktop-portal/hyprland-portals.conf` (installs to `/etc/xdg-desktop-portal/`, which takes precedence over `/usr/share` per `portals.conf(5)`, matched on `XDG_CURRENT_DESKTOP=Hyprland`):

```ini
[preferred]
default=hyprland;gtk
org.freedesktop.impl.portal.Inhibit=none
```

Setting Inhibit to `none` removes the interface so browsers use Wayland idle-inhibit directly. No migration needed — system file delivered by the `omarchy-settings` package (`cp -a etc/.` already covers the new path; consider adding it to `backup=()` in omarchy-pkgs if local admin edits should survive upgrades).

## Tests

- New `test/shell.d/portal-inhibit-test.sh` pins `Inhibit=none` and the `hyprland;gtk` default; config validated with Python `configparser`.
- Full `./test/all` shows only the 6 pre-existing environmental failures (missing omarchy-pkgs checkout, no compositor/network) — verified identical on the clean base.