### PR TITLE
Install missing BCM43602 board NVRAM on MacBookPro13,3

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -42,6 +42,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-bcm43602-nvram.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-bcm43602-nvram.sh
+++ b/install/hardware/apple/fix-bcm43602-nvram.sh
@@ -1,0 +1,51 @@
+# The MacBookPro13,3 BCM43602 can load the stock binary firmware without its
+# board NVRAM, but then miss 5 GHz networks and fail WPA handshakes on 2.4 GHz.
+# Installing this board configuration restored 5 GHz on that model with
+# 7.35.177.61 firmware. Keep the match narrow: a shared chip ID does not imply
+# the same RF wiring/calibration on other Macs or non-Apple boards.
+# Source: https://gist.github.com/MikeRatcliffe/9614c16a8ea09731a9d5e91685bd8c80
+# Fetch a pinned, verified revision rather than redistributing the board data.
+(
+  sys_vendor=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)
+  product_name=$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)
+  if [[ $sys_vendor != Apple* || $product_name != "MacBookPro13,3" ]]; then
+    return 0
+  fi
+
+  for device in /sys/bus/pci/devices/*; do
+    [[ -d $device ]] || continue
+    if [[ $(cat "$device/vendor") == "0x14e4" && $(cat "$device/device") == "0x43ba" &&
+      $(cat "$device/subsystem_vendor") == "0x106b" && $(cat "$device/subsystem_device") == "0x015a" ]]; then
+      firmware_dir=/usr/lib/firmware/brcm
+      target="$firmware_dir/brcmfmac43602-pcie.Apple Inc.-MacBookPro13,3.txt"
+      # Respect administrator and package-provided NVRAM, including compressed
+      # files and symlinks. Reapplying hardware setup must preserve the MAC.
+      for existing in "$target" "$target.zst" "$target.xz" \
+        "$firmware_dir/brcmfmac43602-pcie.txt"{,.zst,.xz}; do
+        if [[ -e $existing || -L $existing ]]; then
+          return 0
+        fi
+      done
+
+      scratch=$(mktemp -d)
+      trap 'rm -rf "$scratch"' EXIT
+      curl --fail --silent --show-error --location --retry 2 --connect-timeout 10 --max-time 60 \
+        https://gist.githubusercontent.com/MikeRatcliffe/9614c16a8ea09731a9d5e91685bd8c80/raw/bd7af7c6f01df3ccee1471d36cb8df15d618a6aa/brcmfmac43602-pcie.txt \
+        -o "$scratch/nvram"
+      echo "b109f3e6663b0e888c2559e36f7e0109f2a3a6b9765786d11f849f16d4b32d06  $scratch/nvram" | sha256sum --check --status
+
+      # The stock firmware can report a shared Broadcom placeholder address.
+      # Use a per-install locally administered unicast MAC in that case, or
+      # when setup runs without a bound network interface.
+      macaddr=$(cat "$device"/net/*/address 2>/dev/null || true)
+      if [[ ! $macaddr =~ ^([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}$ || $macaddr == "00:90:4c:0d:f4:3e" ]]; then
+        macaddr="02$(od -An -N5 -tx1 /dev/urandom | tr -d '\n' | tr ' ' ':')"
+      fi
+      sed "s/^macaddr=.*/macaddr=$macaddr/" "$scratch/nvram" > "$scratch/board.txt"
+      install -Dm644 "$scratch/board.txt" "$target"
+      echo "Installed MacBookPro13,3 BCM43602 board NVRAM; applies on the next boot"
+      # Do not reload the driver: installation may be using this Wi-Fi link.
+      break
+    fi
+  done
+)

