### PR TITLE
Fix display backlight on Lenovo Yoga Pro 7 15IPH11

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -24,9 +24,32 @@ while (( $# > 0 )); do
   esac
 done
 
+backlight_cap_value() {
+  local cap_file="${OMARCHY_BACKLIGHT_CAP_FILE:-/etc/omarchy/backlight-cap}"
+  if [[ -f $cap_file ]]; then
+    local cap
+    cap=$(< "$cap_file")
+    if [[ $cap =~ ^[0-9]+$ ]] && (( cap > 0 )); then
+      printf '%s\n' "$cap"
+      return 0
+    fi
+  fi
+  return 1
+}
+
 # Get the brightness of the passed display
 backlight_brightness() {
-  brightnessctl -d "$1" -m 2>/dev/null | awk -F, '{ gsub("%", "", $4); print $4; found=1 } END{ exit !found }'
+  local device="$1"
+  local cap
+  if cap="$(backlight_cap_value)"; then
+    local raw
+    raw="$(brightnessctl -d "$device" get 2>/dev/null)" || return 1
+    (( raw > cap )) && raw=$cap
+    printf '%s\n' "$(( (raw * 100 + cap / 2) / cap ))"
+    return 0
+  fi
+
+  brightnessctl -d "$device" -m 2>/dev/null | awk -F, '{ gsub("%", "", $4); print $4; found=1 } END{ exit !found }'
 }
 
 [[ -n $monitor ]] || monitor="$(omarchy-hyprland-monitor-focused 2>/dev/null || true)"
@@ -112,6 +135,16 @@ else
 
     (( target < 1 )) && target=1
     step="$target%"
+  fi
+
+  if cap="$(backlight_cap_value)"; then
+    if [[ $step =~ ^([0-9]+)%$ ]]; then
+      pct="${BASH_REMATCH[1]}"
+      (( pct > 100 )) && pct=100
+      raw=$(( (pct * cap + 50) / 100 ))
+      (( raw > cap )) && raw=$cap
+      step="$raw"
+    fi
   fi
 
   # Set brightness of the display device.

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -41,6 +41,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
+run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-display-backlight.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/fix-bcm43xx.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-surface-keyboard.sh"

--- a/install/hardware/lenovo/fix-yoga-pro7-display-backlight.sh
+++ b/install/hardware/lenovo/fix-yoga-pro7-display-backlight.sh
@@ -1,0 +1,20 @@
+# Display backlight fix for Lenovo Yoga Pro 7 15IPH11 (Panther Lake / Xe3 iGPU).
+#
+# Lenovo's VBT specifies PWM backlight control, but the OLED panel
+# (EDO EF25QBA63.B) uses DPCD AUX backlight over eDP. Without
+# xe.enable_dpcd_backlight=1, brightness controls have no effect.
+#
+# Additionally, the OLED panel's 9-bit DPCD register overflows when written
+# with max_brightness=512, dropping the screen to minimum brightness at 100%.
+# Capping maximum brightness at 500 prevents the register overflow.
+
+if omarchy-hw-match "83SN" || omarchy-hw-match "Yoga Pro 7 15IPH11"; then
+  sudo mkdir -p /etc/limine-entry-tool.d
+  sudo tee /etc/limine-entry-tool.d/lenovo-yoga-pro7-display-backlight.conf >/dev/null <<'EOF'
+# Lenovo Yoga Pro 7 15IPH11 display backlight fix
+KERNEL_CMDLINE[default]+=" xe.enable_dpcd_backlight=1"
+EOF
+
+  sudo mkdir -p /etc/omarchy
+  echo "500" | sudo tee /etc/omarchy/backlight-cap >/dev/null
+fi

--- a/test/shell.d/brightness-display-test.sh
+++ b/test/shell.d/brightness-display-test.sh
@@ -32,6 +32,8 @@ cat >"$mock_bin/brightnessctl" <<'SH'
 printf 'brightnessctl %s\n' "$*" >>"$CALL_LOG"
 if [[ $* == *" -m"* ]]; then
   printf 'mock_backlight,backlight,40,40%%\n'
+elif [[ $* == *" get"* ]]; then
+  printf '%s\n' "${MOCK_BRIGHTNESS:-250}"
 fi
 SH
 
@@ -144,3 +146,20 @@ if PATH="$mock_bin:$PATH" "$ROOT/bin/omarchy-hyprland-monitor-focused-apple"; th
   fail "focused non-Apple display is not detected as Apple"
 fi
 pass "named Apple display is detected independently of focus"
+
+cap_file="$test_tmp/backlight-cap"
+printf '500\n' >"$cap_file"
+
+brightness=$(OMARCHY_BACKLIGHT_CAP_FILE="$cap_file" MOCK_BRIGHTNESS=250 run_brightness --monitor eDP-1)
+[[ $brightness == "50" ]] || fail "internal monitor brightness scales against cap" "actual: $brightness"
+pass "internal monitor brightness scales against cap"
+
+OMARCHY_BACKLIGHT_CAP_FILE="$cap_file" MOCK_BRIGHTNESS=250 run_brightness --no-osd --monitor eDP-1 100%
+grep -F 'brightnessctl -d mock_backlight set 500' "$call_log" >/dev/null || \
+  fail "100% brightness is scaled to the configured cap"
+pass "100% brightness is scaled to the configured cap"
+
+OMARCHY_BACKLIGHT_CAP_FILE="$cap_file" MOCK_BRIGHTNESS=250 run_brightness --no-osd --monitor eDP-1 50%
+grep -F 'brightnessctl -d mock_backlight set 250' "$call_log" >/dev/null || \
+  fail "50% brightness is scaled to half of the configured cap"
+pass "50% brightness is scaled to half of the configured cap"


### PR DESCRIPTION
## Summary
Fixes internal display backlight control on the Lenovo Yoga Pro 7 15IPH11 (`83SN`, Intel Core Ultra Panther Lake / Xe3 iGPU with OLED display).

## Problem
1. **No Backlight Control**: The laptop's VBT specifies PWM backlight control, but the OLED panel (`EDO EF25QBA63.B`) uses DPCD AUX backlight over eDP. Without `xe.enable_dpcd_backlight=1`, writes to `intel_backlight` sysfs nodes succeed but have no visible effect on screen brightness.
2. **100% Brightness Drop (Register Overflow)**: When DPCD AUX backlight is enabled, the `xe` driver reports `max_brightness=512`. Writing `512` (`0x200`) overflows the 9-bit DPCD register (`0x000`–`0x1FF`), causing the OLED panel to wrap around to 0 (minimum brightness) when setting 100% brightness.

## Solution
1. Add `install/hardware/lenovo/fix-yoga-pro7-display-backlight.sh` matching `83SN` / `Yoga Pro 7 15IPH11`:
   - Adds `xe.enable_dpcd_backlight=1` via `/etc/limine-entry-tool.d/lenovo-yoga-pro7-display-backlight.conf`.
   - Writes `500` to `/etc/omarchy/backlight-cap`.
2. Add support for `/etc/omarchy/backlight-cap` in `bin/omarchy-brightness-display` (with `OMARCHY_BACKLIGHT_CAP_FILE` test override) to scale 0–100% to the hardware-safe range.
3. Add unit tests in `test/shell.d/brightness-display-test.sh` covering the cap scaling logic.

## Verification
- Verified live on Lenovo Yoga Pro 7 15IPH11 (`83SN`).
- Ran `./test/cli` and `./test/shell.d/brightness-display-test.sh` (all tests pass).