### PR TITLE
Ask for a language at setup, and offer one in the menu

### DIFF
--- a/bin/omarchy-locale-list
+++ b/bin/omarchy-locale-list
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# omarchy:summary=List the UTF-8 locales glibc can generate, with their names
+# omarchy:group=setup
+# omarchy:hidden=true
+
+# Emits "name<TAB>language<TAB>territory", one per line.
+#
+# The name is /usr/share/i18n/SUPPORTED's first field, verbatim. That field is
+# what systemd-localed compares a requested locale against before agreeing to
+# generate one, and it is also the name locale-gen hands to localedef -- so it
+# is the only spelling that survives the whole round trip. About half the
+# entries carry a codeset (en_US.UTF-8) and half do not (aa_ER, be_BY@latin);
+# neither form may be rewritten into the other.
+#
+# The names come from each locale's own LC_IDENTIFICATION block, so this
+# tracks whatever glibc ships rather than a hand-kept list. C.UTF-8 names no
+# language and is left out: it is a fallback, not a language to offer.
+
+set -euo pipefail
+
+SUPPORTED=/usr/share/i18n/SUPPORTED
+LOCALES=/usr/share/i18n/locales
+
+[[ -f $SUPPORTED ]] || exit 0
+
+awk -v locales="$LOCALES" '
+  $2 == "UTF-8" {
+    name = $1
+    base = name
+    sub(/\.UTF-8$/, "", base)
+    file = locales "/" base
+
+    language = ""
+    territory = ""
+    while ((getline line < file) > 0) {
+      if (language == "" && line ~ /^language[ \t]+"/) {
+        language = line
+        sub(/^language[ \t]+"/, "", language)
+        sub(/".*$/, "", language)
+      } else if (territory == "" && line ~ /^territory[ \t]+"/) {
+        territory = line
+        sub(/^territory[ \t]+"/, "", territory)
+        sub(/".*$/, "", territory)
+      }
+      if (language != "" && territory != "") break
+    }
+    close(file)
+
+    if (language != "") print name "\t" language "\t" territory
+  }
+' "$SUPPORTED"

--- a/bin/omarchy-menu-language
+++ b/bin/omarchy-menu-language
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# omarchy:summary=Select and set the system language
+# omarchy:group=menu
+# omarchy:name=language
+
+set -e
+
+current=$(localectl status 2>/dev/null | sed -n 's/.*LANG=\([^ ]*\).*/\1/p' | head -1 || true)
+
+# "<glyph>\t<label>\t<subtext>": the menu shows the glyph and never returns it,
+# and hands back "<label>\t<subtext>", so the locale name rides along as the
+# subtext and comes back as the stable key.
+language=$(omarchy-locale-list |
+  awk -F'\t' -v current="$current" '
+    {
+      label = $2 ($3 != "" ? " (" $3 ")" : "")
+      printf "%s\t%s\t%s\n", ($1 == current ? "󰄬" : "󰗊"), label, $1
+    }' |
+  sort -t$'\t' -k2,2 |
+  omarchy-menu-select "Set language" -- --width 520 --maxheight 520) || exit 1
+
+language=${language##*$'\t'}
+[[ -n $language ]] || exit 1
+
+# localectl generates the locale on the way through when nobody has yet.
+localectl set-locale "LANG=$language"
+
+# LANG is read at login, so this is the one setting that cannot finish here.
+omarchy-notification-send "Language is now set to $language" "Log out and back in to apply it"

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -651,6 +651,9 @@ user_form() {
 
   step "Let's set your timezone..."
   omarchy_prompt_timezone || return $?
+
+  step "Let's set your language..."
+  omarchy_prompt_language || return $?
 }
 
 confirm_form() {
@@ -663,7 +666,8 @@ Password,$(printf "%${#password}s" | tr ' ' '*')
 Full name,${full_name:-[Skipped]}
 Email address,${email_address:-[Skipped]}
 Hostname,${hostname:-omarchy}
-Timezone,${timezone:-UTC}" |
+Timezone,${timezone:-UTC}
+Language,${language_label:-American English (United States)}" |
     gum table -s "," -p | sed "s/^/${PADDING_LEFT_SPACES}/"
 
   echo
@@ -829,6 +833,25 @@ configure_timezone() {
   # /etc/localtime at nothing and break every localtime read afterward.
   [[ -e /usr/share/zoneinfo/$timezone ]] &&
     ln -sf "/usr/share/zoneinfo/$timezone" /etc/localtime 2>&1 || true
+}
+
+# Apply the owner's language, deferred to first boot with the rest of the user
+# step. systemd-firstboot writes /etc/locale.conf; localectl is the fallback,
+# and it is also what generates a locale nobody has generated yet, so a machine
+# whose owner does not speak the image's language still gets a working one. A
+# locale glibc does not know keeps the default rather than failing setup over
+# a language.
+configure_language() {
+  [[ -n ${language:-} ]] || return 0
+
+  if ! omarchy-locale-list | awk -F'\t' -v want="$language" '$1 == want { found = 1 } END { exit !found }'; then
+    log_step "locale $language unknown to glibc; keeping the default"
+    return 0
+  fi
+
+  systemd-firstboot --locale="$language" --force 2>&1 ||
+    localectl set-locale "LANG=$language" 2>&1 ||
+    log_step "could not persist locale $language"
 }
 
 finalize_user() {
@@ -1009,6 +1032,7 @@ run_provisioning() {
 
   log_step "setting timezone to ${timezone:-UTC}"
   configure_timezone
+  configure_language
 
   log_step "finalizing user"
   echo finalize >"$STATE_FILE"

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -357,6 +357,7 @@
   "update.firmware": {"icon":"","label":"Firmware","action":"omarchy-launch-floating-terminal-with-presentation omarchy-update-firmware"},
   "update.password": {"icon":"","label":"Password"},
   "update.timezone": {"icon":"","label":"Timezone","action":"omarchy-menu-timezone"},
+  "update.language": {"icon":"󰗊","label":"Language","aliases":["locale"],"action":"omarchy-menu-language"},
   "update.time": {"icon":"","label":"Time","action":"omarchy-launch-floating-terminal-with-presentation omarchy-update-time"},
   "update.channel.stable": {"icon":"🟢","label":"Stable","checked":"[[ \"$(omarchy-channel-current)\" == \"stable\" ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-channel-set stable'"},
   "update.channel.rc": {"icon":"🟡","label":"RC","checked":"[[ \"$(omarchy-channel-current)\" == \"rc\" ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-channel-set rc'"},

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -18,7 +18,8 @@
 # so it never reaches the shell as SIGINT. Act on the status, never on a trap.
 #
 # Callers supply `notice <message> <seconds>` for validation feedback, and set
-# the variables these prompts write: keyboard, keyboard_label, username,
+# the variables these prompts write: keyboard, keyboard_label, language,
+# language_label, username,
 # password, password_confirmation, full_name, email_address, hostname, timezone.
 
 OMARCHY_FORM_BACK=1
@@ -99,6 +100,39 @@ omarchy_prompt_keyboard() {
 
   keyboard_label="$choice"
   keyboard=$(printf '%s\n' "$OMARCHY_KEYBOARD_LAYOUTS" | awk -F'|' -v c="$choice" '$1==c{print $2; exit}')
+}
+
+# gum filter rather than gum choose because the list is three hundred long --
+# the same reason the timezone prompt filters.
+#
+# The default is not derived from the keyboard layout, tempting as that is.
+# Layout codes are country codes and locale prefixes are language codes, and
+# they collide: the Slovenian layout is "si", while si_LK is Sinhala. A guess
+# that confident and that wrong is worse than no guess, and filtering for
+# "Slov" costs four keystrokes.
+OMARCHY_LANGUAGE_DEFAULT="American English (United States)"
+
+omarchy_prompt_language() {
+  local choice status
+
+  choice=$(omarchy_language_labels |
+    gum filter --height 10 --header "Select language" --value "$OMARCHY_LANGUAGE_DEFAULT") && status=0 || status=$?
+  ((status == 0)) || return $status
+
+  # Nothing selected keeps the default rather than leaving the system with no
+  # language at all, the same way the timezone prompt falls back to UTC.
+  [[ -n $choice ]] || choice="$OMARCHY_LANGUAGE_DEFAULT"
+
+  language_label="$choice"
+  # No `exit` after the match: omarchy-locale-list is upstream in the pipe, and
+  # leaving early hands it a SIGPIPE that a `set -e` caller reads as failure.
+  language=$(omarchy-locale-list | awk -F'\t' -v c="$choice" '
+    { label = $2 ($3 != "" ? " (" $3 ")" : "") }
+    label == c && !found { found = 1; print $1 }')
+}
+
+omarchy_language_labels() {
+  omarchy-locale-list | awk -F'\t' '{ print $2 ($3 != "" ? " (" $3 ")" : "") }' | sort
 }
 
 omarchy_prompt_username() {

--- a/test/shell.d/setup-form-test.sh
+++ b/test/shell.d/setup-form-test.sh
@@ -70,10 +70,12 @@ printf 'full_name=%s\n' "${full_name:-}"
 printf 'email_address=%s\n' "${email_address:-}"
 printf 'hostname=%s\n' "${hostname:-}"
 printf 'timezone=%s\n' "${timezone:-}"
+printf 'language=%s\n' "${language:-}"
+printf 'language_label=%s\n' "${language_label:-}"
 EOF
 
 chmod +x "$tmp_dir/gum" "$tmp_dir/tzupdate" "$tmp_dir/timedatectl" "$tmp_dir/driver"
-export PATH="$tmp_dir:$PATH"
+export PATH="$tmp_dir:$PATH:$ROOT/bin"
 export GUM_DIR="$tmp_dir" GUM_SCRIPT="$tmp_dir/script" GUM_ARGS="$tmp_dir/args" GUM_COUNT="$tmp_dir/count"
 export NOTICES="$tmp_dir/notices" MARKER="$tmp_dir/marker"
 
@@ -208,6 +210,29 @@ run_prompt omarchy_prompt_hostname "1:"
 assert_status "$OMARCHY_FORM_BACK" "hostname prompt reports Esc as back"
 assert_returned "hostname prompt survives Esc under set -e"
 pass "hostname prompt propagates Esc without dying under set -e"
+
+# Language
+
+run_prompt omarchy_prompt_language "0:Slovenian (Slovenia)"
+assert_status 0 "language prompt accepts a choice"
+[[ $(field language) == "sl_SI.UTF-8" ]] || fail "language prompt maps the label back to the locale glibc names"
+[[ $(field language_label) == "Slovenian (Slovenia)" ]] || fail "language prompt keeps the label for the summary"
+[[ $(head -n 1 "$GUM_ARGS") == filter* ]] || fail "language prompt filters rather than paging three hundred options"
+pass "language prompt returns the locale name behind the label"
+
+run_prompt omarchy_prompt_language "0:"
+assert_status 0 "language prompt accepts an empty selection"
+[[ $(field language) == "en_US.UTF-8" ]] || fail "language prompt falls back to the default language"
+pass "language prompt falls back to English when nothing is selected"
+
+run_prompt omarchy_prompt_language "1:"
+assert_status "$OMARCHY_FORM_BACK" "language prompt reports Esc as back"
+assert_returned "language prompt survives Esc under set -e"
+
+run_prompt omarchy_prompt_language "130:"
+assert_status "$OMARCHY_FORM_SIGNAL" "language prompt reports Ctrl+C as the caller's signal"
+assert_returned "language prompt survives Ctrl+C under set -e"
+pass "language prompt propagates Esc and Ctrl+C without dying under set -e"
 
 # Timezone
 


### PR DESCRIPTION
Omarchy asks for a keyboard layout and derives everything else from it, so
`LANG` stays `en_US.UTF-8` until somebody edits `/etc/locale.gen` by hand and
runs `locale-gen`. There is no locale question at setup (#1187) and no way to
change it afterwards short of a terminal (#3161). A Slovenian desktop ends up
as translated applications sitting on an American locale — English dates,
Letter paper, `1,234.56`.

Two additions, both in shapes that already exist here.

**`omarchy-menu-language`** is `omarchy-menu-timezone` with `localectl` in
place of `timedatectl`: list, hand to `omarchy-menu-select`, apply, notify. It
sits at `update.language`, beside Timezone, where someone changing a system
setting already goes. The locale name rides along as the picker's subtext,
which `omarchy-menu-select` hands back as the stable key, so what comes back
is `sl_SI.UTF-8` rather than a label.

**The setup form** asks for a language beside the timezone, and
`configure_language` persists it with the rest of the owner's answers.

### This does not translate anything

Setting the system locale is what GTK and Qt applications, browsers and
`xdg-user-dirs` follow. The Omarchy interface stays English, and this PR takes
no position on whether it ever should be otherwise —
`shell/plugins/panels/clock/Panel.qml` says the interface is English
throughout, and nothing here disagrees with that.

### Three details worth a reviewer's eye

**Locale names go through verbatim.** `omarchy-locale-list` reads
`/usr/share/i18n/SUPPORTED` and each locale's own `LC_IDENTIFICATION` rather
than carrying a table, so it tracks whatever glibc ships. About half the
entries carry a codeset (`en_US.UTF-8`) and half do not (`aa_ER`,
`be_BY@latin`), and that first field is both what `systemd-localed` matches
before agreeing to generate a locale and what `locale-gen` hands to
`localedef`. Rewriting one form into the other breaks it.

**The setup default is not derived from the keyboard layout**, tempting as
that is. Layout codes are country codes and locale prefixes are language
codes, and they collide: the Slovenian layout is `si`, while `si_LK` is
Sinhala. I built that heuristic first and it confidently suggested Sinhala for
a Slovenian keyboard. A guess that wrong is worse than no guess, and filtering
for "Slov" costs four keystrokes.

**`configure_language` tries `systemd-firstboot` first and falls back to
`localectl`**, which is also what generates a locale nobody has generated yet
— so an owner who does not speak the image's language gets a working locale
rather than a named one that does not exist. A locale glibc does not know
keeps the default rather than failing setup over a language.

### Testing

`setup-form-test.sh` covers the new prompt, its fallback and its Esc/Ctrl+C
paths; `menu-test.sh` passes; the menu file still parses. The picker and the
menu row have been exercised on a running 4.0.2 desktop, switching that
machine to `sl_SI.UTF-8` and back.

---

Related but deliberately not in this PR: #7284 asks for a translation layer
for the shell's own strings, which is a much larger question and touches the
English-throughout decision directly. There's a prototype for that on a
separate branch, and it is not needed for any of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMv63sA2aQLdMTiF2MF5LB
