### PR TITLE
Enable resolve_binds_by_sym in Hyprland input configuration

### DIFF
--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -60,6 +60,7 @@ hl.config({
     repeat_rate = 40,
     repeat_delay = 250,
     numlock_by_default = true,
+    resolve_binds_by_sym = true,
 
     touchpad = {
       natural_scroll = false,


### PR DESCRIPTION
The stock touchpad bindings in \default/hypr/bindings/media.lua\ (\XF86TouchpadToggle\, \XF86TouchpadOn\, \XF86TouchpadOff\) never fire on laptops whose EC/hardware emits \KEY_TOUCHPAD_TOGGLE\ (evdev 530 / XKB 538). Because this keycode exceeds 255 and Hyprland's \input:resolve_binds_by_sym\ defaults to \alse\, reverse keysym-to-keycode resolution does not reach that range and the bindings remain inactive.

Setting \esolve_binds_by_sym = true\ in \default/hypr/input.lua\ enables Hyprland to resolve these keysym bindings properly.

Fixes #10449