### PR TITLE
Install qt5-wayland with Google Chrome on Wayland

### DIFF
--- a/bin/omarchy-install-browser
+++ b/bin/omarchy-install-browser
@@ -42,6 +42,10 @@ chromium)
 chrome)
   echo "Installing Chrome..."
   omarchy-pkg-aur-add google-chrome || exit 1
+  # Chrome ships libqt5_shim.so and loads Qt5 under QT_QPA_PLATFORM=wayland;xcb.
+  # Without qt5-wayland the Wayland platform plugin is missing and Chrome aborts
+  # in QGuiApplicationPrivate::createPlatformIntegration (issue #10488).
+  omarchy-pkg-add qt5-wayland || exit 1
 
   setup_chromium_policy_directory /etc/opt/chrome/policies/managed
   copy_chromium_flags ~/.config/chrome-flags.conf

--- a/migrations/1788743895.sh
+++ b/migrations/1788743895.sh
@@ -1,0 +1,10 @@
+echo "Install qt5-wayland so Google Chrome can start under Wayland"
+
+# Chrome's libqt5_shim.so needs the Qt5 Wayland platform plugin. Omarchy sets
+# QT_QPA_PLATFORM=wayland;xcb globally, and without qt5-wayland Chrome aborts
+# at startup (issue #10488). Only pull it in when Chrome is already present so
+# machines that never installed Chrome stay free of the Qt5 stack.
+
+if omarchy-pkg-present google-chrome || omarchy-cmd-present google-chrome-stable; then
+  omarchy-pkg-add qt5-wayland
+fi

