### PR TITLE
Open WhatsApp protocol links in the web app

### DIFF
--- a/applications/WhatsApp.desktop
+++ b/applications/WhatsApp.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Version=1.0
 Name=WhatsApp
-Exec=omarchy-launch-webapp https://web.whatsapp.com/
+Exec=omarchy-webapp-handler-whatsapp %u
 Terminal=false
 Type=Application
 Icon=whatsapp
 StartupNotify=true
+MimeType=x-scheme-handler/whatsapp

--- a/bin/omarchy-webapp-handler-whatsapp
+++ b/bin/omarchy-webapp-handler-whatsapp
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# omarchy:summary=Open WhatsApp links in the WhatsApp web app
+# omarchy:args=[url]
+
+url="${1:-}"
+web_url="https://web.whatsapp.com/"
+
+if [[ $url =~ ^whatsapp://send/?\?([^#]+) ]]; then
+  web_url="https://web.whatsapp.com/send?${BASH_REMATCH[1]}"
+fi
+
+exec omarchy-launch-webapp "$web_url"

--- a/manual/25-web-apps.md
+++ b/manual/25-web-apps.md
@@ -42,7 +42,8 @@ You can start Grok using `Super + Shift + Alt + A`.
 
 [WhatsApp](https://www.whatsapp.com/) is one of the most popular messaging services in the world, and the web version is a great option for Linux.
 
-You can start WhatsApp using `Super + Shift + Alt + G`.
+You can start WhatsApp using `Super + Shift + Alt + G`. Links that use the
+`whatsapp://` protocol also open directly in this web app.
 
 ## Google apps
 

--- a/migrations/1788836249.sh
+++ b/migrations/1788836249.sh
@@ -1,0 +1,8 @@
+echo "Enable whatsapp:// links in the WhatsApp web app"
+
+whatsapp_desktop="$HOME/.local/share/applications/WhatsApp.desktop"
+
+if [[ -f $whatsapp_desktop ]]; then
+  cp "$OMARCHY_PATH/applications/WhatsApp.desktop" "$whatsapp_desktop"
+  update-desktop-database "$HOME/.local/share/applications"
+fi

--- a/test/shell.d/webapp-handler-whatsapp-test.sh
+++ b/test/shell.d/webapp-handler-whatsapp-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stubs="$tmpdir/stubs"
+mkdir -p "$stubs"
+
+cat >"$stubs/omarchy-launch-webapp" <<'SH'
+#!/bin/bash
+printf '<%s>\n' "$@"
+SH
+chmod +x "$stubs/omarchy-launch-webapp"
+
+handler="$ROOT/bin/omarchy-webapp-handler-whatsapp"
+
+actual=$(PATH="$stubs:$PATH" "$handler" 'whatsapp://send?phone=15551234567&text=Hello%20there')
+[[ $actual == '<https://web.whatsapp.com/send?phone=15551234567&text=Hello%20there>' ]] ||
+  fail "WhatsApp handler preserves phone and encoded message parameters" "$actual"
+pass "WhatsApp handler translates send links"
+
+actual=$(PATH="$stubs:$PATH" "$handler" 'whatsapp://send/?phone=15551234567#ignored')
+[[ $actual == '<https://web.whatsapp.com/send?phone=15551234567>' ]] ||
+  fail "WhatsApp handler strips URL fragments" "$actual"
+pass "WhatsApp handler accepts the send slash variant"
+
+for url in '' 'whatsapp://' 'whatsapp://settings' 'https://example.com/?phone=15551234567'; do
+  actual=$(PATH="$stubs:$PATH" "$handler" "$url")
+  [[ $actual == '<https://web.whatsapp.com/>' ]] ||
+    fail "WhatsApp handler falls back safely for '$url'" "$actual"
+done
+pass "WhatsApp handler falls back to the WhatsApp home page"
+
+desktop="$ROOT/applications/WhatsApp.desktop"
+grep -Fxq 'Exec=omarchy-webapp-handler-whatsapp %u' "$desktop" ||
+  fail "WhatsApp desktop entry routes protocol links through the handler"
+grep -Fxq 'MimeType=x-scheme-handler/whatsapp' "$desktop" ||
+  fail "WhatsApp desktop entry registers the whatsapp scheme"
+pass "WhatsApp desktop entry registers the protocol handler"
+
+migration="$ROOT/migrations/1788836249.sh"
+home="$tmpdir/home"
+mkdir -p "$home/.local/share/applications"
+
+cat >"$stubs/update-desktop-database" <<'SH'
+#!/bin/bash
+printf '%s\n' "$1" >>"$UPDATE_LOG"
+SH
+chmod +x "$stubs/update-desktop-database"
+
+update_log="$tmpdir/update.log"
+touch "$home/.local/share/applications/WhatsApp.desktop"
+HOME="$home" OMARCHY_PATH="$ROOT" UPDATE_LOG="$update_log" PATH="$stubs:$PATH" \
+  bash -euo pipefail "$migration" >/dev/null
+cmp -s "$ROOT/applications/WhatsApp.desktop" "$home/.local/share/applications/WhatsApp.desktop" ||
+  fail "WhatsApp migration refreshes an installed launcher"
+[[ $(wc -l <"$update_log") == 1 ]] || fail "WhatsApp migration refreshes the desktop database"
+pass "WhatsApp migration upgrades an existing launcher"
+
+rm -f "$home/.local/share/applications/WhatsApp.desktop"
+: >"$update_log"
+HOME="$home" OMARCHY_PATH="$ROOT" UPDATE_LOG="$update_log" PATH="$stubs:$PATH" \
+  bash -euo pipefail "$migration" >/dev/null
+[[ ! -e $home/.local/share/applications/WhatsApp.desktop ]] ||
+  fail "WhatsApp migration does not restore a removed preinstall"
+[[ ! -s $update_log ]] || fail "WhatsApp migration skips the desktop database when no launcher exists"
+pass "WhatsApp migration preserves a removed preinstall"


### PR DESCRIPTION
The bundled WhatsApp launcher could open the web app directly, but `whatsapp://` links had no registered destination. This adds a small protocol handler that translates `whatsapp://send` URLs to the fixed `web.whatsapp.com` origin, registers it on the existing launcher, and upgrades existing installs without restoring a removed preinstall.

Validation:

- `test/shell.d/webapp-handler-whatsapp-test.sh`
- `./test/cli`
- `desktop-file-validate applications/WhatsApp.desktop`
- `./test/all` matched the clean-checkout failure baseline; the feature test and CLI suite passed

Closes #10761.
