### PR TITLE
Gate active-window title to the focused monitor

### DIFF
--- a/shell/plugins/bar/widgets/ActiveWindow.qml
+++ b/shell/plugins/bar/widgets/ActiveWindow.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Quickshell
+import Quickshell.Hyprland
 import Quickshell.Wayland
 import qs.Commons
 import qs.Ui
@@ -8,8 +9,30 @@ BarWidget {
   id: root
   moduleName: "omarchy.active-window"
 
+  // Wayland foreign-toplevel focus is global; map it onto Hyprland so this
+  // per-monitor bar instance can keep the title on the output that owns it.
+  readonly property var activeWayland: ToplevelManager.activeToplevel
+  readonly property var barWindow: QsWindow.window
+  readonly property var barScreen: barWindow ? barWindow.screen : null
+  readonly property string barScreenName: barScreen ? String(barScreen.name || "") : ""
 
-  readonly property var toplevel: ToplevelManager.activeToplevel
+  function hyprlandToplevelFor(waylandToplevel) {
+    if (!waylandToplevel) return null
+
+    var values = Hyprland.toplevels.values
+    for (var i = 0; i < values.length; i++) {
+      if (values[i].wayland === waylandToplevel) return values[i]
+    }
+
+    return null
+  }
+
+  readonly property var hyprlandToplevel: hyprlandToplevelFor(activeWayland)
+  readonly property var activeMonitor: hyprlandToplevel ? hyprlandToplevel.monitor : null
+  readonly property string activeMonitorName: activeMonitor ? String(activeMonitor.name || "") : ""
+  // Missing Hyprland match or null monitor: hide rather than mirror globally.
+  readonly property bool onThisScreen: barScreenName !== "" && activeMonitorName !== "" && barScreenName === activeMonitorName
+  readonly property var toplevel: onThisScreen ? activeWayland : null
   readonly property string title: toplevel ? (toplevel.title || toplevel.appId || "") : ""
   readonly property int maxLabelWidth: Number(setting("maxWidth", 280))
 

--- a/test/shell.d/active-window-per-monitor-test.sh
+++ b/test/shell.d/active-window-per-monitor-test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+ACTIVE_WINDOW="$ROOT/shell/plugins/bar/widgets/ActiveWindow.qml"
+BAR="$ROOT/shell/plugins/bar/Bar.qml"
+
+[[ -f $ACTIVE_WINDOW ]] || fail "ActiveWindow.qml is missing"
+[[ -f $BAR ]] || fail "Bar.qml is missing"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const active = fs.readFileSync(path.join(root, 'shell/plugins/bar/widgets/ActiveWindow.qml'), 'utf8')
+const bar = fs.readFileSync(path.join(root, 'shell/plugins/bar/Bar.qml'), 'utf8')
+
+// Bars are built once per output; the title widget must not treat focus as
+// global or every copy shows the same window.
+assert(
+  /model:\s*Quickshell\.screens/.test(bar) && /screen:\s*modelData/.test(bar),
+  'bar instantiates a surface per Quickshell.screens entry'
+)
+
+assert(
+  active.includes('import Quickshell.Hyprland'),
+  'active-window imports Hyprland to resolve the focused toplevel monitor'
+)
+
+assert(
+  /ToplevelManager\.activeToplevel/.test(active),
+  'active-window still starts from the Wayland active toplevel'
+)
+
+// Guard against a silent return to global-only display: the Wayland active
+// toplevel must be matched through Hyprland and gated on this bar's screen.
+assert(
+  /Hyprland\.toplevels\.values/.test(active) &&
+    /\.wayland\s*===\s*waylandToplevel/.test(active),
+  'active-window matches the Wayland toplevel to a Hyprland.toplevels entry via .wayland'
+)
+
+assert(
+  /hyprlandToplevel\.monitor|activeMonitor/.test(active) &&
+    /QsWindow\.window/.test(active) &&
+    /barScreenName/.test(active) &&
+    /activeMonitorName/.test(active) &&
+    /onThisScreen/.test(active),
+  'active-window compares the Hyprland monitor name to this bar surface screen name'
+)
+
+assert(
+  /toplevel:\s*onThisScreen\s*\?\s*activeWayland\s*:\s*null/.test(active) ||
+    /onThisScreen\s*\?\s*activeWayland\s*:\s*null/.test(active),
+  'active-window exposes the Wayland toplevel only when onThisScreen'
+)
+
+assert(
+  /visible:\s*title\s*!==\s*""\s*&&\s*!vertical/.test(active),
+  'active-window stays hidden on vertical bars'
+)
+
+assert(
+  /implicitWidth:\s*visible\s*\?[\s\S]*:\s*0/.test(active),
+  'active-window collapses its slot with implicitWidth 0 when hidden'
+)
+
+// Click handlers must keep using the gated toplevel so activate/close cannot
+// fire from a bar that is not showing the title.
+assert(
+  /if\s*\(\s*!root\.toplevel\s*\)\s*return/.test(active) &&
+    active.includes('root.toplevel.close()') &&
+    active.includes('root.toplevel.activate()'),
+  'active-window preserves activate/close against the gated toplevel'
+)
+
+// A raw assignment of the global active toplevel as the displayed toplevel
+// without an onThisScreen gate is the original bug; keep it from returning.
+assert(
+  !/readonly property var toplevel:\s*ToplevelManager\.activeToplevel\b/.test(active),
+  'active-window must not bind toplevel directly to global ToplevelManager.activeToplevel'
+)
+
+assert(
+  !/title:\s*ToplevelManager\.activeToplevel/.test(active),
+  'active-window must not read the title straight from the global active toplevel'
+)
+JS
+
+pass "active-window gates the title to the matching monitor"


### PR DESCRIPTION
## Summary
`omarchy.active-window` was binding every per-monitor bar instance to the global `ToplevelManager.activeToplevel`, so the focused window title appeared on every bar.

This maps the Wayland active toplevel to `Hyprland.toplevels` via `.wayland`, compares the Hyprland monitor name to the bar surface screen name (`QsWindow.window.screen`), and shows the title only on the matching output. Hidden instances keep `implicitWidth` 0 so the slot collapses. Activate/close stay on the gated toplevel. Missing Hyprland match or null monitor hides rather than mirroring globally.

Fixes #10597

## Test plan
- [x] `bash test/shell.d/active-window-per-monitor-test.sh` (static gates + anti-regression against global-only bind)
- [x] `bash test/shell.d/bar-test.sh`
- [ ] Multi-monitor live: focus a window on monitor A; only A's bar shows the title; B collapses
- [ ] Vertical bar: title remains hidden
- [ ] No focused window / unmatched hypr toplevel: no title
- Single-monitor smoke screenshot under `/tmp/evidence-10597/` (multi-monitor visual skipped: only eDP-1 attached; session shell still loads `/usr/share/omarchy`)