### PR TITLE
Fix bar reordering for duplicate widgets

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -865,47 +865,22 @@ Item {
   }
 
   function rawEntryIndex(entries, name) {
-    for (var i = 0; i < entries.length; i++) {
-      if (root.entryId(entries[i]) === name) return i
-    }
-
-    return -1
+    return BarModel.entryIndex(entries, name)
   }
 
-  function moveModuleInConfig(config, fromRegion, fromName, toRegion, beforeName) {
-    var fromEntries = rawLayoutSection(config, fromRegion)
-    var toEntries = rawLayoutSection(config, toRegion)
-    var fromIndex = rawEntryIndex(fromEntries, fromName)
-    if (fromIndex < 0) return false
-
-    var toIndex = beforeName ? rawEntryIndex(toEntries, beforeName) : toEntries.length
-    if (toIndex < 0) toIndex = toEntries.length
-
-    if (fromRegion === toRegion && fromIndex === toIndex) return false
-
-    var movedEntry = fromEntries[fromIndex]
-    fromEntries.splice(fromIndex, 1)
-
-    if (fromRegion === toRegion && fromIndex < toIndex) toIndex -= 1
-    if (toIndex < 0) toIndex = 0
-    if (toIndex > toEntries.length) toIndex = toEntries.length
-    if (fromRegion === toRegion && fromIndex === toIndex) {
-      fromEntries.splice(fromIndex, 0, movedEntry)
-      return false
-    }
-
-    toEntries.splice(toIndex, 0, movedEntry)
-    return true
+  function moveModuleInConfig(config, fromRegion, fromName, toRegion, beforeName, fromIndex, toIndex) {
+    return BarModel.moveModuleInConfig(config, fromRegion, fromName, toRegion, beforeName, fromIndex, toIndex)
   }
 
-  function dropBarModule(source, toRegion, beforeName) {
-    if (!source || !source.region || !source.moduleName || !toRegion) return false
-    if (source.region === toRegion && source.moduleName === beforeName) return false
+  function dropBarModule(source, toRegion, beforeName, targetIndex) {
+    if (!source || !source.region || !toRegion) return false
+    var fromIndex = source.slotIndex !== undefined ? source.slotIndex : -1
+    if (fromIndex < 0 && !source.moduleName) return false
     if (!root.shell || typeof root.shell.mutateShellConfig !== "function") return false
 
     var changed = false
     root.shell.mutateShellConfig(function(config) {
-      changed = moveModuleInConfig(config, source.region, source.moduleName, toRegion, beforeName)
+      changed = moveModuleInConfig(config, source.region, source.moduleName, toRegion, beforeName, fromIndex, targetIndex)
     })
     return changed
   }
@@ -975,8 +950,9 @@ Item {
   function dropBarModuleAtTarget(sourceSlot, targetSlot, afterTarget) {
     if (!sourceSlot || !targetSlot) return false
 
+    var targetIndex = targetSlot.slotIndex !== undefined ? (targetSlot.slotIndex + (afterTarget ? 1 : 0)) : undefined
     var beforeName = afterTarget ? nextVisibleModuleName(targetSlot.region, targetSlot.moduleName, sourceSlot) : targetSlot.moduleName
-    return dropBarModule(sourceSlot, targetSlot.region, beforeName)
+    return dropBarModule(sourceSlot, targetSlot.region, beforeName, targetIndex)
   }
 
   function moduleTargetClickable(target) {
@@ -1566,6 +1542,7 @@ Item {
           visible: centerRoot.hasAnchor
           entries: root.entriesBefore(centerRoot.entries, root.centerAnchor)
           region: "center"
+          indexOffset: 0
           anchors.right: centerAnchorModule.left
           anchors.verticalCenter: centerAnchorModule.verticalCenter
         }
@@ -1575,6 +1552,7 @@ Item {
           visible: centerRoot.hasAnchor
           entry: centerRoot.anchorEntry
           region: "center"
+          slotIndex: root.entryIndex(centerRoot.entries, root.centerAnchor)
           anchors.centerIn: parent
         }
 
@@ -1582,6 +1560,7 @@ Item {
           visible: centerRoot.hasAnchor
           entries: root.entriesAfter(centerRoot.entries, root.centerAnchor)
           region: "center"
+          indexOffset: root.entryIndex(centerRoot.entries, root.centerAnchor) + 1
           anchors.left: centerAnchorModule.right
           anchors.verticalCenter: centerAnchorModule.verticalCenter
         }
@@ -1611,6 +1590,7 @@ Item {
           visible: centerRoot.hasAnchor
           entries: root.entriesBefore(centerRoot.entries, root.centerAnchor)
           region: "center"
+          indexOffset: 0
           anchors.bottom: centerAnchorModule.top
           anchors.horizontalCenter: centerAnchorModule.horizontalCenter
         }
@@ -1620,6 +1600,7 @@ Item {
           visible: centerRoot.hasAnchor
           entry: centerRoot.anchorEntry
           region: "center"
+          slotIndex: root.entryIndex(centerRoot.entries, root.centerAnchor)
           anchors.centerIn: parent
         }
 
@@ -1627,6 +1608,7 @@ Item {
           visible: centerRoot.hasAnchor
           entries: root.entriesAfter(centerRoot.entries, root.centerAnchor)
           region: "center"
+          indexOffset: root.entryIndex(centerRoot.entries, root.centerAnchor) + 1
           anchors.top: centerAnchorModule.bottom
           anchors.horizontalCenter: centerAnchorModule.horizontalCenter
         }
@@ -1721,6 +1703,7 @@ Item {
 
     property var entries: []
     property string region: ""
+    property int indexOffset: 0
 
     visible: entries.length > 0
     // A hidden list must not build its modules. The center section declares
@@ -1744,8 +1727,10 @@ Item {
 
           ModuleSlot {
             required property var modelData
+            required property int index
             entry: modelData
             region: moduleListRoot.region
+            slotIndex: moduleListRoot.indexOffset + index
           }
         }
       }
@@ -1762,8 +1747,10 @@ Item {
 
           ModuleSlot {
             required property var modelData
+            required property int index
             entry: modelData
             region: moduleListRoot.region
+            slotIndex: moduleListRoot.indexOffset + index
           }
         }
       }
@@ -1775,6 +1762,7 @@ Item {
 
     required property var entry
     property string region: ""
+    property int slotIndex: -1
     readonly property string moduleName: root.entryId(entry)
     readonly property var moduleSettings: root.entrySettings(entry)
     readonly property string customType: root.customModuleType(entry)

--- a/shell/plugins/bar/BarModel.js
+++ b/shell/plugins/bar/BarModel.js
@@ -65,6 +65,42 @@ function entriesAfter(entries, name) {
   return index === -1 ? [] : entries.slice(index + 1)
 }
 
+function moveModuleInConfig(config, fromRegion, fromName, toRegion, beforeName, fromIndexOverride, toIndexOverride) {
+  if (!isPlainObject(config.bar)) config.bar = {}
+  if (!isPlainObject(config.bar.layout)) config.bar.layout = {}
+  if (!Array.isArray(config.bar.layout[fromRegion])) config.bar.layout[fromRegion] = []
+  if (!Array.isArray(config.bar.layout[toRegion])) config.bar.layout[toRegion] = []
+
+  var fromEntries = config.bar.layout[fromRegion]
+  var toEntries = config.bar.layout[toRegion]
+
+  var fromIndex = (fromIndexOverride !== undefined && fromIndexOverride !== null && fromIndexOverride >= 0)
+    ? Math.floor(Number(fromIndexOverride))
+    : entryIndex(fromEntries, fromName)
+  if (fromIndex < 0 || fromIndex >= fromEntries.length) return false
+
+  var toIndex = (toIndexOverride !== undefined && toIndexOverride !== null && toIndexOverride >= 0)
+    ? Math.floor(Number(toIndexOverride))
+    : (beforeName ? entryIndex(toEntries, beforeName) : toEntries.length)
+  if (toIndex < 0) toIndex = toEntries.length
+
+  if (fromRegion === toRegion && (fromIndex === toIndex || fromIndex === toIndex - 1)) return false
+
+  var movedEntry = fromEntries[fromIndex]
+  fromEntries.splice(fromIndex, 1)
+
+  if (fromRegion === toRegion && fromIndex < toIndex) toIndex -= 1
+  if (toIndex < 0) toIndex = 0
+  if (toIndex > toEntries.length) toIndex = toEntries.length
+  if (fromRegion === toRegion && fromIndex === toIndex) {
+    fromEntries.splice(fromIndex, 0, movedEntry)
+    return false
+  }
+
+  toEntries.splice(toIndex, 0, movedEntry)
+  return true
+}
+
 // A shell.json write that only changes inline widget settings (the battery
 // percentage toggle, a clock format change) must not rebuild the bar.
 // Compare two normalized layouts: when the structure is unchanged — same
@@ -222,6 +258,7 @@ if (typeof module !== "undefined") {
     entryIndex: entryIndex,
     entriesBefore: entriesBefore,
     entriesAfter: entriesAfter,
+    moveModuleInConfig: moveModuleInConfig,
     inlineSettingsDelta: inlineSettingsDelta,
     expandPath: expandPath,
     customModuleSafeName: customModuleSafeName,

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -354,6 +354,111 @@ assertEqual(
   '/home/dhh/.config/omarchy/bar/modules/local.weather.qml',
   'bar builds default custom module paths'
 )
+
+// Bar drag-reorder moves the exact instance when multiple widgets share a module ID
+const s1 = { id: 'omarchy.spacer', minWidth: 20 }
+const s2 = { id: 'omarchy.spacer', minWidth: 80 }
+
+// 1. Moving second duplicate widget across sections
+const crossSectionLayout = {
+  bar: {
+    layout: {
+      left: ['omarchy.menu', s1, 'omarchy.workspaces', s2],
+      right: []
+    }
+  }
+}
+assertEqual(
+  bar.moveModuleInConfig(crossSectionLayout, 'left', 'omarchy.spacer', 'right', null, 3, 0),
+  true,
+  'moves second duplicate widget across sections'
+)
+assertEqual(crossSectionLayout.bar.layout.left.length, 3, 'source section loses moved widget')
+assertEqual(crossSectionLayout.bar.layout.left[1].minWidth, 20, 'first duplicate instance remains untouched at index 1')
+assertEqual(crossSectionLayout.bar.layout.right[0].minWidth, 80, 'second duplicate instance lands in destination section')
+
+// 2. Moving second duplicate widget before first
+const reorderBeforeLayout = {
+  bar: {
+    layout: {
+      left: ['omarchy.menu', s1, 'omarchy.workspaces', s2]
+    }
+  }
+}
+assertEqual(
+  bar.moveModuleInConfig(reorderBeforeLayout, 'left', 'omarchy.spacer', 'left', null, 3, 1),
+  true,
+  'moves second duplicate widget before first'
+)
+assertEqual(reorderBeforeLayout.bar.layout.left[1].minWidth, 80, 'second duplicate widget placed before first')
+assertEqual(reorderBeforeLayout.bar.layout.left[2].minWidth, 20, 'first duplicate widget shifted after second')
+
+// 3. Moving first duplicate widget after second
+const reorderAfterLayout = {
+  bar: {
+    layout: {
+      left: ['omarchy.menu', s1, 'omarchy.workspaces', s2]
+    }
+  }
+}
+assertEqual(
+  bar.moveModuleInConfig(reorderAfterLayout, 'left', 'omarchy.spacer', 'left', null, 1, 4),
+  true,
+  'moves first duplicate widget after second'
+)
+assertEqual(reorderAfterLayout.bar.layout.left[2].minWidth, 80, 'second duplicate widget shifted forward')
+assertEqual(reorderAfterLayout.bar.layout.left[3].minWidth, 20, 'first duplicate widget placed after second')
+
+// 4. Self-drop before itself
+const selfDropLayout = {
+  bar: {
+    layout: {
+      left: ['omarchy.menu', s1, 'omarchy.workspaces', s2]
+    }
+  }
+}
+assertEqual(
+  bar.moveModuleInConfig(selfDropLayout, 'left', 'omarchy.spacer', 'left', null, 1, 1),
+  false,
+  'self-drop before itself is a no-op'
+)
+assertEqual(selfDropLayout.bar.layout.left[1].minWidth, 20, 'layout untouched on self-drop before itself')
+
+// 5. Self-drop after itself
+assertEqual(
+  bar.moveModuleInConfig(selfDropLayout, 'left', 'omarchy.spacer', 'left', null, 1, 2),
+  false,
+  'self-drop after itself is a no-op'
+)
+assertEqual(selfDropLayout.bar.layout.left[1].minWidth, 20, 'layout untouched on self-drop after itself')
+
+// 6. Normal unique-widget movement
+const uniqueLayout = {
+  bar: {
+    layout: {
+      left: ['omarchy.menu', 'omarchy.workspaces', 'omarchy.clock'],
+      right: []
+    }
+  }
+}
+assertEqual(
+  bar.moveModuleInConfig(uniqueLayout, 'left', 'omarchy.clock', 'right', null),
+  true,
+  'normal unique-widget moves across sections by name'
+)
+assertDeepEqual(uniqueLayout.bar.layout.left, ['omarchy.menu', 'omarchy.workspaces'], 'source loses moved unique widget')
+assertDeepEqual(uniqueLayout.bar.layout.right, ['omarchy.clock'], 'destination gains moved unique widget')
+assertEqual(
+  bar.moveModuleInConfig(uniqueLayout, 'left', 'omarchy.workspaces', 'left', 'omarchy.menu'),
+  true,
+  'normal unique-widget moves before target by name'
+)
+assertDeepEqual(uniqueLayout.bar.layout.left, ['omarchy.workspaces', 'omarchy.menu'], 'unique widgets reordered by name')
+
+assert(
+  /BarModel\.moveModuleInConfig\(config, fromRegion, fromName, toRegion, beforeName, fromIndex, toIndex\)/.test(barSource),
+  'bar delegates module movement to BarModel with explicit indices'
+)
 JS
 
 put_tmp=$(mktemp -d)


### PR DESCRIPTION
## Summary

Fixes incorrect bar widget reordering when multiple instances of the same widget are present.

Previously, drag-and-drop identified the source and target only by module ID. For widgets that allow multiple instances, this could cause the first matching instance to be moved instead of the instance the user actually dragged.

This change propagates the actual slot index through the drag path and uses it when mutating the bar layout.

## Changes

- Track `slotIndex` for bar `ModuleSlot` instances.
- Pass source and target indices through drag-and-drop.
- Move layout mutation logic into `BarModel.js`.
- Preserve name-based fallback for callers without explicit indices.
- Add regression coverage for duplicate widgets, same-section reordering, cross-section moves, and self-drops.

## Validation

- `bash test/shell.d/bar-test.sh` — 99 assertions passed
- `./test/cli` — passed
- `bash test/shell.d/plugin-clone-test.sh` — 20 assertions passed
- `git diff --check` — passed

Fixes #10914