### PR TITLE
Restore Ghostty's default scroll speed for discrete mouse wheels

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -34,8 +34,9 @@ keybind = super+control+shift+alt+arrow_up=resize_split:up,100
 keybind = super+control+shift+alt+arrow_left=resize_split:left,100
 keybind = super+control+shift+alt+arrow_right=resize_split:right,100
 
-# Slowdown mouse scrolling
-mouse-scroll-multiplier = 0.95
+# Slow down precise scrolling only. A bare value applies to both device types,
+# which would drop discrete wheel clicks from Ghostty's default 3 to 0.95.
+mouse-scroll-multiplier = precision:0.95,discrete:3
 
 # Fix general slowness on hyprland (https://github.com/ghostty-org/ghostty/discussions/3224)
 async-backend = epoll

--- a/migrations/1788897876.sh
+++ b/migrations/1788897876.sh
@@ -1,0 +1,13 @@
+echo "Restore Ghostty's default scroll speed for discrete mouse wheels"
+
+ghostty_config="$HOME/.config/ghostty/config"
+
+[[ -f $ghostty_config ]] || exit 0
+grep -qxF 'mouse-scroll-multiplier = 0.95' "$ghostty_config" || exit 0
+
+# A bare multiplier applies to both device types, so the shipped 0.95 also
+# overrode Ghostty's discrete default of 3 and made wheel clicks crawl.
+sed -i \
+  -e 's/^# Slowdown mouse scrolling$/# Slow down precise scrolling only. A bare value applies to both device types,\n# which would drop discrete wheel clicks from Ghostty'"'"'s default 3 to 0.95./' \
+  -e 's/^mouse-scroll-multiplier = 0\.95$/mouse-scroll-multiplier = precision:0.95,discrete:3/' \
+  "$ghostty_config"


### PR DESCRIPTION
`config/ghostty/config` sets the scroll multiplier without a device prefix:

```
# Slowdown mouse scrolling
mouse-scroll-multiplier = 0.95
```

Ghostty's default is `precision:1,discrete:3`, and a bare value applies to **both** device types. So the 0.95 intended as a slight softening of precise scrolling also replaced the discrete default of 3, and wheel clicks move 0.95 lines instead of 3 — a notched mouse scrolls over three times slower than stock Ghostty.

Confirmed with Ghostty's own resolver (1.3.1):

```
mouse-scroll-multiplier = 0.95                      =>  precision:0.95, discrete:0.95
mouse-scroll-multiplier = precision:0.95,discrete:3 =>  precision:0.95, discrete:3
```

Touchpads are unaffected either way: precise scrolling keeps 0.95, and Ghostty already gets `scroll_touchpad = 0.2` from `default/hypr/input.lua`. Ghostty is also the only terminal in `config/` that ships a scroll multiplier at all.

The prefix form needs Ghostty >= 1.2.1; Omarchy ships 1.3.1.

### Migration

`config/` only seeds new installs, so the migration repairs the line already copied into `~/.config/ghostty/config`. It follows `migrations/1780057136.sh`, which patches that same file. It matches the exact shipped line, so anyone who tuned their own value is left alone.

Verified against temporary homes:

| Case | Result |
| --- | --- |
| No Ghostty config | exits 0, creates nothing |
| Stock Omarchy config | rewritten to `precision:0.95,discrete:3` |
| Already migrated | no-op |
| User-set `2.5` | untouched |

### Tests

`./test/all` shows the same failures before and after this change (`config`, `locate`, `snapper`, `unowned-system-paths`), all environmental on this machine — `config-test.sh` wants an `omarchy-pkgs` checkout, for instance.

Worth flagging separately: `locate-test.sh` reads every file under `bin/` as UTF-8, and the suite byte-compiles the Python commands there into `bin/__pycache__`. It passes on a fresh checkout and fails on the next run against the `.pyc` magic bytes. Unrelated to this change, so I left it out rather than mix it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJmu5maK4f8KLVg7tbEd8Z