### PR TITLE
Recover outputs Hyprland thinks are on while DRM DPMS is off

### DIFF
--- a/bin/omarchy-hyprland-monitor-clamshell
+++ b/bin/omarchy-hyprland-monitor-clamshell
@@ -250,3 +250,7 @@ if omarchy-hw-clamshell && omarchy-hyprland-monitor-external-active; then
 else
   enable_internal
 fi
+
+# HDMI on NVIDIA can fail the post-DPMS modeset while Hyprland still reports
+# the output as on. Recover that desync without waking lock-screen blanks.
+omarchy-hyprland-monitor-recover-outputs >/dev/null 2>&1 || true

--- a/bin/omarchy-hyprland-monitor-recover-outputs
+++ b/bin/omarchy-hyprland-monitor-recover-outputs
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# omarchy:summary=Re-DPMS outputs Hyprland reports on while the kernel connector is off
+# omarchy:args=[--print]
+# omarchy:hidden=true
+
+# After lid close or idle DPMS on hybrid NVIDIA, HDMI can fail an atomic
+# modeset. Hyprland then leaves dpmsStatus true, so mouse-move DPMS is a no-op
+# and the panel stays dark. Cycle DPMS only for that desync; lock-screen
+# blanking (hypr dpmsStatus false) is left alone.
+
+DRM_PATH="${OMARCHY_DRM_PATH:-/sys/class/drm}"
+COOLDOWN_SEC=15
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+LOCK="$RUNTIME_DIR/omarchy-hyprland-monitor-recover-outputs.lock"
+
+safe_name() {
+  [[ $1 =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+hypr_truthy() {
+  [[ $1 == "true" || $1 == "1" ]]
+}
+
+connector_dir() {
+  local name="$1" candidate
+
+  for candidate in "$DRM_PATH"/card*-"$name"; do
+    [[ -e $candidate/status ]] || continue
+    [[ $(<"$candidate/status") == "connected" ]] || continue
+    printf '%s\n' "$candidate"
+    return 0
+  done
+  return 1
+}
+
+kernel_off() {
+  local sysfs="$1" enabled kdpms
+
+  enabled=$(cat "$sysfs/enabled") || return 1
+  kdpms=$(cat "$sysfs/dpms") || return 1
+  [[ $enabled == "disabled" || $kdpms == "Off" ]]
+}
+
+cycle_dpms() {
+  local name="$1"
+
+  hyprctl dispatch "hl.dsp.dpms({ action = \"off\", monitor = \"$name\" })" >/dev/null 2>&1 || true
+  hyprctl dispatch "hl.dsp.dpms({ action = \"on\", monitor = \"$name\" })" >/dev/null 2>&1 || true
+}
+
+cooled_down() {
+  local stamp="$RUNTIME_DIR/omarchy-output-recover.$1" age
+
+  [[ -f $stamp ]] || return 1
+  age=$(( $(date +%s) - $(stat -c %Y "$stamp") ))
+  (( age < COOLDOWN_SEC ))
+}
+
+mark_cycled() {
+  : >"$RUNTIME_DIR/omarchy-output-recover.$1"
+}
+
+stuck_names() {
+  local json name disabled dpms sysfs
+
+  json=$(hyprctl monitors all -j 2>/dev/null) || return 0
+  [[ -n $json ]] || return 0
+
+  while IFS=$'\t' read -r name disabled dpms; do
+    safe_name "$name" || continue
+    hypr_truthy "$disabled" && continue
+    hypr_truthy "$dpms" || continue
+    sysfs=$(connector_dir "$name") || continue
+    kernel_off "$sysfs" || continue
+    printf '%s\n' "$name"
+  done < <(printf '%s\n' "$json" | jq -r '.[] | [.name, (.disabled|tostring), (.dpmsStatus|tostring)] | @tsv')
+}
+
+recover_once() {
+  local name
+
+  while IFS= read -r name; do
+    [[ -n $name ]] || continue
+    cooled_down "$name" && continue
+    mark_cycled "$name"
+    logger -t omarchy-hyprland-monitor-recover-outputs "cycling DPMS on $name (hypr on, kernel off)"
+    cycle_dpms "$name"
+  done < <(stuck_names)
+}
+
+case "${1:-}" in
+  --print)
+    stuck_names
+    ;;
+  *)
+    exec 9>"$LOCK"
+    flock -n 9 || exit 0
+    recover_once
+    ;;
+esac

--- a/test/shell.d/hyprland-monitor-recover-outputs-test.sh
+++ b/test/shell.d/hyprland-monitor-recover-outputs-test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+drm="$test_tmp/drm"
+runtime_dir="$test_tmp/runtime"
+call_log="$test_tmp/calls"
+mkdir -p "$mock_bin" "$drm" "$runtime_dir"
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ $1 == "monitors" && $2 == "all" && $3 == "-j" ]]; then
+  cat "$HYPR_MONITORS_JSON"
+  exit 0
+fi
+if [[ $1 == "dispatch" ]]; then
+  printf '%s\n' "$*" >>"$CALL_LOG"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "$mock_bin/hyprctl"
+
+cat >"$mock_bin/logger" <<'SH'
+#!/bin/bash
+printf 'logger %s\n' "$*" >>"$CALL_LOG"
+SH
+chmod +x "$mock_bin/logger"
+
+write_connector() {
+  local dir="$drm/$1"
+  mkdir -p "$dir"
+  printf '%s\n' "$2" >"$dir/status"
+  printf '%s\n' "$3" >"$dir/enabled"
+  printf '%s\n' "$4" >"$dir/dpms"
+}
+
+write_monitors_json() {
+  cat >"$test_tmp/monitors.json"
+}
+
+run_recover() {
+  CALL_LOG="$call_log" \
+    HYPR_MONITORS_JSON="$test_tmp/monitors.json" \
+    OMARCHY_DRM_PATH="$drm" \
+    XDG_RUNTIME_DIR="$runtime_dir" \
+    PATH="$mock_bin:$PATH" \
+    "$ROOT/bin/omarchy-hyprland-monitor-recover-outputs" "$@"
+}
+
+write_monitors_json <<'JSON'
+[
+  {"name":"DP-1","disabled":false,"dpmsStatus":true},
+  {"name":"HDMI-A-1","disabled":false,"dpmsStatus":true},
+  {"name":"eDP-2","disabled":false,"dpmsStatus":true}
+]
+JSON
+
+write_connector card1-DP-1 connected enabled On
+write_connector card1-HDMI-A-1 connected disabled Off
+write_connector card2-eDP-2 connected enabled On
+
+stuck=$(run_recover --print)
+[[ $stuck == "HDMI-A-1" ]] || fail "kernel-off HDMI is reported stuck" "actual: $stuck"
+pass "kernel-off HDMI is reported stuck"
+
+write_connector card1-HDMI-A-1 connected enabled On
+stuck=$(run_recover --print)
+[[ -z $stuck ]] || fail "kernel-on HDMI is not stuck" "actual: $stuck"
+pass "kernel-on HDMI is not stuck"
+
+write_connector card1-HDMI-A-1 connected disabled Off
+write_monitors_json <<'JSON'
+[
+  {"name":"HDMI-A-1","disabled":false,"dpmsStatus":false}
+]
+JSON
+stuck=$(run_recover --print)
+[[ -z $stuck ]] || fail "lock-screen DPMS-off is not recovered" "actual: $stuck"
+pass "lock-screen DPMS-off is not recovered"
+
+write_monitors_json <<'JSON'
+[
+  {"name":"HDMI-A-1","disabled":true,"dpmsStatus":true}
+]
+JSON
+stuck=$(run_recover --print)
+[[ -z $stuck ]] || fail "hypr-disabled HDMI is not recovered" "actual: $stuck"
+pass "hypr-disabled HDMI is not recovered"
+
+write_monitors_json <<'JSON'
+[
+  {"name":"HDMI-A-1; rm -rf /","disabled":false,"dpmsStatus":true}
+]
+JSON
+stuck=$(run_recover --print)
+[[ -z $stuck ]] || fail "unsafe monitor names are ignored" "actual: $stuck"
+pass "unsafe monitor names are ignored"
+
+write_monitors_json <<'JSON'
+[
+  {"name":"HDMI-A-1","disabled":false,"dpmsStatus":true}
+]
+JSON
+: >"$call_log"
+run_recover
+grep -F 'dispatch hl.dsp.dpms({ action = "off", monitor = "HDMI-A-1" })' "$call_log" >/dev/null || \
+  fail "stuck HDMI is DPMS-cycled off first"
+grep -F 'dispatch hl.dsp.dpms({ action = "on", monitor = "HDMI-A-1" })' "$call_log" >/dev/null || \
+  fail "stuck HDMI is DPMS-cycled on"
+pass "stuck HDMI is DPMS-cycled off then on"
+
+: >"$call_log"
+run_recover
+if grep -F 'dispatch' "$call_log" >/dev/null; then
+  fail "cooldown skips a second cycle"
+fi
+pass "cooldown skips a second cycle"
+
+rg -n 'omarchy-hyprland-monitor-recover-outputs' "$ROOT/bin/omarchy-hyprland-monitor-clamshell" >/dev/null || \
+  fail "clamshell invokes output recovery"
+pass "clamshell invokes output recovery"


