### PR TITLE
Prepend user-level tool paths ahead of /usr/bin

### DIFF
--- a/default/bash/env-bootstrap
+++ b/default/bash/env-bootstrap
@@ -15,27 +15,38 @@ else
 fi
 export OMARCHY_PATH
 
+# Prepend a directory, moving it to the front if it is already on PATH.
+# Sourced by bash and zsh; keep this free of bash-only substitution.
+omarchy_path_prepend() {
+  _omarchy_dir="$1"
+  case ":$PATH:" in
+    *":$_omarchy_dir:"*)
+      PATH=":$PATH:"
+      PATH="${PATH%%:$_omarchy_dir:*}:${PATH#*:$_omarchy_dir:}"
+      PATH="${PATH#:}"
+      PATH="${PATH%:}"
+      ;;
+  esac
+  PATH="$_omarchy_dir${PATH:+:$PATH}"
+  unset _omarchy_dir
+}
+
+# User-level tool paths, prepended so they win over /usr/bin. mise shims
+# intercept names that also exist as distro packages; ~/.local/bin is the XDG
+# user executable dir. Move-to-front if already present so a PAM PATH that
+# listed them last still ends up correct in login shells. Keep in sync with
+# install/config/ssh-command-path.sh, which covers SSH commands that run no
+# shell setup at all.
+omarchy_path_prepend "$HOME/.local/bin"
+omarchy_path_prepend "$HOME/.local/share/mise/shims"
+
 # Only prepend in dev-link mode. On a production install, the binaries are
 # already on PATH as /usr/bin/omarchy-* via the omarchy package — prepending
-# /usr/share/omarchy/bin would just be noise.
+# /usr/share/omarchy/bin would just be noise. Do this last so the checkout
+# wins over user-level dirs.
 if [ "$OMARCHY_PATH" != /usr/share/omarchy ]; then
-  case ":$PATH:" in
-    *":${OMARCHY_PATH%/}/bin:"*) ;;
-    *) PATH="${OMARCHY_PATH%/}/bin${PATH:+:$PATH}" ;;
-  esac
+  omarchy_path_prepend "${OMARCHY_PATH%/}/bin"
 fi
 
-# User-level tool paths, appended so system binaries keep precedence. This is
-# what lets login shells (ssh, bash -lc) and the uwsm session find mise-managed
-# tools without an interactive rc. Keep these directories in sync with the PAM
-# PATH line from install/config/ssh-command-path.sh, which covers SSH commands
-# that run no shell setup at all.
-case ":$PATH:" in
-  *":$HOME/.local/share/mise/shims:"*) ;;
-  *) PATH="${PATH:+$PATH:}$HOME/.local/share/mise/shims" ;;
-esac
-case ":$PATH:" in
-  *":$HOME/.local/bin:"*) ;;
-  *) PATH="${PATH:+$PATH:}$HOME/.local/bin" ;;
-esac
+unset -f omarchy_path_prepend
 export PATH

--- a/default/bash/envs
+++ b/default/bash/envs
@@ -27,8 +27,3 @@ if [ -z "${LANG:-}" ]; then
     LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT \
     LC_IDENTIFICATION
 fi
-
-case ":$PATH:" in
-  *":$HOME/.local/bin:"*) ;;
-  *) export PATH="$PATH:$HOME/.local/bin" ;;
-esac

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -163,10 +163,7 @@ Single source of truth for `OMARCHY_PATH` and dev-link-aware `PATH`. It:
 - Prepends `$OMARCHY_PATH/bin` to `PATH` **only when** `OMARCHY_PATH` is
   not `/usr/share/omarchy`. On a production install the binaries are
   already on `PATH` as `/usr/bin/omarchy-*` via the `omarchy` package.
