### PR TITLE
Restrict clipboard history file modes

### DIFF
--- a/migrations/1788843383.sh
+++ b/migrations/1788843383.sh
@@ -1,0 +1,13 @@
+echo "Restrict clipboard history file modes"
+
+state="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
+json="$state/clipboard-history.json"
+images="$state/clipboard-images"
+
+if [[ -f $json ]]; then
+  chmod 600 "$json"
+fi
+
+if [[ -d $images ]]; then
+  chmod 700 "$images"
+fi

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -74,6 +74,10 @@ Item {
 
   function saveHistory() {
     historyFile.setText(JSON.stringify(root.history.slice(0, root.historyLimit), null, 2) + "\n")
+    // FileView creates the JSON at umask 022 (0644). Image blobs from
+    // capture.sh are already 0600; the text dump of the same clipboard
+    // should not be world-readable.
+    Quickshell.execDetached(["chmod", "600", root.historyPath])
   }
 
   function addClipboardEntry(entry) {

--- a/shell/plugins/clipboard/capture.sh
+++ b/shell/plugins/clipboard/capture.sh
@@ -9,6 +9,7 @@ set -o pipefail
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
 IMAGE_DIR="$STATE_DIR/clipboard-images"
 mkdir -p "$IMAGE_DIR"
+chmod 700 "$IMAGE_DIR"
 
 types=$(wl-paste --list-types 2>/dev/null || true)
 

--- a/test/shell.d/clipboard-history-mode-migration-test.sh
+++ b/test/shell.d/clipboard-history-mode-migration-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname -- "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1788843383.sh"
+[[ -f $migration ]] || fail "the clipboard history mode migration exists at $migration"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+run_migration() {
+  HOME="$test_dir/home" XDG_STATE_HOME="$test_dir/state" bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration
+pass "clipboard mode migration no-ops when history is absent"
+
+mkdir -p "$test_dir/state/omarchy/clipboard-images"
+printf '[]\n' >"$test_dir/state/omarchy/clipboard-history.json"
+chmod 644 "$test_dir/state/omarchy/clipboard-history.json"
+chmod 755 "$test_dir/state/omarchy/clipboard-images"
+
+run_migration
+[[ $(stat -c '%a' "$test_dir/state/omarchy/clipboard-history.json") == 600 ]] ||
+  fail "clipboard mode migration sets history JSON 0600"
+pass "clipboard mode migration sets history JSON 0600"
+[[ $(stat -c '%a' "$test_dir/state/omarchy/clipboard-images") == 700 ]] ||
+  fail "clipboard mode migration sets images directory 0700"
+pass "clipboard mode migration sets images directory 0700"
+
+run_migration
+[[ $(stat -c '%a' "$test_dir/state/omarchy/clipboard-history.json") == 600 ]] ||
+  fail "clipboard mode migration is idempotent"
+pass "clipboard mode migration is idempotent"

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -163,6 +163,10 @@ assert(
   'clipboard does not select rows from containsMouse'
 )
 assert(
+  /function saveHistory\(\)[\s\S]*Quickshell\.execDetached\(\["chmod", "600", root\.historyPath\]\)/.test(clipboardQml),
+  'clipboard saveHistory chmods the history file 0600'
+)
+assert(
   clipboardQml.includes('command: ["setpriv", "--pdeathsig", "TERM", "wl-paste", "--type", "text", "--watch", root.captureScript, "text"]'),
   'clipboard text watcher dies with the shell via pdeathsig'
 )
@@ -384,6 +388,11 @@ image_path=$(jq -r '.path' <<<"$capture_output")
 jq -e '.type == "image" and .mime == "image/png" and (.capturedAt | type == "string")' <<<"$capture_output" >/dev/null || fail "clipboard capture records watched png images"
 [[ -s $image_path && $(<"$image_path") == "png-data" ]] || fail "clipboard capture stores watched png image data"
 pass "clipboard capture records watched png images"
+
+[[ $(stat -c '%a' "$TMPDIR/state/omarchy/clipboard-images") == 700 ]] || fail "clipboard capture makes the images directory 0700"
+pass "clipboard capture makes the images directory 0700"
+[[ $(stat -c '%a' "$image_path") == 600 ]] || fail "clipboard capture stores watched png images 0600"
+pass "clipboard capture stores watched png images 0600"
 
 capture_output=$(printf 'jpg-data' | XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" "$ROOT/shell/plugins/clipboard/capture.sh" image/jpeg)
 image_path=$(jq -r '.path' <<<"$capture_output")


### PR DESCRIPTION
## Summary

Clipboard history is a secret store (passwords, tokens, URLs). Image blobs are already `0600` via `mktemp`. The JSON dump of the same clipboard is written by Quickshell `FileView` under umask `022`, so it lands `0644`.

A second local account, a backup, or a tarball of `~/.local/state` can then read recent clipboard text. `$HOME` is often `700`, which hides it on a single-user box; the file mode is still wrong, and the images directory next to it is `755`.

## Change

- `chmod 600` the history JSON after each `FileView.setText`
- `chmod 700` the `clipboard-images` directory from `capture.sh` (files stay `0600`)
- Migration for existing installs

## Check

```bash
umask
# 0022

stat -c '%a %n' ~/.local/state/omarchy/clipboard-history.json ~/.local/state/omarchy/clipboard-images
# before: 644 and 755
# after first save / migration: 600 and 700
```

`test/shell.d/clipboard-test.sh` and `test/shell.d/clipboard-history-mode-migration-test.sh` pass.

## Test plan

- [x] `bash test/shell.d/clipboard-test.sh`
- [x] `bash test/shell.d/clipboard-history-mode-migration-test.sh`
- [x] Copy text, confirm history still records and Super+Ctrl+V still pastes