### PR TITLE
Decide the charge limit from the threshold, not the charge level

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -49,28 +49,59 @@ function batteryFraction(device) {
   return device && device.isPresent ? Math.max(0, Math.min(1, device.percentage)) : 0
 }
 
-function chargeThresholdActive(device, onBattery, states) {
-  var d = device || {}
-  var s = states || {}
-  if (!(d && d.isPresent && !onBattery)) return false
-
-  var fraction = batteryFraction(d)
-  if (d.state === s.Discharging) return false
-  if (d.state === s.PendingCharge) return true
-  if (d.state === s.FullyCharged && fraction < 0.99) return true
-  if (d.state !== s.Charging || fraction >= 0.99) return false
-
-  return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
+// The end threshold out of the `threshold` field omarchy-battery-status emits,
+// which is "80%" for a single value and "75-80%" for a start-end pair. Absent
+// when the battery exposes no charge-control interface, which is a meaningful
+// answer rather than a missing one, so it comes back as NaN and not 0.
+function parseThresholdEnd(text) {
+  var digits = String(text || "").match(/\d+/g)
+  if (!digits || digits.length === 0) return NaN
+  return Number(digits[digits.length - 1])
 }
 
-function batteryIcon(device, onBattery, states) {
+// Whether a charge limit is actually holding the battery back.
+//
+// This has to be answered from the limit itself. UPower exposes no
+// charge-threshold property at all, so the panel used to infer one from the
+// state of charge, and inference cannot tell a real limit apart from the
+// several other reasons a battery sits on AC without charging. It got three
+// distinct cases wrong, and none of them are edge cases:
+//
+//   A cap on a nearly full battery read as no cap. Lowering a cap stops the
+//   charge but does not discharge the pack, so the state is FullyCharged at
+//   99% and the old `fraction >= 0.99` line returned false while the firmware
+//   was holding at 60.
+//
+//   A dead battery read as a cap. `Not charging` (PendingCharge) only means AC
+//   is present and the EC is not charging, for any reason. Returning true on it
+//   unconditionally reported "Holding at 75-80%" for a pack at 0% that the EC
+//   had given up on.
+//
+//   Hardware with no charge control at all read as a cap. Apple's SMC leaves a
+//   battery alone until it falls to roughly 93%, which arrives as FullyCharged
+//   below 0.99 and rendered a charge-limit row on a machine that has no
+//   charge_control_end_threshold to show.
+function chargeThresholdActive(device, onBattery, thresholdEnd) {
+  var d = device || {}
+  if (!(d && d.isPresent && !onBattery)) return false
+
+  // No charge-control interface, or a limit of 100, which is the sysfs way of
+  // saying charge to full. Neither is a limit, whatever the charge level looks
+  // like.
+  var limit = Number(thresholdEnd)
+  if (!isFinite(limit) || limit <= 0 || limit >= 100) return false
+
+  return Math.round(batteryFraction(d) * 100) >= limit
+}
+
+function batteryIcon(device, onBattery, states, thresholdEnd) {
   var d = device || {}
   if (!d.isPresent) return ""
 
   var chargingIcons = ["󰢜", "󰂆", "󰂇", "󰂈", "󰢝", "󰂉", "󰢞", "󰂊", "󰂋", "󰂅"]
   var defaultIcons = ["󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"]
   var index = Math.max(0, Math.min(9, Math.floor(d.percentage * 10)))
-  var threshold = chargeThresholdActive(d, onBattery, states)
+  var threshold = chargeThresholdActive(d, onBattery, thresholdEnd)
 
   if (threshold) return defaultIcons[index]
   if (d.state === states.FullyCharged) return "󰂅"
@@ -78,12 +109,12 @@ function batteryIcon(device, onBattery, states) {
   return defaultIcons[index]
 }
 
-function modeLabel(device, onBattery, states) {
+function modeLabel(device, onBattery, states, thresholdEnd) {
   var d = device || {}
   if (!d.isPresent) return ""
 
   var percentage = d.isPresent ? d.percentage : 0
-  if (chargeThresholdActive(d, onBattery, states)) return "Threshold"
+  if (chargeThresholdActive(d, onBattery, thresholdEnd)) return "Threshold"
   if (onBattery) return "On battery"
   if (!onBattery && percentage >= 1) return "Fully charged"
   return "Charging"
@@ -97,6 +128,7 @@ if (typeof module !== "undefined") {
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
+    parseThresholdEnd: parseThresholdEnd,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,
     modeLabel: modeLabel

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -49,12 +49,12 @@ Panel {
 
   function batteryIcon() {
     var device = UPower.displayDevice
-    return Model.batteryIcon(device, root.discharging, upowerStates())
+    return Model.batteryIcon(device, root.discharging, upowerStates(), root.chargeThresholdEnd)
   }
 
   function modeLabel() {
     var device = UPower.displayDevice
-    return Model.modeLabel(device, root.discharging, upowerStates())
+    return Model.modeLabel(device, root.discharging, upowerStates(), root.chargeThresholdEnd)
   }
 
   function profileIcon(name) {
@@ -69,9 +69,13 @@ Panel {
     var device = UPower.displayDevice
     return !!(device && device.isPresent && UPower.onBattery)
   }
+  // UPower publishes no charge-threshold property, so the only source for the
+  // limit is omarchy-battery-status, which reads it from the hardware. NaN when
+  // the battery exposes no charge-control interface at all.
+  readonly property var chargeThresholdEnd: Model.parseThresholdEnd(root.batteryInfo.threshold)
   readonly property bool chargeThresholdActive: {
     var device = UPower.displayDevice
-    return Model.chargeThresholdActive(device, root.discharging, upowerStates())
+    return Model.chargeThresholdActive(device, root.discharging, root.chargeThresholdEnd)
   }
   readonly property bool batteryFull: fullyCharged || (!root.discharging && batteryFraction >= 1)
   readonly property bool batteryFlowIdle: batteryFull || chargeThresholdActive
@@ -135,9 +139,17 @@ Panel {
   function refresh() {
     if (!batteryPresent) return
 
-    if (!batteryProc.running) batteryProc.running = true
+    refreshBattery()
     if (!profilesProc.running) profilesProc.running = true
     if (!systemProc.running) systemProc.running = true
+  }
+
+  // The bar icon reads the charge limit too, and the full refresh only runs
+  // while the panel is open, so the battery read has to be reachable on its own
+  // or the icon would sit on an unset limit until the panel is first opened.
+  function refreshBattery() {
+    if (!batteryPresent) return
+    if (!batteryProc.running) batteryProc.running = true
   }
 
   function updateKeyValue(raw, targetName) {
@@ -199,7 +211,12 @@ Panel {
     }
   }
 
-  onBatteryPresentChanged: if (!batteryPresent) close()
+  onBatteryPresentChanged: {
+    if (batteryPresent) refreshBattery()
+    else close()
+  }
+
+  Component.onCompleted: refreshBattery()
 
   visible: batteryPresent
   implicitWidth: batteryPresent ? button.implicitWidth : 0

--- a/test/shell.d/power-test.sh
+++ b/test/shell.d/power-test.sh
@@ -23,10 +23,37 @@ assertDeepEqual(
 assert(power.profileIcon('performance').length > 0, 'power maps profile icons')
 assertEqual(power.batteryFraction({ isPresent: true, percentage: 1.5 }), 1, 'power clamps battery fraction')
 
-assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states), 'power detects threshold by pending charge state')
-assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, states), 'power detects threshold by stalled charging')
-assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, states), 'power does not flag active charging as threshold')
-assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'power does not flag discharging as threshold')
+assertEqual(power.parseThresholdEnd('80%'), 80, 'power reads a single charge threshold')
+assertEqual(power.parseThresholdEnd('75-80%'), 80, 'power reads the end of a start-end threshold pair')
+assert(Number.isNaN(power.parseThresholdEnd(undefined)), 'power reports no threshold when the battery exposes none')
+assert(Number.isNaN(power.parseThresholdEnd('')), 'power reports no threshold for an empty reading')
+
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, 80), 'power detects a limit the battery has reached')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Charging }, false, 80), 'power does not flag a limit the battery is still charging toward')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 0.1, timeToFull: 120 }, false, NaN), 'power does not infer a limit from a stalled charge')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.8, state: states.Charging, changeRate: 1.0, timeToFull: 120 }, false, NaN), 'power does not flag active charging as threshold')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, 80), 'power does not flag discharging as threshold')
+
+// A cap lowered below a nearly full battery stops the charge without discharging
+// the pack, so this is the ordinary state for days on mains.
+assert(power.chargeThresholdActive({ isPresent: true, percentage: 0.99, state: states.FullyCharged }, false, 60), 'power reports a cap holding a nearly full battery')
+assertEqual(power.modeLabel({ isPresent: true, percentage: 0.99, state: states.FullyCharged }, false, states, 60), 'Threshold', 'power labels a held battery as threshold')
+
+// "Not charging" only means AC is present and the EC is not charging. A pack the
+// EC has given up on is not a configured limit.
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0, state: states.PendingCharge }, false, 80), 'power does not report a limit for a battery nowhere near one')
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0, state: states.PendingCharge }, false, 100), 'power treats a threshold of 100 as no limit')
+
+// Hardware with no charge-control interface: Apple's SMC leaves the pack alone
+// until it falls to roughly 93%, which arrives as fully-charged below 99%.
+assert(!power.chargeThresholdActive({ isPresent: true, percentage: 0.947, state: states.FullyCharged }, false, NaN), 'power does not invent a limit on hardware that has none')
+assert(power.modeLabel({ isPresent: true, percentage: 0.947, state: states.FullyCharged }, false, states, NaN) !== 'Threshold', 'power does not label an SMC-held battery as threshold')
+
+assertEqual(
+  power.batteryIcon({ isPresent: true, percentage: 0.8, state: states.PendingCharge }, false, states, 80),
+  power.batteryIcon({ isPresent: true, percentage: 0.8, state: states.Discharging }, true, states, NaN),
+  'power shows a non-charging icon while a limit is holding'
+)
 assertEqual(power.modeLabel({ isPresent: true, percentage: 1, state: states.FullyCharged }, false, states), 'Fully charged', 'power labels full battery')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, true, states), 'On battery', 'power labels battery mode')
 assertEqual(power.modeLabel({ isPresent: true, percentage: 0.5, state: states.Discharging }, false, states), 'Charging', 'power treats external power as newer than stale discharging state')
