### PR TITLE
Allow Hyprland binding switches in Lua diagnostics

### DIFF
--- a/config/hypr/.luarc.json
+++ b/config/hypr/.luarc.json
@@ -6,6 +6,6 @@
     "checkThirdParty": false
   },
   "diagnostics": {
-    "globals": ["hl", "o"]
+    "globals": ["hl", "o", "omarchy_default_bindings", "omarchy_preinstalled_bindings"]
   }
 }


### PR DESCRIPTION
Uncommenting either documented binding switch in `hyprland.lua` triggers LuaLS's `lowercase-global` diagnostic in Neovim: “Global variable in lowercase initial, Did you miss `local` or misspell it?” These variables must remain global because Omarchy reads them through `_G`.

Add `omarchy_default_bindings` and `omarchy_preinstalled_bindings` to the allowed globals in `config/hypr/.luarc.json`, alongside `hl` and `o`, so users can enable the documented switches without this diagnostic.

Validation:

- LuaLS check of a minimal file assigning both switches: two `lowercase-global` diagnostics with the original config; no diagnostics with this change.
- JSON parsing and `git diff --check` pass.
- Ran `./test/all`: CLI suite passed; shell suite reported five failing test files. All five failures also reproduce on the unchanged baseline: `bin-style-test.sh` (command helper usage), `launch-about-test.sh` (roomy-window animation), and `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` (missing companion `omarchy-pkgs` checkout).
