### PR TITLE
Drop shift:both_capslock_cancel from default kb_options

### DIFF
--- a/config/hypr/input.lua
+++ b/config/hypr/input.lua
@@ -7,7 +7,7 @@
 --   input = {
 --     -- Use multiple keyboard layouts and switch between them with Left Alt + Right Alt.
 --     kb_layout = "us,dk,eu",
---     kb_options = "compose:caps,shift:both_capslock_cancel,grp:alts_toggle",
+--     kb_options = "compose:caps,grp:alts_toggle",
 --
 --     -- Use a specific keyboard variant if needed (e.g. intl for international keyboards).
 --     kb_variant = "intl",

--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -30,11 +30,14 @@ local vconsole = read_vconsole()
 
 local kb_layout = vconsole.XKBLAYOUT or "us"
 local kb_variant = vconsole.XKBVARIANT or ""
--- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
--- Both Shifts together is the usual home for it, but it's easy to hit by
--- accident while typing. The _cancel variant sets Caps Lock the same way and
--- releases it on the next lone Shift, so a misfire clears itself.
-local kb_options = "compose:caps,shift:both_capslock_cancel"
+-- CapsLock is the compose key (Multi_key). Do not pair that with
+-- shift:both_capslock_cancel: it puts Caps_Lock on level 2 of both Shift keys,
+-- and XWayland's core modifier map then treats Left Shift as lock (ShiftLock),
+-- so every X11 client latches into a permanently shifted state (#10545).
+-- Wayland clients evaluate xkb levels correctly, which is why this only shows
+-- up under XWayland. Leaving Caps without a Caps_Lock keysym is the trade-off
+-- documented in the manual; users who want Caps Lock move compose off Caps.
+local kb_options = "compose:caps"
 
 -- Hyprland resolves keybindings against the first entry in kb_layout, not the
 -- layout that's currently active, so Omarchy's Latin-keysym bindings (SUPER + W

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -9,7 +9,7 @@ hl.config({
   input = {
     -- Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
     kb_layout = "us,dk",
-    kb_options = "compose:caps,shift:both_capslock_cancel,grp:alts_toggle",
+    kb_options = "compose:caps,grp:alts_toggle",
 
     -- Change speed of keyboard repeat
     repeat_rate = 40,
@@ -68,7 +68,7 @@ On some keyboards, it's not convenient to use the primary meta key (Windows/cmd 
 ```lua
 hl.config({
   input = {
-    kb_options = "compose:caps,shift:both_capslock_cancel,altwin:swap_alt_win",
+    kb_options = "compose:caps,altwin:swap_alt_win",
   },
 })
 ```

--- a/manual/45-troubleshooting.md
+++ b/manual/45-troubleshooting.md
@@ -22,6 +22,10 @@ hl.config({
 })
 ```
 
+### Left Shift locks uppercase (and symbols) in X11 / XWayland apps
+
+Older Omarchy defaults paired `compose:caps` with `shift:both_capslock_cancel`. That places `Caps_Lock` on level 2 of both Shift keys. Wayland clients handle it correctly; XWayland's core modifier map does not, so Left Shift becomes a locking key. Drop `shift:both_capslock*` from `kb_options` in `~/.config/hypr/input.lua` (keep `compose:caps` if you still want Caps as compose), then `hyprctl reload`. If you use fcitx5, restart it too so its virtual keyboard picks up the new map.
+
 ### My Wi-Fi, Bluetooth, audio, or trackpad just stopped working
 
 Before you reboot, try restarting the offending subsystem on its own. _Update > Hardware_ in the Omarchy menu has Wi-Fi, Bluetooth, Audio, and Trackpad, and reloading one of those clears up the majority of "it worked five minutes ago" situations — a Bluetooth headset that won't reconnect, a trackpad that went dead after a suspend, sound that vanished when you unplugged a monitor.

--- a/manual/46-faq.md
+++ b/manual/46-faq.md
@@ -9,7 +9,7 @@ hl.config({
   input = {
     -- Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
     kb_layout = "us,fr",
-    kb_options = "compose:caps,shift:both_capslock_cancel,grp:alts_toggle",
+    kb_options = "compose:caps,grp:alts_toggle",
   },
 })
 ```

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -55,8 +55,16 @@ assert_input() {
   pass "$description"
 }
 
-base_options="compose:caps,shift:both_capslock_cancel"
+base_options="compose:caps"
 toggle_options="$base_options,grp:alts_toggle"
+
+# shift:both_capslock_cancel must stay out of the default options: it places
+# Caps_Lock on level 2 of both Shift keys, and XWayland then maps Left Shift to
+# the lock modifier (#10545).
+if grep -Eq 'kb_options = ".*shift:both_capslock' "$ROOT/default/hypr/input.lua"; then
+  fail "default kb_options must not use shift:both_capslock*"
+fi
+pass "default kb_options omit shift:both_capslock*"
 
 assert_input "missing vconsole.conf falls back to us" "[us] [] [$base_options]"
 assert_input "us layout passes through" "[us] [intl] [$base_options]" 'XKBLAYOUT=us
@@ -83,3 +91,30 @@ lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$input_lua" | grep -o '
 [[ $hooks_layouts == "$lua_layouts" ]] ||
   fail "non-latin layout lists stay in sync" "$(diff <(echo "$hooks_layouts") <(echo "$lua_layouts"))"
 pass "non-latin layout lists stay in sync with the initramfs hook"
+
+# Real xkb map: with compose:caps alone, both Shift keys stay Shift-only. The
+# old shift:both_capslock_cancel pair put Caps_Lock on level 2 of <LFSH>/<RTSH>.
+if command -v xkbcli >/dev/null; then
+  map=$(xkbcli compile-keymap --layout us --options "$base_options" 2>/dev/null) ||
+    fail "xkbcli compiles the default kb_options"
+
+  lfsh=$(awk '/key <LFSH>/,/};/' <<<"$map")
+  rtsh=$(awk '/key <RTSH>/,/};/' <<<"$map")
+  caps=$(awk '/key <CAPS>/,/};/' <<<"$map")
+
+  [[ $lfsh == *Shift_L* ]] || fail "Left Shift keeps Shift_L" "$lfsh"
+  [[ $lfsh != *Caps_Lock* ]] || fail "Left Shift must not carry Caps_Lock" "$lfsh"
+  [[ $rtsh == *Shift_R* ]] || fail "Right Shift keeps Shift_R" "$rtsh"
+  [[ $rtsh != *Caps_Lock* ]] || fail "Right Shift must not carry Caps_Lock" "$rtsh"
+  [[ $caps == *Multi_key* ]] || fail "Caps Lock stays Multi_key (compose)" "$caps"
+  pass "xkb map keeps Shift pure under compose:caps"
+
+  broken=$(xkbcli compile-keymap --layout us --options 'compose:caps,shift:both_capslock_cancel' 2>/dev/null) ||
+    fail "xkbcli compiles the legacy broken options for contrast"
+  broken_lfsh=$(awk '/key <LFSH>/,/};/' <<<"$broken")
+  [[ $broken_lfsh == *Caps_Lock* ]] ||
+    fail "contrast: legacy options still put Caps_Lock on Left Shift" "$broken_lfsh"
+  pass "legacy shift:both_capslock_cancel still demonstrates the XWayland trap"
+else
+  pass "xkbcli not installed; skipped keymap shape checks"
+fi


### PR DESCRIPTION
## Summary

Fixes #10545.

Default `kb_options` were `compose:caps,shift:both_capslock_cancel`. The second option puts `Caps_Lock` on level 2 of both Shift keys. Wayland clients evaluate xkb levels correctly; XWayland's core modifier map does not, so Left Shift is assigned to `lock` and every X11 client treats a single Shift tap as ShiftLock (letters and digits stay shifted until Shift is pressed again).

## Change

- Default `kb_options` is now `compose:caps` only (still appends `grp:alts_toggle` for non-Latin layouts).
- Caps Lock remains the compose key (documented Omarchy behaviour).
- Caps Lock is not restored onto the Shift keys; users who want Caps Lock move compose off Caps, as the manual already describes.
- Manual examples, FAQ, user `config/hypr/input.lua` comments, and troubleshooting updated.
- Troubleshooting notes the upgrade path for configs that still carry the old pair.

## Test plan

- [x] `bash test/shell.d/hyprland-keyboard-layout-test.sh`
  - layout resolution still green
  - default options omit `shift:both_capslock*`
  - `xkbcli` map: `<LFSH>`/`<RTSH>` stay Shift-only; `<CAPS>` stays `Multi_key`
  - legacy option pair still shows `Caps_Lock` on Left Shift (contrast)

```
ok - default kb_options omit shift:both_capslock*
ok - xkb map keeps Shift pure under compose:caps
ok - legacy shift:both_capslock_cancel still demonstrates the XWayland trap
```

After merge, users with a personal `kb_options` that still includes `shift:both_capslock_cancel` should drop it and reload (restart fcitx5 if used).