### PR TITLE
Remove agent usage records left behind when their collector goes away

### DIFF
--- a/bin/omarchy-agent-usage-update
+++ b/bin/omarchy-agent-usage-update
@@ -51,6 +51,55 @@ collect() {
   mv "$tmp" "$USAGE_DIR/$agent.json"
 }
 
+# Names of every agent that has a collector installed, either in the
+# standard bin/ directory or in a plugin's scripts/ or bin/ directory.
+known_agents() {
+  local collector agent
+  for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
+    [[ -x $collector ]] || continue
+    agent="${collector##*/omarchy-agent-usage-}"
+    [[ $agent != "update" ]] && printf '%s\n' "$agent"
+  done
+  local plugins_dir="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/plugins"
+  if [[ -d $plugins_dir ]]; then
+    for collector in "$plugins_dir"/*/scripts/omarchy-agent-usage-*; do
+      [[ -f $collector ]] || continue
+      agent="${collector##*/omarchy-agent-usage-}"
+      [[ $agent != "update" ]] && printf '%s\n' "$agent"
+    done
+    for collector in "$plugins_dir"/*/bin/omarchy-agent-usage-*; do
+      [[ -f $collector ]] || continue
+      agent="${collector##*/omarchy-agent-usage-}"
+      [[ $agent != "update" ]] && printf '%s\n' "$agent"
+    done
+  fi
+}
+
+# The panel lists every record in USAGE_DIR, so a record left behind when
+# its agent goes away (like the pre-collector-era copilot.json) keeps
+# showing up forever. Drop those. A record is dropped only when no
+# installed collector produces it and it was last written more than seven
+# days ago — the age guard protects a plugin that writes its own file
+# without following the collector naming scheme, since an active writer
+# keeps its file fresh. Records are derived data, so losing an orphan
+# only costs a bit of history.
+remove_orphans() {
+  local agent record mtime known
+  local cutoff
+  cutoff=$(( $(date +%s) - 604800 ))
+  known=$(known_agents)
+  for record in "$USAGE_DIR"/*.json; do
+    [[ -f $record ]] || continue
+    agent="${record##*/}"
+    agent="${agent%.json}"
+    grep -qx "$agent" <<<"$known" && continue
+    mtime=$(stat -c %Y -- "$record" 2>/dev/null) || mtime=0
+    (( mtime >= cutoff )) && continue
+    rm -f -- "$record"
+    echo "omarchy-agent-usage-update: removed stale record for '$agent' (no collector found)" >&2
+  done
+}
+
 pids=()
 for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
   [[ -x $collector ]] || continue
@@ -65,4 +114,5 @@ status=0
 for pid in "${pids[@]}"; do
   wait "$pid" || status=1
 done
+remove_orphans
 exit $status

--- a/migrations/1788919234.sh
+++ b/migrations/1788919234.sh
@@ -1,0 +1,50 @@
+echo "Remove agent usage records whose collector is no longer installed"
+
+# The agents panel lists every record in the usage directory, so a record
+# left behind by an agent that went away (like the pre-collector-era copilot)
+# would keep showing up forever.
+#
+# omarchy-agent-usage-update now prunes new orphans on every run, so this only
+# needs to clear records left behind before that landed. The same guard is
+# used there: drop a record only when no installed collector produces it and
+# it is at least seven days old, so a writer that keeps a file fresh but does
+# not follow the collector naming scheme is not disturbed.
+
+usage_dir="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/agents/usage"
+[[ -d $usage_dir ]] || exit 0
+
+known=()
+for collector in "$OMARCHY_PATH"/bin/omarchy-agent-usage-*; do
+  [[ -x $collector ]] || continue
+  agent="${collector##*/omarchy-agent-usage-}"
+  [[ $agent != "update" ]] && known+=("$agent")
+done
+plugins_dir="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/plugins"
+for collector in "$plugins_dir"/*/scripts/omarchy-agent-usage-*; do
+  [[ -f $collector ]] || continue
+  agent="${collector##*/omarchy-agent-usage-}"
+  [[ $agent != "update" ]] && known+=("$agent")
+done
+for collector in "$plugins_dir"/*/bin/omarchy-agent-usage-*; do
+  [[ -f $collector ]] || continue
+  agent="${collector##*/omarchy-agent-usage-}"
+  [[ $agent != "update" ]] && known+=("$agent")
+done
+
+cutoff=$(( $(date +%s) - 604800 ))
+for record in "$usage_dir"/*.json; do
+  [[ -f $record ]] || continue
+  agent="${record##*/}"
+  agent="${agent%.json}"
+  alive=0
+  for name in "${known[@]}"; do
+    [[ $name == "$agent" ]] && { alive=1; break; }
+  done
+  (( alive )) && continue
+  mtime=$(stat -c %Y -- "$record" 2>/dev/null) || mtime=0
+  (( mtime >= cutoff )) && continue
+  rm -f -- "$record"
+  echo "Removed stale record for '$agent': no installed collector produces it"
+done
+
+exit 0