--- a/test/shell.d/apple-bcm43602-nvram-test.sh
+++ b/test/shell.d/apple-bcm43602-nvram-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+require_command python3
+
+python3 - "$ROOT" <<'PYTEST'
+import hashlib
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+root = Path(sys.argv[1])
+source = (root / "install/hardware/apple/fix-bcm43602-nvram.sh").read_text()
+fixture = b"sromrev=11\nmacaddr=xx:xx:xx:xx:xx:xx\naa2g=7\naa5g=7\n"
+
+with tempfile.TemporaryDirectory() as tmp:
+    base = Path(tmp)
+    def run_case(name, *, vendor="Apple Inc.", model="MacBookPro13,3", chip="0x43ba",
+                 subsystem="0x015a", mac="00:90:4c:0d:f4:3e", existing=None,
+                 corrupt=False, download_fail=False):
+        case = base / name
+        dmi = case / "sys/class/dmi/id"
+        pci = case / "sys/bus/pci/devices/0000:03:00.0"
+        firmware = case / "firmware"
+        stub = case / "bin"
+        for path in (dmi, pci, firmware, stub):
+            path.mkdir(parents=True)
+        (dmi / "sys_vendor").write_text(vendor)
+        (dmi / "product_name").write_text(model)
+        for key, value in dict(vendor="0x14e4", device=chip,
+                               subsystem_vendor="0x106b", subsystem_device=subsystem).items():
+            (pci / key).write_text(value)
+        if mac is not None:
+            (pci / "net/wlan0").mkdir(parents=True)
+            (pci / "net/wlan0/address").write_text(mac)
+        target = firmware / "brcmfmac43602-pcie.Apple Inc.-MacBookPro13,3.txt"
+        if existing:
+            (firmware / existing).write_text("keep custom configuration")
+        payload = case / "payload"
+        payload.write_bytes(b"corrupt" if corrupt else fixture)
+        curl = stub / "curl"
+        curl.write_text("#!/bin/bash\necho download >> '" + str(case / "calls") + "'\n" +
+                        ("exit 22\n" if download_fail else
+                         "while [[ $1 != -o ]]; do shift; done\ncp '" + str(payload) + "' \"$2\"\n"))
+        curl.chmod(0o755)
+        script = case / "leaf.sh"
+        script.write_text(source.replace("/sys/", str(case / "sys") + "/")
+                          .replace("/usr/lib/firmware/brcm", str(firmware))
+                          .replace("b109f3e6663b0e888c2559e36f7e0109f2a3a6b9765786d11f849f16d4b32d06",
+                                   hashlib.sha256(fixture).hexdigest()))
+        env = dict(os.environ, PATH=str(stub) + os.pathsep + os.environ["PATH"])
+        def invoke():
+            return subprocess.run(["bash", "-e", "-c", 'source "$1"', "bash", str(script)],
+                                  env=env, capture_output=True, text=True)
+        result = invoke()
+        return case, target, result, invoke
+
+    for name, kwargs in [("non-apple", dict(vendor="Dell Inc.")),
+                         ("other-model", dict(model="MacBookPro14,3")),
+                         ("other-chip", dict(chip="0x43a0")),
+                         ("other-board", dict(subsystem="0x9999"))]:
+        case, target, result, _ = run_case(name, **kwargs)
+        assert result.returncode == 0 and not target.exists() and not (case / "calls").exists(), name
+        print("ok - skips " + name)
+
+    for suffix in (".txt", ".txt.zst", ".txt.xz"):
+        for prefix in ("brcmfmac43602-pcie", "brcmfmac43602-pcie.Apple Inc.-MacBookPro13,3"):
+            filename = prefix + suffix
+            case, target, result, _ = run_case("existing-" + filename, existing=filename)
+            assert result.returncode == 0 and not (case / "calls").exists()
+            assert (target.parent / filename).read_text() == "keep custom configuration"
+    print("ok - preserves generic and model-specific NVRAM, including compressed files")
+
+    case, target, result, invoke = run_case("install")
+    assert result.returncode == 0, result.stderr
+    installed = target.read_text()
+    mac = re.search(r"^macaddr=(.*)$", installed, re.M)[1]
+    assert re.fullmatch(r"02(:[0-9a-f]{2}){5}", mac), mac
+    assert installed == fixture.decode().replace("xx:xx:xx:xx:xx:xx", mac)
+    assert target.stat().st_mode & 0o777 == 0o644
+    assert invoke().returncode == 0 and target.read_text() == installed
+    assert (case / "calls").read_text().count("download") == 1
+    print("ok - installs verified NVRAM with a unique local MAC and preserves it on rerun")
+
+    _, target, result, _ = run_case("real-mac", mac="78:12:34:56:78:90")
+    assert result.returncode == 0 and "macaddr=78:12:34:56:78:90" in target.read_text()
+    print("ok - preserves the interface address when it is not the Broadcom placeholder")
+    _, target, result, _ = run_case("no-interface", mac=None)
+    assert result.returncode == 0 and "macaddr=02:" in target.read_text()
+    print("ok - handles installation without a bound network interface")
+    for name, kwargs in [("bad-digest", dict(corrupt=True)), ("download-failure", dict(download_fail=True))]:
+        _, target, result, _ = run_case(name, **kwargs)
+        assert result.returncode != 0 and not target.exists(), name
+        print("ok - refuses installation on " + name)
+PYTEST


