### PR TITLE
Report theme hooks that fail instead of reporting a clean run

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -31,17 +31,30 @@ INSTALLED_THEME_DENIED=(alacritty.toml foot.ini ghostty.conf kitty.conf vscode.j
 IGNORED_THEME_FILES=()
 
 run_parallel() {
-  local pid
+  local index
   local pids=()
+  local commands=()
+  local failures=()
 
   for command in "$@"; do
     bash -lc "$command" &
     pids+=("$!")
+    commands+=("$command")
   done
 
-  for pid in "${pids[@]}"; do
-    wait "$pid"
+  # Applying a theme is best-effort: one hook failing should still leave the
+  # rest of the desktop retinted, so a failure here is reported, not fatal.
+  # Discarding wait's status entirely is what hides it — the caller sees a
+  # clean run whether or not every hook worked.
+  for index in "${!pids[@]}"; do
+    if ! wait "${pids[$index]}"; then
+      failures+=("${commands[$index]}")
+    fi
   done
+
+  if (( ${#failures[@]} > 0 )); then
+    printf 'omarchy-theme-set: theme hook failed: %s\n' "${failures[@]}" >&2
+  fi
 }
 
 shell_ipc() {

--- a/test/shell.d/theme-set-parallel-hooks-test.sh
+++ b/test/shell.d/theme-set-parallel-hooks-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Applying a theme runs its post-theme hooks in parallel. One hook failing must
+# not abort the theme change -- the rest of the desktop still gets retinted --
+# but it must not be reported as a clean run either, or a broken hook stays
+# invisible for as long as the user keeps switching themes.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+theme_set="$ROOT/bin/omarchy-theme-set"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+# Exercise the shipped implementation rather than a copy that can drift from it.
+run_parallel_source=$(sed -n '/^run_parallel() {$/,/^}$/p' "$theme_set")
+[[ -n $run_parallel_source ]] ||
+  fail "run_parallel is defined in bin/omarchy-theme-set"
+
+eval "$run_parallel_source"
+
+stderr_file="$test_tmp/stderr"
+status=0
+
+# omarchy-theme-set does not set -e, so a hook's exit status reaches
+# run_parallel there without unwinding the script. Match that here, or the
+# assertions below test a shell the function never actually runs under.
+call_run_parallel() {
+  : >"$stderr_file"
+  set +e
+  run_parallel "$@" 2>"$stderr_file"
+  status=$?
+  set -e
+}
+
+call_run_parallel \
+  "touch $test_tmp/first" \
+  "exit 3" \
+  "touch $test_tmp/last"
+
+(( status == 0 )) ||
+  fail "a failing hook does not abort the theme change" "run_parallel exited $status"
+
+[[ -f $test_tmp/first && -f $test_tmp/last ]] ||
+  fail "hooks either side of a failing one still run"
+
+grep -q 'exit 3' "$stderr_file" ||
+  fail "the failing hook is named on stderr" "stderr: $(<"$stderr_file")"
+
+grep -q 'touch' "$stderr_file" &&
+  fail "hooks that succeeded are not named on stderr" "stderr: $(<"$stderr_file")"
+
+# A command that is not on PATH at all is the shape a missing helper takes, and
+# it has to be reported the same way as a hook that ran and exited nonzero.
+call_run_parallel "omarchy-command-that-does-not-exist"
+
+grep -q 'omarchy-command-that-does-not-exist' "$stderr_file" ||
+  fail "an unresolvable hook is named on stderr" "stderr: $(<"$stderr_file")"
+
+call_run_parallel "true" "true"
+
+[[ -s $stderr_file ]] &&
+  fail "a run where every hook succeeds stays quiet" "stderr: $(<"$stderr_file")"
+
+pass "run_parallel reports failing theme hooks without aborting the theme change"


### PR DESCRIPTION
Fixes #10720.

`run_parallel` waited on each post-theme hook and discarded the status, so `omarchy-theme-set` finished successfully whether or not any of its fourteen hooks worked. Combined with the shell's theme switcher sending the whole run to `/dev/null` (`shell/plugins/background/Background.qml:119`), a hook that fails — or cannot be resolved on `PATH` at all — produces no exit code, no message, and no notification, and every later theme change fails the same silent way.

## The change

Collect the failing hooks and name them on stderr.

Applying a theme stays best-effort and `run_parallel` still returns zero: one broken retint should leave the rest of the desktop themed, it just should not pass for a clean run. The test asserts that explicitly, so the best-effort contract is now pinned rather than incidental.

I deliberately kept this to stderr rather than routing it through `omarchy-notification-send`. Surfacing it in the GUI path means deciding what a user should see when, say, `omarchy-theme-set-vscode` fails because VS Code isn't running — that's a product call, and a separate change from not throwing the status away. Happy to follow up if you'd want that.

## Test

`test/shell.d/theme-set-parallel-hooks-test.sh` extracts `run_parallel` from `bin/omarchy-theme-set` with `sed` and evaluates it, so it exercises the shipped implementation rather than a copy that can drift.

`omarchy-theme-set` does not `set -e`, so the test disables `errexit` around each call — under `set -e` the old function unwinds at the first failing `wait` instead of continuing, which is not how it behaves in the script.

Coverage: a failing hook is named; hooks either side of it still run; the run still exits zero; an unresolvable command is reported the same as one that exits nonzero; a fully successful run stays silent.

Verified it fails against the unpatched function:

```
$ git stash push bin/omarchy-theme-set
$ bash test/shell.d/theme-set-parallel-hooks-test.sh
stderr:
not ok - the failing hook is named on stderr
```

## Suites

- `./test/cli` — 112 ok, exit 0
- `./test/shell` — 3199 ok, including the new test

`./test/shell` also reports 5 failures on this machine that are **pre-existing and environmental** — they reproduce identically on a clean `upstream/quattro` with this patch stashed. Four want an `omarchy-pkgs` checkout that isn't present (`unowned-system-paths-test.sh`, `config-test.sh`), and `plymouth-set-test.sh` has a umask-sensitive assertion. None touch this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZPURL91JtwPainBiKQJZM
