### PR TITLE
Use the command helper in the AI app removers

### DIFF
--- a/bin/omarchy-remove-ai-hermes
+++ b/bin/omarchy-remove-ai-hermes
@@ -73,7 +73,7 @@ fi
 # never owned, a yes takes that with it, and saying so is the prompt's job.
 # Without a terminal to ask in, keeping everything is the answer.
 data_removed=false
-if [[ -d $HOME/.hermes || -d $HOME/.config/Hermes ]] && [[ -t 0 ]] && command -v gum >/dev/null; then
+if [[ -d $HOME/.hermes || -d $HOME/.config/Hermes ]] && [[ -t 0 ]] && omarchy-cmd-present gum; then
   # du answers non-zero when either directory is missing, and pipefail would
   # turn that into an aborted removal; the size is worth no such thing.
   size=$(du -shc "$HOME/.hermes" "$HOME/.config/Hermes" 2>/dev/null | tail -1 | cut -f1 || true)

--- a/bin/omarchy-remove-ai-openclaw
+++ b/bin/omarchy-remove-ai-openclaw
@@ -61,7 +61,7 @@ gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
 # front of the user with the size rather than left silent. Without a terminal
 # to ask in, keeping it is the answer.
 state_removed=false
-if [[ -d $HOME/.openclaw && -t 0 ]] && command -v gum >/dev/null; then
+if [[ -d $HOME/.openclaw && -t 0 ]] && omarchy-cmd-present gum; then
   size=$(du -sh "$HOME/.openclaw" 2>/dev/null | cut -f1)
   if gum confirm --default=false "Also delete ~/.openclaw ($size: chats, memories, credentials, and downloaded plugins)?"; then
     rm -rf "$HOME/.openclaw"


### PR DESCRIPTION
`test/shell.d/bin-style-test.sh` currently fails on `quattro`. The OpenClaw remover checks for `gum` with a raw `command -v`, which the style rule reserves for the helpers themselves:

```
$ ./test/all
bin/omarchy-remove-ai-openclaw
not ok - bin commands use command helpers
```

The Hermes remover does the same thing. That one is invisible until the first is fixed, because the test reports only the first offending file — so fixing OpenClaw alone just moves the failure along to the next.

Both now use `omarchy-cmd-present`, matching the rest of `bin/`.

## Test plan

- [x] `./test/all` — **226/226 files pass**. Before this change, `bin-style-test.sh` failed and the suite reported 1 of 226 failing.
- [x] `rg -l 'command -v' bin/ | rg -v '/omarchy-(cmd-|pkg-|upgrade-to-quattro)'` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p9Qh6dX4FuwBJAWhNPVbn
