### PR TITLE
Skip unchanged native Codex token snapshots

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -300,6 +300,7 @@ def scan_native_codex_sessions():
 
   for path in files:
     current_model = "codex"
+    previous_total_usage = None
     try:
       with path.open(errors="replace") as handle:
         for raw in handle:
@@ -331,6 +332,16 @@ def scan_native_codex_sessions():
           output_tokens = number(usage.get("output_tokens"))
           if not (input_tokens or output_tokens or cache_read or cache_write):
             continue
+          # Quota updates can repeat the previous request's last_token_usage.
+          # Only an unchanged cumulative snapshot proves this is a repeat:
+          # separate requests may have identical last-token counts, and older
+          # records may not carry cumulative counters at all. Keep this state
+          # per rollout and accept changed counters, including counter resets.
+          total_usage = info.get("total_token_usage")
+          if isinstance(total_usage, dict) and total_usage:
+            if total_usage == previous_total_usage:
+              continue
+            previous_total_usage = total_usage
           day = local_day(entry.get("timestamp") or path.stat().st_mtime)
           add_usage(day, str(path), current_model, input_tokens, output_tokens, cache_read, cache_write)
     except Exception:
@@ -389,9 +400,10 @@ def write_json(path, payload):
 # The cache payload is a versioned envelope around the local-stats dict, so a
 # corrupted or foreign-shaped file is a cache miss (rescan + rewrite) instead
 # of a crash or a garbage record.
+# Version 2 invalidates totals counted before native notification deduplication.
 def read_cached_stats(cache_file, max_age_seconds):
   cached = read_fresh_json(cache_file, max_age_seconds)
-  if not isinstance(cached, dict) or cached.get("schemaVersion") != 1:
+  if not isinstance(cached, dict) or cached.get("schemaVersion") != 2:
     return None
   # today* fields only mean "today" on the day they were scanned. A cache
   # from another local date (midnight passed, or the clock moved) is a miss,
@@ -408,7 +420,7 @@ def read_cached_stats(cache_file, max_age_seconds):
 
 def write_cached_stats(cache_file, stats):
   try:
-    write_json(cache_file, {"schemaVersion": 1, "scanDate": today, "stats": stats})
+    write_json(cache_file, {"schemaVersion": 2, "scanDate": today, "stats": stats})
   except Exception as exc:
     print(f"omarchy-agent-usage-codex: could not write usage cache ({exc})", file=sys.stderr)
 

