### PR TITLE
Wait out an in-flight sleep operation before inhibiting

### DIFF
--- a/bin/omarchy-system-sleep-monitor
+++ b/bin/omarchy-system-sleep-monitor
@@ -4,6 +4,13 @@
 # omarchy:group=system
 # omarchy:hidden=true
 
+# Bounds the wait for logind to finish a sleep operation. The wait only ever
+# spans the tail of a resume, so the cap is a backstop against a stuck
+# PreparingForSleep rather than a duration worth tuning.
+settle_timeout_ms=30000
+settle_interval=0.1
+settle_interval_ms=100
+
 consume_sleep_events() {
   local line sleep_lock
   sleep_lock="$OMARCHY_PATH/bin/omarchy-system-sleep-lock"
@@ -40,6 +47,29 @@ monitor_sleep_events() {
   return "$status"
 }
 
+preparing_for_sleep() {
+  local value
+  value=$(busctl get-property org.freedesktop.login1 /org/freedesktop/login1 \
+    org.freedesktop.login1.Manager PreparingForSleep 2>/dev/null)
+
+  [[ ${value##* } == "true" ]]
+}
+
+# Releasing the inhibitor means exiting, so every locked suspend is followed by
+# a Restart. That restart lands while logind is still working through the sleep
+# operation, and logind refuses a delay inhibitor for an operation already in
+# flight: systemd-inhibit exits 1 and Restart tries again RestartSec later.
+# The retries burn StartLimitBurst, and tripping it leaves the unit failed --
+# so the next suspend gets no lock at all. Wait the operation out instead.
+wait_for_sleep_operation() {
+  local waited_ms=0
+
+  while (( waited_ms < settle_timeout_ms )) && preparing_for_sleep; do
+    sleep "$settle_interval"
+    (( waited_ms += settle_interval_ms ))
+  done
+}
+
 case ${1:-} in
   --consume)
     consume_sleep_events
@@ -52,6 +82,8 @@ case ${1:-} in
 esac
 
 sleep_monitor="$OMARCHY_PATH/bin/omarchy-system-sleep-monitor"
+
+wait_for_sleep_operation
 
 exec systemd-inhibit \
   --what=sleep \

--- a/test/shell.d/sleep-monitor-test.sh
+++ b/test/shell.d/sleep-monitor-test.sh
@@ -104,3 +104,60 @@ if kill -0 "$producer_pid" 2>/dev/null; then
   fail "sleep monitor cleans up its producer when terminated" "producer still running: $producer_pid"
 fi
 pass "sleep monitor cleans up its producer when terminated"
+
+# A restart that lands while logind is still working through a sleep operation
+# cannot take a delay inhibitor. The monitor must wait the operation out rather
+# than exiting 1 and burning through the unit's StartLimitBurst.
+busctl_calls="$tmpdir/busctl-calls"
+inhibit_marker="$tmpdir/inhibit-marker"
+rm -f "$busctl_calls" "$inhibit_marker" "$producer_pid_file" "$lock_log"
+
+cat >"$mock_bin/busctl" <<'SH'
+#!/bin/bash
+
+count=$(<"$BUSCTL_CALLS")
+count=$((count + 1))
+echo "$count" >"$BUSCTL_CALLS"
+
+if (( count < 3 )); then
+  echo "b true"
+else
+  echo "b false"
+fi
+SH
+
+cat >"$mock_bin/systemd-inhibit" <<'SH'
+#!/bin/bash
+
+cp "$BUSCTL_CALLS" "$INHIBIT_MARKER"
+
+while [[ $1 == --* ]]; do
+  shift
+done
+
+exec "$@"
+SH
+
+cat >"$mock_bin/dbus-monitor" <<'SH'
+#!/bin/bash
+
+echo "$$" >"$PRODUCER_PID_FILE"
+printf '   boolean true\n'
+exec sleep 30
+SH
+
+chmod +x "$mock_bin/busctl" "$mock_bin/systemd-inhibit" "$mock_bin/dbus-monitor"
+echo 0 >"$busctl_calls"
+
+OMARCHY_PATH="$mock_omarchy" \
+  PATH="$mock_bin:$PATH" \
+  PRODUCER_PID_FILE="$producer_pid_file" \
+  LOCK_LOG="$lock_log" \
+  BUSCTL_CALLS="$busctl_calls" \
+  INHIBIT_MARKER="$inhibit_marker" \
+  "$sleep_monitor"
+
+(( $(<"$inhibit_marker") >= 3 )) ||
+  fail "sleep monitor waits for an in-flight sleep operation before inhibiting" \
+    "inhibited after $(<"$inhibit_marker") checks"
+pass "sleep monitor waits for an in-flight sleep operation before inhibiting"


### PR DESCRIPTION
Releasing the sleep inhibitor means exiting, so every locked suspend is followed by a `Restart`. That restart lands while logind is still working through the sleep operation, and logind refuses a delay inhibitor for an operation already in flight: `systemd-inhibit` exits 1 and `Restart` tries again `RestartSec` later.

The retries burn `StartLimitBurst` (5 in 10s against `RestartSec=2`). Tripping it leaves the unit `failed`, and a failed unit means the next suspend gets no lock at all.

## Evidence

Two suspends on the same machine eight minutes apart, packaged monitor vs. patched, via an RTC alarm and `systemctl suspend`:

```
STOCK    20:01:12  Started
         20:01:12  systemd-inhibit: Failed to inhibit: The operation inhibition
                                    has been requested for is already running
         20:01:12  Main process exited, code=exited, status=1/FAILURE
         20:01:13  logind: Operation 'suspend' finished.
         20:01:14  Scheduled restart job, restart counter is at 2.

PATCHED  19:54:06  Started
         19:54:07  logind: Operation 'suspend' finished.
                   (waited the operation out, no inhibit failure)
```

Both restarts landed mid-operation; only the unpatched one grabbed for the inhibitor and was refused.

Scale caveat, stated plainly: that was a 25-second suspend, so logind's post-resume window was about a second and only one restart was wasted — the unit recovered on its own. The run demonstrates the mechanism, not user-visible breakage. The severe case comes from a real resume after ~11h of S3 on a hybrid-GPU laptop, where the window stayed open long enough for **six** restarts against a burst limit of five. That one recovered too, but only just.

## The fix

Poll logind's `PreparingForSleep` and wait the operation out before taking the inhibitor, with a 30s cap as a backstop against a stuck property. The wait only ever spans the tail of a resume.

## Test plan

- [x] `test/shell.d/sleep-monitor-test.sh` — new case mocks `busctl` returning `true` twice then `false` and asserts the monitor inhibits only after the property clears. Verified it fails on the unpatched tree ("inhibited after 0 checks").
- [x] Full `./test/all` — `test/shell.d/bin-style-test.sh` fails, but identically on the base commit; it is `bin/omarchy-remove-ai-openclaw` using `command -v`, unrelated to this change.
- [x] A/B on hardware as above.

## Relationship to other open PRs

Independent of #10394 and #10279 — neither touches `PreparingForSleep`, and this changes a different part of the file. #10279 merges cleanly with this branch. #10394 conflicts in `test/shell.d/sleep-monitor-test.sh` only, because it renames the `dbus-monitor` mock to `gdbus`; whichever lands second needs that mock renamed in the new test case. Happy to rebase on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p9Qh6dX4FuwBJAWhNPVbn
