### PR TITLE
Ignore missing group window indexes

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -91,7 +91,14 @@ o.bind("SUPER + ALT + mouse_down", "Next window in group", hl.dsp.group.next())
 o.bind("SUPER + ALT + mouse_up", "Previous window in group", hl.dsp.group.prev())
 
 for index = 1, 5 do
-  o.bind("SUPER + ALT + code:" .. tostring(index + 9), "Switch to group window " .. index, hl.dsp.group.active({ index = index }))
+  o.bind("SUPER + ALT + code:" .. tostring(index + 9), "Switch to group window " .. index, function()
+    local window = hl.get_active_window()
+    local group = window and window.group
+
+    if group and index <= group.size then
+      hl.dispatch(hl.dsp.group.active({ index = index }))
+    end
+  end)
 end
 
 o.bind("SUPER + SLASH", "Monitor scaling up", "omarchy-hyprland-monitor-scaling up")


### PR DESCRIPTION
## What changed

Guard the numbered group-window bindings before dispatching to `hl.dsp.group.active`.

Pressing Super+Alt+1–5 now:

- switches normally when that member exists in the active window group
- quietly does nothing when the active window is ungrouped or the requested index is outside the group

This prevents Hyprland from showing a Lua runtime-error notification for a missing group member.

## Screenshot pre-fix
<img width="295" height="100" alt="image" src="https://github.com/user-attachments/assets/9923894a-3267-4517-9d9a-262935251f95" />

## Testing

- Tested live on Hyprland 0.56.2:
  - valid indexes still switch grouped windows
  - nonexistent indexes on grouped and ungrouped windows are quiet no-ops
- `luac -p default/hypr/bindings/tiling.lua`
- `bash test/shell.d/hyprland-default-config-test.sh`
- `bash test/shell.d/hyprland-binding-conflicts-test.sh`
