### PR TITLE
Detect NVIDIA during install with omarchy-hw-nvidia

### DIFF
--- a/install/hardware/nvidia.sh
+++ b/install/hardware/nvidia.sh
@@ -1,4 +1,6 @@
-if lspci | grep -qi 'nvidia'; then
+# omarchy-hw-nvidia reads sysfs IDs. lspci would walk PCI config space and
+# wake a runtime-suspended GPU, and Hyprland already uses the same helper.
+if omarchy-hw-nvidia; then
   # Check which kernel is installed and set appropriate headers package
   KERNEL_PACKAGE=$(pacman -Qqs '^linux(-zen|-lts|-hardened|-t2|-ptl)?$' | head -1 || true)
   [[ -n $KERNEL_PACKAGE ]] && omarchy-pkg-add "$KERNEL_PACKAGE-headers"

--- a/test/shell.d/nvidia-hw-detect-test.sh
+++ b/test/shell.d/nvidia-hw-detect-test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+nvidia_sh="$ROOT/install/hardware/nvidia.sh"
+
+grep -Fq 'omarchy-hw-nvidia' "$nvidia_sh" ||
+  fail "NVIDIA install uses the sysfs helper already used at session start"
+! grep -Eq "lspci.*nvidia" "$nvidia_sh" ||
+  fail "NVIDIA install does not grep lspci for the GPU"
+
+# The GSP / 580xx split already goes through the helpers; keep that pairing.
+grep -Fq 'omarchy-hw-nvidia-gsp' "$nvidia_sh" ||
+  fail "NVIDIA install still chooses the GSP driver via sysfs"
+grep -Fq 'omarchy-hw-nvidia-without-gsp' "$nvidia_sh" ||
+  fail "NVIDIA install still chooses the 580xx driver via sysfs"
+pass "NVIDIA driver install detects the GPU the same way Hyprland does"


### PR DESCRIPTION
## Summary
- `nvidia.sh` grepped `lspci` for the GPU, then used `omarchy-hw-nvidia-gsp` for the driver split.
- Hyprland already asks `omarchy-hw-nvidia` (sysfs, no PCI config-space wake). Install now uses the same helper.

## Test plan
- [x] `test/shell.d/nvidia-hw-detect-test.sh`
- [ ] NVIDIA install still pulls open-dkms or 580xx on a real GPU
