### PR TITLE
Fix/browser policy refresh timeout

### DIFF
--- a/bin/omarchy-theme-set-browser
+++ b/bin/omarchy-theme-set-browser
@@ -18,7 +18,7 @@ refresh_running_browser() {
   local pgrep_args="${3:--x}"
 
   if omarchy-cmd-present "$command" && pgrep $pgrep_args "$process" >/dev/null; then
-    "$command" --refresh-platform-policy --no-startup-window &>/dev/null
+    timeout 10 "$command" --refresh-platform-policy --no-startup-window &>/dev/null || true
   fi
 }
 

--- a/test/shell.d/browser-policy-refresh-timeout-test.sh
+++ b/test/shell.d/browser-policy-refresh-timeout-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+refresh_function=$(sed -n '/^refresh_running_browser() {/,/^}/p' "$ROOT/bin/omarchy-theme-set-browser")
+[[ -n $refresh_function ]] || fail "omarchy-theme-set-browser defines refresh_running_browser"
+eval "$refresh_function"
+
+omarchy-cmd-present() { return 0; }
+pgrep() { return 0; }
+
+timeout_args=()
+timeout() {
+  timeout_args=("$@")
+  return 124
+}
+
+refresh_running_browser chromium chromium ||
+  fail "a timed-out browser policy refresh does not fail theme application"
+
+expected=(10 chromium --refresh-platform-policy --no-startup-window)
+[[ ${timeout_args[*]} == "${expected[*]}" ]] ||
+  fail "browser policy refresh is bounded to 10 seconds" "got: ${timeout_args[*]}"
+pass "browser policy refresh is bounded to 10 seconds"
+pass "browser policy refresh timeout is best-effort"


### PR DESCRIPTION
Fixes #10636

## Summary

- bound running-browser policy refreshes to 10 seconds
- treat a refresh timeout as best-effort instead of blocking theme updates
- add a regression test covering the timeout path

`pgrep` only confirms that a matching browser process exists; it does not guarantee that `--refresh-platform-policy --no-startup-window` will return. A wedged browser refresh could therefore block `omarchy update` indefinitely.

This change intentionally does not alter update signal traps; the issue reporter's follow-up clarified that the timeout is the relevant fix.

## Testing

- shell syntax check
- `test/shell.d/browser-policy-refresh-timeout-test.sh`