--- a/test/shell.d/install-browser-chrome-qt5-wayland-test.sh
+++ b/test/shell.d/install-browser-chrome-qt5-wayland-test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Chrome install must pull qt5-wayland so libqt5_shim can find the Wayland
+# platform plugin under Omarchy's QT_QPA_PLATFORM=wayland;xcb (issue #10488).
+
+require_command rg
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+home_dir="$test_tmp/home"
+pkg_log="$test_tmp/pkg.log"
+mkdir -p "$mock_bin" "$home_dir/.config"
+
+cat >"$mock_bin/omarchy-pkg-aur-add" <<'SH'
+#!/bin/bash
+printf 'aur:%s\n' "$*" >>"$OMARCHY_TEST_PKG_LOG"
+SH
+
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg:%s\n' "$*" >>"$OMARCHY_TEST_PKG_LOG"
+SH
+
+for stub in \
+  omarchy-install-chromium-copy-url \
+  omarchy-install-chromium-ytdlp \
+  omarchy-theme-set-browser; do
+  cat >"$mock_bin/$stub" <<'SH'
+#!/bin/bash
+exit 0
+SH
+done
+
+# browser-policy helpers need a writable destination; the real helper may call
+# sudo, so stub the policy directory setup path via a no-op sourced helper by
+# shadowing the install script's sourced file is hard — instead provide a
+# minimal browser_policy_setup_dir in a fake OMARCHY_PATH tree.
+fake_root="$test_tmp/omarchy"
+mkdir -p "$fake_root/install/helpers" "$fake_root/bin" "$fake_root/config"
+cp "$ROOT/bin/omarchy-install-browser" "$fake_root/bin/omarchy-install-browser"
+cp "$ROOT/config/chromium-flags.conf" "$fake_root/config/chromium-flags.conf"
+
+cat >"$fake_root/install/helpers/browser-policy.sh" <<'SH'
+# Policy dirs live under /etc; the install under test only needs the helper to
+# succeed so we can assert package selection, not root filesystem writes.
+browser_policy_setup_dir() {
+  :
+}
+browser_policy_setup_firefox_distribution() {
+  :
+}
+SH
+
+chmod +x "$mock_bin"/* "$fake_root/bin/omarchy-install-browser"
+
+: >"$pkg_log"
+HOME="$home_dir" PATH="$mock_bin:/usr/bin:/bin" OMARCHY_PATH="$fake_root" \
+  OMARCHY_TEST_PKG_LOG="$pkg_log" \
+  bash "$fake_root/bin/omarchy-install-browser" chrome >/dev/null
+
+grep -Fx 'aur:google-chrome' "$pkg_log" >/dev/null ||
+  fail "chrome install still adds google-chrome" "$(cat "$pkg_log")"
+grep -Fx 'pkg:qt5-wayland' "$pkg_log" >/dev/null ||
+  fail "chrome install adds qt5-wayland for libqt5_shim under Wayland" "$(cat "$pkg_log")"
+pass "chrome install adds qt5-wayland for libqt5_shim under Wayland"
+
+# Chromium does not ship libqt5_shim and must not pull the Qt5 stack.
+: >"$pkg_log"
+HOME="$home_dir" PATH="$mock_bin:/usr/bin:/bin" OMARCHY_PATH="$fake_root" \
+  OMARCHY_TEST_PKG_LOG="$pkg_log" \
+  bash "$fake_root/bin/omarchy-install-browser" chromium >/dev/null
+
+grep -Fx 'pkg:chromium' "$pkg_log" >/dev/null ||
+  fail "chromium install still adds chromium" "$(cat "$pkg_log")"
+grep -q 'qt5-wayland' "$pkg_log" &&
+  fail "chromium install must not pull qt5-wayland" "$(cat "$pkg_log")"
+pass "chromium install does not pull qt5-wayland"
+
+# Migration only installs qt5-wayland when Chrome is already present.
+migration="$ROOT/migrations/1788743895.sh"
+[[ -f $migration ]] || fail "qt5-wayland chrome migration exists"
+grep -F 'omarchy-pkg-add qt5-wayland' "$migration" >/dev/null ||
+  fail "qt5-wayland chrome migration installs the package"
+grep -F 'google-chrome' "$migration" >/dev/null ||
+  fail "qt5-wayland chrome migration gates on Chrome being present"
+pass "qt5-wayland chrome migration gates on Chrome being present"
+
+# Migration no-ops when Chrome is absent.
+: >"$pkg_log"
+cat >"$mock_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+exit 1
+SH
+cat >"$mock_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$mock_bin/omarchy-pkg-present" "$mock_bin/omarchy-cmd-present"
+
+HOME="$home_dir" PATH="$mock_bin:/usr/bin:/bin" OMARCHY_PATH="$ROOT" \
+  OMARCHY_TEST_PKG_LOG="$pkg_log" \
+  bash -euo pipefail "$migration" >/dev/null
+
+[[ ! -s $pkg_log ]] || fail "qt5-wayland migration is a no-op without Chrome" "$(cat "$pkg_log")"
+pass "qt5-wayland migration is a no-op without Chrome"
+
+# Migration installs when Chrome is present.
+: >"$pkg_log"
+cat >"$mock_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+[[ $1 == "google-chrome" ]]
+SH
+chmod +x "$mock_bin/omarchy-pkg-present"
+
+HOME="$home_dir" PATH="$mock_bin:/usr/bin:/bin" OMARCHY_PATH="$ROOT" \
+  OMARCHY_TEST_PKG_LOG="$pkg_log" \
+  bash -euo pipefail "$migration" >/dev/null
+
+grep -Fx 'pkg:qt5-wayland' "$pkg_log" >/dev/null ||
+  fail "qt5-wayland migration installs when Chrome is present" "$(cat "$pkg_log")"
+pass "qt5-wayland migration installs when Chrome is present"


### PR DESCRIPTION
## Summary

Fixes #10488.

Omarchy sets `QT_QPA_PLATFORM=wayland;xcb` globally (`default/hypr/envs.lua`). Google Chrome ships `libqt5_shim.so` and loads Qt5 during startup. Without `qt5-wayland`, `/usr/lib/qt/plugins/platforms/` has no Wayland plugin and Chrome aborts:

```
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
This application failed to start because no Qt platform plugin could be initialized.
```

`omarchy-install-browser chrome` installed only `google-chrome` and never pulled `qt5-wayland`. Omarchy already dropped the system Qt5 stack, so stock installs only have `qt6-wayland`.

### Change

- `bin/omarchy-install-browser`: after installing Chrome, `omarchy-pkg-add qt5-wayland`
- `migrations/1788743895.sh`: for existing Chrome installs only, install `qt5-wayland` (no-op when Chrome is absent so machines without Chrome stay free of Qt5)

## Evidence

### Bug reproduced (this machine / tree)

```
$ pacman -Q qt5-wayland
error: package 'qt5-wayland' was not found

$ pacman -Q qt6-wayland
qt6-wayland 6.11.2-1

$ ls /usr/lib/qt/plugins/platforms
# missing entirely

$ rg QT_QPA_PLATFORM default/hypr/envs.lua
hl.env("QT_QPA_PLATFORM", "wayland;xcb")
```

Pre-fix `omarchy-install-browser` chrome branch:

```
omarchy-pkg-aur-add google-chrome || exit 1
# no qt5-wayland
```

Reporter confirmed installing `qt5-wayland` alone made Chrome launch under Wayland.

### Fix validated

```
bash test/shell.d/install-browser-chrome-qt5-wayland-test.sh
ok - chrome install adds qt5-wayland for libqt5_shim under Wayland
ok - chromium install does not pull qt5-wayland
ok - qt5-wayland chrome migration gates on Chrome being present
ok - qt5-wayland migration is a no-op without Chrome
ok - qt5-wayland migration installs when Chrome is present
```

## Test plan

- [x] Controlled install harness: chrome path logs `pkg:qt5-wayland`
- [x] Chromium path does not pull qt5-wayland
- [x] Migration gated on Chrome presence
- [ ] Manual: `omarchy install browser chrome` on a machine without qt5-wayland, then launch Chrome under Wayland