### PR TITLE
Add a picture print dialog and Files Print action

### DIFF
--- a/bin/omarchy-launch-image-print
+++ b/bin/omarchy-launch-image-print
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# omarchy:summary=Open a print dialog for a picture
+# omarchy:args=<image>
+# omarchy:examples=omarchy launch image-print ~/Pictures/photo.jpg
+
+exec /usr/bin/python "$OMARCHY_PATH/default/image-print/print.py" "$@"

--- a/config/imv/config
+++ b/config/imv/config
@@ -1,7 +1,7 @@
 [binds]
 
-# Print the current image file
-<Ctrl+p> = exec lp "$imv_current_file"
+# Open a print dialog without blocking the image viewer
+<Ctrl+p> = exec nohup omarchy-launch-image-print "$imv_current_file" </dev/null >/dev/null 2>&1 &
 
 # Trash the current image and quit the viewer (recoverable from Trash)
 <Ctrl+x> = exec gio trash -- "$imv_current_file"; quit

--- a/default/hypr/apps/system.lua
+++ b/default/hypr/apps/system.lua
@@ -31,6 +31,9 @@ o.window("dev.tensaku.Tensaku", { float = true })
 o.window("dev.tensaku.Tensaku", { center = true })
 o.window("omacalc", { float = true })
 
+-- Keep the picture print dialog above floating image viewers.
+o.window("org.omarchy.ImagePrint", { float = true, center = true })
+
 -- Fullscreen screensaver.
 o.window("org.omarchy.screensaver", { fullscreen = true })
 o.window("org.omarchy.screensaver", { float = true })

--- a/default/image-print/print.py
+++ b/default/image-print/print.py
@@ -1,0 +1,71 @@
+"""Print an image through GTK's printer and page setup dialog."""
+
+import argparse
+from pathlib import Path
+import sys
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
+
+
+def draw_image(context, pixbuf, width, height):
+  scale = min(width / pixbuf.get_width(), height / pixbuf.get_height())
+  context.save()
+  context.translate(
+    (width - pixbuf.get_width() * scale) / 2,
+    (height - pixbuf.get_height() * scale) / 2,
+  )
+  context.scale(scale, scale)
+  Gdk.cairo_set_source_pixbuf(context, pixbuf, 0, 0)
+  context.paint()
+  context.restore()
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("image", type=Path)
+  args = parser.parse_args()
+  GLib.set_application_name("Print Picture")
+  GLib.set_prgname("org.omarchy.ImagePrint")
+  try:
+    pixbuf = GdkPixbuf.Pixbuf.new_from_file(str(args.image.resolve()))
+    pixbuf = pixbuf.apply_embedded_orientation()
+    operation = Gtk.PrintOperation()
+    operation.set_job_name(args.image.name)
+    operation.set_n_pages(1)
+    operation.set_unit(Gtk.Unit.POINTS)
+    operation.set_use_full_page(False)
+    operation.set_embed_page_setup(True)
+    setup = Gtk.PageSetup()
+    if pixbuf.get_width() > pixbuf.get_height():
+      setup.set_orientation(Gtk.PageOrientation.LANDSCAPE)
+    operation.set_default_page_setup(setup)
+    operation.connect(
+      "draw-page",
+      lambda op, ctx, page: draw_image(
+        ctx.get_cairo_context(), pixbuf, ctx.get_width(), ctx.get_height()
+      ),
+    )
+    result = operation.run(Gtk.PrintOperationAction.PRINT_DIALOG, None)
+    if result == Gtk.PrintOperationResult.ERROR:
+      operation.get_error()
+      return 1
+  except (GLib.Error, OSError) as error:
+    print(f"Cannot print image: {error}", file=sys.stderr)
+    dialog = Gtk.MessageDialog(
+      message_type=Gtk.MessageType.ERROR,
+      buttons=Gtk.ButtonsType.CLOSE,
+      text="Could not print this picture",
+    )
+    dialog.format_secondary_text(str(error))
+    dialog.run()
+    dialog.destroy()
+    return 1
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/default/nautilus-python/extensions/print_picture.py
+++ b/default/nautilus-python/extensions/print_picture.py
@@ -1,0 +1,34 @@
+"""Add Print… directly to the context menu for local pictures."""
+
+import gi
+
+gi.require_version("Nautilus", "4.1")
+gi.require_version("Gdk", "4.0")
+from gi.repository import Gdk, Gio, GObject, Nautilus
+
+
+class PrintPictureExtension(GObject.GObject, Nautilus.MenuProvider):
+  def get_file_items(self, files):
+    if len(files) != 1:
+      return []
+    selected = files[0]
+    location = selected.get_location()
+    if (selected.is_directory() or not location or not location.is_native()
+        or not (selected.get_mime_type() or "").startswith("image/")):
+      return []
+    item = Nautilus.MenuItem(
+      name="PrintPicture::print",
+      label="Print…",
+      tip="Choose a printer and page settings for this picture",
+      icon="document-print",
+    )
+    item.connect("activate", self.print_picture, location)
+    return [item]
+
+  def print_picture(self, item, location):
+    app = Gio.AppInfo.create_from_commandline(
+      "omarchy-launch-image-print %f", "Print Picture", Gio.AppInfoCreateFlags.NONE
+    )
+    display = Gdk.Display.get_default()
+    context = display.get_app_launch_context() if display else None
+    app.launch([location], context)

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -102,6 +102,7 @@ plocate
 plymouth
 postgresql-libs
 power-profiles-daemon
