### PR TITLE
Recover gracefully when default agent setup or launch fails

### DIFF
--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -23,6 +23,11 @@ if (($# == 0)); then
   exit 0
 fi
 
+previous_agent=""
+if [[ -f $agent_file ]]; then
+  read -r previous_agent <"$agent_file"
+fi
+
 case "$1" in
 pi) agent="pi"; name="Pi" ;;
 omp | oh-my-pi) agent="omp"; name="Oh My Pi"; agent_package="github:can1357/oh-my-pi" ;;
@@ -91,7 +96,21 @@ printf '%s\n' "$agent" >"$agent_file"
 
 if [[ $installing == "true" ]]; then
   printf '\033[2J\033[3J\033[H'
-  exec omarchy-agent --inline
+  trap ':' INT
+  if ! omarchy-agent --inline; then
+    trap - INT
+    if [[ -n ${previous_agent:-} ]]; then
+      printf '%s\n' "$previous_agent" >"$agent_file"
+    else
+      rm -f "$agent_file"
+    fi
+    echo "Could not launch $name" >&2
+    if gum confirm "Would you like to select a different agent?"; then
+      exec omarchy-menu summon setup.default.agent
+    fi
+    exit 1
+  fi
+  trap - INT
 else
   exec omarchy-agent
 fi

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -19,6 +19,7 @@ mise_history="$test_tmp/mise-history"
 stub_log="$test_tmp/stubs"
 terminal_log="$test_tmp/terminal"
 menu_log="$test_tmp/menu"
+gum_log="$test_tmp/gum"
 muse_login_log="$test_tmp/muse-login"
 mkdir -p "$mock_bin" "$test_home"
 
@@ -91,7 +92,13 @@ cat >"$mock_bin/omarchy-test-noop" <<'SH'
 exit 0
 SH
 
-for command in gum hyprctl omarchy-webapp-remove-all omarchy-tui-remove-all omarchy-pkg-drop; do
+cat >"$mock_bin/gum" <<'SH'
+#!/bin/bash
+printf '%s\0' "$@" >>"${OMARCHY_TEST_GUM_LOG:-/dev/null}"
+[[ ${OMARCHY_TEST_GUM_FAIL:-false} != "true" ]]
+SH
+
+for command in hyprctl omarchy-webapp-remove-all omarchy-tui-remove-all omarchy-pkg-drop; do
   ln -s omarchy-test-noop "$mock_bin/$command"
 done
 
@@ -108,6 +115,7 @@ export OMARCHY_TEST_MISE_HISTORY="$mise_history"
 export OMARCHY_TEST_STUB_LOG="$stub_log"
 export OMARCHY_TEST_AGENT_TERMINAL_LOG="$terminal_log"
 export OMARCHY_TEST_AGENT_MENU_LOG="$menu_log"
+export OMARCHY_TEST_GUM_LOG="$gum_log"
 export OMARCHY_TEST_MUSE_LOGIN_LOG="$muse_login_log"
 export OMARCHY_PATH="$ROOT"
 
@@ -357,6 +365,10 @@ pass "agent launcher has a keyboard shortcut"
 cat >"$mock_bin/omarchy-agent" <<'SH'
 #!/bin/bash
 printf '%s\0' omarchy-agent "$@" >"$OMARCHY_TEST_AGENT_OPEN_LOG"
+if [[ -n ${OMARCHY_TEST_AGENT_EXIT:-} ]]; then
+  exit "$OMARCHY_TEST_AGENT_EXIT"
+fi
+[[ ${OMARCHY_TEST_AGENT_FAIL:-false} != "true" ]]
 SH
 chmod +x "$mock_bin/omarchy-agent"
 hash -r
