### PR TITLE
Keep the bar center pinned when centerAnchor's widget leaves the layout

### DIFF
--- a/manual/05-the-top-bar.md
+++ b/manual/05-the-top-bar.md
@@ -127,7 +127,7 @@ All of it is stored in `~/.config/omarchy/shell.json`, under the `bar` key. Here
 
 Every widget is one entry in one of the three layout arrays, and its settings sit inline on that entry — there's no separate settings file and no `config` sub-object. The clock's `format`, `formatAlt` (what right-click cycles to), and `verticalFormat` all live right there on `{ "id": "omarchy.clock" }`.
 
-`centerAnchor` names the one center widget that gets pinned to the exact center of the screen, with the others flanking it. That's how the clock stays dead center even as the weather and update badge come and go. Set it to an empty string and the center list is just centered as a group instead.
+`centerAnchor` names the one center widget that gets pinned to the exact center of the screen, with the others flanking it. That's how the clock stays dead center even as the weather and update badge come and go. If the widget it names has left the center list — you cloned it, dragged it elsewhere, disabled it — the pin falls back to the one center widget of the same kind, so a stale name doesn't quietly unpin the center. Set it to an empty string and the center list is just centered as a group instead.
 
 One rule worth internalizing: **once you have your own `shell.json`, it's canonical**. Until you customize anything, the shell reads Omarchy's default file. The moment you drag a widget, run `omarchy bar`, or edit the file yourself, you own it — there's no deep merge, so new default widgets in future Omarchy releases won't appear on your bar automatically. `omarchy bar defaults` puts the shipped layout back whenever you want a clean slate.
 

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -50,6 +50,13 @@ Item {
   })
   property var layoutConfig: fallbackBarConfig.layout
   property string centerAnchor: ""
+  // A centerAnchor whose widget has left the center list — cloned, dragged to
+  // another region, disabled, its plugin removed — must not silently unpin the
+  // center: the group recenters and the hover reveal of the inactive
+  // indicators then slides every widget in it. Resolve the stale id to the
+  // widget of the same kind that is actually there. Only the raw value above
+  // round-trips to shell.json; everything that lays the center out reads this.
+  readonly property string resolvedCenterAnchor: BarModel.resolveCenterAnchor(layoutEntries("center"), centerAnchor)
   property bool requestedTransparent: false
   property bool useTransparentForeground: false
   property bool transparent: false
