### PR TITLE
fix(systemd): rebind ASUS touchpad after s2idle resume

### DIFF
--- a/default/systemd/system-sleep/asus-touchpad-resume
+++ b/default/systemd/system-sleep/asus-touchpad-resume
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Rebind the ASUS ASUP1206 I2C touchpad after a failed s2idle resume.
+#
+# On affected systems, i2c_hid_acpi can leave the touchpad present but
+# unresponsive after reporting -121 from its resume callback. Rebinding only
+# this device forces a fresh HID probe without disturbing other I2C devices.
+
+device=i2c-ASUP1206:00
+driver=/sys/bus/i2c/drivers/i2c_hid_acpi
+
+if [[ $1 == "post" && -e $driver/$device ]]; then
+  echo "$device" > "$driver/unbind" || exit 0
+  sleep 1
+  echo "$device" > "$driver/bind" || true
+fi


### PR DESCRIPTION
Closes #10924

## Summary

- Restore ASUS ASUP1206 I2C touchpad input after a failed `s2idle` resume.
- Rebind only the affected HID device, leaving the ELAN9008 touchscreen untouched.

## Changes

| File | Change |
|------|--------|
| `default/systemd/system-sleep/asus-touchpad-resume` | Rebind `i2c-ASUP1206:00` during `post` resume so `i2c_hid_acpi` performs a fresh HID probe. |

The workaround targets the resume failure observed on an ASUS Zenbook 14 UM3406KA, where `i2c_hid_acpi` returns `-121` while restoring the touchpad power state.
