### PR TITLE
Add idle.screensaverCommand to swap the screensaver launcher

### DIFF
--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -49,4 +49,6 @@ automatically. If a change somehow fails to apply, force a reload with
 
 Set `idle.screensaver` and `idle.lock` in `~/.config/omarchy/shell.json`,
 in seconds since user idle began. Example: "lock after ten minutes" means
-setting `idle.lock` to `600`.
+setting `idle.lock` to `600`. `idle.screensaverCommand` replaces the
+default `omarchy-launch-screensaver`; the command must open a window with
+app id `org.omarchy.screensaver`.

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -167,6 +167,7 @@ Rules:
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
+   `idle.screensaverCommand` optionally replaces `omarchy-launch-screensaver`.
 8. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -88,6 +88,21 @@ This is about locking and the screensaver, not power. Suspend and hibernation ha
 
 Omarchy's screensaver is ASCII art running through random text effects, one instance per monitor. Any key or mouse movement exits it.
 
+It doesn't have to be. Set `idle.screensaverCommand` in `shell.json` to run something else when the screensaver timer fires:
+
+```json
+{
+  "version": 1,
+  "idle": {
+    "screensaver": 150,
+    "lock": 300,
+    "screensaverCommand": "my-screensaver"
+  }
+}
+```
+
+The only contract is that the command opens a window with app id `org.omarchy.screensaver` and exits on input. Hyprland already fullscreens that class, and the shell watches it to know when the screensaver has been dismissed. Leave the key out to get the default `omarchy-launch-screensaver`.
+
 You can start it on demand from _System > Screensaver_ (`Super + Esc`), which forces it up even if you've turned the idle screensaver off. There's no hotkey bound to it by default.
 
 `omarchy toggle screensaver` is what turns the idle one off, if you'd rather go straight from working to locked. It needs a terminal it knows how to configure — Alacritty, Foot, Ghostty, or Kitty — and will tell you so if your default terminal is something else.

--- a/shell/README.md
+++ b/shell/README.md
@@ -280,7 +280,9 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    entries with their own values.
 7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
    are seconds since user idle began, so the default lock fires at 300s
