### PR TITLE
Install Kujo by default

### DIFF
--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -64,6 +64,7 @@ networkmanager
 jq
 kdenlive
 kernel-modules-hook
+kujo
 lazydocker
 lazygit
 less

--- a/manual/18-development-tools.md
+++ b/manual/18-development-tools.md
@@ -18,6 +18,10 @@ The majority of these environments are managed by [Mise](https://mise.jdx.dev/).
 
 To install, say, Ruby, you'd run `mise use -g ruby`, which will both install Ruby and set it as the global default. Or, if your project has a .ruby-version file, you can just run `mise i` in the root of that project.
 
+## Kujo
+
+[Kujo](https://kujolang.ai) is a programming language and runtime for AI-native software and local automation. It is included on new Omarchy installations. Run `kujo --version` to check the installed version and `kujo run script.kujo` to run a program.
+
 ## Docker
 
 [Docker](https://www.docker.com/) hardly needs any introduction. It allows you to run isolated containers, and Omarchy installs everything needed to run it well, including Docker itself and [Docker Compose](https://docs.docker.com/compose/).


### PR DESCRIPTION
Add `kujo` to the package list used for fresh installations and document it in the development-tools manual. Kujo is a programming language and runtime for AI-native software and local automation, which fits Omarchy's agentic development focus.

The package uses official Linux binaries and Omarchy's existing package infrastructure. Users can run `kujo --version` immediately after installation. The change adds one package-list entry and a short manual section; it does not install Kujo for existing users.

The companion package is proposed in [omacom/omarchy-pkgs#355](https://github.com/omacom/omarchy-pkgs/pull/355). The two PRs can be reviewed together; the package needs to reach the target channel before this change ships so the ISO builder can include it in the offline mirror.

### Validation

- `git diff --check` passed.
- `bash test/shell.d/preinstalls-test.sh` passed all 12 assertions in a disposable Arch container.
- The companion x86_64 package passed installation, offline version and program execution, package ownership, self-update refusal and removal checks. ARM64 execution passed under emulation; native Arch Linux ARM packaging remains unverified.

A fresh ISO installation was not tested. This change has no desktop behavior to verify.
