### PR TITLE
Start Dropbox daemon under uwsm-app from the bar panel

### DIFF
--- a/shell/plugins/panels/dropbox/Service.qml
+++ b/shell/plugins/panels/dropbox/Service.qml
@@ -98,7 +98,7 @@ Item {
     _loginError = ""
     _loginUrlOpened = false
     actionStatus = "Starting Dropbox login…"
-    loginProcess.command = ["dropbox-cli", "start"]
+    loginProcess.command = ["uwsm-app", "--", "dropbox-cli", "start"]
     loginProcess.running = true
   }
 
@@ -107,7 +107,7 @@ Item {
   }
 
   function resume() {
-    runControl(["dropbox-cli", "start"], 1)
+    runControl(["uwsm-app", "--", "dropbox-cli", "start"], 1)
   }
 
   function toggleRunning() {


### PR DESCRIPTION
The Dropbox panel invokes \dropbox-cli start\ directly in \login()\ and \esume()\, unlike the installer which wraps daemon launches with \uwsm-app\. Because \dropbox-cli start\ is a bare \setsid\ fork that inherits the caller's cgroup, starting or resuming Dropbox from the panel placed \dropboxd\ inside Quickshell's cgroup (or a terminal's scope) rather than its own app scope.

Wrapping daemon invocations in \shell/plugins/panels/dropbox/Service.qml\ with \uwsm-app --\ ensures the daemon lands in its own systemd session scope regardless of who triggers it.

Fixes #10423