### PR TITLE
Inhibit idle for Steam game windows

### DIFF
--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -1,4 +1,5 @@
 o.window("steam", { float = true, idle_inhibit = "fullscreen" })
+o.window("^steam_app_.*$", { idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })


### PR DESCRIPTION
## tl;dr

Prevent fullscreen Steam games from triggering Omarchy’s idle screensaver and lock.

## why

Steam games use classes such as `steam_app_990630`, which were not covered by the existing Steam idle-inhibit rule.

## what

Add a window rule matching `steam_app_*` classes with `idle_inhibit = "fullscreen"`.