--- a/test/shell.d/agent-usage-codex-notifications-test.sh
+++ b/test/shell.d/agent-usage-codex-notifications-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command python3
+
+python3 - "$ROOT/bin/omarchy-agent-usage-codex" <<'PY'
+import json
+import os
+import runpy
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+collector = sys.argv[1]
+now = datetime.now().astimezone().replace(hour=12, minute=0, second=0, microsecond=0)
+
+
+def tokens(input_tokens=100, output_tokens=10):
+  return {"input_tokens": input_tokens, "cached_input_tokens": input_tokens // 2,
+          "output_tokens": output_tokens, "reasoning_output_tokens": 2,
+          "total_tokens": input_tokens + output_tokens}
+
+
+def event(total, last=None, offset=0):
+  return {"type": "event_msg", "timestamp": (now + timedelta(seconds=offset)).isoformat(),
+          "payload": {"type": "token_count", "info": {
+            "total_token_usage": total, "last_token_usage": last or tokens()},
+            "rate_limits": {"primary": {"used_percent": offset}}}}
+
+
+def check(name, rollouts, expected_tokens, expected_prompts):
+  with tempfile.TemporaryDirectory() as temporary:
+    root = Path(temporary)
+    os.environ["CODEX_HOME"] = str(root)
+    for relative_path, events in rollouts.items():
+      path = root / relative_path
+      path.parent.mkdir(parents=True, exist_ok=True)
+      path.write_text("\n".join(json.dumps(item) for item in events) + "\n")
+    loaded = runpy.run_path(collector, run_name="notification_test")
+    loaded["scan_native_codex_sessions"]()
+    stats = loaded["local_stats"]()
+    actual = sum(sum(bucket.values()) for bucket in stats["modelUsage"].values())
+    assert actual == expected_tokens, (name, actual, expected_tokens)
+    assert stats["totalPrompts"] == expected_prompts, (name, stats)
+    assert sum(day["messageCount"] for day in stats["recentDays"]) == expected_tokens, (name, stats)
+    print("ok - " + name)
+
+
+check("native repeated snapshots ignore timestamp and quota changes", {
+  "sessions/main.jsonl": [event(tokens()), event(tokens(), offset=1), event(tokens(), offset=2)]
+}, 110, 1)
+
+check("native equal request sizes count when cumulative usage advances", {
+  "sessions/main.jsonl": [event(tokens()), event(tokens(200, 20), offset=1)]
+}, 220, 2)
+
+check("native notification deduplication stays within each rollout", {
+  "sessions/first.jsonl": [event(tokens())],
+  "archived_sessions/second.jsonl": [event(tokens()), event(tokens(), offset=1)]
+}, 220, 2)
+
+check("native requests without cumulative counters remain countable", {
+  "sessions/main.jsonl": [event(None), event(None, offset=1), event({}), event({}, offset=1)]
+}, 440, 4)
+
+check("native counter resets do not discard new requests", {
+  "sessions/main.jsonl": [event(tokens()), event(tokens(200, 20)), event(tokens())]
+}, 330, 3)
+
+check("native quota-only events and model context do not reset deduplication", {
+  "sessions/main.jsonl": [event(tokens()),
+    {"type": "event_msg", "payload": {"type": "token_count", "info": None}},
+    {"type": "turn_context", "payload": {"model": "another-model"}},
+    event(tokens(), offset=1)]
+}, 110, 1)
+PY

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -42,6 +42,7 @@ cat >"$session" <<EOF
 {"timestamp":"$timestamp","type":"turn_context","payload":{"model":"gpt-test"}}
 {"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":60,"output_tokens":20,"reasoning_output_tokens":5,"total_tokens":120},"last_token_usage":{"input_tokens":100,"cached_input_tokens":60,"output_tokens":20,"reasoning_output_tokens":5,"total_tokens":120}}}}
 {"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":180,"cached_input_tokens":110,"output_tokens":30,"reasoning_output_tokens":8,"total_tokens":210},"last_token_usage":{"input_tokens":80,"cached_input_tokens":50,"output_tokens":10,"reasoning_output_tokens":3,"total_tokens":90}}}}
+{"timestamp":"$timestamp","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":180,"cached_input_tokens":110,"output_tokens":30,"reasoning_output_tokens":8,"total_tokens":210},"last_token_usage":{"input_tokens":80,"cached_input_tokens":50,"output_tokens":10,"reasoning_output_tokens":3,"total_tokens":90}},"rate_limits":{"primary":{"used_percent":10}}}}
 EOF
 
 result=$(HOME="$TEST_HOME" CODEX_HOME="$TEST_HOME/.codex" CODEX_ARGS_FILE="$TEST_HOME/codex-args" XDG_DATA_HOME="$TEST_HOME/.local/share" PATH="$TEST_HOME/bin:$PATH" \
@@ -59,6 +60,10 @@ pass "Codex collector uses the supported approval policy"
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "210" ]] ||
   fail "Codex collector counts each turn once" "$result"
 pass "Codex collector counts each turn once"
+
+[[ $(jq -r '.todayPrompts' <<<"$result") == "2" ]] ||
+  fail "Codex collector does not count repeated quota notifications as prompts" "$result"
+pass "Codex collector does not count repeated quota notifications as prompts"
 
 [[ $(jq -c '.modelUsage["gpt-test"]' <<<"$result") == '{"inputTokens":70,"outputTokens":30,"cacheReadInputTokens":110,"cacheCreationInputTokens":0}' ]] ||
   fail "Codex collector does not double-count cache or reasoning tokens" "$result"
