### PR TITLE
Show API-equivalent agent usage cost

### DIFF
--- a/shell/plugins/agents/ApiCost.js
+++ b/shell/plugins/agents/ApiCost.js
@@ -1,0 +1,94 @@
+// Standard API rates in USD per million tokens. The panel estimates from the
+// token categories in the collector contract; batch, priority, regional,
+// tool, and dedicated-deployment charges are not inferable from aggregates.
+// Verified 2026-09-07 against the providers' published pricing pages.
+
+// Rates are [input, cache read, 5-minute/default cache write, output].
+var providerRates = {
+  codex: [
+    [/^gpt-6-astra(?:-|$)/, [10, 1, 12.5, 50]],
+    [/^gpt-5\.6-sol(?:-|$)/, [4, 0.4, 5, 20]],
+    [/^gpt-5\.6-terra(?:-|$)/, [2, 0.2, 2.5, 12]],
+    [/^gpt-5\.6-luna(?:-|$)/, [0.2, 0.02, 0.25, 1.2]],
+    [/^gpt-5\.5-pro(?:-|$)/, [30, 30, 30, 180]],
+    [/^gpt-5\.5(?:-|$)/, [5, 0.5, 6.25, 30]],
+    [/^gpt-5\.4-pro(?:-|$)/, [30, 30, 30, 180]],
+    [/^gpt-5\.4-mini(?:-|$)/, [0.75, 0.075, 0.9375, 4.5]],
+    [/^gpt-5\.4-nano(?:-|$)/, [0.2, 0.02, 0.25, 1.25]],
+    [/^gpt-5\.4(?:-|$)/, [2.5, 0.25, 3.125, 15]],
+    [/^gpt-5\.3-codex(?:-|$)/, [1.75, 0.175, 2.1875, 14]],
+    [/^gpt-5\.2-codex(?:-|$)/, [1.75, 0.175, 2.1875, 14]],
+    [/^gpt-5\.1-codex-mini(?:-|$)/, [0.25, 0.025, 0.3125, 2]],
+    [/^gpt-5\.1-codex(?:-max)?(?:-|$)/, [1.25, 0.125, 1.5625, 10]],
+    [/^gpt-5-codex(?:-|$)/, [1.25, 0.125, 1.5625, 10]],
+    [/^gpt-5-mini(?:-|$)/, [0.25, 0.025, 0.3125, 2]],
+    [/^gpt-5-nano(?:-|$)/, [0.05, 0.005, 0.0625, 0.4]],
+    [/^gpt-5(?:-chat-latest|-[0-9]{4}-[0-9]{2}-[0-9]{2}|$)/, [1.25, 0.125, 1.5625, 10]],
+    [/^chat-latest$/, [5, 0.5, 6.25, 30]],
+    [/^codex-mini-latest$/, [1.5, 0.375, 1.875, 6]]
+  ],
+  claude: [
+    [/^claude-(?:mythos|opus)-(?:4-7|4-6)(?:-|$)/, [5, 0.5, 6.25, 25]],
+    [/^claude-opus-4-5(?:-|$)/, [5, 0.5, 6.25, 25]],
+    [/^claude-opus-(?:4-1|4)(?:-|$)/, [15, 1.5, 18.75, 75]],
+    [/^claude-opus-3(?:-|$)/, [15, 1.5, 18.75, 75]],
+    [/^claude-sonnet-(?:4-6|4-5|4)(?:-|$)/, [3, 0.3, 3.75, 15]],
+    [/^claude-(?:3-7|3-5)-sonnet(?:-|$)/, [3, 0.3, 3.75, 15]],
+    [/^claude-haiku-4-5(?:-|$)/, [1, 0.1, 1.25, 5]],
+    [/^claude-3-5-haiku(?:-|$)/, [0.8, 0.08, 1, 4]],
+    [/^claude-3-haiku(?:-|$)/, [0.25, 0.03, 0.3125, 1.25]]
+  ],
+  fireworks: [
+    [/kimi-k2p6-turbo|kimi-k2\.6-turbo/, [2, 0.3, 0, 8]],
+    [/kimi-k2p6|kimi-k2\.6/, [0.95, 0.16, 0, 4]],
+    [/kimi-k2p5|kimi-k2\.5/, [0.6, 0.1, 0, 3]],
+    [/deepseek-v4.*pro/, [1.74, 0.145, 0, 3.48]],
+    [/deepseek-v3/, [0.56, 0.28, 0, 1.68]],
+    [/glm-?5p1-fast|glm-?5\.1-fast/, [2.8, 0.52, 0, 8.8]],
+    [/glm-?5p1|glm-?5\.1/, [1.4, 0.26, 0, 4.4]],
+    [/glm-?5(?:-|$)/, [1, 0.2, 0, 3.2]],
+    [/glm-?4p7|glm-?4\.7/, [0.6, 0.3, 0, 2.2]],
+    [/minimax-m?2p7|minimax-m?2\.7/, [0.3, 0.06, 0, 1.2]],
+    [/minimax-m?2p5|minimax-m?2\.5/, [0.3, 0.03, 0, 1.2]],
+    [/qwen3.*vl.*30b/, [0.15, 0.075, 0, 0.6]],
+    [/gpt-oss-120b/, [0.15, 0.015, 0, 0.6]],
+    [/gpt-oss-20b/, [0.07, 0.035, 0, 0.3]]
+  ]
+}
+
+function ratesFor(providerId, modelId) {
+  var entries = providerRates[String(providerId || "")] || []
+  var id = String(modelId || "").toLowerCase()
+  for (var i = 0; i < entries.length; i++)
+    if (entries[i][0].test(id)) return entries[i][1]
+  return null
+}
+
+function cost(providerId, modelId, bucket) {
+  var rate = ratesFor(providerId, modelId)
+  if (!rate) return null
+  var fields = ["inputTokens", "cacheReadInputTokens", "cacheCreationInputTokens", "outputTokens"]
+  var total = 0
+  for (var i = 0; i < fields.length; i++) {
+    var tokens = Number(bucket[fields[i]] || 0)
+    if (!isFinite(tokens) || tokens < 0) return null
+    if (tokens > 0 && rate[i] === 0) return null
+    total += tokens * rate[i] / 1000000
+  }
+  return total
+}
+
+function summary(providerId, buckets) {
+  var total = 0
+  var unknown = []
+  var priced = 0
+  for (var id in buckets) {
+    var value = cost(providerId, id, buckets[id])
+    if (value === null) unknown.push(id)
+    else {
+      total += value
+      priced++
+    }
+  }
+  return { total: total, unknown: unknown, priced: priced }
+}

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -4,6 +4,7 @@ import Quickshell
 import Quickshell.Io
 import qs.Commons
 import qs.Ui
