### PR TITLE
Send Broadcom's ACL-priority command to fix Bluetooth A2DP stutter on T2 Macs

### DIFF
--- a/bin/omarchy-hw-apple-bt-a2dp-priority
+++ b/bin/omarchy-hw-apple-bt-a2dp-priority
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# omarchy:summary=Send the Broadcom ACL-priority command for A2DP audio
+# omarchy:hidden=true
+
+# BlueZ never sends Broadcom's vendor-specific Write_High_Priority_Connection
+# command (OGF 0x3f / OCF 0x57) for an A2DP link. Android and macOS send it
+# automatically; without it, BCM43xx firmware treats the A2DP ACL handle as
+# no-priority, so it loses out the instant a concurrent scan/inquiry competes
+# for airtime, and audio stutters badly. See
+# https://github.com/bluez/bluez/issues/1976 and
+# https://github.com/christian-korneck/asahi-bt-a2dp-fix (same root cause,
+# reported on BCM4377/4378/4388 under Asahi).
+#
+# bluetoothctl --monitor reads its own stdin as commands and treats EOF there
+# as an implicit "quit" — under a plain systemd ExecStart, stdin is closed, so
+# it would quit immediately and the unit would sit in a restart loop. Holding
+# stdin open on a pipe that never closes keeps it running as an event feed.
+settle_seconds=${BT_A2DP_PRIORITY_CONNECT_SETTLE_SECONDS:-2}
+
+stdbuf -oL bluetoothctl --monitor < <(sleep infinity) | while read -r line; do
+  [[ $line =~ Device.*([0-9A-F:]{17}).*Connected:\ yes ]] || continue
+  mac=${BASH_REMATCH[1]}
+  sleep "$settle_seconds"
+  bluetoothctl info "$mac" | grep -q "Audio Sink" || continue
+  handle=$(hcitool con | grep -i "$mac" | grep -oP 'handle \K[0-9]+')
+  [[ -n $handle ]] && hcitool cmd 0x3f 0x57 "$(printf '0x%02X' "$handle")" 0x00 0x01
+done

--- a/default/systemd/system/omarchy-bt-a2dp-priority.service
+++ b/default/systemd/system/omarchy-bt-a2dp-priority.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Bluetooth A2DP ACL-priority fix for Broadcom BCM43xx (hci_bcm4377)
+Documentation=https://github.com/bluez/bluez/issues/1976
+ConditionPathIsDirectory=/sys/module/hci_bcm4377
+After=bluetooth.target
+Wants=bluetooth.target
+
+[Service]
+Type=simple
+# If bluetoothd is unavailable, skip cleanly instead of entering a restart loop.
+ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service
+ExecStart=/usr/bin/omarchy-hw-apple-bt-a2dp-priority
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -39,6 +39,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-bt-a2dp-priority.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/bt-a2dp-priority.sh
+++ b/install/hardware/apple/bt-a2dp-priority.sh
@@ -1,0 +1,22 @@
+# Shared helpers for the Broadcom A2DP ACL-priority fix (install leaf + migration).
+#
+# BlueZ never sends Broadcom's vendor-specific Write_High_Priority_Connection
+# command for an A2DP link, so audio stutters badly under any concurrent
+# scan/inquiry. See bin/omarchy-hw-apple-bt-a2dp-priority for the fix itself.
+#
+# Gated on the same PCI ID Omarchy already uses to detect a T2 Mac (see
+# fix-t2.sh) — every T2 Mac's Bluetooth is a member of this Broadcom family,
+# driven by hci_bcm4377.
+
+bt_a2dp_priority_needed() {
+  lspci -nn 2>/dev/null | grep -q "106b:180[12]"
+}
+
+bt_a2dp_priority_installed() {
+  systemctl is-enabled --quiet omarchy-bt-a2dp-priority.service 2>/dev/null
+}
+
+bt_a2dp_priority_install() {
+  omarchy-pkg-add bluez-deprecated-tools
+  sudo systemctl enable --now omarchy-bt-a2dp-priority.service
+}

--- a/install/hardware/apple/fix-bt-a2dp-priority.sh
+++ b/install/hardware/apple/fix-bt-a2dp-priority.sh
@@ -1,0 +1,18 @@
+# BlueZ never sends Broadcom's vendor-specific ACL-priority command for A2DP
+# links, so audio stutters badly under any concurrent scan/inquiry. See
+# bt-a2dp-priority.sh for the mechanism.
+
+: "${OMARCHY_PATH:=/usr/share/omarchy}"
+: "${OMARCHY_INSTALL:=$OMARCHY_PATH/install}"
+# shellcheck source=bt-a2dp-priority.sh
+source "$OMARCHY_INSTALL/hardware/apple/bt-a2dp-priority.sh"
+
+if ! bt_a2dp_priority_needed; then
+  return 0
+fi
+if bt_a2dp_priority_installed; then
+  return 0
+fi
+
+echo "Wiring up the Bluetooth A2DP ACL-priority fix"
+bt_a2dp_priority_install

