### PR TITLE
Fix SDDM password field sometimes not getting focus on load

### DIFF
--- a/default/sddm/omarchy/Main.qml
+++ b/default/sddm/omarchy/Main.qml
@@ -18,12 +18,23 @@ Rectangle {
     return sessionModel.lastIndex
   }
 
+  // Re-grab focus shortly after showing/failing, since a single
+  // forceActiveFocus() call can lose the race with the compositor
+  // handing input focus to the greeter window.
+  Timer {
+    id: focusRetryTimer
+    interval: 100
+    repeat: false
+    onTriggered: password.forceActiveFocus()
+  }
+
   Connections {
     target: sddm
     function onLoginFailed() {
       root.loginFailed = true
       password.text = ""
       password.focus = true
+      focusRetryTimer.restart()
     }
     function onLoginSucceeded() {
       root.loginFailed = false
@@ -113,5 +124,8 @@ Rectangle {
 
   }
 
-  Component.onCompleted: password.forceActiveFocus()
+  Component.onCompleted: {
+    password.forceActiveFocus()
+    focusRetryTimer.restart()
+  }
 }


### PR DESCRIPTION
## Problem

On the omarchy SDDM theme (`default/sddm/omarchy/Main.qml`), the password field is sometimes not focused when the greeter first shows, requiring a click into the field before typing works. It happens intermittently, not on every boot/logout.

## Cause

`Component.onCompleted: password.forceActiveFocus()` fires once, immediately on load. It can lose the race with the compositor handing keyboard focus to the greeter window, so the forced focus doesn't stick. The same single-shot pattern is used in `onLoginFailed`.

## Fix

Add a one-shot `Timer` that re-fires `forceActiveFocus()` ~100ms after the initial call (on load, and again after a failed login attempt), so the retry lands after the window has focus.

## Testing

- Reproduced on my own Omarchy install (SDDM/Hyprland), applied the same patch to the installed theme at `/usr/share/sddm/themes/omarchy/Main.qml`, and confirmed the password field is now reliably focused on load.
- `./test/all` — the 4 pre-existing shell-test failures (`bin-style-test.sh`, `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`) reproduce identically on `quattro` HEAD without this change, so they're unrelated to this patch.
- No automated test covers this QML file; the fix was verified visually per `agents/skills/visual-verification.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)