### PR TITLE
Restore application access for third-party menus

### DIFF
--- a/shell/services/PluginAppLibraryApi.qml
+++ b/shell/services/PluginAppLibraryApi.qml
@@ -7,6 +7,7 @@ QtObject {
   required property string ownerPluginId
 
   signal appsChanged()
+  signal iconIndexChanged()
 
   property var _entryName: null
   property var _entrySubtext: null

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -1053,6 +1053,10 @@ ShellRoot {
 
   Connections {
     target: shell.appLibrary
+    function onIconIndexChanged() {
+      for (var id in shell._pluginAppLibraryApis)
+        shell._pluginAppLibraryApis[id].iconIndexChanged()
+    }
     function onAppsChanged() {
       for (var id in shell._pluginAppLibraryApis)
         shell._pluginAppLibraryApis[id].appsChanged()
@@ -1316,7 +1320,9 @@ ShellRoot {
       id: panelEntry
       required property var modelData
       readonly property string pluginId: modelData.id
-      readonly property var manifest: modelData.manifest
+      // Qt model data turns nested arrays into sequences. Use the registry
+      // object so capability checks see the validated manifest's array types.
+      readonly property var manifest: shell.pluginRegistry.installedPlugins[pluginId] || null
       readonly property string entryKind: modelData.kind
       readonly property bool keepLoaded: modelData.keepLoaded === true
       readonly property string sourceUrl: shell.pluginRegistry.entryPointUrl(manifest, entryKind)

--- a/test/shell.d/fixtures/panel-menu-capability/shell.qml
+++ b/test/shell.d/fixtures/panel-menu-capability/shell.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import QtQml.Models
+import Quickshell
+import "services"
+
+ShellRoot {
+  id: shell
+
+  property var pluginRegistry: ({ installedPlugins: {
+    "example.menu": { id: "example.menu", kinds: ["menu", "bar-widget"] },
+    "example.panel": { id: "example.panel", kinds: ["panel"] }
+  } })
+  property var panelEntries: Object.keys(pluginRegistry.installedPlugins).map(function(id) {
+    return { id: id, manifest: shell.pluginRegistry.installedPlugins[id] }
+  })
+  property var failures: []
+  property int checked: 0
+  property int iconCompletions: 0
+  property int appChanges: 0
+  property QtObject appLibrary: QtObject {
+    property var iconIndex: ({})
+    signal appsChanged()
+  }
+  property var _pluginAppLibraryApis: ({ "example.menu": menuLibrary })
+
+  __APP_LIBRARY_SIGNALS__
+
+  // Filled from shell.qml by the test runner, not a copy of the implementation.
+  __MANIFEST_HAS_KIND__
+
+  PluginAppLibraryApi {
+    id: menuLibrary
+    ownerPluginId: "example.menu"
+    _sortedEntries: function(query) { return [{ entry: { id: "example-app", name: "Example App" } }] }
+  }
+
+  function pluginAppLibraryFor(cacheKey, key) { return menuLibrary }
+
+  Connections {
+    target: menuLibrary
+    function onIconIndexChanged() { shell.iconCompletions += 1 }
+    function onAppsChanged() { shell.appChanges += 1 }
+  }
+
+  Component { id: apiComponent; PluginShellApi {} }
+
+  function check(manifest, pluginId) {
+    var key = pluginId
+    var cacheKey = key
+    var api = apiComponent.createObject(null, {
+      pluginId: key,
+      appLibrary: __APP_LIBRARY_GRANT__
+    })
+    var isMenu = pluginId === "example.menu"
+    var granted = !!api && !!api.appLibrary
+    if (granted !== isMenu) failures.push(pluginId + ": wrong app-library grant")
+    if (granted && api.appLibrary.sortedEntries("")[0].entry.id !== "example-app")
+      failures.push(pluginId + ": app entries unavailable")
+    if (api) api.destroy()
+    checked += 1
+  }
+
+  Instantiator {
+    model: shell.panelEntries
+    delegate: QtObject {
+      required property var modelData
+      readonly property string pluginId: modelData.id
+      __PANEL_MANIFEST_BINDING__
+      Component.onCompleted: shell.check(manifest, pluginId)
+    }
+  }
+
+  Timer {
+    interval: 50
+    running: true
+    onTriggered: {
+      shell.appLibrary.iconIndex = ({ updated: true })
+      shell.appLibrary.appsChanged()
+      if (shell.iconCompletions !== 1) shell.failures.push("icon refresh completion was not forwarded")
+      if (shell.appChanges !== 1) shell.failures.push("app changes were not forwarded")
+      if (shell.checked !== 2) shell.failures.push("both plugin kinds must be checked")
+      if (shell.failures.length) console.error("PANEL_MENU_FAIL", JSON.stringify(shell.failures))
+      else console.log("PANEL_MENU_OK menu receives apps; ordinary panel stays restricted")
+      Qt.quit()
+    }
+  }
+}

--- a/test/shell.d/panel-menu-capability-test.sh
+++ b/test/shell.d/panel-menu-capability-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping panel menu capability runtime test"
+  exit 0
+fi
+require_command python3
+require_command timeout
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+mkdir "$tmpdir/services"
+cp "$ROOT/shell/services/PluginShellApi.qml" "$ROOT/shell/services/PluginAppLibraryApi.qml" "$tmpdir/services/"
+
+# Exercise the production binding and grant across a real Qt model boundary.
+# Node alone cannot reproduce Qt's conversion of nested arrays to sequences.
+python3 - "$ROOT" "$tmpdir/shell.qml" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+source = (root / "shell/shell.qml").read_text()
+fixture = (root / "test/shell.d/fixtures/panel-menu-capability/shell.qml").read_text()
+panel = source[source.index("id: panelEntry"):]
+replacements = {
+    "__PANEL_MANIFEST_BINDING__": re.search(r"readonly property var manifest: [^\n]+", panel).group(),
+    "__MANIFEST_HAS_KIND__": re.search(r"function manifestHasKind\([^)]*\) \{.*?\n  \}", source, re.S).group(),
+    "__APP_LIBRARY_GRANT__": re.search(r"appLibrary: (shell\.manifestHasKind\(manifest, \"menu\"\).*?),\n", source, re.S).group(1),
+    "__APP_LIBRARY_SIGNALS__": re.search(r"Connections \{\s+target: shell\.appLibrary\n.*?\n  \}", source, re.S).group(),
+}
+for marker, code in replacements.items():
+    fixture = fixture.replace(marker, code)
+Path(sys.argv[2]).write_text(fixture)
+PY
+
+# No windows or Wayland services: this test also runs with Qt's offscreen backend.
+if ! env -u WAYLAND_DISPLAY QT_QPA_PLATFORM=offscreen \
+  timeout 8 quickshell --no-color -p "$tmpdir" >"$tmpdir/log" 2>&1; then
+  fail "panel menu capability fixture runs" "$(<"$tmpdir/log")"
+fi
+if ! grep -q 'PANEL_MENU_OK' "$tmpdir/log"; then
+  fail "menu plugins retain their app library across the Qt model boundary" "$(<"$tmpdir/log")"
+fi
+pass "menu plugins retain their app library across the Qt model boundary"
+pass "ordinary panels cannot access the app library"
+pass "app and icon refresh signals reach menu plugins"


### PR DESCRIPTION
## Summary

Restore the app list for third-party menu plugins such as Omalaunch after the scoped plugin API change.

- Read panel manifests from the validated plugin registry, not the Qt model's converted copy.
- Forward `iconIndexChanged` through the app-library facade so menus can finish their icon-refresh cycle. This exposes a signal, not the private icon index.
- Add an offscreen Quickshell regression test for menu access, non-menu denial, and app/icon change signals.

## Cause

Reproduced with Omalaunch 0.3.0 and `omarchy-dev 4.0.0.r2071.ga703092-1`. The current `quattro` branch has the same affected shell code.

`computePanelEntries()` accepts the menu manifest, then passes it through an `Instantiator`. Qt converts its nested `kinds` array to a sequence: it still serializes as `["menu","bar-widget"]` and supports `indexOf("menu")`, but `Array.isArray(modelData.manifest.kinds)` returns `false`. `manifestHasKind()` then rejects the menu grant, and the injected `PluginShellApi.appLibrary` is `null`. The launcher shows an empty Apps menu even though desktop entries remain installed.

The fix keeps the existing capability checks and uses the registry's original validated object. It does not restore the full shell object or widen non-menu access.

Once the app library attaches, Omalaunch also needs its existing `iconIndexChanged` completion signal; without it, an icon refresh can stay pending indefinitely.

## Validation

Passed:

- `bash test/shell.d/panel-menu-capability-test.sh` — real Qt model conversion, actual facade components, and the production binding/grant/signal code; works without a compositor.
- `bash test/shell.d/plugin-auth-boundary-test.sh` — static checks and QML runtime fixture.
- `bash test/shell.d/plugin-registry-contract-test.sh` — QML runtime fixture.
- `bash test/shell.d/app-search-test.sh`.
- `git diff --check`.

The new test first failed on the missing menu grant, then on missing icon completion after applying only the manifest fix. It passes with both changes. Existing authentication and ordinary-panel restrictions still pass.

The patched full desktop has not been visually verified. The installed, package-owned shell was left unchanged; no development link, permission change, migration, or release is included.

## Companion fix

Omalaunch separately relies on the now-private `manifest.__sourceDir` for its helper paths. Its companion PR resolves the plugin directory from its own QML file: https://github.com/DanielLemky/omalaunch/pull/58

Both fixes are needed to restore that launcher on the affected host.
