### PR TITLE
Let plugins contribute actions to the clipboard overlay

### DIFF
--- a/bin/omarchy-plugin-validate
+++ b/bin/omarchy-plugin-validate
@@ -97,6 +97,7 @@ done < <(jq -c '.entryPoints | to_entries[] | .value' "$MANIFEST")
 for kind_entry_point in \
   "bar:bar" \
   "bar-widget:barWidget" \
+  "extension:extension" \
   "menu:menu" \
   "overlay:overlay" \
   "panel:panel" \

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -46,9 +46,7 @@ A third-party replacement bar can render registered widget components, but widge
 
 ## Extensions
 
-An `extension` contributes an action into another plugin's UI instead of
-carrying a surface of its own. It names the plugin it extends and ships one
-entry point:
+An `extension` contributes an action into another plugin's UI instead of carrying a surface of its own. It names the plugin it extends and ships one entry point:
 
 ```json
 {
@@ -76,14 +74,9 @@ Item {
 }
 ```
 
-`host` is the [`PluginExtensions`](../shell/Ui/PluginExtensions.qml) slot the
-plugin offered. `host.openPane(component, entry)` puts a component of yours on
-the host's own surface, `host.closePane()` hands it back, and
-`host.requestClose()` dismisses the host. `host.paneEntry` is the entry the
-pane was opened for.
+`host` is the [`PluginExtensions`](../shell/Ui/PluginExtensions.qml) slot the plugin offered. `host.openPane(component, entry)` puts a component of yours on the host's own surface, `host.closePane()` hands it back, and `host.requestClose()` dismisses the host. `host.paneEntry` is the entry the pane was opened for.
 
-A host offers a slot by naming itself and rendering what comes back; it never
-learns what an extension does:
+A host offers a slot by naming itself and rendering what comes back; it never learns what an extension does:
 
 ```qml
 PluginExtensions {
@@ -94,16 +87,11 @@ PluginExtensions {
 }
 ```
 
-`extensions.available(entry)` is the list to draw as actions,
-`extensions.handleKey(event, entry)` claims contributed shortcuts, and
-`extensions.paneComponent` is what to mount when `extensions.paneOpen`. With
-nothing installed all three collapse to the behavior the host had before it
-offered a slot, and an extension that fails to load, or whose `supports()`
-throws, drops itself rather than the host.
+`extensions.available(entry)` is the list to draw as actions, `extensions.handleKey(event, entry)` claims contributed shortcuts, and `extensions.paneComponent` is what to mount when `extensions.paneOpen`. With nothing installed all three collapse to the behavior the host had before it offered a slot, and an extension that fails to load, or whose `supports()` throws, drops itself rather than the host.
 
-`omarchy.clipboard` is the first host: its detail pane shows contributed
-actions under the preview, and an extension can replace the preview with an
-editing surface of its own.
+The entry passed to an extension contains the complete source value even when the host caps or reshapes text for display. Hosts construct action entries from source records rather than rendered previews.
+
+`omarchy.clipboard` is the first host: its detail pane shows contributed actions under the preview, and an extension can replace the preview with an editing surface of its own.
 
 Full schema: [`shell/services/PluginRegistry.qml`](../shell/services/PluginRegistry.qml).
 

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -34,6 +34,7 @@ wait).
 | `overlay`    | Fullscreen overlay (e.g. background picker)    |
 | `menu`       | Summoned menu surface                          |
 | `service`    | Headless singleton, no UI                      |
+| `extension`  | Actions contributed into another plugin's UI   |
 
 Only one full bar option is active at a time. The built-in `omarchy.bar` is
 used when `bar.id` is omitted or when a selected third-party bar cannot load.
