### PR TITLE
Size ConfirmDialog buttons to their labels

### DIFF
--- a/shell/Ui/ConfirmDialog.qml
+++ b/shell/Ui/ConfirmDialog.qml
@@ -94,8 +94,18 @@ Item {
 
               readonly property bool selected: root.selectedIndex === index
               readonly property bool destructive: index === 1
+              // Grow with the label past the old fixed 88px so long confirm
+              // strings (and translations) stay inside the frame; cap so both
+              // buttons still fit the card side by side.
+              readonly property int labelPadding: Style.space(12)
+              readonly property int minWidth: Style.space(88)
+              readonly property int maxWidth: {
+                var content = card.width - card.contentLeftInset - card.contentRightInset
+                var half = Math.floor((content - Style.space(10)) / 2)
+                return Math.max(minWidth, half)
+              }
 
-              width: Style.space(88)
+              width: Math.min(maxWidth, Math.max(minWidth, label.implicitWidth + labelPadding * 2))
               height: Style.space(34)
               color: selected
                 ? (destructive ? Util.alpha(Color.urgent, 0.22) : root.selectedBackground)
@@ -106,8 +116,12 @@ Item {
               radius: 0
 
               Text {
+                id: label
                 textFormat: Text.PlainText
                 anchors.centerIn: parent
+                width: Math.min(implicitWidth, parent.width - labelPadding * 2)
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignHCenter
                 text: modelData
                 color: destructive ? (selected ? Color.urgent : root.foreground) : (selected ? root.selectedText : root.foreground)
                 font.family: root.fontFamily

--- a/test/shell.d/confirm-dialog-button-width-test.sh
+++ b/test/shell.d/confirm-dialog-button-width-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+DIALOG="$ROOT/shell/Ui/ConfirmDialog.qml"
+
+[[ -f $DIALOG ]] || fail "ConfirmDialog.qml is missing"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const qml = fs.readFileSync(path.join(root, 'shell/Ui/ConfirmDialog.qml'), 'utf8')
+const clipboard = fs.readFileSync(path.join(root, 'shell/plugins/clipboard/Clipboard.qml'), 'utf8')
+const menu = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
+
+// Fixed 88px width is the overflow bug: long confirmText paints past the frame.
+assert(
+  !/^\s*width:\s*Style\.space\(88\)\s*$/m.test(qml),
+  'confirm buttons must not hardcode a fixed Style.space(88) width'
+)
+
+assert(
+  /minWidth:\s*Style\.space\(88\)/.test(qml),
+  'confirm buttons keep Style.space(88) as the minimum width'
+)
+
+assert(
+  /width:\s*Math\.min\(\s*maxWidth\s*,\s*Math\.max\(\s*minWidth\s*,\s*label\.implicitWidth\s*\+\s*labelPadding\s*\*\s*2\s*\)\s*\)/.test(qml),
+  'confirm button width grows with the label up to a card-aware max'
+)
+
+assert(
+  /maxWidth:\s*\{[\s\S]*card\.width[\s\S]*\/\s*2[\s\S]*\}/.test(qml) ||
+    /half\s*=\s*Math\.floor\(\(content\s*-\s*Style\.space\(10\)\)\s*\/\s*2\)/.test(qml),
+  'confirm button max width is half the card content so both buttons fit'
+)
+
+assert(
+  /id:\s*label/.test(qml) &&
+    /elide:\s*Text\.ElideRight/.test(qml) &&
+    /width:\s*Math\.min\(\s*implicitWidth\s*,\s*parent\.width\s*-\s*labelPadding\s*\*\s*2\s*\)/.test(qml),
+  'confirm label is width-constrained and elides inside the button frame'
+)
+
+assert(
+  /horizontalAlignment:\s*Text\.AlignHCenter/.test(qml),
+  'confirm label stays centered while eliding'
+)
+
+// First-party callers still use short English labels that fit the minimum.
+assert(
+  /confirmText:\s*"Delete"/.test(clipboard),
+  'clipboard clear confirm keeps short Delete label'
+)
+assert(
+  /confirmText:\s*"Uninstall"/.test(menu),
+  'menu uninstall confirm keeps short Uninstall label'
+)
+
+// Sizing model: short labels stay at minWidth; long labels grow then cap.
+function buttonWidth(textPx, minW, maxW, pad) {
+  return Math.min(maxW, Math.max(minW, textPx + pad * 2))
+}
+
+const minW = 88
+const pad = 12
+// Card content for default Style.space(370) card with Style.space(18) padding
+// and 1px borders is roughly 370 - 2*(18+1) = 332; half minus gap ≈ 161.
+const maxW = Math.max(minW, Math.floor((332 - 10) / 2))
+
+assertEqual(buttonWidth(37, minW, maxW, pad), minW, 'Cancel-sized label stays at the 88px minimum')
+assertEqual(buttonWidth(54, minW, maxW, pad), minW, 'Uninstall-sized label stays at the 88px minimum')
+assertEqual(buttonWidth(109, minW, maxW, pad), 109 + pad * 2, 'Delete permanently grows past 88px')
+assert(
+  buttonWidth(109, minW, maxW, pad) <= maxW,
+  'grown button still fits beside its pair inside the card'
+)
+assertEqual(
+  buttonWidth(400, minW, maxW, pad),
+  maxW,
+  'extreme labels cap at half the card and rely on elide inside the frame'
+)
+JS
+
+pass "confirm dialog buttons size to their labels without overflowing the card"


### PR DESCRIPTION
## Summary

`ConfirmDialog` buttons used a fixed `Style.space(88)` width with a centered label and no elide. Any `confirmText` / `cancelText` longer than roughly 14 characters at caption size painted outside the button frame and over the card.

## Root cause

```qml
width: Style.space(88)
Text {
  anchors.centerIn: parent  // no width, no elide
  text: modelData
}
```

Issue measurements (JetBrainsMono caption): `Delete permanently` ~109px vs 88px button (overflow ~21px). First-party callers use short English labels (`Delete`, `Uninstall`) that still fit; longer plugin and translated labels overflow. Related: shell i18n (#7434).

## Fix

- Keep `Style.space(88)` as the **minimum** width.
- Grow with `label.implicitWidth + horizontal padding`.
- Cap at half the card content width (minus row spacing) so Cancel and Confirm still sit side by side.
- Constrain the label width and `elide: Text.ElideRight` when a string exceeds the cap.

Short first-party labels keep the previous visual size; long labels expand instead of spilling.

## Evidence

Pre-fix source had fixed width and no elide (`/tmp/evidence-10611/`). Approximate mono overflow matches the issue table. Sizing model in the new shell test: Cancel/Uninstall stay at 88px; `Delete permanently` grows; extreme strings cap and elide.

## Test plan

- [x] `bash test/shell.d/confirm-dialog-button-width-test.sh`
- [x] `bash test/shell.d/clipboard-test.sh`
- [ ] Manual: open menu uninstall confirm (short label) — still looks like before
- [ ] Manual: host with `confirmText: "Delete permanently"` — label stays inside the button
- [ ] Manual: extremely long confirm string — button caps, text elides, pair still fits the card

Fixes #10611