### PR TITLE
feat: add Simplified Chinese UI localization

### DIFF
--- a/docs/chinese-ui.md
+++ b/docs/chinese-ui.md
@@ -1,0 +1,12 @@
+# 中文界面
+
+Omarchy 的 Quickshell 菜单支持简体中文。界面语言遵循当前桌面语言环境：当 `LANG` 或 `LANGUAGE` 以 `zh` 开头时，菜单标签、系统菜单和日历月份/星期会显示中文；其他语言保持英文。
+
+也可以只为 Omarchy 强制指定语言，不改变系统其他程序：
+
+```bash
+export OMARCHY_UI_LANGUAGE=zh-CN  # 中文
+export OMARCHY_UI_LANGUAGE=en     # 英文
+```
+
+将变量加入 `~/.config/environment.d/omarchy.conf` 后重新登录即可长期生效。菜单中的命令 ID、脚本名称和应用名称不会被翻译，因此快捷键、自动化脚本及第三方扩展保持兼容。新增菜单扩展时使用英文 `label`，中文映射位于 `shell/i18n/zh_CN.js`，可直接提交新的词条。

--- a/shell/Ui/ConfirmDialog.qml
+++ b/shell/Ui/ConfirmDialog.qml
@@ -1,4 +1,6 @@
 import QtQuick
