### PR TITLE
feat: theme the screensaver with 4-3-4-3-5 field bands

### DIFF
--- a/bin/omarchy-branding-about-animation
+++ b/bin/omarchy-branding-about-animation
@@ -54,18 +54,20 @@ compose_frame() {
   SHEEN_COMPOSED=$frame
 }
 
-# Builds every frame up front: a tick that recomputed a logo's worth of colour
-# spans in bash would not hold the frame rate, and the sweep is the same every
-# time. Leaves them in SHEEN_FRAMES, and answers whether this logo can be
-# animated at all — one it cannot put back exactly as it found it is one to leave
-# alone, because nothing on screen would say the difference.
+# Whether this logo can be animated at all — one it cannot put back exactly as
+# it found it is one to leave alone, because nothing on screen would say the
+# difference. Composes the settled rest (band off the right) so the caller can
+# write the logo in its real colours before the rest of the centres are walked.
 #
-#   sheen_build <logo-file> <top-row> <left-column> <base-colour> <columns-available>
-sheen_build() {
+#   sheen_prepare <logo-file> <top-row> <left-column> <base-colour> <columns-available>
+sheen_prepare() {
   local file=$1 columns=$5
   SHEEN_TOP=$2
   SHEEN_LEFT=$3
   SHEEN_BASE=$4
+  SHEEN_REST=""
+  SHEEN_LAST=""
+  SHEEN_FRAMES=()
 
   SHEEN_LINES=()
   # A failing redirection reports itself before 2>/dev/null would apply, so order
@@ -119,10 +121,29 @@ sheen_build() {
     done
   fi
 
+  SHEEN_LAST=$(( width + SHEEN_ROWS * SHEEN_SLANT + SHEEN_HALF ))
+  compose_frame "$SHEEN_LAST"
+  SHEEN_REST=$SHEEN_COMPOSED
+}
+
+# A tick that recomputed a logo's worth of colour spans in bash would not hold
+# the frame rate, and the sweep is the same every time, so the centres are walked
+# once and left in SHEEN_FRAMES. The rest is already composed; this is the part
+# that used to keep About green.
+sheen_build_frames() {
+  (( ${SHEEN_ROWS:-0} > 0 )) || return 1
+  [[ -n ${SHEEN_LAST:-} ]] || return 1
+
   SHEEN_FRAMES=()
-  local centre last=$(( width + SHEEN_ROWS * SHEEN_SLANT + SHEEN_HALF ))
-  for (( centre = -SHEEN_HALF; centre <= last; centre++ )); do
+  local centre
+  for (( centre = -SHEEN_HALF; centre <= SHEEN_LAST; centre++ )); do
     compose_frame "$centre"
     SHEEN_FRAMES+=("$SHEEN_COMPOSED")
   done
+}
+
+#   sheen_build <logo-file> <top-row> <left-column> <base-colour> <columns-available>
+sheen_build() {
+  sheen_prepare "$@" || return
+  sheen_build_frames
 }

--- a/bin/omarchy-branding-about-animation
+++ b/bin/omarchy-branding-about-animation
@@ -48,7 +48,7 @@ compose_frame() {
     to=$(( to < 0 ? 0 : to ))
 
     frame+="${ESC}[$((SHEEN_TOP + row));${SHEEN_LEFT}H"
-    frame+="${SHEEN_BASE}${line:0:from}${SHEEN_BAND}${line:from:to - from}${SHEEN_BASE}${line:to}"
+    frame+="${SHEEN_ROW_SGR[row]:-$SHEEN_BASE}${line:0:from}${SHEEN_BAND}${line:from:to - from}${SHEEN_ROW_SGR[row]:-$SHEEN_BASE}${line:to}"
   done
 
   SHEEN_COMPOSED=$frame
@@ -94,6 +94,30 @@ sheen_build() {
     fi
   done
   (( width > 0 && width <= columns )) || return 1
+
+  SHEEN_ROW_SGR=()
+  if [[ ${SHEEN_FIELD_BANDS:-} == 1 ]]; then
+    local band pal_file
+    local -a palette=()
+    # shellcheck source=omarchy-screensaver-theme
+    source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/omarchy-screensaver-theme"
+    pal_file=$(default_colors_file 2>/dev/null) || true
+    if [[ -n ${pal_file:-} ]] && screensaver_theme_from_colors "$pal_file"; then
+      IFS=',' read -r -a palette <<<"$SCREENSAVER_PALETTE"
+    fi
+    for (( row = 0; row < SHEEN_ROWS; row++ )); do
+      if (( ${#palette[@]} >= 5 )); then
+        band=$(field_band_index_n "$row" "$SHEEN_ROWS")
+        SHEEN_ROW_SGR[row]=$(hex_to_sgr_fg "${palette[band]}")
+      else
+        SHEEN_ROW_SGR[row]=$SHEEN_BASE
+      fi
+    done
+  else
+    for (( row = 0; row < SHEEN_ROWS; row++ )); do
+      SHEEN_ROW_SGR[row]=$SHEEN_BASE
+    done
+  fi
 
   SHEEN_FRAMES=()
   local centre last=$(( width + SHEEN_ROWS * SHEEN_SLANT + SHEEN_HALF ))

--- a/bin/omarchy-launch-about
+++ b/bin/omarchy-launch-about
@@ -273,6 +273,7 @@ build_sheen() {
   # The cell the logo's first row starts on, every attribute fastfetch left on
   # those cells so a glint that has passed leaves them as it found them, and the
   # room it has to work in left of the module column.
+  SHEEN_FIELD_BANDS=1
   sheen_build "$LOGO_FILE" "$LOGO_ROW" "$LOGO_COLUMN" "${ESC}[0m${LOGO_COLOR}" "$(( cols - LOGO_COLUMN + 1 ))"
 }
 

--- a/bin/omarchy-launch-about
+++ b/bin/omarchy-launch-about
@@ -247,10 +247,14 @@ logo_landmark() {
 
 # The About screen's own reasons the logo might not be where these frames would
 # draw it. Whether the logo itself can be animated is the sheen's own question.
+# Stops at the settled rest: the sweep is walked after that rest has been written,
+# so the logo is not green for as long as bash takes to compose every centre.
 build_sheen() {
   # Whatever the last build left is not this window's, and the loop below plays
   # whatever is here — so a build that fails has to leave nothing to play.
   SHEEN_FRAMES=()
+  SHEEN_REST=""
+  SHEEN_LAST=""
 
   custom_fastfetch_config && return 1
 
@@ -274,7 +278,7 @@ build_sheen() {
   # those cells so a glint that has passed leaves them as it found them, and the
   # room it has to work in left of the module column.
   SHEEN_FIELD_BANDS=1
-  sheen_build "$LOGO_FILE" "$LOGO_ROW" "$LOGO_COLUMN" "${ESC}[0m${LOGO_COLOR}" "$(( cols - LOGO_COLUMN + 1 ))"
+  sheen_prepare "$LOGO_FILE" "$LOGO_ROW" "$LOGO_COLUMN" "${ESC}[0m${LOGO_COLOR}" "$(( cols - LOGO_COLUMN + 1 ))"
 }
 
 # What the frames were built against. A window that resized, or a logo that was
@@ -341,6 +345,7 @@ if [[ ${1:-} == "--render" ]]; then
     logo_stamp=$(stat -c %Y "$LOGO_FILE" 2>/dev/null)
     resized=false
     LAYOUT_ROWS=""
+    SHEEN_REST=""
     clear
     fastfetch
     # A second pass picks up a fit that could not measure the window the first
@@ -349,9 +354,14 @@ if [[ ${1:-} == "--render" ]]; then
     if [[ $fitted == false ]] && (( ++passes <= 2 )); then
       fit_window && fitted=true
     fi
-    # An empty frame list plays nothing, so a logo that cannot be animated waits
-    # here exactly as the still one did, and there is one loop rather than two.
+    # An empty rest plays nothing extra, so a logo that cannot be animated is
+    # still just fastfetch, and there is one loop rather than two.
     build_sheen
+    # Write the settled colours before walking the sweep. A 26-row About logo is
+    # a hundred centres of bash, and that used to be how long the config's green
+    # sat on screen.
+    printf '%s' "$SHEEN_REST"
+    sheen_build_frames
     while play_sheen && rest_sheen; do :; done
     # A rebranded logo changes the content dimensions, so measure again.
     if [[ $(stat -c %Y "$LOGO_FILE" 2>/dev/null) != $logo_stamp ]]; then

--- a/bin/omarchy-launch-screensaver
+++ b/bin/omarchy-launch-screensaver
@@ -2,6 +2,10 @@
 
 # omarchy:summary=Launch the Omarchy screensaver in the default terminal on the system with the correct font configuration.
 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=omarchy-screensaver-theme
+source "$SCRIPT_DIR/omarchy-screensaver-theme"
+
 # Exit early if screensaver is already running
 pgrep -f '[o]rg.omarchy.screensaver' && exit 0
 
@@ -63,7 +67,11 @@ for m in $(hyprctl monitors -j | jq -r '.[] | .name'); do
     hypr_exec foot --app-id=org.omarchy.screensaver --config="$OMARCHY_PATH/default/foot/screensaver.ini" -e omarchy-screensaver
     ;;
   *kitty*)
-    hypr_exec kitty --class=org.omarchy.screensaver --override font_size=18 --override window_padding_width=0 -e omarchy-screensaver
+    kitty_bg=#000000
+    if colors_file=$(default_colors_file) && screensaver_theme_from_colors "$colors_file"; then
+      kitty_bg=$SCREENSAVER_BG
+    fi
+    hypr_exec kitty --class=org.omarchy.screensaver --override font_size=18 --override window_padding_width=0 --override "background=$kitty_bg" -e omarchy-screensaver
     ;;
   esac
 

--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# omarchy:summary=Run the Omarchy screensaver using random effects from TTE.
+# omarchy:summary=Run the Omarchy screensaver using random effects from ttfx.
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=omarchy-screensaver-theme
+source "$SCRIPT_DIR/omarchy-screensaver-theme"
 
 screensaver_in_focus() {
   hyprctl activewindow -j | jq -e '.class == "org.omarchy.screensaver"' >/dev/null 2>&1
@@ -16,7 +20,16 @@ exit_screensaver() {
 # Exit the screensaver on signals and input from keyboard and mouse
 trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
 
-printf '\033]11;rgb:00/00/00\007'  # Set background color to black
+osc='rgb:00/00/00'
+theme_args=()
+if colors_file=$(default_colors_file) && screensaver_theme_from_colors "$colors_file"; then
+  osc=$SCREENSAVER_OSC
+  if ttfx_supports_palette; then
+    theme_args=(--palette "$SCREENSAVER_PALETTE" --terminal-background-color "$SCREENSAVER_BG")
+  fi
+fi
+
+printf '\033]11;%s\007' "$osc"
 
 hyprctl eval 'hl.config({ cursor = { invisible = true } })' &>/dev/null || hyprctl keyword cursor:invisible true &>/dev/null
 
@@ -37,8 +50,9 @@ wait_for_terminal_resize
 
 while true; do
   ttfx -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
-    --random-effect --no-eol --no-restore-cursor &
+    --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c \
+    --random-effect --no-eol --no-restore-cursor \
+    "${theme_args[@]}" &
 
   while pgrep -t "${tty#/dev/}" -x ttfx >/dev/null; do
     if read -n1 -t 1 || ! screensaver_in_focus; then

--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -26,6 +26,9 @@ if colors_file=$(default_colors_file) && screensaver_theme_from_colors "$colors_
   osc=$SCREENSAVER_OSC
   if ttfx_supports_palette; then
     theme_args=(--palette "$SCREENSAVER_PALETTE" --terminal-background-color "$SCREENSAVER_BG")
+    if ttfx_supports_bands; then
+      theme_args+=(--bands)
+    fi
   fi
 fi
 

--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -27,6 +27,11 @@ if colors_file=$(default_colors_file) && screensaver_theme_from_colors "$colors_
   if ttfx_supports_palette; then
     theme_args=(--palette "$SCREENSAVER_PALETTE" --terminal-background-color "$SCREENSAVER_BG")
     if ttfx_supports_bands; then
+      # Stock art is the 10-line FIGlet in logo.txt. The website wordmark is an
+      # 81x19 square-pixel bitmap painted 5-2-4-3-5 (crest, hover, lit, mid,
+      # dim). --bands spreads that ratio across however many lines the input
+      # has, so ten lines become 3-1-2-1-3. A terminal cell is twice as tall as
+      # it is wide, so the letters will not match the site pixel-for-pixel.
       theme_args+=(--bands)
     fi
   fi

--- a/bin/omarchy-screensaver-theme
+++ b/bin/omarchy-screensaver-theme
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# omarchy:summary=Print screensaver field colours from a theme colors.toml
+# omarchy:group=screensaver
+# omarchy:name=theme
+# omarchy:args=[colors.toml]
+# omarchy:hidden=true
+
+toml_hex() {
+  local file=$1
+  local key=$2
+  local line value
+
+  [[ -f $file ]] || return 1
+  line=$(grep -E "^${key}[[:space:]]*=" "$file" | head -n 1) || return 1
+  if [[ $line =~ \#([0-9A-Fa-f]{6}) ]]; then
+    printf '%s' "#${BASH_REMATCH[1],,}"
+    return 0
+  fi
+  return 1
+}
+
+hex_to_rgb() {
+  local hex=${1#\#}
+  printf '%d %d %d' "0x${hex:0:2}" "0x${hex:2:2}" "0x${hex:4:2}"
+}
+
+rgb_to_hex() {
+  printf '#%02x%02x%02x' "$1" "$2" "$3"
+}
+
+mix_hex() {
+  local from=$1
+  local to=$2
+  local t=$3
+  local fr fg fb tr tg tb
+
+  read -r fr fg fb <<<"$(hex_to_rgb "$from")"
+  read -r tr tg tb <<<"$(hex_to_rgb "$to")"
+  rgb_to_hex \
+    $(((fr * (100 - t) + tr * t) / 100)) \
+    $(((fg * (100 - t) + tg * t) / 100)) \
+    $(((fb * (100 - t) + tb * t) / 100))
+}
+
+hex_to_osc() {
+  local hex=${1#\#}
+  printf 'rgb:%s/%s/%s' "${hex:0:2}" "${hex:2:2}" "${hex:4:2}"
+}
+
+screensaver_theme_from_colors() {
+  local file=$1
+  local mode accent background lit dim mid hover crest toward
+
+  mode=$(grep -E '^mode[[:space:]]*=' "$file" | head -n 1 | sed -E 's/.*=[[:space:]]*"?([^"#]+)"?.*/\1/' | tr -d '[:space:]')
+  mode=${mode:-dark}
+
+  background=$(toml_hex "$file" darker_background || toml_hex "$file" dark_background || toml_hex "$file" background) || return 1
+  lit=$(toml_hex "$file" accent) || return 1
+
+  dim=$(mix_hex "$lit" "$background" 25)
+  mid=$(mix_hex "$lit" "$background" 50)
+
+  if [[ $mode == "light" ]]; then
+    toward=$background
+  else
+    toward=$(toml_hex "$file" bright_foreground || toml_hex "$file" foreground || printf '%s' "$lit")
+  fi
+
+  hover=$(mix_hex "$lit" "$toward" 35)
+  crest=$(mix_hex "$lit" "$toward" 70)
+
+  SCREENSAVER_BG=$background
+  SCREENSAVER_LIT=$lit
+  SCREENSAVER_PALETTE="$dim,$mid,$lit,$hover,$crest"
+  SCREENSAVER_OSC=$(hex_to_osc "$background")
+}
+
+default_colors_file() {
+  local staged=$HOME/.local/state/omarchy/current/theme/colors.toml
+
+  if [[ -f $staged ]]; then
+    printf '%s' "$staged"
+    return 0
+  fi
+  return 1
+}
+
+ttfx_supports_palette() {
+  command -v ttfx >/dev/null || return 1
+  ttfx --help 2>/dev/null | grep -q -- '--palette'
+}
+
+if [[ ${BASH_SOURCE[0]} != "$0" ]]; then
+  return 0
+fi
+
+set -euo pipefail
+
+colors_file=${1:-}
+if [[ -z $colors_file ]]; then
+  colors_file=$(default_colors_file) || {
+    echo "omarchy-screensaver-theme: no colors.toml" >&2
+    exit 1
+  }
+fi
+
+screensaver_theme_from_colors "$colors_file"
+printf '%s\n' "$SCREENSAVER_BG"
+printf '%s\n' "$SCREENSAVER_PALETTE"
+printf '%s\n' "$SCREENSAVER_OSC"

--- a/bin/omarchy-screensaver-theme
+++ b/bin/omarchy-screensaver-theme
@@ -72,7 +72,7 @@ screensaver_theme_from_colors() {
 
   SCREENSAVER_BG=$background
   SCREENSAVER_LIT=$lit
-  SCREENSAVER_PALETTE="$dim,$mid,$lit,$hover,$crest"
+  SCREENSAVER_PALETTE="$crest,$hover,$lit,$mid,$dim"
   SCREENSAVER_OSC=$(hex_to_osc "$background")
 }
 
@@ -89,6 +89,11 @@ default_colors_file() {
 ttfx_supports_palette() {
   command -v ttfx >/dev/null || return 1
   ttfx --help 2>/dev/null | grep -q -- '--palette'
+}
+
+ttfx_supports_bands() {
+  command -v ttfx >/dev/null || return 1
+  ttfx --help 2>/dev/null | grep -q -- '--bands'
 }
 
 if [[ ${BASH_SOURCE[0]} != "$0" ]]; then

--- a/bin/omarchy-screensaver-theme
+++ b/bin/omarchy-screensaver-theme
@@ -96,6 +96,95 @@ ttfx_supports_bands() {
   ttfx --help 2>/dev/null | grep -q -- '--bands'
 }
 
+# Same Hamilton split ttfx uses: 5-2-4-3-5 over n lines. Prints 0..4.
+field_band_index_n() {
+  local i=$1
+  local n=$2
+
+  awk -v i="$i" -v n="$n" 'BEGIN {
+    u[0]=5; u[1]=2; u[2]=4; u[3]=3; u[4]=5
+    bands=5
+    total=19
+    if (n <= 0) { print 0; exit }
+    if (i < 0) i=0
+    if (i > n-1) i=n-1
+    sum=0
+    for (b=0; b<bands; b++) {
+      exact[b]=n*u[b]/total
+      counts[b]=int(exact[b])
+      sum+=counts[b]
+    }
+    remain=n-sum
+    for (b=0; b<bands; b++) order[b]=b
+    for (a=0; a<bands; a++) {
+      for (b=a+1; b<bands; b++) {
+        fa=exact[order[a]]-int(exact[order[a]])
+        fb=exact[order[b]]-int(exact[order[b]])
+        if (fb>fa || (fb==fa && order[b]<order[a])) {
+          t=order[a]; order[a]=order[b]; order[b]=t
+        }
+      }
+    }
+    for (k=0; k<bands && remain>0; k++) {
+      counts[order[k]]++
+      remain--
+    }
+    if (n>=bands) {
+      while (1) {
+        zero=-1
+        for (b=0; b<bands; b++) if (counts[b]==0) { zero=b; break }
+        if (zero<0) break
+        donor=-1
+        for (b=bands-1; b>=0; b--) if (counts[b]>1) { donor=b; break }
+        if (donor<0) break
+        counts[donor]--
+        counts[zero]++
+      }
+    }
+    acc=0
+    for (b=0; b<bands; b++) {
+      acc+=counts[b]
+      if (i<acc) { print b; exit }
+    }
+    print bands-1
+  }'
+}
+
+hex_to_sgr_fg() {
+  local hex=${1#\#}
+  printf '\033[38;2;%d;%d;%dm' "0x${hex:0:2}" "0x${hex:2:2}" "0x${hex:4:2}"
+}
+
+# Paint a text file with one field-band colour per line. Falls back to green.
+print_field_banded_file() {
+  local file=$1
+  local colors_file sgr i n band
+  local -a lines palette
+
+  if [[ ! -f $file ]]; then
+    return 1
+  fi
+
+  mapfile -t lines <"$file"
+  n=${#lines[@]}
+  (( n > 0 )) || return 1
+
+  colors_file=$(default_colors_file 2>/dev/null) || true
+  if [[ -n ${colors_file:-} ]] && screensaver_theme_from_colors "$colors_file"; then
+    IFS=',' read -r -a palette <<<"$SCREENSAVER_PALETTE"
+  fi
+
+  for (( i = 0; i < n; i++ )); do
+    if (( ${#palette[@]} >= 5 )); then
+      band=$(field_band_index_n "$i" "$n")
+      sgr=$(hex_to_sgr_fg "${palette[band]}")
+      printf '%s%s\033[0m\n' "$sgr" "${lines[i]}"
+    else
+      printf '\033[32m%s\033[0m\n' "${lines[i]}"
+    fi
+  done
+}
+
 if [[ ${BASH_SOURCE[0]} != "$0" ]]; then
   return 0
 fi

--- a/bin/omarchy-show-logo
+++ b/bin/omarchy-show-logo
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# omarchy:summary=Display the Omarchy logo in the terminal using green color.
+# omarchy:summary=Display the Omarchy logo in the terminal, coloured with the theme field bands.
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=omarchy-screensaver-theme
+source "$SCRIPT_DIR/omarchy-screensaver-theme"
 
 clear
-echo -e "\033[32m"
-cat <$OMARCHY_PATH/logo.txt
-echo -e "\033[0m"
+print_field_banded_file "$OMARCHY_PATH/logo.txt"
 echo

--- a/manual/41-branding.md
+++ b/manual/41-branding.md
@@ -18,6 +18,8 @@ Then apply the setup with `omarchy plymouth set '#1d2021' '#ebdbb2' logo.png`, w
 
 You can change the logo used for the screensaver under _Style > Screensaver_. It's an ASCII logo, so you can edit the text directly, but you can also hand it a png or svg image, and we'll convert that to ASCII. It looks pretty cool.
 
+The default is the ten-line FIGlet. The website wordmark is a 19-row square-pixel bitmap, so the screensaver will not match omarchy.org stripe-for-stripe: a terminal cell is twice as tall as it is wide, and the field bands stretch across however many lines your file has.
+
  ![branding-screensaver](images/branding-screensaver.webp)
 
 There are three entries in that menu:

--- a/test/shell.d/branding-about-animation-test.sh
+++ b/test/shell.d/branding-about-animation-test.sh
@@ -100,6 +100,32 @@ done
 [[ ${SHEEN_FRAMES[-1]} == "$settled" ]] || fail "a glint settles back to the logo it was given"
 pass "a glint settles back to the logo it was given"
 
+# The settled rest is the last centre, composed before the sweep is walked, so a
+# caller can write the logo in its real colours while bash is still building frames.
+write_logo '████████████████████████' '████████        ████████' '████████████████████████'
+sheen_prepare "$logo" "$top" "$left" "$base" "$columns" || fail "prepare accepts the same logo the sweep does"
+pass "prepare accepts the same logo the sweep does"
+[[ $SHEEN_REST == "$settled" ]] || fail "the rest is the settled logo" "$(printf '%q' "$SHEEN_REST")"
+pass "the rest is the settled logo"
+(( ${#SHEEN_FRAMES[@]} == 0 )) || fail "prepare does not walk the sweep" "${#SHEEN_FRAMES[@]} frames"
+pass "prepare does not walk the sweep"
+sheen_build_frames || fail "the sweep can be walked after the rest is composed"
+pass "the sweep can be walked after the rest is composed"
+[[ ${SHEEN_FRAMES[-1]} == "$SHEEN_REST" ]] || fail "the last centre is the rest that was already composed"
+pass "the last centre is the rest that was already composed"
+
+# Per-row field colours have to be on that rest, or About would still paint green
+# first and only pick up the ramp once the sweep started.
+theme_home=$tmp_dir/theme-home
+mkdir -p "$theme_home/.local/state/omarchy/current/theme"
+cp "$ROOT/themes/tokyo-night/colors.toml" "$theme_home/.local/state/omarchy/current/theme/colors.toml"
+HOME=$theme_home SHEEN_FIELD_BANDS=1 sheen_prepare "$logo" "$top" "$left" "$base" "$columns" ||
+  fail "a themed rest still prepares"
+[[ $SHEEN_REST == *$'\e[38;2;'* ]] || fail "a themed rest uses field-band colours" "$(printf '%q' "$SHEEN_REST")"
+[[ $SHEEN_REST != *$base* ]] || fail "a themed rest is not the config green" "$(printf '%q' "$SHEEN_REST")"
+pass "a themed rest uses field-band colours"
+unset SHEEN_FIELD_BANDS
+
 # A terminal that renders bold text in bright colours — foot's bold-text-in-bright
 # does exactly this — maps a bold regular colour to its bright counterpart, so a
 # band using one of those vanishes into a logo drawn in the matching regular

--- a/test/shell.d/launch-about-test.sh
+++ b/test/shell.d/launch-about-test.sh
@@ -15,6 +15,7 @@ sed '/^presize_window$/,$d' "$about" >"$tmp_dir/about.bash"
 
 export HOME="$tmp_dir/home"
 export PATH="$ROOT/bin:$PATH"
+unset NO_COLOR
 mkdir -p "$HOME/.config/omarchy/branding"
 printf '%s\n' '████████' '████████' >"$HOME/.config/omarchy/branding/about.txt"
 

--- a/test/shell.d/launch-about-test.sh
+++ b/test/shell.d/launch-about-test.sh
@@ -56,7 +56,8 @@ fastfetch() {
 
 # Record what the launcher hands the sheen rather than building any frames.
 handed=()
-sheen_build() { handed=("$@"); }
+sheen_prepare() { handed=("$@"); SHEEN_REST="rest"; }
+sheen_build_frames() { :; }
 
 refuses() {
   if build_sheen; then
@@ -79,6 +80,8 @@ pass "the launcher's padding is the fastfetch config's"
 
 build_sheen || fail "a roomy window animates"
 pass "a roomy window animates"
+(( ${#SHEEN_FRAMES[@]} == 0 )) || fail "the sweep is not computed before the first paint" "${#SHEEN_FRAMES[@]} frames"
+pass "the sweep is not computed before the first paint"
 
 # The sheen is told where the logo is, what colour to hand the cells back in, and
 # how much room it has left of the module column.
@@ -175,10 +178,26 @@ pass "an undisturbed sweep writes every frame"
 # Every builder above can be exercised while nothing on screen ever animates, so
 # check that the render loop is what calls them.
 render_block=$(sed -n '/--render/,$p' "$about")
-for called in build_sheen play_sheen rest_sheen; do
+for called in build_sheen play_sheen rest_sheen sheen_build_frames; do
   [[ $render_block == *"$called"* ]] || fail "the render loop plays the sheen" "it never calls $called"
 done
 pass "the render loop plays the sheen"
+
+# The banded rest has to land before the sweep is walked. A loop that still
+# computed every centre first would leave the config's green on screen for as
+# long as that walk took.
+awk_order='
+  /build_sheen/ { prep=NR }
+  /SHEEN_REST/ { rest=NR }
+  /sheen_build_frames/ { frames=NR }
+  END {
+    if (!(prep && rest && frames)) { print "missing"; exit 1 }
+    if (!(prep < rest && rest < frames)) { print prep, rest, frames; exit 1 }
+  }
+'
+order=$(printf '%s\n' "$render_block" | awk "$awk_order") ||
+  fail "the rest is written before the sweep is computed" "$order"
+pass "the rest is written before the sweep is computed"
 
 measure_layout() { return 1; }
 refuses "a layout fastfetch cannot be measured from leaves it still"

--- a/test/shell.d/screensaver-theme-test.sh
+++ b/test/shell.d/screensaver-theme-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+theme=$ROOT/bin/omarchy-screensaver-theme
+[[ -x $theme ]] || fail "omarchy-screensaver-theme is executable"
+
+catppuccin=$("$theme" "$ROOT/themes/catppuccin/colors.toml")
+[[ $catppuccin == $'#101019\n#6a8bc1,#4c6289,#89b4fa,#a0bff7,#b8cbf5\nrgb:10/10/19' ]] ||
+  fail "catppuccin field ramp follows accent toward background and bright_foreground" "$catppuccin"
+pass "catppuccin field ramp follows accent toward background and bright_foreground"
+
+latte=$("$theme" "$ROOT/themes/catppuccin-latte/colors.toml")
+[[ $latte == *$'\n#4c82ee,#7a9fe8,#1e66f5,#5e8dec,#9fb5e3\n'* ]] ||
+  fail "a light theme mixes hover and crest toward background" "$latte"
+pass "a light theme mixes hover and crest toward background"
+
+tokyo=$("$theme" "$ROOT/themes/tokyo-night/colors.toml")
+[[ $tokyo == $'#0e0e14\n#5f7dbe,#445885,#7aa2f7,#92b0f6,#abbef5\nrgb:0e/0e/14' ]] ||
+  fail "tokyo-night uses accent, not the site's green brand" "$tokyo"
+pass "tokyo-night uses accent, not the site's green brand"
+
+if "$theme" /tmp/missing-omarchy-colors.toml 2>/dev/null; then
+  fail "a missing colors.toml exits non-zero"
+fi
+pass "a missing colors.toml exits non-zero"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+stub=$test_tmp/bin
+mkdir -p "$stub"
+
+cat >"$stub/ttfx" <<'STUB'
+#!/bin/bash
+if [[ $1 == --help ]]; then
+  echo "      --palette"
+  exit 0
+fi
+printf '%s\n' "$@"
+STUB
+chmod +x "$stub/ttfx"
+
+# shellcheck source=../../bin/omarchy-screensaver-theme
+source "$ROOT/bin/omarchy-screensaver-theme"
+PATH="$stub:$PATH"
+
+ttfx_supports_palette || fail "ttfx --help with --palette is detected"
+pass "ttfx --help with --palette is detected"
+
+cat >"$stub/ttfx" <<'STUB'
+#!/bin/bash
+if [[ $1 == --help ]]; then
+  echo "      --random-effect"
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$stub/ttfx"
+ttfx_supports_palette && fail "ttfx --help without --palette is rejected"
+pass "ttfx --help without --palette is rejected"

--- a/test/shell.d/screensaver-theme-test.sh
+++ b/test/shell.d/screensaver-theme-test.sh
@@ -27,6 +27,18 @@ if "$theme" /tmp/missing-omarchy-colors.toml 2>/dev/null; then
 fi
 pass "a missing colors.toml exits non-zero"
 
+# shellcheck source=../../bin/omarchy-screensaver-theme
+source "$theme"
+nineteen=""
+for i in $(seq 0 18); do nineteen+=$(field_band_index_n "$i" 19); done
+[[ $nineteen == 0000011222233344444 ]] || fail "19 lines stay 5-2-4-3-5" "$nineteen"
+pass "19 lines stay 5-2-4-3-5"
+
+ten=""
+for i in $(seq 0 9); do ten+=$(field_band_index_n "$i" 10); done
+[[ $ten == 0001223444 ]] || fail "10 lines scale to 3-1-2-1-3" "$ten"
+pass "10 lines scale to 3-1-2-1-3"
+
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 stub=$test_tmp/bin

--- a/test/shell.d/screensaver-theme-test.sh
+++ b/test/shell.d/screensaver-theme-test.sh
@@ -8,17 +8,17 @@ theme=$ROOT/bin/omarchy-screensaver-theme
 [[ -x $theme ]] || fail "omarchy-screensaver-theme is executable"
 
 catppuccin=$("$theme" "$ROOT/themes/catppuccin/colors.toml")
-[[ $catppuccin == $'#101019\n#6a8bc1,#4c6289,#89b4fa,#a0bff7,#b8cbf5\nrgb:10/10/19' ]] ||
-  fail "catppuccin field ramp follows accent toward background and bright_foreground" "$catppuccin"
-pass "catppuccin field ramp follows accent toward background and bright_foreground"
+[[ $catppuccin == $'#101019\n#b8cbf5,#a0bff7,#89b4fa,#4c6289,#6a8bc1\nrgb:10/10/19' ]] ||
+  fail "catppuccin field ramp is crest, hover, lit, mid, dim" "$catppuccin"
+pass "catppuccin field ramp is crest, hover, lit, mid, dim"
 
 latte=$("$theme" "$ROOT/themes/catppuccin-latte/colors.toml")
-[[ $latte == *$'\n#4c82ee,#7a9fe8,#1e66f5,#5e8dec,#9fb5e3\n'* ]] ||
+[[ $latte == *$'\n#9fb5e3,#5e8dec,#1e66f5,#7a9fe8,#4c82ee\n'* ]] ||
   fail "a light theme mixes hover and crest toward background" "$latte"
 pass "a light theme mixes hover and crest toward background"
 
 tokyo=$("$theme" "$ROOT/themes/tokyo-night/colors.toml")
-[[ $tokyo == $'#0e0e14\n#5f7dbe,#445885,#7aa2f7,#92b0f6,#abbef5\nrgb:0e/0e/14' ]] ||
+[[ $tokyo == $'#0e0e14\n#abbef5,#92b0f6,#7aa2f7,#445885,#5f7dbe\nrgb:0e/0e/14' ]] ||
   fail "tokyo-night uses accent, not the site's green brand" "$tokyo"
 pass "tokyo-night uses accent, not the site's green brand"
 
@@ -60,3 +60,28 @@ STUB
 chmod +x "$stub/ttfx"
 ttfx_supports_palette && fail "ttfx --help without --palette is rejected"
 pass "ttfx --help without --palette is rejected"
+
+cat >"$stub/ttfx" <<'STUB'
+#!/bin/bash
+if [[ $1 == --help ]]; then
+  echo "      --palette"
+  echo "      --bands"
+  exit 0
+fi
+printf '%s\n' "$@"
+STUB
+chmod +x "$stub/ttfx"
+ttfx_supports_bands || fail "ttfx --help with --bands is detected"
+pass "ttfx --help with --bands is detected"
+
+cat >"$stub/ttfx" <<'STUB'
+#!/bin/bash
+if [[ $1 == --help ]]; then
+  echo "      --palette"
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$stub/ttfx"
+ttfx_supports_bands && fail "ttfx --help without --bands is rejected"
+pass "ttfx --help without --bands is rejected"

--- a/test/shell.d/show-logo-test.sh
+++ b/test/shell.d/show-logo-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command python3
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+export HOME=$tmp
+export OMARCHY_PATH=$ROOT
+export PATH="$ROOT/bin:$PATH"
+
+mkdir -p "$HOME/.local/state/omarchy/current/theme"
+ln -sfn "$ROOT/themes/tokyo-night/colors.toml" "$HOME/.local/state/omarchy/current/theme/colors.toml"
+
+out=$(omarchy-show-logo)
+printf '%s\n' "$out" | grep -q $'\033\[38;2;171;190;245m' ||
+  fail "the crest rows use the theme crest colour"
+pass "the crest rows use the theme crest colour"
+
+# tokyo-night lit is #7aa2f7
+printf '%s\n' "$out" | grep -q $'\033\[38;2;122;162;247m' ||
+  fail "a later row uses theme lit"
+pass "a later row uses theme lit"
+
+mapfile -t painted < <(printf '%s\n' "$out" | grep $'\033\[38;2;')
+(( ${#painted[@]} >= 10 )) || fail "every logo line is coloured" "${#painted[@]} lines"
+pass "every logo line is coloured"


### PR DESCRIPTION
## Summary

Screensaver colours come from the staged theme `colors.toml`, then ttfx draws the field.

- Background: `darker_background` (then `dark_background`, then `background`)
- Palette order: crest, hover, lit, mid, dim (mix accent toward background and bright_foreground; light themes mix the bright stops toward background)
- Passed as `--palette`, `--terminal-background-color`, and `--bands` when the installed ttfx advertises those flags
- OSC 11 and Kitty `background=` use the same background
- Stock ttfx 0.3.2 without `--palette` still runs (black, default effect colours)
- The same 4-3-4-3-5 ramp colours `omarchy-show-logo` (the FIGlet in `logo.txt`) and the About sheen (each row of `about.txt` / `icon.txt`). Fastfetch can only set one logo colour; the sheen restores per-row band colours
- Default art remains the 10-line FIGlet in `logo.txt`

Stock `logo.txt` will not match the omarchy.org wordmark stripe-for-stripe: the site is an 81×19 square-pixel bitmap painted **4, 3, 4, 3, 5**, a terminal cell is twice as tall as it is wide, and `--bands` spreads that ratio across however many lines the input has (19 lines stay 4-3-4-3-5; ten lines become 2-2-2-1-3).

Tokyo Night uses `accent`, not the omarchy.org green brand.

Needs a ttfx build that has `--palette` and `--bands` (csfh/ttfx).

## Test plan

- [x] `bash test/shell.d/screensaver-theme-test.sh`
- [x] 19 lines stay `0000111222233344444`; 10 lines scale to `0011223444`
- [ ] Palette-capable ttfx on PATH, then `omarchy-launch-screensaver force` on Catppuccin, Tokyo Night, and a light theme
- [ ] Word shows five stripes on the letter body (FIGlet snaps to whole rows)