--- a/test/shell.d/agent-usage-orphan-migration-test.sh
+++ b/test/shell.d/agent-usage-orphan-migration-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+migration="$ROOT/migrations/1788919234.sh"
+[[ -f $migration ]] || fail "migration 1788919234 is present"
+
+home=$(mktemp -d)
+omarchy=$(mktemp -d)
+trap 'rm -rf "$home" "$omarchy"' EXIT
+
+mkdir -p "$omarchy/bin"
+mkdir -p "$home/.config/omarchy/plugins"
+
+cat >"$omarchy/bin/omarchy-agent-usage-claude" <<'EOF'
+#!/bin/bash
+echo '{"id":"claude"}'
+EOF
+chmod +x "$omarchy/bin/omarchy-agent-usage-claude"
+
+mkdir -p "$home/.config/omarchy/plugins/grok/scripts"
+cat >"$home/.config/omarchy/plugins/grok/scripts/omarchy-agent-usage-grok" <<'EOF'
+#!/bin/bash
+echo '{"id":"grok"}'
+EOF
+
+# A wrapper that runs the orchestrator is not a collector named "update".
+mkdir -p "$home/.config/omarchy/plugins/wrap/scripts"
+cat >"$home/.config/omarchy/plugins/wrap/scripts/omarchy-agent-usage-update" <<'EOF'
+#!/bin/bash
+exec omarchy-agent-usage-update "$@"
+EOF
+
+usage="$home/.local/state/omarchy/agents/usage"
+mkdir -p "$usage"
+
+# Record contents never matter to the migration, only names and ages do.
+for name in copilot update; do
+  echo '{}' >"$usage/$name.json"
+  touch -d "30 days ago" "$usage/$name.json"
+done
+for name in claude grok; do
+  echo '{}' >"$usage/$name.json"
+  touch -d "30 days ago" "$usage/$name.json"
+done
+echo '{}' >"$usage/fresh.json"
+
+message=$(env HOME="$home" XDG_STATE_HOME="" XDG_CONFIG_HOME="$home/.config" \
+  OMARCHY_PATH="$omarchy" bash -euo pipefail "$migration" 2>&1) ||
+  fail "orphan record migration runs clean" "$message"
+
+[[ ! -e $usage/copilot.json ]] ||
+  fail "orphan record migration drops the record of an agent that is gone"
+pass "orphan record migration drops the record of an agent that is gone"
+
+[[ ! -e $usage/update.json ]] ||
+  fail "orphan record migration does not count a wrapper for the orchestrator"
+pass "orphan record migration does not count a wrapper for the orchestrator"
+
+[[ -e $usage/claude.json && -e $usage/grok.json ]] ||
+  fail "orphan record migration keeps records of installed collectors"
+pass "orphan record migration keeps records of installed collectors"
+
+[[ -e $usage/fresh.json ]] ||
+  fail "orphan record migration keeps a record written within the last week"
+pass "orphan record migration keeps a record written within the last week"
+
+[[ $message == *"copilot"* ]] ||
+  fail "orphan record migration reports what it removes" "$message"
+pass "orphan record migration reports what it removes"
+
+first=$(find "$home" -type f | sort)
+env HOME="$home" XDG_STATE_HOME="" XDG_CONFIG_HOME="$home/.config" \
+  OMARCHY_PATH="$omarchy" bash -euo pipefail "$migration" >/dev/null 2>&1 ||
+  fail "orphan record migration runs again with nothing left to do"
+second=$(find "$home" -type f | sort)
+[[ $first == "$second" ]] ||
+  fail "orphan record migration is idempotent"
+pass "orphan record migration is idempotent"

--- a/test/shell.d/agent-usage-update-test.sh
+++ b/test/shell.d/agent-usage-update-test.sh
@@ -63,3 +63,64 @@ pass "update succeeds when the requested collectors all pass"
 [[ -e $usage_dir/skipped.json && ! -e $usage_dir/noisy.json ]] ||
   fail "update with agent arguments only runs the named collectors"
 pass "update with agent arguments only runs the named collectors"
