### PR TITLE
Continue the background wipe across every output

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -161,7 +161,11 @@ Rules:
    First-party non-bar plugins are enabled unless listed in `disabledPlugins[]`.
 6. `barWidget.allowMultiple: true` in the manifest permits multiple instances.
 7. `idle.screensaver` and `idle.lock` are seconds since user idle began.
-8. `version: 1` is required.
+8. `background.transition` is `layout` (one wipe front across every
+   output, the default) or `output` (a wipe per output, each from its own
+   centre); `background.transitionDuration` pins the reveal in
+   milliseconds, and is derived from the output layout when unset.
+9. `version: 1` is required.
 
 `config/omarchy/shell.json` describes the fresh-install state. When no
 user `shell.json` exists, defaults are used verbatim. Once the user

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -304,7 +304,7 @@ Item {
         layer.smooth: true
         layer.effect: MultiEffect {
           maskEnabled: true
-          maskSource: revealMask
+          maskSource: revealMaskSource
           maskThresholdMin: 0.5
           maskSpreadAtMin: 0.02
         }
@@ -322,11 +322,25 @@ Item {
         }
       }
 
+      // The mask has to stay in the render tree for the wipe to animate. An
+      // item kept out of it with visible: false can change its geometry
+      // without dirtying the window, so an output whose scene is otherwise
+      // static never schedules a frame: it held the old wallpaper for the
+      // whole transition and jumped when the reveal ended. hideSource keeps
+      // the mask off the screen while leaving it live, and the effect samples
+      // it from here instead of from the item's own layer.
+      ShaderEffectSource {
+        id: revealMaskSource
+        anchors.fill: parent
+        sourceItem: revealMask
+        live: true
+        hideSource: true
+        visible: false
+      }
+
       Item {
         id: revealMask
         anchors.fill: parent
-        visible: false
-        layer.enabled: true
 
         readonly property real slant: -0.18
         readonly property real centerTop: width / 2 - slant * height / 2

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -30,6 +30,18 @@ Item {
 
   readonly property real slant: -0.18
 
+  readonly property var backgroundConfig: shell && shell.shellConfig && shell.shellConfig.background
+    ? shell.shellConfig.background : ({})
+
+  // "layout" carries one front across every output; "output" restores a wipe
+  // per output, each opening at its own centre. Anything unset means "layout".
+  readonly property bool wipeAcrossLayout: String(backgroundConfig.transition || "layout") !== "output"
+
+  // A positive transitionDuration pins the reveal; anything else derives it.
+  readonly property int configuredDuration: Number(backgroundConfig.transitionDuration) > 0
+    ? Math.round(Number(backgroundConfig.transitionDuration))
+    : 0
+
   // The wipe is one front travelling across the whole output layout rather
   // than an independent wipe per output. It starts at the centre of the output
   // the change was made on and continues onto the others according to where
@@ -55,9 +67,11 @@ Item {
   readonly property real globalReach: reachOver(Quickshell.screens, originX, originY)
   readonly property real originReach: reachOver(
     originScreen ? [originScreen] : Quickshell.screens, originX, originY)
-  readonly property int revealDuration: originReach > 0
-    ? Math.min(900, Math.round(420 * (globalReach / originReach)))
-    : 420
+  readonly property int revealDuration: {
+    if (configuredDuration > 0) return configuredDuration
+    if (!wipeAcrossLayout || originReach <= 0) return 420
+    return Math.min(900, Math.round(420 * (globalReach / originReach)))
+  }
 
   function screenByName(name) {
     if (!name) return null
@@ -426,9 +440,15 @@ Item {
         readonly property real slant: root.slant
         readonly property real dx: root.originX - (panel.screen ? panel.screen.x : 0)
         readonly property real originDy: (panel.screen ? panel.screen.y : 0) - root.originY
-        readonly property real centerTop: dx + slant * originDy
-        readonly property real centerBottom: dx + slant * (originDy + height)
-        readonly property real spread: root.globalReach * root.revealProgress
+        readonly property real localReach: width / 2 + Math.abs(slant) * height / 2 + 4
+        readonly property real centerTop: root.wipeAcrossLayout
+          ? dx + slant * originDy
+          : width / 2 - slant * height / 2
+        readonly property real centerBottom: root.wipeAcrossLayout
+          ? dx + slant * (originDy + height)
+          : width / 2 + slant * height / 2
+        readonly property real spread: (root.wipeAcrossLayout ? root.globalReach : localReach)
+          * root.revealProgress
 
         Shape {
           anchors.fill: parent

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -244,11 +244,19 @@ Item {
 
       property bool maskReady: false
 
+      // Every output that has decoded the incoming image joins the wipe, even
+      // one that gets there after the animation has started. Each output
+      // decodes its own copy, so requiring revealProgress to still be 0 let
+      // whichever output decoded first claim the reveal and locked the rest
+      // out of it: they kept the old wallpaper and jumped to the new one when
+      // the transition ended. startReveal still restarts the animation only
+      // once per backgroundVersion, so a late output picks up the front where
+      // it already is.
       function maybeStartReveal() {
-        if (!root.incomingBackground || root.revealProgress !== 0 || maskReady) return
+        if (!root.incomingBackground || maskReady) return
         if (incomingFrame.status !== Image.Ready) return
         Qt.callLater(function() {
-          if (!root.incomingBackground || root.revealProgress !== 0 || maskReady) return
+          if (!root.incomingBackground || maskReady) return
           if (incomingFrame.status !== Image.Ready) return
           root.startReveal(panel)
         })

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -28,6 +28,81 @@ Item {
   property string pendingShellRaw: ""
   property real revealProgress: 1
 
+  readonly property real slant: -0.18
+
+  // The wipe is one front travelling across the whole output layout rather
+  // than an independent wipe per output. It starts at the centre of the output
+  // the change was made on and continues onto the others according to where
+  // Hyprland places them, so a layout with a vertical offset or a gap between
+  // outputs is followed rather than ignored. originScreenName is snapshotted
+  // when a transition begins, so moving focus mid-wipe cannot drag the origin
+  // along with it.
+  property string originScreenName: ""
+
+  readonly property var originScreen: screenByName(originScreenName)
+  readonly property real originX: originScreen
+    ? originScreen.x + originScreen.width / 2
+    : layoutCenter(true)
+  readonly property real originY: originScreen
+    ? originScreen.y + originScreen.height / 2
+    : layoutCenter(false)
+
+  // How far the front must travel to clear every output, and how far it would
+  // have travelled to clear the origin output alone. Scaling the duration by
+  // the ratio keeps the edge moving at the speed it has on a single screen
+  // instead of racing across the whole layout in the same 420ms; the cap stops
+  // a wide layout from turning the wipe into a crawl.
+  readonly property real globalReach: reachOver(Quickshell.screens, originX, originY)
+  readonly property real originReach: reachOver(
+    originScreen ? [originScreen] : Quickshell.screens, originX, originY)
+  readonly property int revealDuration: originReach > 0
+    ? Math.min(900, Math.round(420 * (globalReach / originReach)))
+    : 420
+
+  function screenByName(name) {
+    if (!name) return null
+    var list = Quickshell.screens
+    for (var i = 0; i < list.length; i++) {
+      if (String(list[i].name || "") === name) return list[i]
+    }
+    return null
+  }
+
+  function layoutCenter(horizontal) {
+    var list = Quickshell.screens
+    if (!list.length) return 0
+    var low = horizontal ? list[0].x : list[0].y
+    var high = low + (horizontal ? list[0].width : list[0].height)
+    for (var i = 1; i < list.length; i++) {
+      var start = horizontal ? list[i].x : list[i].y
+      low = Math.min(low, start)
+      high = Math.max(high, start + (horizontal ? list[i].width : list[i].height))
+    }
+    return (low + high) / 2
+  }
+
+  // Largest horizontal distance from the slanted front line to any corner of
+  // the given outputs: how far spread has to grow to cover all of them.
+  function reachOver(screens, ox, oy) {
+    var furthest = 0
+    for (var i = 0; i < screens.length; i++) {
+      var s = screens[i]
+      var xs = [s.x, s.x + s.width]
+      var ys = [s.y, s.y + s.height]
+      for (var a = 0; a < 2; a++) {
+        for (var b = 0; b < 2; b++) {
+          furthest = Math.max(furthest, Math.abs(xs[a] - (ox + slant * (ys[b] - oy))))
+        }
+      }
+    }
+    return furthest + 4
+  }
+
+  function focusedScreenName() {
+    var monitor = Hyprland.focusedMonitor
+    return monitor ? String(monitor.name || "") : ""
+  }
+
   // Injected by the first-party service loader; used to reach the lock and idle
   // services so playback can stop whenever nothing can see the wallpaper.
   property var shell: null
@@ -69,6 +144,7 @@ Item {
     currentBackground = finalPath
     backgroundVersion += 1
     revealStartedVersion = -1
+    originScreenName = focusedScreenName()
 
     revealAnimation.stop()
     finishingTransition = false
@@ -193,7 +269,7 @@ Item {
     property: "revealProgress"
     from: 0
     to: 1
-    duration: 420
+    duration: root.revealDuration
     easing.type: Easing.InOutCubic
     onFinished: {
       if (root.incomingBackground) {
@@ -342,11 +418,17 @@ Item {
         id: revealMask
         anchors.fill: parent
 
-        readonly property real slant: -0.18
-        readonly property real centerTop: width / 2 - slant * height / 2
-        readonly property real centerBottom: width / 2 + slant * height / 2
-        readonly property real reach: width / 2 + Math.abs(slant) * height / 2 + 4
-        readonly property real spread: reach * root.revealProgress
+        // Local coordinates of the global front. The front at global y sits at
+        // originX + slant * (y - originY); dx and originDy carry this panel's
+        // offset within the layout, so an output away from the origin sees only
+        // the leading edge sweep in, at the y offset its position implies. For
+        // the origin output this reduces to the single-screen centre-out wipe.
+        readonly property real slant: root.slant
+        readonly property real dx: root.originX - (panel.screen ? panel.screen.x : 0)
+        readonly property real originDy: (panel.screen ? panel.screen.y : 0) - root.originY
+        readonly property real centerTop: dx + slant * originDy
+        readonly property real centerBottom: dx + slant * (originDy + height)
+        readonly property real spread: root.globalReach * root.revealProgress
 
         Shape {
           anchors.fill: parent


### PR DESCRIPTION
> Stacked on #10660. The first two commits here are that PR; the change in
> this one is the last two. Once #10660 lands this diff reduces to those.
> Draft until then.

The wipe is the thing that made me stop and look the first time I changed a
theme on Omarchy. It isn't a crossfade and it isn't a swap — it's a tilted
front that opens out of the middle of the screen and pushes the old
wallpaper off both edges. It reads as one deliberate gesture, and it makes
changing a theme feel like an event rather than a settings change.

On a single screen it is perfect. On two, the illusion breaks: each output
opens its own front at its own centre, so instead of one gesture you get
two unrelated ones firing simultaneously, and the effect collapses back
into "the wallpaper changed."

This makes the layout the stage instead of the individual output. The front
starts at the centre of the output you were working on when you changed the
wallpaper or theme, and keeps going onto the others — arriving from
whichever edge faces the output you started on, at the vertical offset your
layout implies. What was two competing animations becomes one front
crossing the desk, which is what the effect was always reaching for. It's a
small change to what the mask is measured against and the whole thing
scales up to however many screens you own.

Three things worth calling out about how it behaves:

**It starts where you are.** The origin is the output Hyprland has focused
when the change is made, snapshotted at the start of the transition so
moving focus mid-wipe can't drag it. Change your theme on the laptop and
the front opens there and travels out to the external; do it on the
external and it goes the other way. The wipe begins where your attention
already is, which is the whole reason it works on one screen.

**It honours your physical layout.** All of it is done in Hyprland's own
layout coordinates, so a stacked, offset, mismatched-height or
mismatched-resolution arrangement is followed rather than approximated —
including a gap, where the front spends a moment crossing the space
between two outputs, exactly as it would if the desk were one surface. The
flip side is the obvious one: it is only as right as your layout is. If
your outputs are not arranged in `monitors.lua` the way they physically
sit on your desk, the front will cross them in the order the compositor
believes in, not the order you see. That is arguably a feature — it gives
you an immediate, visible reason to fix your layout.

**It preserves the original on the output it starts from.** The mask
geometry reduces algebraically to the existing single-screen formula for
the origin output, so nothing about the effect you already know changes on
the screen you triggered it from. The other outputs are the continuation
that was previously missing. Single-monitor setups are unaffected.

### Configuration

Both the behaviour and the timing are configurable, read the same way the
idle service reads its own keys:

| key | values | default |
|---|---|---|
| `background.transition` | `layout`, `output` | `layout` |
| `background.transitionDuration` | milliseconds | derived from the layout |

`output` restores the previous per-output wipe, and reproduces its geometry
exactly rather than approximating it. Unset or unrecognised values fall
back to the defaults.

I'd argue for the defaults as they stand. `layout` is the point of the
change, and the per-output behaviour is the thing this fixes rather than a
taste people are likely to hold. The derived duration matters more:
covering a much longer path in the original 420ms makes the front move
several times faster than it does today, which on my layout turned the
wipe into something closer to a flicker. So the duration scales with how
much further the front actually has to travel, keeping the edge at roughly
the speed it has on one screen.

That scaling is capped at 900ms, and the cap is the one number here I hold
loosely. Constant edge velocity on my two outputs wants about 1180ms,
which felt long enough to notice as waiting; 900ms keeps it a gesture. On
a three- or four-output wall the cap will bind harder and the front will
move faster than it does on one screen — a deliberate trade against a
transition that overstays. Happy to change either number, or drop the cap
and let velocity stay constant, if you'd rather.

### Verification

The geometry is checked against three invariants, over eight layouts
(aligned, offset, gapped, stacked, secondary-on-the-left, negative
coordinates, three outputs with mixed offsets, and a portrait secondary),
for every choice of origin in each:

1. the front is continuous across outputs — a panel's local front plus its
   `screen.x` equals the global front at that y, exactly
2. at `revealProgress == 1` the mask covers every output completely,
   densely sampled down each output's height rather than only at corners
3. the origin output reduces exactly to the untouched single-screen formula

All hold. I also compared the numbers the running shell computes against an
independent implementation of the same formulas, for both origin choices on
my hardware — `originX/originY`, per-output `dx`, `originDy`, `centerTop`,
`centerBottom`, `reach` and `duration` all match to floating point.

Configuration was exercised end to end through `shell.json`: default,
`transition=output`, a pinned duration, both together, and deliberately
invalid values. `transition=output` reproduces the original geometry
exactly (`centerTop 1335.0`, `centerBottom 1065.0`, `reach 1339` on my
internal panel, which is what the pre-change expression gives).

Two limits on that, stated plainly. My machine runs 4.0.2, whose shell
predates `Ui/BackgroundMedia.qml`, so `quattro`'s `Background.qml` will not
load here — I verified against the 4.0.2 copy with the same edits applied,
as in #10660. And `hyprmoncfgd` owns my display layout and reapplies it
over `monitors.lua`, so I could not rearrange my outputs to test the
alignments on real hardware; the eight layouts above are verified at the
formula level, and only one real two-output arrangement (side by side,
748px vertical offset, different heights and resolutions) was exercised
live, in both origin directions.

`./test/all` fails the same 5 of 234 files as `quattro` does on this
machine with the patch reverted, and no others: `config-test.sh`,
`snapper-test.sh` and `unowned-system-paths-test.sh` want an `omarchy-pkgs`
checkout I don't have, `locate-test.sh` dies in a `UnicodeDecodeError` in
its own helper, and `runtime-smoke-test.sh` trips #9975's per-screen
IpcHandler assertion. `config-test.sh` output is byte-identical to the
base-commit run, so the new `background.*` keys don't disturb it.

Setup: Hyprland, eDP-1 at 0,748 (2400x1500 logical) and DP-12 at 2400,0
(2400x1350 logical), both at scale 1.6.
