### PR TITLE
Build the calendar month grid in UTC

### DIFF
--- a/shell/plugins/panels/clock/Model.js
+++ b/shell/plugins/panels/clock/Model.js
@@ -231,10 +231,17 @@ function lifeProgressPercent(age, expectancy) {
 // Always six rows of seven days. A fixed grid keeps the popup exactly the
 // same height in every month, so stepping through the year never makes the
 // panel jump under the pointer.
+//
+// Walked in UTC, where every day is 24 hours long. A local-midnight cursor has
+// to be resolved by the engine in zones that start DST at 00:00 -- Chile every
+// September, Cuba every March -- and V4 resolves the missing midnight backward
+// onto the previous day while V8 resolves it forward, so the local walk repeats
+// a date in the shell and not under the tests. A grid of civil dates never
+// needed a wall clock in the first place.
 function monthGrid(year, month, weekStart, todayKey) {
   var start = normalizedWeekStart(weekStart, 1)
-  var leading = (new Date(year, month, 1).getDay() - start + 7) % 7
-  var cursor = new Date(year, month, 1 - leading)
+  var leading = (new Date(Date.UTC(year, month, 1)).getUTCDay() - start + 7) % 7
+  var cursor = new Date(Date.UTC(year, month, 1 - leading))
   var today = String(todayKey || "")
   var weeks = []
 
@@ -242,10 +249,10 @@ function monthGrid(year, month, weekStart, todayKey) {
     var days = []
     var thursday = null
     for (var d = 0; d < 7; d++) {
-      var cellYear = cursor.getFullYear()
-      var cellMonth = cursor.getMonth()
-      var cellDay = cursor.getDate()
-      var weekday = cursor.getDay()
+      var cellYear = cursor.getUTCFullYear()
+      var cellMonth = cursor.getUTCMonth()
+      var cellDay = cursor.getUTCDate()
+      var weekday = cursor.getUTCDay()
       var key = dateKey(cellYear, cellMonth, cellDay)
       if (weekday === 4) thursday = { year: cellYear, month: cellMonth, day: cellDay }
       days.push({
@@ -258,7 +265,7 @@ function monthGrid(year, month, weekStart, todayKey) {
         weekend: weekday === 0 || weekday === 6,
         today: key === today
       })
-      cursor.setDate(cursor.getDate() + 1)
+      cursor.setUTCDate(cursor.getUTCDate() + 1)
     }
     // Number every row by the ISO week owning its Thursday. That is the
     // definition itself for Monday-start weeks, and the only answer that
@@ -273,9 +280,11 @@ function monthGrid(year, month, weekStart, todayKey) {
   return weeks
 }
 
+// UTC for the same reason as the grid: the month is read back off the date, so
+// a first of the month that has no local midnight would step into the wrong one.
 function stepMonth(year, month, delta) {
-  var target = new Date(year, Number(month) + Number(delta), 1)
-  return { year: target.getFullYear(), month: target.getMonth() }
+  var target = new Date(Date.UTC(year, Number(month) + Number(delta), 1))
+  return { year: target.getUTCFullYear(), month: target.getUTCMonth() }
 }
 
 if (typeof module !== "undefined") {

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -110,6 +110,47 @@ assertDeepEqual(julySunday.map(week => week.week), [27, 28, 29, 30, 31, 32], 'ca
 const januarySunday = calendar.monthGrid(2021, 0, 0, '')
 assertEqual(januarySunday[0].week, 53, 'calendar carries the previous ISO year into a straddling first row')
 
+// Zones that start DST at 00:00 have a calendar day with no local midnight, and
+// the engines disagree about which side of the gap it falls on: V4 resolves it
+// backward onto the previous date, V8 forward. Node therefore cannot see the
+// duplicated day the shell draws, so pin the property that makes the question
+// moot -- the grid is walked in UTC and never asks for a wall clock.
+const RealDate = Date
+class LocalTimeIsForbidden extends RealDate {
+  constructor(...args) {
+    if (args.length > 1) throw new Error('built a Date from local components')
+    super(...args)
+  }
+  getFullYear() { throw new Error('read the local year') }
+  getMonth() { throw new Error('read the local month') }
+  getDate() { throw new Error('read the local day') }
+  getDay() { throw new Error('read the local weekday') }
+  setDate() { throw new Error('stepped the local day') }
+}
+
+function withoutLocalTime(build) {
+  global.Date = LocalTimeIsForbidden
+  try {
+    return { value: build(), localTimeUse: '' }
+  } catch (error) {
+    return { value: null, localTimeUse: error.message }
+  } finally {
+    global.Date = RealDate
+  }
+}
+
+const september = withoutLocalTime(() => calendar.monthGrid(2026, 8, 0, ''))
+assertEqual(september.localTimeUse, '', 'calendar builds the month grid without reading local time')
+assertDeepEqual(
+  september.value.slice(0, 2).flatMap(week => week.days).map(day => day.day),
+  [30, 31, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  'calendar runs September 2026 straight through the Chilean DST midnight'
+)
+
+const stepped = withoutLocalTime(() => calendar.stepMonth(2026, 8, 1))
+assertEqual(stepped.localTimeUse, '', 'calendar steps months without reading local time')
+assertDeepEqual(stepped.value, { year: 2026, month: 9 }, 'calendar steps from September to October')
+
 // ---- stepping
 assertDeepEqual(calendar.stepMonth(2026, 0, 1), { year: 2026, month: 1 }, 'calendar steps to the next month')
 assertDeepEqual(calendar.stepMonth(2026, 0, -1), { year: 2025, month: 11 }, 'calendar steps back across the new year')


### PR DESCRIPTION
September 2026 draws as `30 31 1 2 3 4 5` and then `5 6 7 8 9 10 11` for anyone in Chile: the 5th appears twice and every date after it sits one weekday to the left, including the today highlight.

`monthGrid()` walked a cursor at local midnight and stepped it with `setDate(getDate() + 1)`. Chile starts DST at 24:00 on the first Saturday of September, so local midnight of 6 September 2026 does not exist, and Qt's V4 engine resolves a missing local time backward — onto 5 September 23:00, which is still the 5th, so the next iteration emits that date a second time and the cursor never catches up. Four other zones change over at 00:00 and break in their own transition month:

| Zone | Changes over at | Next broken grid |
| --- | --- | --- |
| `America/Santiago` (and `Chile/Continental`) | first Sunday of September, 00:00 | September 2026, repeating the 5th |
| `America/Havana` (`Cuba`) | second Sunday of March, 00:00 | March 2027, repeating the 13th |
| `Asia/Beirut` | last Sunday of March, 00:00 | March 2027, repeating the 27th |
| `Atlantic/Azores` | last Sunday of March, 00:00 | March 2027, repeating the 27th |
| `Africa/Cairo` (`Egypt`) | last Friday of April, 00:00 | April 2027, repeating the 29th |

Where the gap falls on a leading padding cell rather than inside the month, cell zero is itself a day early and the entire six-week grid shifts with no duplicate anywhere in it — `Asia/Beirut` in April, every year.

Node resolves the identical gap forward, which is why `test/shell.d/clock-test.sh` has always passed: running the shipped `monthGrid()` under Node across all 598 zones in tzdata 2026c for 2020–2035, both week starts, breaks nothing, while the same code under the QML engine breaks 402 grids across nine zones. A grid of civil dates never needed a wall clock, so it now walks UTC, where every day is 24 hours long and there is nothing for an engine to resolve. The test pins that rather than the symptom: it builds the grid with a `Date` whose local constructor and accessors throw, so any future local-midnight arithmetic fails under Node even though Node cannot see the bug itself.

`stepMonth()` reads a month back off the same kind of date and moves with the grid. `Panel.qml`'s month heading still builds a local `new Date(viewYear, viewMonth, 1)` and stays that way on purpose: no zone puts a midnight gap on a first of the month, and formatting a UTC midnight there would print the previous month everywhere west of Greenwich.

#10401 reports the same grid from the same zone and this covers it.

Reviewed at xhigh by Codex (gpt-5.6), which confirmed the mechanism against Qt's V4 date implementation, checked that the today highlight still matches from UTC−12 to UTC+14, and asked for the `Panel.qml` heading to be left local for the reason above.

Fixes #9635
