### PR TITLE
Cap the screensaver frame rate and make it configurable

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -49,25 +49,28 @@ wait_for_screensaver_window() {
   done
 }
 
-for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
+# Each window learns its monitor's refresh rate so omarchy-screensaver never asks ttfx for frames the panel cannot display. 
+# The terminal rasterizes every frame on the CPU at native resolution, so wasted frames are wasted cores.
+
+while read -r m refresh_rate; do
   hypr_focus_monitor "$m"
 
   case $terminal in
   *Alacritty*)
-    hypr_exec alacritty --class=org.omarchy.screensaver --config-file "$OMARCHY_PATH/default/alacritty/screensaver.toml" -e omarchy-screensaver
+    hypr_exec env OMARCHY_SCREENSAVER_MAX_FRAME_RATE="$refresh_rate" alacritty --class=org.omarchy.screensaver --config-file "$OMARCHY_PATH/default/alacritty/screensaver.toml" -e omarchy-screensaver
     ;;
   *ghostty*)
-    hypr_exec ghostty --class=org.omarchy.screensaver --config-file="$OMARCHY_PATH/default/ghostty/screensaver" --font-size=18 -e omarchy-screensaver
+    hypr_exec env OMARCHY_SCREENSAVER_MAX_FRAME_RATE="$refresh_rate" ghostty --class=org.omarchy.screensaver --config-file="$OMARCHY_PATH/default/ghostty/screensaver" --font-size=18 -e omarchy-screensaver
     ;;
   *foot*)
-    hypr_exec foot --app-id=org.omarchy.screensaver --config="$OMARCHY_PATH/default/foot/screensaver.ini" -e omarchy-screensaver
+    hypr_exec env OMARCHY_SCREENSAVER_MAX_FRAME_RATE="$refresh_rate" foot --app-id=org.omarchy.screensaver --config="$OMARCHY_PATH/default/foot/screensaver.ini" -e omarchy-screensaver
     ;;
   *kitty*)
-    hypr_exec kitty --class=org.omarchy.screensaver --override font_size=18 --override window_padding_width=0 -e omarchy-screensaver
+    hypr_exec env OMARCHY_SCREENSAVER_MAX_FRAME_RATE="$refresh_rate" kitty --class=org.omarchy.screensaver --override font_size=18 --override window_padding_width=0 -e omarchy-screensaver
     ;;
   esac
 
   wait_for_screensaver_window
-done
+done < <(hyprctl monitors -j | jq -r '.[] | "\(.name) \(.refreshRate // 0)"')
 
 hypr_focus_monitor "$focused"

