### PR TITLE
Add basecamp (basecamp-cli) as a lazy-installed mise tool

### DIFF
--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -18,6 +18,7 @@ omarchy-cmd-missing cursor-agent && omarchy-mise-install cursor-agent
 omarchy-mise-install npm:@kitlangton/ghui ghui
 omarchy-mise-install aqua:modem-dev/hunk hunk
 omarchy-mise-install github:basecamp/hey-cli hey
+omarchy-mise-install github:basecamp/basecamp-cli basecamp
 omarchy-mise-install github:OpenRouterLabs/ori-releases ori
 # Every line above writes a stub and cannot fail. This one can: it exits
 # non-zero when Hermes Desktop owns Hermes but has not finished setting it up,

--- a/migrations/1788941927.sh
+++ b/migrations/1788941927.sh
@@ -1,0 +1,5 @@
+echo "Install basecamp (basecamp-cli) via mise wrapper"
+
+if [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
+  omarchy-mise-install github:basecamp/basecamp-cli basecamp
+fi


### PR DESCRIPTION
Adds the Basecamp CLI (`basecamp`) alongside `hey`, using the same lazy mise stub.

`omarchy-mise-install github:basecamp/basecamp-cli basecamp` writes a wrapper to `~/.local/bin/basecamp` that installs and upgrades through mise on first run, so the CLI keeps tracking releases rather than going stale. This matters in practice: an agent following the current Basecamp skill against a manually installed 0.9.1 binary silently posts broken message bodies, because stdin `-` support only landed in 0.10.0.

The `github:` backend resolves the same way it does for hey-cli — the repo is `basecamp-cli` but the release asset and binary are `basecamp`, exactly mirroring `hey-cli`/`hey`.

Verified: the generated stub installs and runs 0.10.0 end to end against an isolated mise data dir and config.

Same two-file shape as #7626 (hey): the `install/user/mise.sh` line for fresh installs, and a migration so existing machines get the stub too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