@@ -450,6 +462,67 @@ mapfile -d '' -t agent_open_args <"$agent_open_log"
 [[ ${#agent_open_args[@]} == 2 && ${agent_open_args[0]} == "omarchy-agent" && ${agent_open_args[1]} == "--inline" ]] ||
   fail "newly installed agent opens in the installation terminal"
 pass "missing agents install visibly and open in the same terminal"
+
+rm -f "$agent_file"
+: >"$menu_log"
+: >"$gum_log"
+if ! OMARCHY_TEST_AGENT_FAIL=true omarchy-default-agent --install codex >"$test_tmp/failed-launch-out" 2>"$test_tmp/failed-launch-err"; then
+  fail "failed agent setup exits cleanly when alternate agent is confirmed"
+fi
+[[ $(<"$test_tmp/failed-launch-out") == $'\033[2J\033[3J\033[H' ]] ||
+  fail "failed agent launch clears the terminal before attempting launch"
+[[ ! -e $agent_file ]] || fail "failed agent launch deletes unset default agent selection"
+[[ -z $(omarchy-default-agent) ]] || fail "default agent remains unset after failed launch"
+grep -Fq "Could not launch Codex" "$test_tmp/failed-launch-err" ||
+  fail "failed agent launch reports launch failure"
+mapfile -d '' -t menu_args <"$menu_log"
+[[ ${menu_args[*]} == "summon setup.default.agent" ]] ||
+  fail "failed agent launch reopens agent selection menu when confirmed"
+mapfile -d '' -t gum_args <"$gum_log"
+[[ ${gum_args[0]} == "confirm" && ${gum_args[1]} == "Would you like to select a different agent?" ]] ||
+  fail "failed agent launch confirms before reopening agent menu"
+pass "failed inline agent launch reverts unset selection and reopens menu"
+
+printf '%s\n' pi >"$agent_file"
+: >"$menu_log"
+: >"$gum_log"
+if ! OMARCHY_TEST_AGENT_FAIL=true omarchy-default-agent --install codex >/dev/null 2>"$test_tmp/failed-launch-err"; then
+  fail "failed agent setup exits cleanly when alternate agent is confirmed"
+fi
+[[ $(omarchy-default-agent) == "pi" ]] || fail "failed agent launch restores previous default agent"
+grep -Fq "Could not launch Codex" "$test_tmp/failed-launch-err" ||
+  fail "failed agent launch reports launch failure for previous agent"
+mapfile -d '' -t menu_args <"$menu_log"
+[[ ${menu_args[*]} == "summon setup.default.agent" ]] ||
+  fail "failed agent launch reopens agent menu after restoring previous agent"
+pass "failed inline agent launch restores previous default agent and reopens menu"
+
+printf '%s\n' pi >"$agent_file"
+: >"$menu_log"
+: >"$gum_log"
+if ! OMARCHY_TEST_AGENT_EXIT=130 omarchy-default-agent --install codex >/dev/null 2>"$test_tmp/failed-launch-err"; then
+  fail "signal-interrupted agent setup exits cleanly when alternate agent is confirmed"
+fi
+[[ $(omarchy-default-agent) == "pi" ]] || fail "signal-interrupted launch restores previous default agent"
+grep -Fq "Could not launch Codex" "$test_tmp/failed-launch-err" ||
+  fail "signal-interrupted launch reports launch failure"
+mapfile -d '' -t menu_args <"$menu_log"
+[[ ${menu_args[*]} == "summon setup.default.agent" ]] ||
+  fail "signal-interrupted launch reopens agent menu after restoring previous agent"
+pass "signal-interrupted inline agent launch restores previous default agent and reopens menu"
+
+printf '%s\n' copilot >"$agent_file"
+: >"$menu_log"
+: >"$gum_log"
+declined_exit=0
+OMARCHY_TEST_AGENT_FAIL=true OMARCHY_TEST_GUM_FAIL=true omarchy-default-agent --install codex >/dev/null 2>"$test_tmp/failed-launch-err" || declined_exit=$?
+(( declined_exit == 1 )) || fail "declining alternate agent exits with code 1"
+[[ $(omarchy-default-agent) == "copilot" ]] || fail "declining alternate agent preserves previous default agent"
+[[ ! -s $menu_log ]] || fail "declining alternate agent does not summon menu"
+grep -Fq "Could not launch Codex" "$test_tmp/failed-launch-err" ||
+  fail "declining alternate agent still reports launch failure"
+pass "declining alternate agent preserves selection and exits with error"
+
 
 : >"$notification_history"
 : >"$agent_open_log"
@@ -750,6 +823,7 @@ SH
 cat >"$mock_bin/omarchy-launch-openclaw" <<'SH'
 #!/bin/bash
 printf '%s\0' omarchy-launch-openclaw "$@" >"$OMARCHY_TEST_AGENT_INLINE_LOG"
+[[ ${OMARCHY_TEST_OPENCLAW_LAUNCH_FAIL:-false} != "true" ]]
 SH
 cat >"$mock_bin/openclaw" <<'SH'
 #!/bin/bash
@@ -787,6 +861,22 @@ mapfile -d '' -t inline_args <"$inline_log"
 [[ ${inline_args[*]} == "omarchy-launch-openclaw --tui" ]] ||
   fail "installing OpenClaw as default agent hands over to its terminal UI"
 pass "installing OpenClaw as default agent adds its package"
+
+printf '%s\n' "pi" >"$agent_file"
+: >"$menu_log"
+: >"$gum_log"
+if ! OMARCHY_TEST_OPENCLAW_INSTALLED=false OMARCHY_TEST_OPENCLAW_LAUNCH_FAIL=true \
+  omarchy-default-agent --install openclaw >/dev/null 2>"$test_tmp/openclaw-failed-err"; then
+  fail "failed OpenClaw launch exits cleanly when alternate agent is confirmed"
+fi
+[[ $(omarchy-default-agent) == "pi" ]] || fail "failed OpenClaw launch restores previous default agent"
+grep -Fq "Could not launch OpenClaw" "$test_tmp/openclaw-failed-err" ||
+  fail "failed OpenClaw launch reports launch failure"
+mapfile -d '' -t menu_args <"$menu_log"
+[[ ${menu_args[*]} == "summon setup.default.agent" ]] ||
+  fail "failed OpenClaw launch reopens agent menu after restoring previous agent"
+printf '%s\n' "openclaw" >"$agent_file"
+pass "failed OpenClaw launch restores previous default agent and reopens menu"
 
 : >"$launch_log"
 omarchy agent prompt "Review this project"


### PR DESCRIPTION
### Summary

When setting up or switching coding agents via `omarchy-default-agent --install <agent>` (or selecting an uninstalled agent in the Omarchy menu), the script writes the selection to `~/.config/omarchy/defaults/agent` and executes `omarchy-agent --inline` inside a floating terminal for the initial onboarding session.

If the agent's authentication or startup fails (e.g. an expired token, missing credentials, deprecated OAuth endpoints, or a user aborting setup with Ctrl+C), the broken agent previously remained permanently set as the default, and the terminal would abruptly close with no graceful recourse.

### Solution

1. **State Preservation**: Capture `previous_agent` from `~/.config/omarchy/defaults/agent` before updating the selection.
2. **Failure Recovery**: Trap INT during inline execution and check the exit code of `omarchy-agent --inline`. If it fails:
   - Revert `defaults/agent` to `previous_agent` (or remove the file if no default was previously configured).
   - Print `Could not launch <Agent>` to stderr.
   - Prompt the user with `gum confirm "Would you like to select a different agent?"`.
   - If confirmed, summon the agent picker (`exec omarchy-menu summon setup.default.agent`).
   - If declined, exit with status 1 with the clean reverted state preserved.
3. **Unit Tests**:
   - Added assertions to `test/shell.d/default-agent-test.sh` covering:
     - Unset state reversion and menu reopening on confirmation.
     - Previous state restoration (`pi`) on confirmation.
     - User cancellation / SIGINT (Ctrl+C / exit code 130) state recovery.
     - Non-zero exit code (`1`) when alternate selection is declined.
     - Terminal clear-screen sequence (`\033[2J\033[3J\033[H`) verification before launch attempt.
     - Native package-managed agent failure recovery (`OpenClaw`).
   - Verified that all 50 unit tests in `test/shell.d/default-agent-test.sh` and 108 tests in `./test/cli` pass.