### PR TITLE
Let reminders elapse during suspend

### DIFF
--- a/bin/omarchy-reminder
+++ b/bin/omarchy-reminder
@@ -181,6 +181,7 @@ fi
 
 set_at=$(date +%s)
 remind_at=$(date -d "+${minutes} minutes" +%H:%M)
+deadline=$(date -u -d "+${minutes} minutes" '+%Y-%m-%d %H:%M:%S UTC')
 unit="omarchy-reminder-${minutes}m-$set_at"
 reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
 message_file="$reminder_dir/$unit.message"
@@ -194,7 +195,7 @@ if [[ -n $custom_message ]]; then
   confirmation_title="$custom_message in ${minutes} minutes"
 fi
 
-systemd-run --user --quiet --collect --on-active="${minutes}m" --unit="$unit" \
+systemd-run --user --quiet --collect --on-calendar="$deadline" --unit="$unit" \
   bash -c 'omarchy-notification-send -g 󰢌 "Reminder" "$1"; rm -f "$2"; omarchy-shell -q omarchy.indicators refresh >/dev/null 2>&1 || true' bash "$message" "$message_file"
 
 refresh_indicator

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -182,7 +182,7 @@ Everything goes through the same sender contract, so the pieces are small:
 
 Reminders ride on notifications rather than being their own daemon.
 `bin/omarchy-reminder <minutes> [message]` creates a transient systemd user
-timer via `systemd-run --user --collect --on-active=<minutes>m` under the
+timer via `systemd-run --user --collect --on-calendar=<absolute UTC deadline>` under the
 unit name `omarchy-reminder-<minutes>m-<epoch>`; the timer's payload sends the
 reminder toast, deletes its message file, and refreshes the bar indicator.
 Custom messages are stashed in `$XDG_RUNTIME_DIR/omarchy-reminders/<unit>.message`

--- a/test/shell.d/reminders-test.sh
+++ b/test/shell.d/reminders-test.sh
@@ -32,3 +32,53 @@ assertDeepEqual(
   'reminders command args are empty for invalid minutes'
 )
 JS
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+mkdir -p "$test_dir/bin" "$test_dir/runtime"
+
+cat >"$test_dir/bin/date" <<'EOF'
+#!/bin/bash
+case "$*" in
+"+%s") echo 1788804000 ;;
+"-d +7 minutes +%H:%M") echo 11:07 ;;
+"-u -d +7 minutes +%Y-%m-%d %H:%M:%S UTC") echo "2026-09-07 18:07:00 UTC" ;;
+*) exit 1 ;;
+esac
+EOF
+
+cat >"$test_dir/bin/systemd-run" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$@" >"$TEST_LOG"
+EOF
+
+for command in omarchy-notification-send omarchy-shell; do
+  cat >"$test_dir/bin/$command" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  chmod +x "$test_dir/bin/$command"
+done
+chmod +x "$test_dir/bin/date" "$test_dir/bin/systemd-run"
+
+TEST_LOG="$test_dir/systemd-run.log" \
+  XDG_RUNTIME_DIR="$test_dir/runtime" \
+  PATH="$test_dir/bin:$PATH" \
+  bash "$ROOT/bin/omarchy-reminder" 7 "Tea ready"
+
+grep -Fxq -- '--on-calendar=2026-09-07 18:07:00 UTC' "$test_dir/systemd-run.log" ||
+  fail "reminder deadline uses wall-clock time" "systemd-run did not receive the absolute reminder deadline"
+pass "reminder deadline uses wall-clock time"
+
+if grep -q '^--on-active=' "$test_dir/systemd-run.log"; then
+  fail "reminder avoids an active-time delay" "$(<"$test_dir/systemd-run.log")"
+fi
+pass "reminder avoids an active-time delay"
+
+grep -Fxq -- '--unit=omarchy-reminder-7m-1788804000' "$test_dir/systemd-run.log" ||
+  fail "reminder keeps its unit naming" "$(<"$test_dir/systemd-run.log")"
+pass "reminder keeps its unit naming"
+
+[[ $(<"$test_dir/runtime/omarchy-reminders/omarchy-reminder-7m-1788804000.message") == "Tea ready" ]] ||
+  fail "reminder keeps its custom message file"
+pass "reminder keeps its custom message file"


### PR DESCRIPTION
Fixes #10649

Reminders were scheduled with an active-time delay, so their countdown stopped while the machine was suspended. A 10-minute reminder could therefore arrive much later than expected after the laptop resumed.

This schedules the transient user timer against an absolute UTC deadline instead. The timer does not wake the machine, but an elapsed deadline is handled when the user manager resumes.

Tests:
- `bash test/shell.d/reminders-test.sh`
- Bash syntax and `git diff --check`
- Regression test fails with the old `--on-active` behavior
- `./test/all`: CLI passed; shell passed 234/235 files. The remaining `config-test.sh` package-manifest failure also occurs on an unmodified `quattro` checkout.
