### PR TITLE
Stop Dropbox panel claiming over-quota on plan floors

### DIFF
--- a/shell/plugins/panels/dropbox/status.py
+++ b/shell/plugins/panels/dropbox/status.py
@@ -7,6 +7,10 @@ import heapq
 from pathlib import Path
 
 
+# Base plan floors only. Real account quota can be higher (referral bonuses,
+# add-ons) and is not available locally without the Dropbox API (issue #10356).
+# When local usage exceeds a floor, treat quota as unknown rather than implying
+# the account is over limit.
 PLAN_QUOTAS = {
   "basic": 2_000_000_000,
   "plus": 2_000_000_000_000,
@@ -106,7 +110,13 @@ def main():
     running = status_exit == 0 and status_output != "" and not stopped
 
   used, files = scan_dropbox(account_path, limit) if authenticated else (0, [])
-  usage_percent = (used / quota * 100) if quota > 0 else 0
+
+  # A plan floor is only trustworthy while local usage stays under it. Bonus /
+  # referral space makes "3.11 GB of 2 GB" and a red over-quota reading wrong.
+  quota_known = quota > 0 and used <= quota
+  if not quota_known:
+    quota = 0
+  usage_percent = (used / quota * 100) if quota_known else 0
 
   print(json.dumps({
     "ok": True,
@@ -119,7 +129,7 @@ def main():
     "usedBytes": used,
     "quotaBytes": quota,
     "usagePercent": usage_percent,
-    "quotaKnown": quota > 0,
+    "quotaKnown": quota_known,
     "files": files,
   }))
 

--- a/test/shell.d/dropbox-status-quota-test.sh
+++ b/test/shell.d/dropbox-status-quota-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# status.py's PLAN_QUOTAS are base floors. When local usage exceeds the floor
+# (referral/bonus space), quota must be reported unknown (issue #10356).
+
+require_command python3
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+dropbox_dir="$home/Dropbox"
+mkdir -p "$dropbox_dir" "$home/.dropbox" "$test_tmp/bin"
+
+# Basic plan floor is 2 GB. Write a single file larger than that so used > floor.
+python3 - <<'PY' "$dropbox_dir/big.bin"
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+path.write_bytes(b"\0" * (3 * 1024 * 1024 * 1024 // 100))  # ~30MB is enough if we mock size...
+PY
+
+# os.walk uses real size; create a sparse-looking large file via truncate.
+rm -f "$dropbox_dir/big.bin"
+python3 - <<'PY' "$dropbox_dir/big.bin"
+import os, sys
+fd = os.open(sys.argv[1], os.O_CREAT | os.O_WRONLY, 0o644)
+os.ftruncate(fd, 3_110_000_000)  # 3.11 GB sparse
+os.close(fd)
+PY
+
+cat >"$home/.dropbox/info.json" <<'JSON'
+{
+  "personal": {
+    "path": "REPLACE_PATH",
+    "subscription_type": "Basic"
+  }
+}
+JSON
+# path must match the real folder
+python3 - <<'PY' "$home/.dropbox/info.json" "$dropbox_dir"
+import json, pathlib, sys
+info = pathlib.Path(sys.argv[1])
+data = json.loads(info.read_text())
+data["personal"]["path"] = sys.argv[2]
+info.write_text(json.dumps(data))
+PY
+
+# No dropbox-cli needed for quota path.
+cat >"$test_tmp/bin/dropbox-cli" <<'SH'
+#!/bin/bash
+exit 127
+SH
+chmod +x "$test_tmp/bin/dropbox-cli"
+
+# Prove the bug path first: old logic would set quotaKnown with used > quota.
+# We only run the current helper and assert the fixed behaviour.
+out=$(
+  HOME="$home" PATH="$test_tmp/bin:/usr/bin:/bin" \
+    python3 "$ROOT/shell/plugins/panels/dropbox/status.py" 5
+)
+
+echo "$out" | jq -e '.ok == true' >/dev/null || fail "status.py returns ok JSON" "$out"
+echo "$out" | jq -e '.plan == "Basic"' >/dev/null || fail "status.py reads Basic plan" "$out"
+echo "$out" | jq -e '.usedBytes > 2000000000' >/dev/null || fail "status.py sees used above 2GB floor" "$out"
+echo "$out" | jq -e '.quotaKnown == false' >/dev/null ||
+  fail "status.py marks quota unknown when used exceeds plan floor" "$out"
+echo "$out" | jq -e '.quotaBytes == 0' >/dev/null ||
+  fail "status.py clears quotaBytes when floor is not trustworthy" "$out"
+echo "$out" | jq -e '.usagePercent == 0' >/dev/null ||
+  fail "status.py does not report over-quota percent against a false floor" "$out"
+pass "status.py marks quota unknown when used exceeds Basic plan floor"
+
+# Under-floor usage still trusts the plan floor.
+rm -rf "$dropbox_dir"
+mkdir -p "$dropbox_dir"
+printf 'small\n' >"$dropbox_dir/note.txt"
+python3 - <<'PY' "$home/.dropbox/info.json" "$dropbox_dir"
+import json, pathlib, sys
+info = pathlib.Path(sys.argv[1])
+data = json.loads(info.read_text())
+data["personal"]["path"] = sys.argv[2]
+info.write_text(json.dumps(data))
+PY
+
+out=$(
+  HOME="$home" PATH="$test_tmp/bin:/usr/bin:/bin" \
+    python3 "$ROOT/shell/plugins/panels/dropbox/status.py" 5
+)
+
+echo "$out" | jq -e '.quotaKnown == true' >/dev/null ||
+  fail "status.py still trusts plan floor when used is under it" "$out"
+echo "$out" | jq -e '.quotaBytes == 2000000000' >/dev/null ||
+  fail "status.py reports Basic floor as 2GB when under floor" "$out"
+pass "status.py still trusts plan floor when used is under it"

--- a/test/shell.d/dropbox-test.sh
+++ b/test/shell.d/dropbox-test.sh
@@ -16,6 +16,13 @@ assertEqual(dropbox.formatBytes(2_000_000_000), '2 GB', 'dropbox formats gigabyt
 assertEqual(dropbox.formatPercent(7.25), '7.3%', 'dropbox formats small percentages')
 assertEqual(dropbox.usageText(1000, 2000, true), '1 KB of 2 KB', 'dropbox formats known quota usage')
 assertEqual(dropbox.usageText(1000, 0, false), '1 KB', 'dropbox formats unknown quota usage')
+// When quota is unknown (bonus space above a plan floor), UI must not claim
+// "of 2 GB" — that is how issue #10356 showed used > quota in red.
+assertEqual(
+  dropbox.usageText(3_110_000_000, 0, false),
+  '3.11 GB',
+  'dropbox formats usage without a false plan-floor quota'
+)
 
 const parsed = dropbox.parseStatus(JSON.stringify({
   installed: true,


### PR DESCRIPTION
## Summary

Fixes #10356.

`shell/plugins/panels/dropbox/status.py` maps `subscription_type` to fixed `PLAN_QUOTAS` floors (Basic = 2 GB, …). Real Dropbox capacity can be higher (referral bonuses, add-ons) while the plan name stays `"Basic"`. Combined with a local folder scan for `used`, the panel showed values like **"3.11 GB of 2 GB"** and `usagePercent > 100`, as if the account were over quota.

Authoritative quota needs the Dropbox HTTP API (OAuth). This change does not invent that. It only stops lying with the floor:

- If `used <= plan floor` → still show `used of floor` (lower bound).
- If `used > plan floor` → `quotaKnown=false`, `quotaBytes=0`, `usagePercent=0`, UI shows used only (`3.11 GB`).

## Evidence

### Bug reproduced (logic)

```
OLD: used=3110000000 quota=2000000000 known=True pct=155.5%  -> "3.11 GB of 2 GB"
```

### Fix validated

```
bash test/shell.d/dropbox-status-quota-test.sh
ok - status.py marks quota unknown when used exceeds Basic plan floor
ok - status.py still trusts plan floor when used is under it

bash test/shell.d/dropbox-test.sh
ok - dropbox formats usage without a false plan-floor quota
# ... remaining model helpers green
```

Harness: Basic `info.json` + sparse ~3.11 GB file under `~/Dropbox` → fixed helper reports `quotaKnown=false`.

## Test plan

- [x] Controlled status.py harness: used > Basic floor → unknown quota
- [x] Controlled status.py harness: used < floor → 2 GB floor kept
- [x] Model `usageText` unknown-quota formatting
- [ ] Manual: open Dropbox panel on an account with bonus space above the plan floor — Stored line is used-only, not red over-quota