+
+# Records for agents whose collectors are all gone are dropped, but only
+# after a week so a writer that does not follow the collector naming scheme
+# still gets a chance to be caught up by the collectors themselves.
+mkdir -p "$TEST_HOME/.config/omarchy/plugins/ghost/scripts"
+mkdir -p "$TEST_HOME/.config/omarchy/plugins/hex/bin"
+mkdir -p "$TEST_HOME/.config/omarchy/plugins/wrap/scripts"
+
+cat >"$TEST_HOME/.config/omarchy/plugins/ghost/scripts/omarchy-agent-usage-ghost" <<'EOF'
+#!/bin/bash
+echo '{"id":"ghost"}'
+EOF
+
+cat >"$TEST_HOME/.config/omarchy/plugins/hex/bin/omarchy-agent-usage-hex" <<'EOF'
+#!/bin/bash
+echo '{"id":"hex"}'
+EOF
+
+# A wrapper that runs the orchestrator is not itself a collector named
+# "update", and a record under that name gets the same treatment.
+cat >"$TEST_HOME/.config/omarchy/plugins/wrap/scripts/omarchy-agent-usage-update" <<'EOF'
+#!/bin/bash
+exec omarchy-agent-usage-update "$@"
+EOF
+
+echo '{"id":"old-orphan"}' >"$usage_dir/old-orphan.json"
+touch -d "30 days ago" "$usage_dir/old-orphan.json"
+echo '{"id":"fresh-orphan"}' >"$usage_dir/fresh-orphan.json"
+echo '{"id":"ghost"}' >"$usage_dir/ghost.json"
+touch -d "60 days ago" "$usage_dir/ghost.json"
+echo '{"id":"hex"}' >"$usage_dir/hex.json"
+touch -d "60 days ago" "$usage_dir/hex.json"
+echo '{"id":"update"}' >"$usage_dir/update.json"
+touch -d "30 days ago" "$usage_dir/update.json"
+
+message=$(HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" \
+  OMARCHY_PATH="$FAKE_OMARCHY" XDG_STATE_HOME="" \
+  "$ROOT/bin/omarchy-agent-usage-update" good 2>&1) ||
+  fail "update prunes records for agents whose collectors are gone"
+pass "update prunes records for agents whose collectors are gone"
+
+[[ ! -e $usage_dir/old-orphan.json ]] ||
+  fail "update removes a stale record that no collector can produce"
+pass "update removes a stale record that no collector can produce"
+
+[[ -e $usage_dir/fresh-orphan.json ]] ||
+  fail "update keeps a record written within the last week, collector or not"
+pass "update keeps a record written within the last week, collector or not"
+
+[[ -e $usage_dir/ghost.json && -e $usage_dir/hex.json ]] ||
+  fail "update keeps records of plugin collectors under scripts/ and bin/"
+pass "update keeps records of plugin collectors under scripts/ and bin/"
+
+[[ ! -e $usage_dir/update.json ]] ||
+  fail "update does not take a wrapper script for itself as a collector"
+pass "update does not take a wrapper script for itself as a collector"
+
+[[ $message == *"old-orphan"* ]] ||
+  fail "update reports the records it removes" "$message"
+pass "update reports the records it removed"
+


### PR DESCRIPTION
## Problema

O painel de agentes lista **todos** os arquivos `.json` do diretório de uso, sem checar se ainda existe coletor para aquele agente. Quando um coletor vai embora (plugin desinstalado, agente renomeado, etc.), o registro antigo continua aparecendo no painel — como um fantasma — para sempre.

É o que aconteceu, por exemplo, com antigos plugins que escreviam `copilot.json`: mesmo depois da remediação do plugin, a linha "copilot" continuava visível no bar.

## Correção (em duas camadas)

1. **Migração (`migrations/1788919234.sh`)** — limpa os órfãos já existentes em instalações atuais. Como migrações rodam na `omarchy update`/login, todos os usuários passam por ela uma vez.

2. **GC no orquestrador (`bin/omarchy-agent-usage-update`)** — na primeira coleta de cada dia, apaga registros órfãos, previne o acúmulo futuro e também cobre quem está atrasado nas migrações.

## Regra de segurança

Um registro só é apagado quando **ambas** condições valem:

- nenhum coletor instalado produz esse agente (procura em `bin/ padrão`, `plugins/*/scripts/` e `plugins/*/bin/`, e um wrapper do próprio orquestrador não conta como coletor), **e**
- o arquivo não foi gravado nos últimos **7 dias**.

Agentes que ainda estão ativos — inclusive plugins que escrevem o JSON sem coletor próprio — não são tocados nunca: sua gravação recente os protege.

## Testes

- 6 novos testes de GC em `test/shell.d/agent-usage-update-test.sh` (mantém agente vivo, preserva registro recente de coletor ausente, apaga órfão antigo, não conta wrapper como coletor, preserva coletor de plugin);
- novo `test/shell.d/agent-usage-orphan-migration-test.sh` com 6 testes (remota órfão, não remota agente vivo, não conta wrapper, preserva registro recente, reporta o que remove, idempotência);
- `./test/all` roda limpo para todos os testes relacionados (as 5 falhas restantes em `shell.d` — config, locate, runtime-smoke, snapper, unowned-system-paths — falham idênticas na árvore limpa, por falta de checkout de `omarchy-pkgs`/ambiente, não por esta mudança).