### PR TITLE
Background wipe animates on only one output

### DIFF
--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -304,7 +304,7 @@ Item {
         layer.smooth: true
         layer.effect: MultiEffect {
           maskEnabled: true
-          maskSource: revealMask
+          maskSource: revealMaskSource
           maskThresholdMin: 0.5
           maskSpreadAtMin: 0.02
         }
@@ -322,11 +322,25 @@ Item {
         }
       }
 
+      // The mask has to stay in the render tree for the wipe to animate. An
+      // item kept out of it with visible: false can change its geometry
+      // without dirtying the window, so an output whose scene is otherwise
+      // static never schedules a frame: it held the old wallpaper for the
+      // whole transition and jumped when the reveal ended. hideSource keeps
+      // the mask off the screen while leaving it live, and the effect samples
+      // it from here instead of from the item's own layer.
+      ShaderEffectSource {
+        id: revealMaskSource
+        anchors.fill: parent
+        sourceItem: revealMask
+        live: true
+        hideSource: true
+        visible: false
+      }
+
       Item {
         id: revealMask
         anchors.fill: parent
-        visible: false
-        layer.enabled: true
 
         readonly property real slant: -0.18
         readonly property real centerTop: width / 2 - slant * height / 2

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -244,11 +244,19 @@ Item {
 
       property bool maskReady: false
 
+      // Every output that has decoded the incoming image joins the wipe, even
+      // one that gets there after the animation has started. Each output
+      // decodes its own copy, so requiring revealProgress to still be 0 let
+      // whichever output decoded first claim the reveal and locked the rest
+      // out of it: they kept the old wallpaper and jumped to the new one when
+      // the transition ended. startReveal still restarts the animation only
+      // once per backgroundVersion, so a late output picks up the front where
+      // it already is.
       function maybeStartReveal() {
-        if (!root.incomingBackground || root.revealProgress !== 0 || maskReady) return
+        if (!root.incomingBackground || maskReady) return
         if (incomingFrame.status !== Image.Ready) return
         Qt.callLater(function() {
-          if (!root.incomingBackground || root.revealProgress !== 0 || maskReady) return
+          if (!root.incomingBackground || maskReady) return
           if (incomingFrame.status !== Image.Ready) return
           root.startReveal(panel)
         })


### PR DESCRIPTION
The desktop background wipe animates on one output only. The other outputs
hold the old wallpaper for the length of the transition and then jump
straight to the new one. Which output animates is not stable: it follows
whichever one happens to win a decode race, so it usually looks like "the
monitor I made the change on" and changes between runs.

There are two independent causes, one per commit. Either one alone is
enough to produce the symptom, so both are needed.

### 1. `maybeStartReveal` locks every output but the first out of the reveal

`revealProgress`, `incomingBackground` and `backgroundVersion` are on the
plugin root and shared by every panel, so the wipe is clearly meant to run
everywhere. But the guard required `revealProgress` to still be `0`:

```qml
if (!root.incomingBackground || root.revealProgress !== 0 || maskReady) return
```

`incomingFrame` has `cache: false`, so each output decodes its own copy of
the image and they finish at different times. The first output to decode
calls `startReveal`, which starts the animation and moves `revealProgress`
off `0`. Every other output then fails the guard and never sets
`maskReady`, so its `incomingLayer` stays invisible until `revealProgress`
reaches `1`.

`startReveal` already guards the animation restart with
`revealStartedVersion === backgroundVersion`, so dropping the
`revealProgress` condition just lets a late output set its own mask and
pick the front up where it already is.

### 2. The reveal mask is outside the render tree, so idle outputs never repaint

`revealMask` was `visible: false` with `layer.enabled: true`. Growing the
`Shape` inside it changes only the geometry of an item that is not in the
render tree, and `update()` on such an item does not dirty the window. An
output whose scene is otherwise static therefore schedules no frame for the
whole 420ms and only repaints at the end, when `base`'s source changes.

This is why fixing (1) alone is not enough: with (1) fixed both outputs
have a correct mask, and the wipe is still invisible on any output that has
nothing else driving repaints.

Capturing the mask through a `ShaderEffectSource` with `hideSource: true`
keeps it live in the tree while keeping it off the screen.

### Verification

No automated test covers this, so I measured it. `grim -g` samples a
wallpaper-only strip on each output (below the bar and below the only
mapped window) while a transition runs, in two parallel loops, counting
distinct frames. A wiping output produces a run of distinct frames; an
output that just snaps produces two — the old wallpaper and the new one.

Slowed to a 4s reveal so the sampling window covers the animation
comfortably, 30 samples per output:

| | eDP-1 | DP-12 |
|---|---|---|
| before, run 1 | **2** | 18 |
| before, run 2 | 20 | 10 |
| before, run 3 | 18 | **1** |
| before, run 4 | 29 | **1** |
| before, run 5 | 11 | 18 |
| before, run 6 | 18 | 9 |
| after, run 1 | 13 | 15 |
| after, run 2 | 29 | 27 |
| after, run 3 | 28 | 27 |
| after, run 4 | 28 | 28 |

Before the change, one output collapses to 1-2 distinct frames in half the
runs, and which one it is flips between runs. After it, neither output ever
drops below 13.

At the shipped 420ms duration the same comparison holds with a wider
capture window (40 samples): before, eDP-1 sits at 2-5 distinct frames
across six runs while DP-12 gets 6-9; after, both outputs land at 4-8 on
every run.

`./test/all` reports 5 of 234 test files failing on my machine, but the
same 5 fail identically with the patch reverted at a703092, so none of them
are from this change:

- `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh` want an
  `omarchy-pkgs` checkout I do not have
- `locate-test.sh` dies in a `UnicodeDecodeError` in its own helper
- `runtime-smoke-test.sh` fails `each widget registers its IPC handler once
  per screen (saw 4 for 2 screen(s))`, which is #9975 and needs two screens
  to show up

Their output is byte-identical before and after apart from randomised temp
paths. `runtime-smoke-test.sh` is worth noting positively: it loads the
patched `Background.qml` in a real quickshell and logs no QML warning from
it.

### One caveat on how this was verified

My machine runs 4.0.2, whose shell predates `Ui/BackgroundMedia.qml`, so
`quattro`'s `Background.qml` cannot be loaded there. I verified the two
edits against the 4.0.2 copy of the file instead. All three regions the
patch touches — `maybeStartReveal`, the `revealMask` block and the
`MultiEffect` mask source — are byte-identical between 4.0.2 and
`quattro` at a703092, so the edits and the measurements transfer, but I
have not watched these exact commits run.

Setup: Hyprland, two outputs side by side at scale 1.6, eDP-1 at 0,0
(2400x1500 logical) and DP-12 at 2400,0 (2400x1350 logical).
