### PR TITLE
Enable speakers on Late 2015 21.5-inch iMacs

### DIFF
--- a/bin/omarchy-hw-imac-cs4208
+++ b/bin/omarchy-hw-imac-cs4208
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# omarchy:summary=Detect Late 2015 21.5-inch iMacs whose CS4208 speakers need Analog Surround 4.0.
+
+product_name="${OMARCHY_DMI_PRODUCT_NAME:-/sys/class/dmi/id/product_name}"
+
+grep -Eqix 'iMac16,[12]' "$product_name" 2>/dev/null

--- a/default/wireplumber/wireplumber.conf.d/imac-cs4208-speakers.conf
+++ b/default/wireplumber/wireplumber.conf.d/imac-cs4208-speakers.conf
@@ -1,0 +1,54 @@
+# Late 2015 21.5-inch iMac (iMac16,1 / iMac16,2): the built-in speakers are
+# four digital CS4208 channels (left/right tweeter + woofer). Analog Stereo
+# is the headphone DAC and is silent on those speakers. Master hardware
+# volume also does not affect the digital path, so the output slider would
+# move with no audible change unless software volume is used.
+#
+# HDMI on these machines is the internal display audio device and shows as
+# available even though it does not drive the speakers.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        alsa.mixer_name = "Cirrus Logic CS4208"
+      }
+    ]
+    actions = {
+      update-props = {
+        device.profile = "output:analog-surround-40+input:analog-stereo"
+        api.alsa.soft-mixer = true
+      }
+    }
+  }
+  {
+    matches = [
+      {
+        node.name = "~alsa_output.*hdmi.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        priority.session = 200
+      }
+    }
+  }
+]
+
+device.profile.priority.rules = [
+  {
+    matches = [
+      {
+        alsa.mixer_name = "Cirrus Logic CS4208"
+      }
+    ]
+    actions = {
+      update-props = {
+        priorities = [
+          "output:analog-surround-40+input:analog-stereo"
+          "output:analog-surround-40"
+        ]
+      }
+    }
+  }
+]

--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -6,6 +6,7 @@ run_logged "$OMARCHY_INSTALL/user/mise-work.sh"
 
 run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-audio-mixer.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-mic.sh"
+run_logged "$OMARCHY_INSTALL/user/hardware/apple/fix-imac-cs4208-speakers.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/framework/fix-f13-amd-audio-input.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps13-text-scaling.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/fix-nouveau-cursor.sh"

--- a/install/user/hardware/apple/fix-imac-cs4208-speakers.sh
+++ b/install/user/hardware/apple/fix-imac-cs4208-speakers.sh
@@ -1,0 +1,17 @@
+# Late 2015 21.5-inch iMacs (iMac16,1 / iMac16,2) drive the built-in speakers
+# as four digital CS4208 channels. Analog Stereo is the headphone DAC and is
+# silent on those speakers, and Master hardware volume does not affect them.
+
+if omarchy-hw-imac-cs4208; then
+  mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
+  cp "$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/imac-cs4208-speakers.conf" \
+    ~/.config/wireplumber/wireplumber.conf.d/
+  rm -rf ~/.local/state/wireplumber/default-routes
+
+  # Leave the hardware mixer wide open so software volume is the only attenuation.
+  card=$(aplay -l 2>/dev/null | grep -i "CS4208 Analog" | head -1 | sed 's/card \([0-9]*\).*/\1/')
+  if [[ -n $card ]]; then
+    amixer -c "$card" set Master 100% unmute 2>/dev/null || true
+    amixer -c "$card" set PCM 100% 2>/dev/null || true
+  fi
+fi

--- a/manual/45-troubleshooting.md
+++ b/manual/45-troubleshooting.md
@@ -30,6 +30,10 @@ Before you reboot, try restarting the offending subsystem on its own. _Update > 
 
 Probably because they're not set as the primary output. Click on the speaker icon on the right side of the bar, and it'll open the volume popup where you can pick the output device (and mix per-app volumes too).
 
