### PR TITLE
Point the plugin manual at plugins.omarchy.org

### DIFF
--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -99,4 +99,4 @@ For the full picture, the source is the documentation: `shell/README.md` in the 
 
 Once you've made something you like, put it in a public git repo. That's the whole distribution mechanism — anyone can then run `omarchy plugin add` against your URL and have it running in seconds.
 
-To help people actually find it, list it at [omarchyplugins.com](https://omarchyplugins.com). That's the community directory of Omarchy shell plugins, and it's the first place to look when you're wondering whether someone has already built the widget you're about to write. Browse it before you start!
+To help people actually find it, list it at [plugins.omarchy.org](https://plugins.omarchy.org). That's the marketplace for Omarchy shell plugins, and it's the first place to look when you're wondering whether someone has already built the widget you're about to write. Browse it before you start!


### PR DESCRIPTION
## What

The Shell Plugins chapter still tells people to list plugins at omarchyplugins.com. DHH moved the marketplace to https://plugins.omarchy.org/ on 30 Aug 2026 (https://x.com/dhh/status/2094107602913309080). The old host redirects, but the published manual should name the current URL.

I grepped `manual/` and `docs/` in this repo: this is the only remaining `omarchyplugins.com` reference. Historical news posts on omarchy.org that used the old host (the Aug 19 competition, Aug 28 winners, AIR intro) are left alone — they were correct when published.

## Test

Docs-only. Ran `./test/cli` from the worktree against this change; it passed in ~13s (exit 0). Did not run graphical acceptance tests.