### PR TITLE
Resample screen recordings back to 48 kHz after loudnorm

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -268,7 +268,13 @@ finalize_recording() {
     # Hard-mute the first 400ms to drop the PipeWire capture-open pop (a near-clipping
     # transient around 130-200ms that a gentle fade-in can't attenuate enough), then a
     # 50ms fade avoids a click at the boundary before loudnorm normalizes the rest.
-    args+=(-af "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05,loudnorm=I=-14:TP=-1.5:LRA=11")
+    #
+    # -ar is required: loudnorm analyses at 192 kHz and declares that as its output
+    # rate, so without it the AAC encoder negotiates down to its own 96 kHz ceiling
+    # rather than back to the 48 kHz gpu-screen-recorder captured. 96 kHz AAC is rare
+    # enough that some NLEs (DaVinci Resolve among them) read the stream metadata but
+    # decode no samples, giving a silent clip with a blank waveform.
+    args+=(-af "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05,loudnorm=I=-14:TP=-1.5:LRA=11" -ar 48000)
   fi
 
   local processed="${latest%.mp4}-processed.mp4"


### PR DESCRIPTION
Fixes #10970.

`finalize_recording()` normalizes loudness with ffmpeg's `loudnorm`, which analyses at 192 kHz and declares that as its output rate. With no `-ar` on the command, ffmpeg negotiates that rate with the AAC encoder, which caps at its own 96 kHz ceiling — so every recording made with `--with-desktop-audio` or `--with-microphone-audio` is written at 96 kHz rather than the 48 kHz `gpu-screen-recorder` captured.

96 kHz AAC is rare enough to be poorly supported. DaVinci Resolve reads the stream metadata (reporting `AAC`, `2ch`, `Sample Rate 96000`) but decodes no samples — video scrubs and plays fine while the audio is silent and the timeline waveform is blank. It also costs bitrate for no benefit, since the captured audio was 48 kHz to begin with.

This pins the output rate back to 48 kHz.

### Verification

Running the exact filter chain from `finalize_recording()` against a synthetic 48 kHz capture:

| | sample rate | mean volume |
|---|---|---|
| source (stands in for gsr output) | 48000 | -21.1 dB |
| before fix | **96000** | -13.7 dB |
| after fix | **48000** | -13.6 dB |

Removing `loudnorm` from the chain while leaving `volume` and `afade` in place keeps the source at 48000, which isolates it as the cause.

Loudness normalization is unaffected — the -14 LUFS target is still hit. The change is the sample rate and nothing else.

### Tests

`test/cli` passes. `test/shell` has 5 pre-existing failures on this machine (`bar-icon-geometry`, `config`, `locate`, `snapper`, `unowned-system-paths`); I confirmed the identical set fails on clean `5b91db5` with this patch absent, so they are unrelated to this change and look environment-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TyTUYNN3MKMRcZSPnjmhr
