### PR TITLE
fix: keep 1.25x tooltip and scale-pill borders from dropping edges

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -1329,6 +1329,8 @@ Item {
         id: tooltipBubble
         implicitWidth: tooltipLabel.implicitWidth + 20
         implicitHeight: tooltipLabel.implicitHeight + 14
+        width: tooltipWindow.width
+        height: tooltipWindow.height
         color: Color.tooltip.background
         borderSpec: Border.surfaceSpec("tooltip", "border", Color.tooltip.border, 1)
         radius: Style.cornerRadius

--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -772,7 +772,7 @@ Panel {
               spacing: Style.spacing.xs
 
               readonly property real cellWidth: root.scaleValues.length > 0
-                ? (width - spacing * (columns - 1)) / columns
+                ? Math.floor((width - spacing * (columns - 1)) / columns)
                 : 0
 
               Repeater {

--- a/test/shell.d/fractional-border-snap-test.sh
+++ b/test/shell.d/fractional-border-snap-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const barSource = fs.readFileSync(path.join(root, 'shell/plugins/bar/Bar.qml'), 'utf8')
+const panelSource = fs.readFileSync(path.join(root, 'shell/plugins/panels/monitor/Panel.qml'), 'utf8')
+
+const tooltipBlock = barSource.slice(
+  barSource.indexOf('id: tooltipBubble'),
+  barSource.indexOf('id: tooltipLabel')
+)
+
+assert(
+  /width:\s*tooltipWindow\.width/.test(tooltipBlock)
+    && /height:\s*tooltipWindow\.height/.test(tooltipBlock),
+  'bar tooltip bubble fills its rounded-up window'
+)
+
+assert(
+  /readonly property real cellWidth: root\.scaleValues\.length > 0\s*\n\s*\?\s*Math\.floor\(\(width - spacing \* \(columns - 1\)\) \/ columns\)/.test(panelSource),
+  'monitor scaleRow.cellWidth snaps with Math.floor'
+)
+
+function cellWidth(width, spacing, columns) {
+  return columns > 0 ? Math.floor((width - spacing * (columns - 1)) / columns) : 0
+}
+
+const width = 280
+const spacing = 3
+const columns = 6
+const snapped = cellWidth(width, spacing, columns)
+
+assertEqual(Number.isInteger(snapped), true, 'cellWidth is an integer logical pixel')
+assert(snapped * columns + spacing * (columns - 1) <= width, 'floored cellWidth does not overflow the row')
+assertEqual(snapped, 44, 'six-preset 280px row floors to 44px cells')
+
+const remainderAt125 = (snapped * 1.25) % 1
+assertEqual(remainderAt125, 0, '1.25x maps floored cellWidth onto whole device pixels')
+
+const raw = (width - spacing * (columns - 1)) / columns
+assert(!(Number.isInteger(raw)), 'raw unfloored cellWidth stays fractional (regression fixture)')
+assert((raw * 1.25) % 1 !== 0, 'raw cellWidth leaves a 1.25x device-pixel remainder')
+JS


### PR DESCRIPTION
## Summary
- size the shared bar tooltip `BorderSurface` to fill its `Math.ceil()` `PopupWindow`, so fractional label metrics no longer leave a transparent sliver on one edge at 1.25x (#10084)
- floor `scaleRow.cellWidth` in the Display panel so scale-preset pills land on whole logical pixels and cannot overflow the row (#10085)
- add `test/shell.d/fractional-border-snap-test.sh` source contracts + 1.25 remainder math

Does not touch bar height / `Style.barToken` (separate from #10218).

Fixes #10084.
Fixes #10085.

## Verification
- `bash test/shell.d/fractional-border-snap-test.sh` (8 ok)
- `bash test/shell.d/bar-test.sh` (exit 0)
- `bash test/shell.d/monitor-scaling-test.sh` (exit 0)
- visual 1.25 session still recommended for tooltip outer border + scale-preset four edges