### PR TITLE
Say in plugins.md which services survive a plugin hot-reload

### DIFF
--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -42,7 +42,11 @@ Cloning switches the bar to the cloned copy (e.g. `<username>.workspaces`),
 which is yours to edit and survives updates.
 
 Saving a file anywhere under `~/.config/omarchy/plugins/` reloads plugin code
-automatically. If a change somehow fails to apply, force a reload with
+automatically, with one exception: a service whose manifest sets
+`keepLoaded: true` (`omarchy.lock`, `omarchy.notifications`, `omarchy.polkit`,
+and any clone of them) keeps its running instance across a hot-reload, so edits
+to its code, constants included, only take effect after `omarchy restart shell`.
+For everything else, if a change somehow fails to apply, force a reload with
 `omarchy-shell shell rescanPlugins`.
 
 ## Idle and Lock


### PR DESCRIPTION
## Why

`plugins.md` tells an agent that saving a file under `~/.config/omarchy/plugins/` reloads plugin code automatically, with `rescanPlugins` as the fallback. For a service whose manifest sets `keepLoaded` that is not true: since #9485, `unloadPluginServices()` keeps such a service mounted across a hot-reload so the lock client is not destroyed while Hyprland still holds the session lock. The running instance, its `readonly property` constants included, stays live until `omarchy restart shell`. `omarchy.lock`, `omarchy.notifications` and `omarchy.polkit` declare the flag, and `omarchy plugin clone` copies the manifest, so a cloned notifications service behaves the same way. An agent following the current text edits the clone, rescans, sees the plugin listed as enabled, and gets the old behavior with nothing to say why.

## Change

One paragraph in `default/agents/skills/omarchy/plugins.md`: name the exception where the claim is made, list the three first-party services that carry it plus their clones, and say that `omarchy restart shell` is the way to pick up edits to them. The rest of the paragraph is unchanged.

Scoped to the skill the issue names. `docs/omarchy-shell.md:40` already states that `keepLoaded` keeps a service mounted across hot-reload, so the reference tree is right; `manual/32-shell-plugins.md:71` and `shell/README.md:165` carry the same unqualified sentence as the skill did and could take the same clause in a follow-up. The reload path itself is left as is: #10087 reports that hot-reload of widget code fails too, and that is a shell change, not a doc one; this PR does not claim to address it.

## Tests

Doc-only change; no executable touched. `test/shell.d/plugins-test.sh` still asserts that the three services stay `keepLoaded` and that `unloadPluginServices` honors the flag, which is the behavior the new sentence describes.

Fixes #9999

Related: #9485 (the mechanism), #10087 (the separate hot-reload bug, not addressed here).

Written by Claude Fable 5.1 via Claude Code, reviewed by Marc Morriss