### PR TITLE
Keep cloned menu plugins reading their kinds through the panel

### DIFF
--- a/shell/Commons/Util.qml
+++ b/shell/Commons/Util.qml
@@ -71,6 +71,17 @@ QtObject {
     return value !== null && typeof value === "object" && !Array.isArray(value)
   }
 
+  // A manifest kind check that answers for both shapes the shell hands a
+  // manifest in: the registry path passes a plain object, and the panel
+  // Instantiator path passes one whose kinds arrived through modelData as a
+  // QVariantList — indexable and indexOf-able, but Array.isArray() is false
+  // for it. Duck-type on the method, never on Array.isArray.
+  function hasKind(manifest, kind) {
+    var kinds = manifest ? manifest.kinds : null
+    return !!kinds && typeof kinds.indexOf === "function"
+      && kinds.indexOf(kind) !== -1
+  }
+
   function canonicalWidgetId(id) {
     return String(id || "")
   }

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -347,8 +347,7 @@ ShellRoot {
   }
 
   function manifestHasKind(manifest, kind) {
-    return !!manifest && Array.isArray(manifest.kinds)
-      && manifest.kinds.indexOf(kind) !== -1
+    return Util.hasKind(manifest, kind)
   }
 
   function pluginHasBarCapabilities(manifest) {

--- a/test/shell.d/fixtures/manifest-model-roundtrip/shell.qml
+++ b/test/shell.d/fixtures/manifest-model-roundtrip/shell.qml
@@ -1,0 +1,77 @@
+import QtQuick
+import QtQml.Models
+import Quickshell
+import qs.Commons
+
+// The 4.0.3 cloned-menu regression in a jar. Manifests the panel hands out
+// through Instantiator modelData carry kinds as a QVariantList, and
+// Array.isArray() is false for those, so the menu capability read as absent
+// and the panel nulled a cloned plugin's app library. This fixture
+// round-trips the same shape and asserts Util.hasKind answers for the model
+// path and the plain registry path, so a revert to Array.isArray reddens the
+// model half while the registry half stays green.
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  property var failures: []
+  property var entries: [
+    { id: "acme.menu",
+      manifest: ({ id: "acme.menu", kinds: ["menu", "bar-widget"],
+                   entryPoints: ({ menu: "Menu.qml" }) }) }
+  ]
+
+  function fail(message) {
+    failures.push(String(message))
+  }
+
+  function assertTrue(condition, message) {
+    if (!condition) fail(message)
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    var payload = JSON.stringify({ ok: failures.length === 0, failures: failures })
+    if (resultPath) {
+      Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+    }
+  }
+
+  // The plain-object path the registry uses: never broken by the model shape.
+  readonly property bool directMenu: Util.hasKind(entries[0].manifest, "menu")
+  readonly property bool directPanel: !Util.hasKind(entries[0].manifest, "panel")
+  readonly property bool nullManifest: !Util.hasKind(null, "menu")
+  readonly property bool kindlessManifest: !Util.hasKind({ id: "acme.bare" }, "menu")
+
+  Instantiator {
+    model: root.entries
+    delegate: QtObject {
+      required property var modelData
+      readonly property bool hasMenu: Util.hasKind(modelData.manifest, "menu")
+      readonly property bool hasBarWidget: Util.hasKind(modelData.manifest, "bar-widget")
+      readonly property bool hasService: Util.hasKind(modelData.manifest, "service")
+
+      Component.onCompleted: {
+        var kinds = modelData.manifest.kinds
+        // The precondition that makes this the regression and not a shape
+        // assertion of its own: the model path hands kinds over indexable,
+        // but not as an array Array.isArray recognises.
+        root.assertTrue(kinds && typeof kinds.indexOf === "function",
+                        "fixture: modelData did not carry indexable kinds")
+        root.assertTrue(Array.isArray(kinds) === false,
+                        "fixture: kinds stayed a plain array through the model; the regression cannot reproduce")
+        root.assertTrue(hasMenu, "a cloned menu keeps its menu kind through the model path")
+        root.assertTrue(hasBarWidget, "a cloned bar widget keeps its bar-widget kind through the model path")
+        root.assertTrue(!hasService, "an absent kind stays absent through the model path")
+        root.assertTrue(root.directMenu, "the registry path answers menu")
+        root.assertTrue(root.directPanel, "the registry path refuses an absent kind")
+        root.assertTrue(root.nullManifest, "a null manifest has no kind")
+        root.assertTrue(root.kindlessManifest, "a manifest without kinds has no kind")
+        root.writeResult()
+      }
+    }
+  }
+}

