### PR TITLE
Offer outputs from inactive card profiles in the audio picker

### DIFF
--- a/bin/omarchy-audio-card-output-select
+++ b/bin/omarchy-audio-card-output-select
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# omarchy:summary=Activate a card profile and make its output the default sink
+# omarchy:group=audio
+# omarchy:args=<card-name> <profile-name> [route-name]
+# omarchy:hidden=true
+
+# Counterpart to omarchy-audio-card-outputs: selecting one of the outputs it
+# lists means activating the profile that carries it, because the sink does not
+# exist until then. The sink appears asynchronously once WirePlumber has applied
+# the profile, so wait for it before handing off to the normal default-sink path.
+
+card=${1:-}
+profile=${2:-}
+route=${3:-}
+
+if [[ -z $card || -z $profile ]]; then
+  echo "Usage: omarchy-audio-card-output-select <card-name> <profile-name> [route-name]" >&2
+  exit 1
+fi
+
+timeout 2 pactl set-card-profile "$card" "$profile" || exit 1
+
+# Sinks are named after the card's bus path, which is the card name past its
+# "alsa_card." prefix; that is what ties a sink back to the card it came from.
+suffix=${card#alsa_card.}
+
+for _ in {1..20}; do
+  read -r index name < <(
+    timeout 2 pactl -f json list sinks 2>/dev/null | jq -r --arg suffix "$suffix" --arg route "$route" '
+      [ .[]
+        | select(.name | contains($suffix))
+        | select($route == "" or .active_port == $route) ]
+      | sort_by(-(.index)) | first
+      | if . == null then empty else "\(.index) \(.name)" end
+    '
+  )
+
+  if [[ -n $index && -n $name ]]; then
+    omarchy-audio-output-set-default "$index" "$name"
+    exit 0
+  fi
+
+  sleep 0.1
+done
+
+echo "No sink appeared for profile '$profile' on card '$card'" >&2
+exit 1

--- a/bin/omarchy-audio-card-outputs
+++ b/bin/omarchy-audio-card-outputs
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# omarchy:summary=Print audio outputs reachable only by switching card profile
+# omarchy:group=audio
+# omarchy:hidden=true
+
+# Some cards expose their outputs as MUTUALLY EXCLUSIVE profiles rather than as
+# ports of a single profile: laptop UCM cards split Speaker and Headphones into
+# sibling HiFi profiles, and GPU cards put each HDMI/DP connector in its own
+# profile. Only the active profile's ports get sinks, so every other profile's
+# outputs are invisible to a picker that enumerates sinks alone -- on a docked
+# laptop that is usually the internal speakers.
+#
+# PipeWire's EnumRoute carries direction, availability, and the owning profile
+# indices for every route on the card, including routes belonging to inactive
+# profiles, which is what makes those outputs discoverable at all. PulseAudio's
+# card list has no route direction, so this reads pw-dump rather than pactl.
+#
+# Emits one TSV row per reachable-but-inactive output:
+#   card-name <TAB> profile-name <TAB> label <TAB> route-name
+
+pw-dump 2>/dev/null | jq -r '
+  .[]
+  | select(.type == "PipeWire:Interface:Device")
+  | select(.info.params.EnumRoute != null)
+  | . as $dev
+  | ($dev.info.props["device.name"] // "") as $card
+  | ($dev.info.params.Profile[0].index // -1) as $active
+  | ([ $dev.info.params.EnumProfile[]?
+       | select(.available != "no")
+       | select(.name != "off" and .name != "pro-audio")
+       | {key: (.index | tostring), value: .} ] | from_entries) as $profiles
+  | select($card != "")
+  | $dev.info.params.EnumRoute[]?
+  | select(.direction == "Output")
+  | select(.available != "no")
+  | select(([ .profiles[]? ] | index($active)) == null)
+  | . as $route
+  | ([ .profiles[]? | tostring as $key | $profiles[$key] // empty ]
+     | sort_by(-.priority) | first) as $profile
+  | select($profile != null)
+  | [ $card, $profile.name, ($route.description // $route.name), $route.name ]
+  | @tsv
+'

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -47,6 +47,28 @@ function parseSinkAvailability(raw) {
   return next
 }
 
+// Outputs carried by a card profile that is not active have no sink to
+// enumerate, so they arrive as TSV from omarchy-audio-card-outputs and are
+// rendered from these descriptors. They are plain objects rather than PwNodes;
+// isProfileOutput is what the panel branches on when one is selected.
+function parseCardOutputs(raw) {
+  var list = []
+  var lines = String(raw || "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    if (!lines[i].trim()) continue
+    var parts = lines[i].split("\t")
+    if (parts.length < 4) continue
+    list.push({
+      isProfileOutput: true,
+      card: parts[0],
+      profile: parts[1],
+      description: parts[2],
+      name: parts[3]
+    })
+  }
+  return list
+}
+
 function friendlyDeviceLabel(text) {
   var label = String(text || "").trim()
   label = label.replace(/^sof-soundwire\s+/i, "")
@@ -240,6 +262,7 @@ if (typeof module !== "undefined") {
     listSnapshot: listSnapshot,
     outputVolumeName: outputVolumeName,
     parseSinkAvailability: parseSinkAvailability,
+    parseCardOutputs: parseCardOutputs,
     friendlyDeviceLabel: friendlyDeviceLabel,
     nodeProps: nodeProps,
     nodeLabel: nodeLabel,

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -58,6 +58,10 @@ Panel {
   property var sinkAvailability: ({})
   property bool sinkAvailabilityLoaded: false
 
+  // Outputs belonging to a card profile that is not active, which therefore
+  // have no sink of their own to enumerate. Descriptors, not PwNodes.
+  property var cardOutputs: []
+
   // Identify true playback streams without reading node.properties here:
   // PwNode.properties is invalid until the node is bound, and reading it while
   // capture streams are appearing (for example, when Voxtype starts recording)
@@ -81,6 +85,10 @@ Panel {
     for (var i = 0; i < candidateSinks.length; i++)
       if (sinkAvailable(candidateSinks[i])) list.push(candidateSinks[i])
     if (sink && list.indexOf(sink) < 0) list.unshift(sink)
+    // Cards that split their outputs across mutually exclusive profiles only
+    // publish sinks for the active one. Append the rest so the picker can
+    // still offer them; selecting one activates the profile that carries it.
+    for (var j = 0; j < cardOutputs.length; j++) list.push(cardOutputs[j])
     return list
   }
 
@@ -462,6 +470,17 @@ Panel {
 
   function setDefaultSink(node) {
     if (!node) return
+    // A profile output has no node to prefer yet: the sink comes into
+    // existence only once its card profile has been activated.
+    if (node.isProfileOutput) {
+      Quickshell.execDetached([
+        "omarchy-audio-card-output-select",
+        String(node.card),
+        String(node.profile),
+        String(node.name)
+      ])
+      return
+    }
     Pipewire.preferredDefaultAudioSink = node
     if (node.id !== undefined && node.name) {
       Quickshell.execDetached([
@@ -493,6 +512,10 @@ Panel {
   function updateSinkAvailability(raw) {
     sinkAvailability = Model.parseSinkAvailability(raw)
     sinkAvailabilityLoaded = true
+  }
+
+  function updateCardOutputs(raw) {
+    cardOutputs = Model.parseCardOutputs(raw)
   }
 
   function friendlyDeviceLabel(text) {
@@ -593,6 +616,15 @@ Panel {
   }
 
   Process {
+    id: cardOutputsProc
+    command: ["omarchy-audio-card-outputs"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updateCardOutputs(text)
+    }
+  }
+
+  Process {
     id: volumeSinkProc
     command: ["omarchy-audio-output-sink"]
     stdout: StdioCollector {
@@ -606,7 +638,10 @@ Panel {
     running: root.opened
     repeat: true
     triggeredOnStart: true
-    onTriggered: if (!sinkAvailabilityProc.running) sinkAvailabilityProc.running = true
+    onTriggered: {
+      if (!sinkAvailabilityProc.running) sinkAvailabilityProc.running = true
+      if (!cardOutputsProc.running) cardOutputsProc.running = true
+    }
   }
 
   // Runs whether or not the panel is open: the bar shows and scrolls the output
@@ -1015,7 +1050,8 @@ Panel {
     required property var node
     required property int rowIndex
 
-    readonly property bool isActive: root.sink && node && root.sink.id === node.id
+    readonly property bool isActive: root.sink && node && !node.isProfileOutput
+      && root.sink.id === node.id
     hasCursor: root.cursorActive && root.focusSection === "output" && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sinkRow)
     current: isActive

--- a/test/shell.d/audio-test.sh
+++ b/test/shell.d/audio-test.sh
@@ -19,6 +19,14 @@ assertEqual(audio.outputVolumeName(0.5, true), 'Muted', 'audio labels muted outp
 
 assertDeepEqual(audio.parseSinkAvailability('alsa_output\t1\nhdmi_output\t0\n'), { alsa_output: true, hdmi_output: false }, 'audio parses sink availability')
 assertEqual(audio.friendlyDeviceLabel('Built-in Audio Speakers Output'), 'Speakers', 'audio cleans device labels')
+
+assertDeepEqual(
+  audio.parseCardOutputs('alsa_card.pci\tHiFi (Mic1, Speaker)\tSpeaker\t[Out] Speaker\n'),
+  [{ isProfileOutput: true, card: 'alsa_card.pci', profile: 'HiFi (Mic1, Speaker)', description: 'Speaker', name: '[Out] Speaker' }],
+  'audio parses outputs reachable only by switching card profile'
+)
+assertDeepEqual(audio.parseCardOutputs(''), [], 'audio parses no card outputs when every profile output already has a sink')
+assertDeepEqual(audio.parseCardOutputs('\nalsa_card.pci\tHiFi\n'), [], 'audio ignores card output rows missing fields')
 assertEqual(
   audio.nodeLabel({ ready: true, properties: { 'node.nick': 'Built-in Audio Microphones Input' }, name: 'alsa_input' }),
   'Microphone',


### PR DESCRIPTION
Fixes #8789, and removes the "no way back" half of #8290.

## The problem

Some cards spread their outputs across **mutually exclusive profiles** instead of exposing them as ports of one profile. Only the active profile publishes sinks, so the picker — which enumerates `Pipewire.nodes` sinks — cannot see or select any of the others:

- **Laptop UCM cards** put `Speaker` and `Headphones` in sibling HiFi profiles. Every Intel SOF `sof-hda-dsp` machine is like this.
- **GPU cards** give each HDMI/DP connector its own profile (#8789's original report).

The laptop case is the common one, and it is monitor-dependent. `find-best-profile.lua` picks by priority among profiles reporting `available == "yes"`, and profile availability is per-*profile*, not per-*port*. An attached monitor keeps HDMI1 available, which marks **both** HiFi profiles available, so priority alone decides — and Headphones (10300) outranks Speaker (10200) even with an empty jack:

```
HiFi (HDMI1, HDMI2, HDMI3, Headphones, Mic1, Mic2)  priority: 10300  available: yes   <- selected
HiFi (HDMI1, HDMI2, HDMI3, Mic1, Mic2, Speaker)     priority: 10200  available: yes

[Out] HDMI1      : available        <- monitor attached
[Out] Headphones : not available    <- empty jack
[Out] Speaker    : availability unknown
```

So on a docked laptop, on a **stock install**, the internal speakers are absent from the audio menu with no in-UI way back — `pactl set-card-profile` is the only recovery, and it does not survive a restart.

## The change

`bin/omarchy-audio-card-outputs` reports outputs that exist only inside a profile that is not active. It reads `pw-dump` rather than `pactl`: PipeWire's `EnumRoute` carries `direction`, `available`, and the owning profile indices for **every** route on the card, including routes of inactive profiles. PulseAudio's card list has no route direction at all, and `[Out]`/`[In]` is UCM naming rather than a direction marker, so it cannot be relied on (the GPU card in #8789 names its ports `hdmi-output-0`).

`bin/omarchy-audio-card-output-select` activates the profile carrying a chosen output, waits for its sink to appear, then hands off to the existing `omarchy-audio-output-set-default` path.

The panel polls the first helper on the 5s timer it already runs for sink availability, appends the descriptors to `rawAudioSinks`, and branches in `setDefaultSink` on `isProfileOutput`. Descriptors are plain objects, not `PwNode`s, and are added after `candidateSinks` so they never reach `PwObjectTracker`. Both the mouse and keyboard paths already funnel through `setDefaultSink`, so both are covered by the one branch.

## Verification

On a ThinkPad X1 Carbon 7th (ALC285 / `sof-hda-dsp`) with an external monitor attached and an empty jack, starting from the broken state where the Headphones profile is active and no Speaker sink exists:

```
BEFORE: profile=HiFi (HDMI1, HDMI2, HDMI3, Headphones, Mic1, Mic2)
BEFORE: speaker_sinks=0 default=HiFi__HDMI1__sink
        <- select "Speaker" in the panel
AFTER : profile=HiFi (HDMI1, HDMI2, HDMI3, Mic1, Mic2, Speaker)
AFTER : speaker_sinks=1 default=HiFi__Speaker__sink
```

The new row renders correctly in the panel and was driven through the real UI (keyboard cursor + Enter), not just by calling the helpers. `./test/cli` passes; `./test/shell` shows no failures attributable to this change; `test/shell.d/audio-test.sh` covers the new parser.

I do not have a dual-HDMI GPU card to hand, so #8789's original configuration is covered by construction rather than by test — the helper is card-agnostic and keys off route direction and profile membership, but a check from that reporter would be worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaKn7hHVzAWtWyrQNbNk9c
