### PR TITLE
Don't read an unreferenced omarchy_monitor_scale as a configured scale

### DIFF
--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -101,8 +101,13 @@ configured_monitor_scale() {
   # to nothing usable. Only a rule that names none at all defers to the catch-all,
   # which is the scale Omarchy has always applied for that config.
   [[ -n $scale ]] || scale=$(configured_monitor_value "" scale)
-  # No rule carries a scale at all: fall back to Omarchy's own knob.
-  [[ -n $scale ]] || scale=$(lua_local_value omarchy_monitor_scale)
+  # No rule names a scale for this output, so the config does not configure one.
+  # A leftover omarchy_monitor_scale local that no rule references is not a
+  # configured scale: reading it as one makes clamshell force that number over
+  # whatever owns the layout -- an external manager, or the compositor itself --
+  # on every idle-wake, which is the flap #7265 fixed for "auto". Leave the
+  # panel alone; a panel that is off still gets a number from the remembered
+  # scale in read_monitor_scale.
 
   printf '%s\n' "$scale"
 }

--- a/test/shell.d/monitor-clamshell-scale-test.sh
+++ b/test/shell.d/monitor-clamshell-scale-test.sh
@@ -209,6 +209,19 @@ hl.monitor({ output = "eDP-1"; position = "0x0"; scale = 1.25; transform = 1 })
 LUA
 }
 
+# A numeric omarchy_monitor_scale local that no rule references, the shape left
+# behind when the catch-all rule is commented out to hand the layout to an
+# external manager (hyprmoncfg, kanshi, nwg-displays).
+write_unreferenced_scale_local_config() {
+  cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 1.6
+
+hl.env("GDK_SCALE", tostring(omarchy_gdk_scale))
+-- hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+LUA
+}
+
 remember_scale() {
   mkdir -p "$state_dir"
   printf '%s\n' "$1" >"$scale_state"
@@ -243,6 +256,26 @@ write_default_auto_config
 OMARCHY_TEST_INTERNAL_SCALE=3 run_clamshell
 ! grep -F 'scale = ' "$eval_log" >/dev/null || fail "clamshell recovery leaves the shipped auto default alone"
 pass "clamshell recovery leaves the shipped auto default alone"
+
+# Regression: an omarchy_monitor_scale local that no rule references is not a
+# configured scale. Reading it as one made clamshell force that number over the
+# layout an external monitor manager owns, on every idle-wake -- the same flap
+# #7265 fixed for "auto", reached through a numeric local instead.
+write_unreferenced_scale_local_config
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_SCALE=1.33333 run_clamshell
+! grep -F 'scale = ' "$eval_log" >/dev/null || fail "clamshell leaves a panel alone when no rule names a scale"
+pass "clamshell leaves a panel alone when no rule names a scale"
+
+# The same config with the panel off still needs a number, and takes it from
+# the remembered scale rather than the unreferenced local.
+write_unreferenced_scale_local_config
+remember_scale 1.33333
+: >"$eval_log"
+OMARCHY_TEST_INTERNAL_DISABLED=true run_clamshell
+grep -F 'scale = 1.33333' "$eval_log" >/dev/null || fail "clamshell recovery prefers the remembered scale over an unreferenced local"
+! grep -F 'scale = 1.6' "$eval_log" >/dev/null || fail "clamshell recovery does not use an unreferenced local"
+pass "clamshell recovery prefers the remembered scale over an unreferenced local"
 
 # A numeric config keeps both sync behaviors: a matching active scale is not
 # reapplied, and a drifted one is corrected back to the configured value.


### PR DESCRIPTION
Fixes #10522.

`configured_monitor_scale` falls back to the `omarchy_monitor_scale` local when no `hl.monitor` rule names a scale for the internal panel. That local is only meaningful as the value a rule references; left behind on its own it is not configuration.

Reading it as one makes clamshell force that number over whatever owns the layout, on every idle-wake, for anyone who hands their monitors to an external manager (hyprmoncfg, kanshi, nwg-displays) by commenting out the catch-all rule. The panel snaps to the stale local and the manager reconciles it back a few seconds later, which reads as the screen zooming on every lock/unlock.

This is the flap #7265 and #7301 fixed for `scale = "auto"`, reached through a numeric local instead. `sync_internal_scale` already delegates to whoever owns the panel when no valid configured scale exists — the fallback was manufacturing one, so the guard never fired.

Dropping the fallback lets an unreferenced local fall through to the same delegation path `"auto"` already takes. A panel that is off still gets a number, from the remembered scale in `read_monitor_scale`, so recovery is unchanged.

### Verification

Two regression tests added to `test/shell.d/monitor-clamshell-scale-test.sh`: an enabled panel is left alone when no rule names a scale, and a disabled one still recovers from the remembered scale rather than the unreferenced local. Full file passes, 27 tests including all pre-existing ones.

`monitor-recovery`, `monitor-state`, `monitor-modeless`, `monitor-output-name`, `lid-close` and `sleep-lock` all pass. `bin-style` fails identically before and after this change, on unrelated files.

End-to-end on hardware, same config both times:

```
stock clamshell:    1.3333334 @4096,576  ->  1.6 @0,0
patched clamshell:  1.3333334 @4096,576  ->  unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXHwpPxQ2nRxfZXXKVZtKF
