### PR TITLE
Use uname -n instead of hostname for the machine name

### DIFF
--- a/bin/omarchy-debug
+++ b/bin/omarchy-debug
@@ -36,7 +36,7 @@ fi
 
 cat > "$LOG_FILE" <<EOF
 Date: $(date)
-Hostname: $(hostname)
+Hostname: $(uname -n)
 Omarchy Package: $(pacman -Q omarchy-dev 2>/dev/null || pacman -Q omarchy 2>/dev/null || echo "unknown")
 
 =========================================

--- a/bin/omarchy-setup-security-sshd
+++ b/bin/omarchy-setup-security-sshd
@@ -209,4 +209,4 @@ disable_password_auth
 
 echo -e "\e[32m\nPerfect! The SSH server is running and your key is authorized.\e[0m"
 echo "Password logins are off; this machine now accepts authorized keys only."
-echo "You can now connect with: ssh $USER@$(hostname)"
+echo "You can now connect with: ssh $USER@$(uname -n)"


### PR DESCRIPTION
## What

`omarchy-debug` and `omarchy-setup-security-sshd` print the machine name with `$(hostname)`. This swaps that for `$(uname -n)`, which returns the same nodename.

## Why

`hostname` is provided by `inetutils`, which **is** in `install/omarchy-base.packages`, so this is not a bug on a healthy install. But:

- `omarchy-debug` is a diagnostic tool — it should still produce a usable log when a system is in a degraded state, including one where `inetutils` was removed. Right now it fails its very first lines with `hostname: command not found` (and, once `inetutils` is gone, whatever else the user is debugging is usually the least of it).
- `omarchy-setup-security-sshd` runs under `set -e`, so a missing `hostname` aborts the script *after* it has already enabled sshd, opened the firewall, authorized the key and disabled password auth — the closing confirmation never prints and the command exits non-zero.
- `uname` is in `coreutils`, a hard dependency of the base system, so it cannot go missing without the system already being unbootable.
- `omarchy-provision-owner` already avoids `hostname` (it uses `hostnamectl` with a `/etc/hostname` fallback).

`uname -n` is a no-op on a healthy install and removes one avoidable failure mode from these two scripts.

## Testing

- `./test/cli` — pass
- `bash test/shell.d/setup-security-sshd-test.sh` — pass
- `bash -n` on both scripts — clean