### PR TITLE
Add hardware speaker firmware regression check

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,6 +32,16 @@ A new shell test only needs the right name: drop `<area>-test.sh` into
 `test/shell.d/` and `./test/shell` picks it up automatically. Shared fixtures
 live under `test/shell.d/fixtures/`.
 
+## Built-in speaker hardware smoke test
+
+Run `./test/audio` from an installed desktop session after booting a kernel update. This is a read-only, non-graphical hardware check: it does not restart services, change routing or volume, load drivers, install firmware, or play audio. It is deliberately excluded from `./test/all` and the VM acceptance suite, whose virtual sound hardware cannot exercise a laptop's physical speaker amplifiers. Its fixture tests run in `./test/shell` without audio hardware or journal access.
+
+The check requires each user audio service to be running and a physical ALSA speaker output to be registered. On a `spk:cs35l56-bridge` speaker route it also requires visible firmware initialization in the current boot's kernel journal and rejects `FIRMWARE_MISSING` from either amplifier. Exit status 1 means a check failed; status 2 means required device or journal evidence could not be read. An inaccessible or empty journal does not count as success. On another speaker route the CS35L56 check is explicitly skipped.
+
+This covers the Dell XPS 13 DX13260 regression tracked in [#9687](https://github.com/omacom/omarchy/issues/9687): a kernel update activated the sidecar amplifiers while their selected firmware was unavailable. PipeWire, WirePlumber, an unmuted speaker sink, and application playback all appeared healthy. The missing-firmware fixture contains sanitized kernel messages from that failure; the sink fixture retains only relevant fields. The successful firmware fixture is synthetic. The direct codec route was verified on the affected laptop after reloading `snd_soc_sof_sdw` with `quirk=1`, with audible playback confirmed separately.
+
+The firmware assertion audits errors across the current boot, rather than inferring recovery from a later version banner (ROM firmware also produces that banner). If the bridge remains selected after a same-boot firmware repair, reboot before using this as a clean-boot regression check. Switching to the direct codec route skips the bridge-specific check even if old errors remain in the journal. A pass proves only these software checks: it does not verify the speaker-ID mapping, safe tuning, full speaker performance, or audible output. Finish a hardware release check by playing audio and listening to both speakers.
+
 ## The base-test.sh contract
 
 Every shell test starts the same way:

--- a/test/audio
+++ b/test/audio
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Read-only smoke test for built-in speakers on an installed system.
+# Run after booting an updated kernel; CI exercises its failure cases with stubs.
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/shell.d/base-test.sh"
+
+incomplete() {
+  printf 'not ok - %s (check incomplete)\n' "$1" >&2
+  exit 2
+}
+
+for command in systemctl pactl jq journalctl; do
+  require_command "$command"
+done
+
+# is-active with multiple units succeeds when ANY unit is active.
+for unit in pipewire.service pipewire-pulse.service wireplumber.service; do
+  systemctl --user is-active --quiet "$unit" || fail "$unit is running"
+done
+pass "all user audio services are running"
+
+sinks=$(pactl --format=json list sinks) || incomplete "could not query playback devices"
+speakers=$(jq -ce '
+  if type != "array" then error("expected a sink array") else
+    [.[] | select(.properties["device.api"] == "alsa" and .properties["device.bus"] != "usb")
+      | select(any(.ports[]?; .type == "Speaker"))]
+  end
+' <<<"$sinks") || incomplete "could not parse playback devices"
+
+[[ $speakers != "[]" ]] || fail "a physical built-in speaker output is registered" "Dummy Output, HDMI, USB and Bluetooth do not establish that built-in speakers work."
+pass "a physical built-in speaker output is registered"
+
+# Firmware failures can leave a perfectly normal, unmuted PipeWire sink. Only
+# inspect CS35L56 errors when the current speaker route uses those amplifiers:
+# a same-boot switch back to the direct codec route leaves old errors behind.
+uses_bridge=$(jq -r 'any(.[]; (.properties["alsa.components"] // "") | test("(^| )spk:cs35l56-bridge( |$)"))' <<<"$speakers") ||
+  incomplete "could not parse speaker component metadata"
+if [[ $uses_bridge == "true" ]]; then
+  kernel_log=$(journalctl --quiet --boot=0 --dmesg --output=cat --no-pager) ||
+    incomplete "could not read the current boot kernel journal"
+  [[ -n $kernel_log ]] || incomplete "the current boot kernel journal is empty or inaccessible"
+
+  firmware_errors=$(grep -E '^cs35l56 [^ ]+: FIRMWARE_MISSING([[:space:]]|$)' <<<"$kernel_log" || true)
+  [[ -z $firmware_errors ]] || fail "CS35L56 speaker firmware has no failures this boot" "$firmware_errors"
+
+  # An empty/restricted journal must not become a green hardware test. This is
+  # initialization evidence, not proof of audible output or correct tuning.
+  grep -Eq '^cs35l56 [^ ]+: DSP1: Firmware:' <<<"$kernel_log" ||
+    incomplete "no CS35L56 firmware initialization is visible in the kernel journal"
+  pass "CS35L56 firmware initialization is visible without missing-firmware errors this boot"
+else
+  pass "CS35L56 firmware check not applicable to the current speaker route # SKIP"
+fi
+
+printf '# Audible playback is not verified. Play audio and confirm both speakers by listening.\n'

--- a/test/shell.d/fixtures/speaker-firmware/missing.log
+++ b/test/shell.d/fixtures/speaker-firmware/missing.log
@@ -1,0 +1,9 @@
+sof-audio-pci-intel-ptl 0000:00:1f.3: Booted firmware version: 2.14.1.1
+cs35l56 spi-cs35l56-right: DSP1: Firmware: 1a00d6 vendor: 0x2 v4.2.1, 42 algorithms
+cs35l56 spi-cs35l56-left: DSP1: Firmware: 1a00d6 vendor: 0x2 v4.2.1, 42 algorithms
+cs35l56 spi-cs35l56-right: FIRMWARE_MISSING
+cs35l56 spi-cs35l56-right: Calibration disabled due to missing firmware controls
+cs35l56 spi-cs35l56-left: FIRMWARE_MISSING
+cs35l56 spi-cs35l56-left: Calibration disabled due to missing firmware controls
+cs35l56 spi-cs35l56-right: Can't read tuning IDs
+cs35l56 spi-cs35l56-left: Can't read tuning IDs

--- a/test/shell.d/fixtures/speaker-firmware/sinks.json
+++ b/test/shell.d/fixtures/speaker-firmware/sinks.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "alsa_output.pci-0000_00_1f.3-platform-sof_sdw.HiFi__Speaker__sink",
+    "state": "SUSPENDED",
+    "mute": false,
+    "properties": {
+      "device.api": "alsa",
+      "device.bus": "pci",
+      "alsa.card": "0",
+      "alsa.components": "HDA:80862823,80860101,00100000 cfg-amp:3 iec61937-pcm:7,6,5 mic:cs42l43-dmic spk:cs35l56-bridge"
+    },
+    "active_port": "[Out] Speaker",
+    "ports": [{"name": "[Out] Speaker", "type": "Speaker", "availability": "availability unknown"}]
+  }
+]

