### PR TITLE
Keep the Bluetooth bar icon visible when there's no adapter

### DIFF
--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -55,9 +55,13 @@ Panel {
   readonly property var knownDevices: deviceGroups.known || []
   readonly property var discoveredDevices: deviceGroups.discovered || []
 
+  // No adapter reads the same as "off" here: rfkill-blocking Bluetooth drops
+  // the BlueZ adapter object entirely (confirmed via bluetoothctl show), and
+  // the disabled glyph is the only thing standing between the user and the
+  // one control that turns it back on. An empty string would zero out
+  // BarIconButton's hasVisualContent and hide the widget from the bar.
   readonly property string icon: {
-    if (!adapter) return ""
-    if (!adapter.enabled) return "󰂲"
+    if (!adapter || !adapter.enabled) return "󰂲"
     if (connectedDevices.length > 0) return "󰂱"
     return "󰂯"
   }
@@ -633,8 +637,10 @@ Panel {
   // switch only moves once BlueZ catches up, so a second click inside that window
   // would re-read the old state and undo the first.
   function toggleBluetooth() {
-    if (!adapter) return
-    Quickshell.execDetached(["omarchy-bluetooth-power", adapter.enabled ? "off" : "on"])
+    // No adapter means rfkill-blocked (see the icon comment above), which
+    // reads as "off" — so the direction to ask for is "on", same as an
+    // adapter sitting there with enabled: false.
+    Quickshell.execDetached(["omarchy-bluetooth-power", adapter && adapter.enabled ? "off" : "on"])
   }
 
   IpcHandler {

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -17,8 +17,16 @@ assert(/IpcHandler[\s\S]*?function toggleBluetooth\(\) \{ root\.toggleBluetooth\
 assert(/manageIpc: false/.test(panelSource), 'bluetooth owns its IPC handler so it can extend the target methods')
 
 // Writing adapter.enabled sets BlueZ Powered, which does not survive a reboot.
-assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
+assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter && adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
 assert(!/adapter\.enabled = /.test(panelSource), 'bluetooth never writes the adapter power state directly')
+
+// rfkill-blocking Bluetooth drops the BlueZ adapter object entirely (bluetoothctl
+// show reports "No default controller available"), which used to blank the icon
+// and hide the bar widget via BarIconButton's hasVisualContent — locking out the
+// only control that turns it back on. No adapter has to read as "off" instead.
+assert(!/return ""/.test(panelSource.match(/readonly property string icon: \{[\s\S]*?\n {2}\}/)[0]), 'bluetooth never blanks the bar icon, even with no adapter')
+assert(/if \(!adapter \|\| !adapter\.enabled\) return "󰂲"/.test(panelSource), 'bluetooth shows the disabled glyph instead of hiding when there is no adapter')
+assert(/execDetached\(\["omarchy-bluetooth-power", adapter && adapter\.enabled/.test(panelSource), 'bluetooth still offers to turn on when there is no adapter')
 
 // Discovery is a BlueZ session that nothing ends at panel close: it persists
 // until StopDiscovery or until quickshell's D-Bus connection drops with the


### PR DESCRIPTION
Problem

The Bluetooth bar widget disappears from the top bar entirely when Bluetooth is turned off, instead of staying put so it can be turned back on.

Root cause, traced through shell/plugins/panels/bluetooth/Panel.qml and its dependencies:

1. Turning Bluetooth off routes through omarchy-bluetooth-power, which does rfkill block bluetooth rather than a plain bluetoothctl power off — the block is what survives a reboot; a bare power-off does not.
2. Blocking the radio doesn't just flip BlueZ's Powered property — it removes the adapter object from D-Bus entirely. Confirmed directly: once blocked, bluetoothctl show reports No default controller available, and Bluetooth.defaultAdapter becomes null.
3. Panel.qml's icon property special-cased that as if (!adapter) return "".
4. That empty string feeds BarIconButton.hasVisualContent (text !== "" || iconComponent !== null → false), which feeds WidgetButton.visible (hasVisualContent || keepSpace, and this widget never sets keepSpace) → the whole bar item hides itself.

Net effect: turn Bluetooth off, and the only control that could turn it back on vanishes with it — the user is stuck reaching for bluetoothctl/rfkill in a terminal.

A second bug was hiding behind the first: toggleBluetooth() had if (!adapter) return, so even a visible-but-adapter-less icon would silently no-op on click instead of asking omarchy-bluetooth-power to turn on.

Fix

- icon: no adapter now reads the same as "adapter present but disabled" — both show the existing disabled glyph (󰂲) instead of "".
- toggleBluetooth(): adapter && adapter.enabled ? "off" : "on" "on", lifting the rfkill block that made the adapter disappearin the first place.
- Updated the existing toggleBluetooth regex assertion in testr the null-safe check, and added three assertions pinning theicon down: it never returns "", it shows the disabled glyph with no adapter, and it still offers "on" with no adapter.

Testing

- Reproduced live: rfkill block bluetooth → adapter disappears from bluetoothctl → bar icon vanished pre-fix.
- bash test/shell.d/bluetooth-test.sh — all 49 assertions pass
- test/all — full suite passes (one unrelated, pre-existing environment-only failure: omarchy-pkgs checkout found for package ownership check, which needs a sibling repo checkout not present on this machine).