### PR TITLE
Support pre-GCN AMD GPUs and BCM4321 wireless

### DIFF
--- a/bin/omarchy-hw-nightlight
+++ b/bin/omarchy-hw-nightlight
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the GPU can apply a nightlight color temperature.
+
+# hyprsunset sends its color temperature to Hyprland as a colour transform
+# matrix over hyprland-ctm-control-v1, and aquamarine only submits a CTM on the
+# DRM atomic path. A driver without atomic modesetting accepts the request and
+# drops it, so hyprctl answers "ok", the temperature reads back, and the panel
+# never changes — a silent no-op rather than an error.
+#
+# radeon is the one such driver still in use: it drives pre-GCN AMD cards
+# (TeraScale and older, e.g. the Radeon HD 2400 in a 2007 iMac) and reports
+# "crtc doesn't support CTM". Everything newer is on amdgpu and is atomic.
+#
+# Only answer no when every DRM card is on radeon. A machine that also has a
+# non-radeon GPU may well be driving its display from that one, and hiding a
+# working feature is worse than leaving a broken one visible.
+drm_path="${OMARCHY_DRM_PATH:-/sys/class/drm}"
+
+cards=0
+
+for card in "$drm_path"/card[0-9]*; do
+  name=${card##*/}
+
+  # Connectors are exposed as card0-LVDS-1 alongside the card itself.
+  [[ $name == *-* ]] && continue
+  [[ -e $card/device/driver ]] || continue
+
+  (( ++cards ))
+  [[ $(readlink -f "$card/device/driver") == */radeon ]] || exit 0
+done
+
+(( cards > 0 )) && exit 1
+
+exit 0

--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -29,6 +29,22 @@ status_json() {
     '{enabled:$enabled, temperature:(($temp | tonumber?) // null)}'
 }
 
+# Without a CTM-capable display pipeline hyprsunset still answers "ok" and
+# reports the temperature back, so the retry loop below would run to completion
+# and this command would claim success over a panel that never changed. Say so
+# instead. The menu hides this row on such hardware; this covers the keybind,
+# the CLI, and anything reading --status.
+if ! omarchy-hw-nightlight; then
+  if [[ ${1:-} == "--status" ]]; then
+    jq -cn '{enabled:false, temperature:null}'
+    exit 0
+  fi
+
+  omarchy-notification-send -u normal "Nightlight unavailable" \
+    "This GPU's display driver cannot apply a color temperature."
+  exit 1
+fi
+
 if [[ ${1:-} == "--status" ]]; then
   status_json
   exit 0

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -91,7 +91,7 @@
   "trigger.toggle.notifications": {"icon":"󰂛","label":"Notifications","action":"omarchy-toggle-notification-silencing"},
   "trigger.toggle.crash-capture": {"icon":"󱚡","label":"Crash Capture","action":"omarchy-toggle-crash-capture"},
   "trigger.toggle.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-toggle-screensaver"},
-  "trigger.toggle.nightlight": {"icon":"󰔎","label":"Nightlight","action":"omarchy-toggle-nightlight"},
+  "trigger.toggle.nightlight": {"icon":"󰔎","label":"Nightlight","when":"omarchy-hw-nightlight","action":"omarchy-toggle-nightlight"},
   "trigger.toggle.top-bar": {"icon":"󰍜","label":"Menu Bar","action":"omarchy-toggle-bar"},
   "trigger.toggle.battery-percentage": {"icon":"󰁹","label":"Battery Percentage","when":"omarchy-hw-laptop","action":"omarchy-shell omarchy.power togglePercentage"},
   "trigger.toggle.workspace-layout": {"icon":"󱂬","label":"Workspace Layout","action":"omarchy-hyprland-workspace-layout-toggle"},

--- a/install/hardware/fix-bcm43xx.sh
+++ b/install/hardware/fix-bcm43xx.sh
@@ -1,10 +1,11 @@
 # Install Wi-Fi drivers for Broadcom chips found in some MacBooks, as well as other systems:
 # - BCM4360 (2013–2015 MacBooks)
 # - BCM4331 (2012, early 2013 MacBooks)
+# - BCM4321 (2007–2008 iMacs and MacBooks; 4329 and 432a are the same chip)
 
 pci_info=$(lspci -nn)
 
-if (echo "$pci_info" | grep -q "14e4:43a0" || echo "$pci_info" | grep -q "14e4:4331"); then
-  echo "BCM4360 / BCM4331 detected"
+if echo "$pci_info" | grep -qE "14e4:(43a0|4331|4328|4329|432a)"; then
+  echo "Broadcom BCM4360 / BCM4331 / BCM4321 detected"
   omarchy-pkg-add broadcom-wl-dkms linux-headers
 fi

