### PR TITLE
Require auth to change system NetworkManager connections

### DIFF
--- a/etc/polkit-1/rules.d/omarchy-nm-modify-system.rules
+++ b/etc/polkit-1/rules.d/omarchy-nm-modify-system.rules
@@ -1,0 +1,12 @@
+// NetworkManager ships a wheel+local YES for settings.modify.system, so a
+// desktop session can rewrite system connections (DNS, VPN, routes) with no
+// prompt. That is the same class of grant we declined for the docker group.
+// Restore the action default. Personal connections (modify.own) are untouched.
+//
+// This filename sorts before org.freedesktop.NetworkManager.rules; polkit uses
+// the first returning rule.
+polkit.addRule(function(action, subject) {
+  if (action.id == "org.freedesktop.NetworkManager.settings.modify.system") {
+    return polkit.Result.AUTH_ADMIN_KEEP;
+  }
+});

--- a/test/shell.d/nm-polkit-modify-system-test.sh
+++ b/test/shell.d/nm-polkit-modify-system-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+rules_file="$ROOT/etc/polkit-1/rules.d/omarchy-nm-modify-system.rules"
+nm_rule="org.freedesktop.NetworkManager.rules"
+
+[[ -f $rules_file ]] || fail "omarchy-settings ships a polkit drop-in for system NetworkManager connections"
+
+base=$(basename "$rules_file")
+[[ $base < $nm_rule ]] ||
+  fail "polkit drop-in basename sorts before NetworkManager's YES rule" \
+    "$base would lose to $nm_rule"
+
+# Comments and blanks dropped. A YES on this action, or AUTH_ADMIN_KEEP on some
+# other action, would leave the file looking related while missing the grant.
+active=$(grep -vE '^[[:space:]]*(//|$)' "$rules_file")
+[[ $active == *'org.freedesktop.NetworkManager.settings.modify.system'* ]] ||
+  fail "polkit drop-in names settings.modify.system"
+[[ $active == *'polkit.Result.AUTH_ADMIN_KEEP'* ]] ||
+  fail "polkit drop-in restores AUTH_ADMIN_KEEP"
+[[ $active != *'polkit.Result.YES'* ]] ||
+  fail "polkit drop-in must not return YES"
+[[ $active != *modify.own* ]] ||
+  fail "polkit drop-in must not touch personal connections"
+
+pass "system NetworkManager connections require auth_admin_keep"


### PR DESCRIPTION
NetworkManager ships a polkit rule that returns YES for `settings.modify.system` when the user is in `wheel` and on a local session. Omarchy puts the install user in `wheel` and uses NetworkManager, so any process in the graphical session can rewrite system connections (DNS, VPN, routes) without a prompt.

That is the same class of grant we declined for the docker group. NM's own comment calls the rule optional and discouraged.

This drop-in restores the action default (`auth_admin_keep`). Personal connections (`modify.own`) stay promptless. The filename sorts before `org.freedesktop.NetworkManager.rules`; polkit uses the first returning rule.

Check, before and after an `omarchy-settings` rebuild that includes this file:

```bash
nmcli general permissions | grep modify.system
# expect auth, not yes
```

omarchy-settings already copies `etc/**` into `/etc/**`, so this lands on the next settings rebuild. Arch's polkit rules directory is 0750 (`root:polkitd`); the settings PKGBUILD already special-cases `sudoers.d` the same way if dir-mode warnings appear.