### PR TITLE
Fix lock screen black screen and fingerprint sensor lockout

### DIFF
--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -20,6 +20,7 @@ Item {
   property bool pendingSessionLock: false
   property bool authenticatingPassword: false
   property bool fingerprintAuthenticating: false
+  property int fingerprintFailureCount: 0
   property bool passwordPamConfigured: false
   property bool fingerprintConfigured: false
   property bool previewVisible: false
@@ -130,6 +131,7 @@ Item {
     failedAttempts = 0
     authenticatingPassword = false
     fingerprintAuthenticating = false
+    fingerprintFailureCount = 0
     fingerprintRetryTimer.stop()
     if (passwordPam.active) passwordPam.abort()
     if (fingerprintPam.active) fingerprintPam.abort()
@@ -248,6 +250,13 @@ Item {
     if (!lockRequested || !sessionLock.secure || !fingerprintConfigured) return
     if (fingerprintPam.active || fingerprintAuthenticating) return
 
+    // Each fresh verify attempt is a good moment for the panel to be lit: the
+    // user is actively presenting a finger and expects to see the prompt, and
+    // this also re-arms the idle-blank countdown so a run of retries doesn't
+    // sit in the dark the whole time (fingerprint activity otherwise never
+    // resets it - see idleBlankTimer's onTriggered comment).
+    runWake()
+
     fingerprintAuthenticating = true
     if (!fingerprintPam.start()) {
       fingerprintAuthenticating = false
@@ -261,8 +270,21 @@ Item {
     if (result === PamResult.Success) {
       finishUnlock()
     } else if (fingerprintConfigured) {
-      fingerprintRetryTimer.restart()
+      scheduleFingerprintRetry()
     }
+  }
+
+  // Some fingerprint readers (e.g. Goodix) trip a firmware thermal-protection
+  // cutoff ("Device disabled to prevent overheating") when scanned too fast
+  // too often. Retrying at a fixed short interval regardless of how many
+  // times it just failed can hammer the sensor into that state and then spin
+  // on it forever, since every retry after that fails instantly too. Back
+  // off exponentially after a few consecutive failures instead.
+  function scheduleFingerprintRetry() {
+    fingerprintFailureCount += 1
+    var backoffSteps = Math.max(0, fingerprintFailureCount - 3)
+    fingerprintRetryTimer.interval = Math.min(250 * Math.pow(2, backoffSteps), 15000)
+    fingerprintRetryTimer.restart()
   }
 
   WlSessionLock {
@@ -390,7 +412,7 @@ Item {
 
     onError: function(error) {
       root.fingerprintAuthenticating = false
-      if (root.lockRequested && root.fingerprintConfigured) fingerprintRetryTimer.restart()
+      if (root.lockRequested && root.fingerprintConfigured) root.scheduleFingerprintRetry()
     }
   }
 


### PR DESCRIPTION
## Problem

Two related bugs in the lock screen's fingerprint flow (`shell/plugins/lock/Service.qml`):

1. **Fingerprint retry has no backoff.** `fingerprintRetryTimer` fires at a fixed 250ms on every failure, with no cap. On sensors with firmware thermal-protection (Goodix in my case), sustained rapid retries trip a `Device disabled to prevent overheating` cutoff. Once tripped, every retry fails instantly but the loop keeps firing every 250ms anyway — a busy-loop with no way out short of falling back to password auth. Reproduced consistently: ~90 seconds of continuous retries, dozens of PAM subprocess spawns, until manual password fallback.

2. **`startFingerprint()` never wakes the display.** `idleBlankTimer` deliberately excludes fingerprint auth from resetting its countdown (see its own comment — the fingerprint PAM session stays "armed" for the whole lock, so gating on it would keep the panel lit indefinitely). But that means the display physically blanks (`omarchy-brightness-display off`) after 5s of no keyboard/mouse activity *even while a fingerprint verify is actively in flight*. Any multi-attempt fingerprint unlock over 5s runs mostly with the screen off — which reads as a black/frozen screen.

## Fix

- Add `fingerprintFailureCount`, reset on lock/unlock. `scheduleFingerprintRetry()` backs off exponentially after the first 3 consecutive failures (250ms → 500ms → 1s → ... capped at 15s), so the sensor can never be hammered into thermal lockout.
- Call `runWake()` at the start of each fresh `startFingerprint()` attempt, so the display lights up (and the idle-blank countdown re-arms) every time a new verify attempt begins, instead of staying dark through retries.

First three failures keep the original fast 250ms retry (normal misread UX unchanged); backoff only kicks in on sustained failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjKUq2LkanQxGMeLHSxAwv