### PR TITLE
Keep lock password field focused

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -48,8 +48,16 @@ Item {
   signal clearFailureRequested()
   signal wakeRequested()
 
+  function passwordFocusAllowed() {
+    return inputEnabled && !authenticatingPassword
+  }
+
+  function schedulePasswordFocus() {
+    if (passwordFocusAllowed()) Qt.callLater(forcePasswordFocus)
+  }
+
   function forcePasswordFocus() {
-    passwordInput.forceActiveFocus()
+    if (passwordFocusAllowed() && passwordInput.enabled) passwordInput.forceActiveFocus()
   }
 
   function clearPassword() {
@@ -64,12 +72,11 @@ Item {
   }
 
   onPasswordTextChanged: syncPasswordText()
-  onInputEnabledChanged: {
-    if (inputEnabled) Qt.callLater(forcePasswordFocus)
-  }
+  onInputEnabledChanged: schedulePasswordFocus()
+  onAuthenticatingPasswordChanged: schedulePasswordFocus()
   Component.onCompleted: {
     syncPasswordText()
-    if (inputEnabled) Qt.callLater(forcePasswordFocus)
+    schedulePasswordFocus()
   }
 
   // Measures the masked password at full size; passwordDotScale compares this
@@ -143,6 +150,7 @@ Item {
         verticalAlignment: TextInput.AlignVCenter
         horizontalAlignment: TextInput.AlignHCenter
         activeFocusOnPress: true
+        focus: root.passwordFocusAllowed()
         clip: true
         enabled: root.inputEnabled && !root.authenticatingPassword
         readOnly: root.authenticatingPassword
@@ -160,6 +168,10 @@ Item {
           width: 2
           color: Color.lock.text
           visible: passwordInput.cursorVisible
+        }
+
+        onActiveFocusChanged: {
+          if (!activeFocus) root.schedulePasswordFocus()
         }
 
         onTextChanged: {

--- a/test/shell.d/lock-focus-test.sh
+++ b/test/shell.d/lock-focus-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const lockView = fs.readFileSync(path.join(root, 'shell/plugins/lock/LockView.qml'), 'utf8')
+
+assert(
+  /function\s+passwordFocusAllowed\(\)\s*{[\s\S]*?return\s+inputEnabled\s+&&\s+!authenticatingPassword[\s\S]*?}/.test(lockView),
+  'lock password focus is allowed only while the field can accept input'
+)
+
+assert(
+  /onInputEnabledChanged:\s*schedulePasswordFocus\(\)/.test(lockView) &&
+    /onAuthenticatingPasswordChanged:\s*schedulePasswordFocus\(\)/.test(lockView),
+  'lock password focus is rescheduled when input becomes available'
+)
+
+assert(
+  /focus:\s*root\.passwordFocusAllowed\(\)/.test(lockView) &&
+    /onActiveFocusChanged:\s*{[\s\S]*?if\s*\(!activeFocus\)\s*root\.schedulePasswordFocus\(\)[\s\S]*?}/.test(lockView),
+  'lock password input reclaims focus if it is lost while locked'
+)
+JS


### PR DESCRIPTION
## Summary
- keep the lock screen password TextInput as the active focus target whenever password input is available
- reschedule focus after password authentication finishes
- add shell coverage for the lock focus guard and recovery hooks

## Tests
- ./test/shell.d/lock-focus-test.sh
- ./test/shell (timed out after 120s in this environment after passing the new lock focus test and continuing through later suites)