### PR TITLE
Remember the text size per display

### DIFF
--- a/bin/omarchy-display-text-size
+++ b/bin/omarchy-display-text-size
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Scale text everywhere — omarchy shell, GTK apps, and terminals
-# omarchy:args=[size|reset]
-# omarchy:examples=omarchy display text size | omarchy display text size 16 | omarchy display text size reset
+# omarchy:args=[size|reset|sync]
+# omarchy:examples=omarchy display text size | omarchy display text size 16 | omarchy display text size reset | omarchy display text size sync
 
 # One knob for apparent text size across the desktop. It drives three settings
 # in lockstep, all anchored to the shell default of 12px:
@@ -13,6 +13,12 @@
 # The shell override layers on top of the active theme (so the size survives
 # theme switches) and the shell watches the file, so shell text re-flows live.
 # Accepts an integer from 9 to 20 (px).
+#
+# The size is remembered per display: a laptop panel sits close, a desk monitor
+# sits further back, so the size that suits one rarely suits the other. Setting
+# a size records it for the external monitors connected at the time (or for the
+# built-in panel alone), and `sync` -- run by the monitor watcher on every
+# hotplug -- puts back whatever was last used with that set of displays.
 
 MIN=9
 MAX=20
@@ -24,12 +30,14 @@ TERM_DEFAULT_PT=9
 SHELL_DEFAULT_PX=12
 
 shell_config="$HOME/.config/omarchy/shell.toml"
+sizes_file="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/text-sizes"
 
 usage() {
-  echo "Usage: omarchy-display-text-size [size|reset]"
+  echo "Usage: omarchy-display-text-size [size|reset|sync]"
   echo "  (no args)   print the current text size, GTK factor, and terminal size"
   echo "  <size>      set text size in px ($MIN–$MAX); shell + GTK + terminals together"
   echo "  reset       return all three to their defaults (12px / 1.0 / 9pt)"
+  echo "  sync        apply the size last used with the displays connected right now"
 }
 
 # ---- shell base-size: the rem root every shell type size derives from ----
@@ -193,6 +201,82 @@ term_current_pt() {
   fi
 }
 
+# ---- per-display memory ----
+
+# Which displays the size belongs to: the external monitors by EDID description
+# (so a monitor keeps its size across ports), sorted so the key does not depend
+# on plug order, or "internal" when only the built-in panel is connected.
+display_key() {
+  local key
+  key=$(hyprctl monitors all -j 2>/dev/null | jq -r '
+    [.[] | select(.name | test("^(eDP|LVDS|DSI)-") | not) | .description // .name]
+    | sort | join(" + ")' 2>/dev/null)
+  echo "${key:-internal}"
+}
+
+# Print the size recorded for the current displays, or nothing if none is.
+remembered_size() {
+  [[ -f $sizes_file ]] || return 0
+  awk -F'\t' -v key="$(display_key)" '$1 == key { print $2; exit }' "$sizes_file"
+}
+
+# Record a size (or "default") for the current displays, replacing any earlier
+# entry for the same key.
+remember_size() {
+  local size="$1" key tmp
+  key="$(display_key)"
+  mkdir -p "$(dirname "$sizes_file")"
+  tmp="$(mktemp)"
+  [[ -f $sizes_file ]] && awk -F'\t' -v key="$key" '$1 != key' "$sizes_file" >"$tmp"
+  printf '%s\t%s\n' "$key" "$size" >>"$tmp"
+  mv "$tmp" "$sizes_file"
+}
+
+# ---- applying a size ----
+
+apply_size() {
+  local size="$1"
+
+  # Shell side: base-size in px (the omarchy shell's rem root).
+  set_base_size "$size"
+
+  # GTK side: multiplier anchored so 12px == 1.0, quantized so the interface
+  # font renders at a whole point size. Raw ratios yield fractional point sizes,
+  # which GTK4 menus clip at the ascenders on scale-1 monitors.
+  local factor
+  factor="$(awk -v s="$size" -v b="$SHELL_DEFAULT_PX" -v f="$(gtk_font_pt)" \
+    'BEGIN { printf "%.4f", int(f * s / b + 0.5) / f }')"
+  set_factor "$factor"
+
+  # Terminal side: point size anchored so 12px == 9pt.
+  set_terminal_size "$(term_pt_for "$size")"
+}
+
+apply_default() {
+  reset_base_size
+  gsettings reset "$GKEY_SCHEMA" "$GKEY_NAME" 2>/dev/null || true
+  set_terminal_size "$TERM_DEFAULT_PT"
+}
+
+# Put back the size last used with the displays connected now. Displays seen
+# for the first time adopt the current size, so the next visit finds it.
+sync_size() {
+  local current wanted
+  current="$(current_base_size)"
+  current="${current:-default}"
+  wanted="$(remembered_size)"
+
+  if [[ -z $wanted ]]; then
+    remember_size "$current"
+  elif [[ $wanted == "$current" ]]; then
+    return 0
+  elif [[ $wanted == "default" ]]; then
+    apply_default
+  elif [[ $wanted =~ ^[0-9]+$ ]] && ((wanted >= MIN && wanted <= MAX)); then
+    apply_size "$wanted"
+  fi
+}
+
 case "${1:-}" in
   -h | --help)
     usage
@@ -208,9 +292,12 @@ case "${1:-}" in
     exit 0
     ;;
   reset | default)
