### PR TITLE
Notifications: action buttons and deadlines, as argv hints

### DIFF
--- a/bin/omarchy-notification-send
+++ b/bin/omarchy-notification-send
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Send an Omarchy desktop notification
-# omarchy:args=[--app-name <app-name>] [-g <glyph>] [-u <low|normal|critical>] [-i <icon>] [-t <ms>] [-r <id>] [-p] [--image <path-or-uri>] <headline> [description] [--exec <program> [args...]]
-# omarchy:examples=omarchy notification send "Reminder" "5 minutes are up" -g 󰢌
+# omarchy:args=[--app-name <app-name>] [-g <glyph>] [-u <low|normal|critical>] [-i <icon>] [-t <ms>] [-r <id>] [-p] [--image <path-or-uri>] [--deadline <seconds>] [--deadline-text <template>] <headline> [description] [--action <id>=<label> <program> [args...] \;]... [--exec <program> [args...]]
+# omarchy:examples=omarchy notification send "Reminder" "5 minutes are up" -g 󰢌 | omarchy notification send "Update ready" --action now=Restart omarchy-restart-shell \; --deadline 30 --deadline-text "Later in {s} s"
 
 set -euo pipefail
 
@@ -19,9 +19,40 @@ print_id=0
 exec_args=()
 exec_present=0
 parsed_option_args=0
+# Buttons: the D-Bus actions array as id/label pairs, and one argv per id in
+# the omarchy-action-argv hint (a JSON object), built only from --action.
+action_pairs=()
+action_argv_json='{}'
+deadline_seconds=""
+deadline_text=""
 
 usage() {
-  echo "Usage: omarchy-notification-send [--app-name <app-name>] [-g <glyph>] [-u <low|normal|critical>] [-i <icon>] [-t <ms>] [-r <id>] [-p] [--image <path-or-uri>] <headline> [description] [--exec <program> [args...]]" >&2
+  echo "Usage: omarchy-notification-send [--app-name <app-name>] [-g <glyph>] [-u <low|normal|critical>] [-i <icon>] [-t <ms>] [-r <id>] [-p] [--image <path-or-uri>] [--deadline <seconds>] [--deadline-text <template>] <headline> [description] [--action <id>=<label> <program> [args...] \\;]... [--exec <program> [args...]]" >&2
+}
+
+# The argv rules shared by --exec and --action: a program must be there, and a
+# single word with a space is almost always a whole command passed as one
+# quoted string — which would run a program literally named that. Splitting it
+# ourselves is exactly the injection we avoid, so reject it and point at the
+# unquoted form instead.
+check_argv() { # flag args...
+  local flag=$1
+  shift
+  if (($# == 0)) || [[ -z $1 ]]; then
+    echo "$flag needs a command: $flag <program> [args...]" >&2
+    exit 1
+  fi
+  if (($# == 1)) && [[ $1 == *[[:space:]]* ]]; then
+    echo "$flag takes the command as separate words, not one quoted string." >&2
+    echo "Write:  $flag $1" >&2
+    exit 1
+  fi
+}
+
+# NUL-delimit into jq so every byte survives as data: jq's own --args would eat
+# a bare "--", and a newline in an arg must not split the vector.
+argv_json() {
+  printf '%s\0' "$@" | jq -Rsc 'split("\u0000")[:-1]'
 }
 
 # Recognize a known option, in both `--flag value` and `--flag=value` forms.
@@ -47,7 +78,7 @@ parse_omarchy_option() {
   fi
 
   case $opt in
-  -g | --glyph | -u | --urgency | --app-name | -i | --icon | --image | -r | --replace-id | -t | --expire-time) ;;
+  -g | --glyph | -u | --urgency | --app-name | -i | --icon | --image | -r | --replace-id | -t | --expire-time | --deadline | --deadline-text) ;;
   *) return 1 ;;
   esac
 
@@ -76,6 +107,14 @@ parse_omarchy_option() {
     }
     expire_timeout=$val
     ;;
+  --deadline)
+    [[ $val =~ ^[0-9]+$ ]] && ((val > 0)) || {
+      echo "Invalid $opt value (seconds expected): $val" >&2
+      exit 1
+    }
+    deadline_seconds=$val
+    ;;
+  --deadline-text) deadline_text=$val ;;
   esac
 
   parsed_option_args=$nargs
@@ -103,10 +142,54 @@ shift
 # Only a recognized option flag or --exec in that slot is not the description.
 known_flag() {
   case $1 in
-  -g | --glyph | -u | --urgency | --app-name | -i | --icon | -t | --expire-time | --image | -r | --replace-id | -p | --print-id | --exec) return 0 ;;
-  --glyph=* | --urgency=* | --app-name=* | --icon=* | --expire-time=* | --image=* | --replace-id=*) return 0 ;;
+  -g | --glyph | -u | --urgency | --app-name | -i | --icon | -t | --expire-time | --image | -r | --replace-id | -p | --print-id | --deadline | --deadline-text | --action | --exec) return 0 ;;
+  --glyph=* | --urgency=* | --app-name=* | --icon=* | --expire-time=* | --image=* | --replace-id=* | --deadline=* | --deadline-text=*) return 0 ;;
   esac
   return 1
