### PR TITLE
Ignore FALLBACK output when recovering laptop display

### DIFF
--- a/bin/omarchy-hyprland-monitor-external-active
+++ b/bin/omarchy-hyprland-monitor-external-active
@@ -3,4 +3,6 @@
 # omarchy:summary=Returns true when Hyprland has an active external monitor
 # omarchy:hidden=true
 
-hyprctl monitors all -j | jq -e '.[] | select(.name | test("^(eDP|LVDS|DSI)-") | not) | select(.disabled == false)' >/dev/null 2>&1
+# Hyprland creates FALLBACK when no real output is active. Counting it as an
+# external monitor prevents recovery of the disabled laptop panel after undocking.
+hyprctl monitors all -j | jq -e '.[] | select(.name | test("^(eDP|LVDS|DSI)-") | not) | select(.name != "FALLBACK") | select(.disabled == false)' >/dev/null 2>&1

--- a/test/shell.d/monitor-fallback-test.sh
+++ b/test/shell.d/monitor-fallback-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+mkdir -p "$temp_dir/bin"
+export MONITOR_FIXTURE="$temp_dir/monitors.json"
+export MONITOR_ACTIONS="$temp_dir/actions"
+export PATH="$temp_dir/bin:$ROOT/bin:$PATH"
+
+cat >"$temp_dir/bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ $1 == "monitors" ]]; then
+  [[ $* == "monitors all -j" ]] || exit 1
+  cat "$MONITOR_FIXTURE"
+else
+  printf '%s\n' "$*" >>"$MONITOR_ACTIONS"
+fi
+SH
+cat >"$temp_dir/bin/omarchy-hyprland-toggle-enabled" <<'SH'
+#!/bin/bash
+exit 0
+SH
+cat >"$temp_dir/bin/omarchy-hyprland-toggle" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$MONITOR_ACTIONS"
+SH
+chmod +x "$temp_dir/bin/"*
+
+cat >"$MONITOR_FIXTURE" <<'JSON'
+[
+  {"name":"eDP-2","disabled":true},
+  {"name":"FALLBACK","disabled":false}
+]
+JSON
+if omarchy-hyprland-monitor-external-active; then
+  fail "FALLBACK does not count as an external monitor"
+fi
+omarchy-hyprland-monitor-internal recover
+grep -Fx 'internal-monitor-disable off' "$MONITOR_ACTIONS" >/dev/null || fail "undocking clears the internal display disable flag"
+grep -F 'dpms' "$MONITOR_ACTIONS" >/dev/null || fail "undocking wakes the recovered display"
+pass "disabled laptop panel recovers when only FALLBACK remains"
+
+for connector in eDP-1 LVDS-1 DSI-1; do
+  printf '[{"name":"%s","disabled":false}]\n' "$connector" >"$MONITOR_FIXTURE"
+  if omarchy-hyprland-monitor-external-active; then
+    fail "internal connector $connector does not count as external"
+  fi
+done
+pass "internal connectors do not count as external monitors"
+
+for disabled in true false; do
+  printf '[{"name":"FALLBACK","disabled":false},{"name":"DP-1","disabled":%s,"mirrorOf":"eDP-2"}]\n' "$disabled" >"$MONITOR_FIXTURE"
+  if [[ $disabled == "true" ]]; then
+    if omarchy-hyprland-monitor-external-active; then
+      fail "disabled external output does not prevent recovery"
+    fi
+  else
+    omarchy-hyprland-monitor-external-active || fail "active mirrored external output still counts"
+    : >"$MONITOR_ACTIONS"
+    omarchy-hyprland-monitor-internal recover
+    [[ ! -s $MONITOR_ACTIONS ]] || fail "active external output keeps the internal panel disabled"
+  fi
+done
+pass "external monitor detection preserves disabled and mirrored output behavior"


### PR DESCRIPTION
When the last external monitor is unplugged while the laptop panel is disabled, Hyprland can create an active virtual `FALLBACK` output. The external-monitor helper counts every active non-internal output as external, including `FALLBACK`, so `omarchy-hyprland-monitor-internal recover` returns without clearing the disable flag. The laptop remains dark despite having no external display connected.

Exclude `FALLBACK` from the shared external-monitor predicate. This lets the existing recovery path re-enable the laptop panel while preserving detection of real external outputs, including mirrors.

Reproduced on a running laptop session: `eDP-2` was disabled and `FALLBACK` was the only active output after unplugging the external display. Applying the exclusion and running recovery restored `eDP-2` with DPMS enabled and workspace 2; a subsequent recovery kept it enabled. No compositor restart was needed. This was verified through live monitor state; no before/after screen capture is attached.

Validation:
- Added a regression test exercising the actual helper and internal recovery command with stubbed Hyprland/toggle commands. It fails against unmodified upstream and passes with the fix.
- Covers internal connector names, disabled external outputs, and active mirrored external outputs.
- `bash -n` and `git diff --check` pass.
- Ran `./test/all`: CLI suite passed; shell suite reported six failing files. Four passed on rerun after providing `OMARCHY_PKGS_PATH`/`OMARCHY_ISO_PATH` and unsetting the inherited `NO_COLOR`. `locate-test.sh` passed after moving aside the test-generated `bin/__pycache__` (its source scan attempts to decode `.pyc` files as UTF-8). `network-qr-test.sh` still exits at its automatic-interface case in this environment, and fails identically in a clean worktree of upstream `a7030926`. The monitor regression and existing monitor recovery tests passed in the aggregate run.
