### PR TITLE
Map keypad digits in the polkit dialog when Qt ignores NumLock

### DIFF
--- a/shell/plugins/polkit/PolkitAgent.qml
+++ b/shell/plugins/polkit/PolkitAgent.qml
@@ -54,6 +54,15 @@ Item {
     return PolkitModel.authorizationLabel(message)
   }
 
+  function insertKeypadDigit(event) {
+    if (fingerprintMode || passwordInput.readOnly || !responseRequired) return false
+    if (!(event.modifiers & Qt.KeypadModifier)) return false
+    var digit = PolkitModel.keypadDigit(event.key)
+    if (digit === "") return false
+    passwordInput.insert(passwordInput.cursorPosition, digit)
+    return true
+  }
+
   function loadPamConfig(raw) {
     fingerprintConfigured = PolkitModel.fingerprintConfiguredFromPamConfig(raw)
   }
@@ -264,6 +273,8 @@ Item {
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             if (root.responseRequired) root.submitResponse()
             event.accepted = true
+          } else if (root.insertKeypadDigit(event)) {
+            event.accepted = true
           }
         }
       }
@@ -326,6 +337,8 @@ Item {
             Keys.onPressed: function(event) {
               if (event.key === Qt.Key_Escape) {
                 root.cancelRequest()
+                event.accepted = true
+              } else if (root.insertKeypadDigit(event)) {
                 event.accepted = true
               }
             }

--- a/shell/plugins/polkit/PolkitModel.js
+++ b/shell/plugins/polkit/PolkitModel.js
@@ -23,10 +23,31 @@ function authorizationLabel(message) {
   return match ? "Authorize running '" + match[1] + "'" : text
 }
 
+// Qt never reads system NumLock at startup (QTBUG-32687), so keypad digits
+// arrive as navigation keys. Values are Qt::Key_* from qnamespace.h.
+function keypadDigit(k) {
+  switch (k) {
+    case 0x01000006: return "0" // Key_Insert
+    case 0x01000011: return "1" // Key_End
+    case 0x01000015: return "2" // Key_Down
+    case 0x01000017: return "3" // Key_PageDown
+    case 0x01000012: return "4" // Key_Left
+    case 0x0100000b: return "5" // Key_Clear
+    case 0x00000035: return "5" // Key_5 (some layouts)
+    case 0x01000014: return "6" // Key_Right
+    case 0x01000010: return "7" // Key_Home
+    case 0x01000013: return "8" // Key_Up
+    case 0x01000016: return "9" // Key_PageUp
+    case 0x01000007: return "." // Key_Delete
+  }
+  return ""
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     promptLooksFingerprint: promptLooksFingerprint,
     fingerprintConfiguredFromPamConfig: fingerprintConfiguredFromPamConfig,
-    authorizationLabel: authorizationLabel
+    authorizationLabel: authorizationLabel,
+    keypadDigit: keypadDigit
   }
 }

--- a/test/shell.d/polkit-test.sh
+++ b/test/shell.d/polkit-test.sh
@@ -46,4 +46,19 @@ auth required pam_unix.so
 `),
   'polkit reports no fingerprint when pam_fprintd is absent'
 )
+
+assertEqual(polkit.keypadDigit(0x01000006), "0", "keypad 0 arrives as Insert when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x01000011), "1", "keypad 1 arrives as End when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x01000015), "2", "keypad 2 arrives as Down when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x01000017), "3", "keypad 3 arrives as PageDown when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x01000012), "4", "keypad 4 arrives as Left when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x0100000b), "5", "keypad 5 arrives as Clear when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x35), "5", "keypad 5 can arrive as Key_5 with KeypadModifier")
+assertEqual(polkit.keypadDigit(0x01000014), "6", "keypad 6 arrives as Right when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x01000010), "7", "keypad 7 arrives as Home when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x01000013), "8", "keypad 8 arrives as Up when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x01000016), "9", "keypad 9 arrives as PageUp when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x01000007), ".", "keypad decimal arrives as Delete when NumLock is desynced")
+assertEqual(polkit.keypadDigit(0x34), "", "top-row 4 is not remapped")
+assertEqual(polkit.keypadDigit(0x01000004), "", "Return is not remapped as a keypad digit")
 JS


### PR DESCRIPTION
## Summary
- Qt does not read system NumLock at startup ([QTBUG-32687](https://bugreports.qt.io/browse/QTBUG-32687)), so the polkit PIN/password field treats the numeric keypad as off even when Hyprland reports `numLock: true`.
- Keypad digits then arrive as navigation keys (`Left`, `Home`, `End`, …) with `KeypadModifier` and insert nothing until NumLock is toggled twice.
- Map those keypad keys back to digits in `omarchy.polkit` so a PIN can be typed immediately. The plugin id is unchanged.

Fixes #8552

## Test plan
- [x] `bash test/shell.d/polkit-test.sh`
- [ ] `pkexec true` with NumLock on: type digits on the numeric keypad without toggling NumLock
- [ ] Confirm a wrong PIN still shakes/fails, and Escape still cancels
- [ ] Confirm the top number row still works as before


Made with [Cursor](https://cursor.com)