### PR TITLE
Add an Agents panel default that launches the selected tab

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -37,6 +37,24 @@ done
 
 agent=$(omarchy-default-agent)
 
+# Setup → Defaults → Agent → Agents panel follows the tab last selected in
+# the agents bar widget instead of pinning one CLI.
+if [[ $agent == "agents-panel" ]]; then
+  selected_file="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/selected"
+  selected=""
+  if [[ -f $selected_file ]]; then
+    IFS= read -r selected <"$selected_file" || true
+  fi
+  case "$selected" in
+  pi | omp | opencode | ori | claude | codex | grok | openclaw | agy | hermes | copilot | crush | cursor-agent | muse)
+    agent=$selected
+    ;;
+  *)
+    agent=""
+    ;;
+  esac
+fi
+
 # Omarchy ships without a default, so there is nothing to launch until one is
 # picked. --pick offers the choice instead of the error, which is what the
 # keybinding wants: a keypress that opens nothing explains nothing.

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Set and launch the default coding agent
-# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse]
-# omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent claude
+# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse|agents-panel]
+# omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent agents-panel
 
 installing=false
 if [[ ${1:-} == "--install" ]]; then
@@ -42,8 +42,30 @@ muse | muse-code | musecode)
   agent_package="http:muse[url=https://api.meta.ai/muse-launcher.sh,bin=muse,version_list_url=https://api.meta.ai/muse-code/channels/muse-stable,version_json_path=.version]"
   ;;
 cursor | cursor-agent) agent="cursor-agent"; name="Cursor CLI" ;;
+agents-panel)
+  mkdir -p "$(dirname "$agent_file")"
+  printf '%s\n' "agents-panel" >"$agent_file"
+  # Not a CLI: nothing to install. Launch only if the panel already has a tab.
+  selected_file="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/selected"
+  selected=""
+  if [[ -f $selected_file ]]; then
+    IFS= read -r selected <"$selected_file" || true
+  fi
+  case "$selected" in
+  pi | omp | opencode | ori | claude | codex | grok | openclaw | agy | hermes | copilot | crush | cursor-agent | muse)
+    if [[ $installing == "true" ]]; then
+      exec omarchy-agent --inline
+    else
+      exec omarchy-agent
+    fi
+    ;;
+  *)
+    exit 0
+    ;;
+  esac
+  ;;
 *)
-  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse>"
+  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse|agents-panel>"
   exit 1
   ;;
 esac

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -135,6 +135,7 @@
   "setup.network.qr": {"icon":"󰐲","label":"QR Code","aliases":["wifi-qr"],"when":"[[ $(omarchy-network-status) == wifi* ]]","action":"omarchy-shell shell summon omarchy.wifiqr"},
   "setup.default": {"icon":"","label":"Defaults","aliases":["default","defaults"]},
   "setup.default.agent": {"icon":"󰚩","label":"Agent","title":"Default Agent"},
