### PR TITLE
Tag Brave Origin as a chromium-based browser

### DIFF
--- a/default/hypr/apps/browser.lua
+++ b/default/hypr/apps/browser.lua
@@ -1,5 +1,5 @@
 -- Browser tags and styling.
-o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-browser|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
+o.window("((google-)?[cC]hrom(e|ium)|[bB]rave-(browser|origin)|[mM]icrosoft-edge|Vivaldi-stable|helium)", { tag = "+chromium-based-browser" })
 o.window("([fF]irefox|zen|librewolf)", { tag = "+firefox-based-browser" })
 o.window({ tag = "chromium-based-browser" }, { tag = "-default-opacity", tile = true, opacity = "1.0 0.985" })
 o.window({ tag = "firefox-based-browser" }, { tag = "-default-opacity", opacity = "1.0 0.985" })


### PR DESCRIPTION
Omarchy ships Brave Origin as an installable browser, but its windows are not tagged as one.

## The defect

`default/hypr/apps/browser.lua:2` matches `[bB]rave-browser`. Brave Origin reports its window class as **`brave-origin`**, so it never picks up the `chromium-based-browser` tag. Two consequences follow from `browser.lua:4`: it misses `tile = true`, and it falls through to the catch-all in `default/hypr/windows.lua:25`, rendering at `opacity = "0.985 0.96"` instead of the browser rule's `"1.0 0.985"`. The 0.96 inactive value is the visible one, and it shows on a browser rather than on other apps because a page full of white background and small text reveals blending that a dark terminal hides.

This is not an unsupported browser. Omarchy installs it deliberately: `omarchy-install-browser brave-origin`, plus `install.browser.brave-origin`, `setup.default.browser.brave-origin` and `remove.browser.brave-origin` in `default/omarchy/omarchy-menu.jsonc`.

## Evidence, and exactly how far it goes

On omarchy 4.0.2 with Brave Origin installed from the menu, the **measured** state before any change, which is the defect itself:

```
$ hyprctl clients -j | jq ...
brave-origin  tags: ["default-opacity*"]
```

A window Omarchy offers to install for you, carrying the catch-all opacity tag instead of the browser one.

**What I have NOT measured, stated plainly rather than implied:** the after-state under *this patch*. My machine was fixed with an equivalent user-level rule in `~/.config/hypr/hyprland.lua` before this PR existed, and that rule, not this patch, is what re-tagged the live window. So treat the tag output above as evidence of the defect, and the diff as the proposed fix, verified by inspection against `browser.lua:2` and `windows.lua:25` rather than by a run of this branch.

On `agents/skills/visual-verification.md`: I have deliberately not attached a before/after capture, because the difference is 0.96 against 1.0 inactive opacity and does not survive a screenshot honestly. The `hyprctl clients -j` tag output is the checkable signal, and a maintainer can reproduce it in one command without owning a Brave Origin install.

## The change

One character class, `[bB]rave-browser` becomes `[bB]rave-(browser|origin)`, so both builds tag identically.

## Tests

`./test/all` with the patch applied: 8 of 236 files fail, all under `test/shell.d/` (`bar-icon-geometry`, `config`, `hermes-skin-migration`, `launch-about`, `locate`, `plymouth-set`, `snapper`, `unowned-system-paths`).

Baseline, to show they are not mine: `git stash && ./test/shell` on the unmodified tree at `5b91db50` fails **the same 8 files**. That baseline run was `./test/shell` rather than the full `./test/all`, since every failure lives in that suite. Pre-existing, and unrelated to a change touching only `default/hypr/`.

---

Found and fixed by **Cowork:Alice**, Aunova's multi-agent engineering crew, on a workstation running Brave Origin as the default browser. Contact `c@mailstr.app`.