### PR TITLE
Add Command Code as a coding agent choice

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -95,6 +95,13 @@ codex)
   command=(codex --approve-for-me)
   [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
   ;;
+commandcode)
+  # --yolo skips the tool prompts and implies --trust, so the workspace trust
+  # dialog is skipped with it. -- keeps a prompt starting with a dash from
+  # being read as an option.
+  command=(commandcode --yolo)
+  [[ -n ${prompt:-} ]] && command+=(-- "$prompt")
+  ;;
 cursor-agent)
   # --yolo covers commands only; the workspace trust dialog has its own flag.
   # A one-word prompt naming a subcommand (update, login, help) still runs that

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set and launch the default coding agent
-# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse]
+# omarchy:args=[pi|omp|opencode|ori|claude|codex|commandcode|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse]
 # omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent claude
 
 installing=false
@@ -30,6 +30,7 @@ opencode | open-code) agent="opencode"; name="OpenCode" ;;
 ori | openrouter) agent="ori"; name="Ori"; agent_package="github:OpenRouterLabs/ori-releases" ;;
 claude | claude-code) agent="claude"; name="Claude Code" ;;
 codex) agent="codex"; name="Codex" ;;
+commandcode | command-code | cmdc | cmd) agent="commandcode"; name="Command Code"; agent_package="npm:command-code" ;;
 crush) agent="crush"; name="Crush" ;;
 grok) agent="grok"; name="Grok"; agent_package="npm:@xai-official/grok" ;;
 openclaw) agent="openclaw"; name="OpenClaw"; agent_installer="omarchy-install-openclaw-cli" ;;
@@ -43,7 +44,7 @@ muse | muse-code | musecode)
   ;;
 cursor | cursor-agent) agent="cursor-agent"; name="Cursor CLI" ;;
 *)
-  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse>"
+  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|commandcode|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-remove-preinstalls
+++ b/bin/omarchy-remove-preinstalls
@@ -15,7 +15,8 @@ if gum confirm "Are you sure you want to remove all preinstalled web apps, TUI w
   # Remove mise stubs
   rm -f ~/.local/bin/codex ~/.local/bin/claude ~/.local/bin/agy ~/.local/bin/copilot \
        ~/.local/bin/gh ~/.local/bin/opencode ~/.local/bin/playwright ~/.local/bin/playwright-cli ~/.local/bin/pi \
-       ~/.local/bin/omp ~/.local/bin/ori ~/.local/bin/grok ~/.local/bin/crush ~/.local/bin/ghui ~/.local/bin/hunk
+       ~/.local/bin/omp ~/.local/bin/ori ~/.local/bin/grok ~/.local/bin/crush ~/.local/bin/ghui ~/.local/bin/hunk \
+       ~/.local/bin/commandcode
 
   # Cursor's own installer links ~/.local/bin/cursor-agent as well, so only
   # the mise wrapper omarchy-mise-install wrote is a preinstall.

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -138,6 +138,7 @@
   "setup.default.agent.agy": {"icon":"󰫢","label":"Antigravity","checked":"[[ \"$(omarchy-default-agent)\" == \"agy\" ]]","action":"omarchy-default-agent agy"},
   "setup.default.agent.claude": {"icon":"󰛄","label":"Claude","checked":"[[ \"$(omarchy-default-agent)\" == \"claude\" ]]","action":"omarchy-default-agent claude"},
   "setup.default.agent.codex": {"icon":"","iconFont":"omarchy","label":"Codex","checked":"[[ \"$(omarchy-default-agent)\" == \"codex\" ]]","action":"omarchy-default-agent codex"},
