### PR TITLE
Add default shortcut to delete to beginning of line

### DIFF
--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -16,7 +16,52 @@ o.bind("XF86Calculator", "Calculator", "omacalc")
 o.bind_toggle("SUPER + SHIFT + SPACE", "Toggle top bar", "bar")
 o.bind("SUPER + CTRL + SPACE", "Background switcher", "omarchy-menu toggle background")
 o.bind("SUPER + SHIFT + CTRL + SPACE", "Theme menu", "omarchy-menu toggle theme")
-o.bind("SUPER + BACKSPACE", "Toggle window transparency", "omarchy-hyprland-window-transparency-toggle")
+
+local function active_window_is_terminal()
+  local window = hl.get_active_window()
+  if not window then
+    return false
+  end
+
+  for _, tag in ipairs(window.tags or {}) do
+    if tag:gsub("%*$", "") == "terminal" then
+      return true
+    end
+  end
+
+  return false
+end
+
+local function delete_to_beginning_of_line()
+  local events
+  if active_window_is_terminal() then
+    events = {
+      { mods = "CTRL", key = "U", state = "down" },
+      { mods = "CTRL", key = "U", state = "up" },
+    }
+  else
+    events = {
+      { mods = "SHIFT", key = "HOME", state = "down" },
+      { mods = "SHIFT", key = "HOME", state = "up" },
+      { mods = "", key = "BACKSPACE", state = "down" },
+      { mods = "", key = "BACKSPACE", state = "up" },
+    }
+  end
+
+  local function send(index)
+    hl.dispatch(hl.dsp.send_key_state(events[index]))
+    if index < #events then
+      hl.timer(function()
+        send(index + 1)
+      end, { timeout = 25, type = "oneshot" })
+    end
+  end
+
+  send(1)
+end
+
+o.bind("SUPER + BACKSPACE", "Delete to beginning of line", delete_to_beginning_of_line)
+o.bind("SUPER + ALT + BACKSPACE", "Toggle window transparency", "omarchy-hyprland-window-transparency-toggle")
 o.bind("SUPER + SHIFT + BACKSPACE", "Toggle window gaps", "omarchy-hyprland-window-gaps-toggle")
 o.bind("SUPER + CTRL + BACKSPACE", "Toggle single-window square aspect", "omarchy-hyprland-window-single-square-aspect-toggle")
 o.bind_toggle("SUPER + CTRL + ALT + F", "Toggle full screen desktop", "fullscreen-desktop")

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -17,8 +17,7 @@ o.bind_toggle("SUPER + SHIFT + SPACE", "Toggle top bar", "bar")
 o.bind("SUPER + CTRL + SPACE", "Background switcher", "omarchy-menu toggle background")
 o.bind("SUPER + SHIFT + CTRL + SPACE", "Theme menu", "omarchy-menu toggle theme")
 
-local function active_window_is_terminal()
-  local window = hl.get_active_window()
+local function active_window_is_terminal(window)
   if not window then
     return false
   end
@@ -32,9 +31,16 @@ local function active_window_is_terminal()
   return false
 end
 
+local deleting_line = false
+
 local function delete_to_beginning_of_line()
+  local window = hl.get_active_window()
+  if deleting_line or not window then
+    return
+  end
+
   local events
-  if active_window_is_terminal() then
+  if active_window_is_terminal(window) then
     events = {
       { mods = "CTRL", key = "U", state = "down" },
       { mods = "CTRL", key = "U", state = "up" },
@@ -48,12 +54,22 @@ local function delete_to_beginning_of_line()
     }
   end
 
+  deleting_line = true
   local function send(index)
+    -- Always release an injected key, but never start the next key press
+    -- after focus moves to another window. Ignore overlapping invocations.
+    local active = hl.get_active_window()
+    if events[index].state == "down" and (not active or active.address ~= window.address) then
+      deleting_line = false
+      return
+    end
     hl.dispatch(hl.dsp.send_key_state(events[index]))
     if index < #events then
       hl.timer(function()
         send(index + 1)
       end, { timeout = 25, type = "oneshot" })
+    else
+      deleting_line = false
     end
   end
 

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -138,6 +138,8 @@ Change/add bindings in `~/.config/hypr/bindings.lua`.
 
 Usually on Linux, you need `Ctrl + Shift + C/V` to copy'n'paste in the terminal and `Ctrl + C/V` to do it everywhere else. These Omarchy unified clipboard hotkeys work everywhere.
 
