### PR TITLE
Show LTE/WWAN cellular connections in the network panel

### DIFF
--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -72,6 +72,7 @@ function parseWwanStatus(raw) {
     operator: "",
     radio: "",
     netdev: "",
+    netif: "",
     profiles: []
   }
   var lines = String(raw || "").replace(/\r?\n+$/, "").split("\n")
@@ -85,7 +86,11 @@ function parseWwanStatus(raw) {
       status.tech = parts[3] || ""
       status.operator = parts[4] || ""
       status.radio = parts[5] || ""
+      // NM names the broadband device by its control netdev (cdc-wdm0), but
+      // the IP interface carrying the bearer can differ (wwan0); callers
+      // relabel details by netif and act on the device by netdev.
       status.netdev = parts[6] || ""
+      status.netif = parts[7] || parts[6] || ""
     } else if (parts[0] === "profile" && parts.length >= 4) {
       status.profiles.push({
         name: parts[1] || "",
@@ -430,10 +435,12 @@ var wwanStatusScript =
   "dev=$(nmcli -t -f DEVICE,TYPE device 2>/dev/null | awk -F: '$2 == \"gsm\" { print $1; exit }'); " +
   "[ -n \"$m\" ] || [ -n \"$dev\" ] || exit 0; " +
   "radio=$(nmcli -t -f wwan radio 2>/dev/null); " +
+  "netif=$(nmcli -g GENERAL.IP-IFACE device show \"$dev\" 2>/dev/null); " +
+  "[ -n \"$netif\" ] || netif=\"$dev\"; " +
   "if [ -n \"$m\" ] && vals=$(printf '%s' \"$m\" | jq -r '[(.modem.generic.state // \"\"), (.modem.generic[\"signal-quality\"].value // -1), (.modem.generic[\"access-technologies\"][0] // \"\"), ((.modem[\"3gpp\"][\"operator-name\"] // .modem[\"3gpp\"][\"operator-code\"]) // \"\")] | @tsv' 2>/dev/null) && [ -n \"$vals\" ]; then " +
-  "printf 'wwan\\t%s\\t%s\\t%s\\n' \"$vals\" \"$radio\" \"$dev\"; " +
+  "printf 'wwan\\t%s\\t%s\\t%s\\t%s\\n' \"$vals\" \"$radio\" \"$dev\" \"$netif\"; " +
   "else " +
-  "printf 'wwan\\t\\t\\t\\t\\t%s\\t%s\\n' \"$radio\" \"$dev\"; fi; " +
+  "printf 'wwan\\t\\t\\t\\t\\t%s\\t%s\\t%s\\n' \"$radio\" \"$dev\" \"$netif\"; fi; " +
   "nmcli -t -f NAME,UUID,ACTIVE,TYPE connection show 2>/dev/null | awk '$0 ~ /:gsm$/ { line=$0; sub(/:gsm$/, \"\", line); active=line; sub(/^.*:/, \"\", active); sub(/:[^:]*$/, \"\", line); uuid=line; sub(/^.*:/, \"\", uuid); sub(/:[^:]*$/, \"\", line); name=line; gsub(/\\\\:/, \":\", name); printf \"profile\\t%s\\t%s\\t%s\\n\", name, uuid, active }'"
 
 function networkFailureReason(reason, needsCredentials, reasons) {

--- a/shell/plugins/panels/network/Model.js
+++ b/shell/plugins/panels/network/Model.js
@@ -33,7 +33,70 @@ function connectionIcon(kind, signalStrength, connectivity) {
   var restricted = connectivity === "portal" || connectivity === "limited"
   if (kind === "wifi") return restricted ? "󰤩" : wifiIconFor(signalStrength)
   if (kind === "ethernet") return restricted ? "󰈂" : "󰈀"
+  // Cellular has no separate blocked glyph yet; the signal bars stand in
+  // either way, and the hero meta carries the restriction state.
+  if (kind === "wwan") return wwanIconFor(signalStrength)
   return "󰤮"
+}
+
+// Cellular signal bars, mirroring wifiIconFor's five steps. ModemManager
+// reports percent signal quality on the same 0-100 scale as NM's Wi-Fi
+// SIGNAL, so the bucketing carries over unchanged.
+function wwanIconFor(strength) {
+  var icons = ["󰣽", "󰣴", "󰣶", "󰣸", "󰣺"]
+  var index = Math.max(0, Math.min(4, Math.ceil(strength / 20) - 1))
+  return icons[index]
+}
+
+// ModemManager access-technology names -> the marketing labels people
+// expect beside the carrier name.
+function accessTechLabel(tech) {
+  var value = String(tech || "").toLowerCase()
+  if (value === "nr5g" || value === "5gnr" || value === "5g") return "5G"
+  if (value === "lte" || value === "lte-a" || value === "4g") return "4G"
+  if (value === "umts" || value === "hsdpa" || value === "hsupa" || value === "hspa" || value === "3g") return "3G"
+  if (value === "gsm" || value === "edge" || value === "gprs" || value === "2g") return "2G"
+  return ""
+}
+
+// Output of the wwan probe script (wwanStatusScript): one tab-separated
+// `wwan` header line followed by one `profile` line per GSM connection
+// profile. Empty input means no modem (or no mmcli) -- the panel then
+// reports cellular as simply unavailable.
+function parseWwanStatus(raw) {
+  var status = {
+    available: false,
+    state: "",
+    signal: -1,
+    tech: "",
+    operator: "",
+    radio: "",
+    netdev: "",
+    profiles: []
+  }
+  var lines = String(raw || "").replace(/\r?\n+$/, "").split("\n")
+
+  for (var i = 0; i < lines.length; i++) {
+    var parts = lines[i].split("\t")
+    if (parts[0] === "wwan" && parts.length >= 7) {
+      status.available = true
+      status.state = parts[1] || ""
+      status.signal = parts[2] !== "" ? parseInt(parts[2], 10) : -1
+      status.tech = parts[3] || ""
+      status.operator = parts[4] || ""
+      status.radio = parts[5] || ""
+      status.netdev = parts[6] || ""
+    } else if (parts[0] === "profile" && parts.length >= 4) {
+      status.profiles.push({
+        name: parts[1] || "",
+        uuid: parts[2] || "",
+        active: parts[3] === "yes"
+      })
+    }
+  }
+
+  status.profiles.sort(function(a, b) { return a.active === b.active ? 0 : (a.active ? -1 : 1) })
+  return status
 }
 
 function formatHeaderSpeed(mbps) {
@@ -57,11 +120,24 @@ function formatHeaderFreq(mhz) {
 }
 
 // Wi-Fi band state belongs in the selector section, not beside the hero name.
-// Ethernet has no equivalent selector, so keep its negotiated link speed here.
+// Ethernet has no equivalent selector, so keep its negotiated link speed here;
+// cellular shows its access technology and signal instead.
 function headerDetail(info) {
   var value = info || {}
   if (value.type === "ethernet") return formatHeaderSpeed(value.speed || "")
+  if (value.type === "wwan") return wwanDetail(value)
   return ""
+}
+
+// "4G · 68%" beside the hero name -- the access technology is the cellular
+// equivalent of the wired link speed that rides the header there. The fields
+// are pinned onto `info` by the panel when the routed interface is the modem.
+function wwanDetail(value) {
+  var parts = []
+  var tech = accessTechLabel(value.wwan_tech) || String(value.wwan_tech || "").toUpperCase()
+  if (tech) parts.push(tech)
+  if (value.wwan_signal !== undefined && value.wwan_signal >= 0) parts.push(value.wwan_signal + "%")
+  return parts.join(" · ")
 }
 
 function bandLabel(band) {
@@ -341,6 +417,25 @@ var enterpriseConnectScript =
   " && nmcli connection up uuid \"$u\"" +
   " || { nmcli connection delete uuid \"$u\" >/dev/null 2>&1; false; }"
 
+// One-shot cellular probe, same shape as enterpriseConnectScript above.
+// mmcli carries modem-wide truth (registration, signal quality, access
+// technology, operator); nmcli carries the radio kill switch and the GSM
+// connection profiles. Emits a `wwan` header line then one `profile` line
+// per profile; prints nothing at all when there is no modem (or no mmcli),
+// which parseWwanStatus reads as "unavailable". Profile lines are split
+// from the right so an escaped colon inside a profile name cannot
+// misalign the UUID/active fields.
+var wwanStatusScript =
+  "m=$(mmcli -J -m any 2>/dev/null); " +
+  "dev=$(nmcli -t -f DEVICE,TYPE device 2>/dev/null | awk -F: '$2 == \"gsm\" { print $1; exit }'); " +
+  "[ -n \"$m\" ] || [ -n \"$dev\" ] || exit 0; " +
+  "radio=$(nmcli -t -f wwan radio 2>/dev/null); " +
+  "if [ -n \"$m\" ] && vals=$(printf '%s' \"$m\" | jq -r '[(.modem.generic.state // \"\"), (.modem.generic[\"signal-quality\"].value // -1), (.modem.generic[\"access-technologies\"][0] // \"\"), ((.modem[\"3gpp\"][\"operator-name\"] // .modem[\"3gpp\"][\"operator-code\"]) // \"\")] | @tsv' 2>/dev/null) && [ -n \"$vals\" ]; then " +
+  "printf 'wwan\\t%s\\t%s\\t%s\\n' \"$vals\" \"$radio\" \"$dev\"; " +
+  "else " +
+  "printf 'wwan\\t\\t\\t\\t\\t%s\\t%s\\n' \"$radio\" \"$dev\"; fi; " +
+  "nmcli -t -f NAME,UUID,ACTIVE,TYPE connection show 2>/dev/null | awk '$0 ~ /:gsm$/ { line=$0; sub(/:gsm$/, \"\", line); active=line; sub(/^.*:/, \"\", active); sub(/:[^:]*$/, \"\", line); uuid=line; sub(/^.*:/, \"\", uuid); sub(/:[^:]*$/, \"\", line); name=line; gsub(/\\\\:/, \":\", name); printf \"profile\\t%s\\t%s\\t%s\\n\", name, uuid, active }'"
+
 function networkFailureReason(reason, needsCredentials, reasons) {
   var r = reasons || {}
   if (needsCredentials && reason === r.NoSecrets) return "Passphrase required"
@@ -366,10 +461,10 @@ function shouldRepromptPassphrase(reason, needsCredentials, reasons) {
 if (typeof module !== "undefined") {
   module.exports = {
     parseNetworkStatus: parseNetworkStatus,
-    wifiIconFor: wifiIconFor,
-    connectionIcon: connectionIcon,
     connectivityState: connectivityState,
     captivePortalUrl: captivePortalUrl,
+    wifiIconFor: wifiIconFor,
+    connectionIcon: connectionIcon,
     formatHeaderSpeed: formatHeaderSpeed,
     formatHeaderFreq: formatHeaderFreq,
     headerDetail: headerDetail,
@@ -378,6 +473,11 @@ if (typeof module !== "undefined") {
     bandTooltip: bandTooltip,
     parseBandStatus: parseBandStatus,
     decodeIwSsid: decodeIwSsid,
+    wwanIconFor: wwanIconFor,
+    accessTechLabel: accessTechLabel,
+    parseWwanStatus: parseWwanStatus,
+    wwanDetail: wwanDetail,
+    wwanStatusScript: wwanStatusScript,
     parseKeyValue: parseKeyValue,
     throughputState: throughputState,
     pingLatencyState: pingLatencyState,

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -643,9 +643,11 @@ Panel {
     var next = Model.parseKeyValue(raw)
 
     // The stock status script classifies any routed non-wireless interface
-    // as ethernet, which mislabels the modem's netdev (cdc-wdm0). Relabel
-    // it as wwan and pin the cellular readings the hero header shows.
-    if (next.iface && wwan.netdev && next.iface === wwan.netdev) {
+    // as ethernet, which mislabels the modem's bearer interface (wwan0).
+    // Relabel it as wwan and pin the cellular readings the hero header
+    // shows — matching the IP interface, since NM names the broadband
+    // device itself by its control netdev (cdc-wdm0).
+    if (next.iface && wwan.netif && next.iface === wwan.netif) {
       next.type = "wwan"
       next.wwan_signal = wwan.signal
       next.wwan_tech = wwan.tech

--- a/shell/plugins/panels/network/Panel.qml
+++ b/shell/plugins/panels/network/Panel.qml
@@ -82,6 +82,19 @@ Panel {
   property string bandSelected: "auto"
   property var bandAvailable: []
   property string pendingBand: ""
+  // ---- Cellular / WWAN -------------------------------------------------
+  // Quickshell's Networking service cannot see modem devices (DeviceType
+  // covers Wifi and Wired only), so cellular state comes from a polled
+  // mmcli/nmcli probe (Model.wwanStatusScript). The poll also runs while
+  // the panel is closed, at a slower cadence, so the bar pill tracks the
+  // modem. Profiles are pre-created with nmcli; the panel connects and
+  // disconnects them but never edits APN or SIM settings.
+  property var wwan: ({ available: false, profiles: [] })
+  // In-flight cellular action: the profile UUID being connected, "device"
+  // while the data bearer is being dropped, or "radio" while the modem's
+  // kill switch is toggling. Serializes against itself only.
+  property string wwanAction: ""
+  property int wwanIndex: -1
 
   // Per-row in-flight state. `actionSsid` flips on for the row whose action
   // is currently running so it can render "Connecting…" / "Disconnecting…" /
@@ -119,9 +132,9 @@ Panel {
   property bool cursorActive: false
 
   // Keyboard focus zone for the panel. j/k crosses row boundaries:
-  // header actions ⇄ portal ⇄ band ⇄ DNS row ⇄ Wi-Fi networks. h/l move
+  // header actions ⇄ portal ⇄ band ⇄ DNS ⇄ cellular ⇄ Wi-Fi networks. h/l move
   // within header actions, band pills, or DNS providers.
-  property string focusSection: "dns"  // "header" | "portal" | "band" | "dns" | "wifi"
+  property string focusSection: "dns"  // "header" | "portal" | "band" | "dns" | "cellular" | "wifi"
   property int headerIndex: 0
   readonly property bool canDisconnect: !!connectedWifiNetwork
   readonly property bool headerHasDisconnect: false
@@ -130,14 +143,21 @@ Panel {
   // radio to switch. On a wired box it would otherwise sit there reading
   // "off" beside a perfectly live Ethernet connection.
   readonly property bool canToggleWifi: networkManagerAvailable && wifiStationAvailable
+  // Cellular twin of the radio switch: only when a modem answered.
+  readonly property bool canToggleWwan: networkManagerAvailable && wwanAvailable
   readonly property int qrHeaderIndex: canShareWifi ? 0 : -1
   readonly property int speedHeaderIndex: canRunSpeedTest ? (canShareWifi ? 1 : 0) : -1
   readonly property int toggleHeaderIndex: canToggleWifi ? (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) : -1
-  readonly property int headerActionCount: (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) + (canToggleWifi ? 1 : 0)
+  // The cellular radio switch takes the last hero slot; same visibility
+  // rule as the Wi-Fi one — only when there is a modem to switch.
+  readonly property int wwanToggleHeaderIndex: canToggleWwan ? (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) + (canToggleWifi ? 1 : 0) : -1
+  readonly property int headerActionCount: (canShareWifi ? 1 : 0) + (canRunSpeedTest ? 1 : 0) + (canToggleWifi ? 1 : 0) + (canToggleWwan ? 1 : 0)
   readonly property bool qrHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === qrHeaderIndex
   readonly property bool speedHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === speedHeaderIndex
   readonly property bool toggleHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === toggleHeaderIndex
+  readonly property bool wwanHeaderHasCursor: cursorActive && focusSection === "header" && headerIndex === wwanToggleHeaderIndex
   readonly property string toggleHint: Networking.wifiEnabled ? "Turn Wi-Fi off" : "Turn Wi-Fi on"
+  readonly property string wwanToggleHint: wwan.radio === "enabled" ? "Turn cellular off" : "Turn cellular on"
   readonly property var dnsProviders: ["DHCP", "Cloudflare", "Google", "Custom"]
   property int dnsIndex: 0
   // ["2.4", "5", ...], or empty when there is nothing to choose between.
@@ -207,6 +227,45 @@ Panel {
     Qt.callLater(function() { root.refresh(true) })
   }
 
+  // ---- Cellular actions (nmcli; the native service cannot reach modems) --
+
+  function toggleWwan() {
+    if (!networkManagerAvailable || wwanAction !== "") return
+    wwanAction = "radio"
+    wwanActionProc.command = ["nmcli", "radio", "wwan", wwan.radio === "enabled" ? "off" : "on"]
+    wwanActionProc.running = true
+  }
+
+  function connectWwanProfile(profile) {
+    if (!profile || !profile.uuid || wwanAction !== "") return
+    wwanAction = profile.uuid
+    wwanActionProc.command = ["nmcli", "connection", "up", "uuid", profile.uuid]
+    wwanActionProc.running = true
+  }
+
+  function disconnectWwan() {
+    if (wwanAction !== "" || !wwan.netdev) return
+    wwanAction = "device"
+    wwanActionProc.command = ["nmcli", "device", "disconnect", wwan.netdev]
+    wwanActionProc.running = true
+  }
+
+  function updateWwan(raw) {
+    wwan = Model.parseWwanStatus(raw)
+  }
+
+  function activateWwanSelected() {
+    if (wwanAction !== "") return
+    var profile = wwanProfiles[wwanIndex] || null
+    if (!profile) return
+    if (profile.active) disconnectWwan()
+    else connectWwanProfile(profile)
+  }
+
+  function wwanIconFor(strength) {
+    return Model.wwanIconFor(strength)
+  }
+
   IpcHandler {
     target: "omarchy.network"
 
@@ -216,6 +275,7 @@ Panel {
     function hide() { root.close() }
     function toggle() { root.toggle() }
     function toggleNetwork() { root.toggleNetwork() }
+    function toggleWwan() { root.toggleWwan() }
     // Compat routes for configs that summon the centered cards through the
     // network target; both cards are their own plugins now.
     function showQr() { root.summonWifiQr(true) }
@@ -228,6 +288,7 @@ Panel {
     if (headerIndex === qrHeaderIndex) summonWifiQr()
     else if (headerIndex === speedHeaderIndex) summonSpeedTest()
     else if (headerIndex === toggleHeaderIndex) toggleNetwork()
+    else if (headerIndex === wwanToggleHeaderIndex) toggleWwan()
   }
 
   function setHeaderCursor(index) {
@@ -436,16 +497,32 @@ Panel {
 
   // Bar pill state, derived from the native NetworkManager service so the
   // icon reflects connection changes without polling. Wired is preferred
-  // when both are up, matching the default-route device.
+  // when both are up, matching the default-route device. Cellular comes
+  // from the polled wwan probe instead (see the wwan property above)
+  // because the native service has no modem device type.
   readonly property var wiredDevice: findDevice(DeviceType.Wired)
   readonly property string kind: {
     if (wiredDevice && wiredDevice.connected) return "ethernet"
     if (connectedWifiNetwork) return "wifi"
+    if (connectedWwanProfile) return "wwan"
     return "disconnected"
   }
   readonly property int signalStrength: connectedWifiNetwork
     ? Math.round((connectedWifiNetwork.signalStrength || 0) * 100)
-    : -1
+    : (wwan.signal >= 0 ? wwan.signal : -1)
+  readonly property bool wwanAvailable: wwan.available
+  readonly property var wwanProfiles: wwan.profiles || []
+  readonly property var connectedWwanProfile: {
+    for (var i = 0; i < wwanProfiles.length; i++) {
+      if (wwanProfiles[i] && wwanProfiles[i].active) return wwanProfiles[i]
+    }
+    return null
+  }
+  // The hero names the carrier the modem reports; the profile name and a
+  // generic label are fallbacks for modems that do not expose one.
+  readonly property string wwanTitle: wwan.operator
+    || (connectedWwanProfile ? connectedWwanProfile.name : "")
+    || "Cellular"
 
   function copyToClipboard(value) {
     if (!value || !root.bar) return
@@ -466,7 +543,8 @@ Panel {
   readonly property string icon: Model.connectionIcon(kind, signalStrength, connectivity)
   readonly property string connectionKey: kind === "wifi" && wifiDevice && connectedWifiNetwork
     ? kind + ":" + wifiDevice.name + ":" + connectedWifiNetwork.name
-    : (kind === "ethernet" && wiredDevice ? kind + ":" + wiredDevice.name : "")
+    : (kind === "wwan" && wwan.netdev ? kind + ":" + wwan.netdev
+    : (kind === "ethernet" && wiredDevice ? kind + ":" + wiredDevice.name : ""))
 
   onConnectionKeyChanged: Qt.callLater(checkConnectivity)
   onConnectivityChecksEnabledChanged: Qt.callLater(checkConnectivity)
@@ -534,6 +612,7 @@ Panel {
       bandProc.command = ["omarchy-network-band"]
       bandProc.running = true
     }
+    if (!wwanProc.running) wwanProc.running = true
     // A closed panel has no nearby-network list to fill, and bare refresh()
     // reaches here from action completion, timeouts and construction.
     if (opened && wifiDevice) {
@@ -562,6 +641,15 @@ Panel {
 
   function updateDetails(raw) {
     var next = Model.parseKeyValue(raw)
+
+    // The stock status script classifies any routed non-wireless interface
+    // as ethernet, which mislabels the modem's netdev (cdc-wdm0). Relabel
+    // it as wwan and pin the cellular readings the hero header shows.
+    if (next.iface && wwan.netdev && next.iface === wwan.netdev) {
+      next.type = "wwan"
+      next.wwan_signal = wwan.signal
+      next.wwan_tech = wwan.tech
+    }
 
     // A band change tears the link down and brings it back, and the status
     // command reports nothing at all while there is no route. Publishing that
@@ -710,6 +798,7 @@ Panel {
     var connection = ""
     if (info.type === "wifi") connection = info.ssid || "Wi-Fi"
     else if (info.type === "ethernet") connection = "Ethernet"
+    else if (info.type === "wwan") connection = wwanTitle
     bar.shell.summon("omarchy.speedtest", connection ? JSON.stringify({ connection: connection }) : "{}")
   }
 
@@ -943,6 +1032,44 @@ Panel {
     }
   }
 
+  // Cellular probe: mmcli for modem-wide truth, nmcli for the radio switch
+  // and the GSM connection profiles (Model.wwanStatusScript).
+  Process {
+    id: wwanProc
+    command: ["bash", "-c", Model.wwanStatusScript]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateWwan(text)
+    }
+  }
+
+  // Serialized cellular action runner (radio toggle, connect, disconnect).
+  // nmcli exits before the link settles, so onExited only clears the
+  // in-flight marker and kicks a fresh probe — the kind/signal bindings
+  // pick the new state up from there.
+  Process {
+    id: wwanActionProc
+    stdout: StdioCollector { waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onExited: {
+      root.wwanAction = ""
+      if (!wwanProc.running) wwanProc.running = true
+      root.refresh()
+    }
+  }
+
+  // Cellular poll. Slower than the open-panel cadence on purpose: while
+  // closed only the bar pill cares, and a modem's registration and signal
+  // barely move. The interval change restarts the timer, which is fine.
+  Timer {
+    id: wwanPoll
+    interval: root.opened ? 4000 : 15000
+    repeat: true
+    running: true
+    triggeredOnStart: true
+    onTriggered: if (!wwanProc.running) wwanProc.running = true
+  }
+
   // Poll details while the panel is open so the IP/route header catches up
   // as soon as NetworkManager finishes activating a connection.
   Timer {
@@ -956,7 +1083,7 @@ Panel {
   Timer {
     id: connectionPhraseTimer
     interval: 2800
-    running: root.opened && !root.restricted && (root.info.type === "ethernet" || (root.info.type === "wifi" && root.canDisconnect))
+    running: root.opened && !root.restricted && (root.info.type === "ethernet" || root.info.type === "wwan" || (root.info.type === "wifi" && root.canDisconnect))
     repeat: true
     onTriggered: connectionPhraseSwap.restart()
   }
@@ -979,7 +1106,7 @@ Panel {
   Connections {
     target: root
     function onInfoChanged() {
-      if (!(root.info.type === "ethernet" || (root.info.type === "wifi" && root.canDisconnect))) {
+      if (!(root.info.type === "ethernet" || root.info.type === "wwan" || (root.info.type === "wifi" && root.canDisconnect))) {
         connectionPhraseSwap.stop()
         heroMeta.opacity = 1.0
       }
@@ -1110,15 +1237,35 @@ Panel {
                 root.focusSection = "header"
                 root.headerIndex = 0
               }
+            } else if (root.wwanProfiles.length > 0) {
+              root.focusSection = "cellular"
+              if (root.wwanIndex < 0) root.wwanIndex = 0
+            } else if (root.wifiNetworks.length > 0) {
+              root.focusSection = "wifi"
+              if (root.selectedIndex < 0) root.selectedIndex = 0
+            }
+          } else if (root.focusSection === "cellular") {
+            // One cursor row per profile; k escapes to DNS, j continues
+            // into the wifi list below.
+            if (dy < 0) {
+              root.focusSection = "dns"
+            } else if (root.wwanIndex < root.wwanProfiles.length - 1) {
+              root.wwanIndex = Math.max(0, Math.min(root.wwanProfiles.length - 1, root.wwanIndex + dy))
             } else if (root.wifiNetworks.length > 0) {
               root.focusSection = "wifi"
               if (root.selectedIndex < 0) root.selectedIndex = 0
             }
           } else {  // wifi
-            // k from the top row escapes back up to the DNS row rather than
-            // wrapping around to the bottom of the list.
+            // k from the top row escapes back up to the cellular list when
+            // it's on screen, otherwise the DNS row, rather than wrapping
+            // around to the bottom of the list.
             if (dy < 0 && root.selectedIndex <= 0) {
-              root.focusSection = "dns"
+              if (root.wwanProfiles.length > 0) {
+                root.focusSection = "cellular"
+                root.wwanIndex = Math.max(0, root.wwanProfiles.length - 1)
+              } else {
+                root.focusSection = "dns"
+              }
               root.wifiActionFocused = false
             }
             else root.selectByDelta(dy)
@@ -1137,6 +1284,7 @@ Panel {
           else if (root.focusSection === "portal") root.openCaptivePortal()
           else if (root.focusSection === "band") root.activateBand()
           else if (root.focusSection === "dns") root.activateDns()
+          else if (root.focusSection === "cellular") root.activateWwanSelected()
           else root.activateSelected()
         }
       }
@@ -1228,6 +1376,23 @@ Panel {
               fontFamily: root.bar.fontFamily
             }
           }
+
+          ToggleSwitch {
+            id: wwanPowerSwitch
+            visible: root.canToggleWwan
+            checked: root.wwan.radio === "enabled"
+            hasCursor: root.wwanHeaderHasCursor
+            foreground: root.bar.foreground
+            Layout.alignment: Qt.AlignVCenter
+            onHovered: function(on) { if (on) root.setHeaderCursor(root.wwanToggleHeaderIndex) }
+            onToggled: root.toggleWwan()
+
+            PanelToolTip {
+              visible: wwanPowerSwitch.containsMouse
+              text: root.wwanToggleHint
+              fontFamily: root.bar.fontFamily
+            }
+          }
         }
 
         Column {
@@ -1252,6 +1417,7 @@ Panel {
               if (root.kind === "wifi" && root.connectedWifiNetwork) return root.connectedWifiNetwork.name || "Wi-Fi"
               if (root.info.type === "wifi") return root.info.ssid || "Wi-Fi"
               if (root.info.type === "ethernet") return "Ethernet"
+              if (root.info.type === "wwan") return root.wwanTitle
               return root.info.iface || (root.kind === "disconnected" ? "Disconnected" : "No connection")
             }
             readonly property string detail: root.headerDetail()
@@ -1277,6 +1443,7 @@ Panel {
                 return ""
               }
               if (root.info.type === "ethernet") return root.connectionPhrase.toUpperCase()
+              if (root.info.type === "wwan") return root.connectionPhrase.toUpperCase()
               if (root.kind === "disconnected") return "NOT CONNECTED"
               return ""
             }
@@ -1569,6 +1736,45 @@ Panel {
         }
       }
 
+
+
+      // Cellular profiles (only if a modem answered the probe and has
+      // profiles to list; the hero's radio switch still surfaces the modem
+      // itself when there are none).
+      PanelSeparator {
+        visible: root.wwanAvailable && root.wwanProfiles.length > 0
+        foreground: root.bar.foreground
+      }
+
+      Column {
+        visible: root.wwanAvailable && root.wwanProfiles.length > 0
+        width: parent.width
+        spacing: Style.space(6)
+
+        PanelSectionHeader {
+          text: "CELLULAR"
+          foreground: root.bar.foreground
+          fontFamily: root.bar.fontFamily
+        }
+
+        Repeater {
+          model: root.wwanProfiles
+
+          delegate: Item {
+            required property var modelData
+            required property int index
+            width: parent.width
+            height: cellularRow.implicitHeight
+
+            CellularRow {
+              id: cellularRow
+              width: parent.width
+              profile: modelData
+              slotIndex: index
+            }
+          }
+        }
+      }
 
       // Wi-Fi networks (only if a Wi-Fi station is available).
       PanelSeparator {
@@ -2042,6 +2248,118 @@ Panel {
         foreground: root.bar.foreground
         fontFamily: root.bar.fontFamily
         onClicked: row.submitCredentials()
+      }
+    }
+  }
+
+  // One cellular profile row: click toggles between connecting the profile
+  // and dropping the modem's data bearer. No inline editor — APN and SIM
+  // settings belong to nmcli, not the panel. The signal-bars icon mirrors
+  // the wifi rows; the second line carries action status only.
+  component CellularRow: CursorSurface {
+    id: crow
+    required property var profile
+    required property int slotIndex
+
+    readonly property bool isConnected: !!(profile && profile.active)
+    readonly property bool isBusy: root.wwanAction !== ""
+      && (root.wwanAction === (profile ? profile.uuid : "") || root.wwanAction === "device")
+    readonly property bool isSelected: root.focusSection === "cellular" && root.wwanIndex === crow.slotIndex
+
+    readonly property string statusText: {
+      if (root.wwanAction === "radio") return ""
+      if (isBusy && root.wwanAction === "device") return "Disconnecting…"
+      if (isBusy) return "Connecting…"
+      if (isConnected) return "Connected"
+      if (root.wwan.radio === "disabled") return "Radio off"
+      if (root.wwan.state === "registered") return "Registered"
+      if (root.wwan.state === "searching") return "Searching…"
+      return ""
+    }
+
+    readonly property color statusColor: {
+      if (isBusy || isConnected) return root.bar.foreground
+      return Qt.darker(root.bar.foreground, 1.5)
+    }
+
+    implicitHeight: crowBody.implicitHeight
+    hasCursor: root.cursorActive && isSelected
+    current: isConnected
+    foreground: root.bar.foreground
+    fill: root.hoverFill
+    currentFill: root.selectedFill
+
+    MouseArea {
+      id: crowMouse
+      anchors.fill: parent
+      hoverEnabled: true
+      acceptedButtons: Qt.LeftButton
+      cursorShape: Qt.PointingHandCursor
+      enabled: root.wwanAction === ""
+
+      // Move the cursor here when the mouse enters; mouse leaving doesn't
+      // clear it (so j/k pick up from where the mouse last was).
+      onContainsMouseChanged: if (containsMouse) { root.cursorActive = true; root.focusSection = "cellular"; root.wwanIndex = crow.slotIndex }
+
+      onClicked: {
+        if (!crow.profile) return
+        root.cursorActive = true
+        root.focusSection = "cellular"
+        root.wwanIndex = crow.slotIndex
+        if (crow.isConnected) root.disconnectWwan()
+        else root.connectWwanProfile(crow.profile)
+      }
+    }
+
+    Item {
+      id: crowBody
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.top: parent.top
+      anchors.leftMargin: Style.space(10)
+      anchors.rightMargin: Style.space(10)
+      implicitHeight: Math.max(crowIcon.implicitHeight, crowInfo.implicitHeight) + Style.spacing.rowPaddingX
+
+      Text {
+        id: crowIcon
+        textFormat: Text.PlainText
+        text: root.wwanIconFor(root.wwan.signal)
+        color: crow.statusColor
+        font.family: root.bar.fontFamily
+        font.pixelSize: Style.font.title
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+      }
+
+      Column {
+        id: crowInfo
+        spacing: Style.space(1)
+        anchors.left: crowIcon.right
+        anchors.leftMargin: Style.space(10)
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+
+        Text {
+          textFormat: Text.PlainText
+          text: crow.profile ? crow.profile.name : ""
+          color: root.bar.foreground
+          font.family: root.bar.fontFamily
+          font.pixelSize: Style.font.body
+          elide: Text.ElideRight
+          width: parent.width
+        }
+        Text {
+          textFormat: Text.PlainText
+          // An empty status collapses on its own: no doLayout lines means
+          // zero height, so there is no separate visible/height dance to
+          // keep the row one line tall (and none of its binding churn).
+          text: crow.statusText
+          color: crow.statusColor
+          font.family: root.bar.fontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideRight
+          width: parent.width
+        }
       }
     }
   }

--- a/shell/plugins/panels/network/manifest.json
+++ b/shell/plugins/panels/network/manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "id": "omarchy.network",
   "name": "Network",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Omarchy",
-  "description": "Wi-Fi list and connection state",
+  "description": "Wi-Fi, cellular (WWAN/LTE), and connection state",
   "kinds": [
     "bar-widget"
   ],
@@ -13,7 +13,7 @@
   },
   "barWidget": {
     "displayName": "Network",
-    "description": "Wi-Fi list and connection state",
+    "description": "Wi-Fi, cellular (WWAN/LTE), and connection state",
     "category": "Network",
     "allowMultiple": false
   }

--- a/test/shell.d/network-captive-portal-test.sh
+++ b/test/shell.d/network-captive-portal-test.sh
@@ -74,6 +74,12 @@ chmod +x "$stage/bin/noop"
 for command in omarchy-dns omarchy-network-band; do
   ln -s noop "$stage/bin/$command"
 done
+# The cellular probe shells out to the host's real mmcli/nmcli; a machine
+# with a connected modem would leak its GSM profiles into the fixture and
+# flip the panel's kind to wwan, overriding the mocked connectivity states
+# under test. Stub both so the probe reports no modem at all.
+ln -s noop "$stage/bin/mmcli"
+ln -s noop "$stage/bin/nmcli"
 # Preview uses only synthetic details, never the host's SSID or addresses.
 # Normal assertions keep the details empty to exercise missing-route handling.
 printf '#!/bin/bash\nif [[ -n ${NETWORK_TEST_PREVIEW:-} ]]; then\n  printf "type\\twifi\\niface\\ttest-wifi\\nssid\\tGuest Wi-Fi\\nip\\t192.0.2.10\\ngateway\\t192.0.2.1\\n"\nfi\n' > "$stage/bin/omarchy-network-status"

--- a/test/shell.d/network-wwan-test.sh
+++ b/test/shell.d/network-wwan-test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const network = requireFromRoot('shell/plugins/panels/network/Model.js')
+const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.qml', 'utf8')
+
+// The probe output format is a contract with Model.wwanStatusScript; parse
+// every field and both line kinds, including the empty-modem fallbacks.
+const status = network.parseWwanStatus(
+  'wwan\tregistered\t73\tlte\tCHINA MOBILE\tenabled\tcdc-wdm0\n' +
+  'profile\tChina Mobile LTE\tfb1b894e-6bad-4383-8930-cea5be8cadf7\tno\n')
+assertEqual(status.available, true, 'a modem answering makes wwan available')
+assertEqual(status.state, 'registered', 'registration state parses')
+assertEqual(status.signal, 73, 'signal quality parses as a number')
+assertEqual(status.tech, 'lte', 'access technology parses')
+assertEqual(status.operator, 'CHINA MOBILE', 'operator name parses')
+assertEqual(status.radio, 'enabled', 'radio kill switch state parses')
+assertEqual(status.netdev, 'cdc-wdm0', 'netdev parses so updateDetails can relabel it')
+assertEqual(status.profiles.length, 1, 'one GSM profile row parses')
+assertEqual(status.profiles[0].name, 'China Mobile LTE', 'profile name parses')
+assertEqual(status.profiles[0].active, false, 'inactive profile parses')
+assertEqual(status.profiles[0].uuid, 'fb1b894e-6bad-4383-8930-cea5be8cadf7', 'profile uuid parses')
+
+// An empty probe means "no modem" (or no mmcli), which must read as
+// unavailable rather than as a modem with empty fields.
+const none = network.parseWwanStatus('')
+assertEqual(none.available, false, 'no probe output means no cellular support')
+assertEqual(none.profiles.length, 0, 'no probe output lists no profiles')
+
+// jq emits empty fields when the modem has no operator cached yet; the
+// header line keeps its column count and every field falls back cleanly.
+const sparse = network.parseWwanStatus('wwan\t\t\t\t\tenabled\tcdc-wdm0')
+assertEqual(sparse.available, true, 'a modem without cached readings is still available')
+assertEqual(sparse.state, '', 'missing state falls back to empty')
+assertEqual(sparse.signal, -1, 'missing signal falls back to -1, which renders the empty-bars icon')
+assertEqual(sparse.operator, '', 'missing operator falls back to empty')
+// Active profiles sort first so the connected row tops the section.
+const ordered = network.parseWwanStatus(
+  'wwan\tconnected\t70\tlte\tOp\tenabled\tcdc-wdm0\n' +
+  'profile\tIdle\tuuid-idle\tno\n' +
+  'profile\tLive\tuuid-live\tyes\n')
+assertEqual(ordered.profiles[0].name, 'Live', 'the active profile sorts first')
+
+// Marketing labels for ModemManager access-technology names.
+assertEqual(network.accessTechLabel('lte'), '4G', 'lte maps to 4G')
+assertEqual(network.accessTechLabel('nr5g'), '5G', 'nr5g maps to 5G')
+assertEqual(network.accessTechLabel('umts'), '3G', 'umts maps to 3G')
+assertEqual(network.accessTechLabel('edge'), '2G', 'edge maps to 2G')
+assertEqual(network.accessTechLabel(''), '', 'unknown technology stays empty')
+
+// Signal bars bucket on the same 0-100 scale as Wi-Fi SIGNAL.
+assertEqual(network.wwanIconFor(-1), '󰣽', 'no reading renders the empty-bars icon')
+assertEqual(network.wwanIconFor(0), '󰣽', 'zero signal renders the empty-bars icon')
+assertEqual(network.wwanIconFor(21), '󰣴', 'just above a fifth of scale renders one bar')
+assertEqual(network.wwanIconFor(73), '󰣸', 'mid-high signal renders three bars')
+assertEqual(network.wwanIconFor(100), '󰣺', 'full signal renders four bars')
+assertEqual(network.connectionIcon('wwan', 73), '󰣸', 'the bar pill icon recognises wwan')
+assertEqual(network.connectionIcon('wwan', -1), '󰣽', 'the bar pill icon renders empty bars without a reading')
+
+// Hero detail: technology plus signal, either alone, neither.
+assertEqual(network.headerDetail({ type: 'wwan', wwan_tech: 'lte', wwan_signal: 73 }), '4G · 73%', 'hero detail pairs technology with signal')
+assertEqual(network.headerDetail({ type: 'wwan', wwan_tech: 'lte' }), '4G', 'hero detail survives a missing signal')
+assertEqual(network.headerDetail({ type: 'wwan' }), '', 'hero detail collapses without readings')
+
+// The panel keeps polling while closed so the bar pill tracks the modem:
+// the timer must not gate on the panel being open.
+const poll = panelSource.match(/id: wwanPoll[\s\S]*?onTriggered[^\n]*\n/)
+assert(poll, 'network has a wwan poll timer')
+assert(/running: true/.test(poll[0]), 'the wwan poll runs while the panel is closed')
+assert(/interval: root\.opened \? 4000 : 15000/.test(panelSource), 'the wwan poll slows down while the panel is closed')
+
+// Radio state and profile actions go over IPC, matching toggleNetwork.
+assert(/function toggleWwan\(\) \{ root\.toggleWwan\(\) \}/.test(panelSource), 'network exposes the cellular radio toggle over IPC')
+
+// The section only appears for a modem that answered the probe.
+const section = panelSource.match(/\/\/ Cellular profiles[\s\S]*?Repeater \{[\s\S]*?model: root\.wwanProfiles/)
+assert(section, 'network has a cellular profile section')
+assert(/visible: root\.wwanAvailable && root\.wwanProfiles\.length > 0/.test(section[0]), 'the cellular section hides without a modem or profiles')
+
+// updateDetails relabels the modem netdev the stock status script files
+// under ethernet, so the hero shows cellular state for a routed modem.
+assert(/next\.iface === wwan\.netdev/.test(panelSource), 'details relabel the modem netdev as wwan')
+
+// Cellular state must not leak into the connection pool the wifi rows use:
+// the probe result lands on its own property.
+assert(/wwan = Model\.parseWwanStatus\(raw\)/.test(panelSource), 'the probe result lands on the wwan property')
+JS
+
+pass "network wwan model and structure"

--- a/test/shell.d/network-wwan-test.sh
+++ b/test/shell.d/network-wwan-test.sh
@@ -11,7 +11,7 @@ const panelSource = fs.readFileSync(root + '/shell/plugins/panels/network/Panel.
 // The probe output format is a contract with Model.wwanStatusScript; parse
 // every field and both line kinds, including the empty-modem fallbacks.
 const status = network.parseWwanStatus(
-  'wwan\tregistered\t73\tlte\tCHINA MOBILE\tenabled\tcdc-wdm0\n' +
+  'wwan\tregistered\t73\tlte\tCHINA MOBILE\tenabled\tcdc-wdm0\twwan0\n' +
   'profile\tChina Mobile LTE\tfb1b894e-6bad-4383-8930-cea5be8cadf7\tno\n')
 assertEqual(status.available, true, 'a modem answering makes wwan available')
 assertEqual(status.state, 'registered', 'registration state parses')
@@ -19,7 +19,8 @@ assertEqual(status.signal, 73, 'signal quality parses as a number')
 assertEqual(status.tech, 'lte', 'access technology parses')
 assertEqual(status.operator, 'CHINA MOBILE', 'operator name parses')
 assertEqual(status.radio, 'enabled', 'radio kill switch state parses')
-assertEqual(status.netdev, 'cdc-wdm0', 'netdev parses so updateDetails can relabel it')
+assertEqual(status.netdev, 'cdc-wdm0', 'the NM control device parses for device-level actions')
+assertEqual(status.netif, 'wwan0', 'the bearer IP interface parses so updateDetails can relabel it')
 assertEqual(status.profiles.length, 1, 'one GSM profile row parses')
 assertEqual(status.profiles[0].name, 'China Mobile LTE', 'profile name parses')
 assertEqual(status.profiles[0].active, false, 'inactive profile parses')
@@ -33,10 +34,10 @@ assertEqual(none.profiles.length, 0, 'no probe output lists no profiles')
 
 // jq emits empty fields when the modem has no operator cached yet; the
 // header line keeps its column count and every field falls back cleanly.
-const sparse = network.parseWwanStatus('wwan\t\t\t\t\tenabled\tcdc-wdm0')
+const sparse = network.parseWwanStatus('wwan\t\t\t\t\tenabled\tcdc-wdm0\tcdc-wdm0')
 assertEqual(sparse.available, true, 'a modem without cached readings is still available')
 assertEqual(sparse.state, '', 'missing state falls back to empty')
-assertEqual(sparse.signal, -1, 'missing signal falls back to -1, which renders the empty-bars icon')
+assertEqual(sparse.netif, 'cdc-wdm0', 'a modem without a bearer yet falls back to the control device for netif')
 assertEqual(sparse.operator, '', 'missing operator falls back to empty')
 // Active profiles sort first so the connected row tops the section.
 const ordered = network.parseWwanStatus(
@@ -83,7 +84,7 @@ assert(/visible: root\.wwanAvailable && root\.wwanProfiles\.length > 0/.test(sec
 
 // updateDetails relabels the modem netdev the stock status script files
 // under ethernet, so the hero shows cellular state for a routed modem.
-assert(/next\.iface === wwan\.netdev/.test(panelSource), 'details relabel the modem netdev as wwan')
+assert(/next\.iface === wwan\.netif/.test(panelSource), 'details relabel the bearer interface as wwan')
 
 // Cellular state must not leak into the connection pool the wifi rows use:
 // the probe result lands on its own property.


### PR DESCRIPTION
## Problem

Quickshell's `Networking` service has no modem support — `DeviceType` covers only `None`/`Wifi`/`Wired` — so the stock network panel cannot see a WWAN device at all. On an LTE-only link (handhelds, travel machines, fallback WAN) the widget reads **Disconnected**, the panel offers nothing, and there is no way to manage the connection from the shell.

## Approach

Cellular rides alongside the native service as a polled probe (`Model.wwanStatusScript`): `mmcli -J` for modem truth (registration, signal quality, access technology, operator) and `nmcli` for the radio kill switch plus the GSM connection profiles. Everything is additive to the existing panel:

- Bar pill gains a `wwan` kind with cellular signal bars (`nf-md-network_strength_*`, same 0–100 bucketing as Wi-Fi SIGNAL). The poll also runs while the panel is closed (15s closed / 4s open) so the pill tracks the modem.
- A **CELLULAR** section between DNS and Wi-Fi lists GSM profiles: click to connect, click again to drop the data bearer, with the usual j/k navigation and busy states (Connecting… / Disconnecting… / Registered / Radio off).
- The hero names the carrier with technology and signal ("CHINA MOBILE (4G · 73%)"), and gains a cellular radio switch in the last hero slot mirroring the Wi-Fi one, plus a `toggleWwan` IPC route alongside `toggleNetwork`.
- `updateDetails` relabels the modem netdev that `omarchy-network-status` files under ethernet, so the IP/throughput/ping grid keeps working over LTE; `connectionKey` includes the modem so the existing captive-portal recheck fires when cellular connects.

Profiles are pre-created with `nmcli` (`nmcli connection add type gsm …`); the panel connects and disconnects but never edits APN or SIM settings. With no modem present the probe prints nothing and every cellular affordance stays hidden — behaviour is identical to stock, and no new runtime dependencies are required beyond `modemmanager` on machines that actually have a modem.

## Testing

- New `test/shell.d/network-wwan-test.sh`: probe parser contract (fields, sparse modem readings, empty = unavailable, active-first ordering), technology labels, signal buckets, hero detail, and structural asserts (poll runs while closed, IPC route, section gating, netdev relabel).
- Existing network suites pass, including the captive-portal fixture. One find along the way: a `height: visible ? implicitHeight : 0` dance on the row's status line binding-loops in panel context; the status Text now collapses on its own when empty.
- Live-verified end to end on a GPD Win Max 2 (Quectel modem, China Mobile LTE): profile connect/disconnect through the panel's own command paths, radio cycle over `omarchy-shell omarchy.network toggleWwan` (disabled → re-registered in ~3s), and no disturbance to routing or connectivity checks while connected.

## Notes

- No dedicated "restricted" glyph for wwan yet — signal bars stand in and the hero meta carries the portal/limited state; easy to add a cellular blocked icon later.
- Happy to reshape anything to match the project's taste for the section design or the probe cadence.
