### PR TITLE
Publish Hyprland toggle flags atomically and disbelieve empty ones

### DIFF
--- a/bin/omarchy-hw-recover-internal-monitor
+++ b/bin/omarchy-hw-recover-internal-monitor
@@ -4,6 +4,8 @@
 
 TOGGLE="$HOME/.local/state/omarchy/toggles/hypr/internal-monitor-disable.lua"
 
+# -f, not -s: this removes the flag rather than trusting it, so it has to match
+# a husk an older version could have left behind.
 if [[ -f $TOGGLE ]] && ! omarchy-hw-external-monitors; then
   rm -f "$TOGGLE"
 fi

--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -4,7 +4,8 @@
 # omarchy:hidden=true
 
 TOGGLES_DIR="$HOME/.local/state/omarchy/toggles/hypr"
-CLAMSHELL_FLAG="$TOGGLES_DIR/internal-monitor-clamshell.lua"
+CLAMSHELL_TOGGLE="internal-monitor-clamshell"
+CLAMSHELL_FLAG="$TOGGLES_DIR/$CLAMSHELL_TOGGLE.lua"
 MANUAL_DISABLE_FLAG="$TOGGLES_DIR/internal-monitor-disable.lua"
 SCALE_STATE="$TOGGLES_DIR/internal-monitor-scale"
 MONITOR_LUA="$HOME/.config/hypr/monitors.lua"