--- a/install/hardware/vulkan.sh
+++ b/install/hardware/vulkan.sh
@@ -9,8 +9,32 @@ declare -A VULKAN_DRIVERS=(
 
 PACKAGES=()
 
+# RADV only drives GPUs bound to amdgpu. Pre-GCN cards (TeraScale and older,
+# e.g. the Radeon HD 2400 in a 2007 iMac) stay on the radeon driver, where
+# vulkan-radeon still installs radeon_icd.json but every device enumeration
+# fails with VK_ERROR_INCOMPATIBLE_DRIVER. That stray ICD makes
+# omarchy-hw-vulkan answer yes on a machine with no working Vulkan.
+amd_gpu_on_amdgpu() {
+  local device
+  local pci_devices_path="${OMARCHY_PCI_DEVICES_PATH:-/sys/bus/pci/devices}"
+
+  for device in "$pci_devices_path"/*; do
+    [[ -e $device/vendor ]] || continue
+    [[ $(< "$device/vendor") == "0x1002" ]] || continue
+    [[ $(< "$device/class") == 0x03* ]] || continue
+    [[ $(readlink -f "$device/driver") == */amdgpu ]] && return 0
+  done
+
+  return 1
+}
+
 for vendor in "${!VULKAN_DRIVERS[@]}"; do
   if lspci | grep -iE "(VGA|Display).*$vendor" > /dev/null; then
+    if [[ $vendor == "AMD" ]] && ! amd_gpu_on_amdgpu; then
+      echo "Skipping vulkan-radeon: AMD GPU is not on amdgpu (pre-GCN), RADV cannot drive it"
+      continue
+    fi
+
     PACKAGES+=("${VULKAN_DRIVERS[$vendor]}")
   fi
 done

--- a/test/shell.d/broadcom-wifi-test.sh
+++ b/test/shell.d/broadcom-wifi-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+fix_bcm="$ROOT/install/hardware/fix-bcm43xx.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+# Real lspci keeps printing well past any match, so a grep -q consumer can be
+# killed by SIGPIPE; keep the stub chatty for the same reason as the T2 test.
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+[[ -n ${STUB_WIFI_ID:-} ]] &&
+  echo "04:00.0 Network controller [0280]: Broadcom Inc. and subsidiaries Wireless [$STUB_WIFI_ID] (rev 03)"
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+chmod +x "$stub_bin/lspci"
+
+installs_driver_for() {
+  local wifi_id=${1:-}
+  local calls="$test_tmp/calls-$RANDOM"
+
+  PATH="$stub_bin:$PATH" \
+  STUB_WIFI_ID="$wifi_id" \
+  OMARCHY_TEST_CALLS="$calls" \
+    "$BASH" -c '
+      omarchy-pkg-add() { printf "%s\n" "$@" >>"$OMARCHY_TEST_CALLS"; }
+      source "$1"
+    ' _ "$fix_bcm" >/dev/null 2>&1
+
+  [[ -f $calls ]] && grep -qx 'broadcom-wl-dkms' "$calls"
+}
+
+# BCM4321 is the 2007-2008 iMac/MacBook card. b43 can drive it, but Omarchy
+# standardized on the wl driver, which covers it too.
+for id in 14e4:4328 14e4:4329 14e4:432a; do
+  installs_driver_for "$id" ||
+    fail "BCM4321 ($id) gets broadcom-wl-dkms"
+done
+pass "BCM4321 device ids pull in broadcom-wl-dkms"
+
+# Regression guard: the ids that already worked must keep working.
+installs_driver_for 14e4:43a0 || fail "BCM4360 still gets broadcom-wl-dkms"
+installs_driver_for 14e4:4331 || fail "BCM4331 still gets broadcom-wl-dkms"
+pass "BCM4360 and BCM4331 keep their driver"
+
+# A Broadcom wireless card the wl driver does not claim must not drag it in.
+! installs_driver_for 14e4:4353 ||
+  fail "an unsupported Broadcom id does not install broadcom-wl-dkms"
+! installs_driver_for ||
+  fail "a machine with no Broadcom wireless installs nothing"
+pass "non-matching hardware installs no Broadcom driver"

