### PR TITLE
Skip opening an empty scratchpad on Super+S

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -25,9 +25,32 @@ for workspace = 1, 10 do
   o.bind("SUPER + SHIFT + ALT + " .. key, "Move window silently to workspace " .. workspace, hl.dsp.window.move({ workspace = tostring(workspace), follow = false }))
 end
 
-o.bind("SUPER + S", "Toggle scratchpad", hl.dsp.workspace.toggle_special("scratchpad"))
+-- Opening an empty special workspace steals the next spawn onto it (#10415).
+-- Skip the open when the scratchpad has nothing to show; always allow close.
+local function is_scratchpad(workspace)
+  if not workspace then
+    return false
+  end
+  local name = workspace.name or workspace.config_name or ""
+  return name == "special:scratchpad" or name == "scratchpad"
+end
+
+local function toggle_scratchpad()
+  local special = hl.get_active_special_workspace()
+  if is_scratchpad(special) then
+    hl.dispatch(hl.dsp.workspace.toggle_special("scratchpad"))
+    return
+  end
+
+  local scratchpad = hl.get_workspace("special:scratchpad")
+  if scratchpad and (scratchpad.windows or 0) > 0 then
+    hl.dispatch(hl.dsp.workspace.toggle_special("scratchpad"))
+  end
+end
+
+o.bind("SUPER + S", "Toggle scratchpad", toggle_scratchpad)
 o.bind("SUPER + ALT + S", "Move window to scratchpad", hl.dsp.window.move({ workspace = "special:scratchpad", follow = false }))
-o.bind("SUPER + grave", "Toggle scratchpad", hl.dsp.workspace.toggle_special("scratchpad"))
+o.bind("SUPER + grave", "Toggle scratchpad", toggle_scratchpad)
 o.bind("SUPER + SHIFT + grave", "Move window to scratchpad", hl.dsp.window.move({ workspace = "special:scratchpad", follow = false }))
 
 o.bind("SUPER + TAB", "Next workspace", hl.dsp.focus({ workspace = "e+1" }))

--- a/test/shell.d/scratchpad-toggle-test.sh
+++ b/test/shell.d/scratchpad-toggle-test.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command lua
+
+# SUPER+S used to always toggle special:scratchpad. Opening it empty steals the
+# next spawn onto the special workspace (#10415). The bind must open only when
+# the scratchpad already has windows, and must always close when it is showing.
+OMARCHY_PATH="$ROOT" lua - <<'LUA' || fail "empty scratchpad toggle stays closed"
+local dispatched = {}
+local workspaces = {}
+local active_special = nil
+local toggle_fn = nil
+
+local function proxy()
+  return setmetatable({}, {
+    __index = function(self, key)
+      local value = proxy()
+      rawset(self, key, value)
+      return value
+    end,
+    __call = function()
+      return { kind = "dsp" }
+    end,
+  })
+end
+
+hl = {
+  dsp = proxy(),
+  dispatch = function(action)
+    table.insert(dispatched, action)
+  end,
+  bind = function(keys, dispatcher, opts)
+    opts = opts or {}
+    if opts.description == "Toggle scratchpad" then
+      assert(type(dispatcher) == "function", "toggle scratchpad bind must be a function")
+      toggle_fn = dispatcher
+    end
+  end,
+  get_active_special_workspace = function()
+    return active_special
+  end,
+  get_workspace = function(selector)
+    return workspaces[selector]
+  end,
+}
+
+-- Mark toggle_special calls so assertions can tell them apart from other dsp stubs.
+local real_toggle
+do
+  local workspace = hl.dsp.workspace
+  real_toggle = function(name)
+    assert(name == "scratchpad", "toggle targets scratchpad, got " .. tostring(name))
+    return { kind = "toggle_special", name = name }
+  end
+  workspace.toggle_special = real_toggle
+end
+
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+require("default.hypr.helpers")
+require("default.hypr.bindings.tiling")
+
+assert(toggle_fn, "SUPER+S / grave bind the toggle function")
+
+local function run_toggle()
+  dispatched = {}
+  toggle_fn()
+  return dispatched
+end
+
+-- Case 1: scratchpad does not exist yet — no-op (nothing to show).
+workspaces = {}
+active_special = nil
+local got = run_toggle()
+assert(#got == 0, "missing scratchpad does not open: dispatched " .. #got)
+
+-- Case 2: scratchpad exists but is empty — no-op.
+workspaces["special:scratchpad"] = {
+  name = "special:scratchpad",
+  windows = 0,
+  special = true,
+}
+got = run_toggle()
+assert(#got == 0, "empty scratchpad does not open: dispatched " .. #got)
+
+-- Case 3: scratchpad has windows and is closed — open it.
+workspaces["special:scratchpad"] = {
+  name = "special:scratchpad",
+  windows = 2,
+  special = true,
+}
+got = run_toggle()
+assert(#got == 1 and got[1].kind == "toggle_special", "populated scratchpad opens")
+
+-- Case 4: scratchpad is already showing (even if windows hit 0 mid-close) — close it.
+active_special = {
+  name = "special:scratchpad",
+  windows = 0,
+  special = true,
+}
+got = run_toggle()
+assert(#got == 1 and got[1].kind == "toggle_special", "open empty scratchpad still closes")
+
+-- Case 5: bare name form still counts as the open scratchpad.
+active_special = {
+  name = "scratchpad",
+  windows = 1,
+  special = true,
+}
+got = run_toggle()
+assert(#got == 1 and got[1].kind == "toggle_special", "bare scratchpad name still closes")
+
+-- Case 6: a different special workspace is active — do not treat it as scratchpad open.
+active_special = {
+  name = "special:magic",
+  windows = 1,
+  special = true,
+}
+workspaces["special:scratchpad"] = {
+  name = "special:scratchpad",
+  windows = 0,
+  special = true,
+}
+got = run_toggle()
+assert(#got == 0, "other special workspace does not force a scratchpad open")
+
+-- Case 7: other special active, but scratchpad has windows — open scratchpad.
+workspaces["special:scratchpad"] = {
+  name = "special:scratchpad",
+  windows = 1,
+  special = true,
+}
+got = run_toggle()
+assert(#got == 1 and got[1].kind == "toggle_special", "populated scratchpad opens over another special")
+LUA
+pass "empty scratchpad toggle stays closed"
+
+# Static: both toggle chords share the guarded function, not a bare dispatcher.
+if grep -nE 'o\.bind\("SUPER \+ (S|grave)".*toggle_special' "$ROOT/default/hypr/bindings/tiling.lua" >/dev/null; then
+  fail "toggle chords must not bind bare toggle_special"
+fi
+grep -q 'toggle_scratchpad' "$ROOT/default/hypr/bindings/tiling.lua" ||
+  fail "tiling.lua defines toggle_scratchpad"
+pass "both toggle chords use the empty-guard function"


### PR DESCRIPTION
## Summary

Fixes #10415.

`SUPER + S` / `SUPER + grave` always ran `toggle_special("scratchpad")`. Opening an empty special workspace leaves it as the monitor's active special, so the next launch maps onto `special:scratchpad` instead of the visible workspace. The user sees an empty workspace while the new window is hidden in the scratchpad.

## Change

Guard both toggle chords in `default/hypr/bindings/tiling.lua`:

- If `special:scratchpad` is already showing, toggle it closed (even if empty).
- If it is not showing, open it only when it already has windows.
- An empty or missing scratchpad is a no-op.

Move-to-scratchpad chords are unchanged.

## Test plan

- [x] `bash test/shell.d/scratchpad-toggle-test.sh`
  - missing / empty scratchpad does not open
  - populated scratchpad opens
  - open scratchpad always closes (including bare `scratchpad` name form)
  - another special workspace does not force a scratchpad open
- [x] `bash test/shell.d/hyprland-binding-conflicts-test.sh`
- [x] `bash test/shell.d/hyprland-qconsole-test.sh`

```
ok - empty scratchpad toggle stays closed
ok - both toggle chords use the empty-guard function
```