### PR TITLE
Align `omarchy toggle bar on/off` with its help text (or confirm the current direction is intended)

### DIFF
--- a/bin/omarchy-toggle-bar
+++ b/bin/omarchy-toggle-bar
@@ -4,7 +4,23 @@
 # omarchy:args=[toggle|on|off]
 # omarchy:examples=omarchy toggle bar | omarchy toggle bar off | omarchy toggle bar on
 
-omarchy-toggle bar-off "${1:-toggle}"
+# The flag is named for the off state, so the user-facing on and off run the
+# other way round: `bar on` lifts `bar-off` and `bar off` sets it.
+case "${1:-toggle}" in
+  toggle)
+    omarchy-toggle bar-off
+    ;;
+  on)
+    omarchy-toggle bar-off off
+    ;;
+  off)
+    omarchy-toggle bar-off on
+    ;;
+  *)
+    echo "Usage: omarchy-toggle-bar [toggle|on|off]" >&2
+    exit 1
+    ;;
+esac
 
 # The shell's watch on the toggles directory can miss flag changes that land in
 # quick succession, stranding the bar off screen until the shell restarts.

--- a/test/acceptance.d/session-test.sh
+++ b/test/acceptance.d/session-test.sh
@@ -30,16 +30,16 @@ wait_until "background layer is on screen" 30 layer_on_screen "omarchy-backgroun
 # Hiding parks the bar off-screen without unmapping its layer surface, and
 # revealing brings that same surface back on-screen.
 restore_bar_visibility() {
-  omarchy-toggle-bar off >/dev/null 2>&1 || true
+  omarchy-toggle-bar on >/dev/null 2>&1 || true
 }
 trap restore_bar_visibility EXIT
 
-omarchy-toggle-bar on
+omarchy-toggle-bar off
 wait_until "hidden bar layer stays mapped" 15 layer_present "omarchy-bar"
 wait_until "hidden bar layer parks off screen" 15 layer_off_screen "omarchy-bar"
 screenshot "success-bar-hidden"
 
-omarchy-toggle-bar off
+omarchy-toggle-bar on
 wait_until "revealed bar layer returns on screen" 15 layer_on_screen "omarchy-bar"
 screenshot "success-bar-revealed"
 trap - EXIT

--- a/test/shell.d/toggle-test.sh
+++ b/test/shell.d/toggle-test.sh
@@ -40,14 +40,29 @@ HOME="$test_home" omarchy-toggle example toggle
 [[ ! -f $flag ]] || fail "generic toggle flips enabled state off"
 pass "generic toggle flips enabled state off"
 
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on enables bar-off toggle"
-pass "bar on enables bar-off toggle"
-
-HOME="$test_home" omarchy-toggle-bar on
-[[ -f $bar_flag ]] || fail "bar on is idempotent"
-pass "bar on is idempotent"
+HOME="$test_home" omarchy-toggle-bar off
+[[ -f $bar_flag ]] || fail "bar off sets the bar-off flag"
+pass "bar off sets the bar-off flag"
 
 HOME="$test_home" omarchy-toggle-bar off
-[[ ! -f $bar_flag ]] || fail "bar off disables bar-off toggle"
-pass "bar off disables bar-off toggle"
+[[ -f $bar_flag ]] || fail "bar off is idempotent"
+pass "bar off is idempotent"
+
+HOME="$test_home" omarchy-toggle-bar on
+[[ ! -f $bar_flag ]] || fail "bar on lifts the bar-off flag"
+pass "bar on lifts the bar-off flag"
+
+HOME="$test_home" omarchy-toggle-bar on
+[[ ! -f $bar_flag ]] || fail "bar on is idempotent"
+pass "bar on is idempotent"
+
+HOME="$test_home" omarchy-toggle-bar
+[[ -f $bar_flag ]] || fail "bar toggle hides a visible bar"
+pass "bar toggle hides a visible bar"
+
+HOME="$test_home" omarchy-toggle-bar toggle
+[[ ! -f $bar_flag ]] || fail "bar toggle reveals a hidden bar"
+pass "bar toggle reveals a hidden bar"
+
+HOME="$test_home" omarchy-toggle-bar sideways 2>/dev/null && fail "bar rejects an unknown action"
+pass "bar rejects an unknown action"


### PR DESCRIPTION
## The question first

`omarchy toggle bar` looks inverted against its own help, but there's a signal it might be deliberate, so I'd rather ask than assume.

- `bin/omarchy-toggle-bar:7` forwards to `omarchy-toggle bar-off "${1:-toggle}"`, so `on` sets the `bar-off` flag (hides the bar) and `off` clears it (shows it) — the opposite of what a user expects.
- The command's own examples and two issue reports (#10357, dup #10044) read `on` = bar visible.
- But `test/shell.d/toggle-test.sh` asserts the current (inverted) behavior and passes, and the acceptance calls in `session-test.sh` were written the same way (#9240). That's what makes me unsure whether the current direction is intentional.

## What this PR does, if `on` = visible is what you want

- Maps `on` → clear the `bar-off` flag (show), `off` → set it (hide), `toggle` passed through, bad arg exits with usage — mirroring `omarchy-toggle-idle`.
- Updates `toggle-test.sh` bar assertions and the three `on`/`off` calls in `session-test.sh` to the on=visible reading.

If the current direction is intentional, please just close this — I've rewritten a passing test here, and I don't want to flip a behavior you meant. Happy to send a docs-only fix instead so the help text matches the code.

## Tests

`bash test/shell.d/toggle-test.sh` 12/12 on bash 3.2 after the change; `bash -n` clean on all three files; bad arg exits 1 with usage. Acceptance + visual verification not run (no Omarchy machine here).

Fixes #10357

Related: #10044 (dup), #9240 (added the acceptance calls in the current direction).

Written by Claude Fable 5.1 via Claude Code, reviewed by Marc Morriss