### PR TITLE
Compute menu row height once per rebuild, not per append

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -109,7 +109,10 @@ Item {
   property bool searchDivider: false
   property int layoutSerial: 0
   property int cardWidth: Math.min(root.dmenuActive ? Style.space(root.dmenuWidth) : ((root.activeMenu === "trigger.capture.screenrecord" || root.activeMenu === "style.font") ? Style.space(520) : Style.space(300)), panel.width - Style.gapsOut * 2)
-  property int visibleRowsHeight: root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText) : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider)
+  // Height must not bind to displayModel.count: rebuild appends one row at a
+  // time, and a count dependency re-walks every row on every append (O(n^2)).
+  // layoutSerial is bumped once the model is finished, so one pass is enough.
+  property int visibleRowsHeight: root.dmenuActive ? dmenuRowListHeight(layoutSerial) : rowListHeight(layoutSerial)
   property int cardHeight: root.dmenuActive
     ? Math.min(contentMargin * 2 + headerHeight + (mode === "input" ? 0 : contentSpacing + visibleRowsHeight), panel.height - Style.gapsOut * 2)
     : Math.min(contentMargin * 2 + headerHeight + contentSpacing + visibleRowsHeight, panel.height - Style.gapsOut * 2)
@@ -178,7 +181,8 @@ Item {
     return totals[full - 1] + root.rowSpacing + peek
   }
 
