### PR TITLE
Build NVIDIA DKMS after the Panther Lake kernel swap

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -8,7 +8,6 @@ run_logged "$OMARCHY_INSTALL/hardware/set-wireless-regdom.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-fkeys.sh"
 run_logged "$OMARCHY_INSTALL/hardware/fix-synaptic-touchpad.sh"
 run_logged "$OMARCHY_INSTALL/hardware/bluetooth.sh"
-run_logged "$OMARCHY_INSTALL/hardware/nvidia.sh"
 run_logged "$OMARCHY_INSTALL/hardware/vulkan.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/intel/video-acceleration.sh"
@@ -18,7 +17,9 @@ run_logged "$OMARCHY_INSTALL/hardware/intel/thermald.sh"
 # intel-ipu7-camera drags in ipu7-drivers, vision-drivers and v4l2loopback,
 # and building all three against the stock kernel only to rebuild them against
 # linux-ptl and tear the first set down again cost ~25s of the install.
+# nvidia-open-dkms is the same class of work and used to run before this swap.
 run_logged "$OMARCHY_INSTALL/hardware/intel/ptl-kernel.sh"
+run_logged "$OMARCHY_INSTALL/hardware/nvidia.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/ipu7-camera.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fred.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fix-wifi7-eht.sh"

--- a/test/shell.d/nvidia-after-ptl-kernel-test.sh
+++ b/test/shell.d/nvidia-after-ptl-kernel-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+all="$ROOT/install/hardware/all.sh"
+
+nvidia_line=$(grep -n 'hardware/nvidia.sh' "$all" | cut -d: -f1)
+ptl_line=$(grep -n 'hardware/intel/ptl-kernel.sh' "$all" | cut -d: -f1)
+ipu_line=$(grep -n 'hardware/intel/ipu7-camera.sh' "$all" | cut -d: -f1)
+
+[[ -n $nvidia_line && -n $ptl_line ]] || fail "nvidia and ptl-kernel both run during hardware setup"
+((ptl_line < nvidia_line)) ||
+  fail "NVIDIA DKMS runs after the Panther Lake kernel swap"
+pass "NVIDIA DKMS runs after the Panther Lake kernel swap"
+
+[[ -n $ipu_line ]] || fail "ipu7 camera DKMS still runs during hardware setup"
+((ptl_line < ipu_line)) ||
+  fail "ipu7 camera DKMS still runs after the Panther Lake kernel swap"
+pass "ipu7 camera DKMS still runs after the Panther Lake kernel swap"
+
+# Count nvidia.sh invocations so we did not leave a second early copy.
+nvidia_count=$(grep -c 'hardware/nvidia.sh' "$all")
+((nvidia_count == 1)) || fail "nvidia.sh runs once"
+pass "nvidia.sh runs once"


### PR DESCRIPTION
## Summary
- `install/hardware/all.sh` already installs `linux-ptl` before IPU7 DKMS so those modules are not compiled twice against stock linux. `nvidia-open-dkms` still ran before that swap.
- nvidia.sh now follows ptl-kernel.sh, same as the camera drivers.

## Test plan
- [x] `bash test/shell.d/nvidia-after-ptl-kernel-test.sh`
- [x] `bash test/shell.d/xps13-sidecar-amps-test.sh`
