### PR TITLE
Detach Windows installer progress browser from its terminal

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -1342,7 +1342,7 @@ EOF
 
   # Open browser to monitor installation
   sleep 3
-  xdg-open "http://127.0.0.1:8006"
+  omarchy-launch-browser "http://127.0.0.1:8006"
 
   echo ""
   echo "Installation is running in the background."

--- a/test/shell.d/windows-vm-install-test.sh
+++ b/test/shell.d/windows-vm-install-test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+require_command python3
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import tempfile
+import time
+
+root = Path(os.environ["ROOT"])
+with tempfile.TemporaryDirectory(prefix="omarchy-windows-install-") as scratch:
+  scratch = Path(scratch)
+  home = scratch / "home"
+  applications = home / ".local/share/applications"
+  applications.mkdir(parents=True)
+  mock_bin = scratch / "bin"
+  mock_bin.mkdir()
+  browser_state = scratch / "browser.json"
+  browser_stop = scratch / "stop"
+  installer_done = scratch / "installed"
+
+  def executable(name, body):
+    path = mock_bin / name
+    path.write_text(body)
+    path.chmod(0o755)
+    return path
+
+  browser = executable("test-browser", '''#!/usr/bin/env python3
+import json, os, sys, time
+from pathlib import Path
+if "--help" in sys.argv:
+  sys.exit(0)
+state_file = Path(os.environ["TEST_BROWSER_STATE"])
+pending_state = state_file.with_suffix(".tmp")
+pending_state.write_text(json.dumps({
+  "pid": os.getpid(), "pgid": os.getpgrp(),
+  "fds": [os.readlink(f"/proc/self/fd/{fd}") for fd in range(3)]
+}))
+pending_state.replace(state_file)
+print("browser-output-must-not-reach-installer", flush=True)
+print("browser-errors-must-not-reach-installer", file=sys.stderr, flush=True)
+while not Path(os.environ["TEST_BROWSER_STOP"]).exists():
+  time.sleep(0.02)
+''')
+  applications.joinpath("test-browser.desktop").write_text(f"[Desktop Entry]\nExec={browser} %U\n")
+  executable("xdg-settings", "#!/bin/bash\nprintf '%s\\n' test-browser.desktop\n")
+  executable("xdg-open", '#!/bin/bash\nexec test-browser "$@"\n')
+  executable("uwsm-app", '#!/bin/bash\nshift\nexec "$@"\n')
+
+  # Model the external service manager, not the browser launcher under test:
+  # it starts the requested command independently with disconnected stdio.
+  executable("systemd-run", '''#!/usr/bin/env python3
+import subprocess, sys
+args = sys.argv[1:]
+while args and args[0].startswith("--"):
+  args.pop(0)
+subprocess.Popen(args, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                 stderr=subprocess.DEVNULL, start_new_session=True)
+''')
+
+  # Exercise the real install flow and real omarchy-launch-browser. Only the
+  # interactive setup, package installation, and VM provisioning are stubbed.
+  driver = '''
+set -- help
+source "$ROOT/bin/omarchy-windows-vm" >/dev/null
+check_prerequisites() { :; }
+omarchy-pkg-add() { :; }
+available_storage_gb() { echo 128; }
+write_compose() { :; }
+priv() { [[ $1 == up ]]; }
+sleep() { :; }
+timedatectl() { echo UTC; }
+gum() {
+  case "$1" in
+    choose)
+      for arg in "$@"; do
+        if [[ $arg == --selected=* ]]; then printf '%s\\n' "${arg#*=}"; return; fi
+      done
+      ;;
+    input)
+      case "$*" in
+        *username*) echo alice ;;
+        *password*) echo test-password ;;
+        *) echo 2 ;;
+      esac
+      ;;
+    confirm|style) return 0 ;;
+  esac
+}
+install_windows
+status=$?
+((status == 0)) || exit "$status"
+: > "$TEST_INSTALLER_DONE"
+'''
+  env = dict(os.environ, HOME=str(home), PATH=f"{mock_bin}:{root / 'bin'}:{os.environ['PATH']}",
+             OMARCHY_WINDOWS_DIR=str(scratch / "runtime"), HYPRLAND_INSTANCE_SIGNATURE="",
+             TEST_BROWSER_STATE=str(browser_state), TEST_BROWSER_STOP=str(browser_stop),
+             TEST_INSTALLER_DONE=str(installer_done))
+  process = subprocess.Popen(["bash", "-c", driver], env=env, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, text=True, start_new_session=True)
+  try:
+    try:
+      stdout, stderr = process.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+      raise SystemExit("not ok - installer waits for the progress browser to exit")
+    if process.returncode or not installer_done.exists():
+      raise SystemExit(f"not ok - installer did not complete: {stdout}\n{stderr}")
+    deadline = time.monotonic() + 5
+    while not browser_state.exists() and time.monotonic() < deadline:
+      time.sleep(0.02)
+    if not browser_state.exists():
+      raise SystemExit("not ok - progress browser did not start")
+    state = json.loads(browser_state.read_text())
+    os.kill(state["pid"], 0)
+    if state["pgid"] == process.pid or state["fds"] != ["/dev/null"] * 3:
+      raise SystemExit("not ok - progress browser remains attached to the installer terminal")
+    if "browser-output-must-not-reach-installer" in stdout or "browser-errors-must-not-reach-installer" in stderr:
+      raise SystemExit("not ok - browser diagnostics leaked into installer output")
+    print("ok - installer completes while the progress browser remains alive and detached")
+  finally:
+    browser_stop.touch()
+    if process.poll() is None:
+      os.killpg(process.pid, signal.SIGKILL)
+      process.communicate()
+    if browser_state.exists():
+      try:
+        os.kill(json.loads(browser_state.read_text())["pid"], signal.SIGTERM)
+      except ProcessLookupError:
+        pass
+PY


