### PR TITLE
Open the default agent's web chat with SUPER + SHIFT + A

### DIFF
--- a/bin/omarchy-launch-ai
+++ b/bin/omarchy-launch-ai
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# omarchy:summary=Open the web chat that matches the default coding agent
+# omarchy:examples=omarchy launch ai
+
+# The agent picked with `omarchy default agent` decides which vendor's web chat
+# SUPER + SHIFT + A opens, so the two agent keys stop pointing at different
+# companies. Resolved on every press rather than written down at pick time, so
+# nothing goes stale and users who chose an agent before this existed get the
+# right chat without re-picking.
+agent=$(omarchy-default-agent)
+
+# Only agents whose vendor runs a first-party chat site are mapped. The rest,
+# and an unset default, keep the ChatGPT window the key has always opened;
+# summoning the agent picker from a web app key would be a surprise.
+case "$agent" in
+claude) url="https://claude.ai" ;;
+codex) url="https://chatgpt.com" ;;
+grok) url="https://grok.com" ;;
+agy) url="https://gemini.google.com" ;;
+copilot) url="https://github.com/copilot" ;;
+muse) url="https://www.meta.ai" ;;
+*) url="https://chatgpt.com" ;;
+esac
+
+exec omarchy-launch-webapp "$url"

--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -19,7 +19,7 @@ if o.preinstalled_bindings_enabled() then
   o.bind("SUPER + SHIFT + W", "Omawrite", { launch = "omawrite" })
   o.bind("SUPER + SHIFT + SLASH", "Passwords", { omarchy = "1password" })
 
