### PR TITLE
Show an OSD when the firmware changes the ACPI platform profile

### DIFF
--- a/bin/omarchy-powerprofiles-osd-watch
+++ b/bin/omarchy-powerprofiles-osd-watch
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+
+# omarchy:summary=Show an OSD when the firmware changes the ACPI platform profile
+# omarchy:hidden=true
+
+# Laptops with a mode key (ThinkPad Fn+M, ASUS Fn+F5) let the firmware switch
+# the platform profile behind everyone's back, so the profile changes with no
+# feedback at all -- unlike volume or brightness, which always show an OSD.
+#
+# The kernel asserts POLLPRI on the sysfs node as soon as the firmware flips it.
+# Watching that directly rather than power-profiles-daemon's ActiveProfile is
+# what makes the OSD immediate: the daemon monitors the same file through
+# GLib's GFileMonitor, which coalesces changes for ~2s before emitting the DBus
+# signal, so an OSD driven off DBus lands two seconds after the key press.
+
+import select
+import subprocess
+import sys
+from pathlib import Path
+
+SYSFS = Path("/sys/firmware/acpi/platform_profile")
+
+# Labels and glyphs match the power panel in the Omarchy shell, so the OSD and
+# the panel name the same profile the same way.
+PROFILES = {
+    "performance": ("Performance", "\U000f04c5"),
+    "balanced": ("Balanced", "\U000f029a"),
+    "balanced-performance": ("Balanced", "\U000f029a"),
+    "low-power": ("Power Saver", "\U000f032a"),
+    "power-saver": ("Power Saver", "\U000f032a"),
+    "quiet": ("Power Saver", "\U000f032a"),
+}
+
+
+def show_osd(profile):
+    label, glyph = PROFILES.get(profile, (profile, "\U000f029a"))
+    subprocess.Popen(
+        ["omarchy-osd", "-i", glyph, "-m", label],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def main():
+    # The unit already guards on the node existing; this keeps the command
+    # usable by hand on hardware that has no platform profile.
+    if not SYSFS.exists():
+        return 0
+
+    with SYSFS.open("rb") as node:
+        poller = select.poll()
+        poller.register(node, select.POLLPRI | select.POLLERR)
+        last = node.read().decode().strip()
+
+        while True:
+            poller.poll()
+            node.seek(0)
+            current = node.read().decode().strip()
+
+            if current and current != last:
+                show_osd(current)
+                last = current
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/default/systemd/user/omarchy-powerprofiles-osd.service
+++ b/default/systemd/user/omarchy-powerprofiles-osd.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Show an OSD when the firmware changes the ACPI platform profile
+# The OSD is drawn by the Omarchy shell, which is only up once the graphical
+# session is.
+After=graphical-session.target
+PartOf=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+# Desktops and laptops without a mode key never expose the node, so the unit
+# stays enabled but inert there rather than restarting a watcher with nothing
+# to watch.
+ConditionPathExists=/sys/firmware/acpi/platform_profile
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-powerprofiles-osd-watch
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -18,4 +18,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  omarchy-powerprofiles-osd.service

--- a/migrations/1788961822.sh
+++ b/migrations/1788961822.sh
@@ -1,0 +1,21 @@
+echo "Show an OSD when the firmware changes the ACPI platform profile"
+
+# install/user/first-run only runs on the first login of a fresh install, so
+# existing installs get the unit enabled here instead.
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# `systemctl enable` needs a live user manager, which an update from a TTY does
+# not have, so fall back to writing the symlink it would have written.
+if ! systemctl --user enable omarchy-powerprofiles-osd.service >/dev/null 2>&1; then
+  wants_dir="$HOME/.config/systemd/user/graphical-session.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn /usr/lib/systemd/user/omarchy-powerprofiles-osd.service \
+    "$wants_dir/omarchy-powerprofiles-osd.service"
+fi
+
+# Nothing to start into over SSH; the next graphical login handles it. A failed
+# start only delays the OSD, so it stays quiet.
+if systemctl --user is-active --quiet graphical-session.target; then
+  systemctl --user start omarchy-powerprofiles-osd.service >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
Laptops with a mode key (ThinkPad Fn+M, ASUS Fn+F5) let the firmware switch the ACPI platform profile on its own, and nothing tells the user it happened — unlike volume or brightness, which always show an OSD. This adds that feedback.

This is a rework of #5802, which was closed because it drew the OSD through SwayOSD. It now uses `omarchy-osd`, and the glyphs and labels come from the shell's own power panel (`shell/plugins/panels/power/Model.js`), so the OSD and the panel name each profile the same way.

## Why watch sysfs instead of power-profiles-daemon

Listening to `net.hadess.PowerProfiles` `PropertiesChanged` works, but the OSD lands about two seconds after the key press. Three detectors running side by side on the same change:

```
+11.710s [POLLPRI ] sysfs=performance     ← kernel/firmware updated /sys
+11.712s [INOTIFY ] event=changed
+13.713s [INOTIFY ] event=changes-done-hint
+13.730s [DBUS    ] ActiveProfile=performance
```

`power-profiles-daemon` monitors the same file through GLib's `GFileMonitor`, which coalesces `changed` events for ~2s before firing `changes-done-hint`, and only emits the DBus signal at the end of that window. Watching the sysfs node directly with `POLLPRI` reacts to the kernel notification immediately.

## Files

- `bin/omarchy-powerprofiles-osd-watch` — Python stdlib watcher (`select.poll()` + `POLLPRI`), hidden command.
- `default/systemd/user/omarchy-powerprofiles-osd.service` — modelled on `omarchy-crash-watch.service`; `ConditionPathExists` on the sysfs node keeps it inert on hardware without a platform profile.
- `install/user/first-run/enable-user-units.sh` — enables the unit on new installs.
- `migrations/1788961822.sh` — enables it for existing installs, with the same TTY fallback the crash-watch migration uses.

## Test plan

- [ ] Mode key on a supported laptop shows the OSD immediately.
- [ ] `powerprofilesctl set performance|balanced|power-saver` also produces one.
- [ ] Machine without `/sys/firmware/acpi/platform_profile`: unit stays inert, no restart loop.
- [ ] `omarchy update` on an existing install enables and starts the unit.

Tested on a Lenovo ThinkPad Z13 G2 (AMD, `amd_pstate`). `./test/cli` passes.
