### PR TITLE
Name keycode bindings after the layout the keyboard is using

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -9,11 +9,51 @@ declare -A LUA_BIND_KEY_MAP
 declare -A LUA_BIND_DISPATCHER_MAP
 declare -A LUA_BIND_ARG_MAP
 
+# Compile the keymap Hyprland is actually using. Called with no arguments,
+# `xkbcli compile-keymap` compiles the default US keymap, which names every
+# code: binding after a key a non-US layout does not have: code:20 reads MINUS
+# everywhere, while a German keyboard prints ß there and a Spanish one '.
+active_keymap_command() {
+  local layouts variants index layout variant command
+
+  layouts=$(hyprctl getoption input:kb_layout 2>/dev/null | awk '/^str:/ { sub(/^str:[[:space:]]*/, ""); print; exit }')
+  variants=$(hyprctl getoption input:kb_variant 2>/dev/null | awk '/^str:/ { sub(/^str:[[:space:]]*/, ""); print; exit }')
+
+  # kb_layout may name several layouts; the keyboard says which one is live.
+  # Switching layouts rewrites the `active keymap:` line the cache keys on, so
+  # the menu re-renders against the layout the user just switched to.
+  index=$(hyprctl devices 2>/dev/null | awk '
+    /active layout index:/ { current = $NF; if (first == "") first = current }
+    /main: yes/ { print current; found = 1; exit }
+    END { if (!found) print first }
+  ')
+  [[ $index =~ ^[0-9]+$ ]] || index=0
+
+  layout=$(cut -d, -f$((index + 1)) <<<"$layouts")
+  variant=$(cut -d, -f$((index + 1)) <<<"$variants")
+  [[ -z $layout ]] && layout=$(cut -d, -f1 <<<"$layouts")
+
+  command="xkbcli compile-keymap"
+
+  # awk runs this through a shell, so only pass on what an RMLVO name is made
+  # of. Anything else leaves the command bare and the default keymap compiled.
+  if [[ $layout =~ ^[A-Za-z0-9_-]+$ ]]; then
+    command+=" --layout $layout"
+
+    if [[ $variant =~ ^[A-Za-z0-9_-]+$ ]]; then
+      command+=" --variant $variant"
+    fi
+  fi
+
+  # </dev/null keeps xkbcli from consuming the binding records on stdin
+  printf '%s </dev/null\n' "$command"
+}
+
 # Hyprland reports XKB keycodes for code: bindings. Resolve them to symbols
 # via the compiled keymap, with a small fallback for common keys so the menu
 # remains readable if xkbcli cannot resolve a symbol.
 parse_keycodes() {
-  awk '
+  awk -v keymap_cmd="$(active_keymap_command)" '
     BEGIN {
       split("10=1 11=2 12=3 13=4 14=5 15=6 16=7 17=8 18=9 19=0 20=MINUS 21=EQUAL 59=COMMA 60=PERIOD 61=SLASH", fallbacks, " ")
       for (i in fallbacks) {
@@ -21,21 +61,57 @@ parse_keycodes() {
         keycode_symbol[substr(fallbacks[i], 1, separator - 1)] = substr(fallbacks[i], separator + 1)
       }
 
-      # </dev/null keeps xkbcli from consuming the binding records on stdin
-      keymap_cmd = "xkbcli compile-keymap </dev/null"
+      # Keysym names no keyboard prints on its keys. Uppercasing these puts
+      # SSHARP and DEAD_ACUTE in the menu for keys labelled ß and ´, so name
+      # them by the character instead. Keys a US layout already reaches, like
+      # minus and equal, keep the words the menu has always shown for them.
+      split("ssharp=ß adiaeresis=ä odiaeresis=ö udiaeresis=ü aring=å ae=æ oslash=ø " \
+            "eacute=é egrave=è agrave=à ugrave=ù iacute=í oacute=ó uacute=ú " \
+            "ccedilla=ç ntilde=ñ ccaron=č scaron=š zcaron=ž " \
+            "dead_acute=´ dead_grave=` dead_circumflex=^ dead_diaeresis=¨ " \
+            "dead_tilde=~ dead_caron=ˇ dead_breve=˘ dead_cedilla=¸ dead_abovering=° " \
+            "exclamdown=¡ questiondown=¿ masculine=º ordfeminine=ª degree=° " \
+            "section=§ currency=¤ mu=µ plus=+ numbersign=# apostrophe=\047 " \
+            "asterisk=* bar=| less=< greater=> at=@", named_symbols, " ")
+      for (i in named_symbols) {
+        separator = index(named_symbols[i], "=")
+        symbol_character[substr(named_symbols[i], 1, separator - 1)] = substr(named_symbols[i], separator + 1)
+      }
+
       section = ""
       while ((keymap_cmd | getline line) > 0) {
         if (line ~ /xkb_keycodes/) { section = "codes"; continue }
         if (line ~ /xkb_symbols/)  { section = "syms";  continue }
         if (section == "codes" && match(line, /<([A-Za-z0-9_]+)>\s*=\s*([0-9]+)\s*;/, m)) code_by_name[m[1]] = m[2]
-        if (section == "syms" && match(line, /key\s*<([A-Za-z0-9_]+)>\s*\{\s*\[\s*([^, \]]+)/, m)) sym_by_name[m[1]] = m[2]
+
+        # A key whose type xkbcli spells out puts its symbols on a line of
+        # their own, so remember the key the block opened on and read them off
+        # when they arrive. Only the compact one-line form was matched before,
+        # which left every key carrying an explicit type unresolved.
+        if (section == "syms") {
+          if (match(line, /key\s*<([A-Za-z0-9_]+)>\s*\{\s*\[\s*([^, \]]+)/, m)) {
+            sym_by_name[m[1]] = m[2]
+            open_key = ""
+          } else if (match(line, /key\s*<([A-Za-z0-9_]+)>\s*\{/, m)) {
+            open_key = m[1]
+          } else if (open_key != "" && match(line, /symbols\[[^\]]*\]\s*=\s*\[\s*([^, \]]+)/, m)) {
+            sym_by_name[open_key] = m[1]
+            open_key = ""
+          }
+        }
       }
       close(keymap_cmd)
 
       for (name in code_by_name) {
         code = code_by_name[name]
         symbol = sym_by_name[name]
-        if (code != "" && symbol != "" && symbol != "NoSymbol") keycode_symbol[code] = toupper(symbol)
+        if (code == "" || symbol == "" || symbol == "NoSymbol") continue
+
+        if (symbol in symbol_character) {
+          keycode_symbol[code] = symbol_character[symbol]
+        } else {
+          keycode_symbol[code] = toupper(symbol)
+        }
       }
 
       # Read off the keysym rather than the keycode, so the key left of 1 reads
@@ -530,7 +606,7 @@ output_binding_records_uncached() {
 
 keybindings_cache_key() {
   {
-    printf 'v13\n'
+    printf 'v14\n'
     hyprctl devices 2>/dev/null | grep -F 'active keymap:'
     hyprctl binds 2>/dev/null
   } | sha256sum | awk '{ print $1 }'

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -26,15 +26,27 @@ exec_bind() {
   printf 'bind\n\tmodmask: %s\n\tsubmap: \n\tkey: %s\n\tkeycode: 0\n\tcatchall: false\n\tdescription: %s\n\tdispatcher: exec\n\targ: %s\n' "$1" "$2" "$3" "$4"
 }
 
+# The menu asks Hyprland which layout is live before it resolves keycodes.
+# Leaving these empty stands in for a keyboard Hyprland reports nothing about,
+# which is what sends the menu back to the default keymap.
+stub_kb_layout=""
+stub_kb_variant=""
+stub_layout_index=0
+
 stub_hyprctl() {
   {
     echo '#!/bin/bash'
+    printf 'case "$1 $2" in\n'
+    printf '  "getoption input:kb_layout") echo "str: %s"; exit ;;\n' "$stub_kb_layout"
+    printf '  "getoption input:kb_variant") echo "str: %s"; exit ;;\n' "$stub_kb_variant"
+    printf 'esac\n'
     echo 'case "$1" in'
     echo '  binds) cat <<'"'"'BINDS'"'"''
     cat
     echo 'BINDS'
     echo '  ;;'
-    echo '  devices) echo "active keymap: English (US)" ;;'
+    printf '  devices) echo "active layout index: %s"; echo "active keymap: %s"; echo "main: yes" ;;\n' \
+      "$stub_layout_index" "${stub_kb_layout:-English (US)}"
     echo 'esac'
   } >"$stub_bin/hyprctl"
   chmod +x "$stub_bin/hyprctl"
@@ -130,6 +142,63 @@ rendered=$(keybindings)
 grep -q 'SUPER + ~  *→ Toggle scratchpad' <<<"$rendered" ||
   fail "a keycode resolves to the symbol printed on the key too" "$rendered"
 pass "a keycode resolves to the symbol printed on the key too"
+
+# A keycode is a position on the keyboard, not a key. code:20 sits right of 0,
+# where a US layout prints - and a German one ß, so the menu has to resolve it
+# against the layout in use rather than the one xkbcli compiles by default.
+keycode_bind() {
+  printf 'bind\n\tmodmask: %s\n\tsubmap: \n\tkey: \n\tkeycode: %s\n\tcatchall: false\n\tdescription: %s\n\tdispatcher: exec\n\targ: true\n' "$1" "$2" "$3"
+}
+
+stub_hyprctl <<BINDS
+$(keycode_bind 64 20 "Expand window left")
+$(keycode_bind 64 21 "Shrink window left")
+BINDS
+
+rendered=$(keybindings)
+grep -q 'SUPER + MINUS  *→ Expand window left' <<<"$rendered" ||
+  fail "a keyboard Hyprland says nothing about still reads as the default keymap" "$rendered"
+pass "a keyboard Hyprland says nothing about still reads as the default keymap"
+
+stub_kb_layout="de"
+stub_kb_variant="mac"
+stub_hyprctl <<BINDS
+$(keycode_bind 64 20 "Expand window left")
+$(keycode_bind 64 21 "Shrink window left")
+BINDS
+
+rendered=$(keybindings)
+grep -q 'SUPER + ß  *→ Expand window left' <<<"$rendered" ||
+  fail "a keycode reads as the key the active layout prints there" "$rendered"
+! grep -qE 'MINUS|EQUAL' <<<"$rendered" ||
+  fail "no entry still names the key a US layout would have" "$rendered"
+pass "a keycode reads as the key the active layout prints there"
+
+# ß and ´ are what the keys say. SSHARP and DEAD_ACUTE are what xkb calls them,
+# and no keyboard prints either.
+grep -q 'SUPER + ´  *→ Shrink window left' <<<"$rendered" ||
+  fail "a keysym with no printable name reads as the character instead" "$rendered"
+! grep -qE 'SSHARP|DEAD_ACUTE' <<<"$rendered" ||
+  fail "no entry falls back to the xkb name of a key" "$rendered"
+pass "a keysym with no printable name reads as the character instead"
+
+# kb_layout can list several layouts. The one the keyboard reports as active is
+# the one the menu has to name keys after, not simply the first in the list.
+stub_kb_layout="us,de"
+stub_kb_variant=","
+stub_layout_index=1
+stub_hyprctl <<BINDS
+$(keycode_bind 64 20 "Expand window left")
+BINDS
+
+rendered=$(keybindings)
+grep -q 'SUPER + ß  *→ Expand window left' <<<"$rendered" ||
+  fail "the active layout wins over the first one listed" "$rendered"
+pass "the active layout wins over the first one listed"
+
+stub_kb_layout=""
+stub_kb_variant=""
+stub_layout_index=0
 
 # A chord refused for width opens a row of its own, and the next chord tries
 # that row rather than reaching back past it and printing out of order.


### PR DESCRIPTION
Fixes #8999

```
before (every layout):  SUPER + MINUS → Expand window left
after  (de):            SUPER + ß     → Expand window left
after  (es):            SUPER + '     → Expand window left
after  (us):            SUPER + MINUS → Expand window left   (unchanged, byte-identical)
```

The menu runs `xkbcli compile-keymap` with no arguments, which compiles the US keymap, so every `code:` bind is named after a key non-US keyboards don't have. The binds fire correctly; only the menu names the wrong key. Confirmed on `es` (#8999) and `de(mac)`.

Stacked on #12676 (the first commit here until that merges), then:

- **Compile the layout Hyprland is using** — `kb_layout`/`kb_variant` from `hyprctl getoption`; with several layouts, the main keyboard's active index. Names are only interpolated if they match `^[A-Za-z0-9_-]+$` (awk runs the command through a shell); anything else, or no Hyprland, leaves today's behaviour. Layout switches already change the cache key, so the menu re-renders.
- **Name keysyms no keyboard prints** — cosmetic: `ß`/`´` instead of `SSHARP`/`DEAD_ACUTE`. Droppable without affecting the commit above.

Tests: default fallback, `de`/`mac`, second of `us,de`. `test/shell.d/keybindings-menu-test.sh` passes at every commit. `./test/all` has six failing files that fail identically on a clean `quattro` (`bar-icon-geometry`, `config`, `locate`, `omarchy-kernel-migration`, `snapper`, `unowned-system-paths`); none touch these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCZZN7iuwHavrgZSYStFDo
