### PR TITLE
Invert the bar toggle so on shows the bar and off hides it

### DIFF
--- a/bin/omarchy-toggle-bar
+++ b/bin/omarchy-toggle-bar
@@ -4,7 +4,17 @@
 # omarchy:args=[toggle|on|off]
 # omarchy:examples=omarchy toggle bar | omarchy toggle bar off | omarchy toggle bar on
 
-omarchy-toggle bar-off "${1:-toggle}"
+# The stored flag is negative, so the user-facing action inverts on the way
+# through: showing the bar clears bar-off, hiding it sets bar-off.
+case "${1:-toggle}" in
+  on) omarchy-toggle bar-off off ;;
+  off) omarchy-toggle bar-off on ;;
+  toggle) omarchy-toggle bar-off toggle ;;
+  *)
+    echo "Usage: omarchy-toggle-bar [toggle|on|off]" >&2
+    exit 1
+    ;;
+esac
 
 # The shell's watch on the toggles directory can miss flag changes that land in
 # quick succession, stranding the bar off screen until the shell restarts.

--- a/test/cli
+++ b/test/cli
@@ -611,6 +611,41 @@ while IFS= read -r binary_path; do
 done < <(find "$ROOT/bin" -maxdepth 1 -type f -executable -name 'omarchy-*' | sort)
 pass "all executable bins have slim self-documenting metadata"
 
+# `omarchy toggle bar` speaks in terms of the bar, but the state it writes is the
+# negative flag `bar-off`, so the user-facing action has to be inverted on the way
+# through. Forwarding it verbatim made `on` hide the bar and `off` show it.
+make_tmpdir BAR_TMPDIR
+mkdir -p "$BAR_TMPDIR/fake-bin"
+cat >"$BAR_TMPDIR/fake-bin/omarchy-shell" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$BAR_TMPDIR/fake-bin/omarchy-shell"
+BAR_FLAG="$BAR_TMPDIR/.local/state/omarchy/toggles/bar-off"
+BAR_PATH="$BAR_TMPDIR/fake-bin:$ROOT/bin:$PATH"
+
+PATH="$BAR_PATH" HOME="$BAR_TMPDIR" "$ROOT/bin/omarchy-toggle-bar" off
+[[ -f $BAR_FLAG ]] || fail "toggle bar off hides the bar"
+pass "toggle bar off hides the bar"
+
+PATH="$BAR_PATH" HOME="$BAR_TMPDIR" "$ROOT/bin/omarchy-toggle-bar" on
+[[ ! -f $BAR_FLAG ]] || fail "toggle bar on shows the bar"
+pass "toggle bar on shows the bar"
+
+# on and off name a state, so repeating one holds it rather than flipping it.
+PATH="$BAR_PATH" HOME="$BAR_TMPDIR" "$ROOT/bin/omarchy-toggle-bar" on
+[[ ! -f $BAR_FLAG ]] || fail "toggle bar on is idempotent"
+pass "toggle bar on is idempotent"
+
+PATH="$BAR_PATH" HOME="$BAR_TMPDIR" "$ROOT/bin/omarchy-toggle-bar" toggle
+[[ -f $BAR_FLAG ]] || fail "toggle bar toggle hides a visible bar"
+pass "toggle bar toggle hides a visible bar"
+
+PATH="$BAR_PATH" HOME="$BAR_TMPDIR" "$ROOT/bin/omarchy-toggle-bar"
+[[ ! -f $BAR_FLAG ]] || fail "toggle bar without an argument toggles"
+pass "toggle bar without an argument toggles"
+
+
 make_tmpdir TMPDIR
 ln -s "$CLI" "$TMPDIR/omarchy"
 


### PR DESCRIPTION
Closes #10923. Closes #10896.

## The bug

`omarchy toggle bar on` hides the bar and `omarchy toggle bar off` shows it — the opposite of the command name and of the examples in the command's own metadata. Two people reported it independently against 4.0.2 and 4.0.3.

The state Omarchy stores is a *negative* flag, `~/.local/state/omarchy/toggles/bar-off`, but `omarchy-toggle-bar` forwarded the user's action to it verbatim:

```bash
omarchy-toggle bar-off "${1:-toggle}"
```

`omarchy-toggle <flag> on` creates the flag and `off` removes it, so `on` set `bar-off` (bar hidden) and `off` cleared it (bar shown). `toggle` was unaffected, which is why the keybinding and menu entry always behaved correctly and only the explicit arguments were wrong.

## The fix

Map the user-facing action onto the flag rather than passing it through:

```bash
case "${1:-toggle}" in
  on) omarchy-toggle bar-off off ;;
  off) omarchy-toggle bar-off on ;;
  toggle) omarchy-toggle bar-off toggle ;;
  ...
```

An unknown action now prints this command's own usage instead of forwarding to `omarchy-toggle`, whose error named a command the user never ran.

## Scope

Only `omarchy-toggle-bar` is affected. The other three wrappers over negative flags — `omarchy-toggle-screensaver` (`screensaver-off`), `omarchy-toggle-crash-capture` (`crash-capture-off`) and `omarchy-toggle-suspend` (`suspend-off`) — call `omarchy-toggle` with no action argument, so they only ever plain-toggle and cannot invert. They are left alone.

## Tests

Five assertions added to `test/cli`, following the existing fake-bin/tmpdir pattern in that file, driving the real `omarchy-toggle-bar` and `omarchy-toggle` against a scratch `HOME` with `omarchy-shell` stubbed:

- `off` hides the bar, `on` shows it
- repeating `on` holds the state rather than flipping it, since `on`/`off` name a state
- bare `toggle` still flips in both directions
- no argument still defaults to `toggle`

They were written first and fail on the current tree at the first assertion (`toggle bar off hides the bar`), which is the reported bug.

## Verification

`./test/cli` goes from 112 to 117 passing assertions, exit 0.

Two caveats worth stating plainly rather than leaving you to find out:

- I ran the suite in a `debian:bookworm-slim` container (bash 5 plus `jq`, `python3`, `ripgrep`, `fontconfig`) because my host is macOS, whose bash 3.2 cannot run `test/cli` at all — it uses namerefs. The container is only a bash 5 environment; nothing about the change is container-specific.
- I did not run `./test/shell` or the graphical acceptance suite. The shell suite did not finish inside my time budget, and the acceptance suite needs a VM. This change touches only `bin/` and `test/cli`, so neither should be implicated — but I have not proven that, and I have no Arch or Hyprland machine to confirm the bar visibly returns.

I also walked the reproduction from the issues by hand against the patched script, confirming `on` → visible, `off` → hidden, `on` again → still visible, and bare `toggle` flipping in both directions.
