### PR TITLE
Fall back to foot for Ghostty screensaver on fractional scale

### DIFF
--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -21,6 +21,23 @@ case $terminal in
   ;;
 esac
 
+# Ghostty freezes its GL surface after a large fullscreen resize on fractionally
+# scaled monitors (last pre-resize frame sticks; issue #10420). Foot is in the
+# base install and already has a screensaver config, so prefer it only for the
+# screensaver when any output is non-integer scale. Integer-scale Ghostty keeps
+# working and remains the default terminal everywhere else.
+monitors_have_fractional_scale() {
+  hyprctl monitors -j 2>/dev/null | jq -e '
+    any(.[]; (.scale | type == "number") and (.scale != (.scale | floor)))
+  ' >/dev/null 2>&1
+}
+
+if [[ $terminal == *ghostty* ]] && monitors_have_fractional_scale; then
+  if omarchy-cmd-present foot; then
+    terminal=foot
+  fi
+fi
+
 hypr_focus_monitor() {
   hyprctl dispatch "hl.dsp.focus({ monitor = \"$1\" })" >/dev/null 2>&1 || hyprctl dispatch focusmonitor "$1" >/dev/null
 }

--- a/test/shell.d/launch-screensaver-test.sh
+++ b/test/shell.d/launch-screensaver-test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Ghostty fullscreen freezes on fractional scale; the launcher must fall back to
+# foot for the screensaver only (issue #10420).
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+home_dir="$test_tmp/home"
+hypr_dir="$test_tmp/hypr"
+eval_log="$test_tmp/hyprctl-eval.log"
+mkdir -p "$stub_bin" "$home_dir" "$hypr_dir"
+
+# Minimal Hyprland event socket so wait_for_screensaver_window can open socat.
+# An empty FIFO never delivers openwindow events; the 5s deadline is too slow
+# for a unit test, so stub socat to close immediately (wait returns, loop ends).
+cat >"$stub_bin/socat" <<'SH'
+#!/bin/bash
+# Consume nothing and exit so the event reader hits EOF immediately.
+exit 0
+SH
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+case "$1" in
+monitors)
+  # OMARCHY_TEST_MONITORS_JSON is a full JSON array of monitors.
+  printf '%s\n' "${OMARCHY_TEST_MONITORS_JSON:?}"
+  ;;
+dispatch)
+  printf '%s\n' "$*" >>"$OMARCHY_TEST_HYPRCTL_LOG"
+  ;;
+*)
+  exit 1
+  ;;
+esac
+SH
+
+cat >"$stub_bin/xdg-terminal-exec" <<'SH'
+#!/bin/bash
+[[ $1 == "--print-id" ]] || exit 1
+printf '%s\n' "${OMARCHY_TEST_TERMINAL_ID:?}"
+SH
+
+cat >"$stub_bin/omarchy-hyprland-monitor-focused" <<'SH'
+#!/bin/bash
+printf '%s\n' "eDP-1"
+SH
+
+cat >"$stub_bin/omarchy-toggle-enabled" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$stub_bin/pgrep" <<'SH'
+#!/bin/bash
+# No screensaver already running.
+exit 1
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ $1 == "foot" ]] && exit "${OMARCHY_TEST_FOOT_PRESENT:-0}"
+exit 1
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_NOTIFY_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_launcher() {
+  : >"$eval_log"
+  HOME="$home_dir" \
+    PATH="$stub_bin:/usr/bin:/bin" \
+    OMARCHY_PATH="$ROOT" \
+    XDG_RUNTIME_DIR="$test_tmp" \
+    HYPRLAND_INSTANCE_SIGNATURE=test \
+    OMARCHY_TEST_HYPRCTL_LOG="$eval_log" \
+    OMARCHY_TEST_NOTIFY_LOG="$test_tmp/notify.log" \
+    OMARCHY_TEST_TERMINAL_ID="${1:?}" \
+    OMARCHY_TEST_MONITORS_JSON="${2:?}" \
+    OMARCHY_TEST_FOOT_PRESENT="${3:-0}" \
+    bash "$ROOT/bin/omarchy-launch-screensaver" >/dev/null 2>&1 || true
+}
+
+fractional='[{"name":"DP-1","scale":1.25},{"name":"eDP-1","scale":1}]'
+integer='[{"name":"DP-1","scale":2},{"name":"eDP-1","scale":1}]'
+
+# Ghostty + fractional scale → foot.
+run_launcher "com.mitchellh.ghostty" "$fractional" 0
+grep -E 'foot .*org\.omarchy\.screensaver' "$eval_log" >/dev/null ||
+  fail "ghostty on fractional scale launches foot screensaver" "$(cat "$eval_log")"
+grep -E 'ghostty ' "$eval_log" >/dev/null &&
+  fail "ghostty on fractional scale must not launch ghostty" "$(cat "$eval_log")"
+pass "ghostty on fractional scale launches foot screensaver"
+
+# Ghostty + integer scale → ghostty (no unnecessary fallback).
+run_launcher "com.mitchellh.ghostty" "$integer" 0
+grep -E 'ghostty .*org\.omarchy\.screensaver' "$eval_log" >/dev/null ||
+  fail "ghostty on integer scale keeps ghostty" "$(cat "$eval_log")"
+grep -E 'foot ' "$eval_log" >/dev/null &&
+  fail "ghostty on integer scale must not fall back to foot" "$(cat "$eval_log")"
+pass "ghostty on integer scale keeps ghostty"
+
+# Ghostty + fractional but foot missing → keep ghostty (best effort).
+run_launcher "com.mitchellh.ghostty" "$fractional" 1
+grep -E 'ghostty .*org\.omarchy\.screensaver' "$eval_log" >/dev/null ||
+  fail "ghostty fractional without foot still launches ghostty" "$(cat "$eval_log")"
+pass "ghostty fractional without foot still launches ghostty"
+
+# Foot default is unchanged on fractional scale.
+run_launcher "foot.desktop" "$fractional" 0
+grep -E 'foot .*org\.omarchy\.screensaver' "$eval_log" >/dev/null ||
+  fail "foot default still launches foot" "$(cat "$eval_log")"
+pass "foot default still launches foot"
+
+# Alacritty is never rewritten to foot.
+run_launcher "Alacritty" "$fractional" 0
+grep -E 'alacritty .*org\.omarchy\.screensaver' "$eval_log" >/dev/null ||
+  fail "alacritty on fractional scale keeps alacritty" "$(cat "$eval_log")"
+pass "alacritty on fractional scale keeps alacritty"


