### PR TITLE
Use t2bce_vhci on stable T2 installs instead of apple-bce

### DIFF
--- a/install/config/hardware/apple/fix-t2.sh
+++ b/install/config/hardware/apple/fix-t2.sh
@@ -18,10 +18,16 @@ if lspci -nn | grep -q "106b:180[12]"; then
   sudo systemctl enable t2fanrd.service
   sudo systemctl enable tiny-dfr.service
 
-  echo "apple-bce" | sudo tee /etc/modules-load.d/t2.conf >/dev/null
+  # linux-t2 7.1.4 replaced apple-bce with t2bce. Current arch-mact2 kernels
+  # have no apple-bce module, so writing that name makes every mkinitcpio/UKI
+  # rebuild fail and the install never finishes. Load t2bce_vhci (keyboard USB
+  # host); t2bce_core/t2bce_dma come in via dependencies.
+  echo "t2bce_vhci" | sudo tee /etc/modules-load.d/t2.conf >/dev/null
   echo "hci_bcm4377" | sudo tee -a /etc/modules-load.d/t2.conf >/dev/null
 
-  echo "MODULES+=(apple-bce usbhid hid_apple hid_generic xhci_pci xhci_hcd)" | sudo tee /etc/mkinitcpio.conf.d/apple-t2.conf >/dev/null
+  # Optional '?' keeps both sides of the rename working if a mirror still
+  # ships a pre-7.1.4 linux-t2 (mkinitcpio skips missing optional modules).
+  echo "MODULES+=(t2bce_vhci? apple-bce? usbhid hid_apple hid_generic xhci_pci xhci_hcd)" | sudo tee /etc/mkinitcpio.conf.d/apple-t2.conf >/dev/null
 
   cat <<EOF | sudo tee /etc/modprobe.d/brcmfmac.conf >/dev/null
 # Fix for T2 MacBook WiFi connectivity issues


### PR DESCRIPTION
## Summary

Fixes #10699.

`omarchy.org/install` clones **master**. That branch still writes `apple-bce` into modules-load and mkinitcpio. `linux-t2` 7.1.4 renamed that driver to `t2bce`, and current `arch-mact2` kernels have no `apple-bce` at all. Fresh T2 installs then fail every initramfs/UKI rebuild and never finish.

The same rename already landed on `quattro` (#6559). This is the minimal master backport so the advertised install path works again.

## Change

In `install/config/hardware/apple/fix-t2.sh` only:

- modules-load: `apple-bce` → `t2bce_vhci` (keyboard USB host; core/dma come via deps)
- mkinitcpio: `MODULES+=(t2bce_vhci? apple-bce? …)` so both sides of the rename work if a mirror still has a pre-7.1.4 kernel

No other master T2 defaults touched (tiny-dfr, `pcie_ports=compat`, fans stay as on master).

## Test plan

- [x] Diff limited to the two module lines (+ comments)
- [ ] On a T2 Mac (or chroot with `linux-t2` ≥ 7.1.4): run the installer path / re-source `fix-t2.sh`, confirm `mkinitcpio` resolves modules and builds a UKI
- [ ] Confirm `/etc/modules-load.d/t2.conf` lists `t2bce_vhci` and `/etc/mkinitcpio.conf.d/apple-t2.conf` no longer requires bare `apple-bce`

I do not have a T2 machine here. Happy to adjust if maintainers want master to match quattro's install script more broadly instead of this surgical backport.