### PR TITLE
Reduce image selector process churn

### DIFF
--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -355,8 +355,27 @@ if [[ $open_result != "ok" ]]; then
   exit 1
 fi
 
+wait_started=$SECONDS
+wait_timeout_seconds=${OMARCHY_IMAGE_SELECTOR_TIMEOUT_SECONDS:-3600}
+if [[ ! $wait_timeout_seconds =~ ^[1-9][0-9]*$ ]]; then
+  wait_timeout_seconds=3600
+fi
+done_dir=${done_file%/*}
+done_name=${done_file##*/}
+done_name_pattern="/${done_name//./\\.}$"
+
 while [[ ! -e $done_file ]]; do
-  sleep 0.01
+  if (( SECONDS - wait_started >= wait_timeout_seconds )); then
+    echo "Image selector timed out waiting for completion" >&2
+    exit 1
+  fi
+
+  # Wait for this request's completion event instead of spawning 100 sleep
+  # processes per second. The one-second timeout closes the check/watch race if
+  # the done file appears just before inotifywait begins listening.
+  inotifywait --quiet --timeout 1 \
+    --event create --event close_write --event moved_to \
+    --include "$done_name_pattern" "$done_dir" >/dev/null 2>&1 || true
 done
 
 if [[ -s $selection_file ]]; then

--- a/test/shell.d/menu-images-test.sh
+++ b/test/shell.d/menu-images-test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 require_command flock
+require_command inotifywait
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
@@ -139,3 +140,54 @@ PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" VIPSTHUMBNAIL_CALLS_FILE="$t
 
 (( $(wc -l <"$tmp/calls") == 6 )) || fail "image menu releases thumbnail locks after generation"
 pass "image menu owns locks for exactly one generator lifetime"
+
+real_inotifywait=$(command -v inotifywait)
+cat >"$stub_bin/inotifywait" <<'EOF'
+#!/bin/bash
+
+printf 'call\n' >>"$INOTIFYWAIT_CALLS_FILE"
+exec "$REAL_INOTIFYWAIT" "$@"
+EOF
+chmod +x "$stub_bin/inotifywait"
+
+cat >"$stub_bin/omarchy-shell" <<'EOF'
+#!/bin/bash
+
+[[ $1 == "image-selector" && $2 == "open" ]] || exit 1
+selection_file=$6
+done_file=$7
+
+if [[ $IMAGE_SELECTOR_TEST_MODE == "complete" ]]; then
+  (
+    sleep 0.1
+    printf '%s\n' "$IMAGE_SELECTOR_RESULT" >"$selection_file"
+    touch "$done_file"
+  ) >/dev/null 2>&1 &
+fi
+
+printf 'ok\n'
+EOF
+chmod +x "$stub_bin/omarchy-shell"
+
+: >"$tmp/inotifywait-calls"
+selected_result=$(
+  PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" \
+    IMAGE_SELECTOR_TEST_MODE=complete IMAGE_SELECTOR_RESULT="$images/two.png" \
+    INOTIFYWAIT_CALLS_FILE="$tmp/inotifywait-calls" REAL_INOTIFYWAIT="$real_inotifywait" \
+    "$ROOT/bin/omarchy-menu-images" "$images"
+)
+[[ $selected_result == "$images/two.png" ]] || fail "image menu returns a selection after its completion event"
+(( $(wc -l <"$tmp/inotifywait-calls") <= 2 )) || fail "image menu does not spin while waiting for completion"
+pass "image menu waits efficiently for a completion event"
+
+: >"$tmp/inotifywait-calls"
+if PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" \
+  IMAGE_SELECTOR_TEST_MODE=abandon OMARCHY_IMAGE_SELECTOR_TIMEOUT_SECONDS=1 \
+  INOTIFYWAIT_CALLS_FILE="$tmp/inotifywait-calls" REAL_INOTIFYWAIT="$real_inotifywait" \
+  "$ROOT/bin/omarchy-menu-images" "$images" >"$tmp/abandoned.out" 2>"$tmp/abandoned.err"; then
+  fail "image menu rejects an abandoned selector request"
+fi
+grep -Fxq "Image selector timed out waiting for completion" "$tmp/abandoned.err" ||
+  fail "image menu explains an abandoned selector timeout"
+(( $(wc -l <"$tmp/inotifywait-calls") <= 2 )) || fail "image menu bounds waiting without a hot process loop"
+pass "image menu bounds abandoned selector requests"


### PR DESCRIPTION
## Summary

- replace the image selector's 10 ms `sleep` loop with a file-event wait scoped to the current request
- stop waiting after one hour if the selector never signals completion
- cover successful completion and abandoned-request behavior

## Why

`omarchy-menu-images` currently starts up to 100 `sleep` processes per second for as long as an image picker is open. If the shell exits or reloads after accepting the request but before creating its completion file, the wrapper keeps doing that indefinitely.

`inotify-tools` is already part of Omarchy's base package set. Waiting for the generated completion filename reduces the normal wait to at most one blocking watcher per second. The one-second watcher timeout closes the check/watch race; the overall timeout prevents a lost completion signal from leaving the wrapper alive forever.

Successful requests keep the existing selection-file contract and output behavior.

## Testing

```text
test/shell.d/menu-images-test.sh
```

The focused test exercises both paths:

- an asynchronous completion event returns the selected image
- a missing completion event exits with the expected timeout error
- each path starts no more than two watcher processes during the test window
