### PR TITLE
Make night light temperature configurable

### DIFF
--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -4,9 +4,22 @@
 # omarchy:args=[--status]
 # omarchy:examples=omarchy toggle nightlight
 
-ON_TEMP=4000
 OFF_TEMP=6500
 IDENTITY_TEMP=6000
+CONFIG_FILE="$HOME/.config/omarchy/shell.json"
+
+configured_night_temp() {
+  local temperature
+
+  temperature=$(jq -er '
+    .nightlight.temperature
+    | select(type == "number" and floor == . and . >= 1000 and . < 6000)
+  ' "$CONFIG_FILE" 2>/dev/null) || temperature=4000
+
+  printf '%s\n' "$temperature"
+}
+
+ON_TEMP=$(configured_night_temp)
 
 current_temp() {
   local output

--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -4,6 +4,9 @@
     "screensaver": 150,
     "lock": 300
   },
+  "nightlight": {
+    "temperature": 4000
+  },
   "bar": {
     "position": "top",
     "transparent": false,

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -41,7 +41,13 @@ Inactive indicators are hidden. Hover the area around them and they fade in dimm
 
 ### Night light
 
-`Super + Ctrl + N` warms the screen to 4000K, and hitting it again puts it back to 6500K. It's driven by hyprsunset, which the toggle starts for you if it isn't already running.
+`Super + Ctrl + N` warms the screen to 4000K, and hitting it again puts it back to 6500K. It's driven by hyprsunset, which the toggle starts for you if it isn't already running. To make Night Light warmer or cooler, set `nightlight.temperature` in `~/.config/omarchy/shell.json` to a whole number from 1000 through 5999. The shell and command-line toggle both use this value:
+
+```json
+"nightlight": {
+  "temperature": 2800
+}
+```
 
 By default hyprsunset does nothing to your screen at all. `~/.config/hypr/hyprsunset.conf` ships with an identity profile precisely so the display stays untouched until you ask for warmth. If you'd rather have it switch by the clock, replace that with a time profile:
 
@@ -52,7 +58,7 @@ profile {
 }
 ```
 
-Then start hyprsunset at login by adding `o.launch_on_start("hyprsunset")` to `~/.config/hypr/autostart.lua`. The 4000K/6500K pair used by the toggle is fixed, so the config file is where you go if you want a different temperature.
+Then start hyprsunset at login by adding `o.launch_on_start("hyprsunset")` to `~/.config/hypr/autostart.lua`. Scheduled profiles have their own temperature and do not use the manual toggle's `nightlight.temperature` setting.
 
 ### Do not disturb
 

--- a/shell/plugins/services/nightlight/NightlightModel.js
+++ b/shell/plugins/services/nightlight/NightlightModel.js
@@ -1,6 +1,14 @@
 // Temperatures below the identity point count as night light. Keep in sync
 // with bin/omarchy-toggle-nightlight, which applies the same threshold.
 var IDENTITY_TEMPERATURE = 6000
+var DEFAULT_NIGHT_TEMPERATURE = 4000
+
+function configuredNightTemperature(value) {
+  var temperature = Number(value)
+  if (!Number.isFinite(temperature) || !Number.isInteger(temperature) || temperature < 1000 || temperature >= IDENTITY_TEMPERATURE)
+    return DEFAULT_NIGHT_TEMPERATURE
+  return temperature
+}
 
 function temperatureFromOutput(output) {
   var match = String(output === undefined || output === null ? "" : output).match(/[0-9]+/)
@@ -14,6 +22,8 @@ function isNightlight(temperature) {
 if (typeof module !== "undefined") {
   module.exports = {
     IDENTITY_TEMPERATURE: IDENTITY_TEMPERATURE,
+    DEFAULT_NIGHT_TEMPERATURE: DEFAULT_NIGHT_TEMPERATURE,
+    configuredNightTemperature: configuredNightTemperature,
     temperatureFromOutput: temperatureFromOutput,
     isNightlight: isNightlight
   }

--- a/shell/plugins/services/nightlight/Service.qml
+++ b/shell/plugins/services/nightlight/Service.qml
@@ -8,9 +8,8 @@ Item {
   // Injected by omarchy-shell (the first-party service loader).
   property var shell: null
 
-  // Keep in sync with bin/omarchy-toggle-nightlight, which sets the same
-  // temperatures for callers outside the shell (keybindings, menu, ssh).
-  readonly property int nightTemperature: 4000
+  readonly property var nightlightConfig: shell && shell.shellConfig && shell.shellConfig.nightlight ? shell.shellConfig.nightlight : ({})
+  readonly property int nightTemperature: NightlightModel.configuredNightTemperature(nightlightConfig.temperature)
   readonly property int dayTemperature: 6500
 
   property bool stateLoaded: false

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -16,6 +16,9 @@ pass "default shell.json is valid JSON"
 jq -e '.version == 1 and (.bar.layout.left | type == "array") and (.bar.layout.center | type == "array") and (.bar.layout.right | type == "array")' "$ROOT/config/omarchy/shell.json" >/dev/null
 pass "default shell.json has versioned bar layout"
 
+jq -e '.nightlight.temperature == 4000' "$ROOT/config/omarchy/shell.json" >/dev/null
+pass "default shell.json sets the nightlight temperature"
+
 # Pinning the whole row made this fail every time an unrelated widget moved,
 # so assert the adjacency the name is about and let the rest of the row change.
 jq -e '

--- a/test/shell.d/nightlight-test.sh
+++ b/test/shell.d/nightlight-test.sh
@@ -7,6 +7,10 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const nightlight = requireFromRoot('shell/plugins/services/nightlight/NightlightModel.js')
 
+assertEqual(nightlight.configuredNightTemperature(2800), 2800, 'nightlight accepts a configured warm temperature')
+assertEqual(nightlight.configuredNightTemperature('2800'), 2800, 'nightlight accepts a numeric configured temperature')
+assertEqual(nightlight.configuredNightTemperature(6000), 4000, 'nightlight rejects a temperature that is not warmer than identity')
+assertEqual(nightlight.configuredNightTemperature('warm'), 4000, 'nightlight falls back when its configured temperature is invalid')
 assertEqual(nightlight.temperatureFromOutput('4000\n'), 4000, 'nightlight parses probe temperature')
 assertEqual(nightlight.temperatureFromOutput("Couldn't connect to hyprsunset"), null, 'nightlight treats unreachable hyprsunset as unknown')
 assertEqual(nightlight.isNightlight(4000), true, 'nightlight reports warm temperatures as enabled')
@@ -19,8 +23,11 @@ TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
 mkdir -p "$TMPDIR/bin"
+TEST_HOME="$TMPDIR/home"
 STATE="$TMPDIR/hyprsunset-temp"
 SHELL_LOG="$TMPDIR/omarchy-shell-log"
+
+mkdir -p "$TEST_HOME/.config/omarchy"
 
 cat >"$TMPDIR/bin/hyprctl" <<'SH'
 #!/bin/bash
@@ -51,6 +58,7 @@ chmod +x "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/pgrep" "$TMPDIR/bin/omarchy-shell"
 
 nightlight_cli() {
   PATH="$TMPDIR/bin:$PATH" \
+  HOME="$TEST_HOME" \
   HYPRSUNSET_STATE="$STATE" \
   OMARCHY_SHELL_LOG="$SHELL_LOG" \
     "$ROOT/bin/omarchy-toggle-nightlight" "$@"
@@ -85,6 +93,18 @@ pass "nightlight toggle nudges the shell nightlight service"
 nightlight_cli >/dev/null
 [[ $(<"$STATE") == 6500 ]] || fail "nightlight toggle restores daylight from night light"
 pass "nightlight toggle restores daylight from night light"
+
+printf '{"nightlight":{"temperature":2800}}\n' >"$TEST_HOME/.config/omarchy/shell.json"
+printf '6500\n' >"$STATE"
+nightlight_cli >/dev/null
+[[ $(<"$STATE") == 2800 ]] || fail "nightlight toggle uses the configured temperature"
+pass "nightlight toggle uses the configured temperature"
+
+printf '{"nightlight":{"temperature":6000}}\n' >"$TEST_HOME/.config/omarchy/shell.json"
+printf '6500\n' >"$STATE"
+nightlight_cli >/dev/null
+[[ $(<"$STATE") == 4000 ]] || fail "nightlight toggle falls back for an invalid configured temperature"
+pass "nightlight toggle falls back for an invalid configured temperature"
 
 if rg -q 'omarchy.indicators' "$ROOT/bin/omarchy-toggle-nightlight"; then
   fail "nightlight toggle leaves indicator refresh to the nightlight service"


### PR DESCRIPTION
## Summary

- add `nightlight.temperature` to `~/.config/omarchy/shell.json`
- use the same configured value from the Shell service and CLI toggle
- preserve `4000K` as the default and fallback
- accept whole-number temperatures from `1000K` through `5999K`
- document manual-toggle configuration and its separation from scheduled hyprsunset profiles

## Motivation

Night Light currently hard-codes `4000K` independently in `bin/omarchy-toggle-nightlight` and `shell/plugins/services/nightlight/Service.qml`. I realized that I need a much warmer setting and that meant overriding both paths to keep the CLI, keybinding, and bar indicator behavior consistent.

This makes `shell.json` the shared source of truth while retaining current behavior for existing configurations that do not contain the new key.

## Configuration

```json
"nightlight": {
  "temperature": 2800
}
```

## Testing

- `bash test/shell.d/nightlight-test.sh`
- `bash test/shell.d/config-test.sh` passes all config assertions, then stops at its existing requirement for a sibling `omarchy-pkgs` checkout
- `bash -n bin/omarchy-toggle-nightlight test/shell.d/nightlight-test.sh test/shell.d/config-test.sh`
- `jq empty config/omarchy/shell.json`
- `git diff --check`
- live compositor verification: the branch CLI read `2800` from an isolated config and `hyprctl hyprsunset temperature` reported `2800`

`./test/all` completed with the changed Night Light tests passing.

## Related work

PR #9554 expands Night Light with sunset scheduling and currently retains hard-coded `4000K` values. This change intentionally configures the manual toggle only.