### PR TITLE
Bind Ctrl+Shift+N to a new Alacritty window

### DIFF
--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -24,5 +24,6 @@ bindings = [
 # Send Shift+Return as CSI-u so TUIs can distinguish it from Return without treating it as Alt+Return.
 { key = "Return", mods = "Shift", chars = "\u001B[13;2u" },
 # Legacy encoding sends Alt+Shift+Return the same as Alt+Return; send CSI-u so tmux can match M-S-Enter.
-{ key = "Return", mods = "Alt|Shift", chars = "\u001B[13;4u" }
+{ key = "Return", mods = "Alt|Shift", chars = "\u001B[13;4u" },
+{ key = "N", mods = "Control|Shift", action = "CreateNewWindow" }
 ]

--- a/migrations/1788799151.sh
+++ b/migrations/1788799151.sh
@@ -1,0 +1,15 @@
+echo "Bind Ctrl+Shift+N in Alacritty to create a window"
+
+config="$HOME/.config/alacritty/alacritty.toml"
+[[ -f $config ]] || exit 0
+
+if grep -q 'action = "CreateNewWindow"' "$config"; then
+  exit 0
+fi
+
+if grep -qxF '{ key = "Return", mods = "Alt|Shift", chars = "\u001B[13;4u" }' "$config"; then
+  sed -i '/^{ key = "Return", mods = "Alt|Shift", chars = "\\u001B\[13;4u" }$/s/$/,/' "$config"
+  sed -i '/^{ key = "Return", mods = "Alt|Shift", chars = "\\u001B\[13;4u" },$/a { key = "N", mods = "Control|Shift", action = "CreateNewWindow" }' "$config"
+else
+  printf '\n{ key = "N", mods = "Control|Shift", action = "CreateNewWindow" }\n' >>"$config"
+fi

--- a/test/shell.d/alacritty-new-window-keybind-test.sh
+++ b/test/shell.d/alacritty-new-window-keybind-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+grep -Fq '{ key = "N", mods = "Control|Shift", action = "CreateNewWindow" }' \
+  "$ROOT/config/alacritty/alacritty.toml" ||
+  fail "shipped Alacritty config binds Ctrl+Shift+N to CreateNewWindow"
+pass "shipped Alacritty config binds Ctrl+Shift+N to a new window"
+
+migration="$ROOT/migrations/1788799151.sh"
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+home="$test_tmp/home"
+mkdir -p "$home/.config/alacritty"
+
+run_migration() {
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+# Exact shipped last-binding line: insert after it.
+cat >"$home/.config/alacritty/alacritty.toml" <<'EOF'
+[keyboard]
+bindings = [
+{ key = "Return", mods = "Alt|Shift", chars = "\u001B[13;4u" }
+]
+EOF
+
+run_migration || fail "migration runs against the shipped Alacritty bindings"
+grep -Fq '{ key = "N", mods = "Control|Shift", action = "CreateNewWindow" }' \
+  "$home/.config/alacritty/alacritty.toml" ||
+  fail "migration inserts the CreateNewWindow binding"
+grep -Fq '{ key = "Return", mods = "Alt|Shift", chars = "\u001B[13;4u" },' \
+  "$home/.config/alacritty/alacritty.toml" ||
+  fail "migration keeps the previous binding as a valid array item"
+pass "migration inserts Ctrl+Shift+N after the shipped Shift+Return binding"
+
+# Already present: leave the file alone.
+before=$(cat "$home/.config/alacritty/alacritty.toml")
+run_migration || fail "migration reruns when the binding already exists"
+[[ $(cat "$home/.config/alacritty/alacritty.toml") == "$before" ]] ||
+  fail "migration is a no-op when CreateNewWindow is already bound"
+pass "migration is idempotent"
+
+# No Alacritty config: skip without creating one.
+rm -rf "$home/.config"
+run_migration || fail "migration runs when Alacritty config is absent"
+[[ ! -e $home/.config/alacritty/alacritty.toml ]] ||
+  fail "migration does not create an Alacritty config"
+pass "migration skips a missing Alacritty config"


### PR DESCRIPTION
Foot, Ghostty and Kitty already use Ctrl+Shift+N for a new window. Alacritty does not.

Add CreateNewWindow bind matching Ghostty and Kitty to the shipped alacritty.toml.