### PR TITLE
Add clipboard pins with numbered paste shortcuts

### DIFF
--- a/manual/08-unified-clipboard-history.md
+++ b/manual/08-unified-clipboard-history.md
@@ -25,4 +25,8 @@ You can also search the history just by starting to type:
 
 Press `Ctrl + P` to pin or unpin the selected entry, or click the Pin/Unpin action beside the search field. Pinned text and images appear first and stay saved across restarts, even as older history expires. Copying a pinned item again keeps it pinned.
 
+Pins receive shortcuts `1`–`9`, shown beside each entry. Open clipboard history and press a pin's number to paste it immediately. Numbers stay assigned to the same items when you copy them again or remove another pin. Additional pins remain available through search and selection. Unpinning or deleting an item frees its number for reuse.
+
+Typing searches as usual once you have started a search. To begin a search with a number, press `Ctrl + F` first. `Escape` clears the search and restores numbered shortcuts.
+
 Press `Delete` to remove the selected entry, including a pin. Press `Shift + Delete` to clear history after confirmation; pinned entries are kept.

--- a/manual/08-unified-clipboard-history.md
+++ b/manual/08-unified-clipboard-history.md
@@ -22,3 +22,7 @@ The clipboard history is provided by the Omarchy shell and works for both text a
 You can also search the history just by starting to type:
 
  ![clipboard-history-search](images/clipboard-history-search.webp)
