### PR TITLE
Distinguish sudo failure from missing Snapper configs

### DIFF
--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -22,15 +22,36 @@ create)
   # The description is just a label, so never let it abort the snapshot.
   DESC="$(omarchy-version 2>/dev/null || echo unknown)"
 
-  # Get existing snapper config names from CSV output
-  mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk -F, 'NR>1 {print $1}')
+  # Capture list-configs on its own so a failed sudo is not mistaken for an
+  # empty config list. Process substitution hides the command's exit status,
+  # which previously reported "No Snapper configs found" and pointed users at
+  # install/config/snapper.sh — a script that overwrites a working root config.
+  # Keep stderr on the terminal so sudo can still prompt for a password.
+  if ! configs_csv="$(sudo snapper --csvout list-configs)"; then
+    # Any non-zero status lands here (sudo, D-Bus, snapper). Snapper's own
+    # stderr already printed above; keep this line cause-neutral.
+    echo -e "\e[31mCould not list Snapper configs.\e[0m" >&2
+    exit 1
+  fi
 
-  # Snapper installed but unconfigured snapshots nothing. Staying quiet here
+  mapfile -t CONFIGS < <(printf '%s\n' "$configs_csv" | awk -F, 'NR>1 {print $1}')
+
+  # Snapper installed but listing nothing snapshots nothing. Staying quiet here
   # reads as a successful snapshot, so the next update looks recoverable when