+python-cairo
 python-gobject
 python-poetry-core
 ttfx

--- a/manual/22-guis.md
+++ b/manual/22-guis.md
@@ -8,6 +8,8 @@ Plug in a USB stick or an SD card and it's mounted automatically, so it just sho
 
 Double-clicking follows sensible defaults: images open in imv, video in mpv, PDFs in Document Viewer, and plain text in Neovim.
 
+To print a picture, right-click a local image in Files and choose _Print…_, or press `Ctrl + P` in imv. Choose the printer, copies, paper size, and orientation before printing. The picture is centered and fitted within the printable page without cropping. You can also choose _Print to File_ to save a PDF.
+
 ## Obsidian
 
 [Obsidian](https://obsidian.md/) is a free and highly extensible note taking application that uses simple Markdown files for storage.

--- a/migrations/1788662350.sh
+++ b/migrations/1788662350.sh
@@ -1,0 +1,15 @@
+echo "Add picture printing from Files and imv"
+
+omarchy-pkg-add python-cairo
+
+mkdir -p "$HOME/.local/share/nautilus-python/extensions"
+cp "$OMARCHY_PATH/default/nautilus-python/extensions/print_picture.py" "$HOME/.local/share/nautilus-python/extensions/"
+
+# Replace only the shipped binding, preserving custom shortcuts and other settings.
+imv_config="$HOME/.config/imv/config"
+if [[ -f $imv_config ]] && grep -Fxq '<Ctrl+p> = exec lp "$imv_current_file"' "$imv_config"; then
+  cp -p "$imv_config" "$imv_config.bak.$(date +%s)"
+  sed -i 's|^<Ctrl+p> = exec lp "$imv_current_file"$|<Ctrl+p> = exec nohup omarchy-launch-image-print "$imv_current_file" </dev/null >/dev/null 2>\&1 \&|' "$imv_config"
+fi
+
+echo "Reopen Files and image viewer windows to use the new print action."

--- a/test/shell.d/image-print-test.sh
+++ b/test/shell.d/image-print-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname -- "${BASH_SOURCE[0]}")/base-test.sh"
+
+python <<'PY'
+import os
+from pathlib import Path
+import runpy
+import subprocess
+import tempfile
+
+import cairo
+
+root = Path(os.environ["ROOT"])
+module = runpy.run_path(str(root / "default/image-print/print.py"))
+GdkPixbuf = module["GdkPixbuf"]
+
+# Portrait and landscape images fit the page, with white margins and no distortion.
+for image_width, image_height in [(800, 400), (400, 800)]:
+  pixbuf = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, False, 8, image_width, image_height)
+  pixbuf.fill(0x4287f5ff)
+  surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 600, 800)
+  context = cairo.Context(surface)
+  context.set_source_rgb(1, 1, 1)
+  context.paint()
+  module["draw_image"](context, pixbuf, 600, 800)
+  surface.flush()
+  pixels = surface.get_data()
+  def pixel(x, y):
+    offset = y * surface.get_stride() + x * 4
+    return bytes(pixels[offset:offset + 4])
+  assert pixel(300, 400) != b"\xff\xff\xff\xff"
+  assert pixel(0, 0) == b"\xff\xff\xff\xff"
+  if image_width > image_height:
+    assert pixel(300, 249) == b"\xff\xff\xff\xff"
+    assert pixel(300, 251) != b"\xff\xff\xff\xff"
+  else:
+    assert pixel(99, 400) == b"\xff\xff\xff\xff"
+    assert pixel(101, 400) != b"\xff\xff\xff\xff"
+
+with tempfile.TemporaryDirectory() as directory:
+  scratch = Path(directory)
+  fake_bin = scratch / "bin"
+  fake_bin.mkdir()
+  helper = fake_bin / "omarchy-pkg-add"
+  helper.write_text("#!/bin/bash\nexit 0\n")
+  helper.chmod(0o755)
+  migration = root / "migrations/1788662350.sh"
+  shipped = '<Ctrl+p> = exec lp "$imv_current_file"'
+  replacement = next(line for line in (root / "config/imv/config").read_text().splitlines() if line.startswith("<Ctrl+p>"))
+  for binding in [shipped, '<Ctrl+p> = exec my-custom-printer "$imv_current_file"']:
+    home = scratch / ("stock" if binding == shipped else "custom")
+    config = home / ".config/imv/config"
+    config.parent.mkdir(parents=True)
+    config.write_text("[binds]\n" + binding + "\nx = close\n")
+    env = dict(os.environ, HOME=str(home), OMARCHY_PATH=str(root), PATH=str(fake_bin) + ":" + os.environ["PATH"])
+    for _ in range(2):
+      subprocess.run(["bash", "-euo", "pipefail", str(migration)], env=env, check=True, stdout=subprocess.DEVNULL)
+    assert config.read_text() == "[binds]\n" + (replacement if binding == shipped else binding) + "\nx = close\n"
+    assert (home / ".local/share/nautilus-python/extensions/print_picture.py").is_file()
+    assert len(list(config.parent.glob("config.bak.*"))) == (1 if binding == shipped else 0)
+
+  # The shell must return immediately, including when its output is captured.
+  launcher = fake_bin / "omarchy-launch-image-print"
+  launcher.write_text('#!/bin/bash\nsleep 2\n')
+  launcher.chmod(0o755)
+  command = replacement.split(" = exec ", 1)[1]
+  subprocess.run(command, shell=True, env=dict(os.environ, PATH=str(fake_bin) + ":" + os.environ["PATH"], imv_current_file="/tmp/a picture.png"), capture_output=True, timeout=1, check=True)
+PY
+
+# Nautilus uses GTK 4; test its provider in a separate process from GTK 3 printing.
+python <<'PY'
+import os
+from pathlib import Path
+import runpy
+module = runpy.run_path(str(Path(os.environ["ROOT"]) / "default/nautilus-python/extensions/print_picture.py"), run_name="print_picture")
+Gio = module["Gio"]
+class File:
+  def __init__(self, mime, uri="file:///tmp/a%20picture.png", directory=False):
+    self.mime, self.uri, self.directory = mime, uri, directory
+  def get_location(self): return Gio.File.new_for_uri(self.uri)
+  def get_mime_type(self): return self.mime
+  def is_directory(self): return self.directory
+provider = module["PrintPictureExtension"]()
+assert provider.get_file_items([File("image/png")])[0].props.label == "Print…"
+for files in [[], [File("text/plain")], [File("image/png", directory=True)], [File("image/png", "sftp://example.com/a.png")], [File("image/png"), File("image/jpeg")]]:
+  assert not provider.get_file_items(files)
+PY
+
+pass "picture printing fits images, preserves custom bindings, detaches from imv, and filters the Files action"


