### PR TITLE
Ask before taking the pre-update snapshot

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -30,11 +30,19 @@ if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
   # after it frees nothing until that snapshot ages out.
   omarchy-update-pkg-prune
 
-  # 127 means Snapper is deliberately absent. Any other failure already said
-  # what went wrong, and a missing snapshot is not worth blocking an update
-  # over, but it must not pass for one either.
-  omarchy-snapshot create || (($? == 127)) ||
-    echo -e "\e[33mContinuing the update without a snapshot.\e[0m" >&2
+  # Snapshotting is the safe default, so that is what the prompt offers.
+  # -y is a promise not to ask anything and keeps the default, and with
+  # Snapper absent there is nothing to choose between.
+  if [[ ${1:-} == "-y" ]] || omarchy-cmd-missing snapper ||
+    gum confirm "Create a system snapshot first? (recommended)"; then
+    # 127 means Snapper is deliberately absent. Any other failure already said
+    # what went wrong, and a missing snapshot is not worth blocking an update
+    # over, but it must not pass for one either.
+    omarchy-snapshot create || (($? == 127)) ||
+      echo -e "\e[33mContinuing the update without a snapshot.\e[0m" >&2
+  else
+    echo -e "\e[33mSkipping the snapshot. Continuing the update without one.\e[0m" >&2
+  fi
 
   omarchy-update-stay-awake start
 

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -121,9 +121,11 @@ omarchy-update
   ├─ omarchy-update-pkg-prune
   │    └─ trim the pacman cache to two versions per package, deliberately
   │       before the snapshot since the cache lives on the snapshotted subvolume
-  ├─ create snapper snapshot (skipped silently without snapper; snapper
-  │  installed but unconfigured fails the snapshot loudly, pointing at
-  │  install/config/snapper.sh, and the update continues without one)
+  ├─ create snapper snapshot unless an interactive run declines the prompt
+  │  (-y never asks and keeps the snapshot; snapper absent means there is
+  │  nothing to ask about; snapper installed but unconfigured fails the
+  │  snapshot loudly, pointing at install/config/snapper.sh, and the update
+  │  continues without one)
   ├─ omarchy-update-stay-awake start
   ├─ run package updates, migrations, hooks, and log analysis
   ├─ omarchy-update-status
@@ -265,7 +267,7 @@ scripts.
 
 | Binary | Current purpose | Keep? / Question |
 | --- | --- | --- |
-| `omarchy-update` | Public user command. Adds transcript logging, confirmation, snapshot, and restart checks around the locked, sleep-inhibited update pipeline. | **Keep.** This is the blessed entry point and orchestrates the update pipeline. |
+| `omarchy-update` | Public user command. Adds transcript logging, confirmation, an opt-out snapshot prompt, and restart checks around the locked, sleep-inhibited update pipeline. | **Keep.** This is the blessed entry point and orchestrates the update pipeline. |
 | `omarchy-update-lock` | Hidden command wrapper that holds the per-user update lock while its child runs. | **Keep internal/hidden.** Isolates update concurrency and lock descriptor handling. |
 | `omarchy-update-stay-awake` | Hidden helper that starts or stops update-owned sleep and idle inhibition, restoring only the state it changed. | **Keep internal/hidden.** Keeps inhibitor ownership and cleanup together. |
 | `omarchy-update-status` | Hidden helper that refreshes or clears the shell update indicator after rechecking available updates. | **Keep internal/hidden.** Keeps shell status synchronization out of the main pipeline. |

--- a/manual/30-updates.md
+++ b/manual/30-updates.md
@@ -30,7 +30,7 @@ If you're already familiar with Arch, you might be tempted to just run `pacman -
 
 ### Rolling back bad updates
 
-If you ever have a problem after doing an update, you can rollback your system to the snapshot taken before the update. Just restart and pick the snapshot in the boot loading menu from before you started the update.
+If you ever have a problem after doing an update, you can rollback your system to the snapshot taken before the update. Just restart and pick the snapshot in the boot loading menu from before you started the update. (If you skipped the snapshot when the update offered it, there is nothing to roll back to.)
 
 ![bootloader](images/bootloader.webp)
 

--- a/manual/47-system-snapshots.md
+++ b/manual/47-system-snapshots.md
@@ -1,6 +1,6 @@
 # System snapshots
 
-We create snapshots automatically on every Omarchy update, but should you want to create your own, you can use `omarchy-snapshot create`.
+Every Omarchy update offers to create a snapshot first — accepting is recommended, but you can skip it. Should you want to create one yourself, you can use `omarchy-snapshot create`.
 
 To boot and restore a snapshot, you select it from the Limine boot loader. (If you're currently booting straight into the Omarchy decryption screen, you'll need to select Limine as a boot option via the BIOS first).
 

