### PR TITLE
Clear setgid when hardening Windows VM directories

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,7 +580,9 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  # GNU chmod preserves directory setgid with 0700. Clear it explicitly:
+  # Samba initializes an empty /shared with 2777, which otherwise becomes 2700.
+  chmod 00700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
@@ -1015,7 +1017,7 @@ prepare_user_mount_sources() {
     echo "omarchy-windows-vm: storage and shared must be different directories" >&2
     return 1
   }
-  chmod 0700 -- "$storage" "$shared"
+  chmod 00700 -- "$storage" "$shared"
 }
 
 storage_space_path() {

--- a/test/shell.d/windows-vm-compose-test.sh
+++ b/test/shell.d/windows-vm-compose-test.sh
@@ -54,6 +54,12 @@ reset_case() {
 
 # Fixed protected anchors consume the pinned source inodes.
 prepare_user_mount_sources
+# Samba initializes an empty share with setgid; user-side preparation must
+# remove that bit as well as group/other access before the root handoff.
+chmod 2777 "$HOME/Windows"
+prepare_user_mount_sources || fail "user preparation rejected a setgid shared directory"
+[[ $(stat -Lc '%a' "$HOME/Windows") == 700 ]] || fail "user preparation retained setgid on the shared directory"
+pass "user preparation clears Samba's setgid shared-directory mode"
 write 4G 2 64G alice s3cret Europe/Copenhagen
 resolve_caller
 [[ -f $COMPOSE ]] || fail "writer produced a compose file"

--- a/test/shell.d/windows-vm-mount-boundary-test.sh
+++ b/test/shell.d/windows-vm-mount-boundary-test.sh
@@ -156,6 +156,15 @@ printf 'RAM=4G\nCORES=2\nDISK=64G\nUSERNAME=alice\nPASSWORD=pw\nTZ=UTC\n' |
 with_vm_lock assert_mounts_safe || fail "final root mount/compose assertion rejected the verified pair"
 pass "root writer and final pre-Docker guard revalidate the pinned production mounts"
 
+# Samba can add setgid again after the initial bind. Launch/removal must
+# re-harden that same source rather than fail before touching Docker.
+chmod 2777 /home/shared-target
+with_vm_lock assert_mounts_safe || fail "root rejected a share initialized with Samba's setgid mode"
+mounts_ready || fail "re-hardened setgid share failed final mount validation"
+[[ $(command stat -Lc '%a' /home/shared-target) == 700 ]] || fail "root retained setgid on the shared source"
+[[ $(cat "$EXPECTED_SHARED/shared.txt") == shared ]] || fail "setgid hardening changed shared data"
+pass "root re-hardens Samba's setgid share through the existing pinned bind"
+
 # Upgrade the exact sibling-anchor pair emitted by the earlier fix without
 # moving or replacing either familiar home symlink.
 sed -i "s|$EXPECTED_STORAGE:/storage|$OLD_EXPECTED_STORAGE:/storage|" "$COMPOSE_FILE"


### PR DESCRIPTION
## Problem

Windows VM `launch` and `remove` can fail at `prepare_caller_mounts` after the guest has successfully installed. On Omarchy 4.0.2, launch printed only `Failed to start Windows VM!` despite the guest already running.

Dockurr's Samba setup initializes an empty `/shared` directory with mode `2777`. GNU `chmod 0700` deliberately preserves directory setgid, leaving `2700`. The helper then requires exactly `700` and returns before querying/starting Docker. The same normalization problem exists in user-side source preparation.

Minimal reproduction:

```sh
dir=$(mktemp -d)
chmod 2777 "$dir"
chmod 0700 "$dir"
stat -c %a "$dir"   # 2700, not 700
chmod 00700 "$dir"
stat -c %a "$dir"   # 700
rmdir "$dir"
```

## Change

Use the explicit five-digit `00700` mode in both source-preparation paths. The privileged path still operates through pinned file descriptors. Exact owner/mode checks, mount identity validation, and the privilege boundary remain unchanged; no permission check is relaxed.

Add regressions for user-side normalization and for re-hardening a Samba-modified shared source through an existing privileged bind mount, preserving its data.

## Verification

- The new user-side regression fails before the fix (`user preparation retained setgid on the shared directory`) and passes afterward; the complete `windows-vm-compose-test.sh` passes.
- The complete `windows-vm-mount-boundary-test.sh`, including the new privileged regression, passes in an isolated root mount namespace. Existing live VM binds were detached **only inside that private test namespace** to avoid inherited/covered mountinfo entries colliding with the fixture's fixed production paths.
- `windows-vm-test.sh` and Bash syntax checks pass.
- Built a local package from the exact v4.0.2 source. Payload comparison against the signed official 4.0.2-1 archive shows only `usr/bin/omarchy-windows-vm` changed (no added/removed payload paths).
- Installed that package locally, set the real shared directory back to `2700`, and exercised the installed privileged `up_wait` path: it normalized both the source and bind view to `700` and returned successfully. The existing RDP session remained open.

### Aggregate suite limitations

Ran `./test/all` without a compositor: CLI passed; the shell runner reported 7/229 failing test files. Follow-up isolated checks identified:

- `bar-text-color`: local ffmpeg cannot load `libbluray.so.4`.
- `bin-style`: existing helper-policy violations in `omarchy-remove-ai-hermes` and `omarchy-remove-ai-openclaw`.
- `config`: missing sibling package fixtures; passes after those fixtures are checked out.
- `launch-about`: failed in the aggregate run, passed standalone.
- `locate`: the aggregate run generated `bin/__pycache__` files that its text scan cannot decode; passes after removing those generated files.
- `snapper`: requires additional sibling `omarchy-iso` checkout coverage not available here.
- `windows-vm-mount-boundary`: inherited live production bind mounts collide with the fixture; passes with the private-namespace isolation described above.

No unrelated runtime code or tests were changed to suppress those failures.