### PR DESCRIPTION
## Bug Description

On a docked hybrid-GPU laptop (Intel eDP + NVIDIA HDMI), closing the lid does not suspend (`HandleLidSwitchDocked=ignore`). Omarchy clamshell disables the internal panel. After idle DPMS, opening the lid wakes DP and eDP, but the HDMI monitor stays dark.

Hyprland still reports that output as enabled with `dpmsStatus: true`, so `mouse_move_enables_dpms` is a no-op.

## Root Cause

Aquamarine logs from a live repro (Dell P2725QE on `HDMI-A-1` at 3840x2160@100, RTX 4060 + Intel UHD):

1. Lid close disables `eDP-2`; NVIDIA then reports `HDMI-A-1` disconnected.
2. Idle DPMS disables every output.
3. On wake, DP-1 and eDP-2 modeset. HDMI 4K@100 fails:

```
drm: Modesetting HDMI-A-1 with 3840x2160@100.00Hz
ERR: atomic drm request: failed to commit: Invalid argument, flags: ATOMIC_ALLOW_MODESET
```

4. Kernel sysfs for that connector stays `enabled=disabled dpms=Off` while `hyprctl` still says the monitor is on.

An explicit DPMS off/on of `HDMI-A-1` restored the panel immediately.

## Fix

