### PR TITLE
Bind the scrolling layout's column controls

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -12,6 +12,10 @@ o.bind("SUPER + O", "Pop window out (float & pin)", "omarchy-hyprland-window-pop
 o.bind("SUPER + ALT + Home", "Save window width", "omarchy-hyprland-window-width save")
 o.bind("SUPER + Home", "Restore window width", "omarchy-hyprland-window-width restore")
 o.bind("SUPER + L", "Toggle workspace layout", "omarchy-hyprland-workspace-layout-toggle")
+o.bind("SUPER + BACKSLASH", "Stack or unstack window with next column", hl.dsp.layout("consume_or_expel next"))
+o.bind("SUPER + SHIFT + BACKSLASH", "Stack or unstack window with previous column", hl.dsp.layout("consume_or_expel prev"))
+o.bind("SUPER + BRACKETRIGHT", "Widen column", hl.dsp.layout("colresize +conf"))
+o.bind("SUPER + BRACKETLEFT", "Narrow column", hl.dsp.layout("colresize -conf"))
 
 o.bind("SUPER + LEFT", "Focus on left window", hl.dsp.focus({ direction = "l" }))
 o.bind("SUPER + RIGHT", "Focus on right window", hl.dsp.focus({ direction = "r" }))


### PR DESCRIPTION
`SUPER + L` switches a workspace into the scrolling layout, but nothing binds the two layout messages that layout is steered with, so it arrives without controls: there is no way to stack a window into a column, and no way to change a column's width. In the same file, windows get ten group bindings and twelve resize variants. The scrolling layout gets none.

Four bindings in `default/hypr/bindings/tiling.lua`:

| Binding | Action |
| --- | --- |
| `SUPER + \` | Stack or unstack window with next column |
| `SUPER + SHIFT + \` | Stack or unstack window with previous column |
| `SUPER + ]` | Widen column |
| `SUPER + [` | Narrow column |

**`colresize +conf` rather than a fraction.** `scrolling:explicit_column_widths` already ships as `0.333, 0.5, 0.667, 1.0`, and `+conf`/`-conf` step through exactly that list. Nothing in the repo could reach it, so the setting was configurable and unreachable at the same time.

**`consume_or_expel` is two bindings, not one.** It takes a direction. A bare `consume_or_expel` binds and reloads without complaint, then fails at press time with `not enough args` — silent until pressed — so both directions are spelled out rather than bound as a single toggle.

**Keys.** Brackets and backslash are not bound anywhere in `default/hypr/bindings/` today, so these four take no key away from anything.

**Tests.** `test/all` on this branch: 3248 ok, 1 not ok. The one failure is `bin commands use command helpers`, which flags `bin/omarchy-remove-ai-hermes` and `bin/omarchy-remove-ai-openclaw`. This branch touches neither, and I reproduced the same failure on a clean checkout of `quattro` at a62e34ea before opening this.