### PR DESCRIPTION
# Install missing BCM43602 board NVRAM on MacBookPro13,3

On a MacBookPro13,3 with BCM43602 [14e4:43ba], the stock binary firmware initialized without board NVRAM but only discovered 2.4 GHz networks and reported failed WPA2 handshakes as incorrect passwords. Installing the board configuration and reloading brcmfmac restored 5 GHz discovery and a successful connection at 5240 MHz, with signal −39 dBm.

Add a hardware setup leaf after the existing brcmfmac supplicant workaround. Match Apple DMI, MacBookPro13,3, and PCI/subsystem IDs 14e4:43ba / 106b:015a; the same chip in other models is not sufficient evidence of compatible board calibration. Fetch the tested community NVRAM from an immutable URL and verify SHA-256 before writing a model-specific firmware file. Preserve existing generic/model-specific overrides, including compressed files and symlinks. Substitute the interface MAC; if absent or the shared Broadcom placeholder, generate a persistent locally administered unicast address. Do not reload the adapter during installation.

Source: [Mike Ratcliffe’s BCM43602 board configuration](https://gist.github.com/MikeRatcliffe/9614c16a8ea09731a9d5e91685bd8c80), pinned file blob `bd7af7c6f01df3ccee1471d36cb8df15d618a6aa`, SHA-256 `b109f3e6663b0e888c2559e36f7e0109f2a3a6b9765786d11f849f16d4b32d06`. The data is downloaded rather than vendored; matching installations require network access to the pinned source. Download/checksum failures stop the leaf without installing an unverified file.

Validation:
- Real hardware: MacBookPro13,3, BCM43602 rev 02; Linux 7.1.9-arch1-2; firmware 7.35.177.61; NetworkManager 1.58.1-1. Verified multiple 5 GHz scan results and successful 5 GHz connection after adding the same NVRAM data and reloading brcmfmac_wcc/brcmfmac. The pre-existing feature_disable=0x82000 setting was retained and applied on reload.
- Focused sandbox tests cover hardware exclusions, existing overrides, MAC handling, repeat runs, failed downloads and checksum mismatches.
- Bash syntax and git whitespace checks pass.
- Full `./test/all`: CLI suite passed; 5 of 237 shell test files failed. `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh` require the absent companion omarchy-pkgs checkout; `launch-about-test.sh` fails its roomy-window animation assertion. These four failures reproduce on untouched upstream `5ead8705`. `locate-test.sh` tried to decode ignored Python bytecode generated in bin/__pycache__ by earlier tests; it passes after removing that generated cache. The new Wi-Fi suite passes. No unrelated test changes are included.

Clean ISO installation, reboot persistence, successful 2.4 GHz authentication after the change, other Mac models and long-term stability have not been validated. This PR adds fresh-install hardware setup; it does not add a migration or change WPA settings, regulatory settings, binary firmware, or suspend behavior.
