### PR TITLE
[Security] Stage menu IPC files out of world-writable /tmp

### DIFF
--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -72,10 +72,12 @@ if (( ${#image_dirs[@]} == 0 )); then
   exit 1
 fi
 
-selection_file=$(mktemp)
-done_file=$(mktemp)
-pending_file=$(mktemp)
-pending_video_file=$(mktemp)
+ipc_dir="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}"
+mkdir -m 700 -p "$ipc_dir"
+selection_file=$(mktemp "$ipc_dir/omarchy-menu-images.XXXXXX")
+done_file=$(mktemp "$ipc_dir/omarchy-menu-images.XXXXXX")
+pending_file=$(mktemp "$ipc_dir/omarchy-menu-images.XXXXXX")
+pending_video_file=$(mktemp "$ipc_dir/omarchy-menu-images.XXXXXX")
 rm -f "$done_file"
 trap 'rm -f "$selection_file" "$done_file" "$pending_file" "$pending_video_file"' EXIT
 

--- a/bin/omarchy-menu-input
+++ b/bin/omarchy-menu-input
@@ -29,8 +29,10 @@ while (( $# > 0 )); do
   shift
 done
 
-selection_file=$(mktemp)
-done_file=$(mktemp)
+ipc_dir="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}"
+mkdir -m 700 -p "$ipc_dir"
+selection_file=$(mktemp "$ipc_dir/omarchy-menu-input.XXXXXX")
+done_file=$(mktemp "$ipc_dir/omarchy-menu-input.XXXXXX")
 rm -f "$done_file"
 trap 'rm -f "$selection_file" "$done_file"' EXIT
 

--- a/bin/omarchy-menu-select
+++ b/bin/omarchy-menu-select
@@ -67,8 +67,10 @@ if (( ${#options[@]} == 0 )); then
   exit 1
 fi
 
-selection_file=$(mktemp)
-done_file=$(mktemp)
+ipc_dir="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}"
+mkdir -m 700 -p "$ipc_dir"
+selection_file=$(mktemp "$ipc_dir/omarchy-menu-select.XXXXXX")
+done_file=$(mktemp "$ipc_dir/omarchy-menu-select.XXXXXX")
 rm -f "$done_file"
 trap 'rm -f "$selection_file" "$done_file"' EXIT
 

--- a/test/shell.d/menu-ipc-path-test.sh
+++ b/test/shell.d/menu-ipc-path-test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command perl
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+runtime_dir="$tmpdir/runtime"
+stub_bin="$tmpdir/bin"
+ipc_log="$tmpdir/ipc.log"
+mkdir -m 700 -p "$runtime_dir" "$stub_bin"
+
+cat >"$stub_bin/omarchy-shell" <<'SH'
+#!/bin/bash
+payload="${@: -1}"
+perl -MJSON::PP=decode_json -e '
+  my $p = decode_json($ARGV[0]);
+  my $sel = $p->{selectionFile};
+  my $done = $p->{doneFile};
+  die "missing ipc paths" unless defined $sel && defined $done;
+  if (defined $ENV{IPC_LOG}) {
+    open my $l, ">>", $ENV{IPC_LOG} or die $!;
+    print $l "$sel\n$done\n";
+    close $l;
+  }
+  open my $s, ">", $sel or die $!;
+  print $s "picked\n";
+  close $s;
+  open my $d, ">", $done or die $!;
+  close $d;
+' "$payload"
+SH
+chmod +x "$stub_bin/omarchy-shell"
+
+for cmd in omarchy-menu-select omarchy-menu-input omarchy-menu-images; do
+  if grep -E '^selection_file=\$\(mktemp\)$' "$ROOT/bin/$cmd"; then
+    fail "$cmd must not mktemp in the default /tmp"
+  fi
+  grep -Fq '${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}' "$ROOT/bin/$cmd" ||
+    fail "$cmd stages menu IPC under the runtime directory"
+done
+pass "menu helpers do not stage IPC files in world-writable /tmp"
+
+: >"$ipc_log"
+PATH="$stub_bin:$PATH" XDG_RUNTIME_DIR="$runtime_dir" IPC_LOG="$ipc_log" \
+  "$ROOT/bin/omarchy-menu-select" Prompt one >"$tmpdir/select.out"
+
+[[ $(<"$tmpdir/select.out") == picked ]] ||
+  fail "menu-select still returns the chosen row" "$(<"$tmpdir/select.out")"
+while IFS= read -r path; do
+  [[ $path == "$runtime_dir"/omarchy-menu-select.* ]] ||
+    fail "menu-select IPC path is under XDG_RUNTIME_DIR" "$path"
+done <"$ipc_log"
+pass "menu-select stages IPC under XDG_RUNTIME_DIR"
+
+: >"$ipc_log"
+PATH="$stub_bin:$PATH" XDG_RUNTIME_DIR="$runtime_dir" IPC_LOG="$ipc_log" \
+  "$ROOT/bin/omarchy-menu-input" Reminder >"$tmpdir/input.out"
+
+[[ $(<"$tmpdir/input.out") == picked ]] ||
+  fail "menu-input still returns the typed value" "$(<"$tmpdir/input.out")"
+while IFS= read -r path; do
+  [[ $path == "$runtime_dir"/omarchy-menu-input.* ]] ||
+    fail "menu-input IPC path is under XDG_RUNTIME_DIR" "$path"
+done <"$ipc_log"
+pass "menu-input stages IPC under XDG_RUNTIME_DIR"


### PR DESCRIPTION
## Summary
- `omarchy-menu-select`, `omarchy-menu-input`, and `omarchy-menu-images` used bare `mktemp` for selection/done files
- Typed input (including secrets) and picker results landed in world-writable `/tmp`; after `rm` of the done file, another user can recreate that name
- Stage those files under `$XDG_RUNTIME_DIR` (or a 0700 `/tmp/omarchy-$UID` fallback)

## Test plan
- [x] `bash test/shell.d/menu-ipc-path-test.sh`
- [ ] Run `omarchy menu input` and confirm the IPC files are not created under `/tmp/tmp.*`
