### PR TITLE
Avoid idle headphone pops on ASUS GU605CX

### DIFF
--- a/bin/omarchy-hw-asus-gu605cx-alc285
+++ b/bin/omarchy-hw-asus-gu605cx-alc285
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Detect ASUS GU605CX laptops with the ALC285 idle audio pop issue.
+
+dmi_path="${OMARCHY_DMI_PATH:-/sys/class/dmi/id}"
+hda_devices_path="${OMARCHY_HDA_DEVICES_PATH:-/sys/bus/hdaudio/devices}"
+
+grep -qxF "ASUSTeK COMPUTER INC." "$dmi_path/board_vendor" 2>/dev/null &&
+  grep -qxF "GU605CX" "$dmi_path/board_name" 2>/dev/null || exit 1
+
+# These cached IDs do not wake the codec, unlike reading /proc/asound codecs.
+shopt -s nullglob
+for codec in "$hda_devices_path"/*; do
+  if grep -qxF "0x10ec0285" "$codec/vendor_id" 2>/dev/null &&
+    grep -qxF "0x10431034" "$codec/subsystem_id" 2>/dev/null; then
+    exit 0
+  fi
+done
+
+exit 1

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -32,6 +32,7 @@ run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-display-backlight.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-display.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-z13-touchpad.sh"
+run_logged "$OMARCHY_INSTALL/hardware/asus/fix-gu605cx-audio-pop.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 

--- a/install/hardware/asus/fix-gu605cx-audio-pop.sh
+++ b/install/hardware/asus/fix-gu605cx-audio-pop.sh
@@ -1,6 +1,6 @@
 # The GU605CX ALC285 headphone output pops when idle HDA power saving kicks in.
 # Keeping the codec powered avoids the pop, but may increase idle power use.
-# Only the pause/resume case has been verified; boot and shutdown are untested.
+# Idle pops are fixed; shutdown pops persist and boot popping is unverified.
 
 if omarchy-hw-asus-gu605cx-alc285; then
   audio_config="/etc/modprobe.d/omarchy-asus-gu605cx-audio.conf"

--- a/install/hardware/asus/fix-gu605cx-audio-pop.sh
+++ b/install/hardware/asus/fix-gu605cx-audio-pop.sh
@@ -1,5 +1,5 @@
 # The GU605CX ALC285 headphone output pops when idle HDA power saving kicks in.
-# Keeping HDA powered avoids the pop, at the cost of increased idle power use.
+# Keeping the codec powered avoids the pop, but may increase idle power use.
 # Only the pause/resume case has been verified; boot and shutdown are untested.
 
 if omarchy-hw-asus-gu605cx-alc285; then
@@ -16,8 +16,9 @@ audio_temp=$(mktemp /etc/modprobe.d/.omarchy-asus-gu605cx-audio.XXXXXX)
 trap 'rm -f "$audio_temp"' EXIT
 cat > "$audio_temp" <<'EOF'
 # Avoid idle HDA power transitions that pop on ASUS GU605CX headphone outputs.
-# These driver-wide options also affect other HDA controllers on this laptop.
-options snd_hda_intel power_save=0 power_save_controller=N
+# This driver-wide option also applies to other HDA controllers on this laptop.
+# Leave controller power-saving policy unchanged; disabling codec idle saving is enough.
+options snd_hda_intel power_save=0
 EOF
 chmod 644 "$audio_temp"
 ln -T -- "$audio_temp" "$audio_config"

--- a/install/hardware/asus/fix-gu605cx-audio-pop.sh
+++ b/install/hardware/asus/fix-gu605cx-audio-pop.sh
@@ -1,0 +1,26 @@
+# The GU605CX ALC285 headphone output pops when idle HDA power saving kicks in.
+# Keeping HDA powered avoids the pop, at the cost of increased idle power use.
+# Only the pause/resume case has been verified; boot and shutdown are untested.
+
+if omarchy-hw-asus-gu605cx-alc285; then
+  audio_config="/etc/modprobe.d/omarchy-asus-gu605cx-audio.conf"
+
+  # Preserve administrator overrides, including symlinks and empty opt-out files.
+  if [[ ! -e $audio_config && ! -L $audio_config ]]; then
+    sudo bash -eu <<'ROOT'
+audio_config="/etc/modprobe.d/omarchy-asus-gu605cx-audio.conf"
+mkdir -p /etc/modprobe.d
+
+# Publish only a complete file so a failed write can be retried by the migration.
+audio_temp=$(mktemp /etc/modprobe.d/.omarchy-asus-gu605cx-audio.XXXXXX)
+trap 'rm -f "$audio_temp"' EXIT
+cat > "$audio_temp" <<'EOF'
+# Avoid idle HDA power transitions that pop on ASUS GU605CX headphone outputs.
+# These driver-wide options also affect other HDA controllers on this laptop.
+options snd_hda_intel power_save=0 power_save_controller=N
+EOF
+chmod 644 "$audio_temp"
+ln -T -- "$audio_temp" "$audio_config"
+ROOT
+  fi
+fi

--- a/migrations/1788118369.sh
+++ b/migrations/1788118369.sh
@@ -1,0 +1,11 @@
+echo "Avoid idle audio pops on ASUS GU605CX laptops with Realtek ALC285"
+
+if omarchy-hw-asus-gu605cx-alc285; then
+  audio_config="/etc/modprobe.d/omarchy-asus-gu605cx-audio.conf"
+
+  if [[ ! -e $audio_config && ! -L $audio_config ]]; then
+    source "$OMARCHY_PATH/install/hardware/asus/fix-gu605cx-audio-pop.sh"
+    # Apply on the next boot: changing live power states can itself cause a pop.
+    omarchy-state set reboot-required
+  fi
+fi

--- a/test/shell.d/asus-gu605cx-audio-test.sh
+++ b/test/shell.d/asus-gu605cx-audio-test.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+detector="$ROOT/bin/omarchy-hw-asus-gu605cx-alc285"
+leaf="install/hardware/asus/fix-gu605cx-audio-pop.sh"
+migration="migrations/1788118369.sh"
+
+grep -q 'run_logged .*hardware/asus/fix-gu605cx-audio-pop.sh' "$ROOT/install/hardware/all.sh" ||
+  fail "hardware setup includes the GU605CX audio workaround"
+pass "hardware setup includes the GU605CX audio workaround"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+dmi="$test_tmp/sys/dmi"
+hda="$test_tmp/sys/hda"
+audio_config="$test_tmp/etc/modprobe.d/omarchy-asus-gu605cx-audio.conf"
+call_log="$test_tmp/calls.log"
+mkdir -p "$test_tmp/bin" "$test_tmp/$(dirname "$leaf")" "$test_tmp/migrations"
+
+# Rewrite only scratch copies; no test destination override enters production.
+for script in "$leaf" "$migration"; do
+  sed "s|/etc/modprobe.d|$test_tmp/etc/modprobe.d|g" \
+    "$ROOT/$script" >"$test_tmp/$script"
+  grep -Eq '(^|[[:space:]"(=])/etc/' "$test_tmp/$script" &&
+    fail "test copies contain only the scratch configuration destination"
+done
+
+cat >"$test_tmp/bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$CALL_LOG"
+# Only execute the inspected privileged block after its destinations are rewritten.
+if (( $# != 2 )) || [[ $1 != "bash" || $2 != "-eu" ]]; then
+  printf 'forbidden sudo command\n' >>"$CALL_LOG"
+  exit 98
+fi
+script=$(/usr/bin/cat)
+destinations=${script//"$TEST_CONFIG_DIR"/SCRATCH}
+if [[ $destinations == *"/etc/"* || $destinations == *"/sys/"* || $destinations == *"/proc/"* || $destinations == *"/dev/"* ]]; then
+  printf 'forbidden host path\n' >>"$CALL_LOG"
+  exit 98
+fi
+if (( TEST_SUDO_STATUS != 0 )); then
+  exit "$TEST_SUDO_STATUS"
+fi
+exec /usr/bin/bash -eu <<<"$script"
+SH
+
+cat >"$test_tmp/bin/cat" <<'SH'
+#!/bin/bash
+if (( TEST_WRITE_STATUS != 0 )); then
+  # Simulate a write that leaves some output before reporting failure.
+  /usr/bin/head -n 1
+  exit "$TEST_WRITE_STATUS"
+fi
+exec /usr/bin/cat "$@"
+SH
+
+cat >"$test_tmp/bin/omarchy-state" <<'SH'
+#!/bin/bash
+printf 'state %s\n' "$*" >>"$CALL_LOG"
+[[ $* == "set reboot-required" ]]
+SH
+
+cat >"$test_tmp/bin/forbidden" <<'SH'
+#!/bin/bash
+printf 'forbidden %s %s\n' "${0##*/}" "$*" >>"$CALL_LOG"
+exit 98
+SH
+chmod +x "$test_tmp/bin"/*
+for command in systemctl modprobe rmmod tee pkexec reboot shutdown; do
+  ln -s forbidden "$test_tmp/bin/$command"
+done
+
+reset_hardware() {
+  rm -rf "$test_tmp/sys"
+  mkdir -p "$dmi" "$hda/hdaudioC0D0" "$hda/hdaudioC1D0"
+  printf 'ASUSTeK COMPUTER INC.\n' >"$dmi/board_vendor"
+  printf 'GU605CX\n' >"$dmi/board_name"
+  printf '0x8086281d\n' >"$hda/hdaudioC0D0/vendor_id"
+  printf '0x80860101\n' >"$hda/hdaudioC0D0/subsystem_id"
+  printf '0x10ec0285\n' >"$hda/hdaudioC1D0/vendor_id"
+  printf '0x10431034\n' >"$hda/hdaudioC1D0/subsystem_id"
+}
+
+run_detector() {
+  OMARCHY_DMI_PATH="$dmi" OMARCHY_HDA_DEVICES_PATH="$hda" bash "$detector"
+}
+
+reset_hardware
+run_detector || fail "the detector finds the matching codec after an unrelated controller"
+pass "the detector finds the matching codec after an unrelated controller"
+
+for value in "Other vendor" "ASUSTeK COMPUTER INC. extra"; do
+  printf '%s\n' "$value" >"$dmi/board_vendor"
+  run_detector && fail "the detector requires the exact ASUS board vendor"
+done
+pass "the detector requires the exact ASUS board vendor"
+
+reset_hardware
+for value in GU605CW GU605CX_EXTRA; do
+  printf '%s\n' "$value" >"$dmi/board_name"
+  run_detector && fail "the detector requires the exact GU605CX board name"
+done
+pass "the detector requires the exact GU605CX board name"
+
+for attribute in vendor_id subsystem_id; do
+  reset_hardware
+  expected=$(cat "$hda/hdaudioC1D0/$attribute")
+  printf '0x00000000\n' >"$hda/hdaudioC1D0/$attribute"
+  run_detector && fail "the detector rejects a different codec $attribute"
+  printf '%s0\n' "$expected" >"$hda/hdaudioC1D0/$attribute"
+  run_detector && fail "the detector rejects a longer codec $attribute"
+  pass "the detector requires an exact codec $attribute"
+done
+
+reset_hardware
+printf '0x10431034\n' >"$hda/hdaudioC0D0/subsystem_id"
+printf '0x00000000\n' >"$hda/hdaudioC1D0/subsystem_id"
+run_detector && fail "the codec and subsystem IDs must belong to the same device"
+pass "the codec and subsystem IDs must belong to the same device"
+
+for missing in dmi dmi/board_vendor dmi/board_name hda hda/hdaudioC1D0/vendor_id hda/hdaudioC1D0/subsystem_id; do
+  reset_hardware
+  rm -rf "$test_tmp/sys/$missing"
+  run_detector && fail "the detector fails closed with missing $missing"
+done
+pass "the detector fails closed with missing sysfs directories or attributes"
+
+reset_hardware
+rm -rf "$hda"/*
+run_detector && fail "the detector fails closed with no HDA devices"
+pass "the detector fails closed with no HDA devices"
+
+sysfs_snapshot() {
+  sha256sum "$dmi"/* "$hda"/*/*
+}
+
+run_script() {
+  local script="$1" status before
+  : >"$call_log"
+  before=$(sysfs_snapshot)
+  if PATH="$test_tmp/bin:$ROOT/bin:/usr/bin:/bin" \
+    OMARCHY_PATH="$test_tmp" \
+    OMARCHY_DMI_PATH="$dmi" \
+    OMARCHY_HDA_DEVICES_PATH="$hda" \
+    CALL_LOG="$call_log" \
+    TEST_CONFIG_DIR="$test_tmp/etc/modprobe.d" \
+    TEST_SUDO_STATUS="${2:-0}" \
+    TEST_WRITE_STATUS="${3:-0}" \
+    bash -euo pipefail -c 'source "$1"' bash "$test_tmp/$script" >"$test_tmp/output" 2>&1; then
+    status=0
+  else
+    status=$?
+  fi
+  [[ $(sysfs_snapshot) == "$before" ]] || fail "$script leaves hardware fixture attributes unchanged"
+  grep -q '^forbidden ' "$call_log" && fail "$script avoids live driver or service changes" "$(cat "$call_log")"
+  return "$status"
+}
+
+assert_no_calls() {
+  [[ ! -s $call_log ]] || fail "$1" "$(cat "$call_log")"
+}
+
+assert_config() {
+  [[ -f $audio_config ]] || fail "$1 writes the configuration"
+  grep -qx 'options snd_hda_intel power_save=0 power_save_controller=N' "$audio_config" ||
+    fail "$1 disables both verified HDA power-saving settings"
+  [[ $(stat -c %a "$audio_config") == "644" ]] || fail "$1 installs mode 644"
+}
+
+for script in "$leaf" "$migration"; do
+  reset_hardware
+  rm -rf "$test_tmp/etc"
+  run_script "$script" || fail "$script succeeds on the affected hardware" "$(cat "$test_tmp/output")"
+  assert_config "$script"
+  if [[ $script == "$migration" ]]; then
+    grep -qx 'state set reboot-required' "$call_log" || fail "the migration requests a reboot after installation"
+  else
+    grep -q '^state ' "$call_log" && fail "hardware setup does not write user reboot state"
+  fi
+  pass "$script installs the workaround only for the next boot"
+
+  # A second user running the migration must also leave the existing file alone.
+  touch -d '2000-01-01 00:00:00 UTC' "$audio_config"
+  before=$(stat -c '%i:%Y' "$audio_config")
+  run_script "$script" || fail "$script succeeds when repeated"
+  assert_no_calls "$script is idempotent without new privileged calls or reboot markers"
+  [[ $(stat -c '%i:%Y' "$audio_config") == "$before" ]] || fail "$script does not rewrite an existing configuration"
+  pass "$script is idempotent"
+
+  for mismatch in board codec; do
+    rm -f "$audio_config"
+    reset_hardware
+    if [[ $mismatch == "board" ]]; then
+      printf 'GU605CW\n' >"$dmi/board_name"
+    else
+      printf '0x00000000\n' >"$hda/hdaudioC1D0/subsystem_id"
+    fi
+    run_script "$script" || fail "$script succeeds on unrelated $mismatch hardware"
+    [[ ! -e $audio_config ]] || fail "$script skips unrelated $mismatch hardware"
+    assert_no_calls "$script makes no privileged or state calls for unrelated $mismatch hardware"
+  done
+  pass "$script no-ops on unrelated boards and codecs"
+
+  reset_hardware
+  for existing in custom empty symlink; do
+    rm -f "$audio_config"
+    case "$existing" in
+      custom) printf 'options snd_hda_intel power_save=5\n' >"$audio_config" ;;
+      empty) : >"$audio_config" ;;
+      symlink) ln -s "$test_tmp/missing-custom-config" "$audio_config" ;;
+    esac
+    before=$(stat -c '%F:%i:%s:%Y' "$audio_config")
+    run_script "$script" || fail "$script preserves an existing $existing configuration"
+    assert_no_calls "$script preserves $existing configuration without privileged or state calls"
+    [[ $(stat -c '%F:%i:%s:%Y' "$audio_config") == "$before" ]] || fail "$script preserves the existing $existing file"
+    if [[ $existing == "custom" ]]; then
+      grep -qx 'options snd_hda_intel power_save=5' "$audio_config" || fail "$script preserves custom contents"
+    elif [[ $existing == "symlink" ]]; then
+      [[ $(readlink "$audio_config") == "$test_tmp/missing-custom-config" ]] || fail "$script preserves a dangling symlink"
+      [[ ! -e $test_tmp/missing-custom-config ]] || fail "$script does not populate a dangling symlink target"
+    fi
+  done
+  pass "$script preserves custom configuration, empty opt-outs, and dangling symlinks"
+
+  rm -f "$audio_config"
+  run_script "$script" 1 && fail "$script propagates privilege failure"
+  [[ ! -e $audio_config ]] || fail "$script does not install after privilege failure"
+  grep -q '^state ' "$call_log" && fail "$script does not request reboot after privilege failure"
+  pass "$script propagates privilege failure without requesting reboot"
+
+  run_script "$script" 0 1 && fail "$script propagates a partial write failure"
+  [[ ! -e $audio_config ]] || fail "$script does not publish a partially written configuration"
+  [[ -z $(ls -A "$test_tmp/etc/modprobe.d") ]] || fail "$script cleans up its failed temporary write"
+  grep -q '^state ' "$call_log" && fail "$script does not request reboot after a partial write"
+  run_script "$script" || fail "$script can retry after a partial write failure"
+  assert_config "$script"
+  pass "$script cleans up a partial write and permits a successful retry"
+
+  # A regular file in place of the parent directory forces a real filesystem error.
+  rm -rf "$test_tmp/etc/modprobe.d"
+  : >"$test_tmp/etc/modprobe.d"
+  run_script "$script" && fail "$script propagates configuration write failure"
+  grep -q '^state ' "$call_log" && fail "$script does not request reboot after write failure"
+  pass "$script propagates configuration write failure without requesting reboot"
+done

