### PR TITLE
Let the workspaces widget show only its own monitor's workspaces

### DIFF
--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -1,3 +1,4 @@
+import Quickshell
 import QtQuick
 import QtQuick.Layouts
 import Quickshell.Hyprland
@@ -7,6 +8,49 @@ import qs.Ui
 BarWidget {
   id: root
   moduleName: "omarchy.workspaces"
+
+  // Opt-in: list only the workspaces on this bar's own monitor. Off by default,
+  // so single-screen setups and every existing config behave exactly as before.
+  readonly property bool monitorOnly: setting("monitorOnly", false) === true
+
+  // The monitor this bar surface is drawn on. One bar exists per screen, so
+  // each instance resolves its own. monitorFor() is the reliable route here;
+  // matching Hyprland.monitors by name returns null while the widget is still
+  // completing and the binding never re-fires.
+  readonly property var barMonitor: {
+    var window = root.QsWindow ? root.QsWindow.window : null
+    return window && window.screen ? Hyprland.monitorFor(window.screen) : null
+  }
+
+  // Which workspace this bar should highlight. Per monitor that is the
+  // monitor's own active workspace -- the focused monitor is not necessarily
+  // the one this bar is on -- otherwise the global focus, as before.
+  readonly property int activeId: {
+    if (root.monitorOnly && root.barMonitor !== null && root.barMonitor.activeWorkspace !== null)
+      return root.barMonitor.activeWorkspace.id
+    return Hyprland.focusedWorkspace !== null ? Hyprland.focusedWorkspace.id : -1
+  }
+
+  // Connector the workspace currently sits on. lastIpcObject is the raw
+  // `hyprctl workspaces -j` entry, whose .monitor is already a connector name.
+  function workspaceMonitorName(workspace) {
+    if (!workspace) return ""
+    if (workspace.lastIpcObject && workspace.lastIpcObject.monitor) return String(workspace.lastIpcObject.monitor)
+    if (workspace.monitor && workspace.monitor.name) return String(workspace.monitor.name)
+    return ""
+  }
+
+  // Whether a slot belongs on this bar. Gating the delegate's visibility keeps
+  // the Repeater's model identical across a cross-monitor move, so this cannot
+  // churn the model on the very event that triggers the teardown crash in
+  // basecamp/omarchy#8547; only a visible flag flips.
+  function showsHere(id) {
+    if (!root.monitorOnly) return true
+    // Unresolved monitor, or the one workspace this monitor is displaying:
+    // show it rather than risk rendering an empty bar.
+    if (root.barMonitor === null || id === root.activeId) return true
+    return root.workspaceMonitorName(root.workspaceById(id)) === String(root.barMonitor.name || "")
+  }
 
   function workspaceById(id) {
     var values = Hyprland.workspaces.values
@@ -25,6 +69,11 @@ BarWidget {
       var id = values[i].id
       if (id > 0 && id <= 10 && ids.indexOf(id) === -1) ids.push(id)
     }
+
+    // A monitor with none of 1-10 pinned to it -- the laptop panel when the lid
+    // is opened while docked, say -- is handed a fresh workspace above that
+    // range, which the cap above drops. Keep it so its bar is not left empty.
+    if (root.monitorOnly && root.activeId > 0 && ids.indexOf(root.activeId) === -1) ids.push(root.activeId)
 
     ids.sort(function(left, right) { return left - right })
     return ids
@@ -56,8 +105,9 @@ BarWidget {
 
         readonly property var workspace: root.workspaceById(modelData)
         readonly property bool occupied: workspace !== null && workspace.toplevels.values.length > 0
-        readonly property bool focused: Hyprland.focusedWorkspace !== null && Hyprland.focusedWorkspace.id === modelData
+        readonly property bool focused: root.activeId === modelData
 
+        visible: root.showsHere(modelData)
         bar: root.bar
         text: focused ? "\uDB85\uDCFB" : (modelData === 10 ? "0" : String(modelData))
         opacity: occupied || focused ? 1 : 0.5

--- a/shell/plugins/bar/widgets/Workspaces.qml
+++ b/shell/plugins/bar/widgets/Workspaces.qml
@@ -31,15 +31,6 @@ BarWidget {
     return Hyprland.focusedWorkspace !== null ? Hyprland.focusedWorkspace.id : -1
   }
 
-  // Connector the workspace currently sits on. lastIpcObject is the raw
-  // `hyprctl workspaces -j` entry, whose .monitor is already a connector name.
-  function workspaceMonitorName(workspace) {
-    if (!workspace) return ""
-    if (workspace.lastIpcObject && workspace.lastIpcObject.monitor) return String(workspace.lastIpcObject.monitor)
-    if (workspace.monitor && workspace.monitor.name) return String(workspace.monitor.name)
-    return ""
-  }
-
   // Whether a slot belongs on this bar. Gating the delegate's visibility keeps
   // the Repeater's model identical across a cross-monitor move, so this cannot
   // churn the model on the very event that triggers the teardown crash in
@@ -49,7 +40,12 @@ BarWidget {
     // Unresolved monitor, or the one workspace this monitor is displaying:
     // show it rather than risk rendering an empty bar.
     if (root.barMonitor === null || id === root.activeId) return true
-    return root.workspaceMonitorName(root.workspaceById(id)) === String(root.barMonitor.name || "")
+    // workspace.monitor, not lastIpcObject.monitor: Quickshell updates the
+    // former on a cross-monitor move, but lastIpcObject keeps the old monitor
+    // until some unrelated event refreshes it. A workspace with no monitor
+    // (mid output teardown) is hidden rather than claimed by this bar.
+    var workspace = root.workspaceById(id)
+    return workspace !== null && workspace.monitor !== null && workspace.monitor.name === root.barMonitor.name
   }
 
   function workspaceById(id) {


### PR DESCRIPTION
Adds an opt-in `monitorOnly` setting to `omarchy.workspaces` so each bar lists only the workspaces on its own monitor, and highlights the one that monitor is actually showing.

This is the widget half of #10372, as [discussed there](https://github.com/omacom/omarchy/issues/10372#issuecomment-5570892116). It **complements rather than replaces** that issue's offset design: this variant works on stock Hyprland's single global pool with no compositor-side default to change, so it is useful to people on today's config immediately. If the offset scheme lands later, the two compose — `monitorOnly` filters whatever ids each monitor ends up owning.

## Before / after

Two 1080p monitors, workspaces 1-5 assigned to the left and 6-10 to the right via `hl.workspace_rule`.

<!-- attach workspaces-monitorOnly.png here -->

`BEFORE` is the current behaviour: both bars are byte-identical renders of the same global list, and both highlight workspace 6 because it holds the global focus. `AFTER` shows each bar with its own five slots and its own highlight.

## Opting in

```json
{ "id": "omarchy.workspaces", "monitorOnly": true }
```

Read inline via `setting()` from the widget's `shell.json` layout entry, the same way the clock reads `format` — no manifest change and no settings form. **Defaults to `false`**, so single-screen setups and every existing configuration render exactly as they do today.

## Why `visible` rather than filtering the model

#8547 is an open SIGSEGV: `Workspaces.qml` rebuilds its `Repeater` from inside Quickshell's mid-mutation `valuesChanged` emit while delegates hold live `HyprlandWorkspace` references. Its stated trigger is **Hyprland moving a workspace between monitors**, confirmed on separate AMD and Intel+NVIDIA machines.

That is exactly the event a per-monitor widget has to react to. Filtering the `Repeater`'s model would make the model change on every cross-monitor move — widening the reach of that crash rather than being neutral to it. Gating each delegate's `visible` instead leaves the model untouched; only a flag flips. Verified with an in-widget probe:

```
PROBE mon=DP-1 monitorOnly=true  model=[1,2,3,4,5,6,7,8,9,10] visible=[6,7,8,9,10] activeId=6
PROBE mon=DP-2 monitorOnly=true  model=[1,2,3,4,5,6,7,8,9,10] visible=[1,2,3,4,5]  activeId=2
PROBE mon=DP-1 monitorOnly=false model=[1,2,3,4,5,6,7,8,9,10] visible=[1..10]      activeId=6
PROBE mon=DP-2 monitorOnly=false model=[1,2,3,4,5,6,7,8,9,10] visible=[1..10]      activeId=6
```

Same model on both monitors, and with the setting off the behaviour is identical to today.

## The empty-bar case

A monitor with none of workspaces 1-10 assigned to it is handed a fresh workspace **above** that range, which the existing `id <= 10` cap drops — so a naively filtered widget renders **completely empty**, a regression against stock. The real-world trigger is opening the laptop lid while docked. Reproducible with no extra hardware:

```bash
hyprctl output create headless   # new monitor appears, active_ws=11
hyprctl output remove HEADLESS-1
```

Keeping the monitor's active workspace in the model covers it:

```
PROBE mon=HEADLESS-2 monitorOnly=true model=[1,...,10,11] visible=[11] activeId=11
```

## Monitor resolution

`Hyprland.monitorFor(root.QsWindow.window.screen)` (guarded against a null window), as `Background.qml` does. `QsWindow` is an attached type and needs `import Quickshell` in the widget's own file; without it `root.QsWindow` is `undefined` on every item. Matching `Hyprland.monitors` by name returns null while the widget is still completing and the binding never re-fires — and `QtQuick`'s plain `Screen` attached type comes back empty inside a bar widget, hence the added `import Quickshell` (already used by six other bar widgets).

A workspace's own monitor is read from the bindable `workspace.monitor`, not `lastIpcObject.monitor`: Quickshell 0.3.1 updates only the former on `moveworkspacev2`, so the latter goes stale after a cross-monitor move.

## Testing

- `./test/all` — 7 pre-existing failures on my machine (`agent-usage-claude-scanner`, `bar-icon-geometry`, `config`, `locate`, `runtime-smoke`, `snapper`, `unowned-system-paths`). I re-ran all 7 against a clean `quattro` checkout and they fail identically there, so this change introduces none.
- Verified in the running shell on both settings and across two, then three monitors, via the probe above plus `grim` captures per output.
- Omarchy 4.0.2-1, Hyprland 0.56.2, Quickshell 0.3.1, Qt 6.11.2.

I have not tried to reproduce #8547 itself — the argument here is that this change cannot widen it, not that it fixes it.

---
*Investigated and written with Claude Code; the setup runs on my machine and the findings above are from it.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

