### PR TITLE
Enable nvidia-powerd so laptop GPUs get Dynamic Boost

### DIFF
--- a/install/hardware/nvidia.sh
+++ b/install/hardware/nvidia.sh
@@ -17,6 +17,10 @@ if lspci | grep -qi 'nvidia'; then
 
   omarchy-pkg-add "${PACKAGES[@]}"
 
+  # Dynamic Boost needs nvidia-powerd running; Arch ships the unit disabled.
+  # Without it, laptop GPUs stay at base TGP.
+  systemctl enable nvidia-powerd
+
   # Per-session Hyprland NVIDIA env vars are handled by default/hypr/nvidia.lua.
 
   # Configure modprobe for early KMS

--- a/install/hardware/nvidia.sh
+++ b/install/hardware/nvidia.sh
@@ -17,9 +17,11 @@ if lspci | grep -qi 'nvidia'; then
 
   omarchy-pkg-add "${PACKAGES[@]}"
 
-  # Dynamic Boost needs nvidia-powerd running; Arch ships the unit disabled.
-  # Without it, laptop GPUs stay at base TGP.
-  systemctl enable nvidia-powerd
+  # Enable Dynamic Boost on systems exposing NVIDIA's platform controller.
+  # Match the ACPI hardware ID without assuming a particular device instance.
+  if grep -qx 'NVDA0820' /sys/bus/acpi/devices/*/hid 2>/dev/null; then
+    systemctl enable nvidia-powerd
+  fi
 
   # Per-session Hyprland NVIDIA env vars are handled by default/hypr/nvidia.lua.
 


### PR DESCRIPTION
Fixes #9678

## What

Enables `nvidia-powerd` in `install/hardware/nvidia.sh` after driver installation, only when an ACPI device exposes NVIDIA's platform-controller hardware ID (`NVDA0820`).

## Why

Arch ships `nvidia-powerd.service` with `preset: disabled`. Nothing in the install enables it, so on laptops the GPU stays at its base TGP with no Dynamic Boost.

On an ASUS ROG Strix G16 with an RTX 5060 Laptop GPU:

**Without the daemon:**

    Current Power Limit    : 50.00 W
    Default Power Limit    : 50.00 W

Pinned at 49.5–50W at 65–69°C under sustained 99% load.

**With it:**

    Current Power Limit    : 100.00 W
    Default Power Limit    :  50.00 W
    Max Power Limit        : 115.00 W

85–93W at 78–80°C under the same load.

Reproduced in both directions on the same hardware — masking the daemon on a working install drops the ceiling straight back to 50W, and enabling it on a fresh Omarchy install raises it immediately.

## Notes

- `enable` rather than `enable --now`, since the install runs before the graphical session and the daemon is only useful from next boot.
- Checks for an exact `NVDA0820` match in `/sys/bus/acpi/devices/*/hid`, without assuming instance `:00`. Systems without a match skip enablement.
- Unsupported systems can leave a failed service because the daemon can exit nonzero and the unit restarts on failure. The guard avoids enabling it on systems without the controller; the controller's presence does not guarantee working Dynamic Boost.
- Discussion #4726 reports the same symptom on Acer laptops.
