### PR TITLE
Start 1Password at a fixed device scale factor

### DIFF
--- a/bin/omarchy-launch-1password
+++ b/bin/omarchy-launch-1password
@@ -4,8 +4,11 @@
 
 set -e
 
+# 1Password reads the display scale itself, the way Electron apps do, and comes
+# up oversized next to every other window on a scaled monitor. The packaged
+# .desktop pins it too; this covers the hotkey, which runs the binary directly.
 if omarchy-cmd-present 1password; then
-  exec setsid uwsm-app -- 1password
+  exec setsid uwsm-app -- 1password --force-device-scale-factor=1
 else
   exec omarchy-launch-floating-terminal-with-presentation omarchy-install-service-1password
 fi

--- a/test/shell.d/launch-1password-test.sh
+++ b/test/shell.d/launch-1password-test.sh
@@ -31,8 +31,9 @@ chmod +x "$mock_bin"/*
 launch_log="$test_tmp/launch-log"
 PATH="$mock_bin:$PATH" OMARCHY_TEST_INSTALLED=true OMARCHY_TEST_LOG="$launch_log" \
   bash "$ROOT/bin/omarchy-launch-1password"
-grep -Fxq 'launch:-- 1password' "$launch_log" || fail "1Password launcher starts the installed app"
-pass "1Password launcher starts the installed app"
+grep -Fxq 'launch:-- 1password --force-device-scale-factor=1' "$launch_log" ||
+  fail "1Password launcher starts the installed app at a fixed scale factor"
+pass "1Password launcher starts the installed app at a fixed scale factor"
 
 PATH="$mock_bin:$PATH" OMARCHY_TEST_INSTALLED=false OMARCHY_TEST_LOG="$launch_log" \
   bash "$ROOT/bin/omarchy-launch-1password"


### PR DESCRIPTION
1Password reads the display scale itself, the way Electron apps do, so on a scaled monitor it comes up oversized next to every other window. Pin it with `--force-device-scale-factor=1` and let the compositor scale it.

The app menu is handled in the package instead — omacom/omarchy-pkgs#342 rewrites `Exec=` in the `.desktop` we install, which is the idiom `spotify` and `perplexity` already use there. This is the other route in: `Super + Shift + /` runs the binary through `omarchy-launch-1password` and never reads that file.

An earlier version of this PR shipped a user-level `.desktop` override here instead. Doing it in the package is better on every count, and it removes the override's problems rather than working around them: a leftover entry after `pacman -Rns 1password`, installs that skipped the omarchy installer never getting it, and — the real one — the override shadowing the packaged entry so the app launcher's Remove would delete the override and leave the package installed.

### Testing

`test/shell.d/launch-1password-test.sh` asserts the launch line carries the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB9phxP56gnP7qSidkkUJE