+Line deletion sends `Ctrl + U` in terminal windows and `Shift + Home`, then `Backspace`, in other applications. Its effect follows the application's keybindings, including how Home handles indentation and wrapped lines. Embedded terminals use their host application's route; terminal programs and shell editing modes may interpret `Ctrl + U` differently.
+
 ## Capture
 
 | Hotkey              | Function                       |

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -126,7 +126,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 
 Change/add bindings in `~/.config/hypr/bindings.lua`.
 
-## Universal clipboard
+## Universal clipboard and editing
 
 | Hotkey                  | Function              |
 | ----------------------- | --------------------- |
@@ -134,6 +134,7 @@ Change/add bindings in `~/.config/hypr/bindings.lua`.
 | `Super + X`           | Cut (not in terminal)    |
 | `Super + V`           | Paste    |
 | `Super + Ctrl + V`           | Clipboard manager    |
+| `Super + Backspace` | Delete to beginning of line (`Ctrl + U` in terminals) |
 
 Usually on Linux, you need `Ctrl + Shift + C/V` to copy'n'paste in the terminal and `Ctrl + C/V` to do it everywhere else. These Omarchy unified clipboard hotkeys work everywhere.
 
@@ -173,7 +174,7 @@ All capture options are also accessible under _Trigger > Capture_ in the Omarchy
 | ----------------------- | --------------------- |
 | `Super + Ctrl + Shift + Space` | Pick a new theme  |
 | `Super + Ctrl + Space` | Pick theme background |
-| `Super + Backspace` | Toggle transparency on a window |
+| `Super + Alt + Backspace` | Toggle transparency on a window |
 | `Super + Ctrl + Backspace` | Toggle single-window square aspect |
 
 Extra background images live in `~/.config/omarchy/backgrounds/<theme name>`. Also available via _Install > Style > Background_ in the Omarchy menu.

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -119,22 +119,6 @@ if grep -F 'wtype -M' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null; th
 fi
 pass "universal clipboard shortcuts avoid virtual keyboard modifier merging"
 
-grep -F 'o.bind("SUPER + BACKSPACE", "Delete to beginning of line", delete_to_beginning_of_line)' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
-  fail "Super + Backspace deletes to the beginning of the line"
-grep -F '{ mods = "SHIFT", key = "HOME", state = "down" }' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
-  fail "line deletion selects from the cursor to the beginning of the line"
-grep -F '{ mods = "", key = "BACKSPACE", state = "down" }' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
-  fail "line deletion removes the selected text"
-grep -F 'tag:gsub("%*$", "") == "terminal"' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
-  fail "line deletion detects dynamically tagged terminals"
-grep -F '{ mods = "CTRL", key = "U", state = "down" }' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
-  fail "line deletion uses the terminal-native Ctrl+U shortcut"
-pass "Super + Backspace deletes to the beginning of the line in graphical apps and terminals"
-
-grep -F 'o.bind("SUPER + ALT + BACKSPACE", "Toggle window transparency", "omarchy-hyprland-window-transparency-toggle")' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
-  fail "window transparency moves to Super + Alt + Backspace"
-pass "window transparency remains available on Super + Alt + Backspace"
-
 removed_home="$tmpdir/removed-home"
 mkdir -p "$removed_home/.local/state/omarchy"
 touch "$removed_home/.local/state/omarchy/preinstalls-removed"

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -119,6 +119,22 @@ if grep -F 'wtype -M' "$ROOT/default/hypr/bindings/clipboard.lua" >/dev/null; th
 fi
 pass "universal clipboard shortcuts avoid virtual keyboard modifier merging"
 