--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -35,9 +35,15 @@ wait_for_terminal_resize() {
 
 wait_for_terminal_resize
 
+
+# Every frame is rasterized by the terminal at native panel resolution, so the frame rate decides how many CPU cores a HiDPI panel burns. 
+# The launcher sets OMARCHY_SCREENSAVER_MAX_FRAME_RATE to this monitor's refresh rate.
+
+frame_rate=$(omarchy-screensaver-frame-rate "${OMARCHY_SCREENSAVER_MAX_FRAME_RATE:-}")
+
 while true; do
   ttfx -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
+    --frame-rate "$frame_rate" --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
     --random-effect --no-eol --no-restore-cursor &
 
   while pgrep -t "${tty#/dev/}" -x ttfx >/dev/null; do

--- a/bin/omarchy-screensaver-frame-rate
+++ b/bin/omarchy-screensaver-frame-rate
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# omarchy:summary=Print the screensaver frame rate from shell.json, capped to a monitor refresh rate when one is given.
+# omarchy:args=[max-frame-rate]
+# omarchy:hidden=true
+
+# The screensaver terminal (foot by default) rasterizes every frame on the CPU
+# at native panel resolution, so the frame rate is the main knob on how much a
+# HiDPI panel costs. Users tune it with idle.screensaverFrameRate in shell.json;
+# the launcher passes each monitor's refresh rate so no frame is generated that
+# the panel can never display.
+
+default_frame_rate=60
+
+config_file="$HOME/.config/omarchy/shell.json"
+[[ -s $config_file ]] || config_file="$OMARCHY_PATH/config/omarchy/shell.json"
+
+frame_rate=$(jq -r '.idle.screensaverFrameRate // empty' "$config_file" 2>/dev/null || true)
+[[ $frame_rate =~ ^[1-9][0-9]*$ ]] || frame_rate=$default_frame_rate
+
+max_frame_rate=${1:-}
+if [[ $max_frame_rate =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+  max_frame_rate=$(printf '%.0f' "$max_frame_rate")
+  if ((max_frame_rate > 0 && max_frame_rate < frame_rate)); then
+    frame_rate=$max_frame_rate
+  fi
+fi
+
+echo "$frame_rate"

--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -2,7 +2,8 @@
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "screensaverFrameRate": 60
   },
   "bar": {
     "position": "top",

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -134,7 +134,8 @@ string on a miss.
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "screensaverFrameRate": 60
   },
   "bar": {
     "id": "omarchy.bar",
@@ -167,6 +168,9 @@ Rules:
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+   `idle.screensaverFrameRate` is the screensaver's frames per second (default
+   60), capped to each monitor's refresh rate; the terminal rasterizes every
+   frame on the CPU, so HiDPI panels pay for each one.
 8. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -71,14 +71,17 @@ The Omarchy shell owns idle behavior, and the timings are a top-level `idle` blo
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "screensaverFrameRate": 60
   }
 }
 ```
 
-Both numbers are seconds counted from the moment you went idle — not from each other. So with the defaults, the screensaver comes up after two and a half minutes and the lock screen takes over at five minutes, whether or not the screensaver ran. Save the file and the shell picks up the new timings right away.
+The first two numbers are seconds counted from the moment you went idle, not from each other. So with the defaults, the screensaver comes up after two and a half minutes and the lock screen takes over at five minutes, whether or not the screensaver ran. Save the file and the shell picks up the new timings right away.
 
 If you dismiss the screensaver before the lock deadline, that counts as activity and the pending lock is cancelled. You don't get locked out for glancing at your machine.
+
+`screensaverFrameRate` is how many frames per second the screensaver animates at, capped to each monitor's refresh rate. The terminal draws every frame on the CPU at the panel's native resolution, so on a 4K or 5K display a high frame rate can keep multiple cores busy.
 
 To stop locking on idle entirely, `Super + Ctrl + I` — or `omarchy toggle idle` — flips stay awake on, and the coffee cup indicator appears in the bar. That's the one to hit before a long presentation or a build you want to watch. Hit it again to go back to normal. `omarchy toggle idle status` prints the current state as JSON if you need it from a script.
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -280,7 +280,9 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    entries with their own values.
 7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
    are seconds since user idle began, so the default lock fires at 300s
-   even if the 150s screensaver starts first.
+   even if the 150s screensaver starts first. `idle.screensaverFrameRate`
+   (default 60) is the screensaver's frames per second, capped to each
+   monitor's refresh rate; `omarchy-screensaver-frame-rate` reads it.
 8. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 

--- a/test/shell.d/screensaver-frame-rate-test.sh
+++ b/test/shell.d/screensaver-frame-rate-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+export HOME="$tmp_dir/home"
+export OMARCHY_PATH="$ROOT"
+export PATH="$ROOT/bin:$PATH"
+mkdir -p "$HOME/.config/omarchy"
+
+frame_rate() {
+  "$ROOT/bin/omarchy-screensaver-frame-rate" "$@"
+}
+
+write_config() {
+  printf '%s\n' "$1" >"$HOME/.config/omarchy/shell.json"
+}
+
+# Without a user shell.json the shipped default applies, and the default has to
+# stay well under the old hardcoded 120: foot rasterizes every frame on the CPU
+# at native panel resolution, so 120fps on a 5K panel pinned three cores.
+default=$(jq -r '.idle.screensaverFrameRate' "$ROOT/config/omarchy/shell.json")
+[[ $default =~ ^[0-9]+$ ]] || fail "default shell.json ships idle.screensaverFrameRate" "$default"
+(( default <= 60 )) || fail "default screensaver frame rate is at most 60" "$default"
+[[ $(frame_rate) == "$default" ]] || fail "screensaver frame rate falls back to the shipped default" "$(frame_rate)"
+pass "screensaver frame rate defaults to $default"
+
+write_config '{"version": 1, "idle": {"screensaver": 150, "lock": 300, "screensaverFrameRate": 30}}'
+[[ $(frame_rate) == "30" ]] || fail "screensaver frame rate reads idle.screensaverFrameRate" "$(frame_rate)"
+pass "screensaver frame rate reads idle.screensaverFrameRate"
+
+write_config '{"version": 1, "idle": {"screensaver": 150, "lock": 300}}'
+[[ $(frame_rate) == "$default" ]] || fail "screensaver frame rate defaults when the key is missing" "$(frame_rate)"
+pass "screensaver frame rate defaults when the key is missing"
+
+for bad in '"fast"' '0' '-5' '12.5' 'null'; do
+  write_config "{\"version\": 1, \"idle\": {\"screensaverFrameRate\": $bad}}"
+  [[ $(frame_rate) == "$default" ]] || fail "screensaver frame rate rejects $bad" "$(frame_rate)"
+done
+pass "screensaver frame rate rejects invalid values"
+
+write_config 'not json'
+[[ $(frame_rate 2>/dev/null) == "$default" ]] || fail "screensaver frame rate survives a broken shell.json" "$(frame_rate 2>/dev/null)"
+pass "screensaver frame rate survives a broken shell.json"
+
+# Frames above the panel's refresh rate can never be displayed, so the monitor
+# refresh rate caps whatever is configured.
+write_config '{"version": 1, "idle": {"screensaverFrameRate": 120}}'
+[[ $(frame_rate 60) == "60" ]] || fail "screensaver frame rate is capped to the monitor refresh rate" "$(frame_rate 60)"
+[[ $(frame_rate 144) == "120" ]] || fail "screensaver frame rate keeps the configured rate under a faster refresh rate" "$(frame_rate 144)"
+[[ $(frame_rate 0) == "120" ]] || fail "screensaver frame rate ignores an unknown refresh rate" "$(frame_rate 0)"
+[[ $(frame_rate abc) == "120" ]] || fail "screensaver frame rate ignores a malformed refresh rate" "$(frame_rate abc)"
+[[ $(frame_rate 59.997) == "60" ]] || fail "screensaver frame rate rounds a fractional refresh rate" "$(frame_rate 59.997)"
+pass "screensaver frame rate is capped to the monitor refresh rate"
+
+# The screensaver itself must take the frame rate from the helper rather than
+# hardcoding one, and the launcher must hand each window its monitor's refresh
+# rate so the cap applies per monitor.
+if rg -q -- '--frame-rate [0-9]' "$ROOT/bin/omarchy-screensaver"; then
+  fail "omarchy-screensaver does not hardcode a frame rate"
+fi
+rg -q 'omarchy-screensaver-frame-rate' "$ROOT/bin/omarchy-screensaver" || fail "omarchy-screensaver uses the frame rate helper"
+rg -q 'OMARCHY_SCREENSAVER_MAX_FRAME_RATE' "$ROOT/bin/omarchy-screensaver" || fail "omarchy-screensaver honors the per-monitor refresh rate cap"
+rg -q 'OMARCHY_SCREENSAVER_MAX_FRAME_RATE' "$ROOT/bin/omarchy-launch-screensaver" || fail "omarchy-launch-screensaver passes each monitor's refresh rate"
+pass "screensaver frame rate is wired through the launcher and screensaver"


### PR DESCRIPTION
## Problem

`omarchy-screensaver` hardcoded `--frame-rate 120` for ttfx. The screensaver terminal (foot by default) rasterizes every frame on the CPU at native panel resolution, so on HiDPI displays that pinned several cores and thermally throttled the machine. On QXL VMs it exhausted video memory.

Most of those frames were wasted anyway, since the panels refresh at 60Hz.

## Fix

- **Default to 60fps** instead of 120.
- **Cap each screensaver window to its monitor's refresh rate.** `omarchy-launch-screensaver` reads the rate from `hyprctl monitors` and passes it as `OMARCHY_SCREENSAVER_MAX_FRAME_RATE`.
- **Make the rate configurable.** The new `omarchy-screensaver-frame-rate` helper resolves `idle.screensaverFrameRate` from `shell.json`, so the rate can be lowered further without editing package-owned files.

## Testing

- New `test/shell.d/screensaver-frame-rate-test.sh` covers the default, config reads, invalid values, broken JSON, refresh-rate capping, and the wiring through both scripts.
- `omarchy commands --check` passes with the new hidden helper registered.

## Relationship to PR #8556

#8556 makes the frame rate overridable via OMARCHY_SCREENSAVER_FRAME_RATE but keeps 120 as the default, so affected machines still hit the problem until the user finds the variable. This PR changes the default: 60fps capped to the monitor's real refresh rate, since ttfx frames above that are discarded by the compositor. That fixes #9193 and #8554 for everyone without configuration, and puts the override in shell.json alongside the other idle settings rather than in UWSM env. Happy to add the env var as an additional override if that's preferred.

Fixes #9193
Fixes #8554