@@ -48,4 +75,7 @@ assert(/Math\.round\(root\.batteryFraction \* 100\) \+ "% " \+ root\.batteryIcon
 assert(/openPanelIndicatorWidth:.*showPercentage.*button\.glyphPaintedWidth : 0/.test(panelSource), 'power spans the open-panel mark across the painted percentage block')
 assert(/IpcHandler[\s\S]*?function togglePercentage\(\) \{ root\.togglePercentage\(\) \}/.test(panelSource), 'power exposes togglePercentage over IPC')
 assert(/manageIpc: false/.test(panelSource), 'power owns its IPC handler so it can extend the target methods')
+assert(/parseThresholdEnd\(root\.batteryInfo\.threshold\)/.test(panelSource), 'power reads the charge limit from the battery status output')
+assert(/Model\.chargeThresholdActive\(device, root\.discharging, root\.chargeThresholdEnd\)/.test(panelSource), 'power decides the charge limit from the threshold rather than the charge level')
+assert(/Component\.onCompleted: refreshBattery\(\)/.test(panelSource), 'power reads the battery before the panel is first opened so the bar icon has a limit')
 JS


### PR DESCRIPTION
Fixes #10344 (the panel half), #7803 (the panel half), #10193.

## The problem

`Model.chargeThresholdActive()` decides whether a charge limit is holding the battery back, and it drives the `Charge limit` / `Holding` pair in `Panel.qml`, the `Threshold` mode label, and the battery icon. It never reads a threshold. It infers one from the state of charge:

```js
if (d.state === s.PendingCharge) return true
if (d.state === s.FullyCharged && fraction < 0.99) return true
if (d.state !== s.Charging || fraction >= 0.99) return false
return Number(d.changeRate || 0) <= 0.2 || Number(d.timeToFull || 0) >= 8 * 60 * 60
```

It infers because there is nothing to read: `Quickshell.Services.UPower` publishes no charge-threshold property at all. But inference cannot separate a configured limit from the other reasons a battery sits on AC without charging, and it gets three distinct cases wrong. None of them are edge cases.

**A cap below a nearly full battery reads as no cap** (#10344). Lowering a cap stops the charge but does not discharge the pack, so the state is `FullyCharged` at 99% while the firmware holds at 60. Line 61 returns false and the panel shows FULLY CHARGED with no charge limit row. This is the ordinary state for days on a machine that stays on mains.

**A dead battery reads as a cap** (#7803). `PendingCharge` only means AC is present and the EC is not charging, for any reason: a threshold hold, a battery fault, an insufficient supply, `charge_behaviour=inhibit-charge`. Returning true on it unconditionally reports a hold for a pack at 0% that the EC has given up on.

**Hardware with no charge control reads as a cap** (#10193). Apple's SMC leaves a battery alone until it falls to roughly 93%, which arrives as `FullyCharged` below 0.99 and renders a charge-limit row on a machine with no `charge_control_end_threshold` to show.

## The fix

`bin/omarchy-battery-status` already reads the threshold from the hardware, already emits it as `threshold`, and already gates its own `charge_holding` block on that value existing. `Panel.qml` already displays that value on line 445. The panel simply dropped the guard half and re-derived the answer instead, which is why the CLI and the panel disagree on the same machine, as #10193 sets out.

So take the value the CLI already provides and decide from it:

```js
function chargeThresholdActive(device, onBattery, thresholdEnd) {
  var d = device || {}
  if (!(d && d.isPresent && !onBattery)) return false

  var limit = Number(thresholdEnd)
  if (!isFinite(limit) || limit <= 0 || limit >= 100) return false

  return Math.round(batteryFraction(d) * 100) >= limit
}
```

A limit is in force when the hardware exposes one, it is set below full, and the charge has reached it. `parseThresholdEnd()` takes the end value out of the `threshold` field, which is `80%` for a single value and `75-80%` for a start-end pair, and returns `NaN` when the battery exposes no charge-control interface, since that is a meaningful answer rather than a missing one. A limit of 100 is the sysfs way of saying charge to full, so it is not a limit either.

Every state-based branch goes away. `states` is no longer a parameter of the predicate; `batteryIcon()` and `modeLabel()` still take it and now also forward the limit.

## Scope

**This does not change where the threshold value comes from.** On hardware whose UPower hwdb `CHARGE_LIMIT` default masks the real sysfs value, the number displayed is still UPower's. #9612 fixes that half by preferring sysfs in `omarchy-battery-status`, and the two changes compose without touching the same code: this PR makes the panel ask the right question, #9612 makes the CLI give the right answer. On the ASUS machine in #10344 the panel goes from showing no limit at all to showing `75-80%`, and lands on the true `60%` once #9612 is in.

It also leaves `omarchy-battery-status`'s own `pending-charge` branch alone, which is the CLI half of #7803 and is covered by #7915/#7895.

One behavioural note: the bar icon reads the same predicate, and the full refresh only runs while the panel is open, so the battery status is now also read once on startup. Without it the icon would sit on an unset limit until the panel was first opened.

## Tests

`test/shell.d/power-test.sh` covers the three reported cases directly, plus the threshold parsing, a limit the battery is still charging toward, a limit of 100, and the icon while a limit is holding. The two assertions that encoded the old heuristic are replaced by ones that supply a real limit.

223 of the 230 tests in `test/shell.d/` pass. The 5 failures (`base`, `bin-style`, `config`, `snapper`, `unowned-system-paths`) fail identically on an untouched `quattro`.

I do not have the ThinkPad from #7803 or the MacBook from #10193, so those two are covered by the unit tests and by the reported readings rather than on the hardware. #10344 is my own machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VADsy8CLE8n9hpfWUKt3vM