@@ -1517,7 +1524,7 @@ Item {
 
   function findCenterAnchorEntry() {
     var entries = root.layoutEntries("center")
-    var idx = root.entryIndex(entries, root.centerAnchor)
+    var idx = root.entryIndex(entries, root.resolvedCenterAnchor)
     return idx === -1 ? null : entries[idx]
   }
 
@@ -1535,7 +1542,7 @@ Item {
     id: centerRoot
 
     property var entries: root.layoutEntries("center")
-    readonly property bool hasAnchor: root.entryIndex(entries, root.centerAnchor) !== -1
+    readonly property bool hasAnchor: root.entryIndex(entries, root.resolvedCenterAnchor) !== -1
     readonly property var anchorEntry: root.findCenterAnchorEntry()
 
     Loader {
@@ -1564,7 +1571,7 @@ Item {
 
         ModuleList {
           visible: centerRoot.hasAnchor
-          entries: root.entriesBefore(centerRoot.entries, root.centerAnchor)
+          entries: root.entriesBefore(centerRoot.entries, root.resolvedCenterAnchor)
           region: "center"
           anchors.right: centerAnchorModule.left
           anchors.verticalCenter: centerAnchorModule.verticalCenter
@@ -1580,7 +1587,7 @@ Item {
 
         ModuleList {
           visible: centerRoot.hasAnchor
-          entries: root.entriesAfter(centerRoot.entries, root.centerAnchor)
+          entries: root.entriesAfter(centerRoot.entries, root.resolvedCenterAnchor)
           region: "center"
           anchors.left: centerAnchorModule.right
           anchors.verticalCenter: centerAnchorModule.verticalCenter
@@ -1609,7 +1616,7 @@ Item {
 
         ModuleList {
           visible: centerRoot.hasAnchor
-          entries: root.entriesBefore(centerRoot.entries, root.centerAnchor)
+          entries: root.entriesBefore(centerRoot.entries, root.resolvedCenterAnchor)
           region: "center"
           anchors.bottom: centerAnchorModule.top
           anchors.horizontalCenter: centerAnchorModule.horizontalCenter
@@ -1625,7 +1632,7 @@ Item {
 
         ModuleList {
           visible: centerRoot.hasAnchor
-          entries: root.entriesAfter(centerRoot.entries, root.centerAnchor)
+          entries: root.entriesAfter(centerRoot.entries, root.resolvedCenterAnchor)
           region: "center"
           anchors.top: centerAnchorModule.bottom
           anchors.horizontalCenter: centerAnchorModule.horizontalCenter

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -65,6 +65,46 @@ function entriesAfter(entries, name) {
   return index === -1 ? [] : entries.slice(index + 1)
 }
 
+// The kind half of a widget id. Ids read `<owner>.<kind>` — omarchy.clock,
+// dhh.clock, acme.weather — so the last segment is what the widget *is*,
+// independent of who ships it.
+function widgetKind(id) {
+  var value = String(id || "")
+  var dot = value.lastIndexOf(".")
+  return dot === -1 ? value : value.slice(dot + 1)
+}
+
+// A centerAnchor naming nothing in the center list is a stale pin, not a
+// request to unpin — an empty string is how you ask for that. Cloning,
+// dragging the widget to another region, disabling it, and removing its
+// plugin all splice the entry out and leave the id behind; nothing rewrites
+// centerAnchor. Losing the pin recenters the center list as a group, so the
+// hover reveal of the inactive indicators grows it and every widget in it
+// slides.
+//
+// Exact id wins, so naming the clone (or keeping both) still pins what was
+// named. Otherwise the one center widget of the same kind is the pin: it is
+// what a clone, a rename, or a swapped-in third-party clock leaves behind.
+// Two of a kind is ambiguous, so leave the pin unresolved rather than guess.
+function resolveCenterAnchor(entries, name) {
+  var anchor = String(name || "")
+  if (!anchor) return ""
+  if (entryIndex(entries, anchor) !== -1) return anchor
+  if (!Array.isArray(entries)) return anchor
+
+  var kind = widgetKind(anchor)
+  if (!kind) return anchor
+
+  var match = ""
+  for (var i = 0; i < entries.length; i++) {
+    var id = entryId(entries[i])
+    if (!id || widgetKind(id) !== kind) continue
+    if (match) return anchor
+    match = id
+  }
+  return match || anchor
+}
+
 // A shell.json write that only changes inline widget settings (the battery
 // percentage toggle, a clock format change) must not rebuild the bar.
 // Compare two normalized layouts: when the structure is unchanged — same
@@ -222,6 +262,8 @@ if (typeof module !== "undefined") {
     entryIndex: entryIndex,
     entriesBefore: entriesBefore,
     entriesAfter: entriesAfter,
+    widgetKind: widgetKind,
+    resolveCenterAnchor: resolveCenterAnchor,
     inlineSettingsDelta: inlineSettingsDelta,
     expandPath: expandPath,
     customModuleSafeName: customModuleSafeName,

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -46,7 +46,7 @@ Example `shell.json` (bar subtree only shown):
 }
 ```
 
-`centerAnchor` pins one center module to the exact horizontal/vertical center and flanks others around it. Set to an empty string to disable anchoring (the center list is centered as a group).
+`centerAnchor` pins one center module to the exact horizontal/vertical center and flanks others around it. When the named id is not in the center list, the pin resolves to the one center module of the same kind (the id's last segment), so a clone, a rename, or a removed plugin does not unpin the center; two modules of that kind leave it unresolved. Set to an empty string to disable anchoring (the center list is centered as a group).
 
 ## Module catalogue
 

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -343,6 +343,56 @@ assertEqual(bar.entryIndex(entries, 'b'), 2, 'bar finds entry indexes')
 assertDeepEqual(bar.entriesBefore(entries, 'b').map(bar.entryId), ['a', 'omarchy.tray'], 'bar returns entries before target')
 assertDeepEqual(bar.entriesAfter(entries, 'a').map(bar.entryId), ['omarchy.tray', 'b'], 'bar returns entries after target')
 
+const centerEntries = [
+  { id: 'omarchy.indicators' },
+  { id: 'omarchy.keyboard-layout' },
+  { id: 'omarchy.clock', format: 'HH:mm' },
+  { id: 'omarchy.weather' }
+]
+
+assertEqual(bar.widgetKind('omarchy.clock'), 'clock', 'bar reads the kind off a widget id')
+assertEqual(bar.widgetKind('omarchy.system-update'), 'system-update', 'bar keeps a hyphenated kind whole')
+assertEqual(
+  bar.resolveCenterAnchor(centerEntries, 'omarchy.clock'),
+  'omarchy.clock',
+  'bar prefers an exact center anchor match'
+)
+assertEqual(
+  bar.resolveCenterAnchor(centerEntries, 'acme.clock'),
+  'omarchy.clock',
+  'bar pins the surviving clock when the configured center anchor is gone'
+)
+assertEqual(
+  bar.resolveCenterAnchor([{ id: 'omarchy.indicators' }, { id: 'dhh.clock' }], 'omarchy.clock'),
+  'dhh.clock',
+  'bar pins a clone the configured center anchor no longer names'
+)
+assertEqual(
+  bar.resolveCenterAnchor([{ id: 'omarchy.clock' }, { id: 'dhh.clock' }], 'acme.clock'),
+  'acme.clock',
+  'bar leaves an ambiguous center anchor unresolved'
+)
+assertEqual(
+  bar.resolveCenterAnchor(centerEntries, 'omarchy.media'),
+  'omarchy.media',
+  'bar leaves a center anchor with no widget of that kind unresolved'
+)
+assertEqual(bar.resolveCenterAnchor(centerEntries, ''), '', 'bar treats an empty center anchor as disabled')
+
+assert(
+  /BarModel\.resolveCenterAnchor\(/.test(barSource),
+  'bar resolves the center pin before laying the center out'
+)
+assert(
+  /readonly property bool hasAnchor: root\.entryIndex\(entries, root\.resolvedCenterAnchor\) !== -1/.test(barSource),
+  'bar pins the resolved center widget, not the configured id'
+)
+assertEqual(
+  (barSource.match(/root\.resolvedCenterAnchor/g) || []).length,
+  6,
+  'bar reads the resolved pin at every center layout site, vertical bars included'
+)
+
 assertEqual(bar.expandPath('~/module.qml', '/home/dhh'), '/home/dhh/module.qml', 'bar expands tilde paths')
 assertEqual(bar.expandPath('$HOME/module.qml', '/home/dhh'), '/home/dhh/module.qml', 'bar expands HOME paths')
 assert(bar.customModuleSafeName('local.weather'), 'bar accepts safe custom module names')


### PR DESCRIPTION
Fixes #7868.

`centerAnchor` pins one center widget to the exact center and flanks the rest around it. The lookup is an exact id match, so an id that is no longer in `bar.layout.center` unpins the whole section: the center list falls back to being centered as a group, the hover reveal of the inactive indicators grows it, and every widget in it slides — the clock included, whether or not the clock is the widget that went missing.

Nothing repairs `centerAnchor` when the widget it names leaves the center. Every removal path splices the entry and stops there:

- `PluginRegistry.setEnabled(id, false)` — `shell/services/PluginRegistry.qml:556`
- `moveBarEntry`, i.e. `omarchy bar move` — `shell/services/PluginRegistry.qml:296-298`
- `restoreCloneSource` — `shell/services/PluginRegistry.qml:441-457`
- bar drag-and-drop `moveModuleInConfig` — `shell/plugins/bar/Bar.qml:886-887`
- `omarchy plugin remove` / `omarchy plugin disable` — `bin/omarchy-plugin-remove:94-96`, `bin/omarchy-plugin-disable:22`

`omarchy bar defaults` is the only one that keeps the pair consistent, and only because it resets the whole `.bar` subtree. No migration touches `centerAnchor`; there is no warning and no self-heal.

## The change

Resolve the pin at runtime rather than rewriting `shell.json`:

- exact id still wins, so naming the clone (or keeping both) pins what was named
- otherwise the one center widget of the same **kind** is the pin — the last segment of `<owner>.<kind>`, which is what a clone, a rename, or a swapped-in third-party clock leaves behind
- two center widgets of that kind is ambiguous, so the pin stays unresolved rather than guessing
- an empty `centerAnchor` still disables anchoring, unchanged

The horizontal and vertical center layouts each read the pin in three places. All six now read the resolved value, so all four bar positions are covered.

## Before / after

Center list `omarchy.indicators, omarchy.clock`, `centerAnchor` naming a widget that is not in it. Red line marks the exact screen center; the only difference between the two images is this commit.

<img width="1294" height="293" alt="pr-before" src="https://github.com/user-attachments/assets/4ce70b5d-2909-4926-91bc-b494cc43ae32" />

<img width="1294" height="293" alt="pr-after" src="https://github.com/user-attachments/assets/6f2eb3dd-58d2-4fe6-9ab2-b979e4e447d9" />

## Measurements

4.0.0.alpha, 1920x1200 @ 1.25 scale. Clock glyphs template-matched between a pointer-off-bar capture and a pointer-on-clock capture. Reproduction: `centerAnchor` naming a bar-widget plugin that is no longer in the center list, with `omarchy.clock` still there.

| Bar position | Before | After |
|---|---|---|
| top | 65 px (52 logical) | **0 px** |
| bottom | 65 px | **0 px** |
| left | shift present | **0 px** |
| right | 66 px | **0 px** |

Left and right cross-checked a second way, comparing content bands row by row: both gain exactly the five revealed indicator bands above the clock, and every other band keeps its identical row position.

## Relationship to #7869

#7869 fixes the clone case by carrying `clonedFrom` into bar-widget registry metadata and resolving through it. This resolves on the id's kind instead, which reaches the same clone case with no manifest plumbing, and additionally covers the cases a clone relationship cannot see: the widget dragged to another region, disabled, its plugin removed, or a third-party widget swapped out.

The two cannot merge side by side — both define `BarModel.resolveCenterAnchor`. If you prefer #7869's approach I am happy to close this, or to rebase it down to just the non-clone half on top of it. Flagging it rather than leaving you to find the collision.

## Test plan

- [x] `test/shell.d/bar-test.sh` — `widgetKind` and `resolveCenterAnchor` cases (exact match, stale anchor, clone, ambiguous, no widget of that kind, empty), plus source assertions on the `Bar.qml` wiring and a count of the six resolved reads so the vertical half cannot be missed
- [x] Mutation-tested: removing the fallback fails the stale-anchor case; reverting only the two vertical reads fails the read-count assertion
- [x] Verified in the running shell at all four bar positions, before and after
- [x] `./test/all` — the 4 failing files (`config-test`, `locate-test`, `snapper-test`, `unowned-system-paths-test`) fail identically on clean `quattro` here for want of an `omarchy-pkgs` sibling checkout