--- a/test/shell.d/nightlight-hardware-test.sh
+++ b/test/shell.d/nightlight-hardware-test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hw_nightlight="$ROOT/bin/omarchy-hw-nightlight"
+toggle="$ROOT/bin/omarchy-toggle-nightlight"
+menu="$ROOT/default/omarchy/omarchy-menu.jsonc"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+# A /sys/class/drm shaped tree: one directory per card bound to the named
+# driver, plus the connector directories the real thing interleaves with them.
+make_drm_tree() {
+  local tree="$test_tmp/drm-$RANDOM"
+  local index=0
+  local driver
+
+  mkdir -p "$tree/drivers"
+
+  for driver in "$@"; do
+    mkdir -p "$tree/card$index/device" "$tree/drivers/$driver"
+    ln -s "../../drivers/$driver" "$tree/card$index/device/driver"
+    # Connectors hang off the same directory and must not be counted as cards.
+    mkdir -p "$tree/card$index-LVDS-1" "$tree/card$index-DVI-I-1"
+    (( ++index ))
+  done
+
+  echo "$tree"
+}
+
+supports_nightlight() {
+  OMARCHY_DRM_PATH="$1" "$BASH" "$hw_nightlight"
+}
+
+# Pre-GCN AMD: aquamarine's legacy DRM path never submits a CTM, so hyprsunset
+# is a silent no-op here.
+! supports_nightlight "$(make_drm_tree radeon)" ||
+  fail "a radeon-only machine reports no nightlight support"
+pass "radeon-only hardware reports no nightlight support"
+
+# Everything atomic must keep the feature.
+supports_nightlight "$(make_drm_tree amdgpu)" ||
+  fail "an amdgpu machine still supports nightlight"
+supports_nightlight "$(make_drm_tree i915)" ||
+  fail "an Intel machine still supports nightlight"
+pass "atomic drivers keep nightlight"
+
+# Conservative on mixed hardware: the display may be driven by the other GPU,
+# and hiding a working feature is worse than leaving a broken one visible.
+supports_nightlight "$(make_drm_tree radeon i915)" ||
+  fail "a machine with both radeon and an atomic GPU keeps nightlight"
+pass "mixed radeon plus atomic hardware keeps nightlight"
+
+# Nothing to go on is not evidence of breakage.
+supports_nightlight "$(make_drm_tree)" ||
+  fail "a tree with no DRM cards does not claim nightlight is broken"
+pass "an empty DRM tree keeps nightlight"
+
+# The guard has to be wired up in both places, or the silent no-op comes back.
+grep -Fq '"when":"omarchy-hw-nightlight"' "$menu" ||
+  fail "the menu hides the Nightlight row on hardware that cannot do it"
+grep -Fq 'if ! omarchy-hw-nightlight; then' "$toggle" ||
+  fail "omarchy-toggle-nightlight refuses instead of reporting a false success"
+pass "the nightlight guard is wired into the menu and the toggle"

--- a/test/shell.d/nightlight-test.sh
+++ b/test/shell.d/nightlight-test.sh
@@ -47,12 +47,28 @@ cat >"$TMPDIR/bin/omarchy-shell" <<'SH'
 printf '%s\n' "$*" >>"$OMARCHY_SHELL_LOG"
 SH
 
-chmod +x "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/pgrep" "$TMPDIR/bin/omarchy-shell"
+# Hardware that cannot apply a CTM is the interesting second case, so make the
+# capability probe switchable rather than assuming it always answers yes.
+cat >"$TMPDIR/bin/omarchy-hw-nightlight" <<'SH'
+#!/bin/bash
+exit "${NIGHTLIGHT_SUPPORTED:-0}"
+SH
+
+cat >"$TMPDIR/bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$NOTIFICATION_LOG"
+SH
+
+NOTIFICATIONS="$TMPDIR/notifications"
+
+chmod +x "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/pgrep" "$TMPDIR/bin/omarchy-shell" \
+  "$TMPDIR/bin/omarchy-hw-nightlight" "$TMPDIR/bin/omarchy-notification-send"
 
 nightlight_cli() {
   PATH="$TMPDIR/bin:$PATH" \
   HYPRSUNSET_STATE="$STATE" \
   OMARCHY_SHELL_LOG="$SHELL_LOG" \
+  NOTIFICATION_LOG="$NOTIFICATIONS" \
     "$ROOT/bin/omarchy-toggle-nightlight" "$@"
 }
 
@@ -90,3 +106,21 @@ if rg -q 'omarchy.indicators' "$ROOT/bin/omarchy-toggle-nightlight"; then
   fail "nightlight toggle leaves indicator refresh to the nightlight service"
 fi
 pass "nightlight toggle leaves indicator refresh to the nightlight service"
