### PR TITLE
fix: assert default-no confirmation in Hermes removal test

### DIFF
--- a/test/shell.d/hermes-remove-test.sh
+++ b/test/shell.d/hermes-remove-test.sh
@@ -186,6 +186,8 @@ seed_install
 remove_tty || fail "remove succeeds when the data question is declined"
 tr '\0' '\n' <"$test_tmp/gum-log" | grep -qx 'confirm' ||
   fail "removal asks about the user's data on a terminal"
+tr '\0' '\n' <"$test_tmp/gum-log" | grep -qx -- '--default=false' ||
+  fail "data removal confirmation defaults to no"
 [[ -f $test_home/.hermes/sessions/one.json && -d $test_home/.config/Hermes ]] ||
   fail "declining the question keeps the user's data"
 pass "removal asks on a terminal and declining keeps the data"


### PR DESCRIPTION
Adds an assertion that the Hermes data-removal prompt passes
--default=false to gum confirm.

The existing stub declines the prompt regardless of its arguments,
so removing the flag previously went undetected.

Validation:
- All 16 focused checks pass.
- Removing --default=false makes the new assertion fail.
- Production code is unchanged.

Follow-up to #10271.