+  "setup.default.agent.commandcode": {"icon":"󰆍","label":"Command Code","checked":"[[ \"$(omarchy-default-agent)\" == \"commandcode\" ]]","action":"omarchy-default-agent commandcode"},
   "setup.default.agent.copilot": {"icon":"","label":"Copilot","checked":"[[ \"$(omarchy-default-agent)\" == \"copilot\" ]]","action":"omarchy-default-agent copilot"},
   "setup.default.agent.crush": {"icon":"󰋑","label":"Crush","checked":"[[ \"$(omarchy-default-agent)\" == \"crush\" ]]","action":"omarchy-default-agent crush"},
   "setup.default.agent.cursor-agent": {"icon":"","iconFont":"omarchy","label":"Cursor CLI","checked":"[[ \"$(omarchy-default-agent)\" == \"cursor-agent\" ]]","action":"omarchy-default-agent cursor-agent"},

--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -13,6 +13,8 @@ omarchy-mise-install npm:playwright playwright
 omarchy-mise-install pi
 omarchy-mise-install github:can1357/oh-my-pi omp
 omarchy-mise-install npm:@xai-official/grok grok
+# An npm -g install of command-code already puts commandcode on PATH; leave it be.
+omarchy-cmd-missing commandcode && omarchy-mise-install npm:command-code commandcode
 # Cursor's own installer links the same path, so a re-provision keeps it.
 omarchy-cmd-missing cursor-agent && omarchy-mise-install cursor-agent
 omarchy-mise-install npm:@kitlangton/ghui ghui

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -17,6 +17,7 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 | `hermes`   | [Hermes](https://hermes-agent.nousresearch.com/), Nous Research's agent  |
 | `muse`     | [Muse Code](https://dev.meta.ai), Meta's coding agent           |
 | `cursor-agent` | [Cursor CLI](https://cursor.com/cli)                         |
+| `commandcode` | [Command Code](https://commandcode.ai)                        |
 
 `ori` is the odd one out: it runs the other harnesses against OpenRouter's whole model catalog, so `ori claude`, `ori codex`, or `ori opencode` start those agents on whichever model you point them at, and `ori code` is Ori's own agent.
 

--- a/migrations/1788817888.sh
+++ b/migrations/1788817888.sh
@@ -1,0 +1,7 @@
+echo "Install Command Code via mise wrapper"
+
+# An npm -g install of command-code already puts commandcode on PATH, so an
+# existing command is the user's and stays.
+if omarchy-cmd-missing commandcode && [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
+  omarchy-mise-install npm:command-code commandcode
+fi

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -117,6 +117,7 @@ crush_package="crush"
 agy_package="antigravity-cli"
 ori_package="github:OpenRouterLabs/ori-releases"
 cursor_agent_package="cursor-agent"
+commandcode_package="npm:command-code"
 muse_package="http:muse[url=https://api.meta.ai/muse-launcher.sh,bin=muse,version_list_url=https://api.meta.ai/muse-code/channels/muse-stable,version_json_path=.version]"
 
 assert_lazy_stub() {
@@ -137,6 +138,7 @@ assert_lazy_stub "$omp_package" omp
 assert_lazy_stub "$crush_package" crush
 assert_lazy_stub "$ori_package" ori
 assert_lazy_stub "$cursor_agent_package" cursor-agent
+assert_lazy_stub "$commandcode_package" commandcode
 assert_lazy_stub "$muse_package" muse
 pass "custom agent lazy stubs preserve their mise packages"
 
@@ -149,6 +151,8 @@ grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "user setup creates the
 grep -Fx "$ori_package ori" "$stub_log" >/dev/null || fail "user setup creates the Ori lazy stub"
 OMARCHY_TEST_MISSING_COMMAND=muse source "$ROOT/install/user/mise.sh"
 grep -Fx "$muse_package muse" "$stub_log" >/dev/null || fail "user setup creates the Muse lazy stub"
+OMARCHY_TEST_MISSING_COMMAND=commandcode source "$ROOT/install/user/mise.sh"
+grep -Fx "$commandcode_package commandcode" "$stub_log" >/dev/null || fail "user setup creates the Command Code lazy stub"
 pass "user setup creates the custom agent lazy stubs"
 
 : >"$stub_log"
@@ -156,6 +160,8 @@ source "$ROOT/install/user/mise.sh"
 grep -Fx "$cursor_agent_package" "$stub_log" >/dev/null && fail "user setup replaces an existing cursor-agent command"
 pass "user setup keeps an existing Cursor CLI install"
 grep -Fx "$muse_package muse" "$stub_log" >/dev/null && fail "user setup replaces an existing Muse command"
+grep -Fx "$commandcode_package commandcode" "$stub_log" >/dev/null && fail "user setup replaces an existing commandcode command"
+pass "user setup keeps an existing Command Code install"
 
 : >"$stub_log"
 OMARCHY_TEST_MISSING_COMMAND=muse source "$ROOT/migrations/1788724825.sh" >/dev/null
@@ -169,6 +175,19 @@ OMARCHY_TEST_MISSING_COMMAND=muse source "$ROOT/migrations/1788724825.sh" >/dev/
 [[ ! -s $stub_log ]] || fail "Muse migration ignores the preinstall opt-out"
 rm "$test_home/.local/state/omarchy/preinstalls-removed"
 pass "Muse migration preserves existing installs and the preinstall opt-out"
+
+: >"$stub_log"
+OMARCHY_TEST_MISSING_COMMAND=commandcode source "$ROOT/migrations/1788817888.sh" >/dev/null
+grep -Fx "$commandcode_package commandcode" "$stub_log" >/dev/null || fail "Command Code migration creates its lazy stub"
+: >"$stub_log"
+source "$ROOT/migrations/1788817888.sh" >/dev/null
+[[ ! -s $stub_log ]] || fail "Command Code migration replaces an existing command"
+mkdir -p "$test_home/.local/state/omarchy"
+touch "$test_home/.local/state/omarchy/preinstalls-removed"
+OMARCHY_TEST_MISSING_COMMAND=commandcode source "$ROOT/migrations/1788817888.sh" >/dev/null
+[[ ! -s $stub_log ]] || fail "Command Code migration ignores the preinstall opt-out"
+rm "$test_home/.local/state/omarchy/preinstalls-removed"
+pass "Command Code migration preserves existing installs and the preinstall opt-out"
 
 
 : >"$stub_log"
@@ -300,7 +319,7 @@ pass "agent migrations install working wrappers without overriding the preinstal
 "$ROOT/bin/omarchy-mise-install" "$muse_package" muse
 touch "$test_home/.local/bin/agy" "$test_home/.local/bin/ori"
 omarchy-remove-preinstalls >/dev/null
-for command in agy omp ori grok crush cursor-agent muse; do
+for command in agy omp ori grok crush cursor-agent muse commandcode; do
   [[ ! -e $test_home/.local/bin/$command ]] || fail "Remove Preinstalls deletes the $command lazy stub"
 done
 pass "Remove Preinstalls deletes every optional agent lazy stub"
@@ -372,6 +391,10 @@ declare -A expected_agents=(
   [claude]="claude"
   [claude-code]="claude"
   [codex]="codex"
+  [commandcode]="commandcode"
+  [command-code]="commandcode"
+  [cmdc]="commandcode"
+  [cmd]="commandcode"
   [crush]="crush"
   [grok]="grok"
   [agy]="agy"
@@ -395,6 +418,7 @@ declare -A expected_packages=(
   [ori]="$ori_package"
   [claude]="claude"
   [codex]="codex"
+  [commandcode]="$commandcode_package"
   [crush]="$crush_package"
   [grok]="$grok_package"
   [agy]="$agy_package"
@@ -646,6 +670,7 @@ assert_launch opencode opencode --auto --prompt "Review this project"
 assert_launch ori ori code --interactive --prompt "Review this project"
 assert_launch claude claude --permission-mode auto -- "Review this project"
 assert_launch codex codex --approve-for-me -- "Review this project"
+assert_launch commandcode commandcode --yolo -- "Review this project"
 assert_launch muse muse --approval-mode never -- "Review this project"
 assert_launch crush crush run "Review this project"
 assert_launch grok grok --permission-mode bypassPermissions -- "Review this project"
@@ -674,6 +699,7 @@ assert_bypass opencode opencode --auto
 assert_bypass ori ori code
 assert_bypass claude claude --permission-mode auto
 assert_bypass codex codex --approve-for-me
+assert_bypass commandcode commandcode --yolo
 assert_bypass muse muse --approval-mode never
 assert_bypass crush crush --yolo
 assert_bypass grok grok --permission-mode bypassPermissions

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -223,6 +223,7 @@ const expectedAgents = {
   ori: { icon: '\ue909', iconFont: 'omarchy', label: 'Ori' },
   claude: { icon: '󰛄', label: 'Claude' },
   codex: { icon: '\ue905', iconFont: 'omarchy', label: 'Codex' },
+  commandcode: { icon: '󰆍', label: 'Command Code' },
   grok: { icon: '\ue904', iconFont: 'omarchy', label: 'Grok' },
   hermes: { icon: '\ue90a', iconFont: 'omarchy', label: 'Hermes' },
   openclaw: { icon: '\ue90c', iconFont: 'omarchy', label: 'OpenClaw' },
@@ -249,7 +250,7 @@ assertDeepEqual(
   defaultItems
     .filter(item => item.parent === 'setup.default.agent')
     .map(item => item.label),
-  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
+  ['Antigravity', 'Claude', 'Codex', 'Command Code', 'Copilot', 'Crush', 'Cursor CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
   'menu sorts coding agents alphabetically'
 )
 const expectedDefaults = {


### PR DESCRIPTION
## Why

[Command Code](https://commandcode.ai/) is one of the [most used](https://x.com/MrAhmadAwais/status/2089700590813110657) coding-agent CLIs built for open models, with a user base of over [100K developers](https://x.com/MrAhmadAwais/status/2095238945416302683) in a few months and [low cost plans](https://x.com/CommandCodeAI/status/2085039006203711649).

We have a steady stream of requests from developers to have it available on Omarchy alongside the other agents. Adding it to the default-agent picker gives those users the same one-keybinding launch the other npm-backed agents already get.

## What

Wire `commandcode` into the default-agent picker the way the other npm-backed agents are:

- A lazy mise wrapper for `npm:command-code`, preinstalled by user setup and a migration
- A Setup > Defaults > Agent entry
- A launcher case in `omarchy-agent`

Launched from the keybinding or menu it runs with `--yolo`, which skips the tool prompts and implies `--trust`, so the workspace trust dialog is skipped too. A prompt goes behind `--` so one starting with a dash is not read as an option.

The wrapper is written only when no `commandcode` command exists, so a global npm install of `command-code` keeps working, and Remove Preinstalls deletes the stub with the other agent stubs.

## Before / after

```
BEFORE                                    AFTER

Super + Space                             Super + Space
  → Setup > Defaults > Agent                → Setup > Defaults > Agent
      Claude, Codex, OpenCode, ...              Claude, Codex, Command Code, OpenCode, ...
      (no Command Code)                         │
                                                ▼
user installs it by hand                  ~/.local/bin/commandcode
  npm i -g command-code                     lazy mise stub, npm:command-code
                                            installed on first pick
                                                │
                                                ▼
Super + Shift + Ctrl + A                  Super + Shift + Ctrl + A
  → launches the default agent              → commandcode --yolo -- "<prompt>"
    (never Command Code)                      no tool prompts, trust implied
```

## Testing

`test/shell.d/default-agent-test.sh` covers the new wiring end to end: the `npm:command-code` lazy stub, user setup creating it only when no `commandcode` command exists, the migration doing the same and honoring the preinstall opt-out, the `commandcode` / `command-code` / `cmdc` / `cmd` name mapping, the launch line with `--yolo` and the `--` prompt separator, and the bypass launch. `test/shell.d/menu-test.sh` adds Command Code to the expected Setup > Defaults > Agent list.

Made this PR with AI.

