### PR TITLE
Dismiss screensaver on bare Ctrl while it is open

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -13,7 +13,10 @@ exit_screensaver() {
   exit 0
 }
 
-# Exit the screensaver on signals and input from keyboard and mouse
+# Exit the screensaver on signals and tty input. Bare Ctrl never delivers a
+# tty byte (issue #10583); Hyprland binds Control_L/R (press, non_consuming) to
+# SIGHUP while an org.omarchy.screensaver window is open
+# (default/hypr/bindings/utilities.lua).
 trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
 
 printf '\033]11;rgb:00/00/00\007'  # Set background color to black

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -81,6 +81,70 @@ hl.on("layer.closed", function(layer)
   end
 end)
 
+-- Bare Ctrl does not deliver a tty byte, so omarchy-screensaver's `read -n1`
+-- loop never sees it (issue #10583). While a screensaver window is open, bind
+-- Control_L/R on press so a lone Ctrl tap sends SIGHUP to the same trap
+-- exit_screensaver already handles.
+--
+-- Use press + non_consuming rather than release=true: on Hyprland 0.56.2 bare
+-- modifier binds with release=true register but never dispatch (press works).
+-- non_consuming keeps Ctrl available to other binds/clients if needed; while
+-- the screensaver is up a Ctrl press is intended to wake it anyway.
+-- Scoped to screensaver windows only (mirrors the selection-layer bind pattern
+-- above); no global mouse wake — that path was removed in v3.3.0 for BT mice.
+local screensaver_windows = 0
+local screensaver_binds = {}
+
+local function is_screensaver_window(window)
+  if not window then
+    return false
+  end
+  local class = window.class or window.initialClass or ""
+  return class == "org.omarchy.screensaver"
+end
+
+local function bind_screensaver_wake()
+  if screensaver_windows ~= 1 then
+    return
+  end
+  local wake = hl.dsp.exec_cmd("pkill -HUP -f '[o]rg.omarchy.screensaver' || true")
+  screensaver_binds = {
+    hl.bind("Control_L", wake, { description = "Dismiss screensaver", non_consuming = true, locked = true }),
+    hl.bind("Control_R", wake, { description = "Dismiss screensaver", non_consuming = true, locked = true }),
+  }
+end
+
+local function unbind_screensaver_wake()
+  if screensaver_windows ~= 0 then
+    return
+  end
+  for _, keybind in ipairs(screensaver_binds) do
+    keybind:unbind()
+  end
+  screensaver_binds = {}
+end
+
+hl.on("window.open", function(window)
+  if is_screensaver_window(window) then
+    screensaver_windows = screensaver_windows + 1
+    bind_screensaver_wake()
+  end
+end)
+
+hl.on("window.close", function(window)
+  if is_screensaver_window(window) and screensaver_windows > 0 then
+    screensaver_windows = screensaver_windows - 1
+    unbind_screensaver_wake()
+  end
+end)
+
+hl.on("window.destroy", function(window)
+  if is_screensaver_window(window) and screensaver_windows > 0 then
+    screensaver_windows = screensaver_windows - 1
+    unbind_screensaver_wake()
+  end
+end)
+
 o.bind("SUPER + CTRL + S", "Share", "omarchy-menu toggle share")
 
 o.bind("SUPER + CTRL + PERIOD", "Transcode", "omarchy-transcode")

--- a/test/shell.d/screensaver-ctrl-wake-test.sh
+++ b/test/shell.d/screensaver-ctrl-wake-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Bare Ctrl does not wake omarchy-screensaver via read -n1; scoped Control_L/R
+# press binds must SIGHUP the screensaver while it is open (issue #10583).
+# release=true on bare modifiers does not dispatch on Hyprland 0.56.2, so the
+# binds use press + non_consuming instead.
+
+utilities="$ROOT/default/hypr/bindings/utilities.lua"
+screensaver="$ROOT/bin/omarchy-screensaver"
+
+[[ -f $utilities ]] || fail "utilities bindings exist"
+[[ -f $screensaver ]] || fail "screensaver helper exists"
+
+# Screensaver only wakes on tty bytes or signals — document the gap.
+grep -F 'read -n1' "$screensaver" >/dev/null ||
+  fail "screensaver still uses read -n1 for tty wake"
+grep -E 'trap exit_screensaver .*SIGHUP' "$screensaver" >/dev/null ||
+  fail "screensaver traps SIGHUP for non-tty dismiss"
+pass "screensaver traps SIGHUP for non-tty dismiss"
+
+# Scoped binds: only while screensaver windows are open.
+for needle in \
+  'hl.on("window.open"' \
+  'hl.on("window.close"' \
+  'hl.on("window.destroy"' \
+  'org.omarchy.screensaver' \
+  'Control_L' \
+  'Control_R' \
+  'non_consuming = true' \
+  "pkill -HUP -f '[o]rg.omarchy.screensaver'" \
+  '#10583'; do
+  grep -F "$needle" "$utilities" >/dev/null ||
+    fail "utilities screensaver wake includes $needle"
+done
+pass "utilities binds Control_L/R press (non_consuming) to SIGHUP while screensaver is open"
+
+# Must not rely on bare-modifier release binds (dead on Hyprland 0.56.2).
+# Strip comments so the explanatory note about release=true cannot match.
+code_only=$(grep -vE '^[[:space:]]*--' "$utilities" || true)
+if grep -E 'Control_[LR].*release\s*=\s*true|release\s*=\s*true.*Control_[LR]' <<<"$code_only" >/dev/null; then
+  fail "utilities must not use release=true on bare Control binds" "$code_only"
+fi
+pass "utilities does not use release=true on bare Control screensaver binds"
+
+# Must not reintroduce global mouse wake (removed in v3.3.0 for BT mice).
+if grep -E 'mouse:27[2-4]|mouse_move' <<<"$code_only" >/dev/null; then
+  fail "utilities must not add global mouse screensaver wake" "$code_only"
+fi
+pass "utilities does not reintroduce global mouse screensaver wake"
+
+# Counter discipline: bind only when the first screensaver opens, unbind at zero.
+grep -F 'if screensaver_windows ~= 1 then' "$utilities" >/dev/null ||
+  fail "screensaver wake binds only on the first open window"
+grep -F 'if screensaver_windows ~= 0 then' "$utilities" >/dev/null ||
+  fail "screensaver wake unbinds only when the last window is gone"
+pass "screensaver wake bind lifetime tracks open screensaver windows"


### PR DESCRIPTION
## Summary

Fixes #10583 (Ctrl-tap half only).

`omarchy-screensaver` exits on tty bytes (`read -n1`) or signals. Bare Ctrl is a modifier with no tty byte, so it never wakes the screensaver. Separately, idle's `handleActiveSignal()` intentionally ignores compositor activity while the screensaver window exists (to avoid self-close on launch).

v3.3.0 removed global mouse-to-wake for Bluetooth mice. This PR does **not** restore mouse wake.

### Change

While an `org.omarchy.screensaver` window is open (tracked via `window.open` / `close` / `destroy`, same pattern as selection-layer binds):

- Bind `Control_L` / `Control_R` with `non_consuming = true` and `locked = true`
- On press: `pkill -HUP -f '[o]rg.omarchy.screensaver'` (hits the existing `exit_screensaver` SIGHUP trap)
- Unbind when the last screensaver window closes

Uses **press + `non_consuming`**, not `release = true`: on Hyprland 0.56.2 bare-modifier release binds register but never dispatch (reproduced standalone; see review discussion).

## Evidence

### Bug reproduced

```
bin/omarchy-screensaver:
  trap ... SIGHUP ...
  if read -n1 -t 1 || ! screensaver_in_focus; then exit_screensaver; fi

shell/plugins/services/idle/Service.qml handleActiveSignal:
  if screensaverStartedThisCycle && screensaverWindowCount > 0 → return
```

Ctrl alone → no tty byte → no wake. Activity signal swallowed while window up.

### Fix validated

```
bash test/shell.d/screensaver-ctrl-wake-test.sh
ok - screensaver traps SIGHUP for non-tty dismiss
ok - utilities binds Control_L/R press (non_consuming) to SIGHUP while screensaver is open
ok - utilities does not use release=true on bare Control screensaver binds
ok - utilities does not reintroduce global mouse screensaver wake
ok - screensaver wake bind lifetime tracks open screensaver windows

bash test/shell.d/system-lock-test.sh
ok - system lock waits for ttfx before closing its terminal
```

## Test plan

- [x] Source/assert tests for bind lifetime, non_consuming, and no mouse wake
- [x] system-lock still closes screensaver correctly
- [ ] Manual: `omarchy-launch-screensaver force` → tap Ctrl alone → dismisses
- [ ] Out of scope here: mouse click wake (BT-mouse history); Alt/Super modifier wake