### PR TITLE
Keep Cursor bundled Node off the mise PATH

### DIFF
--- a/etc/mise/conf.d/omarchy.toml
+++ b/etc/mise/conf.d/omarchy.toml
@@ -1,0 +1,4 @@
+# Keep Cursor optional while applying these options whenever mise installs it.
+# Expose only its launcher so the bundled Node cannot shadow the user's Node.
+[tool_alias]
+cursor-agent = 'http:cursor-agent[bin_path=bin,postinstall=mkdir -p "$MISE_TOOL_INSTALL_PATH/bin" && ln -sfn ../dist-package/cursor-agent "$MISE_TOOL_INSTALL_PATH/bin/cursor-agent"]'


### PR DESCRIPTION
Cursor's mise entry adds its entire `dist-package` directory to PATH, including its private Node. When Cursor comes before the selected Node, `node` runs Cursor's bundled 24.5.0 and breaks OpenClaw.

Ship a system mise backend alias in `/etc/mise/conf.d/omarchy.toml`. Its postinstall hook exposes only `cursor-agent` through a separate `bin/` directory. Cursor still uses its private runtime and installs on first use. `omarchy-settings` already packages the `etc/` tree, so this needs no package-script change or migration for the new Cursor addition.

Verified with mise 2026.9.1 and Cursor 2026.09.02-c22c1a3 in isolated mise state: reproduced the Node collision, then confirmed a fresh install runs Cursor through the existing wrapper commands and mise shims while `node` stays at the selected 25.9.0. Cursor is unselected before first use, and `mise unuse --global cursor-agent` removes it without the system config selecting it again.