--- a/test/shell.d/speaker-firmware-test.sh
+++ b/test/shell.d/speaker-firmware-test.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+fixtures="$ROOT/test/shell.d/fixtures/speaker-firmware"
+
+cat >"$test_tmp/bin/systemctl" <<'SH'
+#!/bin/bash
+printf 'systemctl %s\n' "$*" >>"$CALL_LOG"
+[[ $* == "--user is-active --quiet "* && $# == 4 ]] || exit 99
+[[ $4 != "${FAILED_UNIT:-}" ]]
+SH
+
+cat >"$test_tmp/bin/pactl" <<'SH'
+#!/bin/bash
+[[ $* == "--format=json list sinks" ]] || exit 99
+cat "$SINKS_FILE"
+exit "${PACTL_STATUS:-0}"
+SH
+
+cat >"$test_tmp/bin/journalctl" <<'SH'
+#!/bin/bash
+printf 'journalctl %s\n' "$*" >>"$CALL_LOG"
+[[ $* == "--quiet --boot=0 --dmesg --output=cat --no-pager" ]] || exit 99
+cat "$KERNEL_LOG"
+exit "${JOURNAL_STATUS:-0}"
+SH
+
+chmod +x "$test_tmp/bin"/*
+export CALL_LOG="$test_tmp/calls" SINKS_FILE="$test_tmp/sinks.json" KERNEL_LOG="$test_tmp/kernel.log"
+
+reset_case() {
+  cp "$fixtures/sinks.json" "$SINKS_FILE"
+  cp "$fixtures/missing.log" "$KERNEL_LOG"
+  : >"$CALL_LOG"
+  unset FAILED_UNIT PACTL_STATUS JOURNAL_STATUS
+}
+
+assert_result() {
+  local expected=$1 message=$2 description=$3 status=0 output
+  output=$(PATH="$test_tmp/bin:$PATH" bash "$ROOT/test/audio" 2>&1) || status=$?
+  (( status == expected )) || fail "$description" "expected status $expected, got $status: $output"
+  grep -Fq -- "$message" <<<"$output" || fail "$description" "$output"
+  pass "$description"
+}
+
+reset_case
+assert_result 1 "FIRMWARE_MISSING" "a registered unmuted sink and running services do not hide missing amplifier firmware"
+[[ $(grep -c '^systemctl ' "$CALL_LOG") == 3 ]] || fail "every audio service is checked separately"
+pass "every audio service is checked separately"
+
+for side in left right; do
+  reset_case
+  grep -v 'FIRMWARE_MISSING' "$fixtures/missing.log" >"$KERNEL_LOG"
+  printf 'cs35l56 spi-cs35l56-%s: FIRMWARE_MISSING\n' "$side" >>"$KERNEL_LOG"
+  assert_result 1 "spi-cs35l56-$side: FIRMWARE_MISSING" "a failure in only the $side amplifier is detected"
+done
+
+reset_case
+# Synthetic successful initialization: a firmware revision is deliberately not
+# pinned, since a future vendor firmware should not make the detector fail.
+printf 'cs35l56 spi-cs35l56-left: DSP1: Firmware: 1a00d6 vendor: 0x2 v4.5.9, 42 algorithms\ncs35l56 spi-cs35l56-right: DSP1: Firmware: 1a00d6 vendor: 0x2 v4.5.9, 42 algorithms\n' >"$KERNEL_LOG"
+assert_result 0 "Audible playback is not verified" "firmware initialization without known errors passes only the software checks"
+
+printf 'unrelated-device: FIRMWARE_MISSING\n' >>"$KERNEL_LOG"
+assert_result 0 "Audible playback is not verified" "unrelated firmware messages are not attributed to the speaker amplifiers"
+
+cat "$fixtures/missing.log" >>"$KERNEL_LOG"
+printf 'cs35l56 spi-cs35l56-left: DSP1: Firmware: 1a00d6 vendor: 0x2 v4.5.9, 42 algorithms\n' >>"$KERNEL_LOG"
+assert_result 1 "FIRMWARE_MISSING" "a later firmware banner does not erase a current-boot firmware failure"
+
+reset_case
+jq '.[0].properties["alsa.components"] = "cfg-amp:1 mic:cs42l43-dmic spk:cs42l43-spk"' "$fixtures/sinks.json" >"$SINKS_FILE"
+assert_result 0 "not applicable" "the restored direct speaker route ignores stale amplifier errors from before the reload"
+grep -q '^journalctl ' "$CALL_LOG" && fail "the direct route does not require access to kernel logs"
+pass "the direct route does not require access to kernel logs"
+
+for unit in pipewire.service pipewire-pulse.service wireplumber.service; do
+  reset_case
+  export FAILED_UNIT=$unit
+  assert_result 1 "$unit is running" "an inactive $unit fails even when the other services run"
+done
+
+reset_case
+printf '[{"name":"auto_null","properties":{}}]\n' >"$SINKS_FILE"
+assert_result 1 "physical built-in speaker output" "Dummy Output cannot satisfy the speaker test"
+
+reset_case
+jq '.[0].ports = [{"type":"HDMI"}]' "$fixtures/sinks.json" >"$SINKS_FILE"
+assert_result 1 "physical built-in speaker output" "an HDMI output cannot satisfy the built-in speaker test"
+
+reset_case
+jq '.[0].properties["device.api"] = "bluez5"' "$fixtures/sinks.json" >"$SINKS_FILE"
+assert_result 1 "physical built-in speaker output" "a Bluetooth speaker cannot hide a missing built-in speaker output"
+
+reset_case
+jq '.[0].properties["device.bus"] = "usb"' "$fixtures/sinks.json" >"$SINKS_FILE"
+assert_result 1 "physical built-in speaker output" "a USB ALSA speaker cannot hide a missing built-in speaker output"
+
+reset_case
+printf '[]\n' >"$SINKS_FILE"
+assert_result 1 "physical built-in speaker output" "no playback devices fails the speaker test"
+
+reset_case
+export PACTL_STATUS=1
+assert_result 2 "could not query" "an unavailable audio server is reported as incomplete"
+
+for invalid in 'not json' '{}' 'null'; do
+  reset_case
+  printf '%s\n' "$invalid" >"$SINKS_FILE"
+  assert_result 2 "could not parse" "invalid sink data ($invalid) cannot produce a passing check"
+done
+
+reset_case
+jq '.[0].properties["alsa.components"] = {}' "$fixtures/sinks.json" >"$SINKS_FILE"
+assert_result 2 "could not parse speaker component metadata" "malformed component metadata cannot skip the firmware check"
+
+reset_case
+export JOURNAL_STATUS=1
+assert_result 2 "could not read" "a failed kernel journal query is not a passing firmware check"
+
+reset_case
+: >"$KERNEL_LOG"
+assert_result 2 "empty or inaccessible" "an empty journal is not a passing firmware check"
+
+reset_case
+printf 'unrelated kernel message\n' >"$KERNEL_LOG"
+assert_result 2 "no CS35L56 firmware initialization" "a restricted or incomplete journal cannot prove firmware initialization"


### PR DESCRIPTION
Add an opt-in, read-only `./test/audio` smoke test for registered ALSA speaker outputs. It checks all three user audio services independently and detects current-boot CS35L56 missing-firmware errors when the speaker route uses the amplifier bridge. Missing device or journal evidence is reported as incomplete, and other speaker routes explicitly skip the bridge-specific check.

Add 25 fixture assertions to the standard shell suite covering missing firmware in either amplifier, healthy initialization, a direct codec route with stale boot errors, inactive services, Dummy Output, external outputs, malformed metadata, and unavailable journals. The test does not modify the system or play audio. A listening check remains necessary to establish audible playback.

Related to the already-public failure class tracked in #9687. This is detection coverage, not a driver or firmware fix. The hardware check is excluded from the default suite because virtual audio hardware cannot exercise physical speaker amplifiers; its fixture tests run without hardware.

Validation:
- All 25 fixture assertions pass, focused and within `./test/all`.
- ShellCheck and Bash syntax checks pass for the new scripts.
- `./test/all` completed: CLI passes; the initial shell run had 4 failures out of 237 files. Configuration coverage passed after fetching its required sibling checkout, About coverage passed with `NO_COLOR` unset, and locate coverage passed after clearing test-generated Python bytecode. The remaining network QR failure reproduces on unchanged upstream commit `5ead870507dfb68db696b3ddb948cc3d178e8d62`. No unrelated source changes are included.
