### PR TITLE
Add --force to omarchy-restart-shell

### DIFF
--- a/bin/omarchy-restart-shell
+++ b/bin/omarchy-restart-shell
@@ -1,7 +1,14 @@
 #!/bin/bash
 
 # omarchy:summary=Restart the Omarchy shell
+# omarchy:args=[--force]
 # omarchy:examples=omarchy restart shell
+
+force=0
+if [[ ${1:-} == --force ]]; then
+  force=1
+  shift
+fi
 
 # A caller opened after dev link/unlink may disagree with the still-running
 # desktop. The user manager receives Hyprland's environment at session start.
@@ -29,8 +36,16 @@ relock=0
 if omarchy-hyprland-session-locked; then
   locking=$(OMARCHY_PATH="$session_omarchy_path" OMARCHY_SHELL_IPC_TIMEOUT=0.5s omarchy-shell lock status 2>/dev/null |
     jq -r '.secure or .requested' 2>/dev/null)
-  if [[ $locking == "true" ]]; then
+  # A wedged shell keeps answering IPC with the lock state it last reached, so
+  # a locker that has already died still reports the lock secure. That is the
+  # failsafe case this guard exists to allow through, and it is indistinguishable
+  # from a healthy locker over IPC -- the wedge is in the event loop, not the IPC
+  # thread. Let someone looking at the failsafe say so.
+  if [[ $locking == "true" ]] && (( ! force )); then
     echo "Refusing to restart Omarchy shell while the session is locked." >&2
+    echo "If the lock screen is dead and Hyprland's failsafe is on screen, that" >&2
+    echo "state is stale: re-run with --force to restart and re-lock, then" >&2
+    echo "authenticate as usual." >&2
     exit 1
   fi
   relock=1

--- a/test/shell.d/restart-shell-test.sh
+++ b/test/shell.d/restart-shell-test.sh
@@ -118,6 +118,9 @@ case " $* " in
     [[ $pid =~ ^[0-9]+$ ]] || exit 1
     kill "$pid" 2>/dev/null
     while kill -0 "$pid" 2>/dev/null; do sleep 0.01; done
+    # The session lock dies with the client holding it, so a killed shell
+    # leaves the compositor locked with nothing behind the lock.
+    rm -f "$OMARCHY_TEST_QS_STATE.locked"
     awk 'NR > 1' "$OMARCHY_TEST_QS_STATE" >"$OMARCHY_TEST_QS_STATE.next"
     mv "$OMARCHY_TEST_QS_STATE.next" "$OMARCHY_TEST_QS_STATE"
     ;;
@@ -229,7 +232,10 @@ locked_error=$(PATH="$restart_bin:$PATH" \
   OMARCHY_TEST_SESSION_PATH="$restart_root" \
   "$ROOT/bin/omarchy-restart-shell" 2>&1) && fail "restart refuses while the shell lock is active"
 
-[[ $locked_error == "Refusing to restart Omarchy shell while the session is locked." ]] || fail "locked restart explains why it was refused" "$locked_error"
+[[ ${locked_error%%$'\n'*} == "Refusing to restart Omarchy shell while the session is locked." ]] ||
+  fail "locked restart explains why it was refused" "$locked_error"
+[[ $locked_error == *--force* ]] ||
+  fail "locked restart points at the escape hatch" "$locked_error"
 [[ $(<"$restart_state") == 303 ]] || fail "locked restart preserves the running shell"
 [[ ! -s $restart_log ]] || fail "locked restart does not stop or launch Quickshell"
 pass "restart preserves the shell while its lock is active"
@@ -265,3 +271,36 @@ restart_pid_one=""
 grep -F "ipc -n -p $restart_root/shell call -- lock lock" "$ipc_log" >/dev/null || fail "dead-lock recovery re-acquires the session lock"
 grep -F "ipc -n -p $restart_root/shell call -- lock status" "$ipc_log" >/dev/null || fail "dead-lock recovery waits for the lock to become secure"
 pass "restart recovers a locked session whose lock client died"
+
+# A wedged shell answers IPC with the lock state it last reached, so a locker
+# that has already died still reports the lock secure and the guard above
+# cannot tell it from a healthy one. Someone looking at the failsafe can, so
+# --force has to get through a status that still claims an active lock.
+sleep 30 &
+restart_pid_two=$!
+printf '%s\n' "$restart_pid_two" >"$restart_state"
+touch "$restart_state.locked"
+: >"$restart_log"
+: >"$ipc_log"
+
+PATH="$restart_bin:$PATH" \
+OMARCHY_PATH="$restart_root" \
+XDG_RUNTIME_DIR="$runtime_dir" \
+OMARCHY_TEST_SESSION_LOCKED=1 \
+OMARCHY_TEST_QS_STATE="$restart_state" \
+OMARCHY_TEST_QS_LOG="$restart_log" \
+OMARCHY_TEST_QS_ENV_LOG="$restart_env_log" \
+OMARCHY_TEST_DISPATCH_LOG="$dispatch_log" \
+OMARCHY_TEST_IPC_LOG="$ipc_log" \
+OMARCHY_TEST_SESSION_PATH="$restart_root" \
+  timeout 5 "$ROOT/bin/omarchy-restart-shell" --force ||
+  fail "--force restarts a shell whose lock status still claims to be secure"
+
+if kill -0 "$restart_pid_two" 2>/dev/null; then
+  fail "--force stops the wedged shell instance"
+fi
+wait "$restart_pid_two" 2>/dev/null || true
+restart_pid_two=""
+grep -F "ipc -n -p $restart_root/shell call -- lock lock" "$ipc_log" >/dev/null ||
+  fail "--force re-acquires the session lock"
+pass "--force overrides a stale lock status and re-locks"


### PR DESCRIPTION
Recovery half of #10546.

When the shell wedges, its `ext-session-lock` client dies but the compositor keeps holding the lock, so Hyprland's crashed-lockscreen failsafe stays on screen. The wedge is in the event loop rather than the IPC thread, so the shell keeps answering `lock status` with the state it last reached — reporting a secure, healthy lock hours after its locker is gone.

`omarchy-restart-shell` reads exactly that status to decide whether a live lock client is worth preserving, so it refuses:

```
Refusing to restart Omarchy shell while the session is locked.
```

The documented way out of the failsafe is therefore blocked by the state it exists to clear, and short of patching a copy of the script the only way back in is a reboot. It happened twice in one night on this machine.

A dead locker and a healthy one are indistinguishable over IPC. Someone looking at the failsafe can tell them apart, so let them say so: `--force` skips the guard and runs the script's existing dead-locker path, which kills the shell, relaunches it from Hyprland, re-acquires the lock and polls until it reports secure. Default behaviour is unchanged, and the refusal now names the flag instead of being a dead end.

## Test plan

- [x] New case: `--force` gets through a `lock status` that still claims `secure: true`, stops the wedged instance, and re-acquires the lock. Verified non-vacuous — without the flag the script still refuses and the test fails.
- [x] Existing `restart preserves the shell while its lock is active` still passes; the refusal assertion now checks the first line and that the hint names `--force`.
- [x] Fixed a gap in the test's quickshell mock: `quickshell kill` left the fake `.locked` marker in place, so a session lock outlived the client holding it. It now clears on kill, which is what the compositor actually does.
- [x] `./test/all` — the only failure is `bin-style-test.sh`, which fails identically on the base commit (raw `command -v` in the AI app removers, fixed separately in #10460).
- [x] Used on the affected machine to recover from the failsafe twice, once via a hand-patched copy of the script and once via this flag's logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p9Qh6dX4FuwBJAWhNPVbn
