### PR TITLE
Treat app word prefixes as label prefixes in menu search

### DIFF
--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -312,6 +312,15 @@ function termInSearchWords(term, text) {
   return false
 }
 
+function termPrefixesWord(term, text) {
+  if (!term) return false
+  var words = String(text || "").toLowerCase().split(/\s+/)
+  for (var i = 0; i < words.length; i++) {
+    if (words[i].indexOf(term) === 0) return true
+  }
+  return false
+}
+
 function descriptionTextMatches(query, text) {
   var terms = String(query || "").toLowerCase().trim().split(/\s+/)
   for (var i = 0; i < terms.length; i++) {
@@ -350,6 +359,9 @@ function searchScore(items, entry, query) {
   // for Zen Browser) beats exact-labeled menu entries like Install > Zen.
   else if (entry.kind === "app" && label.split(/\s+/).indexOf(needle) >= 0) score = 0
   else if (label.indexOf(needle) === 0) score = 10
+  // "chro" in "Google Chrome" is a word prefix, not a label prefix, so it
+  // would otherwise score as a contains-match and lose to Setup > Chrome.
+  else if (entry.kind === "app" && termPrefixesWord(needle, label)) score = 10
   else if (label.indexOf(needle) >= 0) score = 30
   else if (nameText.indexOf(needle) >= 0) score = 40
   else if (descriptionTextMatches(needle, descriptionText)) score = 60

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -136,7 +136,8 @@ const rankBase = menu.mergeMenuSources(defaultItems, [])
 const ranked = menu.mergeAppRows(rankBase.items, rankBase.itemOrder, [
   { id: 'apps.brave', parent: 'apps', kind: 'app', label: 'Brave', description: '', aliases: [] },
   { id: 'apps.fontforge', parent: 'apps', kind: 'app', label: 'FontForge', description: '', aliases: [] },
-  { id: 'apps.zen', parent: 'apps', kind: 'app', label: 'Zen Browser', description: '', aliases: [] }
+  { id: 'apps.zen', parent: 'apps', kind: 'app', label: 'Zen Browser', description: '', aliases: [] },
+  { id: 'apps.chrome', parent: 'apps', kind: 'app', label: 'Google Chrome', description: '', aliases: [] }
 ])
 const rankScore = (id, query) => menu.searchScore(ranked.items, ranked.items[id], query)
 assert(
@@ -150,6 +151,12 @@ assert(
     id => rankScore('apps.zen', 'zen') < rankScore(id, 'zen')
   ),
   'menu ranks an app matching the query as a whole word above exact-labeled menu entries'
+)
+assert(
+  ['install.browser.chrome', 'remove.browser.chrome', 'setup.default.browser.chrome'].every(
+    id => rankScore('apps.chrome', 'chro') < rankScore(id, 'chro')
+  ),
+  'menu ranks an app whose later name-word the query prefixes above a settings leaf with the same prefix'
 )
 assert(
   rankScore('style.font', 'font') < rankScore('apps.fontforge', 'font'),


### PR DESCRIPTION
## Problem

`chro` is a prefix of Setup › Browser › Chrome (score 10) but only a contains-match inside "Google Chrome" (score 30). Enter changes the default browser instead of launching the app.

## Fix

Score a prefix of any word in an app name as a label prefix. The existing app tiebreak (`score -= 5`) then wins the equal-prefix case. Exact menu matches stay put — Font still beats FontForge.

Fixes #10340

### Before

First hit is Setup › Defaults › Browser. Enter changes the default.

<img width="480" height="720" alt="before" src="https://github.com/user-attachments/assets/559f488e-019e-4fb3-b673-6b3f8829c060" />


### After

First hit is Google Chrome. Enter launches the app.

<img width="480" height="720" alt="after" src="https://github.com/user-attachments/assets/feeb81d9-6155-4143-807b-11d51afaddcf" />


## Tests

`test/shell.d/menu-test.sh` — `chro` on Google Chrome now outranks Setup/Install/Remove › Chrome. Brave, Zen, and FontForge ranking assertions still pass.