### PR TITLE
Prevent infinite loop when parsing Lua binds with ipairs

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -186,7 +186,10 @@ end
 
 local noop
 noop = setmetatable({}, {
-  __index = function()
+  __index = function(t, key)
+    if type(key) == "number" then
+      return nil
+    end
     return noop
   end,
   __call = function()
@@ -219,6 +222,9 @@ hl = setmetatable({
   end,
   get_config = function()
     return nil
+  end,
+  get_loaded_plugins = function()
+    return {}
   end,
 }, {
   __index = function()

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -220,3 +220,19 @@ for action in "${expected_alternatives[@]}"; do
     fail "every action named as having an alternative is bound twice" "$action"
 done
 pass "every action named as having an alternative is bound twice"
+
+# Configs or plugins may iterate over hl.get_loaded_plugins() or mock tables
+# with ipairs; the parser mock must not enter an infinite loop.
+cat >>"$home/.config/hypr/bindings.lua" <<'LUA'
+local plugins = hl.get_loaded_plugins()
+for _, p in ipairs(plugins) do
+  -- should terminate immediately
+end
+for _, v in ipairs(hl.unknown_table()) do
+  -- should terminate immediately
+end
+LUA
+
+rendered=$(keybindings)
+[[ -n $rendered ]] || fail "the keybindings menu renders with ipairs iteration in config"
+pass "the keybindings menu parses configs using ipairs on Hyprland mocks without hanging"


### PR DESCRIPTION
### Problem
When `omarchy-menu-keybindings` parses user configuration (`~/.config/hypr/hyprland.lua`) to build the Lua bind cache, it creates a mock Hyprland table (`hl`) where any unhandled property or invocation resolves to a dummy `noop` object.

Because `noop`'s `__index` metamethod unconditionally returns `noop` for all keys, any access with numeric indices (e.g. `noop[1]`, `noop[2]`, ...) evaluates to `noop` (truthy) rather than `nil`.

If any user or plugin configuration iterates over mock tables or functions using `ipairs` (for example, `for _, p in ipairs(hl.get_loaded_plugins()) do ... end`), `ipairs` never encounters `nil`, producing an infinite loop. This peggs the CPU core at 100% and leaves the parent menu bash process hanging on the pipe waiting for EOF. Repeated presses of the keybinding spawn multiple spinning processes until all CPU cores reach 100%.

### Solution
1. In `bin/omarchy-menu-keybindings`, update `noop`'s `__index` to return `nil` when the key is a number (`type(key) == "number"`). This ensures standard `ipairs` iterations immediately terminate after checking index 1.
2. Provide `hl.get_loaded_plugins = function() return {} end` in the mock table so that scripts calling Hyprland's `hl.get_loaded_plugins()` receive an empty table as expected in a non-compositor scanning context.
3. Added a regression test in `test/shell.d/keybindings-menu-test.sh` verifying that configurations using `ipairs` over Hyprland mocks parse without hanging.

### Verification
- Ran `./test/shell.d/keybindings-menu-test.sh` (passes cleanly including the new regression test).
- Ran `./test/cli` (passes all tests).