@@ -188,9 +193,19 @@ cache_file=$(ls "$CACHE_HOME/.cache/omarchy/agent-usage/"/codex-scan-*.json 2>/d
   fail "Codex collector leaves a cache file behind" "$result"
 [[ $(stat -c %a "$cache_file") == "644" ]] ||
   fail "Codex collector keeps cache files readable" "$result"
-[[ $(jq -r '.schemaVersion' "$cache_file") == "1" && $(jq -r '.stats.todayTotalTokens' "$cache_file") == "5" ]] ||
+[[ $(jq -r '.schemaVersion' "$cache_file") == "2" && $(jq -r '.stats.todayTotalTokens' "$cache_file") == "5" ]] ||
   fail "Codex collector writes a versioned cache envelope" "$result"
 pass "Codex collector writes a local-stats cache on first scan"
+
+# A still-fresh cache from before native notification deduplication must not
+# restore inflated counts, even when only quota limits were requested.
+jq '.schemaVersion = 1 | .stats.todayTotalTokens = 999' "$cache_file" >"$CACHE_HOME/old-cache.json"
+mv "$CACHE_HOME/old-cache.json" "$cache_file"
+result=$(HOME="$CACHE_HOME" CODEX_HOME="$CACHE_HOME/.codex" XDG_CACHE_HOME="$CACHE_HOME/.cache" XDG_DATA_HOME="$CACHE_HOME/.local/share" \
+  PATH="$CACHE_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex" --limits-only)
+[[ $(jq -r '.todayTotalTokens' <<<"$result") == "5" && $(jq -r '.schemaVersion' "$cache_file") == "2" ]] ||
+  fail "Codex collector invalidates pre-deduplication cached totals" "$result"
+pass "Codex collector invalidates pre-deduplication cached totals"
 
 # A corrupt-but-parseable cache (wrong shape) is a cache miss: rescan and
 # rewrite instead of emitting a garbage record.
@@ -200,7 +215,7 @@ result=$(HOME="$CACHE_HOME" CODEX_HOME="$CACHE_HOME/.codex" XDG_CACHE_HOME="$CAC
 
 [[ $(jq -r '.todayTotalTokens' <<<"$result") == "5" ]] ||
   fail "Codex collector recovers from a corrupt cache file" "$result"
-[[ $(jq -r '.schemaVersion' "$cache_file") == "1" ]] ||
+[[ $(jq -r '.schemaVersion' "$cache_file") == "2" ]] ||
   fail "Codex collector rewrites the cache after a corrupt read" "$result"
 pass "Codex collector recovers from a corrupt cache file"
 


### PR DESCRIPTION
Native Codex can emit another `token_count` notification when quota information changes while retaining the previous request's `last_token_usage` and `total_token_usage`. The collector adds that request again: a 100-input/10-output request followed by an unchanged usage notification currently produces 220 tokens and two prompts instead of 110 tokens and one prompt.

Track the last counted cumulative snapshot within each rollout and skip unchanged snapshots. Requests with equal token counts still count when cumulative usage advances; changed/reset counters and records without cumulative counters retain their existing behavior. Cache schema version 2 invalidates totals generated before this correction, including on `--limits-only` refreshes.

This is limited to repeated native notifications. Pi inherited-message handling remains in #8602; its patch applies cleanly alongside this change. The model-aware hourly view discussed in #9204 remains a separate follow-up to #8862.

Observed native Codex coverage: the local corpus scan reported in https://github.com/omacom/omarchy/pull/10531#issuecomment-5575503884 covered 143 rollouts dated 2026-08-23 through 2026-09-06, across Codex 0.149.0–0.153.4, with 11,790 token_count events. All 11,711 countable events carried a non-empty total_token_usage dict; 78 events had empty/zero last_token_usage and one had info: null. No countable event without cumulative counters was observed in that corpus. This is evidence for the sampled versions and rollouts, not a guarantee about all Codex releases. Records with missing or empty cumulative counters remain countable for compatibility: without that signal, a repeated notification cannot reliably be distinguished from two equal-size requests.

Validation:

- New native-notification regression suite: 6 cases pass; the repeated-notification case fails on the unchanged base (330 tokens instead of 110).
- Existing Codex scanner suite passes, including repeated quota notifications, prompt counts, cache/reasoning accounting, and invalidation of a fresh version-1 cache.
- Python syntax and `git diff --check` pass.
- `./test/all`: CLI suite passes; 226/228 shell test files pass. The two failures reproduce on an untouched checkout of base `a62e34ea`: `bin-style-test.sh` flags existing raw command checks in `omarchy-remove-ai-hermes` / `omarchy-remove-ai-openclaw`; `launch-about-test.sh` fails “a roomy window animates.”
