### PR TITLE
Fix omarchy-windows-vm silently failing once shared/storage picks up setgid

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,14 +580,19 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  # A numeric chmod alone is not reliably enough to clear pre-existing special
+  # bits on every system (e.g. setgid the guest's Samba share left on the
+  # shared source): strip them explicitly with a symbolic chmod too.
+  if ! chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" ||
+    ! chmod u-s,g-s,-t -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd"; then
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
-  }
+  fi
   storage_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$storage_fd" 2>/dev/null) || storage_mode=""
   shared_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$shared_fd" 2>/dev/null) || shared_mode=""
   if [[ $storage_mode != 700 || $shared_mode != 700 ]]; then
+    echo "omarchy-windows-vm: could not reduce $LEGACY_STORAGE or $LEGACY_SHARED to private (0700, no special bits) permissions; a service inside the VM (e.g. the shared folder's Samba share) may have left extra permission or setgid/setuid/sticky bits behind. Fix manually with: chmod 0700 '$LEGACY_STORAGE' '$LEGACY_SHARED' && chmod u-s,g-s,-t '$LEGACY_STORAGE' '$LEGACY_SHARED'" >&2
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1


### PR DESCRIPTION
## What happened
After a normal cycle (install → RDP → shut down Windows from inside the guest → close RDP), the very next `omarchy-windows-vm launch` fails with no explanation:

```
Starting Windows VM (this may prompt for authorization)...
❌ Failed to start Windows VM!
   Try checking: omarchy-windows-vm status
```

Nothing else is printed — not on the terminal, not in `journalctl` for `pkexec`/`polkitd`. It fails within ~1 second, well before the `up_wait` 2-minute readiness timeout, so it's failing during pre-flight mount setup, not while bringing the container up.

## Root cause
`~/Windows` (the "shared" bind-mount source) had picked up the setgid bit and open permissions (`drwxrwsrwx`, mode `2777`) — almost certainly set by the `dockurr/windows` container's Samba service while the VM was running, so the guest can write into the share.

`prepare_caller_mounts()` tries to normalize both mount sources back to `0700` via a plain numeric `chmod`, then compares the resulting mode against the exact string `"700"`:

```bash
chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || { ... return 1; }
storage_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$storage_fd" 2>/dev/null) || storage_mode=""
shared_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$shared_fd" 2>/dev/null) || shared_mode=""
if [[ $storage_mode != 700 || $shared_mode != 700 ]]; then
  ...
  return 1
fi
```

On at least some systems, a numeric `chmod` does not clear an already-set setgid bit on a directory — `stat` afterwards still reports `2700`, not `700`. Reproduced independently of this script, on a throwaway directory:

```
$ mkdir -m 2777 x && chmod -v 0700 x
mode of 'x' changed from 2777 (rwxrwsrwx) to 2700 (rwx--S---)
$ stat -c %a x
2700
$ chmod g-s x && stat -c %a x
700
```

`chmod`'s own verbose output confirms it's *applying* `2700`, not `700` — this isn't a `stat` display quirk. (Observed on Arch, coreutils 9.11-2, kernel 7.2.3-arch1-2.) Regardless of exactly which systems hit this:

1. **It's a permanent lock-out.** Once the shared directory picks up setgid — which the VM's own Samba share does routinely — `shared_mode` reads `2700` forever, and the exact-string check `!= 700` fails forever. Every future `launch`/`up`/`status`-triggered remount refuses, with no self-heal path.
2. **The failure is completely silent.** Unlike every other guard in `prepare_caller_mounts`/`assert_mounts_safe`, this branch has no `echo ... >&2` before `return 1`. The user only ever sees the generic "❌ Failed to start Windows VM!" from `launch_windows()`.

## Fix
- Strip the special bits explicitly with a symbolic `chmod u-s,g-s,-t` in addition to the numeric `chmod 0700`, so the special bits are reliably cleared regardless of the numeric-chmod behavior above.
- Print an actionable error (naming the paths and the exact fix command) when the directories still aren't private afterward, instead of failing silently.

## Steps to reproduce (pre-fix)
1. `omarchy-windows-vm install`, let Windows install and boot.
2. Connect via RDP, shut Windows down from inside the guest (Start → Shut down), close the RDP window.
3. Run `omarchy-windows-vm launch` again.
4. Observe: `❌ Failed to start Windows VM!` with no further detail; `stat -c '%a' ~/Windows` shows `2700` instead of `700`.

Workaround without this fix: `chmod g-s ~/Windows` (and `~/.windows` if affected) before relaunching.

## Testing
- `bash -n bin/omarchy-windows-vm` passes.
- Verified the fix logic against the reproduced stuck-setgid case: `mkdir -m 2777 x && chmod 0700 -- x && chmod u-s,g-s,-t -- x` reliably yields mode `700`.

---
Filed by Claude Sonnet 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMUEMu5f47rsXDshPgSRq8