### PR TITLE
Launch Kitty Terminal with --single-instance

### DIFF
--- a/bin/omarchy-install-terminal
+++ b/bin/omarchy-install-terminal
@@ -34,6 +34,9 @@ if omarchy-pkg-add $package; then
   elif [[ $package == "foot" ]]; then
     mkdir -p ~/.local/share/applications
     cp "$OMARCHY_PATH/applications/$desktop_id" ~/.local/share/applications/
+  elif [[ $package == "kitty" ]]; then
+    mkdir -p ~/.local/share/applications
+    cp "$OMARCHY_PATH/default/kitty/$desktop_id" ~/.local/share/applications/
   fi
 
   # Copy default config for optional terminals when missing

--- a/default/kitty/kitty.desktop
+++ b/default/kitty/kitty.desktop
@@ -1,0 +1,21 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=kitty
+GenericName=Terminal emulator
+Comment=Fast, feature-rich, GPU based terminal
+TryExec=kitty
+StartupNotify=true
+Exec=kitty --single-instance
+Icon=kitty
+Categories=System;TerminalEmulator;
+Actions=New;
+X-TerminalArgExec=--
+X-TerminalArgTitle=--title
+X-TerminalArgAppId=--class
+X-TerminalArgDir=--working-directory
+X-TerminalArgHold=--hold
+
+[Desktop Action New]
+Name=New Terminal
+Exec=kitty --single-instance

--- a/migrations/1788799150.sh
+++ b/migrations/1788799150.sh
@@ -1,0 +1,6 @@
+echo "Launch Kitty as a single instance"
+
+if omarchy-cmd-present kitty; then
+  mkdir -p "$HOME/.local/share/applications"
+  cp "$OMARCHY_PATH/default/kitty/kitty.desktop" "$HOME/.local/share/applications/"
+fi

--- a/test/shell.d/kitty-single-instance-test.sh
+++ b/test/shell.d/kitty-single-instance-test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+desktop="$ROOT/default/kitty/kitty.desktop"
+exec_count=$(grep -c '^Exec=kitty --single-instance$' "$desktop")
+[[ $exec_count == 2 ]] || fail "shipped Kitty desktop launches with --single-instance" "count: $exec_count"
+pass "shipped Kitty desktop uses --single-instance"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+mock_bin="$test_tmp/bin"
+mkdir -p "$home/.config" "$mock_bin"
+
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$mock_bin/omarchy-pkg-add"
+
+HOME="$home" PATH="$mock_bin:$PATH" OMARCHY_PATH="$ROOT" \
+  "$ROOT/bin/omarchy-install-terminal" kitty >/dev/null
+
+installed="$home/.local/share/applications/kitty.desktop"
+[[ -f $installed ]] || fail "install-terminal copies the Kitty desktop entry"
+grep -qxF 'Exec=kitty --single-instance' "$installed" ||
+  fail "install-terminal copies the single-instance Kitty desktop"
+pass "install-terminal installs the single-instance Kitty desktop"
+
+migration="$ROOT/migrations/1788799150.sh"
+rm -rf "$home/.local/share/applications"
+mkdir -p "$home/.local/share/applications"
+
+cat >"$mock_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ $1 == kitty ]]
+SH
+chmod +x "$mock_bin/omarchy-cmd-present"
+
+HOME="$home" PATH="$mock_bin:$PATH" OMARCHY_PATH="$ROOT" \
+  bash -euo pipefail "$migration" >/dev/null
+
+[[ -f $home/.local/share/applications/kitty.desktop ]] ||
+  fail "migration copies the Kitty desktop when kitty is present"
+grep -qxF 'Exec=kitty --single-instance' "$home/.local/share/applications/kitty.desktop" ||
+  fail "migration installs --single-instance"
+pass "migration copies the single-instance desktop when kitty is present"
+
+rm -f "$home/.local/share/applications/kitty.desktop"
+cat >"$mock_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$mock_bin/omarchy-cmd-present"
+
+HOME="$home" PATH="$mock_bin:$PATH" OMARCHY_PATH="$ROOT" \
+  bash -euo pipefail "$migration" >/dev/null
+
+[[ ! -e $home/.local/share/applications/kitty.desktop ]] ||
+  fail "migration skips the desktop copy when kitty is absent"
+pass "migration is a no-op when kitty is not installed"


### PR DESCRIPTION
Ghostty already runs as one process. Kitty's packaged desktop starts a new GPU process per window.

Ship default/kitty/kitty.desktop with Exec=kitty --single-instance, copy it from omarchy-install-terminal, and migrate existing Kitty installs.