--- a/test/shell.d/update-sequence-test.sh
+++ b/test/shell.d/update-sequence-test.sh
@@ -41,12 +41,48 @@ STUB
   chmod +x "$stub_bin/$step"
 done
 
+# With Snapper gone the real omarchy-snapshot is the deliberate 127 the update
+# tolerates, so the stub can stand in for both sides of that arrangement.
+cat >"$stub_bin/omarchy-snapshot" <<'STUB'
+#!/bin/bash
+printf '%s unattended=%s\n' "${0##*/}" "${OMARCHY_UPDATE_UNATTENDED:-}" >>"$STEP_LOG"
+[[ ${FAILING_STEP:-} != "${0##*/}" ]] || exit 1
+[[ -z ${SNAPPER_MISSING:-} ]] || exit 127
+STUB
+
+# Snapper is present unless the test says otherwise. Exit 1 means nothing is
+# missing, matching omarchy-cmd-missing.
+cat >"$stub_bin/omarchy-cmd-missing" <<'STUB'
+#!/bin/bash
+for cmd in "$@"; do
+  if [[ $cmd == snapper && -n ${SNAPPER_MISSING:-} ]]; then
+    exit 0
+  fi
+done
+exit 1
+STUB
+
+# gum only has to answer confirm: yes by default, overridable per run. Every
+# ask is logged so the tests can tell prompting from silence.
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+if [[ ${1:-} == confirm ]]; then
+  printf '%s\n' "$*" >>"$GUM_LOG"
+  [[ ${GUM_CONFIRM_ANSWER:-yes} == yes ]]
+fi
+STUB
+chmod +x "$stub_bin/gum" "$stub_bin/omarchy-snapshot" "$stub_bin/omarchy-cmd-missing"
+
 # OMARCHY_UPDATE_LOGGED stands in for the script(1) wrapper the update re-execs
 # itself under; the stubbed lock reports itself already held.
 run_update() {
   : >"$test_tmp/steps"
+  : >"$test_tmp/gum"
   STEP_LOG="$test_tmp/steps" \
+    GUM_LOG="$test_tmp/gum" \
     FAILING_STEP="${FAILING_STEP:-}" \
+    SNAPPER_MISSING="${SNAPPER_MISSING:-}" \
+    GUM_CONFIRM_ANSWER="${GUM_CONFIRM_ANSWER:-}" \
     OMARCHY_UPDATE_LOGGED=1 \
     PATH="$stub_bin:$PATH" \
     bash "$ROOT/bin/omarchy-update" "$@" >"$test_tmp/out" 2>"$test_tmp/err"
@@ -56,15 +92,16 @@ steps_run() {
   cut -d' ' -f1 "$test_tmp/steps"
 }
 
-# Every step of a whole update, in order. $1 asks for the one a person confirms.
-# Stay Awake bookends the work, so it is here twice.
+# Every step of a whole update, in order. $1 asks for the confirm a person
+# gives, $2 for the snapshot step. Stay Awake bookends the work, so it is here
+# twice.
 expected_steps() {
   printf '%s\n' \
     omarchy-update-lock \
     omarchy-update-requires-free-space \
     ${1:+omarchy-update-confirm} \
     omarchy-update-pkg-prune \
-    omarchy-snapshot \
+    ${2:+omarchy-snapshot} \
     omarchy-update-stay-awake \
     omarchy-update-dev \
     omarchy-update-keyring \
@@ -80,19 +117,52 @@ expected_steps() {
     omarchy-update-restart
 }
 
-run_update -y || fail "an update where everything works reports a failure"
-diff <(expected_steps) <(steps_run) >"$test_tmp/order" ||
-  fail "an update where everything works does not run every step in order" "$(cat "$test_tmp/order")"
-pass "an update where every step works runs all of them, in order"
+no_asked_questions() {
+  if [[ -s "$test_tmp/gum" ]]; then
+    fail "the update asked something it should not have" "$(cat "$test_tmp/gum")"
+  fi
+}
 
+# -y promised not to ask anything, so it snapshots without a prompt.
+run_update -y || fail "an unattended update where everything works reports a failure"
+no_asked_questions
+diff <(expected_steps "" snapshot) <(steps_run) >"$test_tmp/order" ||
+  fail "an unattended update does not run every step in order" "$(cat "$test_tmp/order")"
 grep -q '^omarchy-update-system-pkgs unattended=1$' "$test_tmp/steps" ||
   fail "-y does not mark the update unattended"
+pass "-y keeps the snapshot default and asks nothing"
+
+# A missing Snapper is the deliberate 127 the update tolerates, and there is
+# nothing to ask about either.
+SNAPPER_MISSING=1 run_update </dev/null ||
+  fail "an update without Snapper reports a failure"
+no_asked_questions
+diff <(expected_steps confirmed snapshot) <(steps_run) >"$test_tmp/order" ||
+  fail "an update without Snapper runs a different set of steps" "$(cat "$test_tmp/order")"
+if grep -q 'without a snapshot' "$test_tmp/err"; then
+  fail "a tolerated Snapper absence announces a missing snapshot"
+fi
+pass "without Snapper the update never asks and carries on without a snapshot"
+
+# A person who confirms the update gets asked about the snapshot, and taking
+# the recommended answer changes nothing about the step order.
 run_update </dev/null || fail "a confirmed update reports a failure"
-diff <(expected_steps confirmed) <(steps_run) >"$test_tmp/order" ||
+diff <(expected_steps confirmed snapshot) <(steps_run) >"$test_tmp/order" ||
   fail "a confirmed update runs a different set of steps" "$(cat "$test_tmp/order")"
 grep -q '^omarchy-update-system-pkgs unattended=$' "$test_tmp/steps" ||
   fail "an update a person confirmed is treated as unattended"
-pass "-y is what marks an update unattended, not the update itself"
+[[ $(wc -l <"$test_tmp/gum") == 1 ]] ||
+  fail "a confirmed update does not ask exactly one question" "$(cat "$test_tmp/gum")"
+pass "a confirmed update asks once and snapshots on the recommended answer"
+
+# Declining the snapshot skips exactly that step and nothing else.
+GUM_CONFIRM_ANSWER=no run_update </dev/null ||
+  fail "an update without the snapshot the user declined reports a failure"
+diff <(expected_steps confirmed) <(steps_run) >"$test_tmp/order" ||
+  fail "a declined snapshot changes more than the snapshot step" "$(cat "$test_tmp/order")"
+grep -q 'Skipping the snapshot' "$test_tmp/err" ||
+  fail "a declined snapshot passes without saying so"
+pass "declining the snapshot skips it and the update goes on"
 
 # Migrations ship with the packages the upgrade installs and are written against
 # them. Running them against what is still on disk is the failure this ordering


### PR DESCRIPTION
## What

`omarchy update` currently always creates a Snapper snapshot before updating. This adds a confirmation prompt so an interactive run can skip it, with taking the snapshot as the recommended default:

```
Create a system snapshot first? (recommended) [Y/n]
```

Behavior by mode:

| Mode | Behavior |
| --- | --- |
| Interactive | Asked once, right after the update confirmation; Enter / `y` snapshots, `n` skips it with a note on stderr |
| `-y` (unattended) | Never asks; keeps the snapshot (the safe default, and `-y` promises not to ask anything) |
| Snapper absent | Nothing to ask about; existing silent 127-tolerant path unchanged |

Snapshot failures continue to be tolerated exactly as before (warning on stderr, update proceeds).

## Why

One of the main reasons for this change: users on slow or unreliable internet connections often see updates fail partway through and retry several times in a row. Every retry takes another full snapshot, so a single rocky update session can pile up multiple snapshots that eat disk space and linger in the boot menu. Letting the user decide up front (or skip the snapshot on a quick retry they know will be cheap) avoids that accumulation.

Snapshots are still the right default, but they are not free: they take time and disk on every update, and some users run updates they know are low-risk (or manage snapshots themselves). Making the skip an explicit, per-update choice keeps the safety net as the default instead of pushing people toward workarounds.

## Testing

- Expanded `test/shell.d/update-sequence-test.sh`: `gum` and `omarchy-cmd-missing` stubs now cover unattended (snapshots, no prompt), Snapper missing (never asks, 127 tolerated silently), confirmed-yes (exactly one prompt, snapshot taken), and confirmed-no (only the snapshot step is skipped, everything else runs in order).
- `./test/cli` and the other shell suites pass. Four shell test files fail identically on a pristine checkout of `main` in this environment (missing `omarchy-pkgs` checkout for `config-test`/`snapper-test`/`unowned-system-paths-test`, QML runtime warnings for `runtime-smoke-test`), so those failures are unrelated to this change.

## Docs

- `docs/update-process.md`: pipeline diagram and binary table note the prompt.
- `manual/47-system-snapshots.md` and `manual/30-updates.md`: snapshot is now offered (and can be declined) rather than always automatic.