### PR TITLE
feat(weather): show sunrise and sunset times in the panel

### DIFF
--- a/shell/plugins/panels/weather/Model.js
+++ b/shell/plugins/panels/weather/Model.js
@@ -147,7 +147,9 @@ function openMeteoForecastDays(dailyForecastReport, todayString) {
       mintempC: roundedTemp(minC),
       maxtempF: roundedTemp(celsiusToFahrenheit(maxC)),
       mintempF: roundedTemp(celsiusToFahrenheit(minC)),
-      openMeteoWeatherCode: daily.weather_code ? daily.weather_code[i] : null
+      openMeteoWeatherCode: daily.weather_code ? daily.weather_code[i] : null,
+      sunrise: timeOnly(daily.sunrise ? daily.sunrise[i] : ""),
+      sunset: timeOnly(daily.sunset ? daily.sunset[i] : "")
     })
   }
   return result
@@ -204,6 +206,73 @@ function wttrNextForecastDays(report, todayString) {
 function buildForecastDays(report, dailyForecastReport, todayString) {
   var days = openMeteoForecastDays(dailyForecastReport, todayString)
   return days.length > 0 ? days : wttrNextForecastDays(report, todayString)
+}
+
+// Sunrise/sunset arrive in two shapes: open-meteo emits ISO local
+// timestamps ("2026-09-07T18:47"), wttr emits display times ("07:11 PM").
+// Normalize both to a bare 24h clock time ("18:47") so the panel shows one
+// format regardless of source.
+function timeOnly(value) {
+  var s = String(value || "").replace(/^\s+|\s+$/g, "")
+  if (s === "") return ""
+  var i = s.indexOf("T")
+  if (i >= 0) return s.slice(i + 1, i + 6)
+
+  var m = s.match(/^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$/)
+  if (m) {
+    var hours = parseInt(m[1], 10) % 12
+    if (m[3].toLowerCase() === "pm") hours += 12
+    return (hours < 10 ? "0" : "") + hours + ":" + m[2]
+  }
+  return s
+}
+
+// Today's sun times, preferring the fast open-meteo daily payload over
+// wttr's per-day astronomy arrays. Picks the entry whose date matches
+// todayString and falls back to the first entry when the sources disagree
+// about order or the date is unknown.
+function sunTimes(dailyForecastReport, report, todayString) {
+  var daily = dailyForecastReport && dailyForecastReport.daily ? dailyForecastReport.daily : null
+  if (daily && daily.sunrise && daily.sunrise.length && daily.sunset && daily.sunset.length) {
+    var index = 0
+    var key = String(todayString || "").slice(0, 10)
+    if (key !== "" && daily.time && daily.time.length) {
+      for (var i = 0; i < daily.time.length; i++) {
+        if (String(daily.time[i]).slice(0, 10) === key) {
+          index = i
+          break
+        }
+      }
+    }
+    var sunrise = timeOnly(daily.sunrise[index])
+    var sunset = timeOnly(daily.sunset[index])
+    if (sunrise !== "" || sunset !== "") return { sunrise: sunrise, sunset: sunset }
+  }
+
+  var days = report && report.weather ? report.weather : []
+  if (days.length && days[0].astronomy && days[0].astronomy.length) {
+    var astronomy = days[0].astronomy[0]
+    if (astronomy.sunrise !== undefined && astronomy.sunset !== undefined)
+      return { sunrise: timeOnly(astronomy.sunrise), sunset: timeOnly(astronomy.sunset) }
+  }
+  return null
+}
+
+// Sun times for a forecast day object: open-meteo days carry normalized
+// sunrise/sunset strings, wttr days carry an astronomy array.
+function sunTimesForDay(day) {
+  if (!day) return null
+  if (day.sunrise !== undefined && day.sunset !== undefined) {
+    var sunrise = timeOnly(day.sunrise)
+    var sunset = timeOnly(day.sunset)
+    if (sunrise !== "" || sunset !== "") return { sunrise: sunrise, sunset: sunset }
+  }
+  if (day.astronomy && day.astronomy.length) {
+    var astronomy = day.astronomy[0]
+    if (astronomy.sunrise !== undefined && astronomy.sunset !== undefined)
+      return { sunrise: timeOnly(astronomy.sunrise), sunset: timeOnly(astronomy.sunset) }
+  }
+  return null
 }
 
 function bareTempForDay(day, kind, useImperial) {
@@ -290,6 +359,9 @@ if (typeof module !== "undefined") {
     bareTempForDay: bareTempForDay,
     dayIcon: dayIcon,
     iconForOpenMeteoCode: iconForOpenMeteoCode,
-    iconForCode: iconForCode
+    iconForCode: iconForCode,
+    timeOnly: timeOnly,
+    sunTimes: sunTimes,
+    sunTimesForDay: sunTimesForDay
   }
 }

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -149,6 +149,12 @@ Panel {
   readonly property string reportWind:      current ? (useImperial ? (current.windspeedMiles + " mph") : (current.windspeedKmph + " km/h")) : ""
   readonly property string reportHumidity:  current ? (current.humidity + "%") : ""
 
+  // Sunrise/sunset for today, local time. Prefers the open-meteo daily
+  // payload; wttr's astronomy fills the fallback when Open-Meteo fails.
+  readonly property var reportSunTimes: Model.sunTimes(dailyForecastReport, report, Qt.formatDate(new Date(), "yyyy-MM-dd"))
+  readonly property string reportSunrise: reportSunTimes ? reportSunTimes.sunrise : ""
+  readonly property string reportSunset:  reportSunTimes ? reportSunTimes.sunset : ""
+
   function refresh() {
     // Each full refresh cycle gets a fresh retry budget, so an earlier
     // exhausted round (e.g. waking with the network still down) doesn't
@@ -179,7 +185,7 @@ Panel {
     var url = "https://api.open-meteo.com/v1/forecast"
       + "?latitude=" + encodeURIComponent(String(lat))
       + "&longitude=" + encodeURIComponent(String(lon))
-      + "&daily=weather_code,temperature_2m_max,temperature_2m_min"
+      + "&daily=weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset"
       + "&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,weather_code,is_day"
       + "&forecast_days=4"
       + "&timezone=auto"
@@ -319,6 +325,11 @@ Panel {
   // Representative icon for a forecast day: the hourly entry nearest noon.
   function dayIcon(day) {
     return Model.dayIcon(day)
+  }
+
+  // Sun times for one forecast day, or null when the source omitted them.
+  function sunTimesForDay(day) {
+    return Model.sunTimesForDay(day)
   }
 
   function iconForOpenMeteoCode(code) {
@@ -681,6 +692,7 @@ Panel {
             spacing: Style.space(36)
 
             Column {
+              id: feelsCol
               spacing: Style.space(5)
               Text {
                 text: "FEELS"
@@ -699,6 +711,7 @@ Panel {
             }
 
             Column {
+              id: windCol
               spacing: Style.space(5)
               Text {
                 text: "WIND"
@@ -717,6 +730,7 @@ Panel {
             }
 
             Column {
+              id: humidCol
               spacing: Style.space(5)
               Text {
                 text: "HUMID"
@@ -728,6 +742,55 @@ Panel {
               Text {
                 textFormat: Text.PlainText
                 text: root.reportHumidity
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.title
+              }
+            }
+          }
+
+          // Sun times keep their own row (y untouched) but slide horizontally
+          // so each value centers between the two stats columns above it.
+          Item {
+            id: sunStats
+            visible: root.reportSunrise !== "" || root.reportSunset !== ""
+            width: weatherStats.implicitWidth
+            height: Math.max(sunriseCol.height, sunsetCol.height)
+
+            Column {
+              id: sunriseCol
+              x: (feelsCol.x + feelsCol.width / 2 + windCol.x + windCol.width / 2) / 2 - width / 2
+              spacing: Style.space(5)
+              Text {
+                text: "SUNRISE"
+                color: Qt.darker(root.bar.foreground, 1.5)
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.bodySmall
+                font.letterSpacing: 1
+              }
+              Text {
+                textFormat: Text.PlainText
+                text: root.reportSunrise || "—"
+                color: root.bar.foreground
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.title
+              }
+            }
+
+            Column {
+              id: sunsetCol
+              x: (windCol.x + windCol.width / 2 + humidCol.x + humidCol.width / 2) / 2 - width / 2
+              spacing: Style.space(5)
+              Text {
+                text: "SUNSET"
+                color: Qt.darker(root.bar.foreground, 1.5)
+                font.family: root.bar.fontFamily
+                font.pixelSize: Style.font.bodySmall
+                font.letterSpacing: 1
+              }
+              Text {
+                textFormat: Text.PlainText
+                text: root.reportSunset || "—"
                 color: root.bar.foreground
                 font.family: root.bar.fontFamily
                 font.pixelSize: Style.font.title
@@ -827,6 +890,26 @@ Panel {
               required property var modelData
               required property int index
               spacing: Style.space(10)
+
+              // Sunrise/sunset for this forecast day, e.g. "Sunrise 05:36 · Sunset 18:47".
+              property string sunTooltipText: {
+                var sun = root.sunTimesForDay(modelData)
+                if (!sun) return ""
+                var parts = []
+                if (sun.sunrise) parts.push("Sunrise " + sun.sunrise)
+                if (sun.sunset) parts.push("Sunset " + sun.sunset)
+                return parts.join(" · ")
+              }
+
+              HoverHandler {
+                id: forecastDayHover
+                cursorShape: Qt.ArrowCursor
+              }
+              PanelToolTip {
+                visible: forecastDayHover.hovered && sunTooltipText !== ""
+                text: sunTooltipText
+                fontFamily: root.bar.fontFamily
+              }
 
               Text {
                 textFormat: Text.PlainText

--- a/test/acceptance.d/panels-test.sh
+++ b/test/acceptance.d/panels-test.sh
@@ -55,6 +55,7 @@ omarchy-shell shell summon omarchy.weather >/dev/null
 wait_until "weather panel opens" 15 layer_present "omarchy-keyboard-panel"
 wait_until "weather location is visible" 30 screen_contains "SAN FRANCISCO"
 wait_until "weather details are visible" 30 screen_contains "WIND"
+wait_until "weather sun times are visible" 30 screen_contains "SUNRISE"
 screenshot "success-panel-weather"
 omarchy-shell shell hide omarchy.weather >/dev/null
 wait_until "weather panel closes" 15 layer_absent "omarchy-keyboard-panel"

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -85,6 +85,76 @@ assertDeepEqual(
   'weather builds future Open-Meteo forecast days'
 )
 
+const openMeteoWithSun = {
+  daily: {
+    time: ['2026-05-25', '2026-05-26'],
+    temperature_2m_max: [20.1, 21.6],
+    temperature_2m_min: [12.2, 13.1],
+    weather_code: [0, 63],
+    sunrise: ['2026-05-25T05:36', '2026-05-26T05:35'],
+    sunset: ['2026-05-25T18:47', '2026-05-26T18:48']
+  }
+}
+assertDeepEqual(
+  weather.openMeteoForecastDays(openMeteoWithSun, '2026-05-25')[0],
+  {
+    date: '2026-05-26',
+    maxtempC: '22',
+    mintempC: '13',
+    maxtempF: '71',
+    mintempF: '56',
+    openMeteoWeatherCode: 63,
+    sunrise: '05:35',
+    sunset: '18:48'
+  },
+  'weather carries local sunrise/sunset on Open-Meteo forecast days'
+)
+
+assertEqual(weather.timeOnly('2026-05-25T05:36'), '05:36', 'weather strips open-meteo ISO timestamps to a clock time')
+assertEqual(weather.timeOnly('09:05 AM'), '09:05', 'weather normalizes wttr AM times to 24h')
+assertEqual(weather.timeOnly('05:36 PM'), '17:36', 'weather normalizes wttr PM times to 24h')
+assertEqual(weather.timeOnly('12:15 AM'), '00:15', 'weather maps wttr midnight to 00:xx')
+assertEqual(weather.timeOnly('12:30 PM'), '12:30', 'weather keeps wttr noon at 12:xx')
+assertEqual(weather.timeOnly('nope'), 'nope', 'weather leaves unparseable times alone')
+
+assertDeepEqual(
+  weather.sunTimes(openMeteoWithSun, null, '2026-05-25'),
+  { sunrise: '05:36', sunset: '18:47' },
+  'weather normalizes open-meteo sunrise/sunset to local clock times'
+)
+const sunTodayAtEnd = {
+  daily: {
+    time: ['2026-05-26', '2026-05-27', '2026-05-25'],
+    temperature_2m_max: [21.6, 18.2, 20.1],
+    temperature_2m_min: [13.1, 10.8, 12.2],
+    weather_code: [63, 95, 0],
+    sunrise: ['2026-05-26T05:35', '2026-05-27T05:34', '2026-05-25T05:36'],
+    sunset: ['2026-05-26T18:48', '2026-05-27T18:49', '2026-05-25T18:47']
+  }
+}
+assertDeepEqual(
+  weather.sunTimes(sunTodayAtEnd, null, '2026-05-25'),
+  { sunrise: '05:36', sunset: '18:47' },
+  'weather picks the daily entry that matches today, not the first one'
+)
+assertEqual(weather.sunTimes({}, null, '2026-05-25'), null, 'weather returns no sun times without data')
+assertDeepEqual(
+  weather.sunTimes({}, { weather: [{ astronomy: [{ sunrise: '05:36 AM', sunset: '06:47 PM' }] }] }, '2026-05-25'),
+  { sunrise: '05:36', sunset: '18:47' },
+  'weather falls back to wttr astronomy for today'
+)
+assertEqual(weather.sunTimesForDay(null), null, 'weather returns no sun times for a missing forecast day')
+assertDeepEqual(
+  weather.sunTimesForDay({ date: '2026-05-26', sunrise: '05:35', sunset: '18:48' }),
+  { sunrise: '05:35', sunset: '18:48' },
+  'weather reads normalized sun times off Open-Meteo forecast days'
+)
+assertDeepEqual(
+  weather.sunTimesForDay({ date: '2026-05-26', astronomy: [{ sunrise: '05:35 AM', sunset: '06:48 PM' }] }),
+  { sunrise: '05:35', sunset: '18:48' },
+  'weather normalizes sun times off wttr forecast days too'
+)
+
 assertDeepEqual(
   weather.openMeteoCurrentCondition({ current: { temperature_2m: 21.4, apparent_temperature: 19.8, wind_speed_10m: 14.3, relative_humidity_2m: 63 } }),
   { temp_C: '21', temp_F: '71', FeelsLikeC: '20', FeelsLikeF: '68', windspeedKmph: '14', windspeedMiles: '9', humidity: '63' },
@@ -136,6 +206,49 @@ assert(
 assert(
   panelSource.includes('text: root.label || "—"'),
   'weather hero and bar use the same resolved icon'
+)
+assert(
+  panelSource.includes('&daily=weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset'),
+  'weather requests sunrise and sunset from open-meteo daily'
+)
+assert(
+  panelSource.includes('text: "SUNRISE"') && panelSource.includes('text: "SUNSET"'),
+  'weather hero shows sunrise and sunset columns'
+)
+assert(
+  (function() {
+    var sunriseStart = panelSource.indexOf('id: sunriseCol')
+    var sunsetStart = panelSource.indexOf('id: sunsetCol')
+    if (sunriseStart < 0 || sunsetStart < 0 || sunsetStart < sunriseStart) return false
+
+    // Extract only the x: bindings: the sunrise column's block runs up to the
+    // sunset column's declaration, the sunset column's block runs to the end
+    // of the hero section. Tolerant to reformatting of the arithmetic, but
+    // each binding must still name its two adjacent stats columns.
+    var sunriseBlock = panelSource.slice(sunriseStart, sunsetStart)
+    var sunsetBlock = panelSource.slice(sunsetStart, panelSource.indexOf('// ---- Geocoding suggestions'))
+
+    function xBinding(block) {
+      var lines = String(block || '').split('\n')
+      for (var i = 0; i < lines.length; i++)
+        if (/^\s*x\s*:/.test(lines[i])) return lines[i]
+      return ''
+    }
+
+    var sunriseX = xBinding(sunriseBlock)
+    var sunsetX = xBinding(sunsetBlock)
+    return sunriseX.includes('feelsCol') && sunriseX.includes('windCol')
+      && sunsetX.includes('windCol') && sunsetX.includes('humidCol')
+  })(),
+  'weather sun times keep their own row and center between the adjacent stats columns'
+)
+assert(
+  panelSource.includes('PanelToolTip {') && panelSource.includes('sunTooltipText'),
+  'weather forecast days expose a hover tooltip with sun times'
+)
+assert(
+  panelSource.includes('parts.push("Sunrise " + sun.sunrise)') && panelSource.includes('parts.push("Sunset " + sun.sunset)'),
+  'weather forecast day tooltips label sunrise and sunset times'
 )
 assert(
   panelSource.includes('onReturnRequested: root.startEditingLocation()'),


### PR DESCRIPTION
The weather panel now shows today's sunrise and sunset, and hovering a forecast day shows that day's own times (for example `Sunrise 05:35 · Sunset 18:48`).

The sun times get their own row under the FEELS/WIND/HUMID stats. I only moved them sideways: SUNRISE centered between the FEELS and WIND columns, SUNSET between WIND and HUMID. That row is new, so the hero grows a bit to fit it and the panel resizes itself; the temperature and the stats columns keep their relative positions.

Times are local, from Open-Meteo's daily sunrise/sunset, falling back to wttr.in's per-day astronomy only when the Open-Meteo request fails (for example a network timeout) — even with an auto-detected location, the panel derives coordinates from wttr and calls Open-Meteo the same way. Times are always normalized to 24h regardless of source: Open-Meteo's ISO timestamps ("2026-09-07T18:47") become "18:47" and wttr's display times ("05:36 AM") become "05:36". The entry is matched by date against today, not assumed to be the first one, so right after midnight the panel doesn't keep showing yesterday's times. Open-Meteo forecast days now carry normalized sunrise/sunset fields too, so anything that consumes them gets one format.

<img width="640" height="327" alt="screenshot-2026-09-07_22-49-22" src="https://github.com/user-attachments/assets/f0ebfb03-d2bf-40eb-9041-1af18dd55676" />

## Why

I want to know when the sun goes down so I can go for a walk around then, and when it comes up so I know when to get up and train.

## Implementation notes

- `Model.js`: `timeOnly()` turns both sources' times into a 24h clock time: Open-Meteo's ISO timestamps ("2026-09-07T18:47") become "18:47" and wttr's display times ("05:36 AM") become "05:36". `sunTimes()` locates today's entry by matching `daily.time` against today's date (falling back to the first entry when there's no match), and both `sunTimes()` and `sunTimesForDay()` pick whichever source has data.
- `Panel.qml`: the daily request now asks for `sunrise,sunset`. The sun row takes each value's x from the centers of the stats columns, so it re-centers on its own when the panel reflows. The day-row tooltip reuses `PanelToolTip` with a `HoverHandler` and the panel's font family, which adds nothing to the Row layout.

## Tests

- `test/shell.d/weather-test.sh`: unit tests for the helpers (including the 24h AM/PM normalization and the today-date matching), forecast-day parsing, and source assertions for the panel (including the centering check). 76 asserts, all green.
- `test/acceptance.d/panels-test.sh`: waits for the sun times in the weather panel before its success screenshot.
- `qml-text-format-test.sh`: passes.
- Also ran it live: hero, sun row, and forecast days render without QML warnings, and the sun times land between the right columns without touching the temperature.