-  o.bind("SUPER + SHIFT + A", "ChatGPT", { webapp = "https://chatgpt.com" })
+  o.bind("SUPER + SHIFT + A", "AI", { omarchy = "ai" })
   o.bind("SUPER + SHIFT + ALT + A", "Grok", { webapp = "https://grok.com" })
   o.bind("SUPER + SHIFT + C", "Calendar", { webapp = "https://app.hey.com/calendar/weeks/" })
   o.bind("SUPER + SHIFT + E", "Email", { webapp = "https://app.hey.com" })

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -110,7 +110,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Shift + C`           | Calendar ([HEY](https://hey.com/))  |
 | `Super + Shift + E`           | Email ([HEY](https://hey.com/))  |
 | `Super + Shift + Alt + E`           | New email ([HEY](https://hey.com/))  |
-| `Super + Shift + A`           | AI (ChatGPT)  |
+| `Super + Shift + A`           | AI (web chat of your default agent; ChatGPT until one is set)  |
 | `Super + Shift + Alt + A`           | AI (Grok)  |
 | `Super + Shift + G`           | Messenger (Signal)  |
 | `Super + Shift + P`           | Google Photos  |

--- a/test/shell.d/hyprland-binding-conflicts-test.sh
+++ b/test/shell.d/hyprland-binding-conflicts-test.sh
@@ -154,7 +154,7 @@ bindings=$(PATH="$stub_bin:$PATH" list_bindings "$home")
 [[ -n $bindings ]] || fail "default bindings load for the conflict check"
 
 grep -Fq $'SUPER + RETURN\tTerminal' <<<"$bindings" || fail "conflict check sees the essential bindings"
-grep -Fq $'SUPER + SHIFT + A\tChatGPT' <<<"$bindings" || fail "conflict check sees the preinstalled bindings"
+grep -Fq $'SUPER + SHIFT + A\tAI' <<<"$bindings" || fail "conflict check sees the preinstalled bindings"
 grep -Fq $'F9\tStart dictation (push-to-talk)' <<<"$bindings" || fail "conflict check sees the Voxtype bindings"
 pass "conflict check covers the full default binding set"
 

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -102,7 +102,7 @@ fresh_home="$tmpdir/fresh-home"
 mkdir -p "$fresh_home"
 fresh_output=$(run_application_bindings "$fresh_home")
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$fresh_output" || fail "default application bindings include essentials"
-grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
+grep -Fq $'SUPER + SHIFT + A	AI' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
 pass "default application bindings load from package defaults"
 
 grep -F 'hl.dsp.send_key_state({ mods = mods, key = key, state = "down" })' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null ||
@@ -124,7 +124,7 @@ mkdir -p "$removed_home/.local/state/omarchy"
 touch "$removed_home/.local/state/omarchy/preinstalls-removed"
 removed_output=$(run_application_bindings "$removed_home")
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$removed_output" || fail "preinstall removal keeps essential bindings"
-if grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$removed_output"; then
+if grep -Fq $'SUPER + SHIFT + A	AI' <<<"$removed_output"; then
   fail "preinstall removal skips preinstalled web app bindings"
 fi
 pass "preinstall removal flag skips optional application bindings"
@@ -133,7 +133,7 @@ variable_home="$tmpdir/variable-home"
 mkdir -p "$variable_home"
 variable_output=$(run_application_bindings "$variable_home" 'omarchy_preinstalled_bindings = false')
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$variable_output" || fail "preinstalled binding variable keeps essential bindings"
-if grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$variable_output"; then
+if grep -Fq $'SUPER + SHIFT + A	AI' <<<"$variable_output"; then
   fail "preinstalled binding variable skips optional application bindings"
 fi
 pass "preinstalled binding variable skips optional application bindings"

--- a/test/shell.d/launch-ai-test.sh
+++ b/test/shell.d/launch-ai-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+launch_log="$test_tmp/launch"
+mkdir -p "$mock_bin"
+
+# The real getter prints nothing when no agent has been picked, so the stub
+# does the same for an empty OMARCHY_TEST_AGENT.
+cat >"$mock_bin/omarchy-default-agent" <<'SH'
+#!/bin/bash
+[[ -n ${OMARCHY_TEST_AGENT:-} ]] && echo "$OMARCHY_TEST_AGENT"
+exit 0
+SH
+cat >"$mock_bin/omarchy-launch-webapp" <<'SH'
+#!/bin/bash
+printf '%s\n' "$1" >"$OMARCHY_TEST_LAUNCH_LOG"
+SH
+chmod +x "$mock_bin"/*
+
+launched_url() {
+  local agent="$1"
+
+  rm -f "$launch_log"
+  OMARCHY_TEST_AGENT="$agent" OMARCHY_TEST_LAUNCH_LOG="$launch_log" PATH="$mock_bin:$PATH" \
+    bash "$ROOT/bin/omarchy-launch-ai"
+  cat "$launch_log"
+}
+
+[[ $(launched_url claude) == "https://claude.ai" ]] || fail "AI launcher opens Claude for the claude agent"
+pass "AI launcher opens Claude for the claude agent"
+
+[[ $(launched_url codex) == "https://chatgpt.com" ]] || fail "AI launcher opens ChatGPT for the codex agent"
+pass "AI launcher opens ChatGPT for the codex agent"
+
+[[ $(launched_url agy) == "https://gemini.google.com" ]] || fail "AI launcher opens Gemini for the Antigravity agent"
+pass "AI launcher opens Gemini for the Antigravity agent"
+
+[[ $(launched_url "") == "https://chatgpt.com" ]] || fail "AI launcher keeps ChatGPT when no default agent is set"
+pass "AI launcher keeps ChatGPT when no default agent is set"
+
+[[ $(launched_url pi) == "https://chatgpt.com" ]] || fail "AI launcher keeps ChatGPT for an agent without a web chat"
+pass "AI launcher keeps ChatGPT for an agent without a web chat"


### PR DESCRIPTION
`Super + Shift + A` always opens ChatGPT, while `Super + Shift + Ctrl + A` opens whichever coding agent you picked under Setup > Defaults > Agent. If your agent is Claude Code, one key opens Anthropic and the other OpenAI. It makes more sense for the web AI shortcut to follow the agent you chose.

## Change

- New `bin/omarchy-launch-ai` reads `omarchy-default-agent` when the key is pressed and opens the matching web chat with `omarchy-launch-webapp`. Same pattern as `omarchy-launch-browser` and `omarchy-launch-editor`.
- `Super + Shift + A` is bound to `{ omarchy = "ai" }` with the description `AI`.
- Mapping: `claude` → claude.ai, `codex` → chatgpt.com, `grok` → grok.com, `agy` → gemini.google.com, `copilot` → github.com/copilot, `muse` → meta.ai.
- Agents without a chat site (Pi, omp, OpenCode, Ori, OpenClaw, Hermes, Crush, Cursor) and an unset default keep opening ChatGPT, so nothing changes for those users. Opening the agent picker from a web app key felt odd, so it does not do that.

Resolving at press time means no reload and no stored state. `omarchy default agent codex` takes effect on the next keypress.

## Open question: the `Super + Shift + Alt + A` (Grok) shortcut

I left this binding as it is, hard-coded to grok.com, because I did not want to decide it unilaterally. It no longer fits cleanly once the main key follows the default agent:

- With `grok` as the default agent, both keys open grok.com.
- With any other default, Grok is the only vendor that still gets its own dedicated key, which is an accident of history rather than a design choice.

Options I see, in the order I would lean:

1. **Drop it.** The main key already reaches Grok for anyone who picked it as their agent. Frees a chord and removes the only vendor-specific AI key.
2. **Make it the fixed fallback.** Always open ChatGPT (or another single site), so people have one key that follows their agent and one that does not move.
3. **Keep it as is.** Zero behaviour change for existing users, at the cost of the redundancy above.

Happy to do whichever the maintainers prefer in this PR or a follow-up. Please leave this thread unresolved until that is decided.

## Tests and docs

- New `test/shell.d/launch-ai-test.sh` covers a mapped agent, an unset default, and an agent without a web chat.
- `test/shell.d/hyprland-default-config-test.sh` greps for `AI` instead of `ChatGPT`.
- `manual/07-hotkeys.md` updated.
- `./test/all` passes. Checked on a live 4.0.2 session: opens claude.ai with `claude` as default, chatgpt.com after switching to `codex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