+grep -F 'o.bind("SUPER + BACKSPACE", "Delete to beginning of line", delete_to_beginning_of_line)' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
+  fail "Super + Backspace deletes to the beginning of the line"
+grep -F '{ mods = "SHIFT", key = "HOME", state = "down" }' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
+  fail "line deletion selects from the cursor to the beginning of the line"
+grep -F '{ mods = "", key = "BACKSPACE", state = "down" }' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
+  fail "line deletion removes the selected text"
+grep -F 'tag:gsub("%*$", "") == "terminal"' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
+  fail "line deletion detects dynamically tagged terminals"
+grep -F '{ mods = "CTRL", key = "U", state = "down" }' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
+  fail "line deletion uses the terminal-native Ctrl+U shortcut"
+pass "Super + Backspace deletes to the beginning of the line in graphical apps and terminals"
+
+grep -F 'o.bind("SUPER + ALT + BACKSPACE", "Toggle window transparency", "omarchy-hyprland-window-transparency-toggle")' "$ROOT/default/hypr/bindings/utilities.lua" >/dev/null ||
+  fail "window transparency moves to Super + Alt + Backspace"
+pass "window transparency remains available on Super + Alt + Backspace"
+
 removed_home="$tmpdir/removed-home"
 mkdir -p "$removed_home/.local/state/omarchy"
 touch "$removed_home/.local/state/omarchy/preinstalls-removed"

--- a/test/shell.d/line-deletion-test.sh
+++ b/test/shell.d/line-deletion-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+require_command lua
+
+lua <<'LUA' || exit 1
+local bindings, events, timers = {}, {}, {}
+local active
+o = {
+  bind = function(keys, description, action) bindings[keys] = action end,
+  bind_toggle = function() end,
+}
+hl = {
+  on = function() end,
+  get_active_window = function() return active end,
+  dsp = { send_key_state = function(event) return event end },
+  dispatch = function(event)
+    events[#events + 1] = event.mods .. ":" .. event.key .. ":" .. event.state
+  end,
+  timer = function(callback, options)
+    assert(options.type == "oneshot" and options.timeout > 0)
+    timers[#timers + 1] = callback
+  end,
+}
+dofile(os.getenv("ROOT") .. "/default/hypr/bindings/utilities.lua")
+local invoke = assert(bindings["SUPER + BACKSPACE"])
+assert(bindings["SUPER + ALT + BACKSPACE"] == "omarchy-hyprland-window-transparency-toggle")
+local function drain()
+  while #timers > 0 do table.remove(timers, 1)() end
+end
+local function check(tags, expected)
+  events = {}
+  active = { address = "0x1", tags = tags }
+  invoke()
+  invoke() -- A repeated press must not interleave another sequence.
+  drain()
+  assert(table.concat(events, ",") == expected, table.concat(events, ","))
+end
+local graphical = "SHIFT:HOME:down,SHIFT:HOME:up,:BACKSPACE:down,:BACKSPACE:up"
+local terminal = "CTRL:U:down,CTRL:U:up"
+check({ "terminal*" }, terminal)
+check({ "terminal" }, terminal)
+check({ "not-terminal*" }, graphical)
+check(nil, graphical)
+events = {}
+active = nil
+invoke()
+assert(#events == 0 and #timers == 0)
+for _, next_window in ipairs({ { address = "0x2" }, false }) do
+  events = {}
+  active = { address = "0x1" }
+  invoke()
+  active = next_window or nil
+  drain()
+  assert(table.concat(events, ",") == "SHIFT:HOME:down,SHIFT:HOME:up")
+  check({}, graphical) -- Cancellation must allow subsequent invocations.
+end
+print("ok - line deletion routes terminal and graphical events, balances releases, and guards overlap and focus changes")
+LUA


### PR DESCRIPTION
Adds default `Super + Backspace` line deletion: terminal windows receive `Ctrl + U`; other applications receive `Shift + Home`, then `Backspace`. Window transparency moves to `Super + Alt + Backspace`.

Overlapping invocations are ignored until the sequence finishes. If the active window changes, subsequent key presses are cancelled while a pending key release is still emitted. This guard cannot detect focus changes within an application or guarantee layer-surface focus identity. The shortcut does nothing when there is no active window.

The manual documents application-dependent behavior, including embedded terminals, shell editing modes, smart Home, and wrapped lines. This is not an exact universal implementation of macOS editing semantics.

Validation: callback-level tests cover both terminal tag forms, graphical windows, missing focus, overlap, focus changes, and recovery after cancellation. The focused default-config and binding-conflict suites pass, as does `git diff --check`. The user reported the earlier terminal routing working in Neovim and tmux; the new guards have automated coverage but have not been exercised in a live desktop. The user's personal configuration has not been changed by this revision.

An earlier full shell-suite run reported six failures outside this change: config, launch-about, locate, network-qr, snapper, and unowned-system-paths. Their causes have not all been established; the full suite was not rerun for this revision.