--- a/migrations/1788703723.sh
+++ b/migrations/1788703723.sh
@@ -1,0 +1,15 @@
+echo "Wire up the Bluetooth A2DP ACL-priority fix for existing installs"
+
+: "${OMARCHY_PATH:=/usr/share/omarchy}"
+: "${OMARCHY_INSTALL:=$OMARCHY_PATH/install}"
+# shellcheck source=../install/hardware/apple/bt-a2dp-priority.sh
+source "$OMARCHY_INSTALL/hardware/apple/bt-a2dp-priority.sh"
+
+if ! bt_a2dp_priority_needed; then
+  exit 0
+fi
+if bt_a2dp_priority_installed; then
+  exit 0
+fi
+
+bt_a2dp_priority_install

--- a/test/shell.d/apple-bt-a2dp-priority-test.sh
+++ b/test/shell.d/apple-bt-a2dp-priority-test.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+watcher="$ROOT/bin/omarchy-hw-apple-bt-a2dp-priority"
+helpers="$ROOT/install/hardware/apple/bt-a2dp-priority.sh"
+fix="$ROOT/install/hardware/apple/fix-bt-a2dp-priority.sh"
+service="$ROOT/default/systemd/system/omarchy-bt-a2dp-priority.service"
+migration="$ROOT/migrations/1788703723.sh"
+
+[[ -x $watcher ]] || fail "the watcher script is executable"
+
+grep -Fq 'ExecStart=/usr/bin/omarchy-hw-apple-bt-a2dp-priority' "$service" ||
+  fail "service runs the watcher script"
+grep -Fq 'ConditionPathIsDirectory=/sys/module/hci_bcm4377' "$service" ||
+  fail "service is gated on the hci_bcm4377 driver being loaded"
+pass "service runs the watcher script only where hci_bcm4377 is loaded"
+
+grep -Fq 'fix-bt-a2dp-priority.sh' "$ROOT/install/hardware/all.sh" ||
+  fail "hardware install runs the A2DP priority fix hook"
+pass "A2DP priority fix hook is wired into the installer"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+# --- hardware gate ---
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+cat "$LSPCI_OUTPUT"
+SH
+chmod +x "$stub_bin/lspci"
+
+# shellcheck source=../../install/hardware/apple/bt-a2dp-priority.sh
+source "$helpers"
+
+assert_needed() {
+  local pci_line=$1 expect=$2 description=$3
+  local tmp
+  tmp=$(mktemp)
+  printf '%s\n' "$pci_line" >"$tmp"
+  if PATH="$stub_bin:$PATH" LSPCI_OUTPUT="$tmp" bt_a2dp_priority_needed; then
+    [[ $expect == yes ]] || fail "$description"
+  else
+    [[ $expect == no ]] || fail "$description"
+  fi
+  rm -f "$tmp"
+  pass "$description"
+}
+
+assert_needed "00:1f.3 Bluetooth: Broadcom Inc. and subsidiaries [106b:1802] (rev 40)" yes "T2 iBridge (1802) is detected"
+assert_needed "00:1f.3 Bluetooth: Broadcom Inc. and subsidiaries [106b:1801] (rev 40)" yes "T2 iBridge (1801) is detected"
+assert_needed "00:1f.3 Ethernet controller [8086:15d8]" no "non-T2 hardware is not detected"
+
+# --- watcher script picks A2DP connects out of bluetoothctl --monitor ---
+cat >"$stub_bin/bluetoothctl" <<'SH'
+#!/bin/bash
+if [[ $1 == "--monitor" ]]; then
+  cat "$MONITOR_FEED"
+  exit 0
+fi
+if [[ $1 == "info" ]]; then
+  grep -q "$2" "$AUDIO_SINK_DEVICES" && echo "UUID: Audio Sink"
+  exit 0
+fi
+SH
+cat >"$stub_bin/hcitool" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HCITOOL_LOG"
+[[ $1 == "con" ]] && cat "$HCITOOL_CON_OUTPUT"
+SH
+chmod +x "$stub_bin"/*
+
+feed="$test_tmp/monitor-feed"
+con_out="$test_tmp/con-out"
+sink_devices="$test_tmp/sink-devices"
+hcitool_log="$test_tmp/hcitool.log"
+printf '< ACL AA:BB:CC:DD:EE:FF handle 11 state 1 lm MASTER\n' >"$con_out"
+
+# The stub feed ends after one line, unlike the real bluetoothctl --monitor,
+# which never exits — the loop's last `read` then hits EOF and returns 1,
+# which becomes the whole script's exit status. That's a property of this
+# stub, not a bug in the watcher, so the exit status itself isn't asserted on.
+run_watcher() {
+  PATH="$stub_bin:$PATH" \
+    MONITOR_FEED="$feed" \
+    AUDIO_SINK_DEVICES="$sink_devices" \
+    HCITOOL_CON_OUTPUT="$con_out" \
+    HCITOOL_LOG="$hcitool_log" \
+    BT_A2DP_PRIORITY_CONNECT_SETTLE_SECONDS=0 \
+    "$watcher" || true
+}
+
+printf '[CHG] Device AA:BB:CC:DD:EE:FF Connected: yes\n' >"$feed"
+printf 'AA:BB:CC:DD:EE:FF\n' >"$sink_devices"
+: >"$hcitool_log"
+run_watcher
+grep -Fq 'cmd 0x3f 0x57 0x0B 0x00 0x01' "$hcitool_log" ||
+  fail "watcher sends the ACL-priority command for a connected audio sink" "$(cat "$hcitool_log")"
+pass "watcher sends the ACL-priority command for a connected audio sink"
+
+printf '[CHG] Device 11:22:33:44:55:66 Connected: yes\n' >"$feed"
+: >"$sink_devices"
+: >"$hcitool_log"
+run_watcher
+[[ ! -s $hcitool_log ]] || fail "watcher ignores a connect from a non-audio device" "$(cat "$hcitool_log")"
+pass "watcher ignores a connect from a non-audio device"
+
+# --- install hook + migration wiring ---
+calls="$test_tmp/calls.log"
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+[[ $1 == "is-enabled" ]] && [[ -f $SERVICE_ENABLED_MARKER ]]
+SH
+chmod +x "$stub_bin"/*
+
+t2_pci="$test_tmp/pci-t2"
+non_t2_pci="$test_tmp/pci-non-t2"
+printf '00:1f.3 Bluetooth: Broadcom Inc. and subsidiaries [106b:1802]\n' >"$t2_pci"
+printf '00:1f.3 Ethernet controller [8086:15d8]\n' >"$non_t2_pci"
+enabled_marker="$test_tmp/service-enabled"
+
+run_fix_or_migration() {
+  local script=$1 pci=$2
+  PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    LSPCI_OUTPUT="$pci" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_INSTALL="$ROOT/install" \
+    SERVICE_ENABLED_MARKER="$enabled_marker" \
+    bash -c 'source "$1"' _ "$script"
+}
+
+: >"$calls"; rm -f "$enabled_marker"
+run_fix_or_migration "$fix" "$non_t2_pci"
+[[ ! -s $calls ]] || fail "install hook no-ops on non-T2 hardware" "$(cat "$calls")"
+pass "install hook no-ops on non-T2 hardware"
+
+: >"$calls"; rm -f "$enabled_marker"
+run_fix_or_migration "$fix" "$t2_pci"
+grep -Fq $'omarchy-pkg-add\tbluez-deprecated-tools' "$calls" ||
+  fail "install hook installs bluez-deprecated-tools" "$(cat "$calls")"
+grep -Fq $'sudo\tsystemctl\tenable\t--now\tomarchy-bt-a2dp-priority.service' "$calls" ||
+  fail "install hook enables the priority-fix service" "$(cat "$calls")"
+pass "install hook wires the A2DP priority fix on T2 hardware"
+
+touch "$enabled_marker"
+: >"$calls"
+run_fix_or_migration "$fix" "$t2_pci"
+grep -Fq $'sudo\tsystemctl\tenable\t--now\tomarchy-bt-a2dp-priority.service' "$calls" &&
+  fail "install hook is a no-op once already enabled" "$(cat "$calls")"
+pass "install hook is a no-op once already enabled"
+
+rm -f "$enabled_marker"
+: >"$calls"
+run_fix_or_migration "$migration" "$t2_pci"
+grep -Fq $'sudo\tsystemctl\tenable\t--now\tomarchy-bt-a2dp-priority.service' "$calls" ||
+  fail "migration enables the priority-fix service on existing T2 installs" "$(cat "$calls")"
+pass "migration wires the A2DP priority fix on existing T2 installs"
+
+: >"$calls"
+run_fix_or_migration "$migration" "$non_t2_pci"
+[[ ! -s $calls ]] || fail "migration skips unrelated hardware" "$(cat "$calls")"
+pass "migration skips unrelated hardware"


### PR DESCRIPTION
## Why

BlueZ never sends Broadcom's vendor-specific `Write_High_Priority_Connection` HCI command (OGF `0x3f` / OCF `0x57`) for an A2DP link. Android and macOS send this automatically; without it, BCM43xx firmware treats the A2DP ACL handle as no-priority, so it loses out the instant a concurrent scan/inquiry competes for airtime, and audio stutters badly.

This is most visible on T2 Macs whenever the omarchy Bluetooth widget is open: its `discoveryRetry` timer (`shell/plugins/panels/bluetooth/Panel.qml`) intentionally keeps BlueZ discovery running continuously while the panel is open, so it constantly collides with this starvation. But the widget is only exposing a pre-existing condition — the same stutter reproduces with the widget fully closed by running `bluetoothctl scan on` directly, and clears the instant scan stops.

Isolated and confirmed on a T2 MacBook Pro (`hci_bcm4377`) with a root `btmon` capture during `scan on`: BlueZ sets `LE Set Scan Parameters` to `Interval = Window = 11.25ms` (its own `DISCOV_LE_SCAN_INTERVAL_FAST`/`WIN_FAST` constants — 100% duty-cycle scanning) and runs a 5.12s classic BR/EDR General Inquiry. No command errors or abnormal statuses anywhere in the capture — this is stock BlueZ discovery behavior, not something specific to `hci_bcm4377`.

The real fix belongs in BlueZ itself (see [jonas2515/bluez@b7ca931](https://github.com/jonas2515/bluez/commit/b7ca931d7f6ffb5f788bf80d0c8557f8607017dc), which hooks the command into `profiles/audio/avdtp.c` at A2DP stream open), but that has sat unmerged. This PR ships the userspace workaround from [bluez/bluez#1976](https://github.com/bluez/bluez/issues/1976) / [christian-korneck/asahi-bt-a2dp-fix](https://github.com/christian-korneck/asahi-bt-a2dp-fix) (same root cause, reported on BCM4377/4378/4388 under Asahi) instead, ported from their Fedora/AUR-based install to Arch's own packaging.

> **Model note:** diagnosed and verified on one T2 MacBook Pro. The fix targets the PCI ID Omarchy already uses to gate `fix-t2.sh`, so it applies to every T2 Mac (all of which use this same Broadcom family via `hci_bcm4377`), but only field-tested on this one unit.

## What

- `bin/omarchy-hw-apple-bt-a2dp-priority` — watches `bluetoothctl --monitor` for an audio-sink device connecting, then sends the ACL-priority command via `hcitool cmd` for that connection's handle. `bluetoothctl --monitor` reads its own stdin as commands and treats EOF there as an implicit `quit`; under a plain systemd `ExecStart` stdin is closed, so this holds it open on a pipe that never closes.
- `install/hardware/apple/bt-a2dp-priority.sh` — shared `needed`/`installed`/`install` helpers (install leaf + migration), gated on the same T2 PCI ID `fix-t2.sh` already detects.
- `install/hardware/apple/fix-bt-a2dp-priority.sh` — install-time hook, wired into `install/hardware/all.sh` right after the Broadcom Wi-Fi supplicant fix (same chip family).
- `default/systemd/system/omarchy-bt-a2dp-priority.service` — runs the watcher, gated on `hci_bcm4377` being loaded, skips cleanly if `bluetoothd` isn't up (same `ExecCondition` idiom as `bt-agent.service`).
- Migration `1788703723` does the same for existing installs.
- `test/shell.d/apple-bt-a2dp-priority-test.sh` covers the hardware gate, the watcher against a stubbed `bluetoothctl`/`hcitool`, and the install/migration wiring.

## Test plan

- [x] `./test/shell` (224/228 files pass; the 4 pre-existing failures — `bin-style-test.sh` on unrelated older scripts, `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh` — are environment-dependent on this live desktop and untouched by this change)
- [x] `./test/cli`
- [x] `test/shell.d/apple-bt-a2dp-priority-test.sh`
- [x] T2 MacBook Pro: reproduced the stutter with `bluetoothctl scan on` while A2DP audio played, installed the fix, confirmed the same test is clean afterward; journal shows the command firing on reconnect with `Command Complete ... status 00 (Success)`