+
+Press `Ctrl + P` to pin or unpin the selected entry, or click the Pin/Unpin action beside the search field. Pinned text and images appear first and stay saved across restarts, even as older history expires. Copying a pinned item again keeps it pinned.
+
+Press `Delete` to remove the selected entry, including a pin. Press `Shift + Delete` to clear history after confirmation; pinned entries are kept.

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -12,6 +12,7 @@ Item {
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
   property bool opened: false
   property string filterText: ""
+  property bool searchMode: false
   property int selectedIndex: 0
   property bool cursorActive: false
   property bool clearConfirmOpen: false
@@ -42,6 +43,7 @@ Item {
   function open(payloadJson) {
     root.opened = true
     root.filterText = ""
+    root.searchMode = false
     root.selectedIndex = 0
     root.cursorActive = true
     root.disarmPointer()
@@ -162,6 +164,7 @@ Item {
         path: row.path,
         mime: row.mime,
         pinned: row.pinned,
+        pinShortcut: row.pinShortcut,
         historyIndex: row.index
       })
     }
@@ -201,6 +204,16 @@ Item {
     root.cursorActive = true
     root.disarmPointer()
     root.rebuildDisplay()
+  }
+
+  function activatePinShortcut(shortcut) {
+    if (root.searchMode || root.filterText) return false
+    for (var i = 0; i < displayModel.count; i++) {
+      if (displayModel.get(i).pinShortcut !== shortcut) continue
+      root.activateIndex(i)
+      return true
+    }
+    return false
   }
 
   function disarmPointer() {
@@ -376,8 +389,16 @@ Item {
           }
 
           if (event.key === Qt.Key_Escape) {
-            if (root.filterText) root.setFilter("")
+            if (root.filterText || root.searchMode) {
+              root.searchMode = false
+              root.setFilter("")
+            }
             else root.close()
+            event.accepted = true
+          } else if (event.key === Qt.Key_F && event.modifiers === Qt.ControlModifier) {
+            root.searchMode = true
+            event.accepted = true
+          } else if (!(event.modifiers & (Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier)) && /^[1-9]$/.test(event.text) && root.activatePinShortcut(Number(event.text))) {
             event.accepted = true
           } else if (event.key === Qt.Key_P && event.modifiers === Qt.ControlModifier) {
             root.togglePinDisplayIndex(root.selectedIndex)
@@ -459,7 +480,7 @@ Item {
             anchors.right: pinAction.left
             anchors.rightMargin: root.contentSpacing
             anchors.verticalCenter: parent.verticalCenter
-            text: root.filterText || "Search clipboard…"
+            text: root.filterText || (root.searchMode ? "Search clipboard…" : "Search clipboard… (Ctrl+F for numbers)")
             color: root.foreground
             opacity: root.filterText ? 1 : 0.58
             font.family: root.fontFamily
@@ -517,6 +538,7 @@ Item {
                   required property string fullText
                   required property string previewImage
                   required property bool pinned
+                  required property int pinShortcut
 
                   readonly property bool hasCursor: root.cursorActive && index === root.selectedIndex
 
@@ -559,9 +581,10 @@ Item {
 
                     Text {
                       id: pinLabel
+                      textFormat: Text.PlainText
                       visible: row.pinned
                       height: parent.height
-                      text: "Pinned"
+                      text: row.pinShortcut ? row.pinShortcut + " · Pinned" : "Pinned"
                       color: row.hasCursor ? root.selectedText : root.foreground
                       opacity: 0.7
                       font.family: root.fontFamily

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -73,7 +73,8 @@ Item {
   }
 
   function saveHistory() {
-    historyFile.setText(JSON.stringify(root.history.slice(0, root.historyLimit), null, 2) + "\n")
+    root.history = ClipboardHistory.trimHistory(root.history, root.historyLimit)
+    historyFile.setText(JSON.stringify(root.history, null, 2) + "\n")
   }
 
   function addClipboardEntry(entry) {
@@ -102,7 +103,7 @@ Item {
   }
 
   function confirmClearHistory() {
-    root.history = ClipboardHistory.clearHistory()
+    root.history = ClipboardHistory.clearHistory(root.history)
     root.saveHistory()
     root.selectedIndex = 0
     root.cursorActive = false
@@ -130,6 +131,23 @@ Item {
     root.rebuildDisplay()
   }
 
+  function togglePinDisplayIndex(index) {
+    if (index < 0 || index >= displayModel.count) return
+    var historyIndex = displayModel.get(index).historyIndex
+    var key = root.entryKey(root.history[historyIndex])
+    root.history = ClipboardHistory.togglePinAt(root.history, historyIndex)
+    root.saveHistory()
+    root.disarmPointer()
+    root.cursorActive = true
+    root.rebuildDisplay()
+    for (var i = 0; i < displayModel.count; i++) {
+      if (root.entryKey(root.history[displayModel.get(i).historyIndex]) === key) {
+        root.selectedIndex = i
+        break
+      }
+    }
+  }
+
   function rebuildDisplay() {
     var rows = ClipboardHistory.displayRows(root.history, root.filterText, 50)
 
@@ -143,6 +161,7 @@ Item {
         previewImage: row.previewImage ? Util.fileUrl(row.previewImage) : "",
         path: row.path,
         mime: row.mime,
+        pinned: row.pinned,
         historyIndex: row.index
       })
     }
@@ -360,6 +379,9 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.close()
             event.accepted = true
+          } else if (event.key === Qt.Key_P && event.modifiers === Qt.ControlModifier) {
+            root.togglePinDisplayIndex(root.selectedIndex)
+            event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
@@ -403,7 +425,7 @@ Item {
           anchors.fill: parent
           opened: root.clearConfirmOpen
           z: 10
-          message: "Delete entire clipboard history?"
+          message: "Delete clipboard history? Pinned items will be kept."
           confirmText: "Delete"
           background: root.background
           foreground: root.foreground
@@ -434,7 +456,8 @@ Item {
           Text {
             textFormat: Text.PlainText
             anchors.left: parent.left
-            anchors.right: parent.right
+            anchors.right: pinAction.left
+            anchors.rightMargin: root.contentSpacing
             anchors.verticalCenter: parent.verticalCenter
             text: root.filterText || "Search clipboard…"
             color: root.foreground
@@ -442,6 +465,25 @@ Item {
             font.family: root.fontFamily
             font.pixelSize: Style.font.heading
             elide: Text.ElideRight
+          }
+
+          Text {
+            id: pinAction
+            textFormat: Text.PlainText
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            visible: displayModel.count > 0
+            text: "Ctrl+P · " + (displayModel.count > 0 && (displayModel.get(root.selectedIndex) || {}).pinned ? "Unpin" : "Pin")
+            color: root.foreground
+            opacity: 0.7
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+
+            MouseArea {
+              anchors.fill: parent
+              cursorShape: Qt.PointingHandCursor
+              onClicked: root.togglePinDisplayIndex(root.selectedIndex)
+            }
           }
         }
 
@@ -474,6 +516,7 @@ Item {
                   required property string previewText
                   required property string fullText
                   required property string previewImage
+                  required property bool pinned
 
                   readonly property bool hasCursor: root.cursorActive && index === root.selectedIndex
 
@@ -502,7 +545,7 @@ Item {
 
                     Text {
                       textFormat: Text.PlainText
-                      width: parent.width - (parent.parent.previewImage.length > 0 ? parent.height + parent.spacing : 0)
+                      width: Math.max(0, parent.width - (row.previewImage.length > 0 ? parent.height + parent.spacing : 0) - (pinLabel.visible ? pinLabel.width + parent.spacing : 0))
                       height: parent.height
                       text: parent.parent.previewText
                       color: parent.parent.hasCursor ? root.selectedText : root.foreground
@@ -511,6 +554,18 @@ Item {
                       opacity: parent.parent.entryType === "image" || parent.parent.entryType === "file" ? 0.72 : 1.0
                       elide: Text.ElideRight
                       wrapMode: Text.NoWrap
+                      verticalAlignment: Text.AlignVCenter
+                    }
+
+                    Text {
+                      id: pinLabel
+                      visible: row.pinned
+                      height: parent.height
+                      text: "Pinned"
+                      color: row.hasCursor ? root.selectedText : root.foreground
+                      opacity: 0.7
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
                       verticalAlignment: Text.AlignVCenter
                     }
                   }

--- a/shell/plugins/clipboard/ClipboardHistory.js
+++ b/shell/plugins/clipboard/ClipboardHistory.js
@@ -9,7 +9,7 @@ function normalizeEntry(value) {
     var text = String(value.text || "")
     if (!text.trim().length) return null
     var textEntry = { type: "text", text: text }
-    if (value.pinned === true) textEntry.pinned = true
+    copyPin(value, textEntry)
     return textEntry
   }
 
@@ -23,11 +23,43 @@ function normalizeEntry(value) {
     }
     if (value.capturedAt !== undefined && value.capturedAt !== null)
       entry.capturedAt = String(value.capturedAt)
-    if (value.pinned === true) entry.pinned = true
+    copyPin(value, entry)
     return entry
   }
 
   return null
+}
+
+function copyPin(source, target) {
+  if (source.pinned !== true) return
+  target.pinned = true
+  var shortcut = source.pinShortcut
+  if (typeof shortcut === "number" && shortcut % 1 === 0 && shortcut >= 1 && shortcut <= 9)
+    target.pinShortcut = shortcut
+}
+
+// Reserve existing numbers before assigning free ones. Recopying a pin or
+// removing another pin must never change a remembered shortcut.
+function assignPinShortcuts(history) {
+  var next = history.map(normalizeEntry)
+  var used = {}
+  for (var i = 0; i < next.length; i++) {
+    var entry = next[i]
+    if (!entry || !entry.pinned || !entry.pinShortcut) continue
+    if (used[entry.pinShortcut]) delete entry.pinShortcut
+    else used[entry.pinShortcut] = true
+  }
+  for (var i = 0; i < next.length; i++) {
+    var entry = next[i]
+    if (!entry || !entry.pinned || entry.pinShortcut) continue
+    for (var shortcut = 1; shortcut <= 9; shortcut++) {
+      if (used[shortcut]) continue
+      entry.pinShortcut = shortcut
+      used[shortcut] = true
+      break
+    }
+  }
+  return next
 }
 
 function entryKey(entry) {
@@ -46,7 +78,7 @@ function parseHistory(raw) {
       var entry = normalizeEntry(parsed[i])
       if (entry) next.push(entry)
     }
-    return next
+    return assignPinShortcuts(next)
   } catch (e) {
     return []
   }
@@ -67,7 +99,7 @@ function trimHistory(history, limit) {
       if (!entry.pinned) unpinned++
     }
   }
-  return next
+  return assignPinShortcuts(next)
 }
 
 function addEntry(history, entry, limit) {
@@ -82,7 +114,7 @@ function addEntry(history, entry, limit) {
     var existing = normalizeEntry(values[i])
     if (!existing) continue
     if (entryKey(existing) === key) {
-      if (existing.pinned) normalized.pinned = true
+      copyPin(existing, normalized)
       continue
     }
     next.push(existing)
@@ -97,10 +129,12 @@ function togglePinAt(history, index) {
   if (isNaN(target) || target % 1 !== 0 || target < 0 || target >= next.length) return next
   var entry = normalizeEntry(next[target])
   if (!entry) return next
-  if (entry.pinned) delete entry.pinned
-  else entry.pinned = true
+  if (entry.pinned) {
+    delete entry.pinned
+    delete entry.pinShortcut
+  } else entry.pinned = true
   next[target] = entry
-  return next
+  return assignPinShortcuts(next)
 }
 
 function removeEntryAt(history, index) {
@@ -220,6 +254,9 @@ function displayRows(history, query, limit) {
     if (values[index] && values[index].pinned === true) pinnedIndexes.push(index)
     else unpinnedIndexes.push(index)
   }
+  pinnedIndexes.sort(function(a, b) {
+    return (values[a].pinShortcut || 10) - (values[b].pinShortcut || 10) || a - b
+  })
   var indexes = pinnedIndexes.concat(unpinnedIndexes)
 
   for (var position = 0; position < indexes.length; position++) {
@@ -240,6 +277,7 @@ function displayRows(history, query, limit) {
       path: isImage ? String(entry.path || "") : (isFile && paths.length === 1 ? paths[0] : ""),
       mime: isImage ? String(entry.mime || "image/png") : "text/plain",
       pinned: values[i].pinned === true,
+      pinShortcut: values[i].pinShortcut || 0,
       index: i
     })
     if (rows.length >= max) break

--- a/shell/plugins/clipboard/ClipboardHistory.js
+++ b/shell/plugins/clipboard/ClipboardHistory.js
@@ -7,7 +7,10 @@ function normalizeEntry(value) {
   var type = String(value.type || value.kind || "")
   if (type === "text") {
     var text = String(value.text || "")
-    return text.trim().length > 0 ? { type: "text", text: text } : null
+    if (!text.trim().length) return null
+    var textEntry = { type: "text", text: text }
+    if (value.pinned === true) textEntry.pinned = true
+    return textEntry
   }
 
   if (type === "image") {
@@ -20,6 +23,7 @@ function normalizeEntry(value) {
     }
     if (value.capturedAt !== undefined && value.capturedAt !== null)
       entry.capturedAt = String(value.capturedAt)
+    if (value.pinned === true) entry.pinned = true
     return entry
   }
 
@@ -48,24 +52,54 @@ function parseHistory(raw) {
   }
 }
 
-function addEntry(history, entry, limit) {
-  var normalized = normalizeEntry(entry)
+// Pins are saved independently of the rolling limit for ordinary history.
+function trimHistory(history, limit) {
   var max = limit === undefined || limit === null ? 100 : Number(limit)
   if (isNaN(max)) max = 100
   max = Math.max(0, max)
-  if (!normalized) return Array.isArray(history) ? history.slice(0, max) : []
-  if (max === 0) return []
+  var values = Array.isArray(history) ? history : []
+  var next = []
+  var unpinned = 0
+  for (var i = 0; i < values.length; i++) {
+    var entry = normalizeEntry(values[i])
+    if (entry && (entry.pinned || unpinned < max)) {
+      next.push(entry)
+      if (!entry.pinned) unpinned++
+    }
+  }
+  return next
+}
+
+function addEntry(history, entry, limit) {
+  var normalized = normalizeEntry(entry)
+  if (!normalized) return trimHistory(history, limit)
 
   var key = entryKey(normalized)
   var next = [normalized]
   var values = Array.isArray(history) ? history : []
 
-  for (var i = 0; i < values.length && next.length < max; i++) {
+  for (var i = 0; i < values.length; i++) {
     var existing = normalizeEntry(values[i])
-    if (!existing || entryKey(existing) === key) continue
+    if (!existing) continue
+    if (entryKey(existing) === key) {
+      if (existing.pinned) normalized.pinned = true
+      continue
+    }
     next.push(existing)
   }
 
+  return trimHistory(next, limit)
+}
+
+function togglePinAt(history, index) {
+  var next = Array.isArray(history) ? history.slice() : []
+  var target = Number(index)
+  if (isNaN(target) || target % 1 !== 0 || target < 0 || target >= next.length) return next
+  var entry = normalizeEntry(next[target])
+  if (!entry) return next
+  if (entry.pinned) delete entry.pinned
+  else entry.pinned = true
+  next[target] = entry
   return next
 }
 
@@ -79,8 +113,8 @@ function removeEntryAt(history, index) {
   return next
 }
 
-function clearHistory() {
-  return []
+function clearHistory(history) {
+  return trimHistory(history, 0)
 }
 
 function parseEntryJson(line) {
@@ -180,8 +214,16 @@ function displayRows(history, query, limit) {
   if (max === 0) return []
 
   var rows = []
+  var pinnedIndexes = []
+  var unpinnedIndexes = []
+  for (var index = 0; index < values.length; index++) {
+    if (values[index] && values[index].pinned === true) pinnedIndexes.push(index)
+    else unpinnedIndexes.push(index)
+  }
+  var indexes = pinnedIndexes.concat(unpinnedIndexes)
 
-  for (var i = 0; i < values.length; i++) {
+  for (var position = 0; position < indexes.length; position++) {
+    var i = indexes[position]
     var entry = cappedEntry(normalizeEntry(values[i]))
     if (!entry) continue
     if (needle && searchableText(entry).toLowerCase().indexOf(needle) < 0) continue
@@ -197,6 +239,7 @@ function displayRows(history, query, limit) {
       previewImage: previewPath,
       path: isImage ? String(entry.path || "") : (isFile && paths.length === 1 ? paths[0] : ""),
       mime: isImage ? String(entry.mime || "image/png") : "text/plain",
+      pinned: values[i].pinned === true,
       index: i
     })
     if (rows.length >= max) break
@@ -211,6 +254,8 @@ if (typeof module !== "undefined") {
     entryKey: entryKey,
     parseHistory: parseHistory,
     addEntry: addEntry,
+    trimHistory: trimHistory,
+    togglePinAt: togglePinAt,
     removeEntryAt: removeEntryAt,
     clearHistory: clearHistory,
     parseEntryJson: parseEntryJson,

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -67,12 +67,12 @@ assertDeepEqual(
 assertDeepEqual(clipboard.removeEntryAt(history, 10), history, 'clipboard removeEntryAt ignores invalid indexes')
 assertDeepEqual(clipboard.clearHistory(), [], 'clipboard clearHistory returns an empty history')
 
-const pinnedText = { type: 'text', text: 'saved', pinned: true }
-const pinnedImage = { type: 'image', path: '/tmp/saved.png', mime: 'image/png', capturedAt: 'Monday 12:00', pinned: true }
+const pinnedText = { type: 'text', text: 'saved', pinned: true, pinShortcut: 1 }
+const pinnedImage = { type: 'image', path: '/tmp/saved.png', mime: 'image/png', capturedAt: 'Monday 12:00', pinned: true, pinShortcut: 2 }
 const withPins = [history[0], pinnedText, history[1], pinnedImage]
 assertDeepEqual(clipboard.parseHistory(JSON.stringify(withPins)), withPins, 'text and image pins survive saving and reloading')
 assertDeepEqual(clipboard.normalizeEntry({ type: 'text', text: 'hello', pinned: 'false' }), { type: 'text', text: 'hello' }, 'only a boolean true marks a pin')
-assertDeepEqual(clipboard.togglePinAt(history, 1)[1], { ...history[1], pinned: true }, 'pinning marks the selected entry')
+assertDeepEqual(clipboard.togglePinAt(history, 1)[1], { ...history[1], pinned: true, pinShortcut: 1 }, 'pinning marks the selected entry')
 assertDeepEqual(clipboard.togglePinAt(withPins, 1)[1], { type: 'text', text: 'saved' }, 'unpinning removes the pin')
 assertDeepEqual(withPins[1], pinnedText, 'toggling does not mutate the original entry')
 for (const index of [-1, 20, 0.5, NaN]) {
@@ -84,13 +84,69 @@ assertDeepEqual(clipboard.trimHistory(withPins, 1), [history[0], pinnedText, pin
 assertDeepEqual(clipboard.addEntry(withPins, 'next', 1), [{ type: 'text', text: 'next' }, pinnedText, pinnedImage], 'new copies cannot evict old pins')
 assertDeepEqual(clipboard.addEntry(withPins, 'saved', 0), [pinnedText, pinnedImage], 'recopying text keeps its pin even with a zero history limit')
 assertDeepEqual(clipboard.addEntry(withPins, { type: 'image', path: '/tmp/saved.png' }, 1), [
-  { type: 'image', path: '/tmp/saved.png', mime: 'image/png', pinned: true }, history[0], pinnedText
+  { type: 'image', path: '/tmp/saved.png', mime: 'image/png', pinned: true, pinShortcut: 2 }, history[0], pinnedText
 ], 'recopying an image preserves its pin and removes the duplicate')
 assertDeepEqual(clipboard.displayRows(withPins, '', 3).map(row => [row.index, row.pinned]), [[1, true], [3, true], [0, false]], 'pins display first within the result limit while preserving history indexes')
 assertDeepEqual(clipboard.displayRows(withPins, 'saved', 1).map(row => row.index), [1], 'search finds pins with the original action index')
 assertDeepEqual(clipboard.displayRows(withPins, 'old', 1).map(row => row.index), [0], 'search still finds unpinned entries')
 assertEqual(clipboard.displayRows([{ type: 'text', text: 'x'.repeat(20000), pinned: true }], '', 1)[0].pinned, true, 'capping long previews preserves the pin label')
 assertDeepEqual(clipboard.displayRows(clipboard.togglePinAt(withPins, 1), '', 4).map(row => row.index), [3, 0, 1, 2], 'unpinning restores chronological order among ordinary entries')
+
+const legacyPins = [{ type: 'text', text: 'phone', pinned: true }, { type: 'text', text: 'email', pinned: true }]
+const numberedPins = clipboard.parseHistory(JSON.stringify(legacyPins))
+assertDeepEqual(numberedPins.map(entry => entry.pinShortcut), [1, 2], 'existing pins receive numbered shortcuts')
+assertDeepEqual(clipboard.parseHistory(JSON.stringify(numberedPins)), numberedPins, 'shortcut assignments survive reloading')
+const recopiedPins = clipboard.addEntry(numberedPins, 'email', 10)
+assertDeepEqual(clipboard.displayRows(recopiedPins, '', 50).map(row => [row.previewText, row.pinShortcut, row.index]), [['phone', 1, 1], ['email', 2, 0]], 'recopying keeps shortcut order and correct paste indexes')
+assertDeepEqual(clipboard.displayRows(recopiedPins, 'email', 50).map(row => row.pinShortcut), [2], 'search does not renumber a matching pin')
+assertDeepEqual(clipboard.trimHistory(clipboard.removeEntryAt(numberedPins, 0), 10).map(entry => entry.pinShortcut), [2], 'removing a pin leaves other shortcuts unchanged')
+const replacementPin = clipboard.togglePinAt([numberedPins[1], { type: 'text', text: 'replacement' }], 1)
+assertDeepEqual(replacementPin.map(entry => entry.pinShortcut), [2, 1], 'a newly pinned entry receives the lowest free shortcut')
+const tooManyPins = clipboard.parseHistory(JSON.stringify(Array.from({ length: 11 }, (_, i) => ({ type: 'text', text: String(i), pinned: true }))))
+assertDeepEqual(tooManyPins.map(entry => entry.pinShortcut || 0), [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0], 'additional pins remain available without duplicate digit shortcuts')
+const repairedPins = clipboard.parseHistory(JSON.stringify([
+  { type: 'text', text: 'legacy', pinned: true },
+  { type: 'text', text: 'reserved', pinned: true, pinShortcut: 1 },
+  { type: 'text', text: 'duplicate', pinned: true, pinShortcut: 1 },
+  { type: 'text', text: 'invalid', pinned: true, pinShortcut: 20 }
+]))
+assertDeepEqual(repairedPins.map(entry => entry.pinShortcut), [2, 1, 3, 4], 'repair reserves existing valid shortcuts before allocating missing or duplicate ones')
+assertDeepEqual(clipboard.normalizeEntry({ type: 'text', text: 'ordinary', pinShortcut: 1 }), { type: 'text', text: 'ordinary' }, 'unpinned entries cannot retain a shortcut')
+
+// Exercise the actual key handler and activation method with a fake picker;
+// never paste into the active desktop during automated tests.
+const activateBody = clipboardQml.match(/function activatePinShortcut\(shortcut\) \{([\s\S]*?)\n  \}/)[1]
+const keyBody = clipboardQml.match(/Keys.onPressed: function\(event\) \{([\s\S]*?)\n        \}/)[1]
+const pickerRows = clipboard.displayRows(recopiedPins, '', 50)
+const fakeModel = { count: pickerRows.length, get: index => pickerRows[index] }
+const activated = []
+const picker = {
+  filterText: '', searchMode: false, clearConfirmOpen: false,
+  activateIndex: index => activated.push(pickerRows[index].index),
+  setFilter: value => { picker.filterText = value },
+  close: () => {},
+}
+picker.activatePinShortcut = new Function('root', 'displayModel', 'shortcut', activateBody).bind(null, picker, fakeModel)
+const qt = { Key_F: 70, Key_Escape: 27, ControlModifier: 4, AltModifier: 8, MetaModifier: 16 }
+const handleKey = new Function('Qt', 'root', 'Util', 'clearConfirm', 'event', keyBody).bind(null, qt, picker, { editsFilter: () => false }, { handleKey: () => true })
+handleKey({ key: 49, text: '1', modifiers: 0 })
+assertDeepEqual(activated, [1], 'pressing 1 activates the pinned entry by its actual history index')
+handleKey({ key: 50, text: '2', modifiers: qt.AltModifier })
+assertDeepEqual(activated, [1], 'modified digits do not paste')
+picker.filterText = ''
+handleKey({ key: qt.Key_F, text: '', modifiers: qt.ControlModifier })
+handleKey({ key: 49, text: '1', modifiers: 0 })
+assertEqual(picker.filterText, '1', 'Ctrl+F allows a numeric search without pasting')
+assertDeepEqual(activated, [1], 'numeric search does not activate a pin')
+handleKey({ key: qt.Key_Escape, text: '', modifiers: 0 })
+handleKey({ key: 50, text: '2', modifiers: 0 })
+assertDeepEqual(activated, [1, 0], 'Escape leaves search mode and restores numbered activation')
+picker.clearConfirmOpen = true
+handleKey({ key: 49, text: '1', modifiers: 0 })
+assertDeepEqual(activated, [1, 0], 'confirmation dialogs never activate pin shortcuts')
+picker.clearConfirmOpen = false
+handleKey({ key: 57, text: '9', modifiers: 0 })
+assertEqual(picker.filterText, '9', 'an unassigned digit starts a normal search')
 
 assertDeepEqual(
   clipboard.displayRows(history, 'image', 50).map(row => ({ type: row.entryType, preview: row.previewText, mime: row.mime })),
@@ -132,6 +188,7 @@ assertDeepEqual(
     path: '/home/dhh/Videos/screenrecording-2026-05-29_13-56-43-720p.gif',
     mime: 'text/plain',
     pinned: false,
+    pinShortcut: 0,
     index: 0
   },
   'clipboard display rows show file uri entries as files'

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -67,6 +67,31 @@ assertDeepEqual(
 assertDeepEqual(clipboard.removeEntryAt(history, 10), history, 'clipboard removeEntryAt ignores invalid indexes')
 assertDeepEqual(clipboard.clearHistory(), [], 'clipboard clearHistory returns an empty history')
 
+const pinnedText = { type: 'text', text: 'saved', pinned: true }
+const pinnedImage = { type: 'image', path: '/tmp/saved.png', mime: 'image/png', capturedAt: 'Monday 12:00', pinned: true }
+const withPins = [history[0], pinnedText, history[1], pinnedImage]
+assertDeepEqual(clipboard.parseHistory(JSON.stringify(withPins)), withPins, 'text and image pins survive saving and reloading')
+assertDeepEqual(clipboard.normalizeEntry({ type: 'text', text: 'hello', pinned: 'false' }), { type: 'text', text: 'hello' }, 'only a boolean true marks a pin')
+assertDeepEqual(clipboard.togglePinAt(history, 1)[1], { ...history[1], pinned: true }, 'pinning marks the selected entry')
+assertDeepEqual(clipboard.togglePinAt(withPins, 1)[1], { type: 'text', text: 'saved' }, 'unpinning removes the pin')
+assertDeepEqual(withPins[1], pinnedText, 'toggling does not mutate the original entry')
+for (const index of [-1, 20, 0.5, NaN]) {
+  assertDeepEqual(clipboard.togglePinAt(withPins, index), withPins, 'invalid pin indexes leave history intact')
+}
+assertDeepEqual(clipboard.clearHistory(withPins), [pinnedText, pinnedImage], 'clearing history preserves text and image pins')
+assertDeepEqual(clipboard.removeEntryAt([pinnedText], 0), [], 'explicit deletion can remove a pinned entry')
+assertDeepEqual(clipboard.trimHistory(withPins, 1), [history[0], pinnedText, pinnedImage], 'pins do not consume the rolling history limit')
+assertDeepEqual(clipboard.addEntry(withPins, 'next', 1), [{ type: 'text', text: 'next' }, pinnedText, pinnedImage], 'new copies cannot evict old pins')
+assertDeepEqual(clipboard.addEntry(withPins, 'saved', 0), [pinnedText, pinnedImage], 'recopying text keeps its pin even with a zero history limit')
+assertDeepEqual(clipboard.addEntry(withPins, { type: 'image', path: '/tmp/saved.png' }, 1), [
+  { type: 'image', path: '/tmp/saved.png', mime: 'image/png', pinned: true }, history[0], pinnedText
+], 'recopying an image preserves its pin and removes the duplicate')
+assertDeepEqual(clipboard.displayRows(withPins, '', 3).map(row => [row.index, row.pinned]), [[1, true], [3, true], [0, false]], 'pins display first within the result limit while preserving history indexes')
+assertDeepEqual(clipboard.displayRows(withPins, 'saved', 1).map(row => row.index), [1], 'search finds pins with the original action index')
+assertDeepEqual(clipboard.displayRows(withPins, 'old', 1).map(row => row.index), [0], 'search still finds unpinned entries')
+assertEqual(clipboard.displayRows([{ type: 'text', text: 'x'.repeat(20000), pinned: true }], '', 1)[0].pinned, true, 'capping long previews preserves the pin label')
+assertDeepEqual(clipboard.displayRows(clipboard.togglePinAt(withPins, 1), '', 4).map(row => row.index), [3, 0, 1, 2], 'unpinning restores chronological order among ordinary entries')
+
 assertDeepEqual(
   clipboard.displayRows(history, 'image', 50).map(row => ({ type: row.entryType, preview: row.previewText, mime: row.mime })),
   [{ type: 'image', preview: 'Image', mime: 'image/png' }],
@@ -106,6 +131,7 @@ assertDeepEqual(
     previewImage: '/home/dhh/Videos/screenrecording-2026-05-29_13-56-43-720p.gif',
     path: '/home/dhh/Videos/screenrecording-2026-05-29_13-56-43-720p.gif',
     mime: 'text/plain',
+    pinned: false,
     index: 0
   },
   'clipboard display rows show file uri entries as files'


### PR DESCRIPTION
Clipboard history currently loses frequently reused entries when older history expires or the user clears it. Add Ctrl+P and a clickable Pin/Unpin action to keep selected text and images at the top of the picker. Pins survive restarts and history cleanup, and copying one again preserves its pin.

Pins receive stable shortcuts 1–9. For example, pin a phone number as item 1, open clipboard history, and press 1 to paste it immediately. Copying another pin or removing one does not renumber the remaining shortcuts. Ctrl+F starts a numeric search; additional pins remain selectable without a digit shortcut. Delete explicitly removes an entry, including a pin; Shift+Delete keeps pins when clearing history.

<img width="875" alt="Clipboard history showing a pinned entry with shortcut 2 and the Ctrl+P Unpin action" src="https://raw.githubusercontent.com/alsoalter85/omarchy/eb84a03a50d1ebaedaa53c94bf53176577b080fc/numbered-pin.png" />

Pins show their assigned number. Press it immediately after opening clipboard history to paste the item.

The existing JSON format gains optional pin and shortcut fields. Older history is supported, pins are excluded from the rolling history limit, and display sorting preserves the original history indexes used by paste, copy, open, and delete. The manual documents the behavior.

Validation:

- Clipboard and QML text-format tests pass. Coverage includes persistence, duplicate copies, history limits, shortcut assignment and reuse, numeric search, correct paste indexes, and confirmation-dialog handling.
- Live verification checked pinning, labels, ordering, unpinning, and restart persistence. Pressing a numbered key pasted the expected content into a temporary text window without a click or Enter.
- Ran ./test/all: CLI suite passed; 232 of 234 shell test files passed. The two failures are unrelated to this change: launch-about-test.sh reproduces the roomy-window animation assertion on unchanged upstream HEAD, and locate-test.sh encounters Python bytecode generated in bin/__pycache__ by the suite. The locate test passes when rerun after removing that generated bytecode. Packaging checks pass with the companion repositories available.

Local verification note: Quickshell crashed once during the initial plugin reload. Its trace reaches QML object creation, but the cause was not established. Subsequent restarts and feature checks did not reproduce it.