### PR DESCRIPTION
## Problem

The Windows installer invokes `xdg-open http://127.0.0.1:8006` synchronously after starting Docker. When this starts a foreground browser process, the installer remains at `Opening browser to monitor installation...` even after Windows finishes installing. Browser diagnostics continue flooding the installer terminal, and interrupting/closing that terminal can also affect the browser.

Observed process chain:

```text
omarchy-windows-vm install -> xdg-open -> chromium
```

## Change

Use the existing `omarchy-launch-browser` helper. It already launches the browser through systemd/uwsm with disconnected standard streams, allowing the installer to return and print its final instructions without owning the browser's lifetime. No new launcher or detachment mechanism is introduced.

This is independent of the directory-permission fix in #10595.

## Regression coverage

Add an install-flow regression using a browser that stays alive until the test releases it. The test runs the real installer function and real browser launcher; interactive provisioning and the external service-manager boundary are isolated. It verifies that the installer completes while the browser remains alive in a different process group with disconnected stdin/stdout/stderr, and that browser diagnostics do not reach the installer output.

The regression fails before the change with `installer waits for the progress browser to exit` and passes afterward.

## Verification

- `windows-vm-install-test.sh`, `launch-browser-test.sh`, and Bash syntax checks pass.
- A separate smoke test used the **real user systemd manager and real uwsm-app** with a harmless browser probe. The launcher returned successfully while the probe remained alive in its own session, with all three streams pointing to `/dev/null`. The probe and temporary files were then removed.
- Built and installed a local 4.0.2 package retaining #10595. Compared with the previous local package, the sole payload change is this one-line browser handoff in `usr/bin/omarchy-windows-vm`.
- Re-ran the install-flow scenario against the **installed** installer and browser launcher. It passed without provisioning or modifying the actual Windows VM.
- `./test/all` was run headlessly: CLI passed; the new regression passed in the aggregate run. The shell suite reported 5/230 failures already seen before this change: `bar-text-color` (local ffmpeg/libbluray linkage), `bin-style` (unrelated AI removal scripts), `launch-about`, `snapper` (missing sibling ISO checkout), and `windows-vm-mount-boundary` (inherited live production bind mounts collide with the isolated fixture). No unrelated tests were changed to hide these failures.

An already-running installer blocked inside its old `xdg-open` call is not retroactively detached by updating the package; this fixes subsequent invocations.
