### PR TITLE
Add optional usage rings and local session attention to Agents

### DIFF
--- a/bin/omarchy-agent-sessions
+++ b/bin/omarchy-agent-sessions
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# omarchy:summary=Read verified local coding-agent session states
+# omarchy:hidden=true
+
+exec python3 "$OMARCHY_PATH/shell/plugins/agents/sessions.py"

--- a/shell/plugins/agents/GlanceModel.js
+++ b/shell/plugins/agents/GlanceModel.js
@@ -1,0 +1,69 @@
+// Display-only summaries. No endpoint calls or token-to-quota estimates.
+function finiteNumber(value) {
+  return typeof value === "number" && isFinite(value)
+}
+
+function duration(ms) {
+  if (ms <= 0) return "awaiting refresh"
+  var minutes = Math.max(1, Math.ceil(ms / 60000))
+  if (minutes >= 1440) return Math.floor(minutes / 1440) + "d " + Math.floor(minutes % 1440 / 60) + "h"
+  if (minutes >= 60) return Math.floor(minutes / 60) + "h " + minutes % 60 + "m"
+  return minutes + "m"
+}
+
+function summary(provider, now, maxAgeMs) {
+  var p = provider || {}
+  var result = { fraction: 0, known: false, stale: false, alarming: false, text: "—", detail: "Usage unavailable" }
+  if (p.usageStatusText) {
+    result.detail = String(p.usageStatusText)
+    return result
+  }
+  var updated = Date.parse(p.updatedAt || "")
+  result.stale = !isFinite(updated) || now - updated > maxAgeMs || updated > now + 60000
+  var limits = Array.isArray(p.limits) ? p.limits : []
+  var best = null
+  var details = []
+  for (var i = 0; i < limits.length; i++) {
+    var limit = limits[i] || {}
+    if (!finiteNumber(limit.percent) || limit.percent < 0 || limit.percent > 1) continue
+    var reset = Date.parse(limit.resetsAt || "")
+    if (isFinite(reset) && reset <= now) result.stale = true
+    if (!best || limit.percent > best.percent) best = limit
+    details.push(String(limit.title || limit.label || "Limit") + ": " + Math.round(limit.percent * 100) + "% used"
+      + (isFinite(reset) ? " · " + (reset > now ? "resets in " : "") + duration(reset - now) : ""))
+  }
+  if (best) {
+    result.fraction = best.percent
+    result.known = true
+    result.text = Math.round(best.percent * 100) + "%"
+    result.detail = details.join("\n")
+  } else if (p.balance && finiteNumber(p.balance.remaining) && p.balance.remaining >= 0) {
+    var b = p.balance
+    result.text = String(b.currency || "USD") + " " + b.remaining.toFixed(2)
+    result.detail = result.text + " remaining" + (b.estimated ? " (estimated)" : "")
+    if (finiteNumber(b.funded) && b.funded > 0) {
+      result.known = true
+      result.fraction = Math.max(0, Math.min(1, 1 - b.remaining / b.funded))
+    }
+  }
+  result.alarming = result.known && !result.stale && result.fraction >= 0.9
+  if (result.stale && (result.known || p.balance)) {
+    result.text = "~" + result.text
+    result.detail = "Stale reading · " + result.detail
+  }
+  return result
+}
+
+function sessionsFor(sessions, id, now, scannedAt) {
+  if (!Array.isArray(sessions) || !finiteNumber(scannedAt) || now - scannedAt > 15000 || scannedAt > now + 1000) return []
+  return sessions.filter(function(s) { return s && s.providerId === id })
+}
+
+function activity(sessions) {
+  if (sessions.some(function(s) { return s.state === "waiting" })) return "waiting"
+  if (sessions.some(function(s) { return s.state === "working" })) return "working"
+  if (sessions.some(function(s) { return s.state === "idle" })) return "idle"
+  return "unknown"
+}
+
+if (typeof module !== "undefined") module.exports = { summary, duration, sessionsFor, activity }

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -247,6 +247,7 @@ Item {
     return {
       providerId: String(record.id),
       providerName: String(record.name || record.id),
+      updatedAt: String(record.updatedAt || ""),
       ready: record.ready === true || synced,
       usageStatusText: String(record.usageStatusText || ""),
       authHelpText: String(record.authHelpText || ""),

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -4,6 +4,7 @@ import Quickshell
 import Quickshell.Io
 import qs.Commons
 import qs.Ui
+import "GlanceModel.js" as GlanceModel
 
 Panel {
   id: root
@@ -19,6 +20,35 @@ Panel {
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
   readonly property var providers: usage.enabledProviders
+  readonly property bool showRings: setting("barDisplay", "Icon") === "Usage rings"
+  readonly property bool showActivity: setting("sessionActivity", "Off") === "On"
+  readonly property bool verticalBar: bar ? bar.vertical : false
+  readonly property real ringSlot: Style.space(34)
+  readonly property real barExtent: bar ? bar.barSize : Style.bar.sizeHorizontal
+  readonly property var selectedSessions: sessionsFor(provider)
+
+  function glance(p) {
+    return GlanceModel.summary(p, nowMs, Math.max(60000, usage.refreshIntervalSec * 2000))
+  }
+
+  function sessionsFor(p) {
+    return p ? GlanceModel.sessionsFor(sessionData.sessions, p.providerId, nowMs, sessionData.scannedAt) : []
+  }
+
+  function glanceTooltip(p) {
+    var text = p.providerName + "\n" + glance(p).detail
+    var sessions = sessionsFor(p)
+    for (var i = 0; i < sessions.length; i++)
+      text += "\n" + sessions[i].name + " · " + sessionLabel(sessions[i])
+    return text
+  }
+
+  function sessionLabel(session) {
+    if (session.state === "waiting") return "Needs input" + (session.waitingFor ? ": " + session.waitingFor : "")
+    if (session.state === "working") return "Working"
+    if (session.state === "idle") return "Idle"
+    return "Status unknown"
+  }
   // The selection follows the provider, not the slot it happens to sit in: a
   // provider whose first scan lands while the panel is open would otherwise
   // shift the list underneath you and swap out what you were reading.
@@ -298,8 +328,8 @@ Panel {
   // is invisible, so the icon appears the moment the first scan finds usage and
   // stays away entirely on a machine that has never run either CLI.
   visible: providers.length > 0
-  implicitWidth: button.implicitWidth
-  implicitHeight: button.implicitHeight
+  implicitWidth: showRings ? (verticalBar ? barExtent : ringSlot * providers.length) : button.implicitWidth
+  implicitHeight: showRings ? (verticalBar ? ringSlot * providers.length : barExtent) : button.implicitHeight
 
   onProviderIndexChanged: if (panelFlick) panelFlick.contentY = 0
   onOpenedChanged: if (opened) {
@@ -315,11 +345,17 @@ Panel {
     settings: root.settings
   }
 
+  Sessions {
+    id: sessionData
+    enabled: root.showActivity && usage.providerEnabled("claude")
+    onScannedAtChanged: root.nowMs = Date.now()
+  }
+
   // Cheap enough to keep running: it only re-evaluates text bindings, and a
   // stale "resets in 2h" on a panel that is open is worse than a timer.
   Timer {
-    interval: 30000
-    running: root.opened
+    interval: root.showActivity ? 5000 : 30000
+    running: root.opened || root.showRings || root.showActivity
     repeat: true
     onTriggered: root.nowMs = Date.now()
   }
@@ -337,10 +373,11 @@ Panel {
 
   BarIconButton {
     id: button
+    visible: !root.showRings
     anchors.fill: parent
     bar: root.bar
     text: "󱚣"
-    active: root.alarming
+    active: root.alarming || GlanceModel.activity(root.sessionsFor({ providerId: "claude" })) === "waiting"
     onPressed: function(buttonCode) {
       if (buttonCode === Qt.RightButton) root.launchAgent()
       else if (buttonCode === Qt.MiddleButton) root.selectProvider(root.providerIndex + 1)
@@ -348,9 +385,73 @@ Panel {
     }
   }
 
+  Grid {
+    visible: root.showRings
+    columns: root.verticalBar ? 1 : Math.max(1, root.providers.length)
+    Repeater {
+      model: root.showRings ? root.providers : []
+      delegate: WidgetButton {
+        id: providerButton
+        required property var modelData
+        readonly property var reading: root.glance(modelData)
+        readonly property string sessionState: GlanceModel.activity(root.sessionsFor(modelData))
+        bar: root.bar
+        fixedWidth: root.verticalBar ? root.barExtent : root.ringSlot
+        fixedHeight: root.verticalBar ? root.ringSlot : root.barExtent
+        hasVisualContent: true
+        labelVisible: false
+        tooltipText: root.glanceTooltip(modelData)
+        onTooltipTextChanged: if (root.bar && root.bar.tooltipTarget === providerButton)
+          root.bar.tooltipText = tooltipText
+        onPressed: function(buttonCode) {
+          if (buttonCode === Qt.RightButton) root.launchAgent()
+          else if (buttonCode === Qt.MiddleButton) root.selectProvider(root.providerIndex + 1)
+          else {
+            var same = root.provider && root.provider.providerId === modelData.providerId
+            root.selectedProviderId = modelData.providerId
+            if (root.opened && same) root.close()
+            else root.open()
+          }
+        }
+        UsageRing {
+          anchors.centerIn: parent
+          width: Math.min(Style.space(24), parent.width - Style.space(4), parent.height - Style.space(4))
+          height: width
+          fraction: providerButton.reading.fraction
+          known: providerButton.reading.known
+          stale: providerButton.reading.stale
+          foreground: root.foreground
+          trackColor: root.track
+          ringColor: providerButton.reading.alarming ? root.urgent : Color.accent
+          attentionColor: root.urgent
+          activity: providerButton.sessionState
+          glyph: providerMark.status === Image.Ready ? "" : providerButton.modelData.providerName.charAt(0)
+          fontFamily: root.fontFamily
+          Image {
+            id: providerMark
+            anchors.centerIn: parent
+            width: parent.width * 0.48
+            height: width
+            property var candidates: root.iconCandidatesForProvider(providerButton.modelData, Color.background)
+            property string candidatesKey: candidates.join("\n")
+            property int candidateIndex: 0
+            onCandidatesKeyChanged: candidateIndex = 0
+            source: candidateIndex < candidates.length ? candidates[candidateIndex] : ""
+            onStatusChanged: if (status === Image.Error && candidateIndex < candidates.length)
+              Qt.callLater(function() { providerMark.candidateIndex++ })
+            sourceSize.width: width * 2
+            sourceSize.height: height * 2
+            fillMode: Image.PreserveAspectFit
+            opacity: providerButton.reading.stale ? 0.55 : 1
+          }
+        }
+      }
+    }
+  }
+
   KeyboardPanel {
     id: panel
-    anchorItem: button
+    anchorItem: root
     owner: root
     bar: root.bar
     open: root.opened
@@ -443,6 +544,44 @@ Panel {
                   font.pixelSize: Style.font.display
                 }
               }
+            }
+          }
+
+          Column {
+            visible: root.showActivity
+            width: parent.width
+            spacing: Style.space(6)
+            Text {
+              textFormat: Text.PlainText
+              text: "Local sessions"
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.body
+            }
+            Repeater {
+              model: root.selectedSessions
+              delegate: Text {
+                required property var modelData
+                width: parent.width
+                textFormat: Text.PlainText
+                text: modelData.name + " · " + root.sessionLabel(modelData)
+                wrapMode: Text.Wrap
+                color: modelData.state === "waiting" ? root.urgent : root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.bodySmall
+              }
+            }
+            Text {
+              visible: root.selectedSessions.length === 0
+              width: parent.width
+              textFormat: Text.PlainText
+              text: !root.provider || root.provider.providerId !== "claude"
+                ? "Live session status is not available for this provider."
+                : (sessionData.available && root.nowMs - sessionData.scannedAt <= 15000 ? "No verified local sessions." : "Session status unavailable.")
+              wrapMode: Text.Wrap
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.bodySmall
             }
           }
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -99,6 +99,23 @@ only adds the meter and the spent-of-funded line under the real figure.
   Tab moves to the neighboring bar panel, Esc closes.
 - IPC: `omarchy-shell omarchy.agents <open|close|toggle|refresh|next>`.
 
+## Usage at a glance
+
+Choose **Usage rings** in the widget's **Bar display** setting to replace the single icon with one ring per enabled subscription. Rings follow the bar horizontally or vertically and use the current theme. Hover a ring for each allowance's percentage and reset countdown; click it to open that subscription in the existing panel. Right-click still opens the agent picker, and middle-click still changes the selected subscription. The panel's existing keyboard shortcuts also work in this mode.
+
+Each ring represents the fullest reported allowance. Prepaid accounts show the fraction of funded credit consumed, with the remaining currency balance and any estimate label in the tooltip. An unknown allowance has an empty track, not a made-up percentage. Readings older than twice the configured refresh interval (at least one minute), readings without timestamps, and windows past their reset time are dimmed and labelled stale. An elapsed reset time never implies a fresh zero reading. This mode uses the same records and refresh schedule as the panel; hovering does not fetch credentials or call a provider.
+
+```bash
+omarchy bar set omarchy.agents barDisplay 'Usage rings'
+omarchy bar set omarchy.agents sessionActivity On
+```
+
+**Local session activity** is optional and off by default. It reads Claude Code's small `sessions/*.json` registry under `CLAUDE_CONFIG_DIR` or `~/.claude` every five seconds. A filled attention dot means Claude reports that input is needed; a hollow dot means it reports work in progress. The panel lists the verified local sessions and their reported state. Idle is shown as idle, not as successful completion. The single-icon mode also highlights when a verified Claude session needs input.
+
+The reader requires a matching process owner, Claude command, and start time. Dead processes, recycled PIDs, malformed records and records without usable process identity are excluded. It does not read prompts, credentials or transcripts, write hooks, change agent settings, make network requests, or sync session state to other machines. Disabling Claude or the activity setting clears the readings and stops the reader. Results expire after 15 seconds if scans stop. CLI versions without a compatible registry show status unavailable; Codex and other providers have no live session adapter in this change. Recent log writes are deliberately not presented as confirmed work or attention signals.
+
+The Claude registry field reference is [CodeNotch's session parser](https://github.com/vinzdg/codenotch/blob/main/Sources/Sessions/ClaudeSessionRecord.swift). The Linux reader and QML display are new implementations; no macOS application code or artwork is bundled.
+
 ## Settings
 
 Settings live in the widget's entry in `~/.config/omarchy/shell.json`. The
@@ -107,6 +124,8 @@ top-level keys can be set with
 
 | Key | Default | What it does |
 |---|---|---|
+| `barDisplay` | `"Icon"` | `"Usage rings"` shows each subscription in the bar |
+| `sessionActivity` | `"Off"` | `"On"` reads verified local Claude session states |
 | `refreshIntervalSec` | `900` | How often the usage records regenerate |
 | `syncMode` | `"Off"` | `"On"` writes this machine's snapshot and merges the others |
 | `syncDir` | `""` | A folder synced by Syncthing, Dropbox, rsync, … |

--- a/shell/plugins/agents/Sessions.qml
+++ b/shell/plugins/agents/Sessions.qml
@@ -1,0 +1,54 @@
+import QtQuick
+import Quickshell.Io
+
+// Independent of usage refresh: this only reads small, local session records.
+Item {
+  id: root
+  visible: false
+  property var sessions: []
+  property double scannedAt: 0
+  property bool available: false
+
+  onEnabledChanged: {
+    sessions = []
+    scannedAt = 0
+    available = false
+    if (!enabled) scan.running = false
+    else if (!scan.running) scan.running = true
+  }
+
+  Timer {
+    interval: 5000
+    repeat: true
+    running: root.enabled
+    triggeredOnStart: true
+    onTriggered: if (!scan.running) scan.running = true
+  }
+
+  Process {
+    id: scan
+    command: ["omarchy-agent-sessions"]
+    stdout: StdioCollector {
+      onStreamFinished: {
+        if (!root.enabled) return
+        try {
+          var data = JSON.parse(text)
+          root.sessions = Array.isArray(data.sessions) ? data.sessions : []
+          root.available = data.available === true
+          root.scannedAt = Date.now()
+        } catch (e) {
+          root.sessions = []
+          root.available = false
+          root.scannedAt = 0
+        }
+      }
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        root.sessions = []
+        root.available = false
+        root.scannedAt = 0
+      }
+    }
+  }
+}

--- a/shell/plugins/agents/UsageRing.qml
+++ b/shell/plugins/agents/UsageRing.qml
@@ -1,0 +1,79 @@
+import QtQuick
+
+// Theme and size are supplied by the native bar. This component only paints.
+Item {
+  id: root
+  property real fraction: 0
+  property bool known: false
+  property bool stale: false
+  property color foreground: "white"
+  property color trackColor: "gray"
+  property color ringColor: foreground
+  property color attentionColor: ringColor
+  property string glyph: ""
+  property string fontFamily: "monospace"
+  property real glyphSize: width * 0.45
+  property string activity: "unknown"
+
+  onFractionChanged: canvas.requestPaint()
+  onKnownChanged: canvas.requestPaint()
+  onStaleChanged: canvas.requestPaint()
+  onTrackColorChanged: canvas.requestPaint()
+  onRingColorChanged: canvas.requestPaint()
+
+  Canvas {
+    id: canvas
+    anchors.fill: parent
+    onWidthChanged: requestPaint()
+    onHeightChanged: requestPaint()
+    onPaint: {
+      var ctx = getContext("2d")
+      ctx.reset()
+      var line = Math.max(1.5, width / 12)
+      var radius = Math.max(0, Math.min(width, height) / 2 - line)
+      ctx.lineWidth = line
+      ctx.strokeStyle = root.trackColor
+      ctx.beginPath()
+      ctx.arc(width / 2, height / 2, radius, 0, Math.PI * 2)
+      ctx.stroke()
+      if (root.known) {
+        ctx.globalAlpha = root.stale ? 0.4 : 1
+        ctx.strokeStyle = root.ringColor
+        ctx.lineCap = "round"
+        ctx.beginPath()
+        ctx.arc(width / 2, height / 2, radius, -Math.PI / 2,
+          -Math.PI / 2 + Math.PI * 2 * Math.max(0, Math.min(1, root.fraction)))
+        ctx.stroke()
+      }
+    }
+  }
+
+  Text {
+    anchors.centerIn: parent
+    textFormat: Text.PlainText
+    text: root.glyph
+    font.family: root.fontFamily
+    font.pixelSize: root.glyphSize
+    color: root.foreground
+    opacity: root.stale ? 0.55 : 1
+  }
+
+  Rectangle {
+    visible: root.activity === "waiting" || root.activity === "working"
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    width: Math.max(5, parent.width / 4)
+    height: width
+    radius: width / 2
+    color: root.activity === "waiting" ? root.attentionColor : root.ringColor
+    // A hollow dot means working; a filled dot means input is needed.
+    Rectangle {
+      visible: root.activity === "working"
+      anchors.centerIn: parent
+      width: parent.width / 2
+      height: width
+      radius: width / 2
+      color: root.trackColor
+    }
+  }
+}

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -23,6 +23,8 @@
         "codex": { "enabled": true },
         "fireworks": { "enabled": true }
       },
+      "barDisplay": "Icon",
+      "sessionActivity": "Off",
       "refreshIntervalSec": 900,
       "syncMode": "Off",
       "syncDir": "",
@@ -30,6 +32,8 @@
       "syncDeviceId": ""
     },
     "schema": [
+      { "key": "barDisplay", "type": "enum", "label": "Bar display", "options": ["Icon", "Usage rings"], "defaultValue": "Icon", "description": "Show one usage ring per enabled provider. Click a ring to open its panel." },
+      { "key": "sessionActivity", "type": "enum", "label": "Local session activity", "options": ["Off", "On"], "defaultValue": "Off", "description": "Read Claude Code session states locally every five seconds. Other providers remain unsupported." },
       { "key": "refreshIntervalSec", "type": "integer", "label": "Refresh interval (seconds)", "min": 30, "max": 3600, "step": 30, "defaultValue": 900 },
       { "key": "syncMode", "type": "enum", "label": "Synced aggregation", "options": ["Off", "On"], "defaultValue": "Off", "description": "When On, write this machine's local usage snapshot and merge snapshots from other machines." },
       { "key": "syncDir", "type": "path", "label": "Sync folder", "defaultValue": "", "description": "A folder synced by Syncthing, Dropbox, rsync, etc." },

--- a/shell/plugins/agents/sessions.py
+++ b/shell/plugins/agents/sessions.py
@@ -1,0 +1,117 @@
+"""Read Claude's session registry without credentials, transcripts or network IO.
+
+Registry fields are documented by vinzdg/codenotch's ClaudeSessionRecord.swift.
+Linux process identity is checked independently through procfs. Unknown states
+remain unknown; file age alone never implies that a tool is working or done.
+"""
+
+import datetime
+import json
+import math
+import os
+from pathlib import Path
+import stat
+
+
+def text(value, limit=160):
+  if not isinstance(value, str):
+    return ""
+  return "".join(c for c in value if c.isprintable())[:limit]
+
+
+def started_at(record):
+  value = record.get("startedAt")
+  if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value):
+    return value / 1000
+  try:
+    return datetime.datetime.strptime(record.get("procStart", ""), "%a %b %d %H:%M:%S %Y").replace(tzinfo=datetime.timezone.utc).timestamp()
+  except (TypeError, ValueError, OverflowError):
+    return None
+
+
+def process_matches(record, proc=Path("/proc"), uid=None):
+  pid = record.get("pid")
+  expected = started_at(record)
+  if type(pid) is not int or pid <= 0 or expected is None:
+    return False
+  try:
+    folder = proc / str(pid)
+    if folder.stat().st_uid != (os.getuid() if uid is None else uid):
+      return False
+    # The comm field can contain spaces and parentheses; fields after its last
+    # closing parenthesis begin at field 3. starttime is field 22.
+    raw = (folder / "stat").read_text()
+    fields = raw[raw.rfind(")") + 2:].split()
+    if fields[0] in ("Z", "X"):
+      return False
+    boot = next(int(line.split()[1]) for line in (proc / "stat").read_text().splitlines() if line.startswith("btime "))
+    actual = boot + int(fields[19]) / os.sysconf("SC_CLK_TCK")
+    if abs(actual - expected) > 300:
+      return False
+    arguments = [a.decode("utf-8", errors="replace") for a in (folder / "cmdline").read_bytes().split(b"\0")[:2] if a]
+    if not arguments:
+      return False
+    executable = Path(arguments[0]).name
+    if executable in ("claude", "claude-code"):
+      return True
+    return (executable in ("node", "nodejs") and len(arguments) > 1
+      and arguments[1].endswith("/@anthropic-ai/claude-code/cli.js"))
+  except (OSError, ValueError, IndexError, StopIteration):
+    return False
+
+
+def session(record):
+  tempo, status = record.get("tempo"), record.get("status")
+  if tempo == "blocked" or status == "waiting":
+    state = "waiting"
+  elif tempo == "active" or status == "busy":
+    state = "working"
+  elif tempo == "idle" or status == "idle":
+    state = "idle"
+  else:
+    state = "unknown"
+  return {
+    "id": "claude." + str(record["pid"]),
+    "providerId": "claude",
+    "name": text(record.get("name")) or text(Path(record["cwd"]).name) or "Claude Code",
+    "state": state,
+    "waitingFor": text(record.get("waitingFor") or record.get("needs")) if state == "waiting" else "",
+  }
+
+
+def collect(directory, proc=Path("/proc")):
+  found = {}
+  try:
+    # Bound work even if another tool leaves thousands of old registry files.
+    with os.scandir(directory) as entries:
+      paths = []
+      for index, entry in enumerate(entries):
+        if len(paths) >= 256 or index >= 1024:
+          break
+        if entry.name.endswith(".json") and entry.is_file(follow_symlinks=False):
+          paths.append(Path(entry.path))
+  except OSError:
+    return {"available": False, "sessions": []}
+  for path in paths:
+    try:
+      # O_NOFOLLOW also closes the symlink-swap race after discovery.
+      fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+      with os.fdopen(fd, "r") as stream:
+        info = os.fstat(stream.fileno())
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_size > 65536:
+          continue
+        record = json.loads(stream.read(65537))
+      if not isinstance(record, dict) or not isinstance(record.get("cwd"), str):
+        continue
+      if process_matches(record, proc):
+        item = session(record)
+        found[item["id"]] = item
+    except (OSError, ValueError, TypeError, OverflowError):
+      continue
+  priority = {"waiting": 0, "working": 1, "idle": 2, "unknown": 3}
+  return {"available": True, "sessions": sorted(found.values(), key=lambda s: (priority[s["state"]], s["name"], s["id"]))}
+
+
+if __name__ == "__main__":
+  directory = Path(os.environ.get("CLAUDE_CONFIG_DIR") or Path.home() / ".claude") / "sessions"
+  print(json.dumps(collect(directory)))

--- a/test/shell.d/agents-glance-test.sh
+++ b/test/shell.d/agents-glance-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const model = requireFromRoot('shell/plugins/agents/GlanceModel.js')
+const now = Date.parse('2026-09-06T12:00:00Z')
+const fresh = {updatedAt: new Date(now).toISOString()}
+const limit = (percent, reset = now + 3600000) => ({percent, label: 'Session', resetsAt: new Date(reset).toISOString()})
+const read = p => model.summary({...fresh, ...p}, now, 1800000)
+assertEqual(read({limits:[limit(0.2), limit(0.95)]}).fraction, 0.95, 'fullest window determines the ring')
+assert(read({limits:[limit(0.95)]}).alarming, 'fresh nearly exhausted allowance is alarming')
+assert(read({limits:[limit(0)]}).known, 'zero usage is a valid reading')
+for (const value of [null, '', '0.8', NaN, Infinity, -1, 2])
+  assert(!read({limits:[limit(value)]}).known, 'malformed percentage is not a fabricated reading: ' + value)
+assert(!read({limits:[limit(0.9)], usageStatusText:'Sign-in expired'}).known, 'auth error takes precedence over previous limits')
+const expired = read({limits:[limit(0.99, now)]})
+assert(expired.stale && !expired.alarming && expired.fraction === 0.99, 'expired window keeps last reading without claiming reset')
+assert(expired.detail.includes('awaiting refresh'), 'expired window explains pending refresh')
+assert(read({limits:[limit(0.2)], updatedAt:'bad'}).stale, 'missing timestamp cannot masquerade as live data')
+assert(read({limits:[limit(0.2)], updatedAt:new Date(now - 1800001).toISOString()}).stale, 'old record is stale')
+const balance = read({balance:{funded:20, remaining:1, currency:'USD', estimated:true}})
+assert(balance.alarming && balance.detail.includes('estimated') && balance.detail.includes('remaining'), 'prepaid balance preserves its units and estimate label')
+assert(!read({balance:{funded:0, remaining:1}}).known, 'balance without funding does not invent a percentage')
+const sessions = [{providerId:'claude', state:'working'}, {providerId:'claude', state:'waiting'}]
+assertEqual(model.activity(sessions), 'waiting', 'attention takes priority over working')
+assertEqual(model.sessionsFor(sessions, 'codex', now, now).length, 0, 'states stay with their provider')
+assertEqual(model.sessionsFor(sessions, 'claude', now, now - 15001).length, 0, 'stopped scanner cannot leave a working indicator forever')
+assertEqual(model.activity([]), 'unknown', 'no session evidence means unknown')
+JS
+
+PYTHONDONTWRITEBYTECODE=1 python3 "$ROOT/test/shell.d/fixtures/agents-sessions-test.py" "$ROOT"

--- a/test/shell.d/fixtures/agents-rings.qml
+++ b/test/shell.d/fixtures/agents-rings.qml
@@ -1,0 +1,81 @@
+import QtQuick
+import QtQuick.Window
+import "../../../shell/plugins/agents" as Agents
+import "../../../shell/plugins/agents/GlanceModel.js" as Model
+
+// Component visual fixture. Run with Qt's qml tool. It does not launch Omarchy
+// or substitute for the compositor acceptance check.
+Window {
+  id: window
+  width: 780
+  height: 260
+  visible: true
+  title: "Agent usage ring states"
+  color: "#17191e"
+
+  Column {
+    id: content
+    anchors.fill: parent
+    Repeater {
+      model: [false, true]
+      delegate: Rectangle {
+        id: ringPalette
+        required property bool modelData
+        width: content.width
+        height: content.height / 2
+        color: modelData ? "#f4f1eb" : "#17191e"
+        Row {
+          anchors.centerIn: parent
+          spacing: 18
+          Repeater {
+            model: [
+              { label: "20% used", fraction: 0.2, known: true, activity: "unknown" },
+              { label: "95% used", fraction: 0.95, known: true, activity: "unknown" },
+              { label: "Needs input", fraction: 0.4, known: true, activity: "waiting" },
+              { label: "Working", fraction: 0.4, known: true, activity: "working" },
+              { label: "Stale", fraction: 0.95, known: true, stale: true },
+              { label: "Unavailable", fraction: 0, known: false }
+            ]
+            delegate: Column {
+              required property var modelData
+              width: 104
+              spacing: 14
+              Agents.UsageRing {
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: 24
+                height: width
+                fraction: parent.modelData.fraction
+                known: parent.modelData.known
+                stale: parent.modelData.stale === true
+                activity: parent.modelData.activity || "unknown"
+                foreground: ringPalette.modelData ? "#282b32" : "#e0e2e6"
+                trackColor: ringPalette.modelData ? "#d4d0c8" : "#42464e"
+                ringColor: parent.modelData.fraction >= 0.9 ? "#c75151" : (ringPalette.modelData ? "#376985" : "#9cbcd0")
+                attentionColor: "#c75151"
+                glyph: "C"
+              }
+              Text {
+                width: parent.width
+                text: parent.modelData.label
+                textFormat: Text.PlainText
+                color: ringPalette.modelData ? "#282b32" : "#e0e2e6"
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: 12
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  Timer {
+    interval: 500
+    running: true
+    onTriggered: content.grabToImage(function(result) {
+      var args = Qt.application.arguments
+      var target = args[args.length - 1]
+      if (!target.endsWith(".png") || !result.saveToFile(target)) Qt.exit(1)
+      else Qt.quit()
+    })
+  }
+}

--- a/test/shell.d/fixtures/agents-sessions-test.py
+++ b/test/shell.d/fixtures/agents-sessions-test.py
@@ -1,0 +1,53 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+spec = importlib.util.spec_from_file_location("sessions", Path(sys.argv[1]) / "shell/plugins/agents/sessions.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+with tempfile.TemporaryDirectory() as tmp:
+  root = Path(tmp)
+  proc = root / "proc"
+  process = proc / "42"
+  process.mkdir(parents=True)
+  (proc / "stat").write_text("btime 1000\n")
+  fields = ["S"] + ["0"] * 18 + [str(os.sysconf("SC_CLK_TCK") * 10)]
+  (process / "stat").write_text("42 (claude (worker)) " + " ".join(fields))
+  (process / "cmdline").write_bytes(b"/usr/bin/claude\0")
+  record = {"pid":42, "cwd":"/work/project", "startedAt":1010000, "status":"waiting", "waitingFor":"Approval"}
+  assert module.process_matches(record, proc)
+  assert not module.process_matches({**record, "startedAt":2000000}, proc), "reused pid"
+  assert not module.process_matches({**record, "pid":True}, proc), "boolean pid"
+  assert not module.process_matches({**record, "startedAt":None}, proc), "identity without start time"
+  assert not module.process_matches(record, proc, os.getuid() + 1), "other user"
+  assert module.session(record)["state"] == "waiting"
+  assert module.session({**record, "status":"future-state"})["state"] == "unknown"
+  assert module.session({**record, "status":"busy"})["state"] == "working"
+  assert module.session({**record, "status":"idle"})["state"] == "idle"
+  directory = root / "sessions"
+  directory.mkdir()
+  (directory / "42.json").write_text(json.dumps(record))
+  (directory / "broken.json").write_text("{")
+  (directory / "oversized.json").write_text(" " * 65537)
+  (directory / "link.json").symlink_to(directory / "42.json")
+  result = module.collect(directory, proc)
+  assert result["available"] and len(result["sessions"]) == 1
+  assert result["sessions"][0]["name"] == "project"
+  assert "cwd" not in result["sessions"][0], "full working directory is not exported"
+  (process / "cmdline").write_bytes(b"/usr/bin/unrelated\0")
+  assert not module.collect(directory, proc)["sessions"], "unrelated live pid must not resurrect session"
+  (process / "cmdline").write_bytes(b"/usr/bin/echo\0claude\0")
+  assert not module.process_matches(record, proc), "a command argument is not the agent executable"
+  (process / "cmdline").write_bytes(b"/usr/bin/node\0/opt/node_modules/@anthropic-ai/claude-code/cli.js\0")
+  assert module.process_matches(record, proc), "npm CLI entrypoint"
+  (process / "cmdline").write_bytes(b"/usr/bin/claude\0")
+  fields[0] = "Z"
+  (process / "stat").write_text("42 (claude) " + " ".join(fields))
+  assert not module.collect(directory, proc)["sessions"], "zombie is not working"
+  assert not module.collect(root / "missing", proc)["available"]
+
+print("ok - session registry handles identity, unknown states, malformed files and dead processes")


### PR DESCRIPTION
The Agents panel already collects subscription usage, but checking several providers requires opening the panel and switching between them. This adds an optional bar view that keeps each provider’s usage visible, alongside optional local Claude session activity.

Inspired by [CodeNotch](https://github.com/vinzdg/codenotch), implemented within Omarchy’s existing native Agents panel.

Changes

* Optional usage rings for each enabled provider, arranged horizontally or vertically with the bar.
* Hover details showing allowances, reset countdowns or prepaid balances.
* Clicking a ring opens that provider’s existing panel. Existing right-click, middle-click and keyboard controls are preserved.
* Explicit unavailable and stale states. An elapsed reset window never implies that usage has returned to zero.
* Optional local Claude session activity showing working, needs-input, idle or unknown states.
* Settings, documentation, focused tests and a Qt visual fixture.

The default remains the single-icon view, with local session activity off. Usage rings reuse the existing collectors and refresh schedule.

Local session activity

The reader checks Claude’s compatible session registry against Linux process ownership, command and start time. It excludes dead processes and records without usable process identity, and expires results if scanning stops.

It does not read prompts, credentials or transcripts, install hooks, change agent settings, make network requests or sync session state.

Claude versions without a compatible registry show activity as unavailable. Codex and other providers do not yet have live-session adapters.

Validation

Passed on the submitted revision:

* bash test/shell.d/agents-glance-test.sh
* bash test/shell.d/agents-panel-test.sh
* ./test/cli
* Mechanical preflight and whitespace checks.
* Qt 6.8.3 QML syntax parsing for the changed panel and new components.
* Rendering and visual inspection of the actual UsageRing component in light and dark palettes.

The patch also merged cleanly with upstream quattro at 97a86af116b71ffd6b6dd0afc27cdefce5cacee2.

The bar-widget and plugin-registry contract tests were skipped because the development environment has no Wayland compositor. Component rendering does not replace full desktop verification.

Remaining verification

* [ ]	Capture the complete native UI in a running Omarchy desktop.
* [ ]	Document horizontal and vertical bar, tooltip, provider selection, keyboard and settings checks.
* [ ]	Verify real working, waiting and exited Claude sessions with a compatible registry.

Provenance

CodeNotch’s Claude session parser is linked in the plugin README as a registry field reference. The Linux reader and QML display are new implementations; no macOS application code or artwork is bundled.

Prepared with Codex assistance. Reviewed and merged in [fork PR #9](https://github.com/tcballard/omarchy/pull/9).