-  function rowListHeight(_serial, _count, _filter, _divider) {
+  // _serial is a binding dependency only; the walk always reads the model.
+  function rowListHeight(_serial) {
     if (displayModel.count === 0) return root.baseRowHeight
 
     var totals = []
@@ -197,7 +201,7 @@ Item {
     return foldedListHeight(totals, availableRowsHeight())
   }
 
-  function dmenuRowListHeight(_serial, _count, _filter) {
+  function dmenuRowListHeight(_serial) {
     if (root.mode === "input") return 0
     if (displayModel.count === 0) return root.baseRowHeight
 
@@ -610,7 +614,12 @@ Item {
 
     displayModel.clear()
 
-    if (!root.rowsLoaded) return
+    // Without a count binding on visibleRowsHeight, an empty model still needs
+    // a serial bump so the card collapses instead of keeping the prior height.
+    if (!root.rowsLoaded) {
+      layoutSerial += 1
+      return
+    }
 
     var active = root.item(root.activeMenu) ? root.activeMenu : "root"
     root.activeMenu = active

--- a/test/shell.d/menu-height-quadratic-test.sh
+++ b/test/shell.d/menu-height-quadratic-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+MENU_QML="$ROOT/shell/plugins/menu/Menu.qml"
+
+[[ -f $MENU_QML ]] || fail "Menu.qml is missing"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+
+// The bug: visibleRowsHeight bound to displayModel.count, so each append during
+// rebuild re-ran the full row walk (O(n^2) on open). layoutSerial already marks
+// a finished model; height must key off that alone.
+assert(
+  /property int visibleRowsHeight:\s*root\.dmenuActive\s*\?\s*dmenuRowListHeight\(\s*layoutSerial\s*\)\s*:\s*rowListHeight\(\s*layoutSerial\s*\)/.test(menuQml),
+  'visibleRowsHeight binds only to layoutSerial (dmenu and route paths)'
+)
+
+assert(
+  !/visibleRowsHeight:[^\n]*displayModel\.count/.test(menuQml),
+  'visibleRowsHeight must not depend on displayModel.count'
+)
+
+assert(
+  !/dmenuRowListHeight\(\s*layoutSerial\s*,\s*displayModel\.count/.test(menuQml) &&
+    !/rowListHeight\(\s*layoutSerial\s*,\s*displayModel\.count/.test(menuQml),
+  'height helpers are not called with displayModel.count'
+)
+
+assert(
+  /function rowListHeight\(\s*_serial\s*\)/.test(menuQml) &&
+    /function dmenuRowListHeight\(\s*_serial\s*\)/.test(menuQml),
+  'height helpers take only the layout serial as a binding dependency'
+)
+
+// Rebuild still finishes with a single serial bump after all appends.
+assert(
+  /for\s*\(\s*var k = 0;\s*k < rows\.length;\s*k\+\+\)\s*displayModel\.append\(rows\[k\]\)\s*\n\s*layoutSerial \+= 1/.test(menuQml) ||
+    /displayModel\.append\(rows\[k\]\)[\s\S]{0,80}?layoutSerial \+= 1/.test(menuQml),
+  'rebuildDisplay bumps layoutSerial once after appending rows'
+)
+
+assert(
+  /displayModel\.append\(\{[\s\S]*?itemId:\s*"dmenu\."[\s\S]*?\}\)[\s\S]*?layoutSerial \+= 1/.test(menuQml),
+  'rebuildDmenuDisplay bumps layoutSerial once after appending options'
+)
+
+// Early empty-model path must still invalidate height without a count binding.
+assert(
+  /if\s*\(\s*!root\.rowsLoaded\s*\)\s*\{\s*layoutSerial \+= 1\s*;\s*return\s*\}/.test(menuQml) ||
+    /if\s*\(\s*!root\.rowsLoaded\s*\)\s*\{\s*\n\s*layoutSerial \+= 1\s*\n\s*return\s*\n\s*\}/.test(menuQml),
+  'rebuildDisplay bumps layoutSerial when rows are not loaded yet'
+)
+
+// Complexity check: triangular walk on every append vs one final walk.
+function simulate(n, everyAppend) {
+  let calls = 0
+  let walked = 0
+  const model = []
+  const height = () => {
+    calls += 1
+    walked += model.length
+  }
+  for (let i = 0; i < n; i++) {
+    model.push(i)
+    if (everyAppend) height()
+  }
+  if (!everyAppend) height()
+  return { calls, walked }
+}
+
+const bug231 = simulate(231, true)
+const fix231 = simulate(231, false)
+assertEqual(bug231.walked, 26796, 'pre-fix 231-row open walks the triangular sum')
+assertEqual(fix231.walked, 231, 'post-fix 231-row open walks each row once')
+assertEqual(fix231.calls, 1, 'post-fix height runs once per rebuild')
+
+const bug400 = simulate(400, true)
+const fix400 = simulate(400, false)
+assert(bug400.walked > fix400.walked * 100, '400-row every-append walk is orders of magnitude larger than one pass')
+assertEqual(fix400.walked, 400, 'post-fix 400-row open stays linear')
+JS
+
+pass "menu height no longer scales with the square of row count"


### PR DESCRIPTION
## Summary

Opening the Omarchy menu scaled with the **square** of its row count. `SUPER + K` (keybindings, ~231 rows) spent most of its shell-side open time inside repeated full-model height walks.

## Root cause

`visibleRowsHeight` was bound to `displayModel.count`:

```qml
property int visibleRowsHeight: root.dmenuActive
  ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText)
  : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider)
```

`rebuildDisplay` / `rebuildDmenuDisplay` append rows one at a time. Each append bumps `count`, re-evaluates the binding, and re-walks every row already appended.

For n=231 that is the triangular sum ~26,796 row visits across ~231 height passes (issue #10601 measured 234 calls / 111ms). Batching `append(array)` does not help: `ListModel` still emits per-row count changes.

`layoutSerial` is already incremented once after the model is finished; it was the right invalidation signal and did not need `count` beside it.

## Fix

- Bind `visibleRowsHeight` only to `layoutSerial` (dmenu and route paths).
- Narrow `rowListHeight` / `dmenuRowListHeight` to take that serial as the binding dependency; they still read the model when they run.
- When `rebuildDisplay` returns early because rows are not loaded, bump `layoutSerial` so the card collapses without relying on a count binding.

Filter/search-divider/dmenu mode changes still go through rebuild paths that bump the serial. Property reads inside the height walk (including panel geometry used by `availableRowsHeight`) remain binding dependencies when the expression evaluates.

## Evidence

Complexity simulation (matches issue arithmetic):

```
n     walked_every_append  walked_once
231   26796                231
400   80200                400
```

Pre-fix binding and rebuild paths captured under `/tmp/evidence-10601/`. Live `omarchy menu summon keybindings` timings on this machine still hit the **installed** pre-fix shell (`/usr/share/omarchy`); worktree is not dev-linked. Automated tests lock the structural fix.

## Test plan

- [x] `bash test/shell.d/menu-height-quadratic-test.sh`
- [x] `bash test/shell.d/menu-test.sh`
- [x] `bash test/shell.d/menu-guards-test.sh`
- [ ] Manual: `omarchy menu summon keybindings` feels snappier on a stock shell after install
- [ ] Manual: root / apps / theme menus still size and fold correctly while typing to filter
- [ ] Manual: `omarchy menu select` dmenu lists still fold with peek on long option sets

Fixes #10601