### PR TITLE
Read day and month names from the system locale

### DIFF
--- a/shell/plugins/panels/clock/BarWidget.qml
+++ b/shell/plugins/panels/clock/BarWidget.qml
@@ -57,7 +57,10 @@ BarWidget {
   }
 
   function formatted(date) {
-    return Qt.formatDateTime(date, activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
+    // Qt.formatDateTime() renders through the C locale whatever Qt.locale()
+    // resolves to, so "dddd" is always English. toLocaleString() takes the
+    // same format string and reads the locale.
+    return date.toLocaleString(Qt.locale(), activeFormat.replace(/ww/g, Model.isoWeekLiteral(date.getFullYear(), date.getMonth(), date.getDate())))
   }
 
   // ---- Calendar popup. Shape contract for shell.summon/hide/toggle

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -315,7 +315,7 @@ Panel {
                 id: heroDate
                 textFormat: Text.PlainText
                 anchors.verticalCenter: parent.verticalCenter
-                text: Qt.formatDate(root.today, "MMMM d")
+                text: root.today.toLocaleDateString(Qt.locale(), "MMMM d")
                 color: heroMouse.containsMouse
                   ? Style.hoverStateColor(root.contentForeground, Color.accent)
                   : root.contentForeground
@@ -723,7 +723,7 @@ Panel {
                 // "MAY 2026" and a "SEPTEMBER 2026".
                 width: Style.space(130)
                 horizontalAlignment: Text.AlignHCenter
-                text: Qt.formatDate(root.viewDate, "MMMM yyyy").toUpperCase()
+                text: root.viewDate.toLocaleDateString(Qt.locale(), "MMMM yyyy").toUpperCase()
                 color: Qt.darker(root.contentForeground, 1.4)
                 font.family: root.contentFontFamily
                 font.pixelSize: Style.font.body

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -308,7 +308,7 @@ Panel {
   }
 
   function dayName(dateString) {
-    return Model.dayName(dateString, function(date) { return Qt.formatDate(date, "dddd") })
+    return Model.dayName(dateString, function(date) { return date.toLocaleDateString(Qt.locale(), "dddd") })
   }
 
   // Bare degree value (no unit letter), used in the forecast row.

--- a/test/shell.d/clock-test.sh
+++ b/test/shell.d/clock-test.sh
@@ -212,7 +212,15 @@ assert(/function close\(\) \{\s*\n\s*setCenterHoverRevealSuppressed\(false\)/.te
 assert(/width: Math\.max\(calendarScroll\.width, gridColumn\.width\)/.test(panelSource), 'calendar scrolls rather than clipping the grid on a narrow popup')
 assert(/enabled: !root\.viewingCurrentMonth/.test(panelSource) && /onClicked: root\.goToToday\(\)/.test(panelSource), 'calendar hero returns to today once the view has stepped away')
 assert(!/clampMonth/.test(panelSource), 'calendar steps freely into future months')
-assert(/Qt\.formatDate\(root\.today, "MMMM d"\)/.test(panelSource), 'calendar hero spells out today')
+assert(/root\.today\.toLocaleDateString\(Qt\.locale\(\), "MMMM d"\)/.test(panelSource), 'calendar hero spells out today')
+
+// Qt.formatDate/Qt.formatDateTime render through the C locale whatever
+// Qt.locale() resolves to, so a "dddd" or "MMMM" that goes through either is
+// English on every system. Pin the locale-aware calls rather than the names
+// they produce, which depend on whoever is running the suite.
+assert(!/Qt\.format(Date|DateTime|Time)\(/.test(panelSource), 'calendar reads day and month names from the system locale')
+assert(!/Qt\.format(Date|DateTime|Time)\(/.test(widgetSource), 'bar clock reads day and month names from the system locale')
+assert(/date\.toLocaleString\(Qt\.locale\(\), activeFormat/.test(widgetSource), 'bar clock formats its label through the locale')
 assert(/id: yearLabel/.test(panelSource) && /root\.yearDone/.test(panelSource), 'calendar panel shows the year progress bar')
 
 // The memento mori bar is opt-in: double-tapping the year bar asks for an age,


### PR DESCRIPTION
`Qt.formatDate()` and `Qt.formatDateTime()` render format specifiers through the
C locale whatever `Qt.locale()` resolves to, so `dddd`, `MMMM` and `AP` come out
English on every system. #8600 and #7760 already have the diagnosis; this is the
fix.

In a Quickshell process whose `Qt.locale().name` is already `sl_SI`:

```
Qt.formatDateTime(d, "dddd HH:mm")           ->  Wednesday 12:40
d.toLocaleString(Qt.locale(), "dddd HH:mm")  ->  sreda 12:40
```

Same format string, same date. Four display call sites move to
`toLocaleString()` / `toLocaleDateString()`:

| file | what |
|---|---|
| `clock/BarWidget.qml` | the bar label |
| `clock/Panel.qml` | the calendar hero, and the month footer |
| `weather/Panel.qml` | the forecast day names |

**English output is unchanged, byte for byte, in all four.** Verified by running
both locales through an isolated Quickshell instance.

### Deliberately not touched

**The weather panel's other `Qt.formatDate()` calls.** They build `yyyy-MM-dd`
keys compared against forecast payloads. A locale has no business near those.

**The calendar's weekday headers** (#7211). Those are pinned to
`Qt.locale("en_US")` on purpose, with a comment saying the interface is English
throughout. That is a decision, not this bug, and it is independent of these
four lines whichever way it goes — which is why this closes the other three and
leaves #7211 open.

**Date order.** The hero reads `september 9` in Slovenian rather than
`9. september`, because the format string still says `MMMM d`. Getting order
right needs a month-day pattern taken from the locale, which Qt does not expose
directly (`dateFormat(LongFormat)` carries the year, and stripping it back out
is locale-specific guesswork). Worth doing, but bigger than this.

### Tests

`clock-test.sh` pinned the old call as source text, so it moves with the fix. It
now also refuses `Qt.formatDate`/`formatDateTime` anywhere in either clock file
— pinning the locale-aware call rather than the names it produces, which depend
on whoever runs the suite. `weather-test.sh` and `bar-widget-contract-test.sh`
pass unchanged.

### Relationship to the localization work

None. #7284 and #8765 would fix this as a side effect, but these four lines do
not need a framework and do not prejudge which one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMv63sA2aQLdMTiF2MF5LB
