### PR TITLE
Add Ubuntu Cloud Agent environment for CLI and shell tests

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "name": "Omarchy CLI and shell tests",
+  "install": "bash .cursor/install.sh",
+  "repositoryDependencies": [
+    "github.com/omacom-io/omarchy-pkgs",
+    "github.com/omacom/omarchy-iso"
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Idempotent Cloud Agent bootstrap.
+#
+# Spike (2026-09-08): Hyprland 0.56.2 + Aquamarine 0.15 cannot start without
+# /dev/dri. On this Omarchy host, hiding DRM with bwrap --tmpfs /dev/dri and
+# AQ_NO_KMS_REQUIREMENT=1 aborted with CBackend::create() failed!. In a
+# throwaway archlinux:base-devel container (no --device, no seatd/logind)
+# Aquamarine logged "Cannot open backend: no allocator available" and
+# "could not find a GPU". A custom Arch image therefore cannot host a live
+# Omarchy (Hyprland + Quickshell) session on Cloud Agents, which also have
+# no /dev/dri. Cursor computer-use is documented as Debian/Ubuntu-only, so
+# this script stays on the default Ubuntu image and only installs the tools
+# ./test/cli and ./test/shell need. Graphical acceptance stays on omarchy-iso
+# VMs. Do not replay install/ or start Hyprland here.
+
+set -euo pipefail
+
+WORK_DIR="$HOME/Work/omacom"
+PKGS_DIR="$WORK_DIR/omarchy-pkgs"
+ISO_DIR="$WORK_DIR/omarchy-iso"
+
+install_ubuntu_tools() {
+  sudo apt-get update
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ffmpeg \
+    gawk \
+    imagemagick \
+    jq \
+    libxkbcommon-tools \
+    lua5.4 \
+    plocate \
+    python-is-python3 \
+    qrencode \
+    ripgrep
+
+  sudo update-alternatives --install /usr/bin/awk awk /usr/bin/gawk 100
+  sudo update-alternatives --set awk /usr/bin/gawk
+  sudo update-alternatives --install /usr/bin/lua lua /usr/bin/lua5.4 100
+
+  if ! command -v magick >/dev/null; then
+    if command -v convert >/dev/null; then
+      sudo ln -sfn "$(command -v convert)" /usr/local/bin/magick
+    fi
+  fi
+}
+
+ensure_checkout() {
+  local dest="$1"
+  local url="$2"
+  local marker="${3:-.git}"
+
+  if [[ -e $dest/$marker ]]; then
+    git -C "$dest" pull --ff-only || true
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$dest")"
+  git clone --depth 1 "$url" "$dest"
+}
+
+if [[ -r /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  if [[ ${ID:-} == "ubuntu" || ${ID:-} == "debian" || ${ID_LIKE:-} == *debian* ]]; then
+    install_ubuntu_tools
+  fi
+fi
+
+ensure_checkout "$PKGS_DIR" https://github.com/omacom-io/omarchy-pkgs.git pkgbuilds
+ensure_checkout "$ISO_DIR" https://github.com/omacom/omarchy-iso.git .git


### PR DESCRIPTION
## Summary
- Confirmed Hyprland 0.56.2 cannot start without `/dev/dri` (host bwrap hide-DRM and `archlinux:base-devel` container both abort with Aquamarine `no allocator available` / `CBackend::create() failed!`, even with `AQ_NO_KMS_REQUIREMENT=1`).
- A custom Arch/Omarchy desktop image is therefore not viable on Cloud Agents (no GPU, no systemd session, and Cursor computer-use is Debian/Ubuntu-only).
- Adds `.cursor/environment.json` plus an idempotent `.cursor/install.sh` that stays on the default Ubuntu image, installs the CLI/shell test toolchain, and clones `omarchy-pkgs` + `omarchy-iso` where those suites look for them.

## Test plan
- [x] Host spike: `bwrap --tmpfs /dev/dri` + `AQ_NO_KMS_REQUIREMENT=1 Hyprland` → `CBackend::create() failed!`
- [x] Container spike: `podman run archlinux:base-devel` with no `/dev/dri` → `Cannot open backend: no allocator available`
- [x] `bash .cursor/install.sh` on Omarchy (skips apt, clones sibling repos)
- [x] `./test/cli` passes
- [x] `./test/shell.d/snapper-test.sh` passes after sibling checkouts
- [ ] New Cloud Agent starts from this config and `./test/cli` is green
- [ ] Computer-use desktop (XFCE/VNC) still appears on the default Ubuntu image