### PR TITLE
Expose the theme switcher's live selection

### DIFF
--- a/bin/omarchy-menu-images
+++ b/bin/omarchy-menu-images
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # omarchy:summary=Open a generic image selector menu
-# omarchy:args=[--selected <image>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>...
+# omarchy:args=[--selected <image>] [--live-selection-file <path>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>...
 
 selected_image=""
+live_selection_file=""
 print_name=false
 show_labels=false
 filterable=false
@@ -14,7 +15,7 @@ cache_only=false
 image_dirs=()
 
 usage() {
-  echo "Usage: omarchy-menu-images [--selected <image>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>..."
+  echo "Usage: omarchy-menu-images [--selected <image>] [--live-selection-file <path>] [--print-name] [--show-labels] [--filterable] [--lazy-thumbnails] [--preload] [--cache-only] <image-dir>..."
 }
 
 while (( $# > 0 )); do
@@ -26,6 +27,15 @@ while (( $# > 0 )); do
       fi
 
       selected_image="$2"
+      shift 2
+      ;;
+    --live-selection-file)
+      if (( $# < 2 )); then
+        usage >&2
+        exit 1
+      fi
+
+      live_selection_file="$2"
       shift 2
       ;;
     --print-name)
@@ -72,7 +82,15 @@ if (( ${#image_dirs[@]} == 0 )); then
   exit 1
 fi
 
-selection_file=$(mktemp)
+if [[ -n $live_selection_file ]]; then
+  selection_file="$live_selection_file"
+  if ! : >"$selection_file"; then
+    echo "Unable to write live selection file: $selection_file" >&2
+    exit 1
+  fi
+else
+  selection_file=$(mktemp)
+fi
 done_file=$(mktemp)
 pending_file=$(mktemp)
 pending_video_file=$(mktemp)

--- a/bin/omarchy-theme-switcher
+++ b/bin/omarchy-theme-switcher
@@ -12,9 +12,15 @@ fi
 USER_THEMES_PATH="$HOME/.config/omarchy/themes"
 OMARCHY_THEMES_PATH="$OMARCHY_PATH/themes"
 CACHE_PATH="${XDG_CACHE_HOME:-$HOME/.cache}/omarchy/theme-selector"
+LIVE_SELECTION_FILE="${XDG_RUNTIME_DIR:-/run/user/$UID}/omarchy-theme-selection"
 preview_dir="$CACHE_PATH/previews"
 signature_file="$CACHE_PATH/signature"
 fast_signature_file="$CACHE_PATH/fast-signature"
+
+if [[ $preload != true ]]; then
+  exec {live_selection_lock_fd}>"$LIVE_SELECTION_FILE.lock"
+  flock -n "$live_selection_lock_fd" || exit 0
+fi
 
 mkdir -p "$preview_dir"
 
@@ -123,6 +129,8 @@ menu_args=(
 
 if [[ $preload == true ]]; then
   menu_args+=(--preload)
+  omarchy-menu-images "${menu_args[@]}" "$preview_dir"
+else
+  menu_args+=(--live-selection-file "$LIVE_SELECTION_FILE")
+  omarchy-menu-images "${menu_args[@]}" "$preview_dir" {live_selection_lock_fd}>&-
 fi
-
-exec omarchy-menu-images "${menu_args[@]}" "$preview_dir"

--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -110,6 +110,19 @@ Item {
     if (index === selectedIndex && immediate !== true) return
 
     selectedIndex = index
+    publishSelection()
+  }
+
+  function publishSelection() {
+    if (selectionFile) {
+      var path = currentPath()
+      selectionFileView.setText(path ? path + "\n" : "")
+    }
+  }
+
+  function clearSelection() {
+    if (selectionFile)
+      selectionFileView.setText("")
   }
 
   function selectAdjacent(direction) {
@@ -133,6 +146,8 @@ Item {
       var first = ImagePickerModel.nextSelectedIndexForFilter(imageArray, selectedIndex, filterText)
       if (first >= 0) selectedIndex = first
     }
+
+    publishSelection()
   }
 
   function releaseNextDoneFile() {
@@ -168,8 +183,10 @@ Item {
   }
 
   function cancel() {
-    if (requestActive)
+    if (requestActive) {
+      clearSelection()
       finishDoneFile(doneFile)
+    }
 
     requestActive = false
     selectionFile = ""
@@ -180,8 +197,10 @@ Item {
   function closeSelector(nextDoneFile) {
     requestSerial += 1
 
-    if (requestActive)
+    if (requestActive) {
+      clearSelection()
       finishDoneFile(doneFile)
+    }
 
     if (nextDoneFile && nextDoneFile !== doneFile)
       finishDoneFile(nextDoneFile)
@@ -200,6 +219,7 @@ Item {
     root.selectedIndex = root.indexForSelectedImage(newImages)
     root.imageArray = newImages
     root.imagesLoaded = true
+    root.publishSelection()
 
     if (reveal !== false) {
       root.opened = true
@@ -208,8 +228,10 @@ Item {
   }
 
   function openSelector(nextImageDirs, nextImageRows, nextSelectedImage, nextSelectionFile, nextDoneFile, nextShowLabels, nextFilterable) {
-    if (requestActive && doneFile && doneFile !== nextDoneFile)
+    if (requestActive && doneFile && doneFile !== nextDoneFile) {
+      clearSelection()
       finishDoneFile(doneFile)
+    }
 
     requestSerial += 1
 
@@ -352,6 +374,13 @@ Item {
       if (root.applySerial === root.requestSerial)
         root.opened = false
     }
+  }
+
+  FileView {
+    id: selectionFileView
+    path: root.selectionFile
+    atomicWrites: true
+    printErrors: false
   }
 
   Process {

--- a/test/shell.d/image-picker-test.sh
+++ b/test/shell.d/image-picker-test.sh
@@ -51,4 +51,8 @@ assert(
   /source: item\.sourceActivated && item\.thumbnailPath \? Util\.fileUrl\(item\.thumbnailPath\) : ""[\s\S]*asynchronous: false/.test(imagePickerQml),
   'image picker loads activated thumbnails synchronously to avoid carousel flicker'
 )
+assert(
+  /function updateFilter\(nextFilterText\)[\s\S]*if \(!itemMatches\(selectedIndex\)\)[\s\S]*publishSelection\(\)\n  }/.test(imagePickerQml),
+  'image picker republishes live selection after every filter change'
+)
 JS

--- a/test/shell.d/menu-images-test.sh
+++ b/test/shell.d/menu-images-test.sh
@@ -139,3 +139,80 @@ PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" VIPSTHUMBNAIL_CALLS_FILE="$t
 
 (( $(wc -l <"$tmp/calls") == 6 )) || fail "image menu releases thumbnail locks after generation"
 pass "image menu owns locks for exactly one generator lifetime"
+
+cat >"$stub_bin/omarchy-shell" <<'EOF'
+#!/bin/bash
+
+[[ $1 == "image-selector" && $2 == "open" ]] || exit 1
+printf '%s\n' "$OMARCHY_TEST_SELECTION" >"$6"
+: >"$7"
+printf 'ok\n'
+EOF
+chmod +x "$stub_bin/omarchy-shell"
+
+live_selection_file="$tmp/live-selection"
+selection=$(
+  PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$cache_home" OMARCHY_TEST_SELECTION="$images/two.png" \
+    "$ROOT/bin/omarchy-menu-images" --live-selection-file "$live_selection_file" --print-name "$images"
+)
+
+[[ $selection == "two" ]] || fail "image menu preserves final output with a live selection file"
+[[ ! -e $live_selection_file ]] || fail "image menu removes its live selection file when it exits"
+pass "image menu exposes live selection without changing final output"
+
+theme_home="$tmp/theme-home"
+theme_root="$tmp/theme-root"
+theme_runtime="$tmp/theme-runtime"
+theme_calls="$tmp/theme-switcher-calls"
+theme_release="$tmp/theme-switcher-release"
+mkdir -p "$theme_home/.config/omarchy/themes" "$theme_root/themes" "$theme_runtime"
+
+cat >"$stub_bin/omarchy-menu-images" <<'EOF'
+#!/bin/bash
+
+printf 'interactive\n' >>"$OMARCHY_TEST_CALLS"
+for _ in {1..500}; do
+  if [[ -e $OMARCHY_TEST_RELEASE ]]; then
+    if (( $(wc -l <"$OMARCHY_TEST_CALLS") == 1 )); then
+      sleep 2 &
+    fi
+    exit 0
+  fi
+  sleep 0.01
+done
+exit 1
+EOF
+chmod +x "$stub_bin/omarchy-menu-images"
+
+PATH="$stub_bin:$PATH" HOME="$theme_home" OMARCHY_PATH="$theme_root" XDG_CACHE_HOME="$tmp/theme-cache" \
+  XDG_RUNTIME_DIR="$theme_runtime" OMARCHY_TEST_CALLS="$theme_calls" OMARCHY_TEST_RELEASE="$theme_release" \
+  "$ROOT/bin/omarchy-theme-switcher" &
+first_switcher_pid=$!
+
+for _ in {1..100}; do
+  [[ -f $theme_calls ]] && (( $(wc -l <"$theme_calls") == 1 )) && break
+  sleep 0.01
+done
+
+PATH="$stub_bin:$PATH" HOME="$theme_home" OMARCHY_PATH="$theme_root" XDG_CACHE_HOME="$tmp/theme-cache" \
+  XDG_RUNTIME_DIR="$theme_runtime" OMARCHY_TEST_CALLS="$theme_calls" OMARCHY_TEST_RELEASE="$theme_release" \
+  "$ROOT/bin/omarchy-theme-switcher"
+
+[[ $(wc -l <"$theme_calls") == 1 ]] || fail "theme switcher serializes interactive selectors"
+: >"$theme_release"
+wait "$first_switcher_pid"
+rm -f "$theme_release"
+
+PATH="$stub_bin:$PATH" HOME="$theme_home" OMARCHY_PATH="$theme_root" XDG_CACHE_HOME="$tmp/theme-cache" \
+  XDG_RUNTIME_DIR="$theme_runtime" OMARCHY_TEST_CALLS="$theme_calls" OMARCHY_TEST_RELEASE="$theme_release" \
+  "$ROOT/bin/omarchy-theme-switcher" &
+next_switcher_pid=$!
+
+for _ in {1..50}; do
+  (( $(wc -l <"$theme_calls") == 2 )) && break
+  sleep 0.01
+done
+[[ $(wc -l <"$theme_calls") == 2 ]] || fail "theme switcher releases selection ownership before menu descendants exit"
+: >"$theme_release"
+wait "$next_switcher_pid"
+pass "theme switcher keeps one process-scoped owner for its live selection file"

--- a/test/shell.d/runtime-smoke-test.sh
+++ b/test/shell.d/runtime-smoke-test.sh
@@ -452,9 +452,19 @@ for _ in {1..80}; do
   sleep 0.1
 done
 [[ $selector_open == "ok" ]] || fail_with_log "image selector IPC survives plugin rescan"
+for _ in {1..40}; do
+  [[ $(cat "$selector_selection_file" 2>/dev/null) == "$TMPDIR/selector.png" ]] && break
+  sleep 0.05
+done
+[[ $(cat "$selector_selection_file" 2>/dev/null) == "$TMPDIR/selector.png" ]] || fail_with_log "image selector publishes its live selection"
 shell_ipc_quiet image-selector cancel "$selector_done_file" >/dev/null
+for _ in {1..40}; do
+  [[ ! -s $selector_selection_file ]] && break
+  sleep 0.05
+done
+[[ ! -s $selector_selection_file ]] || fail_with_log "image selector clears its live selection on cancel"
 rm -f "$selector_selection_file" "$selector_done_file"
-pass "image selector IPC survives plugin rescan"
+pass "image selector IPC survives plugin rescan and publishes live selection"
 
 lock_status_after=$(shell_ipc lock status)
 jq -e '.locked | type == "boolean"' <<<"$lock_status_after" >/dev/null || fail_with_log "lock IPC survives plugin rescan"


### PR DESCRIPTION
The theme switcher currently exposes when its image-selector layer is open, but
  only returns the selected theme after confirmation. Programs that want to react
  while the user moves through themes cannot determine which theme is currently
  highlighted.

  Add `--live-selection-file <path>` to `omarchy-menu-images`. While the picker is
  open, it atomically writes the highlighted source image path on initial load,
  navigation, and filter changes. It clears the selection when no items match or the
  request is cancelled or replaced. Existing final-selection output remains
  unchanged, and the live file is removed when the command exits.

  The theme switcher uses this at `$XDG_RUNTIME_DIR/omarchy-theme-selection`.
  Interactive switchers take a nonblocking lock so only one process owns the stable
  file. The picker child does not inherit that lock, preventing thumbnail workers
  from extending its lifetime. Cache preloads use neither the lock nor the live-
  selection file.

  This keeps the mechanism generic: other image-selector callers can opt into live
  selection without adding application-specific behavior to the picker.

  ### Validation

  - Added coverage for live-selection output, cleanup, and unchanged final output.
  - Added coverage for concurrent theme-switcher ownership and lock release while
  picker descendants remain alive.
  - Added picker coverage for initial publication, cancellation, filtering with no
  matches, and filter recovery.
  - `menu-images-test.sh` and `image-picker-test.sh` pass.
  - The new live-selection assertions pass through the Quickshell runtime smoke
  test.
  - Command metadata, Bash syntax, and whitespace checks pass.