### PR TITLE
docs: add 2020 iMac models to the T2 Mac list

### DIFF
--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -65,6 +65,7 @@ The Apple T2 Security Chip was introduced in 2017. The T2 chip was discontinued 
 - MacBook Pro 13-inch (2019, two Thunderbolt 3 ports) – Model: A2159
 - MacBook Pro 13-inch (2019, four Thunderbolt 3 ports) – Model: A2178
 - MacBook Pro 15-inch (2019) – Model: A1990
+- iMac (Retina 5K, 27-inch, 2020) – Model: A2115 (iMac20,1 and iMac20,2)
 - MacBook Pro 13-inch (2020, two Thunderbolt 3 ports) – Model: A2265
 - MacBook Pro 15-inch (2020) – Model: A1990
 


### PR DESCRIPTION
The [Mac support page](https://omarchy.org/manual/mac-support/) lists the 2017 iMac Pro but omits the 2020 27-inch Retina 5K iMac from its T2 devices. Add the 2020 model with its A2115 number and both identifiers, `iMac20,1` and `iMac20,2`.

Apple's [T2 model list](https://support.apple.com/en-us/103265) identifies the 2020 27-inch iMac and iMac Pro as the two T2 iMac families. Its [iMac identification guide](https://support.apple.com/en-us/108054) lists both 2020 identifiers, and its [NCC certification table](https://images.apple.com/tw/nccid/) confirms A2115 for the 2020 model. The existing iMac Pro entry already covers `iMacPro1,1`.

This patch adds the missing list item to `manual/44-mac-support.md`.
