### PR TITLE
Enable mpris-proxy so when i take earbuds off the media pauses and vice versa (only to earbuds with this feature)

### DIFF
--- a/default/systemd/user/mpris-proxy.service.d/10-omarchy.conf
+++ b/default/systemd/user/mpris-proxy.service.d/10-omarchy.conf
@@ -1,0 +1,23 @@
+# Let Bluetooth headsets drive the media player.
+#
+# Headsets send transport control as AVRCP passthrough: the play/pause button,
+# and the pause that earbuds with in-ear detection emit when one is taken out.
+# bluez only routes those to a player registered on org.bluez.Media1, and with
+# nothing registered it drops them, so the buttons do nothing and playback runs
+# on into an ear that is no longer listening. mpris-proxy is that registration,
+# exporting session MPRIS players to bluez.
+#
+# bluez-utils ships the unit but leaves it disabled, and it carries no
+# conditions or Restart=. mpris-proxy exits 1 ("Can't get on system bus") when
+# bluetoothd is unreachable, so enabling it as shipped leaves a failed unit on
+# every machine without a usable adapter. These guards mirror bt-agent.service:
+# skip cleanly where there is no bluetooth, and come back if bluetoothd
+# restarts underneath a running proxy. ExecCondition is re-evaluated on each
+# restart, so a stopped bluetooth.service ends the unit instead of looping it.
+[Unit]
+ConditionPathIsDirectory=/sys/class/bluetooth
+
+[Service]
+ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service
+Restart=on-failure
+RestartSec=2

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 systemctl --user daemon-reload
 systemctl --user enable --now \
   bt-agent.service \
+  mpris-proxy.service \
   omarchy-recover-internal-monitor.service \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \

--- a/migrations/1788959623.sh
+++ b/migrations/1788959623.sh
@@ -1,0 +1,23 @@
+echo "Enable the Bluetooth MPRIS proxy so headset transport controls reach the player"
+
+# Only first-run enables the units we ship, so existing installs never picked
+# this one up. The drop-in keeps it inert where there is no bluetooth, so it is
+# safe to enable unconditionally here.
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# `systemctl enable` needs a live user manager, which an update from a TTY does
+# not have, so fall back to writing the symlink it would have written. The unit
+# bluez ships is WantedBy=default.target, not graphical-session.target.
+if ! systemctl --user enable mpris-proxy.service >/dev/null 2>&1; then
+  wants_dir="$HOME/.config/systemd/user/default.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn /usr/lib/systemd/user/mpris-proxy.service \
+    "$wants_dir/mpris-proxy.service"
+fi
+
+# Nothing to start into over SSH; the next login handles it. A failed start
+# only delays headset button support, so it stays quiet.
+if systemctl --user is-active --quiet default.target; then
+  systemctl --user start mpris-proxy.service >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -104,3 +104,16 @@ pass "systemd-oomd acts on sustained memory stall"
 grep -Fx 'systemctl enable systemd-oomd.service' "$ROOT/install/config/enable-services.sh" >/dev/null ||
   fail "new installs ship the oomd drop-ins with the daemon that reads them disabled"
 pass "new installs enable systemd-oomd"
+
+mpris_dropin="$ROOT/default/systemd/user/mpris-proxy.service.d/10-omarchy.conf"
+grep -Fx 'ConditionPathIsDirectory=/sys/class/bluetooth' "$mpris_dropin" >/dev/null ||
+  fail "the AVRCP bridge is pulled in on machines with no bluetooth subsystem"
+grep -Fx 'ExecCondition=/usr/bin/systemctl is-active --quiet bluetooth.service' "$mpris_dropin" >/dev/null ||
+  fail "mpris-proxy exits 1 when bluetoothd is unreachable, so without this it leaves a failed unit instead of skipping"
+grep -Fx 'Restart=on-failure' "$mpris_dropin" >/dev/null ||
+  fail "a bluetoothd restart leaves the proxy dead and headset buttons silently stop working"
+pass "the AVRCP bridge stays inert without bluetooth and recovers with it"
+
+grep -F 'mpris-proxy.service' "$first_run_units" >/dev/null ||
+  fail "first-run does not enable the AVRCP bridge, so bluez has no player registered and headset transport commands are discarded"
+pass "first-run enables the bridge that carries headset play/pause into MPRIS"


