### PR TITLE
Coordinate Hermes graphical setup and native updates

### DIFF
--- a/bin/omarchy-cmd-hermes-home
+++ b/bin/omarchy-cmd-hermes-home
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# omarchy:summary=Resolve the shared Hermes home from a root or profile session
+# omarchy:hidden=true
+
+set -euo pipefail
+
+hermes_home=${HERMES_HOME:-$HOME/.hermes}
+if [[ $hermes_home != /* ]]; then
+  echo "HERMES_HOME must name an absolute Hermes data directory." >&2
+  exit 1
+fi
+
+# Setup, removal and themes share the root above a Hermes profiles/<name> home.
+# Normalize spelling without resolving symlinks, which ownership checks retain.
+hermes_home=$(realpath -ms -- "$hermes_home")
+hermes_parent=${hermes_home%/*}
+if [[ ${hermes_parent##*/} == "profiles" ]]; then
+  hermes_home=${hermes_parent%/*}
+fi
+
+if [[ $hermes_home != /* || $hermes_home == "/" ]]; then
+  echo "HERMES_HOME must name an absolute Hermes data directory other than /." >&2
+  exit 1
+fi
+
+printf '%s\n' "$hermes_home"

--- a/bin/omarchy-install-ai-hermes
+++ b/bin/omarchy-install-ai-hermes
@@ -5,6 +5,9 @@
 
 set -e
 
+HERMES_HOME=$(omarchy-cmd-hermes-home)
+export HERMES_HOME
+
 # The package is the entry point to a writable native installation. Wait for
 # both the runtime and desktop build so the app and CLI update the same copy.
 echo "Installing Hermes Desktop..."
@@ -18,7 +21,7 @@ setsid uwsm-app -- /usr/bin/hermes-desktop >/dev/null 2>&1 &
 echo "Matching Hermes to the current theme once it is set up..."
 systemctl --user stop omarchy-hermes-theme.service 2>/dev/null || true
 systemd-run --user --quiet --collect --unit=omarchy-hermes-theme \
-  --setenv="HERMES_HOME=${HERMES_HOME:-$HOME/.hermes}" omarchy-theme-set-hermes --wait
+  --setenv="HERMES_HOME=$HERMES_HOME" omarchy-theme-set-hermes --wait
 
 echo ""
 echo "Hermes Desktop has been installed."

--- a/bin/omarchy-install-ai-hermes
+++ b/bin/omarchy-install-ai-hermes
@@ -5,28 +5,21 @@
 
 set -e
 
-# No CLI is installed here on purpose. Hermes Desktop only runs against a
-# runtime built from its own commit, so it provisions one itself under
-# ~/.hermes on first launch, which takes a few minutes and shows its own
-# progress. Handing it the mise CLI instead fails: PyPI trails the tags, and
-# the version gap fails the app's readiness probe with a 401.
+# The package is the entry point to a writable native installation. Wait for
+# both the runtime and desktop build so the app and CLI update the same copy.
 echo "Installing Hermes Desktop..."
 omarchy-pkg-add hermes-desktop
-
-# If Hermes was already installed for the terminal, the app supersedes it: one
-# machine, one Hermes. This drops that copy so the terminal, the default agent
-# and the app all end up on the app's installation.
-omarchy-install-hermes-cli || true
+omarchy-install-hermes-cli --now
 
 echo "Opening Hermes Desktop..."
 setsid uwsm-app -- /usr/bin/hermes-desktop >/dev/null 2>&1 &
 
-# Only a running Hermes can be told which skin to show, and the first launch
-# takes minutes; a unit outlives this terminal and reports to the journal.
+# A unit waits for the gateway to start before handing over the current skin.
 echo "Matching Hermes to the current theme once it is set up..."
 systemctl --user stop omarchy-hermes-theme.service 2>/dev/null || true
-systemd-run --user --quiet --collect --unit=omarchy-hermes-theme omarchy-theme-set-hermes --wait
+systemd-run --user --quiet --collect --unit=omarchy-hermes-theme \
+  --setenv="HERMES_HOME=${HERMES_HOME:-$HOME/.hermes}" omarchy-theme-set-hermes --wait
 
 echo ""
 echo "Hermes Desktop has been installed."
-echo "Its first launch installs the Hermes runtime, which takes a few minutes."
+echo "Update it from Hermes Desktop or with: hermes update"

--- a/bin/omarchy-install-ai-hermes
+++ b/bin/omarchy-install-ai-hermes
@@ -8,11 +8,11 @@ set -e
 HERMES_HOME=$(omarchy-cmd-hermes-home)
 export HERMES_HOME
 
-# The package is the entry point to a writable native installation. Wait for
-# both the runtime and desktop build so the app and CLI update the same copy.
+# Install the desktop here; its first launch sets up the shared, writable
+# Hermes runtime inside the app.
 echo "Installing Hermes Desktop..."
 omarchy-pkg-add hermes-desktop
-omarchy-install-hermes-cli --now
+omarchy-install-hermes-cli --check-package
 
 echo "Opening Hermes Desktop..."
 setsid uwsm-app -- /usr/bin/hermes-desktop >/dev/null 2>&1 &
@@ -25,4 +25,5 @@ systemd-run --user --quiet --collect --unit=omarchy-hermes-theme \
 
 echo ""
 echo "Hermes Desktop has been installed."
+echo "Its first launch installs Hermes inside the app, which takes a few minutes."
 echo "Update it from Hermes Desktop or with: hermes update"

--- a/bin/omarchy-install-hermes-cli
+++ b/bin/omarchy-install-hermes-cli
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Install the Hermes CLI as a mise-backed wrapper in ~/.local/bin
+# omarchy:summary=Set up the Hermes CLI, sharing the native desktop installation when present
 # omarchy:args=[--check|--now|--owns|--remove]
 # omarchy:examples=omarchy install hermes cli | omarchy install hermes cli --now
 
@@ -16,12 +16,9 @@
 # dependency -- and omarchy-mise-install writes a fixed stub with nowhere to
 # say otherwise.
 #
-# There is only ever one Hermes on a machine. hermes-desktop cannot run against
-# this one -- it needs a runtime built from its own commit, and the version gap
-# fails its readiness probe -- so it installs its own under ~/.hermes and puts
-# that on PATH. When the package is present it therefore owns Hermes outright:
-# this installer stands aside and removes its own copy, so the terminal, the
-# default agent and the app are all the same installation.
+# With hermes-desktop installed, the package provisions a native installation
+# whose CLI and desktop can update together. Keep any old Omarchy mise CLI
+# until that replacement is ready, and leave foreign environments alone.
 
 set -euo pipefail
 
@@ -33,6 +30,8 @@ python='3.13'
 # The line that identifies the stub as this installer's; matched whole, so a
 # wrapper that merely mentions the command is not mistaken for ours.
 marker='# Written by omarchy-install-hermes-cli.'
+native_root="${HERMES_HOME:-$HOME/.hermes}/hermes-agent"
+predecessor_receipt="$native_root/.git/omarchy-mise-predecessor"
 
 # The package, not the runtime directory: it is installed before the app has
 # ever run, and that is exactly when we must not start building a second copy.
@@ -40,22 +39,16 @@ desktop_owns_hermes() {
   omarchy-pkg-present hermes-desktop
 }
 
-# The venv appears at the python-deps stage, several stages before the one that
-# installs the command, so its presence says nothing about being usable. The
-# marker is written last, and the command is what the agent actually runs.
+# Older packages forward unknown flags to Electron and call this helper on
+# launch. Calling their --check would recurse. Inspect package metadata first.
+desktop_supports_native_install() {
+  pacman -Qlq hermes-desktop 2>/dev/null | grep -qxF '/usr/share/hermes-desktop/install.sh'
+}
+
+# The package knows whether the native checkout, wrapper and desktop build
+# agree. Then probe the actual command for the flags Omarchy's agent needs.
 desktop_hermes_ready() {
-  [[ -f $HOME/.hermes/hermes-agent/.hermes-bootstrap-complete ]] || return 1
-
-  # An executable of that name proves nothing about whose it is; the app's own
-  # points into ~/.hermes, and anything else is not the install we are asking
-  # about. Matched as a plain string, because the path carries a dot and an
-  # unanchored pattern would also claim a wrapper pointing at ~/xhermes.
-  [[ -f $HOME/.local/bin/hermes ]] || return 1
-  grep -qF "$HOME/.hermes" "$HOME/.local/bin/hermes" || return 1
-
-  # And a marker left behind by an install whose venv has since gone answers
-  # for nothing, so the command has to run, exactly as a foreign one must.
-  hermes_prompt_ready
+  desktop_supports_native_install && hermes-desktop --check && hermes_prompt_ready
 }
 
 # Whether Hermes is really installed, not merely whether the stub exists. A
@@ -72,6 +65,29 @@ installed() {
 ours() {
   [[ -f $HOME/.local/bin/hermes && ! -L $HOME/.local/bin/hermes ]] &&
     grep -qxF "$marker" "$HOME/.local/bin/hermes"
+}
+
+# The package records the marked predecessor before replacing its wrapper.
+# Keep that proof across interrupted setup and failed cleanup, without claiming
+# a same-named environment from a symlink or a merely similar receipt.
+owns_predecessor() {
+  [[ -d $native_root/.git && ! -L $native_root/.git && -f $predecessor_receipt && ! -L $predecessor_receipt ]] &&
+    cmp -s <(printf '%s\n' "$tool") "$predecessor_receipt"
+}
+
+remove_predecessor() {
+  echo "Hermes Desktop is ready; removing the superseded Omarchy CLI..." >&2
+  mise rm -g "$tool" >/dev/null 2>&1 || true
+  mise uninstall --all "$tool" >/dev/null 2>&1 || true
+  if mise where "$tool" >/dev/null 2>&1; then
+    echo "Could not remove the superseded Hermes mise environment. Finish by hand:" >&2
+    echo "  mise rm -g '$tool'" >&2
+    echo "  mise uninstall --all '$tool'" >&2
+    return 1
+  fi
+  if owns_predecessor; then
+    rm -f "$predecessor_receipt"
+  fi
 }
 
 foreign_hermes() {
@@ -122,27 +138,23 @@ fi
 # --remove tears down a Hermes CLI this installer put in place -- the mise tool
 # it installed and the stub it marked -- so Remove Hermes clears a CLI the app
 # never superseded (an interrupted install, or the terminal CLI from before the
-# app existed) rather than leaving it stranded on PATH. The whole teardown
-# turns on the marked stub, exactly as replacement does further down: without
-# it nothing proves the mise environment is Omarchy's rather than one the user
-# built against the same spec, and a user's stays theirs. The desktop takeover
-# removes the environment without asking, but that is its own bargain -- a
-# second Hermes has to go whoever built it, and the app still provides the
-# command afterwards; here nothing would. Idempotent: nothing owned, nothing
-# to do.
+# app existed) rather than leaving it stranded on PATH. A marked stub or the
+# package's exact predecessor receipt proves the mise environment is ours.
+# Explicit removal needs no ready replacement. Idempotent: nothing owned,
+# nothing to do.
 if [[ $mode == "--remove" ]]; then
-  if ours; then
+  if ours || owns_predecessor; then
     mise rm -g "$tool" >/dev/null 2>&1 || true
     mise uninstall --all "$tool" >/dev/null 2>&1 || true
-    rm -f "$HOME/.local/bin/hermes" 2>/dev/null || true
+    if ours; then rm -f "$HOME/.local/bin/hermes" 2>/dev/null || true; fi
 
     # Every step is attempted before any is judged, and judged by what is left
     # rather than by what the commands claimed: the marked stub still answering
     # hermes, or mise still resolving the tool, is a CLI still installed no
     # matter how the removal exited.
-    # Not "run --remove again": once the stub is gone nothing marks the mise
-    # environment as ours, so a rerun would find nothing it owns and succeed
-    # without touching what was left. Only the full commands finish the job.
+    # A legacy CLI without a receipt loses ownership when the stub goes, so
+    # include the complete recovery commands instead of assuming a retry can
+    # still identify it. Receipt-backed removals retain their proof on failure.
     if ours || mise where "$tool" >/dev/null 2>&1; then
       echo "Could not remove the Hermes CLI Omarchy installed. Finish by hand:" >&2
       echo "  rm -f ~/.local/bin/hermes" >&2
@@ -150,6 +162,7 @@ if [[ $mode == "--remove" ]]; then
       echo "  mise uninstall --all '$tool'" >&2
       exit 1
     fi
+    if owns_predecessor; then rm -f "$predecessor_receipt"; fi
   fi
 
   exit 0
@@ -169,31 +182,37 @@ if [[ $mode == "--check" ]]; then
   if installed && hermes_prompt_ready; then exit 0; else exit 1; fi
 fi
 
-# Hand Hermes over to the app rather than keeping a second copy beside it.
+# Capture ownership before the native installer replaces the marked wrapper.
+# No cleanup runs on a failed install. A completed package-only setup leaves a
+# receipt so a later invocation can finish removing the proven predecessor.
 if desktop_owns_hermes; then
-  # Not gated on that copy being healthy: `mise up` can rebuild it against the
-  # wrong interpreter and a half-finished install answers to neither test, and
-  # either way it is still a second Hermes. Removing nothing is harmless.
-  if mise where "$tool" >/dev/null 2>&1; then
-    echo "Hermes Desktop provides Hermes; removing the separate CLI install..." >&2
-  fi
+  if [[ $mode == "--now" ]]; then
+    if ! desktop_supports_native_install; then
+      echo "Update the hermes-desktop package before setting up native Hermes updates." >&2
+      exit 1
+    fi
+    owned_cli=false
+    if ours || owns_predecessor; then owned_cli=true; fi
 
-  mise rm -g "$tool" >/dev/null 2>&1 || true
-  mise uninstall --all "$tool" >/dev/null 2>&1 || true
+    hermes-desktop --install
+    if ! desktop_hermes_ready; then
+      echo "Hermes Desktop did not finish setting up a CLI with interactive queries." >&2
+      exit 1
+    fi
 
-  # Our own stub has to go with it. Left in place it still answers `hermes`
-  # until the app's bootstrap overwrites it, and answering means building the
-  # second Hermes this whole arrangement exists to avoid.
-  if ours; then
-    rm -f "$HOME/.local/bin/hermes"
-  fi
-
-  if desktop_hermes_ready; then
+    if [[ $owned_cli == "true" ]]; then
+      remove_predecessor
+    fi
     exit 0
   fi
 
-  echo "Hermes Desktop is installed but has not set Hermes up yet." >&2
-  echo "Launch Hermes Desktop once to finish installing it." >&2
+  if desktop_hermes_ready; then
+    if owns_predecessor; then remove_predecessor; fi
+    exit 0
+  fi
+
+  echo "Hermes Desktop is installed but has not finished setting up Hermes." >&2
+  echo "Run omarchy-install-hermes-cli --now to finish installing it." >&2
   exit 1
 fi
 

--- a/bin/omarchy-install-hermes-cli
+++ b/bin/omarchy-install-hermes-cli
@@ -22,6 +22,9 @@
 
 set -euo pipefail
 
+HERMES_HOME=$(omarchy-cmd-hermes-home)
+export HERMES_HOME
+
 mode=${1:-}
 
 tool='pipx:hermes-agent[extras=all]'
@@ -30,7 +33,7 @@ python='3.13'
 # The line that identifies the stub as this installer's; matched whole, so a
 # wrapper that merely mentions the command is not mistaken for ours.
 marker='# Written by omarchy-install-hermes-cli.'
-native_root="${HERMES_HOME:-$HOME/.hermes}/hermes-agent"
+native_root="$HERMES_HOME/hermes-agent"
 predecessor_receipt="$native_root/.git/omarchy-mise-predecessor"
 
 # The package, not the runtime directory: it is installed before the app has

--- a/bin/omarchy-install-hermes-cli
+++ b/bin/omarchy-install-hermes-cli
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set up the Hermes CLI, sharing the native desktop installation when present
-# omarchy:args=[--check|--now|--owns|--remove]
+# omarchy:args=[--check|--check-package|--now|--owns|--remove]
 # omarchy:examples=omarchy install hermes cli | omarchy install hermes cli --now
 
 # Hermes pins every one of its dependencies exactly and declares
@@ -45,7 +45,7 @@ desktop_owns_hermes() {
 # Older packages forward unknown flags to Electron and call this helper on
 # launch. Calling their --check would recurse. Inspect package metadata first.
 desktop_supports_native_install() {
-  pacman -Qlq hermes-desktop 2>/dev/null | grep -qxF '/usr/share/hermes-desktop/install.sh'
+  pacman -Qlq hermes-desktop 2>/dev/null | grep -xF '/usr/share/hermes-desktop/install.sh' >/dev/null
 }
 
 # The package knows whether the native checkout, wrapper and desktop build
@@ -131,6 +131,20 @@ hermes_prompt_ready() {
     help_defines_flag '--query' "$help"
 }
 
+# The menu needs a compatible package before launching, but a cold runtime is
+# expected: the desktop will install it. Inspect metadata without running it.
+if [[ $mode == "--check-package" ]]; then
+  # Consume the whole file list: grep -q can SIGPIPE pacman on the large seed
+  # package, making a matching capability fail under pipefail.
+  if desktop_owns_hermes &&
+    pacman -Qlq hermes-desktop 2>/dev/null | grep -xF '/usr/share/hermes-desktop/seed/.git/config' >/dev/null; then
+    exit 0
+  else
+    echo "Install or update the hermes-desktop package before setting up native Hermes updates." >&2
+    exit 1
+  fi
+fi
+
 # --owns answers whether the wrapper on PATH is the one this command wrote, so
 # the migration and Remove Preinstalls do not each carry their own copy of the
 # marker and drift from it.
@@ -215,7 +229,8 @@ if desktop_owns_hermes; then
   fi
 
   echo "Hermes Desktop is installed but has not finished setting up Hermes." >&2
-  echo "Run omarchy-install-hermes-cli --now to finish installing it." >&2
+  echo "Launch Hermes Desktop to finish installing it inside the app." >&2
+  echo "For terminal setup, run omarchy-install-hermes-cli --now." >&2
   exit 1
 fi
 

--- a/bin/omarchy-remove-ai-hermes
+++ b/bin/omarchy-remove-ai-hermes
@@ -6,12 +6,10 @@
 # -u so an unset HOME is an error rather than a set of rm -rf paths rooted at /.
 set -euo pipefail
 
-hermes_home=${HERMES_HOME:-$HOME/.hermes}
+HERMES_HOME=$(omarchy-cmd-hermes-home)
+export HERMES_HOME
+hermes_home=$HERMES_HOME
 hermes_root="$hermes_home/hermes-agent"
-if [[ $hermes_home != /* || $hermes_home == "/" ]]; then
-  echo "HERMES_HOME must name an absolute Hermes data directory." >&2
-  exit 1
-fi
 
 omarchy-pkg-drop hermes-desktop
 

--- a/bin/omarchy-remove-ai-hermes
+++ b/bin/omarchy-remove-ai-hermes
@@ -6,6 +6,13 @@
 # -u so an unset HOME is an error rather than a set of rm -rf paths rooted at /.
 set -euo pipefail
 
+hermes_home=${HERMES_HOME:-$HOME/.hermes}
+hermes_root="$hermes_home/hermes-agent"
+if [[ $hermes_home != /* || $hermes_home == "/" ]]; then
+  echo "HERMES_HOME must name an absolute Hermes data directory." >&2
+  exit 1
+fi
+
 omarchy-pkg-drop hermes-desktop
 
 # The installer leaves a unit waiting to hand the app the Omarchy theme.
@@ -16,48 +23,130 @@ systemctl --user stop omarchy-hermes-theme.service 2>/dev/null || true
 # the app never superseded -- an interrupted install, or the terminal CLI from
 # before the app existed. Remove Hermes clears that too, scoped by the installer
 # to what Omarchy owns so a hermes the user set up themselves is left alone.
-# Tolerated here rather than fatal, so the ~/.hermes handling below still runs;
-# the failure is answered for at the end instead of being swallowed.
+# A failed cleanup retains the runtime and its receipt below so it can be
+# retried; the failure is returned after explaining what was kept.
 cli_removed=true
 omarchy-install-hermes-cli --remove || cli_removed=false
 
-# The app writes this when the runtime it provisions under ~/.hermes has landed,
-# and it is the only thing that tells that runtime apart from one the user
-# installed themselves -- the paths are the same either way. Without it the app
-# never got that far: a machine where it was installed but never launched still
-# has whatever was there before, and none of it is ours to delete unasked.
-if [[ -f $HOME/.hermes/hermes-agent/.hermes-bootstrap-complete ]]; then
-  # The checkout and venv, its own uv, its own node. None of it is any use once
-  # the app is gone, so it goes without asking; what the user made with the app
-  # is a different question, answered below.
-  rm -rf \
-    "$HOME/.hermes/hermes-agent" \
-    "$HOME/.hermes/bootstrap-cache" \
-    "$HOME/.hermes/bin" \
-    "$HOME/.hermes/node"
+# New installs mark their runtime explicitly, including an interrupted setup.
+# Legacy app bootstraps predate that marker; only the known package revisions
+# with their upstream remote qualify for removal without the data question.
+managed_runtime=false
+if [[ -f $hermes_root/.omarchy-hermes-desktop && ! -L $hermes_root/.omarchy-hermes-desktop ]] &&
+  grep -qxE 'pending|updating|ready' "$hermes_root/.omarchy-hermes-desktop"; then
+  managed_runtime=true
+elif [[ -f $hermes_root/.hermes-bootstrap-complete ]] &&
+  jq -e '.schemaVersion == 1 and (.pinnedCommit == "e624e9fde561e1add9388384012b295fde669ade" or .pinnedCommit == "29112bef099274229cadff79cdff7bf7b99c4b77")' \
+    "$hermes_root/.hermes-bootstrap-complete" >/dev/null 2>&1; then
+  case "$(git -C "$hermes_root" remote get-url origin 2>/dev/null || true)" in
+    https://github.com/NousResearch/hermes-agent.git | https://github.com/NousResearch/hermes-agent | git@github.com:NousResearch/hermes-agent.git)
+      managed_runtime=true ;;
+  esac
+fi
 
-  # Only the wrappers pointing into ~/.hermes, matched as a plain string: the
-  # path carries a dot, so an unanchored pattern would also claim a wrapper
-  # pointing at a sibling like ~/xhermes.
-  for command in hermes hermes-agent hermes-acp; do
-    wrapper="$HOME/.local/bin/$command"
+# A clean working tree can still contain unpublished history. Compare all
+# local refs and HEAD against fetched remote history; the two old packaged
+# commits are also known upstream history in tag-only bootstrap clones.
+published_history() {
+  local commits branches remotes branch commit
+  local published=(--remotes)
 
-    if [[ -f $wrapper && ! -L $wrapper ]] && grep -qF "$HOME/.hermes" "$wrapper"; then
-      rm -f "$wrapper"
+  if git -C "$hermes_root" rev-parse --verify refs/stash >/dev/null 2>&1; then
+    return 1
+  fi
+  for commit in e624e9fde561e1add9388384012b295fde669ade 29112bef099274229cadff79cdff7bf7b99c4b77; do
+    if git -C "$hermes_root" cat-file -e "$commit^{commit}" 2>/dev/null; then
+      published+=("$commit")
     fi
   done
+  commits=$(git -C "$hermes_root" rev-list --all HEAD --not "${published[@]}" 2>/dev/null) || return 1
+  [[ -z $commits ]] || return 1
 
-  # When Hermes brought its own Node it symlinked these next to its own commands,
-  # and they point at what we just deleted. Only the links into ~/.hermes: a
-  # system Node, or someone else's, lives somewhere else entirely.
+  branches=$(git -C "$hermes_root" for-each-ref --format='%(refname:strip=2)' refs/heads) || return 1
+  remotes=$(git -C "$hermes_root" for-each-ref --format='%(refname:strip=3)' refs/remotes) || return 1
+  while IFS= read -r branch; do
+    [[ -z $branch ]] && continue
+    grep -qxF -- "$branch" <<<"$remotes" || return 1
+  done <<<"$branches"
+}
+
+# An owned checkout can subsequently become a development checkout. Its Git
+# directory may also serve another worktree. Keep it and its launchers intact
+# when removal would take source changes or the other checkout's metadata.
+runtime_kept=false
+if [[ $cli_removed == "false" ]]; then
+  managed_runtime=false
+  runtime_kept=true
+  echo "Keeping $hermes_root and its launchers so the failed CLI cleanup can be retried." >&2
+elif [[ $managed_runtime == "true" ]]; then
+  if [[ -L $hermes_root || -L $hermes_home ]] ||
+    ! changes=$(git -C "$hermes_root" status --porcelain 2>/dev/null) ||
+    [[ -n $changes ]] ||
+    ! worktrees=$(git -C "$hermes_root" worktree list --porcelain 2>/dev/null) ||
+    (( $(grep -c '^worktree ' <<<"$worktrees") != 1 )) ||
+    ! published_history; then
+    managed_runtime=false
+    runtime_kept=true
+    echo "Keeping $hermes_root and its launchers: it has local work, unpublished history, linked worktrees, or is not a regular checkout." >&2
+  fi
+fi
+
+if [[ $managed_runtime == "true" ]]; then
+  # Compare the generated files before removing anything they target. A user's
+  # customized wrapper or launcher is preserved even if it mentions this root.
+  python3 - "$hermes_root" "$HOME/.local/bin" "${XDG_DATA_HOME:-$HOME/.local/share}/applications/hermes.desktop" <<'PYTHON'
+from pathlib import Path
+import shlex
+import sys
+
+root, commands, entry = map(Path, sys.argv[1:])
+wrappers = {
+    "hermes": f'"{root}/hermes"',
+    "hermes-agent": f'"{root}/run_agent.py"',
+    "hermes-acp": f'"{root}/hermes" acp',
+}
+def contents(path):
+    try:
+        return path.read_bytes()
+    except OSError:
+        return b""
+
+owned = []
+for name, args in wrappers.items():
+    wrapper = commands / name
+    expected = f'#!/usr/bin/env bash\nunset PYTHONPATH\nunset PYTHONHOME\nexec "{root}/venv/bin/python" {args} "$@"\n'
+    if wrapper.is_file() and not wrapper.is_symlink() and contents(wrapper) == expected.encode():
+        owned.append(wrapper)
+
+if entry.is_file() and not entry.is_symlink():
+    # These fields are emitted by Hermes' native Linux desktop registration.
+    lines = contents(entry).decode(errors="replace").splitlines()
+    fixed = ["[Desktop Entry]", "Type=Application", "Name=Hermes", "GenericName=Hermes Desktop", "Comment=Launch Hermes Desktop", "Terminal=false", "Categories=Utility;", "StartupNotify=true", "StartupWMClass=Hermes"]
+    rest = [line for line in lines if not line.startswith(("Exec=", "Icon="))]
+    exec_lines = [line[5:] for line in lines if line.startswith("Exec=")]
+    icon_lines = [line[5:] for line in lines if line.startswith("Icon=")]
+    expected_exec = [[str(root / "venv/bin/python"), "-m", "hermes_cli.main", "desktop"]]
+    if commands / "hermes" in owned:
+        expected_exec.append([str(commands / "hermes"), "desktop"])
+    try:
+        matching_exec = len(exec_lines) == 1 and shlex.split(exec_lines[0]) in expected_exec
+    except ValueError:
+        matching_exec = False
+    if rest == fixed and matching_exec and icon_lines in [["hermes"], [str(root / "apps/desktop/assets/icon.png")]]:
+        entry.unlink()
+
+for wrapper in owned:
+    wrapper.unlink()
+PYTHON
+
+  rm -rf "$hermes_root" "$hermes_home/bootstrap-cache" "$hermes_home/bin" "$hermes_home/node"
+
   for command in node npm npx; do
     link="$HOME/.local/bin/$command"
-
-    if [[ -L $link && $(readlink "$link") == "$HOME/.hermes"/* ]]; then
+    if [[ -L $link && $(readlink "$link") == "$hermes_home/node/"* ]]; then
       rm -f "$link"
     fi
   done
-
 fi
 
 # What survives to here is the user's: the chats, memories and skills in
@@ -73,12 +162,12 @@ fi
 # never owned, a yes takes that with it, and saying so is the prompt's job.
 # Without a terminal to ask in, keeping everything is the answer.
 data_removed=false
-if [[ -d $HOME/.hermes || -d $HOME/.config/Hermes ]] && [[ -t 0 ]] && omarchy-cmd-present gum; then
+if [[ $cli_removed == "true" ]] && [[ -d $hermes_home || -d $HOME/.config/Hermes ]] && [[ -t 0 ]]; then
   # du answers non-zero when either directory is missing, and pipefail would
   # turn that into an aborted removal; the size is worth no such thing.
-  size=$(du -shc "$HOME/.hermes" "$HOME/.config/Hermes" 2>/dev/null | tail -1 | cut -f1 || true)
-  if gum confirm --default=false "Also delete ~/.hermes and ~/.config/Hermes ($size: chats, memories, skills, connections and tokens)?"; then
-    rm -rf "$HOME/.hermes" "$HOME/.config/Hermes"
+  size=$(du -shc "$hermes_home" "$HOME/.config/Hermes" 2>/dev/null | tail -1 | cut -f1 || true)
+  if gum confirm --default=false "Also delete $hermes_home and ~/.config/Hermes ($size: chats, memories, skills, connections and tokens)?"; then
+    rm -rf "$hermes_home" "$HOME/.config/Hermes"
     data_removed=true
   fi
 fi
@@ -86,14 +175,16 @@ fi
 echo ""
 echo "Hermes Desktop has been removed."
 if [[ $data_removed == true ]]; then
-  echo "Its chats, memories, and settings in ~/.hermes and ~/.config/Hermes are gone too."
-elif [[ -d $HOME/.hermes || -d $HOME/.config/Hermes ]]; then
-  echo "Your chats, memories, and skills are still in ~/.hermes,"
+  echo "Its chats, memories, and settings in $hermes_home and ~/.config/Hermes are gone too."
+elif [[ $runtime_kept == "true" ]]; then
+  echo "The Hermes runtime, launchers, and user data have been kept."
+elif [[ -d $hermes_home || -d $HOME/.config/Hermes ]]; then
+  echo "Your chats, memories, and skills are still in $hermes_home,"
   echo "and your connections and settings in ~/.config/Hermes."
 fi
 
-# The messages above still hold -- the app and its runtime are gone -- but a CLI
-# teardown that failed already said so on stderr, and that stands.
+# The package is gone; any retained runtime is explained above. A failed CLI
+# teardown still reaches the caller.
 if [[ $cli_removed == "false" ]]; then
   exit 1
 fi

--- a/bin/omarchy-theme-set-hermes
+++ b/bin/omarchy-theme-set-hermes
@@ -16,7 +16,9 @@ HERMES_CONFIG_PATH="$HERMES_HOME/config.yaml"
 HERMES_SKIN_NAME="omarchy"
 # The command the readiness probe vets, rather than whichever hermes is on PATH.
 HERMES_COMMAND="$HOME/.local/bin/hermes"
-# Written by the desktop app once the runtime its first launch provisions is in.
+# Native installation owns its directory before setup finishes; only ready
+# means the desktop build is usable. Keep the legacy completion marker too.
+HERMES_DESKTOP_MARKER="$HERMES_HOME/hermes-agent/.omarchy-hermes-desktop"
 HERMES_BOOTSTRAP_MARKER="$HERMES_HOME/hermes-agent/.hermes-bootstrap-complete"
 HERMES_ACTIVATE=0
 HERMES_WAIT=0
@@ -75,7 +77,7 @@ fi
 # would start Hermes to answer, so poll for the marker instead.
 if (( HERMES_WAIT == 1 )); then
   waited=0
-  until [[ -f $HERMES_BOOTSTRAP_MARKER && -f $HERMES_CONFIG_PATH ]]; do
+  until [[ -f $HERMES_CONFIG_PATH ]] && { grep -qxF ready "$HERMES_DESKTOP_MARKER" 2>/dev/null || [[ ! -e $HERMES_DESKTOP_MARKER && -f $HERMES_BOOTSTRAP_MARKER ]]; }; do
     if (( waited >= HERMES_WAIT_LIMIT )); then
       echo "Hermes did not finish setting up within $((HERMES_WAIT_LIMIT / 60)) minutes; run omarchy-theme-set-hermes --activate once it has." >&2
       exit 0

--- a/bin/omarchy-theme-set-hermes
+++ b/bin/omarchy-theme-set-hermes
@@ -11,7 +11,8 @@ set -euo pipefail
 
 HERMES_SOURCE_PATH="$HOME/.local/state/omarchy/current/theme/hermes.yaml"
 HERMES_THEME_NAME_PATH="$HOME/.local/state/omarchy/current/theme.name"
-HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_HOME=$(omarchy-cmd-hermes-home)
+export HERMES_HOME
 HERMES_CONFIG_PATH="$HERMES_HOME/config.yaml"
 HERMES_SKIN_NAME="omarchy"
 # The command the readiness probe vets, rather than whichever hermes is on PATH.

--- a/test/shell.d/hermes-cli-migration-test.sh
+++ b/test/shell.d/hermes-cli-migration-test.sh
@@ -19,6 +19,12 @@ cat >"$mock_bin/omarchy-pkg-present" <<'SH'
 [[ ${OMARCHY_TEST_DESKTOP_INSTALLED:-0} == 1 ]]
 SH
 
+cat >"$mock_bin/pacman" <<'SH'
+#!/bin/bash
+[[ $* == '-Qlq hermes-desktop' ]] || exit 1
+[[ ${OMARCHY_TEST_DESKTOP_NATIVE:-1} == 1 ]] && echo '/usr/share/hermes-desktop/install.sh'
+SH
+
 cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
 #!/bin/bash
 ! command -v "$1" >/dev/null 2>&1
@@ -29,6 +35,13 @@ cat >"$mock_bin/mise" <<'SH'
 #!/bin/bash
 printf '%s\0' "$@" >>"$OMARCHY_TEST_MISE_LOG"
 [[ $1 != "where" ]]
+SH
+
+# Migration only checks readiness; it must not reach a real desktop launcher.
+cat >"$mock_bin/hermes-desktop" <<'SH'
+#!/bin/bash
+[[ $1 == "--check" ]] || exit 2
+exit 1
 SH
 
 chmod +x "$mock_bin"/*
@@ -69,18 +82,16 @@ run_migration 1 || fail "the migration succeeds when Hermes Desktop owns Hermes"
 [[ ! -e $hermes ]] || fail "the migration writes nothing when Hermes Desktop owns Hermes"
 pass "the migration stands aside for Hermes Desktop"
 
-# Standing aside is not the same as leaving a second Hermes behind: the wrapper
-# an earlier install wrote and the mise copy it points at both go when the
-# desktop app owns Hermes, even though the app has not finished setting up.
+# A cold desktop must preserve the old CLI until explicit native setup has
+# finished. Migration never provisions or removes an environment here.
 printf '%s\n' "#!/bin/bash" "$marker" >"$hermes"
 chmod +x "$hermes"
 : >"$mise_log"
-run_migration 1 || fail "the migration succeeds when Hermes Desktop owns Hermes and the old wrapper is present"
-[[ ! -e $hermes ]] || fail "the migration removes the Omarchy wrapper when Hermes Desktop owns Hermes"
+run_migration 1 || fail "the migration succeeds with an old wrapper and a cold desktop"
+grep -qxF "$marker" "$hermes" || fail "the migration preserves the old wrapper until native setup finishes"
 mise_calls=$(tr '\0' ' ' <"$mise_log")
-[[ $mise_calls == *"rm -g "* ]] || fail "the migration removes the global mise Hermes for Hermes Desktop"
-[[ $mise_calls == *"uninstall --all "* ]] || fail "the migration uninstalls the mise Hermes for Hermes Desktop"
-pass "the migration clears the old Omarchy Hermes for Hermes Desktop"
+[[ $mise_calls != *"rm -g "* && $mise_calls != *"uninstall --all "* ]] || fail "the migration preserves the old mise environment"
+pass "the migration preserves the CLI until native desktop setup finishes"
 
 # ...while anyone else's hermes stays exactly where it is, and is not run.
 foreign_ran="$test_tmp/foreign-ran"

--- a/test/shell.d/hermes-cli-test.sh
+++ b/test/shell.d/hermes-cli-test.sh
@@ -11,6 +11,7 @@ mock_bin="$test_tmp/bin"
 test_home="$test_tmp/home"
 mise_log="$test_tmp/mise-log"
 mkdir -p "$mock_bin" "$test_home/.local/bin"
+ln -s "$ROOT/bin/omarchy-cmd-hermes-home" "$mock_bin/omarchy-cmd-hermes-home"
 export OMARCHY_TEST_DESKTOP_LOG="$test_tmp/desktop-log"
 
 cat >"$mock_bin/omarchy-pkg-present" <<'SH'
@@ -164,6 +165,13 @@ OMARCHY_TEST_HERMES_HOME="$test_home/custom hermes" run_installer 1 --now || fai
 [[ -f "$test_home/custom hermes/hermes-agent/.omarchy-hermes-desktop" ]] || fail "native setup uses HERMES_HOME"
 OMARCHY_TEST_HERMES_HOME="$test_home/custom hermes" run_installer 1 --check || fail "readiness follows the custom data home"
 pass "native setup and readiness follow HERMES_HOME"
+
+for shared_home in "$test_home/.hermes" "$test_home/custom hermes"; do
+  OMARCHY_TEST_HERMES_HOME="$shared_home/profiles/coder/" run_installer 1 --now || fail "profile setup succeeds"
+  [[ -f $shared_home/hermes-agent/.omarchy-hermes-desktop && ! -e $shared_home/profiles/coder/hermes-agent ]] || fail "profile setup reuses the shared runtime"
+  OMARCHY_TEST_HERMES_HOME="$shared_home/profiles/coder/" run_installer 1 --check || fail "profile readiness follows the shared runtime"
+done
+pass "native setup and readiness use the shared installation from default and custom profiles"
 
 # A package-only setup can replace the wrapper before this helper ever runs.
 # Its exact receipt carries the predecessor ownership through a retry.

--- a/test/shell.d/hermes-cli-test.sh
+++ b/test/shell.d/hermes-cli-test.sh
@@ -50,7 +50,15 @@ SH
 cat >"$mock_bin/pacman" <<'SH'
 #!/bin/bash
 [[ $* == '-Qlq hermes-desktop' ]] || exit 1
-[[ ${OMARCHY_TEST_DESKTOP_NATIVE:-1} == 1 ]] && echo '/usr/share/hermes-desktop/install.sh'
+if [[ ${OMARCHY_TEST_DESKTOP_NATIVE:-1} == 1 ]]; then
+  echo '/usr/share/hermes-desktop/install.sh'
+  if [[ ${OMARCHY_TEST_DESKTOP_SEED:-1} == 1 ]]; then
+    echo '/usr/share/hermes-desktop/seed/.git/config'
+  fi
+  if [[ ${OMARCHY_TEST_LARGE_PACKAGE:-0} == 1 ]]; then
+    printf '/usr/share/hermes-desktop/seed/file-%s\n' {1..10000}
+  fi
+fi
 SH
 
 cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
@@ -118,6 +126,26 @@ grep -qxF "$stub_marker" "$test_home/.local/bin/hermes" || fail "the stub record
 tr '\0' ' ' <"$mise_log" | grep -q "use -g --quiet uv" &&
   fail "writing the stub does not install uv"
 pass "writing the Hermes stub provisions nothing"
+
+# The menu's package check must accept an empty runtime without installing or
+# probing it, and must preserve the terminal CLI until the app replaces it.
+cp "$test_home/.local/bin/hermes" "$test_tmp/cli-before-package-check"
+: >"$mise_log"
+: >"$OMARCHY_TEST_DESKTOP_LOG"
+OMARCHY_TEST_DESKTOP_CHECK_FAIL=1 run_installer 1 --check-package || fail "a compatible package can launch with no native runtime"
+[[ ! -s $OMARCHY_TEST_DESKTOP_LOG && ! -s $mise_log ]] || fail "package compatibility must not execute Hermes or mise"
+[[ ! -e $test_home/.hermes ]] || fail "package compatibility must not provision a native runtime"
+cmp -s "$test_home/.local/bin/hermes" "$test_tmp/cli-before-package-check" || fail "package compatibility must preserve the existing CLI"
+pass "package compatibility accepts a cold runtime without executing or changing it"
+OMARCHY_TEST_LARGE_PACKAGE=1 run_installer 1 --check-package || fail "a large seed file list must not cause SIGPIPE during package detection"
+OMARCHY_TEST_DESKTOP_SEED=0 run_installer 1 --check-package && fail "installer-only packages cannot perform graphical bootstrap"
+pass "package compatibility consumes large metadata lists and requires the prebuilt seed"
+
+OMARCHY_TEST_DESKTOP_NATIVE=0 run_installer 1 --check-package && fail "legacy packages do not support native updates"
+run_installer 0 --check-package && fail "an absent package cannot launch the desktop"
+[[ ! -s $OMARCHY_TEST_DESKTOP_LOG && ! -s $mise_log ]] || fail "missing or legacy packages must not invoke the desktop or mise"
+cmp -s "$test_home/.local/bin/hermes" "$test_tmp/cli-before-package-check" || fail "failed package checks must preserve the CLI"
+pass "package compatibility rejects missing and legacy packages without side effects"
 
 # Merely installing the package must not remove a working terminal install.
 printf '%s\n' "#!/bin/bash" "$stub_marker" >"$test_home/.local/bin/hermes"

--- a/test/shell.d/hermes-cli-test.sh
+++ b/test/shell.d/hermes-cli-test.sh
@@ -11,10 +11,45 @@ mock_bin="$test_tmp/bin"
 test_home="$test_tmp/home"
 mise_log="$test_tmp/mise-log"
 mkdir -p "$mock_bin" "$test_home/.local/bin"
+export OMARCHY_TEST_DESKTOP_LOG="$test_tmp/desktop-log"
 
 cat >"$mock_bin/omarchy-pkg-present" <<'SH'
 #!/bin/bash
 [[ ${OMARCHY_TEST_DESKTOP_INSTALLED:-0} == 1 ]]
+SH
+
+# The package's own runtime/build validation is tested in omarchy-pkgs. This
+# fixture exposes its public install/check contract to the Omarchy caller.
+cat >"$mock_bin/hermes-desktop" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_DESKTOP_LOG"
+root="${HERMES_HOME:-$HOME/.hermes}/hermes-agent"
+if [[ $1 == "--install" ]]; then
+  [[ ${OMARCHY_TEST_DESKTOP_FAIL:-0} == 0 ]] || exit 1
+  mkdir -p "$root/venv/bin" "$HOME/.local/bin"
+  cat >"$root/venv/bin/hermes" <<'HERMES'
+#!/bin/bash
+if [[ ${1:-} == "chat" && ${2:-} == "--help" ]]; then
+  [[ ${OMARCHY_TEST_HERMES_CAPABLE:-1} == 1 ]] && echo "[--query QUERY] [--tui]"
+else
+  echo "hermes-agent fixture"
+fi
+HERMES
+  chmod +x "$root/venv/bin/hermes"
+  printf '#!/bin/bash\nexec "%s/venv/bin/hermes" "$@"\n' "$root" >"$HOME/.local/bin/hermes"
+  chmod +x "$HOME/.local/bin/hermes"
+  echo ready >"$root/.omarchy-hermes-desktop"
+fi
+[[ ${OMARCHY_TEST_DESKTOP_CHECK_FAIL:-0} == 0 ]] || exit 1
+[[ -f $root/.omarchy-hermes-desktop || -f $root/.hermes-bootstrap-complete ]] &&
+  [[ -f $HOME/.local/bin/hermes && ! -L $HOME/.local/bin/hermes ]] &&
+  grep -qF "$root/" "$HOME/.local/bin/hermes"
+SH
+
+cat >"$mock_bin/pacman" <<'SH'
+#!/bin/bash
+[[ $* == '-Qlq hermes-desktop' ]] || exit 1
+[[ ${OMARCHY_TEST_DESKTOP_NATIVE:-1} == 1 ]] && echo '/usr/share/hermes-desktop/install.sh'
 SH
 
 cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
@@ -31,6 +66,10 @@ SH
 cat >"$mock_bin/mise" <<'SH'
 #!/bin/bash
 printf '%s\0' "$@" >>"$OMARCHY_TEST_MISE_LOG"
+if [[ ${OMARCHY_TEST_MISE_TRACK_REMOVAL:-0} == 1 ]]; then
+  if [[ $1 == "uninstall" ]]; then touch "$OMARCHY_TEST_MISE_ROOT/removed"; fi
+  if [[ $1 == "where" && -f $OMARCHY_TEST_MISE_ROOT/removed ]]; then exit 1; fi
+fi
 if [[ $1 == "where" && ${OMARCHY_TEST_MISE_WHERE_OK:-0} == 1 ]]; then
   printf '%s\n' "$OMARCHY_TEST_MISE_ROOT"
   exit 0
@@ -57,6 +96,7 @@ run_installer() {
     OMARCHY_TEST_MISE_WHERE_OK="${OMARCHY_TEST_MISE_WHERE_OK:-0}" \
     OMARCHY_TEST_MISE_ROOT="$test_tmp/mise" \
     OMARCHY_TEST_MISE_LOG="$mise_log" \
+    HERMES_HOME="${OMARCHY_TEST_HERMES_HOME:-$test_home/.hermes}" \
     HOME="$test_home" \
     PATH="$mock_bin:$PATH" \
     bash "$ROOT/bin/omarchy-install-hermes-cli" ${2:+"$2"} >/dev/null 2>&1
@@ -78,31 +118,117 @@ tr '\0' ' ' <"$mise_log" | grep -q "use -g --quiet uv" &&
   fail "writing the stub does not install uv"
 pass "writing the Hermes stub provisions nothing"
 
-# The desktop app owns Hermes, so our own stub must go rather than sit there
-# answering `hermes` until the app's bootstrap replaces it.
-printf '%s\n' "#!/bin/bash" "$stub_marker" >"$test_home/.local/bin/hermes"
-chmod +x "$test_home/.local/bin/hermes"
-run_installer 1 || true
-[[ ! -e $test_home/.local/bin/hermes ]] ||
-  fail "the desktop taking over removes the stub this command wrote"
-pass "installing the desktop app removes the CLI stub"
-
-# ...but the app's own hermes is not ours to delete.
-printf '%s\n' "$app_stub_body" >"$test_home/.local/bin/hermes"
-chmod +x "$test_home/.local/bin/hermes"
-run_installer 1 || true
-[[ -x $test_home/.local/bin/hermes ]] ||
-  fail "the desktop app's own hermes command survives"
-pass "the app's own hermes command is left alone"
-
-# A copy mise cannot vouch for is still a second Hermes.
+# Merely installing the package must not remove a working terminal install.
 printf '%s\n' "#!/bin/bash" "$stub_marker" >"$test_home/.local/bin/hermes"
 chmod +x "$test_home/.local/bin/hermes"
 : >"$mise_log"
-OMARCHY_TEST_MISE_WHERE_OK=1 run_installer 1 || true
-tr '\0' '\n' <"$mise_log" | grep -q "uninstall" ||
-  fail "takeover removes a mise copy even when it is not healthy"
-pass "takeover removes an unhealthy mise copy"
+run_installer 1 && fail "a cold desktop is not ready"
+grep -qxF "$stub_marker" "$test_home/.local/bin/hermes" || fail "cold desktop preserves the marked wrapper"
+tr '\0' '\n' <"$mise_log" | grep -Eq '^(rm|uninstall)$' && fail "cold desktop removes no mise environment"
+pass "a cold desktop preserves the existing CLI"
+
+# A failed setup keeps the old CLI and its environment available for retry.
+OMARCHY_TEST_DESKTOP_FAIL=1 run_installer 1 --now && fail "failed native setup reaches the caller"
+grep -qxF "$stub_marker" "$test_home/.local/bin/hermes" || fail "failed setup preserves the old wrapper"
+tr '\0' '\n' <"$mise_log" | grep -Eq '^(rm|uninstall)$' && fail "failed setup removes no mise environment"
+pass "failed native setup preserves the old CLI"
+
+# --now records provenance before the package replaces the wrapper, then drops
+# the superseded environment only after the replacement answers both probes.
+mkdir -p "$test_tmp/mise"
+: >"$mise_log"
+: >"$OMARCHY_TEST_DESKTOP_LOG"
+OMARCHY_TEST_MISE_TRACK_REMOVAL=1 OMARCHY_TEST_MISE_WHERE_OK=1 run_installer 1 --now || fail "native takeover succeeds"
+[[ -f $test_tmp/mise/removed ]] || fail "takeover removes the owned mise environment"
+grep -qx -- '--install' "$OMARCHY_TEST_DESKTOP_LOG" || fail "takeover installs the native package synchronously"
+[[ -x $test_home/.local/bin/hermes ]] || fail "the native replacement remains on PATH"
+grep -qxF "$stub_marker" "$test_home/.local/bin/hermes" && fail "takeover actually replaced the wrapper"
+pass "native takeover removes mise only after the replacement is ready"
+
+# Without an owned wrapper, the same mise spec might be the user's own setup.
+: >"$mise_log"
+OMARCHY_TEST_MISE_WHERE_OK=1 run_installer 1 --now || fail "existing native install remains ready"
+tr '\0' '\n' <"$mise_log" | grep -Eq '^(rm|uninstall)$' && fail "unowned mise environment was removed"
+pass "native setup preserves an unowned mise environment"
+
+OMARCHY_TEST_DESKTOP_CHECK_FAIL=1 run_installer 1 --check && fail "CLI readiness must respect the package's desktop check"
+pass "a working CLI alone does not make an incomplete native desktop ready"
+
+: >"$OMARCHY_TEST_DESKTOP_LOG"
+OMARCHY_TEST_DESKTOP_NATIVE=0 run_installer 1 --check && fail "legacy package is not native-ready"
+OMARCHY_TEST_DESKTOP_NATIVE=0 run_installer 1 --now && fail "legacy package must be upgraded before native setup"
+[[ ! -s $OMARCHY_TEST_DESKTOP_LOG ]] || fail "unsupported flags must not reach the legacy desktop launcher"
+pass "mixed versions never invoke unsupported legacy desktop flags"
+
+OMARCHY_TEST_HERMES_HOME="$test_home/custom hermes" run_installer 1 --now || fail "native setup supports a custom data home"
+[[ -f "$test_home/custom hermes/hermes-agent/.omarchy-hermes-desktop" ]] || fail "native setup uses HERMES_HOME"
+OMARCHY_TEST_HERMES_HOME="$test_home/custom hermes" run_installer 1 --check || fail "readiness follows the custom data home"
+pass "native setup and readiness follow HERMES_HOME"
+
+# A package-only setup can replace the wrapper before this helper ever runs.
+# Its exact receipt carries the predecessor ownership through a retry.
+run_installer 1 --now || fail "the default native installation is ready for receipt checks"
+receipt_dir="$test_home/.hermes/hermes-agent/.git"
+receipt="$receipt_dir/omarchy-mise-predecessor"
+mkdir -p "$receipt_dir"
+printf '%s\n' 'pipx:hermes-agent[extras=all]' >"$receipt"
+: >"$mise_log"
+run_installer 1 --check || fail "readiness accepts a ready native install with pending cleanup"
+[[ -f $receipt && ! -s $mise_log ]] || fail "--check must not consume ownership or remove mise"
+pass "readiness leaves a pending predecessor receipt untouched"
+
+OMARCHY_TEST_DESKTOP_CHECK_FAIL=1 run_installer 1 && fail "an incomplete desktop is not ready for cleanup"
+OMARCHY_TEST_HERMES_CAPABLE=0 run_installer 1 && fail "an incapable CLI is not ready for cleanup"
+[[ -f $receipt && ! -s $mise_log ]] || fail "failed readiness must retain receipt and mise"
+pass "predecessor cleanup waits for both native readiness probes"
+
+OMARCHY_TEST_MISE_WHERE_OK=1 run_installer 1 && fail "failed predecessor removal reaches the caller"
+[[ -f $receipt ]] || fail "failed cleanup must retain its ownership receipt"
+pass "failed predecessor cleanup retains proof for retry"
+
+rm -f "$test_tmp/mise/removed"
+: >"$mise_log"
+OMARCHY_TEST_MISE_TRACK_REMOVAL=1 OMARCHY_TEST_MISE_WHERE_OK=1 run_installer 1 || fail "warm native setup retries predecessor cleanup"
+[[ ! -e $receipt && -f $test_tmp/mise/removed && -x $test_home/.local/bin/hermes ]] || fail "successful cleanup consumes the receipt and preserves the native wrapper"
+pass "warm native setup completes package-only predecessor cleanup"
+
+printf '%s\n' 'pipx:hermes-agent[extras=all]' >"$receipt"
+rm -f "$test_tmp/mise/removed"
+OMARCHY_TEST_MISE_TRACK_REMOVAL=1 OMARCHY_TEST_MISE_WHERE_OK=1 run_installer 1 --now || fail "explicit setup consumes predecessor ownership"
+[[ ! -e $receipt && -f $test_tmp/mise/removed ]] || fail "explicit setup finishes receipt cleanup"
+pass "explicit setup also consumes a predecessor receipt"
+
+printf '%s\n\n' 'pipx:hermes-agent[extras=all]' >"$receipt"
+: >"$mise_log"
+run_installer 1 || fail "an invalid receipt does not prevent using a ready native install"
+[[ -f $receipt && ! -s $mise_log ]] || fail "a receipt must match exact bytes before cleanup"
+pass "a similar receipt cannot authorize mise cleanup"
+
+rm -f "$receipt"
+printf '%s\n' 'pipx:hermes-agent[extras=all]' >"$test_tmp/foreign-receipt"
+ln -s "$test_tmp/foreign-receipt" "$receipt"
+run_installer 1 || fail "a symlink receipt does not prevent using native Hermes"
+[[ -L $receipt && ! -s $mise_log ]] || fail "a receipt symlink cannot authorize cleanup"
+rm -f "$receipt"
+rmdir "$receipt_dir"
+mkdir "$test_tmp/foreign-git"
+printf '%s\n' 'pipx:hermes-agent[extras=all]' >"$test_tmp/foreign-git/omarchy-mise-predecessor"
+ln -s "$test_tmp/foreign-git" "$receipt_dir"
+run_installer 1 || fail "a symlink Git directory does not prevent using native Hermes"
+[[ -L $receipt_dir && ! -s $mise_log ]] || fail "a symlink Git directory cannot authorize cleanup"
+pass "receipt ownership excludes symlinks"
+
+# Uninstall is explicit removal, so receipt ownership is sufficient even with
+# the package gone. Failed cleanup must leave that proof available for retry.
+rm -f "$receipt_dir"
+mkdir "$receipt_dir"
+printf '%s\n' 'pipx:hermes-agent[extras=all]' >"$receipt"
+OMARCHY_TEST_MISE_WHERE_OK=1 run_installer 0 --remove && fail "failed uninstall reports the retained predecessor"
+[[ -f $receipt && -x $test_home/.local/bin/hermes ]] || fail "failed uninstall retains receipt and native wrapper"
+rm -f "$test_tmp/mise/removed"
+OMARCHY_TEST_MISE_TRACK_REMOVAL=1 OMARCHY_TEST_MISE_WHERE_OK=1 run_installer 0 --remove || fail "uninstall can finish receipt cleanup without the package"
+[[ ! -e $receipt && -f $test_tmp/mise/removed && -x $test_home/.local/bin/hermes ]] || fail "explicit predecessor removal consumes receipt and preserves native wrapper"
+pass "explicit uninstall uses predecessor ownership and retains proof on failure"
 
 # --check answers about Hermes being usable, not about the venv appearing. The
 # venv exists from the python-deps stage, several stages before the command.
@@ -266,6 +392,7 @@ run_mise_check() {
     OMARCHY_TEST_MISE_LOG="$mise_log" \
     OMARCHY_TEST_MISE_X_HERMES=1 \
     OMARCHY_TEST_HERMES_CAPABLE="$1" \
+    HERMES_HOME="${OMARCHY_TEST_HERMES_HOME:-$test_home/.hermes}" \
     HOME="$test_home" \
     PATH="$mock_bin:$PATH" \
     bash "$ROOT/bin/omarchy-install-hermes-cli" --check >/dev/null 2>&1

--- a/test/shell.d/hermes-home-test.sh
+++ b/test/shell.d/hermes-home-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+test_home="$test_tmp/home"
+mkdir -p "$test_home/real home"
+ln -s "$test_home/real home" "$test_home/linked home"
+
+check_home() {
+  local configured="$1" expected="$2" actual
+  actual=$(HOME="$test_home" HERMES_HOME="$configured" "$ROOT/bin/omarchy-cmd-hermes-home") || fail "valid Hermes home resolves"
+  [[ $actual == "$expected" ]] || fail "Hermes home resolves to its shared root" "configured: $configured; expected: $expected; actual: $actual"
+}
+
+check_home '' "$test_home/.hermes"
+for root in "$test_home/.hermes" "$test_home/custom hermes" "$test_home/linked home"; do
+  check_home "$root" "$root"
+  check_home "$root/profiles/coder" "$root"
+  check_home "$root//profiles/./coder///" "$root"
+done
+check_home "$test_home/profiles/archive/custom" "$test_home/profiles/archive/custom"
+check_home "$test_home/custom/profiles/outer/profiles/inner" "$test_home/custom/profiles/outer"
+pass "Hermes home resolves default and custom profile sessions once while preserving symlink spelling"
+
+for invalid in relative '/profiles/coder' / '//./' "$test_home/../../../../../../../../.."; do
+  HOME="$test_home" HERMES_HOME="$invalid" "$ROOT/bin/omarchy-cmd-hermes-home" >"$test_tmp/output" 2>"$test_tmp/error" && fail "invalid Hermes home must be rejected: $invalid"
+  [[ ! -s $test_tmp/output ]] || fail "invalid Hermes home must not return a path"
+done
+pass "Hermes home rejects relative paths and a shared root of /"

--- a/test/shell.d/hermes-install-test.sh
+++ b/test/shell.d/hermes-install-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin" "$test_tmp/home"
+
+cat >"$test_tmp/bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+echo "package $*" >>"$OMARCHY_TEST_LOG"
+SH
+cat >"$test_tmp/bin/omarchy-install-hermes-cli" <<'SH'
+#!/bin/bash
+echo "setup $*" >>"$OMARCHY_TEST_LOG"
+[[ $1 == "--now" ]] || exit 2
+exit "${OMARCHY_TEST_SETUP_STATUS:-0}"
+SH
+cat >"$test_tmp/bin/setsid" <<'SH'
+#!/bin/bash
+echo "launch $*" >>"$OMARCHY_TEST_LOG"
+SH
+cat >"$test_tmp/bin/systemd-run" <<'SH'
+#!/bin/bash
+echo "theme $*" >>"$OMARCHY_TEST_LOG"
+SH
+cat >"$test_tmp/bin/systemctl" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$test_tmp/bin/"*
+
+run_install() {
+  HOME="$test_tmp/home" HERMES_HOME="$test_tmp/home/custom hermes" \
+    PATH="$test_tmp/bin:$PATH" OMARCHY_TEST_LOG="$test_tmp/log" \
+    OMARCHY_TEST_SETUP_STATUS="$1" \
+    bash "$ROOT/bin/omarchy-install-ai-hermes" >"$test_tmp/output" 2>&1
+}
+
+: >"$test_tmp/log"
+run_install 42 && fail "native setup failure must fail the desktop installation"
+grep -q '^launch\|^theme' "$test_tmp/log" && fail "failed setup must not launch or schedule the theme"
+grep -q 'has been installed' "$test_tmp/output" && fail "failed setup must not announce success"
+pass "desktop install reports native setup failure before launching"
+
+: >"$test_tmp/log"
+run_install 0 || fail "completed native setup succeeds"
+[[ $(head -2 "$test_tmp/log") == $'package hermes-desktop\nsetup --now' ]] || fail "package and native setup finish in order"
+# The launch is deliberately detached; wait only for our logging fixture.
+for attempt in {1..20}; do
+  if grep -q '^launch ' "$test_tmp/log"; then break; fi
+  sleep 0.01
+done
+grep -qxF 'launch uwsm-app -- /usr/bin/hermes-desktop' "$test_tmp/log" || fail "completed setup launches the package entry point"
+grep -qF -- "--setenv=HERMES_HOME=$test_tmp/home/custom hermes" "$test_tmp/log" || fail "theme handoff follows a custom Hermes home"
+grep -qF 'hermes update' "$test_tmp/output" || fail "completed setup describes native CLI updates"
+pass "desktop install waits for native setup before launch and follows its data home"

--- a/test/shell.d/hermes-install-test.sh
+++ b/test/shell.d/hermes-install-test.sh
@@ -8,17 +8,40 @@ test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 mkdir -p "$test_tmp/bin" "$test_tmp/home"
 ln -s "$ROOT/bin/omarchy-cmd-hermes-home" "$test_tmp/bin/omarchy-cmd-hermes-home"
+ln -s "$ROOT/bin/omarchy-install-hermes-cli" "$test_tmp/bin/omarchy-install-hermes-cli"
 
 cat >"$test_tmp/bin/omarchy-pkg-add" <<'SH'
 #!/bin/bash
 echo "package $*" >>"$OMARCHY_TEST_LOG"
+exit "${OMARCHY_TEST_PACKAGE_STATUS:-0}"
 SH
-cat >"$test_tmp/bin/omarchy-install-hermes-cli" <<'SH'
+cat >"$test_tmp/bin/omarchy-pkg-present" <<'SH'
 #!/bin/bash
-echo "setup $*" >>"$OMARCHY_TEST_LOG"
-printf '%s\n' "$HERMES_HOME" >>"$OMARCHY_TEST_HOME_LOG"
-[[ $1 == "--now" ]] || exit 2
-exit "${OMARCHY_TEST_SETUP_STATUS:-0}"
+[[ $1 == "hermes-desktop" ]]
+SH
+cat >"$test_tmp/bin/pacman" <<'SH'
+#!/bin/bash
+[[ $* == "-Qlq hermes-desktop" ]] || exit 2
+echo "package-check" >>"$OMARCHY_TEST_LOG"
+if [[ ${OMARCHY_TEST_NATIVE_PACKAGE:-1} == 1 ]]; then
+  echo '/usr/share/hermes-desktop/install.sh'
+  if [[ ${OMARCHY_TEST_DESKTOP_SEED:-1} == 1 ]]; then
+    echo '/usr/share/hermes-desktop/seed/.git/config'
+  fi
+  if [[ ${OMARCHY_TEST_LARGE_PACKAGE:-0} == 1 ]]; then
+    printf '/usr/share/hermes-desktop/seed/file-%s\n' {1..10000}
+  fi
+fi
+SH
+cat >"$test_tmp/bin/hermes-desktop" <<'SH'
+#!/bin/bash
+echo "unexpected-desktop $*" >>"$OMARCHY_TEST_LOG"
+exit 42
+SH
+cat >"$test_tmp/bin/mise" <<'SH'
+#!/bin/bash
+echo "unexpected-mise $*" >>"$OMARCHY_TEST_LOG"
+exit 42
 SH
 cat >"$test_tmp/bin/setsid" <<'SH'
 #!/bin/bash
@@ -39,38 +62,48 @@ run_install() {
   HOME="$test_tmp/home" HERMES_HOME="${OMARCHY_TEST_HERMES_HOME:-$test_tmp/home/custom hermes}" \
     PATH="$test_tmp/bin:$PATH" OMARCHY_TEST_LOG="$test_tmp/log" \
     OMARCHY_TEST_HOME_LOG="$test_tmp/home-log" \
-    OMARCHY_TEST_SETUP_STATUS="$1" \
+    OMARCHY_TEST_PACKAGE_STATUS="$1" \
     bash "$ROOT/bin/omarchy-install-ai-hermes" >"$test_tmp/output" 2>&1
 }
 
 : >"$test_tmp/log"
-run_install 42 && fail "native setup failure must fail the desktop installation"
-grep -q '^launch\|^theme' "$test_tmp/log" && fail "failed setup must not launch or schedule the theme"
-grep -q 'has been installed' "$test_tmp/output" && fail "failed setup must not announce success"
-pass "desktop install reports native setup failure before launching"
+run_install 42 && fail "package failure must fail the desktop installation"
+[[ $(cat "$test_tmp/log") == "package hermes-desktop" ]] || fail "failed package installation must stop before checking or launching"
+grep -q 'has been installed' "$test_tmp/output" && fail "failed package installation must not announce success"
+pass "desktop install reports package failure before launching"
 
 : >"$test_tmp/log"
-run_install 0 || fail "completed native setup succeeds"
-[[ $(head -2 "$test_tmp/log") == $'package hermes-desktop\nsetup --now' ]] || fail "package and native setup finish in order"
+OMARCHY_TEST_NATIVE_PACKAGE=0 run_install 0 && fail "legacy package must be upgraded before launch"
+[[ $(cat "$test_tmp/log") == $'package hermes-desktop\npackage-check' ]] || fail "legacy package must not receive flags, launch or schedule the theme"
+grep -q 'update the hermes-desktop package' "$test_tmp/output" || fail "legacy package failure explains the required update"
+grep -q 'has been installed' "$test_tmp/output" && fail "legacy package must not announce successful setup"
+pass "desktop install rejects legacy packages without executing their launcher"
+
+: >"$test_tmp/log"
+run_install 0 || fail "a cold native runtime can launch the desktop"
+[[ $(head -2 "$test_tmp/log") == $'package hermes-desktop\npackage-check' ]] || fail "package installation and compatibility check finish before launch"
 # The launch is deliberately detached; wait only for our logging fixture.
 for attempt in {1..20}; do
   if grep -q '^launch ' "$test_tmp/log"; then break; fi
   sleep 0.01
 done
-grep -qxF 'launch uwsm-app -- /usr/bin/hermes-desktop' "$test_tmp/log" || fail "completed setup launches the package entry point"
+grep -qxF 'launch uwsm-app -- /usr/bin/hermes-desktop' "$test_tmp/log" || fail "cold installation launches the package desktop entry point"
+grep -q '^unexpected-' "$test_tmp/log" && fail "the menu must not run native setup, readiness checks or mise"
+[[ ! -e "$test_tmp/home/custom hermes/hermes-agent" && ! -e $test_tmp/home/.local/bin/hermes ]] || fail "native setup remains inside the desktop"
 grep -qF -- "--setenv=HERMES_HOME=$test_tmp/home/custom hermes" "$test_tmp/log" || fail "theme handoff follows a custom Hermes home"
-grep -qF 'hermes update' "$test_tmp/output" || fail "completed setup describes native CLI updates"
-pass "desktop install waits for native setup before launch and follows its data home"
+grep -qF 'installs Hermes inside the app' "$test_tmp/output" || fail "the menu explains that Hermes setup continues inside the app"
+grep -qF 'hermes update' "$test_tmp/output" || fail "installation describes native CLI updates"
+pass "desktop installation launches the app before native setup and follows its data home"
 
 for root in "$test_tmp/home/.hermes" "$test_tmp/home/custom hermes"; do
   : >"$test_tmp/log"
   : >"$test_tmp/home-log"
   OMARCHY_TEST_HERMES_HOME="$root/profiles/coder/" run_install 0 || fail "profile install succeeds"
   for attempt in {1..20}; do
-    if [[ $(wc -l <"$test_tmp/home-log") == 2 ]]; then break; fi
+    if [[ $(wc -l <"$test_tmp/home-log") == 1 ]]; then break; fi
     sleep 0.01
   done
-  [[ $(cat "$test_tmp/home-log") == "$root"$'\n'"$root" ]] || fail "setup and app receive the shared home"
+  [[ $(cat "$test_tmp/home-log") == "$root" ]] || fail "the app receives the shared home"
   grep -qF -- "--setenv=HERMES_HOME=$root omarchy-theme-set-hermes" "$test_tmp/log" || fail "theme unit receives the shared home"
 done
-pass "profile installation hands the shared default or custom home to setup, app and theme"
+pass "profile installation hands the shared default or custom home to the app and theme"

--- a/test/shell.d/hermes-install-test.sh
+++ b/test/shell.d/hermes-install-test.sh
@@ -7,6 +7,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 mkdir -p "$test_tmp/bin" "$test_tmp/home"
+ln -s "$ROOT/bin/omarchy-cmd-hermes-home" "$test_tmp/bin/omarchy-cmd-hermes-home"
 
 cat >"$test_tmp/bin/omarchy-pkg-add" <<'SH'
 #!/bin/bash
@@ -15,12 +16,14 @@ SH
 cat >"$test_tmp/bin/omarchy-install-hermes-cli" <<'SH'
 #!/bin/bash
 echo "setup $*" >>"$OMARCHY_TEST_LOG"
+printf '%s\n' "$HERMES_HOME" >>"$OMARCHY_TEST_HOME_LOG"
 [[ $1 == "--now" ]] || exit 2
 exit "${OMARCHY_TEST_SETUP_STATUS:-0}"
 SH
 cat >"$test_tmp/bin/setsid" <<'SH'
 #!/bin/bash
 echo "launch $*" >>"$OMARCHY_TEST_LOG"
+printf '%s\n' "$HERMES_HOME" >>"$OMARCHY_TEST_HOME_LOG"
 SH
 cat >"$test_tmp/bin/systemd-run" <<'SH'
 #!/bin/bash
@@ -33,8 +36,9 @@ SH
 chmod +x "$test_tmp/bin/"*
 
 run_install() {
-  HOME="$test_tmp/home" HERMES_HOME="$test_tmp/home/custom hermes" \
+  HOME="$test_tmp/home" HERMES_HOME="${OMARCHY_TEST_HERMES_HOME:-$test_tmp/home/custom hermes}" \
     PATH="$test_tmp/bin:$PATH" OMARCHY_TEST_LOG="$test_tmp/log" \
+    OMARCHY_TEST_HOME_LOG="$test_tmp/home-log" \
     OMARCHY_TEST_SETUP_STATUS="$1" \
     bash "$ROOT/bin/omarchy-install-ai-hermes" >"$test_tmp/output" 2>&1
 }
@@ -57,3 +61,16 @@ grep -qxF 'launch uwsm-app -- /usr/bin/hermes-desktop' "$test_tmp/log" || fail "
 grep -qF -- "--setenv=HERMES_HOME=$test_tmp/home/custom hermes" "$test_tmp/log" || fail "theme handoff follows a custom Hermes home"
 grep -qF 'hermes update' "$test_tmp/output" || fail "completed setup describes native CLI updates"
 pass "desktop install waits for native setup before launch and follows its data home"
+
+for root in "$test_tmp/home/.hermes" "$test_tmp/home/custom hermes"; do
+  : >"$test_tmp/log"
+  : >"$test_tmp/home-log"
+  OMARCHY_TEST_HERMES_HOME="$root/profiles/coder/" run_install 0 || fail "profile install succeeds"
+  for attempt in {1..20}; do
+    if [[ $(wc -l <"$test_tmp/home-log") == 2 ]]; then break; fi
+    sleep 0.01
+  done
+  [[ $(cat "$test_tmp/home-log") == "$root"$'\n'"$root" ]] || fail "setup and app receive the shared home"
+  grep -qF -- "--setenv=HERMES_HOME=$root omarchy-theme-set-hermes" "$test_tmp/log" || fail "theme unit receives the shared home"
+done
+pass "profile installation hands the shared default or custom home to setup, app and theme"

--- a/test/shell.d/hermes-remove-test.sh
+++ b/test/shell.d/hermes-remove-test.sh
@@ -10,6 +10,7 @@ trap 'rm -rf "$test_tmp"' EXIT
 mock_bin="$test_tmp/bin"
 test_home="$test_tmp/home"
 mkdir -p "$mock_bin"
+ln -s "$ROOT/bin/omarchy-cmd-hermes-home" "$mock_bin/omarchy-cmd-hermes-home"
 
 cat >"$mock_bin/omarchy-pkg-drop" <<'SH'
 #!/bin/bash
@@ -22,6 +23,7 @@ SH
 cat >"$mock_bin/omarchy-install-hermes-cli" <<'SH'
 #!/bin/bash
 printf '%s\0' "$@" >>"$OMARCHY_TEST_INSTALLER_LOG"
+printf '%s\n' "$HERMES_HOME" >"$OMARCHY_TEST_HOME_LOG"
 exit "${OMARCHY_TEST_INSTALLER_STATUS:-0}"
 SH
 
@@ -73,6 +75,7 @@ remove() {
   : >"$test_tmp/systemctl-log"
   OMARCHY_TEST_DROP_LOG="$test_tmp/drop-log" \
     OMARCHY_TEST_INSTALLER_LOG="$test_tmp/installer-log" \
+    OMARCHY_TEST_HOME_LOG="$test_tmp/home-log" \
     OMARCHY_TEST_INSTALLER_STATUS="${OMARCHY_TEST_INSTALLER_STATUS:-0}" \
     OMARCHY_TEST_SYSTEMCTL_LOG="$test_tmp/systemctl-log" \
     OMARCHY_TEST_GUM_LOG="$test_tmp/gum-log" \
@@ -90,6 +93,7 @@ remove_tty() {
   : >"$test_tmp/systemctl-log"
   OMARCHY_TEST_DROP_LOG="$test_tmp/drop-log" \
     OMARCHY_TEST_INSTALLER_LOG="$test_tmp/installer-log" \
+    OMARCHY_TEST_HOME_LOG="$test_tmp/home-log" \
     OMARCHY_TEST_SYSTEMCTL_LOG="$test_tmp/systemctl-log" \
     OMARCHY_TEST_GUM_LOG="$test_tmp/gum-log" \
     OMARCHY_TEST_GUM_STATUS="${OMARCHY_TEST_GUM_STATUS:-1}" \
@@ -309,6 +313,17 @@ OMARCHY_TEST_HERMES_HOME="$native_home" remove || fail "native removal supports 
 [[ ! -e $native_root && ! -e $desktop_entry ]] || fail "custom native runtime and launcher are removed"
 [[ -f $native_home/sessions/one.json && -f $test_home/.hermes/hermes-agent/unrelated ]] || fail "custom removal preserves user data and the default home"
 pass "native removal follows HERMES_HOME and leaves other installations alone"
+
+for shared_home in "$test_home/.hermes" "$test_home/custom hermes"; do
+  seed_native "$shared_home"
+  mkdir -p "$shared_home/profiles/coder"
+  echo 'profile chat' >"$shared_home/profiles/coder/session.json"
+  OMARCHY_TEST_HERMES_HOME="$shared_home/profiles/coder/" remove || fail "profile removal succeeds"
+  [[ ! -e $native_root && ! -e $desktop_entry ]] || fail "profile removal targets the shared runtime and generated launcher"
+  [[ -f $shared_home/profiles/coder/session.json && -f $shared_home/sessions/one.json ]] || fail "profile removal preserves root and profile data"
+  [[ $(cat "$test_tmp/home-log") == "$shared_home" ]] || fail "CLI removal receives the same shared home"
+done
+pass "profile removal targets the shared default or custom installation and preserves profile data"
 
 seed_install
 git -C "$test_home/.hermes/hermes-agent" remote set-url origin https://github.com/example/hermes-agent.git

--- a/test/shell.d/hermes-remove-test.sh
+++ b/test/shell.d/hermes-remove-test.sh
@@ -55,7 +55,14 @@ seed_install() {
   ln -sf "$test_home/.hermes/node/bin/npm" "$test_home/.local/bin/npm"
   ln -sf /usr/bin/npx "$test_home/.local/bin/npx"
   printf 'node\n' >"$test_home/.hermes/node/bin/node"
-  touch "$test_home/.hermes/hermes-agent/.hermes-bootstrap-complete"
+  printf '{"schemaVersion":1,"pinnedCommit":"e624e9fde561e1add9388384012b295fde669ade"}\n' >"$test_home/.hermes/hermes-agent/.hermes-bootstrap-complete"
+  git init -q -b main "$test_home/.hermes/hermes-agent"
+  git -C "$test_home/.hermes/hermes-agent" remote add origin https://github.com/NousResearch/hermes-agent.git
+  printf '.omarchy-hermes-desktop\n.hermes-bootstrap-complete\n' >>"$test_home/.hermes/hermes-agent/.git/info/exclude"
+  echo upstream >"$test_home/.hermes/hermes-agent/README.md"
+  git -C "$test_home/.hermes/hermes-agent" add README.md
+  git -C "$test_home/.hermes/hermes-agent" -c user.name=Fixture -c user.email=fixture@example.invalid commit --quiet -m baseline
+  git -C "$test_home/.hermes/hermes-agent" update-ref refs/remotes/origin/main HEAD
 }
 
 # </dev/null pins stdin off a terminal, so these runs exercise the
@@ -69,6 +76,8 @@ remove() {
     OMARCHY_TEST_INSTALLER_STATUS="${OMARCHY_TEST_INSTALLER_STATUS:-0}" \
     OMARCHY_TEST_SYSTEMCTL_LOG="$test_tmp/systemctl-log" \
     OMARCHY_TEST_GUM_LOG="$test_tmp/gum-log" \
+    HERMES_HOME="${OMARCHY_TEST_HERMES_HOME:-$test_home/.hermes}" \
+    XDG_DATA_HOME="$test_home/.local/share" \
     HOME="$test_home" PATH="$mock_bin:$PATH" \
     bash "$ROOT/bin/omarchy-remove-ai-hermes" </dev/null >/dev/null 2>&1
 }
@@ -84,13 +93,15 @@ remove_tty() {
     OMARCHY_TEST_SYSTEMCTL_LOG="$test_tmp/systemctl-log" \
     OMARCHY_TEST_GUM_LOG="$test_tmp/gum-log" \
     OMARCHY_TEST_GUM_STATUS="${OMARCHY_TEST_GUM_STATUS:-1}" \
+    HERMES_HOME="${OMARCHY_TEST_HERMES_HOME:-$test_home/.hermes}" \
+    XDG_DATA_HOME="$test_home/.local/share" \
     HOME="$test_home" PATH="$mock_bin:$PATH" \
     script -qec "bash '$ROOT/bin/omarchy-remove-ai-hermes'" /dev/null >/dev/null 2>&1
 }
 
 # The app brings its own uv and its own node; both are runtime, not data.
 seed_install
-printf '%s\n' "#!/bin/bash" "exec $test_home/.hermes/hermes-agent/venv/bin/hermes \"\$@\"" \
+printf '%s\n' '#!/usr/bin/env bash' 'unset PYTHONPATH' 'unset PYTHONHOME' "exec \"$test_home/.hermes/hermes-agent/venv/bin/python\" \"$test_home/.hermes/hermes-agent/hermes\" \"\$@\"" \
   >"$test_home/.local/bin/hermes"
 remove || fail "remove succeeds"
 [[ ! -d $test_home/.hermes/hermes-agent ]] || fail "the runtime checkout is removed"
@@ -149,7 +160,7 @@ pass "removal leaves a hermes it does not own"
 seed_install
 rm -f "$test_home/.hermes/hermes-agent/.hermes-bootstrap-complete"
 printf 'my local edit\n' >"$test_home/.hermes/hermes-agent/PATCH"
-printf '%s\n' "#!/bin/bash" "exec $test_home/.hermes/hermes-agent/venv/bin/hermes \"\$@\"" \
+printf '%s\n' '#!/usr/bin/env bash' 'unset PYTHONPATH' 'unset PYTHONHOME' "exec \"$test_home/.hermes/hermes-agent/venv/bin/python\" \"$test_home/.hermes/hermes-agent/hermes\" \"\$@\"" \
   >"$test_home/.local/bin/hermes"
 remove || fail "remove succeeds when the app never finished installing Hermes"
 # The stranded pre-desktop CLI is exactly the interrupted-install case, so the
@@ -219,13 +230,159 @@ OMARCHY_TEST_GUM_STATUS=0 remove_tty ||
   fail "a yes takes ~/.hermes whole when the marker never appeared"
 pass "removal honors a yes on the named paths without the marker"
 
-# A CLI teardown that fails must not stop the runtime handling, and must not be
-# papered over either: the data work still happens, and the failure reaches the
-# caller's exit code.
+# A failed CLI teardown retains the runtime and its ownership receipt so a
+# later retry still has the evidence needed to remove the predecessor.
 seed_install
-printf '%s\n' "#!/bin/bash" "exec $test_home/.hermes/hermes-agent/venv/bin/hermes \"\$@\"" \
+printf '%s\n' '#!/usr/bin/env bash' 'unset PYTHONPATH' 'unset PYTHONHOME' "exec \"$test_home/.hermes/hermes-agent/venv/bin/python\" \"$test_home/.hermes/hermes-agent/hermes\" \"\$@\"" \
   >"$test_home/.local/bin/hermes"
 OMARCHY_TEST_INSTALLER_STATUS=1 remove && fail "a failed CLI teardown surfaces in the exit code"
-[[ ! -d $test_home/.hermes/hermes-agent ]] ||
-  fail "a failed CLI teardown does not stop the runtime removal"
-pass "a failed CLI teardown is reported after the runtime is handled"
+[[ -d $test_home/.hermes/hermes-agent && -f $test_home/.local/bin/hermes ]] ||
+  fail "a failed CLI teardown preserves the runtime and launcher for retry"
+pass "a failed CLI teardown retains the runtime for retry"
+
+seed_native() {
+  seed_install
+  native_home=${1:-$test_home/.hermes}
+  if [[ $native_home != "$test_home/.hermes" ]]; then
+    mv "$test_home/.hermes" "$native_home"
+  fi
+  native_root="$native_home/hermes-agent"
+  rm -f "$native_root/.hermes-bootstrap-complete"
+  echo ready >"$native_root/.omarchy-hermes-desktop"
+  for name in hermes hermes-agent hermes-acp; do
+    case "$name" in
+      hermes) args="\"$native_root/hermes\"" ;;
+      hermes-agent) args="\"$native_root/run_agent.py\"" ;;
+      hermes-acp) args="\"$native_root/hermes\" acp" ;;
+    esac
+    printf '%s\n' '#!/usr/bin/env bash' 'unset PYTHONPATH' 'unset PYTHONHOME' \
+      "exec \"$native_root/venv/bin/python\" $args \"\$@\"" >"$test_home/.local/bin/$name"
+  done
+  desktop_entry="$test_home/.local/share/applications/hermes.desktop"
+  mkdir -p "$(dirname "$desktop_entry")"
+  cat >"$desktop_entry" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Hermes
+GenericName=Hermes Desktop
+Comment=Launch Hermes Desktop
+Exec="$test_home/.local/bin/hermes" desktop
+Icon=hermes
+Terminal=false
+Categories=Utility;
+StartupNotify=true
+StartupWMClass=Hermes
+EOF
+}
+
+seed_native
+remove || fail "native removal succeeds"
+[[ ! -e $native_root && ! -e $desktop_entry ]] || fail "native runtime and generated desktop entry are removed"
+for name in hermes hermes-agent hermes-acp; do
+  [[ ! -e $test_home/.local/bin/$name ]] || fail "generated $name wrapper is removed"
+done
+[[ -f $native_home/sessions/one.json ]] || fail "native removal retains user data"
+pass "native runtime removal clears generated launchers and retains data"
+
+seed_native
+echo pending >"$native_root/.omarchy-hermes-desktop"
+remove || fail "interrupted native setup can be removed"
+[[ ! -e $native_root ]] || fail "the owned partial runtime is removed"
+pass "native removal also handles an interrupted setup"
+
+seed_native
+printf '# custom wrapper mentioning %s\n' "$native_root" >>"$test_home/.local/bin/hermes"
+remove || fail "native removal tolerates customized launchers"
+[[ -e $test_home/.local/bin/hermes && -e $desktop_entry ]] || fail "custom wrapper and its desktop entry are preserved"
+pass "native removal preserves a customized wrapper even when it targets this runtime"
+
+seed_native
+sed -i 's/^Icon=hermes$/Icon=my-custom-icon/' "$desktop_entry"
+remove || fail "native removal tolerates a customized desktop entry"
+[[ -e $desktop_entry ]] || fail "a customized desktop icon is preserved"
+pass "native removal preserves a customized desktop entry"
+
+seed_native "$test_home/custom hermes"
+mkdir -p "$test_home/.hermes/hermes-agent"
+echo keep >"$test_home/.hermes/hermes-agent/unrelated"
+OMARCHY_TEST_HERMES_HOME="$native_home" remove || fail "native removal supports a custom data home"
+[[ ! -e $native_root && ! -e $desktop_entry ]] || fail "custom native runtime and launcher are removed"
+[[ -f $native_home/sessions/one.json && -f $test_home/.hermes/hermes-agent/unrelated ]] || fail "custom removal preserves user data and the default home"
+pass "native removal follows HERMES_HOME and leaves other installations alone"
+
+seed_install
+git -C "$test_home/.hermes/hermes-agent" remote set-url origin https://github.com/example/hermes-agent.git
+remove || fail "removal succeeds with a foreign checkout"
+[[ -d $test_home/.hermes/hermes-agent ]] || fail "a legacy marker with a foreign remote is preserved"
+pass "legacy removal requires known package provenance"
+
+seed_native
+echo 'local edit' >>"$native_root/README.md"
+remove || fail "native removal tolerates a development checkout"
+[[ -f $native_root/README.md && -f $test_home/.local/bin/hermes && -f $desktop_entry ]] || fail "local changes retain the runtime and launchers"
+grep -qF 'local edit' "$native_root/README.md" || fail "local source edits survive"
+pass "native removal preserves source edits and their launchers"
+
+seed_native
+echo 'new source' >"$native_root/local.py"
+remove || fail "native removal tolerates untracked source"
+[[ -f $native_root/local.py && -f $test_home/.local/bin/hermes ]] || fail "untracked work retains runtime and launchers"
+pass "native removal preserves untracked source"
+
+seed_native
+external_worktree="$test_tmp/external-worktree"
+git -C "$native_root" worktree add --quiet --detach "$external_worktree"
+remove || fail "native removal tolerates an external worktree"
+[[ -d $native_root/.git && -f $desktop_entry && -f $test_home/.local/bin/hermes ]] || fail "linked worktrees retain Git metadata and launchers"
+git -C "$external_worktree" status --porcelain >/dev/null || fail "the external worktree's Git metadata remains usable"
+pass "native removal preserves metadata used by another worktree"
+
+seed_native
+external_runtime="$test_tmp/external-runtime"
+mv "$native_root" "$external_runtime"
+ln -s "$external_runtime" "$native_root"
+remove || fail "native removal tolerates a symlinked runtime"
+[[ -L $native_root && -f $external_runtime/README.md && -f $test_home/.local/bin/hermes && -f $desktop_entry ]] || fail "symlinked runtime and launchers are retained"
+pass "native removal preserves a symlinked runtime"
+
+seed_native
+echo 'committed local work' >>"$native_root/README.md"
+git -C "$native_root" add README.md
+git -C "$native_root" -c user.name=Fixture -c user.email=fixture@example.invalid commit --quiet -m 'local work'
+local_head=$(git -C "$native_root" rev-parse HEAD)
+remove || fail "native removal tolerates unpublished commits"
+[[ -f $test_home/.local/bin/hermes && -f $desktop_entry ]] || fail "unpublished commits retain their launchers"
+[[ $(git -C "$native_root" rev-parse HEAD) == "$local_head" ]] || fail "clean unpublished history is retained"
+pass "native removal preserves clean unpublished commits"
+
+seed_native
+git -C "$native_root" branch my-local-branch
+remove || fail "native removal tolerates an unpublished branch"
+git -C "$native_root" show-ref --verify --quiet refs/heads/my-local-branch || fail "an unpushed branch is retained even at a published commit"
+[[ -f $test_home/.local/bin/hermes ]] || fail "an unpublished branch retains its launcher"
+pass "native removal preserves a local branch at a published commit"
+
+seed_native
+echo 'stashed work' >>"$native_root/README.md"
+git -C "$native_root" -c user.name=Fixture -c user.email=fixture@example.invalid stash push --quiet
+remove || fail "native removal tolerates stashed work"
+git -C "$native_root" show-ref --verify --quiet refs/stash || fail "stashed work survives removal"
+[[ -f $desktop_entry ]] || fail "stashed work retains its launcher"
+pass "native removal preserves stashed work"
+
+seed_native
+printf '%s\n' 'pipx:hermes-agent[extras=all]' >"$native_root/.git/omarchy-mise-predecessor"
+OMARCHY_TEST_INSTALLER_STATUS=1 remove && fail "failed native predecessor cleanup reaches the caller"
+[[ -f $native_root/.git/omarchy-mise-predecessor && -f $desktop_entry && -f $test_home/.local/bin/hermes ]] || fail "failed cleanup preserves native runtime ownership and launchers"
+[[ -f $native_home/sessions/one.json ]] || fail "failed cleanup retains user data"
+pass "failed native predecessor cleanup preserves the receipt for retry"
+
+OMARCHY_TEST_INSTALLER_STATUS=1 OMARCHY_TEST_GUM_STATUS=0 remove_tty && fail "failed cleanup is reported on a terminal too"
+[[ ! -s $test_tmp/gum-log && -f $native_root/.git/omarchy-mise-predecessor && -f $native_home/sessions/one.json ]] || fail "failed cleanup must not offer to delete its receipt and user data"
+pass "failed predecessor cleanup skips the data deletion question"
+
+seed_native
+git -C "$native_root" update-ref -d refs/remotes/origin/main
+remove || fail "native removal tolerates missing publication evidence"
+[[ -f $native_root/README.md && -f $desktop_entry ]] || fail "unknown local history is retained without a fetched remote"
+pass "native removal requires evidence that local history is published"

--- a/test/shell.d/hermes-theme-test.sh
+++ b/test/shell.d/hermes-theme-test.sh
@@ -399,3 +399,20 @@ OMARCHY_TEST_HERMES_READY=1 run_hook --wait 2>"$test_tmp/stderr"
 [[ $(grep -c 'sleep 10' "$hermes_calls") == 180 ]] || fail "--wait gives up after 30 minutes" "$(grep -c 'sleep 10' "$hermes_calls")"
 grep -q 'did not finish setting up' "$test_tmp/stderr" || fail "giving up is reported"
 pass "--wait polls until the desktop app has built its runtime and gives up in time"
+
+reset_home --set-up
+mkdir -p "$hermes_home/hermes-agent"
+echo ready >"$hermes_home/hermes-agent/.omarchy-hermes-desktop"
+OMARCHY_TEST_HERMES_READY=1 run_hook --wait 2>/dev/null
+grep -q '^config set display.skin omarchy$' "$hermes_calls" || fail "ready native setup activates its skin"
+grep -q '^sleep 10$' "$hermes_calls" && fail "ready native setup must not wait for the legacy bootstrap marker"
+pass "--wait recognizes the native package completion marker"
+
+reset_home --set-up
+mkdir -p "$hermes_home/hermes-agent"
+echo pending >"$hermes_home/hermes-agent/.omarchy-hermes-desktop"
+touch "$hermes_home/hermes-agent/.hermes-bootstrap-complete"
+OMARCHY_TEST_HERMES_READY=1 run_hook --wait 2>/dev/null
+grep -q '^config set' "$hermes_calls" && fail "pending native setup must not activate through a legacy marker"
+[[ $(grep -c '^sleep 10$' "$hermes_calls") == 180 ]] || fail "pending native setup must wait for completion"
+pass "--wait does not mistake native ownership for completed setup"

--- a/test/shell.d/hermes-theme-test.sh
+++ b/test/shell.d/hermes-theme-test.sh
@@ -16,6 +16,7 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 mock_bin="$test_tmp/bin"
 mkdir -p "$mock_bin"
+ln -s "$ROOT/bin/omarchy-cmd-hermes-home" "$mock_bin/omarchy-cmd-hermes-home"
 
 cat >"$mock_bin/omarchy-install-hermes-cli" <<'SH'
 #!/bin/bash
@@ -41,6 +42,7 @@ SH
 cat >"$mock_bin/hermes-stub" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >>"$OMARCHY_TEST_HERMES_CALLS"
+[[ ${HERMES_HOME:-} == "${OMARCHY_TEST_EXPECTED_HOME:-$HOME/.hermes}" ]] || exit 1
 if [[ $1 == "config" && $2 == "get" ]]; then
   [[ ${OMARCHY_TEST_HERMES_GET_FAILS:-0} == 0 ]] || exit 1
   printf '%s\n' "${OMARCHY_TEST_HERMES_SKIN-default}"
@@ -120,7 +122,7 @@ run_hook() {
     OMARCHY_TEST_DROP_SKINS="${OMARCHY_TEST_DROP_SKINS:-0}" \
     PATH="$mock_bin:$PATH" \
     HOME="$test_home" \
-    HERMES_HOME='' \
+    HERMES_HOME="${OMARCHY_TEST_HERMES_HOME:-}" \
     "$ROOT/bin/omarchy-theme-set-hermes" "$@"
 }
 
@@ -416,3 +418,20 @@ OMARCHY_TEST_HERMES_READY=1 run_hook --wait 2>/dev/null
 grep -q '^config set' "$hermes_calls" && fail "pending native setup must not activate through a legacy marker"
 [[ $(grep -c '^sleep 10$' "$hermes_calls") == 180 ]] || fail "pending native setup must wait for completion"
 pass "--wait does not mistake native ownership for completed setup"
+
+for shared_home in "$test_home/.hermes" "$test_home/custom hermes"; do
+  reset_home --set-up
+  if [[ $shared_home != "$hermes_home" ]]; then
+    mv "$hermes_home" "$shared_home"
+  fi
+  mkdir -p "$shared_home/hermes-agent" "$shared_home/profiles/coder" "$shared_home/profiles/reviewer"
+  echo ready >"$shared_home/hermes-agent/.omarchy-hermes-desktop"
+  OMARCHY_TEST_HERMES_HOME="$shared_home/profiles/coder/" OMARCHY_TEST_EXPECTED_HOME="$shared_home" \
+    OMARCHY_TEST_HERMES_READY=1 run_hook --wait 2>/dev/null
+  for home in "$shared_home" "$shared_home/profiles/coder" "$shared_home/profiles/reviewer"; do
+    [[ -f $home/skins/omarchy.yaml ]] || fail "profile handoff publishes the skin to the shared home and every profile"
+  done
+  grep -q '^config set display.skin omarchy$' "$hermes_calls" || fail "profile handoff activates through the shared Hermes home"
+  grep -q '^sleep 10$' "$hermes_calls" && fail "profile handoff must find the shared runtime marker"
+done
+pass "profile theme handoff follows the shared default or custom installation and all sibling profiles"


### PR DESCRIPTION
AI -> Hermes should install the package in the menu terminal, open the desktop immediately, and let Hermes perform first-run installation inside the app. The earlier synchronous `--now` handoff built the runtime and desktop before showing the window.

Use a metadata-only check for the prebuilt package, then launch its entry point and wait separately for theme activation. Explicit CLI setup remains available through `omarchy-install-hermes-cli --now`. Native desktop and CLI readiness, shared profile homes, ownership-based predecessor cleanup, and preservation of user data and custom installations remain coordinated with the package.

Requires the `hermes-desktop 2026.8.31-2` correction in https://github.com/omacom/omarchy-pkgs/pull/334. Package PR #325 has merged, but its installer-only release does not provide the intended graphical setup; the new menu check rejects that payload without executing it. Publish the corrected package before this integration.

This PR remains draft while the final release-2 bootstrap, app/CLI update, and browser-session validation finish. Focused Hermes and CLI tests pass. Independent review and actual Omabot review will be reconciled against the final coordinated heads.

🤖 Generated by GPT-6 in Codex/T3 Code. Independent GPT-6 Codex review at xhigh is in progress.
