### PR TITLE
Dismiss the low battery warning once the charger is back

### DIFF
--- a/bin/omarchy-battery-low
+++ b/bin/omarchy-battery-low
@@ -13,5 +13,8 @@ fi
 
 level=$1
 
+# The shell's battery service dismisses this toast by summary once the charger
+# is back, so keep the headline in sync with lowBatterySummary in
+# shell/plugins/services/battery/Service.qml.
 omarchy-notification-send -g 󱐋 -u critical "Time to recharge!" "Battery is down to ${level}%" -i battery-caution -t 30000
 omarchy-hook battery-low "$level"

--- a/shell/plugins/services/battery/BatteryModel.js
+++ b/shell/plugins/services/battery/BatteryModel.js
@@ -7,14 +7,17 @@ function isDischarging(device, onBattery, dischargingState) {
   return !!(device && device.isPresent && onBattery && device.state === dischargingState)
 }
 
-function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified) {
+function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified, firstCheck) {
   var level = batteryPercentage(device)
-  if (level < 0) return { level: level, notify: false, notifiedLowBattery: false }
+  var low = level >= 0 && isDischarging(device, onBattery, dischargingState) && level <= threshold
 
-  var low = isDischarging(device, onBattery, dischargingState) && level <= threshold
   return {
     level: level,
     notify: low && !alreadyNotified,
+    // A full shell restart forgets alreadyNotified but restores the critical
+    // toast from disk, so the first check clears too rather than trusting the
+    // flag alone.
+    clear: !low && (!!alreadyNotified || !!firstCheck),
     notifiedLowBattery: low
   }
 }

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -11,6 +11,9 @@ Item {
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
 
   readonly property int batteryThreshold: 10
+  readonly property string lowBatterySummary: "Time to recharge!"
+  property bool checkedBattery: false
+  property bool pendingLowBatteryClear: false
   property string pendingPowerSource: ""
   property string activePowerProfile: ""
   readonly property bool powerSaverOnBattery: UPower.onBattery && activePowerProfile === "power-saver"
@@ -30,9 +33,11 @@ Item {
   }
 
   function checkBattery() {
-    var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery)
+    var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery, !checkedBattery)
+    checkedBattery = true
     persisted.notifiedLowBattery = state.notifiedLowBattery
     if (state.notify) sendLowBatteryWarning(state.level)
