### PR TITLE
[Security] Keep the 1Password lock flock out of world-writable /tmp

### DIFF
--- a/bin/omarchy-system-lock
+++ b/bin/omarchy-system-lock
@@ -12,11 +12,18 @@ hyprctl switchxkblayout all 0 > /dev/null 2>&1
 
 # Ensure 1password is locked. Use timeout because `1password --lock` can
 # otherwise leave a full Electron helper tree running after each lock.
+# Keep the flock out of world-writable /tmp: a held lock there used to make
+# `flock -n || exit 0` skip `--lock`. If the private lock file cannot be
+# created, still lock.
 if pgrep -x "1password" >/dev/null && omarchy-cmd-present 1password; then
   (
-    flock -n 9 || exit 0
+    lock_dir="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}"
+    lock_file="$lock_dir/omarchy-1password-lock.lock"
+    if mkdir -m 700 -p "$lock_dir" && exec 9>"$lock_file"; then
+      flock -n 9 || exit 0
+    fi
     timeout --kill-after=1s 3s 1password --lock >/dev/null 2>&1 || true
-  ) 9>"${XDG_RUNTIME_DIR:-/tmp}/omarchy-1password-lock.lock" &
+  ) &
 fi
 
 # Avoid running screensaver when locked

--- a/test/shell.d/system-lock-test.sh
+++ b/test/shell.d/system-lock-test.sh
@@ -34,3 +34,52 @@ mapfile -t shutdown < <(rg '^(pkill|timeout) ' "$call_log")
 [[ ${shutdown[2]} == "pkill -f [o]rg.omarchy.screensaver" ]] ||
   fail "system lock closes the screensaver terminal after ttfx exits" "calls: ${shutdown[*]}"
 pass "system lock waits for ttfx before closing its terminal"
+
+lock_src="$ROOT/bin/omarchy-system-lock"
+if grep -Fq '${XDG_RUNTIME_DIR:-/tmp}/omarchy-1password-lock.lock' "$lock_src"; then
+  fail "1Password flock must not fall back to world-writable /tmp"
+fi
+grep -Fq '${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}' "$lock_src" ||
+  fail "1Password flock falls back to a 0700 /tmp/omarchy-\$UID directory"
+grep -Fq 'flock -n 9 || exit 0' "$lock_src" ||
+  fail "1Password flock still dedupes an in-progress lock"
+grep -Fq 'timeout --kill-after=1s 3s 1password --lock' "$lock_src" ||
+  fail "system lock still issues 1password --lock"
+pass "1Password lock file is not in world-writable /tmp"
+
+runtime_dir="$tmpdir/runtime"
+mkdir -m 700 -p "$runtime_dir"
+: >"$call_log"
+
+cat >"$mock_bin/pgrep" <<'SH'
+#!/bin/bash
+[[ $1 == -x && $2 == 1password ]]
+SH
+cat >"$mock_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ $1 == 1password ]]
+SH
+cat >"$mock_bin/1password" <<'SH'
+#!/bin/bash
+printf '1password %s\n' "$*" >>"$CALL_LOG"
+SH
+# Arch has util-linux flock; this suite also runs where it is not on PATH.
+cat >"$mock_bin/flock" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$mock_bin"/*
+
+PATH="$mock_bin:$PATH" CALL_LOG="$call_log" XDG_RUNTIME_DIR="$runtime_dir" \
+  "$ROOT/bin/omarchy-system-lock"
+
+for _ in {1..40}; do
+  grep -Fq 'timeout --kill-after=1s 3s 1password --lock' "$call_log" && break
+  sleep 0.05
+done
+
+grep -Fq 'timeout --kill-after=1s 3s 1password --lock' "$call_log" ||
+  fail "system lock still calls 1password --lock when 1Password is running" "$(cat "$call_log")"
+[[ -e $runtime_dir/omarchy-1password-lock.lock ]] ||
+  fail "1Password flock is created under XDG_RUNTIME_DIR"
+pass "1Password flock lives in the runtime directory"


### PR DESCRIPTION
## Summary
- `omarchy system lock` flocked `${XDG_RUNTIME_DIR:-/tmp}/omarchy-1password-lock.lock`
- A local user who held that path in `/tmp` made `flock -n || exit 0` skip `1password --lock`
- Stage the flock under `$XDG_RUNTIME_DIR` (or a 0700 `/tmp/omarchy-$UID` fallback). If the private lock file cannot be created, still lock

## Test plan
- [x] `bash test/shell.d/system-lock-test.sh`
- [ ] Lock a session with 1Password running and confirm the flock is not `/tmp/omarchy-1password-lock.lock`
