### PR TITLE
Enable resolve_binds_by_sym for high XF86 keycodes

### DIFF
--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -57,6 +57,13 @@ hl.config({
     follow_mouse = 1,
     sensitivity = 0,
 
+    -- Hyprland defaults this to false and matches binds via keysym→keycode
+    -- reverse lookup. XF86TouchpadToggle sits at XKB keycode 538 (evdev 530),
+    -- above the classic 255 ceiling, so that reverse path never reaches it and
+    -- the stock XF86Touchpad* binds in bindings/media.lua stay dead (issue
+    -- #10449). Resolving by symbol matches those high keycodes.
+    resolve_binds_by_sym = true,
+
     repeat_rate = 40,
     repeat_delay = 250,
     numlock_by_default = true,

--- a/test/shell.d/resolve-binds-by-sym-test.sh
+++ b/test/shell.d/resolve-binds-by-sym-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Stock XF86Touchpad* binds need input:resolve_binds_by_sym (issue #10449).
+# Without it Hyprland's default false reverse-lookup never reaches keycode 538.
+
+require_command lua
+
+input_lua="$ROOT/default/hypr/input.lua"
+media_lua="$ROOT/default/hypr/bindings/media.lua"
+
+[[ -f $input_lua ]] || fail "default hypr input config exists"
+[[ -f $media_lua ]] || fail "default hypr media bindings exist"
+
+# Defaults must ship the option; a bare presence check is not enough — assert
+# the live hl.config table the session actually loads.
+resolved=$(
+  OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+
+io.open = function(path, mode)
+  if path == "/etc/vconsole.conf" then return nil end
+  return io.tmpfile()
+end
+
+hl = {
+  config = function(config)
+    local input = config.input or {}
+    if input.resolve_binds_by_sym == true then
+      print("resolve_binds_by_sym=true")
+    elseif input.resolve_binds_by_sym == false then
+      print("resolve_binds_by_sym=false")
+    else
+      print("resolve_binds_by_sym=missing")
+    end
+  end,
+}
+
+o = { window = function() end }
+
+require("default.hypr.input")
+LUA
+)
+
+[[ $resolved == "resolve_binds_by_sym=true" ]] ||
+  fail "default hypr input enables resolve_binds_by_sym" "actual: $resolved"
+pass "default hypr input enables resolve_binds_by_sym"
+
+# The media binds that depend on symbol resolution must still be present.
+for needle in XF86TouchpadToggle XF86TouchpadOn XF86TouchpadOff; do
+  grep -F "$needle" "$media_lua" >/dev/null ||
+    fail "media bindings still register $needle by keysym"
+done
+pass "media bindings still register XF86Touchpad* by keysym"
+
+# Comment must keep the issue pointer so a future drive-by drop is reviewed.
+grep -F '#10449' "$input_lua" >/dev/null ||
+  fail "input.lua documents issue #10449 next to resolve_binds_by_sym"
+pass "input.lua documents issue #10449 next to resolve_binds_by_sym"


### PR DESCRIPTION
## Summary

Fixes #10449.

Stock touchpad binds in `default/hypr/bindings/media.lua` register `XF86TouchpadToggle` / `On` / `Off`, but Hyprland defaults `input:resolve_binds_by_sym` to `false`. With that default, binds are matched through a keysym→keycode reverse lookup that does not reach XKB keycode 538 (evdev `KEY_TOUCHPAD_TOGGLE` = 530). The binds stay registered and dead.

Related open PR #10539 sets the same option without tests or the issue trail in-tree. This PR adds the default, documents why next to the option, and locks it with a shell test.

### Change

`default/hypr/input.lua`:

```lua
resolve_binds_by_sym = true,
```

## Evidence

### Bug reproduced (this machine, pre-change)

```
$ hyprctl getoption input:resolve_binds_by_sym
bool: false
set: false

$ hyprctl binds | rg -i Touchpad
key: XF86TouchpadToggle
key: XF86TouchpadOn
key: XF86TouchpadOff

$ rg resolve_binds_by_sym default/hypr/
# no hits — option never shipped
```

Binds present, option unset → default false → high XF86 keysyms never match (issue reporter also verified with `evtest` / notify probe).

### Fix validated

```
bash test/shell.d/resolve-binds-by-sym-test.sh
ok - default hypr input enables resolve_binds_by_sym
ok - media bindings still register XF86Touchpad* by keysym
ok - input.lua documents issue #10449 next to resolve_binds_by_sym

bash test/shell.d/hyprland-keyboard-layout-test.sh
# layout resolution still green
```

## Test plan

- [x] Live pre-fix: `resolve_binds_by_sym` false while Touchpad binds registered
- [x] `bash test/shell.d/resolve-binds-by-sym-test.sh`
- [x] `bash test/shell.d/hyprland-keyboard-layout-test.sh`
- [ ] Manual laptop: Fn touchpad hotkey toggles pad + OSD after reload