### PR TITLE
Ignore Hyprland FALLBACK in external-monitor checks

### DIFF
--- a/bin/omarchy-hyprland-monitor-external-active
+++ b/bin/omarchy-hyprland-monitor-external-active
@@ -3,4 +3,14 @@
 # omarchy:summary=Returns true when Hyprland has an active external monitor
 # omarchy:hidden=true
 
-hyprctl monitors all -j | jq -e '.[] | select(.name | test("^(eDP|LVDS|DSI)-") | not) | select(.disabled == false)' >/dev/null 2>&1
+# Hyprland/aquamarine invents a synthetic FALLBACK headless output when every
+# real connector is gone or soft-disabled, so the compositor is never left with
+# zero monitors. That head is not an external display: if we treat it as one,
+# recover() short-circuits after unplug and the internal panel stays disabled
+# forever (issue #10584).
+hyprctl monitors all -j | jq -e '
+  .[]
+  | select(.name != "FALLBACK")
+  | select(.name | test("^(eDP|LVDS|DSI)-") | not)
+  | select(.disabled == false)
+' >/dev/null 2>&1

--- a/test/shell.d/monitor-external-active-test.sh
+++ b/test/shell.d/monitor-external-active-test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# omarchy-hyprland-monitor-external-active must ignore Hyprland's synthetic
+# FALLBACK head. Otherwise internal-panel recover() never runs after unplug
+# (issue #10584).
+
+helper="$ROOT/bin/omarchy-hyprland-monitor-external-active"
+[[ -f $helper ]] || fail "external-active helper exists"
+
+grep -F 'select(.name != "FALLBACK")' "$helper" >/dev/null ||
+  fail "external-active helper excludes the synthetic FALLBACK monitor"
+pass "external-active helper excludes the synthetic FALLBACK monitor"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+[[ $1 == "monitors" && $2 == "all" && $3 == "-j" ]] || exit 1
+printf '%s\n' "${OMARCHY_TEST_MONITORS_JSON:?}"
+SH
+chmod +x "$stub_bin/hyprctl"
+
+run_helper() {
+  OMARCHY_TEST_MONITORS_JSON="${1:?}" PATH="$stub_bin:/usr/bin:/bin" bash "$helper"
+  return $?
+}
+
+# Real external HDMI still active with internal disabled → true.
+hdmi='[
+  {"name":"eDP-1","disabled":true,"width":1920,"height":1200},
+  {"name":"HDMI-A-1","disabled":false,"width":3840,"height":2160}
+]'
+if ! run_helper "$hdmi"; then
+  fail "external-active is true with a live HDMI output"
+fi
+pass "external-active is true with a live HDMI output"
+
+# Unplug case: only disabled internal + FALLBACK → must be false.
+fallback_only='[
+  {"name":"eDP-1","disabled":true,"width":1920,"height":1200},
+  {"name":"FALLBACK","disabled":false,"width":0,"height":0}
+]'
+if run_helper "$fallback_only"; then
+  fail "external-active is false when only FALLBACK remains after unplug"
+fi
+pass "external-active is false when only FALLBACK remains after unplug"
+
+# FALLBACK alone (no internal listed) → false.
+fallback_solo='[{"name":"FALLBACK","disabled":false,"width":0,"height":0}]'
+if run_helper "$fallback_solo"; then
+  fail "external-active is false for FALLBACK alone"
+fi
+pass "external-active is false for FALLBACK alone"
+
+# Internal only, enabled → false (no external).
+internal_only='[{"name":"eDP-1","disabled":false,"width":1920,"height":1200}]'
+if run_helper "$internal_only"; then
+  fail "external-active is false for internal-only"
+fi
+pass "external-active is false for internal-only"
+
+# Mirrored/disabled external must not count (existing contract).
+disabled_hdmi='[
+  {"name":"eDP-1","disabled":false,"width":1920,"height":1200},
+  {"name":"HDMI-A-1","disabled":true,"width":3840,"height":2160}
+]'
+if run_helper "$disabled_hdmi"; then
+  fail "external-active ignores disabled external outputs"
+fi
+pass "external-active ignores disabled external outputs"

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -68,6 +68,8 @@ pass "clamshell helper detects closed-lid external monitor state"
 grep -F 'hyprctl monitors all -j' "$monitor_external_active" >/dev/null
 grep -F 'select(.name | test("^(eDP|LVDS|DSI)-") | not)' "$monitor_external_active" >/dev/null
 grep -F 'select(.disabled == false)' "$monitor_external_active" >/dev/null
+grep -F 'select(.name != "FALLBACK")' "$monitor_external_active" >/dev/null ||
+  fail "active external monitor helper excludes Hyprland's synthetic FALLBACK head"
 pass "active external monitor helper sees mirrors and ignores monitors disabled on purpose"
 
 grep -F 'omarchy-hyprland-monitor-internal recover >/dev/null 2>&1 || true' "$clamshell" >/dev/null


### PR DESCRIPTION
## Summary

Fixes #10584.
Fixes #10935.

When the internal panel is soft-disabled (`omarchy-hyprland-monitor-internal off`) and the external cable is unplugged, Hyprland/aquamarine creates a synthetic `FALLBACK` headless output so it is never left with zero monitors.

`omarchy-hyprland-monitor-external-active` only excluded laptop connector name prefixes (`eDP`/`LVDS`/`DSI`). `FALLBACK` matched as an "active external", so `omarchy-hyprland-monitor-internal recover()` returned early and never cleared `internal-monitor-disable` — black screen until manual recovery.

### Change

```bash
select(.name != "FALLBACK")
```

added to the jq filter in `bin/omarchy-hyprland-monitor-external-active`.

User-created headless outputs (`hyprctl output create headless` → `HEADLESS-*`) still count as active externals; only Hyprland's own `FALLBACK` is excluded.

## Evidence

### Bug reproduced (pre-fix filter)

```json
[{"name":"eDP-1","disabled":true},{"name":"FALLBACK","disabled":false}]
```

Old filter → **external-active = true** (FALLBACK fools it).  
Matches the issue's live socket2 capture after `monitorremoved>>HDMI-A-1`.

### Fix validated

```
NEW filter on same JSON → external-active = false
NEW filter with live HDMI → external-active = true
NEW filter with HEADLESS-1 → external-active = true

bash test/shell.d/monitor-external-active-test.sh
ok - external-active helper excludes the synthetic FALLBACK monitor
ok - external-active is true with a live HDMI output
ok - external-active is false when only FALLBACK remains after unplug
ok - external-active is false for FALLBACK alone
ok - external-active is false for internal-only
ok - external-active ignores disabled external outputs
ok - external-active still counts a user-created headless output

bash test/shell.d/monitor-recovery-test.sh
# still green, including FALLBACK exclusion assert
```

## Test plan

- [x] jq pre/post filter on FALLBACK-only JSON
- [x] `bash test/shell.d/monitor-external-active-test.sh` (incl. HEADLESS-1 pin)
- [x] `bash test/shell.d/monitor-recovery-test.sh`
- [x] Counter-check: `^HEADLESS-` exclusion keeps old cases green and turns the new case red
- [ ] Manual laptop: internal off + external unplug → eDP re-enables (no black FALLBACK)