### PR TITLE
Stop the layout widget switching a device nobody types on

### DIFF
--- a/shell/plugins/bar/widgets/KeyboardLayout.qml
+++ b/shell/plugins/bar/widgets/KeyboardLayout.qml
@@ -27,6 +27,11 @@ BarWidget {
   // the widget ships on the bar and stays out of the way until there are two.
   // An older Hyprland that doesn't report the list keeps showing the label.
   property bool multipleLayouts: true
+  // Where the reading sits in the layout list, how long that list is, and every
+  // keyboard sharing it. A switch moves that set together, so it needs all three.
+  property int layoutIndex: 0
+  property int layoutCount: 0
+  property var syncNames: []
   // Short language code per layout description ("English (US)": "en"), read from
   // xkb's own table rather than maintained by hand.
   property var layoutBriefs: ({})
@@ -63,17 +68,31 @@ BarWidget {
   }
 
   // switchxkblayout is a hyprctl command rather than a dispatcher, so it has to
-  // be run rather than sent over the dispatch socket. It switches the keyboard
-  // the last reading spoke for, so a click always advances the device the label
-  // is describing. Switching the seat together would reach the typed keyboard
-  // without having to name it, but it would also carry the buttons along, and
-  // the whole read depends on those staying where they started: once a button
-  // has been advanced too, a toggle that wraps the keyboard back to the first
-  // layout leaves the button reading as the furthest along, and the label
-  // follows the button.
+  // be run rather than sent over the dispatch socket.
+  //
+  // Move every keyboard holding the same layout list, rather than the single one
+  // the last reading spoke for. Naming one device puts the whole switch behind
+  // UNTYPED_KEYBOARDS recognising every non-keyboard by name, and that list
+  // cannot keep up with what a seat carries: vendor hotkey blocks
+  // (intel-hid-events, dell-wmi-hotkeys), HID consumer controls, and Bluetooth
+  // AVRCP endpoints from a pair of headphones all arrive holding the seat's
+  // layout list, and they sort ahead of the keyboard being typed on. The click
+  // then advances a device nobody types on; that device is now the furthest
+  // along, so it wins the next reading too, and the label describes it while the
+  // real keyboard never moved.
+  //
+  // An absolute index rather than "next", because "next" advances each device
+  // from wherever it already sits: a seat that has drifted apart stays drifted
+  // and merely inverts. One index converges them in a single click, and a seat
+  // in lockstep is what leaves the reading nothing to disagree about afterwards.
+  //
+  // Keyboards given their own kb_layout hold a different list and are left out:
+  // an index into this list would not mean the same layout to them.
   function cycleLayout() {
-    if (!root.keyboardName || !root.bar) return
-    root.bar.run("hyprctl switchxkblayout " + Util.shellQuote(root.keyboardName) + " next")
+    if (!root.bar || root.layoutCount < 2 || root.syncNames.length === 0) return
+    const next = (root.layoutIndex + 1) % root.layoutCount
+    root.bar.run(root.syncNames.map(name =>
+      "hyprctl switchxkblayout " + Util.shellQuote(name) + " " + next).join("; "))
     refreshTimer.restart()
   }
 
@@ -149,6 +168,14 @@ BarWidget {
         root.keyboardCount = typed.length
         root.keyboardName = String(kb.name || "")
         root.multipleLayouts = kb.layout === undefined || String(kb.layout).indexOf(",") !== -1
+        root.layoutIndex = kb.active_layout_index || 0
+        root.layoutCount = kb.layout === undefined ? 0 : String(kb.layout).split(",").length
+        // Buttons and virtual keyboards are included on purpose: they hold the
+        // same list, and leaving them behind is what lets a reading drift onto
+        // one of them later.
+        root.syncNames = listed.filter(k => String(k.layout) === String(kb.layout))
+                               .map(k => String(k.name || ""))
+                               .filter(name => name !== "")
         root.layoutFull = kb.active_keymap
       }
     }


### PR DESCRIPTION
## What's broken

