### PR TITLE
Point the shipped agent skills at omacom/omarchy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Suggestion
-    url: https://github.com/basecamp/omarchy/discussions/categories/suggestions
+    url: https://github.com/omacom/omarchy/discussions/categories/suggestions
     about: Suggest a new feature, change to existing feature, or other ideas in Discussions.
   - name: Support
     url: https://omarchy.org/discord

--- a/default/agents/skills/diagnose-crash/reporting.md
+++ b/default/agents/skills/diagnose-crash/reporting.md
@@ -40,8 +40,8 @@ useful; filing there yourself is not part of this.
 A duplicate issue costs a maintainer more time than no report at all.
 
 ```bash
-gh search issues --repo basecamp/omarchy "<program> crash"
-gh issue list --repo basecamp/omarchy --state all --search "<signal> <program>"
+gh search issues --repo omacom/omarchy "<program> crash"
+gh issue list --repo omacom/omarchy --state all --search "<signal> <program>"
 ```
 
 Search on the crashing program, the signal, and distinctive symbols from the
@@ -59,7 +59,7 @@ more than another duplicate.
 If a plausible match comes back, read it properly first:
 
 ```bash
-gh issue view <number> --repo basecamp/omarchy --comments
+gh issue view <number> --repo omacom/omarchy --comments
 ```
 
 Confirm it is genuinely the same failure. The same program crashing is not the
@@ -74,7 +74,7 @@ A comment that only says the bug happens to you too is noise. If that is all you
 have, tell the user so and file nothing.
 
 ```bash
-gh issue comment <number> --repo basecamp/omarchy --body "..."
+gh issue comment <number> --repo omacom/omarchy --body "..."
 ```
 
 ## Filing a new issue
@@ -82,7 +82,7 @@ gh issue comment <number> --repo basecamp/omarchy --body "..."
 Only when the search turns up nothing that matches:
 
 ```bash
-gh issue create --repo basecamp/omarchy --title "..." --body "..."
+gh issue create --repo omacom/omarchy --title "..." --body "..."
 ```
 
 Include what happened, what was expected, steps to reproduce, system details from

--- a/default/agents/skills/omarchy/contributing.md
+++ b/default/agents/skills/omarchy/contributing.md
@@ -3,13 +3,13 @@
 Read this when the user wants to report an Omarchy bug, suggest a feature, or
 contribute a fix upstream.
 
-Omarchy lives at https://github.com/basecamp/omarchy. Route requests to the
+Omarchy lives at https://github.com/omacom/omarchy. Route requests to the
 right place:
 
 - **Verified bugs** -> GitHub issues. Issues are for validated bugs only, not
   support requests.
 - **Feature ideas and suggestions** ->
-  https://github.com/basecamp/omarchy/discussions/categories/suggestions
+  https://github.com/omacom/omarchy/discussions/categories/suggestions
 - **Support and "is this a bug?" questions** -> the Discord community at
   https://omarchy.org/discord. Start here when the problem isn't clearly a bug
   in Omarchy itself.
@@ -43,7 +43,7 @@ For screen-recording failures specifically, rerun with
 File the issue with `gh` when available:
 
 ```bash
-gh issue create --repo basecamp/omarchy --title "..." --body "..."
+gh issue create --repo omacom/omarchy --title "..." --body "..."
 ```
 
 Include: what happened, what was expected, steps to reproduce, system details,
@@ -54,7 +54,7 @@ the debug log URL (or attached log), and the capture.
 Never develop against `/usr/share/omarchy`. Clone a working copy instead:
 
 ```bash
-gh repo fork basecamp/omarchy --clone
+gh repo fork omacom/omarchy --clone
 cd omarchy
 ```
 


### PR DESCRIPTION
## Why

The repository moved from basecamp/omarchy to omacom/omarchy, but the skills Omarchy installs into `~/.claude/skills`, `~/.codex/skills` and `~/.agents/skills` still name the old owner. Most `gh` calls follow the rename, so nothing looks wrong in normal use. Search does not: `gh issue list --repo basecamp/omarchy --search ...` exits 0 with no output, and the raw search API answers "Validation Failed". An agent following `contributing.md` or `reporting.md` runs its duplicate check before filing, sees zero matches, and files a duplicate. Both skills tell agents to do exactly that check.

## Change

Replace the owner in `contributing.md` (four places), `diagnose-crash/reporting.md` (five places, all `gh` search/view/comment/create examples), and the Suggestion link in `.github/ISSUE_TEMPLATE/config.yml`, which is the same stale name on the contributor path.

Left alone on purpose: the `git clone` URL in `bin/omarchy-channel-set`, the releases link in `bin/omarchy-update-confirm`, the tarball URL in `bin/omarchy-upgrade-to-quattro`, the `Documentation=` line in `omarchy-speaker-tuning.service`, and the links in `manual/`. GitHub redirects all of those, `test/shell.d/channel-test.sh:150` asserts the exact clone URL, and the manual's discussion links are historical. Changing them is a separate change if wanted.

I did not add the two extras the issue suggests (a control-query sentence in `contributing.md` and a CI grep for the old owner): the first is advice to agents that `AGENTS.md` does not currently give, and the repo has no CI workflows to put the second in. Either can be its own PR.

## Tests

Doc-only change, no executable touched. `grep -rn basecamp/omarchy default/agents .github` returns nothing on this branch.

Fixes #10118

Written by Claude Fable 5.1 via Claude Code, reviewed by Marc Morriss