### PR TITLE
Match the class the standalone Battle.net install produces

### DIFF
--- a/default/hypr/apps/battlenet.lua
+++ b/default/hypr/apps/battlenet.lua
@@ -1,7 +1,13 @@
--- Battle.net launches under Proton; all its windows share class steam_app_battlenet.
+-- Battle.net installs standalone under umu-launcher (bin/omarchy-install-gaming-battlenet),
+-- so the launcher and each game get their own class: the launcher is battle.net.exe, the
+-- installer battle.net-setup.exe. default/applications/battlenet.desktop already records
+-- this as StartupWMClass=battle.net.exe.
 
--- The actual launcher: float-centered.
-o.window({ class = "^steam_app_battlenet$", title = "^Battle\\.net$" }, {
+-- The actual launcher: float-centered. Matched on class alone, because a window rule is
+-- applied when the window is mapped and the launcher maps with the title "Battle.net Login",
+-- only becoming "Battle.net" after sign-in. Its dialogs (folder pickers, updates) share the
+-- class and are better floated too.
+o.window({ class = "^battle\\.net\\.exe$" }, {
   float = true,
   center = true,
   size = { 1280, 800 },
@@ -9,7 +15,9 @@ o.window({ class = "^steam_app_battlenet$", title = "^Battle\\.net$" }, {
 
 -- Installer: drop decorations and backdrop blur/shadow so the Blizzard chrome
 -- isn't framed by the WM.
-o.window({ class = "^steam_app_battlenet$", title = "^Battle\\.net Setup$" }, {
+o.window({ class = "^battle\\.net-setup\\.exe$" }, {
+  float = true,
+  center = true,
   decorate = false,
   no_blur = true,
   no_shadow = true,

--- a/test/shell.d/battlenet-test.sh
+++ b/test/shell.d/battlenet-test.sh
@@ -12,3 +12,19 @@ grep -F '$OMARCHY_PATH/default/applications/battlenet.desktop' "$install_script"
   fail "Battle.net installer installs the launcher from the installer-only template"
 
 pass "Battle.net launcher is only installed by the Battle.net installer"
+
+# The window rules must match the class the standalone install actually produces.
+# battlenet.lua used to key on steam_app_battlenet, a class only a Steam-hosted
+# install would have, so none of its rules ever applied to Omarchy's own installer.
+rules="$ROOT/default/hypr/apps/battlenet.lua"
+desktop="$ROOT/default/applications/battlenet.desktop"
+
+wm_class=$(sed -n 's/^StartupWMClass=//p' "$desktop")
+[[ -n $wm_class ]] || fail "battlenet.desktop declares StartupWMClass"
+
+grep -F "$wm_class" "$rules" >/dev/null ||
+  fail "battlenet.lua matches the class battlenet.desktop declares ($wm_class)"
+! grep -F 'steam_app_battlenet' "$rules" >/dev/null ||
+  fail "battlenet.lua no longer matches the Steam-hosted class"
+
+pass "Battle.net window rules match the class the installer produces"


### PR DESCRIPTION
## What happened

`default/hypr/apps/battlenet.lua` matches `class = "^steam_app_battlenet$"`, but Battle.net installed with `omarchy install gaming battlenet` produces `battle.net.exe` (launcher) and `battle.net-setup.exe` (installer). Omarchy's own `default/applications/battlenet.desktop` already records the right value — `StartupWMClass=battle.net.exe` — so the two shipped files disagree and none of these rules ever apply to Omarchy's own installer.

Measured on a fresh standalone install (Omarchy 4.0.2, Hyprland 0.56.2):

```
$ hyprctl clients -j | jq -r '.[] | select(.class|test("battle";"i")) | "class=\(.class) | title=\(.title) | float=\(.floating)"'
class=battle.net-setup.exe | title=Battle.net Setup | float=false
class=battle.net.exe       | title=Battle.net Login | float=false
class=battle.net.exe       | title=Battle.net       | float=false
class=battle.net.exe       | title=Select Folder    | float=false
```

Expected: the launcher floats centered at 1280x800 and the installer loses its decorations, blur and shadow. Actual: the launcher tiles into the current workspace, the Blizzard installer is framed by the WM, and the folder picker used by *Locate this game* tiles at column width, which is where it is genuinely unusable.

`[INFERENCE]` the `steam_app_battlenet` string looks like it predates the move to `umu-launcher`, or was written against a Steam-hosted install.

## Also removed: title predicates that cannot match

A window rule is applied when the window is mapped, and the launcher maps with the title `Battle.net Login`, only becoming `Battle.net` after sign-in — so `title = "^Battle\\.net$"` could not fire even with the class corrected. Matching on class alone is sufficient here, because in the standalone prefix the launcher owns that class by itself (games get their own, e.g. `wow.exe`), and it means the launcher's own dialogs — the folder picker, update prompts — float with it instead of tiling.

## Steps to reproduce

1. `omarchy install gaming battlenet` on a machine with no previous Battle.net.
2. Click through the Blizzard installer, sign in.
3. `hyprctl clients -j | jq -r '.[] | select(.class|test("battle";"i")) | .class'`
4. Observe `battle.net.exe` / `battle.net-setup.exe`, and that the launcher is tiled.

## Tests

`test/shell.d/battlenet-test.sh` gains a check that the rules match whatever `StartupWMClass` the desktop entry declares, and that the Steam-hosted class is gone, so the two files cannot drift apart again. Red before the change:

```
not ok - battlenet.lua matches the class battlenet.desktop declares (battle.net.exe)
```

Green after. `./test/all`: `test/shell` reports three failures on this checkout — `launch-about-test.sh`, `plymouth-set-test.sh`, `snapper-test.sh` — and all three fail identically on clean `main` here (they need a root-authorized checkout, an `omarchy-pkgs` checkout, and a live compositor respectively). No other suite regressed.

## System

Omarchy 4.0.2-1, Hyprland 0.56.2, Arch, AMD RX 7900 XTX, 3 monitors. Battle.net installed via `omarchy install gaming battlenet` (umu-launcher + GE-Proton), prefix `~/Games/battlenet`.