### PR TITLE
Disable unrestricted Kitty remote control

### DIFF
--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -18,8 +18,8 @@ map shift+enter send_text all \e[13;2u
 # Kitty legacy encoding sends Alt+Shift+Enter the same as Alt+Enter; send CSI-u so tmux can match M-S-Enter.
 map alt+shift+enter send_text all \e[13;4u
 
-# Allow remote access
-allow_remote_control yes
+# Prevent terminal output from issuing remote control commands
+allow_remote_control no
 listen_on unix:${XDG_RUNTIME_DIR}/omarchy-kitty-{kitty_pid}
 
 # Aesthetics

--- a/migrations/1788707260.sh
+++ b/migrations/1788707260.sh
@@ -1,0 +1,10 @@
+echo "Disable unrestricted Kitty remote control"
+
+kitty_config="$HOME/.config/kitty/kitty.conf"
+
+if [[ -f $kitty_config ]] && grep -qE '^[[:space:]]*allow_remote_control[[:space:]]+yes[[:space:]]*$' "$kitty_config"; then
+  sed -i -E 's/^([[:space:]]*allow_remote_control[[:space:]]+)yes([[:space:]]*)$/\1no\2/' "$kitty_config"
+
+  # Kitty reads allow_remote_control only at startup; reloading is insufficient.
+  echo "Close and reopen all Kitty windows to disable remote control in running terminals."
+fi

--- a/test/shell.d/kitty-remote-control-migration-test.sh
+++ b/test/shell.d/kitty-remote-control-migration-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1788707260.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+test_home="$test_dir/home"
+kitty_config="$test_home/.config/kitty/kitty.conf"
+mkdir -p "$(dirname "$kitty_config")"
+
+run_migration() {
+  env HOME="$test_home" bash -euo pipefail "$migration"
+}
+
+grep -qx 'allow_remote_control no' "$ROOT/config/kitty/kitty.conf" ||
+  fail "new installs disable Kitty remote control"
+pass "new installs disable Kitty remote control"
+
+cp "$ROOT/config/kitty/kitty.conf" "$kitty_config"
+sed -i 's/^allow_remote_control no$/allow_remote_control yes/' "$kitty_config"
+output=$(run_migration)
+cmp -s "$ROOT/config/kitty/kitty.conf" "$kitty_config" ||
+  fail "migration disables remote control without changing other defaults"
+[[ $output == *"Close and reopen all Kitty windows"* ]] ||
+  fail "migration explains that running Kitty processes need restarting"
+pass "migration disables the shipped yes setting and explains how to apply it"
+
+cp "$kitty_config" "$test_dir/expected"
+output=$(run_migration)
+cmp -s "$test_dir/expected" "$kitty_config" || fail "migration is idempotent"
+[[ $output != *"Close and reopen"* ]] || fail "unchanged config needs no restart reminder"
+pass "migration is idempotent"
+
+cat >"$kitty_config" <<'EOF'
+# allow_remote_control yes
+font_size 14
+  allow_remote_control   yes
+allow_remote_control yes
+listen_on unix:/tmp/custom-kitty
+map ctrl+insert copy_to_clipboard
+EOF
+cat >"$test_dir/expected" <<'EOF'
+# allow_remote_control yes
+font_size 14
+  allow_remote_control   no
+allow_remote_control no
+listen_on unix:/tmp/custom-kitty
+map ctrl+insert copy_to_clipboard
+EOF
+printf 'allow_remote_control yes  \n' >>"$kitty_config"
+printf 'allow_remote_control no  \n' >>"$test_dir/expected"
+run_migration >/dev/null
+cmp -s "$test_dir/expected" "$kitty_config" ||
+  fail "migration handles whitespace and duplicate settings while preserving customizations"
+pass "migration handles whitespace and duplicate settings while preserving customizations"
+
+for setting in no socket-only socket password; do
+  printf 'allow_remote_control %s\nfont_size 14\n' "$setting" >"$kitty_config"
+  cp "$kitty_config" "$test_dir/expected"
+  run_migration >/dev/null
+  cmp -s "$test_dir/expected" "$kitty_config" || fail "migration preserves $setting"
+done
+pass "migration preserves settings other than unrestricted yes"
+
+printf '# allow_remote_control yes\nfont_size 14\n' >"$kitty_config"
+cp "$kitty_config" "$test_dir/expected"
+run_migration >/dev/null
+cmp -s "$test_dir/expected" "$kitty_config" || fail "migration leaves an omitted setting alone"
+pass "migration leaves an omitted setting alone"
+
+test_home="$test_dir/empty-home"
+mkdir -p "$test_home"
+run_migration >/dev/null
+[[ ! -e $test_home/.config/kitty ]] || fail "migration does not create a missing Kitty config"
+pass "migration succeeds without a Kitty config"


### PR DESCRIPTION
Kitty currently ships with `allow_remote_control yes`, allowing untrusted terminal output to issue commands through Kitty's remote-control protocol. Set the default to `no` and migrate existing explicit `yes` settings to `no`, preserving unrelated configuration and other remote-control modes users have selected.

Kitty reads this setting at startup and does not change it on config reload. The migration tells users to close and reopen all Kitty windows; existing processes remain exposed until they exit.

Disabling remote control also disables Omarchy's socket-based lookup of the active Kitty tab's working directory. New terminal and Files launches use the existing process-based fallback when no socket exists, which cannot reliably select the active tab/pane and can fall back to the home directory. Theme and font updates continue using config edits and signals.

Validation: the focused migration test passes all seven checks, covering shipped defaults, migration of `yes`, restart guidance, idempotence, whitespace and duplicate entries, preservation of custom settings, and missing configs. Bash syntax checks and `git diff --check` also pass. Kitty is not installed in the test environment, so no live terminal test was run.