+    else if (state.clear) clearLowBatteryWarning()
   }
 
   function sendLowBatteryWarning(level) {
@@ -42,6 +47,26 @@ Item {
       String(level)
     ]
     warningProcess.running = true
+  }
+
+  // The low-battery toast is critical urgency, so the shell never expires it on
+  // its own. Take it down once the charger is back rather than leaving a stale
+  // warning on screen; it stays in notification history either way.
+  //
+  // Wait for a warning still being posted: dismissing by summary only matches
+  // toasts the server already has, and checkBattery has cleared the notified
+  // flag by now, so a dismissal that runs too early would never be retried and
+  // the toast would linger for good. Defer rather than drop, the way
+  // pendingPowerSource does for the power-profile process.
+  function clearLowBatteryWarning() {
+    pendingLowBatteryClear = true
+    if (!warningProcess.running && !dismissProcess.running) runPendingLowBatteryClear()
+  }
+
+  function runPendingLowBatteryClear() {
+    dismissProcess.command = ["omarchy-notification-dismiss", lowBatterySummary]
+    pendingLowBatteryClear = false
+    dismissProcess.running = true
   }
 
   function applyPowerProfile() {
@@ -59,7 +84,15 @@ Item {
     if (!powerProfileReadProcess.running) powerProfileReadProcess.running = true
   }
 
-  Process { id: warningProcess }
+  Process {
+    id: warningProcess
+    onExited: if (root.pendingLowBatteryClear && !dismissProcess.running) root.runPendingLowBatteryClear()
+  }
+
+  Process {
+    id: dismissProcess
+    onExited: if (root.pendingLowBatteryClear) root.runPendingLowBatteryClear()
+  }
 
   Process {
     id: powerProfileProcess

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -15,17 +15,45 @@ assert(!battery.isDischarging({ isPresent: true, state: discharging }, false, di
 
 assertDeepEqual(
   battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, false),
-  { level: 8, notify: true, notifiedLowBattery: true },
+  { level: 8, notify: true, clear: false, notifiedLowBattery: true },
   'battery warns once under threshold'
 )
 assertDeepEqual(
   battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, true),
-  { level: 8, notify: false, notifiedLowBattery: true },
+  { level: 8, notify: false, clear: false, notifiedLowBattery: true },
   'battery keeps low-battery notified state'
 )
 assertDeepEqual(
   battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, true),
-  { level: 40, notify: false, notifiedLowBattery: false },
+  { level: 40, notify: false, clear: true, notifiedLowBattery: false },
   'battery clears notified state after recovery'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, false, discharging, 10, true),
+  { level: 8, notify: false, clear: true, notifiedLowBattery: false },
+  'battery clears the warning once the charger is plugged in'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, false),
+  { level: 40, notify: false, clear: false, notifiedLowBattery: false },
+  'battery leaves notifications alone when it never warned'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: false, percentage: 0.08, state: discharging }, true, discharging, 10, true),
+  { level: -1, notify: false, clear: true, notifiedLowBattery: false },
+  'battery clears the warning when the battery goes away'
+)
+
+// A shell restart forgets the notified flag but restores the critical toast,
+// so the first check after startup clears on its own.
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, false, true),
+  { level: 40, notify: false, clear: true, notifiedLowBattery: false },
+  'battery clears a restored warning on the first check after a restart'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, false, true),
+  { level: 8, notify: true, clear: false, notifiedLowBattery: true },
+  'battery still warns on the first check when it starts up low'
 )
 JS


### PR DESCRIPTION
## The problem

Hit a 10% battery warning, plugged the charger in, and the toast stayed on screen.

`omarchy-battery-low` sends the warning at `-u critical`, and `durationFor()` in `shell/plugins/notifications/Service.qml` returns `0` for critical urgency — critical popups never expire, so the `-t 30000` on that send is ignored by design. The battery service resets its own `notifiedLowBattery` flag when you plug in, but nothing takes the toast off screen, so a stale "Time to recharge!" sits there until dismissed by hand.

## The fix

Let the service dismiss the warning it sent, once the battery stops being low.

- `BatteryModel.shouldWarnLowBattery()` gains a `clear` flag for the recovery transition (was notified, no longer low). The `level < 0` early return folds into the same expression, so a battery that disappears also clears.
- `Service.qml` calls a new `clearLowBatteryWarning()`, which runs `omarchy-notification-dismiss "Time to recharge!"`. `onOnBatteryChanged` already triggers `checkBattery()`, so it fires the moment the charger lands rather than on the next 30s tick.
- A comment in `bin/omarchy-battery-low` ties the headline to `lowBatterySummary` so the two don't drift.

Dismissing moves the toast to notification history rather than deleting it, so there's still a record that it fired.

I kept the dismissal keyed on the summary rather than tracking the notification id via `omarchy-notification-send -p`: the id would have to survive a shell restart in `PersistentProperties` and could collide with a reused id, for no real gain.

## Testing

`test/shell.d/battery-test.sh` covers the new flag with three added cases — charger plugged in, never-warned, and battery removed. `./test/shell` and `./test/cli` pass; `config-test.sh` and `locate-test.sh` fail identically on an unmodified checkout (plocate packaging and a `UnicodeDecodeError`), unrelated to this change.

Verified in the running UI per `agents/skills/visual-verification.md`: sent the real toast, confirmed it on screen, ran the dismissal, confirmed it gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7sx1LYXKQrhFwchbfqPwz