### PR TITLE
Coalesce plugin reloads and exclude .git from inotify

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -668,6 +668,8 @@ QtObject {
       "-q",
       "-e",
       "close_write,create,delete,move",
+      "--exclude",
+      "/\\.git(/|$)|/__pycache__(/|$)|/node_modules(/|$)",
       "--format",
       "%w%f",
       registry.pluginsDir

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -60,7 +60,7 @@ ShellRoot {
 
   Timer {
     id: localPluginReloadTimer
-    interval: 150
+    interval: 1000
     onTriggered: shell.reloadPlugins()
   }
 

--- a/test/shell.d/plugin-watch-test.sh
+++ b/test/shell.d/plugin-watch-test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+registry="$ROOT/shell/services/PluginRegistry.qml"
+shell="$ROOT/shell/shell.qml"
+
+grep -Fq -- "--exclude" "$registry" || fail "plugin watcher excludes .git and cache dirs"
+grep -Fq '__pycache__' "$registry" || fail "plugin watcher exclude lists __pycache__"
+grep -Fq '.git' "$registry" || fail "plugin watcher exclude lists .git"
+grep -A3 'id: localPluginReloadTimer' "$shell" | grep -Fq 'interval: 1000' \
+  || fail "plugin reload timer coalesces to 1s"
+
+pass "plugin watcher ignores git/cache and coalesces reloads"


### PR DESCRIPTION
Fixes https://github.com/omacom/omarchy/issues/10702

`inotifywait -m -r` on `~/.config/omarchy/plugins` watches every plugin `.git`. Working-tree writes (git checkout, editor saves) still fire `localPluginChanged`, and `localPluginReloadTimer` reloads the whole graph every 150ms. An omamail checkout here produced a reload storm, then no bar (with https://github.com/omacom/omarchy/issues/10703).

- pass `--exclude` for `.git` / `__pycache__` / `node_modules`
- coalesce reloads to 1s
- `test/shell.d/plugin-watch-test.sh` asserts both

`--exclude` filters events, not watches; skipping `.git` in the watch list would be a follow-up.