-- Appends `~/.local/share/mise/shims` and `~/.local/bin` so login shells and
-  the uwsm session find mise-managed tools — kept in sync with the PAM `PATH`
-  line written by `install/config/ssh-command-path.sh`, which covers SSH
-  commands that run no shell setup at all.
+- Prepends `~/.local/share/mise/shims` and `~/.local/bin` (and moves them to the front if they were already later on `PATH`) so login shells and the uwsm session find mise-managed tools ahead of `/usr/bin` — kept in sync with the PAM `PATH` line written by `install/config/ssh-command-path.sh`, which covers SSH commands that run no shell setup at all.
 
 Sourced by every entry point that needs the env set:
 

--- a/install/config/ssh-command-path.sh
+++ b/install/config/ssh-command-path.sh
@@ -1,12 +1,28 @@
 # SSH commands (ssh host cmd) run without a login or interactive shell, so on
-# Arch the PAM environment is the only place they can inherit PATH from. Add
-# the user-level tool paths there so remote tools (herdr, editors, agent CLIs)
-# find mise-managed installs. @{HOME} expands per-user from passwd. Keep the
-# directories in sync with default/bash/env-bootstrap.
-if ! grep -qE '^PATH[[:space:]]' /etc/security/pam_env.conf; then
-  cat >>/etc/security/pam_env.conf <<'EOF'
+# Arch the PAM environment is the only place they can inherit PATH from. Put
+# the user-level tool paths first so remote tools (herdr, editors, agent CLIs)
+# find mise-managed installs ahead of /usr/bin. @{HOME} expands per-user from
+# passwd. Keep the directories in sync with default/bash/env-bootstrap.
 
-# Omarchy: give SSH commands and other non-shell logins the user-level tool paths
-PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin
-EOF
+pam_env="${OMARCHY_PAM_ENV_CONF:-/etc/security/pam_env.conf}"
+old_path='PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin'
+new_path='PATH DEFAULT=@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin'
+
+if grep -qxF "$new_path" "$pam_env" 2>/dev/null; then
+  :
+elif grep -qxF "$old_path" "$pam_env" 2>/dev/null; then
+  tmp=$(mktemp)
+  while IFS= read -r line || [[ -n $line ]]; do
+    if [[ $line == "$old_path" ]]; then
+      printf '%s\n' "$new_path"
+    else
+      printf '%s\n' "$line"
+    fi
+  done <"$pam_env" >"$tmp"
+  cat "$tmp" >"$pam_env"
+  rm -f "$tmp"
+elif ! grep -qE '^PATH[[:space:]]' "$pam_env" 2>/dev/null; then
+  printf '\n%s\n%s\n' \
+    '# Omarchy: give SSH commands and other non-shell logins the user-level tool paths' \
+    "$new_path" >>"$pam_env"
 fi

--- a/migrations/1788729988.sh
+++ b/migrations/1788729988.sh
@@ -1,0 +1,14 @@
+echo "Put user-level tool paths ahead of /usr/bin in the PAM PATH"
+
+# SSH commands inherit PATH only from PAM. The original line listed mise shims
+# and ~/.local/bin after /usr/bin, so a distro node/python hid the user one.
+# Rewrite only that exact Omarchy line; a hand-edited PATH is left alone.
+pam_env="${OMARCHY_PAM_ENV_CONF:-/etc/security/pam_env.conf}"
+old_path='PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin'
+new_path='PATH DEFAULT=@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin'
+
+if grep -qxF "$new_path" "$pam_env" 2>/dev/null; then
+  :
+elif grep -qxF "$old_path" "$pam_env" 2>/dev/null || ! grep -qE '^PATH[[:space:]]' "$pam_env" 2>/dev/null; then
+  sudo env OMARCHY_PAM_ENV_CONF="$pam_env" bash -euo pipefail "$OMARCHY_PATH/install/config/ssh-command-path.sh"
+fi

--- a/test/shell.d/dev-env-path-test.sh
+++ b/test/shell.d/dev-env-path-test.sh
@@ -37,6 +37,26 @@ assert_path_present() {
   esac
 }
 
