### PR TITLE
Add monitor selection for notification popups

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -12,6 +12,16 @@ a compositor.
 The end-user view (hotkey notices for time, battery, weather) is in
 `manual/10-notices.md`; this document is the system shape behind it.
 
+## Monitor selection
+
+By default, notification popups appear on every connected monitor. To choose outputs, add an entry to the `plugins` array in `~/.config/omarchy/shell.json`, preserving any existing entries:
+
+```json
+{ "id": "omarchy.notifications", "monitors": ["DP-2"] }
+```
+
+`monitors` accepts a list of exact output names from `hyprctl monitors`, such as `["DP-1", "DP-2"]`. Omitting it or setting it to `[]` shows popups on all outputs. A nonempty list shows popups only on connected outputs with matching names. If none match, no popup appears. Changes apply when the shell reloads `shell.json`, and reconnecting a selected monitor restores its popup window. A cloned plugin uses its own ID in the entry.
+
 ## Toast lifecycle
 
 A toast lives on screen for at least 5s (low), 8s (normal), or forever

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -1,3 +1,12 @@
+// An omitted or empty monitor list preserves popups on every output.
+function popupScreens(screens, plugins, pluginId) {
+  var entries = Array.isArray(plugins) ? plugins : []
+  var entry = entries.find(function(candidate) { return candidate && candidate.id === pluginId })
+  var monitors = entry && entry.monitors
+  if (!Array.isArray(monitors) || monitors.length === 0) return screens
+  return screens.filter(function(screen) { return monitors.indexOf(screen.name) !== -1 })
+}
+
 function isChromiumDerived(app, appIcon) {
   var source = (String(app || "") + "\n" + String(appIcon || "")).toLowerCase()
   return source.indexOf("chrom") >= 0 || source.indexOf("brave") >= 0 ||
@@ -448,6 +457,7 @@ function historyRows(raw, liveRows, normalUrgency, limit) {
 
 if (typeof module !== "undefined") {
   module.exports = {
+    popupScreens: popupScreens,
     isChromiumDerived: isChromiumDerived,
     sanitizeBody: sanitizeBody,
     styledBody: styledBody,

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -16,6 +16,10 @@ Item {
 
   // Injected by omarchy-shell (the first-party service loader).
   property var shell: null
+  property var manifest: null
+  readonly property var popupScreens: NotificationLogic.popupScreens(
+    Quickshell.screens, shell && shell.shellConfig ? shell.shellConfig.plugins : [],
+    manifest ? manifest.id : "omarchy.notifications")
 
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
   readonly property string home: Quickshell.env("HOME")
@@ -944,13 +948,13 @@ Item {
 
   // -------------------------------------------------------------- popup UI
   //
-  // One PanelWindow per output (Variants on Quickshell.screens) holding the
+  // One PanelWindow per selected output holding the
   // stacked toast cards. Layer is Overlay, exclusionMode Ignore, no
   // keyboard focus — popups are passive surfaces and must never steal input
   // from the focused application.
 
   Variants {
-    model: Quickshell.screens
+    model: service.popupScreens
 
     PanelWindow {
       id: popupWindow

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -8,6 +8,22 @@ run_node_test <<'JS'
 const fs = require('fs')
 const notifications = requireFromRoot('shell/plugins/notifications/NotificationLogic.js')
 
+const screens = [{ name: 'DP-1' }, { name: 'DP-2' }, { name: 'HDMI-A-1' }]
+function selectedScreens(monitors) {
+  return notifications.popupScreens(screens, [{ id: 'omarchy.notifications', monitors }], 'omarchy.notifications')
+}
+assertDeepEqual(selectedScreens(undefined), screens, 'notifications default to all outputs')
+assertDeepEqual(selectedScreens([]), screens, 'an empty monitor list selects all outputs')
+assertDeepEqual(selectedScreens('DP-2'), screens, 'malformed monitor settings preserve the default')
+assertDeepEqual(selectedScreens(['DP-2']), [screens[1]], 'notifications select a named output')
+assertDeepEqual(selectedScreens(['HDMI-A-1', 'DP-1', 'DP-1']), [screens[0], screens[2]], 'notifications select multiple outputs without duplicates')
+assertDeepEqual(selectedScreens(['DP-9']), [], 'disconnected outputs do not redirect notifications')
+assertDeepEqual(selectedScreens(['dp-2']), [], 'output names match exactly')
+assertDeepEqual(notifications.popupScreens(screens, null, 'omarchy.notifications'), screens, 'missing plugin entries use all outputs')
+assertDeepEqual(notifications.popupScreens(screens, [{ id: 'other.plugin', monitors: ['DP-2'] }], 'omarchy.notifications'), screens, 'other plugin settings do not affect notifications')
+assertDeepEqual(notifications.popupScreens(screens, [{ id: 'crab.notifications', monitors: ['DP-2'] }], 'crab.notifications'), [screens[1]], 'cloned notifications use their own settings')
+assertDeepEqual(notifications.popupScreens([screens[0]], [{ id: 'omarchy.notifications', monitors: ['DP-2'] }], 'omarchy.notifications'), [], 'unplugging a selected output removes its popup window')
+
 assert(notifications.isChromiumDerived('Brave Browser', ''), 'notifications detect chromium-derived apps by name')
 assert(notifications.isChromiumDerived('', 'microsoft-edge'), 'notifications detect chromium-derived apps by icon')
 assert(!notifications.isChromiumDerived('Slack', ''), 'notifications do not treat unrelated apps as chromium-derived')


### PR DESCRIPTION
Adds an optional `monitors` setting to control which outputs display notification popups. Supports selecting one or multiple monitors by name.

Omitting the setting preserves the existing behavior of showing notifications on all monitors.

Includes documentation and regression tests. Notification and plugin registry tests pass. Single-monitor selection and the default behavior were verified on a three-monitor setup.