-   even if the 150s screensaver starts first.
+   even if the 150s screensaver starts first. `idle.screensaverCommand`
+   swaps the launcher (default `omarchy-launch-screensaver`); whatever it
+   runs must open a window with app id `org.omarchy.screensaver`.
 8. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -5,8 +5,10 @@ function secondsFromConfig(value, fallback) {
 }
 
 function screensaverCommand(value, fallback) {
-  var command = String(value === undefined || value === null ? "" : value).trim()
-  return command || fallback
+  if (typeof value !== "string") return fallback
+  var command = value.trim()
+  if (command === "" || /[\r\n\0]/.test(command)) return fallback
+  return command
 }
 
 function eventParts(event, count) {

--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -4,6 +4,11 @@ function secondsFromConfig(value, fallback) {
   return Math.floor(n)
 }
 
+function screensaverCommand(value, fallback) {
+  var command = String(value === undefined || value === null ? "" : value).trim()
+  return command || fallback
+}
+
 function eventParts(event, count) {
   try {
     if (event && event.parse) return event.parse(count)
@@ -46,6 +51,7 @@ function screensaverWindowsAfter(windows, address, visible) {
 if (typeof module !== "undefined") {
   module.exports = {
     secondsFromConfig: secondsFromConfig,
+    screensaverCommand: screensaverCommand,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter
   }

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -16,9 +16,11 @@ Item {
   readonly property string stayAwakeStatePath: stayAwakeStateDir + "/stay-awake"
   readonly property int defaultScreensaverSeconds: 150
   readonly property int defaultLockSeconds: 300
+  readonly property string defaultScreensaverCommand: "omarchy-launch-screensaver"
   readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
   readonly property int screensaverTimeoutSeconds: secondsFromConfig(idleConfig.screensaver, defaultScreensaverSeconds)
   readonly property int lockTimeoutSeconds: secondsFromConfig(idleConfig.lock, defaultLockSeconds)
+  readonly property string screensaverCommand: IdleModel.screensaverCommand(idleConfig.screensaverCommand, defaultScreensaverCommand)
   readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
   readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
@@ -65,7 +67,7 @@ Item {
   function launchScreensaver() {
     root.screensaverStartedThisCycle = true
     screensaverLaunchGraceTimer.restart()
-    runProcess(screensaverProcess, "screensaver", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || omarchy-launch-screensaver")
+    runProcess(screensaverProcess, "screensaver", "[[ $(omarchy-shell lock isLocked 2>/dev/null) == \"true\" ]] || " + root.screensaverCommand)
   }
 
   function lockSystem(reason) {
@@ -187,6 +189,7 @@ Item {
       inIdleCycle: root.idledThisCycle,
       screensaverStarted: root.screensaverStartedThisCycle,
       screensaver: root.screensaverTimeoutSeconds,
+      screensaverCommand: root.screensaverCommand,
       lock: root.lockTimeoutSeconds,
       screensaverDelay: root.screensaverDelaySeconds,
       lockDelay: root.lockDelaySeconds,

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -11,6 +11,10 @@ assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seco
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
 
+assertEqual(idle.screensaverCommand('my-saver --fancy', 'default'), 'my-saver --fancy', 'idle uses configured screensaver command')
+assertEqual(idle.screensaverCommand('  ', 'default'), 'default', 'idle falls back on blank screensaver command')
+assertEqual(idle.screensaverCommand(undefined, 'default'), 'default', 'idle falls back on missing screensaver command')
+
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(
   idle.eventParts({ parse: function(count) { return ['parsed', count] } }, 4),

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -14,7 +14,8 @@ assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid second
 assertEqual(idle.screensaverCommand('my-saver --fancy', 'default'), 'my-saver --fancy', 'idle uses configured screensaver command')
 assertEqual(idle.screensaverCommand('  ', 'default'), 'default', 'idle falls back on blank screensaver command')
 assertEqual(idle.screensaverCommand(undefined, 'default'), 'default', 'idle falls back on missing screensaver command')
-
+assertEqual(idle.screensaverCommand(42, 'default'), 'default', 'idle rejects non-string screensaver command')
+assertEqual(idle.screensaverCommand('my-saver\n--fancy', 'default'), 'default', 'idle rejects multiline screensaver command')
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(
   idle.eventParts({ parse: function(count) { return ['parsed', count] } }, 4),


### PR DESCRIPTION
## Add `idle.screensaverCommand` to swap the screensaver launcher

The idle service hardcodes `omarchy-launch-screensaver`. Everything else about the screensaver is already pluggable: Hyprland fullscreens any window with app id `org.omarchy.screensaver`, and the service watches open/close events on that class to cancel the lock when the user dismisses it. Only the launcher name is fixed, so replacing the screensaver today means shadowing a binary that sits first in `PATH`.

This adds an optional `idle.screensaverCommand` string in `shell.json`. When set, the idle service runs it instead of the default; blank or missing falls back to `omarchy-launch-screensaver`. The lock-state guard in front of the command is unchanged.

```json
{ "version": 1, "idle": { "screensaver": 150, "lock": 300, "screensaverCommand": "my-screensaver" } }
```

Motivating example: https://github.com/thiagolunardi/johnny-omarchy runs Sierra's 1992 *Johnny Castaway* as the screensaver through an SDL2 window that claims the app id. With this key it is one config line; without it, it has to edit `~/.bashrc` to win the PATH race.

Changes:
- `IdleModel.js`: `screensaverCommand(value, fallback)` helper, unit-tested in `idle-test.sh`.
- `Service.qml`: reads the key, uses it in `launchScreensaver()`, exposes it in `statusJson()`.
- Docs: `shell/README.md`, `docs/omarchy-shell.md`, manual 13, and the agent skill.

`test/shell.d/idle-test.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDhS4nj6s2117nWvVAuUWp
