### PR TITLE
network speedtest: use tokenless Cloudflare endpoints

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -9,7 +9,6 @@ set -e
 direction="${1:-}"
 probe=1.1.1.1
 parallel=8
-url_count=3
 
 case "$direction" in
   down | up)
@@ -40,14 +39,12 @@ if ! omarchy-cmd-present curl; then
   exit 1
 fi
 
-fast_token="YXNkZmFzZGxmbnNkYWZoYXNkZmhrYWxm"
-fast_api_url="https://api.fast.com/netflix/speedtest/v2?https=true&token=$fast_token&urlCount=$url_count"
-
-fast_urls=$(curl -fsS "$fast_api_url" 2>/dev/null | jq -r '.targets[]?.url // empty')
-
-if [[ -z $fast_urls ]]; then
-  echo "Failed to fetch speed test endpoints" >&2
-  exit 1
+# Cloudflare's speed test hosts expose tokenless download/upload endpoints,
+# so they don't break when a third-party API rotates a token.
+if [[ $direction == "down" ]]; then
+  speed_url="https://speed.cloudflare.com/__down?bytes=10000000"
+else
+  speed_url="https://speed.cloudflare.com/__up"
 fi
 
 traffic_pids=()
@@ -66,28 +63,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Round-robin across the returned URLs so we spread load across Netflix OCA nodes.
 traffic_worker() {
-  local urls=("$@")
-  local url_count=${#urls[@]}
-  local idx=$RANDOM
   if [[ $direction == "down" ]]; then
     while true; do
-      url=${urls[$((idx % url_count))]}
-      curl -fsS -o /dev/null "$url" 2>/dev/null || return
-      idx=$((idx + 1))
+      curl -fsS -o /dev/null "$speed_url" 2>/dev/null || return
     done
   else
     while true; do
-      url=${urls[$((idx % url_count))]}
-      dd if=/dev/zero bs=1M count=64 2>/dev/null | curl -fsS -o /dev/null -X POST --data-binary @- "$url" 2>/dev/null || return
-      idx=$((idx + 1))
+      dd if=/dev/zero bs=1M count=64 2>/dev/null | curl -fsS -o /dev/null -X POST --data-binary @- "$speed_url" 2>/dev/null || return
     done
   fi
 }
 
 for (( i = 0; i < parallel; i++ )); do
-  traffic_worker $fast_urls &
+  traffic_worker &
   traffic_pids+=("$!")
 done
 


### PR DESCRIPTION
Fixes the `omarchy network speedtest` command, which fails with `Failed to fetch speed test endpoints`.

## Problem
The script hardcoded the public Netflix/fast.com OCA token and fetched download URLs from `api.fast.com/netflix/speedtest/v2`. That token is no longer accepted — the API returns **HTTP 403** for it on both `/v1` and `/v2`, so `curl -f` fails and the script exits before measuring anything.

Verified failure:
```
curl -i "https://api.fast.com/netflix/speedtest/v2?https=true&token=YXNkZmFzZGxmbnNkYWZoYXNkZmhrYWxm&urlCount=3"
→ 403
```

## Fix
Switch the traffic backend to Cloudflare's speed test endpoints, which need no token and aren't tied to a rotating third-party API:
- download: `https://speed.cloudflare.com/__down?bytes=10000000`
- upload:   `https://speed.cloudflare.com/__up`

Also removed the now-dead `url_count` variable, the round-robin worker logic (only a single endpoint is used now), and the `jq` fetch that was the failure point.

## Verification
- `bash -n` passes.
- Ran the command live: `./bin/omarchy-network-speedtest down` → printed ~17–19 Mbps; `up` → printed ~38–55 Mbps.
- `./test/cli` passes (`--json` help, metadata, routing).
- grepped the tree: no other file references the dead fast.com token.