### PR TITLE
Add Super + Ctrl + Alt + F to toggle a full screen desktop

### DIFF
--- a/bin/omarchy-toggle-fullscreen-desktop
+++ b/bin/omarchy-toggle-fullscreen-desktop
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle a full screen desktop: hide the top bar and remove the window gaps together
+# omarchy:args=[toggle|on|off]
+# omarchy:examples=omarchy toggle fullscreen desktop | omarchy toggle fullscreen desktop off | omarchy toggle fullscreen desktop on
+
+ACTION="${1:-toggle}"
+
+case $ACTION in
+  toggle|"")
+    # Only leave full screen when both halves are already in it, so a lone bar
+    # or a lone gap toggle is pulled into line rather than flipped away.
+    if omarchy-toggle-enabled bar-off && omarchy-hyprland-toggle-enabled window-no-gaps; then
+      ACTION="off"
+    else
+      ACTION="on"
+    fi
+    ;;
+  on|off) ;;
+  *)
+    echo "Usage: omarchy-toggle-fullscreen-desktop [toggle|on|off]" >&2
+    exit 1
+    ;;
+esac
+
+omarchy-toggle-bar "$ACTION"
+omarchy-hyprland-toggle window-no-gaps "$ACTION"

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -19,6 +19,7 @@ o.bind("SUPER + SHIFT + CTRL + SPACE", "Theme menu", "omarchy-menu toggle theme"
 o.bind("SUPER + BACKSPACE", "Toggle window transparency", "omarchy-hyprland-window-transparency-toggle")
 o.bind("SUPER + SHIFT + BACKSPACE", "Toggle window gaps", "omarchy-hyprland-window-gaps-toggle")
 o.bind("SUPER + CTRL + BACKSPACE", "Toggle single-window square aspect", "omarchy-hyprland-window-single-square-aspect-toggle")
+o.bind_toggle("SUPER + CTRL + ALT + F", "Toggle full screen desktop", "fullscreen-desktop")
 
 -- xkbcommon names the comma keysym "comma"; the upper-case "COMMA" does not match.
 o.bind("SUPER + comma", "Dismiss last notification", "omarchy-shell notifications dismissOne")

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -192,6 +192,7 @@ All style options are also accessible under _Style_ in the Omarchy menu (`Super 
 | `Shift + Mute` | Switch to next audio output |
 | `Shift + Play` | Switch to next media source |
 | `Super + Shift + Backspace` | Toggle window gaps |
+| `Super + Ctrl + Alt + F` | Toggle full screen desktop (top bar + window gaps) |
 
 ## Reminders
 

--- a/test/shell.d/toggle-test.sh
+++ b/test/shell.d/toggle-test.sh
@@ -51,3 +51,36 @@ pass "bar on is idempotent"
 HOME="$test_home" omarchy-toggle-bar off
 [[ ! -f $bar_flag ]] || fail "bar off disables bar-off toggle"
 pass "bar off disables bar-off toggle"
+
+# The gaps half of full screen copies a flag file in and reloads Hyprland, so
+# give it this checkout to copy from and a hyprctl that answers without a
+# compositor.
+export OMARCHY_PATH="$ROOT"
+stub_bin="$TMPDIR/bin"
+mkdir -p "$stub_bin"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/hyprctl"
+chmod +x "$stub_bin/hyprctl"
+export PATH="$stub_bin:$PATH"
+
+gaps_flag="$test_home/.local/state/omarchy/toggles/hypr/window-no-gaps.lua"
+
+HOME="$test_home" omarchy-toggle-fullscreen-desktop
+[[ -f $bar_flag && -f $gaps_flag ]] || fail "fullscreen toggle hides the bar and the gaps together"
+pass "fullscreen toggle hides the bar and the gaps together"
+
+HOME="$test_home" omarchy-toggle-fullscreen-desktop
+[[ ! -f $bar_flag && ! -f $gaps_flag ]] || fail "fullscreen toggle restores the bar and the gaps together"
+pass "fullscreen toggle restores the bar and the gaps together"
+
+HOME="$test_home" omarchy-toggle-bar on
+HOME="$test_home" omarchy-toggle-fullscreen-desktop
+[[ -f $bar_flag && -f $gaps_flag ]] || fail "fullscreen toggle pulls a half-hidden desktop into full screen"
+pass "fullscreen toggle pulls a half-hidden desktop into full screen"
+
+HOME="$test_home" omarchy-toggle-fullscreen-desktop off
+[[ ! -f $bar_flag && ! -f $gaps_flag ]] || fail "fullscreen off leaves full screen"
+pass "fullscreen off leaves full screen"
+
+HOME="$test_home" omarchy-toggle-fullscreen-desktop on
+[[ -f $bar_flag && -f $gaps_flag ]] || fail "fullscreen on enters full screen"
+pass "fullscreen on enters full screen"


### PR DESCRIPTION
Hiding the top bar and removing the window gaps are the two things you do to give the screen entirely to your windows, and doing both took two hotkeys. `Super + Ctrl + Alt + F` does them together, and `omarchy toggle fullscreen desktop` picks it up from the CLI.

`bin/omarchy-toggle-fullscreen-desktop` composes the two toggles that already exist — `omarchy-toggle-bar` (the `bar-off` flag, `Super + Shift + Space`) and `omarchy-hyprland-toggle window-no-gaps` (`Super + Shift + Backspace`) — so there's no new state to keep in sync.

The one judgment call is what a press means when the two halves disagree. It only *leaves* full screen when both are already in it, so pressing it with just the bar hidden pulls the gaps into line instead of flipping the bar back on. It takes `on`/`off` too.

The binding sits in `utilities.lua` next to the two toggles it combines, and the key was free — the F family already has `F` (full screen), `Ctrl + F` (tiled), and `Alt + F` (full width). The description says "full screen desktop" to keep it distinct from `Super + F`'s per-window "Full screen" in the keybindings list.

### Testing

Five cases in `test/shell.d/toggle-test.sh`, covering both halves moving together, the half-hidden case, and explicit `on`/`off`. The test stubs `hyprctl` and pins `OMARCHY_PATH` to the checkout so it passes with no compositor. Also toggled in and back out on a live session.

### Not included

A Toggle menu entry (`"trigger.toggle.fullscreen-desktop"`). Every other `omarchy toggle` has one, but the menu is already crowded — happy to add it if you want it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
