### PR TITLE
audio: guard list snapshots and debounce refresh to prevent crash on device disconnect

### DIFF
--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -19,7 +19,15 @@ function isAudioSource(node) {
 }
 
 function listSnapshot(list) {
-  return list && list.slice ? list.slice() : []
+  if (!list || !list.length) return []
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var item = list[i]
+    if (item && item.id !== undefined && item.name !== undefined) {
+      out.push(item)
+    }
+  }
+  return out
 }
 
 function outputVolumeName(volume, muted) {

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -622,7 +622,7 @@ Panel {
 
   Timer {
     id: audioModelRefreshTimer
-    interval: 75
+    interval: 250
     repeat: false
     onTriggered: root.refreshDisplayAudioModels()
   }


### PR DESCRIPTION
### Problem

When a Bluetooth audio device drops or encounters an error (`Pipewire error on object ... code -14`), PipeWire rapidly destroys and unbinds the corresponding `PwNode` and `PwDevice` objects before reconnecting.

During this teardown, `audioModelRefreshTimer` in `plugins/panels/audio/Panel.qml` triggers after 75ms:
```qml
Timer {
  id: audioModelRefreshTimer
  interval: 75
  repeat: false
  onTriggered: root.refreshDisplayAudioModels()
}
```

Because 75ms is faster than the PipeWire teardown/reconnect cycle, `refreshDisplayAudioModels()` populates `displayAudioSinks`/`displayAudioStreams` with references to `PwNode` C++ objects that are mid-destruction. When the QML `Repeater` regenerates (`QQuickRepeater::regenerate()`), the QML engine attempts to read properties on the dangling `PwNode` pointer (`QV4::QObjectWrapper::getQmlProperty`), resulting in an immediate segmentation fault (`SIGSEGV`):

```
#0  0x00007f354103e6ef in libc.so.6
#1  0x00007f3540edd530 in libQt6QmlModels.so.6
#2  0x00007f3540eddf00 in libQt6QmlModels.so.6
#4  QV4::QObjectWrapper::getQmlProperty(...)
#19 QQuickRepeater::regenerate()
#20 QQuickRepeater::setModel(...)
#47 QQmlTimer::event(...)
```

### Solution

1. **Guard list snapshots (`Model.js`)**:
   Update `listSnapshot()` to verify that items in the list have valid identifiers (`item.id !== undefined && item.name !== undefined`) before passing them to the `Repeater` models, filtering out unbound/destroyed node references.

2. **Increase debounce interval (`Panel.qml`)**:
   Increase `audioModelRefreshTimer.interval` from `75ms` to `250ms`, giving the PipeWire disconnect and reconnection cycle enough time to settle before reconstructing the delegate models.
