### PR TITLE
Fix display backlight on Dell XPS OLED Panther Lake laptops

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -30,6 +30,7 @@ run_logged "$OMARCHY_INSTALL/hardware/fix-elgato-camlink-4k.sh"
 # Rebuilds the boot image, so it has to follow the Panther Lake kernel swap
 # above rather than sit with the other Dell leaf at the top of this file.
 run_logged "$OMARCHY_INSTALL/hardware/dell-xps13-sidecar-amps.sh"
+run_logged "$OMARCHY_INSTALL/hardware/dell-xps-oled-display-backlight.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-display-backlight.sh"
 run_logged "$OMARCHY_INSTALL/hardware/asus/fix-asus-ptl-b9406-display.sh"

--- a/install/hardware/dell-xps-oled-display-backlight.sh
+++ b/install/hardware/dell-xps-oled-display-backlight.sh
@@ -1,0 +1,19 @@
+# Display backlight fix for Dell XPS 14/16 OLED laptops (Panther Lake / Xe3 iGPU).
+#
+# Same failure the ASUS Panther Lake fix covers: the VBT says PWM, but the LG
+# OLED panel takes brightness over DPCD AUX. Without xe.enable_dpcd_backlight=1,
+# intel_backlight sysfs writes succeed and the OSD moves, yet the panel stays
+# put. The kernel says as much at boot: "[CONNECTOR:...:eDP-1] Panel is missing
+# HDR static metadata ... If your backlight controls don't work try booting
+# with i915.enable_dpcd_backlight=3". Confirmed on an XPS 14 DA14260 with the
+# LG Display RW24G.140WT2 panel.
+
+drop_in="${OMARCHY_DELL_XPS_OLED_BACKLIGHT_CONF:-/etc/limine-entry-tool.d/dell-xps-oled-display-backlight.conf}"
+
+if omarchy-hw-dell-xps-oled; then
+  sudo mkdir -p "$(dirname "$drop_in")"
+  sudo tee "$drop_in" >/dev/null <<'EOF'
+# Dell XPS OLED (Panther Lake / Xe3) display backlight fix
+KERNEL_CMDLINE[default]+=" xe.enable_dpcd_backlight=1"
+EOF
+fi

--- a/migrations/1788886195.sh
+++ b/migrations/1788886195.sh
@@ -1,0 +1,11 @@
+echo "Enable DPCD AUX backlight control on Dell XPS OLED panels"
+
+# The kernel command line only changes in the boot image, so rebuild it here
+# and ask for a reboot. Another user running this before that reboot repeats
+# an identical rebuild, which is harmless.
+
+if omarchy-hw-dell-xps-oled && omarchy-cmd-present limine-mkinitcpio; then
+  source "$OMARCHY_PATH/install/hardware/dell-xps-oled-display-backlight.sh"
+  sudo limine-mkinitcpio
+  omarchy-state set reboot-required
+fi

