### PR TITLE
[Security] Keep monitor-watch flock files out of world-writable /tmp

### DIFF
--- a/bin/omarchy-hyprland-monitor-watch
+++ b/bin/omarchy-hyprland-monitor-watch
@@ -3,8 +3,10 @@
 # omarchy:summary=Watch Hyprland monitor events and recover monitor toggles when a monitor is removed
 
 SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
-LOCK="${XDG_RUNTIME_DIR:-/tmp}/omarchy-monitor-clamshell.lock"
-MODELESS_LOCK="${XDG_RUNTIME_DIR:-/tmp}/omarchy-monitor-modeless.lock"
+LOCK_DIR="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}"
+mkdir -m 700 -p "$LOCK_DIR"
+LOCK="$LOCK_DIR/omarchy-monitor-clamshell.lock"
+MODELESS_LOCK="$LOCK_DIR/omarchy-monitor-modeless.lock"
 
 sync_clamshell() {
   (

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -23,6 +23,16 @@ grep -F 'flock -n 9' "$monitor_watch" >/dev/null
 grep -F 'omarchy-hyprland-monitor-clamshell' "$monitor_watch" >/dev/null
 pass "monitor watcher retries internal monitor recovery after removal"
 
+if grep -Fq '${XDG_RUNTIME_DIR:-/tmp}/omarchy-monitor-clamshell.lock' "$monitor_watch" ||
+  grep -Fq '${XDG_RUNTIME_DIR:-/tmp}/omarchy-monitor-modeless.lock' "$monitor_watch"; then
+  fail "monitor watcher flock files must not fall back to world-writable /tmp"
+fi
+grep -Fq '${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}' "$monitor_watch" ||
+  fail "monitor watcher flock falls back to a 0700 /tmp/omarchy-\$UID directory"
+grep -Fq 'mkdir -m 700 -p "$LOCK_DIR"' "$monitor_watch" ||
+  fail "monitor watcher creates the flock directory with mode 0700"
+pass "monitor watcher flock files are not in world-writable /tmp"
+
 grep -F 'monitoradded\>\>*|monitoraddedv2\>\>*)' "$monitor_watch" >/dev/null
 grep -F 'omarchy-hyprland-monitor-clamshell' "$monitor_watch" >/dev/null
 pass "monitor watcher disables the internal monitor after closed-lid external hotplug"


### PR DESCRIPTION
## Summary
- The clamshell and modeless recovery loops flocked `${XDG_RUNTIME_DIR:-/tmp}/omarchy-monitor-*.lock`
- A local user who held those paths in `/tmp` could skip lid/hotplug recovery (`flock -n || exit 0`)
- Stage both flock files under `$XDG_RUNTIME_DIR` (or a 0700 `/tmp/omarchy-$UID` fallback)

## Test plan
- [x] `bash test/shell.d/monitor-recovery-test.sh`
- [ ] Confirm the watcher lock files are not `/tmp/omarchy-monitor-clamshell.lock` / `omarchy-monitor-modeless.lock`