+}
+
+# --action <id>=<label> <program> [args...] \;
+#
+# A button. Like --exec, the command is the words that follow, already split by
+# the caller's shell and never re-parsed; unlike --exec there can be several, so
+# each one ends at a lone ";" (written \; as for find -exec), or at the end of
+# the line for the last one. The id names the button to the shell and keys its
+# argv in the omarchy-action-argv hint; the label is what the button says.
+parse_action() { # args... (after --action); sets consumed
+  consumed=0
+  if (($# == 0)) || [[ $1 != *=* ]]; then
+    echo "--action needs <id>=<label> <program> [args...]" >&2
+    exit 1
+  fi
+  local spec=$1 id label
+  id=${spec%%=*}
+  label=${spec#*=}
+  shift
+  consumed=1
+  if [[ ! $id =~ ^[A-Za-z0-9_.-]+$ ]] || [[ -z $label ]]; then
+    echo "--action needs <id>=<label> with a plain id and a label: $spec" >&2
+    exit 1
+  fi
+  if [[ $id == "default" ]]; then
+    echo "--action id \"default\" is the click itself; use --exec for that" >&2
+    exit 1
+  fi
+  if jq -e --arg id "$id" 'has($id)' <<<"$action_argv_json" >/dev/null; then
+    echo "--action id given twice: $id" >&2
+    exit 1
+  fi
+  local argv=()
+  while (($# > 0)) && [[ $1 != ";" ]]; do
+    argv+=("$1")
+    shift
+    consumed=$((consumed + 1))
+  done
+  if (($# > 0)); then
+    consumed=$((consumed + 1)) # the ";"
+  fi
+  check_argv "--action $spec" "${argv[@]+"${argv[@]}"}"
+  action_pairs+=("$id" "$label")
+  action_argv_json=$(jq -c --arg id "$id" --argjson argv "$(argv_json "${argv[@]}")" '. + {($id): $argv}' <<<"$action_argv_json")
 }
 
 if (($# > 0)) && ! known_flag "$1"; then
@@ -127,6 +210,12 @@ while (($# > 0)); do
     exec_args=("$@")
     exec_present=1
     break
+  elif [[ $1 == "--action" ]]; then
+    # Same position rule as --exec: only after the positionals, so a headline
+    # that is literally "--action" is text.
+    shift
+    parse_action "$@"
+    shift "$consumed"
   elif parse_omarchy_option "$@"; then
     shift "$parsed_option_args"
   else
@@ -160,26 +249,31 @@ if [[ -n $image ]]; then
 fi
 
 if ((exec_present)); then
-  if ((${#exec_args[@]} == 0)) || [[ -z ${exec_args[0]} ]]; then
-    echo "--exec needs a command: --exec <program> [args...]" >&2
-    exit 1
+  check_argv "--exec" "${exec_args[@]+"${exec_args[@]}"}"
+  hints+=(omarchy-exec-argv s "$(argv_json "${exec_args[@]}")")
+fi
+
+if ((${#action_pairs[@]} > 0)); then
+  hints+=(omarchy-action-argv s "$action_argv_json")
+fi
+
+# A deadline is the moment the notification stops meaning anything - the shell
+# counts down to it and expires the toast exactly there, whatever the usual
+# lifetime and the hover pause would have done. Sent as an absolute epoch so a
+# toast restored after a shell restart keeps the same moment.
+if [[ -n $deadline_seconds ]]; then
+  deadline_ms=$(($(date +%s%3N) + deadline_seconds * 1000))
+  hints+=(omarchy-deadline-ms s "$deadline_ms")
+  if [[ -n $deadline_text ]]; then
+    hints+=(omarchy-deadline-text s "$deadline_text")
   fi
-  # A single word with a space is almost always a whole command passed as one
-  # quoted string — which would run a program literally named that. Splitting it
-  # ourselves is exactly the injection we avoid, so reject it and point at the
-  # unquoted form instead.
-  if ((${#exec_args[@]} == 1)) && [[ ${exec_args[0]} == *[[:space:]]* ]]; then
-    echo "--exec takes the command as separate words, not one quoted string." >&2
-    echo "Write:  --exec ${exec_args[0]}" >&2
-    exit 1
-  fi
-  # NUL-delimit into jq so every byte survives as data: jq's own --args would eat
-  # a bare "--", and a newline in an arg must not split the vector.
-  exec_argv_json=$(printf '%s\0' "${exec_args[@]}" | jq -Rsc 'split("\u0000")[:-1]')
-  hints+=(omarchy-exec-argv s "$exec_argv_json")
+elif [[ -n $deadline_text ]]; then
+  echo "--deadline-text needs --deadline <seconds>" >&2
+  exit 1
 fi
 
 hint_count=$((${#hints[@]} / 3))
+action_count=${#action_pairs[@]}
 
 # Call org.freedesktop.Notifications.Notify directly — never notify-send. Its
 # argv parsing is the surface that reinterprets a relayed headline like
@@ -190,14 +284,15 @@ hint_count=$((${#hints[@]} / 3))
 # omarchy-exec-argv is set only from --exec.
 #
 # Signature susssasa{sv}i: app_name, replaces_id, app_icon, summary, body,
-# actions (empty), hints, expire_timeout. replaces_id (from -r) updates a toast
-# in place; -p prints the returned id so a caller can reuse it.
+# actions (id/label pairs, from --action only), hints, expire_timeout.
+# replaces_id (from -r) updates a toast in place; -p prints the returned id so a
+# caller can reuse it.
 notify_cmd=(
   busctl --user -- call
   org.freedesktop.Notifications /org/freedesktop/Notifications
   org.freedesktop.Notifications Notify susssasa{sv}i
   "$app_name" "$replaces_id" "$app_icon" "$headline" "$description"
-  0
+  "$action_count" "${action_pairs[@]+"${action_pairs[@]}"}"
   "$hint_count" "${hints[@]}"
   "$expire_timeout"
 )

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -78,10 +78,13 @@ flags map onto that call:
 | `--app-name` | `app_name` | defaults to `omarchy-action` |
 | `-u` / `--urgency` | hint `urgency` (byte) | `low`/`normal`/`critical`; defaults to `low` |
 | `-t` / `--expire-time` | `expire_timeout` | milliseconds on screen; server default otherwise |
+| `--action <id>=<label> <program> [args…] \;` | `actions` (id, label) + hint `omarchy-action-argv` | a button. The label is what it says; the words after it are its command, ended by a lone `;` (written `\;`, as for `find -exec`) or the end of the line. Repeatable; comes after the positionals like `--exec` (see *Buttons*) |
+| `--deadline <seconds>` | hint `omarchy-deadline-ms` | the moment the notification stops mattering, sent as an absolute epoch; the toast counts down to it and expires exactly there (see *Deadlines*) |
+| `--deadline-text <template>` | hint `omarchy-deadline-text` | what the countdown says, with `{s}` for the seconds left: `"Deny in {s} s"` |
 
-Unknown flags are a hard error, not a silent pass-through: `--exec` is the only
-door to a click command, and there is no generic option pass-through to smuggle
-one through.
+Unknown flags are a hard error, not a silent pass-through: `--exec` and
+`--action` are the only doors to a command, and there is no generic option
+pass-through to smuggle one through.
 
 The defaults are the point: an unadorned `omarchy-notification-send "Done"`
 is a low-urgency user-action toast that pops through DND and is treated as
@@ -98,6 +101,53 @@ immediately. For third-party clients the click falls back to the libnotify
 `default` action while the sender is alive, then to focusing the sender's
 window by class via `omarchy-hyprland-focus-app` — chat apps rarely register
 an action and just expect click-to-jump.
+
+Buttons follow the same split. The freedesktop `actions` array is welcome for
+what it is good at — *labels* — and every action other than `default` is drawn
+as a button on the card. What a button *does* travels the way the click does:
+an argv per button in the `omarchy-action-argv` hint, run by the shell itself.
+A live libnotify sender that registered the action gets `ActionInvoked` when
+its button is pressed — that is how a browser's web notifications (Gmail's
+*Mark as read*, *Archive*, *Reply*) and chat clients' *Reply* get their buttons —
+but nothing in Omarchy relies on it.
+
+### Buttons
+
+```bash
+omarchy-notification-send "Update ready" "Restart when convenient" \
+  --action now=Restart omarchy-restart-shell \; \
+  --action later=Later omarchy-notification-send "Reminder set"
+```
+
+Each `--action` is an id, a label, and a command. The id keys the argv in the
+hint and names the pressed button to the shell; `default` is reserved for the
+click. The command is the words that follow, split by the caller's shell and
+never re-parsed, exactly as for `--exec`; because there can be several, each
+ends at a lone `;` (`\;` in a shell, the `find -exec` convention) — the last one
+may run to the end of the line. `--exec` can still follow, for the click.
+
+The hint is a JSON object, `{"now": ["omarchy-restart-shell"], …}`, validated per
+button with the click argv's rules (an array of strings, a program that is
+present and not a leading-dash option) and run through `Util.execArgv` the same
+way. It is persisted with the popup, so a toast restored after a shell restart
+keeps working buttons, and the history replay shows them too. A pressed button
+dismisses the toast; the card's own click and right-click are unchanged, and
+each button has its own mouse area so a press never doubles as a click.
+
+Nothing changes for senders that pass no actions: the `actions` array stays
+empty and the card is what it was.
+
+### Deadlines
+
+Some notifications stop meaning anything at a known moment — a firewall prompt
+the daemon answers by itself after thirty seconds, an update that will proceed
+on its own. `--deadline <seconds>` sends that moment as an absolute epoch in
+`omarchy-deadline-ms`, and the card counts down to it with `--deadline-text`
+("Deny in {s} s", or just the seconds without one). A declared deadline outranks
+the usual lifetime: the toast is not clamped to thirty seconds, is not paused
+while hovered — the clock it mirrors does not pause — and expires exactly at the
+deadline. Because the moment is absolute, a toast restored after a shell restart
+keeps it, and a history replay drops it: a memory does not count down.
 
 ### Click commands are argv, never shell strings
 

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -176,6 +176,90 @@ function parseExecArgv(value) {
   return parsed
 }
 
+// ---------------------------------------------------- action buttons
+//
+// A notification's freedesktop `actions` become buttons on the card. The
+// "default" action is the whole-card click and is not a button. Carried in
+// the row as JSON text (a ListModel role must be a plain value), so a restored
+// or replayed toast still shows its buttons.
+function actionsFromNotification(notification) {
+  var out = []
+  try {
+    var list = (notification && notification.actions) || []
+    for (var i = 0; i < list.length; i++) {
+      var a = list[i]
+      if (!a) continue
+      var id = String(a.identifier || "")
+      if (!id || id === "default") continue
+      out.push({ id: id, label: String(a.text || id) })
+    }
+  } catch (e) {
+  }
+  return JSON.stringify(out)
+}
+
+function parseActions(value) {
+  try {
+    var parsed = JSON.parse(String(value || "[]"))
+    if (!Array.isArray(parsed)) return []
+    var out = []
+    for (var i = 0; i < parsed.length; i++) {
+      var a = parsed[i]
+      if (a && typeof a.id === "string" && a.id) out.push({ id: a.id, label: String(a.label || a.id) })
+    }
+    return out
+  } catch (e) {
+    return []
+  }
+}
+
+// One argv per action, in the `omarchy-action-argv` hint as a JSON object
+// keyed by action id — the per-button counterpart of omarchy-exec-argv, for
+// senders that are gone by the time a button is pressed (every CLI sender).
+// Validated with the same structural rules as the click argv.
+function actionArgvFromHints(hints) {
+  return stringHint(hints, "omarchy-action-argv")
+}
+
+function parseActionArgv(value, actionId) {
+  var text = String(value || "")
+  if (!text) return null
+  var parsed
+  try {
+    parsed = JSON.parse(text)
+  } catch (e) {
+    return null
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null
+  var argv = parsed[String(actionId)]
+  if (argv === undefined || argv === null) return null
+  return parseExecArgv(JSON.stringify(argv))
+}
+
+// ---------------------------------------------------- deadlines
+//
+// A notification whose meaning ends at a known moment — a firewall prompt the
+// daemon answers by itself at a deadline — carries that moment in the
+// `omarchy-deadline-ms` hint (epoch milliseconds). The card counts down to it
+// with `omarchy-deadline-text` ("Deny in {s} s") and the toast expires exactly
+// there: no clamp to the usual popup lifetime, and no pause while hovered,
+// because the clock it mirrors does not pause either.
+function deadlineFromHints(hints) {
+  var n = Number(stringHint(hints, "omarchy-deadline-ms") || 0)
+  return isFinite(n) && n > 0 ? n : 0
+}
+
+function deadlineTextFromHints(hints) {
+  return stringHint(hints, "omarchy-deadline-text")
+}
+
+function countdownText(template, deadlineMs, nowMs) {
+  var s = Math.max(0, Math.ceil((Number(deadlineMs) - Number(nowMs)) / 1000))
+  var t = String(template || "")
+  if (!t) return s + " s"
+  return t.indexOf("{s}") >= 0 ? t.replace("{s}", String(s)) : t + " " + s + " s"
+}
+
 function shouldRenderCompactGlyph(glyph, iconSource, singleLineToast) {
   return String(glyph || "").length > 0 && String(iconSource || "").length === 0 && !!singleLineToast
 }
@@ -195,6 +279,10 @@ function snapshotOf(notification, timestamp) {
     image: n.image || "",
     glyph: glyphFromHints(n.hints),
     execArgv: execArgvFromHints(n.hints),
+    actionsJson: actionsFromNotification(n),
+    actionArgv: actionArgvFromHints(n.hints),
+    deadlineMs: deadlineFromHints(n.hints),
+    deadlineText: deadlineTextFromHints(n.hints),
     urgency: n.urgency,
     expireTimeout: expireTimeout,
     timestamp: timestamp === undefined ? Date.now() : timestamp
@@ -203,7 +291,7 @@ function snapshotOf(notification, timestamp) {
 
 // Everything the popup card draws, and therefore everything an in-place
 // update has to write through to the row and its file.
-var POPUP_ROLES = ["app", "appIcon", "summary", "body", "image", "glyph", "execArgv", "urgency", "expireTimeout"]
+var POPUP_ROLES = ["app", "appIcon", "summary", "body", "image", "glyph", "execArgv", "actionsJson", "actionArgv", "deadlineMs", "deadlineText", "urgency", "expireTimeout"]
 
 function popupRoles() {
   return POPUP_ROLES
@@ -246,6 +334,10 @@ function historyEntry(value, normalUrgency) {
     image: e.image || "",
     glyph: e.glyph || "",
     execArgv: e.execArgv || "",
+    actionsJson: e.actionsJson || "[]",
+    actionArgv: e.actionArgv || "",
+    deadlineMs: Number(e.deadlineMs || 0) || 0,
+    deadlineText: e.deadlineText || "",
     urgency: typeof e.urgency === "number" ? e.urgency : normalUrgency,
     expireTimeout: 0,
     timestamp: e.timestamp || 0
@@ -388,6 +480,9 @@ function parsePopupFiles(raw, normalUrgency) {
 // second restart would judge a re-shown toast by a clock that no longer
 // governs its display and drop it while it is still on screen.
 function popupExpired(entry, duration, now) {
+  // A sender-declared deadline is absolute and outranks everything else.
+  var declared = Number((entry || {}).deadlineMs || 0)
+  if (isFinite(declared) && declared > 0) return Number(now) >= declared
   var deadline = Number((entry || {}).deadline || 0)
   if (isFinite(deadline) && deadline > 0) return Number(now) >= deadline
   var lifetime = Number(duration || 0)
@@ -436,7 +531,12 @@ function historyRows(raw, liveRows, normalUrgency, limit) {
       var key = popupFileName(entry)
       if (seen[key]) continue
       seen[key] = true
-      out.push(historyEntry(entry, normalUrgency))
+      var replayed = historyEntry(entry, normalUrgency)
+      // A replayed toast is a memory: its deadline has passed and must not
+      // expire it on the spot, nor count down to a moment already gone.
+      replayed.deadlineMs = 0
+      replayed.deadlineText = ""
+      out.push(replayed)
     }
   }
 
@@ -458,6 +558,13 @@ if (typeof module !== "undefined") {
     glyphFromHints: glyphFromHints,
     execArgvFromHints: execArgvFromHints,
     parseExecArgv: parseExecArgv,
+    actionsFromNotification: actionsFromNotification,
+    parseActions: parseActions,
+    actionArgvFromHints: actionArgvFromHints,
+    parseActionArgv: parseActionArgv,
+    deadlineFromHints: deadlineFromHints,
+    deadlineTextFromHints: deadlineTextFromHints,
+    countdownText: countdownText,
     shouldRenderCompactGlyph: shouldRenderCompactGlyph,
     snapshotOf: snapshotOf,
     popupRoles: popupRoles,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -234,7 +234,8 @@ Item {
   // about after the popup exists.
   readonly property var updateSignals: [
     "summaryChanged", "bodyChanged", "appNameChanged", "appIconChanged",
-    "imageChanged", "urgencyChanged", "expireTimeoutChanged", "hintsChanged"
+    "imageChanged", "urgencyChanged", "expireTimeoutChanged", "hintsChanged",
+    "actionsChanged"
   ]
 
   // A client that updates a notification through replaces_id does not produce
@@ -393,6 +394,37 @@ Item {
     // focus their window. Fall back to focusing the sending app by class so
     // that click-to-jump actually works.
     if (!invoked) focusApp(entry)
+    dismissPopup(index)
+  }
+
+  // A button on the card. An argv carried in the omarchy-action-argv hint runs
+  // like the click argv does — detached, as positional parameters, never a
+  // shell string; it is also what keeps a restored toast's buttons working.
+  // Otherwise the libnotify action is invoked on the live object, which sends
+  // ActionInvoked to a sender that is still around to hear it.
+  function invokePopupAction(index, actionId) {
+    if (index < 0 || index >= popupModel.count) return
+    var entry = popupModel.get(index)
+    var argv = NotificationLogic.parseActionArgv(entry ? entry.actionArgv : "", actionId)
+    if (argv) {
+      Util.execArgv(argv)
+      dismissPopup(index)
+      return
+    }
+    var ref = entry && !isRestoredRow(entry) ? liveRefs[entry.originalId] : null
+    try {
+      if (ref && ref.actions) {
+        for (var i = 0; i < ref.actions.length; i++) {
+          var action = ref.actions[i]
+          if (action && String(action.identifier) === String(actionId)) {
+            action.invoke()
+            break
+          }
+        }
+      }
+    } catch (e) {
+      console.warn("invoke action failed:", e)
+    }
     dismissPopup(index)
   }
 
@@ -667,6 +699,10 @@ Item {
         image: row.image,
         glyph: row.glyph || "",
         execArgv: row.execArgv || "",
+        actionsJson: row.actionsJson || "[]",
+        actionArgv: row.actionArgv || "",
+        deadlineMs: row.deadlineMs || 0,
+        deadlineText: row.deadlineText || "",
         urgency: row.urgency,
         timestamp: row.timestamp
       }, imagesDir).entry)
@@ -691,6 +727,10 @@ Item {
         image: "",
         glyph: "󰂚",
         execArgv: "",
+        actionsJson: "[]",
+        actionArgv: "",
+        deadlineMs: 0,
+        deadlineText: "",
         urgency: NotificationUrgency.Low,
         expireTimeout: 0,
         timestamp: Date.now()
@@ -1000,9 +1040,37 @@ Item {
             required property string body
             required property string image
             required property string glyph
+            required property string actionsJson
+            required property string actionArgv
+            required property double deadlineMs
+            required property string deadlineText
             required property int urgency
             required property double expireTimeout
             required property double timestamp
+
+            // A declared deadline replaces the lifetime timer below: the toast
+            // lives exactly until that moment, hovered or not, and shows how
+            // long that is.
+            readonly property bool hasDeadline: cardSlot.deadlineMs > 0
+            property string countdown: ""
+
+            function tickDeadline() {
+              var now = Date.now()
+              if (now >= cardSlot.deadlineMs) {
+                cardSlot.countdown = NotificationLogic.countdownText(cardSlot.deadlineText, cardSlot.deadlineMs, now)
+                service.expirePopup(cardSlot.index)
+                return
+              }
+              cardSlot.countdown = NotificationLogic.countdownText(cardSlot.deadlineText, cardSlot.deadlineMs, now)
+            }
+
+            Timer {
+              interval: 250
+              repeat: true
+              running: cardSlot.hasDeadline
+              triggeredOnStart: true
+              onTriggered: cardSlot.tickDeadline()
+            }
 
             // Each card sizes itself based on mode (text vs media); the slot
             // tracks the card so the column auto-fits to whichever is widest.
@@ -1012,7 +1080,7 @@ Item {
 
             readonly property real lifetime: service.durationFor(cardSlot.urgency, cardSlot.expireTimeout)
             property real remainingLifetime: 1.0
-            readonly property bool ticking: cardSlot.lifetime > 0 && !card.hovered
+            readonly property bool ticking: !cardSlot.hasDeadline && cardSlot.lifetime > 0 && !card.hovered
 
             // A client updating this notification in place rewrites the row
             // under the card (see refreshPopup). New text deserves a full look,
@@ -1051,9 +1119,12 @@ Item {
               cornerRadius: service.cornerRadius
               fontFamily: service.shell && service.shell.bar ? service.shell.bar.fontFamily : ""
               glyph: cardSlot.glyph
+              actions: NotificationLogic.parseActions(cardSlot.actionsJson)
+              countdownText: cardSlot.hasDeadline ? cardSlot.countdown : ""
 
               onCloseRequested: service.dismissPopup(cardSlot.index)
               onCardClicked: service.invokePopupDefault(cardSlot.index)
+              onActionRequested: function(id) { service.invokePopupAction(cardSlot.index, id) }
             }
           }
         }

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -30,10 +30,18 @@ BorderSurface {
   // System monospace font injected by the container.
   property string fontFamily: ""
 
+  // Buttons: [{ id, label }], from the notification's freedesktop actions.
+  // The "default" action is the card click, never a button.
+  property var actions: []
+  // "Deny in 23 s": what is left until a sender-declared deadline (see
+  // Service.qml). Empty for every notification without one.
+  property string countdownText: ""
+
   readonly property bool hovered: hoverTracker.hovered
 
   signal closeRequested()
   signal cardClicked()
+  signal actionRequested(string id)
   // Prefer per-notification media/avatar data, then fall back to the app icon.
   // The `check` flag avoids Qt's missing-texture placeholder for unknown names.
   readonly property string smallIconSource: image.length > 0 ? image : iconSource(appIcon)
@@ -190,6 +198,67 @@ BorderSurface {
           wrapMode: Text.WordWrap
           elide: Text.ElideRight
           maximumLineCount: 3
+        }
+      }
+    }
+
+    // Buttons, right-aligned under the text, with the countdown on the left
+    // when there is one. Each button has its own MouseArea, stacked above the
+    // full-card one, so a press ends here and never reaches cardClicked.
+    RowLayout {
+      visible: root.actions.length > 0 || root.countdownText.length > 0
+      Layout.fillWidth: true
+      Layout.leftMargin: Style.space(12)
+      Layout.rightMargin: Style.space(12)
+      Layout.bottomMargin: Style.space(10)
+      spacing: Style.space(8)
+
+      Text {
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignVCenter
+        textFormat: Text.PlainText
+        visible: root.countdownText.length > 0
+        text: root.countdownText
+        color: root.dimColor
+        font.family: "Liberation Sans"
+        font.pixelSize: Style.font.bodySmall
+        elide: Text.ElideRight
+      }
+      Item { Layout.fillWidth: root.countdownText.length === 0 }
+
+      Repeater {
+        model: root.actions
+
+        Rectangle {
+          id: actionButton
+          required property var modelData
+          readonly property bool hot: actionHover.hovered
+          Layout.preferredWidth: actionLabel.implicitWidth + Style.space(20)
+          Layout.preferredHeight: actionLabel.implicitHeight + Style.space(10)
+          radius: Style.space(4)
+          color: hot ? Util.alpha(Color.notifications.text, 0.14) : Util.alpha(Color.notifications.text, 0.06)
+          border.width: Math.max(1, Style.space(1))
+          border.color: hot ? Color.notifications.countdown : Util.alpha(Color.notifications.border, 0.6)
+
+          Text {
+            id: actionLabel
+            anchors.centerIn: parent
+            textFormat: Text.PlainText
+            text: actionButton.modelData.label
+            color: Color.notifications.text
+            font.family: "Liberation Sans"
+            font.pixelSize: Style.font.bodySmall
+            font.bold: true
+          }
+
+          HoverHandler { id: actionHover }
+
+          MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            acceptedButtons: Qt.LeftButton
+            onClicked: root.actionRequested(actionButton.modelData.id)
+          }
         }
       }
     }

--- a/test/shell.d/notification-send-test.sh
+++ b/test/shell.d/notification-send-test.sh
@@ -197,3 +197,106 @@ send "Timed" -t 3000 >/dev/null
 load
 [[ ${args[12]} == "" && ${args[-1]} == "3000" ]] || fail "notification wrapper still parses a flag after the headline" "body=${args[12]} timeout=${args[-1]}"
 pass "notification wrapper still treats a known flag after the headline as an option"
+
+# ---------------------------------------------------------------- buttons
+#
+# --action adds id/label pairs to the actions array and one argv per id to the
+# omarchy-action-argv hint. The array is no longer empty, so read hints from
+# after it: position 13 is the count of strings, the pairs follow, then the
+# hint count.
+actions_count() { echo "${args[13]}"; }
+action_pair() { # index -> "id label"
+  echo "${args[14 + 2 * $1]} ${args[15 + 2 * $1]}"
+}
+hint_base() { echo $((14 + ${args[13]})); }
+hint_value_after_actions() { # key -> variant value
+  local base i end
+  base=$(hint_base)
+  end=$((base + 1 + 3 * ${args[base]}))
+  for ((i = base + 1; i < end; i += 3)); do [[ ${args[i]} == "$1" ]] && { echo "${args[i + 2]}"; return 0; }; done
+  return 1
+}
+
+: >"$args_file"
+send "Update ready" "Restart when convenient" \
+  --action now=Restart omarchy-restart-shell \; \
+  --action later=Later touch -- "/tmp/a b" \; \
+  --exec mpv -- /tmp/v.mp4 >/dev/null
+load
+[[ $(actions_count) == "4" ]] || fail "notification wrapper sends two actions as four strings" "$(actions_count)"
+[[ $(action_pair 0) == "now Restart" ]] || fail "notification wrapper sends the first action's id and label" "$(action_pair 0)"
+[[ $(action_pair 1) == "later Later" ]] || fail "notification wrapper sends the second action's id and label" "$(action_pair 1)"
+[[ $(hint_value_after_actions omarchy-action-argv) == '{"now":["omarchy-restart-shell"],"later":["touch","--","/tmp/a b"]}' ]] ||
+  fail "notification wrapper builds one argv per action, keeping a spaced argument whole" "$(hint_value_after_actions omarchy-action-argv)"
+[[ $(hint_value_after_actions omarchy-exec-argv) == '["mpv","--","/tmp/v.mp4"]' ]] ||
+  fail "notification wrapper still takes --exec after the actions" "$(hint_value_after_actions omarchy-exec-argv)"
+pass "notification wrapper sends buttons as actions with an argv per button"
+
+# The last action may run to the end of the line without a terminator.
+: >"$args_file"
+send "Head" --action ok=OK omarchy-restart-shell --now >/dev/null
+load
+[[ $(actions_count) == "2" && $(hint_value_after_actions omarchy-action-argv) == '{"ok":["omarchy-restart-shell","--now"]}' ]] ||
+  fail "notification wrapper lets the last action run to the end of the line" "$(hint_value_after_actions omarchy-action-argv)"
+pass "notification wrapper lets the last action omit its terminator"
+
+# A headline that looks like the flag is text, as for --exec.
+: >"$args_file"
+send "--action" "a body" --action go=Go true >/dev/null
+load
+[[ ${args[11]} == "--action" && $(actions_count) == "2" ]] || fail "an --action-looking headline is kept as text" "${args[11]} ${args[13]}"
+pass "an --action-looking positional is not treated as a button"
+
+# Without any --action the actions array stays empty, so existing callers see
+# exactly the call they always did.
+: >"$args_file"
+send "Plain" >/dev/null
+load
+[[ $(actions_count) == "0" ]] || fail "notification wrapper sends an empty actions array without --action" "$(actions_count)"
+pass "notification wrapper leaves the actions array empty without --action"
+
+# The same argv rules as --exec, and the ids the shell relies on.
+if send "Head" --action "x=X" "omarchy toggle something" 2>/dev/null; then
+  fail "notification wrapper rejects a quoted whole command in --action"
+fi
+pass "notification wrapper rejects a quoted whole command in --action"
+if send "Head" --action x=X 2>/dev/null; then
+  fail "notification wrapper rejects --action with no command"
+fi
+pass "notification wrapper rejects --action with no command"
+if send "Head" --action default=Click true 2>/dev/null; then
+  fail "notification wrapper rejects the reserved default action id"
+fi
+pass "notification wrapper rejects the reserved default action id"
+if send "Head" --action a=A true \; --action a=B true 2>/dev/null; then
+  fail "notification wrapper rejects a repeated action id"
+fi
+pass "notification wrapper rejects a repeated action id"
+if send "Head" --action "no label" true 2>/dev/null; then
+  fail "notification wrapper rejects an action without id=label"
+fi
+pass "notification wrapper rejects an action without id=label"
+
+# ---------------------------------------------------------------- deadlines
+#
+# --deadline sends the absolute moment (epoch ms) the toast stops mattering,
+# and --deadline-text the countdown the card shows until then.
+before=$(date +%s%3N)
+: >"$args_file"
+send "Timed" --deadline 30 --deadline-text "Deny in {s} s" >/dev/null
+after=$(date +%s%3N)
+load
+deadline=$(hint_value_after_actions omarchy-deadline-ms)
+[[ $deadline =~ ^[0-9]+$ ]] || fail "notification wrapper sends the deadline as epoch milliseconds" "$deadline"
+((deadline >= before + 30000 && deadline <= after + 30000)) || fail "notification wrapper puts the deadline 30 s from now" "$deadline (now $before..$after)"
+[[ $(hint_value_after_actions omarchy-deadline-text) == "Deny in {s} s" ]] || fail "notification wrapper sends the countdown template" "$(hint_value_after_actions omarchy-deadline-text)"
+pass "notification wrapper sends a deadline and its countdown text"
+
+if send "Head" --deadline-text "x {s}" 2>/dev/null; then
+  fail "notification wrapper rejects --deadline-text without --deadline"
+fi
+pass "notification wrapper rejects --deadline-text without --deadline"
+if send "Head" --deadline 0 2>/dev/null; then
+  fail "notification wrapper rejects a zero deadline"
+fi
+pass "notification wrapper rejects a zero deadline"

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -632,7 +632,7 @@ assert(
   'notifications service re-persists a silenced notification updated while its write was queued'
 )
 assert(
-  /rows\.push\(NotificationLogic\.persistablePopup\(\{[\s\S]{0,400}?\}, imagesDir\)\.entry\)/.test(serviceQml),
+  /rows\.push\(NotificationLogic\.persistablePopup\(\{[\s\S]{0,600}?\}, imagesDir\)\.entry\)/.test(serviceQml),
   'notifications service replays carried-over toasts from their persisted image copies'
 )
 assert(
@@ -723,4 +723,83 @@ assert(
   !/pendingModel|pastModel/.test(serviceQml),
   'notifications service keeps no in-memory history models'
 )
+JS
+
+# ---------------------------------------------------------------- buttons and deadlines
+run_node_test <<'JS'
+const fs = require('fs')
+const notifications = requireFromRoot('shell/plugins/notifications/NotificationLogic.js')
+
+// Buttons come from the freedesktop actions array; the "default" action is the
+// card click and is not a button.
+assertEqual(
+  notifications.actionsFromNotification({ actions: [
+    { identifier: 'default', text: 'Open' },
+    { identifier: 'allow', text: 'Allow' },
+    { identifier: 'deny', text: 'Deny' }
+  ] }),
+  '[{"id":"allow","label":"Allow"},{"id":"deny","label":"Deny"}]',
+  'notifications turn actions into buttons and drop the default one'
+)
+assertEqual(notifications.actionsFromNotification({}), '[]', 'notifications with no actions have no buttons')
+assertDeepEqual(
+  notifications.parseActions('[{"id":"allow","label":"Allow"},{"id":"","label":"x"},{"label":"no id"}]'),
+  [{ id: 'allow', label: 'Allow' }],
+  'notifications parse persisted buttons and drop entries without an id'
+)
+assertDeepEqual(notifications.parseActions('not json'), [], 'notifications parse malformed button JSON as no buttons')
+
+// One argv per button in omarchy-action-argv, validated like the click argv.
+const argv = '{"allow":["omarchy-shell","x","answer","allow"],"bad":"string","dash":["-rf","/"],"empty":[]}'
+assertDeepEqual(
+  notifications.parseActionArgv(argv, 'allow'),
+  ['omarchy-shell', 'x', 'answer', 'allow'],
+  'notifications resolve a button id to its argv'
+)
+assertEqual(notifications.parseActionArgv(argv, 'bad'), null, 'notifications fail closed on a non-array action argv')
+assertEqual(notifications.parseActionArgv(argv, 'dash'), null, 'notifications fail closed on a dash-leading action program')
+assertEqual(notifications.parseActionArgv(argv, 'empty'), null, 'notifications fail closed on an empty action argv')
+assertEqual(notifications.parseActionArgv(argv, 'missing'), null, 'notifications return nothing for an unknown button id')
+assertEqual(notifications.parseActionArgv('["not","an","object"]', 'allow'), null, 'notifications fail closed when the action hint is not an object')
+assertEqual(notifications.parseActionArgv('', 'allow'), null, 'notifications return nothing without an action hint')
+
+// The snapshot carries the buttons and their argv, and an in-place update
+// rewrites them along with everything else the card draws.
+const snap = notifications.snapshotOf({
+  id: 7, appName: 'x', summary: 's', urgency: 1,
+  actions: [{ identifier: 'allow', text: 'Allow' }],
+  hints: { 'omarchy-action-argv': argv }
+}, 1000)
+assertEqual(snap.actionsJson, '[{"id":"allow","label":"Allow"}]', 'notifications snapshot the buttons')
+assertEqual(snap.actionArgv, argv, 'notifications snapshot the action argv hint')
+assert(notifications.popupRoles().includes('actionsJson') && notifications.popupRoles().includes('actionArgv'),
+  'notifications write buttons through on an in-place update')
+assertEqual(notifications.historyEntry({}).actionsJson, '[]', 'notifications history rows default to no buttons')
+
+// Deadlines: an absolute moment, a countdown to it, and expiry exactly there.
+assertEqual(notifications.deadlineFromHints({ 'omarchy-deadline-ms': '1700000000000' }), 1700000000000, 'notifications read the deadline hint')
+assertEqual(notifications.deadlineFromHints({ 'omarchy-deadline-ms': 'soon' }), 0, 'notifications ignore a non-numeric deadline')
+assertEqual(notifications.deadlineFromHints({}), 0, 'notifications default to no deadline')
+assertEqual(notifications.countdownText('Deny in {s} s', 10000, 7400), 'Deny in 3 s', 'notifications count down in whole seconds, rounding up')
+assertEqual(notifications.countdownText('', 10000, 7400), '3 s', 'notifications count down without a template')
+assertEqual(notifications.countdownText('Gone', 10000, 7400), 'Gone 3 s', 'notifications append the seconds to a template without a slot')
+assertEqual(notifications.countdownText('x {s}', 10000, 12000), 'x 0', 'notifications never count below zero')
+assert(notifications.popupExpired({ deadlineMs: 5000, timestamp: 0 }, 0, 5000), 'notifications expire at a declared deadline even with no lifetime')
+assert(!notifications.popupExpired({ deadlineMs: 5000, timestamp: 0 }, 1000, 4999), 'notifications keep a toast until its declared deadline whatever the lifetime')
+assert(notifications.popupRoles().includes('deadlineMs') && notifications.popupRoles().includes('deadlineText'),
+  'notifications write the deadline through on an in-place update')
+const replayed = notifications.historyRows(JSON.stringify({ id: 1, originalId: 1, summary: 's', deadlineMs: 1, deadlineText: 'x', timestamp: 5 }), [], 1, 10)
+assertEqual(replayed[0].deadlineMs, 0, 'notifications replay history without a deadline')
+assertEqual(replayed[0].deadlineText, '', 'notifications replay history without a countdown')
+
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/Service.qml'), 'utf8')
+const cardQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/components/NotificationCard.qml'), 'utf8')
+assert(
+  /function invokePopupAction\(index, actionId\)[\s\S]{0,400}?parseActionArgv\(entry \? entry\.actionArgv : "", actionId\)[\s\S]{0,120}?Util\.execArgv\(argv\)/.test(serviceQml),
+  'notifications service runs a button argv itself, like the click argv'
+)
+assert(/"actionsChanged"/.test(serviceQml), 'notifications service watches the actions of a notification updated in place')
+assert(/ticking: !cardSlot\.hasDeadline/.test(serviceQml), 'notifications service does not run the lifetime timer against a declared deadline')
+assert(/signal actionRequested\(string id\)/.test(cardQml), 'notification card raises a signal per button')
+assert(/onActionRequested: function\(id\) \{ service\.invokePopupAction\(cardSlot\.index, id\) \}/.test(serviceQml), 'notifications service wires the card buttons')
 JS


### PR DESCRIPTION

## What

Two additions to the notification service and its sender, both in the shape the
click command already has:

- **Buttons.** The freedesktop `actions` array (which the server has always
  advertised support for) is drawn as buttons on the card. What a button does
  travels as an argv per action in a new `omarchy-action-argv` hint — the
  per-button counterpart of `omarchy-exec-argv` — validated with the same rules
  and run through `Util.execArgv` by the shell itself. So a sender can exit at
  once, the shell can restart underneath, and a restored or replayed toast keeps
  working buttons. A live libnotify sender that registered the action gets
  `ActionInvoked` when its button is pressed — which is how third-party apps
  get their buttons (below); Omarchy's own senders never depend on it.
- **Deadlines.** A sender can declare the absolute moment a notification stops
  meaning anything (`omarchy-deadline-ms`) with a countdown template
  (`omarchy-deadline-text`, `"Deny in {s} s"`). The card shows the seconds left
  and the toast expires exactly at the deadline — no thirty-second clamp, no pause
  while hovered, since the clock it mirrors does not pause. History replays drop
  it.

`omarchy-notification-send` gains `--action <id>=<label> <program> [args…] \;`
(repeatable; `\;` closes one command as for `find -exec`, the last may run to the
end of the line) and `--deadline <seconds>` / `--deadline-text <template>`.

## Why

An application-firewall prompt has to be answered without stealing the keyboard,
and the two answers that matter — allow this once, allow it always — are two
buttons, not one click. It also expires at a moment the daemon decides, so the
toast should say how long is left and leave exactly then. Nothing in the shell
could do either; the notification service was the right place, since a toast
that is a real notification stacks with the others, obeys Do Not Disturb, and is
archived like everything else.

It also unlocks buttons other apps already send. Web notifications relayed by
Firefox carry actions — Gmail's arrive with *Mark as read*, *Archive* and
*Reply* — and chat and mail clients register *Reply* or *Dismiss* through
libnotify. The server has always accepted those actions and then dropped them
before the card; now they are drawn, and pressing one sends `ActionInvoked` to
the app while it is running, which is exactly the contract those apps expect.

## What stays the same

Senders that pass no actions and no deadline see the call they always did: the
`actions` array stays empty, the card is unchanged, lifetimes and hover behaviour
are unchanged. The design follows `docs/notifications.md`: commands are argv
split at the call site, never shell strings; the shell fails closed on anything
it cannot validate; libnotify callbacks are still not relied on.

## Testing

- `./test/shell` (all suites) and `./test/cli` pass.
- `test/shell.d/notifications-test.sh`: new cases for action snapshotting and
  parsing, fail-closed argv validation per button, deadline parsing, countdown
  text, expiry at a declared deadline, and history replays dropping deadlines;
  plus source assertions that the service runs a button argv itself and does not
  run its lifetime timer against a declared deadline.
- `test/shell.d/notification-send-test.sh`: `--action` pairs and per-button argv
  (spaced arguments kept whole), the last action without a terminator, an
  `--action`-looking headline kept as text, the empty array without `--action`,
  the same refusals as `--exec`, the reserved `default` id, repeated ids,
  `--deadline` as epoch milliseconds and its text, `--deadline-text` without
  `--deadline` refused.
- On a running desktop: `omarchy-notification-send "Update ready" "Restart when
  convenient" --deadline 12 --deadline-text "Later in {s} s" --action now=Restart
  … \; --action later=Later …` shows two buttons and a live countdown, expires at
  twelve seconds, and a pressed button runs its command and dismisses the toast.

## Screenshots

_Before: a plain toast. After: the same toast with two buttons and a live countdown._ (images attached below)

<img width="378" height="92" alt="notification-after" src="https://github.com/user-attachments/assets/9a04bc23-c0a1-4cf6-b4be-7276229cf0fd" />
<img width="378" height="60" alt="notification-before" src="https://github.com/user-attachments/assets/f3b149aa-89e4-48a2-ac1e-aa00c7fccebb" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)
