### PR TITLE
Keep reminder notifications visible until dismissed

### DIFF
--- a/bin/omarchy-reminder
+++ b/bin/omarchy-reminder
@@ -195,7 +195,7 @@ if [[ -n $custom_message ]]; then
 fi
 
 systemd-run --user --quiet --collect --on-active="${minutes}m" --unit="$unit" \
-  bash -c 'omarchy-notification-send -g 󰢌 "Reminder" "$1"; rm -f "$2"; omarchy-shell -q omarchy.indicators refresh >/dev/null 2>&1 || true' bash "$message" "$message_file"
+  bash -c 'omarchy-notification-send -g 󰢌 "Reminder" "$1" -u critical; rm -f "$2"; omarchy-shell -q omarchy.indicators refresh >/dev/null 2>&1 || true' bash "$message" "$message_file"
 
 refresh_indicator
 omarchy-notification-send -g 󰢌 "$confirmation_title" "$confirmation"

--- a/manual/09-reminders.md
+++ b/manual/09-reminders.md
@@ -1,5 +1,5 @@
 # Reminders
 
-Omarchy has a built-in way to set simple reminders based on a countdown timer and with a message. You can do this via `Super + Ctrl + R`, seeing all the ones set via `Super + Ctrl + Alt + R`, and clearing all via `Super + Ctrl + Shift + R`. Everything also accessible via _Trigger > Reminder_. You can also use the cli with `omarchy reminder 7 'Tea ready'`.
+Omarchy has a built-in way to set simple reminders based on a countdown timer and with a message. When a reminder fires, its notification remains visible until you dismiss it. You can do this via `Super + Ctrl + R`, seeing all the ones set via `Super + Ctrl + Alt + R`, and clearing all via `Super + Ctrl + Shift + R`. Everything also accessible via _Trigger > Reminder_. You can also use the cli with `omarchy reminder 7 'Tea ready'`.
 
  ![reminders](images/reminders.webp)

--- a/test/shell.d/reminders-test.sh
+++ b/test/shell.d/reminders-test.sh
@@ -32,3 +32,36 @@ assertDeepEqual(
   'reminders command args are empty for invalid minutes'
 )
 JS
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+printf '%s\n' \
+  '#!/bin/bash' \
+  'printf "%s\n" "$@" >"$OMARCHY_TEST_SYSTEMD_RUN_ARGS"' \
+  >"$tmpdir/systemd-run"
+chmod +x "$tmpdir/systemd-run"
+
+printf '%s\n' '#!/bin/bash' 'exit 0' >"$tmpdir/omarchy-notification-send"
+chmod +x "$tmpdir/omarchy-notification-send"
+
+printf '%s\n' '#!/bin/bash' 'exit 0' >"$tmpdir/omarchy-shell"
+chmod +x "$tmpdir/omarchy-shell"
+
+args_file="$tmpdir/systemd-run-args"
+OMARCHY_TEST_SYSTEMD_RUN_ARGS="$args_file" \
+  PATH="$tmpdir:$ROOT/bin:$PATH" \
+  XDG_RUNTIME_DIR="$tmpdir/runtime" \
+  omarchy-reminder 5 "Check the oven"
+
+mapfile -t run_args <"$args_file"
+timer_payload=""
+for ((i = 0; i < ${#run_args[@]}; i++)); do
+  if [[ ${run_args[i]} == "-c" ]]; then
+    timer_payload=${run_args[i + 1]}
+    break
+  fi
+done
+
+[[ $timer_payload == *'omarchy-notification-send -g 󰢌 "Reminder" "$1" -u critical'* ]] || fail "reminders use a persistent critical notification" "$timer_payload"
+pass "reminders use a persistent critical notification"


### PR DESCRIPTION
## Summary

- Send fired reminder notifications at critical urgency, which stays on screen until dismissed.
- Document the acknowledgement-required behavior.
- Add a regression test for the timer payload.

## Context

Implements the request in https://github.com/omacom/omarchy/discussions/5784.

This is deliberately limited to fired reminders. It does not change the general critical-notification lifetime discussed in #9361; the existing dismissal paths remain available. #10679 independently changes how reminder timers behave across suspend and may need a trivial rebase if it merges first.

## Verification

- `bash test/shell.d/reminders-test.sh`
- `bin/omarchy commands --check`
- `bash -n bin/omarchy-reminder`
- `git diff --check`
- Visual: a critical reminder stayed visible after six seconds and then dismissed normally.