+
+# On a display pipeline with no CTM support hyprsunset still answers "ok" and
+# echoes the temperature back, so the toggle has to refuse up front rather than
+# run its retry loop and claim a success the panel never showed.
+printf '6500\n' >"$STATE"
+: >"$NOTIFICATIONS"
+
+NIGHTLIGHT_SUPPORTED=1 nightlight_cli >/dev/null 2>&1 &&
+  fail "nightlight toggle exits non-zero on hardware that cannot apply a temperature"
+[[ $(<"$STATE") == 6500 ]] ||
+  fail "nightlight toggle leaves the temperature alone on unsupported hardware"
+grep -Fq 'Nightlight unavailable' "$NOTIFICATIONS" ||
+  fail "nightlight toggle tells the user why it did nothing"
+pass "nightlight toggle refuses on hardware that cannot apply a temperature"
+
+[[ $(NIGHTLIGHT_SUPPORTED=1 nightlight_status 4000 | jq -r .enabled) == "false" ]] ||
+  fail "nightlight status reports disabled on unsupported hardware"
+pass "nightlight status reports disabled on unsupported hardware"

--- a/test/shell.d/vulkan-hardware-test.sh
+++ b/test/shell.d/vulkan-hardware-test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+vulkan="$ROOT/install/hardware/vulkan.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+# lspci only has to name the vendor on a VGA line; the driver question is
+# answered from sysfs, which is what this script actually gates on.
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+echo "01:00.0 VGA compatible controller: ${STUB_GPU_VENDOR:-Advanced Micro Devices, Inc. [AMD/ATI]} RV610"
+SH
+chmod +x "$stub_bin/lspci"
+
+# A GPU claimed by $1 ("radeon" or "amdgpu"), shaped like /sys/bus/pci/devices.
+make_pci_tree() {
+  local driver=$1
+  local vendor=${2:-0x1002}
+  local tree="$test_tmp/pci-$driver-$RANDOM"
+
+  mkdir -p "$tree/0000:01:00.0" "$tree/drivers/$driver"
+  echo "$vendor" >"$tree/0000:01:00.0/vendor"
+  echo "0x030000" >"$tree/0000:01:00.0/class"
+  ln -s "../drivers/$driver" "$tree/0000:01:00.0/driver"
+
+  echo "$tree"
+}
+
+# Sourcing vulkan.sh with omarchy-pkg-add stubbed records what it would install.
+# The packages go to a file rather than stdout: the script also explains itself
+# on stdout, and those messages name the very packages being asserted on.
+installed_packages() {
+  local pci_path=$1
+  local calls="$test_tmp/calls-$RANDOM"
+
+  # "$BASH", not "bash": vulkan.sh needs an associative array, and a stray
+  # bash 3.2 earlier in PATH would silently drop the AMD entry instead.
+  PATH="$stub_bin:$PATH" \
+  OMARCHY_PCI_DEVICES_PATH="$pci_path" \
+  OMARCHY_TEST_CALLS="$calls" \
+    "$BASH" -c '
+      omarchy-pkg-add() { printf "%s\n" "$@" >>"$OMARCHY_TEST_CALLS"; }
+      source "$1"
+    ' _ "$vulkan" >/dev/null 2>&1
+
+  [[ -f $calls ]] && cat "$calls" || true
+}
+
+# Pre-GCN: radeon-driven AMD GPUs cannot be used by RADV, and the ICD that
+# vulkan-radeon drops in would otherwise make omarchy-hw-vulkan answer yes.
+pre_gcn=$(make_pci_tree radeon)
+result=$(installed_packages "$pre_gcn")
+[[ $result != *vulkan-radeon* ]] ||
+  fail "vulkan-radeon is skipped on a pre-GCN AMD GPU bound to radeon (got: $result)"
+pass "pre-GCN AMD GPUs on the radeon driver do not get vulkan-radeon"
+
+# GCN and newer still must, or every supported AMD machine loses Vulkan.
+gcn=$(make_pci_tree amdgpu)
+result=$(installed_packages "$gcn")
+[[ $result == *vulkan-radeon* ]] ||
+  fail "vulkan-radeon is still installed for an amdgpu-bound GPU (got: $result)"
+pass "AMD GPUs on the amdgpu driver still get vulkan-radeon"
+
+# A GPU with no bound driver at all is not a working Vulkan target either.
+unbound="$test_tmp/pci-unbound"
+mkdir -p "$unbound/0000:01:00.0"
+echo "0x1002" >"$unbound/0000:01:00.0/vendor"
+echo "0x030000" >"$unbound/0000:01:00.0/class"
+result=$(installed_packages "$unbound")
+[[ $result != *vulkan-radeon* ]] ||
+  fail "vulkan-radeon is skipped when no driver is bound to the AMD GPU (got: $result)"
+pass "an AMD GPU with no bound driver does not get vulkan-radeon"
+
+# The AMD guard must not touch the other vendors' drivers.
+result=$(STUB_GPU_VENDOR="Intel Corporation" installed_packages "$pre_gcn")
+[[ $result == *vulkan-intel* ]] ||
+  fail "Intel GPUs still get vulkan-intel regardless of the AMD guard (got: $result)"
+pass "the AMD guard leaves vulkan-intel selection alone"


