### PR TITLE
fix(terminals): wezterm app_id

### DIFF
--- a/default/hypr/apps/terminals.lua
+++ b/default/hypr/apps/terminals.lua
@@ -3,6 +3,6 @@
 -- (org.omarchy.btop, org.omarchy.terminal, TUI.float, ...), so match those too.
 -- The class is matched in full, so foot's other app-id needs spelling out.
 o.window(
-  "(Alacritty|kitty|com.mitchellh.ghostty|foot|org\\.codeberg\\.dnkl\\.foot|org.wezfurlong.wezterm|org\\.omarchy\\..*|TUI\\..*)",
+  "(Alacritty|kitty|com.mitchellh.ghostty|foot|org\\.codeberg\\.dnkl\\.foot|org\\.wezfurlong\\.wezterm|org\\.omarchy\\..*|TUI\\..*)",
   { tag = "+terminal" }
 )

--- a/default/hypr/apps/terminals.lua
+++ b/default/hypr/apps/terminals.lua
@@ -3,6 +3,6 @@
 -- (org.omarchy.btop, org.omarchy.terminal, TUI.float, ...), so match those too.
 -- The class is matched in full, so foot's other app-id needs spelling out.
 o.window(
-  "(Alacritty|kitty|com.mitchellh.ghostty|foot|org\\.codeberg\\.dnkl\\.foot|wezterm|org\\.omarchy\\..*|TUI\\..*)",
+  "(Alacritty|kitty|com.mitchellh.ghostty|foot|org\\.codeberg\\.dnkl\\.foot|org.wezfurlong.wezterm|org\\.omarchy\\..*|TUI\\..*)",
   { tag = "+terminal" }
 )


### PR DESCRIPTION
Fixes #10839

According to the docs (https://wezterm.org/cli/start.html), wezterm's class/app_id should be `org.wezfurlong.wezterm`:

>--class <CLASS>
>   Override the default windowing system class. The default is
>   "org.wezfurlong.wezterm". Under X11 and Windows this changes the
>   window class. Under Wayland this changes the app_id. This changes the
>   class for all windows spawned by this instance of wezterm, including
>   error, update and ssh authentication dialogs

Having the wrong app_id causes wezterm to not be recognized as a terminal which breaks super copy/paste