### PR TITLE
Bust plugin component URLs on hot-reload

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -110,7 +110,7 @@ or `omarchy.power`. There is no `bar` target.
 | `toggle <id> <payloadJson>`           | summon if closed, hide if open  |
 | `togglePanelAt <section> <index>`     | toggle the panel at a bar position |
 | `call <id> <method> <arg>`            | call an already-loaded plugin   |
-| `rescanPlugins`                       | re-walk plugin dirs and hot-reload plugin code |
+| `rescanPlugins`                       | re-walk plugin dirs and hot-reload plugin code (entry-point URLs are cache-busted so edited QML is re-read; a full `omarchy restart shell` is still the fallback if a reload looks stale) |
 | `reloadConfig`                        | reload shell.json               |
 | `applyTheme <colorsB64> <shellB64>`   | push theme colors + shell.toml  |
 | `toggleBarTransparency`               | flip the bar background between solid and transparent |

--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -23,6 +23,10 @@ QtObject {
   // { pluginId: manifest } — manifests have __sourceDir and __isFirstParty stamped in.
   property var installedPlugins: ({})
   property int registryRevision: 0
+  // Bumped on each plugin hot-reload so entryPointUrl values change. QML's Qt
+  // object does not expose QQmlEngine::clearComponentCache (issue #10568); a
+  // distinct URL is what forces Loaders / createComponent to re-read disk.
+  property int componentCacheEpoch: 0
   property bool scanning: false
   property string lastEnableError: ""
 
@@ -104,7 +108,13 @@ QtObject {
       console.warn("PluginRegistry: entry point escapes sourceDir: " + resolved)
       return ""
     }
-    return Util.fileUrl(resolved)
+    var url = Util.fileUrl(resolved)
+    // Cache-bust after hot-reload so the engine cannot reuse a stale component
+    // compiled from the previous file contents (see componentCacheEpoch).
+    if (componentCacheEpoch > 0) {
+      url += (url.indexOf("?") >= 0 ? "&" : "?") + "omarchyReload=" + componentCacheEpoch
+    }
+    return url
   }
 
   // Enabled = the plugin id is referenced somewhere in shell.json. That can

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -56,6 +56,8 @@ ShellRoot {
   property var shellConfig: builtinShellConfig
   property bool pluginReloading: false
   property bool pluginReloadPending: false
+  // One-shot notice that Qt.clearComponentCache is not a QML API (issue #10568).
+  property bool warnedMissingComponentCacheClear: false
 
   Timer {
     id: localPluginReloadTimer
@@ -781,7 +783,17 @@ ShellRoot {
       shell.pluginReloadPending = true
       return
     }
-    if (typeof Qt.clearComponentCache === "function") Qt.clearComponentCache()
+    // QQmlEngine::clearComponentCache is C++-only; the QML Qt object never
+    // exposes it (typeof is always "undefined", issue #10568). Advance the
+    // entry-point URL epoch so Loaders re-read plugin QML from disk instead of
+    // reusing the previous compiled component.
+    shell.pluginRegistry.componentCacheEpoch++
+    if (typeof Qt.clearComponentCache === "function") {
+      Qt.clearComponentCache()
+    } else if (!shell.warnedMissingComponentCacheClear) {
+      console.warn("Plugin hot-reload: Qt.clearComponentCache is unavailable on the QML Qt object; busting component URLs instead. If an edit still looks stale after reload, run: omarchy restart shell")
+      shell.warnedMissingComponentCacheClear = true
+    }
     shell.pluginRegistry.rescan()
   }
 

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -136,6 +136,16 @@ ShellRoot {
     root.assertEqual(registry.entryPointUrl(registry.installedPlugins["third.panel"], "panel"), "file:///third/panel/Panel.qml", "entryPointUrl resolves plugin-relative paths")
     root.assertEqual(registry.entryPointUrl(registry.installedPlugins["third.widget"], "barWidget"), "file:///third/widget/Widget.qml", "entryPointUrl resolves bar widget paths")
 
+    // Hot-reload cannot call QQmlEngine::clearComponentCache from QML
+    // (issue #10568). Bumping componentCacheEpoch must change entry-point
+    // URLs so Loaders re-read edited plugin sources instead of cached ones.
+    var beforeReload = registry.entryPointUrl(registry.installedPlugins["third.panel"], "panel")
+    registry.componentCacheEpoch = 1
+    var afterReload = registry.entryPointUrl(registry.installedPlugins["third.panel"], "panel")
+    root.assertTrue(afterReload !== beforeReload, "entryPointUrl changes after componentCacheEpoch advances")
+    root.assertTrue(afterReload.indexOf("omarchyReload=1") !== -1, "entryPointUrl carries the reload epoch as a query")
+    registry.componentCacheEpoch = 0
+
     root.assertTrue(!has("omarchy.reserved"), "third-party omarchy namespace ids are rejected")
     root.assertTrue(!has("third.unsafe"), "unsafe entry points are rejected")
     root.assertTrue(!has("third.missing"), "incomplete manifests are rejected")

--- a/test/shell.d/plugin-reload-cache-test.sh
+++ b/test/shell.d/plugin-reload-cache-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Plugin hot-reload must not rely solely on Qt.clearComponentCache — that API
+# is C++-only and is never a function on the QML Qt object (issue #10568).
+
+shell_qml="$ROOT/shell/shell.qml"
+registry_qml="$ROOT/shell/services/PluginRegistry.qml"
+
+[[ -f $shell_qml ]] || fail "shell.qml exists"
+[[ -f $registry_qml ]] || fail "PluginRegistry.qml exists"
+
+grep -F 'componentCacheEpoch' "$registry_qml" >/dev/null ||
+  fail "PluginRegistry tracks a componentCacheEpoch for URL cache-busting"
+grep -F 'omarchyReload=' "$registry_qml" >/dev/null ||
+  fail "entryPointUrl appends omarchyReload epoch query"
+pass "PluginRegistry cache-busts entryPointUrl on reload epoch"
+
+grep -F 'componentCacheEpoch++' "$shell_qml" >/dev/null ||
+  fail "finishPluginReload advances componentCacheEpoch before rescan"
+grep -F 'Qt.clearComponentCache is unavailable' "$shell_qml" >/dev/null ||
+  fail "finishPluginReload warns once when clearComponentCache is missing"
+pass "finishPluginReload advances epoch and warns when cache clear is missing"
+
+# Prove the QML Qt object still lacks clearComponentCache on this machine so
+# the bust path is not dead code relative to the runtime we ship against.
+require_command qml6
+probe=$(mktemp --suffix=.qml)
+trap 'rm -f "$probe"' EXIT
+cat >"$probe" <<'QML'
+import QtQuick
+Item {
+  Component.onCompleted: {
+    Qt.exit(typeof Qt.clearComponentCache === "function" ? 0 : 3)
+  }
+}
+QML
+set +e
+QT_QPA_PLATFORM=offscreen qml6 "$probe" >/dev/null 2>&1
+status=$?
+set -e
+(( status == 3 )) || fail "Qt.clearComponentCache remains unavailable on QML Qt object (exit=$status)"
+pass "Qt.clearComponentCache remains unavailable on QML Qt object"
+
+# Contract fixture must cover the epoch query behaviour.
+fixture="$ROOT/test/shell.d/fixtures/plugin-registry/shell.qml"
+grep -F 'componentCacheEpoch' "$fixture" >/dev/null ||
+  fail "plugin-registry fixture asserts entryPointUrl epoch cache-bust"
+pass "plugin-registry fixture asserts entryPointUrl epoch cache-bust"


### PR DESCRIPTION
## Summary

Fixes #10568.

`finishPluginReload` guarded plugin hot-reload with:

```qml
if (typeof Qt.clearComponentCache === "function") Qt.clearComponentCache()
```

`clearComponentCache` is a `QQmlEngine` C++ method and is **not** on the QML `Qt` object, so `typeof` is always `"undefined"`, the call never runs, and `rescan()` re-instantiates the previous compiled component. Plugin file edits looked like no-ops.

### Change

1. `PluginRegistry.componentCacheEpoch` — advanced on each hot-reload.
2. `entryPointUrl` appends `?omarchyReload=<epoch>` when the epoch is non-zero so Loader / `createComponent` URLs change and QML is re-read from disk.
3. `finishPluginReload` always bumps the epoch before `rescan()`, still calls `Qt.clearComponentCache` if a future Qt/Quickshell exposes it, and logs a one-shot WARN naming `omarchy restart shell` as fallback.
4. Docs: `rescanPlugins` note about cache-bust + restart fallback.

## Evidence

### Bug reproduced

```
$ QT_QPA_PLATFORM=offscreen qml6 /tmp/probe.qml ; echo exit=$?
# typeof Qt.clearComponentCache !== "function"
exit=3
```

Pre-fix `finishPluginReload` only cleared the cache inside that always-false guard.

### Fix validated

```
bash test/shell.d/plugin-reload-cache-test.sh
ok - PluginRegistry cache-busts entryPointUrl on reload epoch
ok - finishPluginReload advances epoch and warns when cache clear is missing
ok - Qt.clearComponentCache remains unavailable on QML Qt object
ok - plugin-registry fixture asserts entryPointUrl epoch cache-bust

bash test/shell.d/plugin-registry-contract-test.sh
ok - plugin registry contract checks pass
```

## Test plan

- [x] qml6 probe: `clearComponentCache` still absent on QML Qt
- [x] `plugin-reload-cache-test.sh`
- [x] `plugin-registry-contract-test.sh` (entryPointUrl epoch assertion)
- [ ] Manual: edit a local plugin QML, trigger reload / save, confirm new behaviour without full shell restart