### PR TITLE
Unset browser LD_PRELOAD in yt-dlp native host

### DIFF
--- a/bin/omarchy-chromium-ytdlp-host
+++ b/bin/omarchy-chromium-ytdlp-host
@@ -15,6 +15,14 @@ export OMARCHY_PATH="${OMARCHY_PATH:-$(cd -- "$(dirname -- "$SCRIPT_PATH")/.." &
 # Make sure the Omarchy bin and yt-dlp are reachable when launched by the browser.
 export PATH="$OMARCHY_PATH/bin:/usr/local/bin:/usr/bin:$PATH"
 
+# Chromium-family browsers (Vivaldi proprietary codecs, some Chrome builds) inject
+# their bundled libffmpeg via LD_PRELOAD / VIVALDI_PRELOADS. The native-messaging
+# host inherits that environment, so yt-dlp's ffmpeg checks and our thumbnail
+# extraction load the browser's stub instead of system FFmpeg — avutil_configuration()
+# returns NULL and ffmpeg segfaults in strcmp during show_banner. Drop both so every
+# child (yt-dlp, ffmpeg) uses the system libraries.
+unset LD_PRELOAD VIVALDI_PRELOADS
+
 DOWNLOAD_DIR="${OMARCHY_YTDLP_DIR:-$HOME/Videos}"
 
 parse_url() {

--- a/test/shell.d/chromium-ytdlp-test.sh
+++ b/test/shell.d/chromium-ytdlp-test.sh
@@ -63,6 +63,20 @@ host_fn() {
   ' bash "$ROOT/bin/omarchy-chromium-ytdlp-host" "$@"
 }
 
+# Sourcing the host must clear browser codec preloads so ffmpeg/yt-dlp never load
+# a bundled libffmpeg stub (issue #10469).
+preload_check=$(
+  LD_PRELOAD=/opt/vivaldi/libffmpeg.so VIVALDI_PRELOADS=/opt/vivaldi/libffmpeg.so \
+    OMARCHY_PATH="$ROOT" bash -c '
+      source "$1"
+      printf "LD_PRELOAD=%s\n" "${LD_PRELOAD-<unset>}"
+      printf "VIVALDI_PRELOADS=%s\n" "${VIVALDI_PRELOADS-<unset>}"
+    ' bash "$ROOT/bin/omarchy-chromium-ytdlp-host"
+)
+[[ $preload_check == $'LD_PRELOAD=<unset>\nVIVALDI_PRELOADS=<unset>' ]] ||
+  fail "yt-dlp native host unsets browser LD_PRELOAD and VIVALDI_PRELOADS" "$preload_check"
+pass "yt-dlp native host unsets browser LD_PRELOAD and VIVALDI_PRELOADS"
+
 download_dir="$TMPDIR/videos"
 mkdir -p "$download_dir" "$TMPDIR/outside"
 good_file="$download_dir/clip [id].mp4"


### PR DESCRIPTION
## Summary

Fixes #10469.

Chromium-family browsers (notably Vivaldi with proprietary media codecs) inject bundled `libffmpeg.so` via `LD_PRELOAD` / `VIVALDI_PRELOADS`. `omarchy-chromium-ytdlp-host` inherited that environment, so `yt-dlp`'s `ffmpeg -bsfs` capability check and the host's own thumbnail `ffmpeg` call loaded the browser stub. In Vivaldi's stub, `avutil_configuration()` returns `NULL` and `ffmpeg` segfaults in `strcmp` during `show_banner`, leaving downloaded streams unmerged.

This change unsets both variables at host startup so every child uses system FFmpeg.

## Test plan

- [x] `bash test/shell.d/chromium-ytdlp-test.sh` (includes new assertion that sourcing the host clears `LD_PRELOAD` and `VIVALDI_PRELOADS`)
- [ ] Manual: trigger an Omarchy yt-dlp download from Vivaldi with proprietary codecs enabled; confirm no `ffmpeg` coredump and that audio/video merge succeeds