### PR TITLE
Prefer active icon theme in menu icon index

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1315,8 +1315,11 @@ Item {
                 source: row.isApp && root.appLibrary ? root.appLibrary.iconSource(row.appIcon) : ""
                 asynchronous: true
                 anchors.left: parent.left
-                anchors.leftMargin: root.rowReservedBorderLeft + Style.space(8) + (Style.space(36) - width) / 2
-                y: contentColumn.y + labelText.y + (labelText.height - height) / 2
+                // Keep icon geometry on whole pixels: odd icon sizes would
+                // otherwise land on half pixels, forcing a bilinear resample
+                // of the whole image that reads as blur.
+                anchors.leftMargin: root.rowReservedBorderLeft + Style.space(8) + Math.round((Style.space(36) - width) / 2)
+                y: Math.round(contentColumn.y + labelText.y + (labelText.height - height) / 2)
               }
 
               Column {

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -125,13 +125,17 @@ Item {
     // icons like "printer" instead of app icons. The active icon theme (plus
     // its Inherits chain) is emitted first so the parser, which keeps the
     // first hit per name, prefers themed icons over stale hicolor fallbacks
-    // when the user switches to a third-party theme such as Papirus. SVGs are
-    // emitted before PNGs so scalable icons win within each tier. Finds follow
+    // when the user switches to a third-party theme such as Papirus. Within
+    // each tier, scalable icons come first and rasters follow largest-first so
+    // a 16x16 file never shadows a crisp source by readdir luck; a catch-all
+    // sweep afterwards still picks up nonstandard layouts. Finds follow
     // symlinks (-L) because theme variants such as Papirus-Dark symlink whole
     // context dirs back to their parent theme. Only apps/devices subtrees are
     // descended, @2x duplicates are pruned, the fallback pass skips theme dirs
     // already covered above (Omarchy's own icons live in hicolor, which is
-    // kept), and awk drops repeat names so the shell parses one line per icon.
+    // kept), a last-resort sweep over the remaining theme dirs preserves
+    // stock coverage for names no preferred location provides, and awk drops
+    // repeat names so the shell parses one line per icon.
     return [
       '{',
       'theme=$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "\u0027");',
@@ -158,20 +162,40 @@ Item {
       '  ordered="$ordered$add";',
       'done;',
       'ctxskip="( -type d ( -name actions -o -name animations -o -name categories -o -name emblems -o -name emotes -o -name filesystems -o -name intl -o -name mimetypes -o -name panel -o -name places -o -name status -o -name stock ) ) -prune -o";',
+      'sizes="scalable 512x512 256x256 192x192 128x128 96x96 72x72 64x64 48x48 42x42 40x40 36x36 32x32 24x24 22x22 18x18 16x16 12x12 8x8";',
+      'sizeprune=();',
+      'for sz in $sizes; do sizeprune+=(-o -path "*/$sz"); done;',
       'for t in $ordered; do',
+      '  for sz in $sizes; do',
+      '    for ext in svg png; do',
+      '      for base in $bases; do',
+      '        d="$base/$t/$sz"; [[ -d $d ]] && find -L "$d" -maxdepth 3 \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" -print 2>/dev/null;',
+      '        d="$base/$t/apps/$sz"; [[ -d $d ]] && find -L "$d" -maxdepth 2 -name "*.$ext" -print 2>/dev/null;',
+      '        d="$base/$t/devices/$sz"; [[ -d $d ]] && find -L "$d" -maxdepth 2 -name "*.$ext" -print 2>/dev/null;',
+      '      done;',
+      '    done;',
+      '  done;',
       '  for ext in svg png; do',
       '    for base in $bases; do',
-      '      [[ -d $base/$t ]] && find -L "$base/$t" -path "*@2x*" -prune -o $ctxskip \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" -print 2>/dev/null;',
+      '      [[ -d $base/$t ]] && find -L "$base/$t" \\( -path "*@2x*" "${sizeprune[@]}" \\) -prune -o $ctxskip \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" -print 2>/dev/null;',
       '    done;',
       '  done;',
       'done;',
-      'prune=(-path "*@2x*");',
+      'prune=(-path "*@2x*"); swept=();',
       'for base in $bases; do',
       '  for d in "$base"/*/; do',
       '    [[ -d $d ]] || continue;',
+      '    [[ -f $d/index.theme ]] || continue;',
       '    n=${d%/}; n=${n##*/};',
       '    [[ $n == "hicolor" ]] && continue;',
-      '    [[ -f $d/index.theme ]] && prune+=(-o -path "${d%/}/*");',
+      '    prune+=(-o -path "${d%/}/*"); swept+=("$d");',
+      '  done;',
+      'done;',
+      'for sz in $sizes; do',
+      '  for ext in svg png; do',
+      '    for base in $bases; do',
+      '      d="$base/hicolor/$sz"; [[ -d $d ]] && find -L "$d" -maxdepth 3 \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" -print 2>/dev/null;',
+      '    done;',
       '  done;',
       'done;',
       'for ext in svg png; do',
@@ -179,6 +203,9 @@ Item {
       '    [[ -d $base ]] && find -L "$base" \\( "${prune[@]}" \\) -prune -o $ctxskip \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" -print 2>/dev/null;',
       '  done;',
       '  find /usr/share/pixmaps -maxdepth 1 -name "*.$ext" 2>/dev/null;',
+      '  for s in "${swept[@]}"; do',
+      '    [[ -d $s ]] && find -L "$s" $ctxskip \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" -print 2>/dev/null;',
+      '  done;',
       'done;',
       '} | awk -F/ \u0027{ n=$NF; sub(/\\.[^.]+$/, "", n) } !seen[n]++\u0027'
     ].join(' ')

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -122,17 +122,65 @@ Item {
   function iconIndexScanCommand() {
     // List app/device icons across the XDG icon dirs and /usr/share/pixmaps as
     // "<path>" lines. Some desktop entries, such as Print Settings, use device
-    // icons like "printer" instead of app icons. SVGs are emitted before PNGs
-    // so the parser, which keeps the first hit per name, prefers scalable icons.
+    // icons like "printer" instead of app icons. The active icon theme (plus
+    // its Inherits chain) is emitted first so the parser, which keeps the
+    // first hit per name, prefers themed icons over stale hicolor fallbacks
+    // when the user switches to a third-party theme such as Papirus. SVGs are
+    // emitted before PNGs so scalable icons win within each tier. Finds follow
+    // symlinks (-L) because theme variants such as Papirus-Dark symlink whole
+    // context dirs back to their parent theme. Only apps/devices subtrees are
+    // descended, @2x duplicates are pruned, the fallback pass skips theme dirs
+    // already covered above (Omarchy's own icons live in hicolor, which is
+    // kept), and awk drops repeat names so the shell parses one line per icon.
     return [
-      'dirs="$HOME/.icons $HOME/.local/share/icons";',
-      'IFS=":"; for d in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do dirs="$dirs $d/icons"; done; unset IFS;',
+      '{',
+      'theme=$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "\u0027");',
+      '[[ -z $theme ]] && theme="hicolor";',
+      'bases="$HOME/.icons $HOME/.local/share/icons";',
+      'IFS=":"; for d in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do bases="$bases $d/icons"; done; unset IFS;',
+      'ordered="$theme"; pending="$theme"; seen=":$theme:";',
+      'for round in 1 2 3 4 5 6; do',
+      '  [[ -z $pending ]] && break;',
+      '  add="";',
+      '  for t in $pending; do',
+      '    for b in $bases; do',
+      '      f="$b/$t/index.theme";',
+      '      if [[ -f $f ]]; then',
+      '        inherits=$(grep -m1 "^Inherits=" "$f" | cut -d= -f2- | tr "," " ");',
+      '        for inh in $inherits; do',
+      '          if [[ $seen != *":$inh:"* ]]; then seen="$seen$inh:"; add="$add $inh"; fi;',
+      '        done;',
+      '        break;',
+      '      fi;',
+      '    done;',
+      '  done;',
+      '  pending=$add;',
+      '  ordered="$ordered$add";',
+      'done;',
+      'ctxskip="( -type d ( -name actions -o -name animations -o -name categories -o -name emblems -o -name emotes -o -name filesystems -o -name intl -o -name mimetypes -o -name panel -o -name places -o -name status -o -name stock ) ) -prune -o";',
+      'for t in $ordered; do',
+      '  for ext in svg png; do',
+      '    for base in $bases; do',
+      '      [[ -d $base/$t ]] && find -L "$base/$t" -path "*@2x*" -prune -o $ctxskip \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" -print 2>/dev/null;',
+      '    done;',
+      '  done;',
+      'done;',
+      'prune=(-path "*@2x*");',
+      'for base in $bases; do',
+      '  for d in "$base"/*/; do',
+      '    [[ -d $d ]] || continue;',
+      '    n=${d%/}; n=${n##*/};',
+      '    [[ $n == "hicolor" ]] && continue;',
+      '    [[ -f $d/index.theme ]] && prune+=(-o -path "${d%/}/*");',
+      '  done;',
+      'done;',
       'for ext in svg png; do',
-      '  for base in $dirs; do',
-      '    [[ -d $base ]] && find "$base" \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" 2>/dev/null;',
+      '  for base in $bases; do',
+      '    [[ -d $base ]] && find -L "$base" \\( "${prune[@]}" \\) -prune -o $ctxskip \\( -path "*/apps/*" -o -path "*/devices/*" \\) -name "*.$ext" -print 2>/dev/null;',
       '  done;',
       '  find /usr/share/pixmaps -maxdepth 1 -name "*.$ext" 2>/dev/null;',
-      'done'
+      'done;',
+      '} | awk -F/ \u0027{ n=$NF; sub(/\\.[^.]+$/, "", n) } !seen[n]++\u0027'
     ].join(' ')
   }
 

--- a/test/shell.d/app-library-icon-index-test.sh
+++ b/test/shell.d/app-library-icon-index-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command node
+require_command gsettings
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Fixture icon tree with adversarial layout: small rasters exist alongside
+# crisp sources so readdir luck alone would serve blurry files.
+data="$tmp/data"
+fake="$data/icons/FakeTheme"
+mid="$data/icons/MidTheme"
+other="$data/icons/OtherTheme"
+hicolor="$data/icons/hicolor"
+mkdir -p \
+  "$fake/16x16/apps" "$fake/48x48/apps" "$fake/scalable/apps" \
+  "$mid/48x48/apps" \
+  "$other/48x48/apps" \
+  "$hicolor/scalable/apps" "$hicolor/48x48/apps"
+
+printf '[Icon Theme]\nName=FakeTheme\nInherits=MidTheme\n' >"$fake/index.theme"
+printf '[Icon Theme]\nName=MidTheme\nInherits=hicolor\n' >"$mid/index.theme"
+printf '[Icon Theme]\nName=OtherTheme\n' >"$other/index.theme"
+printf '[Icon Theme]\nName=hicolor\n' >"$hicolor/index.theme"
+
+# zzvec: every tier has it; scalable svg in the active theme must win.
+touch "$fake/16x16/apps/zzvec.png"
+touch "$fake/48x48/apps/zzvec.png"
+touch "$fake/scalable/apps/zzvec.svg"
+touch "$hicolor/scalable/apps/zzvec.svg"
+# zzras: rasters only; largest must win.
+touch "$fake/16x16/apps/zzras.png"
+touch "$fake/48x48/apps/zzras.png"
+# zztheme: tiny themed file only; theme priority keeps it over nothing.
+touch "$fake/16x16/apps/zztheme.png"
+# zzmid: only in the inherited theme.
+touch "$mid/48x48/apps/zzmid.png"
+# zzother: only in a theme outside the chain; last-resort sweep finds it.
+touch "$other/48x48/apps/zzother.png"
+# zzgadget: hicolor-only name.
+touch "$hicolor/scalable/apps/zzgadget.svg"
+
+stub_bin="$tmp/bin"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/gsettings" <<'EOF'
+#!/bin/bash
+printf '%s' "${FAKE_ICON_THEME-'FakeTheme'}"
+EOF
+chmod +x "$stub_bin/gsettings"
+
+scan_command() {
+  node -e '
+const fs = require("fs");
+const qml = fs.readFileSync(process.env.ROOT + "/shell/services/AppLibrary.qml", "utf8");
+const m = qml.match(/function iconIndexScanCommand\(\) \{([\s\S]*?)\n  \}/);
+if (!m) { console.error("iconIndexScanCommand not found"); process.exit(1); }
+const fn = new Function(m[1] + "; return iconIndexScanCommand();");
+console.log(fn());
+'
+}
+
+run_scan() {
+  env -i HOME="$tmp/home" XDG_DATA_DIRS="$tmp/data" \
+    "FAKE_ICON_THEME=$1" PATH="$stub_bin:/usr/bin:/bin" \
+    bash -c "$2" 2>"$tmp/stderr"
+}
+
+cmd=$(scan_command)
+[[ -n $cmd ]] || fail "icon index scan command extracts from AppLibrary.qml"
+
+out=$(run_scan "'FakeTheme'" "$cmd")
+[[ -s $tmp/stderr ]] && fail "icon index scan runs silently" "$(cat "$tmp/stderr")"
+
+winner() {
+  grep -m1 "/$1\.\(svg\|png\)$" <<<"$out" || fail "icon index finds fixture icon $1"
+}
+
+[[ $(winner zzvec) == "$fake/scalable/apps/zzvec.svg" ]] ||
+  fail "icon index prefers the active theme's scalable svg" "$(winner zzvec)"
+[[ $(winner zzras) == "$fake/48x48/apps/zzras.png" ]] ||
+  fail "icon index prefers the largest raster" "$(winner zzras)"
+[[ $(winner zztheme) == "$fake/16x16/apps/zztheme.png" ]] ||
+  fail "icon index keeps small themed files over no fallback" "$(winner zztheme)"
+[[ $(winner zzmid) == "$mid/48x48/apps/zzmid.png" ]] ||
+  fail "icon index follows the Inherits chain" "$(winner zzmid)"
+[[ $(winner zzother) == "$other/48x48/apps/zzother.png" ]] ||
+  fail "icon index sweeps non-chain themes as a last resort" "$(winner zzother)"
+[[ $(winner zzgadget) == "$hicolor/scalable/apps/zzgadget.svg" ]] ||
+  fail "icon index falls back to hicolor" "$(winner zzgadget)"
+pass "icon index orders theme, size, and fallback coverage deterministically"
+
+out=$(run_scan "" "$cmd")
+[[ -s $tmp/stderr ]] && fail "icon index scan runs silently without a theme" "$(cat "$tmp/stderr")"
+[[ $(winner zzvec) == "$hicolor/scalable/apps/zzvec.svg" ]] ||
+  fail "icon index falls back to hicolor without a theme" "$(winner zzvec)"
+pass "icon index falls back to hicolor without a theme"

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -115,6 +115,27 @@ assert(
 )
 
 assert(
+  /function iconIndexScanCommand\(\) \{[\s\S]*?gsettings get org\.gnome\.desktop\.interface icon-theme[\s\S]*?\n  \}/.test(appLibraryQml),
+  'app library icon index reads the live icon theme instead of assuming one'
+)
+
+assert(
+  /function iconIndexScanCommand\(\) \{[\s\S]*?\^Inherits=[\s\S]*?\n  \}/.test(appLibraryQml),
+  'app library icon index follows the theme Inherits chain'
+)
+
+assert(
+  /function iconIndexScanCommand\(\) \{[\s\S]*?find -L[\s\S]*?\n  \}/.test(appLibraryQml),
+  'app library icon index follows symlinked theme dirs such as Papirus-Dark contexts'
+)
+
+assert(
+  /function iconIndexScanCommand\(\) \{[\s\S]*?ordered=[\s\S]*?for t in \$ordered[\s\S]*?pixmaps[\s\S]*?\n  \}/.test(appLibraryQml) &&
+    appLibraryQml.indexOf('for t in $ordered') < appLibraryQml.lastIndexOf('/usr/share/pixmaps'),
+  'app library icon index emits the active theme before unthemed fallbacks'
+)
+
+assert(
   appLibraryQml.includes('command: ["bash", "-c", root.hiddenEntryScanCommand()]') &&
     appLibraryQml.includes('command: ["bash", "-c", root.iconIndexScanCommand()]') &&
     !appLibraryQml.includes('"-lc"'),

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -167,4 +167,13 @@ assert(
   openMatch[1].includes('root.appLibrary.refreshIcons()'),
   'menu refreshes the shared icon index when opened'
 )
+
+assert(
+  /id: appIconImage[\s\S]*?Math\.round\(\(Style\.space\(36\) - width\) \/ 2\)/.test(menuQml),
+  'menu snaps app icon horizontal offset to whole pixels'
+)
+assert(
+  /id: appIconImage[\s\S]*?Math\.round\(contentColumn\.y \+ labelText\.y/.test(menuQml),
+  'menu snaps app icon vertical offset to whole pixels'
+)
 JS


### PR DESCRIPTION
Third-party icon themes (e.g. Papirus) were ignored by the Omarchy menu: app rows showed generic hicolor fallbacks while GTK/Qt apps themed correctly.

Root cause, both in AppLibrary.iconIndexScanCommand():
- The scan emitted icon dirs in readdir order keeping the first hit per name, so /usr/share/icons/hicolor shadowed the active theme.
- Plain find does not descend into symlinked dirs, and variants like Papirus-Dark symlink whole context dirs (16x16/apps -> ../../Papirus/16x16/apps) back to the parent theme.

This change reads the live gsettings theme, resolves its Inherits chain, and emits theme hits first; follows symlinks (-L); only descends apps/devices subtrees; prunes @2x dupes and already-covered theme dirs (hicolor kept — Omarchy's own icons live there); and dedupes to one line per icon. Index-first order in iconSource() is unchanged, so the zoom-action-icon protection still holds. Scan time stays stock-like (~1.25s vs ~1.0s).

Tests: 4 new assertions in test/shell.d/app-search-test.sh; app-search, menu, menu-plugin, plugin-clone suites pass. ./test/all shows only failures that also fail on the pristine base commit in this environment (verified via worktree), plus one flaky update-lock test that passes on re-run.