--- a/test/shell.d/asus-gu605cx-audio-test.sh
+++ b/test/shell.d/asus-gu605cx-audio-test.sh
@@ -166,8 +166,8 @@ assert_no_calls() {
 
 assert_config() {
   [[ -f $audio_config ]] || fail "$1 writes the configuration"
-  grep -qx 'options snd_hda_intel power_save=0 power_save_controller=N' "$audio_config" ||
-    fail "$1 disables both verified HDA power-saving settings"
+  grep -qx 'options snd_hda_intel power_save=0' "$audio_config" ||
+    fail "$1 disables codec power saving without overriding controller policy"
   [[ $(stat -c %a "$audio_config") == "644" ]] || fail "$1 installs mode 644"
 }
 


### PR DESCRIPTION
On an ASUS ROG Zephyrus G16 GU605CX with Realtek ALC285 audio, pausing video playback produces a loud pop through the 3.5 mm output after approximately ten seconds. Setting `snd_hda_intel.power_save=0` eliminates the pause/resume pop through wired iLoud Micro Monitor speakers while leaving `power_save_controller=Y`.

This change installs an HDA power-saving workaround only when the ASUS board is exactly `GU605CX` and the same codec reports vendor ID `0x10ec0285` and subsystem ID `0x10431034`.

- Add hardware detection using cached sysfs IDs.
- Install a dedicated modprobe configuration during hardware setup and through a migration for existing installations.
- Set only `power_save=0`, leaving controller power-saving policy unchanged.
- Preserve any existing file at that configuration path, including symlinks and empty opt-out files. Publish new configuration atomically so failed writes can be retried.
- Apply the change on the next boot and mark a reboot as required, avoiding live audio power transitions during an update.

## Validation

- Manual runtime test with `power_save=0` and `power_save_controller=Y`: three playback/pause/resume cycles, each paused for at least 30 seconds, produced no audible pop.
- Reboot persistence: the local modprobe configuration loaded `power_save=0` and `power_save_controller=Y` on a new boot without reapplying runtime settings.
- Post-reboot listening test: the user confirmed that playback, a pause of at least 30 seconds, and resumed playback remained free of pops.
- Idle-state comparison: the ALC285 codec and Intel HDA controller suspended with the original `10/Y` settings and remained active with `0/Y`. Both HDMI codecs and the NVIDIA audio controller remained suspended during the sampled idle windows.
- All 23 added fixture checks pass, including hardware matching, idempotence, existing configuration preservation and failed-write recovery. The detector also matches the affected machine.
- Shell syntax and Git whitespace checks pass.
- After rebasing onto `quattro` at `a62e34ea`, a headless `./test/all` run passed the CLI suite and reported four failures among 228 shell test files. All four failures were reproduced on that unchanged upstream commit: `bin-style-test.sh` flags existing command-helper violations in the OpenClaw and Hermes removal scripts; `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` require a missing `omarchy-pkgs` checkout. The 23 audio fixture checks passed in this run.

## Tradeoffs and remaining validation

The remaining option is driver-wide on matching laptops and may increase idle power consumption by keeping the analog codec and its controller active. Short RAPL comparisons had varying background load and did not reliably quantify the extra power; no negligible-cost or battery-life claim is made.

Hardware validation used manual runtime settings followed by a locally persisted modprobe configuration; the installer and migration were tested with isolated fixtures. The user still heard a pop during shutdown with the external speakers powered on, so this workaround does not resolve the reported shutdown pop. Boot-time popping remains unverified.
