### PR TITLE
Paste clipboard files with Ctrl+V instead of Shift+Insert (#10526)

### DIFF
--- a/bin/omarchy-clipboard-paste-file
+++ b/bin/omarchy-clipboard-paste-file
@@ -30,4 +30,4 @@ if [[ $copy_only == "true" ]]; then
 fi
 
 sleep 0.15
-wtype -M shift -k Insert -m shift 2>/dev/null || true
+wtype -M ctrl -k v -m ctrl 2>/dev/null || true

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -495,6 +495,25 @@ pass "clipboard file paste helper copy-only copies file content"
 [[ ! -e "$TMPDIR/wtype" ]] || fail "clipboard file paste helper copy-only skips paste keystroke"
 pass "clipboard file paste helper copy-only skips paste keystroke"
 
+rm -f "$TMPDIR/wtype"
+WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" PATH="$TMPDIR/bin:$PATH" \
+  "$ROOT/bin/omarchy-clipboard-paste-file" image/png "$TMPDIR/image.png"
+
+[[ $(<"$TMPDIR/copied") == "image-data" ]] || fail "clipboard file paste helper copies file content"
+pass "clipboard file paste helper copies file content"
+
+[[ $(<"$TMPDIR/wtype") == "-M ctrl -k v -m ctrl" ]] || fail "clipboard file paste helper pastes files with ctrl v"
+pass "clipboard file paste helper pastes files with ctrl v"
+
+(! PATH="$TMPDIR/bin:$PATH" "$ROOT/bin/omarchy-clipboard-paste-file" 2>/dev/null) || fail "clipboard file paste helper fails on missing arguments"
+pass "clipboard file paste helper fails on missing arguments"
+
+rm -f "$TMPDIR/copied" "$TMPDIR/wtype"
+(! PATH="$TMPDIR/bin:$PATH" "$ROOT/bin/omarchy-clipboard-paste-file" image/png "$TMPDIR/nonexistent.png" 2>/dev/null) || fail "clipboard file paste helper fails on unreadable file"
+[[ ! -e "$TMPDIR/copied" ]] || fail "clipboard file paste helper does not copy unreadable file"
+[[ ! -e "$TMPDIR/wtype" ]] || fail "clipboard file paste helper does not paste when file unreadable"
+pass "clipboard file paste helper fails safely on unreadable file"
+
 jq -n --arg url 'https://example.com/docs' --arg text "$(printf 'plain text\nsecond line')" --arg image "$TMPDIR/image.png" \
   '[{type:"text", text:$url}, {type:"text", text:$text}, {type:"image", mime:"image/png", path:$image}]' >"$TMPDIR/home/.local/state/omarchy/clipboard-history.json"
 


### PR DESCRIPTION
## Problem

When selecting an image entry from the clipboard manager (`Super + Ctrl + V`), `bin/omarchy-clipboard-paste-file` copies the image to the clipboard via `wl-copy --type "$mime"` and then dispatches:

```bash
wtype -M shift -k Insert -m shift 2>/dev/null || true
```

As reported in #10526, terminal emulators (`foot`, `ghostty`, `kitty`, etc.) bind `Shift+Insert` to their own text-only paste handler and consume the keystroke before the running application ever sees it. Because the clipboard only holds an `image/*` flavor without a text flavor, the terminal emulator quietly drops the event, resulting in no paste and no feedback.

Consequently, terminal-based applications that support image paste (such as Claude Code, Gemini CLI, and terminal image viewers) fail to receive the pasted image, forcing users to manually press `Ctrl+V`.

## Solution

Switch the synthetic paste keystroke in `bin/omarchy-clipboard-paste-file` from `Shift+Insert` to `Ctrl+V`:

```bash
wtype -M ctrl -k v -m ctrl 2>/dev/null || true
```

- In terminal emulators, `Ctrl+V` passes through to running applications, allowing image-capable TUIs and CLI agents to read the image from the clipboard.
- In graphical applications (browsers, chat clients, image editors), `Ctrl+V` continues to work as the universal paste shortcut.

## Test plan

- [x] Run automated test suite: `bash test/shell.d/clipboard-test.sh` (all 76 assertions pass, covering `--copy-only` content staging, normal execution with `ctrl v` keystroke dispatch, missing argument fail-closed, and unreadable/nonexistent file fail-closed).
- [x] Run full CLI verification: `./test/cli` (all 108 tests pass).

Closes #10526