+### No sound from the built-in speakers on a Late 2015 21.5-inch iMac
+
+Those machines (iMac16,1 and iMac16,2) drive four digital speaker channels on the CS4208 codec. Analog Stereo is the headphone DAC, and HDMI is the internal display — both look like valid outputs but stay silent. Omarchy selects Analog Surround 4.0 and software volume automatically. If you still hear nothing, pick Analog Surround 4.0 in the volume popup rather than Analog Stereo or HDMI.
+
 ### My laptop speakers sound off
 
 On some laptops, Omarchy automatically applies a speaker tuning that corrects the built-in speakers' frequency response. `omarchy audio tuning status` tells you whether one is active on your machine, and `omarchy audio tuning off` turns it off if you'd rather hear the speakers raw.

--- a/migrations/1788673159.sh
+++ b/migrations/1788673159.sh
@@ -1,0 +1,4 @@
+echo "Select Analog Surround 4.0 and software volume on Late 2015 21.5-inch iMacs"
+
+# The install-time quirk only reaches machines set up after it shipped.
+source "$OMARCHY_PATH/install/user/hardware/apple/fix-imac-cs4208-speakers.sh"

--- a/test/shell.d/imac-cs4208-speakers-test.sh
+++ b/test/shell.d/imac-cs4208-speakers-test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+detector="$ROOT/bin/omarchy-hw-imac-cs4208"
+leaf="$ROOT/install/user/hardware/apple/fix-imac-cs4208-speakers.sh"
+all="$ROOT/install/user/all.sh"
+conf="$ROOT/default/wireplumber/wireplumber.conf.d/imac-cs4208-speakers.conf"
+migration=$(grep -l "fix-imac-cs4208-speakers" "$ROOT"/migrations/*.sh | head -1)
+
+[[ -x $detector ]] || fail "the detector is executable"
+pass "the detector is executable"
+
+grep -q 'run_logged .*hardware/apple/fix-imac-cs4208-speakers.sh' "$all" ||
+  fail "the CS4208 speaker workaround runs during user setup"
+pass "the CS4208 speaker workaround runs during user setup"
+
+[[ -n $migration ]] || fail "a migration enables the workaround on existing installs"
+pass "a migration enables the workaround on existing installs"
+
+grep -q 'output:analog-surround-40+input:analog-stereo' "$conf" ||
+  fail "the WirePlumber drop-in selects Analog Surround 4.0"
+grep -q 'api.alsa.soft-mixer = true' "$conf" ||
+  fail "the WirePlumber drop-in uses software volume"
+grep -q 'alsa.mixer_name = "Cirrus Logic CS4208"' "$conf" ||
+  fail "the WirePlumber drop-in matches the CS4208 mixer, not a PCI path"
+! grep -q '0000_00_1b.0' "$conf" ||
+  fail "the WirePlumber drop-in does not hard-code a PCI device path"
+pass "the WirePlumber drop-in selects 4.0 output and software volume on CS4208"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+run_detector() {
+  local name_file="$test_tmp/product_name"
+  printf '%s\n' "$1" >"$name_file"
+  OMARCHY_DMI_PRODUCT_NAME="$name_file" bash "$detector"
+}
+
+run_detector "iMac16,2" || fail "the detector matches iMac16,2"
+pass "the detector matches iMac16,2"
+
+run_detector "iMac16,1" || fail "the detector matches iMac16,1"
+pass "the detector matches iMac16,1"
+
+run_detector "imac16,2" || fail "the detector matches iMac16,2 case-insensitively"
+pass "the detector matches iMac16,2 case-insensitively"
+
+run_detector "iMac17,1" && fail "the detector rejects iMac17,1"
+pass "the detector rejects iMac17,1"
+
+run_detector "iMac18,3" && fail "the detector rejects later CS8409 iMacs"
+pass "the detector rejects later CS8409 iMacs"
+
+run_detector "MacBookPro12,1" && fail "the detector rejects other Apple machines"
+pass "the detector rejects other Apple machines"
+
+run_detector "iMac16,20" && fail "the detector rejects a longer product name"
+pass "the detector rejects a longer product name"
+
+run_detector "" && fail "the detector fails closed on an empty product name"
+pass "the detector fails closed on an empty product name"
+
+OMARCHY_DMI_PRODUCT_NAME="$test_tmp/absent" bash "$detector" &&
+  fail "the detector fails closed when the DMI attribute is missing"
+pass "the detector fails closed when the DMI attribute is missing"
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/omarchy-hw-imac-cs4208" <<'SH'
+#!/bin/bash
+[[ ${TEST_PRODUCT_NAME:-} == iMac16,1 || ${TEST_PRODUCT_NAME:-} == iMac16,2 ]]
+SH
+
+cat >"$stub_bin/aplay" <<'SH'
+#!/bin/bash
+printf '%s\n' 'card 1: PCH [HDA Intel PCH], device 0: CS4208 Analog [CS4208 Analog]'
+SH
+
+cat >"$stub_bin/amixer" <<'SH'
+#!/bin/bash
+printf 'amixer' >>"$CALL_LOG"
+printf '\t%s' "$@" >>"$CALL_LOG"
+printf '\n' >>"$CALL_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local home="$test_tmp/home"
+  rm -rf "$home"
+  mkdir -p "$home"
+  : >"$test_tmp/calls.log"
+  HOME="$home" \
+    PATH="$stub_bin:$PATH" \
+    OMARCHY_PATH="$ROOT" \
+    CALL_LOG="$test_tmp/calls.log" \
+    TEST_PRODUCT_NAME="${1-iMac16,2}" \
+    bash -c 'source "$1"' bash "$leaf"
+}
+
+run_leaf || fail "the leaf installs the WirePlumber drop-in on the target machine"
+[[ -f $test_tmp/home/.config/wireplumber/wireplumber.conf.d/imac-cs4208-speakers.conf ]] ||
+  fail "the leaf installs the WirePlumber drop-in on the target machine"
+grep -q $'amixer\t-c\t1\tset\tMaster\t100%\tunmute' "$test_tmp/calls.log" ||
+  fail "the leaf opens the CS4208 Master mixer"
+pass "the leaf installs the WirePlumber drop-in on the target machine"
+
+run_leaf "ThinkPad X1" || fail "the leaf no-ops on other hardware"
+[[ -e $test_tmp/home/.config/wireplumber/wireplumber.conf.d/imac-cs4208-speakers.conf ]] &&
+  fail "the leaf no-ops on other hardware"
+[[ -s $test_tmp/calls.log ]] && fail "the leaf no-ops on other hardware"
+pass "the leaf no-ops on other hardware"
+
+run_migration() {
+  local home="$test_tmp/home"
+  rm -rf "$home"
+  mkdir -p "$home"
+  : >"$test_tmp/calls.log"
+  HOME="$home" \
+    PATH="$stub_bin:$PATH" \
+    OMARCHY_PATH="$ROOT" \
+    CALL_LOG="$test_tmp/calls.log" \
+    TEST_PRODUCT_NAME="${1-iMac16,2}" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration || fail "the migration installs the workaround on the target machine"
+[[ -f $test_tmp/home/.config/wireplumber/wireplumber.conf.d/imac-cs4208-speakers.conf ]] ||
+  fail "the migration installs the workaround on the target machine"
+pass "the migration installs the workaround on the target machine"
+
+run_migration "ThinkPad X1" || fail "the migration no-ops on other hardware"
+[[ -e $test_tmp/home/.config/wireplumber/wireplumber.conf.d/imac-cs4208-speakers.conf ]] &&
+  fail "the migration no-ops on other hardware"
+pass "the migration no-ops on other hardware"


### PR DESCRIPTION
## Summary

Late 2015 21.5-inch iMacs (`iMac16,1` / `iMac16,2`) drive four digital CS4208 speaker channels. Analog Stereo is the headphone DAC and HDMI is the internal display, so both look like valid outputs while the speakers stay silent. Master hardware volume also does not change speaker loudness, so the Omarchy output slider moves with no audible change.

This installs a DMI-gated WirePlumber drop-in that:
- selects Analog Surround 4.0 on the CS4208 card
- uses software volume (`api.alsa.soft-mixer`)
- deprioritizes HDMI so it does not steal the default sink

Same shape as the ASUS ROG audio mixer quirk. Does not overlap with the CS8409 DKMS work for 2016–2019 Macs.

## Hardware

Verified on **iMac16,2** (Cirrus Logic CS4208, codec subsystem `0x106b8100`) on linux 7.1.9 / Omarchy 4.0.2: YouTube silent on Analog Stereo and HDMI, plays on Analog Surround 4.0; system volume slider works after software volume.

## Test plan

- `bash test/shell.d/imac-cs4208-speakers-test.sh`
- `./test/cli`
- On iMac16,1 or iMac16,2: install / migrate → `omarchy restart audio` → speakers play, output slider changes loudness
- Other hardware: hook and migration no-op