### PR TITLE
Fix the bar startup stall and the shell restart race

### DIFF
--- a/bin/omarchy-restart-shell
+++ b/bin/omarchy-restart-shell
@@ -62,14 +62,31 @@ relock_session() {
 }
 
 # Each kill stops the oldest matching instance and only returns once it has
-# fully exited, so the no-duplicate launch below can't race a dying shell.
-while timeout 5 quickshell kill -p "$CONFIG_DIR" --any-display >/dev/null 2>&1; do :; done
+# fully exited. A large bar can take longer than a few seconds to tear down,
+# so the client gets time to see that through, and the wait below covers a
+# client that timed out anyway: the fresh shell refuses to start next to a
+# still-dying instance (-n), which is how a restart used to end with no bar.
+while timeout 30 quickshell kill -p "$CONFIG_DIR" --any-display >/dev/null 2>&1; do :; done
+
+shell_instance_running() {
+  quickshell list -a -j 2>/dev/null |
+    jq -e --arg dir "$CONFIG_DIR/" 'any(.[]; .config_path | startswith($dir))' >/dev/null 2>&1
+}
+
+deadline=$((SECONDS + 30))
+while (( SECONDS < deadline )) && shell_instance_running; do
+  sleep 0.1
+done
 
 # Spawn from Hyprland so the shell inherits the canonical session environment,
 # not transient variables from a terminal, SSH connection, or development tool.
 hyprctl dispatch 'hl.dsp.exec_cmd("omarchy-launch-shell")' >/dev/null
 
