### PR TITLE
Harden omarchy-tui-install against desktop-entry injection

### DIFF
--- a/bin/omarchy-tui-install
+++ b/bin/omarchy-tui-install
@@ -13,6 +13,18 @@ safe_icon_name() {
     | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//'
 }
 
+require_plain_name() {
+  # The name becomes a filename. A slash would turn it into directory levels, so
+  # the launcher lands somewhere omarchy-tui-remove cannot address and the app
+  # is stuck in the launcher; a leading ../ leaves the applications directory
+  # altogether. Refuse rather than silently renaming what the user typed -- most
+  # often it is a URL entered in the name field.
+  if [[ $1 == */* ]]; then
+    echo "App name cannot contain '/': $1"
+    exit 1
+  fi
+}
+
 icon_name_from_ref() {
   local ref="$1"
   local name
@@ -37,9 +49,36 @@ install_user_icon() {
   printf '%s\n' "$name"
 }
 
+download_icon() {
+  curl -fsSL --max-time 10 -o "$2" "$1" 2>/dev/null &&
+    [[ -s $2 && $(file -b --mime-type "$2") == image/* ]]
+}
+
+desktop_string_escape() {
+  # Desktop Entry "string" value (freedesktop Desktop Entry Spec, "Value types"):
+  # a raw newline would start a new key line and let a value inject a second
+  # Exec=. Escape backslash first, then tab/CR/LF and a leading space. Every value
+  # written into the .desktop file passes through here.
+  #
+  # Parameter expansion rather than sed: GNU sed's N auto-prints the pattern space
+  # and exits at end of input, so a `:a;N;$!ba` slurp skips every following s///
+  # for a value with no newline in it - which is every value except the injection
+  # attempt this exists to stop.
+  local value="$1"
+
+  value=${value//\\/\\\\}
+  value=${value//$'\t'/\\t}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\n'/\\n}
+  [[ $value == " "* ]] && value="\\s${value# }"
+
+  printf '%s' "$value"
+}
+
 if (( $# != 4 )); then
   echo -e "\e[32mLet's create a TUI shortcut you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My TUI")
+  require_plain_name "$APP_NAME"
   APP_EXEC=$(gum input --prompt "Launch Command> " --placeholder "lazydocker or bash -c 'dust; read -n 1 -s'")
   WINDOW_STYLE=$(gum choose --header "Window style" float tile)
   ICON_REF=$(gum input --prompt "Icon URL/name> " --placeholder "See https://dashboardicons.com or enter an installed icon name")
@@ -55,13 +94,16 @@ if [[ -z $APP_NAME || -z $APP_EXEC || -z $ICON_REF ]]; then
   exit 1
 fi
 
-DESKTOP_FILE="$HOME/.local/share/applications/$APP_NAME.desktop"
-mkdir -p "$(dirname "$DESKTOP_FILE")"
+require_plain_name "$APP_NAME"
+
+DESKTOP_DIR="$HOME/.local/share/applications"
+DESKTOP_FILE="$DESKTOP_DIR/$APP_NAME.desktop"
+mkdir -p "$DESKTOP_DIR"
 
 if [[ $ICON_REF =~ ^https?:// ]]; then
   ICON_VALUE=$(safe_icon_name "$APP_NAME")
   mkdir -p "$ICON_DIR"
-  if ! curl -sL -o "$ICON_DIR/$ICON_VALUE.png" "$ICON_REF"; then
+  if ! download_icon "$ICON_REF" "$ICON_DIR/$ICON_VALUE.png"; then
     echo "Error: Failed to download icon."
     exit 1
   fi
@@ -79,15 +121,21 @@ else
   APP_CLASS="TUI.tile"
 fi
 
+EXEC_COMMAND="xdg-terminal-exec --app-id=$APP_CLASS -e $APP_EXEC"
+
+name_field=$(desktop_string_escape "$APP_NAME")
+exec_field=$(desktop_string_escape "$EXEC_COMMAND")
+icon_field=$(desktop_string_escape "$ICON_VALUE")
+
 cat >"$DESKTOP_FILE" <<EOF
 [Desktop Entry]
 Version=1.0
-Name=$APP_NAME
-Comment=$APP_NAME
-Exec=xdg-terminal-exec --app-id=$APP_CLASS -e $APP_EXEC
+Name=$name_field
+Comment=$name_field
+Exec=$exec_field
 Terminal=false
 Type=Application
-Icon=$ICON_VALUE
+Icon=$icon_field
 StartupNotify=true
 EOF
 

--- a/bin/omarchy-tui-install
+++ b/bin/omarchy-tui-install
@@ -13,6 +13,10 @@ safe_icon_name() {
     | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//'
 }
 
+owned_icon_slug() {
+  safe_icon_name "$1" | tr '\n' '-' | sed 's/-\+/-/g; s/^-//; s/-$//'
+}
+
 require_plain_name() {
   # The name becomes a filename. A slash would turn it into directory levels, so
   # the launcher lands somewhere omarchy-tui-remove cannot address and the app
@@ -100,20 +104,21 @@ DESKTOP_DIR="$HOME/.local/share/applications"
 DESKTOP_FILE="$DESKTOP_DIR/$APP_NAME.desktop"
 mkdir -p "$DESKTOP_DIR"
 
+icon_slug=$(owned_icon_slug "$APP_NAME")
 owned_icon=""
 if [[ $ICON_REF =~ ^https?:// ]]; then
-  ICON_VALUE=$(safe_icon_name "$APP_NAME")
+  ICON_VALUE=$icon_slug
   mkdir -p "$ICON_DIR"
-  if ! download_icon "$ICON_REF" "$ICON_DIR/$ICON_VALUE.png"; then
+  if ! download_icon "$ICON_REF" "$ICON_DIR/$icon_slug.png"; then
     echo "Error: Failed to download icon."
     exit 1
   fi
   gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
-  owned_icon="$ICON_VALUE.png"
+  owned_icon="$icon_slug.png"
 elif [[ -f $ICON_REF ]]; then
-  icon_slug=$(safe_icon_name "$APP_NAME")
   icon_ext="${ICON_REF##*.}"
   [[ $icon_ext == "$ICON_REF" ]] && icon_ext="png"
+  [[ $icon_ext =~ ^[[:alnum:]]+$ ]] || icon_ext="png"
   ICON_VALUE=$(install_user_icon "$ICON_REF" "$icon_slug")
   owned_icon="$icon_slug.$icon_ext"
 else
@@ -145,9 +150,7 @@ Icon=$icon_field
 StartupNotify=true
 EOF
 
-if [[ -n $owned_icon ]]; then
-  printf 'X-Omarchy-OwnedIcon=%s\n' "$owned_icon" >>"$DESKTOP_FILE"
-fi
+printf 'X-Omarchy-OwnedIcon=%s\n' "$(desktop_string_escape "$owned_icon")" >>"$DESKTOP_FILE"
 
 chmod +x "$DESKTOP_FILE"
 

--- a/bin/omarchy-tui-install
+++ b/bin/omarchy-tui-install
@@ -47,10 +47,11 @@ install_user_icon() {
   local ext="${source##*.}"
 
   [[ $ext == "$source" ]] && ext="png"
+  [[ $ext =~ ^[[:alnum:]]+$ ]] || ext="png"
   mkdir -p "$ICON_DIR"
   cp "$source" "$ICON_DIR/$name.$ext"
   gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
-  printf '%s\n' "$name"
+  printf '%s\n' "$name.$ext"
 }
 
 download_icon() {
@@ -105,6 +106,7 @@ DESKTOP_FILE="$DESKTOP_DIR/$APP_NAME.desktop"
 mkdir -p "$DESKTOP_DIR"
 
 icon_slug=$(owned_icon_slug "$APP_NAME")
+[[ -n $icon_slug ]] || icon_slug="tui"
 owned_icon=""
 if [[ $ICON_REF =~ ^https?:// ]]; then
   ICON_VALUE=$icon_slug
@@ -116,11 +118,8 @@ if [[ $ICON_REF =~ ^https?:// ]]; then
   gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
   owned_icon="$icon_slug.png"
 elif [[ -f $ICON_REF ]]; then
-  icon_ext="${ICON_REF##*.}"
-  [[ $icon_ext == "$ICON_REF" ]] && icon_ext="png"
-  [[ $icon_ext =~ ^[[:alnum:]]+$ ]] || icon_ext="png"
-  ICON_VALUE=$(install_user_icon "$ICON_REF" "$icon_slug")
-  owned_icon="$icon_slug.$icon_ext"
+  ICON_VALUE=$icon_slug
+  owned_icon=$(install_user_icon "$ICON_REF" "$icon_slug")
 else
   # Bundled Omarchy icons are package-owned under /usr/share/icons/hicolor.
   ICON_VALUE=$(icon_name_from_ref "$ICON_REF")

--- a/bin/omarchy-tui-install
+++ b/bin/omarchy-tui-install
@@ -100,6 +100,7 @@ DESKTOP_DIR="$HOME/.local/share/applications"
 DESKTOP_FILE="$DESKTOP_DIR/$APP_NAME.desktop"
 mkdir -p "$DESKTOP_DIR"
 
+owned_icon=""
 if [[ $ICON_REF =~ ^https?:// ]]; then
   ICON_VALUE=$(safe_icon_name "$APP_NAME")
   mkdir -p "$ICON_DIR"
@@ -108,8 +109,13 @@ if [[ $ICON_REF =~ ^https?:// ]]; then
     exit 1
   fi
   gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
+  owned_icon="$ICON_VALUE.png"
 elif [[ -f $ICON_REF ]]; then
-  ICON_VALUE=$(install_user_icon "$ICON_REF" "$(safe_icon_name "$APP_NAME")")
+  icon_slug=$(safe_icon_name "$APP_NAME")
+  icon_ext="${ICON_REF##*.}"
+  [[ $icon_ext == "$ICON_REF" ]] && icon_ext="png"
+  ICON_VALUE=$(install_user_icon "$ICON_REF" "$icon_slug")
+  owned_icon="$icon_slug.$icon_ext"
 else
   # Bundled Omarchy icons are package-owned under /usr/share/icons/hicolor.
   ICON_VALUE=$(icon_name_from_ref "$ICON_REF")
@@ -138,6 +144,10 @@ Type=Application
 Icon=$icon_field
 StartupNotify=true
 EOF
+
+if [[ -n $owned_icon ]]; then
+  printf 'X-Omarchy-OwnedIcon=%s\n' "$owned_icon" >>"$DESKTOP_FILE"
+fi
 
 chmod +x "$DESKTOP_FILE"
 

--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -9,14 +9,32 @@ ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
 OLD_ICON_DIR="$HOME/.local/share/applications/icons"
 DESKTOP_DIR="$HOME/.local/share/applications/"
 
-if (( $# == 0 )); then
-  # Find all TUIs
-  while IFS= read -r -d '' file; do
-    if grep -qE '^Exec=.*(\$TERMINAL|xdg-terminal-exec).*-e' "$file"; then
-      TUIS+=("$(basename "${file%.desktop}")")
-    fi
-  done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0)
+# Always index the launchers, so removal deletes the file that was found rather
+# than a path rebuilt from the displayed name. Installs predating the name
+# validation could nest the launcher inside directories, and those are exactly
+# the ones a reconstructed path cannot reach.
+TUIS=()
+TUI_PATHS=()
+while IFS= read -r -d '' file; do
+  if grep -qE '^Exec=.*(\$TERMINAL|xdg-terminal-exec).*-e' "$file"; then
+    TUIS+=("$(basename "${file%.desktop}")")
+    TUI_PATHS+=("$file")
+  fi
+done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0 2>/dev/null)
 
+# The launcher matching a chosen name, or empty when nothing was indexed under
+# it (an app removed between the scan and the pick, say).
+path_for_tui() {
+  local wanted="$1" i
+  for i in "${!TUIS[@]}"; do
+    if [[ ${TUIS[$i]} == "$wanted" ]]; then
+      printf '%s\n' "${TUI_PATHS[$i]}"
+      return 0
+    fi
+  done
+}
+
+if (( $# == 0 )); then
   if ((${#TUIS[@]})); then
     mapfile -t SORTED_TUIS < <(printf '%s\n' "${TUIS[@]}" | sort)
     APP_NAME=$(omarchy-menu-select "Select TUI to remove" "${SORTED_TUIS[@]}" -- --width 520 --maxheight 520)
@@ -34,7 +52,8 @@ if [[ -z $APP_NAME ]]; then
 fi
 
 icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
-rm -f "$DESKTOP_DIR/$APP_NAME.desktop"
+desktop_file=$(path_for_tui "$APP_NAME")
+rm -f "${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}"
 rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
 if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
   omarchy-notification-send -g  "TUI removed" "$APP_NAME"

--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -9,6 +9,17 @@ ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
 OLD_ICON_DIR="$HOME/.local/share/applications/icons"
 DESKTOP_DIR="$HOME/.local/share/applications/"
 
+safe_icon_name() {
+  printf '%s\n' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//'
+}
+
+desktop_value() {
+  local file="$1" key="$2"
+  sed -n "s/^$key=//p" "$file" | head -1
+}
+
 # Always index the launchers, so removal deletes the file that was found rather
 # than a path rebuilt from the displayed name. Installs predating the name
 # validation could nest the launcher inside directories, and those are exactly
@@ -51,10 +62,26 @@ if [[ -z $APP_NAME ]]; then
   exit 1
 fi
 
-icon_name=$(printf '%s\n' "$APP_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//')
+icon_name=$(safe_icon_name "$APP_NAME")
 desktop_file=$(path_for_tui "$APP_NAME")
-rm -f "${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}"
+desktop_file=${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}
+
+launcher_name=""
+launcher_icon=""
+if [[ -f $desktop_file ]]; then
+  launcher_name=$(desktop_value "$desktop_file" Name)
+  launcher_icon=$(desktop_value "$desktop_file" Icon)
+  rm -f "$desktop_file"
+fi
+
 rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
+if [[ -n $launcher_icon ]]; then
+  rm -f "$ICON_DIR/$launcher_icon.png" "$OLD_ICON_DIR/$launcher_icon.png"
+fi
+if [[ -n $launcher_name ]]; then
+  icon_name=$(safe_icon_name "$launcher_name")
+  rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$launcher_name.png" "$OLD_ICON_DIR/$launcher_name.png"
+fi
 if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
   omarchy-notification-send -g  "TUI removed" "$APP_NAME"
 fi

--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -20,15 +20,54 @@ desktop_value() {
   sed -n "s/^$key=//p" "$file" | head -1
 }
 
+desktop_string_unescape() {
+  local value="$1"
+
+  value=${value//\\n/$'\n'}
+  value=${value//\\r/$'\r'}
+  value=${value//\\t/$'\t'}
+  if [[ $value == '\s'* ]]; then
+    value=" ${value:2}"
+  fi
+  value=${value//\\\\/\\}
+
+  printf '%s' "$value"
+}
+
+remove_installed_icon() {
+  local app_name="$1" slug icon_dir
+
+  [[ -z $app_name ]] && return 0
+  slug=$(safe_icon_name "$app_name")
+  [[ $slug =~ ^[[:alnum:]-]+$ ]] || return 0
+
+  for icon_dir in "$ICON_DIR" "$OLD_ICON_DIR"; do
+    shopt -s nullglob
+    rm -f "$icon_dir/$slug".*
+    shopt -u nullglob
+  done
+}
+
+launcher_label() {
+  local file="$1" name
+
+  name=$(desktop_value "$file" Name)
+  if [[ -n $name ]]; then
+    desktop_string_unescape "$name"
+  else
+    basename "${file%.desktop}"
+  fi
+}
+
 # Always index the launchers, so removal deletes the file that was found rather
 # than a path rebuilt from the displayed name. Installs predating the name
 # validation could nest the launcher inside directories, and those are exactly
 # the ones a reconstructed path cannot reach.
-TUIS=()
+TUI_LABELS=()
 TUI_PATHS=()
 while IFS= read -r -d '' file; do
   if grep -qE '^Exec=.*(\$TERMINAL|xdg-terminal-exec).*-e' "$file"; then
-    TUIS+=("$(basename "${file%.desktop}")")
+    TUI_LABELS+=("$(launcher_label "$file")")
     TUI_PATHS+=("$file")
   fi
 done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0 2>/dev/null)
@@ -37,18 +76,40 @@ done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0 2>/dev/null)
 # it (an app removed between the scan and the pick, say).
 path_for_tui() {
   local wanted="$1" i
-  for i in "${!TUIS[@]}"; do
-    if [[ ${TUIS[$i]} == "$wanted" ]]; then
+
+  for i in "${!TUI_LABELS[@]}"; do
+    if [[ ${TUI_LABELS[$i]} == "$wanted" ]]; then
+      printf '%s\n' "${TUI_PATHS[$i]}"
+      return 0
+    fi
+  done
+  for i in "${!TUI_PATHS[@]}"; do
+    if [[ $(basename "${TUI_PATHS[$i]%.desktop}") == "$wanted" ]]; then
       printf '%s\n' "${TUI_PATHS[$i]}"
       return 0
     fi
   done
 }
 
+desktop_file=""
+
 if (( $# == 0 )); then
-  if ((${#TUIS[@]})); then
-    mapfile -t SORTED_TUIS < <(printf '%s\n' "${TUIS[@]}" | sort)
-    APP_NAME=$(omarchy-menu-select "Select TUI to remove" "${SORTED_TUIS[@]}" -- --width 520 --maxheight 520)
+  if ((${#TUI_PATHS[@]})); then
+    picker_options=()
+    mapfile -d '' -t sorted_paths < <(printf '%s\0' "${TUI_PATHS[@]}" | sort -z)
+    for file in "${sorted_paths[@]}"; do
+      for i in "${!TUI_PATHS[@]}"; do
+        if [[ ${TUI_PATHS[$i]} == "$file" ]]; then
+          picker_options+=("${TUI_LABELS[$i]}"$'\t'"$file")
+          break
+        fi
+      done
+    done
+    selection=$(omarchy-menu-select "Select TUI to remove" "${picker_options[@]}" -- --width 520 --maxheight 520)
+    APP_NAME="${selection%%$'\t'*}"
+    if [[ $selection == *$'\t'* ]]; then
+      desktop_file="${selection#*$'\t'}"
+    fi
   else
     echo "No TUIs to remove."
     exit 1
@@ -62,25 +123,21 @@ if [[ -z $APP_NAME ]]; then
   exit 1
 fi
 
-icon_name=$(safe_icon_name "$APP_NAME")
-desktop_file=$(path_for_tui "$APP_NAME")
-desktop_file=${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}
+if [[ -z $desktop_file ]]; then
+  desktop_file=$(path_for_tui "$APP_NAME")
+  desktop_file=${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}
+fi
 
 launcher_name=""
-launcher_icon=""
 if [[ -f $desktop_file ]]; then
   launcher_name=$(desktop_value "$desktop_file" Name)
-  launcher_icon=$(desktop_value "$desktop_file" Icon)
+  launcher_name=$(desktop_string_unescape "$launcher_name")
   rm -f "$desktop_file"
 fi
 
-rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$APP_NAME.png" "$OLD_ICON_DIR/$APP_NAME.png"
-if [[ -n $launcher_icon ]]; then
-  rm -f "$ICON_DIR/$launcher_icon.png" "$OLD_ICON_DIR/$launcher_icon.png"
-fi
+remove_installed_icon "$APP_NAME"
 if [[ -n $launcher_name ]]; then
-  icon_name=$(safe_icon_name "$launcher_name")
-  rm -f "$ICON_DIR/$icon_name.png" "$ICON_DIR/$launcher_name.png" "$OLD_ICON_DIR/$launcher_name.png"
+  remove_installed_icon "$launcher_name"
 fi
 if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
   omarchy-notification-send -g  "TUI removed" "$APP_NAME"

--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -34,17 +34,25 @@ desktop_string_unescape() {
   printf '%s' "$value"
 }
 
-remove_installed_icon() {
-  local app_name="$1" slug icon_dir
+remove_owned_icon() {
+  local basename="$1" icon_dir
 
-  [[ -z $app_name ]] && return 0
-  slug=$(safe_icon_name "$app_name")
+  [[ $basename =~ ^[[:alnum:]-]+\.[[:alnum:]]+$ ]] || return 0
+
+  for icon_dir in "$ICON_DIR" "$OLD_ICON_DIR"; do
+    rm -f "$icon_dir/$basename"
+  done
+}
+
+remove_legacy_icon() {
+  local launcher_name="$1" slug icon_dir
+
+  [[ -z $launcher_name ]] && return 0
+  slug=$(safe_icon_name "$launcher_name")
   [[ $slug =~ ^[[:alnum:]-]+$ ]] || return 0
 
   for icon_dir in "$ICON_DIR" "$OLD_ICON_DIR"; do
-    shopt -s nullglob
-    rm -f "$icon_dir/$slug".*
-    shopt -u nullglob
+    rm -f "$icon_dir/$slug.png"
   done
 }
 
@@ -77,14 +85,14 @@ done < <(find "$DESKTOP_DIR" -name '*.desktop' -print0 2>/dev/null)
 path_for_tui() {
   local wanted="$1" i
 
-  for i in "${!TUI_LABELS[@]}"; do
-    if [[ ${TUI_LABELS[$i]} == "$wanted" ]]; then
+  for i in "${!TUI_PATHS[@]}"; do
+    if [[ $(basename "${TUI_PATHS[$i]%.desktop}") == "$wanted" ]]; then
       printf '%s\n' "${TUI_PATHS[$i]}"
       return 0
     fi
   done
-  for i in "${!TUI_PATHS[@]}"; do
-    if [[ $(basename "${TUI_PATHS[$i]%.desktop}") == "$wanted" ]]; then
+  for i in "${!TUI_LABELS[@]}"; do
+    if [[ ${TUI_LABELS[$i]} == "$wanted" ]]; then
       printf '%s\n' "${TUI_PATHS[$i]}"
       return 0
     fi
@@ -100,7 +108,7 @@ if (( $# == 0 )); then
     for file in "${sorted_paths[@]}"; do
       for i in "${!TUI_PATHS[@]}"; do
         if [[ ${TUI_PATHS[$i]} == "$file" ]]; then
-          picker_options+=("${TUI_LABELS[$i]}"$'\t'"$file")
+          picker_options+=($'\t'"${TUI_LABELS[$i]}"$'\t'"$file")
           break
         fi
       done
@@ -128,16 +136,23 @@ if [[ -z $desktop_file ]]; then
   desktop_file=${desktop_file:-$DESKTOP_DIR/$APP_NAME.desktop}
 fi
 
+launcher_removed=false
+owned_icon=""
 launcher_name=""
 if [[ -f $desktop_file ]]; then
+  owned_icon=$(desktop_value "$desktop_file" X-Omarchy-OwnedIcon)
   launcher_name=$(desktop_value "$desktop_file" Name)
   launcher_name=$(desktop_string_unescape "$launcher_name")
   rm -f "$desktop_file"
+  launcher_removed=true
 fi
 
-remove_installed_icon "$APP_NAME"
-if [[ -n $launcher_name ]]; then
-  remove_installed_icon "$launcher_name"
+if [[ $launcher_removed == true ]]; then
+  if [[ -n $owned_icon ]]; then
+    remove_owned_icon "$owned_icon"
+  elif [[ -n $launcher_name ]]; then
+    remove_legacy_icon "$launcher_name"
+  fi
 fi
 if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
   omarchy-notification-send -g  "TUI removed" "$APP_NAME"

--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -9,12 +9,6 @@ ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
 OLD_ICON_DIR="$HOME/.local/share/applications/icons"
 DESKTOP_DIR="$HOME/.local/share/applications/"
 
-safe_icon_name() {
-  printf '%s\n' "$1" \
-    | tr '[:upper:]' '[:lower:]' \
-    | sed 's/[^[:alnum:]]\+/-/g; s/^-//; s/-$//'
-}
-
 desktop_value() {
   local file="$1" key="$2"
   sed -n "s/^$key=//p" "$file" | head -1
@@ -23,15 +17,11 @@ desktop_value() {
 desktop_string_unescape() {
   local value="$1"
 
-  value=${value//\\n/$'\n'}
-  value=${value//\\r/$'\r'}
-  value=${value//\\t/$'\t'}
   if [[ $value == '\s'* ]]; then
     value=" ${value:2}"
   fi
-  value=${value//\\\\/\\}
 
-  printf '%s' "$value"
+  perl -pe 's/\\(.)/$1 eq "\\" ? "\\" : $1 eq "n" ? "\n" : $1 eq "r" ? "\r" : $1 eq "t" ? "\t" : "\\$1"/ge' <<<"$value"
 }
 
 remove_owned_icon() {
@@ -44,16 +34,13 @@ remove_owned_icon() {
   done
 }
 
-remove_legacy_icon() {
-  local launcher_name="$1" slug icon_dir
+picker_row_label() {
+  local label="$1"
 
-  [[ -z $launcher_name ]] && return 0
-  slug=$(safe_icon_name "$launcher_name")
-  [[ $slug =~ ^[[:alnum:]-]+$ ]] || return 0
-
-  for icon_dir in "$ICON_DIR" "$OLD_ICON_DIR"; do
-    rm -f "$icon_dir/$slug.png"
-  done
+  label=${label//$'\t'/ }
+  label=${label//$'\n'/ }
+  label=${label//$'\r'/ }
+  printf '%s' "$label"
 }
 
 launcher_label() {
@@ -108,7 +95,8 @@ if (( $# == 0 )); then
     for file in "${sorted_paths[@]}"; do
       for i in "${!TUI_PATHS[@]}"; do
         if [[ ${TUI_PATHS[$i]} == "$file" ]]; then
-          picker_options+=($'\t'"${TUI_LABELS[$i]}"$'\t'"$file")
+          row_label=$(picker_row_label "${TUI_LABELS[$i]}")
+          picker_options+=($'\t'"$row_label"$'\t'"$file")
           break
         fi
       done
@@ -137,22 +125,20 @@ if [[ -z $desktop_file ]]; then
 fi
 
 launcher_removed=false
+has_owned_marker=false
 owned_icon=""
-launcher_name=""
 if [[ -f $desktop_file ]]; then
-  owned_icon=$(desktop_value "$desktop_file" X-Omarchy-OwnedIcon)
-  launcher_name=$(desktop_value "$desktop_file" Name)
-  launcher_name=$(desktop_string_unescape "$launcher_name")
+  if grep -q '^X-Omarchy-OwnedIcon=' "$desktop_file"; then
+    has_owned_marker=true
+    owned_icon=$(desktop_value "$desktop_file" X-Omarchy-OwnedIcon)
+    owned_icon=$(desktop_string_unescape "$owned_icon")
+  fi
   rm -f "$desktop_file"
   launcher_removed=true
 fi
 
-if [[ $launcher_removed == true ]]; then
-  if [[ -n $owned_icon ]]; then
-    remove_owned_icon "$owned_icon"
-  elif [[ -n $launcher_name ]]; then
-    remove_legacy_icon "$launcher_name"
-  fi
+if [[ $launcher_removed == true && $has_owned_marker == true && -n $owned_icon ]]; then
+  remove_owned_icon "$owned_icon"
 fi
 if [[ ${OMARCHY_REMOVE_NOTIFY:-true} != "false" ]]; then
   omarchy-notification-send -g  "TUI removed" "$APP_NAME"

--- a/bin/omarchy-tui-remove
+++ b/bin/omarchy-tui-remove
@@ -6,7 +6,6 @@
 set -e
 
 ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
-OLD_ICON_DIR="$HOME/.local/share/applications/icons"
 DESKTOP_DIR="$HOME/.local/share/applications/"
 
 desktop_value() {
@@ -25,13 +24,11 @@ desktop_string_unescape() {
 }
 
 remove_owned_icon() {
-  local basename="$1" icon_dir
+  local basename="$1"
 
   [[ $basename =~ ^[[:alnum:]-]+\.[[:alnum:]]+$ ]] || return 0
 
-  for icon_dir in "$ICON_DIR" "$OLD_ICON_DIR"; do
-    rm -f "$icon_dir/$basename"
-  done
+  rm -f "$ICON_DIR/$basename"
 }
 
 picker_row_label() {

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -291,7 +291,7 @@
   "remove.gaming": {"icon":"","label":"Gaming","title":"Remove"},
   "remove.browser": {"icon":"","label":"Browser","title":"Remove"},
   "remove.webapp": {"icon":"","label":"Web App","when":"grep -qE '^Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler)' $HOME/.local/share/applications/*.desktop","action":"omarchy-webapp-remove"},
-  "remove.tui": {"icon":"","label":"TUI","when":"grep -qE '^Exec=.*(\\$TERMINAL|xdg-terminal-exec).*-e' $HOME/.local/share/applications/*.desktop","action":"omarchy-tui-remove"},
+  "remove.tui": {"icon":"","label":"TUI","when":"find $HOME/.local/share/applications -name '*.desktop' -exec grep -qE '^Exec=.*(\\$TERMINAL|xdg-terminal-exec).*-e' {} + 2>/dev/null","action":"omarchy-tui-remove"},
   "remove.windows": {"icon":"󰍲","label":"Windows","when":"[[ -f $HOME/.local/share/applications/windows-vm.desktop ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-windows-vm remove'"},
   "remove.preinstalls": {"icon":"󰏓","label":"Preinstalls","when":"[[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-preinstalls"},
   "remove.security": {"icon":"","label":"Security","title":"Remove"},

--- a/test/shell.d/tui-install-escaping-test.sh
+++ b/test/shell.d/tui-install-escaping-test.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+export HOME="$test_tmp/home"
+export TMPDIR="$test_tmp/tmp"
+mkdir -p "$HOME" "$TMPDIR"
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+
+for stub in gtk-update-icon-cache omarchy-notification-send; do
+  printf '#!/bin/bash\n:\n' >"$mock_bin/$stub"
+  chmod +x "$mock_bin/$stub"
+done
+
+export PATH="$mock_bin:$PATH"
+
+applications="$HOME/.local/share/applications"
+
+install_tui() {
+  bash "$ROOT/bin/omarchy-tui-install" "$@" >/dev/null
+}
+
+run_install() {
+  bash "$ROOT/bin/omarchy-tui-install" "$@"
+}
+
+run_remove() {
+  HOME="$HOME" PATH="$PATH" OMARCHY_REMOVE_NOTIFY=false \
+    bash "$ROOT/bin/omarchy-tui-remove" "$@"
+}
+
+desktop_value() {
+  sed -n "s/^$2=//p" "$1" | head -1
+}
+
+install_tui Example htop tile someicon
+example_file="$applications/Example.desktop"
+
+[[ -f $example_file ]] || fail "tui install writes a desktop entry"
+(( $(grep -c '^Exec=' "$example_file") == 1 )) ||
+  fail "a normal tui install writes exactly one Exec line" "$(cat "$example_file")"
+[[ $(desktop_value "$example_file" Exec) == 'xdg-terminal-exec --app-id=TUI.tile -e htop' ]] ||
+  fail "tui install writes the expected Exec line" "$(desktop_value "$example_file" Exec)"
+pass "a normal tui install writes exactly one Exec line"
+
+install_tui 'Quoted App' "bash -c 'dust; read -n 1 -s'" tile someicon
+quoted_file="$applications/Quoted App.desktop"
+
+(( $(grep -c '^Exec=' "$quoted_file") == 1 )) ||
+  fail "a quoted command still yields exactly one Exec line" "$(cat "$quoted_file")"
+[[ $(desktop_value "$quoted_file" Exec) == *"bash -c 'dust; read -n 1 -s'"* ]] ||
+  fail "a quoted command keeps its quotes in Exec" "$(desktop_value "$quoted_file" Exec)"
+pass "a quoted command keeps its quotes and one Exec line"
+
+output=$(run_install "http://example.test/oops" htop tile someicon 2>&1) &&
+  fail "tui install rejects a name containing a slash"
+[[ $output == *"App name cannot contain '/'"* ]] ||
+  fail "tui install says why it refused a slashed name" "$output"
+[[ -e "$applications/http:" ]] &&
+  fail "tui install does not create a directory from a slashed name"
+pass "tui install rejects a name that would nest the launcher"
+
+if run_install "../../../../escaped" htop tile someicon >/dev/null 2>&1; then
+  fail "tui install rejects a name that climbs out of the applications directory"
+fi
+[[ -e "$test_tmp/escaped.desktop" ]] &&
+  fail "tui install writes no launcher outside the applications directory"
+pass "tui install refuses a name that would escape the applications directory"
+
+inject_name=$(printf 'Inject\nExec=evil')
+install_tui "$inject_name" htop tile someicon
+inject_file="$applications/$inject_name.desktop"
+
+(( $(grep -c '^Exec=' "$inject_file") == 1 )) ||
+  fail "a newline in the app name cannot inject a second Exec" "$(cat "$inject_file")"
+pass "a newline in the app name cannot inject a second Exec"
+
+inject_exec=$(printf 'htop\nExec=evil')
+install_tui 'Inject Exec' "$inject_exec" tile someicon
+inject_exec_file="$applications/Inject Exec.desktop"
+
+(( $(grep -c '^Exec=' "$inject_exec_file") == 1 )) ||
+  fail "a newline in the command cannot inject a second Exec" "$(cat "$inject_exec_file")"
+pass "a newline in the command cannot inject a second Exec"
+
+inject_icon=$(printf 'someicon\nExec=evil')
+install_tui 'Inject Icon' htop tile "$inject_icon"
+inject_icon_file="$applications/Inject Icon.desktop"
+
+(( $(grep -c '^Exec=' "$inject_icon_file") == 1 )) ||
+  fail "a newline in the icon name cannot inject a second Exec" "$(cat "$inject_icon_file")"
+pass "a newline in the icon name cannot inject a second Exec"
+
+mkdir -p "$applications/http:/127.0.0.1:4000"
+cat >"$applications/http:/127.0.0.1:4000/.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=http://127.0.0.1:4000
+Exec=xdg-terminal-exec --app-id=TUI.tile -e htop
+Type=Application
+DESKTOP
+
+run_remove "127.0.0.1:4000" >/dev/null
+[[ -f "$applications/http:/127.0.0.1:4000/.desktop" ]] &&
+  fail "tui remove deletes a launcher left nested by an older install"
+pass "tui remove reaches a nested legacy launcher"

--- a/test/shell.d/tui-install-escaping-test.sh
+++ b/test/shell.d/tui-install-escaping-test.sh
@@ -99,6 +99,10 @@ inject_icon_file="$applications/Inject Icon.desktop"
 pass "a newline in the icon name cannot inject a second Exec"
 
 mkdir -p "$applications/http:/127.0.0.1:4000"
+icons_dir="$HOME/.local/share/icons/hicolor/256x256/apps"
+legacy_icon="http-127-0-0-1-4000"
+mkdir -p "$icons_dir"
+touch "$icons_dir/$legacy_icon.png"
 cat >"$applications/http:/127.0.0.1:4000/.desktop" <<'DESKTOP'
 [Desktop Entry]
 Name=http://127.0.0.1:4000
@@ -109,4 +113,6 @@ DESKTOP
 run_remove "127.0.0.1:4000" >/dev/null
 [[ -f "$applications/http:/127.0.0.1:4000/.desktop" ]] &&
   fail "tui remove deletes a launcher left nested by an older install"
-pass "tui remove reaches a nested legacy launcher"
+[[ -f "$icons_dir/$legacy_icon.png" ]] &&
+  fail "tui remove deletes the icon named for the launcher's full Name field"
+pass "tui remove reaches a nested legacy launcher and its icon"

--- a/test/shell.d/tui-install-escaping-test.sh
+++ b/test/shell.d/tui-install-escaping-test.sh
@@ -82,6 +82,50 @@ inject_file="$applications/$inject_name.desktop"
   fail "a newline in the app name cannot inject a second Exec" "$(cat "$inject_file")"
 pass "a newline in the app name cannot inject a second Exec"
 
+cat >"$mock_bin/omarchy-menu-select" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$FAKE_PICK"
+STUB
+chmod +x "$mock_bin/omarchy-menu-select"
+
+FAKE_PICK="${inject_name}"$'\t'"${inject_file}" \
+  HOME="$HOME" PATH="$PATH" OMARCHY_REMOVE_NOTIFY=false \
+  bash "$ROOT/bin/omarchy-tui-remove" >/dev/null
+[[ -f $inject_file ]] &&
+  fail "tui remove reaches a newline-named launcher through the picker"
+pass "tui remove reaches a newline-named launcher through the picker"
+
+install_tui "$inject_name" htop tile someicon
+inject_file="$applications/$inject_name.desktop"
+run_remove "$inject_name" >/dev/null
+[[ -f $inject_file ]] &&
+  fail "tui remove deletes a newline-named launcher from the command line"
+pass "tui remove deletes a newline-named launcher from the command line"
+
+icons_dir="$HOME/.local/share/icons/hicolor/256x256/apps"
+mkdir -p "$icons_dir"
+touch "$icons_dir/someicon.png"
+install_tui 'Shared Icon' htop tile someicon
+run_remove 'Shared Icon' >/dev/null
+[[ -f "$icons_dir/someicon.png" ]] ||
+  fail "tui remove leaves a shared icon file it did not install"
+pass "tui remove leaves a shared icon file it did not install"
+
+mkdir -p "$icons_dir"
+touch "$HOME/.local/share/icons/hicolor/outside.png"
+cat >"$applications/Evil Icon.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Evil Icon
+Icon=../../outside
+Exec=xdg-terminal-exec --app-id=TUI.tile -e htop
+Type=Application
+DESKTOP
+
+run_remove 'Evil Icon' >/dev/null
+[[ -f "$HOME/.local/share/icons/hicolor/outside.png" ]] ||
+  fail "tui remove does not delete icons referenced by a malicious Icon field"
+pass "tui remove does not delete icons referenced by a malicious Icon field"
+
 inject_exec=$(printf 'htop\nExec=evil')
 install_tui 'Inject Exec' "$inject_exec" tile someicon
 inject_exec_file="$applications/Inject Exec.desktop"
@@ -99,7 +143,6 @@ inject_icon_file="$applications/Inject Icon.desktop"
 pass "a newline in the icon name cannot inject a second Exec"
 
 mkdir -p "$applications/http:/127.0.0.1:4000"
-icons_dir="$HOME/.local/share/icons/hicolor/256x256/apps"
 legacy_icon="http-127-0-0-1-4000"
 mkdir -p "$icons_dir"
 touch "$icons_dir/$legacy_icon.png"

--- a/test/shell.d/tui-install-escaping-test.sh
+++ b/test/shell.d/tui-install-escaping-test.sh
@@ -126,6 +126,13 @@ run_remove 'My App' >/dev/null
   fail "tui remove leaves an unrelated shared icon that shares the bundled icon slug"
 pass "tui remove leaves an unrelated shared icon that shares the bundled icon slug"
 
+touch "$icons_dir/my-app.png"
+install_tui 'My App Png' htop tile my-app
+run_remove 'My App Png' >/dev/null
+[[ -f "$icons_dir/my-app.png" ]] ||
+  fail "tui remove leaves a pre-existing shared png that shares the bundled icon slug"
+pass "tui remove leaves a pre-existing shared png that shares the bundled icon slug"
+
 touch "$icons_dir/example.png"
 run_remove 'No Such App' >/dev/null 2>&1 || true
 [[ -f "$icons_dir/example.png" ]] ||
@@ -197,6 +204,44 @@ DESKTOP
 run_remove "127.0.0.1:4000" >/dev/null
 [[ -f "$applications/http:/127.0.0.1:4000/.desktop" ]] &&
   fail "tui remove deletes a launcher left nested by an older install"
-[[ -f "$icons_dir/$legacy_icon.png" ]] &&
-  fail "tui remove deletes the icon named for the launcher's full Name field"
-pass "tui remove reaches a nested legacy launcher and its icon"
+[[ -f "$icons_dir/$legacy_icon.png" ]] ||
+  fail "tui remove leaves a legacy icon untouched when no ownership marker is present"
+pass "tui remove reaches a nested legacy launcher without deleting its icon"
+
+multiline_name=$(printf 'Line One\nLine Two')
+icon_src="$test_tmp/icon.png"
+printf '%s' 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==' | base64 -d >"$icon_src"
+install_tui "$multiline_name" htop tile "$icon_src"
+multiline_file="$applications/$multiline_name.desktop"
+multiline_slug=line-one-line-two
+
+(( $(grep -c '^X-Omarchy-OwnedIcon=' "$multiline_file") == 1 )) ||
+  fail "a multiline name writes one owned-icon line" "$(grep X-Omarchy-OwnedIcon "$multiline_file" || true)"
+[[ -f "$icons_dir/$multiline_slug.png" ]] ||
+  fail "a multiline name installs its icon under a single-line slug"
+if command -v desktop-file-validate >/dev/null; then
+  desktop-file-validate "$multiline_file" >/dev/null ||
+    fail "a multiline name still validates as a desktop entry"
+fi
+run_remove "$multiline_name" >/dev/null
+[[ -f "$icons_dir/$multiline_slug.png" ]] &&
+  fail "tui remove deletes an owned icon installed for a multiline name"
+pass "a multiline name round-trips owned-icon metadata and removal"
+
+literal_name=$(printf 'Literal\\tSequence')
+literal_file="$applications/$literal_name.desktop"
+install_tui "$literal_name" htop tile someicon
+run_remove "$literal_name" >/dev/null
+[[ -f $literal_file ]] &&
+  fail "tui remove deletes a literal backslash-t name from the command line"
+pass "tui remove deletes a literal backslash-t name from the command line"
+
+install_tui "$literal_name" htop tile someicon
+literal_file="$applications/$literal_name.desktop"
+literal_row_label=$(printf 'Literal\\tSequence')
+FAKE_PICK=$'\t'"${literal_row_label}"$'\t'"${literal_file}" \
+  HOME="$HOME" PATH="$PATH" OMARCHY_REMOVE_NOTIFY=false \
+  bash "$ROOT/bin/omarchy-tui-remove" >/dev/null
+[[ -f $literal_file ]] &&
+  fail "tui remove deletes a literal backslash-t name through the picker"
+pass "tui remove deletes a literal backslash-t name through the picker"

--- a/test/shell.d/tui-install-escaping-test.sh
+++ b/test/shell.d/tui-install-escaping-test.sh
@@ -84,11 +84,19 @@ pass "a newline in the app name cannot inject a second Exec"
 
 cat >"$mock_bin/omarchy-menu-select" <<'STUB'
 #!/bin/bash
-printf '%s\n' "$FAKE_PICK"
+pick="$FAKE_PICK"
+if [[ $pick == $'\t'* ]]; then
+  pick=${pick#$'\t'}
+  label=${pick%%$'\t'*}
+  path=${pick#*$'\t'}
+  printf '%s\t%s\n' "$label" "$path"
+else
+  printf '%s\n' "$pick"
+fi
 STUB
 chmod +x "$mock_bin/omarchy-menu-select"
 
-FAKE_PICK="${inject_name}"$'\t'"${inject_file}" \
+FAKE_PICK=$'\t'"${inject_name}"$'\t'"${inject_file}" \
   HOME="$HOME" PATH="$PATH" OMARCHY_REMOVE_NOTIFY=false \
   bash "$ROOT/bin/omarchy-tui-remove" >/dev/null
 [[ -f $inject_file ]] &&
@@ -111,20 +119,53 @@ run_remove 'Shared Icon' >/dev/null
   fail "tui remove leaves a shared icon file it did not install"
 pass "tui remove leaves a shared icon file it did not install"
 
+touch "$icons_dir/my-app.svg"
+install_tui 'My App' htop tile my-app
+run_remove 'My App' >/dev/null
+[[ -f "$icons_dir/my-app.svg" ]] ||
+  fail "tui remove leaves an unrelated shared icon that shares the bundled icon slug"
+pass "tui remove leaves an unrelated shared icon that shares the bundled icon slug"
+
+touch "$icons_dir/example.png"
+run_remove 'No Such App' >/dev/null 2>&1 || true
+[[ -f "$icons_dir/example.png" ]] ||
+  fail "tui remove deletes no icons when no launcher was found"
+pass "tui remove deletes no icons when no launcher was found"
+
 mkdir -p "$icons_dir"
 touch "$HOME/.local/share/icons/hicolor/outside.png"
-cat >"$applications/Evil Icon.desktop" <<'DESKTOP'
+cat >"$applications/Evil Owned.desktop" <<'DESKTOP'
 [Desktop Entry]
-Name=Evil Icon
-Icon=../../outside
+Name=Evil Owned
+X-Omarchy-OwnedIcon=../../outside.png
 Exec=xdg-terminal-exec --app-id=TUI.tile -e htop
 Type=Application
 DESKTOP
 
-run_remove 'Evil Icon' >/dev/null
+run_remove 'Evil Owned' >/dev/null
 [[ -f "$HOME/.local/share/icons/hicolor/outside.png" ]] ||
-  fail "tui remove does not delete icons referenced by a malicious Icon field"
-pass "tui remove does not delete icons referenced by a malicious Icon field"
+  fail "tui remove does not delete icons named by a malicious owned-icon field"
+pass "tui remove does not delete icons named by a malicious owned-icon field"
+
+cat >"$applications/Beta.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Alpha
+Exec=xdg-terminal-exec --app-id=TUI.tile -e htop
+Type=Application
+DESKTOP
+cat >"$applications/Alpha.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Beta
+Exec=xdg-terminal-exec --app-id=TUI.tile -e htop
+Type=Application
+DESKTOP
+
+run_remove Beta >/dev/null
+[[ -f "$applications/Beta.desktop" ]] &&
+  fail "tui remove deletes the launcher whose desktop id was requested"
+[[ -f "$applications/Alpha.desktop" ]] ||
+  fail "tui remove does not delete a different launcher that shares the display name"
+pass "tui remove prefers the desktop id over a duplicate display name"
 
 inject_exec=$(printf 'htop\nExec=evil')
 install_tui 'Inject Exec' "$inject_exec" tile someicon


### PR DESCRIPTION
## Summary
- Port `require_plain_name`, `desktop_string_escape`, and `download_icon` from `omarchy-webapp-install` into `omarchy-tui-install`
- Escape Name/Comment/Exec/Icon in the written `.desktop` file (file-syntax only; no Exec-spec re-quoting of `APP_EXEC`)
- Index TUI launchers in `omarchy-tui-remove` and delete the indexed path so pre-fix nested launchers are removable

## Files changed
- `bin/omarchy-tui-install`
- `bin/omarchy-tui-remove`
- `test/shell.d/tui-install-escaping-test.sh`

## Test results
- `bash -n` on touched scripts: pass
- `git diff --check`: clean
- `test/shell.d/tui-install-escaping-test.sh`: pass (8 assertions)
- Related: `webapp-install-escaping-test.sh`, `webapp-name-test.sh`, `webapp-install-test.sh`: pass

Triaged as hardening per discussion with @ErikMelton; follow-up to the webapp-installer hardening in 4.0.2.