### PR TITLE
Sync app launch environment after monitor scaling

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -93,6 +93,8 @@ set_scale() {
   # factor even when the monitor scale itself is fractional.
   local new_gdk_scale="$(awk -v scale="$new_scale" 'BEGIN { printf "%d", int(scale + 0.5) }')"
   local monitor_lua="$HOME/.config/hypr/monitors.lua"
+  local persisted_gdk_scale=false
+  local sync_failed=false
 
   hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
@@ -100,16 +102,36 @@ set_scale() {
   # Persist to monitors.lua if the user still has Omarchy's generic catch-all
   # defaults, so the scale survives reboots.
   if [[ -f $monitor_lua ]] && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
-    sed -i -E \
+    if sed -i -E \
       -e "s|^local omarchy_monitor_scale = .*|local omarchy_monitor_scale = ${new_scale}|" \
       -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${new_gdk_scale}|" \
-      "$monitor_lua"
+      "$monitor_lua" &&
+      grep -Fxq "local omarchy_gdk_scale = ${new_gdk_scale}" "$monitor_lua"; then
+      persisted_gdk_scale=true
+    fi
   elif [[ -f $monitor_lua ]] && grep -Eq '^hl\.monitor\(\{ output = "", mode = "preferred", position = "auto", scale = ("auto"|[0-9.]+) \}\)' "$monitor_lua"; then
-    sed -i -E \
+    if sed -i -E \
       -e "s|^(hl\.monitor\(\{ output = \"\", mode = \"preferred\", position = \"auto\", scale = )([^ ]+)( \}\))|\\1${new_scale}\\3|" \
       -e 's|^hl\.env\("GDK_SCALE", ".*"\)|hl.env("GDK_SCALE", "'"$new_gdk_scale"'")|' \
-      "$monitor_lua"
+      "$monitor_lua" &&
+      grep -Fxq "hl.env(\"GDK_SCALE\", \"${new_gdk_scale}\")" "$monitor_lua"; then
+      persisted_gdk_scale=true
+    fi
   fi
+
+  if [[ $persisted_gdk_scale == true ]]; then
+    if ! hyprctl eval "hl.env(\"GDK_SCALE\", \"$new_gdk_scale\")" >/dev/null; then
+      echo "Failed to update Hyprland GDK_SCALE environment" >&2
+      sync_failed=true
+    fi
+
+    if ! dbus-update-activation-environment --systemd "GDK_SCALE=$new_gdk_scale"; then
+      echo "Failed to update systemd and D-Bus GDK_SCALE environment" >&2
+      sync_failed=true
+    fi
+  fi
+
+  [[ $sync_failed == false ]]
 }
 
 scale_from_current() {

--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -78,11 +78,12 @@ Item {
     var id = String(desktopId || "")
     if (!id) return
     root.beginLaunchFeedback(name)
-    // Start gtk-launch inside a scope under app-graphical.slice so apps do not
-    // inherit wayland-wm@.service. Keeping gtk-launch as the desktop-entry
-    // resolver supports IDs with spaces and entries that UWSM rejects.
+    // Start gtk-launch as a transient service so it inherits the latest
+    // environment imported into the systemd user manager. Keeping gtk-launch
+    // as the desktop-entry resolver supports IDs with spaces and entries that
+    // UWSM rejects.
     // Keep the .desktop suffix or ids like org.telegram.desktop won't resolve.
-    Util.execDetached("uwsm-app -- gtk-launch " + Util.shellQuote(id + ".desktop"))
+    Util.execDetached("uwsm-app -t service -- gtk-launch " + Util.shellQuote(id + ".desktop"))
   }
 
   function remove(desktopId, name) {

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -100,8 +100,8 @@ assert(
 
 assert(
   /function launch\(desktopId, name\) \{[\s\S]*?uwsm-app[\s\S]*?\n  \}/.test(appLibraryQml) &&
-    appLibraryQml.includes('Util.execDetached("uwsm-app -- gtk-launch "'),
-  'app library launches desktop entries through gtk-launch in their own scope'
+    appLibraryQml.includes('Util.execDetached("uwsm-app -t service -- gtk-launch "'),
+  'app library launches desktop entries through gtk-launch in a UWSM service'
 )
 
 assert(

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 eval_out="$test_tmp/hyprctl-eval"
+dbus_out="$test_tmp/dbus-update"
 home_dir="$test_tmp/home"
 monitor_lua="$home_dir/.config/hypr/monitors.lua"
 scale_log="$home_dir/.local/state/omarchy/monitor-scaling.log"
@@ -22,12 +23,23 @@ if [[ $1 == "monitors" && $2 == "-j" ]]; then
   printf '[{"name":"eDP-1","focused":true,"scale":%s,"width":%s,"height":%s,"refreshRate":120.0}]' \
     "${OMARCHY_TEST_MONITOR_SCALE:-2}" "${OMARCHY_TEST_MONITOR_WIDTH:-2880}" "${OMARCHY_TEST_MONITOR_HEIGHT:-1800}"
 elif [[ $1 == "eval" ]]; then
-  printf '%s\n' "$2" >"$OMARCHY_TEST_HYPRCTL_EVAL_OUT"
+  printf '%s\n' "$2" >>"$OMARCHY_TEST_HYPRCTL_EVAL_OUT"
+  if [[ $2 == 'hl.env('* && ${OMARCHY_TEST_HYPR_ENV_FAIL:-0} == 1 ]]; then
+    exit 1
+  fi
 else
   exit 1
 fi
 SH
 chmod +x "$stub_bin/hyprctl"
+
+cat >"$stub_bin/dbus-update-activation-environment" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$OMARCHY_TEST_DBUS_OUT"
+[[ ${OMARCHY_TEST_DBUS_FAIL:-0} == 0 ]]
+SH
+chmod +x "$stub_bin/dbus-update-activation-environment"
 
 write_monitor_config() {
   cat >"$monitor_lua" <<'LUA'
@@ -37,11 +49,16 @@ LUA
 }
 
 run_scaling() {
+  : >"$eval_out"
+  : >"$dbus_out"
   HOME="$home_dir" \
     XDG_STATE_HOME="$home_dir/.local/state" \
     PATH="$stub_bin:$PATH" \
     OMARCHY_TEST_HYPRCTL_EVAL_OUT="$eval_out" \
+    OMARCHY_TEST_DBUS_OUT="$dbus_out" \
     OMARCHY_TEST_MONITOR_SCALE="${OMARCHY_TEST_MONITOR_SCALE:-2}" \
+    OMARCHY_TEST_HYPR_ENV_FAIL="${OMARCHY_TEST_HYPR_ENV_FAIL:-0}" \
+    OMARCHY_TEST_DBUS_FAIL="${OMARCHY_TEST_DBUS_FAIL:-0}" \
     "$ROOT/bin/omarchy-hyprland-monitor-scaling" "$@"
 }
 
@@ -49,6 +66,8 @@ write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=2 run_scaling up
 grep -F 'scale = 3' "$eval_out" >/dev/null || fail "monitor scaling up reaches 3x"
 grep -Fx 'local omarchy_monitor_scale = 3' "$monitor_lua" >/dev/null || fail "monitor scaling up persists 3x"
+grep -Fx 'hl.env("GDK_SCALE", "3")' "$eval_out" >/dev/null || fail "monitor scaling up updates Hyprland GDK scale"
+grep -Fx -- '--systemd GDK_SCALE=3' "$dbus_out" >/dev/null || fail "monitor scaling up updates systemd and D-Bus GDK scale"
 grep -F $'requested=up\tcurrent=2\tnew=3\tmonitor=eDP-1' "$scale_log" >/dev/null || fail "monitor scaling up writes audit log"
 pass "monitor scaling up reaches 3x"
 
@@ -56,6 +75,8 @@ write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=3 run_scaling down
 grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down recovers 3x to 2x"
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null || fail "monitor scaling down persists 2x from 3x"
+grep -Fx 'hl.env("GDK_SCALE", "2")' "$eval_out" >/dev/null || fail "monitor scaling down updates Hyprland GDK scale"
+grep -Fx -- '--systemd GDK_SCALE=2' "$dbus_out" >/dev/null || fail "monitor scaling down updates systemd and D-Bus GDK scale"
 pass "monitor scaling down recovers 3x to 2x"
 
 write_monitor_config
@@ -71,6 +92,14 @@ grep -Fx 'local omarchy_monitor_scale = 3' "$monitor_lua" >/dev/null || fail "mo
 grep -Fx 'local omarchy_gdk_scale = 3' "$monitor_lua" >/dev/null || fail "monitor scaling explicit 3x persists GDK scale"
 pass "monitor scaling explicit 3x remains available"
 
+write_monitor_config
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1
+grep -F 'scale = 1' "$eval_out" >/dev/null || fail "monitor scaling changes 2x to 1x"
+grep -Fx 'local omarchy_monitor_scale = 1' "$monitor_lua" >/dev/null || fail "monitor scaling persists 1x"
+grep -Fx 'hl.env("GDK_SCALE", "1")' "$eval_out" >/dev/null || fail "monitor scaling 1x updates Hyprland GDK scale"
+grep -Fx -- '--systemd GDK_SCALE=1' "$dbus_out" >/dev/null || fail "monitor scaling 1x updates systemd and D-Bus GDK scale"
+pass "monitor scaling propagates 2x to 1x"
+
 # GTK only honors integer GDK_SCALE, so fractional monitor scales persist a
 # rounded GDK scale.
 write_monitor_config
@@ -78,12 +107,16 @@ OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.6
 grep -F 'scale = 1.6' "$eval_out" >/dev/null || fail "monitor scaling explicit 1.6x remains available"
 grep -Fx 'local omarchy_monitor_scale = 1.6' "$monitor_lua" >/dev/null || fail "monitor scaling explicit 1.6x persists"
 grep -Fx 'local omarchy_gdk_scale = 2' "$monitor_lua" >/dev/null || fail "monitor scaling 1.6x persists integer GDK scale 2"
+grep -Fx 'hl.env("GDK_SCALE", "2")' "$eval_out" >/dev/null || fail "monitor scaling 1.6x propagates integer GDK scale 2"
+grep -Fx -- '--systemd GDK_SCALE=2' "$dbus_out" >/dev/null || fail "monitor scaling 1.6x propagates systemd GDK scale 2"
 pass "monitor scaling 1.6x persists integer GDK scale 2"
 
 write_monitor_config
 OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.25
 grep -Fx 'local omarchy_monitor_scale = 1.25' "$monitor_lua" >/dev/null || fail "monitor scaling explicit 1.25x persists"
 grep -Fx 'local omarchy_gdk_scale = 1' "$monitor_lua" >/dev/null || fail "monitor scaling 1.25x persists integer GDK scale 1"
+grep -Fx 'hl.env("GDK_SCALE", "1")' "$eval_out" >/dev/null || fail "monitor scaling 1.25x propagates integer GDK scale 1"
+grep -Fx -- '--systemd GDK_SCALE=1' "$dbus_out" >/dev/null || fail "monitor scaling 1.25x propagates systemd GDK scale 1"
 pass "monitor scaling 1.25x persists integer GDK scale 1"
 
 scale=$(OMARCHY_TEST_MONITOR_SCALE=3 run_scaling)
@@ -129,3 +162,83 @@ grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down skips d
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling down persists 2x after skipping duplicate approximation"
 pass "monitor scaling down skips duplicate approximation"
+
+cat >"$monitor_lua" <<'LUA'
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = "auto" })
+hl.env("GDK_SCALE", "2")
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1.25
+grep -Fx 'hl.monitor({ output = "", mode = "preferred", position = "auto", scale = 1.25 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists the legacy stock monitor scale"
+grep -Fx 'hl.env("GDK_SCALE", "1")' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists the legacy stock GDK scale"
+grep -Fx 'hl.env("GDK_SCALE", "1")' "$eval_out" >/dev/null ||
+  fail "monitor scaling propagates the legacy stock GDK scale"
+grep -Fx -- '--systemd GDK_SCALE=1' "$dbus_out" >/dev/null ||
+  fail "monitor scaling propagates the legacy stock systemd GDK scale"
+pass "monitor scaling persists and propagates the legacy stock config"
+
+cat >"$monitor_lua" <<'LUA'
+hl.monitor({ output = "DP-1", mode = "preferred", position = "auto", scale = 2 })
+hl.env("GDK_SCALE", "2")
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1
+if grep -Fq 'hl.env(' "$eval_out" || [[ -s $dbus_out ]]; then
+  fail "monitor scaling does not propagate GDK scale for a custom config"
+fi
+pass "monitor scaling does not propagate GDK scale for a custom config"
+
+# sed exits successfully for the recognized variable-style config, but there
+# is no GDK line to replace. The post-write check must prevent propagation.
+cat >"$monitor_lua" <<'LUA'
+local omarchy_monitor_scale = 2
+LUA
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 1
+grep -Fx 'local omarchy_monitor_scale = 1' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling still updates the matched monitor line"
+if grep -Fq 'hl.env(' "$eval_out" || [[ -s $dbus_out ]]; then
+  fail "monitor scaling does not propagate when the GDK persistence target is missing"
+fi
+pass "monitor scaling verifies GDK persistence before propagation"
+
+write_monitor_config
+scale=$(OMARCHY_TEST_MONITOR_SCALE=2 run_scaling)
+[[ $scale == "2" ]] || fail "monitor scaling query returns the current scale" "actual: $scale"
+if grep -Fq 'hl.env(' "$eval_out" || [[ -s $dbus_out ]]; then
+  fail "monitor scaling query does not propagate GDK scale"
+fi
+pass "monitor scaling query does not propagate GDK scale"
+
+set +e
+run_scaling invalid >/dev/null 2>&1
+status=$?
+set -e
+(( status != 0 )) || fail "monitor scaling rejects invalid input"
+if grep -Fq 'hl.env(' "$eval_out" || [[ -s $dbus_out ]]; then
+  fail "monitor scaling invalid input does not propagate GDK scale"
+fi
+pass "monitor scaling invalid input does not propagate GDK scale"
+
+write_monitor_config
+set +e
+OMARCHY_TEST_HYPR_ENV_FAIL=1 run_scaling 1 2>"$test_tmp/hypr-env-error"
+status=$?
+set -e
+(( status != 0 )) || fail "monitor scaling fails when Hyprland environment sync fails"
+grep -Fq 'Failed to update Hyprland GDK_SCALE environment' "$test_tmp/hypr-env-error" ||
+  fail "monitor scaling reports a Hyprland environment sync failure"
+grep -Fx -- '--systemd GDK_SCALE=1' "$dbus_out" >/dev/null ||
+  fail "monitor scaling still attempts D-Bus sync after Hyprland sync fails"
+pass "monitor scaling reports Hyprland environment sync failures"
+
+write_monitor_config
+set +e
+OMARCHY_TEST_DBUS_FAIL=1 run_scaling 1 2>"$test_tmp/dbus-error"
+status=$?
+set -e
+(( status != 0 )) || fail "monitor scaling fails when D-Bus environment sync fails"
+grep -Fq 'Failed to update systemd and D-Bus GDK_SCALE environment' "$test_tmp/dbus-error" ||
+  fail "monitor scaling reports a D-Bus environment sync failure"
+grep -Fx 'hl.env("GDK_SCALE", "1")' "$eval_out" >/dev/null ||
+  fail "monitor scaling updates Hyprland before a D-Bus sync failure"
+pass "monitor scaling reports D-Bus environment sync failures"


### PR DESCRIPTION
Fixes #10555.

Changing monitor scale updated the focused output and `monitors.lua`, but left several independent runtime environments with the old `GDK_SCALE`: Hyprland's keybinding-launch environment, the systemd user manager and D-Bus activation environment, and long-running processes such as Quickshell and existing terminals. Newly launched XWayland applications could therefore appear oversized after scaling down.

## Changes

- Preserve the precise fractional monitor scale while rounding `GDK_SCALE` to GTK's nearest supported integer.
- Propagate `GDK_SCALE` only after a supported stock `monitors.lua` form was successfully updated and the persisted GDK value was verified.
- Update Hyprland with `hl.env("GDK_SCALE", ...)` and the systemd user manager plus D-Bus activation environment with `dbus-update-activation-environment --systemd`.
- Return a clear non-zero status if either runtime synchronization step fails, without rolling back the already-applied monitor scale.
- Start Apps-menu desktop entries through `uwsm-app -t service -- gtk-launch …`, so they inherit the current systemd manager environment instead of Quickshell's long-lived environment.

## Verification

Automated coverage includes 2→1, 2→1.25, and 2→1.6; `up`, `down`, and explicit scale requests; both supported stock config forms; no propagation for queries, invalid input, custom configs, or unmatched persistence targets; synchronization failure handling; and Apps-menu desktop-ID quoting and `.desktop` suffix preservation.

Disposable VM verification:

- Ran the graphical acceptance suite in a disposable `omarchy-iso` VM; the acceptance suite passed.
- Started from a 2× login, then changed to 1×.
- Confirmed the focused monitor, persisted `monitors.lua`, systemd user manager, and a newly spawned Hyprland child all used `GDK_SCALE=1`.
- Confirmed Quickshell retained its original PID and `GDK_SCALE=2`.
- Opened Omawrite with unsaved text before scaling; it retained its PID and unsaved content after scaling.
- Launched Aether through the Apps menu; it inherited `GDK_SCALE=1` in an `app-Hyprland-gtk-launch@….service` transient unit. Closing it made the service inactive, and it could be launched again.

Manual dev-link verification repeated the 2×→1× flow in a real session: the existing Omawrite instance remained open with unsaved text, while a new Apps-menu application rendered at the correct 1× scale.

## Non-goals

- Synchronizing after a user manually edits `monitors.lua`.
- Updating or restarting existing applications, Quickshell, or existing terminals.
- Updating applications launched from an old terminal scope.
- Solving mixed-DPI layouts with one integer `GDK_SCALE`.

The VM image did not contain Spotify, so this does not claim a direct Spotify screenshot or launch test. Hyprland's newly spawned child environment was verified instead.