Click the keyboard layout widget and the label flips `EN` → `NO`. Then type `;` and you still get `;`.

The label isn't lying. A device really did switch to Norwegian — just not the keyboard you're typing on.

## Why

`switchxkblayout` is per-device, so the widget has to choose one. It chooses by filtering out the things that aren't keyboards:

```js
var UNTYPED_KEYBOARDS = /^(hl-virtual-keyboard|power-button|sleep-button|lid-switch|video-bus)/
```

…then taking whichever survivor sits furthest through the layout list, or the first one on a settled seat.

The trouble is how much a laptop registers as a keyboard. On a Dell XPS 14, Hyprland reports **10 keyboards. One of them is a keyboard.** The regex catches 3 of the other 9:

| device | keys it can emit | filtered? |
|---|---:|---|
| `hid-sdw:0:0:01fa:4245:01-consumer-control` | 7 | no |
| `hid-sdw:0:0:01fa:4245:01` | 1 | no |
| `intel-hid-events` | 16 | no |
| `intel-hid-5-button-array` | 6 | no |
| `dell-privacy-driver` | 2 | no |
| `dell-wmi-hotkeys` | 19 | no |
| `power-button` / `sleep-button` / `video-bus` | 1–8 | yes |
| **`at-translated-set-2-keyboard`** | **167** | no — and it's the real one |

The real keyboard sorts *last* of the seven survivors, so `typed[0]` is a media-key block — and that's what every click switches.

## Receipts

Pristine widget logic, seat reset to a clean baseline, four clicks:

```
baseline: real keyboard = English (US)
click 1: label read 'English (US)' off hid-sdw:...-consumer-control
         -> real keyboard is now English (US)
click 2: label read 'Norwegian'    off hid-sdw:...-consumer-control
         -> real keyboard is now English (US)
click 3: label read 'English (US)' off hid-sdw:...-consumer-control
         -> real keyboard is now English (US)
click 4: label read 'Norwegian'    off hid-sdw:...-consumer-control
         -> real keyboard is now English (US)
```

The label cycles convincingly. The keyboard never moves.

Device order is stable across repeated polls, so this is deterministic rather than a race — and it needs no Bluetooth device and no pre-existing bad state. Any seat where a hotkey device sorts ahead of the real keyboard hits it.

## The fix

Switch every keyboard sharing the same layout list, and name an **absolute** index rather than `next`.

Absolute matters. `next` advances each device from wherever it already sits, so a seat that has drifted apart just inverts instead of converging:

```
drifted:   real=English (US)  other=Norwegian     lockstep=false
all next:  real=Norwegian     other=English (US)  lockstep=false   # still split
```

One index converges everything in a single call. And once the seat is in lockstep, it stops mattering which device the label reads — which is what the previous comment was protecting by naming just one.

After:

```
click 1: synced 10/10 devices to 1 -> real keyboard = Norwegian     lockstep=true
click 2: synced 10/10 devices to 0 -> real keyboard = English (US)  lockstep=true
```

Keyboards given their own `kb_layout` hold a different layout list and are left alone — an index into this list wouldn't mean the same layout to them. Buttons and virtual keyboards are included on purpose: they carry the same list, and leaving them behind is exactly what lets a later reading drift onto one of them.

## Why not just extend the regex

There is a clean way to tell a keyboard from a headset: the real one emits 167 keys, the pseudo-devices at most 19. But that lives in the evdev `KEY` bitmap, and `hyprctl devices` reports name, layout, keymap, index and `main` — nothing about capability. So the options are chasing every vendor's hotkey naming forever, or taking the switch out from behind that list. This does the latter.

## Notes

Verified on a Dell XPS 14, Hyprland 0.56.2 — typing follows the widget now, `;` gives `ø`.

No test suite covers `shell/` (no `package.json`, no JS runner), so this was checked by driving both the original and patched logic against live `hyprctl devices` output, and by running the built widget via `omarchy restart shell`.

Left as a draft on purpose — you may want a narrower fix, or per-device layouts handled differently than "same list moves together". Happy to rework.
