### PR TITLE
Close Bluetooth panel after connecting

### DIFF
--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -312,7 +312,10 @@ Panel {
       if (finishedConnecting
           || (action === "disconnecting" && found && !found.connected)
           || (action === "forgetting" && (!found || (!found.paired && !found.bonded && !found.trusted)))) {
-        if (finishedConnecting) scheduleAudioOutputSwitch(found)
+        if (finishedConnecting) {
+          scheduleAudioOutputSwitch(found)
+          root.close()
+        }
         delete next[address]
         changed = true
       }

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -20,6 +20,8 @@ assert(/manageIpc: false/.test(panelSource), 'bluetooth owns its IPC handler so 
 assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
 assert(!/adapter\.enabled = /.test(panelSource), 'bluetooth never writes the adapter power state directly')
 
+assert(/if \(finishedConnecting\) \{[\s\S]*?scheduleAudioOutputSwitch\(found\)[\s\S]*?root\.close\(\)/.test(panelSource), 'bluetooth closes the panel after a requested connection succeeds')
+
 // Discovery is a BlueZ session that nothing ends at panel close: it persists
 // until StopDiscovery or until quickshell's D-Bus connection drops with the
 // shell, and a leaked session keeps the radio in inquiry, starving A2DP audio


### PR DESCRIPTION
Close the Bluetooth panel once a connection initiated from the panel is confirmed successful.

Previously, the selected device moved into the Connected section but the panel remained open, requiring another click to dismiss it. The panel now closes only after BlueZ reports the pending device as connected, so pending or failed attempts remain visible. Audio output switching continues as before.

## Verification

- `bash test/shell.d/bluetooth-test.sh`
- Manually verified with AirPods: the stock panel remains open after a successful connection; the patched panel closes after the connection succeeds.
- Captured before and after screen recordings.

Before: 

https://github.com/user-attachments/assets/7b533c18-ed40-40d0-8cd4-4bff96a94a0b

After:

https://github.com/user-attachments/assets/92194c45-c283-4359-9b34-1a38766434be

