### PR TITLE
Install broadcom-wl-dkms now that Arch dropped the prebuilt module

### DIFF
--- a/install/hardware/fix-bcm43xx.sh
+++ b/install/hardware/fix-bcm43xx.sh
@@ -6,5 +6,5 @@ pci_info=$(lspci -nn)
 
 if (echo "$pci_info" | grep -q "14e4:43a0" || echo "$pci_info" | grep -q "14e4:4331"); then
   echo "BCM4360 / BCM4331 detected"
-  omarchy-pkg-add broadcom-wl dkms linux-headers
+  omarchy-pkg-add broadcom-wl-dkms linux-headers
 fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -5,7 +5,7 @@ autoconf-archive
 asusctl
 base
 base-devel
-broadcom-wl
+broadcom-wl-dkms
 btrfs-progs
 dkms
 egl-wayland


### PR DESCRIPTION
Arch removed the prebuilt `broadcom-wl` package on 2026-09-02 and rebuilt `broadcom-wl-dkms` with `replaces=(broadcom-wl)`. A replaces entry only helps upgrades of an already-installed package, so the name is now unresolvable as an explicit pacman target and the ISO offline mirror download fails with `target not found: broadcom-wl`.

- `install/omarchy-other.packages`: `broadcom-wl` → `broadcom-wl-dkms`
- `install/hardware/fix-bcm43xx.sh`: install `broadcom-wl-dkms linux-headers` (the dkms package already depends on `dkms`)

Shell tests that read the package lists (`t2-hardware-test.sh`, `preinstalls-test.sh`) pass.