### PR TITLE
Resolve cloned services in serviceFor lookups

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -272,8 +272,14 @@ ShellRoot {
 
   property var _services: ({})
 
+  // Lookups name the built-in id even after a clone has replaced it. Resolve
+  // through the registry so bar indicators (and anyone else) reach the enabled
+  // implementation, matching IPC routing.
   function serviceFor(pluginId) {
-    return _services[String(pluginId)] || null
+    var id = pluginRegistry
+      ? pluginRegistry.resolveEnabledId(pluginId)
+      : String(pluginId || "")
+    return _services[id] || null
   }
 
   function firstPartyServiceFor(pluginId) {

--- a/test/shell.d/plugins-test.sh
+++ b/test/shell.d/plugins-test.sh
@@ -210,5 +210,28 @@ check(
   '_syncServices still drops disabled or removed services'
 )
 
+// serviceFor must resolve clones the same way IPC does. A plain _services[id]
+// lookup leaves firstPartyServiceFor("omarchy.notifications") null after
+// `omarchy plugin clone omarchy.notifications`, so bar indicators go dark.
+const serviceForMatch = shellSource.match(/function serviceFor\(pluginId\) \{[\s\S]*?\n  \}/)
+check(!!serviceForMatch, 'serviceFor is defined')
+check(
+  !!serviceForMatch && /resolveEnabledId\(pluginId\)/.test(serviceForMatch[0]),
+  'serviceFor routes through resolveEnabledId so cloned services keep driving indicators'
+)
+check(
+  !!serviceForMatch && !/return _services\[String\(pluginId\)\]/.test(serviceForMatch[0]),
+  'serviceFor does not look up the raw plugin id alone'
+)
+
+// resolveEnabledId itself: built-in id maps to the enabled clone when present.
+const registrySource = fs.readFileSync(path.join(root, 'shell/services/PluginRegistry.qml'), 'utf8')
+const resolveMatch = registrySource.match(/function resolveEnabledId\(id\) \{[\s\S]*?\n  \}/)
+check(!!resolveMatch, 'resolveEnabledId is defined')
+check(
+  !!resolveMatch && /clonedFrom/.test(resolveMatch[0]) && /isEnabled\(candidate\)/.test(resolveMatch[0]),
+  'resolveEnabledId returns the enabled clone for a built-in id'
+)
+
 assert(errors.length === 0, 'plugin manifests match shell registry contract', errors.join('\n'))
 JS


### PR DESCRIPTION
## Summary

Fixes #10023.

Bar indicators resolve services with the built-in id, e.g. `firstPartyServiceFor("omarchy.notifications")`. After `omarchy plugin clone omarchy.notifications`, the built-in is disabled and only the clone is loaded into `_services`.

`serviceFor` did a raw map lookup on that built-in id and returned null, so the Dnd / NightLight / StayAwake indicators went dark and their clicks became no-ops. IPC already routes through `pluginRegistry.resolveEnabledId`; `serviceFor` did not.

`serviceFor` now resolves the enabled id first, then looks it up in `_services`.

## Test plan

- [x] `bash test/shell.d/plugins-test.sh` — asserts `serviceFor` calls `resolveEnabledId` and no longer indexes `_services` by the raw plugin id alone
- [x] `bash test/shell.d/plugin-clone-test.sh` — clone lifecycle unchanged
- [x] Decision-matrix repro: with only `fresh.notifications` loaded, old lookup for `omarchy.notifications` is null; new lookup returns the clone

## Notes

Indicators that hardcode built-in ids (`Dnd.qml`, `NightLight.qml`, `StayAwake.qml`) keep working without per-widget changes.