### PR DESCRIPTION
Bluetooth headsets send transport control as AVRCP passthrough — the play/pause button, and the pause that earbuds with in-ear detection emit when you take one out. bluez only routes those to a player registered on `org.bluez.Media1`. Omarchy registers nothing, so bluez discards them: headset buttons do nothing, and music keeps playing into an earbud that has been taken out.

`mpris-proxy` is that registration — it exports session MPRIS players to bluez. `bluez-utils` is already in `omarchy-base.packages`, and it ships both the binary and a `mpris-proxy.service` unit. The unit is just never enabled, so this costs no new dependency.

## Evidence

On a JBL LIVE PRO 2 TWS, which advertises `A/V Remote Control (0x110e)` and `A/V Remote Control Controller (0x110f)`.

Before — the device tree has audio endpoints and no player object, so there is nothing for bluez to route a passthrough command to:

```
/org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX
├── sep1
└── sep2/fd0
```

Taking an earbud out produced no MPRIS traffic at all and nothing in the bluetoothd log.

After starting `mpris-proxy`, bluez accepts the player:

```
bluetoothd: Player registered: sender=:1.296 path=/_1_66
```

and removing/reinserting an earbud twice produced, on the session bus:

```
member=Pause   ← bud removed
member=Play    ← bud reinserted
member=Pause
member=Play
```

with the A2DP transport tracking it (`active → idle → active`). The earbuds were sending correct AVRCP the whole time; only the receiving end was missing.

Worth noting AVRCP *absolute volume* is handled directly by bluez/PipeWire without a registered player, so headset volume keys already worked. That makes the gap easy to miss — volume works, play/pause does not.

## Why the drop-in

`mpris-proxy` exits 1 with `Can't get on system bus` when bluetoothd is unreachable:

```
$ DBUS_SYSTEM_BUS_ADDRESS=unix:path=/nonexistent-bus mpris-proxy
Can't get on system bus
$ echo $?
1
```

The unit bluez ships is `Type=simple` with no conditions and no `Restart=`, so enabling it as-is would leave a failed unit on every machine without a usable adapter. The drop-in mirrors `bt-agent.service`, which solves the same problem for the same reason: `ConditionPathIsDirectory=/sys/class/bluetooth` plus an `ExecCondition` on `bluetooth.service` let it skip cleanly, and `Restart=on-failure` brings it back if bluetoothd restarts underneath a running proxy. Because `ExecCondition` is re-evaluated on each restart, a stopped `bluetooth.service` ends the unit rather than looping it.

## Changes

- `default/systemd/user/mpris-proxy.service.d/10-omarchy.conf` — guards mirroring `bt-agent.service`
- `install/user/first-run/enable-user-units.sh` — enable it alongside the other shipped units
- `migrations/1788959623.sh` — enable it on existing installs, with the same TTY fallback used by `1786539345.sh` (the bluez unit is `WantedBy=default.target`, not `graphical-session.target`)
- `test/shell.d/systemd-test.sh` — cover the guards and the first-run enablement

## Testing

`./test/all` shows the same 4 pre-existing environment-dependent failures (`config`, `locate`, `snapper`, `unowned-system-paths`) before and after this change — verified by running the full suite on a pristine `quattro` worktree and on this branch. No new failures.

Migration verified idempotent and clean against a temporary home:

```
HOME=$(mktemp -d) bash -euo pipefail migrations/1788959623.sh
```

Verified on hardware: with the drop-in installed and the unit enabled, exactly one `mpris-proxy` runs, `ConditionResult=yes`, the `ExecCondition` exits 0, and bluez registers the player. Taking an earbud out pauses playback and reinserting it resumes.
