### PR TITLE
Pin gcr-prompter so Unlock Keyring stays on the current workspace

### DIFF
--- a/default/hypr/apps/system.lua
+++ b/default/hypr/apps/system.lua
@@ -19,6 +19,19 @@ o.window({
   title = "^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)",
 }, { tag = "+floating-window" })
 
+-- Unlock Keyring (gcr-prompter) is a tiny password dialog. Chromium waits
+-- on it for gnome-libsecret. Without a rule it tiles onto workspace 1 and
+-- the browser looks like it never opened. Do not use the floating-window
+-- tag: that forces 875x600 and swallows the dialog.
+o.window("gcr-prompter", {
+  float = true,
+  center = true,
+  pin = true,
+  dim_around = true,
+  stay_focused = true,
+  group = "deny",
+})
+
 -- The About fastfetch layout needs more columns than the standard float provides.
 -- This size only covers the first launch: omarchy-launch-about measures the
 -- rendered content, remembers the size that hugs it, and applies that as its own

--- a/test/shell.d/hyprland-gcr-prompter-test.sh
+++ b/test/shell.d/hyprland-gcr-prompter-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+rules="$ROOT/default/hypr/apps/system.lua"
+
+grep -Fq 'o.window("gcr-prompter"' "$rules" ||
+  fail "system window rules include gcr-prompter" "$(grep -n gcr "$rules" || true)"
+pass "system window rules include gcr-prompter"
+
+block=$(awk '/o.window\("gcr-prompter"/, /^\}\)/' "$rules")
+
+grep -Fq 'float = true' <<<"$block" || fail "gcr-prompter floats" "$block"
+grep -Fq 'center = true' <<<"$block" || fail "gcr-prompter is centered" "$block"
+grep -Fq 'pin = true' <<<"$block" || fail "gcr-prompter is pinned across workspaces" "$block"
+grep -Fq 'stay_focused = true' <<<"$block" || fail "gcr-prompter stays focused" "$block"
+grep -Fq 'group = "deny"' <<<"$block" || fail "gcr-prompter is denied auto_group" "$block"
+
+if grep -Fq 'floating-window' <<<"$block"; then
+  fail "gcr-prompter does not use the 875x600 floating-window tag" "$block"
+fi
+pass "gcr-prompter floats, pins, and stays focused without the large float size"


### PR DESCRIPTION
## Why

Chromium is pinned to `--password-store=gnome-libsecret`. If the Default keyring is locked, it waits on **Unlock Keyring** (`gcr-prompter`) before painting a window.

That dialog is ~550×150 px. With no window rule it tiles onto numbered workspace `1` — often not the active per-monitor workspace, and sometimes the other monitor. Super+Shift+B then looks like Chromium never opened.

This is the same class of miss as portal file-pickers (already tagged `floating-window`) and the webapp "Save password?" dialog landing on the previous workspace (#4349). The *asking every boot* reports (#2308, #2203, #3331, #3523) are a different bug (passwordless Default keyring getting encrypted); this PR only makes the prompt impossible to lose when it does appear.

Verified on Omarchy 4.0.3 / Hyprland Lua: after this rule, `hyprctl clients` shows `gcr-prompter` as `floating=true`, `pinned=true`, ungrouped.

## Change

In `default/hypr/apps/system.lua`, float + center + pin + `stay_focused` + `group = "deny"` for `gcr-prompter`.

Not the shared `floating-window` tag: that forces 875×600 and swallows the dialog.

Existing installs pick this up from package defaults; no migration.

## Risk

Low. Only matches class `gcr-prompter`. Pin keeps it on every workspace of the monitor it opened on until dismissed.

## Test

`test/shell.d/hyprland-gcr-prompter-test.sh` asserts the rule exists with float/center/pin/`stay_focused`/`group = "deny"` and does not use the large float tag.

`./test/all`: new test passes. Unrelated failures on this machine are live dual-monitor geometry and missing `omarchy-pkgs` checkout.