### PR TITLE
Gate NVIDIA session env on a connected NVIDIA output

### DIFF
--- a/bin/omarchy-hw-nvidia-drives-display
+++ b/bin/omarchy-hw-nvidia-drives-display
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether an NVIDIA GPU is driving a connected display.
+# omarchy:hidden=true
+
+# Session-wide NVIDIA env (LIBVA_DRIVER_NAME, __GLX_VENDOR_LIBRARY_NAME, …) must
+# only apply when NVIDIA actually owns a connected connector. On hybrid laptops
+# the dGPU is often present but idle; forcing LIBVA onto nvidia then stalls
+# browser video while the panel hangs off the iGPU (issue #10410).
+#
+# Read cached DRM connector status and the card's PCI vendor. Connector status
+# is served from the driver's cache and does not resume a runtime-suspended
+# GPU the way lspci would.
+
+drm_path="${OMARCHY_DRM_PATH:-/sys/class/drm}"
+
+shopt -s nullglob
+
+for connector in "$drm_path"/card[0-9]*-*; do
+  [[ -r $connector/status ]] || continue
+  [[ $(< "$connector/status") == "connected" ]] || continue
+
+  # cardN-DP-1 → cardN via the connector's device symlink, then PCI vendor.
+  card=$(readlink -f "$connector/device" 2>/dev/null) || continue
+  vendor_file="$card/device/vendor"
+  [[ -r $vendor_file ]] || continue
+  [[ $(< "$vendor_file") == "0x10de" ]] && exit 0
+done
+
+exit 1

--- a/default/hypr/nvidia.lua
+++ b/default/hypr/nvidia.lua
@@ -3,11 +3,18 @@ local paths = require("default.hypr.paths")
 local nvidia = paths.omarchy_path .. "/bin/omarchy-hw-nvidia"
 local nvidia_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-gsp"
 local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without-gsp"
+local nvidia_drives_display = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-drives-display"
 
