### PR TITLE
Fix Wi-Fi password recovery after authentication failure

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -788,11 +788,17 @@ Panel {
 
   function failNetworkAction(network, reason) {
     if (!network || actionKind === "" || actionSsid !== (network.name || "")) return
+    var ssid = actionSsid
+    var needsCredentials = requiresCredentials(network.security)
+    var reprompt = actionKind === "connect" && shouldRepromptPassphrase(reason, needsCredentials)
     actionTimeout.stop()
-    failureSsid = actionSsid
-    failureReason = networkFailureReason(reason, requiresCredentials(network.security))
+    failureSsid = ssid
+    failureReason = networkFailureReason(reason, needsCredentials)
     actionSsid = ""
     actionKind = ""
+    // Keep recovery in the panel: refresh() replaces the rows and can destroy
+    // the delegate that delivered this failure before its handler returns.
+    if (reprompt) openPasswordPrompt(ssid)
     refresh()
   }
 
@@ -1743,12 +1749,7 @@ Panel {
     Connections {
       target: row.net ? root.networkForSsid(row.net.ssid) : null
       function onConnectionFailed(reason) {
-        // Background auto-connect retries fire this too; only reprompt for
-        // the connect started from this panel. Checked before
-        // failNetworkAction, which clears the action state.
-        var ours = root.actionKind === "connect" && root.actionSsid === (row.net.ssid || "")
         root.failNetworkAction(root.networkForSsid(row.net.ssid), reason)
-        if (ours && root.shouldRepromptPassphrase(reason, row.requiresCredentials)) root.openPasswordPrompt(row.net.ssid)
       }
       function onConnectedChanged() {
         if (row.net) root.checkActionCompletion(root.networkForSsid(row.net.ssid))

--- a/test/shell.d/network-test.sh
+++ b/test/shell.d/network-test.sh
@@ -222,14 +222,6 @@ assert(
   'network row clicks gate unknown-network prompts on credential requirements'
 )
 assert(
-  /shouldRepromptPassphrase\(reason, row\.requiresCredentials\)/.test(panelSource),
-  'network failure reprompts use the row credential requirement'
-)
-assert(
-  /networkFailureReason\(reason, requiresCredentials\(network\.security\)\)/.test(panelSource),
-  'network failure copy uses the live network credential requirement'
-)
-assert(
   /readonly property bool canForget: root\.canForgetNetwork\(net\)/.test(panelSource),
   'network rows derive forget eligibility from the tested model helper'
 )
@@ -267,6 +259,48 @@ assertEqual(network.shouldRepromptPassphrase(reasons.NoSecrets, false, reasons),
 assertEqual(network.shouldRepromptPassphrase(reasons.WifiAuthTimeout, true, reasons), true, 'network reprompts a credentialed network after a wrong password')
 assertEqual(network.shouldRepromptPassphrase(reasons.WifiAuthTimeout, false, reasons), false, 'network does not reprompt an open network on auth timeout')
 assertEqual(network.shouldRepromptPassphrase(reasons.WifiClientFailed, true, reasons), false, 'network does not reprompt on generic connection failures')
+
+// A refresh replaces the row model and can destroy the calling delegate.
+// Execute the real handlers with separate panel/delegate scopes, invalidating
+// the delegate on refresh just as QML does during a failed first connection.
+const vm = require('vm')
+const failureHandler = panelSource.match(/function failNetworkAction\(network, reason\) \{[\s\S]*?\n {2}\}/)[0]
+const failureSignal = panelSource.match(/function onConnectionFailed\(reason\) \{[\s\S]*?\n {6}\}/)[0]
+function failConnection(kind, reason, secured = true, actionSsid = 'test-network') {
+  const wifi = { name: 'test-network', security: secured }
+  let delegate
+  const panel = vm.createContext({
+    actionKind: kind, actionSsid, failureSsid: '', failureReason: '',
+    passwordSsid: '', stopped: false, refreshed: false,
+    requiresCredentials: security => security,
+    networkFailureReason: (reason, secured) => network.networkFailureReason(reason, secured, reasons),
+    shouldRepromptPassphrase: (reason, secured) => network.shouldRepromptPassphrase(reason, secured, reasons),
+    networkForSsid: () => wifi,
+    actionTimeout: { stop() { panel.stopped = true } },
+    openPasswordPrompt(ssid) { panel.passwordSsid = ssid },
+    refresh() {
+      panel.refreshed = true
+      delegate.root = undefined
+      delegate.row = undefined
+    }
+  })
+  vm.runInContext(failureHandler, panel)
+  delegate = vm.createContext({ root: panel, row: { net: { ssid: wifi.name }, requiresCredentials: secured }, reason })
+  vm.runInContext(failureSignal + '\nonConnectionFailed(reason)', delegate)
+  return panel
+}
+for (const reason of [reasons.NoSecrets, reasons.WifiAuthTimeout]) {
+  const failed = failConnection('connect', reason)
+  assertEqual(failed.passwordSsid, 'test-network', 'network restores password entry even when refresh destroys the calling row')
+  assert(failed.stopped && failed.refreshed && failed.actionKind === '', 'network ends the failed action and refreshes its rows')
+  assertEqual(failed.failureSsid, 'test-network', 'network preserves the failed SSID for its error message')
+  assertEqual(failed.failureReason, network.networkFailureReason(reason, true, reasons), 'network failure copy uses the live network credential requirement')
+}
+assertEqual(failConnection('', reasons.NoSecrets).passwordSsid, '', 'network does not reprompt for background failures')
+assertEqual(failConnection('connect', reasons.NoSecrets, true, 'another-network').passwordSsid, '', 'network ignores failures for a different action')
+assertEqual(failConnection('disconnect', reasons.NoSecrets).passwordSsid, '', 'network does not reprompt for a failed disconnect')
+assertEqual(failConnection('connect', reasons.NoSecrets, false).passwordSsid, '', 'network does not reprompt for a passwordless connection failure')
+assertEqual(failConnection('connect', reasons.WifiClientFailed).passwordSsid, '', 'network does not reprompt for a generic connection failure')
 
 
 assertEqual(network.bandLabel('2.4'), '2.4ghz', 'network labels the 2.4GHz band')


### PR DESCRIPTION
Closing the Wi-Fi panel while an incorrect password is being authenticated can leave it showing “Passphrase required” without a password field when reopened. The failure handler refreshes the row model, which can destroy the calling delegate before it opens the password prompt, producing a QML reference/type error.

Move password recovery into the panel-owned failure handler before refreshing the rows. The delegate now only forwards the failure. Add a regression test that invalidates the delegate during refresh and verifies credential recovery, action cleanup, and ignored unrelated failures.

Related to #10406. The missing password field was reproduced; the reported inability to forget the network was not reproduced.

Validation:
- Network regression tests and QML text-format checks pass.
- Reproduced before and verified after in an Omarchy 4.0.2 QEMU/KVM guest using two mac80211_hwsim virtual radios, hostapd WPA2, and DHCP.
- After the fix, reopening restores password entry; entering the correct password connects and receives a DHCP address.

[Investigation and screenshots](https://gist.github.com/cristianbica/7b3ff83902fb39246da6fbec70c0f078)

**Before**

https://github.com/user-attachments/assets/834192b8-cae2-43a5-8410-346a733f60f2


**After**

https://github.com/user-attachments/assets/d182ce55-8649-4b65-8611-729ad544aa7e