@@ -42,6 +43,67 @@ Panels, overlays, and menus are loaded when summoned. Plugins can set the top-le
 Entry points are QML `Item`s. Panel, overlay, and menu entry points expose `open(payloadJson)` and `close()` for summon/hide; on load the host injects `omarchyPath`, `shell`, `manifest`, and the registries (`pluginRegistry` / `barWidgetRegistry`) as properties. Built-in plugins receive the trusted host objects. Third-party plugins receive capability-scoped facades instead: ordinary plugins may look up and control only their own service and lifecycle, built-in clones retain narrow source-specific configuration and UI compatibility, menu plugins receive an application-library facade, and plugins can read detached scalar bar state. A full-bar plugin additionally receives detached bar configuration and widget-catalog snapshots, narrow proxies for the non-authentication services used by built-in bar widgets, and lifecycle control over configured non-authentication UI plugins. Authentication capabilities are stamped from trusted first-party manifests, authentication services are kept out of the host's public service map and QML object tree, and third-party registry/configuration snapshots can be changed only locally without mutating host state. The facades are API boundaries, not same-process QML sandboxes: a visual widget shares the host bar's scene and can walk its parent hierarchy to ordinary host objects. Sensitive state must not rely on the facade alone for isolation.
 
 A third-party replacement bar can render registered widget components, but widgets it hosts receive a service-less entry facade. Allowing the bar to manufacture an own-service facade for an arbitrary widget would also let it retrieve that plugin's live service object. Service-backed third-party widgets therefore retain their full integration only under the trusted built-in bar; a replacement bar may still provide their target-scoped lifecycle and settings operations.
