### PR TITLE
Disable idle handling when locking is disabled

### DIFF
--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -23,7 +23,7 @@ Item {
   readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
   readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
-  readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
+  readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake && (lockTimeoutSeconds > 0)
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
   property bool stayAwake: false


### PR DESCRIPTION
idleEnabled was still on even if the lockTimeoutSeconds was 0, which enabled a bug where a wayland SDL application closing triggered the lockscreen to immediately show up. 

This fix prevents the lockscreen from showing up when locking is disabled by adding a condition in the initialization of the idleEnabled property.