--- a/test/shell.d/dell-xps-oled-display-backlight-test.sh
+++ b/test/shell.d/dell-xps-oled-display-backlight-test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/dell-xps-oled-display-backlight.sh"
+all="$ROOT/install/hardware/all.sh"
+migration=$(grep -l "dell-xps-oled-display-backlight" "$ROOT"/migrations/*.sh | head -1)
+
+grep -q 'run_logged .*hardware/dell-xps-oled-display-backlight.sh' "$all" ||
+  fail "the Dell XPS OLED backlight fix runs during hardware setup"
+pass "the Dell XPS OLED backlight fix runs during hardware setup"
+
+[[ -n $migration ]] || fail "a migration enables the fix on existing installs"
+pass "a migration enables the fix on existing installs"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin" "$test_tmp/rebuild-bin"
+
+cat >"$test_tmp/bin/omarchy-hw-dell-xps-oled" <<'SH'
+#!/bin/bash
+[[ ${TEST_XPS_OLED:-0} == 1 ]]
+SH
+
+cat >"$test_tmp/bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$test_tmp/bin/omarchy-state" <<'SH'
+#!/bin/bash
+printf 'state %s\n' "$*" >>"$CALL_LOG"
+SH
+
+cat >"$test_tmp/rebuild-bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+printf 'limine-mkinitcpio\n' >>"$CALL_LOG"
+SH
+
+# Models a machine without limine-mkinitcpio. The helper is stubbed rather than
+# the command dropped from PATH: the real tool sits in /usr/bin on a developer
+# machine, and the mock sudo would run it as the test user. The failing stub
+# stays as a tripwire, so a fall-through shows up in the call log instead.
+mkdir -p "$test_tmp/no-limine-bin"
+cat >"$test_tmp/no-limine-bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ $1 != "limine-mkinitcpio" ]]
+SH
+cat >"$test_tmp/no-limine-bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+printf 'limine-mkinitcpio\n' >>"$CALL_LOG"
+exit 1
+SH
+
+chmod +x "$test_tmp/bin"/* "$test_tmp/rebuild-bin"/* "$test_tmp/no-limine-bin"/*
+
+drop_in="$test_tmp/limine-entry-tool.d/dell-xps-oled-display-backlight.conf"
+call_log="$test_tmp/calls.log"
+expected_param='KERNEL_CMDLINE[default]+=" xe.enable_dpcd_backlight=1"'
+
+# Sourced the way run_logged runs it.
+run_leaf() {
+  PATH="$test_tmp/bin:$ROOT/bin:$PATH" \
+    TEST_XPS_OLED="${1-1}" \
+    OMARCHY_DELL_XPS_OLED_BACKLIGHT_CONF="$drop_in" \
+    bash -c 'source "$1"' bash "$leaf"
+}
+
+run_leaf || fail "the leaf writes the Limine drop-in on a Dell XPS OLED"
+grep -Fxq "$expected_param" "$drop_in" ||
+  fail "the leaf writes the Limine drop-in on a Dell XPS OLED" "$(cat "$drop_in" 2>&1)"
+pass "the leaf writes the Limine drop-in on a Dell XPS OLED"
+
+run_leaf || fail "the leaf is idempotent"
+(( $(grep -c 'enable_dpcd_backlight' "$drop_in") == 1 )) ||
+  fail "the leaf is idempotent" "$(cat "$drop_in")"
+pass "rerunning the leaf leaves one copy of the parameter"
+
+rm -rf "$test_tmp/limine-entry-tool.d"
+run_leaf 0 || fail "the leaf no-ops on other hardware"
+[[ ! -e $drop_in ]] || fail "the leaf no-ops on other hardware"
+pass "the leaf no-ops on other hardware"
+
+run_migration() {
+  : >"$call_log"
+  PATH="$test_tmp/bin:${2-$test_tmp/rebuild-bin}:$ROOT/bin:$PATH" \
+    CALL_LOG="$call_log" \
+    OMARCHY_PATH="$ROOT" \
+    TEST_XPS_OLED="${1-1}" \
+    OMARCHY_DELL_XPS_OLED_BACKLIGHT_CONF="$drop_in" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration || fail "the migration applies the fix, rebuilds the boot image, and asks for a reboot"
+grep -Fxq "$expected_param" "$drop_in" ||
+  fail "the migration writes the Limine drop-in"
+grep -Fxq 'limine-mkinitcpio' "$call_log" ||
+  fail "the migration rebuilds the boot image" "$(cat "$call_log")"
+grep -Fxq 'state set reboot-required' "$call_log" ||
+  fail "the migration asks for a reboot" "$(cat "$call_log")"
+pass "the migration applies the fix, rebuilds the boot image, and asks for a reboot"
+
+rm -rf "$test_tmp/limine-entry-tool.d"
+run_migration 0 || fail "the migration no-ops on other hardware"
+[[ ! -e $drop_in && ! -s $call_log ]] || fail "the migration no-ops on other hardware" "$(cat "$call_log")"
+pass "the migration no-ops on other hardware"
+
+# A drop-in under /etc/limine-entry-tool.d does nothing without the tool that
+# reads it, so the migration must skip cleanly rather than fail and block the
+# queue behind a missing rebuild command.
+run_migration 1 "$test_tmp/no-limine-bin" || fail "the migration skips when limine-mkinitcpio is missing"
+[[ ! -e $drop_in && ! -s $call_log ]] ||
+  fail "the migration skips when limine-mkinitcpio is missing" "$(cat "$call_log")"
+pass "the migration skips cleanly without limine-mkinitcpio"


### PR DESCRIPTION
## Problem

On the Dell XPS 14 (DA14260) with the LG OLED panel, the brightness keys move the OSD but the panel never changes. `intel_backlight` sysfs writes succeed and read back, so the Omarchy side is fine; the panel just isn't listening to that knob. The xe driver takes the backlight type from the VBT (PWM) while the OLED panel wants DPCD AUX. The kernel says so at boot:

```
xe 0000:00:02.0: [drm] [CONNECTOR:512:eDP-1] Panel is missing HDR static metadata.
Possible support for Intel HDR backlight interface is not used.
If your backlight controls don't work try booting with i915.enable_dpcd_backlight=3.
```

This is the same failure `install/hardware/asus/fix-asus-ptl-display-backlight.sh` already fixes for the ExpertBook B9406 and Zenbook UX5406AA (#5435, #5620), and the same one #10463 reports on the Lenovo Yoga Pro 7. The ASUS leaf is gated to those two models, so it never runs on a Dell. `omarchy-hw-dell-xps-oled` already matches this machine, but nothing uses it since the PSR workaround was retired in a70b05e8.

## Solution

- `install/hardware/dell-xps-oled-display-backlight.sh`: writes `/etc/limine-entry-tool.d/dell-xps-oled-display-backlight.conf` with `xe.enable_dpcd_backlight=1`, gated on `omarchy-hw-dell-xps-oled`. Mirrors the ASUS leaf; the drop-in path takes an `OMARCHY_DELL_XPS_OLED_BACKLIGHT_CONF` override for tests, like `fix-nouveau-cursor.sh` and `snapper.sh` do.
- `install/hardware/all.sh`: runs it next to the other Dell leaf.
- `migrations/1788886195.sh`: for existing installs, sources the leaf, runs `limine-mkinitcpio`, and sets `reboot-required`. Skips cleanly on machines without `limine-mkinitcpio`, since the drop-in does nothing without it. No completion marker: a second user running it before the reboot repeats an identical rebuild, which is harmless.
- `test/shell.d/dell-xps-oled-display-backlight-test.sh`: covers the `all.sh` wiring, the leaf writing and no-oping, idempotence, and the migration's rebuild, reboot flag, no-op, and missing-tool paths.

Value `1` lets the driver pick between the Intel HDR and VESA AUX interfaces, matching the ASUS fix. The kernel's own suggestion of `3` forces the Intel HDR interface; `1` was enough here.

## Interaction with #10549

That PR tightens `omarchy-hw-dell-xps-oled` to the 2880x1800 and 3200x2000 OLED modes because the EDID manufacturer check alone also matches the 1920x1200 LG IPS SKU. This leaf inherits whichever matcher lands. With the current matcher the drop-in would also be written on an IPS XPS; at value `1` the driver only takes the AUX path when the panel advertises it, so the IPS panel should keep working over PWM, but I have no IPS unit to confirm that on. I'd rather not duplicate the mode check here; the matcher is the right place for it.

## Testing

- Applied the same drop-in by hand on my XPS 14 DA14260 (Omarchy 4.0.3rc3-1, linux-ptl 7.2.3), rebuilt with `limine-update`, rebooted. `/proc/cmdline` carries the parameter and F7/F8 now change the panel.
- `./test/all`: 234 of 237 shell test files pass, including the new one. The three that fail here fail on `quattro` too and do not touch anything in this diff: `snapper-test.sh` wants an `omarchy-iso` checkout, `locate-test.sh` reads `/usr/bin/updatedb` as text and hits a binary on this machine, and `config-test.sh` wanted an `omarchy-pkgs` checkout and passes once one is present.
- Mutation-checked the test: dropping the hardware gate from the leaf, or the `limine-mkinitcpio` guard from the migration, each fails the corresponding assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