--- These detectors read cached sysfs IDs rather than shelling out to lspci.
--- lspci reads PCI config space, which resumes a runtime-suspended GPU, and on a
--- hybrid laptop that wake alone outlasts Hyprland's 1.5s config reload budget.
-if o.shell_succeeds(o.shell_quote(nvidia)) then
+-- These detectors read cached sysfs / DRM state rather than shelling out to
+-- lspci. lspci reads PCI config space, which resumes a runtime-suspended GPU,
+-- and on a hybrid laptop that wake alone outlasts Hyprland's 1.5s config
+-- reload budget.
+--
+-- Presence alone is not enough for session-wide VA/GL vendor env: on hybrid
+-- laptops the dGPU may be present while the panel hangs off the iGPU. Forcing
+-- LIBVA_DRIVER_NAME=nvidia then stalls browser video decode (issue #10410).
+-- Only set those vars when an NVIDIA card has a connected connector.
+if o.shell_succeeds(o.shell_quote(nvidia)) and o.shell_succeeds(o.shell_quote(nvidia_drives_display)) then
   if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
     hl.env("NVD_BACKEND", "direct")
     hl.env("LIBVA_DRIVER_NAME", "nvidia")

--- a/test/shell.d/hw-nvidia-test.sh
+++ b/test/shell.d/hw-nvidia-test.sh
@@ -97,3 +97,78 @@ assert_detects "a non-display NVIDIA function is not a GPU" no no no
 
 write_pci_devices
 assert_detects "a machine with no PCI devices detects nothing" no no no
+
+# --- omarchy-hw-nvidia-drives-display (issue #10410) ---
+# Fake DRM tree: cardN/device/vendor + cardN-NAME/status, with device → cardN.
+
+drm_root="$tmp_dir/drm"
+
+write_drm_tree() {
+  # Args: pairs of "cardN:vendor" then connector specs "cardN-NAME:status"
+  rm -rf "$drm_root"
+  mkdir -p "$drm_root"
+
+  local arg
+  for arg in "$@"; do
+    if [[ $arg == card[0-9]:* ]]; then
+      local card=${arg%%:*}
+      local vendor=${arg#*:}
+      mkdir -p "$drm_root/$card/device"
+      printf '%s\n' "$vendor" >"$drm_root/$card/device/vendor"
+    elif [[ $arg == card[0-9]-* ]]; then
+      local conn=${arg%%:*}
+      local status=${arg#*:}
+      local card=${conn%%-*}
+      mkdir -p "$drm_root/$conn"
+      printf '%s\n' "$status" >"$drm_root/$conn/status"
+      ln -sfn "../$card" "$drm_root/$conn/device"
+    fi
+  done
+}
+
+drives_display() {
+  OMARCHY_DRM_PATH="$drm_root" "$ROOT/bin/omarchy-hw-nvidia-drives-display"
+}
+
+assert_drives() {
+  local description=$1 expected=$2
+  local actual=no
+  drives_display && actual=yes
+  [[ $actual == "$expected" ]] ||
+    fail "$description" "omarchy-hw-nvidia-drives-display: expected $expected, got $actual"
+  pass "$description"
+}
+
+# Hybrid: NVIDIA present but all its connectors disconnected; iGPU panel connected.
+write_drm_tree \
+  card0:0x10de card1:0x1002 \
+  card0-DP-1:disconnected card0-HDMI-A-1:disconnected \
+  card1-eDP-1:connected
+assert_drives "hybrid with idle NVIDIA dGPU does not drive the display" no
+
+# Same hybrid with an external plugged into the NVIDIA card.
+write_drm_tree \
+  card0:0x10de card1:0x1002 \
+  card0-DP-1:connected card0-HDMI-A-1:disconnected \
+  card1-eDP-1:connected
+assert_drives "hybrid with NVIDIA-connected external drives the display" yes
+
+# NVIDIA-only desktop with a connected panel.
+write_drm_tree \
+  card0:0x10de \
+  card0-DP-1:connected
+assert_drives "NVIDIA-only machine with a connected output drives the display" yes
+
+# NVIDIA card with no connectors at all.
+write_drm_tree card0:0x10de
+assert_drives "NVIDIA card with no connectors does not drive the display" no
+
+# No NVIDIA card.
+write_drm_tree \
+  card0:0x8086 \
+  card0-eDP-1:connected
+assert_drives "Intel-only machine does not report NVIDIA driving the display" no
+
+# Empty DRM tree.
+write_drm_tree
+assert_drives "empty DRM tree does not report NVIDIA driving the display" no

--- a/test/shell.d/nvidia-session-env-test.sh
+++ b/test/shell.d/nvidia-session-env-test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Session NVIDIA env must require both presence and a connected NVIDIA output
+# (issue #10410). Presence alone on a hybrid laptop stalls browser VA-API.
+
+require_command lua
+
+nvidia_lua="$ROOT/default/hypr/nvidia.lua"
+[[ -f $nvidia_lua ]] || fail "default hypr nvidia.lua exists"
+
+grep -F 'omarchy-hw-nvidia-drives-display' "$nvidia_lua" >/dev/null ||
+  fail "nvidia.lua gates session env on nvidia-drives-display"
+grep -F 'LIBVA_DRIVER_NAME' "$nvidia_lua" >/dev/null ||
+  fail "nvidia.lua still sets LIBVA_DRIVER_NAME when appropriate"
+pass "nvidia.lua gates LIBVA on nvidia-drives-display"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+# Fake omarchy path with the real lua module and stub detectors.
+fake_root="$test_tmp/omarchy"
+mkdir -p "$fake_root/bin" "$fake_root/default/hypr"
+cp "$ROOT/default/hypr/nvidia.lua" "$fake_root/default/hypr/nvidia.lua"
+cp "$ROOT/default/hypr/paths.lua" "$fake_root/default/hypr/paths.lua" 2>/dev/null || true
+
+# paths.lua may pull more; inject a minimal paths module via package.path override.
+cat >"$fake_root/default/hypr/paths.lua" <<'LUA'
+return {
+  omarchy_path = os.getenv("OMARCHY_PATH"),
+  home = os.getenv("HOME") or "",
+}
+LUA
+
+# nvidia.lua invokes detectors via $OMARCHY_PATH/bin/..., not PATH.
+for name in omarchy-hw-nvidia omarchy-hw-nvidia-gsp omarchy-hw-nvidia-without-gsp omarchy-hw-nvidia-drives-display; do
+  cat >"$fake_root/bin/$name" <<'SH'
+#!/bin/bash
+case "${0##*/}" in
+omarchy-hw-nvidia) [[ $OMARCHY_TEST_NVIDIA == 1 ]] && exit 0; exit 1 ;;
+omarchy-hw-nvidia-gsp) [[ $OMARCHY_TEST_GSP == 1 ]] && exit 0; exit 1 ;;
+omarchy-hw-nvidia-without-gsp) [[ $OMARCHY_TEST_WITHOUT_GSP == 1 ]] && exit 0; exit 1 ;;
+omarchy-hw-nvidia-drives-display) [[ $OMARCHY_TEST_DRIVES == 1 ]] && exit 0; exit 1 ;;
+esac
+exit 1
+SH
+  chmod +x "$fake_root/bin/$name"
+done
+
+run_nvidia_lua() {
+  local env_out
+  env_out=$(
+    OMARCHY_PATH="$fake_root" HOME="$test_tmp/home" PATH="/usr/bin:/bin" \
+      OMARCHY_TEST_NVIDIA="${1:-0}" \
+      OMARCHY_TEST_GSP="${2:-0}" \
+      OMARCHY_TEST_WITHOUT_GSP="${3:-0}" \
+      OMARCHY_TEST_DRIVES="${4:-0}" \
+      lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+local envs = {}
+hl = {
+  env = function(k, v)
+    envs[#envs + 1] = k .. "=" .. tostring(v)
+  end,
+}
+o = {
+  shell_quote = function(s) return "'" .. tostring(s):gsub("'", "'\\''") .. "'" end,
+  shell_succeeds = function(cmd)
+    -- Lua 5.1 returns exit status as a number; 5.2+ returns success, typ, code.
+    local a, b, c = os.execute(cmd .. " >/dev/null 2>&1")
+    if a == true then return true end
+    if type(a) == "number" then return a == 0 end
+    if b == "exit" and c == 0 then return true end
+    return false
+  end,
+}
+require("default.hypr.nvidia")
+table.sort(envs)
+print(table.concat(envs, " "))
+LUA
+  )
+  printf '%s' "$env_out"
+}
+
+# Hybrid: NVIDIA GSP present, not driving display → no LIBVA.
+out=$(run_nvidia_lua 1 1 0 0)
+[[ $out != *LIBVA_DRIVER_NAME* ]] ||
+  fail "hybrid idle dGPU must not set LIBVA_DRIVER_NAME" "envs: $out"
+[[ $out != *__GLX_VENDOR_LIBRARY_NAME* ]] ||
+  fail "hybrid idle dGPU must not set __GLX_VENDOR_LIBRARY_NAME" "envs: $out"
+pass "hybrid idle dGPU sets no NVIDIA session env"
+
+# NVIDIA GSP driving a display → full env.
+out=$(run_nvidia_lua 1 1 0 1)
+[[ $out == *LIBVA_DRIVER_NAME=nvidia* ]] ||
+  fail "NVIDIA driving display sets LIBVA_DRIVER_NAME" "envs: $out"
+[[ $out == *__GLX_VENDOR_LIBRARY_NAME=nvidia* ]] ||
+  fail "NVIDIA driving display sets __GLX_VENDOR_LIBRARY_NAME" "envs: $out"
+[[ $out == *NVD_BACKEND=direct* ]] ||
+  fail "NVIDIA GSP driving display sets NVD_BACKEND=direct" "envs: $out"
+pass "NVIDIA GSP driving display sets full session env"
+
+# No NVIDIA at all → empty.
+out=$(run_nvidia_lua 0 0 0 0)
+[[ -z $out ]] || fail "no NVIDIA leaves session env empty" "envs: $out"
+pass "no NVIDIA leaves session env empty"
+
+# NVIDIA present + drives display but without GSP → egl path, no LIBVA (legacy).
+out=$(run_nvidia_lua 1 0 1 1)
+[[ $out == *NVD_BACKEND=egl* ]] ||
+  fail "legacy NVIDIA driving display sets NVD_BACKEND=egl" "envs: $out"
+[[ $out != *LIBVA_DRIVER_NAME* ]] ||
+  fail "legacy without-gsp path does not set LIBVA" "envs: $out"
+pass "legacy NVIDIA driving display sets egl path without LIBVA"


### PR DESCRIPTION
## Summary

Fixes #10410.

`default/hypr/nvidia.lua` set `LIBVA_DRIVER_NAME=nvidia` (and related vendor env) whenever `omarchy-hw-nvidia-gsp` succeeded — i.e. whenever a GSP NVIDIA GPU was **present**. On hybrid laptops the dGPU often drives no outputs while the panel hangs off the iGPU. Browsers then composite on the iGPU while VA-API is forced onto NVIDIA, which stalls video-heavy pages. The issue's A/B with only `LIBVA_DRIVER_NAME` swapped confirmed that path.

Related open PR #9483 takes a similar direction; this ships the detector + gate with focused tests.

### Change

- New `bin/omarchy-hw-nvidia-drives-display`: true iff a DRM connector with `status=connected` belongs to a card whose PCI vendor is `0x10de`. Reads cached sysfs only (no `lspci` wake).
- `default/hypr/nvidia.lua`: require **both** `omarchy-hw-nvidia` and `omarchy-hw-nvidia-drives-display` before setting `NVD_BACKEND` / `LIBVA_DRIVER_NAME` / `__GLX_VENDOR_LIBRARY_NAME`.

NVIDIA-only machines and hybrids with a monitor on the dGPU still get the env. Idle hybrid dGPU does not.

## Evidence

### Bug reproduced (pre-fix)

```lua
if o.shell_succeeds(nvidia) then
  if o.shell_succeeds(nvidia_gsp) then
    hl.env("LIBVA_DRIVER_NAME", "nvidia")  -- presence only
```

Issue reporter: hybrid with all NVIDIA connectors `disconnected`, AMD eDP `connected`; Chrome stalls with default LIBVA, smooth with `radeonsi`.

### Fix validated

```
bash test/shell.d/hw-nvidia-test.sh
# includes:
ok - hybrid with idle NVIDIA dGPU does not drive the display
ok - hybrid with NVIDIA-connected external drives the display
ok - NVIDIA-only machine with a connected output drives the display
...

bash test/shell.d/nvidia-session-env-test.sh
ok - hybrid idle dGPU sets no NVIDIA session env
ok - NVIDIA GSP driving display sets full session env
ok - no NVIDIA leaves session env empty
ok - legacy NVIDIA driving display sets egl path without LIBVA
```

## Test plan

- [x] Fake DRM tree: idle hybrid / connected hybrid / NVIDIA-only / empty
- [x] nvidia.lua env matrix via stub detectors
- [x] Existing PCI GPU detector tests still green
- [ ] Manual hybrid laptop: confirm no `LIBVA_DRIVER_NAME=nvidia` in session when dGPU has no connected output; Chrome video smooth