### PR TITLE
Audio panel: list a jack's ports as rows, the way macOS and GNOME do

### DIFF
--- a/bin/omarchy-audio-ports
+++ b/bin/omarchy-audio-ports
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# omarchy:summary=List the ports of every audio device that has more than one, with the active one
+# omarchy:group=audio
+
+# A laptop's speakers and its headphone jack are one device to PipeWire, with
+# a port for each: plugging headphones in switches the port, never the device.
+# A panel that lists devices therefore shows one unchanging entry. What a person
+# recognises is the port -- Speakers, Headphones, Internal Microphone, Headset
+# Microphone -- which is how macOS and GNOME present a jack.
+#
+# One line per port, for every sink and source that has more than one:
+#   <sink|source> TAB <node name> TAB <port id> TAB <description> TAB <active 0|1> TAB <available 0|1>
+# "available" is 0 only when PipeWire says "not available" (nothing plugged
+# into that jack); "unknown" counts as available. Single-port devices are
+# omitted: they are best named by the device.
+
+for kind in sink source; do
+  pactl list "${kind}s" 2>/dev/null | awk -v kind="$kind" '
+    function flush(   i) {
+      if (name == "" || count < 2) return
+      for (i = 1; i <= count; i++)
+        print kind "\t" name "\t" id[i] "\t" desc[i] "\t" (id[i] == active ? 1 : 0) "\t" avail[i]
+    }
+    /^(Sink|Source) #/ { flush(); name = ""; count = 0; active = ""; in_ports = 0; next }
+    /^[[:space:]]*Name:/ { name = $2; if (name ~ /\.monitor$/) name = ""; next }
+    /^[[:space:]]*Ports:$/ { in_ports = 1; next }
+    # "\t\tanalog-output-headphones: Headphones (type: Headphones, ..., not available)"
+    in_ports && /^\t\t[^\t]/ {
+      count++
+      line = $0; sub(/^\t\t/, "", line)
+      id[count] = line; sub(/:.*/, "", id[count])
+      desc[count] = line; sub(/^[^:]*: /, "", desc[count]); sub(/ \(type:.*$/, "", desc[count])
+      avail[count] = (line ~ /not available\)$/) ? 0 : 1
+      next
+    }
+    /^\tActive Port:/ { in_ports = 0; active = $3; next }
+    END { flush() }
+  '
+done

--- a/bin/omarchy-audio-set-port
+++ b/bin/omarchy-audio-set-port
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Select a port (Speakers, Headphones, Headset Microphone...) on an audio device
+# omarchy:args=<sink|source> <node-name> <port-id>
+# omarchy:group=audio
+
+kind=${1:-}
+name=${2:-}
+port=${3:-}
+
+if [[ -z $kind || -z $name || -z $port ]]; then
+  echo "Usage: omarchy-audio-set-port <sink|source> <node-name> <port-id>" >&2
+  exit 1
+fi
+
+case $kind in
+  sink) timeout 2 pactl set-sink-port "$name" "$port" ;;
+  source) timeout 2 pactl set-source-port "$name" "$port" ;;
+  *) echo "kind must be sink or source" >&2; exit 1 ;;
+esac

--- a/shell/plugins/panels/audio/Model.js
+++ b/shell/plugins/panels/audio/Model.js
@@ -47,6 +47,42 @@ function parseSinkAvailability(raw) {
   return next
 }
 
