### PR TITLE
Use Display P3 on Dell XPS OLED internal panels

### DIFF
--- a/bin/omarchy-hw-dell-xps-oled
+++ b/bin/omarchy-hw-dell-xps-oled
@@ -1,7 +1,19 @@
 #!/bin/bash
 
-# omarchy:summary=Match Dell XPS systems with LG OLED panel on Intel Panther Lake (Xe3) GPU.
+# omarchy:summary=Match Dell XPS 14/16 OLED panels on Intel Panther Lake (Xe3) GPU.
 
-omarchy-hw-match "XPS" \
-  && omarchy-hw-intel-ptl \
-  && test "$(od -An -tx1 -j8 -N2 /sys/class/drm/card*-eDP-*/edid 2>/dev/null | tr -d ' \n')" = "30e4"
+# Native OLED SKUs are 2880x1800 (14) and 3200x2000 (16). The 1920x1200 IPS
+# option is also LG Display (EDID mfr 30e4, LGD07C7 on the 16), so the
+# manufacturer id alone matches the sRGB panel.
+
+omarchy-hw-match "XPS" || exit 1
+omarchy-hw-intel-ptl || exit 1
+
+drm_path="${OMARCHY_DRM_PATH:-/sys/class/drm}"
+
+for modes in "$drm_path"/card*-eDP-*/modes; do
+  [[ -e $modes ]] || continue
+  grep -qE '^(2880x1800|3200x2000)$' "$modes" && exit 0
+done
+
+exit 1

--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -8,6 +8,7 @@ run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-audio-mixer.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-mic.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/framework/fix-f13-amd-audio-input.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps13-text-scaling.sh"
+run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps-oled-color.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/fix-nouveau-cursor.sh"
 
 run_logged "$OMARCHY_INSTALL/user/default-keyring.sh"

