### PR TITLE
Support image paste with Super+V in terminals

### DIFF
--- a/bin/omarchy-clipboard-paste-terminal
+++ b/bin/omarchy-clipboard-paste-terminal
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# omarchy:summary=Paste text or images into the focused terminal
+# omarchy:args=<window-address>
+# omarchy:hidden=true
+
+address=${1:-}
+[[ $address =~ ^0x[[:xdigit:]]+$ ]] || exit 1
+
+# Query Wayland outside the compositor's Lua callback: a synchronous wl-paste
+# there would wait on the compositor that is waiting for it. Inspect only the
+# offered types, never transfer image data just to choose a shortcut.
+types=$(timeout 1 wl-paste --list-types 2>/dev/null) || types=""
+mods=SHIFT
+key=Insert
+if grep -q '^image/' <<< "$types"; then
+  # Terminal paste handles text; image-aware TUIs need to receive Ctrl+V.
+  mods=CTRL
+  key=V
+fi
+
+# Don't paste into a different window if focus changed during the MIME query.
+# Keep the same explicit-modifier down/up workaround as clipboard.lua.
+hyprctl eval "
+  local window = hl.get_active_window()
+  if window and window.address == '$address' then
+    hl.dispatch(hl.dsp.send_key_state({ mods = '$mods', key = '$key', state = 'down' }))
+    hl.timer(function()
+      hl.dispatch(hl.dsp.send_key_state({ mods = '$mods', key = '$key', state = 'up' }))
+    end, { timeout = 50, type = 'oneshot' })
+  end
+" >/dev/null

--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -32,23 +32,19 @@ local function active_window_is_terminal()
   return false
 end
 
-local function universal_clipboard_shortcut(default_mods, default_key, terminal_mods, terminal_key)
+local function universal_clipboard_shortcut(default_mods, default_key, terminal_action)
   return function()
     if active_window_is_terminal() then
-      send_shortcut_once(terminal_mods, terminal_key)()
+      terminal_action()
     else
       send_shortcut_once(default_mods, default_key)()
     end
   end
 end
 
-o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "C", "CTRL", "Insert"))
-o.bind("SUPER + V", "Universal paste", function()
-  if active_window_is_terminal() then
-    hl.exec_cmd("omarchy-clipboard-paste-terminal " .. o.shell_quote(hl.get_active_window().address))
-  else
-    send_shortcut_once("CTRL", "V")()
-  end
-end)
+o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "C", send_shortcut_once("CTRL", "Insert")))
+o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "V", function()
+  hl.exec_cmd("omarchy-clipboard-paste-terminal " .. o.shell_quote(hl.get_active_window().address))
+end))
 o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", "X"))
 o.bind("SUPER + CTRL + V", "Clipboard manager", "omarchy-shell shell toggle omarchy.clipboard")