### PR DESCRIPTION
imv's default Ctrl+P sends a picture directly to `lp`, without a chance to choose the printer or page settings. This adds a shared GTK print dialog, available through Ctrl+P and a **Print…** action when right-clicking a single local picture in Files.

The dialog offers printer, copies, paper size, orientation, and Print to File. Pictures are centered and fitted to the printable page without cropping, with embedded orientation applied. The imv launch is detached so the viewer remains responsive, and a dedicated floating window rule keeps the dialog above floating pictures.

Includes the `omarchy launch image-print <image>` command, the Cairo dependency, user documentation, and an idempotent migration that backs up and replaces only the shipped Ctrl+P binding while preserving custom bindings.

Implements the proposal in https://github.com/omacom/omarchy/discussions/10417.

## Validation

- `./test/shell.d/image-print-test.sh` passes: portrait/landscape fitting, menu filtering, detached launch, migration idempotence, and preservation of custom bindings.
- `./test/cli` passes.
- Verified the actual Files context menu and Ctrl+P dialog on Hyprland; the dialog receives focus, and imv still processes zoom commands while it is open.
- Exercised the native Print to File flow and visually checked the resulting single-page landscape PDF. No physical print job was sent.
- `./test/all` reports six failures, reproduced on untouched upstream commit `f1b065c2`: `bar-icon-geometry`, `bin-style`, `config`, `launch-about`, `snapper`, and `unowned-system-paths`. Three require an unavailable sibling `omarchy-pkgs` checkout; the other three are existing geometry, command-style, and About-launcher failures.

## Visual verification

[Short recording: opening the dialog and zooming the image while it remains open](https://github.com/jonnyace/omarchy/blob/picture-print-evidence/print-flow.mp4)

![Print action in Files](https://raw.githubusercontent.com/jonnyace/omarchy/picture-print-evidence/files-print-menu.png)

![Print dialog above the image viewer](https://raw.githubusercontent.com/jonnyace/omarchy/picture-print-evidence/print-dialog.png)