+assert_path_before() {
+  local path_value="$1"
+  local earlier="$2"
+  local later="$3"
+  local description="$4"
+  local IFS=':'
+  local -a parts
+  local i earlier_i=-1 later_i=-1
+
+  read -ra parts <<<"$path_value"
+  for i in "${!parts[@]}"; do
+    [[ ${parts[i]} == "$earlier" ]] && earlier_i=$i
+    [[ ${parts[i]} == "$later" ]] && later_i=$i
+  done
+
+  (( earlier_i >= 0 && later_i >= 0 && earlier_i < later_i )) ||
+    fail "$description" "expected $earlier before $later in $path_value"
+  pass "$description"
+}
+
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -54,9 +74,11 @@ default_path=${default_result[1]}
 [[ ${default_result[0]} == /usr/share/omarchy ]] || fail "env-bootstrap resolves default OMARCHY_PATH" "actual: ${default_result[0]}"
 pass "env-bootstrap resolves default OMARCHY_PATH"
 assert_path_present "$default_path" "$tmpdir/unrelated/bin" "env-bootstrap preserves PATH entries in default mode"
-assert_path_present "$default_path" "$home/.local/share/mise/shims" "env-bootstrap appends mise shims"
-assert_path_present "$default_path" "$home/.local/bin" "env-bootstrap appends ~/.local/bin"
-assert_path_first "$default_path" "$tmpdir/unrelated/bin" "env-bootstrap appends user-level paths after existing entries"
+assert_path_present "$default_path" "$home/.local/share/mise/shims" "env-bootstrap prepends mise shims"
+assert_path_present "$default_path" "$home/.local/bin" "env-bootstrap prepends ~/.local/bin"
+assert_path_first "$default_path" "$home/.local/share/mise/shims" "env-bootstrap puts mise shims first in default mode"
+assert_path_before "$default_path" "$home/.local/share/mise/shims" "$home/.local/bin" "env-bootstrap puts mise shims before ~/.local/bin"
+assert_path_before "$default_path" "$home/.local/bin" "/usr/bin" "env-bootstrap puts ~/.local/bin before /usr/bin"
 
 printf 'export OMARCHY_PATH="%s"\n' "$tmpdir/active" >"$tmpdir/omarchy.conf"
 mapfile -t linked_result < <(run_bootstrap bash "$bootstrap" "$home" "$tmpdir/unrelated/bin:/usr/bin")
@@ -65,11 +87,20 @@ linked_path=${linked_result[1]}
 [[ ${linked_result[0]} == "$tmpdir/active" ]] || fail "env-bootstrap resolves linked OMARCHY_PATH" "actual: ${linked_result[0]}"
 pass "env-bootstrap resolves linked OMARCHY_PATH"
 assert_path_first "$linked_path" "$tmpdir/active/bin" "env-bootstrap prepends active checkout bin in linked mode"
+assert_path_before "$linked_path" "$tmpdir/active/bin" "$home/.local/share/mise/shims" "env-bootstrap puts checkout bin before mise shims in linked mode"
 assert_path_present "$linked_path" "$tmpdir/unrelated/bin" "env-bootstrap preserves unrelated PATH entries in linked mode"
+
+# User dirs already at the end (the old PAM order) must move to the front.
+mapfile -t reorder_result < <(run_bootstrap bash "$bootstrap" "$home" "$tmpdir/unrelated/bin:/usr/bin:$home/.local/share/mise/shims:$home/.local/bin")
+reorder_path=${reorder_result[1]}
+[[ $reorder_path == "$tmpdir/active/bin:$home/.local/share/mise/shims:$home/.local/bin:$tmpdir/unrelated/bin:/usr/bin" ]] ||
+  fail "env-bootstrap moves existing user-level paths to the front" "actual PATH: $reorder_path"
+pass "env-bootstrap moves existing user-level paths to the front"
 
 mapfile -t linked_duplicate_result < <(run_bootstrap bash "$bootstrap" "$home" "$tmpdir/active/bin:/usr/bin:$home/.local/share/mise/shims:$home/.local/bin")
 linked_duplicate_path=${linked_duplicate_result[1]}
