### PR TITLE
Clamp degenerate-saturation chrome seeds for Chromium

### DIFF
--- a/bin/omarchy-theme-set-templates
+++ b/bin/omarchy-theme-set-templates
@@ -418,9 +418,16 @@ if [[ -f $COLORS_FILE ]]; then
   # BrowserThemeColor is a seed, not a paint color (see
   # chrome_seed_from_background). Derive a clamped chrome seed from the
   # background so generated chromium.theme files survive Chromium's seed
-  # derivation.
-  if [[ -n ${THEME_COLORS[background]+_} ]]; then
-    THEME_COLORS[chrome_seed]="#$(chrome_seed_from_background "${THEME_COLORS[background]}")"
+  # derivation. A theme that defines its own chrome_seed keeps it; a
+  # background that is not plain hex passes through untouched so
+  # {{ chrome_seed_rgb }} still resolves instead of leaking a placeholder.
+  if [[ -z ${THEME_COLORS[chrome_seed]+_} && -n ${THEME_COLORS[background]+_} ]]; then
+    if [[ ${THEME_COLORS[background]} =~ ^#[0-9a-fA-F]{6}$ ]]; then
+      THEME_COLORS[chrome_seed]="#$(chrome_seed_from_background "${THEME_COLORS[background]}")"
+    else
+      THEME_COLORS[chrome_seed]="${THEME_COLORS[background]}"
+      printf 's|{{ chrome_seed_rgb }}|%s|g\n' "${THEME_COLORS[background]}" >>"$sed_script"
+    fi
   fi
 
   for key in "${!THEME_COLORS[@]}"; do

--- a/bin/omarchy-theme-set-templates
+++ b/bin/omarchy-theme-set-templates
@@ -16,6 +16,41 @@ hex_to_rgb() {
   printf "%d,%d,%d" "0x${hex:0:2}" "0x${hex:2:2}" "0x${hex:4:2}"
 }
 
+# Chromium derives the browser chrome color from the seed by adjusting
+# lightness while preserving HSL saturation. At the luminance extremes HSL
+# saturation is degenerate — a near-black's max+min is tiny and a near-white's
+# max channel is 255 — so a small hue tint yields full saturation and renders
+# as a loud, saturated tone of that hue: near-black blue-tinted backgrounds
+# render bright blue chrome, near-white warm ones bright yellow. Neutralize
+# degenerate seeds so near-black and near-white backgrounds keep
+# near-neutral chrome.
+chrome_seed_from_background() {
+  local background="$1"
+
+  awk -v background="$background" '
+    function hex_value(char) {
+      return index("0123456789abcdef", tolower(char)) - 1
+    }
+
+    function hex_pair_to_int(hex, idx) {
+      return hex_value(substr(hex, idx, 1)) * 16 + hex_value(substr(hex, idx + 1, 1))
+    }
+
+    BEGIN {
+      r = hex_pair_to_int(background, 2)
+      g = hex_pair_to_int(background, 4)
+      b = hex_pair_to_int(background, 6)
+      max = r; if (g > max) max = g; if (b > max) max = b
+      min = r; if (g < min) min = g; if (b < min) min = b
+      chroma = max - min
+      if (((max == 255) || (max + min <= 16)) && (chroma <= 32)) {
+        r = g = b = int((r + g + b) / 3 + 0.5)
+      }
+      printf "%02x%02x%02x", r, g, b
+    }
+  '
+}
+
 # Mix two hex colors. Amount may be a fraction (0.30) or percentage (30%).
 mix_color() {
   local start="${1#\#}"
@@ -379,6 +414,14 @@ if [[ -f $COLORS_FILE ]]; then
   while IFS=$'\t' read -r key value; do
     THEME_COLORS[$key]="$value"
   done < <(omarchy-theme-color --file "$COLORS_FILE" --all)
+
+  # BrowserThemeColor is a seed, not a paint color (see
+  # chrome_seed_from_background). Derive a clamped chrome seed from the
+  # background so generated chromium.theme files survive Chromium's seed
+  # derivation.
+  if [[ -n ${THEME_COLORS[background]+_} ]]; then
+    THEME_COLORS[chrome_seed]="#$(chrome_seed_from_background "${THEME_COLORS[background]}")"
+  fi
 
   for key in "${!THEME_COLORS[@]}"; do
     add_template_value "$key" "${THEME_COLORS[$key]}"

--- a/default/themed/chromium.theme.tpl
+++ b/default/themed/chromium.theme.tpl
@@ -1,1 +1,1 @@
-{{ background_rgb }}
+{{ chrome_seed_rgb }}

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -143,6 +143,8 @@ For a color key such as `accent = "#7aa2f7"`:
 | `{{ accent_strip }}` | `7aa2f7` |
 | `{{ accent_rgb }}` | `122,162,247` |
 
+`chromium.theme` is generated from the background as a clamped chrome seed rather than the raw color: Chromium derives the browser chrome color from that seed by adjusting lightness, and near-black and near-white degenerate seeds are neutralized so a tinted background keeps near-neutral chrome.
+
 ### Color mixing
 
 `mix`, `mix_strip`, and `mix_rgb` blend two hex colors by a fraction or

--- a/install/helpers/browser-policy.sh
+++ b/install/helpers/browser-policy.sh
@@ -29,7 +29,10 @@ BROWSER_POLICY_FIREFOX_DIRS=(
   /opt/zen-browser/distribution
 )
 
-BROWSER_POLICY_DEFAULT_COLOR="#1c2027"
+# The default must be neutral: Chromium renders the seed's hue at full
+# saturation at the lightness extremes, so a tinted fallback like the old
+# blue-grey #1c2027 rendered as loud blue chrome.
+BROWSER_POLICY_DEFAULT_COLOR="#1f1f1f"
 
 browser_policy_purge_dir() {
   local dir=$1

--- a/manual/43-making-your-own-theme.md
+++ b/manual/43-making-your-own-theme.md
@@ -2,7 +2,7 @@
 
 You can add your own themes to `~/.config/omarchy/themes`. Just copy one of the existing ones as a base (look in `/usr/share/omarchy/themes`), then tweak to your delight. As long as your theme is inside that folder, it'll be included in the theme selection menu.
 
-The main file you have to tweak is `colors.toml`. That defines the color set that's then used to generate configurations for the terminal (Foot/Alacritty/Ghostty/Kitty), btop, Chromium, Hyprland, Neovim, Helix, VSCode, Obsidian, and the entire Omarchy shell (top bar, menu, notifications, OSD, and lock screen).
+The main file you have to tweak is `colors.toml`. That defines the color set that's then used to generate configurations for the terminal (Foot/Alacritty/Ghostty/Kitty), btop, Chromium, Hyprland, Neovim, Helix, VSCode, Obsidian, and the entire Omarchy shell (top bar, menu, notifications, OSD, and lock screen). Chromium's chrome color is generated from the background as a clamped chrome seed — Chromium derives the chrome color from that seed, and degenerate near-black or near-white seeds are neutralized so a tinted background doesn't render as loud, saturated chrome.
 
 You can also use the included Aether application to create a new theme using a lovely GUI interface to play with colors and search for backgrounds. Just start it via the apps menu on `Super + Alt + Space`.
 

--- a/test/shell.d/browser-policy-dir-test.sh
+++ b/test/shell.d/browser-policy-dir-test.sh
@@ -214,7 +214,7 @@ pass "Firefox setup does not follow a planted distribution symlink"
   fail "theme colour treats leading zeros as decimal"
 for malformed in "" "not,a,color" "1,2" "1,2,3,4" "256,0,0" "999,999,999" "-1,0,0" \
   "1,2,3;id" '1,2,$(id)' "0x10,0,0" "1,2,3 4,5,6"; do
-  [[ $(browser_policy_theme_hex "$malformed") == "#1c2027" ]] ||
+  [[ $(browser_policy_theme_hex "$malformed") == "#1f1f1f" ]] ||
     fail "theme colour falls back to the stock grey for '$malformed'"
 done
 pass "theme colour is six hex digits or the stock grey"

--- a/test/shell.d/browser-policy-dir-test.sh
+++ b/test/shell.d/browser-policy-dir-test.sh
@@ -225,7 +225,7 @@ for theme in "$ROOT"/themes/*/chromium.theme; do
   hex=$(browser_policy_theme_hex "$rgb")
   [[ $hex =~ ^#[0-9a-f]{6}$ ]] ||
     fail "shipped $(basename "$(dirname "$theme")") chromium.theme parses as hex" "got: $hex from $(printf %q "$rgb")"
-  if [[ $hex == "#1c2027" && ! $rgb =~ ^[[:space:]]*28[[:space:]]*,[[:space:]]*32[[:space:]]*,[[:space:]]*39[[:space:]]*$ ]]; then
+  if [[ $hex == "#1f1f1f" && ! $rgb =~ ^[[:space:]]*31[[:space:]]*,[[:space:]]*31[[:space:]]*,[[:space:]]*31[[:space:]]*$ ]]; then
     fail "shipped $(basename "$(dirname "$theme")") chromium.theme is a valid RGB triple" "got: $(printf %q "$rgb")"
   fi
 done

--- a/test/shell.d/browser-policy-sudoers-test.sh
+++ b/test/shell.d/browser-policy-sudoers-test.sh
@@ -174,11 +174,11 @@ color_for_theme() {
 for malformed in "" "not,a,color" "1,2" "1,2,3,4" "256,0,0" "999,999,999" "-1,0,0" \
   "1,2,3;id" '1,2,$(id)' "0x10,0,0" "1,2,3 4,5,6"; do
   color=$(color_for_theme "$malformed")
-  [[ $color == "1c2027" ]] ||
+  [[ $color == "1f1f1f" ]] ||
     fail "omarchy-theme-set-browser falls back to the stock colour for '$malformed'" "got: $color"
 done
 
-[[ $(color_for_theme) == "1c2027" ]] ||
+[[ $(color_for_theme) == "1f1f1f" ]] ||
   fail "omarchy-theme-set-browser falls back to the stock colour with no theme file"
 
 pass "browser theme color is derived as six hex digits or falls back to the stock grey"

--- a/test/shell.d/chrome-seed-test.sh
+++ b/test/shell.d/chrome-seed-test.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 # derives the chrome color from it by adjusting lightness while preserving HSL
 # saturation. Near-black and near-white seeds are degenerate there, so a tinted
 # background would render as loud, saturated chrome of its hue. The generated
-# chromium.theme must be the clamped seed, not the raw background.
+# chromium.theme must be the clamped seed, not the raw background — unless the
+# theme defines its own chrome_seed, or the background is not plain hex at all.
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
@@ -17,8 +18,9 @@ home="$test_tmp/home"
 next_theme="$home/.local/state/omarchy/current/next-theme"
 mkdir -p "$next_theme"
 
-generated_chrome_seed() {
+generated_chromium_theme() {
   local background="$1"
+  local chrome_seed="${2:-}"
 
   # Templates never overwrite an output that already exists, so each case
   # starts from a clean staging directory.
@@ -45,21 +47,47 @@ color6 = "#7dcfff"
 color7 = "#a9b1d6"
 TOML
 
+  if [[ -n $chrome_seed ]]; then
+    printf '\nchrome_seed = "%s"\n' "$chrome_seed" >>"$next_theme/colors.toml"
+  fi
+
   HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
     bash "$ROOT/bin/omarchy-theme-set-templates"
 
-  tr -d '[:space:]' <"$next_theme/chromium.theme"
+  cat "$next_theme/chromium.theme"
 }
 
-while read -r background expected; do
-  actual=$(generated_chrome_seed "$background")
+assert_chromium_theme() {
+  local description="$1"
+  local expected="$2"
+  local actual
+
+  actual=$(generated_chromium_theme "$3" "$4")
   [[ $actual == "$expected" ]] ||
-    fail "chromium.theme is the clamped chrome seed of the background" \
-      "background $background: expected $expected, got $actual"
-  pass "background $background generates chromium.theme $expected"
-done <<'EOF'
-#000107 3,3,3
-#fffcf0 249,249,249
-#1a1b26 26,27,38
-#ff0000 255,0,0
-EOF
+    fail "$description" "background $3 chrome_seed ${4:-<none>}: expected $expected, got $actual"
+  pass "$description"
+}
+
+assert_chromium_theme \
+  "a near-black blue-tinted background generates a neutral chrome seed" \
+  "3,3,3" "#000107" ""
+
+assert_chromium_theme \
+  "a near-white warm background generates a neutral chrome seed" \
+  "249,249,249" "#fffcf0" ""
+
+assert_chromium_theme \
+  "a dark tinted background above the degenerate range keeps its seed" \
+  "26,27,38" "#1a1b26" ""
+
+assert_chromium_theme \
+  "a saturated background keeps its seed" \
+  "255,0,0" "#ff0000" ""
+
+assert_chromium_theme \
+  "a theme-defined chrome_seed wins over the derived one" \
+  "18,52,86" "#000107" "#123456"
+
+assert_chromium_theme \
+  "a non-hex background passes through as the chrome seed" \
+  "rgba(010203ee) rgba(040506ee) 45deg" "rgba(010203ee) rgba(040506ee) 45deg" ""

--- a/test/shell.d/chrome-seed-test.sh
+++ b/test/shell.d/chrome-seed-test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Chromium's BrowserThemeColor policy is a seed, not a paint color: Chromium
+# derives the chrome color from it by adjusting lightness while preserving HSL
+# saturation. Near-black and near-white seeds are degenerate there, so a tinted
+# background would render as loud, saturated chrome of its hue. The generated
+# chromium.theme must be the clamped seed, not the raw background.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+next_theme="$home/.local/state/omarchy/current/next-theme"
+mkdir -p "$next_theme"
+
+generated_chrome_seed() {
+  local background="$1"
+
+  # Templates never overwrite an output that already exists, so each case
+  # starts from a clean staging directory.
+  rm -rf "$next_theme"
+  mkdir -p "$next_theme"
+
+  cat >"$next_theme/colors.toml" <<TOML
+mode = "dark"
+
+accent = "#7aa2f7"
+selection = "#292e42"
+muted = "#414868"
+
+background = "$background"
+foreground = "#a9b1d6"
+
+color0 = "#1a1b26"
+color1 = "#f7768e"
+color2 = "#9ece6a"
+color3 = "#e0af68"
+color4 = "#7aa2f7"
+color5 = "#bb9af7"
+color6 = "#7dcfff"
+color7 = "#a9b1d6"
+TOML
+
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+    bash "$ROOT/bin/omarchy-theme-set-templates"
+
+  tr -d '[:space:]' <"$next_theme/chromium.theme"
+}
+
+while read -r background expected; do
+  actual=$(generated_chrome_seed "$background")
+  [[ $actual == "$expected" ]] ||
+    fail "chromium.theme is the clamped chrome seed of the background" \
+      "background $background: expected $expected, got $actual"
+  pass "background $background generates chromium.theme $expected"
+done <<'EOF'
+#000107 3,3,3
+#fffcf0 249,249,249
+#1a1b26 26,27,38
+#ff0000 255,0,0
+EOF


### PR DESCRIPTION
### Summary

`BrowserThemeColor` is a *seed*, not a paint color: Chromium derives the browser chrome color from it by adjusting lightness while preserving HSL saturation. At the luminance extremes HSL saturation is degenerate — a near-black seed's `max+min` is tiny (so `s = (max-min)/(max+min)` → 1.0 for any tint) and a near-white seed whose max channel is 255 also yields `s = 1.0`. A barely-tinted near-black background therefore renders the tab strip as a loud saturated tone of that hue: a theme with `background = "#000107"` renders Chromium's chrome as saturated blue `#0018AC` (#10696; dark-theme counterpart of #7624). Omarchy's fallback `#1c2027` is blue-hued and does the same.

This changes the generated `chromium.theme` to use a clamped chrome seed instead of the raw background, and makes the browser-policy fallback neutral:

- `bin/omarchy-theme-set-templates`: derive `chrome_seed` from `background`; seeds at the luminance extremes (`max == 255` or `max + min <= 16`) with small chroma (`<= 32`) are neutralized to their channel average, so near-black and near-white backgrounds keep near-neutral chrome while genuinely colored backgrounds keep their hue.
- `default/themed/chromium.theme.tpl`: `{{ background_rgb }}` → `{{ chrome_seed_rgb }}`.
- `install/helpers/browser-policy.sh`: fallback `#1c2027` → neutral `#1f1f1f`, with the reason in a comment.
- Docs updated (`docs/theming.md`, `manual/43-making-your-own-theme.md`).
- New test `test/shell.d/chrome-seed-test.sh`; fallback pins updated in `browser-policy-dir-test.sh` and `browser-policy-sudoers-test.sh`.

Theme authors who ship an explicit `chromium.theme` keep full control of their seed.

### Verification

Standalone check of the clamp: `#000107` → `030303`, `#fffcf0` → `f9f9f9`, `#222222`/`#ff0000`/`#1a1b26`/`#738555`/`#ffffff`/`#1c2027` unchanged.

- `./test/cli`: 112 ok, 0 failures
- `./test/shell`: 231 passed / 5 failed — the 5 failures reproduce on a clean quattro tree (verified via `git stash`), so they are pre-existing and unrelated
- `theme-staging-test.sh`, `browser-policy-dir-test.sh`, `browser-policy-sudoers-test.sh`, `chrome-seed-test.sh`: all pass

Rendered behavior on Chromium 151 (before → after, measured from screenshots): tab strip for a `#000107` background goes from saturated blue `#0018AC` to neutral dark; the olive-seeded case renders dark olive tones matching the theme accent. Before/after captures attached.

Note: this intentionally does not touch `BrowserColorScheme: "device"` — that is #10054 / #10056.
