### PR TITLE
Add lock screen blur settings to shell.json

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -4,6 +4,13 @@
     "screensaver": 150,
     "lock": 300
   },
+  "lock": {
+    "blurEnabled": true,
+    "blurAmount": 1.0,
+    "blurMax": 128,
+    "blurMultiplier": 1.25,
+    "contrast": -0.08
+  },
   "bar": {
     "position": "top",
     "transparent": false,

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -14,6 +14,12 @@ Item {
   property int failedAttempts: 0
   property bool inputEnabled: true
   property bool loadBackground: true
+  // Lock screen appearance settings
+  property bool blurEnabled: true
+  property real blurAmount: 1.0
+  property int blurMax: 128
+  property real blurMultiplier: 1.25
+  property real contrast: -0.08
   // A locked session blanks the displays after a few seconds. Nothing is
   // visible from then until the user wakes it, so a video must not keep
   // decoding through what is usually the longest part of a lock.
@@ -97,13 +103,13 @@ Item {
     MultiEffect {
       anchors.fill: wallpaper
       source: wallpaper.video ? null : wallpaper
-      visible: !wallpaper.video
+      visible: !wallpaper.video && root.blurEnabled
       autoPaddingEnabled: false
-      blurEnabled: root.loadBackground && wallpaper.ready
-      blur: 1.0
-      blurMax: 128
-      blurMultiplier: 1.25
-      contrast: -0.08
+      blurEnabled: root.loadBackground && wallpaper.ready && root.blurEnabled
+      blur: root.blurAmount
+      blurMax: root.blurMax
+      blurMultiplier: root.blurMultiplier
+      contrast: root.contrast
     }
 
     // Qt's video output cannot be sampled by MultiEffect on every renderer.

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -16,6 +16,15 @@ Item {
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
 
+  // Lock screen appearance settings
+  readonly property var lockConfig: shell && shell.shellConfig && shell.shellConfig.lock
+    ? shell.shellConfig.lock : ({})
+  readonly property bool lockBlurEnabled: lockConfig.blurEnabled !== undefined ? lockConfig.blurEnabled : true
+  readonly property real lockBlurAmount: lockConfig.blurAmount !== undefined ? lockConfig.blurAmount : 1.0
+  readonly property int lockBlurMax: lockConfig.blurMax !== undefined ? lockConfig.blurMax : 128
+  readonly property real lockBlurMultiplier: lockConfig.blurMultiplier !== undefined ? lockConfig.blurMultiplier : 1.25
+  readonly property real lockContrast: lockConfig.contrast !== undefined ? lockConfig.contrast : -0.08
+
   property bool lockRequested: false
   property bool pendingSessionLock: false
   property bool authenticatingPassword: false
@@ -317,6 +326,11 @@ Item {
         displaysBlank: root.screenBlank(lockSurface.screen ? lockSurface.screen.name : "")
         powerSaverActive: root.powerSaverActive
         passwordText: root.enteredPassword
+        blurEnabled: root.lockBlurEnabled
+        blurAmount: root.lockBlurAmount
+        blurMax: root.lockBlurMax
+        blurMultiplier: root.lockBlurMultiplier
+        contrast: root.lockContrast
         onPasswordTextEdited: function(password) { root.enteredPassword = password }
         onSubmitPassword: function(password) { root.submitPassword(password) }
         onClearFailureRequested: root.failureMessage = ""
@@ -348,6 +362,11 @@ Item {
       loadBackground: root.previewVisible
       powerSaverActive: root.powerSaverActive
       passwordText: ""
+      blurEnabled: root.lockBlurEnabled
+      blurAmount: root.lockBlurAmount
+      blurMax: root.lockBlurMax
+      blurMultiplier: root.lockBlurMultiplier
+      contrast: root.lockContrast
     }
 
     MouseArea {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -40,6 +40,13 @@ ShellRoot {
       screensaver: 150,
       lock: 300
     },
+    lock: {
+      blurEnabled: true,
+      blurAmount: 1.0,
+      blurMax: 128,
+      blurMultiplier: 1.25,
+      contrast: -0.08
+    },
     bar: {
       position: "top",
       transparent: false,

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -13,6 +13,9 @@ require_command python3
 jq empty "$ROOT/config/omarchy/shell.json"
 pass "default shell.json is valid JSON"
 
+jq -e '.lock.blurEnabled == true and .lock.blurAmount == 1.0 and .lock.blurMax == 128 and .lock.blurMultiplier == 1.25' "$ROOT/config/omarchy/shell.json" >/dev/null
+pass "default shell.json has lock blur configuration"
+
 jq -e '.version == 1 and (.bar.layout.left | type == "array") and (.bar.layout.center | type == "array") and (.bar.layout.right | type == "array")' "$ROOT/config/omarchy/shell.json" >/dev/null
 pass "default shell.json has versioned bar layout"
 


### PR DESCRIPTION
## Summary

Expose lock screen blur settings to  for user customization.

## Changes

- Add  section to  with blur configuration options
- Update  to include lock blur defaults in 
- Update  to read config from 
- Update  to accept blur properties instead of hardcoded values
- Add test in ok - default shell.json is valid JSON
ok - default shell.json has lock blur configuration
ok - default shell.json has versioned bar layout
ok - default center layout keeps update next to weather
ok - default center anchor exists in center layout
ok - default clock date format has no leading zero
ok - default right layout keeps agents next to the tray
ok - default bar widget ids resolve to manifests and entry points

## Configuration Options

Users can customize the lock screen background blur in :

```json
"lock": {
  "blurEnabled": false
}
```

Or adjust intensity:

```json
"lock": {
  "blurAmount": 0.5,
  "blurMax": 64,
  "blurMultiplier": 1.0,
  "contrast": 0.0
}
``"

## Defaults

All values default to previous behavior (blur enabled, intensity 1.0, max 128, multiplier 1.25, contrast -0.08) so existing users are unaffected.

## Testing

- Local testing with cloned plugin on daily driver
- ok - default shell.json is valid JSON
ok - default shell.json has lock blur configuration
ok - default shell.json has versioned bar layout
ok - default center layout keeps update next to weather
ok - default center anchor exists in center layout
ok - default clock date format has no leading zero
ok - default right layout keeps agents next to the tray
ok - default bar widget ids resolve to manifests and entry points passes