### PR TITLE
Reset media bar label position when the marquee stops

### DIFF
--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -71,6 +71,7 @@ BarWidget {
           from: scrollClip.width
           to: -labelText.implicitWidth
           easing.type: Easing.Linear
+          onRunningChanged: if (!running) labelText.x = 0
         }
       }
     }


### PR DESCRIPTION
### Problem

The media bar widget marquees its now-playing label with
`NumberAnimation on x`. A value-source animation leaves the property wherever
it was when it stops, and nothing restores `labelText.x` when `needsScroll`
goes false.

So when a scrolling title is followed by one short enough to fit, the marquee
halts mid-flight and the short label stays parked at whatever offset it
reached — `scrollClip`'s `clip: true` then cuts off whatever falls outside the
slot. Depending on where the animation stopped the label can be pushed right,
away from the play/pause glyph, or shifted left so only its tail survives.

It reads to the user as "the song title is stuck and won't move".

### Fix

```qml
onRunningChanged: if (!running) labelText.x = 0
```

The `quickshell.spotify` community plugin carries the same guard
(`onStopped: barLabel.x = 0`) on its equivalent `XAnimator on x`, which
suggests the omission here is accidental rather than intentional.

### Before / after

Played a 10s track with an overflowing title followed by a short one, through
`Quickshell.Services.Mpris`. Third frame of each run, taken after the switch:

**Before** — short title `Drzwi.wav` parked off-origin, clipped down to `av`,
and frozen there for the rest of the track:

![media bar showing a clipped, parked label reading av](https://raw.githubusercontent.com/DukeOfContention/omarchy/media-marquee-screenshots/media-marquee-before.png)

**After** — renders at `x: 0`, flush after the glyph, fully visible:

![media bar showing the full label Drzwi.wav next to the pause glyph](https://raw.githubusercontent.com/DukeOfContention/omarchy/media-marquee-screenshots/media-marquee-after.png)

Long titles still scroll normally in both runs.

### Testing

`./test/all` — the same 5 shell test files fail before and after the change
(`config`, `locate`, `runtime-smoke`, `snapper`, `unowned-system-paths`);
they are environment-dependent and fail on a clean `quattro` checkout here
too. No new failures.

Verified visually in the running shell per
`agents/skills/visual-verification.md`, on Omarchy 4.0.2-1 with
Quickshell 0.3.1.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HWwwKMtHmSdkCLbhT7buj
