### PR TITLE
Add safety auto-dismiss duration and shorter timeout for launch OSD

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -26,9 +26,8 @@ Item {
   property int launchSerial: 0
   property int launchToplevelCount: 0
   property var launchActiveToplevel: null
-  // True while the launch OSD is on screen. It outlives the launch that opened
-  // it: the OSD shows with duration 0, so only closeLaunchFeedback() takes it
-  // down.
+  // True while the launch OSD is on screen. Dismissed when the target toplevel
+  // appears, on launchTimeout, or when the OSD duration expires.
   property bool launchOsdOpen: false
   property string launchOsdMessage: ""
 
@@ -242,13 +241,13 @@ Item {
     onTriggered: {
       if (root.toplevelCount() > root.launchToplevelCount || ToplevelManager.activeToplevel !== root.launchActiveToplevel) return
       root.launchOsdOpen = true
-      Quickshell.execDetached(["omarchy-shell", "osd", "show", JSON.stringify({ icon: "󱓞", message: root.launchOsdMessage, duration: 0 })])
+      Quickshell.execDetached(["omarchy-shell", "osd", "show", JSON.stringify({ icon: "󱓞", message: root.launchOsdMessage, duration: 3500 })])
     }
   }
 
   Timer {
     id: launchTimeout
-    interval: 15000
+    interval: 5000
     onTriggered: root.closeLaunchFeedback(root.launchSerial)
   }
 


### PR DESCRIPTION
The launch feedback toast shown by \shell/services/AppLibrary.qml\ passed \duration: 0\ when displaying via \omarchy-shell osd show\. Setting duration to 0 completely disabled \Osd.qml\'s auto-dismiss timer (\hideTimer\).

When launching web applications or applications that delegate to existing browser instances, window-count changes are not always detected by \ToplevelManager\ in time, or signals can be dropped, leaving the notification permanently frozen on screen over the launched application. Furthermore, the fallback \launchTimeout\ was 15 seconds long.

This passes a 3500ms safety duration to the OSD and lowers \launchTimeout\ to 5000ms, ensuring the notification always clears cleanly even if toplevel events fail to fire.

Fixes #10487