@@ -209,6 +210,8 @@ dpms_internal() {
 enable_internal() {
   local changed=0
 
+  # -f, not -s: this removes the flag rather than trusting it, so it has to
+  # match a husk an older version could have left behind.
   if [[ -f $CLAMSHELL_FLAG ]]; then
     rm -f "$CLAMSHELL_FLAG"
     changed=1
@@ -218,7 +221,8 @@ enable_internal() {
     hyprctl reload >/dev/null 2>&1 || true
   fi
 
-  [[ -f $MANUAL_DISABLE_FLAG ]] && omarchy-hyprland-monitor-external-active && return 0
+  [[ -f $MANUAL_DISABLE_FLAG && -s $MANUAL_DISABLE_FLAG ]] &&
+    omarchy-hyprland-monitor-external-active && return 0
   sync_internal_scale
 
   if (( changed )); then
@@ -228,7 +232,9 @@ enable_internal() {
 
 disable_internal() {
   [[ -n $INTERNAL ]] || exit 0
-  [[ -f $MANUAL_DISABLE_FLAG ]] && return 0
+  # An empty manual flag is a write that did not finish, not an override: it
+  # would veto the disable below while itself disabling nothing.
+  [[ -f $MANUAL_DISABLE_FLAG && -s $MANUAL_DISABLE_FLAG ]] && return 0
 
   mkdir -p "$TOGGLES_DIR"
   remember_internal_scale
@@ -236,8 +242,8 @@ disable_internal() {
   local config
   config=$(printf 'hl.monitor({ output = "%s", disabled = true })' "$INTERNAL")
 
-  if [[ ! -f $CLAMSHELL_FLAG ]] || [[ $(< "$CLAMSHELL_FLAG") != $config ]]; then
-    printf '%s\n' "$config" >"$CLAMSHELL_FLAG"
+  if [[ ! -s $CLAMSHELL_FLAG ]] || [[ $(< "$CLAMSHELL_FLAG") != $config ]]; then
+    printf '%s\n' "$config" | omarchy-hyprland-toggle-write $CLAMSHELL_TOGGLE || return 0
     hyprctl reload >/dev/null 2>&1 || true
   fi
 }

--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -4,7 +4,6 @@
 # omarchy:args=<on|off|toggle|recover>
 
 TOGGLE="internal-monitor-disable"
-TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.lua"
 MIRROR_TOGGLE="internal-monitor-mirror"
 
 INTERNAL=$(omarchy-hyprland-monitor-laptop)
@@ -41,7 +40,8 @@ off() {
   fi
 
   if omarchy-hyprland-toggle-disabled $TOGGLE && omarchy-hyprland-toggle-disabled $MIRROR_TOGGLE; then
-    printf 'hl.monitor({ output = "%s", disabled = true })\n' "$INTERNAL" >"$TOGGLE_FLAG"
+    printf 'hl.monitor({ output = "%s", disabled = true })\n' "$INTERNAL" |
+      omarchy-hyprland-toggle-write $TOGGLE || exit 1
     omarchy-notification-send -g 󰍹 "Laptop display disabled"
     hyprctl reload
   fi

--- a/bin/omarchy-hyprland-monitor-internal-mirror
+++ b/bin/omarchy-hyprland-monitor-internal-mirror
@@ -4,7 +4,6 @@
 # omarchy:args=<on|off|toggle|recover>
 
 TOGGLE="internal-monitor-mirror"
-TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.lua"
 DISABLE_TOGGLE="internal-monitor-disable"
 
 INTERNAL=$(omarchy-hyprland-monitor-laptop)
@@ -34,7 +33,8 @@ on() {
   omarchy-hyprland-toggle $DISABLE_TOGGLE off
 
   if omarchy-hyprland-toggle-disabled $TOGGLE; then
-    printf 'hl.monitor({ output = "%s", mode = "preferred", position = "auto", scale = 1, mirror = "%s" })\n' "$EXTERNAL" "$INTERNAL" >"$TOGGLE_FLAG"
+    printf 'hl.monitor({ output = "%s", mode = "preferred", position = "auto", scale = 1, mirror = "%s" })\n' "$EXTERNAL" "$INTERNAL" |
+      omarchy-hyprland-toggle-write $TOGGLE || exit 1
     omarchy-notification-send -g 󰍹 "Mirroring enabled ($EXTERNAL)"
     hyprctl reload
   fi

--- a/bin/omarchy-hyprland-toggle
+++ b/bin/omarchy-hyprland-toggle
@@ -19,8 +19,7 @@ FLAG_SOURCE="$OMARCHY_PATH/default/hypr/toggles/$FLAG_NAME.lua"
 
 on() {
   if [[ -f $FLAG_SOURCE ]]; then
-    mkdir -p "$(dirname "$FLAG_FILE")"
-    cp "$FLAG_SOURCE" "$FLAG_FILE"
+    omarchy-hyprland-toggle-write "$FLAG_NAME" <"$FLAG_SOURCE"
   else
     echo "Flag not found: $FLAG_NAME" >&2
     exit 1
@@ -32,7 +31,7 @@ off() {
 }
 
 toggle() {
-  if [[ -f $FLAG_FILE ]]; then
+  if [[ -f $FLAG_FILE && -s $FLAG_FILE ]]; then
     off
     echo "off"
   else

--- a/bin/omarchy-hyprland-toggle-disabled
+++ b/bin/omarchy-hyprland-toggle-disabled
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-# omarchy:summary=Check if a Hyprland toggle is currently disabled (missing).
+# omarchy:summary=Check if a Hyprland toggle is currently disabled (missing or empty).
 # omarchy:args=<flag-name>
 
-[[ ! -f "$HOME/.local/state/omarchy/toggles/hypr/$1.lua" ]]
+FLAG_FILE="$HOME/.local/state/omarchy/toggles/hypr/$1.lua"
+
+! [[ -f $FLAG_FILE && -s $FLAG_FILE ]]

--- a/bin/omarchy-hyprland-toggle-enabled
+++ b/bin/omarchy-hyprland-toggle-enabled
@@ -3,4 +3,8 @@
 # omarchy:summary=Check if a Hyprland toggle is currently enabled.
 # omarchy:args=<flag-name>
 
-[[ -f "$HOME/.local/state/omarchy/toggles/hypr/$1.lua" ]]
+FLAG_FILE="$HOME/.local/state/omarchy/toggles/hypr/$1.lua"
+
+# Size as well as kind: the flag is the Lua that acts on it, so an empty one
+# enables nothing even though every reader used to believe it.
+[[ -f $FLAG_FILE && -s $FLAG_FILE ]]

--- a/bin/omarchy-hyprland-toggle-write
+++ b/bin/omarchy-hyprland-toggle-write
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# omarchy:summary=Install a generated Hyprland toggle flag from stdin, atomically.
+# omarchy:args=<flag-name>
+# omarchy:hidden=true
+
+if (($# != 1)); then
+  echo "Usage: omarchy-hyprland-toggle-write <flag-name>" >&2
+  exit 1
+fi
+
+TOGGLES_DIR="$HOME/.local/state/omarchy/toggles/hypr"
+FLAG_FILE="$TOGGLES_DIR/$1.lua"
+
+mkdir -p "$TOGGLES_DIR" || exit 1
+
+temporary=$(mktemp "$TOGGLES_DIR/.$1.XXXXXX") || exit 1
+trap 'rm -f "$temporary"' EXIT
+
+cat >"$temporary" || exit 1
+
+# The flag's existence is the signal and its contents are the Lua that acts on
+# it, so an empty one claims an override it cannot apply. Never install one.
+[[ -s $temporary ]] || exit 1
+
+# Land the data before the name, so an interrupted write leaves the flag either
+# absent or whole rather than a zero-length husk every reader still believes.
+sync -- "$temporary"
+mv -f -- "$temporary" "$FLAG_FILE" || exit 1
+trap - EXIT

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -72,7 +72,7 @@ pass "active external monitor helper sees mirrors and ignores monitors disabled 
 
 grep -F 'omarchy-hyprland-monitor-internal recover >/dev/null 2>&1 || true' "$clamshell" >/dev/null
 grep -F 'omarchy-hyprland-monitor-internal-mirror recover >/dev/null 2>&1 || true' "$clamshell" >/dev/null
-grep -F 'internal-monitor-clamshell.lua' "$clamshell" >/dev/null
+grep -F 'CLAMSHELL_TOGGLE="internal-monitor-clamshell"' "$clamshell" >/dev/null
 grep -F 'disabled = true' "$clamshell" >/dev/null
 grep -F 'MANUAL_DISABLE_FLAG' "$clamshell" >/dev/null
 ! grep -F 'rm -f "$MANUAL_DISABLE_FLAG"' "$clamshell" >/dev/null

--- a/test/shell.d/monitor-toggle-flag-test.sh
+++ b/test/shell.d/monitor-toggle-flag-test.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_dir="$tmpdir/bin"
+home_dir="$tmpdir/home"
+monitors_json="$tmpdir/monitors.json"
+flag_dir="$home_dir/.local/state/omarchy/toggles/hypr"
+mkdir -p "$stub_dir" "$flag_dir"
+
+disable_flag="$flag_dir/internal-monitor-disable.lua"
+clamshell_flag="$flag_dir/internal-monitor-clamshell.lua"
+
+make_stub() {
+  local name=$1
+  local body=$2
+  printf '#!/bin/bash\n%s\n' "$body" >"$stub_dir/$name"
+  chmod +x "$stub_dir/$name"
+}
+
+make_stub omarchy-notification-send ':'
+make_stub omarchy-hyprland-monitor-external-active 'exit 0'
+make_stub omarchy-hyprland-monitor-internal ':'
+make_stub omarchy-hyprland-monitor-internal-mirror ':'
+make_stub omarchy-hw-clamshell 'exit 0'
+make_stub omarchy-hyprland-monitor-laptop 'printf "%s\n" eDP-1'
+make_stub hyprctl 'case "$1 $2" in
+  "monitors all") cat "$MONITORS_JSON" ;;
+esac'
+
+printf '[{"name":"eDP-1","disabled":false,"scale":1.6}]\n' >"$monitors_json"
+
+run() {
+  local command=$1
+  shift
+  HOME="$home_dir" \
+    XDG_STATE_HOME="$home_dir/.local/state" \
+    MONITORS_JSON="$monitors_json" \
+    PATH="$stub_dir:$ROOT/bin:$PATH" \
+    "$ROOT/bin/$command" "$@"
+}
+
+# A crash between the truncate and the write leaves a flag that every reader
+# believes and that applies nothing. It is the file's contents that disable the
+# panel, so an empty one is corruption, never a state a user can be in.
+: >"$disable_flag"
+
+run omarchy-hyprland-toggle-enabled internal-monitor-disable &&
+  fail "a zero-length flag does not read as enabled"
+pass "a zero-length flag does not read as enabled"
+
+run omarchy-hyprland-toggle-disabled internal-monitor-disable ||
+  fail "a zero-length flag reads as disabled"
+pass "a zero-length flag reads as disabled"
+
+# A directory carries a nonzero size, so a size test on its own would call one
+# an active flag that the loader's `find -type f` never sources.
+rm -f "$disable_flag"
+mkdir "$disable_flag"
+run omarchy-hyprland-toggle-enabled internal-monitor-disable &&
+  fail "only a regular file reads as an enabled flag"
+pass "only a regular file reads as an enabled flag"
+rmdir "$disable_flag"
+: >"$disable_flag"
+
+rm -f "$clamshell_flag"
+run omarchy-hyprland-monitor-clamshell
+grep -Fx 'hl.monitor({ output = "eDP-1", disabled = true })' "$clamshell_flag" >/dev/null ||
+  fail "a zero-length manual flag does not veto the clamshell disable" \
+    "clamshell flag: $(cat "$clamshell_flag" 2>&1)"
+pass "clamshell disables the panel despite a zero-length manual flag"
+
+# The writer is the only thing that creates these flags, so the invariant every
+# reader depends on belongs here: absent or whole, never empty.
+rm -f "$disable_flag"
+printf 'hl.monitor({ output = "eDP-1", disabled = true })\n' |
+  run omarchy-hyprland-toggle-write internal-monitor-disable
+grep -Fx 'hl.monitor({ output = "eDP-1", disabled = true })' "$disable_flag" >/dev/null ||
+  fail "the writer installs the flag it was given"
+pass "the writer installs the flag it was given"
+
+: | run omarchy-hyprland-toggle-write internal-monitor-disable &&
+  fail "the writer refuses an empty body"
+grep -Fx 'hl.monitor({ output = "eDP-1", disabled = true })' "$disable_flag" >/dev/null ||
+  fail "a refused write leaves the previous flag intact" \
+    "flag is now: $(cat "$disable_flag" 2>&1)"
+pass "the writer refuses an empty body and leaves the previous flag intact"
+
+[[ -z $(find "$flag_dir" -name '.internal-monitor-disable.*' -print -quit) ]] ||
+  fail "the writer leaves no temporary file behind" \
+    "$(find "$flag_dir" -name '.internal-monitor-disable.*')"
+pass "the writer leaves no temporary file behind"
+
+# off() used to redirect straight into a directory that may not exist yet, then
+# notify and reload as though it had written something.
+rm -rf "$home_dir/.local"
+run omarchy-hyprland-monitor-internal off
+grep -Fx 'hl.monitor({ output = "eDP-1", disabled = true })' "$disable_flag" >/dev/null ||
+  fail "disabling the panel creates the toggles directory it writes into"
+pass "disabling the panel creates the toggles directory it writes into"


### PR DESCRIPTION
`~/.local/state/omarchy/toggles/hypr/*.lua` does two jobs at once: readers test that a flag exists to decide whether its toggle is on, and Hyprland sources the same file for the rule that carries it out. The commands that set these flags redirected or copied straight onto the final name, so a write that did not finish left a file that satisfied every reader and applied nothing.

`internal-monitor-disable.lua` is where that costs something. A zero-length one reads as an active manual override, so `disable_internal` in `omarchy-hyprland-monitor-clamshell` returns before writing the clamshell rule: close the lid on a docked laptop and the internal panel stays lit behind it, holding whatever was on that workspace out of sight. Nothing reports it either — an empty Lua file loads cleanly, so `hyprctl configerrors` says nothing is wrong.

`omarchy-hyprland-toggle-write` is now the only thing that creates one. It creates the toggles directory, writes beside the destination under a name the loader's `*.lua` glob cannot match, refuses a body with nothing in it, and renames it into place, so a flag is either absent or whole. `omarchy-hyprland-monitor-internal off` and `omarchy-hyprland-monitor-internal-mirror on` gain that directory too: they were redirecting into one that may not exist, and then notifying and reloading as though they had written something.

Readers test size as well as kind, so a husk an older version left behind stops being believed and the next lid close reconciles normally. The two callers that remove a flag rather than trust it — `enable_internal` and `omarchy-hw-recover-internal-monitor` — keep testing existence alone, since they have to match a husk to clear it.

Fixes #10456.
