### PR TITLE
Fix stale Wi-Fi connection state in network bar

### DIFF
--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -440,7 +440,7 @@ Panel {
   readonly property var wiredDevice: findDevice(DeviceType.Wired)
   readonly property string kind: {
     if (wiredDevice && wiredDevice.connected) return "ethernet"
-    if (connectedWifiNetwork) return "wifi"
+    if (wifiDevice && wifiDevice.connected) return "wifi"
     return "disconnected"
   }
   readonly property int signalStrength: connectedWifiNetwork

--- a/test/shell.d/network-bar-state-test.sh
+++ b/test/shell.d/network-bar-state-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
+
+const kindBlock = panelSource.match(/readonly property string kind: \{[\s\S]*?\n  \}/)
+assert(kindBlock, 'network bar exposes a connection kind')
+assert(
+  /if \(wifiDevice && wifiDevice\.connected\) return "wifi"/.test(kindBlock[0]),
+  'network bar derives Wi-Fi connection state from the live device'
+)
+assert(
+  !/if \(connectedWifiNetwork\) return "wifi"/.test(kindBlock[0]),
+  'network bar does not depend on scan-derived Wi-Fi state for connectivity'
+)
+JS


### PR DESCRIPTION
## Summary

Fixes #10619.

The network bar currently derives Wi-Fi connectivity from `connectedWifiNetwork`, which is populated from the scan-derived access-point list. Scanning is deliberately paused while the network panel is closed, so that object can be stale or missing even while the Wi-Fi device remains connected.

Use `wifiDevice.connected` for the bar's connection kind, mirroring the existing wired-device branch. Signal strength still uses the connected network object when it is available; this change only fixes the connected/disconnected classification.

## Testing

Added `test/shell.d/network-bar-state-test.sh` to assert that the bar uses the live Wi-Fi device state rather than the scan-derived network list for connectivity.