- Add hidden `omarchy-hyprland-monitor-recover-outputs`.
- For each Hyprland output that is not disabled and has `dpmsStatus` true, if the matching DRM connector is connected and kernel DPMS is Off (or `enabled=disabled`), cycle that output's DPMS.
- Skip lock-screen blanks (`dpmsStatus` false).
- 15s cooldown so the existing 2s clamshell poll cannot flicker.
- Call it at the end of `omarchy-hyprland-monitor-clamshell` so lid binds and the docked poll both recover the desync.

## How to Verify

1. Desk layout with an NVIDIA HDMI 4K monitor and the laptop lid used as a third screen.
2. Close the lid, wait through idle/lock, open the lid.
3. Before this change: middle HDMI stays dark; `hyprctl monitors` shows it on; `/sys/class/drm/card*-HDMI-A-1/{enabled,dpms}` is `disabled` / `Off`.
4. After this change: clamshell/poll cycles HDMI DPMS and the panel comes back. Lock-screen blanking is unchanged.

## Test Plan

- [x] Added `test/shell.d/hyprland-monitor-recover-outputs-test.sh` (stuck HDMI, healthy HDMI, lock-screen skip, disabled skip, unsafe names, off-then-on dispatch, cooldown, clamshell hook)
- [x] `bash test/shell.d/hyprland-monitor-recover-outputs-test.sh` passes
- [x] `bash test/shell.d/bin-style-test.sh` passes
- [x] Manual: DPMS off/on of HDMI-A-1 recovered the live session

## Risk Assessment

Low — only acts when Hyprland already believes the output is on and the kernel connector is off. Does not wake intentionally blanked screens.