### PR TITLE
Clean up speed test workers when interrupted

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -64,7 +64,7 @@ cleanup() {
     wait "$pid" 2>/dev/null || true
   done
 }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
 
 # Round-robin across the returned URLs so we spread load across Netflix OCA nodes.
 traffic_worker() {


### PR DESCRIPTION
`omarchy-network-speedtest` spawns 8 background workers that loop `curl` against Netflix OCA endpoints until told to stop. `cleanup()` is only reachable through `trap cleanup EXIT`.

On **SIGINT** the EXIT trap does not run, so all 8 workers are orphaned and keep downloading indefinitely after the script is gone.

Reproduced on x86_64, bash 5.3.15, Omarchy 4.0.2-1: 4 s into a `down` run, `kill -INT` on the script left **11 `curl` processes still streaming** from `*.oca.nflxvideo.net`. After this change, 0 orphans.

```diff
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
```

| trap | signal | cleanup ran | orphaned workers |
|---|---|---|---|
| `EXIT` (current) | TERM | yes | 0 |
| `EXIT` (current) | **INT** | **no** | **8** |
| `EXIT INT TERM` | INT | yes | 0 |
| either | KILL | no | 8 (unavoidable) |

### Note on #10735

#10735 proposes this same change, but attributes the leak to **SIGTERM**. That part does not reproduce here.

Bash runs the EXIT trap on SIGTERM via `termsig_handler`, so `cleanup()` completes normally and leaves 0 orphans — verified both with a minimal repro and with the real script (8 workers + 8 curls, all gone within 3 s of `kill -TERM`).

Since the panel terminates the process with SIGTERM (`shell/plugins/panels/speedtest/Panel.qml`, "A dismissal's SIGTERM is still in flight"), **this change should not be expected to fix the panel-dismiss symptom reported in #10735** — that has another cause, still unidentified. Worth keeping #10735 open after this merges.

`INT` is the signal that actually changes behavior here; `TERM` is included for correctness on shells that do not run EXIT traps on signals.