--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -43,6 +43,12 @@ local function universal_clipboard_shortcut(default_mods, default_key, terminal_
 end
 
 o.bind("SUPER + C", "Universal copy", universal_clipboard_shortcut("CTRL", "C", "CTRL", "Insert"))
-o.bind("SUPER + V", "Universal paste", universal_clipboard_shortcut("CTRL", "V", "SHIFT", "Insert"))
+o.bind("SUPER + V", "Universal paste", function()
+  if active_window_is_terminal() then
+    hl.exec_cmd("omarchy-clipboard-paste-terminal " .. o.shell_quote(hl.get_active_window().address))
+  else
+    send_shortcut_once("CTRL", "V")()
+  end
+end)
 o.bind("SUPER + X", "Universal cut", send_shortcut_once("CTRL", "X"))
 o.bind("SUPER + CTRL + V", "Clipboard manager", "omarchy-shell shell toggle omarchy.clipboard")

--- a/test/shell.d/clipboard-terminal-paste-test.sh
+++ b/test/shell.d/clipboard-terminal-paste-test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname -- "${BASH_SOURCE[0]}")/base-test.sh"
+require_command lua
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir "$TMPDIR/bin"
+export PASTE_TEST_DIR="$TMPDIR"
+
+cat > "$TMPDIR/bin/wl-paste" <<'STUB'
+#!/bin/bash
+[[ $* == "--list-types" ]] || exit 2
+printf '%s\n' "${PASTE_TYPES:-}"
+exit "${PASTE_STATUS:-0}"
+STUB
+cat > "$TMPDIR/bin/hyprctl" <<'STUB'
+#!/bin/bash
+[[ $1 == "eval" ]] || exit 2
+printf '%s\n' "$2" > "$PASTE_TEST_DIR/dispatch.lua"
+STUB
+chmod +x "$TMPDIR/bin/"*
+
+cat > "$TMPDIR/check.lua" <<'LUA'
+local events = {}
+hl = {
+  get_active_window = function()
+    if arg[3] ~= "none" then return { address = arg[3] or "0x123" } end
+  end,
+  dsp = { send_key_state = function(event) return event end },
+  dispatch = function(event) table.insert(events, event) end,
+  timer = function(callback, options)
+    assert(options.timeout == 50 and options.type == "oneshot")
+    callback()
+  end,
+}
+dofile(os.getenv("PASTE_TEST_DIR") .. "/dispatch.lua")
+if arg[3] then
+  assert(#events == 0, "focus change must cancel paste")
+else
+  assert(#events == 2)
+  for i, state in ipairs({ "down", "up" }) do
+    assert(events[i].mods == arg[1] and events[i].key == arg[2] and events[i].state == state)
+  end
+end
+LUA
+
+check_paste() {
+  local types=$1 mods=$2 key=$3
+  PASTE_TYPES="$types" PATH="$TMPDIR/bin:$PATH" "$ROOT/bin/omarchy-clipboard-paste-terminal" 0x123
+  lua "$TMPDIR/check.lua" "$mods" "$key"
+}
+
+check_paste 'text/plain;charset=utf-8' SHIFT Insert
+pass "terminal text paste sends Shift+Insert down and up"
+for types in 'image/png' 'image/jpeg' $'text/html\nimage/png\ntext/plain'; do
+  check_paste "$types" CTRL V
+done
+pass "image offers, including mixed text and image, send Ctrl+V"
+check_paste '' SHIFT Insert
+check_paste 'application/x-image/png' SHIFT Insert
+PASTE_STATUS=1 check_paste 'image/png' SHIFT Insert
+pass "empty, non-image and failed offers fall back to terminal text paste"
+lua "$TMPDIR/check.lua" SHIFT Insert 0x456
+lua "$TMPDIR/check.lua" SHIFT Insert none
+pass "changed or missing focus cancels paste"
+if PATH="$TMPDIR/bin:$PATH" "$ROOT/bin/omarchy-clipboard-paste-terminal" "bad-address"; then
+  fail "invalid window addresses are rejected"
+fi
+pass "invalid window addresses are rejected"
+
+lua - <<'LUA'
+local binds, events, commands = {}, {}, {}
+local window
+hl = {
+  get_active_window = function() return window end,
+  exec_cmd = function(cmd) table.insert(commands, cmd) end,
+  dsp = { send_key_state = function(event) return event end },
+  dispatch = function(event) table.insert(events, event) end,
+  timer = function(callback) callback() end,
+}
+o = {
+  bind = function(chord, description, callback) binds[chord] = callback end,
+  shell_quote = function(value) return "'" .. value .. "'" end,
+}
+dofile(os.getenv("ROOT") .. "/default/hypr/bindings/clipboard.lua")
+for _, tag in ipairs({ "terminal", "terminal*" }) do
+  window = { address = "0x123", tags = { tag } }
+  binds["SUPER + V"]()
+  assert(commands[#commands] == "omarchy-clipboard-paste-terminal '0x123'")
+  assert(#events == 0, "terminal paste must query asynchronously")
+end
+for _, target in ipairs({ false, { tags = {} } }) do
+  window = target or nil
+  events = {}
+  binds["SUPER + V"]()
+  assert(#events == 2 and events[1].mods == "CTRL" and events[1].key == "V")
+end
+window = { tags = { "terminal*" } }
+events = {}
+binds["SUPER + C"]()
+assert(events[1].mods == "CTRL" and events[1].key == "Insert")
+LUA
+pass "bindings route terminal paste asynchronously and preserve GUI paste and terminal copy"


### PR DESCRIPTION
Super+V currently sends Shift+Insert in every terminal. Terminals consume that as a text paste, so an image on the clipboard never reaches image-aware applications such as Claude Code and Codex. Users have to press Ctrl+V themselves.

Keep terminal/GUI routing in `universal_clipboard_shortcut`, with a terminal action callback shared by the copy and paste bindings. Choose Ctrl+V when the clipboard offers an image MIME type, and retain Shift+Insert for text. The MIME query runs in an asynchronous helper so wl-paste cannot block the compositor waiting for its own Wayland response. It has a one-second timeout, falls back to text paste on failure, and cancels if the focused window changed. Synthetic keys retain the existing explicit modifiers and 50 ms down/up workaround.

This covers the universal Super+V binding. The clipboard-history picker is a separate path covered by #10535 and #10536.

Validation:
- Focused regression test passes: text, PNG/JPEG, mixed image/text offers, empty/failed offers, invalid addresses, focus changes, terminal tags, GUI paste, and terminal copy.
- Bash/Lua syntax and git diff checks pass.
- Live Foot, Ghostty 1.3.1, and Alacritty 0.17.0 probes each received byte `0x16` (Ctrl+V) when invoking the exact Super+V Lua callback with an image clipboard. All three were correctly tagged as terminals. Local binding override loads with no Hyprland configuration errors. Physical Super+V attachment in the agents is awaiting user confirmation.
- Ran `./test/all`: CLI passes; shell reports three failures. Config and About failures also reproduce on unchanged upstream with the same package-checkout setting (missing PKGBUILD install entry; “a roomy window animates”). Locate failed on Python bytecode generated under bin by earlier tests and passes after moving those cache files aside.