+  "setup.default.agent.agents-panel": {"icon":"󱚣","label":"Agents panel","description":"Launch whichever subscription is selected in the Agents bar widget","checked":"[[ \"$(omarchy-default-agent)\" == \"agents-panel\" ]]","action":"omarchy-default-agent agents-panel"},
   "setup.default.agent.agy": {"icon":"󰫢","label":"Antigravity","checked":"[[ \"$(omarchy-default-agent)\" == \"agy\" ]]","action":"omarchy-default-agent agy"},
   "setup.default.agent.claude": {"icon":"󰛄","label":"Claude","checked":"[[ \"$(omarchy-default-agent)\" == \"claude\" ]]","action":"omarchy-default-agent claude"},
   "setup.default.agent.codex": {"icon":"","iconFont":"omarchy","label":"Codex","checked":"[[ \"$(omarchy-default-agent)\" == \"codex\" ]]","action":"omarchy-default-agent codex"},

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -24,7 +24,7 @@ To wrap an additional CLI the same way, run `omarchy-mise-install <package> [com
 
 ### The default agent
 
-Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If the agent isn't installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification.
+Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If the agent isn't installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification. Choose **Agents panel** there to launch whichever subscription is selected in the agents bar widget, instead of pinning one CLI.
 
 [Muse Code](https://dev.meta.ai) — Meta's `muse` — uses a preinstalled mise stub like the other agents. Picking it as the default installs Meta's official launcher through mise's HTTP backend. The launcher verifies and updates the native binary for your machine.
 
@@ -36,7 +36,7 @@ There are terminal shortcuts too: `a` runs the default agent inline in the curre
 
 The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.
 
-Left-click the bar icon for the panel, right-click to launch your default agent. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
+Left-click the bar icon for the panel, right-click to launch your default agent. Switching tabs in the panel is what **Agents panel** follows when that is the default. The usage records behind it are regenerated every 15 minutes by `omarchy agent usage-update`, and the panel can even merge usage from your other machines via a synced folder. See the README under `$OMARCHY_PATH/shell/plugins/agents/` for the full settings.
 
 ### Crash diagnosis
 

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -30,6 +30,9 @@ Panel {
   }
   readonly property var provider: providers.length > 0 ? providers[providerIndex] : null
 
+  readonly property string home: Quickshell.env("HOME") || ""
+  readonly property string selectedPath: (Quickshell.env("XDG_STATE_HOME") || home + "/.local/state") + "/omarchy/agents/selected"
+
   property bool cursorActive: false
 
   // Countdowns and "updated" read this instead of Date.now() so the
@@ -53,6 +56,18 @@ Panel {
     if (providers.length === 0) return
     var wrapped = ((index % providers.length) + providers.length) % providers.length
     selectedProviderId = providers[wrapped].providerId
+    persistSelection(selectedProviderId)
+  }
+
+  function persistSelection(id) {
+    if (!id || id === "agents-panel") return
+    selectedFile.setText(id + "\n")
+  }
+
+  function applyRememberedSelection(id) {
+    var value = String(id || "").trim()
+    if (value === "" || value === "agents-panel") return
+    selectedProviderId = value
   }
 
   function refreshNow() {
@@ -60,6 +75,7 @@ Panel {
   }
 
   function launchAgent() {
+    persistSelection(selectedProviderId || (provider ? provider.providerId : ""))
     if (root.bar) root.bar.run("omarchy-agent --pick")
     root.close()
   }
@@ -333,6 +349,16 @@ Panel {
     function toggle(): void { root.toggle() }
     function refresh(): string { root.refreshNow(); return "ok" }
     function next(): string { root.selectProvider(root.providerIndex + 1); return "ok" }
+    function launch(): string { root.launchAgent(); return "ok" }
+  }
+
+  FileView {
+    id: selectedFile
+    path: root.selectedPath
+    watchChanges: true
+    atomicWrites: true
+    printErrors: false
+    onLoaded: root.applyRememberedSelection(text())
   }
 
   BarIconButton {

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -94,10 +94,11 @@ only adds the meter and the spent-of-funded line under the real figure.
 
 ## Interactions
 
-- Bar icon: left = panel, right = launch agent, middle = next subscription.
+- Bar icon: left = panel, right = launch the default agent, middle = next subscription.
 - Panel: `h`/`l` switch subscription, `j`/`k` scroll, `r` or Enter refresh,
   Tab moves to the neighboring bar panel, Esc closes.
-- IPC: `omarchy-shell omarchy.agents <open|close|toggle|refresh|next>`.
+- When Setup → Defaults → Agent is **Agents panel**, right-click and Super+Shift+Ctrl+A launch the tab currently selected here.
+- IPC: `omarchy-shell omarchy.agents <open|close|toggle|refresh|next|launch>`.
 
 ## Settings
 

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -10,6 +10,8 @@ const panelSource = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'u
 
 assert(/function launchAgent\(\)/.test(panelSource), 'agents panel launches the default agent')
 assert(/root\.bar\.run\("omarchy-agent --pick"\)/.test(panelSource), 'agents panel uses the desktop agent launcher')
+assert(/persistSelection\(selectedProviderId/.test(panelSource), 'agents panel remembers the selected tab before launch')
+assert(/omarchy\/agents\/selected/.test(panelSource), 'agents panel persists the selected tab under XDG state')
 assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelSource), 'agents right click launches the agent')
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -98,6 +98,7 @@ done
 chmod +x "$mock_bin"/*
 
 export HOME="$test_home"
+export XDG_STATE_HOME="$test_home/.local/state"
 export PATH="$mock_bin:$ROOT/bin:$PATH"
 export OMARCHY_TEST_NOTIFICATION_HISTORY="$notification_history"
 export OMARCHY_TEST_AGENT_OPEN_LOG="$agent_open_log"
@@ -713,6 +714,51 @@ mapfile -d '' -t launch_args <"$launch_log"
   fail "--pick launches once an agent is chosen"
 [[ ! -s $menu_log ]] || fail "--pick opens no menu once an agent is chosen"
 pass "--pick launches once an agent is chosen"
+
+# Agents panel is a default, not a CLI: it follows the tab the widget last
+# persisted, and Super+Shift+Ctrl+A stays omarchy-agent --pick.
+rm -f "$XDG_STATE_HOME/omarchy/agents/selected"
+: >"$mise_log"
+: >"$launch_log"
+: >"$menu_log"
+omarchy-default-agent agents-panel
+[[ $(omarchy-default-agent) == "agents-panel" ]] || fail "agents-panel can be the default agent"
+[[ ! -s $mise_log ]] || fail "agents-panel does not install a package"
+[[ ! -s $launch_log ]] || fail "agents-panel with no selected tab launches nothing"
+mapfile -d '' -t menu_args <"$menu_log"
+[[ ${#menu_args[@]} == 0 ]] || fail "agents-panel with no selected tab does not reopen the menu"
+pass "agents-panel records a follow-the-panel default without installing"
+
+: >"$launch_log"
+: >"$menu_log"
+omarchy-agent --pick
+mapfile -d '' -t menu_args <"$menu_log"
+[[ ${menu_args[*]} == "summon setup.default.agent" ]] ||
+  fail "agents-panel with no selected tab opens the picker"
+[[ ! -s $launch_log ]] || fail "agents-panel --pick with no selected tab launches nothing"
+pass "agents-panel --pick with no selected tab opens the picker"
+
+mkdir -p "$XDG_STATE_HOME/omarchy/agents"
+printf '%s\n' claude >"$XDG_STATE_HOME/omarchy/agents/selected"
+: >"$launch_log"
+: >"$menu_log"
+omarchy-agent --pick
+assert_launched claude "follows the Agents panel tab" claude --permission-mode auto
+[[ ! -s $menu_log ]] || fail "agents-panel with a selected tab opens no menu"
+pass "agents-panel launches the CLI for the selected Agents panel tab"
+
+printf '%s\n' fireworks >"$XDG_STATE_HOME/omarchy/agents/selected"
+: >"$launch_log"
+: >"$menu_log"
+omarchy-agent --pick
+mapfile -d '' -t menu_args <"$menu_log"
+[[ ${menu_args[*]} == "summon setup.default.agent" ]] ||
+  fail "agents-panel ignores a usage-only tab"
+[[ ! -s $launch_log ]] || fail "agents-panel does not launch a usage-only tab"
+pass "agents-panel ignores a usage-only Agents panel tab"
+
+printf '%s\n' opencode >"$agent_file"
+rm -f "$test_home/.local/state/omarchy/agents/selected"
 
 : >"$launch_log"
 omarchy agent prompt "Review this project"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -230,7 +230,7 @@ const expectedAgents = {
   crush: { icon: '󰋑', label: 'Crush' },
   muse: { icon: '󰛤', label: 'Muse Code' },
   'cursor-agent': { icon: '\ue90d', iconFont: 'omarchy', label: 'Cursor CLI' },
-
+  'agents-panel': { icon: '󱚣', label: 'Agents panel' },
 }
 assert(
   Object.entries(expectedAgents).every(([agent, expected]) => {
@@ -249,8 +249,8 @@ assertDeepEqual(
   defaultItems
     .filter(item => item.parent === 'setup.default.agent')
     .map(item => item.label),
-  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
-  'menu sorts coding agents alphabetically'
+  ['Agents panel', 'Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
+  'menu lists Agents panel first, then coding agents alphabetically'
 )
 const expectedDefaults = {
   browser: ['Chromium', 'Chrome', 'Brave', 'Brave Origin', 'Edge', 'Firefox', 'Zen'],


### PR DESCRIPTION
## Summary

Adds **Agents panel** as a default-agent choice so launch follows the subscription currently selected in the agents bar widget, instead of pinning one CLI.

Today, `Super+Shift+Ctrl+A` and a right-click on the agents icon always run `omarchy-agent --pick`, which launches whatever is in `~/.config/omarchy/defaults/agent`. Switching tabs in the panel does not change that. This keeps that keybind and that command, and adds a sentinel default:

- **Setup → Defaults → Agent → Agents panel** (listed first) writes `agents-panel` to the default-agent file. It is not a CLI and does not go through mise.
- The agents widget persists the selected tab to `~/.local/state/omarchy/agents/selected`.
- When the default is `agents-panel`, `omarchy-agent --pick` launches that tab's CLI. A missing, empty, or usage-only tab (e.g. Fireworks) still opens the picker.

Related but opposite: #6860 opens the **panel** on the configured default agent. This PR is the other direction — **launch** follows the panel tab when you opt into it.

## How to try it

1. Open **Setup → Defaults → Agent** and choose **Agents panel**.
2. Left-click the agents bar icon, switch to Claude (or Codex, etc.).
3. Right-click the icon, or press `Super+Shift+Ctrl+A`.
4. The selected CLI launches. Switching tabs and launching again follows the new tab.

Pinning a specific agent still works as before; only the new **Agents panel** entry follows the widget.

## Tests

- `bash test/shell.d/default-agent-test.sh`
- `bash test/shell.d/agents-panel-test.sh`
- `bash test/shell.d/menu-test.sh`
- `./test/all` — CLI suite passed.

Visual check: Default Agent menu lists **Agents panel** first, with the existing coding agents after it.