### PR TITLE
Move Kitty defaults to the system config and restrict remote control

### DIFF
--- a/bin/omarchy-display-text-size
+++ b/bin/omarchy-display-text-size
@@ -129,7 +129,8 @@ term_pt_for() {
     'BEGIN { printf "%d", int(s * p / b + 0.5) }'
 }
 
-# Set the font point size in every terminal config that exists. Family is left
+# Set the font point size in terminal configs, creating Kitty overrides when
+# it inherits its size from the system config. Family is left
 # untouched — that is omarchy-font-set's job. Live-reload signals mirror
 # omarchy-font-set; foot has no reload signal, so running instances are nudged.
 set_terminal_size() {
@@ -139,8 +140,13 @@ set_terminal_size() {
     sed -i -E "s/^size[[:space:]]*=.*/size = $pt/" ~/.config/alacritty/alacritty.toml
   fi
 
-  if [[ -f ~/.config/kitty/kitty.conf ]]; then
-    sed -i -E "s/^font_size[[:space:]]+.*/font_size $pt.0/" ~/.config/kitty/kitty.conf
+  if [[ -f ~/.config/kitty/kitty.conf ]] || omarchy-cmd-present kitty; then
+    mkdir -p ~/.config/kitty
+    if grep -qE '^[[:space:]]*font_size[[:space:]]+' ~/.config/kitty/kitty.conf 2>/dev/null; then
+      sed --follow-symlinks -i -E "s/^[[:space:]]*font_size[[:space:]]+.*/font_size $pt.0/" ~/.config/kitty/kitty.conf
+    else
+      printf '\nfont_size %s.0\n' "$pt" >>~/.config/kitty/kitty.conf
+    fi
     pkill -USR1 kitty 2>/dev/null || true
   fi
 
@@ -177,9 +183,13 @@ term_current_pt() {
   elif [[ -f ~/.config/alacritty/alacritty.toml ]]; then
     grep -oP '^size[[:space:]]*=[[:space:]]*\K[0-9.]+' ~/.config/alacritty/alacritty.toml | head -1
   elif [[ -f ~/.config/kitty/kitty.conf ]]; then
-    grep -oP '^font_size[[:space:]]+\K[0-9.]+' ~/.config/kitty/kitty.conf | head -1
+    local pt
+    pt=$(grep -oP '^[[:space:]]*font_size[[:space:]]+\K[0-9.]+' ~/.config/kitty/kitty.conf | tail -1)
+    echo "${pt:-$TERM_DEFAULT_PT}"
   elif [[ -f ~/.config/foot/foot.ini ]]; then
     grep -oP ':size=\K[0-9.]+' ~/.config/foot/foot.ini | head -1
+  elif omarchy-cmd-present kitty; then
+    echo "$TERM_DEFAULT_PT"
   fi
 }
 

--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -30,8 +30,14 @@ if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
   sed -i "s/family = \".*\"/family = \"$font_name\"/g" ~/.config/alacritty/alacritty.toml
 fi
 
-if [[ -f ~/.config/kitty/kitty.conf ]]; then
-  sed -i "s/^font_family .*/font_family $font_name/g" ~/.config/kitty/kitty.conf
+if [[ -f ~/.config/kitty/kitty.conf ]] || omarchy-cmd-present kitty; then
+  mkdir -p ~/.config/kitty
+  if grep -qE '^[[:space:]]*font_family[[:space:]]+' ~/.config/kitty/kitty.conf 2>/dev/null; then
+    kitty_font_name=$(printf '%s' "$font_name" | sed 's/[\\&/]/\\&/g')
+    sed --follow-symlinks -i -E "s/^[[:space:]]*font_family[[:space:]]+.*/font_family $kitty_font_name/" ~/.config/kitty/kitty.conf
+  else
+    printf '\nfont_family %s\n' "$font_name" >>~/.config/kitty/kitty.conf
+  fi
   pkill -USR1 kitty
 fi
 

--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -1,6 +1,6 @@
+# Remove the include below to disconnect Kitty from Omarchy's theming system.
 include ~/.local/state/omarchy/current/theme/kitty.conf
 
-# Remove or replace the include above to stop following Omarchy's theme.
 # Settings below override Omarchy's defaults in /etc/xdg/kitty/kitty.conf.
 # Learn more: https://sw.kovidgoyal.net/kitty/conf/
 

--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -1,35 +1,21 @@
 include ~/.local/state/omarchy/current/theme/kitty.conf
 
+# Remove or replace the include above to stop following Omarchy's theme.
+# Settings below override Omarchy's defaults in /etc/xdg/kitty/kitty.conf.
+# Learn more: https://sw.kovidgoyal.net/kitty/conf/
+
 # Font
-font_family JetBrainsMono Nerd Font
-bold_italic_font auto
-font_size        9.0
+# font_family JetBrainsMono Nerd Font
+# font_size 12
 
-# Window
-window_padding_width 14
-hide_window_decorations yes
-confirm_os_window_close 0
+# Window padding
+# window_padding_width 14
 
-# Keybindings
-map ctrl+insert copy_to_clipboard
-map shift+insert paste_from_clipboard
-# Send Shift+Enter as CSI-u so TUIs can distinguish it from Enter.
-map shift+enter send_text all \e[13;2u
-# Kitty legacy encoding sends Alt+Shift+Enter the same as Alt+Enter; send CSI-u so tmux can match M-S-Enter.
-map alt+shift+enter send_text all \e[13;4u
+# Unmap a shortcut, passing it through to the terminal application
+# map ctrl+insert
 
-# Allow remote access
-allow_remote_control yes
-listen_on unix:${XDG_RUNTIME_DIR}/omarchy-kitty-{kitty_pid}
+# Set or replace a shortcut
+# map ctrl+shift+c copy_to_clipboard
 
-# Aesthetics
-cursor_shape block
-cursor_blink_interval 0
-shell_integration no-cursor
-enable_audio_bell no
-
-# Minimal Tab bar styling
-tab_bar_edge                bottom
-tab_bar_style               powerline
-tab_powerline_style         slanted
-tab_title_template          {title}{' :{}:'.format(num_windows) if num_windows > 1 else ''}
+# Remove all inherited shortcuts, including Kitty's built-in shortcuts
+# clear_all_shortcuts yes

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -84,6 +84,7 @@ version                        ──►  omarchy             /usr/share/omarchy
 config/**                      ──►  omarchy-settings    /etc/skel/.config/**         (seeds new users)
                                                         /usr/share/omarchy/config/** (resync source)
 etc/fastfetch/config.jsonc     ──►  omarchy-settings    /etc/fastfetch/config.jsonc
+etc/xdg/kitty/kitty.conf       ──►  omarchy-settings    /etc/xdg/kitty/kitty.conf
 
 applications/*.desktop         ──►  omarchy-settings    /etc/skel/.local/share/applications/
                                                         /usr/share/omarchy/applications/
@@ -360,3 +361,9 @@ return to the packaged default.
 | New stock theme | `themes/<name>/` (+ matching templates under `default/themed/` if they need theme colors) |
 | User-installed theme | `~/.config/omarchy/themes/<name>/` |
 | Generated current theme/background state | `~/.local/state/omarchy/current/` |
+
+## Kitty defaults and user overrides
+
+Kitty loads `/etc/xdg/kitty/kitty.conf` before `~/.config/kitty/kitty.conf`. The `omarchy-settings` package owns the system file; the user template contains only the active theme include and commented examples for personal overrides. Keeping the theme include in the user file lets users remove it without changing the packaged defaults. Individual inherited keybindings can be unmapped with an empty `map <shortcut>` directive, or all inherited bindings can be cleared with `clear_all_shortcuts yes`.
+
+The system default uses `allow_remote_control socket-only` so Omarchy can query the active terminal directory over its Unix socket while Kitty rejects remote-control requests arriving through terminal output. Changing this setting requires restarting Kitty. The migration refreshes the exact previous stock config with a backup; customized configs retain their settings and ordering, with only explicit unrestricted `yes`, `y`, or `true` remote-control settings commented out.

--- a/etc/xdg/kitty/kitty.conf
+++ b/etc/xdg/kitty/kitty.conf
@@ -1,0 +1,35 @@
+# Omarchy defaults. Put personal overrides in ~/.config/kitty/kitty.conf.
+
+# Font
+font_family JetBrainsMono Nerd Font
+bold_italic_font auto
+font_size        9.0
+
+# Window
+window_padding_width 14
+hide_window_decorations yes
+confirm_os_window_close 0
+
+# Keybindings
+map ctrl+insert copy_to_clipboard
+map shift+insert paste_from_clipboard
+# Send Shift+Enter as CSI-u so TUIs can distinguish it from Enter.
+map shift+enter send_text all \e[13;2u
+# Kitty legacy encoding sends Alt+Shift+Enter the same as Alt+Enter; send CSI-u so tmux can match M-S-Enter.
+map alt+shift+enter send_text all \e[13;4u
+
+# Allow local cwd lookup, but reject remote control through terminal output.
+allow_remote_control socket-only
+listen_on unix:${XDG_RUNTIME_DIR}/omarchy-kitty-{kitty_pid}
+
+# Aesthetics
+cursor_shape block
+cursor_blink_interval 0
+shell_integration no-cursor
+enable_audio_bell no
+
+# Minimal Tab bar styling
+tab_bar_edge                bottom
+tab_bar_style               powerline
+tab_powerline_style         slanted
+tab_title_template          {title}{' :{}:'.format(num_windows) if num_windows > 1 else ''}

--- a/migrations/1788745941.sh
+++ b/migrations/1788745941.sh
@@ -1,0 +1,28 @@
+echo "Move Kitty defaults into the system config and restrict remote control to its local socket"
+
+kitty_config="$HOME/.config/kitty/kitty.conf"
+# config/kitty/kitty.conf as shipped after 008f3a22 (Kitty cwd lookup).
+stock_sha="856cd466bf568d091cb775c5b90d1852178090a419f492fde02a4eaef6407bf9"
+unrestricted='^[[:space:]]*allow_remote_control[[:space:]]+(yes|y|true)[[:space:]]*$'
+
+if [[ -f $kitty_config ]]; then
+  changed=false
+
+  if [[ $(sha256sum "$kitty_config" | cut -d ' ' -f 1) == $stock_sha ]]; then
+    omarchy-refresh-config kitty/kitty.conf
+    changed=true
+  elif grep -qE "$unrestricted" "$kitty_config"; then
+    # Preserve customizations and ordering. An otherwise stock line can be an
+    # intentional override of an earlier include or mapping.
+    backup=$(mktemp "$kitty_config.bak.XXXXXX")
+    cp -p "$kitty_config" "$backup"
+    sed --follow-symlinks -i -E "s/$unrestricted/# &/" "$kitty_config"
+    echo "Commented out unrestricted Kitty remote control. Saved backup as $backup."
+    changed=true
+  fi
+
+  if [[ $changed == "true" ]]; then
+    # Kitty reads allow_remote_control at startup; config reload is insufficient.
+    echo "Close and reopen all Kitty windows to apply the remote-control restriction."
+  fi
+fi

--- a/migrations/1788745941.sh
+++ b/migrations/1788745941.sh
@@ -1,4 +1,4 @@
-echo "Move Kitty defaults into the system config and restrict remote control to its local socket"
+echo "Update Kitty configuration"
 
 kitty_config="$HOME/.config/kitty/kitty.conf"
 # config/kitty/kitty.conf as shipped after 008f3a22 (Kitty cwd lookup).
@@ -17,12 +17,17 @@ if [[ -f $kitty_config ]]; then
     backup=$(mktemp "$kitty_config.bak.XXXXXX")
     cp -p "$kitty_config" "$backup"
     sed --follow-symlinks -i -E "s/$unrestricted/# &/" "$kitty_config"
-    echo "Commented out unrestricted Kitty remote control. Saved backup as $backup."
+    printf '\n%s\n' \
+      "Unrestricted remote control disabled." \
+      "Your other Kitty settings were preserved."
+    printf '\nBackup saved to:\n  %s\n' "$backup"
     changed=true
   fi
 
   if [[ $changed == "true" ]]; then
     # Kitty reads allow_remote_control at startup; config reload is insufficient.
-    echo "Close and reopen all Kitty windows to apply the remote-control restriction."
+    gum style --border rounded --border-foreground 3 --padding "1 2" --margin "1 0" \
+      "Restart Kitty" "" \
+      "Close and reopen all Kitty windows to apply this change."
   fi
 fi

--- a/test/shell.d/fixtures/kitty/check-config.py
+++ b/test/shell.d/fixtures/kitty/check-config.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from kitty.config import load_config
+from kitty.options.utils import parse_map
+
+root = Path(os.environ['ROOT'])
+system = root / 'etc/xdg/kitty/kitty.conf'
+template = root / 'config/kitty/kitty.conf'
+legacy = root / 'test/shell.d/fixtures/kitty/legacy.conf'
+active_lines = [line for line in template.read_text().splitlines() if line and not line.startswith('#')]
+assert active_lines == ['include ~/.local/state/omarchy/current/theme/kitty.conf']
+
+with TemporaryDirectory() as tmp:
+  user = Path(tmp) / 'kitty.conf'
+  # Use a local theme to avoid depending on the developer's generated state.
+  theme = Path(tmp) / 'theme.conf'
+  theme.write_text('background #123456\n')
+  themed = f'include {theme}\n'
+  user.write_text(themed)
+  errors = []
+  opts = load_config(str(system), str(user), accumulate_bad_lines=errors)
+  assert not errors, errors
+  assert opts.allow_remote_control == 'socket-only'
+  assert opts.listen_on == 'unix:${XDG_RUNTIME_DIR}/omarchy-kitty-{kitty_pid}'
+
+  old = Path(tmp) / 'legacy.conf'
+  old.write_text(legacy.read_text().replace(active_lines[0], themed.strip()))
+  before = load_config(str(old), accumulate_bad_lines=errors)
+  # Moving defaults must preserve appearance and behavior except remote control.
+  for key in ('font_family', 'bold_italic_font', 'font_size', 'window_padding_width',
+              'hide_window_decorations', 'confirm_os_window_close', 'cursor_shape',
+              'cursor_blink_interval', 'shell_integration', 'enable_audio_bell',
+              'tab_bar_edge', 'tab_bar_style', 'tab_powerline_style',
+              'tab_title_template', 'background'):
+    assert getattr(opts, key) == getattr(before, key), key
+
+  def binding(options, shortcut):
+    trigger = next(parse_map(shortcut)).trigger
+    return [entry.definition for entry in options.keyboard_modes[''].keymap.get(trigger, [])]
+
+  for shortcut in ('ctrl+insert', 'shift+insert', 'shift+enter', 'alt+shift+enter'):
+    assert binding(opts, shortcut) == binding(before, shortcut), shortcut
+
+  user.write_text(themed + 'font_size 15\nmap ctrl+insert\nmap shift+insert copy_to_clipboard\n')
+  opts = load_config(str(system), str(user), accumulate_bad_lines=errors)
+  assert opts.font_size == 15
+  assert not any(binding(opts, 'ctrl+insert'))
+  assert binding(opts, 'shift+insert')[-1] == 'copy_to_clipboard'
+
+  user.write_text(themed + 'clear_all_shortcuts yes\nmap f1 new_window\n')
+  opts = load_config(str(system), str(user), accumulate_bad_lines=errors)
+  assert len(opts.keyboard_modes[''].keymap) == 1
+  assert binding(opts, 'f1') == ['new_window']
+  assert not errors, errors
+
+print('ok - Kitty loads defaults and theme, preserves appearance, and supports user overrides and unmapping')

--- a/test/shell.d/fixtures/kitty/legacy.conf
+++ b/test/shell.d/fixtures/kitty/legacy.conf
@@ -1,0 +1,35 @@
+include ~/.local/state/omarchy/current/theme/kitty.conf
+
+# Font
+font_family JetBrainsMono Nerd Font
+bold_italic_font auto
+font_size        9.0
+
+# Window
+window_padding_width 14
+hide_window_decorations yes
+confirm_os_window_close 0
+
+# Keybindings
+map ctrl+insert copy_to_clipboard
+map shift+insert paste_from_clipboard
+# Send Shift+Enter as CSI-u so TUIs can distinguish it from Enter.
+map shift+enter send_text all \e[13;2u
+# Kitty legacy encoding sends Alt+Shift+Enter the same as Alt+Enter; send CSI-u so tmux can match M-S-Enter.
+map alt+shift+enter send_text all \e[13;4u
+
+# Allow remote access
+allow_remote_control yes
+listen_on unix:${XDG_RUNTIME_DIR}/omarchy-kitty-{kitty_pid}
+
+# Aesthetics
+cursor_shape block
+cursor_blink_interval 0
+shell_integration no-cursor
+enable_audio_bell no
+
+# Minimal Tab bar styling
+tab_bar_edge                bottom
+tab_bar_style               powerline
+tab_powerline_style         slanted
+tab_title_template          {title}{' :{}:'.format(num_windows) if num_windows > 1 else ''}

--- a/test/shell.d/kitty-config-test.sh
+++ b/test/shell.d/kitty-config-test.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+test_home="$test_dir/home"
+kitty_config="$test_home/.config/kitty/kitty.conf"
+legacy="$ROOT/test/shell.d/fixtures/kitty/legacy.conf"
+migration="$ROOT/migrations/1788745941.sh"
+mkdir -p "$(dirname "$kitty_config")" "$test_dir/bin"
+
+run_migration() {
+  env HOME="$test_home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" bash -euo pipefail "$migration"
+}
+
+cp "$legacy" "$kitty_config"
+output=$(run_migration)
+cmp -s "$ROOT/config/kitty/kitty.conf" "$kitty_config" || fail "stock config becomes the user template"
+backups=("$kitty_config".bak.*)
+cmp -s "$legacy" "${backups[0]}" || fail "refresh backs up the original config"
+[[ $output == *"Close and reopen all Kitty windows"* ]] || fail "migration requires a full restart"
+pass "stock config is refreshed with a backup and restart guidance"
+
+output=$(run_migration)
+cmp -s "$ROOT/config/kitty/kitty.conf" "$kitty_config" || fail "stock migration is idempotent"
+[[ $output != *"Close and reopen"* ]] || fail "rerun does not repeat restart guidance"
+pass "stock migration is idempotent"
+
+cat >"$kitty_config" <<'CONF'
+# Keep this comment and my theme choice
+include my-theme.conf
+font_family My Font
+font_size 13
+map ctrl+insert
+include shortcuts.conf
+map shift+insert paste_from_clipboard
+  allow_remote_control   yes
+allow_remote_control y
+allow_remote_control true
+# allow_remote_control yes
+listen_on unix:/tmp/my-kitty
+CONF
+printf 'allow_remote_control yes  \n' >>"$kitty_config"
+cp "$kitty_config" "$test_dir/custom-original"
+cat >"$test_dir/expected" <<'CONF'
+# Keep this comment and my theme choice
+include my-theme.conf
+font_family My Font
+font_size 13
+map ctrl+insert
+include shortcuts.conf
+map shift+insert paste_from_clipboard
+#   allow_remote_control   yes
+# allow_remote_control y
+# allow_remote_control true
+# allow_remote_control yes
+listen_on unix:/tmp/my-kitty
+CONF
+printf '# allow_remote_control yes  \n' >>"$test_dir/expected"
+chmod 600 "$kitty_config"
+run_migration >/dev/null
+cmp -s "$test_dir/expected" "$kitty_config" || fail "customizations survive the security repair"
+[[ $(stat -c %a "$kitty_config") == "600" ]] || fail "migration preserves config permissions"
+backup=$(rg -l 'allow_remote_control true' "$kitty_config".bak.* | tail -1)
+cmp -s "$test_dir/custom-original" "$backup" || fail "custom config is backed up"
+run_migration >/dev/null
+cmp -s "$test_dir/expected" "$kitty_config" || fail "custom migration is idempotent"
+pass "custom config repair preserves ordering, mappings, theme, permissions, and original backup"
+
+for mode in no n false socket-only socket password; do
+  printf 'allow_remote_control %s\nfont_size 13\n' "$mode" >"$kitty_config"
+  cp "$kitty_config" "$test_dir/expected"
+  run_migration >/dev/null
+  cmp -s "$test_dir/expected" "$kitty_config" || fail "migration preserves $mode"
+done
+pass "explicit restricted remote-control modes are preserved"
+
+printf 'font_size 13\n' >"$kitty_config"
+cp "$kitty_config" "$test_dir/expected"
+run_migration >/dev/null
+cmp -s "$test_dir/expected" "$kitty_config" || fail "omitted setting stays omitted"
+rm "$kitty_config"
+run_migration >/dev/null
+[[ ! -e $kitty_config ]] || fail "absent config stays absent"
+pass "migration leaves omitted settings and absent user configs alone"
+
+printf 'allow_remote_control yes\nfont_size 13\n' >"$test_dir/dotfiles.conf"
+ln -s "$test_dir/dotfiles.conf" "$kitty_config"
+run_migration >/dev/null
+[[ -L $kitty_config ]] || fail "migration preserves a dotfile symlink"
+grep -qx '# allow_remote_control yes' "$test_dir/dotfiles.conf" || fail "symlink target is repaired"
+pass "custom dotfile symlinks survive the repair"
+rm "$kitty_config"
+
+# Exercise the real font commands without changing the running desktop.
+for command in pkill omarchy-restart-shell omarchy-hook omarchy-notification-send; do
+  printf '#!/bin/bash\nexit 0\n' >"$test_dir/bin/$command"
+done
+printf '#!/bin/bash\nexit 1\n' >"$test_dir/bin/pgrep"
+printf '#!/bin/bash\nprintf "Test Font\\n"\n' >"$test_dir/bin/fc-list"
+printf '#!/bin/bash\nexit 0\n' >"$test_dir/bin/kitty"
+cat >"$test_dir/bin/gsettings" <<'SH'
+#!/bin/bash
+if [[ $1 == "get" ]]; then
+  if [[ $3 == "font-name" ]]; then
+    echo "'Sans 11'"
+  else
+    echo 1.0
+  fi
+fi
+SH
+chmod +x "$test_dir/bin/"*
+
+run_command() {
+  env HOME="$test_home" OMARCHY_PATH="$ROOT" PATH="$test_dir/bin:$ROOT/bin:$PATH" "$ROOT/bin/$@"
+}
+
+cp "$ROOT/config/kitty/kitty.conf" "$kitty_config"
+output=$(run_command omarchy-display-text-size)
+[[ $output == *"terminal font: 9 pt"* ]] || fail "size report accounts for inherited Kitty default"
+run_command omarchy-font-set 'Test Font'
+run_command omarchy-display-text-size 16
+grep -qx 'font_family Test Font' "$kitty_config" || fail "font command creates family override"
+run_command omarchy-font-set Font
+grep -qx 'font_family Font' "$kitty_config" || fail "font command updates family override"
+[[ $(grep -c '^font_family ' "$kitty_config") == "1" ]] || fail "font update avoids duplicate overrides"
+grep -qx 'font_size 12.0' "$kitty_config" || fail "size command creates size override"
+grep -qx '# font_size 12' "$kitty_config" || fail "font commands keep commented instructions"
+run_command omarchy-display-text-size 18
+[[ $(grep -c '^font_size ' "$kitty_config") == "1" ]] || fail "size update avoids duplicate overrides"
+run_command omarchy-display-text-size reset
+grep -qx 'font_size 9.0' "$kitty_config" || fail "size reset restores default"
+pass "font controls add and update overrides in the minimal template"
+
+rm "$kitty_config"
+output=$(run_command omarchy-display-text-size)
+[[ $output == *"terminal font: 9 pt"* ]] || fail "size report handles absent Kitty config"
+run_command omarchy-font-set 'Test Font'
+run_command omarchy-display-text-size 16
+grep -qx 'font_family Test Font' "$kitty_config" || fail "font command handles absent config"
+grep -qx 'font_size 12.0' "$kitty_config" || fail "size command handles absent setting"
+! grep -q '^include ' "$kitty_config" || fail "font controls must not opt users back into theming"
+rm "$kitty_config"
+run_command omarchy-display-text-size 16
+grep -qx 'font_size 12.0' "$kitty_config" || fail "size command handles absent config"
+pass "font controls create missing Kitty overrides without restoring the theme include"
+
+if "$ROOT/bin/omarchy-cmd-present" kitty; then
+  kitty +runpy "$(cat "$ROOT/test/shell.d/fixtures/kitty/check-config.py")"
+else
+  pass "Kitty not installed; skipping native config parser checks"
+fi


### PR DESCRIPTION
Kitty currently ships with `allow_remote_control yes`, which lets untrusted terminal output issue remote-control commands as the user. Move Omarchy's defaults into `/etc/xdg/kitty/kitty.conf` and use `socket-only` to reject that channel while keeping the local Unix socket used for active-tab directory lookup.

The user config contains the theme include and commented examples for font, padding, and shortcut overrides. Users can remove the include to disconnect Kitty from Omarchy's theming system, replace individual bindings, or clear inherited shortcuts. Package updates can change the system defaults without rewriting user configs. The existing `omarchy-settings` packaging already installs the `etc/` tree.

The migration refreshes configs matching the exact stock hash shipped in v4.0.0–v4.0.2, with a backup. For customized or older configs, it backs up the file and comments out explicit unrestricted `yes`, `y`, or `true` settings, preserving other settings, ordering, and symlinks. The output separates the backup path from a prominent restart notice: all Kitty processes must exit before the new remote-control setting takes effect.

Font-family and text-size commands now create missing Kitty overrides, including when the user config is absent, without restoring a removed theme include.

Validation:

- Focused migration and native Kitty parser tests pass, covering backups, idempotence, restricted modes, custom configs, symlinks, font overrides, config precedence, and shortcut unmapping.
- CLI and desktop-entry launch tests, Bash syntax checks, and whitespace checks pass.
- Built and installed both dev packages locally. A live Kitty terminal rejected a harmless remote-control `ls` request through the TTY, accepted it through the Unix socket, and returned the correct directory through `omarchy-cmd-terminal-cwd`.
- Visually checked the terminal appearance and revised migration output in Kitty.

Alternative to #10527 that preserves the socket-based directory lookup.