+import "ApiCost.js" as ApiCost
 
 Panel {
   id: root
@@ -29,6 +30,11 @@ Panel {
     return 0
   }
   readonly property var provider: providers.length > 0 ? providers[providerIndex] : null
+
+  readonly property bool hasApiCost: apiCost.priced > 0
+  property bool showDollars: false
+  function toggleUnits() { showDollars = !showDollars }
+  readonly property var apiCost: ApiCost.summary(provider ? provider.providerId : "", provider ? (provider.modelUsage || {}) : {})
 
   property bool cursorActive: false
 
@@ -240,6 +246,7 @@ Panel {
       var cacheWrite = Number(bucket.cacheCreationInputTokens || 0)
       rows.push({
         name: usage.friendlyModelName(id),
+        apiCost: ApiCost.cost(p.providerId, id, bucket),
         total: input + output + cacheRead + cacheWrite,
         input: input,
         output: output,
@@ -332,6 +339,7 @@ Panel {
     function hide(): void { root.close() }
     function toggle(): void { root.toggle() }
     function refresh(): string { root.refreshNow(); return "ok" }
+    function toggleUnits(): void { root.toggleUnits() }
     function next(): string { root.selectProvider(root.providerIndex + 1); return "ok" }
   }
 
@@ -376,7 +384,10 @@ Panel {
       onActivateRequested: root.refreshNow()
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
-      onTextKey: function(t) { if (t === "r" || t === "R") root.refreshNow() }
+      onTextKey: function(t) {
+        if (t === "r" || t === "R") root.refreshNow()
+        if (root.hasApiCost && (t === "d" || t === "D")) root.toggleUnits()
+      }
 
       Flickable {
         id: panelFlick
@@ -403,6 +414,45 @@ Panel {
             meta: root.heroMeta(root.provider)
             foreground: root.foreground
             fontFamily: root.fontFamily
+
+            trailingControl: Component {
+              Row {
+                visible: root.hasApiCost
+                spacing: Style.space(12)
+
+                BorderSurface {
+                  visible: root.apiCost.priced > 0
+                  implicitWidth: costText.implicitWidth + Style.space(10)
+                  implicitHeight: unitButton.implicitHeight
+                  color: "transparent"
+                  borderSpec: Border.controlSpec("normal", root.foreground, Color.accent)
+                  radius: Style.cornerRadius
+
+                  Text {
+                    id: costText
+                    anchors.centerIn: parent
+                    text: root.formatMoney(root.apiCost.total, "USD")
+                    textFormat: Text.PlainText
+                    color: root.dim
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                    font.bold: true
+                  }
+                }
+
+                Button {
+                  id: unitButton
+                  text: root.showDollars ? "Dollars" : "Tokens"
+                  bordered: true
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  fontSize: Style.font.caption
+                  onClicked: root.toggleUnits()
+
+                  tooltipText: "Switch model values between tokens and estimated USD (D).\nTotal covers priced recorded usage at standard short-context rates.\nSome models do not have published pricing."
+                }
+              }
+            }
 
             iconComponent: Component {
               Item {
@@ -664,7 +714,7 @@ Panel {
 
             PanelSectionHeader {
               width: parent.width
-              text: "TOKENS BY MODEL"
+              text: root.hasApiCost && root.showDollars ? "API COST BY MODEL" : "TOKENS BY MODEL"
               foreground: root.foreground
               fontFamily: root.fontFamily
             }
@@ -916,7 +966,9 @@ Panel {
     Text {
       id: modelTokens
       textFormat: Text.PlainText
-      text: modelRow.row ? usage.formatTokenCount(modelRow.row.total) : ""
+      text: modelRow.row ? (root.hasApiCost && root.showDollars
+        ? (modelRow.row.apiCost === null ? "Unpriced" : root.formatMoney(modelRow.row.apiCost, "USD"))
+        : usage.formatTokenCount(modelRow.row.total)) : ""
       color: root.dim
       font.family: root.fontFamily
       font.pixelSize: Style.font.bodySmall

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -24,6 +24,11 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
   to the heaviest model,
   the same way the weekly chart scales to its busiest day. Hover for the
   input / output / cache split.
+- **API equivalent** — when a provider's models have published token prices,
+  the hero shows their estimated standard API cost. The Tokens/Dollars button
+  switches the model rows without adding another section to the panel.
+  Rates cover the currently supported OpenAI, Anthropic, and named Fireworks
+  serverless models. Private deployments and unknown model IDs stay unpriced.
 
 A subscription appears only when it is enabled in settings and has actually
 recorded usage — on this machine or on a synced one. With one such agent
@@ -95,7 +100,8 @@ only adds the meter and the spent-of-funded line under the real figure.
 ## Interactions
 
 - Bar icon: left = panel, right = launch agent, middle = next subscription.
-- Panel: `h`/`l` switch subscription, `j`/`k` scroll, `r` or Enter refresh,
+- Panel: `h`/`l` switch subscription, `j`/`k` scroll, `r` or Enter refresh, `d`
+  switches priced model rows between tokens and dollars,
   Tab moves to the neighboring bar panel, Esc closes.
 - IPC: `omarchy-shell omarchy.agents <open|close|toggle|refresh|next>`.
 

--- a/test/shell.d/agents-api-cost-test.sh
+++ b/test/shell.d/agents-api-cost-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+const pricing = {}
+vm.createContext(pricing)
+vm.runInContext(fs.readFileSync(root + '/shell/plugins/agents/ApiCost.js', 'utf8'), pricing)
+
+function tokens(input, cacheRead, cacheWrite, output) {
+  return { inputTokens: input, cacheReadInputTokens: cacheRead, cacheCreationInputTokens: cacheWrite, outputTokens: output }
+}
+
+const supportedModels = {
+  codex: [
+    'gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna',
+    'gpt-5.5-pro', 'gpt-5.5', 'gpt-5.4-pro', 'gpt-5.4-mini',
+    'gpt-5.4-nano', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex',
+    'gpt-5.1-codex-mini', 'gpt-5.1-codex-max', 'gpt-5-codex',
+    'gpt-5-mini', 'gpt-5-nano', 'gpt-5', 'chat-latest',
+    'codex-mini-latest'
+  ],
+  claude: [
+    'claude-mythos-4-7', 'claude-opus-4-5', 'claude-opus-4-1',
+    'claude-opus-3', 'claude-sonnet-4-6', 'claude-3-7-sonnet',
+    'claude-haiku-4-5', 'claude-3-5-haiku', 'claude-3-haiku'
+  ],
+  fireworks: [
+    'kimi-k2p6-turbo', 'kimi-k2p6', 'kimi-k2p5', 'deepseek-v4-pro',
+    'deepseek-v3', 'glm-5p1-fast', 'glm-5p1', 'glm-5', 'glm-4p7',
+    'minimax-m2p7', 'minimax-m2p5', 'qwen3-vl-30b', 'gpt-oss-120b',
+    'gpt-oss-20b'
+  ]
+}
+
+for (const provider in supportedModels)
+  for (const model of supportedModels[provider])
+    assert(pricing.ratesFor(provider, model) !== null,
+      'API cost has a rate for ' + provider + ' model ' + model)
+
+assert(pricing.cost('codex', 'gpt-6-astra', tokens(1e6, 1e6, 1e6, 1e6)) === 73.5,
+  'API cost prices every OpenAI token category')
+assert(pricing.cost('codex', 'gpt-5.3-codex-20260801', tokens(1e6, 0, 0, 1e6)) === 15.75,
+  'API cost recognizes dated OpenAI model snapshots')
+assert(pricing.cost('codex', 'gpt-5.4-mini-2026-03-17', tokens(1e6, 0, 0, 1e6)) === 5.25,
+  'API cost keeps OpenAI mini models out of the flagship family')
+assert(pricing.cost('codex', 'gpt-5.5-pro', tokens(1e6, 1e6, 0, 1e6)) === 240,
+  'API cost does not apply a cache discount to OpenAI Pro models')
+assert(pricing.cost('claude', 'claude-sonnet-4-6-20260217', tokens(1e6, 1e6, 1e6, 1e6)) === 22.05,
+  'API cost recognizes Claude families and prompt caching')
+assert(Math.abs(pricing.cost('fireworks', 'accounts/fireworks/models/kimi-k2p6', tokens(1e6, 1e6, 0, 1e6)) - 5.11) < 1e-9,
+  'API cost recognizes qualified Fireworks model ids')
+assert(pricing.cost('fireworks', 'custom-lora', tokens(1e6, 0, 0, 0)) === null,
+  'API cost leaves custom deployments unpriced')
+assert(pricing.cost('codex', 'codex-auto-review', tokens(1e6, 0, 0, 0)) === null,
+  'API cost leaves internal services unpriced')
+
+const summary = pricing.summary('claude', {
+  'claude-opus-4-6': tokens(1e6, 0, 0, 0),
+  'private-model': tokens(1e6, 0, 0, 0)
+})
+assert(summary.total === 5 && summary.priced === 1 && summary.unknown[0] === 'private-model',
+  'API cost totals known models and reports unknown models')
+JS


### PR DESCRIPTION
Even though I use a subscription for agents, I think its interesting to see how much my usage would've cost if I was paying API prices for tokens. So that's the spirit of this PR.

The Agents panel now shows the API-equivalent total beside a compact Tokens/Dollars toggle. Dollar mode reuses the existing per-model rows, so the panel keeps its current size and layout. Published standard rates cover the currently supported OpenAI, Anthropic, and named Fireworks serverless models; unknown and private model IDs remain visibly unpriced.

## Screenshot

![Agents widget showing API-equivalent dollars](https://raw.githubusercontent.com/andrewDoing/omarchy/pr-assets-10845/agents-api-cost.png)

## Validation

- `bash test/shell.d/agents-api-cost-test.sh`
- `bash test/shell.d/agents-panel-test.sh`
- `bash test/shell.d/qml-text-format-test.sh`
- `git diff --check`
- Restarted the linked development shell and visually checked both token and dollar views