+
+## Extensions
+
+An `extension` contributes an action into another plugin's UI instead of
+carrying a surface of its own. It names the plugin it extends and ships one
+entry point:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "acme.clipedit",
+  "name": "ClipEdit",
+  "version": "1.0.0",
+  "kinds": ["extension"],
+  "entryPoints": { "extension": "ClipEdit.qml" },
+  "extension": { "host": "omarchy.clipboard" }
+}
+```
+
+The entry point declares what it offers and what it acts on:
+
+```qml
+Item {
+  property var host: null              // injected on load
+
+  readonly property string label: "Edit"
+  readonly property string shortcut: "Ctrl+E"   // optional
+
+  function supports(entry) { return entry && entry.type === "text" }
+  function activate(entry) { host.openPane(editorComponent, entry) }
+}
+```
+
+`host` is the [`PluginExtensions`](../shell/Ui/PluginExtensions.qml) slot the
+plugin offered. `host.openPane(component, entry)` puts a component of yours on
+the host's own surface, `host.closePane()` hands it back, and
+`host.requestClose()` dismisses the host. `host.paneEntry` is the entry the
+pane was opened for.
+
+A host offers a slot by naming itself and rendering what comes back; it never
+learns what an extension does:
+
+```qml
+PluginExtensions {
+  id: extensions
+  hostId: "omarchy.clipboard"
+  pluginRegistry: root.pluginRegistry
+  onCloseRequested: root.close()
+}
+```
+
+`extensions.available(entry)` is the list to draw as actions,
+`extensions.handleKey(event, entry)` claims contributed shortcuts, and
+`extensions.paneComponent` is what to mount when `extensions.paneOpen`. With
+nothing installed all three collapse to the behavior the host had before it
+offered a slot, and an extension that fails to load, or whose `supports()`
+throws, drops itself rather than the host.
+
+`omarchy.clipboard` is the first host: its detail pane shows contributed
+actions under the preview, and an extension can replace the preview with an
+editing surface of its own.
 
 Full schema: [`shell/services/PluginRegistry.qml`](../shell/services/PluginRegistry.qml).
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -81,6 +81,11 @@ Supported `kinds`:
 | `menu`       | A summoned menu surface                                      |
 | `service`    | A headless singleton, no UI                                  |
 | `bar`        | A full bar option that can replace the built-in `omarchy.bar` |
+| `extension`  | An action contributed into another plugin's UI               |
+
+An `extension` names the plugin it extends in `extension.host` and is loaded
+by that plugin's `PluginExtensions` slot rather than by the shell; see
+[`docs/omarchy-shell.md`](../docs/omarchy-shell.md) for the contract.
 
 Only one `bar` plugin is active at a time. Missing or invalid selections fall
 back to the built-in `omarchy.bar`, so users always have a safe path home.

--- a/shell/Ui/PluginExtensions.js
+++ b/shell/Ui/PluginExtensions.js
@@ -1,0 +1,54 @@
+// Pure helpers behind PluginExtensions.qml. They live here so the shortcut
+// grammar and the host lookup can be tested from node without a compositor.
+
+var MODIFIER_NAMES = {
+  "ctrl": "ctrl",
+  "control": "ctrl",
+  "shift": "shift",
+  "alt": "alt",
+  "meta": "meta",
+  "super": "meta"
+}
+
+// "Ctrl+E", "ctrl+shift+Return": modifiers first, exactly one key last. An
+// unreadable spec returns null, so a bad manifest costs that extension its
+// shortcut and nothing else.
+function parseShortcut(spec) {
+  var parts = String(spec === undefined || spec === null ? "" : spec).split("+")
+  var key = String(parts.pop() || "").trim().toUpperCase()
+  if (!key) return null
+
+  var shortcut = { key: key, ctrl: false, shift: false, alt: false, meta: false }
+  for (var i = 0; i < parts.length; i++) {
+    var modifier = MODIFIER_NAMES[String(parts[i]).trim().toLowerCase()]
+    if (!modifier) return null
+    shortcut[modifier] = true
+  }
+  return shortcut
+}
+
+// Enabled plugins that declare themselves an extension of hostId, sorted by id
+// so two extensions claiming one shortcut resolve the same way every boot.
+function hostedExtensions(installedPlugins, hostId, isEnabled) {
+  var hosted = []
+  if (!installedPlugins || !hostId) return hosted
+
+  for (var id in installedPlugins) {
+    var manifest = installedPlugins[id]
+    if (!manifest || !Array.isArray(manifest.kinds)) continue
+    if (manifest.kinds.indexOf("extension") === -1) continue
+    if (!manifest.extension || String(manifest.extension.host || "") !== String(hostId)) continue
+    if (isEnabled && !isEnabled(id)) continue
+    hosted.push(manifest)
+  }
+
+  hosted.sort(function(a, b) { return String(a.id) < String(b.id) ? -1 : 1 })
+  return hosted
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    parseShortcut: parseShortcut,
+    hostedExtensions: hostedExtensions
+  }
+}

--- a/shell/Ui/PluginExtensions.qml
+++ b/shell/Ui/PluginExtensions.qml
@@ -1,0 +1,176 @@
+import QtQuick
+import "PluginExtensions.js" as Extensions
+
+// One contribution point a plugin can offer to other plugins.
+//
+// The host names itself and renders whatever comes back; it never learns what
+// an extension does. An extension is a plugin whose manifest declares
+//
+//   "kinds": ["extension"],
+//   "entryPoints": { "extension": "MyExtension.qml" },
+//   "extension": { "host": "omarchy.clipboard" }
+//
+// and whose entry point exposes `label`, optionally `shortcut`, plus
+// `supports(entry)` and `activate(entry)`. `host` is injected on load: an
+// extension calls host.openPane(component, entry) to take over the host's
+// detail surface, host.closePane() to hand it back, and host.requestClose()
+// to dismiss the host itself.
+//
+// With nothing installed `items` is empty, `paneOpen` is false, and every host
+// binding collapses to the behavior the host had before it offered a slot.
+QtObject {
+  id: extensions
+
+  property var pluginRegistry: null
+  property string hostId: ""
+
+  // The surface an extension has taken over, and the entry it took it for.
+  property Component paneComponent: null
+  property var paneEntry: null
+  readonly property bool paneOpen: paneComponent !== null
+
+  signal paneClosed()
+  signal closeRequested()
+
+  // Bumped when an extension loads so host bindings pick up the new item.
+  property int revision: 0
+
+  readonly property var manifests: {
+    var registry = extensions.pluginRegistry
+    if (!registry) return []
+    // Read the revision so this rebuilds when plugins are installed, enabled,
+    // or hot-reloaded.
+    var registryRevision = registry.registryRevision
+    return Extensions.hostedExtensions(registry.installedPlugins, extensions.hostId,
+      function(id) { return registry.isEnabled(id) })
+  }
+
+  readonly property var items: {
+    var revision = extensions.revision
+    var loaded = []
+    for (var i = 0; i < extensions.hosted.count; i++) {
+      var holder = extensions.hosted.objectAt(i)
+      var item = holder && holder.extensionLoader ? holder.extensionLoader.item : null
+      if (item) loaded.push(item)
+    }
+    return loaded
+  }
+
+  property Instantiator hosted: Instantiator {
+    model: extensions.manifests
+    active: true
+
+    // Additions land in `items` from the Loader below. A removal has no load to
+    // hook, and the delegate is still alive when this fires, so the refresh
+    // waits for the teardown to finish rather than re-reading a dying object.
+    onObjectRemoved: Qt.callLater(function() { extensions.revision++ })
+
+    delegate: QtObject {
+      id: holder
+      required property var modelData
+
+      readonly property string extensionId: String(modelData.id || "")
+      readonly property string sourceUrl: extensions.pluginRegistry
+        ? extensions.pluginRegistry.entryPointUrl(modelData, "extension") : ""
+
+      property Loader extensionLoader: Loader {
+        source: holder.sourceUrl
+        active: holder.sourceUrl !== ""
+        onLoaded: {
+          if (!item) return
+          if ("host" in item) item.host = extensions
+          if ("manifest" in item) item.manifest = holder.modelData
+          extensions.revision++
+        }
+        onStatusChanged: {
+          if (status !== Loader.Error) return
+          // A broken extension costs only itself: it stays unloaded and the
+          // host keeps the UI it had without one.
+          console.warn("plugin extension " + holder.extensionId + " failed to load:",
+            errorString && errorString() ? errorString() : "")
+        }
+      }
+    }
+  }
+
+  // ------------------------------------------------------- called by extensions
+
+  function openPane(component, entry) {
+    extensions.paneEntry = entry === undefined ? null : entry
+    extensions.paneComponent = component
+  }
+
+  function closePane() {
+    if (!extensions.paneComponent) return
+    extensions.paneComponent = null
+    extensions.paneEntry = null
+    extensions.paneClosed()
+  }
+
+  function requestClose() {
+    extensions.closePane()
+    extensions.closeRequested()
+  }
+
+  // ------------------------------------------------------------ called by hosts
+
+  // Extensions that will act on this entry, in id order. A supports() that
+  // throws drops that extension from the row rather than the row itself.
+  function available(entry) {
+    var offered = []
+    var loaded = extensions.items
+    for (var i = 0; i < loaded.length; i++) {
+      var item = loaded[i]
+      if (!item || !item.label) continue
+      try {
+        if (typeof item.supports !== "function" || item.supports(entry)) offered.push(item)
+      } catch (error) {
+        console.warn("plugin extension supports() threw:", error)
+      }
+    }
+    return offered
+  }
+
+  function activate(item, entry) {
+    if (!item || typeof item.activate !== "function") return false
+    try {
+      item.activate(entry)
+    } catch (error) {
+      console.warn("plugin extension activate() threw:", error)
+      return false
+    }
+    return true
+  }
+
+  function handleKey(event, entry) {
+    var candidates = available(entry)
+    for (var i = 0; i < candidates.length; i++) {
+      if (matchesShortcut(candidates[i].shortcut, event)) return activate(candidates[i], entry)
+    }
+    return false
+  }
+
+  function matchesShortcut(spec, event) {
+    var shortcut = Extensions.parseShortcut(spec)
+    if (!shortcut) return false
+    if (shortcut.ctrl !== ((event.modifiers & Qt.ControlModifier) !== 0)) return false
+    if (shortcut.shift !== ((event.modifiers & Qt.ShiftModifier) !== 0)) return false
+    if (shortcut.alt !== ((event.modifiers & Qt.AltModifier) !== 0)) return false
+    if (shortcut.meta !== ((event.modifiers & Qt.MetaModifier) !== 0)) return false
+    return keyMatches(shortcut.key, event.key)
+  }
+
+  // Qt.Key_A..Z and Qt.Key_0..9 are their own ASCII codes, so a one-character
+  // spec needs no table. Both Enter keys answer to one name; nobody writes
+  // "Ctrl+KeypadEnter" in a manifest.
+  function keyMatches(name, key) {
+    if (name.length === 1) return key === name.charCodeAt(0)
+    if (name === "ENTER" || name === "RETURN") return key === Qt.Key_Return || key === Qt.Key_Enter
+    if (name === "ESC" || name === "ESCAPE") return key === Qt.Key_Escape
+    if (name === "SPACE") return key === Qt.Key_Space
+    if (name === "TAB") return key === Qt.Key_Tab
+    if (name === "DELETE") return key === Qt.Key_Delete
+    if (name === "BACKSPACE") return key === Qt.Key_Backspace
+    return false
+  }
+}

--- a/shell/Ui/qmldir
+++ b/shell/Ui/qmldir
@@ -26,6 +26,7 @@ PanelSeparator 1.0 PanelSeparator.qml
 PanelSlider 1.0 PanelSlider.qml
 PanelToolTip 1.0 PanelToolTip.qml
 PluginBarApi 1.0 PluginBarApi.qml
+PluginExtensions 1.0 PluginExtensions.qml
 PointerMoveGate 1.0 PointerMoveGate.qml
 ScreenMoveRemap 1.0 ScreenMoveRemap.qml
 PopupCard 1.0 PopupCard.qml

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -10,6 +10,9 @@ Item {
   id: root
 
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
+  // Injected by the shell on load; the extension slot needs it to find the
+  // plugins that contribute actions here.
+  property var pluginRegistry: null
   property bool opened: false
   property string filterText: ""
   property int selectedIndex: 0
@@ -41,6 +44,7 @@ Item {
 
   function open(payloadJson) {
     root.opened = true
+    extensions.closePane()
     root.filterText = ""
     root.selectedIndex = 0
     root.cursorActive = true
@@ -51,6 +55,7 @@ Item {
 
   function close() {
     root.cancelClearHistory()
+    extensions.closePane()
     root.opened = false
   }
 
@@ -189,9 +194,26 @@ Item {
   }
 
   function selectFromPointer(index, item, mouse) {
+    if (extensions.paneOpen) return
     if (!pointerGate.moved(item, mouse)) return
     root.cursorActive = true
     root.selectedIndex = index
+  }
+
+  // A plain snapshot rather than the ListModel row, so an extension holding on
+  // to it cannot be surprised by the next rebuild.
+  function selectedEntry() {
+    if (!root.cursorActive) return null
+    if (root.selectedIndex < 0 || root.selectedIndex >= displayModel.count) return null
+
+    var row = displayModel.get(root.selectedIndex)
+    return {
+      type: row.entryType,
+      text: row.fullText,
+      path: row.path,
+      mime: row.mime,
+      historyIndex: row.historyIndex
+    }
   }
 
   function activateIndex(index) {
@@ -241,6 +263,16 @@ Item {
   Component.onCompleted: initProc.running = true
 
   ListModel { id: displayModel }
+
+  // The clipboard's one extension point. The built-in id is deliberate: a
+  // clone of this plugin keeps hosting the same extensions.
+  PluginExtensions {
+    id: extensions
+    hostId: "omarchy.clipboard"
+    pluginRegistry: root.pluginRegistry
+    onCloseRequested: root.close()
+    onPaneClosed: Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
 
   PointerMoveGate {
     id: pointerGate
@@ -353,6 +385,21 @@ Item {
         Keys.onPressed: function(event) {
           if (root.clearConfirmOpen) {
             if (clearConfirm.handleKey(event)) event.accepted = true
+            return
+          }
+
+          if (extensions.paneOpen) {
+            // The pane owns the keyboard. Escape is the way back out if it
+            // never took focus.
+            if (event.key === Qt.Key_Escape) {
+              extensions.closePane()
+              event.accepted = true
+            }
+            return
+          }
+
+          if (extensions.handleKey(event, root.selectedEntry())) {
+            event.accepted = true
             return
           }
 
@@ -533,11 +580,22 @@ Item {
             }
 
             Item {
+              id: detailPane
               width: parent.width / 2
               height: parent.height
               clip: true
 
               property var activeRow: displayModel.count > 0 && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count ? displayModel.get(root.selectedIndex) : null
+
+              readonly property var entry: {
+                // selectedEntry() reads the cursor and the model; the filter is
+                // the one input it cannot see, and refiltering can change what
+                // sits at the selected index without changing the row count.
+                var filterText = root.filterText
+                return root.selectedEntry()
+              }
+              readonly property var actions: extensions.available(entry)
+              readonly property int actionsInset: actionRow.visible ? actionRow.height + root.contentSpacing : 0
 
               Rectangle {
                 anchors.left: parent.left
@@ -549,12 +607,12 @@ Item {
 
               Text {
                 textFormat: Text.PlainText
-                visible: parent.activeRow && !parent.activeRow.previewImage
+                visible: !extensions.paneOpen && parent.activeRow && !parent.activeRow.previewImage
                 anchors.fill: parent
                 anchors.leftMargin: root.contentMargin
                 anchors.rightMargin: 0
                 anchors.topMargin: 0
-                anchors.bottomMargin: 0
+                anchors.bottomMargin: detailPane.actionsInset
                 text: parent.activeRow ? parent.activeRow.fullText : ""
                 color: root.foreground
                 font.family: root.fontFamily
@@ -565,17 +623,49 @@ Item {
               }
 
               Image {
-                visible: parent.activeRow && parent.activeRow.previewImage
+                visible: !extensions.paneOpen && parent.activeRow && parent.activeRow.previewImage
                 anchors.fill: parent
                 anchors.leftMargin: root.contentMargin
                 anchors.rightMargin: 0
                 anchors.topMargin: 0
-                anchors.bottomMargin: 0
+                anchors.bottomMargin: detailPane.actionsInset
                 source: parent.activeRow ? parent.activeRow.previewImage : ""
                 fillMode: Image.PreserveAspectFit
                 verticalAlignment: Image.AlignTop
                 asynchronous: true
                 smooth: true
+              }
+
+              // Whatever an extension put here stands in for the preview until
+              // it hands the pane back.
+              Loader {
+                anchors.fill: parent
+                anchors.leftMargin: root.contentMargin
+                active: extensions.paneOpen
+                sourceComponent: extensions.paneComponent
+              }
+
+              Row {
+                id: actionRow
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                spacing: Style.spacing.controlGap
+                visible: !extensions.paneOpen && detailPane.actions.length > 0
+
+                Repeater {
+                  model: detailPane.actions
+
+                  delegate: Button {
+                    required property var modelData
+
+                    text: modelData.shortcut ? modelData.label + "  " + modelData.shortcut : modelData.label
+                    bordered: true
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                    fontSize: Style.font.body
+                    onClicked: extensions.activate(modelData, detailPane.entry)
+                  }
+                }
               }
             }
           }

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -201,19 +201,14 @@ Item {
   }
 
   // A plain snapshot rather than the ListModel row, so an extension holding on
-  // to it cannot be surprised by the next rebuild.
+  // to it cannot be surprised by the next rebuild. ClipboardHistory recovers
+  // the original record because the row's renderable text may be capped.
   function selectedEntry() {
     if (!root.cursorActive) return null
     if (root.selectedIndex < 0 || root.selectedIndex >= displayModel.count) return null
 
     var row = displayModel.get(root.selectedIndex)
-    return {
-      type: row.entryType,
-      text: row.fullText,
-      path: row.path,
-      mime: row.mime,
-      historyIndex: row.historyIndex
-    }
+    return ClipboardHistory.entryForAction(root.history, row.historyIndex)
   }
 
   function activateIndex(index) {
@@ -570,6 +565,7 @@ Item {
                       root.selectFromPointer(row.index, row, mouse)
                     }
                     onClicked: {
+                      if (extensions.paneOpen) return
                       root.cursorActive = true
                       root.selectedIndex = row.index
                       root.activateIndex(row.index)

--- a/shell/plugins/clipboard/ClipboardHistory.js
+++ b/shell/plugins/clipboard/ClipboardHistory.js
@@ -205,6 +205,29 @@ function displayRows(history, query, limit) {
   return rows
 }
 
+// Rows are intentionally capped for rendering, but contextual actions act on
+// clipboard entries rather than previews. Rebuild the action payload from the
+// original history record so an extension can never save a truncated value.
+function entryForAction(history, historyIndex) {
+  var index = Number(historyIndex)
+  var values = Array.isArray(history) ? history : []
+  if (isNaN(index) || index < 0 || index >= values.length) return null
+
+  var entry = normalizeEntry(values[index])
+  if (!entry) return null
+
+  var paths = filePaths(entry)
+  var isFile = paths.length > 0
+  var isImage = entry.type === "image"
+  return {
+    type: isFile ? "file" : entry.type,
+    text: isImage ? "" : fullText(entry),
+    path: isImage ? String(entry.path || "") : (isFile && paths.length === 1 ? paths[0] : ""),
+    mime: isImage ? String(entry.mime || "image/png") : "text/plain",
+    historyIndex: index
+  }
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     normalizeEntry: normalizeEntry,
@@ -220,6 +243,7 @@ if (typeof module !== "undefined") {
     filePaths: filePaths,
     fileEntryText: fileEntryText,
     fullText: fullText,
-    displayRows: displayRows
+    displayRows: displayRows,
+    entryForAction: entryForAction
   }
 }

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -198,6 +198,37 @@ assert(
   'clipboard display rows cap what a huge text entry renders'
 )
 
+const hugeText = 'z'.repeat(100000)
+assertDeepEqual(
+  clipboard.entryForAction([{ type: 'text', text: hugeText }], 0),
+  {
+    type: 'text',
+    text: hugeText,
+    path: '',
+    mime: 'text/plain',
+    historyIndex: 0
+  },
+  'clipboard actions receive the complete text behind a capped display row'
+)
+
+const hugeFilePath = '/tmp/' + 'x'.repeat(9000) + '.txt'
+assertDeepEqual(
+  clipboard.entryForAction([{ type: 'text', text: 'file://' + hugeFilePath + '\n' }], 0),
+  {
+    type: 'file',
+    text: hugeFilePath,
+    path: hugeFilePath,
+    mime: 'text/plain',
+    historyIndex: 0
+  },
+  'clipboard actions receive complete file data behind a capped display row'
+)
+
+assert(
+  /onClicked:\s*\{\s*if \(extensions\.paneOpen\) return/.test(clipboardQml),
+  'clipboard rows cannot activate while an extension pane is open'
+)
+
 const hugeFileList = []
 for (let i = 0; i < 5000; i++) hugeFileList.push('file:///home/dhh/clip-' + i + '.mp4')
 const hugeFileRow = clipboard.displayRows([{ type: 'text', text: hugeFileList.join('\n') + '\n' }], '', 50)[0]

--- a/test/shell.d/plugin-extensions-test.sh
+++ b/test/shell.d/plugin-extensions-test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const extensions = requireFromRoot('shell/Ui/PluginExtensions.js')
+const extensionsQml = fs.readFileSync(path.join(root, 'shell/Ui/PluginExtensions.qml'), 'utf8')
+const clipboardQml = fs.readFileSync(path.join(root, 'shell/plugins/clipboard/Clipboard.qml'), 'utf8')
+
+// ------------------------------------------------------------------ shortcuts
+
+assertDeepEqual(
+  extensions.parseShortcut('Ctrl+E'),
+  { key: 'E', ctrl: true, shift: false, alt: false, meta: false },
+  'shortcut parser reads a modifier and a key'
+)
+
+assertDeepEqual(
+  extensions.parseShortcut('ctrl+shift+return'),
+  { key: 'RETURN', ctrl: true, shift: true, alt: false, meta: false },
+  'shortcut parser is case-insensitive and stacks modifiers'
+)
+
+assertDeepEqual(
+  extensions.parseShortcut('E'),
+  { key: 'E', ctrl: false, shift: false, alt: false, meta: false },
+  'shortcut parser accepts a bare key'
+)
+
+assertEqual(extensions.parseShortcut('Hyper+E'), null, 'shortcut parser rejects an unknown modifier')
+assertEqual(extensions.parseShortcut(''), null, 'shortcut parser rejects an empty spec')
+assertEqual(extensions.parseShortcut(undefined), null, 'shortcut parser rejects a missing spec')
+assertEqual(extensions.parseShortcut('Ctrl+'), null, 'shortcut parser rejects a modifier with no key')
+
+// ------------------------------------------------------------------- host list
+
+const installed = {
+  'zz.late': { id: 'zz.late', kinds: ['extension'], extension: { host: 'omarchy.clipboard' } },
+  'aa.early': { id: 'aa.early', kinds: ['extension'], extension: { host: 'omarchy.clipboard' } },
+  'other.host': { id: 'other.host', kinds: ['extension'], extension: { host: 'omarchy.menu' } },
+  'no.extension': { id: 'no.extension', kinds: ['overlay'], extension: { host: 'omarchy.clipboard' } },
+  'no.host': { id: 'no.host', kinds: ['extension'] },
+  'disabled.one': { id: 'disabled.one', kinds: ['extension'], extension: { host: 'omarchy.clipboard' } }
+}
+const enabled = (id) => id !== 'disabled.one'
+
+assertDeepEqual(
+  extensions.hostedExtensions(installed, 'omarchy.clipboard', enabled).map((m) => m.id),
+  ['aa.early', 'zz.late'],
+  'host lookup returns enabled extensions for that host in id order'
+)
+
+assertDeepEqual(
+  extensions.hostedExtensions(installed, 'omarchy.background', enabled).map((m) => m.id),
+  [],
+  'a host nobody extends gets an empty list'
+)
+
+assertDeepEqual(extensions.hostedExtensions(null, 'omarchy.clipboard', enabled), [], 'host lookup tolerates no registry')
+assertDeepEqual(extensions.hostedExtensions(installed, '', enabled), [], 'host lookup requires a host id')
+
+// ------------------------------------------------------------------- contracts
+
+assert(
+  /if \("host" in item\) item\.host = extensions/.test(extensionsQml),
+  'the slot injects itself as host so extensions can call back'
+)
+
+assert(
+  /status !== Loader\.Error[\s\S]{0,400}console\.warn\("plugin extension /.test(extensionsQml),
+  'an extension that fails to load warns instead of taking the host down'
+)
+
+assert(
+  /function available\(entry\)[\s\S]*?try \{[\s\S]*?catch \(error\)/.test(extensionsQml),
+  'a supports() that throws drops the extension, not the host row'
+)
+
+assert(
+  /onObjectRemoved: Qt\.callLater\(function\(\) \{ extensions\.revision\+\+ \}\)/.test(extensionsQml),
+  'a disabled extension leaves items after its delegate is torn down, not during'
+)
+
+assert(
+  /PluginExtensions \{[\s\S]*?hostId: "omarchy\.clipboard"/.test(clipboardQml),
+  'the clipboard offers its extension point under the built-in id'
+)
+
+assert(
+  /extensions\.handleKey\(event, root\.selectedEntry\(\)\)/.test(clipboardQml),
+  'contributed shortcuts get first refusal over the clipboard search filter'
+)
+
+assert(
+  /if \(extensions\.paneOpen\) \{[\s\S]{0,300}Qt\.Key_Escape/.test(clipboardQml),
+  'Escape still closes an extension pane that never took focus'
+)
+
+assert(
+  /function selectFromPointer\(index, item, mouse\) \{\s*\n\s*if \(extensions\.paneOpen\) return/.test(clipboardQml),
+  'hovering the history cannot move the cursor out from under an open pane'
+)
+JS

--- a/test/shell.d/plugin-validate-test.sh
+++ b/test/shell.d/plugin-validate-test.sh
@@ -61,6 +61,7 @@ while IFS=: read -r kind entry_point; do
 done <<'KINDS'
 bar:bar
 bar-widget:barWidget
+extension:extension
 menu:menu
 overlay:overlay
 panel:panel

--- a/test/shell.d/plugins-test.sh
+++ b/test/shell.d/plugins-test.sh
@@ -11,6 +11,7 @@ const pluginsDir = path.join(root, 'shell/plugins')
 const kindEntryPoints = {
   'bar': 'bar',
   'bar-widget': 'barWidget',
+  'extension': 'extension',
   'menu': 'menu',
   'overlay': 'overlay',
   'panel': 'panel',


### PR DESCRIPTION
## Summary

- add an optional `extension` plugin kind and a reusable `PluginExtensions` host component
- let the clipboard render contributed actions, dispatch their shortcuts, and mount an extension-owned pane inside its existing detail view
- preserve the complete source entry when clipboard previews are capped or reshaped

## Motivation

Third-party plugins can currently provide their own panels, overlays, menus, and services, but they cannot contribute a small action inside an existing plugin's UI. That leaves an integration such as clipboard editing with two poor choices: replace the built-in clipboard or open a second surface.

This change gives a host plugin an explicit, optional extension slot. The clipboard is the first host, but the mechanism contains no clipboard-editing logic and can be reused by other plugin surfaces.

[ClipEdit](https://github.com/Ahmed-Sinkeat/omarchy-clipedit) is the motivating third-party plugin and the real-world implementation used to validate the API. ClipEdit is not included in this PR.

## Compatibility and failure isolation

- with no matching extensions installed, the clipboard retains its previous behavior
- only enabled extensions targeting the host are loaded
- a failed load or throwing `supports()` call drops that extension rather than the host
- shortcut conflicts resolve deterministically by plugin id
- the host passes a narrow slot API instead of exposing clipboard history mutation

## Testing

- `./test/shell.d/plugin-extensions-test.sh`
- `./test/shell.d/clipboard-test.sh`
- `./test/shell.d/plugin-validate-test.sh`
- `./test/shell.d/plugins-test.sh`
- repository-root validation of the linked ClipEdit plugin
- live verification of discovery, enable/disable, action rendering, shortcut dispatch, focus, save, cancel, Unicode and multiline text, long entries, removal, reinstall, and shell restart

The aggregate `./test/shell` suite was also run. The feature-owned suites pass; remaining failures reproduce on the upstream baseline or depend on local packaging/terminal fixtures unavailable in this checkout.