### PR DESCRIPTION
## Summary

Fixes #10420.

On fractionally scaled monitors, a large Ghostty fullscreen (or near-fullscreen) resize can leave the Omarchy screensaver as a solid theme-background rectangle until input dismisses it. Foot fullscreen on the same scale is fine, and foot is already in the base install with `default/foot/screensaver.ini`.

Reporter follow-up on the multi-GPU machine that hit this: Hyprland had selected a different primary render GPU than Ghostty, so every Ghostty frame arrived as a foreign dmabuf the compositor could not import (`eglCreateImageKHR ... EGL_BAD_MATCH`). On the large screensaver resize the new buffers never made it to the screen; foot is immune because it uses shared-memory buffers. Aligning GPUs via `AQ_DRM_DEVICES` fixed Ghostty there too — the foot fallback remains the safe Omarchy-side path regardless.

### Change

In `omarchy-launch-screensaver`, after resolving the default terminal:

- If the terminal is Ghostty **and** any Hyprland monitor has a non-integer `scale`, and `foot` is present → launch the screensaver with foot.
- Integer-scale Ghostty is unchanged.
- Other terminals are never rewritten.
- If foot is missing, Ghostty remains the best-effort path (no hard failure).

This does not change the user's default terminal for normal use — only the screensaver launcher path.

## Evidence

### Bug reproduced (pre-fix)

`bin/omarchy-launch-screensaver` always took the Ghostty branch when `xdg-terminal-exec --print-id` returned Ghostty. There was no fractional-scale check and no foot fallback:

```
*ghostty*)
  hypr_exec ghostty --class=org.omarchy.screensaver ...
```

Reporter isolation (issue body): Ghostty fullscreen freezes at scale 1.25; scale 1.00 is fine; foot fullscreen at 1.25 is fine. Follow-up: same blank frame under cross-GPU dmabuf import failure; foot shm path unaffected.

### Fix validated

```
bash test/shell.d/launch-screensaver-test.sh
ok - ghostty on fractional scale launches foot screensaver
ok - ghostty on integer scale keeps ghostty
ok - ghostty fractional without foot still launches ghostty
ok - foot default still launches foot
ok - alacritty on fractional scale keeps alacritty
```

## Test plan

- [x] Controlled harness: Ghostty + scale 1.25 → foot
- [x] Ghostty + integer scales → ghostty
- [x] Ghostty + fractional, foot missing → ghostty
- [x] Foot / Alacritty defaults unchanged
- [x] Manual (reporter): Ghostty default, Dell 4K @ 1.25, multi-GPU VM — foot path animates; GPU alignment also unblocks Ghostty