### PR TITLE
Toggle the layout of an open scratchpad, not the workspace under it

### DIFF
--- a/bin/omarchy-hyprland-workspace-layout-toggle
+++ b/bin/omarchy-hyprland-workspace-layout-toggle
@@ -2,11 +2,24 @@
 
 # omarchy:summary=Toggle the layout on the current active workspace between dwindle and scrolling
 
-ACTIVE_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
-[[ $ACTIVE_WORKSPACE =~ ^-?[0-9]+$ ]] || exit 1
-CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+# hyprctl activeworkspace never reports a special workspace, so an open scratchpad
+# has to be read off the focused monitor instead. Special workspace ids are handed
+# out at runtime (-98, -97, ...), so address it by its stable name.
+SPECIAL_WORKSPACE=$(hyprctl monitors -j | jq -r 'first(.[] | select(.focused) | .specialWorkspace.name // "")')
+
+if [[ -n $SPECIAL_WORKSPACE ]]; then
+  ACTIVE_WORKSPACE=$SPECIAL_WORKSPACE
+  LAYOUT_KEY=${SPECIAL_WORKSPACE//[^A-Za-z0-9._-]/_}
+  CURRENT_LAYOUT=$(hyprctl workspaces -j | jq -r --arg name "$SPECIAL_WORKSPACE" 'first(.[] | select(.name == $name) | .tiledLayout // "")')
+else
+  ACTIVE_WORKSPACE=$(hyprctl activeworkspace -j | jq -r '.id')
+  [[ $ACTIVE_WORKSPACE =~ ^-?[0-9]+$ ]] || exit 1
+  LAYOUT_KEY=$ACTIVE_WORKSPACE
+  CURRENT_LAYOUT=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+fi
+
 LAYOUTS_DIR="$HOME/.local/state/omarchy/workspace-layouts"
-LAYOUT_FILE="$LAYOUTS_DIR/$ACTIVE_WORKSPACE.lua"
+LAYOUT_FILE="$LAYOUTS_DIR/$LAYOUT_KEY.lua"
 
 case "$CURRENT_LAYOUT" in
   dwindle) NEW_LAYOUT=scrolling ;;


### PR DESCRIPTION
Fixes #4881. Supersedes #5099, which has gone stale against this script.

`hyprctl activeworkspace` never reports a special workspace, so with the scratchpad open and focused, `SUPER + L` read the regular workspace sitting underneath it and toggled that instead — the scratchpad's own layout never changed.

Reproduced on Omarchy 4.0.3-1, Hyprland 0.56.2, scratchpad focused with one window in it:

```
$ hyprctl monitors -j | jq -c '.[] | select(.focused) | {activeWorkspace, specialWorkspace}'
{"activeWorkspace":{"id":1,"name":"1"},"specialWorkspace":{"id":-98,"name":"special:scratchpad"}}

$ hyprctl workspaces -j | jq -c '.[] | {name,tiledLayout}'
{"name":"1","tiledLayout":"scrolling"}
{"name":"special:scratchpad","tiledLayout":"dwindle"}

$ omarchy-hyprland-workspace-layout-toggle
$ hyprctl workspaces -j | jq -c '.[] | {name,tiledLayout}'
{"name":"1","tiledLayout":"dwindle"}            # <- the wrong workspace flipped
{"name":"special:scratchpad","tiledLayout":"dwindle"}
```

The fix reads the special workspace off the **focused** monitor before falling back to `activeworkspace`, and addresses it by name. Two details this needed beyond the earlier attempt in #5099:

- The scratchpad has to come from the focused monitor rather than `.[0]`, or a second monitor's scratchpad wins on a multi-monitor setup.
- The saved rule file is keyed by workspace, and special workspace ids are handed out at runtime (`-98`, `-97`, …), so a name-derived key (`special_scratchpad.lua`) is what survives a restart. `hl.workspace_rule` matches `special:scratchpad` by name, so the rule applies on both the live `hyprctl eval` and the reload path through `default/hypr/workspace-layouts.lua`.

#5099 also predates the persisted workspace rules this script now writes, so merging it as-is would drop them along with the `hyprctl eval` path.

After the fix, same setup:

```
$ omarchy-hyprland-workspace-layout-toggle       # scratchpad focused
$ hyprctl workspaces -j | jq -c '.[] | {name,tiledLayout}'
{"name":"1","tiledLayout":"scrolling"}           # untouched
{"name":"special:scratchpad","tiledLayout":"scrolling"}

$ cat ~/.local/state/omarchy/workspace-layouts/special_scratchpad.lua
hl.workspace_rule({ workspace = "special:scratchpad", layout = "scrolling" })
```

Verified on the running session: both toggle directions on the scratchpad, the regular-workspace path unchanged, the layout surviving `hyprctl reload`, and `hyprctl configerrors` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETVxxboPLPeshzd7FpEAta