--- a/test/shell.d/plugin-manifest-kind-test.sh
+++ b/test/shell.d/plugin-manifest-kind-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+require_compositor "plugin manifest kind test"
+
+require_command jq
+
+# Static guards: shell.qml delegates to the shared check, and the shared check
+# duck-types the list, so a future inlining of Array.isArray reddens here even
+# if the runtime fixture below were skipped.
+qml_matches() {
+  local file=$1
+  local pattern=$2
+
+  tr '\n\r\t' '   ' < "$file" | grep -Eq "$pattern"
+}
+
+qml_matches "$ROOT/shell/shell.qml" 'function manifestHasKind\(manifest, kind\) \{ *return Util\.hasKind\(manifest, kind\) *\}' ||
+  fail "shell.qml does not delegate manifestHasKind to Util.hasKind"
+pass "shell.qml delegates manifest kind checks to the shared helper"
+
+qml_matches "$ROOT/shell/Commons/Util.qml" 'typeof kinds\.indexOf === "function"' ||
+  fail "Util.hasKind no longer duck-types the kind list"
+pass "Util.hasKind duck-types the kind list"
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+config_dir="$TMPDIR/manifest-model-roundtrip"
+mkdir -p "$config_dir"
+cp "$SHELL_TEST_DIR/fixtures/manifest-model-roundtrip/shell.qml" "$config_dir/shell.qml"
+ln -s "$ROOT/shell/Commons" "$config_dir/Commons"
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+QML2_IMPORT_PATH="$ROOT/shell${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}" \
+QML_IMPORT_PATH="$ROOT/shell${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "manifest model roundtrip quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "manifest model roundtrip test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Manifest kind check result:\n' >&2
+  jq . "$result" >&2
+  printf 'Manifest kind check log:\n' >&2
+  sed -n '1,220p' "$log" >&2
+  fail "manifest kind checks pass through the model path"
+fi
+
+pass "manifest kind checks pass through the model path"

--- a/test/shell.d/plugin-manifest-kind-test.sh
+++ b/test/shell.d/plugin-manifest-kind-test.sh
@@ -18,10 +18,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-require_compositor "plugin manifest kind test"
-
-require_command jq
-
 # Static guards: shell.qml delegates to the shared check, and the shared check
 # duck-types the list, so a future inlining of Array.isArray reddens here even
 # if the runtime fixture below were skipped.
@@ -39,6 +35,10 @@ pass "shell.qml delegates manifest kind checks to the shared helper"
 qml_matches "$ROOT/shell/Commons/Util.qml" 'typeof kinds\.indexOf === "function"' ||
   fail "Util.hasKind no longer duck-types the kind list"
 pass "Util.hasKind duck-types the kind list"
+
+require_compositor "plugin manifest kind runtime test"
+
+require_command jq
 
 TMPDIR=$(mktemp -d)
 result="$TMPDIR/result.json"


### PR DESCRIPTION
Fixes #10876 (and the duplicate #10871): cloned or third-party menu plugins showed "Nothing here yet" after upgrading to 4.0.3.

A manifest the panel `Instantiator` hands out as `modelData` carries `kinds` as a `QVariantList`, on which `Array.isArray()` is false, so `manifestHasKind()` read a cloned menu as having no menu kind and the scoped `PluginShellApi` revoked its `appLibrary`.

The check moves to `Util.hasKind()`, which duck-types on `kinds.indexOf`, and `shell.qml` delegates to it. The other `Array.isArray(m.kinds)` sites only ever see raw registry manifests, so they are untouched.

**Tests**

- New `test/shell.d/plugin-manifest-kind-test.sh` with a runtime fixture that round-trips a manifest through the same `Instantiator` model path and pins both shapes (registry object and model-delivered `QVariantList`), plus negative cases.
- Static guards pin the delegation and the duck-typing.
- Mutation-checked both ways: reverting the check to `Array.isArray` reddens the fixture, and the static guards redden on either form of regression.
- `bar-widget-contract`, `plugin-auth-boundary`, `menu-guards`, and `plugins` suites pass.

**Also fixes**

Further reports of the same root cause have come in since this opened, with independent narrowing to `manifestHasKind` and to the `appLibrary` grant at `shell.qml:594`:

Fixes #11006. Fixes #11013. Fixes #11028. Fixes #10990.