### PR DESCRIPTION
Three hardware fixes found while bringing Omarchy up on a 2007 iMac (iMac7,1 — Core 2 Duo, Radeon HD 2400 XT / RV610, BCM4321). All three affect any pre-GCN AMD machine, not just Apple hardware.

Verified on the machine itself against the stock Arch packages — `hyprland 0.56.2-2`, `aquamarine 0.15.0-2`, `mesa 26.2.2`. Hyprland does run on this GPU: it falls back to a GLES 3.0 context and to the legacy DRM interface, and holds 60 Hz at 1680x1050 with blur and shadows on. These three fixes are what stood between that and a clean install.

## 1. `broadcom-wl-dkms` for BCM4321

`fix-bcm43xx.sh` matched only `14e4:43a0` and `14e4:4331`. The 2007–2008 iMacs and MacBooks ship a BCM4321 (`14e4:4328`, also `4329`/`432a`), which the `wl` driver covers alongside the two already listed. Without it the machine installs with no wireless at all.

Folded the id checks into a single `grep -qE` so the list stays readable at five ids.

## 2. Skip `vulkan-radeon` on pre-GCN AMD GPUs

RADV only drives GPUs bound to `amdgpu`. On a `radeon`-driven card `vulkan-radeon` still installs `radeon_icd.json`, and enumeration then fails:

```
WARNING: radv_physical_device.c:2564: Device '/dev/dri/renderD128' is not using
         the AMDGPU kernel driver: Invalid argument (VK_ERROR_INCOMPATIBLE_DRIVER)
ERROR:   setup_loader_term_phys_devs: Failed to detect any valid GPUs in the current config
```

That stray ICD is all `omarchy-hw-vulkan` looks for, so it answered **yes** on a machine with no working Vulkan — and `omarchy-voxtype-install` runs `voxtype setup gpu --enable` off the back of that check. Not installing the ICD on hardware RADV cannot drive makes the probe honest again.

## 3. Hide nightlight where the GPU cannot apply a CTM

`hyprsunset` sends its temperature to Hyprland as a colour transform matrix over `hyprland-ctm-control-v1`, and aquamarine submits a CTM only on the DRM atomic path — `impl/Legacy.cpp` never does. On `radeon`, Hyprland logs:

```
drm: failed to set DRM_CLIENT_CAP_ATOMIC, falling back to legacy
drm: connector LVDS-1 crtc doesn't support CTM
```

The request is accepted and dropped, so `hyprctl hyprsunset temperature 4000` returns `ok`, the value reads back as `4000`, the shell's nightlight state flips to "on" — and the panel never changes. Screenshots taken at 6500K and 4000K were identical. It is a silent no-op rather than an error, which is the part worth fixing.

`omarchy-hw-nightlight` answers no only when *every* DRM card is on `radeon`, so a machine that also has an atomic-capable GPU keeps the feature. The menu drops the row, and `omarchy-toggle-nightlight` refuses up front rather than running its retry loop and reporting a success nobody can see.

**This is the most opinionated of the three.** It hides a UI element based on driver-name inference, because there is no shell-visible way to ask whether a CRTC exposes a CTM property. Happy to drop this commit and land only 1 and 2 if you would rather handle it differently.

## Testing

New test files:

- `test/shell.d/broadcom-wifi-test.sh` — 3 assertions, including a regression guard for BCM4360/BCM4331
- `test/shell.d/vulkan-hardware-test.sh` — 4 assertions (radeon skips, amdgpu still installs, unbound driver skips, Intel unaffected)
- `test/shell.d/nightlight-hardware-test.sh` — 5 assertions, including the mixed-GPU and empty-tree cases

`test/shell.d/nightlight-test.sh` gains a stub for the new capability probe plus 2 assertions for the unsupported path; its existing 14 assertions still pass.

Full `./test/shell` on Linux / bash 5.2: **20 failures before and after**, against a clean clone of `quattro` (the 20 are missing `magick` and `lua` in my environment, not related to these changes). `./test/cli` is unchanged.

One note for anyone running these on a Mac: `install/hardware/vulkan.sh` needs bash 5, since `declare -A` silently drops the AMD entry under the bash 3.2 that ships with macOS. The test invokes `"$BASH"` rather than `bash` for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUboE7GBC75XXqJC1pYUSk