-  # nothing has ever been captured.
+  # nothing has ever been captured. An exit-0 header-only listing also happens
+  # when /etc/snapper/configs/root exists but is unregistered, unreadable, or
+  # empty — never point those at snapper.sh, which overwrites that file.
   if (( ${#CONFIGS[@]} == 0 )); then
+    snapper_root=${OMARCHY_SNAPPER_CONFIG_PATH:-/etc/snapper/configs/root}
+    snapper_conf=${OMARCHY_SNAPPER_CONF_PATH:-/etc/conf.d/snapper}
+
     echo -e "\e[33mNo Snapper configs found, so no snapshot was created.\e[0m" >&2
-    echo "Configure Snapper with: sudo bash -euo pipefail \"$OMARCHY_PATH/install/config/snapper.sh\"" >&2
+    if [[ -e $snapper_root ]]; then
+      echo "A config file exists at $snapper_root but Snapper did not list it." >&2
+      echo "Check SNAPPER_CONFIGS in $snapper_conf and permissions on the config file." >&2
+    else
+      echo "Configure Snapper with: sudo bash -euo pipefail \"$OMARCHY_PATH/install/config/snapper.sh\"" >&2
+    fi
     exit 1
   fi
 

--- a/test/shell.d/snapshot-create-test.sh
+++ b/test/shell.d/snapshot-create-test.sh
@@ -10,7 +10,7 @@ test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
 fake_bin="$test_tmp/bin"
-mkdir -p "$fake_bin"
+mkdir -p "$fake_bin" "$test_tmp/snapper-configs"
 
 cat >"$fake_bin/sudo" <<'STUB'
 #!/bin/bash
@@ -30,38 +30,144 @@ echo 4.0.0
 STUB
 chmod +x "$fake_bin/omarchy-version"
 
-# Snapper with no configs: list-configs prints only the CSV header.
+# Snapper with no configs: list-configs prints only the CSV header, exit 0.
+# No config file on disk — the setup hint is safe to print.
 cat >"$fake_bin/snapper" <<'STUB'
 #!/bin/bash
 printf 'snapper %s\n' "$*" >>"$TEST_LOG"
 if [[ "$*" == *"list-configs"* ]]; then
   echo "config,subvolume"
+  exit 0
 fi
 STUB
 chmod +x "$fake_bin/snapper"
 
-# A snapshot that silently creates nothing reads as a successful snapshot, so
-# an unconfigured Snapper has to fail loudly instead of passing for a backup.
 : >"$test_tmp/calls.log"
 set +e
-stderr=$(TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
-  bash "$snapshot" create 2>&1 >/dev/null)
+stderr=$(
+  TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+    OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/snapper-configs/root" \
+    OMARCHY_SNAPPER_CONF_PATH="$test_tmp/snapper.conf" \
+    bash "$snapshot" create 2>&1 >/dev/null
+)
 status=$?
 set -e
 
-(( status != 0 )) || fail "snapshot create fails when Snapper has no configs"
+(( status == 1 )) || fail "snapshot create fails when Snapper has no configs" "got $status"
 grep -qF 'No Snapper configs found' <<<"$stderr" ||
   fail "snapshot create reports that no snapshot was created" "$stderr"
+grep -qF 'install/config/snapper.sh' <<<"$stderr" ||
+  fail "snapshot create points at snapper setup only when no config file exists" "$stderr"
 ! grep -q '^snapper -c .* create ' "$test_tmp/calls.log" ||
   fail "snapshot create does not invent a config to snapshot"
 pass "snapshot create fails loudly when Snapper is installed but unconfigured"
 
+# Header-only list while a root config file already exists must not recommend
+# snapper.sh — that script overwrites the file (#10421 remainder).
+: >"$test_tmp/snapper-configs/root"
+: >"$test_tmp/calls.log"
+set +e
+stderr=$(
+  TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+    OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/snapper-configs/root" \
+    OMARCHY_SNAPPER_CONF_PATH="$test_tmp/snapper.conf" \
+    bash "$snapshot" create 2>&1 >/dev/null
+)
+status=$?
+set -e
+
+(( status == 1 )) || fail "snapshot create fails when a config file is unlisted" "got $status"
+grep -qF 'No Snapper configs found' <<<"$stderr" ||
+  fail "snapshot create still reports that no snapshot was created" "$stderr"
+grep -qF "$test_tmp/snapper-configs/root" <<<"$stderr" ||
+  fail "snapshot create names the existing config file" "$stderr"
+grep -qF "$test_tmp/snapper.conf" <<<"$stderr" ||
+  fail "snapshot create points at SNAPPER_CONFIGS registration" "$stderr"
+! grep -qF 'install/config/snapper.sh' <<<"$stderr" ||
+  fail "snapshot create does not suggest overwriting an existing root config" "$stderr"
+! grep -q '^snapper -c .* create ' "$test_tmp/calls.log" ||
+  fail "snapshot create does not invent a config when the file is unlisted"
+pass "snapshot create does not recommend snapper.sh when a root config already exists"
+
+# sudo failure must not be reported as "no configs" — that path used to run
+# install/config/snapper.sh, which overwrites a working root config.
+cat >"$fake_bin/sudo" <<'STUB'
+#!/bin/bash
+echo "sudo: a terminal is required to read the password" >&2
+echo "sudo: a password is required" >&2
+exit 1
+STUB
+chmod +x "$fake_bin/sudo"
+
+: >"$test_tmp/calls.log"
+set +e
+stderr=$(
+  TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+    OMARCHY_PATH=/usr/share/omarchy \
+    OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/snapper-configs/root" \
+    bash "$snapshot" create 2>&1 >/dev/null
+)
+status=$?
+set -e
+
+(( status == 1 )) || fail "snapshot create fails when sudo cannot list configs" "got $status"
+grep -qF 'Could not list Snapper configs.' <<<"$stderr" ||
+  fail "snapshot create reports a list failure instead of empty configs" "$stderr"
+! grep -qF 'is sudo available' <<<"$stderr" ||
+  fail "list-failure message stays cause-neutral" "$stderr"
+! grep -qF 'No Snapper configs found' <<<"$stderr" ||
+  fail "snapshot create does not claim configs are missing when sudo failed" "$stderr"
+! grep -qF 'install/config/snapper.sh' <<<"$stderr" ||
+  fail "snapshot create does not suggest overwriting snapper config after sudo failure" "$stderr"
+! grep -q '^snapper ' "$test_tmp/calls.log" ||
+  fail "snapshot create does not reach snapper when sudo fails"
+pass "snapshot create distinguishes sudo failure from missing configs"
+
+# D-Bus / snapper failure after sudo succeeds must use the same neutral message.
+cat >"$fake_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+chmod +x "$fake_bin/sudo"
+
+cat >"$fake_bin/snapper" <<'STUB'
+#!/bin/bash
+printf 'snapper %s\n' "$*" >>"$TEST_LOG"
+if [[ "$*" == *"list-configs"* ]]; then
+  echo "Failure (org.freedesktop.DBus.Error.FileNotFound)." >&2
+  exit 1
+fi
+STUB
+chmod +x "$fake_bin/snapper"
+
+: >"$test_tmp/calls.log"
+set +e
+stderr=$(
+  TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+    bash "$snapshot" create 2>&1 >/dev/null
+)
+status=$?
+set -e
+
+(( status == 1 )) || fail "snapshot create fails when snapper cannot list configs" "got $status"
+grep -qF 'Could not list Snapper configs.' <<<"$stderr" ||
+  fail "snapshot create reports a list failure for snapper errors" "$stderr"
+! grep -qF 'is sudo available' <<<"$stderr" ||
+  fail "snapper list failure does not blame sudo" "$stderr"
+! grep -qF 'No Snapper configs found' <<<"$stderr" ||
+  fail "snapper list failure is not reported as missing configs" "$stderr"
+! grep -qF 'install/config/snapper.sh' <<<"$stderr" ||
+  fail "snapper list failure does not suggest overwriting snapper config" "$stderr"
+pass "snapshot create distinguishes snapper list failure from missing configs"
+
+# Restore happy-path stubs.
 cat >"$fake_bin/snapper" <<'STUB'
 #!/bin/bash
 printf 'snapper %s\n' "$*" >>"$TEST_LOG"
 if [[ "$*" == *"list-configs"* ]]; then
   echo "config,subvolume"
   echo "root,/"
+  exit 0
 fi
 STUB
 chmod +x "$fake_bin/snapper"


### PR DESCRIPTION
## Summary

Fixes #10421.

`omarchy-snapshot create` listed configs via process substitution:

```bash
mapfile -t CONFIGS < <(sudo snapper --csvout list-configs | awk ...)
```

A failed `sudo` yields empty stdout and a hidden non-zero status, so the script reported "No Snapper configs found" and pointed at `install/config/snapper.sh`. That setup script unconditionally overwrites `/etc/snapper/configs/root` and disables `snapper-timeline.timer`.

Capture `list-configs` exit status first. Only the genuine empty-list path still suggests setup.

## Test plan

- [x] `bash test/shell.d/snapshot-create-test.sh`
  - unconfigured snapper still fails with the setup hint
  - sudo failure reports list failure, never "No Snapper configs found", never suggests snapper.sh
  - configured create/cleanup path unchanged
  - missing-snapper exit 127 unchanged
- [x] Manual sudo-failure stub before/after: misreport gone; correct error present

## Notes

sudo stderr is left on the terminal so an interactive password prompt still works.