### PR TITLE
Fix cloned service lookups

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -273,7 +273,10 @@ ShellRoot {
   property var _services: ({})
 
   function serviceFor(pluginId) {
-    return _services[String(pluginId)] || null
+    var id = shell.pluginRegistry
+      ? shell.pluginRegistry.resolveEnabledId(pluginId)
+      : String(pluginId)
+    return _services[String(id)] || _services[String(pluginId)] || null
   }
 
   function firstPartyServiceFor(pluginId) {

--- a/test/shell.d/fixtures/indicator-contract/shell.qml
+++ b/test/shell.d/fixtures/indicator-contract/shell.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Quickshell
+import qs.Commons
 
 ShellRoot {
   id: root
@@ -43,12 +44,52 @@ ShellRoot {
 
   QtObject {
     id: mockShell
-    function firstPartyServiceFor(id) {
-      if (id === "omarchy.notifications") return notificationService
-      if (id === "omarchy.idle") return idleService
-      if (id === "omarchy.nightlight") return nightlightService
-      return null
+    property var shell: mockShell
+    property var pluginRegistry: registry
+    property var clonedServices: []
+    property var _services: {
+      var services = {notifications: notificationService, idle: idleService, nightlight: nightlightService, media: mediaService}
+      var result = {}
+      for (var name in services)
+        result[(clonedServices.indexOf(name) !== -1 ? "tester." : "omarchy.") + name] = services[name]
+      return result
     }
+    // SERVICE_LOOKUP_METHODS
+  }
+
+  QtObject {
+    id: registry
+    property var installedPlugins: ({
+      "tester.notifications": { omarchy: { clonedFrom: "omarchy.notifications" } },
+      "tester.idle": { omarchy: { clonedFrom: "omarchy.idle" } },
+      "tester.nightlight": { omarchy: { clonedFrom: "omarchy.nightlight" } },
+      "tester.media": { omarchy: { clonedFrom: "omarchy.media" } }
+    })
+    function isEnabled(id) { return mockShell.clonedServices.indexOf(id.replace("tester.", "")) !== -1 }
+    // RESOLVE_ENABLED_ID_METHOD
+  }
+
+  QtObject {
+    id: player
+    property string trackTitle: "Lookup test"
+    property string trackArtist: "Test artist"
+    property bool isPlaying: false
+    property bool canGoPrevious: true
+    property bool canGoNext: true
+    property bool canTogglePlaying: true
+    property bool canPlay: true
+    property bool canPause: true
+  }
+
+  QtObject {
+    id: mediaService
+    property var activePlayer: player
+    property var sourcePlayers: [player]
+    function runAction(action, notify, key) {
+      root.commands.push("media:" + action)
+      if (action === "playPause") player.isPlaying = !player.isPlaying
+    }
+    function playerKey(value) { return "test-player" }
   }
 
   QtObject {
@@ -163,6 +204,79 @@ ShellRoot {
     return "'" + String(value).replace(/'/g, "'\\''") + "'"
   }
 
+  function checkCloneConsumers() {
+    var items = [root.createIndicator("StayAwake"), root.createIndicator("NightLight"), root.createIndicator("Dnd")]
+    for (var item of items) if (item) root.injectBar(item)
+    var mediaComponent = Qt.createComponent("file://" + rootPath + "/shell/plugins/services/media/BarWidget.qml")
+    var audioComponent = Qt.createComponent("file://" + rootPath + "/shell/plugins/panels/audio/Panel.qml")
+    var media = mediaComponent.status === Component.Ready ? mediaComponent.createObject(root, {bar: mockBar}) : null
+    var audio = audioComponent.status === Component.Ready ? audioComponent.createObject(root, {bar: mockBar}) : null
+    root.assertTrue(media !== null, "media widget loads: " + mediaComponent.errorString())
+    root.assertTrue(audio !== null, "audio panel loads: " + audioComponent.errorString())
+
+    function clickMediaButtons(item, seen) {
+      if (!item || seen.indexOf(item) !== -1) return
+      seen.push(item)
+      if ("iconText" in item && typeof item.clicked === "function") item.clicked()
+      for (var property of ["data", "children", "contentItem"]) {
+        var children = item[property]
+        if (!children) continue
+        if (typeof children.length === "number") {
+          for (var child of children) clickMediaButtons(child, seen)
+        }
+      }
+    }
+
+    function check(phase) {
+      idleService.setIdleEnabled(true)
+      nightlightService.setNightlight(false)
+      notificationService.setDoNotDisturb(false)
+      for (var item of items) {
+        if (!item) continue
+        root.assertTrue(!item.active, phase + ": external state clears indicator")
+        item.triggerPress(Qt.LeftButton)
+        root.assertTrue(item.active, phase + ": click activates indicator")
+      }
+      root.assertTrue(idleService.stayAwake, phase + ": idle receives click")
+      root.assertTrue(nightlightService.enabled, phase + ": nightlight receives click")
+      root.assertTrue(notificationService.doNotDisturb, phase + ": notifications receives click")
+      if (media && audio) {
+        root.assertTrue(media.mediaService === mediaService, phase + ": media widget resolves service")
+        root.assertTrue(audio.mediaService === mediaService, phase + ": audio panel resolves service")
+        root.assertTrue(media.activePlayer === player && audio.activeMediaPlayer === player, phase + ": both consumers expose player")
+        player.trackTitle = phase
+        root.assertTrue(media.title === phase, phase + ": media title updates")
+        mediaService.activePlayer = null
+        root.assertTrue(media.activePlayer === null && audio.activeMediaPlayer === null, phase + ": both consumers clear removed player")
+        mediaService.activePlayer = player
+        var before = root.commands.length
+        var wasPlaying = player.isPlaying
+        clickMediaButtons(media, [])
+        var actions = root.commands.slice(before)
+        for (var action of ["previous", "playPause", "next"])
+          root.assertTrue(actions.indexOf("media:" + action) !== -1, phase + ": media " + action + " reaches service")
+        root.assertTrue(player.isPlaying !== wasPlaying, phase + ": playback action updates player")
+      }
+    }
+
+    var phases = [[], ["idle"], ["nightlight"], ["notifications"], ["media"], ["idle", "nightlight", "notifications", "media"], []]
+    function nextPhase(index) {
+      mockShell.clonedServices = phases[index]
+      Qt.callLater(function() {
+        check(index === 0 ? "original" : index === phases.length - 1 ? "restored" : "cloned " + phases[index].join(","))
+        if (index + 1 < phases.length) {
+          nextPhase(index + 1)
+          return
+        }
+        for (var item of items) if (item) item.destroy()
+        if (media) media.destroy()
+        if (audio) audio.destroy()
+        root.checkIndicatorTray()
+      })
+    }
+    nextPhase(0)
+  }
+
   readonly property string rootPath: Quickshell.env("OMARCHY_PATH")
 
   Timer {
@@ -216,7 +330,7 @@ ShellRoot {
         root.assertTrue(idleService.stayAwake === true, "Stay Awake left click toggles the idle service")
       }
 
-      root.checkIndicatorTray()
+      root.checkCloneConsumers()
     }
   }
 }

--- a/test/shell.d/indicator-contract-test.sh
+++ b/test/shell.d/indicator-contract-test.sh
@@ -26,6 +26,7 @@ if ! command -v quickshell >/dev/null 2>&1; then
 fi
 
 require_command jq
+require_command node
 
 TMPDIR=$(mktemp -d)
 result="$TMPDIR/result.json"
@@ -33,6 +34,24 @@ log="$TMPDIR/quickshell.log"
 config_dir="$TMPDIR/indicator-contract"
 mkdir -p "$config_dir" "$TMPDIR/home"
 cp "$SHELL_TEST_DIR/fixtures/indicator-contract/shell.qml" "$config_dir/shell.qml"
+# Exercise the production lookup inside the QML binding engine, not a mock
+# that bypasses clone resolution. Only service instances are test doubles.
+node - "$ROOT" "$config_dir/shell.qml" <<'JS'
+const fs = require('fs')
+const path = require('path')
+const [root, target] = process.argv.slice(2)
+function method(file, name) {
+  const source = fs.readFileSync(path.join(root, file), 'utf8')
+  const match = source.match(new RegExp(`^  function ${name}\\([^]*?^  }`, 'm'))
+  if (!match) throw new Error(`Missing ${name} in ${file}`)
+  return match[0]
+}
+let fixture = fs.readFileSync(target, 'utf8')
+fixture = fixture.replace('// SERVICE_LOOKUP_METHODS',
+  ['serviceFor', 'firstPartyServiceFor'].map(name => method('shell/shell.qml', name)).join('\n'))
+fixture = fixture.replace('// RESOLVE_ENABLED_ID_METHOD', method('shell/services/PluginRegistry.qml', 'resolveEnabledId'))
+fs.writeFileSync(target, fixture)
+JS
 ln -s "$ROOT/shell/Ui" "$config_dir/Ui"
 ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
 

--- a/test/shell.d/service-lookup-test.sh
+++ b/test/shell.d/service-lookup-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+
+function qmlFunction(file, name) {
+  const source = fs.readFileSync(path.join(root, file), 'utf8')
+  const match = source.match(new RegExp(`^  function ${name}\\([^]*?^  }`, 'm'))
+  if (!match) throw new Error(`Missing ${name} in ${file}`)
+  return match[0]
+}
+
+const context = vm.createContext({})
+context.Util = vm.runInContext(`({
+  ${qmlFunction('shell/Commons/Util.qml', 'canonicalWidgetId')},
+  ${qmlFunction('shell/Commons/Util.qml', 'isPlainObject')}
+})`.replace(/function (\w+)\(/g, '$1('), context)
+const registry = vm.runInContext(`({
+  installedPlugins: {},
+  enabledIds: [],
+  isEnabled(id) { return this.enabledIds.includes(id) },
+  ${qmlFunction('shell/services/PluginRegistry.qml', 'resolveEnabledId')}
+})`.replace(/function (\w+)\(/g, '$1('), context)
+// QML object properties are in the method's lexical scope.
+context.installedPlugins = registry.installedPlugins
+context.isEnabled = registry.isEnabled.bind(registry)
+context.shell = {pluginRegistry: registry}
+vm.runInContext(qmlFunction('shell/shell.qml', 'serviceFor'), context)
+vm.runInContext(qmlFunction('shell/shell.qml', 'firstPartyServiceFor'), context)
+
+for (const name of ['idle', 'nightlight', 'notifications', 'media']) {
+  const id = `omarchy.${name}`
+  const cloneId = `tester.${name}`
+  const original = {name: id}
+  const clone = {name: cloneId}
+  registry.installedPlugins[id] = {}
+  registry.installedPlugins[cloneId] = {omarchy: {clonedFrom: id}}
+  registry.enabledIds = [id]
+  context._services = {[id]: original}
+  assertEqual(context.firstPartyServiceFor(id), original, `${name}: inactive clone does not replace original`)
+
+  registry.enabledIds = [cloneId]
+  context._services = {[cloneId]: clone}
+  assertEqual(context.firstPartyServiceFor(id), clone, `${name}: built-in lookup reaches enabled clone`)
+  assertEqual(context.serviceFor(cloneId), clone, `${name}: concrete lookup reaches clone`)
+  context._services[id] = original
+  assertEqual(context.serviceFor(id), clone, `${name}: clone wins while original still exists`)
+  delete context._services[cloneId]
+  assertEqual(context.serviceFor(id), original, `${name}: original instance remains a compatibility fallback`)
+
+  registry.enabledIds = [id]
+  assertEqual(context.firstPartyServiceFor(id), original, `${name}: restoring original restores lookup`)
+  context.shell.pluginRegistry = null
+  assertEqual(context.serviceFor(id), original, `${name}: direct lookup works without registry`)
+  context.shell.pluginRegistry = registry
+  context._services = {}
+  assertEqual(context.firstPartyServiceFor(id), null, `${name}: missing instance returns null`)
+}
+JS


### PR DESCRIPTION
Fixes #10404.

Cloning a service plugin registers its instance under the clone’s manifest ID, while consumers keep looking it up by the built-in ID. `serviceFor()` now resolves an enabled clone before looking up the service, with the original ID retained as a compatibility fallback.

Reproduced on Omarchy 4.0.2-1, the latest released build: cloning `omarchy.idle` leaves the Stay Awake indicator unable to read or toggle the running service.

This also fixes the same lookup path for cloned night light, notifications, and media services.

Validation:
- Added service lookup coverage for idle, night light, notifications, and media.
- Verified each service cloned individually, after shell restart, and after restoring the built-in service.
- Verified all four cloned together, including Stay Awake, Night Light, Do Not Disturb, media bar widget, and audio panel.
- Confirmed visually in a disposable VM that the indicators and media controls behave correctly.
