### PR TITLE
Stop the crash watcher from reporting its own probe

### DIFF
--- a/bin/omarchy-crash-watch
+++ b/bin/omarchy-crash-watch
@@ -52,16 +52,21 @@ journalctl -f -n 0 -o json "MESSAGE_ID=$COREDUMP_MESSAGE_ID" 2>/dev/null |
     # IFS whitespace, so an empty field collapses into the next delimiter and
     # every field after it shifts along one. A process can set its own comm to
     # nothing, and that crash used to be read as somebody else's and dropped.
-    IFS=$'\t' read -r uid comm pid exe signal < <(
+    IFS=$'\t' read -r uid comm pid exe signal user_unit < <(
       jq -r 'def field: if . == null or . == "" then "-" else . end;
              [(._UID | field),
               (.COREDUMP_COMM | field),
               (.COREDUMP_PID | field),
               (.COREDUMP_EXE | field),
-              (.COREDUMP_SIGNAL_NAME | field)] | @tsv' <<<"$entry" 2>/dev/null
+              (.COREDUMP_SIGNAL_NAME | field),
+              (.COREDUMP_USER_UNIT | field)] | @tsv' <<<"$entry" 2>/dev/null
     )
 
     [[ $pid =~ ^[0-9]+$ ]] || continue
+
+    # The health probe runs inside this service but crashes as quickshell, so
+    # its service provenance is the only reliable self-exclusion signal.
+    [[ $user_unit == omarchy-crash-watch.service ]] && continue
 
     # The toast only offers a diagnosis, so it has nothing to offer until an
     # agent is chosen. Checked per crash, not at startup, so picking one takes

--- a/test/shell.d/crash-capture-test.sh
+++ b/test/shell.d/crash-capture-test.sh
@@ -96,11 +96,12 @@ reset_entries() {
 # One core dump as systemd-coredump journals it. The UID must be this user's, or
 # the watcher discards it as somebody else's crash before anything under test.
 crash_entry() {
-  local comm="$1" exe="$2"
+  local comm="$1" exe="$2" user_unit="${3:-}"
 
-  jq -cn --arg uid "$UID" --arg comm "$comm" --arg exe "$exe" \
+  jq -cn --arg uid "$UID" --arg comm "$comm" --arg exe "$exe" --arg user_unit "$user_unit" \
     '{_UID: $uid, COREDUMP_COMM: $comm, COREDUMP_PID: "4242",
-      COREDUMP_EXE: $exe, COREDUMP_SIGNAL_NAME: "SIGSEGV"}' >>"$JOURNAL_ENTRIES"
+      COREDUMP_EXE: $exe, COREDUMP_SIGNAL_NAME: "SIGSEGV",
+      COREDUMP_USER_UNIT: $user_unit}' >>"$JOURNAL_ENTRIES"
 }
 
 # The stubbed journalctl ends after the entries, so the watcher's loop ends too.
@@ -140,6 +141,15 @@ run_watch
 announced hyprland ||
   fail "a crash nobody muted still announces itself"
 pass "a crash nobody muted still announces itself"
+
+# The watcher's shell-health probe is launched inside its own user service but
+# crashes as quickshell, so name-based self-exclusion cannot recognize it.
+reset_entries
+crash_entry quickshell /usr/bin/quickshell omarchy-crash-watch.service
+run_watch
+! announced quickshell ||
+  fail "the crash watcher announces a coredump caused by its own service and sustains the loop"
+pass "a crash caused by the watcher service is not announced"
 
 mute hyprland on
 run_watch


### PR DESCRIPTION
Fixes #10662

The watcher excluded its own crashes by executable name. Its notification health probe runs inside `omarchy-crash-watch.service` but can crash as `quickshell`, so the event bypassed that guard and re-entered the same notification path.

This reads `COREDUMP_USER_UNIT` from the existing journal record and drops events attributed to the watcher’s own service before starting notification work. A normal `quickshell` crash outside that unit is still reported.

Tests:
- `bash test/shell.d/crash-capture-test.sh`
- Bash syntax and `git diff --check`
- Regression test fails when the provenance check is removed
- `./test/all`: CLI passed; shell passed 234/235 files. The remaining `config-test.sh` package-manifest failure also occurs on an unmodified `quattro` checkout.

#7155 changes the watcher’s transport but retains name-based self-exclusion, so it does not cover this failure mode. If it lands first, this provenance guard will need to be carried into that implementation.
