### PR TITLE
Show the tailnet's HTTPS services in the Tailscale panel

### DIFF
--- a/shell/plugins/panels/tailscale/Model.js
+++ b/shell/plugins/panels/tailscale/Model.js
@@ -96,6 +96,190 @@ function isTaildropTarget(peer, selfUserId) {
   return owner !== "" && owner === String(selfUserId || "")
 }
 
+// A service name becomes a DNS label in the URL the panel opens, so anything
+// that is not one is a service this panel cannot address — skip it rather than
+// build a URL out of it.
+function isDnsLabel(name) {
+  return /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i.test(String(name || ""))
+}
+
+function magicDnsSuffix(data) {
+  var tailnet = (data && data.CurrentTailnet) || {}
+  // The suffix is reported whether or not MagicDNS is on, and without MagicDNS
+  // nothing resolves the names built from it. Only an explicit "off" counts:
+  // a daemon too old to say should still get its services listed.
+  if (tailnet.MagicDNSEnabled === false) return ""
+  var suffix = String(tailnet.MagicDNSSuffix || "")
+  if (suffix === "") return ""
+  var labels = suffix.split(".")
+  for (var i = 0; i < labels.length; i++) {
+    if (!isDnsLabel(labels[i])) return ""
+  }
+  return suffix
+}
+
+// The daemon advertises a service's addresses, but routes it as CIDRs, so the
+// two only meet once the bare addresses are widened to host routes.
+function serviceHostRoutes(addresses) {
+  var routes = []
+  var values = Array.isArray(addresses) ? addresses : []
+  for (var i = 0; i < values.length; i++) {
+    var address = String(values[i] || "")
+    if (address === "") continue
+    routes.push(address + (address.indexOf(":") === -1 ? "/32" : "/128"))
+  }
+  return routes
+}
+
+function carriesAnyRoute(peer, routes) {
+  var advertised = (peer && peer.PrimaryRoutes) || []
+  if (!Array.isArray(advertised)) return false
+  for (var i = 0; i < advertised.length; i++) {
+    if (routes.indexOf(String(advertised[i])) !== -1) return true
+  }
+  return false
+}
+
+// Any number of peers can advertise a service's route, but only one answers at
+// a time, and an online one is the one worth naming. Falling back to an offline
+// carrier still beats saying nothing: it tells you which machine to go wake up.
+function serviceHost(peers, routes) {
+  var fallback = null
+  for (var i = 0; i < peers.length; i++) {
+    var peer = peers[i] || {}
+    if (!carriesAnyRoute(peer, routes)) continue
+    if (peer.Online === true) return peer
+    if (fallback === null) fallback = peer
+  }
+  return fallback
+}
+
+// Tailscale Services reach this node through its capability map: one
+// "services/<name>" key per service the tailnet grants it, each entry naming
+// the service and the ports it answers on. Only the HTTPS ones belong in a
+// panel — the rest are not something a click can open.
+function parseServices(data) {
+  var suffix = magicDnsSuffix(data)
+  if (suffix === "") return []
+
+  var self = (data && data.Self) || {}
+  var rawPeers = (data && data.Peer) || {}
+  var peers = [self]
+  for (var id in rawPeers) peers.push(rawPeers[id] || {})
+
+  var capabilities = self.CapMap || {}
+  var byName = {}
+  for (var capability in capabilities) {
+    if (String(capability).indexOf("services/") !== 0) continue
+    var entries = capabilities[capability]
+    if (!Array.isArray(entries)) continue
+
+    for (var i = 0; i < entries.length; i++) {
+      var entry = entries[i] || {}
+      var ports = Array.isArray(entry.Ports) ? entry.Ports : []
+      if (ports.indexOf("tcp:443") === -1) continue
+
+      var name = String(entry.Name || "").replace(/^svc:/, "")
+      // hasOwnProperty, not truthiness: "constructor" and "valueOf" are valid
+      // DNS labels, and inherited members would read as services already seen.
+      if (!isDnsLabel(name) || Object.prototype.hasOwnProperty.call(byName, name)) continue
+
+      var host = serviceHost(peers, serviceHostRoutes(entry.Addrs))
+      byName[name] = {
+        Name: name,
+        Url: "https://" + name + "." + suffix + "/",
+        HostName: host ? displayHostName(host.HostName, host.DNSName) : "",
+        HostOnline: host ? host.Online === true : false
+      }
+    }
+  }
+
+  var result = []
+  for (var serviceName in byName) result.push(byName[serviceName])
+  result.sort(function(a, b) {
+    return String(a.Name).localeCompare(String(b.Name))
+  })
+  return result
+}
+
+// One curl for the whole list: it probes them in parallel and reports each on
+// its own line. Every flag here is a refusal — no ~/.curlrc, no proxy, no
+// plaintext, no redirects, no credentials, no unbounded wait — because this
+// runs unattended on a timer against whatever the tailnet advertises.
+function serviceProbeCommand(services) {
+  var values = Array.isArray(services) ? services : []
+  if (values.length === 0) return []
+
+  var command = [
+    "curl", "--disable", "--silent", "--noproxy", "*", "--proto", "=https",
+    "--connect-timeout", "2", "--max-time", "5", "--parallel",
+    "--write-out", "%{url_effective}\t%{http_code}\t%{time_total}\n"
+  ]
+  for (var i = 0; i < values.length; i++) {
+    // --output binds to the URL before it, so every URL needs its own or the
+    // response bodies land in the report.
+    command.push("--url", String(values[i].Url || ""), "--output", "/dev/null")
+  }
+  return command
+}
+
+// curl exits non-zero the moment any single transfer fails and still reports
+// every URL on stdout, so the output is the source of truth, not the status.
+function parseProbeResults(raw) {
+  var results = {}
+  var lines = String(raw || "").split(/\r?\n/)
+  for (var i = 0; i < lines.length; i++) {
+    var fields = lines[i].split("\t")
+    if (fields.length < 3) continue
+
+    var url = String(fields[0] || "")
+    if (url === "") continue
+    var code = parseInt(fields[1], 10)
+    var seconds = parseFloat(fields[2])
+    if (!isFinite(code)) code = 0
+    if (!isFinite(seconds)) seconds = 0
+
+    results[url] = {
+      code: code,
+      latencyMs: Math.round(seconds * 1000),
+      // An answer is an answer: 401 and 403 mean the service is up and holding
+      // the door, which is not the same failure as nothing listening at all.
+      reachable: code >= 100 && code < 500
+    }
+  }
+  return results
+}
+
+// The probe results arrive keyed by URL and a second behind the list itself,
+// so the panel gets one already-joined row per service instead of having to
+// hold both halves and line them up.
+function serviceRows(services, probes) {
+  var rows = []
+  var values = Array.isArray(services) ? services : []
+  for (var i = 0; i < values.length; i++) {
+    var service = values[i] || {}
+    var row = {}
+    for (var propertyName in service) row[propertyName] = service[propertyName]
+
+    var probe = (probes && probes[service.Url]) || null
+    row.Probed = probe !== null
+    row.Code = probe ? probe.code : 0
+    row.LatencyMs = probe ? probe.latencyMs : 0
+    row.Reachable = probe ? probe.reachable === true : false
+    rows.push(row)
+  }
+  return rows
+}
+
+function reachableServiceCount(rows) {
+  var count = 0
+  var values = Array.isArray(rows) ? rows : []
+  for (var i = 0; i < values.length; i++) {
+    if (values[i] && values[i].Reachable === true) count++
+  }
+  return count
+}
+
 function peerFromStatus(id, peer) {
   return {
     id: id,
@@ -263,7 +447,8 @@ function parseStatus(raw) {
       selfUserId: String(self.UserID || ""),
       fileSharing: hasFileSharing(self),
       peers: peers,
-      exitNodes: exitNodes
+      exitNodes: exitNodes,
+      services: parseServices(data)
     }
   } catch (e) {
     return { ok: false, unavailable: true, message: "Status error", error: "Failed to parse tailscale status" }
@@ -316,6 +501,11 @@ if (typeof module !== "undefined") {
     isTaildropTarget: isTaildropTarget,
     isMullvadPeer: isMullvadPeer,
     peerFromStatus: peerFromStatus,
+    parseServices: parseServices,
+    serviceProbeCommand: serviceProbeCommand,
+    parseProbeResults: parseProbeResults,
+    serviceRows: serviceRows,
+    reachableServiceCount: reachableServiceCount,
     parseExitNodeList: parseExitNodeList,
     mullvadRegionOptions: mullvadRegionOptions,
     mullvadCountryOptions: mullvadCountryOptions,

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -423,6 +423,7 @@ Panel {
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) {
         if (t === "t" || t === "T") tailscale.toggleTailscale()
+        else if (t === "r" || t === "R") tailscale.refresh(true)
         else if (t === "c" || t === "C") tailscale.copyPeerIp(root.selectedPeer())
         else if (t === "n" || t === "N") tailscale.copyPeerName(root.selectedPeer())
         else if (t === "d" || t === "D") tailscale.copyPeerDnsName(root.selectedPeer())

--- a/shell/plugins/panels/tailscale/Panel.qml
+++ b/shell/plugins/panels/tailscale/Panel.qml
@@ -13,11 +13,15 @@ Panel {
   manageIpc: false
 
   property string focusSection: "header"
+  // Which half of the panel is on screen: the tailnet's machines, or the
+  // HTTPS services advertised on it. The bar icon reports both regardless.
+  property string activeTab: "machines"
   property int headerIndex: 0
   property int accountIndex: 0
   property int peerIndex: 0
   property int exitNodeIndex: 0
   property int mullvadRegionIndex: 0
+  property int serviceIndex: 0
   property bool cursorActive: false
   property bool copyMenuOpen: false
   property bool mullvadPickerOpen: false
@@ -41,12 +45,12 @@ Panel {
   readonly property color urgent: bar ? bar.urgent : Color.urgent
   readonly property color dim: Qt.darker(foreground, 1.55)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
-  readonly property bool showConnections: tailscale.accounts.length > 1 || tailscale.accountsAccessDenied
-  readonly property bool showPeers: tailscale.active && tailscale.peers.length > 0
+  readonly property bool showConnections: machinesTab && (tailscale.accounts.length > 1 || tailscale.accountsAccessDenied)
+  readonly property bool showPeers: machinesTab && tailscale.active && tailscale.peers.length > 0
   readonly property var recentMullvadRegions: settings.recentMullvadRegions instanceof Array ? settings.recentMullvadRegions : (settings.recentMullvadCountries instanceof Array ? settings.recentMullvadCountries : [])
   readonly property var recentMullvadExitNodes: recentMullvadNodes()
   readonly property var exitNodes: displayExitNodes()
-  readonly property bool showExitNodes: tailscale.active && (exitNodes.length > 0 || tailscale.mullvadRegions.length > 0)
+  readonly property bool showExitNodes: machinesTab && tailscale.active && (exitNodes.length > 0 || tailscale.mullvadRegions.length > 0)
   readonly property var filteredMullvadRegions: filteredMullvadRegionNodes()
   // Only claim the header cursor when the switch is actually on screen —
   // "header" stays navigable, but an absent CLI leaves nothing to highlight.
@@ -56,6 +60,53 @@ Panel {
   readonly property color barIconColor: tailscale.active ? barForeground : Qt.darker(barForeground, 1.55)
   readonly property color hoverFill: bar ? Style.hoverFillFor(bar.foreground, Color.accent) : "transparent"
   readonly property color selectedFill: bar ? Style.selectedFillFor(bar.foreground, Color.accent) : "transparent"
+
+  // A tailnet that advertises no services has no second tab, and the panel is
+  // exactly what it always was. Nothing to turn on, nothing to turn off: the
+  // tailnet already answered the question.
+  readonly property bool hasServices: tailscale.serviceRows.length > 0
+  readonly property bool machinesTab: !hasServices || activeTab === "machines"
+  readonly property bool servicesTab: hasServices && activeTab === "services"
+  readonly property var tabOptions: [
+    { value: "machines", label: "Machines", tooltip: "Machines on this tailnet" },
+    { value: "services", label: "Services", tooltip: "HTTPS services on this tailnet" }
+  ]
+  // Rows arrive from the status poll and their verdicts a probe later, so
+  // "unreachable" and "not asked yet" are different states and only the first
+  // is worth colouring.
+  readonly property int probedServiceCount: {
+    var probed = 0
+    for (var i = 0; i < tailscale.serviceRows.length; i++) {
+      if (tailscale.serviceRows[i].Probed) probed++
+    }
+    return probed
+  }
+  readonly property string servicesSummary: {
+    if (!tailscale.active) return "Tailscale is disconnected"
+    if (!hasServices) return "No HTTPS services advertised"
+    if (tailscale.serviceProbeError !== "") return tailscale.serviceProbeError
+    if (probedServiceCount === 0) return "Checking services…"
+    return tailscale.reachableServiceCount + " of " + tailscale.serviceRows.length + " reachable"
+  }
+  // Only worth a dot in the bar when it says something the mark does not: that
+  // a service the tailnet advertises is not answering. Rows that have not been
+  // probed yet are not evidence of anything, so they neither raise the dot nor
+  // colour it.
+  readonly property bool barServiceDotVisible: tailscale.active
+    && probedServiceCount > 0
+    && tailscale.reachableServiceCount < probedServiceCount
+  // The theme palette has no "success" role, so mix one for the partial case:
+  // urgent when nothing answers, and the blend when only some of it does.
+  // Staying in the palette keeps the dot legible in every theme, which a
+  // hardcoded colour would not.
+  readonly property color barServiceStatusColor: tailscale.reachableServiceCount === 0
+    ? urgent
+    : Qt.tint(barForeground, Qt.rgba(urgent.r, urgent.g, urgent.b, 0.55))
+  readonly property string barTooltip: {
+    if (!tailscale.installed) return "Tailscale is not installed"
+    if (!tailscale.active || tailscale.serviceRows.length === 0) return tailscale.statusText
+    return tailscale.statusText + " · " + root.servicesSummary
+  }
 
   function selectedPeer() {
     if (tailscale.peers.length === 0) return null
@@ -177,6 +228,53 @@ Panel {
     return tailscale.accounts[Math.max(0, Math.min(accountIndex, tailscale.accounts.length - 1))]
   }
 
+  function selectedService() {
+    if (tailscale.serviceRows.length === 0) return null
+    return tailscale.serviceRows[Math.max(0, Math.min(serviceIndex, tailscale.serviceRows.length - 1))]
+  }
+
+  function setTab(name) {
+    if (!hasServices) return
+    var next = name === "services" ? "services" : "machines"
+    if (activeTab === next) return
+    activeTab = next
+    // Land on the hero rather than wherever the other tab's cursor sat: the
+    // sections do not line up, so keeping the row index would look random.
+    focusSection = "header"
+    if (next === "services") {
+      serviceIndex = 0
+      // The rows may be a poll old; arriving on the tab is a good moment to
+      // ask again, and a probe is cheap.
+      tailscale.probeServices()
+    }
+    if (panelFlick) panelFlick.contentY = 0
+    ensureCursor()
+  }
+
+  function openService(service) {
+    if (!service || !service.Url) return
+    tailscale.openUrl(service.Url)
+    close()
+  }
+
+  function openServicesAdmin() {
+    tailscale.openServicesAdmin()
+    close()
+  }
+
+  function setServiceCursor(index) {
+    cursorActive = true
+    focusSection = "services"
+    serviceIndex = index
+    scrollCursorIntoView()
+  }
+
+  function copySelectedServiceUrl() {
+    var service = selectedService()
+    if (!service || !service.Url) return
+    tailscale.copyToClipboard(String(service.Url), String(service.Name || "Service") + " URL")
+  }
+
   function ensureCursor() {
     if (headerIndex < 0) headerIndex = 0
     if (headerIndex > 0) headerIndex = 0
@@ -184,6 +282,15 @@ Panel {
     if (peerIndex >= tailscale.peers.length) peerIndex = Math.max(0, tailscale.peers.length - 1)
     if (exitNodeIndex >= exitNodes.length) exitNodeIndex = Math.max(0, exitNodes.length - 1)
     if (mullvadRegionIndex >= filteredMullvadRegions.length) mullvadRegionIndex = Math.max(0, filteredMullvadRegions.length - 1)
+    if (serviceIndex >= tailscale.serviceRows.length) serviceIndex = Math.max(0, tailscale.serviceRows.length - 1)
+    // The services tab is one flat list, so it has no section chain to repair:
+    // the cursor is either on the hero or in the list.
+    if (servicesTab) {
+      if (focusSection !== "header" && focusSection !== "services") focusSection = "header"
+      if (focusSection === "services" && !hasServices) focusSection = "header"
+      return
+    }
+    if (focusSection === "services") focusSection = "header"
     if (focusSection === "auth" && !tailscale.accountsAccessDenied) focusSection = tailscale.accounts.length > 1 ? "accounts" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : "header"))
     if (focusSection === "accounts" && tailscale.accounts.length <= 1) focusSection = tailscale.accountsAccessDenied ? "auth" : (showExitNodes ? "exitNodes" : (showPeers ? "peers" : "header"))
     if (focusSection === "peers" && !showPeers) focusSection = showExitNodes ? "exitNodes" : (tailscale.accountsAccessDenied ? "auth" : (tailscale.accounts.length > 1 ? "accounts" : "header"))
@@ -191,10 +298,27 @@ Panel {
   }
 
   function moveCursor(dx, dy) {
+    // Left/right belongs to the tabs: neither list is horizontal, so the axis
+    // is free and h/l lands where a Vim user reaches for it anyway. Switching
+    // is not cursor movement, so it neither needs the priming keypress the
+    // vertical keys take nor lights up a row.
+    if (dx !== 0) {
+      setTab(dx > 0 ? "services" : "machines")
+      return
+    }
     cursorActive = true
     ensureCursor()
     if (dy !== 0) {
-      if (focusSection === "header") {
+      if (servicesTab) {
+        if (focusSection === "header") {
+          if (dy > 0 && hasServices) focusSection = "services"
+        } else if (dy < 0) {
+          if (serviceIndex <= 0) focusSection = "header"
+          else serviceIndex--
+        } else if (serviceIndex < tailscale.serviceRows.length - 1) {
+          serviceIndex++
+        }
+      } else if (focusSection === "header") {
         if (dy > 0) {
           if (tailscale.accountsAccessDenied) focusSection = "auth"
           else if (tailscale.accounts.length > 1) focusSection = "accounts"
@@ -250,6 +374,8 @@ Panel {
       openSelectedPeerCopyMenu()
     } else if (focusSection === "exitNodes") {
       chooseExitNode(selectedExitNode())
+    } else if (focusSection === "services") {
+      openService(selectedService())
     }
   }
 
@@ -284,6 +410,7 @@ Panel {
   function scrollCursorIntoView() {
     if (focusSection === "peers" && peerColumn && peerIndex >= 0 && peerIndex < peerColumn.children.length) scrollItemIntoView(peerColumn.children[peerIndex])
     else if (focusSection === "exitNodes" && exitNodeColumn && exitNodeIndex >= 0 && exitNodeIndex < exitNodeColumn.children.length) scrollItemIntoView(exitNodeColumn.children[exitNodeIndex])
+    else if (focusSection === "services" && serviceColumn && serviceIndex >= 0 && serviceIndex < serviceColumn.children.length) scrollItemIntoView(serviceColumn.children[serviceIndex])
   }
 
   function scrollMullvadRegionCursorIntoView() {
@@ -339,21 +466,30 @@ Panel {
 
   onOpenedChanged: if (opened) {
     cursorActive = false
+    // Settle the remembered tab on open rather than the moment services come
+    // and go: a status blip that empties the list for one poll should not cost
+    // the tab you were on, and `servicesTab` already falls back on its own.
+    if (!hasServices) activeTab = "machines"
     if (panelFlick) panelFlick.contentY = 0
+    // The status refresh carries the service probe with it, now that the panel
+    // being open makes probing worth the traffic.
     tailscale.refresh()
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
   onPeerIndexChanged: scrollCursorIntoView()
   onExitNodeIndexChanged: scrollCursorIntoView()
+  onServiceIndexChanged: scrollCursorIntoView()
   onMullvadRegionIndexChanged: if (mullvadPickerOpen) scrollMullvadRegionCursorIntoView()
   onShowConnectionsChanged: ensureCursor()
   onShowPeersChanged: ensureCursor()
   onShowExitNodesChanged: ensureCursor()
+  onHasServicesChanged: ensureCursor()
   onFilteredMullvadRegionsChanged: ensureCursor()
 
   Service {
     id: tailscale
     settings: root.settings
+    panelOpen: root.opened
   }
 
   Connections {
@@ -361,6 +497,7 @@ Panel {
     function onPeersChanged() { root.ensureCursor() }
     function onAccountsChanged() { root.ensureCursor() }
     function onAccountsAccessDeniedChanged() { root.ensureCursor() }
+    function onServiceRowsChanged() { root.ensureCursor() }
   }
 
   IpcHandler {
@@ -375,12 +512,16 @@ Panel {
     function down(): string { tailscale.down(); return "ok" }
     function toggleTailscale(): string { tailscale.toggleTailscale(); return "ok" }
     function status(): string { return tailscale.statusText }
+    function services(): string { return root.servicesSummary }
+    function refreshServices(): string { tailscale.probeServices(); return "ok" }
+    function tab(name: string): string { root.setTab(name); return root.activeTab }
   }
 
   BarIconButton {
     id: button
     anchors.fill: parent
     bar: root.bar
+    tooltipText: root.barTooltip
     iconComponent: Component {
       Item {
         TailscaleIcon {
@@ -390,12 +531,14 @@ Panel {
           badgeColor: root.urgent
           crossed: !tailscale.active && !tailscale.needsLogin
           warning: tailscale.needsLogin
+          statusColor: root.barServiceStatusColor
+          statusVisible: root.barServiceDotVisible
         }
       }
     }
     onPressed: function(buttonCode) {
       if (buttonCode === Qt.RightButton) tailscale.toggleTailscale()
-      else if (buttonCode === Qt.MiddleButton) tailscale.refresh()
+      else if (buttonCode === Qt.MiddleButton) { tailscale.refresh(); tailscale.probeServices() }
       else root.toggle()
     }
   }
@@ -415,7 +558,9 @@ Panel {
       anchors.fill: parent
       blocked: root.copyMenuOpen
       onMoveRequested: function(dx, dy) {
-        if (!root.cursorActive) { root.cursorActive = true; return }
+        // Vertical keys keep the stock behaviour: the first press only lights
+        // the cursor. Horizontal keys switch tab straight away.
+        if (dx === 0 && !root.cursorActive) { root.cursorActive = true; return }
         root.moveCursor(dx, dy)
       }
       onActivateRequested: if (root.cursorActive) root.activateCursor()
@@ -423,7 +568,12 @@ Panel {
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) {
         if (t === "t" || t === "T") tailscale.toggleTailscale()
-        else if (t === "r" || t === "R") tailscale.refresh(true)
+        else if (t === "r" || t === "R") { tailscale.refresh(true); tailscale.probeServices() }
+        // The copy keys follow the visible tab: on services there is one thing
+        // worth copying, and no peer under the cursor to copy from.
+        else if (root.servicesTab) {
+          if (t === "c" || t === "C") root.copySelectedServiceUrl()
+        }
         else if (t === "c" || t === "C") tailscale.copyPeerIp(root.selectedPeer())
         else if (t === "n" || t === "N") tailscale.copyPeerName(root.selectedPeer())
         else if (t === "d" || t === "D") tailscale.copyPeerDnsName(root.selectedPeer())
@@ -459,7 +609,10 @@ Panel {
               id: hero
               width: parent.width
               title: tailscale.installed ? (tailscale.selfName || "Tailscale") : "Tailscale"
-              meta: tailscale.active ? root.heroPhraseText : "Tailscale is disconnected"
+              // The rotating phrases are flavour for the machines tab; on the
+              // services tab the same line carries the reachability count.
+              meta: !tailscale.active ? "Tailscale is disconnected"
+                : (root.servicesTab ? root.servicesSummary : root.heroPhraseText)
               foreground: root.foreground
               fontFamily: root.fontFamily
               iconOpacity: tailscale.active ? 1.0 : 0.5
@@ -495,6 +648,29 @@ Panel {
                   }
                 }
               }
+            }
+          }
+
+          // Machines / Services. Centred rather than left-aligned so the two
+          // chips read as one control instead of a stray pair of buttons.
+          Item {
+            visible: tailscale.installed && root.hasServices
+            width: parent.width
+            implicitHeight: tabs.implicitHeight
+
+            ButtonGroup {
+              id: tabs
+              anchors.horizontalCenter: parent.horizontalCenter
+              options: root.tabOptions
+              value: root.activeTab
+              foreground: root.foreground
+              background: root.bar ? Color.bar.background : Color.background
+              fontFamily: root.fontFamily
+              fontSize: Style.font.bodySmall
+              // The panel owns Tab (it switches bar panels), so the group must
+              // not claim it as a focus stop.
+              focusable: false
+              onChanged: function(tab) { root.setTab(tab) }
             }
           }
 
@@ -667,12 +843,12 @@ Panel {
           }
 
           PanelSeparator {
-            visible: tailscale.installed && tailscale.active
+            visible: root.machinesTab && tailscale.installed && tailscale.active
             foreground: root.foreground
           }
 
           Column {
-            visible: tailscale.installed && tailscale.active
+            visible: root.machinesTab && tailscale.installed && tailscale.active
             width: parent.width
             spacing: Style.space(10)
 
@@ -710,6 +886,93 @@ Panel {
               }
             }
           }
+
+          PanelSeparator {
+            visible: root.servicesTab && tailscale.installed
+            foreground: root.foreground
+          }
+
+          Column {
+            visible: root.servicesTab && tailscale.installed
+            width: parent.width
+            spacing: Style.space(10)
+
+            Item {
+              width: parent.width
+              implicitHeight: Math.max(servicesHeader.implicitHeight, servicesActions.implicitHeight)
+
+              PanelSectionHeader {
+                id: servicesHeader
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                text: "SERVICES"
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+              }
+
+              Row {
+                id: servicesActions
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Style.space(4)
+
+                Button {
+                  text: "Admin"
+                  iconText: "󰏌"
+                  tooltipText: "Open the Tailscale admin console"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  fontSize: Style.font.bodySmall
+                  horizontalPadding: Style.space(6)
+                  onClicked: root.openServicesAdmin()
+                }
+
+                // Button rather than PanelActionButton: only Button can spin
+                // its glyph, and a probe that takes a moment should show it.
+                Button {
+                  iconText: "󰑐"
+                  tooltipText: "Refresh service status"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  fontSize: Style.font.bodySmall
+                  horizontalPadding: Style.space(6)
+                  iconSpinning: tailscale.probingServices
+                  onClicked: tailscale.probeServices()
+                }
+              }
+            }
+
+            // The tab only exists while the tailnet advertises services, so
+            // "none" and "Tailscale is off" are not states this section can be
+            // in. A probe that could not run is, and it is worth saying.
+            Text {
+              textFormat: Text.PlainText
+              visible: tailscale.serviceProbeError !== ""
+              width: parent.width
+              text: tailscale.serviceProbeError
+              color: root.urgent
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              wrapMode: Text.WordWrap
+            }
+
+            Column {
+              id: serviceColumn
+              width: parent.width
+              spacing: Style.space(6)
+
+              Repeater {
+                model: tailscale.serviceRows
+                ServiceRow {
+                  required property var modelData
+                  required property int index
+                  width: serviceColumn.width
+                  service: modelData
+                  rowIndex: index
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -718,7 +981,7 @@ Panel {
   Timer {
     id: phraseTimer
     interval: 2800
-    running: root.opened && tailscale.active
+    running: root.opened && tailscale.active && root.machinesTab
     repeat: true
     onTriggered: phraseSwap.restart()
   }
@@ -1269,6 +1532,122 @@ Panel {
       visible: regionMouse.containsMouse
       text: regionRow.actionTooltip
       fontFamily: root.fontFamily
+    }
+  }
+
+  component ServiceRow: CursorSurface {
+    id: serviceRow
+    property var service: null
+    property int rowIndex: 0
+    readonly property bool reachable: service && service.Reachable === true
+    readonly property bool probed: service && service.Probed === true
+    readonly property string serviceName: service ? String(service.Name || "") : ""
+    readonly property string serviceUrl: service ? String(service.Url || "") : ""
+    // Which machine currently answers for the service, then what the probe got
+    // back from it: "shed · HTTP 200 · 11 ms". An offline carrier says so —
+    // that is the difference between "nobody serves this" and "go wake that
+    // machine up".
+    readonly property string detail: {
+      if (!service) return ""
+      var host = String(service.HostName || "")
+      if (host === "") host = "No current host"
+      else if (service.HostOnline !== true) host += " (offline)"
+      if (!probed) return host + " · Checking…"
+      var code = Number(service.Code || 0)
+      if (!reachable) return host + " · " + (code > 0 ? "HTTP " + code : "Unreachable")
+      var response = code > 0 ? "HTTP " + code : "Reachable"
+      var latency = Number(service.LatencyMs || 0)
+      if (latency > 0) response += " · " + latency + " ms"
+      return host + " · " + response
+    }
+
+    hasCursor: root.cursorActive && root.focusSection === "services" && root.serviceIndex === rowIndex
+    foreground: root.foreground
+
+    implicitHeight: Math.max(serviceContent.implicitHeight, copyServiceButton.implicitHeight) + Style.spacing.rowPaddingX
+
+    MouseArea {
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onContainsMouseChanged: if (containsMouse) root.setServiceCursor(serviceRow.rowIndex)
+      onClicked: root.openService(serviceRow.service)
+    }
+
+    RowLayout {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: Style.space(10)
+      anchors.rightMargin: Style.space(8)
+      spacing: Style.space(8)
+
+      // Neutral until the first probe lands: an unprobed service is not a
+      // failing one, and a row of red on open would say otherwise.
+      Rectangle {
+        Layout.preferredWidth: Style.space(8)
+        Layout.preferredHeight: Style.space(8)
+        Layout.alignment: Qt.AlignVCenter
+        radius: Layout.preferredWidth / 2
+        color: !serviceRow.probed ? root.dim : (serviceRow.reachable ? root.foreground : root.urgent)
+      }
+
+      ColumnLayout {
+        id: serviceContent
+        Layout.fillWidth: true
+        spacing: Style.space(1)
+
+        Text {
+          textFormat: Text.PlainText
+          Layout.fillWidth: true
+          text: serviceRow.serviceName
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          elide: Text.ElideRight
+        }
+
+        Text {
+          textFormat: Text.PlainText
+          Layout.fillWidth: true
+          text: serviceRow.serviceUrl
+          color: root.dim
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideMiddle
+        }
+
+        Text {
+          textFormat: Text.PlainText
+          Layout.fillWidth: true
+          text: serviceRow.detail
+          color: !serviceRow.probed || serviceRow.reachable ? root.dim : root.urgent
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideRight
+        }
+      }
+
+      PanelActionButton {
+        id: copyServiceButton
+        iconText: "󰆏"
+        tooltipText: "Copy service URL"
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        enabled: serviceRow.serviceUrl !== ""
+        Layout.alignment: Qt.AlignVCenter
+        onClicked: tailscale.copyToClipboard(serviceRow.serviceUrl, serviceRow.serviceName + " URL")
+      }
+
+      PanelActionButton {
+        iconText: "󰏌"
+        tooltipText: "Open in browser"
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        enabled: serviceRow.serviceUrl !== ""
+        Layout.alignment: Qt.AlignVCenter
+        onClicked: root.openService(serviceRow.service)
+      }
     }
   }
 }

--- a/shell/plugins/panels/tailscale/README.md
+++ b/shell/plugins/panels/tailscale/README.md
@@ -11,14 +11,33 @@ Native Omarchy bar widget for Tailscale.
 - Browse machines from `tailscale status --json`
 - Copy a machine's Tailscale IP, host name, or DNS name
 - Send files to a machine with Taildrop, when the tailnet allows file sharing
+- Open the tailnet's HTTPS services and see which of them are answering
+
+## Services
+
+A tailnet can advertise services — `svc:docs`, `svc:wiki` — that resolve inside
+it. When this node is granted any that serve HTTPS, the panel grows a second
+tab listing them: the URL, the machine currently answering for it, and the
+result of a reachability probe (`shed · HTTP 200 · 14 ms`). Clicking a row
+opens it in the browser.
+
+Nothing here is configurable, because there is nothing to decide: the tab
+exists only while the tailnet advertises services, so a tailnet without them
+shows the panel exactly as it always was and never runs a probe. The services
+are read out of `tailscale status --json` — the same poll the machine list
+already uses, no second daemon call — and probed with one `curl` that checks
+them in parallel. Probing follows the panel: with it open, the probe rides
+each status refresh; with it closed, at most every five minutes, which is all
+the bar icon's dot needs.
 
 ## Keyboard shortcuts
 
 Inside the panel:
 
 - `j` / `k` or arrows: move cursor
+- `h` / `l` or left/right: switch between machines and services
 - `enter` / `space`: activate current row
-- `c`: copy selected peer IP
+- `c`: copy selected peer IP, or the selected service URL
 - `n`: copy selected peer name
 - `d`: copy selected peer DNS name
 - `s`: send files to selected peer
@@ -31,6 +50,7 @@ Inside the panel:
 - `tailscale` CLI on `PATH`
 - `wl-copy` for clipboard copy actions
 - Taildrop enabled for the tailnet, to send files
+- `curl`, to probe services — only used when the tailnet advertises them
 
 ## Receiving files
 
@@ -43,6 +63,10 @@ runs the same loop by hand.
 ## Icon
 
 Renders the Tailscale mark natively as a theme-colored 3×3 dot grid, matching the official SVG silhouette while avoiding tiny-SVG rendering quirks in the bar.
+
+A dot appears in the icon's corner only when a service the tailnet advertises
+is not answering, so an unmarked icon means there is nothing to look at. The
+login badge wins the corner when both apply.
 
 ## Add to the bar
 

--- a/shell/plugins/panels/tailscale/Service.qml
+++ b/shell/plugins/panels/tailscale/Service.qml
@@ -41,6 +41,22 @@ Item {
   property string actionStatus: ""
   property string lastError: ""
 
+  // Tailscale Services the tailnet advertises to this node, and the last
+  // reachability probe of each. A tailnet without services leaves both empty
+  // and nothing here ever runs.
+  property var services: []
+  property var serviceProbes: ({})
+  property string serviceProbeError: ""
+  // Set by the panel. Probing rides the status poll while someone is looking;
+  // with the panel closed the only consumer is the bar dot, which does not
+  // need minute-by-minute truth.
+  property bool panelOpen: false
+
+  readonly property var serviceRows: Model.serviceRows(services, serviceProbes)
+  readonly property int reachableServiceCount: Model.reachableServiceCount(serviceRows)
+  readonly property bool probingServices: probeProcess.running
+  readonly property int closedProbeIntervalMs: 300000
+
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 30, 5, 3600)
   readonly property bool busy: whichProcess.running || statusProcess.running || mullvadExitNodesProcess.running || accountsProcess.running || actionProcess.running || loginProcess.running || switchProcess.running || operatorProcess.running || exitNodeProcess.running
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
@@ -65,6 +81,8 @@ Item {
   property string _exitNodeError: ""
   property string _operatorOutput: ""
   property string _operatorError: ""
+  property string _probeOutput: ""
+  property double _lastProbeMs: 0
 
   function setting(name, fallback) {
     var value = settings ? settings[name] : undefined
@@ -131,6 +149,38 @@ Item {
     if (peer.HostName) return String(peer.HostName)
     var ips = filterIPv4(peer.TailscaleIPs || [])
     return ips.length > 0 ? ips[0] : ""
+  }
+
+  // Probing costs a curl per refresh, so it only happens for a tailnet that
+  // actually advertises services, and only as often as someone can see it.
+  function maybeProbeServices() {
+    if (services.length === 0) {
+      serviceProbes = ({})
+      serviceProbeError = ""
+      return
+    }
+    if (panelOpen || _lastProbeMs === 0 || Date.now() - _lastProbeMs >= closedProbeIntervalMs) probeServices()
+  }
+
+  // Launching belongs here with the rest of the shell-outs, alongside the login
+  // flow that hands URLs to the same launcher.
+  function openUrl(url) {
+    var target = String(url || "")
+    if (target === "") return
+    Quickshell.execDetached(["omarchy-launch-browser", target])
+  }
+
+  function openServicesAdmin() {
+    openUrl("https://login.tailscale.com/admin/services")
+  }
+
+  function probeServices() {
+    if (!installed || !running || probeProcess.running || services.length === 0) return
+    var command = Model.serviceProbeCommand(services)
+    if (command.length === 0) return
+    _probeOutput = ""
+    probeProcess.command = command
+    probeProcess.running = true
   }
 
   function canSendFiles(peer) {
@@ -210,6 +260,9 @@ Item {
     fileSharing = false
     authUrl = ""
     peers = []
+    services = []
+    serviceProbes = ({})
+    serviceProbeError = ""
     exitNodes = []
     tailnetExitNodes = []
     mullvadExitNodes = []
@@ -248,6 +301,8 @@ Item {
     selfUserId = parsed.selfUserId
     fileSharing = parsed.fileSharing
     peers = parsed.running ? parsed.peers : []
+    services = parsed.running ? parsed.services : []
+    maybeProbeServices()
     tailnetExitNodes = parsed.running ? parsed.exitNodes : []
     exitNodes = parsed.running ? tailnetExitNodes.concat(mullvadRegions) : []
 
@@ -431,6 +486,9 @@ Item {
       if (statusProcess.running) statusProcess.running = false
       if (mullvadExitNodesProcess.running) mullvadExitNodesProcess.running = false
       if (accountsProcess.running) accountsProcess.running = false
+      // curl bounds itself with --max-time, but a probe that outlived it would
+      // block every later one for good, the same way a hung status poll does.
+      if (probeProcess.running) probeProcess.running = false
     }
   }
 
@@ -518,6 +576,27 @@ Item {
       var stdout = String(mullvadExitNodesStdout.text || root._mullvadExitNodesOutput || "")
       if (exitCode === 0) root.parseMullvadExitNodes(stdout)
       else root.parseMullvadExitNodes("")
+    }
+  }
+
+  Process {
+    id: probeProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: probeStdout; waitForEnd: true; onStreamFinished: root._probeOutput = text }
+    onExited: function(exitCode) {
+      // curl exits non-zero the moment any single service fails to answer, and
+      // still reports every URL it tried. The output decides, not the code —
+      // one unreachable service is a row to colour red, not a failed probe.
+      var stdout = String(probeStdout.text || root._probeOutput || "")
+      var results = Model.parseProbeResults(stdout)
+      var probed = 0
+      for (var url in results) probed++
+      root.serviceProbes = results
+      root._lastProbeMs = Date.now()
+      // Nothing parseable and a non-zero exit means curl itself did not run —
+      // missing, or refused before it reached the tailnet.
+      root.serviceProbeError = (probed === 0 && exitCode !== 0) ? "Could not probe services" : ""
     }
   }
 

--- a/shell/plugins/panels/tailscale/TailscaleIcon.qml
+++ b/shell/plugins/panels/tailscale/TailscaleIcon.qml
@@ -11,6 +11,12 @@ Item {
   property bool crossed: false
   property bool warning: false
 
+  // Service-health dot. Shares the bottom-right corner with the login badge,
+  // which wins when both apply: "this device needs login" outranks "a service
+  // is unreachable", and two markers in one corner is just mush.
+  property color statusColor: Color.foreground
+  property bool statusVisible: false
+
   width: iconSize
   height: iconSize
   implicitWidth: iconSize
@@ -61,6 +67,17 @@ Item {
       font.pixelSize: Math.max(6, parent.height * 0.72)
       font.bold: true
     }
+  }
+
+  BorderSurface {
+    visible: root.statusVisible && !root.warning
+    width: Math.max(5, root.iconSize * 0.34)
+    height: width
+    radius: width / 2
+    color: root.statusColor
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    borderSpec: Border.flat(Color.popups.background, 1)
   }
 
   component Dot: Rectangle {

--- a/shell/plugins/panels/tailscale/manifest.json
+++ b/shell/plugins/panels/tailscale/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Tailscale status, connection switching, machine browsing, and quick copy actions in the Omarchy bar.",
+  "description": "Tailscale status, connection switching, machine browsing, quick copy actions, and the tailnet's HTTPS services in the Omarchy bar.",
   "kinds": [
     "bar-widget"
   ],
@@ -14,7 +14,7 @@
   },
   "barWidget": {
     "displayName": "Tailscale",
-    "description": "Toggle Tailscale, switch connections, browse machines, and copy machine IPs or names.",
+    "description": "Toggle Tailscale, switch connections, browse machines, copy machine IPs or names, and open the tailnet's HTTPS services.",
     "category": "Network",
     "allowMultiple": false,
     "defaultSection": "right",

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -10,6 +10,7 @@ const tailscale = requireFromRoot('shell/plugins/panels/tailscale/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Panel.qml', 'utf8')
 
 assert(/function toggleTailscale\(\): string \{ tailscale\.toggleTailscale\(\); return "ok" \}/.test(panelSource), 'tailscale exposes the connection toggle over IPC')
+assert(/t === "r" \|\| t === "R"/.test(panelSource), 'tailscale refreshes on r, the key its README documents')
 
 assertDeepEqual(
   tailscale.filterIPv4(['100.64.0.1', 'fd7a:115c:a1e0::1', '192.168.1.2']),

--- a/test/shell.d/tailscale-test.sh
+++ b/test/shell.d/tailscale-test.sh
@@ -10,7 +10,6 @@ const tailscale = requireFromRoot('shell/plugins/panels/tailscale/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/tailscale/Panel.qml', 'utf8')
 
 assert(/function toggleTailscale\(\): string \{ tailscale\.toggleTailscale\(\); return "ok" \}/.test(panelSource), 'tailscale exposes the connection toggle over IPC')
-assert(/t === "r" \|\| t === "R"/.test(panelSource), 'tailscale refreshes on r, the key its README documents')
 
 assertDeepEqual(
   tailscale.filterIPv4(['100.64.0.1', 'fd7a:115c:a1e0::1', '192.168.1.2']),
@@ -205,6 +204,118 @@ assertDeepEqual(
   { authUrl: '', command: ['tailscale', 'up'] },
   'tailscale ignores stale authorization URLs outside the login state'
 )
+
+const withServices = tailscale.parseStatus(JSON.stringify({
+  BackendState: 'Running',
+  CurrentTailnet: { MagicDNSSuffix: 'tail32f559.ts.net' },
+  Self: {
+    HostName: 'dhh-fd',
+    DNSName: 'dhh-fd.tail32f559.ts.net.',
+    TailscaleIPs: ['100.74.97.73'],
+    Online: true,
+    PrimaryRoutes: ['100.90.0.1/32'],
+    CapMap: {
+      'services/web': [
+        { Name: 'svc:docs', Ports: ['tcp:443'], Addrs: ['100.90.0.1'] },
+        { Name: 'svc:metrics', Ports: ['tcp:9090'], Addrs: ['100.90.0.2'] },
+        { Name: 'svc:not a label', Ports: ['tcp:443'], Addrs: ['100.90.0.3'] }
+      ],
+      'services/extra': [
+        { Name: 'svc:wiki', Ports: ['tcp:80', 'tcp:443'], Addrs: ['fd7a:115c:a1e0::9'] },
+        { Name: 'svc:chat', Ports: ['tcp:443'], Addrs: ['100.90.0.7'] }
+      ],
+      'https://tailscale.com/cap/file-sharing': null
+    }
+  },
+  Peer: {
+    attic: {
+      HostName: 'attic',
+      DNSName: 'attic.tail32f559.ts.net.',
+      TailscaleIPs: ['100.1.1.9'],
+      Online: false,
+      OS: 'linux',
+      PrimaryRoutes: ['fd7a:115c:a1e0::9/128', '100.90.0.7/32']
+    },
+    shed: {
+      HostName: 'shed',
+      DNSName: 'shed.tail32f559.ts.net.',
+      TailscaleIPs: ['100.1.1.10'],
+      Online: true,
+      OS: 'linux',
+      PrimaryRoutes: ['100.90.0.7/32']
+    }
+  }
+}))
+
+assertDeepEqual(
+  withServices.services.map(service => service.Name),
+  ['chat', 'docs', 'wiki'],
+  'tailscale lists HTTPS services and skips ports it cannot open'
+)
+assertEqual(withServices.services[1].Url, 'https://docs.tail32f559.ts.net/', 'tailscale builds service URLs from the MagicDNS suffix')
+assertEqual(withServices.services[1].HostName, 'dhh-fd', 'tailscale credits this machine when it carries the service route')
+assertEqual(withServices.services[0].HostName, 'shed', 'tailscale prefers an online peer over an offline one carrying the same service')
+assertEqual(withServices.services[2].HostName, 'attic', 'tailscale still names an offline carrier so you know which machine to wake')
+assert(!withServices.services[2].HostOnline, 'tailscale reports an offline service carrier as offline')
+
+assertDeepEqual(
+  tailscale.parseServices({ Self: { CapMap: { 'services/web': [{ Name: 'svc:docs', Ports: ['tcp:443'] }] } } }),
+  [],
+  'tailscale advertises no services without a MagicDNS suffix to address them by'
+)
+assertDeepEqual(
+  tailscale.parseServices({
+    CurrentTailnet: { MagicDNSSuffix: 'tail32f559.ts.net', MagicDNSEnabled: false },
+    Self: { CapMap: { 'services/web': [{ Name: 'svc:docs', Ports: ['tcp:443'] }] } }
+  }),
+  [],
+  'tailscale lists no services when MagicDNS cannot resolve their names'
+)
+assertDeepEqual(
+  tailscale.parseServices({
+    CurrentTailnet: { MagicDNSSuffix: 'tail32f559.ts.net' },
+    Self: { CapMap: { 'services/web': [{ Name: 'svc:constructor', Ports: ['tcp:443'] }] } }
+  }).map(service => service.Name),
+  ['constructor'],
+  'tailscale keeps a service whose name collides with an object member'
+)
+
+const probeCommand = tailscale.serviceProbeCommand([
+  { Url: 'https://docs.tail32f559.ts.net/' },
+  { Url: 'https://wiki.tail32f559.ts.net/' }
+])
+
+assert(probeCommand.indexOf('--noproxy') !== -1 && probeCommand.indexOf('--disable') !== -1, 'tailscale probes services without proxies or ~/.curlrc')
+assert(probeCommand.indexOf('--proto') !== -1 && probeCommand.indexOf('=https') !== -1, 'tailscale probes services over HTTPS only')
+assert(probeCommand.indexOf('--location') === -1, 'tailscale does not follow redirects out of the tailnet while probing')
+assertEqual(
+  probeCommand.filter(argument => argument === '--output').length,
+  2,
+  'tailscale gives every probed URL its own output sink so bodies stay out of the report'
+)
+assertDeepEqual(tailscale.serviceProbeCommand([]), [], 'tailscale runs no probe without services')
+
+const probes = tailscale.parseProbeResults(
+  'https://docs.tail32f559.ts.net/\t200\t0.014866\n' +
+  'https://wiki.tail32f559.ts.net/\t401\t1.5\n' +
+  'https://chat.tail32f559.ts.net/\t000\t0.001\n' +
+  'truncated line without fields\n'
+)
+
+assertEqual(probes['https://docs.tail32f559.ts.net/'].latencyMs, 15, 'tailscale reports probe latency in whole milliseconds')
+assert(probes['https://wiki.tail32f559.ts.net/'].reachable, 'tailscale counts an authenticated service as reachable')
+assert(!probes['https://chat.tail32f559.ts.net/'].reachable, 'tailscale counts a service that never answered as unreachable')
+assertEqual(Object.keys(probes).length, 3, 'tailscale ignores probe output it cannot parse')
+
+const rows = tailscale.serviceRows(withServices.services, probes)
+
+assertDeepEqual(rows.map(row => row.Reachable), [false, true, true], 'tailscale joins probe results onto the service rows')
+assertEqual(rows[1].Code, 200, 'tailscale keeps the probe status code for the row')
+assertEqual(tailscale.reachableServiceCount(rows), 2, 'tailscale counts the reachable services')
+assert(!tailscale.serviceRows(withServices.services, {})[0].Probed, 'tailscale marks services as unprobed until the first probe lands')
+
+assert(/function services\(\): string/.test(panelSource), 'tailscale exposes the service summary over IPC')
+assert(/text: "SERVICES"/.test(panelSource), 'tailscale panel renders a services section')
 
 assertDeepEqual(tailscale.parseStatus('{'), { ok: false, unavailable: true, message: 'Status error', error: 'Failed to parse tailscale status' }, 'tailscale reports invalid status JSON')
 assertDeepEqual(tailscale.parseAccounts('{'), { accounts: [], selectedAccountId: '', selectedAccountLabel: '' }, 'tailscale handles invalid account JSON')


### PR DESCRIPTION
Two commits: the first binds the `r` refresh the panel's README has always
documented but nothing implemented, the second is the feature below.

The Tailscale panel answers "which machines do I have", but never "is the thing
I actually open still up". A tailnet can advertise services — `svc:docs`,
`svc:wiki` — that resolve inside it, and the panel had no idea they existed.

This adds a second tab listing them: the URL, the machine currently answering
for it, and the result of a reachability probe. Clicking a row opens it in the
browser.

## Nothing to configure

The tab exists only while the tailnet advertises services to this node. A
tailnet without them sees the panel it always had — no chips, no section, and
no probe ever runs. There is no setting because there is no decision to make:
the tailnet already answered the question.

## Where the data comes from

`tailscale status --json` already carries the services in the node's capability
map, and the panel already polls it for the machine list — so listing them
costs no second daemon call. Only reachability needs asking, and that is one
`curl` checking every URL in parallel.

Probing follows the panel: with it open the probe rides each status refresh;
with it closed, at most every five minutes, which is all the bar icon's dot
needs. The dot appears only when an advertised service is not answering, so an
unmarked icon still means there is nothing to look at.

## Notes for review

- `curl` exits non-zero as soon as any single transfer fails and still reports
  every URL it tried, so the probe reads its output rather than its exit
  status: one unreachable service is a row to colour red, not a failed probe.
- Every probe flag is a refusal — no `~/.curlrc`, no proxy, no plaintext, no
  redirects, no credentials, no unbounded wait — because it runs unattended on
  a timer against whatever the tailnet advertises.
- A service name becomes a DNS label in a URL the panel opens, so a name that
  is not a valid label is skipped rather than turned into a URL.
- Discovery, the probe command, its output parsing and the row join are pure
  functions in `Model.js`, so the whole feature is testable without a tailnet.

## Testing

- `test/shell.d/tailscale-test.sh` passes, with new assertions covering
  discovery, host selection, the probe command's flags, probe parsing and the
  join.
- Verified live against a tailnet with three advertised services: both tabs,
  keyboard switching, and the degraded state (one service answering 502,
  another with no current host).
- Checked the states that only look right by accident: an unprobed row is
  neutral rather than red, and the bar dot stays down until a probe has
  actually come back.
- Verified with discovery stubbed out that a tailnet advertising no services
  renders exactly the panel that shipped before — no tabs, no section, no
  probe.

## Credit

The discovery approach — reading the `services/` capabilities, filtering to
`tcp:443`, and matching a service's addresses against peers' `PrimaryRoutes` —
comes from [digitalbase/omarchy-tailscale-services](https://github.com/digitalbase/omarchy-tailscale-services)
(MIT), a third-party bar widget that shows this in a panel of its own. The
implementation here is written from scratch to fit `Model.js` and the existing
status poll, but the credit for working out where the data lives belongs there.

## Preview

<img width="480" height="462" alt="tailscale-services-tab" src="https://github.com/user-attachments/assets/77102b73-3678-45d5-b8a0-ab01946fa8b1" />
