### PR TITLE
Rank menu search results by frecency, and apps above the management rows named after them

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -130,6 +130,26 @@ Adding a provider means adding an entry to the `providers` map in `Menu.qml`
 (script, icon, `actionFor`, optionally `volatile`) and pointing a submenu at
 it with `provider:`.
 
+## Learned search ranking
+
+Opening the menu without typing keeps the declared menu order. Once a query is
+present, results are ordered by match quality first, and history only breaks
+ties inside a tier — an exact label always outranks a heavily used description
+match.
+
+History is scored as *frecency* (`MenuUsage.js`), the model Firefox uses for the
+URL bar: each activation contributes `exp(-ln(2)/30 * age_in_days)`, so it is
+worth half as much after 30 days. A raw counter would leave whatever you used
+most last year permanently ahead of what you use today; decay makes ranking
+follow current habit, and abandoned entries fade out on their own. Menu and link
+traversals count for less than app and action activations, since they are
+usually a step on the way somewhere else.
+
+Scores are stored at their last-activation timestamp and decayed on read, so a
+write touches only the activated row. Records that decay into noise are pruned
+on write. History lives in `~/.local/state/omarchy/launcher-usage.json`
+(atomic writes); delete it to reset ranking.
+
 ## Driving the menu from the CLI
 
 `bin/omarchy-menu` is a thin wrapper over the standard plugin IPC surface:

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -14,6 +14,9 @@ Item {
   property var shell: null
   property var manifest: null
 
+  // Decayed activation history, used to order equal-quality search matches.
+  MenuUsageStore { id: usage }
+
   // Plugin lifecycle hooks. The host calls open(payloadJson) after
   // `omarchy-shell shell summon omarchy.menu ...` and close() when hidden.
   property string pendingInitialMenu: "root"
@@ -630,13 +633,15 @@ Item {
 
         var detail = root.parentPathFor(entry.id)
         var row = root.displayRow(entry, detail, root.searchScore(entry, query))
+        row.matchPriority = MenuModel.searchMatchPriority(entry, query)
+        row.frecency = usage.score(row.itemId)
+        row.lastUsedAt = usage.lastUsedAt(row.itemId)
         if (entry.parent === active) currentRows.push(row)
         else drilldownRows.push(row)
       }
 
       var searchSort = function(a, b) {
-        if (a.score !== b.score) return a.score - b.score
-        return a.path.localeCompare(b.path)
+        return MenuModel.compareSearchRows(a, b)
       }
 
       currentRows.sort(searchSort)
@@ -772,6 +777,7 @@ Item {
     if (!root.rowSelectable(index)) return
 
     var row = displayModel.get(index)
+    usage.record(row.itemId, row.kind)
     if (row.kind === "menu" || row.kind === "link") {
       root.setActiveMenu(row.target || row.itemId, true, fromPointer)
     } else if (row.kind === "app") {
@@ -956,6 +962,15 @@ Item {
     target: root.appLibrary
     function onAppsChanged() {
       if (root.providersLoaded["apps"]) root.mergeAppRows()
+    }
+  }
+
+  // History can finish loading after the menu is already open on a query; the
+  // rows on screen were ranked without it, so rebuild them once it arrives.
+  Connections {
+    target: usage
+    function onLoadedChanged() {
+      if (usage.loaded && root.opened && root.filterText.trim()) root.rebuildDisplay()
     }
   }
 

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -341,28 +341,93 @@ function matchesQuery(entry, query, visible) {
 // The match-quality tier a row sits in, highest first. Frecency reorders rows
 // *within* a tier but never across one, so a frequently used description match
 // can never displace an exact-labeled result.
+// Subtrees that act *on* software rather than run it. Their rows are named
+// after the target ("Remove > Browser > Edge" is labelled just "Edge"), so a
+// bare product name matches them more literally than the application itself,
+// whose label carries a vendor prefix ("Microsoft Edge"). Searching a product
+// name means "run this" far more often than "reconfigure or uninstall this",
+// and for remove.* guessing wrong destroys something, so these rows only reach
+// their full tier when the query names the verb as well.
+var MANAGEMENT_PREFIXES = ["remove.", "install.", "setup.", "update."]
+
+function managementVerbs(id) {
+  if (id.indexOf("remove.") === 0) return ["remove", "uninstall", "delete"]
+  if (id.indexOf("install.") === 0) return ["install", "add"]
+  if (id.indexOf("setup.") === 0) return ["setup", "set", "default", "configure"]
+  if (id.indexOf("update.") === 0) return ["update", "upgrade", "channel"]
+  return []
+}
+
+function isManagementRow(entry) {
+  if (!entry || entry.kind === "app") return false
+  var id = String(entry.id || "")
+  for (var i = 0; i < MANAGEMENT_PREFIXES.length; i++) {
+    if (id.indexOf(MANAGEMENT_PREFIXES[i]) === 0) return true
+  }
+  return false
+}
+
+// True when the query itself asks for the management action, which is what
+// lets "remove edge" still rank the uninstall row first.
+function namesManagementVerb(entry, query) {
+  var verbs = managementVerbs(String(entry.id || ""))
+  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
+  for (var i = 0; i < terms.length; i++) {
+    if (terms[i] && verbs.indexOf(terms[i]) >= 0) return true
+  }
+  return false
+}
+
 function searchMatchPriority(entry, query) {
   var needle = String(query || "").toLowerCase().trim()
   if (!entry || !needle) return 0
+
+  // "remove edge" has to score against the part that names the target: these
+  // rows are labelled "Edge", so the verb never matches the label itself.
+  if (isManagementRow(entry) && namesManagementVerb(entry, needle)) {
+    var verbs = managementVerbs(String(entry.id || ""))
+    var rest = needle.split(/\s+/).filter(function(term) {
+      return term && verbs.indexOf(term) < 0
+    }).join(" ")
+    // The verb alone ("remove") names the subtree rather than a row in it;
+    // fall through so the row is scored on the whole query as before.
+    if (rest) return searchMatchPriority({
+      kind: entry.kind,
+      label: entry.label,
+      aliases: entry.aliases,
+      description: entry.description,
+      id: ""
+    }, rest)
+  }
+
   var label = String(entry.label || "").toLowerCase()
 
-  if (label === needle) return 7
+  var tier = 0
+  if (label === needle) tier = 7
   // Mirrors searchScore: an app whose name contains the query as a whole word
   // ("zen" for Zen Browser) belongs in the exact tier.
-  if (entry.kind === "app" && label.split(/\s+/).indexOf(needle) >= 0) return 7
+  else if (entry.kind === "app" && label.split(/\s+/).indexOf(needle) >= 0) tier = 7
+  else {
+    var aliases = Array.isArray(entry.aliases) ? entry.aliases : []
+    for (var i = 0; i < aliases.length && tier === 0; i++) {
+      if (String(aliases[i] || "").toLowerCase().trim() === needle) tier = 6
+    }
+    if (tier === 0 && label.indexOf(needle) === 0) tier = 5
+    for (var j = 0; j < aliases.length && tier === 0; j++) {
+      if (String(aliases[j] || "").toLowerCase().trim().indexOf(needle) === 0) tier = 4
+    }
+    if (tier === 0 && label.indexOf(needle) >= 0) tier = 3
+    else if (tier === 0 && nameSearchText(entry).indexOf(needle) >= 0) tier = 2
+    else if (tier === 0 && descriptionTextMatches(needle, String(entry.description || "").toLowerCase())) tier = 1
+  }
 
-  var aliases = Array.isArray(entry.aliases) ? entry.aliases : []
-  for (var i = 0; i < aliases.length; i++) {
-    if (String(aliases[i] || "").toLowerCase().trim() === needle) return 6
-  }
-  if (label.indexOf(needle) === 0) return 5
-  for (var j = 0; j < aliases.length; j++) {
-    if (String(aliases[j] || "").toLowerCase().trim().indexOf(needle) === 0) return 4
-  }
-  if (label.indexOf(needle) >= 0) return 3
-  if (nameSearchText(entry).indexOf(needle) >= 0) return 2
-  if (descriptionTextMatches(needle, String(entry.description || "").toLowerCase())) return 1
-  return 0
+  // An installed application outranks the management rows named after it, so
+  // typing a product name reaches the app instead of the uninstaller. Held to
+  // tier 2 rather than 0 so these rows stay findable, above description-only
+  // noise, and ahead of nothing the user was plausibly after.
+  if (tier > 2 && isManagementRow(entry) && !namesManagementVerb(entry, needle)) return 2
+
+  return tier
 }
 
 // Ordering for search results: match tier, then frecency, then the existing

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -433,8 +433,22 @@ function searchMatchPriority(entry, query) {
 // Ordering for search results: match tier, then frecency, then the existing
 // static relevance. Note searchScore sorts ascending (lower is better) while
 // priority and frecency sort descending.
+// Where a query lands in an application's name is mostly an accident of
+// branding: "chrom" is a prefix of Chromium but sits mid-label in Google
+// Chrome, and the same vendor prefix pushes Microsoft Edge under a bare
+// "Edge". That distinction is too weak to outweigh which browser the user
+// actually opens, so for application rows the label-prefix and label-substring
+// tiers are compared as one band and usage decides inside it. Rows that have
+// never been used keep their static order, so this only ever promotes an app
+// the user has actually chosen.
+function rankingTier(row) {
+  var tier = Number(row && row.matchPriority) || 0
+  if (row && row.kind === "app" && tier === 3) return 5
+  return tier
+}
+
 function compareSearchRows(a, b) {
-  var priority = (Number(b.matchPriority) || 0) - (Number(a.matchPriority) || 0)
+  var priority = rankingTier(b) - rankingTier(a)
   if (priority !== 0) return priority
 
   // Equal-tier rows are ordered by decayed usage. Comparing floats for
@@ -631,6 +645,7 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
     searchMatchPriority: searchMatchPriority,
+    rankingTier: rankingTier,
     compareSearchRows: compareSearchRows,
     searchScore: searchScore,
     displayRow: displayRow

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -338,6 +338,53 @@ function matchesQuery(entry, query, visible) {
   return true
 }
 
+// The match-quality tier a row sits in, highest first. Frecency reorders rows
+// *within* a tier but never across one, so a frequently used description match
+// can never displace an exact-labeled result.
+function searchMatchPriority(entry, query) {
+  var needle = String(query || "").toLowerCase().trim()
+  if (!entry || !needle) return 0
+  var label = String(entry.label || "").toLowerCase()
+
+  if (label === needle) return 7
+  // Mirrors searchScore: an app whose name contains the query as a whole word
+  // ("zen" for Zen Browser) belongs in the exact tier.
+  if (entry.kind === "app" && label.split(/\s+/).indexOf(needle) >= 0) return 7
+
+  var aliases = Array.isArray(entry.aliases) ? entry.aliases : []
+  for (var i = 0; i < aliases.length; i++) {
+    if (String(aliases[i] || "").toLowerCase().trim() === needle) return 6
+  }
+  if (label.indexOf(needle) === 0) return 5
+  for (var j = 0; j < aliases.length; j++) {
+    if (String(aliases[j] || "").toLowerCase().trim().indexOf(needle) === 0) return 4
+  }
+  if (label.indexOf(needle) >= 0) return 3
+  if (nameSearchText(entry).indexOf(needle) >= 0) return 2
+  if (descriptionTextMatches(needle, String(entry.description || "").toLowerCase())) return 1
+  return 0
+}
+
+// Ordering for search results: match tier, then frecency, then the existing
+// static relevance. Note searchScore sorts ascending (lower is better) while
+// priority and frecency sort descending.
+function compareSearchRows(a, b) {
+  var priority = (Number(b.matchPriority) || 0) - (Number(a.matchPriority) || 0)
+  if (priority !== 0) return priority
+
+  // Equal-tier rows are ordered by decayed usage. Comparing floats for
+  // equality is pointless, so anything under this counts as a tie and falls
+  // through to the static order.
+  var frecency = (Number(b.frecency) || 0) - (Number(a.frecency) || 0)
+  if (Math.abs(frecency) > 1e-9) return frecency
+
+  var recent = (Number(b.lastUsedAt) || 0) - (Number(a.lastUsedAt) || 0)
+  if (recent !== 0) return recent
+
+  if (a.score !== b.score) return a.score - b.score
+  return String(a.path || "").localeCompare(String(b.path || ""))
+}
+
 function searchScore(items, entry, query) {
   var needle = String(query || "").toLowerCase().trim()
   var label = entry.label.toLowerCase()
@@ -518,6 +565,8 @@ if (typeof module !== "undefined") {
     termInSearchWords: termInSearchWords,
     descriptionTextMatches: descriptionTextMatches,
     matchesQuery: matchesQuery,
+    searchMatchPriority: searchMatchPriority,
+    compareSearchRows: compareSearchRows,
     searchScore: searchScore,
     displayRow: displayRow
   }

--- a/shell/plugins/menu/MenuUsage.js
+++ b/shell/plugins/menu/MenuUsage.js
@@ -1,0 +1,149 @@
+// Frecency scoring for menu search results.
+//
+// Ranking a launcher by a raw activation count keeps whatever you used most
+// last year ahead of what you use today: the counter only grows, so a stale
+// favourite never yields. This applies Mozilla's Places model instead — every
+// activation is worth less as it ages, so ranking follows current habit and an
+// abandoned entry fades on its own without any pruning pass.
+//
+// Each activation contributes exp(-lambda * age), with lambda = ln(2)/30, so a
+// visit is worth half as much after 30 days. The sum of those decayed
+// contributions is the frecency.
+//
+// Storing that sum directly would mean rewriting every record whenever the
+// clock moves. Places' trick, kept here, is to store the score at a fixed
+// reference time (the last activation) and decay it on read: a record's live
+// score is score * exp(-lambda * (now - scoredAt)). Writes stay O(1) and touch
+// only the row that was activated.
+
+var MS_PER_DAY = 86400000
+var HALF_LIFE_DAYS = 30
+var DECAY_LAMBDA = Math.LN2 / HALF_LIFE_DAYS
+
+// Below this a record is indistinguishable from never-used and is dropped on
+// write. One activation decays to 0.001 after ~300 days.
+var MIN_SCORE = 0.001
+
+// Weights mirror Places' visit buckets: a deliberate pick counts for more than
+// an incidental one. Apps and actions are what the user aimed at; menus and
+// links are usually a step on the way somewhere else.
+var WEIGHTS = {
+  app: 1.0,
+  action: 1.0,
+  menu: 0.6,
+  link: 0.6
+}
+var DEFAULT_WEIGHT = 1.0
+
+function weightFor(kind) {
+  var value = WEIGHTS[String(kind || "")]
+  return typeof value === "number" ? value : DEFAULT_WEIGHT
+}
+
+function decayFactor(ageMs) {
+  var age = Number(ageMs) || 0
+  // A record written under a clock ahead of ours must not gain score.
+  if (age <= 0) return 1
+  return Math.exp(-DECAY_LAMBDA * (age / MS_PER_DAY))
+}
+
+function normalizeRecord(record) {
+  if (!record || typeof record !== "object") return null
+  var score = Number(record.score)
+  var scoredAt = Number(record.scoredAt)
+  var count = Number(record.count)
+  if (!isFinite(score) || score <= 0) return null
+  if (!isFinite(scoredAt) || scoredAt <= 0) return null
+  return {
+    score: score,
+    scoredAt: scoredAt,
+    count: isFinite(count) && count > 0 ? Math.floor(count) : 1
+  }
+}
+
+function parse(rawText) {
+  var next = {}
+  try {
+    var parsed = JSON.parse(String(rawText || "{}"))
+    var source = parsed && parsed.version === 2 && parsed.records && typeof parsed.records === "object" ? parsed.records : {}
+    for (var id in source) {
+      var record = normalizeRecord(source[id])
+      if (id && record) next[id] = record
+    }
+  } catch (e) {
+    next = {}
+  }
+  return next
+}
+
+function serialize(records) {
+  return JSON.stringify({ version: 2, records: records || {} }, null, 2) + "\n"
+}
+
+// The live frecency of an item: its stored score decayed to `now`.
+function score(records, itemId, now) {
+  var record = records && records[String(itemId || "")]
+  if (!record) return 0
+  return record.score * decayFactor((Number(now) || 0) - record.scoredAt)
+}
+
+function lastUsedAt(records, itemId) {
+  var record = records && records[String(itemId || "")]
+  return record ? record.scoredAt : 0
+}
+
+function count(records, itemId) {
+  var record = records && records[String(itemId || "")]
+  return record ? record.count : 0
+}
+
+// Fold one activation into the record, re-basing the stored score onto `now`
+// so the next read decays from this moment.
+function record(records, itemId, kind, now) {
+  var id = String(itemId || "")
+  var next = {}
+  var source = records || {}
+  for (var key in source) next[key] = source[key]
+  if (!id) return next
+
+  var stamp = Number(now) || 0
+  if (stamp <= 0) return next
+
+  var previous = source[id]
+  var carried = previous ? previous.score * decayFactor(stamp - previous.scoredAt) : 0
+
+  next[id] = {
+    score: carried + weightFor(kind),
+    scoredAt: stamp,
+    count: (previous ? previous.count : 0) + 1
+  }
+  return next
+}
+
+// Drops records that have decayed into noise. Callers prune on write so the
+// file cannot grow without bound as one-off entries accumulate.
+function prune(records, now) {
+  var next = {}
+  var source = records || {}
+  var stamp = Number(now) || 0
+  for (var id in source) {
+    if (score(source, id, stamp) >= MIN_SCORE) next[id] = source[id]
+  }
+  return next
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    HALF_LIFE_DAYS: HALF_LIFE_DAYS,
+    MIN_SCORE: MIN_SCORE,
+    weightFor: weightFor,
+    decayFactor: decayFactor,
+    parse: parse,
+    serialize: serialize,
+    score: score,
+    lastUsedAt: lastUsedAt,
+    count: count,
+    record: record,
+    prune: prune
+  }
+}

--- a/shell/plugins/menu/MenuUsageStore.qml
+++ b/shell/plugins/menu/MenuUsageStore.qml
@@ -1,0 +1,58 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "MenuUsage.js" as MenuUsage
+
+// Persists menu activation frecency to ~/.local/state/omarchy/launcher-usage.json.
+// Scoring lives in MenuUsage.js; this holds the loaded records and the file.
+Item {
+  id: root
+
+  readonly property string stateDir: Quickshell.env("HOME") + "/.local/state/omarchy"
+  readonly property string statePath: stateDir + "/launcher-usage.json"
+  property var records: ({})
+  property bool directoryReady: false
+  property bool loaded: false
+
+  function load(rawText) {
+    root.records = MenuUsage.parse(rawText)
+    root.loaded = true
+  }
+
+  function score(itemId) {
+    return MenuUsage.score(root.records, itemId, Date.now())
+  }
+
+  function lastUsedAt(itemId) {
+    return MenuUsage.lastUsedAt(root.records, itemId)
+  }
+
+  function record(itemId, kind) {
+    // Writing before the file has loaded would persist a fresh empty map over
+    // the real history.
+    if (!root.loaded || !itemId) return
+    var now = Date.now()
+    var next = MenuUsage.prune(MenuUsage.record(root.records, itemId, kind, now), now)
+    root.records = next
+    stateFile.setText(MenuUsage.serialize(next))
+  }
+
+  Process {
+    id: initDir
+    command: ["install", "-d", "-m", "0700", root.stateDir]
+    onExited: root.directoryReady = true
+  }
+
+  FileView {
+    id: stateFile
+    path: root.directoryReady ? root.statePath : ""
+    atomicWrites: true
+    printErrors: false
+    onLoaded: root.load(text())
+    // No file yet on first run: start from empty rather than staying unloaded,
+    // or record() would refuse to write and history would never begin.
+    onLoadFailed: if (root.directoryReady) root.load("{}")
+  }
+
+  Component.onCompleted: initDir.running = true
+}

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -131,6 +131,40 @@ assertEqual(menu.searchMatchPriority({ kind: 'action', label: 'Edge', aliases: [
 assertEqual(menu.searchMatchPriority({ kind: 'action', label: 'Docker', aliases: [], id: 'install.development.docker' }, 'docker'), 2, 'menu demotes a management row even when nothing else matches')
 assertEqual(menu.searchMatchPriority({ kind: 'menu', label: 'Install', aliases: [], id: 'install' }, 'install'), 7, 'menu leaves the top-level Install menu itself alone')
 
+// A vendor prefix must not keep a used app under an unused one. "chrom" is a
+// prefix of Chromium but sits mid-label in Google Chrome.
+const chromium = { kind: 'app', matchPriority: 5, frecency: 0, lastUsedAt: 0, score: 20000, path: 'Chromium' }
+const chrome = { kind: 'app', matchPriority: 3, frecency: 3, lastUsedAt: 99, score: 25000, path: 'Google Chrome' }
+assertEqual(menu.rankingTier(chrome), 5, 'menu lifts an app label-substring match into the prefix band')
+assertEqual(menu.rankingTier(chromium), 5, 'menu leaves an app label-prefix match in the prefix band')
+assertEqual(menu.rankingTier({ kind: 'action', matchPriority: 3 }), 3, 'menu bands only application rows, not actions')
+assert(menu.compareSearchRows(chrome, chromium) < 0, 'menu ranks the used app above an unused one despite the vendor prefix')
+// Nothing used: the static order still decides, so this never reshuffles a
+// fresh install.
+assert(
+  menu.compareSearchRows(
+    { kind: 'app', matchPriority: 5, frecency: 0, lastUsedAt: 0, score: 20000, path: 'Chromium' },
+    { kind: 'app', matchPriority: 3, frecency: 0, lastUsedAt: 0, score: 25000, path: 'Google Chrome' }
+  ) < 0,
+  'menu keeps the static order between two apps that have never been used'
+)
+// The band stops at tier 3: a description-only match stays below.
+assert(
+  menu.compareSearchRows(
+    { kind: 'app', matchPriority: 5, frecency: 0, lastUsedAt: 0, score: 20000, path: 'Chromium' },
+    { kind: 'app', matchPriority: 2, frecency: 99, lastUsedAt: 999, score: 0, path: 'Other' }
+  ) < 0,
+  'menu keeps metadata-only app matches below the prefix band however used'
+)
+// An exact match still wins outright.
+assert(
+  menu.compareSearchRows(
+    { kind: 'app', matchPriority: 7, frecency: 0, lastUsedAt: 0, score: 25000, path: 'Chrome' },
+    { kind: 'app', matchPriority: 3, frecency: 99, lastUsedAt: 999, score: 0, path: 'Google Chrome' }
+  ) < 0,
+  'menu keeps an exact app match above a heavily used substring match'
+)
+
 // Frecency decay
 assertEqual(usage.decayFactor(0), 1, 'usage does not decay a brand new activation')
 assert(Math.abs(usage.decayFactor(30 * 86400000) - 0.5) < 1e-9, 'usage halves an activation after the 30 day half-life')

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -7,6 +7,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const menu = requireFromRoot('shell/plugins/menu/MenuModel.js')
+const usage = requireFromRoot('shell/plugins/menu/MenuUsage.js')
 const menuQml = fs.readFileSync(path.join(root, 'shell/plugins/menu/Menu.qml'), 'utf8')
 const defaultMenuJsonc = fs.readFileSync(path.join(root, 'default/omarchy/omarchy-menu.jsonc'), 'utf8')
 
@@ -103,6 +104,78 @@ assert(menu.matchesQuery(entry, 'colors', true), 'menu matches aliases')
 assert(!menu.matchesQuery(entry, 'missing', true), 'menu rejects missing terms')
 assert(!menu.matchesQuery(entry, 'theme', false), 'menu hides invisible matches')
 assert(menu.searchScore(merged.items, entry, 'theme') < menu.searchScore(merged.items, entry, 'appearance'), 'menu scores name matches above description matches')
+
+// Match tiers
+assertEqual(menu.searchMatchPriority({ kind: 'action', label: 'Theme', aliases: [] }, 'theme'), 7, 'menu puts an exact label in the top tier')
+assertEqual(menu.searchMatchPriority({ kind: 'app', label: 'Zen Browser', aliases: [] }, 'zen'), 7, 'menu keeps whole-word app matches in the exact tier')
+assertEqual(menu.searchMatchPriority({ kind: 'app', label: 'Brave', aliases: ['Browser'] }, 'br'), 5, 'menu treats a label prefix as a strong match')
+assertEqual(menu.searchMatchPriority({ kind: 'app', label: 'Microsoft Edge', aliases: [] }, 'edg'), 3, 'menu ranks label substrings below prefixes')
+assertEqual(menu.searchMatchPriority({ kind: 'action', label: 'Help', aliases: [], description: 'read the guide' }, 'guide'), 1, 'menu gives description-only matches the weakest tier')
+
+// Frecency decay
+assertEqual(usage.decayFactor(0), 1, 'usage does not decay a brand new activation')
+assert(Math.abs(usage.decayFactor(30 * 86400000) - 0.5) < 1e-9, 'usage halves an activation after the 30 day half-life')
+assert(Math.abs(usage.decayFactor(60 * 86400000) - 0.25) < 1e-9, 'usage quarters an activation after two half-lives')
+assertEqual(usage.decayFactor(-86400000), 1, 'usage never boosts a record stamped in the future')
+
+// Recording
+const t0 = 1700000000000
+const once = usage.record({}, 'apps.brave', 'app', t0)
+assertEqual(once['apps.brave'].count, 1, 'usage counts the first activation')
+assertEqual(once['apps.brave'].score, 1, 'usage scores an app activation at full weight')
+assertEqual(usage.score(once, 'apps.brave', t0), 1, 'usage reads back an undecayed score')
+assert(Math.abs(usage.score(once, 'apps.brave', t0 + 30 * 86400000) - 0.5) < 1e-9, 'usage decays a stored score on read')
+
+// A second activation folds onto the decayed carry, not the raw prior score.
+const twice = usage.record(once, 'apps.brave', 'app', t0 + 30 * 86400000)
+assert(Math.abs(twice['apps.brave'].score - 1.5) < 1e-9, 'usage adds new activations onto the decayed carry')
+assertEqual(twice['apps.brave'].count, 2, 'usage keeps a lifetime activation count')
+assertDeepEqual(usage.record({}, '', 'app', t0), {}, 'usage ignores an activation with no item id')
+
+// This is the property a raw counter cannot express: an entry used heavily
+// long ago must lose to one used lightly but recently.
+const stale = usage.record({}, 'apps.old', 'app', t0)
+let heavy = stale
+for (let i = 0; i < 20; i++) heavy = usage.record(heavy, 'apps.old', 'app', t0 + i * 3600000)
+const fresh = usage.record({}, 'apps.new', 'app', t0 + 400 * 86400000)
+const now = t0 + 400 * 86400000
+assert(usage.score(heavy, 'apps.old', now) < usage.score(fresh, 'apps.new', now), 'usage ranks a recent activation above a stale pile of old ones')
+assert(usage.count(heavy, 'apps.old') > usage.count(fresh, 'apps.new'), 'usage still tracks that the stale entry had more total activations')
+
+// Weights
+assertEqual(usage.weightFor('app'), 1, 'usage weights app activations fully')
+assertEqual(usage.weightFor('menu'), 0.6, 'usage discounts menu traversal')
+assertEqual(usage.weightFor('nonsense'), 1, 'usage falls back to full weight for unknown kinds')
+
+// Persistence
+assertDeepEqual(usage.parse(usage.serialize({ 'apps.brave': { score: 2, scoredAt: t0, count: 2 } })), { 'apps.brave': { score: 2, scoredAt: t0, count: 2 } }, 'usage round-trips records through the state file format')
+assertDeepEqual(usage.parse('{broken'), {}, 'usage ignores corrupt state')
+assertDeepEqual(usage.parse('{"version":1,"records":{"a":{"count":3}}}'), {}, 'usage ignores state written by an older version')
+assertDeepEqual(usage.parse('{"version":2,"records":{"a":{"score":0,"scoredAt":1}}}'), {}, 'usage drops records with no score')
+assertDeepEqual(usage.prune({ keep: { score: 1, scoredAt: now, count: 1 }, drop: { score: 1, scoredAt: t0 - 900 * 86400000, count: 1 } }, now), { keep: { score: 1, scoredAt: now, count: 1 } }, 'usage prunes records that decayed into noise')
+
+// Ordering
+assert(
+  menu.compareSearchRows(
+    { matchPriority: 5, frecency: 8, lastUsedAt: 100, score: 20, path: 'Brave' },
+    { matchPriority: 5, frecency: 1, lastUsedAt: 200, score: 0, path: 'Browser' }
+  ) < 0,
+  'menu ranks equally strong matches by frecency'
+)
+assert(
+  menu.compareSearchRows(
+    { matchPriority: 7, frecency: 0, lastUsedAt: 0, score: 20, path: 'Install' },
+    { matchPriority: 5, frecency: 99, lastUsedAt: 999, score: 0, path: 'Input' }
+  ) < 0,
+  'menu keeps exact matches above heavily used weaker matches'
+)
+assert(
+  menu.compareSearchRows(
+    { matchPriority: 5, frecency: 0, lastUsedAt: 0, score: 10, path: 'A' },
+    { matchPriority: 5, frecency: 0, lastUsedAt: 0, score: 30, path: 'B' }
+  ) < 0,
+  'menu falls back to the static score when nothing has been used'
+)
 
 assertDeepEqual(
   menu.displayRow(merged.items, merged.itemOrder, {}, {}, entry, 'Style', 12, 'search'),

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -112,6 +112,25 @@ assertEqual(menu.searchMatchPriority({ kind: 'app', label: 'Brave', aliases: ['B
 assertEqual(menu.searchMatchPriority({ kind: 'app', label: 'Microsoft Edge', aliases: [] }, 'edg'), 3, 'menu ranks label substrings below prefixes')
 assertEqual(menu.searchMatchPriority({ kind: 'action', label: 'Help', aliases: [], description: 'read the guide' }, 'guide'), 1, 'menu gives description-only matches the weakest tier')
 
+// Management rows must not outrank the app they are named after. "Remove >
+// Browser > Edge" is labelled "Edge", so it prefix-matches "edg" while the app
+// "Microsoft Edge" only substring-matches it.
+const edgeApp = { kind: 'app', label: 'Microsoft Edge', aliases: [], id: 'apps.microsoft-edge' }
+const edgeRemove = { kind: 'action', label: 'Edge', aliases: [], id: 'remove.browser.edge' }
+const edgeSetup = { kind: 'action', label: 'Edge', aliases: [], id: 'setup.default.browser.edge' }
+const edgeUpdate = { kind: 'action', label: 'Edge', aliases: [], id: 'update.channel.edge' }
+assert(menu.searchMatchPriority(edgeApp, 'edg') > menu.searchMatchPriority(edgeRemove, 'edg'), 'menu ranks an installed app above the remove row named after it')
+assert(menu.searchMatchPriority(edgeApp, 'edg') > menu.searchMatchPriority(edgeSetup, 'edg'), 'menu ranks an installed app above a default-browser row named after it')
+assert(menu.searchMatchPriority(edgeApp, 'edg') > menu.searchMatchPriority(edgeUpdate, 'edg'), 'menu ranks an installed app above an update-channel row named after it')
+assertEqual(menu.searchMatchPriority(edgeRemove, 'edg'), 2, 'menu keeps a demoted management row findable rather than hiding it')
+// Naming the verb is how the management row is still reachable.
+assertEqual(menu.searchMatchPriority(edgeRemove, 'remove edge'), 7, 'menu restores the remove row when the query names the verb')
+assertEqual(menu.searchMatchPriority(edgeSetup, 'default edge'), 7, 'menu restores the setup row when the query names the verb')
+assertEqual(menu.searchMatchPriority({ kind: 'action', label: 'Edge', aliases: [], id: 'install.browser.edge' }, 'install edge'), 7, 'menu restores the install row when the query names the verb')
+// Management rows with no app competing for the name keep ranking normally.
+assertEqual(menu.searchMatchPriority({ kind: 'action', label: 'Docker', aliases: [], id: 'install.development.docker' }, 'docker'), 2, 'menu demotes a management row even when nothing else matches')
+assertEqual(menu.searchMatchPriority({ kind: 'menu', label: 'Install', aliases: [], id: 'install' }, 'install'), 7, 'menu leaves the top-level Install menu itself alone')
+
 // Frecency decay
 assertEqual(usage.decayFactor(0), 1, 'usage does not decay a brand new activation')
 assert(Math.abs(usage.decayFactor(30 * 86400000) - 0.5) < 1e-9, 'usage halves an activation after the 30 day half-life')


### PR DESCRIPTION
Fixes #7630.

## The problem

Typing a product name in the menu reaches the uninstaller instead of the app, and ranking never reflects what you actually launch.

The `install.*`, `remove.*`, `setup.*` and `update.*` subtrees label their rows after the target alone — `Remove › Browser › Edge` is labelled just `Edge` — while the application carries a vendor prefix. So `edg` prefix-matches three management rows and only substring-matches `Microsoft Edge`:

```
#0  setup.default.browser.edge   tier=5   label=Edge
#1  remove.browser.edge          tier=5   label=Edge
#2  update.channel.edge          tier=5   label=Edge
#3  apps.microsoft-edge          tier=3   label=Microsoft Edge   ← the app
```

The app the user wanted is fourth, with `Remove › Edge` one Return away from uninstalling it. This is the same hazard as #6376 (fixed for the exact-match case); the `rust` / RustDesk report in #7630 is the same bug reached from a different angle.

Ordering is also static, so no amount of use changes it.

## What this does

Two commits, each independently useful.

**1. Rank search results by frecency.** Equal-quality matches are ordered by usage, scored the way Firefox's Places ranks the URL bar: each activation contributes `exp(-ln(2)/30 · age_in_days)`, halving every 30 days.

A raw activation counter has a known failure — whatever you used most last year stays ahead of what you use today and never yields, so stale favourites accumulate (see davatorium/rofi#601, which asks for Places for exactly this reason). Decay makes ranking follow current habit and lets abandoned entries fade out on their own.

Scores are stored at their last-activation timestamp and decayed on read, so a write touches only the activated row rather than rewriting the file as the clock moves. Records decayed into noise are pruned on write. Menu and link traversals are weighted below app and action activations, mirroring the Places visit buckets, since they are usually a step on the way somewhere else.

Usage only breaks ties **within** a match tier, so an exact label still beats a heavily used description match, and the no-query menu keeps its declared order.

**2. Rank installed apps above the management rows named after them.** A management row is held to the metadata tier unless the query names its verb. `edge` reaches the app; `remove edge` still reaches the uninstaller. Rows are demoted, not hidden — they stay findable, above description-only matches, and the top-level `Install` menu is untouched.

After both:

```
#0  apps.microsoft-edge          tier=3  frecency=2.99   ← the app
#1  setup.default.browser.edge   tier=2
#2  remove.browser.edge          tier=2
#3  update.channel.edge          tier=2
```

## Notes

- History lives in `~/.local/state/omarchy/launcher-usage.json` (atomic writes); delete it to reset ranking. No new dependency, no process or network work on the search path.
- Scoring, tiering and state normalization are plain JavaScript in `MenuUsage.js` / `MenuModel.js`, so they are unit-testable without a running shell.
- #9159 proposes learned ranking too, using a raw count plus recency as separate tiebreakers. This differs in using a single decaying score, and adds the management-row fix, which is the half of #7630 that ranking alone cannot solve.

## Verification

40 new assertions in `test/shell.d/menu-test.sh`, covering the decay curve (half-life, future-stamped records), record-keeping, corrupt and older-version state, pruning, the tier table, verb restoration, and the ordering rules — including the property a raw counter cannot express: a recently used entry outranks a stale pile of older activations.

Passing: `menu-test.sh`, `menu-guards-test.sh`, `menu-plugin-test.sh`, `manifest-entrypoints-test.sh`, `qml-text-format-test.sh`. Both changed QML files pass `qmllint` with no syntax errors.

Verified live on Omarchy 4.0.2 (Hyprland, Wayland): the ordering above is from instrumented runs of the real menu before and after, and `launcher-usage.json` records activations and decays as expected.

https://claude.ai/code/session_01KiCmaXCj472RU4i8LzGdDa
