### PR TITLE
fix: clear setgid bit from Windows VM mount sources

### DIFF
--- a/bin/omarchy-windows-vm
+++ b/bin/omarchy-windows-vm
@@ -580,7 +580,7 @@ prepare_caller_mounts() {
   # Privacy is an explicit preflight step for both already-pinned sources, not
   # a side effect halfway through the two-mount transaction. Old umask-022
   # installs are hardened together before either Docker-facing anchor changes.
-  chmod 0700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
+  chmod 00700 -- "/proc/$BASHPID/fd/$storage_fd" "/proc/$BASHPID/fd/$shared_fd" || {
     exec {storage_fd}<&-
     exec {shared_fd}<&-
     return 1
@@ -588,8 +588,8 @@ prepare_caller_mounts() {
   storage_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$storage_fd" 2>/dev/null) || storage_mode=""
   shared_mode=$(stat -Lc '%a' "/proc/$BASHPID/fd/$shared_fd" 2>/dev/null) || shared_mode=""
   if [[ $storage_mode != 700 || $shared_mode != 700 ]]; then
-    exec {storage_fd}<&-
-    exec {shared_fd}<&-
+    echo "omarchy-windows-vm: refusing VM mount source with unexpected permissions" \
+      "(storage=$storage_mode shared=$shared_mode, expected 700)" >&2
     return 1
   fi
 
@@ -1015,7 +1015,7 @@ prepare_user_mount_sources() {
     echo "omarchy-windows-vm: storage and shared must be different directories" >&2
     return 1
   }
-  chmod 0700 -- "$storage" "$shared"
+  chmod 00700 -- "$storage" "$shared"
 }
 
 storage_space_path() {


### PR DESCRIPTION
## Problem

The Windows VM shared directories can end up with the setgid bit set after running the VM.

For example:

```text
~/Windows -> 2700
```

The Windows VM permission validation expects `700`, causing subsequent VM starts to fail until the setgid bit is manually removed with:

```bash
chmod g-s ~/Windows
```

## Fix

Use an explicit `00700` mode when hardening the Windows VM mount source directories so that special permission bits such as setgid are cleared.

Also provide a useful error message when the resulting permissions are unexpected.

## Testing

```bash
bash -n bin/omarchy-windows-vm
git diff --check
```

- Reproduced the issue with `~/Windows` having mode `2700`
- Verified that `00700` clears the setgid bit and results in `700`