### PR TITLE
Wake SDDM greeter displays on input and lid events

### DIFF
--- a/default/sddm/hyprland.lua
+++ b/default/sddm/hyprland.lua
@@ -1,13 +1,36 @@
 -- Minimal Hyprland config for the SDDM Wayland greeter.
 -- SDDM starts the greeter itself after the compositor is ready.
+--
+-- Keep this lean: no session shell, no autostart apps. The greeter still needs
+-- the same lid / DPMS behaviour the user session gets from input.lua and the
+-- lid binds in bindings/utilities.lua, otherwise a docked laptop that was left
+-- lid-closed after Log Out never wakes its external monitor on input
+-- (issue #10403).
+
 hl.config({
   misc = {
     disable_hyprland_logo = true,
     disable_splash_rendering = true,
     force_default_wallpaper = 0,
+    -- Match default/hypr/input.lua so a blanked external display comes back on
+    -- mouse or keyboard without forcing the lid open/close cycle.
+    key_press_enables_dpms = true,
+    mouse_move_enables_dpms = true,
   },
 
   animations = {
     enabled = false,
   },
 })
+
+-- Reconcile internal vs external outputs the same way the session does. Call
+-- clamshell directly (not omarchy-system-lid-close): the greeter must not try
+-- to lock a session that does not exist.
+local clamshell = hl.dsp.exec_cmd("omarchy-hyprland-monitor-clamshell")
+hl.bind("switch:on:Lid Switch", clamshell, { locked = true })
+hl.bind("switch:off:Lid Switch", clamshell, { locked = true })
+
+-- Lid may already be closed when the greeter starts after Log Out.
+hl.on("hyprland.start", function()
+  hl.exec_cmd("omarchy-hyprland-monitor-clamshell")
+end)

--- a/test/shell.d/sddm-greeter-hyprland-test.sh
+++ b/test/shell.d/sddm-greeter-hyprland-test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# SDDM's greeter compositor must wake DPMS on input and reconcile lid/clamshell
+# the same way the user session does (issue #10403).
+
+greeter="$ROOT/default/sddm/hyprland.lua"
+[[ -f $greeter ]] || fail "packaged SDDM greeter Hyprland config exists"
+
+# Presence of the three session behaviours the greeter was missing.
+for needle in \
+  'key_press_enables_dpms = true' \
+  'mouse_move_enables_dpms = true' \
+  'switch:on:Lid Switch' \
+  'switch:off:Lid Switch' \
+  'omarchy-hyprland-monitor-clamshell'; do
+  grep -F "$needle" "$greeter" >/dev/null ||
+    fail "SDDM greeter Hyprland config includes $needle"
+done
+pass "SDDM greeter enables DPMS on input and binds lid to clamshell"
+
+# Must not pull the session lock path into the greeter (comments may name the
+# forbidden commands when explaining why they are avoided).
+code_only=$(grep -vE '^[[:space:]]*--' "$greeter" || true)
+if grep -E 'omarchy-system-lid-close|omarchy-system-lock|omarchy-launch-shell' <<<"$code_only" >/dev/null; then
+  fail "SDDM greeter must not lock a session or launch the shell" "$code_only"
+fi
+pass "SDDM greeter does not lock or launch the session shell"
+
+# Startup must reconcile once so a lid-closed Log Out is not stuck until the
+# next physical lid event.
+grep -F 'hyprland.start' "$greeter" >/dev/null ||
+  fail "SDDM greeter reconciles clamshell on hyprland.start"
+pass "SDDM greeter reconciles clamshell on hyprland.start"
+
+# Keep greeter config self-contained: no Omarchy bootstrap (helpers/o.bind).
+if grep -E 'require\(|o\.bind|default\.hypr' <<<"$code_only" >/dev/null; then
+  fail "SDDM greeter stays free of session bootstrap requires" "$code_only"
+fi
+pass "SDDM greeter stays free of session bootstrap requires"


### PR DESCRIPTION
## Summary

Fixes #10403.

SDDM's greeter runs a separate Hyprland via `/usr/share/sddm/hyprland.lua`. That config only turned off animations and the splash. Unlike the user session (`default/hypr/input.lua` + lid binds in `bindings/utilities.lua`) it never:

- set `key_press_enables_dpms` / `mouse_move_enables_dpms`
- bound `switch:on/off:Lid Switch`
- reconciled clamshell at greeter start

So after **Log Out** with the lid closed on a docked laptop, mouse/keyboard input could not wake the external monitor. Opening and closing the lid forced a fresh output probe and "fixed" it.

### Change

In `default/sddm/hyprland.lua`:

1. Enable DPMS-on-input (same flags as the session `input.lua`).
2. Bind both lid edges to `omarchy-hyprland-monitor-clamshell` (not `omarchy-system-lid-close`, which would try to lock a session that does not exist at the greeter).
3. Run clamshell once on `hyprland.start` so a lid already closed at greeter boot is reconciled without waiting for another lid event.

Config stays self-contained (no session bootstrap / `o.bind`).

## Evidence

### Bug reproduced (pre-fix tree)

`git show upstream/quattro:default/sddm/hyprland.lua` contained only splash/animation disables. Checks:

| behaviour | present |
|---|---|
| `key_press_enables_dpms` | no |
| `mouse_move_enables_dpms` | no |
| Lid Switch binds | no |
| clamshell / dpms | no |

Session reference that the greeter lacked:

- `default/hypr/input.lua`: `key_press_enables_dpms` / `mouse_move_enables_dpms`
- `default/hypr/bindings/utilities.lua`: lid → `omarchy-system-lid-close` / `omarchy-hyprland-monitor-clamshell`

### Fix validated

```
bash test/shell.d/sddm-greeter-hyprland-test.sh
ok - SDDM greeter enables DPMS on input and binds lid to clamshell
ok - SDDM greeter does not lock or launch the session shell
ok - SDDM greeter reconciles clamshell on hyprland.start
ok - SDDM greeter stays free of session bootstrap requires
```

## Test plan

- [x] Pre-fix greeter config audit (missing DPMS + lid)
- [x] `bash test/shell.d/sddm-greeter-hyprland-test.sh`
- [ ] Manual laptop: clamshell → Log Out with lid closed → mouse/keyboard wakes external monitor without opening the lid