### PR TITLE
Wake the panel when a laptop-only lid opens

### DIFF
--- a/bin/omarchy-system-lid-open
+++ b/bin/omarchy-system-lid-open
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Reconcile displays and wake the panel when the laptop lid opens
+# omarchy:group=system
+# omarchy:hidden=true
+
+# Reconcile first, exactly as the lid-open binding has always done.
+omarchy-hyprland-monitor-clamshell
+
+# The reconciler only dispatches a DPMS enable when it has just cleared a
+# clamshell flag, and that flag is never written on a laptop with no external
+# monitor. A laptop-only lid open therefore had no path back from the lock
+# screen's idle blank: the panel stayed dark until a keypress reached the
+# password field, and logind swallows the power button, so reaching for that
+# instead makes a working machine look hung.
+#
+# omarchy-brightness-display on already skips its dispatch while every enabled
+# monitor reports dpmsStatus true, so a lid open that never blanked stays a
+# no-op and no display is forced through a second modeset.
+omarchy-brightness-display on

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -32,7 +32,7 @@ o.bind_toggle("SUPER + CTRL + N", "Toggle nightlight", "nightlight")
 o.bind("SUPER + CTRL + Delete", "Toggle laptop display", "omarchy-hyprland-monitor-internal toggle")
 o.bind("SUPER + CTRL + ALT + Delete", "Toggle laptop display mirroring", "omarchy-hyprland-monitor-internal-mirror toggle")
 o.bind("switch:on:Lid Switch", nil, "omarchy-system-lid-close", { locked = true })
-o.bind("switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell", { locked = true })
+o.bind("switch:off:Lid Switch", nil, "omarchy-system-lid-open", { locked = true })
 
 o.bind("PRINT", "Screenshot", "omarchy-capture-screenshot")
 o.bind("ALT + PRINT", "Screenrecording", "omarchy-capture-screenrecording --stop-recording || omarchy-menu toggle trigger.capture.screenrecord")

--- a/test/shell.d/lid-open-test.sh
+++ b/test/shell.d/lid-open-test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+lid_open="$ROOT/bin/omarchy-system-lid-open"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mock_bin="$tmpdir/bin"
+call_log="$tmpdir/calls"
+mkdir -p "$mock_bin"
+: >"$call_log"
+
+for command in omarchy-hyprland-monitor-clamshell omarchy-brightness-display; do
+  cat >"$mock_bin/$command" <<SH
+#!/bin/bash
+echo "$command \$*" >>"\$CALL_LOG"
+SH
+done
+chmod +x "$mock_bin"/*
+
+CALL_LOG="$call_log" PATH="$mock_bin:$PATH" "$lid_open"
+mapfile -t calls <"$call_log"
+
+# The reconciler settles which outputs exist before anything asks the
+# compositor to light them, which is the order the binding has always used.
+[[ ${calls[0]:-} == "omarchy-hyprland-monitor-clamshell " ]] ||
+  fail "lid open reconciles displays first" "first call was ${calls[0]:-none}"
+pass "lid open reconciles displays first"
+
+# Without this the laptop-only case has no path from the lock screen's idle
+# blank back to a lit panel: the reconciler dispatches a DPMS enable only when
+# it has just cleared a clamshell flag, and no such flag is ever written when
+# there is no external monitor to go clamshell with.
+[[ ${calls[1]:-} == "omarchy-brightness-display on" ]] ||
+  fail "lid open wakes the panel" "second call was ${calls[1]:-none}"
+pass "lid open wakes the panel"
+
+(( ${#calls[@]} == 2 )) ||
+  fail "lid open does no more than reconcile and wake" "${#calls[@]} calls"
+pass "lid open does no more than reconcile and wake"

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -98,7 +98,7 @@ grep -F 'omarchy-hyprland-monitor-external-active' "$monitor_mirror" >/dev/null
 pass "internal mirror helper recovers when no active external display remains"
 
 grep -F 'switch:on:Lid Switch", nil, "omarchy-system-lid-close"' "$utilities" >/dev/null
-grep -F 'switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell"' "$utilities" >/dev/null
+grep -F 'switch:off:Lid Switch", nil, "omarchy-system-lid-open"' "$utilities" >/dev/null
 pass "lid switch bindings lock on close and reconcile clamshell display state"
 
 grep -F 'omarchy-hyprland-monitor-clamshell >/dev/null 2>&1 || true' "$system_wake" >/dev/null


### PR DESCRIPTION
Fixes the gap reported in #10170, whose analysis this follows.

The lid-open binding runs `omarchy-hyprland-monitor-clamshell`. That reconciler dispatches a DPMS enable only from `enable_internal()`, behind `if (( changed ))` — true only when a clamshell flag file was just removed. **The flag is never written when there is no external monitor**, so on a laptop-only machine the reconciler runs and dispatches nothing.

Meanwhile `lock/Service.qml`'s `idleBlankTimer` blanks the panel five seconds after a lid-close lock. So a laptop-only lid resume returns to a dark screen with no path back. Only `Keys.onPressed` on the lock screen's password field reaches `omarchy-system-wake`, and logind swallows the power button (`10-ignore-power-button.conf`) — so the machine looks hung to anyone who reaches for the power button rather than typing.

## The fix

Bind lid open to `omarchy-system-lid-open`, mirroring the existing `omarchy-system-lid-close`: reconcile first, exactly as before, then wake.

The wake had to stay a no-op when nothing is dark — `omarchy-hyprland-monitor-internal`'s `recover()` warns that an unconditional wake "undoes lock-screen blanking and races the resume modeset into a visible flash", and the clamshell watcher polls the reconciler every few seconds. Two things keep that true here: the wake sits on a lid-switch **event** rather than in the polled reconciler, and `omarchy-brightness-display on` already exits early while every enabled monitor reports `dpmsStatus` true.

## Test plan

- [x] New `test/shell.d/lid-open-test.sh` asserts the handler reconciles first, then wakes, and does nothing else. Verified non-vacuous — dropping the wake line fails it with "second call was none".
- [x] `test/shell.d/monitor-recovery-test.sh` updated for the new binding.
- [x] `./test/all` — the only failure is `bin-style-test.sh`, which fails identically on the base commit (raw `command -v` in the AI app removers, fixed separately in #10460).
- [x] Hardware A/B on a laptop-only machine (Intel CometLake-H + NVIDIA hybrid, `eDP-1` only, deep S3), blanking the panel exactly as the lock screen does:

```
blanked (as after lid-close lock): [{"name":"eDP-1","dpmsStatus":false}]
after omarchy-system-lid-open   : [{"name":"eDP-1","dpmsStatus":true}]

blanked again                   : [{"name":"eDP-1","dpmsStatus":false}]
after monitor-clamshell alone   : [{"name":"eDP-1","dpmsStatus":false}]   <- current binding
```

Scope note: this machine hit a dark panel on an 11-hour lid-closed resume (lid closed 19:07:14, opened 06:32:06, no external monitor), which is what led here. The structural gap above is confirmed and fixed. I can't prove it was the *only* cause of that particular incident — one observation from it recorded `dpmsStatus: 1` while the panel was dark, and I can't now reconstruct whether that reading was taken before or after a manual `dpms enable`. If a compositor-vs-hardware desync also exists on this hardware, it is a separate bug and this does not address it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p9Qh6dX4FuwBJAWhNPVbn
