### PR TITLE
add `Ctrl + {h,j,k,l}` directional movement for plugins that need it

### DIFF
--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -117,6 +117,12 @@ QtObject {
     return event.key === Qt.Key_Backspace           // plain, Shift, or Ctrl Backspace
   }
 
+  // True when `key` was pressed together with Ctrl: the vim-style Ctrl+{h,j,k,l}
+  // aliases searchable panels wire up alongside their arrow-key equivalents.
+  function ctrlKey(event, key) {
+    return event.key === key && !!(event.modifiers & Qt.ControlModifier)
+  }
+
   // New filter text after applying an edit key. Assumes editsFilter(event, text).
   function editedFilter(event, text) {
     if (event.key === Qt.Key_U) return ""                        // Ctrl+U: clear

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -363,14 +363,14 @@ Item {
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
-          } else if (event.key === Qt.Key_Delete) {
+          } else if (event.key === Qt.Key_Delete || Util.ctrlKey(event, Qt.Key_H)) {
             if (event.modifiers & Qt.ShiftModifier) root.requestClearHistory()
             else root.removeDisplayIndex(root.selectedIndex)
             event.accepted = true
-          } else if (event.key === Qt.Key_Up) {
+          } else if (event.key === Qt.Key_Up || Util.ctrlKey(event, Qt.Key_K)) {
             root.select(-1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Down) {
+          } else if (event.key === Qt.Key_Down || Util.ctrlKey(event, Qt.Key_J)) {
             root.select(1)
             event.accepted = true
           } else if (event.key === Qt.Key_PageUp) {
@@ -385,7 +385,7 @@ Item {
           } else if (event.key === Qt.Key_End) {
             root.selectAbsolute(displayModel.count - 1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || Util.ctrlKey(event, Qt.Key_L)) {
             if (root.cursorActive && (event.modifiers & Qt.AltModifier)) root.openIndex(root.selectedIndex)
             else if (root.cursorActive && (event.modifiers & Qt.ShiftModifier)) root.copyIndex(root.selectedIndex)
             else if (root.cursorActive) root.activateIndex(root.selectedIndex)

--- a/shell/plugins/emojis/Emojis.qml
+++ b/shell/plugins/emojis/Emojis.qml
@@ -203,16 +203,16 @@ Item {
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
-          } else if (event.key === Qt.Key_Left) {
+          } else if (event.key === Qt.Key_Left || Util.ctrlKey(event, Qt.Key_H)) {
             root.select(-1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Right) {
+          } else if (event.key === Qt.Key_Right || Util.ctrlKey(event, Qt.Key_L)) {
             root.select(1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Up) {
+          } else if (event.key === Qt.Key_Up || Util.ctrlKey(event, Qt.Key_K)) {
             root.selectRow(-1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Down) {
+          } else if (event.key === Qt.Key_Down || Util.ctrlKey(event, Qt.Key_J)) {
             root.selectRow(1)
             event.accepted = true
           } else if (event.key === Qt.Key_PageUp) {

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -420,10 +420,10 @@ Item {
             } else if (root.filterable && Util.editsFilter(event, root.filterText)) {
               root.updateFilter(Util.editedFilter(event, root.filterText))
               event.accepted = true
-            } else if (event.key === Qt.Key_Left || (event.key === Qt.Key_Tab && event.modifiers & Qt.ShiftModifier) || event.key === Qt.Key_Backtab) {
+            } else if (event.key === Qt.Key_Left || (event.key === Qt.Key_Tab && event.modifiers & Qt.ShiftModifier) || event.key === Qt.Key_Backtab || Util.ctrlKey(event, Qt.Key_H)) {
               root.selectAdjacent(-1)
               event.accepted = true
-            } else if (event.key === Qt.Key_Right || event.key === Qt.Key_Tab) {
+            } else if (event.key === Qt.Key_Right || event.key === Qt.Key_Tab || Util.ctrlKey(event, Qt.Key_L)) {
               root.selectAdjacent(1)
               event.accepted = true
             } else if (root.filterable && event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1136,13 +1136,13 @@ Item {
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
-          } else if ((event.key === Qt.Key_Backspace || event.key === Qt.Key_Left) && !root.filterText) {
+          } else if ((event.key === Qt.Key_Backspace || event.key === Qt.Key_Left || Util.ctrlKey(event, Qt.Key_H)) && !root.filterText) {
             root.goBack()
             event.accepted = true
-          } else if (event.key === Qt.Key_Up) {
+          } else if (event.key === Qt.Key_Up || Util.ctrlKey(event, Qt.Key_K)) {
             root.select(-1)
             event.accepted = true
-          } else if (event.key === Qt.Key_Down) {
+          } else if (event.key === Qt.Key_Down || Util.ctrlKey(event, Qt.Key_J)) {
             root.select(1)
             event.accepted = true
           } else if (event.key === Qt.Key_PageUp) {
@@ -1151,7 +1151,7 @@ Item {
           } else if (event.key === Qt.Key_PageDown) {
             root.select(6)
             event.accepted = true
-          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Right) {
+          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Right || Util.ctrlKey(event, Qt.Key_L)) {
             if (root.dmenuActive) {
               if (root.mode === "input") root.applyDmenuSelection(root.filterText)
               else if (displayModel.count > 0) root.activateIndex(root.cursorActive ? root.selectedIndex : 0)

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -624,13 +624,13 @@ Panel {
                 if (event.key === Qt.Key_Escape) {
                   root.cancelEditingLocation()
                   event.accepted = true
-                } else if (event.key === Qt.Key_Down) {
+                } else if (event.key === Qt.Key_Down || Util.ctrlKey(event, Qt.Key_J)) {
                   if (root.suggestionIndex < root.locationSuggestions.length - 1) root.suggestionIndex++
                   event.accepted = true
-                } else if (event.key === Qt.Key_Up) {
+                } else if (event.key === Qt.Key_Up || Util.ctrlKey(event, Qt.Key_K)) {
                   if (root.suggestionIndex > 0) root.suggestionIndex--
                   event.accepted = true
-                } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || Util.ctrlKey(event, Qt.Key_L)) {
                   root.commitLocation()
                   event.accepted = true
                 }

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -493,8 +493,14 @@ assert(
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(
-  /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
+  /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left \|\| Util\.ctrlKey\(event, Qt\.Key_H\)\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
   'menu Left key follows empty-filter Backspace navigation'
+)
+assert(
+  /event\.key === Qt\.Key_Up \|\| Util\.ctrlKey\(event, Qt\.Key_K\)[\s\S]*?root\.select\(-1\)/.test(menuQml)
+    && /event\.key === Qt\.Key_Down \|\| Util\.ctrlKey\(event, Qt\.Key_J\)[\s\S]*?root\.select\(1\)/.test(menuQml)
+    && /event\.key === Qt\.Key_Return \|\| event\.key === Qt\.Key_Enter \|\| event\.key === Qt\.Key_Right \|\| Util\.ctrlKey\(event, Qt\.Key_L\)/.test(menuQml),
+  'menu accepts Ctrl+h/j/k/l as vim-style aliases for back/up/down/activate'
 )
 assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),


### PR DESCRIPTION
Some plugins, like those with a text input, cannot be used with plain {h,j,k,l} for movement; Arrow Keys then might be fancy, yet the Ctrl modifier is easier to use.

## Brief

Add `Ctrl + {h,j,k,l}` alongside the existing arrow-key navigation in the searchable list panel plugins.

  - `h` → back / previous / delete-left, matching the existing Left / Backspace / Delete action for that panel
  - `j` → down
  - `k` → up
  - `l` → forward / activate, matching the existing Right / Enter action for that panel

Added a shared helper (`shell/Commons/Util.qml`) instead of repeating the `event.key === X && (event.modifiers & Qt.ControlModifier)` check at each call site, and wired it in.

Basically, they work as Arrow Keys.

  ## Testing

  - Updated `menu-test.sh` for `./test/shell` that regex-locked the exact source text of the condition I changed; full suite otherwise fine (a handful of pre-existing, unrelated failures on my machine, not touched by this at all, probably because I am on Stable).
  - Manually exercised the controls and they work.