-    reset_base_size
-    gsettings reset "$GKEY_SCHEMA" "$GKEY_NAME" 2>/dev/null || true
-    set_terminal_size "$TERM_DEFAULT_PT"
+    apply_default
+    remember_size default
+    exit 0
+    ;;
+  sync)
+    sync_size
     exit 0
     ;;
 esac
@@ -222,15 +309,5 @@ if [[ ! $size =~ ^[0-9]+$ ]] || ((size < MIN || size > MAX)); then
   exit 1
 fi
 
-# Shell side: base-size in px (the omarchy shell's rem root).
-set_base_size "$size"
-
-# GTK side: multiplier anchored so 12px == 1.0, quantized so the interface
-# font renders at a whole point size. Raw ratios yield fractional point sizes,
-# which GTK4 menus clip at the ascenders on scale-1 monitors.
-factor="$(awk -v s="$size" -v b="$SHELL_DEFAULT_PX" -v f="$(gtk_font_pt)" \
-  'BEGIN { printf "%.4f", int(f * s / b + 0.5) / f }')"
-set_factor "$factor"
-
-# Terminal side: point size anchored so 12px == 9pt.
-set_terminal_size "$(term_pt_for "$size")"
+apply_size "$size"
+remember_size "$size"

--- a/bin/omarchy-hyprland-monitor-watch
+++ b/bin/omarchy-hyprland-monitor-watch
@@ -15,6 +15,7 @@ sync_clamshell() {
 
 sync_clamshell_after_monitor_change() {
   sync_clamshell
+  omarchy-display-text-size sync
 
   (
     for delay in 1 3 7; do

--- a/manual/33-monitors.md
+++ b/manual/33-monitors.md
@@ -30,6 +30,8 @@ omarchy display text size 14
 
 That takes a pixel size between 9 and 20, and moves the Omarchy shell, GTK applications, and your terminal together, so the whole desktop stays in proportion. Run it without an argument to see where you're at, and `omarchy display text size reset` to go back to the default. Foot is the one straggler: it has no way to reload its config, so running terminals keep their old size until you open a new one.
 
+The size sticks to the displays you set it with. A laptop screen sits close and a desk monitor sits further back, so pick a size on the laptop, pick another once the monitor is connected, and Omarchy switches between the two whenever you dock and undock. A monitor you plug in for the first time keeps whatever size you're already using.
+
 ### Extending and mirroring laptop displays
 
 When you connect an external screen to your laptop, the display is automatically extended. But you can change that to mirroring instead using _Trigger > Hardware_ in the Omarchy menu or `Super + Ctrl + Alt + Delete`. This is especially helpful if that external screen is a projector, and you want to show something while working.

--- a/test/shell.d/display-text-size-test.sh
+++ b/test/shell.d/display-text-size-test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+home_dir="$test_tmp/home"
+foot_ini="$home_dir/.config/foot/foot.ini"
+shell_toml="$home_dir/.config/omarchy/shell.toml"
+sizes_file="$home_dir/.local/state/omarchy/text-sizes"
+
+mkdir -p "$stub_bin" "$home_dir/.config/foot" "$home_dir/.config/omarchy"
+
+# Monitors come from OMARCHY_TEST_MONITORS: name=description pairs separated
+# by ";", so a test can plug and unplug displays by env.
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+
+if [[ $1 == "monitors" && $2 == "all" && $3 == "-j" ]]; then
+  json="["
+  sep=""
+  IFS=";" read -ra monitors <<<"$OMARCHY_TEST_MONITORS"
+  for monitor in "${monitors[@]}"; do
+    json+="$sep{\"name\":\"${monitor%%=*}\",\"description\":\"${monitor#*=}\"}"
+    sep=","
+  done
+  printf '%s]' "$json"
+else
+  exit 1
+fi
+SH
+
+cat >"$stub_bin/gsettings" <<'SH'
+#!/bin/bash
+[[ $1 == "get" ]] && echo "'Liberation Sans 11'"
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+echo 1
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+chmod +x "$stub_bin"/*
+
+run_text_size() {
+  HOME="$home_dir" \
+    XDG_STATE_HOME="$home_dir/.local/state" \
+    PATH="$stub_bin:$PATH" \
+    OMARCHY_TEST_MONITORS="${OMARCHY_TEST_MONITORS:-}" \
+    "$ROOT/bin/omarchy-display-text-size" "$@"
+}
+
+shell_base_size() {
+  grep -oP '^base-size = \K[0-9]+' "$shell_toml" 2>/dev/null || echo default
+}
+
+foot_size() {
+  grep -oP ':size=\K[0-9]+' "$foot_ini"
+}
+
+reset_configs() {
+  printf '[main]\nfont=JetBrainsMono Nerd Font:size=9\n' >"$foot_ini"
+  : >"$shell_toml"
+  rm -f "$sizes_file"
+}
+
+laptop="eDP-1=BOE 0x0A5D"
+desk="DP-3=Dell Inc. DELL U2720Q ABC123"
+
+# Fresh state: a sync records the size in use for the displays it finds.
+reset_configs
+OMARCHY_TEST_MONITORS="$laptop" run_text_size sync
+grep -Fx $'internal\tdefault' "$sizes_file" >/dev/null || fail "sync records the default size for the internal panel"
+[[ $(shell_base_size) == "default" ]] || fail "sync leaves an unknown display at the current size"
+pass "sync records the current size for displays seen for the first time"
+
+# Setting a size while docked remembers it for that monitor, not the panel.
+OMARCHY_TEST_MONITORS="$laptop;$desk" run_text_size 14
+grep -Fx $'Dell Inc. DELL U2720Q ABC123\t14' "$sizes_file" >/dev/null || fail "setting a size records it for the external monitor"
+grep -Fx $'internal\tdefault' "$sizes_file" >/dev/null || fail "setting a size keeps the internal panel entry"
+[[ $(shell_base_size) == "14" ]] || fail "setting a size updates the shell base-size"
+[[ $(foot_size) == "11" ]] || fail "setting a size updates the terminal size"
+pass "setting a size remembers it for the connected external monitor"
+
+# Undocking puts the panel's size back; docking again restores the monitor's.
+OMARCHY_TEST_MONITORS="$laptop" run_text_size sync
+[[ $(shell_base_size) == "default" ]] || fail "sync restores the default shell size on the internal panel"
+[[ $(foot_size) == "9" ]] || fail "sync restores the default terminal size on the internal panel"
+pass "sync restores the internal panel size after undocking"
+
+OMARCHY_TEST_MONITORS="$laptop;$desk" run_text_size sync
+[[ $(shell_base_size) == "14" ]] || fail "sync restores the shell size for the external monitor"
+[[ $(foot_size) == "11" ]] || fail "sync restores the terminal size for the external monitor"
+pass "sync restores the external monitor size after docking"
+
+# Clamshell: the panel dropping out does not change the key, so no rewrite.
+before=$(stat -c %y "$foot_ini")
+OMARCHY_TEST_MONITORS="$desk" run_text_size sync
+[[ $(shell_base_size) == "14" ]] || fail "sync keeps the external monitor size with the lid closed"
+[[ $(stat -c %y "$foot_ini") == "$before" ]] || fail "sync leaves configs alone when the size already matches"
+pass "closing the lid keeps the external monitor size"
+
+# The same monitor on another port keeps its size; a new one adopts the current.
+OMARCHY_TEST_MONITORS="$laptop;HDMI-A-1=Dell Inc. DELL U2720Q ABC123" run_text_size sync
+[[ $(shell_base_size) == "14" ]] || fail "sync keys the size on the monitor, not the port"
+pass "a monitor keeps its size across ports"
+
+OMARCHY_TEST_MONITORS="$laptop;DP-4=LG Electronics LG ULTRAFINE 0" run_text_size sync
+[[ $(shell_base_size) == "14" ]] || fail "sync keeps the current size for a monitor seen for the first time"
+grep -Fx $'LG Electronics LG ULTRAFINE 0\t14' "$sizes_file" >/dev/null || fail "sync records the current size for a new monitor"
+pass "a new monitor adopts the size in use"
+
+# Two monitors form their own key, sorted so plug order does not matter.
+OMARCHY_TEST_MONITORS="$laptop;DP-4=LG Electronics LG ULTRAFINE 0;$desk" run_text_size 16
+OMARCHY_TEST_MONITORS="$laptop;$desk;DP-4=LG Electronics LG ULTRAFINE 0" run_text_size sync
+[[ $(shell_base_size) == "16" ]] || fail "sync matches a pair of monitors regardless of plug order"
+pass "a pair of monitors shares one size regardless of plug order"
+
+# Reset remembers the default for the current displays.
+OMARCHY_TEST_MONITORS="$laptop;$desk" run_text_size reset
+grep -Fx $'Dell Inc. DELL U2720Q ABC123\tdefault' "$sizes_file" >/dev/null || fail "reset records the default for the external monitor"
+[[ $(shell_base_size) == "default" ]] || fail "reset drops the shell base-size"
+pass "reset remembers the default for the connected displays"
+
+# Without Hyprland, everything keys on the internal panel and still works.
+reset_configs
+OMARCHY_TEST_MONITORS="" run_text_size 13
+grep -Fx $'internal\t13' "$sizes_file" >/dev/null || fail "no monitors keys on the internal panel"
+pass "no monitor information falls back to the internal panel"

--- a/test/shell.d/monitor-modeless-test.sh
+++ b/test/shell.d/monitor-modeless-test.sh
@@ -91,6 +91,12 @@ cat >"$fake_bin/omarchy-hw-laptop" <<'SH'
 exit 1
 SH
 
+cat >"$fake_bin/omarchy-display-text-size" <<'SH'
+#!/bin/bash
+
+exit 0
+SH
+
 cat >"$fake_bin/omarchy-hyprland-monitor-clamshell" <<'SH'
 #!/bin/bash
 

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -31,6 +31,9 @@ grep -F 'sync_clamshell_after_monitor_change' "$monitor_watch" >/dev/null
 grep -F 'socat -U - "UNIX-CONNECT:$SOCKET"' "$monitor_watch" >/dev/null
 pass "monitor watcher reconciles clamshell state on startup"
 
+grep -F 'omarchy-display-text-size sync' "$monitor_watch" >/dev/null
+pass "monitor watcher restores the text size for the connected displays"
+
 grep -F 'omarchy-hw-laptop && omarchy-hyprland-monitor-external-active' "$monitor_watch" >/dev/null
 grep -F 'sync_poll_state' "$monitor_watch" >/dev/null
 grep -F 'done < <(socat' "$monitor_watch" >/dev/null


### PR DESCRIPTION
`omarchy display text size` is one global knob, and the size that reads well on the laptop panel is too small on a desk monitor a metre away. I kept bumping it up when docking and back down when leaving, so this makes the command remember the size per display and has the monitor watcher put it back on hotplug.

How it works:

- Setting a size (or `reset`) records it in `~/.local/state/omarchy/text-sizes`, keyed by the EDID descriptions of the external monitors connected at the time, sorted so plug order doesn't matter. With only the built-in panel the key is `internal`.
- A new `sync` subcommand applies whatever was last used with the displays connected now. A display set seen for the first time adopts the current size, so the first dock doesn't move anything.
- `omarchy-hyprland-monitor-watch` runs `sync` on every monitor add/remove, right after the clamshell reconcile, and once at startup.

The key only looks at external monitors, so closing the lid on a docked laptop changes nothing: panel + Studio and Studio alone share one size.

Foot still needs a new window to pick the size up, same as with a manual change. #7794 would make the hotplug switch seamless there too.

Tested on a MacBook Pro with an Apple Studio Display: 12px on the panel, 14px docked, switching both ways through dock/undock and the clamshell path. `./test/cli` and the monitor and text-size shell tests pass. New coverage is in `test/shell.d/display-text-size-test.sh`, and the watcher tests stub the new call.