+import Quickshell
+import "../i18n/zh_CN.js" as ZhCN
 import qs.Commons
 
 Item {
@@ -6,8 +8,9 @@ Item {
 
   property bool opened: false
   property string message: ""
-  property string cancelText: "Cancel"
-  property string confirmText: "Confirm"
+  readonly property bool chineseUi: (Quickshell.env("OMARCHY_UI_LANGUAGE") || Quickshell.env("LANGUAGE") || Quickshell.env("LANG") || "").toLowerCase().indexOf("zh") === 0
+  property string cancelText: chineseUi ? ZhCN.translate("Cancel") : "Cancel"
+  property string confirmText: chineseUi ? ZhCN.translate("Confirm") : "Confirm"
   property int selectedIndex: 1
   property color background: Color.background
   property color foreground: Color.foreground

--- a/shell/i18n/zh_CN.js
+++ b/shell/i18n/zh_CN.js
@@ -1,0 +1,69 @@
+// Chinese (Simplified) labels for the Omarchy shell.
+// Keys intentionally match the English source labels so extensions and
+// third-party plugins continue to work without changing their IDs.
+var labels = {
+  "Go": "前往", "Input": "输入", "Select": "选择",
+  "Apps": "应用", "Learn": "学习", "Trigger": "快捷操作", "Style": "外观",
+  "Setup": "设置", "Install": "安装", "Remove": "卸载", "Update": "更新",
+  "About": "关于", "System": "系统", "Screensaver": "屏幕保护",
+  "Lock": "锁定", "Suspend": "挂起", "Hibernate": "休眠", "Logout": "退出登录",
+  "Reboot": "重启", "Shutdown": "关机", "Keybindings": "快捷键",
+  "Community": "社区", "Emoji": "表情符号", "Reminder": "提醒",
+  "Capture": "截取", "Screenshot": "截图", "Stop Screenrecording": "停止录屏",
+  "Screenrecord": "录屏", "Text": "文字", "QR Code": "二维码", "Color": "取色",
+  "With no audio": "无音频", "With desktop audio": "桌面音频",
+  "With desktop + microphone audio": "桌面音频 + 麦克风",
+  "With desktop + microphone audio + webcam": "桌面音频 + 麦克风 + 摄像头",
+  "Transcode": "转码", "Share": "分享", "Toggle": "切换", "Hardware": "硬件",
+  "Speed Test": "测速", "Laptop Display": "笔记本屏幕", "Mirror Display": "镜像显示",
+  "Hybrid GPU": "混合显卡", "Touchpad": "触控板", "Touchpad Haptics": "触控板触感",
+  "Touchscreen": "触摸屏", "Set one": "设置提醒", "Show all": "显示全部",
+  "Clear all": "清除全部", "Clipboard": "剪贴板", "File": "文件", "Folder": "文件夹",
+  "Receive": "接收", "Stay Awake": "保持唤醒", "Notifications": "通知",
+  "Crash Capture": "崩溃捕获", "Nightlight": "夜间模式", "Menu Bar": "菜单栏",
+  "Battery Percentage": "电池百分比", "Workspace Layout": "工作区布局",
+  "Window Gaps": "窗口间距", "1-Window Ratio": "单窗口比例", "Network Speed Test": "网络测速",
+  "Disk Speed Test": "磁盘测速", "Theme": "主题", "Background": "背景",
+  "Unlock": "解锁界面", "Font": "字体", "Position": "位置", "Transparency": "透明度",
+  "Top": "顶部", "Bottom": "底部", "Left": "左侧", "Right": "右侧",
+  "Edit Text": "编辑文字", "Set From Image": "从图片设置", "Restore Default": "恢复默认",
+  "Monitors": "显示器", "Input": "输入", "Network": "网络", "DNS": "DNS",
+  "DHCP": "DHCP", "Custom": "自定义", "Defaults": "默认值", "Browser": "浏览器",
+  "Terminal": "终端", "Editor": "编辑器", "Plugins": "插件", "Enable Plugin": "启用插件",
+  "Disable Plugin": "禁用插件", "Add Plugin": "添加插件", "Clone Plugin": "克隆插件",
+  "Remove Plugin": "移除插件", "Security": "安全", "Password": "密码",
+  "Package": "软件包", "AI": "人工智能", "Service": "服务", "Services": "服务",
+  "Development": "开发", "Gaming": "游戏", "Web App": "网页应用", "TUI": "终端界面",
+  "Windows": "Windows", "Preinstalls": "预装软件", "Extra Themes": "额外主题",
+  "Process": "进程", "Firmware": "固件", "Timezone": "时区", "Time": "时间",
+  "Reset to default": "恢复默认", "Restart": "重启", "Remove": "卸载",
+  "Stable": "稳定版", "Edge": "体验版", "Dev": "开发版", "Audio": "音频",
+  "Wi-Fi": "Wi-Fi", "Bluetooth": "蓝牙", "Trackpad": "触控板", "User": "用户",
+  "Drive Encryption": "磁盘加密", "No matches for": "没有匹配项", "Nothing here yet": "这里还没有内容",
+  "Search...": "搜索…", "Search emojis…": "搜索表情符号…", "Search city": "搜索城市",
+  "No options": "没有选项", "No matches": "没有匹配项", "Cancel": "取消", "Confirm": "确认",
+  "Back to today": "回到今天", "Open Captive Portal": "打开认证门户",
+  "Connected": "已连接", "Disconnected": "未连接", "No connection": "无网络连接",
+  "No adapter": "没有适配器", "No Bluetooth adapter": "没有蓝牙适配器"
+}
+
+function translate(value) {
+  var text = String(value || "")
+  return labels[text] || text
+}
+
+function translateItems(items) {
+  var out = []
+  for (var i = 0; i < (items || []).length; i++) {
+    var item = items[i]
+    var copy = {}
+    for (var key in item) copy[key] = item[key]
+    copy.label = translate(copy.label)
+    if (copy.title) copy.title = translate(copy.title)
+    if (copy.description) copy.description = translate(copy.description)
+    out.push(copy)
+  }
+  return out
+}
+
+if (typeof module !== "undefined") module.exports = { labels: labels, translate: translate, translateItems: translateItems }

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -5,12 +5,17 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 import "MenuModel.js" as MenuModel
+import "../../i18n/zh_CN.js" as ZhCN
 
 Item {
   id: root
 
   // Injected by omarchy-shell when this plugin is summoned.
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+  // Set OMARCHY_UI_LANGUAGE=en to force English, or zh-CN to force Chinese.
+  // With no override, the desktop LANG is used.
+  readonly property string uiLanguage: Quickshell.env("OMARCHY_UI_LANGUAGE") || Quickshell.env("LANGUAGE") || Quickshell.env("LANG") || "en_US"
+  readonly property bool chineseUi: uiLanguage.toLowerCase().indexOf("zh") === 0
   property var shell: null
   property var manifest: null
 
@@ -237,7 +242,8 @@ Item {
   }
 
   function parseMenuJsonc(raw) {
-    return MenuModel.parseMenuJsonc(raw)
+    var parsed = MenuModel.parseMenuJsonc(raw)
+    return root.chineseUi ? ZhCN.translateItems(parsed) : parsed
   }
 
   // Merge defaults + user extension. Later entries override earlier ones
@@ -861,7 +867,8 @@ Item {
   function openDmenu(payload) {
     requestSerial += 1
     mode = payload.mode === "input" ? "input" : "select"
-    dmenuPrompt = String(payload.prompt || (mode === "input" ? "Input" : "Select"))
+    var prompt = String(payload.prompt || (mode === "input" ? "Input" : "Select"))
+    dmenuPrompt = root.chineseUi ? ZhCN.translate(prompt) : prompt
     dmenuOptions = Array.isArray(payload.options) ? payload.options : []
     selectionFile = String(payload.selectionFile || "")
     doneFile = String(payload.doneFile || "")
@@ -1459,7 +1466,9 @@ Item {
 
             Text {
               textFormat: Text.PlainText
-              text: root.filterText ? "No matches for “" + root.filterText + "”" : "Nothing here yet"
+            text: root.filterText
+              ? (root.chineseUi ? "没有匹配项：“" + root.filterText + "”" : "No matches for “" + root.filterText + "”")
+              : (root.chineseUi ? "这里还没有内容" : "Nothing here yet")
               color: root.foreground
               opacity: 0.7
               font.family: root.fontFamily

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -64,10 +64,9 @@ Panel {
   // convention. Clicking the grid's "W" heading writes the choice back to
   // shell.json.
   readonly property int weekStart: Model.normalizedWeekStart(setting("weekStartDay", null), Qt.locale().firstDayOfWeek)
-  // The interface is English throughout, so day names are not taken from the
-  // system locale. Where the week starts still is: that is a regional
-  // convention rather than a translation, and it stays overridable above.
-  readonly property var labelLocale: Qt.locale("en_US")
+  // Follow the desktop locale so Chinese installations get Chinese month and
+  // weekday names while the week-start preference remains overridable above.
+  readonly property var labelLocale: Qt.locale()
   readonly property string nextWeekStartLabel: labelLocale.dayName(Model.toggledWeekStart(weekStart), Locale.LongFormat)
   readonly property var weekdays: Model.weekdayOrder(weekStart)
   readonly property var weeks: Model.monthGrid(viewYear, viewMonth, weekStart, todayKey)


### PR DESCRIPTION
## Summary

This pull request adds initial Simplified Chinese localization support for the Omarchy shell.

- Translate common Omarchy menu labels and titles into Simplified Chinese.
- Automatically use Chinese when `LANG` or `LANGUAGE` starts with `zh`.
- Allow users to override the language with `OMARCHY_UI_LANGUAGE=zh-CN` or `OMARCHY_UI_LANGUAGE=en`.
- Localize confirmation dialog actions and calendar month/weekday names.
- Keep command IDs, actions, application IDs, and extension compatibility unchanged.
- Document how to enable and extend the Chinese translation map.

## Backward compatibility

The default English UI remains unchanged for non-Chinese locales.

## Verification

- `bash test/shell.d/menu-test.sh`
- `git diff --check`