-for (( attempt = 0; attempt < 20; attempt++ )); do
+# The shell answers once its plugins have loaded, which on a large bar is
+# well past ten seconds, so wait on a deadline rather than a fixed handful
+# of attempts.
+deadline=$((SECONDS + 60))
+while (( SECONDS < deadline )); do
   if OMARCHY_PATH="$session_omarchy_path" OMARCHY_SHELL_IPC_TIMEOUT=0.5s omarchy-shell shell ping >/dev/null 2>&1; then
     # The session stays compositor-locked after the old lock client died, so
     # re-acquire the lock and let the user authenticate out of it.

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -110,7 +110,11 @@ Item {
   property var clickTargets: []
   property var moduleSlots: []
   property var pluginBarApis: ({})
-  property var pluginObjectOwners: []
+  // target -> { target, pluginId, clickTarget, popout }. Keyed by object so
+  // ownership checks stay O(1) however many targets six bars' worth of
+  // widgets register; every lookup used to scan a plain array.
+  readonly property var pluginObjectOwners: new Map()
+  property bool pluginBarApiSyncQueued: false
 
   Component {
     id: pluginBarApiComponent
@@ -138,20 +142,20 @@ Item {
     root.syncPluginBarApiObjects(api)
   }
 
-  function syncPluginBarApiObjects(api) {
+  // Each api keeps its own detached copy of the layout. A flush serialises
+  // the layout once and passes the string in so it is not re-serialised for
+  // every plugin.
+  function syncPluginBarApiObjects(api, layoutSnapshot) {
     if (!api) return
     api.activePopout = root.pluginOwnsBarObject(api.pluginId, root.activePopout)
       ? root.activePopout : (root.activePopout ? api.foreignPopoutMarker : null)
     api.clickTargets = root.pluginClickTargets(api.pluginId)
-    api.layoutConfig = root.publicLayoutConfig()
+    api.layoutConfig = layoutSnapshot !== undefined
+      ? JSON.parse(layoutSnapshot) : root.publicLayoutConfig()
   }
 
   function pluginObjectRecord(target) {
-    for (var i = 0; i < pluginObjectOwners.length; i++) {
-      var record = pluginObjectOwners[i]
-      if (record && record.target === target) return record
-    }
-    return null
+    return target ? (pluginObjectOwners.get(target) || null) : null
   }
 
   function markPluginObject(pluginId, target, role) {
@@ -159,31 +163,20 @@ Item {
     if (!key || !target) return false
     var record = root.pluginObjectRecord(target)
     if (record && record.pluginId !== key) return false
-    var next = []
-    for (var i = 0; i < pluginObjectOwners.length; i++) {
-      var existing = pluginObjectOwners[i]
-      if (!existing || existing.target !== target) next.push(existing)
+    if (!record) {
+      record = { target: target, pluginId: key, clickTarget: false, popout: false }
+      pluginObjectOwners.set(target, record)
     }
-    var updated = record || { target: target, pluginId: key, clickTarget: false, popout: false }
-    updated[role] = true
-    next.push(updated)
-    pluginObjectOwners = next
+    record[role] = true
     return true
   }
 
   function unmarkPluginObject(pluginId, target, role) {
     var key = String(pluginId || "")
-    var next = []
-    for (var i = 0; i < pluginObjectOwners.length; i++) {
-      var record = pluginObjectOwners[i]
-      if (!record || record.target !== target || record.pluginId !== key) {
-        next.push(record)
-        continue
-      }
-      record[role] = false
-      if (record.clickTarget || record.popout) next.push(record)
-    }
-    pluginObjectOwners = next
+    var record = root.pluginObjectRecord(target)
+    if (!record || record.pluginId !== key) return
+    record[role] = false
+    if (!record.clickTarget && !record.popout) pluginObjectOwners.delete(target)
   }
 
   function pluginOwnsBarObject(pluginId, target) {
@@ -200,8 +193,25 @@ Item {
     return out
   }
 
+  // Every click target registration, popout change and layout change used to
+  // resync every plugin api synchronously. Startup alone is hundreds of
+  // registrations, each walking every api and every target, so coalesce them
+  // into one resync per event-loop turn (as onModuleSlotsChanged already does
+  // for prunePluginBarApis). bindPluginBarApi still syncs a brand-new api
+  // directly so a widget never sees an empty api on its first read.
+  function schedulePluginBarApiSync() {
+    if (pluginBarApiSyncQueued) return
+    pluginBarApiSyncQueued = true
+    Qt.callLater(root.syncAllPluginBarApiObjects)
+  }
+
   function syncAllPluginBarApiObjects() {
-    for (var id in pluginBarApis) root.syncPluginBarApiObjects(pluginBarApis[id])
+    pluginBarApiSyncQueued = false
+    var layoutSnapshot = JSON.stringify(root.layoutConfig || {})
+    for (var id in pluginBarApis) {
+      var api = pluginBarApis[id]
+      if (api) root.syncPluginBarApiObjects(api, layoutSnapshot)
+    }
   }
 
   function registerPluginClickTarget(pluginId, target) {
@@ -215,15 +225,20 @@ Item {
     root.unmarkPluginObject(pluginId, target, "clickTarget")
   }
 
+  // A plugin may read api.activePopout right after asking for its popout, so
+  // its own api is brought up to date inline; everyone else waits for the
+  // coalesced resync.
   function requestPluginPopout(pluginId, owner) {
     if (!root.markPluginObject(pluginId, owner, "popout")) return
     root.requestPopout(owner)
+    root.syncPluginBarApiObjects(pluginBarApis[String(pluginId || "")])
   }
 
   function releasePluginPopout(pluginId, owner) {
     if (!root.pluginOwnsBarObject(pluginId, owner)) return
     root.releasePopout(owner)
     root.unmarkPluginObject(pluginId, owner, "popout")
+    root.syncPluginBarApiObjects(pluginBarApis[String(pluginId || "")])
   }
 
   function pluginBarApiFor(pluginId, moduleName, registered) {
@@ -287,16 +302,14 @@ Item {
   }
 
   function releasePluginObjects(pluginId) {
-    var owned = pluginObjectOwners.slice()
+    var owned = Array.from(pluginObjectOwners.values())
     for (var i = 0; i < owned.length; i++) {
       var record = owned[i]
       if (!record || record.pluginId !== pluginId) continue
       if (record.clickTarget) root.unregisterClickTarget(record.target)
       if (record.popout && root.activePopout === record.target) root.releasePopout(record.target)
+      pluginObjectOwners.delete(record.target)
     }
-    pluginObjectOwners = pluginObjectOwners.filter(function(record) {
-      return record && record.pluginId !== pluginId
-    })
   }
 
   function prunePluginBarApis() {
@@ -313,9 +326,9 @@ Item {
     pluginBarApis = next
   }
 
-  onActivePopoutChanged: syncAllPluginBarApiObjects()
-  onClickTargetsChanged: syncAllPluginBarApiObjects()
-  onLayoutConfigChanged: syncAllPluginBarApiObjects()
+  onActivePopoutChanged: schedulePluginBarApiSync()
+  onClickTargetsChanged: schedulePluginBarApiSync()
+  onLayoutConfigChanged: schedulePluginBarApiSync()
   onModuleSlotsChanged: Qt.callLater(prunePluginBarApis)
 
   Component.onDestruction: {
@@ -1913,7 +1926,9 @@ Item {
       acceptedButtons: Qt.LeftButton
       enabled: slot.visible && slot.width > 0 && slot.height > 0
       propagateComposedEvents: true
-      cursorShape: root.moduleClickTargetAt(slot, mouseX, mouseY) ? Qt.PointingHandCursor : Qt.ArrowCursor
+      // Only the hovered slot needs the hit test; without the guard every
+      // slot on every monitor re-ran it on each click target change.
+      cursorShape: moduleHover.hovered && root.moduleClickTargetAt(slot, mouseX, mouseY) ? Qt.PointingHandCursor : Qt.ArrowCursor
       // Do not assign drag.target here: ModuleSlot is owned by Row/Column
       // positioners, and mutating slot.x/slot.y can leave stale offsets that
       // make neighboring modules overlap after a small aborted drag.

--- a/shell/plugins/bar/widgets/Indicators.qml
+++ b/shell/plugins/bar/widgets/Indicators.qml
@@ -158,12 +158,12 @@ BarWidget {
 
   onIndicatorEntriesChanged: syncActiveIndicatorOrder()
 
-  implicitWidth: root.vertical
-    ? Math.max(activeVerticalBlock.implicitWidth, inactiveVerticalArea.implicitWidth)
-    : activeHorizontalBlock.implicitWidth + inactiveHorizontalArea.implicitWidth
-  implicitHeight: root.vertical
-    ? activeVerticalBlock.implicitHeight + inactiveVerticalArea.implicitHeight
-    : Math.max(activeHorizontalBlock.implicitHeight, inactiveHorizontalArea.implicitHeight)
+  // Only the tree for the current orientation exists (see orientationLoader
+  // below); its wrapper keeps the stock sizing expressions, so the root's
+  // implicit size still follows the blocks synchronously rather than waiting
+  // on a positioner's polish.
+  implicitWidth: orientationLoader.item ? orientationLoader.item.implicitWidth : 0
+  implicitHeight: orientationLoader.item ? orientationLoader.item.implicitHeight : 0
 
   IpcHandler {
     target: "omarchy.indicators"
@@ -184,89 +184,117 @@ BarWidget {
 
   Component.onCompleted: root.refreshRequested()
 
-  Row {
-    id: horizontalIndicators
+  // Instantiating both orientation trees and toggling `visible` doubled every
+  // indicator per bar (and every process an indicator spawns, once per
+  // monitor). Load only the tree that matches the bar orientation instead.
+  Loader {
+    id: orientationLoader
+    sourceComponent: root.vertical ? verticalIndicatorsTree : horizontalIndicatorsTree
+  }
 
-    visible: !root.vertical
-    spacing: 0
-
-    HoverHandler {
-      onHoveredChanged: root.setIndicatorAreaHovered(hovered)
-    }
+  Component {
+    id: horizontalIndicatorsTree
 
     Item {
-      id: inactiveHorizontalArea
-
-      implicitWidth: root.revealInactiveIndicators ? inactiveHorizontalBlock.implicitWidth : 0
-      implicitHeight: Math.max(inactiveHorizontalBlock.implicitHeight, root.barSize)
+      implicitWidth: activeHorizontalBlock.implicitWidth + inactiveHorizontalArea.implicitWidth
+      implicitHeight: Math.max(activeHorizontalBlock.implicitHeight, inactiveHorizontalArea.implicitHeight)
       width: implicitWidth
       height: implicitHeight
-      clip: true
 
-      IndicatorBlock {
-        id: inactiveHorizontalBlock
-        anchors.verticalCenter: parent.verticalCenter
-        indicatorsModule: root
-        indicatorEntries: root.indicatorEntries
-        indicatorBlock: "inactive"
-        horizontal: true
-        reportActiveState: !root.vertical
+      Row {
+        id: horizontalIndicators
+
+        spacing: 0
+
+        HoverHandler {
+          onHoveredChanged: root.setIndicatorAreaHovered(hovered)
+        }
+
+        Item {
+          id: inactiveHorizontalArea
+
+          implicitWidth: root.revealInactiveIndicators ? inactiveHorizontalBlock.implicitWidth : 0
+          implicitHeight: Math.max(inactiveHorizontalBlock.implicitHeight, root.barSize)
+          width: implicitWidth
+          height: implicitHeight
+          clip: true
+
+          IndicatorBlock {
+            id: inactiveHorizontalBlock
+            anchors.verticalCenter: parent.verticalCenter
+            indicatorsModule: root
+            indicatorEntries: root.indicatorEntries
+            indicatorBlock: "inactive"
+            horizontal: true
+            reportActiveState: !root.vertical
+          }
+
+          HoverHandler {
+            onHoveredChanged: root.setIndicatorAreaHovered(hovered)
+          }
+        }
+
+        ActiveIndicatorBlock {
+          id: activeHorizontalBlock
+          indicatorsModule: root
+          indicatorModel: activeIndicatorModel
+          horizontal: true
+          reportActiveState: !root.vertical
+        }
       }
-
-      HoverHandler {
-        onHoveredChanged: root.setIndicatorAreaHovered(hovered)
-      }
-    }
-
-    ActiveIndicatorBlock {
-      id: activeHorizontalBlock
-      indicatorsModule: root
-      indicatorModel: activeIndicatorModel
-      horizontal: true
-      reportActiveState: !root.vertical
     }
   }
 
-  Column {
-    id: verticalIndicators
-
-    visible: root.vertical
-    spacing: 0
-
-    HoverHandler {
-      onHoveredChanged: root.setIndicatorAreaHovered(hovered)
-    }
+  Component {
+    id: verticalIndicatorsTree
 
     Item {
-      id: inactiveVerticalArea
-
-      implicitWidth: Math.max(inactiveVerticalBlock.implicitWidth, root.barSize)
-      implicitHeight: root.revealInactiveIndicators ? inactiveVerticalBlock.implicitHeight : 0
+      implicitWidth: Math.max(activeVerticalBlock.implicitWidth, inactiveVerticalArea.implicitWidth)
+      implicitHeight: activeVerticalBlock.implicitHeight + inactiveVerticalArea.implicitHeight
       width: implicitWidth
       height: implicitHeight
-      clip: true
 
-      IndicatorBlock {
-        id: inactiveVerticalBlock
-        anchors.horizontalCenter: parent.horizontalCenter
-        indicatorsModule: root
-        indicatorEntries: root.indicatorEntries
-        indicatorBlock: "inactive"
-        horizontal: false
-        reportActiveState: root.vertical
+      Column {
+        id: verticalIndicators
+
+        spacing: 0
+
+        HoverHandler {
+          onHoveredChanged: root.setIndicatorAreaHovered(hovered)
+        }
+
+        Item {
+          id: inactiveVerticalArea
+
+          implicitWidth: Math.max(inactiveVerticalBlock.implicitWidth, root.barSize)
+          implicitHeight: root.revealInactiveIndicators ? inactiveVerticalBlock.implicitHeight : 0
+          width: implicitWidth
+          height: implicitHeight
+          clip: true
+
+          IndicatorBlock {
+            id: inactiveVerticalBlock
+            anchors.horizontalCenter: parent.horizontalCenter
+            indicatorsModule: root
+            indicatorEntries: root.indicatorEntries
+            indicatorBlock: "inactive"
+            horizontal: false
+            reportActiveState: root.vertical
+          }
+
+          HoverHandler {
+            onHoveredChanged: root.setIndicatorAreaHovered(hovered)
+          }
+        }
+
+        ActiveIndicatorBlock {
+          id: activeVerticalBlock
+          indicatorsModule: root
+          indicatorModel: activeIndicatorModel
+          horizontal: false
+          reportActiveState: root.vertical
+        }
       }
-
-      HoverHandler {
-        onHoveredChanged: root.setIndicatorAreaHovered(hovered)
-      }
-    }
-
-    ActiveIndicatorBlock {
-      id: activeVerticalBlock
-      indicatorsModule: root
-      indicatorModel: activeIndicatorModel
-      horizontal: false
-      reportActiveState: root.vertical
     }
   }
 

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -30,6 +30,21 @@ if ! perl -0ne 'exit(/onPressAndHold:\s*function[^{]*\{[^}]*?\bpressed\b[^}]*?\b
 fi
 pass "bar move ignores a press-and-hold propagated from a widget above"
 
+# Every click target registration used to resync every plugin api inline. With
+# six monitors' worth of widgets that is hundreds of full walks at startup, so
+# the change handlers coalesce into one deferred resync and ownership lookups
+# are keyed by target instead of scanning an array.
+if ! rg -q 'onClickTargetsChanged: schedulePluginBarApiSync\(\)' "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "bar coalesces plugin api resyncs instead of running one per click target change"
+fi
+if ! rg -q 'Qt\.callLater\(root\.syncAllPluginBarApiObjects\)' "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "bar defers the coalesced plugin api resync to the event loop"
+fi
+if ! rg -q 'pluginObjectOwners\.get\(target\)' "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "bar looks plugin object ownership up by target instead of scanning"
+fi
+pass "bar coalesces plugin api resyncs and looks ownership up by target"
+
 # Both bar orientations used to be instantiated and toggled with `visible`,
 # doubling every indicator (and every process an indicator spawns) per bar.
 if ! rg -q 'sourceComponent: root\.vertical \? verticalIndicatorsTree : horizontalIndicatorsTree' \

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -30,6 +30,14 @@ if ! perl -0ne 'exit(/onPressAndHold:\s*function[^{]*\{[^}]*?\bpressed\b[^}]*?\b
 fi
 pass "bar move ignores a press-and-hold propagated from a widget above"
 
+# Both bar orientations used to be instantiated and toggled with `visible`,
+# doubling every indicator (and every process an indicator spawns) per bar.
+if ! rg -q 'sourceComponent: root\.vertical \? verticalIndicatorsTree : horizontalIndicatorsTree' \
+  "$ROOT/shell/plugins/bar/widgets/Indicators.qml"; then
+  fail "indicators instantiate only the tree for the current bar orientation"
+fi
+pass "indicators instantiate only the tree for the current bar orientation"
+
 run_node_test <<'JS'
 const fs = require('fs')
 const bar = requireFromRoot('shell/plugins/bar/BarModel.js')


### PR DESCRIPTION
## Summary

The bar takes 16–20 seconds of pegged single-core QML time to populate on a 6-monitor machine with a full widget layout (23 widgets per bar). Profiling with perf and qmlprofiler put the whole stall in `shell/plugins/bar/Bar.qml`'s click-target bookkeeping, with `widgets/Indicators.qml` as the largest multiplier, and the same cost at teardown is what makes `omarchy-restart-shell` race itself. Three changes:

**Bar.qml — coalesce the plugin API resync and make ownership lookups O(1).**
Every `WidgetButton` registers itself as a click target on creation. `registerClickTarget` replaces the `clickTargets` array, `onClickTargetsChanged` ran `syncAllPluginBarApiObjects()` inline, and that walked every plugin API × every click target × a linear scan of `pluginObjectOwners` in `pluginObjectRecord`. In an 8-second trace that was 1.36M `pluginOwnsBarObject` calls and 46–71ms per registration; startup alone is a few hundred registrations, so the cost is quadratic in bar size and multiplied by monitor count.
- `pluginObjectOwners` is now a `Map` keyed by target, so `pluginObjectRecord`/`mark`/`unmark`/`releasePluginObjects` are O(1) per object (nothing outside `Bar.qml` read the array).
- `onActivePopoutChanged`/`onClickTargetsChanged`/`onLayoutConfigChanged` schedule one resync per event-loop turn via `Qt.callLater` (same pattern `onModuleSlotsChanged` already uses for `prunePluginBarApis`). `bindPluginBarApi` still syncs a brand-new API inline, and `requestPluginPopout`/`releasePluginPopout` sync the owning API inline, so a plugin never observes a stale API on its own actions.
- The layout is serialised once per flush instead of once per API (`publicLayoutConfig()` deep-copied per API per sync); each API still receives its own detached copy.
- `ModuleSlot`'s `cursorShape` binding read `clickTargets` for every slot on every monitor (26,700 evaluations per start); it is now gated on the slot's existing `moduleHover.hovered`, which is the only time the cursor is visible there.

**Indicators.qml — instantiate only the current orientation's tree.**
Both the `Row` and the `Column` were built and toggled with `visible`, so every indicator existed twice per bar, along with every process an indicator spawns (two `voxtype status --follow` per monitor from `Dictation.qml`). A `Loader` now picks the tree for `root.vertical`. Each tree is wrapped in an `Item` that keeps the stock explicit implicit-size expressions, so the root's size still follows the blocks synchronously (a bare positioner only updates its implicit size on polish, which `test/shell.d/indicator-contract-test.sh` catches).

**omarchy-restart-shell — wait for the old shell to actually exit.**
The same cascade runs in reverse at teardown (every button unregisters on destruction), so the stock shell takes 5.4–6.0s to exit on this machine. The restart script wrapped `quickshell kill` in `timeout 5` and launched the replacement as soon as the loop ended; the fresh instance's `-n` no-duplicate check saw the still-dying one and quit, leaving no bar. Worse, the readiness ping was answered by the dying instance, so the script reported success (reproduced: exit at 11:14:52.59, "already running" at 11:14:57.61 — 5.01s). The client now gets 30s, the script then waits (bounded) until `quickshell list` shows no instance of the session config, and readiness waits on a 60s deadline instead of 20 attempts. Three consecutive restarts against the stock shell: exit 0 in ~6s, one instance, no "already running".

## Measurements (6 monitors, 23 widgets/bar, Omarchy 4.0.3, 3 runs each, `omarchy restart shell`)

The Indicators change was measured in isolation as a user-plugin clone before this branch existed:

| | stall (Configuration Loaded → polkit agent registered) | bar fully populated | quickshell CPU | `voxtype status` followers |
|---|---|---|---|---|
| stock | 19.8 / 19.8 / 20.3s | 33.8 / 34.1 / 34.9s | 29 / 29 / 30s | 12 |
| Indicators change | 15.5 / 15.6 / 15.7s | 28.8 / 30.1 / 30.2s | 24 / 25 / 24s | 6 |

With both shell changes, launching the shell from a `v4-0-3` checkout on the same machine (two runs): stall **0.70s / 0.70s**, bar fully populated **1.69s / 1.70s after launch** (stock: ~30s after launch), quickshell CPU **2.0s / 2.0s**, clean log. The `Bar.qml` change is the bulk of it: it removes the per-registration cost rather than the registration count. Teardown drops from 5.4–6.0s to ~1.2s.

Profile signature for reference (qmlprofiler, 8.4s capture during the stall): `Bar.qml:317 onClickTargetsChanged` 162 calls, `Bar.qml:189 pluginOwnsBarObject` 1,363,923 calls, `Bar.qml:149 pluginObjectRecord` 1,358,577 calls, `Bar.qml:1916 cursorShape` 26,700 evaluations, `Indicators.qml` 8.8s inclusive; perf: 85% of samples in libQt6Qml (`Runtime::LoadElement`, `QObjectWrapper::virtualIsEqualTo`, `RuntimeHelpers::strictEqual`, `lookupScopeObjectProperty`).

## Test plan

- `./test/all` on this branch.
- `test/shell.d/bar-test.sh` gains source-shape assertions for the coalesced resync, the keyed ownership lookup, and the single-orientation indicators tree.
- `test/shell.d/restart-shell-test.sh`, `bin-style-test.sh`, `launch-shell-test.sh`, `shell-launch-test.sh` pass with the restart change.
- `test/shell.d/indicator-contract-test.sh` and `bar-widget-contract-test.sh` pass (the latter injects a bar whose `serviceFor()` is null and flips `vertical`).
- Manual, on the 6-monitor machine: every widget clickable, tooltips, popouts, drag/reorder, workspace buttons, all six indicators toggle and reveal on hover, `omarchy bar position left` and back (exercises the orientation loader), `omarchy-shell omarchy.indicators refresh`, repeated `omarchy restart shell`.
