### PR TITLE
Ignore Hyprland’s FALLBACK output when recovering the laptop display

### DIFF
--- a/bin/omarchy-hyprland-monitor-external-active
+++ b/bin/omarchy-hyprland-monitor-external-active
@@ -3,4 +3,4 @@
 # omarchy:summary=Returns true when Hyprland has an active external monitor
 # omarchy:hidden=true
 
-hyprctl monitors all -j | jq -e '.[] | select(.name | test("^(eDP|LVDS|DSI)-") | not) | select(.disabled == false)' >/dev/null 2>&1
+hyprctl monitors all -j | jq -e '.[] | select(.name != "FALLBACK") | select(.name | test("^(eDP|LVDS|DSI)-") | not) | select(.disabled == false)' >/dev/null 2>&1


### PR DESCRIPTION
When the laptop display is disabled and the last external monitor is unplugged, Hyprland creates a virtual output named `FALLBACK`. Omarchy counts it as an active external monitor, so automatic recovery leaves the laptop screen disabled.

Exclude `FALLBACK` in `omarchy-hyprland-monitor-external-active` so the existing recovery watcher can restore the laptop display.

Validation: captured this state during a physical unplug test; six detection cases pass, including fallback-only and real external displays.

`./test/all`: CLI suite passed; shell suite reported failures in `config`, `launch-about`, `locate`, `network-qr`, `snapper`, and `unowned-system-paths` tests. Three require an `omarchy-pkgs` checkout that is not present. Monitor recovery tests passed.
