### PR TITLE
Backport: install broadcom-wl-dkms now that Arch dropped the prebuilt module

### DIFF
--- a/install/hardware/fix-bcm43xx.sh
+++ b/install/hardware/fix-bcm43xx.sh
@@ -6,5 +6,5 @@ pci_info=$(lspci -nn)
 
 if (echo "$pci_info" | grep -q "14e4:43a0" || echo "$pci_info" | grep -q "14e4:4331"); then
   echo "BCM4360 / BCM4331 detected"
-  omarchy-pkg-add broadcom-wl dkms linux-headers
+  omarchy-pkg-add broadcom-wl-dkms linux-headers
 fi

--- a/install/omarchy-other.packages
+++ b/install/omarchy-other.packages
@@ -5,7 +5,7 @@ autoconf-archive
 asusctl
 base
 base-devel
-broadcom-wl
+broadcom-wl-dkms
 btrfs-progs
 dkms
 egl-wayland


### PR DESCRIPTION
Cherry-pick of 649c0b74 from quattro onto v4-0-3. Arch removed the prebuilt `broadcom-wl` package on 2026-09-02; the old name now fails as an explicit pacman target and breaks the ISO offline mirror download. Swaps it for `broadcom-wl-dkms` in `omarchy-other.packages` and the BCM4360 hardware fix.