### PR TITLE
Reuse one Alacritty process for new windows

### DIFF
--- a/bin/omarchy-launch-alacritty
+++ b/bin/omarchy-launch-alacritty
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Open a new Alacritty window in the existing process, or start one
+# omarchy:args=[options...]
+
+if ! alacritty msg create-window "$@" 2>/dev/null; then
+  exec alacritty "$@"
+fi

--- a/default/alacritty/Alacritty.desktop
+++ b/default/alacritty/Alacritty.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 TryExec=alacritty
-Exec=alacritty
+Exec=omarchy-launch-alacritty
 Icon=Alacritty
 Terminal=false
 Categories=System;TerminalEmulator;
@@ -18,4 +18,4 @@ X-TerminalArgDir=--working-directory=
 
 [Desktop Action New]
 Name=New Terminal
-Exec=alacritty
+Exec=omarchy-launch-alacritty

--- a/migrations/1788799152.sh
+++ b/migrations/1788799152.sh
@@ -1,0 +1,6 @@
+echo "Reuse one Alacritty process for new windows"
+
+dest="$HOME/.local/share/applications/Alacritty.desktop"
+if [[ -f $dest ]]; then
+  cp "$OMARCHY_PATH/default/alacritty/Alacritty.desktop" "$dest"
+fi

--- a/test/shell.d/launch-alacritty-test.sh
+++ b/test/shell.d/launch-alacritty-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+desktop="$ROOT/default/alacritty/Alacritty.desktop"
+exec_count=$(grep -c '^Exec=omarchy-launch-alacritty$' "$desktop")
+[[ $exec_count == 2 ]] || fail "shipped Alacritty desktop launches through omarchy-launch-alacritty" "count: $exec_count"
+pass "shipped Alacritty desktop uses omarchy-launch-alacritty"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+log="$test_tmp/alacritty.log"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/alacritty" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"${ALACRITTY_LOG:?}"
+if [[ ${1:-} == msg && ${2:-} == create-window ]]; then
+  exit "${ALACRITTY_MSG_RC:-0}"
+fi
+exit 0
+SH
+chmod +x "$mock_bin/alacritty"
+
+run_launch() {
+  rm -f "$log"
+  PATH="$mock_bin:$PATH" ALACRITTY_LOG="$log" ALACRITTY_MSG_RC="$1" \
+    "$ROOT/bin/omarchy-launch-alacritty" "${@:2}"
+}
+
+run_launch 0 --working-directory /tmp -e htop
+[[ $(cat "$log") == "msg create-window --working-directory /tmp -e htop" ]] ||
+  fail "launcher creates a window on the existing process" "$(cat "$log")"
+pass "launcher uses msg create-window when an instance is running"
+
+run_launch 1 --working-directory /tmp -e htop
+mapfile -t lines <"$log"
+[[ ${lines[0]} == "msg create-window --working-directory /tmp -e htop" ]] ||
+  fail "launcher tries create-window first when no instance is running" "${lines[0]:-}"
+[[ ${lines[1]} == "--working-directory /tmp -e htop" ]] ||
+  fail "launcher falls back to starting Alacritty" "${lines[1]:-}"
+pass "launcher starts Alacritty when create-window fails"
+
+migration="$ROOT/migrations/1788799152.sh"
+home="$test_tmp/home"
+omarchy_path="$test_tmp/omarchy"
+mkdir -p "$home/.local/share/applications" "$omarchy_path/default/alacritty"
+printf 'NEW-LAUNCHER\n' >"$omarchy_path/default/alacritty/Alacritty.desktop"
+printf 'OLD-LAUNCHER\n' >"$home/.local/share/applications/Alacritty.desktop"
+
+HOME="$home" OMARCHY_PATH="$omarchy_path" bash -euo pipefail "$migration" >/dev/null
+[[ $(cat "$home/.local/share/applications/Alacritty.desktop") == "NEW-LAUNCHER" ]] ||
+  fail "migration refreshes an existing Alacritty desktop"
+pass "migration refreshes the Alacritty desktop when present"
+
+rm -f "$home/.local/share/applications/Alacritty.desktop"
+HOME="$home" OMARCHY_PATH="$omarchy_path" bash -euo pipefail "$migration" >/dev/null
+[[ ! -e $home/.local/share/applications/Alacritty.desktop ]] ||
+  fail "migration does not create an Alacritty desktop that was not there"
+pass "migration skips a missing Alacritty desktop"


### PR DESCRIPTION
Alacritty has no "single-instance" flag like Ghostty or Kitty. msg create-window || alacritty has to live in a shell, and no one Exec line is valid for both GLib (gtk-launch / app menu) and xdg-terminal-exec while still forwarding --working-directory, -e, and --class.

Add omarchy-launch-alacritty:

  alacritty msg create-window "$@" || exec alacritty "$@"

Point default/alacritty/Alacritty.desktop at it (main Exec and New). Migrate existing ~/.local/share/applications/Alacritty.desktop copies.