--- a/install/user/hardware/dell/xps-oled-color.sh
+++ b/install/user/hardware/dell/xps-oled-color.sh
@@ -1,0 +1,95 @@
+# Native wide-gamut OLED: Hyprland's default cm=srgb oversaturates the panel.
+#
+# Dell XPS 14/16 OLED is Display P3. Leaving the compositor on sRGB primaries
+# makes sRGB content look too punchy. Set the internal eDP to dp3 and leave
+# the catch-all rule for other outputs.
+
+if omarchy-hw-dell-xps-oled; then
+  monitors="$HOME/.config/hypr/monitors.lua"
+
+  if [[ -f $monitors ]]; then
+    tmp=$(mktemp)
+    awk '
+      function strip_comment(s) {
+        if (s ~ /^[[:space:]]*--([^[]|$)/) return ""
+        sub(/--($|[^\[]).*$/, "", s)
+        return s
+      }
+
+      function brace_delta(s, i, c, d) {
+        d = 0
+        for (i = 1; i <= length(s); i++) {
+          c = substr(s, i, 1)
+          if (c == "{") {
+            d++
+            opened = 1
+          } else if (c == "}") {
+            d--
+          }
+        }
+        return d
+      }
+
+      function scan_line(s) {
+        if (s ~ /output[[:space:]]*=[[:space:]]*"eDP-1"/) call_edp = 1
+        if (s ~ /output[[:space:]]*=[[:space:]]*""/) call_empty = 1
+        if (s ~ /cm[[:space:]]*=/) call_cm = 1
+      }
+
+      NR == FNR {
+        live = strip_comment($0)
+        if (!in_call && live ~ /hl\.monitor[[:space:]]*\(/) {
+          in_call = 1
+          call_start = FNR
+          call_edp = 0
+          call_empty = 0
+          call_cm = 0
+          depth = 0
+          opened = 0
+        }
+        if (in_call) {
+          scan_line(live)
+          depth += brace_delta(live)
+          if (opened && depth <= 0) {
+            if (call_edp) {
+              edp_start = call_start
+              edp_has_cm = call_cm
+            } else if (call_empty && catchall_start == 0) {
+              catchall_start = call_start
+            }
+            in_call = 0
+            opened = 0
+          }
+        }
+        next
+      }
+
+      edp_start {
+        if (FNR == edp_start && !edp_has_cm) sub(/\{/, "{ cm = \"dp3\",")
+        print
+        next
+      }
+
+      catchall_start && FNR == catchall_start {
+        print "-- Internal OLED is native Display P3; Hyprland'\''s default cm=srgb oversaturates it."
+        print "hl.monitor({"
+        print "  output = \"eDP-1\","
+        print "  mode = \"preferred\","
+        print "  position = \"auto\","
+        print "  scale = omarchy_monitor_scale,"
+        print "  cm = \"dp3\","
+        print "})"
+        print ""
+      }
+
+      { print }
+    ' "$monitors" "$monitors" >"$tmp"
+
+    if ! cmp -s "$monitors" "$tmp" && grep -q 'cm = "dp3"' "$tmp"; then
+      echo "Detected Dell XPS OLED. Using Display P3 color management on eDP-1."
+      mv "$tmp" "$monitors"
+    else
+      rm -f "$tmp"
+    fi
+  fi
+fi

--- a/migrations/1788700327.sh
+++ b/migrations/1788700327.sh
@@ -1,0 +1,3 @@
+echo "Use Display P3 color management on Dell XPS OLED panels"
+
+source "$OMARCHY_PATH/install/user/hardware/dell/xps-oled-color.sh"

--- a/test/shell.d/hw-dell-xps-oled-test.sh
+++ b/test/shell.d/hw-dell-xps-oled-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+detector="$ROOT/bin/omarchy-hw-dell-xps-oled"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+drm_path="$test_tmp/drm"
+
+cat >"$test_tmp/bin/omarchy-hw-match" <<'SH'
+#!/bin/bash
+[[ ${TEST_PRODUCT_NAME:-} == *"$1"* ]]
+SH
+
+cat >"$test_tmp/bin/omarchy-hw-intel-ptl" <<'SH'
+#!/bin/bash
+(( ${TEST_PTL:-0} == 1 ))
+SH
+
+chmod +x "$test_tmp/bin"/*
+
+write_modes() {
+  local connector="$1" mode="$2"
+  rm -rf "$drm_path"
+  mkdir -p "$drm_path/card0-$connector"
+  printf '%s\n' "$mode" >"$drm_path/card0-$connector/modes"
+}
+
+run_detector() {
+  PATH="$test_tmp/bin:$PATH" \
+    TEST_PRODUCT_NAME="${1-XPS 14 DA14260}" \
+    TEST_PTL="${2-1}" \
+    OMARCHY_DRM_PATH="$drm_path" \
+    bash "$detector"
+}
+
+write_modes eDP-1 2880x1800
+run_detector || fail "the detector matches XPS 14 OLED resolution"
+pass "the detector matches XPS 14 OLED resolution"
+
+write_modes eDP-1 3200x2000
+run_detector "XPS 16 DA16260" || fail "the detector matches XPS 16 OLED resolution"
+pass "the detector matches XPS 16 OLED resolution"
+
+# Notebookcheck's XPS 16 IPS is LGD07C7: same manufacturer id 30e4 as the
+# 14 OLED (LGD07C6), 1920x1200, 100% sRGB.
+write_modes eDP-1 1920x1200
+if run_detector; then
+  fail "the detector rejects the LG IPS SKU"
+fi
+pass "the detector rejects the LG IPS SKU"
+
+write_modes eDP-1 2880x1800
+if run_detector "ThinkPad X1"; then
+  fail "the detector rejects other machines"
+fi
+pass "the detector rejects other machines"
+
+write_modes eDP-1 2880x1800
+if run_detector "XPS 14 DA14260" 0; then
+  fail "the detector requires Panther Lake"
+fi
+pass "the detector requires Panther Lake"
+
+rm -rf "$drm_path"
+if run_detector; then
+  fail "the detector fails closed without an eDP mode list"
+fi
+pass "the detector fails closed without an eDP mode list"
+
+write_modes HDMI-A-1 2880x1800
+if run_detector; then
+  fail "the detector ignores OLED-sized external outputs"
+fi
+pass "the detector ignores OLED-sized external outputs"

--- a/test/shell.d/xps-oled-color-test.sh
+++ b/test/shell.d/xps-oled-color-test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mkdir -p "$test_tmp/bin" "$test_tmp/home/.config/hypr"
+chmod +x "$test_tmp/bin"
+
+cat >"$test_tmp/bin/omarchy-hw-dell-xps-oled" <<'SH'
+#!/bin/bash
+exit "${TEST_XPS_OLED:-0}"
+SH
+chmod +x "$test_tmp/bin/omarchy-hw-dell-xps-oled"
+
+monitors="$test_tmp/home/.config/hypr/monitors.lua"
+cp "$ROOT/config/hypr/monitors.lua" "$monitors"
+
+run_fix() {
+  HOME="$test_tmp/home" \
+    PATH="$test_tmp/bin:$ROOT/bin:$PATH" \
+    TEST_XPS_OLED="${1:-0}" \
+    bash -euo pipefail -c 'source "$ROOT/install/user/hardware/dell/xps-oled-color.sh"'
+}
+
+run_fix 0 >/dev/null
+grep -F 'cm = "dp3"' "$monitors" >/dev/null
+grep -F 'output = "eDP-1"' "$monitors" >/dev/null
+pass "XPS OLED setup adds Display P3 on eDP-1"
+
+run_fix 0 >/dev/null
+(( $(grep -c 'cm = "dp3"' "$monitors") == 1 )) || fail "XPS OLED color setup is idempotent"
+pass "XPS OLED color setup is idempotent"
+
+cp "$ROOT/config/hypr/monitors.lua" "$monitors"
+run_fix 1 >/dev/null
+if grep -q 'cm =' "$monitors"; then
+  fail "XPS OLED color setup ignores other machines"
+fi
+pass "XPS OLED color setup ignores other machines"
+
+rm -f "$monitors"
+run_fix 0 >/dev/null
+pass "XPS OLED color setup skips a missing monitors.lua"
+
+cat >"$monitors" <<'LUA'
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = 1, cm = "srgb" })
+LUA
+run_fix 0 >/dev/null
+grep -F 'cm = "srgb"' "$monitors" >/dev/null || fail "preserved existing color management"
+if grep -q 'cm = "dp3"' "$monitors"; then
+  fail "XPS OLED color setup should not override an existing cm"
+fi
+pass "XPS OLED color setup leaves an existing cm alone"
+
+cat >"$monitors" <<'LUA'
+hl.monitor({ output = "eDP-1", mode = "preferred", position = "auto", scale = 1, cm="srgb" })
+LUA
+run_fix 0 >/dev/null
+grep -F 'cm="srgb"' "$monitors" >/dev/null || fail "preserved compact color management"
+if grep -q 'cm = "dp3"' "$monitors"; then
+  fail "XPS OLED color setup should not override a compact cm"
+fi
+pass "XPS OLED color setup leaves a compact cm alone"
+
+cat >"$monitors" <<'LUA'
+hl.monitor({ output = "eDP-1", mode = "2880x1800@120", position = "0x0", scale = 1.25 })
+hl.monitor({ output = "", mode = "preferred", position = "auto-right", scale = 1 })
+LUA
+run_fix 0 >/dev/null
+grep -F 'mode = "2880x1800@120"' "$monitors" >/dev/null || fail "preserved existing eDP-1 mode"
+grep -F 'position = "0x0"' "$monitors" >/dev/null || fail "preserved existing eDP-1 position"
+grep -F 'scale = 1.25' "$monitors" >/dev/null || fail "preserved existing eDP-1 scale"
+grep -F 'cm = "dp3"' "$monitors" >/dev/null || fail "added Display P3 to existing eDP-1"
+(( $(grep -c 'output = "eDP-1"' "$monitors") == 1 )) || fail "did not insert a second eDP-1 rule"
+pass "XPS OLED color setup patches an existing eDP-1 instead of replacing it"
+
+run_fix 0 >/dev/null
+(( $(grep -c 'cm = "dp3"' "$monitors") == 1 )) || fail "patching existing eDP-1 is idempotent"
+pass "XPS OLED color setup patching existing eDP-1 is idempotent"
+
+cat >"$monitors" <<'LUA'
+hl.monitor({
+  output = "eDP-1",
+  mode = "preferred",
+  position = "auto",
+  scale = 1.25,
+})
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = 1 })
+LUA
+run_fix 0 >/dev/null
+grep -F 'scale = 1.25' "$monitors" >/dev/null || fail "preserved multiline eDP-1 scale"
+grep -F 'cm = "dp3"' "$monitors" >/dev/null || fail "added Display P3 to multiline eDP-1"
+(( $(grep -c 'output = "eDP-1"' "$monitors") == 1 )) || fail "did not insert a second eDP-1 on a multiline rule"
+pass "XPS OLED color setup patches a multiline eDP-1"
+
+cat >"$monitors" <<'LUA'
+-- hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
+LUA
+run_fix 0 >/dev/null
+if grep -q 'output = "eDP-1"' "$monitors"; then
+  fail "XPS OLED color setup should not match a commented catch-all"
+fi
+pass "XPS OLED color setup ignores a commented catch-all"
+
+cat >"$monitors" <<'LUA'
+hl.monitor({ output = "DP-1", mode = "preferred", position = "auto", scale = 1 }) -- output = "eDP-1"
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = 1 })
+LUA
+run_fix 0 >/dev/null
+grep -F 'output = "eDP-1"' "$monitors" >/dev/null || fail "still inserts when eDP-1 is only in a comment"
+grep -F 'output = "DP-1"' "$monitors" >/dev/null || fail "preserved unrelated named output"
+pass "XPS OLED color setup ignores eDP-1 mentioned in a trailing comment"


### PR DESCRIPTION
So I install Omarchy Quattro on my shiny new dell xps 14 oled (the new one) and the colors are all oversaturated, which I found odd as this is the "flagship" notebook for Omarchy currently. Had to add this to monitors.lua to get reasonable colors.  This PR detects XPS 14/16 OLEDs during install and sets them to cm = "dp3", and fixes the detection to not misidentify sRGB LG IPs panels.


```
-- XPS 14 OLED is native Display P3. Hyprland defaults to cm=srgb, which
-- oversaturates this panel.
hl.monitor({
  output = "eDP-1",
  mode = "preferred",
  position = "auto",
  scale = omarchy_monitor_scale,
  cm = "dp3",
})

-- Fallback for any other monitor.
hl.monitor({ output = "", mode = "preferred", position = "auto", scale = omarchy_monitor_scale })
```

Hyprland defaults to sRGB, which oversaturates the LG P3 OLED in the XPS 14/16. Gate on omarchy-hw-dell-xps-oled by OLED resolution so the 1920x1200 LG IPS SKU is left on sRGB. Set cm=dp3 on eDP-1 in monitors.lua.