+// {node name: [port]} from omarchy-audio-ports, which lists only devices with
+// more than one port. "available" is false when nothing is plugged into that
+// jack, or when the driver has routed away from the port on its own.
+function parsePorts(raw) {
+  var next = {}
+  var lines = String(raw || "").split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var p = lines[i].split("\t")
+    if (p.length < 6 || !p[1] || !p[2]) continue
+    if (!next[p[1]]) next[p[1]] = []
+    next[p[1]].push({
+      kind: p[0],
+      id: p[2],
+      label: p[3].trim(),
+      active: p[4] === "1",
+      available: p[5] === "1"
+    })
+  }
+  return next
+}
+
+function portGlyph(port) {
+  if (!port) return ""
+  if (labelIsHeadphones(port.label)) return "󰋋"
+  return port.kind === "source" ? "󰍬" : "󰓃"
+}
+
+function labelIsHeadphones(label) {
+  var blob = String(label || "").toLowerCase()
+  return blob.indexOf("headphone") !== -1
+    || blob.indexOf("headset") !== -1
+    || blob.indexOf("earbud") !== -1
+    || blob.indexOf("earphone") !== -1
+    || blob.indexOf("airpod") !== -1
+}
+
 function friendlyDeviceLabel(text) {
   var label = String(text || "").trim()
   label = label.replace(/^sof-soundwire\s+/i, "")
@@ -78,12 +114,8 @@ function isHeadphones(node) {
     p["device.product.name"] || "",
     p["node.description"] || "",
     p["node.nick"] || ""
-  ].join(" ")).toLowerCase()
-  return blob.indexOf("headphone") !== -1
-    || blob.indexOf("headset") !== -1
-    || blob.indexOf("earbud") !== -1
-    || blob.indexOf("earphone") !== -1
-    || blob.indexOf("airpod") !== -1
+  ].join(" "))
+  return labelIsHeadphones(blob)
 }
 
 function sinkGlyph(node) {
@@ -240,6 +272,9 @@ if (typeof module !== "undefined") {
     listSnapshot: listSnapshot,
     outputVolumeName: outputVolumeName,
     parseSinkAvailability: parseSinkAvailability,
+    parsePorts: parsePorts,
+    portGlyph: portGlyph,
+    labelIsHeadphones: labelIsHeadphones,
     friendlyDeviceLabel: friendlyDeviceLabel,
     nodeProps: nodeProps,
     nodeLabel: nodeLabel,

--- a/shell/plugins/panels/audio/Panel.qml
+++ b/shell/plugins/panels/audio/Panel.qml
@@ -58,6 +58,16 @@ Panel {
   property var sinkAvailability: ({})
   property bool sinkAvailabilityLoaded: false
 
+  // Ports per device that has more than one, from omarchy-audio-ports:
+  // {name: [{id, label, active, available}]}. Speakers and a headphone jack
+  // are one device with two ports, so plugging in switches the port and the
+  // device name never changes. The port is what a person calls the output, so
+  // a multi-port device is listed as one row per available port, the way
+  // macOS and GNOME present a jack: Speakers / Headphones, and Internal /
+  // Headset Microphone. The active one is highlighted; picking another is a
+  // port switch, which the session manager undoes itself on the next jack event.
+  property var devicePorts: ({})
+
   // Identify true playback streams without reading node.properties here:
   // PwNode.properties is invalid until the node is bound, and reading it while
   // capture streams are appearing (for example, when Voxtype starts recording)
@@ -81,13 +91,13 @@ Panel {
     for (var i = 0; i < candidateSinks.length; i++)
       if (sinkAvailable(candidateSinks[i])) list.push(candidateSinks[i])
     if (sink && list.indexOf(sink) < 0) list.unshift(sink)
-    return list
+    return expandPorts(list)
   }
 
   readonly property var rawAudioSources: {
     var list = candidateSources.slice()
     if (source && list.indexOf(source) < 0) list.unshift(source)
-    return list
+    return expandPorts(list)
   }
 
   readonly property var audioSinks: rawAudioSinks.length > 0 ? rawAudioSinks : cachedAudioSinks
@@ -147,6 +157,13 @@ Panel {
   readonly property bool outputMuted: volumeSink && volumeSink.audio ? volumeSink.audio.muted : false
   readonly property real inputVolume: source && source.audio ? source.audio.volume : 0
   readonly property bool inputMuted: source && source.audio ? source.audio.muted : false
+
+  // Each port keeps its own volume, so a jack event usually shows up here as a
+  // level change on the physical sink the moment the port switches. Using that
+  // as a nudge makes the bar icon follow a plug within a fraction of a second
+  // instead of waiting for the next poll; the poll remains the safety net.
+  onOutputVolumeChanged: portsNudge.restart()
+  onInputVolumeChanged: portsNudge.restart()
 
   onRawAudioSinksChanged: if (rawAudioSinks.length > 0) cachedAudioSinks = rawAudioSinks
   onRawAudioSourcesChanged: if (rawAudioSources.length > 0) cachedAudioSources = rawAudioSources
@@ -291,14 +308,14 @@ Panel {
     if (focusSection === "header") { toggleAllMuted(); return }
     if (focusSection === "output") {
       if (selectedIndex === -1) { toggleOutputMute(); return }
-      var sink = displayAudioSinks[selectedIndex]
-      if (sink) setDefaultSink(sink)
+      var entry = displayAudioSinks[selectedIndex]
+      if (entry) selectOutput(entry)
       return
     }
     if (focusSection === "input") {
       if (selectedIndex === -1) { toggleInputMute(); return }
-      var src = displayAudioSources[selectedIndex]
-      if (src) setDefaultSource(src)
+      var srcEntry = displayAudioSources[selectedIndex]
+      if (srcEntry) selectInput(srcEntry)
       return
     }
     if (focusSection === "streams" && selectedIndex >= 0) {
@@ -495,6 +512,101 @@ Panel {
     sinkAvailabilityLoaded = true
   }
 
+  function updatePorts(raw) {
+    devicePorts = Model.parsePorts(raw)
+  }
+
+  function refreshPorts() {
+    if (!portsProc.running) portsProc.running = true
+  }
+
+  // The device whose ports a row should show, or "". A tuning sink has no ports
+  // of its own; when it is the selected output, the ports that matter are on
+  // the physical sink it feeds, which volumeSinkName already resolves.
+  function portOwner(node) {
+    if (!node || !node.name) return ""
+    var name = String(node.name)
+    if (devicePorts[name]) return name
+    if (node === sink && volumeSinkName && devicePorts[volumeSinkName]) return volumeSinkName
+    return ""
+  }
+
+  // Only ports the driver reports available: a jack port appears while
+  // something is plugged in, and a driver that routes on the jack itself marks
+  // the port it has taken out of use "not available" -- offering that one
+  // would move the highlight and not the sound.
+  function shownPorts(owner) {
+    var ports = owner ? devicePorts[owner] : null
+    if (!ports) return []
+    var list = []
+    for (var i = 0; i < ports.length; i++)
+      if (ports[i].available) list.push(ports[i])
+    return list
+  }
+
+  function activePortLabel(node) {
+    var owner = portOwner(node)
+    var ports = owner ? devicePorts[owner] : null
+    if (!ports) return ""
+    for (var i = 0; i < ports.length; i++)
+      if (ports[i].active) return ports[i].label
+    return ""
+  }
+
+  // One row per available port for a multi-port device -- even when only one
+  // is available, since "Headphones" says more than the device name does --
+  // else the device itself.
+  function expandPorts(nodes) {
+    var rows = []
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i]
+      var owner = portOwner(node)
+      var ports = shownPorts(owner)
+      if (ports.length > 0) {
+        for (var j = 0; j < ports.length; j++) rows.push({ node: node, owner: owner, port: ports[j] })
+      } else {
+        rows.push({ node: node, owner: owner, port: null })
+      }
+    }
+    return rows
+  }
+
+  function selectOutput(entry) {
+    if (!entry || !entry.node) return
+    if (!sink || sink.id !== entry.node.id) setDefaultSink(entry.node)
+    if (entry.port && entry.owner) {
+      Quickshell.execDetached(["omarchy-audio-set-port", "sink", entry.owner, entry.port.id])
+      markActivePort(entry.owner, entry.port.id)
+    }
+  }
+
+  function selectInput(entry) {
+    if (!entry || !entry.node) return
+    if (!source || source.id !== entry.node.id) setDefaultSource(entry.node)
+    if (entry.port && entry.owner) {
+      Quickshell.execDetached(["omarchy-audio-set-port", "source", entry.owner, entry.port.id])
+      markActivePort(entry.owner, entry.port.id)
+    }
+  }
+
+  // Move the highlight now; the next refresh confirms it from PipeWire.
+  function markActivePort(owner, id) {
+    var next = {}
+    for (var name in devicePorts) {
+      var ports = devicePorts[name]
+      var copy = []
+      for (var i = 0; i < ports.length; i++) {
+        var q = {}
+        for (var k in ports[i]) q[k] = ports[i][k]
+        if (name === owner) q.active = q.id === id
+        copy.push(q)
+      }
+      next[name] = copy
+    }
+    devicePorts = next
+    portsNudge.restart()
+  }
+
   function friendlyDeviceLabel(text) {
     return Model.friendlyDeviceLabel(text)
   }
@@ -508,7 +620,7 @@ Panel {
   }
 
   function isHeadphones(node) {
-    return Model.isHeadphones(node)
+    return Model.labelIsHeadphones(activePortLabel(node)) || Model.isHeadphones(node)
   }
 
   function sinkGlyph(node) {
@@ -517,6 +629,10 @@ Panel {
 
   function sourceGlyph(node) {
     return Model.sourceGlyph(node)
+  }
+
+  function portGlyph(port) {
+    return Model.portGlyph(port)
   }
 
   function friendlyStreamLabel(label) {
@@ -601,12 +717,24 @@ Panel {
     }
   }
 
+  Process {
+    id: portsProc
+    command: ["omarchy-audio-ports"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.updatePorts(text)
+    }
+  }
+
   Timer {
     interval: 5000
     running: root.opened
     repeat: true
     triggeredOnStart: true
-    onTriggered: if (!sinkAvailabilityProc.running) sinkAvailabilityProc.running = true
+    onTriggered: {
+      if (!sinkAvailabilityProc.running) sinkAvailabilityProc.running = true
+      root.refreshPorts()
+    }
   }
 
   // Runs whether or not the panel is open: the bar shows and scrolls the output
@@ -617,7 +745,17 @@ Panel {
     running: true
     repeat: true
     triggeredOnStart: true
-    onTriggered: root.resolveVolumeSink()
+    onTriggered: {
+      root.resolveVolumeSink()
+      root.refreshPorts()
+    }
+  }
+
+  Timer {
+    id: portsNudge
+    interval: 300
+    repeat: false
+    onTriggered: root.refreshPorts()
   }
 
   Timer {
@@ -857,7 +995,7 @@ Panel {
                 required property var modelData
                 required property int index
                 width: panelColumn.width
-                node: modelData
+                entry: modelData
                 rowIndex: index
               }
             }
@@ -965,7 +1103,7 @@ Panel {
                 required property var modelData
                 required property int index
                 width: panelColumn.width
-                node: modelData
+                entry: modelData
                 rowIndex: index
               }
             }
@@ -1012,10 +1150,11 @@ Panel {
   // from hasCursor/current via CursorSurface, never from containsMouse.
   component SinkRow: CursorSurface {
     id: sinkRow
-    required property var node
+    required property var entry
     required property int rowIndex
-
-    readonly property bool isActive: root.sink && node && root.sink.id === node.id
+    readonly property var node: entry ? entry.node : null
+    readonly property var port: entry ? entry.port : null
+    readonly property bool isActive: root.sink && node && root.sink.id === node.id && (!port || port.active)
     hasCursor: root.cursorActive && root.focusSection === "output" && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sinkRow)
     current: isActive
@@ -1035,7 +1174,7 @@ Panel {
 
       Text {
         textFormat: Text.PlainText
-        text: root.sinkGlyph(sinkRow.node)
+        text: sinkRow.port ? root.portGlyph(sinkRow.port) : root.sinkGlyph(sinkRow.node)
         color: root.bar.foreground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.title
@@ -1046,7 +1185,7 @@ Panel {
 
       Text {
         textFormat: Text.PlainText
-        text: root.nodeLabel(sinkRow.node)
+        text: sinkRow.port ? sinkRow.port.label : root.nodeLabel(sinkRow.node)
         color: root.bar.foreground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.body
@@ -1066,17 +1205,18 @@ Panel {
         root.focusSection = "output"
         root.selectedIndex = sinkRow.rowIndex
       }
-      onClicked: root.setDefaultSink(sinkRow.node)
+      onClicked: root.selectOutput(sinkRow.entry)
     }
   }
 
   // Input device row — sibling of SinkRow for the "input" section.
   component SourceRow: CursorSurface {
     id: sourceRow
-    required property var node
+    required property var entry
     required property int rowIndex
-
-    readonly property bool isActive: root.source && node && root.source.id === node.id
+    readonly property var node: entry ? entry.node : null
+    readonly property var port: entry ? entry.port : null
+    readonly property bool isActive: root.source && node && root.source.id === node.id && (!port || port.active)
     hasCursor: root.cursorActive && root.focusSection === "input" && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sourceRow)
     current: isActive
@@ -1096,7 +1236,7 @@ Panel {
 
       Text {
         textFormat: Text.PlainText
-        text: root.sourceGlyph(sourceRow.node)
+        text: sourceRow.port ? root.portGlyph(sourceRow.port) : root.sourceGlyph(sourceRow.node)
         color: root.bar.foreground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.title
@@ -1107,7 +1247,7 @@ Panel {
 
       Text {
         textFormat: Text.PlainText
-        text: root.nodeLabel(sourceRow.node)
+        text: sourceRow.port ? sourceRow.port.label : root.nodeLabel(sourceRow.node)
         color: root.bar.foreground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.body
@@ -1127,7 +1267,7 @@ Panel {
         root.focusSection = "input"
         root.selectedIndex = sourceRow.rowIndex
       }
-      onClicked: root.setDefaultSource(sourceRow.node)
+      onClicked: root.selectInput(sourceRow.entry)
     }
   }
 


### PR DESCRIPTION
On any machine with a combo jack, speakers and headphones are one PipeWire device with a port for each. Plugging headphones in switches the port, never the device, so the panel keeps one unchanging row ("Built-in Audio", or a tuning's name) and the bar keeps the speaker glyph. macOS and GNOME both show the port instead.

This lists a multi-port device as one row per **available** port, with the active one highlighted, and the bar glyph follows:

- Output: **Speakers** / **Headphones**. Input: **Internal Microphone** / **Headset Microphone**.
- A jack port is listed only while something is plugged in. A port the driver has routed away from (reported `not available`) is not offered, since selecting it would move the highlight and not the sound. Where a driver leaves both available, clicking the other row switches the port and the session manager reselects on the next jack event, as it does today.
- Single-port devices (USB DACs, Bluetooth) are unchanged and keep their device names, so nothing regresses for hardware with no ports to choose from.
- A speaker tuning is a virtual sink with no ports of its own; when it is the selected output, the rows come from the physical sink it feeds, which the panel already resolves for volume (`volumeSinkName`). So a tuning fronting a combo jack still reads Headphones.
- Ports keep their own volume, so a jack event usually surfaces as a level change on the physical sink; that is used as a 300 ms nudge so the bar glyph follows a plug promptly. The existing 5 s and 15 s polls remain the safety net.

Two small helpers: `omarchy-audio-ports` prints `<sink|source>`, node, port id, description, active and available for every device with more than one port; `omarchy-audio-set-port` switches one. Keyboard navigation and Enter/Space activation work on the rows unchanged.

Tested on an iMac18,3 (CS8409/CS42L83 — one sink with speaker and headphone ports, one source with internal and headset mic), with and without a speaker tuning in front: rows, highlight, header and bar glyphs follow the jack within about two seconds, and USB/Bluetooth devices are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
