### PR TITLE
Fix Super+V in Codex's integrated terminal

### DIFF
--- a/default/hypr/bindings/clipboard.lua
+++ b/default/hypr/bindings/clipboard.lua
@@ -34,8 +34,12 @@ end
 
 local function universal_clipboard_shortcut(default_mods, default_key, terminal_mods, terminal_key)
   return function()
+    local window = hl.get_active_window()
     if active_window_is_terminal() then
       send_shortcut_once(terminal_mods, terminal_key)()
+    elseif default_key == "V" and window and window.class == "chatgpt" then
+      -- Codex's embedded terminal and composer both accept Shift+Insert.
+      send_shortcut_once("SHIFT", "Insert")()
     else
       send_shortcut_once(default_mods, default_key)()
     end

--- a/test/shell.d/hyprland-clipboard-bindings-test.sh
+++ b/test/shell.d/hyprland-clipboard-bindings-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+require_command lua
+
+lua - <<'LUA' || fail "universal clipboard shortcuts preserve app and terminal routing"
+local bindings, events, timers = {}, {}, {}
+local window
+
+o = { bind = function(keys, description, callback) bindings[keys] = callback end }
+hl = {
+  get_active_window = function() return window end,
+  dsp = { send_key_state = function(event) return event end },
+  dispatch = function(event) table.insert(events, event) end,
+  timer = function(callback, options)
+    assert(options.timeout == 50 and options.type == "oneshot")
+    table.insert(timers, callback)
+  end,
+}
+
+dofile(os.getenv("ROOT") .. "/default/hypr/bindings/clipboard.lua")
+
+local function check(active, shortcut, mods, key, description)
+  window, events, timers = active, {}, {}
+  bindings[shortcut]()
+  assert(#events == 1 and #timers == 1, description .. ": one press and release timer")
+  timers[1]()
+  assert(#events == 2, description .. ": one release")
+  for index, state in ipairs({ "down", "up" }) do
+    local event = events[index]
+    assert(event.mods == mods and event.key == key and event.state == state,
+      description .. ": expected " .. mods .. "+" .. key .. " " .. state)
+    assert(event.window == nil, description .. ": target stays the focused surface")
+  end
+end
+
+check({ class = "chatgpt" }, "SUPER + V", "SHIFT", "Insert", "Codex embedded terminal paste")
+check({ class = "chatgpt" }, "SUPER + C", "CTRL", "C", "Codex copy")
+check({ class = "chatgpt" }, "SUPER + X", "CTRL", "X", "Codex cut")
+
+for _, tags in ipairs({ { "terminal" }, { "other", "terminal*" } }) do
+  check({ class = "Alacritty", tags = tags }, "SUPER + V", "SHIFT", "Insert", "terminal paste")
+  check({ class = "Alacritty", tags = tags }, "SUPER + C", "CTRL", "Insert", "terminal copy")
+  check({ class = "Alacritty", tags = tags }, "SUPER + X", "CTRL", "X", "terminal cut")
+end
+
+for _, active in ipairs({ { class = "chromium", tags = {} }, {}, false }) do
+  check(active or nil, "SUPER + V", "CTRL", "V", "ordinary window or layer-shell paste")
+  check(active or nil, "SUPER + C", "CTRL", "C", "ordinary window or layer-shell copy")
+  check(active or nil, "SUPER + X", "CTRL", "X", "ordinary window or layer-shell cut")
+end
+LUA
+pass "universal clipboard shortcuts preserve app and terminal routing"


### PR DESCRIPTION
Super+V forwards Ctrl+V to the ChatGPT desktop window (`chatgpt`), but its integrated Codex terminal on Linux treats Ctrl+V as terminal input. Route paste to Shift+Insert for this app so it works in both the terminal and composer. Copy, cut, terminal-tag routing, and the ordinary-window/layer-shell fallback keep their existing behavior.

The new regression test runs the real Lua callbacks and covers 18 routes, including paired key press/release events. It fails on the base branch and passes with the fix.

Validation:
- `./test/all`: 112 CLI checks and all 236 shell test files passed, including 14 headless skips. Run with the required `omarchy-pkgs` and `omarchy-iso` checkouts, display variables and `NO_COLOR` unset, and `PYTHONDONTWRITEBYTECODE=1`.
- Live Linux desktop: Super+V pasted text into the integrated terminal and composer; image/png paste added an unsent composer attachment. Tested with ChatGPT desktop 26.901.51231.
- `luac -p default/hypr/bindings/clipboard.lua` and `git diff --check` passed.
- `bin/omarchy commands --check`: 451 commands passed.
- Shebang-aware syntax checks: 453 command files passed.