-[[ $linked_duplicate_path == "$tmpdir/active/bin:/usr/bin:$home/.local/share/mise/shims:$home/.local/bin" ]] || fail "env-bootstrap does not duplicate PATH entries" "actual PATH: $linked_duplicate_path"
+[[ $linked_duplicate_path == "$tmpdir/active/bin:$home/.local/share/mise/shims:$home/.local/bin:/usr/bin" ]] ||
+  fail "env-bootstrap does not duplicate PATH entries" "actual PATH: $linked_duplicate_path"
 pass "env-bootstrap does not duplicate PATH entries"
 
 # An empty PATH must not produce empty entries (a bare ":" means the cwd)
@@ -83,4 +114,5 @@ if command -v zsh >/dev/null 2>&1; then
   zsh_path=${zsh_result[1]}
   assert_path_first "$zsh_path" "$tmpdir/active/bin" "env-bootstrap works when sourced by zsh"
   assert_path_present "$zsh_path" "$tmpdir/unrelated/bin" "env-bootstrap zsh mode preserves unrelated PATH entries"
+  assert_path_before "$zsh_path" "$home/.local/bin" "/usr/bin" "env-bootstrap zsh mode puts ~/.local/bin before /usr/bin"
 fi

--- a/test/shell.d/pam-command-path-test.sh
+++ b/test/shell.d/pam-command-path-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+old_path='PATH DEFAULT=/usr/local/sbin:/usr/local/bin:/usr/bin:@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin'
+new_path='PATH DEFAULT=@{HOME}/.local/share/mise/shims:@{HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin'
+comment='# Omarchy: give SSH commands and other non-shell logins the user-level tool paths'
+
+migration=$(grep -rl 'Put user-level tool paths ahead of /usr/bin in the PAM PATH' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "PAM PATH order migration exists"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_bin="$test_tmp/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$TEST_LOG"
+exec "$@"
+STUB
+chmod +x "$fake_bin/sudo"
+
+run_install() {
+  OMARCHY_PAM_ENV_CONF="$1" bash -euo pipefail "$ROOT/install/config/ssh-command-path.sh"
+}
+
+run_migration() {
+  : >"$TEST_LOG"
+  TEST_LOG="$TEST_LOG" \
+    PATH="$fake_bin:$PATH" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_PAM_ENV_CONF="$1" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+TEST_LOG="$test_tmp/calls.log"
+
+pam="$test_tmp/empty.conf"
+: >"$pam"
+run_install "$pam"
+grep -qxF "$comment" "$pam" || fail "install writes the Omarchy PAM PATH comment"
+grep -qxF "$new_path" "$pam" || fail "install writes user-level paths before /usr/bin"
+! grep -qxF "$old_path" "$pam" || fail "install does not write the old PATH order"
+pass "install writes the new PAM PATH on a file with no PATH line"
+
+before=$(cat "$pam")
+run_install "$pam"
+[[ $(cat "$pam") == "$before" ]] || fail "install is a no-op when the new PATH is already present"
+pass "install is a no-op when the new PATH is already present"
+
+pam="$test_tmp/old.conf"
+printf '%s\n%s\n' "$comment" "$old_path" >"$pam"
+run_install "$pam"
+grep -qxF "$new_path" "$pam" || fail "install rewrites the old Omarchy PATH line"
+! grep -qxF "$old_path" "$pam" || fail "install removes the old Omarchy PATH line"
+grep -qxF "$comment" "$pam" || fail "install keeps the surrounding PAM comment when rewriting"
+pass "install rewrites the old Omarchy PATH line"
+
+pam="$test_tmp/custom.conf"
+printf '%s\n' 'PATH DEFAULT=/opt/custom/bin:/usr/bin' >"$pam"
+run_install "$pam"
+grep -qxF 'PATH DEFAULT=/opt/custom/bin:/usr/bin' "$pam" || fail "install leaves a hand-edited PATH alone"
+! grep -qxF "$new_path" "$pam" || fail "install does not append when a custom PATH exists"
+pass "install leaves a hand-edited PATH alone"
+
+pam="$test_tmp/migrate-old.conf"
+printf '%s\n%s\n' "$comment" "$old_path" >"$pam"
+run_migration "$pam"
+grep -qxF "$new_path" "$pam" || fail "migration rewrites the old Omarchy PATH line"
+! grep -qxF "$old_path" "$pam" || fail "migration removes the old Omarchy PATH line"
+grep -q '^sudo env OMARCHY_PAM_ENV_CONF=' "$TEST_LOG" || fail "migration uses sudo to rewrite PAM PATH"
+pass "migration rewrites the old Omarchy PATH line"
+
+pam="$test_tmp/migrate-new.conf"
+printf '%s\n%s\n' "$comment" "$new_path" >"$pam"
+run_migration "$pam"
+[[ ! -s $TEST_LOG ]] || fail "migration does not sudo when the new PATH is already present" "$(cat "$TEST_LOG")"
+pass "migration is a no-op when the new PATH is already present"
+
+pam="$test_tmp/migrate-custom.conf"
+printf '%s\n' 'PATH DEFAULT=/opt/custom/bin:/usr/bin' >"$pam"
+run_migration "$pam"
+grep -qxF 'PATH DEFAULT=/opt/custom/bin:/usr/bin' "$pam" || fail "migration leaves a hand-edited PATH alone"
+[[ ! -s $TEST_LOG ]] || fail "migration does not sudo for a hand-edited PATH" "$(cat "$TEST_LOG")"
+pass "migration leaves a hand-edited PATH alone"
+
+pam="$test_tmp/migrate-missing.conf"
+: >"$pam"
+run_migration "$pam"
+grep -qxF "$new_path" "$pam" || fail "migration writes the new PATH when none is set"
+pass "migration writes the new PATH when none is set"


### PR DESCRIPTION
`~/.local/bin` and mise shims were appended after `/usr/bin`. A user-installed or mise-managed `node`/`python`/`rg` therefore lost to the distro copy. That is the opposite of what those directories are for.

mise shims only intercept a name that also exists in `/usr/bin` when they sit **first**. Interactive shells hid this because `mise activate` prepends; `ssh host node`, PAM, and `bash -lc` did not.

Debian/Ubuntu prepend `~/.local/bin`. XDG only says "at an appropriate place"; the appropriate place for the user executable dir is before the packaged one.

Appending was justified as "system binaries keep precedence", often with `~/.local/bin/env` shadowing `/usr/bin/env` as the example. That is a caller bug: use `/usr/bin/env`. It is not a reason to put the user executable dir last. A bad name in `~/.local/bin` should not make every cargo, pip, and mise install lose to `/usr/bin`.

## Changes

- `default/bash/env-bootstrap` prepends `~/.local/bin`, then mise shims, then (in dev-link) the checkout `bin`. Already-present entries are moved to the front, so an old PAM PATH that listed them last is corrected in new shells.
- `install/config/ssh-command-path.sh` writes the same order into the PAM PATH, and rewrites the exact previous Omarchy line if it is still there.
- A migration does that rewrite on existing installs. A hand-edited `PATH` line is left alone.
- The leftover append in `default/bash/envs` is removed; bootstrap is the single source of truth.

Order after this:

```
[dev-link checkout/bin] : ~/.local/share/mise/shims : ~/.local/bin : /usr/local/... : /usr/bin
```

## Tests

`test/shell.d/dev-env-path-test.sh` and `test/shell.d/pam-command-path-test.sh`.