### PR TITLE
Silence fcitx5 startup layout tip notifications

### DIFF
--- a/default/systemd/user/omarchy-fcitx5.service
+++ b/default/systemd/user/omarchy-fcitx5.service
@@ -20,8 +20,12 @@ ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 Type=simple
-# notificationitem duplicates the tray entry omarchy already renders itself.
-ExecStart=/usr/bin/fcitx5 --disable notificationitem
+# notificationitem duplicates the tray entry Omarchy already renders itself.
+# notifications is the freedesktop tip channel the keyboard addon uses to announce
+# layout/IM changes on startup; Omarchy only runs fcitx5 for CapsLock compose
+# sequences, so those tips are noise (issue #10474). XKB override stays off via
+# config/fcitx5/conf/xcb.conf.
+ExecStart=/usr/bin/fcitx5 --disable notificationitem,notifications
 # always, not on-failure: fcitx5 exits 0 when it detects another instance owning
 # its bus name, and a clean exit still leaves the user with no input method.
 Restart=always

--- a/migrations/1788745469.sh
+++ b/migrations/1788745469.sh
@@ -1,0 +1,15 @@
+echo "Silence fcitx5 startup layout tip notifications"
+
+# The unit used to only disable notificationitem (tray duplicate). The keyboard
+# addon still fired freedesktop tips on layout/IM startup (issue #10474). The
+# packaged unit now disables notifications as well; reload so an already-enabled
+# user manager picks up the new ExecStart without waiting for the next login.
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+if systemctl --user is-enabled --quiet omarchy-fcitx5.service 2>/dev/null &&
+  systemctl --user is-active --quiet graphical-session.target 2>/dev/null; then
+  # Restart only in a live graphical session so compose sequences come back
+  # under the new flags; outside a session ConditionEnvironment would skip.
+  systemctl --user restart omarchy-fcitx5.service >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -59,7 +59,8 @@ grep -F 'omarchy-update-user-notify' "$first_run_units" >/dev/null &&
 pass "first-run enables the login-only migration notifier"
 
 fcitx_service="$ROOT/default/systemd/user/omarchy-fcitx5.service"
-grep -Fx 'ExecStart=/usr/bin/fcitx5 --disable notificationitem' "$fcitx_service" >/dev/null
+grep -Fx 'ExecStart=/usr/bin/fcitx5 --disable notificationitem,notifications' "$fcitx_service" >/dev/null ||
+  fail "fcitx5 must disable both the tray duplicate and startup layout tip notifications"
 grep -Fx 'Restart=always' "$fcitx_service" >/dev/null ||
   fail "fcitx5 exits 0 on a duplicate bus name, so on-failure would leave the user with no input method"
 grep -Fx 'After=graphical-session.target' "$fcitx_service" >/dev/null ||


### PR DESCRIPTION
## Summary

Fixes #10474.

Omarchy runs fcitx5 only for CapsLock compose (`~/.XCompose`). The user unit already disabled `notificationitem` (tray duplicate of the Omarchy shell) but left the `notifications` addon enabled. The keyboard addon optionally depends on that module and fires freedesktop tips on layout/IM startup — the boot notification reported in the issue.

`Allow Overriding System XKB Settings=False` is already shipped in `config/fcitx5/conf/xcb.conf` (the issue's suggested workaround for XKB ownership). That does not stop the tip channel.

### Change

- `default/systemd/user/omarchy-fcitx5.service`:  
  `ExecStart=/usr/bin/fcitx5 --disable notificationitem,notifications`
- `migrations/1788745469.sh`: `daemon-reload` + restart when a graphical session is live
- `test/shell.d/systemd-test.sh`: assert both addons are disabled

## Evidence

### Bug reproduced

```
$ systemctl --user cat omarchy-fcitx5.service | rg ExecStart
ExecStart=/usr/bin/fcitx5 --disable notificationitem

$ cat config/fcitx5/conf/xcb.conf
Allow Overriding System XKB Settings=False

$ rg notifications /usr/share/fcitx5/addon/keyboard.conf
2=notifications
```

Unit only silenced the tray; keyboard→notifications path still active. XKB override already present and insufficient for the tip.

### Fix validated

```
bash test/shell.d/systemd-test.sh
# includes: fcitx5 runs supervised...
# asserts: ExecStart=... --disable notificationitem,notifications
```

## Test plan

- [x] Pre-fix unit only disables `notificationitem`
- [x] `bash test/shell.d/systemd-test.sh`
- [ ] Manual: reboot / restart `omarchy-fcitx5.service` with multi-layout fcitx profile — no layout tip notification; CapsLock compose still works